### PR TITLE
feat(rocjpeg): add async decode API/Sample

### DIFF
--- a/projects/rocjpeg/CHANGELOG.md
+++ b/projects/rocjpeg/CHANGELOG.md
@@ -3,6 +3,12 @@
 Documentation for rocJPEG is available at
 [https://rocm.docs.amd.com/projects/rocJPEG/en/latest/](https://rocm.docs.amd.com/projects/rocJPEG/en/latest/)
 
+## rocJPEG 1.7.0
+
+### Added
+
+* Added rocJpegDecodeAsync and rocJpegDecodeSync APIs to support asynchronous single-image JPEG decoding, allowing decode submission and completion to be separated across threads for improved pipeline throughput.
+
 ## (unreleased) rocJPEG 1.6.1
 
 ### Changed

--- a/projects/rocjpeg/CMakeLists.txt
+++ b/projects/rocjpeg/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 
 # rocjpeg Version
 # NOTE: package version and rocjpeg_version.h is generated with this version
-set(VERSION "1.6.1")
+set(VERSION "1.7.0")
 
 # Set Project Version and Language
 project(rocjpeg VERSION ${VERSION} LANGUAGES CXX)

--- a/projects/rocjpeg/CMakeLists.txt
+++ b/projects/rocjpeg/CMakeLists.txt
@@ -276,6 +276,7 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND AND Threads_FOUND)
   install(FILES samples/jpegDecode/CMakeLists.txt samples/jpegDecode/jpegdecode.cpp samples/jpegDecode/README.md DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/samples/jpegDecode)
   install(FILES samples/jpegDecodePerf/CMakeLists.txt samples/jpegDecodePerf/jpegdecodeperf.cpp samples/jpegDecodePerf/README.md DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/samples/jpegDecodePerf)
   install(FILES samples/jpegDecodeBatched/CMakeLists.txt samples/jpegDecodeBatched/jpegdecodebatched.cpp samples/jpegDecodeBatched/README.md DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/samples/jpegDecodeBatched)
