### PR TITLE
feat(rocprofiler-systems): add navi2/3/4 runners to nightly CI

### DIFF
--- a/projects/rocprofiler-systems/.github/ci-matrix.yml
+++ b/projects/rocprofiler-systems/.github/ci-matrix.yml
@@ -9,6 +9,6 @@ matrix-nightly:
   - { os-release: '24.04', gpu: 'mi325', arch: 'gfx94X', runner: 'linux-gfx942-1gpu-ccs-csp-ossci-rocm' }
 matrix-ci:
   # MI355
-  - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
+  # - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
   # Navi4x
   - { os-release: '24.04', gpu: 'navi4x', arch: 'gfx120X', runner: 'linux-gfx120X-gpu-rocm' }

--- a/projects/rocprofiler-systems/.github/ci-matrix.yml
+++ b/projects/rocprofiler-systems/.github/ci-matrix.yml
@@ -7,12 +7,12 @@ matrix-nightly:
   # MI325
   - { os-release: '22.04', gpu: 'mi325', arch: 'gfx94X', runner: 'linux-gfx942-1gpu-ccs-csp-ossci-rocm' }
   - { os-release: '24.04', gpu: 'mi325', arch: 'gfx94X', runner: 'linux-gfx942-1gpu-ccs-csp-ossci-rocm' }
-matrix-ci:
-  # MI355
-  # - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
   # Navi 2x
   - { os-release: '24.04', gpu: 'navi2x', arch: 'gfx103X', runner: 'linux-gfx1030-gpu-rocm' }
   # Navi 3x
   - { os-release: '24.04', gpu: 'navi3x', arch: 'gfx110X', runner: 'linux-gfx110X-gpu-rocm' }
   # Navi 4x
   - { os-release: '24.04', gpu: 'navi4x', arch: 'gfx120X', runner: 'linux-gfx120X-gpu-rocm' }
+matrix-ci:
+  # MI355
+  - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }

--- a/projects/rocprofiler-systems/.github/ci-matrix.yml
+++ b/projects/rocprofiler-systems/.github/ci-matrix.yml
@@ -10,5 +10,9 @@ matrix-nightly:
 matrix-ci:
   # MI355
   # - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
-  # Navi4x
+  # Navi 2x
+  - { os-release: '24.04', gpu: 'navi2x', arch: 'gfx103X', runner: 'linux-gfx1030-gpu-rocm' }
+  # Navi 3x
+  - { os-release: '24.04', gpu: 'navi3x', arch: 'gfx110X', runner: 'linux-gfx110X-gpu-rocm' }
+  # Navi 4x
   - { os-release: '24.04', gpu: 'navi4x', arch: 'gfx120X', runner: 'linux-gfx120X-gpu-rocm' }

--- a/projects/rocprofiler-systems/.github/ci-matrix.yml
+++ b/projects/rocprofiler-systems/.github/ci-matrix.yml
@@ -10,3 +10,5 @@ matrix-nightly:
 matrix-ci:
   # MI355
   - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
+  # Navi4x
+  - { os-release: '24.04', gpu: 'navi4x', arch: 'gfx120X', runner: 'linux-gfx120X-gpu-rocm' }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
We want to add CI coverage for rocprofiler-systems to the navi2/3/4 systems.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Updated `projects/rocprofiler-systems/.github/ci-matrix.yml` to include configurations for navi2/3/4
  - Only added to nightly coverage

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
JIRA ID : ROCM-21325
JIRA ID : ROCM-21311
JIRA ID : ROCM-21315

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Ensure workflows run correctly on the new runners
  - https://github.com/ROCm/rocm-systems/actions/runs/29443761433

## Test Result

<!-- Briefly summarize test outcomes. -->
- Navi2 and Navi4 runs pass but Navi3 running into test failures
  - To be investigated later

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
