### PR TITLE
[rocr-runtime][trap handler] Refactors the GFX9 PC sampling trap handler to mirror the structure already established in trap_handler_gfx12.s

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s
@@ -206,6 +206,66 @@
   .endif
  .endm
 
+ // ============================================================================
+ // GFX9.4+ PC Sampling Refactored Macros
+ // ============================================================================
+ // These macros unify duplicated code between hosttrap and stochastic paths.
+
+ // CALC_XCC_OFFSET_GFX94 - Calculate per-XCC buffer address for multi-XCC systems
+ // Input:
+ //   ttmp[2:3] = buffer base address
+ //   ttmp4     = per_xcc_size (stride per XCC)
+ //   ttmp5     = XCC_ID
+ // Output:
+ //   ttmp[14:15] = buffer_base + (XCC_ID * per_xcc_size)
+ // Clobbers: ttmp[14:15] (output), uses ttmp4, ttmp5
+ .macro CALC_XCC_OFFSET_GFX94
+  .if (.amdgcn.gfx_generation_minor >= 4)
+    s_mul_i32                             ttmp14, ttmp4, ttmp5            // ttmp14 = lo32(offset)
+    s_mul_hi_u32                          ttmp15, ttmp4, ttmp5            // ttmp15 = hi32(offset)
+    s_add_u32                             ttmp14, ttmp2, ttmp14           // ttmp14:15 = base + offset
+    s_addc_u32                            ttmp15, ttmp3, ttmp15
+  .endif
+ .endm
+
+ // FILL_SAMPLE_COMMON_GFX94 - Store common sample fields shared by hosttrap and stochastic
+ // This stores: timestamp, EXEC mask, workgroup IDs, wave_in_wg with chiplet, HW_ID
+ // Input:
+ //   ttmp[2:3] = pointer to sample buffer entry (&buffer[local_entry])
+ //   ttmp[4:5] = timestamp (from s_memrealtime, must be read before calling)
+ //   ttmp[8:9:10] = workgroup IDs (from ABI)
+ //   ttmp11 = wave_in_wg info (from ABI)
+ // Output:
+ //   Stores fields at offsets 0x08-0x20, 0x30 in sample structure
+ // Clobbers: ttmp4, ttmp5, ttmp6 (on gfx94x)
+ .macro FILL_SAMPLE_COMMON_GFX94
+  .if (.amdgcn.gfx_generation_minor >= 4)
+    // Store timestamp at offset 0x30
+    s_store_dwordx2                       ttmp[4:5], ttmp[2:3], 0x30
+
+    // Store EXEC mask at offset 0x08-0x0c
+    s_mov_b32                             ttmp6, exec_lo
+    s_store_dword                         ttmp6, ttmp[2:3], 0x8
+    s_mov_b32                             ttmp6, exec_hi
+    s_store_dword                         ttmp6, ttmp[2:3], 0xc
+
+    // Store workgroup IDs at offsets 0x10-0x18
+    s_store_dwordx2                       ttmp[8:9], ttmp[2:3], 0x10
+    s_store_dword                         ttmp10, ttmp[2:3], 0x18
+
+    // Store wave_in_wg and chiplet (XCC_ID) at offset 0x1c
+    s_getreg_b32                          ttmp4, hwreg(HW_REG_XCC_ID)
+    s_lshl_b32                            ttmp4, ttmp4, 8
+    s_and_b32                             ttmp5, ttmp11, TTMP11_WAVE_IN_WG_MASK
+    s_or_b32                              ttmp4, ttmp4, ttmp5
+    s_store_dword                         ttmp4, ttmp[2:3], 0x1c
+
+    // Store HW_ID at offset 0x20
+    s_getreg_b32                          ttmp4, hwreg(HW_REG_HW_ID)
+    s_store_dword                         ttmp4, ttmp[2:3], 0x20
+  .endif
+ .endm
+
 .endif
 
 // ABI between first and second level trap handler:
@@ -317,13 +377,8 @@ trap_entry:
   s_cmp_eq_u64                          ttmp[2:3], 0
   s_cbranch_scc1                        .exit_trap
 
