### PR TITLE
feat(rccl): add weekly JAX collective smoke tests to CI [AICOMRCCL-1547]

### DIFF
--- a/.github/scripts/rccl_ci_utils.py
+++ b/.github/scripts/rccl_ci_utils.py
@@ -1,0 +1,125 @@
+"""Shared utilities for RCCL CI test scripts (JAX, PyTorch)."""
+
+import logging
+import os
+import smtplib
+import sys
+import xml.etree.ElementTree as ET
+from email.mime.text import MIMEText
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+SMTP_SERVERS = ["smtp.amd.com", "aussmtp.amd.com", "mail.amd.com", "localhost"]
+
+
+def find_rccl_library(artifact_dir: Path) -> Path:
+    """Find librccl.so in the artifact directory tree."""
+    matches = list(artifact_dir.rglob("librccl.so"))
+    if not matches:
+        so_files = list(artifact_dir.rglob("*.so"))[:20]
+        log.error("librccl.so not found in %s", artifact_dir)
+        log.error("Shared libraries found: %s", [str(f) for f in so_files])
+        sys.exit(1)
+    lib_path = matches[0].resolve()
+    log.info("Found librccl.so at: %s", lib_path)
+    return lib_path
+
+
+def verify_rccl_override(rccl_lib_dir: Path) -> None:
+    """Verify that the CI-built librccl.so exists on disk."""
+    ci_rccl = rccl_lib_dir.resolve() / "librccl.so"
+    if not ci_rccl.exists():
+        log.error("CI-built librccl.so not found at %s", ci_rccl)
+        sys.exit(1)
+    log.info("CI-built RCCL: %s (%d bytes)", ci_rccl, ci_rccl.stat().st_size)
+
+
+def parse_junit_xml(xml_path: Path) -> dict:
+    """Parse JUnit XML and return structured results."""
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+
+    passed_tests = []
+    failed_tests = []
+    error_details = []
+    tests_run = 0
+    failures = 0
+    errors = 0
+
+    for suite in root.iter("testsuite"):
+        tests_run = int(suite.get("tests", 0))
+        failures = int(suite.get("failures", 0))
+        errors = int(suite.get("errors", 0))
+
+    for tc in root.iter("testcase"):
+        name = tc.get("name", "")
+        time_s = tc.get("time", "")
+        duration = f"{float(time_s):.2f}s" if time_s else ""
+
+        failure = tc.find("failure")
+        error = tc.find("error")
+        if failure is not None:
+            failed_tests.append(name)
+            error_details.append(
+                f"FAILED: {name}\n  {failure.get('message', '')}"
+            )
+        elif error is not None:
+            failed_tests.append(name)
+            error_details.append(
+                f"ERROR: {name}\n  {error.get('message', '')}"
+            )
+        else:
+            passed_tests.append((name, duration))
+
+    return {
+        "passed": passed_tests,
+        "failed": failed_tests,
+        "error_details": error_details,
+        "tests_run": tests_run,
+        "failures": failures,
+        "errors": errors,
+    }
+
+
+def write_github_summary(report: str) -> None:
+    """Write report to GITHUB_STEP_SUMMARY if available."""
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a") as f:
+            f.write("```\n")
+            f.write(report)
+            f.write("\n```\n")
+        log.info("Summary written to GITHUB_STEP_SUMMARY")
+
+
+def set_github_output(key: str, value: str) -> None:
+    """Write a key=value pair to GITHUB_OUTPUT if available."""
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a") as f:
+            f.write(f"{key}={value}\n")
+
+
+def send_email_report(
+    report: str, recipient: str, status: str, subject_prefix: str
+) -> None:
+    """Send the summary report via email."""
+    subject = f"{subject_prefix}: {status}"
+    msg = MIMEText(report)
+    msg["Subject"] = subject
+    msg["From"] = "rccl-ci@amd.com"
+    msg["To"] = recipient
+
+    for server in SMTP_SERVERS:
+        try:
+            with smtplib.SMTP(server, timeout=10) as s:
+                s.sendmail(msg["From"], [recipient], msg.as_string())
+            log.info("Email sent to %s via %s", recipient, server)
+            return
+        except Exception as e:
+            log.debug("SMTP %s failed: %s", server, e)
+            continue
+    log.warning(
+        "Could not send email to %s (tried: %s)", recipient, ", ".join(SMTP_SERVERS)
+    )

--- a/.github/scripts/test_jax_collective.py
+++ b/.github/scripts/test_jax_collective.py
@@ -79,7 +79,10 @@ def find_lib_dirs(artifact_dir: Path) -> list[Path]:
         lib_dirs.add(so_file.parent.resolve())
     sorted_dirs = sorted(lib_dirs)
     for d in sorted_dirs:
-        log.info("Found lib dir: %s", d)
+        so_files = [f.name for f in d.iterdir() if ".so" in f.name]
+        log.info("Found lib dir: %s (%d libs)", d, len(so_files))
+        for f in sorted(so_files):
+            log.info("  %s", f)
     return sorted_dirs
 
 

--- a/.github/scripts/test_jax_collective.py
+++ b/.github/scripts/test_jax_collective.py
@@ -113,6 +113,9 @@ def setup_ld_library_path(lib_dirs: list[Path]) -> str:
     create_soname_symlinks(lib_dirs)
 
     parts = [str(d) for d in lib_dirs]
+    rocm_lib = Path("/opt/rocm/lib")
+    if rocm_lib.is_dir():
+        parts.insert(0, str(rocm_lib))
     existing = os.environ.get("LD_LIBRARY_PATH", "")
     if existing:
         parts.append(existing)
@@ -164,6 +167,34 @@ def diagnose_shared_libs(lib_dirs: list[Path]) -> None:
                     log.info("  %s", line.strip())
     except ImportError:
         log.info("xla_rocm7 plugin not installed — skipping plugin ldd")
+
+
+def populate_rocm_lib_dir(lib_dirs: list[Path]) -> None:
+    """Populate /opt/rocm/lib with symlinks to artifact libraries.
+
+    JAX's xla_rocm_plugin.so typically has RUNPATH set to /opt/rocm/lib.
+    With ELF RUNPATH semantics, transitive dependencies are resolved via
+    RUNPATH rather than LD_LIBRARY_PATH. In a container with no system
+    ROCm, we populate /opt/rocm/lib so the loader can find them.
+    """
+    rocm_lib = Path("/opt/rocm/lib")
+    try:
+        rocm_lib.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        log.warning("Cannot create %s — not running as root", rocm_lib)
+        return
+
+    count = 0
+    for d in lib_dirs:
+        for so_file in d.iterdir():
+            if ".so" not in so_file.name:
+                continue
+            target = rocm_lib / so_file.name
+            if target.exists() or target.is_symlink():
+                continue
+            target.symlink_to(so_file.resolve())
+            count += 1
+    log.info("Created %d symlinks in %s", count, rocm_lib)
 
 
 def verify_rccl_override(rccl_lib_dir: Path) -> None:
@@ -503,7 +534,8 @@ def main() -> None:
     if args.discover_only:
         return
 
-    # Step 2: Set up LD_LIBRARY_PATH and verify override
+    # Step 2: Set up library paths and verify override
+    populate_rocm_lib_dir(lib_dirs)
     setup_ld_library_path(lib_dirs)
     verify_rccl_override(rccl_lib_dir)
     diagnose_shared_libs(lib_dirs)

