### PR TITLE
fix(rocjitsu): Harden SimulatedDriver concurrency for daemon mode

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.cpp
@@ -38,16 +38,24 @@ EventState::~EventState() {
 void EventState::adopt_page(void *ptr, size_t size) {
   assert(ptr && "adopt_page called with null pointer");
   assert(size > 0 && "adopt_page called with zero size");
+  std::lock_guard<std::mutex> lock(mutex_);
   if (page)
     return;
   page = ptr;
   page_size = size;
-
-  std::lock_guard<std::mutex> lock(mutex_);
   for (const auto &[id, ev] : events_) {
     if (ev.signaled)
       write_event_slot(page, page_size, id, ev.event_age);
   }
+}
+
+bool EventState::release_page(void *ptr) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (page != ptr)
+    return false;
+  page = nullptr;
+  page_size = 0;
+  return true;
 }
 
 /// @brief Signal event(s) from the CP's interrupt callback.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.h
@@ -74,6 +74,12 @@ public:
   /// @details Idempotent, subsequent calls after the first are no-ops.
   void adopt_page(void *ptr, size_t size);
 
+  /// @brief If @p ptr is the adopted event page, clear page/page_size and return true.
+  /// @details Clears the fields under mutex_ so the CP interrupt thread (which
+  /// reads page/page_size under the same lock in signal_interrupt) can never race
+  /// a concurrent munmap tearing the mapping down.
+  [[nodiscard]] bool release_page(void *ptr);
+
   /// @brief Signal event(s) from the CP's interrupt callback.
   /// @details When event_id is non-zero, signals that specific event. When
   ///          event_id is zero, broadcasts to all type-0 events — matching

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -248,6 +248,12 @@ public:
   pid_t client_pid_ = 0;
   std::atomic<uint32_t> open_ref_count_{1};
 
+  /// @brief Serializes this process's ioctls, analogous to the real KFD's
+  /// per-process lock. Taken as the outermost per-process lock in dispatch_ioctl.
+  /// AMDKFD_IOC_WAIT_EVENTS is intentionally NOT taken under this lock: it blocks
+  /// waiting for signals that SET_EVENT/RESET_EVENT (which DO run under this lock)
+  /// must produce, so holding it would deadlock forward progress.
+  std::mutex op_mutex_;
   mutable std::mutex alloc_mutex_;
   std::unordered_map<uint64_t, GpuAllocation> allocations_;
   uint64_t next_handle_ = 1;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -148,8 +148,22 @@ const SimulatedKfd::GpuDevice *SimulatedKfd::find_gpu(uint32_t gpu_id) const {
 }
 
 SimulatedKfd::~SimulatedKfd() {
-  while (!processes_.empty())
-    close(processes_.begin()->first);
+  std::vector<uint32_t> pids;
+  {
+    std::lock_guard<std::mutex> lk(process_mutex_);
+    pids.reserve(processes_.size());
+    for (auto &[id, proc] : processes_)
+      pids.push_back(id);
+  }
+  // close() only tears a process down on the LAST open reference (release_open()
+  // returns true at zero); a process opened more than once (dup/daemon reuse)
+  // would otherwise survive with its allocations, queues, and CP callbacks still
+  // live past this driver. Keep closing each snapshotted pid until it is actually
+  // removed from the table, so destruction always fully drains every process.
+  for (auto pid : pids) {
+    while (find_process(pid))
+      close(pid);
+  }
 }
 
 void SimulatedKfd::setup_topology(const Sysfs::GpuInfo &gpu) {
@@ -180,11 +194,21 @@ bool SimulatedKfd::is_doorbell_range(const void *addr, size_t length) const {
   auto p = find_process(local_process_id_);
   if (!p)
     return false;
-  auto &gs = p->gpu(0);
-  if (!gs.doorbell_page || gs.doorbell_page_size == 0 || !addr || length == 0)
+  // Snapshot the doorbell page/size under alloc_mutex_ so a concurrent
+  // dispatch_mmap/dispatch_munmap (which mutate these under the same lock) cannot
+  // tear the pointer/size read.
+  void *doorbell_page;
+  size_t doorbell_page_size;
+  {
+    std::lock_guard<std::mutex> lock(p->alloc_mutex_);
+    auto &gs = p->gpu(0);
+    doorbell_page = gs.doorbell_page;
+    doorbell_page_size = gs.doorbell_page_size;
+  }
+  if (!doorbell_page || doorbell_page_size == 0 || !addr || length == 0)
     return false;
-  auto base = reinterpret_cast<uintptr_t>(gs.doorbell_page);
-  auto end = base + gs.doorbell_page_size;
+  auto base = reinterpret_cast<uintptr_t>(doorbell_page);
+  auto end = base + doorbell_page_size;
   auto query_base = reinterpret_cast<uintptr_t>(addr);
   auto query_end = query_base + length;
   return query_base < end && query_end > base;
@@ -203,6 +227,51 @@ bool SimulatedKfd::ensure_fd_created() {
                                    std::memory_order_acquire))
     syscall(SYS_close, new_fd);
   return true;
+}
+
+void SimulatedKfd::init_command_processors_locked() {
+  for (size_t i = 0; i < gpus_.size(); ++i) {
+    auto &g = gpus_[i];
+    if (g.cps_initialized)
+      continue;
+    if (!g.soc)
+      continue;
+    uint64_t lds_base = 0x1000000000000ULL + i * 0x10000000000ULL;
+    uint64_t scratch_base = 0x2000000000000ULL + i * 0x10000000000ULL;
+    g.soc->set_apertures(lds_base, lds_base + 0xFFFFFFFFULL, scratch_base,
+                         scratch_base + 0xFFFFFFFFULL);
+    g.soc->for_each_cp([this](amdgpu::CommandProcessor *cp) {
+      cp->set_interrupt_callback([this](uint32_t process_id, uint32_t event_id) {
+        std::lock_guard<std::mutex> ilk(interrupt_mutex_);
+        auto it = event_dispatch_.find(process_id);
+        if (it != event_dispatch_.end()) {
+          util::Logger::cp("INTERRUPT_ROUTE: pid=", process_id, " event_id=", event_id,
+                           " found=true");
+          it->second->signal_interrupt(event_id);
+        } else {
+          util::Logger::cp("INTERRUPT_ROUTE: pid=", process_id, " event_id=", event_id,
+                           " found=false");
+        }
+      });
+      cp->set_scratch_backing_resolver([this](uint32_t process_id) -> uint64_t {
+        std::lock_guard<std::mutex> plk(process_mutex_);
+        for (auto &[fd, proc] : processes_) {
+          if (proc->process_id() == process_id) {
+            for (auto &gs : proc->gpu_state_) {
+              if (gs.scratch_backing_va != 0)
+                return gs.scratch_backing_va << 16;
+            }
+          }
+        }
+        return 0;
+      });
+      cp->set_scratch_backing_allocator(
+          [this](uint32_t process_id, uint64_t gpu_va, size_t size) -> bool {
+            return allocate_scratch_backing(process_id, gpu_va, size);
+          });
+    });
+    g.cps_initialized = true;
+  }
 }
 
 int SimulatedKfd::open() {
@@ -251,48 +320,7 @@ int SimulatedKfd::open() {
     event_dispatch_[pid] = &proc->event_state_;
   }
 
-  for (size_t i = 0; i < gpus_.size(); ++i) {
-    auto &g = gpus_[i];
-    if (g.cps_initialized)
-      continue;
-    if (!g.soc)
-      continue;
-    uint64_t lds_base = 0x1000000000000ULL + i * 0x10000000000ULL;
-    uint64_t scratch_base = 0x2000000000000ULL + i * 0x10000000000ULL;
-    g.soc->set_apertures(lds_base, lds_base + 0xFFFFFFFFULL, scratch_base,
-                         scratch_base + 0xFFFFFFFFULL);
-    g.soc->for_each_cp([this](amdgpu::CommandProcessor *cp) {
-      cp->set_interrupt_callback([this](uint32_t process_id, uint32_t event_id) {
-        std::lock_guard<std::mutex> ilk(interrupt_mutex_);
-        auto it = event_dispatch_.find(process_id);
-        if (it != event_dispatch_.end()) {
-          util::Logger::cp("INTERRUPT_ROUTE: pid=", process_id, " event_id=", event_id,
-                           " found=true");
-          it->second->signal_interrupt(event_id);
-        } else {
-          util::Logger::cp("INTERRUPT_ROUTE: pid=", process_id, " event_id=", event_id,
-                           " found=false");
-        }
-      });
-      cp->set_scratch_backing_resolver([this](uint32_t process_id) -> uint64_t {
-        std::lock_guard<std::mutex> plk(process_mutex_);
-        for (auto &[fd, proc] : processes_) {
-          if (proc->process_id() == process_id) {
-            for (auto &gs : proc->gpu_state_) {
-              if (gs.scratch_backing_va != 0)
-                return gs.scratch_backing_va << 16;
-            }
-          }
-        }
-        return 0;
-      });
-      cp->set_scratch_backing_allocator(
-          [this](uint32_t process_id, uint64_t gpu_va, size_t size) -> bool {
-            return allocate_scratch_backing(process_id, gpu_va, size);
-          });
-    });
-    g.cps_initialized = true;
-  }
+  init_command_processors_locked();
 
   return fd_.load(std::memory_order_acquire);
 }
