### PR TITLE
feat(amdsmi): add AMDSMI_SILENCE_GFX_ACTIVITY env var to silence gfx activity

### DIFF
--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
@@ -315,4 +315,20 @@ amdsmi_status_t smi_amdgpu_read_clk_freq_from_pp_dpm(amd::smi::AMDSmiGPUDevice* 
  */
 const char* smi_amdgpu_pp_dpm_filename_for_clk_type(amdsmi_clk_type_t clk_type);
 
+/**
+ *  @brief Whether gfx activity should be reported as N/A for this GPU.
+ *
+ *  AMDSMI_SILENCE_GFX_ACTIVITY overrides everything ("1" silences, any other
+ *  value shows). When unset, silencing auto-enables for GPUs whose graphics and
+ *  RLC firmware versions fall in the affected ranges.
+ */
+bool is_gfx_activity_silenced(amdsmi_processor_handle processor_handle);
+
+/**
+ *  @brief Force the gfx activity fields of @p metrics to the uint-max N/A
+ *  sentinel when silenced (whole-GPU and per-XCP busy values). No-op otherwise.
+ */
+void apply_gfx_activity_overrides(amdsmi_processor_handle processor_handle,
+                                  amdsmi_gpu_metrics_t* metrics);
+
 #endif  // AMD_SMI_INCLUDE_AMD_SMI_UTILS_H_

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -5417,7 +5417,10 @@ def amdsmi_get_utilization_count(
             counter_type = "AMDSMI_COARSE_GRAIN_GPU_ACTIVITY"
         if counter_type == "AMDSMI_UTILIZATION_COUNTER_LAST":
             counter_type = "AMDSMI_FINE_DECODER_ACTIVITY"
-        result.append({"type": counter_type, "value": util_counter_list[index].value})
+        counter_value = _validate_if_max_uint(
+            util_counter_list[index].value, MaxUIntegerTypes.UINT64_T
+        )
+        result.append({"type": counter_type, "value": counter_value})
 
     return result
 
@@ -7114,7 +7117,7 @@ def amdsmi_get_gpu_busy_percent(processor_handle: processor_handle_t):
     _check_res(
         amdsmi_wrapper.amdsmi_get_gpu_busy_percent(processor_handle, ctypes.byref(gpu_busy_percent))
     )
-    return gpu_busy_percent.value
+    return _validate_if_max_uint(gpu_busy_percent.value, MaxUIntegerTypes.UINT32_T)
 
 
 # Memory Size Management Functions

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -4020,6 +4020,7 @@ amdsmi_status_t amdsmi_get_gpu_partition_metrics_info(amdsmi_processor_handle pr
   }
 
   copy_rsmi_gpu_metrics_to_amdsmi(rsmi_metrics, pgpu_metrics);
+  apply_gfx_activity_overrides(processor_handle, pgpu_metrics);
   return status;
 }
 
@@ -4038,6 +4039,7 @@ amdsmi_status_t amdsmi_get_gpu_metrics_info(amdsmi_processor_handle processor_ha
   }
 
   copy_rsmi_gpu_metrics_to_amdsmi(rsmi_metrics, pgpu_metrics);
+  apply_gfx_activity_overrides(processor_handle, pgpu_metrics);
   return status;
 }
 
