### PR TITLE
test(rccl): add CPU affinity restore regression test

### DIFF
--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -197,6 +197,7 @@ if(BUILD_TESTS)
     DdaIpcTests.cpp
     NetPluginReloadTests.cpp
     plugin/net_reload_plugin.cpp
+    CpuAffinityTests.cpp
     TeardownStressTests.cpp
     _RecorderTests.cpp
     common/main.cpp

--- a/projects/rccl/test/CpuAffinityTests.cpp
+++ b/projects/rccl/test/CpuAffinityTests.cpp
@@ -1,0 +1,81 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include <gtest/gtest.h>
+#include <rccl/rccl.h>
+
+#include <sched.h>
+#include <unistd.h>
+#include <algorithm>
+#include <cerrno>
+#include <cstring>
+
+#include "StandaloneUtils.hpp"
+#include "common/ProcessIsolatedTestRunner.hpp"
+
+namespace RcclUnitTesting
+{
+  /**
+   * \brief Verify the calling thread's CPU affinity is restored after ncclCommInitRank.
+   *
+   * Regression guard for NCCL issue #2033 / AICOMRCCL-1537: initTransportsRank() must
+   * restore the mask it saved before applying the GPU-local one. Single-rank
+   * ncclCommInitRank runs initTransportsRank on the calling thread, so a leak is
+   * observable here. The check only bites when the GPU-local CPU set is a strict
+   * subset of the process mask (multi-NUMA hosts); elsewhere the invariant still holds.
+   * ******************************************************************************************/
+  TEST(CpuAffinity, RestoredAfterInitRank)
+  {
+    RUN_ISOLATED_TEST("CpuAffinity_RestoredAfterInitRank", []()
+    {
+      int numDevices;
+      HIPCALL(hipGetDeviceCount(&numDevices));
+      if (numDevices < 1) {
+        GTEST_SKIP() << "No devices available.";
+      }
+
+      // Widen to the full online CPU set so the GPU-local subset is more likely to be
+      // strictly narrower, then record what the kernel actually granted.
+      long numCpus = sysconf(_SC_NPROCESSORS_ONLN);
+      ASSERT_GT(numCpus, 0);
+
+      cpu_set_t fullMask;
+      CPU_ZERO(&fullMask);
+
+      int maxCpus = static_cast<int>(std::min<long>(numCpus, CPU_SETSIZE));
+      for (int cpu = 0; cpu < maxCpus; ++cpu) {
+        CPU_SET(cpu, &fullMask);
+      }
+
+      if (sched_setaffinity(0, sizeof(fullMask), &fullMask) != 0) {
+        GTEST_SKIP() << "Could not widen CPU affinity, cannot exercise the "
+                     << "GPU-local subset case: " << strerror(errno);
+      }
+
+      cpu_set_t before;
+      CPU_ZERO(&before);
+      ASSERT_EQ(sched_getaffinity(0, sizeof(before), &before), 0)
+          << "sched_getaffinity failed: " << strerror(errno);
+
+      ncclComm_t comm;
+      ncclUniqueId id;
+      NCCLCHECK(ncclGetUniqueId(&id));
+      HIPCALL(hipSetDevice(0));
+      NCCLCHECK(ncclCommInitRank(&comm, 1, id, 0));
+
+      cpu_set_t after;
+      CPU_ZERO(&after);
+      ASSERT_EQ(sched_getaffinity(0, sizeof(after), &after), 0)
+          << "sched_getaffinity failed: " << strerror(errno);
+
+      NCCLCHECK(ncclCommDestroy(comm));
+
+      ASSERT_TRUE(CPU_EQUAL(&before, &after))
+          << "CPU affinity was not restored after ncclCommInitRank "
+          << "(NCCL issue #2033 / AICOMRCCL-1537 regression)";
+    });
+  }
+}

