### PR TITLE
fix(rocr): Destroy GWS queue before agent resource teardown

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1038,6 +1038,15 @@ void GpuAgent::ReleaseResources() {
   if (this->Enabled()) {
     this->Disable();
 
+    // Destroy the persistent GWS/cooperative queue before tearing down
+    // resources. Otherwise ~AqlQueue may run later and store to a freed
+    // queue_inactive_signal.
+    {
+      std::lock_guard<std::mutex> lock(gws_queue_.lock_);
+      gws_queue_.queue_.reset();
+      gws_queue_.ref_ct_ = 0;
+    }
+
     // Remove all shared hardware queues from pool
     queue_pool_.Cleanup();
 


### PR DESCRIPTION
## Summary
Destroy the persistent GWS/cooperative queue during `GpuAgent::ReleaseResources()` instead of leaving it to be destroyed later during agent teardown.

This prevents a shutdown-time use-after-free when a cooperative queue survives until `hsa_shut_down()`. In that case, `Runtime::Unload()` may clear shared signal resources before `Runtime::DestroyAgents()` destroys the GpuAgent, causing `AqlQueue::~AqlQueue()` to store to a freed queue_inactive_signal.

## Motivation (Where this was found)
This was found while enabling a JAX/XLA function with cooperative kernels in ROCm. The computation completes successfully, but the process segfaults later during Python shutdown.

A simple standalone HIP program that launches a cooperative kernel did not reproduce the issue. That appears to be because the simple HIP application follows a different teardown path and does not leave the persistent cooperative/GWS queue alive long enough until ROCR shutdown.

The JAX/XLA plugin path is different: XLA owns ROCm executors, streams, and plugin-global state, and those objects are torn down during Python/module shutdown. That lifetime shape can leave the runtime-owned cooperative/GWS queue alive until hsa_shut_down(), exposing a bad ordering inside ROCR shutdown.

The invalid access itself occurs entirely inside ROCR/HIP shutdown, not inside JAX/XLA.

Backtrace:
```
Thread 1 "python3" received signal SIGSEGV, Segmentation fault.
#0  rocr::HSA::hsa_signal_store_screlease(hsa_signal_s, long)
#1  rocr::AMD::AqlQueue::~AqlQueue()
#2  rocr::AMD::AqlQueue::~AqlQueue()
#3  rocr::AMD::GpuAgent::~GpuAgent()
#4  rocr::AMD::GpuAgent::~GpuAgent()
#5  rocr::core::Runtime::DestroyAgents()
#6  rocr::core::Runtime::Unload()
#7  rocr::core::Runtime::Release()
#8  rocr::HSA::hsa_shut_down()
#9  libamdhip64.so.7
#10 libamdhip64.so.7
#11 __run_exit_handlers
```

## Details
A cooperative/GWS queue is owned by `GpuAgent::gws_queue_` and can remain alive until runtime shutdown. Currently, if it is still present when agents are destroyed, its AqlQueue destructor runs from the GpuAgent destructor path.

```
Runtime::Unload()
  ...
  SharedSignalPool.clear()
  EventPool.clear()
  system_regions_fine_.clear()
  system_regions_coarse_.clear()
  DestroyAgents()
    GpuAgent::~GpuAgent()
      AqlQueue::~AqlQueue()
```
`AqlQueue::~AqlQueue()` stores to `amd_queue_.queue_inactive_signal`. If the shared signal backing has already been cleared, this can segfault during process exit.

This change resets `gws_queue_.queue_` from `GpuAgent::ReleaseResources()`, before `Runtime::Unload()` clears shared signal resources. The queue destructor therefore runs while the resources it depends on are still valid.

The GWS queue lock is held while resetting queue_ and ref_ct_, matching the existing synchronization used by the cooperative queue acquire/release path.

## Testing
A stand alone unit test to address this is very difficult as the failure depends on full process/runtime shutdown ordering: HIP/ROCR atexit handling, cooperative/GWS queue lifetime, async signal handler teardown, shared signal pool teardown, and agent destruction during `hsa_shut_down()`. The issue is not reproducible as a small in-process unit test. Instead, it needs to be invoked through a cooperative kernel launched through a larger framework like JAX/XLA (that is also how I verified that the patch in this PR works).