-  // Calculate offset directly into ttmp14:15 (TMA2 pointer no longer needed after loads complete)
-  s_mul_i32                             ttmp14, ttmp4, ttmp5            // ttmp14 = lo32(offset)
-  s_mul_hi_u32                          ttmp15, ttmp4, ttmp5            // ttmp15 = hi32(offset)
-
-  // ttmp14:15 = base (ttmp2:3) + offset (ttmp14:15)
-  s_add_u32                             ttmp14, ttmp2, ttmp14
-  s_addc_u32                            ttmp15, ttmp3, ttmp15
+  // Calculate per-XCC buffer address: ttmp[14:15] = ttmp[2:3] + (ttmp4 * ttmp5)
+  CALC_XCC_OFFSET_GFX94
   s_branch                              .profile_trap_handlers_gfx9
 .else
   // GFX9.0-9.3 (single-XCC): Simple pointer copy, no per-XCC offset needed
@@ -383,13 +438,8 @@ trap_entry:
   s_cmp_eq_u64                          ttmp[2:3], 0
   s_cbranch_scc1                        .exit_trap
 
-  // Calculate offset directly into ttmp14:15 (TMA2 pointer no longer needed after loads complete)
-  s_mul_i32                             ttmp14, ttmp4, ttmp5            // ttmp14 = lo32(offset)
-  s_mul_hi_u32                          ttmp15, ttmp4, ttmp5            // ttmp15 = hi32(offset)
-
-  // ttmp14:15 = base (ttmp2:3) + offset (ttmp14:15)
-  s_add_u32                             ttmp14, ttmp2, ttmp14
-  s_addc_u32                            ttmp15, ttmp3, ttmp15
+  // Calculate per-XCC buffer address: ttmp[14:15] = ttmp[2:3] + (ttmp4 * ttmp5)
+  CALC_XCC_OFFSET_GFX94
   s_branch                              .profile_trap_handlers_gfx9      // Off to the profile handlers
 .else
   s_branch                              .no_skip_debugtrap
@@ -526,14 +576,25 @@ trap_entry:
   //    buf->correlation_id = get_correlation_id();
   // }
 .fill_sample_hosttrap:
+  // Calculate buffer entry address: ttmp[2:3] = &bufferX[local_entry]
   s_mul_i32                             ttmp2, ttmp7, 0x40              // offset into buffer for 64B objects
   s_mul_hi_u32                          ttmp3, ttmp7, 0x40              // ttmp[2:3] will contain byte ...
   s_add_u32                             ttmp2, ttmp2, ttmp4
   s_addc_u32                            ttmp3, ttmp3, ttmp5             // ttmp[2:3]=&bufferX[local_entry]
+
+  // Read timestamp and wait for it
   s_memrealtime                         ttmp[4:5]
+  s_waitcnt                             lgkmcnt(0)
+
+  // Store hosttrap-specific field: PC at offset 0x00
   s_and_b32                             ttmp1, ttmp1, 0xffff            // clear out extra data from PC_HI
   s_store_dwordx2                       ttmp[0:1], ttmp[2:3]            // store PC
-  s_waitcnt                             lgkmcnt(0)                      // wait for timestamp
+
+.if (.amdgcn.gfx_generation_number == 9 && .amdgcn.gfx_generation_minor >= 4)
+  // GFX9.4+: Use unified macro for common sample fields
+  FILL_SAMPLE_COMMON_GFX94
+.else
+  // GFX9.0-9.3: Store common fields inline (no XCC_ID, different register usage)
   S_MOV_B32_SRC_PCS_TTMP_REG1           exec_lo
   S_STORE_DWORD_PCS_TTMP_REG1           ttmp[2:3], 0x8                  // store EXEC_LO
   S_MOV_B32_SRC_PCS_TTMP_REG1           exec_hi
@@ -541,53 +602,36 @@ trap_entry:
   s_store_dwordx2                       ttmp[8:9], ttmp[2:3], 0x10      // store wg_id_x and wg_id_y
   s_store_dword                         ttmp10, ttmp[2:3], 0x18         // store wg_id_z
   s_store_dwordx2                       ttmp[4:5], ttmp[2:3], 0x30      // store timestamp
-
-.if (.amdgcn.gfx_generation_number == 9 && .amdgcn.gfx_generation_minor >= 4)
-  s_getreg_b32                          ttmp4, hwreg(HW_REG_XCC_ID)     //store XCC_ID
-  s_lshl_b32                            ttmp4, ttmp4, 8
-  s_and_b32                             ttmp5, ttmp11, TTMP11_WAVE_IN_WG_MASK
-  s_or_b32                              ttmp4, ttmp4, ttmp5
-  s_store_dword                         ttmp4, ttmp[2:3], 0x1c          // store wave_in_wg
-.else
   s_and_b32                             ttmp4, ttmp11, 0x3f
   s_store_dword                         ttmp4, ttmp[2:3], 0x1c          // store wave_in_wg