+  install(FILES samples/jpegDecodeAsync/CMakeLists.txt samples/jpegDecodeAsync/jpegdecodeasync.cpp samples/jpegDecodeAsync/README.md DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/samples/jpegDecodeAsync)
   install(FILES samples/rocjpeg_samples_utils.h DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/samples)
   install(DIRECTORY data/images DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
   # install license information - {ROCM_PATH}/share/doc/rocjpeg

--- a/projects/rocjpeg/api/amd_detail/rocjpeg_api_trace.h
+++ b/projects/rocjpeg/api/amd_detail/rocjpeg_api_trace.h
@@ -55,11 +55,10 @@ typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegCreate)(RocJpegBackend backend, int
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDestroy)(RocJpegHandle handle);
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegGetImageInfo)(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, uint8_t *num_components, RocJpegChromaSubsampling *subsampling, uint32_t *widths, uint32_t *heights);
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecode)(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
-typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeAsync)(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
-typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegSyncSurface)(RocJpegHandle handle, RocJpegImage *destination);
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeBatched)(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
 typedef const char* (ROCJPEGAPI *PfnRocJpegGetErrorName)(RocJpegStatus rocjpeg_status);
-
+typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeAsync)(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegSyncSurface)(RocJpegHandle handle, RocJpegImage *destination);
 
 // rocJPEG API dispatch table
 struct RocJpegDispatchTable {

--- a/projects/rocjpeg/api/amd_detail/rocjpeg_api_trace.h
+++ b/projects/rocjpeg/api/amd_detail/rocjpeg_api_trace.h
@@ -58,7 +58,7 @@ typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecode)(RocJpegHandle handle, RocJp
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeBatched)(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
 typedef const char* (ROCJPEGAPI *PfnRocJpegGetErrorName)(RocJpegStatus rocjpeg_status);
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeAsync)(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
-typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegSyncSurface)(RocJpegHandle handle, RocJpegImage *destination);
+typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeSync)(RocJpegHandle handle, RocJpegImage *destination);
 
 // rocJPEG API dispatch table
 struct RocJpegDispatchTable {
@@ -77,7 +77,7 @@ struct RocJpegDispatchTable {
     // PLEASE DO NOT EDIT ABOVE!
     // ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 1
     PfnRocJpegDecodeAsync pfn_rocjpeg_decode_async;
-    PfnRocJpegSyncSurface pfn_rocjpeg_sync_surface;
+    PfnRocJpegDecodeSync pfn_rocjpeg_decode_sync;
 
     // PLEASE DO NOT EDIT ABOVE!
     // ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 2

--- a/projects/rocjpeg/api/amd_detail/rocjpeg_api_trace.h
+++ b/projects/rocjpeg/api/amd_detail/rocjpeg_api_trace.h
@@ -45,7 +45,7 @@ THE SOFTWARE.
 
 // Increment the ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION when new runtime API functions are added.
 // If the corresponding ROCJPEG_RUNTIME_API_TABLE_MAJOR_VERSION increases reset the ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION to zero.
-#define ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION 0
+#define ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION 1
 
 // rocJPEG API interface
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegStreamCreate)(RocJpegStreamHandle *jpeg_stream_handle);
@@ -55,6 +55,8 @@ typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegCreate)(RocJpegBackend backend, int
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDestroy)(RocJpegHandle handle);
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegGetImageInfo)(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, uint8_t *num_components, RocJpegChromaSubsampling *subsampling, uint32_t *widths, uint32_t *heights);
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecode)(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeAsync)(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegSyncSurface)(RocJpegHandle handle, RocJpegImage *destination);
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeBatched)(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
 typedef const char* (ROCJPEGAPI *PfnRocJpegGetErrorName)(RocJpegStatus rocjpeg_status);
 
@@ -75,6 +77,11 @@ struct RocJpegDispatchTable {
 
     // PLEASE DO NOT EDIT ABOVE!
     // ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 1
+    PfnRocJpegDecodeAsync pfn_rocjpeg_decode_async;
+    PfnRocJpegSyncSurface pfn_rocjpeg_sync_surface;
+
+    // PLEASE DO NOT EDIT ABOVE!
+    // ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 2
 
     // ******************************************************************************************* //
     //                                            READ BELOW

--- a/projects/rocjpeg/api/rocjpeg/rocjpeg.h
+++ b/projects/rocjpeg/api/rocjpeg/rocjpeg.h
@@ -355,7 +355,7 @@ extern const char* ROCJPEGAPI rocJpegGetErrorName(RocJpegStatus rocjpeg_status);
 RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 
 /**
- * @fn RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
+ * @fn RocJpegStatus ROCJPEGAPI rocJpegDecodeSync(RocJpegHandle handle, RocJpegImage *destination);
  * @ingroup group_amd_rocjpeg
  * @brief Synchronizes a pending asynchronous JPEG decode.
  *
@@ -363,7 +363,7 @@ RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamH
  * @param destination A pointer to RocJpegImage where the decoded image will be stored.
  * @return A RocJpegStatus indicating the success or failure of the sync operation.
  */
-RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
+RocJpegStatus ROCJPEGAPI rocJpegDecodeSync(RocJpegHandle handle, RocJpegImage *destination);
 
 #if defined(__cplusplus)
   }

--- a/projects/rocjpeg/api/rocjpeg/rocjpeg.h
+++ b/projects/rocjpeg/api/rocjpeg/rocjpeg.h
@@ -313,6 +313,30 @@ RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, RocJpegStream
 
 RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 
+/**
+ * @fn RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+ * @ingroup group_amd_rocjpeg
+ * @brief Submits a JPEG decode operation without waiting for the output.
+ *
+ * @param handle The rocJPEG handle.
+ * @param jpeg_stream_handle The rocJPEG stream handle.
+ * @param decode_params The decoding parameters.
+ * @param destination The output image.
+ * @return A RocJpegStatus indicating the success or failure of the submit operation.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+
+/**
+ * @fn RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
+ * @ingroup group_amd_rocjpeg
+ * @brief Synchronizes a pending asynchronous JPEG decode.
+ *
+ * @param handle The rocJPEG handle.
+ * @param destination A pointer to RocJpegImage where the decoded image will be stored.
+ * @return A RocJpegStatus indicating the success or failure of the sync operation.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
+
 
 /**
  * @fn RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);

--- a/projects/rocjpeg/api/rocjpeg/rocjpeg.h
+++ b/projects/rocjpeg/api/rocjpeg/rocjpeg.h
@@ -314,31 +314,6 @@ RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, RocJpegStream
 RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 
 /**
- * @fn RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
- * @ingroup group_amd_rocjpeg
- * @brief Submits a JPEG decode operation without waiting for the output.
- *
- * @param handle The rocJPEG handle.
- * @param jpeg_stream_handle The rocJPEG stream handle.
- * @param decode_params The decoding parameters.
- * @param destination The output image.
- * @return A RocJpegStatus indicating the success or failure of the submit operation.
- */
-RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
-
-/**
- * @fn RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
- * @ingroup group_amd_rocjpeg
- * @brief Synchronizes a pending asynchronous JPEG decode.
- *
- * @param handle The rocJPEG handle.
- * @param destination A pointer to RocJpegImage where the decoded image will be stored.
- * @return A RocJpegStatus indicating the success or failure of the sync operation.
- */
-RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
-
-
-/**
  * @fn RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
  * @ingroup group_amd_rocjpeg
  * @brief Decodes a batch of JPEG images using the rocJPEG library.
@@ -365,6 +340,30 @@ RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStrea
  * @return A pointer to a constant character string representing the error name.
  */
 extern const char* ROCJPEGAPI rocJpegGetErrorName(RocJpegStatus rocjpeg_status);
+
+/**
+ * @fn RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+ * @ingroup group_amd_rocjpeg
+ * @brief Submits a JPEG decode operation without waiting for the output.
+ *
+ * @param handle The rocJPEG handle.
+ * @param jpeg_stream_handle The rocJPEG stream handle.
+ * @param decode_params The decoding parameters.
+ * @param destination The output image.
+ * @return A RocJpegStatus indicating the success or failure of the submit operation.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+
+/**
+ * @fn RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
+ * @ingroup group_amd_rocjpeg
+ * @brief Synchronizes a pending asynchronous JPEG decode.
+ *
+ * @param handle The rocJPEG handle.
+ * @param destination A pointer to RocJpegImage where the decoded image will be stored.
+ * @return A RocJpegStatus indicating the success or failure of the sync operation.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
 
 #if defined(__cplusplus)
   }

--- a/projects/rocjpeg/api/rocjpeg/rocjpeg.h
+++ b/projects/rocjpeg/api/rocjpeg/rocjpeg.h
@@ -359,6 +359,9 @@ RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamH
  * @ingroup group_amd_rocjpeg
  * @brief Synchronizes a pending asynchronous JPEG decode.
  *
+ * This function must be used in conjunction with rocJpegDecodeAsync to ensure the decoding
+ * is complete before accessing the decoded output.
+ *
  * @param handle The rocJPEG handle.
  * @param destination A pointer to RocJpegImage where the decoded image will be stored.
  * @return A RocJpegStatus indicating the success or failure of the sync operation.

--- a/projects/rocjpeg/samples/jpegDecode/jpegdecode.cpp
+++ b/projects/rocjpeg/samples/jpegDecode/jpegdecode.cpp
@@ -192,20 +192,22 @@ int main(int argc, char **argv) {
 
             // Sync thread: waits for submitted decodes and syncs them
             std::thread sync_thread([&]() {
-                hipSetDevice(device_id);
+                CHECK_HIP(hipSetDevice(device_id));
                 for (int iter = 0; iter < num_iterations; iter++) {
                     RocJpegImage* img;
                     {
                         std::unique_lock<std::mutex> lock(mtx);
-                        cv_pending.wait(lock, [&]{ return !pending_queue.empty(); });
+                        cv_pending.wait(lock, [&]{ return !pending_queue.empty() || sync_error; });
+                        if (sync_error) return;
                         img = pending_queue.front();
                         pending_queue.pop();
                     }
-                    RocJpegStatus s = rocJpegSyncSurface(rocjpeg_handle, img);
-                    if (s != ROCJPEG_STATUS_SUCCESS) {
-                        std::lock_guard<std::mutex> lock(mtx);
-                        status = s;
-                        sync_error = true;
+                    status = rocJpegSyncSurface(rocjpeg_handle, img);
+                    if (status != ROCJPEG_STATUS_SUCCESS) {
+                        {
+                            std::lock_guard<std::mutex> lock(mtx);
+                            sync_error = true;
+                        }
                         cv_available.notify_one();
                         return;
                     }
@@ -228,7 +230,16 @@ int main(int argc, char **argv) {
                     img = available_queue.front();
                     available_queue.pop();
                 }
-                CHECK_ROCJPEG(rocJpegDecodeAsync(rocjpeg_handle, rocjpeg_stream_handle, &decode_params, img));
+                status = rocJpegDecodeAsync(rocjpeg_handle, rocjpeg_stream_handle, &decode_params, img);
+                if (status != ROCJPEG_STATUS_SUCCESS) {
+                    std::cout << "rocJpegDecodeAsync return: " << rocJpegGetErrorName(status) << std::endl;
+                    {
+                        std::lock_guard<std::mutex> lock(mtx);
+                        sync_error = true;
+                    }
+                    cv_pending.notify_one();
+                    break;
+                }
                 {
                     std::lock_guard<std::mutex> lock(mtx);
                     pending_queue.push(img);

--- a/projects/rocjpeg/samples/jpegDecode/jpegdecode.cpp
+++ b/projects/rocjpeg/samples/jpegDecode/jpegdecode.cpp
@@ -51,11 +51,8 @@ int main(int argc, char **argv) {
     uint64_t num_jpegs_with_411_subsampling = 0;
     uint64_t num_jpegs_with_unknown_subsampling = 0;
     uint64_t num_jpegs_with_unsupported_resolution = 0;
-    // decode mode: 0 = sync (default), 1 = async
-    int decode_mode = 0;
-    int num_iterations = 1;
 
-    RocJpegUtils::ParseCommandLine(input_path, output_file_path, save_images, device_id, rocjpeg_backend, decode_params, nullptr, nullptr, argc, argv, &decode_mode, &num_iterations);
+    RocJpegUtils::ParseCommandLine(input_path, output_file_path, save_images, device_id, rocjpeg_backend, decode_params, nullptr, nullptr, argc, argv);
 
     bool is_roi_valid = false;
     uint32_t roi_width;
@@ -163,116 +160,9 @@ int main(int argc, char **argv) {
         }
         std::cout << "Decoding started, please wait! ... " << std::endl;
         auto start_time = std::chrono::high_resolution_clock::now();
-        if (decode_mode == 0) {
-            for (int iter = 0; iter < num_iterations; iter++) {
-                CHECK_ROCJPEG(rocJpegDecode(rocjpeg_handle, rocjpeg_stream_handle, &decode_params, &output_image));
-            }
-        } else {
-            // Async mode: submit and sync in separate threads
-            const int buf_num = 5;
-            std::vector<RocJpegImage> pipeline_images(buf_num);
-            for (int p = 0; p < buf_num; p++) {
-                memset(&pipeline_images[p], 0, sizeof(RocJpegImage));
-                for (uint32_t c = 0; c < num_channels; c++) {
-                    pipeline_images[p].pitch[c] = output_image.pitch[c];
-                    CHECK_HIP(hipMalloc(&pipeline_images[p].channel[c], channel_sizes[c]));
-                }
-            }
-
-            std::queue<RocJpegImage*> pending_queue;
-            std::queue<RocJpegImage*> available_queue;
-            std::mutex mtx;
-            std::condition_variable cv_pending, cv_available;
-            RocJpegImage* last_sync_image = nullptr;
-            RocJpegStatus status = ROCJPEG_STATUS_SUCCESS;
-            bool sync_error = false;
-
-            for (int p = 0; p < buf_num; p++)
-                available_queue.push(&pipeline_images[p]);
-
-            // Sync thread: waits for submitted decodes and syncs them
-            std::thread sync_thread([&]() {
-                CHECK_HIP(hipSetDevice(device_id));
-                for (int iter = 0; iter < num_iterations; iter++) {
-                    RocJpegImage* img;
-                    {
-                        std::unique_lock<std::mutex> lock(mtx);
-                        cv_pending.wait(lock, [&]{ return !pending_queue.empty() || sync_error; });
-                        if (sync_error) return;
-                        img = pending_queue.front();
-                        pending_queue.pop();
-                    }
-                    status = rocJpegDecodeSync(rocjpeg_handle, img);
-                    if (status != ROCJPEG_STATUS_SUCCESS) {
-                        {
-                            std::lock_guard<std::mutex> lock(mtx);
-                            sync_error = true;
-                        }
-                        cv_available.notify_one();
-                        return;
-                    }
-                    last_sync_image = img;
-                    {
-                        std::lock_guard<std::mutex> lock(mtx);
-                        available_queue.push(img);
-                    }
-                    cv_available.notify_one();
-                }
-            });
-
-            // Main thread: submits decodes
-            for (int iter = 0; iter < num_iterations; iter++) {
-                RocJpegImage* img;
-                {
-                    std::unique_lock<std::mutex> lock(mtx);
-                    cv_available.wait(lock, [&]{ return !available_queue.empty() || sync_error; });
-                    if (sync_error) break;
-                    img = available_queue.front();
-                    available_queue.pop();
-                }
-                status = rocJpegDecodeAsync(rocjpeg_handle, rocjpeg_stream_handle, &decode_params, img);
-                if (status != ROCJPEG_STATUS_SUCCESS) {
-                    std::cout << "rocJpegDecodeAsync return: " << rocJpegGetErrorName(status) << std::endl;
-                    {
-                        std::lock_guard<std::mutex> lock(mtx);
-                        sync_error = true;
-                    }
-                    cv_pending.notify_one();
-                    break;
-                }
-                {
-                    std::lock_guard<std::mutex> lock(mtx);
-                    pending_queue.push(img);
-                }
-                cv_pending.notify_one();
-            }
-
-            sync_thread.join();
-            if (sync_error) {
-                std::cerr << "ERROR: Sync thread failed with " << rocJpegGetErrorName(status) << std::endl;
-                return EXIT_FAILURE;
-            }
-
-            // Copy last result to output_image for saving
-            if (save_images && last_sync_image != nullptr) {
-                for (uint32_t c = 0; c < num_channels; c++) {
-                    if (last_sync_image->channel[c] != nullptr && output_image.channel[c] != nullptr) {
-                        CHECK_HIP(hipMemcpy(output_image.channel[c], last_sync_image->channel[c], channel_sizes[c], hipMemcpyDeviceToDevice));
-                    }
-                }
-            }
-
-            // Free pipeline buffers
-            for (int p = 0; p < buf_num; p++) {
-                for (int c = 0; c < ROCJPEG_MAX_COMPONENT; c++) {
-                    if (pipeline_images[p].channel[c] != nullptr) {
-                        CHECK_HIP(hipFree(pipeline_images[p].channel[c]));
-                    }
-                }
-            }
-        }
+        CHECK_ROCJPEG(rocJpegDecode(rocjpeg_handle, rocjpeg_stream_handle, &decode_params, &output_image));
         auto end_time = std::chrono::high_resolution_clock::now();
-        double time_per_image_in_milli_sec = std::chrono::duration<double, std::milli>(end_time - start_time).count() / num_iterations;
+        double time_per_image_in_milli_sec = std::chrono::duration<double, std::milli>(end_time - start_time).count();
         double image_size_in_mpixels = (static_cast<double>(widths[0]) * static_cast<double>(heights[0]) / 1000000);
         image_count++;
 

--- a/projects/rocjpeg/samples/jpegDecode/jpegdecode.cpp
+++ b/projects/rocjpeg/samples/jpegDecode/jpegdecode.cpp
@@ -202,7 +202,7 @@ int main(int argc, char **argv) {
                         img = pending_queue.front();
                         pending_queue.pop();
                     }
-                    status = rocJpegSyncSurface(rocjpeg_handle, img);
+                    status = rocJpegDecodeSync(rocjpeg_handle, img);
                     if (status != ROCJPEG_STATUS_SUCCESS) {
                         {
                             std::lock_guard<std::mutex> lock(mtx);

--- a/projects/rocjpeg/samples/jpegDecode/jpegdecode.cpp
+++ b/projects/rocjpeg/samples/jpegDecode/jpegdecode.cpp
@@ -51,8 +51,11 @@ int main(int argc, char **argv) {
     uint64_t num_jpegs_with_411_subsampling = 0;
     uint64_t num_jpegs_with_unknown_subsampling = 0;
     uint64_t num_jpegs_with_unsupported_resolution = 0;
+    // decode mode: 0 = sync (default), 1 = async
+    int decode_mode = 0;
+    int num_iterations = 1;
 
-    RocJpegUtils::ParseCommandLine(input_path, output_file_path, save_images, device_id, rocjpeg_backend, decode_params, nullptr, nullptr, argc, argv);
+    RocJpegUtils::ParseCommandLine(input_path, output_file_path, save_images, device_id, rocjpeg_backend, decode_params, nullptr, nullptr, argc, argv, &decode_mode, &num_iterations);
 
     bool is_roi_valid = false;
     uint32_t roi_width;
@@ -160,9 +163,105 @@ int main(int argc, char **argv) {
         }
         std::cout << "Decoding started, please wait! ... " << std::endl;
         auto start_time = std::chrono::high_resolution_clock::now();
-        CHECK_ROCJPEG(rocJpegDecode(rocjpeg_handle, rocjpeg_stream_handle, &decode_params, &output_image));
+        if (decode_mode == 0) {
+            for (int iter = 0; iter < num_iterations; iter++) {
+                CHECK_ROCJPEG(rocJpegDecode(rocjpeg_handle, rocjpeg_stream_handle, &decode_params, &output_image));
+            }
+        } else {
+            // Async mode: submit and sync in separate threads
+            const int buf_num = 5;
+            std::vector<RocJpegImage> pipeline_images(buf_num);
+            for (int p = 0; p < buf_num; p++) {
+                memset(&pipeline_images[p], 0, sizeof(RocJpegImage));
+                for (uint32_t c = 0; c < num_channels; c++) {
+                    pipeline_images[p].pitch[c] = output_image.pitch[c];
+                    CHECK_HIP(hipMalloc(&pipeline_images[p].channel[c], channel_sizes[c]));
+                }
+            }
+
+            std::queue<RocJpegImage*> pending_queue;
+            std::queue<RocJpegImage*> available_queue;
+            std::mutex mtx;
+            std::condition_variable cv_pending, cv_available;
+            RocJpegImage* last_sync_image = nullptr;
+            RocJpegStatus status = ROCJPEG_STATUS_SUCCESS;
+            bool sync_error = false;
+
+            for (int p = 0; p < buf_num; p++)
+                available_queue.push(&pipeline_images[p]);
+
+            // Sync thread: waits for submitted decodes and syncs them
+            std::thread sync_thread([&]() {
+                hipSetDevice(device_id);
+                for (int iter = 0; iter < num_iterations; iter++) {
+                    RocJpegImage* img;
+                    {
+                        std::unique_lock<std::mutex> lock(mtx);
+                        cv_pending.wait(lock, [&]{ return !pending_queue.empty(); });
+                        img = pending_queue.front();
+                        pending_queue.pop();
+                    }
+                    RocJpegStatus s = rocJpegSyncSurface(rocjpeg_handle, img);
+                    if (s != ROCJPEG_STATUS_SUCCESS) {
+                        std::lock_guard<std::mutex> lock(mtx);
+                        status = s;
+                        sync_error = true;
+                        cv_available.notify_one();
+                        return;
+                    }
+                    last_sync_image = img;
+                    {
+                        std::lock_guard<std::mutex> lock(mtx);
+                        available_queue.push(img);
+                    }
+                    cv_available.notify_one();
+                }
+            });
+
+            // Main thread: submits decodes
+            for (int iter = 0; iter < num_iterations; iter++) {
+                RocJpegImage* img;
+                {
+                    std::unique_lock<std::mutex> lock(mtx);
+                    cv_available.wait(lock, [&]{ return !available_queue.empty() || sync_error; });
+                    if (sync_error) break;
+                    img = available_queue.front();
+                    available_queue.pop();
+                }
+                CHECK_ROCJPEG(rocJpegDecodeAsync(rocjpeg_handle, rocjpeg_stream_handle, &decode_params, img));
+                {
+                    std::lock_guard<std::mutex> lock(mtx);
+                    pending_queue.push(img);
+                }
+                cv_pending.notify_one();
+            }
+
+            sync_thread.join();
+            if (sync_error) {
+                std::cerr << "ERROR: Sync thread failed with " << rocJpegGetErrorName(status) << std::endl;
+                return EXIT_FAILURE;
+            }
+
+            // Copy last result to output_image for saving
+            if (save_images && last_sync_image != nullptr) {
+                for (uint32_t c = 0; c < num_channels; c++) {
+                    if (last_sync_image->channel[c] != nullptr && output_image.channel[c] != nullptr) {
+                        CHECK_HIP(hipMemcpy(output_image.channel[c], last_sync_image->channel[c], channel_sizes[c], hipMemcpyDeviceToDevice));
+                    }
+                }
+            }
+
+            // Free pipeline buffers
+            for (int p = 0; p < buf_num; p++) {
+                for (int c = 0; c < ROCJPEG_MAX_COMPONENT; c++) {
+                    if (pipeline_images[p].channel[c] != nullptr) {
+                        CHECK_HIP(hipFree(pipeline_images[p].channel[c]));
+                    }
+                }
+            }
+        }
         auto end_time = std::chrono::high_resolution_clock::now();
-        double time_per_image_in_milli_sec = std::chrono::duration<double, std::milli>(end_time - start_time).count();
+        double time_per_image_in_milli_sec = std::chrono::duration<double, std::milli>(end_time - start_time).count() / num_iterations;
         double image_size_in_mpixels = (static_cast<double>(widths[0]) * static_cast<double>(heights[0]) / 1000000);
         image_count++;
 

--- a/projects/rocjpeg/samples/jpegDecodeAsync/CMakeLists.txt
+++ b/projects/rocjpeg/samples/jpegDecodeAsync/CMakeLists.txt
@@ -1,0 +1,78 @@
+################################################################################
+# Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+cmake_minimum_required (VERSION 3.10)
+
+# ROCM Path
+if(DEFINED ENV{ROCM_PATH})
+  set(ROCM_PATH $ENV{ROCM_PATH} CACHE PATH "Default ROCm installation path")
+elseif(ROCM_PATH)
+  message("-- INFO:ROCM_PATH Set -- ${ROCM_PATH}")
+else()
+  set(ROCM_PATH /opt/rocm CACHE PATH "Default ROCm installation path")
+endif()
+# Set AMD Clang as default compiler
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED On)
+set(CMAKE_CXX_EXTENSIONS ON)
+if(NOT DEFINED CMAKE_CXX_COMPILER)
+  set(CMAKE_C_COMPILER ${ROCM_PATH}/lib/llvm/bin/amdclang)
+  set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/amdclang++)
+endif()
+
+project(jpegdecodeasync)
+
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
+
+set (HIP_PLATFORM amd CACHE STRING "HIP platform")
+find_package(HIP QUIET)
+find_package(rocjpeg QUIET)
+find_package(rocprofiler-register QUIET)
+
+if(HIP_FOUND AND rocjpeg_FOUND AND rocprofiler-register_FOUND)
+    # HIP
+    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} hip::host)
+    # rocJPEG
+    include_directories (${rocjpeg_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)
+    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocjpeg::rocjpeg)
+    # std filesystem
+    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} stdc++fs)
+    # rocprofiler-register
+    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocprofiler-register::rocprofiler-register)
+
+    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} jpegdecodeasync.cpp)
+    add_executable(${PROJECT_NAME} ${SOURCES})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17")
+    target_link_libraries(${PROJECT_NAME} ${LINK_LIBRARY_LIST})
+else()
+    message("-- ERROR!: ${PROJECT_NAME} excluded! unmet dependencies")
+    if (NOT HIP_FOUND)
+        message(FATAL_ERROR "-- ERROR!: HIP Not Found!")
+    endif()
+    if (NOT rocjpeg_FOUND)
+        message(FATAL_ERROR "-- ERROR!: rocJPEG Not Found!")
+    endif()
+    if (NOT rocprofiler-register_FOUND)
+        message(FATAL_ERROR "-- ERROR!: rocprofiler-register Not Found!")
+    endif()
+endif()

--- a/projects/rocjpeg/samples/jpegDecodeAsync/README.md
+++ b/projects/rocjpeg/samples/jpegDecodeAsync/README.md
@@ -1,0 +1,27 @@
+# jpegDecodeAsync
+
+This sample demonstrates the asynchronous JPEG decoding API using `rocJpegDecodeAsync` and `rocJpegDecodeSync`. It uses a threaded pipeline where decode submissions and completions are separated across threads for improved throughput.
+
+## Usage
+
+```bash
+./jpegdecodeasync -i <input_path> [-o <output_path>] [-be <backend>] [-d <device_id>] [-fmt <format>] [-crop <rect>] [-n <iterations>]
+```
+
+## Options
+
+- `-i [input path]` - Input path to a single JPEG image (required)
+- `-o [output path]` - Path to save the decoded output image (optional)
+- `-be [backend]` - Select rocJPEG backend: 0 for hardware-accelerated JPEG decoding using VCN (default: 0)
+- `-d [device_id]` - Specify the GPU device ID (default: 0)
+- `-fmt [output format]` - Output format: native, yuv_planar, y, rgb, rgb_planar (optional, default: native)
+- `-crop [crop rectangle]` - Crop rectangle: left,top,right,bottom (optional)
+- `-n [iterations]` - Number of decode iterations per image (optional, default: 1)
+
+## Pipeline Architecture
+
+The sample uses a producer-consumer pipeline:
+- **Main thread (producer)**: Reads JPEG files and submits decode operations via `rocJpegDecodeAsync`
+- **Sync thread (consumer)**: Waits for decode completions via `rocJpegDecodeSync`
+
+This enables true cross-image async pipelining — submitting image N+1 while image N is still being synchronized.

--- a/projects/rocjpeg/samples/jpegDecodeAsync/README.md
+++ b/projects/rocjpeg/samples/jpegDecodeAsync/README.md
@@ -25,5 +25,4 @@ make -j
                   -d        <[device id] - specify the GPU device id for the desired device (use 0 for the first device, 1 for the second device, and so on) [optional - default: 0]>
                   -crop     <[crop rectangle] - crop rectangle for output in a comma-separated format: left,top,right,bottom - [optional]>
                   -n        <[iterations] - number of decode iterations per image - [optional - default: 1]>
-                  -profile  <run synchronous decode benchmark before async for performance comparison - [optional]>
 ```

--- a/projects/rocjpeg/samples/jpegDecodeAsync/README.md
+++ b/projects/rocjpeg/samples/jpegDecodeAsync/README.md
@@ -1,27 +1,29 @@
-# jpegDecodeAsync
+# JPEG decode async sample
 
-This sample demonstrates the asynchronous JPEG decoding API using `rocJpegDecodeAsync` and `rocJpegDecodeSync`. It uses a threaded pipeline where decode submissions and completions are separated across threads for improved throughput.
+The jpeg decode async sample illustrates decoding JPEG images asynchronously using rocJPEG library to get the individual decoded images in one of the supported output format (i.e., native, yuv, y, rgb, rgb_planar). It uses a threaded pipeline with `rocJpegDecodeAsync` and `rocJpegDecodeSync` APIs for improved throughput. This sample can be configured with a device ID and optionally able to dump the output to a file.
 
-## Usage
+## Prerequisites:
 
-```bash
-./jpegdecodeasync -i <input_path> [-o <output_path>] [-be <backend>] [-d <device_id>] [-fmt <format>] [-crop <rect>] [-n <iterations>]
+* Install [rocJPEG](https://rocm.docs.amd.com/projects/rocJPEG/en/latest/install/rocjpeg-build-and-install.html)
+
+## Build
+
+```shell
+mkdir jpeg_decode_async_sample && cd jpeg_decode_async_sample
+cmake ../
+make -j
 ```
 
-## Options
+## Run
 
-- `-i [input path]` - Input path to a single JPEG image (required)
-- `-o [output path]` - Path to save the decoded output image (optional)
-- `-be [backend]` - Select rocJPEG backend: 0 for hardware-accelerated JPEG decoding using VCN (default: 0)
-- `-d [device_id]` - Specify the GPU device ID (default: 0)
-- `-fmt [output format]` - Output format: native, yuv_planar, y, rgb, rgb_planar (optional, default: native)
-- `-crop [crop rectangle]` - Crop rectangle: left,top,right,bottom (optional)
-- `-n [iterations]` - Number of decode iterations per image (optional, default: 1)
-
-## Pipeline Architecture
-
-The sample uses a producer-consumer pipeline:
-- **Main thread (producer)**: Reads JPEG files and submits decode operations via `rocJpegDecodeAsync`
-- **Sync thread (consumer)**: Waits for decode completions via `rocJpegDecodeSync`
-
-This enables true cross-image async pipelining — submitting image N+1 while image N is still being synchronized.
+```shell
+./jpegdecodeasync -i        <[input path] - input path to a single JPEG image or a directory containing JPEG images - [required]>
+                  -be       <[backend] - select rocJPEG backend (0 for hardware-accelerated JPEG decoding using VCN,
+                                                                  1 for hybrid JPEG decoding using CPU and GPU HIP kernels (currently not supported)) [optional - default: 0]>
+                  -fmt      <[output format] - select rocJPEG output format for decoding, one of the [native, yuv_planar, y, rgb, rgb_planar] [optional - default: native]>
+                  -o        <[output path] - path to an output file or a path to a directory - write decoded images to a file or directory based on selected output format [optional]>
+                  -d        <[device id] - specify the GPU device id for the desired device (use 0 for the first device, 1 for the second device, and so on) [optional - default: 0]>
+                  -crop     <[crop rectangle] - crop rectangle for output in a comma-separated format: left,top,right,bottom - [optional]>
+                  -n        <[iterations] - number of decode iterations per image - [optional - default: 1]>
+                  -profile  <run synchronous decode benchmark before async for performance comparison - [optional]>
+```

--- a/projects/rocjpeg/samples/jpegDecodeAsync/jpegdecodeasync.cpp
+++ b/projects/rocjpeg/samples/jpegDecodeAsync/jpegdecodeasync.cpp
@@ -21,10 +21,6 @@ THE SOFTWARE.
 */
 
 #include "../rocjpeg_samples_utils.h"
-#include <thread>
-#include <mutex>
-#include <condition_variable>
-#include <queue>
 
 int main(int argc, char **argv) {
     int device_id = 0;
@@ -34,6 +30,7 @@ int main(int argc, char **argv) {
     uint32_t heights[ROCJPEG_MAX_COMPONENT] = {};
     uint32_t channel_sizes[ROCJPEG_MAX_COMPONENT] = {};
     uint32_t num_channels = 0;
+    int total_images = 0;
     std::string chroma_sub_sampling = "";
     std::string input_path, output_file_path;
     std::vector<std::string> file_paths = {};
@@ -46,23 +43,21 @@ int main(int argc, char **argv) {
     RocJpegImage output_image = {};
     RocJpegDecodeParams decode_params = {};
     RocJpegUtils rocjpeg_utils;
+    uint64_t num_bad_jpegs = 0;
+    uint64_t num_jpegs_with_411_subsampling = 0;
+    uint64_t num_jpegs_with_unknown_subsampling = 0;
+    uint64_t num_jpegs_with_unsupported_resolution = 0;
     int num_iterations = 1;
-    const int buf_num = 5;
+    bool profiling = false;
 
-    RocJpegUtils::ParseCommandLine(input_path, output_file_path, save_images, device_id, rocjpeg_backend, decode_params, nullptr, nullptr, argc, argv, &num_iterations);
+    RocJpegUtils::ParseCommandLine(input_path, output_file_path, save_images, device_id, rocjpeg_backend, decode_params, nullptr, nullptr, argc, argv, &num_iterations, &profiling);
 
     bool is_roi_valid = false;
-    uint32_t roi_width;
-    uint32_t roi_height;
-    roi_width = decode_params.crop_rectangle.right - decode_params.crop_rectangle.left;
-    roi_height = decode_params.crop_rectangle.bottom - decode_params.crop_rectangle.top;
+    uint32_t roi_width  = decode_params.crop_rectangle.right  - decode_params.crop_rectangle.left;
+    uint32_t roi_height = decode_params.crop_rectangle.bottom - decode_params.crop_rectangle.top;
 
     if (!RocJpegUtils::GetFilePaths(input_path, file_paths, is_dir, is_file)) {
         std::cerr << "ERROR: Failed to get input file paths!" << std::endl;
-        return EXIT_FAILURE;
-    }
-    if (file_paths.empty()) {
-        std::cerr << "ERROR: No input file found!" << std::endl;
         return EXIT_FAILURE;
     }
     if (!RocJpegUtils::InitHipDevice(device_id)) {
@@ -73,188 +68,345 @@ int main(int argc, char **argv) {
     CHECK_ROCJPEG(rocJpegCreate(rocjpeg_backend, device_id, &rocjpeg_handle));
     CHECK_ROCJPEG(rocJpegStreamCreate(&rocjpeg_stream_handle));
 
-    // Use the first file only
-    std::string file_path = file_paths[0];
+    std::vector<char> file_data;
 
-    // Read the image from disk.
-    std::ifstream input(file_path.c_str(), std::ios::in | std::ios::binary | std::ios::ate);
-    if (!(input.is_open())) {
-        std::cerr << "ERROR: Cannot open image: " << file_path << std::endl;
-        return EXIT_FAILURE;
-    }
-    std::streamsize file_size = input.tellg();
-    input.seekg(0, std::ios::beg);
-    std::vector<char> file_data(file_size);
-    if (!input.read(file_data.data(), file_size)) {
-        std::cerr << "ERROR: Cannot read from file: " << file_path << std::endl;
-        return EXIT_FAILURE;
-    }
+    // Synchronous decode benchmark for profiling comparison.
+    if (profiling) {
+        uint32_t sync_channel_sizes[ROCJPEG_MAX_COMPONENT] = {};
 
-    std::cout << "Input file name: " << file_path << std::endl;
-    CHECK_ROCJPEG(rocJpegStreamParse(reinterpret_cast<uint8_t*>(file_data.data()), file_size, rocjpeg_stream_handle));
-    CHECK_ROCJPEG(rocJpegGetImageInfo(rocjpeg_handle, rocjpeg_stream_handle, &num_components, &subsampling, widths, heights));
+        std::cout << "Synchronous decoding started, please wait! ... " << std::endl;
+        auto sync_start_time = std::chrono::high_resolution_clock::now();
 
-    if (roi_width > 0 && roi_height > 0 && roi_width <= widths[0] && roi_height <= heights[0]) {
-        is_roi_valid = true;
-    }
+        for (auto& file_path : file_paths) {
+            std::ifstream input(file_path.c_str(), std::ios::in | std::ios::binary | std::ios::ate);
+            if (!input.is_open()) {
+                std::cerr << "ERROR: Cannot open image: " << file_path << std::endl;
+                return EXIT_FAILURE;
+            }
+            std::streamsize file_size = input.tellg();
+            input.seekg(0, std::ios::beg);
+            if (file_data.size() < (size_t)file_size)
+                file_data.resize(file_size);
+            if (!input.read(file_data.data(), file_size)) {
+                std::cerr << "ERROR: Cannot read from file: " << file_path << std::endl;
+                return EXIT_FAILURE;
+            }
 
-    rocjpeg_utils.GetChromaSubsamplingStr(subsampling, chroma_sub_sampling);
-    std::cout << "Input image resolution: " << widths[0] << "x" << heights[0] << std::endl;
-    std::cout << "Chroma subsampling: " + chroma_sub_sampling << std::endl;
-    if (widths[0] < 64 || heights[0] < 64) {
-        std::cerr << "The image resolution is not supported by VCN Hardware" << std::endl;
-        return EXIT_FAILURE;
-    }
-    if (subsampling == ROCJPEG_CSS_411 || subsampling == ROCJPEG_CSS_UNKNOWN) {
-        std::cerr << "The chroma sub-sampling is not supported by VCN Hardware" << std::endl;
-        return EXIT_FAILURE;
-    }
+            RocJpegStatus s = rocJpegStreamParse(reinterpret_cast<uint8_t*>(file_data.data()), file_size, rocjpeg_stream_handle);
+            if (s != ROCJPEG_STATUS_SUCCESS) {
+                if (is_dir) continue;
+                std::cerr << "ERROR: Failed to parse the input jpeg stream with " << rocJpegGetErrorName(s) << std::endl;
+                return EXIT_FAILURE;
+            }
 
-    if (rocjpeg_utils.GetChannelPitchAndSizes(decode_params, subsampling, widths, heights, num_channels, output_image, channel_sizes)) {
-        std::cerr << "ERROR: Failed to get the channel pitch and sizes" << std::endl;
-        return EXIT_FAILURE;
-    }
+            CHECK_ROCJPEG(rocJpegGetImageInfo(rocjpeg_handle, rocjpeg_stream_handle, &num_components, &subsampling, widths, heights));
+            if (widths[0] < 64 || heights[0] < 64) { if (is_dir) continue; return EXIT_FAILURE; }
+            if (subsampling == ROCJPEG_CSS_411 || subsampling == ROCJPEG_CSS_UNKNOWN) { if (is_dir) continue; return EXIT_FAILURE; }
 
-    // Allocate pipeline buffers
-    std::vector<RocJpegImage> pipeline_images(buf_num);
-    for (int p = 0; p < buf_num; p++) {
-        memset(&pipeline_images[p], 0, sizeof(RocJpegImage));
-        for (uint32_t c = 0; c < num_channels; c++) {
-            pipeline_images[p].pitch[c] = output_image.pitch[c];
-            CHECK_HIP(hipMalloc(&pipeline_images[p].channel[c], channel_sizes[c]));
+            if (rocjpeg_utils.GetChannelPitchAndSizes(decode_params, subsampling, widths, heights, num_channels, output_image, channel_sizes)) {
+                std::cerr << "ERROR: Failed to get the channel pitch and sizes" << std::endl;
+                return EXIT_FAILURE;
+            }
+
+            // Check the buffer size, reallocate if not enough.
+            for (uint32_t c = 0; c < num_channels; c++) {
+                if (channel_sizes[c] > sync_channel_sizes[c]) {
+                    if (output_image.channel[c] != nullptr) {
+                        CHECK_HIP(hipFree(output_image.channel[c]));
+                        output_image.channel[c] = nullptr;
+                    }
+                    CHECK_HIP(hipMalloc(&output_image.channel[c], channel_sizes[c]));
+                    sync_channel_sizes[c] = channel_sizes[c];
+                }
+            }
+
+            for (int iter = 0; iter < num_iterations; iter++) {
+                s = rocJpegDecode(rocjpeg_handle, rocjpeg_stream_handle, &decode_params, &output_image);
+                if (s != ROCJPEG_STATUS_SUCCESS) {
+                    std::cerr << "ERROR: rocJpegDecode failed with " << rocJpegGetErrorName(s) << std::endl;
+                    for (int c = 0; c < ROCJPEG_MAX_COMPONENT; c++) {
+                        if (output_image.channel[c] != nullptr) { hipFree(output_image.channel[c]); output_image.channel[c] = nullptr; }
+                    }
+                    return EXIT_FAILURE;
+                }
+            }
+            total_images++;
         }
+
+        auto sync_end_time = std::chrono::high_resolution_clock::now();
+        // Free GPU buffers used by synchronous profiling.
+        for (int c = 0; c < ROCJPEG_MAX_COMPONENT; c++) {
+            if (output_image.channel[c] != nullptr) { CHECK_HIP(hipFree(output_image.channel[c])); output_image.channel[c] = nullptr; }
+        }
+        if (total_images > 0) {
+            double sync_total_ms = std::chrono::duration<double, std::milli>(sync_end_time - sync_start_time).count();
+            double sync_per_image_ms = sync_total_ms / (total_images * num_iterations);
+            std::cout << "Synchronous total decoded images: "          << total_images * num_iterations << std::endl;
+            std::cout << "Synchronous average per image (ms): "        << sync_per_image_ms << std::endl;
+            std::cout << "Synchronous images per sec (Images/Sec): "   << 1000.0 / sync_per_image_ms << std::endl;
+        }
+        std::cout << std::endl;
+        total_images = 0;
     }
 
-    // Allocate output_image for saving
-    for (uint32_t i = 0; i < num_channels; i++) {
-        CHECK_HIP(hipMalloc(&output_image.channel[i], channel_sizes[i]));
-    }
+    // Each pipeline slot is self-contained: it owns its GPU buffers and carries
+    // the image metadata needed for saving, so the main thread can overwrite its
+    // local variables for the next image without touching in-flight slots.
+    struct PipelineSlot {
+        RocJpegImage image = {};
+        uint32_t channel_sizes[ROCJPEG_MAX_COMPONENT] = {};
+        uint32_t num_channels = 0;
+        uint32_t width = 0;
+        uint32_t height = 0;
+        RocJpegChromaSubsampling subsampling = {};
+        std::string file_path;
+    };
 
-    std::queue<RocJpegImage*> pending_queue;
-    std::queue<RocJpegImage*> available_queue;
+    // Pipeline uses buf_num slots shared between main (submit) and sync (wait) threads.
+    // The main thread only blocks when all slots are in-flight (available_queue empty).
+    const int buf_num = 5;
+    std::vector<PipelineSlot> pipeline_slots(buf_num);
+    std::queue<PipelineSlot*> pending_queue;   // submitted, awaiting rocJpegDecodeSync
+    std::queue<PipelineSlot*> available_queue; // idle, ready for next submit
     std::mutex mtx;
     std::condition_variable cv_pending, cv_available;
-    RocJpegStatus sync_status = ROCJPEG_STATUS_SUCCESS;
-    bool sync_error = false;
-    RocJpegImage* last_sync_image = nullptr;
+    RocJpegStatus async_status = ROCJPEG_STATUS_SUCCESS;
+    bool sync_done  = false; // set by main thread when all images are submitted
+    bool sync_error = false; // set by sync thread on failure
+    int  in_flight  = 0;     // decodes submitted but not yet synced
 
     for (int p = 0; p < buf_num; p++)
-        available_queue.push(&pipeline_images[p]);
+        available_queue.push(&pipeline_slots[p]);
 
-    // Sync thread: waits for submitted decodes and syncs them
+    // Sync thread: continuously drains pending_queue by calling rocJpegDecodeSync,
+    // optionally saves the result, then returns the slot to available_queue.
     std::thread sync_thread([&]() {
         CHECK_HIP(hipSetDevice(device_id));
-        for (int iter = 0; iter < num_iterations; iter++) {
-            RocJpegImage* img;
+        while (true) {
+            PipelineSlot* slot;
             {
                 std::unique_lock<std::mutex> lock(mtx);
-                cv_pending.wait(lock, [&]{ return !pending_queue.empty() || sync_error; });
+                cv_pending.wait(lock, [&]{ return !pending_queue.empty() || sync_done || sync_error; });
                 if (sync_error) return;
-                img = pending_queue.front();
+                if (pending_queue.empty()) return; // sync_done with nothing left
+                slot = pending_queue.front();
                 pending_queue.pop();
             }
-            RocJpegStatus status = rocJpegDecodeSync(rocjpeg_handle, img);
-            if (status != ROCJPEG_STATUS_SUCCESS) {
-                sync_status = status;
-                sync_error = true;
-                cv_available.notify_one();
-                return;
+
+            RocJpegStatus s = rocJpegDecodeSync(rocjpeg_handle, &slot->image);
+
+            if (s == ROCJPEG_STATUS_SUCCESS && save_images) {
+                std::string image_save_path = output_file_path;
+                uint32_t width  = is_roi_valid ? roi_width  : slot->width;
+                uint32_t height = is_roi_valid ? roi_height : slot->height;
+                std::string base = slot->file_path.substr(slot->file_path.find_last_of("/\\") + 1);
+                if (is_dir)
+                    rocjpeg_utils.GetOutputFileExt(decode_params.output_format, base, width, height, slot->subsampling, image_save_path);
+                rocjpeg_utils.SaveImage(image_save_path, &slot->image, width, height, slot->subsampling, decode_params.output_format);
             }
-            last_sync_image = img;
+
             {
                 std::lock_guard<std::mutex> lock(mtx);
-                available_queue.push(img);
+                in_flight--;
+                if (s != ROCJPEG_STATUS_SUCCESS) {
+                    async_status = s;
+                    sync_error   = true;
+                    cv_available.notify_all();
+                    return;
+                }
+                available_queue.push(slot);
             }
             cv_available.notify_one();
         }
     });
 
-    if (is_roi_valid) {
-        std::cout << "Cropped image resolution: " << roi_width << "x" << roi_height << std::endl;
-    }
-    std::cout << "Async decoding started (" << num_iterations << " iterations), please wait! ... " << std::endl;
-    auto start_time = std::chrono::high_resolution_clock::now();
-
-    // Main thread: submits decodes
-    for (int iter = 0; iter < num_iterations; iter++) {
-        RocJpegImage* img;
-        {
-            std::unique_lock<std::mutex> lock(mtx);
-            cv_available.wait(lock, [&]{ return !available_queue.empty() || sync_error; });
-            if (sync_error) break;
-            img = available_queue.front();
-            available_queue.pop();
-        }
-        RocJpegStatus status = rocJpegDecodeAsync(rocjpeg_handle, rocjpeg_stream_handle, &decode_params, img);
-        if (status != ROCJPEG_STATUS_SUCCESS) {
-            std::cerr << "ERROR: rocJpegDecodeAsync failed with " << rocJpegGetErrorName(status) << std::endl;
-            sync_error = true;
-            cv_pending.notify_one();
-            break;
-        }
+    auto shutdown = [&]() {
         {
             std::lock_guard<std::mutex> lock(mtx);
-            pending_queue.push(img);
+            sync_done = true;
         }
         cv_pending.notify_one();
+        if (sync_thread.joinable()) sync_thread.join();
+    };
+
+    auto total_start_time = std::chrono::high_resolution_clock::now();
+
+    for (auto& file_path : file_paths) {
+        std::string base_file_name = file_path.substr(file_path.find_last_of("/\\") + 1);
+
+        // Read image from disk.
+        std::ifstream input(file_path.c_str(), std::ios::in | std::ios::binary | std::ios::ate);
+        if (!input.is_open()) {
+            std::cerr << "ERROR: Cannot open image: " << file_path << std::endl;
+            shutdown();
+            return EXIT_FAILURE;
+        }
+        std::streamsize file_size = input.tellg();
+        input.seekg(0, std::ios::beg);
+        if (file_data.size() < (size_t)file_size)
+            file_data.resize(file_size);
+        if (!input.read(file_data.data(), file_size)) {
+            std::cerr << "ERROR: Cannot read from file: " << file_path << std::endl;
+            shutdown();
+            return EXIT_FAILURE;
+        }
+
+        std::cout << "Input file name: " << file_path << std::endl;
+        RocJpegStatus rocjpeg_status = rocJpegStreamParse(reinterpret_cast<uint8_t*>(file_data.data()), file_size, rocjpeg_stream_handle);
+        if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+            if (is_dir) { num_bad_jpegs++; std::cout << std::endl; continue; }
+            std::cerr << "ERROR: Failed to parse the input jpeg stream with " << rocJpegGetErrorName(rocjpeg_status) << std::endl;
+            shutdown();
+            return EXIT_FAILURE;
+        }
+
+        CHECK_ROCJPEG(rocJpegGetImageInfo(rocjpeg_handle, rocjpeg_stream_handle, &num_components, &subsampling, widths, heights));
+
+        if (roi_width > 0 && roi_height > 0 && roi_width <= widths[0] && roi_height <= heights[0])
+            is_roi_valid = true;
+
+        rocjpeg_utils.GetChromaSubsamplingStr(subsampling, chroma_sub_sampling);
+        std::cout << "Input image resolution: " << widths[0] << "x" << heights[0] << std::endl;
+        std::cout << "Chroma subsampling: " << chroma_sub_sampling << std::endl;
+
+        if (widths[0] < 64 || heights[0] < 64) {
+            std::cerr << "The image resolution is not supported by VCN Hardware" << std::endl;
+            if (is_dir) { num_jpegs_with_unsupported_resolution++; std::cout << std::endl; continue; }
+            shutdown();
+            return EXIT_FAILURE;
+        }
+        if (subsampling == ROCJPEG_CSS_411 || subsampling == ROCJPEG_CSS_UNKNOWN) {
+            std::cerr << "The chroma sub-sampling is not supported by VCN Hardware" << std::endl;
+            if (is_dir) {
+                if (subsampling == ROCJPEG_CSS_411)    num_jpegs_with_411_subsampling++;
+                if (subsampling == ROCJPEG_CSS_UNKNOWN) num_jpegs_with_unknown_subsampling++;
+                std::cout << std::endl;
+                continue;
+            }
+            shutdown();
+            return EXIT_FAILURE;
+        }
+
+        if (rocjpeg_utils.GetChannelPitchAndSizes(decode_params, subsampling, widths, heights, num_channels, output_image, channel_sizes)) {
+            std::cerr << "ERROR: Failed to get the channel pitch and sizes" << std::endl;
+            shutdown();
+            return EXIT_FAILURE;
+        }
+
+        // Submit num_iterations async decodes for this image without waiting for
+        // any of them to complete — the sync thread drains concurrently.
+        for (int iter = 0; iter < num_iterations; iter++) {
+            // Check for async failure before blocking on a slot.
+            {
+                std::lock_guard<std::mutex> lock(mtx);
+                if (sync_error) {
+                    std::cerr << "ERROR: Async decode failed with " << rocJpegGetErrorName(async_status) << std::endl;
+                    sync_done = true;
+                    cv_pending.notify_one();
+                    if (sync_thread.joinable()) sync_thread.join();
+                    return EXIT_FAILURE;
+                }
+            }
+
+            PipelineSlot* slot;
+            {
+                std::unique_lock<std::mutex> lock(mtx);
+                // Block only when all slots are in-flight (natural backpressure).
+                cv_available.wait(lock, [&]{ return !available_queue.empty() || sync_error; });
+                if (sync_error) {
+                    std::cerr << "ERROR: Async decode failed with " << rocJpegGetErrorName(async_status) << std::endl;
+                    sync_done = true;
+                    cv_pending.notify_one();
+                    lock.unlock();
+                    if (sync_thread.joinable()) sync_thread.join();
+                    return EXIT_FAILURE;
+                }
+                slot = available_queue.front();
+                available_queue.pop();
+            }
+
+            // Grow slot GPU buffers if this image's channels exceed current allocation.
+            for (uint32_t c = 0; c < num_channels; c++) {
+                if (channel_sizes[c] > slot->channel_sizes[c]) {
+                    if (slot->image.channel[c] != nullptr) {
+                        CHECK_HIP(hipFree(slot->image.channel[c]));
+                        slot->image.channel[c] = nullptr;
+                    }
+                    CHECK_HIP(hipMalloc(&slot->image.channel[c], channel_sizes[c]));
+                    slot->channel_sizes[c] = channel_sizes[c];
+                }
+                slot->image.pitch[c] = output_image.pitch[c];
+            }
+            slot->num_channels = num_channels;
+            slot->width         = widths[0];
+            slot->height        = heights[0];
+            slot->subsampling   = subsampling;
+            slot->file_path     = file_path;
+
+            rocjpeg_status = rocJpegDecodeAsync(rocjpeg_handle, rocjpeg_stream_handle, &decode_params, &slot->image);
+            if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+                std::cerr << "ERROR: rocJpegDecodeAsync returned " << rocJpegGetErrorName(rocjpeg_status) << std::endl;
+                {
+                    std::lock_guard<std::mutex> lock(mtx);
+                    async_status = rocjpeg_status;
+                    sync_error   = true;
+                }
+                cv_pending.notify_one();
+                shutdown();
+                return EXIT_FAILURE;
+            }
+
+            {
+                std::lock_guard<std::mutex> lock(mtx);
+                in_flight++;
+                pending_queue.push(slot);
+            }
+            cv_pending.notify_one();
+        }
+
+        total_images++;
     }
 
-    // Wait for sync thread to finish
-    sync_thread.join();
+    // Drain: wait for all in-flight decodes to complete before reporting stats.
+    {
+        std::unique_lock<std::mutex> lock(mtx);
+        cv_available.wait(lock, [&]{ return in_flight == 0 || sync_error; });
+    }
+    auto total_end_time = std::chrono::high_resolution_clock::now();
 
-    auto end_time = std::chrono::high_resolution_clock::now();
-    double total_time_ms = std::chrono::duration<double, std::milli>(end_time - start_time).count();
-    double time_per_image_ms = total_time_ms / num_iterations;
+    shutdown();
 
     if (sync_error) {
-        std::cerr << "ERROR: Sync thread failed with " << rocJpegGetErrorName(sync_status) << std::endl;
-        for (int p = 0; p < buf_num; p++) {
-            for (int c = 0; c < ROCJPEG_MAX_COMPONENT; c++) {
-                if (pipeline_images[p].channel[c] != nullptr)
-                    hipFree(pipeline_images[p].channel[c]);
-            }
-        }
-        for (int i = 0; i < ROCJPEG_MAX_COMPONENT; i++) {
-            if (output_image.channel[i] != nullptr)
-                hipFree((void *)output_image.channel[i]);
-        }
-        rocJpegDestroy(rocjpeg_handle);
-        rocJpegStreamDestroy(rocjpeg_stream_handle);
-        return EXIT_FAILURE;
+        std::cerr << "ERROR: Async decode failed with " << rocJpegGetErrorName(async_status) << std::endl;
+    } else if (total_images > 0) {
+        double total_time_ms    = std::chrono::duration<double, std::milli>(total_end_time - total_start_time).count();
+        double time_per_image_ms = total_time_ms / (total_images * num_iterations);
+        std::cout << "Total decoded images: "                       << total_images * num_iterations << std::endl;
+        std::cout << "Average processing time per image (ms): "     << time_per_image_ms             << std::endl;
+        std::cout << "Average images per sec (Images/Sec): "        << 1000.0 / time_per_image_ms    << std::endl;
     }
 
-    // Copy last result to output_image for saving
-    if (save_images && last_sync_image != nullptr) {
-        for (uint32_t c = 0; c < num_channels; c++) {
-            if (last_sync_image->channel[c] != nullptr && output_image.channel[c] != nullptr) {
-                CHECK_HIP(hipMemcpy(output_image.channel[c], last_sync_image->channel[c], channel_sizes[c], hipMemcpyDeviceToDevice));
-            }
-        }
-        std::string image_save_path = output_file_path;
-        uint32_t width = is_roi_valid ? roi_width : widths[0];
-        uint32_t height = is_roi_valid ? roi_height : heights[0];
-        rocjpeg_utils.SaveImage(image_save_path, &output_image, width, height, subsampling, decode_params.output_format);
+    if (num_bad_jpegs || num_jpegs_with_411_subsampling || num_jpegs_with_unknown_subsampling || num_jpegs_with_unsupported_resolution) {
+        std::cout << "Total skipped images: "
+                  << num_bad_jpegs + num_jpegs_with_411_subsampling + num_jpegs_with_unknown_subsampling + num_jpegs_with_unsupported_resolution;
+        if (num_bad_jpegs)                        std::cout << " ,total images that cannot be parsed: "               << num_bad_jpegs;
+        if (num_jpegs_with_411_subsampling)        std::cout << " ,total images with YUV 4:1:1 chroma subsampling: "  << num_jpegs_with_411_subsampling;
+        if (num_jpegs_with_unknown_subsampling)    std::cout << " ,total images with unknown chroma subsampling: "    << num_jpegs_with_unknown_subsampling;
+        if (num_jpegs_with_unsupported_resolution) std::cout << " ,total images with unsupported resolution: "        << num_jpegs_with_unsupported_resolution;
+        std::cout << std::endl;
     }
 
-    std::cout << "Total time (ms): " << total_time_ms << std::endl;
-    std::cout << "Average processing time per image (ms): " << time_per_image_ms << std::endl;
-    std::cout << "Average images per sec: " << 1000.0 / time_per_image_ms << std::endl;
-
-    // Free pipeline buffers
+    // Cleanup pipeline slot GPU buffers.
     for (int p = 0; p < buf_num; p++) {
         for (int c = 0; c < ROCJPEG_MAX_COMPONENT; c++) {
-            if (pipeline_images[p].channel[c] != nullptr) {
-                CHECK_HIP(hipFree(pipeline_images[p].channel[c]));
+            if (pipeline_slots[p].image.channel[c] != nullptr) {
+                CHECK_HIP(hipFree(pipeline_slots[p].image.channel[c]));
+                pipeline_slots[p].image.channel[c] = nullptr;
             }
         }
     }
-    for (int i = 0; i < ROCJPEG_MAX_COMPONENT; i++) {
-        if (output_image.channel[i] != nullptr) {
-            CHECK_HIP(hipFree((void *)output_image.channel[i]));
-            output_image.channel[i] = nullptr;
-        }
-    }
 
+    // output_image holds only pitch/size metadata (no channel buffers allocated in async mode).
     CHECK_ROCJPEG(rocJpegDestroy(rocjpeg_handle));
     CHECK_ROCJPEG(rocJpegStreamDestroy(rocjpeg_stream_handle));
     std::cout << "Decoding completed!" << std::endl;

--- a/projects/rocjpeg/samples/jpegDecodeAsync/jpegdecodeasync.cpp
+++ b/projects/rocjpeg/samples/jpegDecodeAsync/jpegdecodeasync.cpp
@@ -74,7 +74,6 @@ int main(int argc, char **argv) {
     if (profiling) {
         uint32_t sync_channel_sizes[ROCJPEG_MAX_COMPONENT] = {};
 
-        std::cout << "Synchronous decoding started, please wait! ... " << std::endl;
         auto sync_start_time = std::chrono::high_resolution_clock::now();
 
         for (auto& file_path : file_paths) {
@@ -100,6 +99,10 @@ int main(int argc, char **argv) {
             }
 
             CHECK_ROCJPEG(rocJpegGetImageInfo(rocjpeg_handle, rocjpeg_stream_handle, &num_components, &subsampling, widths, heights));
+            rocjpeg_utils.GetChromaSubsamplingStr(subsampling, chroma_sub_sampling);
+            std::cout << "(Sync) Input file name: " << file_path << std::endl;
+            std::cout << "(Sync) Input image resolution: " << widths[0] << "x" << heights[0] << std::endl;
+            std::cout << "(Sync) Chroma subsampling: " << chroma_sub_sampling << std::endl;
             if (widths[0] < 64 || heights[0] < 64) { if (is_dir) continue; return EXIT_FAILURE; }
             if (subsampling == ROCJPEG_CSS_411 || subsampling == ROCJPEG_CSS_UNKNOWN) { if (is_dir) continue; return EXIT_FAILURE; }
 
@@ -141,9 +144,9 @@ int main(int argc, char **argv) {
         if (total_images > 0) {
             double sync_total_ms = std::chrono::duration<double, std::milli>(sync_end_time - sync_start_time).count();
             double sync_per_image_ms = sync_total_ms / (total_images * num_iterations);
-            std::cout << "Synchronous total decoded images: "          << total_images * num_iterations << std::endl;
-            std::cout << "Synchronous average per image (ms): "        << sync_per_image_ms << std::endl;
-            std::cout << "Synchronous images per sec (Images/Sec): "   << 1000.0 / sync_per_image_ms << std::endl;
+            std::cout << "(Sync) Total decoded images: "                << total_images * num_iterations << std::endl;
+            std::cout << "(Sync) Average processing time per image (ms): " << sync_per_image_ms << std::endl;
+            std::cout << "(Sync) Average images per sec (Images/Sec): " << 1000.0 / sync_per_image_ms << std::endl;
         }
         std::cout << std::endl;
         total_images = 0;
@@ -251,7 +254,7 @@ int main(int argc, char **argv) {
             return EXIT_FAILURE;
         }
 
-        std::cout << "Input file name: " << file_path << std::endl;
+        std::cout << "(Async) Input file name: " << file_path << std::endl;
         RocJpegStatus rocjpeg_status = rocJpegStreamParse(reinterpret_cast<uint8_t*>(file_data.data()), file_size, rocjpeg_stream_handle);
         if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
             if (is_dir) { num_bad_jpegs++; std::cout << std::endl; continue; }
@@ -266,8 +269,8 @@ int main(int argc, char **argv) {
             is_roi_valid = true;
 
         rocjpeg_utils.GetChromaSubsamplingStr(subsampling, chroma_sub_sampling);
-        std::cout << "Input image resolution: " << widths[0] << "x" << heights[0] << std::endl;
-        std::cout << "Chroma subsampling: " << chroma_sub_sampling << std::endl;
+        std::cout << "(Async) Input image resolution: " << widths[0] << "x" << heights[0] << std::endl;
+        std::cout << "(Async) Chroma subsampling: " << chroma_sub_sampling << std::endl;
 
         if (widths[0] < 64 || heights[0] < 64) {
             std::cerr << "The image resolution is not supported by VCN Hardware" << std::endl;
@@ -381,9 +384,9 @@ int main(int argc, char **argv) {
     } else if (total_images > 0) {
         double total_time_ms    = std::chrono::duration<double, std::milli>(total_end_time - total_start_time).count();
         double time_per_image_ms = total_time_ms / (total_images * num_iterations);
-        std::cout << "Total decoded images: "                       << total_images * num_iterations << std::endl;
-        std::cout << "Average processing time per image (ms): "     << time_per_image_ms             << std::endl;
-        std::cout << "Average images per sec (Images/Sec): "        << 1000.0 / time_per_image_ms    << std::endl;
+        std::cout << "(Async) Total decoded images: "                << total_images * num_iterations << std::endl;
+        std::cout << "(Async) Average processing time per image (ms): " << time_per_image_ms << std::endl;
+        std::cout << "(Async) Average images per sec (Images/Sec): " << 1000.0 / time_per_image_ms << std::endl;
     }
 
     if (num_bad_jpegs || num_jpegs_with_411_subsampling || num_jpegs_with_unknown_subsampling || num_jpegs_with_unsupported_resolution) {

--- a/projects/rocjpeg/samples/jpegDecodeAsync/jpegdecodeasync.cpp
+++ b/projects/rocjpeg/samples/jpegDecodeAsync/jpegdecodeasync.cpp
@@ -1,0 +1,262 @@
+/*
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "../rocjpeg_samples_utils.h"
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <queue>
+
+int main(int argc, char **argv) {
+    int device_id = 0;
+    bool save_images = false;
+    uint8_t num_components;
+    uint32_t widths[ROCJPEG_MAX_COMPONENT] = {};
+    uint32_t heights[ROCJPEG_MAX_COMPONENT] = {};
+    uint32_t channel_sizes[ROCJPEG_MAX_COMPONENT] = {};
+    uint32_t num_channels = 0;
+    std::string chroma_sub_sampling = "";
+    std::string input_path, output_file_path;
+    std::vector<std::string> file_paths = {};
+    bool is_dir = false;
+    bool is_file = false;
+    RocJpegChromaSubsampling subsampling;
+    RocJpegBackend rocjpeg_backend = ROCJPEG_BACKEND_HARDWARE;
+    RocJpegHandle rocjpeg_handle = nullptr;
+    RocJpegStreamHandle rocjpeg_stream_handle = nullptr;
+    RocJpegImage output_image = {};
+    RocJpegDecodeParams decode_params = {};
+    RocJpegUtils rocjpeg_utils;
+    int num_iterations = 1;
+    const int buf_num = 5;
+
+    RocJpegUtils::ParseCommandLine(input_path, output_file_path, save_images, device_id, rocjpeg_backend, decode_params, nullptr, nullptr, argc, argv, &num_iterations);
+
+    bool is_roi_valid = false;
+    uint32_t roi_width;
+    uint32_t roi_height;
+    roi_width = decode_params.crop_rectangle.right - decode_params.crop_rectangle.left;
+    roi_height = decode_params.crop_rectangle.bottom - decode_params.crop_rectangle.top;
+
+    if (!RocJpegUtils::GetFilePaths(input_path, file_paths, is_dir, is_file)) {
+        std::cerr << "ERROR: Failed to get input file paths!" << std::endl;
+        return EXIT_FAILURE;
+    }
+    if (file_paths.empty()) {
+        std::cerr << "ERROR: No input file found!" << std::endl;
+        return EXIT_FAILURE;
+    }
+    if (!RocJpegUtils::InitHipDevice(device_id)) {
+        std::cerr << "ERROR: Failed to initialize HIP!" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    CHECK_ROCJPEG(rocJpegCreate(rocjpeg_backend, device_id, &rocjpeg_handle));
+    CHECK_ROCJPEG(rocJpegStreamCreate(&rocjpeg_stream_handle));
+
+    // Use the first file only
+    std::string file_path = file_paths[0];
+
+    // Read the image from disk.
+    std::ifstream input(file_path.c_str(), std::ios::in | std::ios::binary | std::ios::ate);
+    if (!(input.is_open())) {
+        std::cerr << "ERROR: Cannot open image: " << file_path << std::endl;
+        return EXIT_FAILURE;
+    }
+    std::streamsize file_size = input.tellg();
+    input.seekg(0, std::ios::beg);
+    std::vector<char> file_data(file_size);
+    if (!input.read(file_data.data(), file_size)) {
+        std::cerr << "ERROR: Cannot read from file: " << file_path << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "Input file name: " << file_path << std::endl;
+    CHECK_ROCJPEG(rocJpegStreamParse(reinterpret_cast<uint8_t*>(file_data.data()), file_size, rocjpeg_stream_handle));
+    CHECK_ROCJPEG(rocJpegGetImageInfo(rocjpeg_handle, rocjpeg_stream_handle, &num_components, &subsampling, widths, heights));
+
+    if (roi_width > 0 && roi_height > 0 && roi_width <= widths[0] && roi_height <= heights[0]) {
+        is_roi_valid = true;
+    }
+
+    rocjpeg_utils.GetChromaSubsamplingStr(subsampling, chroma_sub_sampling);
+    std::cout << "Input image resolution: " << widths[0] << "x" << heights[0] << std::endl;
+    std::cout << "Chroma subsampling: " + chroma_sub_sampling << std::endl;
+    if (widths[0] < 64 || heights[0] < 64) {
+        std::cerr << "The image resolution is not supported by VCN Hardware" << std::endl;
+        return EXIT_FAILURE;
+    }
+    if (subsampling == ROCJPEG_CSS_411 || subsampling == ROCJPEG_CSS_UNKNOWN) {
+        std::cerr << "The chroma sub-sampling is not supported by VCN Hardware" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    if (rocjpeg_utils.GetChannelPitchAndSizes(decode_params, subsampling, widths, heights, num_channels, output_image, channel_sizes)) {
+        std::cerr << "ERROR: Failed to get the channel pitch and sizes" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Allocate pipeline buffers
+    std::vector<RocJpegImage> pipeline_images(buf_num);
+    for (int p = 0; p < buf_num; p++) {
+        memset(&pipeline_images[p], 0, sizeof(RocJpegImage));
+        for (uint32_t c = 0; c < num_channels; c++) {
+            pipeline_images[p].pitch[c] = output_image.pitch[c];
+            CHECK_HIP(hipMalloc(&pipeline_images[p].channel[c], channel_sizes[c]));
+        }
+    }
+
+    // Allocate output_image for saving
+    for (uint32_t i = 0; i < num_channels; i++) {
+        CHECK_HIP(hipMalloc(&output_image.channel[i], channel_sizes[i]));
+    }
+
+    std::queue<RocJpegImage*> pending_queue;
+    std::queue<RocJpegImage*> available_queue;
+    std::mutex mtx;
+    std::condition_variable cv_pending, cv_available;
+    RocJpegStatus sync_status = ROCJPEG_STATUS_SUCCESS;
+    bool sync_error = false;
+    RocJpegImage* last_sync_image = nullptr;
+
+    for (int p = 0; p < buf_num; p++)
+        available_queue.push(&pipeline_images[p]);
+
+    // Sync thread: waits for submitted decodes and syncs them
+    std::thread sync_thread([&]() {
+        CHECK_HIP(hipSetDevice(device_id));
+        for (int iter = 0; iter < num_iterations; iter++) {
+            RocJpegImage* img;
+            {
+                std::unique_lock<std::mutex> lock(mtx);
+                cv_pending.wait(lock, [&]{ return !pending_queue.empty() || sync_error; });
+                if (sync_error) return;
+                img = pending_queue.front();
+                pending_queue.pop();
+            }
+            RocJpegStatus status = rocJpegDecodeSync(rocjpeg_handle, img);
+            if (status != ROCJPEG_STATUS_SUCCESS) {
+                sync_status = status;
+                sync_error = true;
+                cv_available.notify_one();
+                return;
+            }
+            last_sync_image = img;
+            {
+                std::lock_guard<std::mutex> lock(mtx);
+                available_queue.push(img);
+            }
+            cv_available.notify_one();
+        }
+    });
+
+    if (is_roi_valid) {
+        std::cout << "Cropped image resolution: " << roi_width << "x" << roi_height << std::endl;
+    }
+    std::cout << "Async decoding started (" << num_iterations << " iterations), please wait! ... " << std::endl;
+    auto start_time = std::chrono::high_resolution_clock::now();
+
+    // Main thread: submits decodes
+    for (int iter = 0; iter < num_iterations; iter++) {
+        RocJpegImage* img;
+        {
+            std::unique_lock<std::mutex> lock(mtx);
+            cv_available.wait(lock, [&]{ return !available_queue.empty() || sync_error; });
+            if (sync_error) break;
+            img = available_queue.front();
+            available_queue.pop();
+        }
+        RocJpegStatus status = rocJpegDecodeAsync(rocjpeg_handle, rocjpeg_stream_handle, &decode_params, img);
+        if (status != ROCJPEG_STATUS_SUCCESS) {
+            std::cerr << "ERROR: rocJpegDecodeAsync failed with " << rocJpegGetErrorName(status) << std::endl;
+            sync_error = true;
+            cv_pending.notify_one();
+            break;
+        }
+        {
+            std::lock_guard<std::mutex> lock(mtx);
+            pending_queue.push(img);
+        }
+        cv_pending.notify_one();
+    }
+
+    // Wait for sync thread to finish
+    sync_thread.join();
+
+    auto end_time = std::chrono::high_resolution_clock::now();
+    double total_time_ms = std::chrono::duration<double, std::milli>(end_time - start_time).count();
+    double time_per_image_ms = total_time_ms / num_iterations;
+
+    if (sync_error) {
+        std::cerr << "ERROR: Sync thread failed with " << rocJpegGetErrorName(sync_status) << std::endl;
+        for (int p = 0; p < buf_num; p++) {
+            for (int c = 0; c < ROCJPEG_MAX_COMPONENT; c++) {
+                if (pipeline_images[p].channel[c] != nullptr)
+                    hipFree(pipeline_images[p].channel[c]);
+            }
+        }
+        for (int i = 0; i < ROCJPEG_MAX_COMPONENT; i++) {
+            if (output_image.channel[i] != nullptr)
+                hipFree((void *)output_image.channel[i]);
+        }
+        rocJpegDestroy(rocjpeg_handle);
+        rocJpegStreamDestroy(rocjpeg_stream_handle);
+        return EXIT_FAILURE;
+    }
+
+    // Copy last result to output_image for saving
+    if (save_images && last_sync_image != nullptr) {
+        for (uint32_t c = 0; c < num_channels; c++) {
+            if (last_sync_image->channel[c] != nullptr && output_image.channel[c] != nullptr) {
+                CHECK_HIP(hipMemcpy(output_image.channel[c], last_sync_image->channel[c], channel_sizes[c], hipMemcpyDeviceToDevice));
+            }
+        }
+        std::string image_save_path = output_file_path;
+        uint32_t width = is_roi_valid ? roi_width : widths[0];
+        uint32_t height = is_roi_valid ? roi_height : heights[0];
+        rocjpeg_utils.SaveImage(image_save_path, &output_image, width, height, subsampling, decode_params.output_format);
+    }
+
+    std::cout << "Total time (ms): " << total_time_ms << std::endl;
+    std::cout << "Average processing time per image (ms): " << time_per_image_ms << std::endl;
+    std::cout << "Average images per sec: " << 1000.0 / time_per_image_ms << std::endl;
+
+    // Free pipeline buffers
+    for (int p = 0; p < buf_num; p++) {
+        for (int c = 0; c < ROCJPEG_MAX_COMPONENT; c++) {
+            if (pipeline_images[p].channel[c] != nullptr) {
+                CHECK_HIP(hipFree(pipeline_images[p].channel[c]));
+            }
+        }
+    }
+    for (int i = 0; i < ROCJPEG_MAX_COMPONENT; i++) {
+        if (output_image.channel[i] != nullptr) {
+            CHECK_HIP(hipFree((void *)output_image.channel[i]));
+            output_image.channel[i] = nullptr;
+        }
+    }
+
+    CHECK_ROCJPEG(rocJpegDestroy(rocjpeg_handle));
+    CHECK_ROCJPEG(rocJpegStreamDestroy(rocjpeg_stream_handle));
+    std::cout << "Decoding completed!" << std::endl;
+    return EXIT_SUCCESS;
+}

--- a/projects/rocjpeg/samples/jpegDecodeAsync/jpegdecodeasync.cpp
+++ b/projects/rocjpeg/samples/jpegDecodeAsync/jpegdecodeasync.cpp
@@ -48,9 +48,8 @@ int main(int argc, char **argv) {
     uint64_t num_jpegs_with_unknown_subsampling = 0;
     uint64_t num_jpegs_with_unsupported_resolution = 0;
     int num_iterations = 1;
-    bool profiling = false;
 
-    RocJpegUtils::ParseCommandLine(input_path, output_file_path, save_images, device_id, rocjpeg_backend, decode_params, nullptr, nullptr, argc, argv, &num_iterations, &profiling);
+    RocJpegUtils::ParseCommandLine(input_path, output_file_path, save_images, device_id, rocjpeg_backend, decode_params, nullptr, nullptr, argc, argv, &num_iterations);
 
     bool is_roi_valid = false;
     uint32_t roi_width  = decode_params.crop_rectangle.right  - decode_params.crop_rectangle.left;
@@ -69,88 +68,6 @@ int main(int argc, char **argv) {
     CHECK_ROCJPEG(rocJpegStreamCreate(&rocjpeg_stream_handle));
 
     std::vector<char> file_data;
-
-    // Synchronous decode benchmark for profiling comparison.
-    if (profiling) {
-        uint32_t sync_channel_sizes[ROCJPEG_MAX_COMPONENT] = {};
-
-        auto sync_start_time = std::chrono::high_resolution_clock::now();
-
-        for (auto& file_path : file_paths) {
-            std::ifstream input(file_path.c_str(), std::ios::in | std::ios::binary | std::ios::ate);
-            if (!input.is_open()) {
-                std::cerr << "ERROR: Cannot open image: " << file_path << std::endl;
-                return EXIT_FAILURE;
-            }
-            std::streamsize file_size = input.tellg();
-            input.seekg(0, std::ios::beg);
-            if (file_data.size() < (size_t)file_size)
-                file_data.resize(file_size);
-            if (!input.read(file_data.data(), file_size)) {
-                std::cerr << "ERROR: Cannot read from file: " << file_path << std::endl;
-                return EXIT_FAILURE;
-            }
-
-            RocJpegStatus s = rocJpegStreamParse(reinterpret_cast<uint8_t*>(file_data.data()), file_size, rocjpeg_stream_handle);
-            if (s != ROCJPEG_STATUS_SUCCESS) {
-                if (is_dir) continue;
-                std::cerr << "ERROR: Failed to parse the input jpeg stream with " << rocJpegGetErrorName(s) << std::endl;
-                return EXIT_FAILURE;
-            }
-
-            CHECK_ROCJPEG(rocJpegGetImageInfo(rocjpeg_handle, rocjpeg_stream_handle, &num_components, &subsampling, widths, heights));
-            rocjpeg_utils.GetChromaSubsamplingStr(subsampling, chroma_sub_sampling);
-            std::cout << "(Sync) Input file name: " << file_path << std::endl;
-            std::cout << "(Sync) Input image resolution: " << widths[0] << "x" << heights[0] << std::endl;
-            std::cout << "(Sync) Chroma subsampling: " << chroma_sub_sampling << std::endl;
-            if (widths[0] < 64 || heights[0] < 64) { if (is_dir) continue; return EXIT_FAILURE; }
-            if (subsampling == ROCJPEG_CSS_411 || subsampling == ROCJPEG_CSS_UNKNOWN) { if (is_dir) continue; return EXIT_FAILURE; }
-
-            if (rocjpeg_utils.GetChannelPitchAndSizes(decode_params, subsampling, widths, heights, num_channels, output_image, channel_sizes)) {
-                std::cerr << "ERROR: Failed to get the channel pitch and sizes" << std::endl;
-                return EXIT_FAILURE;
-            }
-
-            // Check the buffer size, reallocate if not enough.
-            for (uint32_t c = 0; c < num_channels; c++) {
-                if (channel_sizes[c] > sync_channel_sizes[c]) {
-                    if (output_image.channel[c] != nullptr) {
-                        CHECK_HIP(hipFree(output_image.channel[c]));
-                        output_image.channel[c] = nullptr;
-                    }
-                    CHECK_HIP(hipMalloc(&output_image.channel[c], channel_sizes[c]));
-                    sync_channel_sizes[c] = channel_sizes[c];
-                }
-            }
-
-            for (int iter = 0; iter < num_iterations; iter++) {
-                s = rocJpegDecode(rocjpeg_handle, rocjpeg_stream_handle, &decode_params, &output_image);
-                if (s != ROCJPEG_STATUS_SUCCESS) {
-                    std::cerr << "ERROR: rocJpegDecode failed with " << rocJpegGetErrorName(s) << std::endl;
-                    for (int c = 0; c < ROCJPEG_MAX_COMPONENT; c++) {
-                        if (output_image.channel[c] != nullptr) { hipFree(output_image.channel[c]); output_image.channel[c] = nullptr; }
-                    }
-                    return EXIT_FAILURE;
-                }
-            }
-            total_images++;
-        }
-
-        auto sync_end_time = std::chrono::high_resolution_clock::now();
-        // Free GPU buffers used by synchronous profiling.
-        for (int c = 0; c < ROCJPEG_MAX_COMPONENT; c++) {
-            if (output_image.channel[c] != nullptr) { CHECK_HIP(hipFree(output_image.channel[c])); output_image.channel[c] = nullptr; }
-        }
-        if (total_images > 0) {
-            double sync_total_ms = std::chrono::duration<double, std::milli>(sync_end_time - sync_start_time).count();
-            double sync_per_image_ms = sync_total_ms / (total_images * num_iterations);
-            std::cout << "(Sync) Total decoded images: "                << total_images * num_iterations << std::endl;
-            std::cout << "(Sync) Average processing time per image (ms): " << sync_per_image_ms << std::endl;
-            std::cout << "(Sync) Average images per sec (Images/Sec): " << 1000.0 / sync_per_image_ms << std::endl;
-        }
-        std::cout << std::endl;
-        total_images = 0;
-    }
 
     // Each pipeline slot is self-contained: it owns its GPU buffers and carries
     // the image metadata needed for saving, so the main thread can overwrite its
@@ -254,7 +171,7 @@ int main(int argc, char **argv) {
             return EXIT_FAILURE;
         }
 
-        std::cout << "(Async) Input file name: " << file_path << std::endl;
+        std::cout << "Input file name: " << file_path << std::endl;
         RocJpegStatus rocjpeg_status = rocJpegStreamParse(reinterpret_cast<uint8_t*>(file_data.data()), file_size, rocjpeg_stream_handle);
         if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
             if (is_dir) { num_bad_jpegs++; std::cout << std::endl; continue; }
@@ -269,8 +186,8 @@ int main(int argc, char **argv) {
             is_roi_valid = true;
 
         rocjpeg_utils.GetChromaSubsamplingStr(subsampling, chroma_sub_sampling);
-        std::cout << "(Async) Input image resolution: " << widths[0] << "x" << heights[0] << std::endl;
-        std::cout << "(Async) Chroma subsampling: " << chroma_sub_sampling << std::endl;
+        std::cout << "Input image resolution: " << widths[0] << "x" << heights[0] << std::endl;
+        std::cout << "Chroma subsampling: " << chroma_sub_sampling << std::endl;
 
         if (widths[0] < 64 || heights[0] < 64) {
             std::cerr << "The image resolution is not supported by VCN Hardware" << std::endl;
@@ -384,9 +301,9 @@ int main(int argc, char **argv) {
     } else if (total_images > 0) {
         double total_time_ms    = std::chrono::duration<double, std::milli>(total_end_time - total_start_time).count();
         double time_per_image_ms = total_time_ms / (total_images * num_iterations);
-        std::cout << "(Async) Total decoded images: "                << total_images * num_iterations << std::endl;
-        std::cout << "(Async) Average processing time per image (ms): " << time_per_image_ms << std::endl;
-        std::cout << "(Async) Average images per sec (Images/Sec): " << 1000.0 / time_per_image_ms << std::endl;
+        std::cout << "Total decoded images: "                << total_images * num_iterations << std::endl;
+        std::cout << "Average processing time per image (ms): " << time_per_image_ms << std::endl;
+        std::cout << "Average images per sec (Images/Sec): " << 1000.0 / time_per_image_ms << std::endl;
     }
 
     if (num_bad_jpegs || num_jpegs_with_411_subsampling || num_jpegs_with_unknown_subsampling || num_jpegs_with_unsupported_resolution) {

--- a/projects/rocjpeg/samples/rocjpeg_samples_utils.h
+++ b/projects/rocjpeg/samples/rocjpeg_samples_utils.h
@@ -87,13 +87,14 @@ public:
      * @param argv The command line arguments.
      */
     static void ParseCommandLine(std::string &input_path, std::string &output_file_path, bool &save_images, int &device_id,
-                                 RocJpegBackend &rocjpeg_backend, RocJpegDecodeParams &decode_params, int *num_threads, int *batch_size, int argc, char *argv[]) {
+                                 RocJpegBackend &rocjpeg_backend, RocJpegDecodeParams &decode_params, int *num_threads, int *batch_size,
+                                 int argc, char *argv[], int *decode_mode = nullptr, int *num_iterations = nullptr) {
         if(argc <= 1) {
-            ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr);
+            ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr, num_iterations != nullptr);
         }
         for (int i = 1; i < argc; i++) {
             if (!strcmp(argv[i], "-h")) {
-                ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr);
+                ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr, num_iterations != nullptr);
             }
             if (!strcmp(argv[i], "-i")) {
                 if (++i == argc) {
@@ -174,7 +175,33 @@ public:
                 }
                 continue;
             }
-            ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr);
+            if (!strcmp(argv[i], "-m")) {
+                if (++i == argc) {
+                    ShowHelpAndExit("-m", num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr);
+                }
+                if (decode_mode != nullptr) {
+                    std::string mode = argv[i];
+                    if (mode == "sync") *decode_mode = 0;
+                    else if (mode == "async") *decode_mode = 1;
+                    else {
+                        ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr);
+                    }
+                }
+                continue;
+            }
+            if (!strcmp(argv[i], "-n")) {
+                if (++i == argc) {
+                    ShowHelpAndExit("-n", num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr, num_iterations != nullptr);
+                }
+                if (num_iterations != nullptr) {
+                    *num_iterations = atoi(argv[i]);
+                    if (*num_iterations <= 0) {
+                        ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr, num_iterations != nullptr);
+                    }
+                }
+                continue;
+            }
+            ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr, num_iterations != nullptr);
         }
     }
 
@@ -641,7 +668,7 @@ private:
      * @param option The option to display in the help message (optional).
      * @param show_threads Flag indicating whether to show the number of threads in the help message.
      */
-    static void ShowHelpAndExit(const char *option = nullptr, bool show_threads = false, bool show_batch_size = false) {
+    static void ShowHelpAndExit(const char *option = nullptr, bool show_threads = false, bool show_batch_size = false, bool show_decode_mode = false, bool show_iterations = false) {
         std::cout  << "Options:\n"
         "-i     [input path] - input path to a single JPEG image or a directory containing JPEG images - [required]\n"
         "-be    [backend] - select rocJPEG backend (0 for hardware-accelerated JPEG decoding using VCN,\n"
@@ -655,6 +682,12 @@ private:
         }
         if (show_batch_size) {
             std::cout << "-b     [batch_size] - decode images from input by batches of a specified size - [optional - default: 1]\n";
+        }
+        if (show_decode_mode) {
+            std::cout << "-m     [decode mode] - select decode mode: sync or async - [optional - default: sync]\n";
+        }
+        if (show_iterations) {
+            std::cout << "-n     [iterations] - number of decode iterations per image - [optional - default: 1]\n";
         }
         exit(0);
     }

--- a/projects/rocjpeg/samples/rocjpeg_samples_utils.h
+++ b/projects/rocjpeg/samples/rocjpeg_samples_utils.h
@@ -87,13 +87,13 @@ public:
      * @param argv The command line arguments.
      */
     static void ParseCommandLine(std::string &input_path, std::string &output_file_path, bool &save_images, int &device_id,
-                                 RocJpegBackend &rocjpeg_backend, RocJpegDecodeParams &decode_params, int *num_threads, int *batch_size, int argc, char *argv[], int *num_iterations = nullptr) {
+                                 RocJpegBackend &rocjpeg_backend, RocJpegDecodeParams &decode_params, int *num_threads, int *batch_size, int argc, char *argv[], int *num_iterations = nullptr, bool *profiling = nullptr) {
         if(argc <= 1) {
-            ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr);
+            ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr, profiling != nullptr);
         }
         for (int i = 1; i < argc; i++) {
             if (!strcmp(argv[i], "-h")) {
-                ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr);
+                ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr, profiling != nullptr);
             }
             if (!strcmp(argv[i], "-i")) {
                 if (++i == argc) {
@@ -176,17 +176,23 @@ public:
             }
             if (!strcmp(argv[i], "-n")) {
                 if (++i == argc) {
-                    ShowHelpAndExit("-n", num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr);
+                    ShowHelpAndExit("-n", num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr, profiling != nullptr);
                 }
                 if (num_iterations != nullptr) {
                     *num_iterations = atoi(argv[i]);
                     if (*num_iterations <= 0) {
-                        ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr);
+                        ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr, profiling != nullptr);
                     }
                 }
                 continue;
             }
-            ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr);
+            if (!strcmp(argv[i], "-profile")) {
+                if (profiling != nullptr) {
+                    *profiling = true;
+                }
+                continue;
+            }
+            ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr, profiling != nullptr);
         }
     }
 
@@ -653,7 +659,7 @@ private:
      * @param option The option to display in the help message (optional).
      * @param show_threads Flag indicating whether to show the number of threads in the help message.
      */
-    static void ShowHelpAndExit(const char *option = nullptr, bool show_threads = false, bool show_batch_size = false, bool show_iterations = false) {
+    static void ShowHelpAndExit(const char *option = nullptr, bool show_threads = false, bool show_batch_size = false, bool show_iterations = false, bool show_profiling = false) {
         std::cout  << "Options:\n"
         "-i     [input path] - input path to a single JPEG image or a directory containing JPEG images - [required]\n"
         "-be    [backend] - select rocJPEG backend (0 for hardware-accelerated JPEG decoding using VCN,\n"
@@ -670,6 +676,9 @@ private:
         }
         if (show_iterations) {
             std::cout << "-n     [iterations] - number of decode iterations per image - [optional - default: 1]\n";
+        }
+        if (show_profiling) {
+            std::cout << "-profile - run synchronous decode benchmark for comparison - [optional]\n";
         }
         exit(0);
     }

--- a/projects/rocjpeg/samples/rocjpeg_samples_utils.h
+++ b/projects/rocjpeg/samples/rocjpeg_samples_utils.h
@@ -87,14 +87,13 @@ public:
      * @param argv The command line arguments.
      */
     static void ParseCommandLine(std::string &input_path, std::string &output_file_path, bool &save_images, int &device_id,
-                                 RocJpegBackend &rocjpeg_backend, RocJpegDecodeParams &decode_params, int *num_threads, int *batch_size,
-                                 int argc, char *argv[], int *decode_mode = nullptr, int *num_iterations = nullptr) {
+                                 RocJpegBackend &rocjpeg_backend, RocJpegDecodeParams &decode_params, int *num_threads, int *batch_size, int argc, char *argv[], int *num_iterations = nullptr) {
         if(argc <= 1) {
-            ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr, num_iterations != nullptr);
+            ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr);
         }
         for (int i = 1; i < argc; i++) {
             if (!strcmp(argv[i], "-h")) {
-                ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr, num_iterations != nullptr);
+                ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr);
             }
             if (!strcmp(argv[i], "-i")) {
                 if (++i == argc) {
@@ -175,33 +174,19 @@ public:
                 }
                 continue;
             }
-            if (!strcmp(argv[i], "-m")) {
-                if (++i == argc) {
-                    ShowHelpAndExit("-m", num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr);
-                }
-                if (decode_mode != nullptr) {
-                    std::string mode = argv[i];
-                    if (mode == "sync") *decode_mode = 0;
-                    else if (mode == "async") *decode_mode = 1;
-                    else {
-                        ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr);
-                    }
-                }
-                continue;
-            }
             if (!strcmp(argv[i], "-n")) {
                 if (++i == argc) {
-                    ShowHelpAndExit("-n", num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr, num_iterations != nullptr);
+                    ShowHelpAndExit("-n", num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr);
                 }
                 if (num_iterations != nullptr) {
                     *num_iterations = atoi(argv[i]);
                     if (*num_iterations <= 0) {
-                        ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr, num_iterations != nullptr);
+                        ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr);
                     }
                 }
                 continue;
             }
