### PR TITLE
ROCM-1028 - Toggle L2 Cache of pinned host buffer on device.

### DIFF
--- a/projects/clr/rocclr/device/pal/palresource.cpp
+++ b/projects/clr/rocclr/device/pal/palresource.cpp
@@ -1133,6 +1133,12 @@ bool Resource::CreatePinned(CreateParams* params) {
   createInfo.pSysMem = pinAddress;
   createInfo.size = allocSize;
   createInfo.vaRange = Pal::VaRange::Default;
+  // Fine-grain pinning requires bypassing GPU L2 for CPU-GPU coherency.
+  // Coarse-grain (hipExtHostRegisterCoarseGrained, no CL_MEM_SVM_ATOMICS) leaves gl2Uncached=0,
+  // so the GPU can cache in L2; explicit sync is the caller's responsibility.
+  if ((params->owner_ != nullptr) && (params->owner_->getMemFlags() & CL_MEM_SVM_ATOMICS)) {
+    createInfo.flags.gl2Uncached = 1;
+  }
   memRef_ = GpuMemoryReference::Create(dev(), createInfo);
   if (nullptr == memRef_) {
     LogError("Failed PAL memory allocation!");

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -400,7 +400,10 @@ memory:
   Unit_hipHostRegister_DuplicateAndDisjoint:
     <<: *level_2
     tags: [alloc]
-  Unit_hipHostRegister_with_hipExtHostRegisterCoarseGrained:
+  Unit_hipHostRegister_with_coarse_grain:
+    <<: *level_2
+    tags: [alloc]
+  Unit_hipHostRegister_with_fine_grain:
     <<: *level_2
     tags: [alloc]
   Unit_hipHostRegister_Capture:

--- a/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
@@ -42,7 +42,7 @@ __global__ void AtomicFAddKernelKernel(float* data, size_t n) {
   size_t i = blockDim.x * blockIdx.x + threadIdx.x;
   if (i < n) {
 #if __has_builtin(__builtin_amdgcn_global_atomic_fadd_f32)
-    __builtin_amdgcn_global_atomic_fadd_f32(data, 1.0f);  // Only work on coarse grained buffer
+    __builtin_amdgcn_global_atomic_fadd_f32(data, 1.0f);
 #else
     if (i == 0) {
       *data = -1.0;
@@ -862,7 +862,7 @@ HIP_TEST_CASE(Unit_hipHostRegister_Capture) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEST_CASE(Unit_hipHostRegister_with_hipExtHostRegisterCoarseGrained) {
+HIP_TEST_CASE(Unit_hipHostRegister_with_coarse_grain) {
 #if HT_AMD
   const size_t count = 65536;
   const size_t threadsPerBlock = 64;
@@ -878,7 +878,8 @@ HIP_TEST_CASE(Unit_hipHostRegister_with_hipExtHostRegisterCoarseGrained) {
   HIP_CHECK(hipHostUnregister(hostPtr));
   std::cout << "hostPtr=" << hostPtr << ", devicePtr=" << devicePtr << std::endl;
   if (*hostPtr == static_cast<float>(count)) {
-    std::cout << "__builtin_amdgcn_global_atomic_fadd_f32 works well!" << std::endl;
+    std::cout << "__builtin_amdgcn_global_atomic_fadd_f32 works well on coarse grain!"
+              << std::endl;
     REQUIRE(true);
   } else if (*hostPtr == -1.0f) {
     std::cout << "__builtin_amdgcn_global_atomic_fadd_f32 not supported!" << std::endl;
@@ -891,6 +892,74 @@ HIP_TEST_CASE(Unit_hipHostRegister_with_hipExtHostRegisterCoarseGrained) {
 #endif
 }
 
+/**
+ * Test Description
+ * ------------------------
+ *    - This testcase verifies hipHostRegisterDefault (fine-grain) flags of hipHostRegister
+ *    - with __builtin_amdgcn_global_atomic_fadd_f32.
+ *    - The builtin hardcodes agent scope. Behavior varies by chip:
+ *    - * Chips with AgentScopeFineGrainedRemoteMemoryAtomics (gfx942, gfx945, gfx950, GFX12+):
+ *    -   native global_atomic_add_f32 at agent scope is coherent on fine-grain host memory;
+ *    -   atomic succeeds and hostPtr equals count.
+ *    - * Chips without the native instruction (GFX9 consumer, GFX10):
+ *    -   backend expands to a CAS loop; global_atomic_cmpswap is PCIe-native so it
+ *    -   works on fine-grain host memory; atomic succeeds and hostPtr equals count.
+ *    - * Chips with the native instruction but without AgentScopeFineGrainedRemoteMemoryAtomics
+ *    -   (gfx908, gfx90a, GFX11): agent-scope coherency on PCIe host memory is not
+ *    -   guaranteed; result may be a partial sum.
+ * Test source
+ * ------------------------
+ *    - catch\unit\memory\hipHostRegister.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 5.2
+ */
+HIP_TEST_CASE(Unit_hipHostRegister_with_fine_grain) {
+#if HT_AMD
+  const size_t count = 65536;
+  const size_t threadsPerBlock = 64;
+  size_t sizeBytes = sizeof(float);
+  float* hostPtr = reinterpret_cast<float*>(malloc(sizeBytes));
+  float* devicePtr = nullptr;
+  *hostPtr = 0;
+  HIP_CHECK(hipHostRegister(hostPtr, sizeBytes, hipHostRegisterDefault));
+  HIP_CHECK(hipHostGetDevicePointer(reinterpret_cast<void**>(&devicePtr), hostPtr, 0));
+  AtomicFAddKernelKernel<<<(count + threadsPerBlock - 1) / threadsPerBlock, threadsPerBlock>>>(
+      devicePtr, count);
+  HIP_CHECK(hipDeviceSynchronize());
+  HIP_CHECK(hipHostUnregister(hostPtr));
+  std::cout << "hostPtr=" << hostPtr << ", devicePtr=" << devicePtr << std::endl;
+
+  hipDeviceProp_t prop;
+  HIP_CHECK(hipGetDeviceProperties(&prop, 0));
+  std::string archName(prop.gcnArchName);
+  // Chips with native global_atomic_add_f32 but without
+  // AgentScopeFineGrainedRemoteMemoryAtomics: agent-scope coherency on PCIe
+  // host memory is not guaranteed, so a partial/racy result is acceptable.
+  const bool partialResultExpected =
+      archName.find("gfx908") != std::string::npos ||
+      archName.find("gfx90a") != std::string::npos ||
+      archName.find("gfx11") != std::string::npos;
+
+  if (*hostPtr == static_cast<float>(count)) {
+    // Atomic succeeded: either via native global_atomic_add_f32 (chips with
+    // AgentScopeFineGrainedRemoteMemoryAtomics) or via CAS loop expansion
+    // (all other chips, since global_atomic_cmpswap is PCIe-native).
+    std::cout << "__builtin_amdgcn_global_atomic_fadd_f32 succeeded on fine grain!"
+              << std::endl;
+    REQUIRE(true);
+  } else if (*hostPtr == -1.0f) {
+    std::cout << "__builtin_amdgcn_global_atomic_fadd_f32 not supported!" << std::endl;
+    REQUIRE(true);
+  } else {
+    // Partial/racy result: only expected on chips where agent-scope coherency
+    // on PCIe host memory is not guaranteed (gfx908, gfx90a, GFX11 discrete).
+    std::cout << count << " -> " << *hostPtr << std::endl;
+    REQUIRE(partialResultExpected);
+  }
+  free(hostPtr);
+#endif
+}
 /**
  * End doxygen group MemoryTest.
  * @}

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
@@ -784,7 +784,7 @@ hsaKmtMapMemoryToGPUNodes(
     void*           MemoryAddress,         //IN (page-aligned)
     HSAuint64       MemorySizeInBytes,     //IN (page-aligned)
     HSAuint64*      AlternateVAGPU,        //OUT (page-aligned)
-    HsaMemMapFlags  MemMapFlags,           //IN
+    HsaMemFlags     MemFlags,              //IN
     HSAuint64       NumberOfNodes,         //IN
     HSAuint32*      NodeArray              //IN
     );

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt_virtio.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt_virtio.h
@@ -47,7 +47,7 @@ HSAKMT_STATUS HSAKMTAPI vhsaKmtAllocMemoryAlign(HSAuint32 PreferredNode, HSAuint
 HSAKMT_STATUS HSAKMTAPI vhsaKmtFreeMemory(void* MemoryAddress, HSAuint64 SizeInBytes);
 HSAKMT_STATUS HSAKMTAPI vhsaKmtMapMemoryToGPUNodes(void* MemoryAddress, HSAuint64 MemorySizeInBytes,
                                                    HSAuint64* AlternateVAGPU,
-                                                   HsaMemMapFlags MemMapFlags,
+                                                   HsaMemFlags MemFlags,
                                                    HSAuint64 NumberOfNodes, HSAuint32* NodeArray);
 HSAKMT_STATUS HSAKMTAPI vhsaKmtUnmapMemoryToGPU(void* MemoryAddress);
 HSAKMT_STATUS HSAKMTAPI vhsaKmtAvailableMemory(HSAuint32 Node, HSAuint64* AvailableBytes);

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmtctx.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmtctx.h
@@ -681,7 +681,7 @@ hsaKmtMapMemoryToGPUNodesCtx(
     void*             MemoryAddress,         //IN (page-aligned)
     HSAuint64         MemorySizeInBytes,     //IN (page-aligned)
     HSAuint64*        AlternateVAGPU,        //OUT (page-aligned)
-    HsaMemMapFlags    MemMapFlags,           //IN
+    HsaMemFlags       MemFlags,              //IN
     HSAuint64         NumberOfNodes,         //IN
     HSAuint32*        NodeArray              //IN
     );

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
@@ -608,35 +608,6 @@ typedef struct _HsaMemFlags
     };
 } HsaMemFlags;
 
-typedef struct _HsaMemMapFlags
-{
-    union
-    {
-        struct
-        {
-            unsigned int Reserved1      :  1; //
-            unsigned int CachePolicy    :  2; // see HSA_CACHING_TYPE
-            unsigned int ReadOnly       :  1; // memory is not modified while mapped
-            	    	    	    	      // allows migration scale-out
-	    unsigned int PageSize	    :  2; // see HSA_PAGE_SIZE, hint to use
-					  // this page size if possible and
-					  // smaller than default
-	    unsigned int HostAccess     :  1; // default = 0: GPU access only
-	    unsigned int Migrate        :  1; // Hint: Allows migration to local mem
-						  // of mapped GPU(s), instead of mapping
-						  // physical location
-            unsigned int Probe          :  1;     // default = 0: Indicates that a range
-                                                  // will be mapped by the process soon,
-						  // but does not initiate a map operation
-						  // may trigger eviction of nonessential
-						  // data from the memory, reduces latency
-						  // “cleanup hint” only, may be ignored
-            unsigned int Reserved       : 23;
-        } ui32;
-        HSAuint32 Value;
-    };
-} HsaMemMapFlags;
-
 typedef struct _HsaGraphicsResourceInfo {
     void       *MemoryAddress;      // For use in hsaKmtMapMemoryToGPU(Nodes)
     HSAuint64  SizeInBytes;         // Buffer size (OUT)

--- a/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
@@ -809,15 +809,17 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMapMemoryToGPU(void *MemoryAddress,
 
   HSAuint64 NumberOfNodes = 1;
   HSAuint32 NodeArray[] = {dxg_runtime->default_node};
-  HsaMemMapFlags MemMapFlags;
-  MemMapFlags.Value = 0;
+  HsaMemFlags MemFlags;
+  MemFlags.Value = 0;
+  MemFlags.ui32.CoarseGrain = 1;
 
   return hsaKmtMapMemoryToGPUNodes(MemoryAddress, MemorySizeInBytes, AlternateVAGPU,
-    MemMapFlags, NumberOfNodes, NodeArray);
+    MemFlags, NumberOfNodes, NodeArray);
 }
+
 HSAKMT_STATUS HSAKMTAPI hsaKmtMapMemoryToGPUNodes(
     void *MemoryAddress, HSAuint64 MemorySizeInBytes, HSAuint64 *AlternateVAGPU,
-    HsaMemMapFlags MemMapFlags, HSAuint64 NumberOfNodes, HSAuint32 *NodeArray) {
+    HsaMemFlags MemFlags, HSAuint64 NumberOfNodes, HSAuint32 *NodeArray) {
   CHECK_DXG_OPEN();
 
   if (!MemoryAddress || !AlternateVAGPU) {
@@ -900,7 +902,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMapMemoryToGPUNodes(
   create_info.size = aligned_size;
   create_info.user_ptr = aligned_ptr;
   // create_info.mem_flags = 0 means coarse grain by default
-  if (MemMapFlags.ui32.CachePolicy == HSA_CACHING_NONCACHED) {
+  if (!MemFlags.ui32.CoarseGrain) {
     create_info.mem_flags = Wkmi::kFineGrain;
   }
   auto code = dev->CreateGpuMemory(create_info, &gpu_mem);

--- a/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
@@ -899,7 +899,10 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMapMemoryToGPUNodes(
   create_info.domain = Wkmi::kUserMemory;
   create_info.size = aligned_size;
   create_info.user_ptr = aligned_ptr;
-
+  // create_info.mem_flags = 0 means coarse grain by default
+  if (MemMapFlags.ui32.CachePolicy == HSA_CACHING_NONCACHED) {
+    create_info.mem_flags = Wkmi::kFineGrain;
+  }
   auto code = dev->CreateGpuMemory(create_info, &gpu_mem);
   if (code == ErrorCode::Success) {
     addr = gpu_mem->GpuAddress();

--- a/projects/rocr-runtime/libhsakmt/src/memory.c
+++ b/projects/rocr-runtime/libhsakmt/src/memory.c
@@ -543,7 +543,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMapMemoryToGPUNodesCtx(HsaKFDContext *ctx,
 						  void *MemoryAddress,
 						  HSAuint64 MemorySizeInBytes,
 						  HSAuint64 *AlternateVAGPU,
-						  HsaMemMapFlags MemMapFlags,
+						  HsaMemFlags MemFlags,
 						  HSAuint64 NumberOfNodes,
 						  HSAuint32 *NodeArray)
 {
@@ -880,12 +880,12 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMapMemoryToGPUNodes(
 					  void *MemoryAddress,
 					  HSAuint64 MemorySizeInBytes,
 					  HSAuint64 *AlternateVAGPU,
-					  HsaMemMapFlags MemMapFlags,
+					  HsaMemFlags MemFlags,
 					  HSAuint64 NumberOfNodes,
 					  HSAuint32 *NodeArray)
 {
 	return hsaKmtMapMemoryToGPUNodesCtx(&hsakmt_primary_kfd_ctx, MemoryAddress,
-				MemorySizeInBytes, AlternateVAGPU, MemMapFlags, NumberOfNodes, NodeArray);
+				MemorySizeInBytes, AlternateVAGPU, MemFlags, NumberOfNodes, NodeArray);
 }
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtUnmapMemoryToGPU(void *MemoryAddress)

--- a/projects/rocr-runtime/libhsakmt/src/queues.c
+++ b/projects/rocr-runtime/libhsakmt/src/queues.c
@@ -456,10 +456,9 @@ void *hsakmt_allocate_exec_aligned_memory_gpu(HsaKFDContext *ctx,
 
 	if (NodeId != 0) {
 		uint32_t nodes_array[1] = {NodeId};
-		HsaMemMapFlags map_flags = {0};
 		HSAKMT_STATUS result;
 
-		result = hsaKmtMapMemoryToGPUNodesCtx(ctx, mem, size, &gpu_va, map_flags, 1, nodes_array);
+		result = hsaKmtMapMemoryToGPUNodesCtx(ctx, mem, size, &gpu_va, flags, 1, nodes_array);
 		if (result != HSAKMT_STATUS_SUCCESS) {
 			hsaKmtFreeMemoryCtx(ctx, mem, size);
 			return NULL;

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_memory.c
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_memory.c
@@ -412,7 +412,7 @@ HSAKMT_STATUS HSAKMTAPI vhsaKmtFreeMemory(void* MemoryAddress, HSAuint64 SizeInB
 
 HSAKMT_STATUS HSAKMTAPI vhsaKmtMapMemoryToGPUNodes(void* MemoryAddress, HSAuint64 MemorySizeInBytes,
                                                    HSAuint64* AlternateVAGPU,
-                                                   HsaMemMapFlags MemMapFlags,
+                                                   HsaMemFlags MemFlags,
                                                    HSAuint64 NumberOfNodes, HSAuint32* NodeArray) {
   CHECK_VIRTIO_KFD_OPEN();
 
@@ -429,7 +429,6 @@ HSAKMT_STATUS HSAKMTAPI vhsaKmtMapMemoryToGPUNodes(void* MemoryAddress, HSAuint6
   req->hdr = VHSAKMT_CCMD(MEMORY, req_len);
   req->type = VHSAKMT_CCMD_MEMORY_MAP_TO_GPU_NODES;
   req->map_to_GPU_nodes_args.MemorySizeInBytes = MemorySizeInBytes;
-  req->map_to_GPU_nodes_args.MemMapFlags = MemMapFlags;
   req->map_to_GPU_nodes_args.NumberOfNodes = NumberOfNodes;
 
   bo = vhsakmt_find_bo_by_addr(dev, MemoryAddress);

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_proto.h
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_proto.h
@@ -397,7 +397,6 @@ typedef struct _memory_req_map_to_GPU_nodes_args {
   uint64_t MemoryAddress;
   uint64_t MemorySizeInBytes;
   uint64_t AlternateVAGPU;
-  HsaMemMapFlags MemMapFlags;
   uint32_t pad;
   uint64_t NumberOfNodes;
   uint32_t* NodeArray;

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDEvictTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDEvictTest.cpp
@@ -63,10 +63,8 @@ void KFDEvictTest::AllocBuffers(bool m_IsParent, HSAuint32 defaultGPUNode, HSAui
               << totalMB << ")MB VRAM in KFD" << std::endl;
     }
 
-    HsaMemMapFlags mapFlags = {0};
-    HSAKMT_STATUS ret;
+    HSAKMT_STATUS ret = 0;
     HSAuint32 retry = 0;
-
     m_Flags.Value = 0;
     m_Flags.ui32.PageSize = HSA_PAGE_SIZE_4KB;
     m_Flags.ui32.HostAccess = 0;
@@ -77,7 +75,7 @@ void KFDEvictTest::AllocBuffers(bool m_IsParent, HSAuint32 defaultGPUNode, HSAui
         if (ret == HSAKMT_STATUS_SUCCESS) {
             if (hsakmt_is_dgpu()) {
                 if (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, m_pBuf, vramBufSize, NULL,
-                       mapFlags, 1, reinterpret_cast<HSAuint32 *>(&defaultGPUNode)) == HSAKMT_STATUS_ERROR) {
+                       m_Flags, 1, reinterpret_cast<HSAuint32 *>(&defaultGPUNode)) == HSAKMT_STATUS_ERROR) {
                     EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, m_pBuf, vramBufSize));
                     LOG() << "Map failed for " << i << "/" << count << " buffer. Retrying allocation" << std::endl;
                     goto retry;

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDIPCTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDIPCTest.cpp
@@ -78,7 +78,6 @@ void KFDIPCTest::BasicTestChildProcess(int defaultGPUNode, int *pipefd, HsaMemFl
     HSAuint64 size = PAGE_SIZE, sharedSize;
     HsaMemoryBuffer tempSysBuffer(size, defaultGPUNode, false);
     HSAuint32 *sharedLocalBuffer = NULL;
-    HsaMemMapFlags mapFlags = {0};
 
     /* Read from Pipe the shared Handle. Import shared Local Memory */
     ASSERT_GE(read(pipefd[0], reinterpret_cast<void*>(&sharedHandleLM), sizeof(sharedHandleLM)), 0);
@@ -86,7 +85,7 @@ void KFDIPCTest::BasicTestChildProcess(int defaultGPUNode, int *pipefd, HsaMemFl
     ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterSharedHandle, m_hsakmt_current_ctx, &sharedHandleLM,
                   reinterpret_cast<void**>(&sharedLocalBuffer), &sharedSize));
     ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, sharedLocalBuffer, sharedSize, NULL,
-                  mapFlags, 1, reinterpret_cast<HSAuint32 *>(&defaultGPUNode)));
+                  mflags, 1, reinterpret_cast<HSAuint32 *>(&defaultGPUNode)));
 
     /* Check for pattern in the shared Local Memory */
     ASSERT_SUCCESS(sdmaQueue.Create(defaultGPUNode));
@@ -127,12 +126,11 @@ void KFDIPCTest::BasicTestParentProcess(int defaultGPUNode, pid_t cpid, int *pip
     HsaMemoryBuffer tempSysBuffer(PAGE_SIZE, defaultGPUNode, false);
     SDMAQueue sdmaQueue;
     HsaSharedMemoryHandle sharedHandleLM;
-    HsaMemMapFlags mapFlags = {0};
 
     ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, defaultGPUNode, size, mflags, &toShareLocalBuffer));
     /* Fill a Local Buffer with a pattern */
     ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, toShareLocalBuffer, size, &AlternateVAGPU,
-                       mapFlags, 1, reinterpret_cast<HSAuint32 *>(&defaultGPUNode)));
+                       mflags, 1, reinterpret_cast<HSAuint32 *>(&defaultGPUNode)));
     tempSysBuffer.Fill(0xAAAAAAAA);
 
     /* Copy pattern in Local Memory before sharing it */

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDLocalMemoryTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDLocalMemoryTest.cpp
@@ -85,7 +85,8 @@ void KFDLocalMemoryTest::BasicTest(int gpuNode) {
     PM4Queue queue;
     HSAuint64 AlternateVAGPU;
     unsigned int BufferSize = PAGE_SIZE;
-    HsaMemMapFlags mapFlags = {0};
+    HsaMemFlags memFlags = {0};
+    memFlags.ui32.CoarseGrain = 1;
 
     Assembler* m_pAsm;
     m_pAsm = GetAssemblerFromNodeId(gpuNode);
@@ -102,9 +103,9 @@ void KFDLocalMemoryTest::BasicTest(int gpuNode) {
     ASSERT_SUCCESS_GPU(m_pAsm->RunAssembleBuf(CopyDwordIsa, isaBuffer.As<char*>()), gpuNode);
 
     ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, srcLocalBuffer.As<void*>(), srcLocalBuffer.Size(), &AlternateVAGPU,
-                       mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)), gpuNode);
+                       memFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)), gpuNode);
     ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, dstLocalBuffer.As<void*>(), dstLocalBuffer.Size(), &AlternateVAGPU,
