### PR TITLE
fix(clr): prepares for ocl32 build in the Rock

### DIFF
--- a/projects/clr/rocclr/cmake/ROCclr.cmake
+++ b/projects/clr/rocclr/cmake/ROCclr.cmake
@@ -93,9 +93,12 @@ if(WIN32)
   target_sources(rocclr PRIVATE
   ${ROCCLR_SRC_DIR}/platform/interop_d3d9.cpp
   ${ROCCLR_SRC_DIR}/platform/interop_d3d10.cpp
-  ${ROCCLR_SRC_DIR}/platform/interop_d3d11.cpp
-  ${ROCCLR_SRC_DIR}/device/rocm/rocd3d10interop.cpp
-  ${ROCCLR_SRC_DIR}/device/rocm/rocd3d11interop.cpp)
+  ${ROCCLR_SRC_DIR}/platform/interop_d3d11.cpp)
+  if(ROCCLR_ENABLE_HSA)
+    target_sources(rocclr PRIVATE
+    ${ROCCLR_SRC_DIR}/device/rocm/rocd3d10interop.cpp
+    ${ROCCLR_SRC_DIR}/device/rocm/rocd3d11interop.cpp)
+  endif()
   target_link_libraries(rocclr PRIVATE dxguid.lib)
   target_compile_definitions(rocclr PUBLIC ATI_OS_WIN)
 else()

--- a/projects/clr/rocclr/device/pal/palblit.cpp
+++ b/projects/clr/rocclr/device/pal/palblit.cpp
@@ -2268,18 +2268,22 @@ bool KernelBlitManager::fillBuffer(device::Memory& memory, const void* pattern, 
     uint16_t s0, s1, s2, s3;
   } counts = {static_cast<uint16_t>(head_count), static_cast<uint16_t>(body_count),
               static_cast<uint16_t>(body_tail_count), static_cast<uint16_t>(tail_count)};
-  static_assert(sizeof(size_t) == sizeof(uint64_t),
-                "Kernel arg passing assumes 64-bit size_t");
+  // Convert size_t to uint64_t for kernel arguments to support both 32-bit and 64-bit builds
+  uint64_t body_tile_count_arg = static_cast<uint64_t>(body_tile_count);
+  uint64_t body_tile_passes_arg = static_cast<uint64_t>(body_tile_passes);
+  uint64_t globalWorkSize_arg = static_cast<uint64_t>(globalWorkSize);
+  uint64_t patternSize_arg = static_cast<uint64_t>(patternSize);
+  uint64_t tail_offset_arg = static_cast<uint64_t>(tail_offset);
   setArgument(kernels_[kFillType], 0, sizeof(cl_mem), &mem, origin[0]);
   setArgument(kernels_[kFillType], 1, sizeof(cl_mem), &pGpuCB);
   setArgument(kernels_[kFillType], 2, sizeof(tiled_pattern), &tiled_pattern);
   setArgument(kernels_[kFillType], 3, sizeof(body_pattern), &body_pattern);
   setArgument(kernels_[kFillType], 4, sizeof(body_tail_pattern), &body_tail_pattern);
-  setArgument(kernels_[kFillType], 5, sizeof(body_tile_count), &body_tile_count);
-  setArgument(kernels_[kFillType], 6, sizeof(body_tile_passes), &body_tile_passes);
-  setArgument(kernels_[kFillType], 7, sizeof(globalWorkSize), &globalWorkSize /* stride */);
-  setArgument(kernels_[kFillType], 8, sizeof(patternSize), &patternSize);
-  setArgument(kernels_[kFillType], 9, sizeof(tail_offset), &tail_offset);
+  setArgument(kernels_[kFillType], 5, sizeof(body_tile_count_arg), &body_tile_count_arg);
+  setArgument(kernels_[kFillType], 6, sizeof(body_tile_passes_arg), &body_tile_passes_arg);
+  setArgument(kernels_[kFillType], 7, sizeof(globalWorkSize_arg), &globalWorkSize_arg /* stride */);
+  setArgument(kernels_[kFillType], 8, sizeof(patternSize_arg), &patternSize_arg);
+  setArgument(kernels_[kFillType], 9, sizeof(tail_offset_arg), &tail_offset_arg);
   setArgument(kernels_[kFillType], 10, sizeof(cl_mem), &mem, origin[0] + body_offset);
   setArgument(kernels_[kFillType], 11, sizeof(cl_mem), &mem, origin[0] + body_tail_offset);
   setArgument(kernels_[kFillType], 12, sizeof(cl_mem), &mem, origin[0] + tail_offset);


### PR DESCRIPTION
## Motivation
enables ocl32 bit build

## Technical Details
assert size_t fails for ocl32 bit, this casts the size_t to uint64_t so it works for both 64 and 32 bit

rocd3d10interop.cpp, rocd3d11interop.cpp  include hsa headers so conditionally including them


## JIRA ID
JIRA ID : AIRUNTIME-2434

## Test Plan
all hip-tests should build/execute fine. No new tests

## Test Result
all hip-tests should build/execute fine. No new tests

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
