### PR TITLE
Enable segmented cross-device graph launches

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1077,11 +1077,11 @@ hipError_t GraphExecBase::CreateStreams(uint32_t num_streams, int devId) {
     return hipSuccess;
   }
 
-  // num_streams is already capped by Init() but guard here defensively.
-  // For the instantiation device one slot is occupied by the launch stream,
-  // so create one fewer extra stream. Other devices use all slots as parallel streams.
-  uint32_t capped = std::min(num_streams, DEBUG_HIP_FORCE_GRAPH_QUEUES);
-  uint32_t max_streams = (devId == captureDeviceId_ && capped > 0) ? capped - 1 : capped;
+  // num_streams is already capped by Init() but guard here defensively. Create
+  // the full requested internal pool: cross-device launches do not have a
+  // launch stream on captureDeviceId_, so streams_[0] must be an internal
+  // capture-device stream.
+  uint32_t max_streams = std::min(num_streams, DEBUG_HIP_FORCE_GRAPH_QUEUES);
   if (max_streams == 0) {
     return hipSuccess;
   }
@@ -1107,14 +1107,21 @@ hipError_t GraphExecBase::CreateStreams(uint32_t num_streams, int devId) {
       return hipErrorOutOfMemory;
     }
 
-    // Pin the queue so dynamic queue management won't release it between launches
-    stream->vdev()->PinQueue();
-    // Acquire a queue that doesn't collide with previously created internal streams.
-    // On the first stream (used_qids empty) this is a normal acquisition.
-    if (!used_qids.empty()) {
-      stream->vdev()->ReacquireQueueExcluding(used_qids);
+    // Same-device launches supply stream slot 0 with the user launch stream, so
+    // keep the last capture-device stream as an unpinned reserve. It does not
+    // acquire a HW queue unless a cross-device launch needs the full internal
+    // pool. All other streams stay pinned for the graph lifetime.
+    const bool cross_device_reserve =
+        devId == captureDeviceId_ && (i + 1) == max_streams;
+    if (!cross_device_reserve) {
+      stream->vdev()->PinQueue();
+      // Acquire a queue that doesn't collide with previously created internal streams.
+      // On the first stream (used_qids empty) this is a normal acquisition.
+      if (!used_qids.empty()) {
+        stream->vdev()->ReacquireQueueExcluding(used_qids);
+      }
+      used_qids.insert(stream->getQueueID());
     }
-    used_qids.insert(stream->getQueueID());
 
     parallel_streams_[devId].push_back(stream);
   }
