### PR TITLE
fix(rccl): allow HSA DMA-BUF fallback when cuMem is disabled 

### DIFF
--- a/projects/rccl/src/transport/coll_net.cc
+++ b/projects/rccl/src/transport/coll_net.cc
@@ -560,9 +560,8 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
     (void)close(dmabuf_fd);
     needReg = false;
   }
-peermem_send:
-#else
-  if (resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
+#endif
+  if (needReg && resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
       proxyState->ncclCollNet->regMrDmaBuf) {
     uint64_t offset;
     HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)mapMem->cpuPtr, mapMem->size, &dmabuf_fd, &offset), ret,
@@ -575,7 +574,6 @@ peermem_send:
     needReg = false;
   }
 peermem_send:
-#endif
   if (needReg) {
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
                                                  resources->useGdr ? NCCL_PTR_CUDA : NCCL_PTR_HOST,
@@ -672,9 +670,8 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
     (void)close(dmabuf_fd);
     needReg = false;
   }
-peermem_recv:
-#else
-  if (resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
+#endif
+  if (needReg && resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
       proxyState->ncclCollNet->regMrDmaBuf) {
     uint64_t offset;
     HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)mapMem->cpuPtr, mapMem->size, &dmabuf_fd, &offset), ret,
@@ -687,7 +684,6 @@ peermem_recv:
     needReg = false;
   }
 peermem_recv:
-#endif
   if (needReg) {
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
                                                  resources->useGdr ? NCCL_PTR_CUDA : NCCL_PTR_HOST,
@@ -1491,9 +1487,8 @@ static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, s
     dmabuf_fd = -1;
     needReg = false;
   }
-peermem:
-#else
-  if (resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
+#endif
+  if (needReg && resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
       proxyState->ncclCollNet->regMrDmaBuf) {
     uint64_t offset;
     HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret,
@@ -1506,7 +1501,6 @@ peermem:
     needReg = false;
   }
 peermem:
-#endif
   if (needReg) {
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA,
                                                  &handle),
@@ -1553,9 +1547,8 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
     dmabuf_fd = -1;
     needReg = false;
   }
-peermem:
-#else
-  if (resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
+#endif
+  if (needReg && resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
       proxyState->ncclCollNet->regMrDmaBuf) {
     uint64_t offset;
     HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret,
@@ -1568,7 +1561,6 @@ peermem:
     needReg = false;
   }
 peermem:
-#endif
   if (needReg) {
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA,
                                                  &handle),

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -1291,9 +1291,9 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     resources->buffers[p] = NCCL_NET_MAP_GET_POINTER(map, cpu, buffs[p]);
     if (resources->buffers[p]) {
+      int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
 #if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
       /* DMA-BUF support */
-      int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
       if (type == NCCL_PTR_CUDA && resources->useDmaBuf && ncclCuMemEnable()) {
         int bank = NCCL_NET_MAP_OFFSET_BANK(map, buffs[p]);
         if (bank == NCCL_NET_MAP_DEVMEM && map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd >= 0) {
@@ -1311,10 +1311,8 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
                                                      &resources->mhandles[p]));
           (void)close(dmabuf_fd);
         }
-      } else // FALL-THROUGH to nv_peermem GDR path
-#else
-      /* DMA-BUF support */
-      int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
+      } else
+#endif
       if (type == NCCL_PTR_CUDA && resources->useDmaBuf && proxyState->dmaBufSupport &&
           pfn_hsa_amd_portable_export_dmabuf) {
         int dmabuf_fd;
@@ -1328,10 +1326,9 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
         TRACE(NCCL_INIT | NCCL_NET, "hsa_amd_portable_export_dmabuf buffer %p size %d handle %x offset %ld",
               (const void*)resources->buffers[p], resources->buffSizes[p], dmabuf_fd, offset);
       } else // FALL-THROUGH to nv_peermem GDR path
-#endif
       {
         NCCLCHECK(proxyState->ncclNet->regMr(resources->netSendComm, resources->buffers[p], resources->buffSizes[p],
-                                             NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST,
+                                             type,
                                              &resources->mhandles[p]));
       }
 