-.endif
   s_getreg_b32                          ttmp4, hwreg(HW_REG_HW_ID)
   s_store_dword                         ttmp4, ttmp[2:3], 0x20          // store HW_ID
+.endif
 
   s_branch                              .get_correlation_id
 
 .if .amdgcn.gfx_generation_number == 9 && .amdgcn.gfx_generation_minor >= 4
 .fill_sample_stochastic:
+  // Calculate buffer entry address: ttmp[2:3] = &buffer[local_entry]
   s_mul_i32                             ttmp2, ttmp7, 0x40              // offset into buffer for 64B objects
   s_mul_hi_u32                          ttmp3, ttmp7, 0x40
   s_add_u32                             ttmp2, ttmp2, ttmp4
   s_addc_u32                            ttmp3, ttmp3, ttmp5             // ttmp[2:3]=&buffer[local_entry]
+
+  // Read timestamp and wait for it
   s_memrealtime                         ttmp[4:5]
-  s_waitcnt                             lgkmcnt(0)                      // Wait for timestamp
-  s_store_dwordx2                       ttmp[4:5], ttmp[2:3] 0x30       // Store timestamp
+  s_waitcnt                             lgkmcnt(0)
 
-  s_getreg_b32                          ttmp4, hwreg(HW_REG_SQ_PERF_SNAPSHOT_PC_LO)
-  s_getreg_b32                          ttmp5, hwreg(HW_REG_SQ_PERF_SNAPSHOT_PC_HI)
-  s_store_dwordx2                       ttmp[4:5], ttmp[2:3] 0x00       // store snapshot data
-  s_getreg_b32                          ttmp5, hwreg(HW_REG_SQ_PERF_SNAPSHOT_DATA1)
-  s_getreg_b32                          ttmp4, hwreg(HW_REG_SQ_PERF_SNAPSHOT_DATA)
-  s_store_dwordx2                       ttmp[4:5], ttmp[2:3], 0x24            // store snapshot PC
+  // Store stochastic-specific fields: snapshot PC and data
+  s_getreg_b32                          ttmp6, hwreg(HW_REG_SQ_PERF_SNAPSHOT_PC_LO)
+  s_getreg_b32                          ttmp7, hwreg(HW_REG_SQ_PERF_SNAPSHOT_PC_HI)
+  s_store_dwordx2                       ttmp[6:7], ttmp[2:3] 0x00       // store snapshot PC at offset 0x00
+  s_getreg_b32                          ttmp7, hwreg(HW_REG_SQ_PERF_SNAPSHOT_DATA1)
+  s_getreg_b32                          ttmp6, hwreg(HW_REG_SQ_PERF_SNAPSHOT_DATA)
+  s_store_dwordx2                       ttmp[6:7], ttmp[2:3], 0x24      // store snapshot data at offset 0x24
 
-  s_mov_b32                             ttmp6, exec_lo
-  s_store_dword                         ttmp6, ttmp[2:3], 0x8           // store EXEC_LO
-  s_mov_b32                             ttmp6, exec_hi
-  s_store_dword                         ttmp6, ttmp[2:3], 0xc           // store EXEC_HI
-
-  s_store_dwordx2                       ttmp[8:9], ttmp[2:3], 0x10      // store wg_id_x and wg_id_y
-  s_store_dword                         ttmp10, ttmp[2:3], 0x18         // store wg_id_z
-  s_getreg_b32                          ttmp4, hwreg(HW_REG_XCC_ID)
-  s_lshl_b32                            ttmp4, ttmp4, 8
-  s_and_b32                             ttmp5, ttmp11, TTMP11_WAVE_IN_WG_MASK
-  s_or_b32                              ttmp4, ttmp4, ttmp5
-  s_store_dword                         ttmp4, ttmp[2:3], 0x1c          // store chiplet_and_wave_id
-  s_getreg_b32                          ttmp4, hwreg(HW_REG_HW_ID)
-  s_store_dword                         ttmp4, ttmp[2:3], 0x20          // store HW_ID
+  // Store common sample fields using unified macro
+  FILL_SAMPLE_COMMON_GFX94
   // ttmp[2:3]=&buffer[local_entry]; ttmp[4:5], ttmp[6:7] are free
   // ttmp[14:15]=ptr to ‘tma’ and is live out; ttmp11.b31 is buf_to_use, 0 or 1
   s_branch                              .get_correlation_id

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s
@@ -206,44 +206,6 @@
   .endif
  .endm
 
