### PR TITLE
fix(rccl): [AICOMRCCL-1539] Fix gather/scatter P2P channel mismatch

### DIFF
--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1168,10 +1168,10 @@ static ncclResult_t addP2pToPlan(
     else {
       ssize_t minPartSize = comm->nNodes > 1 ? stepSize[dir]/2 : stepSize[dir]/8;
       ssize_t maxPartSize = comm->nNodes > 1 ? stepSize[dir]   : stepSize[dir]*32;
-      // Single-node asymmetric patterns (gather/scatter): use nChannelsMax to
-      // fully utilize XGMI bandwidth when only one rank is the traffic hub.
-      // Symmetric patterns (alltoall): stay at nChannelsMin to avoid contention.
-      bool asymmetric = planTotalTasks[0] == 0 || planTotalTasks[1] == 0;
+      // Use collAPI (collective type) rather than per-rank task counts so both
+      // sides of a P2P pair agree on nChStart — planTotalTasks varies per rank.
+      bool asymmetric = p2pTasks[dir] &&
+        (p2pTasks[dir]->collAPI == ncclFuncGather || p2pTasks[dir]->collAPI == ncclFuncScatter);
       int nChStart = (comm->nNodes <= 1 && asymmetric) ? nChannelsMax : nChannelsMin;
       nChannels[dir] = std::min<int>(nChStart, divUp(bytes[dir], minPartSize));
       size_t partSize = std::max(minPartSize, divUp(bytes[dir], nChannels[dir]));
@@ -1247,10 +1247,10 @@ static ncclResult_t addP2pToPlan(
     else {
       ssize_t minPartSize = comm->nNodes > 1 ? stepSize[dir]/2 : stepSize[dir]/8;
       ssize_t maxPartSize = comm->nNodes > 1 ? stepSize[dir]   : stepSize[dir]*32;
-      // Single-node asymmetric patterns (gather/scatter): use nChannelsMax to
-      // fully utilize XGMI bandwidth when only one rank is the traffic hub.
-      // Symmetric patterns (alltoall): stay at nChannelsMin to avoid contention.
-      bool asymmetric = planTotalTasks[0] == 0 || planTotalTasks[1] == 0;
+      // Use collAPI (collective type) rather than per-rank task counts so both
+      // sides of a P2P pair agree on nChStart — planTotalTasks varies per rank.
+      bool asymmetric = p2pTasks[dir] &&
+        (p2pTasks[dir]->collAPI == ncclFuncGather || p2pTasks[dir]->collAPI == ncclFuncScatter);
       int nChStart = (comm->nNodes <= 1 && asymmetric) ? nChannelsMax : nChannelsMin;
       nChannels[dir] = std::min<int>(nChStart, divUp(bytes[dir], minPartSize));
       size_t partSize = std::max(minPartSize, divUp(bytes[dir], nChannels[dir]));

--- a/projects/rccl/test/GatherTests.cpp
+++ b/projects/rccl/test/GatherTests.cpp
@@ -84,6 +84,26 @@ namespace RcclUnitTesting
     testBed.Finalize();
   }
 
+  // Regression test for AICOMRCCL-1539: non-zero root with large messages
+  // must not deadlock when nChannelsMax != nChannelsMin.
+  TEST(Gather, OutOfPlaceNonZeroRootLargeMsg)
+  {
+    TestBed testBed;
+
+    std::vector<ncclFunc_t>     const funcTypes       = {ncclCollGather};
+    std::vector<ncclDataType_t> const dataTypes       = {ncclFloat32};
+    std::vector<ncclRedOp_t>    const redOps          = {ncclSum};
+    std::vector<int>            const roots           = {1};
+    std::vector<int>            const numElements     = {16 * 1024 * 1024};
+    std::vector<bool>           const inPlaceList     = {false};
+    std::vector<bool>           const managedMemList  = {false};
+    std::vector<bool>           const useHipGraphList = {false};
+
+    testBed.RunSimpleSweep(funcTypes, dataTypes, redOps, roots, numElements,
+                           inPlaceList, managedMemList, useHipGraphList);
+    testBed.Finalize();
+  }
+
   TEST(Gather, ManagedMem)
   {
     TestBed testBed;

--- a/projects/rccl/test/ScatterTests.cpp
+++ b/projects/rccl/test/ScatterTests.cpp
@@ -83,6 +83,26 @@ namespace RcclUnitTesting
     testBed.Finalize();
   }
 
+  // Regression test for AICOMRCCL-1539: non-zero root with large messages
+  // must not deadlock when nChannelsMax != nChannelsMin.
+  TEST(Scatter, OutOfPlaceNonZeroRootLargeMsg)
+  {
+    TestBed testBed;
+
+    std::vector<ncclFunc_t>     const funcTypes       = {ncclCollScatter};
+    std::vector<ncclDataType_t> const dataTypes       = {ncclFloat32};
+    std::vector<ncclRedOp_t>    const redOps          = {ncclSum};
+    std::vector<int>            const roots           = {1};
+    std::vector<int>            const numElements     = {16 * 1024 * 1024};
+    std::vector<bool>           const inPlaceList     = {false};
+    std::vector<bool>           const managedMemList  = {false};
+    std::vector<bool>           const useHipGraphList = {false};
+
+    testBed.RunSimpleSweep(funcTypes, dataTypes, redOps, roots, numElements,
+                           inPlaceList, managedMemList, useHipGraphList);
+    testBed.Finalize();
+  }
+
   TEST(Scatter, ManagedMem)
   {
     TestBed testBed;


### PR DESCRIPTION
## Summary

- Fixes Gather.OutOfPlace deadlock on gfx1100 (and potentially MI355X) caused by PR #8349's asymmetric P2P channel detection
- Root cause: `planTotalTasks` differs per rank for gather/scatter — root has both send+recv tasks (`asymmetric=false`, uses `nChannelsMin`), non-root has only send tasks (`asymmetric=true`, uses `nChannelsMax`), causing a sender/receiver channel count mismatch that deadlocks
- Fix: replace per-rank `planTotalTasks` check with per-collective `collAPI` check (`ncclFuncGather`/`ncclFuncScatter`), which evaluates identically on all ranks

## Root Cause Detail

PR #8349 added this asymmetric detection in `addP2pToPlan()`:
```c
bool asymmetric = planTotalTasks[0] == 0 || planTotalTasks[1] == 0;
int nChStart = (comm->nNodes <= 1 && asymmetric) ? nChannelsMax : nChannelsMin;
```

For gather with root=1, 2 ranks on gfx1100 (`nChannelsMax=2, nChannelsMin=1`):
- **Rank 0** (non-root): `planTotalTasks=[0,1]` → `asymmetric=true` → `nChStart=2` → splits send across 2 channels
- **Rank 1** (root): `planTotalTasks=[2,1]` → `asymmetric=false` → `nChStart=1` → listens on 1 channel

Data sent on channel 1 is never consumed → both ranks wait forever → deadlock.

## Fix

Replace the per-rank task count check with a per-collective type check:
```c
ncclFunc_t collAPI = p2pTasks[dir] ? p2pTasks[dir]->collAPI : (ncclFunc_t)0;
bool asymmetric = (collAPI == ncclFuncGather || collAPI == ncclFuncScatter);
int nChStart = (comm->nNodes <= 1 && asymmetric) ? nChannelsMax : nChannelsMin;
```

Each P2P task already carries the originating collective type via `collAPI`, which is a property of the collective (not the rank), ensuring both sides of each P2P pair agree on channel count.

## Test plan

- [x] Gather.OutOfPlace passes on gfx1100 2-GPU (previously deadlocked 5/5 runs)
- [x] All 5 P2pChannelScaling tests pass (GatherLargeMessage, ScatterLargeMessage, AllToAllLargeMessage, AllToAllVLargeMessage, GatherNonZeroRoot)
- [x] All Scatter tests pass (OutOfPlace, OutOfPlaceGraph, InPlace, InPlaceGraph, InPlaceRoot0, InPlaceRoot0Graph)
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)