### PR TITLE
[hotswap] Add env var to force entry trampolines for all agents

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -35,6 +35,8 @@ constexpr const char* kGfx1251Isa = "amdgcn-amd-amdhsa--gfx1251";
 constexpr const char* kGfx12_5GenericIsa =
     "amdgcn-amd-amdhsa--gfx12-5-generic";
 constexpr const char* kGfx942Isa = "amdgcn-amd-amdhsa--gfx942";
+constexpr const char* kGfx1030Isa = "amdgcn-amd-amdhsa--gfx1030";
+constexpr const char* kGfx1200Isa = "amdgcn-amd-amdhsa--gfx1200";
 constexpr const char* kGfx1250B0Isa =
     "amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+";
 constexpr const char* kGfx1250A0Isa =
@@ -399,6 +401,72 @@ TEST(HotswapRewriteDecision, EntryTrampolinesBlockNonGfx12_5) {
   options.entry_trampolines_enabled = true;
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
       MakeRevision("gfx942", 0), kGfx942Isa, kGfx942Isa, options);
+
+  EXPECT_FALSE(decision.has_value());
+}
+
+// Without any option set, gfx10.3 / gfx12.0 are not rewritten: entry
+// trampolines are driven by AMD_COMGR_HOTSWAP_FORCE_ENTRY_TRAMPOLINES (or the
+// gfx12.5 opt-in), not hardcoded per target.
+TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOffForGfx1030) {
+  const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx1030", 0), kGfx1030Isa, kGfx1030Isa, {});
+
+  EXPECT_FALSE(decision.has_value());
+}
+
+// Force-all routes gfx10.3 to entry trampolines: best-effort (rewrite not
+// required), with the source ISA reused as the target.
+TEST(HotswapRewriteDecision, ForceAllRoutesGfx1030) {
+  rocr::hotswap::RewriteOptions options;
+  options.force_all_entry_trampolines = true;
+  const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx1030", 0), kGfx1030Isa, kGfx1030Isa, options);
+
+  ASSERT_TRUE(decision.has_value());
+  EXPECT_EQ(decision->source_isa, kGfx1030Isa);
+  EXPECT_EQ(decision->target_isa, kGfx1030Isa);
+  EXPECT_TRUE(decision->request_entry_trampolines);
+  EXPECT_FALSE(decision->request_strict_mode);
+  EXPECT_FALSE(decision->rewrite_required);
+}
+
+// Force-all also routes gfx12.0.
+TEST(HotswapRewriteDecision, ForceAllRoutesGfx1200) {
+  rocr::hotswap::RewriteOptions options;
+  options.force_all_entry_trampolines = true;
+  const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx1200", 0), kGfx1200Isa, kGfx1200Isa, options);
+
+  ASSERT_TRUE(decision.has_value());
+  EXPECT_EQ(decision->source_isa, kGfx1200Isa);
+  EXPECT_EQ(decision->target_isa, kGfx1200Isa);
+  EXPECT_TRUE(decision->request_entry_trampolines);
+  EXPECT_FALSE(decision->request_strict_mode);
+  EXPECT_FALSE(decision->rewrite_required);
+}
+
+// Force-all is best-effort for every target: even a target COMGR does not
+// support (gfx942) yields a decision; COMGR rejects it at rewrite time and the
+// loader falls back to the original code object.
+TEST(HotswapRewriteDecision, ForceAllRoutesUnsupportedTargetBestEffort) {
+  rocr::hotswap::RewriteOptions options;
+  options.force_all_entry_trampolines = true;
+  const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx942", 0), kGfx942Isa, kGfx942Isa, options);
+
+  ASSERT_TRUE(decision.has_value());
+  EXPECT_TRUE(decision->request_entry_trampolines);
+  EXPECT_FALSE(decision->rewrite_required);
+}
+
+// Force-all still requires the code object's ISA to match the agent's gfx
+// target (a gfx1200 ELF on a gfx1030 agent is not rewritten).
+TEST(HotswapRewriteDecision, ForceAllRequiresMatchingIsa) {
+  rocr::hotswap::RewriteOptions options;
+  options.force_all_entry_trampolines = true;
+  const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx1030", 0), kGfx1200Isa, kGfx1200Isa, options);
 
   EXPECT_FALSE(decision.has_value());
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
@@ -71,6 +71,12 @@ inline constexpr bool kDefaultEntryTrampolinesEnabled = false;
 struct RewriteOptions {
   bool entry_trampolines_enabled = kDefaultEntryTrampolinesEnabled;
   bool strict_mode_enabled = false;
+  // When set (AMD_COMGR_HOTSWAP_FORCE_ENTRY_TRAMPOLINES), request entry
+  // trampolines for every agent whose loaded code object's ISA matches, not
+  // just gfx12.5. This is best-effort: COMGR applies the rewrite only on
+  // targets it supports and reports an error otherwise, so unsupported targets
+  // fall back to the original code object.
+  bool force_all_entry_trampolines = false;
 };
 
 struct RewriteDecision {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -108,6 +108,12 @@ bool AreEntryTrampolinesRequested() {
   return IsEnvFlagEnabled(kEnvName);
 }
 
+// Opt-in override to force the entry-trampoline rewrite on every agent (not
+// only gfx12.5). Best-effort: COMGR gates actual support per target.
+bool AreEntryTrampolinesForcedForAll() {
+  return IsEnvFlagEnabled("AMD_COMGR_HOTSWAP_FORCE_ENTRY_TRAMPOLINES");
+}
+
 bool IsStrictModeRequested() {
   return IsEnvFlagEnabled("HSA_HOTSWAP_STRICT_MODE");
 }
@@ -290,7 +296,8 @@ bool HasCandidateHotswapRewrite(const AgentGfxRevision& gfx,
                                 const RewriteOptions& options) {
   return IsHotswapSupportedGfxRevision(gfx) ||
       (options.strict_mode_enabled && gfx.gfx_target == kGfx1250) ||
-      (options.entry_trampolines_enabled && IsGfx12_5Target(gfx.gfx_target));
+      (options.entry_trampolines_enabled && IsGfx12_5Target(gfx.gfx_target)) ||
+      (options.force_all_entry_trampolines && !gfx.gfx_target.empty());
 }
 
 std::optional<RewriteDecision> DecideHotswapRewrite(
@@ -316,8 +323,14 @@ std::optional<RewriteDecision> DecideHotswapRewrite(
     return decision;
   }
 
-  const bool request_entry_trampolines = options.entry_trampolines_enabled &&
-      IsGfx12_5Target(gfx.gfx_target) && IsGfx12_5Target(source_gfx);
+  // Force-all: request entry trampolines for any agent whose loaded code
+  // object's ISA matches, independent of the gfx12.5 opt-in. Best-effort --
+  // COMGR gates actual per-target support and the load falls back on error.
+  const bool force_all_trampolines = options.force_all_entry_trampolines &&
+      !source_gfx.empty() && source_gfx == gfx.gfx_target;
+  const bool request_entry_trampolines = force_all_trampolines ||
+      (options.entry_trampolines_enabled &&
+       IsGfx12_5Target(gfx.gfx_target) && IsGfx12_5Target(source_gfx));
   const bool request_strict_mode =
       options.strict_mode_enabled && gfx.gfx_target == kGfx1250 &&
       source_gfx == kGfx1250;
@@ -485,6 +498,7 @@ RetargetCodeObjectResult TryRetargetCodeObject(const CodeObjectView& code_object
   RewriteOptions options;
   options.entry_trampolines_enabled = AreEntryTrampolinesRequested();
   options.strict_mode_enabled = IsStrictModeRequested();
+  options.force_all_entry_trampolines = AreEntryTrampolinesForcedForAll();
   if (!IsAgentEligibleForHotswap(gfx, options)) {
     return {};
   }


### PR DESCRIPTION
Introduce AMD_COMGR_HOTSWAP_FORCE_ENTRY_TRAMPOLINES: when enabled, the loader requests the entry-trampoline rewrite for every agent whose loaded code object's ISA matches, instead of only gfx12.5. This replaces any per-target hardcoding with a single, general override useful for bring-up and validation on any target COMGR supports (currently gfx1250, gfx1030, gfx1200).

The override is best-effort: the decision reuses the source ISA as the target and leaves rewrite_required false, so COMGR gates actual per-target support and a rewrite/rewritten-load failure falls back to the original code object. A target COMGR cannot handle simply loads unrewritten.

- hotswap.hpp: add RewriteOptions::force_all_entry_trampolines.
- hotswap.cpp: read AMD_COMGR_HOTSWAP_FORCE_ENTRY_TRAMPOLINES into the option; admit any non-empty gfx target in HasCandidateHotswapRewrite(); and OR a force-all clause into DecideHotswapRewrite()'s request_entry_trampolines. The force-all path still requires the code object's gfx target to equal the agent's, preserving COMGR's source==target contract.

Behavior notes:
- Default (no env) is unchanged: nothing is forced; gfx12.5 keeps its existing AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES opt-in.
- HSA_HOTSWAP_DISABLE still disables the rewrite globally (checked first).

Tests (hotswap_rewrite_test.cc): gfx1030/gfx1200 are not rewritten by default; force-all routes gfx1030, gfx1200, and (best-effort) an unsupported target; and force-all still requires the code object ISA to match the agent.