### PR TITLE
feat(rocjitsu): Add kernel-scoped AMDGPU code analysis

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/CMakeLists.txt
@@ -4,5 +4,6 @@
 rj_add_object_library(rocjitsu_analysis
     def_use_chain.cpp
     indirect_branch_discovery.cpp
+    kernel_scope.cpp
     liveness.cpp
 )

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/kernel_scope.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/kernel_scope.cpp
@@ -1,0 +1,230 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/analysis/kernel_scope.h"
+
+#include "rocjitsu/code/basic_block.h"
+#include "rocjitsu/isa/instruction.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <functional>
+#include <unordered_set>
+
+namespace rocjitsu {
+
+namespace {
+
+[[nodiscard]] uint32_t text_word_at(std::span<const uint8_t> text, uint64_t offset) {
+  uint32_t word = 0;
+  if (offset + sizeof(word) <= text.size())
+    std::memcpy(&word, text.data() + offset, sizeof(word));
+  return word;
+}
+
+struct ReachableKernelBlocks {
+  std::vector<BasicBlock *> blocks;
+  std::unordered_map<const BasicBlock *, KernelCfgOwnerProofKind> proofs;
+};
+
+[[nodiscard]] KernelCfgOwnerProofKind call_proof(KernelCfgOwnerProofKind caller,
+                                                 BasicBlock::CallEdgeKind edge) {
+  const KernelCfgOwnerProofKind call = edge == BasicBlock::CallEdgeKind::DirectCall
+                                           ? KernelCfgOwnerProofKind::DirectCall
+                                           : KernelCfgOwnerProofKind::RecoveredIndirectCall;
+  return static_cast<uint8_t>(caller) >= static_cast<uint8_t>(call) ? caller : call;
+}
+
+[[nodiscard]] ReachableKernelBlocks
+reachable_kernel_blocks(const std::vector<std::unique_ptr<BasicBlock>> &blocks,
+                        const BlockOffsetIndex &block_index, BasicBlock &entry,
+                        const std::unordered_set<uint64_t> &kernel_entries,
+                        const std::unordered_set<uint64_t> &own_entries) {
+  struct WorkItem {
+    BasicBlock *block = nullptr;
+    KernelCfgOwnerProofKind proof = KernelCfgOwnerProofKind::KernelLocal;
+  };
+  std::unordered_map<const BasicBlock *, KernelCfgOwnerProofKind> reachable;
+  std::vector<WorkItem> stack{{.block = &entry}};
+  for (const uint64_t own_entry : own_entries) {
+    if (own_entry == entry.start_offset())
+      continue;
+    if (BasicBlock *extra_entry = block_for_offset(block_index, own_entry);
+        extra_entry != nullptr && extra_entry != &entry) {
+      stack.push_back({.block = extra_entry});
+    }
+  }
+
+  while (!stack.empty()) {
+    const WorkItem item = stack.back();
+    stack.pop_back();
+    BasicBlock *block = item.block;
+    assert(block != nullptr && "reachable walk stack should contain only decoded blocks");
+    const auto prior = reachable.find(block);
+    if (prior != reachable.end() &&
+        static_cast<uint8_t>(prior->second) <= static_cast<uint8_t>(item.proof))
+      continue;
+    reachable[block] = item.proof;
+
+    for (BasicBlock *succ : block->successors()) {
+      assert(succ != nullptr && "BasicBlock successors should never be null");
+      if (!own_entries.contains(succ->start_offset()) &&
+          kernel_entries.contains(succ->start_offset()))
+        continue;
+      stack.push_back({.block = succ, .proof = item.proof});
+    }
+    for (const BasicBlock::CallEdge &call : block->call_edges()) {
+      BasicBlock *callee = call.callee;
+      assert(callee != nullptr && "BasicBlock call edges should always have a callee");
+      if (!own_entries.contains(callee->start_offset()) &&
+          kernel_entries.contains(callee->start_offset()))
+        continue;
+      stack.push_back({.block = callee, .proof = call_proof(item.proof, call.kind)});
+    }
+  }
+
+  ReachableKernelBlocks result;
+  result.blocks.reserve(reachable.size());
+  for (const auto &block : blocks) {
+    if (block && reachable.contains(block.get()))
+      result.blocks.push_back(block.get());
+  }
+  result.proofs = std::move(reachable);
+  return result;
+}
+
+[[nodiscard]] bool s_setpc_from_sreg(const Instruction &inst, uint32_t word, uint16_t ssrc0) {
+  if (inst.size() != sizeof(uint32_t) || inst.mnemonic() != "s_setpc_b64")
+    return false;
+  return static_cast<uint16_t>(word & 0xffu) == ssrc0;
+}
+
+[[nodiscard]] std::vector<BasicBlock *>
+function_return_blocks(BasicBlock &callee, uint16_t return_sreg, std::span<const uint8_t> text,
+                       const std::unordered_set<BasicBlock *> &allowed_blocks) {
+  std::vector<BasicBlock *> returns;
+  std::vector<BasicBlock *> stack{&callee};
+  std::unordered_set<BasicBlock *> visited;
+
+  while (!stack.empty()) {
+    BasicBlock *block = stack.back();
+    stack.pop_back();
+    assert(block != nullptr && "return-block walk stack should contain only decoded blocks");
+    if (!allowed_blocks.contains(block) || !visited.insert(block).second)
+      continue;
+
+    const Instruction *term = block->terminator();
+    assert(term != nullptr && "decoded BasicBlock should contain at least one instruction");
+    if (s_setpc_from_sreg(*term, text_word_at(text, term->src_loc()), return_sreg)) {
+      returns.push_back(block);
+      continue;
+    }
+
+    for (BasicBlock *succ : block->successors()) {
+      assert(succ != nullptr && "BasicBlock successors should never be null");
+      stack.push_back(succ);
+    }
+  }
+
+  return returns;
+}
+
+void add_scoped_call_flow(KernelCfgScope &scope, std::span<const uint8_t> text) {
+  std::unordered_set<BasicBlock *> allowed_blocks;
+  allowed_blocks.reserve(scope.blocks.size());
+  for (BasicBlock *block : scope.blocks) {
+    assert(block != nullptr && "kernel scope should contain only decoded blocks");
+    allowed_blocks.insert(block);
+  }
+
+  for (BasicBlock *block : scope.blocks) {
+    for (const BasicBlock::CallEdge &call : block->call_edges()) {
+      assert(call.callee != nullptr && "BasicBlock call edges should always have a callee");
+      assert(call.continuation != nullptr &&
+             "BasicBlock call edges should always have a continuation");
+      if (!allowed_blocks.contains(call.callee) || !allowed_blocks.contains(call.continuation))
+        continue;
+
+      scope.liveness_edges.push_back({.from = block, .to = call.callee});
+      for (BasicBlock *return_block :
+           function_return_blocks(*call.callee, call.return_sreg, text, allowed_blocks)) {
+        scope.liveness_edges.push_back({.from = return_block, .to = call.continuation});
+        const Instruction *term = return_block->terminator();
+        assert(term != nullptr && "return block should contain a terminator");
+        scope.call_return_offsets.insert(term->src_loc());
+      }
+    }
+  }
+}
+
+} // namespace
+
+BlockOffsetIndex build_block_offset_index(const std::vector<std::unique_ptr<BasicBlock>> &blocks) {
+  BlockOffsetIndex index;
+  index.reserve(blocks.size());
+  for (const auto &block : blocks) {
+    if (block != nullptr)
+      index.emplace_back(block->start_offset(), block.get());
+  }
+  std::ranges::sort(index, {}, &std::pair<uint64_t, BasicBlock *>::first);
+  return index;
+}
+
+BasicBlock *block_for_offset(const BlockOffsetIndex &index, uint64_t offset) {
+  auto it = std::ranges::upper_bound(index, offset, std::less<>{},
+                                     &std::pair<uint64_t, BasicBlock *>::first);
+  if (it == index.begin())
+    return nullptr;
+  --it;
+
+  BasicBlock *block = it->second;
+  if (block == nullptr || offset >= block->end_offset())
+    return nullptr;
+  return block;
+}
+
+std::vector<KernelCfgOwnerProof>
+kernel_cfg_owners_for_offset(std::span<const KernelCfgOwnerScope> owner_scopes,
+                             const BlockOffsetIndex &block_index, uint64_t offset) {
+  BasicBlock *block = block_for_offset(block_index, offset);
+  if (block == nullptr)
+    return {};
+  std::vector<KernelCfgOwnerProof> owners;
+  for (const KernelCfgOwnerScope &owner : owner_scopes) {
+    const auto proof = owner.scope.owner_proofs.find(block);
+    if (proof != owner.scope.owner_proofs.end())
+      owners.push_back(
+          {.descriptor_file_offset = owner.descriptor_file_offset, .kind = proof->second});
+  }
+  return owners;
+}
+
+std::optional<KernelCfgScope>
+build_kernel_cfg_scope(const std::vector<std::unique_ptr<BasicBlock>> &blocks,
+                       const BlockOffsetIndex &block_index, const KernelScopeRequest &request,
+                       std::span<const uint64_t> all_kernel_entries,
+                       std::span<const uint8_t> text) {
+  BasicBlock *entry = block_for_offset(block_index, request.entry_offset);
+  if (entry == nullptr)
+    return std::nullopt;
+
+  std::unordered_set<uint64_t> own_entries{request.entry_offset};
+  for (const uint64_t extra : request.additional_entry_offsets) {
+    if (block_for_offset(block_index, extra) == nullptr)
+      return std::nullopt;
+    own_entries.insert(extra);
+  }
+
+  std::unordered_set<uint64_t> kernel_entries(all_kernel_entries.begin(), all_kernel_entries.end());
+  KernelCfgScope scope;
+  scope.entry = entry;
+  ReachableKernelBlocks reachable =
+      reachable_kernel_blocks(blocks, block_index, *entry, kernel_entries, own_entries);
+  scope.blocks = std::move(reachable.blocks);
+  scope.owner_proofs = std::move(reachable.proofs);
+  add_scoped_call_flow(scope, text);
+  return scope;
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/kernel_scope.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/kernel_scope.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file kernel_scope.h
+/// @brief Shared kernel-local CFG ownership and call/return analysis.
+
+#pragma once
+
+#include "rocjitsu/analysis/liveness.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <span>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace rocjitsu {
+
+class BasicBlock;
+
+/// @brief Sorted source-offset index for decoded basic blocks.
+using BlockOffsetIndex = std::vector<std::pair<uint64_t, BasicBlock *>>;
+
+/// @brief Entry points that belong to one kernel descriptor.
+struct KernelScopeRequest {
+  uint64_t entry_offset = 0;
+  std::vector<uint64_t> additional_entry_offsets;
+};
+
+/// @brief Strongest validated path by which one kernel reaches a block.
+enum class KernelCfgOwnerProofKind : uint8_t {
+  KernelLocal,
+  DirectCall,
+  RecoveredIndirectCall,
+};
+
+/// @brief Kernel-local control-flow scope shared by DBT and DBI clients.
+struct KernelCfgScope {
+  BasicBlock *entry = nullptr;
+  std::vector<BasicBlock *> blocks;
+  std::vector<ScopedCfgEdge> liveness_edges;
+  std::unordered_set<uint64_t> call_return_offsets;
+  std::unordered_map<const BasicBlock *, KernelCfgOwnerProofKind> owner_proofs;
+};
+
+/// @brief One descriptor and its complete validated execution scope.
+struct KernelCfgOwnerScope {
+  uint64_t descriptor_file_offset = 0;
+  KernelCfgScope scope;
+};
+
+/// @brief One descriptor proven to execute a queried instruction.
+struct KernelCfgOwnerProof {
+  uint64_t descriptor_file_offset = 0;
+  KernelCfgOwnerProofKind kind = KernelCfgOwnerProofKind::KernelLocal;
+};
+
+/// @brief Build a sorted lookup from source text offsets to decoded blocks.
+[[nodiscard]] BlockOffsetIndex
+build_block_offset_index(const std::vector<std::unique_ptr<BasicBlock>> &blocks);
+
+/// @brief Return the decoded block containing @p offset, or nullptr.
+[[nodiscard]] BasicBlock *block_for_offset(const BlockOffsetIndex &index, uint64_t offset);
+
+/// @brief Return every descriptor whose validated scope contains @p offset.
+[[nodiscard]] std::vector<KernelCfgOwnerProof>
+kernel_cfg_owners_for_offset(std::span<const KernelCfgOwnerScope> owner_scopes,
+                             const BlockOffsetIndex &block_index, uint64_t offset);
+
+/// @brief Build one descriptor-owned CFG scope without entering other kernels.
+///
+/// @details The walk follows ordinary CFG successors and validated call edges,
+/// but stops at entry points owned by other descriptors. Additional hardware
+/// entry points (for example, kernarg-preload entries) are seeded explicitly.
+/// Context-sensitive call and return edges are materialized for liveness
+/// without mutating the process-wide BasicBlock graph.
+///
+/// @param blocks All decoded blocks in source order.
+/// @param block_index Sorted lookup built from @p blocks.
+/// @param request Primary and additional entries owned by this descriptor.
+/// @param all_kernel_entries Every hardware kernel entry in the code object.
+/// @param text Original text bytes used to validate return instructions.
+/// @returns A complete kernel-local scope, or nullopt when an owned entry is not
+/// decoded.
+[[nodiscard]] std::optional<KernelCfgScope>
+build_kernel_cfg_scope(const std::vector<std::unique_ptr<BasicBlock>> &blocks,
+                       const BlockOffsetIndex &block_index, const KernelScopeRequest &request,
+                       std::span<const uint64_t> all_kernel_entries, std::span<const uint8_t> text);
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
@@ -11,7 +11,11 @@
 
 #include <algorithm>
 #include <cstring>
+#include <limits>
 #include <optional>
+#include <span>
+#include <string_view>
+#include <unordered_map>
 #include <utility>
 
 namespace rocjitsu {
@@ -56,6 +60,320 @@ using detail::fits_in_bounds;
  * \NPI new GPU: map its MACH value and its gfxNNNN triple to a target id in \
  * both target_from_machine_flags() and target_from_triple() below.
  */
+
+struct FunctionSymbolInfo {
+  uint64_t entry_text_offset = 0;
+  uint64_t text_file_offset = 0;
+  uint64_t text_size = 0;
+  uint64_t code_size = 0;
+};
+
+[[nodiscard]] std::optional<uint64_t> symbol_file_offset(const Elf64_Sym &sym,
+                                                         const std::vector<Elf64_Shdr> &shdrs) {
+  if (sym.st_shndx >= shdrs.size())
+    return std::nullopt;
+  const auto &section = shdrs[sym.st_shndx];
+  if (sym.st_value < section.sh_addr)
+    return std::nullopt;
+  const uint64_t section_delta = sym.st_value - section.sh_addr;
+  if (section_delta > section.sh_size)
+    return std::nullopt;
+  return section.sh_offset + section_delta;
+}
+
+struct MetadataCursor {
+  std::span<const uint8_t> bytes;
+  size_t offset = 0;
+};
+
+[[nodiscard]] bool skip_metadata_bytes(MetadataCursor &cursor, uint64_t count) {
+  if (cursor.offset > cursor.bytes.size() || count > cursor.bytes.size() - cursor.offset)
+    return false;
+  cursor.offset += static_cast<size_t>(count);
+  return true;
+}
+
+[[nodiscard]] bool read_metadata_be(MetadataCursor &cursor, unsigned byte_count, uint64_t &value) {
+  if (byte_count > sizeof(value) || cursor.offset > cursor.bytes.size() ||
+      byte_count > cursor.bytes.size() - cursor.offset) {
+    return false;
+  }
+  value = 0;
+  for (unsigned i = 0; i < byte_count; ++i)
+    value = (value << 8u) | cursor.bytes[cursor.offset++];
+  return true;
+}
+
+[[nodiscard]] bool read_metadata_collection_count(MetadataCursor &cursor, bool map,
+                                                  uint32_t &count) {
+  if (cursor.offset >= cursor.bytes.size())
+    return false;
+  const uint8_t tag = cursor.bytes[cursor.offset++];
+  if (map && (tag & 0xf0u) == 0x80u) {
+    count = tag & 0x0fu;
+    return true;
+  }
+  if (!map && (tag & 0xf0u) == 0x90u) {
+    count = tag & 0x0fu;
+    return true;
+  }
+  uint64_t wide_count = 0;
+  if (tag == (map ? 0xdeu : 0xdcu)) {
+    if (!read_metadata_be(cursor, 2u, wide_count))
+      return false;
+  } else if (tag == (map ? 0xdfu : 0xddu)) {
+    if (!read_metadata_be(cursor, 4u, wide_count))
+      return false;
+  } else {
+    return false;
+  }
+  if (wide_count > std::numeric_limits<uint32_t>::max())
+    return false;
+  count = static_cast<uint32_t>(wide_count);
+  return true;
+}
+
+[[nodiscard]] bool read_metadata_string(MetadataCursor &cursor, std::string_view &value) {
+  if (cursor.offset >= cursor.bytes.size())
+    return false;
+  const uint8_t tag = cursor.bytes[cursor.offset++];
+  uint64_t length = 0;
+  if ((tag & 0xe0u) == 0xa0u) {
+    length = tag & 0x1fu;
+  } else if (tag == 0xd9u) {
+    if (!read_metadata_be(cursor, 1u, length))
+      return false;
+  } else if (tag == 0xdau) {
+    if (!read_metadata_be(cursor, 2u, length))
+      return false;
+  } else if (tag == 0xdbu) {
+    if (!read_metadata_be(cursor, 4u, length))
+      return false;
+  } else {
+    return false;
+  }
+  if (cursor.offset > cursor.bytes.size() || length > cursor.bytes.size() - cursor.offset)
+    return false;
+  value = std::string_view(reinterpret_cast<const char *>(cursor.bytes.data() + cursor.offset),
+                           static_cast<size_t>(length));
+  cursor.offset += static_cast<size_t>(length);
+  return true;
+}
+
+[[nodiscard]] bool read_metadata_unsigned(MetadataCursor &cursor, uint64_t &value) {
+  if (cursor.offset >= cursor.bytes.size())
+    return false;
+  const uint8_t tag = cursor.bytes[cursor.offset++];
+  if (tag <= 0x7fu) {
+    value = tag;
+    return true;
+  }
+  switch (tag) {
+  case 0xccu:
+    return read_metadata_be(cursor, 1u, value);
+  case 0xcdu:
+    return read_metadata_be(cursor, 2u, value);
+  case 0xceu:
+    return read_metadata_be(cursor, 4u, value);
+  case 0xcfu:
+    return read_metadata_be(cursor, 8u, value);
+  default:
+    return false;
+  }
+}
+
+[[nodiscard]] bool skip_metadata_value(MetadataCursor &cursor, unsigned depth = 0) {
+  if (depth > 64u || cursor.offset >= cursor.bytes.size())
+    return false;
+  const uint8_t tag = cursor.bytes[cursor.offset];
+  if (tag <= 0x7fu || tag >= 0xe0u || tag == 0xc0u || tag == 0xc2u || tag == 0xc3u)
+    return skip_metadata_bytes(cursor, 1u);
+  if ((tag & 0xe0u) == 0xa0u)
+    return skip_metadata_bytes(cursor, 1u + (tag & 0x1fu));
+  if ((tag & 0xf0u) == 0x90u || (tag & 0xf0u) == 0x80u) {
+    ++cursor.offset;
+    const uint32_t elements =
+        (tag & 0xf0u) == 0x80u ? static_cast<uint32_t>(tag & 0x0fu) * 2u : tag & 0x0fu;
+    for (uint32_t i = 0; i < elements; ++i) {
+      if (!skip_metadata_value(cursor, depth + 1u))
+        return false;
+    }
+    return true;
+  }
+
+  ++cursor.offset;
+  uint64_t length = 0;
+  const auto skip_length_prefixed = [&](unsigned length_bytes, uint64_t extra) {
+    return read_metadata_be(cursor, length_bytes, length) &&
+           skip_metadata_bytes(cursor, length + extra);
+  };
+  switch (tag) {
+  case 0xc4u:
+  case 0xd9u:
+    return skip_length_prefixed(1u, 0u);
+  case 0xc5u:
+  case 0xdau:
+    return skip_length_prefixed(2u, 0u);
+  case 0xc6u:
+  case 0xdbu:
+    return skip_length_prefixed(4u, 0u);
+  case 0xc7u:
+    return skip_length_prefixed(1u, 1u);
+  case 0xc8u:
+    return skip_length_prefixed(2u, 1u);
+  case 0xc9u:
+    return skip_length_prefixed(4u, 1u);
+  case 0xcau:
+  case 0xceu:
+  case 0xd2u:
+    return skip_metadata_bytes(cursor, 4u);
+  case 0xcbu:
+  case 0xcfu:
+  case 0xd3u:
+    return skip_metadata_bytes(cursor, 8u);
+  case 0xccu:
+  case 0xd0u:
+    return skip_metadata_bytes(cursor, 1u);
+  case 0xcdu:
+  case 0xd1u:
+    return skip_metadata_bytes(cursor, 2u);
+  case 0xd4u:
+    return skip_metadata_bytes(cursor, 2u);
+  case 0xd5u:
+    return skip_metadata_bytes(cursor, 3u);
+  case 0xd6u:
+    return skip_metadata_bytes(cursor, 5u);
+  case 0xd7u:
+    return skip_metadata_bytes(cursor, 9u);
+  case 0xd8u:
+    return skip_metadata_bytes(cursor, 17u);
+  case 0xdcu:
+  case 0xddu:
+  case 0xdeu:
+  case 0xdfu: {
+    const bool map = tag == 0xdeu || tag == 0xdfu;
+    const unsigned count_bytes = tag == 0xdcu || tag == 0xdeu ? 2u : 4u;
+    if (!read_metadata_be(cursor, count_bytes, length) ||
+        (map && length > std::numeric_limits<uint64_t>::max() / 2u)) {
+      return false;
+    }
+    const uint64_t elements = map ? length * 2u : length;
+    for (uint64_t i = 0; i < elements; ++i) {
+      if (!skip_metadata_value(cursor, depth + 1u))
+        return false;
+    }
+    return true;
+  }
+  default:
+    return false;
+  }
+}
+
+struct KernelMetadata {
+  std::optional<bool> uses_dynamic_stack;
+  std::optional<uint16_t> sgpr_count;
+};
+
+[[nodiscard]] std::unordered_map<std::string, KernelMetadata>
+parse_kernel_metadata(std::span<const uint8_t> payload) {
+  std::unordered_map<std::string, KernelMetadata> result;
+  MetadataCursor root{payload};
+  uint32_t root_entries = 0;
+  if (!read_metadata_collection_count(root, /*map=*/true, root_entries))
+    return result;
+  for (uint32_t entry = 0; entry < root_entries; ++entry) {
+    std::string_view key;
+    if (!read_metadata_string(root, key))
+      return {};
+    if (key != "amdhsa.kernels") {
+      if (!skip_metadata_value(root))
+        return {};
+      continue;
+    }
+    uint32_t kernel_count = 0;
+    if (!read_metadata_collection_count(root, /*map=*/false, kernel_count))
+      return {};
+    for (uint32_t kernel_index = 0; kernel_index < kernel_count; ++kernel_index) {
+      uint32_t kernel_entries = 0;
+      if (!read_metadata_collection_count(root, /*map=*/true, kernel_entries))
+        return {};
+      std::optional<std::string> name;
+      KernelMetadata metadata;
+      for (uint32_t kernel_entry = 0; kernel_entry < kernel_entries; ++kernel_entry) {
+        std::string_view kernel_key;
+        if (!read_metadata_string(root, kernel_key))
+          return {};
+        if (kernel_key == ".name") {
+          std::string_view parsed_name;
+          if (!read_metadata_string(root, parsed_name))
+            return {};
+          name = parsed_name;
+        } else if (kernel_key == ".uses_dynamic_stack") {
+          if (root.offset >= root.bytes.size())
+            return {};
+          const uint8_t tag = root.bytes[root.offset++];
+          if (tag != 0xc2u && tag != 0xc3u)
+            return {};
+          metadata.uses_dynamic_stack = tag == 0xc3u;
+        } else if (kernel_key == ".sgpr_count") {
+          uint64_t count = 0;
+          if (!read_metadata_unsigned(root, count) ||
+              count > std::numeric_limits<uint16_t>::max()) {
+            return {};
+          }
+          metadata.sgpr_count = static_cast<uint16_t>(count);
+        } else if (!skip_metadata_value(root)) {
+          return {};
+        }
+      }
+      if (name && (metadata.uses_dynamic_stack || metadata.sgpr_count))
+        result[*name] = metadata;
+    }
+    break;
+  }
+  return result;
+}
+
+[[nodiscard]] uint64_t align4(uint64_t value) { return (value + 3u) & ~uint64_t{3}; }
+
+[[nodiscard]] std::unordered_map<std::string, KernelMetadata>
+read_kernel_metadata(std::span<const uint8_t> image, const Elf64_Ehdr &header) {
+  std::unordered_map<std::string, KernelMetadata> result;
+  if (header.e_phentsize != sizeof(Elf64_Phdr) || header.e_phoff > image.size() ||
+      static_cast<uint64_t>(header.e_phnum) * sizeof(Elf64_Phdr) > image.size() - header.e_phoff) {
+    return result;
+  }
+  for (uint16_t index = 0; index < header.e_phnum; ++index) {
+    Elf64_Phdr program_header{};
+    std::memcpy(&program_header,
+                image.data() + header.e_phoff + static_cast<uint64_t>(index) * sizeof(Elf64_Phdr),
+                sizeof(program_header));
+    if (program_header.p_type != PT_NOTE || program_header.p_offset > image.size() ||
+        program_header.p_filesz > image.size() - program_header.p_offset) {
+      continue;
+    }
+    uint64_t cursor = program_header.p_offset;
+    const uint64_t end = cursor + program_header.p_filesz;
+    while (cursor <= end && sizeof(Elf64_Nhdr) <= end - cursor) {
+      Elf64_Nhdr note{};
+      std::memcpy(&note, image.data() + cursor, sizeof(note));
+      cursor += sizeof(note);
+      const uint64_t name_bytes = align4(note.n_namesz);
+      const uint64_t desc_bytes = align4(note.n_descsz);
+      if (name_bytes > end - cursor || desc_bytes > end - cursor - name_bytes)
+        break;
+      const uint64_t desc_offset = cursor + name_bytes;
+      cursor = desc_offset + desc_bytes;
+      if (note.n_type != NT_AMDGPU_METADATA || note.n_descsz > image.size() - desc_offset)
+        continue;
+      auto parsed =
+          parse_kernel_metadata(image.subspan(static_cast<size_t>(desc_offset), note.n_descsz));
+      result.insert(parsed.begin(), parsed.end());
+    }
+  }
+  return result;
+}
+
 rj_code_target_id_t target_from_machine_flags(uint32_t flags) {
   uint32_t mach = flags & EF_AMDGPU_MACH;
   if (mach == EF_AMDGPU_MACH_AMDGCN_GFX90A)
@@ -100,6 +418,9 @@ AmdGpuCodeObject::AmdGpuCodeObject(AmdGpuCodeObject &&other) noexcept
   sections_ = std::move(other.sections_);
   text_sections_ = std::move(other.text_sections_);
   rodata_sections_ = std::move(other.rodata_sections_);
+  kd_offsets_ = std::move(other.kd_offsets_);
+  kernels_ = std::move(other.kernels_);
+  functions_ = std::move(other.functions_);
 }
 
 AmdGpuCodeObject::AmdGpuCodeObject(const std::string &elf_path) {
@@ -188,8 +509,9 @@ AmdGpuCodeObject::~AmdGpuCodeObject() = default;
 void AmdGpuCodeObject::load_sections() {
   const auto shoff = header_->sectionHeaderOff();
   const int num_shdrs = header_->numSectionHeaders();
-  if (num_shdrs < 0 || !fits_in_bounds(shoff, static_cast<uint64_t>(num_shdrs) * sizeof(Elf64_Shdr),
-                                       image_.size())) {
+  if (num_shdrs <= 0 ||
+      !fits_in_bounds(shoff, static_cast<uint64_t>(num_shdrs) * sizeof(Elf64_Shdr),
+                      image_.size())) {
     is_valid_ = false;
     return;
   }
@@ -210,19 +532,28 @@ void AmdGpuCodeObject::load_sections() {
   }
   const char *shstrtab_data = image_.data() + shstrtab.sh_offset;
 
-  for (const auto &shdr : section_hdrs) {
+  std::vector<std::string> section_names(section_hdrs.size());
+  for (size_t i = 0; i < section_hdrs.size(); ++i) {
+    const auto &shdr = section_hdrs[i];
+    if (shdr.sh_name >= shstrtab.sh_size)
+      continue;
+    size_t max_len = shstrtab.sh_size - shdr.sh_name;
+    section_names[i] =
+        std::string(shstrtab_data + shdr.sh_name, strnlen(shstrtab_data + shdr.sh_name, max_len));
+  }
+
+  for (size_t i = 0; i < section_hdrs.size(); ++i) {
+    const auto &shdr = section_hdrs[i];
     if (shdr.sh_type == SHT_NULL || shdr.sh_type == SHT_NOBITS)
       continue;
-    if (shdr.sh_name >= shstrtab.sh_size)
+    if (section_names[i].empty())
       continue;
     if (!fits_in_bounds(shdr.sh_offset, shdr.sh_size, image_.size())) {
       is_valid_ = false;
       return;
     }
 
-    size_t max_len = shstrtab.sh_size - shdr.sh_name;
-    std::string sec_name(shstrtab_data + shdr.sh_name,
-                         strnlen(shstrtab_data + shdr.sh_name, max_len));
+    const std::string &sec_name = section_names[i];
 
     auto sec_data = std::make_unique<char[]>(shdr.sh_size);
     std::memcpy(sec_data.get(), image_.data() + shdr.sh_offset, shdr.sh_size);
@@ -237,6 +568,9 @@ void AmdGpuCodeObject::load_sections() {
   // Parse symbol table for kernel descriptor offsets.
   // Scan both SHT_SYMTAB and SHT_DYNSYM — stripped code objects may
   // only have the latter.
+  std::unordered_map<std::string, uint64_t> descriptor_file_offsets;
+  std::unordered_map<std::string, FunctionSymbolInfo> function_symbols;
+  std::unordered_map<std::string, bool> dynamic_stack_symbols;
   for (size_t i = 0; i < section_hdrs.size(); ++i) {
     if (section_hdrs[i].sh_type != SHT_SYMTAB && section_hdrs[i].sh_type != SHT_DYNSYM)
       continue;
@@ -268,13 +602,93 @@ void AmdGpuCodeObject::load_sections() {
         continue;
       std::string sym_name(sym_strtab + sym.st_name,
                            strnlen(sym_strtab + sym.st_name, strtab_shdr.sh_size - sym.st_name));
+      constexpr std::string_view kDynamicStackSuffix = ".has_dyn_sized_stack";
+      if (sym.st_shndx == SHN_ABS && sym_name.ends_with(kDynamicStackSuffix)) {
+        const std::string kernel_name =
+            sym_name.substr(0, sym_name.size() - kDynamicStackSuffix.size());
+        dynamic_stack_symbols[kernel_name] = sym.st_value != 0;
+        continue;
+      }
       // AMDHSA kernel descriptors have a ".kd" suffix symbol.
       if (sym_name.size() > 3 && sym_name.substr(sym_name.size() - 3) == ".kd") {
         std::string kernel_name = sym_name.substr(0, sym_name.size() - 3);
         kd_offsets_[kernel_name] = sym.st_value;
+        if (auto file_offset = symbol_file_offset(sym, section_hdrs))
+          descriptor_file_offsets[kernel_name] = *file_offset;
+        continue;
+      }
+
+      if (elf_symbol_type(sym.st_info) == kElfSymbolTypeFunc && sym.st_size > 0 &&
+          sym.st_shndx < section_hdrs.size() && section_names[sym.st_shndx] == ".text") {
+        const auto &text = section_hdrs[sym.st_shndx];
+        if (sym.st_value >= text.sh_addr && sym.st_value - text.sh_addr <= text.sh_size) {
+          FunctionSymbolInfo info;
+          info.entry_text_offset = sym.st_value - text.sh_addr;
+          info.text_file_offset = text.sh_offset;
+          info.text_size = text.sh_size;
+          info.code_size = sym.st_size;
+          function_symbols[sym_name] = info;
+        }
       }
     }
   }
+
+  Elf64_Ehdr elf_header{};
+  std::memcpy(&elf_header, image_.data(), sizeof(elf_header));
+  const auto metadata = read_kernel_metadata(
+      std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(image_.data()), image_.size()),
+      elf_header);
+
+  kernels_.clear();
+  kernels_.reserve(kd_offsets_.size());
+  for (const auto &entry : kd_offsets_) {
+    const std::string &kernel_name = entry.first;
+    AmdGpuKernelInfo kernel;
+    kernel.name = kernel_name;
+    if (auto file_offset = descriptor_file_offsets.find(kernel_name);
+        file_offset != descriptor_file_offsets.end())
+      kernel.descriptor_file_offset = file_offset->second;
+
+    if (auto func = function_symbols.find(kernel_name); func != function_symbols.end()) {
+      kernel.entry_text_offset = func->second.entry_text_offset;
+      kernel.text_file_offset = func->second.text_file_offset;
+      kernel.text_size = func->second.text_size;
+      kernel.code_size = func->second.code_size;
+      kernel.has_text_range = true;
+    } else {
+      kernel.code_size = 0;
+      kernel.has_text_range = false;
+    }
+    if (auto metadata_entry = metadata.find(kernel_name); metadata_entry != metadata.end()) {
+      kernel.uses_dynamic_stack = metadata_entry->second.uses_dynamic_stack;
+      kernel.sgpr_count = metadata_entry->second.sgpr_count;
+    }
+    if (!kernel.uses_dynamic_stack) {
+      auto dynamic_stack = dynamic_stack_symbols.find(kernel_name);
+      if (dynamic_stack != dynamic_stack_symbols.end())
+        kernel.uses_dynamic_stack = dynamic_stack->second;
+    }
+    kernels_.push_back(std::move(kernel));
+  }
+  std::sort(kernels_.begin(), kernels_.end(),
+            [](const auto &lhs, const auto &rhs) { return lhs.name < rhs.name; });
+
+  functions_.clear();
+  functions_.reserve(function_symbols.size());
+  for (const auto &entry : function_symbols) {
+    AmdGpuFunctionInfo function;
+    function.name = entry.first;
+    function.entry_text_offset = entry.second.entry_text_offset;
+    function.text_file_offset = entry.second.text_file_offset;
+    function.text_size = entry.second.text_size;
+    function.code_size = entry.second.code_size;
+    functions_.push_back(std::move(function));
+  }
+  std::sort(functions_.begin(), functions_.end(), [](const auto &lhs, const auto &rhs) {
+    if (lhs.entry_text_offset != rhs.entry_text_offset)
+      return lhs.entry_text_offset < rhs.entry_text_offset;
+    return lhs.name < rhs.name;
+  });
 
   is_valid_ = true;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.h
@@ -19,6 +19,26 @@
 
 namespace rocjitsu {
 
+struct AmdGpuKernelInfo {
+  std::string name;
+  uint64_t descriptor_file_offset = 0;
+  uint64_t entry_text_offset = 0;
+  uint64_t text_file_offset = 0;
+  uint64_t text_size = 0;
+  uint64_t code_size = 0;
+  bool has_text_range = false;
+  std::optional<bool> uses_dynamic_stack;
+  std::optional<uint16_t> sgpr_count;
+};
+
+struct AmdGpuFunctionInfo {
+  std::string name;
+  uint64_t entry_text_offset = 0;
+  uint64_t text_file_offset = 0;
+  uint64_t text_size = 0;
+  uint64_t code_size = 0;
+};
+
 /// @brief Represents a single AMD GPU HSA ELF code object.
 ///
 /// A code object is a device ELF containing GPU machine code (.text sections),
@@ -60,6 +80,12 @@ public:
   /// @returns Reference to the target triple string.
   const std::string &target_triple() const { return target_triple_; }
 
+  /// @brief Kernel descriptor/function symbols discovered in this code object.
+  const std::vector<AmdGpuKernelInfo> &kernels() const { return kernels_; }
+
+  /// @brief All `.text` function symbols discovered in this code object.
+  const std::vector<AmdGpuFunctionInfo> &functions() const { return functions_; }
+
   uint64_t kernel_descriptor_offset(const std::string &kernel_name) const override;
 
   /// @brief Smallest per-wavefront SGPR allocation across this object's kernels.
@@ -81,6 +107,8 @@ private:
   std::string offload_kind_;
   std::string target_triple_;
   std::unordered_map<std::string, uint64_t> kd_offsets_; ///< kernel_name -> .kd symbol offset
+  std::vector<AmdGpuKernelInfo> kernels_;
+  std::vector<AmdGpuFunctionInfo> functions_;
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
@@ -14,6 +14,7 @@
 #include <optional>
 #include <set>
 #include <span>
+#include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -116,28 +117,61 @@ void BasicBlock::add_static_indirect_call_fixup(IndirectCallFixup fixup) {
   static_indirect_call_fixups_.push_back(fixup);
 }
 
-std::vector<std::unique_ptr<BasicBlock>>
-BasicBlock::build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
-                  std::span<const uint64_t> extra_leaders) {
+std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co, Decoder &decoder,
+                                                           rj_code_arch_t arch,
+                                                           std::span<const uint64_t> extra_leaders,
+                                                           std::span<const CodeRange> code_ranges) {
   std::vector<std::unique_ptr<BasicBlock>> blocks;
 
   for (const auto *sec : co.text_sections()) {
     const auto *inst_data = reinterpret_cast<const uint32_t *>(sec->data());
-    std::size_t inst_data_size = sec->size() / sizeof(uint32_t);
-    uint64_t pc = 0;
-    uint64_t byte_offset = 0;
-
     std::vector<std::unique_ptr<Instruction>> decoded;
 
-    while (pc < inst_data_size) {
-      auto *raw_inst = decoder.decode(&inst_data[pc], byte_offset);
-      std::unique_ptr<Instruction> inst(raw_inst);
-      uint32_t inst_size_bytes = static_cast<uint32_t>(inst->size());
-      uint32_t inst_words = inst_size_bytes / sizeof(uint32_t);
+    std::vector<CodeRange> section_ranges;
+    if (code_ranges.empty()) {
+      section_ranges.push_back({.start_offset = 0, .size = sec->size()});
+    } else {
+      section_ranges.reserve(code_ranges.size());
+      for (const CodeRange &range : code_ranges) {
+        if (range.start_offset >= sec->size() || range.size == 0)
+          continue;
+        if (range.start_offset % sizeof(uint32_t) != 0 || range.size % sizeof(uint32_t) != 0) {
+          throw std::runtime_error("Declared code range is not dword aligned");
+        }
+        const uint64_t available = sec->size() - range.start_offset;
+        section_ranges.push_back(
+            {.start_offset = range.start_offset, .size = std::min(range.size, available)});
+      }
+      std::ranges::sort(section_ranges, {}, &CodeRange::start_offset);
+      std::vector<CodeRange> merged_ranges;
+      for (const CodeRange &range : section_ranges) {
+        if (merged_ranges.empty() ||
+            merged_ranges.back().start_offset + merged_ranges.back().size < range.start_offset) {
+          merged_ranges.push_back(range);
+          continue;
+        }
+        CodeRange &merged = merged_ranges.back();
+        const uint64_t merged_end = merged.start_offset + merged.size;
+        const uint64_t range_end = range.start_offset + range.size;
+        merged.size = std::max(merged_end, range_end) - merged.start_offset;
+      }
+      section_ranges = std::move(merged_ranges);
+    }
 
-      decoded.push_back(std::move(inst));
-      pc += inst_words;
-      byte_offset += inst_size_bytes;
+    for (const CodeRange &range : section_ranges) {
+      uint64_t byte_offset = range.start_offset;
+      const uint64_t range_end = range.start_offset + range.size;
+      while (byte_offset < range_end) {
+        const size_t pc = static_cast<size_t>(byte_offset / sizeof(uint32_t));
+        auto *raw_inst = decoder.decode(&inst_data[pc], byte_offset);
+        std::unique_ptr<Instruction> inst(raw_inst);
+        const uint32_t inst_size_bytes = static_cast<uint32_t>(inst->size());
+        if (inst_size_bytes == 0 || inst_size_bytes > range_end - byte_offset)
+          throw std::runtime_error("Instruction extends past declared code range");
+
+        decoded.push_back(std::move(inst));
+        byte_offset += inst_size_bytes;
+      }
     }
 
     if (decoded.empty())
@@ -148,7 +182,7 @@ BasicBlock::build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
     for (const auto &inst : decoded)
       decoded_insts.push_back(inst.get());
 
-    const uint64_t section_end = byte_offset;
+    const uint64_t section_end = sec->size();
     // Indirect target discovery belongs with block construction because
     // recovered branch targets must become leaders before instructions are
     // moved into final BasicBlock storage. The discovery pass first walks the
@@ -208,7 +242,9 @@ BasicBlock::build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
         current->add_instruction(std::move(decoded[i]));
         ++i;
 
-        if (terminates || (i < decoded.size() && leaders.contains(next_offset)))
+        const bool discontinuity = i < decoded.size() && decoded[i]->src_loc() != next_offset;
+        if (terminates || discontinuity ||
+            (i < decoded.size() && leaders.contains(decoded[i]->src_loc())))
           break;
       }
       section_blocks.push_back(std::move(current));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.h
@@ -28,6 +28,12 @@ class Decoder;
 /// at a branch, conditional branch, or program terminator instruction.
 class BasicBlock : public util::IListNode<BasicBlock> {
 public:
+  /// @brief Half-open byte range in `.text` known to contain instructions.
+  struct CodeRange {
+    uint64_t start_offset = 0;
+    uint64_t size = 0;
+  };
+
   /// @brief Kind of call-like edge recorded outside the local CFG successor list.
   enum class CallEdgeKind {
     DirectCall,
@@ -121,10 +127,13 @@ public:
   /// @param[in] decoder Decoder for the target ISA.
   /// @param[in] arch ISA architecture used to match static PC builders.
   /// @param[in] extra_leaders Byte offsets that must start a basic block.
+  /// @param[in] code_ranges Optional symbol-backed instruction ranges. When
+  /// empty, decode the complete text section. Supplying ranges excludes
+  /// alignment padding and embedded data from instruction decoding.
   /// @returns Ordered list of basic blocks with their decoded instructions.
   static std::vector<std::unique_ptr<BasicBlock>>
   build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
-        std::span<const uint64_t> extra_leaders = {});
+        std::span<const uint64_t> extra_leaders = {}, std::span<const CodeRange> code_ranges = {});
 
 private:
   void add_instruction(std::unique_ptr<Instruction> inst);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -3,6 +3,7 @@
 
 #include "rocjitsu/code/dbt/binary_translator.h"
 
+#include "rocjitsu/analysis/kernel_scope.h"
 #include "rocjitsu/analysis/liveness.h"
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
@@ -80,13 +81,6 @@ LegalizationLookupFn select_legalization(rj_code_arch_t guest, rj_code_arch_t ho
   if (!raw)
     return {};
   return {raw, raw + inst.size() / sizeof(uint32_t)};
-}
-
-[[nodiscard]] uint32_t text_word_at(std::span<const uint8_t> text, uint64_t offset) {
-  uint32_t word = 0;
-  if (offset + sizeof(word) <= text.size())
-    std::memcpy(&word, text.data() + offset, sizeof(word));
-  return word;
 }
 
 [[nodiscard]] bool words_changed(std::span<const uint32_t> before,
@@ -169,108 +163,20 @@ struct KernelTranslationScope {
   KdTranslation *translation = nullptr;
   BasicBlock *entry = nullptr;
   std::vector<BasicBlock *> blocks;
+  std::vector<ScopedCfgEdge> liveness_edges;
+  std::unordered_set<uint64_t> call_return_offsets;
 };
-
-/// @brief Sorted index from source .text byte offsets to decoded blocks.
-///
-/// @details DBT relocation repeatedly maps descriptor entries, branch targets,
-/// and recovered indirect targets back to the BasicBlock that owns a source
-/// offset. Keeping this compact sorted index avoids rebuilding that lookup while
-/// preserving BasicBlock ownership in the vector returned by BasicBlock::build().
-using BlockOffsetIndex = std::vector<std::pair<uint64_t, BasicBlock *>>;
-
-[[nodiscard]] BlockOffsetIndex
-build_block_offset_index(const std::vector<std::unique_ptr<BasicBlock>> &blocks) {
-  BlockOffsetIndex index;
-  index.reserve(blocks.size());
-  for (const auto &block : blocks) {
-    if (block != nullptr)
-      index.emplace_back(block->start_offset(), block.get());
-  }
-  std::ranges::sort(index, {}, &std::pair<uint64_t, BasicBlock *>::first);
-  return index;
-}
-
-[[nodiscard]] BasicBlock *block_for_offset(const BlockOffsetIndex &index, uint64_t offset) {
-  auto it = std::ranges::upper_bound(index, offset, std::less<>{},
-                                     &std::pair<uint64_t, BasicBlock *>::first);
-  if (it == index.begin())
-    return nullptr;
-  --it;
-
-  BasicBlock *block = it->second;
-  if (block == nullptr || offset >= block->end_offset())
-    return nullptr;
-  return block;
-}
-
-[[nodiscard]] std::vector<BasicBlock *>
-reachable_kernel_blocks(const std::vector<std::unique_ptr<BasicBlock>> &blocks,
-                        const BlockOffsetIndex &block_index, BasicBlock &entry,
-                        const std::unordered_set<uint64_t> &kernel_entries,
-                        const std::unordered_set<uint64_t> &own_entries) {
-  std::unordered_set<const BasicBlock *> reachable;
-  std::vector<BasicBlock *> stack{&entry};
-  for (const uint64_t own_entry : own_entries) {
-    if (own_entry == entry.start_offset())
-      continue;
-    if (BasicBlock *extra_entry = block_for_offset(block_index, own_entry);
-        extra_entry != nullptr && extra_entry != &entry) {
-      stack.push_back(extra_entry);
-    }
-  }
-
-  while (!stack.empty()) {
-    BasicBlock *block = stack.back();
-    stack.pop_back();
-    assert(block != nullptr && "reachable walk stack should contain only decoded blocks");
-    if (!reachable.insert(block).second)
-      continue;
-
-    for (BasicBlock *succ : block->successors()) {
-      assert(succ != nullptr && "BasicBlock successors should never be null");
-      if (!own_entries.contains(succ->start_offset()) &&
-          kernel_entries.contains(succ->start_offset()))
-        continue;
-      stack.push_back(succ);
-    }
-    // Ordinary CFG successors describe control that always follows from the
-    // current program counter: fallthroughs, conditional targets, direct branch
-    // targets, and recovered non-returning setpc targets. Call edges are tracked
-    // separately because a shared callee block can return to different
-    // continuations depending on which call site entered it. Reachability for
-    // translation still has to include the callee body, but later liveness gets
-    // explicit call/return edges rather than treating every possible return as a
-    // global CFG successor.
-    for (const BasicBlock::CallEdge &call : block->call_edges()) {
-      BasicBlock *callee = call.callee;
-      assert(callee != nullptr && "BasicBlock call edges should always have a callee");
-      if (!own_entries.contains(callee->start_offset()) &&
-          kernel_entries.contains(callee->start_offset()))
-        continue;
-      stack.push_back(callee);
-    }
-  }
-
-  std::vector<BasicBlock *> ordered;
-  ordered.reserve(reachable.size());
-  for (const auto &block : blocks) {
-    if (block && reachable.contains(block.get()))
-      ordered.push_back(block.get());
-  }
-  return ordered;
-}
 
 [[nodiscard]] std::vector<KernelTranslationScope>
 kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks,
-                          const BlockOffsetIndex &block_index, std::span<KdTranslation> kernels) {
+                          const BlockOffsetIndex &block_index, std::span<KdTranslation> kernels,
+                          std::span<const uint8_t> text) {
   std::vector<KernelTranslationScope> scopes;
   const auto entries = kernel_entry_offsets(kernels);
   if (entries.empty())
     return scopes;
 
   const auto hardware_entries = kernel_hardware_entry_offsets(kernels);
-  std::unordered_set<uint64_t> entry_set(hardware_entries.begin(), hardware_entries.end());
   std::vector<KdTranslation *> ordered_kernels;
   ordered_kernels.reserve(kernels.size());
   std::unordered_set<uint64_t> seen_entries;
@@ -285,152 +191,21 @@ kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks
 
   scopes.reserve(ordered_kernels.size());
   for (KdTranslation *kernel : ordered_kernels) {
-    BasicBlock *entry = block_for_offset(block_index, kernel->entry_text_offset);
-    if (entry == nullptr)
-      continue;
-    std::unordered_set<uint64_t> own_entries{kernel->entry_text_offset};
-    if (kernel->has_kernarg_preload) {
-      if (block_for_offset(block_index, kernel->kernarg_preload_entry_text_offset) == nullptr)
-        continue;
-      own_entries.insert(kernel->kernarg_preload_entry_text_offset);
-    }
+    KernelScopeRequest request{.entry_offset = kernel->entry_text_offset,
+                               .additional_entry_offsets = {}};
+    if (kernel->has_kernarg_preload)
+      request.additional_entry_offsets.push_back(kernel->kernarg_preload_entry_text_offset);
 
-    scopes.push_back(
-        {kernel, entry,
-         reachable_kernel_blocks(blocks, block_index, *entry, entry_set, own_entries)});
+    auto scope = build_kernel_cfg_scope(blocks, block_index, request, hardware_entries, text);
+    if (!scope)
+      continue;
+    scopes.push_back({.translation = kernel,
+                      .entry = scope->entry,
+                      .blocks = std::move(scope->blocks),
+                      .liveness_edges = std::move(scope->liveness_edges),
+                      .call_return_offsets = std::move(scope->call_return_offsets)});
   }
   return scopes;
-}
-
-/// @brief Return whether an instruction is an `s_setpc_b64` through one SGPR pair.
-///
-/// @details Return-like scalar control flow is left as an indirect branch in the
-/// translated instruction stream, so DBT must validate that the block terminator
-/// reads the call edge's saved return SGPR. This helper intentionally checks the
-/// raw SOP1 source field instead of broader instruction semantics: only the exact
-/// `s_setpc_b64 s[return:return+1]` form is a scoped call return.
-[[nodiscard]] bool s_setpc_from_sreg(const Instruction &inst, uint32_t word, uint16_t ssrc0) {
-  if (inst.size() != sizeof(uint32_t) || inst.mnemonic() != "s_setpc_b64")
-    return false;
-  return static_cast<uint16_t>(word & 0xffu) == ssrc0;
-}
-
-/// @brief Find return blocks inside one context-sensitive call target.
-///
-/// @details Call-like scalar control flow is not represented as a normal CFG
-/// edge from the callee back to every possible continuation. The same helper
-/// block can be entered by multiple kernels or multiple call sites, and the
-/// correct continuation is the one selected by the return SGPR written at that
-/// call site. This walk therefore stays inside @p allowed_blocks, follows only
-/// ordinary successors within the callee body, and reports terminators that
-/// return through @p return_sreg. The caller then pairs each return with the
-/// specific continuation from the call edge being analyzed.
-[[nodiscard]] std::vector<BasicBlock *>
-function_return_blocks(BasicBlock &callee, uint16_t return_sreg, std::span<const uint8_t> text,
-                       const std::unordered_set<BasicBlock *> &allowed_blocks) {
-  std::vector<BasicBlock *> returns;
-  std::vector<BasicBlock *> stack{&callee};
-  std::unordered_set<BasicBlock *> visited;
-
-  while (!stack.empty()) {
-    BasicBlock *block = stack.back();
-    stack.pop_back();
-    assert(block != nullptr && "return-block walk stack should contain only decoded blocks");
-    if (!allowed_blocks.contains(block) || !visited.insert(block).second)
-      continue;
-
-    const Instruction *term = block->terminator();
-    assert(term != nullptr && "decoded BasicBlock should contain at least one instruction");
-    if (s_setpc_from_sreg(*term, text_word_at(text, term->src_loc()), return_sreg)) {
-      returns.push_back(block);
-      continue;
-    }
-
-    for (BasicBlock *succ : block->successors()) {
-      assert(succ != nullptr && "BasicBlock successors should never be null");
-      stack.push_back(succ);
-    }
-  }
-
-  return returns;
-}
-
-/// @brief Collect validated return-like terminators for one kernel scope.
-///
-/// @details Binary translation rejects unresolved indirect branches after CFG
-/// construction, but a call-return `s_setpc_b64` is intentionally left as an
-/// indirect instruction in the emitted code: its dynamic target is the return PC
-/// saved by the matching `s_call_b64` or `s_swappc_b64`. To avoid accepting an
-/// arbitrary `s_setpc_b64`, this helper only marks return offsets that are
-/// reachable from a `BasicBlock::CallEdge` whose callee and continuation both
-/// belong to the current kernel-local scope.
-[[nodiscard]] std::unordered_set<uint64_t>
-scoped_call_return_offsets(std::span<BasicBlock *const> blocks, std::span<const uint8_t> text) {
-  std::unordered_set<BasicBlock *> allowed_blocks;
-  allowed_blocks.reserve(blocks.size());
-  for (BasicBlock *block : blocks) {
-    assert(block != nullptr && "kernel scope should contain only decoded blocks");
-    allowed_blocks.insert(block);
-  }
-
-  std::unordered_set<uint64_t> returns;
-  for (BasicBlock *block : blocks) {
-    assert(block != nullptr && "kernel scope should contain only decoded blocks");
-    for (const BasicBlock::CallEdge &call : block->call_edges()) {
-      assert(call.callee != nullptr && "BasicBlock call edges should always have a callee");
-      assert(call.continuation != nullptr &&
-             "BasicBlock call edges should always have a continuation");
-      if (!allowed_blocks.contains(call.callee) || !allowed_blocks.contains(call.continuation))
-        continue;
-
-      for (BasicBlock *return_block :
-           function_return_blocks(*call.callee, call.return_sreg, text, allowed_blocks)) {
-        const Instruction *term = return_block->terminator();
-        assert(term != nullptr && "function_return_blocks returns non-empty decoded blocks");
-        returns.insert(term->src_loc());
-      }
-    }
-  }
-  return returns;
-}
-
-/// @brief Materialize context-sensitive call edges for liveness.
-///
-/// @details `BasicBlock` deliberately separates call edges from ordinary CFG
-/// successors. The translator still needs liveness to see the effects of a
-/// call: values live into the callee are used by the callee, and values live
-/// after the call continuation must be live at each validated return block.
-/// This helper converts each scoped call edge into temporary analysis edges
-/// `caller -> callee` and `return -> continuation` without mutating the CFG or
-/// creating cross-kernel return edges.
-[[nodiscard]] std::vector<ScopedCfgEdge>
-scoped_call_liveness_edges(std::span<BasicBlock *const> blocks, std::span<const uint8_t> text) {
-  std::unordered_set<BasicBlock *> allowed_blocks;
-  allowed_blocks.reserve(blocks.size());
-  for (BasicBlock *block : blocks) {
-    assert(block != nullptr && "kernel scope should contain only decoded blocks");
-    allowed_blocks.insert(block);
-  }
-
-  std::vector<ScopedCfgEdge> edges;
-  for (BasicBlock *block : blocks) {
-    assert(block != nullptr && "kernel scope should contain only decoded blocks");
-    for (const BasicBlock::CallEdge &call : block->call_edges()) {
-      assert(call.callee != nullptr && "BasicBlock call edges should always have a callee");
-      assert(call.continuation != nullptr &&
-             "BasicBlock call edges should always have a continuation");
-      if (!allowed_blocks.contains(call.callee) || !allowed_blocks.contains(call.continuation))
-        continue;
-
-      edges.push_back({.from = block, .to = call.callee});
-      for (BasicBlock *return_block :
-           function_return_blocks(*call.callee, call.return_sreg, text, allowed_blocks)) {
-        edges.push_back({.from = return_block, .to = call.continuation});
-      }
-    }
-  }
-
-  return edges;
 }
 
 } // namespace
@@ -529,7 +304,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // map without borrowing another kernel's return continuation.
   auto blocks = BasicBlock::build(obj, *decoder, guest_arch_, block_leaders);
   const BlockOffsetIndex block_index = build_block_offset_index(blocks);
-  auto scopes = kernel_translation_scopes(blocks, block_index, descriptor_translations);
+  auto scopes = kernel_translation_scopes(blocks, block_index, descriptor_translations, text);
 
   if (scopes.size() != entry_offsets.size()) {
     append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
@@ -752,8 +527,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     LivenessAnalysisOptions liveness_options;
     if (options_.debug_min_free_vgpr)
       liveness_options.min_free_vgpr = *options_.debug_min_free_vgpr;
-    const auto liveness_edges = scoped_call_liveness_edges(KernelBlockScope(scope.blocks), text);
-    LivenessAnalysis liveness(KernelBlockScope(scope.blocks), liveness_options, liveness_edges);
+    LivenessAnalysis liveness(KernelBlockScope(scope.blocks), liveness_options,
+                              scope.liveness_edges);
 
     // Phase 4: translate each relocated body instruction. Oversized semantic
     // expansions branch into this kernel's private cave immediately after the body.
@@ -761,8 +536,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     // Return-like s_setpc_b64 instructions are accepted only when they are the
     // terminator of a block reached from a validated call edge in this
     // kernel-local scope.
-    const std::unordered_set<uint64_t> valid_call_return_offsets =
-        scoped_call_return_offsets(KernelBlockScope(scope.blocks), text);
+    const std::unordered_set<uint64_t> &valid_call_return_offsets = scope.call_return_offsets;
     std::unordered_set<uint64_t> recovered_indirect_call_offsets;
     for (const BlockPlacement &placement : layout.blocks) {
       BasicBlock *block = placement.block;

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocjitsu/analysis/def_use_chain.h"
+#include "rocjitsu/analysis/kernel_scope.h"
 #include "rocjitsu/analysis/liveness.h"
 #include "rocjitsu/code/basic_block.h"
 #include "rocjitsu/code/code_object.h"
@@ -583,6 +584,127 @@ TEST(CfgAnalysis, DirectCallKillsCarriedPcBuilderFacts) {
 
   EXPECT_TRUE(continuation->static_indirect_call_fixups().empty());
   EXPECT_FALSE(has_successor_start(*continuation, stale_target->start_offset()));
+}
+
+TEST(KernelScopeAnalysis, SeparatesAdjacentKernelEntries) {
+  std::vector<uint32_t> words = {
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),
+  };
+  TestCodeObject co(words);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  constexpr std::array<uint64_t, 2> entries{0, 4};
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, entries);
+  const auto index = build_block_offset_index(blocks);
+  const auto text = std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(words.data()),
+                                             words.size() * sizeof(uint32_t));
+
+  const auto first = build_kernel_cfg_scope(
+      blocks, index, KernelScopeRequest{.entry_offset = 0, .additional_entry_offsets = {}}, entries,
+      text);
+  const auto second = build_kernel_cfg_scope(
+      blocks, index, KernelScopeRequest{.entry_offset = 4, .additional_entry_offsets = {}}, entries,
+      text);
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(second.has_value());
+  ASSERT_EQ(first->blocks.size(), 1u);
+  ASSERT_EQ(second->blocks.size(), 1u);
+  EXPECT_EQ(first->blocks[0]->start_offset(), 0u);
+  EXPECT_EQ(second->blocks[0]->start_offset(), 4u);
+  EXPECT_EQ(first->entry, block_for_offset(index, 0));
+  EXPECT_EQ(second->entry, block_for_offset(index, 4));
+}
+
+TEST(KernelScopeAnalysis, SymbolRangesExcludeTextPadding) {
+  std::vector<uint32_t> words = {
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),
+      0,
+      0,
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),
+  };
+  TestCodeObject co(words);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  constexpr std::array<uint64_t, 2> entries{0, 12};
+  constexpr std::array<BasicBlock::CodeRange, 2> ranges{{{0, 4}, {12, 4}}};
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, entries, ranges);
+
+  ASSERT_EQ(blocks.size(), 2u);
+  EXPECT_EQ(blocks[0]->start_offset(), 0u);
+  EXPECT_EQ(blocks[1]->start_offset(), 12u);
+  EXPECT_TRUE(blocks[0]->successors().empty());
+  EXPECT_TRUE(blocks[1]->predecessors().empty());
+}
+
+TEST(KernelScopeAnalysis, SeedsAdditionalDescriptorEntryWithoutClaimingNextKernel) {
+  std::vector<uint32_t> words = {
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),
+  };
+  TestCodeObject co(words);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  constexpr std::array<uint64_t, 3> leaders{0, 4, 8};
+  constexpr std::array<uint64_t, 2> kernel_entries{0, 8};
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, leaders);
+  const auto index = build_block_offset_index(blocks);
+  const auto text = std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(words.data()),
+                                             words.size() * sizeof(uint32_t));
+
+  KernelScopeRequest request{.entry_offset = 0, .additional_entry_offsets = {4}};
+  const auto scope = build_kernel_cfg_scope(blocks, index, request, kernel_entries, text);
+  ASSERT_TRUE(scope.has_value());
+  ASSERT_EQ(scope->blocks.size(), 2u);
+  EXPECT_EQ(scope->blocks[0]->start_offset(), 0u);
+  EXPECT_EQ(scope->blocks[1]->start_offset(), 4u);
+
+  request.additional_entry_offsets = {12};
+  EXPECT_FALSE(build_kernel_cfg_scope(blocks, index, request, kernel_entries, text).has_value());
+}
+
+TEST(KernelScopeAnalysis, SharedHelperGetsContextSpecificReturnEdges) {
+  constexpr uint16_t kReturnSreg = 30;
+  std::vector<uint32_t> words = {
+      build_s_call_b64(kReturnSreg, 3),         // 0x00 -> helper at 0x10.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), // 0x04 kernel 0 continuation.
+      build_s_call_b64(kReturnSreg, 1),         // 0x08 -> helper at 0x10.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), // 0x0c kernel 1 continuation.
+      pack_sop1(0x1d, 0, kReturnSreg),          // 0x10 shared helper return.
+  };
+  TestCodeObject co(words);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  constexpr std::array<uint64_t, 2> kernel_entries{0, 8};
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, kernel_entries);
+  const auto index = build_block_offset_index(blocks);
+  const auto text = std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(words.data()),
+                                             words.size() * sizeof(uint32_t));
+
+  const auto first = build_kernel_cfg_scope(
+      blocks, index, KernelScopeRequest{.entry_offset = 0, .additional_entry_offsets = {}},
+      kernel_entries, text);
+  const auto second = build_kernel_cfg_scope(
+      blocks, index, KernelScopeRequest{.entry_offset = 8, .additional_entry_offsets = {}},
+      kernel_entries, text);
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(second.has_value());
+  EXPECT_EQ(first->blocks.size(), 3u);
+  EXPECT_EQ(second->blocks.size(), 3u);
+  EXPECT_TRUE(first->call_return_offsets.contains(16));
+  EXPECT_TRUE(second->call_return_offsets.contains(16));
+  ASSERT_EQ(first->liveness_edges.size(), 2u);
+  ASSERT_EQ(second->liveness_edges.size(), 2u);
+
+  BasicBlock *helper = block_for_offset(index, 16);
+  BasicBlock *first_continuation = block_for_offset(index, 4);
+  BasicBlock *second_continuation = block_for_offset(index, 12);
+  ASSERT_NE(helper, nullptr);
+  EXPECT_EQ(first->liveness_edges[1].from, helper);
+  EXPECT_EQ(first->liveness_edges[1].to, first_continuation);
+  EXPECT_EQ(second->liveness_edges[1].from, helper);
+  EXPECT_EQ(second->liveness_edges[1].to, second_continuation);
 }
 
 TEST(CfgAnalysis, KillPredecessorPreventsRecoveredConsumer) {
@@ -1244,6 +1366,20 @@ TEST(GeneratedInstDefUse, Vop3SdstEncDppPartialRowMaskReadsOnlyVgprResult) {
   EXPECT_TRUE(idu.defs.contains({RegClass::SGPR, 8, 2}));
   EXPECT_TRUE(idu.uses.contains({RegClass::VGPR, 6, 1}));
   EXPECT_FALSE(idu.uses.contains({RegClass::SGPR, 8, 2}));
+}
+
+TEST(InstDefUse, Rdna4Vop3ScalarSource) {
+  constexpr std::array<uint32_t, 2> words = {
+      0xD7001141u,
+      0x0202821Eu,
+  }; // v_add_co_u32 v65, s17, s30, v65
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> instruction(decoder->decode(words.data()));
+  ASSERT_NE(instruction, nullptr);
+
+  const InstDefUse def_use(*instruction);
+  EXPECT_TRUE(def_use.uses.contains({RegClass::SGPR, 30, 1}));
 }
 
 } // namespace


### PR DESCRIPTION
DBT and DBI clients need a common, descriptor-owned view of native code. Decoding an entire text section treats alignment padding as instructions, while a process-wide CFG cannot model a helper called by multiple kernels with context-specific returns.

Expose validated kernel and function ranges from AMDGPU symbols and metadata, let BasicBlock decode only declared code ranges, and add a shared kernel-scope analysis that stops at neighboring kernel entries while materializing call/return liveness edges. Migrate BinaryTranslator to that common analysis instead of retaining a private implementation.

Tests cover adjacent descriptors, symbol padding, alternate descriptor entries, shared-helper returns, and the RDNA4 scalar-source liveness shape used by these scopes.

ISSUE ID : #8701
