### PR TITLE
refactor(rocprofiler-compute): extract shared mem_chart helpers 

### DIFF
--- a/projects/rocprofiler-compute/src/utils/mem_chart_common.py
+++ b/projects/rocprofiler-compute/src/utils/mem_chart_common.py
@@ -1,0 +1,104 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""
+Shared helpers for memory chart renderers (gfx9, gfx11).
+"""
+
+from typing import Any, Optional, Union
+
+from utils.utils_analysis import format_bw_human_readable
+
+COLORS = {
+    "kernel": "green",
+    "block": "blue",
+    "tcp": "cyan",
+    "lds": "magenta",
+    "sqc": "yellow",
+    "read": "bright_cyan",
+    "write": "bright_yellow",
+    "atomic": "bright_magenta",
+    "util": "bright_green",
+    "hit": "yellow",
+    "stall": "indian_red",
+    "bw": "bright_cyan",
+}
+
+
+def format_value(
+    value: Union[int, float, str, None], unit: str = "", precision: int = 1
+) -> str:
+    if value is None:
+        return "N/A"
+    if isinstance(value, str):
+        try:
+            value = float(value)
+        except (ValueError, TypeError):
+            return value
+    if unit == "%":
+        return f"{value:.{precision}f}%"
+    if unit in ("GB/s", "Bytes/s"):
+        return format_bw_human_readable(value, unit, precision)
+    return f"{value:.{precision}f}{unit}"
+
+
+def format_sci(value: Union[int, float, str, None], precision: int = 2) -> str:
+    if value is None:
+        return "N/A"
+    try:
+        value = float(value)
+    except (ValueError, TypeError):
+        return "N/A"
+    if abs(value) < 1000:
+        return f"{int(value)}"
+    return f"{value:.{precision}e}"
+
+
+def metric_line(
+    label: str,
+    value: Any,  # noqa: ANN401
+    unit: str = "%",
+    color: str = "bright_green",
+) -> str:
+    formatted = format_value(value, unit)
+    return f"{label} [{color}]{formatted}[/{color}]"
+
+
+def bar(pct: float, w: int = 10) -> str:
+    if pct is None:
+        return "░" * w
+    try:
+        pct = float(pct)
+    except (ValueError, TypeError):
+        return "░" * w
+    filled = int(w * min(100, max(0, pct)) / 100)
+    return "█" * filled + "░" * (w - filled)
+
+
+def _safe_float_sum(
+    *values: Union[int, float, str, None],
+) -> Optional[float]:
+    """Sum non-None numeric values. Returns None if no value is valid."""
+    total = 0.0
+    any_valid = False
+    for v in values:
+        if v is not None:
+            try:
+                total += float(v)
+                any_valid = True
+            except (ValueError, TypeError):
+                pass
+    return total if any_valid else None
+
+
+def _fmt_edge(
+    label: str,
+    value: Any,  # noqa: ANN401
+    width: int = 7,
+) -> str:
+    label_str = f"{label:<{width}}"
+    if value is not None:
+        value_str = f": {format_sci(value):>7}"
+    else:
+        value_str = ""
+    return f"{label_str}{value_str}"

--- a/projects/rocprofiler-compute/src/utils/mem_chart_common.py
+++ b/projects/rocprofiler-compute/src/utils/mem_chart_common.py
@@ -64,7 +64,7 @@ def metric_line(
     return f"{label} [{color}]{formatted}[/{color}]"
 
 
-def bar(pct: float, w: int = 10) -> str:
+def bar(pct: Optional[float], w: int = 10) -> str:
     if pct is None:
         return "░" * w
     try:
@@ -75,7 +75,7 @@ def bar(pct: float, w: int = 10) -> str:
     return "█" * filled + "░" * (w - filled)
 
 
-def _safe_float_sum(
+def safe_float_sum(
     *values: Union[int, float, str, None],
 ) -> Optional[float]:
     """Sum non-None numeric values. Returns None if no value is valid."""
@@ -91,7 +91,7 @@ def _safe_float_sum(
     return total if any_valid else None
 
 
-def _fmt_edge(
+def fmt_edge(
     label: str,
     value: Any,  # noqa: ANN401
     width: int = 7,

--- a/projects/rocprofiler-compute/src/utils/mem_chart_gfx11.py
+++ b/projects/rocprofiler-compute/src/utils/mem_chart_gfx11.py
@@ -42,14 +42,12 @@ from rich.text import Text
 
 from utils.mem_chart_common import (
     COLORS,
-    _fmt_edge,
-    _safe_float_sum,
     bar,
-    format_sci,
+    fmt_edge,
     format_value,
     metric_line,
+    safe_float_sum,
 )
-from utils.utils_analysis import format_bw_human_readable
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -215,7 +213,7 @@ def _extract_metrics(metric_dict: dict[str, Any]) -> dict[str, Any]:
     m["tcp_gl1_read_bw"] = metric_dict.get("TCP-GL1 Read Bandwidth")
     m["tcp_gl1_write_bw"] = metric_dict.get("TCP-GL1 Write Bandwidth")
 
-    m["sqc_gl1_read_bw"] = _safe_float_sum(m["icache_gl1_bw"], m["dcache_gl1_bw"])
+    m["sqc_gl1_read_bw"] = safe_float_sum(m["icache_gl1_bw"], m["dcache_gl1_bw"])
 
     m["gl1c_util"] = metric_dict.get("GL1 Cache Utilization")
     m["gl1c_hit"] = metric_dict.get("GL1 Cache Hit Rate")
@@ -248,7 +246,7 @@ def _build_kernel_and_l0(
 
     Returns (kernel_panel, kernel_edges_text, l0_stack, gl1_edges_text).
     """
