### PR TITLE
fix(rccl): fix ddaPeerPtrsHost heap overflow in DDA fabric path

### DIFF
--- a/projects/rccl/src/fabric_init.cu
+++ b/projects/rccl/src/fabric_init.cu
@@ -42,6 +42,24 @@ ncclResult_t ncclDdaFabricCommInit(ncclComm* comm) {
     return ncclSuccess;
   }
 
+  // Fabric DDA is a flat, single-shot collective: every rank exports a VMM
+  // handle for its scratch buffer and every rank imports every other rank's
+  // handle, reducing in one stage. That assumes all nRanks live in the same
+  // UALink/fabric clique. comm->clique.size (computed in ncclMnnvlCheck) counts
+  // the ranks sharing this rank's clusterUuid + cliqueId. When it is smaller
+  // than nRanks the job spans more than one clique (e.g. multiple racks), so
+  // some peers are not fabric-reachable and cuMemImportFromShareableHandle
+  // against them would fail. Multi-clique support would require a clique-scoped
+  // handle exchange plus a second cross-clique reduction stage, which is out of
+  // scope here; fall back to the normal RCCL path instead. Checked before any
+  // allocation so a multi-clique job does zero extra work before falling back.
+  if (comm->clique.size != comm->nRanks) {
+    INFO(NCCL_INIT,
+         "ncclDdaFabricCommInit: comm spans multiple fabric cliques (nRanks %d, clique.size %d); skipping fabric DDA path",
+         comm->nRanks, comm->clique.size);
+    return ncclSuccess;
+  }
+
   const int nRanks = comm->nRanks;
 
   size_t bytes = DDA_FABRIC_BUFFER_SIZE;
@@ -67,6 +85,7 @@ ncclResult_t ncclDdaFabricCommInit(ncclComm* comm) {
   CUmemGenericAllocationHandle scratchHandle{};
   ncclFabricMemHandler* handler = nullptr;
   void* peerDev = nullptr;
+  void** peerHost = nullptr;
   DdaFabricBarrierState* barrierState = nullptr;
   uint32_t* epochDev = nullptr;
   std::vector<void*> h_ptrs(nRanks, nullptr);
@@ -106,12 +125,13 @@ ncclResult_t ncclDdaFabricCommInit(ncclComm* comm) {
           peerDev, h_ptrs.data(), nRanks * sizeof(void*),
           cudaMemcpyHostToDevice),
       res, fail);
