### PR TITLE
fix(rccl): Enable fabric handles in ncclMemAlloc_impl

### DIFF
--- a/projects/rccl/src/allocator.cc
+++ b/projects/rccl/src/allocator.cc
@@ -36,13 +36,16 @@ ncclResult_t  ncclMemAlloc_impl(void **ptr, size_t size) {
 
   if (ncclCuMemEnable()) {
     size_t handleSize = size;
-    int requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
-#if CUDART_VERSION >= 12030
-    // Query device to see if FABRIC handle support is available
-    flag = 0;
-    (void) CUPFN(cuDeviceGetAttribute(&flag, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED, currentDev));
-    if (flag) requestedHandleTypes |= CU_MEM_HANDLE_TYPE_FABRIC;
-#endif
+    int requestedHandleTypes = ncclCuMemHandleType;
+    if (requestedHandleTypes == CU_MEM_HANDLE_TYPE_FABRIC) {
+      flag = 0;
+      // Check if the device supports FABRIC handles, if not, fall back to POSIX
+      CUresult err = CUPFN(cuDeviceGetAttribute(&flag, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED, currentDev));
+      if (err != CUDA_SUCCESS || !flag) {
+        WARN("ncclMemAlloc: device %d has no FABRIC handles support, falling back to POSIX", cudaDev);
+        requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+      }
+    }
 #if defined(HIP_VMM_UNCACHED_MEMORY)
     memprop.type = hipMemAllocationTypeUncached;
 #else
@@ -66,25 +69,8 @@ ncclResult_t  ncclMemAlloc_impl(void **ptr, size_t size) {
     CUDACHECK(cudaGetDeviceCount(&dcnt));
     ALIGN_SIZE(handleSize, memGran);
 
-#if CUDART_VERSION >= 12030
-    if (requestedHandleTypes & CU_MEM_HANDLE_TYPE_FABRIC) {
-      /* First try cuMemCreate() with FABRIC handle support and then remove if it fails */
-      CUresult err = CUPFN(cuMemCreate(&handle, handleSize, &memprop, 0));
-      if (err == CUDA_ERROR_NOT_SUPPORTED) {
-        requestedHandleTypes &= ~CU_MEM_HANDLE_TYPE_FABRIC;
-        memprop.requestedHandleTypes = (CUmemAllocationHandleType) requestedHandleTypes;
-        /* Allocate the physical memory on the device */
-        CUCHECK(cuMemCreate(&handle, handleSize, &memprop, 0));
-      } else if (err != CUDA_SUCCESS) {
-        // Catch and report any error from above
-        CUCHECK(cuMemCreate(&handle, handleSize, &memprop, 0));
-      }
-    } else
-#endif
-    {
-      /* Allocate the physical memory on the device */
-      CUCHECK(cuMemCreate(&handle, handleSize, &memprop, 0));
-    }
+    /* Allocate the physical memory on the device */
+    CUCHECK(cuMemCreate(&handle, handleSize, &memprop, 0));
     /* Reserve a virtual address range */
     CUCHECK(cuMemAddressReserve((CUdeviceptr*)ptr, handleSize, memGran, 0, 0));
     /* Map the virtual address range to the physical allocation */

--- a/projects/rccl/test/AllocHandleTypeTests.cpp
+++ b/projects/rccl/test/AllocHandleTypeTests.cpp
@@ -1,0 +1,87 @@
+/*************************************************************************
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include <gtest/gtest.h>
+#include <rccl/rccl.h>
+
+#include <cstring>
+
+#include "common/ProcessIsolatedTestRunner.hpp"
+
+namespace RcclUnitTesting
+{
+namespace {
+
+// Mirror hipified p2p.h / allocator.cc: fabric uses int sentinel 0x8, attr probe uses 128.
+constexpr int kFabricHandleTypeInt = 0x8;
+constexpr int kFabricAttrInt       = 128;
+
+int resolveMemAllocHandleType(
+    int fabricHandleType, int requested, hipError_t attrErr, int fabricSupported)
+{
+    if(requested == fabricHandleType)
+    {
+        if(attrErr != hipSuccess || !fabricSupported)
+        {
+            return static_cast<int>(hipMemHandleTypePosixFileDescriptor);
+        }
+    }
+    return requested;
+}
+
+} // namespace
+
+#if ROCM_VERSION >= 70000
+// Mirrors ncclMemAlloc_impl handle resolution: gfx1250 keeps FABRIC when supported;
+// all other arches fall back to POSIX. Uses only public HIP/RCCL APIs so this runs
+// in Release via rccl-UnitTestsFixtures (no librccl internal symbols).
+TEST(Alloc, NcclMemAlloc_HandleTypeByArch)
+{
+    RUN_ISOLATED_TEST(
+        "NcclMemAlloc_HandleTypeByArch",
+        []()
+        {
+            ASSERT_EQ(setenv("NCCL_CUMEM_ENABLE", "1", 1), 0);
+            ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+            hipDeviceProp_t prop{};
+            ASSERT_EQ(hipGetDeviceProperties(&prop, 0), hipSuccess);
+            const bool gfx1250 = strncmp(prop.gcnArchName, "gfx1250", 7) == 0;
+
+            int              fabricSupported = 0;
+            const hipError_t attrErr         = hipDeviceGetAttribute(
+                &fabricSupported,
+                static_cast<hipDeviceAttribute_t>(kFabricAttrInt),
+                0);
+
+            const int fabricHandleType    = kFabricHandleTypeInt;
+            const int requestedHandleType = resolveMemAllocHandleType(
+                fabricHandleType, fabricHandleType, attrErr, fabricSupported);
+
+            if(gfx1250)
+            {
+                EXPECT_EQ(attrErr, hipSuccess);
+                EXPECT_NE(fabricSupported, 0);
+                EXPECT_EQ(requestedHandleType, fabricHandleType);
+            }
+            else
+            {
+                EXPECT_EQ(requestedHandleType,
+                          static_cast<int>(hipMemHandleTypePosixFileDescriptor))
+                    << "Non-gfx1250 arch " << prop.gcnArchName
+                    << " must use POSIX handles";
+            }
+
+            void*        ptr    = nullptr;
+            const size_t kBytes = 4096;
+            ASSERT_EQ(ncclMemAlloc(&ptr, kBytes), ncclSuccess);
+            ASSERT_NE(ptr, nullptr);
+            ASSERT_EQ(ncclMemFree(ptr), ncclSuccess);
+        }
+    );
+}
+#endif // ROCM_VERSION >= 70000
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/AllocTests.cpp
+++ b/projects/rccl/test/AllocTests.cpp
@@ -8,6 +8,8 @@
 #include <gtest/gtest.h>
 #include <rccl/rccl.h>
 
+#include <cstring>
+
 #include "TestBed.hpp"
 #include "common/ErrCode.hpp"
 #include "common/ProcessIsolatedTestRunner.hpp"
@@ -237,4 +239,5 @@ TEST(Alloc, MemcpyNullSrcOrDstPointer)
         }
     );
 }
+
 } // namespace RcclUnitTesting

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -232,6 +232,7 @@ if(BUILD_TESTS)
     list(APPEND RCCL_TEST_EXECUTABLES rccl-UnitTestsFixtures)
 
     set(TEST_FIXTURE_SOURCE_FILES
+      AllocHandleTypeTests.cpp
       BitOpsTests.cpp
       IommuPassthrough_test.cpp
       MiscTests.cpp


### PR DESCRIPTION
## Motivation

In this PR, we enable the Fabric handles by default in ncclMemAlloc_impl. On devices that do not support Fabric, the implementation automatically falls back to the POSIX file descriptor handle type. This approach is required because HIP does not support a combined handle-type bitmask like CUDA.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AICOMRCCL-928

## Test Plan

The changes got tested in MI355 to make sure it's functional.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