@@ -351,49 +379,8 @@ uint32_t SimulatedKfd::open_process(pid_t client_pid) {
       std::lock_guard<std::mutex> ilk(interrupt_mutex_);
       event_dispatch_[pid] = &proc->event_state_;
     }
-  }
 
-  for (size_t i = 0; i < gpus_.size(); ++i) {
-    auto &g = gpus_[i];
-    if (g.cps_initialized)
-      continue;
-    if (!g.soc)
-      continue;
-    uint64_t lds_base = 0x1000000000000ULL + i * 0x10000000000ULL;
-    uint64_t scratch_base = 0x2000000000000ULL + i * 0x10000000000ULL;
-    g.soc->set_apertures(lds_base, lds_base + 0xFFFFFFFFULL, scratch_base,
-                         scratch_base + 0xFFFFFFFFULL);
-    g.soc->for_each_cp([this](amdgpu::CommandProcessor *cp) {
-      cp->set_interrupt_callback([this](uint32_t process_id, uint32_t event_id) {
-        std::lock_guard<std::mutex> ilk(interrupt_mutex_);
-        auto it = event_dispatch_.find(process_id);
-        if (it != event_dispatch_.end()) {
-          util::Logger::cp("INTERRUPT_ROUTE: pid=", process_id, " event_id=", event_id,
-                           " found=true");
-          it->second->signal_interrupt(event_id);
-        } else {
-          util::Logger::cp("INTERRUPT_ROUTE: pid=", process_id, " event_id=", event_id,
-                           " found=false");
-        }
-      });
-      cp->set_scratch_backing_resolver([this](uint32_t process_id) -> uint64_t {
-        std::lock_guard<std::mutex> plk(process_mutex_);
-        for (auto &[fd, proc] : processes_) {
-          if (proc->process_id() == process_id) {
-            for (auto &gs : proc->gpu_state_) {
-              if (gs.scratch_backing_va != 0)
-                return gs.scratch_backing_va << 16;
-            }
-          }
-        }
-        return 0;
-      });
-      cp->set_scratch_backing_allocator(
-          [this](uint32_t process_id, uint64_t gpu_va, size_t size) -> bool {
-            return allocate_scratch_backing(process_id, gpu_va, size);
-          });
-    });
-    g.cps_initialized = true;
+    init_command_processors_locked();
   }
 
   return pid;
@@ -451,6 +438,37 @@ int SimulatedKfd::close(uint32_t process_id) {
     processes_.erase(it);
   }
 
+  auto &proc = *extracted;
+
+  // Serialize ALL teardown against any in-flight ioctl on this process. ioctl()
+  // only snapshots a shared_ptr via find_process() and does NOT retain an open
+  // reference, so an ioctl that started before this close() removed the process
+  // from the table can still be running (or about to run) under proc.op_mutex_.
+  // Acquire op_mutex_ BEFORE any teardown step — including event_dispatch_ erase
+  // and mem->unregister_process() — so those cannot overlap an active
+  // op_mutex_-guarded ioctl handler and break CP interrupt routing / memory
+  // translation mid-ioctl. notify_closing() (below, still under op_mutex_) sets
+  // the closing flag that dispatch_ioctl checks right after it takes op_mutex_,
+  // so any ioctl that was blocked on op_mutex_ behind this close() will observe
+  // is_closing() and bail instead of operating on a torn-down process.
+  //
+  // The process was already erased from processes_ above, so no NEW ioctl can
+  // find it. Ordering is safe: process_mutex_ was released before taking
+  // op_mutex_, so this does not nest against dispatch_ioctl's op_mutex_ ->
+  // process_mutex_ order. WAIT_EVENTS does not take op_mutex_, so notify_closing()
+  // / signal_page_shutdown() below still wake any parked waiter.
+  //
+  // NOTE: the mmap/munmap/is_doorbell_range family is NOT dispatched through
+  // op_mutex_ — it synchronizes on alloc_mutex_. So the allocation and doorbell
+  // teardown below additionally takes alloc_mutex_ to serialize against those
+  // paths; op_mutex_ alone does not cover them.
+  std::lock_guard<std::mutex> op_lock(proc.op_mutex_);
+
+  // Set the closing flag first, under op_mutex_, so the dispatch_ioctl guard sees
+  // it before any state is dismantled.
+  proc.event_state_.notify_closing();
+  proc.event_state_.signal_page_shutdown();
+
   {
     std::lock_guard<std::mutex> ilk(interrupt_mutex_);
     event_dispatch_.erase(process_id);
@@ -461,14 +479,11 @@ int SimulatedKfd::close(uint32_t process_id) {
       mem->unregister_process(process_id);
   }
 
-  auto &proc = *extracted;
   const bool trace_enabled = vm_trace_enabled();
   size_t leaked_allocations = 0;
   uint64_t leaked_bytes = 0;
   size_t leaked_queues = 0;
   std::vector<uint64_t> leaked_handles;
-  proc.event_state_.notify_closing();
-  proc.event_state_.signal_page_shutdown();
 
   {
     std::lock_guard<std::mutex> alk(proc.alloc_mutex_);
@@ -507,9 +522,23 @@ int SimulatedKfd::close(uint32_t process_id) {
         });
   }
 
