### PR TITLE
fix(rocjitsu): resolve VMID-mapped kernel names

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1059,14 +1059,19 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
 
   std::string kernel_sym;
   if (host_accessible && memory_) {
-    auto [range_base, range_size] = memory_->find_host_range(pkt.kernel_object);
-    if (range_base != 0) {
-      auto *ko = reinterpret_cast<const uint8_t *>(pkt.kernel_object);
-      auto *range_start = reinterpret_cast<const uint8_t *>(range_base);
-      auto *elf = find_elf_base(ko, range_start);
-      if (elf) {
-        uint64_t accessible = range_size - static_cast<uint64_t>(elf - range_start);
-        kernel_sym = find_kernel_symbol(ko, elf, accessible);
+    auto [host_range_base, host_range_size] =
+        memory_->find_host_range(pkt.kernel_object, queue.process_id);
+    if (host_range_base != 0) {
+      auto *kernel_object_page = memory_->translate_debug(pkt.kernel_object, queue.process_id);
+      auto *kernel_object_host_ptr = kernel_object_page
+                                         ? kernel_object_page + (pkt.kernel_object & 0xFFF)
+                                         : reinterpret_cast<const uint8_t *>(pkt.kernel_object);
+      auto *host_range_begin = reinterpret_cast<const uint8_t *>(host_range_base);
+      auto *elf_base = find_elf_base(kernel_object_host_ptr, host_range_begin);
+      if (elf_base) {
+        uint64_t elf_accessible =
+            host_range_size - static_cast<uint64_t>(elf_base - host_range_begin);
+        kernel_sym = find_kernel_symbol(kernel_object_host_ptr, elf_base, elf_accessible);
       }
     }
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -51,6 +51,10 @@ public:
     });
   }
 
+  // Keep the one-argument SparseMemory host-map lookup visible; the overload
+  // below adds VMID page-table lookup for KFD/daemon mappings.
+  using SparseMemory::find_host_range;
+
   simdojo::Port *cpl_port() { return cpl_; }
 
   /// @brief Register a process's page table in the VMID table.
@@ -142,6 +146,53 @@ public:
   }
 
   uint8_t *translate_debug(uint64_t addr, uint32_t vmid) const { return translate(addr, vmid); }
+
+  /// @brief Find the contiguous host range containing a VMID-scoped GPU VA.
+  /// @details KFD dispatches use per-process page tables instead of
+  /// SparseMemory::map_host_pages(). Kernel-symbol resolution needs a
+  /// daemon-accessible host pointer range so it can safely scan backward from a
+  /// kernel descriptor to the loaded ELF header.
+  std::pair<uint64_t, uint64_t> find_host_range(uint64_t addr, uint32_t vmid) const {
+    if (vmid == 0)
+      return SparseMemory::find_host_range(addr);
+
+    std::shared_lock vmid_lock(vmid_mutex_);
+    auto vmid_entry = vmid_table_.find(vmid);
+    if (vmid_entry == vmid_table_.end())
+      return SparseMemory::find_host_range(addr);
+
+    auto &entry = vmid_entry->second;
+    std::shared_lock page_table_lock(*entry.mutex);
+    uint64_t page = addr >> PAGE_SHIFT;
+    auto page_entry = entry.page_table->find(page);
+    if (page_entry == entry.page_table->end())
+      return SparseMemory::find_host_range(addr);
+
+    uint64_t first_page = page;
+    uint8_t *first_host_page = page_entry->second.host_ptr;
+    while (first_page > 0) {
+      auto previous_page_entry = entry.page_table->find(first_page - 1);
+      if (previous_page_entry == entry.page_table->end() ||
+          previous_page_entry->second.host_ptr + PAGE_SIZE != first_host_page)
+        break;
+      --first_page;
+      first_host_page = previous_page_entry->second.host_ptr;
+    }
+
+    uint64_t last_page = page;
+    uint8_t *last_host_page = page_entry->second.host_ptr;
+    while (true) {
+      auto next_page_entry = entry.page_table->find(last_page + 1);
+      if (next_page_entry == entry.page_table->end() ||
+          next_page_entry->second.host_ptr != last_host_page + PAGE_SIZE)
+        break;
+      ++last_page;
+      last_host_page = next_page_entry->second.host_ptr;
+    }
+
+    uint64_t range_size = ((last_page - first_page) + 1) << PAGE_SHIFT;
+    return {reinterpret_cast<uint64_t>(first_host_page), range_size};
+  }
 
   std::string debug_page_table_info(uint32_t vmid, uint64_t page_key) const {
     std::shared_lock lk(vmid_mutex_);

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -4,6 +4,8 @@
 #include "aql_queue.h"
 
 #include "embedded_schema.h"
+#include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/kernel_symbol.h"
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna4/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
@@ -151,6 +153,58 @@ void step_until_halted(simdojo::SimulationEngine &engine,
   }
 }
 