--- a/.github/scripts/test_jax_collective.py
+++ b/.github/scripts/test_jax_collective.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Run JAX collective smoke tests against CI-built RCCL.
+
+This script handles:
+  1. Discovering the CI-built librccl.so in the artifact directory
+  2. Setting LD_LIBRARY_PATH to override JAX's bundled RCCL
+  3. Cloning the matching JAX test sources (sparse checkout of ROCm/jax)
+  4. Setting XLA environment variables for ROCm
+  5. Running 10 collective smoke tests via pytest
+
+Usage from GitHub Actions:
+  python .github/scripts/test_jax_collective.py \
+      --artifact-dir ./build \
+      --jax-src ./jax-src \
+      --results-log ./jax_collective_results.log
+
+Local prototyping (no RCCL override):
+  python .github/scripts/test_jax_collective.py \
+      --jax-src ./jax-src \
+      --results-log ./jax_collective_results.log \
+      --skip-rccl-override
+"""
+
+import argparse
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+log = logging.getLogger(__name__)
+
+JAX_REPO = "https://github.com/ROCm/jax.git"
+DEFAULT_BRANCH = "jax-v0.10.2-testing"
+
+SMOKE_TESTS = [
+    "tests/pmap_test.py::PythonPmapTest::testBasic",
+    "tests/pmap_test.py::PythonPmapTest::testGather",
+    "tests/pmap_test.py::PythonPmapTest::testReduceScatter",
+    "tests/pmap_test.py::PythonPmapTest::testCollectivePermute",
+    "tests/pmap_test.py::PythonPmapTest::testAllToAll0",
+    "tests/shard_map_test.py::ShardMapTest::test_all_gather",
+    "tests/shard_map_test.py::ShardMapTest::test_matmul_reduce_scatter",
+    "tests/shard_map_test.py::ShardMapTest::test_collective_permute",
+    "tests/shard_map_test.py::ShardMapTest::test_axis_index",
+    "tests/shard_map_test.py::ShardMapTest::test_all_to_all_multiple_axis_names",
+]
+
+XLA_ENV = {
+    "XLA_PYTHON_CLIENT_ALLOCATOR": "default",
+    "XLA_PYTHON_CLIENT_PREALLOCATE": "false",
+    "XLA_FLAGS": (
+        "--xla_gpu_force_compilation_parallelism=1 "
+        "--xla_gpu_enable_nccl_comm_splitting=false "
+        "--xla_gpu_enable_command_buffer= "
+        "--xla_gpu_enable_cublaslt=false"
+    ),
+}
+
+
+def find_rccl_library(artifact_dir: Path) -> Path:
+    """Find librccl.so in the artifact directory tree."""
+    matches = list(artifact_dir.rglob("librccl.so"))
+    if not matches:
+        so_files = list(artifact_dir.rglob("*.so"))[:20]
+        log.error("librccl.so not found in %s", artifact_dir)
+        log.error("Shared libraries found: %s", [str(f) for f in so_files])
+        sys.exit(1)
+    lib_path = matches[0]
+    log.info("Found librccl.so at: %s", lib_path)
+    return lib_path
+
+
+def find_rocm_lib_dir(artifact_dir: Path) -> Path | None:
+    """Find the dist/rocm/lib directory in artifacts."""
+    for d in artifact_dir.rglob("dist/rocm/lib"):
+        if d.is_dir():
+            log.info("Found ROCm lib dir: %s", d)
+            return d
+    return None
+
+
+def setup_ld_library_path(rccl_lib_dir: Path, rocm_lib_dir: Path | None) -> str:
+    """Prepend RCCL and ROCm lib dirs to LD_LIBRARY_PATH."""
+    parts = [str(rccl_lib_dir.resolve())]
+    if rocm_lib_dir:
+        parts.append(str(rocm_lib_dir.resolve()))
+    existing = os.environ.get("LD_LIBRARY_PATH", "")
+    if existing:
+        parts.append(existing)
+    new_path = ":".join(parts)
+    os.environ["LD_LIBRARY_PATH"] = new_path
+    log.info("LD_LIBRARY_PATH=%s", new_path)
+    return new_path
+
+
+def verify_rccl_override(rccl_lib_dir: Path) -> None:
+    """Verify that the CI-built librccl.so exists on disk."""
+    ci_rccl = rccl_lib_dir.resolve() / "librccl.so"
+    if not ci_rccl.exists():
+        log.error("CI-built librccl.so not found at %s", ci_rccl)
+        sys.exit(1)
+    log.info("CI-built RCCL: %s (%d bytes)", ci_rccl, ci_rccl.stat().st_size)
+
+
+def setup_xla_environment() -> None:
+    """Set XLA environment variables required for JAX on ROCm."""
+    for key, value in XLA_ENV.items():
+        os.environ[key] = value
+        log.info("Set %s=%s", key, value)
+
+
+def clone_jax_test_sources(jax_src: Path, branch: str) -> None:
+    """Sparse-clone ROCm/jax to get test sources and test-requirements.txt."""
+    if jax_src.exists() and (jax_src / "tests" / "pmap_test.py").exists():
+        log.info("JAX test sources already present at %s, skipping clone", jax_src)
+        return
+
+    log.info("Cloning ROCm/jax (branch=%s, sparse) into %s", branch, jax_src)
+    subprocess.run(
+        [
+            "git", "clone",
+            "--depth=1",
+            f"--branch={branch}",
+            "--filter=blob:none",
+            "--sparse",
+            JAX_REPO,
+            str(jax_src),
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "sparse-checkout", "set", "tests/", "build/", "jax/"],
+        cwd=jax_src,
+        check=True,
+    )
+
+    test_file = jax_src / "tests" / "pmap_test.py"
+    if not test_file.exists():
+        log.error("pmap_test.py not found after clone")
+        sys.exit(1)
+    log.info("JAX test sources ready: %s", jax_src)
+
+
+def _pip_install(args: list[str]) -> None:
+    """Install packages using uv pip (preferred) or pip."""
+    if shutil.which("uv"):
+        cmd = ["uv", "pip", "install"] + args
+    else:
+        cmd = [sys.executable, "-m", "pip", "install"] + args
+    log.info("Running: %s", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def install_test_requirements(jax_src: Path) -> None:
+    """Install test dependencies from build/test-requirements.txt."""
+    req_file = jax_src / "build" / "test-requirements.txt"
+    if not req_file.exists():
+        log.warning("build/test-requirements.txt not found, installing minimal deps")
+        _pip_install(["pytest", "pytest-timeout", "hypothesis", "numpy", "absl-py"])
+        return
+
+    log.info("Installing test requirements from %s", req_file)
+    _pip_install(["-r", str(req_file)])
+
+
+def print_environment_info() -> None:
+    """Print GPU and environment details for CI logs."""
+    log.info("--- Environment Info ---")
+    try:
+        import jax
+        log.info("JAX version: %s", jax.__version__)
+        log.info("Devices: %s", jax.devices())
+        log.info("Device count: %d", jax.device_count())
+        log.info("Local device count: %d", jax.local_device_count())
+    except Exception as e:
+        log.error("Failed to query JAX devices: %s", e)
+        sys.exit(1)
+
+    log.info("LD_LIBRARY_PATH: %s", os.environ.get("LD_LIBRARY_PATH", ""))
+    for key in sorted(XLA_ENV):
+        log.info("%s=%s", key, os.environ.get(key, "<unset>"))
+    log.info("--- End Environment Info ---")
+
+
+def run_tests(jax_src: Path, results_log: Path, timeout: int) -> int:
+    """Run pytest on the 10 collective smoke tests and return exit code."""
+    cmd = [
+        sys.executable, "-m", "pytest",
+        "-sv",
+        f"--timeout={timeout}",
+        "--tb=short",
+    ] + SMOKE_TESTS
+
+    log.info("Running: %s", " ".join(cmd))
+
+    with open(results_log, "w") as log_file:
+        proc = subprocess.run(
+            cmd,
+            cwd=jax_src,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        log_file.write(proc.stdout)
+        print(proc.stdout, end="")
+
+    log.info("Test exit code: %d", proc.returncode)
+    log.info("Results written to: %s", results_log)
+    return proc.returncode
+
+
+def set_github_output(key: str, value: str) -> None:
+    """Write a key=value pair to GITHUB_OUTPUT if available."""
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a") as f:
+            f.write(f"{key}={value}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        default=None,
+        help="Directory containing CI-built RCCL artifacts",
+    )
+    parser.add_argument(
+        "--jax-src",
+        type=Path,
+        required=True,
+        help="Directory to clone JAX test sources into",
+    )
+    parser.add_argument(
+        "--jax-branch",
+        default=DEFAULT_BRANCH,
+        help=f"ROCm/jax branch for test sources (default: {DEFAULT_BRANCH})",
+    )
+    parser.add_argument(
+        "--results-log",
+        type=Path,
+        default=Path("jax_collective_results.log"),
+        help="Path for test results log file",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=120,
+        help="Per-test timeout in seconds (default: 120)",
+    )
+    parser.add_argument(
+        "--skip-rccl-override",
+        action="store_true",
+        help="Skip RCCL library override (use system/wheel-bundled RCCL)",
+    )
+    parser.add_argument(
+        "--discover-only",
+        action="store_true",
+        help="Only discover library paths and set GITHUB_OUTPUT, then exit",
+    )
+    parser.add_argument(
+        "--skip-clone",
+        action="store_true",
+        help="Skip cloning JAX sources (assume already present)",
+    )
+    parser.add_argument(
+        "--skip-install-deps",
+        action="store_true",
+        help="Skip installing test dependencies",
+    )
+
+    args = parser.parse_args()
+
+    # Step 1: RCCL library discovery and override
+    if not args.skip_rccl_override:
+        if args.artifact_dir is None:
+            log.error("--artifact-dir required unless --skip-rccl-override is set")
+            sys.exit(1)
+        rccl_lib = find_rccl_library(args.artifact_dir)
+        rccl_lib_dir = rccl_lib.parent
+        rocm_lib_dir = find_rocm_lib_dir(args.artifact_dir)
+
+        set_github_output("RCCL_LIB_DIR", str(rccl_lib_dir))
+        if rocm_lib_dir:
+            set_github_output("ROCM_LIB_DIR", str(rocm_lib_dir))
+
+        if args.discover_only:
+            return
+
+        setup_ld_library_path(rccl_lib_dir, rocm_lib_dir)
+        verify_rccl_override(rccl_lib_dir)
+    elif args.discover_only:
+        return
+
+    # Step 2: Set XLA environment variables
+    setup_xla_environment()
+
+    # Step 3: Clone JAX test sources
+    if not args.skip_clone:
+        clone_jax_test_sources(args.jax_src, args.jax_branch)
+
+    # Step 4: Install test dependencies
+    if not args.skip_install_deps:
+        install_test_requirements(args.jax_src)
+
+    # Step 5: Print environment info (also validates JAX can see GPUs)
+    print_environment_info()
+
+    # Step 6: Run smoke tests
+    exit_code = run_tests(args.jax_src, args.results_log, args.timeout)
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_jax_collective.py
+++ b/.github/scripts/test_jax_collective.py
@@ -3,7 +3,7 @@
 
 This script handles:
   1. Discovering the CI-built librccl.so in the artifact directory
-  2. Verifying that LD_LIBRARY_PATH overrides JAX's bundled RCCL
+  2. Prepending its directory to LD_LIBRARY_PATH so JAX loads it
   3. Cloning the matching JAX test sources (sparse checkout)
   4. Running pytest on pmap_test.py and shard_map_test.py
 
@@ -46,6 +46,7 @@ XLA_ENV = {
     "XLA_FLAGS": (
         "--xla_gpu_force_compilation_parallelism=1 "
         "--xla_gpu_enable_nccl_comm_splitting=false "
+        # Empty value disables all command buffer types (HIP graphs) on ROCm.
         "--xla_gpu_enable_command_buffer= "
         "--xla_gpu_enable_cublaslt=false"
     ),

--- a/.github/scripts/test_jax_collective.py
+++ b/.github/scripts/test_jax_collective.py
@@ -83,8 +83,34 @@ def find_lib_dirs(artifact_dir: Path) -> list[Path]:
     return sorted_dirs
 
 
+def create_soname_symlinks(lib_dirs: list[Path]) -> None:
+    """Create missing SONAME symlinks (e.g. libfoo.so.1 -> libfoo.so.1.2.3).
+
+    Artifact flattening can strip versioned symlinks. JAX wheels link
+    against SONAME versions (librocprofiler-sdk.so.1) that may only
+    exist as librocprofiler-sdk.so.1.0.0 after flattening.
+    """
+    for d in lib_dirs:
+        for so_file in d.glob("*.so.*"):
+            name = so_file.name
+            # Match libfoo.so.X.Y.Z — create libfoo.so.X symlink
+            parts = name.split(".so.")
+            if len(parts) != 2:
+                continue
+            version_parts = parts[1].split(".")
+            if len(version_parts) <= 1:
+                continue
+            soname = f"{parts[0]}.so.{version_parts[0]}"
+            soname_path = d / soname
+            if not soname_path.exists():
+                soname_path.symlink_to(so_file.name)
+                log.info("Created symlink: %s -> %s", soname_path, so_file.name)
+
+
 def setup_ld_library_path(lib_dirs: list[Path]) -> str:
     """Prepend all artifact lib dirs to LD_LIBRARY_PATH."""
+    create_soname_symlinks(lib_dirs)
+
     parts = [str(d) for d in lib_dirs]
     existing = os.environ.get("LD_LIBRARY_PATH", "")
     if existing:

--- a/.github/scripts/test_jax_collective.py
+++ b/.github/scripts/test_jax_collective.py
@@ -17,10 +17,10 @@ Usage from GitHub Actions:
 import argparse
 import logging
 import os
-import re
 import smtplib
 import subprocess
 import sys
+import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from email.mime.text import MIMEText
 from pathlib import Path
@@ -206,21 +206,66 @@ def print_environment_info() -> None:
     log.info("--- End Environment Info ---")
 
 
+def parse_junit_xml(xml_path: Path) -> dict:
+    """Parse JUnit XML and return structured results."""
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+
+    passed_tests = []
+    failed_tests = []
+    error_details = []
+    tests_run = 0
+    failures = 0
+    errors = 0
+
+    for suite in root.iter("testsuite"):
+        tests_run = int(suite.get("tests", 0))
+        failures = int(suite.get("failures", 0))
+        errors = int(suite.get("errors", 0))
+
+    for tc in root.iter("testcase"):
+        name = tc.get("name", "")
+        time_s = tc.get("time", "")
+        duration = f"{float(time_s):.2f}s" if time_s else ""
+
+        failure = tc.find("failure")
+        error = tc.find("error")
+        if failure is not None:
+            failed_tests.append(name)
+            error_details.append(
+                f"FAILED: {name}\n  {failure.get('message', '')}"
+            )
+        elif error is not None:
+            failed_tests.append(name)
+            error_details.append(
+                f"ERROR: {name}\n  {error.get('message', '')}"
+            )
+        else:
+            passed_tests.append((name, duration))
+
+    return {
+        "passed": passed_tests,
+        "failed": failed_tests,
+        "error_details": error_details,
+        "tests_run": tests_run,
+        "failures": failures,
+        "errors": errors,
+    }
+
+
 def run_tests(jax_src: Path, results_log: Path) -> tuple[int, dict]:
     """Run pytest on the 10 collective smoke tests and return (exit_code, summary)."""
+    junit_xml = results_log.parent / "jax_collective_results.xml"
+
     cmd = [
         sys.executable, "-m", "pytest",
         "-sv",
         "--timeout=120",
         "--tb=short",
+        f"--junitxml={junit_xml}",
     ] + SMOKE_TESTS
 
     log.info("Running: %s", " ".join(cmd))
-
-    passed_tests = []
-    failed_tests = []
-    summary_line = ""
-    current_test = ""
 
     with open(results_log, "w") as log_file:
         proc = subprocess.Popen(
@@ -235,31 +280,55 @@ def run_tests(jax_src: Path, results_log: Path) -> tuple[int, dict]:
             sys.stdout.write(line)
             sys.stdout.flush()
             log_file.write(line)
-            test_header = re.match(r"tests/.*?::([\w:]+)", line)
-            if test_header:
-                current_test = test_header.group(1)
-            if "PASSED" in line and re.search(r"PASSED\s+\[", line):
-                dur_match = re.search(r"\[(\d+\.\d+s)\]", line)
-                duration = dur_match.group(1) if dur_match else ""
-                passed_tests.append((current_test, duration))
-                current_test = ""
-            elif "FAILED" in line and re.search(r"FAILED\s+\[", line):
-                failed_tests.append(current_test)
-                current_test = ""
-            elif line.strip().startswith("=") and "passed" in line:
-                summary_line = line.strip()
         proc.wait()
 
     log.info("Test exit code: %d", proc.returncode)
     log.info("Results written to: %s", results_log)
 
+    exit_code = proc.returncode
+    passed_tests = []
+    failed_tests = []
+    tests_run = 0
+    summary_line = ""
+
+    if junit_xml.exists():
+        log.info("Parsing JUnit XML: %s", junit_xml)
+        junit = parse_junit_xml(junit_xml)
+        passed_tests = junit["passed"]
+        failed_tests = junit["failed"]
+        tests_run = junit["tests_run"]
+        parts = []
+        if passed_tests:
+            parts.append(f"{len(passed_tests)} passed")
+        if failed_tests:
+            parts.append(f"{len(failed_tests)} failed")
+        summary_line = ", ".join(parts)
+
+        if junit["error_details"]:
+            log.info("Failure/error details from JUnit XML:")
+            for detail in junit["error_details"]:
+                log.info("  %s", detail)
+    else:
+        log.warning("JUnit XML not found at %s, falling back to exit code only", junit_xml)
+
+    if tests_run < len(SMOKE_TESTS):
+        log.error(
+            "Expected %d smoke tests but only %d were collected — "
+            "tests may have been skipped or deselected",
+            len(SMOKE_TESTS),
+            tests_run,
+        )
+        exit_code = 1
+
     summary = {
-        "exit_code": proc.returncode,
+        "exit_code": exit_code,
         "passed": passed_tests,
         "failed": failed_tests,
-        "summary_line": summary_line.strip("= "),
+        "summary_line": summary_line,
+        "tests_run": tests_run,
+        "expected_tests": len(SMOKE_TESTS),
     }
-    return proc.returncode, summary
+    return exit_code, summary
 
 
 def generate_summary_report(summary: dict, rccl_lib: Path) -> str:
@@ -281,8 +350,11 @@ def generate_summary_report(summary: dict, rccl_lib: Path) -> str:
         f"GPUs:       {len(devices)}x {gpu_name}",
         "",
         f"Results:    {summary['summary_line']}",
-        "",
     ]
+
+    if summary.get("expected_tests") is not None:
+        lines.append(f"Collected:  {summary['tests_run']}/{summary['expected_tests']} expected smoke tests")
+    lines.append("")
 
     if summary["failed"]:
         lines.append(f"FAILED tests ({len(summary['failed'])}):")

--- a/.github/scripts/test_jax_collective.py
+++ b/.github/scripts/test_jax_collective.py
@@ -35,7 +35,6 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 log = logging.getLogger(__name__)
 
 JAX_REPO = "https://github.com/ROCm/jax.git"
-JAX_REF = "66918cf7a6adef25e8f71dbebb954e6dd5393109"  # jax-v0.10.2-testing
 
 SMOKE_TEST_FILES = [
     "tests/pmap_test.py",
@@ -133,33 +132,42 @@ def setup_xla_environment() -> None:
 
 
 def clone_jax_test_sources(jax_src: Path) -> None:
-    """Sparse-clone ROCm/jax at a pinned commit to get test sources."""
+    """Sparse-clone ROCm/jax to get test sources matching the installed version.
+
+    Tries to find a tag matching the installed JAX version (e.g. jax-v0.5.3).
+    Falls back to the default branch HEAD for nightly/dev builds.
+    """
     if jax_src.exists() and (jax_src / "tests" / "pmap_test.py").exists():
         log.info("JAX test sources already present at %s, skipping clone", jax_src)
         return
 
-    log.info("Cloning ROCm/jax (commit=%s, sparse) into %s", JAX_REF[:12], jax_src)
-    subprocess.run(
-        [
-            "git", "clone",
-            "--depth=1",
-            "--filter=blob:none",
-            "--sparse",
-            JAX_REPO,
-            str(jax_src),
-        ],
-        check=True,
+    import jax
+    jax_version = jax.__version__
+    base_version = jax_version.split(".dev")[0].split("+")[0]
+    git_ref = f"jax-v{base_version}"
+    log.info("JAX version: %s, trying tag: %s", jax_version, git_ref)
+
+    result = subprocess.run(
+        ["git", "ls-remote", "--tags", JAX_REPO, git_ref],
+        capture_output=True, text=True,
     )
-    subprocess.run(
-        ["git", "fetch", "--depth=1", "origin", JAX_REF],
-        cwd=jax_src,
-        check=True,
-    )
-    subprocess.run(
-        ["git", "checkout", JAX_REF],
-        cwd=jax_src,
-        check=True,
-    )
+    if not result.stdout.strip():
+        log.info("Tag %s not found, using default branch HEAD", git_ref)
+        git_ref = None
+
+    clone_cmd = [
+        "git", "clone",
+        "--depth=1",
+        "--filter=blob:none",
+        "--sparse",
+        JAX_REPO,
+        str(jax_src),
+    ]
+    if git_ref:
+        clone_cmd.insert(-1, f"--branch={git_ref}")
+
+    log.info("Cloning ROCm/jax (ref=%s, sparse) into %s", git_ref or "HEAD", jax_src)
+    subprocess.run(clone_cmd, check=True)
     subprocess.run(
         ["git", "sparse-checkout", "set", "tests/", "build/", "jax/"],
         cwd=jax_src,

--- a/.github/scripts/test_jax_collective.py
+++ b/.github/scripts/test_jax_collective.py
@@ -79,10 +79,8 @@ def find_lib_dirs(artifact_dir: Path) -> list[Path]:
         lib_dirs.add(so_file.parent.resolve())
     sorted_dirs = sorted(lib_dirs)
     for d in sorted_dirs:
-        so_files = [f.name for f in d.iterdir() if ".so" in f.name]
-        log.info("Found lib dir: %s (%d libs)", d, len(so_files))
-        for f in sorted(so_files):
-            log.info("  %s", f)
+        count = sum(1 for f in d.iterdir() if ".so" in f.name)
+        log.info("Found lib dir: %s (%d libs)", d, count)
     return sorted_dirs
 
 
@@ -122,6 +120,50 @@ def setup_ld_library_path(lib_dirs: list[Path]) -> str:
     os.environ["LD_LIBRARY_PATH"] = new_path
     log.info("LD_LIBRARY_PATH=%s", new_path)
     return new_path
+
+
+def diagnose_shared_libs(lib_dirs: list[Path]) -> None:
+    """Run ldd on critical libraries to surface missing transitive deps."""
+    targets = ["librocprofiler-sdk.so.1", "libamdhip64.so"]
+    for d in lib_dirs:
+        for name in targets:
+            lib = d / name
+            if lib.exists():
+                log.info("ldd %s:", lib)
+                result = subprocess.run(
+                    ["ldd", str(lib)],
+                    capture_output=True, text=True,
+                )
+                for line in result.stdout.splitlines():
+                    log.info("  %s", line)
+                if result.returncode != 0:
+                    log.warning("ldd stderr: %s", result.stderr.strip())
+
+    try:
+        import jax_plugins.xla_rocm7 as xla_mod
+        plugin_dir = Path(xla_mod.__file__).parent
+        plugin_so = plugin_dir / "xla_rocm_plugin.so"
+        if plugin_so.exists():
+            log.info("ldd %s:", plugin_so)
+            result = subprocess.run(
+                ["ldd", str(plugin_so)],
+                capture_output=True, text=True,
+            )
+            for line in result.stdout.splitlines():
+                if "not found" in line:
+                    log.warning("  MISSING: %s", line.strip())
+                else:
+                    log.info("  %s", line)
+            log.info("readelf -d %s (RPATH/RUNPATH):", plugin_so)
+            result = subprocess.run(
+                ["readelf", "-d", str(plugin_so)],
+                capture_output=True, text=True,
+            )
+            for line in result.stdout.splitlines():
+                if "RPATH" in line or "RUNPATH" in line:
+                    log.info("  %s", line.strip())
+    except ImportError:
+        log.info("xla_rocm7 plugin not installed — skipping plugin ldd")
 
 
 def verify_rccl_override(rccl_lib_dir: Path) -> None:
@@ -464,6 +506,7 @@ def main() -> None:
     # Step 2: Set up LD_LIBRARY_PATH and verify override
     setup_ld_library_path(lib_dirs)
     verify_rccl_override(rccl_lib_dir)
+    diagnose_shared_libs(lib_dirs)
 
     # Step 3: Set XLA environment variables
     setup_xla_environment()

--- a/.github/scripts/test_jax_collective.py
+++ b/.github/scripts/test_jax_collective.py
@@ -17,13 +17,19 @@ Usage from GitHub Actions:
 import argparse
 import logging
 import os
-import smtplib
 import subprocess
 import sys
-import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
-from email.mime.text import MIMEText
 from pathlib import Path
+
+from rccl_ci_utils import (
+    find_rccl_library,
+    parse_junit_xml,
+    send_email_report,
+    set_github_output,
+    verify_rccl_override,
+    write_github_summary,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 log = logging.getLogger(__name__)
@@ -57,65 +63,22 @@ XLA_ENV = {
 }
 
 
-def find_rccl_library(artifact_dir: Path) -> Path:
-    """Find librccl.so in the artifact directory tree."""
-    matches = list(artifact_dir.rglob("librccl.so"))
-    if not matches:
-        so_files = list(artifact_dir.rglob("*.so"))[:20]
-        log.error("librccl.so not found in %s", artifact_dir)
-        log.error("Shared libraries found: %s", [str(f) for f in so_files])
-        sys.exit(1)
-    lib_path = matches[0].resolve()
-    log.info("Found librccl.so at: %s", lib_path)
-    return lib_path
+def find_rocm_lib_dir(artifact_dir: Path) -> Path | None:
+    """Find the dist/rocm/lib directory in artifacts."""
+    for d in artifact_dir.rglob("dist/rocm/lib"):
+        if d.is_dir():
+            log.info("Found ROCm lib dir: %s", d)
+            return d
+    return None
 
 
-def find_lib_dirs(artifact_dir: Path) -> list[Path]:
-    """Find all directories containing .so files in the artifact tree."""
-    lib_dirs: set[Path] = set()
-    for so_file in artifact_dir.rglob("*.so"):
-        lib_dirs.add(so_file.parent.resolve())
-    for so_file in artifact_dir.rglob("*.so.*"):
-        lib_dirs.add(so_file.parent.resolve())
-    sorted_dirs = sorted(lib_dirs)
-    for d in sorted_dirs:
-        count = sum(1 for f in d.iterdir() if ".so" in f.name)
-        log.info("Found lib dir: %s (%d libs)", d, count)
-    return sorted_dirs
-
-
-def create_soname_symlinks(lib_dirs: list[Path]) -> None:
-    """Create missing SONAME symlinks (e.g. libfoo.so.1 -> libfoo.so.1.2.3).
-
-    Artifact flattening can strip versioned symlinks. JAX wheels link
-    against SONAME versions (librocprofiler-sdk.so.1) that may only
-    exist as librocprofiler-sdk.so.1.0.0 after flattening.
-    """
-    for d in lib_dirs:
-        for so_file in d.glob("*.so.*"):
-            name = so_file.name
-            # Match libfoo.so.X.Y.Z — create libfoo.so.X symlink
-            parts = name.split(".so.")
-            if len(parts) != 2:
-                continue
-            version_parts = parts[1].split(".")
-            if len(version_parts) <= 1:
-                continue
-            soname = f"{parts[0]}.so.{version_parts[0]}"
-            soname_path = d / soname
-            if not soname_path.exists():
-                soname_path.symlink_to(so_file.name)
-                log.info("Created symlink: %s -> %s", soname_path, so_file.name)
-
-
-def setup_ld_library_path(lib_dirs: list[Path]) -> str:
-    """Prepend all artifact lib dirs to LD_LIBRARY_PATH."""
-    create_soname_symlinks(lib_dirs)
-
-    parts = [str(d) for d in lib_dirs]
-    rocm_lib = Path("/opt/rocm/lib")
-    if rocm_lib.is_dir():
-        parts.insert(0, str(rocm_lib))
+def setup_ld_library_path(
+    rccl_lib_dir: Path, rocm_lib_dir: Path | None
+) -> str:
+    """Prepend RCCL and ROCm lib dirs to LD_LIBRARY_PATH."""
+    parts = [str(rccl_lib_dir.resolve())]
+    if rocm_lib_dir:
+        parts.append(str(rocm_lib_dir.resolve()))
     existing = os.environ.get("LD_LIBRARY_PATH", "")
     if existing:
         parts.append(existing)
@@ -123,87 +86,6 @@ def setup_ld_library_path(lib_dirs: list[Path]) -> str:
     os.environ["LD_LIBRARY_PATH"] = new_path
     log.info("LD_LIBRARY_PATH=%s", new_path)
     return new_path
-
-
-def diagnose_shared_libs(lib_dirs: list[Path]) -> None:
-    """Run ldd on critical libraries to surface missing transitive deps."""
-    targets = ["librocprofiler-sdk.so.1", "libamdhip64.so"]
-    for d in lib_dirs:
-        for name in targets:
-            lib = d / name
-            if lib.exists():
-                log.info("ldd %s:", lib)
-                result = subprocess.run(
-                    ["ldd", str(lib)],
-                    capture_output=True, text=True,
-                )
-                for line in result.stdout.splitlines():
-                    log.info("  %s", line)
-                if result.returncode != 0:
-                    log.warning("ldd stderr: %s", result.stderr.strip())
-
-    try:
-        import jax_plugins.xla_rocm7 as xla_mod
-        plugin_dir = Path(xla_mod.__file__).parent
-        plugin_so = plugin_dir / "xla_rocm_plugin.so"
-        if plugin_so.exists():
-            log.info("ldd %s:", plugin_so)
-            result = subprocess.run(
-                ["ldd", str(plugin_so)],
-                capture_output=True, text=True,
-            )
-            for line in result.stdout.splitlines():
-                if "not found" in line:
-                    log.warning("  MISSING: %s", line.strip())
-                else:
-                    log.info("  %s", line)
-            log.info("readelf -d %s (RPATH/RUNPATH):", plugin_so)
-            result = subprocess.run(
-                ["readelf", "-d", str(plugin_so)],
-                capture_output=True, text=True,
-            )
-            for line in result.stdout.splitlines():
-                if "RPATH" in line or "RUNPATH" in line:
-                    log.info("  %s", line.strip())
-    except ImportError:
-        log.info("xla_rocm7 plugin not installed — skipping plugin ldd")
-
-
-def populate_rocm_lib_dir(lib_dirs: list[Path]) -> None:
-    """Populate /opt/rocm/lib with symlinks to artifact libraries.
-
-    JAX's xla_rocm_plugin.so typically has RUNPATH set to /opt/rocm/lib.
-    With ELF RUNPATH semantics, transitive dependencies are resolved via
-    RUNPATH rather than LD_LIBRARY_PATH. In a container with no system
-    ROCm, we populate /opt/rocm/lib so the loader can find them.
-    """
-    rocm_lib = Path("/opt/rocm/lib")
-    try:
-        rocm_lib.mkdir(parents=True, exist_ok=True)
-    except PermissionError:
-        log.warning("Cannot create %s — not running as root", rocm_lib)
-        return
-
-    count = 0
-    for d in lib_dirs:
-        for so_file in d.iterdir():
-            if ".so" not in so_file.name:
-                continue
-            target = rocm_lib / so_file.name
-            if target.exists() or target.is_symlink():
-                continue
-            target.symlink_to(so_file.resolve())
-            count += 1
-    log.info("Created %d symlinks in %s", count, rocm_lib)
-
-
-def verify_rccl_override(rccl_lib_dir: Path) -> None:
-    """Verify that the CI-built librccl.so exists on disk."""
-    ci_rccl = rccl_lib_dir.resolve() / "librccl.so"
-    if not ci_rccl.exists():
-        log.error("CI-built librccl.so not found at %s", ci_rccl)
-        sys.exit(1)
-    log.info("CI-built RCCL: %s (%d bytes)", ci_rccl, ci_rccl.stat().st_size)
 
 
 def setup_xla_environment() -> None:
@@ -277,53 +159,6 @@ def print_environment_info() -> None:
     for key in sorted(XLA_ENV):
         log.info("%s=%s", key, os.environ.get(key, "<unset>"))
     log.info("--- End Environment Info ---")
-
-
-def parse_junit_xml(xml_path: Path) -> dict:
-    """Parse JUnit XML and return structured results."""
-    tree = ET.parse(xml_path)
-    root = tree.getroot()
-
-    passed_tests = []
-    failed_tests = []
-    error_details = []
-    tests_run = 0
-    failures = 0
-    errors = 0
-
-    for suite in root.iter("testsuite"):
-        tests_run = int(suite.get("tests", 0))
-        failures = int(suite.get("failures", 0))
-        errors = int(suite.get("errors", 0))
-
-    for tc in root.iter("testcase"):
-        name = tc.get("name", "")
-        time_s = tc.get("time", "")
-        duration = f"{float(time_s):.2f}s" if time_s else ""
-
-        failure = tc.find("failure")
-        error = tc.find("error")
-        if failure is not None:
-            failed_tests.append(name)
-            error_details.append(
-                f"FAILED: {name}\n  {failure.get('message', '')}"
-            )
-        elif error is not None:
-            failed_tests.append(name)
-            error_details.append(
-                f"ERROR: {name}\n  {error.get('message', '')}"
-            )
-        else:
-            passed_tests.append((name, duration))
-
-    return {
-        "passed": passed_tests,
-        "failed": failed_tests,
-        "error_details": error_details,
-        "tests_run": tests_run,
-        "failures": failures,
-        "errors": errors,
-    }
 
 
 def run_tests(jax_src: Path, results_log: Path) -> tuple[int, dict]:
@@ -450,46 +285,6 @@ def generate_summary_report(summary: dict, rccl_lib: Path) -> str:
     return "\n".join(lines)
 
 
-def write_github_summary(report: str) -> None:
-    """Write report to GITHUB_STEP_SUMMARY if available."""
-    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
-    if summary_file:
-        with open(summary_file, "a") as f:
-            f.write("```\n")
-            f.write(report)
-            f.write("\n```\n")
-        log.info("Summary written to GITHUB_STEP_SUMMARY")
-
-
-def send_email_report(report: str, recipient: str, status: str) -> None:
-    """Send the summary report via email."""
-    subject = f"RCCL JAX Collective Test: {status}"
-    msg = MIMEText(report)
-    msg["Subject"] = subject
-    msg["From"] = "rccl-ci@amd.com"
-    msg["To"] = recipient
-
-    smtp_servers = ["smtp.amd.com", "aussmtp.amd.com", "mail.amd.com", "localhost"]
-    for server in smtp_servers:
-        try:
-            with smtplib.SMTP(server, timeout=10) as s:
-                s.sendmail(msg["From"], [recipient], msg.as_string())
-            log.info("Email sent to %s via %s", recipient, server)
-            return
-        except Exception as e:
-            log.debug("SMTP %s failed: %s", server, e)
-            continue
-    log.warning("Could not send email to %s (tried: %s)", recipient, ", ".join(smtp_servers))
-
-
-def set_github_output(key: str, value: str) -> None:
-    """Write a key=value pair to GITHUB_OUTPUT if available."""
-    output_file = os.environ.get("GITHUB_OUTPUT")
-    if output_file:
-        with open(output_file, "a") as f:
-            f.write(f"{key}={value}\n")
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -524,21 +319,21 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    # Step 1: Discover RCCL library and all lib dirs in artifacts
+    # Step 1: Discover RCCL library path
     rccl_lib = find_rccl_library(args.artifact_dir)
     rccl_lib_dir = rccl_lib.parent
-    lib_dirs = find_lib_dirs(args.artifact_dir)
+    rocm_lib_dir = find_rocm_lib_dir(args.artifact_dir)
 
     set_github_output("RCCL_LIB_DIR", str(rccl_lib_dir))
+    if rocm_lib_dir:
+        set_github_output("ROCM_LIB_DIR", str(rocm_lib_dir))
 
     if args.discover_only:
         return
 
-    # Step 2: Set up library paths and verify override
-    populate_rocm_lib_dir(lib_dirs)
-    setup_ld_library_path(lib_dirs)
+    # Step 2: Set up LD_LIBRARY_PATH and verify override
+    setup_ld_library_path(rccl_lib_dir, rocm_lib_dir)
     verify_rccl_override(rccl_lib_dir)
-    diagnose_shared_libs(lib_dirs)
 
     # Step 3: Set XLA environment variables
     setup_xla_environment()
@@ -561,7 +356,8 @@ def main() -> None:
 
     if args.notify_email:
         status = "PASSED" if exit_code == 0 else "FAILED"
-        send_email_report(report, args.notify_email, status)
+        send_email_report(report, args.notify_email, status,
+                          subject_prefix="RCCL JAX Collective Test")
 
     sys.exit(exit_code)
 

--- a/.github/scripts/test_jax_collective.py
+++ b/.github/scripts/test_jax_collective.py
@@ -3,28 +3,20 @@
 
 This script handles:
   1. Discovering the CI-built librccl.so in the artifact directory
-  2. Setting LD_LIBRARY_PATH to override JAX's bundled RCCL
-  3. Cloning the matching JAX test sources (sparse checkout of ROCm/jax)
-  4. Setting XLA environment variables for ROCm
-  5. Running 10 collective smoke tests via pytest
+  2. Verifying that LD_LIBRARY_PATH overrides JAX's bundled RCCL
+  3. Cloning the matching JAX test sources (sparse checkout)
+  4. Running pytest on pmap_test.py and shard_map_test.py
 
 Usage from GitHub Actions:
   python .github/scripts/test_jax_collective.py \
       --artifact-dir ./build \
       --jax-src ./jax-src \
       --results-log ./jax_collective_results.log
-
-Local prototyping (no RCCL override):
-  python .github/scripts/test_jax_collective.py \
-      --jax-src ./jax-src \
-      --results-log ./jax_collective_results.log \
-      --skip-rccl-override
 """
 
 import argparse
 import logging
 import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -33,7 +25,7 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 log = logging.getLogger(__name__)
 
 JAX_REPO = "https://github.com/ROCm/jax.git"
