### PR TITLE
ci(rocprofiler-systems): Increase roctx-runtime-instrument timeout to 300

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/test_roctx.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_roctx.py
@@ -99,6 +99,7 @@ class TestROCTx(RocprofsysTest):
         return [1, 1, 1, 0, 0, 1, 1, 1]
 
     BINARY_REWRITE_ARGS = ["-e", "-v", "2", "--instrument-loops"]
+    RUNTIME_INSTRUMENT_ARGS = ["-v", "2"]
 
     @pytest.mark.parametrize(
         "mode",
@@ -106,7 +107,7 @@ class TestROCTx(RocprofsysTest):
             pytest.param("baseline", marks=pytest.mark.timeout(120)),
             pytest.param("binary_rewrite", marks=pytest.mark.timeout(120)),
             pytest.param("sys_run", marks=pytest.mark.timeout(120)),
-            pytest.param("runtime_instrument", marks=pytest.mark.timeout(180)),
+            pytest.param("runtime_instrument", marks=pytest.mark.timeout(300)),
         ],
     )
     def test(self, mode, roctx_env):
@@ -115,6 +116,7 @@ class TestROCTx(RocprofsysTest):
             "roctx",
             env=roctx_env,
             binary_rewrite_args=self.BINARY_REWRITE_ARGS,
+            runtime_instrument_args=self.RUNTIME_INSTRUMENT_ARGS,
             check_target_arch=True,
         )
         self.assert_regex(result)


### PR DESCRIPTION
Fixes Issue: #8543 

## Motivation

Closes #8543 

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

When `OMP_NUM_THREADS` is set to `0` or `1`, dyninst takes much longer to create the process and parse the shared libraries. On my system, it takes `120` seconds for `roctx-runtime-instrument` to finish. On TheRock CI, machine load pushes this past the `180` seconds timeout.

Increasing the timeout to `300` seconds would solve this issue as the `transpose-runtime-instrument` test, which also pulls in `libLLVM.so` and `libclang-cpp.so`, takes ~`200` seconds to run.

## Technical Details

 - Increase timeout of `roctx-runtime-instrument` test to 300
 - Add `-v 2` to the test to see timing information and more logs.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Workflows
Locally on TheRock with `OMP_NUM_THREADS=0`.

## Test Result

<!-- Briefly summarize test outcomes. -->

Workflows - See below
Locally: Passes in `120` seconds. On TheRock CI runner, it will probably pass in `300` seconds.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