- // FILL_SAMPLE_COMMON_GFX94 - Store common sample fields shared by hosttrap and stochastic
- // This stores: timestamp, EXEC mask, workgroup IDs, wave_in_wg with chiplet, HW_ID
- // Input:
- //   ttmp[2:3] = pointer to sample buffer entry (&buffer[local_entry])
- //   ttmp[4:5] = timestamp (from s_memrealtime, must be read before calling)
- //   ttmp[8:9:10] = workgroup IDs (from ABI)
- //   ttmp11 = wave_in_wg info (from ABI)
- // Output:
- //   Stores fields at offsets 0x08-0x20, 0x30 in sample structure
- // Clobbers: ttmp4, ttmp5, ttmp6 (on gfx94x)
- .macro FILL_SAMPLE_COMMON_GFX94
-  .if (.amdgcn.gfx_generation_minor >= 4)
-    // Store timestamp at offset 0x30
-    s_store_dwordx2                       ttmp[4:5], ttmp[2:3], 0x30
-
-    // Store EXEC mask at offset 0x08-0x0c
-    s_mov_b32                             ttmp6, exec_lo
-    s_store_dword                         ttmp6, ttmp[2:3], 0x8
-    s_mov_b32                             ttmp6, exec_hi
-    s_store_dword                         ttmp6, ttmp[2:3], 0xc
-
-    // Store workgroup IDs at offsets 0x10-0x18
-    s_store_dwordx2                       ttmp[8:9], ttmp[2:3], 0x10
-    s_store_dword                         ttmp10, ttmp[2:3], 0x18
-
-    // Store wave_in_wg and chiplet (XCC_ID) at offset 0x1c
-    s_getreg_b32                          ttmp4, hwreg(HW_REG_XCC_ID)
-    s_lshl_b32                            ttmp4, ttmp4, 8
-    s_and_b32                             ttmp5, ttmp11, TTMP11_WAVE_IN_WG_MASK
-    s_or_b32                              ttmp4, ttmp4, ttmp5
-    s_store_dword                         ttmp4, ttmp[2:3], 0x1c
-
-    // Store HW_ID at offset 0x20
-    s_getreg_b32                          ttmp4, hwreg(HW_REG_HW_ID)
-    s_store_dword                         ttmp4, ttmp[2:3], 0x20
-  .endif
- .endm
-
 .endif
 
 // ABI between first and second level trap handler:
@@ -488,32 +450,9 @@ trap_entry:
 
  .if .amdgcn.gfx_generation_number == 9
 
- .if .amdgcn.gfx_generation_minor >= 4
-  // Check if it's a stochastic trap
-  s_bitcmp1_b32                         ttmp13, TTMP13_PCS_IS_STOCHASTIC
-  s_cbranch_scc1                        .fill_sample_stochastic
-  // Check if it's a host trap
-  s_bitcmp1_b32                         ttmp13, TTMP13_PCS_IS_HOSTTRAP
-  s_cbranch_scc1                        .fill_sample_hosttrap
-.else
- // Check if it's a host trap
-  s_bitcmp1_b32                         ttmp11, TTMP11_PCS_IS_HOSTTRAP
-  s_cbranch_scc1                        .fill_sample_hosttrap
-
-.endif
-.endif
-  // If neither bit is set, this is unexpected.
-  // This branch is not expected to be taken.
-  s_branch                              .no_skip_debugtrap
-
-  // ttmp7 contains local_entry, ttmp[4:5] contains "&bufferX",
-  // ttmp[14:15] holds 'tma->host_trap_buffers' pointer
-  // ttmp[2:3] and ttmp13 are available for gathering perf sample info
-  // ttmp[14:15] is live out
-
   // fill_sample(...) - begin //
   // typedef struct {
-  // [0x00]  uint64_t pc;
+  // [0x00]  uint64_t pc;              // host trap PC, or stochastic snapshot PC
   // [0x08]  uint64_t exec_mask;
   // [0x10]  uint32_t workgroup_id_x;
   // [0x14]  uint32_t workgroup_id_y;
@@ -523,27 +462,15 @@ trap_entry:
   //         uint32_t chiplet    : 3;    // XCC_ID on gfx94x, zero on older gfx9
   //         uint32_t reserved   : 21;
   // [0x20]  uint32_t hw_id;