-DEFAULT_BRANCH = "jax-v0.10.2-testing"
+JAX_REF = "66918cf7a6adef25e8f71dbebb954e6dd5393109"  # jax-v0.10.2-testing
 
 SMOKE_TESTS = [
     "tests/pmap_test.py::PythonPmapTest::testBasic",
@@ -112,23 +104,32 @@ def setup_xla_environment() -> None:
         log.info("Set %s=%s", key, value)
 
 
-def clone_jax_test_sources(jax_src: Path, branch: str) -> None:
-    """Sparse-clone ROCm/jax to get test sources and test-requirements.txt."""
+def clone_jax_test_sources(jax_src: Path) -> None:
+    """Sparse-clone ROCm/jax at a pinned commit to get test sources."""
     if jax_src.exists() and (jax_src / "tests" / "pmap_test.py").exists():
         log.info("JAX test sources already present at %s, skipping clone", jax_src)
         return
 
-    log.info("Cloning ROCm/jax (branch=%s, sparse) into %s", branch, jax_src)
+    log.info("Cloning ROCm/jax (commit=%s, sparse) into %s", JAX_REF[:12], jax_src)
     subprocess.run(
         [
             "git", "clone",
             "--depth=1",
-            f"--branch={branch}",
             "--filter=blob:none",
             "--sparse",
             JAX_REPO,
             str(jax_src),
         ],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "fetch", "--depth=1", "origin", JAX_REF],
+        cwd=jax_src,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "checkout", JAX_REF],
+        cwd=jax_src,
         check=True,
     )
     subprocess.run(
@@ -142,28 +143,6 @@ def clone_jax_test_sources(jax_src: Path, branch: str) -> None:
         log.error("pmap_test.py not found after clone")
         sys.exit(1)
     log.info("JAX test sources ready: %s", jax_src)
-
-
-def _pip_install(args: list[str]) -> None:
-    """Install packages using uv pip (preferred) or pip."""
-    if shutil.which("uv"):
-        cmd = ["uv", "pip", "install"] + args
-    else:
-        cmd = [sys.executable, "-m", "pip", "install"] + args
-    log.info("Running: %s", " ".join(cmd))
-    subprocess.run(cmd, check=True)
-
-
-def install_test_requirements(jax_src: Path) -> None:
-    """Install test dependencies from build/test-requirements.txt."""
-    req_file = jax_src / "build" / "test-requirements.txt"
-    if not req_file.exists():
-        log.warning("build/test-requirements.txt not found, installing minimal deps")
-        _pip_install(["pytest", "pytest-timeout", "hypothesis", "numpy", "absl-py"])
-        return
-
-    log.info("Installing test requirements from %s", req_file)
-    _pip_install(["-r", str(req_file)])
 
 
 def print_environment_info() -> None:
@@ -185,12 +164,12 @@ def print_environment_info() -> None:
     log.info("--- End Environment Info ---")
 
 
-def run_tests(jax_src: Path, results_log: Path, timeout: int) -> int:
+def run_tests(jax_src: Path, results_log: Path) -> int:
     """Run pytest on the 10 collective smoke tests and return exit code."""
     cmd = [
         sys.executable, "-m", "pytest",
         "-sv",
-        f"--timeout={timeout}",
+        "--timeout=120",
         "--tb=short",
     ] + SMOKE_TESTS
 
@@ -221,13 +200,12 @@ def set_github_output(key: str, value: str) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__,
-                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--artifact-dir",
         type=Path,
-        default=None,
-        help="Directory containing CI-built RCCL artifacts",
+        required=True,
+        help="Directory containing CI-built artifacts",
     )
     parser.add_argument(
         "--jax-src",
@@ -236,82 +214,44 @@ def main() -> None:
         help="Directory to clone JAX test sources into",
     )
     parser.add_argument(
-        "--jax-branch",
-        default=DEFAULT_BRANCH,
-        help=f"ROCm/jax branch for test sources (default: {DEFAULT_BRANCH})",
-    )
-    parser.add_argument(
         "--results-log",
         type=Path,
         default=Path("jax_collective_results.log"),
         help="Path for test results log file",
     )
     parser.add_argument(
-        "--timeout",
-        type=int,
-        default=120,
-        help="Per-test timeout in seconds (default: 120)",
-    )
-    parser.add_argument(
-        "--skip-rccl-override",
-        action="store_true",
-        help="Skip RCCL library override (use system/wheel-bundled RCCL)",
-    )
-    parser.add_argument(
         "--discover-only",
         action="store_true",
         help="Only discover library paths and set GITHUB_OUTPUT, then exit",
     )