-   CUDACHECKGOTO(
+  NCCLCHECKGOTO(ncclCalloc(&peerHost, nRanks), res, fail);
+  CUDACHECKGOTO(
       cudaMemcpy(
-          comm->ddaPeerPtrsHost, h_ptrs.data(), nRanks * sizeof(void*),
+          peerHost, h_ptrs.data(), nRanks * sizeof(void*),
           cudaMemcpyHostToHost),
       res, fail);
- 
+
 
   {
     auto barrierPair = meta::comms::FabricGpuBarrier::mallocAndInit(
@@ -147,6 +167,7 @@ ncclResult_t ncclDdaFabricCommInit(ncclComm* comm) {
   comm->ddaScratchBytes = bytes;
   comm->ddaScratchIsVmm = true;
   comm->ddaPeerPtrsDev = peerDev;
+  comm->ddaPeerPtrsHost = peerHost;
   comm->ddaFabricBarrierState = barrierState;
   comm->ddaFabricMaxBlocks = nBlocksMax;
   comm->ddaLLEpochDev = epochDev;
@@ -165,6 +186,9 @@ fail:
   }
   if (epochDev != nullptr) {
     CUDACHECKIGNORE(cudaFree(epochDev));
+  }
+  if (peerHost != nullptr) {
+    free(peerHost);
   }
   if (peerDev != nullptr) {
     CUDACHECKIGNORE(cudaFree(peerDev));
@@ -191,6 +215,8 @@ ncclResult_t ncclDdaFabricCommFini(ncclComm* comm) {
   CUDACHECKIGNORE(cudaFree(comm->ddaLLEpochDev));
   comm->ddaLLEpochDev = nullptr;
   comm->ddaLLEpochLen = 0;
+  free(comm->ddaPeerPtrsHost);
+  comm->ddaPeerPtrsHost = nullptr;
   // Destroying the fabric handler unmaps/frees the imported peer scratch buffers.
   if (comm->ddaFabricMemHandler != nullptr) {
     delete static_cast<ncclFabricMemHandler*>(comm->ddaFabricMemHandler);

--- a/projects/rccl/src/fabric_init.cu
+++ b/projects/rccl/src/fabric_init.cu
@@ -42,17 +42,8 @@ ncclResult_t ncclDdaFabricCommInit(ncclComm* comm) {
     return ncclSuccess;
   }
 
-  // Fabric DDA is a flat, single-shot collective: every rank exports a VMM
-  // handle for its scratch buffer and every rank imports every other rank's
-  // handle, reducing in one stage. That assumes all nRanks live in the same
-  // UALink/fabric clique. comm->clique.size (computed in ncclMnnvlCheck) counts
-  // the ranks sharing this rank's clusterUuid + cliqueId. When it is smaller
-  // than nRanks the job spans more than one clique (e.g. multiple racks), so
-  // some peers are not fabric-reachable and cuMemImportFromShareableHandle
-  // against them would fail. Multi-clique support would require a clique-scoped
-  // handle exchange plus a second cross-clique reduction stage, which is out of
-  // scope here; fall back to the normal RCCL path instead. Checked before any
-  // allocation so a multi-clique job does zero extra work before falling back.
+  // Fabric DDA assumes every rank shares one UALink clique; skip (fall back to
+  // normal RCCL) if this comm spans multiple cliques -- e.g. multiple racks.
   if (comm->clique.size != comm->nRanks) {
     INFO(NCCL_INIT,
          "ncclDdaFabricCommInit: comm spans multiple fabric cliques (nRanks %d, clique.size %d); skipping fabric DDA path",

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -950,7 +950,14 @@ struct ncclComm {
   // Temporary Buffer [RCCL]
   void* tempBuff;
 
-  void* ddaPeerPtrsHost[nccl_dda_detail::kDdaNranks];
+  // Host mirror of the per-rank DDA scratch base pointers. Heap-allocated once
+  // per comm and sized to the number of ranks actually served by the active DDA
+  // path (kDdaNranks for the IPC path, comm->nRanks for the fabric path), not a
+  // fixed in-struct array: the fabric path admits up to kDdaMaxNranks ranks, so
+  // a fixed kDdaNranks-element array here would overflow into endMagic and past
+  // the end of the ncclComm allocation. Allocated in the *CommInit routines and
+  // freed in the matching *CommFini; nullptr when no DDA path is active.
+  void** ddaPeerPtrsHost;
 
   uint64_t endMagic;
 };

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -950,13 +950,8 @@ struct ncclComm {
   // Temporary Buffer [RCCL]
   void* tempBuff;
 
-  // Host mirror of the per-rank DDA scratch base pointers. Heap-allocated once
-  // per comm and sized to the number of ranks actually served by the active DDA
-  // path (kDdaNranks for the IPC path, comm->nRanks for the fabric path), not a
-  // fixed in-struct array: the fabric path admits up to kDdaMaxNranks ranks, so
-  // a fixed kDdaNranks-element array here would overflow into endMagic and past
-  // the end of the ncclComm allocation. Allocated in the *CommInit routines and
-  // freed in the matching *CommFini; nullptr when no DDA path is active.
+  // Heap-allocated per comm (kDdaNranks for IPC, nRanks for fabric), not a fixed
+  // array -- fabric's larger nRanks used to overflow a fixed kDdaNranks array here.
   void** ddaPeerPtrsHost;
 
   uint64_t endMagic;

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -669,6 +669,7 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   comm->ddaScratchBytes = 0;
   comm->ddaScratchIsVmm = false;
   comm->ddaPeerPtrsDev = nullptr;
+  comm->ddaPeerPtrsHost = nullptr;
   comm->ddaIpcBarrierState = nullptr;
   comm->ddaFabricBarrierState = nullptr;
   comm->ddaFabricMemHandler = nullptr;

--- a/projects/rccl/src/ipc_init.cu
+++ b/projects/rccl/src/ipc_init.cu
@@ -6,6 +6,7 @@
 
 #include "ipc_init.h"
 
+#include "alloc.h"
 #include "archinfo.h"
 #include "checks.h"
 #include "comm.h"
@@ -156,12 +157,25 @@ ncclResult_t ncclDdaIpcCommInit(ncclComm* comm) {
     return ncclSuccess;
   }
 
+  if (ncclCalloc(&comm->ddaPeerPtrsHost, kDdaNranks) != ncclSuccess) {
+    CUDACHECKIGNORE(cudaFree(peerDev));
+    delete handler;
+    CUDACHECKIGNORE(cudaFree(scratch));
+    WARN("ncclDdaIpcCommInit: OOM allocating host peer table");
+    return ncclSuccess;
+  }
+
   cudaError_t ddaCe = cudaMemcpy(
     comm->ddaPeerPtrsHost,
     h_ptrs,
     kDdaNranks * sizeof(void*),
     cudaMemcpyHostToHost);
   if (ddaCe != cudaSuccess) {
+    free(comm->ddaPeerPtrsHost);
+    comm->ddaPeerPtrsHost = nullptr;
+    CUDACHECKIGNORE(cudaFree(peerDev));
+    delete handler;
+    CUDACHECKIGNORE(cudaFree(scratch));
     WARN(
         "ncclDdaIpcCommInit: cudaMemcpy(host peer table) failed (%s)",
         cudaGetErrorString(ddaCe));
@@ -173,6 +187,8 @@ ncclResult_t ncclDdaIpcCommInit(ncclComm* comm) {
   auto barrierPair = meta::comms::IpcGpuBarrier::mallocAndInit(
       kDdaNranks, nBlocksMax, comm->rank, comm->bootstrap);
   if (!barrierPair.first) {
+    free(comm->ddaPeerPtrsHost);
+    comm->ddaPeerPtrsHost = nullptr;
     CUDACHECKIGNORE(cudaFree(peerDev));
     delete handler;
     CUDACHECKIGNORE(cudaFree(scratch));
@@ -183,6 +199,8 @@ ncclResult_t ncclDdaIpcCommInit(ncclComm* comm) {
   auto* barrierState = new (std::nothrow) DdaIpcBarrierState();
   if (barrierState == nullptr) {
     barrierPair.first.reset();
+    free(comm->ddaPeerPtrsHost);
+    comm->ddaPeerPtrsHost = nullptr;
     CUDACHECKIGNORE(cudaFree(peerDev));
     delete handler;
     CUDACHECKIGNORE(cudaFree(scratch));
@@ -215,6 +233,8 @@ ncclResult_t ncclDdaIpcCommFini(ncclComm* comm) {
   }
   CUDACHECKIGNORE(cudaFree(comm->ddaPeerPtrsDev));
   comm->ddaPeerPtrsDev = nullptr;
+  free(comm->ddaPeerPtrsHost);
+  comm->ddaPeerPtrsHost = nullptr;
   if (comm->ddaIpcMemHandler != nullptr) {
     delete comm->ddaIpcMemHandler;
     comm->ddaIpcMemHandler = nullptr;


### PR DESCRIPTION
## Motivation

Fix a heap buffer overflow in the DDA fabric path that corrupts the ncclComm object on multi-node runs with more than 8 total ranks.

## Technical Details

ncclDdaFabricCommInit() wrote up to comm->nRanks pointers into ddaPeerPtrsHost, a fixed 8-element array left over from the single-node IPC DDA path. For nRanks > 8 this overflowed past the array into endMagic and beyond the ncclComm heap allocation.

ddaPeerPtrsHost is now heap-allocated and sized correctly per active path (8 entries for the IPC path, comm->nRanks for the fabric path), freed on every error/teardown path. Also added a fallback so the fabric path is skipped when a communicator spans more than one fabric clique, since the handle exchange only works within one clique.

## JIRA ID

AICOMRCCL-1541

## Test Plan

Incremental build of the changed files. rccl-tests on 8 GPUs (gfx942) exercising the shared IPC DDA code path across AllReduce, AllGather, ReduceScatter, and AllToAll.

## Test Result

Build clean, no warnings or errors. rccl-tests correctness passed on all four collectives. Multi-node gfx1250 hardware validation of the original crash repro is still outstanding.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.