-                       mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)), gpuNode);
+                       memFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)), gpuNode);
 
     ASSERT_SUCCESS_GPU(queue.Create(gpuNode), gpuNode);
     queue.SetSkipWaitConsump(0);
@@ -147,7 +148,8 @@ void KFDLocalMemoryTest::VerifyContentsAfterUnmapAndMap(int gpuNode)
     PM4Queue queue;
     HSAuint64 AlternateVAGPU;
     unsigned int BufferSize = PAGE_SIZE;
-    HsaMemMapFlags mapFlags = {0};
+    HsaMemFlags memFlags = {0};
+    memFlags.ui32.CoarseGrain = 1;
 
     Assembler* m_pAsm;
     m_pAsm = GetAssemblerFromNodeId(gpuNode);
@@ -167,7 +169,7 @@ void KFDLocalMemoryTest::VerifyContentsAfterUnmapAndMap(int gpuNode)
 
     if (!hsakmt_is_dgpu())
         ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, LocalBuffer.As<void*>(), LocalBuffer.Size(), &AlternateVAGPU,
-                           mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)), gpuNode);
+                           memFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)), gpuNode);
 
     Dispatch dispatch(isaBuffer);
 
@@ -177,7 +179,7 @@ void KFDLocalMemoryTest::VerifyContentsAfterUnmapAndMap(int gpuNode)
 
     EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, LocalBuffer.As<void*>()), gpuNode);
     EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, LocalBuffer.As<void*>(), LocalBuffer.Size(), &AlternateVAGPU,
