### PR TITLE
Amd/dev/weizhu12/jpeg async decode

### DIFF
--- a/projects/rocjpeg/api/amd_detail/rocjpeg_api_trace.h
+++ b/projects/rocjpeg/api/amd_detail/rocjpeg_api_trace.h
@@ -45,7 +45,7 @@ THE SOFTWARE.
 
 // Increment the ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION when new runtime API functions are added.
 // If the corresponding ROCJPEG_RUNTIME_API_TABLE_MAJOR_VERSION increases reset the ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION to zero.
-#define ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION 0
+#define ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION 1
 
 // rocJPEG API interface
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegStreamCreate)(RocJpegStreamHandle *jpeg_stream_handle);
@@ -55,6 +55,8 @@ typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegCreate)(RocJpegBackend backend, int
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDestroy)(RocJpegHandle handle);
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegGetImageInfo)(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, uint8_t *num_components, RocJpegChromaSubsampling *subsampling, uint32_t *widths, uint32_t *heights);
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecode)(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeAsync)(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegSyncSurface)(RocJpegHandle handle, RocJpegImage *destination);
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeBatched)(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
 typedef const char* (ROCJPEGAPI *PfnRocJpegGetErrorName)(RocJpegStatus rocjpeg_status);
 
@@ -75,6 +77,11 @@ struct RocJpegDispatchTable {
 
     // PLEASE DO NOT EDIT ABOVE!
     // ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 1
+    PfnRocJpegDecodeAsync pfn_rocjpeg_decode_async;
+    PfnRocJpegSyncSurface pfn_rocjpeg_sync_surface;
+
+    // PLEASE DO NOT EDIT ABOVE!
+    // ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 2
 
     // ******************************************************************************************* //
     //                                            READ BELOW

--- a/projects/rocjpeg/api/rocjpeg/rocjpeg.h
+++ b/projects/rocjpeg/api/rocjpeg/rocjpeg.h
@@ -313,6 +313,30 @@ RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, RocJpegStream
 
 RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 
+/**
+ * @fn RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+ * @ingroup group_amd_rocjpeg
+ * @brief Submits a JPEG decode operation without waiting for the output.
+ *
+ * @param handle The rocJPEG handle.
+ * @param jpeg_stream_handle The rocJPEG stream handle.
+ * @param decode_params The decoding parameters.
+ * @param destination The output image.
+ * @return A RocJpegStatus indicating the success or failure of the submit operation.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+
+/**
+ * @fn RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
+ * @ingroup group_amd_rocjpeg
+ * @brief Synchronizes a pending asynchronous JPEG decode.
+ *
+ * @param handle The rocJPEG handle.
+ * @param destination A pointer to RocJpegImage where the decoded image will be stored.
+ * @return A RocJpegStatus indicating the success or failure of the sync operation.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
+
 
 /**
  * @fn RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);

--- a/projects/rocjpeg/samples/jpegDecode/jpegdecode.cpp
+++ b/projects/rocjpeg/samples/jpegDecode/jpegdecode.cpp
@@ -51,8 +51,11 @@ int main(int argc, char **argv) {
     uint64_t num_jpegs_with_411_subsampling = 0;
     uint64_t num_jpegs_with_unknown_subsampling = 0;
     uint64_t num_jpegs_with_unsupported_resolution = 0;
+    // decode mode: 0 = sync (default), 1 = async
+    int decode_mode = 0;
+    int num_iterations = 1;
 
-    RocJpegUtils::ParseCommandLine(input_path, output_file_path, save_images, device_id, rocjpeg_backend, decode_params, nullptr, nullptr, argc, argv);
+    RocJpegUtils::ParseCommandLine(input_path, output_file_path, save_images, device_id, rocjpeg_backend, decode_params, nullptr, nullptr, argc, argv, &decode_mode, &num_iterations);
 
     bool is_roi_valid = false;
     uint32_t roi_width;
@@ -160,9 +163,105 @@ int main(int argc, char **argv) {
         }
         std::cout << "Decoding started, please wait! ... " << std::endl;
         auto start_time = std::chrono::high_resolution_clock::now();
-        CHECK_ROCJPEG(rocJpegDecode(rocjpeg_handle, rocjpeg_stream_handle, &decode_params, &output_image));
+        if (decode_mode == 0) {
+            for (int iter = 0; iter < num_iterations; iter++) {
+                CHECK_ROCJPEG(rocJpegDecode(rocjpeg_handle, rocjpeg_stream_handle, &decode_params, &output_image));
+            }
+        } else {
+            // Async mode: submit and sync in separate threads
+            const int buf_num = 5;
+            std::vector<RocJpegImage> pipeline_images(buf_num);
+            for (int p = 0; p < buf_num; p++) {
+                memset(&pipeline_images[p], 0, sizeof(RocJpegImage));
+                for (uint32_t c = 0; c < num_channels; c++) {
+                    pipeline_images[p].pitch[c] = output_image.pitch[c];
+                    CHECK_HIP(hipMalloc(&pipeline_images[p].channel[c], channel_sizes[c]));
+                }
+            }
+
+            std::queue<RocJpegImage*> pending_queue;
+            std::queue<RocJpegImage*> available_queue;
+            std::mutex mtx;
+            std::condition_variable cv_pending, cv_available;
+            RocJpegImage* last_sync_image = nullptr;
+            RocJpegStatus status = ROCJPEG_STATUS_SUCCESS;
+            bool sync_error = false;
+
+            for (int p = 0; p < buf_num; p++)
+                available_queue.push(&pipeline_images[p]);
+
+            // Sync thread: waits for submitted decodes and syncs them
+            std::thread sync_thread([&]() {
+                hipSetDevice(device_id);
+                for (int iter = 0; iter < num_iterations; iter++) {
+                    RocJpegImage* img;
+                    {
+                        std::unique_lock<std::mutex> lock(mtx);
+                        cv_pending.wait(lock, [&]{ return !pending_queue.empty(); });
+                        img = pending_queue.front();
+                        pending_queue.pop();
+                    }
+                    RocJpegStatus s = rocJpegSyncSurface(rocjpeg_handle, img);
+                    if (s != ROCJPEG_STATUS_SUCCESS) {
+                        std::lock_guard<std::mutex> lock(mtx);
+                        status = s;
+                        sync_error = true;
+                        cv_available.notify_one();
+                        return;
+                    }
+                    last_sync_image = img;
+                    {
+                        std::lock_guard<std::mutex> lock(mtx);
+                        available_queue.push(img);
+                    }
+                    cv_available.notify_one();
+                }
+            });
+
+            // Main thread: submits decodes
+            for (int iter = 0; iter < num_iterations; iter++) {
+                RocJpegImage* img;
+                {
+                    std::unique_lock<std::mutex> lock(mtx);
+                    cv_available.wait(lock, [&]{ return !available_queue.empty() || sync_error; });
+                    if (sync_error) break;
+                    img = available_queue.front();
+                    available_queue.pop();
+                }
+                CHECK_ROCJPEG(rocJpegDecodeAsync(rocjpeg_handle, rocjpeg_stream_handle, &decode_params, img));
+                {
+                    std::lock_guard<std::mutex> lock(mtx);
+                    pending_queue.push(img);
+                }
+                cv_pending.notify_one();
+            }
+
+            sync_thread.join();
+            if (sync_error) {
+                std::cerr << "ERROR: Sync thread failed with " << rocJpegGetErrorName(status) << std::endl;
+                return EXIT_FAILURE;
+            }
+
+            // Copy last result to output_image for saving
+            if (save_images && last_sync_image != nullptr) {
+                for (uint32_t c = 0; c < num_channels; c++) {
+                    if (last_sync_image->channel[c] != nullptr && output_image.channel[c] != nullptr) {
+                        CHECK_HIP(hipMemcpy(output_image.channel[c], last_sync_image->channel[c], channel_sizes[c], hipMemcpyDeviceToDevice));
+                    }
+                }
+            }
+
+            // Free pipeline buffers
+            for (int p = 0; p < buf_num; p++) {
+                for (int c = 0; c < ROCJPEG_MAX_COMPONENT; c++) {
+                    if (pipeline_images[p].channel[c] != nullptr) {
+                        CHECK_HIP(hipFree(pipeline_images[p].channel[c]));
+                    }
+                }
+            }
+        }
         auto end_time = std::chrono::high_resolution_clock::now();
-        double time_per_image_in_milli_sec = std::chrono::duration<double, std::milli>(end_time - start_time).count();
+        double time_per_image_in_milli_sec = std::chrono::duration<double, std::milli>(end_time - start_time).count() / num_iterations;
         double image_size_in_mpixels = (static_cast<double>(widths[0]) * static_cast<double>(heights[0]) / 1000000);
         image_count++;
 

--- a/projects/rocjpeg/samples/rocjpeg_samples_utils.h
+++ b/projects/rocjpeg/samples/rocjpeg_samples_utils.h
@@ -87,13 +87,14 @@ public:
      * @param argv The command line arguments.
      */
     static void ParseCommandLine(std::string &input_path, std::string &output_file_path, bool &save_images, int &device_id,
-                                 RocJpegBackend &rocjpeg_backend, RocJpegDecodeParams &decode_params, int *num_threads, int *batch_size, int argc, char *argv[]) {
+                                 RocJpegBackend &rocjpeg_backend, RocJpegDecodeParams &decode_params, int *num_threads, int *batch_size,
+                                 int argc, char *argv[], int *decode_mode = nullptr, int *num_iterations = nullptr) {
         if(argc <= 1) {
-            ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr);
+            ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr, num_iterations != nullptr);
         }
         for (int i = 1; i < argc; i++) {
             if (!strcmp(argv[i], "-h")) {
-                ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr);
+                ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr, num_iterations != nullptr);
             }
             if (!strcmp(argv[i], "-i")) {
                 if (++i == argc) {
@@ -174,7 +175,33 @@ public:
                 }
                 continue;
             }
