### PR TITLE
rccl: add CAST environment variables to docs

### DIFF
--- a/projects/rccl/docs/api-reference/env-variables.rst
+++ b/projects/rccl/docs/api-reference/env-variables.rst
@@ -223,6 +223,13 @@ in the following table.
       - | Integer value in bytes (default: ``128``)
         | ``N``: Split only when message size >= N bytes
 
+    * - | ``NCCL_IB_SPLIT_DATA_ON_QPS``
+        | Controls how multiple QPs are used when more than one QP is
+          configured per connection.
+      - | ``0``: Round-robin mode (default). Each message is sent on a single
+          QP, cycling through available QPs across messages.
+        | ``1``: Split mode. Each message is split evenly across all QPs.
+
     * - | ``NCCL_RINGS``
         | Defines custom ring topology.
       - | Ring topology specification string
@@ -237,6 +244,76 @@ in the following table.
         | Controls ring remapping for specific topologies.
       - | Remapping specification string
         | Used with Rome 4P2H topology
+
+QP scheduling (CAST)
+==============================
+
+CAST (Congestion Aware Sprayed Traffic) adds a dynamic QP (Queue Pair) scheduler
+that balances RDMA traffic across multiple QPs per connection based on measured
+round-trip time (RTT). The following variables tune the scheduler and are
+accessible with either the ``RCCL_`` or ``NCCL_`` prefix; the ``RCCL_`` form is
+shown below.
+
+These variables only take effect when the CAST QP scheduler is active.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40,60
+
+    * - **Environment variable**
+      - **Values**
+
+    * - | ``RCCL_IB_QP_SCHED_ENABLE``
+        | Enables the CAST QP scheduler.
+      - | ``-1``: Auto (default). Disabled unless ``NCCL_NET=IB-CAST`` is set,
+          which forces it on. Can be explicitly overridden regardless of
+          ``NCCL_NET``.
+        | ``0``: Force off.
+        | ``1``: Force on.
+
+    * - | ``RCCL_IB_QP_SCHED_WRR_ENABLE``
+        | Enables Weighted Round-Robin (WRR) scheduling within the QP scheduler.
+      - | ``0``: Disabled.
+        | ``1``: Enabled (default).
+
+    * - | ``RCCL_IB_QP_SCHED_RESET_INTERVAL``
+        | Interval at which accumulated RTT statistics are reset, to prevent
+          stale samples from permanently biasing the scheduler. Value is in
+          milliseconds.
+      - | Integer milliseconds. Default: ``60000`` (60 seconds).
+        | ``0``: Never reset.
+
+    * - | ``RCCL_IB_QP_SCHED_UPDATE_INTERVAL``
+        | Minimum interval between scheduler weight updates. Value is in
+          microseconds.
+      - | Integer microseconds. Default: ``50``.
+        | Clamped to the range 1 µs to 60 s; out-of-range values are ignored.
+
+    * - | ``RCCL_IB_QP_SCHED_WEIGHT``
+        | Exponential moving average (EMA) weight applied to new RTT samples.
+      - | Floating-point value in the range ``0`` to ``1.0``. Default: ``0``.
+        | ``0``: Simple average.
+        | Values closer to ``1.0`` react faster to recent samples.
+
+    * - | ``RCCL_IB_QP_SCHED_SPLIT_DATA_MIN``
+        | Minimum chunk size when splitting a message across QPs (split-data
+          mode, enabled via ``NCCL_IB_SPLIT_DATA_ON_QPS``). Value is in bytes.
+      - | Integer bytes. Default: ``65536``.
+        | Only positive values are applied.
+
+    * - | ``RCCL_IB_QP_SCHED_LOG_PATH``
+        | Directory for per-QP scheduler log files (RTT samples, computed
+          weights, token allocations). Log files are named
+          ``cast_log_<hostname>_<pid>``.
+      - | String directory path.
+        | Default: unset (logging disabled).
+
+    * - | ``RCCL_IB_QP_SCHED_LOG_INTERVAL``
+        | Interval at which scheduler statistics are written to the log file.
+          Value is in microseconds. Only used when
+          ``RCCL_IB_QP_SCHED_LOG_PATH`` is set.
+      - | Integer microseconds. Default: ``1000000`` (1 second).
+        | Clamped to the range 1 µs to 60 s; out-of-range values are ignored.
 
 Development and testing (advanced)
 ==================================


### PR DESCRIPTION
## Motivation

This pull request adds documentation for the CAST (Congestion aware sprayed traffic) QP (Queue Pair) scheduler in the RCCL library. These variables allow users to tune the scheduler's operation, logging, and message distribution modes.

**QP scheduling (CAST) documentation:**

* Added a new section describing the CAST QP scheduler, its purpose, and how it balances RDMA traffic using measured RTT.
* Documented all CAST-related environment variables (with `RCCL_` or `NCCL_` prefixes), including enabling/disabling the scheduler, WRR scheduling, intervals for statistics reset and update, EMA weighting, minimum split size, logging options, and message distribution modes.
* Clarified default values, valid ranges, and the effect of each variable, making it easier for users to configure and troubleshoot the scheduler.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

JIRA ID AICOMNET-37

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