-    parser.add_argument(
-        "--skip-clone",
-        action="store_true",
-        help="Skip cloning JAX sources (assume already present)",
-    )
-    parser.add_argument(
-        "--skip-install-deps",
-        action="store_true",
-        help="Skip installing test dependencies",
-    )
 
     args = parser.parse_args()
 
-    # Step 1: RCCL library discovery and override
-    if not args.skip_rccl_override:
-        if args.artifact_dir is None:
-            log.error("--artifact-dir required unless --skip-rccl-override is set")
-            sys.exit(1)
-        rccl_lib = find_rccl_library(args.artifact_dir)
-        rccl_lib_dir = rccl_lib.parent
-        rocm_lib_dir = find_rocm_lib_dir(args.artifact_dir)
+    # Step 1: Discover RCCL library path
+    rccl_lib = find_rccl_library(args.artifact_dir)
+    rccl_lib_dir = rccl_lib.parent
+    rocm_lib_dir = find_rocm_lib_dir(args.artifact_dir)
 
-        set_github_output("RCCL_LIB_DIR", str(rccl_lib_dir))
-        if rocm_lib_dir:
-            set_github_output("ROCM_LIB_DIR", str(rocm_lib_dir))
+    set_github_output("RCCL_LIB_DIR", str(rccl_lib_dir))
+    if rocm_lib_dir:
+        set_github_output("ROCM_LIB_DIR", str(rocm_lib_dir))
 