-                       mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)), gpuNode);
+                       memFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)), gpuNode);
 
     dispatch.SetArgs(LocalBuffer.As<void*>(), SysBufferB.As<void*>());
     dispatch.Submit(queue);
@@ -318,7 +320,6 @@ void KFDLocalMemoryTest::Fragmentation(int gpuNode){
     /* Allocate and test memory using the strategy explained at the top */
     HSAKMT_STATUS status;
     HsaMemFlags memFlags = {0};
-    HsaMemMapFlags mapFlags = {0};
     memFlags.ui32.PageSize = HSA_PAGE_SIZE_4KB;
     memFlags.ui32.HostAccess = 0;
     memFlags.ui32.NonPaged = 1;
@@ -368,7 +369,7 @@ void KFDLocalMemoryTest::Fragmentation(int gpuNode){
             sysBuffer.As<unsigned *>()[0] = ++value;
 
             status = HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, pages[order].pointers[p], size, NULL,
-                               mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode));
+                               memFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode));
             if (status != HSAKMT_STATUS_SUCCESS) {
                 ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, pages[order].pointers[p],
                                                 size), gpuNode);
@@ -555,19 +556,17 @@ TEST_F(KFDLocalMemoryTest, MapVramToGPUNodesTest) {
     memFlags.ui32.NonPaged = 1;
     memFlags.ui32.ExecuteAccess = 1;
 
-    HsaMemMapFlags mapFlags = {0};
-
     EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtAllocMemory, g_baseTest->m_hsakmt_current_ctx, nodes[1], PAGE_SIZE, memFlags, &shared_addr));