@@ -1221,9 +1228,9 @@ hipError_t GraphExecSegmented::FindStreamsReqPerDevForSegments() {
 // ================================================================================================
 void GraphExecSegmented::RoundRobinStreamAssignment() {
   // max_streams_dev_ holds the raw parallelism count per device as computed by
-  // FindStreamsReqPerDevForSegments() and capped in Init(). CreateStreams() handles
-  // the -1 adjustment for the instantiation device internally, so the value here
-  // represents the total stream pool size for every device uniformly.
+  // FindStreamsReqPerDevForSegments() and capped in Init(). It represents the
+  // total stream pool size uniformly; UpdateStreams() substitutes the user
+  // launch stream for the capture-device reserve on same-device launches.
   auto getPoolSize = [&](int dev_id) -> size_t {
     auto it = max_streams_dev_.find(dev_id);
     return (it != max_streams_dev_.end() && it->second > 0)
@@ -2800,20 +2807,34 @@ hipError_t GraphExecSegmented::EnqueueSegment(const Segment& segment, hip::Strea
 
 // ================================================================================================
 void GraphExecBase::UpdateStreams(hip::Stream* launch_stream) {
-  int devId = launch_stream->vdev()->device().index();
+  int devId = (launch_stream != nullptr) ? launch_stream->vdev()->device().index()
+                                         : captureDeviceId_;
   streams_.clear();
-  streams_.push_back(launch_stream);
+  if (launch_stream != nullptr) {
+    streams_.push_back(launch_stream);
+  }
   if (parallel_streams_.find(devId) == parallel_streams_.end()) {
-    // No parallel streams were created for this device
+    if (launch_stream == nullptr) {
+      LogPrintfError("UpdateStreams failed for capture device id:%d", devId);
+    }
     return;
   }
   auto& parallel_streams = parallel_streams_[devId];
 
-  // Collect queue IDs already in use, starting with the launch stream
+  // Collect queue IDs already in use, starting with the launch stream if present.
   std::unordered_set<uint64_t> used_qids;
-  used_qids.insert(launch_stream->getQueueID());
+  hip::Stream* skipped_stream = nullptr;
+  if (launch_stream != nullptr) {
+    used_qids.insert(launch_stream->getQueueID());
+    // Same-device launches use the user launch stream as stream slot 0, so
+    // leave the unpinned reserve unused.
+    skipped_stream = parallel_streams.back();
+  }
 
-  for (auto stream : parallel_streams) {
+  for (auto* stream : parallel_streams) {
+    if (stream == skipped_stream) {
+      continue;
+    }
     uint64_t qid = stream->getQueueID();
     if (used_qids.count(qid) > 0) {
       // Collision: this stream shares a HW queue with the launch stream or another
@@ -3091,9 +3112,24 @@ hipError_t GraphExecSegmented::Run(hip::Stream* launch_stream) {
   // try to re-acquire the same one it used last time.
   // Then run collision detection to ensure graph-internal streams don't share
   // a HW queue with the launch stream.
+  const bool cross_device_launch = (captureDeviceId_ != launch_stream->DeviceId());
   launch_stream->vdev()->SetPreferredQueue();
   launch_stream->vdev()->AcquireQueueWithPreference();
-  UpdateStreams(launch_stream);
+  if (cross_device_launch) {
+    // The last capture-device stream is kept unpinned and queue-less while the
+    // graph is used only on its capture device. Pin the full pool before a
+    // cross-device launch; UpdateStreams() will acquire a distinct queue for
+    // the reserve when it builds streams_.
+    auto it = parallel_streams_.find(captureDeviceId_);
+    if (it != parallel_streams_.end()) {
+      for (auto* stream : it->second) {
+        if (stream != nullptr) {
+          stream->vdev()->PinQueue();
+        }
+      }
+    }
+  }
+  UpdateStreams(cross_device_launch ? nullptr : launch_stream);
 
   // Signals borrowed from the per-graph pool for this launch (segmented path
   // only); handed to the completion callback to re-arm and return to the pool.
@@ -3103,15 +3139,17 @@ hipError_t GraphExecSegmented::Run(hip::Stream* launch_stream) {
   // reuse the graph's own accumulate command instead of enqueuing a dedicated marker
   amd::Command* completion_cmd = nullptr;
 
-  if (captureDeviceId_ == launch_stream->DeviceId()) {
-    // If the graph has kernels that does device side allocation,  during packet capture, heap is
-    // allocated because heap pointer has to be added to the AQL packet, and initialized during
-    // graph launch.
-    // Todo: Hidden heap initialization is done only for single device graph
-    if (HasHiddenHeap() && hiddenHeapInitializedDevices_.insert(launch_stream->DeviceId()).second) {
-      launch_stream->vdev()->HiddenHeapInit();
-    }
-    amd::Command* last_cmd = nullptr;
+  // If the graph has kernels that do device-side allocation, packet capture
+  // needs the hidden heap on the graph/capture device, not necessarily the
+  // user-visible launch stream device.
+  hip::Stream* graph_launch_stream = cross_device_launch ? streams_[0] : launch_stream;
+  if (HasHiddenHeap() &&
+      hiddenHeapInitializedDevices_.insert(captureDeviceId_).second) {
+    graph_launch_stream->vdev()->HiddenHeapInit();
+  }
+
+  amd::Command* last_cmd = nullptr;
+  if (!cross_device_launch) {
     if (max_streams_dev_.size() == 1) {
       // Single-device: pass collision-handled streams_ to EnqueueSegmentedGraph
       last_cmd = EnqueueSegmentedGraph(launch_stream, streams_, &status, &launch_signal_set);
@@ -3119,23 +3157,49 @@ hipError_t GraphExecSegmented::Run(hip::Stream* launch_stream) {
       // Multi-device: pass empty vector, will use parallel_streams_ internally
       last_cmd = EnqueueSegmentedGraph(launch_stream, {}, &status, &launch_signal_set);
     }
-
-    // Drive OnLaunchComplete off this command's completion (its leaf-sync deps
-    // already imply all parallel work is done). Our reference is released after
-    // the callback is registered below; the queue keeps it alive until done.
-    completion_cmd = last_cmd;
-  } else if (max_streams_ == 1 && captureDeviceId_ != launch_stream->DeviceId()) {
-    for (int i = 0; i < topoOrder_.size(); i++) {
-      topoOrder_[i]->SetStream(launch_stream);
-      status = topoOrder_[i]->CreateCommand(topoOrder_[i]->GetQueue());
-      topoOrder_[i]->EnqueueCommands(launch_stream);
+  } else {
+    // Cross-device launch: replay segmented AQL on a capture-device stream.
+    // A marker on the graph stream preserves prior foreign launch-stream
+    // ordering when such work exists. The completion marker below makes graph
+    // completion visible on the foreign launch stream.
+    hip::Stream* graph_stream = streams_[0];
+    constexpr bool kRetainCommand = true;
+    amd::Command* launch_last_cmd = launch_stream->getLastQueuedCommand(kRetainCommand);
+    if (launch_last_cmd != nullptr) {
+      amd::Command::EventWaitList launch_wait_list;
+      launch_wait_list.push_back(launch_last_cmd);
+      auto* graph_start = new amd::Marker(*graph_stream, true, launch_wait_list);
+      graph_start->enqueue();
+      graph_start->release();
+      launch_last_cmd->release();
     }
-  } else if (captureDeviceId_ != launch_stream->DeviceId()) {
-    ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
-      "[hipGraph] GraphExecSegmented::Run: launch stream device %d does not match capture device %d",
-      launch_stream->DeviceId(), captureDeviceId_);
-    status = hipErrorInvalidValue;
+
+    last_cmd = EnqueueSegmentedGraph(graph_stream, streams_, &status, &launch_signal_set);
+    if (status == hipSuccess && last_cmd != nullptr) {
+      amd::Command::EventWaitList completion_wait_list;
+      completion_wait_list.push_back(last_cmd);
+
+      auto* launch_done = new amd::Marker(*launch_stream, kMarkerDisableFlush, completion_wait_list);
+      launch_done->enqueue();
+      // The launch stream queue owns this marker now. Keep last_cmd as the
+      // capture-device completion command that drives graph resource cleanup.
+      launch_done->release();
+    } else if (status != hipSuccess) {
+      // Error path only: EnqueueSegmentedGraph may have queued partial work
+      // before failing. Drain the capture-device streams before the common
+      // cleanup path can recycle launch signals or drop this exec reference.
+      for (auto* stream : streams_) {
+        if (stream != nullptr) {
+          stream->finish();
+        }
+      }
+    }
   }
+
+  // Drive OnLaunchComplete off this command's completion (its leaf-sync deps
+  // already imply all parallel work is done). Our reference is released after
+  // the callback is registered below; the queue keeps it alive until done.
+  completion_cmd = last_cmd;
   if (DEBUG_HIP_GRAPH_DOT_PRINT == 2 && !graph_dumped_) {
     graph_dumped_ = true;
     std::string filename =
@@ -3151,7 +3215,7 @@ hipError_t GraphExecSegmented::Run(hip::Stream* launch_stream) {
   amd::Command* CallbackCommand = completion_cmd;
   const bool own_callback_cmd = (CallbackCommand == nullptr);
   if (own_callback_cmd) {
-    CallbackCommand = new amd::Marker(*launch_stream, kMarkerDisableFlush, {});
+    CallbackCommand = new amd::Marker(*graph_launch_stream, kMarkerDisableFlush, {});
     // we may not need to flush any caches.
     CallbackCommand->setCommandEntryScope(amd::Device::kCacheStateIgnore);
   }
@@ -3159,7 +3223,7 @@ hipError_t GraphExecSegmented::Run(hip::Stream* launch_stream) {
   constexpr bool kBlocking = false;
   auto* cleanup = new GraphLaunchCleanup();
   cleanup->exec = this;
-  cleanup->device = g_devices[launch_stream->DeviceId()]->devices()[0];
+  cleanup->device = g_devices[captureDeviceId_]->devices()[0];
   cleanup->signal_set = std::move(launch_signal_set);
   if (!event.setCallback(CL_COMPLETE, GraphExecBase::OnLaunchComplete, cleanup, kBlocking)) {
     // setCallback essentially never fails, but if it does the launch's GPU work
@@ -3167,7 +3231,7 @@ hipError_t GraphExecSegmented::Run(hip::Stream* launch_stream) {
     // its signals). Drain that work, then run the same completion handling the
     // callback would have (recycle the borrowed pooled signals + drop our
     // reference) so they are not leaked and the pool does not shrink.
-    launch_stream->finish();
+    graph_launch_stream->finish();
     OnLaunchComplete(nullptr, CL_COMPLETE, cleanup);
     CallbackCommand->release();
     return hipErrorInvalidHandle;

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1083,7 +1083,8 @@ class GraphExecBase : public amd::ReferenceCountedObject, public Graph {
   hipError_t CreateStreams(uint32_t num_streams, int devId);
   //! Compute per-device stream requirements from streams_dev_ids_ mappings
   void FindStreamsReqPerDev();
-  //! Update streams_[0] to the launch stream and resolve HW queue collisions
+  //! Update streams_ for a launch and resolve HW queue collisions.
+  //! If launch_stream is null, streams_ is built from captureDeviceId_ internal streams only.
   void UpdateStreams(hip::Stream* launch_stream);
 };
 

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -112,8 +112,7 @@ graph:
   Unit_hipGraphInstantiateWithFlags_DependencyGraphDeviceCtxtChg:
     <<: *level_2
     tags: [lifecycle, multigpu]
-    # Enable the below test when multi-device graph launches are fully supported
-    disabled: [amd_linux, amd_wsl]
+    disabled: [amd_wsl]
   Unit_hipGraphInstantiateWithFlags_StreamCapture:
     <<: *level_2
     tags: [lifecycle, multigpu]
@@ -1391,9 +1390,8 @@ graph:
   Unit_hipGraphUpload_Functional_multidevice_test:
     <<: *level_2
     tags: [exec]
-    # (amd_linux) SWDEV-553920 disabled until multi device graph issues are resolved
     # (amd_windows) SWDEV-446588 - Disable graph multi gpu testcases until graph has support for it
-    disabled: [amd_linux, amd_windows, amd_wsl]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipGraphUpload_Functional_With_Priority_Stream:
     <<: *level_2
     tags: [exec]
@@ -1402,6 +1400,14 @@ graph:
     # SWDEV-434878: Below tests failed in stress test on 24/11/23
     disabled: [amd_windows, amd_wsl]
     tags: [exec]
+  Unit_hipGraphCrossDeviceLaunch_CrossStreamDependencyOrdering:
+    <<: *level_2
+    tags: [exec]
+    disabled: [amd_windows]
+  Unit_hipGraphCrossDeviceLaunch_ExplicitNodes:
+    <<: *level_2
+    tags: [exec]
+    disabled: [amd_windows]
   Unit_hipGraphKernelNodeCopyAttributes_Functional:
     <<: *level_2
     tags: [node]

--- a/projects/hip-tests/catch/unit/graph/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/graph/CMakeLists.txt
@@ -131,6 +131,7 @@ set(TEST_SRC
   hipGraphNodeGetEnabled.cc
   hipGraphExecDestroy.cc
   hipGraphUpload.cc
+  hipGraphCrossDeviceLaunch.cc
   hipGraphKernelNodeCopyAttributes.cc
   hipGraphCycle.cc
   hipGraphPerf.cc
@@ -146,6 +147,7 @@ set(TEST_SRC
   hipDeviceGetGraphMemAttribute.cc
   hipDeviceGraphMemTrim.cc
   hipDrvGraphExecMemsetNodeSetParams.cc
+  hipGraphMultiDevice.cc
 )
 
 if(HIP_PLATFORM MATCHES "amd")

--- a/projects/hip-tests/catch/unit/graph/hipGraphCrossDeviceLaunch.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphCrossDeviceLaunch.cc
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Tests for hipGraphLaunch when the launch stream's device differs from the
+ * device on which the graph was instantiated (cross-device launch). This
+ * exercises segmented replay on capture-device streams and the dependency
+ * bridging required to preserve ordering with the foreign launch stream.
+ */
+
+#include <hip_test_common.hh>
+#include <hip_test_checkers.hh>
+#include <hip_test_kernels.hh>
+#include <utils.hh>
+
+// ---------------------------------------------------------------------------
+// Helper: set up a cross-device launch context.
+// launch_stream - created on launch_dev (caller-owned)
+// ---------------------------------------------------------------------------
+static void setupCrossDeviceStream(int inst_dev, int launch_dev, hipStream_t& launch_stream) {
+  HIP_CHECK(hipSetDevice(launch_dev));
+  HIP_CHECK(hipStreamCreate(&launch_stream));
+  HIP_CHECK(hipSetDevice(inst_dev));
+}
+
+struct HostCheckContext {
+  int* value = nullptr;
+  int expected = 0;
+  int observed = 0;
+};
+
+static void recordHostValue(void* user_data) {
+  auto* context = reinterpret_cast<HostCheckContext*>(user_data);
+  context->observed = *context->value;
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Cross-stream dependency ordering: a host node on the launch-device stream depends on work
+ *    dispatched to the instantiate-device stream. The host node observes a D2H result that is only
+ *    valid if the kernel and memcpy dependencies completed first.
+ * ------------------------
+ *  - catch/unit/graph/hipGraphCrossDeviceLaunch.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.2
+ *  - Multi-device
+ */
+HIP_TEST_CASE(Unit_hipGraphCrossDeviceLaunch_CrossStreamDependencyOrdering) {
+  int nGpus = 0;
+  HIP_CHECK(hipGetDeviceCount(&nGpus));
+  if (nGpus < 2) HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+
+  hipStream_t launch_stream;
+  setupCrossDeviceStream(1, 0, launch_stream);
+
+  HIP_CHECK(hipSetDevice(1));
+  hipGraph_t graph = nullptr;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+  int* d_value = nullptr;
+  HIP_CHECK(hipMalloc(&d_value, sizeof(int)));
+  int h_value = 0;
+
+  constexpr int expected_value = 1234;
+  hipGraphNode_t set_node = nullptr;
+  hipKernelNodeParams set_params{};
+  int set_value = expected_value;
+  size_t count = 1;
+  void* set_args[] = {&d_value, &set_value, &count};
+  set_params.func = reinterpret_cast<void*>(VectorSet<int>);
+  set_params.gridDim = dim3(1);
+  set_params.blockDim = dim3(1);
+  set_params.kernelParams = reinterpret_cast<void**>(set_args);
+  HIP_CHECK(hipGraphAddKernelNode(&set_node, graph, nullptr, 0, &set_params));
+
+  hipGraphNode_t memcpy_node = nullptr;
+  HIP_CHECK(hipGraphAddMemcpyNode1D(&memcpy_node, graph, &set_node, 1, &h_value, d_value,
+                                    sizeof(int), hipMemcpyDeviceToHost));
+
+  HostCheckContext context;
+  context.value = &h_value;
+  context.expected = expected_value;
+  hipGraphNode_t host_node = nullptr;
+  hipHostNodeParams host_params = {0, 0};
+  host_params.fn = recordHostValue;
+  host_params.userData = &context;
+
+  HIP_CHECK(hipSetDevice(0));
+  HIP_CHECK(hipGraphAddHostNode(&host_node, graph, &memcpy_node, 1, &host_params));
+
+  HIP_CHECK(hipSetDevice(1));
+  hipGraphExec_t graph_exec = nullptr;
+  HIP_CHECK(hipGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
+
+  HIP_CHECK(hipSetDevice(0));
+  HIP_CHECK(hipGraphLaunch(graph_exec, launch_stream));
+  HIP_CHECK(hipStreamSynchronize(launch_stream));
+
+  REQUIRE(context.observed == context.expected);
+
+  HIP_CHECK(hipGraphExecDestroy(graph_exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_value));
+  HIP_CHECK(hipStreamDestroy(launch_stream));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Explicit-node graph (hipGraphAdd*): verifies cross-device launch works
+ *    for graphs built via hipGraphAdd* rather than stream capture. These nodes
+ *    have stream_id_==-1, which previously caused an assertion failure in
+ *    RunNodes() when max_streams > 1; the cross-device branch must handle them.
+ * ------------------------
+ *  - catch/unit/graph/hipGraphCrossDeviceLaunch.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.2
+ *  - Multi-device
+ */
+HIP_TEST_CASE(Unit_hipGraphCrossDeviceLaunch_ExplicitNodes) {
+  int nGpus = 0;
+  HIP_CHECK(hipGetDeviceCount(&nGpus));
+  if (nGpus < 2) HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+
+  constexpr size_t N = 1024;
+  constexpr size_t Nbytes = N * sizeof(int);
+  constexpr auto blocksPerCU = 6;
+  constexpr auto threadsPerBlock = 256;
+
+  hipStream_t launch_stream;
+  setupCrossDeviceStream(1, 0, launch_stream);
+
+  HIP_CHECK(hipSetDevice(1));
+  int *A_d, *B_d, *C_d;
+  int *A_h, *B_h, *C_h;
+  HipTest::initArrays(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, N, false);
+  unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, N);
+
+  hipGraph_t graph = nullptr;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  hipGraphNode_t memcpy_A, memcpy_B, kernel_node, memcpy_C;
+  HIP_CHECK(hipGraphAddMemcpyNode1D(&memcpy_A, graph, nullptr, 0, A_d, A_h, Nbytes,
+                                    hipMemcpyHostToDevice));
+  HIP_CHECK(hipGraphAddMemcpyNode1D(&memcpy_B, graph, nullptr, 0, B_d, B_h, Nbytes,
+                                    hipMemcpyHostToDevice));
+
+  size_t NElem = N;
+  void* kernelArgs[] = {&A_d, &B_d, &C_d, reinterpret_cast<void*>(&NElem)};
+  hipKernelNodeParams kNodeParams{};
+  kNodeParams.func = reinterpret_cast<void*>(HipTest::vectorADD<int>);
+  kNodeParams.gridDim = dim3(blocks);
+  kNodeParams.blockDim = dim3(threadsPerBlock);
+  kNodeParams.kernelParams = reinterpret_cast<void**>(kernelArgs);
+  HIP_CHECK(hipGraphAddKernelNode(&kernel_node, graph, nullptr, 0, &kNodeParams));
+
+  HIP_CHECK(hipGraphAddMemcpyNode1D(&memcpy_C, graph, nullptr, 0, C_h, C_d, Nbytes,
+                                    hipMemcpyDeviceToHost));
+
+  HIP_CHECK(hipGraphAddDependencies(graph, &memcpy_A, &kernel_node, 1));
+  HIP_CHECK(hipGraphAddDependencies(graph, &memcpy_B, &kernel_node, 1));
+  HIP_CHECK(hipGraphAddDependencies(graph, &kernel_node, &memcpy_C, 1));
+
+  HIP_CHECK(hipSetDevice(1));
+  hipGraphExec_t graph_exec = nullptr;
+  HIP_CHECK(hipGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
+
+  HIP_CHECK(hipSetDevice(0));
+  HIP_CHECK(hipGraphLaunch(graph_exec, launch_stream));
+  HIP_CHECK(hipStreamSynchronize(launch_stream));
+
+  HipTest::checkVectorADD(A_h, B_h, C_h, N);
+
+  HipTest::freeArrays(A_d, B_d, C_d, A_h, B_h, C_h, false);
+  HIP_CHECK(hipGraphExecDestroy(graph_exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipStreamDestroy(launch_stream));
+}
+

--- a/projects/hip-tests/catch/unit/graph/hipGraphMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMultiDevice.cc
@@ -54,6 +54,14 @@ HIP_TEST_CASE(Unit_hipGraphMultiDevice) {
   if (nGpus < 2) {
     HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
+  int can_access_peer = 0;
+  HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, 1, 0));
+  if (!can_access_peer) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+  }
+  HIP_CHECK(hipSetDevice(1));
+  HIP_CHECK(hipDeviceEnablePeerAccess(0, 0));
+
   hipStream_t streamdev1, streamdev2;
   hipEvent_t eventdev1, eventdev2;
   hipGraph_t graph = nullptr;
@@ -89,14 +97,15 @@ HIP_TEST_CASE(Unit_hipGraphMultiDevice) {
   HipTest::vector_square<int>
       <<<grid_size, block_size, 0, streamdev1>>>(buf_d1, buf_d1, buffer_size);
   HIP_CHECK(hipEventRecord(eventdev1, streamdev1));
-  HIP_CHECK(hipStreamWaitEvent(streamdev2, eventdev1));
+  HIP_CHECK(hipStreamWaitEvent(streamdev2, eventdev1, 0));
 
   HIP_CHECK(hipSetDevice(1));
-  HIP_CHECK(hipMemcpyDtoDAsync(buf_d2, buf_d1, sizeof(int) * buffer_size, streamdev2));
+  HIP_CHECK(
+      hipMemcpyAsync(buf_d2, buf_d1, sizeof(int) * buffer_size, hipMemcpyDeviceToDevice, streamdev2));
   HipTest::vector_square<int>
       <<<grid_size, block_size, 0, streamdev2>>>(buf_d2, buf_d2, buffer_size);
   HIP_CHECK(hipEventRecord(eventdev2, streamdev2));
-  HIP_CHECK(hipStreamWaitEvent(streamdev1, eventdev2));
+  HIP_CHECK(hipStreamWaitEvent(streamdev1, eventdev2, 0));
 
   HIP_CHECK(hipStreamEndCapture(streamdev1, &graph));
 
@@ -106,7 +115,7 @@ HIP_TEST_CASE(Unit_hipGraphMultiDevice) {
   HIP_CHECK(hipStreamSynchronize(streamdev1));
 
   HIP_CHECK(hipSetDevice(1));
-  HIP_CHECK(hipMemcpy(outbuf_h, buf_d2, sizeof(int) * buffer_size, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(outbuf_h, buf_d2, sizeof(int) * buffer_size, hipMemcpyDeviceToHost));
   check_output(ibuf_h, outbuf_h, buffer_size);
 
   HIP_CHECK(hipGraphExecDestroy(graph_exec));


### PR DESCRIPTION
## Motivation

Enable HIP graph launches where a graph is captured or instantiated on one GPU but launched from a stream on another GPU. The current segmented graph path rejected or mishandled this case after the classic graph execution path was removed, which blocked multidevice graph workflows such as hipGraphUpload with device context changes.

## Technical Details

This change implements cross-device launch support in GraphExecSegmented by replaying segmented AQL on an internal stream from the graph capture device, rather than falling back to per-node classic execution or running graph packets on the foreign launch stream.

For cross-device launches, the runtime does next:

- Builds streams_ from capture-device internal streams via UpdateStreams(nullptr).
- Creates the full internal capture-device stream pool during graph exec initialization.
- Uses marker pairs to preserve ordering between the user launch stream and the capture-device graph stream before replay, and to make graph completion visible back on the user launch stream after replay.
- Keeps same-device launch behavior unchanged by exposing one fewer internal stream when the user launch stream occupies stream slot 0.
- Cleans up segmented internal streams in ~GraphExecSegmented.
- Enables relevant graph tests and adds focused cross-device graph launch coverage.

## JIRA ID

AIRUNTIME-572

## Test Plan
 Unit_hipGraphUpload_Functional_multidevice_test
 Unit_hipGraphCrossDeviceLaunch_CrossStreamDependencyOrdering
 Unit_hipGraphCrossDeviceLaunch_ExplicitNodes
 Unit_hipGraphLaunch_Functional_multidevice_test
 Unit_hipGraphInstantiateWithFlags_DependencyGraphDeviceCtxtChg
 Unit_hipGraphExecUpdate_Negative_MultiDevice_Context_Changed
 Unit_hipDeviceGetGraphMemAttribute_Functional_Multi_Device
 Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_MultiDevice
 Unit_hipGraphMultiDevice

## Test Result

Tests are passing on MI300.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
