### PR TITLE
test(rccl): add net plugin reload regression test

### DIFF
--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -195,6 +195,8 @@ if(BUILD_TESTS)
     SendRecvTests.cpp
     StandaloneTests.cpp
     DdaIpcTests.cpp
+    NetPluginReloadTests.cpp
+    plugin/net_reload_plugin.cpp
     TeardownStressTests.cpp
     _RecorderTests.cpp
     common/main.cpp
@@ -227,6 +229,17 @@ if(BUILD_TESTS)
 
   # Create rccl-UnitTests binary
   add_executable(rccl-UnitTests ${TEST_SOURCE_FILES})
+
+  # AICOMRCCL-1534: net_reload_plugin.cpp is compiled into rccl-UnitTests and loaded
+  # in-process via NCCL_NET_PLUGIN=STATIC_PLUGIN (dlopen(NULL)), so no external .so.
+  # Scope its headers to the file so the generic example headers don't shadow others.
+  set_source_files_properties(plugin/net_reload_plugin.cpp PROPERTIES
+    INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../plugins/net/example/nccl)
+
+  # dlsym(dlopen(NULL), ...) only finds symbols present in the dynamic symbol table;
+  # export just the one plugin symbol (narrow, unlike a broad -rdynamic).
+  target_link_options(rccl-UnitTests PRIVATE
+    "LINKER:--export-dynamic-symbol=ncclNetPlugin_v10")
 
   # rccl-UnitTestsFixtures: Tests that only use header-only internal dependencies
   # (inline, static, constexpr, template functions) and can run in both Release and Debug.

