### PR TITLE
ci: bump systems-pr-bot actions to Node 24 releases

### DIFF
--- a/.github/workflows/systems-pr-bot.yml
+++ b/.github/workflows/systems-pr-bot.yml
@@ -41,12 +41,12 @@ jobs:
       # guarantees we run OUR policy_check.py / policy.yml — not the fork's.
       # `persist-credentials: false` follows the safer-checkout defaults
       # (https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/).
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
 
@@ -66,7 +66,7 @@ jobs:
       - name: Create GitHub App token
         id: app-token
         if: steps.app-secrets.outputs.available == 'true'
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.THEROCK_PR_BOT_APPID }}
           private-key: ${{ secrets.THEROCK_PRBOT_KEY }}


### PR DESCRIPTION
## Motivation
The `systems-pr-bot.yml` workflow (added in #7839) references GitHub Actions that still run on the deprecated Node 20 runtime. These need bumping to Node 24-based releases before the runtime is removed.

## Technical Details
Bump the three SHA-pinned actions in `.github/workflows/systems-pr-bot.yml` to their latest releases, each of which ships on Node 24:

- `actions/checkout` v4.2.2 → v7.0.0 (`9c091bb`)
- `actions/setup-python` v5.3.0 → v6.3.0 (`ece7cb0`)
- `actions/create-github-app-token` v1.11.0 → v3.2.0 (`bcd2ba4`)

Each action remains SHA-pinned with a version comment, per the repo's pinning policy. SHAs were resolved from the release tags via the GitHub API and confirmed to point at commit objects. No workflow logic, permissions, or security posture changed — only the pinned refs.

## Issue Tracking

https://github.com/ROCm/rocm-systems/issues/7872

## Test Plan
- [ ] Workflow parses (YAML lint / pre-commit `check yaml` passed locally).
- [ ] Workflow runs successfully on a PR targeting `develop` / `pr-bot-test`.