-  // [0x24]  uint32_t reserved0;
-  // [0x28]  uint64_t reserved1;
+  // [0x24]  uint32_t reserved0;        // stochastic: snapshot DATA
+  // [0x28]  uint64_t reserved1;        // stochastic: snapshot DATA1
   // [0x30]  uint64_t timestamp;
   // [0x38]  uint64_t correlation_id;
   // } perf_sample_hosttrap_v1_t;
-  //
-  // __device__ void fill_sample_hosttrap_v1(perf_sample_hosttrap_v1_t* buf) {
-  //    buf->pc = ((ttmp1 & 0xffff) << 32) | ttmp0;
-  //    buf->exec_mask = EXEC;
-  //    buf->workgroup_id_x = ttmp8;
-  //    buf->workgroup_id_y = ttmp9;
-  //    buf->workgroup_id_z = ttmp10;
-  //    buf->chiplet_and_wave_id = ttmp11 & 0x3f;
-  //    buf->hw_id = s_getreg_b32(HW_REG_HW_ID);
-  //    buf->timestamp = s_memrealtime;
-  //    buf->correlation_id = get_correlation_id();
-  // }
-.fill_sample_hosttrap:
+
   // Calculate buffer entry address: ttmp[2:3] = &bufferX[local_entry]
   s_mul_i32                             ttmp2, ttmp7, 0x40              // offset into buffer for 64B objects
-  s_mul_hi_u32                          ttmp3, ttmp7, 0x40              // ttmp[2:3] will contain byte ...
+  s_mul_hi_u32                          ttmp3, ttmp7, 0x40
   s_add_u32                             ttmp2, ttmp2, ttmp4
   s_addc_u32                            ttmp3, ttmp3, ttmp5             // ttmp[2:3]=&bufferX[local_entry]
 
@@ -551,15 +478,41 @@ trap_entry:
   s_memrealtime                         ttmp[4:5]
   s_waitcnt                             lgkmcnt(0)
 
-  // Store hosttrap-specific field: PC at offset 0x00
-  s_and_b32                             ttmp1, ttmp1, 0xffff            // clear out extra data from PC_HI
-  s_store_dwordx2                       ttmp[0:1], ttmp[2:3]            // store PC
+.if (.amdgcn.gfx_generation_minor >= 4)
+  // GFX9.4+: store common fields shared by both sample types
 
-.if (.amdgcn.gfx_generation_number == 9 && .amdgcn.gfx_generation_minor >= 4)
-  // GFX9.4+: Use unified macro for common sample fields
-  FILL_SAMPLE_COMMON_GFX94
+  // Store timestamp at offset 0x30
+  s_store_dwordx2                       ttmp[4:5], ttmp[2:3], 0x30
+
+  // Store EXEC mask at offset 0x08-0x0c
+  s_mov_b32                             ttmp6, exec_lo
+  s_store_dword                         ttmp6, ttmp[2:3], 0x8
+  s_mov_b32                             ttmp6, exec_hi
+  s_store_dword                         ttmp6, ttmp[2:3], 0xc
+
+  // Store workgroup IDs at offsets 0x10-0x18
+  s_store_dwordx2                       ttmp[8:9], ttmp[2:3], 0x10
+  s_store_dword                         ttmp10, ttmp[2:3], 0x18
+
+  // Store wave_in_wg and chiplet (XCC_ID) at offset 0x1c
+  s_getreg_b32                          ttmp4, hwreg(HW_REG_XCC_ID)
+  s_lshl_b32                            ttmp4, ttmp4, 8
+  s_and_b32                             ttmp5, ttmp11, TTMP11_WAVE_IN_WG_MASK
+  s_or_b32                              ttmp4, ttmp4, ttmp5
+  s_store_dword                         ttmp4, ttmp[2:3], 0x1c
+
+  // Store HW_ID at offset 0x20
+  s_getreg_b32                          ttmp4, hwreg(HW_REG_HW_ID)
+  s_store_dword                         ttmp4, ttmp[2:3], 0x20
+
+  // Check if it’s a stochastic trap
+  s_bitcmp1_b32                         ttmp13, TTMP13_PCS_IS_STOCHASTIC
+  s_cbranch_scc1                        .fill_sample_stochastic
+  // Check if it’s a host trap
+  s_bitcmp1_b32                         ttmp13, TTMP13_PCS_IS_HOSTTRAP
+  s_cbranch_scc1                        .fill_sample_hosttrap
 .else