-            ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, decode_mode != nullptr, num_iterations != nullptr);
+            ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr);
         }
     }
 
@@ -668,7 +653,7 @@ private:
      * @param option The option to display in the help message (optional).
      * @param show_threads Flag indicating whether to show the number of threads in the help message.
      */
-    static void ShowHelpAndExit(const char *option = nullptr, bool show_threads = false, bool show_batch_size = false, bool show_decode_mode = false, bool show_iterations = false) {
+    static void ShowHelpAndExit(const char *option = nullptr, bool show_threads = false, bool show_batch_size = false, bool show_iterations = false) {
         std::cout  << "Options:\n"
         "-i     [input path] - input path to a single JPEG image or a directory containing JPEG images - [required]\n"
         "-be    [backend] - select rocJPEG backend (0 for hardware-accelerated JPEG decoding using VCN,\n"
@@ -682,9 +667,6 @@ private:
         }
         if (show_batch_size) {
             std::cout << "-b     [batch_size] - decode images from input by batches of a specified size - [optional - default: 1]\n";
-        }
-        if (show_decode_mode) {
-            std::cout << "-m     [decode mode] - select decode mode: sync or async - [optional - default: sync]\n";
         }
         if (show_iterations) {
             std::cout << "-n     [iterations] - number of decode iterations per image - [optional - default: 1]\n";

--- a/projects/rocjpeg/samples/rocjpeg_samples_utils.h
+++ b/projects/rocjpeg/samples/rocjpeg_samples_utils.h
@@ -87,13 +87,13 @@ public:
      * @param argv The command line arguments.
      */
     static void ParseCommandLine(std::string &input_path, std::string &output_file_path, bool &save_images, int &device_id,
-                                 RocJpegBackend &rocjpeg_backend, RocJpegDecodeParams &decode_params, int *num_threads, int *batch_size, int argc, char *argv[], int *num_iterations = nullptr, bool *profiling = nullptr) {
+                                 RocJpegBackend &rocjpeg_backend, RocJpegDecodeParams &decode_params, int *num_threads, int *batch_size, int argc, char *argv[], int *num_iterations = nullptr) {
         if(argc <= 1) {
-            ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr, profiling != nullptr);
+            ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr);
         }
         for (int i = 1; i < argc; i++) {
             if (!strcmp(argv[i], "-h")) {
-                ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr, profiling != nullptr);
+                ShowHelpAndExit("", num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr);
             }
             if (!strcmp(argv[i], "-i")) {
                 if (++i == argc) {
@@ -176,23 +176,17 @@ public:
             }
             if (!strcmp(argv[i], "-n")) {
                 if (++i == argc) {
-                    ShowHelpAndExit("-n", num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr, profiling != nullptr);
+                    ShowHelpAndExit("-n", num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr);
                 }
                 if (num_iterations != nullptr) {
                     *num_iterations = atoi(argv[i]);
                     if (*num_iterations <= 0) {
-                        ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr, profiling != nullptr);
+                        ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr);
                     }
                 }
                 continue;
             }
