### PR TITLE
fix(rocr): Force legacy IPC under Valgrind; Auto-detect Valgrind

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -2872,9 +2872,13 @@ void Runtime::CheckVirtualMemApiSupport() {
 void Runtime::InitIPCDmaBufSupport() {
   bool dmabuf_supported = false;
 
+  // dma-buf IPC passes the FD via SCM_RIGHTS, which Valgrind can't reproduce.
+  // Force legacy IPC (no FD passing) under Valgrind, no effect otherwise.
+  const bool force_legacy_ipc = flag().running_valgrind();
+
   // Early exit so we don't double load lib DRM
   if (virtual_mem_api_supported_) {
-    ipc_dmabuf_supported_ = !flag().enable_ipc_mode_legacy();
+    ipc_dmabuf_supported_ = !flag().enable_ipc_mode_legacy() && !force_legacy_ipc;
     return;
   }
 
@@ -2890,7 +2894,7 @@ void Runtime::InitIPCDmaBufSupport() {
     debug_warning("amdgpu_device_get_fd not available. Please update version of libdrm");
     fn_amdgpu_device_get_fd = &fn_amdgpu_device_get_fd_nosupport;
   } else {
-    ipc_dmabuf_supported_ = !flag().enable_ipc_mode_legacy();
+    ipc_dmabuf_supported_ = !flag().enable_ipc_mode_legacy() && !force_legacy_ipc;
   }
 #else
   ipc_dmabuf_supported_ = false;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.cpp
@@ -51,7 +51,18 @@
 #include <locale>
 #include <iomanip>
 
+// RUNNING_ON_VALGRIND is 0 outside Valgrind / when unavailable.
+#if defined(__has_include) && __has_include(<valgrind/valgrind.h>)
+#  include <valgrind/valgrind.h>
+#endif
+#ifndef RUNNING_ON_VALGRIND
+#  define RUNNING_ON_VALGRIND 0
+#endif
+
 namespace rocr {
+
+bool Flag::DetectRunningUnderValgrind() { return RUNNING_ON_VALGRIND != 0; }
+
 FILE* log_file = stderr;
 uint8_t log_flags[8];
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -130,8 +130,13 @@ class Flag {
     visible_gpus_ = os::GetEnvVar("ROCR_VISIBLE_DEVICES");
     filter_visible_gpus_ = os::IsEnvVarSet("ROCR_VISIBLE_DEVICES");
 
-    var = os::GetEnvVar("HSA_RUNNING_UNDER_VALGRIND");
-    running_valgrind_ = (var == "1") ? true : false;
+    // Honor the env var as an explicit override; otherwise auto-detect Valgrind.
+    if (os::IsEnvVarSet("HSA_RUNNING_UNDER_VALGRIND")) {
+      var = os::GetEnvVar("HSA_RUNNING_UNDER_VALGRIND");
+      running_valgrind_ = (var == "1") ? true : false;
+    } else {
+      running_valgrind_ = DetectRunningUnderValgrind();
+    }
 
     var = os::GetEnvVar("HSA_SDMA_WAIT_IDLE");
     sdma_wait_idle_ = (var == "1") ? true : false;
@@ -622,6 +627,9 @@ class Flag {
   std::map<uint32_t, std::vector<uint32_t>> cu_mask_;
 
   void parse_masks(std::string& args, uint32_t maxGpu, uint32_t maxCU);
+
+  // Returns true when the process runs under Valgrind.
+  static bool DetectRunningUnderValgrind();
 
   DISALLOW_COPY_AND_ASSIGN(Flag);
 };


### PR DESCRIPTION
## Motivation

dma-buf IPC passes the buffer FD across processes via SCM_RIGHTS, which
Valgrind cannot reproduce, causing `hsa_amd_ipc_memory_attach` to fail with
error 4097.

## Technical Details

Fall back to the legacy IPC path (no FD passing) when running
under Valgrind. No effect outside Valgrind.

## JIRA ID

ROCM-27031

## Test Plan

Tested successfully with: `valgrind --leak-check=full /opt/rocm-7.15.0/bin/rocrtst64 --gtest_filter=rocrtstFunc.IPC`

## Additional Changes

Detect Valgrind at runtime via valgrind.h's `RUNNING_ON_VALGRIND` so the
`HSA_RUNNING_UNDER_VALGRIND` flag activates without requiring the env var to
be set manually. The env var is still honored as an explicit override.