-    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, shared_addr, PAGE_SIZE, NULL, mapFlags, 2, nodes));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, shared_addr, PAGE_SIZE, NULL, memFlags, 2, nodes));
     EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtQueryPointerInfo, g_baseTest->m_hsakmt_current_ctx, shared_addr, &info));
     EXPECT_EQ(info.NMappedNodes, 2);
 
-    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, shared_addr, PAGE_SIZE, NULL, mapFlags, 1, &nodes[0]));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, shared_addr, PAGE_SIZE, NULL, memFlags, 1, &nodes[0]));
     EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtQueryPointerInfo, g_baseTest->m_hsakmt_current_ctx, shared_addr, &info));
     EXPECT_EQ(info.NMappedNodes, 1);
     EXPECT_EQ(info.MappedNodes[0], nodes[0]);
 
-    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, shared_addr, PAGE_SIZE, NULL, mapFlags, 1, &nodes[1]));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, shared_addr, PAGE_SIZE, NULL, memFlags, 1, &nodes[1]));
     EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtQueryPointerInfo, g_baseTest->m_hsakmt_current_ctx, shared_addr, &info));
     EXPECT_EQ(info.NMappedNodes, 1);
     EXPECT_EQ(info.MappedNodes[0], nodes[1]);
@@ -576,7 +575,7 @@ TEST_F(KFDLocalMemoryTest, MapVramToGPUNodesTest) {
     EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtQueryPointerInfo, g_baseTest->m_hsakmt_current_ctx, shared_addr, &info));
     EXPECT_EQ(info.NMappedNodes, 0);
 