-            ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr);
+            if (!strcmp(argv[i], "-m")) {
+                if (++i == argc) {
+                    ShowHelpAndExit("-m", num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr);
+                }
+                if (decode_mode != nullptr) {
+                    std::string mode = argv[i];
+                    if (mode == "sync") *decode_mode = 0;
+                    else if (mode == "async") *decode_mode = 1;
+                    else {
+                        ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr);
+                    }
+                }
+                continue;
+            }
+            if (!strcmp(argv[i], "-n")) {
+                if (++i == argc) {
+                    ShowHelpAndExit("-n", num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr, num_iterations != nullptr);
+                }
+                if (num_iterations != nullptr) {
+                    *num_iterations = atoi(argv[i]);
+                    if (*num_iterations <= 0) {
+                        ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr, num_iterations != nullptr);
+                    }
+                }
+                continue;
+            }
+            ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr, num_iterations != nullptr);
         }
     }
 
@@ -641,7 +668,7 @@ private:
      * @param option The option to display in the help message (optional).
      * @param show_threads Flag indicating whether to show the number of threads in the help message.
      */
-    static void ShowHelpAndExit(const char *option = nullptr, bool show_threads = false, bool show_batch_size = false) {
+    static void ShowHelpAndExit(const char *option = nullptr, bool show_threads = false, bool show_batch_size = false, bool show_decode_mode = false, bool show_iterations = false) {
         std::cout  << "Options:\n"
         "-i     [input path] - input path to a single JPEG image or a directory containing JPEG images - [required]\n"
         "-be    [backend] - select rocJPEG backend (0 for hardware-accelerated JPEG decoding using VCN,\n"
@@ -655,6 +682,12 @@ private:
         }
         if (show_batch_size) {
             std::cout << "-b     [batch_size] - decode images from input by batches of a specified size - [optional - default: 1]\n";
+        }
+        if (show_decode_mode) {
+            std::cout << "-m     [decode mode] - select decode mode: sync or async - [optional - default: sync]\n";
+        }
+        if (show_iterations) {
+            std::cout << "-n     [iterations] - number of decode iterations per image - [optional - default: 1]\n";
         }
         exit(0);
     }

