### PR TITLE
fix(rocjitsu): Keep DRM layout checks warning-clean with Clang

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/base/rj_compiler.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/base/rj_compiler.h
@@ -33,18 +33,22 @@
 #define RJ_DIAGNOSTIC_IGNORE_NONNULL_COMPARE                                                       \
   _Pragma("GCC diagnostic ignored \"-Wpointer-bool-conversion\"")
 #define RJ_DIAGNOSTIC_IGNORE_CLOBBERED // Clang does not have -Wclobbered.
+#define RJ_DIAGNOSTIC_IGNORE_NESTED_ANON_TYPES                                                     \
+  _Pragma("clang diagnostic ignored \"-Wnested-anon-types\"")
 #elif defined(__GNUC__)
 #define RJ_DIAGNOSTIC_PUSH _Pragma("GCC diagnostic push")
 #define RJ_DIAGNOSTIC_POP _Pragma("GCC diagnostic pop")
 #define RJ_DIAGNOSTIC_IGNORE_PEDANTIC _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
 #define RJ_DIAGNOSTIC_IGNORE_NONNULL_COMPARE _Pragma("GCC diagnostic ignored \"-Wnonnull-compare\"")
 #define RJ_DIAGNOSTIC_IGNORE_CLOBBERED _Pragma("GCC diagnostic ignored \"-Wclobbered\"")
+#define RJ_DIAGNOSTIC_IGNORE_NESTED_ANON_TYPES // Clang-only warning.
 #elif defined(_MSC_VER)
 #define RJ_DIAGNOSTIC_PUSH __pragma(warning(push))
 #define RJ_DIAGNOSTIC_POP __pragma(warning(pop))
 #define RJ_DIAGNOSTIC_IGNORE_PEDANTIC __pragma(warning(disable : 4200))
 #define RJ_DIAGNOSTIC_IGNORE_NONNULL_COMPARE
 #define RJ_DIAGNOSTIC_IGNORE_CLOBBERED
+#define RJ_DIAGNOSTIC_IGNORE_NESTED_ANON_TYPES
 #else
 static_assert(false, "Unsupported compiler: define RJ_DIAGNOSTIC macros for your toolchain");
 #endif

--- a/emulation/rocjitsu/tests/drm_info_layout_test.cpp
+++ b/emulation/rocjitsu/tests/drm_info_layout_test.cpp
@@ -10,7 +10,11 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_NESTED_ANON_TYPES
 #include <libdrm/amdgpu_drm.h>
+RJ_DIAGNOSTIC_POP
 
 namespace {
 


### PR DESCRIPTION
Recent libdrm headers intentionally use nested anonymous types. Clang diagnoses those declarations under rocJITsu warning settings before the ABI layout assertions can compile.

Suppress only -Wnested-anon-types around the external header include, leaving project sources and every other diagnostic unchanged.

ISSUE ID : #8701
