### PR TITLE
chore(hip-tests): cleanup warnings

### DIFF
--- a/projects/hip-tests/catch/multiproc/childMalloc.cc
+++ b/projects/hip-tests/catch/multiproc/childMalloc.cc
@@ -49,14 +49,10 @@ bool testMallocFromChild() {
     else
       testResult = false;
 
-    if (A_d != nullptr) {
-      hipFree(A_d);
-    }
-
     // send the value on the write-descriptor:
     write(fd[1], &testResult, sizeof(testResult));
 
-    hipFree(A_d);
+    ret = hipFree(A_d);
     // close the write descriptor:
     close(fd[1]);
     exit(0);

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParams.cc
@@ -215,7 +215,7 @@ HIP_TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParams_Negative_Parameters) {
  *    - HIP_VERSION >= 5.2
  */
 HIP_TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Direction) {
-  int *host, *dev, *src, *dst;
+  int *host = nullptr, *dev = nullptr, *src = nullptr, *dst = nullptr;
   HIP_CHECK(hipHostMalloc(&host, sizeof(int)));
   HIP_CHECK(hipMalloc(&dev, sizeof(int)));
 
@@ -240,7 +240,7 @@ HIP_TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Dire
     dst = dev;
     break;
   default:
-    REQUIRE(false);
+    FAIL("Unhandled enumerator encountered, test requires an update");
     assert(false);
   }
 

