### PR TITLE
test(amdsmi): privilege-tier detection + rename-agnostic therock runner

### DIFF
--- a/projects/amdsmi/tests/amd_smi_test/detect_asic_filter.sh
+++ b/projects/amdsmi/tests/amd_smi_test/detect_asic_filter.sh
@@ -73,6 +73,35 @@ if [ -z "$ASIC_NAME" ] && command -v amd-smi >/dev/null 2>&1; then
     fi
 fi
 
+# ---------- Privilege tier detection ----------
+# amdsmitst gates state-modifying tests on AMDSMI_NON_PRIVILEGED (skip) and
+# is_sudo_user() (uid == 0). Inside an unprivileged container the process is
+# uid 0 yet lacks CAP_SYS_ADMIN, so uid alone cannot tell it apart from
+# baremetal root. Detect that case and export AMDSMI_NON_PRIVILEGED so a plain
+# `source detect_asic_filter.sh && ./amdsmitst` skips the write tests instead of
+# hanging. A caller that already set AMDSMI_NON_PRIVILEGED is left untouched.
+if [ -z "${AMDSMI_NON_PRIVILEGED+x}" ]; then
+    in_container=""
+    if [ -f /.dockerenv ] || grep -qE 'docker|kubepods|containerd' /proc/1/cgroup 2>/dev/null; then
+        in_container="1"
+    fi
+    if [ -n "$in_container" ]; then
+        # CAP_SYS_ADMIN is bit 21; CapEff is a hex mask in /proc/self/status.
+        cap_eff=$(awk '/^CapEff:/{print $2}' /proc/self/status 2>/dev/null)
+        if [ -n "$cap_eff" ] && [ $(( 0x$cap_eff & (1 << 21) )) -ne 0 ]; then
+            echo "Privilege tier: privileged container" >&2
+        else
+            export AMDSMI_NON_PRIVILEGED=1
+            echo "Privilege tier: unprivileged container — exporting AMDSMI_NON_PRIVILEGED=1" >&2
+        fi
+    elif [ "$(id -u)" -ne 0 ]; then
+        export AMDSMI_NON_PRIVILEGED=1
+        echo "Privilege tier: non-root baremetal — exporting AMDSMI_NON_PRIVILEGED=1" >&2
+    else
+        echo "Privilege tier: baremetal root" >&2
+    fi
+fi
+
 # ---------- Virtualization detection ----------
 VIRT_MODE=""
 virt_file=$(find /sys/class/drm/card*/device/ -name 'current_virtualization_mode' 2>/dev/null | head -1)

--- a/test/therock/test_amdsmi.py
+++ b/test/therock/test_amdsmi.py
@@ -57,28 +57,32 @@ env["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 # If quick mode is enabled, run minimal suite (only dynamic metric tests)
 test_type = os.getenv("TEST_TYPE", "full")
 
+# Suite names are matched under both their legacy names and the post-rename
+# names (GpuFunctional*/GpuUnit) so a suite rename cannot silently drop
+# coverage or match zero tests.
 if test_type == "quick":
     logging.info("Running quick tests only for amdsmitst")
-    test_filter = ["--gtest_filter=AmdSmiDynamicMetricTest.*"]
+    test_filter = ["--gtest_filter=AmdSmiDynamicMetricTest.*:*Unit*"]
 else:
     # Full test mode: run whitelist and explicitly exclude known failing tests
     logging.info("Running full amdsmitst test suite (include + exclude filter)")
 
     include_tests = [
         "amdsmitstReadOnly.*",
-        "amdsmitstReadWrite.FanReadWrite",
-        "amdsmitstReadWrite.TestOverdriveReadWrite",
-        "amdsmitstReadWrite.TestPciReadWrite",
-        "amdsmitstReadWrite.TestPowerReadWrite",
-        "amdsmitstReadWrite.TestPerfCntrReadWrite",
-        "amdsmitstReadWrite.TestEvtNotifReadWrite",
+        "amdsmitstReadWrite.*",
         "AmdSmiDynamicMetricTest.*",
+        "*FunctionalReadOnly.*",
+        "*FunctionalReadWrite.*",
+        "*Unit*",
     ]
 
     exclude_tests = [
         "amdsmitstReadOnly.TempRead",
         "amdsmitstReadOnly.TestFrequenciesRead",
         "amdsmitstReadWrite.TestPowerReadWrite",
+        "*FunctionalReadOnly.TempRead",
+        "*FunctionalReadOnly.TestFrequenciesRead",
+        "*FunctionalReadWrite.TestPowerReadWrite",
     ]
 
     gtest_filter = f"{':'.join(include_tests)}:-{':'.join(exclude_tests)}"


### PR DESCRIPTION
## Problem
`amdsmitst` gates state-modifying tests on `AMDSMI_NON_PRIVILEGED` (skip) and `is_sudo_user()` (uid == 0). Inside an unprivileged container the process is uid 0 yet lacks `CAP_SYS_ADMIN`, so `is_sudo_user()` cannot tell it apart from baremetal root and the write tests run (and can hang) where they should skip.

Separately, the manual `test/therock/test_amdsmi.py` runner hardcoded legacy gtest suite names, so the upcoming suite rename (#8508) would make its filters match zero tests.

## Change
**1. Privilege-tier detection (`detect_asic_filter.sh`)**
Classifies the runtime (baremetal root, non-root baremetal, privileged container, unprivileged container) via `/.dockerenv`, `/proc/1/cgroup`, and the effective capability mask (`CapEff` / `CAP_SYS_ADMIN`), and exports `AMDSMI_NON_PRIVILEGED=1` for runtimes that cannot safely run state-modifying tests. A caller that already set the variable is left untouched. Complements the TheRock-side detection (ROCm/TheRock#4228) so manual `source detect_asic_filter.sh && ./amdsmitst` runs get the same skip behavior.

**2. Rename-agnostic therock runner (`test/therock/test_amdsmi.py`)**
The manual runner now matches both legacy and post-rename (`GpuFunctional*`/`GpuUnit`) suite names in its quick and full filters, so the suite rename cannot silently drop coverage. Mirrors the same logic applied in ROCm/TheRock#4228.

## Dependency
Standalone — `detect_asic_filter.sh` is identical on `develop` and the test-taxonomy branch (#8508); these commits cherry-pick cleanly onto `develop` with no dependency on that PR. The therock-runner change touches the same file as #8508 but is rename-agnostic, so it stays correct before and after that rename regardless of merge order.

## Unit Test
`bash -n` passes on `detect_asic_filter.sh`; sourced on baremetal (non-root) and verified it exports `AMDSMI_NON_PRIVILEGED=1` and still emits the correct `GTEST_EXCLUDE`. The privileged self-hosted `amdsmi-build.yml` CI run on this branch confirmed `Privilege tier: privileged container` and unchanged write-test behavior. `python3 -m ast` parses `test_amdsmi.py`.

## JIRA ID
N/A
