### PR TITLE
fix(rocjitsu): smem don't scale ioffset

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/addr_calc.cpp
@@ -154,7 +154,6 @@ uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &
   uint64_t base = (static_cast<uint64_t>(cu.read_sgpr(sbase + 1)) << 32) | cu.read_sgpr(sbase);
   int64_t off = static_cast<int64_t>(static_cast<int32_t>(inst.ioffset << 8) >> 8);
   uint32_t scale = inst.scale_offset ? access_size_bytes : 1;
-  off *= scale;
   if (has_smem_offset(inst.soffset))
     off += static_cast<int64_t>(read_sreg_m0_operand(wf, inst.soffset)) * scale;
   uint64_t addr = base + off;

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -3635,7 +3635,7 @@ TEST(Gfx1250SimulationTest, DispatchPreloadsKernargWhenDescriptorSizeIsUnknown) 
   EXPECT_EQ(sim.cu()->read_sgpr(sbase + 3), args[2]);
 }
 
-TEST(Gfx1250SimulationTest, SLoadB32ScalesImmediateOffset) {
+TEST(Gfx1250SimulationTest, SLoadB32DoesNotScaleImmediateOffset) {
   using namespace rocr::llvm::amdhsa;
 
   constexpr uint64_t kKernelAddr = 0x10000;
@@ -3643,7 +3643,8 @@ TEST(Gfx1250SimulationTest, SLoadB32ScalesImmediateOffset) {
   constexpr uint32_t kExpected = 0x12345678u;
 
   std::vector<uint32_t> code;
-  append_instruction(code, make_s_load_b32_scaled_imm(4, 0, 1));
+  // s_load_b32 s4, s[0:1], 0x4 scale_offset
+  append_instruction(code, make_s_load_b32_scaled_imm(4, 0, 4));
   append_instruction(code, S_WAIT_KMCNT_0_GFX12);
   append_instruction(code, S_ENDPGM_GFX12);
 


### PR DESCRIPTION
## Motivation

was causing problems.

## Technical Details

gfx1250 smem offset should not.

so delete `off *= scale;`

## JIRA ID

resolves #8539

## Test Plan

ran tests

## Test Result

tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
