### PR TITLE
fix(rocr): update gran_vgprs calculation of blit shaders for gfx1250

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -436,7 +436,7 @@ void GpuAgent::AssembleShader(const char* func_name, AssembleTarget assemble_tar
     int gran_sgprs = std::max(0, (int(asic_shader->num_sgprs) - 1) / 8);
     int gran_vgprs;
     if (supported_isas()[0]->GetMajorVersion() == 12 && supported_isas()[0]->GetMinorVersion() >= 5) {
-      // gfx1250 (MI450) changed the VGPR granularity: the field is now
+      // gfx1250 changed the VGPR granularity: the field is now
       // max(0, ceil(vgprs_used / 16) - 1). See SWDEV-512636 / SWDEV-510239.
       gran_vgprs = std::max(0, (int(asic_shader->num_vgprs) + 15) / 16 - 1);
     } else {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -434,14 +434,14 @@ void GpuAgent::AssembleShader(const char* func_name, AssembleTarget assemble_tar
     amd_kernel_code_t* header = reinterpret_cast<amd_kernel_code_t*>(code_buf);
 
     int gran_sgprs = std::max(0, (int(asic_shader->num_sgprs) - 1) / 8);
-    int gran_vgprs;
-    if (supported_isas()[0]->GetMajorVersion() == 12 && supported_isas()[0]->GetMinorVersion() >= 5) {
-      // gfx1250 changed the VGPR granularity: the field is now
-      // max(0, ceil(vgprs_used / 16) - 1). See SWDEV-512636 / SWDEV-510239.
-      gran_vgprs = std::max(0, (int(asic_shader->num_vgprs) + 15) / 16 - 1);
-    } else {
-      gran_vgprs = std::max(0, (int(asic_shader->num_vgprs) - 1) / 4);
-    }
+    // gfx1250 changed the VGPR granularity from 4 to 16: the field is now
+    // max(0, ceil(vgprs_used / 16) - 1). See SWDEV-512636 / SWDEV-510239.
+    const int vgpr_gran = (supported_isas()[0]->GetMajorVersion() == 12 &&
+                           supported_isas()[0]->GetMinorVersion() >= 5)
+                              ? 16
+                              : 4;
+    int gran_vgprs =
+        std::max(0, (int(asic_shader->num_vgprs) + vgpr_gran - 1) / vgpr_gran - 1);
 
     header->kernel_code_entry_byte_offset = sizeof(amd_kernel_code_t);
     AMD_HSA_BITS_SET(header->kernel_code_properties,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -434,7 +434,14 @@ void GpuAgent::AssembleShader(const char* func_name, AssembleTarget assemble_tar
     amd_kernel_code_t* header = reinterpret_cast<amd_kernel_code_t*>(code_buf);
 
     int gran_sgprs = std::max(0, (int(asic_shader->num_sgprs) - 1) / 8);
-    int gran_vgprs = std::max(0, (int(asic_shader->num_vgprs) - 1) / 4);
+    int gran_vgprs;
+    if (supported_isas()[0]->GetMajorVersion() == 12 && supported_isas()[0]->GetMinorVersion() >= 5) {
+      // gfx1250 (MI450) changed the VGPR granularity: the field is now
+      // max(0, ceil(vgprs_used / 16) - 1). See SWDEV-512636 / SWDEV-510239.
+      gran_vgprs = std::max(0, (int(asic_shader->num_vgprs) + 15) / 16 - 1);
+    } else {
+      gran_vgprs = std::max(0, (int(asic_shader->num_vgprs) - 1) / 4);
+    }
 
     header->kernel_code_entry_byte_offset = sizeof(amd_kernel_code_t);
     AMD_HSA_BITS_SET(header->kernel_code_properties,


### PR DESCRIPTION
## Summary

The formula for `compute_pgm_rsrc1.GRANULATED_WORKITEM_VGPR_COUNT` (used to compute `gran_vgprs` in `GpuAgent::AssembleShader`) has changed for gfx1250. It is now:

```
max(0, ceil(vgprs_used / 16) - 1)
```

## JIRA ID

JIRA ID : ROCM-19804

## Test plan

- [ ] Build ROCr and confirm blit-kernel dispatch (copy/fill) works on gfx1250.
- [ ] Verify `granulated_workitem_vgpr_count` in the assembled blit-shader headers matches `max(0, ceil(vgprs_used / 16) - 1)` on gfx1250 and is unchanged on other targets.
