### PR TITLE
feat(rocprofiler-sdk): rename rocprofv3 CLI to rocprofiler-core

### DIFF
--- a/projects/rocprofiler-sdk/CONTRIBUTING.md
+++ b/projects/rocprofiler-sdk/CONTRIBUTING.md
@@ -145,8 +145,8 @@ pushd /home/user/rocm-systems/projects/rocprofiler-sdk/build-rocprofiler-sdk/tes
 gdb --args /home/user/rocm-systems/projects/rocprofiler-sdk/build-rocprofiler-sdk/bin/hip-graph
 ```
 
-If the test command uses [rocprofv3](./source/bin/rocprofv3.py), using debuggers such as `gdb` will require replacing prefixing with `gdb --args python3 /path/to/rocprofv3 ...`.
-If rocprofv3 requires application replay, execute `set follow-fork-mode child` within the GDB command line prompt.
+If the test command uses [rocprofiler-core](./source/bin/rocprofiler-core.py) (formerly `rocprofv3`, retained as a deprecated alias), using debuggers such as `gdb` will require replacing prefixing with `gdb --args python3 /path/to/rocprofiler-core ...`.
+If rocprofiler-core requires application replay, execute `set follow-fork-mode child` within the GDB command line prompt.
 
 ### Test Locations ###
 

--- a/projects/rocprofiler-sdk/CONTRIBUTING.md
+++ b/projects/rocprofiler-sdk/CONTRIBUTING.md
@@ -145,7 +145,7 @@ pushd /home/user/rocm-systems/projects/rocprofiler-sdk/build-rocprofiler-sdk/tes
 gdb --args /home/user/rocm-systems/projects/rocprofiler-sdk/build-rocprofiler-sdk/bin/hip-graph
 ```
 
-If the test command uses [rocprofiler-core](./source/bin/rocprofiler-core.py) (formerly `rocprofv3`, retained as a deprecated alias), using debuggers such as `gdb` will require replacing prefixing with `gdb --args python3 /path/to/rocprofiler-core ...`.
+If the test command uses [rocprofiler-core](./source/bin/rocprofiler-core.py) (formerly `rocprofv3`, retained as a deprecated alias), using debuggers such as `gdb` will require prefixing the command with `gdb --args python3 /path/to/rocprofiler-core ...`.
 If rocprofiler-core requires application replay, execute `set follow-fork-mode child` within the GDB command line prompt.
 
 ### Test Locations ###

--- a/projects/rocprofiler-sdk/README.md
+++ b/projects/rocprofiler-sdk/README.md
@@ -1,7 +1,7 @@
 # ROCprofiler-SDK:  Application Profiling, Tracing, and Performance Analysis
 
 > [!IMPORTANT]
-We are phasing out development and support for `ROCTracer, ROCprofiler, rocprof, and rocprofv2` in favour of `ROCprofiler-SDK` and `rocprofv3` in upcoming ROCm releases. Starting with the `ROCm 6.4` release, only critical defect fixes will be addressed for older versions of the profiling tools and libraries. We encourage all users to upgrade to the latest version of the `ROCprofiler-SDK` library and the `rocprofv3` tool to ensure continued support and access to new features.
+We are phasing out development and support for `ROCTracer, ROCprofiler, rocprof, and rocprofv2` in favour of `ROCprofiler-SDK` and `rocprofiler-core` (formerly `rocprofv3`) in upcoming ROCm releases. Starting with the `ROCm 6.4` release, only critical defect fixes will be addressed for older versions of the profiling tools and libraries. We encourage all users to upgrade to the latest version of the `ROCprofiler-SDK` library and the `rocprofiler-core` tool to ensure continued support and access to new features.
 
     Please note that we anticipate the end of life for ROCprofiler V1/V2 and ROCTracer within nine months after the ROCm 7.0 release, aligning with the Q1 2026.
 
@@ -43,9 +43,12 @@ ROCprofiler-SDK is AMD’s new and improved tooling infrastructure, providing a 
 
 ## Tool Support
 
-rocprofv3 is the command line tool built using the rocprofiler-sdk library and shipped with the ROCm stack. It supports both launching applications with profiling enabled and attaching to already running processes for dynamic profiling using `--attach`/`--pid`/`-p` options.
+`rocprofiler-core` is the command line tool built using the rocprofiler-sdk library and shipped with the ROCm stack. It supports both launching applications with profiling enabled and attaching to already running processes for dynamic profiling using `--attach`/`--pid`/`-p` options.
 
-To see details on the command line options of rocprofv3, please see rocprofv3 user guide
+> [!NOTE]
+> The `rocprofv3` command has been renamed to `rocprofiler-core`. `rocprofv3` is retained as a deprecated alias (a symlink to `rocprofiler-core`) and will be removed in a future ROCm release; invoking it prints a deprecation warning. Update your scripts and automation to use `rocprofiler-core`.
+
+To see details on the command line options of `rocprofiler-core`, please see the `rocprofiler-core` user guide
 [Click Here](source/docs/how-to/using-rocprofv3.rst)
 
 ## Documentation

--- a/projects/rocprofiler-sdk/cmake/Templates/rocprofiler-sdk/config.cmake.in
+++ b/projects/rocprofiler-sdk/cmake/Templates/rocprofiler-sdk/config.cmake.in
@@ -144,6 +144,13 @@ else()
                           INTERFACE @PACKAGE_NAME@::@PACKAGE_NAME@-external-nolink)
 endif()
 