--- a/projects/rocjpeg/src/amd_detail/rocjpeg_api_dispatch_interface.cpp
+++ b/projects/rocjpeg/src/amd_detail/rocjpeg_api_dispatch_interface.cpp
@@ -47,6 +47,12 @@ RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, RocJpegStream
 RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
     return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode(handle, jpeg_stream_handle, decode_params, destination);
 }
+RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
+    return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode_async(handle, jpeg_stream_handle, decode_params, destination);
+}
+RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination) {
+    return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_sync_surface(handle, destination);
+}
 RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations) {
     return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode_batched(handle, jpeg_stream_handles, batch_size, decode_params, destinations);
 }

--- a/projects/rocjpeg/src/amd_detail/rocjpeg_api_trace.cpp
+++ b/projects/rocjpeg/src/amd_detail/rocjpeg_api_trace.cpp
@@ -41,6 +41,8 @@ RocJpegStatus ROCJPEGAPI rocJpegCreate(RocJpegBackend backend, int device_id, Ro
 RocJpegStatus ROCJPEGAPI rocJpegDestroy(RocJpegHandle handle);
 RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, uint8_t *num_components, RocJpegChromaSubsampling *subsampling, uint32_t *widths, uint32_t *heights);
 RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
 RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
 const char* ROCJPEGAPI rocJpegGetErrorName(RocJpegStatus rocjpeg_status);
 }