-    fmt_bw = format_bw_human_readable
+
     c_rd = COLORS["read"]
     c_wr = COLORS["write"]
     c_at = COLORS["atomic"]
@@ -271,19 +269,19 @@ def _build_kernel_and_l0(
         "",
         "     [white]Request[/white]",
         "",
-        f"[{c_rd}]{_fmt_edge('Read', m['lds_insts'])}[/{c_rd}]",
+        f"[{c_rd}]{fmt_edge('Read', m['lds_insts'])}[/{c_rd}]",
         f"[{c_rd}]{ka_l}[/{c_rd}]",
-        f"[{c_wr}]{_fmt_edge('Write', m['lds_inst_cycles'])}[/{c_wr}]",
+        f"[{c_wr}]{fmt_edge('Write', m['lds_inst_cycles'])}[/{c_wr}]",
         f"[{c_wr}]{ka_r}[/{c_wr}]",
-        f"[{c_at}]{_fmt_edge('Atomic', m['lds_atomic_insts'])}[/{c_at}]",
+        f"[{c_at}]{fmt_edge('Atomic', m['lds_atomic_insts'])}[/{c_at}]",
         f"[{c_at}]{ka_b}[/{c_at}]",
         "",
         "",
         "",
         "",
-        f"[{c_rd}]{_fmt_edge('Read', m['tcp_read_req'])}[/{c_rd}]",
+        f"[{c_rd}]{fmt_edge('Read', m['tcp_read_req'])}[/{c_rd}]",
         f"[{c_rd}]{ka_l}[/{c_rd}]",
-        f"[{c_wr}]{_fmt_edge('Write', m['tcp_write_req'])}[/{c_wr}]",
+        f"[{c_wr}]{fmt_edge('Write', m['tcp_write_req'])}[/{c_wr}]",
         f"[{c_wr}]{ka_r}[/{c_wr}]",
         "",
         "",
@@ -293,9 +291,9 @@ def _build_kernel_and_l0(
         "",
         "",
         "",
-        f"[{c_rd}]{_fmt_edge('ICache', m['icache_req'])}[/{c_rd}]",
+        f"[{c_rd}]{fmt_edge('ICache', m['icache_req'])}[/{c_rd}]",
         f"[{c_rd}]{ka_l}[/{c_rd}]",
-        f"[{c_rd}]{_fmt_edge('DCache', m['dcache_req'])}[/{c_rd}]",
+        f"[{c_rd}]{fmt_edge('DCache', m['dcache_req'])}[/{c_rd}]",
         f"[{c_rd}]{ka_l}[/{c_rd}]",
     ]
     kernel_edges_text = Text.from_markup("\n".join(kernel_edges_lines))
@@ -349,9 +347,9 @@ def _build_kernel_and_l0(
     # Edges to GL1 Cache (TCP and SQC connect, LDS does NOT)
     sa_l = std_arrows["left"]
     sa_r = std_arrows["right"]
-    tcp_gl1_rd = fmt_bw(m["tcp_gl1_read_bw"], precision=1)
-    tcp_gl1_wr = fmt_bw(m["tcp_gl1_write_bw"], precision=1)
-    sqc_gl1_rd = fmt_bw(m["sqc_gl1_read_bw"], precision=1)
+    tcp_gl1_rd = format_value(m["tcp_gl1_read_bw"], "Bytes/s", 1)
+    tcp_gl1_wr = format_value(m["tcp_gl1_write_bw"], "Bytes/s", 1)
+    sqc_gl1_rd = format_value(m["sqc_gl1_read_bw"], "Bytes/s", 1)
     gl1_edges_lines = [
         "",
         "",
@@ -391,7 +389,7 @@ def _build_cache_columns(
 
     Returns (gl1_panel, gl1_gl2_edges_text, gl2_panel).
     """
-    fmt_bw = format_bw_human_readable
+
     c_rd = COLORS["read"]
     c_wr = COLORS["write"]
     c_bl = COLORS["block"]
@@ -412,8 +410,8 @@ def _build_cache_columns(
         height=30,
     )
 
-    rd_bw = fmt_bw(m["gl1_gl2_read_bw"], precision=1)
-    wr_bw = fmt_bw(m["gl1_gl2_write_bw"], precision=1)
+    rd_bw = format_value(m["gl1_gl2_read_bw"], "Bytes/s", 1)
+    wr_bw = format_value(m["gl1_gl2_write_bw"], "Bytes/s", 1)
     gl1_gl2_edges_lines = [
         "",
         "",
@@ -463,15 +461,15 @@ def _build_memory_columns(
 
     Returns (gl2_gcea_edges_text, gcea_panel, dram_edges_text, dram_panel).
     """
-    fmt_bw = format_bw_human_readable
+
     c_rd = COLORS["read"]
     c_wr = COLORS["write"]
     c_bl = COLORS["block"]
     sa_l = std_arrows["left"]
     sa_r = std_arrows["right"]
 
-    gl2_rd = fmt_bw(m["gl2c_read_bw"], precision=1)
-    gl2_wr = fmt_bw(m["gl2c_write_bw"], precision=1)
+    gl2_rd = format_value(m["gl2c_read_bw"], "Bytes/s", 1)
+    gl2_wr = format_value(m["gl2c_write_bw"], "Bytes/s", 1)
     gl2_gcea_edges_lines = [
         "",
         "",
@@ -509,8 +507,8 @@ def _build_memory_columns(
         height=30,
     )
 
-    dram_rd = fmt_bw(m["dram_read_bw"], precision=1)
-    dram_wr = fmt_bw(m["dram_write_bw"], precision=1)
+    dram_rd = format_value(m["dram_read_bw"], "Bytes/s", 1)
+    dram_wr = format_value(m["dram_write_bw"], "Bytes/s", 1)
     dram_edges_lines = [
         "",
         "",
@@ -537,7 +535,7 @@ def _build_memory_columns(
     ]
     dram_edges_text = Text.from_markup("\n".join(dram_edges_lines))
 
-    total = fmt_bw(m["total_bw"], precision=1)
+    total = format_value(m["total_bw"], "Bytes/s", 1)
     dram_panel = Panel(
         "[dim]DDR5/LPDDR5[/dim]\n"
         "\n"

--- a/projects/rocprofiler-compute/src/utils/mem_chart_gfx11.py
+++ b/projects/rocprofiler-compute/src/utils/mem_chart_gfx11.py
@@ -40,6 +40,15 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from utils.mem_chart_common import (
+    COLORS,
+    _fmt_edge,
+    _safe_float_sum,
+    bar,
+    format_sci,
+    format_value,
+    metric_line,
+)
 from utils.utils_analysis import format_bw_human_readable
 
 # ---------------------------------------------------------------------------
@@ -123,105 +132,6 @@ MEM_CHART_PANEL_METRIC_KEYS: tuple[str, ...] = tuple(
 )
 
 DEFAULT_SAMPLE_METRICS: dict[str, Union[int, float]] = dict(_MEM_CHART_DEFAULT_ROWS)
-
-COLORS = {
-    "kernel": "green",
-    "block": "blue",
-    "tcp": "cyan",
-    "lds": "magenta",
-    "sqc": "yellow",
-    "read": "bright_cyan",
-    "write": "bright_yellow",
-    "atomic": "bright_magenta",
-    "util": "bright_green",
-    "hit": "yellow",
-    "stall": "indian_red",
-    "bw": "bright_cyan",
-}
-
-# ---------------------------------------------------------------------------
-# Formatting helpers
-# ---------------------------------------------------------------------------
-
-
-def format_value(
-    value: Union[int, float, str, None], unit: str = "", precision: int = 1
-) -> str:
-    if value is None:
-        return "N/A"
-    if isinstance(value, str):
-        try:
-            value = float(value)
-        except (ValueError, TypeError):
-            return value
-    if unit == "%":
-        return f"{value:.{precision}f}%"
-    elif unit in ("GB/s", "Bytes/s"):
-        return format_bw_human_readable(value, unit, precision)
-    else:
-        return f"{value:.{precision}f}{unit}"
-
-
-def format_sci(value: Union[int, float, str, None], precision: int = 2) -> str:
-    if value is None:
-        return "N/A"
-    try:
-        value = float(value)
-    except (ValueError, TypeError):
-        return "N/A"
-    if abs(value) < 1000:
-        return f"{int(value)}"
-    return f"{value:.{precision}e}"
-
-
-def metric_line(
-    label: str,
-    value: Any,  # noqa: ANN401
-    unit: str = "%",
-    color: str = "bright_green",
-) -> str:
-    formatted = format_value(value, unit)
-    return f"{label} [{color}]{formatted}[/{color}]"
-
-
-def bar(pct: float, w: int = 10) -> str:
-    if pct is None:
-        return "░" * w
-    try:
-        pct = float(pct)
-    except (ValueError, TypeError):
-        return "░" * w
-    filled = int(w * min(100, max(0, pct)) / 100)
-    return "█" * filled + "░" * (w - filled)
-
-
-def _safe_float_sum(
-    *values: Union[int, float, str, None],
-) -> Optional[float]:
-    """Sum non-None numeric values. Returns None if no value is valid."""
-    total = 0.0
-    any_valid = False
-    for v in values:
-        if v is not None:
-            try:
-                total += float(v)
-                any_valid = True
-            except (ValueError, TypeError):
-                pass
-    return total if any_valid else None
-
-
-def _fmt_edge(
-    label: str,
-    value: Any,  # noqa: ANN401
-    width: int = 7,
-) -> str:
-    label_str = f"{label:<{width}}"
-    if value is not None:
-        value_str = f": {format_sci(value):>7}"
-    else:
-        value_str = ""
-    return f"{label_str}{value_str}"
 
 
 # ---------------------------------------------------------------------------

--- a/projects/rocprofiler-compute/tests/test_mem_chart.py
+++ b/projects/rocprofiler-compute/tests/test_mem_chart.py
@@ -11,7 +11,8 @@ Covers:
 
 import common
 
-from utils import mem_chart_gfx9, mem_chart_gfx11
+from utils import mem_chart_common, mem_chart_gfx9, mem_chart_gfx11
+from utils.utils_analysis import format_bw_human_readable
 
 # =============================================================================
 # Tests for format_bw_human_readable function (gfx11)
@@ -24,104 +25,93 @@ class TestFormatBwHumanReadable:
     def test_terabytes_per_second(self):
         """Test TB/s formatting for values >= 1e12."""
         # 1 TB/s
-        result = mem_chart_gfx11.format_bw_human_readable(1e12, "Bytes/s", 1)
+        result = format_bw_human_readable(1e12, "Bytes/s", 1)
         assert result == "1.0 TB/s"
 
         # 2.5 TB/s
-        result = mem_chart_gfx11.format_bw_human_readable(2.5e12, "Bytes/s", 1)
+        result = format_bw_human_readable(2.5e12, "Bytes/s", 1)
         assert result == "2.5 TB/s"
 
         # Large value with higher precision
-        result = mem_chart_gfx11.format_bw_human_readable(1.234e12, "Bytes/s", 2)
+        result = format_bw_human_readable(1.234e12, "Bytes/s", 2)
         assert result == "1.23 TB/s"
 
     def test_gigabytes_per_second(self):
         """Test GB/s formatting for values >= 1e9 and < 1e12."""
         # 1 GB/s
-        result = mem_chart_gfx11.format_bw_human_readable(1e9, "Bytes/s", 1)
+        result = format_bw_human_readable(1e9, "Bytes/s", 1)
         assert result == "1.0 GB/s"
 
         # 100 GB/s (typical HBM bandwidth)
-        result = mem_chart_gfx11.format_bw_human_readable(100e9, "Bytes/s", 1)
+        result = format_bw_human_readable(100e9, "Bytes/s", 1)
         assert result == "100.0 GB/s"
 
         # 512.5 GB/s
-        result = mem_chart_gfx11.format_bw_human_readable(512.5e9, "Bytes/s", 1)
+        result = format_bw_human_readable(512.5e9, "Bytes/s", 1)
         assert result == "512.5 GB/s"
 
     def test_megabytes_per_second(self):
         """Test MB/s formatting for values >= 1e6 and < 1e9."""
         # 1 MB/s
-        result = mem_chart_gfx11.format_bw_human_readable(1e6, "Bytes/s", 1)
+        result = format_bw_human_readable(1e6, "Bytes/s", 1)
         assert result == "1.0 MB/s"
 
         # 500 MB/s
-        result = mem_chart_gfx11.format_bw_human_readable(500e6, "Bytes/s", 1)
+        result = format_bw_human_readable(500e6, "Bytes/s", 1)
         assert result == "500.0 MB/s"
 
     def test_kilobytes_per_second(self):
         """Test KB/s formatting for values >= 1e3 and < 1e6."""
         # 1 KB/s
-        result = mem_chart_gfx11.format_bw_human_readable(1e3, "Bytes/s", 1)
+        result = format_bw_human_readable(1e3, "Bytes/s", 1)
         assert result == "1.0 KB/s"
 
         # 512 KB/s
-        result = mem_chart_gfx11.format_bw_human_readable(512e3, "Bytes/s", 1)
+        result = format_bw_human_readable(512e3, "Bytes/s", 1)
         assert result == "512.0 KB/s"
 
     def test_bytes_per_second(self):
         """Test B/s formatting for values < 1e3."""
         # 500 B/s
-        result = mem_chart_gfx11.format_bw_human_readable(500, "Bytes/s", 1)
+        result = format_bw_human_readable(500, "Bytes/s", 1)
         assert result == "500.0 B/s"
 
         # 0 B/s
-        result = mem_chart_gfx11.format_bw_human_readable(0, "Bytes/s", 1)
+        result = format_bw_human_readable(0, "Bytes/s", 1)
         assert result == "0.0 B/s"
 
     def test_legacy_gbps_unit_conversion(self):
         """Test conversion from legacy GB/s unit to human-readable."""
         # Input is 100 GB/s, should convert to Bytes/s first then format
-        result = mem_chart_gfx11.format_bw_human_readable(100, "GB/s", 1)
+        result = format_bw_human_readable(100, "GB/s", 1)
         assert result == "100.0 GB/s"
 
         # 1500 GB/s -> 1.5 TB/s
-        result = mem_chart_gfx11.format_bw_human_readable(1500, "GB/s", 1)
+        result = format_bw_human_readable(1500, "GB/s", 1)
         assert result == "1.5 TB/s"
 
     def test_none_value(self):
         """Test handling of None values."""
-        result = mem_chart_gfx11.format_bw_human_readable(None, "Bytes/s", 1)
+        result = format_bw_human_readable(None, "Bytes/s", 1)
         assert result == "N/A"
 
     def test_invalid_string_value(self):
         """Test handling of non-numeric string values."""
-        result = mem_chart_gfx11.format_bw_human_readable("invalid", "Bytes/s", 1)
+        result = format_bw_human_readable("invalid", "Bytes/s", 1)
         assert result == "N/A"
 
     def test_precision_parameter(self):
         """Test different precision values."""
         value = 123.456789e9  # 123.456789 GB/s
 
-        assert (
-            mem_chart_gfx11.format_bw_human_readable(value, "Bytes/s", 0) == "123 GB/s"
-        )
-        assert (
-            mem_chart_gfx11.format_bw_human_readable(value, "Bytes/s", 1)
-            == "123.5 GB/s"
-        )
-        assert (
-            mem_chart_gfx11.format_bw_human_readable(value, "Bytes/s", 2)
-            == "123.46 GB/s"
-        )
-        assert (
-            mem_chart_gfx11.format_bw_human_readable(value, "Bytes/s", 3)
-            == "123.457 GB/s"
-        )
+        assert format_bw_human_readable(value, "Bytes/s", 0) == "123 GB/s"
+        assert format_bw_human_readable(value, "Bytes/s", 1) == "123.5 GB/s"
+        assert format_bw_human_readable(value, "Bytes/s", 2) == "123.46 GB/s"
+        assert format_bw_human_readable(value, "Bytes/s", 3) == "123.457 GB/s"
 
 
 # =============================================================================
-# Tests for format_value function (gfx11)
+# Tests for format_value function (mem_chart_common)
 # =============================================================================
 
 
@@ -130,40 +120,40 @@ class TestFormatValue:
 
     def test_percentage_formatting(self):
         """Test percentage formatting."""
-        result = mem_chart_gfx11.format_value(85.5, "%", 1)
+        result = mem_chart_common.format_value(85.5, "%", 1)
         assert result == "85.5%"
 
-        result = mem_chart_gfx11.format_value(100, "%", 0)
+        result = mem_chart_common.format_value(100, "%", 0)
         assert result == "100%"
 
     def test_bytes_per_second_unit(self):
         """Test Bytes/s formatting routes to human-readable."""
-        result = mem_chart_gfx11.format_value(100e9, "Bytes/s", 1)
+        result = mem_chart_common.format_value(100e9, "Bytes/s", 1)
         assert "GB/s" in result
 
     def test_gbps_unit(self):
         """Test GB/s formatting routes to human-readable."""
-        result = mem_chart_gfx11.format_value(100, "GB/s", 1)
+        result = mem_chart_common.format_value(100, "GB/s", 1)
         assert "GB/s" in result
 
     def test_none_value(self):
         """Test handling of None values."""
-        result = mem_chart_gfx11.format_value(None, "%", 1)
+        result = mem_chart_common.format_value(None, "%", 1)
         assert result == "N/A"
 
     def test_string_value_conversion(self):
         """Test conversion of string values to float."""
-        result = mem_chart_gfx11.format_value("50.5", "%", 1)
+        result = mem_chart_common.format_value("50.5", "%", 1)
         assert result == "50.5%"
 
     def test_invalid_string_value(self):
         """Test handling of non-convertible string values."""
-        result = mem_chart_gfx11.format_value("invalid", "%", 1)
+        result = mem_chart_common.format_value("invalid", "%", 1)
         assert result == "invalid"
 
 
 # =============================================================================
-# Tests for format_sci function (gfx11)
+# Tests for format_sci function (mem_chart_common)
 # =============================================================================
 
 
@@ -172,38 +162,38 @@ class TestFormatSci:
 
     def test_small_numbers_no_scientific(self):
         """Test that small numbers are displayed as integers."""
-        assert mem_chart_gfx11.format_sci(100) == "100"
-        assert mem_chart_gfx11.format_sci(999) == "999"
+        assert mem_chart_common.format_sci(100) == "100"
+        assert mem_chart_common.format_sci(999) == "999"
 
     def test_large_numbers_scientific(self):
         """Test that large numbers are displayed in scientific notation."""
-        result = mem_chart_gfx11.format_sci(1000000)
+        result = mem_chart_common.format_sci(1000000)
         assert "e" in result.lower()
 
-        result = mem_chart_gfx11.format_sci(12345678, 2)
+        result = mem_chart_common.format_sci(12345678, 2)
         assert "e" in result.lower()
 
     def test_none_value(self):
         """Test handling of None values."""
-        result = mem_chart_gfx11.format_sci(None)
+        result = mem_chart_common.format_sci(None)
         assert result == "N/A"
 
     def test_invalid_value(self):
         """Test handling of invalid values."""
-        result = mem_chart_gfx11.format_sci("invalid")
+        result = mem_chart_common.format_sci("invalid")
         assert result == "N/A"
 
     def test_negative_numbers(self):
         """Test negative number handling."""
-        result = mem_chart_gfx11.format_sci(-500)
+        result = mem_chart_common.format_sci(-500)
         assert result == "-500"
 
-        result = mem_chart_gfx11.format_sci(-1000000)
+        result = mem_chart_common.format_sci(-1000000)
         assert "e" in result.lower()
 
 
 # =============================================================================
-# Tests for bar function (gfx11)
+# Tests for bar function (mem_chart_common)
 # =============================================================================
 
 
@@ -212,45 +202,45 @@ class TestBar:
 
     def test_full_bar(self):
         """Test 100% progress bar."""
-        result = mem_chart_gfx11.bar(100, 10)
+        result = mem_chart_common.bar(100, 10)
         assert "█" * 10 in result
         assert "░" not in result
 
     def test_empty_bar(self):
         """Test 0% progress bar."""
-        result = mem_chart_gfx11.bar(0, 10)
+        result = mem_chart_common.bar(0, 10)
         assert "░" * 10 in result
         assert "█" not in result
 
     def test_partial_bar(self):
         """Test 50% progress bar."""
-        result = mem_chart_gfx11.bar(50, 10)
+        result = mem_chart_common.bar(50, 10)
         assert "█" * 5 in result
         assert "░" * 5 in result
 
     def test_none_value(self):
         """Test None value returns empty bar."""
-        result = mem_chart_gfx11.bar(None, 10)
+        result = mem_chart_common.bar(None, 10)
         assert "░" * 10 in result
 
     def test_invalid_value(self):
         """Test invalid value returns empty bar."""
-        result = mem_chart_gfx11.bar("invalid", 10)
+        result = mem_chart_common.bar("invalid", 10)
         assert "░" * 10 in result
 
     def test_over_100_clamped(self):
         """Test values over 100% are clamped."""
-        result = mem_chart_gfx11.bar(150, 10)
+        result = mem_chart_common.bar(150, 10)
         assert "█" * 10 in result
 
     def test_negative_clamped(self):
         """Test negative values are clamped to 0."""
-        result = mem_chart_gfx11.bar(-50, 10)
+        result = mem_chart_common.bar(-50, 10)
         assert "░" * 10 in result
 
 
 # =============================================================================
-# Tests for metric_line function (gfx11)
+# Tests for metric_line function (mem_chart_common)
 # =============================================================================
 
 
@@ -259,14 +249,14 @@ class TestMetricLine:
 
     def test_basic_metric(self):
         """Test basic metric line formatting."""
-        result = mem_chart_gfx11.metric_line("Util", 75.5, "%", "green")
+        result = mem_chart_common.metric_line("Util", 75.5, "%", "green")
         assert "Util" in result
         assert "75.5%" in result
         assert "green" in result
 
     def test_with_none_value(self):
         """Test metric line with None value."""
-        result = mem_chart_gfx11.metric_line("BW", None, "GB/s", "cyan")
+        result = mem_chart_common.metric_line("BW", None, "GB/s", "cyan")
         assert "BW" in result
         assert "N/A" in result
 
@@ -624,12 +614,22 @@ class TestPlotMemChartGfx9:
     def test_contains_cdna_architecture_elements(self):
         """Output contains all CDNA memory hierarchy block names."""
         result = mem_chart_gfx9.plot_mem_chart(
-            "per_kernel", dict(GFX9_SAMPLE_METRICS),
+            "per_kernel",
+            dict(GFX9_SAMPLE_METRICS),
         )
         stripped = common.strip_ansi(result)
         expected_blocks = [
-            "Kernel", "Requests", "VL1D", "LDS", "sL1D",
-            "L1I", "L2", "Data Fabric", "MALL", "UMC", "HBM",
+            "Kernel",
+            "Requests",
+            "VL1D",
+            "LDS",
+            "sL1D",
+            "L1I",
+            "L2",
+            "Data Fabric",
+            "MALL",
+            "UMC",
+            "HBM",
         ]
         for block in expected_blocks:
             assert block in stripped, f"Missing block: {block}"
@@ -649,7 +649,9 @@ class TestPlotMemChartGfx9:
         """Custom chart_title appears in output."""
         title = "Custom CDNA Chart Title"
         result = mem_chart_gfx9.plot_mem_chart(
-            "per_kernel", dict(GFX9_SAMPLE_METRICS), chart_title=title,
+            "per_kernel",
+            dict(GFX9_SAMPLE_METRICS),
+            chart_title=title,
         )
         stripped = common.strip_ansi(result)
         assert title in stripped
@@ -731,3 +733,45 @@ class TestIntegrationGfx9:
         result = mem_chart_gfx9.plot_mem_chart("per_kernel", metrics)
         assert isinstance(result, str)
         assert len(result) > 100
+
+
+# =============================================================================
+# Tests for mem_chart_common helpers
+# =============================================================================
+
+
+class TestSafeFloatSum:
+    """Tests for safe_float_sum — tolerant numeric aggregation."""
+
+    def test_mixed_valid_and_none(self):
+        assert mem_chart_common.safe_float_sum(1.5, None, 2.5) == 4.0
+
+    def test_all_none_returns_none(self):
+        assert mem_chart_common.safe_float_sum(None, None) is None
+
+    def test_string_numbers_coerced(self):
+        assert mem_chart_common.safe_float_sum("10", 5) == 15.0
+
+    def test_unparseable_strings_skipped(self):
+        assert mem_chart_common.safe_float_sum("bad", 7) == 7.0
+
+    def test_all_unparseable_returns_none(self):
+        assert mem_chart_common.safe_float_sum(None, "bad") is None
+
+
+class TestFmtEdge:
+    """Tests for fmt_edge — edge label formatter for diagram arrows."""
+
+    def test_with_value_includes_sci_notation(self):
+        result = mem_chart_common.fmt_edge("Read", 1_500_000)
+        assert "Read" in result
+        assert "1.50e+06" in result
+
+    def test_none_value_omits_number(self):
+        result = mem_chart_common.fmt_edge("Write", None)
+        assert "Write" in result
+        assert ":" not in result
+
+    def test_small_value_shows_integer(self):
+        result = mem_chart_common.fmt_edge("Atomic", 42)
+        assert "42" in result

--- a/projects/rocprofiler-compute/tests/test_mem_chart.py
+++ b/projects/rocprofiler-compute/tests/test_mem_chart.py
@@ -620,3 +620,114 @@ class TestPlotMemChartGfx9:
         result = mem_chart_gfx9.plot_mem_chart("per_kernel", partial)
         assert isinstance(result, str)
         assert len(result) > 0
+
+    def test_contains_cdna_architecture_elements(self):
+        """Output contains all CDNA memory hierarchy block names."""
+        result = mem_chart_gfx9.plot_mem_chart(
+            "per_kernel", dict(GFX9_SAMPLE_METRICS),
+        )
+        stripped = common.strip_ansi(result)
+        expected_blocks = [
+            "Kernel", "Requests", "VL1D", "LDS", "sL1D",
+            "L1I", "L2", "Data Fabric", "MALL", "UMC", "HBM",
+        ]
+        for block in expected_blocks:
+            assert block in stripped, f"Missing block: {block}"
+
+    def test_contains_legend(self):
+        """Output contains the color legend."""
+        result = mem_chart_gfx9.plot_mem_chart("per_kernel", dict(GFX9_SAMPLE_METRICS))
+        stripped = common.strip_ansi(result)
+        assert "Legend" in stripped
+
+    def test_contains_utilization_bars(self):
+        """Output contains utilization bar characters."""
+        result = mem_chart_gfx9.plot_mem_chart("per_kernel", dict(GFX9_SAMPLE_METRICS))
+        assert "█" in result or "░" in result
+
+    def test_chart_title_override(self):
+        """Custom chart_title appears in output."""
+        title = "Custom CDNA Chart Title"
+        result = mem_chart_gfx9.plot_mem_chart(
+            "per_kernel", dict(GFX9_SAMPLE_METRICS), chart_title=title,
+        )
+        stripped = common.strip_ansi(result)
+        assert title in stripped
+
+
+class TestGetSampleMetricsGfx9:
+    """Tests for gfx9 get_sample_metrics."""
+
+    def test_returns_dict(self):
+        result = mem_chart_gfx9.get_sample_metrics()
+        assert isinstance(result, dict)
+
+    def test_contains_all_keys(self):
+        result = mem_chart_gfx9.get_sample_metrics()
+        for key in mem_chart_gfx9.MEM_CHART_PANEL_METRIC_KEYS:
+            assert key in result, f"Missing key: {key}"
+
+    def test_all_values_numeric(self):
+        result = mem_chart_gfx9.get_sample_metrics()
+        for key, val in result.items():
+            assert isinstance(val, (int, float)), f"Non-numeric: {key}={val}"
+
+    def test_returns_copy(self):
+        a = mem_chart_gfx9.get_sample_metrics()
+        b = mem_chart_gfx9.get_sample_metrics()
+        a["VL1 Hit"] = -999
+        assert b["VL1 Hit"] != -999
+
+
+class TestNormalizeMemChartMetricsGfx9:
+    """Tests for gfx9 normalize_mem_chart_metrics."""
+
+    def test_preserves_known_keys(self):
+        result = mem_chart_gfx9.normalize_mem_chart_metrics({"VL1 Hit": 92})
+        assert result["VL1 Hit"] == 92
+
+    def test_fills_missing_with_none(self):
+        result = mem_chart_gfx9.normalize_mem_chart_metrics({})
+        for key in mem_chart_gfx9.MEM_CHART_PANEL_METRIC_KEYS:
+            assert key in result
+            assert result[key] is None
+
+    def test_drops_unknown_keys(self):
+        result = mem_chart_gfx9.normalize_mem_chart_metrics({"UNKNOWN_KEY": 42})
+        assert "UNKNOWN_KEY" not in result
+
+
+class TestDefaultSampleMetricsGfx9:
+    """Tests for gfx9 DEFAULT_SAMPLE_METRICS."""
+
+    def test_keys_match_panel_keys(self):
+        assert set(mem_chart_gfx9.DEFAULT_SAMPLE_METRICS.keys()) == set(
+            mem_chart_gfx9.MEM_CHART_PANEL_METRIC_KEYS
+        )
+
+    def test_has_all_hierarchy_levels(self):
+        keys = set(mem_chart_gfx9.DEFAULT_SAMPLE_METRICS.keys())
+        for prefix in ["VL1", "sL1D", "IL1", "L2", "Fabric", "HBM"]:
+            assert any(prefix in k for k in keys), f"Missing hierarchy: {prefix}"
+
+
+class TestFormatMemChartHeadingGfx9:
+    """Tests for gfx9 format_mem_chart_heading."""
+
+    def test_default_heading(self):
+        result = mem_chart_gfx9.format_mem_chart_heading("per_kernel")
+        assert result == "3. Memory Chart (Normalization: per_kernel)"
+
+    def test_custom_panel_id(self):
+        result = mem_chart_gfx9.format_mem_chart_heading("per_wave", panel_id=500)
+        assert "5." in result
+
+
+class TestIntegrationGfx9:
+    """Integration tests for gfx9 chart."""
+
+    def test_full_workflow(self):
+        metrics = mem_chart_gfx9.get_sample_metrics()
+        result = mem_chart_gfx9.plot_mem_chart("per_kernel", metrics)
+        assert isinstance(result, str)
+        assert len(result) > 100


### PR DESCRIPTION
## Motivation

`mem_chart_gfx11.py` contained general-purpose formatting functions that are not specific to the RDNA3.5 architecture. Moving them to a shared module avoids duplication when adding chart renderers for other architectures.

Prep work for #8648 

## Technical Details

- New file `src/utils/mem_chart_common.py` — contains common helper functions
- `src/utils/mem_chart_gfx11.py` — removed the inlined helpers and imports them from `mem_chart_common`. Replaced 10 direct `format_bw_human_readable` call sites with `format_value(..., "Bytes/s", ...)` to consolidate bandwidth formatting through a single code path.
- `tests/test_mem_chart.py` — updated existing tests to reference `mem_chart_common` instead of `mem_chart_gfx11`. Added new tests for `safe_float_sum` and `fmt_edge`. Fixed a fragile test import that accessed `format_bw_human_readable` through a re-export instead of its canonical module.

## JIRA ID

AIPROFCOMP-116

## Test Plan

- All test_mem_chart.py tests pass (gfx11 + common helpers)

## Test Result

- [x] All test_mem_chart.py tests pass (gfx11 + common helpers)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
