### PR TITLE
hip-tests: skip peer-device graph test when hipErrorNotSupported

### DIFF
--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNode1D_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNode1D_old.cc
@@ -73,7 +73,16 @@ static void validateMemcpyNode1DArray(bool peerAccess,
                                     numBytes, hipMemcpyDeviceToHost));
 
   // Instantiate and launch the graph
-  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+  hipError_t graphInstStatus = hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0);
+  if (peerAccess && graphInstStatus == hipErrorNotSupported) {
+    HIP_CHECK(hipSetDevice(0));
+    hipGraphDestroy(graph);
+    hipStreamDestroy(streamForGraph);
+    hipFree(devArray1);
+    hipFree(devArray2);
+    SKIP("Multi-device graph instantiation not supported (hipErrorNotSupported)");
+  }
+  HIP_CHECK(graphInstStatus);
   HIP_CHECK(hipGraphLaunch(graphExec, streamForGraph));
   HIP_CHECK(hipStreamSynchronize(streamForGraph));
 


### PR DESCRIPTION
## Motivation                                                                                                                                                                            
                                                                                                                                                                                           
  On systems where `hipDeviceCanAccessPeer` returns true (e.g., gfx1250 with AIFM                                                                                                          
  fabric), `Unit_hipGraphAddMemcpyNode1D_Functional`'s peer device section proceeds                                                                                                        
  to call `hipGraphInstantiate`, which fails with `hipErrorNotSupported` (error 801)                                                                                                       
  because multi-device graphs are not yet supported on either the classic or segmented                                                                                                     
  graph scheduling paths in CLR. The test hard-fails rather than skipping, producing                                                                                                       
  a misleading failure on otherwise healthy systems.                                                                                                                                       
                                                                                                                                                                                           
  ## Technical Details                                                                                                                                                                     
                                                                                                                                                                                           
  In `validateMemcpyNode1DArray`, replace the unconditional                                                                                                                                
  `HIP_CHECK(hipGraphInstantiate(...))` in the peer device path with an explicit                                                                                                           
  return-code check. When `hipGraphInstantiate` returns `hipErrorNotSupported`, clean                                                                                                      
  up allocated resources and call `SKIP()` (Catch2 v3.3+) instead of failing. All                                                                                                          
  other error codes continue through `HIP_CHECK` as before.                                                                                                                                
                                                                                                                                                                                           
  The root cause is a known CLR limitation documented in both                                                                                                                              
  `GraphExecClassic::Init()` and `GraphExecSegmented::FindStreamsReqPerDevForSegments()`:                                                                                                  
    [hipGraph] Multi-device graph is not supported on the segment scheduling path                                                                                                          
                                                                                                                                                                                           
  The fix is test-side only. `validateMemcpyNode1DArray` is `static` and called from                                                                                                       
  exactly three SECTION blocks within a single test case; the new code path triggers                                                                                                       
  only on `hipErrorNotSupported`, leaving the single-device sections unaffected.                                                                                                           
                                                                                                                                                                                           
  ## JIRA ID                                                                                                                                                                               
                                                                                                                                                                                           
ROCM-28108                                                                                                                                                                                  
                                                                                                                                                                                           
  ## Test Plan                                                                                                                                                                             
                                                                                                                                                                                           
  Rebuilt `GraphsTest1` from the patched source on a gfx1250 system with AIFM fabric                                                                                                       
  active (4 GPUs, all ACCEL_STATE: READY), with PRs #8254 and #8534 applied to                                                                                                             
  CLR/ROCr. Ran with AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1 HSA_ENABLE_SDMA=1,                                                                                                              
  all 4 GPUs visible.                                                                                                                                                                      
                                                                                                                                                                                           
  ## Test Result                                                                          
                                                                                          
  Test                                                                                    | Before       | After                                                                                                     
  --------------------------------------------------------------|--------------|----------                                                                                                 
  Unit_hipGraphAddMemcpyNode1D_Functional (default device)      | Passed       | Passed                                                                                                    
  Unit_hipGraphAddMemcpyNode1D_Functional (peer device)         | Failed (801) | Skipped  

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