@@ -58,6 +60,8 @@ void UpdateDispatchTable(RocJpegDispatchTable* ptr_dispatch_table) {
     ptr_dispatch_table->pfn_rocjpeg_decode = rocjpeg::rocJpegDecode;
     ptr_dispatch_table->pfn_rocjpeg_decode_batched = rocjpeg::rocJpegDecodeBatched;
     ptr_dispatch_table->pfn_rocjpeg_get_error_name = rocjpeg::rocJpegGetErrorName;
+    ptr_dispatch_table->pfn_rocjpeg_decode_async = rocjpeg::rocJpegDecodeAsync;
+    ptr_dispatch_table->pfn_rocjpeg_sync_surface = rocjpeg::rocJpegSyncSurface;
 }
 
 #if ROCJPEG_ROCPROFILER_REGISTER > 0
@@ -140,14 +144,16 @@ ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_get_image_info, 5)
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode, 6)
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode_batched, 7)
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_get_error_name, 8)
+ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode_async, 9)
+ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_sync_surface, 10)
 
 // If ROCJPEG_ENFORCE_ABI entries are added for each new function pointer in the table,
 // the number below will be one greater than the number in the last ROCJPEG_ENFORCE_ABI line. For example:
-//  ROCJPEG_ENFORCE_ABI(<table>, <functor>, 8)
-//  ROCJPEG_ENFORCE_ABI_VERSIONING(<table>, 9) <- 8 + 1 = 9
-ROCJPEG_ENFORCE_ABI_VERSIONING(RocJpegDispatchTable, 9)
+//  ROCJPEG_ENFORCE_ABI(<table>, <functor>, 10)
+//  ROCJPEG_ENFORCE_ABI_VERSIONING(<table>, 11) <- 10 + 1 = 11
+ROCJPEG_ENFORCE_ABI_VERSIONING(RocJpegDispatchTable, 11)
 
