### PR TITLE
fix(rccl): gate CE AllReduce across graph capture lifecycle to avoid deadlock

### DIFF
--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -229,7 +229,7 @@ bool ncclCeAvailable(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDevRedOp_t
   return true;
 }
 
-bool ncclCeScartchAvailable(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty, ncclSymRegType_t winRegType) {
+bool ncclCeScratchAvailable(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty, ncclSymRegType_t winRegType) {
   if (!ncclCeImplemented(coll, red, ty)) {
     TRACE(NCCL_TUNING, "Skipping CE collective: not implemented");
     return false;

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -504,7 +504,8 @@ ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t cou
   struct ncclCudaGraph ceGraph;
   NCCLCHECK(ncclCudaGetCapturingGraph(&ceGraph, stream, comm->config.graphUsageMode));
   bool ceCapturing = ncclCudaGraphValid(ceGraph);
-  bool ceArGraphAllowed = rcclCeAllReduceGraphAllowed(comm, ceCapturing);
+  rcclCeAllReduceGraphLatchTick(comm, ceCapturing);
+  bool ceArGraphAllowed = rcclCeAllReduceAllowed(comm);
   if (ceArGraphAllowed &&
       rcclUseCeAllReduce(comm, count, datatype, op) && comm->ceColl.ceARTmpBuf != NULL) {
     if (count == 0) return ncclSuccess;

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -512,6 +512,10 @@ ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t cou
          count, (int)datatype, (int)op, comm->rank, comm->nRanks);
     return ncclCeAllReduce(comm, sendbuff, recvbuff, count, datatype, op, stream);
   }
+  // Pass the decision to taskAppend() via info to avoid recomputing it.
+  info.ceCapturing = ceCapturing;
+  info.ceArGraphAllowed = ceArGraphAllowed;
+  info.ceGraphDecisionValid = true;
   size_t msgBytes = count * ncclTypeSize(datatype);
   if (rcclDdaEnabled(comm, count * ncclTypeSize(datatype), 8388608) &&  msgBytes < NCCL_CE_AR_MIN_MSG_BYTES) {
     if (IsArchMatch(comm->archName, "gfx1250")) {

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -497,8 +497,16 @@ ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t cou
 
   NCCLCHECK(Recorder::instance().record(rrAllReduce, info));
 
-  // CE AllReduce 
-  if (rcclUseCeAllReduce(comm, count, datatype, op) && comm->ceColl.ceARTmpBuf != NULL) {
+  // CE AllReduce
+  // Disable CE AllReduce while this comm has live graph-captured plans. Per-call
+  // capture checks are not enough because CE AR can still deadlock on eager
+  // calls sharing a graph-mode comm (e.g. rccl-tests warmup).
+  struct ncclCudaGraph ceGraph;
+  NCCLCHECK(ncclCudaGetCapturingGraph(&ceGraph, stream, comm->config.graphUsageMode));
+  bool ceCapturing = ncclCudaGraphValid(ceGraph);
+  bool ceArGraphAllowed = rcclCeAllReduceGraphAllowed(comm, ceCapturing);
+  if (ceArGraphAllowed &&
+      rcclUseCeAllReduce(comm, count, datatype, op) && comm->ceColl.ceARTmpBuf != NULL) {
     if (count == 0) return ncclSuccess;
     INFO(NCCL_COLL, "CE 2-shot AllReduce: count=%zu datatype=%d op=%d rank=%d/%d",
          count, (int)datatype, (int)op, comm->rank, comm->nRanks);

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -3606,13 +3606,24 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
   
       bool hasSysmemSegment = ncclDevrWindowHasSysmemSegment(sendWin) || ncclDevrWindowHasSysmemSegment(recvWin);
 
+      // CE collectives are not graph-capture-safe (hipMemcpyBatchAsync and the
+      // cross-rank memop barrier deadlock on graph replay), so skip CE entirely
+      // while the stream is capturing and fall through to the graph-safe
+      // DDA/symmetric/kernel paths.
+      struct ncclCudaGraph ceGraph;
+      NCCLCHECK(ncclCudaGetCapturingGraph(&ceGraph, info->stream, comm->config.graphUsageMode));
+      bool ceCapturing = ncclCudaGraphValid(ceGraph);
+      // Apply shared CE AllReduce graph-latch policy.
+      bool ceArGraphAllowed = rcclCeAllReduceGraphAllowed(comm, ceCapturing);
+
       // Trigger CE initialization on the first CE-capable collective.
       // This covers collectives whose user buffers ARE registered (AllGather,
       // AlltoAll, Scatter, Gather) as well as AllReduce, which may bypass the
       // ceCollTaskAppend path when user buffers are not symmetrically registered.
       // Without this trigger, CE AllReduce-only workloads would never initialize
       // the CE runtime (ceARTmpBuf stays NULL).
-      if (ncclCeImplemented(info->coll, info->op, info->datatype) &&
+      if (!ceCapturing &&
+          ncclCeImplemented(info->coll, info->op, info->datatype) &&
           comm->symmetricSupport && comm->nNodes == 1 &&
           comm->ceColl.baseUCSymReadyPtr == NULL &&
           ncclIntruQueueEmpty(&comm->ceInitTaskQueue)) {
@@ -3628,9 +3639,9 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
       bool ceAllReduceFits = true;
       ncclSymRegType_t winRegType;
       NCCLCHECK(ncclGetSymRegType(sendWin, recvWin, &winRegType));
-      bool ceAvailable = ncclCeAvailable(comm, info->coll, info->op, info->datatype, winRegType);
+      bool ceAvailable = !ceCapturing && ncclCeAvailable(comm, info->coll, info->op, info->datatype, winRegType);
       if (info->coll == ncclFuncAllReduce) {
-        if (!rcclUseCeAllReduce(comm, info->count, info->datatype, info->op)) {
+        if (!ceArGraphAllowed || !rcclUseCeAllReduce(comm, info->count, info->datatype, info->op)) {
           ceAvailable = false;
         } else {
           size_t totalBytes = info->count * ncclTypeSize(info->datatype);
@@ -3643,7 +3654,7 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
       }
 
       // Append CE collective task if CE is supported and requested by user
-      bool CeScratchAvailable = ncclCeScratchAvailable(comm, info->coll, info->op, info->datatype, winRegType);
+      bool CeScratchAvailable = !ceCapturing && ncclCeScratchAvailable(comm, info->coll, info->op, info->datatype, winRegType);
       size_t recvBytes = (size_t)comm->nRanks * info->count * ncclTypeSize(info->datatype);
       if (rcclParamForceCe() && CeScratchAvailable && winRegType != ncclSymSendRegRecvReg && winRegType != ncclSymSendNonregRecvReg && !hasSysmemSegment && comm->ddaScratch != nullptr && recvBytes <= comm->ddaScratchBytes && info->coll != ncclFuncAllReduce) {
         INFO(NCCL_TUNING, "Using DDA scratch for CE collective, count=%zu, recvBytes=%zu", info->count, recvBytes);      

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -3610,11 +3610,17 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
       // cross-rank memop barrier deadlock on graph replay), so skip CE entirely
       // while the stream is capturing and fall through to the graph-safe
       // DDA/symmetric/kernel paths.
-      struct ncclCudaGraph ceGraph;
-      NCCLCHECK(ncclCudaGetCapturingGraph(&ceGraph, info->stream, comm->config.graphUsageMode));
-      bool ceCapturing = ncclCudaGraphValid(ceGraph);
-      // Apply shared CE AllReduce graph-latch policy.
-      bool ceArGraphAllowed = rcclCeAllReduceGraphAllowed(comm, ceCapturing);
+      bool ceCapturing, ceArGraphAllowed;
+      if (info->ceGraphDecisionValid) {
+        // Already computed by ncclAllReduce_impl() for this call.
+        ceCapturing = info->ceCapturing;
+        ceArGraphAllowed = info->ceArGraphAllowed;
+      } else {
+        struct ncclCudaGraph ceGraph;
+        NCCLCHECK(ncclCudaGetCapturingGraph(&ceGraph, info->stream, comm->config.graphUsageMode));
+        ceCapturing = ncclCudaGraphValid(ceGraph);
+        ceArGraphAllowed = rcclCeAllReduceGraphAllowed(comm, ceCapturing);
+      }
 
       // Trigger CE initialization on the first CE-capable collective.
       // This covers collectives whose user buffers ARE registered (AllGather,

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -3281,7 +3281,7 @@ static ncclResult_t ceCollTaskAppend(
     struct ncclDevrWindow* sendWin,
     struct ncclDevrWindow* recvWin,
     void* ddaRecvBase, // non-null -> DDA path: local scratch buffer
-    void** ddaPeerBasesHost, // host [nRanks] peer scartch bases (DDA path)
+    void** ddaPeerBasesHost, // host [nRanks] peer scratch bases (DDA path)
     struct ncclDevRedOpFull opDev) {
   struct ncclKernelPlanner *planner = &comm->planner;
 
@@ -3643,9 +3643,9 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
       }
 
       // Append CE collective task if CE is supported and requested by user
-      bool CeScartchAvailable = ncclCeScartchAvailable(comm, info->coll, info->op, info->datatype, winRegType);
+      bool CeScratchAvailable = ncclCeScratchAvailable(comm, info->coll, info->op, info->datatype, winRegType);
       size_t recvBytes = (size_t)comm->nRanks * info->count * ncclTypeSize(info->datatype);
-      if (rcclParamForceCe() && CeScartchAvailable && winRegType != ncclSymSendRegRecvReg && winRegType != ncclSymSendNonregRecvReg && !hasSysmemSegment && comm->ddaScratch != nullptr && recvBytes <= comm->ddaScratchBytes && info->coll != ncclFuncAllReduce) {
+      if (rcclParamForceCe() && CeScratchAvailable && winRegType != ncclSymSendRegRecvReg && winRegType != ncclSymSendNonregRecvReg && !hasSysmemSegment && comm->ddaScratch != nullptr && recvBytes <= comm->ddaScratchBytes && info->coll != ncclFuncAllReduce) {
         INFO(NCCL_TUNING, "Using DDA scratch for CE collective, count=%zu, recvBytes=%zu", info->count, recvBytes);      
           NCCLCHECK(ceCollTaskAppend(comm, info, /*sendWin=*/nullptr, /*recvWin=*/nullptr,
                                       comm->ddaScratch, comm->ddaPeerPtrsHost, opDev));

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -3619,7 +3619,8 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
         struct ncclCudaGraph ceGraph;
         NCCLCHECK(ncclCudaGetCapturingGraph(&ceGraph, info->stream, comm->config.graphUsageMode));
         ceCapturing = ncclCudaGraphValid(ceGraph);
-        ceArGraphAllowed = rcclCeAllReduceGraphAllowed(comm, ceCapturing);
+        rcclCeAllReduceGraphLatchTick(comm, ceCapturing);
+        ceArGraphAllowed = rcclCeAllReduceAllowed(comm);
       }
 
       // Trigger CE initialization on the first CE-capable collective.

--- a/projects/rccl/src/include/ce_coll.h
+++ b/projects/rccl/src/include/ce_coll.h
@@ -52,6 +52,8 @@ struct ncclCeColl {
   // Latched while this comm has live graph-captured plans. CE 2-shot AllReduce
   // can deadlock on eager calls that share a graph-mode comm, so we disable CE
   // AR during that period and re-enable it after captured plans are reclaimed.
+  // Written only from rcclCeAllReduceGraphLatchTick(); no internal lock, same
+  // single-writer-per-comm contract as localPersistentRefs (comm.h).
   bool graphModeSeen;
 };
 

--- a/projects/rccl/src/include/ce_coll.h
+++ b/projects/rccl/src/include/ce_coll.h
@@ -48,6 +48,11 @@ struct ncclCeColl {
   //         [nRanks*chunkBytes .. (nRanks+1)*chunkBytes) reduce scratch.
   uint8_t*               ceARTmpBuf;
   struct ncclDevrWindow* ceARTmpWin;
+
+  // Latched while this comm has live graph-captured plans. CE 2-shot AllReduce
+  // can deadlock on eager calls that share a graph-mode comm, so we disable CE
+  // AR during that period and re-enable it after captured plans are reclaimed.
+  bool graphModeSeen;
 };
 
 struct ncclCeInitTask {

--- a/projects/rccl/src/include/ce_coll.h
+++ b/projects/rccl/src/include/ce_coll.h
@@ -89,7 +89,7 @@ struct ncclCeBatchOpsParams {
 
 bool ncclCeAvailable(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty, ncclSymRegType_t winRegType);
 
-bool ncclCeScartchAvailable(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty, ncclSymRegType_t winRegType);
+bool ncclCeScratchAvailable(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty, ncclSymRegType_t winRegType);
 
 bool ncclCeImplemented(ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty);
 

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -826,7 +826,12 @@ struct ncclComm {
   struct ncclComm* groupNext[ncclGroupTaskTypeNum];
   // Subset of those in groupNext list. Holds 0x1 if not needing preconnect.
   struct ncclComm* preconnectNext;
-  int localPersistentRefs; // number of persistent plan-lists capturing this comm
+  // Number of persistent plan-lists (graph captures) referencing this comm.
+  // Incremented synchronously on plan creation; decremented asynchronously by
+  // a per-rank host callback on plan reclaim (no cross-rank sync). No
+  // internal lock: relies on the same single-writer-per-comm contract as the
+  // rest of ncclComm (serialized via the group/enqueue API).
+  int localPersistentRefs;
   struct P2pSchedulePair { int sendRank; int recvRank; } *p2pSchedule;
 
   struct ncclKernelPlanner planner;

--- a/projects/rccl/src/include/info.h
+++ b/projects/rccl/src/include/info.h
@@ -43,6 +43,12 @@ struct ncclInfo {
   unsigned int flags;
   int nDesc;
   ncclWaitSignalDesc_t* signalDescs;
+  // CE AllReduce graph-capture decision, precomputed by ncclAllReduce_impl()
+  // and reused by taskAppend() to avoid recomputing it. Valid only when
+  // ceGraphDecisionValid is true (false for non-AllReduce collectives).
+  bool ceCapturing;
+  bool ceArGraphAllowed;
+  bool ceGraphDecisionValid;
 };
 
 #endif

--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -126,6 +126,9 @@ bool rcclUseAlltoAllGda(struct ncclComm* comm);
 // Does NOT check ceARTmpBuf initialization; the caller is responsible.
 bool rcclUseCeAllReduce(struct ncclComm* comm, size_t count,
                         ncclDataType_t datatype, ncclRedOp_t op);
+// Updates CE AllReduce graph latch state and returns whether CE AllReduce is
+// allowed for this call. Should be invoked at each CE AR decision point.
+bool rcclCeAllReduceGraphAllowed(struct ncclComm* comm, bool ceCapturing);
 void rcclSetPxn(struct ncclComm* comm,  int& rcclPxnDisable);
 void rcclSetP2pNetChunkSize(struct ncclComm* comm,  int& rcclP2pNetChunkSize);
 ncclResult_t rcclFuncMaxSendRecvCount(ncclFunc_t func, int nRanks, size_t count, size_t& maxCount);

--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -126,9 +126,11 @@ bool rcclUseAlltoAllGda(struct ncclComm* comm);
 // Does NOT check ceARTmpBuf initialization; the caller is responsible.
 bool rcclUseCeAllReduce(struct ncclComm* comm, size_t count,
                         ncclDataType_t datatype, ncclRedOp_t op);
-// Updates CE AllReduce graph latch state and returns whether CE AllReduce is
-// allowed for this call. Should be invoked at each CE AR decision point.
-bool rcclCeAllReduceGraphAllowed(struct ncclComm* comm, bool ceCapturing);
+// Updates the CE AllReduce graph latch from this call's capture state.
+// Invoke once per collective (any type) at each CE AR decision point.
+void rcclCeAllReduceGraphLatchTick(struct ncclComm* comm, bool ceCapturing);
+// Pure query: is CE AllReduce currently allowed on this comm?
+bool rcclCeAllReduceAllowed(struct ncclComm* comm);
 void rcclSetPxn(struct ncclComm* comm,  int& rcclPxnDisable);
 void rcclSetP2pNetChunkSize(struct ncclComm* comm,  int& rcclP2pNetChunkSize);
 ncclResult_t rcclFuncMaxSendRecvCount(ncclFunc_t func, int nRanks, size_t count, size_t& maxCount);

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -27,6 +27,7 @@
 #include "argcheck.h"
 #include "device.h"
 #include "collectives.h"
+#include "sym_kernels.h"
 #include "tuner.h"
 #include "ras.h"
 #include "profiler.h"
@@ -2243,6 +2244,24 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   // Call devCommSetup before the last barrier, making sure we don't have a thread running in front and starting to
   // launch NCCL kernels before all cuda mem allocation is complete. That could cause a deadlock.
   NCCLCHECKGOTO(devCommSetup(comm), ret, fail);
+
+  // Pre-init the symmetric-kernel runtime now. It allocates device memory
+  // (window table / shadow pools) on first use, which HIP forbids during graph
+  // capture. Deferring this to the first collective is not safe: some graph
+  // users' very first call on a comm is itself captured, with no preceding
+  // eager call at all (e.g. rccl-tests' per-size warm-up-for-all-sizes loop
+  // begins capture before issuing a single collective), so there is no
+  // reliably-eager "first use" moment to hook a lazy trigger into. Doing it
+  // here makes the narrower per-collective lazy triggers no-ops.
+  //
+  // Note: the CE (copy-engine) runtime is intentionally NOT pre-inited here.
+  // CE collectives are not graph-capture-safe (hipMemcpyBatchAsync and the
+  // cross-rank memop barrier deadlock on graph replay), so CE is instead
+  // skipped entirely while a stream is capturing (see taskAppend() in
+  // enqueue.cc and ncclAllReduce_impl() in collectives.cc).
+  if (comm->symmetricSupport) {
+    NCCLCHECKGOTO(ncclSymkInitOnce(comm), ret, fail);
+  }
 
   timers[TIMER_INIT_CONNECT] = clockNano() -  timers[TIMER_INIT_CONNECT];
 

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -600,7 +600,7 @@ bool rcclUseCeAllReduce(struct ncclComm* comm, size_t count,
   return true;
 }
 
-bool rcclCeAllReduceGraphAllowed(struct ncclComm* comm, bool ceCapturing) {
+void rcclCeAllReduceGraphLatchTick(struct ncclComm* comm, bool ceCapturing) {
   if (ceCapturing) {
     if (!comm->ceColl.graphModeSeen) {
       INFO(NCCL_COLL, "Disabling CE AllReduce; graph latch set (rank %d): capture detected", comm->rank);
@@ -619,6 +619,9 @@ bool rcclCeAllReduceGraphAllowed(struct ncclComm* comm, bool ceCapturing) {
     INFO(NCCL_COLL, "Re-enabling CE AllReduce; graph latch cleared (rank %d): no live captured plans", comm->rank);
     comm->ceColl.graphModeSeen = false;
   }
+}
+
+bool rcclCeAllReduceAllowed(struct ncclComm* comm) {
   return !comm->ceColl.graphModeSeen;
 }
 

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -601,10 +601,21 @@ bool rcclUseCeAllReduce(struct ncclComm* comm, size_t count,
 }
 
 bool rcclCeAllReduceGraphAllowed(struct ncclComm* comm, bool ceCapturing) {
-  if (ceCapturing && !comm->ceColl.graphModeSeen) {
-    INFO(NCCL_COLL, "Disabling CE AllReduce; graph latch set (rank %d): capture detected", comm->rank);
-    comm->ceColl.graphModeSeen = true;
+  if (ceCapturing) {
+    if (!comm->ceColl.graphModeSeen) {
+      INFO(NCCL_COLL, "Disabling CE AllReduce; graph latch set (rank %d): capture detected", comm->rank);
+      comm->ceColl.graphModeSeen = true;
+    }
+    // Stay latched while capturing, even if an unrelated older plan on this
+    // comm was just reclaimed: clearing here would wrongly re-enable CE
+    // mid-capture.
   } else if (comm->ceColl.graphModeSeen && comm->localPersistentRefs == 0) {
+    // Do not proactively drain comm->callbackQueue to freshen this check.
+    // localPersistentRefs is reclaimed via a per-rank async callback with no
+    // cross-rank sync, but all ranks must reach the same decision for the
+    // same call. The ambient once-every-few-group-ends cadence in group.cc
+    // gives every rank's reclaim equal time to complete first; checking more
+    // eagerly let ranks diverge and deadlock (confirmed experimentally).
     INFO(NCCL_COLL, "Re-enabling CE AllReduce; graph latch cleared (rank %d): no live captured plans", comm->rank);
     comm->ceColl.graphModeSeen = false;
   }

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -600,6 +600,17 @@ bool rcclUseCeAllReduce(struct ncclComm* comm, size_t count,
   return true;
 }
 
+bool rcclCeAllReduceGraphAllowed(struct ncclComm* comm, bool ceCapturing) {
+  if (ceCapturing && !comm->ceColl.graphModeSeen) {
+    INFO(NCCL_COLL, "Disabling CE AllReduce; graph latch set (rank %d): capture detected", comm->rank);
+    comm->ceColl.graphModeSeen = true;
+  } else if (comm->ceColl.graphModeSeen && comm->localPersistentRefs == 0) {
+    INFO(NCCL_COLL, "Re-enabling CE AllReduce; graph latch cleared (rank %d): no live captured plans", comm->rank);
+    comm->ceColl.graphModeSeen = false;
+  }
+  return !comm->ceColl.graphModeSeen;
+}
+
 bool rcclUseReduceScatterDirect(struct ncclComm* comm, size_t& msgSize) {
   // Direct ReduceScatter is supported for MI350 (gfx950):
   // Only if PXN is enabled

--- a/projects/rccl/test/RcclWrapTests.cpp
+++ b/projects/rccl/test/RcclWrapTests.cpp
@@ -1544,4 +1544,100 @@ TEST(Rcclwrap, RcclUseHierarchicalAllGatherTests)
     TEST_INFO("=== Process-Isolated rcclUseHierarchicalAllGather Tests Completed ===");
 }
 
+// ===========================================================================
+// CE AllReduce graph latch state machine (rccl_wrap.cc). Regression coverage
+// for the capture-vs-eager ordering bug: the latch must stay set for the
+// entire lifetime of a captured plan and must never clear mid-capture.
+// ===========================================================================
+
+TEST(RcclCeGraphLatch, SetsLatchOnFirstCapture)
+{
+    ncclComm comm{};
+    comm.ceColl.graphModeSeen = false;
+    comm.localPersistentRefs  = 0;
+
+    rcclCeAllReduceGraphLatchTick(&comm, /*ceCapturing=*/true);
+
+    EXPECT_TRUE(comm.ceColl.graphModeSeen);
+    EXPECT_FALSE(rcclCeAllReduceAllowed(&comm));
+}
+
+TEST(RcclCeGraphLatch, StaysSetAcrossRepeatedCaptureTicks)
+{
+    ncclComm comm{};
+    comm.ceColl.graphModeSeen = false;
+    comm.localPersistentRefs  = 0;
+
+    for(int i = 0; i < 3; ++i)
+    {
+        rcclCeAllReduceGraphLatchTick(&comm, /*ceCapturing=*/true);
+        EXPECT_TRUE(comm.ceColl.graphModeSeen) << "iteration " << i;
+    }
+}
+
+// Regression: an unrelated plan reclaiming to zero refs must not re-enable
+// CE AR while still capturing -- this previously caused a cross-rank deadlock.
+TEST(RcclCeGraphLatch, DoesNotClearMidCaptureEvenWithZeroRefs)
+{
+    ncclComm comm{};
+    comm.ceColl.graphModeSeen = true;
+    comm.localPersistentRefs  = 0;
+
+    rcclCeAllReduceGraphLatchTick(&comm, /*ceCapturing=*/true);
+
+    EXPECT_TRUE(comm.ceColl.graphModeSeen);
+    EXPECT_FALSE(rcclCeAllReduceAllowed(&comm));
+}
+
+TEST(RcclCeGraphLatch, ClearsWhenCaptureEndsAndNoRefsRemain)
+{
+    ncclComm comm{};
+    comm.ceColl.graphModeSeen = true;
+    comm.localPersistentRefs  = 0;
+
+    rcclCeAllReduceGraphLatchTick(&comm, /*ceCapturing=*/false);
+
+    EXPECT_FALSE(comm.ceColl.graphModeSeen);
+    EXPECT_TRUE(rcclCeAllReduceAllowed(&comm));
+}
+
+TEST(RcclCeGraphLatch, StaysSetWhileCapturedPlanStillReferencesComm)
+{
+    ncclComm comm{};
+    comm.ceColl.graphModeSeen = true;
+    comm.localPersistentRefs  = 1;
+
+    rcclCeAllReduceGraphLatchTick(&comm, /*ceCapturing=*/false);
+
+    EXPECT_TRUE(comm.ceColl.graphModeSeen)
+        << "Latch must stay set until every captured plan is reclaimed";
+    EXPECT_FALSE(rcclCeAllReduceAllowed(&comm));
+
+    // Reclaim completes: the next tick clears the latch.
+    comm.localPersistentRefs = 0;
+    rcclCeAllReduceGraphLatchTick(&comm, /*ceCapturing=*/false);
+    EXPECT_FALSE(comm.ceColl.graphModeSeen);
+    EXPECT_TRUE(rcclCeAllReduceAllowed(&comm));
+}
+
+TEST(RcclCeGraphLatch, AllowedQueryHasNoSideEffects)
+{
+    ncclComm comm{};
+    comm.ceColl.graphModeSeen = true;
+
+    for(int i = 0; i < 5; ++i)
+    {
+        EXPECT_FALSE(rcclCeAllReduceAllowed(&comm));
+    }
+    EXPECT_TRUE(comm.ceColl.graphModeSeen) << "Query must be a pure read, not a state transition";
+}
+
+TEST(RcclCeGraphLatch, NeverLatchedAllowsCeAllReduceByDefault)
+{
+    ncclComm comm{};
+    comm.ceColl.graphModeSeen = false;
+
+    EXPECT_TRUE(rcclCeAllReduceAllowed(&comm));
+}
+
 } // namespace RcclUnitTesting

--- a/projects/rccl/test/ce/CeInternalMPITests.cpp
+++ b/projects/rccl/test/ce/CeInternalMPITests.cpp
@@ -290,7 +290,7 @@ TEST_F(CeInternalMPITest, GraphThenEagerAllReduceDoesNotHang)
               ncclSuccess) << "ncclSymBufAlloc for recvBuf failed";
     ASSERT_EQ(hipSuccess, ceFillRankScalarFloat(sendSym.ptr, kElem, rank));
 
-    const float expectedSum = static_cast<float>(nRanks * (nRanks - 1) / 2); // sum(0..nRanks-1)
+    const float expectedSum = static_cast<float>(nRanks * (nRanks + 1) / 2); // sum(1..nRanks)
 
     hipGraph_t graph = nullptr;
     hipGraphExec_t graphExec = nullptr;

--- a/projects/rccl/test/ce/CeInternalMPITests.cpp
+++ b/projects/rccl/test/ce/CeInternalMPITests.cpp
@@ -264,6 +264,82 @@ TEST_F(CeInternalMPITest, FiniAfterZeroCollectives)
 }
 
 // ===========================================================================
+// CeInternal_GraphLatch – graph-captured AllReduce immediately followed by an
+// eager AllReduce on the same comm. Regression for a latch bug where CE
+// 2-shot AllReduce could be selected right after a graph capture, deadlocking
+// if ranks disagreed on whether CE was allowed for a given call.
+// ===========================================================================
+
+// LATCH-01: with the captured plan still live, an eager AllReduce at a
+// CE-eligible size on the same comm must not hang and must be correct.
+// hipStreamSynchronize has no timeout; a regression here either corrupts
+// data (latch silently cleared) or hangs, caught by the test runner's
+// external --timeout (same pattern as the CE dispatch tests above).
+TEST_F(CeInternalMPITest, GraphThenEagerAllReduceDoesNotHang)
+{
+    // CE AllReduce range is [NCCL_CE_AR_MIN_MSG_BYTES, NCCL_CE_AR_MAX_MSG_BYTES];
+    // 8MiB of float32 sits comfortably inside it.
+    constexpr size_t kElem = (8ull * 1024 * 1024) / sizeof(float);
+    const int nRanks = ceComm->nRanks;
+    const int rank = ceComm->rank;
+
+    RCCLTestHelpers::SymBuf sendSym, recvSym;
+    ASSERT_EQ(RCCLTestHelpers::ncclSymBufAlloc(getActiveCommunicator(), kElem * sizeof(float), sendSym),
+              ncclSuccess) << "ncclSymBufAlloc for sendBuf failed";
+    ASSERT_EQ(RCCLTestHelpers::ncclSymBufAlloc(getActiveCommunicator(), kElem * sizeof(float), recvSym),
+              ncclSuccess) << "ncclSymBufAlloc for recvBuf failed";
+    ASSERT_EQ(hipSuccess, ceFillRankScalarFloat(sendSym.ptr, kElem, rank));
+
+    const float expectedSum = static_cast<float>(nRanks * (nRanks - 1) / 2); // sum(0..nRanks-1)
+
+    hipGraph_t graph = nullptr;
+    hipGraphExec_t graphExec = nullptr;
+
+    ASSERT_EQ(hipSuccess, hipStreamBeginCapture(getActiveStream(), hipStreamCaptureModeThreadLocal));
+    ncclResult_t ncclErr = ncclAllReduce(sendSym.ptr, recvSym.ptr, kElem, ncclFloat32, ncclSum,
+                                          getActiveCommunicator(), getActiveStream());
+    ASSERT_EQ(ncclSuccess, ncclErr);
+    ASSERT_EQ(hipSuccess, hipStreamEndCapture(getActiveStream(), &graph));
+    ASSERT_NE(nullptr, graph);
+    ASSERT_EQ(hipSuccess, hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+    SCOPE_EXIT(if(graphExec) (void)hipGraphExecDestroy(graphExec); if(graph) (void)hipGraphDestroy(graph));
+
+    ASSERT_EQ(hipSuccess, hipMemset(recvSym.ptr, 0, kElem * sizeof(float)));
+    ASSERT_EQ(hipSuccess, hipGraphLaunch(graphExec, getActiveStream()));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+    size_t errIdx; float errExp, errAct;
+    ASSERT_TRUE(RCCLTestHelpers::verifyBufferData<float>(
+                    recvSym.ptr, kElem,
+                    [expectedSum](size_t) { return expectedSum; },
+                    0, 1e-3, &errIdx, &errExp, &errAct))
+        << "Captured AllReduce result mismatch at idx=" << errIdx
+        << " expected=" << errExp << " got=" << errAct;
+
+    // White-box: graphExec is still live, so the CE latch must still be
+    // engaged -- otherwise the eager call below could pick CE while another
+    // rank is still mid-teardown of its own captured plan.
+    EXPECT_TRUE(ceComm->ceColl.graphModeSeen)
+        << "CE AllReduce graph latch should still be set right after launch";
+
+    // Eager AllReduce, same comm/stream, CE-eligible size, issued immediately.
+    ASSERT_EQ(hipSuccess, hipMemset(recvSym.ptr, 0, kElem * sizeof(float)));
+    ncclErr = ncclAllReduce(sendSym.ptr, recvSym.ptr, kElem, ncclFloat32, ncclSum,
+                             getActiveCommunicator(), getActiveStream());
+    ASSERT_EQ(ncclSuccess, ncclErr);
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+    ASSERT_TRUE(RCCLTestHelpers::verifyBufferData<float>(
+                    recvSym.ptr, kElem,
+                    [expectedSum](size_t) { return expectedSum; },
+                    0, 1e-3, &errIdx, &errExp, &errAct))
+        << "Eager AllReduce immediately after graph capture produced wrong data"
+        << " at idx=" << errIdx << " expected=" << errExp << " got=" << errAct;
+    // SCOPE_EXIT above destroys graphExec/graph on return.
+}
+
+// ===========================================================================
 // CeInternal_Sync – ncclPrepUCSync op-count and self-target checks
 // ===========================================================================
 

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -2836,6 +2836,22 @@
         }
       ]
     },
+    "ce_allreduce_graph_latch": {
+      "extends": "perf_base",
+      "num_nodes": 1,
+      "timeout": 120,
+      "env_variables": {
+        "RCCL_CE_ALLREDUCE": "1"
+      },
+      "tests": [
+        {
+          "name": "AllReduce_CE_GraphThenEager_4MB_32MB",
+          "description": "CE AllReduce graph latch regression: captured (-G 2) then eager AllReduce, CE-eligible sizes (4MB-32MB). A latch bug corrupts data or hangs; timeout turns a hang into a fast failure.",
+          "command_args": "-b 4M -e 32M -f 2 -g 1 -n 5 -w 2 -c 1 -G 2 -o sum",
+          "timeout": 90
+        }
+      ]
+    },
     "device_api_symmetric": {
       "extends": "perf_base",
       "command_args": "-b 8 -e 1G -f 2 -g 1 -n 5 -w 2 -c 1 -R 2",
@@ -3476,6 +3492,12 @@
       "name": "rccl-tests - Default Collectives",
       "description": "All collectives (all_reduce, reduce, reduce_scatter, all_gather, broadcast, alltoall, scatter, gather, sendrecv) at three message sizes (1 KiB, 64 MiB, 1 GiB), all datatypes (-d all), and all operations (-o all) for reduction collectives",
       "config": "default_collectives",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - CE AllReduce Graph Latch",
+      "description": "Regression for the CE AllReduce graph-capture latch: captured AllReduce immediately followed by eager AllReduce on the same comm, at CE-eligible sizes",
+      "config": "ce_allreduce_graph_latch",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Motivation

Fix CE AllReduce behavior around HIP graph capture lifecycle to prevent deadlocks and rank divergence, while keeping existing public APIs/knobs unchanged. Also, improve maintainability by separating latch state mutation from latch query and adding targeted regression coverage.

## Technical Details

- Made symmetric-kernel init eager at communicator setup so first-use device allocations do not occur during stream capture.
- Fixed CE AllReduce graph-latch lifecycle:
  - Keep the latch set while capture is active.
  - Only clear latch when not capturing and no live captured plans remain (`localPersistentRefs == 0`).
  - Avoid proactive callback-queue draining that can desynchronize rank decisions.
- Removed duplicate graph-capture/latch recomputation in one `ncclAllReduce` call by caching the CE graph decision in `ncclInfo` and reusing it in `taskAppend`.
- Refactored latch helper API for clarity:
  - `rcclCeAllReduceGraphLatchTick(...)` (state update/side effect)
  - `rcclCeAllReduceAllowed(...)` (pure query)
- Documented threading contract around `graphModeSeen` / `localPersistentRefs` (single-writer-per-comm assumption; no internal lock).
- Added regression coverage:
  - New latch state-machine unit tests in `test/RcclWrapTests.cpp`.
  - New MPI regression test for “graph-captured AllReduce immediately followed by eager AllReduce on same comm” in `test/ce/CeInternalMPITests.cpp`.
  - New test-runner config entry in `tools/scripts/test_runner/configs/mi300x_mellanox_ib.json` for CE graph-latch scenario with timeout-based hang detection.

## JIRA ID

N/A

## Test Plan

- Build:
  - `make rccl`
  - `make rccl-UnitTests`
  - `make rccl-UnitTestsFixturesDebug`
  - `make rccl-UnitTestsMPI`
- Unit tests:
  - `rccl-UnitTestsFixturesDebug --gtest_filter='RcclCeGraphLatch.*'`
  - `rccl-UnitTestsFixturesDebug --gtest_filter='Rcclwrap.*:RcclCeGraphLatch.*'`
- MPI regression path:
  - `mpirun -np 4 rccl-UnitTestsMPI --gtest_filter='CeInternalMPITest.GraphThenEagerAllReduceDoesNotHang'`
- Runtime sanity:
  - `mpirun -np 4 all_reduce_perf -b 4M -e 16M -f 2 -g 1 -n 5 -w 2 -c 1 -G 2 -o sum`
  - with `LD_LIBRARY_PATH` pointing at branch build and CE env (`RCCL_CE_ALLREDUCE=1`).

## Test Result

- All builds succeeded.
- `RcclCeGraphLatch.*`: 7/7 passed.
- `Rcclwrap.*:RcclCeGraphLatch.*`: 44/44 passed.
- MPI CE regression test compiled/ran and was skipped in this environment due to CE runtime prerequisites (consistent with existing CE test gating).
- `all_reduce_perf` graph-mode sweep completed without hang and with `#wrong = 0`.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