--- a/projects/rccl/test/CpuAffinityTests.cpp
+++ b/projects/rccl/test/CpuAffinityTests.cpp
@@ -10,14 +10,69 @@
 #include <sched.h>
 #include <unistd.h>
 #include <algorithm>
+#include <cctype>
 #include <cerrno>
+#include <cstdio>
 #include <cstring>
 
 #include "StandaloneUtils.hpp"
+#include "common/ErrCode.hpp"
 #include "common/ProcessIsolatedTestRunner.hpp"
 
 namespace RcclUnitTesting
 {
+  namespace
+  {
+    // CPUs in the NUMA node the device hangs off, or -1 when sysfs does not expose it.
+    // RCCL narrows the calling thread to exactly this set, so the regression is only
+    // observable when the set is a strict subset of the process mask.
+    int GetDeviceLocalCpuCount(int device)
+    {
+      char busId[32];
+      if (hipDeviceGetPCIBusId(busId, sizeof(busId), device) != hipSuccess) {
+        return -1;
+      }
+      for (char* c = busId; *c != '\0'; ++c) {
+        *c = static_cast<char>(tolower(static_cast<unsigned char>(*c)));
+      }
+
+      char path[128];
+      snprintf(path, sizeof(path), "/sys/bus/pci/devices/%s/numa_node", busId);
+      FILE* file = fopen(path, "r");
+      if (file == nullptr) {
+        return -1;
+      }
+      int numaNode = -1;
+      if (fscanf(file, "%d", &numaNode) != 1) {
+        numaNode = -1;
+      }
+      fclose(file);
+      // The topology parser attaches devices that report no NUMA node to node 0.
+      if (numaNode < 0) {
+        numaNode = 0;
+      }
+
+      snprintf(path, sizeof(path), "/sys/devices/system/node/node%d/cpumap", numaNode);
+      file = fopen(path, "r");
+      if (file == nullptr) {
+        return -1;
+      }
+
+      // Hex bitmap in comma-separated 32-bit groups, e.g. "00000000,0000ffff".
+      int count = 0;
+      for (int c = fgetc(file); c != EOF; c = fgetc(file)) {
+        int nibble = -1;
+        if (c >= '0' && c <= '9') nibble = c - '0';
+        else if (c >= 'a' && c <= 'f') nibble = c - 'a' + 10;
+        if (nibble >= 0) {
+          count += __builtin_popcount(static_cast<unsigned>(nibble));
+        }
+      }
+      fclose(file);
+      return count;
+    }
+  }
+
   /**
    * \brief Verify the calling thread's CPU affinity is restored after ncclCommInitRank.
    *
@@ -25,7 +80,9 @@ namespace RcclUnitTesting
    * restore the mask it saved before applying the GPU-local one. Single-rank
    * ncclCommInitRank runs initTransportsRank on the calling thread, so a leak is
    * observable here. The check only bites when the GPU-local CPU set is a strict
-   * subset of the process mask (multi-NUMA hosts); elsewhere the invariant still holds.
+   * subset of the process mask (multi-NUMA hosts); elsewhere the invariant still holds
+   * but the regression is not exercised, which the test reports so that a pass is not
+   * mistaken for coverage.
    * ******************************************************************************************/
   TEST(CpuAffinity, RestoredAfterInitRank)
   {
@@ -45,6 +102,8 @@ namespace RcclUnitTesting
       cpu_set_t fullMask;
       CPU_ZERO(&fullMask);
 
+      // cpu_set_t is fixed at CPU_SETSIZE, so on larger hosts the widening is partial.
+      // That only narrows the test's reach; dynamic CPU_ALLOC sets are out of scope.
       int maxCpus = static_cast<int>(std::min<long>(numCpus, CPU_SETSIZE));
       for (int cpu = 0; cpu < maxCpus; ++cpu) {
         CPU_SET(cpu, &fullMask);
@@ -60,6 +119,16 @@ namespace RcclUnitTesting
       ASSERT_EQ(sched_getaffinity(0, sizeof(before), &before), 0)
           << "sched_getaffinity failed: " << strerror(errno);
 
+      int localCpus = GetDeviceLocalCpuCount(0);
+      if (localCpus < 0) {
+        TEST_WARN("Could not read the NUMA-local CPU set of GPU 0 from sysfs, cannot tell "
+                  "whether this host narrows the affinity mask.");
+      } else if (localCpus >= CPU_COUNT(&before)) {
+        TEST_WARN("GPU 0 is local to all %d CPUs of the process mask, so RCCL never narrows it "
+                  "here: the invariant is still checked, but the regression is not exercised. "
+                  "Real coverage requires a multi-NUMA host.", CPU_COUNT(&before));
+      }
+
       ncclComm_t comm;
       ncclUniqueId id;
       NCCLCHECK(ncclGetUniqueId(&id));
@@ -68,11 +137,14 @@ namespace RcclUnitTesting
 
       cpu_set_t after;
       CPU_ZERO(&after);
-      ASSERT_EQ(sched_getaffinity(0, sizeof(after), &after), 0)
-          << "sched_getaffinity failed: " << strerror(errno);
+      // Destroy the communicator before asserting, and keep errno across it.
+      int getAffinityStatus = sched_getaffinity(0, sizeof(after), &after);
+      int getAffinityErrno  = errno;
 
       NCCLCHECK(ncclCommDestroy(comm));
 
+      ASSERT_EQ(getAffinityStatus, 0)
+          << "sched_getaffinity failed: " << strerror(getAffinityErrno);
       ASSERT_TRUE(CPU_EQUAL(&before, &after))
           << "CPU affinity was not restored after ncclCommInitRank "
           << "(NCCL issue #2033 / AICOMRCCL-1537 regression)";

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -869,7 +869,8 @@
         {"name": "CollTraceUtils.aggregateResults", "description": "CollTrace utils aggregate results", "test_filter": "CollTraceUtilsTest.aggregateResultsTest"},
         {"name": "CollTraceUtils.EventQueueOperation", "description": "CollTrace utils event queue operation", "test_filter": "CollTraceUtilsTest.EventQueueOperationTest"},
         {"name": "CollTraceUtils.EventQueueMultiThread", "description": "CollTrace utils event queue multithread", "test_filter": "CollTraceUtilsTest.EventQueueMultiThreadTest"},
-        {"name": "CollTraceUtils.getSizeMb", "description": "CollTrace utils get size MB", "test_filter": "CollTraceUtilsTest.getSizeMbTest"}
+        {"name": "CollTraceUtils.getSizeMb", "description": "CollTrace utils get size MB", "test_filter": "CollTraceUtilsTest.getSizeMbTest"},
+        {"name": "CpuAffinity.RestoredAfterInitRank", "description": "Verify CPU affinity mask is restored after ncclCommInitRank (NCCL #2033 regression)", "test_filter": "CpuAffinity.RestoredAfterInitRank"}
       ]
     },
     "asymmetric_visibility": {


### PR DESCRIPTION
## Motivation

initTransportsRank() must restore the CPU affinity mask it saved before applying the GPU-local one. A regression from 2.29.2 re-applied the temporary comm->cpuAffinity instead of the saved affinitySave, leaking the GPU-local affinity into the caller thread (NCCL issue 2033, fixed upstream in 2.30.3). 

## Technical Details

Add an isolated single-rank gtest that widens the thread affinity, runs ncclCommInitRank (which executes initTransportsRank on the calling thread), and asserts the mask is unchanged afterwards. Register it in the mi300x_mellanox_ib test runner config.

## JIRA ID

AICOMRCCL-1537

## Test Plan

Validated on MI350X (gfx950):

## Test Result

Passes with the current state of develop branch, fails with the version without the fix 

[ RUN      ] CpuAffinity.RestoredAfterInitRank
[       OK ] CpuAffinity.RestoredAfterInitRank (3551 ms)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
