### PR TITLE
fix(rocdecode): initialize device_id before retrieving device capabilities

### DIFF
--- a/projects/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
+++ b/projects/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
@@ -272,6 +272,7 @@ int RocVideoDecoder::HandleVideoSequence(RocdecVideoFormat *p_video_format) {
     decode_caps.codec_type = p_video_format->codec;
     decode_caps.chroma_format = p_video_format->chroma_format;
     decode_caps.bit_depth_minus_8 = p_video_format->bit_depth_luma_minus8;
+    decode_caps.device_id = device_id_;
 
     rocDecGetDecoderCaps(&decode_caps);
     if(!decode_caps.is_supported) {

--- a/projects/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
+++ b/projects/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
@@ -274,7 +274,7 @@ int RocVideoDecoder::HandleVideoSequence(RocdecVideoFormat *p_video_format) {
     decode_caps.bit_depth_minus_8 = p_video_format->bit_depth_luma_minus8;
     decode_caps.device_id = device_id_;
 
-    rocDecGetDecoderCaps(&decode_caps);
+    ROCDEC_API_CALL(rocDecGetDecoderCaps(&decode_caps));
     if(!decode_caps.is_supported) {
         ROCDEC_THROW("rocDecode:: Codec not supported on this GPU ", ROCDEC_NOT_SUPPORTED);
         return 0;


### PR DESCRIPTION
## Motivation

Initialize device_id before retrieving device capabilities.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
