### PR TITLE
fix(rocdecode): bind VA-API/VCN decode to the requested GPU by PCI BDF

### DIFF
--- a/projects/rocdecode/CHANGELOG.md
+++ b/projects/rocdecode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for rocDecode is available at [https://rocm.docs.amd.com/projects/rocDecode/en/latest/](https://rocm.docs.amd.com/projects/rocDecode/en/latest/)
 
-## (Unreleased) rocDecode 1.8.1
+## (Unreleased) rocDecode 1.9.0
 
 ### Added
 

--- a/projects/rocdecode/CMakeLists.txt
+++ b/projects/rocdecode/CMakeLists.txt
@@ -47,7 +47,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 endif()
 
 # rocdecode Version
-set(VERSION "1.8.1")
+set(VERSION "1.9.0")
 
 # Set Project Version and Language
 project(rocdecode VERSION ${VERSION} LANGUAGES CXX)

--- a/projects/rocdecode/src/rocdecode/vaapi/vaapi_videodecoder.cpp
+++ b/projects/rocdecode/src/rocdecode/vaapi/vaapi_videodecoder.cpp
@@ -22,6 +22,10 @@ THE SOFTWARE.
 
 #include "vaapi_videodecoder.h"
 
+#include <algorithm>
+#include <cctype>
+#include <stdlib.h>
+
 VaapiVideoDecoder::VaapiVideoDecoder(RocDecoderCreateInfo &decoder_create_info) : decoder_create_info_{decoder_create_info},
     output_surface_format_override_{false}, va_display_{0}, va_config_attrib_{{}}, va_config_id_{0}, va_profile_ {VAProfileNone},
     va_context_id_{0}, va_surface_ids_{{}}, supports_modifiers_{false}, pic_params_buf_id_{0}, iq_matrix_buf_id_{0}, num_slices_{0},
@@ -689,9 +693,24 @@ rocDecStatus VaContext::GetVaContext(int device_id, uint32_t *va_ctx_id) {
     }
     std::string gpu_uuid(hip_dev_prop.uuid.bytes, sizeof(hip_dev_prop.uuid.bytes));
 
+    // Match by PCI BDF (consistent between HIP and sysfs), with unique_id as fallback.
+    char pci_bus_id_buf[64] = {0};
+    std::string gpu_pci_bdf;
+    if (hipDeviceGetPCIBusId(pci_bus_id_buf, sizeof(pci_bus_id_buf), device_id) == hipSuccess) {
+        gpu_pci_bdf = pci_bus_id_buf;
+        std::transform(gpu_pci_bdf.begin(), gpu_pci_bdf.end(), gpu_pci_bdf.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+        // Drop the PCI function suffix so partition children match their base BDF.
+        size_t dot_pos = gpu_pci_bdf.find_last_of('.');
+        if (dot_pos != std::string::npos) {
+            gpu_pci_bdf = gpu_pci_bdf.substr(0, dot_pos);
+        }
+    }
+
     if (!va_contexts_.empty()) {
         for (va_ctx_idx = 0; va_ctx_idx < va_contexts_.size(); va_ctx_idx++) {
-            if (gpu_uuid.compare(va_contexts_[va_ctx_idx].gpu_uuid) == 0) {
+            if ((!gpu_pci_bdf.empty() && gpu_pci_bdf == va_contexts_[va_ctx_idx].gpu_pci_bdf) ||
+                gpu_uuid.compare(va_contexts_[va_ctx_idx].gpu_uuid) == 0) {
                 found_existing = true;
                 break;
             }
@@ -707,6 +726,7 @@ rocDecStatus VaContext::GetVaContext(int device_id, uint32_t *va_ctx_id) {
 
         va_contexts_[va_ctx_idx].device_id = device_id;
         va_contexts_[va_ctx_idx].gpu_uuid.assign(gpu_uuid);
+        va_contexts_[va_ctx_idx].gpu_pci_bdf = gpu_pci_bdf;
         va_contexts_[va_ctx_idx].hip_dev_prop = hip_dev_prop;
         va_contexts_[va_ctx_idx].drm_fd = -1;
         va_contexts_[va_ctx_idx].va_display = 0;
@@ -718,25 +738,67 @@ rocDecStatus VaContext::GetVaContext(int device_id, uint32_t *va_ctx_id) {
         GetVisibleDevices(visible_devices);
 
         int offset = 0;
-        ComputePartition current_compute_partition = (gpu_uuids_to_compute_partition_map_.find(gpu_uuid) != gpu_uuids_to_compute_partition_map_.end()) ? gpu_uuids_to_compute_partition_map_[gpu_uuid] : kSpx;
+        ComputePartition current_compute_partition = kSpx;
+        {
+            auto bdf_it = gpu_pci_bdf_to_compute_partition_map_.find(gpu_pci_bdf);
+            if (bdf_it != gpu_pci_bdf_to_compute_partition_map_.end()) {
+                current_compute_partition = bdf_it->second;
+            } else {
+                auto uuid_it = gpu_uuids_to_compute_partition_map_.find(gpu_uuid);
+                if (uuid_it != gpu_uuids_to_compute_partition_map_.end()) {
+                    current_compute_partition = uuid_it->second;
+                }
+            }
+        }
         GetDrmNodeOffset(va_contexts_[va_ctx_idx].hip_dev_prop.name, va_contexts_[va_ctx_idx].device_id, visible_devices, current_compute_partition, offset);
 
-        std::string drm_node = "/dev/dri/renderD";
-        int render_node_id = (gpu_uuids_to_render_nodes_map_.find(gpu_uuid) != gpu_uuids_to_render_nodes_map_.end()) ? gpu_uuids_to_render_nodes_map_[gpu_uuid] : 128;
-        drm_node += std::to_string(render_node_id + offset);
+        int render_node_id = -1;
+        {
+            auto bdf_it = gpu_pci_bdf_to_render_nodes_map_.find(gpu_pci_bdf);
+            if (bdf_it != gpu_pci_bdf_to_render_nodes_map_.end()) {
+                render_node_id = bdf_it->second;
+            } else {
+                auto uuid_it = gpu_uuids_to_render_nodes_map_.find(gpu_uuid);
+                if (uuid_it != gpu_uuids_to_render_nodes_map_.end()) {
+                    render_node_id = uuid_it->second;
+                }
+            }
+        }
+
+        std::string drm_node;
+        if (render_node_id >= 0) {
+            drm_node = "/dev/dri/renderD" + std::to_string(render_node_id + offset);
+        } else {
+            drm_node = GetFirstAvailableDrmNode();
+            if (drm_node.empty()) {
+                drm_node = "/dev/dri/renderD128";
+            }
+        }
 
         if (g_rocdec_logger.GetLogLevel() >= kRocDecLogInfo) {
-            std::ostringstream oss;
-            oss << '{';
-            bool first = true;
+            InfoLog(g_rocdec_logger, "gpu_uuids_to_render_nodes_map_:");
             for (const auto& entry : gpu_uuids_to_render_nodes_map_) {
-                if (!first) oss << ", ";
-                oss << entry.first << ": " << entry.second;
-                first = false;
+                InfoLog(g_rocdec_logger, "  " + entry.first + " -> renderD" + std::to_string(entry.second));
             }
-            oss << '}';
-            InfoLog(g_rocdec_logger, "gpu_uuids_to_render_nodes_map_: " + oss.str());
+            InfoLog(g_rocdec_logger, "gpu_pci_bdf_to_render_nodes_map_:");
+            for (const auto& entry : gpu_pci_bdf_to_render_nodes_map_) {
+                InfoLog(g_rocdec_logger, "  " + entry.first + " -> renderD" + std::to_string(entry.second));
+            }
+
+            auto partition_name = [](ComputePartition p) -> const char* {
+                switch (p) {
+                    case kSpx: return "SPX";
+                    case kDpx: return "DPX";
+                    case kTpx: return "TPX";
+                    case kQpx: return "QPX";
+                    case kCpx: return "CPX";
+                    default:   return "unknown";
+                }
+            };
             InfoLog(g_rocdec_logger, "Selected GPU UUID: " + gpu_uuid);
+            InfoLog(g_rocdec_logger, "Selected GPU BDF: " + gpu_pci_bdf);
+            InfoLog(g_rocdec_logger, "Selected compute partition: " + std::string(partition_name(current_compute_partition)));
+            InfoLog(g_rocdec_logger, "Selected DRM node: " + drm_node);
         }
 
         rocdec_status = InitVAAPI(va_ctx_idx, drm_node);
@@ -1175,6 +1237,10 @@ void VaContext::GetGpuUuids() {
                 std::string sys_device_path = "/sys/class/drm/" + filename + "/device";
                 struct stat info;
                 if (stat(sys_device_path.c_str(), &info) == 0) {
+                    std::string bus_id = GetRenderNodeBusId(filename);
+                    if (!bus_id.empty()) {
+                        gpu_pci_bdf_to_render_nodes_map_[bus_id] = render_id;
+                    }
                     std::string unique_id_path = sys_device_path + "/unique_id";
                     std::ifstream unique_id_file(unique_id_path);
                     std::string unique_id;
@@ -1205,6 +1271,9 @@ void VaContext::GetGpuUuids() {
                                 }
                                 // Map the unique GPU UUID to the compute partition
                                 gpu_uuids_to_compute_partition_map_[unique_id] = current_compute_partition;
+                                if (!bus_id.empty()) {
+                                    gpu_pci_bdf_to_compute_partition_map_[bus_id] = current_compute_partition;
+                                }
                             }
                         }
                         partition_file.close();
@@ -1214,4 +1283,53 @@ void VaContext::GetGpuUuids() {
         }
         closedir(dir);
     }
+}
+
+std::string VaContext::GetRenderNodeBusId(const std::string& render_node_name) {
+    std::string device_link = "/sys/class/drm/" + render_node_name + "/device";
+    char* resolved = realpath(device_link.c_str(), nullptr);
+    if (resolved == nullptr) {
+        return "";
+    }
+    std::string path(resolved);
+    free(resolved);
+    size_t pos = path.find_last_of('/');
+    std::string bus_id = (pos == std::string::npos) ? path : path.substr(pos + 1);
+    if (bus_id.find(':') == std::string::npos || bus_id.find('.') == std::string::npos) {
+        return "";
+    }
+    std::transform(bus_id.begin(), bus_id.end(), bus_id.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    size_t dot_pos = bus_id.find_last_of('.');
+    if (dot_pos != std::string::npos) {
+        bus_id = bus_id.substr(0, dot_pos);
+    }
+    return bus_id;
+}
+
+std::string VaContext::GetFirstAvailableDrmNode() {
+    std::string dri_path = "/dev/dri";
+    DIR* dir = opendir(dri_path.c_str());
+    if (!dir) {
+        return "";
+    }
+    int min_render_id = -1;
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != nullptr) {
+        std::string filename = entry->d_name;
+        if (filename.find("renderD") == 0 && filename.size() > 7) {
+            try {
+                int render_id = std::stoi(filename.substr(7));
+                if (min_render_id < 0 || render_id < min_render_id) {
+                    min_render_id = render_id;
+                }
+            } catch (...) {
+            }
+        }
+    }
+    closedir(dir);
+    if (min_render_id < 0) {
+        return "";
+    }
+    return "/dev/dri/renderD" + std::to_string(min_render_id);
 }

--- a/projects/rocdecode/src/rocdecode/vaapi/vaapi_videodecoder.h
+++ b/projects/rocdecode/src/rocdecode/vaapi/vaapi_videodecoder.h
@@ -72,6 +72,7 @@ typedef enum {
 typedef struct {
     int device_id;
     std::string gpu_uuid;
+    std::string gpu_pci_bdf;
     int drm_fd;
     VADisplay va_display;
     hipDeviceProp_t hip_dev_prop;
@@ -145,13 +146,18 @@ private:
     std::mutex mutex;
     /**
      * @brief A map that associates GPU UUIDs with their corresponding render node indices.
-     * 
-     * This unordered map uses GPU UUIDs as keys (std::string) and maps them to their 
-     * respective render node indices (int). It provides a fast lookup mechanism to 
+     *
+     * This unordered map uses GPU UUIDs as keys (std::string) and maps them to their
+     * respective render node indices (int). It provides a fast lookup mechanism to
      * retrieve the render node index for a given GPU UUID.
      */
     std::unordered_map<std::string, int> gpu_uuids_to_render_nodes_map_;
     std::unordered_map<std::string, ComputePartition> gpu_uuids_to_compute_partition_map_;
+
+    // GPU PCI BDF -> render node index / compute partition (primary match key).
+    std::unordered_map<std::string, int> gpu_pci_bdf_to_render_nodes_map_;
+    std::unordered_map<std::string, ComputePartition> gpu_pci_bdf_to_compute_partition_map_;
+
     VaContext();
     VaContext(const VaContext&) = delete;
     VaContext& operator = (const VaContext) = delete;
@@ -162,4 +168,10 @@ private:
     void GetVisibleDevices(std::vector<int>& visible_devices_vetor);
     void GetDrmNodeOffset(std::string device_name, uint8_t device_id, std::vector<int>& visible_devices, ComputePartition current_compute_partition, int &offset);
     void GetGpuUuids();
+
+    // Returns the lowercased PCI BDF (function suffix stripped) for a render node, or "" if not a PCI device.
+    std::string GetRenderNodeBusId(const std::string& render_node_name);
+
+    // Returns the lowest-numbered /dev/dri/renderD* node, or "" if none.
+    std::string GetFirstAvailableDrmNode();
 };


### PR DESCRIPTION
## Problem

On architectures where the HIP device UUID (`hipDeviceProp_t.uuid`) and the amdgpu sysfs `unique_id` come from different namespaces (observed on gfx950 / MI355X), `VaContext::GetVaContext` never finds a match in `gpu_uuids_to_render_nodes_map_` (the map is keyed by `unique_id` but looked up by the HIP UUID) and hard-falls-back to `renderD128`. As a result every `rocDecCreateDecoder(..., device_id)`, for any `device_id`, binds the VCN decoder to `renderD128` = GPU 0 — all hardware video decode is funneled onto a single GPU.

## Root cause

- `VaContext::GetVaContext` builds the lookup key from the HIP UUID: `std::string gpu_uuid(hip_dev_prop.uuid.bytes, ...)`.
- `VaContext::GetGpuUuids` keys `gpu_uuids_to_render_nodes_map_` by the sysfs `unique_id`.
- On gfx950 these two namespaces are disjoint, so the lookup always misses → fallback to `renderD128` (GPU 0).

This is the same root cause fixed for rocJPEG in commit 544c3c0c63b1 ("fix(rocjpeg): bind VA-API/VCN decode to the requested GPU by PCI BDF").

## Fix

Select the DRM render node by matching the device's PCI bus ID (BDF) via `hipDeviceGetPCIBusId` <-> `/sys/class/drm/renderD*/device`, which is consistent between the HIP runtime and the amdgpu sysfs nodes. The `unique_id` match is kept as a fallback (no behaviour change where it already works, e.g. gfx942), and when nothing matches the first available render node is used instead of hard-coding `renderD128` (this also lets single-GPU containers that expose a non-default render node work correctly).

### Changes to `vaapi_videodecoder.h`

- Added `gpu_pci_bdf` field to `VaContextInfo` struct, storing the normalised (lowercase, function-suffix-stripped) PCI BDF for the device so it can be used for cache lookup on subsequent calls.
- Added two new private maps to `VaContext`:
  - `gpu_pci_bdf_to_render_nodes_map_` — BDF -> render node index
  - `gpu_pci_bdf_to_compute_partition_map_` — BDF -> ComputePartition
- Declared two new private helpers:
  - `GetRenderNodeBusId()` — resolves a renderD sysfs symlink to its normalised PCI BDF string via `realpath`.
  - `GetFirstAvailableDrmNode()` — returns the lowest-numbered `/dev/dri/renderD*` node as a safe fallback.

### Changes to `vaapi_videodecoder.cpp`

- `GetGpuUuids()`: for each render node, calls `GetRenderNodeBusId()` and populates `gpu_pci_bdf_to_render_nodes_map_` and `gpu_pci_bdf_to_compute_partition_map_` alongside the existing UUID maps.
- `GetVaContext()`:
  - Calls `hipDeviceGetPCIBusId()` immediately after `InitHIP()` to obtain the device BDF; normalises to lowercase and strips the PCI function suffix (`.0`) so partition children match their base BDF.
  - Existing-context cache lookup now checks `gpu_pci_bdf` first, then falls back to `gpu_uuid`.
  - Stores `gpu_pci_bdf` into `va_contexts_[va_ctx_idx].gpu_pci_bdf` for future cache hits.
  - Compute-partition and render-node lookups now try the BDF map first, UUID map second.
  - When no render node matches, falls back to `GetFirstAvailableDrmNode()` (lowest-numbered node) rather than the hard-coded `renderD128`.
  - Improved Info-level logging: both `gpu_uuids_to_render_nodes_map_` and `gpu_pci_bdf_to_render_nodes_map_` are printed one entry per line with the render node shown as `renderDNNN` for readability; selected compute partition is logged by name (SPX/DPX/TPX/QPX/CPX).
- Added implementations for `GetRenderNodeBusId()` and `GetFirstAvailableDrmNode()`.

## No API/ABI change

All modifications are internal to `VaContext`; the public `rocDecode` C API is unchanged.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
