### PR TITLE
docs(rccl): Update docs to recommend HSA_NO_SCRATCH_RECLAIM=1 on gfx90a

### DIFF
--- a/projects/rccl/CHANGELOG.md
+++ b/projects/rccl/CHANGELOG.md
@@ -60,6 +60,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * Fixed RCCL initialization failing (`Failed to find ROCm runtime library`) on runtime-only ROCm trees that ship no unversioned `libhsa-runtime64.so` developer symlink (e.g. TheRock multi-arch pip-wheel `/opt/rocm-less` deployments). RCCL no longer `dlopen`s the HSA runtime by name; instead it directly links `hsa-runtime64::hsa-runtime64` (already a hard transitive dependency via the HIP runtime) and binds `hsa_init`, `hsa_system_get_info`, `hsa_status_string`, and `hsa_amd_portable_export_dmabuf` to those symbols. The linker records `DT_NEEDED libhsa-runtime64.so.1` and resolves it through librccl's existing RPATH, removing the SONAME version-string fragility and load-scope (`RTLD_LOCAL`) issues. The `RCCL_ROCR_PATH` override is no longer needed and has been removed.
 
 ### Known issues
+* On gfx90a (MI210/MI250/MI250X) with ROCm 7.13 or later, per-launch scratch-memory reclaim in the runtime degrades RCCL performance. Set `HSA_NO_SCRATCH_RECLAIM=1` to restore performance.
 * Elastic-buffer support for GIN (multi-segment symmetric memory windows backed by a mix of device and CPU/`HOST_NUMA` memory, exposed through `NCCL_ELASTIC_BUFFER_REGISTER` and `NCCL_SYM_REUSE_SYSMEM_HANDLES`) was newly synced from upstream and compiles on ROCm, but is unverified on AMD hardware.
 
 ## RCCL 2.28.3 for ROCm 7.13

--- a/projects/rccl/docs/how-to/rccl-usage-tips.rst
+++ b/projects/rccl/docs/how-to/rccl-usage-tips.rst
@@ -92,6 +92,22 @@ ignore the job's supplied CPU affinity and use the GPU affinity only.
 For general usage, this environment variable is not set so it doesn't interfere with the user or launcher
 supplied preferences.
 
+Improving performance on the MI200 series
+=========================================
+
+On MI200 series (gfx90a) systems, such as MI210, MI250, and MI250X, running
+ROCm 7.13 or later, set ``HSA_NO_SCRATCH_RECLAIM=1`` when running RCCL:
+
+.. code-block:: shell
+
+   export HSA_NO_SCRATCH_RECLAIM=1
+
+Without this setting, per-launch scratch-memory reclaim in the runtime adds a
+fixed overhead to every collective launch. This overhead dominates
+small-message (under 16 MB) latency and can degrade it by roughly
+5-10x compared to earlier ROCm releases. Setting ``HSA_NO_SCRATCH_RECLAIM=1``
+removes the overhead and restores the expected small-message latency.
+
 Improving performance on the MI300X 
 ===================================
 


### PR DESCRIPTION
## Motivation

On MI250X (gfx90a) systems running ROCm 7.13 or later, per-launch scratch-memory
reclaim in the runtime adds a fixed overhead to every collective launch. This
dominates small-message (<16 MB) latency and can degrade it by ~5-10x versus
earlier ROCm releases. Setting `HSA_NO_SCRATCH_RECLAIM=1` removes the overhead
and restores expected small-message latency. This adds a usage tip documenting
the workaround.

## JIRA ID

JIRA ID : ROCM-27957

## Submission Checklist

- [x] I have read and followed the contributing guidelines