-    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, shared_addr, PAGE_SIZE, NULL, mapFlags, 1, &nodes[0]));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, shared_addr, PAGE_SIZE, NULL, memFlags, 1, &nodes[0]));
     EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtQueryPointerInfo, g_baseTest->m_hsakmt_current_ctx, shared_addr, &info));
     EXPECT_EQ(info.NMappedNodes, 1);
     EXPECT_EQ(info.MappedNodes[0], nodes[0]);

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
@@ -80,7 +80,7 @@ void KFDMemoryTest::MMapLarge(int gpuNode) {
 	const HSAuint64 nObjects = 1<<14;
     HSAuint64 *AlternateVAGPU = new HSAuint64[nObjects];
     ASSERT_NE_GPU((HSAuint64)AlternateVAGPU, 0, gpuNode);
-    HsaMemMapFlags mapFlags = {0};
+    HsaMemFlags memFlags = {0};
     HSAuint64 s;
     char *addr;
     HSAuint64 flags = MAP_ANONYMOUS | MAP_PRIVATE;
@@ -106,7 +106,7 @@ void KFDMemoryTest::MMapLarge(int gpuNode) {
         if (HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx, addr + i, s - i))
             break;
         if (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, addr + i, s - i,
-                    &AlternateVAGPU[i], mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode))) {
+                    &AlternateVAGPU[i], memFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode))) {
             HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, addr + i);
             break;
         }
@@ -196,7 +196,7 @@ void KFDMemoryTest::MapUnmapToNodes(int gpuNode) {
     dispatch0.SetArgs(srcBuffer.As<void*>(), dstBuffer.As<void*>());
     dispatch0.Submit(pm4Queue);
 
-    HsaMemMapFlags memFlags = {0};
+    HsaMemFlags memFlags = {0};
     memFlags.ui32.PageSize = HSA_PAGE_SIZE_4KB;
     memFlags.ui32.HostAccess = 1;
 
@@ -516,7 +516,8 @@ void KFDMemoryTest::MemoryRegisterSamePtr(int gpuNode) {
     EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, reinterpret_cast<void *>(gpuva2)));
 
     /* Same address, same size */
-    HsaMemMapFlags memFlags = {0};
+    HsaMemFlags memFlags = {0};
+    memFlags.ui32.CoarseGrain = 1;
     memFlags.ui32.PageSize = HSA_PAGE_SIZE_4KB;
     memFlags.ui32.HostAccess = 1;
 
@@ -723,8 +724,6 @@ void KFDMemoryTest::SearchLargestBuffer(int allocNode, const HsaMemFlags &memFla
                                         HSAuint64 highMB, int nodeToMap,
                                         HSAuint64 *lastSizeMB) {
     int ret;
-
-    HsaMemMapFlags mapFlags = {0};
     HSAuint64 granularityMB = 8;
 
     /* Testing big buffers in VRAM */
@@ -752,7 +751,7 @@ void KFDMemoryTest::SearchLargestBuffer(int allocNode, const HsaMemFlags &memFla
         }
 
         ret = HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, pDb, size, NULL,
-                        mapFlags, 1, reinterpret_cast<HSAuint32 *>(&nodeToMap));
+                        memFlags, 1, reinterpret_cast<HSAuint32 *>(&nodeToMap));
         if (ret) {
             EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, pDb, size), nodeToMap);
             highMB = sizeMB;
@@ -882,7 +881,6 @@ void KFDMemoryTest::BigSysBufferStressTest(int gpuNode) {
     }
 
     HSAuint64 AlternateVAGPU;
-    HsaMemMapFlags mapFlags = {0};
     int ret;
 
     /* Repeatedly allocate and map big buffers in system memory until it fails,
@@ -905,7 +903,7 @@ void KFDMemoryTest::BigSysBufferStressTest(int gpuNode) {
                 break;
 
             ret = HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, pDb_array[i], block_size,
-                    &AlternateVAGPU, mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode));
+                    &AlternateVAGPU, GetHsaMemFlags(), 1, reinterpret_cast<HSAuint32 *>(&gpuNode));
             if (ret) {
                 EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, pDb_array[i], block_size), gpuNode);
                 break;
@@ -968,7 +966,6 @@ void KFDMemoryTest::MMBench(int gpuNode) {
     unsigned i;
     HSAKMT_STATUS ret;
     HsaMemFlags memFlags = {0};
-    HsaMemMapFlags mapFlags = {0};
     HSAuint64 altVa;
 
     HSAuint64 vramSizeMB = GetVramSize(gpuNode) >> 20;
@@ -1082,7 +1079,7 @@ void KFDMemoryTest::MMBench(int gpuNode) {
         start = GetSystemTickCountInMicroSec();
         for (i = 0; i < nBufs; i++) {
             ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, bufs[i], bufSize,
-                                                     &altVa, mapFlags, 1,
+                                                     &altVa, memFlags, 1,
                                                      (HSAuint32*)&gpuNode),  gpuNode);
             INTERLEAVE_SDMA();
         }
@@ -1459,7 +1456,6 @@ void KFDMemoryTest::PtraceAccessInvisibleVram(int gpuNode) {
         return;
     }
 
-    HsaMemMapFlags mapFlags = {0};
     HsaMemFlags memFlags = {0};
     memFlags.ui32.PageSize = HSA_PAGE_SIZE_4KB;
     /* Allocate host not accessible vram */
@@ -1476,7 +1472,7 @@ void KFDMemoryTest::PtraceAccessInvisibleVram(int gpuNode) {
 
     ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, gpuNode, size, memFlags, &mem), gpuNode);
     ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, mem, size, NULL,
-                                mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)), gpuNode);
+                                memFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)), gpuNode);
     /* Set the word before 4M boundary to 0xdeadbeefdeadbeef
      * and the word after 4M boundary to 0xcafebabecafebabe
      */
