### PR TITLE
docs(amdsmi): document gfx_activity N/A sentinel 0x0000FFFF

### DIFF
--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -1386,7 +1386,9 @@ typedef struct {
  * @cond @tag{gpu_bm_linux} @tag{guest_windows} @tag{host} @endcond
  **/
 typedef struct {
-  uint32_t gfx_activity;  //!< In %
+  uint32_t gfx_activity;  //!< In %. Reported as N/A via the sentinel 0x0000FFFF
+                          //!< (a uint16_t max value carried in this uint32_t field,
+                          //!< inherited from average_gfx_activity), not 0xFFFFFFFF.
   uint32_t umc_activity;  //!< In %
   uint32_t mm_activity;   //!< In %
   uint32_t reserved[13];
@@ -7635,6 +7637,8 @@ amdsmi_status_t amdsmi_get_temp_metric(amdsmi_processor_handle processor_handle,
  *  @param[in] processor_handle Device which to query
  *
  *  @param[out] info Reference to the gpu engine usage structure. Must be allocated by user.
+ *  When @p gfx_activity is unavailable it is reported as N/A using the sentinel
+ *  0x0000FFFF (a uint16_t max value carried in the uint32_t field), not 0xFFFFFFFF.
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */


### PR DESCRIPTION
## Motivation

The `gfx_activity` field of `amdsmi_engine_usage_t` reports "not available" using an unusual sentinel: `0x0000FFFF` rather than the full `0xFFFFFFFF`. This is because the value is derived from `average_gfx_activity` (a `uint16_t`) and copied into the `uint32_t` field, so the N/A sentinel is a `uint16_t` max carried in a `uint32_t` slot. This is easy to misread as a valid ~65535 value; the header did not document it.

## Technical Details

**Header / docs** (`include/amd_smi/amdsmi.h`):
- Documented on the `amdsmi_engine_usage_t.gfx_activity` field that its N/A sentinel is `0x0000FFFF` (a `uint16_t` max in the `uint32_t` field, inherited from `average_gfx_activity`), not `0xFFFFFFFF`
- Added the same note to the `amdsmi_get_gpu_activity()` doxygen so callers checking for N/A use the correct sentinel

## JIRA ID

JIRA ID: ROCM-26000

## Test Plan

- Docs-only change; no functional impact
- `pre-commit` (clang-format) run locally

## Test Result

- `pre-commit` passed

## Submission Checklist

- [x] The code changes are covered by tests, or the change is docs/config-only
- [x] The commit message follows Conventional Commits
- [x] Signed-off-by is present