-            if (!strcmp(argv[i], "-profile")) {
-                if (profiling != nullptr) {
-                    *profiling = true;
-                }
-                continue;
-            }
-            ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr, profiling != nullptr);
+            ShowHelpAndExit(argv[i], num_threads != nullptr, batch_size != nullptr, num_iterations != nullptr);
         }
     }
 
@@ -659,7 +653,7 @@ private:
      * @param option The option to display in the help message (optional).
      * @param show_threads Flag indicating whether to show the number of threads in the help message.
      */
-    static void ShowHelpAndExit(const char *option = nullptr, bool show_threads = false, bool show_batch_size = false, bool show_iterations = false, bool show_profiling = false) {
+    static void ShowHelpAndExit(const char *option = nullptr, bool show_threads = false, bool show_batch_size = false, bool show_iterations = false) {
         std::cout  << "Options:\n"
         "-i     [input path] - input path to a single JPEG image or a directory containing JPEG images - [required]\n"
         "-be    [backend] - select rocJPEG backend (0 for hardware-accelerated JPEG decoding using VCN,\n"
@@ -676,9 +670,6 @@ private:
         }
         if (show_iterations) {
             std::cout << "-n     [iterations] - number of decode iterations per image - [optional - default: 1]\n";
-        }
-        if (show_profiling) {
-            std::cout << "-profile - run synchronous decode benchmark for comparison - [optional]\n";
         }
         exit(0);
     }