@@ -1792,7 +1788,6 @@ void KFDMemoryTest::MMBandWidth(int gpuNode) {
     unsigned i;
     HSAKMT_STATUS ret;
     HsaMemFlags memFlags = {0};
-    HsaMemMapFlags mapFlags = {0};
 
     HSAuint64 vramSizeMB = GetVramSize(gpuNode) >> 20;
 
@@ -3123,9 +3118,10 @@ void KFDMemoryTest::ExportDMABufTest(int gpuNode) {
     buf = reinterpret_cast<HSAuint32 *>(info.MemoryAddress);
     ASSERT_EQ_GPU(info.SizeInBytes, PAGE_SIZE, gpuNode);
 
-    HsaMemMapFlags mapFlags = {0};
+    memFlags.Value = 0;
+    memFlags.ui32.CoarseGrain = 1;
     ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx,
-                                             buf, PAGE_SIZE, NULL, mapFlags, 1,
+                                             buf, PAGE_SIZE, NULL, memFlags, 1,
                                              (HSAuint32 *)&gpuNode), gpuNode);
 
     PM4Queue pm4Queue;
@@ -3173,8 +3169,7 @@ void KFDMemoryTest::VA_VRAM_Only_AllocTest(int gpuNode) {
     HsaMemFlags memFlags = GetHsaMemFlags();
     memFlags.ui32.NonPaged = 1;
     memFlags.ui32.HostAccess = 0;
-
-    HsaMemMapFlags mapFlags = {0};
+    memFlags.ui32.CoarseGrain = 1;
 
     HSAuint32 *buf;
 
@@ -3186,7 +3181,7 @@ void KFDMemoryTest::VA_VRAM_Only_AllocTest(int gpuNode) {
     /*mapping VA allocated by kfd api would fail*/
     ASSERT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, buf, PAGE_SIZE, NULL));
     ASSERT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, buf, PAGE_SIZE, NULL,
-                               mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)));
+                               memFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)));
 
     ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, buf, PAGE_SIZE));
 
@@ -3199,7 +3194,7 @@ void KFDMemoryTest::VA_VRAM_Only_AllocTest(int gpuNode) {
     /*mapping handle allocated by kfd API would fail*/
     ASSERT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, buf, PAGE_SIZE, NULL));
     ASSERT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, buf, PAGE_SIZE, NULL,
-                               mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)));
+                               memFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)));
 
     ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, buf, PAGE_SIZE));
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDQMTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDQMTest.cpp
@@ -2419,7 +2419,6 @@ TEST_F(KFDQMTest, P2PTest) {
     HSAuint32 *sysBuf;
     HSAuint32 size = 16ULL<<20;  // bigger than 16MB to test non-contiguous memory
     HsaMemFlags memFlags = {0};
-    HsaMemMapFlags mapFlags = {0};
     memFlags.ui32.PageSize = HSA_PAGE_SIZE_4KB;
     memFlags.ui32.HostAccess = 0;
     memFlags.ui32.NonPaged = 1;
@@ -2430,7 +2429,7 @@ TEST_F(KFDQMTest, P2PTest) {
     EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtAllocMemory, g_baseTest->m_hsakmt_current_ctx, 0, size, m_MemoryFlags,
                                      reinterpret_cast<void **>(&sysBuf)));
     EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, sysBuf, size, NULL,
-                                             mapFlags, nodes.size(), (HSAuint32 *)&nodes[0]));
+                                             memFlags, nodes.size(), (HSAuint32 *)&nodes[0]));
 #define MAGIC_NUM 0xdeadbeaf
 
     /* First GPU fills mem with MAGIC_NUM */

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDTestUtil.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDTestUtil.cpp
@@ -333,7 +333,6 @@ HsaMemoryBuffer::HsaMemoryBuffer(HSAuint64 size, unsigned int node, bool zero, b
     m_Node(node) {
     m_Flags.Value = 0;
 
-    HsaMemMapFlags mapFlags = {0};
     bool map_specific_gpu = (node && !isScratch);
 
     if (isScratch) {
@@ -367,7 +366,7 @@ HsaMemoryBuffer::HsaMemoryBuffer(HSAuint64 size, unsigned int node, bool zero, b
     EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtAllocMemory, g_baseTest->m_hsakmt_current_ctx, m_Node, m_Size, m_Flags, &m_pBuf));
     if (hsakmt_is_dgpu()) {
         if (map_specific_gpu)
-            EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, m_pBuf, m_Size, NULL, mapFlags, 1, &m_Node));
+            EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, m_pBuf, m_Size, NULL, m_Flags, 1, &m_Node));
         else
             EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, m_pBuf, m_Size, NULL));
         m_MappedNodes = 1 << m_Node;
