### PR TITLE
feat(systems-pr-bot): require PR testing declaration

### DIFF
--- a/docs/SYSTEMS_PR_BOT_FAQ.md
+++ b/docs/SYSTEMS_PR_BOT_FAQ.md
@@ -185,30 +185,34 @@ ______________________________________________________________________
 ## 🧪 Unit Test
 
 **What does it check?**
-PRs that change real source code must include at least one accompanying unit test.
+PRs that change real source code must include a **testing declaration** in the PR **description** that explains, per changed code file, what changed and how it was tested. The bot only checks that the declaration is **present and well-formed** — it does **not** verify that the referenced tests exist, run any commands, or inspect test contents.
 
 **Rules**
 
 - **Doc / config-only PRs are exempt.** If your PR only touches files like
-  `.md`, `.txt`, `.yml`, `.yaml`, `.ini`, the check **passes automatically** — no test required.
-- **Code PRs require a test.** If your PR changes source files such as
-  `.py`, `.cpp`, `.cc`, `.c`, `.h`, `.js`, `.ts`, `.go`, `.java`, it must also
-  include changes to a test file (a new test, or edits to an existing one).
+  `.md`, `.txt`, `.yml`, `.yaml`, `.ini`, the check **passes automatically** — no declaration required.
+- **Code PRs require a declaration.** If your PR changes source files such as
+  `.py`, `.cpp`, `.cc`, `.c`, `.h`, `.js`, `.ts`, `.go`, `.java`, the PR description must contain a `## Testing` section with one entry per changed code file.
+- Each entry needs a non-empty **Description** and a **Tests** list with **at least one** item. Removed files are ignored.
 
-**How a test file is recognised**
+**Declaration format**
 
-| Pattern    | Example          |
-| ---------- | ---------------- |
-| `test_*`   | `test_parser.py` |
-| `*_test.*` | `parser_test.py` |
+Add this to your PR description (the marker line must appear exactly):
+
+<pre><code>&lt;!-- systems-pr-bot:testing:v1 --&gt;
+## Testing
+
+### File: `path/to/changed_file.cpp`
+- **Description:** Explain the behavior changed in this file.
+- **Tests:**
+  - `path/to/test_or_validation`
+  - `ctest --test-dir build -R relevant_test`
+</code></pre>
+
+Repeat the `### File:` block for every changed code file. The **Tests** items are free-form, human-readable references (a test path, a `ctest`/`pytest` command, a manual validation note, etc.) — they are treated as opaque text and are not executed or verified.
 
 **How to fix**
-Add a unit test for the code you changed, named `test_<something>`:
-
-```bash
-# example for Python
-touch tests/test_my_feature.py
-```
+Add the `## Testing` section above (including the exact `<!-- systems-pr-bot:testing:v1 -->` marker) to your PR description, with one `### File:` entry per changed code file, each with a Description and at least one Tests item.
 
 ______________________________________________________________________
 

--- a/tools/systems_pr_bot/policy.yml
+++ b/tools/systems_pr_bot/policy.yml
@@ -93,13 +93,19 @@ pr:
       # GitHub issue URL, e.g. https://github.com/org/repo/issues/123
       - '(?i)https?:\/\/github\.com\/[^\/\s]+\/[^\/\s]+\/issues\/\d+'
 
-  # Unit test requirement:
-  #   - Doc/config-only PRs (e.g. .md, .txt, .yml, .ini) never need a unit test
-  #     and PASS automatically.
-  #   - PRs that change real source code (.py, .cpp, .js, ...) must include at
-  #     least one accompanying test file (e.g. test_xxx.py, test_xxx.cpp).
+  # Unit test requirement (testing declaration):
+  #   - Doc/config-only PRs (e.g. .md, .txt, .yml, .ini) never need a testing
+  #     declaration and PASS automatically.
+  #   - PRs that change real source code (.py, .cpp, .js, ...) must include a
+  #     `## Testing` section in the PR DESCRIPTION that begins with the exact
+  #     marker `<!-- systems-pr-bot:testing:v1 -->` and declares, for every
+  #     changed code file, a `### File: `path`` entry with a non-empty
+  #     Description and a non-empty Tests list.
+  #   - The bot only checks that the declaration is PRESENT and well-formed. It
+  #     never verifies that the referenced tests exist, runs any command, or
+  #     inspects test contents. Test-list items are opaque human-readable text.
   unit_tests:
-    # Source/code file extensions that REQUIRE an accompanying unit test.
+    # Source/code file extensions that REQUIRE a testing declaration entry.
     code_extensions:
       - .py
       - .cpp
@@ -116,16 +122,9 @@ pr:
       - .java
       - .rb
       - .rs
-    # A changed file is treated as a unit test if its basename matches one of
-    # these glob patterns (e.g. test_parser.py, parser_test.cpp).
-    test_file_patterns:
-      - 'test_*'
-      - '*_test.*'
-    # Unit tests are required for source code ANYWHERE in the repository — there
-    # are NO folder-based exemptions. A test file may also live in any folder;
-    # it is recognised by its name (test_* / *_test.*), not its location.
-    # Doc/config files are still skipped by EXTENSION (they are simply not in
-    # `code_extensions`), not by path.
+    # Testing declarations are required for source code ANYWHERE in the repo —
+    # there are NO folder-based exemptions. Doc/config files are skipped by
+    # EXTENSION (they are simply not in `code_extensions`), not by path.
     exempt_paths: []
 
 diff:

--- a/tools/systems_pr_bot/policy_check.py
+++ b/tools/systems_pr_bot/policy_check.py
@@ -16,7 +16,7 @@ import re
 import sys
 import time
 import urllib.parse
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
@@ -24,6 +24,157 @@ import requests
 import yaml
 
 NOT_READY_LABEL = "Not ready to Review"