+std::vector<uint8_t> make_loaded_kernel_symbol_elf(uint64_t kernel_descriptor_offset,
+                                                   std::string_view symbol_name) {
+  constexpr uint64_t dyn_offset = 0x100;
+  constexpr uint64_t symtab_offset = 0x200;
+  constexpr uint64_t strtab_offset = 0x300;
+  constexpr uint64_t hash_offset = 0x380;
+
+  std::vector<uint8_t> image(4096, 0);
+
+  Elf64_Ehdr ehdr{};
+  std::memcpy(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
+  ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+  ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  ehdr.e_type = ET_DYN;
+  ehdr.e_machine = EM_AMDGPU;
+  ehdr.e_version = 1;
+  ehdr.e_phoff = sizeof(Elf64_Ehdr);
+  ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  ehdr.e_phentsize = sizeof(Elf64_Phdr);
+  ehdr.e_phnum = 1;
+  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+
+  Elf64_Phdr phdr{};
+  phdr.p_type = PT_DYNAMIC;
+  phdr.p_vaddr = dyn_offset;
+  phdr.p_memsz = 5 * sizeof(Elf64_Dyn);
+  std::memcpy(image.data() + ehdr.e_phoff, &phdr, sizeof(phdr));
+
+  auto *dyn = reinterpret_cast<Elf64_Dyn *>(image.data() + dyn_offset);
+  dyn[0].d_tag = DT_SYMTAB;
+  dyn[0].d_un.d_val = symtab_offset;
+  dyn[1].d_tag = DT_STRTAB;
+  dyn[1].d_un.d_val = strtab_offset;
+  dyn[2].d_tag = DT_STRSZ;
+  dyn[2].d_un.d_val = symbol_name.size() + 2;
+  dyn[3].d_tag = DT_HASH;
+  dyn[3].d_un.d_val = hash_offset;
+  dyn[4].d_tag = DT_NULL;
+
+  image[strtab_offset] = '\0';
+  std::memcpy(image.data() + strtab_offset + 1, symbol_name.data(), symbol_name.size());
+
+  auto *sym = reinterpret_cast<Elf64_Sym *>(image.data() + symtab_offset);
+  sym[1].st_name = 1;
+  sym[1].st_value = kernel_descriptor_offset;
+
+  auto *hash = reinterpret_cast<uint32_t *>(image.data() + hash_offset);
+  hash[1] = 2; // nchain: null symbol + kernel descriptor symbol.
+
+  return image;
+}
+
 TEST(GpuMemoryTest, ReadWriteRoundTrip) {
   VmFixture f;
   auto *mem = f.mem();
@@ -289,6 +343,80 @@ TEST(RdnaDispatchTest, WgpModeRequiresConfiguredSiblingCuPair) {
   queue.dispatch(ko, 64, 64);
 
   EXPECT_THROW((void)f.engine->step(), std::runtime_error);
+}
+
+TEST(GpuMemoryTest, FindHostRangeUsesVmidPageTable) {
+  amdgpu::GpuMemory mem("vmid_range_mem");
+  KfdProcess process(/*process_id=*/123);
+  std::vector<uint8_t> backing(3 * amdgpu::GpuMemory::PAGE_SIZE);
+  constexpr uint64_t gpu_va = 0x100000;
+
+  mem.register_process(process.process_id(), &process.page_table_, &process.page_table_mutex_);
+  process.map_pages(gpu_va, backing.data(), backing.size());
+
+  // VMID mappings are not stored in SparseMemory::host_page_map_. This must
+  // walk the KfdProcess page table and return the daemon host range that backs
+  // the queried GPU VA, including adjacent pages with contiguous host backing.
+  auto [host_base, size] =
+      mem.find_host_range(gpu_va + amdgpu::GpuMemory::PAGE_SIZE + 0x123, process.process_id());
+  EXPECT_EQ(host_base, reinterpret_cast<uint64_t>(backing.data()));
+  EXPECT_EQ(size, backing.size());
+
+  mem.unregister_process(process.process_id());
+}
+
+TEST(GpuMemoryTest, FindHostRangeStopsAtNonContiguousVmidHostPages) {
+  amdgpu::GpuMemory mem("vmid_noncontiguous_range_mem");
+  KfdProcess process(/*process_id=*/124);
+  std::vector<uint8_t> backing(3 * amdgpu::GpuMemory::PAGE_SIZE);
+  constexpr uint64_t gpu_va = 0x200000;
+
+  mem.register_process(process.process_id(), &process.page_table_, &process.page_table_mutex_);
+  process.map_pages(gpu_va, backing.data(), amdgpu::GpuMemory::PAGE_SIZE);
+  process.map_pages(gpu_va + amdgpu::GpuMemory::PAGE_SIZE,
+                    backing.data() + 2 * amdgpu::GpuMemory::PAGE_SIZE,
+                    amdgpu::GpuMemory::PAGE_SIZE);
+
+  auto [first_host_base, first_size] = mem.find_host_range(gpu_va, process.process_id());
+  EXPECT_EQ(first_host_base, reinterpret_cast<uint64_t>(backing.data()));
+  EXPECT_EQ(first_size, amdgpu::GpuMemory::PAGE_SIZE);
+
+  auto [second_host_base, second_size] =
+      mem.find_host_range(gpu_va + amdgpu::GpuMemory::PAGE_SIZE, process.process_id());
+  EXPECT_EQ(second_host_base,
+            reinterpret_cast<uint64_t>(backing.data() + 2 * amdgpu::GpuMemory::PAGE_SIZE));
+  EXPECT_EQ(second_size, amdgpu::GpuMemory::PAGE_SIZE);
+
+  mem.unregister_process(process.process_id());
+}
+
+TEST(GpuMemoryTest, VmidMappedKernelSymbolUsesTranslatedHostPointer) {
+  amdgpu::GpuMemory mem("vmid_kernel_symbol_mem");
+  KfdProcess process(/*process_id=*/125);
+  constexpr uint64_t gpu_va = 0x5400200000;
+  constexpr uint64_t kernel_descriptor_offset = 0x800;
+  auto image = make_loaded_kernel_symbol_elf(kernel_descriptor_offset, "vmid_kernel.kd");
+
+  mem.register_process(process.process_id(), &process.page_table_, &process.page_table_mutex_);
+  process.map_pages(gpu_va, image.data(), image.size());
+
+  uint64_t kernel_object = gpu_va + kernel_descriptor_offset;
+  auto [host_base, host_size] = mem.find_host_range(kernel_object, process.process_id());
+  ASSERT_NE(host_base, 0u);
+
+  // Kernel descriptors arrive as GPU VAs. Symbol lookup needs the translated
+  // host pointer so pointer subtraction against the loaded ELF image produces
+  // the descriptor offset recorded in .dynsym.
+  auto *mapped_page = mem.translate_debug(kernel_object, process.process_id());
+  ASSERT_NE(mapped_page, nullptr);
+  auto *kernel_object_host = mapped_page + (kernel_object & amdgpu::GpuMemory::PAGE_MASK);
+
+  EXPECT_NE(reinterpret_cast<uint64_t>(kernel_object_host), kernel_object);
+  EXPECT_EQ(find_kernel_symbol(kernel_object_host, reinterpret_cast<const uint8_t *>(host_base),
+                               host_size),
+            "vmid_kernel");
+
+  mem.unregister_process(process.process_id());
 }
 
 TEST(VmLifecycleTest, CreateAndDestroy) {

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -7,8 +7,10 @@
 #include "aql_queue.h"
 
 #include "embedded_schema.h"
+#include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/kmd/linux/kfd_process.h"
 #include "rocjitsu/vm/soc.h"
 
 #include "rocjitsu/base/rj_compiler.h"
@@ -22,11 +24,14 @@ RJ_DIAGNOSTIC_POP
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
+#include <cstring>
 #include <format>
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace {
@@ -72,6 +77,7 @@ struct HookEvent {
   uint32_t sgpr_count = 0;
   uint64_t pc = 0;
   std::string mnemonic;
+  std::string kernel_name;
 };
 
 /// A plugin that records an ordered event log for ordering assertions.
@@ -87,6 +93,7 @@ public:
   void onAmdgpuDispatchPacketProcessed(const KernelDispatchInfo &info) override {
     HookEvent e{HookEvent::DISPATCH_PACKET_PROCESSED};
     e.dispatch_id = info.dispatch_id;
+    e.kernel_name = info.kernel_name;
     events.push_back(e);
   }
 
@@ -462,10 +469,144 @@ struct PluginFixture {
   }
 };
 
+std::vector<uint8_t> make_loaded_kernel_symbol_elf(uint64_t kernel_descriptor_offset,
+                                                   std::string_view symbol_name) {
+  constexpr uint64_t dyn_offset = 0x100;
+  constexpr uint64_t symtab_offset = 0x200;
+  constexpr uint64_t strtab_offset = 0x300;
+  constexpr uint64_t hash_offset = 0x380;
+  constexpr uint64_t text_offset = 0x900;
+
+  std::vector<uint8_t> image(4096, 0);
+
+  Elf64_Ehdr ehdr{};
+  std::memcpy(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
+  ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+  ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  ehdr.e_type = ET_DYN;
+  ehdr.e_machine = EM_AMDGPU;
+  ehdr.e_version = 1;
+  ehdr.e_phoff = sizeof(Elf64_Ehdr);
+  ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  ehdr.e_phentsize = sizeof(Elf64_Phdr);
+  ehdr.e_phnum = 1;
+  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+
+  Elf64_Phdr phdr{};
+  phdr.p_type = PT_DYNAMIC;
+  phdr.p_vaddr = dyn_offset;
+  phdr.p_memsz = 5 * sizeof(Elf64_Dyn);
+  std::memcpy(image.data() + ehdr.e_phoff, &phdr, sizeof(phdr));
+
+  auto *dyn = reinterpret_cast<Elf64_Dyn *>(image.data() + dyn_offset);
+  dyn[0].d_tag = DT_SYMTAB;
+  dyn[0].d_un.d_val = symtab_offset;
+  dyn[1].d_tag = DT_STRTAB;
+  dyn[1].d_un.d_val = strtab_offset;
+  dyn[2].d_tag = DT_STRSZ;
+  dyn[2].d_un.d_val = symbol_name.size() + 2;
+  dyn[3].d_tag = DT_HASH;
+  dyn[3].d_un.d_val = hash_offset;
+  dyn[4].d_tag = DT_NULL;
+
+  image[strtab_offset] = '\0';
+  std::memcpy(image.data() + strtab_offset + 1, symbol_name.data(), symbol_name.size());
+
+  auto *sym = reinterpret_cast<Elf64_Sym *>(image.data() + symtab_offset);
+  sym[1].st_name = 1;
+  sym[1].st_value = kernel_descriptor_offset;
+
+  auto *hash = reinterpret_cast<uint32_t *>(image.data() + hash_offset);
+  hash[1] = 2; // nchain: null symbol + kernel descriptor symbol.
+
+  using namespace rocr::llvm::amdhsa;
+  kernel_descriptor_t kd{};
+  kd.kernel_code_entry_byte_offset = text_offset - kernel_descriptor_offset;
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT, 31);
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT, 12);
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT, 2);
+  std::memcpy(image.data() + kernel_descriptor_offset, &kd, sizeof(kd));
+
+  const std::array<uint32_t, 2> code = {S_NOP, S_ENDPGM};
+  std::memcpy(image.data() + text_offset, code.data(), code.size() * sizeof(code[0]));
+
+  return image;
+}
+
 TEST(ExecutionPluginTest, NoPluginNoCrash) {
   PluginFixture f;
   const uint32_t code[] = {S_NOP, S_ENDPGM};
   f.run_kernel(code, 2);
+}
+
+TEST(ExecutionPluginTest, DispatchPacketNameResolvesForVmidMappedCodeObject) {
+  PluginFixture f;
+  auto *plugin = f.attach_ordering_plugin();
+
+  constexpr uint32_t process_id = 123;
+  constexpr uint64_t code_object_va = 0x5400200000;
+  constexpr uint64_t kernel_descriptor_offset = 0x800;
+  auto image = make_loaded_kernel_symbol_elf(kernel_descriptor_offset, "vmid_dispatch_kernel.kd");
+  std::vector<uint8_t> image_backing(image.size() + amdgpu::GpuMemory::PAGE_SIZE, 0);
+  auto *image_host = reinterpret_cast<uint8_t *>(
+      (reinterpret_cast<uintptr_t>(image_backing.data()) + amdgpu::GpuMemory::PAGE_MASK) &
+      ~static_cast<uintptr_t>(amdgpu::GpuMemory::PAGE_MASK));
+  std::memcpy(image_host, image.data(), image.size());
+
+  KfdProcess process(process_id);
+  f.mem->register_process(process_id, &process.page_table_, &process.page_table_mutex_);
+  process.map_pages(code_object_va, image_host, image.size());
+
+  std::vector<uint8_t> ring(4096, 0);
+  std::array<uint8_t, 4096> queue_state{};
+  *reinterpret_cast<uint64_t *>(queue_state.data()) = 0;
+  *reinterpret_cast<uint64_t *>(queue_state.data() + 8) = 1;
+  uint64_t doorbell = 0;
+  constexpr uint64_t ring_va = 0x6100000000;
+  constexpr uint64_t read_ptr_va = 0x6100010000;
+  constexpr uint64_t write_ptr_va = 0x6100010008;
+  process.map_pages(ring_va, ring.data(), ring.size());
+  process.map_pages(read_ptr_va, queue_state.data(), queue_state.size());
+
+  hsa_kernel_dispatch_packet_t packet{};
+  packet.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  packet.setup = 1;
+  packet.workgroup_size_x = 64;
+  packet.workgroup_size_y = 1;
+  packet.workgroup_size_z = 1;
+  packet.grid_size_x = 64;
+  packet.grid_size_y = 1;
+  packet.grid_size_z = 1;
+  packet.kernel_object = code_object_va + kernel_descriptor_offset;
+  std::memcpy(ring.data(), &packet, sizeof(packet));
+
+  constexpr uint32_t queue_id = 7;
+  amdgpu::HwQueue queue{};
+  queue.queue_id = queue_id;
+  queue.process_id = process_id;
+  queue.ring_base_va = ring_va;
+  queue.ring_size = static_cast<uint32_t>(ring.size());
+  queue.read_ptr_va = read_ptr_va;
+  queue.write_ptr_va = write_ptr_va;
+  queue.doorbell_base = &doorbell;
+  queue.host_accessible = true;
+  f.cp()->register_queue(std::move(queue));
+  f.cp()->engine()->schedule_event_now(f.cp()->doorbell_event());
+  f.run_until_idle();
+
+  auto dispatch_event =
+      std::find_if(plugin->events.begin(), plugin->events.end(), [](const HookEvent &event) {
+        return event.kind == HookEvent::DISPATCH_PACKET_PROCESSED;
+      });
+  bool found_dispatch = dispatch_event != plugin->events.end();
+  std::string kernel_name = found_dispatch ? dispatch_event->kernel_name : "";
+
+  f.cp()->unregister_queue(queue_id, process_id);
+  f.shutdown();
+  f.mem->unregister_process(process_id);
+
+  ASSERT_TRUE(found_dispatch);
+  EXPECT_EQ(kernel_name, "vmid_dispatch_kernel");
 }
 
 // -- Ordering tests ----------------------------------------------------------


### PR DESCRIPTION
Draft for review.

Fix kernel-name lookup for KFD/daemon VMID-mapped dispatches by resolving the kernel-object GPU VA through the process page table before scanning ELF metadata.

Tests:
- cmake --build $BUILD_DIR --target rocjitsu_tests --parallel 8
- $BUILD_DIR/tests/rocjitsu_tests --gtest_filter='GpuMemoryTest.FindHostRangeUsesVmidPageTable:GpuMemoryTest.FindHostRangeStopsAtNonContiguousVmidHostPages:GpuMemoryTest.VmidMappedKernelSymbolUsesTranslatedHostPointer:ExecutionPluginTest.DispatchPacketNameResolvesForVmidMappedCodeObject'