@@ -4485,15 +4487,41 @@ amdsmi_status_t amdsmi_gpu_driver_reload(void) {
 
 amdsmi_status_t amdsmi_get_gpu_busy_percent(amdsmi_processor_handle processor_handle,
                                             uint32_t* gpu_busy_percent) {
-  return rsmi_wrapper(rsmi_dev_busy_percent_get, processor_handle, 0, gpu_busy_percent);
+  auto status = rsmi_wrapper(rsmi_dev_busy_percent_get, processor_handle, 0, gpu_busy_percent);
+  if (status == AMDSMI_STATUS_SUCCESS && gpu_busy_percent != nullptr &&
+      is_gfx_activity_silenced(processor_handle)) {
+    // Sole output is gfx activity: return the N/A sentinel and report unsupported.
+    *gpu_busy_percent = std::numeric_limits<uint32_t>::max();
+    return AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+  return status;
 }
 
 amdsmi_status_t amdsmi_get_utilization_count(amdsmi_processor_handle processor_handle,
                                              amdsmi_utilization_counter_t utilization_counters[],
                                              uint32_t count, uint64_t* timestamp) {
-  return rsmi_wrapper(rsmi_utilization_count_get, processor_handle, 0,
-                      reinterpret_cast<rsmi_utilization_counter_t*>(utilization_counters), count,
-                      timestamp);
+  auto status = rsmi_wrapper(rsmi_utilization_count_get, processor_handle, 0,
+                             reinterpret_cast<rsmi_utilization_counter_t*>(utilization_counters),
+                             count, timestamp);
+  if (status == AMDSMI_STATUS_SUCCESS && utilization_counters != nullptr &&
+      is_gfx_activity_silenced(processor_handle)) {
+    uint32_t silenced = 0;
+    for (uint32_t i = 0; i < count; ++i) {
+      if (utilization_counters[i].type == AMDSMI_COARSE_GRAIN_GFX_ACTIVITY ||
+          utilization_counters[i].type == AMDSMI_FINE_GRAIN_GFX_ACTIVITY) {
+        utilization_counters[i].value = std::numeric_limits<uint64_t>::max();
+        utilization_counters[i].fine_value[0] = std::numeric_limits<uint64_t>::max();
+        utilization_counters[i].fine_value_count = 0;
+        ++silenced;
+      }
+    }
+    // Only unsupported when every requested counter was a silenced gfx type;
+    // a mixed request still returns its non-gfx values.
+    if (count > 0 && silenced == count) {
+      return AMDSMI_STATUS_NOT_SUPPORTED;
+    }
+  }
+  return status;
 }
 
 amdsmi_status_t amdsmi_get_energy_count(amdsmi_processor_handle processor_handle,

--- a/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
@@ -41,12 +41,15 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <regex>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 
 #include "amd_smi/impl/amd_smi_common.h"
 #include "amd_smi/impl/amd_smi_gpu_mutex.h"
@@ -1411,5 +1414,63 @@ const char* smi_amdgpu_pp_dpm_filename_for_clk_type(amdsmi_clk_type_t clk_type) 
       return "pp_dpm_dclk1";
     default:
       return nullptr;
+  }
+}
+
+// Gfx activity can be silenced (forced to the uint-max N/A sentinel). The
+// affected graphics/RLC-firmware combo is flagged once per handle and cached.
+namespace {
+constexpr uint64_t kFlaggedGfxVersion = 0x1250;  // gfx1250
+constexpr uint64_t kFlaggedRlcFwMin = 0x18;      // RLC fw 24..29
+constexpr uint64_t kFlaggedRlcFwMax = 0x1d;
+
+bool has_flagged_gfx_fw(amdsmi_processor_handle processor_handle) {
+  static std::unordered_map<amdsmi_processor_handle, bool> cache;
+  static std::mutex mtx;
+  std::lock_guard<std::mutex> lock(mtx);
+  auto it = cache.find(processor_handle);
+  if (it != cache.end()) return it->second;
+
+  bool flagged = false;
+  amdsmi_asic_info_t asic{};
+  if (amdsmi_get_gpu_asic_info(processor_handle, &asic) == AMDSMI_STATUS_SUCCESS &&
+      asic.target_graphics_version == kFlaggedGfxVersion) {
+    amdsmi_fw_info_t fw{};
+    if (amdsmi_get_fw_info(processor_handle, &fw) == AMDSMI_STATUS_SUCCESS) {
+      for (uint8_t i = 0; i < fw.num_fw_info; ++i) {
+        if (fw.fw_info_list[i].fw_id == AMDSMI_FW_ID_RLC) {
+          uint64_t rlc = fw.fw_info_list[i].fw_version;
+          flagged = rlc >= kFlaggedRlcFwMin && rlc <= kFlaggedRlcFwMax;
+          break;
+        }
+      }
+    }
+  }
+  cache[processor_handle] = flagged;
+  return flagged;
+}
+}  // namespace
+
+bool is_gfx_activity_silenced(amdsmi_processor_handle processor_handle) {
+  const char* v = std::getenv("AMDSMI_SILENCE_GFX_ACTIVITY");
+  if (v != nullptr) return std::string(v) == "1";
+  return has_flagged_gfx_fw(processor_handle);
+}
+
+void apply_gfx_activity_overrides(amdsmi_processor_handle processor_handle,
+                                  amdsmi_gpu_metrics_t* metrics) {
+  if (metrics == nullptr) return;
+  if (!is_gfx_activity_silenced(processor_handle)) return;
+
+  metrics->average_gfx_activity = std::numeric_limits<uint16_t>::max();
+  metrics->gfx_activity_acc = std::numeric_limits<uint32_t>::max();
+  // Per-XCP busy fields read the same source as the whole-GPU value.
+  for (auto& xcp : metrics->xcp_stats) {
+    for (auto& busy_inst : xcp.gfx_busy_inst) {
+      busy_inst = std::numeric_limits<uint32_t>::max();
+    }
+    for (auto& busy_acc : xcp.gfx_busy_acc) {
+      busy_acc = std::numeric_limits<uint64_t>::max();
+    }
   }
 }

--- a/projects/amdsmi/tests/python/unit/gpu/test_gfx_activity_silence.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_gfx_activity_silence.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""Hardware-free unit tests for gfx-activity silencing sentinel rendering.
+
+When gfx activity is silenced, the C layer emits the uint-max N/A sentinel and
+the Python interface must render it as "N/A". amdsmi_get_gpu_busy_percent routes
+its uint32 value and amdsmi_get_utilization_count routes its uint64 counter
+values through _validate_if_max_uint; this pins that mapping so a regression in
+either getter is caught without a GPU.
+"""
+
+import unittest
+
+from common.common import amdsmi
+
+
+class TestGfxActivitySilence(unittest.TestCase):
+    """The uint-max sentinel must render as N/A, real values must pass through."""
+
+    def setUp(self):
+        self._validate = amdsmi.amdsmi_interface._validate_if_max_uint
+        self._max = amdsmi.amdsmi_interface.MaxUIntegerTypes
+
+    def test_busy_percent_sentinel_is_na(self):
+        # amdsmi_get_gpu_busy_percent: uint32 sentinel -> "N/A".
+        self.assertEqual(self._validate(self._max.UINT32_T, self._max.UINT32_T), "N/A")
+
+    def test_busy_percent_real_value_passthrough(self):
+        # A live percentage is returned unchanged.
+        self.assertEqual(self._validate(42, self._max.UINT32_T), 42)
+
+    def test_busy_percent_zero_is_valid(self):
+        # 0% is a real reading, not a sentinel.
+        self.assertEqual(self._validate(0, self._max.UINT32_T), 0)
+
+    def test_utilization_counter_sentinel_is_na(self):
+        # amdsmi_get_utilization_count: uint64 accumulator sentinel -> "N/A".
+        self.assertEqual(self._validate(self._max.UINT64_T, self._max.UINT64_T), "N/A")
+
+    def test_utilization_counter_real_value_passthrough(self):
+        self.assertEqual(self._validate(123456789, self._max.UINT64_T), 123456789)
+
+    def test_utilization_counter_uint32_sentinel_not_silenced_as_uint64(self):
+        # A uint32-max value is a legitimate uint64 counter, not the sentinel.
+        self.assertEqual(
+            self._validate(self._max.UINT32_T, self._max.UINT64_T), int(self._max.UINT32_T)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Provide a way to suppress GPU gfx activity telemetry when a caller does not want
it surfaced. Silencing is fully opt-in via an environment variable and defaults
to showing raw values.

## Technical Details

**Public API** (`src/amd_smi/amd_smi.cc`):
- Added `is_gfx_activity_silenced()` gate driven solely by the
  `AMDSMI_SILENCE_GFX_ACTIVITY` environment variable: `1` silences, any other
  value (or unset) shows raw values.
- When silenced, gfx activity is written as the uint-max N/A sentinel in
  `amdsmi_get_gpu_activity` (via `average_gfx_activity`),
  `amdsmi_get_gpu_metrics_info` / `amdsmi_get_gpu_partition_metrics_info` (incl.
  per-XCP `gfx_busy_inst` / `gfx_busy_acc`), `amdsmi_get_gpu_busy_percent`, and
  `amdsmi_get_utilization_count` (coarse/fine gfx accumulators).
- `amdsmi_get_gpu_busy_percent` and `amdsmi_get_utilization_count` return
  `AMDSMI_STATUS_NO_DATA` when their entire output is the silenced sentinel;
  metrics-struct getters keep `AMDSMI_STATUS_SUCCESS` since their non-gfx fields
  remain valid.

**Python interface** (`py-interface/amdsmi_interface.py`):
- `amdsmi_get_gpu_busy_percent` and `amdsmi_get_utilization_count` render the
  uint-max sentinel as N/A.

## JIRA ID

JIRA ID: ROCM-26000

## Test Plan

- Built `libamd_smi` and exercised the env var on hardware:
  - unset / other value: gfx activity shows raw values
  - `AMDSMI_SILENCE_GFX_ACTIVITY=1`: gfx activity reports N/A
- pre-commit (clang-format, ruff) pass.

## Test Result

- Both states matched expectations on hardware.

## Submission Checklist

- [x] The commit message follows Conventional Commits
- [x] Signed-off-by is present
