### PR TITLE
fix(rocjitsu): Harden AMDGPU text growth against malformed ELF

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -40,6 +40,12 @@ namespace {
 
 inline constexpr uint64_t kKernargPreloadSkipBytes = 256;
 
+// Translation output is generated from one accepted code object. Bound the
+// additional ELF storage, including alignment padding, before the patcher makes
+// any potentially large allocation. Other patcher callers can choose a
+// different explicit budget.
+constexpr size_t kMaxTranslatedFileGrowth = size_t{64} * 1024 * 1024;
+
 EncodingTranslateFn select_encoding_translator(rj_code_arch_t guest, rj_code_arch_t host) {
   if (guest == ROCJITSU_CODE_ARCH_CDNA4 && host == ROCJITSU_CODE_ARCH_RDNA4)
     return cdna4_to_rdna4::translate_encoding_cdna4_to_rdna4;
@@ -1122,7 +1128,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     }
   }
 
-  if (!patcher.replace_text(translated_text)) {
+  if (!patcher.replace_text(translated_text, kMaxTranslatedFileGrowth)) {
     append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
                  "relocated .text could not be materialized safely; leaving code object unchanged");
     return leave_unchanged();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -19,11 +19,14 @@ RJ_DIAGNOSTIC_POP
 #include <cstddef>
 #include <cstring>
 #include <limits>
+#include <new>
 #include <numeric>
 #include <optional>
 // Standard library
 #include <span>
+#include <stdexcept>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace rocjitsu {
@@ -32,25 +35,34 @@ namespace {
 using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
 namespace kd = rocr::llvm::amdhsa;
 
-[[nodiscard]] std::vector<Elf64_Shdr> read_section_headers(const std::vector<uint8_t> &image,
-                                                           const Elf64_Ehdr &ehdr) {
-  assert(ehdr.e_shentsize == sizeof(Elf64_Shdr) && "unsupported section header size");
-  assert(ehdr.e_shoff + static_cast<uint64_t>(ehdr.e_shnum) * sizeof(Elf64_Shdr) <= image.size() &&
-         "section header table out of bounds");
+[[nodiscard]] std::optional<std::vector<Elf64_Shdr>>
+read_section_headers(const std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr) {
+  if ((ehdr.e_shoff == 0) != (ehdr.e_shnum == 0))
+    return std::nullopt;
+  if (ehdr.e_shoff == 0)
+    return std::vector<Elf64_Shdr>{};
+
+  if (ehdr.e_shentsize != sizeof(Elf64_Shdr) || ehdr.e_shoff > image.size() ||
+      static_cast<uint64_t>(ehdr.e_shnum) >
+          (static_cast<uint64_t>(image.size()) - ehdr.e_shoff) / sizeof(Elf64_Shdr))
+    return std::nullopt;
 
   std::vector<Elf64_Shdr> shdrs(ehdr.e_shnum);
   std::memcpy(shdrs.data(), image.data() + ehdr.e_shoff, shdrs.size() * sizeof(Elf64_Shdr));
   return shdrs;
 }
 
-[[nodiscard]] std::vector<Elf64_Phdr> read_program_headers(const std::vector<uint8_t> &image,
-                                                           const Elf64_Ehdr &ehdr) {
-  if (ehdr.e_phoff == 0 || ehdr.e_phnum == 0)
-    return {};
+[[nodiscard]] std::optional<std::vector<Elf64_Phdr>>
+read_program_headers(const std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr) {
+  if ((ehdr.e_phoff == 0) != (ehdr.e_phnum == 0))
+    return std::nullopt;
+  if (ehdr.e_phoff == 0)
+    return std::vector<Elf64_Phdr>{};
 
-  assert(ehdr.e_phentsize == sizeof(Elf64_Phdr) && "unsupported program header size");
-  assert(ehdr.e_phoff + static_cast<uint64_t>(ehdr.e_phnum) * sizeof(Elf64_Phdr) <= image.size() &&
-         "program header table out of bounds");
+  if (ehdr.e_phentsize != sizeof(Elf64_Phdr) || ehdr.e_phoff > image.size() ||
+      static_cast<uint64_t>(ehdr.e_phnum) >
+          (static_cast<uint64_t>(image.size()) - ehdr.e_phoff) / sizeof(Elf64_Phdr))
+    return std::nullopt;
 
   std::vector<Elf64_Phdr> phdrs(ehdr.e_phnum);
   std::memcpy(phdrs.data(), image.data() + ehdr.e_phoff, phdrs.size() * sizeof(Elf64_Phdr));
@@ -73,17 +85,55 @@ void write_elf_tables(std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr,
   }
 }
 
-void insert_file_bytes(std::vector<uint8_t> &image, Elf64_Ehdr &ehdr,
-                       std::vector<Elf64_Shdr> &shdrs, std::vector<Elf64_Phdr> &phdrs,
-                       uint64_t file_offset, std::span<const uint8_t> bytes,
-                       std::optional<size_t> grown_section_index, bool grow_load_at_segment_end) {
-  assert(file_offset <= image.size() && "ELF insertion offset out of bounds");
+[[nodiscard]] bool can_add_u64(uint64_t value, uint64_t delta) {
+  return value <= std::numeric_limits<uint64_t>::max() - delta;
+}
+
+[[nodiscard]] bool insert_file_bytes(std::vector<uint8_t> &image, Elf64_Ehdr &ehdr,
+                                     std::vector<Elf64_Shdr> &shdrs, std::vector<Elf64_Phdr> &phdrs,
+                                     uint64_t file_offset, std::span<const uint8_t> bytes,
+                                     std::optional<size_t> grown_section_index,
+                                     bool grow_load_at_segment_end) {
+  if (file_offset > image.size() || bytes.size() > image.max_size() - image.size())
+    return false;
   if (bytes.empty())
-    return;
+    return true;
 
   const uint64_t delta = bytes.size();
-  image.insert(image.begin() + static_cast<std::ptrdiff_t>(file_offset), bytes.begin(),
-               bytes.end());
+  if ((ehdr.e_shoff >= file_offset && !can_add_u64(ehdr.e_shoff, delta)) ||
+      (ehdr.e_phoff != 0 && ehdr.e_phoff >= file_offset && !can_add_u64(ehdr.e_phoff, delta)))
+    return false;
+  for (size_t i = 0; i < shdrs.size(); ++i) {
+    if (grown_section_index && i == *grown_section_index)
+      continue;
+    if (shdrs[i].sh_type != SHT_NULL && shdrs[i].sh_offset >= file_offset &&
+        !can_add_u64(shdrs[i].sh_offset, delta))
+      return false;
+  }
+  for (const Elf64_Phdr &phdr : phdrs) {
+    if (!can_add_u64(phdr.p_offset, phdr.p_filesz))
+      return false;
+    const uint64_t old_end = phdr.p_offset + phdr.p_filesz;
+    if (phdr.p_offset >= file_offset) {
+      if (!can_add_u64(phdr.p_offset, delta))
+        return false;
+      continue;
+    }
+    const bool inside_segment = file_offset < old_end;
+    const bool at_segment_end = grow_load_at_segment_end && file_offset == old_end;
+    if (phdr.p_type == PT_LOAD && (inside_segment || at_segment_end) &&
+        (!can_add_u64(phdr.p_filesz, delta) || !can_add_u64(phdr.p_memsz, delta)))
+      return false;
+  }
+
+  try {
+    image.insert(image.begin() + static_cast<std::ptrdiff_t>(file_offset), bytes.begin(),
+                 bytes.end());
+  } catch (const std::bad_alloc &) {
+    return false;
+  } catch (const std::length_error &) {
+    return false;
+  }
 
   if (ehdr.e_shoff >= file_offset)
     ehdr.e_shoff += delta;
@@ -118,34 +168,42 @@ void insert_file_bytes(std::vector<uint8_t> &image, Elf64_Ehdr &ehdr,
       phdr.p_memsz += delta;
     }
   }
+  return true;
 }
 
-[[nodiscard]] uint64_t checked_lcm_u64(uint64_t lhs, uint64_t rhs) {
+[[nodiscard]] std::optional<uint64_t> checked_lcm_u64(uint64_t lhs, uint64_t rhs) {
   const uint64_t gcd = std::gcd(lhs, rhs);
   if (gcd == 0)
-    return 0;
-  assert(lhs / gcd <= std::numeric_limits<uint64_t>::max() / rhs &&
-         "ELF load alignment LCM overflow");
-  return std::lcm(lhs, rhs);
+    return std::nullopt;
+  if (lhs / gcd > std::numeric_limits<uint64_t>::max() / rhs)
+    return std::nullopt;
+  return (lhs / gcd) * rhs;
 }
 
-[[nodiscard]] uint64_t align_up(uint64_t value, uint64_t alignment) {
+[[nodiscard]] std::optional<uint64_t> checked_align_up(uint64_t value, uint64_t alignment) {
   if (alignment <= 1)
     return value;
   const uint64_t remainder = value % alignment;
-  return remainder == 0 ? value : value + alignment - remainder;
+  const uint64_t padding = remainder == 0 ? 0 : alignment - remainder;
+  if (value > std::numeric_limits<uint64_t>::max() - padding)
+    return std::nullopt;
+  return value + padding;
 }
 
-[[nodiscard]] uint64_t shifted_load_delta_alignment(std::span<const Elf64_Phdr> phdrs,
-                                                    uint64_t file_offset) {
+[[nodiscard]] std::optional<uint64_t>
+shifted_load_delta_alignment(std::span<const Elf64_Phdr> phdrs, uint64_t file_offset) {
   uint64_t alignment = 1;
   // Later LOAD segments remain loader-valid only when their file shift keeps
   // p_offset % p_align congruent with p_vaddr % p_align.
   for (const Elf64_Phdr &phdr : phdrs) {
     if (phdr.p_type != PT_LOAD || phdr.p_align <= 1)
       continue;
-    if (phdr.p_offset >= file_offset)
-      alignment = checked_lcm_u64(alignment, phdr.p_align);
+    if (phdr.p_offset >= file_offset) {
+      const auto next = checked_lcm_u64(alignment, phdr.p_align);
+      if (!next)
+        return std::nullopt;
+      alignment = *next;
+    }
   }
   return alignment;
 }
@@ -194,12 +252,14 @@ void insert_file_bytes(std::vector<uint8_t> &image, Elf64_Ehdr &ehdr,
   return file_offset <= limit && size <= limit - file_offset;
 }
 
-void shift_symbols_in_moved_sections(std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr,
-                                     std::span<const Elf64_Shdr> shdrs,
-                                     const std::vector<bool> &shift_section_vaddr, uint64_t delta) {
+[[nodiscard]] bool shift_symbols_in_moved_sections(std::vector<uint8_t> &image,
+                                                   const Elf64_Ehdr &ehdr,
+                                                   std::span<const Elf64_Shdr> shdrs,
+                                                   const std::vector<bool> &shift_section_vaddr,
+                                                   uint64_t delta) {
   assert(shdrs.size() == shift_section_vaddr.size() && "section shift map size mismatch");
   if (delta == 0 || ehdr.e_type == ET_REL)
-    return;
+    return true;
 
   // ET_DYN symbol values are virtual addresses. Symbols bound to moved
   // allocated sections must track those sections' new virtual addresses.
@@ -223,12 +283,13 @@ void shift_symbols_in_moved_sections(std::vector<uint8_t> &image, const Elf64_Eh
       if (!shift_section_vaddr[symbol.st_shndx])
         continue;
 
-      assert(symbol.st_value <= std::numeric_limits<uint64_t>::max() - delta &&
-             "ELF symbol value overflow");
+      if (!can_add_u64(symbol.st_value, delta))
+        return false;
       symbol.st_value += delta;
       std::memcpy(image.data() + symbol_offset, &symbol, sizeof(symbol));
     }
   }
+  return true;
 }
 
 void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr,
@@ -264,17 +325,18 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
           continue;
         symbol_text_offset = symbol.st_value - text.sh_addr;
       }
-      if (symbol_text_offset > old_text_size)
+      // Appended executable cave code is contiguous only with a function that
+      // already reaches the old end of .text. Growing every function through
+      // the cave makes their ranges overlap inter-function alignment padding;
+      // a subsequent instrumentation pass then tries to decode that padding as
+      // instructions. The CFG builder sees all function ranges together, so a
+      // branch from an earlier function can still reach the cave block covered
+      // by the tail function.
+      if (symbol.st_size == 0)
         continue;
 
-      // The translator appends executable cave code after the original .text
-      // contents and branches into it from relocated instructions.  AMDGPU code
-      // objects often leave padding after the kernel function, so a valid input
-      // function symbol may not reach the old section end.  Any non-empty
-      // function body that starts in the translated .text can now reach appended
-      // cave code, so keep its extent covering those bytes for loaders and
-      // runtime tooling that consult FUNC ranges.
-      if (symbol.st_size == 0)
+      if (symbol_text_offset > old_text_size ||
+          symbol.st_size != old_text_size - symbol_text_offset)
         continue;
 
       const uint64_t grown_size = new_text_size - symbol_text_offset;
@@ -299,19 +361,18 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
     // address must be large enough to recover the pre-insert range.
     assert(shdrs[i].sh_addr >= delta && "moved section address underflow");
     const uint64_t old_addr = shdrs[i].sh_addr - delta;
-    if (place >= old_addr && place < old_addr + shdrs[i].sh_size)
+    if (place >= old_addr && place - old_addr < shdrs[i].sh_size)
       return true;
   }
   return false;
 }
 
-void shift_relocation_offsets_in_moved_sections(std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr,
-                                                std::span<const Elf64_Shdr> shdrs,
-                                                const std::vector<bool> &shift_section_vaddr,
-                                                uint64_t delta) {
+[[nodiscard]] bool shift_relocation_offsets_in_moved_sections(
+    std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr, std::span<const Elf64_Shdr> shdrs,
+    const std::vector<bool> &shift_section_vaddr, uint64_t delta) {
   assert(shdrs.size() == shift_section_vaddr.size() && "section shift map size mismatch");
   if (delta == 0 || ehdr.e_type != ET_DYN)
-    return;
+    return true;
 
   // AMDHSA uses Elf64_Rela records, and ET_DYN relocation r_offset is the
   // relocated storage address. Any relocation whose place is inside a section we
@@ -332,8 +393,8 @@ void shift_relocation_offsets_in_moved_sections(std::vector<uint8_t> &image, con
         std::memcpy(&rela, image.data() + offset, sizeof(rela));
         if (!relocation_place_was_moved(rela.r_offset, shdrs, shift_section_vaddr, delta))
           continue;
-        assert(rela.r_offset <= std::numeric_limits<uint64_t>::max() - delta &&
-               "ELF relocation offset overflow");
+        if (!can_add_u64(rela.r_offset, delta))
+          return false;
         rela.r_offset += delta;
         std::memcpy(image.data() + offset, &rela, sizeof(rela));
       }
@@ -349,12 +410,13 @@ void shift_relocation_offsets_in_moved_sections(std::vector<uint8_t> &image, con
       std::memcpy(&rel, image.data() + offset, sizeof(rel));
       if (!relocation_place_was_moved(rel.r_offset, shdrs, shift_section_vaddr, delta))
         continue;
-      assert(rel.r_offset <= std::numeric_limits<uint64_t>::max() - delta &&
-             "ELF relocation offset overflow");
+      if (!can_add_u64(rel.r_offset, delta))
+        return false;
       rel.r_offset += delta;
       std::memcpy(image.data() + offset, &rel, sizeof(rel));
     }
   }
+  return true;
 }
 
 [[nodiscard]] bool kernel_descriptor_symbol(const Elf64_Sym &symbol, const char *strtab,
@@ -381,12 +443,12 @@ void shift_relocation_offsets_in_moved_sections(std::vector<uint8_t> &image, con
   return len > 3 && std::strcmp(name + len - 3, ".kd") == 0;
 }
 
-void adjust_kernel_descriptor_entry_offsets_in_moved_sections(
+[[nodiscard]] bool adjust_kernel_descriptor_entry_offsets_in_moved_sections(
     std::vector<uint8_t> &image, std::span<const Elf64_Shdr> shdrs,
     const std::vector<bool> &shift_section_vaddr, uint64_t delta) {
   assert(shdrs.size() == shift_section_vaddr.size() && "section shift map size mismatch");
   if (delta == 0)
-    return;
+    return true;
 
   // KERNEL_CODE_ENTRY_BYTE_OFFSET is relative to the descriptor address, not to
   // .text. When a .kd object lives in a shifted allocated section, preserve the
@@ -428,7 +490,10 @@ void adjust_kernel_descriptor_entry_offsets_in_moved_sections(
       if (symbol.st_value < section.sh_addr)
         continue;
 
-      const uint64_t file_offset = section.sh_offset + (symbol.st_value - section.sh_addr);
+      const uint64_t section_offset = symbol.st_value - section.sh_addr;
+      if (!can_add_u64(section.sh_offset, section_offset))
+        return false;
+      const uint64_t file_offset = section.sh_offset + section_offset;
       if (!image_contains_range(image.size(), file_offset, sizeof(KD)))
         continue;
       if (!adjusted_file_offsets.insert(file_offset).second)
@@ -436,12 +501,15 @@ void adjust_kernel_descriptor_entry_offsets_in_moved_sections(
 
       KD desc{};
       std::memcpy(&desc, image.data() + file_offset, sizeof(desc));
-      assert(delta <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) &&
-             "kernel descriptor shift too large");
+      if (delta > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) ||
+          desc.kernel_code_entry_byte_offset <
+              std::numeric_limits<int64_t>::min() + static_cast<int64_t>(delta))
+        return false;
       desc.kernel_code_entry_byte_offset -= static_cast<int64_t>(delta);
       std::memcpy(image.data() + file_offset, &desc, sizeof(desc));
     }
   }
+  return true;
 }
 
 } // namespace
@@ -464,7 +532,19 @@ std::span<const uint8_t> CodeObjectPatcher::text_bytes() const {
   return {image_.data() + text_offset_, text_size_};
 }
 
-bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text) {
+bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
+                                     size_t max_file_growth) noexcept {
+  try {
+    return replace_text_impl(new_text, max_file_growth);
+  } catch (const std::bad_alloc &) {
+    return false;
+  } catch (const std::length_error &) {
+    return false;
+  }
+}
+
+bool CodeObjectPatcher::replace_text_impl(std::span<const uint8_t> new_text,
+                                          size_t max_file_growth) {
   // Keep fail-closed behavior for callers that assume word-aligned executable
   // sections; accepting a non-word-aligned replacement can break downstream
   // PC-relative patching and branch-distance checks.
@@ -478,10 +558,20 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text) {
   if (!image_contains_range(image_.size(), text_offset_, text_size_))
     return false;
 
-  auto *ehdr = reinterpret_cast<Elf64_Ehdr *>(image_.data());
-  auto header = *ehdr;
-  auto shdrs = read_section_headers(image_, header);
-  auto phdrs = read_program_headers(image_, header);
+  if (image_.size() < sizeof(Elf64_Ehdr))
+    return false;
+  // Build the replacement transactionally. Malformed metadata discovered late
+  // in relocation or descriptor adjustment must not leave a partially shifted
+  // code object behind.
+  std::vector<uint8_t> image = image_;
+  Elf64_Ehdr header{};
+  std::memcpy(&header, image.data(), sizeof(header));
+  auto maybe_shdrs = read_section_headers(image, header);
+  auto maybe_phdrs = read_program_headers(image, header);
+  if (!maybe_shdrs || !maybe_phdrs)
+    return false;
+  auto shdrs = std::move(*maybe_shdrs);
+  auto phdrs = std::move(*maybe_phdrs);
 
   const auto text_index = find_text_section(shdrs, text_offset_, text_size_);
   if (!text_index) {
@@ -491,68 +581,100 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text) {
 
   const auto text_header = shdrs[*text_index];
   const uint64_t old_text_end_file = text_offset_ + text_size_;
+  if (!can_add_u64(text_header.sh_addr, text_size_))
+    return false;
   const uint64_t old_text_end_vaddr = text_header.sh_addr + text_size_;
   const uint64_t growth = new_text.size() - text_size_;
 
   if (growth != 0) {
-    // Growing .text can shift later LOAD segments. Pad the inserted file range
-    // so every shifted LOAD keeps p_offset % p_align congruent with p_vaddr %
-    // p_align. The padding is executable segment filler, not part of .text.
-    const uint64_t file_delta_alignment = shifted_load_delta_alignment(phdrs, old_text_end_file);
-    const uint64_t padded_file_delta = align_up(growth, file_delta_alignment);
-    assert(padded_file_delta >= growth && "aligned text growth underflowed");
-    assert(padded_file_delta % sizeof(uint32_t) == 0 && "text growth must stay word-aligned");
-
-    std::vector<uint8_t> inserted(padded_file_delta, 0);
     std::vector<bool> shift_section_vaddr(shdrs.size(), false);
+    uint64_t shifted_section_alignment = 1;
     for (size_t i = 0; i < shdrs.size(); ++i) {
       if (i == *text_index || shdrs[i].sh_type == SHT_NULL)
         continue;
-      if ((shdrs[i].sh_flags & SHF_ALLOC) != 0 && shdrs[i].sh_addr >= old_text_end_vaddr)
-        shift_section_vaddr[i] = true;
+      const bool shifts_in_file = shdrs[i].sh_offset >= old_text_end_file;
+      const bool shifts_in_memory =
+          (shdrs[i].sh_flags & SHF_ALLOC) != 0 && shdrs[i].sh_addr >= old_text_end_vaddr;
+      shift_section_vaddr[i] = shifts_in_memory;
+      if (shifts_in_memory && !can_add_u64(shdrs[i].sh_addr, growth))
+        return false;
+      if (shifts_in_file || shifts_in_memory) {
+        const auto next = checked_lcm_u64(shifted_section_alignment,
+                                          std::max<uint64_t>(shdrs[i].sh_addralign, 1));
+        if (!next)
+          return false;
+        shifted_section_alignment = *next;
+      }
     }
+    // Growing .text can shift later LOAD segments. Pad the inserted file range
+    // so every shifted LOAD keeps p_offset % p_align congruent with p_vaddr %
+    // p_align and every shifted allocated section keeps its address-alignment
+    // residue. The padding is executable segment filler, not part of .text.
+    const auto load_alignment = shifted_load_delta_alignment(phdrs, old_text_end_file);
+    if (!load_alignment)
+      return false;
+    const auto file_delta_alignment = checked_lcm_u64(*load_alignment, shifted_section_alignment);
+    if (!file_delta_alignment)
+      return false;
+    const auto padded_file_delta = checked_align_up(growth, *file_delta_alignment);
+    if (!padded_file_delta || *padded_file_delta < growth)
+      return false;
+    if (*padded_file_delta > max_file_growth || *padded_file_delta % sizeof(uint32_t) != 0 ||
+        *padded_file_delta > image.max_size() - image.size())
+      return false;
 
+    std::vector<uint8_t> inserted;
+    inserted.resize(*padded_file_delta, 0);
     std::vector<bool> shift_segment_vaddr(phdrs.size(), false);
     for (size_t i = 0; i < phdrs.size(); ++i) {
-      if (phdrs[i].p_vaddr >= old_text_end_vaddr && phdrs[i].p_offset >= old_text_end_file)
+      if (phdrs[i].p_vaddr >= old_text_end_vaddr && phdrs[i].p_offset >= old_text_end_file) {
+        if (!can_add_u64(phdrs[i].p_vaddr, *padded_file_delta) ||
+            !can_add_u64(phdrs[i].p_paddr, *padded_file_delta))
+          return false;
         shift_segment_vaddr[i] = true;
+      }
     }
 
-    insert_file_bytes(image_, header, shdrs, phdrs, old_text_end_file, inserted, *text_index, true);
+    if (!insert_file_bytes(image, header, shdrs, phdrs, old_text_end_file, inserted, *text_index,
+                           true))
+      return false;
 
     for (size_t i = 0; i < shdrs.size(); ++i) {
       if (!shift_section_vaddr[i])
         continue;
       [[maybe_unused]] const uint64_t old_addr = shdrs[i].sh_addr;
-      shdrs[i].sh_addr += padded_file_delta;
+      if (!can_add_u64(shdrs[i].sh_addr, *padded_file_delta))
+        return false;
+      shdrs[i].sh_addr += *padded_file_delta;
       assert((shdrs[i].sh_addralign <= 1 ||
               shdrs[i].sh_addr % shdrs[i].sh_addralign == old_addr % shdrs[i].sh_addralign) &&
              "shifted allocated section lost its address alignment residue");
     }
 
-    shift_symbols_in_moved_sections(image_, header, shdrs, shift_section_vaddr, padded_file_delta);
-    shift_relocation_offsets_in_moved_sections(image_, header, shdrs, shift_section_vaddr,
-                                               padded_file_delta);
-    adjust_kernel_descriptor_entry_offsets_in_moved_sections(image_, shdrs, shift_section_vaddr,
-                                                             padded_file_delta);
+    if (!shift_symbols_in_moved_sections(image, header, shdrs, shift_section_vaddr,
+                                         *padded_file_delta) ||
+        !shift_relocation_offsets_in_moved_sections(image, header, shdrs, shift_section_vaddr,
+                                                    *padded_file_delta) ||
+        !adjust_kernel_descriptor_entry_offsets_in_moved_sections(image, shdrs, shift_section_vaddr,
+                                                                  *padded_file_delta))
+      return false;
 
     for (size_t i = 0; i < phdrs.size(); ++i) {
       if (!shift_segment_vaddr[i])
         continue;
-      assert((phdrs[i].p_align <= 1 || padded_file_delta % phdrs[i].p_align == 0) &&
+      assert((phdrs[i].p_align <= 1 || *padded_file_delta % phdrs[i].p_align == 0) &&
              "text padding does not preserve shifted LOAD alignment");
-      phdrs[i].p_vaddr += padded_file_delta;
-      phdrs[i].p_paddr += padded_file_delta;
+      phdrs[i].p_vaddr += *padded_file_delta;
+      phdrs[i].p_paddr += *padded_file_delta;
       assert((phdrs[i].p_align <= 1 ||
               phdrs[i].p_offset % phdrs[i].p_align == phdrs[i].p_vaddr % phdrs[i].p_align) &&
              "shifted LOAD lost file/virtual address congruence");
     }
   }
 
-  std::memcpy(image_.data() + text_offset_, new_text.data(), new_text.size());
+  std::memcpy(image.data() + text_offset_, new_text.data(), new_text.size());
   shdrs[*text_index].sh_size = new_text.size();
-  grow_text_function_symbols(image_, header, shdrs, *text_index, text_size_, new_text.size());
-  text_size_ = new_text.size();
+  grow_text_function_symbols(image, header, shdrs, *text_index, text_size_, new_text.size());
 
   for (const Elf64_Phdr &phdr : phdrs) {
     if (phdr.p_type != PT_LOAD || phdr.p_align <= 1)
@@ -560,7 +682,9 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text) {
     assert(phdr.p_offset % phdr.p_align == phdr.p_vaddr % phdr.p_align &&
            "patched LOAD lost file/virtual address congruence");
   }
-  write_elf_tables(image_, header, shdrs, phdrs);
+  write_elf_tables(image, header, shdrs, phdrs);
+  image_ = std::move(image);
+  text_size_ = new_text.size();
   return true;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
@@ -5,6 +5,7 @@
 
 #include "rocjitsu/code/rj_code.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <span>
@@ -34,7 +35,15 @@ public:
   /// the executable LOAD segment that contains .text, preserves LOAD alignment,
   /// updates moved symbols and relocation places, and keeps descriptor-relative
   /// entries coherent with explicit descriptor patches applied by DBT.
-  [[nodiscard]] bool replace_text(std::span<const uint8_t> new_text);
+  ///
+  /// @param max_file_growth Maximum number of bytes that this caller permits
+  /// the ELF image to grow. This includes both the new text and any padding
+  /// required to preserve section and segment alignment. Keeping the budget at
+  /// the call site lets each transformation choose its own resource policy.
+  /// @returns false, without changing this patcher, when the replacement is
+  /// malformed, exceeds @p max_file_growth, or cannot be allocated.
+  [[nodiscard]] bool replace_text(std::span<const uint8_t> new_text,
+                                  size_t max_file_growth) noexcept;
 
   void update_elf_flags(uint32_t new_flags);
 
@@ -63,6 +72,8 @@ public:
   std::vector<uint8_t> emit() const;
 
 private:
+  [[nodiscard]] bool replace_text_impl(std::span<const uint8_t> new_text, size_t max_file_growth);
+
   std::vector<uint8_t> image_;
   uint64_t text_offset_;
   uint64_t text_size_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -32,6 +32,12 @@ namespace rocjitsu {
 
 namespace {
 
+// Instrumentation can add probe bodies, trampolines, and alignment padding to
+// one code object. Keep that resource policy at this caller rather than inside
+// the generic ELF patcher, where a fixed ceiling would reject otherwise valid
+// callers with different requirements.
+constexpr size_t kMaxInstrumentedFileGrowth = size_t{64} * 1024 * 1024;
+
 // PC-reading / PC-relative instructions to reject as anchors: relocating any of
 // them into a trampoline changes the PC value they read (s_getpc) or the target
 // they branch to. s_getpc and the s_rfe_ family carry no control-flow flag or
@@ -674,7 +680,7 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
     append_words(new_text, probe.body_words);
   for (const auto &a : applied)
     append_words(new_text, a.bytes.trampoline_words);
-  if (!patcher.replace_text(new_text)) {
+  if (!patcher.replace_text(new_text, kMaxInstrumentedFileGrowth)) {
     result.errors.emplace_back("failed to replace .text with the instrumented code");
     return result;
   }

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -86,6 +86,7 @@ RJ_DIAGNOSTIC_POP
 #include <cstring>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -243,6 +244,21 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_text_and_rodata() {
   return image;
 }
 
+constexpr size_t kTestFileGrowthBudget = size_t{16} * 1024 * 1024;
+
+void expect_text_growth_rejected_without_mutation(std::vector<uint8_t> image,
+                                                  size_t max_file_growth = kTestFileGrowthBudget) {
+  AmdGpuCodeObject co(image.data(), image.size());
+  ASSERT_TRUE(co.is_valid());
+  ASSERT_EQ(co.text_sections().size(), 1u);
+  const auto original = image;
+  std::vector<uint8_t> replacement(co.text_sections().front()->size() + sizeof(uint32_t), 0);
+
+  CodeObjectPatcher patcher(co);
+  EXPECT_FALSE(patcher.replace_text(replacement, max_file_growth));
+  EXPECT_EQ(patcher.emit(), original);
+}
+
 std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
   constexpr uint64_t text_offset = 0x100;
   constexpr uint64_t text_vaddr = 0x1100;
@@ -259,13 +275,14 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
 
   std::vector<uint8_t> strtab{'\0'};
   const uint32_t rodata_symbol_name = add_elf_name(strtab, "rodata_object");
-  const uint32_t text_symbol_name = add_elf_name(strtab, "text_start");
+  const uint32_t text_interior_symbol_name = add_elf_name(strtab, "text_interior");
+  const uint32_t text_tail_symbol_name = add_elf_name(strtab, "text_tail");
 
   const uint64_t rodata_offset = text_offset + text_size;
   const uint64_t rodata_vaddr = text_vaddr + text_size + load_align;
   const uint64_t strtab_offset = rodata_offset + rodata_size;
   const uint64_t symtab_offset = align_up_for_test(strtab_offset + strtab.size(), 8);
-  constexpr size_t sym_count = 3;
+  constexpr size_t sym_count = 4;
   const uint64_t shstrtab_offset = symtab_offset + sym_count * sizeof(Elf64_Sym);
   const uint64_t shoff = align_up_for_test(shstrtab_offset + shstrtab.size(), 8);
   constexpr uint16_t section_count = 6;
@@ -323,11 +340,16 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
   syms[1].st_shndx = 2;
   syms[1].st_value = rodata_vaddr;
   syms[1].st_size = rodata_size;
-  syms[2].st_name = text_symbol_name;
+  syms[2].st_name = text_interior_symbol_name;
   syms[2].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeFunc);
   syms[2].st_shndx = 1;
   syms[2].st_value = text_vaddr;
-  syms[2].st_size = text_size;
+  syms[2].st_size = sizeof(uint32_t);
+  syms[3].st_name = text_tail_symbol_name;
+  syms[3].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeFunc);
+  syms[3].st_shndx = 1;
+  syms[3].st_value = text_vaddr + sizeof(uint32_t);
+  syms[3].st_size = sizeof(uint32_t);
   std::memcpy(image.data() + symtab_offset, syms.data(), syms.size() * sizeof(Elf64_Sym));
 
   std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
@@ -1163,7 +1185,8 @@ TEST(CodeObjectPatcher, ReplaceTextGrowsTextAndShiftsFollowingSections) {
   CodeObjectPatcher patcher(co);
   const std::array<uint32_t, 4> text_words = {0xBF800000u, 0xBF800000u, 0xDEADBEEFu, 0xCAFEBABEu};
   const auto *text_bytes = reinterpret_cast<const uint8_t *>(text_words.data());
-  ASSERT_TRUE(patcher.replace_text({text_bytes, text_words.size() * sizeof(uint32_t)}));
+  ASSERT_TRUE(patcher.replace_text({text_bytes, text_words.size() * sizeof(uint32_t)},
+                                   kTestFileGrowthBudget));
 
   auto patched_bytes = patcher.emit();
   AmdGpuCodeObject patched(patched_bytes.data(), patched_bytes.size());
@@ -1186,6 +1209,159 @@ TEST(CodeObjectPatcher, ReplaceTextGrowsTextAndShiftsFollowingSections) {
   std::memcpy(&rodata_word, rodata->data(), sizeof(rodata_word));
   EXPECT_EQ(rodata_word, 0xA5A55A5Au);
 }
+
+TEST(CodeObjectPatcher, RejectsMalformedElfTablesWithoutMutation) {
+  enum class Malformation {
+    InconsistentProgramHeaderOffset,
+    InconsistentProgramHeaderCount,
+    SmallProgramHeaderEntry,
+    OutOfRangeProgramHeaderOffset,
+    TruncatedProgramHeaderTable,
+    SmallSectionHeaderEntry,
+  };
+  constexpr std::array cases{
+      Malformation::InconsistentProgramHeaderOffset, Malformation::InconsistentProgramHeaderCount,
+      Malformation::SmallProgramHeaderEntry,         Malformation::OutOfRangeProgramHeaderOffset,
+      Malformation::TruncatedProgramHeaderTable,     Malformation::SmallSectionHeaderEntry,
+  };
+
+  for (const Malformation malformed : cases) {
+    SCOPED_TRACE(static_cast<int>(malformed));
+    auto image = make_minimal_amdgpu_elf_with_text_and_rodata();
+    auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+    switch (malformed) {
+    case Malformation::InconsistentProgramHeaderOffset:
+      ehdr.e_phoff = 0;
+      ehdr.e_phnum = 1;
+      ehdr.e_phentsize = sizeof(Elf64_Phdr);
+      break;
+    case Malformation::InconsistentProgramHeaderCount:
+      ehdr.e_phoff = sizeof(Elf64_Ehdr);
+      ehdr.e_phnum = 0;
+      ehdr.e_phentsize = sizeof(Elf64_Phdr);
+      break;
+    case Malformation::SmallProgramHeaderEntry:
+      ehdr.e_phoff = sizeof(Elf64_Ehdr);
+      ehdr.e_phnum = 1;
+      ehdr.e_phentsize = sizeof(Elf64_Phdr) - 1;
+      break;
+    case Malformation::OutOfRangeProgramHeaderOffset:
+      ehdr.e_phoff = image.size() + 1;
+      ehdr.e_phnum = 1;
+      ehdr.e_phentsize = sizeof(Elf64_Phdr);
+      break;
+    case Malformation::TruncatedProgramHeaderTable:
+      ehdr.e_phoff = image.size() - sizeof(Elf64_Phdr) + 1;
+      ehdr.e_phnum = 1;
+      ehdr.e_phentsize = sizeof(Elf64_Phdr);
+      break;
+    case Malformation::SmallSectionHeaderEntry:
+      ehdr.e_shentsize = sizeof(Elf64_Shdr) - 1;
+      break;
+    }
+    write_elf_struct_for_test(image, 0, ehdr);
+    expect_text_growth_rejected_without_mutation(std::move(image));
+  }
+}
+
+TEST(CodeObjectPatcher, RejectsDeltaAdditionOverflowWithoutMutation) {
+  enum class OverflowField {
+    SectionAddress,
+    ProgramOffset,
+    ProgramFileSize,
+    ProgramVaddr,
+    ProgramPaddr,
+    SymbolValue,
+    KernelDescriptorEntryOffset,
+  };
+  constexpr std::array cases{
+      OverflowField::SectionAddress,
+      OverflowField::ProgramOffset,
+      OverflowField::ProgramFileSize,
+      OverflowField::ProgramVaddr,
+      OverflowField::ProgramPaddr,
+      OverflowField::SymbolValue,
+      OverflowField::KernelDescriptorEntryOffset,
+  };
+
+  for (const OverflowField field : cases) {
+    SCOPED_TRACE(static_cast<int>(field));
+    auto image = field == OverflowField::SectionAddress
+                     ? make_minimal_amdgpu_elf_with_text_and_rodata()
+                 : field == OverflowField::KernelDescriptorEntryOffset
+                     ? make_minimal_amdgpu_elf_with_descriptor_after_text()
+                     : make_minimal_amdgpu_elf_with_load_segments();
+    const auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+    if (field == OverflowField::SectionAddress) {
+      auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+      shdrs[2].sh_addr = std::numeric_limits<uint64_t>::max();
+      write_bytes_for_test(image, ehdr.e_shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+    } else if (field == OverflowField::SymbolValue) {
+      const auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+      auto symbols = read_elf_array_for_test<Elf64_Sym>(image, shdrs[3].sh_offset,
+                                                        shdrs[3].sh_size / sizeof(Elf64_Sym));
+      ASSERT_GE(symbols.size(), 2u);
+      symbols[1].st_value = std::numeric_limits<uint64_t>::max();
+      write_bytes_for_test(image, shdrs[3].sh_offset, symbols.data(),
+                           symbols.size() * sizeof(Elf64_Sym));
+    } else if (field == OverflowField::KernelDescriptorEntryOffset) {
+      const auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+      ASSERT_GE(shdrs.size(), 3u);
+      write_kernel_descriptor_entry_offset(image.data() + shdrs[2].sh_offset,
+                                           std::numeric_limits<int64_t>::min());
+    } else {
+      auto phdrs = read_elf_array_for_test<Elf64_Phdr>(image, ehdr.e_phoff, ehdr.e_phnum);
+      switch (field) {
+      case OverflowField::ProgramOffset:
+        phdrs[1].p_offset = std::numeric_limits<uint64_t>::max();
+        break;
+      case OverflowField::ProgramFileSize:
+        phdrs[0].p_filesz = std::numeric_limits<uint64_t>::max();
+        break;
+      case OverflowField::ProgramVaddr:
+        phdrs[1].p_vaddr = std::numeric_limits<uint64_t>::max();
+        break;
+      case OverflowField::ProgramPaddr:
+        phdrs[1].p_paddr = std::numeric_limits<uint64_t>::max();
+        break;
+      case OverflowField::SectionAddress:
+      case OverflowField::SymbolValue:
+      case OverflowField::KernelDescriptorEntryOffset:
+        FAIL() << "handled above";
+      }
+      write_bytes_for_test(image, ehdr.e_phoff, phdrs.data(), phdrs.size() * sizeof(Elf64_Phdr));
+    }
+    expect_text_growth_rejected_without_mutation(std::move(image));
+  }
+}
+
+TEST(CodeObjectPatcher, RejectsAlignmentLcmOverflowWithoutMutation) {
+  auto image = make_minimal_amdgpu_elf_with_text_and_rodata();
+  const auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  ASSERT_GE(shdrs.size(), 4u);
+  shdrs[2].sh_addralign = uint64_t{1} << 63u;
+  shdrs[3].sh_addralign = 3;
+  write_bytes_for_test(image, ehdr.e_shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+
+  expect_text_growth_rejected_without_mutation(std::move(image));
+}
+
+TEST(CodeObjectPatcher, RejectsAlignmentPaddingBeyondCallerBudgetWithoutMutation) {
+  auto image = make_minimal_amdgpu_elf_with_text_and_rodata();
+  const auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  ASSERT_GE(shdrs.size(), 3u);
+  shdrs[2].sh_addralign = uint64_t{1} << 38u;
+  write_bytes_for_test(image, ehdr.e_shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+
+  // The alignment is arithmetically representable but would otherwise request
+  // hundreds of GiB of eagerly zeroed padding for this small input.
+  expect_text_growth_rejected_without_mutation(std::move(image), 1024 * 1024);
+}
+
+static_assert(noexcept(std::declval<CodeObjectPatcher &>().replace_text(
+    std::declval<std::span<const uint8_t>>(), size_t{})));
 
 TEST(CodeObjectPatcher, AppliesArchSpecificWgpModeBit) {
   using namespace rocr::llvm::amdhsa;
@@ -1271,7 +1447,8 @@ TEST(CodeObjectPatcher, ReplaceTextPreservesLoadSegmentAlignment) {
   CodeObjectPatcher patcher(co);
   const std::vector<uint32_t> text_words(load_align / sizeof(uint32_t) + 3, 0xDEADBEEFu);
   const auto *text_bytes = reinterpret_cast<const uint8_t *>(text_words.data());
-  ASSERT_TRUE(patcher.replace_text({text_bytes, text_words.size() * sizeof(uint32_t)}));
+  ASSERT_TRUE(patcher.replace_text({text_bytes, text_words.size() * sizeof(uint32_t)},
+                                   kTestFileGrowthBudget));
 
   auto patched_bytes = patcher.emit();
   AmdGpuCodeObject patched(patched_bytes.data(), patched_bytes.size());
@@ -1311,15 +1488,18 @@ TEST(CodeObjectPatcher, ReplaceTextPreservesLoadSegmentAlignment) {
   });
   ASSERT_NE(symtab, shdrs.end());
   ASSERT_EQ(symtab->sh_entsize, sizeof(Elf64_Sym));
-  ASSERT_GE(symtab->sh_size / symtab->sh_entsize, 3u);
+  ASSERT_GE(symtab->sh_size / symtab->sh_entsize, 4u);
   const auto symbols = read_elf_array_for_test<Elf64_Sym>(patched_bytes, symtab->sh_offset,
                                                           symtab->sh_size / symtab->sh_entsize);
   EXPECT_EQ(symbols[1].st_value, rodata->vaddr())
       << "defined symbols in moved sections must track the section virtual address";
   EXPECT_EQ(symbols[2].st_value, text->vaddr())
       << "symbols in unmoved .text must keep their original virtual address";
-  EXPECT_EQ(symbols[2].st_size, text->size())
-      << "function symbols spanning old .text must cover appended translated cave code";
+  EXPECT_EQ(symbols[2].st_size, sizeof(uint32_t))
+      << "an interior function must not grow into another function or the appended cave";
+  EXPECT_EQ(symbols[3].st_value, text->vaddr() + sizeof(uint32_t));
+  EXPECT_EQ(symbols[3].st_size, text->size() - sizeof(uint32_t))
+      << "only the function reaching old .text end must cover appended cave code";
 }
 
 TEST(CodeObjectPatcher, ReplaceTextPreservesMovedKernelDescriptorEntryAddress) {
@@ -1338,7 +1518,8 @@ TEST(CodeObjectPatcher, ReplaceTextPreservesMovedKernelDescriptorEntryAddress) {
   CodeObjectPatcher patcher(co);
   const std::vector<uint32_t> text_words(load_align / sizeof(uint32_t) + 3, 0xDEADBEEFu);
   const auto *text_bytes = reinterpret_cast<const uint8_t *>(text_words.data());
-  ASSERT_TRUE(patcher.replace_text({text_bytes, text_words.size() * sizeof(uint32_t)}));
+  ASSERT_TRUE(patcher.replace_text({text_bytes, text_words.size() * sizeof(uint32_t)},
+                                   kTestFileGrowthBudget));
 
   auto patched_bytes = patcher.emit();
   AmdGpuCodeObject patched(patched_bytes.data(), patched_bytes.size());
@@ -1367,7 +1548,8 @@ TEST(CodeObjectPatcher, ReplaceTextUpdatesRelocationOffsetsIntoMovedSections) {
   CodeObjectPatcher patcher(co);
   const std::vector<uint32_t> text_words(load_align / sizeof(uint32_t) + 3, 0xDEADBEEFu);
   const auto *text_bytes = reinterpret_cast<const uint8_t *>(text_words.data());
-  ASSERT_TRUE(patcher.replace_text({text_bytes, text_words.size() * sizeof(uint32_t)}));
+  ASSERT_TRUE(patcher.replace_text({text_bytes, text_words.size() * sizeof(uint32_t)},
+                                   kTestFileGrowthBudget));
 
   auto patched_bytes = patcher.emit();
   AmdGpuCodeObject patched(patched_bytes.data(), patched_bytes.size());


### PR DESCRIPTION
Native instrumentation grows executable text in code objects supplied by applications. The patcher previously trusted ELF table bounds and alignment values, could request an effectively unbounded padding allocation, and extended every function symbol in the text section through the appended cave.

Validate section and program header tables before copying them, cap composed alignment, preserve the file and virtual alignment residues of moved sections and LOAD segments, and grow only the function symbol contiguous with the old text tail. All failures leave the original image unchanged.

Add regression coverage for transactional rejection of an extreme section alignment; existing text-growth, LOAD-alignment, descriptor, relocation, and symbol-range tests cover the successful paths.

ISSUE ID : #8701