+
+# ---------------------------------------------------------------------------
+# Testing declaration (Unit Test policy)
+# ---------------------------------------------------------------------------
+# The Unit Test policy is satisfied by an explicit, human-authored declaration
+# in the PR DESCRIPTION rather than by test-filename heuristics. The bot only
+# verifies that the declaration is PRESENT and well-formed for every changed
+# code file — it never checks whether the referenced tests exist, runs any
+# command, or inspects test contents. Test-list items are opaque, non-empty
+# human-readable strings.
+TESTING_MARKER = "<!-- systems-pr-bot:testing:v1 -->"
+
+# A "### File: `path`" header (1-6 leading '#', optional backticks around path).
+_TESTING_FILE_HEADER_RE = re.compile(
+    r"^\s{0,3}#{1,6}\s+File\s*:\s*(?P<path>.+?)\s*$", re.IGNORECASE
+)
+# Any Markdown ATX header — used to detect the end of an entry.
+_TESTING_ANY_HEADER_RE = re.compile(r"^\s{0,3}#{1,6}\s+")
+# Top-level list item (0-1 leading spaces): the "Description:" / "Tests:" lines.
+_TESTING_TOP_LIST_RE = re.compile(r"^\s{0,1}[-*+]\s+(?P<content>.+?)\s*$")
+# Nested list item (2+ leading spaces): an individual Tests entry.
+_TESTING_NESTED_LIST_RE = re.compile(r"^\s{2,}[-*+]\s+(?P<item>.+?)\s*$")
+# "Label: rest" splitter (after emphasis characters are stripped).
+_TESTING_LABEL_RE = re.compile(r"^(?P<label>[A-Za-z ]+?)\s*:\s*(?P<rest>.*)$")
+
+
+@dataclass
+class TestingEntry:
+    """One declared file entry: a path, a description, and >=1 test items."""
+
+    path: str
+    description: str
+    tests: List[str] = field(default_factory=list)
+
+
+@dataclass
+class TestingDeclaration:
+    """Parsed result of the PR-body testing declaration.
+
+    - marker_present: whether the exact TESTING_MARKER was found.
+    - entries: normalized-path -> VALID entry (non-empty description + >=1 test).
+    - invalid_paths: declared paths that were malformed (empty description or no
+      tests) and have no other valid entry.
+    - duplicate_paths: paths declared more than once (last valid entry wins).
+    """
+
+    marker_present: bool
+    entries: Dict[str, "TestingEntry"]
+    invalid_paths: List[str]
+    duplicate_paths: List[str]
+
+
+def _strip_md_emphasis(text: str) -> str:
+    """Strip Markdown emphasis/code markers (`*`, backtick) for robust matching."""
+    return text.replace("*", "").replace("`", "").strip()
+
+
+def _normalize_declared_path(raw: str) -> str:
+    """Normalize a declared file path for comparison with changed-file paths."""
+    raw = (raw or "").strip()
+    raw = raw.strip("`").strip()
+    raw = _strip_md_emphasis(raw)
+    if not raw:
+        return ""
+    return Path(raw).as_posix().lstrip("./")
+
+
+def parse_testing_declarations(body: str) -> TestingDeclaration:
+    """Deterministically parse the PR-body testing declaration.
+
+    The parser is intentionally simple and marker-anchored. It NEVER evaluates
+    or trusts the content of descriptions/tests — those are opaque strings. If
+    the exact marker is absent, an empty declaration is returned. Malformed and
+    duplicate entries are collected so callers can produce useful messages.
+    """
+    body = body or ""
+    if TESTING_MARKER not in body:
+        return TestingDeclaration(False, {}, [], [])
+
+    lines = body.splitlines()
+    raw_entries: List[TestingEntry] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        header = _TESTING_FILE_HEADER_RE.match(lines[i])
+        if not header:
+            i += 1
+            continue
+        entry = TestingEntry(
+            path=_normalize_declared_path(header.group("path")),
+            description="",
+            tests=[],
+        )
+        i += 1
+        in_tests = False
+        while i < n:
+            line = lines[i]
+            if _TESTING_ANY_HEADER_RE.match(line):
+                break  # next header ends this entry
+            nested = _TESTING_NESTED_LIST_RE.match(line)
+            if nested and in_tests:
+                item = _strip_md_emphasis(nested.group("item"))
+                if item:
+                    entry.tests.append(item)
+                i += 1
+                continue
+            top = _TESTING_TOP_LIST_RE.match(line)
+            if top:
+                label_match = _TESTING_LABEL_RE.match(
+                    _strip_md_emphasis(top.group("content").strip())
+                )
+                if label_match:
+                    label = label_match.group("label").strip().lower()
+                    rest = label_match.group("rest").strip()
+                    if label == "description":
+                        entry.description = rest
+                        in_tests = False
+                        i += 1
+                        continue
+                    if label == "tests":
+                        in_tests = True
+                        if rest:
+                            entry.tests.append(rest)
+                        i += 1
+                        continue
+                # Any other top-level bullet ends the tests block.
+                in_tests = False
+                i += 1
+                continue
+            if line.strip() == "":
+                i += 1
+                continue
+            # Any other non-empty line ends the tests capture.
+            in_tests = False
+            i += 1
+        raw_entries.append(entry)
+
+    entries: Dict[str, TestingEntry] = {}
+    invalid: List[str] = []
+    seen: Dict[str, int] = {}
+    for e in raw_entries:
+        if e.path:
+            seen[e.path] = seen.get(e.path, 0) + 1
+        if e.path and e.description and e.tests:
+            entries[e.path] = e  # last valid entry for a path wins
+        elif e.path:
+            invalid.append(e.path)
+    duplicate_paths = sorted(p for p, c in seen.items() if c > 1)
+    invalid_paths = sorted({p for p in invalid if p not in entries})
+    return TestingDeclaration(True, entries, invalid_paths, duplicate_paths)
+
 
 # Anchor file paths to THIS script's location rather than the current working
 # directory or a ".git"/".github" walk-up (which breaks with nested repos /
@@ -113,7 +264,6 @@ class Policy:
     max_single_file_changes: int
     forbidden_paths: List[str]
     unit_test_code_extensions: List[str]
-    unit_test_patterns: List[str]
     unit_test_exempt_paths: List[str]
     bump_bot_authors: List[str]
     required_checks: List[str]
@@ -174,9 +324,6 @@ def load_policy(policy_path: Path) -> Policy:
     unit_test_code_extensions = [
         str(e).lower() for e in (unit_cfg.get("code_extensions", []) or [])
     ]
