### PR TITLE
fix(rocshmem/api) LOGD in broadcast_wave use nelem, all shmem apis should use nelems

### DIFF
--- a/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
@@ -349,7 +349,7 @@ __device__ ATTR_NO_INLINE void rocshmem_ulonglong_alltoallv_wg(rocshmem_team_t t
  *                         symmetric heap.
  * @param[in] source       Source address. Must be an address on the symmetric
                            heap.
- * @param[in] nelement     Size of the buffer to participate in the broadcast.
+ * @param[in] nelems       Size of the buffer to participate in the broadcast.
  * @param[in] PE_root      Zero-based ordinal of the PE, with respect to the
                            active set, from which the data is copied
  * @param[in] PE_start     PE to start the reduction.
@@ -516,14 +516,14 @@ __host__ void rocshmem_ctx_ulonglong_broadcast(
  *                         symmetric heap.
  * @param[in] source       Source address. Must be an address on the symmetric
  *                         heap.
- * @param[in] nelement     Size of buffer to participate in the broadcast.
+ * @param[in] nelems       Size of buffer to participate in the broadcast.
  * @param[in] PE_root      Root PE (relative to team) from which to broadcast.
  * 
  *
  * @return void
  */
 __device__ void rocshmem_ctx_broadcastmem_wg(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              void *dest, const void *source, int nelement, int PE_root);
+              void *dest, const void *source, int nelems, int PE_root);
 
 /**
  * @name ROCSHMEM_CTX_TYPE_BROADCAST_WAVE
@@ -538,50 +538,50 @@ __device__ void rocshmem_ctx_broadcastmem_wg(rocshmem_ctx_t ctx, rocshmem_team_t
  *                         symmetric heap.
  * @param[in] source       Source address. Must be an address on the symmetric
  *                         heap.
- * @param[in] nelement     Number of elements to participate in the broadcast.
+ * @param[in] nelems       Number of elements to participate in the broadcast.
  * @param[in] PE_root      Root PE (relative to team) from which to broadcast.
  * 
  *
  * @return int; zero when sucessful, non-zero otherwise
  */
 __device__ int rocshmem_ctx_float_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              float *dest, const float *source, int nelement, int PE_root);
+              float *dest, const float *source, int nelems, int PE_root);
 
 __device__ int rocshmem_ctx_double_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              double *dest, const double *source, int nelement, int PE_root);
+              double *dest, const double *source, int nelems, int PE_root);
 
 __device__ int rocshmem_ctx_char_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              char *dest, const char *source, int nelement, int PE_root);
+              char *dest, const char *source, int nelems, int PE_root);
 
 __device__ int rocshmem_ctx_schar_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              signed char *dest, const signed char *source, int nelement, int PE_root);
+              signed char *dest, const signed char *source, int nelems, int PE_root);
 
 __device__ int rocshmem_ctx_short_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              short *dest, const short *source, int nelement, int PE_root);
+              short *dest, const short *source, int nelems, int PE_root);
 
 __device__ int rocshmem_ctx_int_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              int *dest, const int *source, int nelement, int PE_root);
+              int *dest, const int *source, int nelems, int PE_root);
 
 __device__ int rocshmem_ctx_long_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              long *dest, const long *source, int nelement, int PE_root);
+              long *dest, const long *source, int nelems, int PE_root);
 
 __device__ int rocshmem_ctx_longlong_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              long long *dest, const long long *source, int nelement, int PE_root);
+              long long *dest, const long long *source, int nelems, int PE_root);
 
 __device__ int rocshmem_ctx_uchar_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              unsigned char *dest, const unsigned char *source, int nelement, int PE_root);
+              unsigned char *dest, const unsigned char *source, int nelems, int PE_root);
 
 __device__ int rocshmem_ctx_ushort_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              unsigned short *dest, const unsigned short *source, int nelement, int PE_root);
+              unsigned short *dest, const unsigned short *source, int nelems, int PE_root);
 
 __device__ int rocshmem_ctx_uint_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              unsigned int *dest, const unsigned int *source, int nelement, int PE_root);
+              unsigned int *dest, const unsigned int *source, int nelems, int PE_root);
 
 __device__ int rocshmem_ctx_ulong_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              unsigned long *dest, const unsigned long *source, int nelement, int PE_root);
+              unsigned long *dest, const unsigned long *source, int nelems, int PE_root);
 
 __device__ int rocshmem_ctx_ulonglong_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              unsigned long long *dest, const unsigned long long *source, int nelement, int PE_root);
+              unsigned long long *dest, const unsigned long long *source, int nelems, int PE_root);
 
 /**
  * @name ROCSHMEM_CTX_BROADCASTMEM_WAVE
@@ -596,14 +596,14 @@ __device__ int rocshmem_ctx_ulonglong_broadcast_wave(rocshmem_ctx_t ctx, rocshme
  *                         symmetric heap.
  * @param[in] source       Source address. Must be an address on the symmetric
  *                         heap.
- * @param[in] nelement     Size of buffer to participate in the broadcast.
+ * @param[in] nelems       Size of buffer to participate in the broadcast.
  * @param[in] PE_root      Root PE (relative to team) from which to broadcast.
  * 
  *
  * @return int; zero when successful, non-zero otherwise
  */
 __device__ int rocshmem_ctx_broadcastmem_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              void *dest, const void *source, int nelement, int PE_root);