-        if args.discover_only:
-            return
-
-        setup_ld_library_path(rccl_lib_dir, rocm_lib_dir)
-        verify_rccl_override(rccl_lib_dir)
-    elif args.discover_only:
+    if args.discover_only:
         return
 
-    # Step 2: Set XLA environment variables
+    # Step 2: Set up LD_LIBRARY_PATH and verify override
+    setup_ld_library_path(rccl_lib_dir, rocm_lib_dir)
+    verify_rccl_override(rccl_lib_dir)
+
+    # Step 3: Set XLA environment variables
     setup_xla_environment()
 
-    # Step 3: Clone JAX test sources
-    if not args.skip_clone:
-        clone_jax_test_sources(args.jax_src, args.jax_branch)
+    # Step 4: Clone JAX test sources
+    clone_jax_test_sources(args.jax_src)
 
-    # Step 4: Install test dependencies
-    if not args.skip_install_deps:
-        install_test_requirements(args.jax_src)
-
-    # Step 5: Print environment info (also validates JAX can see GPUs)
+    # Step 5: Print environment info and run tests
     print_environment_info()
-
-    # Step 6: Run smoke tests
-    exit_code = run_tests(args.jax_src, args.results_log, args.timeout)
+    exit_code = run_tests(args.jax_src, args.results_log)
     sys.exit(exit_code)
 
 

--- a/.github/scripts/test_jax_collective.py
+++ b/.github/scripts/test_jax_collective.py
@@ -37,17 +37,22 @@ log = logging.getLogger(__name__)
 JAX_REPO = "https://github.com/ROCm/jax.git"
 JAX_REF = "66918cf7a6adef25e8f71dbebb954e6dd5393109"  # jax-v0.10.2-testing
 
-SMOKE_TESTS = [
-    "tests/pmap_test.py::PythonPmapTest::testBasic",
-    "tests/pmap_test.py::PythonPmapTest::testGather",
-    "tests/pmap_test.py::PythonPmapTest::testReduceScatter",
-    "tests/pmap_test.py::PythonPmapTest::testCollectivePermute",
-    "tests/pmap_test.py::PythonPmapTest::testAllToAll0",
-    "tests/shard_map_test.py::ShardMapTest::test_all_gather",
-    "tests/shard_map_test.py::ShardMapTest::test_matmul_reduce_scatter",
-    "tests/shard_map_test.py::ShardMapTest::test_collective_permute",
-    "tests/shard_map_test.py::ShardMapTest::test_axis_index",
-    "tests/shard_map_test.py::ShardMapTest::test_all_to_all_multiple_axis_names",
+SMOKE_TEST_FILES = [
+    "tests/pmap_test.py",
+    "tests/shard_map_test.py",
+]
+
+SMOKE_TEST_KEYWORDS = [
+    "PythonPmapTest and testBasic",
+    "PythonPmapTest and testGather and not testGatherBool and not testGatherNeg and not testGatherTiled and not testGatherReplica",
+    "PythonPmapTest and testReduceScatter and not Tiled and not Replica",
+    "PythonPmapTest and testCollectivePermute and not Grad and not Cyclic",
+    "PythonPmapTest and testAllToAll and not Replica and not Vmap and not Grad",
+    "ShardMapTest and test_all_gather and not invariant and not axis_index",
+    "ShardMapTest and test_matmul_reduce_scatter",
+    "ShardMapTest and test_collective_permute and not multiple",
+    "ShardMapTest and test_axis_index and not basic and not twoaxes and not eager",
+    "ShardMapTest and test_all_to_all and not axis_index and not grad",
 ]
 
 XLA_ENV = {
@@ -197,13 +202,15 @@ def run_tests(jax_src: Path, results_log: Path) -> tuple[int, dict]:
     """Run pytest on the 10 collective smoke tests and return (exit_code, summary)."""
     junit_xml = results_log.parent / "jax_collective_results.xml"
 
+    k_expr = " or ".join(f"({kw})" for kw in SMOKE_TEST_KEYWORDS)
     cmd = [
         sys.executable, "-m", "pytest",
         "-sv",
         "--timeout=120",
         "--tb=short",
         f"--junitxml={junit_xml}",
-    ] + SMOKE_TESTS
+        "-k", k_expr,
+    ] + SMOKE_TEST_FILES
 
     log.info("Running: %s", " ".join(cmd))
 
@@ -251,11 +258,11 @@ def run_tests(jax_src: Path, results_log: Path) -> tuple[int, dict]:
     else:
         log.warning("JUnit XML not found at %s, falling back to exit code only", junit_xml)
 
-    if tests_run < len(SMOKE_TESTS):
+    if tests_run < len(SMOKE_TEST_KEYWORDS):
         log.error(
-            "Expected %d smoke tests but only %d were collected — "
+            "Expected at least %d smoke tests but only %d were collected — "
             "tests may have been skipped or deselected",
-            len(SMOKE_TESTS),
+            len(SMOKE_TEST_KEYWORDS),
             tests_run,
         )
         exit_code = 1
@@ -266,7 +273,7 @@ def run_tests(jax_src: Path, results_log: Path) -> tuple[int, dict]:
         "failed": failed_tests,
         "summary_line": summary_line,
         "tests_run": tests_run,
-        "expected_tests": len(SMOKE_TESTS),
+        "expected_tests": len(SMOKE_TEST_KEYWORDS),
     }
     return exit_code, summary
 

--- a/.github/scripts/test_jax_collective.py
+++ b/.github/scripts/test_jax_collective.py
@@ -63,22 +63,54 @@ XLA_ENV = {
 }
 
 