--- a/projects/rccl/test/NetPluginReloadTests.cpp
+++ b/projects/rccl/test/NetPluginReloadTests.cpp
@@ -1,0 +1,115 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Regression test for AICOMRCCL-1534 (NCCL GitHub issue #1978): a non-default
+// NCCL_NET_PLUGIN must remain reloadable after the communicator that first used
+// it is destroyed. Before the fix, ncclNetPluginUnload memset() the plugin
+// struct and wiped the plugin name parsed once from NCCL_NET_PLUGIN, so the
+// second communicator silently fell back to the default net plugin.
+//
+// The test uses a tiny net plugin (plugin/net_reload_plugin.cpp) compiled into
+// this test binary that records every real init() call, then creates and
+// destroys a communicator twice in one process. The plugin must be initialised
+// twice (once per comm).
+
+#include <gtest/gtest.h>
+#include <rccl/rccl.h>
+#include <hip/hip_runtime.h>
+
+#include <unistd.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+#include "common/ProcessIsolatedTestRunner.hpp"
+
+namespace RcclUnitTesting {
+namespace {
+
+// One create/destroy cycle per iteration; the plugin must be (re)initialised
+// once per cycle, so the expected init count equals this.
+constexpr int kNumCommCycles = 2;
+
+// Creates a unique file from an mkstemp template and unlinks it on scope exit,
+// so an early-returning ASSERT_ cannot leak it into /tmp
+class ScopedTempFile {
+ public:
+  explicit ScopedTempFile(const char* pathTemplate) : path_(pathTemplate) {
+    int fd = mkstemp(path_.data());
+    if (fd >= 0) {
+      valid_ = true;
+      close(fd);
+    }
+  }
+
+  ~ScopedTempFile() {
+    if (valid_) unlink(path_.c_str());
+  }
+
+  ScopedTempFile(const ScopedTempFile&) = delete;
+  ScopedTempFile& operator=(const ScopedTempFile&) = delete;
+
+  bool valid() const { return valid_; }
+
+  const std::string& path() const { return path_; }
+
+ private:
+  std::string path_;
+  bool valid_ = false;
+};
+
+int countLines(const std::string& path) {
+  std::ifstream f(path);
+  int count = 0;
+  std::string line;
+  while (std::getline(f, line))
+    if (!line.empty()) ++count;
+  return count;
+}
+
+} // namespace
+
+TEST(NetPluginReload, CustomPluginReloadsAfterCommDestroy) {
+  RUN_ISOLATED_TEST("NetPluginReload.CustomPluginReloadsAfterCommDestroy", []() {
+    int deviceCount = 0;
+    if (hipGetDeviceCount(&deviceCount) != hipSuccess || deviceCount < 1)
+      GTEST_SKIP() << "requires at least one GPU";
+
+    ScopedTempFile counterFile("/tmp/rccl_net_reload_XXXXXX");
+    ASSERT_TRUE(counterFile.valid()) << "failed to create counter file";
+
+    ASSERT_EQ(setenv("RCCL_NET_RELOAD_COUNTER_FILE", counterFile.path().c_str(), 1), 0);
+
+    // The test plugin is compiled into this binary and its ncclNetPlugin_v10
+    // symbol is exported (see test/CMakeLists.txt). NCCL_NET_PLUGIN=STATIC_PLUGIN
+    // makes the loader dlopen(NULL) and resolve that in-process symbol
+    ASSERT_EQ(setenv("NCCL_NET_PLUGIN", "STATIC_PLUGIN", 1), 0);
+
+    ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+    for (int cycle = 0; cycle < kNumCommCycles; ++cycle) {
+      ncclUniqueId id;
+      ASSERT_EQ(ncclGetUniqueId(&id), ncclSuccess);
+
+      ncclComm_t comm = nullptr;
+      ASSERT_EQ(ncclCommInitRank(&comm, 1, id, 0), ncclSuccess)
+        << "comm init cycle " << cycle << " failed";
+
+      ASSERT_EQ(ncclCommDestroy(comm), ncclSuccess);
+    }
+
+    int loads = countLines(counterFile.path());
+
+    // Fixed: plugin reloaded for every cycle -> kNumCommCycles init calls.
+    // Pre-fix: name wiped on unload, later cycles use the default plugin -> 1.
+    EXPECT_EQ(loads, kNumCommCycles)
+        << "custom net plugin init count = " << loads << " (expected "
+        << kNumCommCycles << "; fewer means the plugin was not reloaded after destroy)";
+  });
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/plugin/net_reload_plugin.cpp
+++ b/projects/rccl/test/plugin/net_reload_plugin.cpp
@@ -1,0 +1,112 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Minimal external RCCL net plugin used only by NetPluginReloadTests
+// (AICOMRCCL-1534). It reports one device so RCCL selects it as the active net
+// plugin, and records every real init() call by appending a line to the file
+// named in RCCL_NET_RELOAD_COUNTER_FILE. The test counts those lines to detect
+// whether the plugin is reloaded after a communicator is destroyed.
+//
+// Compiled as C++ (the RCCL project only enables CXX/HIP), so the plugin symbol
+// is exported with C linkage and default visibility for RCCL's dlsym() lookup.
+//
+// The vtable below is built from the vendored example net headers, which are a
+// separate copy of the v10 plugin ABI from the one getNcclNet_v10() casts the
+// dlsym'd symbol to. Keeping the plugin on v10 is deliberate, and a mismatch
+// between the two copies cannot silently weaken the test: a changed struct
+// layout makes the loader call through wrong offsets and the test fails, and if
+// v10 support is ever dropped the symbol is never looked up, the counter file
+// stays empty and the test asserts with an init count of 0.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "net.h" // from plugins/net/example/nccl
+
+#define __hidden __attribute__((visibility("hidden")))
+#define __exported __attribute__((visibility("default")))
+#define NCCL_PLUGIN_MAX_RECVS 1
+
+static char kPluginName[] = "ReloadTest";
+
+static void recordLoad() {
+  const char* path = getenv("RCCL_NET_RELOAD_COUNTER_FILE");
+  if (path == nullptr) return;
+
+  FILE* f = fopen(path, "a");
+  if (f == nullptr) return;
+
+  fputs("1\n", f);
+  fclose(f);
+}
+
+__hidden ncclResult_t pluginInit_v10(ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction) {
+  (void)logFunction; (void)profFunction;
+  recordLoad();
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t pluginDevices(int* ndev) { *ndev = 1; return ncclSuccess; }
+
+__hidden ncclResult_t pluginGetProperties_v10(int dev, ncclNetProperties_v10_t* props) {
+  props->name = kPluginName;
+  props->pciPath = nullptr;
+  props->guid = 0;
+  props->ptrSupport = NCCL_PTR_HOST;
+  props->regIsGlobal = 0;
+  props->forceFlush = 0;
+  props->speed = 100000;
+  props->port = 0;
+  props->latency = 0;
+  props->maxComms = 1024 * 1024;
+  props->maxRecvs = NCCL_PLUGIN_MAX_RECVS;
+  props->netDeviceType = NCCL_NET_DEVICE_HOST;
+  props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
+  props->vProps.ndevs = 1;
+  props->vProps.devs[0] = dev;
+  props->maxP2pBytes = NCCL_MAX_NET_SIZE_BYTES;
+  props->maxCollBytes = NCCL_MAX_NET_SIZE_BYTES;
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t pluginListen_v10(int d, void* handle, void** listenComm) { return ncclInternalError; }
+__hidden ncclResult_t pluginConnect_v10(int dev, ncclNetCommConfig_v10_t* config, void* handle, void** sendComm, ncclNetDeviceHandle_v10_t** sendDevComm) { return ncclInternalError; }
+__hidden ncclResult_t pluginAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle_v10_t** recvDevComm) { return ncclInternalError; }
+__hidden ncclResult_t pluginRegMr(void* comm, void* data, size_t size, int type, void** mhandle) { return ncclInternalError; }
+__hidden ncclResult_t pluginRegMrDmaBuf(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle) { return ncclInternalError; }
+__hidden ncclResult_t pluginDeregMr(void* comm, void* mhandle) { return ncclInternalError; }
+__hidden ncclResult_t pluginIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request) { return ncclInternalError; }
+__hidden ncclResult_t pluginIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request) { return ncclInternalError; }
+__hidden ncclResult_t pluginIflush(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request) { return ncclInternalError; }
+__hidden ncclResult_t pluginTest(void* request, int* done, int* size) { return ncclInternalError; }
+__hidden ncclResult_t pluginCloseSend(void* sendComm) { return ncclInternalError; }
+__hidden ncclResult_t pluginCloseRecv(void* recvComm) { return ncclInternalError; }
+__hidden ncclResult_t pluginCloseListen(void* listenComm) { return ncclInternalError; }
+__hidden ncclResult_t pluginIrecvConsumed(void* recvComm, int n, void* request) { return ncclInternalError; }
+__hidden ncclResult_t pluginGetDeviceMr(void* comm, void* mhandle, void** dptr_mhandle) { return ncclInternalError; }
+__hidden ncclResult_t pluginMakeVDevice_v10(int* d, ncclNetVDeviceProps_v10_t* props) { return ncclInternalError; }
+
+extern "C" __exported const ncclNet_v10_t ncclNetPlugin_v10 = {
+  kPluginName,
+  pluginInit_v10,
+  pluginDevices,
+  pluginGetProperties_v10,
+  pluginListen_v10,
+  pluginConnect_v10,
+  pluginAccept,
+  pluginRegMr,
+  pluginRegMrDmaBuf,
+  pluginDeregMr,
+  pluginIsend,
+  pluginIrecv,
+  pluginIflush,
+  pluginTest,
+  pluginCloseSend,
+  pluginCloseRecv,
+  pluginCloseListen,
+  pluginGetDeviceMr,
+  pluginIrecvConsumed,
+  pluginMakeVDevice_v10,
+};

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -904,6 +904,20 @@
         {"name": "PluginCompatV11.CollNetLazyInitialization", "description": "AICOMRCCL-1532: v11 collnet plugin compat layer initializes lazily", "test_filter": "PluginCompatV11.CollNetLazyInitialization"}
       ]
     },