+              void *dest, const void *source, int nelems, int PE_root);
 
 /**
  * @name SHMEM_FCOLLECT

--- a/projects/rocshmem/src/context.hpp
+++ b/projects/rocshmem/src/context.hpp
@@ -122,7 +122,7 @@ class Context {
   __device__ void putmem_nbi(void* dest, const void* source, size_t nelems,
                              int pe);
 
-  __device__ void getmem_nbi(void* dest, const void* source, size_t size,
+  __device__ void getmem_nbi(void* dest, const void* source, size_t nelems,
                              int pe);
 
   __device__ void fence();
@@ -293,7 +293,7 @@ class Context {
   __device__ void putmem_nbi_wg(void* dest, const void* source, size_t nelems,
                                 int pe);
 
-  __device__ void getmem_nbi_wg(void* dest, const void* source, size_t size,
+  __device__ void getmem_nbi_wg(void* dest, const void* source, size_t nelems,
                                 int pe);
 
   __device__ void putmem_wave(void* dest, const void* source, size_t nelems,
@@ -305,7 +305,7 @@ class Context {
   __device__ void putmem_nbi_wave(void* dest, const void* source, size_t nelems,
                                   int pe);
 
-  __device__ void getmem_nbi_wave(void* dest, const void* source, size_t size,
+  __device__ void getmem_nbi_wave(void* dest, const void* source, size_t nelems,
                                   int pe);
 
   template <typename T>
@@ -507,7 +507,7 @@ class Context {
   __host__ void putmem_nbi(void* dest, const void* source, size_t nelems,
                            int pe);
 
-  __host__ void getmem_nbi(void* dest, const void* source, size_t size, int pe);
+  __host__ void getmem_nbi(void* dest, const void* source, size_t nelems, int pe);
 
   template <typename T>
   __host__ void amo_add(void* dst, T value, int pe);
@@ -566,7 +566,7 @@ class Context {
   __host__ void sync_on_stream(rocshmem_team_t team, hipStream_t stream);
 
   __host__ void alltoallmem_on_stream(rocshmem_team_t team, void *dest,
-                                      const void *source, size_t size,
+                                      const void *source, size_t nelems,
                                       hipStream_t stream);
 
   __host__ void broadcastmem_on_stream(rocshmem_team_t team, void *dest,

--- a/projects/rocshmem/src/context.hpp
+++ b/projects/rocshmem/src/context.hpp
@@ -274,15 +274,15 @@ class Context {
                             int pe_start, int log_pe_stride, int pe_size,
                             long* p_sync);  // NOLINT(runtime/int)
 
-  __device__ void broadcastmem_wg(rocshmem_team_t team, void *dest, const void *source, 
-                                  int nelement, int PE_root);
+  __device__ void broadcastmem_wg(rocshmem_team_t team, void *dest, const void *source,
+                                  int nelems, int PE_root);
 
   template <typename T>
-  __device__ int broadcast_wave(rocshmem_team_t team, T *dest, const T *source, 
-                                int nelement, int PE_root);
+  __device__ int broadcast_wave(rocshmem_team_t team, T *dest, const T *source,
+                                int nelems, int PE_root);
 
-  __device__ int broadcastmem_wave(rocshmem_team_t team, void *dest, const void *source, 
-                                   int nelement, int PE_root);
+  __device__ int broadcastmem_wave(rocshmem_team_t team, void *dest, const void *source,
+                                   int nelems, int PE_root);
 
   __device__ void putmem_wg(void* dest, const void* source, size_t nelems,
                             int pe);

--- a/projects/rocshmem/src/context_device.cpp
+++ b/projects/rocshmem/src/context_device.cpp
@@ -293,14 +293,14 @@ __device__ void Context::getmem_nbi_wave(void* dest, const void* source,
   DISPATCH(getmem_nbi_wave(dest, source, size, pe));
 }
 
-__device__ int Context::broadcastmem_wave(rocshmem_team_t team, void *dest, const void *source, 
-                                          int nelement, int PE_root){
-  DISPATCH_RET(broadcastmem_wave(team, dest, source, nelement, PE_root));
+__device__ int Context::broadcastmem_wave(rocshmem_team_t team, void *dest, const void *source,
+                                          int nelems, int PE_root){
+  DISPATCH_RET(broadcastmem_wave(team, dest, source, nelems, PE_root));
 }
 
-__device__ void Context::broadcastmem_wg(rocshmem_team_t team, void *dest, const void *source, 
-                                        int nelement, int PE_root){
-  DISPATCH(broadcastmem_wg(team, dest, source, nelement, PE_root));
+__device__ void Context::broadcastmem_wg(rocshmem_team_t team, void *dest, const void *source,
+                                        int nelems, int PE_root){
+  DISPATCH(broadcastmem_wg(team, dest, source, nelems, PE_root));
 }
 
 __device__ void Context::alltoallmem_wg(rocshmem_team_t team, void* dest,

--- a/projects/rocshmem/src/context_device.cpp
+++ b/projects/rocshmem/src/context_device.cpp
@@ -92,15 +92,15 @@ __device__ void Context::putmem_nbi(void* dest, const void* source,
   DISPATCH(putmem_nbi(dest, source, nelems, pe));
 }
 
-__device__ void Context::getmem_nbi(void* dest, const void* source, size_t size,
+__device__ void Context::getmem_nbi(void* dest, const void* source, size_t nelems,
                                     int pe) {
-  if (size == 0) {
+  if (nelems == 0) {
     return;
   }
 
   ctxStats.incStat(NUM_GET_NBI);
 
-  DISPATCH(getmem_nbi(dest, source, size, pe));
+  DISPATCH(getmem_nbi(dest, source, nelems, pe));
 }
 
 __device__ void Context::fence() {
@@ -239,14 +239,14 @@ __device__ void Context::putmem_nbi_wg(void* dest, const void* source,
 }
 
 __device__ void Context::getmem_nbi_wg(void* dest, const void* source,
-                                       size_t size, int pe) {
-  if (size == 0) {
+                                       size_t nelems, int pe) {
+  if (nelems == 0) {
     return;
   }
 
   ctxStats.incStat(NUM_GET_NBI_WG);
 
-  DISPATCH(getmem_nbi_wg(dest, source, size, pe));
+  DISPATCH(getmem_nbi_wg(dest, source, nelems, pe));
 }
 
 __device__ void Context::putmem_wave(void* dest, const void* source,
@@ -283,14 +283,14 @@ __device__ void Context::putmem_nbi_wave(void* dest, const void* source,
 }
 
 __device__ void Context::getmem_nbi_wave(void* dest, const void* source,
-                                         size_t size, int pe) {
-  if (size == 0) {
+                                         size_t nelems, int pe) {
+  if (nelems == 0) {
     return;
   }
 
   ctxStats.incStat(NUM_GET_NBI_WAVE);
 
-  DISPATCH(getmem_nbi_wave(dest, source, size, pe));
+  DISPATCH(getmem_nbi_wave(dest, source, nelems, pe));
 }
 
 __device__ int Context::broadcastmem_wave(rocshmem_team_t team, void *dest, const void *source,

--- a/projects/rocshmem/src/context_host.cpp
+++ b/projects/rocshmem/src/context_host.cpp
@@ -160,11 +160,11 @@ __host__ void Context::sync_on_stream(rocshmem_team_t team,
 }
 
 __host__ void Context::alltoallmem_on_stream(rocshmem_team_t team, void *dest,
-                                             const void *source, size_t size,
+                                             const void *source, size_t nelems,
                                              hipStream_t stream) {
   ctxHostStats.incStat(NUM_HOST_ALLTOALL);
 
-  HOST_DISPATCH(alltoallmem_on_stream(team, dest, source, size, stream));
+  HOST_DISPATCH(alltoallmem_on_stream(team, dest, source, nelems, stream));
 }
 
 __host__ void Context::broadcastmem_on_stream(rocshmem_team_t team, void *dest,

--- a/projects/rocshmem/src/context_tmpl_device.hpp
+++ b/projects/rocshmem/src/context_tmpl_device.hpp
@@ -901,8 +901,8 @@ __device__ inline int Context::tile_min_reduce_wg(rocshmem_team_t team, void* ds
 
 template <typename T>
 __device__ int Context::broadcast_wave(rocshmem_team_t team, 
-                              T *dest, const T *source, int nelement, int PE_root){
-  DISPATCH_RET(broadcast_wave<T>(team, dest, source, nelement, PE_root));
+                              T *dest, const T *source, int nelems, int PE_root){
+  DISPATCH_RET(broadcast_wave<T>(team, dest, source, nelems, PE_root));
 }
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -50,7 +50,7 @@ class GDAContext : public Context {
   __device__ void putmem_nbi(void *dest, const void *source, size_t nelems,
                              int pe);
 
-  __device__ void getmem_nbi(void *dest, const void *source, size_t size,
+  __device__ void getmem_nbi(void *dest, const void *source, size_t nelems,
                              int pe);
 
   __device__ void fence();
@@ -226,7 +226,7 @@ class GDAContext : public Context {
   __device__ void putmem_nbi_wg(void *dest, const void *source, size_t nelems,
                                 int pe);
 
-  __device__ void getmem_nbi_wg(void *dest, const void *source, size_t size,
+  __device__ void getmem_nbi_wg(void *dest, const void *source, size_t nelems,
                                 int pe);
 
   __device__ void putmem_wave(void *dest, const void *source, size_t nelems,
@@ -238,7 +238,7 @@ class GDAContext : public Context {
   __device__ void putmem_nbi_wave(void *dest, const void *source, size_t nelems,
                                   int pe);
 
-  __device__ void getmem_nbi_wave(void *dest, const void *source, size_t size,
+  __device__ void getmem_nbi_wave(void *dest, const void *source, size_t nelems,
                                   int pe);
 
   template <typename T>

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -157,15 +157,15 @@ class GDAContext : public Context {
   __device__ void broadcast_wg(rocshmem_team_t team, T *dest, const T *source,
                             int nelems, int pe_root);
 
-  __device__ void broadcastmem_wg(rocshmem_team_t team, void *dest, const void* source, 
-                                  int nelement, int PE_root);
+  __device__ void broadcastmem_wg(rocshmem_team_t team, void *dest, const void* source,
+                                  int nelems, int PE_root);
 
   template <typename T>
   __device__ int broadcast_wave(rocshmem_team_t team,
-                                T *dest, const T* source, int nelement, int PE_root);
+                                T *dest, const T* source, int nelems, int PE_root);
 
   __device__ int broadcastmem_wave(rocshmem_team_t team,
-                                void *dest, const void* source, int nelement, int PE_root);
+                                void *dest, const void* source, int nelems, int PE_root);
 
   template <typename T>
   __device__ void alltoall_wg(rocshmem_team_t team, T *dest, const T *source,

--- a/projects/rocshmem/src/gda/context_gda_device_coll.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device_coll.cpp
@@ -320,7 +320,7 @@ __device__ void GDAContext::internal_get_broadcastmem_wave(void *dst, const void
 }
 
 __device__ int GDAContext::broadcastmem_wave(rocshmem_team_t team, void *dest, 
-    const void* source, int nelement, int PE_root) {
+    const void* source, int nelems, int PE_root) {
   if (dest == nullptr || 
     source == nullptr || 
     team == ROCSHMEM_TEAM_INVALID)
@@ -335,7 +335,7 @@ __device__ int GDAContext::broadcastmem_wave(rocshmem_team_t team, void *dest,
 
   // Passed pe_root is relative to team, convert to world root
   int pe_root_world = team_obj->get_pe_in_world(PE_root);
-  internal_broadcastmem_wave(dest, source, nelement, pe_root_world, pe_start, stride,
+  internal_broadcastmem_wave(dest, source, nelems, pe_root_world, pe_start, stride,
                pe_size, p_sync);
   return ROCSHMEM_SUCCESS;
 }

--- a/projects/rocshmem/src/gda/context_gda_host.cpp
+++ b/projects/rocshmem/src/gda/context_gda_host.cpp
@@ -150,9 +150,9 @@ __host__ void GDAHostContext::sync_on_stream(rocshmem_team_t team,
 __host__ void GDAHostContext::alltoallmem_on_stream(rocshmem_team_t team,
                                                     void *dest,
                                                     const void *source,
-                                                    size_t size,
+                                                    size_t nelems,
                                                     hipStream_t stream) {
-  host_interface->alltoallmem_on_stream(team, dest, source, size, stream);
+  host_interface->alltoallmem_on_stream(team, dest, source, nelems, stream);
 }
 
 __host__ void GDAHostContext::broadcastmem_on_stream(rocshmem_team_t team,

--- a/projects/rocshmem/src/gda/context_gda_host.hpp
+++ b/projects/rocshmem/src/gda/context_gda_host.hpp
@@ -60,7 +60,7 @@ class GDAHostContext : public Context {
   __host__ void putmem_nbi(void *dest, const void *source, size_t nelems,
                            int pe);
 
-  __host__ void getmem_nbi(void *dest, const void *source, size_t size, int pe);
+  __host__ void getmem_nbi(void *dest, const void *source, size_t nelems, int pe);
 
   template <typename T>
   __host__ void amo_add(void *dst, T value, int pe);
@@ -93,7 +93,7 @@ class GDAHostContext : public Context {
   __host__ void sync_on_stream(rocshmem_team_t team, hipStream_t stream);
 
   __host__ void alltoallmem_on_stream(rocshmem_team_t team, void *dest,
-                                      const void *source, size_t size,
+                                      const void *source, size_t nelems,
                                       hipStream_t stream);
 
   __host__ void broadcastmem_on_stream(rocshmem_team_t team, void *dest,

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -877,7 +877,7 @@ __device__ void GDAContext::internal_get_broadcast_wave(T *dst, const T *src,
 
 template <typename T>
 __device__ int GDAContext::broadcast_wave(rocshmem_team_t team, T *dest, 
-    const T* source, int nelement, int PE_root) {
+    const T* source, int nelems, int PE_root) {
   if (dest == nullptr || 
     source == nullptr || 
     team == ROCSHMEM_TEAM_INVALID)
@@ -892,7 +892,7 @@ __device__ int GDAContext::broadcast_wave(rocshmem_team_t team, T *dest,
 
   // Passed pe_root is relative to team, convert to world root
   int pe_root_world = team_obj->get_pe_in_world(PE_root);
-  internal_broadcast_wave<T>(dest, source, nelement, pe_root_world, pe_start, stride,
+  internal_broadcast_wave<T>(dest, source, nelems, pe_root_world, pe_start, stride,
                pe_size, p_sync);
   return ROCSHMEM_SUCCESS;
 }

--- a/projects/rocshmem/src/host/host.cpp
+++ b/projects/rocshmem/src/host/host.cpp
@@ -417,11 +417,11 @@ __host__ void HostInterface::sync_on_stream(rocshmem_team_t team,
 __host__ void HostInterface::alltoallmem_on_stream(rocshmem_team_t team,
                                                    void *dest,
                                                    const void *source,
-                                                   size_t size,
+                                                   size_t nelems,
                                                    hipStream_t stream) {
   // Use dynamic block size determination:
   // - Query optimal block size using occupancy API
-  // - Limit block size to size (number of bytes) to avoid over-subscription
+  // - Limit block size to nelems (number of bytes) to avoid over-subscription
   // - Always use 1 block (single workgroup collective)
   int optimal_block_size = 0;
   int grid_size = 0;
@@ -429,16 +429,16 @@ __host__ void HostInterface::alltoallmem_on_stream(rocshmem_team_t team,
                                               rocshmem_alltoallmem_kernel, 0,
                                               0));
 
-  // Limit block size to size (bytes) to avoid over-subscription
-  int num_threads_per_block = (optimal_block_size > static_cast<int>(size))
-                                  ? static_cast<int>(size)
+  // Limit block size to nelems (bytes) to avoid over-subscription
+  int num_threads_per_block = (optimal_block_size > static_cast<int>(nelems))
+                                  ? static_cast<int>(nelems)
                                   : optimal_block_size;
 
-  // Launch kernel to do alltoall with given stream                                  
+  // Launch kernel to do alltoall with given stream
   dim3 gridSize(1);
   dim3 blockSize(num_threads_per_block);
   rocshmem_alltoallmem_kernel<<<gridSize, blockSize, 0, stream>>>(team, dest,
-                                                                  source, size);
+                                                                  source, nelems);
 }
 
 __host__ void HostInterface::broadcastmem_on_stream(rocshmem_team_t team,

--- a/projects/rocshmem/src/host/host.hpp
+++ b/projects/rocshmem/src/host/host.hpp
@@ -171,7 +171,7 @@ class HostInterface {
   __host__ void putmem_nbi(void* dest, const void* source, size_t nelems,
                            int pe, WindowInfo* window_info);
 
-  __host__ void getmem_nbi(void* dest, const void* source, size_t size, int pe,
+  __host__ void getmem_nbi(void* dest, const void* source, size_t nelems, int pe,
                            WindowInfo* window_info);
 
   template <typename T>
@@ -207,7 +207,7 @@ class HostInterface {
   __host__ void sync_on_stream(rocshmem_team_t team, hipStream_t stream);
 
   __host__ void alltoallmem_on_stream(rocshmem_team_t team, void *dest,
-                                      const void *source, size_t size,
+                                      const void *source, size_t nelems,
                                       hipStream_t stream);
 
   __host__ void broadcastmem_on_stream(rocshmem_team_t team, void *dest,

--- a/projects/rocshmem/src/ipc/context_ipc_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.hpp
@@ -152,14 +152,14 @@ class IPCContext : public Context {
                             int nelems, int pe_root);
 
   __device__ void broadcastmem_wg(rocshmem_team_t team,
-                                void *dest, const void *source, int nelement, int PE_root);
+                                void *dest, const void *source, int nelems, int PE_root);
 
   template <typename T>
   __device__ int broadcast_wave(rocshmem_team_t team,
-                                T *dest, const T *source, int nelement, int PE_root);
+                                T *dest, const T *source, int nelems, int PE_root);
 
   __device__ int broadcastmem_wave(rocshmem_team_t team,
-                                void *dest, const void *source, int nelement, int PE_root);
+                                void *dest, const void *source, int nelems, int PE_root);
 
   template <typename T>
   __device__ void alltoall_wg(rocshmem_team_t team, T *dest, const T *source,

--- a/projects/rocshmem/src/ipc/context_ipc_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.hpp
@@ -44,7 +44,7 @@ class IPCContext : public Context {
   __device__ void putmem_nbi(void *dest, const void *source, size_t nelems,
                              int pe);
 
-  __device__ void getmem_nbi(void *dest, const void *source, size_t size,
+  __device__ void getmem_nbi(void *dest, const void *source, size_t nelems,
                              int pe);
 
   __device__ void fence();
@@ -206,7 +206,7 @@ class IPCContext : public Context {
   __device__ void putmem_nbi_wg(void *dest, const void *source, size_t nelems,
                                 int pe);
 
-  __device__ void getmem_nbi_wg(void *dest, const void *source, size_t size,
+  __device__ void getmem_nbi_wg(void *dest, const void *source, size_t nelems,
                                 int pe);
 
   __device__ void putmem_wave(void *dest, const void *source, size_t nelems,
@@ -218,7 +218,7 @@ class IPCContext : public Context {
   __device__ void putmem_nbi_wave(void *dest, const void *source, size_t nelems,
                                   int pe);
 
-  __device__ void getmem_nbi_wave(void *dest, const void *source, size_t size,
+  __device__ void getmem_nbi_wave(void *dest, const void *source, size_t nelems,
                                   int pe);
 
   template <typename T>

--- a/projects/rocshmem/src/ipc/context_ipc_device_coll.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device_coll.cpp
@@ -349,7 +349,7 @@ __device__ void IPCContext::internal_broadcastmem_wave(void *dst, const void *sr
 }
 
 __device__ int IPCContext::broadcastmem_wave(rocshmem_team_t team,
-                              void *dest, const void *source, int nelement, int PE_root) {
+                              void *dest, const void *source, int nelems, int PE_root) {
 
   if (dest == nullptr || source == nullptr || team == ROCSHMEM_TEAM_INVALID)
     return ROCSHMEM_ERROR;
@@ -364,7 +364,7 @@ __device__ int IPCContext::broadcastmem_wave(rocshmem_team_t team,
   // Passed pe_root is relative to team, convert to world root
   int pe_root_world = team_obj->get_pe_in_world(PE_root);
 
-  internal_broadcastmem_wave(dest, source, nelement, pe_root_world, 
+  internal_broadcastmem_wave(dest, source, nelems, pe_root_world,
                               pe_start, stride, pe_size, p_sync);
   return ROCSHMEM_SUCCESS;
 }
@@ -400,7 +400,7 @@ __device__ void IPCContext::internal_broadcastmem_wg(void *dst, const void *src,
 }
 
 __device__ void IPCContext::broadcastmem_wg(rocshmem_team_t team,
-                              void *dest, const void *source, int nelement, int PE_root) {
+                              void *dest, const void *source, int nelems, int PE_root) {
   IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
 
   int stride = team_obj->tinfo_wrt_world->stride;
@@ -411,7 +411,7 @@ __device__ void IPCContext::broadcastmem_wg(rocshmem_team_t team,
   // Passed pe_root is relative to team, convert to world root
   int pe_root_world = team_obj->get_pe_in_world(PE_root);
 
-  internal_broadcastmem_wg(dest, source, nelement, pe_root_world, 
+  internal_broadcastmem_wg(dest, source, nelems, pe_root_world,
                               pe_start, stride, pe_size, p_sync);
 }
 __device__ int IPCContext::alltoallmem_wave(rocshmem_team_t team, void* dest, 

--- a/projects/rocshmem/src/ipc/context_ipc_host.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_host.cpp
@@ -218,9 +218,9 @@ __host__ void IPCHostContext::sync_on_stream(rocshmem_team_t team,
 __host__ void IPCHostContext::alltoallmem_on_stream(rocshmem_team_t team,
                                                     void *dest,
                                                     const void *source,
-                                                    size_t size,
+                                                    size_t nelems,
                                                     hipStream_t stream) {
-  host_interface->alltoallmem_on_stream(team, dest, source, size, stream);
+  host_interface->alltoallmem_on_stream(team, dest, source, nelems, stream);
 }
 
 __host__ void IPCHostContext::broadcastmem_on_stream(rocshmem_team_t team,

--- a/projects/rocshmem/src/ipc/context_ipc_host.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_host.hpp
@@ -61,7 +61,7 @@ class IPCHostContext : public Context {
   __host__ void putmem_nbi(void *dest, const void *source, size_t nelems,
                            int pe);
 
-  __host__ void getmem_nbi(void *dest, const void *source, size_t size, int pe);
+  __host__ void getmem_nbi(void *dest, const void *source, size_t nelems, int pe);
 
   template <typename T>
   __host__ void amo_add(void *dst, T value, int pe);
@@ -94,7 +94,7 @@ class IPCHostContext : public Context {
   __host__ void sync_on_stream(rocshmem_team_t team, hipStream_t stream);
 
   __host__ void alltoallmem_on_stream(rocshmem_team_t team, void *dest,
-                                      const void *source, size_t size,
+                                      const void *source, size_t nelems,
                                       hipStream_t stream);
 
   __host__ void broadcastmem_on_stream(rocshmem_team_t team, void *dest,

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -680,7 +680,7 @@ __device__ void IPCContext::internal_get_broadcast_wave(
 
 template <typename T>
 __device__ int IPCContext::broadcast_wave(rocshmem_team_t team,
-                              T *dest, const T *source, int nelement, int PE_root) {
+                              T *dest, const T *source, int nelems, int PE_root) {
   if (dest == nullptr || 
     source == nullptr || 
     team == ROCSHMEM_TEAM_INVALID)
@@ -695,7 +695,7 @@ __device__ int IPCContext::broadcast_wave(rocshmem_team_t team,
 
   // Passed pe_root is relative to team, convert to world root
   int pe_root_world = team_obj->get_pe_in_world(PE_root);
-  internal_broadcast_wave<T>(dest, source, nelement, pe_root_world, 
+  internal_broadcast_wave<T>(dest, source, nelems, pe_root_world,
                               pe_start, stride, pe_size, p_sync);
 
   return ROCSHMEM_SUCCESS;

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
@@ -576,7 +576,7 @@ __device__ uint64_t broadcast(bool lowest_active, uint64_t value) {
 __device__ int ROContext::broadcastmem_wave([[maybe_unused]] rocshmem_team_t team,
                                         [[maybe_unused]] void *dest, 
                                         [[maybe_unused]] const void* source, 
-                                        [[maybe_unused]] int nelement, 
+                                        [[maybe_unused]] int nelems,
                                         [[maybe_unused]] int PE_root) {
   LOGD_WARN("Broadcastmem Wave API not implemented for reverse offload backend");
   return ROCSHMEM_ERROR;

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
@@ -50,7 +50,7 @@ class ROContext : public Context {
   __device__ void putmem_nbi(void *dest, const void *source, size_t nelems,
                              int pe);
 
-  __device__ void getmem_nbi(void *dest, const void *source, size_t size,
+  __device__ void getmem_nbi(void *dest, const void *source, size_t nelems,
                              int pe);
 
   __device__ void fence();
@@ -216,7 +216,7 @@ class ROContext : public Context {
   __device__ void putmem_nbi_wg(void *dest, const void *source, size_t nelems,
                                 int pe);
 
-  __device__ void getmem_nbi_wg(void *dest, const void *source, size_t size,
+  __device__ void getmem_nbi_wg(void *dest, const void *source, size_t nelems,
                                 int pe);
 
   __device__ void putmem_wave(void *dest, const void *source, size_t nelems,
@@ -228,7 +228,7 @@ class ROContext : public Context {
   __device__ void putmem_nbi_wave(void *dest, const void *source, size_t nelems,
                                   int pe);
 
-  __device__ void getmem_nbi_wave(void *dest, const void *source, size_t size,
+  __device__ void getmem_nbi_wave(void *dest, const void *source, size_t nelems,
                                   int pe);
 
   template <typename T>

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
@@ -167,10 +167,10 @@ class ROContext : public Context {
                             
   template <typename T>
   __device__ int broadcast_wave(rocshmem_team_t team,
-                                T *dest, const T* source, int nelement, int PE_root);
+                                T *dest, const T* source, int nelems, int PE_root);
 
   __device__ int broadcastmem_wave(rocshmem_team_t team,
-                                  void *dest, const void* source, int nelement, int PE_root);
+                                  void *dest, const void* source, int nelems, int PE_root);
 
   template <typename T>
   __device__ void alltoall_wg(rocshmem_team_t team, T *dest, const T *source,

--- a/projects/rocshmem/src/reverse_offload/context_ro_host.cpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_host.cpp
@@ -167,10 +167,10 @@ __host__ void ROHostContext::sync_on_stream(rocshmem_team_t team,
 __host__ void ROHostContext::alltoallmem_on_stream(rocshmem_team_t team,
                                                     void *dest,
                                                     const void *source,
-                                                    size_t size,
+                                                    size_t nelems,
                                                     hipStream_t stream) {
 
-  host_interface->alltoallmem_on_stream(team, dest, source, size, stream);
+  host_interface->alltoallmem_on_stream(team, dest, source, nelems, stream);
 }
 
 __host__ void ROHostContext::broadcastmem_on_stream(rocshmem_team_t team,

--- a/projects/rocshmem/src/reverse_offload/context_ro_host.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_host.hpp
@@ -109,7 +109,7 @@ class ROHostContext : public Context {
   __host__ void putmem_nbi(void *dest, const void *source, size_t nelems,
                            int pe);
 
-  __host__ void getmem_nbi(void *dest, const void *source, size_t size, int pe);
+  __host__ void getmem_nbi(void *dest, const void *source, size_t nelems, int pe);
 
   template <typename T>
   __host__ void amo_add(void *dst, T value, int pe);
@@ -142,7 +142,7 @@ class ROHostContext : public Context {
   __host__ void sync_on_stream(rocshmem_team_t team, hipStream_t stream);
 
   __host__ void alltoallmem_on_stream(rocshmem_team_t team, void *dest,
-                                      const void *source, size_t size,
+                                      const void *source, size_t nelems,
                                       hipStream_t stream);
 
   __host__ void broadcastmem_on_stream(rocshmem_team_t team, void *dest,

--- a/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
@@ -360,7 +360,7 @@ template <typename T>
 __device__ int ROContext::broadcast_wave([[maybe_unused]] rocshmem_team_t team,
                                         [[maybe_unused]] T *dest, 
                                         [[maybe_unused]] const T* source, 
-                                        [[maybe_unused]] int nelement, 
+                                        [[maybe_unused]] int nelems,
                                         [[maybe_unused]] int PE_root) {
   LOGD_WARN("Broadcast Wave API not implemented for reverse offload backend");
   return ROCSHMEM_ERROR;

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -1321,9 +1321,9 @@ __host__ void rocshmem_team_sync_on_stream(rocshmem_team_t team,
 }
 
 __host__ void rocshmem_alltoallmem_on_stream(rocshmem_team_t team, void *dest,
-                                             const void *source, size_t size,
+                                             const void *source, size_t nelems,
                                              hipStream_t stream) {
-  RocshmemGetFunctionTable()->alltoallmem_on_stream_fn(team, dest, source, size, stream);
+  RocshmemGetFunctionTable()->alltoallmem_on_stream_fn(team, dest, source, nelems, stream);
 }
 
 __host__ void rocshmem_broadcastmem_on_stream(rocshmem_team_t team, void *dest,

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -1373,24 +1373,24 @@ __host__ void rocshmem_team_sync(rocshmem_team_t team) {
 
 template <typename T>
 __host__ void rocshmem_broadcast([[maybe_unused]] rocshmem_ctx_t ctx, T *dest,
-                                  const T *source, int nelem, int pe_root,
+                                  const T *source, int nelems, int pe_root,
                                   int pe_start, int log_pe_stride, int pe_size,
                                   long *p_sync) {
-  LOG_API("host::broadcast (dest=%p, source=%p, nelem=%d, pe_root=%d)", dest, source, nelem, pe_root);
+  LOG_API("host::broadcast (dest=%p, source=%p, nelems=%d, pe_root=%d)", dest, source, nelems, pe_root);
 
   get_internal_ctx(ROCSHMEM_HOST_CTX_DEFAULT)
-      ->broadcast<T>(dest, source, nelem, pe_root, pe_start, log_pe_stride,
+      ->broadcast<T>(dest, source, nelems, pe_root, pe_start, log_pe_stride,
                      pe_size, p_sync);
 }
 
 template <typename T>
 __host__ void rocshmem_broadcast([[maybe_unused]] rocshmem_ctx_t ctx,
                                   rocshmem_team_t team, T *dest,
-                                  const T *source, int nelem, int pe_root) {
-  LOG_API("host::broadcast (dest=%p, source=%p, nelem=%d, pe_root=%d)", dest, source, nelem, pe_root);
+                                  const T *source, int nelems, int pe_root) {
+  LOG_API("host::broadcast (dest=%p, source=%p, nelems=%d, pe_root=%d)", dest, source, nelems, pe_root);
 
   get_internal_ctx(ROCSHMEM_HOST_CTX_DEFAULT)
-      ->broadcast<T>(team, dest, source, nelem, pe_root);
+      ->broadcast<T>(team, dest, source, nelems, pe_root);
 }
 
 template <typename T, ROCSHMEM_OP Op>
@@ -1554,11 +1554,11 @@ __host__ int rocshmem_test(T *ivars, int cmp, T val) {
                                               size_t nelems, int pe);         \
   template __host__ T rocshmem_g<T>(const T *source, int pe);                 \
   template __host__ void rocshmem_broadcast<T>(                               \
-      rocshmem_ctx_t ctx, T * dest, const T *source, int nelem, int pe_root,  \
+      rocshmem_ctx_t ctx, T * dest, const T *source, int nelems, int pe_root,  \
       int pe_start, int log_pe_stride, int pe_size, long *p_sync);            \
   template __host__ void rocshmem_broadcast<T>(                               \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,    \
-      int nelem, int pe_root);
+      int nelems, int pe_root);
 
 /**
  * Declare templates for the standard amo types
@@ -1738,15 +1738,15 @@ __host__ int rocshmem_test(T *ivars, int cmp, T val) {
     return rocshmem_g<T>(source, pe);                                         \
   }                                                                           \
   __host__ void rocshmem_ctx_##TNAME##_broadcast(                             \
-      rocshmem_ctx_t ctx, T *dest, const T *source, int nelem, int pe_root,   \
+      rocshmem_ctx_t ctx, T *dest, const T *source, int nelems, int pe_root,  \
       int pe_start, int log_pe_stride, int pe_size, long *p_sync) {           \
-    rocshmem_broadcast<T>(ctx, dest, source, nelem, pe_root, pe_start,        \
+    rocshmem_broadcast<T>(ctx, dest, source, nelems, pe_root, pe_start,       \
                            log_pe_stride, pe_size, p_sync);                   \
   }                                                                           \
   __host__ void rocshmem_ctx_##TNAME##_broadcast(                             \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest, const T *source,     \
-      int nelem, int pe_root) {                                               \
-    rocshmem_broadcast<T>(ctx, team, dest, source, nelem, pe_root);           \
+      int nelems, int pe_root) {                                              \
+    rocshmem_broadcast<T>(ctx, team, dest, source, nelems, pe_root);          \
   }
 
 #define AMO_STANDARD_DEF_GEN(T, TNAME)                                        \

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -664,62 +664,62 @@ __device__ int rocshmem_reduce_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
 template <typename T>
 __device__ void rocshmem_broadcast_wg(rocshmem_ctx_t ctx,
                                        rocshmem_team_t team, T *dest,
-                                       const T *source, int nelem,
+                                       const T *source, int nelems,
                                        int pe_root) {
-  LOGD_API("device::broadcast_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d, root=%d)",
-    ctx.ctx_opaque, team, dest, source, nelem, pe_root);
+  LOGD_API("device::broadcast_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelems=%d, root=%d)",
+    ctx.ctx_opaque, team, dest, source, nelems, pe_root);
 
-  get_internal_ctx(ctx)->broadcast_wg<T>(team, dest, source, nelem, pe_root);
+  get_internal_ctx(ctx)->broadcast_wg<T>(team, dest, source, nelems, pe_root);
 }
 
 __device__ void rocshmem_ctx_broadcastmem_wg(rocshmem_ctx_t ctx, rocshmem_team_t team,
-  void *dest, const void *source, int nelem, int pe_root) {
-    LOGD_API("device::broadcastmem_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d, root=%d)",
-      ctx.ctx_opaque, team, dest, source, nelem, pe_root);
+  void *dest, const void *source, int nelems, int pe_root) {
+    LOGD_API("device::broadcastmem_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelems=%d, root=%d)",
+      ctx.ctx_opaque, team, dest, source, nelems, pe_root);
 
-    get_internal_ctx(ctx)->broadcastmem_wg(team, dest, source, nelem, pe_root);
+    get_internal_ctx(ctx)->broadcastmem_wg(team, dest, source, nelems, pe_root);
 }
 
 template <typename T>
 __device__ int rocshmem_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest,
-                                       const T *source, int nelem, int pe_root) {
-  LOGD_API("device::broadcast_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d, root=%d)",
-    ctx.ctx_opaque, team, dest, source, nelem, pe_root);
+                                       const T *source, int nelems, int pe_root) {
+  LOGD_API("device::broadcast_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelems=%d, root=%d)",
+    ctx.ctx_opaque, team, dest, source, nelems, pe_root);
 
-  return get_internal_ctx(ctx)->broadcast_wave<T>(team, dest, source, nelem, pe_root);
+  return get_internal_ctx(ctx)->broadcast_wave<T>(team, dest, source, nelems, pe_root);
 }
 
 __device__ int rocshmem_ctx_broadcastmem_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-  void *dest, const void *source, int nelem, int pe_root) {
-    LOGD_API("device::broadcastmem_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d, root=%d)",
-      ctx.ctx_opaque, team, dest, source, nelem, pe_root);
+  void *dest, const void *source, int nelems, int pe_root) {
+    LOGD_API("device::broadcastmem_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelems=%d, root=%d)",
+      ctx.ctx_opaque, team, dest, source, nelems, pe_root);
 
-    return get_internal_ctx(ctx)->broadcastmem_wave(team, dest, source, nelem, pe_root);
+    return get_internal_ctx(ctx)->broadcastmem_wave(team, dest, source, nelems, pe_root);
 }
 
 template <typename T>
 __device__ void rocshmem_ctx_alltoall_wg(rocshmem_ctx_t ctx,
                                          rocshmem_team_t team, T *dest,
-                                         const T *source, int nelem) {
-  LOGD_API("device::ctx_alltoall_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d)",
-              ctx.ctx_opaque, team, dest, source, nelem);
+                                         const T *source, int nelems) {
+  LOGD_API("device::ctx_alltoall_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelems=%d)",
+              ctx.ctx_opaque, team, dest, source, nelems);
 
-  get_internal_ctx(ctx)->alltoall_wg<T>(team, dest, source, nelem);
+  get_internal_ctx(ctx)->alltoall_wg<T>(team, dest, source, nelems);
 }
 
 template <typename T>
 __device__ void rocshmem_alltoall_wg(rocshmem_team_t team, T *dest,
-                                     const T *source, int nelem) {
-  LOGD_API("device::alltoall_wg (team=%zd, dest=%p, source=%p, nelem=%d)",
-              team, dest, source, nelem);
+                                     const T *source, int nelems) {
+  LOGD_API("device::alltoall_wg (team=%zd, dest=%p, source=%p, nelems=%d)",
+              team, dest, source, nelems);
 
-  get_internal_ctx(ROCSHMEM_CTX_DEFAULT)->alltoall_wg<T>(team, dest, source, nelem);
+  get_internal_ctx(ROCSHMEM_CTX_DEFAULT)->alltoall_wg<T>(team, dest, source, nelems);
 }
 
 __device__ void rocshmem_ctx_alltoallmem_wg(rocshmem_ctx_t ctx,
           rocshmem_team_t team, void *dest, const void *source, int nelems){
-  LOGD_API("device::ctx_alltoallmem_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d)",
-              ctx.ctx_opaque, team, dest, source, nelem);
+  LOGD_API("device::ctx_alltoallmem_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelems=%d)",
+              ctx.ctx_opaque, team, dest, source, nelems);
 
   get_internal_ctx(ctx)->alltoallmem_wg(team, dest, source, nelems);
 }
@@ -742,17 +742,17 @@ template <typename T>
 __device__ int rocshmem_ctx_alltoall_wave(rocshmem_ctx_t ctx,
                                            rocshmem_team_t team,
                                            T *dest, const T *source,
-                                           int nelem) {
-  LOGD_API("device::ctx_alltoall_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d)",
-              ctx.ctx_opaque, team, dest, source, nelem);
+                                           int nelems) {
+  LOGD_API("device::ctx_alltoall_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelems=%d)",
+              ctx.ctx_opaque, team, dest, source, nelems);
 
-  return get_internal_ctx(ctx)->alltoall_wave<T>(team, dest, source, nelem);
+  return get_internal_ctx(ctx)->alltoall_wave<T>(team, dest, source, nelems);
 }
 
 __device__ int rocshmem_ctx_alltoallmem_wave(rocshmem_ctx_t ctx,
           rocshmem_team_t team, void *dest, const void *source, int nelems){
-  LOGD_API("device::ctx_alltoallmem_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d)",
-              ctx.ctx_opaque, team, dest, source, nelem);
+  LOGD_API("device::ctx_alltoallmem_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelems=%d)",
+              ctx.ctx_opaque, team, dest, source, nelems);
 
   return get_internal_ctx(ctx)->alltoallmem_wave(team, dest, source, nelems);
 }
@@ -760,36 +760,36 @@ __device__ int rocshmem_ctx_alltoallmem_wave(rocshmem_ctx_t ctx,
 template <typename T>
 __device__ void rocshmem_fcollect_wg(rocshmem_ctx_t ctx,
                                       rocshmem_team_t team, T *dest,
-                                      const T *source, int nelem) {
-  LOGD_API("device::fcollect_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d",
-    ctx.ctx_opaque, team, dest, source, nelem);
+                                      const T *source, int nelems) {
+  LOGD_API("device::fcollect_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelems=%d",
+    ctx.ctx_opaque, team, dest, source, nelems);
 
-  get_internal_ctx(ctx)->fcollect_wg<T>(team, dest, source, nelem);
+  get_internal_ctx(ctx)->fcollect_wg<T>(team, dest, source, nelems);
 }
 
 __device__ void rocshmem_ctx_fcollectmem_wg(rocshmem_ctx_t ctx,
-    rocshmem_team_t team, void *dest, const void *source, int nelem) {
-  LOGD_API("device::fcollectmem_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d",
-    ctx.ctx_opaque, team, dest, source, nelem);
+    rocshmem_team_t team, void *dest, const void *source, int nelems) {
+  LOGD_API("device::fcollectmem_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelems=%d",
+    ctx.ctx_opaque, team, dest, source, nelems);
 
-  get_internal_ctx(ctx)->fcollectmem_wg(team, dest, source, nelem);
+  get_internal_ctx(ctx)->fcollectmem_wg(team, dest, source, nelems);
 }
 
 template <typename T>
 __device__ int rocshmem_fcollect_wave(rocshmem_ctx_t ctx,
-    rocshmem_team_t team, T *dest, const T *source, int nelem) {
-  LOGD_API("device::fcollect_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d",
-    ctx.ctx_opaque, team, dest, source, nelem);
+    rocshmem_team_t team, T *dest, const T *source, int nelems) {
+  LOGD_API("device::fcollect_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelems=%d",
+    ctx.ctx_opaque, team, dest, source, nelems);
 
-  return get_internal_ctx(ctx)->fcollect_wave<T>(team, dest, source, nelem);
+  return get_internal_ctx(ctx)->fcollect_wave<T>(team, dest, source, nelems);
 }
 
 __device__ int rocshmem_ctx_fcollectmem_wave(rocshmem_ctx_t ctx,
-    rocshmem_team_t team, void *dest, const void *source, int nelem) {
-  LOGD_API("device::fcollectmem_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d",
-    ctx.ctx_opaque, team, dest, source, nelem);
+    rocshmem_team_t team, void *dest, const void *source, int nelems) {
+  LOGD_API("device::fcollectmem_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelems=%d",
+    ctx.ctx_opaque, team, dest, source, nelems);
 
-  return get_internal_ctx(ctx)->fcollectmem_wave(team, dest, source, nelem);
+  return get_internal_ctx(ctx)->fcollectmem_wave(team, dest, source, nelems);
 }
 
 template <typename T>
@@ -1502,18 +1502,18 @@ __device__ int rocshmem_team_translate_pe(rocshmem_team_t src_team,
   template __device__ T rocshmem_g<T>(const T *source, int pe);                \
   template __device__ void rocshmem_broadcast_wg<T>(                           \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,     \
-      int nelem, int pe_root);                                                 \
-  template __device__ int rocshmem_broadcast_wave<T>(                         \
+      int nelems, int pe_root);                                                \
+  template __device__ int rocshmem_broadcast_wave<T>(                          \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,     \
-      int nelem, int pe_root);                                                 \
+      int nelems, int pe_root);                                                \
   template __device__ void rocshmem_ctx_alltoall_wg<T>(                        \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,     \
-      int nelem);                                                              \
+      int nelems);                                                             \
   template __device__ void rocshmem_alltoall_wg<T>(                            \
       rocshmem_team_t team, T * dest, const T *source,                         \
-      int nelem);                                                              \
+      int nelems);                                                             \
   template __device__ int rocshmem_ctx_alltoall_wave<T>(rocshmem_ctx_t ctx,    \
-      rocshmem_team_t team, T *dest, const T *source, int nelem);              \
+      rocshmem_team_t team, T *dest, const T *source, int nelems);             \
   template __device__ void rocshmem_alltoallv_wg<T>(                           \
                                       rocshmem_team_t team,                    \
                                       T *dest, const size_t dest_nelems[],     \
@@ -1522,10 +1522,10 @@ __device__ int rocshmem_team_translate_pe(rocshmem_team_t src_team,
                                       const size_t source_displs[]);           \
   template __device__ void rocshmem_fcollect_wg<T>(                            \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,     \
-      int nelem);                                                              \
+      int nelems);                                                             \
   template __device__ int rocshmem_fcollect_wave<T>(                           \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,     \
-      int nelem);                                                              \
+      int nelems);                                                             \
   template __device__ void rocshmem_put_wave<T>(                               \
       rocshmem_ctx_t ctx, T * dest, const T *source, size_t nelems, int pe);   \
   template __device__ void rocshmem_put_wg<T>(                                 \
@@ -1850,28 +1850,28 @@ __device__ int rocshmem_team_translate_pe(rocshmem_team_t src_team,
   }                                                                           \
   __device__ void rocshmem_ctx_##TNAME##_broadcast_wg(                        \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest, const T *source,     \
-      int nelem, int pe_root) {                                               \
-    rocshmem_broadcast_wg<T>(ctx, team, dest, source, nelem, pe_root);        \
+      int nelems, int pe_root) {                                              \
+    rocshmem_broadcast_wg<T>(ctx, team, dest, source, nelems, pe_root);       \
   }                                                                           \
   __device__ int rocshmem_ctx_##TNAME##_broadcast_wave(                       \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest, const T *source,     \
-      int nelem, int pe_root) {                                               \
+      int nelems, int pe_root) {                                              \
     return rocshmem_broadcast_wave<T>(ctx, team, dest,                        \
-                                       source, nelem, pe_root);               \
+                                       source, nelems, pe_root);              \
   }                                                                           \
   __device__ void rocshmem_ctx_##TNAME##_alltoall_wg(                         \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest, const T *source,     \
-      int nelem) {                                                            \
-    rocshmem_ctx_alltoall_wg<T>(ctx, team, dest, source, nelem);              \
+      int nelems) {                                                           \
+    rocshmem_ctx_alltoall_wg<T>(ctx, team, dest, source, nelems);             \
   }                                                                           \
   __device__ void rocshmem_##TNAME##_alltoall_wg(                             \
       rocshmem_team_t team, T *dest, const T *source,                         \
-      int nelem) {                                                            \
-    rocshmem_alltoall_wg<T>(team, dest, source, nelem);                       \
+      int nelems) {                                                           \
+    rocshmem_alltoall_wg<T>(team, dest, source, nelems);                      \
   }                                                                           \
   __device__ int rocshmem_ctx_##TNAME##_alltoall_wave(rocshmem_ctx_t ctx,     \
-      rocshmem_team_t team, T *dest, const T *source, int nelem) {            \
-    return rocshmem_ctx_alltoall_wave<T>(ctx, team, dest, source, nelem);     \
+      rocshmem_team_t team, T *dest, const T *source, int nelems) {           \
+    return rocshmem_ctx_alltoall_wave<T>(ctx, team, dest, source, nelems);    \
   }                                                                           \
   __device__ void rocshmem_##TNAME##_alltoallv_wg(                            \
                                       rocshmem_team_t team,                   \
@@ -1885,13 +1885,13 @@ __device__ int rocshmem_team_translate_pe(rocshmem_team_t src_team,
   }                                                                           \
   __device__ void rocshmem_ctx_##TNAME##_fcollect_wg(                         \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest, const T *source,     \
-      int nelem) {                                                            \
-    rocshmem_fcollect_wg<T>(ctx, team, dest, source, nelem);                  \
+      int nelems) {                                                           \
+    rocshmem_fcollect_wg<T>(ctx, team, dest, source, nelems);                 \
   }                                                                           \
    __device__ int rocshmem_ctx_##TNAME##_fcollect_wave(                       \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest, const T *source,     \
-      int nelem) {                                                            \
-    return rocshmem_fcollect_wave<T>(ctx, team, dest, source, nelem);         \
+      int nelems) {                                                           \
+    return rocshmem_fcollect_wave<T>(ctx, team, dest, source, nelems);        \
   }
 
 #define AMO_STANDARD_DEF_GEN(T, TNAME)                                        \

--- a/projects/rocshmem/src/templates.hpp
+++ b/projects/rocshmem/src/templates.hpp
@@ -420,7 +420,7 @@ __device__ int rocshmem_test(T *ivars, int cmp, T val);
  *                         symmetric heap.
  * @param[in] source       Source address. Must be an address on the symmetric
                            heap.
- * @param[in] nelement     Size of the buffer to participate in the broadcast.
+ * @param[in] nelems       Size of the buffer to participate in the broadcast.
  * @param[in] PE_root      Zero-based ordinal of the PE, with respect to the
                            active set, from which the data is copied
  * @param[in] PE_start     PE to start the reduction.
@@ -434,7 +434,7 @@ __device__ int rocshmem_test(T *ivars, int cmp, T val);
  */
 template <typename T>
 __device__ void rocshmem_wg_broadcast(rocshmem_ctx_t ctx, T *dest,
-                                       const T *source, int nelement,
+                                       const T *source, int nelems,
                                        int PE_root, int PE_start,
                                        int logPE_stride, int PE_size,
                                        long *pSync);