-def find_rocm_lib_dir(artifact_dir: Path) -> Path | None:
-    """Find the dist/rocm/lib directory in artifacts."""
-    for d in artifact_dir.rglob("dist/rocm/lib"):
-        if d.is_dir():
-            log.info("Found ROCm lib dir: %s", d)
-            return d
-    return None
+def find_lib_dirs(artifact_dir: Path) -> list[Path]:
+    """Find all directories containing .so files in the artifact tree."""
+    lib_dirs: set[Path] = set()
+    for so_file in artifact_dir.rglob("*.so"):
+        lib_dirs.add(so_file.parent.resolve())
+    for so_file in artifact_dir.rglob("*.so.*"):
+        lib_dirs.add(so_file.parent.resolve())
+    sorted_dirs = sorted(lib_dirs)
+    for d in sorted_dirs:
+        count = sum(1 for f in d.iterdir() if ".so" in f.name)
+        log.info("Found lib dir: %s (%d libs)", d, count)
+    return sorted_dirs
 
 
-def setup_ld_library_path(
-    rccl_lib_dir: Path, rocm_lib_dir: Path | None
-) -> str:
-    """Prepend RCCL and ROCm lib dirs to LD_LIBRARY_PATH."""
-    parts = [str(rccl_lib_dir.resolve())]
-    if rocm_lib_dir:
-        parts.append(str(rocm_lib_dir.resolve()))
+def populate_rocm_lib_dir(lib_dirs: list[Path]) -> None:
+    """Populate /opt/rocm/lib with symlinks to artifact libraries.
+
+    JAX's xla_rocm_plugin.so has RUNPATH including /opt/rocm/lib. With ELF
+    RUNPATH semantics, transitive dependencies are resolved via RUNPATH
+    rather than LD_LIBRARY_PATH. In a container with no system ROCm, we
+    populate /opt/rocm/lib so the loader can find them.
+    """
+    rocm_lib = Path("/opt/rocm/lib")
+    try:
+        rocm_lib.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        log.warning("Cannot create %s — not running as root", rocm_lib)
+        return
+
+    count = 0
+    for d in lib_dirs:
+        for so_file in d.iterdir():
+            if ".so" not in so_file.name:
+                continue
+            target = rocm_lib / so_file.name
+            if target.exists() or target.is_symlink():
+                continue
+            target.symlink_to(so_file.resolve())
+            count += 1
+    log.info("Created %d symlinks in %s", count, rocm_lib)
+
+
+def setup_ld_library_path(lib_dirs: list[Path]) -> str:
+    """Prepend all artifact lib dirs to LD_LIBRARY_PATH."""
+    parts = [str(d) for d in lib_dirs]
+    rocm_lib = Path("/opt/rocm/lib")
+    if rocm_lib.is_dir():
+        parts.insert(0, str(rocm_lib))
     existing = os.environ.get("LD_LIBRARY_PATH", "")
     if existing:
         parts.append(existing)
@@ -319,20 +351,19 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    # Step 1: Discover RCCL library path
+    # Step 1: Discover RCCL library and all lib dirs in artifacts
     rccl_lib = find_rccl_library(args.artifact_dir)
     rccl_lib_dir = rccl_lib.parent
-    rocm_lib_dir = find_rocm_lib_dir(args.artifact_dir)
+    lib_dirs = find_lib_dirs(args.artifact_dir)
 
     set_github_output("RCCL_LIB_DIR", str(rccl_lib_dir))
-    if rocm_lib_dir:
-        set_github_output("ROCM_LIB_DIR", str(rocm_lib_dir))
 
     if args.discover_only:
         return
 
-    # Step 2: Set up LD_LIBRARY_PATH and verify override
-    setup_ld_library_path(rccl_lib_dir, rocm_lib_dir)
+    # Step 2: Set up library paths and verify override
+    populate_rocm_lib_dir(lib_dirs)
+    setup_ld_library_path(lib_dirs)
     verify_rccl_override(rccl_lib_dir)
 
     # Step 3: Set XLA environment variables

--- a/.github/scripts/test_jax_collective.py
+++ b/.github/scripts/test_jax_collective.py
@@ -17,8 +17,12 @@ Usage from GitHub Actions:
 import argparse
 import logging
 import os
+import re
+import smtplib
 import subprocess
 import sys
+from datetime import datetime, timezone
+from email.mime.text import MIMEText
 from pathlib import Path
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -61,7 +65,7 @@ def find_rccl_library(artifact_dir: Path) -> Path:
         log.error("librccl.so not found in %s", artifact_dir)
         log.error("Shared libraries found: %s", [str(f) for f in so_files])
         sys.exit(1)
-    lib_path = matches[0]
+    lib_path = matches[0].resolve()
     log.info("Found librccl.so at: %s", lib_path)
     return lib_path
 
@@ -165,8 +169,8 @@ def print_environment_info() -> None:
     log.info("--- End Environment Info ---")
 
 