--- a/projects/rocjpeg/src/amd_detail/rocjpeg_api_dispatch_interface.cpp
+++ b/projects/rocjpeg/src/amd_detail/rocjpeg_api_dispatch_interface.cpp
@@ -47,15 +47,15 @@ RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, RocJpegStream
 RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
     return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode(handle, jpeg_stream_handle, decode_params, destination);
 }
-RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
-    return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode_async(handle, jpeg_stream_handle, decode_params, destination);
-}
-RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination) {
-    return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_sync_surface(handle, destination);
-}
 RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations) {
     return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode_batched(handle, jpeg_stream_handles, batch_size, decode_params, destinations);
 }
 const char* ROCJPEGAPI rocJpegGetErrorName(RocJpegStatus rocjpeg_status) {
     return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_get_error_name(rocjpeg_status);
+}
+RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
+    return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode_async(handle, jpeg_stream_handle, decode_params, destination);
+}
+RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination) {
+    return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_sync_surface(handle, destination);
 }

--- a/projects/rocjpeg/src/amd_detail/rocjpeg_api_dispatch_interface.cpp
+++ b/projects/rocjpeg/src/amd_detail/rocjpeg_api_dispatch_interface.cpp
@@ -56,6 +56,6 @@ const char* ROCJPEGAPI rocJpegGetErrorName(RocJpegStatus rocjpeg_status) {
 RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
     return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode_async(handle, jpeg_stream_handle, decode_params, destination);
 }
-RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination) {
-    return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_sync_surface(handle, destination);
+RocJpegStatus ROCJPEGAPI rocJpegDecodeSync(RocJpegHandle handle, RocJpegImage *destination) {
+    return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode_sync(handle, destination);
 }

--- a/projects/rocjpeg/src/amd_detail/rocjpeg_api_dispatch_interface.cpp
+++ b/projects/rocjpeg/src/amd_detail/rocjpeg_api_dispatch_interface.cpp
@@ -47,6 +47,12 @@ RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, RocJpegStream
 RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
     return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode(handle, jpeg_stream_handle, decode_params, destination);
 }
+RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
+    return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode_async(handle, jpeg_stream_handle, decode_params, destination);
+}
+RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination) {
+    return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_sync_surface(handle, destination);
+}
 RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations) {
     return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode_batched(handle, jpeg_stream_handles, batch_size, decode_params, destinations);
 }

--- a/projects/rocjpeg/src/amd_detail/rocjpeg_api_trace.cpp
+++ b/projects/rocjpeg/src/amd_detail/rocjpeg_api_trace.cpp
@@ -44,7 +44,7 @@ RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle
 RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
 const char* ROCJPEGAPI rocJpegGetErrorName(RocJpegStatus rocjpeg_status);
 RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
-RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
+RocJpegStatus ROCJPEGAPI rocJpegDecodeSync(RocJpegHandle handle, RocJpegImage *destination);
 }
 
 namespace rocjpeg {
@@ -61,7 +61,7 @@ void UpdateDispatchTable(RocJpegDispatchTable* ptr_dispatch_table) {
     ptr_dispatch_table->pfn_rocjpeg_decode_batched = rocjpeg::rocJpegDecodeBatched;
     ptr_dispatch_table->pfn_rocjpeg_get_error_name = rocjpeg::rocJpegGetErrorName;
     ptr_dispatch_table->pfn_rocjpeg_decode_async = rocjpeg::rocJpegDecodeAsync;
-    ptr_dispatch_table->pfn_rocjpeg_sync_surface = rocjpeg::rocJpegSyncSurface;
+    ptr_dispatch_table->pfn_rocjpeg_decode_sync = rocjpeg::rocJpegDecodeSync;
 }
 
 #if ROCJPEG_ROCPROFILER_REGISTER > 0
@@ -146,7 +146,7 @@ ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode_batched, 7)
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_get_error_name, 8)
 // ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 1
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode_async, 9)
-ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_sync_surface, 10)
+ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode_sync, 10)
 
 // If ROCJPEG_ENFORCE_ABI entries are added for each new function pointer in the table,
 // the number below will be one greater than the number in the last ROCJPEG_ENFORCE_ABI line. For example:

