### PR TITLE
fix(rocdecdecode sample): initialize device_id before creating the decoder

### DIFF
--- a/projects/rocdecode/docs/how-to/using-rocDecode-rocdecdecoder.rst
+++ b/projects/rocdecode/docs/how-to/using-rocDecode-rocdecdecoder.rst
@@ -111,6 +111,7 @@ The ``create_decoder()`` function sets the decoder parameters and passes them to
   
   void create_decoder(DecoderInfo& dec_info) {
     RocDecoderCreateInfo create_info = {};
+    create_info.device_id = static_cast<uint8_t>(dec_info.dec_device_id);
     create_info.codec_type = dec_info.rocdec_codec_id;     // user specified codec_type for raw files
     [...]
     CHECK(rocDecCreateDecoder(&dec_info.decoder, &create_info));

--- a/projects/rocdecode/samples/rocdecDecode/rocdecdecode.cpp
+++ b/projects/rocdecode/samples/rocdecDecode/rocdecdecode.cpp
@@ -354,6 +354,7 @@ void init() {}
 
 void create_decoder(DecoderInfo& dec_info) {
     RocDecoderCreateInfo create_info = {};
+    create_info.device_id = dec_info.dec_device_id;
     create_info.codec_type = dec_info.rocdec_codec_id;     // user specified codec_type for raw files
     create_info.max_width = DEFAULT_WIDTH;
     create_info.max_height = DEFAULT_HEIGHT;

--- a/projects/rocdecode/samples/rocdecDecode/rocdecdecode.cpp
+++ b/projects/rocdecode/samples/rocdecDecode/rocdecdecode.cpp
@@ -354,7 +354,11 @@ void init() {}
 
 void create_decoder(DecoderInfo& dec_info) {
     RocDecoderCreateInfo create_info = {};
-    create_info.device_id = dec_info.dec_device_id;
+    if (dec_info.dec_device_id < 0 || dec_info.dec_device_id > 255) {
+        std::cerr << "Invalid device id: " << dec_info.dec_device_id << " (expected 0-255)" << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    create_info.device_id = static_cast<uint8_t>(dec_info.dec_device_id);
     create_info.codec_type = dec_info.rocdec_codec_id;     // user specified codec_type for raw files
     create_info.max_width = DEFAULT_WIDTH;
     create_info.max_height = DEFAULT_HEIGHT;


### PR DESCRIPTION
## Motivation

The create_info.device_id must be set before calling rocDecCreateDecoder to create a decoder on the correct device.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