-def run_tests(jax_src: Path, results_log: Path) -> int:
-    """Run pytest on the 10 collective smoke tests and return exit code."""
+def run_tests(jax_src: Path, results_log: Path) -> tuple[int, dict]:
+    """Run pytest on the 10 collective smoke tests and return (exit_code, summary)."""
     cmd = [
         sys.executable, "-m", "pytest",
         "-sv",
@@ -176,20 +180,124 @@ def run_tests(jax_src: Path, results_log: Path) -> int:
 
     log.info("Running: %s", " ".join(cmd))
 
+    passed_tests = []
+    failed_tests = []
+    summary_line = ""
+    current_test = ""
+
     with open(results_log, "w") as log_file:
-        proc = subprocess.run(
+        proc = subprocess.Popen(
             cmd,
             cwd=jax_src,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            bufsize=1,
         )
-        log_file.write(proc.stdout)
-        print(proc.stdout, end="")
+        for line in proc.stdout:
+            sys.stdout.write(line)
+            sys.stdout.flush()
+            log_file.write(line)
+            test_header = re.match(r"tests/.*?::([\w:]+)", line)
+            if test_header:
+                current_test = test_header.group(1)
+            if "PASSED" in line and re.search(r"PASSED\s+\[", line):
+                dur_match = re.search(r"\[(\d+\.\d+s)\]", line)
+                duration = dur_match.group(1) if dur_match else ""
+                passed_tests.append((current_test, duration))
+                current_test = ""
+            elif "FAILED" in line and re.search(r"FAILED\s+\[", line):
+                failed_tests.append(current_test)
+                current_test = ""
+            elif line.strip().startswith("=") and "passed" in line:
+                summary_line = line.strip()
+        proc.wait()
 
     log.info("Test exit code: %d", proc.returncode)
     log.info("Results written to: %s", results_log)
-    return proc.returncode
+
+    summary = {
+        "exit_code": proc.returncode,
+        "passed": passed_tests,
+        "failed": failed_tests,
+        "summary_line": summary_line.strip("= "),
+    }
+    return proc.returncode, summary
+
+
+def generate_summary_report(summary: dict, rccl_lib: Path) -> str:
+    """Generate a plain-text summary report."""
+    import jax
+
+    status = "PASSED" if summary["exit_code"] == 0 else "FAILED"
+    devices = jax.devices()
+    gpu_name = str(devices[0]) if devices else "unknown"
+
+    lines = [
+        "RCCL JAX Collective Test Report",
+        "=" * 40,
+        f"Status:     {status}",
+        f"Date:       {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}",
+        "",
+        f"JAX:        {jax.__version__}",
+        f"RCCL:       {rccl_lib}",
+        f"GPUs:       {len(devices)}x {gpu_name}",
+        "",
+        f"Results:    {summary['summary_line']}",
+        "",
+    ]
+
+    if summary["failed"]:
+        lines.append(f"FAILED tests ({len(summary['failed'])}):")
+        for name in summary["failed"]:
+            lines.append(f"  FAIL  {name}")
+        lines.append("")
+
+    if summary["passed"]:
+        lines.append(f"PASSED tests ({len(summary['passed'])}):")
+        for name, duration in summary["passed"]:
+            lines.append(f"  OK    {name:60s} {duration}")
+        lines.append("")
+
+    run_url = os.environ.get("GITHUB_SERVER_URL", "")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    if run_url and repo and run_id:
+        lines.append(f"CI run: {run_url}/{repo}/actions/runs/{run_id}")
+
+    return "\n".join(lines)
+
+
+def write_github_summary(report: str) -> None:
+    """Write report to GITHUB_STEP_SUMMARY if available."""
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a") as f:
+            f.write("```\n")
+            f.write(report)
+            f.write("\n```\n")
+        log.info("Summary written to GITHUB_STEP_SUMMARY")
+
+
+def send_email_report(report: str, recipient: str, status: str) -> None:
+    """Send the summary report via email."""
+    subject = f"RCCL JAX Collective Test: {status}"
+    msg = MIMEText(report)
+    msg["Subject"] = subject
+    msg["From"] = "rccl-ci@amd.com"
+    msg["To"] = recipient
+
+    smtp_servers = ["smtp.amd.com", "aussmtp.amd.com", "mail.amd.com", "localhost"]
+    for server in smtp_servers:
+        try:
+            with smtplib.SMTP(server, timeout=10) as s:
+                s.sendmail(msg["From"], [recipient], msg.as_string())
+            log.info("Email sent to %s via %s", recipient, server)
+            return
+        except Exception as e:
+            log.debug("SMTP %s failed: %s", server, e)
+            continue
+    log.warning("Could not send email to %s (tried: %s)", recipient, ", ".join(smtp_servers))
 
 
 def set_github_output(key: str, value: str) -> None:
@@ -219,6 +327,12 @@ def main() -> None:
         type=Path,
         default=Path("jax_collective_results.log"),
         help="Path for test results log file",
+    )
+    parser.add_argument(
+        "--notify-email",
+        type=str,
+        default="",
+        help="Send summary report to this email address",
     )
     parser.add_argument(
         "--discover-only",
@@ -252,7 +366,21 @@ def main() -> None:
 
     # Step 5: Print environment info and run tests
     print_environment_info()
-    exit_code = run_tests(args.jax_src, args.results_log)
+    exit_code, summary = run_tests(args.jax_src, args.results_log)
+
+    # Step 6: Generate and distribute summary report
+    report = generate_summary_report(summary, rccl_lib)
+    log.info("\n%s", report)
+    write_github_summary(report)
+
+    summary_path = args.results_log.parent / "jax_collective_summary.txt"
+    summary_path.write_text(report)
+    log.info("Summary written to: %s", summary_path)
+
+    if args.notify_email:
+        status = "PASSED" if exit_code == 0 else "FAILED"
+        send_email_report(report, args.notify_email, status)
+
     sys.exit(exit_code)
 
 

--- a/.github/scripts/test_jax_collective.py
+++ b/.github/scripts/test_jax_collective.py
@@ -70,20 +70,22 @@ def find_rccl_library(artifact_dir: Path) -> Path:
     return lib_path
 
 
-def find_rocm_lib_dir(artifact_dir: Path) -> Path | None:
-    """Find the dist/rocm/lib directory in artifacts."""
-    for d in artifact_dir.rglob("dist/rocm/lib"):
-        if d.is_dir():
-            log.info("Found ROCm lib dir: %s", d)
-            return d
-    return None
+def find_lib_dirs(artifact_dir: Path) -> list[Path]:
+    """Find all directories containing .so files in the artifact tree."""
+    lib_dirs: set[Path] = set()
+    for so_file in artifact_dir.rglob("*.so"):
+        lib_dirs.add(so_file.parent.resolve())
+    for so_file in artifact_dir.rglob("*.so.*"):
+        lib_dirs.add(so_file.parent.resolve())
+    sorted_dirs = sorted(lib_dirs)
+    for d in sorted_dirs:
+        log.info("Found lib dir: %s", d)
+    return sorted_dirs
 
 
-def setup_ld_library_path(rccl_lib_dir: Path, rocm_lib_dir: Path | None) -> str:
-    """Prepend RCCL and ROCm lib dirs to LD_LIBRARY_PATH."""
-    parts = [str(rccl_lib_dir.resolve())]
-    if rocm_lib_dir:
-        parts.append(str(rocm_lib_dir.resolve()))
+def setup_ld_library_path(lib_dirs: list[Path]) -> str:
+    """Prepend all artifact lib dirs to LD_LIBRARY_PATH."""
+    parts = [str(d) for d in lib_dirs]
     existing = os.environ.get("LD_LIBRARY_PATH", "")
     if existing:
         parts.append(existing)
@@ -156,9 +158,15 @@ def print_environment_info() -> None:
     try:
         import jax
         log.info("JAX version: %s", jax.__version__)
-        log.info("Devices: %s", jax.devices())
+        devices = jax.devices()
+        log.info("Devices: %s", devices)
         log.info("Device count: %d", jax.device_count())
         log.info("Local device count: %d", jax.local_device_count())
+        gpu_devices = [d for d in devices if d.platform != "cpu"]
+        if not gpu_devices:
+            log.error("No GPU devices found — JAX fell back to CPU only")
+            log.error("Check that ROCm libraries are on LD_LIBRARY_PATH")
+            sys.exit(1)
     except Exception as e:
         log.error("Failed to query JAX devices: %s", e)
         sys.exit(1)
@@ -342,20 +350,18 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    # Step 1: Discover RCCL library path
+    # Step 1: Discover RCCL library and all lib dirs in artifacts
     rccl_lib = find_rccl_library(args.artifact_dir)
     rccl_lib_dir = rccl_lib.parent
-    rocm_lib_dir = find_rocm_lib_dir(args.artifact_dir)
+    lib_dirs = find_lib_dirs(args.artifact_dir)
 
     set_github_output("RCCL_LIB_DIR", str(rccl_lib_dir))
-    if rocm_lib_dir:
-        set_github_output("ROCM_LIB_DIR", str(rocm_lib_dir))
 
     if args.discover_only:
         return
 
     # Step 2: Set up LD_LIBRARY_PATH and verify override
-    setup_ld_library_path(rccl_lib_dir, rocm_lib_dir)
+    setup_ld_library_path(lib_dirs)
     verify_rccl_override(rccl_lib_dir)
 
     # Step 3: Set XLA environment variables

--- a/.github/scripts/test_pytorch_c10d.py
+++ b/.github/scripts/test_pytorch_c10d.py
@@ -17,15 +17,20 @@ Usage from GitHub Actions:
 import argparse
 import logging
 import os
-import re
-import smtplib
 import subprocess
 import sys
 import tempfile
-import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
-from email.mime.text import MIMEText
 from pathlib import Path
+
+from rccl_ci_utils import (
+    find_rccl_library,
+    parse_junit_xml,
+    send_email_report,
+    set_github_output,
+    verify_rccl_override,
+    write_github_summary,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 log = logging.getLogger(__name__)
@@ -56,19 +61,6 @@ SMOKE_TESTS = [
 ]
 
 
-def find_rccl_library(artifact_dir: Path) -> Path:
-    """Find librccl.so in the artifact directory tree."""
-    matches = list(artifact_dir.rglob("librccl.so"))
-    if not matches:
-        so_files = list(artifact_dir.rglob("*.so"))[:20]
-        log.error("librccl.so not found in %s", artifact_dir)
-        log.error("Shared libraries found: %s", [str(f) for f in so_files])
-        sys.exit(1)
-    lib_path = matches[0].resolve()
-    log.info("Found librccl.so at: %s", lib_path)
-    return lib_path
-
-
 def find_rocm_lib_dir(artifact_dir: Path) -> Path | None:
     """Find the dist/rocm/lib directory in artifacts."""
     for d in artifact_dir.rglob("dist/rocm/lib"):
@@ -90,15 +82,6 @@ def setup_ld_library_path(rccl_lib_dir: Path, rocm_lib_dir: Path | None) -> str:
     os.environ["LD_LIBRARY_PATH"] = new_path
     log.info("LD_LIBRARY_PATH=%s", new_path)
     return new_path
-
-
-def verify_rccl_override(rccl_lib_dir: Path) -> None:
-    """Verify that the CI-built librccl.so exists on disk."""
-    ci_rccl = rccl_lib_dir.resolve() / "librccl.so"
-    if not ci_rccl.exists():
-        log.error("CI-built librccl.so not found at %s", ci_rccl)
-        sys.exit(1)
-    log.info("CI-built RCCL: %s (%d bytes)", ci_rccl, ci_rccl.stat().st_size)
 
 
 def clone_pytorch_test_sources(pytorch_src: Path) -> None:
@@ -231,53 +214,6 @@ def print_environment_info() -> None:
     for i in range(torch.cuda.device_count()):
         log.info("  GPU %d: %s", i, torch.cuda.get_device_name(i))
     log.info("LD_LIBRARY_PATH: %s", os.environ.get("LD_LIBRARY_PATH", ""))
-
-
-def parse_junit_xml(xml_path: Path) -> dict:
-    """Parse JUnit XML and return structured results."""
-    tree = ET.parse(xml_path)
-    root = tree.getroot()
-
-    passed_tests = []
-    failed_tests = []
-    error_details = []
-    tests_run = 0
-    failures = 0
-    errors = 0
-
-    for suite in root.iter("testsuite"):
-        tests_run = int(suite.get("tests", 0))
-        failures = int(suite.get("failures", 0))
-        errors = int(suite.get("errors", 0))
-
-    for tc in root.iter("testcase"):
-        name = tc.get("name", "")
-        time_s = tc.get("time", "")
-        duration = f"{float(time_s):.2f}s" if time_s else ""
-
-        failure = tc.find("failure")
-        error = tc.find("error")
-        if failure is not None:
-            failed_tests.append(name)
-            error_details.append(
-                f"FAILED: {name}\n  {failure.get('message', '')}"
-            )
-        elif error is not None:
-            failed_tests.append(name)
-            error_details.append(
-                f"ERROR: {name}\n  {error.get('message', '')}"
-            )
-        else:
-            passed_tests.append((name, duration))
-
-    return {
-        "passed": passed_tests,
-        "failed": failed_tests,
-        "error_details": error_details,
-        "tests_run": tests_run,
-        "failures": failures,
-        "errors": errors,
-    }
 
 
 def run_tests(pytorch_src: Path, results_log: Path, test_scope: str = "smoke") -> tuple[int, dict]:
@@ -429,46 +365,6 @@ def generate_summary_report(summary: dict, rccl_lib: Path) -> str:
     return "\n".join(lines)
 
 
-def write_github_summary(report: str) -> None:
-    """Write report to GITHUB_STEP_SUMMARY if available."""
-    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
-    if summary_file:
-        with open(summary_file, "a") as f:
-            f.write("```\n")
-            f.write(report)
-            f.write("\n```\n")
-        log.info("Summary written to GITHUB_STEP_SUMMARY")
-
-
-def send_email_report(report: str, recipient: str, status: str) -> None:
-    """Send the summary report via email."""
-    subject = f"RCCL PyTorch c10d Test: {status}"
-    msg = MIMEText(report)
-    msg["Subject"] = subject
-    msg["From"] = "rccl-ci@amd.com"
-    msg["To"] = recipient
-
-    smtp_servers = ["smtp.amd.com", "aussmtp.amd.com", "mail.amd.com", "localhost"]
-    for server in smtp_servers:
-        try:
-            with smtplib.SMTP(server, timeout=10) as s:
-                s.sendmail(msg["From"], [recipient], msg.as_string())
-            log.info("Email sent to %s via %s", recipient, server)
-            return
-        except Exception as e:
-            log.debug("SMTP %s failed: %s", server, e)
-            continue
-    log.warning("Could not send email to %s (tried: %s)", recipient, ", ".join(smtp_servers))
-
-
-def set_github_output(key: str, value: str) -> None:
-    """Write a key=value pair to GITHUB_OUTPUT if available."""
-    output_file = os.environ.get("GITHUB_OUTPUT")
-    if output_file:
-        with open(output_file, "a") as f:
-            f.write(f"{key}={value}\n")
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -544,7 +440,8 @@ def main() -> None:
 
     if args.notify_email:
         status = "PASSED" if exit_code == 0 else "FAILED"
-        send_email_report(report, args.notify_email, status)
+        send_email_report(report, args.notify_email, status,
+                          subject_prefix="RCCL PyTorch c10d Test")
 
     sys.exit(exit_code)
 

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -19,6 +19,7 @@ on:
         type: string
         default: ''
       test_scope:
+        description: 'Test scope: smoke (22 curated tests) or all'
         type: string
         default: 'smoke'
       notify_email:
@@ -31,6 +32,8 @@ permissions:
 jobs:
   therock-build-linux:
     name: Build Linux Packages
+    # Skipped when artifact_run_id is provided (reuse mode). Downstream jobs
+    # use `!cancelled()` in their `if:` so they still run when this is skipped.
     if: ${{ inputs.artifact_run_id == '' }}
     runs-on: azure-linux-scale-rocm
     permissions:

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -177,3 +177,15 @@ jobs:
       artifact_run_id: ${{ inputs.artifact_run_id || github.run_id }}
       test_scope: ${{ inputs.test_scope }}
       notify_email: ${{ inputs.notify_email }}
+
+  therock-test-jax-collective:
+    name: "Test JAX collective (scheduled)"
+    if: ${{ !cancelled() && inputs.amdgpu_families != 'gfx950-dcgpu' && (inputs.event_name == 'schedule' || inputs.event_name == 'workflow_dispatch') }}
+    needs: [therock-build-linux]
+    uses: ./.github/workflows/therock-rccl-test-jax-collective.yml
+    with:
+      amdgpu_families: ${{ inputs.amdgpu_families }}
+      artifact_group: ${{ inputs.artifact_group }}
+      test_runs_on: linux-gfx942-8gpu-ossci-rocm
+      artifact_run_id: ${{ inputs.artifact_run_id || github.run_id }}
+      notify_email: ${{ inputs.notify_email }}

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -49,6 +49,9 @@ jobs:
           echo "Changed files:"
           git diff --name-only HEAD^
 
+          # Scheduled and manual runs always execute the full CI pipeline.
+          # PR/push runs only trigger CI when files under projects/rccl/
+          # have changed, to avoid burning GPU runner time on unrelated commits.
           if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "run_linux_ci=true" >> "$GITHUB_OUTPUT"
             echo "Scheduled/manual run — always run CI"

--- a/.github/workflows/therock-rccl-test-jax-collective.yml
+++ b/.github/workflows/therock-rccl-test-jax-collective.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           AMDGPU_LOWER=$(echo "${{ inputs.amdgpu_families }}" | tr '[:upper:]' '[:lower:]')
           uv pip install --prerelease=allow \
-            rocm-sdk-core "rocm-sdk-libraries-${AMDGPU_LOWER}" \
+            "rocm-sdk-core>=7.0" "rocm-sdk-libraries-${AMDGPU_LOWER}>=7.0" \
             --index-url "https://rocm.nightlies.amd.com/v2/${{ inputs.amdgpu_families }}/" \
             --extra-index-url https://pypi.org/simple/
           uv pip install --prerelease=allow \

--- a/.github/workflows/therock-rccl-test-jax-collective.yml
+++ b/.github/workflows/therock-rccl-test-jax-collective.yml
@@ -76,6 +76,9 @@ jobs:
 
       - name: Install JAX and test dependencies
         timeout-minutes: 15
+        # Intentionally installs latest nightly wheels against pinned test sources.
+        # The 10 smoke tests use stable pmap/shard_map APIs that are compatible
+        # across JAX versions. This lets us catch RCCL regressions with current JAX.
         run: |
           uv pip install --prerelease=allow \
             jax-rocm7-plugin jax-rocm7-pjrt jax \

--- a/.github/workflows/therock-rccl-test-jax-collective.yml
+++ b/.github/workflows/therock-rccl-test-jax-collective.yml
@@ -91,9 +91,6 @@ jobs:
       - name: Run JAX collective smoke tests
         timeout-minutes: 10
         env:
-          XLA_PYTHON_CLIENT_ALLOCATOR: default
-          XLA_PYTHON_CLIENT_PREALLOCATE: "false"
-          XLA_FLAGS: "--xla_gpu_force_compilation_parallelism=1 --xla_gpu_enable_nccl_comm_splitting=false --xla_gpu_enable_command_buffer= --xla_gpu_enable_cublaslt=false"
           NCCL_DEBUG: INFO
         run: |
           python rocm-systems/.github/scripts/test_jax_collective.py \

--- a/.github/workflows/therock-rccl-test-jax-collective.yml
+++ b/.github/workflows/therock-rccl-test-jax-collective.yml
@@ -1,0 +1,110 @@
+name: TheRock Test JAX Collective for rccl
+
+on:
+  workflow_call:
+    inputs:
+      amdgpu_families:
+        type: string
+      artifact_group:
+        type: string
+      test_runs_on:
+        type: string
+      artifact_run_id:
+        type: string
+  workflow_dispatch:
+    inputs:
+      amdgpu_families:
+        type: string
+      artifact_group:
+        type: string
+      test_runs_on:
+        type: string
+      artifact_run_id:
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  test_jax_collective:
+    name: 'Test JAX collective smoke'
+    runs-on: ${{ inputs.test_runs_on }}
+    container:
+      image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98
+      options: --ipc host
+        --group-add video
+        --device /dev/kfd
+        --device /dev/dri
+        --group-add 110
+        --group-add 993
+        --group-add 992
+        --ulimit memlock=-1:-1
+        --security-opt seccomp=unconfined
+        --env-file /etc/podinfo/gha-gpu-isolation-settings
+        --user 0:0
+    defaults:
+      run:
+        shell: bash
+    env:
+      VENV_DIR: ${{ github.workspace }}/.venv
+      ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
+      OUTPUT_ARTIFACTS_DIR: "./build"
+      JAX_SRC: ${{ github.workspace }}/jax-src
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "ROCm/TheRock"
+          ref: d8e27dff1d165462ffa5bd50057a075b943c97c5 # 2026-07-13
+
+      - name: Checkout rocm-systems scripts
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: .github/scripts
+          path: rocm-systems
+
+      - name: Run setup test environment workflow
+        uses: './.github/actions/setup_test_environment'
+        with:
+          ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
+          AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+          ARTIFACT_GROUP: ${{ inputs.artifact_group }}
+          OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
+          VENV_DIR: ${{ env.VENV_DIR }}
+          FETCH_ARTIFACT_ARGS: "--rccl --tests"
+          IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
+
+      - name: Install JAX and test dependencies
+        timeout-minutes: 15
+        run: |
+          uv pip install --prerelease=allow \
+            jax-rocm7-plugin jax-rocm7-pjrt jax \
+            --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+            --extra-index-url https://pypi.org/simple/
+          uv pip install \
+            pytest \
+            pytest-timeout \
+            hypothesis \
+            numpy \
+            absl-py
+
+      - name: Run JAX collective smoke tests
+        timeout-minutes: 10
+        env:
+          XLA_PYTHON_CLIENT_ALLOCATOR: default
+          XLA_PYTHON_CLIENT_PREALLOCATE: "false"
+          XLA_FLAGS: "--xla_gpu_force_compilation_parallelism=1 --xla_gpu_enable_nccl_comm_splitting=false --xla_gpu_enable_command_buffer= --xla_gpu_enable_cublaslt=false"
+          NCCL_DEBUG: INFO
+        run: |
+          python rocm-systems/.github/scripts/test_jax_collective.py \
+            --artifact-dir ${{ env.OUTPUT_ARTIFACTS_DIR }} \
+            --jax-src ${{ env.JAX_SRC }} \
+            --results-log ${{ env.JAX_SRC }}/jax_collective_results.log
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: jax-collective-results-${{ inputs.amdgpu_families }}
+          path: ${{ env.JAX_SRC }}/jax_collective_results.log
+          retention-days: 14

--- a/.github/workflows/therock-rccl-test-jax-collective.yml
+++ b/.github/workflows/therock-rccl-test-jax-collective.yml
@@ -11,6 +11,9 @@ on:
         type: string
       artifact_run_id:
         type: string
+      notify_email:
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -21,6 +24,10 @@ on:
         type: string
       artifact_run_id:
         type: string
+      notify_email:
+        description: 'Email address to send test summary report'
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -96,15 +103,22 @@ jobs:
         env:
           NCCL_DEBUG: INFO
         run: |
+          NOTIFY_ARGS=""
+          if [ -n "${{ inputs.notify_email }}" ]; then
+            NOTIFY_ARGS="--notify-email ${{ inputs.notify_email }}"
+          fi
           python rocm-systems/.github/scripts/test_jax_collective.py \
             --artifact-dir ${{ env.OUTPUT_ARTIFACTS_DIR }} \
             --jax-src ${{ env.JAX_SRC }} \
-            --results-log ${{ env.JAX_SRC }}/jax_collective_results.log
+            --results-log ${{ env.JAX_SRC }}/jax_collective_results.log \
+            $NOTIFY_ARGS
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jax-collective-results-${{ inputs.amdgpu_families }}
-          path: ${{ env.JAX_SRC }}/jax_collective_results.log
+          path: |
+            ${{ env.JAX_SRC }}/jax_collective_results.log
+            ${{ env.JAX_SRC }}/jax_collective_summary.txt
           retention-days: 14

--- a/.github/workflows/therock-rccl-test-jax-collective.yml
+++ b/.github/workflows/therock-rccl-test-jax-collective.yml
@@ -95,9 +95,8 @@ jobs:
         run: |
           AMDGPU_LOWER=$(echo "${{ inputs.amdgpu_families }}" | tr '[:upper:]' '[:lower:]')
           uv pip install --prerelease=allow \
-            "rocm-sdk-core>=7.0" "rocm-sdk-libraries-${AMDGPU_LOWER}>=7.0" \
-            --index-url "https://rocm.nightlies.amd.com/v2/${{ inputs.amdgpu_families }}/" \
-            --extra-index-url https://pypi.org/simple/
+            rocm-sdk-core "rocm-sdk-libraries-${AMDGPU_LOWER}" \
+            --index-url "https://rocm.nightlies.amd.com/v2/${{ inputs.amdgpu_families }}/"
           uv pip install --prerelease=allow \
             jax-rocm7-plugin jax-rocm7-pjrt jax \
             --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \

--- a/.github/workflows/therock-rccl-test-jax-collective.yml
+++ b/.github/workflows/therock-rccl-test-jax-collective.yml
@@ -120,5 +120,6 @@ jobs:
           name: jax-collective-results-${{ inputs.amdgpu_families }}
           path: |
             ${{ env.JAX_SRC }}/jax_collective_results.log
+            ${{ env.JAX_SRC }}/jax_collective_results.xml
             ${{ env.JAX_SRC }}/jax_collective_summary.txt
           retention-days: 14

--- a/.github/workflows/therock-rccl-test-jax-collective.yml
+++ b/.github/workflows/therock-rccl-test-jax-collective.yml
@@ -86,9 +86,14 @@ jobs:
         # Intentionally installs latest nightly wheels against pinned test sources.
         # The 10 smoke tests use stable pmap/shard_map APIs that are compatible
         # across JAX versions. This lets us catch RCCL regressions with current JAX.
+        # rocm-sdk-core and rocm-sdk-libraries provide the ROCm runtime libs
+        # (hipBLASLt, hipFFT, MIOpen, rocBLAS, etc.) that xla_rocm_plugin.so
+        # links against via RUNPATH. The test script overrides librccl.so with
+        # the CI-built version via LD_LIBRARY_PATH.
         run: |
           uv pip install --prerelease=allow \
             jax-rocm7-plugin jax-rocm7-pjrt jax \
+            rocm-sdk-core rocm-sdk-libraries \
             --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
             --extra-index-url https://pypi.org/simple/
           uv pip install \

--- a/.github/workflows/therock-rccl-test-jax-collective.yml
+++ b/.github/workflows/therock-rccl-test-jax-collective.yml
@@ -86,14 +86,20 @@ jobs:
         # Intentionally installs latest nightly wheels against pinned test sources.
         # The 10 smoke tests use stable pmap/shard_map APIs that are compatible
         # across JAX versions. This lets us catch RCCL regressions with current JAX.
-        # rocm-sdk-core and rocm-sdk-libraries provide the ROCm runtime libs
-        # (hipBLASLt, hipFFT, MIOpen, rocBLAS, etc.) that xla_rocm_plugin.so
-        # links against via RUNPATH. The test script overrides librccl.so with
-        # the CI-built version via LD_LIBRARY_PATH.
+        #
+        # xla_rocm_plugin.so has RUNPATH entries that resolve math libraries
+        # (hipBLASLt, hipFFT, MIOpen, rocBLAS, etc.) from the _rocm_sdk_libraries
+        # site-package. The arch-specific v2 index provides the real binary
+        # wheels; the whl-multi-arch index only has stub metapackages.
+        # The test script overrides librccl.so with the CI-built version.
         run: |
+          AMDGPU_LOWER=$(echo "${{ inputs.amdgpu_families }}" | tr '[:upper:]' '[:lower:]')
+          uv pip install --prerelease=allow \
+            rocm-sdk-core "rocm-sdk-libraries-${AMDGPU_LOWER}" \
+            --index-url "https://rocm.nightlies.amd.com/v2/${{ inputs.amdgpu_families }}/" \
+            --extra-index-url https://pypi.org/simple/
           uv pip install --prerelease=allow \
             jax-rocm7-plugin jax-rocm7-pjrt jax \
-            rocm-sdk-core rocm-sdk-libraries \
             --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
             --extra-index-url https://pypi.org/simple/
           uv pip install \


### PR DESCRIPTION
## Summary

- Add a scheduled weekly run (Sunday 06:17 UTC) that exercises JAX collective smoke tests against the CI-built RCCL on the 8-GPU runner
- The JAX test job is gated on `schedule`/`workflow_dispatch` events so it never runs on PR builds
- Installs JAX ROCm nightly wheels (`jax-rocm7-plugin`, `jax-rocm7-pjrt`), clones ROCm/jax test sources (pinned to commit SHA), overrides RCCL via `LD_LIBRARY_PATH`, and runs 10 collective smoke tests via pytest

JIRA ID : AICOMRCCL-1547

## Changes

- `therock-rccl-ci.yml`: add weekly schedule trigger, pass `event_name` downstream
- `therock-rccl-ci-linux.yml`: accept `event_name` input, add conditional JAX test job
- `therock-rccl-test-jax-collective.yml`: new reusable test workflow
- `test_jax_collective.py`: new test runner script (mirrors `test_pytorch_c10d.py` pattern)

## Tests covered (10 smoke tests, ~50s on 8 GPUs)

| Collective | pmap_test | shard_map_test |
|---|---|---|
| AllGather | testGather | test_all_gather |
| ReduceScatter | testReduceScatter | test_matmul_reduce_scatter |
| CollectivePermute | testCollectivePermute | test_collective_permute |
| AllToAll | testAllToAll0 | test_all_to_all_multiple_axis_names |
| Basic/AxisIndex | testBasic | test_axis_index |

## Prototype results (ruby cluster, 8x MI325 GPUs)

```
10 passed in 49.52s
```

All 10 tests passed on 8 RocmDevices. JAX nightly wheels (jax==0.10.2, jax-rocm7-plugin==0.11.0a0) installed from `rocm.nightlies.amd.com`.

## Test plan

- [ ] Trigger via `workflow_dispatch` to verify the JAX job runs
- [ ] Verify JAX nightly wheels install successfully in the container
- [ ] Verify RCCL override via `LD_LIBRARY_PATH` loads the CI-built RCCL
- [ ] Verify all 10 collective smoke tests pass
- [ ] Verify the job is skipped on normal PR builds

## Related

- Companion to #8505 (PyTorch c10d distributed tests)