@@ -527,10 +526,9 @@ unsigned int HsaMemoryBuffer::Node() const {
 }
 
 int HsaMemoryBuffer::MapMemToNodes(unsigned int *nodes, unsigned int nodes_num) {
-    HsaMemMapFlags mapFlags = {0};
     int ret, bit;
 
-    ret = HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, m_pBuf, m_Size, NULL, mapFlags, nodes_num, nodes);
+    ret = HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, m_pBuf, m_Size, NULL, m_Flags, nodes_num, nodes);
     if (ret != 0) {
         return ret;
     }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -350,7 +350,7 @@ hsa_status_t KfdDriver::AllocateMemory(const core::MemoryRegion& mem_region,
     // no need to map
     // For local memory, only map it to the owning GPU. Mapping to other GPU,
     // if the access is allowed, is performed on AllowAccess.
-    HsaMemMapFlags map_flag = m_region.map_flags();
+    HsaMemFlags mem_flags = m_region.mem_flags();
     size_t map_node_count = 1;
     const uint32_t owner_node_id = m_region.owner()->node_id();
     const uint32_t *map_node_id = &owner_node_id;
@@ -384,7 +384,7 @@ hsa_status_t KfdDriver::AllocateMemory(const core::MemoryRegion& mem_region,
     uint64_t alternate_va = 0;
 
     const bool is_resident = (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(
-                                  mem, size, &alternate_va, map_flag, map_node_count,
+                                  mem, size, &alternate_va, mem_flags, map_node_count,
                                   const_cast<uint32_t*>(map_node_id))) == HSAKMT_STATUS_SUCCESS);
 
     // On Windows/DXG, allow allocations to succeed even if MakeResident
@@ -955,7 +955,7 @@ hsa_status_t KfdDriver::DeregisterMemory(void* ptr) const {
 }
 
 hsa_status_t KfdDriver::MakeMemoryResident(const void* mem, size_t size, uint64_t* alternate_va,
-                                           const HsaMemMapFlags* mem_flags, uint32_t num_nodes,
+                                           const HsaMemFlags* mem_flags, uint32_t num_nodes,
                                            const uint32_t* nodes) const {
   if (mem_flags == nullptr && nodes == nullptr) {
     if (HSAKMT_CALL(hsaKmtMapMemoryToGPU(const_cast<void*>(mem), size, alternate_va)) !=

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
@@ -322,7 +322,7 @@ hsa_status_t KfdVirtioDriver::AllocateMemory(const core::MemoryRegion& mem_regio
     // no need to map
     // For local memory, only map it to the owning GPU. Mapping to other GPU,
     // if the access is allowed, is performed on AllowAccess.
-    HsaMemMapFlags map_flag = m_region.map_flags();
+    HsaMemFlags mem_flags = m_region.mem_flags();
     size_t map_node_count = 1;
     const uint32_t owner_node_id = m_region.owner()->node_id();
     const uint32_t* map_node_id = &owner_node_id;
@@ -348,7 +348,7 @@ hsa_status_t KfdVirtioDriver::AllocateMemory(const core::MemoryRegion& mem_regio
 
     uint64_t alternate_va = 0;
     const bool is_resident =
-        (MakeMemoryResident(mem, size, &alternate_va, &map_flag, map_node_count, map_node_id) ==
+        (MakeMemoryResident(mem, size, &alternate_va, &mem_flags, map_node_count, map_node_id) ==
          HSA_STATUS_SUCCESS);
 
     const bool require_pinning =
@@ -422,7 +422,7 @@ hsa_status_t KfdVirtioDriver::AvailableMemory(uint32_t node_id, uint64_t* availa
 
 hsa_status_t KfdVirtioDriver::MakeMemoryResident(const void* mem, size_t size,
                                                  uint64_t* alternate_va,
-                                                 const HsaMemMapFlags* mem_flags,
+                                                 const HsaMemFlags* mem_flags,
                                                  uint32_t num_nodes, const uint32_t* nodes) const {
   assert(mem != nullptr);
   assert(size != 0);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -1417,7 +1417,7 @@ hsa_status_t XdnaDriver::RegisterMemory(void* ptr, uint64_t size, HsaMemFlags me
 hsa_status_t XdnaDriver::DeregisterMemory(void* ptr) const { return HSA_STATUS_ERROR; }
 
 hsa_status_t XdnaDriver::MakeMemoryResident(const void* mem, size_t size, uint64_t* alternate_va,
-                                            const HsaMemMapFlags* mem_flags, uint32_t num_nodes,
+                                            const HsaMemFlags* mem_flags, uint32_t num_nodes,
                                             const uint32_t* nodes) const {
   return HSA_STATUS_ERROR;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -136,7 +136,7 @@ public:
   hsa_status_t RegisterMemory(void* ptr, uint64_t size, HsaMemFlags mem_flags) const override;
   hsa_status_t DeregisterMemory(void* ptr) const override;
   hsa_status_t MakeMemoryResident(const void* mem, size_t size, uint64_t* alternate_va,
-                                  const HsaMemMapFlags* mem_flags, uint32_t num_nodes,
+                                  const HsaMemFlags* mem_flags, uint32_t num_nodes,
                                   const uint32_t* nodes) const override;
   hsa_status_t MakeMemoryUnresident(const void* mem) const override;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_memory_region.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_memory_region.h
@@ -165,7 +165,6 @@ class MemoryRegion : public core::MemoryRegion {
   __forceinline static size_t GetPageSize() { return kPageSize_; }
 
   __forceinline const HsaMemFlags &mem_flags() const { return mem_flag_; }
-  __forceinline const HsaMemMapFlags &map_flags() const { return map_flag_; }
 
   void *fragment_alloc(size_t size) const {
     return fragment_allocator_.alloc(size);
@@ -176,8 +175,6 @@ private:
   const HsaMemoryProperties mem_props_;
 
   HsaMemFlags mem_flag_;
-
-  HsaMemMapFlags map_flag_;
 
   size_t max_single_alloc_size_;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_virtio_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_virtio_driver.h
@@ -87,7 +87,7 @@ class KfdVirtioDriver final : public core::Driver {
   hsa_status_t DeregisterMemory(void* ptr) const override;
   hsa_status_t AvailableMemory(uint32_t node_id, uint64_t* available_size) const;
   hsa_status_t MakeMemoryResident(const void* mem, size_t size, uint64_t* alternate_va,
-                                  const HsaMemMapFlags* mem_flags, uint32_t num_nodes,
+                                  const HsaMemFlags* mem_flags, uint32_t num_nodes,
                                   const uint32_t* nodes) const override;
   hsa_status_t MakeMemoryUnresident(const void* mem) const override;
   hsa_status_t CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -178,7 +178,7 @@ public:
   hsa_status_t RegisterMemory(void* ptr, uint64_t size, HsaMemFlags mem_flags) const override;
   hsa_status_t DeregisterMemory(void* ptr) const override;
   hsa_status_t MakeMemoryResident(const void* mem, size_t size, uint64_t* alternate_va,
-                                  const HsaMemMapFlags* mem_flags, uint32_t num_nodes,
+                                  const HsaMemFlags* mem_flags, uint32_t num_nodes,
                                   const uint32_t* nodes) const override;
   hsa_status_t MakeMemoryUnresident(const void* mem) const override;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -460,7 +460,7 @@ public:
   /// @param[in] nodes nodes to be used can be null
   /// @return HSA_STATUS_SUCCESS if the driver successfully makes the memory
   virtual hsa_status_t MakeMemoryResident(const void* mem, size_t size, uint64_t* alternate_va,
-                                          const HsaMemMapFlags* mem_flags = nullptr,
+                                          const HsaMemFlags* mem_flags = nullptr,
                                           uint32_t num_nodes = 0,
                                           const uint32_t* nodes = nullptr) const = 0;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
@@ -205,7 +205,7 @@ class ThunkLoader {
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtMapMemoryToGPUNodes))(void* MemoryAddress, \
                                       HSAuint64 MemorySizeInBytes, \
                                       HSAuint64* AlternateVAGPU, \
-                                      HsaMemMapFlags MemMapFlags, \
+                                      HsaMemFlags MemFlags, \
                                       HSAuint64 NumberOfNodes, \
                                       HSAuint32* NodeArray);
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtUnmapMemoryToGPU))(void* MemoryAddress);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
@@ -86,7 +86,8 @@ MemoryRegion::MemoryRegion(bool fine_grain, bool kernarg, bool full_profile,
   // Bind the memory region based on whether it is
   // coarse or fine grain or extended scope fine grain.
   mem_flag_.ui32.CoarseGrain = (fine_grain || extended_scope_fine_grain) ? 0 : 1;
-
+  map_flag_.ui32.CachePolicy =
+      (fine_grain || extended_scope_fine_grain) ? HSA_CACHING_NONCACHED : HSA_CACHING_CACHED;
   // Extended scope fine-grained memory: Device scope atomics are promoted
   // to system scope atomics. Non-compliant systems may require the
   // application to perform device-specific actions, like HDP flushes,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
@@ -80,14 +80,12 @@ MemoryRegion::MemoryRegion(bool fine_grain, bool kernarg, bool full_profile,
   assert(!(fine_grain && extended_scope_fine_grain));
 
   mem_flag_.Value = 0;
-  map_flag_.Value = 0;
   static const HSAuint64 kGpuVmSize = (1ULL << 40);
 
   // Bind the memory region based on whether it is
   // coarse or fine grain or extended scope fine grain.
   mem_flag_.ui32.CoarseGrain = (fine_grain || extended_scope_fine_grain) ? 0 : 1;
-  map_flag_.ui32.CachePolicy =
-      (fine_grain || extended_scope_fine_grain) ? HSA_CACHING_NONCACHED : HSA_CACHING_CACHED;
+
   // Extended scope fine-grained memory: Device scope atomics are promoted
   // to system scope atomics. Non-compliant systems may require the
   // application to perform device-specific actions, like HDP flushes,
@@ -517,14 +515,14 @@ hsa_status_t MemoryRegion::AllowAccess(uint32_t num_agents,
     whitelist_nodes.push_back(owner()->node_id());
   }
 
-  HsaMemMapFlags map_flag = map_flag_;
-  map_flag.ui32.HostAccess |= (cpu_in_list) ? 1 : 0;
+  HsaMemFlags mem_flags = mem_flag_;
+  mem_flags.ui32.HostAccess |= (cpu_in_list) ? 1 : 0;
 
   {  // Sequence with pointer info since queries to other fragments of the block may be adjusted by
      // this call.
     std::shared_lock<std::shared_mutex> lock(core::Runtime::runtime_singleton_->memory_lock_);
     uint64_t alternate_va = 0;
-    if (owner()->driver().MakeMemoryResident(ptr, size, &alternate_va, &map_flag,
+    if (owner()->driver().MakeMemoryResident(ptr, size, &alternate_va, &mem_flags,
                                              whitelist_nodes.size(),
                                              whitelist_nodes.data()) != HSA_STATUS_SUCCESS) {
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
@@ -601,7 +599,7 @@ hsa_status_t MemoryRegion::Lock(uint32_t num_agents, const hsa_agent_t* agents,
   if (owner()->driver().RegisterMemory(host_ptr, size, local_mem_flag) ==
       HSA_STATUS_SUCCESS) {
     uint64_t alternate_va = 0;
-    if (owner()->driver().MakeMemoryResident(host_ptr, size, &alternate_va, &map_flag_,
+    if (owner()->driver().MakeMemoryResident(host_ptr, size, &alternate_va, &local_mem_flag,
                                              whitelist_nodes.size(),
                                              whitelist_nodes.data()) == HSA_STATUS_SUCCESS) {
       if (alternate_va != 0) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -1020,13 +1020,14 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents, hsa_handle
   auto& driver = agents[0]->driver();
 
   uint64_t altAddress;
-  HsaMemMapFlags map_flags;
-  map_flags.Value = 0;
-  map_flags.ui32.PageSize = HSA_PAGE_SIZE_64KB;
-  if (driver.MakeMemoryResident(info.MemoryAddress, info.SizeInBytes, &altAddress, &map_flags,
+  HsaMemFlags mem_flags;
+  mem_flags.Value = 0;
+  mem_flags.ui32.CoarseGrain = 1;
+  mem_flags.ui32.PageSize = HSA_PAGE_SIZE_64KB;
+  if (driver.MakeMemoryResident(info.MemoryAddress, info.SizeInBytes, &altAddress, &mem_flags,
                                 num_agents, nodes) != HSA_STATUS_SUCCESS) {
-    map_flags.ui32.PageSize = HSA_PAGE_SIZE_4KB;
-    if (driver.MakeMemoryResident(info.MemoryAddress, info.SizeInBytes, &altAddress, &map_flags,
+    mem_flags.ui32.PageSize = HSA_PAGE_SIZE_4KB;
+    if (driver.MakeMemoryResident(info.MemoryAddress, info.SizeInBytes, &altAddress, &mem_flags,
                                   num_agents, nodes) != HSA_STATUS_SUCCESS) {
       driver.DeregisterMemory(info.MemoryAddress);
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
@@ -1760,14 +1761,15 @@ hsa_status_t Runtime::IPCAttach(const hsa_amd_ipc_memory_t* handle, size_t len, 
         return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
       }
     } else {
-      HsaMemMapFlags map_flags;
-      map_flags.Value = 0;
-      map_flags.ui32.PageSize = HSA_PAGE_SIZE_64KB;
-      if (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(importAddress, importSize, &altAddress, map_flags,
-                                                numNodes, nodes)) != HSAKMT_STATUS_SUCCESS) {
-        map_flags.ui32.PageSize = HSA_PAGE_SIZE_4KB;
-        if (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(importAddress, importSize, &altAddress, map_flags,
-                                                  numNodes, nodes)) != HSAKMT_STATUS_SUCCESS) {
+      HsaMemFlags mem_flags;
+      mem_flags.Value = 0;
+      mem_flags.ui32.CoarseGrain = 1;
+      mem_flags.ui32.PageSize = HSA_PAGE_SIZE_64KB;
+      if (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(importAddress, importSize, &altAddress, mem_flags, numNodes,
+                                    nodes)) != HSAKMT_STATUS_SUCCESS) {
+        mem_flags.ui32.PageSize = HSA_PAGE_SIZE_4KB;
+        if (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(importAddress, importSize, &altAddress, mem_flags, numNodes,
+                                      nodes)) != HSAKMT_STATUS_SUCCESS) {
           HSAKMT_CALL(hsaKmtDeregisterMemory(importAddress));
           return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
         }


### PR DESCRIPTION
In PAL,
  Add gl2Uncached in PinnedGpuMemoryCreateInfo.
  When hipExtHostRegisterCoarseGrained is set in hipHostRegister(),
    gl2Uncached = 0,
    m_mtype = MType::Default(0) in PAL,
    KMD will map MType to MEMORY_CACHE_POLICY__NC, which enables L2
    cache on device for pinned host (i.e., coarse grain).
  Otherwise,
    gl2Uncached = 1,
    m_mtype = MType::Uncached in PAL,
    KMD will map MType to MEMORY_CACHE_POLICY__UC, which disables L2
    cache on device for pinned host (i.e., fine grain).

In Rocr,
  Replace HsaMemMapFlags with HsaMemFlags in some functions where
  HsaMemMapFlags is not refereneced, so that we can transfer CoarseGrain bit.
  Remove HsaMemMapFlags as it isn't referenced anymore.

Without this change, PAL/Rocr in Windows will always enable L2 cache with or without hipExtHostRegisterCoarseGrained in hipHostRegister().  This isn't expected.

## Motivation

Fix an unexpected behavior of hipHostRegister().

## Technical Details

Add gl2Uncached in PinnedGpuMemoryCreateInfo to transfer L2 cache info from clr to pal.
hipHostRegister(hipExtHostRegisterCoarseGrained) should follow coarse grain behavior.
hipHostRegister(Non hipExtHostRegisterCoarseGrained) should follow fine grain behavior.

## JIRA ID
ROCM-1028

## Test Plan
hipHostRegister test should pass.

## Test Result
all pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