@@ -1530,9 +1527,9 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     resources->buffers[p] = NCCL_NET_MAP_GET_POINTER(map, cpu, buffs[p]);
     if (resources->buffers[p]) {
+      int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
 #if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
       /* DMA-BUF support */
-      int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
       if (type == NCCL_PTR_CUDA && resources->useDmaBuf && ncclCuMemEnable()) {
         int bank = NCCL_NET_MAP_OFFSET_BANK(map, buffs[p]);
         if (bank == NCCL_NET_MAP_DEVMEM && map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd >= 0) {
@@ -1550,10 +1547,8 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
                                                      &resources->mhandles[p]));
           (void)close(dmabuf_fd);
         }
-      } else // FALL-THROUGH to nv_peermem GDR path
-#else
-      /* DMA-BUF support */
-      int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
+      } else
+#endif
       if (type == NCCL_PTR_CUDA && resources->useDmaBuf && proxyState->dmaBufSupport &&
           pfn_hsa_amd_portable_export_dmabuf) {
         int dmabuf_fd;
@@ -1567,10 +1562,9 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
         TRACE(NCCL_INIT | NCCL_NET, "hsa_amd_portable_export_dmabuf buffer %p size %d handle %x offset %ld",
               (const void*)resources->buffers[p], resources->buffSizes[p], dmabuf_fd, offset);
       } else // FALL-THROUGH to nv_peermem GDR path
-#endif
       {
         NCCLCHECK(proxyState->ncclNet->regMr(resources->netRecvComm, resources->buffers[p], resources->buffSizes[p],
-                                             NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST,
+                                             type,
                                              &resources->mhandles[p]));
       }
 
@@ -2396,9 +2390,8 @@ static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, s
     (void)close(dmabuf_fd);
     needReg = false;
   }
-peermem:
-#else
-  if (resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf) {
+#endif
+  if (needReg && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf) {
     int dmabuf_fd;
     uint64_t offset;
     HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret,
@@ -2410,7 +2403,6 @@ peermem:
     needReg = false;
   }
 peermem:
-#endif
   if (needReg) {
     // Non-dmabuf regMr does not support multiple physical segments
     if (numSegments > 1) {
@@ -2468,9 +2460,8 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
     (void)close(dmabuf_fd);
     needReg = false;
   }
-peermem:
-#else
-  if (resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf) {
+#endif
+  if (needReg && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf) {
     int dmabuf_fd;
     uint64_t offset;
     HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret,
@@ -2482,7 +2473,6 @@ peermem:
     needReg = false;
   }
 peermem:
-#endif
   if (needReg) {
     // Non-dmabuf regMr does not support multiple physical segments
     if (numSegments > 1) {


### PR DESCRIPTION
## Motivation

Follow-up fix for #2758. The version-gated `#if/#else/#endif` blocks in `coll_net.cc` and `net.cc` prevented the `pfn_hsa_amd_portable_export_dmabuf` path from being compiled when `NCCL_CUMEM_DMABUF_EXPORT_GATE` evaluates to true (HIP > 71260540). This meant that on systems where `ncclCuMemEnable()` returns false, DMA-BUF registration via HSA was unreachable and fell through directly to plain `regMr`.


## Technical Details

Move the HSA DMA-BUF path outside the version gate so it is always compiled as a runtime fallback. The registration priority becomes:

1. **cuMem path** (`cuMemGetHandleForAddressRange`) — version-gated, requires `ncclCuMemEnable()`
2. **HSA path** (`pfn_hsa_amd_portable_export_dmabuf`) — always available as fallback
3. **Plain `regMr`** — final fallback

Additionally, in `net.cc`, the duplicated `int type = ...` declaration is hoisted before the `#if` block to eliminate the now-unnecessary `#else` branch.


## Test Plan

I encountered this issue and verified this pr on my RDNA R9700 systems which seems not support cumem.

## Test Result

Verified with multi-node RCCL communication tests on R9700 systems where `ncclCuMemEnable()` returns false.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