--- a/projects/rocjpeg/src/amd_detail/rocjpeg_api_trace.cpp
+++ b/projects/rocjpeg/src/amd_detail/rocjpeg_api_trace.cpp
@@ -41,10 +41,10 @@ RocJpegStatus ROCJPEGAPI rocJpegCreate(RocJpegBackend backend, int device_id, Ro
 RocJpegStatus ROCJPEGAPI rocJpegDestroy(RocJpegHandle handle);
 RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, uint8_t *num_components, RocJpegChromaSubsampling *subsampling, uint32_t *widths, uint32_t *heights);
 RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
-RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
-RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
 RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
 const char* ROCJPEGAPI rocJpegGetErrorName(RocJpegStatus rocjpeg_status);
+RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
 }
 
 namespace rocjpeg {
@@ -144,6 +144,7 @@ ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_get_image_info, 5)
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode, 6)
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode_batched, 7)
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_get_error_name, 8)
+// ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 1
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode_async, 9)
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_sync_surface, 10)
 

--- a/projects/rocjpeg/src/amd_detail/rocjpeg_api_trace.cpp
+++ b/projects/rocjpeg/src/amd_detail/rocjpeg_api_trace.cpp
@@ -41,6 +41,8 @@ RocJpegStatus ROCJPEGAPI rocJpegCreate(RocJpegBackend backend, int device_id, Ro
 RocJpegStatus ROCJPEGAPI rocJpegDestroy(RocJpegHandle handle);
 RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, uint8_t *num_components, RocJpegChromaSubsampling *subsampling, uint32_t *widths, uint32_t *heights);
 RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
 RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
 const char* ROCJPEGAPI rocJpegGetErrorName(RocJpegStatus rocjpeg_status);
 }
@@ -58,6 +60,8 @@ void UpdateDispatchTable(RocJpegDispatchTable* ptr_dispatch_table) {
     ptr_dispatch_table->pfn_rocjpeg_decode = rocjpeg::rocJpegDecode;
     ptr_dispatch_table->pfn_rocjpeg_decode_batched = rocjpeg::rocJpegDecodeBatched;
     ptr_dispatch_table->pfn_rocjpeg_get_error_name = rocjpeg::rocJpegGetErrorName;
+    ptr_dispatch_table->pfn_rocjpeg_decode_async = rocjpeg::rocJpegDecodeAsync;
+    ptr_dispatch_table->pfn_rocjpeg_sync_surface = rocjpeg::rocJpegSyncSurface;
 }
 
 #if ROCJPEG_ROCPROFILER_REGISTER > 0
@@ -140,14 +144,16 @@ ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_get_image_info, 5)
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode, 6)
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode_batched, 7)
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_get_error_name, 8)
+ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode_async, 9)
+ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_sync_surface, 10)
 
 // If ROCJPEG_ENFORCE_ABI entries are added for each new function pointer in the table,
 // the number below will be one greater than the number in the last ROCJPEG_ENFORCE_ABI line. For example:
-//  ROCJPEG_ENFORCE_ABI(<table>, <functor>, 8)
-//  ROCJPEG_ENFORCE_ABI_VERSIONING(<table>, 9) <- 8 + 1 = 9
-ROCJPEG_ENFORCE_ABI_VERSIONING(RocJpegDispatchTable, 9)
+//  ROCJPEG_ENFORCE_ABI(<table>, <functor>, 10)
+//  ROCJPEG_ENFORCE_ABI_VERSIONING(<table>, 11) <- 10 + 1 = 11
+ROCJPEG_ENFORCE_ABI_VERSIONING(RocJpegDispatchTable, 11)
 
-static_assert(ROCJPEG_RUNTIME_API_TABLE_MAJOR_VERSION == 0 && ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 0,
+static_assert(ROCJPEG_RUNTIME_API_TABLE_MAJOR_VERSION == 0 && ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 1,
               "If you encounter this error, add the new ROCJPEG_ENFORCE_ABI(...) code for the updated function pointers, "
               "and then modify this check to ensure it evaluates to true.");
 #endif

--- a/projects/rocjpeg/src/rocjpeg_api.cpp
+++ b/projects/rocjpeg/src/rocjpeg_api.cpp
@@ -237,50 +237,6 @@ RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle
 }
 
 /**
- * @brief Submits a JPEG decode operation without waiting for output completion.
- */
-RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params,
-    RocJpegImage *destination) {
-    FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(handle) + ", " + RocJpegFmtPtr(jpeg_stream_handle) + ", " +
-                             RocJpegFmtPtr(decode_params) + ", " + RocJpegFmtPtr(destination));
-    if (handle == nullptr || jpeg_stream_handle == nullptr || decode_params == nullptr || destination == nullptr) {
-        return ROCJPEG_STATUS_INVALID_PARAMETER;
-    }
-    RocJpegStatus rocjpeg_status = ROCJPEG_STATUS_SUCCESS;
-    auto rocjpeg_handle = static_cast<RocJpegDecoderHandle*>(handle);
-    try {
-        rocjpeg_status = rocjpeg_handle->rocjpeg_decoder->DecodeAsync(jpeg_stream_handle, decode_params, destination);
-    } catch (const std::exception& e) {
-        rocjpeg_handle->CaptureError(e.what());
-        ErrorLog(g_rocjpeg_logger, e.what());
-        return ROCJPEG_STATUS_RUNTIME_ERROR;
-    }
-
-    return rocjpeg_status;
-}
-
-/**
- * @brief Synchronizes an asynchronous JPEG decode surface and writes the decoded output.
- */
-RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination) {
-    FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(handle) + ", " + RocJpegFmtPtr(destination));
-    if (handle == nullptr || destination == nullptr) {
-        return ROCJPEG_STATUS_INVALID_PARAMETER;
-    }
-    RocJpegStatus rocjpeg_status = ROCJPEG_STATUS_SUCCESS;
-    auto rocjpeg_handle = static_cast<RocJpegDecoderHandle*>(handle);
-    try {
-        rocjpeg_status = rocjpeg_handle->rocjpeg_decoder->SyncSurface(destination);
-    } catch (const std::exception& e) {
-        rocjpeg_handle->CaptureError(e.what());
-        ErrorLog(g_rocjpeg_logger, e.what());
-        return ROCJPEG_STATUS_RUNTIME_ERROR;
-    }
-
-    return rocjpeg_status;
-}
-
-/**
  * @brief Decodes a batch of JPEG images using the rocJPEG library.
  *
  * Decodes a batch of JPEG images using the specified handle, stream handles, decode parameters, and destination images.
@@ -348,5 +304,49 @@ extern const char* ROCJPEGAPI rocJpegGetErrorName(RocJpegStatus rocjpeg_status) 
         default:
             return "UNKNOWN_ERROR";
     }
+}
+
+/**
+ * @brief Submits a JPEG decode operation without waiting for output completion.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params,
+    RocJpegImage *destination) {
+    FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(handle) + ", " + RocJpegFmtPtr(jpeg_stream_handle) + ", " +
+                             RocJpegFmtPtr(decode_params) + ", " + RocJpegFmtPtr(destination));
+    if (handle == nullptr || jpeg_stream_handle == nullptr || decode_params == nullptr || destination == nullptr) {
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    RocJpegStatus rocjpeg_status = ROCJPEG_STATUS_SUCCESS;
+    auto rocjpeg_handle = static_cast<RocJpegDecoderHandle*>(handle);
+    try {
+        rocjpeg_status = rocjpeg_handle->rocjpeg_decoder->DecodeAsync(jpeg_stream_handle, decode_params, destination);
+    } catch (const std::exception& e) {
+        rocjpeg_handle->CaptureError(e.what());
+        ErrorLog(g_rocjpeg_logger, e.what());
+        return ROCJPEG_STATUS_RUNTIME_ERROR;
+    }
+
+    return rocjpeg_status;
+}
+
+/**
+ * @brief Synchronizes an asynchronous JPEG decode surface and writes the decoded output.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination) {
+    FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(handle) + ", " + RocJpegFmtPtr(destination));
+    if (handle == nullptr || destination == nullptr) {
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    RocJpegStatus rocjpeg_status = ROCJPEG_STATUS_SUCCESS;
+    auto rocjpeg_handle = static_cast<RocJpegDecoderHandle*>(handle);
+    try {
+        rocjpeg_status = rocjpeg_handle->rocjpeg_decoder->SyncSurface(destination);
+    } catch (const std::exception& e) {
+        rocjpeg_handle->CaptureError(e.what());
+        ErrorLog(g_rocjpeg_logger, e.what());
+        return ROCJPEG_STATUS_RUNTIME_ERROR;
+    }
+
+    return rocjpeg_status;
 }
 } //namespace rocjpeg

--- a/projects/rocjpeg/src/rocjpeg_api.cpp
+++ b/projects/rocjpeg/src/rocjpeg_api.cpp
@@ -330,9 +330,9 @@ RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamH
 }
 
 /**
- * @brief Synchronizes an asynchronous JPEG decode surface and writes the decoded output.
+ * @brief Synchronizes an asynchronous JPEG decode associated with the specified RocJpegImage* and writes the decoded output.
  */
-RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination) {
+RocJpegStatus ROCJPEGAPI rocJpegDecodeSync(RocJpegHandle handle, RocJpegImage *destination) {
     FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(handle) + ", " + RocJpegFmtPtr(destination));
     if (handle == nullptr || destination == nullptr) {
         return ROCJPEG_STATUS_INVALID_PARAMETER;
@@ -340,7 +340,7 @@ RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *
     RocJpegStatus rocjpeg_status = ROCJPEG_STATUS_SUCCESS;
     auto rocjpeg_handle = static_cast<RocJpegDecoderHandle*>(handle);
     try {
-        rocjpeg_status = rocjpeg_handle->rocjpeg_decoder->SyncSurface(destination);
+        rocjpeg_status = rocjpeg_handle->rocjpeg_decoder->DecodeSync(destination);
     } catch (const std::exception& e) {
         rocjpeg_handle->CaptureError(e.what());
         ErrorLog(g_rocjpeg_logger, e.what());

--- a/projects/rocjpeg/src/rocjpeg_api.cpp
+++ b/projects/rocjpeg/src/rocjpeg_api.cpp
@@ -237,6 +237,50 @@ RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle
 }
 
 /**
+ * @brief Submits a JPEG decode operation without waiting for output completion.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params,
+    RocJpegImage *destination) {
+    FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(handle) + ", " + RocJpegFmtPtr(jpeg_stream_handle) + ", " +
+                             RocJpegFmtPtr(decode_params) + ", " + RocJpegFmtPtr(destination));
+    if (handle == nullptr || jpeg_stream_handle == nullptr || decode_params == nullptr || destination == nullptr) {
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    RocJpegStatus rocjpeg_status = ROCJPEG_STATUS_SUCCESS;
+    auto rocjpeg_handle = static_cast<RocJpegDecoderHandle*>(handle);
+    try {
+        rocjpeg_status = rocjpeg_handle->rocjpeg_decoder->DecodeAsync(jpeg_stream_handle, decode_params, destination);
+    } catch (const std::exception& e) {
+        rocjpeg_handle->CaptureError(e.what());
+        ErrorLog(g_rocjpeg_logger, e.what());
+        return ROCJPEG_STATUS_RUNTIME_ERROR;
+    }
+
+    return rocjpeg_status;
+}
+
+/**
+ * @brief Synchronizes an asynchronous JPEG decode surface and writes the decoded output.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination) {
+    FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(handle) + ", " + RocJpegFmtPtr(destination));
+    if (handle == nullptr || destination == nullptr) {
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    RocJpegStatus rocjpeg_status = ROCJPEG_STATUS_SUCCESS;
+    auto rocjpeg_handle = static_cast<RocJpegDecoderHandle*>(handle);
+    try {
+        rocjpeg_status = rocjpeg_handle->rocjpeg_decoder->SyncSurface(destination);
+    } catch (const std::exception& e) {
+        rocjpeg_handle->CaptureError(e.what());
+        ErrorLog(g_rocjpeg_logger, e.what());
+        return ROCJPEG_STATUS_RUNTIME_ERROR;
+    }
+
+    return rocjpeg_status;
+}
+
+/**
  * @brief Decodes a batch of JPEG images using the rocJPEG library.
  *
  * Decodes a batch of JPEG images using the specified handle, stream handles, decode parameters, and destination images.

--- a/projects/rocjpeg/src/rocjpeg_api.cpp
+++ b/projects/rocjpeg/src/rocjpeg_api.cpp
@@ -330,7 +330,7 @@ RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamH
 }
 
 /**
- * @brief Synchronizes an asynchronous JPEG decode associated with the specified RocJpegImage* and writes the decoded output.
+ * @brief Synchronizes a pending asynchronous JPEG decode associated with the specified RocJpegImage* and writes the decoded output.
  */
 RocJpegStatus ROCJPEGAPI rocJpegDecodeSync(RocJpegHandle handle, RocJpegImage *destination) {
     FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(handle) + ", " + RocJpegFmtPtr(destination));

--- a/projects/rocjpeg/src/rocjpeg_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_decoder.cpp
@@ -26,6 +26,7 @@ RocJpegDecoder::RocJpegDecoder(RocJpegBackend backend, int device_id) :
     num_devices_{0}, device_id_ {device_id}, hip_stream_ {0}, backend_{backend} {}
 
 RocJpegDecoder::~RocJpegDecoder() {
+    std::lock_guard<std::mutex> lock(mutex_);
     for (auto &[dest, state] : pending_decodes_) {
         RocJpegStatus rocjpeg_status = jpeg_vaapi_decoder_.SyncSurface(state.surface_id);
         if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
@@ -259,6 +260,8 @@ RocJpegStatus RocJpegDecoder::SyncDecodeSurface(VASurfaceID current_surface_id, 
         is_roi_valid = false;
     }
 
+    // Serialize HIP stream for concurrent SyncSurface calls
+    std::lock_guard<std::mutex> stream_lock(stream_mutex_);
     switch (decode_params->output_format) {
         case ROCJPEG_OUTPUT_NATIVE:
             // Copy the native decoded output buffers from interop memory directly to the destination buffers
@@ -300,6 +303,7 @@ RocJpegStatus RocJpegDecoder::SyncDecodeSurface(VASurfaceID current_surface_id, 
 
     CHECK_HIP(hipStreamSynchronize(hip_stream_));
     CHECK_ROCJPEG(jpeg_vaapi_decoder_.SetSurfaceAsIdle(current_surface_id));
+    FunctionExitLog(g_rocjpeg_logger);
     return ROCJPEG_STATUS_SUCCESS;
 }
 

--- a/projects/rocjpeg/src/rocjpeg_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_decoder.cpp
@@ -260,8 +260,7 @@ RocJpegStatus RocJpegDecoder::FinalizeDecode(VASurfaceID current_surface_id, con
         is_roi_valid = false;
     }
 
-    // Serialize HIP stream for concurrent SyncSurface calls
-    std::lock_guard<std::mutex> stream_lock(stream_mutex_);
+
     switch (decode_params->output_format) {
         case ROCJPEG_OUTPUT_NATIVE:
             // Copy the native decoded output buffers from interop memory directly to the destination buffers

--- a/projects/rocjpeg/src/rocjpeg_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_decoder.cpp
@@ -147,7 +147,7 @@ RocJpegStatus RocJpegDecoder::Decode(RocJpegStreamHandle jpeg_stream_handle, con
     VASurfaceID current_surface_id;
     CHECK_ROCJPEG(jpeg_vaapi_decoder_.SubmitDecode(jpeg_stream_params, current_surface_id, decode_params));
 
-    RocJpegStatus rocjpeg_status = SyncDecodeSurface(current_surface_id, jpeg_stream_params, decode_params, destination);
+    RocJpegStatus rocjpeg_status = FinalizeDecode(current_surface_id, jpeg_stream_params, decode_params, destination);
     if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
         jpeg_vaapi_decoder_.SetSurfaceAsIdle(current_surface_id);
     }
@@ -191,9 +191,9 @@ RocJpegStatus RocJpegDecoder::DecodeAsync(RocJpegStreamHandle jpeg_stream_handle
 }
 
 /**
- * @brief Synchronizes an asynchronous decode surface and copies/converts the decoded output.
+ * @brief Synchronizes a pending asynchronous decode and copies/converts the decoded output.
  */
-RocJpegStatus RocJpegDecoder::SyncSurface(RocJpegImage *destination) {
+RocJpegStatus RocJpegDecoder::DecodeSync(RocJpegImage *destination) {
     FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(destination));
     if (destination == nullptr) {
         CriticalLog(g_rocjpeg_logger, "Null pointer");
@@ -215,7 +215,7 @@ RocJpegStatus RocJpegDecoder::SyncSurface(RocJpegImage *destination) {
     }
 
     // Sync the VA surface and copy the decoded output to the destination without holding the mutex
-    RocJpegStatus rocjpeg_status = SyncDecodeSurface(state.surface_id, &state.jpeg_stream_params, &state.decode_params, destination);
+    RocJpegStatus rocjpeg_status = FinalizeDecode(state.surface_id, &state.jpeg_stream_params, &state.decode_params, destination);
     if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
         jpeg_vaapi_decoder_.SetSurfaceAsIdle(state.surface_id);
         FunctionExitLog(g_rocjpeg_logger);
@@ -228,7 +228,7 @@ RocJpegStatus RocJpegDecoder::SyncSurface(RocJpegImage *destination) {
 /**
  * @brief Waits for a submitted VA surface, maps it through HIP interop, and writes the requested output.
  */
-RocJpegStatus RocJpegDecoder::SyncDecodeSurface(VASurfaceID current_surface_id, const JpegStreamParameters *jpeg_stream_params, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
+RocJpegStatus RocJpegDecoder::FinalizeDecode(VASurfaceID current_surface_id, const JpegStreamParameters *jpeg_stream_params, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
     if (jpeg_stream_params == nullptr || decode_params == nullptr || destination == nullptr) {
         return ROCJPEG_STATUS_INVALID_PARAMETER;
     }

--- a/projects/rocjpeg/src/rocjpeg_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_decoder.cpp
@@ -26,6 +26,14 @@ RocJpegDecoder::RocJpegDecoder(RocJpegBackend backend, int device_id) :
     num_devices_{0}, device_id_ {device_id}, hip_stream_ {0}, backend_{backend} {}
 
 RocJpegDecoder::~RocJpegDecoder() {
+    for (auto &[dest, state] : pending_decodes_) {
+        RocJpegStatus rocjpeg_status = jpeg_vaapi_decoder_.SyncSurface(state.surface_id);
+        if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+            ErrorLog(g_rocjpeg_logger, "Failed to sync pending async surface during destroy!");
+        }
+        jpeg_vaapi_decoder_.SetSurfaceAsIdle(state.surface_id);
+    }
+    pending_decodes_.clear();
     if (hip_stream_) {
         hipError_t hip_status = hipStreamDestroy(hip_stream_);
         if (hip_status != hipSuccess) {
@@ -127,11 +135,102 @@ RocJpegStatus RocJpegDecoder::Decode(RocJpegStreamHandle jpeg_stream_handle, con
         FunctionExitLog(g_rocjpeg_logger);
         return ROCJPEG_STATUS_INVALID_PARAMETER;
     }
+    if (!pending_decodes_.empty()) {
+        ErrorLog(g_rocjpeg_logger, "Asynchronous decodes are pending for this handle!");
+        FunctionExitLog(g_rocjpeg_logger);
+        return ROCJPEG_STATUS_EXECUTION_FAILED;
+    }
     auto rocjpeg_stream_handle = static_cast<RocJpegStreamParserHandle*>(jpeg_stream_handle);
     const JpegStreamParameters *jpeg_stream_params = rocjpeg_stream_handle->rocjpeg_stream->GetJpegStreamParameters();
 
     VASurfaceID current_surface_id;
     CHECK_ROCJPEG(jpeg_vaapi_decoder_.SubmitDecode(jpeg_stream_params, current_surface_id, decode_params));
+
+    RocJpegStatus rocjpeg_status = SyncDecodeSurface(current_surface_id, jpeg_stream_params, decode_params, destination);
+    if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+        jpeg_vaapi_decoder_.SetSurfaceAsIdle(current_surface_id);
+    }
+    FunctionExitLog(g_rocjpeg_logger);
+    return rocjpeg_status;
+}
+
+/**
+ * @brief Submits a JPEG decode operation and returns immediately with pending state stored in this decoder handle.
+ */
+RocJpegStatus RocJpegDecoder::DecodeAsync(RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
+    FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(jpeg_stream_handle) + ", " + RocJpegFmtPtr(decode_params) + ", " + RocJpegFmtPtr(destination));
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (jpeg_stream_handle == nullptr || decode_params == nullptr || destination == nullptr) {
+        CriticalLog(g_rocjpeg_logger, "Null pointer");
+        FunctionExitLog(g_rocjpeg_logger);
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    if (pending_decodes_.count(destination) > 0) {
+        ErrorLog(g_rocjpeg_logger, "An async decode is already pending for this destination!");
+        FunctionExitLog(g_rocjpeg_logger);
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+
+    auto rocjpeg_stream_handle = static_cast<RocJpegStreamParserHandle*>(jpeg_stream_handle);
+    const JpegStreamParameters *jpeg_stream_params = rocjpeg_stream_handle->rocjpeg_stream->GetJpegStreamParameters();
+
+    AsyncDecodeState state;
+    state.jpeg_stream_params = *jpeg_stream_params;
+    state.decode_params = *decode_params;
+
+    RocJpegStatus rocjpeg_status = jpeg_vaapi_decoder_.SubmitDecode(&state.jpeg_stream_params, state.surface_id, &state.decode_params);
+    if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+        FunctionExitLog(g_rocjpeg_logger);
+        return rocjpeg_status;
+    }
+    pending_decodes_.emplace(destination, std::move(state));
+
+    FunctionExitLog(g_rocjpeg_logger);
+    return ROCJPEG_STATUS_SUCCESS;
+}
+
+/**
+ * @brief Synchronizes an asynchronous decode surface and copies/converts the decoded output.
+ */
+RocJpegStatus RocJpegDecoder::SyncSurface(RocJpegImage *destination) {
+    FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(destination));
+    if (destination == nullptr) {
+        CriticalLog(g_rocjpeg_logger, "Null pointer");
+        FunctionExitLog(g_rocjpeg_logger);
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+
+    AsyncDecodeState state;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = pending_decodes_.find(destination);
+        if (it == pending_decodes_.end()) {
+            ErrorLog(g_rocjpeg_logger, "No asynchronous decode is pending for this destination!");
+            FunctionExitLog(g_rocjpeg_logger);
+            return ROCJPEG_STATUS_INVALID_PARAMETER;
+        }
+        state = std::move(it->second);
+        pending_decodes_.erase(it);
+    }
+
+    // Sync the VA surface and copy the decoded output to the destination without holding the mutex
+    RocJpegStatus rocjpeg_status = SyncDecodeSurface(state.surface_id, &state.jpeg_stream_params, &state.decode_params, destination);
+    if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+        jpeg_vaapi_decoder_.SetSurfaceAsIdle(state.surface_id);
+        FunctionExitLog(g_rocjpeg_logger);
+        return rocjpeg_status;
+    }
+    FunctionExitLog(g_rocjpeg_logger);
+    return ROCJPEG_STATUS_SUCCESS;
+}
+
+/**
+ * @brief Waits for a submitted VA surface, maps it through HIP interop, and writes the requested output.
+ */
+RocJpegStatus RocJpegDecoder::SyncDecodeSurface(VASurfaceID current_surface_id, const JpegStreamParameters *jpeg_stream_params, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
+    if (jpeg_stream_params == nullptr || decode_params == nullptr || destination == nullptr) {
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
 
     HipInteropDeviceMem hip_interop_dev_mem = {};
     CHECK_ROCJPEG(jpeg_vaapi_decoder_.SyncSurface(current_surface_id));
@@ -199,9 +298,8 @@ RocJpegStatus RocJpegDecoder::Decode(RocJpegStreamHandle jpeg_stream_handle, con
             break;
     }
 
-    CHECK_ROCJPEG(jpeg_vaapi_decoder_.SetSurfaceAsIdle(current_surface_id));
     CHECK_HIP(hipStreamSynchronize(hip_stream_));
-    FunctionExitLog(g_rocjpeg_logger);
+    CHECK_ROCJPEG(jpeg_vaapi_decoder_.SetSurfaceAsIdle(current_surface_id));
     return ROCJPEG_STATUS_SUCCESS;
 }
 
@@ -221,6 +319,11 @@ RocJpegStatus RocJpegDecoder::DecodeBatched(RocJpegStreamHandle *jpeg_streams, i
         CriticalLog(g_rocjpeg_logger, "Null pointer");
         FunctionExitLog(g_rocjpeg_logger);
         return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    if (!pending_decodes_.empty()) {
+        ErrorLog(g_rocjpeg_logger, "Asynchronous decodes are pending for this handle!");
+        FunctionExitLog(g_rocjpeg_logger);
+        return ROCJPEG_STATUS_EXECUTION_FAILED;
     }
 
     std::vector<VASurfaceID> current_surface_ids;

--- a/projects/rocjpeg/src/rocjpeg_decoder.h
+++ b/projects/rocjpeg/src/rocjpeg_decoder.h
@@ -200,7 +200,6 @@ private:
    hipDeviceProp_t hip_dev_prop_; // HIP device properties
    hipStream_t hip_stream_; // HIP stream
    std::mutex mutex_; // Mutex for thread safety
-   std::mutex stream_mutex_; // Mutex for HIP stream
    RocJpegBackend backend_; // RocJpeg backend
    RocJpegVappiDecoder jpeg_vaapi_decoder_; // RocJpeg VAAPI decoder object
    std::unordered_map<RocJpegImage*, AsyncDecodeState> pending_decodes_; // Map of pending asynchronous decodes keyed by destination

--- a/projects/rocjpeg/src/rocjpeg_decoder.h
+++ b/projects/rocjpeg/src/rocjpeg_decoder.h
@@ -85,6 +85,21 @@ public:
    RocJpegStatus Decode(RocJpegStreamHandle jpeg_stream, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 
    /**
+    * Decodes a batch of JPEG streams.
+    *
+    * This function decodes a batch of JPEG streams specified by `jpeg_streams` into a batch of destination images specified by `destinations`.
+    * The number of JPEG streams in the batch is specified by `batch_size`.
+    * The decoding parameters are specified by `decode_params`.
+    *
+    * @param jpeg_streams The array of JPEG stream handles.
+    * @param batch_size The number of JPEG streams in the batch.
+    * @param decode_params The decoding parameters.
+    * @param destinations The array of destination images.
+    * @return The status of the decoding operation.
+    */
+   RocJpegStatus DecodeBatched(RocJpegStreamHandle *jpeg_streams, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
+
+   /**
     * @brief Submits a JPEG decode operation and stores pending state in this decoder handle.
     * @param jpeg_stream The handle to the JPEG stream.
     * @param decode_params The decoding parameters.
@@ -99,21 +114,6 @@ public:
     * @return The status of the sync operation.
     */
    RocJpegStatus SyncSurface(RocJpegImage *destination);
-
-   /**
-    * Decodes a batch of JPEG streams.
-    *
-    * This function decodes a batch of JPEG streams specified by `jpeg_streams` into a batch of destination images specified by `destinations`.
-    * The number of JPEG streams in the batch is specified by `batch_size`.
-    * The decoding parameters are specified by `decode_params`.
-    *
-    * @param jpeg_streams The array of JPEG stream handles.
-    * @param batch_size The number of JPEG streams in the batch.
-    * @param decode_params The decoding parameters.
-    * @param destinations The array of destination images.
-    * @return The status of the decoding operation.
-    */
-   RocJpegStatus DecodeBatched(RocJpegStreamHandle *jpeg_streams, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
 
 private:
    struct AsyncDecodeState {
@@ -200,6 +200,7 @@ private:
    hipDeviceProp_t hip_dev_prop_; // HIP device properties
    hipStream_t hip_stream_; // HIP stream
    std::mutex mutex_; // Mutex for thread safety
+   std::mutex stream_mutex_; // Mutex for HIP stream
    RocJpegBackend backend_; // RocJpeg backend
    RocJpegVappiDecoder jpeg_vaapi_decoder_; // RocJpeg VAAPI decoder object
    std::unordered_map<RocJpegImage*, AsyncDecodeState> pending_decodes_; // Map of pending asynchronous decodes keyed by destination

--- a/projects/rocjpeg/src/rocjpeg_decoder.h
+++ b/projects/rocjpeg/src/rocjpeg_decoder.h
@@ -109,11 +109,11 @@ public:
    RocJpegStatus DecodeAsync(RocJpegStreamHandle jpeg_stream, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 
    /**
-    * @brief Synchronizes an asynchronous decode surface and copies/converts the output.
+    * @brief Synchronizes a pending asynchronous decode and copies/converts the output.
     * @param destination Pointer to the destination image.
     * @return The status of the sync operation.
     */
-   RocJpegStatus SyncSurface(RocJpegImage *destination);
+   RocJpegStatus DecodeSync(RocJpegImage *destination);
 
 private:
    struct AsyncDecodeState {
@@ -132,7 +132,7 @@ private:
    /**
     * @brief Waits for a submitted surface and copies/converts the decoded output.
     */
-   RocJpegStatus SyncDecodeSurface(VASurfaceID surface_id, const JpegStreamParameters *jpeg_stream_params, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+   RocJpegStatus FinalizeDecode(VASurfaceID surface_id, const JpegStreamParameters *jpeg_stream_params, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 
    /**
     * @brief Retrieves the height of the chroma channel.

--- a/projects/rocjpeg/src/rocjpeg_decoder.h
+++ b/projects/rocjpeg/src/rocjpeg_decoder.h
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include <unistd.h>
 #include <vector>
 #include <mutex>
-#include <queue>
+#include <unordered_map>
 #include "../api/rocjpeg/rocjpeg.h"
 #include "rocjpeg_api_stream_handle.h"
 #include "rocjpeg_parser.h"
@@ -85,6 +85,22 @@ public:
    RocJpegStatus Decode(RocJpegStreamHandle jpeg_stream, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 
    /**
+    * @brief Submits a JPEG decode operation and stores pending state in this decoder handle.
+    * @param jpeg_stream The handle to the JPEG stream.
+    * @param decode_params The decoding parameters.
+    * @param destination Pointer to the output image.
+    * @return The status of the submit operation.
+    */
+   RocJpegStatus DecodeAsync(RocJpegStreamHandle jpeg_stream, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+
+   /**
+    * @brief Synchronizes an asynchronous decode surface and copies/converts the output.
+    * @param destination Pointer to the destination image.
+    * @return The status of the sync operation.
+    */
+   RocJpegStatus SyncSurface(RocJpegImage *destination);
+
+   /**
     * Decodes a batch of JPEG streams.
     *
     * This function decodes a batch of JPEG streams specified by `jpeg_streams` into a batch of destination images specified by `destinations`.
@@ -100,12 +116,23 @@ public:
    RocJpegStatus DecodeBatched(RocJpegStreamHandle *jpeg_streams, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
 
 private:
+   struct AsyncDecodeState {
+      VASurfaceID surface_id;
+      JpegStreamParameters jpeg_stream_params;
+      RocJpegDecodeParams decode_params;
+   };
+
    /**
     * @brief Initializes the HIP framework.
     * @param device_id The ID of the device to be used for HIP operations.
     * @return The status of the initialization process.
     */
    RocJpegStatus InitHIP(int device_id);
+
+   /**
+    * @brief Waits for a submitted surface and copies/converts the decoded output.
+    */
+   RocJpegStatus SyncDecodeSurface(VASurfaceID surface_id, const JpegStreamParameters *jpeg_stream_params, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 
    /**
     * @brief Retrieves the height of the chroma channel.
@@ -175,6 +202,7 @@ private:
    std::mutex mutex_; // Mutex for thread safety
    RocJpegBackend backend_; // RocJpeg backend
    RocJpegVappiDecoder jpeg_vaapi_decoder_; // RocJpeg VAAPI decoder object
+   std::unordered_map<RocJpegImage*, AsyncDecodeState> pending_decodes_; // Map of pending asynchronous decodes keyed by destination
 };
 
 #endif //ROC_JPEG_DECODER_H_


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Add asynchronous decode APIs to rocJPEG to improve VCN hardware utilization. The current `rocJpegDecode` API serializes submission → decode → copy, leaving VCN idle during the interop/copy phase. The async API allows applications to overlap decode and copy operations.

## Technical Details
- Add `rocJpegDecodeAsync()` API that submits decode without waiting for completion
- Add `rocJpegDecodeSync()` API that waits for a specific decode to complete and copies the result
- Add jpegDecodeAsync sample demonstrating a threaded submit/sync pipeline
- Support -n <iterations> for repeated-decode benchmarking and -profile for sync-vs-async comparison
Closes #8600

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
ISSUE ID: #8600

## Test Plan
<!-- Explain any relevant testing done to verify this PR. -->
 ./jpegdecodeasync  -i pic -o output
 ./jpegdecodeasync  -i pic -n 1000


## Test Result

<!-- Briefly summarize test outcomes. -->
For 1920x1440 JPEG (1000 iterations):
(base) amd@cse-cluster-1:~/wayne/rocm-systems/projects/rocjpeg/samples/jpegDecodeAsync/build$ ./jpegdecodeasync  -i pic/89_target.jpg  -n 1000  -profile
Reading images from disk, please wait!
Using GPU device 0: AMD Radeon AI PRO R9700[gfx1201] on PCI bus 63:00.0
(Sync) Input file name: pic/89_target.jpg
(Sync) Input image resolution: 1920x1440
(Sync) Chroma subsampling: YUV 4:2:0
(Sync) Total decoded images: 1000
(Sync) Average processing time per image (ms): 15.6565
(Sync) Average images per sec (Images/Sec): 63.871

(Async) Input file name: pic/89_target.jpg
(Async) Input image resolution: 1920x1440
(Async) Chroma subsampling: YUV 4:2:0
(Async) Total decoded images: 1000
(Async) Average processing time per image (ms): 13.7191(14% improvement)
(Async) Average images per sec (Images/Sec): 72.891
Decoding completed!

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
