### PR TITLE
fix(rocjitsu): Harden the rocjitsu KFD, CP, and multi-process runtime

### DIFF
--- a/emulation/rocjitsu/configs/gfx950_cdna4_kmd.json
+++ b/emulation/rocjitsu/configs/gfx950_cdna4_kmd.json
@@ -1,5 +1,5 @@
 {
-  "max_ticks": 100000,
+  "max_ticks": 0,
   "num_threads": 1,
   "exec_mode": "functional",
   "vm": {

--- a/emulation/rocjitsu/configs/gfx950_cdna4_kmd_2gpu.json
+++ b/emulation/rocjitsu/configs/gfx950_cdna4_kmd_2gpu.json
@@ -1,5 +1,5 @@
 {
-  "max_ticks": 100000,
+  "max_ticks": 0,
   "num_threads": 1,
   "exec_mode": "functional",
   "vm": {

--- a/emulation/rocjitsu/docs/simdojo.md
+++ b/emulation/rocjitsu/docs/simdojo.md
@@ -68,10 +68,9 @@ registered directly on ports via `Port::set_handler()`. Key virtual
 methods:
 
 - `initialize()` / `startup()` / `shutdown()` - lifecycle hooks called by
-  the engine
-- `step()` - execute one logical step; return true to continue
-- `run()` - default loops `while (step()) {}`; override for custom
-  lifecycle (e.g., blocking on a condition variable)
+  the engine during `create()`, `run()`, and `shutdown()` respectively
+- `step()` - execute one unit of component-specific work (domain-level
+  API for concrete types, not called by the engine)
 - `is_composite()` - returns false for leaves, true for composites
 
 **CompositeComponent** extends Component with a child list. Critically, a
@@ -80,13 +79,9 @@ container. This lets you model a block that both contains sub-blocks
 and directly handles some events (e.g., routing, arbitration) without
 introducing artificial wrapper components.
 
-`CompositeComponent` overrides `run()` and `step()` with default
-delegation behavior: `run()` calls `run()` on each child, and `step()`
-calls `step()` on each child, returning true if any child is still active.
-Subclasses (e.g., SoC) override these for custom lifecycle
-logic. This means a `CompositeComponent` can serve as the topology root
-directly - the engine calls `root->run()` and the composite delegates to
-its children automatically.
+`CompositeComponent` can serve as the topology root directly. All
+execution is event-driven — components schedule events during `startup()`
+and respond to them via event handlers.
 
 `collect_components()` flattens the entire subtree including composites,
 so the engine initializes and dispatches to all components uniformly.
@@ -290,7 +285,7 @@ engine.topology().set_root(std::move(root));
 engine.topology().add_link(pipe_req_port, mem_req_port, /*latency=*/10);
 engine.topology().add_link(mem_resp_port, pipe_resp_port, /*latency=*/5);
 
-engine.build();
+engine.create();
 auto exit = engine.run();
 ```
 
@@ -315,7 +310,7 @@ library dependencies.
 
 The `SimulationEngine` owns the simulation `Topology` and drives the full
 lifecycle: build, run/step, and shutdown. Components participate by
-scheduling events during `initialize()` or `startup()`:
+scheduling events during `startup()`:
 
 - A `Clocked` component schedules clock-edge events (timing simulation).
 - A `Functional` component self-schedules a timer callback and re-enqueues
@@ -506,11 +501,11 @@ injected events realistic timestamps instead of tick 0.
 ### Interactive Stepping (`step()`)
 
 For GUI, debugger, or test harness use. Single-threaded only. On the first
-call, starts all components (initialization happens in `build()`). Each
-subsequent call drains async events and processes all events at the next
-timestamp (one tick step). Returns true if the simulation can continue.
-If the queue is empty but primaries are registered, returns true so the
-caller can poll.
+call, starts all components (initialization happens in `create()`). Each
+subsequent call drains async events and advances to the next event time,
+processing all events at that timestamp. Ticks without scheduled events
+are skipped. Returns true if the simulation can continue. If the queue is
+empty but primaries are registered, returns true so the caller can poll.
 
 ---
 
@@ -520,13 +515,13 @@ caller can poll.
 SimulationEngine engine({.max_ticks = 10000, .num_threads = 4});
 engine.topology().set_root(std::move(my_model));
 engine.topology().add_link(src_port, dst_port, latency);
-engine.build();       // partitions, initializes components
+engine.create();       // partitions, initializes components
 // (user enqueues work via CP)
 auto exit = engine.run();   // starts up components, runs to completion
 engine.shutdown();    // called automatically by destructor if needed
 ```
 
-`build()` partitions the topology and calls `initialize()` on all
+`create()` partitions the topology and calls `initialize()` on all
 components. `run()` calls `startup()` on all components and enters the
 event loop. `shutdown()` is called automatically by the destructor if the
 engine is still built.

--- a/emulation/rocjitsu/docs/vm-design.md
+++ b/emulation/rocjitsu/docs/vm-design.md
@@ -73,26 +73,33 @@ compute units in round-robin order.
 The CP is event-driven. During `startup()`, it schedules a doorbell event
 for any pre-loaded packets. Each doorbell event triggers `step()`, which
 processes one dispatch packet: for each workgroup, it calls `dispatch_wf()`
-on the next CU in round-robin order, then calls `activate()` on that CU.
+on the next CU in round-robin order. `dispatch_wf()` self-schedules the CU's
+tick via `schedule_work()`; there is no separate `activate()` call.
 
 - `enqueue(packet)` - pre-loads packets without triggering dispatch (used
   by config loader and tests)
 - `submit(packet)` - thread-safe; appends packet and schedules an async
   doorbell event via `schedule_event_now()`
-- `activate()` - registers the CP as a primary component and begins
-  processing doorbell events
 
 Each CU runs its dispatched wavefronts independently. The CU is
-self-driving: `dispatch_wf()` schedules a tick event that calls
-`execute_quantum()`, which executes up to `functional_quantum`
-instructions before yielding back to the event loop. The tick event
-reschedules itself at `now + quantum` if work remains. Since functional
-mode is 1 CPI, ticks advance proportionally to instruction count. The
-quantum allows CU events to interleave, guaranteeing forward progress
-for inter-CU synchronization patterns such as spin-locks or semaphore
-acquire/release on global memory. When a CU becomes idle, it stops
-scheduling and fires its `on_idle` callback. When all CUs are idle
-and no packets remain, the CP signals completion via
+self-driving: `dispatch_wf()` calls `schedule_work()`, which schedules a
+tick event (only when the CU has runnable wavefronts) that calls
+`execute_quantum()`. A quantum executes up to `kFunctionalQuantum`
+instructions, but may yield early when a wavefront requests it (e.g.
+`s_sleep`, a vendor-dependency retry). The tick reschedules itself at
+`now + max(1, last_quantum_executed_)` — i.e. by the work actually
+executed, so an early yield resumes promptly instead of leaping a full
+quantum, while `max(1, ...)` keeps the event strictly in the future.
+Since functional mode is 1 CPI, ticks advance proportionally to
+instruction count. The quantum allows CU events to interleave,
+guaranteeing forward progress for inter-CU synchronization patterns such
+as spin-locks or semaphore acquire/release on global memory.
+
+A wavefront that reaches `s_endpgm` halts: it frees its SGPR/VGPR
+resources immediately and notifies the CP of workgroup completion (there
+is no separate lazy retirement pass). When a CU has no resident
+wavefronts it stops scheduling and fires its `on_idle` callback. When all
+CUs are idle and no packets remain, the CP signals completion via
 `engine()->primary_release()`.
 
 ---
@@ -108,7 +115,7 @@ Config loader / Driver::submit()
                 cu->dispatch_wf(wg_id, pc, sgprs, vgprs)
                   └── find idle slot, allocate SGPR/VGPR blocks
                       initialize wavefront state (pc, wg_id)
-                      schedule tick event if CU was idle (self-driving)
+                      schedule_work() -> tick event (self-driving)
 ```
 
 A `DispatchPacket` specifies:

--- a/emulation/rocjitsu/docs/vm-design.md
+++ b/emulation/rocjitsu/docs/vm-design.md
@@ -82,13 +82,16 @@ on the next CU in round-robin order, then calls `activate()` on that CU.
 - `activate()` - registers the CP as a primary component and begins
   processing doorbell events
 
-Each CU runs its dispatched wavefronts independently. In functional mode,
-a work event calls `advance()`, which executes up to `functional_quantum`
-instructions (or all remaining if quantum is 0) before yielding back to
-the event loop. A non-zero quantum allows CU events to interleave,
-guaranteeing forward progress for inter-CU synchronization patterns such
-as spin-locks or semaphore acquire/release on global memory. When a CU
-becomes idle, it fires its `on_idle` callback. When all CUs are idle
+Each CU runs its dispatched wavefronts independently. The CU is
+self-driving: `dispatch_wf()` schedules a tick event that calls
+`execute_quantum()`, which executes up to `functional_quantum`
+instructions before yielding back to the event loop. The tick event
+reschedules itself at `now + quantum` if work remains. Since functional
+mode is 1 CPI, ticks advance proportionally to instruction count. The
+quantum allows CU events to interleave, guaranteeing forward progress
+for inter-CU synchronization patterns such as spin-locks or semaphore
+acquire/release on global memory. When a CU becomes idle, it stops
+scheduling and fires its `on_idle` callback. When all CUs are idle
 and no packets remain, the CP signals completion via
 `engine()->primary_release()`.
 
@@ -105,8 +108,7 @@ Config loader / Driver::submit()
                 cu->dispatch_wf(wg_id, pc, sgprs, vgprs)
                   └── find idle slot, allocate SGPR/VGPR blocks
                       initialize wavefront state (pc, wg_id)
-                cu->activate()
-                  └── schedule work event (functional) or resume clock (clocked)
+                      schedule tick event if CU was idle (self-driving)
 ```
 
 A `DispatchPacket` specifies:
@@ -208,7 +210,7 @@ The SoC plugs into simdojo's `SimulationEngine` directly. The C API layer
    config and creates a `SoC` with engine configuration. The C API sets the
    SoC as the topology root via `engine.topology().set_root(std::move(soc))`.
 
-2. **`build()`** - Partitions topology, initializes all components, and
+2. **`create()`** - Partitions topology, initializes all components, and
    sets up the engine.
 
 3. **`run()`** - Starts all components and drains events continuously.

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/vm/rj_vm.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/vm/rj_vm.h
@@ -253,6 +253,12 @@ RJ_API_EXPORT rj_status_t rj_vm_device_open(rj_vm_t *vm, rj_client_pid_t client_
 /// @param[in] process_id The process ID to close (0 closes the local process).
 RJ_API_EXPORT rj_status_t rj_vm_device_close(rj_vm_t *vm, uint32_t process_id);
 
+/// @brief Close every registered KFD process, waking any parked event waiters.
+/// @details Daemon-teardown helper: closes all live processes so client threads
+/// blocked in an infinite-timeout WAIT_EVENTS unblock and can be joined.
+/// @param[in] vm VM handle.
+RJ_API_EXPORT rj_status_t rj_vm_close_all_devices(rj_vm_t *vm);
+
 /// @brief Map device memory (local mode).
 /// @param[in] vm VM handle.
 /// @param[in,out] map Mapping descriptor; mapped_addr is set on success.

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/vm/rj_vm.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/vm/rj_vm.h
@@ -70,6 +70,7 @@ typedef struct rj_vm_map_t {
   uint32_t prot;        ///< Memory protection flags.
   uint32_t flags;       ///< Mapping flags.
   uint64_t mapped_addr; ///< [out] Address the mapping was placed at.
+  int32_t map_errno;    ///< [out] errno captured at the failing mmap (0 on success).
 } rj_vm_map_t;
 
 /// @brief Device memory unmapping descriptor.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.h
@@ -54,7 +54,7 @@ struct TopologyBuildResult {
 ///   SimulationEngine engine(loaded.engine_config);
 ///   engine.topology().set_root(loaded.take_root());
 ///   loaded.wire_links(engine.topology());
-///   engine.build();
+///   engine.create();
 /// @endcode
 struct LoadedConfig {
   simdojo::SimulationEngine::Config engine_config;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
@@ -16,6 +16,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <unistd.h>
 
 namespace rocjitsu {
 namespace config {
@@ -135,9 +136,17 @@ DbtGuestConfig load_dbt_guest_config_from_file(const std::string &path) {
 }
 
 std::optional<DbtGuestConfig> load_dbt_guest_config_from_runtime_config() {
-  std::ifstream file(rocjitsu::rpc_default_config_file_path());
-  if (!file.is_open())
-    return std::nullopt;
+  // The launcher writes the config-path handoff file into its per-PID invocation
+  // directory. The DBT HSA hook runs inside the exec'd app, which inherits the
+  // launcher's PID via execvp, so it locates the file with getpid(). Fall back to
+  // the well-known location for attach / daemon-only scenarios that use it.
+  std::string handoff = rocjitsu::rpc_invocation_config_file_path(getpid());
+  std::ifstream file(handoff);
+  if (!file.is_open()) {
+    file.open(rocjitsu::rpc_default_config_file_path());
+    if (!file.is_open())
+      return std::nullopt;
+  }
 
   std::string path;
   std::getline(file, path);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
@@ -136,11 +136,18 @@ DbtGuestConfig load_dbt_guest_config_from_file(const std::string &path) {
 }
 
 std::optional<DbtGuestConfig> load_dbt_guest_config_from_runtime_config() {
-  // The launcher writes the config-path handoff file into its per-PID invocation
-  // directory. The DBT HSA hook runs inside the exec'd app, which inherits the
-  // launcher's PID via execvp, so it locates the file with getpid(). Fall back to
-  // the well-known location for attach / daemon-only scenarios that use it.
-  std::string handoff = rocjitsu::rpc_invocation_config_file_path(getpid());
+  // The launcher writes the config-path handoff file into its per-invocation
+  // directory and exports that directory via $ROCJITSU_INVOCATION_DIR before
+  // execvp. Prefer that env var: every descendant (including grandchildren
+  // spawned through wrappers like ctest, whose PID differs from the launcher's)
+  // inherits the exact directory holding config_path. Fall back to this process's
+  // PID-scoped path (execvp preserves the launcher's PID for the direct child),
+  // then to the well-known location for attach / daemon-only scenarios.
+  std::string handoff;
+  if (const char *dir = getenv(rocjitsu::kRpcInvocationDirEnv))
+    handoff = std::string(dir) + "/config_path";
+  else
+    handoff = rocjitsu::rpc_invocation_config_file_path(getpid());
   std::ifstream file(handoff);
   if (!file.is_open()) {
     file.open(rocjitsu::rpc_default_config_file_path());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
@@ -17,6 +17,7 @@
 #include <stdexcept>
 #include <string>
 #include <unistd.h>
+#include <vector>
 
 namespace rocjitsu {
 namespace config {
@@ -136,27 +137,30 @@ DbtGuestConfig load_dbt_guest_config_from_file(const std::string &path) {
 }
 
 std::optional<DbtGuestConfig> load_dbt_guest_config_from_runtime_config() {
-  // The launcher writes the config-path handoff file into its per-invocation
-  // directory and exports that directory via $ROCJITSU_INVOCATION_DIR before
-  // execvp. Prefer that env var: every descendant (including grandchildren
-  // spawned through wrappers like ctest, whose PID differs from the launcher's)
-  // inherits the exact directory holding config_path. Fall back to this process's
-  // PID-scoped path (execvp preserves the launcher's PID for the direct child),
-  // then to the well-known location for attach / daemon-only scenarios.
-  std::string handoff;
-  // Treat an empty $ROCJITSU_INVOCATION_DIR as unset (dir && *dir), matching the
-  // interposer's init() so the two config readers resolve the handoff identically;
-  // an empty value would otherwise build "/config_path".
+  // Try the handoff tiers in priority order, opening the first that exists:
+  //   1. $ROCJITSU_INVOCATION_DIR/config_path — the launcher exports this dir before
+  //      execvp so every descendant (incl. grandchildren via ctest, whose PID differs)
+  //      finds it. Treat an empty value as unset (dir && *dir), matching interposer
+  //      init(); an empty value would otherwise build "/config_path".
+  //   2. this process's PID-scoped path (execvp preserves the launcher's PID for the
+  //      direct child) — also the fallback if the env var is set but stale/misdirected.
+  //   3. the well-known location for attach / daemon-only scenarios.
+  // Falling straight from tier 1 to tier 3 (skipping tier 2) would miss a valid
+  // per-PID handoff when the env var is set but its config_path is absent.
+  std::vector<std::string> candidates;
   if (const char *dir = getenv(rocjitsu::kRpcInvocationDirEnv); dir && *dir)
-    handoff = std::string(dir) + "/config_path";
-  else
-    handoff = rocjitsu::rpc_invocation_config_file_path(getpid());
-  std::ifstream file(handoff);
-  if (!file.is_open()) {
-    file.open(rocjitsu::rpc_default_config_file_path());
-    if (!file.is_open())
-      return std::nullopt;
+    candidates.push_back(std::string(dir) + "/config_path");
+  candidates.push_back(rocjitsu::rpc_invocation_config_file_path(getpid()));
+  candidates.push_back(rocjitsu::rpc_default_config_file_path());
+
+  std::ifstream file;
+  for (const auto &candidate : candidates) {
+    file.open(candidate);
+    if (file.is_open())
+      break;
   }
+  if (!file.is_open())
+    return std::nullopt;
 
   std::string path;
   std::getline(file, path);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
@@ -144,7 +144,10 @@ std::optional<DbtGuestConfig> load_dbt_guest_config_from_runtime_config() {
   // PID-scoped path (execvp preserves the launcher's PID for the direct child),
   // then to the well-known location for attach / daemon-only scenarios.
   std::string handoff;
-  if (const char *dir = getenv(rocjitsu::kRpcInvocationDirEnv))
+  // Treat an empty $ROCJITSU_INVOCATION_DIR as unset (dir && *dir), matching the
+  // interposer's init() so the two config readers resolve the handoff identically;
+  // an empty value would otherwise build "/config_path".
+  if (const char *dir = getenv(rocjitsu::kRpcInvocationDirEnv); dir && *dir)
     handoff = std::string(dir) + "/config_path";
   else
     handoff = rocjitsu::rpc_invocation_config_file_path(getpid());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -90,12 +90,30 @@ using rocjitsu::Sysfs;
 namespace {
 
 /// @brief Attempt to connect @p sock to the AF_UNIX socket at @p path.
-/// @returns 0 on success; -1 with errno set on failure (socket left open).
-int try_connect(int sock, const std::string &path) {
+/// @returns A connected socket fd on success; -1 with errno set on failure.
+/// @details Creates a FRESH socket for each attempt: POSIX leaves a stream
+/// socket's state unspecified after a failed connect(), so a socket must not be
+/// reused for a second connect(). Fails with ENAMETOOLONG rather than silently
+/// truncating a path that does not fit sun_path, so a too-long runtime dir cannot
+/// connect to an unintended (truncated) socket endpoint.
+int try_connect(const std::string &path) {
   sockaddr_un addr{};
   addr.sun_family = AF_UNIX;
-  path.copy(addr.sun_path, sizeof(addr.sun_path) - 1);
-  return connect(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr));
+  if (path.size() >= sizeof(addr.sun_path)) {
+    errno = ENAMETOOLONG;
+    return -1;
+  }
+  std::memcpy(addr.sun_path, path.c_str(), path.size());
+  int sock = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (sock < 0)
+    return -1;
+  if (connect(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) != 0) {
+    int saved = errno;
+    rocjitsu::libc_passthrough().close(sock);
+    errno = saved;
+    return -1;
+  }
+  return sock;
 }
 
 /// @brief Connect to the daemon for this invocation's per-PID runtime directory.
@@ -106,21 +124,21 @@ int try_connect(int sock, const std::string &path) {
 /// app is never silently cross-connected to an unrelated daemon at the shared
 /// well-known socket if its own daemon's socket is transiently unavailable.
 int connect_to_daemon(const std::string &runtime_dir) {
-  int sock = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
-  if (sock < 0)
-    return -1;
-
-  if (try_connect(sock, runtime_dir + "/daemon.sock") == 0)
+  int sock = try_connect(runtime_dir + "/daemon.sock");
+  if (sock >= 0)
     return sock;
 
   // Fall back to the well-known socket only for invocations that never created a
   // per-PID directory (attach / daemon-only). access() goes through the real libc
-  // so it does not re-enter this interposer's own path hooks.
-  if (rocjitsu::libc_passthrough().access(runtime_dir.c_str(), F_OK) != 0 &&
-      try_connect(sock, rocjitsu::rpc_default_socket_path()) == 0)
-    return sock;
-
-  rocjitsu::libc_passthrough().close(sock);
+  // so it does not re-enter this interposer's own path hooks. Gate strictly on the
+  // dir genuinely not existing (ENOENT / a non-directory component, ENOTDIR): any
+  // other error (EACCES/EPERM, transient IO) must NOT trigger the fallback, or a
+  // daemon-mode client whose own dir is momentarily inaccessible could be silently
+  // cross-connected to an unrelated daemon at the shared socket.
+  const bool dir_absent = rocjitsu::libc_passthrough().access(runtime_dir.c_str(), F_OK) != 0 &&
+                          (errno == ENOENT || errno == ENOTDIR);
+  if (dir_absent)
+    return try_connect(rocjitsu::rpc_default_socket_path());
   return -1;
 }
 
@@ -263,11 +281,18 @@ public:
     sysfs_fds_.clear();
     drm_fds_.clear();
     kfd_dup_fds_.clear();
+    // Drop GEM bookkeeping WITHOUT munmapping cpu_ptr or unmapping PTEs: those host
+    // pages and the parent's page table belong to the parent process and the child
+    // must not touch them. The child re-initializes a fresh driver; any GEM mappings
+    // it needs are re-created via EXPORT/PRIME/GEM_VA. (Deliberate, like the remote_
+    // and mutex handling above — not an oversight.)
     gem_entries_.clear();
     in_construction = false;
   }
 
   LinuxKfd *driver() { return active_driver_.load(std::memory_order_acquire); }
+  /// @brief True if the active driver is the local SimulatedKfd (not remote/guest).
+  bool driver_is_simulated() { return dynamic_cast<SimulatedKfd *>(driver()) != nullptr; }
   int driver_fd() {
     auto *d = driver();
     return d ? d->fd() : -1;
@@ -838,59 +863,99 @@ public:
   /// @brief A GEM buffer object synthesized from a prime (dmabuf) fd.
   /// @details The native DRM emulation has no real GEM objects. EXPORT_DMABUF
   /// hands userspace a dmabuf fd whose KFD allocation flags determine the GPU
-  /// PTE MTYPE; PRIME_FD_TO_HANDLE later mints handle = dmabuf_fd + 1. Because
-  /// handle and fd are a fixed bijection, a single map keyed by the dmabuf fd
-  /// carries the flags from export through to GEM_VA, where it also records the
-  /// size and a lazily created host mapping used to install the pages into the
-  /// GPU page table. installed_vas holds the GPU VA ranges mapped from this BO so
-  /// close() can tear down the page-table entries before munmapping cpu_ptr.
+  /// PTE MTYPE; PRIME_FD_TO_HANDLE later mints handle = dmabuf_fd + 1. The entry
+  /// is keyed by that GEM handle, which owns the mapping's lifetime: it carries
+  /// the flags from export through to GEM_VA (where it records the size and a
+  /// lazily created host mapping used to install pages into the GPU page table)
+  /// and lives until DRM_IOCTL_GEM_CLOSE. It deliberately does NOT die when the
+  /// transient dmabuf export fd is closed — ROCr closes that fd immediately after
+  /// GEM_VA returns, while the GPU mapping must stay live for the caller.
+  /// installed_vas holds the GPU VA ranges mapped from this BO so GEM_CLOSE can
+  /// tear down the page-table entries before munmapping cpu_ptr.
+  ///
+  /// `owner` records the SimulatedKfd whose page table actually holds these PTEs,
+  /// captured at map time. The local driver may be absent when GEM_CLOSE arrives
+  /// (e.g. a remote/DBT-guest backend is active, or — in a forked child — before the
+  /// driver is recreated), so teardown unmaps through `owner` only while it is still
+  /// the active driver, and skips the unmap otherwise (that page table is gone).
+  /// The local driver is a process-lifetime singleton (see get_or_create), so
+  /// `owner` never points at a freed-and-replaced driver.
+  struct GemMapping {
+    uint64_t va_address = 0;
+    uint64_t map_size = 0;
+    bool operator==(const GemMapping &) const = default;
+  };
+
   struct GemEntry {
     uint64_t size = 0;
     uint32_t alloc_flags = 0;
     void *cpu_ptr = nullptr;
-    std::vector<std::pair<uint64_t, uint64_t>> installed_vas;
-  };
-
-  /// @brief A GPU VA range still installed in the page table at close time.
-  struct GemMapping {
-    uint64_t va_address = 0;
-    uint64_t map_size = 0;
+    SimulatedKfd *owner = nullptr;
+    std::vector<GemMapping> installed_vas;
   };
 
   /// @brief GEM handle for a dmabuf fd (PRIME_FD_TO_HANDLE convention).
+  /// @details Valid domain: @p dmabuf_fd >= 0, yielding a handle >= 1. Handle 0 is
+  /// never minted, so it can be treated as "no handle" by the ioctl handlers.
   static constexpr uint32_t gem_handle_for_fd(int dmabuf_fd) {
     return static_cast<uint32_t>(dmabuf_fd) + 1u;
   }
 
   /// @brief dmabuf fd backing a GEM handle (inverse of gem_handle_for_fd).
+  /// @details Defined for handle >= 1 (the only values gem_handle_for_fd mints).
   static constexpr int gem_fd_for_handle(uint32_t handle) { return static_cast<int>(handle) - 1; }
 
   /// @brief Record KFD alloc flags for an exported dmabuf fd (at EXPORT_DMABUF).
   /// @details The flags must be captured at export time because the underlying
-  /// allocation may be freed before the fd is mapped via GEM_VA.
+  /// allocation may be freed before the fd is mapped via GEM_VA. Keyed by the GEM
+  /// handle the fd will resolve to (handle = fd + 1). A GEM entry lives until
+  /// DRM_IOCTL_GEM_CLOSE, but dmabuf fd integers are recycled, so a re-exported fd
+  /// can resolve to a handle whose previous owner never issued GEM_CLOSE. Tear down
+  /// any such stale predecessor before reusing the slot so its host mapping and GPU
+  /// PTEs cannot bleed into the new BO.
   void track_gem_flags(int dmabuf_fd, uint32_t alloc_flags) {
     std::lock_guard lock(fd_mutex_);
-    gem_entries_[dmabuf_fd].alloc_flags = alloc_flags;
+    GemEntry &gem = fresh_gem_entry_locked(gem_handle_for_fd(dmabuf_fd));
+    gem.alloc_flags = alloc_flags;
   }
 
   /// @brief Record the BO size for a dmabuf fd (at PRIME_FD_TO_HANDLE).
+  /// @details PRIME_FD_TO_HANDLE follows EXPORT_DMABUF on the same fd, so an entry
+  /// with the correct flags already exists; only refresh the size. If PRIME arrives
+  /// without a preceding EXPORT (or on a recycled handle), start a clean entry.
   void track_gem_size(int dmabuf_fd, uint64_t size) {
     std::lock_guard lock(fd_mutex_);
-    gem_entries_[dmabuf_fd].size = size;
+    uint32_t handle = gem_handle_for_fd(dmabuf_fd);
+    auto it = gem_entries_.find(handle);
+    if (it != gem_entries_.end() && it->second.cpu_ptr == nullptr &&
+        it->second.installed_vas.empty()) {
+      // Live entry from the matching EXPORT with no mapping yet — just set the size.
+      it->second.size = size;
+      return;
+    }
+    // No entry, or a stale predecessor with a live mapping from a recycled fd.
+    fresh_gem_entry_locked(handle).size = size;
   }
 
-  /// @brief Resolve a GEM_VA MAP into a host pointer to install in the page table.
-  /// @details Runs entirely under fd_mutex_: it lazily mmaps the dmabuf fd's
-  /// backing pages the first time (publishing cpu_ptr while locked, so racing
-  /// maps cannot double-mmap or observe a torn write), bounds-checks the request
-  /// against the BO size, records the VA range for teardown, and returns the host
-  /// pointer + PTE MTYPE flags by value so no GemEntry pointer escapes the lock.
-  /// @retval true @p host_out / @p flags_out are set; the caller installs them.
-  /// @retval false unknown fd, out-of-bounds request, or the lazy mmap failed.
-  [[nodiscard]] bool gem_prepare_map(int dmabuf_fd, uint64_t va_address, uint64_t offset_in_bo,
-                                     uint64_t map_size, void **host_out, uint32_t *flags_out) {
+  /// @brief Install a GEM_VA MAP range into the GPU page table for @p handle.
+  /// @details Runs entirely under fd_mutex_ and performs BOTH the bookkeeping AND
+  /// the page-table install (drv->gem_va_map) atomically, so a concurrent GEM_CLOSE
+  /// (untrack_gem, also under fd_mutex_) can never interleave between recording the
+  /// range and installing the PTEs — which would otherwise leave PTEs pointing into
+  /// a munmapped cpu_ptr with no entry left to tear them down. It lazily mmaps the
+  /// dmabuf fd's backing pages the first time (the fd is still open at GEM_VA time),
+  /// bounds-checks the request against the BO size, records the range, and installs
+  /// the PTEs. The lock order fd_mutex_ -> driver page-table lock matches
+  /// teardown_gem_entry_locked, so there is no inversion.
+  /// @retval true the range was installed.
+  /// @retval false unknown handle, out-of-bounds request, failed mmap, or no driver.
+  [[nodiscard]] bool gem_map(uint32_t handle, uint64_t va_address, uint64_t offset_in_bo,
+                             uint64_t map_size) {
     std::lock_guard lock(fd_mutex_);
-    auto it = gem_entries_.find(dmabuf_fd);
+    auto *drv = dynamic_cast<SimulatedKfd *>(driver());
+    if (!drv)
+      return false;
+    auto it = gem_entries_.find(handle);
     if (it == gem_entries_.end())
       return false;
     GemEntry &gem = it->second;
@@ -903,51 +968,60 @@ public:
       return false;
     if (!gem.cpu_ptr) {
       void *p = InterposerContext::real().mmap(nullptr, gem.size, PROT_READ | PROT_WRITE,
-                                               MAP_SHARED, dmabuf_fd, 0);
+                                               MAP_SHARED, gem_fd_for_handle(handle), 0);
       if (p == MAP_FAILED)
         return false;
       gem.cpu_ptr = p;
     }
-    gem.installed_vas.emplace_back(va_address, map_size);
-    *host_out = static_cast<uint8_t *>(gem.cpu_ptr) + offset_in_bo;
-    *flags_out = gem.alloc_flags;
+    // Record which SimulatedKfd's page table receives these PTEs so GEM_CLOSE (or a
+    // stale-predecessor teardown) unmaps through the driver that installed them,
+    // never a replacement one. Set the owner on the first mapping and keep it: all
+    // ranges of one BO install into the same driver's page table. The local driver
+    // is a process-lifetime singleton (created once, never destroyed except in the
+    // fork child, which also clears gem_entries_), so the owner never dangles and
+    // every subsequent map observes the same driver.
+    if (gem.installed_vas.empty())
+      gem.owner = drv;
+    else
+      assert(gem.owner == drv && "GEM ranges of one BO must share one owning driver");
+    void *host = static_cast<uint8_t *>(gem.cpu_ptr) + offset_in_bo;
+    // Install the PTEs while still holding fd_mutex_ so the range record and the
+    // page-table state stay consistent against a concurrent teardown.
+    drv->gem_va_map(va_address, host, map_size, gem.alloc_flags);
+    gem.installed_vas.push_back({va_address, map_size});
     return true;
   }
 
-  /// @brief Forget a GPU VA range previously recorded for a dmabuf fd.
-  /// @details Called after a GEM_VA UNMAP tears the range down, so close() does
-  /// not redundantly unmap an already-removed range.
-  void gem_forget_map(int dmabuf_fd, uint64_t va_address, uint64_t map_size) {
+  /// @brief Remove a GEM_VA range from the GPU page table for @p handle.
+  /// @details Performs the page-table unmap AND the bookkeeping erase atomically
+  /// under fd_mutex_ (same rationale as gem_map). @p handle unknown or no driver is
+  /// a no-op returning false.
+  [[nodiscard]] bool gem_unmap(uint32_t handle, uint64_t va_address, uint64_t map_size) {
     std::lock_guard lock(fd_mutex_);
-    auto it = gem_entries_.find(dmabuf_fd);
+    auto *drv = dynamic_cast<SimulatedKfd *>(driver());
+    if (!drv)
+      return false;
+    auto it = gem_entries_.find(handle);
     if (it == gem_entries_.end())
-      return;
-    auto &vas = it->second.installed_vas;
-    std::erase(vas, std::pair<uint64_t, uint64_t>{va_address, map_size});
+      return false;
+    drv->gem_va_unmap(va_address, map_size);
+    std::erase(it->second.installed_vas, GemMapping{va_address, map_size});
+    return true;
   }
 
-  /// @brief Drop the GEM entry for a closing dmabuf fd.
-  /// @details Called from close() so a closed dmabuf fd cannot leave a stale
-  /// entry behind: fd integers are reused, and a later EXPORT_DMABUF on the same
-  /// value must start clean. Returns (under the lock) any GPU VA ranges still
-  /// installed from this BO so the caller can tear them out of the page table
-  /// BEFORE munmapping cpu_ptr — otherwise the page table would hold pointers
-  /// into freed host memory. @p cpu_ptr_out / @p size_out receive the lazy host
-  /// mapping to munmap (nullptr if none). Returns the still-installed VA ranges.
-  std::vector<GemMapping> untrack_gem(int dmabuf_fd, void **cpu_ptr_out, uint64_t *size_out) {
-    std::vector<GemMapping> ranges;
-    *cpu_ptr_out = nullptr;
-    *size_out = 0;
+  /// @brief Drop the GEM entry for a closing GEM handle (at DRM_IOCTL_GEM_CLOSE).
+  /// @details The handle owns the mapping lifetime, so this is the point where the
+  /// BO is truly gone. Tears down the page-table entries (through the owning driver)
+  /// and munmaps the host mapping entirely under fd_mutex_, so no GemEntry pointer
+  /// or driver pointer escapes the lock and a concurrent GEM_VA cannot race the
+  /// teardown.
+  void untrack_gem(uint32_t handle) {
     std::lock_guard lock(fd_mutex_);
-    auto it = gem_entries_.find(dmabuf_fd);
+    auto it = gem_entries_.find(handle);
     if (it == gem_entries_.end())
-      return ranges;
-    for (auto &[va, sz] : it->second.installed_vas)
-      ranges.push_back({va, sz});
-    *cpu_ptr_out = it->second.cpu_ptr;
-    *size_out = it->second.size;
+      return;
+    teardown_gem_entry_locked(it->second);
     gem_entries_.erase(it);
-    return ranges;
   }
 
   LinuxKfd *get_or_create() {
@@ -1067,7 +1141,43 @@ private:
   /// recorded only if a reference was actually acquired, so track/untrack stay
   /// balanced and can never over-release or resurrect the wrong connection.
   std::unordered_map<int, DupBackend> kfd_dup_fds_;
-  std::unordered_map<int, GemEntry> gem_entries_;
+  /// @brief Imported GEM buffer objects, keyed by GEM handle (not dmabuf fd).
+  /// @details The handle owns the mapping lifetime; entries live from
+  /// PRIME_FD_TO_HANDLE / EXPORT_DMABUF until DRM_IOCTL_GEM_CLOSE.
+  std::unordered_map<uint32_t, GemEntry> gem_entries_;
+
+  /// @brief Tear down a GEM entry's GPU PTEs and host mapping. Caller holds
+  /// fd_mutex_. Removes page-table ranges through the driver that installed them
+  /// (owner), BEFORE munmapping cpu_ptr, so the page table never holds pointers
+  /// into freed host memory. If that driver is no longer the active one, its page
+  /// table is already gone with it, so the PTE removal is skipped (never applied to
+  /// a different, replacement driver).
+  void teardown_gem_entry_locked(GemEntry &gem) {
+    if (gem.owner && gem.owner == dynamic_cast<SimulatedKfd *>(driver())) {
+      for (const auto &r : gem.installed_vas)
+        gem.owner->gem_va_unmap(r.va_address, r.map_size);
+    }
+    if (gem.cpu_ptr && gem.size)
+      InterposerContext::real().munmap(gem.cpu_ptr, gem.size);
+    gem.cpu_ptr = nullptr;
+    gem.installed_vas.clear();
+  }
+
+  /// @brief Return a clean GEM entry for @p handle, reaping any stale predecessor.
+  /// @details Caller holds fd_mutex_. dmabuf fd integers are recycled, so a
+  /// re-exported fd can resolve to a handle whose previous BO was never GEM_CLOSE'd
+  /// (e.g. the app exited, or the BO was freed by a path other than GEM_CLOSE). If
+  /// the predecessor had a live mapping, fully tear it down (PTEs + host mmap) so it
+  /// cannot bleed into the new BO. A flags-only predecessor (no mapping yet) carries
+  /// nothing to tear down and is simply overwritten — the intended reset.
+  GemEntry &fresh_gem_entry_locked(uint32_t handle) {
+    GemEntry &gem = gem_entries_[handle];
+    if (gem.cpu_ptr || !gem.installed_vas.empty())
+      teardown_gem_entry_locked(gem);
+    gem = {};
+    return gem;
+  }
+
   std::string invocation_runtime_dir_;
 
   alignas(16) static uint8_t storage_[];
@@ -1318,23 +1428,11 @@ RJ_INTERPOSER_EXPORT int close(int fd) {
     return 0;
   }
   InterposerContext::ctx.untrack_sysfs(fd);
-  {
-    // Tear down any GPU page-table ranges still installed from this dmabuf BO
-    // BEFORE munmapping its lazy host mapping: the page table holds host
-    // pointers into cpu_ptr, so unmapping the pages without clearing the PTEs
-    // would leave the simulated GPU dereferencing freed memory. gem_va_unmap
-    // needs the local simulated driver; if none, the ranges are moot (the page
-    // table went away with the driver).
-    void *gem_cpu_ptr = nullptr;
-    uint64_t gem_size = 0;
-    auto gem_ranges = InterposerContext::ctx.untrack_gem(fd, &gem_cpu_ptr, &gem_size);
-    if (auto *sim = dynamic_cast<SimulatedKfd *>(InterposerContext::ctx.driver())) {
-      for (const auto &r : gem_ranges)
-        sim->gem_va_unmap(r.va_address, r.map_size);
-    }
-    if (gem_cpu_ptr && gem_size)
-      InterposerContext::real().munmap(gem_cpu_ptr, gem_size);
-  }
+  // NOTE: a GEM/dmabuf mapping is NOT torn down here. ROCr closes the temporary
+  // dmabuf export fd immediately after VMemorySetAccessPerHandle() returns, while
+  // the GPU mapping must stay live for the caller. GEM state is keyed by the GEM
+  // handle and released on DRM_IOCTL_GEM_CLOSE (see the ioctl handler), not when
+  // this transient fd closes.
   if (InterposerContext::ctx.untrack_drm(fd)) {
     InterposerContext::real().close(fd);
     return 0;
@@ -1363,9 +1461,10 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
 
   constexpr unsigned kDrmIoctlType = 'd';
   constexpr unsigned kDrmIoctlNrVersion = 0x00;
+  constexpr unsigned kDrmIoctlNrGemClose = _IOC_NR(DRM_IOCTL_GEM_CLOSE);
   constexpr unsigned kDrmIoctlNrAmdgpuInfo = DRM_COMMAND_BASE + DRM_AMDGPU_INFO;
   constexpr unsigned kDrmIoctlNrGemVa = DRM_COMMAND_BASE + DRM_AMDGPU_GEM_VA;
-  constexpr unsigned kDrmIoctlNrPrimeFdToHandle = 0x2e;
+  constexpr unsigned kDrmIoctlNrPrimeFdToHandle = _IOC_NR(DRM_IOCTL_PRIME_FD_TO_HANDLE);
 
   if (InterposerContext::ctx.is_drm(fd)) {
     unsigned nr = _IOC_NR(request);
@@ -1397,11 +1496,6 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
       return 0;
     }
     if (type == kDrmIoctlType && nr == kDrmIoctlNrPrimeFdToHandle && arg) {
-      struct drm_prime_handle {
-        uint32_t handle;
-        uint32_t flags;
-        int32_t fd;
-      };
       auto *prime = static_cast<drm_prime_handle *>(arg);
       if (prime->fd < 0) {
         errno = EINVAL;
@@ -1412,10 +1506,19 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
       // Record the BO size so GEM_VA can map the dmabuf into the GPU page table.
       // The dmabuf fd is mmap-able (it dups the allocation's backing memfd); its
       // KFD alloc flags were captured on the same entry at EXPORT_DMABUF time.
+      // Use the real fstat (not the interposed one) so we don't re-enter our own hook.
       uint64_t sz = 0;
       struct stat st {};
-      if (fstat(prime->fd, &st) == 0 && st.st_size > 0)
+      if (InterposerContext::real().fstat_fn(prime->fd, &st) == 0 && st.st_size > 0) {
         sz = static_cast<uint64_t>(st.st_size);
+      } else {
+        // No size means a later GEM_VA MAP on this handle will fail (EINVAL);
+        // log here so that EINVAL is traceable to its real cause rather than
+        // looking like a bad map request.
+        util::Logger::warn("PRIME_FD_TO_HANDLE: dmabuf fd=", prime->fd,
+                           " has no usable size (fstat st_size<=0); GEM_VA maps for handle ",
+                           prime->handle, " will fail");
+      }
       InterposerContext::ctx.track_gem_size(prime->fd, sz);
       return 0;
     }
@@ -1512,32 +1615,49 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
         return 0;
       }
     }
+    if (type == kDrmIoctlType && nr == kDrmIoctlNrGemClose && arg) {
+      // GEM_CLOSE releases a GEM handle — the true end of the imported BO's
+      // lifetime (the transient dmabuf export fd was closed long ago). untrack_gem
+      // removes the GPU page-table ranges (through the driver that installed them)
+      // BEFORE munmapping the host pages, entirely under fd_mutex_ so no state
+      // escapes the lock.
+      auto *gc = static_cast<drm_gem_close *>(arg);
+      InterposerContext::ctx.untrack_gem(gc->handle);
+      return 0;
+    }
     if (type == kDrmIoctlType && nr == kDrmIoctlNrGemVa && arg) {
       // GEM_VA installs (or tears down) a GPU virtual mapping for a prime-
       // imported buffer. HSA's vmem path (hsa_amd_vmem_map) lowers to this via
       // amdgpu_bo_va_op; IREE's ring allocator triple-maps one BO at adjacent
-      // VAs. We resolve the GEM handle back to its dmabuf fd, lazily mmap the
-      // fd's backing pages, and install/remove them in the GPU page table.
+      // VAs. We map by GEM handle, lazily mmap the backing pages, and
+      // install/remove them in the GPU page table.
       auto *va = static_cast<drm_amdgpu_gem_va *>(arg);
-      // GEM_VA page-table installation only applies to the local simulated
-      // driver; there is no such path for a remote (daemon) or DBT-guest backend.
-      auto *drv = dynamic_cast<SimulatedKfd *>(InterposerContext::ctx.driver());
-      if (!drv)
-        return 0;
-
-      int dmabuf_fd = InterposerContext::ctx.gem_fd_for_handle(va->handle);
+      // GEM_VA page-table installation only applies to the local simulated driver;
+      // there is no such path for a remote (daemon) or DBT-guest backend. Report
+      // failure rather than a phantom success so userspace does not record a mapping
+      // that was never installed and later fault on the GPU page table. gem_map/
+      // gem_unmap do the bookkeeping AND the page-table mutation atomically under
+      // fd_mutex_ (so a concurrent GEM_CLOSE cannot leave dangling PTEs); they
+      // return false on no-driver / unknown handle / out-of-bounds / failed mmap.
+      if (!InterposerContext::ctx.driver_is_simulated()) {
+        errno = ENODEV;
+        return -1;
+      }
       if (va->operation == AMDGPU_VA_OP_MAP || va->operation == AMDGPU_VA_OP_REPLACE) {
-        void *host = nullptr;
-        uint32_t alloc_flags = 0;
-        // gem_prepare_map does the lazy mmap, bounds check, and VA-range tracking
-        // under fd_mutex_, returning the host pointer by value so no GEM entry
-        // pointer escapes the lock (avoids a race/UAF against a concurrent close).
-        if (InterposerContext::ctx.gem_prepare_map(dmabuf_fd, va->va_address, va->offset_in_bo,
-                                                   va->map_size, &host, &alloc_flags))
-          drv->gem_va_map(va->va_address, host, va->map_size, alloc_flags);
+        if (!InterposerContext::ctx.gem_map(va->handle, va->va_address, va->offset_in_bo,
+                                            va->map_size)) {
+          errno = EINVAL;
+          return -1;
+        }
       } else if (va->operation == AMDGPU_VA_OP_UNMAP || va->operation == AMDGPU_VA_OP_CLEAR) {
-        drv->gem_va_unmap(va->va_address, va->map_size);
-        InterposerContext::ctx.gem_forget_map(dmabuf_fd, va->va_address, va->map_size);
+        if (!InterposerContext::ctx.gem_unmap(va->handle, va->va_address, va->map_size)) {
+          errno = EINVAL;
+          return -1;
+        }
+      } else {
+        // Unknown GEM_VA operation — do not claim it succeeded.
+        errno = EINVAL;
+        return -1;
       }
       return 0;
     }
@@ -1571,15 +1691,10 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
       if (rc == 0 && request == AMDKFD_IOC_EXPORT_DMABUF && arg) {
         if (auto *sim = dynamic_cast<SimulatedKfd *>(drv)) {
           auto *export_args = static_cast<kfd_ioctl_export_dmabuf_args *>(arg);
-          uint32_t alloc_flags = 0;
-          if (auto proc = sim->find_process(sim->local_process_id())) {
-            std::lock_guard<std::mutex> lk(proc->alloc_mutex_);
-            auto it = proc->allocations_.find(export_args->handle);
-            if (it != proc->allocations_.end())
-              alloc_flags = it->second.flags;
-          }
+          // alloc_flags_for_handle locks the process alloc mutex internally, so the
+          // interposer does not reach into driver-private per-process state.
           InterposerContext::ctx.track_gem_flags(static_cast<int>(export_args->dmabuf_fd),
-                                                 alloc_flags);
+                                                 sim->alloc_flags_for_handle(export_args->handle));
         }
       }
       return kfd_ioctl_ret(rc);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -1541,6 +1541,9 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
       }
       return 0;
     }
+    unsigned rejected_nr = nr - 0x40;
+    util::Logger::warn("DRM ioctl rejected: nr=0x", std::hex, nr, " (AMDGPU cmd 0x", rejected_nr,
+                       std::dec, ") fd=", fd);
     errno = EINVAL;
     return -1;
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -263,6 +263,7 @@ public:
     sysfs_fds_.clear();
     drm_fds_.clear();
     kfd_dup_fds_.clear();
+    gem_entries_.clear();
     in_construction = false;
   }
 
@@ -834,6 +835,121 @@ public:
     std::thread([vm = rj_vm_]() { rj_vm_run(vm, nullptr); }).detach();
   }
 
+  /// @brief A GEM buffer object synthesized from a prime (dmabuf) fd.
+  /// @details The native DRM emulation has no real GEM objects. EXPORT_DMABUF
+  /// hands userspace a dmabuf fd whose KFD allocation flags determine the GPU
+  /// PTE MTYPE; PRIME_FD_TO_HANDLE later mints handle = dmabuf_fd + 1. Because
+  /// handle and fd are a fixed bijection, a single map keyed by the dmabuf fd
+  /// carries the flags from export through to GEM_VA, where it also records the
+  /// size and a lazily created host mapping used to install the pages into the
+  /// GPU page table. installed_vas holds the GPU VA ranges mapped from this BO so
+  /// close() can tear down the page-table entries before munmapping cpu_ptr.
+  struct GemEntry {
+    uint64_t size = 0;
+    uint32_t alloc_flags = 0;
+    void *cpu_ptr = nullptr;
+    std::vector<std::pair<uint64_t, uint64_t>> installed_vas;
+  };
+
+  /// @brief A GPU VA range still installed in the page table at close time.
+  struct GemMapping {
+    uint64_t va_address = 0;
+    uint64_t map_size = 0;
+  };
+
+  /// @brief GEM handle for a dmabuf fd (PRIME_FD_TO_HANDLE convention).
+  static constexpr uint32_t gem_handle_for_fd(int dmabuf_fd) {
+    return static_cast<uint32_t>(dmabuf_fd) + 1u;
+  }
+
+  /// @brief dmabuf fd backing a GEM handle (inverse of gem_handle_for_fd).
+  static constexpr int gem_fd_for_handle(uint32_t handle) { return static_cast<int>(handle) - 1; }
+
+  /// @brief Record KFD alloc flags for an exported dmabuf fd (at EXPORT_DMABUF).
+  /// @details The flags must be captured at export time because the underlying
+  /// allocation may be freed before the fd is mapped via GEM_VA.
+  void track_gem_flags(int dmabuf_fd, uint32_t alloc_flags) {
+    std::lock_guard lock(fd_mutex_);
+    gem_entries_[dmabuf_fd].alloc_flags = alloc_flags;
+  }
+
+  /// @brief Record the BO size for a dmabuf fd (at PRIME_FD_TO_HANDLE).
+  void track_gem_size(int dmabuf_fd, uint64_t size) {
+    std::lock_guard lock(fd_mutex_);
+    gem_entries_[dmabuf_fd].size = size;
+  }
+
+  /// @brief Resolve a GEM_VA MAP into a host pointer to install in the page table.
+  /// @details Runs entirely under fd_mutex_: it lazily mmaps the dmabuf fd's
+  /// backing pages the first time (publishing cpu_ptr while locked, so racing
+  /// maps cannot double-mmap or observe a torn write), bounds-checks the request
+  /// against the BO size, records the VA range for teardown, and returns the host
+  /// pointer + PTE MTYPE flags by value so no GemEntry pointer escapes the lock.
+  /// @retval true @p host_out / @p flags_out are set; the caller installs them.
+  /// @retval false unknown fd, out-of-bounds request, or the lazy mmap failed.
+  [[nodiscard]] bool gem_prepare_map(int dmabuf_fd, uint64_t va_address, uint64_t offset_in_bo,
+                                     uint64_t map_size, void **host_out, uint32_t *flags_out) {
+    std::lock_guard lock(fd_mutex_);
+    auto it = gem_entries_.find(dmabuf_fd);
+    if (it == gem_entries_.end())
+      return false;
+    GemEntry &gem = it->second;
+    // Bound the request within the BO without letting offset_in_bo + map_size
+    // overflow (both are caller-controlled __u64 from the UAPI struct): a wrap
+    // would defeat a naive sum-vs-size check and install PTEs pointing outside
+    // the mmap. Reject a zero-size BO, a zero-size map, and any range past the end.
+    if (gem.size == 0 || map_size == 0 || offset_in_bo > gem.size ||
+        map_size > gem.size - offset_in_bo)
+      return false;
+    if (!gem.cpu_ptr) {
+      void *p = InterposerContext::real().mmap(nullptr, gem.size, PROT_READ | PROT_WRITE,
+                                               MAP_SHARED, dmabuf_fd, 0);
+      if (p == MAP_FAILED)
+        return false;
+      gem.cpu_ptr = p;
+    }
+    gem.installed_vas.emplace_back(va_address, map_size);
+    *host_out = static_cast<uint8_t *>(gem.cpu_ptr) + offset_in_bo;
+    *flags_out = gem.alloc_flags;
+    return true;
+  }
+
+  /// @brief Forget a GPU VA range previously recorded for a dmabuf fd.
+  /// @details Called after a GEM_VA UNMAP tears the range down, so close() does
+  /// not redundantly unmap an already-removed range.
+  void gem_forget_map(int dmabuf_fd, uint64_t va_address, uint64_t map_size) {
+    std::lock_guard lock(fd_mutex_);
+    auto it = gem_entries_.find(dmabuf_fd);
+    if (it == gem_entries_.end())
+      return;
+    auto &vas = it->second.installed_vas;
+    std::erase(vas, std::pair<uint64_t, uint64_t>{va_address, map_size});
+  }
+
+  /// @brief Drop the GEM entry for a closing dmabuf fd.
+  /// @details Called from close() so a closed dmabuf fd cannot leave a stale
+  /// entry behind: fd integers are reused, and a later EXPORT_DMABUF on the same
+  /// value must start clean. Returns (under the lock) any GPU VA ranges still
+  /// installed from this BO so the caller can tear them out of the page table
+  /// BEFORE munmapping cpu_ptr — otherwise the page table would hold pointers
+  /// into freed host memory. @p cpu_ptr_out / @p size_out receive the lazy host
+  /// mapping to munmap (nullptr if none). Returns the still-installed VA ranges.
+  std::vector<GemMapping> untrack_gem(int dmabuf_fd, void **cpu_ptr_out, uint64_t *size_out) {
+    std::vector<GemMapping> ranges;
+    *cpu_ptr_out = nullptr;
+    *size_out = 0;
+    std::lock_guard lock(fd_mutex_);
+    auto it = gem_entries_.find(dmabuf_fd);
+    if (it == gem_entries_.end())
+      return ranges;
+    for (auto &[va, sz] : it->second.installed_vas)
+      ranges.push_back({va, sz});
+    *cpu_ptr_out = it->second.cpu_ptr;
+    *size_out = it->second.size;
+    gem_entries_.erase(it);
+    return ranges;
+  }
+
   LinuxKfd *get_or_create() {
     std::lock_guard lock(init_mutex_);
     if (active_driver_.load(std::memory_order_acquire) == nullptr) {
@@ -951,6 +1067,7 @@ private:
   /// recorded only if a reference was actually acquired, so track/untrack stay
   /// balanced and can never over-release or resurrect the wrong connection.
   std::unordered_map<int, DupBackend> kfd_dup_fds_;
+  std::unordered_map<int, GemEntry> gem_entries_;
   std::string invocation_runtime_dir_;
 
   alignas(16) static uint8_t storage_[];
@@ -1201,6 +1318,23 @@ RJ_INTERPOSER_EXPORT int close(int fd) {
     return 0;
   }
   InterposerContext::ctx.untrack_sysfs(fd);
+  {
+    // Tear down any GPU page-table ranges still installed from this dmabuf BO
+    // BEFORE munmapping its lazy host mapping: the page table holds host
+    // pointers into cpu_ptr, so unmapping the pages without clearing the PTEs
+    // would leave the simulated GPU dereferencing freed memory. gem_va_unmap
+    // needs the local simulated driver; if none, the ranges are moot (the page
+    // table went away with the driver).
+    void *gem_cpu_ptr = nullptr;
+    uint64_t gem_size = 0;
+    auto gem_ranges = InterposerContext::ctx.untrack_gem(fd, &gem_cpu_ptr, &gem_size);
+    if (auto *sim = dynamic_cast<SimulatedKfd *>(InterposerContext::ctx.driver())) {
+      for (const auto &r : gem_ranges)
+        sim->gem_va_unmap(r.va_address, r.map_size);
+    }
+    if (gem_cpu_ptr && gem_size)
+      InterposerContext::real().munmap(gem_cpu_ptr, gem_size);
+  }
   if (InterposerContext::ctx.untrack_drm(fd)) {
     InterposerContext::real().close(fd);
     return 0;
@@ -1230,6 +1364,7 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
   constexpr unsigned kDrmIoctlType = 'd';
   constexpr unsigned kDrmIoctlNrVersion = 0x00;
   constexpr unsigned kDrmIoctlNrAmdgpuInfo = DRM_COMMAND_BASE + DRM_AMDGPU_INFO;
+  constexpr unsigned kDrmIoctlNrGemVa = DRM_COMMAND_BASE + DRM_AMDGPU_GEM_VA;
   constexpr unsigned kDrmIoctlNrPrimeFdToHandle = 0x2e;
 
   if (InterposerContext::ctx.is_drm(fd)) {
@@ -1272,7 +1407,16 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
         errno = EINVAL;
         return -1;
       }
-      prime->handle = static_cast<uint32_t>(prime->fd) + 1u;
+      prime->handle = InterposerContext::ctx.gem_handle_for_fd(prime->fd);
+
+      // Record the BO size so GEM_VA can map the dmabuf into the GPU page table.
+      // The dmabuf fd is mmap-able (it dups the allocation's backing memfd); its
+      // KFD alloc flags were captured on the same entry at EXPORT_DMABUF time.
+      uint64_t sz = 0;
+      struct stat st {};
+      if (fstat(prime->fd, &st) == 0 && st.st_size > 0)
+        sz = static_cast<uint64_t>(st.st_size);
+      InterposerContext::ctx.track_gem_size(prime->fd, sz);
       return 0;
     }
     if (type == kDrmIoctlType && nr == kDrmIoctlNrAmdgpuInfo && arg) {
@@ -1368,6 +1512,35 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
         return 0;
       }
     }
+    if (type == kDrmIoctlType && nr == kDrmIoctlNrGemVa && arg) {
+      // GEM_VA installs (or tears down) a GPU virtual mapping for a prime-
+      // imported buffer. HSA's vmem path (hsa_amd_vmem_map) lowers to this via
+      // amdgpu_bo_va_op; IREE's ring allocator triple-maps one BO at adjacent
+      // VAs. We resolve the GEM handle back to its dmabuf fd, lazily mmap the
+      // fd's backing pages, and install/remove them in the GPU page table.
+      auto *va = static_cast<drm_amdgpu_gem_va *>(arg);
+      // GEM_VA page-table installation only applies to the local simulated
+      // driver; there is no such path for a remote (daemon) or DBT-guest backend.
+      auto *drv = dynamic_cast<SimulatedKfd *>(InterposerContext::ctx.driver());
+      if (!drv)
+        return 0;
+
+      int dmabuf_fd = InterposerContext::ctx.gem_fd_for_handle(va->handle);
+      if (va->operation == AMDGPU_VA_OP_MAP || va->operation == AMDGPU_VA_OP_REPLACE) {
+        void *host = nullptr;
+        uint32_t alloc_flags = 0;
+        // gem_prepare_map does the lazy mmap, bounds check, and VA-range tracking
+        // under fd_mutex_, returning the host pointer by value so no GEM entry
+        // pointer escapes the lock (avoids a race/UAF against a concurrent close).
+        if (InterposerContext::ctx.gem_prepare_map(dmabuf_fd, va->va_address, va->offset_in_bo,
+                                                   va->map_size, &host, &alloc_flags))
+          drv->gem_va_map(va->va_address, host, va->map_size, alloc_flags);
+      } else if (va->operation == AMDGPU_VA_OP_UNMAP || va->operation == AMDGPU_VA_OP_CLEAR) {
+        drv->gem_va_unmap(va->va_address, va->map_size);
+        InterposerContext::ctx.gem_forget_map(dmabuf_fd, va->va_address, va->map_size);
+      }
+      return 0;
+    }
     errno = EINVAL;
     return -1;
   }
@@ -1387,7 +1560,26 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
       if (auto remote = InterposerContext::ctx.remote())
         return kfd_ioctl_ret(remote->ioctl(request, arg));
     } else if (auto *drv = InterposerContext::ctx.driver()) {
-      return kfd_ioctl_ret(drv->ioctl(request, arg));
+      int rc = drv->ioctl(request, arg);
+      // Capture the KFD allocation flags for a freshly exported dmabuf fd. The
+      // flags determine the GPU PTE MTYPE when the fd is later mapped via GEM_VA,
+      // and must be recorded now because the allocation may be freed first. Only
+      // the local simulated driver exports dmabufs this path can later map.
+      if (rc == 0 && request == AMDKFD_IOC_EXPORT_DMABUF && arg) {
+        if (auto *sim = dynamic_cast<SimulatedKfd *>(drv)) {
+          auto *export_args = static_cast<kfd_ioctl_export_dmabuf_args *>(arg);
+          uint32_t alloc_flags = 0;
+          if (auto proc = sim->find_process(sim->local_process_id())) {
+            std::lock_guard<std::mutex> lk(proc->alloc_mutex_);
+            auto it = proc->allocations_.find(export_args->handle);
+            if (it != proc->allocations_.end())
+              alloc_flags = it->second.flags;
+          }
+          InterposerContext::ctx.track_gem_flags(static_cast<int>(export_args->dmabuf_fd),
+                                                 alloc_flags);
+        }
+      }
+      return kfd_ioctl_ret(rc);
     }
   }
   // Late-ioctl safety net: an AMDKFD ('K') ioctl may arrive on a tracked KFD fd

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -200,16 +200,26 @@ public:
 
   static void init() {
     new (storage_) InterposerContext();
-    // Resolve the per-PID invocation directory once here, in the library
+    // Resolve the per-invocation runtime directory once here, in the library
     // constructor: this runs single-threaded before any app code (and thus before
-    // any app fork). Eager init closes two hazards of a lazy accessor: (1) a data
-    // race — invocation_runtime_dir() is called from paths holding different locks
+    // any app fork). Writing it once here keeps invocation_runtime_dir() an
+    // immutable, lock-free read and closes two hazards a lazy resolve would have:
+    // (1) a data race — the accessor is reached from paths holding different locks
     // (remote_mutex_ vs init_mutex_); (2) an empty-at-fork window — a child the app
     // forks inherits this populated string and reconnects to the parent's daemon,
     // instead of recomputing rpc_invocation_runtime_dir(child_pid) and missing it.
+    //
+    // Prefer the dir the launcher exported before execvp: every descendant
+    // (including grandchildren spawned through wrappers like ctest, whose PID
+    // differs from the launcher's) inherits the exact directory holding
+    // config_path/daemon.sock. Fall back to this process's PID-scoped default for
+    // attach mode, where no launcher set the variable.
     // Assigned before resolve() (which flips real().ready() true, the gate every
     // interposed entry point checks) so no reader can observe an empty value.
-    ctx.invocation_runtime_dir_ = rocjitsu::rpc_invocation_runtime_dir(getpid());
+    if (const char *dir = getenv(rocjitsu::kRpcInvocationDirEnv))
+      ctx.invocation_runtime_dir_ = dir;
+    else
+      ctx.invocation_runtime_dir_ = rocjitsu::rpc_invocation_runtime_dir(getpid());
     real().resolve();
   }
 
@@ -280,7 +290,7 @@ public:
                : nullptr;
   }
 
-  /// @brief The per-PID invocation runtime directory for this process image.
+  /// @brief The per-invocation runtime directory for this process image.
   /// @details Populated once in init() before any thread or app fork, so this is
   /// a lock-free immutable read. A forked app child inherits the parent's value
   /// (reset_after_fork() intentionally does not clear it) and thus reconnects to

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -87,22 +87,42 @@ using rocjitsu::RemoteDriver;
 using rocjitsu::SimulatedKfd;
 using rocjitsu::Sysfs;
 
-static int connect_to_daemon() {
-  auto path = rocjitsu::rpc_default_socket_path();
-  int sock = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
-  if (sock < 0)
-    return -1;
+namespace {
+
+/// @brief Attempt to connect @p sock to the AF_UNIX socket at @p path.
+/// @returns 0 on success; -1 with errno set on failure (socket left open).
+int try_connect(int sock, const std::string &path) {
   sockaddr_un addr{};
   addr.sun_family = AF_UNIX;
   path.copy(addr.sun_path, sizeof(addr.sun_path) - 1);
-  if (connect(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) != 0) {
-    rocjitsu::libc_passthrough().close(sock);
-    return -1;
-  }
-  return sock;
+  return connect(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr));
 }
 
-namespace {
+/// @brief Connect to the daemon for this invocation's per-PID runtime directory.
+/// @details Connects to <runtime_dir>/daemon.sock. Only when that per-PID
+/// directory does not exist (attach / daemon-only clients that share the
+/// well-known location) does it fall back to rpc_default_socket_path(). The
+/// fallback is gated on dir-absence rather than connect-failure so a daemon-mode
+/// app is never silently cross-connected to an unrelated daemon at the shared
+/// well-known socket if its own daemon's socket is transiently unavailable.
+int connect_to_daemon(const std::string &runtime_dir) {
+  int sock = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (sock < 0)
+    return -1;
+
+  if (try_connect(sock, runtime_dir + "/daemon.sock") == 0)
+    return sock;
+
+  // Fall back to the well-known socket only for invocations that never created a
+  // per-PID directory (attach / daemon-only). access() goes through the real libc
+  // so it does not re-enter this interposer's own path hooks.
+  if (rocjitsu::libc_passthrough().access(runtime_dir.c_str(), F_OK) != 0 &&
+      try_connect(sock, rocjitsu::rpc_default_socket_path()) == 0)
+    return sock;
+
+  rocjitsu::libc_passthrough().close(sock);
+  return -1;
+}
 
 /// @brief Convert a kernel-style driver ioctl result into the libc ioctl(2)
 /// return/`errno` contract.
@@ -118,12 +138,12 @@ int kfd_ioctl_ret(int r) {
   return r;
 }
 
-/// @brief Return the child-process rocjitsu config path.
+/// @brief Read the child-process rocjitsu config path from @p cfg_file.
 ///
-/// @details The launcher writes the config path to the shared runtime file for
-/// both local simulation and DBT guest mode.
-std::optional<std::string> child_config_path() {
-  auto cfg_file = rocjitsu::rpc_default_config_file_path();
+/// @details The launcher writes the config path to a runtime file (per-PID
+/// invocation directory) that the interposer reads back for both local
+/// simulation and DBT guest mode.
+std::optional<std::string> child_config_path(const std::string &cfg_file) {
   char cfg_buf[4096]{};
   auto &real = rocjitsu::libc_passthrough();
   int cfg_fd = real.openat(AT_FDCWD, cfg_file.c_str(), O_RDONLY, 0);
@@ -180,6 +200,16 @@ public:
 
   static void init() {
     new (storage_) InterposerContext();
+    // Resolve the per-PID invocation directory once here, in the library
+    // constructor: this runs single-threaded before any app code (and thus before
+    // any app fork). Eager init closes two hazards of a lazy accessor: (1) a data
+    // race — invocation_runtime_dir() is called from paths holding different locks
+    // (remote_mutex_ vs init_mutex_); (2) an empty-at-fork window — a child the app
+    // forks inherits this populated string and reconnects to the parent's daemon,
+    // instead of recomputing rpc_invocation_runtime_dir(child_pid) and missing it.
+    // Assigned before resolve() (which flips real().ready() true, the gate every
+    // interposed entry point checks) so no reader can observe an empty value.
+    ctx.invocation_runtime_dir_ = rocjitsu::rpc_invocation_runtime_dir(getpid());
     real().resolve();
   }
 
@@ -249,6 +279,13 @@ public:
                ? active_remote
                : nullptr;
   }
+
+  /// @brief The per-PID invocation runtime directory for this process image.
+  /// @details Populated once in init() before any thread or app fork, so this is
+  /// a lock-free immutable read. A forked app child inherits the parent's value
+  /// (reset_after_fork() intentionally does not clear it) and thus reconnects to
+  /// the same daemon rather than recomputing a dir under its own PID.
+  const std::string &invocation_runtime_dir() const { return invocation_runtime_dir_; }
 
   // No lock needed: the snapshot keeps the RemoteDriver alive, and its handshake
   // metadata (topology/drm paths, gpu_info) is immutable after open() — close()
@@ -346,7 +383,7 @@ public:
       // cannot clear it before the caller uses it.
       return {active_remote, fd};
     }
-    int sock = connect_to_daemon();
+    int sock = connect_to_daemon(invocation_runtime_dir());
     if (sock < 0)
       return {};
     // Build the driver and open its KFD connection BEFORE publishing remote_.
@@ -791,7 +828,8 @@ public:
     std::lock_guard lock(init_mutex_);
     if (active_driver_.load(std::memory_order_acquire) == nullptr) {
       in_construction = true;
-      std::optional<std::string> cfg_path = child_config_path();
+      std::optional<std::string> cfg_path =
+          child_config_path(invocation_runtime_dir() + "/config_path");
       if (!cfg_path) {
         util::Logger::debug_print("rocjitsu: no child config path");
         in_construction = false;
@@ -903,6 +941,7 @@ private:
   /// recorded only if a reference was actually acquired, so track/untrack stay
   /// balanced and can never over-release or resurrect the wrong connection.
   std::unordered_map<int, DupBackend> kfd_dup_fds_;
+  std::string invocation_runtime_dir_;
 
   alignas(16) static uint8_t storage_[];
 };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -1174,19 +1174,34 @@ public:
     std::lock_guard lock(init_mutex_);
     if (active_driver_.load(std::memory_order_acquire) == nullptr) {
       in_construction = true;
-      // Config-path discovery mirrors the DBT-guest reader precedence: the
-      // per-invocation directory first (the launcher writes config_path there and
-      // exports $ROCJITSU_INVOCATION_DIR), then the well-known
-      // $ROCJITSU_RUNTIME_DIR/config_path for a bare LD_PRELOAD client that sets no
-      // invocation dir (e.g. a standalone HSA program that writes the handoff to the
-      // documented well-known location). Without the fallback such a client's
-      // config is never found and hsa_init fails with OUT_OF_RESOURCES.
-      std::optional<std::string> cfg_path =
-          child_config_path(invocation_runtime_dir() + "/config_path");
-      if (!cfg_path) {
-        const std::string well_known = rocjitsu::rpc_default_config_file_path();
-        if (well_known != invocation_runtime_dir() + "/config_path")
-          cfg_path = child_config_path(well_known);
+      // Config-path discovery mirrors load_dbt_guest_config_from_runtime_config()'s
+      // reader precedence exactly, probing tiers in order and using the first whose
+      // config_path handoff actually exists:
+      //   1. the per-invocation directory (the launcher writes config_path there and
+      //      exports $ROCJITSU_INVOCATION_DIR); invocation_runtime_dir() already
+      //      collapses to the per-PID default when that env var is unset.
+      //   2. this process's PID-scoped default — reached only when the env var is set
+      //      but its config_path is absent/stale, matching the reader's tier 2 (a
+      //      no-op duplicate of tier 1 when the env var is unset).
+      //   3. the well-known $ROCJITSU_RUNTIME_DIR/config_path for a bare LD_PRELOAD
+      //      client that sets no invocation dir. Without this fallback such a client's
+      //      config is never found and hsa_init fails with OUT_OF_RESOURCES.
+      // Probing tier 2 as well as tier 1 keeps the interposer's view consistent with
+      // the reader's: an env var pointing at a dir without config_path must still find
+      // a valid per-PID handoff instead of skipping straight to the well-known path.
+      std::vector<std::string> cfg_candidates;
+      cfg_candidates.push_back(invocation_runtime_dir() + "/config_path");
+      cfg_candidates.push_back(rocjitsu::rpc_invocation_config_file_path(getpid()));
+      cfg_candidates.push_back(rocjitsu::rpc_default_config_file_path());
+      std::optional<std::string> cfg_path;
+      std::string tried_last;
+      for (const auto &candidate : cfg_candidates) {
+        if (candidate == tried_last)
+          continue; // Skip a duplicate tier (e.g. env unset collapses 1 and 2).
+        tried_last = candidate;
+        cfg_path = child_config_path(candidate);
+        if (cfg_path)
+          break;
       }
       if (!cfg_path) {
         util::Logger::debug_print("rocjitsu: no child config path");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -261,9 +261,11 @@ public:
     // parent's connection. pthread_atfork's child handler runs inside libc fork,
     // covering every fork that goes through glibc. (vfork/posix_spawn children run
     // no atfork handlers by design, but they may only exec/_exit, so there is no
-    // interposer state for them to corrupt.) reset_after_fork() is idempotent and
-    // async-signal-safe (store/clear/placement-new only), as an atfork child
-    // handler requires.
+    // interposer state for them to corrupt.) reset_after_fork() is idempotent. It is
+    // NOT strictly async-signal-safe — container clear()/destructors call free() and it
+    // closes the child's dmabuf-dup fds — so it relies on the standard fork-then-exec /
+    // single-threaded-fork assumption (the same one the remote_ handling documents
+    // below); a multithreaded fork from a signal handler is out of scope.
     pthread_atfork(nullptr, nullptr, &InterposerContext::atfork_child);
     real().resolve();
   }
@@ -316,6 +318,17 @@ public:
     // must not touch them. The child re-initializes a fresh driver; any GEM mappings
     // it needs are re-created via EXPORT/PRIME/GEM_VA. (Deliberate, like the remote_
     // and mutex handling above — not an oversight.)
+    //
+    // DO close each entry's private dmabuf dup though: it was created with
+    // F_DUPFD_CLOEXEC (closes on exec, NOT on fork), so a fork-without-exec child
+    // inherits these descriptors and clearing the map without closing them leaks a
+    // child-local fd per live GEM handle. The fd is the child's own copy — closing it
+    // touches no parent state. (real().close() is not async-signal-safe, but this runs
+    // under the same fork-then-exec / single-threaded-fork assumption as the remote_
+    // handling above.)
+    for (auto &[handle, gem] : gem_entries_)
+      if (gem.owns_dmabuf_fd && gem.dmabuf_fd >= 0)
+        real().close(gem.dmabuf_fd);
     gem_entries_.clear();
     // Also drop the transient EXPORT_DMABUF fd->flags handoffs: they key on the
     // parent's dmabuf fd numbers, so a child that reuses one of those fd numbers
@@ -1343,6 +1356,10 @@ private:
   ///   ioctl reports EINVAL.
   /// @retval true nothing overlapped (allow_missing) or all overlaps were evicted.
   /// @retval false nothing overlapped (only when !allow_missing) or an unmap failed.
+  /// @note Not rolled back on a mid-loop unmap failure: already-evicted ranges stay
+  ///   evicted. This is safe because gem_va_unmap() only fails when the local process
+  ///   has already vanished (SimulatedKfd::gem_va_unmap), i.e. its page table is being
+  ///   torn down anyway, so a partially-evicted state is never observed by a live GPU.
   [[nodiscard]] bool evict_range_locked(SimulatedKfd *drv, const GemMapping &range,
                                         bool allow_missing) {
     bool evicted_any = false;
@@ -1353,7 +1370,7 @@ private:
           continue;
         }
         if (!drv->gem_va_unmap(vit->va_address, vit->map_size))
-          return false;
+          return false; // process gone; page table already being destroyed (see @note)
         vit = gem.installed_vas.erase(vit);
         evicted_any = true;
       }
@@ -1984,7 +2001,13 @@ namespace {
 // Then the replacement is recorded on the reserved source backend.
 void reconcile_dup_target(int newfd, std::optional<InterposerContext::DupBackend> reserved) {
   InterposerContext::ctx.untrack_sysfs(newfd);
-  InterposerContext::ctx.untrack_drm(newfd);
+  // dup2/dup3 atomically close whatever newfd was, bypassing the close() hook. If
+  // newfd was a DRM render fd still owning live GEM handles, reap them here just as
+  // close() does (untrack_drm + reap_gem_for_drm_fd) — otherwise those GemEntry
+  // objects (keyed by drm_fd == newfd) leak their PTEs, host mmap, and dup'd dmabuf
+  // fd, and a later commit_dup could re-tag the same number as a KFD dup.
+  if (InterposerContext::ctx.untrack_drm(newfd))
+    InterposerContext::ctx.reap_gem_for_drm_fd(newfd);
   InterposerContext::ctx.invalidate_overwritten_kfd_fd(newfd);
   if (reserved)
     InterposerContext::ctx.commit_dup(newfd, *reserved);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -1091,8 +1091,20 @@ public:
     std::lock_guard lock(init_mutex_);
     if (active_driver_.load(std::memory_order_acquire) == nullptr) {
       in_construction = true;
+      // Config-path discovery mirrors the DBT-guest reader precedence: the
+      // per-invocation directory first (the launcher writes config_path there and
+      // exports $ROCJITSU_INVOCATION_DIR), then the well-known
+      // $ROCJITSU_RUNTIME_DIR/config_path for a bare LD_PRELOAD client that sets no
+      // invocation dir (e.g. a standalone HSA program that writes the handoff to the
+      // documented well-known location). Without the fallback such a client's
+      // config is never found and hsa_init fails with OUT_OF_RESOURCES.
       std::optional<std::string> cfg_path =
           child_config_path(invocation_runtime_dir() + "/config_path");
+      if (!cfg_path) {
+        const std::string well_known = rocjitsu::rpc_default_config_file_path();
+        if (well_known != invocation_runtime_dir() + "/config_path")
+          cfg_path = child_config_path(well_known);
+      }
       if (!cfg_path) {
         util::Logger::debug_print("rocjitsu: no child config path");
         in_construction = false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -44,6 +44,7 @@ RJ_DIAGNOSTIC_POP
 #include "util/dynamic_loader.h"
 #include "util/log.h"
 
+#include <algorithm>
 #include <atomic>
 #include <cassert>
 #include <cerrno>
@@ -299,6 +300,11 @@ public:
     // it needs are re-created via EXPORT/PRIME/GEM_VA. (Deliberate, like the remote_
     // and mutex handling above — not an oversight.)
     gem_entries_.clear();
+    // Also drop the transient EXPORT_DMABUF fd->flags handoffs: they key on the
+    // parent's dmabuf fd numbers, so a child that reuses one of those fd numbers
+    // before a fresh EXPORT could otherwise fold a stale parent MTYPE hint into its
+    // own PRIME import.
+    pending_gem_flags_.clear();
     in_construction = false;
   }
 
@@ -916,14 +922,24 @@ public:
   /// @brief Record KFD alloc flags for an exported dmabuf fd (at EXPORT_DMABUF).
   /// @details The flags determine the GPU PTE MTYPE when the fd is later mapped via
   /// GEM_VA and must be captured at export time because the underlying allocation
-  /// may be freed before the map. This is only a TRANSIENT fd→flags association: it
-  /// is consumed by the next PRIME_FD_TO_HANDLE on the same fd, which folds the
-  /// flags into a stable-handle GemEntry. Keying this transient map by fd is safe
-  /// (unlike keying the durable BO state by fd) because it is short-lived and
-  /// overwritten by the next EXPORT on a reused fd.
+  /// may be freed before the map. This is only a TRANSIENT fd→flags association,
+  /// consumed by the next PRIME_FD_TO_HANDLE on the same fd (which folds the flags
+  /// into a stable-handle GemEntry). To keep the fd key from going stale — a dmabuf
+  /// fd closed without a PRIME, then recycled by the kernel for an unrelated file —
+  /// drop_pending_gem_flags(fd) clears the record at close(fd), so a reused fd
+  /// number can never inherit a previous export's MTYPE.
   void track_gem_flags(int dmabuf_fd, uint32_t alloc_flags) {
     std::lock_guard lock(fd_mutex_);
     pending_gem_flags_[dmabuf_fd] = alloc_flags;
+  }
+
+  /// @brief Drop any transient EXPORT_DMABUF flags recorded for @p fd (at close(fd)).
+  /// @details Called from the close() hook for every fd. Cheap no-op when @p fd is
+  /// not a pending dmabuf export. Prevents a closed-without-PRIME export fd from
+  /// leaving a stale flag that a later PRIME on the recycled fd number would apply.
+  void drop_pending_gem_flags(int fd) {
+    std::lock_guard lock(fd_mutex_);
+    pending_gem_flags_.erase(fd);
   }
 
   /// @brief Mint a stable GEM handle for a prime-imported dmabuf (PRIME_FD_TO_HANDLE).
@@ -940,7 +956,12 @@ public:
       alloc_flags = it->second;
       pending_gem_flags_.erase(it);
     }
+    // Mint the next free handle. Skip 0 ("no handle") and any handle still live, so a
+    // uint32 wrap after a very long-lived process cannot silently overwrite an
+    // in-use entry (which would detach its PTEs from a future GEM_CLOSE).
     uint32_t handle = next_gem_handle_++;
+    while (handle == 0 || gem_entries_.count(handle) != 0)
+      handle = next_gem_handle_++;
     GemEntry &gem = gem_entries_[handle];
     gem = {};
     gem.dmabuf_fd = dmabuf_fd;
@@ -1549,6 +1570,11 @@ RJ_INTERPOSER_EXPORT int close(int fd) {
     return 0;
   }
   InterposerContext::ctx.untrack_sysfs(fd);
+  // Drop any transient EXPORT_DMABUF flags for this fd: a dmabuf export fd closed
+  // before a PRIME_FD_TO_HANDLE would otherwise leave a stale fd→flags record that a
+  // later PRIME on the recycled fd number could misapply as the wrong PTE MTYPE.
+  // No-op for non-dmabuf fds.
+  InterposerContext::ctx.drop_pending_gem_flags(fd);
   // NOTE: a GEM/dmabuf mapping is NOT torn down when a transient dmabuf EXPORT fd
   // closes. ROCr closes that fd immediately after VMemorySetAccessPerHandle()
   // returns, while the GPU mapping must stay live for the caller. GEM state is keyed

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -62,6 +62,7 @@ RJ_DIAGNOSTIC_POP
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <pthread.h>
 #include <signal.h>
 #include <sstream>
 #include <string>
@@ -251,8 +252,24 @@ public:
       ctx.invocation_runtime_dir_ = dir;
     else
       ctx.invocation_runtime_dir_ = rocjitsu::rpc_invocation_runtime_dir(getpid());
+    // Reset child state on ANY glibc fork-family primitive, not just the
+    // interposed fork() symbol. system()/popen()/posix_spawn() and libraries that
+    // call fork() through a path that doesn't bind to our exported fork() would
+    // otherwise leave the child with mutexes locked-by-a-dead-thread and a live
+    // remote_ aliasing the parent's daemon connection — the next interposed
+    // open()/ioctl()/close() in that child would then deadlock or corrupt the
+    // parent's connection. pthread_atfork's child handler runs inside libc fork,
+    // covering every fork that goes through glibc. (vfork/posix_spawn children run
+    // no atfork handlers by design, but they may only exec/_exit, so there is no
+    // interposer state for them to corrupt.) reset_after_fork() is idempotent and
+    // async-signal-safe (store/clear/placement-new only), as an atfork child
+    // handler requires.
+    pthread_atfork(nullptr, nullptr, &InterposerContext::atfork_child);
     real().resolve();
   }
+
+  /// @brief pthread_atfork child handler: reset interposer state in the child.
+  static void atfork_child() { ctx.reset_after_fork(); }
 
   /// @brief Reset interposer state in a forked child process.
   /// @details After fork(), the child inherits the parent's address space but
@@ -890,9 +907,11 @@ public:
   /// closed — ROCr closes that fd immediately after GEM_VA returns, while the GPU
   /// mapping must stay live for the caller. Because handles are not fd-derived, a
   /// recycled dmabuf fd number can never resolve to a still-live handle and tear
-  /// down an unrelated BO. `dmabuf_fd` is retained only for the lazy backing mmap
-  /// (the fd is still open at GEM_VA time); `drm_fd` scopes the handle to its DRM
-  /// file so a file close reaps any handles the caller never GEM_CLOSE'd.
+  /// down an unrelated BO. `dmabuf_fd` is a PRIVATE dup taken at PRIME time and held
+  /// only for the lazy backing mmap, so the backing stays valid even if the caller
+  /// closes the export fd before GEM_VA (the fd number cannot be recycled out from
+  /// under us); `drm_fd` scopes the handle to its DRM file so a file close reaps any
+  /// handles the caller never GEM_CLOSE'd.
   /// installed_vas holds the GPU VA ranges mapped from this BO so teardown can
   /// remove the page-table entries before munmapping cpu_ptr.
   ///
@@ -907,11 +926,18 @@ public:
     uint64_t va_address = 0;
     uint64_t map_size = 0;
     bool operator==(const GemMapping &) const = default;
+    /// @brief True if this VA interval intersects @p other. Half-open [va, va+size).
+    /// map_size is already bounds-checked non-zero and non-overflowing in gem_map().
+    [[nodiscard]] bool overlaps(const GemMapping &other) const {
+      return va_address < other.va_address + other.map_size &&
+             other.va_address < va_address + map_size;
+    }
   };
 
   struct GemEntry {
-    int dmabuf_fd = -1; ///< Backing dmabuf fd for the lazy mmap (open at GEM_VA time).
-    int drm_fd = -1;    ///< Owning DRM file; the entry is reaped when it closes.
+    int dmabuf_fd = -1;          ///< Private dup of the backing dmabuf fd for the lazy mmap.
+    bool owns_dmabuf_fd = false; ///< True if dmabuf_fd is our dup (close at teardown).
+    int drm_fd = -1;             ///< Owning DRM file; the entry is reaped when it closes.
     uint64_t size = 0;
     uint32_t alloc_flags = 0;
     void *cpu_ptr = nullptr;
@@ -956,6 +982,15 @@ public:
       alloc_flags = it->second;
       pending_gem_flags_.erase(it);
     }
+    // Pin the backing to the HANDLE's lifetime by dup'ing the dmabuf fd now, rather
+    // than storing the caller's fd number for a later lazy mmap. ROCr closes the
+    // export fd right after GEM_VA returns, but nothing in the DRM ABI forbids a
+    // client from closing it between PRIME and a deferred GEM_VA MAP; the fd number
+    // could then be recycled and the lazy mmap in gem_map() would map an unrelated
+    // file. The dup keeps the same dmabuf open under a private fd until the handle is
+    // torn down. Falls back to the raw fd if dup fails (best effort; the common
+    // fd-still-open case is unaffected).
+    int backing_fd = InterposerContext::real().fcntl(dmabuf_fd, F_DUPFD_CLOEXEC, 0);
     // Mint the next free handle. Skip 0 ("no handle") and any handle still live, so a
     // uint32 wrap after a very long-lived process cannot silently overwrite an
     // in-use entry (which would detach its PTEs from a future GEM_CLOSE).
@@ -964,7 +999,8 @@ public:
       handle = next_gem_handle_++;
     GemEntry &gem = gem_entries_[handle];
     gem = {};
-    gem.dmabuf_fd = dmabuf_fd;
+    gem.dmabuf_fd = (backing_fd >= 0) ? backing_fd : dmabuf_fd;
+    gem.owns_dmabuf_fd = (backing_fd >= 0);
     gem.drm_fd = drm_fd;
     gem.size = size;
     gem.alloc_flags = alloc_flags;
@@ -981,10 +1017,10 @@ public:
   /// bounds-checks the request against the BO size, records the range, and installs
   /// the PTEs. The lock order fd_mutex_ -> driver page-table lock matches
   /// teardown_gem_entry_locked, so there is no inversion.
-  /// @param replace When true (AMDGPU_VA_OP_REPLACE), first evict any existing exact
-  ///   {va_address, map_size} range — from whatever handle currently owns it — so the
-  ///   old owner's bookkeeping does not later tear down the replacement's PTEs. When
-  ///   false (AMDGPU_VA_OP_MAP), a pre-existing range at that VA is a conflict.
+  /// @param replace When true (AMDGPU_VA_OP_REPLACE), first evict any existing range
+  ///   that OVERLAPS {va_address, map_size} — from whatever handle currently owns it —
+  ///   so the old owner's bookkeeping does not later tear down the replacement's PTEs.
+  ///   When false (AMDGPU_VA_OP_MAP), an overlapping pre-existing range is a conflict.
   /// @retval true the range was installed.
   /// @retval false unknown handle, out-of-bounds request, failed mmap, no driver, or
   ///   (MAP only) the range is already mapped.
@@ -1074,12 +1110,13 @@ public:
   }
 
   /// @brief Clear a GEM_VA range from the GPU page table (CLEAR).
-  /// @details CLEAR is handle-agnostic: it tears down the exact {va_address,
-  /// map_size} range wherever it is currently recorded, updating the owning entry's
-  /// bookkeeping so a later GEM_CLOSE does not double-unmap it. Fails if no entry
-  /// owns that exact range (so the ioctl reports EINVAL instead of a phantom clear).
-  /// @retval true the range was found and cleared.
-  /// @retval false no driver, or no entry owns that exact range.
+  /// @details CLEAR is handle-agnostic: it tears down every recorded range that
+  /// OVERLAPS {va_address, map_size} wherever it is currently recorded, updating the
+  /// owning entries' bookkeeping so a later GEM_CLOSE does not double-unmap them.
+  /// Fails if no recorded range overlaps (so the ioctl reports EINVAL instead of a
+  /// phantom clear).
+  /// @retval true at least one overlapping range was found and cleared.
+  /// @retval false no driver, or no recorded range overlaps.
   [[nodiscard]] bool gem_clear(uint64_t va_address, uint64_t map_size) {
     std::lock_guard lock(fd_mutex_);
     auto *drv = dynamic_cast<SimulatedKfd *>(driver());
@@ -1281,42 +1318,57 @@ private:
       InterposerContext::real().munmap(gem.cpu_ptr, gem.size);
     gem.cpu_ptr = nullptr;
     gem.installed_vas.clear();
+    // Release our private dup of the backing dmabuf (taken in prime_import) now that
+    // no lazy mmap can reference it. Close through the passthrough table so we don't
+    // re-enter our own close() hook and its GEM/dup bookkeeping.
+    if (gem.owns_dmabuf_fd && gem.dmabuf_fd >= 0)
+      InterposerContext::real().close(gem.dmabuf_fd);
+    gem.dmabuf_fd = -1;
+    gem.owns_dmabuf_fd = false;
   }
 
-  /// @brief Remove the exact @p range from whatever GEM entry currently owns it.
+  /// @brief Evict every recorded range that OVERLAPS @p range, across all handles.
   /// @details Caller holds fd_mutex_ and passes the live simulated @p drv. Used by
-  /// GEM_VA REPLACE (evict the prior mapping before installing the new one) and CLEAR
-  /// (handle-agnostic teardown). Removes the PTEs through the owning driver and drops
-  /// the range from that entry's bookkeeping so a later GEM_CLOSE cannot double-unmap
-  /// it. The host mmap is left intact — the owning handle still exists and other
-  /// ranges may reference it; it is munmapped only at GEM_CLOSE / reap.
-  /// @param allow_missing When true, a range that no entry owns is a success (a MAP
-  ///   onto a free VA has nothing to evict); when false (REPLACE/CLEAR), a missing
-  ///   range is a failure so the ioctl reports EINVAL.
-  /// @retval true nothing needed evicting (allow_missing) or the range was evicted.
-  /// @retval false the range was not owned (only when !allow_missing) or the unmap
-  ///   failed.
+  /// GEM_VA REPLACE (evict prior mappings before installing the new one) and CLEAR
+  /// (handle-agnostic teardown). Matching is by interval intersection, not exact
+  /// equality: a REPLACE at a VA previously mapped with a DIFFERENT size (or a
+  /// sub/super-range) must still evict the old mapping, otherwise its stale
+  /// bookkeeping would later double-unmap or leak the new PTEs. Each overlapping
+  /// range is unmapped by its OWN {va_address, map_size} extent (not @p range's) so
+  /// the page-table removal matches what was installed, then dropped from its entry's
+  /// bookkeeping. The host mmap is left intact — the owning handle still exists and
+  /// other ranges may reference it; it is munmapped only at GEM_CLOSE / reap.
+  /// @param allow_missing When true, no overlap is a success (a MAP onto a free VA has
+  ///   nothing to evict); when false (REPLACE/CLEAR), no overlap is a failure so the
+  ///   ioctl reports EINVAL.
+  /// @retval true nothing overlapped (allow_missing) or all overlaps were evicted.
+  /// @retval false nothing overlapped (only when !allow_missing) or an unmap failed.
   [[nodiscard]] bool evict_range_locked(SimulatedKfd *drv, const GemMapping &range,
                                         bool allow_missing) {
+    bool evicted_any = false;
     for (auto &[handle, gem] : gem_entries_) {
-      auto vit = std::find(gem.installed_vas.begin(), gem.installed_vas.end(), range);
-      if (vit == gem.installed_vas.end())
-        continue;
-      if (!drv->gem_va_unmap(range.va_address, range.map_size))
-        return false;
-      gem.installed_vas.erase(vit);
-      return true;
+      for (auto vit = gem.installed_vas.begin(); vit != gem.installed_vas.end();) {
+        if (!vit->overlaps(range)) {
+          ++vit;
+          continue;
+        }
+        if (!drv->gem_va_unmap(vit->va_address, vit->map_size))
+          return false;
+        vit = gem.installed_vas.erase(vit);
+        evicted_any = true;
+      }
     }
-    return allow_missing;
+    return evicted_any || allow_missing;
   }
 
-  /// @brief Whether any GEM entry currently owns the exact @p range. Caller holds
-  /// fd_mutex_. Used by plain MAP to reject a double-map over an existing range.
+  /// @brief Whether any GEM entry owns a range OVERLAPPING @p range. Caller holds
+  /// fd_mutex_. Used by plain MAP to reject a map that would collide with (not just
+  /// exactly duplicate) an existing range's PTEs.
   [[nodiscard]] bool range_is_mapped_locked(const GemMapping &range) const {
     for (const auto &[handle, gem] : gem_entries_)
-      if (std::find(gem.installed_vas.begin(), gem.installed_vas.end(), range) !=
-          gem.installed_vas.end())
-        return true;
+      for (const auto &existing : gem.installed_vas)
+        if (existing.overlaps(range))
+          return true;
     return false;
   }
 
@@ -2618,12 +2670,9 @@ RJ_INTERPOSER_EXPORT int __lxstat64(int ver, const char *path, struct stat64 *bu
   return real_lxstat64(ver, actual, buf);
 }
 
-RJ_INTERPOSER_EXPORT pid_t fork() {
-  assert(InterposerContext::real().ready());
-  pid_t pid = InterposerContext::real().fork();
-  if (pid == 0)
-    InterposerContext::ctx.reset_after_fork();
-  return pid;
-}
+// fork() is intentionally NOT interposed: the child reset is registered via
+// pthread_atfork() in InterposerContext::init(), which libc runs for every
+// fork-family primitive that goes through glibc (fork/system/popen), not just an
+// interposed fork() symbol. A passthrough wrapper here would double-run the reset.
 
 } // extern "C"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -2001,8 +2001,14 @@ namespace {
 // Then the replacement is recorded on the reserved source backend.
 void reconcile_dup_target(int newfd, std::optional<InterposerContext::DupBackend> reserved) {
   InterposerContext::ctx.untrack_sysfs(newfd);
-  // dup2/dup3 atomically close whatever newfd was, bypassing the close() hook. If
-  // newfd was a DRM render fd still owning live GEM handles, reap them here just as
+  // dup2/dup3 atomically close whatever newfd was, bypassing the close() hook, so
+  // every per-fd cleanup close() performs must be mirrored here. Drop any transient
+  // EXPORT_DMABUF flags for newfd: a dmabuf export fd overwritten before a
+  // PRIME_FD_TO_HANDLE would otherwise leave a stale fd→flags record that a later
+  // PRIME on the recycled fd number could misapply as the wrong PTE MTYPE. No-op for
+  // non-dmabuf fds.
+  InterposerContext::ctx.drop_pending_gem_flags(newfd);
+  // If newfd was a DRM render fd still owning live GEM handles, reap them here just as
   // close() does (untrack_drm + reap_gem_for_drm_fd) — otherwise those GemEntry
   // objects (keyed by drm_fd == newfd) leak their PTEs, host mmap, and dup'd dmabuf
   // fd, and a later commit_dup could re-tag the same number as a KFD dup.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -862,16 +862,21 @@ public:
 
   /// @brief A GEM buffer object synthesized from a prime (dmabuf) fd.
   /// @details The native DRM emulation has no real GEM objects. EXPORT_DMABUF
-  /// hands userspace a dmabuf fd whose KFD allocation flags determine the GPU
-  /// PTE MTYPE; PRIME_FD_TO_HANDLE later mints handle = dmabuf_fd + 1. The entry
-  /// is keyed by that GEM handle, which owns the mapping's lifetime: it carries
-  /// the flags from export through to GEM_VA (where it records the size and a
-  /// lazily created host mapping used to install pages into the GPU page table)
-  /// and lives until DRM_IOCTL_GEM_CLOSE. It deliberately does NOT die when the
-  /// transient dmabuf export fd is closed — ROCr closes that fd immediately after
-  /// GEM_VA returns, while the GPU mapping must stay live for the caller.
-  /// installed_vas holds the GPU VA ranges mapped from this BO so GEM_CLOSE can
-  /// tear down the page-table entries before munmapping cpu_ptr.
+  /// hands userspace a dmabuf fd whose KFD allocation flags determine the GPU PTE
+  /// MTYPE; PRIME_FD_TO_HANDLE then mints a STABLE, monotonically-increasing GEM
+  /// handle (never derived from the fd number). The entry is keyed by that handle,
+  /// which owns the mapping's lifetime: it carries the flags from export through to
+  /// GEM_VA (where it lazily mmaps the backing pages used to install the GPU page
+  /// table) and lives until DRM_IOCTL_GEM_CLOSE (or until its owning DRM file
+  /// closes). It deliberately does NOT die when the transient dmabuf export fd is
+  /// closed — ROCr closes that fd immediately after GEM_VA returns, while the GPU
+  /// mapping must stay live for the caller. Because handles are not fd-derived, a
+  /// recycled dmabuf fd number can never resolve to a still-live handle and tear
+  /// down an unrelated BO. `dmabuf_fd` is retained only for the lazy backing mmap
+  /// (the fd is still open at GEM_VA time); `drm_fd` scopes the handle to its DRM
+  /// file so a file close reaps any handles the caller never GEM_CLOSE'd.
+  /// installed_vas holds the GPU VA ranges mapped from this BO so teardown can
+  /// remove the page-table entries before munmapping cpu_ptr.
   ///
   /// `owner` records the SimulatedKfd whose page table actually holds these PTEs,
   /// captured at map time. The local driver may be absent when GEM_CLOSE arrives
@@ -887,6 +892,8 @@ public:
   };
 
   struct GemEntry {
+    int dmabuf_fd = -1; ///< Backing dmabuf fd for the lazy mmap (open at GEM_VA time).
+    int drm_fd = -1;    ///< Owning DRM file; the entry is reaped when it closes.
     uint64_t size = 0;
     uint32_t alloc_flags = 0;
     void *cpu_ptr = nullptr;
@@ -894,50 +901,44 @@ public:
     std::vector<GemMapping> installed_vas;
   };
 
-  /// @brief GEM handle for a dmabuf fd (PRIME_FD_TO_HANDLE convention).
-  /// @details Valid domain: @p dmabuf_fd >= 0, yielding a handle >= 1. Handle 0 is
-  /// never minted, so it can be treated as "no handle" by the ioctl handlers.
-  static constexpr uint32_t gem_handle_for_fd(int dmabuf_fd) {
-    return static_cast<uint32_t>(dmabuf_fd) + 1u;
-  }
-
-  /// @brief dmabuf fd backing a GEM handle (inverse of gem_handle_for_fd).
-  /// @details Defined for handle >= 1 (the only values gem_handle_for_fd mints).
-  static constexpr int gem_fd_for_handle(uint32_t handle) { return static_cast<int>(handle) - 1; }
-
   /// @brief Record KFD alloc flags for an exported dmabuf fd (at EXPORT_DMABUF).
-  /// @details The flags must be captured at export time because the underlying
-  /// allocation may be freed before the fd is mapped via GEM_VA. Keyed by the GEM
-  /// handle the fd will resolve to (handle = fd + 1). A GEM entry lives until
-  /// DRM_IOCTL_GEM_CLOSE, but dmabuf fd integers are recycled, so a re-exported fd
-  /// can resolve to a handle whose previous owner never issued GEM_CLOSE. Tear down
-  /// any such stale predecessor before reusing the slot so its host mapping and GPU
-  /// PTEs cannot bleed into the new BO.
+  /// @details The flags determine the GPU PTE MTYPE when the fd is later mapped via
+  /// GEM_VA and must be captured at export time because the underlying allocation
+  /// may be freed before the map. This is only a TRANSIENT fd→flags association: it
+  /// is consumed by the next PRIME_FD_TO_HANDLE on the same fd, which folds the
+  /// flags into a stable-handle GemEntry. Keying this transient map by fd is safe
+  /// (unlike keying the durable BO state by fd) because it is short-lived and
+  /// overwritten by the next EXPORT on a reused fd.
   void track_gem_flags(int dmabuf_fd, uint32_t alloc_flags) {
     std::lock_guard lock(fd_mutex_);
-    GemEntry &gem = fresh_gem_entry_locked(gem_handle_for_fd(dmabuf_fd));
-    gem.alloc_flags = alloc_flags;
+    pending_gem_flags_[dmabuf_fd] = alloc_flags;
   }
 
-  /// @brief Record the BO size for a dmabuf fd (at PRIME_FD_TO_HANDLE).
-  /// @details PRIME_FD_TO_HANDLE follows EXPORT_DMABUF on the same fd, so an entry
-  /// with the correct flags already exists; only refresh the size. If PRIME arrives
-  /// without a preceding EXPORT (or on a recycled handle), start a clean entry.
-  void track_gem_size(int dmabuf_fd, uint64_t size) {
+  /// @brief Mint a stable GEM handle for a prime-imported dmabuf (PRIME_FD_TO_HANDLE).
+  /// @details Allocates a fresh monotonically-increasing handle (never fd-derived),
+  /// consumes the transient EXPORT_DMABUF flags for @p dmabuf_fd (defaulting to 0 if
+  /// PRIME arrives without a preceding EXPORT), records @p size and the owning DRM
+  /// file, and returns the handle. Handle 0 is never minted, so callers may treat 0
+  /// as "no handle".
+  /// @returns The stable GEM handle (>= 1).
+  uint32_t prime_import(int dmabuf_fd, int drm_fd, uint64_t size) {
     std::lock_guard lock(fd_mutex_);
-    uint32_t handle = gem_handle_for_fd(dmabuf_fd);
-    auto it = gem_entries_.find(handle);
-    if (it != gem_entries_.end() && it->second.cpu_ptr == nullptr &&
-        it->second.installed_vas.empty()) {
-      // Live entry from the matching EXPORT with no mapping yet — just set the size.
-      it->second.size = size;
-      return;
+    uint32_t alloc_flags = 0;
+    if (auto it = pending_gem_flags_.find(dmabuf_fd); it != pending_gem_flags_.end()) {
+      alloc_flags = it->second;
+      pending_gem_flags_.erase(it);
     }
-    // No entry, or a stale predecessor with a live mapping from a recycled fd.
-    fresh_gem_entry_locked(handle).size = size;
+    uint32_t handle = next_gem_handle_++;
+    GemEntry &gem = gem_entries_[handle];
+    gem = {};
+    gem.dmabuf_fd = dmabuf_fd;
+    gem.drm_fd = drm_fd;
+    gem.size = size;
+    gem.alloc_flags = alloc_flags;
+    return handle;
   }
 
-  /// @brief Install a GEM_VA MAP range into the GPU page table for @p handle.
+  /// @brief Install (or replace) a GEM_VA range in the GPU page table for @p handle.
   /// @details Runs entirely under fd_mutex_ and performs BOTH the bookkeeping AND
   /// the page-table install (drv->gem_va_map) atomically, so a concurrent GEM_CLOSE
   /// (untrack_gem, also under fd_mutex_) can never interleave between recording the
@@ -947,10 +948,15 @@ public:
   /// bounds-checks the request against the BO size, records the range, and installs
   /// the PTEs. The lock order fd_mutex_ -> driver page-table lock matches
   /// teardown_gem_entry_locked, so there is no inversion.
+  /// @param replace When true (AMDGPU_VA_OP_REPLACE), first evict any existing exact
+  ///   {va_address, map_size} range — from whatever handle currently owns it — so the
+  ///   old owner's bookkeeping does not later tear down the replacement's PTEs. When
+  ///   false (AMDGPU_VA_OP_MAP), a pre-existing range at that VA is a conflict.
   /// @retval true the range was installed.
-  /// @retval false unknown handle, out-of-bounds request, failed mmap, or no driver.
+  /// @retval false unknown handle, out-of-bounds request, failed mmap, no driver, or
+  ///   (MAP only) the range is already mapped.
   [[nodiscard]] bool gem_map(uint32_t handle, uint64_t va_address, uint64_t offset_in_bo,
-                             uint64_t map_size) {
+                             uint64_t map_size, bool replace) {
     std::lock_guard lock(fd_mutex_);
     auto *drv = dynamic_cast<SimulatedKfd *>(driver());
     if (!drv)
@@ -966,36 +972,55 @@ public:
     if (gem.size == 0 || map_size == 0 || offset_in_bo > gem.size ||
         map_size > gem.size - offset_in_bo)
       return false;
+    const GemMapping range{va_address, map_size};
+    // Handle the target VA range's current occupant. REPLACE evicts any current
+    // holder (possibly a different handle) so its records cannot later unmap the new
+    // PTEs. Plain MAP treats an existing range as a conflict rather than silently
+    // double-mapping over another handle's PTEs.
+    if (replace) {
+      if (!evict_range_locked(drv, range, /*allow_missing=*/true))
+        return false;
+    } else if (range_is_mapped_locked(range)) {
+      return false;
+    }
     if (!gem.cpu_ptr) {
       void *p = InterposerContext::real().mmap(nullptr, gem.size, PROT_READ | PROT_WRITE,
-                                               MAP_SHARED, gem_fd_for_handle(handle), 0);
+                                               MAP_SHARED, gem.dmabuf_fd, 0);
       if (p == MAP_FAILED)
         return false;
       gem.cpu_ptr = p;
     }
     // Record which SimulatedKfd's page table receives these PTEs so GEM_CLOSE (or a
-    // stale-predecessor teardown) unmaps through the driver that installed them,
-    // never a replacement one. Set the owner on the first mapping and keep it: all
-    // ranges of one BO install into the same driver's page table. The local driver
-    // is a process-lifetime singleton (created once, never destroyed except in the
-    // fork child, which also clears gem_entries_), so the owner never dangles and
-    // every subsequent map observes the same driver.
+    // DRM-file-close reap) unmaps through the driver that installed them, never a
+    // replacement one. Set the owner on the first mapping and keep it: all ranges of
+    // one BO install into the same driver's page table. The local driver is a
+    // process-lifetime singleton (created once, never destroyed except in the fork
+    // child, which also clears gem_entries_), so the owner never dangles and every
+    // subsequent map observes the same driver.
     if (gem.installed_vas.empty())
       gem.owner = drv;
     else
       assert(gem.owner == drv && "GEM ranges of one BO must share one owning driver");
     void *host = static_cast<uint8_t *>(gem.cpu_ptr) + offset_in_bo;
     // Install the PTEs while still holding fd_mutex_ so the range record and the
-    // page-table state stay consistent against a concurrent teardown.
-    drv->gem_va_map(va_address, host, map_size, gem.alloc_flags);
-    gem.installed_vas.push_back({va_address, map_size});
+    // page-table state stay consistent against a concurrent teardown. gem_va_map
+    // only returns false if the local process vanished mid-call; treat that as a
+    // failed map (do not record the range) so GEM_VA reports the error rather than a
+    // phantom success.
+    if (!drv->gem_va_map(va_address, host, map_size, gem.alloc_flags))
+      return false;
+    gem.installed_vas.push_back(range);
     return true;
   }
 
-  /// @brief Remove a GEM_VA range from the GPU page table for @p handle.
+  /// @brief Remove a GEM_VA range from the GPU page table for @p handle (UNMAP).
   /// @details Performs the page-table unmap AND the bookkeeping erase atomically
-  /// under fd_mutex_ (same rationale as gem_map). @p handle unknown or no driver is
-  /// a no-op returning false.
+  /// under fd_mutex_ (same rationale as gem_map). Validates that @p handle actually
+  /// owns the exact {va_address, map_size} range before mutating the page table, so
+  /// an UNMAP with a wrong handle or range cannot tear down PTEs the handle does not
+  /// own and cannot report success for a no-op.
+  /// @retval true the range was owned by @p handle and has been unmapped.
+  /// @retval false no driver, unknown handle, or @p handle does not own that range.
   [[nodiscard]] bool gem_unmap(uint32_t handle, uint64_t va_address, uint64_t map_size) {
     std::lock_guard lock(fd_mutex_);
     auto *drv = dynamic_cast<SimulatedKfd *>(driver());
@@ -1004,9 +1029,47 @@ public:
     auto it = gem_entries_.find(handle);
     if (it == gem_entries_.end())
       return false;
-    drv->gem_va_unmap(va_address, map_size);
-    std::erase(it->second.installed_vas, GemMapping{va_address, map_size});
+    GemEntry &gem = it->second;
+    const GemMapping range{va_address, map_size};
+    if (std::find(gem.installed_vas.begin(), gem.installed_vas.end(), range) ==
+        gem.installed_vas.end())
+      return false; // This handle does not own the exact range — do not touch PTEs.
+    if (!drv->gem_va_unmap(va_address, map_size))
+      return false;
+    std::erase(gem.installed_vas, range);
     return true;
+  }
+
+  /// @brief Clear a GEM_VA range from the GPU page table (CLEAR).
+  /// @details CLEAR is handle-agnostic: it tears down the exact {va_address,
+  /// map_size} range wherever it is currently recorded, updating the owning entry's
+  /// bookkeeping so a later GEM_CLOSE does not double-unmap it. Fails if no entry
+  /// owns that exact range (so the ioctl reports EINVAL instead of a phantom clear).
+  /// @retval true the range was found and cleared.
+  /// @retval false no driver, or no entry owns that exact range.
+  [[nodiscard]] bool gem_clear(uint64_t va_address, uint64_t map_size) {
+    std::lock_guard lock(fd_mutex_);
+    auto *drv = dynamic_cast<SimulatedKfd *>(driver());
+    if (!drv)
+      return false;
+    return evict_range_locked(drv, GemMapping{va_address, map_size}, /*allow_missing=*/false);
+  }
+
+  /// @brief Reap every GEM handle owned by a closing DRM file (at its close()).
+  /// @details A well-behaved caller GEM_CLOSEs each handle, but a crash or leak can
+  /// leave handles live; the DRM file close is their backstop, mirroring the kernel
+  /// dropping a drm_file's GEM objects. Tears each entry's PTEs + host mmap down
+  /// under fd_mutex_ before erasing, so no state escapes the lock.
+  void reap_gem_for_drm_fd(int drm_fd) {
+    std::lock_guard lock(fd_mutex_);
+    for (auto it = gem_entries_.begin(); it != gem_entries_.end();) {
+      if (it->second.drm_fd == drm_fd) {
+        teardown_gem_entry_locked(it->second);
+        it = gem_entries_.erase(it);
+      } else {
+        ++it;
+      }
+    }
   }
 
   /// @brief Drop the GEM entry for a closing GEM handle (at DRM_IOCTL_GEM_CLOSE).
@@ -1141,10 +1204,18 @@ private:
   /// recorded only if a reference was actually acquired, so track/untrack stay
   /// balanced and can never over-release or resurrect the wrong connection.
   std::unordered_map<int, DupBackend> kfd_dup_fds_;
-  /// @brief Imported GEM buffer objects, keyed by GEM handle (not dmabuf fd).
-  /// @details The handle owns the mapping lifetime; entries live from
-  /// PRIME_FD_TO_HANDLE / EXPORT_DMABUF until DRM_IOCTL_GEM_CLOSE.
+  /// @brief Imported GEM buffer objects, keyed by a stable, minted GEM handle.
+  /// @details The handle (never fd-derived) owns the mapping lifetime; entries live
+  /// from PRIME_FD_TO_HANDLE until DRM_IOCTL_GEM_CLOSE, or until the owning DRM file
+  /// closes (reap_gem_for_drm_fd). Because handles are not recycled with fd numbers,
+  /// a reused dmabuf fd can never collide with a still-live BO.
   std::unordered_map<uint32_t, GemEntry> gem_entries_;
+  /// @brief Next stable GEM handle to mint. Starts at 1 so 0 means "no handle".
+  uint32_t next_gem_handle_ = 1;
+  /// @brief Transient EXPORT_DMABUF fd→alloc_flags association awaiting the next
+  /// PRIME_FD_TO_HANDLE on the same fd, which folds the flags into a GemEntry and
+  /// erases the pending record. Short-lived, so keying by (recyclable) fd is safe.
+  std::unordered_map<int, uint32_t> pending_gem_flags_;
 
   /// @brief Tear down a GEM entry's GPU PTEs and host mapping. Caller holds
   /// fd_mutex_. Removes page-table ranges through the driver that installed them
@@ -1154,8 +1225,12 @@ private:
   /// a different, replacement driver).
   void teardown_gem_entry_locked(GemEntry &gem) {
     if (gem.owner && gem.owner == dynamic_cast<SimulatedKfd *>(driver())) {
+      // The owning driver is still active; remove its PTEs. gem_va_unmap only fails
+      // if the local process already vanished, in which case the page table is gone
+      // and there is nothing to remove — either way the range must not remain
+      // recorded, so the return value is intentionally not actionable here.
       for (const auto &r : gem.installed_vas)
-        gem.owner->gem_va_unmap(r.va_address, r.map_size);
+        (void)gem.owner->gem_va_unmap(r.va_address, r.map_size);
     }
     if (gem.cpu_ptr && gem.size)
       InterposerContext::real().munmap(gem.cpu_ptr, gem.size);
@@ -1163,19 +1238,41 @@ private:
     gem.installed_vas.clear();
   }
 
-  /// @brief Return a clean GEM entry for @p handle, reaping any stale predecessor.
-  /// @details Caller holds fd_mutex_. dmabuf fd integers are recycled, so a
-  /// re-exported fd can resolve to a handle whose previous BO was never GEM_CLOSE'd
-  /// (e.g. the app exited, or the BO was freed by a path other than GEM_CLOSE). If
-  /// the predecessor had a live mapping, fully tear it down (PTEs + host mmap) so it
-  /// cannot bleed into the new BO. A flags-only predecessor (no mapping yet) carries
-  /// nothing to tear down and is simply overwritten — the intended reset.
-  GemEntry &fresh_gem_entry_locked(uint32_t handle) {
-    GemEntry &gem = gem_entries_[handle];
-    if (gem.cpu_ptr || !gem.installed_vas.empty())
-      teardown_gem_entry_locked(gem);
-    gem = {};
-    return gem;
+  /// @brief Remove the exact @p range from whatever GEM entry currently owns it.
+  /// @details Caller holds fd_mutex_ and passes the live simulated @p drv. Used by
+  /// GEM_VA REPLACE (evict the prior mapping before installing the new one) and CLEAR
+  /// (handle-agnostic teardown). Removes the PTEs through the owning driver and drops
+  /// the range from that entry's bookkeeping so a later GEM_CLOSE cannot double-unmap
+  /// it. The host mmap is left intact — the owning handle still exists and other
+  /// ranges may reference it; it is munmapped only at GEM_CLOSE / reap.
+  /// @param allow_missing When true, a range that no entry owns is a success (a MAP
+  ///   onto a free VA has nothing to evict); when false (REPLACE/CLEAR), a missing
+  ///   range is a failure so the ioctl reports EINVAL.
+  /// @retval true nothing needed evicting (allow_missing) or the range was evicted.
+  /// @retval false the range was not owned (only when !allow_missing) or the unmap
+  ///   failed.
+  [[nodiscard]] bool evict_range_locked(SimulatedKfd *drv, const GemMapping &range,
+                                        bool allow_missing) {
+    for (auto &[handle, gem] : gem_entries_) {
+      auto vit = std::find(gem.installed_vas.begin(), gem.installed_vas.end(), range);
+      if (vit == gem.installed_vas.end())
+        continue;
+      if (!drv->gem_va_unmap(range.va_address, range.map_size))
+        return false;
+      gem.installed_vas.erase(vit);
+      return true;
+    }
+    return allow_missing;
+  }
+
+  /// @brief Whether any GEM entry currently owns the exact @p range. Caller holds
+  /// fd_mutex_. Used by plain MAP to reject a double-map over an existing range.
+  [[nodiscard]] bool range_is_mapped_locked(const GemMapping &range) const {
+    for (const auto &[handle, gem] : gem_entries_)
+      if (std::find(gem.installed_vas.begin(), gem.installed_vas.end(), range) !=
+          gem.installed_vas.end())
+        return true;
+    return false;
   }
 
   std::string invocation_runtime_dir_;
@@ -1428,12 +1525,15 @@ RJ_INTERPOSER_EXPORT int close(int fd) {
     return 0;
   }
   InterposerContext::ctx.untrack_sysfs(fd);
-  // NOTE: a GEM/dmabuf mapping is NOT torn down here. ROCr closes the temporary
-  // dmabuf export fd immediately after VMemorySetAccessPerHandle() returns, while
-  // the GPU mapping must stay live for the caller. GEM state is keyed by the GEM
-  // handle and released on DRM_IOCTL_GEM_CLOSE (see the ioctl handler), not when
-  // this transient fd closes.
+  // NOTE: a GEM/dmabuf mapping is NOT torn down when a transient dmabuf EXPORT fd
+  // closes. ROCr closes that fd immediately after VMemorySetAccessPerHandle()
+  // returns, while the GPU mapping must stay live for the caller. GEM state is keyed
+  // by a stable GEM handle and released on DRM_IOCTL_GEM_CLOSE (see the ioctl
+  // handler). Closing the DRM FILE itself, however, is the true backstop: reap any
+  // handles still open on it (mirroring the kernel dropping a drm_file's GEM
+  // objects) so a leaked/never-GEM_CLOSE'd handle cannot outlive its DRM file.
   if (InterposerContext::ctx.untrack_drm(fd)) {
+    InterposerContext::ctx.reap_gem_for_drm_fd(fd);
     InterposerContext::real().close(fd);
     return 0;
   }
@@ -1501,12 +1601,10 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
         errno = EINVAL;
         return -1;
       }
-      prime->handle = InterposerContext::ctx.gem_handle_for_fd(prime->fd);
 
-      // Record the BO size so GEM_VA can map the dmabuf into the GPU page table.
-      // The dmabuf fd is mmap-able (it dups the allocation's backing memfd); its
-      // KFD alloc flags were captured on the same entry at EXPORT_DMABUF time.
-      // Use the real fstat (not the interposed one) so we don't re-enter our own hook.
+      // Size the BO so GEM_VA can map the dmabuf into the GPU page table. The dmabuf
+      // fd is mmap-able (it dups the allocation's backing memfd). Use the real fstat
+      // (not the interposed one) so we don't re-enter our own hook.
       uint64_t sz = 0;
       struct stat st {};
       if (InterposerContext::real().fstat_fn(prime->fd, &st) == 0 && st.st_size > 0) {
@@ -1516,10 +1614,13 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
         // log here so that EINVAL is traceable to its real cause rather than
         // looking like a bad map request.
         util::Logger::warn("PRIME_FD_TO_HANDLE: dmabuf fd=", prime->fd,
-                           " has no usable size (fstat st_size<=0); GEM_VA maps for handle ",
-                           prime->handle, " will fail");
+                           " has no usable size (fstat st_size<=0); GEM_VA maps for the minted "
+                           "handle will fail");
       }
-      InterposerContext::ctx.track_gem_size(prime->fd, sz);
+      // Mint a stable handle (independent of the fd number) scoped to this DRM file,
+      // folding in the alloc flags captured at EXPORT_DMABUF. The caller closes the
+      // export fd right after access setup; the handle — not the fd — owns the BO.
+      prime->handle = InterposerContext::ctx.prime_import(prime->fd, fd, sz);
       return 0;
     }
     if (type == kDrmIoctlType && nr == kDrmIoctlNrAmdgpuInfo && arg) {
@@ -1643,27 +1744,46 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
         errno = ENODEV;
         return -1;
       }
-      if (va->operation == AMDGPU_VA_OP_MAP || va->operation == AMDGPU_VA_OP_REPLACE) {
-        if (!InterposerContext::ctx.gem_map(va->handle, va->va_address, va->offset_in_bo,
-                                            va->map_size)) {
-          errno = EINVAL;
-          return -1;
-        }
-      } else if (va->operation == AMDGPU_VA_OP_UNMAP || va->operation == AMDGPU_VA_OP_CLEAR) {
-        if (!InterposerContext::ctx.gem_unmap(va->handle, va->va_address, va->map_size)) {
-          errno = EINVAL;
-          return -1;
-        }
-      } else {
+      bool ok = false;
+      switch (va->operation) {
+      case AMDGPU_VA_OP_MAP:
+      case AMDGPU_VA_OP_REPLACE:
+        // REPLACE evicts any prior occupant of the VA range (from whatever handle
+        // owns it) before installing the new mapping, so closing the old handle
+        // cannot later unmap the replacement. MAP rejects a range already in use.
+        ok = InterposerContext::ctx.gem_map(va->handle, va->va_address, va->offset_in_bo,
+                                            va->map_size,
+                                            /*replace=*/va->operation == AMDGPU_VA_OP_REPLACE);
+        break;
+      case AMDGPU_VA_OP_UNMAP:
+        // UNMAP requires the supplied handle to own the exact range.
+        ok = InterposerContext::ctx.gem_unmap(va->handle, va->va_address, va->map_size);
+        break;
+      case AMDGPU_VA_OP_CLEAR:
+        // CLEAR is handle-agnostic: tear down the exact range wherever it lives.
+        ok = InterposerContext::ctx.gem_clear(va->va_address, va->map_size);
+        break;
+      default:
         // Unknown GEM_VA operation — do not claim it succeeded.
+        errno = EINVAL;
+        return -1;
+      }
+      if (!ok) {
         errno = EINVAL;
         return -1;
       }
       return 0;
     }
-    unsigned rejected_nr = nr - 0x40;
-    util::Logger::warn("DRM ioctl rejected: nr=0x", std::hex, nr, " (AMDGPU cmd 0x", rejected_nr,
-                       std::dec, ") fd=", fd);
+    // Only DRM command ioctls (nr >= DRM_COMMAND_BASE) carry an AMDGPU-relative
+    // command number; core DRM ioctls (nr < DRM_COMMAND_BASE) would underflow and
+    // log a nonsense "AMDGPU cmd", so report the raw nr for those.
+    if (nr >= DRM_COMMAND_BASE) {
+      util::Logger::warn("DRM ioctl rejected: nr=0x", std::hex, nr, " (AMDGPU cmd 0x",
+                         nr - DRM_COMMAND_BASE, std::dec, ") fd=", fd);
+    } else {
+      util::Logger::warn("DRM ioctl rejected: nr=0x", std::hex, nr, std::dec,
+                         " (core DRM) fd=", fd);
+    }
     errno = EINVAL;
     return -1;
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -127,6 +127,11 @@ int connect_to_daemon(const std::string &runtime_dir) {
   int sock = try_connect(runtime_dir + "/daemon.sock");
   if (sock >= 0)
     return sock;
+  // Preserve the per-PID connect() failure reason across the access() probe below:
+  // access() overwrites errno on error and leaves it unspecified on success
+  // (POSIX), so without saving it a caller that reaches the final `return -1`
+  // would see an unrelated errno instead of the real connect failure.
+  const int connect_errno = errno;
 
   // Fall back to the well-known socket only for invocations that never created a
   // per-PID directory (attach / daemon-only). access() goes through the real libc
@@ -139,6 +144,7 @@ int connect_to_daemon(const std::string &runtime_dir) {
                           (errno == ENOENT || errno == ENOTDIR);
   if (dir_absent)
     return try_connect(rocjitsu::rpc_default_socket_path());
+  errno = connect_errno;
   return -1;
 }
 
@@ -234,7 +240,13 @@ public:
     // attach mode, where no launcher set the variable.
     // Assigned before resolve() (which flips real().ready() true, the gate every
     // interposed entry point checks) so no reader can observe an empty value.
-    if (const char *dir = getenv(rocjitsu::kRpcInvocationDirEnv))
+    // Treat an unset OR empty $ROCJITSU_INVOCATION_DIR as "no launcher dir": an
+    // empty value would otherwise leave invocation_runtime_dir_ empty, so
+    // connect_to_daemon() would target "/daemon.sock" and access("") would probe
+    // the CWD — either mis-gating the fallback or connecting to an unintended
+    // socket. Fall back to this process's PID-scoped default in that case.
+    const char *dir = getenv(rocjitsu::kRpcInvocationDirEnv);
+    if (dir && *dir)
       ctx.invocation_runtime_dir_ = dir;
     else
       ctx.invocation_runtime_dir_ = rocjitsu::rpc_invocation_runtime_dir(getpid());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -123,6 +123,11 @@ public:
     bool user_va = false;
     bool imported = false;
     int dmabuf_fd = -1;
+    // True when the driver created host_ptr (mmap it itself) and must munmap it
+    // on teardown. False for caller-owned pages (e.g. reused MAP_FIXED pages
+    // from the thunk) that the driver must never unmap, since unmapping them
+    // races with the owning process still accessing the memory.
+    bool host_ptr_owned = false;
   };
 
   /// @brief Memory policy descriptor.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/rpc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/rpc.h
@@ -257,11 +257,20 @@ inline std::string rpc_default_config_file_path() {
   return rpc_default_runtime_dir() + "/config_path";
 }
 
+/// @brief Environment variable carrying the resolved per-invocation runtime dir.
+/// @details The CLI exports this before execvp, so every descendant process
+/// (direct children and grandchildren spawned through wrappers like ctest)
+/// inherits the exact directory holding config_path/daemon.sock without
+/// re-deriving it from its own PID. Absent in attach mode, where the interposer
+/// falls back to its own PID-scoped runtime dir (which does not exist, so
+/// connect_to_daemon then uses the well-known socket).
+inline constexpr char kRpcInvocationDirEnv[] = "ROCJITSU_INVOCATION_DIR";
+
 /// @brief Per-invocation runtime directory scoped by PID.
-/// @details The CLI creates <runtime_dir>/<pid>/ before execvp, so the
-/// interposer can locate the correct config/socket using getpid(). Forked
-/// children inherit the parent's cached directory to reconnect to the same
-/// daemon instance.
+/// @details The CLI creates <runtime_dir>/<pid>/ before execvp and exports its
+/// path via $ROCJITSU_INVOCATION_DIR so the interposer locates the correct
+/// config/socket without depending on the process-tree shape. All descendants
+/// inherit the same directory through the environment.
 inline std::string rpc_invocation_runtime_dir(pid_t pid) {
   return rpc_default_runtime_dir() + "/" + std::to_string(pid);
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/rpc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/rpc.h
@@ -257,6 +257,25 @@ inline std::string rpc_default_config_file_path() {
   return rpc_default_runtime_dir() + "/config_path";
 }
 
+/// @brief Per-invocation runtime directory scoped by PID.
+/// @details The CLI creates <runtime_dir>/<pid>/ before execvp, so the
+/// interposer can locate the correct config/socket using getpid(). Forked
+/// children inherit the parent's cached directory to reconnect to the same
+/// daemon instance.
+inline std::string rpc_invocation_runtime_dir(pid_t pid) {
+  return rpc_default_runtime_dir() + "/" + std::to_string(pid);
+}
+
+/// @brief Per-invocation daemon socket path scoped by PID.
+inline std::string rpc_invocation_socket_path(pid_t pid) {
+  return rpc_invocation_runtime_dir(pid) + "/daemon.sock";
+}
+
+/// @brief Per-invocation config-path handoff file scoped by PID.
+inline std::string rpc_invocation_config_file_path(pid_t pid) {
+  return rpc_invocation_runtime_dir(pid) + "/config_path";
+}
+
 } // namespace rocjitsu
 
 #endif // ROCJITSU_KMD_LINUX_RPC_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/rpc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/rpc.h
@@ -240,11 +240,14 @@ inline bool rpc_send_exact(int sock, const void *buffer, size_t total_bytes) {
 /// @brief Per-user runtime directory for rocjitsu state files.
 /// @details Checks $ROCJITSU_RUNTIME_DIR first (used by test infrastructure
 /// for per-process isolation), then $XDG_RUNTIME_DIR/rocjitsu, falling back
-/// to /tmp/rocjitsu-<uid>.
+/// to /tmp/rocjitsu-<uid>. An env var that is SET BUT EMPTY is treated as unset:
+/// returning "" would root every derived path (socket, config, per-PID dirs) at
+/// the filesystem root and make the reapers iterate/delete from "/" or CWD, so we
+/// never return an empty string.
 inline std::string rpc_default_runtime_dir() {
-  if (const char *rj = getenv("ROCJITSU_RUNTIME_DIR"))
+  if (const char *rj = getenv("ROCJITSU_RUNTIME_DIR"); rj && *rj)
     return rj;
-  if (const char *xdg = getenv("XDG_RUNTIME_DIR"))
+  if (const char *xdg = getenv("XDG_RUNTIME_DIR"); xdg && *xdg)
     return std::string(xdg) + "/rocjitsu";
   return "/tmp/rocjitsu-" + std::to_string(getuid());
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -497,10 +497,11 @@ int SimulatedKfd::close(uint32_t process_id) {
       leaked_bytes += alloc.size;
       if (trace_enabled)
         leaked_handles.push_back(handle);
-      if (alloc.host_ptr && !(alloc.flags & KFD_IOC_ALLOC_MEM_FLAGS_USERPTR)) {
+      if (alloc.host_ptr && alloc.host_ptr_owned) {
         unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
         syscall(SYS_munmap, alloc.host_ptr, alloc.size);
         alloc.host_ptr = nullptr;
+        alloc.host_ptr_owned = false;
       }
       if (alloc.memfd >= 0) {
         {
@@ -522,10 +523,15 @@ int SimulatedKfd::close(uint32_t process_id) {
         });
   }
 
-  // Tear down doorbell pages under alloc_mutex_ (the lock the doorbell readers
-  // use — is_doorbell_range/dispatch_mmap/dispatch_munmap), not op_mutex_ (those
-  // readers do not take op_mutex_). Snapshot and clear the fields under the lock,
-  // then munmap outside it so the syscall does not run while alloc_mutex_ is held.
+  // Tear down doorbell pages. The mapped page pointer lives in gpu_state_ (not in
+  // allocations_), so the generic host_ptr teardown above does not cover it — hence
+  // this separate loop. The doorbell page is always driver-created (dispatch_mmap
+  // maps it via safe_mmap in BOTH modes: a memfd MAP_SHARED page in daemon mode, a
+  // fresh MAP_ANONYMOUS page in non-daemon mode), so the driver owns it and must
+  // reclaim it unconditionally on close. Snapshot and clear the fields under
+  // alloc_mutex_ (the lock the doorbell readers use —
+  // is_doorbell_range/dispatch_mmap/dispatch_munmap), then munmap outside the lock
+  // so the syscall does not run while alloc_mutex_ is held.
   for (auto &gs : proc.gpu_state_) {
     void *doorbell_page;
     size_t doorbell_page_size;
@@ -888,6 +894,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
     return alloc.host_ptr;
 
   void *host_ptr;
+  bool host_ptr_owned = true;
 
   if (alloc.memfd >= 0) {
     if (length > alloc.size) {
@@ -936,6 +943,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
     }
     if (reuse_pages) {
       host_ptr = addr;
+      host_ptr_owned = false;
     } else {
       int mflags = MAP_ANONYMOUS;
       mflags |= (flags & MAP_SHARED) ? MAP_SHARED : MAP_PRIVATE;
@@ -948,6 +956,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
   }
 
   alloc.host_ptr = host_ptr;
+  alloc.host_ptr_owned = host_ptr_owned;
 
   util::Logger::vm([&](auto &os) {
     os << std::format("mmap: gpu_va={:#x} host_ptr={:#x} size={} flags={:#x}"
@@ -1010,6 +1019,7 @@ int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
       unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
       syscall(SYS_munmap, addr, length);
       alloc.host_ptr = nullptr;
+      alloc.host_ptr_owned = false;
       return 0;
     }
   }
@@ -1143,7 +1153,9 @@ int SimulatedKfd::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
   alloc.user_va = user_provided_va;
 
   auto alloc_mtype = pte_mtype_for_flags(args->flags);
-  if ((args->flags & KFD_IOC_ALLOC_MEM_FLAGS_USERPTR) && !daemon_mode_) {
+  bool is_userptr = (args->flags & KFD_IOC_ALLOC_MEM_FLAGS_USERPTR) != 0;
+  bool is_doorbell = (args->flags & KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL) != 0;
+  if (is_userptr && !daemon_mode_) {
     alloc.host_ptr = reinterpret_cast<void *>(va);
     map_to_gpu(proc, va, reinterpret_cast<void *>(va), args->size, alloc_mtype);
   } else if (daemon_mode_ || !user_provided_va) {
@@ -1164,11 +1176,12 @@ int SimulatedKfd::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
         fallocate(alloc.memfd, 0, 0, static_cast<off_t>(alloc.size));
         fcntl(alloc.memfd, F_ADD_SEALS, F_SEAL_SHRINK);
 
-        if (daemon_mode_ && !(args->flags & KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL)) {
+        if (daemon_mode_ && !is_doorbell) {
           auto *mapped =
               safe_mmap(nullptr, alloc.size, PROT_READ | PROT_WRITE, MAP_SHARED, alloc.memfd, 0);
           if (mapped != MAP_FAILED) {
             alloc.host_ptr = mapped;
+            alloc.host_ptr_owned = true;
             map_to_gpu(proc, va, alloc.host_ptr, alloc.size, alloc_mtype);
           }
         }
@@ -1259,6 +1272,7 @@ bool SimulatedKfd::allocate_scratch_backing(uint32_t process_id, uint64_t gpu_va
     alloc.gpu_va = gpu_va;
     alloc.size = aligned_size;
     alloc.host_ptr = host_ptr;
+    alloc.host_ptr_owned = true;
     alloc.handle = proc->next_handle_++;
     alloc.memfd = -1;
     proc->allocations_[alloc.handle] = alloc;
@@ -1610,10 +1624,11 @@ int SimulatedKfd::ipc_export_handle_ioctl(KfdProcess &proc, void *arg) {
         }
       }
 
-      if (!(alloc.flags & KFD_IOC_ALLOC_MEM_FLAGS_USERPTR))
+      if (alloc.host_ptr_owned)
         syscall(SYS_munmap, alloc.host_ptr, alloc.size);
 
       alloc.host_ptr = new_host_ptr;
+      alloc.host_ptr_owned = true;
       alloc.memfd = promoted_fd;
       {
         std::lock_guard<std::mutex> flk(owned_fds_mutex_);
@@ -1748,6 +1763,7 @@ int SimulatedKfd::ipc_import_handle_ioctl(KfdProcess &proc, void *arg) {
     alloc.flags = alloc_flags;
     alloc.handle = handle;
     alloc.host_ptr = host_ptr;
+    alloc.host_ptr_owned = true;
     alloc.memfd = dup_fd;
     alloc.gpu_id = source_gpu_id;
     alloc.imported = true;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -99,6 +99,15 @@ std::shared_ptr<KfdProcess> SimulatedKfd::find_local_process() const {
   return find_process(local_process_id_);
 }
 
+uint32_t SimulatedKfd::alloc_flags_for_handle(uint64_t handle) const {
+  auto proc = find_process(local_process_id_);
+  if (!proc)
+    return 0;
+  std::lock_guard<std::mutex> lk(proc->alloc_mutex_);
+  auto it = proc->allocations_.find(handle);
+  return it != proc->allocations_.end() ? it->second.flags : 0;
+}
+
 void SimulatedKfd::map_to_gpu(KfdProcess &proc, uint64_t gpu_va, void *host_ptr, size_t size,
                               amdgpu::Mtype mtype) {
   util::Logger::cp("MAP pid=", proc.process_id(), " va=0x", std::hex, gpu_va, " size=0x", size,
@@ -1049,18 +1058,24 @@ int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
       }
     }
     if (is_doorbell) {
+      // Clear the CP's doorbell base for this process BEFORE munmapping the page.
+      // The doorbell poll thread reads and dereferences doorbell_base under the CP's
+      // hw_queue_mutex_ (scan_doorbells); if we munmapped first, the poll thread
+      // could deref the freed page in the window before the base is cleared and
+      // SIGSEGV. update_cp_doorbell_base takes hw_queue_mutex_, so once it returns
+      // no poll-thread reader can still observe the stale base, and the munmap below
+      // is safe.
+      //
+      // Both steps run AFTER releasing alloc_mutex_: the CP engine thread takes
+      // alloc_mutex_ under hw_queue_mutex_ (allocate_scratch_backing), so holding
+      // alloc_mutex_ across update_cp_doorbell_base (hw_queue_mutex_) would be an
+      // alloc_mutex_->hw_queue_mutex_ inversion that can deadlock.
+      update_cp_doorbell_base(doorbell_ord, proc.process_id(), nullptr);
       // Unmap the exact page we mapped: use the recorded doorbell page size, not
       // the caller-provided length. A length that differs from the tracked mapping
-      // would otherwise partially unmap the CPU page and leave it inconsistent
-      // with the GPU page-table unmap above. Both the munmap syscall and the CP
-      // notification run AFTER releasing alloc_mutex_: update_cp_doorbell_base
-      // takes the CP's hw_queue_mutex_, and the CP engine thread takes alloc_mutex_
-      // under hw_queue_mutex_ (allocate_scratch_backing), so holding alloc_mutex_
-      // here would be an alloc_mutex_->hw_queue_mutex_ inversion that can deadlock.
+      // would otherwise partially unmap the CPU page and leave it inconsistent with
+      // the GPU page-table unmap above.
       libc_passthrough().munmap(addr, doorbell_page_size ? doorbell_page_size : length);
-      // Clear the CP's doorbell base for this process: the page it pointed at is
-      // gone, so a stale base must not be dereferenced by the CP.
-      update_cp_doorbell_base(doorbell_ord, proc.process_id(), nullptr);
       return 0;
     }
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -112,6 +112,16 @@ void SimulatedKfd::unmap_from_gpu(KfdProcess &proc, uint64_t gpu_va, size_t size
   proc.unmap_pages(gpu_va, size);
 }
 
+void SimulatedKfd::update_cp_doorbell_base(uint32_t gpu_ordinal, uint32_t process_id, void *base) {
+  if (gpu_ordinal >= gpus_.size())
+    return;
+  auto &g = gpus_[gpu_ordinal];
+  if (!g.soc)
+    return;
+  g.soc->for_each_cp(
+      [=](amdgpu::CommandProcessor *cp) { cp->set_doorbell_base(process_id, base); });
+}
+
 std::string SimulatedKfd::redirect_sysfs_path(const char *path) const {
   auto result = redirect_sysfs_root_path(path, topology_path(), topology().drm_path());
   if (!result.empty()) {
@@ -645,100 +655,110 @@ int SimulatedKfd::dispatch_ioctl(KfdProcess &proc, unsigned long request, void *
   // signal to wake).
   if (proc.event_state_.is_closing())
     return -ESRCH;
-  switch (dispatch_request) {
-  case AMDKFD_IOC_GET_VERSION:
-    return get_version_ioctl(arg);
-  case AMDKFD_IOC_GET_CLOCK_COUNTERS:
-    return get_clock_counters_ioctl(arg);
-  case AMDKFD_IOC_GET_PROCESS_APERTURES_NEW:
-    return get_process_apertures_ioctl(arg);
-  case AMDKFD_IOC_ACQUIRE_VM:
-    return acquire_vm_ioctl(arg);
-  case AMDKFD_IOC_ALLOC_MEMORY_OF_GPU:
-    return alloc_memory_ioctl(proc, arg);
-  case AMDKFD_IOC_FREE_MEMORY_OF_GPU:
-    return free_memory_ioctl(proc, arg);
-  case AMDKFD_IOC_MAP_MEMORY_TO_GPU:
-    return map_memory_ioctl(proc, arg);
-  case AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU:
-    return unmap_memory_ioctl(proc, arg);
-  case AMDKFD_IOC_CREATE_QUEUE:
-    return create_queue_ioctl(proc, arg);
-  case AMDKFD_IOC_UPDATE_QUEUE:
-    return update_queue_ioctl(proc, arg);
-  case AMDKFD_IOC_DESTROY_QUEUE:
-    return destroy_queue_ioctl(proc, arg);
-  case AMDKFD_IOC_CREATE_EVENT:
-    return create_event_ioctl(proc, arg);
-  case AMDKFD_IOC_DESTROY_EVENT:
-    return destroy_event_ioctl(proc, arg);
-  case AMDKFD_IOC_SET_EVENT:
-    return set_event_ioctl(proc, arg);
-  case AMDKFD_IOC_RESET_EVENT:
-    return reset_event_ioctl(proc, arg);
-  // WAIT_EVENTS is handled before op_mutex_ above (it blocks on a condition
-  // variable and must not hold the per-process op lock), so it never reaches
-  // this switch.
-  case AMDKFD_IOC_SET_XNACK_MODE:
-    return set_xnack_mode_ioctl(arg);
-  case AMDKFD_IOC_SET_MEMORY_POLICY:
-    return set_memory_policy_ioctl(proc, arg);
-  case AMDKFD_IOC_AVAILABLE_MEMORY:
-    return get_available_memory_ioctl(proc, arg);
-  case AMDKFD_IOC_RUNTIME_ENABLE:
-    return runtime_enable_ioctl(proc, arg);
-  case AMDKFD_IOC_DBG_TRAP:
-    return debug_trap_ioctl(proc, arg);
-  case AMDKFD_IOC_SET_SCRATCH_BACKING_VA: {
-    auto *a = static_cast<kfd_ioctl_set_scratch_backing_va_args *>(arg);
-    uint32_t ord = gpu_ordinal(a->gpu_id);
-    {
-      std::lock_guard<std::mutex> plk(process_mutex_);
-      proc.gpu(ord).scratch_backing_va = a->va_addr;
+  auto dispatch_one = [&]() -> int {
+    switch (dispatch_request) {
+    case AMDKFD_IOC_GET_VERSION:
+      return get_version_ioctl(arg);
+    case AMDKFD_IOC_GET_CLOCK_COUNTERS:
+      return get_clock_counters_ioctl(arg);
+    case AMDKFD_IOC_GET_PROCESS_APERTURES_NEW:
+      return get_process_apertures_ioctl(arg);
+    case AMDKFD_IOC_ACQUIRE_VM:
+      return acquire_vm_ioctl(arg);
+    case AMDKFD_IOC_ALLOC_MEMORY_OF_GPU:
+      return alloc_memory_ioctl(proc, arg);
+    case AMDKFD_IOC_FREE_MEMORY_OF_GPU:
+      return free_memory_ioctl(proc, arg);
+    case AMDKFD_IOC_MAP_MEMORY_TO_GPU:
+      return map_memory_ioctl(proc, arg);
+    case AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU:
+      return unmap_memory_ioctl(proc, arg);
+    case AMDKFD_IOC_CREATE_QUEUE:
+      return create_queue_ioctl(proc, arg);
+    case AMDKFD_IOC_UPDATE_QUEUE:
+      return update_queue_ioctl(proc, arg);
+    case AMDKFD_IOC_DESTROY_QUEUE:
+      return destroy_queue_ioctl(proc, arg);
+    case AMDKFD_IOC_CREATE_EVENT:
+      return create_event_ioctl(proc, arg);
+    case AMDKFD_IOC_DESTROY_EVENT:
+      return destroy_event_ioctl(proc, arg);
+    case AMDKFD_IOC_SET_EVENT:
+      return set_event_ioctl(proc, arg);
+    case AMDKFD_IOC_RESET_EVENT:
+      return reset_event_ioctl(proc, arg);
+    // WAIT_EVENTS is handled before op_mutex_ above (it blocks on a condition
+    // variable and must not hold the per-process op lock), so it never reaches
+    // this switch.
+    case AMDKFD_IOC_SET_XNACK_MODE:
+      return set_xnack_mode_ioctl(arg);
+    case AMDKFD_IOC_SET_MEMORY_POLICY:
+      return set_memory_policy_ioctl(proc, arg);
+    case AMDKFD_IOC_AVAILABLE_MEMORY:
+      return get_available_memory_ioctl(proc, arg);
+    case AMDKFD_IOC_RUNTIME_ENABLE:
+      return runtime_enable_ioctl(proc, arg);
+    case AMDKFD_IOC_DBG_TRAP:
+      return debug_trap_ioctl(proc, arg);
+    case AMDKFD_IOC_SET_SCRATCH_BACKING_VA: {
+      auto *a = static_cast<kfd_ioctl_set_scratch_backing_va_args *>(arg);
+      uint32_t ord = gpu_ordinal(a->gpu_id);
+      {
+        std::lock_guard<std::mutex> plk(process_mutex_);
+        proc.gpu(ord).scratch_backing_va = a->va_addr;
+      }
+      util::Logger::vm([&](auto &os) {
+        os << "SET_SCRATCH_BACKING_VA pid=" << proc.process_id() << " gpu_id=" << a->gpu_id
+           << " va=" << std::hex << a->va_addr << std::dec;
+      });
+      return 0;
     }
-    util::Logger::vm([&](auto &os) {
-      os << "SET_SCRATCH_BACKING_VA pid=" << proc.process_id() << " gpu_id=" << a->gpu_id
-         << " va=" << std::hex << a->va_addr << std::dec;
+    case AMDKFD_IOC_SET_TRAP_HANDLER: {
+      auto *a = static_cast<kfd_ioctl_set_trap_handler_args *>(arg);
+      uint32_t ord = gpu_ordinal(a->gpu_id);
+      {
+        // Held under process_mutex_ for symmetry with SET_SCRATCH_BACKING_VA and
+        // to be race-free once the trap handler is wired into the SoC. NOTE: as of
+        // now trap_tba_addr/trap_tma_addr have no reader anywhere (the CP does not
+        // yet consume them), so this lock currently guards against a non-existent
+        // concurrent access — kept for forward-compatibility.
+        std::lock_guard<std::mutex> plk(process_mutex_);
+        proc.gpu(ord).trap_tba_addr = a->tba_addr;
+        proc.gpu(ord).trap_tma_addr = a->tma_addr;
+      }
+      return 0;
+    }
+    case AMDKFD_IOC_GET_TILE_CONFIG:
+      return get_tile_config_ioctl(arg);
+    case AMDKFD_IOC_GET_DMABUF_INFO:
+      return get_dmabuf_info_ioctl(proc, arg);
+    case AMDKFD_IOC_IMPORT_DMABUF:
+      return import_dmabuf_ioctl(proc, arg);
+    case AMDKFD_IOC_EXPORT_DMABUF:
+      return export_dmabuf_ioctl(proc, arg);
+    case AMDKFD_IOC_IPC_EXPORT_HANDLE:
+      return ipc_export_handle_ioctl(proc, arg);
+    case AMDKFD_IOC_IPC_IMPORT_HANDLE:
+      return ipc_import_handle_ioctl(proc, arg);
+    case AMDKFD_IOC_SVM:
+      // SVM requests carry a trailing attribute array, so libhsakmt sets _IOC_SIZE
+      // to the actual buffer size. canonical_ioctl_request() lets this follow the
+      // normal switch-dispatch style while still accepting those runtime-sized
+      // request values.
+      return svm_ioctl(proc, arg);
+    default:
+      util::Logger::debug_print("rocjitsu: unhandled ioctl 0x", std::hex, request);
+      return 0;
+    }
+  };
+  int ret = dispatch_one();
+  if (ret != 0) {
+    util::Logger::driver([&](auto &os) {
+      os << std::format("IOCTL_ERROR pid={} {} ret={}", proc.process_id(), ioctl_name(request),
+                        ret);
     });
-    return 0;
   }
-  case AMDKFD_IOC_SET_TRAP_HANDLER: {
-    auto *a = static_cast<kfd_ioctl_set_trap_handler_args *>(arg);
-    uint32_t ord = gpu_ordinal(a->gpu_id);
-    {
-      // Held under process_mutex_ for symmetry with SET_SCRATCH_BACKING_VA and to
-      // be race-free once the trap handler is wired into the SoC. NOTE: as of now
-      // trap_tba_addr/trap_tma_addr have no reader anywhere (the CP does not yet
-      // consume them), so this lock currently guards against a non-existent
-      // concurrent access — kept for forward-compatibility.
-      std::lock_guard<std::mutex> plk(process_mutex_);
-      proc.gpu(ord).trap_tba_addr = a->tba_addr;
-      proc.gpu(ord).trap_tma_addr = a->tma_addr;
-    }
-    return 0;
-  }
-  case AMDKFD_IOC_GET_TILE_CONFIG:
-    return get_tile_config_ioctl(arg);
-  case AMDKFD_IOC_GET_DMABUF_INFO:
-    return get_dmabuf_info_ioctl(proc, arg);
-  case AMDKFD_IOC_IMPORT_DMABUF:
-    return import_dmabuf_ioctl(proc, arg);
-  case AMDKFD_IOC_EXPORT_DMABUF:
-    return export_dmabuf_ioctl(proc, arg);
-  case AMDKFD_IOC_IPC_EXPORT_HANDLE:
-    return ipc_export_handle_ioctl(proc, arg);
-  case AMDKFD_IOC_IPC_IMPORT_HANDLE:
-    return ipc_import_handle_ioctl(proc, arg);
-  case AMDKFD_IOC_SVM:
-    // SVM requests carry a trailing attribute array, so libhsakmt sets _IOC_SIZE
-    // to the actual buffer size. canonical_ioctl_request() lets this follow the
-    // normal switch-dispatch style while still accepting those runtime-sized
-    // request values.
-    return svm_ioctl(proc, arg);
-  default:
-    util::Logger::debug_print("rocjitsu: unhandled ioctl 0x", std::hex, request);
-    return 0;
-  }
+  return ret;
 }
 
 void *SimulatedKfd::mmap(void *addr, size_t length, int prot, int flags, off_t offset) {
@@ -766,7 +786,6 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
         (static_cast<uint64_t>(offset) & ~KFD_MMAP_TYPE_MASK) >> KFD_MMAP_GPU_ID_SHIFT;
     uint32_t db_gpu_id = static_cast<uint32_t>(encoded_gpu);
     uint32_t ord = gpu_ordinal(db_gpu_id);
-    auto *gpu = find_gpu(db_gpu_id);
 
     int doorbell_fd = -1;
     {
@@ -851,9 +870,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
       // Use the local ptr (== the doorbell_gpu_va just written) rather than
       // re-reading gs.doorbell_gpu_va without alloc_mutex_.
       map_to_gpu(proc, reinterpret_cast<uint64_t>(ptr), ptr, length, amdgpu::Mtype::UC);
-      if (gpu && gpu->soc)
-        gpu->soc->for_each_cp(
-            [&](amdgpu::CommandProcessor *cp) { cp->set_doorbell_base(proc.process_id(), ptr); });
+      update_cp_doorbell_base(ord, proc.process_id(), ptr);
     }
     return ptr;
   }
@@ -1006,27 +1023,45 @@ int SimulatedKfd::munmap(uint32_t process_id, void *addr, size_t length) {
 
 int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
   {
-    std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
-    for (auto &gs : proc.gpu_state_) {
-      if (gs.doorbell_page == addr) {
-        if (!proc.event_state_.is_closing()) {
-          errno = EPERM;
-          return -1;
+    uint32_t doorbell_ord = 0;
+    size_t doorbell_page_size = 0;
+    bool is_doorbell = false;
+    {
+      std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
+      for (size_t ord = 0; ord < proc.gpu_state_.size(); ++ord) {
+        auto &gs = proc.gpu(ord);
+        if (gs.doorbell_page == addr) {
+          if (!proc.event_state_.is_closing()) {
+            errno = EPERM;
+            return -1;
+          }
+          uint64_t gpu_va = gs.doorbell_gpu_va;
+          doorbell_page_size = gs.doorbell_page_size;
+          gs.doorbell_page = nullptr;
+          gs.doorbell_gpu_va = 0;
+          gs.doorbell_page_size = 0;
+          if (gpu_va && doorbell_page_size)
+            unmap_from_gpu(proc, gpu_va, doorbell_page_size);
+          doorbell_ord = static_cast<uint32_t>(ord);
+          is_doorbell = true;
+          break;
         }
-        uint64_t gpu_va = gs.doorbell_gpu_va;
-        size_t page_size = gs.doorbell_page_size;
-        gs.doorbell_page = nullptr;
-        gs.doorbell_gpu_va = 0;
-        gs.doorbell_page_size = 0;
-        if (gpu_va && page_size)
-          unmap_from_gpu(proc, gpu_va, page_size);
-        // Unmap the exact page we mapped: use the recorded doorbell page size,
-        // not the caller-provided length. A length that differs from the tracked
-        // mapping would otherwise partially unmap the CPU page and leave it
-        // inconsistent with the GPU page-table unmap above.
-        libc_passthrough().munmap(addr, page_size ? page_size : length);
-        return 0;
       }
+    }
+    if (is_doorbell) {
+      // Unmap the exact page we mapped: use the recorded doorbell page size, not
+      // the caller-provided length. A length that differs from the tracked mapping
+      // would otherwise partially unmap the CPU page and leave it inconsistent
+      // with the GPU page-table unmap above. Both the munmap syscall and the CP
+      // notification run AFTER releasing alloc_mutex_: update_cp_doorbell_base
+      // takes the CP's hw_queue_mutex_, and the CP engine thread takes alloc_mutex_
+      // under hw_queue_mutex_ (allocate_scratch_backing), so holding alloc_mutex_
+      // here would be an alloc_mutex_->hw_queue_mutex_ inversion that can deadlock.
+      libc_passthrough().munmap(addr, doorbell_page_size ? doorbell_page_size : length);
+      // Clear the CP's doorbell base for this process: the page it pointed at is
+      // gone, so a stale base must not be dereferenced by the CP.
+      update_cp_doorbell_base(doorbell_ord, proc.process_id(), nullptr);
+      return 0;
     }
   }
   // release_page() clears page/page_size under EventState::mutex_, the same lock
@@ -1065,8 +1100,13 @@ int SimulatedKfd::get_process_apertures_ioctl(void *arg) {
     apertures[i].lds_limit = apertures[i].lds_base + 0xFFFFFFFFULL;
     apertures[i].scratch_base = 0x2000000000000ULL + static_cast<uint64_t>(i) * 0x10000000000ULL;
     apertures[i].scratch_limit = apertures[i].scratch_base + 0xFFFFFFFFULL;
-    apertures[i].gpuvm_base = 0x1000000000ULL;
-    apertures[i].gpuvm_limit = 0x3FFFFFFFFFFFULL;
+    // Wide GPUVM aperture: rocjitsu maps GPU VAs directly to host pointers (the
+    // doorbell base and GEM_VA mappings publish reinterpret_cast<uint64_t>(ptr) as
+    // the GPU VA), so this aperture must span the host address range the runtime
+    // validates VAs against — hence a low base and a 47-bit limit rather than the
+    // narrower hardware GPUVM window.
+    apertures[i].gpuvm_base = 0x10000ULL;
+    apertures[i].gpuvm_limit = 0x7FFFFFFFFFFFULL;
     apertures[i].gpu_id = gpus_[i].gpu_id;
     apertures[i].pad = 0;
   }
@@ -1221,6 +1261,10 @@ int SimulatedKfd::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
     args->mmap_offset = alloc.handle << 12;
   }
 
+  util::Logger::cp([&](auto &os) {
+    os << std::format("ALLOC_MEMORY handle={} gpu_va={:#x} size={:#x} flags={:#x}", alloc.handle,
+                      va, args->size, args->flags);
+  });
   util::Logger::vm([&](auto &os) {
     os << std::format(
         "ALLOC pid={} handle={} gpu_va={:#x} size={} flags={:#x} memfd={} host_ptr={}",
@@ -1359,13 +1403,16 @@ int SimulatedKfd::map_memory_ioctl(KfdProcess &proc, void *arg) {
 
   std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
   auto it = proc.allocations_.find(args->handle);
-  if (it == proc.allocations_.end())
+  if (it == proc.allocations_.end()) {
+    util::Logger::cp(
+        [&](auto &os) { os << std::format("MAP_MEMORY_FAIL handle={} not found", args->handle); });
     return -EINVAL;
+  }
   auto &alloc = it->second;
-  util::Logger::vm([&](auto &os) {
-    os << std::format("MAP_MEMORY handle={} gpu_va={:#x} size={} flags={:#x} host_ptr={:#x}",
-                      alloc.handle, alloc.gpu_va, alloc.size, alloc.flags,
-                      reinterpret_cast<uintptr_t>(alloc.host_ptr));
+  util::Logger::cp([&](auto &os) {
+    os << std::format("MAP_MEMORY handle={} gpu_va={:#x} size={:#x} n_devices={} host_ptr={}",
+                      alloc.handle, alloc.gpu_va, alloc.size, args->n_devices,
+                      alloc.host_ptr != nullptr);
   });
   if (alloc.host_ptr)
     map_to_gpu(proc, alloc.gpu_va, alloc.host_ptr, alloc.size, pte_mtype_for_flags(alloc.flags));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -49,8 +49,9 @@ bool vm_trace_enabled() {
 constexpr uint32_t kTileConfigCount = 32;
 constexpr uint32_t kMacroTileConfigCount = 16;
 
-/// @brief Derive PTE MTYPE from KFD allocation flags (mirrors amdgpu driver).
-amdgpu::Mtype pte_mtype_for_flags(uint32_t flags) {
+} // namespace
+
+amdgpu::Mtype SimulatedKfd::pte_mtype_for_flags(uint32_t flags) {
   if (flags & KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED)
     return amdgpu::Mtype::UC;
   if (flags & (KFD_IOC_ALLOC_MEM_FLAGS_GTT | KFD_IOC_ALLOC_MEM_FLAGS_USERPTR))
@@ -61,6 +62,22 @@ amdgpu::Mtype pte_mtype_for_flags(uint32_t flags) {
     return amdgpu::Mtype::CC;
   return amdgpu::Mtype::RW;
 }
+
+void SimulatedKfd::gem_va_map(uint64_t gpu_va, void *host_ptr, size_t size, uint32_t alloc_flags) {
+  auto proc = find_process(local_process_id_);
+  if (!proc)
+    return;
+  map_to_gpu(*proc, gpu_va, host_ptr, size, pte_mtype_for_flags(alloc_flags));
+}
+
+void SimulatedKfd::gem_va_unmap(uint64_t gpu_va, size_t size) {
+  auto proc = find_process(local_process_id_);
+  if (!proc)
+    return;
+  unmap_from_gpu(*proc, gpu_va, size);
+}
+
+namespace {
 
 /// @brief mmap via the real libc, bypassing the interposer.
 /// @details Routes through the process-wide libc_passthrough() table so the

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -4,6 +4,7 @@
 #include "rocjitsu/kmd/linux/simulated_kfd.h"
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
 #include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
+#include "rocjitsu/kmd/linux/libc_passthrough.h"
 #include "rocjitsu/vm/amdgpu/command_processor.h"
 
 #include "rocjitsu/base/rj_compiler.h"
@@ -16,6 +17,7 @@ RJ_DIAGNOSTIC_POP
 #include "util/log.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cerrno>
 #include <cstdint>
 #include <cstdlib>
@@ -28,7 +30,6 @@ RJ_DIAGNOSTIC_POP
 #include <sys/random.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
-#include <sys/syscall.h>
 #ifndef MADV_POPULATE_WRITE
 #define MADV_POPULATE_WRITE 23
 #endif
@@ -61,11 +62,12 @@ amdgpu::Mtype pte_mtype_for_flags(uint32_t flags) {
   return amdgpu::Mtype::RW;
 }
 
+/// @brief mmap via the real libc, bypassing the interposer.
+/// @details Routes through the process-wide libc_passthrough() table so the
+/// driver's own mappings never re-enter the interposer's mmap hook. The table is
+/// resolved once in the SimulatedKfd constructor.
 void *safe_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
-  long rc = syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
-  if (rc < 0)
-    return MAP_FAILED;
-  return reinterpret_cast<void *>(static_cast<uintptr_t>(rc));
+  return libc_passthrough().mmap(addr, length, prot, flags, fd, offset);
 }
 
 } // namespace
@@ -124,11 +126,16 @@ void SimulatedKfd::setup_topology(const config::KfdDeviceConfig &dev, uint32_t n
 }
 
 SimulatedKfd::SimulatedKfd(SoC &soc, bool daemon_mode) : daemon_mode_(daemon_mode) {
+  // Resolve the real libc entry points once, up front and single-threaded, so no
+  // passthrough call site ever triggers a first-time dlsym under a per-process
+  // lock. Idempotent: a no-op if the interposer already resolved the table.
+  libc_passthrough().resolve();
   gpus_.push_back({&soc, 0, false, {}});
 }
 
 SimulatedKfd::SimulatedKfd(std::vector<SoC *> socs, std::vector<uint32_t> gpu_ids, bool daemon_mode)
     : daemon_mode_(daemon_mode) {
+  libc_passthrough().resolve();
   for (size_t i = 0; i < socs.size(); ++i)
     gpus_.push_back({socs[i], i < gpu_ids.size() ? gpu_ids[i] : socs[i]->gpu_id(), false, {}});
 }
@@ -217,7 +224,7 @@ bool SimulatedKfd::is_doorbell_range(const void *addr, size_t length) const {
 bool SimulatedKfd::ensure_fd_created() {
   if (fd_.load(std::memory_order_acquire) >= 0)
     return true;
-  int new_fd = static_cast<int>(syscall(SYS_memfd_create, "rocjitsu_kfd", 0));
+  int new_fd = memfd_create("rocjitsu_kfd", 0);
   if (new_fd < 0)
     return false;
   int expected = -1;
@@ -225,7 +232,7 @@ bool SimulatedKfd::ensure_fd_created() {
   // its own memfd and adopts the winner's, avoiding a double create / fd leak.
   if (!fd_.compare_exchange_strong(expected, new_fd, std::memory_order_acq_rel,
                                    std::memory_order_acquire))
-    syscall(SYS_close, new_fd);
+    libc_passthrough().close(new_fd);
   return true;
 }
 
@@ -499,7 +506,7 @@ int SimulatedKfd::close(uint32_t process_id) {
         leaked_handles.push_back(handle);
       if (alloc.host_ptr && alloc.host_ptr_owned) {
         unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
-        syscall(SYS_munmap, alloc.host_ptr, alloc.size);
+        libc_passthrough().munmap(alloc.host_ptr, alloc.size);
         alloc.host_ptr = nullptr;
         alloc.host_ptr_owned = false;
       }
@@ -508,7 +515,7 @@ int SimulatedKfd::close(uint32_t process_id) {
           std::lock_guard<std::mutex> flk(owned_fds_mutex_);
           owned_fds_.erase(alloc.memfd);
         }
-        syscall(SYS_close, alloc.memfd);
+        libc_passthrough().close(alloc.memfd);
         alloc.memfd = -1;
       }
     }
@@ -544,7 +551,7 @@ int SimulatedKfd::close(uint32_t process_id) {
       gs.doorbell_page_size = 0;
     }
     if (doorbell_page && doorbell_page_size)
-      syscall(SYS_munmap, doorbell_page, doorbell_page_size);
+      libc_passthrough().munmap(doorbell_page, doorbell_page_size);
   }
 
   leaked_queues = queue_ids.size();
@@ -578,7 +585,7 @@ int SimulatedKfd::close(uint32_t process_id) {
     for (auto &[handle, dmabuf] : proc.imported_dmabufs_) {
       [[maybe_unused]] auto &_ = handle;
       if (dmabuf.fd >= 0)
-        syscall(SYS_close, dmabuf.fd);
+        libc_passthrough().close(dmabuf.fd);
     }
     proc.imported_dmabufs_.clear();
     // Clear the reverse fd->handle map too, so it stays consistent with
@@ -777,7 +784,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
           safe_mmap(nullptr, length, PROT_WRITE, MAP_SHARED, doorbell_fd, 0));
       if (init_ptr != MAP_FAILED) {
         std::memset(init_ptr, 0xFF, length);
-        syscall(SYS_munmap, init_ptr, length);
+        libc_passthrough().munmap(init_ptr, length);
       }
     }
 
@@ -815,7 +822,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
         // set by close() under op_mutex_, which we now hold, so this check is
         // race-free against teardown.
         if (proc.event_state_.is_closing()) {
-          syscall(SYS_munmap, ptr, length);
+          libc_passthrough().munmap(ptr, length);
           errno = ENODEV;
           return MAP_FAILED;
         }
@@ -836,15 +843,14 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
 
   if (type == KFD_MMAP_TYPE_EVENTS) {
     if (proc.event_state_.memfd < 0) {
-      auto raw_events_fd = static_cast<int>(
-          syscall(SYS_memfd_create, "rocjitsu_events", MFD_CLOEXEC | MFD_ALLOW_SEALING));
+      auto raw_events_fd = memfd_create("rocjitsu_events", MFD_CLOEXEC | MFD_ALLOW_SEALING);
       if (raw_events_fd < 0)
         return MAP_FAILED;
       proc.event_state_.memfd = fcntl(raw_events_fd, F_DUPFD_CLOEXEC, 4096);
       if (proc.event_state_.memfd < 0)
         proc.event_state_.memfd = raw_events_fd;
       else
-        syscall(SYS_close, raw_events_fd);
+        libc_passthrough().close(raw_events_fd);
       {
         std::lock_guard<std::mutex> lk(owned_fds_mutex_);
         owned_fds_.insert(proc.event_state_.memfd);
@@ -854,7 +860,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
           std::lock_guard<std::mutex> lk(owned_fds_mutex_);
           owned_fds_.erase(proc.event_state_.memfd);
         }
-        syscall(SYS_close, proc.event_state_.memfd);
+        libc_passthrough().close(proc.event_state_.memfd);
         proc.event_state_.memfd = -1;
         return MAP_FAILED;
       }
@@ -863,9 +869,9 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
         auto *init_ptr = static_cast<uint8_t *>(
             safe_mmap(nullptr, length, PROT_WRITE, MAP_SHARED, proc.event_state_.memfd, 0));
         if (init_ptr != MAP_FAILED) {
-          syscall(SYS_madvise, init_ptr, length, MADV_POPULATE_WRITE);
+          libc_passthrough().madvise(init_ptr, length, MADV_POPULATE_WRITE);
           std::memset(init_ptr, 0xFF, length);
-          syscall(SYS_munmap, init_ptr, length);
+          libc_passthrough().munmap(init_ptr, length);
         }
       }
       fcntl(proc.event_state_.memfd, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW);
@@ -904,12 +910,12 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
       }
     }
     if (alloc.user_va && (flags & MAP_FIXED) && addr != nullptr) {
-      auto prot_rc = syscall(SYS_mprotect, addr, length, PROT_READ | PROT_WRITE);
+      auto prot_rc = libc_passthrough().mprotect(addr, length, PROT_READ | PROT_WRITE);
       if (prot_rc == 0) {
         constexpr size_t page_size = 4096;
         size_t num_pages = (length + page_size - 1) / page_size;
         std::vector<uint8_t> page_resident(num_pages);
-        auto mc_rc = syscall(SYS_mincore, addr, length, page_resident.data());
+        auto mc_rc = mincore(addr, length, page_resident.data());
 
         auto *temp_mapping = static_cast<uint8_t *>(
             safe_mmap(nullptr, length, PROT_WRITE, MAP_SHARED, alloc.memfd, 0));
@@ -924,7 +930,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
               }
             }
           }
-          syscall(SYS_munmap, temp_mapping, length);
+          libc_passthrough().munmap(temp_mapping, length);
         }
       }
     }
@@ -938,7 +944,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
   } else {
     bool reuse_pages = false;
     if (alloc.user_va && (flags & MAP_FIXED) && addr != nullptr) {
-      auto rc = syscall(SYS_mprotect, addr, length, PROT_READ | PROT_WRITE);
+      auto rc = libc_passthrough().mprotect(addr, length, PROT_READ | PROT_WRITE);
       reuse_pages = (rc == 0);
     }
     if (reuse_pages) {
@@ -1001,7 +1007,7 @@ int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
         // not the caller-provided length. A length that differs from the tracked
         // mapping would otherwise partially unmap the CPU page and leave it
         // inconsistent with the GPU page-table unmap above.
-        syscall(SYS_munmap, addr, page_size ? page_size : length);
+        libc_passthrough().munmap(addr, page_size ? page_size : length);
         return 0;
       }
     }
@@ -1010,14 +1016,14 @@ int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
   // the CP interrupt thread holds when reading them in signal_interrupt, so the
   // munmap below cannot race a concurrent signal writing into the mapping.
   if (proc.event_state_.release_page(addr)) {
-    syscall(SYS_munmap, addr, length);
+    libc_passthrough().munmap(addr, length);
     return 0;
   }
   std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
   for (auto &[handle, alloc] : proc.allocations_) {
     if (alloc.host_ptr == addr) {
       unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
-      syscall(SYS_munmap, addr, length);
+      libc_passthrough().munmap(addr, length);
       alloc.host_ptr = nullptr;
       alloc.host_ptr_owned = false;
       return 0;
@@ -1159,14 +1165,13 @@ int SimulatedKfd::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
     alloc.host_ptr = reinterpret_cast<void *>(va);
     map_to_gpu(proc, va, reinterpret_cast<void *>(va), args->size, alloc_mtype);
   } else if (daemon_mode_ || !user_provided_va) {
-    auto raw_fd = static_cast<int>(
-        syscall(SYS_memfd_create, "rocjitsu_alloc", MFD_CLOEXEC | MFD_ALLOW_SEALING));
+    auto raw_fd = memfd_create("rocjitsu_alloc", MFD_CLOEXEC | MFD_ALLOW_SEALING);
     if (raw_fd >= 0) {
       alloc.memfd = fcntl(raw_fd, F_DUPFD_CLOEXEC, 4096);
       if (alloc.memfd < 0)
         alloc.memfd = raw_fd;
       else
-        syscall(SYS_close, raw_fd);
+        libc_passthrough().close(raw_fd);
       {
         std::lock_guard<std::mutex> lk(owned_fds_mutex_);
         owned_fds_.insert(alloc.memfd);
@@ -1227,7 +1232,7 @@ bool SimulatedKfd::allocate_scratch_backing(uint32_t process_id, uint64_t gpu_va
     return false;
 
   size_t aligned_size = (size + 0xFFF) & ~0xFFFULL;
-  auto raw_fd = static_cast<int>(syscall(SYS_memfd_create, "rocjitsu_scratch", MFD_CLOEXEC));
+  auto raw_fd = memfd_create("rocjitsu_scratch", MFD_CLOEXEC);
   if (raw_fd < 0)
     return false;
 
@@ -1235,7 +1240,7 @@ bool SimulatedKfd::allocate_scratch_backing(uint32_t process_id, uint64_t gpu_va
   if (memfd < 0)
     memfd = raw_fd;
   else
-    syscall(SYS_close, raw_fd);
+    libc_passthrough().close(raw_fd);
   {
     std::lock_guard<std::mutex> lk(owned_fds_mutex_);
     owned_fds_.insert(memfd);
@@ -1246,7 +1251,7 @@ bool SimulatedKfd::allocate_scratch_backing(uint32_t process_id, uint64_t gpu_va
       std::lock_guard<std::mutex> lk(owned_fds_mutex_);
       owned_fds_.erase(memfd);
     }
-    syscall(SYS_close, memfd);
+    libc_passthrough().close(memfd);
     return false;
   }
   auto *host_ptr = safe_mmap(nullptr, aligned_size, PROT_READ | PROT_WRITE, MAP_SHARED, memfd, 0);
@@ -1255,14 +1260,14 @@ bool SimulatedKfd::allocate_scratch_backing(uint32_t process_id, uint64_t gpu_va
       std::lock_guard<std::mutex> lk(owned_fds_mutex_);
       owned_fds_.erase(memfd);
     }
-    syscall(SYS_close, memfd);
+    libc_passthrough().close(memfd);
     return false;
   }
   {
     std::lock_guard<std::mutex> lk(owned_fds_mutex_);
     owned_fds_.erase(memfd);
   }
-  syscall(SYS_close, memfd);
+  libc_passthrough().close(memfd);
   std::memset(host_ptr, 0, aligned_size);
   proc->map_pages(gpu_va, host_ptr, aligned_size);
 
@@ -1294,7 +1299,7 @@ int SimulatedKfd::free_memory_ioctl(KfdProcess &proc, void *arg) {
   if (it != proc.allocations_.end()) {
     auto &alloc = it->second;
     if (alloc.imported && alloc.dmabuf_fd >= 0) {
-      syscall(SYS_close, alloc.dmabuf_fd);
+      libc_passthrough().close(alloc.dmabuf_fd);
       if (auto dmabuf_it = proc.imported_dmabufs_.find(args->handle);
           dmabuf_it != proc.imported_dmabufs_.end()) {
         proc.fd_to_import_handle_.erase(dmabuf_it->second.fd);
@@ -1308,7 +1313,7 @@ int SimulatedKfd::free_memory_ioctl(KfdProcess &proc, void *arg) {
         std::lock_guard<std::mutex> lk(owned_fds_mutex_);
         owned_fds_.erase(alloc.memfd);
       }
-      syscall(SYS_close, alloc.memfd);
+      libc_passthrough().close(alloc.memfd);
     }
 
     uint32_t freed_process_id = proc.process_id();
@@ -1321,7 +1326,7 @@ int SimulatedKfd::free_memory_ioctl(KfdProcess &proc, void *arg) {
         if (ipc_it->second.source_process_id == freed_process_id &&
             ipc_it->second.source_alloc_handle == freed_handle) {
           if (ipc_it->second.backing_memfd >= 0)
-            syscall(SYS_close, ipc_it->second.backing_memfd);
+            libc_passthrough().close(ipc_it->second.backing_memfd);
           ipc_it = ipc_store_.erase(ipc_it);
         } else {
           ++ipc_it;
@@ -1591,18 +1596,17 @@ int SimulatedKfd::ipc_export_handle_ioctl(KfdProcess &proc, void *arg) {
     auto &alloc = it->second;
 
     if (alloc.memfd < 0 && alloc.host_ptr) {
-      int promoted_fd = static_cast<int>(
-          syscall(SYS_memfd_create, "rocjitsu_ipc_promote", MFD_CLOEXEC | MFD_ALLOW_SEALING));
+      int promoted_fd = memfd_create("rocjitsu_ipc_promote", MFD_CLOEXEC | MFD_ALLOW_SEALING);
       if (promoted_fd < 0)
         return -errno;
       if (ftruncate(promoted_fd, static_cast<off_t>(alloc.size)) != 0) {
-        syscall(SYS_close, promoted_fd);
+        libc_passthrough().close(promoted_fd);
         return -errno;
       }
       auto *new_host_ptr =
           safe_mmap(nullptr, alloc.size, PROT_READ | PROT_WRITE, MAP_SHARED, promoted_fd, 0);
       if (new_host_ptr == MAP_FAILED) {
-        syscall(SYS_close, promoted_fd);
+        libc_passthrough().close(promoted_fd);
         return -ENOMEM;
       }
       std::memcpy(new_host_ptr, alloc.host_ptr, alloc.size);
@@ -1625,7 +1629,7 @@ int SimulatedKfd::ipc_export_handle_ioctl(KfdProcess &proc, void *arg) {
       }
 
       if (alloc.host_ptr_owned)
-        syscall(SYS_munmap, alloc.host_ptr, alloc.size);
+        libc_passthrough().munmap(alloc.host_ptr, alloc.size);
 
       alloc.host_ptr = new_host_ptr;
       alloc.host_ptr_owned = true;
@@ -1635,12 +1639,11 @@ int SimulatedKfd::ipc_export_handle_ioctl(KfdProcess &proc, void *arg) {
         owned_fds_.insert(promoted_fd);
       }
     } else if (alloc.memfd < 0) {
-      int new_fd = static_cast<int>(
-          syscall(SYS_memfd_create, "rocjitsu_ipc_lazy", MFD_CLOEXEC | MFD_ALLOW_SEALING));
+      int new_fd = memfd_create("rocjitsu_ipc_lazy", MFD_CLOEXEC | MFD_ALLOW_SEALING);
       if (new_fd < 0)
         return -errno;
       if (ftruncate(new_fd, static_cast<off_t>(alloc.size)) != 0) {
-        syscall(SYS_close, new_fd);
+        libc_passthrough().close(new_fd);
         return -errno;
       }
       alloc.memfd = new_fd;
@@ -1675,7 +1678,7 @@ int SimulatedKfd::ipc_export_handle_ioctl(KfdProcess &proc, void *arg) {
 
   IpcHandleKey key{};
   if (getrandom(key.words, sizeof(key.words), 0) != sizeof(key.words)) {
-    syscall(SYS_close, dup_fd);
+    libc_passthrough().close(dup_fd);
     return -errno;
   }
 
@@ -1741,7 +1744,7 @@ int SimulatedKfd::ipc_import_handle_ioctl(KfdProcess &proc, void *arg) {
       std::lock_guard<std::mutex> flk(owned_fds_mutex_);
       owned_fds_.erase(dup_fd);
     }
-    syscall(SYS_close, dup_fd);
+    libc_passthrough().close(dup_fd);
     return -ENOMEM;
   }
 
@@ -2082,8 +2085,8 @@ int SimulatedKfd::claim_fd(int real_fd) {
     init_reserved_fd_range();
   int vfd = next_reserved_fd_++;
   assert(vfd < reserved_fd_base_ + kReservedFdCount && "reserved fd range exhausted");
-  syscall(SYS_dup2, real_fd, vfd);
-  syscall(SYS_close, real_fd);
+  libc_passthrough().dup2(real_fd, vfd);
+  libc_passthrough().close(real_fd);
   return vfd;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -89,6 +89,23 @@ void *safe_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t of
   return libc_passthrough().mmap(addr, length, prot, flags, fd, offset);
 }
 
+/// @brief fstat via the real libc, bypassing the interposer.
+/// @details Like safe_mmap: the interposer exports fstat with default visibility,
+/// so a bare fstat() from this TU binds to our own hook (which takes fd_mutex_ via
+/// is_drm()). Routing through the passthrough table keeps "the driver never
+/// re-enters the interposer" total and avoids acquiring fd_mutex_ under a held
+/// per-process lock (alloc_mutex_/etc.).
+int safe_fstat(int fd, struct stat *st) { return libc_passthrough().fstat_fn(fd, st); }
+
+/// @brief fcntl via the real libc, bypassing the interposer.
+/// @details The interposer's fcntl hook takes fd_mutex_ on F_DUPFD paths; calling
+/// it from the driver while holding a per-process lock is a latent lock-order
+/// inversion. The passthrough table's fcntl is variadic; the int-arg forms
+/// (F_DUPFD_CLOEXEC, F_ADD_SEALS, F_GETFL/no-arg) used here forward cleanly.
+template <typename... Args> int safe_fcntl(int fd, int cmd, Args... args) {
+  return libc_passthrough().fcntl(fd, cmd, args...);
+}
+
 } // namespace
 
 std::shared_ptr<KfdProcess> SimulatedKfd::find_process(uint32_t process_id) const {
@@ -813,7 +830,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
       off_t cur_size = 0;
       {
         struct stat st {};
-        if (fstat(doorbell_fd, &st) == 0)
+        if (safe_fstat(doorbell_fd, &st) == 0)
           cur_size = st.st_size;
       }
       if (static_cast<off_t>(length) > cur_size) {
@@ -891,7 +908,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
       auto raw_events_fd = memfd_create("rocjitsu_events", MFD_CLOEXEC | MFD_ALLOW_SEALING);
       if (raw_events_fd < 0)
         return MAP_FAILED;
-      proc.event_state_.memfd = fcntl(raw_events_fd, F_DUPFD_CLOEXEC, 4096);
+      proc.event_state_.memfd = safe_fcntl(raw_events_fd, F_DUPFD_CLOEXEC, 4096);
       if (proc.event_state_.memfd < 0)
         proc.event_state_.memfd = raw_events_fd;
       else
@@ -919,7 +936,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
           libc_passthrough().munmap(init_ptr, length);
         }
       }
-      fcntl(proc.event_state_.memfd, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW);
+      safe_fcntl(proc.event_state_.memfd, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW);
     }
     int mflags = MAP_SHARED;
     if (flags & MAP_FIXED)
@@ -1241,7 +1258,7 @@ int SimulatedKfd::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
   } else if (daemon_mode_ || !user_provided_va) {
     auto raw_fd = memfd_create("rocjitsu_alloc", MFD_CLOEXEC | MFD_ALLOW_SEALING);
     if (raw_fd >= 0) {
-      alloc.memfd = fcntl(raw_fd, F_DUPFD_CLOEXEC, 4096);
+      alloc.memfd = safe_fcntl(raw_fd, F_DUPFD_CLOEXEC, 4096);
       if (alloc.memfd < 0)
         alloc.memfd = raw_fd;
       else
@@ -1253,7 +1270,7 @@ int SimulatedKfd::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
       if (alloc.memfd >= 0) {
         [[maybe_unused]] auto ft_rc = ftruncate(alloc.memfd, static_cast<off_t>(alloc.size));
         fallocate(alloc.memfd, 0, 0, static_cast<off_t>(alloc.size));
-        fcntl(alloc.memfd, F_ADD_SEALS, F_SEAL_SHRINK);
+        safe_fcntl(alloc.memfd, F_ADD_SEALS, F_SEAL_SHRINK);
 
         if (daemon_mode_ && !is_doorbell) {
           auto *mapped =
@@ -1314,7 +1331,7 @@ bool SimulatedKfd::allocate_scratch_backing(uint32_t process_id, uint64_t gpu_va
   if (raw_fd < 0)
     return false;
 
-  int memfd = fcntl(raw_fd, F_DUPFD_CLOEXEC, 4096);
+  int memfd = safe_fcntl(raw_fd, F_DUPFD_CLOEXEC, 4096);
   if (memfd < 0)
     memfd = raw_fd;
   else
@@ -1603,11 +1620,11 @@ int SimulatedKfd::import_dmabuf_ioctl(KfdProcess &proc, void *arg) {
     return -EINVAL;
 
   struct stat st {};
-  if (fstat(args->dmabuf_fd, &st) != 0)
+  if (safe_fstat(args->dmabuf_fd, &st) != 0)
     return -errno;
   uint64_t size = static_cast<uint64_t>(st.st_size);
 
-  int dupfd = fcntl(args->dmabuf_fd, F_DUPFD_CLOEXEC, 0);
+  int dupfd = safe_fcntl(args->dmabuf_fd, F_DUPFD_CLOEXEC, 0);
   if (dupfd < 0)
     return -errno;
 
@@ -1654,7 +1671,7 @@ int SimulatedKfd::export_dmabuf_ioctl(KfdProcess &proc, void *arg) {
   const auto &alloc = it->second;
   if (alloc.memfd < 0)
     return -EINVAL;
-  int dupfd = fcntl(alloc.memfd, F_DUPFD_CLOEXEC, 0);
+  int dupfd = safe_fcntl(alloc.memfd, F_DUPFD_CLOEXEC, 0);
   if (dupfd < 0)
     return -errno;
   args->dmabuf_fd = dupfd;
@@ -1751,7 +1768,7 @@ int SimulatedKfd::ipc_export_handle_ioctl(KfdProcess &proc, void *arg) {
     alloc_size = alloc.size;
     alloc_flags = alloc.flags;
     alloc_gpu_id = alloc.gpu_id;
-    dup_fd = fcntl(alloc.memfd, F_DUPFD_CLOEXEC, 0);
+    dup_fd = safe_fcntl(alloc.memfd, F_DUPFD_CLOEXEC, 0);
   }
 
   if (dup_fd < 0)
@@ -1802,7 +1819,7 @@ int SimulatedKfd::ipc_import_handle_ioctl(KfdProcess &proc, void *arg) {
     alloc_size = it->second.allocation_size;
     alloc_flags = it->second.allocation_flags;
     source_gpu_id = it->second.source_gpu_id;
-    dup_fd = fcntl(it->second.backing_memfd, F_DUPFD_CLOEXEC, 0);
+    dup_fd = safe_fcntl(it->second.backing_memfd, F_DUPFD_CLOEXEC, 0);
   }
 
   if (args->gpu_id != 0 && args->gpu_id != source_gpu_id) {
@@ -1890,7 +1907,7 @@ int SimulatedKfd::get_dmabuf_info_ioctl(KfdProcess &proc, void *arg) {
 
   if (!found) {
     struct stat st {};
-    if (fstat(args->dmabuf_fd, &st) != 0)
+    if (safe_fstat(args->dmabuf_fd, &st) != 0)
       return -errno;
     size = static_cast<uint64_t>(st.st_size);
   }
@@ -2070,11 +2087,11 @@ int SimulatedKfd::debug_trap_ioctl(KfdProcess &caller, void *arg) {
     // received via SCM_RIGHTS and already substituted into our fd space; in
     // local mode it is the debugger's own descriptor. Either way the driver
     // *writes* to it to wake the debugger, so it must be a live, writable
-    // descriptor. fcntl(F_GETFL) both proves the fd is open (EBADF otherwise)
+    // descriptor. safe_fcntl(F_GETFL) both proves the fd is open (EBADF otherwise)
     // and reports its access mode, so a read-only or otherwise unusable fd —
     // e.g. one a client passed over SCM_RIGHTS that is not a real event target —
     // is rejected instead of being stored on the session.
-    const int fl = fcntl(dbg_fd, F_GETFL);
+    const int fl = safe_fcntl(dbg_fd, F_GETFL);
     if (fl == -1 || (fl & O_ACCMODE) == O_RDONLY)
       return -EBADF;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -494,6 +494,15 @@ void SimulatedKfd::close_all_processes() {
   // unblock such threads so their jthread joins can complete instead of hanging
   // forever. A client that races us to its own rj_vm_device_close() just finds the
   // process already gone and no-ops.
+  //
+  // Drain each pid to a full teardown rather than a single close(): in daemon mode
+  // several client opens of the same client_pid share one KfdProcess and bump
+  // open_ref_count_ (open_process()'s retain path), so close() only reaches
+  // notify_closing() on the LAST reference. A single decrement would leave a
+  // multiply-opened process — exactly the one whose waiters we must wake — parked.
+  // Loop close() while the process is still present, mirroring the destructor. The
+  // find_process() re-check makes a concurrent client close() benign: whoever drops
+  // the last reference tears it down, the other observes it gone and stops.
   std::vector<uint32_t> pids;
   {
     std::lock_guard<std::mutex> lk(process_mutex_);
@@ -502,7 +511,8 @@ void SimulatedKfd::close_all_processes() {
       pids.push_back(pid);
   }
   for (uint32_t pid : pids)
-    close(pid);
+    while (find_process(pid))
+      close(pid);
 }
 
 int SimulatedKfd::close(uint32_t process_id) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -486,6 +486,25 @@ uint32_t SimulatedKfd::local_open_ref_count() const {
 
 int SimulatedKfd::close() { return close(local_process_id_); }
 
+void SimulatedKfd::close_all_processes() {
+  // Snapshot the live process ids under process_mutex_, then close each with the lock
+  // RELEASED (close() takes process_mutex_ itself). Closing a process fires
+  // notify_closing()/signal_page_shutdown(), which wakes any client thread parked in
+  // an infinite-timeout WAIT_EVENTS — the daemon teardown path relies on this to
+  // unblock such threads so their jthread joins can complete instead of hanging
+  // forever. A client that races us to its own rj_vm_device_close() just finds the
+  // process already gone and no-ops.
+  std::vector<uint32_t> pids;
+  {
+    std::lock_guard<std::mutex> lk(process_mutex_);
+    pids.reserve(processes_.size());
+    for (const auto &[pid, proc] : processes_)
+      pids.push_back(pid);
+  }
+  for (uint32_t pid : pids)
+    close(pid);
+}
+
 int SimulatedKfd::close(uint32_t process_id) {
   std::shared_ptr<KfdProcess> extracted;
   std::vector<uint32_t> queue_ids;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -254,26 +254,26 @@ void SimulatedKfd::setup_topology(const std::vector<config::KfdDeviceConfig> &de
 
 bool SimulatedKfd::is_doorbell_range(const void *addr, size_t length) const {
   auto p = find_process(local_process_id_);
-  if (!p)
+  if (!p || !addr || length == 0)
     return false;
-  // Snapshot the doorbell page/size under alloc_mutex_ so a concurrent
-  // dispatch_mmap/dispatch_munmap (which mutate these under the same lock) cannot
-  // tear the pointer/size read.
-  void *doorbell_page;
-  size_t doorbell_page_size;
-  {
-    std::lock_guard<std::mutex> lock(p->alloc_mutex_);
-    auto &gs = p->gpu(0);
-    doorbell_page = gs.doorbell_page;
-    doorbell_page_size = gs.doorbell_page_size;
+  // Check every GPU ordinal's doorbell page: dispatch_mmap/dispatch_munmap install
+  // and tear down a doorbell page per ordinal, so a multi-GPU process has more than
+  // one to guard (checking only ordinal 0 would leave a higher ordinal's page
+  // unprotected against a client mprotect). Snapshot each page/size under
+  // alloc_mutex_ so a concurrent dispatch_mmap/dispatch_munmap (which mutate these
+  // under the same lock) cannot tear the pointer/size read.
+  const auto query_base = reinterpret_cast<uintptr_t>(addr);
+  const auto query_end = query_base + length;
+  std::lock_guard<std::mutex> lock(p->alloc_mutex_);
+  for (const auto &gs : p->gpu_state_) {
+    if (!gs.doorbell_page || gs.doorbell_page_size == 0)
+      continue;
+    const auto base = reinterpret_cast<uintptr_t>(gs.doorbell_page);
+    const auto end = base + gs.doorbell_page_size;
+    if (query_base < end && query_end > base)
+      return true;
   }
-  if (!doorbell_page || doorbell_page_size == 0 || !addr || length == 0)
-    return false;
-  auto base = reinterpret_cast<uintptr_t>(doorbell_page);
-  auto end = base + doorbell_page_size;
-  auto query_base = reinterpret_cast<uintptr_t>(addr);
-  auto query_end = query_base + length;
-  return query_base < end && query_end > base;
+  return false;
 }
 
 bool SimulatedKfd::ensure_fd_created() {
@@ -796,8 +796,10 @@ void *SimulatedKfd::mmap(void *addr, size_t length, int prot, int flags, off_t o
 void *SimulatedKfd::mmap(uint32_t process_id, void *addr, size_t length, int prot, int flags,
                          off_t offset) {
   auto p = find_process(process_id);
-  if (!p)
+  if (!p) {
+    errno = ESRCH;
     return MAP_FAILED;
+  }
   if (daemon_mode_)
     return dispatch_mmap(*p, nullptr, length, prot, flags & ~MAP_FIXED, offset);
   return dispatch_mmap(*p, addr, length, prot, flags, offset);
@@ -918,12 +920,14 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
         owned_fds_.insert(proc.event_state_.memfd);
       }
       if (ftruncate(proc.event_state_.memfd, static_cast<off_t>(length)) != 0) {
+        const int ftruncate_errno = errno; // preserve across close() below
         {
           std::lock_guard<std::mutex> lk(owned_fds_mutex_);
           owned_fds_.erase(proc.event_state_.memfd);
         }
         libc_passthrough().close(proc.event_state_.memfd);
         proc.event_state_.memfd = -1;
+        errno = ftruncate_errno;
         return MAP_FAILED;
       }
       fallocate(proc.event_state_.memfd, 0, 0, static_cast<off_t>(length));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -63,18 +63,20 @@ amdgpu::Mtype SimulatedKfd::pte_mtype_for_flags(uint32_t flags) {
   return amdgpu::Mtype::RW;
 }
 
-void SimulatedKfd::gem_va_map(uint64_t gpu_va, void *host_ptr, size_t size, uint32_t alloc_flags) {
+bool SimulatedKfd::gem_va_map(uint64_t gpu_va, void *host_ptr, size_t size, uint32_t alloc_flags) {
   auto proc = find_process(local_process_id_);
   if (!proc)
-    return;
+    return false;
   map_to_gpu(*proc, gpu_va, host_ptr, size, pte_mtype_for_flags(alloc_flags));
+  return true;
 }
 
-void SimulatedKfd::gem_va_unmap(uint64_t gpu_va, size_t size) {
+bool SimulatedKfd::gem_va_unmap(uint64_t gpu_va, size_t size) {
   auto proc = find_process(local_process_id_);
   if (!proc)
-    return;
+    return false;
   unmap_from_gpu(*proc, gpu_va, size);
+  return true;
 }
 
 namespace {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -17,6 +17,7 @@ RJ_DIAGNOSTIC_POP
 #include "util/log.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cerrno>
 #include <cstdint>
@@ -1513,15 +1514,34 @@ int SimulatedKfd::create_queue_ioctl(KfdProcess &proc, void *arg) {
     uint32_t ord = gpu_ordinal(args->gpu_id);
     auto &gs = proc.gpu(ord);
     uint32_t db_offset;
+    bool recycled_offset = false;
     if (!gs.free_doorbell_offsets.empty()) {
       db_offset = gs.free_doorbell_offsets.back();
       gs.free_doorbell_offsets.pop_back();
+      recycled_offset = true;
     } else {
       if (gs.doorbell_page_size > 0 &&
           gs.next_doorbell_offset + sizeof(uint64_t) > gs.doorbell_page_size)
         return -ENOSPC;
       db_offset = static_cast<uint32_t>(gs.next_doorbell_offset);
       gs.next_doorbell_offset += sizeof(uint64_t);
+    }
+
+    // Reset a recycled doorbell slot to the ~0 sentinel. The mmap-time 0xFF fill
+    // only primes freshly-mapped pages; a slot freed by destroy_queue() still
+    // holds the prior queue's last-rung write index (typically a small value like
+    // 0). The CP starts every queue with last_doorbell==~0, so if the poll thread
+    // scans this slot in the window between register_queue() and the host's first
+    // ring, it latches that stale value as last_doorbell. When the host then rings
+    // the new queue with the same value (write_index 0 for a one-packet queue),
+    // val==last_doorbell, no edge is detected, and the submission is never fetched
+    // — a lost doorbell that hangs the waiter in hsa_signal_wait. Restoring the
+    // sentinel keeps the "first real ring is always an edge" invariant.
+    if (recycled_offset && gs.doorbell_page &&
+        db_offset + sizeof(uint64_t) <= gs.doorbell_page_size) {
+      std::atomic_ref<uint64_t>(
+          *reinterpret_cast<uint64_t *>(static_cast<char *>(gs.doorbell_page) + db_offset))
+          .store(~uint64_t(0), std::memory_order_release);
     }
 
     hw.process_id = proc.process_id();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
@@ -206,6 +206,8 @@ private:
                   amdgpu::Mtype mtype = amdgpu::Mtype::RW);
   void unmap_from_gpu(KfdProcess &proc, uint64_t gpu_va, size_t size);
 
+  void update_cp_doorbell_base(uint32_t gpu_ordinal, uint32_t process_id, void *base);
+
   int dispatch_ioctl(KfdProcess &proc, unsigned long request, void *arg);
   void *dispatch_mmap(KfdProcess &proc, void *addr, size_t length, int prot, int flags,
                       off_t offset);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
@@ -152,6 +152,25 @@ public:
   [[nodiscard]] int claim_fd(int real_fd);
   [[nodiscard]] bool owns_reserved_fd(int fd) const;
 
+  /// @brief Derive the PTE MTYPE from KFD allocation flags (mirrors amdgpu).
+  /// @details Public so the interposer's DRM GEM_VA path can install page-table
+  /// entries with the same coherency type the KFD alloc requested.
+  static amdgpu::Mtype pte_mtype_for_flags(uint32_t alloc_flags);
+
+  /// @brief Install a host range into the local process's GPU page table.
+  /// @details Drives DRM AMDGPU_GEM_VA MAP/REPLACE from the interposer: maps
+  /// @p size bytes at @p gpu_va to @p host_ptr with the MTYPE derived from
+  /// @p alloc_flags. No-op if the local process is gone.
+  void gem_va_map(uint64_t gpu_va, void *host_ptr, size_t size, uint32_t alloc_flags);
+
+  /// @brief Remove a GPU page-table range installed by gem_va_map (GEM_VA UNMAP).
+  void gem_va_unmap(uint64_t gpu_va, size_t size);
+
+  /// @brief Look up a KfdProcess by ID. Returns nullptr if not found.
+  /// @details Public so the interposer can read a local allocation's flags when
+  /// synthesizing GEM bookkeeping at EXPORT_DMABUF time.
+  std::shared_ptr<KfdProcess> find_process(uint32_t process_id) const;
+
   /// @brief Per-GPU device state (mirrors kfd_dev in the kernel).
   struct GpuDevice {
     SoC *soc = nullptr;
@@ -161,9 +180,6 @@ public:
   };
 
 private:
-  /// @brief Look up a KfdProcess by ID. Returns nullptr if not found.
-  std::shared_ptr<KfdProcess> find_process(uint32_t process_id) const;
-
   /// @brief Look up the local-mode process.
   std::shared_ptr<KfdProcess> find_local_process() const;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
@@ -167,9 +167,14 @@ public:
   void gem_va_unmap(uint64_t gpu_va, size_t size);
 
   /// @brief Look up a KfdProcess by ID. Returns nullptr if not found.
-  /// @details Public so the interposer can read a local allocation's flags when
-  /// synthesizing GEM bookkeeping at EXPORT_DMABUF time.
   std::shared_ptr<KfdProcess> find_process(uint32_t process_id) const;
+
+  /// @brief KFD allocation flags for a local-process allocation @p handle, or 0.
+  /// @details Locks the process alloc mutex internally, keeping lock discipline for
+  /// per-process allocation state inside the driver. Used by the interposer to
+  /// capture the GPU PTE MTYPE flags at EXPORT_DMABUF time (before the allocation
+  /// may be freed).
+  uint32_t alloc_flags_for_handle(uint64_t handle) const;
 
   /// @brief Per-GPU device state (mirrors kfd_dev in the kernel).
   struct GpuDevice {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
@@ -160,11 +160,16 @@ public:
   /// @brief Install a host range into the local process's GPU page table.
   /// @details Drives DRM AMDGPU_GEM_VA MAP/REPLACE from the interposer: maps
   /// @p size bytes at @p gpu_va to @p host_ptr with the MTYPE derived from
-  /// @p alloc_flags. No-op if the local process is gone.
-  void gem_va_map(uint64_t gpu_va, void *host_ptr, size_t size, uint32_t alloc_flags);
+  /// @p alloc_flags.
+  /// @retval true the range was installed.
+  /// @retval false the local process is gone, so nothing was mapped (the caller
+  ///         must surface an error rather than report a phantom success).
+  [[nodiscard]] bool gem_va_map(uint64_t gpu_va, void *host_ptr, size_t size, uint32_t alloc_flags);
 
   /// @brief Remove a GPU page-table range installed by gem_va_map (GEM_VA UNMAP).
-  void gem_va_unmap(uint64_t gpu_va, size_t size);
+  /// @retval true the range was unmapped.
+  /// @retval false the local process is gone, so nothing was unmapped.
+  [[nodiscard]] bool gem_va_unmap(uint64_t gpu_va, size_t size);
 
   /// @brief Look up a KfdProcess by ID. Returns nullptr if not found.
   std::shared_ptr<KfdProcess> find_process(uint32_t process_id) const;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
@@ -312,6 +312,11 @@ private:
   std::unordered_map<uint32_t, EventState *> event_dispatch_;
 
   /// @brief Process ID for local-mode (interposer). Set once in open().
+  /// @details Written under process_mutex_ in open(), then read lock-free from the
+  /// ioctl/mmap/munmap/gem paths. Safe only under the local-mode contract: the app
+  /// opens /dev/kfd before issuing any ioctl and never re-opens concurrently, so the
+  /// single publishing write happens-before every read. Not for use outside that
+  /// single-primary-fd local path.
   uint32_t local_process_id_ = 0;
 
   static constexpr kfd_process_device_apertures default_apertures_{

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
@@ -105,6 +105,13 @@ public:
   void *mmap(uint32_t process_id, void *addr, size_t length, int prot, int flags, off_t offset);
   int munmap(uint32_t process_id, void *addr, size_t length);
   int close(uint32_t process_id);
+
+  /// @brief Close every registered process, waking any parked event waiters.
+  /// @details Daemon-teardown helper: iterates all live processes and closes each,
+  /// firing notify_closing() so client threads blocked in an infinite-timeout
+  /// WAIT_EVENTS unblock and their jthread joins can complete.
+  void close_all_processes();
+
   [[nodiscard]] int get_mmap_memfd(uint32_t process_id, off_t offset) const;
   /// @}
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
@@ -67,7 +67,13 @@ void reap_stale_sysfs_dirs() {
   const fs::directory_iterator end;
   for (; !ec && it != end; it.increment(ec)) {
     const auto &entry = *it;
-    if (!entry.is_directory(ec))
+    // Only reap a real directory, never chase a symlink out of the runtime root:
+    // symlink_status() does NOT follow the link, whereas is_directory() would let a
+    // symlink-to-directory pass and have remove_all() delete its target. Matches the
+    // hardened launcher reaper (main.cpp reap_stale_runtime_dirs).
+    std::error_code st_ec;
+    auto st = fs::symlink_status(entry.path(), st_ec);
+    if (st_ec || st.type() != fs::file_type::directory)
       continue;
     std::string name = entry.path().filename().string();
     if (name.rfind("rocjitsu_drm_", 0) != 0 && name.rfind("rocjitsu_topology_", 0) != 0)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
@@ -12,10 +12,14 @@ RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "linux/uapi/kfd_sysfs.h"
 RJ_DIAGNOSTIC_POP
 
+#include <cerrno>
+#include <charconv>
+#include <csignal>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <mutex>
 #include <sstream>
 #include <string>
 #include <unistd.h>
@@ -28,23 +32,61 @@ namespace fs = std::filesystem;
 
 namespace {
 
-std::string make_runtime_temp_dir(const char *prefix) {
+/// @brief Create a process-tagged scratch directory under the XDG runtime root.
+/// @details Replaces raw mkdtemp("/tmp/...") so synthetic sysfs trees live under
+/// rpc_default_runtime_dir() (tmpfs, reaped at logout) and carry the owning PID
+/// in their name (rocjitsu_<kind>_<pid>_XXXXXX) so reap_stale_sysfs_dirs() can
+/// remove the trees an earlier SIGKILL/crash orphaned. Returns empty on failure.
+std::string make_tagged_dir(const char *kind) {
   std::error_code ec;
-  fs::path base = rpc_default_runtime_dir();
-  fs::create_directories(base, ec);
-  if (ec)
-    return {};
+  std::string root = rpc_default_runtime_dir();
+  // Errors from create_directories are intentionally not checked here: if the root
+  // could not be created, mkdtemp below fails and returns empty, which both callers
+  // already treat as "no synthetic tree" via an empty-string early return.
+  fs::create_directories(root, ec);
+  std::string tmpl = root + "/rocjitsu_" + kind + "_" + std::to_string(getpid()) + "_XXXXXX";
+  std::vector<char> buf(tmpl.begin(), tmpl.end());
+  buf.push_back('\0');
+  char *dir = mkdtemp(buf.data());
+  return dir ? std::string(dir) : std::string{};
+}
 
-  // Synthetic sysfs/DRM trees are process-owned and removed by Sysfs::cleanup().
-  // Place them under the rocjitsu runtime directory so crashes leave state in a
-  // known per-user location instead of scattering entries directly under /tmp.
-  std::string tmpl = (base / (std::string(prefix) + "_XXXXXX")).string();
-  std::vector<char> tmpl_buffer(tmpl.begin(), tmpl.end());
-  tmpl_buffer.push_back('\0');
-  char *dir = mkdtemp(tmpl_buffer.data());
-  if (!dir)
-    return {};
-  return dir;
+/// @brief Remove orphaned rocjitsu_{drm,topology}_<pid>_* dirs of dead processes.
+/// @details RAII cleanup (Sysfs::cleanup) only fires on graceful teardown; a
+/// SIGKILL/OOM/crash leaks the scratch tree forever. This sweeps the runtime
+/// root once per process, deleting any tagged dir whose embedded PID is no
+/// longer alive (kill(pid, 0) == ESRCH). The live process's own dirs are kept.
+void reap_stale_sysfs_dirs() {
+  // Advance the iterator with an error_code (not the throwing operator++): another
+  // rocjitsu process sharing this runtime root may remove_all an entry concurrently,
+  // and a throw here would escape std::call_once and abort topology generation on a
+  // best-effort cleanup path. Best-effort — any filesystem error just ends the scan.
+  std::error_code ec;
+  std::string root = rpc_default_runtime_dir();
+  fs::directory_iterator it(root, ec);
+  const fs::directory_iterator end;
+  for (; !ec && it != end; it.increment(ec)) {
+    const auto &entry = *it;
+    if (!entry.is_directory(ec))
+      continue;
+    std::string name = entry.path().filename().string();
+    if (name.rfind("rocjitsu_drm_", 0) != 0 && name.rfind("rocjitsu_topology_", 0) != 0)
+      continue;
+    // Extract the PID between the last two underscores: <prefix>_<pid>_<suffix>.
+    auto suffix_us = name.rfind('_');
+    if (suffix_us == std::string::npos || suffix_us == 0)
+      continue;
+    auto pid_us = name.rfind('_', suffix_us - 1);
+    if (pid_us == std::string::npos)
+      continue;
+    std::string pid_str = name.substr(pid_us + 1, suffix_us - pid_us - 1);
+    pid_t pid = 0;
+    auto [ptr, perr] = std::from_chars(pid_str.data(), pid_str.data() + pid_str.size(), pid);
+    if (perr != std::errc{} || ptr != pid_str.data() + pid_str.size() || pid <= 0)
+      continue;
+    if (kill(pid, 0) == -1 && errno == ESRCH)
+      fs::remove_all(entry.path(), ec);
+  }
 }
 
 /// @brief Debug-related topology bits derived from a GPU's GFXIP version.
@@ -144,15 +186,21 @@ uint32_t default_non_debug_capability() {
 
 Sysfs::~Sysfs() { cleanup(); }
 
-Sysfs::Sysfs(Sysfs &&other) noexcept : topology_dir_(std::move(other.topology_dir_)) {
+Sysfs::Sysfs(Sysfs &&other) noexcept
+    : topology_dir_(std::move(other.topology_dir_)), drm_dir_(std::move(other.drm_dir_)) {
+  // Clear both owned-tree paths in the moved-from object so its cleanup() cannot
+  // remove_all a tree this object now owns.
   other.topology_dir_.clear();
+  other.drm_dir_.clear();
 }
 
 Sysfs &Sysfs::operator=(Sysfs &&other) noexcept {
   if (this != &other) {
     cleanup();
     topology_dir_ = std::move(other.topology_dir_);
+    drm_dir_ = std::move(other.drm_dir_);
     other.topology_dir_.clear();
+    other.drm_dir_.clear();
   }
   return *this;
 }
@@ -463,10 +511,9 @@ void Sysfs::write_gpu_node(const std::string &nodes_dir, uint32_t node_idx, cons
 }
 
 void Sysfs::write_drm_tree(const std::vector<GpuInfo> &gpus) {
-  std::string dir = make_runtime_temp_dir("rocjitsu_drm");
-  if (dir.empty())
+  drm_dir_ = make_tagged_dir("drm");
+  if (drm_dir_.empty())
     return;
-  drm_dir_ = std::move(dir);
 
   for (size_t i = 0; i < gpus.size(); ++i) {
     auto &gpu = gpus[i];
@@ -522,11 +569,13 @@ std::string Sysfs::generate(const GpuInfo &gpu) { return generate(std::vector<Gp
 std::string Sysfs::generate(const std::vector<GpuInfo> &gpus) {
   cleanup();
 
-  std::string dir = make_runtime_temp_dir("rocjitsu_topology");
-  if (dir.empty())
+  static std::once_flag reap_once;
+  std::call_once(reap_once, reap_stale_sysfs_dirs);
+
+  topology_dir_ = make_tagged_dir("topology");
+  if (topology_dir_.empty())
     return {};
 
-  topology_dir_ = std::move(dir);
   if (!gpus.empty())
     gpu_info_ = gpus[0];
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
@@ -90,8 +90,14 @@ void reap_stale_sysfs_dirs() {
     auto [ptr, perr] = std::from_chars(pid_str.data(), pid_str.data() + pid_str.size(), pid);
     if (perr != std::errc{} || ptr != pid_str.data() + pid_str.size() || pid <= 0)
       continue;
-    if (kill(pid, 0) == -1 && errno == ESRCH)
-      fs::remove_all(entry.path(), ec);
+    if (kill(pid, 0) == -1 && errno == ESRCH) {
+      // Use a dedicated error_code for the removal: reusing the loop-control `ec`
+      // would let one un-removable orphan (e.g. EACCES on another user's tree)
+      // set `ec` and terminate the whole sweep, skipping every remaining stale
+      // dir for the life of the process (this runs under std::call_once).
+      std::error_code rm_ec;
+      fs::remove_all(entry.path(), rm_ec);
+    }
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
@@ -37,6 +37,11 @@ namespace {
 /// rpc_default_runtime_dir() (tmpfs, reaped at logout) and carry the owning PID
 /// in their name (rocjitsu_<kind>_<pid>_XXXXXX) so reap_stale_sysfs_dirs() can
 /// remove the trees an earlier SIGKILL/crash orphaned. Returns empty on failure.
+/// @note The PID tag makes reaping best-effort, not exact: PID reuse means a
+/// recycled-but-live PID can keep a genuinely-orphaned tree from being reaped (a
+/// bounded leak until logout clears the tmpfs), and the mkdtemp XXXXXX suffix keeps
+/// two same-PID generations from colliding. This matches the launcher reaper
+/// (main.cpp reap_stale_runtime_dirs); the tmpfs backstop bounds any leak.
 std::string make_tagged_dir(const char *kind) {
   std::error_code ec;
   std::string root = rpc_default_runtime_dir();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
@@ -45,6 +45,11 @@ namespace {
 std::string make_tagged_dir(const char *kind) {
   std::error_code ec;
   std::string root = rpc_default_runtime_dir();
+  // Fail closed on an empty root: an empty base would make tmpl "/rocjitsu_..._XXXXXX"
+  // and try to mkdtemp scratch dirs in the filesystem root. rpc_default_runtime_dir()
+  // already treats a set-but-empty $ROCJITSU_RUNTIME_DIR as unset; guard defensively.
+  if (root.empty())
+    return {};
   // Errors from create_directories are intentionally not checked here: if the root
   // could not be created, mkdtemp below fails and returns empty, which both callers
   // already treat as "no synthetic tree" via an empty-string early return.
@@ -68,6 +73,11 @@ void reap_stale_sysfs_dirs() {
   // best-effort cleanup path. Best-effort — any filesystem error just ends the scan.
   std::error_code ec;
   std::string root = rpc_default_runtime_dir();
+  // Never scan an empty root: directory_iterator("") walks the CWD, and this loop
+  // remove_all's matching entries. rpc_default_runtime_dir() already maps a set-but-
+  // empty $ROCJITSU_RUNTIME_DIR to a real path; guard here too since we delete.
+  if (root.empty())
+    return;
   fs::directory_iterator it(root, ec);
   const fs::directory_iterator end;
   for (; !ec && it != end; it.increment(ec)) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -120,7 +120,6 @@ bool plan_cluster_workgroups(const DispatchEntry &entry, uint32_t cluster_base_l
     for (size_t attempt = 0; attempt < cus.size(); ++attempt) {
       size_t cu_idx = (next_cu + rank + attempt) % cus.size();
       auto *cu = cus[cu_idx];
-      cu->retire_halted_wfs();
 
       uint32_t reserved_wgs = planned_per_cu[cu_idx] + 1;
       uint64_t reserved_wfs = static_cast<uint64_t>(entry.wfs_per_workgroup) * reserved_wgs;
@@ -645,8 +644,12 @@ void CommandProcessor::mark_cluster_workgroup_complete(uint32_t dispatch_id, uin
 
   for (uint32_t peer_wg_id : peer_wg_ids) {
     auto peer_it = cluster_wg_placements_.find(wg_key(dispatch_id, peer_wg_id));
-    if (peer_it != cluster_wg_placements_.end() && peer_it->second.cu)
+    if (peer_it != cluster_wg_placements_.end() && peer_it->second.cu) {
       peer_it->second.cu->unpin_lds_for_cluster(cluster_key);
+      // The waves halted (and freed) before the pin was released, so reclaim each
+      // peer CU's LDS now that the whole cluster is done.
+      peer_it->second.cu->maybe_reset_lds_alloc();
+    }
   }
   for (uint32_t peer_wg_id : peer_wg_ids)
     cluster_wg_placements_.erase(wg_key(dispatch_id, peer_wg_id));
@@ -656,8 +659,10 @@ void CommandProcessor::erase_cluster_workgroups(uint32_t dispatch_id) {
   std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
   for (auto it = cluster_wg_placements_.begin(); it != cluster_wg_placements_.end();) {
     if ((it->first >> 32) == dispatch_id) {
-      if (it->second.cu)
+      if (it->second.cu) {
         it->second.cu->unpin_lds_for_cluster(it->second.cluster_key);
+        it->second.cu->maybe_reset_lds_alloc();
+      }
       it = cluster_wg_placements_.erase(it);
     } else {
       ++it;
@@ -710,8 +715,14 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
   // reserves that CU's sibling and binds the waves to their shared LDS pool.
   // Query the complete placement before dispatching for all-or-nothing setup.
   uint32_t dispatched = 0;
-  auto dispatch_to_placement = [&](uint32_t local_wg_id, uint32_t global_wg_id,
-                                   const ShaderProcessorInput::WorkgroupPlacement &placement) {
+  // Places one workgroup's waves on the chosen CU. Returns false only on an
+  // internal invariant violation: dispatch_wf() returning null after placement was
+  // gated on can_accept_workgroup(). The caller turns that into a hard error rather
+  // than silently dereferencing a null wave in a release build (where the callee's
+  // assert is compiled out).
+  auto dispatch_to_placement =
+      [&](uint32_t local_wg_id, uint32_t global_wg_id,
+          const ShaderProcessorInput::WorkgroupPlacement &placement) -> bool {
     // Fire the dispatch-execution-begin hook exactly once, on the first workgroup
     // actually placed on a CU, guarded by the per-dispatch flag.
     if (!entry.execution_begun) {
@@ -720,15 +731,34 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
     }
     ComputeUnitCore *cu = placement.cu;
     uint32_t lds_base = placement.lds_base;
-    cu->begin_workgroup(entry.dispatch_id, global_wg_id, entry.wfs_per_workgroup);
-    register_cluster_workgroup(entry, local_wg_id, global_wg_id, cu, lds_base);
-
+    // Reserve all waves BEFORE committing WG-completion bookkeeping. begin_workgroup()
+    // installs the WG refcount and register_cluster_workgroup() installs the LDS pin;
+    // both are released only via release_wf() when the waves halt. Committing them
+    // first and then failing mid-workgroup (a dispatch_wf null) would orphan the
+    // refcount and pin, permanently blocking maybe_reset_lds_alloc() on this CU.
+    // Placement is already gated on can_accept_workgroup()/cluster planning, so this
+    // dry allocation cannot actually fail — but doing it up front makes the commit
+    // below all-or-nothing.
     std::vector<Wavefront *> wg_wavefronts;
     wg_wavefronts.reserve(entry.wfs_per_workgroup);
     for (uint32_t w = 0; w < entry.wfs_per_workgroup; ++w) {
       Wavefront *wf = cu->dispatch_wf(global_wg_id, entry.kernel_entry_pc, entry.sgprs_per_wf,
                                       entry.vgprs_per_wf);
-      assert(wf && "dispatch_wf failed after can_accept_workgroup returned true");
+      if (!wf) {
+        // Unreachable given the placement gating; free any waves already claimed for
+        // this WG and fail without having touched the WG refcount / cluster pin.
+        assert(false && "dispatch_wf failed after placement was reserved");
+        for (auto *claimed : wg_wavefronts)
+          claimed->halt();
+        return false;
+      }
+      wg_wavefronts.push_back(wf);
+    }
+    cu->begin_workgroup(entry.dispatch_id, global_wg_id, entry.wfs_per_workgroup);
+    register_cluster_workgroup(entry, local_wg_id, global_wg_id, cu, lds_base);
+
+    for (uint32_t w = 0; w < entry.wfs_per_workgroup; ++w) {
+      Wavefront *wf = wg_wavefronts[w];
       wf->set_lds_base(lds_base);
       wf->set_lds(placement.lds);
       wf->set_dispatch_id(entry.dispatch_id);
@@ -736,7 +766,6 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
       wf->set_exec(initial_exec_mask_for_wave(entry, global_wg_id, w, cu->wf_size()));
       wf->set_cluster_info(entry.cluster_rank_for_local_wg(local_wg_id), entry.cluster_size());
       init_wavefront_regs(cu, wf, entry, global_wg_id, w);
-      wg_wavefronts.push_back(wf);
     }
     plugin_group_->onAmdgpuWorkgroupDispatched(entry.dispatch_id, global_wg_id,
                                                cu->vgpr_allocation_block_size(), entry.sgprs_per_wf,
@@ -746,6 +775,7 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
 
     ++entry.dispatched_wgs;
     ++dispatched;
+    return true;
   };
 
   while (entry.dispatched_wgs < entry.total_wgs) {
@@ -778,7 +808,8 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
       for (const auto &wg : plan) {
         ShaderProcessorInput::WorkgroupPlacement placement{
             wg.cu, &wg.cu->lds(), wg.cu->allocate_lds(entry.group_segment_fixed_size)};
-        dispatch_to_placement(wg.local_wg_id, wg.global_wg_id, placement);
+        if (!dispatch_to_placement(wg.local_wg_id, wg.global_wg_id, placement))
+          throw std::runtime_error("dispatch_wf failed after cluster placement was reserved");
       }
       continue;
     }
@@ -795,7 +826,6 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
     } else if (!entry.wgp_mode) {
       for (size_t attempt = 0; attempt < cus_.size(); ++attempt) {
         size_t cu_idx = (next_cu_ + attempt) % cus_.size();
-        cus_[cu_idx]->retire_halted_wfs();
         if (cus_[cu_idx]->can_accept_workgroup(entry.wfs_per_workgroup,
                                                entry.group_segment_fixed_size)) {
           auto *cu = cus_[cu_idx];
@@ -817,7 +847,8 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
       break;
     }
 
-    dispatch_to_placement(local_wg_id, global_wg_id, *placement);
+    if (!dispatch_to_placement(local_wg_id, global_wg_id, *placement))
+      throw std::runtime_error("dispatch_wf failed after workgroup placement was reserved");
   }
   return dispatched;
 }
@@ -1306,9 +1337,14 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
 
         if (!condition_satisfied) {
           // The packet stalls this queue, but other queues (notably SDMA) must
-          // keep running so they can satisfy the dependency.
+          // keep running so they can satisfy the dependency. fetch_from_queue runs
+          // on the engine thread (via handle_doorbell), so reschedule with
+          // schedule_event(now + 1) — advancing the tick per re-check — like the
+          // sibling barrier/vendor-dep retries. schedule_event_now() is only for the
+          // external doorbell poll thread; using it here would collapse re-checks
+          // onto one tick and take the async queue's lock needlessly.
           process_limit = read_idx;
-          engine()->schedule_event_now(&doorbell_event_);
+          schedule_event(&doorbell_event_, now + 1);
           break;
         }
 
@@ -1396,7 +1432,10 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
 }
 
 void CommandProcessor::handle_doorbell(simdojo::Tick now) {
-  invalid_pending_.store(false, std::memory_order_relaxed);
+  // Release so the doorbell poll thread's acquire-load (invalid_retry) cannot
+  // observe a stale "pending" after this handler has re-fetched; pairs with the
+  // release-store at the INVALID-packet site.
+  invalid_pending_.store(false, std::memory_order_release);
   util::Logger::cp(
       [&](auto &os) { os << std::format("{}: DOORBELL queues={}", name(), hw_queues_.size()); });
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -29,7 +29,6 @@ RJ_DIAGNOSTIC_POP
 #include <format>
 #include <limits>
 #include <optional>
-#include <set>
 #include <stdexcept>
 #include <string>
 #include <sys/mman.h>
@@ -391,13 +390,16 @@ void CommandProcessor::register_queue(HwQueue queue) {
                       reinterpret_cast<uintptr_t>(queue.doorbell_base));
   });
   bool start_poll = queue.host_accessible;
+  bool host_accessible = queue.host_accessible;
   {
     std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
     HwQueueState qs{};
     qs.queue_desc_va = queue.queue_desc_va;
     hw_queues_.push_back(std::move(queue));
     new_queue_states_.push_back(std::move(qs));
-    if (!is_primary_ && engine()) {
+    // KFD queues rely on the VM-level primary (rj_vm.cpp); only internal test
+    // queues need the CP to own the primary lifecycle.
+    if (!is_primary_ && engine() && !host_accessible) {
       engine()->register_as_primary();
       is_primary_ = true;
     }
@@ -519,9 +521,19 @@ void CommandProcessor::doorbell_poll_loop(std::stop_token stop) {
   using namespace std::chrono_literals;
   uint64_t poll_count = 0;
   while (!stop.stop_requested()) {
-    if (scan_doorbells())
+    bool doorbell_changed = scan_doorbells();
+    // Retry on a pending INVALID packet (the runtime has not finished writing it
+    // yet) even when no doorbell value changed. Pace those retries with the same
+    // 100us idle wait rather than spinning: a real doorbell change fires the event
+    // immediately (latency-sensitive), but an INVALID retry only needs to poll
+    // until the runtime finalizes the header, so it should not burn a core.
+    bool invalid_retry = !doorbell_changed && invalid_pending_.load(std::memory_order_acquire);
+    if (doorbell_changed)
       engine()->schedule_event_now(&doorbell_event_);
-    else
+    else if (invalid_retry) {
+      std::this_thread::sleep_for(100us);
+      engine()->schedule_event_now(&doorbell_event_);
+    } else
       std::this_thread::sleep_for(100us);
     ++poll_count;
 
@@ -1098,7 +1110,7 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   qs.entries.push_back(std::move(dp));
 }
 
-void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
+void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdojo::Tick now) {
   if (!memory_)
     return;
   if (queue.host_accessible ? (queue.doorbell_base == nullptr) : (queue.doorbell_va == 0))
@@ -1133,7 +1145,7 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
     });
     if (read_idx >= write_idx)
       return;
-    process_sdma_ring(queue, read_idx, write_idx);
+    process_sdma_ring(queue, read_idx, write_idx, now);
     return;
   }
 
@@ -1167,19 +1179,35 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
     }
 
     uint8_t pkt_type = pkt.header & 0xFF;
-    util::Logger::vm([&](auto &os) {
-      os << std::format("PKT q={} slot={} type={} header={:#x} read_idx={}", queue.queue_id, slot,
-                        pkt_type, pkt.header, read_idx);
+    util::Logger::cp([&](auto &os) {
+      auto type_name = [](uint8_t t) -> const char * {
+        switch (t) {
+        case 0:
+          return "VENDOR_SPECIFIC";
+        case 1:
+          return "INVALID";
+        case 2:
+          return "KERNEL_DISPATCH";
+        case 3:
+          return "BARRIER_AND";
+        case 5:
+          return "BARRIER_OR";
+        default:
+          return "UNKNOWN";
+        }
+      };
+      os << std::format("PKT q={} slot={} type={}({}) header={:#x} barrier_bit={} read_idx={}",
+                        queue.queue_id, slot, pkt_type, type_name(pkt_type), pkt.header,
+                        (pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1, read_idx);
     });
 
     if (pkt_type == HSA_PACKET_TYPE_INVALID) {
-      auto *host_ptr = memory_->resolve_host_ptr(pkt_addr, queue.process_id);
-      uint16_t raw_header = 0;
-      if (host_ptr)
-        std::memcpy(&raw_header, host_ptr, sizeof(raw_header));
-      util::Logger::warn("INVALID pkt at 0x", std::hex, pkt_addr, " host=0x",
-                         reinterpret_cast<uintptr_t>(host_ptr), " raw=0x", raw_header);
+      util::Logger::cp([&](auto &os) {
+        os << std::format("{}: INVALID_RETRY q={} slot={} read_idx={} va={:#x}", name(),
+                          queue.queue_id, slot, read_idx, pkt_addr);
+      });
       process_limit = read_idx;
+      invalid_pending_.store(true, std::memory_order_release);
       break;
     }
 
@@ -1218,11 +1246,13 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
       }
       if (!has_deps)
         deps_satisfied = true;
+      util::Logger::cp([&](auto &os) {
+        os << std::format("BARRIER_DEP q={} type={} deps_ok={} has_deps={}", queue.queue_id,
+                          is_and ? "AND" : "OR", deps_satisfied, has_deps);
+      });
       if (!deps_satisfied) {
-        // Dependencies not ready. Stop fetching — don't advance read pointer
-        // past this packet. Schedule a re-check via doorbell event.
         process_limit = read_idx;
-        engine()->schedule_event_now(&doorbell_event_);
+        schedule_event(&doorbell_event_, now + 1);
         break;
       }
 
@@ -1241,6 +1271,10 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
     } else if (pkt_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC) {
       AmdExtKernelDispatchPacket ext{};
       std::memcpy(&ext, &pkt, sizeof(ext));
+      util::Logger::cp([&](auto &os) {
+        os << std::format("VENDOR_PKT q={} amd_format={} dep_sig={:#x}", queue.queue_id,
+                          ext.amd_format, ext.dep_signal.handle);
+      });
       if (ext.amd_format == kHsaAmdPacketTypeBarrierValue) {
         AmdBarrierValuePacket barrier{};
         std::memcpy(&barrier, &pkt, sizeof(barrier));
@@ -1292,9 +1326,13 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
           constexpr uint32_t SIG_VAL_OFF = 8;
           auto v = static_cast<int64_t>(
               read_gpu_u64(ext.dep_signal.handle + SIG_VAL_OFF, queue.process_id));
+          util::Logger::cp([&](auto &os) {
+            os << std::format("VENDOR_DEP_CHECK q={} dep_sig={:#x} val={}", queue.queue_id,
+                              ext.dep_signal.handle, v);
+          });
           if (v != 0) {
             process_limit = read_idx;
-            engine()->schedule_event_now(&doorbell_event_);
+            schedule_event(&doorbell_event_, now + 1);
             break;
           }
         }
@@ -1357,13 +1395,8 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
   }
 }
 
-void CommandProcessor::fetch_packets() {
-  std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
-  for (size_t i = 0; i < hw_queues_.size(); ++i)
-    fetch_from_queue(hw_queues_[i], new_queue_states_[i]);
-}
-
-void CommandProcessor::handle_doorbell(simdojo::Tick) {
+void CommandProcessor::handle_doorbell(simdojo::Tick now) {
+  invalid_pending_.store(false, std::memory_order_relaxed);
   util::Logger::cp(
       [&](auto &os) { os << std::format("{}: DOORBELL queues={}", name(), hw_queues_.size()); });
 
@@ -1375,7 +1408,7 @@ void CommandProcessor::handle_doorbell(simdojo::Tick) {
 
   // Fetch packets (uses last_doorbell values set by the poll thread).
   for (size_t i = 0; i < hw_queues_.size(); ++i)
-    fetch_from_queue(hw_queues_[i], new_queue_states_[i]);
+    fetch_from_queue(hw_queues_[i], new_queue_states_[i], now);
 
   // Ensure interrupt callback is set on completion tracker.
   if (completion_ && interrupt_cb_)
@@ -1471,13 +1504,27 @@ void CommandProcessor::handle_doorbell(simdojo::Tick) {
         ++active_cus;
     os << std::format("{}: PHASE1_DONE remaining={} active_cus={}/{}", name(), remaining,
                       active_cus, cus_.size());
+    for (size_t qi = 0; qi < new_queue_states_.size(); ++qi) {
+      auto &qs = new_queue_states_[qi];
+      if (qs.entries.empty())
+        continue;
+      os << std::format("\n  queue[{}] entries={} next_disp={} implicit_barrier={}", qi,
+                        qs.entries.size(), qs.next_dispatch_idx, qs.implicit_barrier_next);
+      for (size_t ei = 0; ei < qs.entries.size(); ++ei) {
+        auto &e = qs.entries[ei];
+        os << std::format(
+            "\n    [{}] d={} qid={} total_wgs={} disp={} comp={} barrier={} sig={:#x} non_kern={}",
+            ei, e.dispatch_id, e.queue_id, e.total_wgs, e.dispatched_wgs, e.completed_wgs,
+            e.barrier_bit, e.completion_signal, e.is_non_kernel());
+      }
+    }
   });
 
   // Re-fetch: pick up any packets the host submitted while we were executing
   // (e.g., barrier packets queued after a kernel dispatch). Process them
   // immediately so host signal waits see completed barriers before returning.
   for (size_t i = 0; i < hw_queues_.size(); ++i)
-    fetch_from_queue(hw_queues_[i], new_queue_states_[i]);
+    fetch_from_queue(hw_queues_[i], new_queue_states_[i], now);
   // Process any new non-kernel entries (barriers with total_wgs==0).
   for (size_t qi = 0; qi < hw_queues_.size(); ++qi) {
     auto &qs = new_queue_states_[qi];
@@ -1494,8 +1541,10 @@ void CommandProcessor::handle_doorbell(simdojo::Tick) {
   if (completion_)
     completion_->drain_completions(new_queue_states_);
 
-  // Register as primary on first dispatch.
-  if (!is_primary_ && pending_entries() > 0) {
+  // Register as primary on first dispatch (internal test queues only).
+  // KFD queues rely on the VM-level primary registered at rj_vm.cpp.
+  bool kfd = has_kfd_queues();
+  if (!is_primary_ && pending_entries() > 0 && !kfd) {
     engine()->register_as_primary();
     is_primary_ = true;
   }
@@ -1509,24 +1558,20 @@ void CommandProcessor::handle_doorbell(simdojo::Tick) {
     }
   }
 
-  bool do_teardown = false;
   bool all_done = completion_ && completion_->all_complete(new_queue_states_);
-  bool kfd = has_kfd_queues();
-  if (all_done && !kfd) {
-    if (is_primary_)
-      do_teardown = true;
-  }
+  bool should_release = all_done && is_primary_ && !kfd;
+
   util::Logger::cp([&](auto &os) {
-    os << std::format("{}: TEARDOWN_CHECK all_done={} kfd={} primary={} teardown={}", name(),
-                      all_done, kfd, is_primary_, do_teardown);
+    os << std::format("{}: TEARDOWN_CHECK all_done={} kfd={} primary={} release={}", name(),
+                      all_done, kfd, is_primary_, should_release);
   });
 
+  // CRITICAL: must unlock before stop_doorbell_monitor() — the doorbell poll
+  // thread takes hw_queue_mutex_ in scan_doorbells(); joining while holding
+  // the lock would deadlock.
   lock.unlock();
 
-  if (do_teardown) {
-    util::Logger::cp([&](auto &os) {
-      os << std::format("{}: STOPPING doorbell monitor + primary_release", name());
-    });
+  if (should_release) {
     stop_doorbell_monitor();
     engine()->primary_release();
     is_primary_ = false;
@@ -1656,7 +1701,8 @@ void CommandProcessor::invalidate_gpu_caches() {
     cu->l1_vector().invalidate_all();
 }
 
-void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint64_t write_idx) {
+void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint64_t write_idx,
+                                         simdojo::Tick now) {
   uint32_t ring_mask = (queue.ring_size / sizeof(uint32_t)) - 1;
 
   uint64_t rpos = read_idx / sizeof(uint32_t);
@@ -1699,7 +1745,7 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
   // write below to incorrectly advance past the pending packet.
   auto stop_and_retry_current_packet = [&] {
     write_read_ptr();
-    engine()->schedule_event_now(&doorbell_event_);
+    schedule_event(&doorbell_event_, now + 1);
   };
 
   while (rpos < wpos) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -700,6 +700,12 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
   uint32_t dispatched = 0;
   auto dispatch_to_placement = [&](uint32_t local_wg_id, uint32_t global_wg_id,
                                    const ShaderProcessorInput::WorkgroupPlacement &placement) {
+    // Fire the dispatch-execution-begin hook exactly once, on the first workgroup
+    // actually placed on a CU, guarded by the per-dispatch flag.
+    if (!entry.execution_begun) {
+      entry.execution_begun = true;
+      plugin_group_->onAmdgpuDispatchExecutionBegin(entry.dispatch_id);
+    }
     ComputeUnitCore *cu = placement.cu;
     uint32_t lds_base = placement.lds_base;
     cu->begin_workgroup(entry.dispatch_id, global_wg_id, entry.wfs_per_workgroup);
@@ -820,6 +826,11 @@ void CommandProcessor::notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id) 
     completion_->notify_wg_complete(dispatch_id, wg_id, new_queue_states_);
 }
 
+// INVARIANT: on_cu_idle() runs on the owning partition's engine thread — it is
+// invoked from CU::execute_quantum() (the CU's own per-partition tick event), so
+// the CU, this CP, and doorbell_event_ all share one partition. schedule_event()
+// (same-partition, non-thread-safe) is correct here; schedule_event_now() would
+// collapse ticks and break causal ordering.
 void CommandProcessor::on_cu_idle() {
   if (cus_.empty())
     return;
@@ -829,43 +840,8 @@ void CommandProcessor::on_cu_idle() {
   if (completion_)
     completion_->drain_completions(new_queue_states_);
 
-  for (auto &qs : new_queue_states_) {
-    while (qs.next_dispatch_idx < qs.entries.size()) {
-      auto &e = qs.entries[qs.next_dispatch_idx];
-      if (e.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
-        break;
-      if (!e.is_non_kernel())
-        break;
-      e.completed_wgs = e.total_wgs;
-      ++qs.next_dispatch_idx;
-    }
-  }
-  if (completion_)
-    completion_->drain_completions(new_queue_states_);
-
-  std::vector<bool> was_idle(cus_.size());
-  for (size_t i = 0; i < cus_.size(); ++i)
-    was_idle[i] = !cus_[i]->has_active_wfs();
-
-  for (auto &qs : new_queue_states_) {
-    if (qs.next_dispatch_idx < qs.entries.size()) {
-      auto &entry = qs.entries[qs.next_dispatch_idx];
-      if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
-        continue;
-      if (!entry.is_non_kernel() && !entry.fully_dispatched()) {
-        if (entry.dispatched_wgs == 0)
-          plugin_group_->onAmdgpuDispatchExecutionBegin(entry.dispatch_id);
-        uint32_t sent = dispatch_workgroups(entry);
-        if (sent > 0 && entry.fully_dispatched())
-          ++qs.next_dispatch_idx;
-      }
-    }
-  }
-
-  for (size_t i = 0; i < cus_.size(); ++i) {
-    if (was_idle[i] && cus_[i]->has_active_wfs())
-      cus_[i]->activate();
-  }
+  auto now = engine()->context(partition_id()).current_tick();
+  schedule_event(&doorbell_event_, now + 1);
 }
 
 bool CommandProcessor::step() {
@@ -1444,8 +1420,6 @@ void CommandProcessor::handle_doorbell(simdojo::Tick) {
         // NOTE: drain_completions may pop entries, so we must re-check indices
         // after each drain and not hold stale references.
         uint32_t dispatch_id = entry.dispatch_id;
-        if (entry.dispatched_wgs == 0)
-          plugin_group_->onAmdgpuDispatchExecutionBegin(dispatch_id);
         bool backpressure = false;
         for (;;) {
           if (qs.next_dispatch_idx >= qs.entries.size())
@@ -1531,7 +1505,7 @@ void CommandProcessor::handle_doorbell(simdojo::Tick) {
       if (dispatch_ports_[i]->link())
         dispatch_ports_[i]->send(std::make_unique<simdojo::Message>(simdojo::MessageHeader{}));
       else
-        cus_[i]->activate();
+        cus_[i]->schedule_work();
     }
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -699,6 +699,18 @@ void CommandProcessor::mark_cluster_workgroup_complete(uint32_t dispatch_id, uin
     cluster_wg_placements_.erase(wg_key(dispatch_id, peer_wg_id));
 }
 
+void CommandProcessor::erase_cluster_workgroup(uint32_t dispatch_id, uint32_t wg_id) {
+  std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+  auto it = cluster_wg_placements_.find(wg_key(dispatch_id, wg_id));
+  if (it == cluster_wg_placements_.end())
+    return;
+  if (it->second.cu) {
+    it->second.cu->unpin_lds_for_cluster(it->second.cluster_key);
+    it->second.cu->maybe_reset_lds_alloc();
+  }
+  cluster_wg_placements_.erase(it);
+}
+
 void CommandProcessor::erase_cluster_workgroups(uint32_t dispatch_id) {
   std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
   for (auto it = cluster_wg_placements_.begin(); it != cluster_wg_placements_.end();) {
@@ -881,11 +893,32 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
         break;
       }
       next_cu_ = planned_next_cu;
-      for (const auto &wg : plan) {
-        ShaderProcessorInput::WorkgroupPlacement placement{
-            wg.cu, &wg.cu->lds(), wg.cu->allocate_lds(entry.group_segment_fixed_size)};
-        if (!dispatch_to_placement(wg.local_wg_id, wg.global_wg_id, placement))
-          throw std::runtime_error("dispatch_wf failed after cluster placement was reserved");
+      // A cluster is all-or-nothing: dispatch_to_placement() commits each peer's WG
+      // bookkeeping (begin_workgroup) and LDS cluster pin (register_cluster_workgroup)
+      // as it succeeds. If a later peer fails (dispatch_wf null or an init_wavefront_regs
+      // throw), the already-committed peers would otherwise keep their refcount and pin
+      // forever, permanently blocking maybe_reset_lds_alloc() on those CUs. Track the
+      // committed peers and roll them back on any failure before propagating the error.
+      std::vector<std::pair<ComputeUnitCore *, uint32_t>> committed_peers;
+      committed_peers.reserve(plan.size());
+      try {
+        for (const auto &wg : plan) {
+          ShaderProcessorInput::WorkgroupPlacement placement{
+              wg.cu, &wg.cu->lds(), wg.cu->allocate_lds(entry.group_segment_fixed_size)};
+          if (!dispatch_to_placement(wg.local_wg_id, wg.global_wg_id, placement))
+            throw std::runtime_error("dispatch_wf failed after cluster placement was reserved");
+          committed_peers.emplace_back(wg.cu, wg.global_wg_id);
+        }
+      } catch (...) {
+        // Roll back the peers committed before the failure (dispatch_to_placement
+        // already unwound its own reserved-but-uncommitted waves). erase_cluster_workgroup
+        // unpins that peer's cluster LDS and drops its placement; abort_workgroup frees
+        // its resident waves and clears the WG refcount without a completion notify.
+        for (const auto &[cu, gwg] : committed_peers) {
+          erase_cluster_workgroup(entry.dispatch_id, gwg);
+          cu->abort_workgroup(entry.dispatch_id, gwg);
+        }
+        throw;
       }
       continue;
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -545,14 +545,19 @@ void CommandProcessor::doorbell_poll_loop(std::stop_token stop) {
   while (!stop.stop_requested()) {
     bool doorbell_changed = scan_doorbells();
     // Retry on a pending INVALID packet (the runtime has not finished writing it
-    // yet) even when no doorbell value changed. Pace those retries with the same
-    // 100us idle wait rather than spinning: a real doorbell change fires the event
-    // immediately (latency-sensitive), but an INVALID retry only needs to poll
-    // until the runtime finalizes the header, so it should not burn a core.
-    bool invalid_retry = !doorbell_changed && invalid_pending_.load(std::memory_order_acquire);
+    // yet) OR a pending barrier/dependency stall (waiting on a signal a peer rank
+    // or another queue will write) even when no doorbell value changed. Pace those
+    // retries with the same 100us idle wait rather than spinning: a real doorbell
+    // change fires the event immediately (latency-sensitive), but a pending retry
+    // only needs to poll until the awaited state changes, so it must not burn a
+    // core. Rescheduling these on the main event queue (now+1) instead would spin
+    // simulated time millions of ticks per collective while wall-clock RPC latency
+    // elapses — the RCCL slowdown this replaces.
+    bool retry = !doorbell_changed && (invalid_pending_.load(std::memory_order_acquire) ||
+                                       stall_pending_.load(std::memory_order_acquire));
     if (doorbell_changed)
       engine()->schedule_event_now(&doorbell_event_);
-    else if (invalid_retry) {
+    else if (retry) {
       std::this_thread::sleep_for(100us);
       engine()->schedule_event_now(&doorbell_event_);
     } else
@@ -1217,6 +1222,17 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   qs.entries.push_back(std::move(dp));
 }
 
+void CommandProcessor::arm_stall_recheck(simdojo::Tick now) {
+  // A doorbell poll thread runs only for host-accessible (KFD) queues; it re-checks
+  // stall_pending_ at its 100us cadence, so the engine can idle instead of spinning.
+  // Internal test queues have no poll thread — they are driven by engine->run()/
+  // step() — so there the re-check must be kept alive on the main event queue.
+  if (has_kfd_queues())
+    stall_pending_.store(true, std::memory_order_release);
+  else
+    schedule_event(&doorbell_event_, now + 1);
+}
+
 void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdojo::Tick now) {
   if (!memory_)
     return;
@@ -1358,8 +1374,11 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
                           is_and ? "AND" : "OR", deps_satisfied, has_deps);
       });
       if (!deps_satisfied) {
+        // Stall this queue until the dependency signal is satisfied (by an SDMA
+        // queue on this engine, or a peer rank's completion arriving via the
+        // daemon). arm_stall_recheck() re-arms without spinning simulated time.
         process_limit = read_idx;
-        schedule_event(&doorbell_event_, now + 1);
+        arm_stall_recheck(now);
         break;
       }
 
@@ -1412,15 +1431,12 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
         }
 
         if (!condition_satisfied) {
-          // The packet stalls this queue, but other queues (notably SDMA) must
-          // keep running so they can satisfy the dependency. fetch_from_queue runs
-          // on the engine thread (via handle_doorbell), so reschedule with
-          // schedule_event(now + 1) — advancing the tick per re-check — like the
-          // sibling barrier/vendor-dep retries. schedule_event_now() is only for the
-          // external doorbell poll thread; using it here would collapse re-checks
-          // onto one tick and take the async queue's lock needlessly.
+          // The barrier-value packet stalls this queue until the awaited signal
+          // reaches its target value (written by another queue on this engine or a
+          // peer rank via the daemon). arm_stall_recheck() re-arms the re-check
+          // without spinning simulated time.
           process_limit = read_idx;
-          schedule_event(&doorbell_event_, now + 1);
+          arm_stall_recheck(now);
           break;
         }
 
@@ -1443,8 +1459,10 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
                               ext.dep_signal.handle, v);
           });
           if (v != 0) {
+            // Vendor kernel-dispatch dependency not yet satisfied: re-arm the
+            // re-check via arm_stall_recheck() without spinning simulated time.
             process_limit = read_idx;
-            schedule_event(&doorbell_event_, now + 1);
+            arm_stall_recheck(now);
             break;
           }
         }
@@ -1508,10 +1526,12 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
 }
 
 void CommandProcessor::handle_doorbell(simdojo::Tick now) {
-  // Release so the doorbell poll thread's acquire-load (invalid_retry) cannot
-  // observe a stale "pending" after this handler has re-fetched; pairs with the
-  // release-store at the INVALID-packet site.
+  // Release so the doorbell poll thread's acquire-load cannot observe a stale
+  // "pending" after this handler has re-fetched; pairs with the release-stores at
+  // the INVALID-packet and barrier/dependency stall sites. A site that is still
+  // unsatisfied on this pass re-sets its flag below, re-arming the paced re-check.
   invalid_pending_.store(false, std::memory_order_release);
+  stall_pending_.store(false, std::memory_order_release);
   util::Logger::cp(
       [&](auto &os) { os << std::format("{}: DOORBELL queues={}", name(), hw_queues_.size()); });
 
@@ -1860,7 +1880,9 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
   // write below to incorrectly advance past the pending packet.
   auto stop_and_retry_current_packet = [&] {
     write_read_ptr();
-    schedule_event(&doorbell_event_, now + 1);
+    // Wait/poll SDMA packet, or a packet whose translated VA is not yet ready:
+    // arm_stall_recheck() re-arms the re-check without spinning simulated time.
+    arm_stall_recheck(now);
   };
 
   while (rpos < wpos) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -372,8 +372,8 @@ void CommandProcessor::startup() {
   for ([[maybe_unused]] const auto *cu : cus_)
     assert(cu->partition_id() == partition_id() &&
            "CommandProcessor and its compute units must share one partition");
-  doorbell_event_.set_handler(
-      [this](simdojo::Tick ts, simdojo::Message *) { handle_doorbell(ts); });
+  // doorbell_event_'s handler is bound in the constructor (see there) so it is live
+  // before register_queue() can start the poll thread; nothing to (re)bind here.
   completion_ = std::make_unique<CompletionTracker>(memory_, cus_);
   completion_->set_plugin_group(plugin_group_);
   completion_->set_dispatch_retired_callback(
@@ -790,17 +790,27 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
     // "completed" wave. free_wavefront_resources() frees the SGPR/VGPR blocks and
     // resets the slot without the hook or a CP completion notify — and since
     // begin_workgroup() has not run, there is no active_wgs_ entry / cluster pin to
-    // unwind either. Also reclaim the placement's LDS bump: the SPI already advanced
-    // the CU's next_lds_alloc_ (allocate_lds) before this call, and normally only a
-    // WG completing via release_wf() resets it; on this failure path
-    // maybe_reset_lds_alloc() rolls it back iff the CU is now idle (freeing these
-    // waves left no active waves) and unpinned, so a leaked bump cannot starve later
-    // placements. It correctly no-ops when peers of the same dispatch are resident.
+    // unwind either. Also reclaim the placement's LDS/WGP reservation symmetrically
+    // with how it was reserved:
+    //   - CU / cluster mode: the SPI (or the direct CU path) advanced the CU's
+    //     next_lds_alloc_ via allocate_lds(); maybe_reset_lds_alloc() rolls it back
+    //     iff the CU is now idle (freeing these waves left no active waves) and
+    //     unpinned. It correctly no-ops when peers of the same dispatch are resident.
+    //   - WGP mode: allocate_workgroup() reserved SPI-side state (wgp.next_lds_alloc,
+    //     wgp.active_workgroups, resident_wgp_workgroups_) that is NOT CU-local, so
+    //     maybe_reset_lds_alloc() cannot reach it; release_wgp_workgroup() is the
+    //     matching release (the same call notify_wg_complete uses on the normal path).
+    // Without the WGP release a failed WGP dispatch would permanently pin that WGP.
     std::vector<Wavefront *> wg_wavefronts;
     wg_wavefronts.reserve(entry.wfs_per_workgroup);
-    const auto free_reserved = [&wg_wavefronts, cu]() {
+    const auto free_reserved = [&]() {
       for (auto *claimed : wg_wavefronts)
         cu->free_wavefront_resources(*claimed);
+      if (entry.wgp_mode) {
+        for (auto *spi : spis_)
+          if (spi->release_wgp_workgroup(entry.dispatch_id, global_wg_id))
+            break;
+      }
       cu->maybe_reset_lds_alloc();
     };
     for (uint32_t w = 0; w < entry.wfs_per_workgroup; ++w) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -871,9 +871,9 @@ void CommandProcessor::notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id) 
 
 // INVARIANT: on_cu_idle() runs on the owning partition's engine thread — it is
 // invoked from CU::execute_quantum() (the CU's own per-partition tick event), so
-// the CU, this CP, and doorbell_event_ all share one partition. schedule_event()
-// (same-partition, non-thread-safe) is correct here; schedule_event_now() would
-// collapse ticks and break causal ordering.
+// the CU, this CP, and the CUs it dispatches to all share one partition. Dispatch
+// therefore happens inline (same-partition, non-thread-safe path); a
+// schedule_event_now() here would collapse ticks and break causal ordering.
 void CommandProcessor::on_cu_idle() {
   if (cus_.empty())
     return;
@@ -883,8 +883,40 @@ void CommandProcessor::on_cu_idle() {
   if (completion_)
     completion_->drain_completions(new_queue_states_);
 
-  auto now = engine()->context(partition_id()).current_tick();
-  schedule_event(&doorbell_event_, now + 1);
+  // Retire any non-kernel entries (barriers with total_wgs==0) that are now at
+  // the head, then drain again so a dependent kernel behind them can proceed.
+  for (auto &qs : new_queue_states_) {
+    while (qs.next_dispatch_idx < qs.entries.size()) {
+      auto &e = qs.entries[qs.next_dispatch_idx];
+      if (e.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
+        break;
+      if (!e.is_non_kernel())
+        break;
+      e.completed_wgs = e.total_wgs;
+      ++qs.next_dispatch_idx;
+    }
+  }
+  if (completion_)
+    completion_->drain_completions(new_queue_states_);
+
+  // Continue dispatching pending workgroups onto the just-freed CU in this same
+  // tick rather than deferring to a now+1 doorbell event. Deferring routed every
+  // dispatch continuation through the doorbell path; across the many tiny kernels
+  // of an RCCL collective the engine would idle a full tick between steps, adding
+  // latency the host socket layer then paid for. dispatch_workgroups() schedules
+  // the CU's own tick event, so no explicit CU nudge is needed here.
+  for (auto &qs : new_queue_states_) {
+    if (qs.next_dispatch_idx < qs.entries.size()) {
+      auto &entry = qs.entries[qs.next_dispatch_idx];
+      if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
+        continue;
+      if (!entry.is_non_kernel() && !entry.fully_dispatched()) {
+        uint32_t sent = dispatch_workgroups(entry);
+        if (sent > 0 && entry.fully_dispatched())
+          ++qs.next_dispatch_idx;
+      }
+    }
+  }
 }
 
 bool CommandProcessor::step() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -361,6 +361,17 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
 }
 
 void CommandProcessor::startup() {
+  // INVARIANT: this CP and every CU it dispatches to share one partition (engine
+  // thread). on_cu_idle() dispatches inline and calls ComputeUnitCore::schedule_work()
+  // on those CUs, which mutates their non-atomic executing_/tick_event_ and pushes to
+  // the partition event queue without synchronization — safe only same-partition. The
+  // recursive-bisection partitioner (topology.partition(), run in the engine's
+  // create() before startup) could in principle split a CP from a CU under
+  // num_threads > 1; assert here (after partitioning, before the run loop) so any such
+  // split fails loudly rather than silently racing.
+  for ([[maybe_unused]] const auto *cu : cus_)
+    assert(cu->partition_id() == partition_id() &&
+           "CommandProcessor and its compute units must share one partition");
   doorbell_event_.set_handler(
       [this](simdojo::Tick ts, simdojo::Message *) { handle_doorbell(ts); });
   completion_ = std::make_unique<CompletionTracker>(memory_, cus_);
@@ -411,15 +422,18 @@ void CommandProcessor::register_queue(HwQueue queue) {
       engine()->primary_release();
       is_primary_ = false;
     }
-  }
-  // Only start the doorbell poll thread for KFD (host-accessible) queues.
-  // Internal test queues inject doorbell events directly via schedule_event_now().
-  // NOTE: the joinable() check is intentionally outside hw_queue_mutex_ — this
-  // is safe because ROCR always creates queues from a single thread (the HSA
-  // queue-creation path is not re-entrant), so there is no concurrent caller.
-  if (start_poll && !doorbell_thread_.joinable()) {
-    util::Logger::cp([&](auto &os) { os << std::format("{}: STARTING doorbell thread", name()); });
-    doorbell_thread_ = std::jthread([this](std::stop_token stop) { doorbell_poll_loop(stop); });
+    // Start the doorbell poll thread for KFD (host-accessible) queues under the
+    // same lock that guards doorbell_thread_'s companion state. Internal test
+    // queues inject doorbell events directly via schedule_event_now(). Starting the
+    // jthread while holding hw_queue_mutex_ is safe: the new thread's first action
+    // (scan_doorbells) takes hw_queue_mutex_, so it simply blocks until this scope
+    // releases. Holding the lock also removes a data race on doorbell_thread_ if a
+    // second register_queue ever runs concurrently.
+    if (start_poll && !doorbell_thread_.joinable()) {
+      util::Logger::cp(
+          [&](auto &os) { os << std::format("{}: STARTING doorbell thread", name()); });
+      doorbell_thread_ = std::jthread([this](std::stop_token stop) { doorbell_poll_loop(stop); });
+    }
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -542,6 +542,13 @@ bool CommandProcessor::scan_doorbells() {
 void CommandProcessor::doorbell_poll_loop(std::stop_token stop) {
   using namespace std::chrono_literals;
   uint64_t poll_count = 0;
+  // INVARIANT: this loop must re-read invalid_pending_/stall_pending_ (below) on
+  // EVERY iteration, unconditionally. Those flags are level-triggered — the engine
+  // clears them at handle_doorbell entry and re-sets them if a stall is still
+  // unsatisfied — so this unconditional 100us heartbeat re-check is what guarantees a
+  // pending stall is eventually retried. A future change that lets the loop skip the
+  // flag re-read on some iterations (an early continue before the retry check) would
+  // reintroduce a lost-wakeup.
   while (!stop.stop_requested()) {
     bool doorbell_changed = scan_doorbells();
     // Retry on a pending INVALID packet (the runtime has not finished writing it
@@ -783,12 +790,18 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
     // "completed" wave. free_wavefront_resources() frees the SGPR/VGPR blocks and
     // resets the slot without the hook or a CP completion notify — and since
     // begin_workgroup() has not run, there is no active_wgs_ entry / cluster pin to
-    // unwind either.
+    // unwind either. Also reclaim the placement's LDS bump: the SPI already advanced
+    // the CU's next_lds_alloc_ (allocate_lds) before this call, and normally only a
+    // WG completing via release_wf() resets it; on this failure path
+    // maybe_reset_lds_alloc() rolls it back iff the CU is now idle (freeing these
+    // waves left no active waves) and unpinned, so a leaked bump cannot starve later
+    // placements. It correctly no-ops when peers of the same dispatch are resident.
     std::vector<Wavefront *> wg_wavefronts;
     wg_wavefronts.reserve(entry.wfs_per_workgroup);
     const auto free_reserved = [&wg_wavefronts, cu]() {
       for (auto *claimed : wg_wavefronts)
         cu->free_wavefront_resources(*claimed);
+      cu->maybe_reset_lds_alloc();
     };
     for (uint32_t w = 0; w < entry.wfs_per_workgroup; ++w) {
       Wavefront *wf = cu->dispatch_wf(global_wg_id, entry.kernel_entry_pc, entry.sgprs_per_wf,
@@ -1334,6 +1347,13 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
                           queue.queue_id, slot, read_idx, pkt_addr);
       });
       process_limit = read_idx;
+      // The runtime has not finished writing this packet's header. invalid_pending_
+      // mirrors the barrier/dependency stalls' stall_pending_: the KFD poll thread
+      // re-checks at its 100us cadence (both flags gate the same poll-loop nudge).
+      // Unlike those stalls this has no internal-test-queue fallback because a test
+      // writes the whole packet before ringing the doorbell, so a test queue never
+      // observes an in-flight INVALID header (the only writer that leaves one is the
+      // real runtime racing the doorbell, which always has a poll thread).
       invalid_pending_.store(true, std::memory_order_release);
       break;
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -567,13 +567,22 @@ void CommandProcessor::doorbell_poll_loop(std::stop_token stop) {
     // signal. Re-broadcasting every ~10ms ensures late-created events see
     // the idle state within a bounded window.
     if (poll_count % 100 == 0) {
-      std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
-      for (size_t i = 0; i < hw_queues_.size(); ++i) {
-        if (new_queue_states_[i].entries.empty() && hw_queues_[i].process_id != 0) {
-          if (interrupt_cb_)
-            interrupt_cb_(hw_queues_[i].process_id, 0);
+      // Snapshot the idle queues' process ids under the lock, then fire interrupt_cb_
+      // OUTSIDE it. interrupt_cb_ is an external KFD-layer callback whose internal
+      // locking is opaque to the CP; invoking it while holding hw_queue_mutex_ risks a
+      // lock-order inversion if that callback ever takes a lock held elsewhere while
+      // acquiring hw_queue_mutex_.
+      std::vector<uint32_t> idle_pids;
+      {
+        std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+        for (size_t i = 0; i < hw_queues_.size(); ++i) {
+          if (new_queue_states_[i].entries.empty() && hw_queues_[i].process_id != 0)
+            idle_pids.push_back(hw_queues_[i].process_id);
         }
       }
+      if (interrupt_cb_)
+        for (uint32_t pid : idle_pids)
+          interrupt_cb_(pid, 0);
     }
 
     if (poll_count % 5000 == 1) {
@@ -754,32 +763,34 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
     }
     ComputeUnitCore *cu = placement.cu;
     uint32_t lds_base = placement.lds_base;
-    // Reserve all waves BEFORE committing WG-completion bookkeeping. begin_workgroup()
-    // installs the WG refcount and register_cluster_workgroup() installs the LDS pin;
-    // both are released only via release_wf() when the waves halt. Committing them
-    // first and then failing mid-workgroup (a dispatch_wf null) would orphan the
-    // refcount and pin, permanently blocking maybe_reset_lds_alloc() on this CU.
-    // Placement is already gated on can_accept_workgroup()/cluster planning, so this
-    // dry allocation cannot actually fail — but doing it up front makes the commit
-    // below all-or-nothing.
+    // Reserve AND fully initialize all waves BEFORE committing WG-completion
+    // bookkeeping. begin_workgroup() installs the WG refcount and
+    // register_cluster_workgroup() installs the LDS pin; both are released only via
+    // release_wf() when the waves halt. Committing them first and then failing
+    // mid-workgroup would orphan the refcount and pin, permanently blocking
+    // maybe_reset_lds_alloc() on this CU. Two failure modes are covered by doing all
+    // fallible work up front: a dispatch_wf() null (placement gating makes this
+    // unreachable, but the assert is compiled out in release), and a throw from
+    // init_wavefront_regs() (malformed kernarg-preload / undersized TTMP SGPR block).
+    // On either, halt the reserved-but-uncommitted waves — release_wf() is a no-op
+    // for a WG with no active_wgs_ entry — and fail/rethrow without having touched
+    // the WG refcount or cluster pin.
     std::vector<Wavefront *> wg_wavefronts;
     wg_wavefronts.reserve(entry.wfs_per_workgroup);
+    const auto halt_reserved = [&wg_wavefronts]() {
+      for (auto *claimed : wg_wavefronts)
+        claimed->halt();
+    };
     for (uint32_t w = 0; w < entry.wfs_per_workgroup; ++w) {
       Wavefront *wf = cu->dispatch_wf(global_wg_id, entry.kernel_entry_pc, entry.sgprs_per_wf,
                                       entry.vgprs_per_wf);
       if (!wf) {
-        // Unreachable given the placement gating; free any waves already claimed for
-        // this WG and fail without having touched the WG refcount / cluster pin.
         assert(false && "dispatch_wf failed after placement was reserved");
-        for (auto *claimed : wg_wavefronts)
-          claimed->halt();
+        halt_reserved();
         return false;
       }
       wg_wavefronts.push_back(wf);
     }
-    cu->begin_workgroup(entry.dispatch_id, global_wg_id, entry.wfs_per_workgroup);
-    register_cluster_workgroup(entry, local_wg_id, global_wg_id, cu, lds_base);
-
     for (uint32_t w = 0; w < entry.wfs_per_workgroup; ++w) {
       Wavefront *wf = wg_wavefronts[w];
       wf->set_lds_base(lds_base);
@@ -788,8 +799,18 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
       wf->set_process_id(entry.process_id);
       wf->set_exec(initial_exec_mask_for_wave(entry, global_wg_id, w, cu->wf_size()));
       wf->set_cluster_info(entry.cluster_rank_for_local_wg(local_wg_id), entry.cluster_size());
-      init_wavefront_regs(cu, wf, entry, global_wg_id, w);
+      try {
+        init_wavefront_regs(cu, wf, entry, global_wg_id, w);
+      } catch (...) {
+        halt_reserved();
+        throw;
+      }
     }
+
+    // All fallible per-wave work succeeded: commit WG bookkeeping and the cluster pin.
+    cu->begin_workgroup(entry.dispatch_id, global_wg_id, entry.wfs_per_workgroup);
+    register_cluster_workgroup(entry, local_wg_id, global_wg_id, cu, lds_base);
+
     plugin_group_->onAmdgpuWorkgroupDispatched(entry.dispatch_id, global_wg_id,
                                                cu->vgpr_allocation_block_size(), entry.sgprs_per_wf,
                                                std::span<Wavefront *>(wg_wavefronts));
@@ -1657,7 +1678,7 @@ void CommandProcessor::handle_doorbell(simdojo::Tick now) {
 
   util::Logger::cp([&](auto &os) {
     os << std::format("{}: TEARDOWN_CHECK all_done={} kfd={} primary={} release={}", name(),
-                      all_done, kfd, is_primary_, should_release);
+                      all_done, kfd, is_primary_.load(), should_release);
   });
 
   // CRITICAL: must unlock before stop_doorbell_monitor() — the doorbell poll

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -777,21 +777,25 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
     // fallible work up front: a dispatch_wf() null (placement gating makes this
     // unreachable, but the assert is compiled out in release), and a throw from
     // init_wavefront_regs() (malformed kernarg-preload / undersized TTMP SGPR block).
-    // On either, halt the reserved-but-uncommitted waves — release_wf() is a no-op
-    // for a WG with no active_wgs_ entry — and fail/rethrow without having touched
-    // the WG refcount or cluster pin.
+    // On either, release the reserved-but-uncommitted waves. Use
+    // free_wavefront_resources() rather than halt(): these waves never executed, so
+    // firing halt()'s onAmdgpuWavefrontHalted hook would feed observers a spurious
+    // "completed" wave. free_wavefront_resources() frees the SGPR/VGPR blocks and
+    // resets the slot without the hook or a CP completion notify — and since
+    // begin_workgroup() has not run, there is no active_wgs_ entry / cluster pin to
+    // unwind either.
     std::vector<Wavefront *> wg_wavefronts;
     wg_wavefronts.reserve(entry.wfs_per_workgroup);
-    const auto halt_reserved = [&wg_wavefronts]() {
+    const auto free_reserved = [&wg_wavefronts, cu]() {
       for (auto *claimed : wg_wavefronts)
-        claimed->halt();
+        cu->free_wavefront_resources(*claimed);
     };
     for (uint32_t w = 0; w < entry.wfs_per_workgroup; ++w) {
       Wavefront *wf = cu->dispatch_wf(global_wg_id, entry.kernel_entry_pc, entry.sgprs_per_wf,
                                       entry.vgprs_per_wf);
       if (!wf) {
         assert(false && "dispatch_wf failed after placement was reserved");
-        halt_reserved();
+        free_reserved();
         return false;
       }
       wg_wavefronts.push_back(wf);
@@ -807,7 +811,7 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
       try {
         init_wavefront_regs(cu, wf, entry, global_wg_id, w);
       } catch (...) {
-        halt_reserved();
+        free_reserved();
         throw;
       }
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -389,7 +389,6 @@ void CommandProcessor::register_queue(HwQueue queue) {
                       reinterpret_cast<uintptr_t>(queue.doorbell_base));
   });
   bool start_poll = queue.host_accessible;
-  bool host_accessible = queue.host_accessible;
   {
     std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
     HwQueueState qs{};
@@ -397,10 +396,20 @@ void CommandProcessor::register_queue(HwQueue queue) {
     hw_queues_.push_back(std::move(queue));
     new_queue_states_.push_back(std::move(qs));
     // KFD queues rely on the VM-level primary (rj_vm.cpp); only internal test
-    // queues need the CP to own the primary lifecycle.
-    if (!is_primary_ && engine() && !host_accessible) {
+    // queues (no host-accessible queue anywhere on this CP) need the CP to own the
+    // primary lifecycle. Gate on the same aggregate predicate as the teardown
+    // release (!has_kfd_queues()) — checked AFTER the push_back so it reflects the
+    // new queue — so a CP can never register a primary it will never release.
+    if (!is_primary_ && engine() && !has_kfd_queues()) {
       engine()->register_as_primary();
       is_primary_ = true;
+    } else if (is_primary_ && engine() && has_kfd_queues()) {
+      // A KFD queue joined a CP that had registered a test-owned primary; the
+      // VM-level primary now anchors this CP's lifecycle, so drop the CP-owned
+      // primary to keep register/release symmetric (the teardown path only
+      // releases when !has_kfd_queues()).
+      engine()->primary_release();
+      is_primary_ = false;
     }
   }
   // Only start the doorbell poll thread for KFD (host-accessible) queues.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -179,14 +179,11 @@ private:
 
   void handle_doorbell(simdojo::Tick timestamp);
 
-  /// @brief Fetch AQL packets from all registered HW queues.
-  void fetch_packets();
-
   /// @brief Fetch AQL packets from a single HW queue.
-  void fetch_from_queue(HwQueue &queue, HwQueueState &qs);
+  void fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdojo::Tick now);
 
   /// @brief Process SDMA packets from an SDMA queue's ring buffer.
-  void process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint64_t write_idx);
+  void process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint64_t write_idx, simdojo::Tick now);
 
   /// @brief Coarse invalidate of the GPU data caches (L1 V$ + L2/GL2).
   /// @details Emulated SDMA and CP writes land directly in the backing store,
@@ -323,6 +320,8 @@ private:
   ScratchBackingResolver scratch_resolver_;
   ScratchBackingAllocator scratch_allocator_;
   std::unique_ptr<CompletionTracker> completion_;
+
+  std::atomic<bool> invalid_pending_{false};
 
   void doorbell_poll_loop(std::stop_token stop);
   std::jthread doorbell_thread_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -92,7 +92,15 @@ enum class SdmaPacketDialect {
 /// not on global CU idle. Signals fire in per-queue submission order.
 class CommandProcessor : public simdojo::Component {
 public:
-  explicit CommandProcessor(std::string name) : simdojo::Component(std::move(name)) {}
+  explicit CommandProcessor(std::string name) : simdojo::Component(std::move(name)) {
+    // Bind the doorbell handler at construction, not in startup(): register_queue()
+    // may start the doorbell poll thread (which fires doorbell_event_ via
+    // schedule_event_now) as soon as a host-accessible queue is registered, which can
+    // happen before startup() runs. Binding here removes that ordering hazard — a
+    // handlerless doorbell_event_ would be silently dropped by the engine.
+    doorbell_event_.set_handler(
+        [this](simdojo::Tick ts, simdojo::Message *) { handle_doorbell(ts); });
+  }
   ~CommandProcessor() override { stop_doorbell_monitor(); }
 
   void set_memory(GpuMemory *mem) { memory_ = mem; }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -180,6 +180,17 @@ private:
 
   void handle_doorbell(simdojo::Tick timestamp);
 
+  /// @brief Re-arm a re-check of a queue stalled on an unsatisfied external wait
+  /// (barrier/dependency signal, or an SDMA VA not yet translatable).
+  /// @details Runs on the engine thread. When a doorbell poll thread is monitoring
+  /// this CP (host-accessible/KFD queues), it sets stall_pending_ so the poll thread
+  /// re-nudges the idle engine at its 100us cadence — the engine must NOT reschedule
+  /// the doorbell on the main event queue, which models simulated timing and would
+  /// spin millions of ticks while wall-clock RPC latency elapses. Internal test
+  /// queues have no poll thread and are driven by engine->run()/step(), so there the
+  /// re-check must be kept alive by rescheduling the doorbell event at @p now + 1.
+  void arm_stall_recheck(simdojo::Tick now);
+
   /// @brief Fetch AQL packets from a single HW queue.
   void fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdojo::Tick now);
 
@@ -329,6 +340,17 @@ private:
   std::unique_ptr<CompletionTracker> completion_;
 
   std::atomic<bool> invalid_pending_{false};
+
+  // Set when a queue stalls on an unsatisfied barrier/dependency signal (or an
+  // SDMA VA not yet translatable) — a wait on progress that is external to the
+  // current engine pass (a peer rank's kernel completion arriving via the daemon,
+  // or a producer on another queue). Re-checking such a stall by rescheduling the
+  // doorbell event at now+1 spins the main event queue (which models simulated
+  // timing) millions of times per collective, pegging a core while wall-clock RPC
+  // latency elapses. Instead, like invalid_pending_, the doorbell poll thread
+  // re-nudges the (idle) engine at its 100us cadence so the stall is re-evaluated
+  // without a busy simulated-time spin.
+  std::atomic<bool> stall_pending_{false};
 
   void doorbell_poll_loop(std::stop_token stop);
   std::jthread doorbell_thread_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -32,6 +32,7 @@
 #include "simdojo/sim/component.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -275,7 +276,13 @@ private:
 
   size_t next_cu_ = 0;
   size_t next_queue_idx_ = 0;
-  bool is_primary_ = false;
+  // Almost always accessed under hw_queue_mutex_, but the teardown path in
+  // handle_doorbell() must clear it AFTER unlocking (stop_doorbell_monitor() joins
+  // the poll thread, which takes hw_queue_mutex_). Atomic so that lock-held reads in
+  // register_queue() cannot data-race that one unlocked write. Only the internal
+  // test-queue path (!has_kfd_queues()) ever sets it; KFD queues anchor the primary
+  // at the VM level (rj_vm.cpp).
+  std::atomic<bool> is_primary_ = false;
   uint32_t workgroup_id_offset_ = 0;
   uint32_t vgpr_granularity_ = 8;
   bool packed_tid_ = false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -241,6 +241,7 @@ private:
   void register_cluster_workgroup(const DispatchEntry &entry, uint32_t local_wg_id,
                                   uint32_t global_wg_id, ComputeUnitCore *cu, uint32_t lds_base);
   void mark_cluster_workgroup_complete(uint32_t dispatch_id, uint32_t wg_id);
+  void erase_cluster_workgroup(uint32_t dispatch_id, uint32_t wg_id);
   void erase_cluster_workgroups(uint32_t dispatch_id);
 
   /// @brief Asynchronous Compute Engine (ACE): dispatch workgroups from all

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -95,13 +95,8 @@ std::unique_ptr<ComputeUnitCore> ComputeUnitCore::create(std::string name, const
 Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t num_sgprs,
                                         uint32_t num_vgprs) {
   assert(wfs_.size() == config_.num_wf_slots && "wavefront slots not properly initialized");
-  // Free register allocations from previously halted wavefronts before claiming
-  // a new slot. This is needed so SGPR/VGPR blocks can be reused. However, we
-  // must NOT reset the LDS allocator here — that would zero next_lds_alloc_
-  // between WF dispatches of the same WG, causing concurrent WGs to share
-  // the same LDS base. The LDS reset is handled separately by the CP.
-  retire_halted_wfs_no_lds_reset();
-  // Find an idle slot.
+  // Halted wavefronts have already freed their SGPR/VGPR blocks at s_endpgm, so a
+  // halted slot is immediately available. Find an idle slot.
   size_t slot = config_.num_wf_slots;
   for (size_t i = 0; i < wfs_.size(); ++i) {
     if (wfs_[i]->is_halted()) {
@@ -110,7 +105,12 @@ Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t nu
     }
   }
 
-  assert(slot < config_.num_wf_slots && "tried to dispatch to an invalid wavefront slot");
+  // No free slot: fail the dispatch (like the register-allocation failures below)
+  // rather than indexing wfs_ out of bounds. The CP normally gates placement on
+  // can_accept_workgroup(), but returning nullptr is part of this API's contract
+  // and must hold even when a caller dispatches directly to a full CU.
+  if (slot >= config_.num_wf_slots)
+    return nullptr;
 
   int32_t sgpr_base = sgpr_file_.allocate(num_sgprs);
   if (sgpr_base < 0)
@@ -162,45 +162,23 @@ Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t nu
 size_t ComputeUnitCore::num_wfs() const {
   size_t count = 0;
   for (const auto &w : wfs_)
-    if (w->sgpr_alloc().count > 0)
+    if (!w->is_halted())
       ++count;
   return count;
 }
 
-void ComputeUnitCore::reset_all_wf() {
-  lds_pinned_clusters_.clear();
-  for (auto &w : wfs_) {
-    if (w->sgpr_alloc().count > 0) {
-      sgpr_file_.free(w->sgpr_alloc().base);
-      free_vgprs(w->vgpr_alloc().base);
-    }
-    w->reset();
+void ComputeUnitCore::free_wavefront_resources(Wavefront &wf) {
+  if (wf.sgpr_alloc().count > 0) {
+    sgpr_file_.free(wf.sgpr_alloc().base);
+    free_vgprs(wf.vgpr_alloc().base);
   }
+  wf.trace_inst_count_ = 0;
+  wf.reset();
 }
 
-void ComputeUnitCore::retire_halted_wfs_no_lds_reset() {
-  for (auto &w : wfs_) {
-    if (w->is_halted() && w->sgpr_alloc().count > 0) {
-      sgpr_file_.free(w->sgpr_alloc().base);
-      free_vgprs(w->vgpr_alloc().base);
-      w->trace_inst_count_ = 0;
-      w->reset();
-    }
-  }
-}
-
-void ComputeUnitCore::retire_halted_wfs() {
-  for (auto &w : wfs_) {
-    if (w->is_halted() && w->sgpr_alloc().count > 0) {
-      sgpr_file_.free(w->sgpr_alloc().base);
-      free_vgprs(w->vgpr_alloc().base);
-      w->trace_inst_count_ = 0;
-      w->reset();
-    }
-  }
-  if (!has_active_wfs() && !lds_allocation_pinned()) {
+void ComputeUnitCore::maybe_reset_lds_alloc() {
+  if (!has_active_wfs() && !lds_allocation_pinned())
     reset_lds_alloc();
-  }
 }
 
 void ComputeUnitCore::release_wf(uint32_t dispatch_id, uint32_t wg_id) {
@@ -212,6 +190,9 @@ void ComputeUnitCore::release_wf(uint32_t dispatch_id, uint32_t wg_id) {
     if (cp_)
       cp_->notify_wg_complete(dispatch_id, wg_id);
   }
+  // The whole workgroup's per-WG LDS region can be reclaimed once the CU has fully
+  // drained and no cluster peer can still multicast into it.
+  maybe_reset_lds_alloc();
 }
 
 bool ComputeUnitCore::can_accept_workgroup(uint32_t num_wfs, uint32_t lds_bytes) const {
@@ -411,6 +392,24 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
   }
 
   execute_instruction(inst, *active);
+
+  // A terminating instruction (s_endpgm with no pending waits) halts the wave
+  // inside execute_instruction, which frees and resets its slot. Its registers,
+  // pc, and allocations are now zeroed, so the after-execute hook, result logging,
+  // and pc-advance below must not run on the dead slot. The dedicated
+  // onAmdgpuWavefrontHalted hook already fired (with live state) from halt().
+  // s_endpgm is never a memory op, so just reclaim the decoded instruction.
+  //
+  // Note the intentional asymmetry: an s_endpgm that defers to ENDING (pending
+  // memory waits) is NOT halted here, so it DOES fire onAmdgpuAfterExecuteInstruction
+  // below; the immediate-halt case does not. onAmdgpuWavefrontHalted is the
+  // authoritative terminal hook and fires in both cases — consumers should observe
+  // termination there, not via the after-execute hook.
+  if (active->is_halted()) {
+    delete inst;
+    return;
+  }
+
   plugin_group_->onAmdgpuAfterExecuteInstruction(active->pc, *inst, *active);
 
   if constexpr (util::Logger::group_enabled(util::Logger::GROUP_VM)) {
@@ -444,15 +443,10 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
 bool ComputeUnitCore::step() {
   update_wf_states();
 
-  bool issued = false;
   for (auto &wf : wfs_) {
-    if (wf->state() == WfState::RUNNING) {
+    if (wf->state() == WfState::RUNNING)
       issue_instruction(wf.get());
-      issued = true;
-    }
   }
-  if (!issued)
-    retire_halted_wfs();
 
   ++step_count_;
   if constexpr (util::Logger::group_enabled(util::Logger::GROUP_CP)) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -50,7 +50,7 @@ ComputeUnitCore::ComputeUnitCore(std::string name, const Config &config, GpuMemo
   // Completer port: CP sends dispatch activation messages here.
   cpl_ = add_port(std::make_unique<simdojo::Port>("cpl", 0, this, simdojo::PortDirection::IN,
                                                   simdojo::PortProtocol::DISPATCH));
-  cpl_->set_handler([this](simdojo::Tick, simdojo::Message *) { activate(); });
+  cpl_->set_handler([this](simdojo::Tick, simdojo::Message *) { schedule_work(); });
 
   // Requester port: structural connection to shared L2 cache.
   req_ = add_port(std::make_unique<simdojo::Port>("req", 1, this, simdojo::PortDirection::OUT,
@@ -92,8 +92,8 @@ std::unique_ptr<ComputeUnitCore> ComputeUnitCore::create(std::string name, const
   throw std::runtime_error("Unsupported architecture for ComputeUnit");
 }
 
-Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t sgprs,
-                                        uint32_t vgprs) {
+Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t num_sgprs,
+                                        uint32_t num_vgprs) {
   assert(wfs_.size() == config_.num_wf_slots && "wavefront slots not properly initialized");
   // Free register allocations from previously halted wavefronts before claiming
   // a new slot. This is needed so SGPR/VGPR blocks can be reused. However, we
@@ -109,14 +109,14 @@ Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t sg
       break;
     }
   }
-  if (slot >= config_.num_wf_slots)
-    return nullptr;
 
-  int32_t sgpr_base = sgpr_file_.allocate(sgprs);
+  assert(slot < config_.num_wf_slots && "tried to dispatch to an invalid wavefront slot");
+
+  int32_t sgpr_base = sgpr_file_.allocate(num_sgprs);
   if (sgpr_base < 0)
     return nullptr;
 
-  int32_t vgpr_base = allocate_vgprs(vgprs);
+  int32_t vgpr_base = allocate_vgprs(num_vgprs);
   if (vgpr_base < 0) {
     sgpr_file_.free(static_cast<uint32_t>(sgpr_base));
     return nullptr;
@@ -136,10 +136,10 @@ Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t sg
   auto *wf = wfs_[slot].get();
   wf->wg_id_ = wg_id;
   wf->pc = pc;
-  wf->sgpr_alloc_ = {static_cast<uint32_t>(sgpr_base), sgprs};
-  wf->vgpr_alloc_ = {static_cast<uint32_t>(vgpr_base), vgprs};
-  wf->num_sgprs_ = sgprs;
-  wf->num_vgprs_ = vgprs;
+  wf->sgpr_alloc_ = {static_cast<uint32_t>(sgpr_base), num_sgprs};
+  wf->vgpr_alloc_ = {static_cast<uint32_t>(vgpr_base), num_vgprs};
+  wf->num_sgprs_ = num_sgprs;
+  wf->num_vgprs_ = num_vgprs;
   wf->exec_ = wf_size_ == 64 ? ~0ULL : (1ULL << wf_size_) - 1;
   wf->vcc_ = 0;
   wf->m0_ = 0;
@@ -149,11 +149,13 @@ Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t sg
   wf->set_ready_cycle(cycle_counter_);
   wf->trace_inst_count_ = 0;
 
-  std::fill(sgpr_to_wave_.begin() + sgpr_base, sgpr_to_wave_.begin() + sgpr_base + sgprs, wf);
+  std::fill(sgpr_to_wave_.begin() + sgpr_base, sgpr_to_wave_.begin() + sgpr_base + num_sgprs, wf);
   fill_vgpr_to_wave(static_cast<uint32_t>(vgpr_base), vgpr_allocation_block_size(), wf);
 
   util::Logger::cp("DISPATCH_WF cu=", this->full_path(), " wf=", wf->wf_id(), " slot=", slot,
                    " pc=0x", std::hex, pc, std::dec, " wg=", wg_id, " pid=", wf->process_id());
+
+  schedule_work();
   return wf;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -195,6 +195,21 @@ void ComputeUnitCore::release_wf(uint32_t dispatch_id, uint32_t wg_id) {
   maybe_reset_lds_alloc();
 }
 
+void ComputeUnitCore::abort_workgroup(uint32_t dispatch_id, uint32_t wg_id) {
+  // Roll back a workgroup that was committed via begin_workgroup() but whose peers
+  // in the same clustered dispatch failed to fully dispatch. Unlike release_wf(),
+  // this fires no completion hook and no CP notify — the WG never executed. Free any
+  // resident (not-yet-halted) waves belonging to this WG, drop the refcount entry,
+  // and reclaim LDS if the CU is now idle and unpinned. The caller unpins the cluster
+  // LDS separately (the pin is CP-side bookkeeping).
+  for (const auto &w : wfs_) {
+    if (!w->is_halted() && w->dispatch_id() == dispatch_id && w->wg_id() == wg_id)
+      free_wavefront_resources(*w);
+  }
+  active_wgs_.erase(wg_key(dispatch_id, wg_id));
+  maybe_reset_lds_alloc();
+}
+
 bool ComputeUnitCore::can_accept_workgroup(uint32_t num_wfs, uint32_t lds_bytes) const {
   // Count free wavefront slots.
   uint32_t free_slots = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -631,7 +631,9 @@ public:
     if constexpr (Mode == simdojo::ExecMode::FUNCTIONAL) {
       // A request left by direct step() execution must not shorten this quantum.
       functional_yield_requested_ = false;
+      last_quantum_executed_ = 0;
       for (uint32_t i = 0; i < kFunctionalQuantum && step(); ++i) {
+        ++last_quantum_executed_;
         if (std::exchange(functional_yield_requested_, false))
           break;
       }
@@ -657,11 +659,17 @@ public:
   }
 
 private:
-  simdojo::Event tick_event_{this, simdojo::EventType::TIMER_CALLBACK,
-                             [this](simdojo::Tick now, simdojo::Message *) {
-                               if (execute_quantum())
-                                 this->schedule_event(&tick_event_, now + kFunctionalQuantum);
-                             }};
+  // Advance time by the work actually executed, not the full quantum: a wavefront
+  // that requests a yield after k<kFunctionalQuantum instructions (e.g. s_sleep,
+  // vendor-dep retry) must resume at now+k so a peer component's published state is
+  // observed promptly, rather than leaping a full quantum ahead. max(1,...) keeps
+  // the event strictly in the future so re-entries never collapse onto one tick.
+  simdojo::Event tick_event_{
+      this, simdojo::EventType::TIMER_CALLBACK, [this](simdojo::Tick now, simdojo::Message *) {
+        if (execute_quantum())
+          this->schedule_event(&tick_event_, now + std::max<uint64_t>(1, last_quantum_executed_));
+      }};
+  uint64_t last_quantum_executed_ = 0;
   bool executing_ = false;
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -99,11 +99,11 @@ public:
   /// and initializes the slot's dynamic state (wg_id, pc, allocations).
   /// @param wg_id Workgroup ID for this wavefront.
   /// @param pc Kernel entry point (byte address).
-  /// @param sgprs Number of scalar registers to allocate.
-  /// @param vgprs Number of vector registers to allocate.
+  /// @param num_sgprs Number of scalar registers to allocate.
+  /// @param num_vgprs Number of vector registers to allocate.
   /// @returns Pointer to the activated wavefront, or nullptr if no free slot
   ///          or insufficient register space.
-  Wavefront *dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t sgprs, uint32_t vgprs);
+  Wavefront *dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t num_sgprs, uint32_t num_vgprs);
 
   /// @brief Execute one instruction on the next active wavefront.
   /// @retval true An instruction was executed.
@@ -127,7 +127,7 @@ public:
   bool can_accept_workgroup(uint32_t num_wfs, uint32_t lds_bytes = 0) const;
 
   /// @brief Execute up to kFunctionalQuantum instructions, then yield.
-  virtual bool advance() = 0;
+  virtual bool execute_quantum() = 0;
 
   /// @brief End the current functional-mode quantum after this instruction.
   ///
@@ -135,12 +135,9 @@ public:
   /// components can publish the state on which the wavefront is polling.
   void request_functional_yield() { functional_yield_requested_ = true; }
 
-  /// @brief Signal that work has been dispatched; begin processing.
-  ///
-  /// @details Schedules an engine event that calls advance() repeatedly
-  /// until all wavefronts are exhausted. Called by the command processor
-  /// after dispatch_wf().
-  virtual void activate() = 0;
+  /// @brief Schedule the tick event if the CU is not already executing.
+  /// Called from dispatch_wf() and the cpl_ port handler.
+  virtual void schedule_work() = 0;
 
   /// @brief Check whether this CU has no active wavefronts.
   /// @retval true No wavefronts are actively executing.
@@ -619,7 +616,7 @@ inline void InstructionComputeUnitView::write_sgpr(uint32_t reg_idx, uint32_t va
 ///
 /// @details Adds event-driven activation on top of ComputeUnitCore.
 ///
-/// In FUNCTIONAL mode, advance() executes up to kFunctionalQuantum
+/// In FUNCTIONAL mode, execute_quantum() runs up to kFunctionalQuantum
 /// instructions, then yields to the simulation event loop. This
 /// interleaving ensures forward progress when wavefronts on different
 /// CUs synchronize via global memory (e.g., spin-locks, semaphores).
@@ -630,7 +627,7 @@ public:
   using ComputeUnitCore::ComputeUnitCore;
 
   /// @brief Execute work up to the quantum limit, then yield.
-  bool advance() override {
+  bool execute_quantum() override {
     if constexpr (Mode == simdojo::ExecMode::FUNCTIONAL) {
       // A request left by direct step() execution must not shorten this quantum.
       functional_yield_requested_ = false;
@@ -643,23 +640,29 @@ public:
     }
     if (is_idle()) {
       notify_idle();
-      return !is_idle();
+      if (is_idle()) {
+        executing_ = false;
+        return false;
+      }
     }
     return true;
   }
 
-  /// @brief Schedule CU execution via the event loop.
-  void activate() override {
+  void schedule_work() override {
+    if (executing_ || !this->engine())
+      return;
+    executing_ = true;
     auto now = this->engine()->context(this->partition_id()).current_tick();
-    this->schedule_event(&work_event_, now + 1);
+    this->schedule_event(&tick_event_, now + 1);
   }
 
 private:
-  simdojo::Event work_event_{this, simdojo::EventType::TIMER_CALLBACK,
+  simdojo::Event tick_event_{this, simdojo::EventType::TIMER_CALLBACK,
                              [this](simdojo::Tick now, simdojo::Message *) {
-                               if (advance())
-                                 this->schedule_event(&work_event_, now + 1);
+                               if (execute_quantum())
+                                 this->schedule_event(&tick_event_, now + kFunctionalQuantum);
                              }};
+  bool executing_ = false;
 };
 
 /// @brief ISA-parameterized compute unit owning the typed VGPR register file.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -662,6 +662,13 @@ public:
     // nudge can arrive a tick after the last wavefront has halted and freed itself.
     // Waking the CU then would run an empty tick with no wave to issue — pure waste.
     // Work is scheduled only when there is work to do.
+    //
+    // ENGINE-THREAD ONLY: executing_ and tick_event_ are touched without
+    // synchronization, and schedule_event() pushes to the partition's event queue
+    // non-thread-safely. All callers (dispatch_wf(), the cpl_ port handler, and the
+    // CP on the same partition) run on this CU's owning partition engine thread. A
+    // cross-partition schedule_work() would be an executing_ data race plus an
+    // unsynchronized event-queue push.
     if (executing_ || !this->engine() || !this->has_active_wfs())
       return;
     executing_ = true;
@@ -670,11 +677,14 @@ public:
   }
 
 private:
-  // Advance time by the work actually executed, not the full quantum: a wavefront
-  // that requests a yield after k<kFunctionalQuantum instructions (e.g. s_sleep,
-  // vendor-dep retry) must resume at now+k so a peer component's published state is
-  // observed promptly, rather than leaping a full quantum ahead. max(1,...) keeps
-  // the event strictly in the future so re-entries never collapse onto one tick.
+  // Reschedule by the number of quantum loop iterations taken, not a fixed
+  // kFunctionalQuantum: a wavefront that requests a yield after k<kFunctionalQuantum
+  // iterations (e.g. s_sleep, vendor-dep retry) resumes at now+k so a peer
+  // component's published state is observed promptly rather than leaping a full
+  // quantum ahead. Note this counts loop iterations, not instructions issued —
+  // step() advances even when every wave is WAITCNT/BARRIER-stalled — so a fully
+  // stalled CU still advances by the full quantum. max(1,...) keeps the event
+  // strictly in the future so re-entries never collapse onto one tick.
   simdojo::Event tick_event_{
       this, simdojo::EventType::TIMER_CALLBACK, [this](simdojo::Tick now, simdojo::Message *) {
         if (execute_quantum())

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -107,9 +107,14 @@ public:
   ///          or insufficient register space.
   Wavefront *dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t num_sgprs, uint32_t num_vgprs);
 
-  /// @brief Execute one instruction on the next active wavefront.
-  /// @retval true An instruction was executed.
-  /// @retval false No active wavefronts remain.
+  /// @brief Advance every RUNNING wavefront by one instruction, then report
+  /// residency.
+  /// @details Issues one instruction to each wavefront currently in the RUNNING
+  /// state (waves stalled on WAITCNT/BARRIER, or halted, issue nothing this tick).
+  /// @retval true At least one wavefront is still resident (active), regardless of
+  ///         whether any instruction issued this call — so a fully WAITCNT/BARRIER-
+  ///         stalled CU still returns true.
+  /// @retval false No wavefronts remain resident (the CU is idle).
   bool step() override;
 
   /// @brief Free a halted wavefront's register allocations and reset its slot.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -155,6 +155,7 @@ public:
   /// @brief Check whether this CU has no active wavefronts.
   /// @retval true No wavefronts are actively executing.
   /// @retval false At least one wavefront is active.
+  /// @warning NOT thread-safe (see has_active_wfs()): engine-thread only.
   virtual bool is_idle() const { return !has_active_wfs(); }
 
   /// @brief Register a callback invoked when this CU becomes idle.
@@ -359,6 +360,9 @@ public:
   /// @brief Check whether any wavefront slot is actively executing.
   /// @retval true At least one wavefront is not halted.
   /// @retval false All wavefronts are halted.
+  /// @warning NOT thread-safe: reads the non-atomic per-wave state_. Safe only on the
+  ///   shared partition engine thread (CP and its CUs share one partition, asserted in
+  ///   CommandProcessor::startup()); callers on any other thread would race a halt().
   bool has_active_wfs() const {
     for (const auto &w : wfs_)
       if (!w->is_halted())

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -56,8 +56,10 @@ class CommandProcessor;
 /// back to this CU and its slot index (wf_id).
 ///
 /// dispatch_wf() finds the first idle slot, allocates registers, and
-/// activates it. retire_halted_wfs() frees register allocations and calls
-/// clear() so the slot can be reused.
+/// activates it. When a wavefront reaches s_endpgm it halts: free_wavefront_resources()
+/// frees its register allocations and resets the slot for reuse, mirroring how real
+/// hardware reclaims a wave's resources at termination (there is no separate lazy
+/// retirement pass).
 ///
 /// Each step() call picks the next active wavefront (round-robin) and executes
 /// one instruction using the ISA-specific decoder.
@@ -110,11 +112,17 @@ public:
   /// @retval false No active wavefronts remain.
   bool step() override;
 
-  /// @brief Clear all halted wavefront slots and free their register allocations.
-  void retire_halted_wfs();
+  /// @brief Free a halted wavefront's register allocations and reset its slot.
+  /// @details Called from Wavefront::halt() at s_endpgm so a terminated wave
+  /// releases its SGPR/VGPR blocks immediately, exactly as hardware reclaims
+  /// resources at wave termination. LDS is per-workgroup and reclaimed separately
+  /// via maybe_reset_lds_alloc() once the whole workgroup completes.
+  void free_wavefront_resources(Wavefront &wf);
 
-  /// @brief Like retire_halted_wfs but without resetting the LDS allocator.
-  void retire_halted_wfs_no_lds_reset();
+  /// @brief Reset the per-WG LDS bump allocator once the CU has fully drained.
+  /// @details No-op while any wavefront is resident or a cluster pin is held (peer
+  /// cluster workgroups may still multicast into LDS after the source wave halts).
+  void maybe_reset_lds_alloc();
 
   /// @brief Check whether this CU can accept an entire workgroup.
   ///
@@ -173,7 +181,7 @@ public:
 
   /// @brief Register a new workgroup with its expected WF count.
   /// @details Called by the DispatchController when assigning a WG to this CU.
-  /// Initializes the refcount so retire_halted_wfs() can detect WG completion.
+  /// Initializes the refcount so release_wf() can detect WG completion.
   void begin_workgroup(uint32_t dispatch_id, uint32_t wg_id, uint32_t wf_count) {
     active_wgs_[wg_key(dispatch_id, wg_id)] = wf_count;
   }
@@ -191,8 +199,10 @@ public:
   /// @brief Return the execution plugin group.
   ExecutionPluginGroup &plugin_group() { return *plugin_group_; }
 
-  /// @brief Return the number of dispatched (active or halted) wavefront slots.
-  /// @returns Count of non-idle wavefront slots.
+  /// @brief Return the number of resident (not-yet-halted) wavefront slots.
+  /// @details A wave frees its resources and its slot at s_endpgm, so halted
+  /// waves are not counted. Equivalent to the number of active wavefronts.
+  /// @returns Count of resident wavefront slots.
   size_t num_wfs() const;
 
   /// @brief Return the total number of wavefront slots.
@@ -499,13 +509,6 @@ public:
   /// @param wf The wavefront executing the instruction.
   virtual void execute_instruction(Instruction *inst, Wavefront &wf) = 0;
 
-  /// @brief Reset all wavefront slots to halted state.
-  ///
-  /// Frees all register allocations and resets every slot.  Used by the
-  /// instruction execution test harness between instructions.
-  /// @warning NOT thread-safe.  Must not be called while step() is running.
-  void reset_all_wf();
-
 protected:
   ComputeUnitCore(std::string name, const Config &config, GpuMemory *memory, L2Cache *l2,
                   uint32_t wf_size);
@@ -597,6 +600,9 @@ inline uint32_t InstructionComputeUnitView::wf_size() const { return raw_cu().wf
 inline uint32_t InstructionComputeUnitView::sgprs_per_wf() const {
   return raw_cu().config().sgprs_per_wf;
 }
+inline uint32_t InstructionComputeUnitView::vgpr_allocation_block_size() const {
+  return raw_cu().vgpr_allocation_block_size();
+}
 inline std::string InstructionComputeUnitView::full_path() const { return raw_cu().full_path(); }
 inline simdojo::ComponentID InstructionComputeUnitView::id() const { return raw_cu().id(); }
 inline simdojo::SimulationEngine *InstructionComputeUnitView::engine() const {
@@ -651,7 +657,12 @@ public:
   }
 
   void schedule_work() override {
-    if (executing_ || !this->engine())
+    // Never wake an idle CU. The CP nudges the CU through the cp->cu.cpl port,
+    // gated on has_active_wfs() when sent, but that port carries link latency, so a
+    // nudge can arrive a tick after the last wavefront has halted and freed itself.
+    // Waking the CU then would run an empty tick with no wave to issue — pure waste.
+    // Work is scheduled only when there is work to do.
+    if (executing_ || !this->engine() || !this->has_active_wfs())
       return;
     executing_ = true;
     auto now = this->engine()->context(this->partition_id()).current_tick();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -197,6 +197,14 @@ public:
   /// and the CP is notified via notify_wg_complete.
   void release_wf(uint32_t dispatch_id, uint32_t wg_id);
 
+  /// @brief Roll back a committed-but-never-run workgroup on a dispatch error.
+  /// @details Used to unwind an already-committed cluster peer when a later peer in
+  /// the same clustered dispatch fails. Frees the WG's resident waves and drops its
+  /// refcount WITHOUT firing the completion hook or CP notify (the WG never executed),
+  /// then reclaims LDS if the CU is now idle and unpinned. The caller is responsible
+  /// for unpinning any CP-side cluster LDS pin.
+  void abort_workgroup(uint32_t dispatch_id, uint32_t wg_id);
+
   /// @brief Set the execution plugin group (shared ownership).
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) {
     plugin_group_ = pg ? pg : ExecutionPluginGroup::empty_group();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -100,6 +100,7 @@ struct DispatchEntry {
   uint64_t profiling_start_timestamp = 0;
   bool host_signal = false;
   bool barrier_bit = false;
+  bool execution_begun = false;
 
   bool fully_dispatched() const { return dispatched_wgs >= total_wgs; }
   bool fully_completed() const { return completed_wgs >= total_wgs; }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/instruction_compute_unit_view.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/instruction_compute_unit_view.h
@@ -47,6 +47,7 @@ public:
   rj_code_arch_t arch() const;
   uint32_t wf_size() const;
   uint32_t sgprs_per_wf() const;
+  uint32_t vgpr_allocation_block_size() const;
   std::string full_path() const;
   simdojo::ComponentID id() const;
   simdojo::SimulationEngine *engine() const;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
@@ -127,18 +127,6 @@ public:
     return false;
   }
 
-  /// @brief Step each CU once (one round-robin pass within this SE).
-  bool step() {
-    bool any_active = false;
-    for (auto *cu : cus_) {
-      if (cu->has_active_wfs()) {
-        cu->step();
-        any_active = true;
-      }
-    }
-    return any_active;
-  }
-
   /// @brief Check if any WGs are queued or any CU is active.
   bool has_pending() const {
     for (auto &q : pipe_queues_)
@@ -148,20 +136,6 @@ public:
       if (cu->has_active_wfs())
         return true;
     return false;
-  }
-
-  /// @brief Run all CUs to idle (functional mode, for test harness use).
-  void run_to_idle() {
-    bool progress = true;
-    while (progress) {
-      progress = false;
-      for (auto *cu : cus_) {
-        if (cu->has_active_wfs()) {
-          cu->step();
-          progress = true;
-        }
-      }
-    }
   }
 
   /// @brief Legacy: select a CU with capacity for direct dispatch.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
@@ -148,7 +148,6 @@ public:
     for (size_t attempt = 0; attempt < cus_.size(); ++attempt) {
       size_t idx = (next_cu_ + attempt) % cus_.size();
       auto *cu = cus_[idx];
-      cu->retire_halted_wfs();
       const size_t wgp_index = cu_to_wgp_[idx];
       if (wgp_index != std::numeric_limits<size_t>::max() &&
           wgps_[wgp_index]->active_workgroups != 0)
@@ -180,8 +179,6 @@ public:
     for (size_t attempt = 0; attempt < wgps_.size(); ++attempt) {
       size_t wgp_index = (next_wgp_ + attempt) % wgps_.size();
       auto &wgp = *wgps_[wgp_index];
-      wgp.cu0->retire_halted_wfs();
-      wgp.cu1->retire_halted_wfs();
 
       // A WGP allocation cannot overlap CU-mode residents or cluster-pinned
       // CU-local LDS state. Existing WGP-mode workgroups may share the pool.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.cpp
@@ -13,9 +13,19 @@ Lds &Wavefront::lds() { return lds_ ? *lds_ : cu_.lds(); }
 const Lds &Wavefront::lds() const { return lds_ ? *lds_ : cu_.lds(); }
 
 void Wavefront::halt() {
+  // s_endpgm terminates the wave, frees its resources, and notifies the CP as one
+  // action, mirroring hardware. Order matters:
+  //   (1) fire the halt hook while registers are still live so observers snapshot
+  //       final state before it is freed,
+  //   (2) free SGPR/VGPR and reset the slot (sets state HALTED); capture the WG ids
+  //       first because reset() zeroes them,
+  //   (3) notify the CU/CP of workgroup completion. Freeing before release_wf keeps
+  //       has_active_wfs() accurate so the last wave triggers LDS reclaim.
   cu_.plugin_group().onAmdgpuWavefrontHalted(*this);
-  state_ = WfState::HALTED;
-  cu_.release_wf(dispatch_id_, wg_id_);
+  uint32_t dispatch_id = dispatch_id_;
+  uint32_t wg_id = wg_id_;
+  cu_.free_wavefront_resources(*this);
+  cu_.release_wf(dispatch_id, wg_id);
 }
 
 void Wavefront::release_wait_counter(WaitCounterType type) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.cpp
@@ -22,8 +22,8 @@ void Wavefront::halt() {
   //   (3) notify the CU/CP of workgroup completion. Freeing before release_wf keeps
   //       has_active_wfs() accurate so the last wave triggers LDS reclaim.
   cu_.plugin_group().onAmdgpuWavefrontHalted(*this);
-  uint32_t dispatch_id = dispatch_id_;
-  uint32_t wg_id = wg_id_;
+  const uint32_t dispatch_id = dispatch_id_;
+  const uint32_t wg_id = wg_id_;
   cu_.free_wavefront_resources(*this);
   cu_.release_wf(dispatch_id, wg_id);
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
@@ -143,8 +143,21 @@ public:
   }
 
   static std::shared_ptr<ExecutionPluginGroup> empty_group() {
-    static auto instance = std::make_shared<ExecutionPluginGroup>();
-    return instance;
+    // Immortal singleton: the shared_ptr is heap-allocated and deliberately never
+    // deleted, so its control block outlives process teardown. In local-mode
+    // (LD_PRELOAD interposer) the simulation engine runs on a detached thread that
+    // is still executing when exit() drives static/atexit destructors on the main
+    // thread. A plain function-local `static shared_ptr` would have its control
+    // block destroyed by a __cxa_atexit handler during __run_exit_handlers while the
+    // engine thread is mid-startup() copying this default plugin group into a
+    // CompletionTracker/ComputeUnit — a data race on the refcount that surfaced as a
+    // use-after-free SIGSEGV in _Sp_counted_base::_M_release under `ctest -jN`.
+    // Leaking the control block removes that teardown race; the OS reclaims the
+    // memory at process death. Matches the interposer singleton's never-destructed
+    // design for the same reason.
+    static std::shared_ptr<ExecutionPluginGroup> *instance =
+        new std::shared_ptr<ExecutionPluginGroup>(std::make_shared<ExecutionPluginGroup>());
+    return *instance;
   }
 
 protected:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
@@ -81,7 +81,7 @@ rj_status_t create_from_loaded(config::LoadedConfig &loaded, rj_vm_mode_t mode, 
     loaded.wire_links(s->engine->topology());
     s->soc->wire_backing(s->engine->topology());
   }
-  s->engine->build();
+  s->engine->create();
 
   if (serve) {
     s->engine->register_as_primary();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
@@ -64,11 +64,21 @@ rj_status_t create_from_loaded(config::LoadedConfig &loaded, rj_vm_mode_t mode, 
     auto vm_ptr = std::make_unique<VirtualMachine>(std::move(socs), std::move(gpu_ids), daemon);
     s->vm = vm_ptr.get();
     s->engine->topology().set_root(std::move(vm_ptr));
+
+    auto prefix_specs = [](std::vector<simdojo::LinkSpec> &specs, const std::string &pfx) {
+      for (auto &ls : specs) {
+        ls.src = pfx + ls.src;
+        ls.dst = pfx + ls.dst;
+      }
+    };
+    prefix_specs(loaded.build_result.link_specs, "gpu0.");
     loaded.wire_links(s->engine->topology());
     s->soc->wire_backing(s->engine->topology());
-    for (auto &eb : loaded.extra_gpu_builds) {
+    for (size_t i = 0; i < loaded.extra_gpu_builds.size(); ++i) {
+      auto &eb = loaded.extra_gpu_builds[i];
+      prefix_specs(eb.link_specs, "gpu" + std::to_string(i + 1) + ".");
       s->engine->topology().wire_links(eb.link_specs, loaded.exec_mode);
-      auto *extra_soc = dynamic_cast<SoC *>(s->vm->soc());
+      auto *extra_soc = s->vm->soc(static_cast<uint32_t>(i + 1));
       if (extra_soc)
         extra_soc->wire_backing(s->engine->topology());
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
@@ -345,6 +345,13 @@ rj_status_t rj_vm_device_close(rj_vm_t *vm, uint32_t process_id) {
   return ROCJITSU_STATUS_SUCCESS;
 }
 
+rj_status_t rj_vm_close_all_devices(rj_vm_t *vm) {
+  if (!vm || !vm->vm || !vm->vm->driver())
+    return ROCJITSU_STATUS_INVALID_ARGUMENT;
+  vm->vm->driver()->close_all_processes();
+  return ROCJITSU_STATUS_SUCCESS;
+}
+
 rj_status_t rj_vm_device_map(rj_vm_t *vm, rj_vm_map_t *map) {
   if (!vm || !map || !vm->vm || !vm->vm->driver())
     return ROCJITSU_STATUS_INVALID_ARGUMENT;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
@@ -15,10 +15,12 @@ RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "linux/uapi/kfd_ioctl.h"
 RJ_DIAGNOSTIC_POP
 
+#include <cerrno>
 #include <cstring>
 #include <memory>
 #include <stdexcept>
 #include <sys/ioctl.h>
+#include <sys/mman.h>
 
 using namespace rocjitsu;
 
@@ -360,6 +362,10 @@ rj_status_t rj_vm_device_map_as(rj_vm_t *vm, uint32_t process_id, rj_vm_map_t *m
   auto *result = vm->vm->driver()->mmap(
       process_id, reinterpret_cast<void *>(map->addr), static_cast<size_t>(map->length),
       static_cast<int>(map->prot), static_cast<int>(map->flags), static_cast<off_t>(map->offset));
+  // Capture errno HERE, immediately after the driver mmap, before any bookkeeping
+  // syscall on the way back out can clobber it. Callers (the daemon RPC path) relay
+  // this to the client rather than reading their own errno across the API boundary.
+  map->map_errno = (result == MAP_FAILED) ? errno : 0;
   map->mapped_addr = reinterpret_cast<uint64_t>(result);
   return ROCJITSU_STATUS_SUCCESS;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
@@ -168,17 +168,4 @@ const std::vector<amdgpu::ComputeUnitCore *> &SoC::all_cus() {
   return all_cus_cache_;
 }
 
-void SoC::run_to_idle() {
-  if (exec_mode_ == simdojo::ExecMode::FUNCTIONAL) {
-    bool progress = true;
-    while (progress) {
-      progress = false;
-      for (auto *xcd : xcds_)
-        for (auto *se : xcd->shader_engines())
-          if (se->spi().step())
-            progress = true;
-    }
-  }
-}
-
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.h
@@ -160,8 +160,6 @@ public:
   /// @brief Set the execution plugin group and distribute to CPs/CUs.
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> plugin_group);
 
-  void run_to_idle();
-
   const std::vector<amdgpu::ComputeUnitCore *> &all_cus();
 
   ExecutionPluginGroup &plugin_group() { return *plugin_group_; }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/virtual_machine.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/virtual_machine.cpp
@@ -17,12 +17,14 @@ VirtualMachine::VirtualMachine(const Config &config)
   set_weight(0);
   auto soc = std::make_unique<SoC>("gpu_soc", config.soc);
   soc_ = soc.get();
+  socs_.push_back(soc_);
   add_child(std::move(soc));
 }
 
 VirtualMachine::VirtualMachine(std::unique_ptr<SoC> soc, bool daemon_mode)
     : simdojo::CompositeComponent(soc->name()), soc_(soc.get()) {
   set_weight(0);
+  socs_.push_back(soc_);
   adopt_children(*soc);
   add_child(std::move(soc));
   driver_ = std::make_unique<SimulatedKfd>(*soc_, daemon_mode);
@@ -37,10 +39,18 @@ VirtualMachine::VirtualMachine(std::vector<std::unique_ptr<SoC>> socs,
   for (size_t i = 0; i < socs.size(); ++i) {
     auto *p = socs[i].get();
     ptrs.push_back(p);
+    socs_.push_back(p);
     if (i == 0)
       soc_ = p;
-    adopt_children(*socs[i]);
-    add_child(std::move(socs[i]));
+    auto wrapper = std::make_unique<simdojo::CompositeComponent>("gpu" + std::to_string(i));
+    wrapper->set_weight(0);
+    wrapper->adopt_children(*socs[i]);
+    // Keep the now-emptied SoC alive/owned under its own uniquely-named gpuN
+    // wrapper rather than directly under the VM: every SoC is named "soc" from
+    // the config, so adding them at the VM level would recreate the duplicate-
+    // name-in-tree hazard this change fixes (find_child returns the first match).
+    wrapper->add_child(std::move(socs[i]));
+    add_child(std::move(wrapper));
   }
   driver_ = std::make_unique<SimulatedKfd>(ptrs, std::move(gpu_ids), daemon_mode);
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/virtual_machine.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/virtual_machine.h
@@ -49,6 +49,10 @@ public:
 
   SoC *soc() { return soc_; }
   const SoC *soc() const { return soc_; }
+  /// @brief Access the Nth SoC (GPU), or nullptr if idx is out of range.
+  SoC *soc(uint32_t idx) { return idx < socs_.size() ? socs_[idx] : nullptr; }
+  /// @brief Number of SoCs (GPUs) in this VM. At least 1 for any constructed VM.
+  uint32_t num_socs() const { return static_cast<uint32_t>(socs_.size()); }
   amdgpu::GpuMemory *memory() { return soc_->memory(); }
   const amdgpu::GpuMemory *memory() const { return soc_->memory(); }
   const Config &config() const { return config_; }
@@ -58,6 +62,7 @@ public:
 private:
   Config config_;
   SoC *soc_ = nullptr;
+  std::vector<SoC *> socs_;
   std::unique_ptr<SimulatedKfd> driver_;
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/virtual_machine.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/virtual_machine.h
@@ -51,6 +51,7 @@ public:
   const SoC *soc() const { return soc_; }
   /// @brief Access the Nth SoC (GPU), or nullptr if idx is out of range.
   SoC *soc(uint32_t idx) { return idx < socs_.size() ? socs_[idx] : nullptr; }
+  const SoC *soc(uint32_t idx) const { return idx < socs_.size() ? socs_[idx] : nullptr; }
   /// @brief Number of SoCs (GPUs) in this VM. At least 1 for any constructed VM.
   uint32_t num_socs() const { return static_cast<uint32_t>(socs_.size()); }
   amdgpu::GpuMemory *memory() { return soc_->memory(); }

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/clocked.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/clocked.h
@@ -31,8 +31,8 @@ public:
   Clocked(std::string name, const ClockDomain &domain) : Base(std::move(name)), domain_(domain) {}
 
   /// @brief Schedule the first clock-edge event when the simulation starts.
-  void initialize() override {
-    assert(this->engine() && "Clocked component must be added to a topology before initialize()");
+  void startup() override {
+    assert(this->engine() && "Clocked component must be added to a topology before startup()");
     running_ = true;
     this->schedule_event(&clock_event_, domain_.first_edge());
   }

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/component.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/component.h
@@ -127,20 +127,14 @@ public:
   /// @brief Called once after simulation ends. Override to release resources.
   virtual void shutdown() {}
 
-  /// @brief Execute one functional step.
+  /// @brief Execute one unit of component-specific work.
   ///
-  /// Components that participate in functional simulation override this.
-  /// The default run() loops `while (step()) {}`.
-  /// @retval true Component is still active (continue stepping).
-  /// @retval false Component has halted (no more work).
+  /// What constitutes a "step" is defined by each component: one instruction
+  /// for a compute unit, one packet for a command processor, etc. The engine
+  /// does not call this — it is a domain-level API for use on concrete types.
+  /// @retval true Component has more work.
+  /// @retval false Component is idle.
   virtual bool step() { return false; }
-
-  /// @brief Run the component until halted.
-  ///
-  /// The default implementation loops step() until it returns false.
-  /// Concrete components (e.g., SoC, CommandProcessor) override
-  /// this with their own lifecycle logic (doorbell waits, driver commands).
-  virtual void run();
 
   /// @brief Return the list of ports owned by this component.
   /// @returns Const reference to the port vector.
@@ -209,19 +203,6 @@ public:
 
   /// @brief This is a composite component.
   bool is_composite() const override { return true; }
-
-  /// @brief Run all children until they halt.
-  ///
-  /// Default composite behavior: delegates to each child's run().
-  /// Subclasses (e.g., SoC) override for custom lifecycle.
-  void run() override;
-
-  /// @brief Step all children once.
-  ///
-  /// Default composite behavior: calls step() on each child.
-  /// @retval true At least one child is still active.
-  /// @retval false All children have halted.
-  bool step() override;
 
   /// @brief Add a child component. Sets the child's parent and depth.
   /// @param[in] child The child to add (ownership transferred).

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/functional.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/functional.h
@@ -36,9 +36,9 @@ public:
   Functional(std::string name) : Base(std::move(name)) {}
 
   /// @brief Schedule the first advance event when the simulation starts.
-  void initialize() override {
+  void startup() override {
     assert(this->engine() != nullptr &&
-           "Functional component must be added to a topology before initialize()");
+           "Functional component must be added to a topology before startup()");
     active_ = true;
     this->schedule_event(&step_event_, 1);
   }

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/simulation.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/simulation.h
@@ -96,9 +96,9 @@ private:
 ///   4. Arrive at barrier (completion function computes new global_lbts)
 ///
 /// Components participate in the simulation by scheduling events during
-/// initialize() or startup(). Untimed (functional) components use the
+/// startup(). Untimed (functional) components use the
 /// Functional\<Base\> CRTP mixin, which self-schedules a timer callback and
-/// re-enqueues after each step(). If no events are ever scheduled and no
+/// re-enqueues after each advance(). If no events are ever scheduled and no
 /// primaries are registered, the simulation terminates via quiescence. If
 /// primaries are registered, the engine blocks until async events arrive or
 /// all primaries signal completion.
@@ -107,7 +107,7 @@ private:
 /// @code
 ///   SimulationEngine engine(config);
 ///   engine.topology().set_root(std::move(my_model));
-///   engine.build(); // partitions, initializes components
+///   engine.create(); // partitions, initializes components
 ///   // (user enqueues work via CP)
 ///   auto exit = engine.run(); // starts up components, runs to completion
 ///   // OR: while (engine.step()) {} // starts up on first call, one tick per call
@@ -125,7 +125,7 @@ public:
                                   ///< engine alive while waiting for external stimuli (doorbells).
   };
 
-  /// @brief Construct with config. Caller populates topology(), then calls build().
+  /// @brief Construct with config. Caller populates topology(), then calls create().
   /// @param config Engine configuration parameters.
   explicit SimulationEngine(Config config);
 
@@ -142,18 +142,18 @@ public:
   /// populated. Also used to rebuild after shutdown(). Calls
   /// initialize_components() so that components can set up ports and handlers
   /// before run() or step() starts them.
-  void build();
+  void create();
 
   /// @brief Tear down engine state (shutdown components, join workers).
   ///
-  /// @details After shutdown(), the engine can be rebuilt with a new build() call.
+  /// @details After shutdown(), the engine can be rebuilt with a new create() call.
   /// Called automatically by the destructor if still built.
   void shutdown();
 
-  /// @brief Return whether the engine has been built and is ready for execution.
-  /// @retval true Engine is built and ready for run() or step().
-  /// @retval false Engine has not been built or has been shut down.
-  bool is_built() const { return built_; }
+  /// @brief Return whether the engine has been created and is ready for execution.
+  /// @retval true Engine is created and ready for run() or step().
+  /// @retval false Engine has not been created or has been shut down.
+  bool is_created() const { return created_; }
 
   /// @brief Access the topology for model setup (add components, links, clock domains).
   ///
@@ -168,17 +168,19 @@ public:
 
   /// @brief Run the simulation to completion.
   ///
-  /// @details Starts all components (initialization happens in build()),
+  /// @details Starts all components (initialization happens in create()),
   /// then enters the PDES epoch loop. Components are shut down on return.
   /// @returns An ExitStatus describing why the simulation stopped.
   ExitStatus run();
 
-  /// @brief Advance the simulation by one tick (single-threaded only).
+  /// @brief Process all events at the next event time (single-threaded only).
   ///
   /// @details On the first call, starts all components (initialization
-  /// happens in build()). Each subsequent call processes all events at the
-  /// next timestamp, then returns. If the queue is empty but primaries are
-  /// registered, returns true so the caller can poll for async events.
+  /// happens in create()). Each subsequent call advances to the next event
+  /// time and processes all events at that timestamp, then returns.
+  /// Ticks without scheduled events are skipped. If the queue is empty
+  /// but primaries are registered, returns true so the caller can poll
+  /// for async events.
   /// @retval true Simulation can continue.
   /// @retval false Simulation is done (query last_exit() for details).
   bool step();
@@ -365,7 +367,7 @@ private:
   std::atomic<uint32_t> active_primaries_{0};
   std::atomic<bool> has_primaries_{false}; ///< Set on first register_as_primary().
   ExitStatus exit_status_;                 ///< Exit information from the last run/step.
-  bool built_ = false;   ///< Whether build() has completed (components initialized).
+  bool created_ = false; ///< Whether create() has completed (components initialized).
   bool running_ = false; ///< True while running; also guards step() first-call startup.
 
   /// @brief Global lower bound on time stamp, updated by barrier completion.
@@ -380,6 +382,7 @@ private:
   struct AsyncQueue {
     std::mutex mutex;
     std::vector<EventQueueEntry> events;
+    std::atomic<bool> pending{false}; ///< Set by producer, checked before locking.
   };
   std::vector<std::unique_ptr<AsyncQueue>> async_queues_; ///< One per partition.
 

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/simulation.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/simulation.h
@@ -142,7 +142,7 @@ public:
   /// populated. Also used to rebuild after shutdown(). Calls
   /// initialize_components() so that components can set up ports and handlers
   /// before run() or step() starts them. Event self-scheduling is deferred: the
-  /// Clocked/Functional mixins enqueue their first event in startup() (run to by the
+  /// Clocked/Functional mixins enqueue their first event in startup() (invoked by the
   /// first run()/step() call), not here, so no events exist until execution begins.
   void create();
 

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/simulation.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/simulation.h
@@ -141,7 +141,9 @@ public:
   /// @details Required after the Config-only constructor once the topology is
   /// populated. Also used to rebuild after shutdown(). Calls
   /// initialize_components() so that components can set up ports and handlers
-  /// before run() or step() starts them.
+  /// before run() or step() starts them. Event self-scheduling is deferred: the
+  /// Clocked/Functional mixins enqueue their first event in startup() (run to by the
+  /// first run()/step() call), not here, so no events exist until execution begins.
   void create();
 
   /// @brief Tear down engine state (shutdown components, join workers).

--- a/emulation/rocjitsu/lib/simdojo/src/component.cpp
+++ b/emulation/rocjitsu/lib/simdojo/src/component.cpp
@@ -7,11 +7,6 @@
 
 namespace simdojo {
 
-void Component::run() {
-  while (step()) {
-  }
-}
-
 void Component::schedule_event(Event *event, Tick timestamp, std::unique_ptr<Message> message) {
   engine_->schedule_event(event, timestamp, std::move(message));
 }
@@ -28,20 +23,6 @@ Port *Component::find_port(PortID port_id) const {
       return p.get();
   }
   return nullptr;
-}
-
-void CompositeComponent::run() {
-  for (auto &child : children_)
-    child->run();
-}
-
-bool CompositeComponent::step() {
-  bool any_active = false;
-  for (auto &child : children_) {
-    if (child->step())
-      any_active = true;
-  }
-  return any_active;
 }
 
 Component *CompositeComponent::add_child(std::unique_ptr<Component> child) {

--- a/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
+++ b/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
@@ -17,12 +17,12 @@ SimulationEngine::SimulationEngine(Config config)
     : config_(config), pacer_(PacingController::Config{.ratio = config.wall_clock_ratio}) {}
 
 SimulationEngine::~SimulationEngine() {
-  if (built_)
+  if (created_)
     shutdown();
 }
 
-void SimulationEngine::build() {
-  assert(!built_ && "build() called twice without shutdown()");
+void SimulationEngine::create() {
+  assert(!created_ && "create() called twice without shutdown()");
   if (topology_.partitions().empty())
     topology_.partition(config_.num_threads);
   setup_partitions();
@@ -36,11 +36,11 @@ void SimulationEngine::build() {
   global_lbts_.store(0, std::memory_order_release);
 
   initialize_components();
-  built_ = true;
+  created_ = true;
 }
 
 void SimulationEngine::shutdown() {
-  if (!built_)
+  if (!created_)
     return;
 
   // Signal done. Workers will see this after the next barrier and exit.
@@ -61,7 +61,7 @@ void SimulationEngine::shutdown() {
   running_ = false;
   contexts_.clear();
   async_queues_.clear();
-  built_ = false;
+  created_ = false;
 }
 
 void SimulationEngine::setup_partitions() {
@@ -94,7 +94,7 @@ void SimulationEngine::setup_partitions() {
 }
 
 ExitStatus SimulationEngine::run() {
-  assert(built_ && "run() called before build()");
+  assert(created_ && "run() called before create()");
   const uint32_t num_threads = config_.num_threads;
 
   startup_components();
@@ -128,7 +128,7 @@ ExitStatus SimulationEngine::run() {
 }
 
 bool SimulationEngine::step() {
-  assert(built_ && "step() called before build()");
+  assert(created_ && "step() called before create()");
   assert(config_.num_threads == 1 && "step() requires single-threaded mode");
 
   if (!running_) {
@@ -192,6 +192,9 @@ void SimulationEngine::worker_loop(PartitionID partition_id) {
       // threads (e.g. doorbell poll threads) are merged promptly instead of
       // waiting for the main queue to empty — which may never happen when
       // CU work events continuously reschedule.
+      //
+      // Within a tick, defer pushes so that handler reschedules don't
+      // interleave with pops (avoids O(N log N) heap churn per tick).
       Tick last_drained_tick = 0;
       while (!ctx.event_queue.empty()) {
         Tick next_tick = ctx.event_queue.next_event_time();
@@ -464,6 +467,7 @@ void SimulationEngine::schedule_event_async(Event *event, Tick timestamp,
   {
     std::lock_guard<std::mutex> lock(aq.mutex);
     aq.events.push_back(EventQueueEntry{timestamp, 0, event, std::move(message)});
+    aq.pending.store(true, std::memory_order_release);
   }
 
   // Wake the target partition so idle workers pick up the new event.
@@ -484,10 +488,13 @@ void SimulationEngine::schedule_event_now(Event *event, std::unique_ptr<Message>
 void SimulationEngine::drain_async_events() {
   for (uint32_t i = 0; i < async_queues_.size(); ++i) {
     auto &aq = *async_queues_[i];
+    if (!aq.pending.load(std::memory_order_acquire))
+      continue;
     std::lock_guard<std::mutex> lock(aq.mutex);
     for (auto &e : aq.events)
       contexts_[i]->event_queue.push(std::move(e));
     aq.events.clear();
+    aq.pending.store(false, std::memory_order_release);
   }
 }
 
@@ -535,9 +542,9 @@ Tick SimulationEngine::compute_async_floor(const PartitionContext &ctx) const {
 
 void SimulationEngine::drain_async_for_partition(PartitionContext &ctx) {
   auto &aq = *async_queues_[ctx.partition_id];
-  std::lock_guard<std::mutex> lock(aq.mutex);
-  if (aq.events.empty())
+  if (!aq.pending.load(std::memory_order_acquire))
     return;
+  std::lock_guard<std::mutex> lock(aq.mutex);
   Tick floor = compute_async_floor(ctx);
   for (auto &e : aq.events) {
     if (e.timestamp < floor)
@@ -545,6 +552,7 @@ void SimulationEngine::drain_async_for_partition(PartitionContext &ctx) {
     ctx.event_queue.push(std::move(e));
   }
   aq.events.clear();
+  aq.pending.store(false, std::memory_order_release);
 }
 
 } // namespace simdojo

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -874,6 +874,8 @@ foreach(
         UnmapWithWrongHandleFails
         MapSucceedsAfterExportFdClosed
         ReplaceEvictsOverlappingDifferentSizeRange
+        ReplaceTransfersOwnershipAcrossOldOwnerClose
+        ClearUpdatesOwnerBookkeeping
 )
     rj_add_test(
         NAME "InterposerGemTest.${_interposer_gem_test}"

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -869,7 +869,11 @@ endforeach()
 foreach(
     _interposer_gem_test
     IN
-    ITEMS ReusedDmabufFdMintsDistinctHandles UnmapWithWrongHandleFails
+    ITEMS
+        ReusedDmabufFdMintsDistinctHandles
+        UnmapWithWrongHandleFails
+        MapSucceedsAfterExportFdClosed
+        ReplaceEvictsOverlappingDifferentSizeRange
 )
     rj_add_test(
         NAME "InterposerGemTest.${_interposer_gem_test}"

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -866,6 +866,32 @@ foreach(
     )
 endforeach()
 
+foreach(
+    _interposer_gem_test
+    IN
+    ITEMS ReusedDmabufFdMintsDistinctHandles UnmapWithWrongHandleFails
+)
+    rj_add_test(
+        NAME "InterposerGemTest.${_interposer_gem_test}"
+        COMMAND
+            ${RJ_CLI}
+            --config
+            ${RJ_CDNA4_KMD_CONFIG}
+            --
+            $<TARGET_FILE:interposer_dup_test>
+            "--gtest_filter=InterposerGemTest.${_interposer_gem_test}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        SKIP_REGULAR_EXPRESSION "\\[  SKIPPED \\]"
+        INSTALL_COMMAND
+            "\${RJ_INSTALLED_BINDIR}/rocjitsu"
+            "--config"
+            "\${RJ_INSTALLED_CONFIG_DIR}/${RJ_CDNA4_KMD_CONFIG_NAME}"
+            "--"
+            "bin/interposer_dup_test"
+            "--gtest_filter=InterposerGemTest.${_interposer_gem_test}"
+    )
+endforeach()
+
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---
 # Spawns rocminfo via the rocjitsu CLI and validates output.
 

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -90,7 +90,7 @@ struct VmFixture {
     engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
     engine->topology().set_root(loaded.take_root());
     loaded.wire_links(engine->topology());
-    engine->build();
+    engine->create();
   }
 
   amdgpu::Xcd *xcd(uint32_t idx = 0) { return soc_ptr->xcd(idx); }

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "aql_queue.h"
+#include "halt_snapshot_plugin.h"
 
 #include "embedded_schema.h"
 #include "rocjitsu/config/config_loader.h"
@@ -99,6 +100,25 @@ struct VmFixture {
   amdgpu::ComputeUnitCore *cu(uint32_t idx = 0) { return se()->compute_unit(idx); }
   amdgpu::CommandProcessor *cp(uint32_t idx = 0) { return xcd(idx)->command_processor(); }
 
+  /// Install a HaltSnapshotPlugin that records each wavefront's final register
+  /// state at s_endpgm (before resources are freed). Call before dispatching.
+  test::HaltSnapshotPlugin *capture_halts() {
+    plugin_group_ = test::make_halt_snapshot_group(&snapshot_plugin_);
+    soc_ptr->set_plugin_group(plugin_group_);
+    return snapshot_plugin_;
+  }
+
+  /// Place a single resident wavefront on CU 0 without running it to s_endpgm.
+  /// Used by tests that drive individual instructions and then read the register
+  /// file directly — the wave stays resident (its resources are not freed) until
+  /// the fixture is destroyed.
+  amdgpu::Wavefront *dispatch_scratch_wf(uint32_t num_sgprs = 104, uint32_t num_vgprs = 256) {
+    return cu()->dispatch_wf(/*wg_id=*/0, /*pc=*/0x1040, num_sgprs, num_vgprs);
+  }
+
+  std::shared_ptr<ExecutionPluginGroup> plugin_group_;
+  test::HaltSnapshotPlugin *snapshot_plugin_ = nullptr;
+
   /// Write a kernel descriptor + instructions to GPU memory per AMDHSA ABI.
   /// Returns the kernel_object address.
   uint64_t write_kernel(uint64_t addr, const void *code, size_t code_size, uint32_t sgprs = 104,
@@ -125,28 +145,25 @@ struct VmFixture {
   }
 };
 
+// Drive the engine until the listed CUs have no resident wavefronts. A wavefront
+// frees itself at s_endpgm (num_wfs()/has_active_wfs() drop as it halts), so the
+// kernel is complete once every listed CU reports idle. Waves that need their final
+// register state inspected should capture it via HaltSnapshotPlugin, which snapshots
+// at halt regardless of where this loop stops.
 void step_until_halted(simdojo::SimulationEngine &engine,
                        std::initializer_list<amdgpu::ComputeUnitCore *> cus,
                        uint32_t max_steps = 10000) {
-  for (uint32_t i = 0; i < max_steps && engine.step(); ++i) {
-    bool all_halted = true;
-    for (auto *cu : cus) {
-      if (!cu->has_active_wfs())
-        continue;
-      for (uint32_t w = 0; w < cu->num_wfs(); ++w) {
-        if (cu->wf(w) && !cu->wf(w)->is_halted()) {
-          all_halted = false;
-          break;
-        }
-      }
-      if (!all_halted)
-        break;
-    }
-    bool any_wf = false;
+  auto any_active = [&]() {
     for (auto *cu : cus)
-      if (cu->num_wfs() > 0)
-        any_wf = true;
-    if (any_wf && all_halted)
+      if (cu->has_active_wfs())
+        return true;
+    return false;
+  };
+  bool saw_work = false;
+  for (uint32_t i = 0; i < max_steps && engine.step(); ++i) {
+    if (any_active())
+      saw_work = true;
+    else if (saw_work)
       break;
   }
 }
@@ -234,6 +251,7 @@ TEST(RdnaDispatchTest, WgpModeCombinesSiblingCuLdsCapacity) {
   for (const char *arch : {"rdna1", "rdna2", "rdna3", "rdna3_5", "rdna4"}) {
     SCOPED_TRACE(arch);
     VmFixture f(arch, 2, 10, /*lds_size_kb=*/64, /*sgprs_per_wf=*/128);
+    auto *snap = f.capture_halts();
     uint64_t ko = f.write_kernel(0x1000, code, sizeof(code), 104, 64, 2, kWgpLdsBytes,
                                  /*wgp_mode=*/true);
     test::AqlQueue queue(f.mem(), f.cp());
@@ -243,20 +261,11 @@ TEST(RdnaDispatchTest, WgpModeCombinesSiblingCuLdsCapacity) {
     EXPECT_EQ(f.cu(0)->lds().size_bytes(), kPerCuLdsBytes);
     EXPECT_EQ(f.se()->spi().max_wgp_lds_bytes(), kWgpLdsBytes);
 
-    amdgpu::Wavefront *wf = nullptr;
-    for (uint32_t cu_idx = 0; cu_idx < 2 && !wf; ++cu_idx) {
-      auto *cu = f.cu(cu_idx);
-      for (uint32_t wf_idx = 0; wf_idx < cu->num_wf_slots(); ++wf_idx) {
-        if (cu->wf(wf_idx)->sgpr_alloc().count != 0) {
-          wf = cu->wf(wf_idx);
-          break;
-        }
-      }
-    }
-    ASSERT_NE(wf, nullptr);
-    EXPECT_EQ(wf->lds().size_bytes(), kWgpLdsBytes);
-    wf->lds().write32(kPerCuLdsBytes + 4, 0xC001D00Du);
-    EXPECT_EQ(wf->lds().read32(kPerCuLdsBytes + 4), 0xC001D00Du);
+    // A WGP-mode wave sees the combined sibling-CU LDS capacity (wave32 splits the
+    // 64-thread workgroup into two waves; both see the same combined pool).
+    ASSERT_GE(snap->snapshots().size(), 1u);
+    for (const auto &wf : snap->snapshots())
+      EXPECT_EQ(wf.lds_size_bytes, kWgpLdsBytes);
   }
 }
 
@@ -408,15 +417,13 @@ protected:
 TEST_P(IsaTest, RegisterAccess) {
   VmFixture f(arch());
 
-  const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
-  uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
-  test::AqlQueue queue(f.mem(), f.cp());
-  queue.dispatch(ko, 64);
-  step_until_halted(*f.engine, {f.cu()});
-
+  // Exercise the CU register-file read/write API on a live, resident wavefront.
+  // dispatch_wf() allocates a slot without running the kernel to s_endpgm (which
+  // would free the slot), so the registers stay readable/writable here.
   auto *cu = f.cu();
+  auto *w = cu->dispatch_wf(/*wg_id=*/0, /*pc=*/0x1040, /*num_sgprs=*/104, /*num_vgprs=*/256);
+  ASSERT_NE(w, nullptr);
   ASSERT_GE(cu->num_wfs(), 1u);
-  auto *w = cu->wf(0);
 
   EXPECT_EQ(w->wf_size(), 64u);
   EXPECT_EQ(w->num_sgprs(), 104u);
@@ -445,6 +452,7 @@ TEST(RdnaDispatchTest, PackedTidHonorsRequestedComponents) {
     for (uint32_t component_count = 0; component_count <= 2; ++component_count) {
       SCOPED_TRACE(arch + " component_count=" + std::to_string(component_count));
       VmFixture f(arch, 1, 10, /*lds_size_kb=*/64, /*sgprs_per_wf=*/128);
+      auto *snap = f.capture_halts();
       uint64_t ko =
           f.write_kernel(0x1000, code, sizeof(code), 104, 32, 2, 0, false, component_count);
 
@@ -462,18 +470,15 @@ TEST(RdnaDispatchTest, PackedTidHonorsRequestedComponents) {
       queue.submit(pkt);
       step_until_halted(*f.engine, {f.cu()});
 
-      ASSERT_EQ(f.cu()->num_wfs(), 2u);
-      auto *wf0 = f.cu()->wf(0);
-      auto *wf1 = f.cu()->wf(1);
+      ASSERT_EQ(snap->snapshots().size(), 2u);
+      const auto *wf0 = snap->by_wf_id(0);
+      const auto *wf1 = snap->by_wf_id(1);
       ASSERT_NE(wf0, nullptr);
       ASSERT_NE(wf1, nullptr);
-      const uint32_t vbase0 = wf0->vgpr_alloc().base;
-      const uint32_t vbase1 = wf1->vgpr_alloc().base;
-      EXPECT_EQ(f.cu()->read_vgpr(vbase0, 0), amdgpu::pack_workitem_id({0, 0, 0}, component_count));
-      EXPECT_EQ(f.cu()->read_vgpr(vbase0, 9), amdgpu::pack_workitem_id({1, 1, 0}, component_count));
-      EXPECT_EQ(f.cu()->read_vgpr(vbase1, 8), amdgpu::pack_workitem_id({0, 1, 1}, component_count));
-      EXPECT_EQ(f.cu()->read_vgpr(vbase1, 31),
-                amdgpu::pack_workitem_id({7, 3, 1}, component_count));
+      EXPECT_EQ(wf0->vgpr(0, 0), amdgpu::pack_workitem_id({0, 0, 0}, component_count));
+      EXPECT_EQ(wf0->vgpr(0, 9), amdgpu::pack_workitem_id({1, 1, 0}, component_count));
+      EXPECT_EQ(wf1->vgpr(0, 8), amdgpu::pack_workitem_id({0, 1, 1}, component_count));
+      EXPECT_EQ(wf1->vgpr(0, 31), amdgpu::pack_workitem_id({7, 3, 1}, component_count));
     }
   }
 }
@@ -485,6 +490,7 @@ TEST(CdnaDispatchTest, Wave64PackedTidHonorsRequestedComponents) {
     for (uint32_t component_count = 0; component_count <= 2; ++component_count) {
       SCOPED_TRACE(::testing::Message() << arch << " component_count=" << component_count);
       VmFixture f(arch);
+      auto *snap = f.capture_halts();
       ASSERT_TRUE(f.cp()->packed_tid());
       uint64_t ko =
           f.write_kernel(0x1000, code, sizeof(code), 104, 256, 2, 0, false, component_count);
@@ -503,19 +509,18 @@ TEST(CdnaDispatchTest, Wave64PackedTidHonorsRequestedComponents) {
       queue.submit(pkt);
       step_until_halted(*f.engine, {f.cu()});
 
-      ASSERT_EQ(f.cu()->num_wfs(), 1u);
-      auto *wf = f.cu()->wf(0);
-      ASSERT_NE(wf, nullptr);
-      EXPECT_EQ(wf->wf_size(), 64u);
-      const uint32_t vbase = wf->vgpr_alloc().base;
-      EXPECT_EQ(f.cu()->read_vgpr(vbase, 40), amdgpu::pack_workitem_id({0, 1, 1}, component_count));
-      EXPECT_EQ(f.cu()->read_vgpr(vbase, 63), amdgpu::pack_workitem_id({7, 3, 1}, component_count));
+      ASSERT_EQ(snap->snapshots().size(), 1u);
+      const auto *wf = &snap->snapshots().front();
+      EXPECT_EQ(wf->wf_size, 64u);
+      EXPECT_EQ(wf->vgpr(0, 40), amdgpu::pack_workitem_id({0, 1, 1}, component_count));
+      EXPECT_EQ(wf->vgpr(0, 63), amdgpu::pack_workitem_id({7, 3, 1}, component_count));
     }
   }
 }
 
 TEST(CdnaDispatchTest, Wave64MasksMultidimensionalGridTailAcrossLane32) {
   VmFixture f("cdna3");
+  auto *snap = f.capture_halts();
   const uint32_t code[] = {SOPP_S_ENDPGM};
   uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
 
@@ -533,14 +538,13 @@ TEST(CdnaDispatchTest, Wave64MasksMultidimensionalGridTailAcrossLane32) {
   queue.submit(pkt);
   step_until_halted(*f.engine, {f.cu()});
 
-  ASSERT_EQ(f.cu()->num_wfs(), 1u);
-  auto *wf = f.cu()->wf(0);
-  ASSERT_NE(wf, nullptr);
-  EXPECT_EQ(wf->wf_size(), 64u);
+  ASSERT_EQ(snap->snapshots().size(), 1u);
+  const auto *wf = &snap->snapshots().front();
+  EXPECT_EQ(wf->wf_size, 64u);
   // Five active X lanes in each of five Y rows. The final active row starts
   // at lane 32; lanes 40-47 are past grid_size_y, and lanes 48-63 map beyond
   // workgroup_size_z.
-  EXPECT_EQ(wf->exec(), 0x0000'001F'1F1F'1F1FULL);
+  EXPECT_EQ(wf->exec, 0x0000'001F'1F1F'1F1FULL);
 }
 
 TEST(CdnaDispatchTest, Cdna1UnpackedTidHonorsRequestedComponents) {
@@ -549,6 +553,7 @@ TEST(CdnaDispatchTest, Cdna1UnpackedTidHonorsRequestedComponents) {
   for (uint32_t component_count = 0; component_count <= 2; ++component_count) {
     SCOPED_TRACE("component_count=" + std::to_string(component_count));
     VmFixture f("cdna1");
+    auto *snap = f.capture_halts();
     ASSERT_FALSE(f.cp()->packed_tid());
     uint64_t ko =
         f.write_kernel(0x1000, code, sizeof(code), 104, 256, 2, 0, false, component_count);
@@ -567,14 +572,12 @@ TEST(CdnaDispatchTest, Cdna1UnpackedTidHonorsRequestedComponents) {
     queue.submit(pkt);
     step_until_halted(*f.engine, {f.cu()});
 
-    ASSERT_EQ(f.cu()->num_wfs(), 1u);
-    auto *wf = f.cu()->wf(0);
-    ASSERT_NE(wf, nullptr);
-    EXPECT_EQ(wf->wf_size(), 64u);
-    const uint32_t vbase = wf->vgpr_alloc().base;
-    EXPECT_EQ(f.cu()->read_vgpr(vbase, 63), 7u);
-    EXPECT_EQ(f.cu()->read_vgpr(vbase + 1, 63), component_count >= 1 ? 3u : 0u);
-    EXPECT_EQ(f.cu()->read_vgpr(vbase + 2, 63), component_count >= 2 ? 1u : 0u);
+    ASSERT_EQ(snap->snapshots().size(), 1u);
+    const auto *wf = &snap->snapshots().front();
+    EXPECT_EQ(wf->wf_size, 64u);
+    EXPECT_EQ(wf->vgpr(0, 63), 7u);
+    EXPECT_EQ(wf->vgpr(1, 63), component_count >= 1 ? 3u : 0u);
+    EXPECT_EQ(wf->vgpr(2, 63), component_count >= 2 ? 1u : 0u);
   }
 }
 
@@ -607,31 +610,17 @@ TEST(DispatchEntryTest, InitialExecMaskHandles3DTailWithWorkgroupOffset) {
 TEST_P(IsaTest, RegisterFileIsolation) {
   VmFixture f(arch(), 1, 2);
 
-  // Two wavefronts in one workgroup: grid=128 items, wg=64 -> 2 wfs.
-  // But that gives 2 workgroups. Use 1 workgroup with 128 items for 2 wfs.
-  const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
-  uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
-  {
-    test::AqlQueue queue(f.mem(), f.cp());
-    hsa_kernel_dispatch_packet_t pkt{};
-    pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
-    pkt.setup = 1;
-    pkt.workgroup_size_x = 128; // 2 wavefronts per workgroup
-    pkt.workgroup_size_y = 1;
-    pkt.workgroup_size_z = 1;
-    pkt.grid_size_x = 128; // 1 workgroup
-    pkt.grid_size_y = 1;
-    pkt.grid_size_z = 1;
-    pkt.kernel_object = ko;
-    pkt.kernarg_address = nullptr;
-    queue.submit(pkt);
-  }
-  step_until_halted(*f.engine, {f.cu()});
-
+  // Two concurrently-resident wavefronts must own disjoint register blocks.
+  // dispatch_wf() places both without running to s_endpgm (which would free them),
+  // so their register files stay live for the isolation checks below.
   auto *cu = f.cu();
+  auto *w0 = cu->dispatch_wf(/*wg_id=*/0, /*pc=*/0x1040, /*num_sgprs=*/104, /*num_vgprs=*/256);
+  auto *w1 = cu->dispatch_wf(/*wg_id=*/0, /*pc=*/0x1040, /*num_sgprs=*/104, /*num_vgprs=*/256);
+  ASSERT_NE(w0, nullptr);
+  ASSERT_NE(w1, nullptr);
   ASSERT_EQ(cu->num_wfs(), 2u);
-  auto *w0 = cu->wf(0);
-  auto *w1 = cu->wf(1);
+  ASSERT_NE(w0->sgpr_alloc().base, w1->sgpr_alloc().base);
+  ASSERT_NE(w0->vgpr_alloc().base, w1->vgpr_alloc().base);
 
   cu->write_sgpr(w0->sgpr_alloc().base + 0, 42);
   cu->write_sgpr(w1->sgpr_alloc().base + 0, 99);
@@ -654,12 +643,27 @@ TEST_P(IsaTest, DispatchAndCapacity) {
   queue.dispatch(ko, 128, 64); // grid=128, wg=64 → 2 workgroups
   f.engine->run();
 
-  // Both slots were used (wavefronts have now halted and been retired).
+  // Both workgroups ran to completion; their waves freed themselves at s_endpgm.
   EXPECT_EQ(f.cp()->dispatched_count(), 1u);
+}
+
+TEST_P(IsaTest, DispatchWfReturnsNullWhenSlotsExhausted) {
+  // dispatch_wf() promises nullptr (not an out-of-bounds slot) when the CU is full.
+  // The CP relies on can_accept_workgroup() gating, but the API contract must hold
+  // independently so it cannot silently drift into OOB access in release builds.
+  constexpr uint32_t kSlots = 4;
+  VmFixture f(arch(), 1, kSlots);
+  auto *cu = f.cu();
+  for (uint32_t i = 0; i < kSlots; ++i)
+    ASSERT_NE(cu->dispatch_wf(0, 0x1040, 104, 256), nullptr) << "slot " << i;
+  EXPECT_EQ(cu->num_wfs(), kSlots);
+  // All slots are occupied by resident (non-halted) waves — the next dispatch fails.
+  EXPECT_EQ(cu->dispatch_wf(0, 0x1040, 104, 256), nullptr);
 }
 
 TEST_P(IsaTest, VendorSpecificExtKernelDispatch) {
   VmFixture f(arch(), 1, 8);
+  auto *snap = f.capture_halts();
 
   const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
   uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
@@ -685,8 +689,11 @@ TEST_P(IsaTest, VendorSpecificExtKernelDispatch) {
   queue.submit(raw);
   f.engine->run();
 
+  // The clustered dispatch produced one consolidated dispatch, and its cluster
+  // wavefronts ran and halted (freeing themselves at s_endpgm). Observe the waves
+  // at halt rather than as post-run residents.
   EXPECT_EQ(f.cp()->dispatched_count(), 1u);
-  EXPECT_GE(f.cu()->num_wfs(), 1u);
+  EXPECT_GE(snap->snapshots().size(), 1u);
 }
 
 TEST_P(IsaTest, VendorSpecificExtKernelDispatchReadsDependencySignalFromGpuMemory) {
@@ -1058,6 +1065,7 @@ TEST(ClusterDispatchTest, RejectsExtKernelDispatchGridOverflow) {
 
 TEST_P(IsaTest, DispatchCreatesWavefronts) {
   VmFixture f(arch(), 2);
+  auto *snap = f.capture_halts();
 
   const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
   uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
@@ -1065,12 +1073,14 @@ TEST_P(IsaTest, DispatchCreatesWavefronts) {
   queue.dispatch(ko, 128); // 2 workgroups of 64
   step_until_halted(*f.engine, {f.se()->compute_unit(0), f.se()->compute_unit(1)});
 
-  EXPECT_EQ(f.se()->compute_unit(0)->num_wfs(), 1u);
-  EXPECT_EQ(f.se()->compute_unit(1)->num_wfs(), 1u);
+  // Round-robin placement puts one workgroup (one wave) on each CU.
+  EXPECT_EQ(snap->for_cu(f.se()->compute_unit(0)).size(), 1u);
+  EXPECT_EQ(snap->for_cu(f.se()->compute_unit(1)).size(), 1u);
 }
 
 TEST_P(IsaTest, MultipleWavesPerWorkgroup) {
   VmFixture f(arch());
+  auto *snap = f.capture_halts();
 
   const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
   uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
@@ -1091,7 +1101,8 @@ TEST_P(IsaTest, MultipleWavesPerWorkgroup) {
   }
   step_until_halted(*f.engine, {f.cu()});
 
-  EXPECT_EQ(f.cu()->num_wfs(), 3u);
+  // One workgroup of 192 work-items = 3 wavefronts, all on the single CU.
+  EXPECT_EQ(snap->for_cu(f.cu()).size(), 3u);
 }
 
 TEST_P(IsaTest, RunToCompletion) {
@@ -1244,6 +1255,7 @@ TEST(RdnaDispatchTest, WgpModeRoutesDsWritesThroughSiblingLdsPool) {
   };
 
   VmFixture f("rdna4", 2, 10, /*lds_size_kb=*/64, /*sgprs_per_wf=*/128);
+  auto *snap = f.capture_halts();
   uint64_t ko = f.write_kernel(0x1000, code, sizeof(code), 128, 64, 2, kWgpLdsBytes,
                                /*wgp_mode=*/true);
   test::AqlQueue queue(f.mem(), f.cp());
@@ -1251,30 +1263,28 @@ TEST(RdnaDispatchTest, WgpModeRoutesDsWritesThroughSiblingLdsPool) {
 
   ASSERT_NO_THROW(f.engine->run());
 
-  amdgpu::Wavefront *wf = nullptr;
-  amdgpu::ComputeUnitCore *active_cu = nullptr;
-  for (uint32_t cu_idx = 0; cu_idx < 2 && !wf; ++cu_idx) {
-    auto *cu = f.cu(cu_idx);
-    for (uint32_t wf_idx = 0; wf_idx < cu->num_wf_slots(); ++wf_idx) {
-      if (cu->wf(wf_idx)->sgpr_alloc().count != 0) {
-        active_cu = cu;
-        wf = cu->wf(wf_idx);
-        break;
-      }
-    }
-  }
-  ASSERT_NE(wf, nullptr);
-  ASSERT_NE(active_cu, nullptr);
-  ASSERT_EQ(wf->lds().size_bytes(), kWgpLdsBytes);
-  EXPECT_EQ(wf->lds().read32(kAddress), kValue);
-  EXPECT_EQ(active_cu->read_vgpr(wf->vgpr_alloc().base + 2, 0), kValue);
+  // The DS store wrote an offset in the sibling CU's half of the combined WGP LDS
+  // pool, then the DS load read it back into v2. A correct v2 proves the store and
+  // load both resolved through the combined pool (kAddress > per-CU capacity, so it
+  // only succeeds if the sibling half is addressable).
+  ASSERT_EQ(snap->snapshots().size(), 1u);
+  const auto &wf = snap->snapshots().front();
+  EXPECT_EQ(wf.lds_size_bytes, kWgpLdsBytes);
+  EXPECT_EQ(wf.vgpr(2, 0), kValue);
 }
 
+// Runs a self-contained scalar/vector program to s_endpgm and exposes the
+// wavefront's final architectural state. Because a wave frees its registers the
+// instant it halts, the final state is captured at halt time via HaltSnapshotPlugin
+// and served from that snapshot rather than from the (now-freed) slot.
 struct ExecFixture {
   VmFixture f;
   std::string arch_;
+  test::HaltSnapshotPlugin *snap_ = nullptr;
 
-  explicit ExecFixture(const std::string &arch) : f(arch), arch_(arch) {}
+  explicit ExecFixture(const std::string &arch) : f(arch), arch_(arch) {
+    snap_ = f.capture_halts();
+  }
 
   bool is_cdna4() const { return arch_ == "cdna4"; }
   uint32_t sopp_bytes() const { return 4u; }
@@ -1295,24 +1305,24 @@ struct ExecFixture {
     step_until_halted(*f.engine, {f.cu()});
   }
 
-  amdgpu::Wavefront *wf() { return f.cu()->wf(0); }
   amdgpu::ComputeUnitCore *cu() { return f.cu(); }
-  bool step() { return f.cu()->step(); }
 
-  uint32_t read_sgpr(uint32_t idx) { return cu()->read_sgpr(wf()->sgpr_alloc().base + idx); }
-  void write_sgpr(uint32_t idx, uint32_t val) {
-    cu()->write_sgpr(wf()->sgpr_alloc().base + idx, val);
+  /// Snapshot of the (single) halted wavefront's final state.
+  const test::WavefrontSnapshot &snap() const {
+    EXPECT_EQ(snap_->snapshots().size(), 1u);
+    return snap_->snapshots().front();
   }
-  uint32_t read_vgpr(uint32_t reg, uint32_t lane) {
-    return cu()->read_vgpr(wf()->vgpr_alloc().base + reg, lane);
-  }
-  void write_vgpr(uint32_t reg, uint32_t lane, uint32_t val) {
-    cu()->write_vgpr(wf()->vgpr_alloc().base + reg, lane, val);
-  }
+
+  bool halted() const { return !snap_->snapshots().empty(); }
+  uint32_t status_raw() const { return snap().status; }
+  uint64_t vcc() const { return snap().vcc; }
+  uint32_t read_sgpr(uint32_t idx) { return snap().sgpr(idx); }
+  uint32_t read_vgpr(uint32_t reg, uint32_t lane) { return snap().vgpr(reg, lane); }
 };
 
 TEST_P(IsaTest, StepExecutesAndHalts) {
   VmFixture f(arch());
+  auto *snap = f.capture_halts();
 
   auto prog = ExecFixture::cat({{SOPP_S_NOP}, {SOPP_S_NOP}, {SOPP_S_ENDPGM}});
   uint64_t ko = f.write_kernel(0x0, prog.data(), prog.size() * sizeof(uint32_t));
@@ -1320,9 +1330,9 @@ TEST_P(IsaTest, StepExecutesAndHalts) {
   queue.dispatch(ko, 64);
   step_until_halted(*f.engine, {f.cu()});
 
-  auto *cu = f.cu();
-  ASSERT_GE(cu->num_wfs(), 1u);
-  EXPECT_TRUE(cu->wf(0)->is_halted());
+  // The wave executed and halted (freeing itself at s_endpgm).
+  EXPECT_EQ(snap->snapshots().size(), 1u);
+  EXPECT_EQ(f.cu()->num_wfs(), 0u);
 }
 
 TEST_P(IsaTest, RoundRobinScheduling) {
@@ -1346,6 +1356,7 @@ TEST_P(IsaTest, RoundRobinScheduling) {
 
 TEST_P(IsaTest, EngineRunsToCompletion) {
   VmFixture f(arch());
+  auto *snap = f.capture_halts();
 
   auto prog = ExecFixture::cat({{SOPP_S_NOP}, {SOPP_S_ENDPGM}});
   uint64_t ko = f.write_kernel(0x0, prog.data(), prog.size() * sizeof(uint32_t));
@@ -1353,8 +1364,8 @@ TEST_P(IsaTest, EngineRunsToCompletion) {
   queue.dispatch(ko, 64);
   step_until_halted(*f.engine, {f.cu()});
 
-  ASSERT_GE(f.cu()->num_wfs(), 1u);
-  EXPECT_TRUE(f.cu()->wf(0)->is_halted());
+  EXPECT_EQ(snap->snapshots().size(), 1u);
+  EXPECT_EQ(f.cu()->num_wfs(), 0u);
 }
 
 TEST_P(IsaTest, SMovB32_InlineConst) {
@@ -1418,7 +1429,7 @@ TEST_P(IsaTest, SCmpEqI32_Equal) {
   fx.load_program({enc::s_mov_b32(0, enc::INLINE_CONST(42)),
                    enc::s_mov_b32(1, enc::INLINE_CONST(42)),
                    enc::s_cmp_eq_i32(enc::SGPR(0), enc::SGPR(1)), SOPP_S_ENDPGM});
-  EXPECT_EQ(fx.wf()->status_raw() & 1u, 1u); // SCC=1
+  EXPECT_EQ(fx.status_raw() & 1u, 1u); // SCC=1
 }
 
 TEST_P(IsaTest, SCmpEqI32_NotEqual) {
@@ -1426,7 +1437,7 @@ TEST_P(IsaTest, SCmpEqI32_NotEqual) {
   fx.load_program({enc::s_mov_b32(0, enc::INLINE_CONST(42)),
                    enc::s_mov_b32(1, enc::INLINE_CONST(43)),
                    enc::s_cmp_eq_i32(enc::SGPR(0), enc::SGPR(1)), SOPP_S_ENDPGM});
-  EXPECT_EQ(fx.wf()->status_raw() & 1u, 0u); // SCC=0
+  EXPECT_EQ(fx.status_raw() & 1u, 0u); // SCC=0
 }
 
 TEST_P(IsaTest, SCmpGtI32) {
@@ -1436,7 +1447,7 @@ TEST_P(IsaTest, SCmpGtI32) {
   fx.load_program({enc::s_mov_b32(0, NEG_5),  // s0 = -5
                    enc::s_mov_b32(1, NEG_10), // s1 = -10
                    enc::s_cmp_gt_i32(enc::SGPR(0), enc::SGPR(1)), SOPP_S_ENDPGM});
-  EXPECT_EQ(fx.wf()->status_raw() & 1u, 1u); // -5 > -10, SCC=1
+  EXPECT_EQ(fx.status_raw() & 1u, 1u); // -5 > -10, SCC=1
 }
 
 TEST_P(IsaTest, SBranch_Forward) {
@@ -1449,8 +1460,7 @@ TEST_P(IsaTest, SBranch_Forward) {
   test::AqlQueue queue(fx.f.mem(), fx.f.cp());
   queue.dispatch(ko, 64);
   step_until_halted(*fx.f.engine, {fx.cu()});
-  ASSERT_GE(fx.cu()->num_wfs(), 1u);
-  EXPECT_TRUE(fx.wf()->is_halted());
+  EXPECT_TRUE(fx.halted());
 }
 
 TEST_P(IsaTest, SCbranchScc0_Taken) {
@@ -1470,7 +1480,7 @@ TEST_P(IsaTest, SCbranchScc0_Taken) {
   test::AqlQueue queue(fx.f.mem(), fx.f.cp());
   queue.dispatch(ko, 64);
   step_until_halted(*fx.f.engine, {fx.cu()});
-  EXPECT_TRUE(fx.wf()->is_halted());
+  EXPECT_TRUE(fx.halted());
 }
 
 TEST_P(IsaTest, SCbranchScc0_NotTaken) {
@@ -1488,7 +1498,7 @@ TEST_P(IsaTest, SCbranchScc0_NotTaken) {
   test::AqlQueue queue(fx.f.mem(), fx.f.cp());
   queue.dispatch(ko, 64);
   step_until_halted(*fx.f.engine, {fx.cu()});
-  EXPECT_TRUE(fx.wf()->is_halted());
+  EXPECT_TRUE(fx.halted());
 }
 
 TEST_P(IsaTest, SCbranchScc1_Taken) {
@@ -1506,13 +1516,13 @@ TEST_P(IsaTest, SCbranchScc1_Taken) {
   test::AqlQueue queue(fx.f.mem(), fx.f.cp());
   queue.dispatch(ko, 64);
   step_until_halted(*fx.f.engine, {fx.cu()});
-  EXPECT_TRUE(fx.wf()->is_halted());
+  EXPECT_TRUE(fx.halted());
 }
 
 TEST_P(IsaTest, SEndpgm_Halts) {
   ExecFixture fx(arch());
   fx.load_program({SOPP_S_ENDPGM});
-  EXPECT_TRUE(fx.wf()->is_halted());
+  EXPECT_TRUE(fx.halted());
 }
 
 TEST_P(IsaTest, VMovB32_PerLane) {
@@ -1566,7 +1576,7 @@ TEST_P(IsaTest, VCmpEqF32_SetsVCC) {
   // Lane 0: v0=0, compared with 0 -> equal -> VCC[0]=1.
   // Lane 1: v0=1, compared with 0 -> not equal -> VCC[1]=0.
   fx.load_program({enc::v_cmp_eq_f32(enc::INLINE_CONST(0), 0), SOPP_S_ENDPGM});
-  uint64_t vcc = fx.wf()->vcc();
+  uint64_t vcc = fx.vcc();
   EXPECT_TRUE(vcc & (1ULL << 0));  // lane 0: 0.0 == 0.0
   EXPECT_FALSE(vcc & (1ULL << 1)); // lane 1: int 1 as float != 0.0
 }
@@ -1592,7 +1602,7 @@ TEST_P(IsaTest, ExecMask_PreservesInactiveLanes) {
   // We can't set EXEC before run. Instead, verify that the engine runs to completion.
   // This test is simplified to just verify halting behavior.
   fx.load_program({enc::v_mov_b32(2, enc::VGPR_SRC(0)), SOPP_S_ENDPGM});
-  EXPECT_TRUE(fx.wf()->is_halted());
+  EXPECT_TRUE(fx.halted());
   EXPECT_EQ(fx.read_vgpr(2, 0), 0u);
   EXPECT_EQ(fx.read_vgpr(2, 1), 1u);
 }
@@ -1608,7 +1618,7 @@ TEST_P(IsaTest, MultiInstructionProgram) {
   EXPECT_EQ(fx.read_sgpr(3), 10u);
   EXPECT_EQ(fx.read_sgpr(4), 20u);
   EXPECT_EQ(fx.read_sgpr(5), 30u);
-  EXPECT_TRUE(fx.wf()->is_halted());
+  EXPECT_TRUE(fx.halted());
 }
 
 TEST_P(IsaTest, BranchLoop) {
@@ -1629,7 +1639,7 @@ TEST_P(IsaTest, BranchLoop) {
   step_until_halted(*fx.f.engine, {fx.cu()});
 
   EXPECT_EQ(fx.read_sgpr(3), 0u);
-  EXPECT_TRUE(fx.wf()->is_halted());
+  EXPECT_TRUE(fx.halted());
 }
 
 INSTANTIATE_TEST_SUITE_P(Cdna, IsaTest, ::testing::Values("cdna3", "cdna4"),
@@ -1642,14 +1652,11 @@ INSTANTIATE_TEST_SUITE_P(Cdna, IsaTest, ::testing::Values("cdna3", "cdna4"),
 TEST_P(IsaTest, MfmaF16Accumulation) {
   VmFixture f(arch());
 
-  const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
-  uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
-  test::AqlQueue queue(f.mem(), f.cp());
-  queue.dispatch(ko, 64);
-  step_until_halted(*f.engine, {f.cu()});
-
+  // Resident scratch wave: this test drives MFMA directly and reads the VGPR file,
+  // so the wave must stay allocated (not run to s_endpgm, which would free it).
   auto *cu = f.cu();
-  auto *wf = cu->wf(0);
+  auto *wf = f.dispatch_scratch_wf();
+  ASSERT_NE(wf, nullptr);
   uint32_t vb = wf->vgpr_alloc().base;
 
   // Test v_mfma_f32_16x16x32_f16: M=16, N=16, K=32, B=1, in_bits=16
@@ -1703,14 +1710,10 @@ TEST_P(IsaTest, MfmaF16Accumulation) {
 TEST_P(IsaTest, MfmaF16AccumulationPatterned) {
   VmFixture f(arch());
 
-  const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
-  uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
-  test::AqlQueue queue(f.mem(), f.cp());
-  queue.dispatch(ko, 64);
-  step_until_halted(*f.engine, {f.cu()});
-
+  // Resident scratch wave (see MfmaF16Accumulation): driven directly, not to endpgm.
   auto *cu = f.cu();
-  auto *wf = cu->wf(0);
+  auto *wf = f.dispatch_scratch_wf();
+  ASSERT_NE(wf, nullptr);
   uint32_t vb = wf->vgpr_alloc().base;
 
   // Test with patterned data: A[i][k] = (i+1) as FP16, B[k][j] = 1.0h
@@ -1793,14 +1796,10 @@ void expect_mfma_f64_outputs(amdgpu::ComputeUnitCore *cu, uint32_t dst, double e
 void expect_mfma_f64_neg_modifier(const std::string &arch) {
   VmFixture f(arch);
 
-  const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
-  uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
-  test::AqlQueue queue(f.mem(), f.cp());
-  queue.dispatch(ko, 64);
-  step_until_halted(*f.engine, {f.cu()});
-
+  // Resident scratch wave (see MfmaF16Accumulation): driven directly, not to endpgm.
   auto *cu = f.cu();
-  auto *wf = cu->wf(0);
+  auto *wf = f.dispatch_scratch_wf();
+  ASSERT_NE(wf, nullptr);
   uint32_t vb = wf->vgpr_alloc().base;
   uint32_t dst = vb + amdgpu::ACC_VGPR_OFFSET;
   uint32_t s0 = vb + 10;
@@ -1829,14 +1828,10 @@ TEST(MfmaF64Cdna4Test, NegModifier) { expect_mfma_f64_neg_modifier("cdna4"); }
 TEST(MfmaF64Cdna4Test, GeneratedInstructionUsesBlgpNegModifier) {
   VmFixture f("cdna4");
 
-  const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
-  uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
-  test::AqlQueue queue(f.mem(), f.cp());
-  queue.dispatch(ko, 64);
-  step_until_halted(*f.engine, {f.cu()});
-
+  // Resident scratch wave (see MfmaF16Accumulation): driven directly, not to endpgm.
   auto *cu = f.cu();
-  auto *wf = cu->wf(0);
+  auto *wf = f.dispatch_scratch_wf();
+  ASSERT_NE(wf, nullptr);
   uint32_t vb = wf->vgpr_alloc().base;
   constexpr uint32_t kSrc0 = 10;
   constexpr uint32_t kSrc1 = 20;
@@ -2040,6 +2035,7 @@ TEST(AtomicStressTest, GlobalAtomicAdd_MultiWorkgroup) {
 // not to VGPR (vb+vdst).
 TEST(DsTransposeTest, ReadB64TrB16_AccBit) {
   VmFixture f("cdna4", 1, 10);
+  auto *snap = f.capture_halts();
 
   constexpr uint32_t VDST = 4;
   constexpr uint32_t ADDR_REG = 0;
@@ -2074,16 +2070,15 @@ TEST(DsTransposeTest, ReadB64TrB16_AccBit) {
   queue.dispatch(ko, 64);
   f.engine->run();
 
-  auto *wf = cu->wf(0);
-  ASSERT_NE(wf, nullptr);
-  uint32_t vb = wf->vgpr_alloc().base;
+  ASSERT_EQ(snap->snapshots().size(), 1u);
+  const auto &wf = snap->snapshots().front();
 
   // VGPR v4 should still hold the sentinel (42), not overwritten by ds_read.
-  uint32_t vgpr_val = cu->read_vgpr(vb + VDST, 0);
+  uint32_t vgpr_val = wf.vgpr(VDST, 0);
   EXPECT_EQ(vgpr_val, 42u) << "VGPR v" << VDST << " should NOT have been written when acc=1";
 
   // AccVGPR a4 should have been written with LDS data (not 42, not 0).
-  uint32_t acc_val = cu->read_vgpr(vb + 256 + VDST, 0);
+  uint32_t acc_val = wf.vgpr(256 + VDST, 0);
   EXPECT_NE(acc_val, 0u) << "AccVGPR a" << VDST << " should have been written by ds_read";
   EXPECT_NE(acc_val, 42u) << "AccVGPR a" << VDST
                           << " should contain LDS data, not the VGPR sentinel";

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "aql_queue.h"
+#include "halt_snapshot_plugin.h"
 
 #include "embedded_schema.h"
 #include "rocjitsu/config/checkpoint.h"
@@ -711,6 +712,10 @@ TEST(ConfigLoaderTest, DispatchDistributesAcrossCUs) {
   loaded.wire_links(engine.topology());
   engine.create();
 
+  rocjitsu::test::DispatchCountPlugin *dispatch_count = nullptr;
+  auto plugin_group = rocjitsu::test::make_dispatch_count_group(&dispatch_count);
+  soc->set_plugin_group(plugin_group);
+
   // Write a kernel descriptor + invalid instruction so wavefronts halt immediately.
   using namespace rocr::llvm::amdhsa;
   kernel_descriptor_t kd{};
@@ -732,12 +737,13 @@ TEST(ConfigLoaderTest, DispatchDistributesAcrossCUs) {
 
   engine.step();
 
-  // After one step, the doorbell event dispatched wavefronts to CUs
-  // (allocated but not yet executed). Verify round-robin distribution.
+  // After one step, the doorbell event dispatched wavefronts to CUs. Count them
+  // via the dispatch hook (fired at placement) so the check is independent of when
+  // waves execute and free themselves. Verify round-robin distribution.
   EXPECT_EQ(xcd->command_processor()->dispatched_count(), 1u);
   auto *se = soc->xcd(0)->shader_engine(0);
-  EXPECT_EQ(se->compute_unit(0)->num_wfs(), 1u);
-  EXPECT_EQ(se->compute_unit(1)->num_wfs(), 1u);
+  EXPECT_EQ(dispatch_count->for_cu(se->compute_unit(0)), 1u);
+  EXPECT_EQ(dispatch_count->for_cu(se->compute_unit(1)), 1u);
 }
 
 TEST(CheckpointTest, SaveAndRestoreMemory) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -709,7 +709,7 @@ TEST(ConfigLoaderTest, DispatchDistributesAcrossCUs) {
   simdojo::SimulationEngine engine(loaded.engine_config);
   engine.topology().set_root(loaded.take_root());
   loaded.wire_links(engine.topology());
-  engine.build();
+  engine.create();
 
   // Write a kernel descriptor + invalid instruction so wavefronts halt immediately.
   using namespace rocr::llvm::amdhsa;

--- a/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
@@ -40,6 +40,16 @@ namespace {
 using test::kernel_hsaco_path;
 using test::kernel_path;
 
+// Upper bound on how long to block for a dispatch's completion signal. This is a
+// correctness guard against a stuck dispatch, NOT a performance budget: the real
+// hang guard is the ctest-level TIMEOUT (120-300s). Under CI's `ctest -j`, these
+// CPU-bound DBT matmul simulations are starved and a correct dispatch can take far
+// longer in wall time than it does when run alone, so a tight per-signal budget
+// (the old 5-10s) produced false "dispatch timed out" failures. Keep it generously
+// below the ctest TIMEOUT so a genuine hang still surfaces as a signal-wait failure
+// rather than a hard ctest kill.
+constexpr uint64_t kDispatchSignalWaitTimeoutNs = 120'000'000'000ULL;
+
 std::vector<uint8_t> load_kernel_hsaco_bytes(const char *name) {
   std::ifstream file(kernel_hsaco_path(name), std::ios::binary);
   if (!file)
@@ -510,7 +520,7 @@ void run_dynamic_copy_loop(const std::vector<uint8_t> &elf_bytes, const Dispatch
     hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
 
     const hsa_signal_value_t val = hsa_signal_wait_scacquire(
-        signal, HSA_SIGNAL_CONDITION_LT, 1, 5'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+        signal, HSA_SIGNAL_CONDITION_LT, 1, kDispatchSignalWaitTimeoutNs, HSA_WAIT_STATE_BLOCKED);
     ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
 
     ASSERT_EQ(hsa_memory_copy(dst_host.data(), dst_dev, kMaxBytes), HSA_STATUS_SUCCESS);
@@ -691,8 +701,9 @@ void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const DispatchTarg
   __atomic_store_n(reinterpret_cast<uint16_t *>(aql), header, __ATOMIC_RELEASE);
   hsa_signal_store_relaxed(resources.queue->doorbell_signal, write_idx);
 
-  const hsa_signal_value_t val = hsa_signal_wait_scacquire(
-      resources.signal, HSA_SIGNAL_CONDITION_LT, 1, 5'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+  const hsa_signal_value_t val =
+      hsa_signal_wait_scacquire(resources.signal, HSA_SIGNAL_CONDITION_LT, 1,
+                                kDispatchSignalWaitTimeoutNs, HSA_WAIT_STATE_BLOCKED);
   ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
 
   ASSERT_EQ(hsa_memory_copy(c_host.data(), c_dev, kCBytes), HSA_STATUS_SUCCESS);
@@ -865,7 +876,7 @@ void run_buffer_async_triton_matmul(const std::vector<uint8_t> &elf_bytes,
   hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
 
   const hsa_signal_value_t val = hsa_signal_wait_scacquire(
-      signal, HSA_SIGNAL_CONDITION_LT, 1, 10'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+      signal, HSA_SIGNAL_CONDITION_LT, 1, kDispatchSignalWaitTimeoutNs, HSA_WAIT_STATE_BLOCKED);
   ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
 
   ASSERT_EQ(hsa_memory_copy(c_host.data(), c_dev, kCBytes), HSA_STATUS_SUCCESS);
@@ -1021,7 +1032,7 @@ void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const Dis
   hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
 
   const hsa_signal_value_t val = hsa_signal_wait_scacquire(
-      signal, HSA_SIGNAL_CONDITION_LT, 1, 10'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+      signal, HSA_SIGNAL_CONDITION_LT, 1, kDispatchSignalWaitTimeoutNs, HSA_WAIT_STATE_BLOCKED);
   ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
 
   ASSERT_EQ(hsa_memory_copy(o_host.data(), o_dev, kOBytes), HSA_STATUS_SUCCESS);

--- a/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
@@ -40,16 +40,6 @@ namespace {
 using test::kernel_hsaco_path;
 using test::kernel_path;
 
-// Upper bound on how long to block for a dispatch's completion signal. This is a
-// correctness guard against a stuck dispatch, NOT a performance budget: the real
-// hang guard is the ctest-level TIMEOUT (120-300s). Under CI's `ctest -j`, these
-// CPU-bound DBT matmul simulations are starved and a correct dispatch can take far
-// longer in wall time than it does when run alone, so a tight per-signal budget
-// (the old 5-10s) produced false "dispatch timed out" failures. Keep it generously
-// below the ctest TIMEOUT so a genuine hang still surfaces as a signal-wait failure
-// rather than a hard ctest kill.
-constexpr uint64_t kDispatchSignalWaitTimeoutNs = 120'000'000'000ULL;
-
 std::vector<uint8_t> load_kernel_hsaco_bytes(const char *name) {
   std::ifstream file(kernel_hsaco_path(name), std::ios::binary);
   if (!file)
@@ -520,7 +510,7 @@ void run_dynamic_copy_loop(const std::vector<uint8_t> &elf_bytes, const Dispatch
     hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
 
     const hsa_signal_value_t val = hsa_signal_wait_scacquire(
-        signal, HSA_SIGNAL_CONDITION_LT, 1, kDispatchSignalWaitTimeoutNs, HSA_WAIT_STATE_BLOCKED);
+        signal, HSA_SIGNAL_CONDITION_LT, 1, 5'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
     ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
 
     ASSERT_EQ(hsa_memory_copy(dst_host.data(), dst_dev, kMaxBytes), HSA_STATUS_SUCCESS);
@@ -701,9 +691,8 @@ void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const DispatchTarg
   __atomic_store_n(reinterpret_cast<uint16_t *>(aql), header, __ATOMIC_RELEASE);
   hsa_signal_store_relaxed(resources.queue->doorbell_signal, write_idx);
 
-  const hsa_signal_value_t val =
-      hsa_signal_wait_scacquire(resources.signal, HSA_SIGNAL_CONDITION_LT, 1,
-                                kDispatchSignalWaitTimeoutNs, HSA_WAIT_STATE_BLOCKED);
+  const hsa_signal_value_t val = hsa_signal_wait_scacquire(
+      resources.signal, HSA_SIGNAL_CONDITION_LT, 1, 5'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
   ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
 
   ASSERT_EQ(hsa_memory_copy(c_host.data(), c_dev, kCBytes), HSA_STATUS_SUCCESS);
@@ -876,7 +865,7 @@ void run_buffer_async_triton_matmul(const std::vector<uint8_t> &elf_bytes,
   hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
 
   const hsa_signal_value_t val = hsa_signal_wait_scacquire(
-      signal, HSA_SIGNAL_CONDITION_LT, 1, kDispatchSignalWaitTimeoutNs, HSA_WAIT_STATE_BLOCKED);
+      signal, HSA_SIGNAL_CONDITION_LT, 1, 10'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
   ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
 
   ASSERT_EQ(hsa_memory_copy(c_host.data(), c_dev, kCBytes), HSA_STATUS_SUCCESS);
@@ -1032,7 +1021,7 @@ void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const Dis
   hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
 
   const hsa_signal_value_t val = hsa_signal_wait_scacquire(
-      signal, HSA_SIGNAL_CONDITION_LT, 1, kDispatchSignalWaitTimeoutNs, HSA_WAIT_STATE_BLOCKED);
+      signal, HSA_SIGNAL_CONDITION_LT, 1, 10'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
   ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
 
   ASSERT_EQ(hsa_memory_copy(o_host.data(), o_dev, kOBytes), HSA_STATUS_SUCCESS);

--- a/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
@@ -40,6 +40,16 @@ namespace {
 using test::kernel_hsaco_path;
 using test::kernel_path;
 
+// Upper bound on how long to block for a dispatch's completion signal. This is a
+// hang guard, NOT a performance budget: the real hang guard is the ctest-level
+// TIMEOUT (120-300s). The larger fixtures (e.g. the 1024^3 buffer-async Triton
+// matmul) are genuinely ~10s of single-threaded functional emulation; under CI's
+// `ctest -j` the emulating thread is CPU-starved and a correct dispatch can take
+// well past a tight per-signal budget, so a 5-10s wait produced false "dispatch
+// timed out" failures. Keep this generously below the ctest TIMEOUT so a real hang
+// still surfaces as a signal-wait failure rather than a hard ctest kill.
+constexpr uint64_t kDispatchSignalWaitTimeoutNs = 120'000'000'000ULL;
+
 std::vector<uint8_t> load_kernel_hsaco_bytes(const char *name) {
   std::ifstream file(kernel_hsaco_path(name), std::ios::binary);
   if (!file)
@@ -510,7 +520,7 @@ void run_dynamic_copy_loop(const std::vector<uint8_t> &elf_bytes, const Dispatch
     hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
 
     const hsa_signal_value_t val = hsa_signal_wait_scacquire(
-        signal, HSA_SIGNAL_CONDITION_LT, 1, 5'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+        signal, HSA_SIGNAL_CONDITION_LT, 1, kDispatchSignalWaitTimeoutNs, HSA_WAIT_STATE_BLOCKED);
     ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
 
     ASSERT_EQ(hsa_memory_copy(dst_host.data(), dst_dev, kMaxBytes), HSA_STATUS_SUCCESS);
@@ -691,8 +701,9 @@ void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const DispatchTarg
   __atomic_store_n(reinterpret_cast<uint16_t *>(aql), header, __ATOMIC_RELEASE);
   hsa_signal_store_relaxed(resources.queue->doorbell_signal, write_idx);
 
-  const hsa_signal_value_t val = hsa_signal_wait_scacquire(
-      resources.signal, HSA_SIGNAL_CONDITION_LT, 1, 5'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+  const hsa_signal_value_t val =
+      hsa_signal_wait_scacquire(resources.signal, HSA_SIGNAL_CONDITION_LT, 1,
+                                kDispatchSignalWaitTimeoutNs, HSA_WAIT_STATE_BLOCKED);
   ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
 
   ASSERT_EQ(hsa_memory_copy(c_host.data(), c_dev, kCBytes), HSA_STATUS_SUCCESS);
@@ -865,7 +876,7 @@ void run_buffer_async_triton_matmul(const std::vector<uint8_t> &elf_bytes,
   hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
 
   const hsa_signal_value_t val = hsa_signal_wait_scacquire(
-      signal, HSA_SIGNAL_CONDITION_LT, 1, 10'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+      signal, HSA_SIGNAL_CONDITION_LT, 1, kDispatchSignalWaitTimeoutNs, HSA_WAIT_STATE_BLOCKED);
   ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
 
   ASSERT_EQ(hsa_memory_copy(c_host.data(), c_dev, kCBytes), HSA_STATUS_SUCCESS);
@@ -1021,7 +1032,7 @@ void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const Dis
   hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
 
   const hsa_signal_value_t val = hsa_signal_wait_scacquire(
-      signal, HSA_SIGNAL_CONDITION_LT, 1, 10'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+      signal, HSA_SIGNAL_CONDITION_LT, 1, kDispatchSignalWaitTimeoutNs, HSA_WAIT_STATE_BLOCKED);
   ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
 
   ASSERT_EQ(hsa_memory_copy(o_host.data(), o_dev, kOBytes), HSA_STATUS_SUCCESS);

--- a/emulation/rocjitsu/tests/decode_execute_benchmark.cpp
+++ b/emulation/rocjitsu/tests/decode_execute_benchmark.cpp
@@ -135,7 +135,7 @@ void run_benchmark(rj_code_arch_t arch, std::string_view arch_name, const TestEn
 
   // Build corpus (decode-only filtering, no execute warmup).
   auto corpus = build_corpus(encodings, num_encodings, *decoder);
-  cu->reset_all_wf();
+  wf->halt();
   wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
   ASSERT_NE(wf, nullptr);
 
@@ -186,6 +186,11 @@ void run_benchmark(rj_code_arch_t arch, std::string_view arch_name, const TestEn
       std::chrono::duration_cast<std::chrono::nanoseconds>(decode_end - decode_start).count();
 
   // --- Measure decode + execute (non-memory only) ---
+  // build_corpus() already excludes program terminators (s_endpgm et al.) via
+  // should_skip(), so no instruction here frees the wave. Guard defensively anyway:
+  // a wave frees its resources at s_endpgm, so if the skip list ever drifts and a
+  // terminator slips in, re-dispatch a fresh wave rather than execute on a freed
+  // slot (which would benchmark dead work).
   auto full_start = Clock::now();
   for (int iter = 0; iter < ITERATIONS; ++iter) {
     for (const auto *entry : executable) {
@@ -196,6 +201,10 @@ void run_benchmark(rj_code_arch_t arch, std::string_view arch_name, const TestEn
         } catch (...) {
         }
         delete inst;
+        if (wf->is_halted()) {
+          wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+          ASSERT_NE(wf, nullptr); // single-slot CU: re-dispatch must succeed
+        }
       }
     }
   }

--- a/emulation/rocjitsu/tests/decode_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/decode_smoke_test.cpp
@@ -708,7 +708,7 @@ void expect_sleep_yields_before_quantum_expires(rj_code_arch_t arch, uint32_t sl
   auto *wf = cu->dispatch_wf(0, kCodeAddress, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
   ASSERT_NE(wf, nullptr);
 
-  EXPECT_TRUE(cu->advance());
+  EXPECT_TRUE(cu->execute_quantum());
   EXPECT_EQ(wf->pc, kCodeAddress + sizeof(uint32_t));
 }
 

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -512,7 +512,7 @@ struct PluginFixture {
     engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
     engine->topology().set_root(loaded.take_root());
     loaded.wire_links(engine->topology());
-    engine->build();
+    engine->create();
   }
 
   amdgpu::ComputeUnitCore *cu() { return soc->xcd(0)->shader_engine(0)->compute_unit(0); }

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -901,6 +901,52 @@ TEST(HookOrderingTest, WorkgroupDispatchedReportsPhysicalVgprBlockSize) {
   EXPECT_EQ(it->sgpr_count, f.cu()->config().sgprs_per_wf);
 }
 
+// The immediate-halt branch frees a wave's registers the instant s_endpgm
+// executes, so instruction hooks must not read the slot afterward. Concretely:
+// the terminator must fire BEFORE_INSTRUCTION (it is fetched and decoded) but NOT
+// AFTER_INSTRUCTION (there is no live slot to observe once it halts+frees), while
+// every non-terminator retains a matched BEFORE/AFTER pair. This pins the guard
+// that prevents hooks/logging from touching a freed register slot.
+TEST(HookOrderingTest, TerminatorEmitsBeforeButNotAfterInstruction) {
+  PluginFixture f(/*num_wf_slots=*/1);
+  auto *p = f.attach_ordering_plugin();
+  // Two non-terminators then the terminator, so the sequence exercises matched
+  // BEFORE/AFTER pairs and the terminator's asymmetry in one run.
+  const uint32_t code[] = {S_NOP, S_NOP, S_ENDPGM};
+  f.run_kernel(code, 3);
+  f.shutdown();
+
+  // Collect the BEFORE/AFTER instruction hooks in order.
+  size_t before_endpgm = 0, after_endpgm = 0;
+  size_t before_nop = 0, after_nop = 0;
+  for (const auto &e : p->events) {
+    if (e.kind == HookEvent::BEFORE_INSTRUCTION) {
+      if (e.mnemonic == "s_endpgm")
+        ++before_endpgm;
+      else if (e.mnemonic == "s_nop")
+        ++before_nop;
+    } else if (e.kind == HookEvent::AFTER_INSTRUCTION) {
+      if (e.mnemonic == "s_endpgm")
+        ++after_endpgm;
+      else if (e.mnemonic == "s_nop")
+        ++after_nop;
+    }
+  }
+
+  // The terminator is observed before execution but frees the wave on execution,
+  // so it must not emit an AFTER hook.
+  EXPECT_EQ(before_endpgm, 1u) << "s_endpgm must fire BEFORE_INSTRUCTION";
+  EXPECT_EQ(after_endpgm, 0u) << "s_endpgm must NOT fire AFTER_INSTRUCTION (slot freed at halt)";
+
+  // Non-terminators keep matched BEFORE/AFTER pairs.
+  EXPECT_EQ(before_nop, 2u);
+  EXPECT_EQ(after_nop, 2u);
+
+  // Exactly one wave, and it halted.
+  EventLog log(p->events);
+  EXPECT_EQ(log.count(HookEvent::WAVEFRONT_HALTED), 1u);
+}
+
 TEST(HookOrderingTest, FiveDispatchLifecycle) {
   PluginFixture f(/*num_wf_slots=*/1);
   auto *p = f.attach_ordering_plugin();

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -139,7 +139,7 @@ struct Gfx1250Sim {
     engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
     engine->topology().set_root(loaded.take_root());
     loaded.wire_links(engine->topology());
-    engine->build();
+    engine->create();
   }
 
   amdgpu::Xcd *xcd(uint32_t idx = 0) { return soc->xcd(idx); }

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -391,14 +391,19 @@ void step_until_xcd_halted(Gfx1250Sim &sim, uint32_t max_steps = 10000) {
 }
 
 // Runs a one-wave kernel to s_endpgm and returns the wave's final-state snapshot
-// (captured at halt, before its registers are freed), or nullptr if no wave halted.
+// (captured at halt, before its registers are freed), or nullptr if THIS dispatch
+// produced no new halt. Snapshots accumulate across calls in the fixture plugin, so
+// compare the count before/after and only return a pointer when this dispatch
+// appended one — otherwise a regression that fails to run/halt would silently return
+// a stale snapshot from a previous dispatch.
 const test::WavefrontSnapshot *dispatch_one_wave(Gfx1250Sim &sim, const uint32_t *code,
                                                  size_t num_words, uint32_t vgprs = 32) {
+  const size_t before = sim.snapshot->snapshots().size();
   uint64_t kernel_object = sim.write_kernel(0x10000, code, num_words, 104, vgprs);
   test::AqlQueue queue(sim.memory, sim.cp());
   queue.dispatch(kernel_object, 32, 32);
   step_until_halted(*sim.engine, *sim.cu());
-  if (sim.snapshot->snapshots().empty())
+  if (sim.snapshot->snapshots().size() == before)
     return nullptr;
   return &sim.snapshot->snapshots().back();
 }
@@ -3969,9 +3974,9 @@ TEST(Gfx1250SimulationTest, VgprMsbRolesSelectHighVgprBanks) {
 
 TEST(Gfx1250SimulationTest, VMovDppReadsSelectedHighVgprBank) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: these tests inject instructions directly (execute_impl) and read
+  // live register state, so they need a live wavefront, not a run-to-halt snapshot.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
   ASSERT_NE(wf, nullptr);
   ASSERT_GE(wf->vgpr_alloc().count, kGfx1250Wave32VgprAllocation);
 
@@ -4015,9 +4020,9 @@ TEST(Gfx1250SimulationTest, VMovDppReadsSelectedHighVgprBank) {
 
 TEST(Gfx1250SimulationTest, VMovDpp8ReadsSelectedHighVgprBank) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: these tests inject instructions directly (execute_impl) and read
+  // live register state, so they need a live wavefront, not a run-to-halt snapshot.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
   ASSERT_NE(wf, nullptr);
   ASSERT_GE(wf->vgpr_alloc().count, kGfx1250Wave32VgprAllocation);
 
@@ -4056,9 +4061,9 @@ TEST(Gfx1250SimulationTest, VMovDpp8ReadsSelectedHighVgprBank) {
 
 TEST(Gfx1250SimulationTest, VMovDppPreservesMaskedHighDestinationLanes) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: these tests inject instructions directly (execute_impl) and read
+  // live register state, so they need a live wavefront, not a run-to-halt snapshot.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
   ASSERT_NE(wf, nullptr);
 
   constexpr uint32_t kSrc = 7;
@@ -4098,9 +4103,9 @@ TEST(Gfx1250SimulationTest, VMovDppPreservesMaskedHighDestinationLanes) {
 
 TEST(Gfx1250SimulationTest, VAddDppReadsHighBanksAndPreservesMaskedHighDst) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: these tests inject instructions directly (execute_impl) and read
+  // live register state, so they need a live wavefront, not a run-to-halt snapshot.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
   ASSERT_NE(wf, nullptr);
 
   constexpr uint32_t kSrc0 = 2;
@@ -4147,9 +4152,9 @@ TEST(Gfx1250SimulationTest, VAddDppReadsHighBanksAndPreservesMaskedHighDst) {
 
 TEST(Gfx1250SimulationTest, VCvtF64DppPreservesBothMaskedHighDstDwords) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: these tests inject instructions directly (execute_impl) and read
+  // live register state, so they need a live wavefront, not a run-to-halt snapshot.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
   ASSERT_NE(wf, nullptr);
 
   constexpr uint32_t kSrc = 7;
@@ -4199,9 +4204,9 @@ TEST(Gfx1250SimulationTest, VCvtF64DppPreservesBothMaskedHighDstDwords) {
 
 TEST(Gfx1250SimulationTest, VAddF32Vop3DppPreservesMaskedHighDestinationLanes) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: these tests inject instructions directly (execute_impl) and read
+  // live register state, so they need a live wavefront, not a run-to-halt snapshot.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
   ASSERT_NE(wf, nullptr);
 
   constexpr uint32_t kSrc0 = 2;
@@ -4246,9 +4251,9 @@ TEST(Gfx1250SimulationTest, VAddF32Vop3DppPreservesMaskedHighDestinationLanes) {
 
 TEST(Gfx1250SimulationTest, VMovDppComposesVgprMsbWithGprIdx) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: these tests inject instructions directly (execute_impl) and read
+  // live register state, so they need a live wavefront, not a run-to-halt snapshot.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
   ASSERT_NE(wf, nullptr);
 
   constexpr uint32_t kSrc = 7;
@@ -4307,9 +4312,9 @@ TEST(Gfx1250SimulationTest, PackedTrue16SourcesHonorGprIdx) {
 
 TEST(Gfx1250SimulationTest, PackedTrue16InstructionComposesHighBanksWithGprIdx) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: these tests inject instructions directly (execute_impl) and read
+  // live register state, so they need a live wavefront, not a run-to-halt snapshot.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
   ASSERT_NE(wf, nullptr);
   wf->set_exec(1u);
 
@@ -4344,9 +4349,9 @@ TEST(Gfx1250SimulationTest, PackedTrue16InstructionComposesHighBanksWithGprIdx) 
 
 TEST(Gfx1250SimulationTest, DsPermuteUsesIndependentHighOperandBanks) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: these tests inject instructions directly (execute_impl) and read
+  // live register state, so they need a live wavefront, not a run-to-halt snapshot.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
   ASSERT_NE(wf, nullptr);
 
   constexpr uint32_t kAddr = 1;
@@ -4384,9 +4389,9 @@ TEST(Gfx1250SimulationTest, DsPermuteUsesIndependentHighOperandBanks) {
 
 TEST(Gfx1250SimulationTest, DsStore2addrUsesSrc2HighBank) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: these tests inject instructions directly (execute_impl) and read
+  // live register state, so they need a live wavefront, not a run-to-halt snapshot.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
   ASSERT_NE(wf, nullptr);
   wf->set_exec(1u);
 
@@ -4434,9 +4439,9 @@ TEST(Gfx1250SimulationTest, DsStore2addrUsesSrc2HighBank) {
 
 TEST(Gfx1250SimulationTest, DsTransposeLoadUsesHighDestinationBank) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: these tests inject instructions directly (execute_impl) and read
+  // live register state, so they need a live wavefront, not a run-to-halt snapshot.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
   ASSERT_NE(wf, nullptr);
   wf->set_exec(1u);
 
@@ -4461,9 +4466,9 @@ TEST(Gfx1250SimulationTest, DsTransposeLoadUsesHighDestinationBank) {
 
 TEST(Gfx1250SimulationTest, Vop2FmamkUsesSrc2HighBank) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: these tests inject instructions directly (execute_impl) and read
+  // live register state, so they need a live wavefront, not a run-to-halt snapshot.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
   ASSERT_NE(wf, nullptr);
   wf->set_exec(1u);
 
@@ -4524,9 +4529,9 @@ TEST(Gfx1250SimulationTest, VopdFmamkUsesSrc2HighBank) {
 
 TEST(Gfx1250SimulationTest, VSwapUsesIndependentSourceAndDestinationBanks) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: these tests inject instructions directly (execute_impl) and read
+  // live register state, so they need a live wavefront, not a run-to-halt snapshot.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
   ASSERT_NE(wf, nullptr);
   wf->set_exec(1u);
 
@@ -4557,9 +4562,9 @@ TEST(Gfx1250SimulationTest, VSwapUsesIndependentSourceAndDestinationBanks) {
 
 TEST(Gfx1250SimulationTest, AsyncToLdsUsesDstAndSrc0HighBanks) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: these tests inject instructions directly (execute_impl) and read
+  // live register state, so they need a live wavefront, not a run-to-halt snapshot.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
   ASSERT_NE(wf, nullptr);
   wf->set_exec(1u);
 
@@ -4595,9 +4600,9 @@ TEST(Gfx1250SimulationTest, AsyncToLdsUsesDstAndSrc0HighBanks) {
 
 TEST(Gfx1250SimulationTest, AddtidStoresUseSrc1HighBank) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: these tests inject instructions directly (execute_impl) and read
+  // live register state, so they need a live wavefront, not a run-to-halt snapshot.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
   ASSERT_NE(wf, nullptr);
   wf->set_exec(1u);
 

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "aql_queue.h"
+#include "halt_snapshot_plugin.h"
 
 #include "embedded_schema.h"
 #include "rocjitsu/code/amdgpu_code_object.h"
@@ -123,6 +124,8 @@ struct Gfx1250Sim {
   SoC *soc = nullptr;
   amdgpu::GpuMemory *memory = nullptr;
   std::unique_ptr<simdojo::SimulationEngine> engine;
+  std::shared_ptr<ExecutionPluginGroup> plugin_group;
+  test::HaltSnapshotPlugin *snapshot = nullptr;
 
   Gfx1250Sim() : loaded(config::load_config(kGfx1250ConfigPath, rocjitsu::kEmbeddedSchema)) {
     build();
@@ -140,12 +143,23 @@ struct Gfx1250Sim {
     engine->topology().set_root(loaded.take_root());
     loaded.wire_links(engine->topology());
     engine->create();
+    // Capture every wavefront's final register state at halt. A wave frees its
+    // registers at s_endpgm, so tests that run a kernel to completion read the
+    // result from the snapshot rather than the (freed) slot.
+    plugin_group = test::make_halt_snapshot_group(&snapshot);
+    soc->set_plugin_group(plugin_group);
   }
 
   amdgpu::Xcd *xcd(uint32_t idx = 0) { return soc->xcd(idx); }
   amdgpu::CommandProcessor *cp(uint32_t idx = 0) { return xcd(idx)->command_processor(); }
   amdgpu::ComputeUnitCore *cu(uint32_t idx = 0) {
     return xcd()->shader_engine(0)->compute_unit(idx);
+  }
+
+  /// Place a single resident wavefront on CU 0 without running it to s_endpgm, for
+  /// tests that drive individual instructions and inspect/modify live wave state.
+  amdgpu::Wavefront *dispatch_scratch_wf(uint32_t vgprs = kGfx1250Wave32VgprAllocation) {
+    return cu()->dispatch_wf(/*wg_id=*/0, /*pc=*/0, kGfx1250ScalarSlots, vgprs);
   }
 
   uint64_t write_kernel(uint64_t addr, const uint32_t *words, size_t num_words,
@@ -340,54 +354,53 @@ void write_sdma_qword_address(uint32_t *packet, uint32_t lo_dw, uint32_t hi_dw, 
   write_sdma_qword_va(packet, lo_dw, hi_dw, reinterpret_cast<uintptr_t>(addr));
 }
 
+// Drive the engine until the CU has no resident wavefronts. A wave frees itself at
+// s_endpgm, so the kernel is complete once the CU reports idle (after having had
+// work). Final wavefront state should be captured via HaltSnapshotPlugin.
 void step_until_halted(simdojo::SimulationEngine &engine, amdgpu::ComputeUnitCore &cu,
                        uint32_t max_steps = 10000) {
+  bool saw_work = false;
   for (uint32_t i = 0; i < max_steps && engine.step(); ++i) {
-    if (cu.num_wfs() == 0)
-      continue;
-    bool all_halted = true;
-    for (uint32_t w = 0; w < cu.num_wfs(); ++w) {
-      if (cu.wf(w) && !cu.wf(w)->is_halted()) {
-        all_halted = false;
-        break;
-      }
-    }
-    if (all_halted)
+    if (cu.has_active_wfs())
+      saw_work = true;
+    else if (saw_work)
       return;
   }
 }
 
 void step_until_xcd_halted(Gfx1250Sim &sim, uint32_t max_steps = 10000) {
-  auto all_halted = [&]() {
+  auto any_active = [&]() {
     for (uint32_t se_idx = 0; se_idx < sim.xcd()->num_shader_engines(); ++se_idx) {
       auto *se = sim.xcd()->shader_engine(se_idx);
-      for (uint32_t cu_idx = 0; cu_idx < se->num_compute_units(); ++cu_idx) {
-        auto *cu = se->compute_unit(cu_idx);
-        for (uint32_t wf_idx = 0; wf_idx < cu->num_wf_slots(); ++wf_idx) {
-          auto *wf = cu->wf(wf_idx);
-          if (wf && wf->sgpr_alloc().count > 0 && !wf->is_halted())
-            return false;
-        }
-      }
+      for (uint32_t cu_idx = 0; cu_idx < se->num_compute_units(); ++cu_idx)
+        if (se->compute_unit(cu_idx)->has_active_wfs())
+          return true;
     }
-    return true;
+    return false;
   };
 
+  bool saw_work = false;
   for (uint32_t i = 0; i < max_steps && sim.engine->step(); ++i) {
-    if (all_halted())
+    if (any_active()) {
+      saw_work = true;
+      continue;
+    }
+    if (saw_work)
       return;
   }
 }
 
-amdgpu::Wavefront *dispatch_one_wave(Gfx1250Sim &sim, const uint32_t *code, size_t num_words,
-                                     uint32_t vgprs = 32) {
+// Runs a one-wave kernel to s_endpgm and returns the wave's final-state snapshot
+// (captured at halt, before its registers are freed), or nullptr if no wave halted.
+const test::WavefrontSnapshot *dispatch_one_wave(Gfx1250Sim &sim, const uint32_t *code,
+                                                 size_t num_words, uint32_t vgprs = 32) {
   uint64_t kernel_object = sim.write_kernel(0x10000, code, num_words, 104, vgprs);
   test::AqlQueue queue(sim.memory, sim.cp());
   queue.dispatch(kernel_object, 32, 32);
   step_until_halted(*sim.engine, *sim.cu());
-  if (sim.cu()->num_wfs() == 0)
+  if (sim.snapshot->snapshots().empty())
     return nullptr;
-  return sim.cu()->wf(0);
+  return &sim.snapshot->snapshots().back();
 }
 
 constexpr uint32_t make_vmov_b32(uint8_t vdst) {
@@ -449,13 +462,6 @@ void append_instruction(std::vector<uint32_t> &code, uint32_t word) { code.push_
 void write_wave_sgpr(amdgpu::ComputeUnitCore &cu, amdgpu::Wavefront &wf, uint32_t reg,
                      uint32_t value) {
   cu.write_sgpr(wf.sgpr_alloc().base + reg, value);
-}
-
-uint64_t read_wave_sgpr64(const amdgpu::ComputeUnitCore &cu, const amdgpu::Wavefront &wf,
-                          uint32_t reg) {
-  uint32_t lo = cu.read_sgpr(wf.sgpr_alloc().base + reg);
-  uint32_t hi = cu.read_sgpr(wf.sgpr_alloc().base + reg + 1);
-  return (static_cast<uint64_t>(hi) << 32) | lo;
 }
 
 uint32_t read_wave_sgpr(const amdgpu::ComputeUnitCore &cu, const amdgpu::Wavefront &wf,
@@ -1826,11 +1832,13 @@ TEST(Gfx1250ExecutionTest, ClusterLdsPinPreventsAllocatorReuseUntilClusterComple
 
   EXPECT_EQ(cu->allocate_lds(257), 0u);
   cu->pin_lds_until_cluster_retired(7);
-  cu->retire_halted_wfs();
+  // A cluster pin blocks LDS reclamation even when the CU has no resident waves.
+  cu->maybe_reset_lds_alloc();
 
   EXPECT_EQ(cu->allocate_lds(257), 512u);
   cu->unpin_lds_for_cluster(7);
-  cu->retire_halted_wfs();
+  // Once the pin is released and the CU is idle, the LDS allocator resets.
+  cu->maybe_reset_lds_alloc();
   EXPECT_EQ(cu->allocate_lds(257), 0u);
 }
 
@@ -3391,9 +3399,9 @@ TEST(Gfx1250SimulationTest, DispatchesEndpgmThroughConfig) {
   step_until_halted(*sim.engine, *sim.cu());
 
   EXPECT_EQ(sim.cp()->dispatched_count(), 1u);
-  ASSERT_EQ(sim.cu()->num_wfs(), 1u);
-  EXPECT_EQ(sim.cu()->wf(0)->wf_size(), 32u);
-  EXPECT_TRUE(sim.cu()->wf(0)->is_halted());
+  ASSERT_EQ(sim.snapshot->snapshots().size(), 1u);
+  EXPECT_EQ(sim.snapshot->snapshots().front().wf_size, 32u);
+  EXPECT_EQ(sim.cu()->num_wfs(), 0u);
 }
 
 TEST(Gfx1250SimulationTest, MultiWaveDispatchHonorsPackedTidComponentCount) {
@@ -3421,19 +3429,9 @@ TEST(Gfx1250SimulationTest, MultiWaveDispatchHonorsPackedTidComponentCount) {
 
     std::vector<uint32_t> lane0_values;
     std::vector<uint32_t> lane31_values;
-    for (uint32_t se_idx = 0; se_idx < sim.xcd()->num_shader_engines(); ++se_idx) {
-      auto *se = sim.xcd()->shader_engine(se_idx);
-      for (uint32_t cu_idx = 0; cu_idx < se->num_compute_units(); ++cu_idx) {
-        auto *cu = se->compute_unit(cu_idx);
-        for (uint32_t wf_idx = 0; wf_idx < cu->num_wf_slots(); ++wf_idx) {
-          auto *wf = cu->wf(wf_idx);
-          if (!wf || wf->sgpr_alloc().count == 0)
-            continue;
-          const uint32_t vbase = wf->vgpr_alloc().base;
-          lane0_values.push_back(cu->read_vgpr(vbase, 0));
-          lane31_values.push_back(cu->read_vgpr(vbase, 31));
-        }
-      }
+    for (const auto &wf : sim.snapshot->snapshots()) {
+      lane0_values.push_back(wf.vgpr(0, 0));
+      lane31_values.push_back(wf.vgpr(0, 31));
     }
 
     std::sort(lane0_values.begin(), lane0_values.end());
@@ -3447,19 +3445,11 @@ TEST(Gfx1250SimulationTest, MultiWaveDispatchHonorsPackedTidComponentCount) {
   }
 }
 
+// Collect the EXEC mask each wavefront had at halt (captured before it freed).
 std::vector<uint64_t> collect_active_exec_masks(Gfx1250Sim &sim) {
   std::vector<uint64_t> exec_masks;
-  for (uint32_t se_idx = 0; se_idx < sim.xcd()->num_shader_engines(); ++se_idx) {
-    auto *se = sim.xcd()->shader_engine(se_idx);
-    for (uint32_t cu_idx = 0; cu_idx < se->num_compute_units(); ++cu_idx) {
-      auto *cu = se->compute_unit(cu_idx);
-      for (uint32_t wf_idx = 0; wf_idx < cu->num_wf_slots(); ++wf_idx) {
-        auto *wf = cu->wf(wf_idx);
-        if (wf && wf->sgpr_alloc().count > 0)
-          exec_masks.push_back(wf->exec());
-      }
-    }
-  }
+  for (const auto &wf : sim.snapshot->snapshots())
+    exec_masks.push_back(wf.exec);
   std::sort(exec_masks.begin(), exec_masks.end());
   return exec_masks;
 }
@@ -3483,17 +3473,8 @@ TEST(Gfx1250SimulationTest, PartialWorkgroupMasksTailWaveExec) {
 // workgroups, so it cannot observe the rounding; wavefront wg_ids can.
 uint32_t count_dispatched_workgroups(Gfx1250Sim &sim) {
   std::set<uint32_t> wg_ids;
-  for (uint32_t se_idx = 0; se_idx < sim.xcd()->num_shader_engines(); ++se_idx) {
-    auto *se = sim.xcd()->shader_engine(se_idx);
-    for (uint32_t cu_idx = 0; cu_idx < se->num_compute_units(); ++cu_idx) {
-      auto *cu = se->compute_unit(cu_idx);
-      for (uint32_t wf_idx = 0; wf_idx < cu->num_wf_slots(); ++wf_idx) {
-        auto *wf = cu->wf(wf_idx);
-        if (wf && wf->sgpr_alloc().count > 0)
-          wg_ids.insert(wf->wg_id());
-      }
-    }
-  }
+  for (const auto &wf : sim.snapshot->snapshots())
+    wg_ids.insert(wf.wg_id);
   return static_cast<uint32_t>(wg_ids.size());
 }
 
@@ -3599,13 +3580,11 @@ TEST(Gfx1250SimulationTest, DispatchPreloadsKernargDwordsIntoUserSgprs) {
   queue.dispatch(kernel_object, 32, 32, kKernargAddr);
   step_until_halted(*sim.engine, *sim.cu());
 
-  ASSERT_EQ(sim.cu()->num_wfs(), 1u);
-  auto *wf = sim.cu()->wf(0);
-  ASSERT_NE(wf, nullptr);
-  uint32_t sbase = wf->sgpr_alloc().base;
-  EXPECT_EQ(read_wave_sgpr64(*sim.cu(), *wf, 0), kKernargAddr);
-  EXPECT_EQ(sim.cu()->read_sgpr(sbase + 2), args.first);
-  EXPECT_EQ(sim.cu()->read_sgpr(sbase + 3), args.second);
+  ASSERT_EQ(sim.snapshot->snapshots().size(), 1u);
+  const auto &wf = sim.snapshot->snapshots().front();
+  EXPECT_EQ(wf.sgpr64(0), kKernargAddr);
+  EXPECT_EQ(wf.sgpr(2), args.first);
+  EXPECT_EQ(wf.sgpr(3), args.second);
 }
 
 TEST(Gfx1250SimulationTest, DispatchPreloadsKernargWhenDescriptorSizeIsUnknown) {
@@ -3629,13 +3608,11 @@ TEST(Gfx1250SimulationTest, DispatchPreloadsKernargWhenDescriptorSizeIsUnknown) 
   queue.dispatch(kernel_object, 32, 32, kKernargAddr);
   step_until_halted(*sim.engine, *sim.cu());
 
-  ASSERT_EQ(sim.cu()->num_wfs(), 1u);
-  auto *wf = sim.cu()->wf(0);
-  ASSERT_NE(wf, nullptr);
-  uint32_t sbase = wf->sgpr_alloc().base;
-  EXPECT_EQ(read_wave_sgpr64(*sim.cu(), *wf, 0), kKernargAddr);
-  EXPECT_EQ(sim.cu()->read_sgpr(sbase + 2), args[1]);
-  EXPECT_EQ(sim.cu()->read_sgpr(sbase + 3), args[2]);
+  ASSERT_EQ(sim.snapshot->snapshots().size(), 1u);
+  const auto &wf = sim.snapshot->snapshots().front();
+  EXPECT_EQ(wf.sgpr64(0), kKernargAddr);
+  EXPECT_EQ(wf.sgpr(2), args[1]);
+  EXPECT_EQ(wf.sgpr(3), args[2]);
 }
 
 TEST(Gfx1250SimulationTest, SLoadB32DoesNotScaleImmediateOffset) {
@@ -3663,10 +3640,8 @@ TEST(Gfx1250SimulationTest, SLoadB32DoesNotScaleImmediateOffset) {
   queue.dispatch(kernel_object, 32, 32, kKernargAddr);
   step_until_halted(*sim.engine, *sim.cu());
 
-  ASSERT_EQ(sim.cu()->num_wfs(), 1u);
-  auto *wf = sim.cu()->wf(0);
-  ASSERT_NE(wf, nullptr);
-  EXPECT_EQ(read_wave_sgpr(*sim.cu(), *wf, 4), kExpected);
+  ASSERT_EQ(sim.snapshot->snapshots().size(), 1u);
+  EXPECT_EQ(sim.snapshot->snapshots().front().sgpr(4), kExpected);
 }
 
 TEST(Gfx1250SimulationTest, TtmpWorkgroupIdsUseGridCoordinatesFor2DDispatch) {
@@ -3689,32 +3664,11 @@ TEST(Gfx1250SimulationTest, TtmpWorkgroupIdsUseGridCoordinatesFor2DDispatch) {
   queue.submit(pkt);
   step_until_xcd_halted(sim);
 
-  amdgpu::Wavefront *target = nullptr;
-  amdgpu::ComputeUnitCore *target_cu = nullptr;
-  for (uint32_t se_idx = 0; se_idx < sim.xcd()->num_shader_engines(); ++se_idx) {
-    auto *se = sim.xcd()->shader_engine(se_idx);
-    for (uint32_t cu_idx = 0; cu_idx < se->num_compute_units(); ++cu_idx) {
-      auto *cu = se->compute_unit(cu_idx);
-      for (uint32_t wf_idx = 0; wf_idx < cu->num_wf_slots(); ++wf_idx) {
-        auto *wf = cu->wf(wf_idx);
-        if (wf && wf->sgpr_alloc().count > 0 && wf->wg_id() == 4) {
-          target = wf;
-          target_cu = cu;
-          break;
-        }
-      }
-      if (target)
-        break;
-    }
-    if (target)
-      break;
-  }
-
+  const auto *target = sim.snapshot->by_wg_id(4);
   ASSERT_NE(target, nullptr);
-  const uint32_t sbase = target->sgpr_alloc().base;
-  ASSERT_NE(target_cu, nullptr);
-  EXPECT_EQ(target_cu->read_sgpr(sbase + 117), 1u);
-  EXPECT_EQ(target_cu->read_sgpr(sbase + 115), 1u);
+  // TTMP9 (s117) holds grid_wg_id_x; TTMP7 (s115) packs wg_id_y/z.
+  EXPECT_EQ(target->sgpr(117), 1u);
+  EXPECT_EQ(target->sgpr(115), 1u);
 }
 
 TEST(Gfx1250SimulationTest, SGetPcI64ReturnsNextInstructionAddress) {
@@ -3730,10 +3684,10 @@ TEST(Gfx1250SimulationTest, SGetPcI64ReturnsNextInstructionAddress) {
   queue.dispatch(kernel_object, 32, 32);
   step_until_halted(*sim.engine, *sim.cu());
 
-  amdgpu::Wavefront *wf = sim.cu()->wf(0);
-  ASSERT_NE(wf, nullptr);
+  ASSERT_EQ(sim.snapshot->snapshots().size(), 1u);
+  const auto &wf = sim.snapshot->snapshots().front();
   uint64_t entry_pc = kKernelAddr + sizeof(rocr::llvm::amdhsa::kernel_descriptor_t);
-  EXPECT_EQ(read_wave_sgpr64(*sim.cu(), *wf, 4), entry_pc + sizeof(uint32_t));
+  EXPECT_EQ(wf.sgpr64(4), entry_pc + sizeof(uint32_t));
 }
 
 TEST(Gfx1250SimulationTest, SAddPcI64SkipsRelativeToNextPc) {
@@ -3745,9 +3699,9 @@ TEST(Gfx1250SimulationTest, SAddPcI64SkipsRelativeToNextPc) {
   };
 
   Gfx1250Sim sim;
-  amdgpu::Wavefront *wf = dispatch_one_wave(sim, code, std::size(code));
+  const auto *wf = dispatch_one_wave(sim, code, std::size(code));
   ASSERT_NE(wf, nullptr);
-  EXPECT_EQ(sim.cu()->read_sgpr(wf->sgpr_alloc().base + 4), 2u);
+  EXPECT_EQ(wf->sgpr(4), 2u);
 }
 
 TEST(Gfx1250SimulationTest, SSetPcI64JumpsToScalarAddress) {
@@ -3770,9 +3724,8 @@ TEST(Gfx1250SimulationTest, SSetPcI64JumpsToScalarAddress) {
   queue.dispatch(kernel_object, 32, 32);
   step_until_halted(*sim.engine, *sim.cu());
 
-  amdgpu::Wavefront *wf = sim.cu()->wf(0);
-  ASSERT_NE(wf, nullptr);
-  EXPECT_EQ(sim.cu()->read_sgpr(wf->sgpr_alloc().base + 6), 2u);
+  ASSERT_EQ(sim.snapshot->snapshots().size(), 1u);
+  EXPECT_EQ(sim.snapshot->snapshots().front().sgpr(6), 2u);
 }
 
 TEST(Gfx1250SimulationTest, SSwapPcI64StoresReturnAddressAndJumps) {
@@ -3797,10 +3750,10 @@ TEST(Gfx1250SimulationTest, SSwapPcI64StoresReturnAddressAndJumps) {
   queue.dispatch(kernel_object, 32, 32);
   step_until_halted(*sim.engine, *sim.cu());
 
-  amdgpu::Wavefront *wf = sim.cu()->wf(0);
-  ASSERT_NE(wf, nullptr);
-  EXPECT_EQ(read_wave_sgpr64(*sim.cu(), *wf, 6), return_pc);
-  EXPECT_EQ(sim.cu()->read_sgpr(wf->sgpr_alloc().base + 8), 2u);
+  ASSERT_EQ(sim.snapshot->snapshots().size(), 1u);
+  const auto &wf = sim.snapshot->snapshots().front();
+  EXPECT_EQ(wf.sgpr64(6), return_pc);
+  EXPECT_EQ(wf.sgpr(8), 2u);
 }
 
 TEST(Gfx1250SimulationTest, SBitreplicateB64B32DuplicatesEachSourceBit) {
@@ -3812,9 +3765,9 @@ TEST(Gfx1250SimulationTest, SBitreplicateB64B32DuplicatesEachSourceBit) {
   };
 
   Gfx1250Sim sim;
-  amdgpu::Wavefront *wf = dispatch_one_wave(sim, code, std::size(code));
+  const auto *wf = dispatch_one_wave(sim, code, std::size(code));
   ASSERT_NE(wf, nullptr);
-  EXPECT_EQ(read_wave_sgpr64(*sim.cu(), *wf, 4), 0xC000000000000003ULL);
+  EXPECT_EQ(wf->sgpr64(4), 0xC000000000000003ULL);
 }
 
 TEST(Gfx1250SimulationTest, SGetShaderCyclesU64ReadsSimulationTime) {
@@ -3828,9 +3781,9 @@ TEST(Gfx1250SimulationTest, SGetShaderCyclesU64ReadsSimulationTime) {
   ASSERT_TRUE(sim.engine->step());
   ASSERT_EQ(sim.engine->global_time(), 17u);
 
-  amdgpu::Wavefront *wf = dispatch_one_wave(sim, code, std::size(code));
+  const auto *wf = dispatch_one_wave(sim, code, std::size(code));
   ASSERT_NE(wf, nullptr);
-  const auto observed_time = read_wave_sgpr64(*sim.cu(), *wf, 4);
+  const auto observed_time = wf->sgpr64(4);
   EXPECT_GE(observed_time, 17u);
   EXPECT_LE(observed_time, sim.engine->global_time());
 }
@@ -3847,12 +3800,12 @@ TEST(Gfx1250SimulationTest, SSendmsgRtnB64ReadsRealtimeAndB32UsesPlaceholder) {
   ASSERT_TRUE(sim.engine->step());
   ASSERT_EQ(sim.engine->global_time(), 23u);
 
-  amdgpu::Wavefront *wf = dispatch_one_wave(sim, code, std::size(code));
+  const auto *wf = dispatch_one_wave(sim, code, std::size(code));
   ASSERT_NE(wf, nullptr);
-  const auto observed_time = read_wave_sgpr64(*sim.cu(), *wf, 4);
+  const auto observed_time = wf->sgpr64(4);
   EXPECT_GE(observed_time, 23u);
   EXPECT_LE(observed_time, sim.engine->global_time());
-  EXPECT_EQ(read_wave_sgpr(*sim.cu(), *wf, 6), 0u);
+  EXPECT_EQ(wf->sgpr(6), 0u);
 }
 
 TEST(Gfx1250SimulationTest, SMovrelsReadsM0IndexedScalarSources) {
@@ -3868,10 +3821,10 @@ TEST(Gfx1250SimulationTest, SMovrelsReadsM0IndexedScalarSources) {
   };
 
   Gfx1250Sim sim;
-  amdgpu::Wavefront *wf = dispatch_one_wave(sim, code, std::size(code));
+  const auto *wf = dispatch_one_wave(sim, code, std::size(code));
   ASSERT_NE(wf, nullptr);
-  EXPECT_EQ(sim.cu()->read_sgpr(wf->sgpr_alloc().base + 8), 0x22222222u);
-  EXPECT_EQ(read_wave_sgpr64(*sim.cu(), *wf, 10), 0x4444444433333333ULL);
+  EXPECT_EQ(wf->sgpr(8), 0x22222222u);
+  EXPECT_EQ(wf->sgpr64(10), 0x4444444433333333ULL);
 }
 
 TEST(Gfx1250SimulationTest, SMovreldWritesM0IndexedScalarDestinations) {
@@ -3885,10 +3838,10 @@ TEST(Gfx1250SimulationTest, SMovreldWritesM0IndexedScalarDestinations) {
   };
 
   Gfx1250Sim sim;
-  amdgpu::Wavefront *wf = dispatch_one_wave(sim, code, std::size(code));
+  const auto *wf = dispatch_one_wave(sim, code, std::size(code));
   ASSERT_NE(wf, nullptr);
-  EXPECT_EQ(sim.cu()->read_sgpr(wf->sgpr_alloc().base + 9), 0x55555555u);
-  EXPECT_EQ(read_wave_sgpr64(*sim.cu(), *wf, 12), 0x6666666655555555ULL);
+  EXPECT_EQ(wf->sgpr(9), 0x55555555u);
+  EXPECT_EQ(wf->sgpr64(12), 0x6666666655555555ULL);
 }
 
 TEST(Gfx1250SimulationTest, SMovrelsd2B32UsesSeparatePackedM0Offsets) {
@@ -3901,9 +3854,9 @@ TEST(Gfx1250SimulationTest, SMovrelsd2B32UsesSeparatePackedM0Offsets) {
   };
 
   Gfx1250Sim sim;
-  amdgpu::Wavefront *wf = dispatch_one_wave(sim, code, std::size(code));
+  const auto *wf = dispatch_one_wave(sim, code, std::size(code));
   ASSERT_NE(wf, nullptr);
-  EXPECT_EQ(sim.cu()->read_sgpr(wf->sgpr_alloc().base + 10), 0x88888888u);
+  EXPECT_EQ(wf->sgpr(10), 0x88888888u);
 }
 
 TEST(Gfx1250SimulationTest, SplitNamedBarrierOpsReportIdleState) {
@@ -3918,15 +3871,15 @@ TEST(Gfx1250SimulationTest, SplitNamedBarrierOpsReportIdleState) {
   };
 
   Gfx1250Sim sim;
-  amdgpu::Wavefront *wf = dispatch_one_wave(sim, code, std::size(code));
+  const auto *wf = dispatch_one_wave(sim, code, std::size(code));
   ASSERT_NE(wf, nullptr);
-  EXPECT_EQ(sim.cu()->read_sgpr(wf->sgpr_alloc().base + 4), 0u);
+  EXPECT_EQ(wf->sgpr(4), 0u);
 }
 
 TEST(Gfx1250SimulationTest, VgprMsbModeTracksModeRegisterLayout) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf = dispatch_one_wave(sim, code, std::size(code));
+  // Resident wave: this test mutates and reads live wavefront MODE state.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf();
   ASSERT_NE(wf, nullptr);
 
   constexpr uint8_t kSetLayout = 0xB9;  // src0=1, src1=2, src2=3, dst=2.
@@ -3961,20 +3914,27 @@ TEST(Gfx1250SimulationTest, SSetVgprMsbUpdatesWavefrontMode) {
   Gfx1250Sim sim;
   const uint32_t code[] = {S_SET_VGPR_MSB | kSetLayout, S_ENDPGM_GFX12};
 
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
-  ASSERT_NE(wf, nullptr);
+  // The s_set_vgpr_msb result lives in the wavefront MODE register; capture it at
+  // halt so it survives the wave freeing itself.
+  auto *snapshot = sim.snapshot;
+  uint64_t kernel_object =
+      sim.write_kernel(0x10000, code, std::size(code), 104, kGfx1250Wave32VgprAllocation);
+  {
+    test::AqlQueue queue(sim.memory, sim.cp());
+    queue.dispatch(kernel_object, 32, 32);
+  }
+  step_until_halted(*sim.engine, *sim.cu());
+  ASSERT_EQ(snapshot->snapshots().size(), 1u);
+  const auto &wf = snapshot->snapshots().front();
 
-  EXPECT_EQ(wf->vgpr_msb_mode(), kSetLayout);
-  EXPECT_EQ((wf->mode_raw() & amdgpu::VGPR_MSB_MODE_MASK) >> amdgpu::VGPR_MSB_MODE_SHIFT,
-            kModeLayout);
+  EXPECT_EQ(wf.vgpr_msb_mode, kSetLayout);
+  EXPECT_EQ((wf.mode_raw & amdgpu::VGPR_MSB_MODE_MASK) >> amdgpu::VGPR_MSB_MODE_SHIFT, kModeLayout);
 }
 
 TEST(Gfx1250SimulationTest, VgprMsbRolesSelectHighVgprBanks) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: this test drives Operand read/write against live VGPR banks.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf();
   ASSERT_NE(wf, nullptr);
   ASSERT_GE(wf->vgpr_alloc().count, kGfx1250Wave32VgprAllocation);
 
@@ -4325,9 +4285,8 @@ TEST(Gfx1250SimulationTest, VMovDppComposesVgprMsbWithGprIdx) {
 
 TEST(Gfx1250SimulationTest, PackedTrue16SourcesHonorGprIdx) {
   Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  amdgpu::Wavefront *wf =
-      dispatch_one_wave(sim, code, std::size(code), kGfx1250Wave32VgprAllocation);
+  // Resident wave: this test drives Operand reads against live VGPR banks.
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf();
   ASSERT_NE(wf, nullptr);
   ASSERT_GE(wf->vgpr_alloc().count, kGfx1250Wave32VgprAllocation);
 
@@ -4687,12 +4646,11 @@ TEST(Gfx1250SimulationTest, VMovrelsReadsM0RelativeVgpr) {
   };
 
   Gfx1250Sim sim;
-  amdgpu::Wavefront *wf = dispatch_one_wave(sim, code, std::size(code), 16);
+  const auto *wf = dispatch_one_wave(sim, code, std::size(code), 16);
   ASSERT_NE(wf, nullptr);
 
-  const uint32_t vb = wf->vgpr_alloc().base;
-  for (uint32_t lane = 0; lane < wf->wf_size(); ++lane)
-    EXPECT_EQ(sim.cu()->read_vgpr(vb + 1, lane), 99u) << "lane " << lane;
+  for (uint32_t lane = 0; lane < wf->wf_size; ++lane)
+    EXPECT_EQ(wf->vgpr(1, lane), 99u) << "lane " << lane;
 }
 
 TEST(Gfx1250SimulationTest, VopdMulDx9ZeroOverridesNanProducts) {
@@ -4712,17 +4670,14 @@ TEST(Gfx1250SimulationTest, VopdMulDx9ZeroOverridesNanProducts) {
   append_instruction(code, S_ENDPGM_GFX12);
 
   Gfx1250Sim sim;
-  amdgpu::Wavefront *wf = dispatch_one_wave(sim, code.data(), code.size(), 16);
+  const auto *wf = dispatch_one_wave(sim, code.data(), code.size(), 16);
   ASSERT_NE(wf, nullptr);
 
-  const uint32_t vb = wf->vgpr_alloc().base;
-  for (uint32_t lane = 0; lane < wf->wf_size(); ++lane) {
-    EXPECT_EQ(sim.cu()->read_vgpr(vb + 4, lane), 0x00000000u) << "lane " << lane;
-    EXPECT_EQ(sim.cu()->read_vgpr(vb + 5, lane), 0x00000000u) << "lane " << lane;
-    EXPECT_TRUE(std::isnan(std::bit_cast<float>(sim.cu()->read_vgpr(vb + 6, lane))))
-        << "lane " << lane;
-    EXPECT_TRUE(std::isnan(std::bit_cast<float>(sim.cu()->read_vgpr(vb + 7, lane))))
-        << "lane " << lane;
+  for (uint32_t lane = 0; lane < wf->wf_size; ++lane) {
+    EXPECT_EQ(wf->vgpr(4, lane), 0x00000000u) << "lane " << lane;
+    EXPECT_EQ(wf->vgpr(5, lane), 0x00000000u) << "lane " << lane;
+    EXPECT_TRUE(std::isnan(std::bit_cast<float>(wf->vgpr(6, lane)))) << "lane " << lane;
+    EXPECT_TRUE(std::isnan(std::bit_cast<float>(wf->vgpr(7, lane)))) << "lane " << lane;
   }
 }
 
@@ -4745,13 +4700,12 @@ TEST(Gfx1250SimulationTest, VopdFmaUsesSingleRounding) {
   append_instruction(code, S_ENDPGM_GFX12);
 
   Gfx1250Sim sim;
-  amdgpu::Wavefront *wf = dispatch_one_wave(sim, code.data(), code.size(), 16);
+  const auto *wf = dispatch_one_wave(sim, code.data(), code.size(), 16);
   ASSERT_NE(wf, nullptr);
 
-  const uint32_t vb = wf->vgpr_alloc().base;
-  for (uint32_t lane = 0; lane < wf->wf_size(); ++lane) {
-    EXPECT_EQ(sim.cu()->read_vgpr(vb + 4, lane), expected) << "lane " << lane;
-    EXPECT_EQ(sim.cu()->read_vgpr(vb + 5, lane), expected) << "lane " << lane;
+  for (uint32_t lane = 0; lane < wf->wf_size; ++lane) {
+    EXPECT_EQ(wf->vgpr(4, lane), expected) << "lane " << lane;
+    EXPECT_EQ(wf->vgpr(5, lane), expected) << "lane " << lane;
   }
 }
 
@@ -4771,13 +4725,12 @@ TEST(Gfx1250SimulationTest, VopdFmacUsesDestinationAccumulator) {
   };
 
   Gfx1250Sim sim;
-  amdgpu::Wavefront *wf = dispatch_one_wave(sim, code, std::size(code), 16);
+  const auto *wf = dispatch_one_wave(sim, code, std::size(code), 16);
   ASSERT_NE(wf, nullptr);
 
-  const uint32_t vb = wf->vgpr_alloc().base;
-  for (uint32_t lane = 0; lane < wf->wf_size(); ++lane) {
-    EXPECT_EQ(sim.cu()->read_vgpr(vb + 10, lane), 0x40E00000u) << "lane " << lane;
-    EXPECT_EQ(sim.cu()->read_vgpr(vb + 9, lane), 0x40000000u) << "lane " << lane;
+  for (uint32_t lane = 0; lane < wf->wf_size; ++lane) {
+    EXPECT_EQ(wf->vgpr(10, lane), 0x40E00000u) << "lane " << lane;
+    EXPECT_EQ(wf->vgpr(9, lane), 0x40000000u) << "lane " << lane;
   }
 }
 

--- a/emulation/rocjitsu/tests/guest_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/guest_kfd_test.cpp
@@ -45,12 +45,26 @@ constexpr int kStressIterations = 25;
 constexpr uint64_t kAllocVa = 0x1000000000ULL;
 constexpr uint64_t kAllocSize = 4096;
 
+// Resolve the directory holding the config-path handoff file, mirroring the
+// precedence in load_dbt_guest_config_from_runtime_config(): the launcher exports
+// $ROCJITSU_INVOCATION_DIR (its per-PID directory) and the DBT guest hook reads
+// config_path from there first. Tests that install a config the hook must observe
+// have to write to the same directory; falling back to $ROCJITSU_RUNTIME_DIR keeps
+// the standalone (no-launcher) case working.
+std::optional<std::filesystem::path> config_handoff_dir() {
+  if (const char *inv = std::getenv("ROCJITSU_INVOCATION_DIR"); inv && *inv)
+    return std::filesystem::path(inv);
+  if (const char *runtime_dir = std::getenv("ROCJITSU_RUNTIME_DIR"); runtime_dir && *runtime_dir)
+    return std::filesystem::path(runtime_dir);
+  return std::nullopt;
+}
+
 std::optional<std::string> read_active_config_json() {
-  const char *runtime_dir = std::getenv("ROCJITSU_RUNTIME_DIR");
-  if (!runtime_dir || !*runtime_dir)
+  const auto dir = config_handoff_dir();
+  if (!dir)
     return std::nullopt;
 
-  std::ifstream active_config(std::filesystem::path(runtime_dir) / "config_path");
+  std::ifstream active_config(*dir / "config_path");
   std::string configured_path;
   if (!std::getline(active_config, configured_path) || configured_path.empty())
     return std::nullopt;
@@ -63,12 +77,12 @@ std::optional<std::string> read_active_config_json() {
 
 bool install_inline_dbt_config(std::string simulator_json, const char *host_isa,
                                uint32_t lds_size_kb, std::string_view external_host_config = {}) {
-  const char *runtime_dir = std::getenv("ROCJITSU_RUNTIME_DIR");
-  if (!runtime_dir || !*runtime_dir)
+  const auto dir = config_handoff_dir();
+  if (!dir)
     return false;
 
   try {
-    const std::filesystem::path runtime(runtime_dir);
+    const std::filesystem::path runtime(*dir);
     std::filesystem::create_directories(runtime);
     const std::filesystem::path config_path = runtime / "inline_dbt_failure_config.json";
 
@@ -356,10 +370,9 @@ TEST(GuestKfdMemoryTest, GuestAllocationMmapOffsetIsRejected) {
 }
 
 TEST(GuestKfdFailureTest, NonexistentSimulatorConfigFailsCleanly) {
-  const char *runtime_dir = std::getenv("ROCJITSU_RUNTIME_DIR");
-  ASSERT_NE(runtime_dir, nullptr);
-  const std::string nonexistent =
-      (std::filesystem::path(runtime_dir) / "nonexistent_simulator_config.json").string();
+  const auto dir = config_handoff_dir();
+  ASSERT_TRUE(dir.has_value());
+  const std::string nonexistent = (*dir / "nonexistent_simulator_config.json").string();
   ASSERT_TRUE(install_inline_dbt_config(R"({"max_ticks": 1})", "gfx942", 64, nonexistent));
 
   errno = 0;

--- a/emulation/rocjitsu/tests/guest_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/guest_kfd_test.cpp
@@ -53,23 +53,31 @@ constexpr uint64_t kAllocSize = 4096;
 //   2. <$ROCJITSU_RUNTIME_DIR>/<pid>/ (the per-PID tier the reader probes next;
 //      the test and the hook share this process, so getpid() matches), then
 //   3. <$ROCJITSU_RUNTIME_DIR>/ (the well-known location for the no-launcher case).
-// Return the first tier whose config_path handoff exists, else the highest-priority
-// writable tier so install_inline_dbt_config() writes where the reader will look.
-// This must mirror load_dbt_guest_config_from_runtime_config()'s resolution order
-// exactly: $ROCJITSU_INVOCATION_DIR, then the per-PID default runtime dir, then the
-// base default runtime dir. rpc_default_runtime_dir() already treats an unset OR
-// empty $ROCJITSU_RUNTIME_DIR as "use $XDG_RUNTIME_DIR/rocjitsu or /tmp/rocjitsu-
-// <uid>", so this never returns nullopt on that account — otherwise the test would
-// write nowhere while the runtime hook still reads the default location.
+// The reader opens the FIRST tier whose config_path handoff actually exists, so this
+// must probe them in the same order rather than short-circuiting on tier 1 merely
+// being set: an $ROCJITSU_INVOCATION_DIR pointing at a dir without config_path must
+// still fall through to the per-PID/base tiers a valid handoff may live in. When no
+// tier has a handoff yet, return the highest-priority writable tier so
+// install_inline_dbt_config() writes where the reader looks first.
+// rpc_default_runtime_dir() already treats an unset OR empty $ROCJITSU_RUNTIME_DIR as
+// "use $XDG_RUNTIME_DIR/rocjitsu or /tmp/rocjitsu-<uid>", so this never returns
+// nullopt on that account — otherwise the test would write nowhere while the runtime
+// hook still reads the default location.
 std::optional<std::filesystem::path> config_handoff_dir() {
+  std::vector<std::filesystem::path> tiers;
   if (const char *inv = std::getenv("ROCJITSU_INVOCATION_DIR"); inv && *inv)
-    return std::filesystem::path(inv);
+    tiers.emplace_back(inv);
   const std::filesystem::path base(rocjitsu::rpc_default_runtime_dir());
-  const std::filesystem::path per_pid = base / std::to_string(getpid());
+  tiers.push_back(base / std::to_string(getpid()));
+  tiers.push_back(base);
+
   std::error_code ec;
-  if (std::filesystem::exists(per_pid / "config_path", ec))
-    return per_pid;
-  return base;
+  for (const auto &tier : tiers) {
+    if (std::filesystem::exists(tier / "config_path", ec))
+      return tier;
+  }
+  // No handoff exists yet: install into the highest-priority tier the reader probes.
+  return tiers.front();
 }
 
 std::optional<std::string> read_active_config_json() {

--- a/emulation/rocjitsu/tests/guest_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/guest_kfd_test.cpp
@@ -45,18 +45,27 @@ constexpr int kStressIterations = 25;
 constexpr uint64_t kAllocVa = 0x1000000000ULL;
 constexpr uint64_t kAllocSize = 4096;
 
-// Resolve the directory holding the config-path handoff file, mirroring the
-// precedence in load_dbt_guest_config_from_runtime_config(): the launcher exports
-// $ROCJITSU_INVOCATION_DIR (its per-PID directory) and the DBT guest hook reads
-// config_path from there first. Tests that install a config the hook must observe
-// have to write to the same directory; falling back to $ROCJITSU_RUNTIME_DIR keeps
-// the standalone (no-launcher) case working.
+// Resolve the directory holding the config-path handoff file, mirroring the exact
+// precedence in load_dbt_guest_config_from_runtime_config() so a config the test
+// installs is the one the in-process DBT guest hook actually reads:
+//   1. $ROCJITSU_INVOCATION_DIR (the launcher's per-invocation dir), then
+//   2. <$ROCJITSU_RUNTIME_DIR>/<pid>/ (the per-PID tier the reader probes next;
+//      the test and the hook share this process, so getpid() matches), then
+//   3. <$ROCJITSU_RUNTIME_DIR>/ (the well-known location for the no-launcher case).
+// Return the first tier whose config_path handoff exists, else the highest-priority
+// writable tier so install_inline_dbt_config() writes where the reader will look.
 std::optional<std::filesystem::path> config_handoff_dir() {
   if (const char *inv = std::getenv("ROCJITSU_INVOCATION_DIR"); inv && *inv)
     return std::filesystem::path(inv);
-  if (const char *runtime_dir = std::getenv("ROCJITSU_RUNTIME_DIR"); runtime_dir && *runtime_dir)
-    return std::filesystem::path(runtime_dir);
-  return std::nullopt;
+  const char *runtime_dir = std::getenv("ROCJITSU_RUNTIME_DIR");
+  if (!runtime_dir || !*runtime_dir)
+    return std::nullopt;
+  const std::filesystem::path per_pid =
+      std::filesystem::path(runtime_dir) / std::to_string(getpid());
+  std::error_code ec;
+  if (std::filesystem::exists(per_pid / "config_path", ec))
+    return per_pid;
+  return std::filesystem::path(runtime_dir);
 }
 
 std::optional<std::string> read_active_config_json() {

--- a/emulation/rocjitsu/tests/guest_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/guest_kfd_test.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include "rocjitsu/base/rj_compiler.h"
+#include "rocjitsu/kmd/linux/rpc.h"
 RJ_DIAGNOSTIC_PUSH
 RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "linux/uapi/kfd_ioctl.h"
@@ -54,18 +55,21 @@ constexpr uint64_t kAllocSize = 4096;
 //   3. <$ROCJITSU_RUNTIME_DIR>/ (the well-known location for the no-launcher case).
 // Return the first tier whose config_path handoff exists, else the highest-priority
 // writable tier so install_inline_dbt_config() writes where the reader will look.
+// This must mirror load_dbt_guest_config_from_runtime_config()'s resolution order
+// exactly: $ROCJITSU_INVOCATION_DIR, then the per-PID default runtime dir, then the
+// base default runtime dir. rpc_default_runtime_dir() already treats an unset OR
+// empty $ROCJITSU_RUNTIME_DIR as "use $XDG_RUNTIME_DIR/rocjitsu or /tmp/rocjitsu-
+// <uid>", so this never returns nullopt on that account — otherwise the test would
+// write nowhere while the runtime hook still reads the default location.
 std::optional<std::filesystem::path> config_handoff_dir() {
   if (const char *inv = std::getenv("ROCJITSU_INVOCATION_DIR"); inv && *inv)
     return std::filesystem::path(inv);
-  const char *runtime_dir = std::getenv("ROCJITSU_RUNTIME_DIR");
-  if (!runtime_dir || !*runtime_dir)
-    return std::nullopt;
-  const std::filesystem::path per_pid =
-      std::filesystem::path(runtime_dir) / std::to_string(getpid());
+  const std::filesystem::path base(rocjitsu::rpc_default_runtime_dir());
+  const std::filesystem::path per_pid = base / std::to_string(getpid());
   std::error_code ec;
   if (std::filesystem::exists(per_pid / "config_path", ec))
     return per_pid;
-  return std::filesystem::path(runtime_dir);
+  return base;
 }
 
 std::optional<std::string> read_active_config_json() {

--- a/emulation/rocjitsu/tests/halt_snapshot_plugin.h
+++ b/emulation/rocjitsu/tests/halt_snapshot_plugin.h
@@ -47,7 +47,8 @@ struct WavefrontSnapshot {
   uint8_t vgpr_msb_mode = 0;      ///< Decoded s_set_vgpr_msb layout at halt.
   uint64_t lds_size_bytes = 0;    ///< Size of the LDS region visible to this wave.
   simdojo::ComponentID cu_id = 0; ///< Originating CU component id (for per-CU grouping).
-  std::vector<uint32_t> sgprs;    ///< [num_sgprs]
+  std::vector<uint32_t> sgprs;    ///< Full physical SGPR block (sgprs_per_wf), so TTMP
+                                  ///< slots past num_sgprs remain visible to tests.
   std::vector<uint32_t> vgprs;    ///< [vgpr_block * wf_size], row-major by physical reg.
 
   /// @brief Read a captured SGPR by architectural index.

--- a/emulation/rocjitsu/tests/halt_snapshot_plugin.h
+++ b/emulation/rocjitsu/tests/halt_snapshot_plugin.h
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+/// @file halt_snapshot_plugin.h
+/// @brief Test-only ExecutionPlugin that captures each wavefront's final register
+/// state at halt.
+///
+/// @details Under the hardware-accurate model a wavefront frees its SGPR/VGPR
+/// allocations the instant it reaches s_endpgm, so its register file is no longer
+/// readable through the (now-free) slot after a kernel finishes. Tests that need to
+/// observe a wave's final state install this plugin, which snapshots the full
+/// register file from `onAmdgpuWavefrontHalted` — fired while the registers are
+/// still live, before they are freed.
+
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/register_access.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+#include "rocjitsu/vm/plugins/execution_plugin.h"
+#include "rocjitsu/vm/plugins/execution_plugin_group.h"
+
+#include "simdojo/sim/component.h"
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+namespace rocjitsu::test {
+
+/// @brief Captured final state of a single halted wavefront.
+struct WavefrontSnapshot {
+  uint32_t wf_id = 0;
+  uint32_t wg_id = 0;
+  uint32_t dispatch_id = 0;
+  uint32_t wf_size = 0;
+  uint32_t num_sgprs = 0;
+  uint32_t num_vgprs = 0;  ///< Architectural VGPR count requested by the dispatch.
+  uint32_t vgpr_block = 0; ///< Physical VGPR block size (includes the AccVGPR bank).
+  uint64_t exec = 0;
+  uint64_t vcc = 0;
+  uint32_t status = 0;
+  uint32_t mode_raw = 0;          ///< MODE register at halt.
+  uint8_t vgpr_msb_mode = 0;      ///< Decoded s_set_vgpr_msb layout at halt.
+  uint64_t lds_size_bytes = 0;    ///< Size of the LDS region visible to this wave.
+  simdojo::ComponentID cu_id = 0; ///< Originating CU component id (for per-CU grouping).
+  std::vector<uint32_t> sgprs;    ///< [num_sgprs]
+  std::vector<uint32_t> vgprs;    ///< [vgpr_block * wf_size], row-major by physical reg.
+
+  /// @brief Read a captured SGPR by architectural index.
+  uint32_t sgpr(uint32_t idx) const { return sgprs.at(idx); }
+
+  /// @brief Read a captured 64-bit SGPR pair (lo at idx, hi at idx+1).
+  uint64_t sgpr64(uint32_t idx) const {
+    return (static_cast<uint64_t>(sgprs.at(idx + 1)) << 32) | sgprs.at(idx);
+  }
+
+  /// @brief Read a captured VGPR lane by physical register index and lane.
+  /// @details The physical index space includes the AccVGPR bank on CDNA, so
+  /// callers may pass `ACC_VGPR_OFFSET + acc_reg` to read accumulator registers.
+  uint32_t vgpr(uint32_t reg, uint32_t lane) const {
+    return vgprs.at(static_cast<size_t>(reg) * wf_size + lane);
+  }
+};
+
+/// @brief Records a WavefrontSnapshot for every wavefront that halts.
+/// @details onAmdgpuWavefrontHalted can fire concurrently from multiple partition
+/// engine threads in a multi-threaded simulation, so the append is serialized by
+/// mutex_. The read accessors below are for POST-RUN inspection only — call them
+/// after the engine has drained (no waves still executing); they return references
+/// into snapshots_ and must not race a concurrent halt.
+class HaltSnapshotPlugin : public ExecutionPlugin {
+public:
+  HaltSnapshotPlugin() : ExecutionPlugin("halt_snapshot") {}
+
+  const std::vector<WavefrontSnapshot> &snapshots() const { return snapshots_; }
+
+  /// @brief Snapshots taken on a specific CU, in halt order.
+  std::vector<const WavefrontSnapshot *> for_cu(const amdgpu::ComputeUnitCore *cu) const {
+    std::vector<const WavefrontSnapshot *> out;
+    for (const auto &s : snapshots_)
+      if (cu && s.cu_id == cu->id())
+        out.push_back(&s);
+    return out;
+  }
+
+  /// @brief First snapshot matching a wavefront slot id, or nullptr.
+  const WavefrontSnapshot *by_wf_id(uint32_t wf_id) const {
+    for (const auto &s : snapshots_)
+      if (s.wf_id == wf_id)
+        return &s;
+    return nullptr;
+  }
+
+  /// @brief First snapshot matching a workgroup id, or nullptr.
+  const WavefrontSnapshot *by_wg_id(uint32_t wg_id) const {
+    for (const auto &s : snapshots_)
+      if (s.wg_id == wg_id)
+        return &s;
+    return nullptr;
+  }
+
+  void onAmdgpuWavefrontHalted(amdgpu::Wavefront &wf) override {
+    WavefrontSnapshot s;
+    s.wf_id = wf.wf_id();
+    s.wg_id = wf.wg_id();
+    s.dispatch_id = wf.dispatch_id();
+    s.wf_size = wf.wf_size();
+    s.num_sgprs = wf.num_sgprs();
+    s.num_vgprs = wf.num_vgprs();
+    s.exec = wf.exec();
+    s.vcc = wf.vcc();
+    s.status = wf.status_raw();
+    s.mode_raw = wf.mode_raw();
+    s.vgpr_msb_mode = wf.vgpr_msb_mode();
+    s.lds_size_bytes = wf.lds().size_bytes();
+    s.cu_id = wf.cu().id();
+
+    // Read the live register file through the instruction-facing facade rather
+    // than the CU's raw storage: the hardware-accurate model hides the full
+    // ComputeUnitCore behind Wavefront, so RegisterAccess is the supported path
+    // to observe physical registers while the wave is still resident at halt.
+    const amdgpu::RegisterAccess regs(wf);
+
+    // Capture the full physical SGPR block (sgprs_per_wf), not just the requested
+    // count: TTMP registers alias into the high slots of the block and tests read
+    // them by physical index (e.g. TTMP7 at 115, TTMP9 at 117).
+    const uint32_t sbase = wf.sgpr_alloc().base;
+    const uint32_t sgpr_block = wf.cu().sgprs_per_wf();
+    s.sgprs.reserve(sgpr_block);
+    for (uint32_t i = 0; i < sgpr_block; ++i)
+      s.sgprs.push_back(regs.read_sgpr(sbase + i));
+
+    // Capture the full physical VGPR block (normal + AccVGPR bank) so tests can
+    // inspect accumulator registers as well as ordinary VGPRs.
+    s.vgpr_block = wf.cu().vgpr_allocation_block_size();
+    const uint32_t vbase = wf.vgpr_alloc().base;
+    s.vgprs.reserve(static_cast<size_t>(s.vgpr_block) * s.wf_size);
+    for (uint32_t r = 0; r < s.vgpr_block; ++r)
+      for (uint32_t lane = 0; lane < s.wf_size; ++lane)
+        s.vgprs.push_back(regs.read_vgpr(vbase + r, lane));
+
+    // Serialize the append: concurrent halts from different partition threads
+    // would otherwise race the vector.
+    std::lock_guard<std::mutex> lk(mutex_);
+    snapshots_.push_back(std::move(s));
+  }
+
+private:
+  mutable std::mutex mutex_;
+  std::vector<WavefrontSnapshot> snapshots_;
+};
+
+/// @brief Build a plugin group holding a HaltSnapshotPlugin, keep a raw handle.
+/// @details Returns the group (attach with `soc->set_plugin_group(group)`), and
+/// sets @p out to the contained plugin for later inspection.
+inline std::shared_ptr<ExecutionPluginGroup> make_halt_snapshot_group(HaltSnapshotPlugin **out) {
+  auto group = std::make_shared<ExecutionPluginGroup>();
+  auto plugin = std::make_unique<HaltSnapshotPlugin>();
+  *out = plugin.get();
+  [[maybe_unused]] const bool added = group->add(std::move(plugin));
+  assert(added && "HaltSnapshotPlugin add() must not fail on a fresh group");
+  return group;
+}
+
+/// @brief Counts wavefront dispatches per CU at the moment they are placed.
+/// @details Fires from onAmdgpuWavefrontDispatched (before execution), so it
+/// observes workgroup-to-CU distribution independent of when waves later halt and
+/// free themselves.
+class DispatchCountPlugin : public ExecutionPlugin {
+public:
+  DispatchCountPlugin() : ExecutionPlugin("dispatch_count") {}
+
+  void onAmdgpuWavefrontDispatched(amdgpu::Wavefront &wf) override {
+    // Serialize: onAmdgpuWavefrontDispatched can fire from multiple partition
+    // engine threads in a multi-threaded simulation.
+    std::lock_guard<std::mutex> lk(mutex_);
+    counts_[wf.cu().id()]++;
+    total_++;
+  }
+
+  uint32_t total() const {
+    std::lock_guard<std::mutex> lk(mutex_);
+    return total_;
+  }
+  uint32_t for_cu(const amdgpu::ComputeUnitCore *cu) const {
+    std::lock_guard<std::mutex> lk(mutex_);
+    if (!cu)
+      return 0u;
+    auto it = counts_.find(cu->id());
+    return it == counts_.end() ? 0u : it->second;
+  }
+
+private:
+  mutable std::mutex mutex_;
+  std::unordered_map<simdojo::ComponentID, uint32_t> counts_;
+  uint32_t total_ = 0;
+};
+
+/// @brief Build a plugin group holding a DispatchCountPlugin, keep a raw handle.
+inline std::shared_ptr<ExecutionPluginGroup> make_dispatch_count_group(DispatchCountPlugin **out) {
+  auto group = std::make_shared<ExecutionPluginGroup>();
+  auto plugin = std::make_unique<DispatchCountPlugin>();
+  *out = plugin.get();
+  [[maybe_unused]] const bool added = group->add(std::move(plugin));
+  assert(added && "DispatchCountPlugin add() must not fail on a fresh group");
+  return group;
+}
+
+} // namespace rocjitsu::test

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -272,13 +272,10 @@ void run_execution_harness(rj_code_arch_t arch, std::string_view arch_name,
     }
     ++decoded;
 
-    // Dispatch a fresh wavefront for each instruction to avoid state leaks.
+    // Dispatch a fresh wavefront for each instruction to avoid state leaks. The
+    // previous iteration halted its wave (freeing the slot), so this always
+    // succeeds on the single-slot scratch CU.
     amdgpu::Wavefront *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
-    if (!wf) {
-      // Reset the slot and try again.
-      cu->reset_all_wf();
-      wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
-    }
     ASSERT_NE(wf, nullptr) << "Failed to dispatch WF for " << te.mnemonic;
 
     // Execute and catch UnimplementedInst.
@@ -294,7 +291,8 @@ void run_execution_harness(rj_code_arch_t arch, std::string_view arch_name,
     }
 
     // Reset the wavefront for the next instruction.
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 
   size_t testable = total - skipped;
@@ -490,7 +488,138 @@ TEST(Gfx1250MemoryExecutionHarness, ExecutesRepresentativeValidAddressStores) {
   EXPECT_EQ(gpu_mem.read32(kBufferAddr + 32), 0u);
   EXPECT_EQ(gpu_mem.read32(kBufferAddr + 48), 0x22000001u);
 
-  cu.reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
+}
+
+TEST(Rdna4ScalarSccTest, AddSubCoI32UseSignedOverflow) {
+  amdgpu::GpuMemory gpu_mem("rdna4_scc_i32_overflow_mem");
+  amdgpu::L2Cache l2("rdna4_scc_i32_overflow_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_RDNA4;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+
+  auto cu = amdgpu::ComputeUnitCore::create("rdna4", cfg, &gpu_mem, &l2);
+  ASSERT_NE(cu, nullptr);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+
+  auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+
+  const uint32_t sb = wf->sgpr_alloc().base;
+  auto run = [&](const std::array<uint32_t, 2> &words, std::string_view mnemonic, uint32_t lhs,
+                 uint32_t rhs, uint32_t expected_result, bool expected_scc) {
+    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    ASSERT_NE(inst, nullptr);
+    ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic);
+
+    cu->write_sgpr(sb + 0, lhs);
+    cu->write_sgpr(sb + 1, rhs);
+    wf->write_scc(!expected_scc);
+    cu->execute_instruction(inst.get(), *wf);
+
+    EXPECT_EQ(cu->read_sgpr(sb + 2), expected_result) << mnemonic;
+    EXPECT_EQ(wf->read_scc(), expected_scc) << mnemonic;
+  };
+
+  const auto add = encode_sop2(/*op=*/2, /*sdst=*/2, /*ssrc0=*/0, /*ssrc1=*/1);
+  const auto sub = encode_sop2(/*op=*/3, /*sdst=*/2, /*ssrc0=*/0, /*ssrc1=*/1);
+
+  run(add, "s_add_co_i32", 0x7FFFFFFFu, 1u, 0x80000000u, true);
+  run(add, "s_add_co_i32", 0x7FFFFFFFu, 0u, 0x7FFFFFFFu, false);
+  run(sub, "s_sub_co_i32", 0x80000000u, 1u, 0x7FFFFFFFu, true);
+  run(sub, "s_sub_co_i32", 5u, 3u, 2u, false);
+
+  if (!wf->is_halted())
+    wf->halt();
+}
+
+struct ScalarCvtSccCase {
+  uint32_t op;
+  const char *mnemonic;
+  uint32_t src;
+  uint32_t expected;
+};
+
+void run_scalar_cvt_preserves_scc(rj_code_arch_t arch, std::string_view arch_name,
+                                  const ScalarCvtSccCase *cases, size_t num_cases) {
+  amdgpu::GpuMemory gpu_mem(std::string(arch_name) + "_s_cvt_scc_mem");
+  amdgpu::L2Cache l2(std::string(arch_name) + "_s_cvt_scc_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = arch;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+
+  auto cu = amdgpu::ComputeUnitCore::create(std::string(arch_name), cfg, &gpu_mem, &l2);
+  ASSERT_NE(cu, nullptr) << arch_name;
+
+  auto decoder = Decoder::create(arch);
+  ASSERT_NE(decoder, nullptr) << arch_name;
+
+  auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr) << arch_name;
+
+  const uint32_t sb = wf->sgpr_alloc().base;
+
+  for (size_t i = 0; i < num_cases; ++i) {
+    const auto &tc = cases[i];
+    const auto words = encode_sop1(tc.op, /*sdst=*/1, /*ssrc0=*/0);
+    for (bool initial_scc : std::array<bool, 2>{false, true}) {
+      std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+      ASSERT_NE(inst, nullptr);
+      ASSERT_EQ(std::string_view(inst->mnemonic()), tc.mnemonic) << arch_name;
+
+      cu->write_sgpr(sb + 0, tc.src);
+      cu->write_sgpr(sb + 1, 0u);
+      wf->write_scc(initial_scc);
+      cu->execute_instruction(inst.get(), *wf);
+
+      EXPECT_EQ(cu->read_sgpr(sb + 1), tc.expected) << arch_name << " " << tc.mnemonic;
+      EXPECT_EQ(wf->read_scc(), initial_scc)
+          << arch_name << " " << tc.mnemonic << " initial_scc=" << initial_scc;
+    }
+  }
+
+  if (!wf->is_halted())
+    wf->halt();
+}
+
+TEST(ScalarSccTest, ScalarCvtPreservesScc) {
+  const uint32_t one_f32 = std::bit_cast<uint32_t>(1.0f);
+  const uint32_t one_f16 = util::f32_to_f16(1.0f);
+  const uint32_t qnan_f32 = 0x7FC00000u;
+  const uint32_t i32_overflow_f32 = std::bit_cast<uint32_t>(2147483648.0f);
+  const uint32_t below_i32_min_f32 = std::bit_cast<uint32_t>(-2147483904.0f);
+  const uint32_t u32_overflow_f32 = std::bit_cast<uint32_t>(4294967296.0f);
+
+  const std::array<ScalarCvtSccCase, 13> cases{{
+      {0x64u, "s_cvt_f32_i32", 1u, one_f32},
+      {0x65u, "s_cvt_f32_u32", 1u, one_f32},
+      {0x66u, "s_cvt_i32_f32", one_f32, 1u},
+      {0x66u, "s_cvt_i32_f32", qnan_f32, 0u},
+      {0x66u, "s_cvt_i32_f32", i32_overflow_f32, 0x7FFFFFFFu},
+      {0x66u, "s_cvt_i32_f32", below_i32_min_f32, 0x80000000u},
+      {0x67u, "s_cvt_u32_f32", one_f32, 1u},
+      {0x67u, "s_cvt_u32_f32", qnan_f32, 0u},
+      {0x67u, "s_cvt_u32_f32", std::bit_cast<uint32_t>(-1.0f), 0u},
+      {0x67u, "s_cvt_u32_f32", u32_overflow_f32, 0xFFFFFFFFu},
+      {0x68u, "s_cvt_f16_f32", one_f32, one_f16},
+      {0x69u, "s_cvt_f32_f16", one_f16, one_f32},
+      {0x6Au, "s_cvt_hi_f32_f16", one_f16 << 16, one_f32},
+  }};
+
+  run_scalar_cvt_preserves_scc(ROCJITSU_CODE_ARCH_RDNA3_5, "rdna3_5", cases.data(), cases.size());
+  run_scalar_cvt_preserves_scc(ROCJITSU_CODE_ARCH_RDNA4, "rdna4", cases.data(), cases.size());
+  run_scalar_cvt_preserves_scc(ROCJITSU_CODE_ARCH_GFX1250, "gfx1250", cases.data(), cases.size());
 }
 
 TEST(Cdna4Vop3Test, CmpClassF16WritesWave64UpperMaskDword) {
@@ -561,7 +690,8 @@ TEST(Cdna4Vop3Test, CmpClassF16WritesWave64UpperMaskDword) {
     EXPECT_EQ(cu->read_sgpr(sb + 0), static_cast<uint32_t>(expected_mask));
     EXPECT_EQ(cu->read_sgpr(sb + 1), static_cast<uint32_t>(expected_mask >> 32));
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -656,7 +786,8 @@ TEST(CdnaVop3True16Test, B16I16U16OpsUseOpSelAndCdnaDestinationPolicy) {
             << arch.name << " force_scalar=" << force_scalar << " lane " << lane;
       }
 
-      cu->reset_all_wf();
+      if (!wf->is_halted())
+        wf->halt();
     }
   }
 }
@@ -695,7 +826,8 @@ TEST(Rdna3Dot2ExecutionTest, Vop2Dot2accF32F16AccumulatesDst) {
 
   EXPECT_EQ(cu->read_vgpr(vb + 2, 0), std::bit_cast<uint32_t>(16.0f));
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Rdna4Dot2True16ExecutionTest, F16AppliesVop3ModifiersAndSelectedHalves) {
@@ -735,7 +867,8 @@ TEST(Rdna4Dot2True16ExecutionTest, F16AppliesVop3ModifiersAndSelectedHalves) {
 
   EXPECT_EQ(cu->read_vgpr(vb + 3, 0), pack16(0xBEEFu, util::f32_to_f16(1.0f)));
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Rdna4Dot2True16ExecutionTest, Bf16UsesSelectedAccumulatorAndDestinationHalf) {
@@ -774,7 +907,8 @@ TEST(Rdna4Dot2True16ExecutionTest, Bf16UsesSelectedAccumulatorAndDestinationHalf
 
   EXPECT_EQ(cu->read_vgpr(vb + 3, 0), pack16(util::f32_to_bf16(16.0f), 0xCAFEu));
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 uint32_t wmma64_ab_lane(uint32_t row_or_col, uint32_t k) {
@@ -908,7 +1042,8 @@ TEST(Gfx1250WmmaTest, F16Fp8K64MatchesReferenceLayout) {
   cu->execute_instruction(inst.get(), *wf);
   expect_reference();
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250WmmaTest, CModifierAppliesAbsBeforeNegate) {
@@ -1000,7 +1135,8 @@ TEST(Gfx1250WmmaTest, Bf16F32K32Bf16PreservesAccumulatorLayout) {
     }
   }
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250Dpp8Test, Vop2AddF16UsesPermutedSourceLanes) {
@@ -1054,7 +1190,8 @@ TEST(Gfx1250Dpp8Test, Vop2AddF16UsesPermutedSourceLanes) {
     EXPECT_EQ(raw & 0xFFFFu, util::f32_to_f16(static_cast<float>(src_lane + 1))) << "lane=" << lane;
   }
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250ExecMaskTest, CmpxNeqAndScalarOrRestoreExec) {
@@ -1110,7 +1247,8 @@ TEST(Gfx1250ExecMaskTest, CmpxNeqAndScalarOrRestoreExec) {
   cu->execute_instruction(restore_exec.get(), *wf);
   EXPECT_EQ(wf->exec(), all_lanes);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250ExecMaskTest, Vop3CmpxGtI32KeepsInRangeLanesActive) {
@@ -1149,7 +1287,8 @@ TEST(Gfx1250ExecMaskTest, Vop3CmpxGtI32KeepsInRangeLanesActive) {
   cu->execute_instruction(in_range.get(), *wf);
   EXPECT_EQ(wf->exec(), all_lanes);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250ExecMaskTest, Vop3CmpF32PreservesHighMaskSgprOnWave32) {
@@ -1194,7 +1333,8 @@ TEST(Gfx1250ExecMaskTest, Vop3CmpF32PreservesHighMaskSgprOnWave32) {
   EXPECT_EQ(cu->read_sgpr(wf->sgpr_alloc().base + 0), 1u << 4);
   EXPECT_EQ(cu->read_sgpr(wf->sgpr_alloc().base + 1), saved_exec);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250True16Vop3Test, SelectedHalfArithmeticPreservesDestinationHalf) {
@@ -1226,7 +1366,7 @@ TEST(Gfx1250True16Vop3Test, SelectedHalfArithmeticPreservesDestinationHalf) {
     cu->write_vgpr(v3, lane, 0xBEEF0007u);
   }
 
-  auto execute = [&](const uint32_t(&words)[2], std::string_view mnemonic) {
+  auto execute = [&](const uint32_t (&words)[2], std::string_view mnemonic) {
     std::unique_ptr<Instruction> inst(decoder->decode(words));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic);
@@ -1267,7 +1407,8 @@ TEST(Gfx1250True16Vop3Test, SelectedHalfArithmeticPreservesDestinationHalf) {
   for (uint32_t lane = 0; lane < wf->wf_size(); ++lane)
     EXPECT_EQ(cu->read_vgpr(v3, lane), 0xBEEF0023u);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250True16Vop2Test, AddF16UsesSelectedHighVsrc1AndPreservesLowDestination) {
@@ -1308,7 +1449,8 @@ TEST(Gfx1250True16Vop2Test, AddF16UsesSelectedHighVsrc1AndPreservesLowDestinatio
 
   EXPECT_EQ(cu->read_vgpr(vb + 2, 0), 0x4600CAFEu); // high=6.0h, low preserved
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250True16Vop2Test, FmacF16HighDestinationUsesSelectedAccumulatorHalf) {
@@ -1349,7 +1491,8 @@ TEST(Gfx1250True16Vop2Test, FmacF16HighDestinationUsesSelectedAccumulatorHalf) {
 
   EXPECT_EQ(cu->read_vgpr(vb + 0, 0), 0x4B003C00u); // high=14.0h, low preserved
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250True16Vop3Test, MulLoU16UsesSelectedHighSourceHalf) {
@@ -1386,7 +1529,8 @@ TEST(Gfx1250True16Vop3Test, MulLoU16UsesSelectedHighSourceHalf) {
 
   EXPECT_EQ(cu->read_vgpr(vb + 2, 0), 0xAAAA625Cu);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250True16Vop3Test, CmpLtI16UsesSelectedHighSourceHalf) {
@@ -1427,7 +1571,8 @@ TEST(Gfx1250True16Vop3Test, CmpLtI16UsesSelectedHighSourceHalf) {
   EXPECT_EQ(cu->read_sgpr(sb + 0), 0u);
   EXPECT_EQ(cu->read_sgpr(sb + 1), 0xDEADBEEFu);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250True16Vop3Test, CmpClassF16UsesSelectedMaskHalf) {
@@ -1473,7 +1618,8 @@ TEST(Gfx1250True16Vop3Test, CmpClassF16UsesSelectedMaskHalf) {
     EXPECT_EQ(cu->read_sgpr(sb + 0), 0x1u);
     EXPECT_EQ(cu->read_sgpr(sb + 1), 0xDEADBEEFu);
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -1518,7 +1664,8 @@ TEST(Gfx1250True16Vop3Test, CmpxClassF16UsesSelectedMaskHalf) {
     EXPECT_EQ(wf->exec(), 0x1u);
     EXPECT_EQ(wf->vcc(), 0xA5A5u);
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -1600,7 +1747,8 @@ TEST(Gfx1250True16Vop3Test, SpecialVop3OpsUseSelectedHalves) {
             "v_div_fixup_f16");
     EXPECT_EQ(cu->read_vgpr(vb + 12, 0), pack16(0xBEEFu, util::f32_to_f16(2.0f)));
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -1640,7 +1788,8 @@ TEST(Gfx1250True16VopcTest, CmpLtI16ReadsPackedHighVsrc1) {
 
   EXPECT_EQ(wf->vcc(), 0x2u);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Rdna4True16Vop3Test, CmpGeF16UsesSelectedHighSourceHalf) {
@@ -1686,7 +1835,8 @@ TEST(Rdna4True16Vop3Test, CmpGeF16UsesSelectedHighSourceHalf) {
     EXPECT_EQ(cu->read_sgpr(sb + 0), 0x2u);
     EXPECT_EQ(cu->read_sgpr(sb + 1), 0xDEADBEEFu);
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -1733,7 +1883,8 @@ TEST(Rdna4True16Vop3Test, CmpClassF16UsesSelectedMaskHalf) {
     EXPECT_EQ(cu->read_sgpr(sb + 0), 0x1u);
     EXPECT_EQ(cu->read_sgpr(sb + 1), 0xDEADBEEFu);
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -1779,7 +1930,8 @@ TEST(Rdna4True16Vop3Test, CmpClassF16InlineConstantUsesF16Broadcast) {
     EXPECT_EQ(cu->read_sgpr(sb + 0), 0x3u);
     EXPECT_EQ(cu->read_sgpr(sb + 1), 0xDEADBEEFu);
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -1824,7 +1976,8 @@ TEST(Rdna4True16Vop3Test, CmpxClassF16UsesSelectedMaskHalf) {
     EXPECT_EQ(wf->exec(), 0x1u);
     EXPECT_EQ(wf->vcc(), 0xA5A5u);
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -1922,7 +2075,8 @@ TEST(Rdna4True16Vop3Test, ClassF16HelperSequenceMovesMaskIntoSelectedHighHalf) {
       EXPECT_EQ(cu->read_vgpr(vb + 0, test.lane), test.expected ? 1u : 0u) << "lane " << test.lane;
     }
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -1963,7 +2117,8 @@ TEST(Rdna4True16Vop3Test, RcpF16WritesSelectedHighDestinationHalf) {
 
     EXPECT_EQ(cu->read_vgpr(vb + 0, 0), 0xB8004000u); // high=-0.5h, low preserved
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -2004,7 +2159,8 @@ TEST(Rdna4True16Vop3Test, CvtF32F16AppliesAbsToSelectedSourceHalf) {
 
     EXPECT_EQ(cu->read_vgpr(vb + 4, 0), 0x40800000u);
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -2054,7 +2210,8 @@ TEST(Rdna4True16Vop3Test, AddF16UsesSelectedHalvesAndPreservesDestinationHalf) {
     EXPECT_EQ(cu->read_vgpr(vb + 2, 0), pack16(0xBEEFu, util::f32_to_f16(5.0f)));
     EXPECT_EQ(cu->read_vgpr(vb + 2, 1), pack16(0x1234u, util::f32_to_f16(-0.5f)));
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -2115,7 +2272,8 @@ TEST(Rdna4True16Vop3Test, AddF16DppPreservesMaskedDestinationHalf) {
   EXPECT_EQ(cu->read_vgpr(vb + kDst, 2), pack16(0x4002u, util::f32_to_f16(11.5f)));
   EXPECT_EQ(cu->read_vgpr(vb + kDst, 16), pack16(0x4010u, 0x7010u));
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Rdna4True16Vop3Test, FmacF16UsesSelectedAccumulatorHalfAndPreservesDestinationHalf) {
@@ -2163,7 +2321,8 @@ TEST(Rdna4True16Vop3Test, FmacF16UsesSelectedAccumulatorHalfAndPreservesDestinat
     EXPECT_EQ(cu->read_vgpr(vb + 3, 0), pack16(0xBEEFu, util::f32_to_f16(10.0f)));
     EXPECT_EQ(cu->read_vgpr(vb + 3, 1), pack16(0x1234u, util::f32_to_f16(0.5f)));
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -2224,7 +2383,8 @@ TEST(Rdna4True16Vop3Test, TernaryI16U16UsesSelectedHalvesAndPreservesDestination
     execute(/*op=*/0x24E, /*dst=*/14, /*src0=*/260, /*src1=*/261, /*src2=*/262, "v_max3_u16", 7u);
     execute(/*op=*/0x251, /*dst=*/15, /*src0=*/260, /*src1=*/261, /*src2=*/262, "v_med3_u16", 5u);
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -2306,7 +2466,8 @@ TEST(Rdna4True16Vop3Test, SpecialVop3OpsUseSelectedHalves) {
             "v_div_fixup_f16");
     EXPECT_EQ(cu->read_vgpr(vb + 12, 0), pack16(0xBEEFu, util::f32_to_f16(2.0f)));
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -2356,7 +2517,8 @@ TEST(Rdna4Vop3CndmaskTest, B32AppliesNegModifierBeforeSelect) {
     EXPECT_EQ(cu->read_vgpr(vb + 2, 0), 0x11223344u);
     EXPECT_EQ(cu->read_vgpr(vb + 2, 1), 0xBF000000u);
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -2416,7 +2578,8 @@ TEST(Rdna4Atan2F16Test, SignedHalfCompareFeedsQuadrantSelect) {
     cu->execute_instruction(f16_cmp.get(), *wf);
     EXPECT_EQ(wf->vcc() & 0x3u, 0x1u);
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -2461,7 +2624,8 @@ TEST(Rdna4Atan2F16Test, DualCndmaskReadsOldPairedSlotSource) {
   EXPECT_EQ(cu->read_vgpr(vb + 5, 0), 0x4016CBE4u);
   EXPECT_EQ(cu->read_vgpr(vb + 5, 1), 0x4016CBE4u);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Rdna4Atan2F16Test, TailSequenceKeepsNegativeXQuadrant) {
@@ -2520,7 +2684,8 @@ TEST(Rdna4Atan2F16Test, TailSequenceKeepsNegativeXQuadrant) {
 
   EXPECT_EQ(cu->read_vgpr(vb + 1, 0) & 0xFFFFu, 0xC0B6u);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Rdna4Vop3pFmaMixTest, F32AppliesAbsModifiersFromNegHi) {
@@ -2631,7 +2796,8 @@ TEST(Rdna4Vop3pFmaMixTest, F32AppliesAbsModifiersFromNegHi) {
     cu->execute_instruction(atanh_scale_inst.get(), *wf);
     EXPECT_EQ(cu->read_vgpr(vb + 0, 0), 0xBBC9BEEFu);
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -2717,7 +2883,8 @@ TEST(Rdna4True16Vop3Test, B16BitwiseLiteralPreservesInputSignBit) {
     cu->execute_instruction(xor_inst.get(), *wf);
     EXPECT_EQ(cu->read_vgpr(vb + 0, 0), 0xCAFEB4D0u);
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -2764,7 +2931,8 @@ TEST(Gfx1250True16Vop3Test, CndmaskB16UsesSelectedSourceHalfAndPreservesDestinat
   EXPECT_EQ(cu->read_vgpr(vb + 2, 1), 0x1234CAFEu);
   EXPECT_EQ(cu->read_vgpr(vb + 2, 2), 0xDEADCAFEu);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250True16Vop3Test, LshrrevB16UsesSelectedSourceHalfAndPreservesDestinationHalf) {
@@ -2801,7 +2969,8 @@ TEST(Gfx1250True16Vop3Test, LshrrevB16UsesSelectedSourceHalfAndPreservesDestinat
 
   EXPECT_EQ(cu->read_vgpr(vb + 16, 0), 0x00125555u);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250True16Vop3Test, Bitop3B16UsesSelectedSourceHalfAndPreservesDestinationHalf) {
@@ -2835,7 +3004,7 @@ TEST(Gfx1250True16Vop3Test, Bitop3B16UsesSelectedSourceHalfAndPreservesDestinati
     cu->write_vgpr(v8, lane, 0x55550014u);
   }
 
-  auto execute = [&](const uint32_t(&words)[2], std::string_view mnemonic) {
+  auto execute = [&](const uint32_t (&words)[2], std::string_view mnemonic) {
     std::unique_ptr<Instruction> inst(decoder->decode(words));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic);
@@ -2864,7 +3033,8 @@ TEST(Gfx1250True16Vop3Test, Bitop3B16UsesSelectedSourceHalfAndPreservesDestinati
   for (uint32_t lane = 0; lane < wf->wf_size(); ++lane)
     EXPECT_EQ(cu->read_vgpr(v2, lane), 0xA5A50000u | expected);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250True16Vop1Test, MovB16HighDestinationPreservesLowHalf) {
@@ -2902,7 +3072,8 @@ TEST(Gfx1250True16Vop1Test, MovB16HighDestinationPreservesLowHalf) {
 
   EXPECT_EQ(cu->read_vgpr(vb + 2, 0), 0x12345555u);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Rdna3True16Vop1Test, MovB16HighDestinationPreservesLowHalf) {
@@ -2940,7 +3111,8 @@ TEST(Rdna3True16Vop1Test, MovB16HighDestinationPreservesLowHalf) {
 
   EXPECT_EQ(cu->read_vgpr(vb + 2, 0), 0x12345555u);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Rdna3DppTest, VAddF32RowShrMatchesWaveReduceSequence) {
@@ -3006,7 +3178,8 @@ TEST(Rdna3DppTest, VAddF32RowShrMatchesWaveReduceSequence) {
     cu->execute_instruction(final_add_inst.get(), *wf);
     EXPECT_EQ(cu->read_vgpr(vb + 3, 31), std::bit_cast<uint32_t>(-2.0f));
 
-    cu->reset_all_wf();
+    if (!wf->is_halted())
+      wf->halt();
   }
 }
 
@@ -3053,7 +3226,8 @@ TEST(Rdna3ScalarOperandTest, NullSdstDoesNotClobberM0) {
   EXPECT_EQ(cu->read_vgpr(vb + 5, 1), 0u);
   EXPECT_EQ(cu->read_vgpr(vb + 5, 2), 0xCAFECAFEu);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250True16Vop1Test, CvtF16F32HighDestinationPreservesLowHalf) {
@@ -3091,7 +3265,8 @@ TEST(Gfx1250True16Vop1Test, CvtF16F32HighDestinationPreservesLowHalf) {
 
   EXPECT_EQ(cu->read_vgpr(vb + 0, 0), 0x3C005555u);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250CvtFp8Test, F16DecodeVop3UsesSelectedByte) {
@@ -3138,7 +3313,8 @@ TEST(Gfx1250CvtFp8Test, F16DecodeVop3UsesSelectedByte) {
   cu->execute_instruction(bf8_inst.get(), *wf);
   EXPECT_EQ(cu->read_vgpr(vb + 1, 0), 0xBEEF3C00u);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250CvtFp8Test, F32DecodeVop3UsesSelectedByte) {
@@ -3183,7 +3359,8 @@ TEST(Gfx1250CvtFp8Test, F32DecodeVop3UsesSelectedByte) {
   cu->execute_instruction(bf8_inst.get(), *wf);
   EXPECT_EQ(cu->read_vgpr(vb + 1, 0), std::bit_cast<uint32_t>(1.0f));
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250CvtFp8Test, E4M3OverflowProducesNaN) {
@@ -3304,7 +3481,8 @@ TEST(Gfx1250CvtFp8Test, E5M3ClampSelectsUnsignedFp8Format) {
   cu->execute_instruction(sr_f16_inst.get(), *wf);
   EXPECT_EQ(cu->read_vgpr(vb + 2, 0), 0xDE38BEEFu);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250CvtScaleTest, UnpackUsesSelectedE8M0ScaleByte) {
@@ -3358,7 +3536,8 @@ TEST(Gfx1250CvtScaleTest, UnpackUsesSelectedE8M0ScaleByte) {
   for (uint32_t i = 18; i <= 33; ++i)
     EXPECT_EQ(cu->read_vgpr(vb + i, 0), std::bit_cast<uint32_t>(2.0f)) << "vgpr=" << i;
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250DsSwizzleTest, VdsBroadcastReadsAddrSource) {
@@ -3417,7 +3596,8 @@ TEST(Gfx1250DsSwizzleTest, VdsBroadcastReadsAddrSource) {
     EXPECT_EQ(cu->read_vgpr(vb + 2, lane), 0x1000u + src_lane) << "lane=" << lane;
   }
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250AtomicReturnTest, GlobalAtomicAddF32ReturnsOldValue) {
@@ -3459,7 +3639,8 @@ TEST(Gfx1250AtomicReturnTest, GlobalAtomicAddF32ReturnsOldValue) {
   EXPECT_EQ(cu.read_vgpr(wf->vgpr_alloc().base + 0, 0), std::bit_cast<uint32_t>(kOld));
   EXPECT_EQ(gpu_mem.read32(kAddr), std::bit_cast<uint32_t>(kOld + kAdd));
 
-  cu.reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250AtomicReturnTest, GlobalAtomicAddF32AllowsDstSrcAlias) {
@@ -3501,7 +3682,8 @@ TEST(Gfx1250AtomicReturnTest, GlobalAtomicAddF32AllowsDstSrcAlias) {
   EXPECT_EQ(cu.read_vgpr(wf->vgpr_alloc().base + 1, 0), std::bit_cast<uint32_t>(kOld));
   EXPECT_EQ(gpu_mem.read32(kAddr), std::bit_cast<uint32_t>(kOld + kAdd));
 
-  cu.reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250AtomicReturnTest, GlobalAtomicAddU64CopiesHighSourceDword) {
@@ -3543,7 +3725,8 @@ TEST(Gfx1250AtomicReturnTest, GlobalAtomicAddU64CopiesHighSourceDword) {
 
   EXPECT_EQ(gpu_mem.read64(kAddr), kOld + kAdd);
 
-  cu.reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250AtomicReturnTest, GlobalAtomicCmpswapB32ReturnsOldValue) {
@@ -3586,7 +3769,8 @@ TEST(Gfx1250AtomicReturnTest, GlobalAtomicCmpswapB32ReturnsOldValue) {
   EXPECT_EQ(cu.read_vgpr(wf->vgpr_alloc().base + 0, 0), kOld);
   EXPECT_EQ(gpu_mem.read32(kAddr), kNew);
 
-  cu.reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 /// @brief Targeted test for s_setreg_imm32_b32: verifies that the imm32
@@ -3632,7 +3816,8 @@ TEST(HwregTest, SetregImm32WritesStatus) {
   EXPECT_EQ(wf->status_raw(), kImm32Value)
       << "s_setreg_imm32_b32 did not write imm32 to STATUS register";
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 /// @brief Targeted test for s_setreg_imm32_b32 with partial bitfield write.
@@ -3673,7 +3858,8 @@ TEST(HwregTest, SetregImm32PartialBitfield) {
   // all other bits should be unchanged from 0xAAAAAAAA.
   EXPECT_EQ(wf->status_raw(), 0xAAAAAfAAu) << "Partial bitfield write to STATUS incorrect";
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -1366,7 +1366,7 @@ TEST(Gfx1250True16Vop3Test, SelectedHalfArithmeticPreservesDestinationHalf) {
     cu->write_vgpr(v3, lane, 0xBEEF0007u);
   }
 
-  auto execute = [&](const uint32_t (&words)[2], std::string_view mnemonic) {
+  auto execute = [&](const uint32_t(&words)[2], std::string_view mnemonic) {
     std::unique_ptr<Instruction> inst(decoder->decode(words));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic);
@@ -3004,7 +3004,7 @@ TEST(Gfx1250True16Vop3Test, Bitop3B16UsesSelectedSourceHalfAndPreservesDestinati
     cu->write_vgpr(v8, lane, 0x55550014u);
   }
 
-  auto execute = [&](const uint32_t (&words)[2], std::string_view mnemonic) {
+  auto execute = [&](const uint32_t(&words)[2], std::string_view mnemonic) {
     std::unique_ptr<Instruction> inst(decoder->decode(words));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic);
@@ -3398,7 +3398,8 @@ TEST(Gfx1250CvtFp8Test, E4M3OverflowProducesNaN) {
   cu->execute_instruction(inst.get(), *wf);
   EXPECT_EQ(cu->read_vgpr(vb + 2, 0), 0xA5A5FF7Fu);
 
-  cu->reset_all_wf();
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(Gfx1250CvtFp8Test, E5M3ClampSelectsUnsignedFp8Format) {

--- a/emulation/rocjitsu/tests/interposer_dup_test.cpp
+++ b/emulation/rocjitsu/tests/interposer_dup_test.cpp
@@ -17,6 +17,8 @@
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
 RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "drm/amdgpu_drm.h"
+#include "drm/drm.h"
 #include "linux/uapi/kfd_ioctl.h"
 RJ_DIAGNOSTIC_POP
 
@@ -27,6 +29,7 @@ RJ_DIAGNOSTIC_POP
 #include <chrono>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <sys/mman.h>
 #include <thread>
 #include <unistd.h>
 
@@ -287,4 +290,199 @@ TEST(InterposerDupTest, SerializedReopenUnderContentionStaysRoutable) {
     EXPECT_EQ(close(primary), 0);
   }
   EXPECT_EQ(close(keeper), 0);
+}
+
+namespace {
+
+// Open the synthetic DRM render node the interposer exposes for the simulated GPU
+// (render minor 128 in the KMD test configs). Requires the KFD driver to be up, so
+// callers open /dev/kfd first.
+int open_drm_render() { return open("/dev/dri/renderD128", O_RDWR | O_CLOEXEC); }
+
+// Create an mmap-able, sized stand-in for a dmabuf export fd. PRIME_FD_TO_HANDLE
+// fstats the fd for the BO size and later MAP mmaps it, so the fd must be a real
+// sized, mappable object; a memfd satisfies both without a KFD allocation.
+int make_sized_memfd(size_t size) {
+  int fd = memfd_create("rocjitsu_gem_test", MFD_CLOEXEC);
+  if (fd < 0)
+    return -1;
+  if (ftruncate(fd, static_cast<off_t>(size)) != 0) {
+    close(fd);
+    return -1;
+  }
+  return fd;
+}
+
+// Mint a stable GEM handle for a dmabuf fd via PRIME_FD_TO_HANDLE on the DRM fd.
+bool prime_import(int drm_fd, int dmabuf_fd, uint32_t *handle) {
+  drm_prime_handle prime{};
+  prime.fd = dmabuf_fd;
+  if (ioctl(drm_fd, DRM_IOCTL_PRIME_FD_TO_HANDLE, &prime) != 0)
+    return false;
+  *handle = prime.handle;
+  return true;
+}
+
+// DRM_AMDGPU_GEM_VA is a DRM_COMMAND-relative ioctl; build the request number the
+// same way libdrm_amdgpu does. Wrapped in a function so the test reads cleanly.
+unsigned long DRM_AMDGPU_GEM_VA_request() {
+  return DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_VA, drm_amdgpu_gem_va);
+}
+
+int gem_close(int drm_fd, uint32_t handle) {
+  drm_gem_close gc{};
+  gc.handle = handle;
+  return ioctl(drm_fd, DRM_IOCTL_GEM_CLOSE, &gc);
+}
+
+} // namespace
+
+// A dmabuf export fd number that is closed and then recycled by a second export
+// must resolve to a DISTINCT, stable GEM handle — never one derived from the fd
+// number. Two concurrently-live BOs whose export fds happened to reuse the same
+// integer must keep independent handles and independent GPU mappings, and closing
+// one handle must not disturb the other. This pins the fix for the old
+// handle = dmabuf_fd + 1 scheme, under which a recycled fd tore down a live BO.
+TEST(InterposerGemTest, ReusedDmabufFdMintsDistinctHandles) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  constexpr size_t kBoSize = 0x1000;
+  const unsigned long gem_va = DRM_AMDGPU_GEM_VA_request();
+  const uint64_t va_a = 0x1000000000ULL;
+  const uint64_t va_b = 0x1000100000ULL;
+
+  // First BO: import and map it (the export fd must stay open across MAP, which
+  // lazily mmaps the backing pages — mirrors ROCr, which closes the export fd only
+  // AFTER access setup). Then close the export fd so its number becomes free.
+  int dmabuf_a = make_sized_memfd(kBoSize);
+  ASSERT_GE(dmabuf_a, 0);
+  uint32_t handle_a = 0;
+  ASSERT_TRUE(prime_import(drm, dmabuf_a, &handle_a));
+  ASSERT_NE(handle_a, 0u);
+
+  drm_amdgpu_gem_va map_a{};
+  map_a.handle = handle_a;
+  map_a.operation = AMDGPU_VA_OP_MAP;
+  map_a.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  map_a.va_address = va_a;
+  map_a.map_size = kBoSize;
+  ASSERT_EQ(ioctl(drm, gem_va, &map_a), 0);
+
+  const int reused_number = dmabuf_a;
+  ASSERT_EQ(close(dmabuf_a), 0); // A's mapping stays live; the handle owns it now.
+
+  // Second BO: force a fresh memfd onto the SAME fd number A's export used, then
+  // import + map it. Under the old handle = dmabuf_fd + 1 scheme this PRIME would
+  // collide with A's still-live handle and tear down A's BO; with stable handles it
+  // must mint a distinct handle and leave A untouched.
+  int tmp = make_sized_memfd(kBoSize);
+  ASSERT_GE(tmp, 0);
+  int dmabuf_b = reused_number;
+  // If make_sized_memfd already recycled the freed number for `tmp`, it is already
+  // the reused number — dup2 onto itself then close would leave it closed, so just
+  // use it directly. Otherwise move it onto the reused number.
+  if (tmp != dmabuf_b) {
+    ASSERT_EQ(dup2(tmp, dmabuf_b), dmabuf_b);
+    ASSERT_EQ(close(tmp), 0);
+  }
+  uint32_t handle_b = 0;
+  ASSERT_TRUE(prime_import(drm, dmabuf_b, &handle_b));
+  ASSERT_NE(handle_b, 0u);
+  EXPECT_NE(handle_a, handle_b)
+      << "a recycled dmabuf fd number must not collide with a live handle";
+
+  drm_amdgpu_gem_va map_b{};
+  map_b.handle = handle_b;
+  map_b.operation = AMDGPU_VA_OP_MAP;
+  map_b.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  map_b.va_address = va_b;
+  map_b.map_size = kBoSize;
+  ASSERT_EQ(ioctl(drm, gem_va, &map_b), 0);
+  close(dmabuf_b); // B's mapping stays live via its handle.
+
+  // A must still be fully live despite B reusing its export fd number: A's own
+  // UNMAP through A's handle must still succeed (proving B's PRIME did not tear
+  // down A's mapping).
+  drm_amdgpu_gem_va unmap_a{};
+  unmap_a.handle = handle_a;
+  unmap_a.operation = AMDGPU_VA_OP_UNMAP;
+  unmap_a.va_address = va_a;
+  unmap_a.map_size = kBoSize;
+  EXPECT_EQ(ioctl(drm, gem_va, &unmap_a), 0)
+      << "reusing A's export fd number for B must not tear down A's mapping";
+
+  // Closing A's handle must not disturb B: B's UNMAP through its own handle must
+  // still succeed afterward.
+  EXPECT_EQ(gem_close(drm, handle_a), 0);
+  drm_amdgpu_gem_va unmap_b{};
+  unmap_b.handle = handle_b;
+  unmap_b.operation = AMDGPU_VA_OP_UNMAP;
+  unmap_b.va_address = va_b;
+  unmap_b.map_size = kBoSize;
+  EXPECT_EQ(ioctl(drm, gem_va, &unmap_b), 0)
+      << "closing the recycled-fd sibling handle must not tear down this BO's mapping";
+
+  EXPECT_EQ(gem_close(drm, handle_b), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+// UNMAP with a handle that does not own the exact range must fail rather than
+// tear down another handle's PTEs or report a phantom success.
+TEST(InterposerGemTest, UnmapWithWrongHandleFails) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  constexpr size_t kBoSize = 0x1000;
+  int dmabuf_a = make_sized_memfd(kBoSize);
+  ASSERT_GE(dmabuf_a, 0);
+  int dmabuf_b = make_sized_memfd(kBoSize);
+  ASSERT_GE(dmabuf_b, 0);
+  uint32_t handle_a = 0, handle_b = 0;
+  ASSERT_TRUE(prime_import(drm, dmabuf_a, &handle_a));
+  ASSERT_TRUE(prime_import(drm, dmabuf_b, &handle_b));
+
+  const unsigned long gem_va = DRM_AMDGPU_GEM_VA_request();
+  const uint64_t va_a = 0x1000000000ULL;
+  drm_amdgpu_gem_va map_a{};
+  map_a.handle = handle_a;
+  map_a.operation = AMDGPU_VA_OP_MAP;
+  map_a.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  map_a.va_address = va_a;
+  map_a.map_size = kBoSize;
+  ASSERT_EQ(ioctl(drm, gem_va, &map_a), 0);
+
+  // UNMAP of A's range through B's handle must fail (B does not own it) and leave
+  // A's mapping intact, so A's own UNMAP then succeeds.
+  drm_amdgpu_gem_va bad_unmap{};
+  bad_unmap.handle = handle_b;
+  bad_unmap.operation = AMDGPU_VA_OP_UNMAP;
+  bad_unmap.va_address = va_a;
+  bad_unmap.map_size = kBoSize;
+  EXPECT_EQ(ioctl(drm, gem_va, &bad_unmap), -1);
+
+  drm_amdgpu_gem_va good_unmap{};
+  good_unmap.handle = handle_a;
+  good_unmap.operation = AMDGPU_VA_OP_UNMAP;
+  good_unmap.va_address = va_a;
+  good_unmap.map_size = kBoSize;
+  EXPECT_EQ(ioctl(drm, gem_va, &good_unmap), 0)
+      << "A's mapping must survive a wrong-handle UNMAP attempt";
+
+  EXPECT_EQ(gem_close(drm, handle_a), 0);
+  EXPECT_EQ(gem_close(drm, handle_b), 0);
+  EXPECT_EQ(close(dmabuf_a), 0);
+  EXPECT_EQ(close(dmabuf_b), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
 }

--- a/emulation/rocjitsu/tests/interposer_dup_test.cpp
+++ b/emulation/rocjitsu/tests/interposer_dup_test.cpp
@@ -648,6 +648,20 @@ TEST(InterposerGemTest, ReplaceTransfersOwnershipAcrossOldOwnerClose) {
   replace_b.operation = AMDGPU_VA_OP_REPLACE;
   ASSERT_EQ(ioctl(drm, gem_va, &replace_b), 0);
 
+  // Ownership of the VA transferred to B: A must no longer own the range, so A's
+  // UNMAP of it fails. This is the load-bearing assertion — gem_va_unmap() reports
+  // success purely on process existence, not PTE presence, so without this negative
+  // check the later "B's UNMAP succeeds" alone could pass even if REPLACE had failed
+  // to evict A's record (A's close would then quietly tear down the shared PTE while
+  // B's bookkeeping stayed intact).
+  drm_amdgpu_gem_va unmap_a{};
+  unmap_a.handle = handle_a;
+  unmap_a.operation = AMDGPU_VA_OP_UNMAP;
+  unmap_a.va_address = va;
+  unmap_a.map_size = kBoSize;
+  EXPECT_EQ(ioctl(drm, gem_va, &unmap_a), -1)
+      << "A must not own the range after REPLACE transferred it to B";
+
   // Close A entirely. Its GEM_CLOSE reap must not unmap va — B owns it now.
   EXPECT_EQ(gem_close(drm, handle_a), 0);
   EXPECT_EQ(close(dmabuf_a), 0);

--- a/emulation/rocjitsu/tests/interposer_dup_test.cpp
+++ b/emulation/rocjitsu/tests/interposer_dup_test.cpp
@@ -486,3 +486,128 @@ TEST(InterposerGemTest, UnmapWithWrongHandleFails) {
   EXPECT_EQ(close(drm), 0);
   EXPECT_EQ(close(kfd), 0);
 }
+
+// PRIME_FD_TO_HANDLE dups the export fd internally, so the caller may close its
+// export fd BEFORE GEM_VA MAP and the deferred lazy backing mmap must still succeed
+// (the handle owns a private dup of the dmabuf that outlives the caller's fd).
+TEST(InterposerGemTest, MapSucceedsAfterExportFdClosed) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  constexpr size_t kBoSize = 0x1000;
+  int dmabuf = make_sized_memfd(kBoSize);
+  ASSERT_GE(dmabuf, 0);
+  uint32_t handle = 0;
+  ASSERT_TRUE(prime_import(drm, dmabuf, &handle));
+  ASSERT_NE(handle, 0u);
+
+  // Close the export fd BEFORE mapping. Under the old scheme (store the raw fd for a
+  // later lazy mmap) this would either fail or map an unrelated recycled fd. Force a
+  // recycle of the number so a lingering raw-fd dependency would be caught.
+  const int reused_number = dmabuf;
+  ASSERT_EQ(close(dmabuf), 0);
+  int filler = make_sized_memfd(kBoSize);
+  ASSERT_GE(filler, 0);
+  if (filler != reused_number) {
+    ASSERT_EQ(dup2(filler, reused_number), reused_number);
+    ASSERT_EQ(close(filler), 0);
+  }
+
+  const unsigned long gem_va = DRM_AMDGPU_GEM_VA_request();
+  const uint64_t va = 0x1000000000ULL;
+  drm_amdgpu_gem_va map{};
+  map.handle = handle;
+  map.operation = AMDGPU_VA_OP_MAP;
+  map.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  map.va_address = va;
+  map.map_size = kBoSize;
+  EXPECT_EQ(ioctl(drm, gem_va, &map), 0)
+      << "GEM_VA MAP must succeed via the handle's private dmabuf dup after the "
+         "caller closed (and recycled) its export fd";
+
+  drm_amdgpu_gem_va unmap{};
+  unmap.handle = handle;
+  unmap.operation = AMDGPU_VA_OP_UNMAP;
+  unmap.va_address = va;
+  unmap.map_size = kBoSize;
+  EXPECT_EQ(ioctl(drm, gem_va, &unmap), 0);
+  EXPECT_EQ(gem_close(drm, handle), 0);
+  EXPECT_EQ(close(reused_number), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+// AMDGPU_VA_OP_REPLACE at a VA that overlaps an existing mapping of a DIFFERENT size
+// must evict the old mapping (by its own extent), not silently install overlapping
+// PTEs. After a REPLACE, the old owner's stale range must be gone: its handle's UNMAP
+// of the original range must fail, and no double-unmap can occur.
+TEST(InterposerGemTest, ReplaceEvictsOverlappingDifferentSizeRange) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  constexpr size_t kBigBo = 0x4000;
+  constexpr size_t kSmallBo = 0x1000;
+  const unsigned long gem_va = DRM_AMDGPU_GEM_VA_request();
+  const uint64_t va = 0x1000000000ULL;
+
+  int dmabuf_a = make_sized_memfd(kBigBo);
+  ASSERT_GE(dmabuf_a, 0);
+  int dmabuf_b = make_sized_memfd(kSmallBo);
+  ASSERT_GE(dmabuf_b, 0);
+  uint32_t handle_a = 0, handle_b = 0;
+  ASSERT_TRUE(prime_import(drm, dmabuf_a, &handle_a));
+  ASSERT_TRUE(prime_import(drm, dmabuf_b, &handle_b));
+
+  // A maps a large range at va.
+  drm_amdgpu_gem_va map_a{};
+  map_a.handle = handle_a;
+  map_a.operation = AMDGPU_VA_OP_MAP;
+  map_a.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  map_a.va_address = va;
+  map_a.map_size = kBigBo;
+  ASSERT_EQ(ioctl(drm, gem_va, &map_a), 0);
+
+  // B REPLACEs a SMALLER range at the same base va. This overlaps A's range but is
+  // not identical; it must still evict A's mapping.
+  drm_amdgpu_gem_va replace_b{};
+  replace_b.handle = handle_b;
+  replace_b.operation = AMDGPU_VA_OP_REPLACE;
+  replace_b.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  replace_b.va_address = va;
+  replace_b.map_size = kSmallBo;
+  EXPECT_EQ(ioctl(drm, gem_va, &replace_b), 0)
+      << "REPLACE overlapping a different-size range must succeed and evict it";
+
+  // A's original range is gone: A's UNMAP of it must now fail (the record was evicted
+  // by the overlap-aware REPLACE, so A cannot double-unmap B's new PTEs).
+  drm_amdgpu_gem_va unmap_a{};
+  unmap_a.handle = handle_a;
+  unmap_a.operation = AMDGPU_VA_OP_UNMAP;
+  unmap_a.va_address = va;
+  unmap_a.map_size = kBigBo;
+  EXPECT_EQ(ioctl(drm, gem_va, &unmap_a), -1)
+      << "A's overlapping range must have been evicted by B's REPLACE";
+
+  // B's new range is live and its UNMAP succeeds exactly once.
+  drm_amdgpu_gem_va unmap_b{};
+  unmap_b.handle = handle_b;
+  unmap_b.operation = AMDGPU_VA_OP_UNMAP;
+  unmap_b.va_address = va;
+  unmap_b.map_size = kSmallBo;
+  EXPECT_EQ(ioctl(drm, gem_va, &unmap_b), 0);
+
+  EXPECT_EQ(gem_close(drm, handle_a), 0);
+  EXPECT_EQ(gem_close(drm, handle_b), 0);
+  EXPECT_EQ(close(dmabuf_a), 0);
+  EXPECT_EQ(close(dmabuf_b), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}

--- a/emulation/rocjitsu/tests/interposer_dup_test.cpp
+++ b/emulation/rocjitsu/tests/interposer_dup_test.cpp
@@ -611,3 +611,110 @@ TEST(InterposerGemTest, ReplaceEvictsOverlappingDifferentSizeRange) {
   EXPECT_EQ(close(drm), 0);
   EXPECT_EQ(close(kfd), 0);
 }
+
+// After B REPLACEs A's range, closing A must NOT tear down B's PTEs: the REPLACE
+// transferred ownership of the VA to B, so A's teardown has nothing to unmap there
+// and B's mapping stays live (its own UNMAP still succeeds afterward).
+TEST(InterposerGemTest, ReplaceTransfersOwnershipAcrossOldOwnerClose) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  constexpr size_t kBoSize = 0x1000;
+  const unsigned long gem_va = DRM_AMDGPU_GEM_VA_request();
+  const uint64_t va = 0x1000000000ULL;
+
+  int dmabuf_a = make_sized_memfd(kBoSize);
+  ASSERT_GE(dmabuf_a, 0);
+  int dmabuf_b = make_sized_memfd(kBoSize);
+  ASSERT_GE(dmabuf_b, 0);
+  uint32_t handle_a = 0, handle_b = 0;
+  ASSERT_TRUE(prime_import(drm, dmabuf_a, &handle_a));
+  ASSERT_TRUE(prime_import(drm, dmabuf_b, &handle_b));
+
+  drm_amdgpu_gem_va map_a{};
+  map_a.handle = handle_a;
+  map_a.operation = AMDGPU_VA_OP_MAP;
+  map_a.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  map_a.va_address = va;
+  map_a.map_size = kBoSize;
+  ASSERT_EQ(ioctl(drm, gem_va, &map_a), 0);
+
+  drm_amdgpu_gem_va replace_b = map_a;
+  replace_b.handle = handle_b;
+  replace_b.operation = AMDGPU_VA_OP_REPLACE;
+  ASSERT_EQ(ioctl(drm, gem_va, &replace_b), 0);
+
+  // Close A entirely. Its GEM_CLOSE reap must not unmap va — B owns it now.
+  EXPECT_EQ(gem_close(drm, handle_a), 0);
+  EXPECT_EQ(close(dmabuf_a), 0);
+
+  // B's mapping is still live: its UNMAP through its own handle succeeds.
+  drm_amdgpu_gem_va unmap_b{};
+  unmap_b.handle = handle_b;
+  unmap_b.operation = AMDGPU_VA_OP_UNMAP;
+  unmap_b.va_address = va;
+  unmap_b.map_size = kBoSize;
+  EXPECT_EQ(ioctl(drm, gem_va, &unmap_b), 0)
+      << "B's mapping must survive A's close after REPLACE transferred ownership";
+
+  EXPECT_EQ(gem_close(drm, handle_b), 0);
+  EXPECT_EQ(close(dmabuf_b), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+// AMDGPU_VA_OP_CLEAR tears down a range's PTEs and updates the owning handle's
+// bookkeeping, so a later GEM_CLOSE of that handle does not double-unmap the range.
+// A UNMAP of the cleared range must fail (it is gone), and GEM_CLOSE must still
+// succeed cleanly.
+TEST(InterposerGemTest, ClearUpdatesOwnerBookkeeping) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  constexpr size_t kBoSize = 0x1000;
+  const unsigned long gem_va = DRM_AMDGPU_GEM_VA_request();
+  const uint64_t va = 0x1000000000ULL;
+
+  int dmabuf = make_sized_memfd(kBoSize);
+  ASSERT_GE(dmabuf, 0);
+  uint32_t handle = 0;
+  ASSERT_TRUE(prime_import(drm, dmabuf, &handle));
+
+  drm_amdgpu_gem_va map{};
+  map.handle = handle;
+  map.operation = AMDGPU_VA_OP_MAP;
+  map.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  map.va_address = va;
+  map.map_size = kBoSize;
+  ASSERT_EQ(ioctl(drm, gem_va, &map), 0);
+
+  // CLEAR is handle-agnostic; it uses handle 0 and tears down whatever owns the VA.
+  drm_amdgpu_gem_va clear{};
+  clear.handle = 0;
+  clear.operation = AMDGPU_VA_OP_CLEAR;
+  clear.va_address = va;
+  clear.map_size = kBoSize;
+  EXPECT_EQ(ioctl(drm, gem_va, &clear), 0) << "CLEAR of a mapped range must succeed";
+
+  // The range is gone from the owner's bookkeeping: an UNMAP now fails.
+  drm_amdgpu_gem_va unmap{};
+  unmap.handle = handle;
+  unmap.operation = AMDGPU_VA_OP_UNMAP;
+  unmap.va_address = va;
+  unmap.map_size = kBoSize;
+  EXPECT_EQ(ioctl(drm, gem_va, &unmap), -1) << "CLEAR must have removed the range record";
+
+  // GEM_CLOSE must not double-unmap the already-cleared range.
+  EXPECT_EQ(gem_close(drm, handle), 0);
+  EXPECT_EQ(close(dmabuf), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -55,7 +55,7 @@ uint32_t query_gb_addr_config(const std::string &config_path, uint32_t gpu_id) {
   engine.topology().set_root(std::move(vm));
   loaded.wire_links(engine.topology());
   soc->wire_backing(engine.topology());
-  engine.build();
+  engine.create();
   engine.register_as_primary();
 
   driver->setup_topology(loaded.device, num_xcds);
@@ -92,7 +92,7 @@ protected:
     engine_->topology().set_root(std::move(vm));
     loaded_.wire_links(engine_->topology());
     soc->wire_backing(engine_->topology());
-    engine_->build();
+    engine_->create();
     engine_->register_as_primary();
 
     driver_->setup_topology(loaded_.device, num_xcds);

--- a/emulation/rocjitsu/tests/matmul_test.cpp
+++ b/emulation/rocjitsu/tests/matmul_test.cpp
@@ -123,7 +123,7 @@ struct KernelExecFixture {
     if (num_threads > 1)
       partition_by_xcd(num_threads);
     else
-      engine->build();
+      engine->create();
 
     Executable exec(kernel_path(kernel_name));
     ASSERT_TRUE(exec.is_valid());
@@ -156,7 +156,7 @@ struct KernelExecFixture {
           }
           return 0; // Top-level components → partition 0.
         });
-    engine->build();
+    engine->create();
   }
 
   amdgpu::GpuMemory *mem() { return gpu_mem; }
@@ -392,7 +392,7 @@ TEST(MatmulStressTest, Cdna4TopologyDispatchAndHalt) {
   auto engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
   engine->topology().set_root(loaded.take_root());
   loaded.wire_links(engine->topology());
-  engine->build();
+  engine->create();
 
   // Write a kernel descriptor + s_endpgm to GPU memory.
   using namespace rocr::llvm::amdhsa;
@@ -459,7 +459,7 @@ TEST(MatmulStressTest, Cdna4TopologyDispatchAndHalt_MultiThreaded) {
         }
         return 0;
       });
-  engine->build();
+  engine->create();
 
   using namespace rocr::llvm::amdhsa;
   kernel_descriptor_t kd{};

--- a/emulation/rocjitsu/tests/rvsim_test.cpp
+++ b/emulation/rocjitsu/tests/rvsim_test.cpp
@@ -30,7 +30,7 @@ protected:
     hart_ = static_cast<rocjitsu::risc_v::Hart *>(root_ptr->add_child(std::move(hart_ptr)));
 
     engine_->topology().set_root(std::move(root_ptr));
-    engine_->build();
+    engine_->create();
   }
 
   void load_and_run(const uint32_t *program, size_t num_words, uint64_t base_addr = 0) {

--- a/emulation/rocjitsu/tests/scalar_scc_test.cpp
+++ b/emulation/rocjitsu/tests/scalar_scc_test.cpp
@@ -200,8 +200,11 @@ public:
   }
 
   ~ScalarSccFixture() {
-    if (cu)
-      cu->reset_all_wf();
+    // A wave frees its SGPR/VGPR blocks when it halts (s_endpgm-equivalent
+    // termination), so halt the resident wave to release its resources rather
+    // than a CU-wide reset.
+    if (wf && !wf->is_halted())
+      wf->halt();
   }
 
   bool ready() const { return cu != nullptr && decoder != nullptr && wf != nullptr; }

--- a/emulation/rocjitsu/tests/scaling_test.cpp
+++ b/emulation/rocjitsu/tests/scaling_test.cpp
@@ -92,7 +92,7 @@ double run_kernel(const char *kernel_name, uint32_t N, uint32_t num_threads) {
           return 0;
         });
   }
-  engine->build();
+  engine->create();
 
   memory->load_image(reinterpret_cast<const uint8_t *>(co->image_data()), co->image_size(),
                      KD_ADDR);

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -166,7 +166,10 @@ TEST(RdnaWaitcntTest, Rdna3NamedSopkWaitcntsSetFineGrainedTargets) {
   ASSERT_NE(cu, nullptr);
 
   auto dispatch = [&]() -> amdgpu::Wavefront * {
-    cu->reset_all_wf();
+    // Recycle the single scratch slot: terminate a resident wave (freeing it) so
+    // the next dispatch has a free slot, mirroring s_endpgm on real hardware.
+    if (cu->wf(0) && !cu->wf(0)->is_halted())
+      cu->wf(0)->halt();
     auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
     EXPECT_NE(wf, nullptr);
     return wf;
@@ -575,7 +578,7 @@ TEST(MfmaExecTest, SwmmacF32K32Fp8MatchesSparseReference) {
     }
   }
 
-  cu->reset_all_wf();
+  wf->halt();
 }
 
 TEST(MfmaExecTest, WmmaF8f6f4K128InputLocUsesPairAwareSubbyteLayouts) {
@@ -1483,7 +1486,7 @@ TEST(CuFactoryTest, CdnaAccVgprsAreClearedOnRedispatch) {
     cu->write_vgpr(acc0, 0, 0xFFFFFFFFu);
     cu->write_vgpr(acc_last, 0, 0xDEADBEEFu);
 
-    cu->reset_all_wf();
+    wf->halt();
     wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
     ASSERT_NE(wf, nullptr);
 

--- a/emulation/rocjitsu/tests/simdojo_sim_test.cpp
+++ b/emulation/rocjitsu/tests/simdojo_sim_test.cpp
@@ -181,7 +181,7 @@ private:
 void build_with_manual_partitions(SimulationEngine &engine, uint32_t num_partitions,
                                   std::function<PartitionID(Component *)> assigner) {
   engine.topology().partition_manual(num_partitions, std::move(assigner));
-  engine.build();
+  engine.create();
 }
 
 /// Helper: partition by component name suffix digit (e.g., "a0" → 0, "b1" → 1).
@@ -428,7 +428,7 @@ TEST(TerminationTest, QuiescenceDetection) {
   auto root = std::make_unique<CompositeComponent>("root");
   root->add_child(std::make_unique<CounterComponent>("c0", 10));
   engine.topology().set_root(std::move(root));
-  engine.build();
+  engine.create();
   auto exit = engine.run();
 
   EXPECT_EQ(exit.reason, ExitReason::COMPLETED);
@@ -443,7 +443,7 @@ TEST(TerminationTest, AllPrimaryDoneTrigger) {
   engine.topology().set_root(std::move(root));
   engine.topology().add_link(static_cast<ProducerComponent *>(p)->out_port(),
                              static_cast<ConsumerComponent *>(c)->in_port(), 1);
-  engine.build();
+  engine.create();
   auto exit = engine.run();
 
   EXPECT_EQ(exit.reason, ExitReason::COMPLETED);
@@ -456,7 +456,7 @@ TEST(TerminationTest, MaxTicksSentinel) {
   auto root = std::make_unique<CompositeComponent>("root");
   root->add_child(std::make_unique<InfiniteComponent>("inf0"));
   engine.topology().set_root(std::move(root));
-  engine.build();
+  engine.create();
   auto exit = engine.run();
 
   EXPECT_EQ(exit.reason, ExitReason::COMPLETED);
@@ -470,7 +470,7 @@ TEST(TerminationTest, RequestExitWakesAllPartitions) {
   for (int i = 0; i < 4; ++i)
     root->add_child(std::make_unique<InfiniteComponent>("inf" + std::to_string(i)));
   engine.topology().set_root(std::move(root));
-  engine.build();
+  engine.create();
 
   // Run in background, request exit after 50ms.
   std::thread runner([&]() { engine.run(); });
@@ -489,7 +489,7 @@ TEST(TerminationTest, StepModeConsistency) {
   auto root = std::make_unique<CompositeComponent>("root");
   auto *c = root->add_child(std::make_unique<CounterComponent>("c0", 10));
   engine.topology().set_root(std::move(root));
-  engine.build();
+  engine.create();
 
   while (engine.step())
     ;
@@ -615,7 +615,7 @@ TEST(AsyncCausalityTest, ScheduleEventNowProducesReasonableTimestamp) {
   auto root = std::make_unique<CompositeComponent>("root");
   auto *c = root->add_child(std::make_unique<CounterComponent>("c0", 5));
   engine.topology().set_root(std::move(root));
-  engine.build();
+  engine.create();
 
   // Run a few steps to advance time.
   for (int i = 0; i < 3; ++i)
@@ -707,7 +707,7 @@ TEST(StressTest, AsyncInjectionDuringActiveSimulation) {
   root->add_child(std::make_unique<InfiniteComponent>("inf0"));
   root->add_child(std::make_unique<InfiniteComponent>("inf1"));
   engine.topology().set_root(std::move(root));
-  engine.build();
+  engine.create();
 
   std::atomic<uint32_t> async_processed{0};
   auto *target = engine.topology().partitions()[0].components[0];

--- a/emulation/rocjitsu/tests/simulated_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/simulated_kfd_test.cpp
@@ -67,7 +67,7 @@ TestVM create_test_vm() {
   t.engine->topology().set_root(std::move(vm));
   t.loaded.wire_links(t.engine->topology());
   soc->wire_backing(t.engine->topology());
-  t.engine->build();
+  t.engine->create();
   t.engine->register_as_primary();
 
   return t;

--- a/emulation/rocjitsu/tests/vector_add_test.cpp
+++ b/emulation/rocjitsu/tests/vector_add_test.cpp
@@ -75,7 +75,7 @@ TEST(VectorAddStressTest, AllCUsGoldenReference) {
   auto engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
   engine->topology().set_root(loaded.take_root());
   loaded.wire_links(engine->topology());
-  engine->build();
+  engine->create();
 
   // Load code into GPU memory. Place .rodata (kernel descriptor) and .text (code)
   // at their virtual addresses relative to a base. The .kd symbol value matches
@@ -170,7 +170,7 @@ TEST(VectorAddStressTest, AllCUsGoldenReference_MultiThreaded) {
         }
         return 0;
       });
-  engine->build();
+  engine->create();
 
   co->load_to_memory(memory, KD_ADDR);
   uint64_t kernel_object = KD_ADDR + co->kernel_descriptor_offset("vector_add");

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -798,6 +798,11 @@ int main(int argc, char *argv[]) {
     setenv("HSA_TOOLS_DISABLE_REGISTER", "1", 1);
     setenv("HSA_TOOLS_LIB", hooks_path.c_str(), 1);
   }
+  // Export the invocation runtime dir so every descendant (including grandchild
+  // processes spawned through wrappers like ctest) inherits the exact directory
+  // holding config_path/daemon.sock. Attach mode creates no such dir.
+  if (!attach_mode)
+    setenv(rocjitsu::kRpcInvocationDirEnv, rpc_invocation_runtime_dir(my_pid).c_str(), 1);
   execvp(app_argv[0], app_argv);
 
   std::cerr << std::format("rocjitsu: execvp failed: {}\n", strerror(errno));

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -413,10 +413,14 @@ void reap_stale_runtime_dirs() {
   std::filesystem::directory_iterator it(rpc_default_runtime_dir(), ec);
   const std::filesystem::directory_iterator end;
   for (; !ec && it != end; it.increment(ec)) {
-    // Only per-PID directories are reapable; a numeric plain file/symlink under the
-    // runtime root is not one of ours, so never remove_all it.
-    std::error_code dir_ec;
-    if (!it->is_directory(dir_ec) || dir_ec)
+    // Only real per-PID directories are reapable. Use symlink_status() (which does
+    // NOT follow the link) and require a plain directory: is_directory() follows
+    // symlinks, so a numeric symlink pointing at a directory would otherwise pass
+    // and have its target remove_all'd — never chase a symlink out of the runtime
+    // root.
+    std::error_code st_ec;
+    auto st = std::filesystem::symlink_status(it->path(), st_ec);
+    if (st_ec || st.type() != std::filesystem::file_type::directory)
       continue;
     const std::string name = it->path().filename().string();
     if (!std::all_of(name.begin(), name.end(), [](unsigned char c) { return std::isdigit(c); }))

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -252,7 +252,7 @@ void handle_client(int client_fd, rj_vm_t *vm, pid_t client_pid, std::stop_token
 
 volatile sig_atomic_t g_listen_fd = -1;
 
-int run_daemon_server(const char *config_path) {
+int run_daemon_server(const char *config_path, const std::string &socket_path = {}) {
   rj_vm_t *vm = nullptr;
   if (rj_vm_create(config_path, RJ_VM_MODE_DAEMON, &vm) != ROCJITSU_STATUS_SUCCESS) {
     std::cerr << std::format("rocjitsu: failed to create VM from {}\n", config_path);
@@ -261,7 +261,7 @@ int run_daemon_server(const char *config_path) {
 
   std::jthread engine_thread([vm]() { rj_vm_run(vm, nullptr); });
 
-  auto sock_path = rpc_default_socket_path();
+  auto sock_path = socket_path.empty() ? rpc_default_socket_path() : socket_path;
   std::filesystem::create_directories(std::filesystem::path(sock_path).parent_path());
   unlink(sock_path.c_str());
 
@@ -386,8 +386,8 @@ void prepend_env_path(const char *name, const std::string &value) {
   setenv(name, value.c_str(), 1);
 }
 
-bool write_config_file(const std::string &config_path) {
-  auto cfg_file = rpc_default_config_file_path();
+bool write_config_file(const std::string &config_path, pid_t pid) {
+  auto cfg_file = rpc_invocation_config_file_path(pid);
   std::filesystem::create_directories(std::filesystem::path(cfg_file).parent_path());
   std::ofstream ofs(cfg_file);
   if (!ofs)
@@ -396,11 +396,38 @@ bool write_config_file(const std::string &config_path) {
   return ofs.good();
 }
 
-void cleanup_runtime_files() {
-  auto cfg_file = rpc_default_config_file_path();
-  unlink(cfg_file.c_str());
-  auto sock_file = rpc_default_socket_path();
-  unlink(sock_file.c_str());
+void cleanup_runtime_files(pid_t pid) {
+  std::error_code ec;
+  std::filesystem::remove_all(rpc_invocation_runtime_dir(pid), ec);
+}
+
+// Best-effort reap of per-PID runtime dirs left behind by prior invocations that
+// exited via execvp (which never returns, so cleanup_runtime_files does not run).
+// Each numeric <pid> subdir of the runtime root is removed if that PID is no
+// longer alive, so a recycled PID cannot inherit a stale config_path/daemon.sock.
+void reap_stale_runtime_dirs() {
+  // Advance the iterator with an error_code (not the throwing operator++): another
+  // launcher may remove_all an entry concurrently, and a throw here would abort the
+  // launcher before exec. Best-effort — any filesystem error just ends the scan.
+  std::error_code ec;
+  std::filesystem::directory_iterator it(rpc_default_runtime_dir(), ec);
+  const std::filesystem::directory_iterator end;
+  for (; !ec && it != end; it.increment(ec)) {
+    const std::string name = it->path().filename().string();
+    if (!std::all_of(name.begin(), name.end(), [](unsigned char c) { return std::isdigit(c); }))
+      continue;
+    pid_t pid = 0;
+    auto [ptr, err] = std::from_chars(name.data(), name.data() + name.size(), pid);
+    if (err != std::errc{} || ptr != name.data() + name.size() || pid <= 0)
+      continue;
+    // kill(pid, 0) probes existence without signalling: ESRCH means the process
+    // is gone and its runtime dir is safe to reclaim. EPERM/success mean it is
+    // still alive (possibly another user's PID), so leave it alone.
+    if (kill(pid, 0) != 0 && errno == ESRCH) {
+      std::error_code rm_ec;
+      std::filesystem::remove_all(it->path(), rm_ec);
+    }
+  }
 }
 
 struct KfdGpuOrdinal {
@@ -684,6 +711,11 @@ int main(int argc, char *argv[]) {
 
   bool has_app = (separator_idx >= 0 && separator_idx + 1 < argc);
 
+  // Reclaim per-PID runtime dirs orphaned by prior runs (execvp never returns, so
+  // those invocations could not clean up after themselves). Done for every mode,
+  // including daemon-only, before this invocation creates its own directory.
+  reap_stale_runtime_dirs();
+
   if (daemon_mode && !has_app)
     return run_daemon_server(abs_config.c_str());
 
@@ -716,6 +748,8 @@ int main(int argc, char *argv[]) {
     }
   }
 
+  pid_t my_pid = getpid();
+
   if (attach_mode) {
     auto sock_path = rpc_default_socket_path();
     if (!std::filesystem::exists(sock_path)) {
@@ -723,6 +757,9 @@ int main(int argc, char *argv[]) {
       return 1;
     }
   } else if (daemon_mode) {
+    auto sock_path = rpc_invocation_socket_path(my_pid);
+    std::filesystem::create_directories(rpc_invocation_runtime_dir(my_pid));
+
     pid_t daemon_pid = fork();
     if (daemon_pid < 0) {
       std::cerr << std::format("rocjitsu: fork failed: {}\n", strerror(errno));
@@ -731,10 +768,9 @@ int main(int argc, char *argv[]) {
 
     if (daemon_pid == 0) {
       prctl(PR_SET_PDEATHSIG, SIGTERM);
-      return run_daemon_server(abs_config.c_str());
+      return run_daemon_server(abs_config.c_str(), sock_path);
     }
 
-    auto sock_path = rpc_default_socket_path();
     for (int i = 0; i < 300; ++i) {
       if (std::filesystem::exists(sock_path))
         break;
@@ -747,7 +783,7 @@ int main(int argc, char *argv[]) {
       return 1;
     }
   } else {
-    if (!write_config_file(abs_config)) {
+    if (!write_config_file(abs_config, my_pid)) {
       std::cerr << "rocjitsu: failed to write config file\n";
       return 1;
     }
@@ -765,6 +801,6 @@ int main(int argc, char *argv[]) {
   execvp(app_argv[0], app_argv);
 
   std::cerr << std::format("rocjitsu: execvp failed: {}\n", strerror(errno));
-  cleanup_runtime_files();
+  cleanup_runtime_files(my_pid);
   return 1;
 }

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -413,6 +413,11 @@ void reap_stale_runtime_dirs() {
   std::filesystem::directory_iterator it(rpc_default_runtime_dir(), ec);
   const std::filesystem::directory_iterator end;
   for (; !ec && it != end; it.increment(ec)) {
+    // Only per-PID directories are reapable; a numeric plain file/symlink under the
+    // runtime root is not one of ours, so never remove_all it.
+    std::error_code dir_ec;
+    if (!it->is_directory(dir_ec) || dir_ec)
+      continue;
     const std::string name = it->path().filename().string();
     if (!std::all_of(name.begin(), name.end(), [](unsigned char c) { return std::isdigit(c); }))
       continue;

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -318,6 +318,15 @@ int run_daemon_server(const char *config_path, const std::string &socket_path = 
   }
   ::close(listen_fd);
   unlink(sock_path.c_str());
+  // In daemon-with-app mode (a per-PID socket_path was supplied) the socket lives in
+  // this invocation's own <runtime>/<pid>/ directory; remove it now that the socket is
+  // gone so a normal shutdown does not leave an empty dir for a later run to reap.
+  // The default (daemon-only) socket sits directly in the shared runtime root, whose
+  // parent must never be removed — hence the socket_path.empty() guard.
+  if (!socket_path.empty()) {
+    std::error_code rm_ec;
+    std::filesystem::remove(std::filesystem::path(sock_path).parent_path(), rm_ec);
+  }
 
   rj_vm_request_exit(vm, "daemon shutdown");
   engine_thread.join();

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -396,6 +396,14 @@ int run_daemon_server(const char *config_path, const std::string &socket_path = 
   }
 
   stop_source.request_stop();
+  // Wake any client thread parked in an infinite-timeout WAIT_EVENTS ioctl before we
+  // join below. request_stop() is only observed at the top of handle_client's loop and
+  // shutdown(fd) only interrupts a thread blocked in recv() — neither unblocks a thread
+  // stuck inside a blocking ioctl on a condition variable. Closing every process fires
+  // notify_closing(), which wakes those waiters so their jthread joins can complete
+  // instead of hanging until the client happens to disconnect. A client that closes its
+  // own device concurrently just finds the process already gone.
+  rj_vm_close_all_devices(vm);
   {
     std::unordered_map<uint64_t, std::jthread> to_join;
     {

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -476,11 +476,18 @@ void cleanup_runtime_files(pid_t pid) {
 // Each numeric <pid> subdir of the runtime root is removed if that PID is no
 // longer alive, so a recycled PID cannot inherit a stale config_path/daemon.sock.
 void reap_stale_runtime_dirs() {
+  // Never iterate an empty root: directory_iterator("") scans the CWD, which would
+  // let this reaper remove_all unrelated numeric directories. rpc_default_runtime_dir()
+  // already treats a set-but-empty $ROCJITSU_RUNTIME_DIR as unset, but guard here too
+  // since the loop body deletes.
+  const std::string root = rpc_default_runtime_dir();
+  if (root.empty())
+    return;
   // Advance the iterator with an error_code (not the throwing operator++): another
   // launcher may remove_all an entry concurrently, and a throw here would abort the
   // launcher before exec. Best-effort — any filesystem error just ends the scan.
   std::error_code ec;
-  std::filesystem::directory_iterator it(rpc_default_runtime_dir(), ec);
+  std::filesystem::directory_iterator it(root, ec);
   const std::filesystem::directory_iterator end;
   for (; !ec && it != end; it.increment(ec)) {
     // Only real per-PID directories are reapable. Use symlink_status() (which does

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -269,7 +269,11 @@ void handle_client(int client_fd, rj_vm_t *vm, pid_t client_pid, std::stop_token
 
   if (process_id != 0)
     rj_vm_device_close(vm, process_id);
-  ::close(client_fd);
+  // NOTE: the client fd is intentionally NOT closed here. The spawning thread closes
+  // it under client_threads_mutex together with erasing it from active_fds, so the
+  // close and the active_fds removal are atomic w.r.t. the shutdown path — otherwise
+  // a window exists where this thread has closed the fd but not yet removed it, and
+  // teardown could shutdown() the (closed, possibly recycled) descriptor.
 }
 
 volatile sig_atomic_t g_listen_fd = -1;
@@ -281,33 +285,59 @@ int run_daemon_server(const char *config_path, const std::string &socket_path = 
     return 1;
   }
 
-  std::jthread engine_thread([vm]() { rj_vm_run(vm, nullptr); });
+  // Set up the listening socket BEFORE spawning the engine thread. rj_vm_run() blocks
+  // in engine->run() (daemon mode runs indefinitely) and the jthread destructor joins
+  // it, so if the engine thread existed during socket setup an early error return
+  // would deadlock in ~jthread. Doing all fallible socket setup first means the error
+  // paths simply destroy the VM and return with no engine thread to join.
+  auto socket_setup_failed = [&](int rc) {
+    rj_vm_destroy(vm);
+    return rc;
+  };
 
   auto sock_path = socket_path.empty() ? rpc_default_socket_path() : socket_path;
-  std::filesystem::create_directories(std::filesystem::path(sock_path).parent_path());
+  std::error_code mkdir_ec;
+  std::filesystem::create_directories(std::filesystem::path(sock_path).parent_path(), mkdir_ec);
+  if (mkdir_ec) {
+    std::cerr << std::format("rocjitsu: cannot create runtime dir for {}: {}\n", sock_path,
+                             mkdir_ec.message());
+    return socket_setup_failed(1);
+  }
   unlink(sock_path.c_str());
 
   int listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);
   if (listen_fd < 0)
-    return 1;
-  g_listen_fd = listen_fd;
+    return socket_setup_failed(1);
 
   sockaddr_un addr{};
   addr.sun_family = AF_UNIX;
+  // Reject an over-long socket path rather than silently binding a truncated one.
+  if (sock_path.size() >= sizeof(addr.sun_path)) {
+    std::cerr << std::format("rocjitsu: daemon socket path too long ({} bytes): {}\n",
+                             sock_path.size(), sock_path);
+    ::close(listen_fd);
+    return socket_setup_failed(1);
+  }
   sock_path.copy(addr.sun_path, sizeof(addr.sun_path) - 1);
 
   if (bind(listen_fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) != 0 ||
       listen(listen_fd, 16) != 0) {
     ::close(listen_fd);
-    return 1;
+    return socket_setup_failed(1);
   }
+
+  // Socket is ready; now start the engine. From here, error/normal exit must request
+  // exit and join the engine thread (see the end of this function).
+  std::jthread engine_thread([vm]() { rj_vm_run(vm, nullptr); });
+  g_listen_fd = listen_fd;
 
   std::stop_source stop_source;
   // Per-connection threads keyed by a monotonic id (never a recyclable fd number).
-  // active_fds tracks each live connection's fd for shutdown-on-teardown; a finished
-  // client removes its own fd here (its handle_client already ::close'd it) so we
-  // never shutdown() a closed-and-possibly-recycled fd. finished_ids lets the accept
-  // loop reap completed threads instead of accumulating them until server shutdown.
+  // active_fds tracks each live connection's fd for shutdown-on-teardown; a finishing
+  // client closes its fd and removes it from active_fds atomically under
+  // client_threads_mutex, so teardown never shutdown()s a closed-and-possibly-recycled
+  // fd. finished_ids lets the accept loop reap completed threads instead of
+  // accumulating them until server shutdown.
   std::unordered_map<uint64_t, std::jthread> client_threads;
   std::unordered_map<uint64_t, int> active_fds;
   std::vector<uint64_t> finished_ids;
@@ -353,9 +383,13 @@ int run_daemon_server(const char *config_path, const std::string &socket_path = 
         std::jthread([&client_threads_mutex, &active_fds, &finished_ids, conn_id, client, vm,
                       peer_pid, token = stop_source.get_token()]() {
           handle_client(client, vm, peer_pid, token);
-          // Record completion: drop our (now-closed) fd from the active set and mark
+          // Close the fd and drop it from the active set ATOMICALLY under the lock, so
+          // the teardown path (which shutdown()s every active_fds entry under the same
+          // lock) can never observe this fd after it is closed — closing it here rather
+          // than in handle_client() is what makes close+erase indivisible. Then mark
           // ourselves for reaping by the accept loop / teardown.
           std::lock_guard<std::mutex> done_lock(client_threads_mutex);
+          ::close(client);
           active_fds.erase(conn_id);
           finished_ids.push_back(conn_id);
         });

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -42,6 +42,7 @@
 #include <sys/wait.h>
 #include <thread>
 #include <unistd.h>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -85,9 +86,23 @@ void handle_client(int client_fd, rj_vm_t *vm, pid_t client_pid, std::stop_token
 
     switch (hdr.opcode) {
     case RPC_HANDSHAKE: {
+      // One connection opens exactly one device. A second HANDSHAKE would overwrite
+      // process_id without closing the first, leaking that daemon-side process (its
+      // allocations, queues, CP callbacks) until the connection tears down. Treat a
+      // repeat handshake as a protocol violation and drop the connection.
+      if (process_id != 0) {
+        RpcHeader resp{};
+        resp.opcode = hdr.opcode;
+        resp.request_id = hdr.request_id;
+        resp.result = -1;
+        rpc_send_exact(client_fd, &resp, sizeof(resp));
+        connected = false;
+        break;
+      }
       auto open_rc = rj_vm_device_open(vm, client_pid, &process_id);
       if (open_rc != ROCJITSU_STATUS_SUCCESS) {
         RpcHeader resp{};
+        resp.opcode = hdr.opcode;
         resp.request_id = hdr.request_id;
         resp.result = -1;
         rpc_send_exact(client_fd, &resp, sizeof(resp));
@@ -107,6 +122,7 @@ void handle_client(int client_fd, rj_vm_t *vm, pid_t client_pid, std::stop_token
       auto drm_len = drm ? std::strlen(drm) : 0;
 
       RpcHeader resp{};
+      resp.opcode = hdr.opcode;
       resp.request_id = hdr.request_id;
 
       RpcHandshakeResponse hs{};
@@ -130,6 +146,7 @@ void handle_client(int client_fd, rj_vm_t *vm, pid_t client_pid, std::stop_token
       rj_vm_device_close(vm, process_id);
       process_id = 0;
       RpcHeader resp{};
+      resp.opcode = hdr.opcode;
       resp.request_id = hdr.request_id;
       rpc_send_exact(client_fd, &resp, sizeof(resp));
       connected = false;
@@ -152,8 +169,12 @@ void handle_client(int client_fd, rj_vm_t *vm, pid_t client_pid, std::stop_token
       rj_vm_device_map_as(vm, process_id, &map);
 
       RpcHeader resp{};
+      resp.opcode = hdr.opcode;
       resp.request_id = hdr.request_id;
-      resp.result = (reinterpret_cast<void *>(map.mapped_addr) == MAP_FAILED) ? -errno : 0;
+      // Relay the errno captured inside rj_vm_device_map_as at the failing mmap, not
+      // this thread's errno — bookkeeping syscalls between the mmap and here could
+      // have clobbered it, sending the client a misleading error code.
+      resp.result = (reinterpret_cast<void *>(map.mapped_addr) == MAP_FAILED) ? -map.map_errno : 0;
       resp.payload_bytes = sizeof(RpcMmapResponse);
 
       RpcMmapResponse mresp{.mapped_addr = map.mapped_addr};
@@ -182,6 +203,7 @@ void handle_client(int client_fd, rj_vm_t *vm, pid_t client_pid, std::stop_token
       rj_vm_device_unmap_as(vm, process_id, &unmap);
 
       RpcHeader resp{};
+      resp.opcode = hdr.opcode;
       resp.request_id = hdr.request_id;
       rpc_send_exact(client_fd, &resp, sizeof(resp));
       break;
@@ -214,7 +236,7 @@ void handle_client(int client_fd, rj_vm_t *vm, pid_t client_pid, std::stop_token
         ::close(cmd.in_handle);
 
       RpcHeader resp{};
-      resp.opcode = RPC_IOCTL;
+      resp.opcode = hdr.opcode;
       resp.request_id = hdr.request_id;
       resp.result = cmd.result;
       resp.payload_bytes = static_cast<uint32_t>(cmd.buf_size);
@@ -281,9 +303,16 @@ int run_daemon_server(const char *config_path, const std::string &socket_path = 
   }
 
   std::stop_source stop_source;
-  std::vector<std::jthread> client_threads;
-  std::vector<int> active_client_fds;
+  // Per-connection threads keyed by a monotonic id (never a recyclable fd number).
+  // active_fds tracks each live connection's fd for shutdown-on-teardown; a finished
+  // client removes its own fd here (its handle_client already ::close'd it) so we
+  // never shutdown() a closed-and-possibly-recycled fd. finished_ids lets the accept
+  // loop reap completed threads instead of accumulating them until server shutdown.
+  std::unordered_map<uint64_t, std::jthread> client_threads;
+  std::unordered_map<uint64_t, int> active_fds;
+  std::vector<uint64_t> finished_ids;
   std::mutex client_threads_mutex;
+  uint64_t next_conn_id = 1;
 
   std::signal(SIGINT, [](int) {
     int fd = g_listen_fd;
@@ -298,6 +327,18 @@ int run_daemon_server(const char *config_path, const std::string &socket_path = 
       shutdown(fd, SHUT_RDWR);
   });
 
+  // Join and erase any threads that finished since the last accept. Caller holds
+  // client_threads_mutex. Draining a moved-out jthread list under the lock is safe:
+  // each id in finished_ids belongs to a thread that has run to completion and only
+  // needs its handle joined (the jthread destructor does that on erase).
+  auto reap_finished = [&]() {
+    for (uint64_t id : finished_ids) {
+      active_fds.erase(id);
+      client_threads.erase(id);
+    }
+    finished_ids.clear();
+  };
+
   while (g_listen_fd >= 0) {
     int client = accept(listen_fd, nullptr, nullptr);
     if (client < 0)
@@ -305,16 +346,36 @@ int run_daemon_server(const char *config_path, const std::string &socket_path = 
 
     pid_t peer_pid = peer_pid_for_socket(client);
     std::lock_guard<std::mutex> lock(client_threads_mutex);
-    active_client_fds.push_back(client);
-    client_threads.emplace_back(handle_client, client, vm, peer_pid, stop_source.get_token());
+    reap_finished();
+    uint64_t conn_id = next_conn_id++;
+    active_fds[conn_id] = client;
+    client_threads[conn_id] =
+        std::jthread([&client_threads_mutex, &active_fds, &finished_ids, conn_id, client, vm,
+                      peer_pid, token = stop_source.get_token()]() {
+          handle_client(client, vm, peer_pid, token);
+          // Record completion: drop our (now-closed) fd from the active set and mark
+          // ourselves for reaping by the accept loop / teardown.
+          std::lock_guard<std::mutex> done_lock(client_threads_mutex);
+          active_fds.erase(conn_id);
+          finished_ids.push_back(conn_id);
+        });
   }
 
   stop_source.request_stop();
   {
-    std::lock_guard<std::mutex> lock(client_threads_mutex);
-    for (int fd : active_client_fds)
-      shutdown(fd, SHUT_RDWR);
-    client_threads.clear();
+    std::unordered_map<uint64_t, std::jthread> to_join;
+    {
+      std::lock_guard<std::mutex> lock(client_threads_mutex);
+      reap_finished();
+      for (const auto &[conn_id, fd] : active_fds)
+        shutdown(fd, SHUT_RDWR);
+      // Move the threads OUT and join them below without holding the mutex: a client
+      // thread's completion lambda takes client_threads_mutex, so joining while
+      // holding it would deadlock against a thread mid-completion.
+      to_join = std::move(client_threads);
+      client_threads.clear();
+    }
+    to_join.clear(); // ~jthread joins each, off-lock.
   }
   ::close(listen_fd);
   unlink(sock_path.c_str());


### PR DESCRIPTION
## Motivation

rocjitsu runs unmodified ROCr/HIP applications against an emulated AMD GPU by intercepting /dev/kfd + DRM render-node ioctls (LD_PRELOAD interposer + SimulatedKfd driver) and executing kernels on the simdojo simulation engine. As coverage grew to multi-process workloads (RCCL collectives via a shared daemon), real Triton/HIP dispatch, and multi-GPU topologies, several classes of latent defect surfaced — process-teardown races, doorbell/dispatch-lifecycle bugs, GEM/fd leaks, and a severe RCCL performance regression. This PR hardens the KFD driver, command processor (CP), dispatch lifecycle, and the multi-process/daemon runtime so the emulator is correct and deterministic under concurrency and load.

## Technical Details

Command processor & dispatch lifecycle

  - Hardware-accurate wavefront termination. s_endpgm/halt() now frees a wave's SGPR/VGPR immediately and notifies the CP as one action (matching real HW),
  replacing the old lazy two-phase retire_halted_wfs*. num_wfs() now counts resident (non-halted) waves. This removes an event-ordering nondeterminism where
   a stray empty CU tick could free halted waves and make dispatch-count assertions flaky in full-suite runs.
  - Lost-doorbell fix on recycled queue slots. Doorbell offsets recycled via free_doorbell_offsets retained the prior queue's last-rung write index;
  combined with the CP's last_doorbell = ~0 init, a poll-thread scan in the register→ring window could latch a stale value and drop the next submission —
  hanging the host in hsa_signal_wait. Recycled slots are now reset to the ~0 sentinel at queue creation.
  - Cluster dispatch is now all-or-nothing. A clustered (gfx1250) dispatch that fails partway (dispatch_wf null or a malformed-kernarg/TTMP throw) now rolls
   back already-committed peers (abort_workgroup + erase_cluster_workgroup) instead of orphaning WG refcounts and LDS pins.
  - Inline CU dispatch continuation on CU-idle (avoids a per-step tick of latency across the many tiny kernels of a collective), plus a schedule_work()
  guard that never wakes an idle CU.

  RCCL / daemon performance

  - Eliminated a busy-wait on external dependency stalls. Barrier/dependency/SDMA-wait stalls were rescheduled on the MAIN (simulated-time) event queue via
  now+1, spinning millions of ticks per collective while real wall-clock RPC latency elapsed (~7–8× RCCL slowdown). arm_stall_recheck() now routes
  host-accessible (KFD) queues — which have a doorbell poll thread — to a paced 100 µs re-check via stall_pending_, keeping the MAIN queue for
  simulated-world timing only; internal test queues (no poll thread) keep the now+1 fallback.

  Multi-process / daemon runtime

  - Per-PID runtime directories for sockets and config handoff, inherited by descendants via $ROCJITSU_INVOCATION_DIR, eliminating stale-socket/config
  collisions across concurrent invocations; stale dead-PID dirs are reaped with a kill(pid,0) liveness check and symlink-safe teardown.
  - Daemon teardown wakes parked waiters. A client thread blocked in an infinite-timeout WAIT_EVENTS ioctl cannot be interrupted by stop_token or
  shutdown(fd); teardown now calls rj_vm_close_all_devices → close_all_processes, which drains each process's open-refcount to fire notify_closing() and
  unblock the join.
  - Daemon startup ordering (bind/listen before spawning the engine thread so error paths have nothing to join) and atomic client-fd close+erase under
  client_threads_mutex.
  - Local-mode engine thread is joined at exit. The interposer's local VM engine thread was detached and never stopped, so process exit() ran librocjitsu's
  static destructors while the engine was still in CommandProcessor::startup() — a use-after-free SIGSEGV that flaked under ctest -jN. The thread is now
  joinable and stopped/joined from an early (destructor(101)) hook before library teardown.

  GEM / DRM memory & fd lifetime

  - AMDGPU_GEM_VA MAP/REPLACE/UNMAP/CLEAR with interval-overlap matching for vmem GPU page-table mapping; PRIME_FD_TO_HANDLE mints stable monotonic handles
  and dup()s the dmabuf fd; GEM handles are reaped at DRM-file close and dup2/dup3 overwrite.
  - fork safety: reset_after_fork closes owned dmabuf dups before clearing GEM tables; async-signal-safety of the atfork child path documented.
  - Fixed premature munmap on close() via host_ptr ownership tracking, and a pending_gem_flags_ leak on dup2/dup3 target overwrite.

Config handoff

  - Three-tier config-path resolution ($ROCJITSU_INVOCATION_DIR → per-PID → well-known), applied consistently in the interposer, the DBT-guest loader, and
  the test helper; empty env vars treated as unset; bare-LD_PRELOAD clients fall back to the well-known location.

  simdojo engine

  - First-event self-scheduling moved from initialize() to startup() (so it runs after topology is frozen/partitioned); lock-free async-event drain via a
  pending double-checked flag; spin-based idle wait with no lost-wakeup between request_exit() and wait entry; improved run/dispatch flow.
  - Multi-GPU naming fix: each SoC is wrapped in a uniquely-named gpuN node so multi-GPU topologies no longer collide on the shared "soc" name (which had
  routed both GPUs' links to the same CUs).

  Tests & docs

  - New HaltSnapshotPlugin records wavefront register/exec/TID state at halt (reading live registers before they free), letting value/distribution tests
  observe dispatch results deterministically without reading freed slots; broad test migration to the new resident-num_wfs() semantics.
  - New interposer GEM/dup fd-lifetime tests; widened DBT dispatch completion-signal wait into a hang guard; updated vm-design.md / simdojo.md.

  Testing

  - Full serial Release ctest suite passes (daemon/RCCL tests are timing-sensitive and are run serially).
  - The previously-flaky CI hang (Cdna4ToCdna3SimulatedDispatchTest.TritonDynamicMatmulDispatchAndRun) is fixed and verified 40/40 under 2-core
  CPU-starvation repro (was a deterministic hang before).
  - The -jN interposer SIGSEGV is fixed and verified 0 failures across -j16×12 and -j32×15 over the Interposer/Daemon/GuestKfd suites (≈50% crash rate
  before).

## JIRA ID

N/A

PR #8672

## Test Plan

Run all CI tests
Run all rocjitsu test corpus tests

## Test Result

All CI tests: PASSED
All rocjitsu test corpus tests: PASSED

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