+  // Tear down doorbell pages under alloc_mutex_ (the lock the doorbell readers
+  // use — is_doorbell_range/dispatch_mmap/dispatch_munmap), not op_mutex_ (those
+  // readers do not take op_mutex_). Snapshot and clear the fields under the lock,
+  // then munmap outside it so the syscall does not run while alloc_mutex_ is held.
   for (auto &gs : proc.gpu_state_) {
-    if (gs.doorbell_page && gs.doorbell_page_size)
-      syscall(SYS_munmap, gs.doorbell_page, gs.doorbell_page_size);
+    void *doorbell_page;
+    size_t doorbell_page_size;
+    {
+      std::lock_guard<std::mutex> alk(proc.alloc_mutex_);
+      doorbell_page = gs.doorbell_page;
+      doorbell_page_size = gs.doorbell_page_size;
+      gs.doorbell_page = nullptr;
+      gs.doorbell_gpu_va = 0;
+      gs.doorbell_page_size = 0;
+    }
+    if (doorbell_page && doorbell_page_size)
+      syscall(SYS_munmap, doorbell_page, doorbell_page_size);
   }
 
   leaked_queues = queue_ids.size();
@@ -533,10 +562,23 @@ int SimulatedKfd::close(uint32_t process_id) {
     }
   }
 
