### PR TITLE
perf(rocprofiler-sdk): cache perfetto event names for static interning.

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
@@ -134,10 +134,10 @@ PerfettoSession::PerfettoSession(const tool::output_config& output_cfg, sqlite3*
 ::perfetto::StaticString
 PerfettoSession::get_static_event_name(const std::string& value) const
 {
-    // insert() is a no-op when the name is already cached; the returned iterator
+    // emplace() is a no-op when the name is already cached; the returned iterator
     // points to storage that stays valid for the whole PerfettoSession lifetime,
     // which is what perfetto::StaticString interning requires.
-    return ::perfetto::StaticString{static_event_names.insert(value).first->c_str()};
+    return ::perfetto::StaticString{static_event_names.emplace(value).first->c_str()};
 }
 
 PerfettoSession::~PerfettoSession()

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
@@ -43,6 +43,10 @@
 #include <atomic>
 #include <future>
 #include <mutex>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <variant>
 #include <vector>
 
@@ -71,6 +75,7 @@ get_hash_id(Tp&& _val)
     else
         return get_hash_id(*_val);
 }
+
 }  // namespace
 
 PerfettoSession::PerfettoSession(const tool::output_config& output_cfg, sqlite3* conn)
@@ -124,6 +129,15 @@ PerfettoSession::PerfettoSession(const tool::output_config& output_cfg, sqlite3*
 
     tracing_session->Setup(cfg);
     tracing_session->StartBlocking();
+}
+
+::perfetto::StaticString
+PerfettoSession::get_static_event_name(const std::string& value) const
+{
+    // insert() is a no-op when the name is already cached; the returned iterator
+    // points to storage that stays valid for the whole PerfettoSession lifetime,
+    // which is what perfetto::StaticString interning requires.
+    return ::perfetto::StaticString{static_event_names.insert(value).first->c_str()};
 }
 
 PerfettoSession::~PerfettoSession()
@@ -451,7 +465,7 @@ write_perfetto(
                 auto _category = ::perfetto::DynamicCategory{get_category_string(itr.category)};
                 TRACE_EVENT_BEGIN(
                     _category,
-                    ::perfetto::DynamicString{_name},
+                    perfetto_session.get_static_event_name(_name),
                     track,
                     itr.start,
                     ::perfetto::Flow::Global(itr.stack_id ^ uuid_pid),
@@ -539,7 +553,7 @@ write_perfetto(
 
                 auto _category = ::perfetto::DynamicCategory{get_category_string(itr.category)};
                 TRACE_EVENT_INSTANT(_category,
-                                    ::perfetto::DynamicString{_name},
+                                    perfetto_session.get_static_event_name(_name),
                                     track,
                                     itr.timestamp,
                                     ::perfetto::Flow::Global(itr.stack_id ^ uuid_pid),
@@ -583,7 +597,7 @@ write_perfetto(
                 auto src_agent_index = agent_data.at(itr.src_agent_abs_index).second;
                 auto dst_agent_index = agent_data.at(itr.dst_agent_abs_index).second;
                 TRACE_EVENT_BEGIN(sdk::perfetto_category<sdk::category::memory_copy>::name,
-                                  ::perfetto::DynamicString{itr.name},
+                                  perfetto_session.get_static_event_name(itr.name),
                                   *_track,
                                   itr.start,
                                   ::perfetto::Flow::Global(itr.stack_id ^ uuid_pid),
@@ -773,7 +787,7 @@ write_perfetto(
                 auto _name =
                     (ocfg.kernel_rename && !current.region.empty()) ? current.region : current.name;
                 TRACE_EVENT_BEGIN(sdk::perfetto_category<sdk::category::kernel_dispatch>::name,
-                                  ::perfetto::DynamicString{_name},
+                                  perfetto_session.get_static_event_name(_name),
                                   *_track,
                                   current.start,
                                   ::perfetto::Flow::Global(current.stack_id ^ uuid_pid),

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.hpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.hpp
@@ -35,6 +35,8 @@
 
 #include <rocprofiler-sdk/cxx/perfetto.hpp>
 
+#include <string>
+#include <unordered_set>
 #include <vector>
 
 namespace rocpd
@@ -45,8 +47,14 @@ namespace tool = ::rocprofiler::tool;
 
 struct PerfettoSession
 {
+private:
+    mutable std::unordered_set<std::string> static_event_names = {};
+
+public:
     PerfettoSession(const tool::output_config&, sqlite3* connection);
     ~PerfettoSession();
+
+    ::perfetto::StaticString get_static_event_name(const std::string& value) const;
 
     std::unique_ptr<::perfetto::TracingSession> tracing_session = {};
     const tool::output_config&                  config;

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.hpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.hpp
@@ -47,18 +47,17 @@ namespace tool = ::rocprofiler::tool;
 
 struct PerfettoSession
 {
-private:
-    mutable std::unordered_set<std::string> static_event_names = {};
-
-public:
     PerfettoSession(const tool::output_config&, sqlite3* connection);
     ~PerfettoSession();
 
+    // NOTE: not thread-safe; assumes write_perfetto() is invoked single-threaded per session.
     ::perfetto::StaticString get_static_event_name(const std::string& value) const;
 
     std::unique_ptr<::perfetto::TracingSession> tracing_session = {};
     const tool::output_config&                  config;
     sqlite3*                                    connection = nullptr;
+
+    mutable std::unordered_set<std::string> static_event_names = {};
 };
 
 void


### PR DESCRIPTION
## Motivation

The pftrace file generated from rocprofv3 is smaller in size than the one generated by rocpd. After investigation found out that the difference in the pftrace files is because the one generated from rocpd uses dynamic string copy which creates string deduplication whereas the one generated from rocprofv3 uses static copies.


## Technical Details

rocpd2pftrace was emitting DB-derived event names as Perfetto DynamicString values. DynamicString writes the full event name into each TrackEvent packet, while the direct rocprofv3 Perfetto path uses StaticString and lets Perfetto emit interned name IDs.

Add a local static_string_cache in the rocpd Perfetto writer so event names loaded from the database have stable storage for the lifetime of trace generation. The converter can then pass those cached names as StaticString values, allowing Perfetto to intern repeated names safely.

Apply the cache to region, sample, memory-copy, and kernel-dispatch event names. This reduces repeated string payload in generated pftrace files without changing event timing, tracks, annotations, categories, or other trace metadata.

## JIRA ID

ROCM-21204

## Test Plan

## Test Result

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
