### PR TITLE
[rocjitsu] Allow CDNA4 DBT guests on simulated CDNA3 target

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -134,6 +134,8 @@ jobs:
           ASAN_UBSAN_EXCLUDED_TESTS=(
             "HsaTest\.InitSucceeded"
             "HsaTest\.GpuAgentFound"
+            "Cdna4ToCdna3SimulatedDispatchTest\..*"
+            "Cdna4ToCdna3DbtGuestTest\..*"
             "HipMemcpyTest\.RoundTripFloat"
             "HipMemcpyTest\.RoundTripInt"
             "HipMemcpyTest\.DeviceToDevice"

--- a/emulation/rocjitsu/cmake/rj_flatbuffers.cmake
+++ b/emulation/rocjitsu/cmake/rj_flatbuffers.cmake
@@ -12,6 +12,11 @@ set(SCHEMA_FILES
     ${PROJECT_SOURCE_DIR}/schemas/checkpoint.fbs
 )
 
+# embedded_schema.h is generated at configure time below. Make schema edits
+# trigger CMake regeneration as well as the flatc custom command so the runtime
+# JSON parser and generated typed accessors always use the same table layout.
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${SCHEMA_FILES})
+
 set(GENERATED_HEADERS)
 foreach(schema ${SCHEMA_FILES})
     get_filename_component(schema_name ${schema} NAME_WE)

--- a/emulation/rocjitsu/configs/guest_gfx950_on_missing_simulator.json
+++ b/emulation/rocjitsu/configs/guest_gfx950_on_missing_simulator.json
@@ -1,9 +1,0 @@
-{
-  "dbt_guest": {
-    "enabled": true,
-    "guest_isa": "gfx950",
-    "host_isa": "gfx942",
-    "execution_backend": "simulator",
-    "simulator_config": "missing_simulator_config.json"
-  }
-}

--- a/emulation/rocjitsu/configs/guest_gfx950_on_missing_simulator.json
+++ b/emulation/rocjitsu/configs/guest_gfx950_on_missing_simulator.json
@@ -1,0 +1,9 @@
+{
+  "dbt_guest": {
+    "enabled": true,
+    "guest_isa": "gfx950",
+    "host_isa": "gfx942",
+    "execution_backend": "simulator",
+    "simulator_config": "missing_simulator_config.json"
+  }
+}

--- a/emulation/rocjitsu/configs/guest_gfx950_on_simulated_gfx942.json
+++ b/emulation/rocjitsu/configs/guest_gfx950_on_simulated_gfx942.json
@@ -24,7 +24,7 @@
       "wave_front_size": 64,
       "max_slots_scratch_cu": 32,
       "local_mem_size": 309237645312,
-      "lds_size_kb": 160,
+      "lds_size_kb": 64,
       "mem_width": 8192,
       "mem_clk_max": 1600,
       "l1_size_kb": 32,

--- a/emulation/rocjitsu/configs/guest_gfx950_on_simulated_gfx942.json
+++ b/emulation/rocjitsu/configs/guest_gfx950_on_simulated_gfx942.json
@@ -1,0 +1,42 @@
+{
+  "dbt_guest": {
+    "enabled": true,
+    "guest_isa": "gfx950",
+    "host_isa": "gfx942",
+    "host_gpu_id": 0,
+    "execution_backend": "simulator",
+    "simulator_config": "gfx942_cdna3_kmd.json",
+    "guest_device": {
+      "gpu_id": 38144,
+      "gfx_target_version": 90500,
+      "vendor_id": 4098,
+      "device_id": 30112,
+      "family_id": 160,
+      "unique_id": 5929628898254127105,
+      "marketing_name": "AMD Instinct MI350X",
+      "drm_render_minor": 191,
+      "simd_count": 64,
+      "max_waves_per_simd": 8,
+      "num_shader_engines": 4,
+      "num_shader_arrays_per_engine": 2,
+      "num_cu_per_sh": 4,
+      "simd_per_cu": 4,
+      "wave_front_size": 64,
+      "max_slots_scratch_cu": 32,
+      "local_mem_size": 309237645312,
+      "lds_size_kb": 160,
+      "mem_width": 8192,
+      "mem_clk_max": 1600,
+      "l1_size_kb": 32,
+      "l1_line_size": 128,
+      "l1_assoc": 4,
+      "l2_size_kb": 4096,
+      "l2_line_size": 128,
+      "l2_assoc": 16,
+      "num_sdma_engines": 5,
+      "num_sdma_xgmi_engines": 12,
+      "num_cp_queues": 128,
+      "max_engine_clk_fcompute": 2400
+    }
+  }
+}

--- a/emulation/rocjitsu/docs/dbt-design.md
+++ b/emulation/rocjitsu/docs/dbt-design.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Dynamic Binary Translation (DBT) system translates AMDGPU code objects compiled for one ISA to execute on a different ISA. The initial target pair is CDNA4 (GFX950) → RDNA4 (GFX1200/1201), but the architecture is designed to support any directional ISA pair.
+The Dynamic Binary Translation (DBT) system translates AMDGPU code objects compiled for one ISA to execute on a different ISA. The initial target pairs are CDNA4 (GFX950) → RDNA4 (GFX1200/1201) and CDNA4 (GFX950) → CDNA3 (GFX942), but the architecture is designed to support any directional ISA pair.
 
 The translation pipeline is organized into layers with clear responsibility boundaries. The binary translator orchestrates the process without owning ISA-specific policy. The encoding translator handles per-instruction binary format conversion. The semantic translator handles instruction-level behavioral differences. The kernel descriptor translator handles descriptor ABI and resource differences.
 
