### PR TITLE
test(rocprofv3): add PC sampling attach/detach integration tests

### DIFF
--- a/projects/rocprofiler-sdk/tests/bin/pc-sampling/exec-mask-manipulation/exec_mask_manipulation.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/pc-sampling/exec-mask-manipulation/exec_mask_manipulation.cpp
@@ -511,36 +511,37 @@ kernel3(const float c, const int iter_num)
 // ======================================================
 
 void
-run_kernel()
+run_kernel(size_t iter_num)
 {
     int wave_size = 0;
     HIP_API_CALL(hipDeviceGetAttribute(&wave_size, hipDeviceAttributeWarpSize, 0));
 
     // Get device properties to retrieve GFXIP version
     size_t num_blocks = BLOCK_SIZE;
-    size_t num_iters  = ITER_NUM;
 
     for(int i = 1; i <= wave_size; i++)
     {
         if(i % 2 == 1)
-            kernel1<<<num_blocks, i>>>(i, num_iters);
+            kernel1<<<num_blocks, i>>>(i, iter_num);
         else
-            kernel2<<<num_blocks, i>>>(i, num_iters);
+            kernel2<<<num_blocks, i>>>(i, iter_num);
 
         check_hip_error();
         HIP_API_CALL(hipDeviceSynchronize());
     }
 
     float arg = 0;
-    kernel3<<<num_blocks, 4 * wave_size>>>(arg, num_iters);
+    kernel3<<<num_blocks, 4 * wave_size>>>(arg, iter_num);
     check_hip_error();
     HIP_API_CALL(hipDeviceSynchronize());
 }
 
 int
-main()
+main(int argc, char* argv[])
 {
-    run_kernel();
+    size_t iter_num = ITER_NUM;
+    if(argc > 1) iter_num = std::stoull(argv[1]);
+    run_kernel(iter_num);
     return 0;
 }
 

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/attach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/attach/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,21 +20,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-#
-
 set(PACKAGE_OUTPUT_DIR
-    ${ROCPROFILER_SDK_TESTS_BINARY_DIR}/pytest-packages/rocprofiler_sdk/pc_sampling)
+    ${ROCPROFILER_SDK_TESTS_BINARY_DIR}/pytest-packages/rocprofiler_sdk/pc_sampling/attach
+    )
 