-    unit_test_patterns = [
-        str(p) for p in (unit_cfg.get("test_file_patterns", []) or [])
-    ]
     unit_test_exempt_paths = [str(p) for p in (unit_cfg.get("exempt_paths", []) or [])]
 
     # Bump-PR bot authors that bypass all policy checks.
@@ -207,7 +354,6 @@ def load_policy(policy_path: Path) -> Policy:
         max_single_file_changes=max_single_file_changes,
         forbidden_paths=forbidden_paths,
         unit_test_code_extensions=unit_test_code_extensions,
-        unit_test_patterns=unit_test_patterns,
         unit_test_exempt_paths=unit_test_exempt_paths,
         bump_bot_authors=bump_bot_authors,
         required_checks=required_checks,
@@ -479,80 +625,108 @@ def ensure_no_forbidden_files(
 
 
 def ensure_unit_tests(
-    policy: Policy, pr_files: Iterable[Dict[str, Any]], errors: List[str]
+    policy: Policy,
+    pr_files: Iterable[Dict[str, Any]],
+    body: str,
+    errors: List[str],
 ) -> None:
-    """
-    Require a unit test when real source code changes.
+    """Require a testing declaration in the PR body for every changed code file.
 
-    - Doc/config files (anything NOT in code_extensions, e.g. .md/.txt/.yml/.ini)
-      never trigger the requirement — a doc/config-only PR passes automatically.
-    - If any code file is changed, the PR must also add/modify at least one
-      test file (basename matching test_file_patterns, e.g. test_xxx.py).
+    - Doc/config files (extensions NOT in code_extensions) never trigger the
+      requirement — a doc/config-only PR passes automatically.
+    - Removed files are ignored.
+    - For every changed, non-removed code file, the PR body must contain a
+      well-formed declaration entry (non-empty Description + >=1 Tests item)
+      keyed by that file's path.
+
+    The bot does NOT verify that the referenced tests exist, run any command, or
+    inspect test contents. Test-list items are opaque, non-empty strings.
     """
     if not policy.unit_test_code_extensions:
         return
 
     code_files: List[str] = []
-    has_test = False
-
     for f in pr_files:
         status = str(f.get("status") or "")
         if status == "removed":
             continue
-        filename = Path(str(f.get("filename") or "")).as_posix()
+        filename = Path(str(f.get("filename") or "")).as_posix().lstrip("./")
         if not filename:
             continue
-
-        # Files under exempt paths never require an accompanying unit test.
         if any(
             _matches_forbidden(filename, pat) for pat in policy.unit_test_exempt_paths
         ):
             continue
-
-        base = Path(filename).name
         ext = Path(filename).suffix.lower()
-
-        # A test file satisfies the requirement.
-        if any(fnmatch.fnmatch(base, pat) for pat in policy.unit_test_patterns):
-            has_test = True
-            continue
-
-        # A real source/code file triggers the requirement.
         if ext in policy.unit_test_code_extensions:
             code_files.append(filename)
 
-    if code_files and not has_test:
+    if not code_files:
+        return  # no code files -> auto-pass
+
+    declaration = parse_testing_declarations(body)
+    if not declaration.marker_present:
         listed = ", ".join(f"`{c}`" for c in code_files[:5])
         more = "" if len(code_files) <= 5 else f" (+{len(code_files) - 5} more)"
         errors.append(
-            "**Error:** Source/code files changed without an accompanying unit test.\n"
-            "**Expected:** add at least one test file named like "
-            "`test_<name>.py` / `test_<name>.cpp` (or `<name>_test.*`).\n"
-            f"**Current:** code file(s) changed: {listed}{more}; no test file found"
+            "**Error:** No testing declaration found in the PR description.\n"
+            "**Expected:** add a `## Testing` section that begins with the exact "
+            f"marker `{TESTING_MARKER}` and declares, for every changed code "
+            "file, a `### File: `path`` entry with a non-empty **Description** "
+            "and a non-empty **Tests** list.\n"
+            f"**Current:** code file(s) changed: {listed}{more}; no declaration marker present"
+        )
+        return
+
+    missing: List[str] = []
+    invalid: List[str] = []
+    for c in code_files:
+        if c in declaration.entries:
+            continue
+        if c in declaration.invalid_paths:
+            invalid.append(c)
+        else:
+            missing.append(c)
+
+    if missing:
+        listed = ", ".join(f"`{c}`" for c in missing[:5])
+        more = "" if len(missing) <= 5 else f" (+{len(missing) - 5} more)"
+        errors.append(
+            "**Error:** Changed code file(s) have no testing declaration entry.\n"
+            "**Expected:** add a `### File: `path`` entry (with a non-empty "
+            "**Description** and a non-empty **Tests** list) for each listed file.\n"
+            f"**Current:** missing entries for: {listed}{more}"
+        )
+
+    if invalid:
+        listed = ", ".join(f"`{c}`" for c in invalid[:5])
+        more = "" if len(invalid) <= 5 else f" (+{len(invalid) - 5} more)"
+        errors.append(
+            "**Error:** Testing declaration entry is incomplete.\n"
+            "**Expected:** each `### File: `path`` entry needs a non-empty "
+            "**Description** and at least one **Tests** list item.\n"
+            f"**Current:** incomplete entries for: {listed}{more}"
         )
 
 
 def pr_has_code_files(policy: Policy, pr_files: Iterable[Dict[str, Any]]) -> bool:
     """True if the PR changes at least one real source/code file.
 
-    Doc/config files (.md, .txt, .yml, .ini, ...), exempt paths, and test files
-    do NOT count as code.
+    Doc/config files (.md, .txt, .yml, .ini, ...) and exempt paths do NOT count
+    as code. Removed files are ignored.
     """
     for f in pr_files:
         status = str(f.get("status") or "")
         if status == "removed":
             continue
-        filename = Path(str(f.get("filename") or "")).as_posix()
+        filename = Path(str(f.get("filename") or "")).as_posix().lstrip("./")
         if not filename:
             continue
         if any(
             _matches_forbidden(filename, pat) for pat in policy.unit_test_exempt_paths
         ):
             continue
-        base = Path(filename).name
         ext = Path(filename).suffix.lower()
-        if any(fnmatch.fnmatch(base, pat) for pat in policy.unit_test_patterns):
-            continue
         if ext in policy.unit_test_code_extensions:
             return True
     return False
@@ -787,7 +961,9 @@ def build_policy_table_comment(
     else:
         footer = "\n\n> 🎉 All policy checks passed!"
 
-    faq_url = "https://github.com/ROCm/rocm-systems/tree/develop/docs/SYSTEMS_PR_BOT_FAQ.md"
+    faq_url = (
+        "https://github.com/ROCm/rocm-systems/tree/develop/docs/SYSTEMS_PR_BOT_FAQ.md"
+    )
 
     faq_link = (
         "\n\n📖 **Need help?** See the "
@@ -1105,7 +1281,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     results.append(CheckResult("Forbidden Files", "⛔", not check_errors, check_errors))
 
     check_errors = []
-    ensure_unit_tests(policy, pr_files, check_errors)
+    ensure_unit_tests(policy, pr_files, body, check_errors)
     ut_note = None
     if not check_errors and not pr_has_code_files(policy, pr_files):
         ut_note = "PR does not contain code files — Unit Test auto-passed"

--- a/tools/systems_pr_bot/tests/test_policy_check.py
+++ b/tools/systems_pr_bot/tests/test_policy_check.py
@@ -1,0 +1,169 @@
+"""Focused unit tests for the Systems PR Bot testing-declaration policy.
+
+Covers the deterministic PR-body parser (`parse_testing_declarations`) and the
+`ensure_unit_tests` policy behavior. These tests never touch the network — they
+exercise pure functions only.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "policy_check.py"
+_spec = importlib.util.spec_from_file_location("policy_check", _MODULE_PATH)
+policy_check = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(policy_check)
+
+
+MARKER = policy_check.TESTING_MARKER
+
+
+def _load_policy():
+    return policy_check.load_policy(_MODULE_PATH.parent / "policy.yml")
+
+
+def _file(name, status="modified"):
+    return {"filename": name, "status": status}
+
+
+def test_parse_missing_marker_returns_empty():
+    d = policy_check.parse_testing_declarations("no marker here")
+    assert d.marker_present is False
+    assert d.entries == {}
+
+
+def test_parse_valid_multi_file():
+    body = f"""Intro.
+
+{MARKER}
+## Testing
+
+### File: `src/foo.cpp`
+- **Description:** Fixed batching.
+- **Tests:**
+  - `ctest --test-dir build -R widget`
+  - manual smoke test
+
+### File: `src/bar.py`
+- **Description:** New parser.
+- **Tests:**
+  - pytest tools/tests/test_bar.py
+"""
+    d = policy_check.parse_testing_declarations(body)
+    assert d.marker_present is True
+    assert set(d.entries) == {"src/foo.cpp", "src/bar.py"}
+    assert d.entries["src/foo.cpp"].tests == [
+        "ctest --test-dir build -R widget",
+        "manual smoke test",
+    ]
+    assert d.entries["src/bar.py"].description == "New parser."
+    assert d.invalid_paths == []
+    assert d.duplicate_paths == []
+
+
+def test_parse_plain_non_bold_variant():
+    body = f"{MARKER}\n### File: src/x.go\n- Description: did a thing\n- Tests:\n    - go test ./...\n"
+    d = policy_check.parse_testing_declarations(body)
+    assert set(d.entries) == {"src/x.go"}
+    assert d.entries["src/x.go"].tests == ["go test ./..."]
+
+
+def test_parse_empty_tests_is_invalid():
+    body = f"{MARKER}\n### File: `a.c`\n- **Description:** did stuff\n- **Tests:**\n"
+    d = policy_check.parse_testing_declarations(body)
+    assert d.entries == {}
+    assert d.invalid_paths == ["a.c"]
+
+
+def test_parse_empty_description_is_invalid():
+    body = (
+        f"{MARKER}\n### File: `a.c`\n- **Description:**\n- **Tests:**\n  - something\n"
+    )
+    d = policy_check.parse_testing_declarations(body)
+    assert d.entries == {}
+    assert d.invalid_paths == ["a.c"]
+
+
+def test_parse_duplicate_paths_last_wins_and_flagged():
+    body = (
+        f"{MARKER}\n"
+        "### File: `a.c`\n- **Description:** first\n- **Tests:**\n  - t1\n"
+        "### File: `./a.c`\n- **Description:** second\n- **Tests:**\n  - t2\n"
+    )
+    d = policy_check.parse_testing_declarations(body)
+    assert set(d.entries) == {"a.c"}
+    assert d.entries["a.c"].description == "second"
+    assert d.duplicate_paths == ["a.c"]
+
+
+def test_ensure_docs_only_passes():
+    policy = _load_policy()
+    errors = []
+    policy_check.ensure_unit_tests(
+        policy, [_file("README.md"), _file("policy.yml")], "", errors
+    )
+    assert errors == []
+
+
+def test_ensure_removed_code_file_ignored():
+    policy = _load_policy()
+    errors = []
+    policy_check.ensure_unit_tests(
+        policy, [_file("src/foo.cpp", status="removed")], "", errors
+    )
+    assert errors == []
+
+
+def test_ensure_code_without_marker_fails():
+    policy = _load_policy()
+    errors = []
+    policy_check.ensure_unit_tests(
+        policy, [_file("src/foo.cpp")], "a description with no marker", errors
+    )
+    assert errors
+    assert "No testing declaration" in errors[0]
+
+
+def test_ensure_code_with_valid_declaration_passes():
+    policy = _load_policy()
+    body = (
+        f"{MARKER}\n### File: `src/foo.cpp`\n"
+        "- **Description:** did it\n- **Tests:**\n  - ctest -R foo\n"
+    )
+    errors = []
+    policy_check.ensure_unit_tests(policy, [_file("src/foo.cpp")], body, errors)
+    assert errors == []
+
+
+def test_ensure_missing_entry_for_one_file_fails():
+    policy = _load_policy()
+    body = (
+        f"{MARKER}\n### File: `src/foo.cpp`\n"
+        "- **Description:** did it\n- **Tests:**\n  - ctest -R foo\n"
+    )
+    errors = []
+    policy_check.ensure_unit_tests(
+        policy, [_file("src/foo.cpp"), _file("src/bar.py")], body, errors
+    )
+    assert errors
+    assert any("no testing declaration entry" in e.lower() for e in errors)
+
+
+def test_ensure_incomplete_entry_reported_as_invalid():
+    policy = _load_policy()
+    body = (
+        f"{MARKER}\n### File: `src/foo.cpp`\n- **Description:** did it\n- **Tests:**\n"
+    )
+    errors = []
+    policy_check.ensure_unit_tests(policy, [_file("src/foo.cpp")], body, errors)
+    assert errors
+    assert any("incomplete" in e.lower() for e in errors)
+
+
+def test_pr_has_code_files():
+    policy = _load_policy()
+    assert policy_check.pr_has_code_files(policy, [_file("src/foo.cpp")]) is True
+    assert policy_check.pr_has_code_files(policy, [_file("README.md")]) is False
+    assert (
+        policy_check.pr_has_code_files(policy, [_file("src/foo.cpp", status="removed")])
+        is False
+    )


### PR DESCRIPTION
## Summary

Replaces the Systems PR Bot's Unit Test check — previously a test-**filename**
heuristic (`test_*` / `*_test.*`) — with an explicit, human-authored **testing
declaration** in the PR description. For every changed, non-removed code file,
the PR body must declare a short description of what changed and a non-empty
list of tests/validation references.

## Motivation

The filename heuristic was easy to game (any `test_*` file satisfied it) and
gave no signal about *what* was actually tested or *how*. A per-file declaration
makes the author state, in plain language, how each changed file was validated —
useful context for reviewers — while keeping the bot dumb and safe: it only
checks that the declaration is **present and well-formed**. It never verifies
that referenced tests exist, executes anything from the PR body, or inspects
test contents. Test-list items are opaque, human-readable strings.

## Implementation changes

- `tools/systems_pr_bot/policy_check.py`
  - Add a deterministic, marker-anchored parser `parse_testing_declarations`
    (marker `<!-- systems-pr-bot:testing:v1 -->`) with `TestingEntry` /
    `TestingDeclaration` models. Handles bold/plain fields, duplicate paths
    (last valid wins, flagged), and malformed entries.
  - Rewrite `ensure_unit_tests` to require a valid declaration entry for every
    changed, non-removed code file; docs/config-only PRs still auto-pass and
    removed files are ignored.
  - Drop the `unit_test_patterns` field and the filename-matching logic in
    `pr_has_code_files`.
- `tools/systems_pr_bot/policy.yml` — remove `test_file_patterns`; document the
  declaration model. `code_extensions` unchanged.
- `docs/SYSTEMS_PR_BOT_FAQ.md` — rewrite the Unit Test section to document the
  declaration format and remove the old filename table/example.
- `tools/systems_pr_bot/tests/test_policy_check.py` — new focused unit tests
  for the parser and policy behavior.

Label behavior is unchanged: a Unit Test declaration failure remains a Unit
Test failure and may add `Not ready to Review`. Pre-commit and unrelated
behavior are untouched.

## Testing

```
python3 -m pytest tools/systems_pr_bot/tests/test_policy_check.py -v   # 13 passed
python3 -m black --check tools/systems_pr_bot/policy_check.py \
    tools/systems_pr_bot/tests/test_policy_check.py                    # clean
python3 -c "import yaml; yaml.safe_load(open('tools/systems_pr_bot/policy.yml'))"  # ok
git diff --check                                                       # clean
```

<!-- systems-pr-bot:testing:v1 -->
### File: `tools/systems_pr_bot/policy_check.py`
- **Description:** Added the marker-anchored testing-declaration parser and rewrote the Unit Test policy to require a per-code-file declaration instead of a test-filename heuristic.
- **Tests:**
  - `python3 -m pytest tools/systems_pr_bot/tests/test_policy_check.py -v`

### File: `tools/systems_pr_bot/tests/test_policy_check.py`
- **Description:** New focused unit tests covering the parser (marker presence, valid/invalid/duplicate entries, plain vs bold) and `ensure_unit_tests` / `pr_has_code_files` behavior.
- **Tests:**
  - `python3 -m pytest tools/systems_pr_bot/tests/test_policy_check.py -v`

JIRA ID : AIPROFSDK-978