--- a/projects/rocshmem/src/templates_host.hpp
+++ b/projects/rocshmem/src/templates_host.hpp
@@ -129,7 +129,7 @@ __host__ void rocshmem_atomic_set(rocshmem_ctx_t ctx, T *dest, T val, int pe);
 
 template <typename T>
 __host__ void rocshmem_broadcast(rocshmem_ctx_t ctx, T *dest, const T *source,
-                                  int nelement, int PE_root, int PE_start,
+                                  int nelems, int PE_root, int PE_start,
                                   int logPE_stride, int PE_size, long *pSync);
 
 template <typename T, ROCSHMEM_OP Op>

--- a/projects/rocshmem/tests/functional_tests/alltoall_wave_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/alltoall_wave_tester.cpp
@@ -25,7 +25,7 @@
 /* Declare the template with a generic implementation */
 template <typename T>
 __device__ void alltoall_wave([[maybe_unused]] rocshmem_ctx_t ctx, [[maybe_unused]] rocshmem_team_t team,
-                              [[maybe_unused]] T *dest, [[maybe_unused]] const T *source, [[maybe_unused]] int nelem) {
+                              [[maybe_unused]] T *dest, [[maybe_unused]] const T *source, [[maybe_unused]] int nelems) {
   return;
 }
 