--- a/projects/hip-tests/catch/unit/hrr/hrr_workload_test.cc
+++ b/projects/hip-tests/catch/unit/hrr/hrr_workload_test.cc
@@ -1271,8 +1271,9 @@ TEST_CASE("Unit_HRR_Occupancy_Direct", "[.][hrr-direct]") {
 TEST_CASE("Unit_HRR_HostAliases_Direct", "[.][hrr-direct]") {
   // Drain any GPU errors left by earlier tests; this test mixes array + 3D
   // alloc with regular device memory — on Windows the driver needs a clean slate.
-  hipDeviceSynchronize();
-  hipGetLastError();
+  [[maybe_unused]] hipError_t errorSink;
+  errorSink = hipDeviceSynchronize();
+  errorSink = hipGetLastError();
   HIP_CHECK(hipSetDevice(0));
   constexpr int N = 256;
   constexpr size_t SZ = N * sizeof(int);
@@ -1343,8 +1344,8 @@ TEST_CASE("Unit_HRR_HostAliases_Direct", "[.][hrr-direct]") {
 
   // D2H blob (value = 8)
   // Drain any pending GPU errors from earlier tests before D2H.
-  hipDeviceSynchronize();
-  hipGetLastError();
+  errorSink = hipDeviceSynchronize();
+  errorSink = hipGetLastError();
   int* d = nullptr; int* h = new int[N]();
   HIP_CHECK(hipMalloc(&d, SZ));
   hipStream_t s;
@@ -1601,7 +1602,7 @@ TEST_CASE("Unit_HRR_MemcpyExtra_Direct", "[.][hrr-direct]") {
   // Requires image support — skip on GPUs that don't support texture arrays.
   {
     int supportsImages = 0;
-    hipDeviceGetAttribute(&supportsImages, hipDeviceAttributeImageSupport, 0);
+    HIP_CHECK(hipDeviceGetAttribute(&supportsImages, hipDeviceAttributeImageSupport, 0));
     if (supportsImages) {
       hipChannelFormatDesc desc = hipCreateChannelDesc(32, 0, 0, 0, hipChannelFormatKindFloat);
       hipArray_t arr = nullptr;
@@ -2644,9 +2645,10 @@ TEST_CASE("Unit_HRR_ChevronLaunch_Direct", "[.][hrr][direct]") {
   hipStream_t s;
   HIP_CHECK(hipStreamCreate(&s));
 
+  [[maybe_unused]] hipError_t errorSink;
   // Drain any pending GPU errors from earlier tests before the <<<>>> launch.
-  hipDeviceSynchronize();
-  hipGetLastError();
+  errorSink = hipDeviceSynchronize();
+  errorSink = hipGetLastError();
 
   int blocks = (N + 255) / 256;
   // Triple-chevron launch — goes through __hipPushCallConfiguration + hipLaunchByPtr

--- a/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
+++ b/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
@@ -9,6 +9,8 @@
 #include <utils.hh>
 #include "../device/hipGetProcAddressHelpers.hh"
 
+#include <vector>
+
 /**
  * Test Description
  * ------------------------
@@ -1447,7 +1449,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
     REQUIRE(hostMem != nullptr);
     fillHostArray(hostMem, N, value);
 
-    hipStream_t stream[Ns];
+    std::vector<hipStream_t> stream(Ns);
     for (int s = 0; s < Ns; s++) {
       HIP_CHECK(hipStreamCreate(&stream[s]));
     }
@@ -1481,7 +1483,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
     REQUIRE(devMem != nullptr);
     fillDeviceArray(devMem, N, value);
 
-    hipStream_t stream[Ns];
+    std::vector<hipStream_t> stream(Ns);
     for (int s = 0; s < Ns; s++) {
       HIP_CHECK(hipStreamCreate(&stream[s]));
     }
@@ -1515,7 +1517,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
     REQUIRE(devMem != nullptr);
     fillDeviceArray(devMem, N, value);
 
-    hipStream_t stream[Ns];
+    std::vector<hipStream_t> stream(Ns);
     for (int s = 0; s < Ns; s++) {
       HIP_CHECK(hipStreamCreate(&stream[s]));
     }
@@ -1552,7 +1554,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(hostMem != nullptr);
       fillHostArray(hostMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1585,7 +1587,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(hostMem != nullptr);
       fillHostArray(hostMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1619,7 +1621,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1653,7 +1655,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1688,7 +1690,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1722,7 +1724,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(hostMem != nullptr);
       fillHostArray(hostMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1755,7 +1757,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(hostMem != nullptr);
       fillHostArray(hostMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1789,7 +1791,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1823,7 +1825,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1861,7 +1863,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(hostMem != nullptr);
       fillHostArray(hostMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1894,7 +1896,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(hostMem != nullptr);
       fillHostArray(hostMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1928,7 +1930,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1962,7 +1964,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1997,7 +1999,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -2032,7 +2034,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(hostMem != nullptr);
       fillHostArray(hostMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -2065,7 +2067,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(hostMem != nullptr);
       fillHostArray(hostMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -2099,7 +2101,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -2133,7 +2135,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -2294,7 +2296,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemset) {
     HIP_CHECK(hipMalloc(&devMem, Nbytes));
     REQUIRE(devMem != nullptr);
 
-    hipStream_t stream[Ns];
+    std::vector<hipStream_t> stream(Ns);
     for (int s = 0; s < Ns; s++) {
       HIP_CHECK(hipStreamCreate(&stream[s]));
     }
@@ -2332,7 +2334,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemset) {
     HIP_CHECK(hipMalloc(&devMem, Nbytes));
     REQUIRE(devMem != nullptr);
 
-    hipStream_t stream[Ns];
+    std::vector<hipStream_t> stream(Ns);
     for (int s = 0; s < Ns; s++) {
       HIP_CHECK(hipStreamCreate(&stream[s]));
     }
@@ -2370,7 +2372,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemset) {
     HIP_CHECK(hipMalloc(&devMem, Nbytes));
     REQUIRE(devMem != nullptr);
 
-    hipStream_t stream[Ns];
+    std::vector<hipStream_t> stream(Ns);
     for (int s = 0; s < Ns; s++) {
       HIP_CHECK(hipStreamCreate(&stream[s]));
     }
@@ -2429,7 +2431,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemset) {
     HIP_CHECK(hipMalloc(&devMem, Nbytes));
     REQUIRE(devMem != nullptr);
 
-    hipStream_t stream[Ns];
+    std::vector<hipStream_t> stream(Ns);
     for (int s = 0; s < Ns; s++) {
       HIP_CHECK(hipStreamCreate(&stream[s]));
     }
@@ -2541,7 +2543,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemset2D3D) {
     HIP_CHECK(dyn_hipMemset2DAsync_ptr(devMem, pitch, 5, width, height, 0));
     HIP_CHECK(hipStreamSynchronize(0));
 
-    hipStream_t stream[Ns];
+    std::vector<hipStream_t> stream(Ns);
     for (int s = 0; s < Ns; s++) {
       HIP_CHECK(hipStreamCreate(&stream[s]));
     }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_old.cc
@@ -17,6 +17,7 @@ This testcase verifies the following scenarios
 #include <hip_test_kernels.hh>
 #include <hip_test_checkers.hh>
 #include <atomic>
+#include <vector>
 
 static constexpr auto NUM_ELM{1024 * 1024};
 
@@ -203,7 +204,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyAsync_hipMultiMemcpyMultiThread, int, float
   HIP_CHECK(hipStreamCreateWithFlags(&mystream, hipStreamNonBlocking));
   HIP_CHECK(hipMemcpyAsync(A_d, A_h, Nbytes, hipMemcpyHostToDevice, mystream));
 
-  std::thread T[NUM_THREADS];
+  std::vector<std::thread> T(NUM_THREADS);
   for (int i = 0; i < NUM_THREADS; i++) {
     T[i] = std::thread(Thread_func<TestType>, A_d, B_d, C_d, C_h, Nbytes, mystream);
   }
@@ -233,7 +234,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyAsync_hipMultiMemcpyMultiThread, int, float
 HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyAsync_hipMultiMemcpyMultiThreadMultiStream, int, float,
                    double) {
   const int NUM_THREADS = isQuickLevel() ? 4 : 16;
-  std::thread T[NUM_THREADS];
+  std::vector<std::thread> T(NUM_THREADS);
   for (int i = 0; i < NUM_THREADS; i++) {
     T[i] = std::thread(Thread_func_MultiStream<TestType>);
   }

--- a/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
@@ -759,7 +759,7 @@ void testIncrementDecrementMultiStreamMultiDevice(uint32_t operationFlag) {
     }
   }
 
-  TestType expected_value;
+  TestType expected_value = TestType{};
   switch (operationFlag) {
     case hipExtStreamWriteValueIncrement: {
       expected_value =


### PR DESCRIPTION
## Motivation

Reduce build logs clutter, general cleanup.

## Technical Details

The following kinds of warnings are addressed:
- ignoring return value of a `nodiscard` function (i.e. HIP APIs)
- using an uninitialized variable when going through `default` switch case
- using non-standard variable-length arrays extension

## JIRA ID

SWDEV-574976

## Test Plan

N/A, the change is supposed to be non-functional

## Test Result

N/A, the change is supposed to be non-functional

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
