### PR TITLE
rocr: DRM user-queue fixes for UKI (user_queue=1, gfx1200)

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -4892,10 +4892,16 @@ HSAKMT_STATUS hsakmt_fmm_export_dma_buf_fd(HsaKFDContext *ctx,
 		if (offset + MemorySizeInBytes <= obj->size) {
 			/* DRM-allocated BOs have no valid KFD handle for the KFD
 			 * export ioctl; export them through libdrm instead so the
-			 * unified interface (hsakmt_enable_drm) works.
+			 * unified interface (hsakmt_enable_drm) works. Guard on a
+			 * non-NULL DRM handle: some VRAM-domain BOs fall back to the
+			 * KFD alloc path (e.g. contiguous VRAM, which the kernel
+			 * rejects from userspace DRM BOs) and thus have no DRM handle;
+			 * those must use the KFD export ioctl below to avoid passing
+			 * NULL to amdgpu_bo_export().
 			 */
 			if (hsakmt_enable_drm &&
-			    is_supported_on_drm(obj->alloc_flags)) {
+			    is_supported_on_drm(obj->alloc_flags) &&
+			    obj->handles[0].drm) {
 				export_use_drm = true;
 				export_drm_bo = obj->handles[0].drm;
 			} else {

--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -4872,6 +4872,8 @@ HSAKMT_STATUS hsakmt_fmm_export_dma_buf_fd(HsaKFDContext *ctx,
 	HsaApertureInfo ApeInfo;
 	vm_object_t *obj;
 	HSAuint64 offset;
+	bool export_use_drm = false;
+	amdgpu_bo_handle export_drm_bo = NULL;
 	int r;
 	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
@@ -4884,9 +4886,19 @@ HSAKMT_STATUS hsakmt_fmm_export_dma_buf_fd(HsaKFDContext *ctx,
 	if (obj) {
 		offset = VOID_PTRS_SUB(MemoryAddress, obj->start);
 		if (offset + MemorySizeInBytes <= obj->size) {
-			exportArgs.handle = obj->handles[0].kfd;
-			exportArgs.flags = O_CLOEXEC;
-			exportArgs.dmabuf_fd = 0;
+			/* DRM-allocated BOs have no valid KFD handle for the KFD
+			 * export ioctl; export them through libdrm instead so the
+			 * unified interface (hsakmt_enable_drm) works.
+			 */
+			if (hsakmt_enable_drm &&
+			    is_supported_on_drm(obj->alloc_flags)) {
+				export_use_drm = true;
+				export_drm_bo = obj->handles[0].drm;
+			} else {
+				exportArgs.handle = obj->handles[0].kfd;
+				exportArgs.flags = O_CLOEXEC;
+				exportArgs.dmabuf_fd = 0;
+			}
 		} else {
 			obj = NULL;
 		}
@@ -4894,6 +4906,19 @@ HSAKMT_STATUS hsakmt_fmm_export_dma_buf_fd(HsaKFDContext *ctx,
 	pthread_mutex_unlock(&aperture->fmm_mutex);
 	if (!obj)
 		return HSAKMT_STATUS_INVALID_PARAMETER;
+
+	if (export_use_drm) {
+		uint32_t drm_dmabuf_fd = 0;
+
+		if (amdgpu_bo_export(export_drm_bo,
+				     amdgpu_bo_handle_type_dma_buf_fd,
+				     &drm_dmabuf_fd) != 0)
+			return HSAKMT_STATUS_ERROR;
+
+		*DMABufFd = (int)drm_dmabuf_fd;
+		*Offset = offset;
+		return HSAKMT_STATUS_SUCCESS;
+	}
 
 	r = hsakmt_ioctl(ctx->fd, AMDKFD_IOC_EXPORT_DMABUF, (void *)&exportArgs);
 	if (r)

--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -1566,7 +1566,11 @@ static vm_object_t *fmm_allocate_memory_object(HsaKFDContext *ctx,
 {
 	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
-	if (hsakmt_enable_drm && is_supported_on_drm(alloc_flags)) {
+	/* AMDGPU_GEM_CREATE_VRAM_CONTIGUOUS is not in SETTABLE_MASK so the kernel
+	 * rejects it from userspace DRM BOs. Fall back to the KFD path which has
+	 * its own KFD_IOC_ALLOC_MEM_FLAGS_CONTIGUOUS_BEST_EFFORT mechanism. */
+	if (hsakmt_enable_drm && is_supported_on_drm(alloc_flags) &&
+	    !alloc_flags.mflags.ui32.Contiguous) {
 		return fmm_allocate_memory_object_drm(fmm_ctx, gpu_id, mem,
 						MemorySizeInBytes, aperture, mmap_offset, alloc_flags);
 	} else {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/drm/amd_drm_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/drm/amd_drm_driver.cpp
@@ -66,7 +66,10 @@ hsa_status_t DrmDriver::CreateQueue(const CreateQueueInParams *queueIn, CreateQu
     fprintf(stderr, "DEBUG DRM: Creating compute queue with eop_va=0x%llx, cwsr_va=0x%llx, cwsr_size=%u\n",
             (unsigned long long)compute_mqd.eop_va, (unsigned long long)compute_mqd.ctx_save_area_addr, compute_mqd.ctx_save_area_size);
     mqd_in = &compute_mqd;
-    flags = AMDGPU_USERQ_CREATE_FLAGS_QUEUE_SECURE;
+    // This is an HSA AQL queue — tell the kernel/MES to configure it in AQL mode.
+    // Previously set SECURE (1<<2) which made MES treat it as a non-AQL (PM4) TMZ
+    // queue; AQL packets then never executed → dispatch hang. AQL_COMPUTE is 1<<3.
+    flags = AMDGPU_USERQ_CREATE_FLAGS_QUEUE_AQL_COMPUTE;
     ip_type = AMDGPU_HW_IP_COMPUTE;
   } else if (type == SDMA_QUEUE) {
     sdma_mqd.csa_va = drmQueueIn->extra_va;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -373,6 +373,10 @@ public:
   // GPU-visible indirect buffer holding PM4 commands.
   void* pm4_ib_buf_;
   uint32_t pm4_ib_size_b_;
+  // True if pm4_ib_buf_ was allocated from device memory (DRM VM) rather than
+  // system memory. In DRM/UKI mode the utility queue's CPF must fetch this IB
+  // from the DRM VM, so it is device-allocated; the free path must match.
+  bool pm4_ib_dev_mem_;
   std::mutex pm4_ib_mutex_;
 
   // Error handler control variable.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -346,7 +346,19 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
   // queue (AQL, HOST) in the same process during its lifetime.
   amd_queue_.hsa_queue.id = this->GetQueueId();
 
-  MAKE_NAMED_SCOPE_GUARD(QueueGuard, [&]() { agent_->driver().DestroyQueue(queue_id_); });
+  MAKE_NAMED_SCOPE_GUARD(QueueGuard, [&]() {
+    if (core::Runtime::runtime_singleton_->flag().enable_drm() && drm_queue_id_ != 0) {
+      // DRM queue was created — destroy it via the DRM path.
+      // Using queue_id_ (KFD) here leaves the kernel userq alive, which
+      // causes amdgpu_userq_evict to crash when RingGuard frees EOP/CWSR.
+      DrmDriver::DestroyQueueInParams queueIn(*agent_, drm_queue_id_, drm_doorbell_offset_);
+      static_cast<DrmDriver&>(agent_->driver()).DestroyQueue(&queueIn);
+      drm_queue_id_ = 0;
+      drm_doorbell_offset_ = 0;
+    } else {
+      agent_->driver().DestroyQueue(queue_id_);
+    }
+  });
 
   amd_queue_.scratch_max_use_index = UINT64_MAX;
   amd_queue_.alt_scratch_max_use_index = UINT64_MAX;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -103,6 +103,7 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
       errors_data_(err_data),
       pm4_ib_buf_(nullptr),
       pm4_ib_size_b_(0x1000),
+      pm4_ib_dev_mem_(false),
       dynamicScratchState(0),
       exceptionState(0),
       suspended_(false),
@@ -394,13 +395,30 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
     exceptionState = ERROR_HANDLER_DONE;
   }
 
-  // Allocate IB for icache flushes.
-  pm4_ib_buf_ =
-      agent_->system_allocator()(pm4_ib_size_b_, 0x1000, core::MemoryRegion::AllocateExecutable);
+  // Allocate IB for icache flushes. In DRM/UKI mode the utility queue is a DRM
+  // user queue whose CPF fetches this IB from the DRM VM; a system (KFD-VM)
+  // allocation is invisible to it and the CPF page-faults fetching the IB
+  // (INDIRECT_BUFFER jump). Route it through device memory so it lands in the
+  // DRM VM, mirroring the queue descriptor/ring device-mem workaround. Requires
+  // LargeBAR since ExecutePM4 memcpys into this buffer (CPU-writable VRAM).
+  pm4_ib_dev_mem_ =
+      core::Runtime::runtime_singleton_->flag().enable_drm() && agent_->LargeBarEnabled();
+  if (pm4_ib_dev_mem_) {
+    pm4_ib_buf_ =
+        agent_->finegrain_allocator()(pm4_ib_size_b_, core::MemoryRegion::AllocateExecutable);
+  } else {
+    pm4_ib_buf_ =
+        agent_->system_allocator()(pm4_ib_size_b_, 0x1000, core::MemoryRegion::AllocateExecutable);
+  }
   if (pm4_ib_buf_ == nullptr)
     throw AMD::hsa_exception(HSA_STATUS_ERROR_OUT_OF_RESOURCES, "PM4 IB allocation failed.\n");
 
-  MAKE_NAMED_SCOPE_GUARD(PM4IBGuard, [&]() { agent_->system_deallocator()(pm4_ib_buf_); });
+  MAKE_NAMED_SCOPE_GUARD(PM4IBGuard, [&]() {
+    if (pm4_ib_dev_mem_)
+      agent_->finegrain_deallocator()(pm4_ib_buf_);
+    else
+      agent_->system_deallocator()(pm4_ib_buf_);
+  });
 
   // Set initial CU mask
   if (!core::Runtime::runtime_singleton_->flag().cu_mask_skip_init()) SetCUMasking(0, nullptr);
@@ -481,7 +499,10 @@ AqlQueue::~AqlQueue() {
       queue_event() = nullptr;
     }
   }
-  agent_->system_deallocator()(pm4_ib_buf_);
+  if (pm4_ib_dev_mem_)
+    agent_->finegrain_deallocator()(pm4_ib_buf_);
+  else
+    agent_->system_deallocator()(pm4_ib_buf_);
 }
 
 void AqlQueue::Destroy() {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -816,9 +816,21 @@ void AqlQueue::Resume() {
 hsa_status_t AqlQueue::Inactivate() {
   bool active = active_.exchange(false, std::memory_order_relaxed);
   if (active) {
-    auto err = agent_->driver().DestroyQueue(queue_id_);
-    assert(err == HSA_STATUS_SUCCESS && "Destroy queue failed.");
-    (void)err;
+    if (core::Runtime::runtime_singleton_->flag().enable_drm() && drm_queue_id_ != 0) {
+      // DRM path: destroy using the DRM queue ID, not the KFD queue_id_.
+      // Using queue_id_ (KFD) here leaves the kernel userq alive, which
+      // causes amdgpu_userq_evict to crash when EOP/CWSR buffers are freed.
+      DrmDriver::DestroyQueueInParams queueIn(*agent_, drm_queue_id_, drm_doorbell_offset_);
+      auto err = static_cast<DrmDriver&>(agent_->driver()).DestroyQueue(&queueIn);
+      assert(err == HSA_STATUS_SUCCESS && "DRM DestroyQueue failed.");
+      (void)err;
+      drm_queue_id_ = 0;
+      drm_doorbell_offset_ = 0;
+    } else {
+      auto err = agent_->driver().DestroyQueue(queue_id_);
+      assert(err == HSA_STATUS_SUCCESS && "Destroy queue failed.");
+      (void)err;
+    }
     atomic::Fence(std::memory_order_acquire);
   }
   return HSA_STATUS_SUCCESS;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -2699,7 +2699,7 @@ hsa_status_t GpuAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type, u
   // (CPU-accessible VRAM); gfx1200 has it.
   // NOTE(UKI): umr shows the descriptor still resolves to system memory even with
   // these flags set — the CPF descriptor fault is gone, but the intended VRAM
-  // placement is unconfirmed. Workaround pending KFD/DRM VM unification.
+  // placement is unconfirmed. Tracked in AILIKGD-549; pending KFD/DRM VM unification.
   if (core::Runtime::runtime_singleton_->flag().enable_drm() && LargeBarEnabled()) {
     flags |= HSA_AMD_QUEUE_CREATE_DEVICE_MEM_QUEUE_DESCRIPTOR |
              HSA_AMD_QUEUE_CREATE_DEVICE_MEM_RING_BUF;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -2692,6 +2692,19 @@ hsa_status_t GpuAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type, u
   // ensured.
   queues_[QueueUtility].touch();
 
+  // DRM/UKI mode: the DRM user queue's CPF runs in the DRM VM, but the queue
+  // descriptor (amd_queue_v2_t rptr/wptr) and AQL ring default to system memory,
+  // which lands in the KFD VM and page-faults the CPF. Route them through the
+  // device-memory path so they are DRM-allocated/mapped. Requires LargeBAR
+  // (CPU-accessible VRAM); gfx1200 has it.
+  // NOTE(UKI): umr shows the descriptor still resolves to system memory even with
+  // these flags set — the CPF descriptor fault is gone, but the intended VRAM
+  // placement is unconfirmed. Workaround pending KFD/DRM VM unification.
+  if (core::Runtime::runtime_singleton_->flag().enable_drm() && LargeBarEnabled()) {
+    flags |= HSA_AMD_QUEUE_CREATE_DEVICE_MEM_QUEUE_DESCRIPTOR |
+             HSA_AMD_QUEUE_CREATE_DEVICE_MEM_RING_BUF;
+  }
+
   bool dev_mem_queue_descriptor = (flags & HSA_AMD_QUEUE_CREATE_DEVICE_MEM_QUEUE_DESCRIPTOR) != 0;
 
   // Create an HW AQL queue

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -2523,6 +2523,13 @@ hsa_status_t Runtime::Load() {
 #endif
 
   g_use_interrupt_wait = flag_.enable_interrupt();
+  /* The KGD/DRM userq path has no event framework yet (no KFD-style event page,
+   * VM-fault/signal event delivery). Interrupt-based waits would require KFD
+   * events, which we must not use in unified-interface mode. Fall back to
+   * polling signals until the KGD userq event patch is ready.
+   */
+  if (flag_.enable_drm())
+    g_use_interrupt_wait = false;
   g_use_mwaitx = flag_.check_mwaitx(cpuinfo.mwaitx);
 
   if (!AMD::Load()) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -941,7 +941,11 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents, hsa_handle
   });
 
   for (uint32_t i = 0; i < num_agents; i++) {
-    if (agents[i]->driver().kernel_driver_type_ != DriverType::KFD) {
+    // DRM (UKI) agents derive from KfdDriver and inherit its residency path, and
+    // interop import still uses the libhsakmt KFD ioctls in enable_drm mode, so
+    // accept both KFD and DRM driver types here.
+    if (agents[i]->driver().kernel_driver_type_ != DriverType::KFD &&
+        agents[i]->driver().kernel_driver_type_ != DriverType::DRM) {
       return HSA_STATUS_ERROR_INVALID_AGENT;
     }
     agents[i]->GetInfo(static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_DRIVER_NODE_ID), &nodes[i]);
@@ -985,7 +989,12 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents, hsa_handle
 }
 
 hsa_status_t Runtime::InteropUnmap(void* ptr) {
-  auto& driver = core::Runtime::runtime_singleton_->AgentDriver(DriverType::KFD);
+  // In enable_drm (UKI) mode the registered memory driver is DRM-type (it
+  // derives from KfdDriver and inherits MakeMemoryUnresident/DeregisterMemory),
+  // and there is no KFD-type driver to look up. Select the type that exists.
+  const DriverType drv_type =
+      flag().enable_drm() ? DriverType::DRM : DriverType::KFD;
+  auto& driver = core::Runtime::runtime_singleton_->AgentDriver(drv_type);
 
   hsa_status_t err = driver.MakeMemoryUnresident(ptr);
   if (err != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR_INVALID_ARGUMENT;


### PR DESCRIPTION
## Summary

Five ROCr fixes for the DRM user-queue (UKI) path on gfx1200 with `amdgpu.user_queue=1`, taking a DRM AQL compute queue from crash/hang to executing dispatches.

- **libhsakmt,hsa-runtime: DRM userq fixes from Jesse Zhang** — export DRM-allocated BOs via `amdgpu_bo_export` for dma-buf (fixes `hsa_amd_vmem_map` `OUT_OF_RESOURCES` in the DRM path); force polling signals (`g_use_interrupt_wait=false`) in DRM mode until the KGD userq event framework lands.
- **fix `AqlQueue::Inactivate` to use the DRM queue ID** — it was destroying via the KFD `queue_id_` (which is 0 in DRM mode), leaving the kernel userq alive → `amdgpu_userq_evict` NULL deref when EOP/CWSR buffers were freed.
- **fix the constructor `QueueGuard`** — same KFD-vs-DRM queue-id bug in the error-cleanup scope guard.
- **create the DRM AQL queue with `AQL_COMPUTE`, not `SECURE`** — the queue was created with `AMDGPU_USERQ_CREATE_FLAGS_QUEUE_SECURE` (1<<2) but never `..._AQL_COMPUTE` (1<<3), so MES/CP configured it as non-AQL (PM4) + TMZ while ROCr wrote AQL packets → the CP never executed them → dispatch hang → MODE1 reset. **This is the core dispatch-hang fix.**
- **place the AQL queue descriptor+ring in device memory in DRM mode** — the descriptor (rptr/wptr) and ring defaulted to system memory (KFD VM), invisible to the DRM userq's CPF (page fault). Route them through the device-memory path when `enable_drm()` + LargeBAR. Eliminates the CPF descriptor fault. Workaround pending KFD/DRM VM unification (see the commit note — the descriptor still resolves to system memory per `umr`; the fault is gone but VRAM placement is unconfirmed).

## Test plan

gfx1200, `amdgpu.user_queue=1`, kernel including the AILIKGD-530 fix:

- [x] `rocrtst.Test_Example` (trivial dispatch): passes (previously hung).
- [x] `rocrtstFunc.VirtMemory_Access_Test` — CPU-to-GPU subtests pass (previously hung at first dispatch).
- Known residual, tracked separately in **AILIKGD-547**: the GPU-to-GPU subtest hits a CPF read permission fault (map/unmap eviction race on a dispatch-referenced buffer).

## Related

- AILIKGD-531 — DRM user-queue AQL dispatch hang (this PR)
- AILIKGD-530 — kernel `amdgpu_userq_evict_all` NULL deref (prerequisite)
- AILIKGD-547 — GPU-to-GPU CPF permission fault (residual, follow-up)
- AILIKGD-528 — original user-queue hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)