### PR TITLE
fix(rocprofiler): Update MI355 runner labels

### DIFF
--- a/.github/workflows/rocprofiler-compute-sanitizers.yml
+++ b/.github/workflows/rocprofiler-compute-sanitizers.yml
@@ -55,7 +55,7 @@ env:
 jobs:
   sanitizer:
     name: ${{ matrix.sanitizer.name }}
-    runs-on: linux-mi355-1gpu-ossci-rocm
+    runs-on: linux-gfx950-1gpu-ccs-ossci-rocm
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -182,7 +182,7 @@ jobs:
           python3 ./tools/run-ci.py \
             --name "ROCm/rocprofiler-compute-${{ github.ref_name }}-ubuntu-24.04-${{ matrix.sanitizer.name }}" \
             --actor "${{ github.actor }}" \
-            --site linux-mi355-1gpu-ossci-rocm \
+            --site linux-gfx950-1gpu-ccs-ossci-rocm \
             --mode Continuous \
             --build-jobs 16 \
             --repeat-until-pass 1 \

--- a/projects/rocprofiler-compute/.github/ci-matrix.yml
+++ b/projects/rocprofiler-compute/.github/ci-matrix.yml
@@ -2,8 +2,8 @@
 
 matrix-ubuntu-nightly:
   # MI355
-  - { os-release: '22.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
-  - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
+  - { os-release: '22.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-gfx950-1gpu-ccs-ossci-rocm' }
+  - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-gfx950-1gpu-ccs-ossci-rocm' }
   # MI325
   - { os-release: '22.04', gpu: 'mi325', arch: 'gfx94X', runner: 'linux-gfx942-1gpu-ccs-csp-ossci-rocm' }
   - { os-release: '24.04', gpu: 'mi325', arch: 'gfx94X', runner: 'linux-gfx942-1gpu-ccs-csp-ossci-rocm' }
@@ -15,6 +15,6 @@ matrix-ubuntu-nightly:
   - { os-release: '24.04', gpu: 'strix-halo', arch: 'gfx1151', runner: 'linux-gfx1151-gpu-rocm' }
 matrix-ubuntu-ci:
   # MI355
-  - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
+  - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-gfx950-1gpu-ccs-ossci-rocm' }
   # Strix Halo
   - { os-release: '24.04', gpu: 'strix-halo', arch: 'gfx1151', runner: 'linux-gfx1151-gpu-rocm' }

--- a/projects/rocprofiler-systems/.github/ci-matrix.yml
+++ b/projects/rocprofiler-systems/.github/ci-matrix.yml
@@ -2,8 +2,8 @@
 
 matrix-nightly:
   # MI355
-  - { os-release: '22.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
-  - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
+  - { os-release: '22.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-gfx950-1gpu-ccs-ossci-rocm' }
+  - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-gfx950-1gpu-ccs-ossci-rocm' }
   # MI325
   - { os-release: '22.04', gpu: 'mi325', arch: 'gfx94X', runner: 'linux-gfx942-1gpu-ccs-csp-ossci-rocm' }
   - { os-release: '24.04', gpu: 'mi325', arch: 'gfx94X', runner: 'linux-gfx942-1gpu-ccs-csp-ossci-rocm' }
@@ -15,4 +15,4 @@ matrix-nightly:
   - { os-release: '24.04', gpu: 'navi4x', arch: 'gfx120X', runner: 'linux-gfx120X-gpu-rocm' }
 matrix-ci:
   # MI355
-  - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
+  - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-gfx950-1gpu-ccs-ossci-rocm' }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
It appears that the MI355 runner label we were using has been changed. Quick fix to update these while we await #8551 to be merged which will instead pull runner labels directly from therock-ci-config.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
- Updated rocprofiler-compute and rocprofiler-systems runner labels to use new name from therock-ci-config
  - `.github/workflows/rocprofiler-compute-sanitizers.yml`
  - `projects/rocprofiler-compute/.github/ci-matrix.yml`
  - `projects/rocprofiler-systems/.github/ci-matrix.yml`

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
JIRA ID : AIPROFSYST-591

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ensure MI355 runs get picked up properly

## Test Result

<!-- Briefly summarize test outcomes. -->
MI355 runners are picked up

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
