### PR TITLE
feat(clr): add metadata in HRR capture stage

### DIFF
--- a/projects/clr/hipamd/src/hrr/CMakeLists.txt
+++ b/projects/clr/hipamd/src/hrr/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 target_sources(amdhip64 PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/hip_capture.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip_capture_metadata.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/hip_capture_writer.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/hip_capture_generated.cpp
 )

--- a/projects/clr/hipamd/src/hrr/hip_capture.cpp
+++ b/projects/clr/hipamd/src/hrr/hip_capture.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "hip_capture.h"
+#include "hip_capture_metadata.h"
 #include "hip_capture_writer.h"
 
 // hrr_api_args.h — for hrr_args_* struct types and hrr_api_id_t enum
@@ -1475,6 +1476,9 @@ void hip_capture_init() {
 
   // Open the events writer now — Flag::init() has run so output_dir is valid.
   if (!hrr_cap::writer::open(hip_capture_output_dir())) return;
+
+  hrr_cap::writer::set_capture_metadata_json(
+      hrr_cap::metadata::collect_json());
 
   hrr_install_clr_exception_handler();
 

--- a/projects/clr/hipamd/src/hrr/hip_capture.cpp
+++ b/projects/clr/hipamd/src/hrr/hip_capture.cpp
@@ -29,7 +29,6 @@
  */
 
 #include "hip_capture.h"
-#include "hip_capture_metadata.h"
 #include "hip_capture_writer.h"
 
 // hrr_api_args.h — for hrr_args_* struct types and hrr_api_id_t enum
@@ -1476,9 +1475,6 @@ void hip_capture_init() {
 
   // Open the events writer now — Flag::init() has run so output_dir is valid.
   if (!hrr_cap::writer::open(hip_capture_output_dir())) return;
-
-  hrr_cap::writer::set_capture_metadata_json(
-      hrr_cap::metadata::collect_json());
 
   hrr_install_clr_exception_handler();
 

--- a/projects/clr/hipamd/src/hrr/hip_capture_metadata.cpp
+++ b/projects/clr/hipamd/src/hrr/hip_capture_metadata.cpp
@@ -14,7 +14,11 @@
 #include <string>
 #include <vector>
 
-#include "../hip_internal.hpp"  // hip::g_devices, hip::ihipGetDeviceProperties
+namespace hip {
+class Device;
+extern std::vector<hip::Device*> g_devices;
+extern hipError_t ihipGetDeviceProperties(hipDeviceProp_t* props, hipDevice_t device);
+}  // namespace hip
 
 namespace hrr_cap {
 namespace metadata {
@@ -118,10 +122,8 @@ std::string collect_comgr_json() {
   amd_comgr_get_version(&major, &minor);
   std::ostringstream os;
   os << "{\n"
-     << "    \"available\": true,\n"
      << "    \"major\": " << static_cast<unsigned long long>(major) << ",\n"
-     << "    \"minor\": " << static_cast<unsigned long long>(minor) << ",\n"
-     << "    \"source\": \"amd_comgr_get_version\"\n"
+     << "    \"minor\": " << static_cast<unsigned long long>(minor) << "\n"
      << "  }";
   return os.str();
 }

--- a/projects/clr/hipamd/src/hrr/hip_capture_metadata.cpp
+++ b/projects/clr/hipamd/src/hrr/hip_capture_metadata.cpp
@@ -136,33 +136,52 @@ std::string collect_runtime_json() {
   return os.str();
 }
 
-std::string collect_devices_json() {
-  std::ostringstream os;
-  os << "[";
+struct DeviceMetadata {
+  std::string devices_json;
+  std::string errors_json;
+  int captured_count = 0;
+};
 
-  const int count = static_cast<int>(hip::g_devices.size());
+DeviceMetadata collect_device_metadata() {
+  std::ostringstream devices;
+  std::ostringstream errors;
+  devices << "[";
+  errors << "[";
 
-  for (int device = 0; device < count; ++device) {
-    if (device > 0) os << ",";
-    os << "\n"
-       << "    {\n"
-       << "      \"ordinal\": " << device << ",\n";
+  const int device_count = static_cast<int>(hip::g_devices.size());
+  bool first_device = true;
+  bool first_error = true;
+  int captured_count = 0;
 
+  for (int device = 0; device < device_count; ++device) {
     hipDeviceProp_t prop{};
     const hipError_t prop_err = hip::ihipGetDeviceProperties(&prop, device);
-    if (prop_err == hipSuccess) {
-      append_prop_fields(os, prop);
-    } else {
-      os << "      \"properties_error\": " << quote(hip_error_name(prop_err)) << "\n";
+    if (prop_err != hipSuccess) {
+      if (!first_error) errors << ",";
+      first_error = false;
+      errors << "\n"
+             << "    { \"ordinal\": " << device
+             << ", \"api\": \"ihipGetDeviceProperties\""
+             << ", \"error\": " << quote(hip_error_name(prop_err)) << " }";
+      continue;
     }
 
-    os << "\n"
-       << "    }";
+    if (!first_device) devices << ",";
+    first_device = false;
+    ++captured_count;
+    devices << "\n"
+            << "    {\n"
+            << "      \"ordinal\": " << device << ",\n";
+    append_prop_fields(devices, prop);
+    devices << "\n"
+            << "    }";
   }
 
-  os << "\n"
-     << "  ]";
-  return os.str();
+  devices << "\n"
+          << "  ]";
+  errors << "\n"
+         << "  ]";
+  return {devices.str(), errors.str(), captured_count};
 }
 
 }  // namespace
@@ -175,9 +194,11 @@ std::string Metadata::collect_json() const {
 
   int count = 0;
   count = static_cast<int>(hip::g_devices.size());
+  DeviceMetadata device_metadata = collect_device_metadata();
   os << "  \"device_count\": " << count << ",\n";
-
-  os << "  \"devices\": " << collect_devices_json() << "\n"
+  os << "  \"captured_device_count\": " << device_metadata.captured_count << ",\n";
+  os << "  \"device_metadata_errors\": " << device_metadata.errors_json << ",\n";
+  os << "  \"devices\": " << device_metadata.devices_json << "\n"
      << "}";
   return os.str();
 }

--- a/projects/clr/hipamd/src/hrr/hip_capture_metadata.cpp
+++ b/projects/clr/hipamd/src/hrr/hip_capture_metadata.cpp
@@ -14,11 +14,7 @@
 #include <string>
 #include <vector>
 
-namespace hip {
-class Device;
-extern std::vector<hip::Device*> g_devices;
-extern hipError_t ihipGetDeviceProperties(hipDeviceProp_t* props, hipDevice_t device);
-}  // namespace hip
+#include "../hip_internal.hpp"  // hip::g_devices, hip::ihipGetDeviceProperties
 
 namespace hrr_cap {
 namespace metadata {

--- a/projects/clr/hipamd/src/hrr/hip_capture_metadata.cpp
+++ b/projects/clr/hipamd/src/hrr/hip_capture_metadata.cpp
@@ -10,6 +10,7 @@
 #include "hip/hip_runtime_api.h"
 
 #include <cstdio>
+#include <cstring>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -27,7 +28,9 @@ namespace {
 std::string json_escape(const char* s) {
   std::string out;
   if (!s) return out;
-  for (const unsigned char c : std::string(s)) {
+  out.reserve(strlen(s));
+  for (const unsigned char* p = reinterpret_cast<const unsigned char*>(s); *p != '\0'; ++p) {
+    const unsigned char c = *p;
     switch (c) {
       case '\\': out += "\\\\"; break;
       case '"':  out += "\\\""; break;
@@ -53,6 +56,16 @@ std::string json_escape(const char* s) {
 std::string json_escape(const std::string& s) { return json_escape(s.c_str()); }
 
 std::string quote(const std::string& s) { return "\"" + json_escape(s) + "\""; }
+
+size_t bounded_strlen(const char* s, size_t max_len) {
+  size_t n = 0;
+  while (n < max_len && s[n] != '\0') ++n;
+  return n;
+}
+
+std::string bounded_string(const char* s, size_t max_len) {
+  return std::string(s, bounded_strlen(s, max_len));
+}
 
 std::string version_string_from_int(int version) {
   if (version <= 0) return "";
@@ -81,8 +94,9 @@ std::string uuid_to_hex(const hipUUID& uuid) {
 
 void append_prop_fields(std::ostringstream& os, const hipDeviceProp_t& prop) {
   os << "      \"properties\": {\n"
-     << "        \"name\": " << quote(prop.name) << ",\n"
-     << "        \"gcn_arch_name\": " << quote(prop.gcnArchName) << ",\n"
+     << "        \"name\": " << quote(bounded_string(prop.name, sizeof(prop.name))) << ",\n"
+     << "        \"gcn_arch_name\": "
+     << quote(bounded_string(prop.gcnArchName, sizeof(prop.gcnArchName))) << ",\n"
      << "        \"total_global_mem\": " << static_cast<unsigned long long>(prop.totalGlobalMem) << ",\n"
      << "        \"multi_processor_count\": " << prop.multiProcessorCount << ",\n"
      << "        \"warp_size\": " << prop.warpSize << ",\n"
@@ -114,15 +128,13 @@ std::string collect_comgr_version() {
          std::to_string(static_cast<unsigned long long>(minor));
 }
 
-std::string collect_runtime_json() {
-  std::ostringstream os;
+void append_runtime_json(std::ostringstream& os) {
   os << "{\n";
 
   const int hip_version = HIP_VERSION;
   os << "    \"hip_runtime_version\": " << quote(version_string_from_int(hip_version)) << ",\n"
      << "    \"comgr_version\": " << quote(collect_comgr_version()) << "\n"
      << "  }";
-  return os.str();
 }
 
 struct DeviceMetadata {
@@ -130,11 +142,10 @@ struct DeviceMetadata {
   int captured_count = 0;
 };
 
-DeviceMetadata collect_device_metadata() {
+DeviceMetadata collect_device_metadata(int device_count) {
   std::ostringstream devices;
   devices << "[";
 
-  const int device_count = static_cast<int>(hip::g_devices.size());
   bool first_device = true;
   int captured_count = 0;
 
@@ -161,24 +172,21 @@ DeviceMetadata collect_device_metadata() {
 
 }  // namespace
 
-std::string Metadata::collect_json() const {
+std::string collect_json() {
   std::ostringstream os;
   os << "{\n"
      << "  \"schema_version\": 1,\n"
-     << "  \"runtime\": " << collect_runtime_json() << ",\n";
+     << "  \"runtime\": ";
+  append_runtime_json(os);
+  os << ",\n";
 
-  int count = 0;
-  count = static_cast<int>(hip::g_devices.size());
-  DeviceMetadata device_metadata = collect_device_metadata();
+  const int count = static_cast<int>(hip::g_devices.size());
+  DeviceMetadata device_metadata = collect_device_metadata(count);
   os << "  \"device_count\": " << count << ",\n";
   os << "  \"captured_device_count\": " << device_metadata.captured_count << ",\n";
   os << "  \"devices\": " << device_metadata.devices_json << "\n"
      << "}";
   return os.str();
-}
-
-std::string collect_json() {
-  return Metadata().collect_json();
 }
 
 }  // namespace metadata

--- a/projects/clr/hipamd/src/hrr/hip_capture_metadata.cpp
+++ b/projects/clr/hipamd/src/hrr/hip_capture_metadata.cpp
@@ -90,7 +90,7 @@ std::string uuid_to_hex(const hipUUID& uuid) {
   return bytes_to_hex(uuid.bytes, sizeof(uuid.bytes));
 }
 
-void append_prop_fields(std::ostringstream& os, const hipDeviceProp_tR0600& prop) {
+void append_prop_fields(std::ostringstream& os, const hipDeviceProp_t& prop) {
   os << "      \"properties\": {\n"
      << "        \"name\": " << quote(prop.name) << ",\n"
      << "        \"gcn_arch_name\": " << quote(prop.gcnArchName) << ",\n"
@@ -105,27 +105,24 @@ void append_prop_fields(std::ostringstream& os, const hipDeviceProp_tR0600& prop
      << "        \"integrated\": " << prop.integrated << ",\n"
      << "        \"managed_memory\": " << prop.managedMemory << ",\n"
      << "        \"memory_pools_supported\": " << prop.memoryPoolsSupported << ",\n"
-     << "        \"compute_capability\": { \"major\": " << prop.major
-     << ", \"minor\": " << prop.minor << " },\n"
-     << "        \"pci\": { \"domain\": " << prop.pciDomainID
-     << ", \"bus\": " << prop.pciBusID
-     << ", \"device\": " << prop.pciDeviceID << " },\n"
+     << "        \"compute_mode\": " << prop.computeMode << ",\n"
+     << "        \"compute_capability\": " << quote(std::to_string(prop.major) + "." +
+                                                  std::to_string(prop.minor)) << ",\n"
+     << "        \"pci\": " << quote(std::to_string(prop.pciDomainID) + ":" +
+                                    std::to_string(prop.pciBusID) + ":" +
+                                    std::to_string(prop.pciDeviceID)) << ",\n"
      << "        \"uuid\": " << quote(uuid_to_hex(prop.uuid)) << ",\n"
      << "        \"luid\": " << quote(bytes_to_hex(prop.luid, sizeof(prop.luid))) << ",\n"
      << "        \"luid_device_node_mask\": " << prop.luidDeviceNodeMask << "\n"
      << "      }";
 }
 
-std::string collect_comgr_json() {
+std::string collect_comgr_version() {
   size_t major = 0;
   size_t minor = 0;
   amd_comgr_get_version(&major, &minor);
-  std::ostringstream os;
-  os << "{\n"
-     << "    \"major\": " << static_cast<unsigned long long>(major) << ",\n"
-     << "    \"minor\": " << static_cast<unsigned long long>(minor) << "\n"
-     << "  }";
-  return os.str();
+  return std::to_string(static_cast<unsigned long long>(major)) + "." +
+         std::to_string(static_cast<unsigned long long>(minor));
 }
 
 std::string collect_runtime_json() {
@@ -134,10 +131,7 @@ std::string collect_runtime_json() {
 
   const int hip_version = HIP_VERSION;
   os << "    \"hip_runtime_version\": " << quote(version_string_from_int(hip_version)) << ",\n"
-     << "    \"hip_driver_version\": " << quote(version_string_from_int(hip_version));
-
-  os << ",\n"
-     << "    \"comgr\": " << collect_comgr_json() << "\n"
+     << "    \"comgr_version\": " << quote(collect_comgr_version()) << "\n"
      << "  }";
   return os.str();
 }
@@ -154,7 +148,7 @@ std::string collect_devices_json() {
        << "    {\n"
        << "      \"ordinal\": " << device << ",\n";
 
-    hipDeviceProp_tR0600 prop{};
+    hipDeviceProp_t prop{};
     const hipError_t prop_err = hip::ihipGetDeviceProperties(&prop, device);
     if (prop_err == hipSuccess) {
       append_prop_fields(os, prop);

--- a/projects/clr/hipamd/src/hrr/hip_capture_metadata.cpp
+++ b/projects/clr/hipamd/src/hrr/hip_capture_metadata.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "hip_capture_metadata.h"
+
+#include "amd_comgr/amd_comgr.h"
+#include "hip/hip_runtime_api.h"
+
+#include <cstdio>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace hip {
+class Device;
+extern std::vector<hip::Device*> g_devices;
+extern hipError_t ihipGetDeviceProperties(hipDeviceProp_t* props, hipDevice_t device);
+}  // namespace hip
+
+namespace hrr_cap {
+namespace metadata {
+namespace {
+
+std::string json_escape(const char* s) {
+  std::string out;
+  if (!s) return out;
+  for (const unsigned char c : std::string(s)) {
+    switch (c) {
+      case '\\': out += "\\\\"; break;
+      case '"':  out += "\\\""; break;
+      case '\b': out += "\\b"; break;
+      case '\f': out += "\\f"; break;
+      case '\n': out += "\\n"; break;
+      case '\r': out += "\\r"; break;
+      case '\t': out += "\\t"; break;
+      default:
+        if (c < 0x20) {
+          char buf[7];
+          snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned>(c));
+          out += buf;
+        } else {
+          out += static_cast<char>(c);
+        }
+        break;
+    }
+  }
+  return out;
+}
+
+std::string json_escape(const std::string& s) { return json_escape(s.c_str()); }
+
+std::string quote(const std::string& s) { return "\"" + json_escape(s) + "\""; }
+
+std::string hip_error_name(hipError_t err) {
+  switch (err) {
+    case hipSuccess: return "hipSuccess";
+    case hipErrorInvalidValue: return "hipErrorInvalidValue";
+    case hipErrorInvalidDevice: return "hipErrorInvalidDevice";
+    case hipErrorNoDevice: return "hipErrorNoDevice";
+    case hipErrorNotInitialized: return "hipErrorNotInitialized";
+    default: return "hipError(" + std::to_string(static_cast<int>(err)) + ")";
+  }
+}
+
+std::string version_string_from_int(int version) {
+  if (version <= 0) return "";
+  const int major = version / 10000000;
+  const int minor = (version / 100000) % 100;
+  const int patch = version % 100000;
+  if (major <= 0) return std::to_string(version);
+  return std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch);
+}
+
+std::string bytes_to_hex(const char* bytes, size_t len) {
+  static constexpr char kHex[] = "0123456789abcdef";
+  std::string result;
+  result.resize(len * 2);
+  for (size_t i = 0; i < len; ++i) {
+    const auto v = static_cast<unsigned char>(bytes[i]);
+    result[2 * i] = kHex[v >> 4];
+    result[2 * i + 1] = kHex[v & 0xf];
+  }
+  return result;
+}
+
+std::string uuid_to_hex(const hipUUID& uuid) {
+  return bytes_to_hex(uuid.bytes, sizeof(uuid.bytes));
+}
+
+void append_prop_fields(std::ostringstream& os, const hipDeviceProp_tR0600& prop) {
+  os << "      \"properties\": {\n"
+     << "        \"name\": " << quote(prop.name) << ",\n"
+     << "        \"gcn_arch_name\": " << quote(prop.gcnArchName) << ",\n"
+     << "        \"total_global_mem\": " << static_cast<unsigned long long>(prop.totalGlobalMem) << ",\n"
+     << "        \"multi_processor_count\": " << prop.multiProcessorCount << ",\n"
+     << "        \"warp_size\": " << prop.warpSize << ",\n"
+     << "        \"max_threads_per_block\": " << prop.maxThreadsPerBlock << ",\n"
+     << "        \"clock_rate_khz\": " << prop.clockRate << ",\n"
+     << "        \"memory_clock_rate_khz\": " << prop.memoryClockRate << ",\n"
+     << "        \"memory_bus_width\": " << prop.memoryBusWidth << ",\n"
+     << "        \"l2_cache_size\": " << prop.l2CacheSize << ",\n"
+     << "        \"integrated\": " << prop.integrated << ",\n"
+     << "        \"managed_memory\": " << prop.managedMemory << ",\n"
+     << "        \"memory_pools_supported\": " << prop.memoryPoolsSupported << ",\n"
+     << "        \"compute_capability\": { \"major\": " << prop.major
+     << ", \"minor\": " << prop.minor << " },\n"
+     << "        \"pci\": { \"domain\": " << prop.pciDomainID
+     << ", \"bus\": " << prop.pciBusID
+     << ", \"device\": " << prop.pciDeviceID << " },\n"
+     << "        \"uuid\": " << quote(uuid_to_hex(prop.uuid)) << ",\n"
+     << "        \"luid\": " << quote(bytes_to_hex(prop.luid, sizeof(prop.luid))) << ",\n"
+     << "        \"luid_device_node_mask\": " << prop.luidDeviceNodeMask << "\n"
+     << "      }";
+}
+
+std::string collect_comgr_json() {
+  size_t major = 0;
+  size_t minor = 0;
+  amd_comgr_get_version(&major, &minor);
+  std::ostringstream os;
+  os << "{\n"
+     << "    \"available\": true,\n"
+     << "    \"major\": " << static_cast<unsigned long long>(major) << ",\n"
+     << "    \"minor\": " << static_cast<unsigned long long>(minor) << ",\n"
+     << "    \"source\": \"amd_comgr_get_version\"\n"
+     << "  }";
+  return os.str();
+}
+
+std::string collect_runtime_json() {
+  std::ostringstream os;
+  os << "{\n";
+
+  const int hip_version = HIP_VERSION;
+  os << "    \"hip_runtime_version\": " << quote(version_string_from_int(hip_version)) << ",\n"
+     << "    \"hip_driver_version\": " << quote(version_string_from_int(hip_version));
+
+  os << ",\n"
+     << "    \"comgr\": " << collect_comgr_json() << "\n"
+     << "  }";
+  return os.str();
+}
+
+std::string collect_devices_json() {
+  std::ostringstream os;
+  os << "[";
+
+  const int count = static_cast<int>(hip::g_devices.size());
+
+  for (int device = 0; device < count; ++device) {
+    if (device > 0) os << ",";
+    os << "\n"
+       << "    {\n"
+       << "      \"ordinal\": " << device << ",\n";
+
+    hipDeviceProp_tR0600 prop{};
+    const hipError_t prop_err = hip::ihipGetDeviceProperties(&prop, device);
+    if (prop_err == hipSuccess) {
+      append_prop_fields(os, prop);
+    } else {
+      os << "      \"properties_error\": " << quote(hip_error_name(prop_err)) << "\n";
+    }
+
+    os << "\n"
+       << "    }";
+  }
+
+  os << "\n"
+     << "  ]";
+  return os.str();
+}
+
+}  // namespace
+
+std::string Metadata::collect_json() const {
+  std::ostringstream os;
+  os << "{\n"
+     << "  \"schema_version\": 1,\n"
+     << "  \"runtime\": " << collect_runtime_json() << ",\n";
+
+  int count = 0;
+  count = static_cast<int>(hip::g_devices.size());
+  os << "  \"device_count\": " << count << ",\n";
+
+  os << "  \"devices\": " << collect_devices_json() << "\n"
+     << "}";
+  return os.str();
+}
+
+std::string collect_json() {
+  return Metadata().collect_json();
+}
+
+}  // namespace metadata
+}  // namespace hrr_cap

--- a/projects/clr/hipamd/src/hrr/hip_capture_metadata.cpp
+++ b/projects/clr/hipamd/src/hrr/hip_capture_metadata.cpp
@@ -54,17 +54,6 @@ std::string json_escape(const std::string& s) { return json_escape(s.c_str()); }
 
 std::string quote(const std::string& s) { return "\"" + json_escape(s) + "\""; }
 
-std::string hip_error_name(hipError_t err) {
-  switch (err) {
-    case hipSuccess: return "hipSuccess";
-    case hipErrorInvalidValue: return "hipErrorInvalidValue";
-    case hipErrorInvalidDevice: return "hipErrorInvalidDevice";
-    case hipErrorNoDevice: return "hipErrorNoDevice";
-    case hipErrorNotInitialized: return "hipErrorNotInitialized";
-    default: return "hipError(" + std::to_string(static_cast<int>(err)) + ")";
-  }
-}
-
 std::string version_string_from_int(int version) {
   if (version <= 0) return "";
   const int major = version / 10000000;
@@ -138,33 +127,21 @@ std::string collect_runtime_json() {
 
 struct DeviceMetadata {
   std::string devices_json;
-  std::string errors_json;
   int captured_count = 0;
 };
 
 DeviceMetadata collect_device_metadata() {
   std::ostringstream devices;
-  std::ostringstream errors;
   devices << "[";
-  errors << "[";
 
   const int device_count = static_cast<int>(hip::g_devices.size());
   bool first_device = true;
-  bool first_error = true;
   int captured_count = 0;
 
   for (int device = 0; device < device_count; ++device) {
     hipDeviceProp_t prop{};
     const hipError_t prop_err = hip::ihipGetDeviceProperties(&prop, device);
-    if (prop_err != hipSuccess) {
-      if (!first_error) errors << ",";
-      first_error = false;
-      errors << "\n"
-             << "    { \"ordinal\": " << device
-             << ", \"api\": \"ihipGetDeviceProperties\""
-             << ", \"error\": " << quote(hip_error_name(prop_err)) << " }";
-      continue;
-    }
+    if (prop_err != hipSuccess) continue;
 
     if (!first_device) devices << ",";
     first_device = false;
@@ -179,9 +156,7 @@ DeviceMetadata collect_device_metadata() {
 
   devices << "\n"
           << "  ]";
-  errors << "\n"
-         << "  ]";
-  return {devices.str(), errors.str(), captured_count};
+  return {devices.str(), captured_count};
 }
 
 }  // namespace
@@ -197,7 +172,6 @@ std::string Metadata::collect_json() const {
   DeviceMetadata device_metadata = collect_device_metadata();
   os << "  \"device_count\": " << count << ",\n";
   os << "  \"captured_device_count\": " << device_metadata.captured_count << ",\n";
-  os << "  \"device_metadata_errors\": " << device_metadata.errors_json << ",\n";
   os << "  \"devices\": " << device_metadata.devices_json << "\n"
      << "}";
   return os.str();

--- a/projects/clr/hipamd/src/hrr/hip_capture_metadata.h
+++ b/projects/clr/hipamd/src/hrr/hip_capture_metadata.h
@@ -14,12 +14,6 @@ namespace metadata {
 // The collector is safe to call from hip_capture_init(): it reads HIP runtime
 // constants and initialized internal device state rather than calling public HIP
 // APIs that would re-enter hip::init().
-class Metadata {
- public:
-  // Returns a JSON object string containing capture environment metadata.
-  std::string collect_json() const;
-};
-
 std::string collect_json();
 
 }  // namespace metadata

--- a/projects/clr/hipamd/src/hrr/hip_capture_metadata.h
+++ b/projects/clr/hipamd/src/hrr/hip_capture_metadata.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+
+#include <string>
+
+namespace hrr_cap {
+namespace metadata {
+
+// Collects best-effort capture environment metadata for the HRR manifest.
+// The collector is safe to call from hip_capture_init(): it reads HIP runtime
+// constants and initialized internal device state rather than calling public HIP
+// APIs that would re-enter hip::init().
+class Metadata {
+ public:
+  // Returns a complete JSON object. The object is always valid JSON; individual
+  // sections carry an "available": false marker when optional probes fail.
+  std::string collect_json() const;
+};
+
+std::string collect_json();
+
+}  // namespace metadata
+}  // namespace hrr_cap

--- a/projects/clr/hipamd/src/hrr/hip_capture_metadata.h
+++ b/projects/clr/hipamd/src/hrr/hip_capture_metadata.h
@@ -16,8 +16,7 @@ namespace metadata {
 // APIs that would re-enter hip::init().
 class Metadata {
  public:
-  // Returns a complete JSON object. The object is always valid JSON; individual
-  // sections carry an "available": false marker when optional probes fail.
+  // Returns a JSON object string containing capture environment metadata.
   std::string collect_json() const;
 };
 

--- a/projects/clr/hipamd/src/hrr/hip_capture_writer.cpp
+++ b/projects/clr/hipamd/src/hrr/hip_capture_writer.cpp
@@ -157,7 +157,6 @@ static constexpr size_t   kBufCap           = 256u * 1024u;
 static constexpr uint64_t kCheckpointEvents = 4096;
 // Path buffers are filled at open() so the signal path never touches std::string.
 static constexpr size_t   kPathMax          = 4096;
-static constexpr uint32_t kRootManifestVersion = 2;
 
 static std::mutex   g_file_mu;
 static int          g_events_fd = -1;
@@ -511,7 +510,6 @@ struct ProcessManifestEntry {
   uint64_t event_count = 0;
   uint64_t blob_count = 0;
   bool complete = false;
-  std::string metadata_json;
 };
 
 static bool read_process_manifest(const std::string& path, ProcessManifestEntry* out) {
@@ -552,65 +550,6 @@ static bool read_process_manifest(const std::string& path, ProcessManifestEntry*
   return true;
 }
 
-static std::string read_text_file(const std::string& path) {
-  FILE* f = fopen(path.c_str(), "rb");
-  if (!f) return {};
-  if (fseek(f, 0, SEEK_END) != 0) {
-    fclose(f);
-    return {};
-  }
-  const long len = ftell(f);
-  if (len < 0) {
-    fclose(f);
-    return {};
-  }
-  rewind(f);
-  std::string out(static_cast<size_t>(len), '\0');
-  if (!out.empty() && fread(out.data(), 1, out.size(), f) != out.size()) {
-    fclose(f);
-    return {};
-  }
-  fclose(f);
-  return out;
-}
-
-static std::string extract_json_object_member(const std::string& json, const char* key) {
-  const std::string needle = std::string("\"") + key + "\"";
-  size_t pos = json.find(needle);
-  if (pos == std::string::npos) return {};
-  pos = json.find(':', pos + needle.size());
-  if (pos == std::string::npos) return {};
-  pos = json.find('{', pos + 1);
-  if (pos == std::string::npos) return {};
-
-  int depth = 0;
-  bool in_string = false;
-  bool escape = false;
-  for (size_t i = pos; i < json.size(); ++i) {
-    const char c = json[i];
-    if (in_string) {
-      if (escape) {
-        escape = false;
-      } else if (c == '\\') {
-        escape = true;
-      } else if (c == '"') {
-        in_string = false;
-      }
-      continue;
-    }
-    if (c == '"') {
-      in_string = true;
-    } else if (c == '{') {
-      ++depth;
-    } else if (c == '}') {
-      --depth;
-      if (depth == 0)
-        return json.substr(pos, i - pos + 1);
-    }
-  }
-  return {};
-}
-
 static uint64_t derive_owner_pid(const std::vector<ProcessManifestEntry>& entries) {
   if (entries.empty()) return 0;
   for (const auto& candidate : entries) {
@@ -632,40 +571,19 @@ static void update_root_manifest() {
     if (name.rfind("pid-", 0) != 0) continue;
     ProcessManifestEntry entry{};
     const std::string manifest_path = (ent.path() / "manifest.json").string();
-    if (read_process_manifest(manifest_path, &entry)) {
-      std::string metadata = extract_json_object_member(read_text_file(manifest_path), "metadata");
-      if (is_json_object_fragment(metadata))
-        entry.metadata_json = std::move(metadata);
+    if (read_process_manifest(manifest_path, &entry))
       entries.push_back(entry);
-    }
   }
 
   std::sort(entries.begin(), entries.end(),
             [](const auto& a, const auto& b) { return a.pid < b.pid; });
   const uint64_t owner_pid = derive_owner_pid(entries);
-  std::string root_metadata;
-  for (const auto& e : entries) {
-    if (e.pid == owner_pid && is_json_object_fragment(e.metadata_json)) {
-      root_metadata = e.metadata_json;
-      break;
-    }
-  }
-  if (root_metadata.empty()) {
-    for (const auto& e : entries) {
-      if (is_json_object_fragment(e.metadata_json)) {
-        root_metadata = e.metadata_json;
-        break;
-      }
-    }
-  }
 
   std::string json;
   json += "{\n";
-  json += "  \"version\": " + std::to_string(kRootManifestVersion) + ",\n";
+  json += "  \"version\": 1,\n";
   json += "  \"capture_mode\": \"in-tree\",\n";
   json += "  \"owner_pid\": " + std::to_string(owner_pid) + ",\n";
-  if (is_json_object_fragment(root_metadata))
-    json += "  \"metadata\": " + root_metadata + ",\n";
   json += "  \"processes\": [\n";
   for (size_t i = 0; i < entries.size(); ++i) {
     const auto& e = entries[i];
@@ -673,9 +591,7 @@ static void update_root_manifest() {
             ", \"parent_pid\": " + std::to_string(e.parent_pid) +
             ", \"complete\": " + (e.complete ? "true" : "false") +
             ", \"event_count\": " + std::to_string(e.event_count) +
-            ", \"blob_count\": " + std::to_string(e.blob_count) +
-            ", \"has_metadata\": " + (is_json_object_fragment(e.metadata_json) ? "true" : "false") +
-            " }";
+            ", \"blob_count\": " + std::to_string(e.blob_count) + " }";
     json += (i + 1 == entries.size()) ? "\n" : ",\n";
   }
   json += "  ]\n";

--- a/projects/clr/hipamd/src/hrr/hip_capture_writer.cpp
+++ b/projects/clr/hipamd/src/hrr/hip_capture_writer.cpp
@@ -24,6 +24,7 @@
 
 #include "hip_capture_writer.h"
 #include "hip_capture.h"
+#include "hip_capture_metadata.h"
 
 #include "os/os.hpp"           // amd::Os::timeNanos()
 #include "utils/debug.hpp"     // LogPrintfError, LogPrintfWarning, LogPrintfInfo
@@ -168,7 +169,6 @@ static std::string  g_output_dir;
 static char         g_manifest_path[kPathMax] = {0};
 static uint64_t     g_pid = 0;
 static uint64_t     g_parent_pid = 0;
-static std::string  g_metadata_json;
 
 // App-managed write buffer for events.bin (protected by g_file_mu).
 static uint8_t  g_buf[kBufCap];
@@ -495,8 +495,9 @@ static void write_manifest_stdio(const char* output_dir, bool complete) {
           complete ? "true" : "false",
           static_cast<unsigned long long>(g_event_count.load()),
           static_cast<unsigned long long>(g_blob_count.load()));
-  if (is_json_object_fragment(g_metadata_json)) {
-    fprintf(mf, ",\n  \"metadata\": %s\n", g_metadata_json.c_str());
+  const std::string metadata_json = hrr_cap::metadata::collect_json();
+  if (is_json_object_fragment(metadata_json)) {
+    fprintf(mf, ",\n  \"metadata\": %s\n", metadata_json.c_str());
   } else {
     fprintf(mf, "\n");
   }
@@ -1007,12 +1008,6 @@ Hash128 write_code_object(const void* image, size_t image_size) {
 bool     is_open()      { std::lock_guard<std::mutex> lk(g_file_mu); return g_events_fd >= 0; }
 uint64_t event_count()  { return g_event_count.load(); }
 uint64_t blob_count()   { return g_blob_count.load(); }
-
-void set_capture_metadata_json(std::string metadata_json) {
-  if (!is_json_object_fragment(metadata_json)) return;
-  std::lock_guard<std::mutex> lk(g_file_mu);
-  g_metadata_json = std::move(metadata_json);
-}
 
 }  // namespace writer
 }  // namespace hrr_cap

--- a/projects/clr/hipamd/src/hrr/hip_capture_writer.cpp
+++ b/projects/clr/hipamd/src/hrr/hip_capture_writer.cpp
@@ -860,8 +860,12 @@ void emergency_finalize(bool clean_shutdown) {
   p += u64_to_dec(g_event_count.load(), buf + p);
   p = append_lit(buf, p, ",\n  \"blob_count\": ");
   p += u64_to_dec(g_blob_count.load(), buf + p);
-  if (g_metadata_json_len > 0) {
-    p = append_lit(buf, p, ",\n  \"metadata\": ");
+  // g_metadata_json is written once during HRR init before event capture starts.
+  // The crash path reads it lock-free to avoid taking g_file_mu from an exception callback.
+  static constexpr const char* kMetadataFieldPrefix = ",\n  \"metadata\": ";
+  if (g_metadata_json_len > 0 &&
+      p + strlen(kMetadataFieldPrefix) + g_metadata_json_len + sizeof("\n}\n") < sizeof(buf)) {
+    p = append_lit(buf, p, kMetadataFieldPrefix);
     memcpy(buf + p, g_metadata_json, g_metadata_json_len);
     p += g_metadata_json_len;
   }

--- a/projects/clr/hipamd/src/hrr/hip_capture_writer.cpp
+++ b/projects/clr/hipamd/src/hrr/hip_capture_writer.cpp
@@ -157,6 +157,7 @@ static constexpr size_t   kBufCap           = 256u * 1024u;
 static constexpr uint64_t kCheckpointEvents = 4096;
 // Path buffers are filled at open() so the signal path never touches std::string.
 static constexpr size_t   kPathMax          = 4096;
+static constexpr uint32_t kRootManifestVersion = 2;
 
 static std::mutex   g_file_mu;
 static int          g_events_fd = -1;
@@ -168,6 +169,7 @@ static std::string  g_output_dir;
 static char         g_manifest_path[kPathMax] = {0};
 static uint64_t     g_pid = 0;
 static uint64_t     g_parent_pid = 0;
+static std::string  g_metadata_json;
 
 // App-managed write buffer for events.bin (protected by g_file_mu).
 static uint8_t  g_buf[kBufCap];
@@ -268,6 +270,19 @@ static void ensure_dir(const std::string& path) {
 }
 
 static bool atomic_write_file(const std::string& path, const void* data, size_t len);
+
+static bool is_json_object_fragment(const std::string& json) {
+  const auto begin = json.find_first_not_of(" \t\r\n");
+  if (begin == std::string::npos || json[begin] != '{') return false;
+  const auto end = json.find_last_not_of(" \t\r\n");
+  return end != std::string::npos && json[end] == '}';
+}
+
+static void write_metadata_file_if_available() {
+  if (g_output_dir.empty() || !is_json_object_fragment(g_metadata_json)) return;
+  const std::string path = g_output_dir + "/metadata.json";
+  (void)atomic_write_file(path, g_metadata_json.data(), g_metadata_json.size());
+}
 
 // ---------------------------------------------------------------------------
 // manifest writers
@@ -481,14 +496,20 @@ static void write_manifest_stdio(const char* output_dir, bool complete) {
           "  \"parent_pid\": %llu,\n"
           "  \"complete\": %s,\n"
           "  \"event_count\": %llu,\n"
-          "  \"blob_count\": %llu\n"
-          "}\n",
+          "  \"blob_count\": %llu",
           static_cast<unsigned long long>(g_pid),
           static_cast<unsigned long long>(g_parent_pid),
           complete ? "true" : "false",
           static_cast<unsigned long long>(g_event_count.load()),
           static_cast<unsigned long long>(g_blob_count.load()));
+  if (is_json_object_fragment(g_metadata_json)) {
+    fprintf(mf, ",\n  \"metadata\": %s\n", g_metadata_json.c_str());
+  } else {
+    fprintf(mf, "\n");
+  }
+  fprintf(mf, "}\n");
   fclose(mf);
+  write_metadata_file_if_available();
 }
 
 struct ProcessManifestEntry {
@@ -497,6 +518,7 @@ struct ProcessManifestEntry {
   uint64_t event_count = 0;
   uint64_t blob_count = 0;
   bool complete = false;
+  std::string metadata_json;
 };
 
 static bool read_process_manifest(const std::string& path, ProcessManifestEntry* out) {
@@ -537,6 +559,28 @@ static bool read_process_manifest(const std::string& path, ProcessManifestEntry*
   return true;
 }
 
+static std::string read_text_file(const std::string& path) {
+  FILE* f = fopen(path.c_str(), "rb");
+  if (!f) return {};
+  if (fseek(f, 0, SEEK_END) != 0) {
+    fclose(f);
+    return {};
+  }
+  const long len = ftell(f);
+  if (len < 0) {
+    fclose(f);
+    return {};
+  }
+  rewind(f);
+  std::string out(static_cast<size_t>(len), '\0');
+  if (!out.empty() && fread(out.data(), 1, out.size(), f) != out.size()) {
+    fclose(f);
+    return {};
+  }
+  fclose(f);
+  return out;
+}
+
 static uint64_t derive_owner_pid(const std::vector<ProcessManifestEntry>& entries) {
   if (entries.empty()) return 0;
   for (const auto& candidate : entries) {
@@ -557,19 +601,40 @@ static void update_root_manifest() {
     const std::string name = ent.path().filename().string();
     if (name.rfind("pid-", 0) != 0) continue;
     ProcessManifestEntry entry{};
-    if (read_process_manifest((ent.path() / "manifest.json").string(), &entry))
+    if (read_process_manifest((ent.path() / "manifest.json").string(), &entry)) {
+      std::string metadata = read_text_file((ent.path() / "metadata.json").string());
+      if (is_json_object_fragment(metadata))
+        entry.metadata_json = std::move(metadata);
       entries.push_back(entry);
+    }
   }
 
   std::sort(entries.begin(), entries.end(),
             [](const auto& a, const auto& b) { return a.pid < b.pid; });
   const uint64_t owner_pid = derive_owner_pid(entries);
+  std::string root_metadata;
+  for (const auto& e : entries) {
+    if (e.pid == owner_pid && is_json_object_fragment(e.metadata_json)) {
+      root_metadata = e.metadata_json;
+      break;
+    }
+  }
+  if (root_metadata.empty()) {
+    for (const auto& e : entries) {
+      if (is_json_object_fragment(e.metadata_json)) {
+        root_metadata = e.metadata_json;
+        break;
+      }
+    }
+  }
 
   std::string json;
   json += "{\n";
-  json += "  \"version\": 1,\n";
+  json += "  \"version\": " + std::to_string(kRootManifestVersion) + ",\n";
   json += "  \"capture_mode\": \"in-tree\",\n";
   json += "  \"owner_pid\": " + std::to_string(owner_pid) + ",\n";
+  if (is_json_object_fragment(root_metadata))
+    json += "  \"metadata\": " + root_metadata + ",\n";
   json += "  \"processes\": [\n";
   for (size_t i = 0; i < entries.size(); ++i) {
     const auto& e = entries[i];
@@ -577,7 +642,9 @@ static void update_root_manifest() {
             ", \"parent_pid\": " + std::to_string(e.parent_pid) +
             ", \"complete\": " + (e.complete ? "true" : "false") +
             ", \"event_count\": " + std::to_string(e.event_count) +
-            ", \"blob_count\": " + std::to_string(e.blob_count) + " }";
+            ", \"blob_count\": " + std::to_string(e.blob_count) +
+            ", \"has_metadata\": " + (is_json_object_fragment(e.metadata_json) ? "true" : "false") +
+            " }";
     json += (i + 1 == entries.size()) ? "\n" : ",\n";
   }
   json += "  ]\n";
@@ -993,6 +1060,13 @@ Hash128 write_code_object(const void* image, size_t image_size) {
 bool     is_open()      { std::lock_guard<std::mutex> lk(g_file_mu); return g_events_fd >= 0; }
 uint64_t event_count()  { return g_event_count.load(); }
 uint64_t blob_count()   { return g_blob_count.load(); }
+
+void set_capture_metadata_json(std::string metadata_json) {
+  if (!is_json_object_fragment(metadata_json)) return;
+  std::lock_guard<std::mutex> lk(g_file_mu);
+  g_metadata_json = std::move(metadata_json);
+  write_metadata_file_if_available();
+}
 
 }  // namespace writer
 }  // namespace hrr_cap

--- a/projects/clr/hipamd/src/hrr/hip_capture_writer.cpp
+++ b/projects/clr/hipamd/src/hrr/hip_capture_writer.cpp
@@ -278,12 +278,6 @@ static bool is_json_object_fragment(const std::string& json) {
   return end != std::string::npos && json[end] == '}';
 }
 
-static void write_metadata_file_if_available() {
-  if (g_output_dir.empty() || !is_json_object_fragment(g_metadata_json)) return;
-  const std::string path = g_output_dir + "/metadata.json";
-  (void)atomic_write_file(path, g_metadata_json.data(), g_metadata_json.size());
-}
-
 // ---------------------------------------------------------------------------
 // manifest writers
 // ---------------------------------------------------------------------------
@@ -509,7 +503,6 @@ static void write_manifest_stdio(const char* output_dir, bool complete) {
   }
   fprintf(mf, "}\n");
   fclose(mf);
-  write_metadata_file_if_available();
 }
 
 struct ProcessManifestEntry {
@@ -581,6 +574,43 @@ static std::string read_text_file(const std::string& path) {
   return out;
 }
 
+static std::string extract_json_object_member(const std::string& json, const char* key) {
+  const std::string needle = std::string("\"") + key + "\"";
+  size_t pos = json.find(needle);
+  if (pos == std::string::npos) return {};
+  pos = json.find(':', pos + needle.size());
+  if (pos == std::string::npos) return {};
+  pos = json.find('{', pos + 1);
+  if (pos == std::string::npos) return {};
+
+  int depth = 0;
+  bool in_string = false;
+  bool escape = false;
+  for (size_t i = pos; i < json.size(); ++i) {
+    const char c = json[i];
+    if (in_string) {
+      if (escape) {
+        escape = false;
+      } else if (c == '\\') {
+        escape = true;
+      } else if (c == '"') {
+        in_string = false;
+      }
+      continue;
+    }
+    if (c == '"') {
+      in_string = true;
+    } else if (c == '{') {
+      ++depth;
+    } else if (c == '}') {
+      --depth;
+      if (depth == 0)
+        return json.substr(pos, i - pos + 1);
+    }
+  }
+  return {};
+}
+
 static uint64_t derive_owner_pid(const std::vector<ProcessManifestEntry>& entries) {
   if (entries.empty()) return 0;
   for (const auto& candidate : entries) {
@@ -601,8 +631,9 @@ static void update_root_manifest() {
     const std::string name = ent.path().filename().string();
     if (name.rfind("pid-", 0) != 0) continue;
     ProcessManifestEntry entry{};
-    if (read_process_manifest((ent.path() / "manifest.json").string(), &entry)) {
-      std::string metadata = read_text_file((ent.path() / "metadata.json").string());
+    const std::string manifest_path = (ent.path() / "manifest.json").string();
+    if (read_process_manifest(manifest_path, &entry)) {
+      std::string metadata = extract_json_object_member(read_text_file(manifest_path), "metadata");
       if (is_json_object_fragment(metadata))
         entry.metadata_json = std::move(metadata);
       entries.push_back(entry);
@@ -1065,7 +1096,6 @@ void set_capture_metadata_json(std::string metadata_json) {
   if (!is_json_object_fragment(metadata_json)) return;
   std::lock_guard<std::mutex> lk(g_file_mu);
   g_metadata_json = std::move(metadata_json);
-  write_metadata_file_if_available();
 }
 
 }  // namespace writer

--- a/projects/clr/hipamd/src/hrr/hip_capture_writer.cpp
+++ b/projects/clr/hipamd/src/hrr/hip_capture_writer.cpp
@@ -158,6 +158,8 @@ static constexpr size_t   kBufCap           = 256u * 1024u;
 static constexpr uint64_t kCheckpointEvents = 4096;
 // Path buffers are filled at open() so the signal path never touches std::string.
 static constexpr size_t   kPathMax          = 4096;
+static constexpr size_t   kMetadataJsonMax  = 128u * 1024u;
+static constexpr size_t   kEmergencyManifestMax = kMetadataJsonMax + 1024u;
 
 static std::mutex   g_file_mu;
 static int          g_events_fd = -1;
@@ -169,6 +171,8 @@ static std::string  g_output_dir;
 static char         g_manifest_path[kPathMax] = {0};
 static uint64_t     g_pid = 0;
 static uint64_t     g_parent_pid = 0;
+static char         g_metadata_json[kMetadataJsonMax] = {0};
+static size_t       g_metadata_json_len = 0;
 
 // App-managed write buffer for events.bin (protected by g_file_mu).
 static uint8_t  g_buf[kBufCap];
@@ -495,9 +499,9 @@ static void write_manifest_stdio(const char* output_dir, bool complete) {
           complete ? "true" : "false",
           static_cast<unsigned long long>(g_event_count.load()),
           static_cast<unsigned long long>(g_blob_count.load()));
-  const std::string metadata_json = hrr_cap::metadata::collect_json();
-  if (is_json_object_fragment(metadata_json)) {
-    fprintf(mf, ",\n  \"metadata\": %s\n", metadata_json.c_str());
+  if (g_metadata_json_len > 0) {
+    fprintf(mf, ",\n  \"metadata\": %.*s\n",
+            static_cast<int>(g_metadata_json_len), g_metadata_json);
   } else {
     fprintf(mf, "\n");
   }
@@ -842,7 +846,7 @@ void emergency_finalize(bool clean_shutdown) {
   bool complete = clean_shutdown && locked;
   int mfd = HRR_OPEN(g_manifest_path);
   if (mfd < 0) return;
-  char buf[256];
+  char buf[kEmergencyManifestMax];
   size_t p = 0;
   p = append_lit(buf, p,
                  "{\n"
@@ -856,6 +860,11 @@ void emergency_finalize(bool clean_shutdown) {
   p += u64_to_dec(g_event_count.load(), buf + p);
   p = append_lit(buf, p, ",\n  \"blob_count\": ");
   p += u64_to_dec(g_blob_count.load(), buf + p);
+  if (g_metadata_json_len > 0) {
+    p = append_lit(buf, p, ",\n  \"metadata\": ");
+    memcpy(buf + p, g_metadata_json, g_metadata_json_len);
+    p += g_metadata_json_len;
+  }
   p = append_lit(buf, p, "\n}\n");
   write_all_fd(mfd, buf, p);
   HRR_FSYNC(mfd);
@@ -1008,6 +1017,16 @@ Hash128 write_code_object(const void* image, size_t image_size) {
 bool     is_open()      { std::lock_guard<std::mutex> lk(g_file_mu); return g_events_fd >= 0; }
 uint64_t event_count()  { return g_event_count.load(); }
 uint64_t blob_count()   { return g_blob_count.load(); }
+
+void set_capture_metadata_json(const std::string& metadata_json) {
+  if (!is_json_object_fragment(metadata_json)) return;
+  if (metadata_json.size() >= kMetadataJsonMax) return;
+  std::lock_guard<std::mutex> lk(g_file_mu);
+  const size_t n = metadata_json.size();
+  memcpy(g_metadata_json, metadata_json.data(), n);
+  g_metadata_json[n] = '\0';
+  g_metadata_json_len = n;
+}
 
 }  // namespace writer
 }  // namespace hrr_cap

--- a/projects/clr/hipamd/src/hrr/hip_capture_writer.h
+++ b/projects/clr/hipamd/src/hrr/hip_capture_writer.h
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 
 namespace hrr_cap {
 namespace writer {
@@ -20,6 +21,10 @@ bool open(const char* output_dir);
 
 // Returns true if open() has been called successfully.
 bool is_open();
+
+// Cache process-level metadata JSON for manifest writers. The emergency
+// finalizer only raw-writes this cached byte buffer; it never collects metadata.
+void set_capture_metadata_json(const std::string& metadata_json);
 
 // Flush events.bin, append the clean-shutdown trailer (hrr_eof_record), fsync,
 // and write manifest.json with "complete": true. Safe to call multiple times

--- a/projects/clr/hipamd/src/hrr/hip_capture_writer.h
+++ b/projects/clr/hipamd/src/hrr/hip_capture_writer.h
@@ -10,7 +10,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <string>
 
 namespace hrr_cap {
 namespace writer {
@@ -21,11 +20,6 @@ bool open(const char* output_dir);
 
 // Returns true if open() has been called successfully.
 bool is_open();
-
-// Store process-level capture metadata as a JSON object fragment. The writer
-// embeds this in pid-<pid>/manifest.json and promotes the owner process metadata
-// into the root manifest.json. Best-effort: invalid/empty metadata is ignored.
-void set_capture_metadata_json(std::string metadata_json);
 
 // Flush events.bin, append the clean-shutdown trailer (hrr_eof_record), fsync,
 // and write manifest.json with "complete": true. Safe to call multiple times

--- a/projects/clr/hipamd/src/hrr/hip_capture_writer.h
+++ b/projects/clr/hipamd/src/hrr/hip_capture_writer.h
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 
 namespace hrr_cap {
 namespace writer {
@@ -20,6 +21,11 @@ bool open(const char* output_dir);
 
 // Returns true if open() has been called successfully.
 bool is_open();
+
+// Store process-level capture metadata as a JSON object fragment. The writer
+// embeds this in pid-<pid>/manifest.json and promotes the owner process metadata
+// into the root manifest.json. Best-effort: invalid/empty metadata is ignored.
+void set_capture_metadata_json(std::string metadata_json);
 
 // Flush events.bin, append the clean-shutdown trailer (hrr_eof_record), fsync,
 // and write manifest.json with "complete": true. Safe to call multiple times

--- a/projects/hip-tests/catch/config/configs/unit/hrr.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/hrr.yaml
@@ -78,6 +78,9 @@ hrr:
   Unit_HRR_DeviceInfoRoundtrip:
     <<: *level_2
     tags: [capture, device, playback, roundtrip]
+  Unit_HRR_MetadataManifest:
+    <<: *level_2
+    tags: [capture, metadata]
   Unit_HRR_StreamAdvancedRoundtrip:
     <<: *level_2
     tags: [capture, stream, playback, roundtrip]

--- a/projects/hip-tests/catch/unit/hrr/hrr_roundtrip_test.cc
+++ b/projects/hip-tests/catch/unit/hrr/hrr_roundtrip_test.cc
@@ -124,6 +124,42 @@ static long long json_integer_value(const std::string& json, const std::string& 
   return (end == json.c_str() + pos) ? missing : value;
 }
 
+static std::string json_object_value(const std::string& json, const std::string& key) {
+  const std::string needle = "\"" + key + "\"";
+  size_t pos = json.find(needle);
+  if (pos == std::string::npos) return {};
+  pos = json.find(':', pos + needle.size());
+  if (pos == std::string::npos) return {};
+  pos = json.find('{', pos + 1);
+  if (pos == std::string::npos) return {};
+
+  int depth = 0;
+  bool in_string = false;
+  bool escape = false;
+  for (size_t i = pos; i < json.size(); ++i) {
+    const char c = json[i];
+    if (in_string) {
+      if (escape) {
+        escape = false;
+      } else if (c == '\\') {
+        escape = true;
+      } else if (c == '"') {
+        in_string = false;
+      }
+      continue;
+    }
+    if (c == '"') {
+      in_string = true;
+    } else if (c == '{') {
+      ++depth;
+    } else if (c == '}') {
+      --depth;
+      if (depth == 0) return json.substr(pos, i - pos + 1);
+    }
+  }
+  return {};
+}
+
 // ---------------------------------------------------------------------------
 // hrr_run_playback — spawn hrr-playback, capture stdout, assert:
 //   1. Exit code == 0.
@@ -734,11 +770,10 @@ HIP_TEST_CASE(Unit_HRR_MetadataManifest) {
   fs::path archive_path = hrr_single_process_archive(cap.path);
   REQUIRE(fs::exists(cap.path / "manifest.json"));
   REQUIRE(fs::exists(archive_path / "manifest.json"));
-  REQUIRE(fs::exists(archive_path / "metadata.json"));
 
   const std::string root_manifest = read_text_file(cap.path / "manifest.json");
   const std::string proc_manifest = read_text_file(archive_path / "manifest.json");
-  const std::string metadata = read_text_file(archive_path / "metadata.json");
+  const std::string metadata = json_object_value(proc_manifest, "metadata");
 
   INFO("Root manifest:\n" << root_manifest);
   INFO("Process manifest:\n" << proc_manifest);
@@ -747,6 +782,7 @@ HIP_TEST_CASE(Unit_HRR_MetadataManifest) {
   REQUIRE(json_integer_value(root_manifest, "version") == 2);
   REQUIRE(json_has_key(root_manifest, "metadata"));
   REQUIRE(json_has_key(proc_manifest, "metadata"));
+  REQUIRE_FALSE(metadata.empty());
   REQUIRE(json_has_key(root_manifest, "has_metadata"));
   REQUIRE(root_manifest.find("\"has_metadata\": true") != std::string::npos);
 
@@ -758,7 +794,10 @@ HIP_TEST_CASE(Unit_HRR_MetadataManifest) {
   CHECK_FALSE(runtime_version.empty());
   CHECK_FALSE(driver_version.empty());
   CHECK(json_has_key(metadata, "comgr"));
-  CHECK(json_has_key(metadata, "available"));
+  const std::string comgr = json_object_value(metadata, "comgr");
+  CHECK_FALSE(comgr.empty());
+  CHECK(json_has_key(comgr, "major"));
+  CHECK(json_has_key(comgr, "minor"));
   CHECK(json_has_key(metadata, "device_count"));
   CHECK(json_integer_value(metadata, "device_count") >= 1);
   CHECK(json_has_key(metadata, "devices"));

--- a/projects/hip-tests/catch/unit/hrr/hrr_roundtrip_test.cc
+++ b/projects/hip-tests/catch/unit/hrr/hrr_roundtrip_test.cc
@@ -786,7 +786,13 @@ HIP_TEST_CASE(Unit_HRR_MetadataManifest) {
   CHECK_FALSE(runtime_version.empty());
   CHECK_FALSE(comgr_version.empty());
   CHECK(json_has_key(metadata, "device_count"));
-  CHECK(json_integer_value(metadata, "device_count") >= 1);
+  CHECK(json_has_key(metadata, "captured_device_count"));
+  CHECK(json_has_key(metadata, "device_metadata_errors"));
+  const long long device_count = json_integer_value(metadata, "device_count");
+  const long long captured_device_count = json_integer_value(metadata, "captured_device_count");
+  CHECK(device_count >= 1);
+  CHECK(captured_device_count >= 1);
+  CHECK(captured_device_count <= device_count);
   CHECK(json_has_key(metadata, "devices"));
   CHECK(json_has_key(metadata, "ordinal"));
   CHECK(json_has_key(metadata, "properties"));

--- a/projects/hip-tests/catch/unit/hrr/hrr_roundtrip_test.cc
+++ b/projects/hip-tests/catch/unit/hrr/hrr_roundtrip_test.cc
@@ -787,7 +787,6 @@ HIP_TEST_CASE(Unit_HRR_MetadataManifest) {
   CHECK_FALSE(comgr_version.empty());
   CHECK(json_has_key(metadata, "device_count"));
   CHECK(json_has_key(metadata, "captured_device_count"));
-  CHECK(json_has_key(metadata, "device_metadata_errors"));
   const long long device_count = json_integer_value(metadata, "device_count");
   const long long captured_device_count = json_integer_value(metadata, "captured_device_count");
   CHECK(device_count >= 1);

--- a/projects/hip-tests/catch/unit/hrr/hrr_roundtrip_test.cc
+++ b/projects/hip-tests/catch/unit/hrr/hrr_roundtrip_test.cc
@@ -35,8 +35,11 @@
 #include "hrr_reader.h"
 #include "hrr_api_args.h"
 
+#include <cctype>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -81,6 +84,44 @@ static fs::path hrr_single_process_archive(const fs::path& root) {
   INFO("Process archive count: " << archives.size());
   REQUIRE(archives.size() == 1);
   return archives.front();
+}
+
+static std::string read_text_file(const fs::path& path) {
+  std::ifstream in(path, std::ios::binary);
+  std::ostringstream ss;
+  ss << in.rdbuf();
+  return ss.str();
+}
+
+static bool json_has_key(const std::string& json, const std::string& key) {
+  return json.find("\"" + key + "\"") != std::string::npos;
+}
+
+static std::string json_string_value(const std::string& json, const std::string& key) {
+  const std::string needle = "\"" + key + "\"";
+  size_t pos = json.find(needle);
+  if (pos == std::string::npos) return {};
+  pos = json.find(':', pos + needle.size());
+  if (pos == std::string::npos) return {};
+  pos = json.find('"', pos + 1);
+  if (pos == std::string::npos) return {};
+  size_t end = json.find('"', pos + 1);
+  if (end == std::string::npos) return {};
+  return json.substr(pos + 1, end - pos - 1);
+}
+
+static long long json_integer_value(const std::string& json, const std::string& key,
+                                    long long missing = -1) {
+  const std::string needle = "\"" + key + "\"";
+  size_t pos = json.find(needle);
+  if (pos == std::string::npos) return missing;
+  pos = json.find(':', pos + needle.size());
+  if (pos == std::string::npos) return missing;
+  ++pos;
+  while (pos < json.size() && std::isspace(static_cast<unsigned char>(json[pos]))) ++pos;
+  char* end = nullptr;
+  long long value = std::strtoll(json.c_str() + pos, &end, 10);
+  return (end == json.c_str() + pos) ? missing : value;
 }
 
 // ---------------------------------------------------------------------------
@@ -676,6 +717,60 @@ HIP_TEST_CASE(Unit_HRR_MemsetVariantsRoundtrip) {
 HIP_TEST_CASE(Unit_HRR_DeviceInfoRoundtrip) {
   ScopedDir cap{fs::temp_directory_path() / "hrr_roundtrip_deviceinfo"};
   hrr_run_roundtrip("Unit_HRR_DeviceInfo_Direct", cap.path);
+}
+
+HIP_TEST_CASE(Unit_HRR_MetadataManifest) {
+  ScopedDir cap{fs::temp_directory_path() / "hrr_metadata_manifest"};
+
+  {
+    hip::SpawnProc proc(HRR_TEST_EXE);
+    proc.setEnv("HIP_HRR_CAPTURE_OUTPUT", cap.path.string());
+    set_proc_search_path(proc);
+    int ret = proc.run("\"Unit_HRR_DeviceInfo_Direct\"");
+    INFO("Metadata capture subprocess exit code: " << ret);
+    REQUIRE(ret == 0);
+  }
+
+  fs::path archive_path = hrr_single_process_archive(cap.path);
+  REQUIRE(fs::exists(cap.path / "manifest.json"));
+  REQUIRE(fs::exists(archive_path / "manifest.json"));
+  REQUIRE(fs::exists(archive_path / "metadata.json"));
+
+  const std::string root_manifest = read_text_file(cap.path / "manifest.json");
+  const std::string proc_manifest = read_text_file(archive_path / "manifest.json");
+  const std::string metadata = read_text_file(archive_path / "metadata.json");
+
+  INFO("Root manifest:\n" << root_manifest);
+  INFO("Process manifest:\n" << proc_manifest);
+  INFO("Metadata:\n" << metadata);
+
+  REQUIRE(json_integer_value(root_manifest, "version") == 2);
+  REQUIRE(json_has_key(root_manifest, "metadata"));
+  REQUIRE(json_has_key(proc_manifest, "metadata"));
+  REQUIRE(json_has_key(root_manifest, "has_metadata"));
+  REQUIRE(root_manifest.find("\"has_metadata\": true") != std::string::npos);
+
+  CHECK(json_integer_value(metadata, "schema_version") == 1);
+  const std::string runtime_version = json_string_value(metadata, "hip_runtime_version");
+  const std::string driver_version = json_string_value(metadata, "hip_driver_version");
+  INFO("hip_runtime_version=" << runtime_version);
+  INFO("hip_driver_version=" << driver_version);
+  CHECK_FALSE(runtime_version.empty());
+  CHECK_FALSE(driver_version.empty());
+  CHECK(json_has_key(metadata, "comgr"));
+  CHECK(json_has_key(metadata, "available"));
+  CHECK(json_has_key(metadata, "device_count"));
+  CHECK(json_integer_value(metadata, "device_count") >= 1);
+  CHECK(json_has_key(metadata, "devices"));
+  CHECK(json_has_key(metadata, "ordinal"));
+  CHECK(json_has_key(metadata, "properties"));
+  CHECK(json_has_key(metadata, "name"));
+  CHECK(json_has_key(metadata, "gcn_arch_name"));
+  CHECK(json_has_key(metadata, "total_global_mem"));
+  CHECK(json_has_key(metadata, "multi_processor_count"));
+  CHECK(json_has_key(metadata, "compute_capability"));
+  CHECK(json_has_key(metadata, "pci"));
+  CHECK(json_has_key(metadata, "uuid"));
 }
 
 HIP_TEST_CASE(Unit_HRR_StreamAdvancedRoundtrip) {

--- a/projects/hip-tests/catch/unit/hrr/hrr_roundtrip_test.cc
+++ b/projects/hip-tests/catch/unit/hrr/hrr_roundtrip_test.cc
@@ -35,6 +35,7 @@
 #include "hrr_reader.h"
 #include "hrr_api_args.h"
 
+#include <algorithm>
 #include <cctype>
 #include <cstdlib>
 #include <filesystem>
@@ -93,31 +94,52 @@ static std::string read_text_file(const fs::path& path) {
   return ss.str();
 }
 
-static bool json_has_key(const std::string& json, const std::string& key) {
-  return json.find("\"" + key + "\"") != std::string::npos;
+static size_t find_string_end(const std::string& json, size_t quote_pos) {
+  bool escape = false;
+  for (size_t i = quote_pos + 1; i < json.size(); ++i) {
+    const char c = json[i];
+    if (escape) {
+      escape = false;
+    } else if (c == '\\') {
+      escape = true;
+    } else if (c == '"') {
+      return i;
+    }
+  }
+  return std::string::npos;
+}
+
+static size_t find_key_value(const std::string& json, const std::string& key) {
+  size_t pos = 0;
+  while ((pos = json.find('"', pos)) != std::string::npos) {
+    const size_t end = find_string_end(json, pos);
+    if (end == std::string::npos) return std::string::npos;
+    if (json.compare(pos + 1, end - pos - 1, key) == 0) {
+      size_t colon = end + 1;
+      while (colon < json.size() && std::isspace(static_cast<unsigned char>(json[colon]))) ++colon;
+      if (colon < json.size() && json[colon] == ':') {
+        size_t value = colon + 1;
+        while (value < json.size() && std::isspace(static_cast<unsigned char>(json[value]))) ++value;
+        return value;
+      }
+    }
+    pos = end + 1;
+  }
+  return std::string::npos;
 }
 
 static std::string json_string_value(const std::string& json, const std::string& key) {
-  const std::string needle = "\"" + key + "\"";
-  size_t pos = json.find(needle);
-  if (pos == std::string::npos) return {};
-  pos = json.find(':', pos + needle.size());
-  if (pos == std::string::npos) return {};
-  pos = json.find('"', pos + 1);
-  if (pos == std::string::npos) return {};
-  size_t end = json.find('"', pos + 1);
+  size_t pos = find_key_value(json, key);
+  if (pos == std::string::npos || pos >= json.size() || json[pos] != '"') return {};
+  size_t end = find_string_end(json, pos);
   if (end == std::string::npos) return {};
   return json.substr(pos + 1, end - pos - 1);
 }
 
 static long long json_integer_value(const std::string& json, const std::string& key,
                                     long long missing = -1) {
-  const std::string needle = "\"" + key + "\"";
-  size_t pos = json.find(needle);
+  size_t pos = find_key_value(json, key);
   if (pos == std::string::npos) return missing;
-  pos = json.find(':', pos + needle.size());
-  if (pos == std::string::npos) return missing;
-  ++pos;
   while (pos < json.size() && std::isspace(static_cast<unsigned char>(json[pos]))) ++pos;
   char* end = nullptr;
   long long value = std::strtoll(json.c_str() + pos, &end, 10);
@@ -125,13 +147,8 @@ static long long json_integer_value(const std::string& json, const std::string& 
 }
 
 static std::string json_object_value(const std::string& json, const std::string& key) {
-  const std::string needle = "\"" + key + "\"";
-  size_t pos = json.find(needle);
-  if (pos == std::string::npos) return {};
-  pos = json.find(':', pos + needle.size());
-  if (pos == std::string::npos) return {};
-  pos = json.find('{', pos + 1);
-  if (pos == std::string::npos) return {};
+  size_t pos = find_key_value(json, key);
+  if (pos == std::string::npos || pos >= json.size() || json[pos] != '{') return {};
 
   int depth = 0;
   bool in_string = false;
@@ -158,6 +175,11 @@ static std::string json_object_value(const std::string& json, const std::string&
     }
   }
   return {};
+}
+
+static bool json_array_exists(const std::string& json, const std::string& key) {
+  size_t pos = find_key_value(json, key);
+  return pos != std::string::npos && pos < json.size() && json[pos] == '[';
 }
 
 // ---------------------------------------------------------------------------
@@ -785,24 +807,38 @@ HIP_TEST_CASE(Unit_HRR_MetadataManifest) {
   INFO("comgr_version=" << comgr_version);
   CHECK_FALSE(runtime_version.empty());
   CHECK_FALSE(comgr_version.empty());
-  CHECK(json_has_key(metadata, "device_count"));
-  CHECK(json_has_key(metadata, "captured_device_count"));
+  CHECK(std::count(runtime_version.begin(), runtime_version.end(), '.') == 2);
+  CHECK(std::count(comgr_version.begin(), comgr_version.end(), '.') == 1);
+
   const long long device_count = json_integer_value(metadata, "device_count");
   const long long captured_device_count = json_integer_value(metadata, "captured_device_count");
   CHECK(device_count >= 1);
   CHECK(captured_device_count >= 1);
   CHECK(captured_device_count <= device_count);
-  CHECK(json_has_key(metadata, "devices"));
-  CHECK(json_has_key(metadata, "ordinal"));
-  CHECK(json_has_key(metadata, "properties"));
-  CHECK(json_has_key(metadata, "name"));
-  CHECK(json_has_key(metadata, "gcn_arch_name"));
-  CHECK(json_has_key(metadata, "total_global_mem"));
-  CHECK(json_has_key(metadata, "multi_processor_count"));
-  CHECK(json_has_key(metadata, "compute_mode"));
-  CHECK(json_has_key(metadata, "compute_capability"));
-  CHECK(json_has_key(metadata, "pci"));
-  CHECK(json_has_key(metadata, "uuid"));
+  CHECK(json_array_exists(metadata, "devices"));
+
+  const long long ordinal = json_integer_value(metadata, "ordinal");
+  const long long total_global_mem = json_integer_value(metadata, "total_global_mem");
+  const long long multi_processor_count = json_integer_value(metadata, "multi_processor_count");
+  const long long compute_mode = json_integer_value(metadata, "compute_mode");
+  const std::string name = json_string_value(metadata, "name");
+  const std::string gcn_arch_name = json_string_value(metadata, "gcn_arch_name");
+  const std::string compute_capability = json_string_value(metadata, "compute_capability");
+  const std::string pci = json_string_value(metadata, "pci");
+  const std::string uuid = json_string_value(metadata, "uuid");
+
+  CHECK(ordinal >= 0);
+  CHECK_FALSE(json_object_value(metadata, "properties").empty());
+  CHECK_FALSE(name.empty());
+  CHECK_FALSE(gcn_arch_name.empty());
+  CHECK(total_global_mem > 0);
+  CHECK(multi_processor_count > 0);
+  CHECK(compute_mode >= 0);
+  CHECK_FALSE(compute_capability.empty());
+  CHECK(std::count(compute_capability.begin(), compute_capability.end(), '.') == 1);
+  CHECK_FALSE(pci.empty());
+  CHECK(std::count(pci.begin(), pci.end(), ':') == 2);
+  CHECK_FALSE(uuid.empty());
 }
 
 HIP_TEST_CASE(Unit_HRR_StreamAdvancedRoundtrip) {

--- a/projects/hip-tests/catch/unit/hrr/hrr_roundtrip_test.cc
+++ b/projects/hip-tests/catch/unit/hrr/hrr_roundtrip_test.cc
@@ -768,36 +768,23 @@ HIP_TEST_CASE(Unit_HRR_MetadataManifest) {
   }
 
   fs::path archive_path = hrr_single_process_archive(cap.path);
-  REQUIRE(fs::exists(cap.path / "manifest.json"));
   REQUIRE(fs::exists(archive_path / "manifest.json"));
 
-  const std::string root_manifest = read_text_file(cap.path / "manifest.json");
   const std::string proc_manifest = read_text_file(archive_path / "manifest.json");
   const std::string metadata = json_object_value(proc_manifest, "metadata");
 
-  INFO("Root manifest:\n" << root_manifest);
   INFO("Process manifest:\n" << proc_manifest);
   INFO("Metadata:\n" << metadata);
 
-  REQUIRE(json_integer_value(root_manifest, "version") == 2);
-  REQUIRE(json_has_key(root_manifest, "metadata"));
-  REQUIRE(json_has_key(proc_manifest, "metadata"));
   REQUIRE_FALSE(metadata.empty());
-  REQUIRE(json_has_key(root_manifest, "has_metadata"));
-  REQUIRE(root_manifest.find("\"has_metadata\": true") != std::string::npos);
 
   CHECK(json_integer_value(metadata, "schema_version") == 1);
   const std::string runtime_version = json_string_value(metadata, "hip_runtime_version");
-  const std::string driver_version = json_string_value(metadata, "hip_driver_version");
+  const std::string comgr_version = json_string_value(metadata, "comgr_version");
   INFO("hip_runtime_version=" << runtime_version);
-  INFO("hip_driver_version=" << driver_version);
+  INFO("comgr_version=" << comgr_version);
   CHECK_FALSE(runtime_version.empty());
-  CHECK_FALSE(driver_version.empty());
-  CHECK(json_has_key(metadata, "comgr"));
-  const std::string comgr = json_object_value(metadata, "comgr");
-  CHECK_FALSE(comgr.empty());
-  CHECK(json_has_key(comgr, "major"));
-  CHECK(json_has_key(comgr, "minor"));
+  CHECK_FALSE(comgr_version.empty());
   CHECK(json_has_key(metadata, "device_count"));
   CHECK(json_integer_value(metadata, "device_count") >= 1);
   CHECK(json_has_key(metadata, "devices"));
@@ -807,6 +794,7 @@ HIP_TEST_CASE(Unit_HRR_MetadataManifest) {
   CHECK(json_has_key(metadata, "gcn_arch_name"));
   CHECK(json_has_key(metadata, "total_global_mem"));
   CHECK(json_has_key(metadata, "multi_processor_count"));
+  CHECK(json_has_key(metadata, "compute_mode"));
   CHECK(json_has_key(metadata, "compute_capability"));
   CHECK(json_has_key(metadata, "pci"));
   CHECK(json_has_key(metadata, "uuid"));


### PR DESCRIPTION
## Motivation

feat: Add HRR capture metadata to manifests

## Technical Details

 Summary
  - Added HRR metadata collection for capture archives.
  - Metadata is written and embedded in per-process manifest.json.
  - Added Unit_HRR_MetadataManifest coverage in hip-tests.

  Details
  - Captures runtime metadata:
      - hip_runtime_version
      - comgr version via amd_comgr_get_version
  - Captures device metadata from initialized HIP internal state:
      - device count from hip::g_devices
      - selected hipGetDeviceProperties fields via hip::ihipGetDeviceProperties
  - Avoids public HIP API calls during hip_capture_init() to prevent re-entering HIP initialization.
  - Keeps metadata best-effort and separate from HRR event stream semantics.

JIRA ID: AIRUNTIME-2509

## Test Plan

./HrrTest 'Unit_HRR_MetadataManifest' -s

## Test Result

all passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