-  // GFX9.0-9.3: Store common fields inline (no XCC_ID, different register usage)
+  // GFX9.0-9.3: store common fields inline (no XCC_ID, different register usage)
   S_MOV_B32_SRC_PCS_TTMP_REG1           exec_lo
   S_STORE_DWORD_PCS_TTMP_REG1           ttmp[2:3], 0x8                  // store EXEC_LO
   S_MOV_B32_SRC_PCS_TTMP_REG1           exec_hi
@@ -571,35 +524,36 @@ trap_entry:
   s_store_dword                         ttmp4, ttmp[2:3], 0x1c          // store wave_in_wg
   s_getreg_b32                          ttmp4, hwreg(HW_REG_HW_ID)
   s_store_dword                         ttmp4, ttmp[2:3], 0x20          // store HW_ID
-.endif
 
+  // Check if it’s a host trap
+  s_bitcmp1_b32                         ttmp11, TTMP11_PCS_IS_HOSTTRAP
+  s_cbranch_scc1                        .fill_sample_hosttrap
+.endif
+  // If neither bit is set, this is unexpected.
+  // This branch is not expected to be taken.
+  s_branch                              .no_skip_debugtrap
+
+  // ttmp[2:3]=&bufferX[local_entry]; ttmp[4:5] free (timestamp already stored above on gfx94+)
+  // ttmp[14:15] is live out
+
+.fill_sample_hosttrap:
+  // Store hosttrap-specific field: PC at offset 0x00
+  s_and_b32                             ttmp1, ttmp1, 0xffff            // clear out extra data from PC_HI
+  s_store_dwordx2                       ttmp[0:1], ttmp[2:3]            // store PC
   s_branch                              .get_correlation_id
 
-.if .amdgcn.gfx_generation_number == 9 && .amdgcn.gfx_generation_minor >= 4
+.if .amdgcn.gfx_generation_minor >= 4
 .fill_sample_stochastic:
-  // Calculate buffer entry address: ttmp[2:3] = &buffer[local_entry]
-  s_mul_i32                             ttmp2, ttmp7, 0x40              // offset into buffer for 64B objects
-  s_mul_hi_u32                          ttmp3, ttmp7, 0x40
-  s_add_u32                             ttmp2, ttmp2, ttmp4
-  s_addc_u32                            ttmp3, ttmp3, ttmp5             // ttmp[2:3]=&buffer[local_entry]
-
-  // Read timestamp and wait for it
-  s_memrealtime                         ttmp[4:5]
-  s_waitcnt                             lgkmcnt(0)
-
-  // Store stochastic-specific fields: snapshot PC and data
+  // Store stochastic-specific fields: snapshot PC at 0x00, snapshot data at 0x24
   s_getreg_b32                          ttmp6, hwreg(HW_REG_SQ_PERF_SNAPSHOT_PC_LO)
   s_getreg_b32                          ttmp7, hwreg(HW_REG_SQ_PERF_SNAPSHOT_PC_HI)
-  s_store_dwordx2                       ttmp[6:7], ttmp[2:3] 0x00       // store snapshot PC at offset 0x00
+  s_store_dwordx2                       ttmp[6:7], ttmp[2:3], 0x00      // store snapshot PC at offset 0x00
   s_getreg_b32                          ttmp7, hwreg(HW_REG_SQ_PERF_SNAPSHOT_DATA1)
   s_getreg_b32                          ttmp6, hwreg(HW_REG_SQ_PERF_SNAPSHOT_DATA)
   s_store_dwordx2                       ttmp[6:7], ttmp[2:3], 0x24      // store snapshot data at offset 0x24
-
-  // Store common sample fields using unified macro
-  FILL_SAMPLE_COMMON_GFX94
-  // ttmp[2:3]=&buffer[local_entry]; ttmp[4:5], ttmp[6:7] are free
-  // ttmp[14:15]=ptr to ‘tma’ and is live out; ttmp11.b31 is buf_to_use, 0 or 1
   s_branch                              .get_correlation_id
+
+.endif
 
 .endif
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s
@@ -206,28 +206,6 @@
   .endif
  .endm
 
