### PR TITLE
fix(rocshmem): install test binaries to CMAKE_INSTALL_BINDIR

### DIFF
--- a/projects/rocshmem/tests/functional_tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/functional_tests/CMakeLists.txt
@@ -110,7 +110,7 @@ target_compile_definitions(
 
 configure_file(../../scripts/functional_tests/driver.sh rocshmem_functional_driver.sh COPYONLY)
 rocm_install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/rocshmem_functional_driver.sh COMPONENT tests DESTINATION ${CMAKE_INSTALL_DATADIR}/rocshmem)
-install(TARGETS rocshmem_functional_tests COMPONENT tests RUNTIME DESTINATION ${CMAKE_INSTALL_DATADIR}/rocshmem)
+install(TARGETS rocshmem_functional_tests COMPONENT tests RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 target_link_libraries(
   ${PROJECT_NAME}
@@ -159,6 +159,31 @@ rocm_install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.sh
 # Include CTest-based functional tests
 # Set BUILD_CTESTS=ON to register all tests (can be slow for large test suites)
 # By default, only the shell script is installed for compatibility
+if(BUILD_CTESTS)
+    # Probe for Python3 + PyYAML before registering tests. Tests rely on
+    # test_categories.yaml for tier labels (quick/standard/comprehensive/full);
+    # without those labels they would be invisible to `ctest -L <tier>` in CI.
+    find_package(Python3 COMPONENTS Interpreter QUIET)
+    if(NOT Python3_FOUND)
+        message(WARNING
+            "Python3 not found — skipping CTest functional test registration. "
+            "Tests require PyYAML to apply tier labels from test_categories.yaml.")
+        set(BUILD_CTESTS OFF CACHE BOOL "CTests disabled: Python3 not found" FORCE)
+    else()
+        execute_process(
+            COMMAND ${Python3_EXECUTABLE} -c "import yaml"
+            RESULT_VARIABLE _pyyaml_result
+            ERROR_QUIET)
+        if(NOT _pyyaml_result EQUAL 0)
+            message(WARNING
+                "PyYAML not found for '${Python3_EXECUTABLE}' — skipping CTest functional "
+                "test registration. Tests require PyYAML to apply tier labels from "
+                "test_categories.yaml. Install with: pip install pyyaml")
+            set(BUILD_CTESTS OFF CACHE BOOL "CTests disabled: PyYAML not found" FORCE)
+        endif()
+    endif()
+endif()
+
 if(BUILD_CTESTS)
     message(STATUS "Registering CTest-based functional tests")
     include(${CMAKE_CURRENT_SOURCE_DIR}/CTestFunctionalTests.cmake OPTIONAL)

--- a/projects/rocshmem/tests/functional_tests/CTestFunctionalInstall.cmake.in
+++ b/projects/rocshmem/tests/functional_tests/CTestFunctionalInstall.cmake.in
@@ -6,7 +6,7 @@
 # This file registers functional tests using installed binaries and scripts.
 # Test commands use relative paths from the working directory:
 #   - Wrapper script: ../../../../share/rocshmem/test_wrapper.sh
-#   - Test executable: ../../../../share/rocshmem/rocshmem_functional_tests
+#   - Test executable: ../../../rocshmem_functional_tests  (installed to bin/)
 #   - MPI paths are absolute (found at build configure time)
 #
 # Note: Test definitions are generated during CMake configuration

--- a/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
+++ b/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
@@ -229,9 +229,9 @@ function(write_install_test_definition TEST_NAME TEST_COMMAND TEST_LABELS TEST_T
             # Relative from working dir: ../../../../share/rocshmem/test_wrapper.sh
             list(APPEND INSTALL_CMD_PARTS "../../../../share/rocshmem/test_wrapper.sh")
         elseif("${part}" STREQUAL "$<TARGET_FILE:rocshmem_functional_tests>")
-            # Executable is at: <install>/share/rocshmem/rocshmem_functional_tests
-            # Relative from working dir: ../../../../share/rocshmem/rocshmem_functional_tests
-            list(APPEND INSTALL_CMD_PARTS "../../../../share/rocshmem/rocshmem_functional_tests")
+            # Executable is at: <install>/bin/rocshmem_functional_tests
+            # Relative from working dir bin/rocshmem/tests/functional: ../../../rocshmem_functional_tests
+            list(APPEND INSTALL_CMD_PARTS "../../../rocshmem_functional_tests")
         elseif("${part}" STREQUAL "${CMAKE_COMMAND}")
             # Replace build-host cmake path with portable system env
             # This prevents build-host absolute paths from leaking into install files

--- a/projects/rocshmem/tests/unit_tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/unit_tests/CMakeLists.txt
@@ -143,7 +143,7 @@ FetchContent_MakeAvailable(googletest)
 
 configure_file(../../scripts/unit_tests/driver.sh rocshmem_unit_driver.sh COPYONLY)
 rocm_install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/rocshmem_unit_driver.sh COMPONENT tests DESTINATION ${CMAKE_INSTALL_DATADIR}/rocshmem)
-install(TARGETS rocshmem_unit_tests COMPONENT tests RUNTIME DESTINATION ${CMAKE_INSTALL_DATADIR}/rocshmem)
+install(TARGETS rocshmem_unit_tests COMPONENT tests RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 target_link_libraries(
   ${PROJECT_NAME}
@@ -166,6 +166,31 @@ rocm_install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/unit_test_wrapper.sh
 
 # Include CTest-based unit tests
 # Set BUILD_CTESTS=ON to register unit tests
+if(BUILD_CTESTS)
+    # Probe for Python3 + PyYAML before registering tests. Tests rely on
+    # test_categories.yaml for tier labels (quick/standard/comprehensive/full);
+    # without those labels they would be invisible to `ctest -L <tier>` in CI.
+    find_package(Python3 COMPONENTS Interpreter QUIET)
+    if(NOT Python3_FOUND)
+        message(WARNING
+            "Python3 not found — skipping CTest unit test registration. "
+            "Tests require PyYAML to apply tier labels from test_categories.yaml.")
+        set(BUILD_CTESTS OFF CACHE BOOL "CTests disabled: Python3 not found" FORCE)
+    else()
+        execute_process(
+            COMMAND ${Python3_EXECUTABLE} -c "import yaml"
+            RESULT_VARIABLE _pyyaml_result
+            ERROR_QUIET)
+        if(NOT _pyyaml_result EQUAL 0)
+            message(WARNING
+                "PyYAML not found for '${Python3_EXECUTABLE}' — skipping CTest unit "
+                "test registration. Tests require PyYAML to apply tier labels from "
+                "test_categories.yaml. Install with: pip install pyyaml")
+            set(BUILD_CTESTS OFF CACHE BOOL "CTests disabled: PyYAML not found" FORCE)
+        endif()
+    endif()
+endif()
+
 if(BUILD_CTESTS)
     message(STATUS "Registering CTest-based unit tests")
     include(${CMAKE_CURRENT_SOURCE_DIR}/CTestUnitTests.cmake OPTIONAL)

--- a/projects/rocshmem/tests/unit_tests/CTestUnitInstall.cmake.in
+++ b/projects/rocshmem/tests/unit_tests/CTestUnitInstall.cmake.in
@@ -6,7 +6,7 @@
 # This file registers unit tests using installed binaries and scripts.
 # Test commands use relative paths from the working directory:
 #   - Wrapper script: ../../../../share/rocshmem/unit_test_wrapper.sh
-#   - Test executable: ../../../../share/rocshmem/rocshmem_unit_tests
+#   - Test executable: ../../../rocshmem_unit_tests  (installed to bin/)
 #   - MPI paths are absolute (found at build configure time)
 #
 # Note: Test definitions are generated during CMake configuration

--- a/projects/rocshmem/tests/unit_tests/CTestUnitTests.cmake
+++ b/projects/rocshmem/tests/unit_tests/CTestUnitTests.cmake
@@ -60,9 +60,9 @@ function(write_install_unit_test_definition TEST_NAME TEST_COMMAND TEST_LABELS T
             # Relative from working dir: ../../../../share/rocshmem/unit_test_wrapper.sh
             list(APPEND INSTALL_CMD_PARTS "../../../../share/rocshmem/unit_test_wrapper.sh")
         elseif("${part}" STREQUAL "$<TARGET_FILE:rocshmem_unit_tests>")
-            # Executable is at: <install>/share/rocshmem/rocshmem_unit_tests
-            # Relative from working dir: ../../../../share/rocshmem/rocshmem_unit_tests
-            list(APPEND INSTALL_CMD_PARTS "../../../../share/rocshmem/rocshmem_unit_tests")
+            # Executable is at: <install>/bin/rocshmem_unit_tests
+            # Relative from working dir bin/rocshmem/tests/unit: ../../../rocshmem_unit_tests
+            list(APPEND INSTALL_CMD_PARTS "../../../rocshmem_unit_tests")
         elseif("${part}" STREQUAL "${MPIEXEC_EXECUTABLE}")
             # Use the MPI executable found at configure time (absolute path)
             list(APPEND INSTALL_CMD_PARTS "${MPIEXEC_EXECUTABLE}")


### PR DESCRIPTION
## Motivation
Install rocshmem_functional_tests and rocshmem_unit_tests to
CMAKE_INSTALL_BINDIR instead of CMAKE_INSTALL_DATADIR/rocshmem so that
executables land in the standard binary directory and are found by the
monorepo CI CTest pass.

Also probe for Python3 and PyYAML before register_all_*_tests() in both
functional and unit CMakeLists. Without PyYAML, test_categories.yaml
cannot be parsed and tier labels (quick/standard/comprehensive/full) are
not applied, making tests invisible to `ctest -L <tier>` in CI. If
either is absent, emit a warning and skip registration entirely.

## JIRA ID

JIRA ID: AIROCSHMEM-340

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