@@ -33,8 +33,8 @@ __device__ void alltoall_wave([[maybe_unused]] rocshmem_ctx_t ctx, [[maybe_unuse
 #define ALLTOALLWAVEGEN(T, TNAME)                                              \
   template <>                                                                  \
   __device__ void alltoall_wave<T>(rocshmem_ctx_t ctx, rocshmem_team_t team,   \
-                                 T * dest, const T *source, int nelem) {       \
-    rocshmem_ctx_##TNAME##_alltoall_wave(ctx, team, dest, source, nelem);}
+                                 T * dest, const T *source, int nelems) {      \
+    rocshmem_ctx_##TNAME##_alltoall_wave(ctx, team, dest, source, nelems);}
 
 ALLTOALLWAVEGEN(float, float)
 ALLTOALLWAVEGEN(double, double)

--- a/projects/rocshmem/tests/functional_tests/broadcast_wave_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/broadcast_wave_tester.cpp
@@ -24,7 +24,7 @@
 
 template <typename T>
 __device__ void wave_broadcast([[maybe_unused]] rocshmem_ctx_t ctx, [[maybe_unused]] rocshmem_team_t team,
-                                  [[maybe_unused]] T *dest, [[maybe_unused]] const T *source, [[maybe_unused]] int nelem,
+                                  [[maybe_unused]] T *dest, [[maybe_unused]] const T *source, [[maybe_unused]] int nelems,
                                   [[maybe_unused]] int pe_root) {
   return;
 }
@@ -32,10 +32,10 @@ __device__ void wave_broadcast([[maybe_unused]] rocshmem_ctx_t ctx, [[maybe_unus
 /* Define templates to call ROCSHMEM */
 #define BROADCAST_WAVE_DEF_GEN(T, TNAME)                                      \
   template <>                                                                 \
-  __device__ void wave_broadcast<T>(                                       \
+  __device__ void wave_broadcast<T>(                                          \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,    \
-      int nelem, int pe_root) {                                               \
-    rocshmem_ctx_##TNAME##_broadcast_wave(ctx, team, dest, source, nelem,     \
+      int nelems, int pe_root) {                                              \
+    rocshmem_ctx_##TNAME##_broadcast_wave(ctx, team, dest, source, nelems,    \
                                          pe_root);                            \
   }
 

--- a/projects/rocshmem/tests/functional_tests/fcollect_wave_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/fcollect_wave_tester.cpp
@@ -33,8 +33,8 @@ __device__ int wave_fcollect([[maybe_unused]] rocshmem_ctx_t ctx, [[maybe_unused
 #define FCOLLECT_WAVE_DEF_GEN(T, TNAME)                                          \
   template <>                                                                    \
   __device__ int wave_fcollect<T>(rocshmem_ctx_t ctx, rocshmem_team_t team,      \
-                                  T *dest, const T *source, int nelem) {         \
-    return rocshmem_ctx_##TNAME##_fcollect_wave(ctx, team, dest, source, nelem); \
+                                  T *dest, const T *source, int nelems) {        \
+    return rocshmem_ctx_##TNAME##_fcollect_wave(ctx, team, dest, source, nelems);\
   }
 
 FCOLLECT_WAVE_DEF_GEN(float, float)

--- a/projects/rocshmem/tests/functional_tests/team_alltoall_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_alltoall_tester.cpp
@@ -25,7 +25,7 @@
 /* Declare the template with a generic implementation */
 template <typename T>
 __device__ void wg_team_alltoall([[maybe_unused]] rocshmem_ctx_t ctx, [[maybe_unused]] rocshmem_team_t team,
-                                 [[maybe_unused]] T *dest, [[maybe_unused]] const T *source, [[maybe_unused]] int nelem) {
+                                 [[maybe_unused]] T *dest, [[maybe_unused]] const T *source, [[maybe_unused]] int nelems) {
   return;
 }
 
@@ -33,8 +33,8 @@ __device__ void wg_team_alltoall([[maybe_unused]] rocshmem_ctx_t ctx, [[maybe_un
 #define TEAM_ALLTOALL_DEF_GEN(T, TNAME)                                        \
   template <>                                                                  \
   __device__ void wg_team_alltoall<T>(rocshmem_ctx_t ctx, rocshmem_team_t team,\
-                                 T * dest, const T *source, int nelem) {       \
-    rocshmem_ctx_##TNAME##_alltoall_wg(ctx, team, dest, source, nelem);        \
+                                 T * dest, const T *source, int nelems) {      \
+    rocshmem_ctx_##TNAME##_alltoall_wg(ctx, team, dest, source, nelems);       \
   }
 
 TEAM_ALLTOALL_DEF_GEN(float, float)

--- a/projects/rocshmem/tests/functional_tests/team_alltoall_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_alltoall_tester.cpp
@@ -80,7 +80,7 @@ __global__ void TeamAlltoallTest(int loop, int skip, long long int *start_time,
     wg_team_alltoall<T1>(ctx, teams[wg_id],
                     dest_buf,               // T* dest
                     source_buf,             // const T* source
-                    num_elems);             // int nelement
+                    num_elems);             // int nelems
   }
 
   __syncthreads();

--- a/projects/rocshmem/tests/functional_tests/team_broadcast_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_broadcast_tester.cpp
@@ -25,7 +25,7 @@
 /* Declare the template with a generic implementation */
 template <typename T>
 __device__ void wg_team_broadcast([[maybe_unused]] rocshmem_ctx_t ctx, [[maybe_unused]] rocshmem_team_t team,
-                                  [[maybe_unused]] T *dest, [[maybe_unused]] const T *source, [[maybe_unused]] int nelem,
+                                  [[maybe_unused]] T *dest, [[maybe_unused]] const T *source, [[maybe_unused]] int nelems,
                                   [[maybe_unused]] int pe_root) {
   return;
 }
@@ -35,8 +35,8 @@ __device__ void wg_team_broadcast([[maybe_unused]] rocshmem_ctx_t ctx, [[maybe_u
   template <>                                                                 \
   __device__ void wg_team_broadcast<T>(                                       \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,    \
-      int nelem, int pe_root) {                                               \
-    rocshmem_ctx_##TNAME##_broadcast_wg(ctx, team, dest, source, nelem,       \
+      int nelems, int pe_root) {                                              \
+    rocshmem_ctx_##TNAME##_broadcast_wg(ctx, team, dest, source, nelems,      \
                                          pe_root);                            \
   }
 

--- a/projects/rocshmem/tests/functional_tests/team_broadcast_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_broadcast_tester.cpp
@@ -85,7 +85,7 @@ __global__ void TeamBroadcastTest(int loop, int skip, long long int *start_time,
     wg_team_broadcast<T1>(ctx, teams[wg_id],
                           dest_buf,         // T* dest
                           source_buf,       // const T* source
-                          size,             // int nelement
+                          size,             // int nelems
                           0);               // int PE_root
   }
 

--- a/projects/rocshmem/tests/functional_tests/team_fcollect_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_fcollect_tester.cpp
@@ -33,8 +33,8 @@ __device__ void wg_team_fcollect([[maybe_unused]] rocshmem_ctx_t ctx, [[maybe_un
 #define TEAM_FCOLLECT_DEF_GEN(T, TNAME)                                        \
   template <>                                                                  \
   __device__ void wg_team_fcollect<T>(rocshmem_ctx_t ctx, rocshmem_team_t team,\
-                                      T * dest, const T *source, int nelem) {  \
-    rocshmem_ctx_##TNAME##_fcollect_wg(ctx, team, dest, source, nelem);        \
+                                      T * dest, const T *source, int nelems) { \
+    rocshmem_ctx_##TNAME##_fcollect_wg(ctx, team, dest, source, nelems);       \
   }
 
 TEAM_FCOLLECT_DEF_GEN(float, float)

--- a/projects/rocshmem/tests/functional_tests/team_fcollect_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_fcollect_tester.cpp
@@ -79,7 +79,7 @@ __global__ void TeamFcollectTest(int loop, int skip, long long int *start_time,
     wg_team_fcollect<T1>(ctx, teams[wg_id],
                          dest_buf,          // T* dest
                          source_buf,        // const T* source
-                         num_elems);        // int nelement
+                         num_elems);        // int nelems
   }
 
   __syncthreads();


### PR DESCRIPTION
## Motivation

* Code does not compile with BUILD_DEBUG_TRACE_DEVICE
* shmem convention is to use `nelems` for the buffer size, even for xxxmem procedures. We had an inconsistent mix and match.

## Technical Details

All code uses the same conventional `nelems`, not variants `nelements`, `nelem`, `size`, reducing inconsistency and chances to use the wrong spelling. 

## JIRA ID 

JIRA ID AIROCSHMEM-450

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
compiles with debug logs enabled. 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