+add_executable(@PACKAGE_NAME@::rocprofiler-core IMPORTED)
+set_property(
+    TARGET @PACKAGE_NAME@::rocprofiler-core
+    PROPERTY IMPORTED_LOCATION
+             ${@PACKAGE_NAME@_ROOT_DIR}/@CMAKE_INSTALL_BINDIR@/rocprofiler-core)
+
+# Deprecated alias target; 'rocprofv3' is a symlink to 'rocprofiler-core'.
 add_executable(@PACKAGE_NAME@::rocprofv3 IMPORTED)
 set_property(
     TARGET @PACKAGE_NAME@::rocprofv3

--- a/projects/rocprofiler-sdk/source/bin/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/bin/CMakeLists.txt
@@ -4,14 +4,25 @@
 
 rocprofiler_activate_clang_tidy()
 
-# Adding main rocprofv3
-configure_file(rocprofv3.py ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/rocprofv3 @ONLY)
+# Adding main rocprofiler-core
+configure_file(rocprofiler-core.py
+               ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/rocprofiler-core @ONLY)
+
+install(
+    FILES ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/rocprofiler-core
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ
+                WORLD_EXECUTE
+    COMPONENT tools)
+
+# Ship the legacy 'rocprofv3' name as a deprecated relative symlink to 'rocprofiler-core'.
+# The script emits a deprecation warning when invoked via the old name.
+execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink rocprofiler-core
+                        ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/rocprofv3)
 
 install(
     FILES ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/rocprofv3
     DESTINATION ${CMAKE_INSTALL_BINDIR}
-    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ
-                WORLD_EXECUTE
     COMPONENT tools)
 
 configure_file(rocprofv3-avail.py

--- a/projects/rocprofiler-sdk/source/bin/rocprofiler-core.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofiler-core.py
@@ -79,14 +79,14 @@ def patch_message(msg, *args):
 
 def fatal_error(msg, *args, exit_code=1):
     msg = patch_message(msg, *args)
-    sys.stderr.write(f"[rocprofv3] Fatal error: {msg}\n")
+    sys.stderr.write(f"[rocprofiler-core] Fatal error: {msg}\n")
     sys.stderr.flush()
     sys.exit(exit_code)
 
 
 def warning(msg, *args):
     msg = patch_message(msg, *args)
-    sys.stderr.write(f"[rocprofv3] Warning: {msg}\n")
+    sys.stderr.write(f"[rocprofiler-core] Warning: {msg}\n")
     sys.stderr.flush()
 
 
@@ -413,22 +413,22 @@ def parse_arguments(args=None):
 
 %(prog)s requires double-hyphen (--) before the application to be executed, e.g.
 
-    $ rocprofv3 [<rocprofv3-option> ...] -- <application> [<application-arg> ...]
-    $ rocprofv3 --hip-trace -- ./myapp -n 1
+    $ rocprofiler-core [<rocprofiler-core-option> ...] -- <application> [<application-arg> ...]
+    $ rocprofiler-core --hip-trace -- ./myapp -n 1
 
-For MPI applications (or other job launchers such as SLURM), place rocprofv3 inside the job launcher:
+For MPI applications (or other job launchers such as SLURM), place rocprofiler-core inside the job launcher:
 
-    $ mpirun -n 4 rocprofv3 --hip-trace -- ./mympiapp
+    $ mpirun -n 4 rocprofiler-core --hip-trace -- ./mympiapp
 
 For MPI applications, select specific ranks to provide profile/trace output:
 
-    $ mpirun -n 16 rocprofv3 --hip-trace --profile-mpi-ranks 0-3,8 -- ./mympiapp
-    $ srun -n 32 rocprofv3 --hip-trace --profile-mpi-ranks 0 -- ./myapp
+    $ mpirun -n 16 rocprofiler-core --hip-trace --profile-mpi-ranks 0-3,8 -- ./mympiapp
+    $ srun -n 32 rocprofiler-core --hip-trace --profile-mpi-ranks 0 -- ./myapp
 
 For attachment profiling of running processes:
 
-    $ rocprofv3 --attach <PID> --hip-trace --kernel-trace
-    $ rocprofv3 --attach 1234 --attach-duration-msec 10 --hsa-trace
+    $ rocprofiler-core --attach <PID> --hip-trace --kernel-trace
+    $ rocprofiler-core --attach 1234 --attach-duration-msec 10 --hsa-trace
 
 """
 
@@ -2306,6 +2306,14 @@ def run(app_args, args, **kwargs):
 
 
 def main(argv=None):
+
+    _invoked_as = os.path.basename(sys.argv[0]) if sys.argv else ""
+    if _invoked_as == "rocprofv3":
+        warning(
+            "rocprofv3 has been renamed to rocprofiler-core. Please update your "
+            "scripts and automation; the rocprofv3 command will be removed in a "
+            "future ROCm release. Use 'rocprofiler-core' instead."
+        )
 
     cmd_args, app_args = parse_arguments(argv)
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/advanced-rocprofv3-options.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/advanced-rocprofv3-options.rst
@@ -1,21 +1,21 @@
 .. meta::
   :description: ROCprofiler-SDK is a tooling infrastructure for profiling general-purpose GPU compute applications running on the ROCm software
-  :keywords: ROCprofiler-SDK tool usage, rocprofv3 user manual, rocprofv3 usage, rocprofv3 user guide, using rocprofv3, ROCprofiler-SDK tool user guide, ROCprofiler-SDK tool user manual, using ROCprofiler-SDK tool, ROCprofiler-SDK command-line tool, ROCprofiler-SDK CLI, ROCprofiler-SDK command line tool
+  :keywords: ROCprofiler-SDK tool usage, rocprofiler-core user manual, rocprofiler-core usage, rocprofiler-core user guide, using rocprofiler-core, ROCprofiler-SDK tool user guide, ROCprofiler-SDK tool user manual, using ROCprofiler-SDK tool, ROCprofiler-SDK command-line tool, ROCprofiler-SDK CLI, ROCprofiler-SDK command line tool
 
 .. _rocprofv3-advanced-options:
 
-===========================
-rocprofv3 advanced options
-===========================
+=================================
+rocprofiler-core advanced options
+=================================
 
-``rocprofv3`` provides the following miscellaneous functionalities for improved control and flexibility.
+``rocprofiler-core`` provides the following miscellaneous functionalities for improved control and flexibility.
 
 Minimum output data threshold
 ------------------------------
 
 The ``--minimum-output-data`` option allows you to control the generation of output files by setting a minimum data size threshold. This prevents the creation of empty or very small output files that contain no meaningful profiling data.
 
-When this option is specified, ``rocprofv3`` only generates output files if the collected data size exceeds the specified threshold. This is particularly useful in scenarios where:
+When this option is specified, ``rocprofiler-core`` only generates output files if the collected data size exceeds the specified threshold. This is particularly useful in scenarios where:
 
 - You're profiling applications that may have sporadic GPU activity
 - You want to avoid processing empty trace files in automated workflows
@@ -25,7 +25,7 @@ To specify the minimum output data threshold, use the ``--minimum-output-data`` 
 
 .. code-block:: bash
 
-    rocprofv3 --minimum-output-data 100 --hip-trace --output-format csv -- <application_path>
+    rocprofiler-core --minimum-output-data 100 --hip-trace --output-format csv -- <application_path>
 
 The preceding command only generates output files if the HIP trace data is larger than 100 KB.
 
@@ -36,14 +36,14 @@ The preceding command only generates output files if the HIP trace data is large
 .. code-block:: bash
 
     # Only generate output if kernel trace data > 50 KB
-    rocprofv3 --minimum-output-data 50 --kernel-trace --output-format csv -- <application_path>
+    rocprofiler-core --minimum-output-data 50 --kernel-trace --output-format csv -- <application_path>
 
 **Scenario 2: Batch profiling with meaningful data collection**
 
 .. code-block:: bash
 
     # For system tracing, only output files if data > 1 MB
-    rocprofv3 --minimum-output-data 1024 --sys-trace --output-format pftrace -- <application_path>
+    rocprofiler-core --minimum-output-data 1024 --sys-trace --output-format pftrace -- <application_path>
 
 **Using with input files:**
 
@@ -84,15 +84,15 @@ This feature is especially valuable in automated testing environments where you 
 Signal handler control
 -----------------------
 
-The ``--disable-signal-handlers`` option provides control over signal handling behavior in ``rocprofv3``, allowing you to manage how the profiler responds to system signals like SIGSEGV, SIGTERM, and others.
+The ``--disable-signal-handlers`` option provides control over signal handling behavior in ``rocprofiler-core``, allowing you to manage how the profiler responds to system signals like SIGSEGV, SIGTERM, and others.
 
-By default, ``rocprofv3`` installs its own signal handlers to ensure proper cleanup and data collection when the application encounters errors or is terminated. However, in some scenarios, you may want the application's own signal handlers to take precedence.
+By default, ``rocprofiler-core`` installs its own signal handlers to ensure proper cleanup and data collection when the application encounters errors or is terminated. However, in some scenarios, you may want the application's own signal handlers to take precedence.
 
-When ``--disable-signal-handlers`` is set to ``true``, ``rocprofv3`` disables the prioritization of its signal handlers over application-installed signal handlers. This means:
+When ``--disable-signal-handlers`` is set to ``true``, ``rocprofiler-core`` disables the prioritization of its signal handlers over application-installed signal handlers. This means:
 
-- If your application has custom signal handlers for SIGSEGV, SIGTERM, or similar signals, those handlers will be executed instead of ``rocprofv3``'s handlers
+- If your application has custom signal handlers for SIGSEGV, SIGTERM, or similar signals, those handlers will be executed instead of ``rocprofiler-core``'s handlers
 - The application maintains full control over signal handling behavior
-- ``rocprofv3`` will still attempt to collect and save profiling data when possible
+- ``rocprofiler-core`` will still attempt to collect and save profiling data when possible
 
 **Important note**: Even with this option enabled, the underlying ``glog`` library may still install signal handlers that provide stack backtraces for debugging purposes.
 
@@ -100,9 +100,9 @@ When ``--disable-signal-handlers`` is set to ``true``, ``rocprofv3`` disables th
 
 .. code-block:: bash
 
-    rocprofv3 --disable-signal-handlers --hip-trace --output-format csv -- <application_path>
+    rocprofiler-core --disable-signal-handlers --hip-trace --output-format csv -- <application_path>
 
-The preceding command disables ``rocprofv3`` signal handler prioritization, allowing the application's signal handlers to take precedence.
+The preceding command disables ``rocprofiler-core`` signal handler prioritization, allowing the application's signal handlers to take precedence.
 
 **Example scenarios:**
 
@@ -111,21 +111,21 @@ The preceding command disables ``rocprofv3`` signal handler prioritization, allo
 .. code-block:: bash
 
     # For applications that implement custom crash reporting or recovery
-    rocprofv3 --disable-signal-handlers --sys-trace --output-format pftrace -- ./my_app_with_custom_handlers
+    rocprofiler-core --disable-signal-handlers --sys-trace --output-format pftrace -- ./my_app_with_custom_handlers
 
 **Scenario 2: Debugging applications with existing signal handlers**
 
 .. code-block:: bash
 
     # When debugging applications that rely on specific signal handling behavior
-    rocprofv3 --disable-signal-handlers --kernel-trace --pmc SQ_WAVES -- ./debug_application
+    rocprofiler-core --disable-signal-handlers --kernel-trace --pmc SQ_WAVES -- ./debug_application
 
 **Scenario 3: Integration with testing frameworks**
 
 .. code-block:: bash
 
     # For test frameworks that need to handle signals for test orchestration
-    rocprofv3 --disable-signal-handlers --runtime-trace --output-directory test_results -- ./test_suite
+    rocprofiler-core --disable-signal-handlers --runtime-trace --output-directory test_results -- ./test_suite
 
 **Using with input files:**
 
@@ -163,7 +163,7 @@ You can also specify this option in YAML or JSON input files:
 
 **Avoid this option when:**
 
-- You want ``rocprofv3`` to provide maximum protection against data loss
+- You want ``rocprofiler-core`` to provide maximum protection against data loss
 - Your application doesn't have custom signal handlers
 - You're doing standard profiling where signal handling isn't a concern
 
@@ -191,28 +191,28 @@ Use ``--disable-signal-handlers`` to ensure your custom handler executes:
 
 .. code-block:: bash
 
-    rocprofv3 --disable-signal-handlers --hip-trace -- ./app_with_custom_handler
+    rocprofiler-core --disable-signal-handlers --hip-trace -- ./app_with_custom_handler
 
 **Troubleshooting:**
 
 - If profiling data appears incomplete with this option enabled, check if your application's signal handlers are properly saving or flushing data
-- Consider implementing explicit ``rocprofv3`` cleanup calls in your application's signal handlers if data integrity is important
+- Consider implementing explicit ``rocprofiler-core`` cleanup calls in your application's signal handlers if data integrity is important
 - Monitor application behavior to ensure custom signal handling doesn't interfere with profiling data collection
 
-This option provides the flexibility needed for complex applications and testing environments while maintaining ``rocprofv3``'s core profiling functionality.
+This option provides the flexibility needed for complex applications and testing environments while maintaining ``rocprofiler-core``'s core profiling functionality.
 
 Library preloading
 -------------------
 
 The ``--preload`` option allows you to specify additional libraries to prepend to the ``LD_PRELOAD`` environment variable. This is particularly useful when working with sanitizer libraries, debugging tools, or other instrumentation libraries that need to be loaded before the application starts.
 
-``LD_PRELOAD`` is a powerful mechanism in Linux that allows you to load shared libraries before any other libraries, effectively intercepting and overriding function calls. The ``--preload`` option in ``rocprofv3`` provides a convenient way to manage this without manually setting environment variables.
+``LD_PRELOAD`` is a powerful mechanism in Linux that allows you to load shared libraries before any other libraries, effectively intercepting and overriding function calls. The ``--preload`` option in ``rocprofiler-core`` provides a convenient way to manage this without manually setting environment variables.
 
 **Basic usage:**
 
 .. code-block:: bash
 
-    rocprofv3 --preload /path/to/library.so --hip-trace --output-format csv -- <application_path>
+    rocprofiler-core --preload /path/to/library.so --hip-trace --output-format csv -- <application_path>
 
 The preceding command preloads the specified library and enables HIP tracing.
 
@@ -223,28 +223,28 @@ The preceding command preloads the specified library and enables HIP tracing.
 .. code-block:: bash
 
     # Preload AddressSanitizer for memory error detection
-    rocprofv3 --preload /usr/lib/x86_64-linux-gnu/libasan.so.5 --sys-trace -- ./my_application
+    rocprofiler-core --preload /usr/lib/x86_64-linux-gnu/libasan.so.5 --sys-trace -- ./my_application
 
 **Scenario 2: Using ThreadSanitizer (TSan)**
 
 .. code-block:: bash
 
     # Preload ThreadSanitizer for race condition detection
-    rocprofv3 --preload /usr/lib/x86_64-linux-gnu/libtsan.so.0 --kernel-trace --pmc SQ_WAVES -- ./threaded_app
+    rocprofiler-core --preload /usr/lib/x86_64-linux-gnu/libtsan.so.0 --kernel-trace --pmc SQ_WAVES -- ./threaded_app
 
 **Scenario 3: Multiple preloaded libraries**
 
 .. code-block:: bash
 
     # Preload multiple libraries (custom profiler and sanitizer)
-    rocprofv3 --preload /opt/custom/libprofiler.so /usr/lib/libasan.so --runtime-trace -- ./complex_app
+    rocprofiler-core --preload /opt/custom/libprofiler.so /usr/lib/libasan.so --runtime-trace -- ./complex_app
 
 **Scenario 4: Using MemorySanitizer (MSan)**
 
 .. code-block:: bash
 
     # Preload MemorySanitizer for uninitialized memory detection
-    rocprofv3 --preload /usr/lib/x86_64-linux-gnu/libmsan.so.0 --hip-trace -- ./memory_intensive_app
+    rocprofiler-core --preload /usr/lib/x86_64-linux-gnu/libmsan.so.0 --hip-trace -- ./memory_intensive_app
 
 **Using with input files:**
 
@@ -302,7 +302,7 @@ The order of libraries in ``--preload`` matters as they are processed in the ord
 .. code-block:: bash
 
     # Library1 will be loaded before Library2
-    rocprofv3 --preload /path/to/library1.so /path/to/library2.so --hip-trace -- ./app
+    rocprofiler-core --preload /path/to/library1.so /path/to/library2.so --hip-trace -- ./app
 
 **Environment variable interaction:**
 
@@ -312,7 +312,7 @@ The ``--preload`` option works alongside existing ``LD_PRELOAD`` settings:
 
     # If LD_PRELOAD is already set, --preload libraries are prepended
     export LD_PRELOAD="/existing/library.so"
-    rocprofv3 --preload /new/library.so --hip-trace -- ./app
+    rocprofiler-core --preload /new/library.so --hip-trace -- ./app
     # Effective LD_PRELOAD: "/new/library.so:/existing/library.so"
 
 **Troubleshooting:**
@@ -327,13 +327,13 @@ ROCm root path configuration
 
 The ``--rocm-root`` option allows you to specify a custom ROCm installation directory instead of using the default relative path detection. This is useful when working with multiple ROCm installations, custom builds, or non-standard installation locations.
 
-By default, ``rocprofv3`` automatically detects the ROCm installation path relative to its own location. However, in some environments, you may need to explicitly specify which ROCm installation to use.
+By default, ``rocprofiler-core`` automatically detects the ROCm installation path relative to its own location. However, in some environments, you may need to explicitly specify which ROCm installation to use.
 
 **Basic usage:**
 
 .. code-block:: bash
 
-    rocprofv3 --rocm-root /opt/custom-rocm --hip-trace --output-format csv -- <application_path>
+    rocprofiler-core --rocm-root /opt/custom-rocm --hip-trace --output-format csv -- <application_path>
 
 The preceding command uses the ROCm installation located at ``/opt/custom-rocm``.
 
@@ -344,31 +344,31 @@ The preceding command uses the ROCm installation located at ``/opt/custom-rocm``
 .. code-block:: bash
 
     # Use ROCm 5.7.0 specifically
-    rocprofv3 --rocm-root /opt/rocm-5.7.0 --sys-trace -- ./app_for_rocm_5_7
+    rocprofiler-core --rocm-root /opt/rocm-5.7.0 --sys-trace -- ./app_for_rocm_5_7
 
     # Use ROCm 6.0.0 for comparison
-    rocprofv3 --rocm-root /opt/rocm-6.0.0 --sys-trace -- ./app_for_rocm_6_0
+    rocprofiler-core --rocm-root /opt/rocm-6.0.0 --sys-trace -- ./app_for_rocm_6_0
 
 **Scenario 2: Custom ROCm build**
 
 .. code-block:: bash
 
     # Use custom ROCm build with debugging symbols
-    rocprofv3 --rocm-root /home/developer/rocm-debug-build --kernel-trace --pmc SQ_WAVES -- ./debug_app
+    rocprofiler-core --rocm-root /home/developer/rocm-debug-build --kernel-trace --pmc SQ_WAVES -- ./debug_app
 
 **Scenario 3: Development environment**
 
 .. code-block:: bash
 
     # Use locally built ROCm for development
-    rocprofv3 --rocm-root /workspace/rocm-dev --runtime-trace -- ./test_application
+    rocprofiler-core --rocm-root /workspace/rocm-dev --runtime-trace -- ./test_application
 
 **Scenario 4: Container environments**
 
 .. code-block:: bash
 
     # Use ROCm mounted at custom location in container
-    rocprofv3 --rocm-root /usr/local/rocm --hip-trace -- ./containerized_app
+    rocprofiler-core --rocm-root /usr/local/rocm --hip-trace -- ./containerized_app
 
 **Directory structure requirements:**
 
@@ -392,7 +392,7 @@ This option is typically used from the command line, but can be specified in wra
     #!/bin/bash
     # profile_with_custom_rocm.sh
     ROCM_PATH="/opt/rocm-custom"
-    rocprofv3 --rocm-root "$ROCM_PATH" -i input.yaml -- "$@"
+    rocprofiler-core --rocm-root "$ROCM_PATH" -i input.yaml -- "$@"
 
 **Environment variable interaction:**
 
@@ -402,7 +402,7 @@ The ``--rocm-root`` option overrides automatic path detection and environment va
 
     # --rocm-root takes precedence over environment variables
     export ROCM_PATH="/opt/rocm-default"
-    rocprofv3 --rocm-root /opt/rocm-override --hip-trace -- ./app
+    rocprofiler-core --rocm-root /opt/rocm-override --hip-trace -- ./app
     # Uses /opt/rocm-override, not /opt/rocm-default
 
 **Validation and troubleshooting:**
@@ -423,7 +423,7 @@ Shared object versioning follows the Linux convention where libraries have versi
 
 .. code-block:: bash
 
-    rocprofv3 --sdk-soversion 2 --hip-trace --output-format csv -- <application_path>
+    rocprofiler-core --sdk-soversion 2 --hip-trace --output-format csv -- <application_path>
 
 The preceding command uses ``librocprofiler-sdk.so.2`` instead of the default version.
 
@@ -434,31 +434,31 @@ The preceding command uses ``librocprofiler-sdk.so.2`` instead of the default ve
 .. code-block:: bash
 
     # Test application with SDK version 1
-    rocprofv3 --sdk-soversion 1 --kernel-trace --pmc SQ_WAVES -- ./app_v1_test
+    rocprofiler-core --sdk-soversion 1 --kernel-trace --pmc SQ_WAVES -- ./app_v1_test
 
     # Test same application with SDK version 2
-    rocprofv3 --sdk-soversion 2 --kernel-trace --pmc SQ_WAVES -- ./app_v2_test
+    rocprofiler-core --sdk-soversion 2 --kernel-trace --pmc SQ_WAVES -- ./app_v2_test
 
 **Scenario 2: Compatibility verification**
 
 .. code-block:: bash
 
     # Verify backward compatibility with older SDK
-    rocprofv3 --sdk-soversion 0 --sys-trace -- ./legacy_application
+    rocprofiler-core --sdk-soversion 0 --sys-trace -- ./legacy_application
 
 **Scenario 3: Development and testing**
 
 .. code-block:: bash
 
     # Use specific version for regression testing
-    rocprofv3 --sdk-soversion 3 --runtime-trace --output-directory regression_test -- ./test_suite
+    rocprofiler-core --sdk-soversion 3 --runtime-trace --output-directory regression_test -- ./test_suite
 
 **Scenario 4: Production environment pinning**
 
 .. code-block:: bash
 
     # Pin to specific version for production consistency
-    rocprofv3 --sdk-soversion 1 --hip-trace --minimum-output-data 100 -- ./production_app
+    rocprofiler-core --sdk-soversion 1 --hip-trace --minimum-output-data 100 -- ./production_app
 
 **Library resolution behavior:**
 
@@ -475,7 +475,7 @@ The option affects library loading in the following order:
     # test_matrix.sh - Test with multiple SDK versions
     for version in 0 1 2; do
         echo "Testing with SDK SO version $version"
-        rocprofv3 --sdk-soversion $version --hip-trace -- ./test_app
+        rocprofiler-core --sdk-soversion $version --hip-trace -- ./test_app
     done
 
 **Troubleshooting:**
@@ -496,7 +496,7 @@ This option helps resolve library paths for version-specific libraries like ``li
 
 .. code-block:: bash
 
-    rocprofv3 --sdk-version 1.2.3 --hip-trace --output-format csv -- <application_path>
+    rocprofiler-core --sdk-version 1.2.3 --hip-trace --output-format csv -- <application_path>
 
 The preceding command uses ``librocprofiler-sdk.so.1.2.3`` if available.
 
@@ -507,17 +507,17 @@ The preceding command uses ``librocprofiler-sdk.so.1.2.3`` if available.
 .. code-block:: bash
 
     # Test with specific patch version for bug verification
-    rocprofv3 --sdk-version 2.1.5 --kernel-trace -- ./bug_reproduction_case
+    rocprofiler-core --sdk-version 2.1.5 --kernel-trace -- ./bug_reproduction_case
 
     # Test with fixed version
-    rocprofv3 --sdk-version 2.1.6 --kernel-trace -- ./bug_verification_case
+    rocprofiler-core --sdk-version 2.1.6 --kernel-trace -- ./bug_verification_case
 
 **Scenario 2: Reproducible profiling**
 
 .. code-block:: bash
 
     # Ensure exact same SDK version for reproducible results
-    rocprofv3 --sdk-version 2.2.1 --pmc SQ_WAVES GRBM_COUNT --output-format pftrace -- ./benchmark_app
+    rocprofiler-core --sdk-version 2.2.1 --pmc SQ_WAVES GRBM_COUNT --output-format pftrace -- ./benchmark_app
 
 **Version format support:**
 
@@ -546,7 +546,7 @@ While typically used from command line, it can be scripted:
 
     for version in "${VERSIONS[@]}"; do
         echo "Testing SDK version $version"
-        rocprofv3 --sdk-version "$version" --hip-trace --output-directory "results_$version" -- ./test_app
+        rocprofiler-core --sdk-version "$version" --hip-trace --output-directory "results_$version" -- ./test_app
     done
 
 **Combined with other version options:**
@@ -554,15 +554,15 @@ While typically used from command line, it can be scripted:
 .. code-block:: bash
 
     # Combine with soversion for maximum control
-    rocprofv3 --sdk-version 2.1.5 --sdk-soversion 2 --hip-trace -- ./app
+    rocprofiler-core --sdk-version 2.1.5 --sdk-soversion 2 --hip-trace -- ./app
 
     # Combine with custom ROCm root
-    rocprofv3 --rocm-root /opt/rocm-6.0 --sdk-version 2.2.0 --sys-trace -- ./app
+    rocprofiler-core --rocm-root /opt/rocm-6.0 --sdk-version 2.2.0 --sys-trace -- ./app
 
 Agent index
 ------------
 
-The agent index is a unique identifier for each agent in the system. It is used to identify the agent in the output files. Since, each runtime or tool has an independent representation of the agent's indices, ``rocprofv3`` provides an option to configure the agent index in the output files.
+The agent index is a unique identifier for each agent in the system. It is used to identify the agent in the output files. Since, each runtime or tool has an independent representation of the agent's indices, ``rocprofiler-core`` provides an option to configure the agent index in the output files.
 
 - **absolute == node_id:** Absolute index of the agent, regardless of cgroups masking. This is a monotonically increasing number, which is incremented for every folder in ``/sys/class/kfd/kfd/topology/nodes``. For example, Agent-0, Agent-2, Agent-4.
 - **relative == logical_node_id:** Relative index of the agent accounting for cgroups masking. This is a monotonically increasing number, which is incremented for every folder in ``/sys/class/kfd/kfd/topology/nodes/``, whose properties file is non-empty. For example, Agent-0, Agent-1, Agent-2.
@@ -581,7 +581,7 @@ To set the agent index to relative, use:
 
 .. code-block:: shell
 
-    rocprofv3 --kernel-trace --agent-index=relative --output-format csv -- <application_path>
+    rocprofiler-core --kernel-trace --agent-index=relative --output-format csv -- <application_path>
 
 Here is the generated output file with ``Agent_Id`` as "Agent 7":
 
@@ -596,7 +596,7 @@ To set the agent index to type-relative, use:
 
 .. code-block:: shell
 
-    rocprofv3 --kernel-trace --agent-index=type-relative --output-format csv -- <application_path>
+    rocprofiler-core --kernel-trace --agent-index=type-relative --output-format csv -- <application_path>
 
 Here is the generated output file with ``Agent_Id`` as "GPU 3":
 
@@ -610,13 +610,13 @@ Here is the generated output file with ``Agent_Id`` as "GPU 3":
 Group by queue
 ---------------
 
-By default, ``rocprofv3`` shows the HIP streams to which the kernel and memory copy operations were submitted, when outputting a perfetto trace. Whereas, the ``--group-by-queue`` option displays the HSA queues to which these kernel and memory operations were submitted.
+By default, ``rocprofiler-core`` shows the HIP streams to which the kernel and memory copy operations were submitted, when outputting a perfetto trace. Whereas, the ``--group-by-queue`` option displays the HSA queues to which these kernel and memory operations were submitted.
 
 .. image:: /data/streams_pftrace.png
 
 .. code-block:: shell
 
-    rocprofv3 -s --group-by-queue --output-format pftrace  -- <application_path>
+    rocprofiler-core -s --group-by-queue --output-format pftrace  -- <application_path>
 
 The preceding command generates a ``pftrace`` file with the kernel and memory copy operations grouped into HSA queues instead of HIP streams.
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/rocprofv3-io-options.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/rocprofv3-io-options.rst
@@ -1,15 +1,15 @@
 
 .. meta::
   :description: ROCprofiler-SDK is a tooling infrastructure for profiling general-purpose GPU compute applications running on the ROCm software
-  :keywords: ROCprofiler-SDK tool usage, rocprofv3 user manual, rocprofv3 usage, rocprofv3 user guide, using rocprofv3, ROCprofiler-SDK tool user guide, ROCprofiler-SDK tool user manual, using ROCprofiler-SDK tool, ROCprofiler-SDK command-line tool, ROCprofiler-SDK CLI, ROCprofiler-SDK command line tool
+  :keywords: ROCprofiler-SDK tool usage, rocprofiler-core user manual, rocprofiler-core usage, rocprofiler-core user guide, using rocprofiler-core, ROCprofiler-SDK tool user guide, ROCprofiler-SDK tool user manual, using ROCprofiler-SDK tool, ROCprofiler-SDK command-line tool, ROCprofiler-SDK CLI, ROCprofiler-SDK command line tool
 
 .. _rocprofv3-io-options:
 
-==============================
-rocprofv3 I/O control options
-==============================
+====================================
+rocprofiler-core I/O control options
+====================================
 
-``rocprofv3`` provides the following options to control the output.
+``rocprofiler-core`` provides the following options to control the output.
 
 .. _output-prefix-keys:
 
@@ -73,7 +73,7 @@ To specify the output directory, use ``--output-directory`` or ``-d`` option. If
 
 .. code-block:: shell
 
-   rocprofv3 --hip-trace --output-directory output_dir --output-format csv -- <application_path>
+   rocprofiler-core --hip-trace --output-directory output_dir --output-format csv -- <application_path>
 
 The preceding command generates an ``output_dir/%hostname%/%pid%_hip_api_trace.csv`` file.
 
@@ -93,9 +93,9 @@ The following example shows how to use the output directory option with placehol
 
 .. code-block:: bash
 
-   mpirun -n 2 rocprofv3 --hip-trace -d %h.%p.%env{OMPI_COMM_WORLD_RANK}% --output-format csv -- <application_path>
+   mpirun -n 2 rocprofiler-core --hip-trace -d %h.%p.%env{OMPI_COMM_WORLD_RANK}% --output-format csv -- <application_path>
 
-The preceding command runs the application with ``rocprofv3`` and generates the trace file for each rank. The trace files are prefixed with hostname, process ID, and MPI rank.
+The preceding command runs the application with ``rocprofiler-core`` and generates the trace file for each rank. The trace files are prefixed with hostname, process ID, and MPI rank.
 
 Assuming the hostname as ``ubuntu-latest`` and the process IDs as 3000020 and 3000019, the output file names are:
 
@@ -113,7 +113,7 @@ To specify the output file name, use ``--output-file`` or ``-o`` option. If not 
 
 .. code-block:: shell
 
-   rocprofv3 --hip-trace --output-file output --output-format csv -- <application_path>
+   rocprofiler-core --hip-trace --output-file output --output-format csv -- <application_path>
 
 The preceding command generates an ``output_hip_api_trace.csv`` file.
 
@@ -121,7 +121,7 @@ The output file name can also include placeholders such as ``%hostname%`` and ``
 
 .. code-block:: shell
 
-   rocprofv3 --hip-trace --output-file %hostname%/%pid%_hip_api_trace --output-format csv -- <application_path>
+   rocprofiler-core --hip-trace --output-file %hostname%/%pid%_hip_api_trace --output-format csv -- <application_path>
 
 The preceding command generates an ``%hostname%/%pid%_hip_api_trace.csv`` file.
 
@@ -141,7 +141,7 @@ The triplet is defined as follows:
 
 .. code-block:: shell
 
-   rocprofv3 --collection-period 5:1:1 --hip-trace -- <application_path>
+   rocprofiler-core --collection-period 5:1:1 --hip-trace -- <application_path>
 
 The preceding command collects the profiling data for 1 second, starting 5 seconds after the application starts, and this cycle will be repeated once.
 
@@ -155,7 +155,7 @@ To specify the time unit as milliseconds, use:
 
 .. code-block:: shell
 
-   rocprofv3 --collection-period 5:1:0 --collection-period-unit msec --hip-trace -- <application_path>
+   rocprofiler-core --collection-period 5:1:0 --collection-period-unit msec --hip-trace -- <application_path>
 
 Perfetto-specific options
 --------------------------

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-avail.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-avail.rst
@@ -1,6 +1,6 @@
 .. meta::
   :description: Documentation of the usage of rocprofv3-avail
-  :keywords: ROCprofiler-SDK tool usage, rocprofv3-avail usage, rocprofv3 user manual, rocprofv3 usage, rocprofv3 user guide, using rocprofv3, ROCprofiler-SDK tool user guide, ROCprofiler-SDK tool user manual, using ROCprofiler-SDK tool, ROCprofiler-SDK command-line tool, ROCprofiler-SDK CLI, ROCprofiler-SDK command line tool
+  :keywords: ROCprofiler-SDK tool usage, rocprofv3-avail usage, rocprofiler-core user manual, rocprofiler-core usage, rocprofiler-core user guide, using rocprofiler-core, ROCprofiler-SDK tool user guide, ROCprofiler-SDK tool user manual, using ROCprofiler-SDK tool, ROCprofiler-SDK command-line tool, ROCprofiler-SDK CLI, ROCprofiler-SDK command line tool
 
 .. _using-rocprofv3-avail:
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-process-attachment.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-process-attachment.rst
@@ -1,21 +1,21 @@
 
 .. meta::
-  :description: Guide for using rocprofv3 process attachment
+  :description: Guide for using rocprofiler-core process attachment
   :keywords: ROCprofiler-SDK, process attachment, ptrace, dynamic profiling
 
 .. _rocprofv3-process-attachment:
 
-==========================================
-Dynamic process attachment using rocprofv3
-==========================================
+=================================================
+Dynamic process attachment using rocprofiler-core
+=================================================
 
-For profiling long-running applications or services where restarting the application is not feasible, ``rocprofv3`` provides dynamic process attachment using the ``--attach`` option. This feature facilitates attaching the profiler to a running application without the need to restart it. The attachment is performed using the ``ptrace`` system call, which enables the profiler to monitor and collect performance data from the target process.
+For profiling long-running applications or services where restarting the application is not feasible, ``rocprofiler-core`` provides dynamic process attachment using the ``--attach`` option. This feature facilitates attaching the profiler to a running application without the need to restart it. The attachment is performed using the ``ptrace`` system call, which enables the profiler to monitor and collect performance data from the target process.
 
 Here is an example syntax for dynamic process attachment:
 
 .. code-block:: bash
 
-   rocprofv3 --attach <PID> [--hip-trace] [--output-format <format>]
+   rocprofiler-core --attach <PID> [--hip-trace] [--output-format <format>]
 
 Here are the options used in the preceding example:
 
@@ -27,17 +27,17 @@ Here are the options used in the preceding example:
 
 .. note::
 
-   In process-attachment mode, ``rocprofv3`` may generate output files asynchronously during detachment. As a result, output files might not be fully written immediately when ``rocprofv3`` returns. If your workflow needs output files to be complete before continuing, for example, if a script processes or removes the output directory right after detach, use ``--attach-sync-output``. This makes detach wait for output generation to finish, which can increase detach time.
+   In process-attachment mode, ``rocprofiler-core`` may generate output files asynchronously during detachment. As a result, output files might not be fully written immediately when ``rocprofiler-core`` returns. If your workflow needs output files to be complete before continuing, for example, if a script processes or removes the output directory right after detach, use ``--attach-sync-output``. This makes detach wait for output generation to finish, which can increase detach time.
 
 **Basic attachment syntax:**
 
 .. code-block:: bash
 
-    rocprofv3 -p <PID> <tracing_options>
+    rocprofiler-core -p <PID> <tracing_options>
     # or
-    rocprofv3 --pid <PID> <tracing_options>
+    rocprofiler-core --pid <PID> <tracing_options>
     # or
-    rocprofv3 --attach <PID> <tracing_options>
+    rocprofiler-core --attach <PID> <tracing_options>
 
 Basic dynamic process attachment
 ---------------------------------
@@ -58,15 +58,15 @@ Follow these steps to attach the profiler to a running process and profile:
       OR
       ps aux | grep myapp
 
-3. Attach ``rocprofv3`` to the running application:
+3. Attach ``rocprofiler-core`` to the running application:
 
    .. code-block:: bash
 
-      rocprofv3 --attach <PID> --hip-trace --output-format rocpd
+      rocprofiler-core --attach <PID> --hip-trace --output-format rocpd
 
 4. Detach the profiler when done:
 
-   To detach the profiler from the target application, press "Enter" in the terminal where ``rocprofv3`` is running. You can also send SIGINT (Ctrl+C) to ``rocprofv3`` to detach from the target.
+   To detach the profiler from the target application, press "Enter" in the terminal where ``rocprofiler-core`` is running. You can also send SIGINT (Ctrl+C) to ``rocprofiler-core`` to detach from the target.
 
 5. The profiling data will be saved in the format specified using ``output-format``.
 
@@ -91,11 +91,11 @@ Follow these steps to attach the profiler to a running process and profile for a
       OR
       ps aux | grep myapp
 
-3. Attach ``rocprofv3`` to the running application:
+3. Attach ``rocprofiler-core`` to the running application:
 
    .. code-block:: bash
 
-      rocprofv3 --attach <PID> --attach-duration-msec 5000 --sys-trace --output-format csv
+      rocprofiler-core --attach <PID> --attach-duration-msec 5000 --sys-trace --output-format csv
 
 4. The profiler will automatically detach after the specified duration (5 seconds in this case). Note that the duration is to be specified in milliseconds (ms).
 
@@ -104,22 +104,22 @@ Follow these steps to attach the profiler to a running process and profile for a
 Dynamic process attachment with counter collection
 ---------------------------------------------------
 
-The dynamic process attachment functionality works with all tracing and profiling options available in ``rocprofv3``, providing the same comprehensive analysis capabilities as standard application launching.
+The dynamic process attachment functionality works with all tracing and profiling options available in ``rocprofiler-core``, providing the same comprehensive analysis capabilities as standard application launching.
 
 The following example attaches the profiler to a process with PID "12345", collects counters ``SQ_WAVES`` and ``GRBM_COUNT``, and saves profiling data in a CSV file:
 
 .. code-block:: bash
 
-   rocprofv3 --pid 12345 --pmc SQ_WAVES GRBM_COUNT --output-format csv
+   rocprofiler-core --pid 12345 --pmc SQ_WAVES GRBM_COUNT --output-format csv
 
 Reattaching to the same process
 --------------------------------
 
-The dynamic process attachment functionality supports reattachment, allowing attaching multiple times to the same PID over a process's lifetime. You need to provide the same PID to ``rocprofv3`` to reattach.
+The dynamic process attachment functionality supports reattachment, allowing attaching multiple times to the same PID over a process's lifetime. You need to provide the same PID to ``rocprofiler-core`` to reattach.
 
-There are some restrictions on what the options are allowed to change when reattaching. Typically, tracing, PC sampling, ATT, counter collection, and other options that decide the data to be collected can't be changed. ``rocprofv3`` throws a ``RuntimeError`` if it detects a configuration change that isn't supported.
+There are some restrictions on what the options are allowed to change when reattaching. Typically, tracing, PC sampling, ATT, counter collection, and other options that decide the data to be collected can't be changed. ``rocprofiler-core`` throws a ``RuntimeError`` if it detects a configuration change that isn't supported.
 
-By default, the output file generation runs asynchronously after detachment, allowing for faster tool detachment. This implies that the output files might not be immediately available when ``rocprofv3`` exits. If the output file generation from the previous attachment is still in progress, ``rocprofv3`` blocks reattachment until the ongoing output generation completes.
+By default, the output file generation runs asynchronously after detachment, allowing for faster tool detachment. This implies that the output files might not be immediately available when ``rocprofiler-core`` exits. If the output file generation from the previous attachment is still in progress, ``rocprofiler-core`` blocks reattachment until the ongoing output generation completes.
 
 .. class:: details
 
@@ -139,9 +139,9 @@ By default, the output file generation runs asynchronously after detachment, all
 Synchronous output generation for scripts
 ------------------------------------------
 
-For use cases requiring output files to be fully written before detachment completes, such as scripts that process or delete output directories immediately after detachment, you can enable synchronous output generation using the ``--attach-sync-output`` flag. This causes ``tool_detach`` to wait for all output files to be written before returning, ensuring output files are complete when the ``rocprofv3`` process exits.
+For use cases requiring output files to be fully written before detachment completes, such as scripts that process or delete output directories immediately after detachment, you can enable synchronous output generation using the ``--attach-sync-output`` flag. This causes ``tool_detach`` to wait for all output files to be written before returning, ensuring output files are complete when the ``rocprofiler-core`` process exits.
 
-For example, consider a script that attaches for a fixed duration and then terminates the workload as soon as ``rocprofv3`` returns:
+For example, consider a script that attaches for a fixed duration and then terminates the workload as soon as ``rocprofiler-core`` returns:
 
 .. code-block:: bash
 
@@ -150,42 +150,42 @@ For example, consider a script that attaches for a fixed duration and then termi
    WL_PID=$!
 
    # Attach for 5 seconds, then detach
-   rocprofv3 --pid "$WL_PID" --attach-duration-msec 5000 \
+   rocprofiler-core --pid "$WL_PID" --attach-duration-msec 5000 \
        --output-format csv -o profile -d "$PWD"
 
-   # Workload is killed immediately after rocprofv3 returns
+   # Workload is killed immediately after rocprofiler-core returns
    kill "$WL_PID"
 
-With the default asynchronous output generation, the output thread runs inside the target process. Killing the workload right after ``rocprofv3`` returns can terminate that thread before it finishes writing, producing truncated or incomplete output files. Add ``--attach-sync-output`` so that detachment waits for output generation to finish before returning:
+With the default asynchronous output generation, the output thread runs inside the target process. Killing the workload right after ``rocprofiler-core`` returns can terminate that thread before it finishes writing, producing truncated or incomplete output files. Add ``--attach-sync-output`` so that detachment waits for output generation to finish before returning:
 
 .. code-block:: bash
 
    ./myapp &
    WL_PID=$!
 
-   rocprofv3 --pid "$WL_PID" --attach-duration-msec 5000 \
+   rocprofiler-core --pid "$WL_PID" --attach-duration-msec 5000 \
        --attach-sync-output \
        --output-format csv -o profile -d "$PWD"
 
-   # Safe: output files are fully written before rocprofv3 returns
+   # Safe: output files are fully written before rocprofiler-core returns
    kill "$WL_PID"
 
 Attaching to a process tree
 ----------------------------
 
-By default, ``rocprofv3 --attach`` attaches to the target process **and all of its descendant processes**. This is useful for profiling applications that spawn child processes, such as multiprocess MPI jobs or launchers that fork workers.
+By default, ``rocprofiler-core --attach`` attaches to the target process **and all of its descendant processes**. This is useful for profiling applications that spawn child processes, such as multiprocess MPI jobs or launchers that fork workers.
 
 To attach to a PID and all its children (default behavior), use:
 
 .. code-block:: bash
 
-   rocprofv3 --attach 1234 --hip-trace
+   rocprofiler-core --attach 1234 --hip-trace
 
 To attach only to the specified PID and skip its descendants, use ``--attach-children=false``:
 
 .. code-block:: bash
 
-   rocprofv3 --attach 1234 --attach-children=false --hip-trace
+   rocprofiler-core --attach 1234 --attach-children=false --hip-trace
 
 The child process tree is enumerated once at attach time using ``/proc``. Processes that are spawned after the attachment has begun are not automatically profiled.
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-with-mpi.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-with-mpi.rst
@@ -31,7 +31,7 @@ The preceding command runs the application with ``rocprofiler-core`` and generat
     2293215_agent_info.csv
     2293215_hip_api_trace.csv
 
-Since the data collection is performed in-process, it's ideal to collect data from within the processes launched by MPI. When ``rocprofiler-core`` is run outside of ``mpirun``, the tool library is loaded into the `mpirun` executable..
+Since the data collection is performed in-process, it's ideal to collect data from within the processes launched by MPI. When ``rocprofiler-core`` is run outside of ``mpirun``, the tool library is loaded into the `mpirun` executable.
 Collecting data outside of ``mpirun`` works but fetches agent info for the ``mpirun`` process too. For example:
 
 .. code-block:: bash

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-with-mpi.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-with-mpi.rst
@@ -1,24 +1,24 @@
 .. meta::
-  :description: Documentation of the MPI usage for rocprofv3
-  :keywords: ROCprofiler-SDK tool, mpirun, rocprofv3, rocprofv3 tool usage, mpich, ROCprofiler-SDK command line tool, ROCprofiler-SDK CLI
+  :description: Documentation of the MPI usage for rocprofiler-core
+  :keywords: ROCprofiler-SDK tool, mpirun, rocprofiler-core, rocprofiler-core tool usage, mpich, ROCprofiler-SDK command line tool, ROCprofiler-SDK CLI
 
 
 .. _using-rocprofv3-with-mpi:
 
-=========================
-Using rocprofv3 with MPI
-=========================
+===============================
+Using rocprofiler-core with MPI
+===============================
 
 Message Passing Interface (MPI) is a standardized and portable message-passing system designed to function on a wide variety of parallel computing architectures. MPI is widely used for developing parallel applications and is considered the de facto standard for communication in high-performance computing (HPC) environments.
 MPI applications are parallel programs that run across multiple processes, which can be distributed over one or more nodes.
 
-For MPI applications or other job launchers such as `SLURM <https://slurm.schedmd.com/documentation.html>`_, place ``rocprofv3`` inside the job launcher. The following example demonstrates how to use ``rocprofv3`` with MPI:
+For MPI applications or other job launchers such as `SLURM <https://slurm.schedmd.com/documentation.html>`_, place ``rocprofiler-core`` inside the job launcher. The following example demonstrates how to use ``rocprofiler-core`` with MPI:
 
 .. code-block:: bash
 
-    mpirun -n 4 rocprofv3 --hip-trace --output-format csv -- <application_path>
+    mpirun -n 4 rocprofiler-core --hip-trace --output-format csv -- <application_path>
 
-The preceding command runs the application with ``rocprofv3`` and generates the trace file for each rank. The trace files are prefixed with the process ID.
+The preceding command runs the application with ``rocprofiler-core`` and generates the trace file for each rank. The trace files are prefixed with the process ID.
 
 .. code-block:: bash
 
@@ -31,12 +31,12 @@ The preceding command runs the application with ``rocprofv3`` and generates the 
     2293215_agent_info.csv
     2293215_hip_api_trace.csv
 
-Since the data collection is performed in-process, it's ideal to collect data from within the processes launched by MPI. When ``rocprofv3`` is run outside of ``mpirun``, the tool library is loaded into the `mpirun` executable..
+Since the data collection is performed in-process, it's ideal to collect data from within the processes launched by MPI. When ``rocprofiler-core`` is run outside of ``mpirun``, the tool library is loaded into the `mpirun` executable..
 Collecting data outside of ``mpirun`` works but fetches agent info for the ``mpirun`` process too. For example:
 
 .. code-block:: bash
 
-    rocprofv3 --hip-trace -d %h.%p.%env{OMPI_COMM_WORLD_RANK}% --output-format csv -- mpirun -n 2  <application_path>
+    rocprofiler-core --hip-trace -d %h.%p.%env{OMPI_COMM_WORLD_RANK}% --output-format csv -- mpirun -n 2  <application_path>
 
 In the preceding example, an extra agent info file is generated for the ``mpirun`` process. The trace files are prefixed with the hostname, process ID, and the MPI rank.
 
@@ -153,11 +153,11 @@ The preceding sample program generates output similar to the following:
 Output format features
 =======================
 
-To collect the profiles of the individual MPI processes, use ``rocprofv3`` with output directory option which sends output to unique files.
+To collect the profiles of the individual MPI processes, use ``rocprofiler-core`` with output directory option which sends output to unique files.
 
 .. code-block:: bash
 
-    mpirun -n 2 rocprofv3 --hip-trace -d %h.%p.%env{OMPI_COMM_WORLD_RANK}% --output-format csv --  <application_path>
+    mpirun -n 2 rocprofiler-core --hip-trace -d %h.%p.%env{OMPI_COMM_WORLD_RANK}% --output-format csv --  <application_path>
 
 To see the placeholders supported by the output directory option, see :ref:`output directory placeholders <output_field_format>`.
 
@@ -183,16 +183,16 @@ To specify the ranks for profiling, use the ``--profile-mpi-ranks`` option with 
 .. code-block:: bash
 
     # Profiles only rank 0
-    mpirun -n 16 rocprofv3 --hip-trace --profile-mpi-ranks 0 -- <application_path>
+    mpirun -n 16 rocprofiler-core --hip-trace --profile-mpi-ranks 0 -- <application_path>
 
     # Profiles ranks 0-3 and rank 8
-    mpirun -n 16 rocprofv3 --hip-trace --profile-mpi-ranks 0-3,8 -- <application_path>
+    mpirun -n 16 rocprofiler-core --hip-trace --profile-mpi-ranks 0-3,8 -- <application_path>
 
     # Profiles ranks 0, 4, 8, and 12
-    mpirun -n 16 rocprofv3 --hip-trace --profile-mpi-ranks 0,4,8,12 -- <application_path>
+    mpirun -n 16 rocprofiler-core --hip-trace --profile-mpi-ranks 0,4,8,12 -- <application_path>
 
     # Profiles a range of ranks (10 through 15)
-    srun -n 32 rocprofv3 --kernel-trace --profile-mpi-ranks 10-15 -- <application_path>
+    srun -n 32 rocprofiler-core --kernel-trace --profile-mpi-ranks 10-15 -- <application_path>
 
 The rank specification syntax supports:
 
@@ -205,7 +205,7 @@ Behavior
 
 When using ``--profile-mpi-ranks``:
 
-- The ``rocprofv3`` tool runs on **all** MPI ranks to avoid disrupting the application's execution.
+- The ``rocprofiler-core`` tool runs on **all** MPI ranks to avoid disrupting the application's execution.
 - Only the specified ranks collect and output profiling or trace data.
 - Non-selected ranks execute the application without profiling overhead or output generation.
 - This reduces output file count and storage requirements for large-scale runs.
@@ -241,7 +241,7 @@ For mixed environments or non-standard MPI configurations (such as interactive S
 .. code-block:: bash
 
     # Uses custom environment variables for rank and world size detection
-    mpirun -n 16 rocprofv3 --hip-trace --profile-mpi-ranks 0-3 \
+    mpirun -n 16 rocprofiler-core --hip-trace --profile-mpi-ranks 0-3 \
         --mpi-world-rank-variable MY_CUSTOM_RANK \
         --mpi-world-size-variable MY_CUSTOM_SIZE -- <application_path>
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-with-openmp.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-with-openmp.rst
@@ -1,15 +1,15 @@
 .. meta::
-  :description: Documentation for using rocprofv3 with OpenMP applications
-  :keywords: ROCprofiler-SDK tool, OpenMP, rocprofv3, rocprofv3 tool usage, ROCprofiler-SDK command line tool, ROCprofiler-SDK CLI
+  :description: Documentation for using rocprofiler-core with OpenMP applications
+  :keywords: ROCprofiler-SDK tool, OpenMP, rocprofiler-core, rocprofiler-core tool usage, ROCprofiler-SDK command line tool, ROCprofiler-SDK CLI
 
 
 .. _using-rocprofv3-with-openmp:
 
-============================
-Using rocprofv3 with OpenMP
-============================
+==================================
+Using rocprofiler-core with OpenMP
+==================================
 
-For computations offloaded to AMD GPUs using OpenMP (for example, via OpenMP target offload), ``rocprofv3`` can be used to capture and profile GPU activities initiated by these offloaded regions. The ``--ompt-trace`` option additionally records host-side OpenMP execution — parallel regions, tasks, work-sharing, and sync — for any application linked against an OMPT-capable OpenMP runtime; see :ref:`tracing-openmp-with-ompt-trace`.
+For computations offloaded to AMD GPUs using OpenMP (for example, via OpenMP target offload), ``rocprofiler-core`` can be used to capture and profile GPU activities initiated by these offloaded regions. The ``--ompt-trace`` option additionally records host-side OpenMP execution — parallel regions, tasks, work-sharing, and sync — for any application linked against an OMPT-capable OpenMP runtime; see :ref:`tracing-openmp-with-ompt-trace`.
 
 Example: Vector addition using OpenMP offload on AMD GPUs
 ==========================================================
@@ -72,16 +72,16 @@ To compile the application for AMD GPU offload, use:
 
     amdclang++ -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -L/opt/rocm/lib --offload-arch=gfx9xx -o vector_add <application>
 
-Profiling the application with rocprofv3
-=========================================
+Profiling the application with rocprofiler-core
+===============================================
 
-To profile the GPU activity during execution, run the application with ``rocprofv3``:
+To profile the GPU activity during execution, run the application with ``rocprofiler-core``:
 
 .. code-block:: bash
 
-    rocprofv3 -s --output-format csv -- ./vector_add
+    rocprofiler-core -s --output-format csv -- ./vector_add
 
-Upon execution, ``rocprofv3`` generates several CSV trace files, such as:
+Upon execution, ``rocprofiler-core`` generates several CSV trace files, such as:
 
 - <pid>_kernel_trace.csv
 - <pid>_hsa_api_trace.csv
@@ -100,9 +100,9 @@ The flags shown above capture HIP / HSA / kernel-dispatch / memory activity but 
 
 .. code-block:: bash
 
-    rocprofv3 --ompt-trace --kernel-trace --memory-copy-trace --output-format rocpd -- ./vector_add
+    rocprofiler-core --ompt-trace --kernel-trace --memory-copy-trace --output-format rocpd -- ./vector_add
 
-OMPT is a rocpd-only trace: records are written to the rocpd database (``rocpd`` is also the default output format) and are **not** emitted by the direct CSV / JSON / Perfetto / OTF2 generators. If ``--ompt-trace`` is combined with another ``--output-format``, ``rocprofv3`` prints a warning and adds ``rocpd`` automatically so OMPT data is not lost. To view OMPT in CSV / Perfetto / OTF2, convert the database with ``rocpd convert`` (see below).
+OMPT is a rocpd-only trace: records are written to the rocpd database (``rocpd`` is also the default output format) and are **not** emitted by the direct CSV / JSON / Perfetto / OTF2 generators. If ``--ompt-trace`` is combined with another ``--output-format``, ``rocprofiler-core`` prints a warning and adds ``rocpd`` automatically so OMPT data is not lost. To view OMPT in CSV / Perfetto / OTF2, convert the database with ``rocpd convert`` (see below).
 
 Combined with ``--kernel-trace`` / ``--memory-copy-trace``, each GPU kernel can be correlated with the surrounding ``target_submit`` / ``target_data_op`` region on the host and placed on the same timeline as the enclosing ``parallel`` / ``work`` regions and tasks.
 
@@ -125,13 +125,13 @@ By default ``--ompt-trace`` records every OMPT operation. To cut down on high ev
 .. code-block:: bash
 
     # All OMPT operations (default; same as bare --ompt-trace or --ompt-trace=all)
-    rocprofv3 --ompt-trace -- ./vector_add
+    rocprofiler-core --ompt-trace -- ./vector_add
 
     # Only host parallel regions, tasks, and target offload
-    rocprofv3 --ompt-trace parallel task target -- ./vector_add
+    rocprofiler-core --ompt-trace parallel task target -- ./vector_add
 
     # Only target-offload events, correlated with kernel dispatches
-    rocprofv3 --ompt-trace target --kernel-trace -- ./vector_add
+    rocprofiler-core --ompt-trace target --kernel-trace -- ./vector_add
 
 Recognised categories are ``thread``, ``parallel``, ``task``, ``sync``, ``mutex``, ``target``, ``device``, ``error``, and ``all``. Each resolves to a fixed set of OMPT operations (for example, ``parallel`` covers ``parallel_begin``/``parallel_end``/``implicit_task``/``work``/``dispatch``/``reduction``/``masked``; ``target`` covers ``target_emi``/``target_data_op_emi``/``target_submit_emi``). The CLI rejects unknown categories, and comma-separated tokens, at parse time.
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
@@ -1,25 +1,29 @@
 .. meta::
   :description: ROCprofiler-SDK is a tooling infrastructure for profiling general-purpose GPU compute applications running on the ROCm software
-  :keywords: ROCprofiler-SDK tool usage, rocprofv3 user manual, rocprofv3 usage, rocprofv3 user guide, using rocprofv3, ROCprofiler-SDK tool user guide, ROCprofiler-SDK tool user manual, using ROCprofiler-SDK tool, ROCprofiler-SDK command-line tool, ROCprofiler-SDK CLI, ROCprofiler-SDK command line tool
+  :keywords: ROCprofiler-SDK tool usage, rocprofiler-core user manual, rocprofiler-core usage, rocprofiler-core user guide, using rocprofiler-core, ROCprofiler-SDK tool user guide, ROCprofiler-SDK tool user manual, using ROCprofiler-SDK tool, ROCprofiler-SDK command-line tool, ROCprofiler-SDK CLI, ROCprofiler-SDK command line tool
 
 .. _using-rocprofv3:
 
-==================================================
-Application tracing and profiling using rocprofv3
-==================================================
+========================================================
+Application tracing and profiling using rocprofiler-core
+========================================================
 
-``rocprofv3`` is a CLI tool that helps you optimize applications and analyze the low-level kernel details without requiring any modification in the source code.
+``rocprofiler-core`` is a CLI tool that helps you optimize applications and analyze the low-level kernel details without requiring any modification in the source code.
 It's backward compatible with its predecessor, `rocprof <https://rocm.docs.amd.com/projects/rocprofiler/en/latest/index.html>`_, and provides enhanced features for application profiling with better accuracy.
 
-The following sections demonstrate the use of ``rocprofv3`` for application tracing and kernel counter collection using various command-line options.
+.. note::
 
-``rocprofv3`` is installed with ROCm under ``/opt/rocm/bin``. To use the tool from anywhere in the system, export the ``PATH`` variable:
+   ``rocprofv3`` has been renamed to ``rocprofiler-core``. The ``rocprofv3`` command is retained as a deprecated alias (a symlink to ``rocprofiler-core``) and will be removed in a future ROCm release. Invoking ``rocprofv3`` prints a deprecation warning to stderr. Update your scripts and automation to use ``rocprofiler-core``.
+
+The following sections demonstrate the use of ``rocprofiler-core`` for application tracing and kernel counter collection using various command-line options.
+
+``rocprofiler-core`` is installed with ROCm under ``/opt/rocm/bin``. To use the tool from anywhere in the system, export the ``PATH`` variable:
 
 .. code-block:: bash
 
    export PATH=$PATH:/opt/rocm/bin
 
-Before tracing or profiling your HIP application using ``rocprofv3``, build it using:
+Before tracing or profiling your HIP application using ``rocprofiler-core``, build it using:
 
 .. code-block:: bash
 
@@ -124,11 +128,11 @@ Application tracing
 
 Application tracing provides the big picture of a program’s execution by collecting data on the execution times of API calls and GPU commands, such as kernel execution, async memory copy, and barrier packets. This information can be used as the first step in the profiling process to answer important questions, such as how much percentage of time was spent on memory copy and which kernel took the longest time to execute.
 
-To use ``rocprofv3`` for application tracing, run:
+To use ``rocprofiler-core`` for application tracing, run:
 
 .. code-block:: bash
 
-    rocprofv3 <tracing_option> -- <application_path>
+    rocprofiler-core <tracing_option> -- <application_path>
 
 
 .. note::
@@ -148,7 +152,7 @@ To trace HIP runtime APIs, use:
 
 .. code-block:: bash
 
-    rocprofv3 --hip-trace --output-format csv -- <application_path>
+    rocprofiler-core --hip-trace --output-format csv -- <application_path>
 
 The preceding command generates a ``hip_api_trace.csv`` file prefixed with the process ID.
 
@@ -164,7 +168,7 @@ Here are the contents of ``hip_api_trace.csv`` file:
    :header-rows: 1
 
 
-``rocprofv3`` provides options to collect traces at more granular level. For HIP, you can collect traces for HIP compile-time APIs and runtime APIs separately.
+``rocprofiler-core`` provides options to collect traces at more granular level. For HIP, you can collect traces for HIP compile-time APIs and runtime APIs separately.
 
 HIP compile-time API traces
 ****************************
@@ -173,7 +177,7 @@ To collect HIP compile-time API traces, use:
 
 .. code-block:: shell
 
-    rocprofv3 --hip-compiler-trace --output-format csv -- <application_path>
+    rocprofiler-core --hip-compiler-trace --output-format csv -- <application_path>
 
 The preceding command generates a ``hip_api_trace.csv`` file prefixed with the process ID.
 
@@ -195,7 +199,7 @@ To collect HIP runtime time API traces, use:
 
 .. code-block:: shell
 
-    rocprofv3 --hip-runtime-trace --output-format csv -- <application_path>
+    rocprofiler-core --hip-runtime-trace --output-format csv -- <application_path>
 
 The preceding command generates a ``hip_api_trace.csv`` file prefixed with the process ID.
 
@@ -221,7 +225,7 @@ HSA trace contains the start and end time of HSA runtime API calls and their asy
 
 .. code-block:: bash
 
-    rocprofv3 --hsa-trace --output-format csv -- <application_path>
+    rocprofiler-core --hsa-trace --output-format csv -- <application_path>
 
 The preceding command generates a ``hsa_api_trace.csv`` file prefixed with process ID. Note that the contents of this file have been truncated for demonstration purposes.
 
@@ -237,13 +241,13 @@ Here are the contents of ``hsa_api_trace.csv`` file:
    :header-rows: 1
 
 
-``rocprofv3`` provides options to collect HSA traces at more granular level. HSA traces can be collected separately for four API domains: ``HSA_AMD_EXT_API``, ``HSA_CORE_API``, ``HSA_IMAGE_EXT_API`` and ``HSA_FINALIZE_EXT_API``.
+``rocprofiler-core`` provides options to collect HSA traces at more granular level. HSA traces can be collected separately for four API domains: ``HSA_AMD_EXT_API``, ``HSA_CORE_API``, ``HSA_IMAGE_EXT_API`` and ``HSA_FINALIZE_EXT_API``.
 
 To collect HSA core API traces, use:
 
 .. code-block:: bash
 
-    rocprofv3 --hsa-core-trace --output-format csv -- <application_path>
+    rocprofiler-core --hsa-core-trace --output-format csv -- <application_path>
 
 The preceding command generates a ``hsa_api_trace.csv`` file prefixed with process ID. Note that the contents of this file have been truncated for demonstration purposes.
 
@@ -265,7 +269,7 @@ Marker trace
 
 .. note::
 
-  To use ``rocprofv3`` for marker tracing, including and linking to old ``ROCTx`` works but it's recommended to switch to the new ``ROCTx`` to utilize new APIs.
+  To use ``rocprofiler-core`` for marker tracing, including and linking to old ``ROCTx`` works but it's recommended to switch to the new ``ROCTx`` to utilize new APIs.
   To use the new ``ROCTx``, include header ``"rocprofiler-sdk-roctx/roctx.h"`` and link your application with ``librocprofiler-sdk-roctx.so``.
   To see the complete list of ``ROCTx`` APIs, see public header file ``"rocprofiler-sdk-roctx/roctx.h"``.
 
@@ -275,12 +279,12 @@ Kokkos trace
 ++++++++++++++
 
 `Kokkos <https://github.com/kokkos/kokkos>`_ is a C++ library for writing performance portable applications. Kokkos is widely used in scientific applications to write performance-portable code for CPUs, GPUs, and other accelerators.
-``rocprofv3`` loads an inbuilt `Kokkos Tools library <https://github.com/kokkos/kokkos-tools>`_, which emits roctx ranges with the labels passed using Kokkos APIs. For example, ``Kokkos::parallel_for(“MyParallelForLabel”, …)`` calls ``roctxRangePush`` internally and enables the kernel renaming option to replace the highly templated kernel names with the Kokkos labels.
+``rocprofiler-core`` loads an inbuilt `Kokkos Tools library <https://github.com/kokkos/kokkos-tools>`_, which emits roctx ranges with the labels passed using Kokkos APIs. For example, ``Kokkos::parallel_for(“MyParallelForLabel”, …)`` calls ``roctxRangePush`` internally and enables the kernel renaming option to replace the highly templated kernel names with the Kokkos labels.
 To enable the inbuilt marker support, use the ``kokkos-trace`` option. Internally, this option automatically enables ``marker-trace`` and ``kernel-rename``:
 
 .. code-block:: bash
 
-    rocprofv3 --kokkos-trace --output-format csv -- <application_path>
+    rocprofiler-core --kokkos-trace --output-format csv -- <application_path>
 
 The preceding command generates a ``marker-trace`` file prefixed with the process ID.
 
@@ -300,7 +304,7 @@ To trace kernel dispatch traces, use:
 
 .. code-block:: shell
 
-    rocprofv3 --kernel-trace --output-format csv -- <application_path>
+    rocprofiler-core --kernel-trace --output-format csv -- <application_path>
 
 The preceding command generates a ``kernel_trace.csv`` file prefixed with the process ID.
 
@@ -324,7 +328,7 @@ Memory copy traces track ``hipMemcpy`` and ``hipMemcpyAsync`` functions, which u
 
 .. code-block:: shell
 
-    rocprofv3 –-memory-copy-trace --output-format csv -- <application_path>
+    rocprofiler-core –-memory-copy-trace --output-format csv -- <application_path>
 
 The preceding command generates a ``memory_copy_trace.csv`` file prefixed with the process ID.
 
@@ -362,7 +366,7 @@ To trace memory allocations during the application run, use:
 
 .. code-block:: shell
 
-    rocprofv3 –-memory-allocation-trace --output-format csv -- <application_path>
+    rocprofiler-core –-memory-allocation-trace --output-format csv -- <application_path>
 
 The preceding command generates a ``memory_allocation_trace.csv`` file prefixed with the process ID.
 
@@ -393,7 +397,7 @@ memory operations (copies, allocations, and scratch).
 
 .. code-block:: shell
 
-    rocprofv3 –-runtime-trace --output-format csv -- <application_path>
+    rocprofiler-core –-runtime-trace --output-format csv -- <application_path>
 
 Running the preceding command generates ``hip_api_trace.csv``, ``kernel_trace.csv``, ``memory_copy_trace.csv``, ``scratch_memory_trace.csv``, ``memory_allocation_trace.csv``, and ``marker_api_trace.csv`` (if ``ROCTx`` APIs are specified in the application) files prefixed with the process ID.
 
@@ -404,7 +408,7 @@ This is an all-inclusive option to collect HIP, HSA, kernel, memory copy, memory
 
 .. code-block:: shell
 
-    rocprofv3 –-sys-trace --output-format csv -- <application_path>
+    rocprofiler-core –-sys-trace --output-format csv -- <application_path>
 
 Running the preceding command generates ``hip_api_trace.csv``, ``hsa_api_trace.csv``, ``kernel_trace.csv``, ``memory_copy_trace.csv``, ``scratch_memory_trace.csv``, ``memory_allocation_trace.csv``, and ``marker_api_trace.csv`` if ``ROCTx`` APIs are specified in the application.
 
@@ -417,7 +421,7 @@ To trace scratch memory allocations during the application run, use:
 
 .. code-block:: shell
 
-    rocprofv3 –-scratch-memory-trace --output-format csv -- <application_path>
+    rocprofiler-core –-scratch-memory-trace --output-format csv -- <application_path>
 
 The preceding command generates a ``scratch_memory_trace.csv`` file prefixed with the process ID.
 
@@ -437,12 +441,12 @@ For the description of the fields in the output file, see :ref:`output-file-fiel
 RCCL trace
 ++++++++++++
 
-This section demonstrates how to trace `RCCL` (Rickle) collective communication routines using rocprofv3. `RCCL <https://github.com/ROCm/rccl>`_ (pronounced "Rickle") is a stand-alone library that provides standard collective communication operations for GPUs.
+This section demonstrates how to trace `RCCL` (Rickle) collective communication routines using rocprofiler-core. `RCCL <https://github.com/ROCm/rccl>`_ (pronounced "Rickle") is a stand-alone library that provides standard collective communication operations for GPUs.
 The trace output is captured in a rocpd database file and can be converted to pftrace format for visualization in the Perfetto UI. This approach is useful for analyzing GPU communication performance and identifying bottlenecks in collective operations.
 
 .. code-block:: shell
 
-   rocprofv3 --rccl-trace --sys-trace -- <application_path>
+   rocprofiler-core --rccl-trace --sys-trace -- <application_path>
 
 The preceding command generates a rocpd database file prefixed with the process ID, which can be converted into PFTrace for visualization in the Perfetto UI.
 
@@ -465,7 +469,7 @@ rocDecode trace
 
 .. code-block:: shell
 
-    rocprofv3 --rocdecode-trace --output-format csv -- <application_path>
+    rocprofiler-core --rocdecode-trace --output-format csv -- <application_path>
 
 The above command generates a ``rocdecode_api_trace`` file prefixed with the process ID.
 
@@ -489,7 +493,7 @@ rocJPEG trace
 
 .. code-block:: shell
 
-    rocprofv3 --rocjpeg-trace --output-format csv -- <application_path>
+    rocprofiler-core --rocjpeg-trace --output-format csv -- <application_path>
 
 The above command generates a ``rocjpeg_api_trace`` file prefixed with the process ID.
 
@@ -511,9 +515,9 @@ OMPT trace
 
 .. code-block:: shell
 
-    rocprofv3 --ompt-trace --output-format rocpd -- <application_path>
+    rocprofiler-core --ompt-trace --output-format rocpd -- <application_path>
 
-OMPT is a rocpd-only trace: records are written to the rocpd database (the default output format) and are not emitted by the direct CSV / JSON / Perfetto / OTF2 generators. If ``--ompt-trace`` is used with another ``--output-format``, ``rocprofv3`` warns and adds ``rocpd`` automatically; use ``rocpd convert`` to export OMPT to CSV / Perfetto / OTF2. ``--ompt-trace`` is also enabled implicitly by ``--sys-trace`` and ``--runtime-trace``.
+OMPT is a rocpd-only trace: records are written to the rocpd database (the default output format) and are not emitted by the direct CSV / JSON / Perfetto / OTF2 generators. If ``--ompt-trace`` is used with another ``--output-format``, ``rocprofiler-core`` warns and adds ``rocpd`` automatically; use ``rocpd convert`` to export OMPT to CSV / Perfetto / OTF2. ``--ompt-trace`` is also enabled implicitly by ``--sys-trace`` and ``--runtime-trace``.
 
 .. note::
 
@@ -522,7 +526,7 @@ OMPT is a rocpd-only trace: records are written to the rocpd database (the defau
 Dynamic process attachment
 +++++++++++++++++++++++++++
 
-To profile applications dynamically without requiring to restart the application,``rocprofv3`` provides dynamic process attachment. This is particularly useful for profiling long-running applications, services, or applications in a specific state.
+To profile applications dynamically without requiring to restart the application,``rocprofiler-core`` provides dynamic process attachment. This is particularly useful for profiling long-running applications, services, or applications in a specific state.
 
 Dynamic process attachment uses the ``-p``, ``--pid``, or ``--attach`` options (all equivalent) followed by the target process ID. The profiler instruments the target process and collects the specified tracing or counter data for the configured duration.
 
@@ -531,7 +535,7 @@ For more information, see :ref:`rocprofv3-process-attachment`.
 Post-processing tracing options
 ++++++++++++++++++++++++++++++++
 
-``rocprofv3`` provides options to collect tracing summary or statistics after conclusion of a tracing session. These options are described here.
+``rocprofiler-core`` provides options to collect tracing summary or statistics after conclusion of a tracing session. These options are described here.
 
 Stats
 ######
@@ -541,7 +545,7 @@ The statistics help to determine the API or function that took the most amount o
 
 .. code-block:: shell
 
-    rocprofv3 --stats --hip-trace --output-format csv -- <application_path>
+    rocprofiler-core --stats --hip-trace --output-format csv -- <application_path>
 
 The preceding command generates a ``hip_api_stats.csv``, ``domain_stats.csv`` and ``hip_api_trace.csv`` file prefixed with the process ID.
 
@@ -572,7 +576,7 @@ This option displays a summary of tracing data for the enabled tracing type, aft
 
 .. code-block:: shell
 
-   rocprofv3 -S --hip-trace -- <application_path>
+   rocprofiler-core -S --hip-trace -- <application_path>
 
 .. image:: /data/rocprofv3_summary.png
 
@@ -583,7 +587,7 @@ This option displays a summary of each tracing domain for the enabled tracing ty
 
 .. code-block:: shell
 
-    rocprofv3 -D --hsa-trace --hip-trace --output-format csv  -- <application_path>
+    rocprofiler-core -D --hsa-trace --hip-trace --output-format csv  -- <application_path>
 
 The preceding command generates a ``hip_trace.csv`` and ``hsa_trace.csv`` file prefixed with the process ID along with displaying the summary of each domain.
 
@@ -596,7 +600,7 @@ To see a summary for ``MEMORY_COPY`` domains, use:
 
 .. code-block:: shell
 
-   rocprofv3 --summary-groups MEMORY_COPY --sys-trace  -- <application_path>
+   rocprofiler-core --summary-groups MEMORY_COPY --sys-trace  -- <application_path>
 
 .. image:: /data/rocprofv3_memcpy_summary.png
 
@@ -604,7 +608,7 @@ To see a summary for ``MEMORY_COPY`` and ``HIP_API`` domains, use:
 
 .. code-block:: shell
 
-   rocprofv3 --summary-groups 'MEMORY_COPY|HIP_API' --sys-trace -- <application_path>
+   rocprofiler-core --summary-groups 'MEMORY_COPY|HIP_API' --sys-trace -- <application_path>
 
 .. image:: /data/rocprofv3_hip_memcpy_summary.png
 
@@ -615,7 +619,7 @@ This option specifies the output file for the summary. By default, the summary i
 
 .. code-block:: shell
 
-   rocprofv3 -S -D --summary-output-file filename --sys-trace -- <application_path>
+   rocprofiler-core -S -D --summary-output-file filename --sys-trace -- <application_path>
 
 The preceding command generates an output file named "filename" consisting of the summary for each domain. This also generates the files for the enabled tracing types under ``-sys-trace`` option.
 
@@ -625,13 +629,13 @@ The preceding command generates an output file named "filename" consisting of th
 Configuration output
 +++++++++++++++++++++++
 
-The ``--output-config`` option generates a comprehensive configuration output file that contains all resolved ``rocprofv3`` settings and options used during a profiling session. This feature is essential for debugging, reproducibility, and configuration validation.
+The ``--output-config`` option generates a comprehensive configuration output file that contains all resolved ``rocprofiler-core`` settings and options used during a profiling session. This feature is essential for debugging, reproducibility, and configuration validation.
 
 To generate a configuration output file during profiling, use:
 
 .. code-block:: bash
 
-    rocprofv3 --output-config --hip-trace -- <application_path>
+    rocprofiler-core --output-config --hip-trace -- <application_path>
 
 This command generates a configuration file (typically ``<process_id>_config.json``) alongside the regular profiling output files.
 
@@ -699,7 +703,7 @@ Sample configuration output structure:
       ]
     }
 
-The configuration output file provides complete transparency into ``rocprofv3`` operation, documenting all settings, defaults, and environmental context required for profiling sessions.
+The configuration output file provides complete transparency into ``rocprofiler-core`` operation, documenting all settings, defaults, and environmental context required for profiling sessions.
 
 Collecting traces using input file
 ++++++++++++++++++++++++++++++++++++
@@ -745,9 +749,9 @@ Here is a sample input.json file for collecting tracing summary:
 
 Here is the input schema (properties) of JSON or YAML input files:
 
--  **jobs** *(array)*: ``rocprofv3`` input data per application run.
+-  **jobs** *(array)*: ``rocprofiler-core`` input data per application run.
 
-   -  **Items** *(object)*: Data for ``rocprofv3``
+   -  **Items** *(object)*: Data for ``rocprofiler-core``
 
       -  **hip_trace** *(boolean)*
       -  **hip_runtime_trace** *(boolean)*
@@ -780,7 +784,7 @@ To supply the input file for collecting traces, use:
 
 .. code-block:: shell
 
-   rocprofv3 -i input.yaml -- <application_path>
+   rocprofiler-core -i input.yaml -- <application_path>
 
 Please note that input file format must be a valid YAML or JSON file.
 
@@ -791,7 +795,7 @@ When using aggregate tracing options like ``--runtime-trace`` or ``--sys-trace``
 
 .. code-block:: shell
 
-   rocprofv3 --runtime-trace --scratch-memory-trace=False -- <application_path>
+   rocprofiler-core --runtime-trace --scratch-memory-trace=False -- <application_path>
 
 The preceding command enables all traces included in ``--runtime-trace`` except for scratch memory tracing.
 
@@ -799,7 +803,7 @@ Similarly, for ``--sys-trace``:
 
 .. code-block:: shell
 
-   rocprofv3 --sys-trace --hsa-trace=False -- <application_path>
+   rocprofiler-core --sys-trace --hsa-trace=False -- <application_path>
 
 The preceding command enables all traces included in ``--sys-trace`` except for HSA API tracing.
 
@@ -807,7 +811,7 @@ To disable multiple specific tracing options, use:
 
 .. code-block:: shell
 
-   rocprofv3 --sys-trace --hsa-trace=False --scratch-memory-trace=False -- <application_path>
+   rocprofiler-core --sys-trace --hsa-trace=False --scratch-memory-trace=False -- <application_path>
 
 This feature is particularly useful to collect most traces excluding specific ones that might be unnecessary for your analysis or that generate excessive data.
 
@@ -828,7 +832,7 @@ To see the counters available on the GPU, use:
 
 .. code-block:: shell
 
-   rocprofv3 --list-avail
+   rocprofiler-core --list-avail
 
 Sample output for the list-avail command:
 
@@ -844,7 +848,7 @@ For a comprehensive list of counters available on MI200, see `MI200 performance 
 
    **Counter dimension collection:** When collecting counters with multiple dimensions or instances, such as ``TCC_MISS`` with ``DIMENSION_INSTANCE[0:15]``, individual dimension values can't be collected separately using bracket notation, such as ``TCC_MISS[0]`` or ``TCC_MISS[15]`` in the input files.
 
-   **To collect aggregated values:** Specify the counter name without dimension specifiers, such as ``pmc: TCC_MISS``. The ``rocprofv3`` tool automatically collects accumulated values across all instances.
+   **To collect aggregated values:** Specify the counter name without dimension specifiers, such as ``pmc: TCC_MISS``. The ``rocprofiler-core`` tool automatically collects accumulated values across all instances.
 
    **To collect values per instance:** Use JSON output format, which includes detailed dimension information for individual counter instances.
 
@@ -868,9 +872,9 @@ While the input file in text format can only be used for counter collection, JSO
 
 Here is the input schema (properties) of JSON or YAML input files:
 
--  **jobs** *(array)*: ``rocprofv3`` input data per application run
+-  **jobs** *(array)*: ``rocprofiler-core`` input data per application run
 
-   -  **Items** *(object)*: Data for ``rocprofv3``
+   -  **Items** *(object)*: Data for ``rocprofiler-core``
 
       -  **pmc** *(array)*: list of counters for collection
       -  **kernel_include_regex** *(string)*
@@ -939,7 +943,7 @@ To supply the input file for kernel counter collection, use:
 
 .. code-block:: bash
 
-   rocprofv3 -i input.yaml -- <application_path>
+   rocprofiler-core -i input.yaml -- <application_path>
 
 Counter collection using command line
 ++++++++++++++++++++++++++++++++++++++
@@ -950,7 +954,7 @@ To supply the counters in the command line, use:
 
 .. code-block:: shell
 
-   rocprofv3 --pmc SQ_WAVES GRBM_COUNT GRBM_GUI_ACTIVE -- <application_path>
+   rocprofiler-core --pmc SQ_WAVES GRBM_COUNT GRBM_GUI_ACTIVE -- <application_path>
 
 .. note::
 
@@ -968,7 +972,7 @@ You can specify multiple ``--pmc`` flags to define different counter groups. Eac
 
 .. code-block:: shell
 
-   rocprofv3 --pmc SQ_WAVES SQ_WAVE_CYCLES --pmc GRBM_COUNT GRBM_GUI_ACTIVE -- <application_path>
+   rocprofiler-core --pmc SQ_WAVES SQ_WAVE_CYCLES --pmc GRBM_COUNT GRBM_GUI_ACTIVE -- <application_path>
 
 The preceding command creates two profiling passes:
 
@@ -982,7 +986,7 @@ You can combine ``--pmc`` flag with an input file. The counters specified in CLI
 
 .. code-block:: shell
 
-   rocprofv3 -i input.txt --pmc GRBM_COUNT --pmc SQ_WAVES -- <application_path>
+   rocprofiler-core -i input.txt --pmc GRBM_COUNT --pmc SQ_WAVES -- <application_path>
 
 If ``input.txt`` contains:
 
@@ -1078,14 +1082,14 @@ in the ``extra_counters.yaml`` file, use the ``-E`` / ``--extra-counters`` optio
 
 .. code-block:: shell
 
-   rocprofv3 -E <path-to-extra_counters.yaml> --pmc GRBM_GUI_ACTIVE_SUM --output-format csv -- <application_path>
+   rocprofiler-core -E <path-to-extra_counters.yaml> --pmc GRBM_GUI_ACTIVE_SUM --output-format csv -- <application_path>
 
 Where the option ``--pmc`` is used to specify the extra counters to be collected.
 
 Kernel counter collection output
 +++++++++++++++++++++++++++++++++
 
-Using ``rocprofv3`` for counter collection using input file or command line generates a ``./pmc_n/counter_collection.csv`` file prefixed with the process ID. For each ``pmc`` row, a directory ``pmc_n`` containing a ``counter_collection.csv`` file is generated, where n = 1 for the first row and so on.
+Using ``rocprofiler-core`` for counter collection using input file or command line generates a ``./pmc_n/counter_collection.csv`` file prefixed with the process ID. For each ``pmc`` row, a directory ``pmc_n`` containing a ``counter_collection.csv`` file is generated, where n = 1 for the first row and so on.
 
 When using input file in JSON or YAML format, for each job, a directory ``pass_n`` containing a ``counter_collection.csv`` file is generated, where n = 1 for the first job and so on.
 
@@ -1159,7 +1163,7 @@ To generate a Perfetto trace file, use the ``--output-format pftrace`` option al
 
 .. code-block:: bash
 
-  rocprofv3 --sys-trace --output-format pftrace -- <application_path>
+  rocprofiler-core --sys-trace --output-format pftrace -- <application_path>
 
 The generated Perfetto trace file can be opened in the `Perfetto UI <https://ui.perfetto.dev/>`_.
 
@@ -1184,7 +1188,7 @@ To generate a Perfetto trace file with counter data, use:
 
 .. code-block:: shell
 
-    rocprofv3 --pmc SQ_WAVES GRBM_COUNT --output-format pftrace -- <application_path>
+    rocprofiler-core --pmc SQ_WAVES GRBM_COUNT --output-format pftrace -- <application_path>
 
 The generated Perfetto trace file can be opened in the `Perfetto UI <https://ui.perfetto.dev/>`_. In the viewer, performance counters will appear as counter tracks organized by agent, allowing you to visualize counter values changing over time alongside kernel executions and other traced activities.
 
@@ -1192,7 +1196,7 @@ You can also combine this with the system trace option to get a more comprehensi
 
 .. code-block:: bash
 
-  rocprofv3 --pmc SQ_WAVES GRBM_COUNT --sys-trace --output-format pftrace -- <application_path>
+  rocprofiler-core --pmc SQ_WAVES GRBM_COUNT --sys-trace --output-format pftrace -- <application_path>
 
 .. image:: /data/perfetto_counters.png
    :width: 100%
@@ -1207,7 +1211,7 @@ To generate a Perfetto trace file that includes scratch memory visualization:
 
 .. code-block:: bash
 
-  rocprofv3 --scratch-memory-trace --output-format pftrace -- <application_path>
+  rocprofiler-core --scratch-memory-trace --output-format pftrace -- <application_path>
 
 In the Perfetto UI, scratch memory appears as counter tracks that show:
 
@@ -1225,7 +1229,7 @@ For comprehensive GPU execution insights, combine scratch memory tracing with ke
 
 .. code-block:: bash
 
-  rocprofv3 --kernel-trace --scratch-memory-trace --output-format pftrace -- <application_path>
+  rocprofiler-core --kernel-trace --scratch-memory-trace --output-format pftrace -- <application_path>
 
 This allows you to correlate scratch memory allocation patterns with specific kernel executions in the Perfetto visualization.
 
@@ -1387,7 +1391,7 @@ To specify the particular output format, use the ``--output-format`` option foll
 
 .. code-block::
 
-   rocprofv3 -i input.txt --output-format json -- <application_path>
+   rocprofiler-core -i input.txt --output-format json -- <application_path>
 
 Format selection is case-insensitive and multiple output formats are supported. While ``--output-format json`` exclusively enables JSON output, ``--output-format csv json pftrace otf2, rocpd`` enables all four output formats for the run.
 
@@ -1401,7 +1405,7 @@ For OTF2 trace visualization, open the trace in `vampir.eu <https://vampir.eu/>`
 JSON output schema
 ++++++++++++++++++++
 
-``rocprofv3`` supports a custom JSON output format designed for programmatic analysis and **NOT** for visualization.
+``rocprofiler-core`` supports a custom JSON output format designed for programmatic analysis and **NOT** for visualization.
 The schema is optimized for size while factoring in usability.
 
 .. note::
@@ -1415,8 +1419,8 @@ Properties
 
 Here are the properties of the JSON output schema:
 
-- **rocprofiler-sdk-tool** `(array)`: rocprofv3 data per process (each element represents a process).
-   - **Items** `(object)`: Data for rocprofv3.
+- **rocprofiler-sdk-tool** `(array)`: rocprofiler-core data per process (each element represents a process).
+   - **Items** `(object)`: Data for rocprofiler-core.
       - **metadata** `(object, required)`: Metadata related to the profiler session.
          - **pid** `(integer, required)`: Process ID.
          - **init_time** `(integer, required)`: Initialization time in nanoseconds.

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
@@ -328,7 +328,7 @@ Memory copy traces track ``hipMemcpy`` and ``hipMemcpyAsync`` functions, which u
 
 .. code-block:: shell
 
-    rocprofiler-core –-memory-copy-trace --output-format csv -- <application_path>
+    rocprofiler-core --memory-copy-trace --output-format csv -- <application_path>
 
 The preceding command generates a ``memory_copy_trace.csv`` file prefixed with the process ID.
 
@@ -366,7 +366,7 @@ To trace memory allocations during the application run, use:
 
 .. code-block:: shell
 
-    rocprofiler-core –-memory-allocation-trace --output-format csv -- <application_path>
+    rocprofiler-core --memory-allocation-trace --output-format csv -- <application_path>
 
 The preceding command generates a ``memory_allocation_trace.csv`` file prefixed with the process ID.
 
@@ -397,7 +397,7 @@ memory operations (copies, allocations, and scratch).
 
 .. code-block:: shell
 
-    rocprofiler-core –-runtime-trace --output-format csv -- <application_path>
+    rocprofiler-core --runtime-trace --output-format csv -- <application_path>
 
 Running the preceding command generates ``hip_api_trace.csv``, ``kernel_trace.csv``, ``memory_copy_trace.csv``, ``scratch_memory_trace.csv``, ``memory_allocation_trace.csv``, and ``marker_api_trace.csv`` (if ``ROCTx`` APIs are specified in the application) files prefixed with the process ID.
 
@@ -408,7 +408,7 @@ This is an all-inclusive option to collect HIP, HSA, kernel, memory copy, memory
 
 .. code-block:: shell
 
-    rocprofiler-core –-sys-trace --output-format csv -- <application_path>
+    rocprofiler-core --sys-trace --output-format csv -- <application_path>
 
 Running the preceding command generates ``hip_api_trace.csv``, ``hsa_api_trace.csv``, ``kernel_trace.csv``, ``memory_copy_trace.csv``, ``scratch_memory_trace.csv``, ``memory_allocation_trace.csv``, and ``marker_api_trace.csv`` if ``ROCTx`` APIs are specified in the application.
 
@@ -421,7 +421,7 @@ To trace scratch memory allocations during the application run, use:
 
 .. code-block:: shell
 
-    rocprofiler-core –-scratch-memory-trace --output-format csv -- <application_path>
+    rocprofiler-core --scratch-memory-trace --output-format csv -- <application_path>
 
 The preceding command generates a ``scratch_memory_trace.csv`` file prefixed with the process ID.
 

--- a/projects/rocprofiler-sdk/source/docs/quick-reference/rocprofv3-cli-options.rst
+++ b/projects/rocprofiler-sdk/source/docs/quick-reference/rocprofv3-cli-options.rst
@@ -4,9 +4,9 @@
 
 .. _cli-options:
 
-==============================
-roprofv3 command-line options
-==============================
+=====================================
+rocprofiler-core command-line options
+=====================================
 
 The following table lists the commonly used ``rocprofiler-core`` command-line options categorized according to their purpose.
 
@@ -29,7 +29,7 @@ The following table lists the commonly used ``rocprofiler-core`` command-line op
                 <tr>
                     <th rowspan="7">I/O options</th>
                     <td>-i INPUT | --input INPUT</td>
-                    <td>Specifies the path to the input file. JSON and YAML formats support configuration of all command-line options for tracing and profiling whereas the text format supports only the specification of HW counters. See <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#collecting-traces-using-input-file">collecting traces using input file</a> and <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#counter-collection-using-input-file">counter collection using input file.</a></td>
+                    <td>Specifies the path to the input file. JSON and YAML formats support configuration of all command-line options for tracing and profiling whereas the text format supports only the specification of HW counters. See <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#collecting-traces-using-input-file">collecting traces using input file</a> and <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#counter-collection-using-input-file">counter collection using input file.</a></td>
                 </tr>
                 <tr>
                     <td>-o OUTPUT_FILE | --output-file OUTPUT_FILE</td>
@@ -41,11 +41,11 @@ The following table lists the commonly used ``rocprofiler-core`` command-line op
                 </tr>
                 <tr>
                     <td>-f {csv,json,pftrace,otf2,rocpd} [{csv,json,pftrace,otf2,rocpd} ...] | --output-format {csv,json,pftrace,otf2,rocpd} [{csv,json,pftrace,otf2,rocpd} ...]</td>
-                    <td>Specifies output format. Supported formats: CSV, JSON, PFTrace, OTF2 and rocpd. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#output-formats">Read more...</a></td>
+                    <td>Specifies output format. Supported formats: CSV, JSON, PFTrace, OTF2 and rocpd. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#output-formats">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--output-config [BOOL]</td>
-                    <td>Generates a configuration output file containing the resolved rocprofiler-core settings and options used for the profiling session. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#configuration-output">Read more...</a></td>
+                    <td>Generates a configuration output file containing the resolved rocprofiler-core settings and options used for the profiling session. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#configuration-output">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--log-level {fatal,error,warning,info,trace,env}</td>
@@ -53,7 +53,7 @@ The following table lists the commonly used ``rocprofiler-core`` command-line op
                 </tr>
                 <tr>
                     <td>-E EXTRA_COUNTERS | --extra-counters EXTRA_COUNTERS</td>
-                    <td>Specifies the path to a YAML file consisting of extra counter definitions. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#extra-counters">Read more...</a></td>
+                    <td>Specifies the path to a YAML file consisting of extra counter definitions. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#extra-counters">Read more...</a></td>
                 </tr>
                 <tr>
                     <th>Dynamic process attachment</th>
@@ -63,11 +63,11 @@ The following table lists the commonly used ``rocprofiler-core`` command-line op
                 <tr>
                     <th rowspan="2">Aggregate tracing</th>
                     <td>-r [BOOL] | --runtime-trace [BOOL]</td>
-                    <td>Collects tracing data for HIP runtime API, marker (ROCTx) API, RCCL API, memory operations (copies, scratch, and allocation), and kernel dispatches. Similar to --sys-trace without HIP compiler API and the underlying HSA API tracing. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#runtime-trace">Read more...</a></td>
+                    <td>Collects tracing data for HIP runtime API, marker (ROCTx) API, RCCL API, memory operations (copies, scratch, and allocation), and kernel dispatches. Similar to --sys-trace without HIP compiler API and the underlying HSA API tracing. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#runtime-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>-s [BOOL] | --sys-trace [BOOL]</td>
-                    <td>Collects tracing data for HIP API, HSA API, marker (ROCTx) API, RCCL API, memory operations (copies, scratch, and allocations), and kernel dispatches. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#system-trace">Read more...</a></td>
+                    <td>Collects tracing data for HIP API, HSA API, marker (ROCTx) API, RCCL API, memory operations (copies, scratch, and allocations), and kernel dispatches. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#system-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <th rowspan="4">PC sampling</th>
@@ -89,7 +89,7 @@ The following table lists the commonly used ``rocprofiler-core`` command-line op
                 <tr>
                     <th rowspan="12">Basic tracing</th>
                     <td>--hip-trace [BOOL]</td>
-                    <td>Combination of --hip-runtime-trace and --hip-compiler-trace. This option enables only the HIP API tracing. Unlike previous iterations of rocprofiler-core, this option doesn’t enable kernel tracing, memory copy tracing, and so on. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#hip-trace">Read more...</a></td>
+                    <td>Combination of --hip-runtime-trace and --hip-compiler-trace. This option enables only the HIP API tracing. Unlike previous iterations of rocprofiler-core, this option doesn’t enable kernel tracing, memory copy tracing, and so on. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#hip-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--marker-trace [BOOL]</td>
@@ -97,14 +97,14 @@ The following table lists the commonly used ``rocprofiler-core`` command-line op
                 </tr>
                 <tr>
                     <td>--kernel-trace [BOOL]</td>
-                    <td>Collects kernel dispatch traces. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#kernel-trace">Read more...</a></td>
+                    <td>Collects kernel dispatch traces. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#kernel-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--memory-copy-trace [BOOL]</td>
-                    <td>Collects memory copy traces. This was a part of the HIP and HSA traces in previous rocprof versions. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#memory-copy-trace">Read more...</a></td>
+                    <td>Collects memory copy traces. This was a part of the HIP and HSA traces in previous rocprof versions. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#memory-copy-trace">Read more...</a></td>
                 <tr>
                     <td>--memory-allocation-trace [BOOL]</td>
-                    <td>Collects memory allocation traces. Displays starting address, allocation size, and the agent where allocation occurs. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#memory-allocation-trace">Read more...</a></td>
+                    <td>Collects memory allocation traces. Displays starting address, allocation size, and the agent where allocation occurs. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#memory-allocation-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--kfd-trace</td>
@@ -112,27 +112,27 @@ The following table lists the commonly used ``rocprofiler-core`` command-line op
                 </tr>
                 <tr>
                     <td>--scratch-memory-trace [BOOL]</td>
-                    <td>Collects scratch memory operations traces. Helps in determining scratch allocations and manage them efficiently. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#scratch-memory-trace">Read more...</a></td>
+                    <td>Collects scratch memory operations traces. Helps in determining scratch allocations and manage them efficiently. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#scratch-memory-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--hsa-trace [BOOL]</td>
-                    <td>Collects --hsa-core-trace, --hsa-amd-trace, --hsa-image-trace, and --hsa-finalizer-trace. This option only enables the HSA API tracing. Unlike previous iterations of rocprof, this doesn’t enable kernel tracing, memory copy tracing, and so on. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#hsa-trace">Read more...</a></td>
+                    <td>Collects --hsa-core-trace, --hsa-amd-trace, --hsa-image-trace, and --hsa-finalizer-trace. This option only enables the HSA API tracing. Unlike previous iterations of rocprof, this doesn’t enable kernel tracing, memory copy tracing, and so on. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#hsa-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--rccl-trace [BOOL]</td>
-                    <td>Collects traces for RCCL (ROCm Communication Collectives Library), which is also pronounced as ‘Rickle’. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#rccl-trace">Read more...</a></td>
+                    <td>Collects traces for RCCL (ROCm Communication Collectives Library), which is also pronounced as ‘Rickle’. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#rccl-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--kokkos-trace [BOOL]</td>
-                    <td>Enables builtin Kokkos tools support, which implies enabling --marker-trace collection and --kernel-rename. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#kokkos-trace">Read more...</a></td>
+                    <td>Enables builtin Kokkos tools support, which implies enabling --marker-trace collection and --kernel-rename. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#kokkos-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--rocdecode-trace [BOOL]</td>
-                    <td>Collects traces for rocDecode APIs. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#rocdecode-trace">Read more...</a></td>
+                    <td>Collects traces for rocDecode APIs. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#rocdecode-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--ompt-trace [CATEGORY ...]</td>
-                    <td>Collects OMPT (OpenMP Tools) traces from applications linked against an OMPT-capable OpenMP runtime (e.g. LLVM-based <code>libomp</code> from AOMP / ROCm). Captures host parallel regions, tasks, sync, mutex, and target-offload events. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#ompt-trace">Read more...</a></td>
+                    <td>Collects OMPT (OpenMP Tools) traces from applications linked against an OMPT-capable OpenMP runtime (e.g. LLVM-based <code>libomp</code> from AOMP / ROCm). Captures host parallel regions, tasks, sync, mutex, and target-offload events. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#ompt-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <th rowspan="10">Granular tracing</th>
@@ -145,19 +145,19 @@ The following table lists the commonly used ``rocprofiler-core`` command-line op
                 </tr>
                 <tr>
                     <td>--hsa-core-trace [BOOL]</td>
-                    <td>Collects HSA API traces (core API). For example, HSA functions prefixed with only hsa_ such as hsa_init. For more details, see <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#hsa-trace">HSA trace</a></td>
+                    <td>Collects HSA API traces (core API). For example, HSA functions prefixed with only hsa_ such as hsa_init. For more details, see <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#hsa-trace">HSA trace</a></td>
                 </tr>
                 <tr>
                     <td>--hsa-amd-trace [BOOL]</td>
-                    <td>Collects HSA API traces (AMD-extension API). For example, HSA functions prefixed with hsa_amd_ such as hsa_amd_coherency_get_type. For more details, see <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#hsa-trace">HSA trace</a></td>
+                    <td>Collects HSA API traces (AMD-extension API). For example, HSA functions prefixed with hsa_amd_ such as hsa_amd_coherency_get_type. For more details, see <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#hsa-trace">HSA trace</a></td>
                 </tr>
                 <tr>
                     <td>--hsa-image-trace [BOOL]</td>
-                    <td>Collects HSA API traces (image-extenson API). For example, HSA functions prefixed with only hsa_ext_image_ such as hsa_ext_image_get_capability. For more details, see <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#hsa-trace">HSA trace</a></td>
+                    <td>Collects HSA API traces (image-extenson API). For example, HSA functions prefixed with only hsa_ext_image_ such as hsa_ext_image_get_capability. For more details, see <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#hsa-trace">HSA trace</a></td>
                 </tr>
                 <tr>
                     <td>--hsa-finalizer-trace [BOOL]</td>
-                    <td>Collects HSA API traces (Finalizer-extension API). For example, HSA functions prefixed with only hsa_ext_program_ such as hsa_ext_program_create. For more details, see <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#hsa-trace">HSA trace</a></td>
+                    <td>Collects HSA API traces (Finalizer-extension API). For example, HSA functions prefixed with only hsa_ext_program_ such as hsa_ext_program_create. For more details, see <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#hsa-trace">HSA trace</a></td>
                 </tr>
                 <tr>
                     <td>--kfd-page-migration-trace</td>
@@ -178,29 +178,29 @@ The following table lists the commonly used ``rocprofiler-core`` command-line op
                 <tr>
                     <th>Counter collection</th>
                     <td>--pmc [PMC …]</td>
-                    <td>Specifies performance monitoring counters to be collected. Use comma or space to specify more than one counter. For multi-pass collection, use multiple --pmc flags where each flag defines a separate counter group. The job fails if a counter group can't be collected in a single pass. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#counter-collection-using-command-line">Read more...</a></td>
+                    <td>Specifies performance monitoring counters to be collected. Use comma or space to specify more than one counter. For multi-pass collection, use multiple --pmc flags where each flag defines a separate counter group. The job fails if a counter group can't be collected in a single pass. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#counter-collection-using-command-line">Read more...</a></td>
                 </tr>
                 <tr>
                     <th rowspan="4">Post-processing tracing</th>
                     <td>--stats [BOOL]</td>
-                    <td>Collects statistics of enabled tracing types. Must be combined with one or more tracing options. Doesn’t include default kernel stats unlike previous rocprof versions. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#stats">Read more...</a></td>
+                    <td>Collects statistics of enabled tracing types. Must be combined with one or more tracing options. Doesn’t include default kernel stats unlike previous rocprof versions. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#stats">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>-S [BOOL] | --summary [BOOL]</td>
-                    <td>Displays single summary of tracing data for the enabled tracing type, after conclusion of the profiling session. Displays a summary of tracing data for the enabled tracing type, after conclusion of the profiling session. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#summary">Read more...</a></td>
+                    <td>Displays single summary of tracing data for the enabled tracing type, after conclusion of the profiling session. Displays a summary of tracing data for the enabled tracing type, after conclusion of the profiling session. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#summary">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>-D [BOOL] | --summary-per-domain [BOOL]</td>
-                    <td>Displays a summary of each tracing domain for the enabled tracing type, after conclusion of the profiling session. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#summary-per-domain">Read more...</a></td>
+                    <td>Displays a summary of each tracing domain for the enabled tracing type, after conclusion of the profiling session. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#summary-per-domain">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--summary-groups REGULAR_EXPRESSION [REGULAR_EXPRESSION …]</td>
-                    <td>Displays a summary for each set of domains matching the specified regular expression. For example, ‘KERNEL_DISPATCH|MEMORY_COPY’ generates a summary of all the tracing data in the KERNEL_DISPATCH and MEMORY_COPY domains. Similarly ‘*._API’ generates a summary of all the tracing data in the HIP_API, HSA_API, and MARKER_API domains. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#summary-groups">Read more...</a></td>
+                    <td>Displays a summary for each set of domains matching the specified regular expression. For example, ‘KERNEL_DISPATCH|MEMORY_COPY’ generates a summary of all the tracing data in the KERNEL_DISPATCH and MEMORY_COPY domains. Similarly ‘*._API’ generates a summary of all the tracing data in the HIP_API, HSA_API, and MARKER_API domains. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#summary-groups">Read more...</a></td>
                 </tr>
                 <tr>
                     <th rowspan="2">Summary</th>
                     <td>--summary-output-file SUMMARY_OUTPUT_FILE</td>
-                    <td>Outputs summary to a file, stdout, or stderr. By default, outputs to stderr. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#summary-output-file">Read more...</a></td>
+                    <td>Outputs summary to a file, stdout, or stderr. By default, outputs to stderr. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#summary-output-file">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>-u {sec,msec,usec,nsec} | --summary-units {sec,msec,usec,nsec}</td>
@@ -263,7 +263,7 @@ The following table lists the commonly used ``rocprofiler-core`` command-line op
                 <tr>
                     <th rowspan="2">Display</th>
                     <td>-L [BOOL] | --list-avail [BOOL]</td>
-                    <td>Lists the PC sampling configurations and metrics available in the counter_defs.yaml file for counter collection. In earlier rocprof versions, this was known as --list-basic, --list-derived, and --list-counters. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#kernel-counter-collection">Read more...</a></td>
+                    <td>Lists the PC sampling configurations and metrics available in the counter_defs.yaml file for counter collection. In earlier rocprof versions, this was known as --list-basic, --list-derived, and --list-counters. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#kernel-counter-collection">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--group-by-queue [BOOL]</td>

--- a/projects/rocprofiler-sdk/source/docs/quick-reference/rocprofv3-cli-options.rst
+++ b/projects/rocprofiler-sdk/source/docs/quick-reference/rocprofv3-cli-options.rst
@@ -1,6 +1,6 @@
 .. meta::
   :description: ROCprofiler-SDK is a tooling infrastructure for profiling general-purpose GPU compute applications running on the ROCm software
-  :keywords: ROCprofiler-SDK tool usage, rocprofv3 user manual, rocprofv3 usage, rocprofv3 user guide, using rocprofv3, ROCprofiler-SDK tool user guide, ROCprofiler-SDK tool user manual, using ROCprofiler-SDK tool, ROCprofiler-SDK command-line tool, ROCprofiler-SDK CLI, ROCprofiler-SDK command line tool
+  :keywords: ROCprofiler-SDK tool usage, rocprofiler-core user manual, rocprofiler-core usage, rocprofiler-core user guide, using rocprofiler-core, ROCprofiler-SDK tool user guide, ROCprofiler-SDK tool user manual, using ROCprofiler-SDK tool, ROCprofiler-SDK command-line tool, ROCprofiler-SDK CLI, ROCprofiler-SDK command line tool
 
 .. _cli-options:
 
@@ -8,7 +8,7 @@
 roprofv3 command-line options
 ==============================
 
-The following table lists the commonly used ``rocprofv3`` command-line options categorized according to their purpose.
+The following table lists the commonly used ``rocprofiler-core`` command-line options categorized according to their purpose.
 
 .. raw:: html
 
@@ -29,7 +29,7 @@ The following table lists the commonly used ``rocprofv3`` command-line options c
                 <tr>
                     <th rowspan="7">I/O options</th>
                     <td>-i INPUT | --input INPUT</td>
-                    <td>Specifies the path to the input file. JSON and YAML formats support configuration of all command-line options for tracing and profiling whereas the text format supports only the specification of HW counters. See <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#collecting-traces-using-input-file">collecting traces using input file</a> and <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#counter-collection-using-input-file">counter collection using input file.</a></td>
+                    <td>Specifies the path to the input file. JSON and YAML formats support configuration of all command-line options for tracing and profiling whereas the text format supports only the specification of HW counters. See <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#collecting-traces-using-input-file">collecting traces using input file</a> and <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#counter-collection-using-input-file">counter collection using input file.</a></td>
                 </tr>
                 <tr>
                     <td>-o OUTPUT_FILE | --output-file OUTPUT_FILE</td>
@@ -41,11 +41,11 @@ The following table lists the commonly used ``rocprofv3`` command-line options c
                 </tr>
                 <tr>
                     <td>-f {csv,json,pftrace,otf2,rocpd} [{csv,json,pftrace,otf2,rocpd} ...] | --output-format {csv,json,pftrace,otf2,rocpd} [{csv,json,pftrace,otf2,rocpd} ...]</td>
-                    <td>Specifies output format. Supported formats: CSV, JSON, PFTrace, OTF2 and rocpd. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#output-formats">Read more...</a></td>
+                    <td>Specifies output format. Supported formats: CSV, JSON, PFTrace, OTF2 and rocpd. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#output-formats">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--output-config [BOOL]</td>
-                    <td>Generates a configuration output file containing the resolved rocprofv3 settings and options used for the profiling session. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#configuration-output">Read more...</a></td>
+                    <td>Generates a configuration output file containing the resolved rocprofiler-core settings and options used for the profiling session. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#configuration-output">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--log-level {fatal,error,warning,info,trace,env}</td>
@@ -53,7 +53,7 @@ The following table lists the commonly used ``rocprofv3`` command-line options c
                 </tr>
                 <tr>
                     <td>-E EXTRA_COUNTERS | --extra-counters EXTRA_COUNTERS</td>
-                    <td>Specifies the path to a YAML file consisting of extra counter definitions. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#extra-counters">Read more...</a></td>
+                    <td>Specifies the path to a YAML file consisting of extra counter definitions. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#extra-counters">Read more...</a></td>
                 </tr>
                 <tr>
                     <th>Dynamic process attachment</th>
@@ -63,11 +63,11 @@ The following table lists the commonly used ``rocprofv3`` command-line options c
                 <tr>
                     <th rowspan="2">Aggregate tracing</th>
                     <td>-r [BOOL] | --runtime-trace [BOOL]</td>
-                    <td>Collects tracing data for HIP runtime API, marker (ROCTx) API, RCCL API, memory operations (copies, scratch, and allocation), and kernel dispatches. Similar to --sys-trace without HIP compiler API and the underlying HSA API tracing. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#runtime-trace">Read more...</a></td>
+                    <td>Collects tracing data for HIP runtime API, marker (ROCTx) API, RCCL API, memory operations (copies, scratch, and allocation), and kernel dispatches. Similar to --sys-trace without HIP compiler API and the underlying HSA API tracing. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#runtime-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>-s [BOOL] | --sys-trace [BOOL]</td>
-                    <td>Collects tracing data for HIP API, HSA API, marker (ROCTx) API, RCCL API, memory operations (copies, scratch, and allocations), and kernel dispatches. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#system-trace">Read more...</a></td>
+                    <td>Collects tracing data for HIP API, HSA API, marker (ROCTx) API, RCCL API, memory operations (copies, scratch, and allocations), and kernel dispatches. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#system-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <th rowspan="4">PC sampling</th>
@@ -89,7 +89,7 @@ The following table lists the commonly used ``rocprofv3`` command-line options c
                 <tr>
                     <th rowspan="12">Basic tracing</th>
                     <td>--hip-trace [BOOL]</td>
-                    <td>Combination of --hip-runtime-trace and --hip-compiler-trace. This option enables only the HIP API tracing. Unlike previous iterations of rocprofv3, this option doesn’t enable kernel tracing, memory copy tracing, and so on. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#hip-trace">Read more...</a></td>
+                    <td>Combination of --hip-runtime-trace and --hip-compiler-trace. This option enables only the HIP API tracing. Unlike previous iterations of rocprofiler-core, this option doesn’t enable kernel tracing, memory copy tracing, and so on. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#hip-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--marker-trace [BOOL]</td>
@@ -97,14 +97,14 @@ The following table lists the commonly used ``rocprofv3`` command-line options c
                 </tr>
                 <tr>
                     <td>--kernel-trace [BOOL]</td>
-                    <td>Collects kernel dispatch traces. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#kernel-trace">Read more...</a></td>
+                    <td>Collects kernel dispatch traces. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#kernel-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--memory-copy-trace [BOOL]</td>
-                    <td>Collects memory copy traces. This was a part of the HIP and HSA traces in previous rocprof versions. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#memory-copy-trace">Read more...</a></td>
+                    <td>Collects memory copy traces. This was a part of the HIP and HSA traces in previous rocprof versions. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#memory-copy-trace">Read more...</a></td>
                 <tr>
                     <td>--memory-allocation-trace [BOOL]</td>
-                    <td>Collects memory allocation traces. Displays starting address, allocation size, and the agent where allocation occurs. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#memory-allocation-trace">Read more...</a></td>
+                    <td>Collects memory allocation traces. Displays starting address, allocation size, and the agent where allocation occurs. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#memory-allocation-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--kfd-trace</td>
@@ -112,27 +112,27 @@ The following table lists the commonly used ``rocprofv3`` command-line options c
                 </tr>
                 <tr>
                     <td>--scratch-memory-trace [BOOL]</td>
-                    <td>Collects scratch memory operations traces. Helps in determining scratch allocations and manage them efficiently. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#scratch-memory-trace">Read more...</a></td>
+                    <td>Collects scratch memory operations traces. Helps in determining scratch allocations and manage them efficiently. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#scratch-memory-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--hsa-trace [BOOL]</td>
-                    <td>Collects --hsa-core-trace, --hsa-amd-trace, --hsa-image-trace, and --hsa-finalizer-trace. This option only enables the HSA API tracing. Unlike previous iterations of rocprof, this doesn’t enable kernel tracing, memory copy tracing, and so on. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#hsa-trace">Read more...</a></td>
+                    <td>Collects --hsa-core-trace, --hsa-amd-trace, --hsa-image-trace, and --hsa-finalizer-trace. This option only enables the HSA API tracing. Unlike previous iterations of rocprof, this doesn’t enable kernel tracing, memory copy tracing, and so on. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#hsa-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--rccl-trace [BOOL]</td>
-                    <td>Collects traces for RCCL (ROCm Communication Collectives Library), which is also pronounced as ‘Rickle’. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#rccl-trace">Read more...</a></td>
+                    <td>Collects traces for RCCL (ROCm Communication Collectives Library), which is also pronounced as ‘Rickle’. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#rccl-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--kokkos-trace [BOOL]</td>
-                    <td>Enables builtin Kokkos tools support, which implies enabling --marker-trace collection and --kernel-rename. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#kokkos-trace">Read more...</a></td>
+                    <td>Enables builtin Kokkos tools support, which implies enabling --marker-trace collection and --kernel-rename. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#kokkos-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--rocdecode-trace [BOOL]</td>
-                    <td>Collects traces for rocDecode APIs. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#rocdecode-trace">Read more...</a></td>
+                    <td>Collects traces for rocDecode APIs. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#rocdecode-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--ompt-trace [CATEGORY ...]</td>
-                    <td>Collects OMPT (OpenMP Tools) traces from applications linked against an OMPT-capable OpenMP runtime (e.g. LLVM-based <code>libomp</code> from AOMP / ROCm). Captures host parallel regions, tasks, sync, mutex, and target-offload events. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#ompt-trace">Read more...</a></td>
+                    <td>Collects OMPT (OpenMP Tools) traces from applications linked against an OMPT-capable OpenMP runtime (e.g. LLVM-based <code>libomp</code> from AOMP / ROCm). Captures host parallel regions, tasks, sync, mutex, and target-offload events. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#ompt-trace">Read more...</a></td>
                 </tr>
                 <tr>
                     <th rowspan="10">Granular tracing</th>
@@ -145,19 +145,19 @@ The following table lists the commonly used ``rocprofv3`` command-line options c
                 </tr>
                 <tr>
                     <td>--hsa-core-trace [BOOL]</td>
-                    <td>Collects HSA API traces (core API). For example, HSA functions prefixed with only hsa_ such as hsa_init. For more details, see <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#hsa-trace">HSA trace</a></td>
+                    <td>Collects HSA API traces (core API). For example, HSA functions prefixed with only hsa_ such as hsa_init. For more details, see <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#hsa-trace">HSA trace</a></td>
                 </tr>
                 <tr>
                     <td>--hsa-amd-trace [BOOL]</td>
-                    <td>Collects HSA API traces (AMD-extension API). For example, HSA functions prefixed with hsa_amd_ such as hsa_amd_coherency_get_type. For more details, see <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#hsa-trace">HSA trace</a></td>
+                    <td>Collects HSA API traces (AMD-extension API). For example, HSA functions prefixed with hsa_amd_ such as hsa_amd_coherency_get_type. For more details, see <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#hsa-trace">HSA trace</a></td>
                 </tr>
                 <tr>
                     <td>--hsa-image-trace [BOOL]</td>
-                    <td>Collects HSA API traces (image-extenson API). For example, HSA functions prefixed with only hsa_ext_image_ such as hsa_ext_image_get_capability. For more details, see <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#hsa-trace">HSA trace</a></td>
+                    <td>Collects HSA API traces (image-extenson API). For example, HSA functions prefixed with only hsa_ext_image_ such as hsa_ext_image_get_capability. For more details, see <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#hsa-trace">HSA trace</a></td>
                 </tr>
                 <tr>
                     <td>--hsa-finalizer-trace [BOOL]</td>
-                    <td>Collects HSA API traces (Finalizer-extension API). For example, HSA functions prefixed with only hsa_ext_program_ such as hsa_ext_program_create. For more details, see <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#hsa-trace">HSA trace</a></td>
+                    <td>Collects HSA API traces (Finalizer-extension API). For example, HSA functions prefixed with only hsa_ext_program_ such as hsa_ext_program_create. For more details, see <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#hsa-trace">HSA trace</a></td>
                 </tr>
                 <tr>
                     <td>--kfd-page-migration-trace</td>
@@ -178,29 +178,29 @@ The following table lists the commonly used ``rocprofv3`` command-line options c
                 <tr>
                     <th>Counter collection</th>
                     <td>--pmc [PMC …]</td>
-                    <td>Specifies performance monitoring counters to be collected. Use comma or space to specify more than one counter. For multi-pass collection, use multiple --pmc flags where each flag defines a separate counter group. The job fails if a counter group can't be collected in a single pass. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#counter-collection-using-command-line">Read more...</a></td>
+                    <td>Specifies performance monitoring counters to be collected. Use comma or space to specify more than one counter. For multi-pass collection, use multiple --pmc flags where each flag defines a separate counter group. The job fails if a counter group can't be collected in a single pass. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#counter-collection-using-command-line">Read more...</a></td>
                 </tr>
                 <tr>
                     <th rowspan="4">Post-processing tracing</th>
                     <td>--stats [BOOL]</td>
-                    <td>Collects statistics of enabled tracing types. Must be combined with one or more tracing options. Doesn’t include default kernel stats unlike previous rocprof versions. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#stats">Read more...</a></td>
+                    <td>Collects statistics of enabled tracing types. Must be combined with one or more tracing options. Doesn’t include default kernel stats unlike previous rocprof versions. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#stats">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>-S [BOOL] | --summary [BOOL]</td>
-                    <td>Displays single summary of tracing data for the enabled tracing type, after conclusion of the profiling session. Displays a summary of tracing data for the enabled tracing type, after conclusion of the profiling session. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#summary">Read more...</a></td>
+                    <td>Displays single summary of tracing data for the enabled tracing type, after conclusion of the profiling session. Displays a summary of tracing data for the enabled tracing type, after conclusion of the profiling session. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#summary">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>-D [BOOL] | --summary-per-domain [BOOL]</td>
-                    <td>Displays a summary of each tracing domain for the enabled tracing type, after conclusion of the profiling session. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#summary-per-domain">Read more...</a></td>
+                    <td>Displays a summary of each tracing domain for the enabled tracing type, after conclusion of the profiling session. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#summary-per-domain">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--summary-groups REGULAR_EXPRESSION [REGULAR_EXPRESSION …]</td>
-                    <td>Displays a summary for each set of domains matching the specified regular expression. For example, ‘KERNEL_DISPATCH|MEMORY_COPY’ generates a summary of all the tracing data in the KERNEL_DISPATCH and MEMORY_COPY domains. Similarly ‘*._API’ generates a summary of all the tracing data in the HIP_API, HSA_API, and MARKER_API domains. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#summary-groups">Read more...</a></td>
+                    <td>Displays a summary for each set of domains matching the specified regular expression. For example, ‘KERNEL_DISPATCH|MEMORY_COPY’ generates a summary of all the tracing data in the KERNEL_DISPATCH and MEMORY_COPY domains. Similarly ‘*._API’ generates a summary of all the tracing data in the HIP_API, HSA_API, and MARKER_API domains. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#summary-groups">Read more...</a></td>
                 </tr>
                 <tr>
                     <th rowspan="2">Summary</th>
                     <td>--summary-output-file SUMMARY_OUTPUT_FILE</td>
-                    <td>Outputs summary to a file, stdout, or stderr. By default, outputs to stderr. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#summary-output-file">Read more...</a></td>
+                    <td>Outputs summary to a file, stdout, or stderr. By default, outputs to stderr. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#summary-output-file">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>-u {sec,msec,usec,nsec} | --summary-units {sec,msec,usec,nsec}</td>
@@ -263,7 +263,7 @@ The following table lists the commonly used ``rocprofv3`` command-line options c
                 <tr>
                     <th rowspan="2">Display</th>
                     <td>-L [BOOL] | --list-avail [BOOL]</td>
-                    <td>Lists the PC sampling configurations and metrics available in the counter_defs.yaml file for counter collection. In earlier rocprof versions, this was known as --list-basic, --list-derived, and --list-counters. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#kernel-counter-collection">Read more...</a></td>
+                    <td>Lists the PC sampling configurations and metrics available in the counter_defs.yaml file for counter collection. In earlier rocprof versions, this was known as --list-basic, --list-derived, and --list-counters. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-core.html#kernel-counter-collection">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--group-by-queue [BOOL]</td>
@@ -280,7 +280,7 @@ The following table lists the commonly used ``rocprofv3`` command-line options c
                 </tr>
                 <tr>
                     <td>--disable-signal-handlers [BOOL]</td>
-                    <td>Controls signal handler prioritization. When set to true, disables rocprofv3 signal handler prioritization, allowing application signal handlers to take precedence. Useful for applications with custom crash handling or when integrating with testing frameworks. Default value is false (rocprofv3 handlers have priority). <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/advanced-rocprofv3-options.html#signal-handler-control">Read more...</a></td>
+                    <td>Controls signal handler prioritization. When set to true, disables rocprofiler-core signal handler prioritization, allowing application signal handlers to take precedence. Useful for applications with custom crash handling or when integrating with testing frameworks. Default value is false (rocprofiler-core handlers have priority). <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/advanced-rocprofv3-options.html#signal-handler-control">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--rocm-root PATH</td>
@@ -296,31 +296,31 @@ The following table lists the commonly used ``rocprofv3`` command-line options c
                 </tr>
                 <tr>
                     <td>--selected-regions</td>
-                    <td>If set, rocprofv3 profiles only regions of code surrounded by roctxMark(name) and roctxMark(0). <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-sdk-roctx.html#using-selected-regions-option">Read more...</a></td>
+                    <td>If set, rocprofiler-core profiles only regions of code surrounded by roctxMark(name) and roctxMark(0). <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-sdk-roctx.html#using-selected-regions-option">Read more...</a></td>
                 </tr>
             </tbody>
         </table>
     </div>
 
-To see the exhaustive list of ``rocprofv3`` options, use:
+To see the exhaustive list of ``rocprofiler-core`` options, use:
 
 .. code-block:: bash
 
-    rocprofv3 -h
-    rocprofv3 --help
+    rocprofiler-core -h
+    rocprofiler-core --help
 
-To display the version information for ``rocprofv3``, use:
+To display the version information for ``rocprofiler-core``, use:
 
 .. code-block:: bash
 
-    rocprofv3 -v
-    rocprofv3 --version
+    rocprofiler-core -v
+    rocprofiler-core --version
 
 The version command provides comprehensive build and system information including the following:
 
 .. code-block:: shell
 
-    $ rocprofv3 -v
+    $ rocprofiler-core -v
                  version: 1.0.0
             git_revision: a1b2c3d4e5f6789012345678901234567890abcd
             library_arch: x86_64-linux-gnu


### PR DESCRIPTION
Rename the user-facing profiling command from rocprofv3 to rocprofiler-core in a backward-compatible way. rocprofiler-core is now the real installed file and rocprofv3 is shipped as a deprecated relative symlink to it, so existing scripts and automation continue to work. Invoking the tool as rocprofv3 emits a one-time deprecation warning to stderr (no effect on stdout or exit codes); invoking it as rocprofiler-core runs clean.

- git mv source/bin/rocprofv3.py -> rocprofiler-core.py; add invocation-name gated deprecation warning in main(); update message prefixes and --help epilog
- source/bin/CMakeLists.txt: install rocprofiler-core and ship rocprofv3 as a relative symlink (COMPONENT tools)
- config.cmake.in: export new ::rocprofiler-core target; keep ::rocprofv3 and ::rocprofv3-avail for downstream consumers
- docs + README: use rocprofiler-core, note rocprofv3 is a deprecated alias
- CONTRIBUTING.md: update stale rocprofv3.py path reference

Out of scope (unchanged): rocprofv3-avail, librocprofv3-list-avail.so, the rocprofv3 Python package, internal C symbols, and doc/schema filenames.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
JIRA ID: ROCM-28035
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