@@ -34,6 +34,31 @@ The translation pipeline is organized into layers with clear responsibility boun
 │  └───────────────────────────────────────────────────────────┘│
 └───────────────────────────────────────────────────────────────┘
 ```
+
+### Runtime host configuration
+
+DBT guest mode keeps the synthetic guest identity separate from the target that
+runs translated code. `DbtGuestConfig` describes the advertised guest ISA and
+device, while its `DbtHostConfig` describes the host ISA, topology GPU ID, and
+execution backend. The backend is an enum with two modes:
+
+- `hardware` forwards execution-facing operations to a real host GPU.
+- `simulator` delegates host KFD execution to `SimulatedKfd` and runs the
+  translated code on a RocJITsu VM.
+
+A simulator-backed DBT config supports two layouts. When `simulator_config` is
+set, it names an external host simulator config; relative paths are resolved
+beside the DBT guest config, and that external file overrides any simulator
+VM/topology in the DBT guest file. This is the normal composition form and lets
+`guest_gfx950_on_simulated_gfx942.json` reuse the golden
+`gfx942_cdna3_kmd.json` config. When `simulator_config` is omitted, the DBT
+guest block and simulator VM/topology are read from the same file. The
+self-contained form is useful for tests and generated temporary configs.
+
+Both layouts use the same translation and validation path. Before discovery,
+the runtime rejects guest execution limits that the selected simulator device
+cannot provide, including LDS size, scratch slots, waves per SIMD, and wavefront
+size.
 
 ---
 

--- a/emulation/rocjitsu/docs/rocjitsu_dbt_guest.md
+++ b/emulation/rocjitsu/docs/rocjitsu_dbt_guest.md
@@ -1,15 +1,22 @@
 # rocjitsu DBT Guest Mode
 
-A rocjitsu-only path where an unmodified ROCm process can see a
-guest GPU, but translate kernels and execute on a real host GPU.
+A rocjitsu-only path where an unmodified ROCm process can see a guest GPU, but
+translate kernels and execute on either a real or simulated host GPU.
 
 The design has three main components with their own responsibilities:
 
 1. **GuestKfd Interposer**: Shows applications a guest GPU device that looks
    like a real KFD/DRM device.
 2. **HSA Hooks**: Intercepts HSA Runtime calls for the guest GPU and forwards
-   them to the host GPU, translating kernels as needed.
+   them to the selected host backend, translating kernels as needed.
 3. **DBT**: Translates guest GPU kernels to host GPU kernels.
+
+The `dbt_guest.execution_backend` enum selects `hardware` or `simulator`.
+Simulator mode can reference an external host config with `simulator_config`,
+which takes precedence over VM/topology in the enclosing file, or omit that
+field and keep the simulator VM/topology in the same file. The checked-in
+CDNA4-on-CDNA3 config references the golden CDNA3 simulator config; the
+self-contained layout is primarily useful for tests and temporary configs.
 
 ## High Level Flow
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_common.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_common.h
@@ -36,12 +36,15 @@ inline std::string read_config_file(const std::string &path) {
 /// @details FlatBuffers returns pointers into `Parser::builder_`. Keeping the
 /// parser local to this helper makes the lifetime explicit: callers must copy
 /// any values they need inside @p callback rather than retaining raw pointers.
+/// @param skip_unexpected_fields Preserve the general simulation config's
+/// forward-compatible unknown-field behavior when true; use false for strict
+/// sub-configs whose misspelled keys could change execution behavior.
 template <typename Callback>
-decltype(auto) with_parsed_simulation_config_json(const std::string &json,
-                                                  const std::string &schema_text,
-                                                  Callback &&callback) {
+decltype(auto)
+with_parsed_simulation_config_json(const std::string &json, const std::string &schema_text,
+                                   Callback &&callback, bool skip_unexpected_fields = true) {
   flatbuffers::Parser parser;
-  parser.opts.skip_unexpected_fields_in_json = true;
+  parser.opts.skip_unexpected_fields_in_json = skip_unexpected_fields;
   if (!parser.Parse(schema_text.c_str()))
     throw std::runtime_error("Failed to parse schema: " + std::string(parser.error_));
   if (!parser.Parse(json.c_str()))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
@@ -21,16 +21,14 @@ namespace rocjitsu {
 namespace config {
 namespace {
 
-DbtExecutionBackend parse_execution_backend(const fb::DbtGuestConfig *guest) {
-  if (!guest->execution_backend())
+DbtExecutionBackend execution_backend_from_fb(fb::DbtExecutionBackend backend) {
+  switch (backend) {
+  case fb::DbtExecutionBackend_hardware:
     return DbtExecutionBackend::Hardware;
-  const std::string value = guest->execution_backend()->str();
-  if (value == "hardware")
-    return DbtExecutionBackend::Hardware;
-  if (value == "simulator")
+  case fb::DbtExecutionBackend_simulator:
     return DbtExecutionBackend::Simulator;
-  throw std::runtime_error("dbt_guest.execution_backend must be 'hardware' or 'simulator', got '" +
-                           value + "'");
+  }
+  throw std::runtime_error("dbt_guest.execution_backend is invalid");
 }
 
 void validate_guest_device_geometry(const KfdDeviceConfig &device) {
@@ -53,27 +51,9 @@ void validate_guest_device_geometry(const KfdDeviceConfig &device) {
 
 } // namespace
 
-const char *dbt_execution_backend_name(DbtExecutionBackend backend) {
-  switch (backend) {
-  case DbtExecutionBackend::Hardware:
-    return "hardware";
-  case DbtExecutionBackend::Simulator:
-    return "simulator";
-  }
-  return "unknown";
-}
-
-std::string resolve_dbt_simulator_config_path(const std::string &dbt_config_path,
-                                              const std::string &simulator_config) {
-  std::filesystem::path resolved(simulator_config);
-  if (resolved.is_relative())
-    resolved = std::filesystem::path(dbt_config_path).parent_path() / resolved;
-  return resolved.lexically_normal().string();
-}
-
 void validate_dbt_simulator_device_limits(const DbtGuestConfig &guest,
                                           const KfdDeviceConfig &simulator_device) {
-  if (!guest.enabled || guest.execution_backend != DbtExecutionBackend::Simulator)
+  if (!guest.enabled || guest.host.backend != DbtExecutionBackend::Simulator)
     return;
   if (!guest.guest_device.present || !simulator_device.present)
     throw std::runtime_error("simulator-backed dbt_guest requires guest and simulator devices");
@@ -107,23 +87,31 @@ DbtGuestConfig dbt_guest_from_fb(const fb::DbtGuestConfig *guest) {
   if (guest->guest_isa())
     config.guest_isa = guest->guest_isa()->str();
   if (guest->host_isa())
-    config.host_isa = guest->host_isa()->str();
-  config.host_gpu_id = guest->host_gpu_id();
-  config.execution_backend = parse_execution_backend(guest);
+    config.host.isa = guest->host_isa()->str();
+  config.host.gpu_id = guest->host_gpu_id();
+  config.host.backend = execution_backend_from_fb(guest->execution_backend());
   if (guest->simulator_config())
-    config.simulator_config = guest->simulator_config()->str();
+    config.host.simulator_config_path = guest->simulator_config()->str();
   config.log_level = guest->log_level();
   config.signal_backtrace = guest->signal_backtrace();
   config.guest_device = kfd_device_from_fb(guest->guest_device());
   validate_guest_device_geometry(config.guest_device);
-  if (config.enabled && config.execution_backend == DbtExecutionBackend::Simulator &&
-      config.simulator_config.empty())
-    throw std::runtime_error(
-        "dbt_guest.simulator_config is required when execution_backend is 'simulator'");
-  if (config.enabled && config.execution_backend == DbtExecutionBackend::Hardware &&
-      !config.simulator_config.empty())
-    throw std::runtime_error("dbt_guest.simulator_config requires execution_backend 'simulator'");
+  if (config.enabled && config.host.backend == DbtExecutionBackend::Hardware &&
+      !config.host.simulator_config_path.empty())
+    throw std::runtime_error("dbt_guest.simulator_config requires execution_backend=\"simulator\"");
   return config;
+}
+
+std::string resolve_dbt_host_config_path(const std::string &dbt_config_path,
+                                         const std::string &host_config_path) {
+  const std::filesystem::path dbt_path(dbt_config_path);
+  if (host_config_path.empty())
+    return dbt_path.lexically_normal().string();
+
+  const std::filesystem::path host_path(host_config_path);
+  if (host_path.is_absolute())
+    return host_path.lexically_normal().string();
+  return (dbt_path.parent_path() / host_path).lexically_normal().string();
 }
 
 DbtGuestConfig load_dbt_guest_config_from_file(const std::string &path) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
@@ -11,6 +11,7 @@
 #include "simulation_config_generated.h"
 
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <optional>
 #include <stdexcept>
@@ -19,6 +20,17 @@
 namespace rocjitsu {
 namespace config {
 namespace {
+
+DbtExecutionBackend parse_execution_backend(const fb::DbtGuestConfig *guest) {
+  const std::string value =
+      guest->execution_backend() ? guest->execution_backend()->str() : std::string("hardware");
+  if (value.empty() || value == "hardware")
+    return DbtExecutionBackend::Hardware;
+  if (value == "simulator")
+    return DbtExecutionBackend::Simulator;
+  throw std::runtime_error("dbt_guest.execution_backend must be 'hardware' or 'simulator', got '" +
+                           value + "'");
+}
 
 void validate_guest_device_geometry(const KfdDeviceConfig &device) {
   if (!device.present || device.simd_count == 0)
@@ -40,6 +52,24 @@ void validate_guest_device_geometry(const KfdDeviceConfig &device) {
 
 } // namespace
 
+const char *dbt_execution_backend_name(DbtExecutionBackend backend) {
+  switch (backend) {
+  case DbtExecutionBackend::Hardware:
+    return "hardware";
+  case DbtExecutionBackend::Simulator:
+    return "simulator";
+  }
+  return "unknown";
+}
+
+std::string resolve_dbt_simulator_config_path(const std::string &dbt_config_path,
+                                              const std::string &simulator_config) {
+  std::filesystem::path resolved(simulator_config);
+  if (resolved.is_relative())
+    resolved = std::filesystem::path(dbt_config_path).parent_path() / resolved;
+  return resolved.lexically_normal().string();
+}
+
 DbtGuestConfig dbt_guest_from_fb(const fb::DbtGuestConfig *guest) {
   DbtGuestConfig config;
   if (guest == nullptr)
@@ -51,10 +81,20 @@ DbtGuestConfig dbt_guest_from_fb(const fb::DbtGuestConfig *guest) {
   if (guest->host_isa())
     config.host_isa = guest->host_isa()->str();
   config.host_gpu_id = guest->host_gpu_id();
+  config.execution_backend = parse_execution_backend(guest);
+  if (guest->simulator_config())
+    config.simulator_config = guest->simulator_config()->str();
   config.log_level = guest->log_level();
   config.signal_backtrace = guest->signal_backtrace();
   config.guest_device = kfd_device_from_fb(guest->guest_device());
   validate_guest_device_geometry(config.guest_device);
+  if (config.enabled && config.execution_backend == DbtExecutionBackend::Simulator &&
+      config.simulator_config.empty())
+    throw std::runtime_error(
+        "dbt_guest.simulator_config is required when execution_backend is 'simulator'");
+  if (config.enabled && config.execution_backend == DbtExecutionBackend::Hardware &&
+      !config.simulator_config.empty())
+    throw std::runtime_error("dbt_guest.simulator_config requires execution_backend 'simulator'");
   return config;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
@@ -22,9 +22,10 @@ namespace config {
 namespace {
 
 DbtExecutionBackend parse_execution_backend(const fb::DbtGuestConfig *guest) {
-  const std::string value =
-      guest->execution_backend() ? guest->execution_backend()->str() : std::string("hardware");
-  if (value.empty() || value == "hardware")
+  if (!guest->execution_backend())
+    return DbtExecutionBackend::Hardware;
+  const std::string value = guest->execution_backend()->str();
+  if (value == "hardware")
     return DbtExecutionBackend::Hardware;
   if (value == "simulator")
     return DbtExecutionBackend::Simulator;
@@ -70,6 +71,33 @@ std::string resolve_dbt_simulator_config_path(const std::string &dbt_config_path
   return resolved.lexically_normal().string();
 }
 
+void validate_dbt_simulator_device_limits(const DbtGuestConfig &guest,
+                                          const KfdDeviceConfig &simulator_device) {
+  if (!guest.enabled || guest.execution_backend != DbtExecutionBackend::Simulator)
+    return;
+  if (!guest.guest_device.present || !simulator_device.present)
+    throw std::runtime_error("simulator-backed dbt_guest requires guest and simulator devices");
+
+  const auto require_at_most = [](const char *name, uint32_t guest_value,
+                                  uint32_t simulator_value) {
+    if (guest_value <= simulator_value)
+      return;
+    throw std::runtime_error("dbt_guest.guest_device." + std::string(name) + " (" +
+                             std::to_string(guest_value) + ") exceeds simulator device capacity (" +
+                             std::to_string(simulator_value) + ")");
+  };
+  require_at_most("lds_size_kb", guest.guest_device.lds_size_kb, simulator_device.lds_size_kb);
+  require_at_most("max_slots_scratch_cu", guest.guest_device.max_slots_scratch_cu,
+                  simulator_device.max_slots_scratch_cu);
+  require_at_most("max_waves_per_simd", guest.guest_device.max_waves_per_simd,
+                  simulator_device.max_waves_per_simd);
+  if (guest.guest_device.wave_front_size != simulator_device.wave_front_size)
+    throw std::runtime_error("dbt_guest.guest_device.wave_front_size (" +
+                             std::to_string(guest.guest_device.wave_front_size) +
+                             ") must match simulator device wave_front_size (" +
+                             std::to_string(simulator_device.wave_front_size) + ")");
+}
+
 DbtGuestConfig dbt_guest_from_fb(const fb::DbtGuestConfig *guest) {
   DbtGuestConfig config;
   if (guest == nullptr)
@@ -99,9 +127,23 @@ DbtGuestConfig dbt_guest_from_fb(const fb::DbtGuestConfig *guest) {
 }
 
 DbtGuestConfig load_dbt_guest_config_from_file(const std::string &path) {
+  const std::string json = read_config_file(path);
+  bool has_dbt_guest = false;
+  DbtGuestConfig parsed = with_parsed_simulation_config_json(
+      json, rocjitsu::kEmbeddedSchema, [&has_dbt_guest](const fb::SimulationConfig *config) {
+        has_dbt_guest = config->dbt_guest() != nullptr;
+        return dbt_guest_from_fb(config->dbt_guest());
+      });
+  if (!has_dbt_guest)
+    return parsed;
+
+  // Simulation configs remain forward-compatible with unknown fields, but a
+  // DBT guest block selects execution behavior and must reject misspelled keys
+  // instead of silently falling back to the hardware backend.
   return with_parsed_simulation_config_json(
-      read_config_file(path), rocjitsu::kEmbeddedSchema,
-      [](const fb::SimulationConfig *config) { return dbt_guest_from_fb(config->dbt_guest()); });
+      json, rocjitsu::kEmbeddedSchema,
+      [](const fb::SimulationConfig *config) { return dbt_guest_from_fb(config->dbt_guest()); },
+      false);
 }
 
 std::optional<DbtGuestConfig> load_dbt_guest_config_from_runtime_config() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.h
@@ -19,21 +19,40 @@ struct DbtGuestConfig;
 
 namespace rocjitsu::config {
 
+/// @brief Execution target used by DBT guest mode.
+enum class DbtExecutionBackend {
+  Hardware,  ///< Forward execution-facing operations to a real host GPU.
+  Simulator, ///< Forward execution-facing operations to a RocJITsu simulated GPU.
+};
+
 /// @brief DBT guest-GPU discovery configuration.
 ///
 /// @details When enabled, the Linux KFD interposer exposes one synthetic guest
-/// GPU alongside the real host GPUs and the HSA tools hook maps guest-agent
-/// execution calls to the host agent. The KFD layer only owns discovery; DBT and
-/// HSA forwarding happen in the HSA hook.
+/// GPU. The hardware backend forwards host-facing KFD operations to real
+/// `/dev/kfd`; the simulator backend delegates them to SimulatedKfd. The HSA
+/// tools hook translates guest code and maps guest-agent execution calls to the
+/// selected hardware or simulated host agent.
 struct DbtGuestConfig {
-  bool enabled = false;          ///< True when GuestKfd mode is active.
-  std::string guest_isa;         ///< Guest ISA advertised by the synthetic agent.
-  std::string host_isa;          ///< Host ISA used for actual ROCR execution.
-  uint32_t host_gpu_id = 0;      ///< Host KFD topology gpu_id; 0 matches topology to host_isa.
-  int log_level = 0;             ///< DBT hook logging level loaded from the config file.
-  bool signal_backtrace = false; ///< Install a best-effort HSA-hook crash backtrace handler.
-  KfdDeviceConfig guest_device;  ///< Synthetic guest device appended to KFD topology.
+  bool enabled = false;     ///< True when GuestKfd mode is active.
+  std::string guest_isa;    ///< Guest ISA advertised by the synthetic agent.
+  std::string host_isa;     ///< Host ISA used for actual ROCR execution.
+  uint32_t host_gpu_id = 0; ///< Host KFD topology gpu_id; 0 matches topology to host_isa.
+  DbtExecutionBackend execution_backend =
+      DbtExecutionBackend::Hardware; ///< Execution backend selected for the host agent.
+  std::string simulator_config;      ///< Simulator VM config path for the simulator backend.
+  int log_level = 0;                 ///< DBT hook logging level loaded from the config file.
+  bool signal_backtrace = false;     ///< Install a best-effort HSA-hook crash backtrace handler.
+  KfdDeviceConfig guest_device;      ///< Synthetic guest device appended to KFD topology.
 };
+
+/// @brief Return the stable configuration spelling for an execution backend.
+const char *dbt_execution_backend_name(DbtExecutionBackend backend);
+
+/// @brief Resolve a simulator config relative to its enclosing DBT config.
+/// @details Absolute paths are preserved and the result is normalized
+/// lexically without requiring the target to exist.
+std::string resolve_dbt_simulator_config_path(const std::string &dbt_config_path,
+                                              const std::string &simulator_config);
 
 /// @brief Convert a generated FlatBuffers DBT guest table into runtime config.
 ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.h
@@ -54,6 +54,16 @@ const char *dbt_execution_backend_name(DbtExecutionBackend backend);
 std::string resolve_dbt_simulator_config_path(const std::string &dbt_config_path,
                                               const std::string &simulator_config);
 
+/// @brief Reject guest limits that exceed a simulator execution target.
+/// @details Simulator-backed discovery must not advertise resource limits that
+/// the selected target cannot execute. Limits not represented in KFD device
+/// topology, such as per-kernel VGPR usage, remain the translator/runtime's
+/// responsibility.
+/// @throws std::runtime_error when an execution-relevant guest limit is not
+/// supported by the simulator device.
+void validate_dbt_simulator_device_limits(const DbtGuestConfig &guest,
+                                          const KfdDeviceConfig &simulator_device);
+
 /// @brief Convert a generated FlatBuffers DBT guest table into runtime config.
 ///
 /// @details Shared by the DBT-only loader and the full simulation config

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.h
@@ -25,6 +25,14 @@ enum class DbtExecutionBackend {
   Simulator, ///< Forward execution-facing operations to a RocJITsu simulated GPU.
 };
 
+/// @brief Host target selected for DBT translation and execution.
+struct DbtHostConfig {
+  std::string isa;     ///< Host ISA used for DBT output and ROCR execution.
+  uint32_t gpu_id = 0; ///< Host KFD topology gpu_id; 0 matches topology to isa.
+  DbtExecutionBackend backend = DbtExecutionBackend::Hardware; ///< Hardware or simulator execution.
+  std::string simulator_config_path; ///< Optional external simulator host config.
+};
+
 /// @brief DBT guest-GPU discovery configuration.
 ///
 /// @details When enabled, the Linux KFD interposer exposes one synthetic guest
@@ -33,26 +41,20 @@ enum class DbtExecutionBackend {
 /// tools hook translates guest code and maps guest-agent execution calls to the
 /// selected hardware or simulated host agent.
 struct DbtGuestConfig {
-  bool enabled = false;     ///< True when GuestKfd mode is active.
-  std::string guest_isa;    ///< Guest ISA advertised by the synthetic agent.
-  std::string host_isa;     ///< Host ISA used for actual ROCR execution.
-  uint32_t host_gpu_id = 0; ///< Host KFD topology gpu_id; 0 matches topology to host_isa.
-  DbtExecutionBackend execution_backend =
-      DbtExecutionBackend::Hardware; ///< Execution backend selected for the host agent.
-  std::string simulator_config;      ///< Simulator VM config path for the simulator backend.
-  int log_level = 0;                 ///< DBT hook logging level loaded from the config file.
-  bool signal_backtrace = false;     ///< Install a best-effort HSA-hook crash backtrace handler.
-  KfdDeviceConfig guest_device;      ///< Synthetic guest device appended to KFD topology.
+  bool enabled = false;          ///< True when GuestKfd mode is active.
+  std::string guest_isa;         ///< Guest ISA advertised by the synthetic agent.
+  DbtHostConfig host;            ///< Host translation and execution target.
+  int log_level = 0;             ///< DBT hook logging level loaded from the config file.
+  bool signal_backtrace = false; ///< Install a best-effort HSA-hook crash backtrace handler.
+  KfdDeviceConfig guest_device;  ///< Synthetic guest device appended to KFD topology.
 };
 
-/// @brief Return the stable configuration spelling for an execution backend.
-const char *dbt_execution_backend_name(DbtExecutionBackend backend);
-
-/// @brief Resolve a simulator config relative to its enclosing DBT config.
-/// @details Absolute paths are preserved and the result is normalized
-/// lexically without requiring the target to exist.
-std::string resolve_dbt_simulator_config_path(const std::string &dbt_config_path,
-                                              const std::string &simulator_config);
+/// @brief Resolve the simulator host config selected by a DBT guest config.
+/// @details An empty host_config_path selects dbt_config_path itself. Relative
+/// external paths are resolved beside the DBT guest config. A non-empty path
+/// selects that external file instead of VM/topology in the DBT guest file.
+std::string resolve_dbt_host_config_path(const std::string &dbt_config_path,
+                                         const std::string &host_config_path);
 
 /// @brief Reject guest limits that exceed a simulator execution target.
 /// @details Simulator-backed discovery must not advertise resource limits that

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
@@ -266,10 +266,10 @@ void restore_signal_backtrace_handlers() {
     return std::nullopt;
   }
 
-  auto target = parse_target(dbt_guest->host_isa);
+  auto target = parse_target(dbt_guest->host.isa);
   if (!target) {
     std::fprintf(stderr, "[rocjitsu-hooks] invalid dbt_guest.host_isa='%s'\n",
-                 dbt_guest->host_isa.c_str());
+                 dbt_guest->host.isa.c_str());
     return std::nullopt;
   }
   auto guest = parse_target(dbt_guest->guest_isa);
@@ -283,7 +283,7 @@ void restore_signal_backtrace_handlers() {
   config.target = *target;
   config.source_override = *guest;
   config.guest_target = *guest;
-  config.host_gpu_id = dbt_guest->host_gpu_id;
+  config.host_gpu_id = dbt_guest->host.gpu_id;
   config.log_level = clamp_log_level(dbt_guest->log_level);
   config.signal_backtrace = dbt_guest->signal_backtrace;
   return config;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
@@ -575,9 +575,19 @@ bool GuestKfd::ensure_real_kfd_locked() {
   if (execution_driver_) {
     int fd = execution_driver_->fd();
     if (fd < 0) {
+      const bool already_owns_open = owns_execution_driver_open_;
       fd = execution_driver_->open();
-      if (fd >= 0)
-        owns_execution_driver_open_ = true;
+      if (fd >= 0) {
+        if (already_owns_open) {
+          // Re-minting an overwritten simulator primary retains the existing
+          // process once. GuestKfd already pins that process for the lifetime
+          // of its app-facing opens, so balance the temporary retain and keep
+          // the original owned reference for final teardown.
+          execution_driver_->close();
+        } else {
+          owns_execution_driver_open_ = true;
+        }
+      }
     }
     if (fd < 0) {
       errno = ENODEV;
@@ -684,10 +694,13 @@ LinuxKfd::PrimaryInvalidation GuestKfd::invalidate_primary_fd(int fd) {
   int expected = fd;
   if (!real_kfd_fd_.compare_exchange_strong(expected, -1, std::memory_order_acq_rel))
     return PrimaryInvalidation::kNotPrimary;
-  if (execution_driver_) {
-    if (execution_driver_->invalidate_primary_fd(fd) == PrimaryInvalidation::kClearedDropRef)
-      execution_driver_->close();
-  }
+  if (execution_driver_)
+    // Clear the simulator's stale primary-fd classification, but do not honor
+    // kClearedDropRef here. That counted reference is the execution-backend
+    // open GuestKfd owns and must keep pinned while app-facing dups are live.
+    // ensure_real_kfd_locked() balances the extra retain if a later open has to
+    // re-mint the simulator primary.
+    (void)execution_driver_->invalidate_primary_fd(fd);
   // Also drop out of the ready state (mirroring close()'s teardown, minus the
   // fd close / overlay cleanup / ref decrement). This matters because GuestKfd
   // forwards every ioctl/mmap through real_kfd_fd_: with the number now cleared,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
@@ -534,7 +534,7 @@ void GuestKfd::TopologyOverlay::release_after_fork() {
 GuestKfd::GuestKfd(config::DbtGuestConfig config, LinuxKfd *execution_driver)
     : config_(std::move(config)), execution_driver_(execution_driver),
       overlay_(std::make_unique<TopologyOverlay>()),
-      owns_execution_driver_open_(execution_driver != nullptr) {
+      owns_execution_driver_open_(execution_driver && execution_driver->fd() >= 0) {
   libc_passthrough().resolve();
   guest_ = gpu_info_from_config(config_.guest_device,
                                 std::max(1u, config_.guest_device.num_shader_engines));
@@ -608,6 +608,10 @@ bool GuestKfd::ensure_ready() {
     return true;
 
   std::lock_guard lock(mutex_);
+  return ensure_ready_locked();
+}
+
+bool GuestKfd::ensure_ready_locked() {
   if (ready_.load(std::memory_order_acquire))
     return true;
   if (!config_.enabled || !config_.guest_device.present) {
@@ -641,37 +645,44 @@ bool GuestKfd::ensure_ready() {
 bool GuestKfd::prepare_for_discovery() { return ensure_ready(); }
 
 int GuestKfd::open() {
-  for (;;) {
-    if (!ensure_ready())
+  std::lock_guard lock(mutex_);
+  if (!ensure_ready_locked())
+    return -1;
+
+  bool opened_execution_driver = false;
+  if (execution_driver_ && !owns_execution_driver_open_) {
+    const int execution_fd = execution_driver_->open();
+    if (execution_fd < 0)
       return -1;
-    std::lock_guard lock(mutex_);
-    bool opened_execution_driver = false;
-    if (execution_driver_ && !owns_execution_driver_open_) {
-      const int execution_fd = execution_driver_->open();
-      if (execution_fd < 0)
-        return -1;
-      real_kfd_fd_.store(execution_fd, std::memory_order_release);
-      owns_execution_driver_open_ = true;
-      opened_execution_driver = true;
-    }
-    int kfd_fd = real_kfd_fd_.load(std::memory_order_acquire);
-    if (ready_.load(std::memory_order_acquire) && kfd_fd >= 0) {
-      // Keep the real /dev/kfd fd internal to the driver. Applications receive
-      // ordinary dup fds, so close(fd) releases that fd number immediately while
-      // the hidden real fd keeps host-KFD forwarding alive until the last
-      // app-facing open/dup reference is closed.
-      int app_fd = libc_passthrough().fcntl(kfd_fd, F_DUPFD_CLOEXEC, 0);
-      if (app_fd < 0) {
-        if (opened_execution_driver) {
-          execution_driver_->close();
-          owns_execution_driver_open_ = false;
-        }
-        return -1;
-      }
-      ++open_refs_;
-      return app_fd;
-    }
+    real_kfd_fd_.store(execution_fd, std::memory_order_release);
+    owns_execution_driver_open_ = true;
+    opened_execution_driver = true;
   }
+
+  const int kfd_fd = real_kfd_fd_.load(std::memory_order_acquire);
+  if (kfd_fd < 0) {
+    if (opened_execution_driver) {
+      execution_driver_->close();
+      owns_execution_driver_open_ = false;
+    }
+    errno = ENODEV;
+    return -1;
+  }
+
+  // Keep the real /dev/kfd fd internal to the driver. Applications receive
+  // ordinary dup fds, so close(fd) releases that fd number immediately while
+  // the hidden real fd keeps host-KFD forwarding alive until the last
+  // app-facing open/dup reference is closed.
+  const int app_fd = libc_passthrough().fcntl(kfd_fd, F_DUPFD_CLOEXEC, 0);
+  if (app_fd < 0) {
+    if (opened_execution_driver) {
+      execution_driver_->close();
+      owns_execution_driver_open_ = false;
+    }
+    return -1;
+  }
+  ++open_refs_;
+  return app_fd;
 }
 
 bool GuestKfd::retain_local_open() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
@@ -346,9 +346,9 @@ public:
 
   /// @brief Build the overlay from the current host sysfs topology.
   /// @param guest Synthetic guest GPU properties to append.
-  /// @param host_topology Optional generated simulated-host topology root.
+  /// @param host_topology_path Optional path to a generated simulated-host topology root.
   /// @returns true when topology and guest DRM paths are ready.
-  bool generate(const Sysfs::GpuInfo &guest, const std::string &host_topology = {});
+  bool generate(const Sysfs::GpuInfo &guest, const std::string &host_topology_path = {});
 
   /// @brief Remove generated overlay directories.
   void cleanup();
@@ -369,8 +369,8 @@ private:
   /// @brief Copy a host sysfs subtree into the generated overlay.
   bool copy_tree(const std::string &src, const std::string &dst);
 
-  /// @brief Copy a simulated topology or the first available real KFD topology.
-  bool copy_host_topology(const std::string &host_topology);
+  /// @brief Copy a simulated topology path or the first available real KFD topology.
+  bool copy_host_topology(const std::string &host_topology_path);
 
   /// @brief Generate the appended guest KFD node and guest DRM metadata.
   bool copy_guest_node(const Sysfs::GpuInfo &guest);
@@ -442,9 +442,9 @@ bool GuestKfd::TopologyOverlay::copy_tree(const std::string &src, const std::str
   return ok;
 }
 
-bool GuestKfd::TopologyOverlay::copy_host_topology(const std::string &host_topology) {
-  if (!host_topology.empty())
-    return copy_tree(host_topology, topology_dir_);
+bool GuestKfd::TopologyOverlay::copy_host_topology(const std::string &host_topology_path) {
+  if (!host_topology_path.empty())
+    return copy_tree(host_topology_path, topology_dir_);
 
   for (std::string_view topology_path : kRealTopologyPaths) {
     if (copy_tree(std::string(topology_path), topology_dir_))
@@ -498,11 +498,11 @@ bool GuestKfd::TopologyOverlay::patch_topology_files() {
 }
 
 bool GuestKfd::TopologyOverlay::generate(const Sysfs::GpuInfo &guest,
-                                         const std::string &host_topology) {
+                                         const std::string &host_topology_path) {
   cleanup();
   if (!make_temp_dir("rocjitsu_guest_topology", &topology_dir_))
     return false;
-  if (!copy_host_topology(host_topology)) {
+  if (!copy_host_topology(host_topology_path)) {
     cleanup();
     return false;
   }
@@ -539,7 +539,7 @@ GuestKfd::GuestKfd(config::DbtGuestConfig config, LinuxKfd *execution_driver)
   guest_ = gpu_info_from_config(config_.guest_device,
                                 std::max(1u, config_.guest_device.num_shader_engines));
   guest_.drm_render_minor = choose_render_minor(guest_.drm_render_minor);
-  host_gpu_id_ = config_.host_gpu_id;
+  host_gpu_id_ = config_.host.gpu_id;
 }
 
 GuestKfd::~GuestKfd() {
@@ -624,9 +624,9 @@ bool GuestKfd::ensure_ready_locked() {
     std::optional<uint32_t> host_gpu_id;
     if (execution_driver_)
       host_gpu_id = first_gpu_id_matching_isa_in_topology(execution_driver_->topology_path(),
-                                                          config_.host_isa);
+                                                          config_.host.isa);
     else
-      host_gpu_id = first_real_gpu_id_matching_isa(config_.host_isa);
+      host_gpu_id = first_real_gpu_id_matching_isa(config_.host.isa);
     if (!host_gpu_id) {
       errno = ENODEV;
       return false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
@@ -176,25 +176,32 @@ uint32_t max_numeric_dir(const fs::path &dir) {
   return max_id;
 }
 
-std::optional<uint32_t> first_real_gpu_id_matching_isa(std::string_view host_isa) {
+std::optional<uint32_t> first_gpu_id_matching_isa_in_topology(const fs::path &topology_root,
+                                                              std::string_view host_isa) {
   std::optional<uint32_t> target_version = kmd::gfx_target_version_from_name(host_isa);
   if (!target_version)
     return std::nullopt;
 
-  for (std::string_view topology_path : kRealTopologyPaths) {
-    fs::path nodes_dir = fs::path(std::string(topology_path)) / "nodes";
-    const uint32_t max_node = max_numeric_dir(nodes_dir);
-    for (uint32_t node_id = 1; node_id <= max_node; ++node_id) {
-      fs::path node_dir = nodes_dir / std::to_string(node_id);
-      const uint32_t gfx_target_version =
-          read_u32_property(node_dir / "properties", "gfx_target_version", 0);
-      if (gfx_target_version != *target_version)
-        continue;
+  fs::path nodes_dir = topology_root / "nodes";
+  const uint32_t max_node = max_numeric_dir(nodes_dir);
+  for (uint32_t node_id = 1; node_id <= max_node; ++node_id) {
+    fs::path node_dir = nodes_dir / std::to_string(node_id);
+    const uint32_t gfx_target_version =
+        read_u32_property(node_dir / "properties", "gfx_target_version", 0);
+    if (gfx_target_version != *target_version)
+      continue;
 
-      std::optional<uint32_t> gpu_id = read_u32_file(node_dir / "gpu_id");
-      if (gpu_id && *gpu_id != 0)
-        return gpu_id;
-    }
+    std::optional<uint32_t> gpu_id = read_u32_file(node_dir / "gpu_id");
+    if (gpu_id && *gpu_id != 0)
+      return gpu_id;
+  }
+  return std::nullopt;
+}
+
+std::optional<uint32_t> first_real_gpu_id_matching_isa(std::string_view host_isa) {
+  for (std::string_view topology_path : kRealTopologyPaths) {
+    if (auto gpu_id = first_gpu_id_matching_isa_in_topology(fs::path(topology_path), host_isa))
+      return gpu_id;
   }
   return std::nullopt;
 }
@@ -339,8 +346,9 @@ public:
 
   /// @brief Build the overlay from the current host sysfs topology.
   /// @param guest Synthetic guest GPU properties to append.
+  /// @param host_topology Optional generated simulated-host topology root.
   /// @returns true when topology and guest DRM paths are ready.
-  bool generate(const Sysfs::GpuInfo &guest);
+  bool generate(const Sysfs::GpuInfo &guest, const std::string &host_topology = {});
 
   /// @brief Remove generated overlay directories.
   void cleanup();
@@ -361,8 +369,8 @@ private:
   /// @brief Copy a host sysfs subtree into the generated overlay.
   bool copy_tree(const std::string &src, const std::string &dst);
 
-  /// @brief Copy the first available real KFD topology root into the overlay.
-  bool copy_host_topology();
+  /// @brief Copy a simulated topology or the first available real KFD topology.
+  bool copy_host_topology(const std::string &host_topology);
 
   /// @brief Generate the appended guest KFD node and guest DRM metadata.
   bool copy_guest_node(const Sysfs::GpuInfo &guest);
@@ -434,7 +442,10 @@ bool GuestKfd::TopologyOverlay::copy_tree(const std::string &src, const std::str
   return ok;
 }
 
-bool GuestKfd::TopologyOverlay::copy_host_topology() {
+bool GuestKfd::TopologyOverlay::copy_host_topology(const std::string &host_topology) {
+  if (!host_topology.empty())
+    return copy_tree(host_topology, topology_dir_);
+
   for (std::string_view topology_path : kRealTopologyPaths) {
     if (copy_tree(std::string(topology_path), topology_dir_))
       return true;
@@ -486,11 +497,12 @@ bool GuestKfd::TopologyOverlay::patch_topology_files() {
   return true;
 }
 
-bool GuestKfd::TopologyOverlay::generate(const Sysfs::GpuInfo &guest) {
+bool GuestKfd::TopologyOverlay::generate(const Sysfs::GpuInfo &guest,
+                                         const std::string &host_topology) {
   cleanup();
   if (!make_temp_dir("rocjitsu_guest_topology", &topology_dir_))
     return false;
-  if (!copy_host_topology()) {
+  if (!copy_host_topology(host_topology)) {
     cleanup();
     return false;
   }
@@ -519,8 +531,10 @@ void GuestKfd::TopologyOverlay::release_after_fork() {
   guest_sysfs_.release_after_fork();
 }
 
-GuestKfd::GuestKfd(config::DbtGuestConfig config)
-    : config_(std::move(config)), overlay_(std::make_unique<TopologyOverlay>()) {
+GuestKfd::GuestKfd(config::DbtGuestConfig config, LinuxKfd *execution_driver)
+    : config_(std::move(config)), execution_driver_(execution_driver),
+      overlay_(std::make_unique<TopologyOverlay>()),
+      owns_execution_driver_open_(execution_driver != nullptr) {
   libc_passthrough().resolve();
   guest_ = gpu_info_from_config(config_.guest_device,
                                 std::max(1u, config_.guest_device.num_shader_engines));
@@ -530,7 +544,9 @@ GuestKfd::GuestKfd(config::DbtGuestConfig config)
 
 GuestKfd::~GuestKfd() {
   int kfd_fd = real_kfd_fd_.load(std::memory_order_acquire);
-  if (kfd_fd >= 0)
+  if (execution_driver_ && owns_execution_driver_open_)
+    execution_driver_->close();
+  else if (kfd_fd >= 0 && !execution_driver_)
     libc_passthrough().close(kfd_fd);
 }
 
@@ -542,8 +558,10 @@ void GuestKfd::reset_after_fork() {
   new (&mutex_) std::mutex();
   ready_.store(false, std::memory_order_release);
   int kfd_fd = real_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
-  if (kfd_fd >= 0)
+  if (kfd_fd >= 0 && !execution_driver_)
     libc_passthrough().close(kfd_fd);
+  owns_execution_driver_open_ = false;
+  execution_driver_ = nullptr;
   open_refs_ = 0;
   overlay_->release_after_fork();
   synthetic_handles_.clear();
@@ -554,6 +572,20 @@ void GuestKfd::reset_after_fork() {
 bool GuestKfd::ensure_real_kfd_locked() {
   if (real_kfd_fd_.load(std::memory_order_acquire) >= 0)
     return true;
+  if (execution_driver_) {
+    int fd = execution_driver_->fd();
+    if (fd < 0) {
+      fd = execution_driver_->open();
+      if (fd >= 0)
+        owns_execution_driver_open_ = true;
+    }
+    if (fd < 0) {
+      errno = ENODEV;
+      return false;
+    }
+    real_kfd_fd_.store(fd, std::memory_order_release);
+    return true;
+  }
   int fd = libc_passthrough().openat(AT_FDCWD, "/dev/kfd", O_RDWR | O_CLOEXEC, 0);
   if (fd < 0)
     return false;
@@ -575,14 +607,20 @@ bool GuestKfd::ensure_ready() {
   if (!ensure_real_kfd_locked())
     return false;
   if (host_gpu_id_ == 0) {
-    std::optional<uint32_t> host_gpu_id = first_real_gpu_id_matching_isa(config_.host_isa);
+    std::optional<uint32_t> host_gpu_id;
+    if (execution_driver_)
+      host_gpu_id = first_gpu_id_matching_isa_in_topology(execution_driver_->topology_path(),
+                                                          config_.host_isa);
+    else
+      host_gpu_id = first_real_gpu_id_matching_isa(config_.host_isa);
     if (!host_gpu_id) {
       errno = ENODEV;
       return false;
     }
     host_gpu_id_ = *host_gpu_id;
   }
-  if (!overlay_->generate(guest_)) {
+  const std::string host_topology = execution_driver_ ? execution_driver_->topology_path() : "";
+  if (!overlay_->generate(guest_, host_topology)) {
     errno = ENODEV;
     return false;
   }
@@ -597,6 +635,15 @@ int GuestKfd::open() {
     if (!ensure_ready())
       return -1;
     std::lock_guard lock(mutex_);
+    bool opened_execution_driver = false;
+    if (execution_driver_ && !owns_execution_driver_open_) {
+      const int execution_fd = execution_driver_->open();
+      if (execution_fd < 0)
+        return -1;
+      real_kfd_fd_.store(execution_fd, std::memory_order_release);
+      owns_execution_driver_open_ = true;
+      opened_execution_driver = true;
+    }
     int kfd_fd = real_kfd_fd_.load(std::memory_order_acquire);
     if (ready_.load(std::memory_order_acquire) && kfd_fd >= 0) {
       // Keep the real /dev/kfd fd internal to the driver. Applications receive
@@ -604,8 +651,13 @@ int GuestKfd::open() {
       // the hidden real fd keeps host-KFD forwarding alive until the last
       // app-facing open/dup reference is closed.
       int app_fd = libc_passthrough().fcntl(kfd_fd, F_DUPFD_CLOEXEC, 0);
-      if (app_fd < 0)
+      if (app_fd < 0) {
+        if (opened_execution_driver) {
+          execution_driver_->close();
+          owns_execution_driver_open_ = false;
+        }
         return -1;
+      }
       ++open_refs_;
       return app_fd;
     }
@@ -632,6 +684,10 @@ LinuxKfd::PrimaryInvalidation GuestKfd::invalidate_primary_fd(int fd) {
   int expected = fd;
   if (!real_kfd_fd_.compare_exchange_strong(expected, -1, std::memory_order_acq_rel))
     return PrimaryInvalidation::kNotPrimary;
+  if (execution_driver_) {
+    if (execution_driver_->invalidate_primary_fd(fd) == PrimaryInvalidation::kClearedDropRef)
+      execution_driver_->close();
+  }
   // Also drop out of the ready state (mirroring close()'s teardown, minus the
   // fd close / overlay cleanup / ref decrement). This matters because GuestKfd
   // forwards every ioctl/mmap through real_kfd_fd_: with the number now cleared,
@@ -647,6 +703,7 @@ LinuxKfd::PrimaryInvalidation GuestKfd::invalidate_primary_fd(int fd) {
 
 int GuestKfd::close() {
   int kfd_fd = -1;
+  LinuxKfd *execution_driver_to_close = nullptr;
   std::unique_ptr<TopologyOverlay> overlay_to_cleanup;
   auto fresh_overlay = std::make_unique<TopologyOverlay>();
   {
@@ -662,6 +719,10 @@ int GuestKfd::close() {
     // final open reference closes the primary real fd and tears down discovery
     // state; the close hook separately closes any dup fd that triggered this.
     kfd_fd = real_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
+    if (execution_driver_ && owns_execution_driver_open_) {
+      execution_driver_to_close = execution_driver_;
+      owns_execution_driver_open_ = false;
+    }
     ready_.store(false, std::memory_order_release);
     synthetic_handles_.clear();
     synthetic_mmap_offsets_.clear();
@@ -673,12 +734,17 @@ int GuestKfd::close() {
     overlay_ = std::move(fresh_overlay);
   }
   overlay_to_cleanup.reset();
-  if (kfd_fd >= 0)
+  if (execution_driver_to_close)
+    execution_driver_to_close->close();
+  else if (kfd_fd >= 0 && !execution_driver_)
     libc_passthrough().close(kfd_fd);
   return 0;
 }
 
 int GuestKfd::forward_ioctl(unsigned long request, void *arg) {
+  if (execution_driver_)
+    return execution_driver_->ioctl(request, arg);
+
   int kfd_fd = fd();
   if (kfd_fd < 0) {
     errno = ENODEV;
@@ -958,13 +1024,21 @@ void *GuestKfd::mmap(void *addr, size_t length, int prot, int flags, off_t offse
     errno = ENODEV;
     return MAP_FAILED;
   }
+  if (execution_driver_)
+    return execution_driver_->mmap(addr, length, prot, flags, offset);
   return libc_passthrough().mmap(addr, length, prot, flags, kfd_fd, offset);
 }
 
-int GuestKfd::munmap(void *, size_t) { return -ENOENT; }
+int GuestKfd::munmap(void *addr, size_t length) {
+  return execution_driver_ ? execution_driver_->munmap(addr, length) : -ENOENT;
+}
 
 bool GuestKfd::owns_fd(int fd) const {
-  return fd >= 0 && fd == real_kfd_fd_.load(std::memory_order_acquire);
+  if (fd < 0)
+    return false;
+  if (fd == real_kfd_fd_.load(std::memory_order_acquire))
+    return true;
+  return execution_driver_ && execution_driver_->owns_fd(fd);
 }
 
 int GuestKfd::fd() const { return real_kfd_fd_.load(std::memory_order_acquire); }
@@ -1013,22 +1087,32 @@ std::string GuestKfd::redirect_sysfs_path(const char *path) const {
     }
   }
 
-  return {};
+  return execution_driver_ ? execution_driver_->redirect_sysfs_path(path) : std::string{};
 }
 
-bool GuestKfd::is_doorbell_range(const void *, size_t) const { return false; }
+bool GuestKfd::is_doorbell_range(const void *addr, size_t length) const {
+  return execution_driver_ && execution_driver_->is_doorbell_range(addr, length);
+}
 
 bool GuestKfd::handles_drm_render_minor(uint32_t minor) const {
-  return ready_.load(std::memory_order_acquire) && minor == guest_.drm_render_minor;
+  if (ready_.load(std::memory_order_acquire) && minor == guest_.drm_render_minor)
+    return true;
+  return execution_driver_ && execution_driver_->handles_drm_render_minor(minor);
 }
 
 const Sysfs::GpuInfo *GuestKfd::gpu_info_for_render_minor(uint32_t minor) const {
-  return handles_drm_render_minor(minor) ? &guest_ : nullptr;
+  if (ready_.load(std::memory_order_acquire) && minor == guest_.drm_render_minor)
+    return &guest_;
+  return execution_driver_ ? execution_driver_->gpu_info_for_render_minor(minor) : nullptr;
 }
 
 std::string GuestKfd::topology_path() const {
   std::lock_guard lock(mutex_);
   return ready_.load(std::memory_order_acquire) ? overlay_->topology_path() : std::string{};
+}
+
+std::string GuestKfd::drm_path() const {
+  return execution_driver_ ? execution_driver_->drm_path() : std::string{};
 }
 
 int GuestKfd::reject_guest_execution_ioctl(unsigned long request, void *) const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
@@ -104,8 +104,10 @@ public:
   /// close are not routed to whatever now occupies the number. The real fd is NOT
   /// counted in open_refs_ (only app-facing dups are), so a match returns
   /// kClearedKeepRefs — the interposer must clear the classification WITHOUT
-  /// dropping an open reference. Returns kNotPrimary if @p fd is not the current
-  /// hidden real fd.
+  /// dropping an open reference. For simulator execution, the separately owned
+  /// backend open also stays pinned until the final app-facing close; a later
+  /// primary-fd re-mint is balanced so it does not add another backend reference.
+  /// Returns kNotPrimary if @p fd is not the current hidden real fd.
   [[nodiscard]] PrimaryInvalidation invalidate_primary_fd(int fd) override;
 
 private:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
@@ -116,6 +116,9 @@ private:
   /// @brief Open real KFD, generate topology, and select the host GPU.
   bool ensure_ready();
 
+  /// @brief Prepare guest discovery while mutex_ is already held.
+  bool ensure_ready_locked();
+
   /// @brief Open the process's real /dev/kfd fd while mutex_ is held.
   bool ensure_real_kfd_locked();
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
@@ -28,26 +28,31 @@ namespace rocjitsu {
 
 /// @brief KFD driver that exposes a guest GPU for DBT while forwarding host GPU work.
 ///
-/// @details KFD emulation ends at discovery: this class appends one guest GPU
-/// to KFD topology and process apertures, but does not execute guest queues.
-/// Host-GPU ioctls are forwarded to the real /dev/kfd. If an execution ioctl
-/// still targets the guest GPU, the driver returns an error so the missing HSA
-/// forwarding path is visible.
+/// @details This class appends one guest GPU to KFD topology and process
+/// apertures, but does not execute guest queues itself. With the hardware
+/// backend, host-GPU operations are forwarded to real /dev/kfd. With the
+/// simulator backend, they are delegated to the supplied simulated KFD. If an
+/// execution ioctl still targets the guest GPU, the driver returns an error so
+/// the missing HSA forwarding path is visible.
 class GuestKfd : public LinuxKfd {
 public:
   /// @brief Construct a guest discovery driver from parsed DBT configuration.
-  explicit GuestKfd(config::DbtGuestConfig config);
+  /// @param execution_driver Optional simulated host KFD. When null, host
+  ///        execution is forwarded to the real `/dev/kfd`. When provided,
+  ///        GuestKfd adopts its bootstrap open reference (or opens it lazily)
+  ///        and releases that reference on the last application close.
+  explicit GuestKfd(config::DbtGuestConfig config, LinuxKfd *execution_driver = nullptr);
 
-  /// @brief Close the real KFD fd and remove generated overlay state.
+  /// @brief Close the execution KFD and remove generated overlay state.
   ~GuestKfd() override;
 
-  /// @brief Open the real /dev/kfd fd and lazily prepare guest discovery.
+  /// @brief Open the execution KFD and lazily prepare guest discovery.
   int open() override;
 
   /// @brief Handle close for the /dev/kfd fd represented by this driver.
   int close() override;
 
-  /// @brief Route guest discovery ioctls locally and host ioctls to real KFD.
+  /// @brief Route guest discovery ioctls locally and host ioctls to the execution KFD.
   int ioctl(unsigned long request, void *arg) override;
 
   /// @brief Map host-backed KFD offsets and reject unsupported guest doorbells.
@@ -56,7 +61,7 @@ public:
   /// @brief Forward unmaps for mappings created through this driver.
   int munmap(void *addr, size_t length) override;
 
-  /// @brief Return the real /dev/kfd fd.
+  /// @brief Return the underlying hardware or simulated KFD fd.
   [[nodiscard]] int fd() const override;
 
   /// @brief Return true when @p fd is an internal rocjitsu-owned fd.
@@ -77,8 +82,8 @@ public:
   /// @brief Return the generated KFD topology root.
   [[nodiscard]] std::string topology_path() const override;
 
-  /// @brief Return an empty DRM root because host DRM paths stay real.
-  [[nodiscard]] std::string drm_path() const override { return {}; }
+  /// @brief Return the simulated host DRM root, or empty for hardware execution.
+  [[nodiscard]] std::string drm_path() const override;
 
   /// @brief Detach inherited child-process state before destroying this copy.
   void reset_after_fork() override;
@@ -155,11 +160,14 @@ private:
   kfd_process_device_apertures guest_apertures() const;
 
   config::DbtGuestConfig config_;
+  /// @brief Non-owning simulated execution driver owned by the local VM.
+  LinuxKfd *execution_driver_ = nullptr;
   Sysfs::GpuInfo guest_{};
   std::unique_ptr<TopologyOverlay> overlay_;
   mutable std::mutex mutex_;
   std::atomic<int> real_kfd_fd_{-1};
   uint32_t open_refs_ = 0;
+  bool owns_execution_driver_open_ = false;
   uint32_t host_gpu_id_ = 0;
   static constexpr uint64_t kSyntheticHandleBase = 1ULL << 63;
   uint64_t next_synthetic_handle_ = kSyntheticHandleBase;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -803,11 +803,11 @@ public:
         if (dbt_guest.enabled) {
           LinuxKfd *execution_driver = nullptr;
           const bool simulator_backend =
-              dbt_guest.execution_backend == rocjitsu::config::DbtExecutionBackend::Simulator;
+              dbt_guest.host.backend == rocjitsu::config::DbtExecutionBackend::Simulator;
           if (simulator_backend) {
-            const std::string simulator_path = rocjitsu::config::resolve_dbt_simulator_config_path(
-                *cfg_path, dbt_guest.simulator_config);
-            if (!create_local_vm(simulator_path)) {
+            const std::string host_config_path = rocjitsu::config::resolve_dbt_host_config_path(
+                *cfg_path, dbt_guest.host.simulator_config_path);
+            if (!create_local_vm(host_config_path)) {
               in_construction = false;
               return nullptr;
             }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -7,12 +7,11 @@
 /// @details Intercepts open, close, ioctl, mmap, munmap, and filesystem access
 /// to route /dev/kfd operations and sysfs topology reads through one of two
 /// strategies. Normal simulation creates a VM and uses SimulatedKfd to own all
-/// visible GPU discovery and queue execution. DBT guest mode does not create a
-/// VM: GuestKfd forwards host-GPU KFD work to the real /dev/kfd while appending
-/// one synthetic guest GPU for ROCR discovery. The HSA tools hook then maps
-/// guest-agent API calls to the selected host agent and translates guest code
-/// objects before loading them. All mutable state is consolidated in
-/// InterposerContext.
+/// visible GPU discovery and queue execution. DBT guest mode uses GuestKfd to
+/// append one synthetic guest GPU over either real KFD hardware or an existing
+/// SimulatedKfd target. The HSA tools hook maps guest-agent API calls to that
+/// execution agent and translates guest code objects before loading them. All
+/// mutable state is consolidated in InterposerContext.
 
 #include "rocjitsu/base/rj_compiler.h"
 #include "rocjitsu/config/dbt_guest_config.h"
@@ -723,6 +722,58 @@ public:
     return drm_fds_.erase(fd) != 0;
   }
 
+  bool create_local_vm(const std::string &config_path) {
+    rj_vm_t *created_vm = nullptr;
+    if (rj_vm_create(config_path.c_str(), RJ_VM_MODE_LOCAL, &created_vm) !=
+        ROCJITSU_STATUS_SUCCESS) {
+      util::Logger::debug_print("rocjitsu: failed to create VM from ", config_path);
+      return false;
+    }
+    rj_vm_ = created_vm;
+
+    if (rj_vm_->soc) {
+      std::shared_ptr<rocjitsu::ExecutionPluginGroup> pg;
+      if (std::getenv("RJ_USE_PROFILED_EXECUTION_PLUGIN_GROUP"))
+        pg = std::make_shared<rocjitsu::ProfiledExecutionPluginGroup>();
+      else
+        pg = std::make_shared<rocjitsu::ExecutionPluginGroup>();
+
+      std::string sinks_str = "stderr";
+      if (const char *s = std::getenv("RJ_SINKS"))
+        sinks_str = s;
+      std::istringstream ss(sinks_str);
+      std::string token;
+      while (std::getline(ss, token, ',')) {
+        if (token == "stderr")
+          pg->add_sink(&rocjitsu::StderrSink::instance());
+        else if (token == "stdout")
+          pg->add_sink(&rocjitsu::StdoutSink::instance());
+        else if (token == "file") {
+          const char *dir = std::getenv("RJ_SINK_DIR");
+          if (dir)
+            pg->set_sink_dir(dir);
+        }
+      }
+
+      if (const char *rj_log = std::getenv("RJ_LOG"); rj_log && std::string(rj_log) == "1") {
+        pg->add(std::unique_ptr<rocjitsu::ExecutionPlugin>(createKernelLoggingPlugin()));
+        fprintf(stderr, "[rocjitsu] Logging enabled (RJ_LOG)\n");
+      }
+
+      if (const char *race = std::getenv("RJ_RACE"); race && std::string(race) == "1") {
+        pg->add(std::unique_ptr<rocjitsu::ExecutionPlugin>(createRaceDetectorPlugin()));
+        fprintf(stderr, "[rocjitsu] Race detection enabled (RJ_RACE)\n");
+      }
+      rj_vm_->soc->set_plugin_group(pg);
+    }
+    return true;
+  }
+
+  void start_local_vm() {
+    assert(rj_vm_ != nullptr);
+    std::thread([vm = rj_vm_]() { rj_vm_run(vm, nullptr); }).detach();
+  }
+
   LinuxKfd *get_or_create() {
     std::lock_guard lock(init_mutex_);
     if (active_driver_.load(std::memory_order_acquire) == nullptr) {
@@ -737,14 +788,33 @@ public:
       try {
         auto dbt_guest = rocjitsu::config::load_dbt_guest_config_from_file(*cfg_path);
         if (dbt_guest.enabled) {
-          auto guest_driver = std::make_unique<GuestKfd>(std::move(dbt_guest));
+          LinuxKfd *execution_driver = nullptr;
+          const bool simulator_backend =
+              dbt_guest.execution_backend == rocjitsu::config::DbtExecutionBackend::Simulator;
+          if (simulator_backend) {
+            const std::string simulator_path = rocjitsu::config::resolve_dbt_simulator_config_path(
+                *cfg_path, dbt_guest.simulator_config);
+            if (!create_local_vm(simulator_path)) {
+              in_construction = false;
+              return nullptr;
+            }
+            execution_driver = rj_vm_->vm->driver();
+          }
+
+          auto guest_driver = std::make_unique<GuestKfd>(std::move(dbt_guest), execution_driver);
           if (!guest_driver->prepare_for_discovery()) {
+            if (rj_vm_) {
+              rj_vm_destroy(rj_vm_);
+              rj_vm_ = nullptr;
+            }
             in_construction = false;
             return nullptr;
           }
           auto *driver = guest_driver.get();
           guest_driver_ = std::move(guest_driver);
           active_driver_.store(driver, std::memory_order_release);
+          if (simulator_backend)
+            start_local_vm();
           in_construction = false;
           return driver;
         }
@@ -753,51 +823,9 @@ public:
         in_construction = false;
         return nullptr;
       }
-      rj_vm_t *created_vm = nullptr;
-      if (rj_vm_create(cfg_path->c_str(), RJ_VM_MODE_LOCAL, &created_vm) !=
-          ROCJITSU_STATUS_SUCCESS) {
-        util::Logger::debug_print("rocjitsu: failed to create VM");
+      if (!create_local_vm(*cfg_path)) {
         in_construction = false;
         return nullptr;
-      }
-      rj_vm_ = created_vm;
-
-      if (created_vm->soc) {
-        std::shared_ptr<rocjitsu::ExecutionPluginGroup> pg;
-        if (std::getenv("RJ_USE_PROFILED_EXECUTION_PLUGIN_GROUP"))
-          pg = std::make_shared<rocjitsu::ProfiledExecutionPluginGroup>();
-        else
-          pg = std::make_shared<rocjitsu::ExecutionPluginGroup>();
-
-        std::string sinks_str = "stderr";
-        if (const char *s = std::getenv("RJ_SINKS"))
-          sinks_str = s;
-        {
-          std::istringstream ss(sinks_str);
-          std::string token;
-          while (std::getline(ss, token, ',')) {
-            if (token == "stderr")
-              pg->add_sink(&rocjitsu::StderrSink::instance());
-            else if (token == "stdout")
-              pg->add_sink(&rocjitsu::StdoutSink::instance());
-            else if (token == "file") {
-              const char *dir = std::getenv("RJ_SINK_DIR");
-              if (dir)
-                pg->set_sink_dir(dir);
-            }
-          }
-        }
-
-        if (const char *rj_log = std::getenv("RJ_LOG"); rj_log && std::string(rj_log) == "1") {
-          pg->add(std::unique_ptr<rocjitsu::ExecutionPlugin>(createKernelLoggingPlugin()));
-          fprintf(stderr, "[rocjitsu] Logging enabled (RJ_LOG)\n");
-        }
-
-        if (const char *race = std::getenv("RJ_RACE"); race && std::string(race) == "1") {
-          pg->add(std::unique_ptr<rocjitsu::ExecutionPlugin>(createRaceDetectorPlugin()));
-          fprintf(stderr, "[rocjitsu] Race detection enabled (RJ_RACE)\n");
-        }
-        created_vm->soc->set_plugin_group(pg);
       }
 
       // Publish the fully-constructed, not-yet-running driver BEFORE starting the
@@ -806,9 +834,9 @@ public:
       // also observes all of the setup above (config, plugin group, sinks).
       // Starting rj_vm_run() before the store would let the detached engine
       // thread begin mutating the VM before it is published.
-      LinuxKfd *driver = created_vm->vm->driver();
+      LinuxKfd *driver = rj_vm_->vm->driver();
       active_driver_.store(driver, std::memory_order_release);
-      std::thread([vm = created_vm]() { rj_vm_run(vm, nullptr); }).detach();
+      start_local_vm();
       in_construction = false;
     }
     return driver();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -730,6 +730,12 @@ public:
       return false;
     }
     rj_vm_ = created_vm;
+    if (!rj_vm_->vm || !rj_vm_->vm->driver() || rj_vm_->vm->driver()->fd() < 0) {
+      util::Logger::debug_print("rocjitsu: local VM did not acquire a KFD open");
+      rj_vm_destroy(rj_vm_);
+      rj_vm_ = nullptr;
+      return false;
+    }
 
     if (rj_vm_->soc) {
       std::shared_ptr<rocjitsu::ExecutionPluginGroup> pg;
@@ -769,6 +775,13 @@ public:
     return true;
   }
 
+  void destroy_local_vm() {
+    if (!rj_vm_)
+      return;
+    rj_vm_destroy(rj_vm_);
+    rj_vm_ = nullptr;
+  }
+
   void start_local_vm() {
     assert(rj_vm_ != nullptr);
     std::thread([vm = rj_vm_]() { rj_vm_run(vm, nullptr); }).detach();
@@ -799,14 +812,16 @@ public:
               return nullptr;
             }
             execution_driver = rj_vm_->vm->driver();
+            rocjitsu::config::validate_dbt_simulator_device_limits(dbt_guest,
+                                                                   rj_vm_->loaded.device);
           }
 
           auto guest_driver = std::make_unique<GuestKfd>(std::move(dbt_guest), execution_driver);
           if (!guest_driver->prepare_for_discovery()) {
-            if (rj_vm_) {
-              rj_vm_destroy(rj_vm_);
-              rj_vm_ = nullptr;
-            }
+            // GuestKfd owns the simulator's bootstrap open, so destroy it while
+            // the VM and execution driver are still alive.
+            guest_driver.reset();
+            destroy_local_vm();
             in_construction = false;
             return nullptr;
           }
@@ -820,6 +835,7 @@ public:
         }
       } catch (const std::exception &e) {
         util::Logger::debug_print("rocjitsu: failed to load child config: ", e.what());
+        destroy_local_vm();
         in_construction = false;
         return nullptr;
       }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/linux_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/linux_kfd.h
@@ -33,9 +33,10 @@ inline constexpr uint64_t kfd_mmap_gpu_id(uint32_t gpu_id) {
 ///
 /// @details The base Driver interface handles /dev/kfd calls. The Linux shim
 /// also needs sysfs redirection, DRM render-node ownership, and fd tracking.
-/// SimulatedKfd and GuestKfd both implement this surface, but with
-/// different ownership rules: simulation owns all visible GPU discovery, while
-/// GuestKfd owns only the appended guest GPU.
+/// SimulatedKfd and GuestKfd both implement this surface, but with different
+/// ownership rules: simulation owns all visible GPU discovery, while GuestKfd
+/// owns the appended guest and delegates host operations to either hardware or
+/// a SimulatedKfd execution backend.
 class LinuxKfd : public Driver {
 public:
   ~LinuxKfd() override = default;
@@ -107,8 +108,9 @@ public:
 
   /// @brief Return a generated /sys/class/drm root for full DRM redirection.
   ///
-  /// @details GuestKfd returns an empty string because host DRM entries
-  /// must remain real; it redirects only the synthetic guest render node.
+  /// @details Hardware-backed GuestKfd returns an empty string because host DRM
+  /// entries must remain real; simulator-backed GuestKfd delegates this to its
+  /// SimulatedKfd backend.
   [[nodiscard]] virtual std::string drm_path() const = 0;
 
   /// @brief Redirect standard KFD topology and DRM sysfs roots.

--- a/emulation/rocjitsu/schemas/simulation_config.fbs
+++ b/emulation/rocjitsu/schemas/simulation_config.fbs
@@ -120,11 +120,11 @@ table AmdgpuConfig {
 
 /// DBT guest-GPU discovery mode.
 ///
-/// When enabled, the KFD interposer does not start the simulated VM. Instead it
-/// forwards real host-GPU KFD ioctls to /dev/kfd and appends one synthetic guest
-/// GPU to the topology seen by ROCR. HSA hooks then map execution-facing calls
-/// from the guest agent to the host agent and translate guest code objects to
-/// host code objects before loading them.
+/// The execution_backend selects whether the host agent is backed by real KFD
+/// hardware or by a separate RocJITsu simulator config. In both modes the KFD
+/// interposer appends one synthetic guest GPU to the execution topology. HSA
+/// hooks map execution-facing calls from the guest agent to the host agent and
+/// translate guest code objects to host code objects before loading them.
 table DbtGuestConfig {
   enabled: bool = false;          // Enables GuestKfd discovery mode.
   guest_isa: string;              // Guest ISA advertised by the synthetic agent, e.g. "gfx950".
@@ -133,6 +133,9 @@ table DbtGuestConfig {
   log_level: int32 = 0;           // DBT hook logging: 0 off, 1 info, 2 verbose, 3 debug.
   signal_backtrace: bool = false; // Install a best-effort crash backtrace handler in the HSA hook.
   guest_device: KfdDeviceInfo;    // Synthetic guest KFD/sysfs identity appended to host topology.
+  // Keep new fields after the original table members to preserve FlatBuffers field IDs.
+  execution_backend: string;      // "hardware" or "simulator"; omitted means hardware.
+  simulator_config: string;       // Simulator VM config, relative to this file when not absolute.
 }
 
 /// A dispatch packet describing a kernel launch.

--- a/emulation/rocjitsu/schemas/simulation_config.fbs
+++ b/emulation/rocjitsu/schemas/simulation_config.fbs
@@ -118,13 +118,18 @@ table AmdgpuConfig {
   num_gpus: uint32 = 1;          // Number of simulated GPU instances.
 }
 
+enum DbtExecutionBackend: byte {
+  hardware,
+  simulator,
+}
+
 /// DBT guest-GPU discovery mode.
 ///
 /// The execution_backend selects whether the host agent is backed by real KFD
-/// hardware or by a separate RocJITsu simulator config. In both modes the KFD
-/// interposer appends one synthetic guest GPU to the execution topology. HSA
-/// hooks map execution-facing calls from the guest agent to the host agent and
-/// translate guest code objects to host code objects before loading them.
+/// hardware or by a simulation configuration. In both modes the KFD interposer
+/// appends one synthetic guest GPU to the execution topology.
+/// HSA hooks map execution-facing calls from the guest agent to the host agent
+/// and translate guest code objects to host code objects before loading them.
 table DbtGuestConfig {
   enabled: bool = false;          // Enables GuestKfd discovery mode.
   guest_isa: string;              // Guest ISA advertised by the synthetic agent, e.g. "gfx950".
@@ -133,9 +138,8 @@ table DbtGuestConfig {
   log_level: int32 = 0;           // DBT hook logging: 0 off, 1 info, 2 verbose, 3 debug.
   signal_backtrace: bool = false; // Install a best-effort crash backtrace handler in the HSA hook.
   guest_device: KfdDeviceInfo;    // Synthetic guest KFD/sysfs identity appended to host topology.
-  // Keep new fields after the original table members to preserve FlatBuffers field IDs.
-  execution_backend: string;      // "hardware" or "simulator"; omitted means hardware.
-  simulator_config: string;       // Simulator VM config, relative to this file when not absolute.
+  execution_backend: DbtExecutionBackend = hardware;
+  simulator_config: string;       // External host config; when set, overrides this file's VM/topology.
 }
 
 /// A dispatch packet describing a kernel launch.

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -533,9 +533,6 @@ set(RJ_CDNA3_KMD_CONFIG "${CMAKE_SOURCE_DIR}/configs/gfx942_cdna3_kmd.json")
 set(RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG
     "${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_simulated_gfx942.json"
 )
-set(RJ_CDNA4_TO_CDNA3_MISSING_SIM_DBT_CONFIG
-    "${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_missing_simulator.json"
-)
 set(RJ_HIP_TEST_ARCH
     "gfx950"
     CACHE STRING
@@ -556,11 +553,6 @@ get_filename_component(RJ_CDNA3_KMD_CONFIG_NAME "${RJ_CDNA3_KMD_CONFIG}" NAME)
 get_filename_component(
     RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG_NAME
     "${RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG}"
-    NAME
-)
-get_filename_component(
-    RJ_CDNA4_TO_CDNA3_MISSING_SIM_DBT_CONFIG_NAME
-    "${RJ_CDNA4_TO_CDNA3_MISSING_SIM_DBT_CONFIG}"
     NAME
 )
 get_filename_component(
@@ -637,20 +629,52 @@ target_link_libraries(guest_kfd_test PRIVATE Threads::Threads GTest::gtest_main)
 rj_configure_target(guest_kfd_test TEST)
 add_dependencies(guest_kfd_test rocjitsu_bin rocjitsu_shared rocjitsu_hooks)
 rj_add_test(
-    NAME "GuestKfdFailureTest.MissingSimulatorConfigFailsCleanly"
+    NAME "GuestKfdFailureTest.NonexistentSimulatorConfigFailsCleanly"
     COMMAND
-        ${RJ_CLI} --config ${RJ_CDNA4_TO_CDNA3_MISSING_SIM_DBT_CONFIG} --
+        ${RJ_CLI} --config ${RJ_CDNA3_KMD_CONFIG} --
         $<TARGET_FILE:guest_kfd_test>
-        --gtest_filter=GuestKfdFailureTest.MissingSimulatorConfigFailsCleanly
+        --gtest_filter=GuestKfdFailureTest.NonexistentSimulatorConfigFailsCleanly
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     TIMEOUT 60
     INSTALL_COMMAND
         "\${RJ_INSTALLED_BINDIR}/rocjitsu"
         "--config"
-        "\${RJ_INSTALLED_CONFIG_DIR}/${RJ_CDNA4_TO_CDNA3_MISSING_SIM_DBT_CONFIG_NAME}"
+        "\${RJ_INSTALLED_CONFIG_DIR}/${RJ_CDNA3_KMD_CONFIG_NAME}"
         "--"
         "bin/guest_kfd_test"
-        "--gtest_filter=GuestKfdFailureTest.MissingSimulatorConfigFailsCleanly"
+        "--gtest_filter=GuestKfdFailureTest.NonexistentSimulatorConfigFailsCleanly"
+)
+rj_add_test(
+    NAME "GuestKfdFailureTest.SimulatorHostIsaMismatchFailsCleanly"
+    COMMAND
+        ${RJ_CLI} --config ${RJ_CDNA3_KMD_CONFIG} --
+        $<TARGET_FILE:guest_kfd_test>
+        --gtest_filter=GuestKfdFailureTest.SimulatorHostIsaMismatchFailsCleanly
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    TIMEOUT 60
+    INSTALL_COMMAND
+        "\${RJ_INSTALLED_BINDIR}/rocjitsu"
+        "--config"
+        "\${RJ_INSTALLED_CONFIG_DIR}/${RJ_CDNA3_KMD_CONFIG_NAME}"
+        "--"
+        "bin/guest_kfd_test"
+        "--gtest_filter=GuestKfdFailureTest.SimulatorHostIsaMismatchFailsCleanly"
+)
+rj_add_test(
+    NAME "GuestKfdFailureTest.SimulatorOversizedLdsFailsCleanly"
+    COMMAND
+        ${RJ_CLI} --config ${RJ_CDNA3_KMD_CONFIG} --
+        $<TARGET_FILE:guest_kfd_test>
+        --gtest_filter=GuestKfdFailureTest.SimulatorOversizedLdsFailsCleanly
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    TIMEOUT 60
+    INSTALL_COMMAND
+        "\${RJ_INSTALLED_BINDIR}/rocjitsu"
+        "--config"
+        "\${RJ_INSTALLED_CONFIG_DIR}/${RJ_CDNA3_KMD_CONFIG_NAME}"
+        "--"
+        "bin/guest_kfd_test"
+        "--gtest_filter=GuestKfdFailureTest.SimulatorOversizedLdsFailsCleanly"
 )
 if(RJ_HAS_GFX1201_GPU)
     add_test(

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -530,6 +530,12 @@ set(RJ_CDNA4_KMD_2GPU_CONFIG
     "${CMAKE_SOURCE_DIR}/configs/gfx950_cdna4_kmd_2gpu.json"
 )
 set(RJ_CDNA3_KMD_CONFIG "${CMAKE_SOURCE_DIR}/configs/gfx942_cdna3_kmd.json")
+set(RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG
+    "${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_simulated_gfx942.json"
+)
+set(RJ_CDNA4_TO_CDNA3_MISSING_SIM_DBT_CONFIG
+    "${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_missing_simulator.json"
+)
 set(RJ_HIP_TEST_ARCH
     "gfx950"
     CACHE STRING
@@ -546,6 +552,17 @@ set(RJ_HIP_TEST_2GPU_CONFIG
     "rocjitsu config used by basic two-GPU HIP tests"
 )
 get_filename_component(RJ_CDNA4_KMD_CONFIG_NAME "${RJ_CDNA4_KMD_CONFIG}" NAME)
+get_filename_component(RJ_CDNA3_KMD_CONFIG_NAME "${RJ_CDNA3_KMD_CONFIG}" NAME)
+get_filename_component(
+    RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG_NAME
+    "${RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG}"
+    NAME
+)
+get_filename_component(
+    RJ_CDNA4_TO_CDNA3_MISSING_SIM_DBT_CONFIG_NAME
+    "${RJ_CDNA4_TO_CDNA3_MISSING_SIM_DBT_CONFIG}"
+    NAME
+)
 get_filename_component(
     RJ_CDNA4_KMD_2GPU_CONFIG_NAME
     "${RJ_CDNA4_KMD_2GPU_CONFIG}"
@@ -619,6 +636,22 @@ target_include_directories(
 target_link_libraries(guest_kfd_test PRIVATE Threads::Threads GTest::gtest_main)
 rj_configure_target(guest_kfd_test TEST)
 add_dependencies(guest_kfd_test rocjitsu_bin rocjitsu_shared rocjitsu_hooks)
+rj_add_test(
+    NAME "GuestKfdFailureTest.MissingSimulatorConfigFailsCleanly"
+    COMMAND
+        ${RJ_CLI} --config ${RJ_CDNA4_TO_CDNA3_MISSING_SIM_DBT_CONFIG} --
+        $<TARGET_FILE:guest_kfd_test>
+        --gtest_filter=GuestKfdFailureTest.MissingSimulatorConfigFailsCleanly
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    TIMEOUT 60
+    INSTALL_COMMAND
+        "\${RJ_INSTALLED_BINDIR}/rocjitsu"
+        "--config"
+        "\${RJ_INSTALLED_CONFIG_DIR}/${RJ_CDNA4_TO_CDNA3_MISSING_SIM_DBT_CONFIG_NAME}"
+        "--"
+        "bin/guest_kfd_test"
+        "--gtest_filter=GuestKfdFailureTest.MissingSimulatorConfigFailsCleanly"
+)
 if(RJ_HAS_GFX1201_GPU)
     add_test(
         NAME "GuestKfdMultiprocessTest.ForkedChildrenDoNotRemoveParentOverlay"
@@ -1208,7 +1241,13 @@ if(HSA_RUNTIME64)
             ${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}
             PRIVATE HAS_HOST_AMDGPU=1 KERNEL_DIR="${KERNEL_OUTPUT_DIR}"
         )
-        add_dependencies(${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE} device_kernels)
+        add_dependencies(
+            ${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}
+            device_kernels
+            rocjitsu_bin
+            rocjitsu_shared
+            rocjitsu_hooks
+        )
         rj_configure_target(${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE} TEST)
         if(RJ_INSTALL_TESTS)
             rj_install_test_target(${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE})
@@ -1235,15 +1274,75 @@ if(HSA_RUNTIME64)
             )
         endforeach()
 
-        if(HAS_CDNA3_GPU)
-            set(RJ_CDNA4_TO_CDNA3_DISPATCH_RUN_TESTS
-                DynamicCopyLoopDispatchAndRun
-                TritonDynamicMatmulDispatchAndRun
-                TritonBufferAsyncMatmulDispatchAndRun
-                TritonBufferAsyncMatmulConservativeLivenessDispatchAndRun
-                TritonFlashAttentionNoAsyncDispatchAndRun
-                TritonFlashAttentionBufferAsyncDispatchAndRun
+        _rj_path_from_installed_test_bin(
+            _rj_installed_cdna3_kmd_config
+            "${CMAKE_INSTALL_DATADIR}/rocjitsu/configs"
+            "${RJ_CDNA3_KMD_CONFIG_NAME}"
+        )
+        _rj_path_from_installed_test_bin(
+            _rj_installed_cdna4_to_cdna3_sim_dbt_config
+            "${CMAKE_INSTALL_DATADIR}/rocjitsu/configs"
+            "${RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG_NAME}"
+        )
+
+        set(RJ_CDNA4_TO_CDNA3_DISPATCH_RUN_TESTS
+            DynamicCopyLoopDispatchAndRun
+            TritonDynamicMatmulDispatchAndRun
+            TritonBufferAsyncMatmulDispatchAndRun
+            TritonBufferAsyncMatmulConservativeLivenessDispatchAndRun
+            TritonFlashAttentionNoAsyncDispatchAndRun
+            TritonFlashAttentionBufferAsyncDispatchAndRun
+        )
+        foreach(_test_name IN LISTS RJ_CDNA4_TO_CDNA3_DISPATCH_RUN_TESTS)
+            rj_add_test(
+                NAME "Cdna4ToCdna3SimulatedDispatchTest.${_test_name}"
+                COMMAND
+                    ${RJ_CLI} --config ${RJ_CDNA3_KMD_CONFIG} --
+                    $<TARGET_FILE:${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}>
+                    --gtest_filter=Cdna4ToCdna3DispatchTest.${_test_name}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                TIMEOUT 300
+                INSTALL_COMMAND
+                    "\${RJ_INSTALLED_BINDIR}/rocjitsu"
+                    "--config"
+                    "${_rj_installed_cdna3_kmd_config}"
+                    "--"
+                    "bin/${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}"
+                    "--gtest_filter=Cdna4ToCdna3DispatchTest.${_test_name}"
             )
+        endforeach()
+        message(STATUS "CDNA4->CDNA3 simulator dispatch tests enabled")
+
+        set(RJ_CDNA4_TO_CDNA3_DBT_GUEST_TESTS
+            DynamicCopyLoopDispatchAndRun
+            TritonDynamicMatmulDispatchAndRun
+            TritonBufferAsyncMatmulDispatchAndRun
+            TritonFlashAttentionNoAsyncDispatchAndRun
+            TritonFlashAttentionBufferAsyncDispatchAndRun
+        )
+        # The conservative-liveness variant injects BinaryTranslatorOptions
+        # directly and cannot be expressed through the public DBT hook. Running
+        # it here would duplicate the default buffer-async guest path.
+        foreach(_test_name IN LISTS RJ_CDNA4_TO_CDNA3_DBT_GUEST_TESTS)
+            rj_add_test(
+                NAME "Cdna4ToCdna3DbtGuestTest.${_test_name}"
+                COMMAND
+                    ${RJ_CLI} --config ${RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG} --
+                    $<TARGET_FILE:${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}>
+                    --gtest_filter=Cdna4ToCdna3DbtGuestTest.${_test_name}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                TIMEOUT 300
+                INSTALL_COMMAND
+                    "\${RJ_INSTALLED_BINDIR}/rocjitsu"
+                    "--config"
+                    "${_rj_installed_cdna4_to_cdna3_sim_dbt_config}"
+                    "--"
+                    "bin/${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}"
+                    "--gtest_filter=Cdna4ToCdna3DbtGuestTest.${_test_name}"
+            )
+        endforeach()
+
+        if(HAS_CDNA3_GPU)
             foreach(_test_name IN LISTS RJ_CDNA4_TO_CDNA3_DISPATCH_RUN_TESTS)
                 rj_add_test(
                     NAME "Cdna4ToCdna3DispatchTest.${_test_name}"
@@ -1264,7 +1363,7 @@ if(HSA_RUNTIME64)
         else()
             message(
                 STATUS
-                "CDNA4->CDNA3 dispatch tests built but NOT registered with CTest "
+                "CDNA4->CDNA3 hardware dispatch tests built but NOT registered with CTest "
                 "(no CDNA3 GPU)"
             )
         endif()

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -525,7 +525,7 @@ TEST(ConfigLoaderTest, LoadsExplicitHardwareDbtBackendConfig) {
   EXPECT_STREQ(config::dbt_execution_backend_name(dbt.execution_backend), "hardware");
 }
 
-TEST(ConfigLoaderTest, EmptyDbtExecutionBackendUsesHardware) {
+TEST(ConfigLoaderTest, RejectsEmptyDbtExecutionBackend) {
   const std::filesystem::path path =
       write_temp_config("rocjitsu_empty_dbt_backend_config_test.json", R"({
         "dbt_guest": {
@@ -534,10 +534,46 @@ TEST(ConfigLoaderTest, EmptyDbtExecutionBackendUsesHardware) {
         }
       })");
 
-  auto dbt = config::load_dbt_guest_config_from_file(path.string());
+  EXPECT_THROW(config::load_dbt_guest_config_from_file(path.string()), std::runtime_error);
   std::filesystem::remove(path);
+}
 
-  EXPECT_EQ(dbt.execution_backend, config::DbtExecutionBackend::Hardware);
+TEST(ConfigLoaderTest, RejectsMisspelledDbtExecutionBackend) {
+  const std::filesystem::path path =
+      write_temp_config("rocjitsu_misspelled_dbt_backend_config_test.json", R"({
+        "dbt_guest": {
+          "enabled": true,
+          "execution_backed": "simulator"
+        }
+      })");
+
+  EXPECT_THROW(config::load_dbt_guest_config_from_file(path.string()), std::runtime_error);
+  std::filesystem::remove(path);
+}
+
+TEST(ConfigLoaderTest, ValidatesSimulatorDbtGuestDeviceLimits) {
+  config::DbtGuestConfig guest;
+  guest.enabled = true;
+  guest.execution_backend = config::DbtExecutionBackend::Simulator;
+  guest.guest_device.present = true;
+  guest.guest_device.lds_size_kb = 64;
+  guest.guest_device.max_slots_scratch_cu = 32;
+  guest.guest_device.max_waves_per_simd = 8;
+  guest.guest_device.wave_front_size = 64;
+
+  config::KfdDeviceConfig simulator;
+  simulator.present = true;
+  simulator.lds_size_kb = 64;
+  simulator.max_slots_scratch_cu = 32;
+  simulator.max_waves_per_simd = 8;
+  simulator.wave_front_size = 64;
+
+  EXPECT_NO_THROW(config::validate_dbt_simulator_device_limits(guest, simulator));
+  guest.guest_device.lds_size_kb = 65;
+  EXPECT_THROW(config::validate_dbt_simulator_device_limits(guest, simulator), std::runtime_error);
+  guest.guest_device.lds_size_kb = 64;
+  guest.guest_device.max_slots_scratch_cu = 33;
+  EXPECT_THROW(config::validate_dbt_simulator_device_limits(guest, simulator), std::runtime_error);
 }
 
 TEST(ConfigLoaderTest, DisabledDbtBackendSkipsBackendSpecificValidation) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -354,10 +354,9 @@ TEST(ConfigLoaderTest, LoadsDbtOnlyConfigWithoutVmOrTopology) {
 
   EXPECT_TRUE(dbt.enabled);
   EXPECT_EQ(dbt.guest_isa, "gfx950");
-  EXPECT_EQ(dbt.host_isa, "gfx1201");
-  EXPECT_EQ(dbt.host_gpu_id, 8716u);
-  EXPECT_EQ(dbt.execution_backend, config::DbtExecutionBackend::Hardware);
-  EXPECT_TRUE(dbt.simulator_config.empty());
+  EXPECT_EQ(dbt.host.isa, "gfx1201");
+  EXPECT_EQ(dbt.host.gpu_id, 8716u);
+  EXPECT_EQ(dbt.host.backend, config::DbtExecutionBackend::Hardware);
   EXPECT_EQ(dbt.log_level, 2);
   EXPECT_TRUE(dbt.signal_backtrace);
   ASSERT_TRUE(dbt.guest_device.present);
@@ -433,9 +432,9 @@ TEST(ConfigLoaderTest, LoadsDbtGuestThroughFullConfigLoader) {
 
   EXPECT_TRUE(loaded.dbt_guest.enabled);
   EXPECT_EQ(loaded.dbt_guest.guest_isa, "gfx950");
-  EXPECT_EQ(loaded.dbt_guest.host_isa, "gfx1201");
-  EXPECT_EQ(loaded.dbt_guest.host_gpu_id, 8716u);
-  EXPECT_EQ(loaded.dbt_guest.execution_backend, config::DbtExecutionBackend::Hardware);
+  EXPECT_EQ(loaded.dbt_guest.host.isa, "gfx1201");
+  EXPECT_EQ(loaded.dbt_guest.host.gpu_id, 8716u);
+  EXPECT_EQ(loaded.dbt_guest.host.backend, config::DbtExecutionBackend::Hardware);
   EXPECT_EQ(loaded.dbt_guest.log_level, 2);
   EXPECT_TRUE(loaded.dbt_guest.signal_backtrace);
   ASSERT_TRUE(loaded.dbt_guest.guest_device.present);
@@ -453,10 +452,9 @@ TEST(ConfigLoaderTest, MissingDbtGuestConfigReturnsDefaults) {
 
   EXPECT_FALSE(dbt.enabled);
   EXPECT_TRUE(dbt.guest_isa.empty());
-  EXPECT_TRUE(dbt.host_isa.empty());
-  EXPECT_EQ(dbt.host_gpu_id, 0u);
-  EXPECT_EQ(dbt.execution_backend, config::DbtExecutionBackend::Hardware);
-  EXPECT_TRUE(dbt.simulator_config.empty());
+  EXPECT_TRUE(dbt.host.isa.empty());
+  EXPECT_EQ(dbt.host.gpu_id, 0u);
+  EXPECT_EQ(dbt.host.backend, config::DbtExecutionBackend::Hardware);
   EXPECT_EQ(dbt.log_level, 0);
   EXPECT_FALSE(dbt.signal_backtrace);
   EXPECT_FALSE(dbt.guest_device.present);
@@ -477,7 +475,7 @@ TEST(ConfigLoaderTest, MissingDbtGuestDeviceLeavesDeviceAbsent) {
 
   EXPECT_TRUE(dbt.enabled);
   EXPECT_EQ(dbt.guest_isa, "gfx950");
-  EXPECT_EQ(dbt.host_isa, "gfx1201");
+  EXPECT_EQ(dbt.host.isa, "gfx1201");
   EXPECT_FALSE(dbt.guest_device.present);
 }
 
@@ -490,7 +488,7 @@ TEST(ConfigLoaderTest, MalformedDbtGuestConfigThrows) {
 }
 
 TEST(ConfigLoaderTest, LoadsSimulatorDbtBackendConfig) {
-  const std::filesystem::path path =
+  const std::filesystem::path external_path =
       write_temp_config("rocjitsu_simulator_dbt_guest_config_test.json", R"({
         "dbt_guest": {
           "enabled": true,
@@ -500,13 +498,26 @@ TEST(ConfigLoaderTest, LoadsSimulatorDbtBackendConfig) {
           "simulator_config": "gfx942_cdna3_kmd.json"
         }
       })");
+  const std::filesystem::path self_contained_path =
+      write_temp_config("rocjitsu_self_contained_dbt_guest_config_test.json", R"({
+        "dbt_guest": {
+          "enabled": true,
+          "guest_isa": "gfx950",
+          "host_isa": "gfx942",
+          "execution_backend": "simulator"
+        }
+      })");
 
-  auto dbt = config::load_dbt_guest_config_from_file(path.string());
-  std::filesystem::remove(path);
+  auto external = config::load_dbt_guest_config_from_file(external_path.string());
+  auto self_contained = config::load_dbt_guest_config_from_file(self_contained_path.string());
+  std::filesystem::remove(external_path);
+  std::filesystem::remove(self_contained_path);
 
-  EXPECT_EQ(dbt.execution_backend, config::DbtExecutionBackend::Simulator);
-  EXPECT_EQ(dbt.simulator_config, "gfx942_cdna3_kmd.json");
-  EXPECT_STREQ(config::dbt_execution_backend_name(dbt.execution_backend), "simulator");
+  EXPECT_EQ(external.host.isa, "gfx942");
+  EXPECT_EQ(external.host.backend, config::DbtExecutionBackend::Simulator);
+  EXPECT_EQ(external.host.simulator_config_path, "gfx942_cdna3_kmd.json");
+  EXPECT_EQ(self_contained.host.backend, config::DbtExecutionBackend::Simulator);
+  EXPECT_TRUE(self_contained.host.simulator_config_path.empty());
 }
 
 TEST(ConfigLoaderTest, LoadsExplicitHardwareDbtBackendConfig) {
@@ -521,8 +532,7 @@ TEST(ConfigLoaderTest, LoadsExplicitHardwareDbtBackendConfig) {
   auto dbt = config::load_dbt_guest_config_from_file(path.string());
   std::filesystem::remove(path);
 
-  EXPECT_EQ(dbt.execution_backend, config::DbtExecutionBackend::Hardware);
-  EXPECT_STREQ(config::dbt_execution_backend_name(dbt.execution_backend), "hardware");
+  EXPECT_EQ(dbt.host.backend, config::DbtExecutionBackend::Hardware);
 }
 
 TEST(ConfigLoaderTest, RejectsEmptyDbtExecutionBackend) {
@@ -554,7 +564,7 @@ TEST(ConfigLoaderTest, RejectsMisspelledDbtExecutionBackend) {
 TEST(ConfigLoaderTest, ValidatesSimulatorDbtGuestDeviceLimits) {
   config::DbtGuestConfig guest;
   guest.enabled = true;
-  guest.execution_backend = config::DbtExecutionBackend::Simulator;
+  guest.host.backend = config::DbtExecutionBackend::Simulator;
   guest.guest_device.present = true;
   guest.guest_device.lds_size_kb = 64;
   guest.guest_device.max_slots_scratch_cu = 32;
@@ -599,28 +609,13 @@ TEST(ConfigLoaderTest, DisabledDbtBackendSkipsBackendSpecificValidation) {
   std::filesystem::remove(hardware_path);
 }
 
-TEST(ConfigLoaderTest, ResolvesDbtSimulatorConfigPath) {
-  EXPECT_EQ(config::resolve_dbt_simulator_config_path("/a/b/dbt.json", "sim.json"),
-            "/a/b/sim.json");
-  EXPECT_EQ(config::resolve_dbt_simulator_config_path("/a/b/dbt.json", "/abs/sim.json"),
+TEST(ConfigLoaderTest, ResolvesDbtHostConfigPath) {
+  EXPECT_EQ(config::resolve_dbt_host_config_path("/a/b/dbt.json", ""), "/a/b/dbt.json");
+  EXPECT_EQ(config::resolve_dbt_host_config_path("/a/b/dbt.json", "sim.json"), "/a/b/sim.json");
+  EXPECT_EQ(config::resolve_dbt_host_config_path("/a/b/dbt.json", "/abs/sim.json"),
             "/abs/sim.json");
-  EXPECT_EQ(config::resolve_dbt_simulator_config_path("/a/b/dbt.json", "../c/./sim.json"),
+  EXPECT_EQ(config::resolve_dbt_host_config_path("/a/b/dbt.json", "../c/./sim.json"),
             "/a/c/sim.json");
-}
-
-TEST(ConfigLoaderTest, RejectsSimulatorDbtBackendWithoutSimulatorConfig) {
-  const std::filesystem::path path =
-      write_temp_config("rocjitsu_missing_simulator_dbt_config_test.json", R"({
-        "dbt_guest": {
-          "enabled": true,
-          "guest_isa": "gfx950",
-          "host_isa": "gfx942",
-          "execution_backend": "simulator"
-        }
-      })");
-
-  EXPECT_THROW(config::load_dbt_guest_config_from_file(path.string()), std::runtime_error);
-  std::filesystem::remove(path);
 }
 
 TEST(ConfigLoaderTest, RejectsUnknownDbtExecutionBackend) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -356,6 +356,8 @@ TEST(ConfigLoaderTest, LoadsDbtOnlyConfigWithoutVmOrTopology) {
   EXPECT_EQ(dbt.guest_isa, "gfx950");
   EXPECT_EQ(dbt.host_isa, "gfx1201");
   EXPECT_EQ(dbt.host_gpu_id, 8716u);
+  EXPECT_EQ(dbt.execution_backend, config::DbtExecutionBackend::Hardware);
+  EXPECT_TRUE(dbt.simulator_config.empty());
   EXPECT_EQ(dbt.log_level, 2);
   EXPECT_TRUE(dbt.signal_backtrace);
   ASSERT_TRUE(dbt.guest_device.present);
@@ -433,6 +435,7 @@ TEST(ConfigLoaderTest, LoadsDbtGuestThroughFullConfigLoader) {
   EXPECT_EQ(loaded.dbt_guest.guest_isa, "gfx950");
   EXPECT_EQ(loaded.dbt_guest.host_isa, "gfx1201");
   EXPECT_EQ(loaded.dbt_guest.host_gpu_id, 8716u);
+  EXPECT_EQ(loaded.dbt_guest.execution_backend, config::DbtExecutionBackend::Hardware);
   EXPECT_EQ(loaded.dbt_guest.log_level, 2);
   EXPECT_TRUE(loaded.dbt_guest.signal_backtrace);
   ASSERT_TRUE(loaded.dbt_guest.guest_device.present);
@@ -452,6 +455,8 @@ TEST(ConfigLoaderTest, MissingDbtGuestConfigReturnsDefaults) {
   EXPECT_TRUE(dbt.guest_isa.empty());
   EXPECT_TRUE(dbt.host_isa.empty());
   EXPECT_EQ(dbt.host_gpu_id, 0u);
+  EXPECT_EQ(dbt.execution_backend, config::DbtExecutionBackend::Hardware);
+  EXPECT_TRUE(dbt.simulator_config.empty());
   EXPECT_EQ(dbt.log_level, 0);
   EXPECT_FALSE(dbt.signal_backtrace);
   EXPECT_FALSE(dbt.guest_device.present);
@@ -479,6 +484,131 @@ TEST(ConfigLoaderTest, MissingDbtGuestDeviceLeavesDeviceAbsent) {
 TEST(ConfigLoaderTest, MalformedDbtGuestConfigThrows) {
   const std::filesystem::path path =
       write_temp_config("rocjitsu_malformed_dbt_guest_config_test.json", R"({ "dbt_guest": )");
+
+  EXPECT_THROW(config::load_dbt_guest_config_from_file(path.string()), std::runtime_error);
+  std::filesystem::remove(path);
+}
+
+TEST(ConfigLoaderTest, LoadsSimulatorDbtBackendConfig) {
+  const std::filesystem::path path =
+      write_temp_config("rocjitsu_simulator_dbt_guest_config_test.json", R"({
+        "dbt_guest": {
+          "enabled": true,
+          "guest_isa": "gfx950",
+          "host_isa": "gfx942",
+          "execution_backend": "simulator",
+          "simulator_config": "gfx942_cdna3_kmd.json"
+        }
+      })");
+
+  auto dbt = config::load_dbt_guest_config_from_file(path.string());
+  std::filesystem::remove(path);
+
+  EXPECT_EQ(dbt.execution_backend, config::DbtExecutionBackend::Simulator);
+  EXPECT_EQ(dbt.simulator_config, "gfx942_cdna3_kmd.json");
+  EXPECT_STREQ(config::dbt_execution_backend_name(dbt.execution_backend), "simulator");
+}
+
+TEST(ConfigLoaderTest, LoadsExplicitHardwareDbtBackendConfig) {
+  const std::filesystem::path path =
+      write_temp_config("rocjitsu_hardware_dbt_guest_config_test.json", R"({
+        "dbt_guest": {
+          "enabled": true,
+          "execution_backend": "hardware"
+        }
+      })");
+
+  auto dbt = config::load_dbt_guest_config_from_file(path.string());
+  std::filesystem::remove(path);
+
+  EXPECT_EQ(dbt.execution_backend, config::DbtExecutionBackend::Hardware);
+  EXPECT_STREQ(config::dbt_execution_backend_name(dbt.execution_backend), "hardware");
+}
+
+TEST(ConfigLoaderTest, EmptyDbtExecutionBackendUsesHardware) {
+  const std::filesystem::path path =
+      write_temp_config("rocjitsu_empty_dbt_backend_config_test.json", R"({
+        "dbt_guest": {
+          "enabled": true,
+          "execution_backend": ""
+        }
+      })");
+
+  auto dbt = config::load_dbt_guest_config_from_file(path.string());
+  std::filesystem::remove(path);
+
+  EXPECT_EQ(dbt.execution_backend, config::DbtExecutionBackend::Hardware);
+}
+
+TEST(ConfigLoaderTest, DisabledDbtBackendSkipsBackendSpecificValidation) {
+  const std::filesystem::path simulator_path =
+      write_temp_config("rocjitsu_disabled_simulator_dbt_config_test.json", R"({
+        "dbt_guest": {
+          "enabled": false,
+          "execution_backend": "simulator"
+        }
+      })");
+  const std::filesystem::path hardware_path =
+      write_temp_config("rocjitsu_disabled_hardware_dbt_config_test.json", R"({
+        "dbt_guest": {
+          "enabled": false,
+          "execution_backend": "hardware",
+          "simulator_config": "ignored.json"
+        }
+      })");
+
+  EXPECT_NO_THROW(config::load_dbt_guest_config_from_file(simulator_path.string()));
+  EXPECT_NO_THROW(config::load_dbt_guest_config_from_file(hardware_path.string()));
+  std::filesystem::remove(simulator_path);
+  std::filesystem::remove(hardware_path);
+}
+
+TEST(ConfigLoaderTest, ResolvesDbtSimulatorConfigPath) {
+  EXPECT_EQ(config::resolve_dbt_simulator_config_path("/a/b/dbt.json", "sim.json"),
+            "/a/b/sim.json");
+  EXPECT_EQ(config::resolve_dbt_simulator_config_path("/a/b/dbt.json", "/abs/sim.json"),
+            "/abs/sim.json");
+  EXPECT_EQ(config::resolve_dbt_simulator_config_path("/a/b/dbt.json", "../c/./sim.json"),
+            "/a/c/sim.json");
+}
+
+TEST(ConfigLoaderTest, RejectsSimulatorDbtBackendWithoutSimulatorConfig) {
+  const std::filesystem::path path =
+      write_temp_config("rocjitsu_missing_simulator_dbt_config_test.json", R"({
+        "dbt_guest": {
+          "enabled": true,
+          "guest_isa": "gfx950",
+          "host_isa": "gfx942",
+          "execution_backend": "simulator"
+        }
+      })");
+
+  EXPECT_THROW(config::load_dbt_guest_config_from_file(path.string()), std::runtime_error);
+  std::filesystem::remove(path);
+}
+
+TEST(ConfigLoaderTest, RejectsUnknownDbtExecutionBackend) {
+  const std::filesystem::path path =
+      write_temp_config("rocjitsu_unknown_dbt_backend_config_test.json", R"({
+        "dbt_guest": {
+          "enabled": true,
+          "execution_backend": "magic"
+        }
+      })");
+
+  EXPECT_THROW(config::load_dbt_guest_config_from_file(path.string()), std::runtime_error);
+  std::filesystem::remove(path);
+}
+
+TEST(ConfigLoaderTest, RejectsSimulatorConfigForHardwareDbtBackend) {
+  const std::filesystem::path path =
+      write_temp_config("rocjitsu_hardware_with_simulator_config_test.json", R"({
+        "dbt_guest": {
+          "enabled": true,
+          "execution_backend": "hardware",
+          "simulator_config": "gfx942_cdna3_kmd.json"
+        }
+      })");
 
   EXPECT_THROW(config::load_dbt_guest_config_from_file(path.string()), std::runtime_error);
   std::filesystem::remove(path);

--- a/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
@@ -72,7 +72,7 @@ void expect_float_vectors_near(const std::vector<float> &actual, const std::vect
   uint32_t mismatches = 0;
   for (size_t i = 0; i < actual.size(); ++i) {
     const float diff = std::fabs(actual[i] - expected[i]);
-    if (diff > tolerance) {
+    if (!std::isfinite(actual[i]) || !std::isfinite(expected[i]) || diff > tolerance) {
       if (mismatches < 8)
         ADD_FAILURE() << label << " mismatch at i=" << i << ": got=" << actual[i]
                       << " expected=" << expected[i] << " diff=" << diff;
@@ -575,7 +575,8 @@ void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const DispatchTarg
 
 void run_buffer_async_triton_matmul(const std::vector<uint8_t> &elf_bytes,
                                     const DispatchTarget &target, uint32_t shared_bytes,
-                                    std::vector<float> *observed = nullptr) {
+                                    std::vector<float> *observed = nullptr,
+                                    std::vector<float> *reference = nullptr) {
   hsa_agent_t cpu = find_cpu_agent();
   ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
 
@@ -664,7 +665,18 @@ void run_buffer_async_triton_matmul(const std::vector<uint8_t> &elf_bytes,
   std::vector<float> c_init(kCElements, kSentinel);
   std::vector<float> c_host(kCElements);
   fill_seeded_half_inputs(a_host, 0xA0D4'1001u);
-  fill_seeded_half_inputs(b_host, 0xB0D4'1001u);
+  if (reference) {
+    // An identity RHS gives every output element a cheap closed-form CPU
+    // reference while still exercising the full translated 1024^3 kernel.
+    std::fill(b_host.begin(), b_host.end(), 0);
+    for (uint32_t i = 0; i < kK; ++i)
+      b_host[static_cast<size_t>(i) * kN + i] = 0x3c00; // fp16 1.0
+    reference->resize(kCElements);
+    for (size_t i = 0; i < kCElements; ++i)
+      (*reference)[i] = util::f16_to_f32(a_host[i]);
+  } else {
+    fill_seeded_half_inputs(b_host, 0xB0D4'1001u);
+  }
   ASSERT_EQ(hsa_memory_copy(a_dev, a_host.data(), kABytes), HSA_STATUS_SUCCESS);
   ASSERT_EQ(hsa_memory_copy(b_dev, b_host.data(), kBBytes), HSA_STATUS_SUCCESS);
   ASSERT_EQ(hsa_memory_copy(c_dev, c_init.data(), kCBytes), HSA_STATUS_SUCCESS);
@@ -724,7 +736,8 @@ void run_buffer_async_triton_matmul(const std::vector<uint8_t> &elf_bytes,
 
 void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const DispatchTarget &target,
                                 const char *symbol_name, uint32_t shared_bytes,
-                                std::vector<float> *observed = nullptr) {
+                                std::vector<float> *observed = nullptr,
+                                std::vector<float> *reference = nullptr) {
   hsa_agent_t cpu = find_cpu_agent();
   ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
   ASSERT_LE(shared_bytes, 65536u)
@@ -817,9 +830,25 @@ void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const Dis
   std::vector<uint16_t> v_host(kKVElements);
   std::vector<float> o_init(kOElements, -12345.0f);
   std::vector<float> o_host(kOElements);
-  fill_seeded_half_inputs(q_host, 0xF1A5'0001u);
-  fill_seeded_half_inputs(k_host, 0xF1A5'0002u);
-  fill_seeded_half_inputs(v_host, 0xF1A5'0003u);
+  if (reference) {
+    // Zero Q/K makes every attention score equal. Repeating one V row across
+    // all keys means both causal and non-causal softmax produce that row, so
+    // every output element has a full, inexpensive CPU reference.
+    std::fill(q_host.begin(), q_host.end(), 0);
+    std::fill(k_host.begin(), k_host.end(), 0);
+    std::vector<uint16_t> v_row(kHeadDim);
+    fill_seeded_half_inputs(v_row, 0xF1A5'0003u);
+    for (uint32_t kv = 0; kv < kKV; ++kv)
+      std::copy(v_row.begin(), v_row.end(), v_host.begin() + static_cast<size_t>(kv) * kHeadDim);
+    reference->resize(kOElements);
+    for (uint32_t q = 0; q < kQ; ++q)
+      for (uint32_t d = 0; d < kHeadDim; ++d)
+        (*reference)[static_cast<size_t>(q) * kHeadDim + d] = util::f16_to_f32(v_row[d]);
+  } else {
+    fill_seeded_half_inputs(q_host, 0xF1A5'0001u);
+    fill_seeded_half_inputs(k_host, 0xF1A5'0002u);
+    fill_seeded_half_inputs(v_host, 0xF1A5'0003u);
+  }
   ASSERT_EQ(hsa_memory_copy(q_dev, q_host.data(), kQBytes), HSA_STATUS_SUCCESS);
   ASSERT_EQ(hsa_memory_copy(k_dev, k_host.data(), kKVBytes), HSA_STATUS_SUCCESS);
   ASSERT_EQ(hsa_memory_copy(v_dev, v_host.data(), kKVBytes), HSA_STATUS_SUCCESS);
@@ -1004,16 +1033,15 @@ TEST(Cdna4ToCdna3DbtGuestTest, TritonBufferAsyncMatmulDispatchAndRun) {
   DispatchTarget guest = find_gpu_target_named("gfx950");
   ASSERT_NE(guest.agent.handle, 0u) << "DBT guest launch must publicly expose gfx950; found: "
                                     << join_seen_isas(guest.seen_gpu_isas);
-
   const std::vector<uint8_t> guest_elf =
       load_gfx950_code_object("triton_cdna4_matmul_buffer_async_1024");
   ASSERT_FALSE(guest_elf.empty());
 
   std::vector<float> observed;
-  ASSERT_NO_FATAL_FAILURE(run_buffer_async_triton_matmul(guest_elf, guest, 65536, &observed));
-  ASSERT_FALSE(observed.empty());
-  EXPECT_TRUE(std::all_of(observed.begin(), observed.end(),
-                          [](float value) { return std::isfinite(value) && value != -12345.0f; }));
+  std::vector<float> expected;
+  ASSERT_NO_FATAL_FAILURE(
+      run_buffer_async_triton_matmul(guest_elf, guest, 65536, &observed, &expected));
+  expect_float_vectors_near(observed, expected, 0.02f, "guest DBT buffer async Triton matmul");
 }
 
 TEST(Cdna4ToCdna3DbtGuestTest, TritonFlashAttentionNoAsyncDispatchAndRun) {
@@ -1025,17 +1053,15 @@ TEST(Cdna4ToCdna3DbtGuestTest, TritonFlashAttentionNoAsyncDispatchAndRun) {
   DispatchTarget guest = find_gpu_target_named("gfx950");
   ASSERT_NE(guest.agent.handle, 0u) << "DBT guest launch must publicly expose gfx950; found: "
                                     << join_seen_isas(guest.seen_gpu_isas);
-
   const std::vector<uint8_t> guest_elf =
       load_gfx950_code_object("triton_cdna4_flash_attention_no_async_1024");
   ASSERT_FALSE(guest_elf.empty());
 
   std::vector<float> observed;
+  std::vector<float> expected;
   ASSERT_NO_FATAL_FAILURE(run_flash_attention_triton(
-      guest_elf, guest, "flash_attention_fwd_no_async_kernel.kd", 65536, &observed));
-  ASSERT_FALSE(observed.empty());
-  EXPECT_TRUE(std::all_of(observed.begin(), observed.end(),
-                          [](float value) { return std::isfinite(value) && value != -12345.0f; }));
+      guest_elf, guest, "flash_attention_fwd_no_async_kernel.kd", 65536, &observed, &expected));
+  expect_float_vectors_near(observed, expected, 0.02f, "guest DBT flash attention no-async");
 }
 
 TEST(Cdna4ToCdna3DbtGuestTest, TritonFlashAttentionBufferAsyncDispatchAndRun) {
@@ -1047,17 +1073,15 @@ TEST(Cdna4ToCdna3DbtGuestTest, TritonFlashAttentionBufferAsyncDispatchAndRun) {
   DispatchTarget guest = find_gpu_target_named("gfx950");
   ASSERT_NE(guest.agent.handle, 0u) << "DBT guest launch must publicly expose gfx950; found: "
                                     << join_seen_isas(guest.seen_gpu_isas);
-
   const std::vector<uint8_t> guest_elf =
       load_gfx950_code_object("triton_cdna4_flash_attention_buffer_async_1024");
   ASSERT_FALSE(guest_elf.empty());
 
   std::vector<float> observed;
+  std::vector<float> expected;
   ASSERT_NO_FATAL_FAILURE(run_flash_attention_triton(
-      guest_elf, guest, "flash_attention_fwd_async_buffer_kernel.kd", 65536, &observed));
-  ASSERT_FALSE(observed.empty());
-  EXPECT_TRUE(std::all_of(observed.begin(), observed.end(),
-                          [](float value) { return std::isfinite(value) && value != -12345.0f; }));
+      guest_elf, guest, "flash_attention_fwd_async_buffer_kernel.kd", 65536, &observed, &expected));
+  expect_float_vectors_near(observed, expected, 0.02f, "guest DBT flash attention buffer-async");
 }
 
 TEST(Cdna4ToCdna3DispatchTest, TritonDynamicMatmulDispatchAndRun) {

--- a/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
@@ -66,6 +66,22 @@ struct TritonMatmulCase {
   uint32_t k;
 };
 
+constexpr uint32_t kFlashAttentionQ = 1024;
+constexpr uint32_t kFlashAttentionKV = 1024;
+constexpr uint32_t kFlashAttentionHeadDim = 64;
+constexpr uint32_t kFlashAttentionBlockN = 64;
+
+struct FlashAttentionReferenceSlice {
+  uint32_t row;
+  uint32_t begin;
+  uint32_t end;
+};
+
+constexpr std::array<FlashAttentionReferenceSlice, 2> kFlashAttentionReferenceSlices = {{
+    {0, 0, kFlashAttentionHeadDim / 2},
+    {kFlashAttentionQ - 1, kFlashAttentionHeadDim / 2, kFlashAttentionHeadDim},
+}};
+
 void expect_float_vectors_near(const std::vector<float> &actual, const std::vector<float> &expected,
                                float tolerance, const char *label) {
   ASSERT_EQ(actual.size(), expected.size()) << label;
@@ -93,6 +109,92 @@ void fill_seeded_half_inputs(std::vector<uint16_t> &values, uint32_t seed) {
     const uint16_t sign = static_cast<uint16_t>(sign_dist(rng) << 15);
     value = static_cast<uint16_t>(sign | magnitude_dist(rng));
   }
+}
+
+std::vector<float> reference_flash_attention_slices(const std::vector<uint16_t> &q,
+                                                    const std::vector<uint16_t> &k,
+                                                    const std::vector<uint16_t> &v) {
+  std::vector<float> result;
+  result.reserve(kFlashAttentionHeadDim);
+
+  for (const FlashAttentionReferenceSlice &slice : kFlashAttentionReferenceSlices) {
+    float max_score = -1.0e20f;
+    float normalization = 0.0f;
+    std::vector<float> accumulator(slice.end - slice.begin, 0.0f);
+
+    for (uint32_t block = 0; block < kFlashAttentionKV; block += kFlashAttentionBlockN) {
+      std::array<float, kFlashAttentionBlockN> scores{};
+      float block_max = -1.0e20f;
+      for (uint32_t n = 0; n < kFlashAttentionBlockN; ++n) {
+        float score = 0.0f;
+        for (uint32_t d = 0; d < kFlashAttentionHeadDim; ++d) {
+          const float q_value =
+              util::f16_to_f32(q[static_cast<size_t>(slice.row) * kFlashAttentionHeadDim + d]);
+          const float k_value =
+              util::f16_to_f32(k[static_cast<size_t>(block + n) * kFlashAttentionHeadDim + d]);
+          score = std::fma(q_value, k_value, score);
+        }
+        // The Triton fixture scales by log2(e) and uses exp2 for the online
+        // softmax recurrence.
+        scores[n] = score * 1.4426950408889634f;
+        block_max = std::max(block_max, scores[n]);
+      }
+
+      const float new_max = std::max(max_score, block_max);
+      const float alpha = std::exp2(max_score - new_max);
+      float block_normalization = 0.0f;
+      std::array<float, kFlashAttentionBlockN> probabilities{};
+      for (uint32_t n = 0; n < kFlashAttentionBlockN; ++n) {
+        const float probability = std::exp2(scores[n] - new_max);
+        block_normalization += probability;
+        probabilities[n] = util::f16_to_f32(util::f32_to_f16(probability));
+      }
+
+      for (float &value : accumulator)
+        value *= alpha;
+      for (uint32_t n = 0; n < kFlashAttentionBlockN; ++n) {
+        for (uint32_t d = slice.begin; d < slice.end; ++d) {
+          const float v_value =
+              util::f16_to_f32(v[static_cast<size_t>(block + n) * kFlashAttentionHeadDim + d]);
+          accumulator[d - slice.begin] =
+              std::fma(probabilities[n], v_value, accumulator[d - slice.begin]);
+        }
+      }
+
+      normalization = normalization * alpha + block_normalization;
+      max_score = new_max;
+    }
+
+    for (float value : accumulator)
+      result.push_back(value / normalization);
+  }
+  return result;
+}
+
+void expect_flash_attention_slices_near(const std::vector<float> &actual,
+                                        const std::vector<float> &expected, float tolerance,
+                                        const char *label) {
+  ASSERT_EQ(actual.size(), static_cast<size_t>(kFlashAttentionQ) * kFlashAttentionHeadDim) << label;
+  ASSERT_EQ(expected.size(), kFlashAttentionHeadDim) << label;
+
+  uint32_t mismatches = 0;
+  size_t reference_index = 0;
+  for (const FlashAttentionReferenceSlice &slice : kFlashAttentionReferenceSlices) {
+    for (uint32_t d = slice.begin; d < slice.end; ++d, ++reference_index) {
+      const float actual_value =
+          actual[static_cast<size_t>(slice.row) * kFlashAttentionHeadDim + d];
+      const float expected_value = expected[reference_index];
+      const float diff = std::fabs(actual_value - expected_value);
+      if (!std::isfinite(actual_value) || !std::isfinite(expected_value) || diff > tolerance) {
+        if (mismatches < 8)
+          ADD_FAILURE() << label << " mismatch at row=" << slice.row << " d=" << d
+                        << ": got=" << actual_value << " expected=" << expected_value
+                        << " diff=" << diff;
+        ++mismatches;
+      }
+    }
+  }
+  EXPECT_EQ(mismatches, 0u) << mismatches << " " << label << " mismatches";
 }
 
 std::vector<float> reference_triton_matmul(const TritonMatmulCase &test_case) {
@@ -248,6 +350,42 @@ std::string join_seen_isas(const std::vector<std::string> &isas) {
 
 struct HsaShutdownGuard {
   ~HsaShutdownGuard() { hsa_shut_down(); }
+};
+
+struct HsaMatmulResources {
+  hsa_code_object_reader_t reader{};
+  hsa_executable_t executable{};
+  hsa_queue_t *queue = nullptr;
+  hsa_signal_t signal{};
+  void *kernarg = nullptr;
+  void *a = nullptr;
+  void *b = nullptr;
+  void *c = nullptr;
+  bool reader_created = false;
+  bool executable_created = false;
+  bool signal_created = false;
+
+  ~HsaMatmulResources() {
+    // Stop queue execution before releasing anything referenced by an AQL
+    // packet. This also makes an assertion after a dispatch timeout safe: the
+    // test must not leave a live simulator dispatch for hsa_shut_down().
+    if (queue)
+      hsa_queue_destroy(queue);
+    if (signal_created)
+      hsa_signal_destroy(signal);
+    if (kernarg)
+      hsa_amd_memory_pool_free(kernarg);
+    if (a)
+      hsa_amd_memory_pool_free(a);
+    if (b)
+      hsa_amd_memory_pool_free(b);
+    if (c)
+      hsa_amd_memory_pool_free(c);
+    if (executable_created)
+      hsa_executable_destroy(executable);
+    if (reader_created)
+      hsa_code_object_reader_destroy(reader);
+  }
 };
 
 void run_dynamic_copy_loop(const std::vector<uint8_t> &elf_bytes, const DispatchTarget &target) {
@@ -427,22 +565,25 @@ void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const DispatchTarg
   hsa_agent_t cpu = find_cpu_agent();
   ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
 
-  hsa_code_object_reader_t reader{};
-  auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(), &reader);
+  HsaMatmulResources resources;
+  auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(),
+                                                      &resources.reader);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  resources.reader_created = true;
 
-  hsa_executable_t executable{};
   st = hsa_executable_create_alt(HSA_PROFILE_FULL, HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT, nullptr,
-                                 &executable);
+                                 &resources.executable);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
-  st = hsa_executable_load_agent_code_object(executable, target.agent, reader, nullptr, nullptr);
+  resources.executable_created = true;
+  st = hsa_executable_load_agent_code_object(resources.executable, target.agent, resources.reader,
+                                             nullptr, nullptr);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
-  st = hsa_executable_freeze(executable, nullptr);
+  st = hsa_executable_freeze(resources.executable, nullptr);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
 
   hsa_executable_symbol_t symbol{};
-  st = hsa_executable_get_symbol_by_name(executable, "triton_cdna4_matmul_kernel.kd", &target.agent,
-                                         &symbol);
+  st = hsa_executable_get_symbol_by_name(resources.executable, "triton_cdna4_matmul_kernel.kd",
+                                         &target.agent, &symbol);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
 
   uint64_t kernel_object = 0;
@@ -467,15 +608,12 @@ void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const DispatchTarg
 
   auto gpu_pool = find_pool(target.agent, HSA_AMD_SEGMENT_GLOBAL);
   ASSERT_NE(gpu_pool.handle, 0u);
-  uint16_t *a_dev = nullptr;
-  uint16_t *b_dev = nullptr;
-  float *c_dev = nullptr;
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kABytes, 0, reinterpret_cast<void **>(&a_dev)),
-            HSA_STATUS_SUCCESS);
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kBBytes, 0, reinterpret_cast<void **>(&b_dev)),
-            HSA_STATUS_SUCCESS);
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kCBytes, 0, reinterpret_cast<void **>(&c_dev)),
-            HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kABytes, 0, &resources.a), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kBBytes, 0, &resources.b), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kCBytes, 0, &resources.c), HSA_STATUS_SUCCESS);
+  auto *a_dev = static_cast<uint16_t *>(resources.a);
+  auto *b_dev = static_cast<uint16_t *>(resources.b);
+  auto *c_dev = static_cast<float *>(resources.c);
 
   hsa_agent_t both[] = {cpu, target.agent};
   ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, a_dev), HSA_STATUS_SUCCESS);
@@ -484,10 +622,10 @@ void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const DispatchTarg
 
   auto kernarg_pool = find_pool(cpu, HSA_AMD_SEGMENT_GLOBAL, true);
   ASSERT_NE(kernarg_pool.handle, 0u);
-  void *kernarg = nullptr;
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(kernarg_pool, 256, 0, &kernarg), HSA_STATUS_SUCCESS);
-  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, kernarg), HSA_STATUS_SUCCESS);
-  std::memset(kernarg, 0, 256);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(kernarg_pool, 256, 0, &resources.kernarg),
+            HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, resources.kernarg), HSA_STATUS_SUCCESS);
+  std::memset(resources.kernarg, 0, 256);
 
   struct __attribute__((packed)) DynamicKernArgs {
     const uint16_t *a;
@@ -502,7 +640,7 @@ void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const DispatchTarg
   };
   static_assert(sizeof(DynamicKernArgs) == 56, "Dynamic Triton matmul kernarg layout changed");
 
-  auto *args = static_cast<DynamicKernArgs *>(kernarg);
+  auto *args = static_cast<DynamicKernArgs *>(resources.kernarg);
   args->a = a_dev;
   args->b = b_dev;
   args->c = c_dev;
@@ -520,20 +658,19 @@ void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const DispatchTarg
   ASSERT_EQ(hsa_memory_copy(b_dev, b_host.data(), kBBytes), HSA_STATUS_SUCCESS);
   ASSERT_EQ(hsa_memory_copy(c_dev, c_init.data(), kCBytes), HSA_STATUS_SUCCESS);
 
-  hsa_queue_t *queue = nullptr;
   uint32_t queue_size = 0;
   hsa_agent_get_info(target.agent, HSA_AGENT_INFO_QUEUE_MAX_SIZE, &queue_size);
   st = hsa_queue_create(target.agent, queue_size, HSA_QUEUE_TYPE_SINGLE, nullptr, nullptr,
-                        UINT32_MAX, UINT32_MAX, &queue);
+                        UINT32_MAX, UINT32_MAX, &resources.queue);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
 
-  hsa_signal_t signal{};
-  ASSERT_EQ(hsa_signal_create(1, 0, nullptr, &signal), HSA_STATUS_SUCCESS);
-  hsa_signal_store_relaxed(signal, 1);
+  ASSERT_EQ(hsa_signal_create(1, 0, nullptr, &resources.signal), HSA_STATUS_SUCCESS);
+  resources.signal_created = true;
+  hsa_signal_store_relaxed(resources.signal, 1);
 
-  const uint64_t write_idx = hsa_queue_add_write_index_relaxed(queue, 1);
-  auto *aql = static_cast<hsa_kernel_dispatch_packet_t *>(queue->base_address) +
-              (write_idx & (queue->size - 1));
+  const uint64_t write_idx = hsa_queue_add_write_index_relaxed(resources.queue, 1);
+  auto *aql = static_cast<hsa_kernel_dispatch_packet_t *>(resources.queue->base_address) +
+              (write_idx & (resources.queue->size - 1));
   std::memset(aql, 0, sizeof(*aql));
   aql->setup = 2;
   aql->workgroup_size_x = kWorkgroupSize;
@@ -544,33 +681,45 @@ void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const DispatchTarg
   aql->grid_size_z = 1;
   aql->group_segment_size = shared_bytes;
   aql->kernel_object = kernel_object;
-  aql->kernarg_address = kernarg;
-  aql->completion_signal = signal;
+  aql->kernarg_address = resources.kernarg;
+  aql->completion_signal = resources.signal;
 
   uint16_t header = HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE;
   header |= 1 << HSA_PACKET_HEADER_BARRIER;
   header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE;
   header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE;
   __atomic_store_n(reinterpret_cast<uint16_t *>(aql), header, __ATOMIC_RELEASE);
-  hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
+  hsa_signal_store_relaxed(resources.queue->doorbell_signal, write_idx);
 
   const hsa_signal_value_t val = hsa_signal_wait_scacquire(
-      signal, HSA_SIGNAL_CONDITION_LT, 1, 5'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+      resources.signal, HSA_SIGNAL_CONDITION_LT, 1, 5'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
   ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
 
   ASSERT_EQ(hsa_memory_copy(c_host.data(), c_dev, kCBytes), HSA_STATUS_SUCCESS);
 
   if (observed)
     *observed = std::move(c_host);
+}
 
-  hsa_signal_destroy(signal);
-  hsa_queue_destroy(queue);
-  hsa_amd_memory_pool_free(kernarg);
-  hsa_amd_memory_pool_free(a_dev);
-  hsa_amd_memory_pool_free(b_dev);
-  hsa_amd_memory_pool_free(c_dev);
-  hsa_executable_destroy(executable);
-  hsa_code_object_reader_destroy(reader);
+template <size_t N>
+void compare_dynamic_triton_matmul_cases(const DispatchTarget &target,
+                                         const std::array<TritonMatmulCase, N> &cases) {
+  std::vector<uint8_t> translated;
+  ASSERT_NO_FATAL_FAILURE(translate_dynamic_triton_matmul(target.mach, translated));
+  std::vector<uint8_t> native = load_kernel_hsaco_bytes("triton_cdna3_matmul_dynamic_32x32x64");
+  ASSERT_FALSE(native.empty());
+
+  for (const TritonMatmulCase &test_case : cases) {
+    SCOPED_TRACE(::testing::Message()
+                 << "M=" << test_case.m << " N=" << test_case.n << " K=" << test_case.k);
+    std::vector<float> translated_out;
+    std::vector<float> native_out;
+    ASSERT_NO_FATAL_FAILURE(
+        run_triton_matmul(translated, target, test_case, 8192, &translated_out));
+    ASSERT_NO_FATAL_FAILURE(run_triton_matmul(native, target, test_case, 4096, &native_out));
+    expect_float_vectors_near(translated_out, native_out, 0.02f,
+                              "translated-vs-native dynamic Triton matmul");
+  }
 }
 
 void run_buffer_async_triton_matmul(const std::vector<uint8_t> &elf_bytes,
@@ -764,15 +913,12 @@ void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const Dis
   hsa_executable_symbol_get_info(symbol, HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_OBJECT, &kernel_object);
   ASSERT_NE(kernel_object, 0u);
 
-  constexpr uint32_t kQ = 1024;
-  constexpr uint32_t kKV = 1024;
-  constexpr uint32_t kHeadDim = 64;
   constexpr uint32_t kBlockM = 64;
   constexpr uint32_t kWorkgroupSize = 256;
-  constexpr uint32_t kGroups = (kQ + kBlockM - 1) / kBlockM;
-  const size_t kQElements = static_cast<size_t>(kQ) * kHeadDim;
-  const size_t kKVElements = static_cast<size_t>(kKV) * kHeadDim;
-  const size_t kOElements = static_cast<size_t>(kQ) * kHeadDim;
+  constexpr uint32_t kGroups = (kFlashAttentionQ + kBlockM - 1) / kBlockM;
+  const size_t kQElements = static_cast<size_t>(kFlashAttentionQ) * kFlashAttentionHeadDim;
+  const size_t kKVElements = static_cast<size_t>(kFlashAttentionKV) * kFlashAttentionHeadDim;
+  const size_t kOElements = static_cast<size_t>(kFlashAttentionQ) * kFlashAttentionHeadDim;
   const size_t kQBytes = kQElements * sizeof(uint16_t);
   const size_t kKVBytes = kKVElements * sizeof(uint16_t);
   const size_t kOBytes = kOElements * sizeof(float);
@@ -830,25 +976,11 @@ void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const Dis
   std::vector<uint16_t> v_host(kKVElements);
   std::vector<float> o_init(kOElements, -12345.0f);
   std::vector<float> o_host(kOElements);
-  if (reference) {
-    // Zero Q/K makes every attention score equal. Repeating one V row across
-    // all keys means both causal and non-causal softmax produce that row, so
-    // every output element has a full, inexpensive CPU reference.
-    std::fill(q_host.begin(), q_host.end(), 0);
-    std::fill(k_host.begin(), k_host.end(), 0);
-    std::vector<uint16_t> v_row(kHeadDim);
-    fill_seeded_half_inputs(v_row, 0xF1A5'0003u);
-    for (uint32_t kv = 0; kv < kKV; ++kv)
-      std::copy(v_row.begin(), v_row.end(), v_host.begin() + static_cast<size_t>(kv) * kHeadDim);
-    reference->resize(kOElements);
-    for (uint32_t q = 0; q < kQ; ++q)
-      for (uint32_t d = 0; d < kHeadDim; ++d)
-        (*reference)[static_cast<size_t>(q) * kHeadDim + d] = util::f16_to_f32(v_row[d]);
-  } else {
-    fill_seeded_half_inputs(q_host, 0xF1A5'0001u);
-    fill_seeded_half_inputs(k_host, 0xF1A5'0002u);
-    fill_seeded_half_inputs(v_host, 0xF1A5'0003u);
-  }
+  fill_seeded_half_inputs(q_host, 0xF1A5'0001u);
+  fill_seeded_half_inputs(k_host, 0xF1A5'0002u);
+  fill_seeded_half_inputs(v_host, 0xF1A5'0003u);
+  if (reference)
+    *reference = reference_flash_attention_slices(q_host, k_host, v_host);
   ASSERT_EQ(hsa_memory_copy(q_dev, q_host.data(), kQBytes), HSA_STATUS_SUCCESS);
   ASSERT_EQ(hsa_memory_copy(k_dev, k_host.data(), kKVBytes), HSA_STATUS_SUCCESS);
   ASSERT_EQ(hsa_memory_copy(v_dev, v_host.data(), kKVBytes), HSA_STATUS_SUCCESS);
@@ -1061,7 +1193,8 @@ TEST(Cdna4ToCdna3DbtGuestTest, TritonFlashAttentionNoAsyncDispatchAndRun) {
   std::vector<float> expected;
   ASSERT_NO_FATAL_FAILURE(run_flash_attention_triton(
       guest_elf, guest, "flash_attention_fwd_no_async_kernel.kd", 65536, &observed, &expected));
-  expect_float_vectors_near(observed, expected, 0.02f, "guest DBT flash attention no-async");
+  expect_flash_attention_slices_near(observed, expected, 0.02f,
+                                     "guest DBT flash attention no-async");
 }
 
 TEST(Cdna4ToCdna3DbtGuestTest, TritonFlashAttentionBufferAsyncDispatchAndRun) {
@@ -1081,22 +1214,17 @@ TEST(Cdna4ToCdna3DbtGuestTest, TritonFlashAttentionBufferAsyncDispatchAndRun) {
   std::vector<float> expected;
   ASSERT_NO_FATAL_FAILURE(run_flash_attention_triton(
       guest_elf, guest, "flash_attention_fwd_async_buffer_kernel.kd", 65536, &observed, &expected));
-  expect_float_vectors_near(observed, expected, 0.02f, "guest DBT flash attention buffer-async");
+  expect_flash_attention_slices_near(observed, expected, 0.02f,
+                                     "guest DBT flash attention buffer-async");
 }
 
 TEST(Cdna4ToCdna3DispatchTest, TritonDynamicMatmulDispatchAndRun) {
-  const std::array<TritonMatmulCase, 11> cases = {{
+  const std::array<TritonMatmulCase, 5> cases = {{
       {32, 32, 64},
-      {32, 32, 65},
-      {32, 32, 66},
-      {32, 32, 128},
-      {32, 32, 130},
-      {32, 32, 192},
-      {32, 32, 512},
-      {512, 512, 512},
-      {31, 31, 64},
-      {32, 32, 63},
-      {257, 129, 130},
+      {31, 31, 63},
+      {33, 33, 65},
+      {128, 128, 128},
+      {65, 33, 130},
   }};
 
   const hsa_status_t init_status = hsa_init();
@@ -1110,22 +1238,7 @@ TEST(Cdna4ToCdna3DispatchTest, TritonDynamicMatmulDispatchAndRun) {
     GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
                  << join_seen_isas(target.seen_gpu_isas);
 
-  std::vector<uint8_t> translated;
-  ASSERT_NO_FATAL_FAILURE(translate_dynamic_triton_matmul(target.mach, translated));
-  std::vector<uint8_t> native = load_kernel_hsaco_bytes("triton_cdna3_matmul_dynamic_32x32x64");
-  ASSERT_FALSE(native.empty());
-
-  for (const TritonMatmulCase &test_case : cases) {
-    SCOPED_TRACE(::testing::Message()
-                 << "M=" << test_case.m << " N=" << test_case.n << " K=" << test_case.k);
-    std::vector<float> translated_out;
-    std::vector<float> native_out;
-    ASSERT_NO_FATAL_FAILURE(
-        run_triton_matmul(translated, target, test_case, 8192, &translated_out));
-    ASSERT_NO_FATAL_FAILURE(run_triton_matmul(native, target, test_case, 4096, &native_out));
-    expect_float_vectors_near(translated_out, native_out, 0.02f,
-                              "translated-vs-native dynamic Triton matmul");
-  }
+  ASSERT_NO_FATAL_FAILURE(compare_dynamic_triton_matmul_cases(target, cases));
 }
 
 TEST(Cdna4ToCdna3DispatchTest, TritonBufferAsyncMatmulDispatchAndRun) {

--- a/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
@@ -16,6 +16,7 @@ RJ_DIAGNOSTIC_POP
 #include "rocjitsu/code/dbt/binary_translator.h"
 #include "rocjitsu/code/executable.h"
 #include "rocjitsu/code/rj_code.h"
+#include "util/data_types.h"
 
 #include <gtest/gtest.h>
 
@@ -28,6 +29,7 @@ RJ_DIAGNOSTIC_POP
 #include <iterator>
 #include <random>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #ifdef HAS_HOST_AMDGPU
@@ -44,6 +46,18 @@ std::vector<uint8_t> load_kernel_hsaco_bytes(const char *name) {
     return {};
   return std::vector<uint8_t>(std::istreambuf_iterator<char>(file),
                               std::istreambuf_iterator<char>());
+}
+
+std::vector<uint8_t> load_gfx950_code_object(const char *name) {
+  Executable exec(kernel_hsaco_path(name));
+  if (!exec.is_valid() || exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950) == 0)
+    return {};
+  const auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  if (!co)
+    return {};
+  std::vector<uint8_t> bytes(co->image_size());
+  std::memcpy(bytes.data(), co->image_data(), co->image_size());
+  return bytes;
 }
 
 struct TritonMatmulCase {
@@ -79,6 +93,27 @@ void fill_seeded_half_inputs(std::vector<uint16_t> &values, uint32_t seed) {
     const uint16_t sign = static_cast<uint16_t>(sign_dist(rng) << 15);
     value = static_cast<uint16_t>(sign | magnitude_dist(rng));
   }
+}
+
+std::vector<float> reference_triton_matmul(const TritonMatmulCase &test_case) {
+  std::vector<uint16_t> a(static_cast<size_t>(test_case.m) * test_case.k);
+  std::vector<uint16_t> b(static_cast<size_t>(test_case.k) * test_case.n);
+  fill_seeded_half_inputs(a, 0xA0D4'0001u ^ test_case.m ^ (test_case.k << 8));
+  fill_seeded_half_inputs(b, 0xB0D4'0001u ^ test_case.n ^ (test_case.k << 8));
+
+  std::vector<float> result(static_cast<size_t>(test_case.m) * test_case.n, 0.0f);
+  for (uint32_t m = 0; m < test_case.m; ++m) {
+    for (uint32_t n = 0; n < test_case.n; ++n) {
+      float sum = 0.0f;
+      for (uint32_t k = 0; k < test_case.k; ++k) {
+        const float lhs = util::f16_to_f32(a[static_cast<size_t>(m) * test_case.k + k]);
+        const float rhs = util::f16_to_f32(b[static_cast<size_t>(k) * test_case.n + n]);
+        sum = std::fma(lhs, rhs, sum);
+      }
+      result[static_cast<size_t>(m) * test_case.n + n] = sum;
+    }
+  }
+  return result;
 }
 
 hsa_agent_t find_cpu_agent() {
@@ -126,7 +161,7 @@ hsa_amd_memory_pool_t find_pool(hsa_agent_t agent, hsa_amd_segment_t segment,
   return ctx.pool;
 }
 
-struct Cdna3Target {
+struct DispatchTarget {
   hsa_agent_t agent{};
   uint32_t mach = 0;
   std::string isa_name;
@@ -143,11 +178,11 @@ uint32_t cdna3_mach_for_isa_name(const char *name) {
   return 0;
 }
 
-Cdna3Target find_cdna3_target() {
-  Cdna3Target target;
+DispatchTarget find_cdna3_target() {
+  DispatchTarget target;
   hsa_iterate_agents(
       [](hsa_agent_t agent, void *data) -> hsa_status_t {
-        auto *t = static_cast<Cdna3Target *>(data);
+        auto *t = static_cast<DispatchTarget *>(data);
         hsa_device_type_t type;
         hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &type);
         if (type != HSA_DEVICE_TYPE_GPU)
@@ -172,6 +207,36 @@ Cdna3Target find_cdna3_target() {
   return target;
 }
 
+DispatchTarget find_gpu_target_named(std::string_view expected_isa) {
+  struct Context {
+    std::string_view expected_isa;
+    DispatchTarget target;
+  } context{expected_isa, {}};
+
+  hsa_iterate_agents(
+      [](hsa_agent_t agent, void *data) -> hsa_status_t {
+        auto *ctx = static_cast<Context *>(data);
+        hsa_device_type_t type;
+        hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &type);
+        if (type != HSA_DEVICE_TYPE_GPU)
+          return HSA_STATUS_SUCCESS;
+
+        hsa_isa_t isa{};
+        char isa_name[128]{};
+        hsa_agent_get_info(agent, HSA_AGENT_INFO_ISA, &isa);
+        hsa_isa_get_info_alt(isa, HSA_ISA_INFO_NAME, isa_name);
+        ctx->target.seen_gpu_isas.emplace_back(isa_name);
+        if (std::string_view(isa_name).find(ctx->expected_isa) == std::string_view::npos)
+          return HSA_STATUS_SUCCESS;
+
+        ctx->target.agent = agent;
+        ctx->target.isa_name = isa_name;
+        return HSA_STATUS_INFO_BREAK;
+      },
+      &context);
+  return context.target;
+}
+
 std::string join_seen_isas(const std::vector<std::string> &isas) {
   if (isas.empty())
     return "<none>";
@@ -185,7 +250,7 @@ struct HsaShutdownGuard {
   ~HsaShutdownGuard() { hsa_shut_down(); }
 };
 
-void run_dynamic_copy_loop(const std::vector<uint8_t> &elf_bytes, const Cdna3Target &target) {
+void run_dynamic_copy_loop(const std::vector<uint8_t> &elf_bytes, const DispatchTarget &target) {
   hsa_agent_t cpu = find_cpu_agent();
   ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
 
@@ -356,7 +421,7 @@ void translate_dynamic_triton_matmul(uint32_t mach, std::vector<uint8_t> &elf_by
   translate_triton_fixture("triton_cdna4_matmul_dynamic_32x32x64", mach, elf_bytes);
 }
 
-void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const Cdna3Target &target,
+void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const DispatchTarget &target,
                        const TritonMatmulCase &test_case, uint32_t shared_bytes,
                        std::vector<float> *observed = nullptr) {
   hsa_agent_t cpu = find_cpu_agent();
@@ -509,7 +574,7 @@ void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const Cdna3Target 
 }
 
 void run_buffer_async_triton_matmul(const std::vector<uint8_t> &elf_bytes,
-                                    const Cdna3Target &target, uint32_t shared_bytes,
+                                    const DispatchTarget &target, uint32_t shared_bytes,
                                     std::vector<float> *observed = nullptr) {
   hsa_agent_t cpu = find_cpu_agent();
   ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
@@ -657,7 +722,7 @@ void run_buffer_async_triton_matmul(const std::vector<uint8_t> &elf_bytes,
   hsa_code_object_reader_destroy(reader);
 }
 
-void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const Cdna3Target &target,
+void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const DispatchTarget &target,
                                 const char *symbol_name, uint32_t shared_bytes,
                                 std::vector<float> *observed = nullptr) {
   hsa_agent_t cpu = find_cpu_agent();
@@ -862,7 +927,7 @@ TEST(Cdna4ToCdna3DispatchTest, DynamicCopyLoopDispatchAndRun) {
                  << "; CDNA4->CDNA3 dispatch verification requires an HSA-capable host";
   const HsaShutdownGuard shutdown;
 
-  Cdna3Target target = find_cdna3_target();
+  DispatchTarget target = find_cdna3_target();
   if (target.agent.handle == 0)
     GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
                  << join_seen_isas(target.seen_gpu_isas);
@@ -880,6 +945,119 @@ TEST(Cdna4ToCdna3DispatchTest, DynamicCopyLoopDispatchAndRun) {
                                << translated.diagnostics.front().message;
 
   ASSERT_NO_FATAL_FAILURE(run_dynamic_copy_loop(translated.elf_bytes, target));
+}
+
+TEST(Cdna4ToCdna3DbtGuestTest, DynamicCopyLoopDispatchAndRun) {
+  const hsa_status_t init_status = hsa_init();
+  ASSERT_EQ(init_status, HSA_STATUS_SUCCESS)
+      << "DBT guest simulator launch must provide an HSA-capable execution backend";
+  const HsaShutdownGuard shutdown;
+
+  DispatchTarget guest = find_gpu_target_named("gfx950");
+  ASSERT_NE(guest.agent.handle, 0u) << "DBT guest launch must publicly expose gfx950; found: "
+                                    << join_seen_isas(guest.seen_gpu_isas);
+
+  Executable exec(kernel_path("dynamic_copy_loop"));
+  ASSERT_TRUE(exec.is_valid());
+  ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
+  const auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  ASSERT_NE(co, nullptr);
+  std::vector<uint8_t> guest_elf(co->image_size());
+  std::memcpy(guest_elf.data(), co->image_data(), co->image_size());
+
+  // Deliberately load the original gfx950 ELF through the public guest agent.
+  // The DBT HSA hook owns translation and maps execution to simulated gfx942.
+  ASSERT_NO_FATAL_FAILURE(run_dynamic_copy_loop(guest_elf, guest));
+}
+
+TEST(Cdna4ToCdna3DbtGuestTest, TritonDynamicMatmulDispatchAndRun) {
+  const hsa_status_t init_status = hsa_init();
+  ASSERT_EQ(init_status, HSA_STATUS_SUCCESS)
+      << "DBT guest simulator launch must provide an HSA-capable execution backend";
+  const HsaShutdownGuard shutdown;
+
+  DispatchTarget guest = find_gpu_target_named("gfx950");
+  ASSERT_NE(guest.agent.handle, 0u) << "DBT guest launch must publicly expose gfx950; found: "
+                                    << join_seen_isas(guest.seen_gpu_isas);
+
+  Executable exec(kernel_hsaco_path("triton_cdna4_matmul_dynamic_32x32x64"));
+  ASSERT_TRUE(exec.is_valid());
+  ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
+  const auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  ASSERT_NE(co, nullptr);
+  std::vector<uint8_t> guest_elf(co->image_size());
+  std::memcpy(guest_elf.data(), co->image_data(), co->image_size());
+
+  constexpr TritonMatmulCase kCase{32, 32, 64};
+  std::vector<float> observed;
+  ASSERT_NO_FATAL_FAILURE(run_triton_matmul(guest_elf, guest, kCase, 8192, &observed));
+  expect_float_vectors_near(observed, reference_triton_matmul(kCase), 0.02f,
+                            "guest DBT dynamic Triton matmul");
+}
+
+TEST(Cdna4ToCdna3DbtGuestTest, TritonBufferAsyncMatmulDispatchAndRun) {
+  const hsa_status_t init_status = hsa_init();
+  ASSERT_EQ(init_status, HSA_STATUS_SUCCESS)
+      << "DBT guest simulator launch must provide an HSA-capable execution backend";
+  const HsaShutdownGuard shutdown;
+
+  DispatchTarget guest = find_gpu_target_named("gfx950");
+  ASSERT_NE(guest.agent.handle, 0u) << "DBT guest launch must publicly expose gfx950; found: "
+                                    << join_seen_isas(guest.seen_gpu_isas);
+
+  const std::vector<uint8_t> guest_elf =
+      load_gfx950_code_object("triton_cdna4_matmul_buffer_async_1024");
+  ASSERT_FALSE(guest_elf.empty());
+
+  std::vector<float> observed;
+  ASSERT_NO_FATAL_FAILURE(run_buffer_async_triton_matmul(guest_elf, guest, 65536, &observed));
+  ASSERT_FALSE(observed.empty());
+  EXPECT_TRUE(std::all_of(observed.begin(), observed.end(),
+                          [](float value) { return std::isfinite(value) && value != -12345.0f; }));
+}
+
+TEST(Cdna4ToCdna3DbtGuestTest, TritonFlashAttentionNoAsyncDispatchAndRun) {
+  const hsa_status_t init_status = hsa_init();
+  ASSERT_EQ(init_status, HSA_STATUS_SUCCESS)
+      << "DBT guest simulator launch must provide an HSA-capable execution backend";
+  const HsaShutdownGuard shutdown;
+
+  DispatchTarget guest = find_gpu_target_named("gfx950");
+  ASSERT_NE(guest.agent.handle, 0u) << "DBT guest launch must publicly expose gfx950; found: "
+                                    << join_seen_isas(guest.seen_gpu_isas);
+
+  const std::vector<uint8_t> guest_elf =
+      load_gfx950_code_object("triton_cdna4_flash_attention_no_async_1024");
+  ASSERT_FALSE(guest_elf.empty());
+
+  std::vector<float> observed;
+  ASSERT_NO_FATAL_FAILURE(run_flash_attention_triton(
+      guest_elf, guest, "flash_attention_fwd_no_async_kernel.kd", 65536, &observed));
+  ASSERT_FALSE(observed.empty());
+  EXPECT_TRUE(std::all_of(observed.begin(), observed.end(),
+                          [](float value) { return std::isfinite(value) && value != -12345.0f; }));
+}
+
+TEST(Cdna4ToCdna3DbtGuestTest, TritonFlashAttentionBufferAsyncDispatchAndRun) {
+  const hsa_status_t init_status = hsa_init();
+  ASSERT_EQ(init_status, HSA_STATUS_SUCCESS)
+      << "DBT guest simulator launch must provide an HSA-capable execution backend";
+  const HsaShutdownGuard shutdown;
+
+  DispatchTarget guest = find_gpu_target_named("gfx950");
+  ASSERT_NE(guest.agent.handle, 0u) << "DBT guest launch must publicly expose gfx950; found: "
+                                    << join_seen_isas(guest.seen_gpu_isas);
+
+  const std::vector<uint8_t> guest_elf =
+      load_gfx950_code_object("triton_cdna4_flash_attention_buffer_async_1024");
+  ASSERT_FALSE(guest_elf.empty());
+
+  std::vector<float> observed;
+  ASSERT_NO_FATAL_FAILURE(run_flash_attention_triton(
+      guest_elf, guest, "flash_attention_fwd_async_buffer_kernel.kd", 65536, &observed));
+  ASSERT_FALSE(observed.empty());
+  EXPECT_TRUE(std::all_of(observed.begin(), observed.end(),
+                          [](float value) { return std::isfinite(value) && value != -12345.0f; }));
 }
 
 TEST(Cdna4ToCdna3DispatchTest, TritonDynamicMatmulDispatchAndRun) {
@@ -903,7 +1081,7 @@ TEST(Cdna4ToCdna3DispatchTest, TritonDynamicMatmulDispatchAndRun) {
                  << "; CDNA4->CDNA3 dispatch verification requires an HSA-capable host";
   const HsaShutdownGuard shutdown;
 
-  Cdna3Target target = find_cdna3_target();
+  DispatchTarget target = find_cdna3_target();
   if (target.agent.handle == 0)
     GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
                  << join_seen_isas(target.seen_gpu_isas);
@@ -933,7 +1111,7 @@ TEST(Cdna4ToCdna3DispatchTest, TritonBufferAsyncMatmulDispatchAndRun) {
                  << "; CDNA4->CDNA3 dispatch verification requires an HSA-capable host";
   const HsaShutdownGuard shutdown;
 
-  Cdna3Target target = find_cdna3_target();
+  DispatchTarget target = find_cdna3_target();
   if (target.agent.handle == 0)
     GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
                  << join_seen_isas(target.seen_gpu_isas);
@@ -960,7 +1138,7 @@ TEST(Cdna4ToCdna3DispatchTest, TritonBufferAsyncMatmulConservativeLivenessDispat
                  << "; CDNA4->CDNA3 dispatch verification requires an HSA-capable host";
   const HsaShutdownGuard shutdown;
 
-  Cdna3Target target = find_cdna3_target();
+  DispatchTarget target = find_cdna3_target();
   if (target.agent.handle == 0)
     GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
                  << join_seen_isas(target.seen_gpu_isas);
@@ -994,7 +1172,7 @@ TEST(Cdna4ToCdna3DispatchTest, TritonFlashAttentionNoAsyncDispatchAndRun) {
                  << "; CDNA4->CDNA3 dispatch verification requires an HSA-capable host";
   const HsaShutdownGuard shutdown;
 
-  Cdna3Target target = find_cdna3_target();
+  DispatchTarget target = find_cdna3_target();
   if (target.agent.handle == 0)
     GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
                  << join_seen_isas(target.seen_gpu_isas);
@@ -1023,7 +1201,7 @@ TEST(Cdna4ToCdna3DispatchTest, TritonFlashAttentionBufferAsyncDispatchAndRun) {
                  << "; CDNA4->CDNA3 dispatch verification requires an HSA-capable host";
   const HsaShutdownGuard shutdown;
 
-  Cdna3Target target = find_cdna3_target();
+  DispatchTarget target = find_cdna3_target();
   if (target.agent.handle == 0)
     GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
                  << join_seen_isas(target.seen_gpu_isas);

--- a/emulation/rocjitsu/tests/guest_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/guest_kfd_test.cpp
@@ -271,6 +271,15 @@ TEST(GuestKfdMemoryTest, GuestAllocationMmapOffsetIsRejected) {
   close(fd);
 }
 
+TEST(GuestKfdFailureTest, MissingSimulatorConfigFailsCleanly) {
+  errno = 0;
+  const int fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
+  EXPECT_EQ(fd, -1);
+  EXPECT_EQ(errno, ENODEV);
+  if (fd >= 0)
+    close(fd);
+}
+
 // Overwriting the interposer's hidden real /dev/kfd fd number via dup2 must not
 // leave a stale KFD classification behind. In guest/DBT mode open("/dev/kfd")
 // returns an app-facing dup while the real fd stays internal; if some dup2/dup3

--- a/emulation/rocjitsu/tests/guest_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/guest_kfd_test.cpp
@@ -13,9 +13,13 @@ RJ_DIAGNOSTIC_POP
 #include <cerrno>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <dirent.h>
 #include <fcntl.h>
+#include <filesystem>
+#include <fstream>
+#include <optional>
 #include <string>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
@@ -37,6 +41,72 @@ constexpr int kStressThreadCount = 8;
 constexpr int kStressIterations = 25;
 constexpr uint64_t kAllocVa = 0x1000000000ULL;
 constexpr uint64_t kAllocSize = 4096;
+
+std::optional<std::string> read_active_config_path() {
+  const char *runtime_dir = std::getenv("ROCJITSU_RUNTIME_DIR");
+  if (!runtime_dir || !*runtime_dir)
+    return std::nullopt;
+
+  std::ifstream active_config(std::filesystem::path(runtime_dir) / "config_path");
+  std::string configured_path;
+  if (!std::getline(active_config, configured_path) || configured_path.empty())
+    return std::nullopt;
+
+  return std::filesystem::absolute(configured_path).lexically_normal().string();
+}
+
+bool install_inline_dbt_config(const std::string &simulator_config, const char *host_isa,
+                               uint32_t lds_size_kb) {
+  const char *runtime_dir = std::getenv("ROCJITSU_RUNTIME_DIR");
+  if (!runtime_dir || !*runtime_dir)
+    return false;
+
+  try {
+    const std::filesystem::path runtime(runtime_dir);
+    std::filesystem::create_directories(runtime);
+    const std::filesystem::path config_path = runtime / "inline_dbt_failure_config.json";
+
+    std::ofstream config(config_path);
+    if (!config)
+      return false;
+    config << R"({
+  "dbt_guest": {
+    "enabled": true,
+    "guest_isa": "gfx950",
+    "host_isa": ")"
+           << host_isa << R"(",
+    "execution_backend": "simulator",
+    "simulator_config": ")"
+           << simulator_config << R"(",
+    "guest_device": {
+      "gpu_id": 38144,
+      "gfx_target_version": 90500,
+      "simd_count": 64,
+      "max_waves_per_simd": 8,
+      "num_shader_engines": 4,
+      "num_cu_per_sh": 4,
+      "simd_per_cu": 4,
+      "wave_front_size": 64,
+      "max_slots_scratch_cu": 32,
+      "lds_size_kb": )"
+           << lds_size_kb << R"(
+    }
+  }
+}
+)";
+    config.close();
+    if (!config)
+      return false;
+
+    std::ofstream active_config(runtime / "config_path");
+    if (!active_config)
+      return false;
+    active_config << config_path.string() << '\n';
+    return active_config.good();
+  } catch (const std::filesystem::filesystem_error &) {
+    return false;
+  }
+}
 
 bool read_gpu_id(const std::string &path, uint32_t *gpu_id) {
   FILE *file = fopen(path.c_str(), "r");
@@ -271,7 +341,39 @@ TEST(GuestKfdMemoryTest, GuestAllocationMmapOffsetIsRejected) {
   close(fd);
 }
 
-TEST(GuestKfdFailureTest, MissingSimulatorConfigFailsCleanly) {
+TEST(GuestKfdFailureTest, NonexistentSimulatorConfigFailsCleanly) {
+  const char *runtime_dir = std::getenv("ROCJITSU_RUNTIME_DIR");
+  ASSERT_NE(runtime_dir, nullptr);
+  const std::string nonexistent =
+      (std::filesystem::path(runtime_dir) / "nonexistent_simulator_config.json").string();
+  ASSERT_TRUE(install_inline_dbt_config(nonexistent, "gfx942", 64));
+
+  errno = 0;
+  const int fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
+  EXPECT_EQ(fd, -1);
+  EXPECT_EQ(errno, ENODEV);
+  if (fd >= 0)
+    close(fd);
+}
+
+TEST(GuestKfdFailureTest, SimulatorHostIsaMismatchFailsCleanly) {
+  const auto simulator_config = read_active_config_path();
+  ASSERT_TRUE(simulator_config.has_value());
+  ASSERT_TRUE(install_inline_dbt_config(*simulator_config, "gfx940", 64));
+
+  errno = 0;
+  const int fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
+  EXPECT_EQ(fd, -1);
+  EXPECT_EQ(errno, ENODEV);
+  if (fd >= 0)
+    close(fd);
+}
+
+TEST(GuestKfdFailureTest, SimulatorOversizedLdsFailsCleanly) {
+  const auto simulator_config = read_active_config_path();
+  ASSERT_TRUE(simulator_config.has_value());
+  ASSERT_TRUE(install_inline_dbt_config(*simulator_config, "gfx942", 65));
+
   errno = 0;
   const int fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
   EXPECT_EQ(fd, -1);

--- a/emulation/rocjitsu/tests/guest_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/guest_kfd_test.cpp
@@ -19,8 +19,11 @@ RJ_DIAGNOSTIC_POP
 #include <fcntl.h>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <optional>
+#include <sstream>
 #include <string>
+#include <string_view>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/wait.h>
@@ -42,7 +45,7 @@ constexpr int kStressIterations = 25;
 constexpr uint64_t kAllocVa = 0x1000000000ULL;
 constexpr uint64_t kAllocSize = 4096;
 
-std::optional<std::string> read_active_config_path() {
+std::optional<std::string> read_active_config_json() {
   const char *runtime_dir = std::getenv("ROCJITSU_RUNTIME_DIR");
   if (!runtime_dir || !*runtime_dir)
     return std::nullopt;
@@ -52,11 +55,14 @@ std::optional<std::string> read_active_config_path() {
   if (!std::getline(active_config, configured_path) || configured_path.empty())
     return std::nullopt;
 
-  return std::filesystem::absolute(configured_path).lexically_normal().string();
+  std::ifstream config(std::filesystem::absolute(configured_path).lexically_normal());
+  if (!config)
+    return std::nullopt;
+  return std::string(std::istreambuf_iterator<char>(config), std::istreambuf_iterator<char>());
 }
 
-bool install_inline_dbt_config(const std::string &simulator_config, const char *host_isa,
-                               uint32_t lds_size_kb) {
+bool install_inline_dbt_config(std::string simulator_json, const char *host_isa,
+                               uint32_t lds_size_kb, std::string_view external_host_config = {}) {
   const char *runtime_dir = std::getenv("ROCJITSU_RUNTIME_DIR");
   if (!runtime_dir || !*runtime_dir)
     return false;
@@ -66,18 +72,22 @@ bool install_inline_dbt_config(const std::string &simulator_config, const char *
     std::filesystem::create_directories(runtime);
     const std::filesystem::path config_path = runtime / "inline_dbt_failure_config.json";
 
-    std::ofstream config(config_path);
-    if (!config)
+    const size_t insert_pos = simulator_json.find('{');
+    if (insert_pos == std::string::npos)
       return false;
-    config << R"({
+    std::ostringstream dbt_guest;
+    dbt_guest << R"(
   "dbt_guest": {
     "enabled": true,
     "guest_isa": "gfx950",
     "host_isa": ")"
-           << host_isa << R"(",
-    "execution_backend": "simulator",
+              << host_isa << R"(",
+    "execution_backend": "simulator",)";
+    if (!external_host_config.empty())
+      dbt_guest << R"(
     "simulator_config": ")"
-           << simulator_config << R"(",
+                << external_host_config << R"(",)";
+    dbt_guest << R"(
     "guest_device": {
       "gpu_id": 38144,
       "gfx_target_version": 90500,
@@ -89,11 +99,15 @@ bool install_inline_dbt_config(const std::string &simulator_config, const char *
       "wave_front_size": 64,
       "max_slots_scratch_cu": 32,
       "lds_size_kb": )"
-           << lds_size_kb << R"(
+              << lds_size_kb << R"(
     }
-  }
-}
-)";
+  },)";
+    simulator_json.insert(insert_pos + 1, dbt_guest.str());
+
+    std::ofstream config(config_path);
+    if (!config)
+      return false;
+    config << simulator_json;
     config.close();
     if (!config)
       return false;
@@ -346,7 +360,7 @@ TEST(GuestKfdFailureTest, NonexistentSimulatorConfigFailsCleanly) {
   ASSERT_NE(runtime_dir, nullptr);
   const std::string nonexistent =
       (std::filesystem::path(runtime_dir) / "nonexistent_simulator_config.json").string();
-  ASSERT_TRUE(install_inline_dbt_config(nonexistent, "gfx942", 64));
+  ASSERT_TRUE(install_inline_dbt_config(R"({"max_ticks": 1})", "gfx942", 64, nonexistent));
 
   errno = 0;
   const int fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
@@ -357,9 +371,9 @@ TEST(GuestKfdFailureTest, NonexistentSimulatorConfigFailsCleanly) {
 }
 
 TEST(GuestKfdFailureTest, SimulatorHostIsaMismatchFailsCleanly) {
-  const auto simulator_config = read_active_config_path();
-  ASSERT_TRUE(simulator_config.has_value());
-  ASSERT_TRUE(install_inline_dbt_config(*simulator_config, "gfx940", 64));
+  const auto simulator_json = read_active_config_json();
+  ASSERT_TRUE(simulator_json.has_value());
+  ASSERT_TRUE(install_inline_dbt_config(*simulator_json, "gfx940", 64));
 
   errno = 0;
   const int fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
@@ -370,9 +384,9 @@ TEST(GuestKfdFailureTest, SimulatorHostIsaMismatchFailsCleanly) {
 }
 
 TEST(GuestKfdFailureTest, SimulatorOversizedLdsFailsCleanly) {
-  const auto simulator_config = read_active_config_path();
-  ASSERT_TRUE(simulator_config.has_value());
-  ASSERT_TRUE(install_inline_dbt_config(*simulator_config, "gfx942", 65));
+  const auto simulator_json = read_active_config_json();
+  ASSERT_TRUE(simulator_json.has_value());
+  ASSERT_TRUE(install_inline_dbt_config(*simulator_json, "gfx942", 65));
 
   errno = 0;
   const int fd = open(kKfdPath, O_RDWR | O_CLOEXEC);

--- a/emulation/rocjitsu/tests/simulated_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/simulated_kfd_test.cpp
@@ -11,6 +11,12 @@
 #include "rocjitsu/vm/rj_vm_impl.h"
 #include "rocjitsu/vm/virtual_machine.h"
 
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "linux/uapi/kfd_ioctl.h"
+RJ_DIAGNOSTIC_POP
+
 #include "embedded_schema.h"
 #include "simdojo/sim/simulation.h"
 
@@ -123,6 +129,68 @@ TEST_F(SimulatedKfdTest, GuestDiscoveryOpenIsReleasedOnLastClose) {
     EXPECT_EQ(execution_driver->local_open_ref_count(), 0u)
         << "last guest close must release the simulated process";
   }
+}
+
+TEST_F(SimulatedKfdTest, GuestOpenSurvivesExecutionPrimaryOverwrite) {
+  rj_vm_t *raw_vm = nullptr;
+  ASSERT_EQ(rj_vm_create(CONFIG_PATH.c_str(), RJ_VM_MODE_LOCAL, &raw_vm), ROCJITSU_STATUS_SUCCESS);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> vm(raw_vm, &rj_vm_destroy);
+  ASSERT_NE(vm, nullptr);
+  ASSERT_NE(vm->vm, nullptr);
+  auto *execution_driver = vm->vm->driver();
+  ASSERT_NE(execution_driver, nullptr);
+  ASSERT_EQ(execution_driver->local_open_ref_count(), 1u);
+
+  rocjitsu::config::DbtGuestConfig config;
+  config.enabled = true;
+  config.guest_isa = "gfx950";
+  config.host_isa = "gfx950";
+  config.host_gpu_id = execution_driver->gpu_id();
+  config.execution_backend = rocjitsu::config::DbtExecutionBackend::Simulator;
+  config.guest_device = vm->loaded.device;
+  config.guest_device.gpu_id += 1;
+  config.guest_device.drm_render_minor += 1;
+
+  rocjitsu::GuestKfd guest(std::move(config), execution_driver);
+  ASSERT_TRUE(guest.prepare_for_discovery());
+  const int app_fd = guest.open();
+  ASSERT_GE(app_fd, 0);
+  ASSERT_EQ(execution_driver->local_open_ref_count(), 1u);
+  const uint32_t process_id = execution_driver->local_process_id();
+
+  const int hidden_fd = execution_driver->fd();
+  ASSERT_GE(hidden_fd, 0);
+  int pipefd[2];
+  ASSERT_EQ(::pipe(pipefd), 0);
+  ASSERT_EQ(::dup2(pipefd[0], hidden_fd), hidden_fd);
+  ASSERT_EQ(::close(pipefd[0]), 0);
+
+  EXPECT_EQ(guest.invalidate_primary_fd(hidden_fd),
+            rocjitsu::LinuxKfd::PrimaryInvalidation::kClearedKeepRefs);
+  EXPECT_EQ(execution_driver->fd(), -1);
+  EXPECT_EQ(execution_driver->local_open_ref_count(), 1u)
+      << "hidden-fd overwrite must not release GuestKfd's backend open";
+  EXPECT_EQ(execution_driver->local_process_id(), process_id);
+
+  kfd_ioctl_get_version_args version{};
+  EXPECT_EQ(guest.ioctl(AMDKFD_IOC_GET_VERSION, &version), 0)
+      << "the surviving app open must keep the simulated process usable";
+
+  const int reopened_fd = guest.open();
+  ASSERT_GE(reopened_fd, 0);
+  EXPECT_EQ(execution_driver->local_open_ref_count(), 1u)
+      << "re-minting the simulator primary must not leak another backend open";
+  EXPECT_EQ(execution_driver->local_process_id(), process_id);
+
+  EXPECT_EQ(::close(reopened_fd), 0);
+  EXPECT_EQ(guest.close(), 0);
+  EXPECT_EQ(execution_driver->local_open_ref_count(), 1u);
+  EXPECT_EQ(::close(app_fd), 0);
+  EXPECT_EQ(guest.close(), 0);
+  EXPECT_EQ(execution_driver->local_open_ref_count(), 0u);
+
+  EXPECT_EQ(::close(hidden_fd), 0);
+  EXPECT_EQ(::close(pipefd[1]), 0);
 }
 
 TEST_F(SimulatedKfdTest, TopologyDirectoryExists) {

--- a/emulation/rocjitsu/tests/simulated_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/simulated_kfd_test.cpp
@@ -5,7 +5,10 @@
 /// @brief Tests for SimulatedKfd creation, open/close, and topology generation.
 
 #include "rocjitsu/config/config_loader.h"
+#include "rocjitsu/kmd/linux/guest_kfd.h"
 #include "rocjitsu/kmd/linux/simulated_kfd.h"
+#include "rocjitsu/vm/rj_vm.h"
+#include "rocjitsu/vm/rj_vm_impl.h"
 #include "rocjitsu/vm/virtual_machine.h"
 
 #include "embedded_schema.h"
@@ -24,6 +27,8 @@ RJ_DIAGNOSTIC_POP
 #include <filesystem>
 #include <thread>
 #include <vector>
+
+#include <unistd.h>
 
 namespace {
 
@@ -81,6 +86,43 @@ TEST_F(SimulatedKfdTest, OpenAndClose) {
 
   int ret = t.driver()->close();
   EXPECT_EQ(ret, 0);
+}
+
+TEST_F(SimulatedKfdTest, GuestDiscoveryOpenIsReleasedOnLastClose) {
+  rj_vm_t *raw_vm = nullptr;
+  ASSERT_EQ(rj_vm_create(CONFIG_PATH.c_str(), RJ_VM_MODE_LOCAL, &raw_vm), ROCJITSU_STATUS_SUCCESS);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> vm(raw_vm, &rj_vm_destroy);
+  ASSERT_NE(vm, nullptr);
+  ASSERT_NE(vm->vm, nullptr);
+  auto *execution_driver = vm->vm->driver();
+  ASSERT_NE(execution_driver, nullptr);
+  ASSERT_EQ(execution_driver->local_open_ref_count(), 1u)
+      << "RJ_VM_MODE_LOCAL must provide the bootstrap open adopted by GuestKfd";
+
+  rocjitsu::config::DbtGuestConfig config;
+  config.enabled = true;
+  config.guest_isa = "gfx950";
+  config.host_isa = "gfx950";
+  config.host_gpu_id = execution_driver->gpu_id();
+  config.execution_backend = rocjitsu::config::DbtExecutionBackend::Simulator;
+  config.guest_device = vm->loaded.device;
+  config.guest_device.gpu_id += 1;
+  config.guest_device.drm_render_minor += 1;
+
+  rocjitsu::GuestKfd guest(std::move(config), execution_driver);
+  for (int cycle = 0; cycle < 2; ++cycle) {
+    ASSERT_TRUE(guest.prepare_for_discovery());
+
+    const int app_fd = guest.open();
+    ASSERT_GE(app_fd, 0);
+    EXPECT_EQ(execution_driver->local_open_ref_count(), 1u)
+        << "application open must reuse the discovery-owned reference";
+
+    EXPECT_EQ(::close(app_fd), 0);
+    EXPECT_EQ(guest.close(), 0);
+    EXPECT_EQ(execution_driver->local_open_ref_count(), 0u)
+        << "last guest close must release the simulated process";
+  }
 }
 
 TEST_F(SimulatedKfdTest, TopologyDirectoryExists) {

--- a/emulation/rocjitsu/tests/simulated_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/simulated_kfd_test.cpp
@@ -108,9 +108,9 @@ TEST_F(SimulatedKfdTest, GuestDiscoveryOpenIsReleasedOnLastClose) {
   rocjitsu::config::DbtGuestConfig config;
   config.enabled = true;
   config.guest_isa = "gfx950";
-  config.host_isa = "gfx950";
-  config.host_gpu_id = execution_driver->gpu_id();
-  config.execution_backend = rocjitsu::config::DbtExecutionBackend::Simulator;
+  config.host.isa = "gfx950";
+  config.host.gpu_id = execution_driver->gpu_id();
+  config.host.backend = rocjitsu::config::DbtExecutionBackend::Simulator;
   config.guest_device = vm->loaded.device;
   config.guest_device.gpu_id += 1;
   config.guest_device.drm_render_minor += 1;
@@ -144,9 +144,9 @@ TEST_F(SimulatedKfdTest, GuestOpenSurvivesExecutionPrimaryOverwrite) {
   rocjitsu::config::DbtGuestConfig config;
   config.enabled = true;
   config.guest_isa = "gfx950";
-  config.host_isa = "gfx950";
-  config.host_gpu_id = execution_driver->gpu_id();
-  config.execution_backend = rocjitsu::config::DbtExecutionBackend::Simulator;
+  config.host.isa = "gfx950";
+  config.host.gpu_id = execution_driver->gpu_id();
+  config.host.backend = rocjitsu::config::DbtExecutionBackend::Simulator;
   config.guest_device = vm->loaded.device;
   config.guest_device.gpu_id += 1;
   config.guest_device.drm_render_minor += 1;

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -496,11 +496,11 @@ std::vector<KfdGpuOrdinal> real_kfd_gpu_ordinals() {
 /// the config to name the shared KFD gpu_id so every layer routes to the same
 /// physical GPU.
 bool has_unambiguous_host_gpu(const rocjitsu::config::DbtGuestConfig &dbt_guest) {
-  if (dbt_guest.host_gpu_id != 0)
+  if (dbt_guest.host.gpu_id != 0)
     return true;
 
   std::optional<uint32_t> target_version =
-      rocjitsu::kmd::gfx_target_version_from_name(dbt_guest.host_isa);
+      rocjitsu::kmd::gfx_target_version_from_name(dbt_guest.host.isa);
   if (!target_version)
     return true;
 
@@ -514,7 +514,7 @@ bool has_unambiguous_host_gpu(const rocjitsu::config::DbtGuestConfig &dbt_guest)
 
   std::cerr << std::format(
       "rocjitsu: dbt_guest.host_isa '{}' matches {} host GPUs; set host_gpu_id to one of:",
-      dbt_guest.host_isa, matching_gpu_ids.size());
+      dbt_guest.host.isa, matching_gpu_ids.size());
   for (uint32_t gpu_id : matching_gpu_ids)
     std::cerr << ' ' << gpu_id;
   std::cerr << '\n';
@@ -550,16 +550,16 @@ void maybe_expand_rocr_visible_devices(const rocjitsu::config::DbtGuestConfig &d
     return;
 
   uint32_t host_ordinal = 0;
-  if (dbt_guest.host_gpu_id != 0) {
+  if (dbt_guest.host.gpu_id != 0) {
     auto match = std::find_if(gpus.begin(), gpus.end(), [&](const KfdGpuOrdinal &gpu) {
-      return gpu.gpu_id == dbt_guest.host_gpu_id;
+      return gpu.gpu_id == dbt_guest.host.gpu_id;
     });
     if (match == gpus.end())
       return;
     host_ordinal = match->ordinal;
   } else {
     std::optional<uint32_t> target_version =
-        rocjitsu::kmd::gfx_target_version_from_name(dbt_guest.host_isa);
+        rocjitsu::kmd::gfx_target_version_from_name(dbt_guest.host.isa);
     if (!target_version)
       return;
 
@@ -703,7 +703,7 @@ int main(int argc, char *argv[]) {
 
   std::string hooks_path;
   if (dbt_guest_mode) {
-    if (dbt_guest_config.guest_isa.empty() || dbt_guest_config.host_isa.empty()) {
+    if (dbt_guest_config.guest_isa.empty() || dbt_guest_config.host.isa.empty()) {
       std::cerr << "rocjitsu: dbt_guest requires guest_isa and host_isa\n";
       return 1;
     }


### PR DESCRIPTION
## Motivation

This is so that we can develop and test DBT on systems without the target HW. It's also surprisingly good for testing both the DBT (since the simulator is often less forgiving than the real hw) and the simulator (since DBT often exercises rare ASM patterns).

Add a simulator-backed execution mode for DBT guests, allowing CDNA4 (gfx950) code to be translated to CDNA3 (gfx942) and executed without physical CDNA3 hardware.

## Technical Details

- Add hardware and simulator DBT execution backends, including simulator-config validation and relative path resolution.
- Connect GuestKfd to SimulatedKfd, exposing a synthetic gfx950 guest while executing translated code on simulated gfx942.
- Correctly manage the simulator’s bootstrap KFD open across guest discovery, application opens, closes, and teardown.
- Add clean failure handling for missing simulator configurations.
- Register simulator-backed CDNA4->CDNA3 tests by default while retaining hardware-backed tests when a CDNA3 GPU is detected.
- Add end-to-end coverage through the public DBT guest path for dynamic copy, Triton matmul, and flash-attention kernels

## JIRA ID

N/A

## Test Plan

New unit and e2e tests. I also tested this on many kernel libraries and iree on the gx1250->rdna4 dbt path.

## Test Result

All good.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