-file(
-    WRITE "${PACKAGE_OUTPUT_DIR}/__init__.py"
-    "#
-from __future__ import absolute_import
+set(ATTACH_PYTHON_SOURCES __init__.py csv.py json.py)
 
-from . import exec_mask_manipulation
-from . import attach
-")
-
-add_subdirectory(exec_mask_manipulation)
-add_subdirectory(attach)
-add_subdirectory(stochastic)
-add_subdirectory(transpose_multiple_agents)
+foreach(_FILE ${ATTACH_PYTHON_SOURCES})
+    configure_file(${CMAKE_CURRENT_LIST_DIR}/${_FILE} ${PACKAGE_OUTPUT_DIR}/${_FILE}
+                   COPYONLY)
+endforeach()

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/attach/__init__.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/attach/__init__.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,21 +20,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-#
-
-set(PACKAGE_OUTPUT_DIR
-    ${ROCPROFILER_SDK_TESTS_BINARY_DIR}/pytest-packages/rocprofiler_sdk/pc_sampling)
-
-file(
-    WRITE "${PACKAGE_OUTPUT_DIR}/__init__.py"
-    "#
 from __future__ import absolute_import
-
-from . import exec_mask_manipulation
-from . import attach
-")
-
-add_subdirectory(exec_mask_manipulation)
-add_subdirectory(attach)
-add_subdirectory(stochastic)
-add_subdirectory(transpose_multiple_agents)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/attach/csv.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/attach/csv.py
@@ -1,0 +1,63 @@
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import absolute_import
+
+
+def normalize_attach_csv(df):
+    # In attach mode the profiler joins mid-run. Early samples that were not yet mapped
+    # to a dispatch carry Correlation_Id == 0 -- drop that prefix. The first mapped
+    # dispatch is numbered Correlation_Id == 1 instead of its true index, so shift
+    # Correlation_Id and Dispatch_Id by that offset so the shared exec-mask validators apply unchanged.
+    assert not df.empty, "attach-mode PC sampling CSV is empty"
+
+    df = df.sort_values("Sample_Timestamp").reset_index(drop=True)
+    resolved = df[df["Correlation_Id"] != 0]
+    assert not resolved.empty, "no resolved samples (all Correlation_Id == 0)"
+    first_resolved_idx = int(resolved.index.min())
+    # the dropped prefix must be genuinely unresolved (Dispatch_Id == 0)
+    prefix = df.iloc[:first_resolved_idx]
+    assert (
+        prefix["Dispatch_Id"] == 0
+    ).all(), "unresolved prefix has a non-zero Dispatch_Id"
+    df = df.iloc[first_resolved_idx:].copy()
+    assert (
+        df["Correlation_Id"] != 0
+    ).all(), "Correlation_Id == 0 samples found after the first resolved sample"
+
+    cid1 = df[df["Correlation_Id"] == 1]
+    assert not cid1.empty, (
+        "no Correlation_Id == 1 samples; the attach window missed the first captured "
+        "dispatch and the offset cannot be inferred"
+    )
+    # loop kernel i launches i active threads, so popcount(Exec_Mask) == true index
+    offset = int(cid1["Exec_Mask"].apply(lambda m: bin(int(m)).count("1")).mode()[0]) - 1
+    df["Correlation_Id"] = df["Correlation_Id"].astype(int) + offset
+    df["Dispatch_Id"] = df["Dispatch_Id"].astype(int) + offset
+
+    # a gap in the dispatch range means a lost correlation-id mapping during attach
+    lo, hi = int(df["Dispatch_Id"].min()), int(df["Dispatch_Id"].max())
+    assert df["Dispatch_Id"].nunique() == hi - lo + 1, (
+        f"gap in Dispatch_Id range [{lo}, {hi}]: "
+        f"{df['Dispatch_Id'].nunique()} unique, expected {hi - lo + 1}"
+    )
+    return df, hi

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/attach/json.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/attach/json.py
@@ -1,0 +1,57 @@
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import absolute_import
+
+
+def _tool(json_data):
+    tool = json_data["rocprofiler-sdk-tool"]
+    return tool[0] if isinstance(tool, list) else tool
+
+
+def validate_attach_json(json_data, method, csv_row_count):
+    tool = _tool(json_data)
+    records = tool["buffer_records"]["pc_sample_" + method]
+    instructions = tool["strings"]["pc_sample_instructions"]
+
+    # CSV and JSON must describe the same set of samples
+    assert (
+        len(records) == csv_row_count
+    ), f"CSV rows ({csv_row_count}) != JSON records ({len(records)})"
+
+    for sample in records:
+        rec = sample.get("record", sample)
+        inst_index = sample["inst_index"]
+        # inst_index is -1 (undecodable) or a valid index into the string table
+        assert inst_index == -1 or 0 <= inst_index < len(
+            instructions
+        ), f"inst_index out of range: {inst_index}"
+        dispatch_id = rec.get("dispatch_id")
+        internal_cid = rec.get("corr_id", {}).get("internal")
+        # a sample is correlated to a dispatch iff it has a correlation id
+        assert (internal_cid == 0) == (dispatch_id == 0), (
+            "corr_id.internal and dispatch_id disagree on whether the sample "
+            "is correlated"
+        )
+        # correlated samples must carry a non-zero execution mask
+        if dispatch_id and dispatch_id > 0:
+            assert rec.get("exec_mask", 0) > 0, "correlated sample has exec_mask == 0"

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/exec_mask_manipulation/csv.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/exec_mask_manipulation/csv.py
@@ -149,7 +149,9 @@ def validate_exec_mask_based_on_correlation_id(df):
     ).all(), "Exec_Mask does not match expected mask derived from Correlation_Id for all samples"
 
 
-def exec_mask_manipulation_validate_csv(df, all_sampled=False):
+def exec_mask_manipulation_validate_csv(
+    df, all_sampled=False, wave_size=None, num_kernels=None
+):
     assert not df.empty
 
     validate_instruction_comment(df)
@@ -158,40 +160,55 @@ def exec_mask_manipulation_validate_csv(df, all_sampled=False):
     # Validate samples with non-zero correlation IDs (and with decoded instructions)
     samples_cid_non_zero_df = df[df["Correlation_Id"] != 0]
 
-    # We have exactly wave_size + 1 kernels and matching correaltion IDs.
-    # Depending on the underlying architecture, that's either 33 (32 + 1)
-    # or 65
-    unique_kernels_num = samples_cid_non_zero_df["Correlation_Id"].max()
-    assert unique_kernels_num in [
-        33,
-        65,
-    ], f"Expected 33 or 65 unique kernels, got {unique_kernels_num}"
+    # Number of captured kernels (== max correlation id). In wrap mode this is the
+    # full run (wave_size + 1 kernels); in attach mode the window may capture fewer.
+    max_correlation_id = int(samples_cid_non_zero_df["Correlation_Id"].max())
+
+    if wave_size is None:
+        # Backward-compatible path: infer from the data. A full wrap-mode run always
+        # has exactly wave_size + 1 kernels, i.e. 33 (wave32) or 65 (wave64).
+        assert max_correlation_id in [
+            33,
+            65,
+        ], f"Expected 33 or 65 unique kernels, got {max_correlation_id}"
+        wave_size = max_correlation_id - 1
+
+    if num_kernels is None:
+        num_kernels = max_correlation_id
+    # Never expect more kernels than a full run would produce.
+    num_kernels = min(num_kernels, wave_size + 1)
 
     assert (samples_cid_non_zero_df["Correlation_Id"].astype(int) >= 1).all()
-    assert (
-        samples_cid_non_zero_df["Correlation_Id"].astype(int) <= unique_kernels_num
-    ).all()
+    assert (samples_cid_non_zero_df["Correlation_Id"].astype(int) <= num_kernels).all()
     if all_sampled:
         # all correlation IDs must be sampled
         assert (
             len(samples_cid_non_zero_df["Correlation_Id"].astype(int).unique())
-            == unique_kernels_num
+            == num_kernels
         )
+
+    is_full_capture = num_kernels == wave_size + 1
+
+    # The last kernel (kernel3, the v_rcp kernel) is only present on a full capture.
+    # On a partial attach capture, validate the exec masks on the captured kernels.
+    if not is_full_capture:
+        validate_exec_mask_based_on_correlation_id(samples_cid_non_zero_df.copy())
+        return
 
     # all kernels except the last one
     first_kernels_df = samples_cid_non_zero_df[
-        samples_cid_non_zero_df["Correlation_Id"] <= unique_kernels_num - 1
+        samples_cid_non_zero_df["Correlation_Id"] <= num_kernels - 1
     ]
 
     # Make a copy, so that we don't work (modify) a view.
     validate_exec_mask_based_on_correlation_id(first_kernels_df.copy())
 
     # validate the last kernel
-    last_kernel = df[df["Correlation_Id"] == unique_kernels_num]
+    last_kernel = df[df["Correlation_Id"] == num_kernels]
 
     # For 32 wave size, the exec mask is 32 bits or 8 hex digits.
     # For 64 wave size, the exec mask is 64 bits or 16 hex digits.
-    exec_mask_size_hex_digits = unique_kernels_num // 4
+    exec_mask_size_hex_digits = num_kernels // 4
     even_simd_threads_active_exec_mask = int("5" * exec_mask_size_hex_digits, 16)
     odd_simd_threads_active_exec_mask = int("A" * exec_mask_size_hex_digits, 16)
 

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/CMakeLists.txt
@@ -5,3 +5,4 @@
 add_subdirectory(attach-once)
 add_subdirectory(attach-twice)
 add_subdirectory(attach-tree)
+add_subdirectory(attach-pc-sampling)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,21 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-#
-
-set(PACKAGE_OUTPUT_DIR
-    ${ROCPROFILER_SDK_TESTS_BINARY_DIR}/pytest-packages/rocprofiler_sdk/pc_sampling)
-
-file(
-    WRITE "${PACKAGE_OUTPUT_DIR}/__init__.py"
-    "#
-from __future__ import absolute_import
-
-from . import exec_mask_manipulation
-from . import attach
-")
-
-add_subdirectory(exec_mask_manipulation)
-add_subdirectory(attach)
+add_subdirectory(host-trap)
 add_subdirectory(stochastic)
-add_subdirectory(transpose_multiple_agents)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/host-trap/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/host-trap/CMakeLists.txt
@@ -1,0 +1,85 @@
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
+
+project(
+    rocprofiler-sdk-tests-rocprofv3-attachment-attach-pc-sampling-host-trap
+    LANGUAGES CXX
+    VERSION 0.0.0)
+
+find_package(rocprofiler-sdk REQUIRED)
+
+rocprofiler_sdk_pc_sampling_disabled(IS_PC_SAMPLING_DISABLED)
+
+set(ROCPROFILER_MEMCHECK_TYPES "AddressSanitizer" "UndefinedBehaviorSanitizer"
+                               "ThreadSanitizer")
+
+if(IS_PC_SAMPLING_DISABLED OR (ROCPROFILER_MEMCHECK AND ROCPROFILER_MEMCHECK IN_LIST
+                                                        ROCPROFILER_MEMCHECK_TYPES))
+    set(IS_DISABLED ON)
+else()
+    set(IS_DISABLED OFF)
+endif()
+
+set(attach-pc-sampling-host-trap-env
+    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
+    )
+
+set(ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX
+    "PC sampling unavailable|PC sampling configuration is not supported")
+
+rocprofiler_configure_pytest_files(CONFIG pytest.ini COPY validate.py conftest.py)
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-attachment-attach-pc-sampling-host-trap
+    COMMAND
+        ${CMAKE_CURRENT_SOURCE_DIR}/../run_attach_pc_sampling_test.sh
+        $<TARGET_FILE:exec-mask-manipulation> $<TARGET_FILE:rocprofiler-sdk::rocprofv3>
+        ${CMAKE_CURRENT_BINARY_DIR} warning out host_trap time 1000 5000 1048576
+    DEPENDS rocprofiler-sdk::rocprofv3 exec-mask-manipulation
+    TIMEOUT 120
+    LABELS "integration-tests;attachment;pc-sampling"
+    ENVIRONMENT "${attach-pc-sampling-host-trap-env}"
+    SKIP_REGULAR_EXPRESSION
+        "This test is skipped.|${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
+    FIXTURES_SETUP rocprofv3-test-attachment-attach-pc-sampling-host-trap
+    DISABLED "${IS_DISABLED}")
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-attachment-attach-pc-sampling-host-trap
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    ARGS --input-csv
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-pc-sampling-output/out_pc_sampling_host_trap.csv
+         --input-json
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-pc-sampling-output/out_results.json
+         --agent-info-csv
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-pc-sampling-output/out_agent_info.csv
+         --skip-if
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-pc-sampling-output/skipped
+    TIMEOUT 60
+    LABELS "integration-tests;attachment;pc-sampling"
+    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-pc-sampling-host-trap
+    SKIP_REGULAR_EXPRESSION "SKIPPED|${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
+    DISABLED "${IS_DISABLED}")

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/host-trap/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/host-trap/conftest.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import json
+
+import pandas as pd
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--input-csv", action="store", default=None)
+    parser.addoption("--input-json", action="store", default=None)
+    parser.addoption("--agent-info-csv", action="store", default=None)
+    parser.addoption("--skip-if", action="store", default=None)
+
+
+def _check_skip(request):
+    skip_path = request.config.getoption("--skip-if")
+    if skip_path and os.path.exists(skip_path):
+        pytest.skip("attach tests unavailable (insufficient ptrace permissions)")
+
+
+@pytest.fixture
+def input_csv(request):
+    _check_skip(request)
+    fname = request.config.getoption("--input-csv")
+    if not fname or not os.path.isfile(fname):
+        pytest.skip("PC sampling unavailable")
+    return pd.read_csv(
+        fname, na_filter=False, keep_default_na=False, dtype={"Exec_Mask": "uint64"}
+    )
+
+
+@pytest.fixture
+def input_json(request):
+    _check_skip(request)
+    fname = request.config.getoption("--input-json")
+    if not fname or not os.path.isfile(fname):
+        pytest.skip("PC sampling unavailable")
+    with open(fname, "r") as inp:
+        return json.load(inp)
+
+
+@pytest.fixture
+def wave_size(request):
+    fname = request.config.getoption("--agent-info-csv")
+    if not fname or not os.path.isfile(fname):
+        pytest.skip("agent info unavailable")
+    df = pd.read_csv(fname)
+    gpu = df[df["Wave_Front_Size"].astype(int) > 0]
+    assert not gpu.empty, "no GPU agent with a wave front size in agent info"
+    return int(gpu["Wave_Front_Size"].astype(int).iloc[0])

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/host-trap/pytest.ini
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/host-trap/pytest.ini
@@ -1,0 +1,5 @@
+
+[pytest]
+addopts = --durations=20 -rA -s
+testpaths = validate.py
+pythonpath = @ROCPROFILER_SDK_TESTS_BINARY_DIR@/pytest-packages

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/host-trap/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/host-trap/validate.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Validate rocprofv3 host_trap PC sampling output collected in attach mode.
+
+import sys
+
+import pytest
+
+from rocprofiler_sdk.pc_sampling.attach.csv import normalize_attach_csv
+from rocprofiler_sdk.pc_sampling.attach.json import validate_attach_json
+from rocprofiler_sdk.pc_sampling.exec_mask_manipulation.csv import (
+    exec_mask_manipulation_validate_csv,
+)
+
+METHOD = "host_trap"
+
+
+def test_validate_pc_sampling_attach_csv(input_csv, wave_size):
+    # normalize the attach-mode distortions, then reuse the shared exec-mask checks
+    df, num_kernels = normalize_attach_csv(input_csv)
+    exec_mask_manipulation_validate_csv(df, wave_size=wave_size, num_kernels=num_kernels)
+
+
+def test_validate_pc_sampling_attach_json(input_csv, input_json):
+    # parity plus basic per-record checks; the full exec-mask JSON validator
+    # assumes a complete run, so it is not applied to attach captures
+    validate_attach_json(input_json, METHOD, len(input_csv))
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-x", __file__] + sys.argv[1:]))

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/run_attach_pc_sampling_test.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/run_attach_pc_sampling_test.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -e
+
+TEST_APP=$1
+ROCPROFV3=$2
+OUTPUT_DIR=${3:-${PWD}}
+LOG_LEVEL=${4:-warning}
+OUTPUT_FILENAME=${5:-out}
+PC_SAMPLING_METHOD=${6:-host_trap}
+PC_SAMPLING_UNIT=${7:-time}
+PC_SAMPLING_INTERVAL=${8:-1000}
+ATTACH_DURATION_MSEC=${9:-5000}
+# Iteration count for exec-mask-manipulation: keeps the app alive long enough
+# for the profiler to attach, sample, and detach within ATTACH_DURATION_MSEC.
+TEST_APP_ITER_NUM=${10:-1048576}
+
+# The target process must load rocprofiler-register to expose the attach thread.
+export ROCP_TOOL_ATTACH=1
+
+OUTPUT_SUBDIR="attachment-pc-sampling-output"
+EXPECTED_FILES=("${OUTPUT_FILENAME}_pc_sampling_${PC_SAMPLING_METHOD}.csv" "${OUTPUT_FILENAME}_agent_info.csv")
+
+rm -rf ${OUTPUT_DIR}/${OUTPUT_SUBDIR}
+mkdir -p ${OUTPUT_DIR}/${OUTPUT_SUBDIR}
+
+# Skip when ptrace is not permitted and we lack the privileges to override it.
+if [ -e /proc/sys/kernel/yama/ptrace_scope ]                             \
+&& [ $(cat /proc/sys/kernel/yama/ptrace_scope) -ne 0 ]                   \
+&& [ $(id -u) -ne 0 ]                                                    \
+&& [[ $(getpcaps self 2>/dev/null) != *"cap_sys_ptrace"* ]]
+    then
+    echo "ptrace not permitted (ptrace_scope != 0, not root, no CAP_SYS_PTRACE). This test is skipped."
+    touch ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/skipped
+    exit 0
+fi
+
+wait_for_attach_ready() {
+    local pid=$1 max_wait=30 elapsed=0
+    while [ $elapsed -lt $max_wait ]; do
+        if grep -ql "rocp-bg-attach" /proc/${pid}/task/*/comm 2>/dev/null; then
+            echo "attach thread ready after ${elapsed}s"
+            return 0
+        fi
+        kill -0 $pid 2>/dev/null || { echo "target exited before becoming attach-ready"; return 1; }
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    echo "timed out waiting for rocp-bg-attach thread"
+    return 1
+}
+
+echo "Launching ${TEST_APP} ${TEST_APP_ITER_NUM} in the background..."
+LD_PRELOAD=${ROCPROF_PRELOAD} ${TEST_APP} ${TEST_APP_ITER_NUM} &
+APP_PID=$!
+
+if ! wait_for_attach_ready $APP_PID; then
+    kill $APP_PID 2>/dev/null || true
+    exit 1
+fi
+
+echo "Attaching ${PC_SAMPLING_METHOD} PC sampling to PID ${APP_PID} for ${ATTACH_DURATION_MSEC}ms..."
+LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach ${APP_PID} \
+    --attach-duration-msec ${ATTACH_DURATION_MSEC} --attach-sync-output \
+    --pc-sampling-beta-enabled --pc-sampling-unit ${PC_SAMPLING_UNIT} \
+    --pc-sampling-method ${PC_SAMPLING_METHOD} --pc-sampling-interval ${PC_SAMPLING_INTERVAL} \
+    -f csv json -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} -o ${OUTPUT_FILENAME} --log-level ${LOG_LEVEL}
+
+# --attach-sync-output makes detach block until the output file is fully written,
+# so the app can be stopped safely here. Removing that flag risks a truncated file.
+echo "Profiler detached. Stopping the application..."
+kill -2 ${APP_PID} 2>/dev/null || true
+wait ${APP_PID} 2>/dev/null || true
+
+for f in "${EXPECTED_FILES[@]}"; do
+    if [ ! -f "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${f}" ]; then
+        echo "Error: expected output file ${f} not found"
+        exit 1
+    fi
+done
+
+echo "PC sampling attachment test (method=${PC_SAMPLING_METHOD}) completed successfully"
+exit 0

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/stochastic/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/stochastic/CMakeLists.txt
@@ -1,0 +1,85 @@
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
+
+project(
+    rocprofiler-sdk-tests-rocprofv3-attachment-attach-pc-sampling-stochastic
+    LANGUAGES CXX
+    VERSION 0.0.0)
+
+find_package(rocprofiler-sdk REQUIRED)
+
+rocprofiler_sdk_pc_sampling_stochastic_disabled(IS_PC_SAMPLING_STOCHASTIC_DISABLED)
+
+set(ROCPROFILER_MEMCHECK_TYPES "AddressSanitizer" "UndefinedBehaviorSanitizer"
+                               "ThreadSanitizer")
+
+if(IS_PC_SAMPLING_STOCHASTIC_DISABLED
+   OR (ROCPROFILER_MEMCHECK AND ROCPROFILER_MEMCHECK IN_LIST ROCPROFILER_MEMCHECK_TYPES))
+    set(IS_DISABLED ON)
+else()
+    set(IS_DISABLED OFF)
+endif()
+
+set(attach-pc-sampling-stochastic-env
+    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
+    )
+
+set(ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX
+    "PC sampling unavailable|PC sampling configuration is not supported")
+
+rocprofiler_configure_pytest_files(CONFIG pytest.ini COPY validate.py conftest.py)
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-attachment-attach-pc-sampling-stochastic
+    COMMAND
+        ${CMAKE_CURRENT_SOURCE_DIR}/../run_attach_pc_sampling_test.sh
+        $<TARGET_FILE:exec-mask-manipulation> $<TARGET_FILE:rocprofiler-sdk::rocprofv3>
+        ${CMAKE_CURRENT_BINARY_DIR} warning out stochastic cycles 16777216 5000 1048576
+    DEPENDS rocprofiler-sdk::rocprofv3 exec-mask-manipulation
+    TIMEOUT 120
+    LABELS "integration-tests;attachment;pc-sampling;stochastic"
+    ENVIRONMENT "${attach-pc-sampling-stochastic-env}"
+    SKIP_REGULAR_EXPRESSION
+        "This test is skipped.|${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
+    FIXTURES_SETUP rocprofv3-test-attachment-attach-pc-sampling-stochastic
+    DISABLED "${IS_DISABLED}")
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-attachment-attach-pc-sampling-stochastic
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    ARGS --input-csv
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-pc-sampling-output/out_pc_sampling_stochastic.csv
+         --input-json
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-pc-sampling-output/out_results.json
+         --agent-info-csv
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-pc-sampling-output/out_agent_info.csv
+         --skip-if
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-pc-sampling-output/skipped
+    TIMEOUT 60
+    LABELS "integration-tests;attachment;pc-sampling;stochastic"
+    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-pc-sampling-stochastic
+    SKIP_REGULAR_EXPRESSION "SKIPPED|${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
+    DISABLED "${IS_DISABLED}")

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/stochastic/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/stochastic/conftest.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import json
+
+import pandas as pd
+import pytest
+
+STOCHASTIC_DTYPES = {
+    "Exec_Mask": "uint64",
+    "Wave_Issued_Instruction": bool,
+    "Instruction_Type": str,
+    "Stall_Reason": str,
+}
+
+
+def pytest_addoption(parser):
+    parser.addoption("--input-csv", action="store", default=None)
+    parser.addoption("--input-json", action="store", default=None)
+    parser.addoption("--agent-info-csv", action="store", default=None)
+    parser.addoption("--skip-if", action="store", default=None)
+
+
+def _check_skip(request):
+    skip_path = request.config.getoption("--skip-if")
+    if skip_path and os.path.exists(skip_path):
+        pytest.skip("attach tests unavailable (insufficient ptrace permissions)")
+
+
+@pytest.fixture
+def input_csv(request):
+    _check_skip(request)
+    fname = request.config.getoption("--input-csv")
+    if not fname or not os.path.isfile(fname):
+        pytest.skip("PC sampling unavailable")
+    return pd.read_csv(
+        fname, na_filter=False, keep_default_na=False, dtype=STOCHASTIC_DTYPES
+    )
+
+
+@pytest.fixture
+def input_json(request):
+    _check_skip(request)
+    fname = request.config.getoption("--input-json")
+    if not fname or not os.path.isfile(fname):
+        pytest.skip("PC sampling unavailable")
+    with open(fname, "r") as inp:
+        return json.load(inp)
+
+
+@pytest.fixture
+def input_agent_info_csv(request):
+    fname = request.config.getoption("--agent-info-csv")
+    if not fname or not os.path.isfile(fname):
+        pytest.skip("agent info unavailable")
+    return pd.read_csv(fname)
+
+
+@pytest.fixture
+def wave_size(request):
+    fname = request.config.getoption("--agent-info-csv")
+    if not fname or not os.path.isfile(fname):
+        pytest.skip("agent info unavailable")
+    df = pd.read_csv(fname)
+    gpu = df[df["Wave_Front_Size"].astype(int) > 0]
+    assert not gpu.empty, "no GPU agent with a wave front size in agent info"
+    return int(gpu["Wave_Front_Size"].astype(int).iloc[0])

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/stochastic/pytest.ini
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/stochastic/pytest.ini
@@ -1,0 +1,5 @@
+
+[pytest]
+addopts = --durations=20 -rA -s
+testpaths = validate.py
+pythonpath = @ROCPROFILER_SDK_TESTS_BINARY_DIR@/pytest-packages

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/stochastic/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/stochastic/validate.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Validate rocprofv3 stochastic PC sampling output collected in attach mode.
+
+import sys
+
+import pandas as pd
+import pytest
+
+from rocprofiler_sdk.pc_sampling.attach.csv import normalize_attach_csv
+from rocprofiler_sdk.pc_sampling.attach.json import validate_attach_json
+from rocprofiler_sdk.pc_sampling.exec_mask_manipulation.csv import (
+    exec_mask_manipulation_validate_csv,
+)
+
+METHOD = "stochastic"
+
+
+def _is_gfx12(input_agent_info_csv: pd.DataFrame):
+    return input_agent_info_csv["Name"].str.contains("gfx12").any()
+
+
+def test_validate_pc_sampling_attach_csv(input_csv, wave_size):
+    # normalize the attach-mode distortions, then reuse the shared exec-mask checks
+    df, num_kernels = normalize_attach_csv(input_csv)
+    exec_mask_manipulation_validate_csv(df, wave_size=wave_size, num_kernels=num_kernels)
+
+
+def test_validate_pc_sampling_attach_json(input_csv, input_json):
+    # parity plus basic per-record checks
+    validate_attach_json(input_json, METHOD, len(input_csv))
+
+
+def test_validate_pc_sampling_attach_stochastic_specific_csv(
+    input_csv, input_agent_info_csv
+):
+    if _is_gfx12(input_agent_info_csv):
+        pytest.skip("stochastic-specific checks are not implemented for gfx12")
+    from rocprofiler_sdk.pc_sampling.stochastic.csv.gfx9 import (
+        validate_stochastic_samples_csv,
+    )
+
+    validate_stochastic_samples_csv(input_csv)
+
+
+def test_validate_pc_sampling_attach_stochastic_specific_json(
+    input_json, input_agent_info_csv
+):
+    if _is_gfx12(input_agent_info_csv):
+        pytest.skip("stochastic-specific checks are not implemented for gfx12")
+    from rocprofiler_sdk.pc_sampling.stochastic.json.gfx9 import (
+        validate_stochastic_samples_json,
+    )
+
+    tool = input_json["rocprofiler-sdk-tool"]
+    tool = tool[0] if isinstance(tool, list) else tool
+    validate_stochastic_samples_json(tool)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-x", __file__] + sys.argv[1:]))


### PR DESCRIPTION
## Motivation

rocprofv3 supports PC sampling in attach mode, but that path had no integration coverage. This PR aims to add it for both host_trap and stochastic methods. Supersedes #5344 (closed), addressing its review feedback.

## Technical Details

New tests under `tests/rocprofv3/attachment/attach-pc-sampling/` (`host-trap/` + `stochastic/`), driven by a shared `run_attach_pc_sampling_test.sh`: launch `exec-mask-manipulation` in the background, wait for it to become attach-ready, attach rocprofv3 with `--pc-sampling-*` for a fixed window, detach, and validate the output.

- The `exec-mask-manipulation` app takes an optional iteration count so it stays alive across the attach window; the default is unchanged, so existing tests are unaffected.
- The shared `exec_mask_manipulation_validate_csv` is extended with `wave_size`/`num_kernels` parameters — it reads the wave size from `out_agent_info.csv` and handles partial captures, replacing the hardcoded 33/65-kernel assumption.
- Attach output is normalized before the shared validators run: drop the unresolved `Correlation_Id == 0` prefix, then shift `Correlation_Id`/`Dispatch_Id` by the attach offset back into wrap-mode alignment.
- CSV validation: after normalization, reuses the shared exec-mask checks — instruction comments, correlation/dispatch relation, and per-kernel exec-mask patterns (popcount == correlation id); plus the gfx9 stochastic-specific checks (wave count, instruction types, arbiter state) for the stochastic method.
- JSON validation scope: JSON is checked via CSV↔JSON parity, per-record checks (inst_index, correlation/dispatch consistency, exec_mask), and the gfx9 stochastic checks. We intentionally don't run the full validate_json_exec_mask_manipulation — it assumes a complete run and un-normalized IDs, so applying it to attach data would mean a complete re-do for offset normalization on the nested JSON. Currently the parity check plus the CSV validation cover the same records.

**Note:** the test normalizes attach-mode correlation IDs to match their current behavior, as it starts from 1 at the attach point, preceded by an unresolved Correlation_Id == 0 prefix. If this behavior changes in the tool (for example, absolute dispatch IDs or a different handling of the prefix), `normalize_attach_csv` will need to be updated accordingly.

## JIRA ID

JIRA ID: AIROCVAL-54

## Test Plan

`ctest -R attach-pc-sampling`

## Test Result

All 8 tests pass on MI300x (gfx942)