-  for (auto &[handle, dmabuf] : proc.imported_dmabufs_) {
-    [[maybe_unused]] auto &_ = handle;
-    if (dmabuf.fd >= 0)
-      syscall(SYS_close, dmabuf.fd);
+  // Guard the dmabuf teardown under alloc_mutex_ for consistency with the
+  // import_dmabuf_ioctl/get_dmabuf_info_ioctl accessors: although this process was
+  // already erased from the table under process_mutex_ and its last open reference
+  // released, an ioctl that took a shared_ptr snapshot before the erase could still
+  // be touching imported_dmabufs_ under alloc_mutex_.
+  {
+    std::lock_guard<std::mutex> alk(proc.alloc_mutex_);
+    for (auto &[handle, dmabuf] : proc.imported_dmabufs_) {
+      [[maybe_unused]] auto &_ = handle;
+      if (dmabuf.fd >= 0)
+        syscall(SYS_close, dmabuf.fd);
+    }
+    proc.imported_dmabufs_.clear();
+    // Clear the reverse fd->handle map too, so it stays consistent with
+    // imported_dmabufs_ (both are maintained together under alloc_mutex_ by
+    // import_dmabuf_ioctl/free_memory_ioctl); its fds were just closed above.
+    proc.fd_to_import_handle_.clear();
   }
 
   return 0;
@@ -556,7 +598,24 @@ int SimulatedKfd::ioctl(uint32_t process_id, unsigned long request, void *arg) {
 int SimulatedKfd::dispatch_ioctl(KfdProcess &proc, unsigned long request, void *arg) {
   util::Logger::driver("IOCTL pid=", proc.process_id(), " ", LinuxKfd::ioctl_name(request));
 
-  switch (canonical_ioctl_request(request)) {
+  unsigned long dispatch_request = canonical_ioctl_request(request);
+
+  if (dispatch_request == AMDKFD_IOC_WAIT_EVENTS)
+    return wait_events_ioctl(proc, arg);
+
+  std::lock_guard<std::mutex> op_lock(proc.op_mutex_);
+  // A concurrent close() may have snapshotted-then-erased this process and be
+  // tearing it down under op_mutex_. ioctl() holds only a shared_ptr (no open
+  // reference), so an ioctl that raced close() can end up here AFTER teardown
+  // ran (allocations/queues cleared, event_dispatch_ removed, memory
+  // unregistered). close() sets the closing flag under op_mutex_ before any
+  // teardown, so once we hold op_mutex_, is_closing() means the process is
+  // logically gone — reject rather than operate on dismantled state. WAIT_EVENTS
+  // is handled above and is intentionally exempt (it must observe the closing
+  // signal to wake).
+  if (proc.event_state_.is_closing())
+    return -ESRCH;
+  switch (dispatch_request) {
   case AMDKFD_IOC_GET_VERSION:
     return get_version_ioctl(arg);
   case AMDKFD_IOC_GET_CLOCK_COUNTERS:
@@ -587,8 +646,9 @@ int SimulatedKfd::dispatch_ioctl(KfdProcess &proc, unsigned long request, void *
     return set_event_ioctl(proc, arg);
   case AMDKFD_IOC_RESET_EVENT:
     return reset_event_ioctl(proc, arg);
-  case AMDKFD_IOC_WAIT_EVENTS:
-    return wait_events_ioctl(proc, arg);
+  // WAIT_EVENTS is handled before op_mutex_ above (it blocks on a condition
+  // variable and must not hold the per-process op lock), so it never reaches
+  // this switch.
   case AMDKFD_IOC_SET_XNACK_MODE:
     return set_xnack_mode_ioctl(arg);
   case AMDKFD_IOC_SET_MEMORY_POLICY:
@@ -602,7 +662,10 @@ int SimulatedKfd::dispatch_ioctl(KfdProcess &proc, unsigned long request, void *
   case AMDKFD_IOC_SET_SCRATCH_BACKING_VA: {
     auto *a = static_cast<kfd_ioctl_set_scratch_backing_va_args *>(arg);
     uint32_t ord = gpu_ordinal(a->gpu_id);
-    proc.gpu(ord).scratch_backing_va = a->va_addr;
+    {
+      std::lock_guard<std::mutex> plk(process_mutex_);
+      proc.gpu(ord).scratch_backing_va = a->va_addr;
+    }
     util::Logger::vm([&](auto &os) {
       os << "SET_SCRATCH_BACKING_VA pid=" << proc.process_id() << " gpu_id=" << a->gpu_id
          << " va=" << std::hex << a->va_addr << std::dec;
@@ -612,8 +675,16 @@ int SimulatedKfd::dispatch_ioctl(KfdProcess &proc, unsigned long request, void *
   case AMDKFD_IOC_SET_TRAP_HANDLER: {
     auto *a = static_cast<kfd_ioctl_set_trap_handler_args *>(arg);
     uint32_t ord = gpu_ordinal(a->gpu_id);
-    proc.gpu(ord).trap_tba_addr = a->tba_addr;
-    proc.gpu(ord).trap_tma_addr = a->tma_addr;
+    {
+      // Held under process_mutex_ for symmetry with SET_SCRATCH_BACKING_VA and to
+      // be race-free once the trap handler is wired into the SoC. NOTE: as of now
+      // trap_tba_addr/trap_tma_addr have no reader anywhere (the CP does not yet
+      // consume them), so this lock currently guards against a non-existent
+      // concurrent access — kept for forward-compatibility.
+      std::lock_guard<std::mutex> plk(process_mutex_);
+      proc.gpu(ord).trap_tba_addr = a->tba_addr;
+      proc.gpu(ord).trap_tma_addr = a->tma_addr;
+    }
     return 0;
   }
   case AMDKFD_IOC_GET_TILE_CONFIG:
@@ -721,11 +792,35 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
       // processes the submission.
       std::memset(ptr, 0xFF, length);
 
-      auto &gs = proc.gpu(ord);
-      gs.doorbell_page = ptr;
-      gs.doorbell_page_size = length;
-      gs.doorbell_gpu_va = reinterpret_cast<uint64_t>(ptr);
-      map_to_gpu(proc, gs.doorbell_gpu_va, ptr, length, amdgpu::Mtype::UC);
+      // Hold op_mutex_ across the whole publish -> map_to_gpu -> set_doorbell_base
+      // sequence so a concurrent close() (which tears down doorbells under
+      // op_mutex_) cannot clear+munmap this page between publishing it and handing
+      // it to the CP, which would leave the CP with a dangling doorbell_base.
+      // op_mutex_ is the outer lock (op_mutex_ -> alloc_mutex_, matching close());
+      // set_doorbell_base takes hw_queue_mutex_, which is never held while taking
+      // op_mutex_, so there is no inversion. alloc_mutex_ is taken only for the
+      // field publish and released before set_doorbell_base (hw_queue_mutex_).
+      std::lock_guard<std::mutex> op_lock(proc.op_mutex_);
+      {
+        std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
+        // If close() has begun tearing this process down, do NOT publish a new
+        // doorbell page: it would never be reclaimed (leaked) and would hand the
+        // CP a base for a dying process. Fail the mmap instead. is_closing() is
+        // set by close() under op_mutex_, which we now hold, so this check is
+        // race-free against teardown.
+        if (proc.event_state_.is_closing()) {
+          syscall(SYS_munmap, ptr, length);
+          errno = ENODEV;
+          return MAP_FAILED;
+        }
+        auto &gs = proc.gpu(ord);
+        gs.doorbell_page = ptr;
+        gs.doorbell_page_size = length;
+        gs.doorbell_gpu_va = reinterpret_cast<uint64_t>(ptr);
+      }
+      // Use the local ptr (== the doorbell_gpu_va just written) rather than
+      // re-reading gs.doorbell_gpu_va without alloc_mutex_.
+      map_to_gpu(proc, reinterpret_cast<uint64_t>(ptr), ptr, length, amdgpu::Mtype::UC);
       if (gpu && gpu->soc)
         gpu->soc->for_each_cp(
             [&](amdgpu::CommandProcessor *cp) { cp->set_doorbell_base(proc.process_id(), ptr); });
@@ -878,24 +973,34 @@ int SimulatedKfd::munmap(uint32_t process_id, void *addr, size_t length) {
 }
 
 int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
-  for (auto &gs : proc.gpu_state_) {
-    if (gs.doorbell_page == addr) {
-      if (!proc.event_state_.is_closing()) {
-        errno = EPERM;
-        return -1;
+  {
+    std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
+    for (auto &gs : proc.gpu_state_) {
+      if (gs.doorbell_page == addr) {
+        if (!proc.event_state_.is_closing()) {
+          errno = EPERM;
+          return -1;
+        }
+        uint64_t gpu_va = gs.doorbell_gpu_va;
+        size_t page_size = gs.doorbell_page_size;
+        gs.doorbell_page = nullptr;
+        gs.doorbell_gpu_va = 0;
+        gs.doorbell_page_size = 0;
+        if (gpu_va && page_size)
+          unmap_from_gpu(proc, gpu_va, page_size);
+        // Unmap the exact page we mapped: use the recorded doorbell page size,
+        // not the caller-provided length. A length that differs from the tracked
+        // mapping would otherwise partially unmap the CPU page and leave it
+        // inconsistent with the GPU page-table unmap above.
+        syscall(SYS_munmap, addr, page_size ? page_size : length);
+        return 0;
       }
-      if (gs.doorbell_gpu_va && gs.doorbell_page_size)
-        unmap_from_gpu(proc, gs.doorbell_gpu_va, gs.doorbell_page_size);
-      gs.doorbell_page = nullptr;
-      gs.doorbell_gpu_va = 0;
-      gs.doorbell_page_size = 0;
-      syscall(SYS_munmap, addr, length);
-      return 0;
     }
   }
-  if (addr == proc.event_state_.page) {
-    proc.event_state_.page = nullptr;
-    proc.event_state_.page_size = 0;
+  // release_page() clears page/page_size under EventState::mutex_, the same lock
+  // the CP interrupt thread holds when reading them in signal_interrupt, so the
+  // munmap below cannot race a concurrent signal writing into the mapping.
+  if (proc.event_state_.release_page(addr)) {
     syscall(SYS_munmap, addr, length);
     return 0;
   }
@@ -1255,73 +1360,93 @@ int SimulatedKfd::create_queue_ioctl(KfdProcess &proc, void *arg) {
   if (!gpu || !gpu->soc)
     return -EINVAL;
 
-  std::lock_guard<std::mutex> lk(proc.alloc_mutex_);
-
-  if (!daemon_mode_) {
-    map_to_gpu(proc, args->ring_base_address, reinterpret_cast<void *>(args->ring_base_address),
-               args->ring_size, amdgpu::Mtype::UC);
-    uint64_t rptr_page = args->read_pointer_address & ~0xFFFULL;
-    uint64_t wptr_page = args->write_pointer_address & ~0xFFFULL;
-    map_to_gpu(proc, rptr_page, reinterpret_cast<void *>(rptr_page), 4096, amdgpu::Mtype::UC);
-    if (wptr_page != rptr_page)
-      map_to_gpu(proc, wptr_page, reinterpret_cast<void *>(wptr_page), 4096, amdgpu::Mtype::UC);
-  }
-
-  uint32_t queue_id = proc.next_queue_id_++;
-  uint32_t ord = gpu_ordinal(args->gpu_id);
-  auto &gs = proc.gpu(ord);
-  uint32_t db_offset;
-  if (!gs.free_doorbell_offsets.empty()) {
-    db_offset = gs.free_doorbell_offsets.back();
-    gs.free_doorbell_offsets.pop_back();
-  } else {
-    if (gs.doorbell_page_size > 0 &&
-        gs.next_doorbell_offset + sizeof(uint64_t) > gs.doorbell_page_size)
-      return -ENOSPC;
-    db_offset = static_cast<uint32_t>(gs.next_doorbell_offset);
-    gs.next_doorbell_offset += sizeof(uint64_t);
-  }
-
-  amdgpu::HwQueue hw{};
-  hw.process_id = proc.process_id();
-  hw.queue_id = queue_id;
-  hw.ring_base_va = args->ring_base_address;
-  hw.ring_size = args->ring_size;
-  hw.read_ptr_va = args->read_pointer_address;
-  hw.write_ptr_va = args->write_pointer_address;
-  hw.doorbell_offset = db_offset;
-  hw.doorbell_base = gs.doorbell_page;
-  hw.last_doorbell = ~uint64_t(0);
-  hw.host_accessible = true;
-  hw.is_sdma = (args->queue_type == 1 /*KFD_IOC_QUEUE_TYPE_SDMA*/ ||
-                args->queue_type == 3 /*KFD_IOC_QUEUE_TYPE_SDMA_XGMI*/ ||
-                args->queue_type == 4 /*KFD_IOC_QUEUE_TYPE_SDMA_BY_ENG_ID*/);
-  // amd_queue_t base: write_pointer_address points to write_dispatch_id.
-  if (!hw.is_sdma)
-    hw.queue_desc_va = args->write_pointer_address - offsetof(amd_queue_t, write_dispatch_id);
-  if (hw.is_sdma && !daemon_mode_) {
-    auto *wptr = reinterpret_cast<uint64_t *>(args->write_pointer_address);
-    auto *rptr = reinterpret_cast<uint64_t *>(args->read_pointer_address);
-    util::Logger::vm("SDMA wptr before init: addr=0x", std::hex, args->write_pointer_address,
-                     " val=", std::dec, *wptr, " rptr val=", *rptr);
-    *wptr = 0;
-    *rptr = 0;
-  } else if (hw.is_sdma && daemon_mode_) {
-    auto *mem = gpu->soc ? gpu->soc->memory() : nullptr;
-    if (mem) {
-      mem->write64(args->write_pointer_address, 0, proc.process_id());
-      mem->write64(args->read_pointer_address, 0, proc.process_id());
-    }
-  }
+  // Select the target CP before reserving any per-process state, so a null CP
+  // cannot leave a doorbell offset / queue-id bookkeeping entry orphaned.
   auto *target_cp = gpu->soc->assign_queue_cp();
   if (!target_cp)
     return -EINVAL;
-  target_cp->register_queue(std::move(hw));
 
-  args->queue_id = queue_id;
-  args->doorbell_offset = KFD_MMAP_TYPE_DOORBELL | kfd_mmap_gpu_id(gpu->gpu_id) | db_offset;
-  proc.active_queue_ids_.push_back(queue_id);
-  proc.queue_doorbell_map_[queue_id] = {ord, db_offset};
+  // Build the HW queue and reserve all per-process state under alloc_mutex_, then
+  // register it with the CommandProcessor with the lock RELEASED. The CP thread
+  // takes alloc_mutex_ under hw_queue_mutex_ (allocate_scratch_backing), so holding
+  // alloc_mutex_ across register_queue() — which takes hw_queue_mutex_ — would be
+  // an alloc_mutex_->hw_queue_mutex_ inversion against that thread and can deadlock.
+  // op_mutex_ already serializes all ioctls for this process, so no concurrent
+  // ioctl can observe the partially-registered queue in the window between the
+  // unlock and register_queue().
+  amdgpu::HwQueue hw{};
+  {
+    std::lock_guard<std::mutex> lk(proc.alloc_mutex_);
+
+    if (!daemon_mode_) {
+      map_to_gpu(proc, args->ring_base_address, reinterpret_cast<void *>(args->ring_base_address),
+                 args->ring_size, amdgpu::Mtype::UC);
+      uint64_t rptr_page = args->read_pointer_address & ~0xFFFULL;
+      uint64_t wptr_page = args->write_pointer_address & ~0xFFFULL;
+      map_to_gpu(proc, rptr_page, reinterpret_cast<void *>(rptr_page), 4096, amdgpu::Mtype::UC);
+      if (wptr_page != rptr_page)
+        map_to_gpu(proc, wptr_page, reinterpret_cast<void *>(wptr_page), 4096, amdgpu::Mtype::UC);
+    }
+
+    uint32_t queue_id = proc.next_queue_id_++;
+    uint32_t ord = gpu_ordinal(args->gpu_id);
+    auto &gs = proc.gpu(ord);
+    uint32_t db_offset;
+    if (!gs.free_doorbell_offsets.empty()) {
+      db_offset = gs.free_doorbell_offsets.back();
+      gs.free_doorbell_offsets.pop_back();
+    } else {
+      if (gs.doorbell_page_size > 0 &&
+          gs.next_doorbell_offset + sizeof(uint64_t) > gs.doorbell_page_size)
+        return -ENOSPC;
+      db_offset = static_cast<uint32_t>(gs.next_doorbell_offset);
+      gs.next_doorbell_offset += sizeof(uint64_t);
+    }
+
+    hw.process_id = proc.process_id();
+    hw.queue_id = queue_id;
+    hw.ring_base_va = args->ring_base_address;
+    hw.ring_size = args->ring_size;
+    hw.read_ptr_va = args->read_pointer_address;
+    hw.write_ptr_va = args->write_pointer_address;
+    hw.doorbell_offset = db_offset;
+    // doorbell_base is captured here under alloc_mutex_ but register_queue() runs
+    // after the lock is released. This is stable because ROCr maps the doorbell
+    // page before creating queues, and queue creation for a process is single-
+    // threaded (serialized by op_mutex_), so no concurrent dispatch_mmap re-maps
+    // the doorbell in the unlock->register window.
+    hw.doorbell_base = gs.doorbell_page;
+    hw.last_doorbell = ~uint64_t(0);
+    hw.host_accessible = true;
+    hw.is_sdma = (args->queue_type == 1 /*KFD_IOC_QUEUE_TYPE_SDMA*/ ||
+                  args->queue_type == 3 /*KFD_IOC_QUEUE_TYPE_SDMA_XGMI*/ ||
+                  args->queue_type == 4 /*KFD_IOC_QUEUE_TYPE_SDMA_BY_ENG_ID*/);
+    // amd_queue_t base: write_pointer_address points to write_dispatch_id.
+    if (!hw.is_sdma)
+      hw.queue_desc_va = args->write_pointer_address - offsetof(amd_queue_t, write_dispatch_id);
+    if (hw.is_sdma && !daemon_mode_) {
+      auto *wptr = reinterpret_cast<uint64_t *>(args->write_pointer_address);
+      auto *rptr = reinterpret_cast<uint64_t *>(args->read_pointer_address);
+      util::Logger::vm("SDMA wptr before init: addr=0x", std::hex, args->write_pointer_address,
+                       " val=", std::dec, *wptr, " rptr val=", *rptr);
+      *wptr = 0;
+      *rptr = 0;
+    } else if (hw.is_sdma && daemon_mode_) {
+      auto *mem = gpu->soc ? gpu->soc->memory() : nullptr;
+      if (mem) {
+        mem->write64(args->write_pointer_address, 0, proc.process_id());
+        mem->write64(args->read_pointer_address, 0, proc.process_id());
+      }
+    }
+
+    args->queue_id = queue_id;
+    args->doorbell_offset = KFD_MMAP_TYPE_DOORBELL | kfd_mmap_gpu_id(gpu->gpu_id) | db_offset;
+    proc.active_queue_ids_.push_back(queue_id);
+    proc.queue_doorbell_map_[queue_id] = {ord, db_offset};
+  }
+
+  // Register with the CP OUTSIDE alloc_mutex_ (see note above).
+  target_cp->register_queue(std::move(hw));
   return 0;
 }
 
@@ -1400,20 +1525,20 @@ int SimulatedKfd::import_dmabuf_ioctl(KfdProcess &proc, void *arg) {
     alloc.dmabuf_fd = dupfd;
     alloc.host_ptr = reinterpret_cast<void *>(args->va_addr);
     proc.allocations_[handle] = alloc;
+
+    KfdProcess::ImportedDmabuf info{};
+    info.handle = handle;
+    info.fd = dupfd;
+    info.size = size;
+    info.va = args->va_addr;
+    info.gpu_id = args->gpu_id;
+    proc.imported_dmabufs_[handle] = info;
+    proc.fd_to_import_handle_[dupfd] = handle;
   }
 
   if (args->va_addr)
     map_to_gpu(proc, args->va_addr, reinterpret_cast<void *>(args->va_addr), size,
                amdgpu::Mtype::UC);
-
-  KfdProcess::ImportedDmabuf info{};
-  info.handle = handle;
-  info.fd = dupfd;
-  info.size = size;
-  info.va = args->va_addr;
-  info.gpu_id = args->gpu_id;
-  proc.imported_dmabufs_[handle] = info;
-  proc.fd_to_import_handle_[dupfd] = handle;
 
   args->handle = handle;
   return 0;
@@ -1650,13 +1775,16 @@ int SimulatedKfd::get_dmabuf_info_ioctl(KfdProcess &proc, void *arg) {
   uint32_t gpu_id = gpus_.empty() ? 0 : gpus_[0].gpu_id;
 
   bool found = false;
-  for (const auto &[handle, info] : proc.imported_dmabufs_) {
-    [[maybe_unused]] auto &_ = handle;
-    if (info.fd >= 0 && static_cast<uint32_t>(info.fd) == args->dmabuf_fd) {
-      size = info.size;
-      gpu_id = info.gpu_id;
-      found = true;
-      break;
+  {
+    std::lock_guard<std::mutex> lk(proc.alloc_mutex_);
+    for (const auto &[handle, info] : proc.imported_dmabufs_) {
+      [[maybe_unused]] auto &_ = handle;
+      if (info.fd >= 0 && static_cast<uint32_t>(info.fd) == args->dmabuf_fd) {
+        size = info.size;
+        gpu_id = info.gpu_id;
+        found = true;
+        break;
+      }
     }
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
@@ -236,12 +236,43 @@ private:
   /// @retval true fd_ holds a valid descriptor. @retval false memfd_create failed.
   [[nodiscard]] bool ensure_fd_created();
 
+  /// @brief One-time per-GPU CP setup: apertures + interrupt/scratch callbacks.
+  /// @details Idempotent per GpuDevice via the cps_initialized flag. The caller
+  /// MUST hold process_mutex_ so the check-and-set of cps_initialized is atomic
+  /// against concurrent daemon opens that would otherwise both register callbacks.
+  void init_command_processors_locked();
+
   std::vector<GpuDevice> gpus_;
   bool daemon_mode_ = false;
   std::atomic<int> fd_{-1};
 
   /// @brief Process table mapping process_id to KfdProcess.
   /// @details Protected by process_mutex_ for concurrent daemon access.
+  ///
+  /// Global lock ordering (acquire in this order; never the reverse).
+  /// op_mutex_ (KfdProcess) is the outermost per-process ioctl lock. Under it,
+  /// process_mutex_ and alloc_mutex_ are independent siblings — they are NEVER
+  /// held simultaneously (allocate_scratch_backing and close() both release
+  /// process_mutex_ before taking alloc_mutex_):
+  ///   op_mutex_ < process_mutex_
+  ///   op_mutex_ < alloc_mutex_ < {ipc_mutex_, page_table_mutex_, owned_fds_mutex_}
+  ///   op_mutex_ < runtime_mutex_ < alloc_mutex_        (runtime_enable_ioctl)
+  ///   op_mutex_ < debug_mutex_ < runtime_mutex_        (debug_trap_ioctl)
+  ///   process_mutex_ < interrupt_mutex_                (open()/open_process())
+  /// The op_mutex_ in the debug rule is always the CALLER's, while debug_mutex_/
+  /// runtime_mutex_ may belong to a DIFFERENT process (the debug target resolved
+  /// by client pid). debug_trap_ioctl holds only the caller's op_mutex_ and never
+  /// acquires the target's op_mutex_, so a cross-process attach cannot deadlock.
+  /// interrupt_mutex_ is a leaf: the CP interrupt callback takes it and only
+  /// descends into EventState::mutex_, and close() takes it only after releasing
+  /// process_mutex_, so there is no cycle.
+  /// The CP engine thread acquires hw_queue_mutex_ first, then reaches
+  /// process_mutex_ (scratch resolver) or alloc_mutex_ (scratch allocator) through
+  /// the callbacks — hw_queue_mutex_ -> process_mutex_ and, separately,
+  /// hw_queue_mutex_ -> alloc_mutex_ (never both nested). To avoid an ABBA against
+  /// that thread, an ioctl MUST NOT hold a per-process lock (alloc_mutex_) across a
+  /// CommandProcessor call that takes hw_queue_mutex_ (e.g. register_queue) — build
+  /// state under alloc_mutex_, release it, then call the CP.
   mutable std::mutex process_mutex_;
   std::unordered_map<uint32_t, std::shared_ptr<KfdProcess>> processes_;
   uint32_t next_process_id_ = 1;

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -1217,4 +1217,87 @@ TEST(RemoteDriverDbgEnableTest, FailedEnableLeavesCallerRuntimeInfoUntouched) {
   server.join();
 }
 
+// Deterministic regression for the close()-vs-in-flight-ioctl teardown ordering.
+// After close() fully tears a process down, a subsequent ioctl on that process id
+// must FAIL cleanly (-ESRCH) rather than operate on dismantled per-process state
+// (allocations/queues/doorbells already cleared). This exercises the lifetime
+// invariant that ioctl() must not mutate a torn-down process; the threaded
+// SimulatedKfdTest.ConcurrentIoctlAndCloseIsRaceFree covers the racing variant
+// under TSan, this one pins the post-teardown contract without timing.
+TEST_F(KfdIoctlTest, IoctlAfterCloseFailsCleanly) {
+  ASSERT_NE(soc_, nullptr);
+  rocjitsu::SimulatedKfd daemon_driver(*soc_, true);
+  uint32_t pid = daemon_driver.open_process();
+  ASSERT_NE(pid, 0u);
+
+  // A state-touching ioctl works while the process is live.
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = 0x100000000ULL;
+  alloc.size = 0x1000;
+  alloc.gpu_id = kGpuId;
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  EXPECT_EQ(daemon_driver.ioctl(pid, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+
+  // Tear the process down (single open reference -> full teardown).
+  EXPECT_EQ(daemon_driver.close(pid), 0);
+
+  // Any ioctl on the now-closed process id must fail cleanly, not touch freed
+  // state. -ESRCH is returned once the process is gone from the table.
+  kfd_ioctl_alloc_memory_of_gpu_args after{};
+  after.va_addr = 0x200000000ULL;
+  after.size = 0x1000;
+  after.gpu_id = kGpuId;
+  after.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  EXPECT_EQ(daemon_driver.ioctl(pid, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &after), -ESRCH);
+
+  kfd_ioctl_get_version_args ver{};
+  EXPECT_EQ(daemon_driver.ioctl(pid, AMDKFD_IOC_GET_VERSION, &ver), -ESRCH);
+}
+
+// Deterministic regression for destructor teardown of a multiply-opened process.
+// close() only tears a process down on the LAST open reference, so a process with
+// open_ref_count_ > 1 survives a single close(). ~SimulatedKfd must keep closing
+// each snapshotted pid until it is fully drained, otherwise its allocations,
+// queues, and CP callbacks leak past the driver. This pins that drain: a daemon
+// process opened twice (same client_pid -> shared, refcount 2) plus a live
+// allocation, then the driver is destroyed without an explicit close().
+TEST_F(KfdIoctlTest, DestructorDrainsMultiplyOpenedProcess) {
+  ASSERT_NE(soc_, nullptr);
+  uint32_t pid = 0;
+  {
+    rocjitsu::SimulatedKfd daemon_driver(*soc_, true);
+    // Same client_pid twice -> one shared process with open_ref_count_ == 2.
+    pid = daemon_driver.open_process(/*client_pid=*/4242);
+    ASSERT_NE(pid, 0u);
+    uint32_t pid2 = daemon_driver.open_process(/*client_pid=*/4242);
+    EXPECT_EQ(pid2, pid);
+
+    kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+    alloc.va_addr = 0x100000000ULL;
+    alloc.size = 0x1000;
+    alloc.gpu_id = kGpuId;
+    alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+    EXPECT_EQ(daemon_driver.ioctl(pid, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+
+    // A single close() drops one of the two references; the process is still live.
+    EXPECT_EQ(daemon_driver.close(pid), 0);
+
+    // Prove the process survived the first close() (open_ref_count_ still 1): a
+    // state-touching ioctl must still succeed rather than return -ESRCH. If close()
+    // had torn it down on the first reference, this would fail cleanly instead.
+    kfd_ioctl_alloc_memory_of_gpu_args live{};
+    live.va_addr = 0x200000000ULL;
+    live.size = 0x1000;
+    live.gpu_id = kGpuId;
+    live.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+    EXPECT_EQ(daemon_driver.ioctl(pid, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &live), 0);
+
+    // daemon_driver goes out of scope here -> ~SimulatedKfd must drain the
+    // still-open (refcount 1) process fully. Under ASan/leak checking this fails
+    // if the destructor leaks the process's allocation/memfd.
+  }
+  // No crash / no leak reported == pass. (pid intentionally unused past scope.)
+  (void)pid;
+}
+
 } // namespace

--- a/emulation/rocjitsu/tests/simulated_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/simulated_kfd_test.cpp
@@ -11,10 +11,19 @@
 #include "embedded_schema.h"
 #include "simdojo/sim/simulation.h"
 
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "linux/uapi/kfd_ioctl.h"
+RJ_DIAGNOSTIC_POP
+
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <cstdlib>
 #include <filesystem>
+#include <thread>
+#include <vector>
 
 namespace {
 
@@ -84,6 +93,78 @@ TEST_F(SimulatedKfdTest, TopologyDirectoryExists) {
   EXPECT_TRUE(std::filesystem::exists(path + "/generation_id"));
   EXPECT_TRUE(std::filesystem::exists(path + "/nodes/0/properties"));
   EXPECT_TRUE(std::filesystem::exists(path + "/nodes/1/properties"));
+}
+
+// Regression test for the close()-vs-in-flight-ioctl teardown race. ioctl()
+// snapshots the KfdProcess shared_ptr WITHOUT retaining an open reference, so a
+// concurrent close() can erase and tear down the process while other threads are
+// dispatching ioctls against the same process id. The hardening (op_mutex_ held
+// across all teardown + an is_closing() guard taken right after op_mutex_ in
+// dispatch_ioctl) must ensure: (a) no crash / use-after-free, and (b) an ioctl
+// that loses the race returns a clean error (-ESRCH) instead of operating on a
+// dismantled process. This drives that race in-process, many times, under TSan/
+// ASan in the sanitizer CI job.
+TEST_F(SimulatedKfdTest, ConcurrentIoctlAndCloseIsRaceFree) {
+  auto t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  auto *drv = t.driver();
+
+  constexpr int kRounds = 200;
+  constexpr int kIoctlThreads = 4;
+
+  for (int round = 0; round < kRounds; ++round) {
+    uint32_t pid = drv->open_process(/*client_pid=*/0);
+    ASSERT_NE(pid, 0u);
+
+    const uint32_t gpu_id = drv->gpu_id();
+    std::atomic<bool> go{false};
+    std::atomic<int> bad{0};
+    std::vector<std::thread> workers;
+    workers.reserve(kIoctlThreads);
+    for (int i = 0; i < kIoctlThreads; ++i) {
+      workers.emplace_back([&, pid] {
+        while (!go.load(std::memory_order_acquire))
+          ;
+        // Accepted outcomes for every ioctl below: success (process still live),
+        // or a clean -ESRCH/-EINVAL once close() has torn it down. Any other value
+        // (or a crash / ASAN-TSAN report) means teardown overlapped a live ioctl.
+        auto ok = [](int rc) { return rc == 0 || rc == -ESRCH || rc == -EINVAL; };
+        for (int k = 0; k < 50; ++k) {
+          // Stateless routing probe.
+          kfd_ioctl_get_version_args ver{};
+          if (!ok(drv->ioctl(pid, AMDKFD_IOC_GET_VERSION, &ver)))
+            bad.fetch_add(1, std::memory_order_relaxed);
+
+          // State-touching ioctls that read/write alloc_mutex_-guarded
+          // allocations_, so close()'s teardown can actually overlap a handler
+          // dereferencing per-process state (not just the op_mutex_/is_closing
+          // gate). alloc then free the returned handle.
+          kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+          alloc.va_addr = 0x100000000ULL + static_cast<uint64_t>(k) * 0x1000ULL;
+          alloc.size = 0x1000;
+          alloc.gpu_id = gpu_id;
+          alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+          int arc = drv->ioctl(pid, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc);
+          if (!ok(arc))
+            bad.fetch_add(1, std::memory_order_relaxed);
+          if (arc == 0) {
+            kfd_ioctl_free_memory_of_gpu_args freed{};
+            freed.handle = alloc.handle;
+            if (!ok(drv->ioctl(pid, AMDKFD_IOC_FREE_MEMORY_OF_GPU, &freed)))
+              bad.fetch_add(1, std::memory_order_relaxed);
+          }
+        }
+      });
+    }
+
+    go.store(true, std::memory_order_release);
+    // Race close() against the in-flight ioctls.
+    int cret = drv->close(pid);
+    EXPECT_EQ(cret, 0);
+    for (auto &w : workers)
+      w.join();
+    EXPECT_EQ(bad.load(), 0) << "round " << round << ": ioctl saw invalid state during close";
+  }
 }
 
 } // namespace


### PR DESCRIPTION
## Motivation

In daemon mode a single SimulatedKfd serves many client connections
concurrently, so its per-process state (allocations, queues, events,
doorbells) can be touched by several threads at once. The prior code
lacked a per-process ioctl lock analogous to the real KFD's p->mutex,
so concurrent ioctls on the same process, and ioctls racing a close()
of that process, could corrupt or use-after-free per-process state.

The teardown path was the sharpest edge: ioctl() resolves its target
by snapshotting a shared_ptr via find_process() WITHOUT retaining an
open reference, so a concurrent close() can erase the process from the
table and dismantle it while another thread is mid-ioctl against the
same id. Several lock-order inversions (create_queue vs the CP engine
thread) and unsynchronized fields (doorbell state, scratch/trap
pointers read by the CP thread, dmabuf maps, cps_initialized) rounded
out the exposure. This change makes the concurrent and racing-teardown
paths safe, and adds focused regression coverage for the lifetime
invariants.

## Technical Details

Add a per-process op_mutex_ (analogous to real KFD's p->mutex) taken
as the outermost per-process lock in dispatch_ioctl to serialize most
ioctls. WAIT_EVENTS is handled before op_mutex_ and never takes it: it
blocks on a condition variable for signals that SET_EVENT/RESET_EVENT
(which run under op_mutex_) must produce, so holding it would deadlock
forward progress.

Make close()-vs-in-flight-ioctl teardown race-free. close() erases the
process from the table and releases its open reference under
process_mutex_, then acquires op_mutex_ BEFORE any teardown step and
calls notify_closing() first, under op_mutex_. dispatch_ioctl checks
is_closing() immediately after taking op_mutex_ and returns -ESRCH, so
an ioctl that lost the race to close() fails cleanly instead of
operating on a torn-down process. process_mutex_ is released before
op_mutex_ is taken, preserving the op_mutex_ -> process_mutex_ order.
Doorbell and dmabuf teardown additionally take alloc_mutex_ (the lock
their readers use; those readers do not take op_mutex_), snapshotting
and clearing the fields under the lock and running munmap outside it.

Fix a create_queue lock-order inversion: create_queue_ioctl previously
held alloc_mutex_ across register_queue(), which takes the CP's
hw_queue_mutex_, while the CP engine thread takes alloc_mutex_ under
hw_queue_mutex_ via scratch-backing allocation (ABBA). Build the HW
queue and reserve per-process bookkeeping under alloc_mutex_, release
it, then register with the CP; op_mutex_ serializes same-process
create_queue so the window is unobservable.

Protect doorbell state (doorbell_page/_size/_gpu_va) under alloc_mutex_
consistently in dispatch_mmap/dispatch_munmap, and snapshot it under
alloc_mutex_ in is_doorbell_range().

Protect SET_SCRATCH_BACKING_VA and SET_TRAP_HANDLER writes under
process_mutex_ to synchronize with the CP thread's
scratch_backing_resolver reader.

Guard imported_dmabufs_/fd_to_import_handle_ under alloc_mutex_ in
import_dmabuf_ioctl, get_dmabuf_info_ioctl, free_memory_ioctl, and the
close() teardown.

Move the cps_initialized check-and-set into a shared
init_command_processors_locked() helper (requires process_mutex_),
called from both open() and open_process(), preventing double CP
callback registration when concurrent daemon clients both observe
cps_initialized==false.

Snapshot process IDs in the destructor under process_mutex_ before
closing each process, and keep closing each snapshotted pid until it is
fully drained, since close() only tears a process down on its LAST open
reference (a process with open_ref_count_ > 1 survives a single close).

Add regression coverage for the lifetime invariants. In
simulated_kfd_test.cpp, ConcurrentIoctlAndCloseIsRaceFree drives the
racing close()/ioctl path many times for TSan/ASan. In
kfd_ioctl_test.cpp, IoctlAfterCloseFailsCleanly pins the deterministic
post-teardown contract (ioctls on a closed process id return -ESRCH),
and DestructorDrainsMultiplyOpenedProcess covers destruction draining a
process whose open_ref_count_ is still > 1 after a single close().

## JIRA ID

PR #8583

## Test Plan

Run all CI tests

## Test Result

CI tests: PASSED

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
