### PR TITLE
feat(rocshmem/gda/ionic) Latency optimization for inline data on ionic

### DIFF
--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -1700,6 +1700,7 @@ void GDABackend::create_cqs(int cqe) {
 }
 
 void GDABackend::initialize_gpu_qp(QueuePair* gpu_qp, int conn_num) {
+  assert(inline_threshold >= 8);
   switch (gda_provider) {
   case GDAProvider::IONIC:
     ionic_initialize_gpu_qp(gpu_qp, conn_num);

--- a/projects/rocshmem/src/gda/ionic/backend_gda_ionic.cpp
+++ b/projects/rocshmem/src/gda/ionic/backend_gda_ionic.cpp
@@ -115,6 +115,7 @@ void GDABackend::ionic_initialize_gpu_qp(QueuePair* gpu_qp, int conn_num) {
   int nic_idx = nic_idx_for_qp(conn_num);
   gpu_qp->lkey = nic.heap_mr->lkey;
   gpu_qp->rkey = heap_rkey[pe * num_nics_ + nic_idx];
+  gpu_qp->inline_threshold = inline_threshold;
 
   /* Base Heap information */
   gpu_qp->base_heap = (uintptr_t) heap.get_local_heap_base();

--- a/projects/rocshmem/src/gda/ionic/backend_gda_ionic.cpp
+++ b/projects/rocshmem/src/gda/ionic/backend_gda_ionic.cpp
@@ -115,7 +115,6 @@ void GDABackend::ionic_initialize_gpu_qp(QueuePair* gpu_qp, int conn_num) {
   int nic_idx = nic_idx_for_qp(conn_num);
   gpu_qp->lkey = nic.heap_mr->lkey;
   gpu_qp->rkey = heap_rkey[pe * num_nics_ + nic_idx];
-  gpu_qp->inline_threshold = 32;
 
   /* Base Heap information */
   gpu_qp->base_heap = (uintptr_t) heap.get_local_heap_base();

--- a/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
+++ b/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
@@ -22,6 +22,8 @@
  * IN THE SOFTWARE.
  *****************************************************************************/
 
+#include <cassert>
+
 #include "gda/queue_pair.hpp"
 #include "gda/endian.hpp"
 #include "util.hpp"
@@ -327,13 +329,15 @@ __device__ void QueuePair::ionic_post_wqe_rma(int32_t length,
 
   if (length) {
     if (opcode == IONIC_V2_OP_RDMA_WRITE && static_cast<int32_t>(length) <= static_cast<int32_t>(inline_threshold)) {
+      assert(inline_threshold <= 8);
       wqe_flags |= byteswap<uint16_t>(IONIC_V1_FLAG_INL);
       wqe->base.num_sge_key = 0;
       if (!laddr) {
         // TODO why is this needed?
         wqe->common.pld.data[0] = 1;
       } else {
-        memcpy(wqe->common.pld.data, reinterpret_cast<const void*>(laddr), length);
+        *reinterpret_cast<uint64_t*>(wqe->common.pld.data) =
+            *reinterpret_cast<const uint64_t*>(laddr);
       }
     } else {
       wqe->common.pld.sgl[0].va = byteswap<uint64_t>(laddr);
@@ -382,13 +386,15 @@ __device__ void QueuePair::ionic_post_wqe_rma_single(int32_t length,
 
   if (length) {
     if (opcode == IONIC_V2_OP_RDMA_WRITE && static_cast<int32_t>(length) <= static_cast<int32_t>(inline_threshold)) {
+      assert(inline_threshold <= 8);
       wqe_flags |= byteswap<uint16_t>(IONIC_V1_FLAG_INL);
       wqe->base.num_sge_key = 0;
       if (!laddr) {
         // TODO why is this needed?
         wqe->common.pld.data[0] = 1;
       } else {
-        memcpy(wqe->common.pld.data, reinterpret_cast<const void*>(laddr), length);
+        *reinterpret_cast<uint64_t*>(wqe->common.pld.data) =
+            *reinterpret_cast<const uint64_t*>(laddr);
       }
     } else {
       wqe->common.pld.sgl[0].va = byteswap<uint64_t>(laddr);

--- a/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
+++ b/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
@@ -336,8 +336,11 @@ __device__ void QueuePair::ionic_post_wqe_rma(int32_t length,
         // TODO why is this needed?
         wqe->common.pld.data[0] = 1;
       } else {
-        *reinterpret_cast<uint64_t*>(wqe->common.pld.data) =
-            *reinterpret_cast<const uint64_t*>(laddr);
+        // Always read/write 8B to emit a single load+store instruction;
+        // overread is safe (heap page), NIC uses wqe length for actual size.
+        uint64_t val;
+        __builtin_memcpy(&val, reinterpret_cast<const void*>(laddr), sizeof(val));
+        *reinterpret_cast<uint64_t*>(wqe->common.pld.data) = val;
       }
     } else {
       wqe->common.pld.sgl[0].va = byteswap<uint64_t>(laddr);
@@ -393,8 +396,11 @@ __device__ void QueuePair::ionic_post_wqe_rma_single(int32_t length,
         // TODO why is this needed?
         wqe->common.pld.data[0] = 1;
       } else {
-        *reinterpret_cast<uint64_t*>(wqe->common.pld.data) =
-            *reinterpret_cast<const uint64_t*>(laddr);
+        // Always read/write 8B to emit a single load+store instruction;
+        // overread is safe (heap page), NIC uses wqe length for actual size.
+        uint64_t val;
+        __builtin_memcpy(&val, reinterpret_cast<const void*>(laddr), sizeof(val));
+        *reinterpret_cast<uint64_t*>(wqe->common.pld.data) = val;
       }
     } else {
       wqe->common.pld.sgl[0].va = byteswap<uint64_t>(laddr);


### PR DESCRIPTION
single store to set the inline value

## Motivation

Using 32B inline write to WQE causes a latency spike for message sizes 8, 16, 32, most pronounced for 16 and 32. This is due to using multiple memory transactions to write to the wqe inline field. From analysis there appear to be very little benefit to using inlining for sizes>8B. 

## Technical Details

* Do not override the max inline
* Use a single 8B write to set the inline wqe field (single memory transaction). Overwrite for sizes 1-7 is harmless. 

## JIRA ID

JIRA ID AIROCSHMEM-453

## Test Plan

Performance evaluated on Pollara 400G

## Test Result

Latency curve flat for sizes 1-128

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