- // ============================================================================
- // GFX9.4+ PC Sampling Refactored Macros
- // ============================================================================
- // These macros unify duplicated code between hosttrap and stochastic paths.
-
- // CALC_XCC_OFFSET_GFX94 - Calculate per-XCC buffer address for multi-XCC systems
- // Input:
- //   ttmp[2:3] = buffer base address
- //   ttmp4     = per_xcc_size (stride per XCC)
- //   ttmp5     = XCC_ID
- // Output:
- //   ttmp[14:15] = buffer_base + (XCC_ID * per_xcc_size)
- // Clobbers: ttmp[14:15] (output), uses ttmp4, ttmp5
- .macro CALC_XCC_OFFSET_GFX94
-  .if (.amdgcn.gfx_generation_minor >= 4)
-    s_mul_i32                             ttmp14, ttmp4, ttmp5            // ttmp14 = lo32(offset)
-    s_mul_hi_u32                          ttmp15, ttmp4, ttmp5            // ttmp15 = hi32(offset)
-    s_add_u32                             ttmp14, ttmp2, ttmp14           // ttmp14:15 = base + offset
-    s_addc_u32                            ttmp15, ttmp3, ttmp15
-  .endif
- .endm
-
  // FILL_SAMPLE_COMMON_GFX94 - Store common sample fields shared by hosttrap and stochastic
  // This stores: timestamp, EXEC mask, workgroup IDs, wave_in_wg with chiplet, HW_ID
  // Input:
@@ -364,33 +342,14 @@ trap_entry:
 
   s_load_dwordx2                        ttmp[2:3], ttmp[14:15], 0   // ttmp[2:3] = host_trap_buffers base
 .if .amdgcn.gfx_generation_minor >= 4
-  // GFX9.4+ (multi-XCC): PC sampling bits cleared at trap_entry (bits 21-22)
-  // Multi-XCC: Load per_xcc_size and XCC_ID for offset calculation
-  s_load_dword                          ttmp4, ttmp[14:15], 0x10        // ttmp4 = per_xcc_size
-  s_getreg_b32                          ttmp5, hwreg(HW_REG_XCC_ID)     // ttmp5 = XCC_ID
+  // GFX9.4+ (multi-XCC): mark hosttrap and branch to profile handler
   s_setreg_imm32_b32                    hwreg(HW_REG_TRAPSTS, SQ_WAVE_TRAPSTS_HOST_TRAP_SHIFT, 1), 0
   s_bitset1_b32                         ttmp13, TTMP13_PCS_IS_HOSTTRAP  // set bit 22 in TTMP13
-  s_waitcnt                             lgkmcnt(0)
-
-  // Check if host_trap_buffers is NULL (not configured for hosttrap).
-  // If NULL, exit cleanly - hosttrap and stochastic are mutually exclusive.
-  s_cmp_eq_u64                          ttmp[2:3], 0
-  s_cbranch_scc1                        .exit_trap
-
-  // Calculate per-XCC buffer address: ttmp[14:15] = ttmp[2:3] + (ttmp4 * ttmp5)
-  CALC_XCC_OFFSET_GFX94
   s_branch                              .profile_trap_handlers_gfx9
 .else
   // GFX9.0-9.3 (single-XCC): Simple pointer copy, no per-XCC offset needed
   s_bitset1_b32                         ttmp11, TTMP11_PCS_IS_HOSTTRAP  // Set bit 22 in TTMP11
   s_waitcnt                             lgkmcnt(0)
-
-  // Check if host_trap_buffers is NULL (not configured for hosttrap).
-  // If NULL, exit cleanly - nothing to do (no stochastic on GFX9.0-9.3).
-  s_cmp_eq_u64                          ttmp[2:3], 0
-  s_cbranch_scc1                        .exit_trap
-
-  s_mov_b64                             ttmp[14:15], ttmp[2:3]          // ttmp14:15 = host_trap_buffers
   s_branch                              .profile_trap_handlers_gfx9
 .endif
 .else
@@ -424,23 +383,11 @@ trap_entry:
   s_bitcmp1_b32                         ttmp7, SQ_WAVE_TRAPSTS_PERF_SNAPSHOT_SHIFT   // is stochastic_sample_trap
   s_cbranch_scc0                        .no_skip_debugtrap
 
-  // Handle stochastic trap (PC sampling bits cleared at trap_entry)
-  s_setreg_imm32_b32                    hwreg(HW_REG_TRAPSTS, SQ_WAVE_TRAPSTS_PERF_SNAPSHOT_SHIFT, 1), 0
+  // Handle stochastic trap: load buffer base, mark in ttmp13, branch to profile handler
   s_load_dwordx2                        ttmp[2:3], ttmp[14:15], 0x8     // ttmp[2:3] = stochastic_trap_buffers base