+    "net_plugin_reload": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTests",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 120,
+      "rerun_env_variables": {
+        "NCCL_DEBUG": "INFO"
+      },
+      "tests": [
+        {"name": "NetPluginReload.CustomPluginReloadsAfterCommDestroy", "description": "AICOMRCCL-1534: a non-default NCCL_NET_PLUGIN must remain reloadable after the communicator that first used it is destroyed", "test_filter": "NetPluginReload.CustomPluginReloadsAfterCommDestroy"}
+      ]
+    },
     "debug_tests": {
       "is_gtest": true,
       "binary": "rccl-UnitTests",
@@ -3395,6 +3409,12 @@
       "name": "Asymmetric Visibility",
       "description": "Comm init + AllReduce under asymmetric HIP_VISIBLE_DEVICES",
       "config": "asymmetric_visibility",
+      "enabled": true
+    },
+    {
+      "name": "Net Plugin Reload",
+      "description": "AICOMRCCL-1534: custom NCCL_NET_PLUGIN reloads after comm destroy",
+      "config": "net_plugin_reload",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Motivation

A non-default NCCL_NET_PLUGIN must remain reloadable after the communicator that first used it is destroyed. Before the fix, ncclNetPluginUnload wiped the saved plugin name, so a second communicator silently fell back to the default net plugin 

## Technical Details

Add a tiny C++ net plugin (MODULE) that counts init() calls and an isolated gtest that creates/destroys a communicator twice, asserting the plugin is reloaded each cycle. Wire it into rccl-UnitTests and the mi300x_mellanox_ib CI config

## JIRA ID

AICOMRCCL-1534

## Test Plan

Validated on MI350X (gfx950): 

## Test Result

Passes with the current state of develop branch, fails on the pre-fix memset revision.

2026-07-16T20:57:00.9825023Z [ RUN      ] NetPluginReload.CustomPluginReloadsAfterCommDestroy
2026-07-16T20:57:00.9825996Z [       OK ] NetPluginReload.CustomPluginReloadsAfterCommDestroy (4515 ms)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