-static_assert(ROCJPEG_RUNTIME_API_TABLE_MAJOR_VERSION == 0 && ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 0,
+static_assert(ROCJPEG_RUNTIME_API_TABLE_MAJOR_VERSION == 0 && ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 1,
               "If you encounter this error, add the new ROCJPEG_ENFORCE_ABI(...) code for the updated function pointers, "
               "and then modify this check to ensure it evaluates to true.");
 #endif

--- a/projects/rocjpeg/src/rocjpeg_api.cpp
+++ b/projects/rocjpeg/src/rocjpeg_api.cpp
@@ -237,6 +237,50 @@ RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle
 }
 
 /**
+ * @brief Submits a JPEG decode operation without waiting for output completion.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params,
+    RocJpegImage *destination) {
+    FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(handle) + ", " + RocJpegFmtPtr(jpeg_stream_handle) + ", " +
+                             RocJpegFmtPtr(decode_params) + ", " + RocJpegFmtPtr(destination));
+    if (handle == nullptr || jpeg_stream_handle == nullptr || decode_params == nullptr || destination == nullptr) {
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    RocJpegStatus rocjpeg_status = ROCJPEG_STATUS_SUCCESS;
+    auto rocjpeg_handle = static_cast<RocJpegDecoderHandle*>(handle);
+    try {
+        rocjpeg_status = rocjpeg_handle->rocjpeg_decoder->DecodeAsync(jpeg_stream_handle, decode_params, destination);
+    } catch (const std::exception& e) {
+        rocjpeg_handle->CaptureError(e.what());
+        ErrorLog(g_rocjpeg_logger, e.what());
+        return ROCJPEG_STATUS_RUNTIME_ERROR;
+    }
+
+    return rocjpeg_status;
+}
+
+/**
+ * @brief Synchronizes an asynchronous JPEG decode surface and writes the decoded output.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination) {
+    FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(handle) + ", " + RocJpegFmtPtr(destination));
+    if (handle == nullptr || destination == nullptr) {
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    RocJpegStatus rocjpeg_status = ROCJPEG_STATUS_SUCCESS;
+    auto rocjpeg_handle = static_cast<RocJpegDecoderHandle*>(handle);
+    try {
+        rocjpeg_status = rocjpeg_handle->rocjpeg_decoder->SyncSurface(destination);
+    } catch (const std::exception& e) {
+        rocjpeg_handle->CaptureError(e.what());
+        ErrorLog(g_rocjpeg_logger, e.what());
+        return ROCJPEG_STATUS_RUNTIME_ERROR;
+    }
+
+    return rocjpeg_status;
+}
+
+/**
  * @brief Decodes a batch of JPEG images using the rocJPEG library.
  *
  * Decodes a batch of JPEG images using the specified handle, stream handles, decode parameters, and destination images.

--- a/projects/rocjpeg/src/rocjpeg_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_decoder.cpp
@@ -26,6 +26,14 @@ RocJpegDecoder::RocJpegDecoder(RocJpegBackend backend, int device_id) :
     num_devices_{0}, device_id_ {device_id}, hip_stream_ {0}, backend_{backend} {}
 
 RocJpegDecoder::~RocJpegDecoder() {
+    for (auto &[dest, state] : pending_decodes_) {
+        RocJpegStatus rocjpeg_status = jpeg_vaapi_decoder_.SyncSurface(state.surface_id);
+        if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+            ErrorLog(g_rocjpeg_logger, "Failed to sync pending async surface during destroy!");
+        }
+        jpeg_vaapi_decoder_.SetSurfaceAsIdle(state.surface_id);
+    }
+    pending_decodes_.clear();
     if (hip_stream_) {
         hipError_t hip_status = hipStreamDestroy(hip_stream_);
         if (hip_status != hipSuccess) {
@@ -124,11 +132,102 @@ RocJpegStatus RocJpegDecoder::Decode(RocJpegStreamHandle jpeg_stream_handle, con
         FunctionExitLog(g_rocjpeg_logger);
         return ROCJPEG_STATUS_INVALID_PARAMETER;
     }
+    if (!pending_decodes_.empty()) {
+        ErrorLog(g_rocjpeg_logger, "Asynchronous decodes are pending for this handle!");
+        FunctionExitLog(g_rocjpeg_logger);
+        return ROCJPEG_STATUS_EXECUTION_FAILED;
+    }
     auto rocjpeg_stream_handle = static_cast<RocJpegStreamParserHandle*>(jpeg_stream_handle);
     const JpegStreamParameters *jpeg_stream_params = rocjpeg_stream_handle->rocjpeg_stream->GetJpegStreamParameters();
 
     VASurfaceID current_surface_id;
     CHECK_ROCJPEG(jpeg_vaapi_decoder_.SubmitDecode(jpeg_stream_params, current_surface_id, decode_params));
+
+    RocJpegStatus rocjpeg_status = SyncDecodeSurface(current_surface_id, jpeg_stream_params, decode_params, destination);
+    if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+        jpeg_vaapi_decoder_.SetSurfaceAsIdle(current_surface_id);
+    }
+    FunctionExitLog(g_rocjpeg_logger);
+    return rocjpeg_status;
+}
+
+/**
+ * @brief Submits a JPEG decode operation and returns immediately with pending state stored in this decoder handle.
+ */
+RocJpegStatus RocJpegDecoder::DecodeAsync(RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
+    FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(jpeg_stream_handle) + ", " + RocJpegFmtPtr(decode_params) + ", " + RocJpegFmtPtr(destination));
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (jpeg_stream_handle == nullptr || decode_params == nullptr || destination == nullptr) {
+        CriticalLog(g_rocjpeg_logger, "Null pointer");
+        FunctionExitLog(g_rocjpeg_logger);
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    if (pending_decodes_.count(destination) > 0) {
+        ErrorLog(g_rocjpeg_logger, "An async decode is already pending for this destination!");
+        FunctionExitLog(g_rocjpeg_logger);
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+
+    auto rocjpeg_stream_handle = static_cast<RocJpegStreamParserHandle*>(jpeg_stream_handle);
+    const JpegStreamParameters *jpeg_stream_params = rocjpeg_stream_handle->rocjpeg_stream->GetJpegStreamParameters();
+
+    AsyncDecodeState state;
+    state.jpeg_stream_params = *jpeg_stream_params;
+    state.decode_params = *decode_params;
+
+    RocJpegStatus rocjpeg_status = jpeg_vaapi_decoder_.SubmitDecode(&state.jpeg_stream_params, state.surface_id, &state.decode_params);
+    if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+        FunctionExitLog(g_rocjpeg_logger);
+        return rocjpeg_status;
+    }
+    pending_decodes_.emplace(destination, std::move(state));
+
+    FunctionExitLog(g_rocjpeg_logger);
+    return ROCJPEG_STATUS_SUCCESS;
+}
+
+/**
+ * @brief Synchronizes an asynchronous decode surface and copies/converts the decoded output.
+ */
+RocJpegStatus RocJpegDecoder::SyncSurface(RocJpegImage *destination) {
+    FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(destination));
+    if (destination == nullptr) {
+        CriticalLog(g_rocjpeg_logger, "Null pointer");
+        FunctionExitLog(g_rocjpeg_logger);
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+
+    AsyncDecodeState state;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = pending_decodes_.find(destination);
+        if (it == pending_decodes_.end()) {
+            ErrorLog(g_rocjpeg_logger, "No asynchronous decode is pending for this destination!");
+            FunctionExitLog(g_rocjpeg_logger);
+            return ROCJPEG_STATUS_INVALID_PARAMETER;
+        }
+        state = std::move(it->second);
+        pending_decodes_.erase(it);
+    }
+
+    // Sync the VA surface and copy the decoded output to the destination without holding the mutex
+    RocJpegStatus rocjpeg_status = SyncDecodeSurface(state.surface_id, &state.jpeg_stream_params, &state.decode_params, destination);
+    if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+        jpeg_vaapi_decoder_.SetSurfaceAsIdle(state.surface_id);
+        FunctionExitLog(g_rocjpeg_logger);
+        return rocjpeg_status;
+    }
+    FunctionExitLog(g_rocjpeg_logger);
+    return ROCJPEG_STATUS_SUCCESS;
+}
+
+/**
+ * @brief Waits for a submitted VA surface, maps it through HIP interop, and writes the requested output.
+ */
+RocJpegStatus RocJpegDecoder::SyncDecodeSurface(VASurfaceID current_surface_id, const JpegStreamParameters *jpeg_stream_params, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
+    if (jpeg_stream_params == nullptr || decode_params == nullptr || destination == nullptr) {
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
 
     HipInteropDeviceMem hip_interop_dev_mem = {};
     CHECK_ROCJPEG(jpeg_vaapi_decoder_.SyncSurface(current_surface_id));
@@ -196,9 +295,8 @@ RocJpegStatus RocJpegDecoder::Decode(RocJpegStreamHandle jpeg_stream_handle, con
             break;
     }
 
-    CHECK_ROCJPEG(jpeg_vaapi_decoder_.SetSurfaceAsIdle(current_surface_id));
     CHECK_HIP(hipStreamSynchronize(hip_stream_));
-    FunctionExitLog(g_rocjpeg_logger);
+    CHECK_ROCJPEG(jpeg_vaapi_decoder_.SetSurfaceAsIdle(current_surface_id));
     return ROCJPEG_STATUS_SUCCESS;
 }
 
@@ -218,6 +316,11 @@ RocJpegStatus RocJpegDecoder::DecodeBatched(RocJpegStreamHandle *jpeg_streams, i
         CriticalLog(g_rocjpeg_logger, "Null pointer");
         FunctionExitLog(g_rocjpeg_logger);
         return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    if (!pending_decodes_.empty()) {
+        ErrorLog(g_rocjpeg_logger, "Asynchronous decodes are pending for this handle!");
+        FunctionExitLog(g_rocjpeg_logger);
+        return ROCJPEG_STATUS_EXECUTION_FAILED;
     }
 
     std::vector<VASurfaceID> current_surface_ids;

--- a/projects/rocjpeg/src/rocjpeg_decoder.h
+++ b/projects/rocjpeg/src/rocjpeg_decoder.h
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include <unistd.h>
 #include <vector>
 #include <mutex>
-#include <queue>
+#include <unordered_map>
 #include "../api/rocjpeg/rocjpeg.h"
 #include "rocjpeg_api_stream_handle.h"
 #include "rocjpeg_parser.h"
@@ -85,6 +85,22 @@ public:
    RocJpegStatus Decode(RocJpegStreamHandle jpeg_stream, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 
    /**
+    * @brief Submits a JPEG decode operation and stores pending state in this decoder handle.
+    * @param jpeg_stream The handle to the JPEG stream.
+    * @param decode_params The decoding parameters.
+    * @param destination Pointer to the output image.
+    * @return The status of the submit operation.
+    */
+   RocJpegStatus DecodeAsync(RocJpegStreamHandle jpeg_stream, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+
+   /**
+    * @brief Synchronizes an asynchronous decode surface and copies/converts the output.
+    * @param destination Pointer to the destination image.
+    * @return The status of the sync operation.
+    */
+   RocJpegStatus SyncSurface(RocJpegImage *destination);
+
+   /**
     * Decodes a batch of JPEG streams.
     *
     * This function decodes a batch of JPEG streams specified by `jpeg_streams` into a batch of destination images specified by `destinations`.
@@ -100,12 +116,23 @@ public:
    RocJpegStatus DecodeBatched(RocJpegStreamHandle *jpeg_streams, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
 
 private:
+   struct AsyncDecodeState {
+      VASurfaceID surface_id;
+      JpegStreamParameters jpeg_stream_params;
+      RocJpegDecodeParams decode_params;
+   };
+
    /**
     * @brief Initializes the HIP framework.
     * @param device_id The ID of the device to be used for HIP operations.
     * @return The status of the initialization process.
     */
    RocJpegStatus InitHIP(int device_id);
+
+   /**
+    * @brief Waits for a submitted surface and copies/converts the decoded output.
+    */
+   RocJpegStatus SyncDecodeSurface(VASurfaceID surface_id, const JpegStreamParameters *jpeg_stream_params, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 
    /**
     * @brief Retrieves the height of the chroma channel.
@@ -175,6 +202,7 @@ private:
    std::mutex mutex_; // Mutex for thread safety
    RocJpegBackend backend_; // RocJpeg backend
    RocJpegVappiDecoder jpeg_vaapi_decoder_; // RocJpeg VAAPI decoder object
+   std::unordered_map<RocJpegImage*, AsyncDecodeState> pending_decodes_; // Map of pending asynchronous decodes keyed by destination
 };
 
 #endif //ROC_JPEG_DECODER_H_


### PR DESCRIPTION
## Motivation

<!-- Current decode API  always serialize submission -> decode -> copy,  it will cause VCN can not be 100% used. -->
Current decode API  always serialize submission -> decode -> copy,  it will cause VCN can not be 100% used. 
## Technical Details

<!-- Add asynchronouse API  to let submission/decode/copy run in parallel. -->
Add asynchronouse API  to let submission/decode/copy run in parallel. 
## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- add a new option to compare perf between sync and async mode -->
command:  ./jpegdecode -i 89_target.jpg  -m sync -n 1000
                   ./jpegdecode -i 89_target.jpg  -m async -n 1000
## Test Result

<!-- Briefly summarize test outcomes. -->
For 1920x1440,  asynchronous mode: 13.6789
                          synchronous mode:  17.9206
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