-  // Multi-XCC: Load per_xcc_size and XCC_ID for offset calculation
-  s_load_dword                          ttmp4, ttmp[14:15], 0x10        // ttmp4 = per_xcc_size
-  s_getreg_b32                          ttmp5, hwreg(HW_REG_XCC_ID)     // ttmp5 = XCC_ID
+  s_setreg_imm32_b32                    hwreg(HW_REG_TRAPSTS, SQ_WAVE_TRAPSTS_PERF_SNAPSHOT_SHIFT, 1), 0
   s_bitset1_b32                         ttmp13, TTMP13_PCS_IS_STOCHASTIC  // set bit 21 in TTMP13
-  s_waitcnt                             lgkmcnt(0)
-
-  // Check if stochastic_trap_buffers is NULL (not configured for stochastic).
-  // If NULL, exit cleanly - nothing to do for this trap.
-  s_cmp_eq_u64                          ttmp[2:3], 0
-  s_cbranch_scc1                        .exit_trap
-
-  // Calculate per-XCC buffer address: ttmp[14:15] = ttmp[2:3] + (ttmp4 * ttmp5)
-  CALC_XCC_OFFSET_GFX94
-  s_branch                              .profile_trap_handlers_gfx9      // Off to the profile handlers
+  s_branch                              .profile_trap_handlers_gfx9
 .else
   s_branch                              .no_skip_debugtrap
 .endif // PC_SAMPLING_GFX9
@@ -485,8 +432,26 @@ trap_entry:
   //  }
   //}
 
-  // ttmp[14:15] is tma->host_trap_buffers; Available: ttmp[2:3], ttmp[4:5], ttmp7, ttmp13
+  // ttmp[14:15] is tma->host_trap_buffers; ttmp[2:3] is buffer base (for NULL check); Available: ttmp[4:5], ttmp7, ttmp13
 .profile_trap_handlers_gfx9:
+  // Exit immediately if the buffer pointer is NULL (sampling not configured for this trap type).
+  s_cmp_eq_u64                          ttmp[2:3], 0
+  s_cbranch_scc1                        .exit_trap
+
+.if .amdgcn.gfx_generation_minor >= 4
+  // GFX9.4+ (multi-XCC): ttmp[14:15] = ttmp[2:3] + (XCC_ID * per_xcc_size)
+  s_load_dword                          ttmp4, ttmp[14:15], 0x10        // ttmp4 = per_xcc_size
+  s_getreg_b32                          ttmp5, hwreg(HW_REG_XCC_ID)     // ttmp5 = XCC_ID
+  s_waitcnt                             lgkmcnt(0)
+  s_mul_i32                             ttmp14, ttmp4, ttmp5            // lo32(offset)
+  s_mul_hi_u32                          ttmp15, ttmp4, ttmp5            // hi32(offset)
+  s_add_u32                             ttmp14, ttmp2, ttmp14
+  s_addc_u32                            ttmp15, ttmp3, ttmp15
+.else
+  // GFX9.0-9.3 (single-XCC): buffer pointer needs no per-XCC adjustment
+  s_mov_b64                             ttmp[14:15], ttmp[2:3]
+.endif
+
   s_mov_b64                             ttmp[2:3], 1                    // atomic increment buf_write_val
   s_atomic_add_x2                       ttmp[2:3], ttmp[14:15], glc     // ttmp[2:3] = packed local_entry
   S_LOAD_DWORD_PCS_TTMP_REG1            ttmp[14:15], 0x8                // TTMP_REG1 = tma->buf_size


### PR DESCRIPTION
  Description:

  Refactors the GFX9 PC sampling trap handler to mirror the structure already established in trap_handler_gfx12.s.

  Changes:

  - Hoist the buffer entry address calculation (&bufferX[local_entry]) and s_memrealtime timestamp read above the hosttrap/stochastic branch — these are common to both sample types and were previously duplicated in each label.
  - For GFX9.4+, also hoist all common sample field stores (timestamp, EXEC mask, workgroup IDs, wave_in_wg + chiplet, HW_ID) above the branch, so each sample-type label only handles what is unique to it:
    - .fill_sample_hosttrap: stores wave PC at offset 0x00
    - .fill_sample_stochastic: stores snapshot PC at 0x00 and snapshot DATA/DATA1 at 0x24
  - Remove the FILL_SAMPLE_COMMON_GFX94 macro, which had a single call site, and inline its body directly.

  The GFX9.0–9.3 path is unchanged in behaviour; it still stores common fields inline before branching to .fill_sample_hosttrap (stochastic sampling does not exist on those generations).

No functional change.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
