### PR TITLE
feat(rocjitsu): Add transactional DBI placement and RDNA4 encoders

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <limits>
 #include <optional>
@@ -55,13 +56,29 @@ class Instruction;
 /// @brief SOPP encoding prefix, consistent across all AMDGPU ISA generations.
 inline constexpr uint32_t kSoppEncodingPrefix = cdna4::encoding::kSopp;
 inline constexpr uint32_t kSop1EncodingPrefix = cdna4::encoding::kSop1;
+inline constexpr uint32_t kSopcEncodingPrefix = cdna4::encoding::kSopc;
 // SOP2 stores only a two-bit fixed prefix in MachineInst::encoding. Generated
 // encoding::kSop2 is instead the wider primary-decode selector (word0 >> 23),
 // so using it directly here would conflate two different representations.
 inline constexpr uint32_t kSop2EncodingPrefix = 0x2;
-inline constexpr uint32_t kSopcEncodingPrefix = 0x17E;
+inline constexpr uint32_t kSopkEncodingPrefix = 0xB;
 inline constexpr uint16_t kScalarPositiveInlineBase = 128;
 inline constexpr uint16_t kDelayAluSaluDep1 = 9;
+inline constexpr uint16_t kVectorSourceVgprBase = 256;
+inline constexpr uint16_t kVopLiteralSource = 255;
+/// Largest non-negative, dword-aligned offset in VSCRATCH's signed 24-bit
+/// immediate field.
+inline constexpr uint32_t kMaxAddressFreeScratchDwordOffset = 0x7ffffcu;
+/// Largest per-lane private segment whose last dword starts at an encodable
+/// address-free VSCRATCH offset.
+inline constexpr uint32_t kMaxAddressFreeScratchPrivateBytes = 0x800000u;
+
+/// GFX12 and GFX12.5 share the encodings used by these RDNA4-family
+/// instrumentation recipes. Generated opcode tables and decoder fixtures are
+/// the authority for each builder enabled through this predicate.
+[[nodiscard]] inline constexpr bool is_rdna4_family_arch(rj_code_arch_t arch) {
+  return arch == ROCJITSU_CODE_ARCH_RDNA4 || arch == ROCJITSU_CODE_ARCH_GFX1250;
+}
 
 /// @brief Pack a SOPP instruction word from its constituent fields.
 ///
@@ -250,9 +267,25 @@ inline constexpr uint16_t kDelayAluSaluDep1 = 9;
   }
 }
 
+/// @brief Pack a SOPK instruction word from its constituent fields.
+[[nodiscard]] inline constexpr uint32_t pack_sopk(uint32_t op, uint32_t sdst, uint16_t simm16) {
+  return (kSopkEncodingPrefix << 28) | ((op & 0x1Fu) << 23) | ((sdst & 0x7Fu) << 16) | simm16;
+}
+
+/// @brief Pack a VOP2 instruction word from its constituent fields.
+[[nodiscard]] inline constexpr uint32_t pack_vop2(uint32_t op, uint32_t vdst, uint32_t src0,
+                                                  uint32_t vsrc1) {
+  return (src0 & 0x1FFu) | ((vsrc1 & 0xFFu) << 9) | ((vdst & 0xFFu) << 17) | ((op & 0x3Fu) << 25);
+}
+
 /// @brief Scalar source operand encoding for a non-negative inline integer.
 [[nodiscard]] inline constexpr uint16_t scalar_positive_inline_u32(uint16_t value) {
   return static_cast<uint16_t>(kScalarPositiveInlineBase + value);
+}
+
+/// @brief Vector source operand encoding for a VGPR.
+[[nodiscard]] inline constexpr uint16_t vector_source_vgpr(uint16_t vgpr) {
+  return static_cast<uint16_t>(kVectorSourceVgprBase + vgpr);
 }
 
 /// @brief Compute the SOPP simm16 dword field for a branch from @p branch_pc
@@ -370,6 +403,25 @@ inline constexpr uint16_t kDelayAluSaluDep1 = 9;
   default:
     return cdna4::kSNopSopp;
   }
+}
+
+/// @brief Get the s_sleep opcode for a target ISA.
+[[nodiscard]] inline constexpr uint32_t sopp_op_sleep(rj_code_arch_t arch) {
+  // GFX9/RDNA1/RDNA2: opcode 14; GFX12-class ISA: opcode 3.
+  switch (arch) {
+  case ROCJITSU_CODE_ARCH_RDNA3:
+  case ROCJITSU_CODE_ARCH_RDNA3_5:
+  case ROCJITSU_CODE_ARCH_RDNA4:
+  case ROCJITSU_CODE_ARCH_GFX1250:
+    return 3;
+  default:
+    return 14;
+  }
+}
+
+/// @brief Get the s_sleep_var opcode for a target ISA.
+[[nodiscard]] inline constexpr uint32_t sop1_op_sleep_var([[maybe_unused]] rj_code_arch_t arch) {
+  return 0x58;
 }
 
 /// @brief Get the s_lshl_b32 opcode for a target ISA.
@@ -581,6 +633,86 @@ inline constexpr uint16_t kDelayAluSaluDep1 = 9;
     return gfx1250::kSCmpLgU32Sopc;
   default:
     return cdna4::kSCmpLgU32Sopc;
+  }
+}
+
+/// @brief Get the VOP2 v_lshrrev_b32 opcode for a target ISA.
+[[nodiscard]] inline constexpr std::optional<uint32_t> vop2_op_lshrrev_b32(rj_code_arch_t arch) {
+  switch (arch) {
+  case ROCJITSU_CODE_ARCH_CDNA1:
+  case ROCJITSU_CODE_ARCH_CDNA2:
+  case ROCJITSU_CODE_ARCH_CDNA3:
+  case ROCJITSU_CODE_ARCH_CDNA4:
+    return 16;
+  case ROCJITSU_CODE_ARCH_RDNA1:
+  case ROCJITSU_CODE_ARCH_RDNA2:
+    return 22;
+  case ROCJITSU_CODE_ARCH_RDNA3:
+  case ROCJITSU_CODE_ARCH_RDNA3_5:
+  case ROCJITSU_CODE_ARCH_RDNA4:
+  case ROCJITSU_CODE_ARCH_GFX1250:
+    return 25;
+  case ROCJITSU_CODE_ARCH_RV32I:
+  case ROCJITSU_CODE_ARCH_RV64I:
+  case ROCJITSU_CODE_ARCH_NUM_ARCHS:
+    return std::nullopt;
+  }
+  return std::nullopt;
+}
+
+/// @brief Get the VOP2 v_lshlrev_b32 opcode for a target ISA.
+[[nodiscard]] inline constexpr std::optional<uint32_t> vop2_op_lshlrev_b32(rj_code_arch_t arch) {
+  switch (arch) {
+  case ROCJITSU_CODE_ARCH_RDNA4:
+  case ROCJITSU_CODE_ARCH_GFX1250:
+    return 24;
+  default:
+    return std::nullopt;
+  }
+}
+
+/// @brief Get the VOP2 v_add_nc_u32 opcode for a target ISA.
+[[nodiscard]] inline constexpr std::optional<uint32_t> vop2_op_add_nc_u32(rj_code_arch_t arch) {
+  switch (arch) {
+  case ROCJITSU_CODE_ARCH_RDNA4:
+  case ROCJITSU_CODE_ARCH_GFX1250:
+    return 37;
+  default:
+    return std::nullopt;
+  }
+}
+
+/// @brief Get the VOP2 v_min_u32 opcode for a target ISA.
+[[nodiscard]] inline constexpr std::optional<uint32_t> vop2_op_min_u32(rj_code_arch_t arch) {
+  switch (arch) {
+  case ROCJITSU_CODE_ARCH_RDNA4:
+    return rdna4::kVMinU32Vop2;
+  case ROCJITSU_CODE_ARCH_GFX1250:
+    return gfx1250::kVMinU32Vop2;
+  default:
+    return std::nullopt;
+  }
+}
+
+/// @brief Get the VOP2 v_and_b32 opcode for a target ISA.
+[[nodiscard]] inline constexpr std::optional<uint32_t> vop2_op_and_b32(rj_code_arch_t arch) {
+  switch (arch) {
+  case ROCJITSU_CODE_ARCH_RDNA4:
+  case ROCJITSU_CODE_ARCH_GFX1250:
+    return 27;
+  default:
+    return std::nullopt;
+  }
+}
+
+/// @brief Get the VOP2 v_xor_b32 opcode for a target ISA.
+[[nodiscard]] inline constexpr std::optional<uint32_t> vop2_op_xor_b32(rj_code_arch_t arch) {
+  switch (arch) {
+  case ROCJITSU_CODE_ARCH_RDNA4:
+  case ROCJITSU_CODE_ARCH_GFX1250:
+    return 29;
+  default:
+    return std::nullopt;
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -451,7 +451,6 @@ Instrumentor::ResolvedPoints Instrumentor::resolve_points() {
       out.errors.push_back(std::move(perr));
       continue;
     }
-
     if (clause_blocked_offsets_.contains(pt.anchor_offset)) {
       out.errors.emplace_back("anchor is inside an s_clause run, anchor_offset = " +
                               std::to_string(pt.anchor_offset));
@@ -692,6 +691,8 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
     patch.anchor_offset = a.site->anchor_offset;
     patch.original_size = a.site->original_size;
     patch.trampoline_offset = a.trampoline_offset;
+    patch.trampoline_size =
+        static_cast<uint32_t>(a.bytes.trampoline_words.size() * sizeof(uint32_t));
     patch.return_target = a.site->anchor_offset + a.site->original_size;
     patch.original_bytes = a.site->original_bytes;
     patch.patched_anchor_bytes = a.bytes.patched_anchor_bytes;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
@@ -127,6 +127,7 @@ struct InstrumentationPatch {
   uint64_t anchor_offset;
   uint32_t original_size;
   uint64_t trampoline_offset; // .text-relative.
+  uint32_t trampoline_size;
   uint64_t return_target;
   std::vector<uint8_t> original_bytes;
   std::vector<uint8_t> patched_anchor_bytes;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/rdna4_instrumentation_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/rdna4_instrumentation_builder.h
@@ -1,0 +1,704 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file rdna4_instrumentation_builder.h
+/// @brief RDNA4-family instruction encoders used by DBI instrumentation.
+
+#pragma once
+
+#include "rocjitsu/code/patch/instruction_builder.h"
+
+namespace rocjitsu {
+
+/// @brief Encode an s_sleep instruction for the given target ISA.
+///
+/// @param delay  ISA-defined sleep delay immediate.
+/// @param arch   Target ISA architecture.
+/// @returns The encoded 32-bit instruction word.
+[[nodiscard]] inline constexpr uint32_t
+build_s_sleep(uint16_t delay, rj_code_arch_t arch = ROCJITSU_CODE_ARCH_RDNA4) {
+  return pack_sopp(sopp_op_sleep(arch), delay);
+}
+
+/// @brief Encode an s_sleep_var instruction for the given target ISA.
+///
+/// @param ssrc0  Scalar source operand encoding that supplies the delay.
+/// @param arch   Target ISA architecture.
+/// @returns The encoded 32-bit instruction word.
+[[nodiscard]] inline constexpr uint32_t
+build_s_sleep_var(uint16_t ssrc0, rj_code_arch_t arch = ROCJITSU_CODE_ARCH_RDNA4) {
+  return pack_sop1(sop1_op_sleep_var(arch), 0, ssrc0);
+}
+
+/// @brief Build the SOPK hwreg immediate used by s_getreg/s_setreg instructions.
+[[nodiscard]] inline constexpr std::optional<uint16_t>
+build_hwreg_imm(uint16_t reg_id, uint16_t offset, uint16_t size_bits) {
+  if (reg_id > 63 || offset > 31 || size_bits == 0 || size_bits > 32)
+    return std::nullopt;
+  return static_cast<uint16_t>(reg_id | (offset << 6u) | ((size_bits - 1u) << 11u));
+}
+
+/// @brief Encode RDNA4-class `s_getreg_b32 sdst, hwreg`.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_s_getreg_b32(uint16_t sdst, uint16_t hwreg, rj_code_arch_t arch) {
+  if ((arch != ROCJITSU_CODE_ARCH_RDNA4 && arch != ROCJITSU_CODE_ARCH_GFX1250) || sdst > 127)
+    return std::nullopt;
+  return pack_sopk(/*op=*/17, sdst, hwreg);
+}
+
+/// @brief Encode v_mov_b32_e32 for the given target ISA.
+///
+/// @param vdst  Destination VGPR.
+/// @param src0  VOP1 source operand encoding.
+/// @param arch  Target ISA architecture.
+/// @returns The encoded 32-bit instruction word.
+[[nodiscard]] inline constexpr uint32_t build_v_mov_b32_e32(uint16_t vdst, uint16_t src0,
+                                                            [[maybe_unused]] rj_code_arch_t arch) {
+  return (0x3Fu << 25) | (static_cast<uint32_t>(vdst) << 17) | (1u << 9) | (src0 & 0x1FFu);
+}
+
+/// @brief Encode VOP2 `v_lshrrev_b32 vdst, src0, vsrc1`.
+///
+/// @details The operation is `vdst = vsrc1 >> src0`. @p src0 is a VOP source
+/// operand encoding, so inline constants such as `scalar_positive_inline_u32(2)`
+/// are allowed. @p vsrc1 is a VGPR number.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_v_lshrrev_b32_e32(uint16_t vdst, uint16_t src0, uint16_t vsrc1, rj_code_arch_t arch) {
+  if (vdst > 255 || src0 > 511 || vsrc1 > 255)
+    return std::nullopt;
+  const std::optional<uint32_t> op = vop2_op_lshrrev_b32(arch);
+  if (!op)
+    return std::nullopt;
+  return pack_vop2(*op, vdst, src0, vsrc1);
+}
+
+/// @brief Encode VOP2 `v_lshlrev_b32 vdst, src0, vsrc1`.
+///
+/// @details The operation is `vdst = vsrc1 << src0`. @p src0 is a VOP source
+/// operand encoding, so inline constants such as `scalar_positive_inline_u32(16)`
+/// are allowed. @p vsrc1 is a VGPR number.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_v_lshlrev_b32_e32(uint16_t vdst, uint16_t src0, uint16_t vsrc1, rj_code_arch_t arch) {
+  if (vdst > 255 || src0 > 511 || vsrc1 > 255)
+    return std::nullopt;
+  const std::optional<uint32_t> op = vop2_op_lshlrev_b32(arch);
+  if (!op)
+    return std::nullopt;
+  return pack_vop2(*op, vdst, src0, vsrc1);
+}
+
+/// @brief Encode VOP2 `v_add_nc_u32 vdst, src0, vsrc1`.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_v_add_nc_u32_e32(uint16_t vdst, uint16_t src0, uint16_t vsrc1, rj_code_arch_t arch) {
+  if (vdst > 255 || src0 > 511 || vsrc1 > 255)
+    return std::nullopt;
+  const std::optional<uint32_t> op = vop2_op_add_nc_u32(arch);
+  if (!op)
+    return std::nullopt;
+  return pack_vop2(*op, vdst, src0, vsrc1);
+}
+
+/// @brief Encode VOP2 `v_add_nc_u32 vdst, literal, vsrc1`.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 2>>
+build_v_add_nc_u32_e32_literal(uint16_t vdst, uint32_t literal, uint16_t vsrc1,
+                               rj_code_arch_t arch) {
+  if (vdst > 255 || vsrc1 > 255)
+    return std::nullopt;
+  const std::optional<uint32_t> op = vop2_op_add_nc_u32(arch);
+  if (!op)
+    return std::nullopt;
+  return std::array<uint32_t, 2>{pack_vop2(*op, vdst, kVopLiteralSource, vsrc1), literal};
+}
+
+/// @brief Encode RDNA4 `ds_store_b32 vaddr, vdata offset:byte_offset`.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 2>>
+build_ds_store_b32(uint16_t vaddr, uint16_t vdata, uint8_t byte_offset, rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || vaddr > 255 || vdata > 255)
+    return std::nullopt;
+  return std::array<uint32_t, 2>{0xD8340000u | byte_offset,
+                                 static_cast<uint32_t>(vaddr) |
+                                     (static_cast<uint32_t>(vdata) << 8u)};
+}
+
+/// @brief Encode RDNA4 `ds_storexchg_rtn_b64 vdst, vaddr, vdata`.
+///
+/// @details The data and destination operands each name the first register of
+/// a consecutive VGPR pair. The returned pair contains the prior 64-bit LDS
+/// value after the caller waits for DSCNT.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 2>>
+build_ds_storexchg_rtn_b64(uint16_t vdst, uint16_t vaddr, uint16_t vdata, uint8_t byte_offset,
+                           rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || vdst > 254 || vaddr > 255 || vdata > 254)
+    return std::nullopt;
+  return std::array<uint32_t, 2>{
+      0xD9B40000u | byte_offset,
+      static_cast<uint32_t>(vaddr) | (static_cast<uint32_t>(vdata) << 8u) |
+          (static_cast<uint32_t>(vdata + 1u) << 16u) | (static_cast<uint32_t>(vdst) << 24u)};
+}
+
+/// @brief Encode VOP2 `v_min_u32 vdst, literal, vsrc1`.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 2>>
+build_v_min_u32_e32_literal(uint16_t vdst, uint32_t literal, uint16_t vsrc1, rj_code_arch_t arch) {
+  if (vdst > 255 || vsrc1 > 255)
+    return std::nullopt;
+  const std::optional<uint32_t> op = vop2_op_min_u32(arch);
+  if (!op)
+    return std::nullopt;
+  return std::array<uint32_t, 2>{pack_vop2(*op, vdst, kVopLiteralSource, vsrc1), literal};
+}
+
+/// @brief Encode VOP2 `v_and_b32 vdst, src0, vsrc1`.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_v_and_b32_e32(uint16_t vdst, uint16_t src0, uint16_t vsrc1, rj_code_arch_t arch) {
+  if (vdst > 255 || src0 > 511 || vsrc1 > 255)
+    return std::nullopt;
+  const std::optional<uint32_t> op = vop2_op_and_b32(arch);
+  if (!op)
+    return std::nullopt;
+  return pack_vop2(*op, vdst, src0, vsrc1);
+}
+
+/// @brief Encode VOP2 `v_and_b32 vdst, literal, vsrc1`.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 2>>
+build_v_and_b32_e32_literal(uint16_t vdst, uint32_t literal, uint16_t vsrc1, rj_code_arch_t arch) {
+  if (vdst > 255 || vsrc1 > 255)
+    return std::nullopt;
+  const std::optional<uint32_t> op = vop2_op_and_b32(arch);
+  if (!op)
+    return std::nullopt;
+  return std::array<uint32_t, 2>{pack_vop2(*op, vdst, kVopLiteralSource, vsrc1), literal};
+}
+
+/// @brief Encode RDNA4 VOP3 `v_mul_lo_u32 vdst, literal, vsrc1`.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 3>>
+build_v_mul_lo_u32_vop3_literal(uint16_t vdst, uint32_t literal, uint16_t vsrc1,
+                                rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || vdst > 255 || vsrc1 > 255)
+    return std::nullopt;
+  return std::array<uint32_t, 3>{0xD72C0000u | vdst,
+                                 0x02000000u | kVopLiteralSource |
+                                     (static_cast<uint32_t>(vector_source_vgpr(vsrc1)) << 9u),
+                                 literal};
+}
+
+/// @brief Encode VOP2 `v_xor_b32 vdst, src0, vsrc1`.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_v_xor_b32_e32(uint16_t vdst, uint16_t src0, uint16_t vsrc1, rj_code_arch_t arch) {
+  if (vdst > 255 || src0 > 511 || vsrc1 > 255)
+    return std::nullopt;
+  const std::optional<uint32_t> op = vop2_op_xor_b32(arch);
+  if (!op)
+    return std::nullopt;
+  return pack_vop2(*op, vdst, src0, vsrc1);
+}
+
+/// @brief Encode an RDNA4 64-bit VGPR add of a zero-extended VGPR offset.
+/// @details Produces `v_add_co_u32`/`v_add_co_ci_u32` and the required gfx12
+/// ALU dependency wait. VCC is clobbered and must be saved by the caller.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 5>>
+build_v_add_u64_vgpr_offset(uint16_t address_vgpr, uint16_t offset_vgpr, rj_code_arch_t arch) {
+  if (arch != ROCJITSU_CODE_ARCH_RDNA4 || address_vgpr >= 255 || offset_vgpr > 255)
+    return std::nullopt;
+  constexpr uint16_t kVccLo = 106;
+  const auto pack_vop3 = [](uint16_t op, uint8_t vdst, uint16_t src0, uint16_t src1, uint16_t src2,
+                            uint16_t sdst) {
+    const uint32_t w0 =
+        (vdst & 0xffu) | ((sdst & 0x7fu) << 8u) | ((op & 0x3ffu) << 16u) | (0x35u << 26u);
+    const uint32_t w1 = (src0 & 0x1ffu) | ((src1 & 0x1ffu) << 9u) | ((src2 & 0x1ffu) << 18u);
+    return std::array<uint32_t, 2>{w0, w1};
+  };
+  const auto low =
+      pack_vop3(rdna4::kVAddCoU32Vop3SdstEnc, static_cast<uint8_t>(address_vgpr),
+                vector_source_vgpr(offset_vgpr), vector_source_vgpr(address_vgpr), 0, kVccLo);
+  const auto high =
+      pack_vop3(rdna4::kVAddCoCiU32Vop3SdstEnc, static_cast<uint8_t>(address_vgpr + 1u),
+                scalar_positive_inline_u32(0),
+                vector_source_vgpr(static_cast<uint16_t>(address_vgpr + 1u)), kVccLo, kVccLo);
+  return std::array<uint32_t, 5>{low[0], low[1], pack_sopp(rdna4::kSWaitAlu, 0xfffdu), high[0],
+                                 high[1]};
+}
+
+/// @brief Encode an RDNA4 64-bit VGPR add of a signed 24-bit displacement.
+/// @details Produces `v_add_co_u32`/`v_add_co_ci_u32`, including the literal
+/// low dword, sign-extended high dword, and required gfx12 ALU dependency
+/// wait. VCC is clobbered and must be saved by the caller.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 6>>
+build_v_add_u64_signed_i24(uint16_t address_vgpr, int32_t displacement, rj_code_arch_t arch) {
+  constexpr int32_t kSigned24Min = -(1 << 23);
+  constexpr int32_t kSigned24Max = (1 << 23) - 1;
+  if (arch != ROCJITSU_CODE_ARCH_RDNA4 || address_vgpr >= 255 || displacement < kSigned24Min ||
+      displacement > kSigned24Max)
+    return std::nullopt;
+  constexpr uint16_t kVccLo = 106;
+  constexpr uint16_t kScalarInlineNegativeOne = 193;
+  const auto pack_vop3 = [](uint16_t op, uint8_t vdst, uint16_t src0, uint16_t src1, uint16_t src2,
+                            uint16_t sdst) {
+    const uint32_t w0 =
+        (vdst & 0xffu) | ((sdst & 0x7fu) << 8u) | ((op & 0x3ffu) << 16u) | (0x35u << 26u);
+    const uint32_t w1 = (src0 & 0x1ffu) | ((src1 & 0x1ffu) << 9u) | ((src2 & 0x1ffu) << 18u);
+    return std::array<uint32_t, 2>{w0, w1};
+  };
+  const auto low = pack_vop3(rdna4::kVAddCoU32Vop3SdstEnc, static_cast<uint8_t>(address_vgpr),
+                             kVopLiteralSource, vector_source_vgpr(address_vgpr), 0, kVccLo);
+  const uint16_t high_displacement =
+      displacement < 0 ? kScalarInlineNegativeOne : scalar_positive_inline_u32(0);
+  const auto high = pack_vop3(
+      rdna4::kVAddCoCiU32Vop3SdstEnc, static_cast<uint8_t>(address_vgpr + 1u), high_displacement,
+      vector_source_vgpr(static_cast<uint16_t>(address_vgpr + 1u)), kVccLo, kVccLo);
+  return std::array<uint32_t, 6>{
+      low[0],  low[1], static_cast<uint32_t>(displacement), pack_sopp(rdna4::kSWaitAlu, 0xfffdu),
+      high[0], high[1]};
+}
+
+/// @brief Encode RDNA4 `v_readfirstlane_b32 sdst, vsrc`.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_v_readfirstlane_b32(uint16_t sdst, uint16_t vsrc, rj_code_arch_t arch) {
+  if (arch != ROCJITSU_CODE_ARCH_RDNA4 || sdst > 127 || vsrc > 255)
+    return std::nullopt;
+  return (0x3Fu << 25) | (static_cast<uint32_t>(sdst) << 17) | (2u << 9) | vector_source_vgpr(vsrc);
+}
+
+/// @brief Encode RDNA4 `v_mbcnt_lo_u32_b32 vdst, src0, src1`.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 2>>
+build_v_mbcnt_lo_u32_b32(uint16_t vdst, uint16_t src0, uint16_t src1, rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || vdst > 255 || src0 > 511 || src1 > 511)
+    return std::nullopt;
+  return std::array<uint32_t, 2>{0xD71F0000u | static_cast<uint32_t>(vdst),
+                                 0x02000000u | (static_cast<uint32_t>(src1) << 9u) | src0};
+}
+
+/// @brief Encode RDNA4 `v_mbcnt_hi_u32_b32 vdst, src0, src1`.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 2>>
+build_v_mbcnt_hi_u32_b32(uint16_t vdst, uint16_t src0, uint16_t src1, rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || vdst > 255 || src0 > 511 || src1 > 511)
+    return std::nullopt;
+  return std::array<uint32_t, 2>{0xD7200000u | static_cast<uint32_t>(vdst),
+                                 0x02000000u | (static_cast<uint32_t>(src1) << 9u) | src0};
+}
+
+/// @brief Encode RDNA4 `v_cmp_eq_u32_e32 vcc_lo, src0, vsrc1`.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_v_cmp_eq_u32_e32_vcc(uint16_t src0, uint16_t vsrc1, rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || src0 > 511 || vsrc1 > 255)
+    return std::nullopt;
+  return 0x7C940000u | (static_cast<uint32_t>(vsrc1) << 9u) | src0;
+}
+
+/// @brief Encode RDNA4 `v_cmp_ne_u32_e32 vcc_lo, src0, vsrc1`.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_v_cmp_ne_u32_e32_vcc(uint16_t src0, uint16_t vsrc1, rj_code_arch_t arch) {
+  if (arch != ROCJITSU_CODE_ARCH_RDNA4 || src0 > 511 || vsrc1 > 255)
+    return std::nullopt;
+  return 0x7C9A0000u | (static_cast<uint32_t>(vsrc1) << 9u) | src0;
+}
+
+/// @brief Encode RDNA4 `v_cmp_gt_u32_e32 vcc_lo, src0, vsrc1`.
+///
+/// Useful as `src0=capacity, vsrc1=slot`, which tests `slot < capacity` while
+/// keeping the immediate-like operand in the source position this encoding
+/// accepts.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_v_cmp_gt_u32_e32_vcc(uint16_t src0, uint16_t vsrc1, rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || src0 > 511 || vsrc1 > 255)
+    return std::nullopt;
+  return 0x7C980000u | (static_cast<uint32_t>(vsrc1) << 9u) | src0;
+}
+
+/// @brief Encode RDNA4 `v_mov_b32` in VOP3 form with a literal source.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 3>>
+build_v_mov_b32_e64_literal(uint16_t vdst, uint32_t literal, rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || vdst > 255)
+    return std::nullopt;
+  return std::array<uint32_t, 3>{0xD5810000u | static_cast<uint32_t>(vdst), 0x000000FFu, literal};
+}
+
+/// @brief Encode RDNA4 `flat_store_b32 v[vaddr:vaddr+1], vsrc`.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 3>>
+build_flat_store_b32_vaddr_vsrc(uint16_t vaddr, uint16_t vsrc, rj_code_arch_t arch,
+                                uint32_t byte_offset = 0) {
+  if (!is_rdna4_family_arch(arch) || vaddr > 255 || vsrc > 255 || byte_offset > 0xffffffu)
+    return std::nullopt;
+  constexpr uint32_t kRdna4FlatNoSaddr = 0x7C;
+  return std::array<uint32_t, 3>{0xEC068000u | kRdna4FlatNoSaddr,
+                                 static_cast<uint32_t>(vsrc) << 23u,
+                                 static_cast<uint32_t>(vaddr) | (byte_offset << 8u)};
+}
+
+/// @brief Encode RDNA4 `flat_load_b32 vdst, v[vaddr:vaddr+1]`.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 3>>
+build_flat_load_b32_vaddr_vdst(uint16_t vaddr, uint16_t vdst, rj_code_arch_t arch,
+                               uint32_t byte_offset = 0) {
+  if (arch != ROCJITSU_CODE_ARCH_RDNA4 || vaddr > 255 || vdst > 255 || byte_offset > 0xffffffu)
+    return std::nullopt;
+  constexpr uint32_t kRdna4FlatNoSaddr = 0x7C;
+  return std::array<uint32_t, 3>{0xEC050000u | kRdna4FlatNoSaddr, static_cast<uint32_t>(vdst),
+                                 static_cast<uint32_t>(vaddr) | (byte_offset << 8u)};
+}
+
+/// @brief Encode gfx12 `scratch_store_b32 off, vsrc, off offset:byte_offset`.
+///
+/// @details The address-free form uses only the implicit per-lane scratch base
+/// and the positive signed-24-bit immediate. DBI spill slots are dword
+/// aligned, so unaligned offsets are rejected even though the ISA field itself
+/// is byte-addressed.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 3>>
+build_address_free_scratch_store_b32(uint16_t vsrc, uint32_t byte_offset, rj_code_arch_t arch) {
+  if (arch != ROCJITSU_CODE_ARCH_RDNA4 || vsrc > 255 ||
+      byte_offset > kMaxAddressFreeScratchDwordOffset || byte_offset % sizeof(uint32_t) != 0) {
+    return std::nullopt;
+  }
+  constexpr uint32_t kRdna4ScratchNoSaddr = 0x7c;
+  return std::array<uint32_t, 3>{0xed068000u | kRdna4ScratchNoSaddr,
+                                 static_cast<uint32_t>(vsrc) << 23u, byte_offset << 8u};
+}
+
+/// @brief Encode gfx12 `scratch_load_b32 vdst, off, off offset:byte_offset`.
+/// @copydetails build_address_free_scratch_store_b32
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 3>>
+build_address_free_scratch_load_b32(uint16_t vdst, uint32_t byte_offset, rj_code_arch_t arch) {
+  if (arch != ROCJITSU_CODE_ARCH_RDNA4 || vdst > 255 ||
+      byte_offset > kMaxAddressFreeScratchDwordOffset || byte_offset % sizeof(uint32_t) != 0) {
+    return std::nullopt;
+  }
+  constexpr uint32_t kRdna4ScratchNoSaddr = 0x7c;
+  return std::array<uint32_t, 3>{0xed050000u | kRdna4ScratchNoSaddr, static_cast<uint32_t>(vdst),
+                                 byte_offset << 8u};
+}
+
+/// @brief Encode gfx12 `scratch_store_b32 off, vsrc, saddr offset:byte_offset`.
+///
+/// @details The explicit scalar offset form is used for a dynamic-stack frame
+/// whose base is held in @p saddr. Unlike the address-free fixed-segment form,
+/// offsets are relative to the frame selected by the caller.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 3>>
+build_scratch_store_b32_saddr(uint16_t vsrc, uint16_t saddr, uint32_t byte_offset,
+                              rj_code_arch_t arch) {
+  if (arch != ROCJITSU_CODE_ARCH_RDNA4 || vsrc > 255 || saddr > 127 ||
+      byte_offset > kMaxAddressFreeScratchDwordOffset || byte_offset % sizeof(uint32_t) != 0) {
+    return std::nullopt;
+  }
+  return std::array<uint32_t, 3>{0xed068000u | saddr, static_cast<uint32_t>(vsrc) << 23u,
+                                 byte_offset << 8u};
+}
+
+/// @brief Encode gfx12 `scratch_load_b32 vdst, off, saddr offset:byte_offset`.
+/// @copydetails build_scratch_store_b32_saddr
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 3>>
+build_scratch_load_b32_saddr(uint16_t vdst, uint16_t saddr, uint32_t byte_offset,
+                             rj_code_arch_t arch) {
+  if (arch != ROCJITSU_CODE_ARCH_RDNA4 || vdst > 255 || saddr > 127 ||
+      byte_offset > kMaxAddressFreeScratchDwordOffset || byte_offset % sizeof(uint32_t) != 0) {
+    return std::nullopt;
+  }
+  return std::array<uint32_t, 3>{0xed050000u | saddr, static_cast<uint32_t>(vdst),
+                                 byte_offset << 8u};
+}
+
+/// @brief Encode gfx12 `s_wait_storecnt 0`.
+[[nodiscard]] inline constexpr std::optional<uint32_t> build_s_wait_storecnt0(rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch))
+    return std::nullopt;
+  return pack_sopp(rdna4::kSWaitStorecntSopp, 0);
+}
+
+/// @brief Encode gfx12 `s_wait_storecnt_dscnt 0`.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_s_wait_storecnt_dscnt0(rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch))
+    return std::nullopt;
+  return pack_sopp(rdna4::kSWaitStorecntDscntSopp, 0);
+}
+
+/// @brief Encode gfx12 `s_wait_loadcnt_dscnt 0`.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_s_wait_loadcnt_dscnt0(rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch))
+    return std::nullopt;
+  return pack_sopp(rdna4::kSWaitLoadcntDscntSopp, 0);
+}
+
+/// @brief Encode gfx12 `s_wait_loadcnt 0`.
+[[nodiscard]] inline constexpr std::optional<uint32_t> build_s_wait_loadcnt0(rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch))
+    return std::nullopt;
+  return pack_sopp(rdna4::kSWaitLoadcntSopp, 0);
+}
+
+/// @brief Encode gfx12 `s_wait_alu depctr_sa_sdst(0)`.
+///
+/// This is the conservative scalar dependency drain emitted by LLVM before an
+/// indirect branch consumes an SGPR pair that was just constructed by SALU
+/// instructions. A one-cycle `s_delay_alu` is not sufficient for a chained
+/// low/high PC calculation.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_s_wait_alu_sa_sdst0(rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch))
+    return std::nullopt;
+  return pack_sopp(rdna4::kSWaitAlu, 0xff9eu);
+}
+
+/// @brief Encode RDNA4 `flat_atomic_add_u32 vdst, v[vaddr:vaddr+1], vsrc`.
+///
+/// @details Uses the no-SADDR flat form. `return_old_value=true` encodes the
+/// GFX12 atomic-return TH value so the old memory value is written to @p vdst.
+/// @p scope is the two-bit RDNA4 SCOPE field; device scope is 2.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 3>>
+build_flat_atomic_add_u32_vaddr_vsrc_vdst(uint16_t vaddr, uint16_t vsrc, uint16_t vdst,
+                                          bool return_old_value, uint8_t scope,
+                                          rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || vaddr > 255 || vsrc > 255 || vdst > 255 || scope > 3)
+    return std::nullopt;
+  constexpr uint32_t kRdna4FlatNoSaddr = 0x7C;
+  constexpr uint32_t kRdna4AtomicReturnTh = 1;
+  const uint32_t th = return_old_value ? kRdna4AtomicReturnTh : 0u;
+  return std::array<uint32_t, 3>{0xEC0D4000u | kRdna4FlatNoSaddr,
+                                 static_cast<uint32_t>(vdst) |
+                                     (static_cast<uint32_t>(scope) << 18u) | (th << 20u) |
+                                     (static_cast<uint32_t>(vsrc) << 23u),
+                                 static_cast<uint32_t>(vaddr)};
+}
+
+/// @brief Encode RDNA4 `flat_atomic_or_b32 vdst, v[vaddr:vaddr+1], vsrc`.
+///
+/// @details Uses the no-SADDR flat form. `return_old_value=true` encodes the
+/// GFX12 atomic-return TH value so the old memory value is written to @p vdst.
+/// @p scope is the two-bit RDNA4 SCOPE field; device scope is 2.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 3>>
+build_flat_atomic_or_u32_vaddr_vsrc_vdst(uint16_t vaddr, uint16_t vsrc, uint16_t vdst,
+                                         bool return_old_value, uint8_t scope,
+                                         rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || vaddr > 255 || vsrc > 255 || vdst > 255 || scope > 3)
+    return std::nullopt;
+  constexpr uint32_t kRdna4FlatNoSaddr = 0x7C;
+  constexpr uint32_t kRdna4AtomicReturnTh = 1;
+  const uint32_t th = return_old_value ? kRdna4AtomicReturnTh : 0u;
+  return std::array<uint32_t, 3>{0xEC0F4000u | kRdna4FlatNoSaddr,
+                                 static_cast<uint32_t>(vdst) |
+                                     (static_cast<uint32_t>(scope) << 18u) | (th << 20u) |
+                                     (static_cast<uint32_t>(vsrc) << 23u),
+                                 static_cast<uint32_t>(vaddr)};
+}
+
+/// @brief Encode RDNA4 `flat_atomic_cmpswap_b32 vdst, v[vaddr:vaddr+1],
+///        v[vsrc:vsrc+1]` with `vsrc=new_value` and `vsrc+1=compare_value`.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 3>>
+build_flat_atomic_cmpswap_b32_vaddr_vsrc_vdst(uint16_t vaddr, uint16_t vsrc, uint16_t vdst,
+                                              bool return_old_value, uint8_t scope,
+                                              rj_code_arch_t arch) {
+  if (arch != ROCJITSU_CODE_ARCH_RDNA4 || vaddr > 254 || vsrc > 254 || vdst > 255 || scope > 3)
+    return std::nullopt;
+  constexpr uint32_t kRdna4FlatNoSaddr = 0x7C;
+  constexpr uint32_t kRdna4AtomicReturnTh = 1;
+  const uint32_t th = return_old_value ? kRdna4AtomicReturnTh : 0u;
+  return std::array<uint32_t, 3>{0xEC0D0000u | kRdna4FlatNoSaddr,
+                                 static_cast<uint32_t>(vdst) |
+                                     (static_cast<uint32_t>(scope) << 18u) | (th << 20u) |
+                                     (static_cast<uint32_t>(vsrc) << 23u),
+                                 static_cast<uint32_t>(vaddr)};
+}
+
+/// @brief Encode RDNA4 `flat_atomic_swap_b64 v[vdst:vdst+1], v[vaddr:vaddr+1],
+///        v[vsrc:vsrc+1]`.
+///
+/// @details Uses the no-SADDR flat form. `return_old_value=true` encodes the
+/// GFX12 atomic-return TH value so the old 64-bit memory value is written to
+/// @p vdst/@p vdst+1. @p scope is the two-bit RDNA4 SCOPE field; device scope
+/// is 2.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 3>>
+build_flat_atomic_swap_b64_vaddr_vsrc_vdst(uint16_t vaddr, uint16_t vsrc, uint16_t vdst,
+                                           bool return_old_value, uint8_t scope,
+                                           rj_code_arch_t arch) {
+  if (arch != ROCJITSU_CODE_ARCH_RDNA4 || vaddr > 254 || vsrc > 254 || vdst > 254 || scope > 3)
+    return std::nullopt;
+  constexpr uint32_t kRdna4FlatNoSaddr = 0x7C;
+  constexpr uint32_t kRdna4AtomicReturnTh = 1;
+  const uint32_t th = return_old_value ? kRdna4AtomicReturnTh : 0u;
+  return std::array<uint32_t, 3>{0xEC104000u | kRdna4FlatNoSaddr,
+                                 static_cast<uint32_t>(vdst) |
+                                     (static_cast<uint32_t>(scope) << 18u) | (th << 20u) |
+                                     (static_cast<uint32_t>(vsrc) << 23u),
+                                 static_cast<uint32_t>(vaddr)};
+}
+
+/// @brief Encode RDNA4 `flat_atomic_add_u64 v[vdst:vdst+1],
+///        v[vaddr:vaddr+1], v[vsrc:vsrc+1]`.
+///
+/// @details A zero source with `return_old_value=true` is an atomic 64-bit
+/// snapshot that leaves memory unchanged.
+[[nodiscard]] inline constexpr std::optional<std::array<uint32_t, 3>>
+build_flat_atomic_add_u64_vaddr_vsrc_vdst(uint16_t vaddr, uint16_t vsrc, uint16_t vdst,
+                                          bool return_old_value, uint8_t scope,
+                                          rj_code_arch_t arch) {
+  if (arch != ROCJITSU_CODE_ARCH_RDNA4 || vaddr > 254 || vsrc > 254 || vdst > 254 || scope > 3)
+    return std::nullopt;
+  constexpr uint32_t kRdna4FlatNoSaddr = 0x7C;
+  constexpr uint32_t kRdna4AtomicReturnTh = 1;
+  const uint32_t th = return_old_value ? kRdna4AtomicReturnTh : 0u;
+  return std::array<uint32_t, 3>{0xEC10C000u | kRdna4FlatNoSaddr,
+                                 static_cast<uint32_t>(vdst) |
+                                     (static_cast<uint32_t>(scope) << 18u) | (th << 20u) |
+                                     (static_cast<uint32_t>(vsrc) << 23u),
+                                 static_cast<uint32_t>(vaddr)};
+}
+
+/// @brief Encode RDNA4 `s_sub_u32 sdst, ssrc0, ssrc1`.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_s_sub_u32(uint16_t sdst, uint16_t ssrc0, uint16_t ssrc1, rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || sdst > 127 || ssrc0 > 255 || ssrc1 > 255)
+    return std::nullopt;
+  constexpr uint32_t kRdna4Sop2SubU32 = 1;
+  return pack_sop2(kRdna4Sop2SubU32, sdst, ssrc0, ssrc1);
+}
+
+/// @brief Encode RDNA4 `s_add_u32 sdst, ssrc0, ssrc1`.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_rdna4_s_add_u32(uint16_t sdst, uint16_t ssrc0, uint16_t ssrc1, rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || sdst > 127 || ssrc0 > 255 || ssrc1 > 255)
+    return std::nullopt;
+  constexpr uint32_t kRdna4Sop2AddU32 = 2;
+  return pack_sop2(kRdna4Sop2AddU32, sdst, ssrc0, ssrc1);
+}
+
+/// @brief Encode RDNA4 `s_mov_b64 s[sdst:sdst+1], s[ssrc0:ssrc0+1]`.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_s_mov_b64(uint16_t sdst, uint16_t ssrc0, rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || sdst > 126 || ssrc0 > 255)
+    return std::nullopt;
+  return pack_sop1(1, sdst, ssrc0);
+}
+
+/// @brief Encode RDNA4 `s_and_saveexec_b64 s[sdst:sdst+1], s[ssrc0:ssrc0+1]`.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_s_and_saveexec_b64(uint16_t sdst, uint16_t ssrc0, rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || sdst > 126 || ssrc0 > 255)
+    return std::nullopt;
+  return pack_sop1(0x21, sdst, ssrc0);
+}
+
+/// @brief Encode RDNA4 `s_and_not1_b64 s[sdst:sdst+1],
+/// s[ssrc0:ssrc0+1], s[ssrc1:ssrc1+1]`.
+///
+/// This is the gfx12 spelling of the older `s_andn2_b64` operation. It is
+/// useful when an instrumentation loop must remove an already-processed lane
+/// partition from a saved EXEC mask without disturbing EXEC itself.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_s_and_not1_b64(uint16_t sdst, uint16_t ssrc0, uint16_t ssrc1, rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || sdst > 126 || ssrc0 > 254 || ssrc1 > 254)
+    return std::nullopt;
+  constexpr uint32_t kRdna4Sop2AndNot1B64 = 0x23;
+  return pack_sop2(kRdna4Sop2AndNot1B64, sdst, ssrc0, ssrc1);
+}
+
+/// @brief Encode RDNA4 `s_xor_b64 s[sdst:sdst+1],
+/// s[ssrc0:ssrc0+1], s[ssrc1:ssrc1+1]`.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_s_xor_b64(uint16_t sdst, uint16_t ssrc0, uint16_t ssrc1, rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || sdst > 126 || ssrc0 > 254 || ssrc1 > 254)
+    return std::nullopt;
+  constexpr uint32_t kRdna4Sop2XorB64 = 0x1b;
+  return pack_sop2(kRdna4Sop2XorB64, sdst, ssrc0, ssrc1);
+}
+
+/// @brief Encode RDNA4 `s_cselect_b32 sdst, ssrc0, ssrc1`.
+///
+/// This is useful for materializing SCC without changing it: choose inline 1
+/// when SCC is set and inline 0 otherwise.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_rdna4_s_cselect_b32(uint16_t sdst, uint16_t ssrc0, uint16_t ssrc1, rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || sdst > 127 || ssrc0 > 255 || ssrc1 > 255)
+    return std::nullopt;
+  constexpr uint32_t kRdna4Sop2CselectB32 = 0x30;
+  return pack_sop2(kRdna4Sop2CselectB32, sdst, ssrc0, ssrc1);
+}
+
+/// @brief Encode RDNA4 `s_cmp_lg_u32 ssrc0, ssrc1`.
+///
+/// Comparing a previously materialized SCC value with inline zero restores
+/// SCC to that saved Boolean value.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_rdna4_s_cmp_lg_u32(uint16_t ssrc0, uint16_t ssrc1, rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || ssrc0 > 255 || ssrc1 > 255)
+    return std::nullopt;
+  constexpr uint32_t kRdna4SopcCmpLgU32 = 7;
+  return pack_sopc(kRdna4SopcCmpLgU32, ssrc0, ssrc1);
+}
+
+/// @brief Encode RDNA4 `s_cmp_eq_u32 ssrc0, ssrc1`.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_s_cmp_eq_u32(uint16_t ssrc0, uint16_t ssrc1, rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch) || ssrc0 > 255 || ssrc1 > 255)
+    return std::nullopt;
+  constexpr uint32_t kRdna4SopcCmpEqU32 = 6;
+  return pack_sopc(kRdna4SopcCmpEqU32, ssrc0, ssrc1);
+}
+
+/// @brief Encode RDNA4 `s_cbranch_scc0`.
+[[nodiscard]] inline constexpr std::optional<uint32_t> build_s_cbranch_scc0(int16_t offset_dwords,
+                                                                            rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch))
+    return std::nullopt;
+  constexpr uint32_t kRdna4SoppCbranchScc0 = 33;
+  return pack_sopp(kRdna4SoppCbranchScc0, static_cast<uint16_t>(offset_dwords));
+}
+
+/// @brief Encode RDNA4 `s_cbranch_scc1`.
+[[nodiscard]] inline constexpr std::optional<uint32_t> build_s_cbranch_scc1(int16_t offset_dwords,
+                                                                            rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch))
+    return std::nullopt;
+  constexpr uint32_t kRdna4SoppCbranchScc1 = 34;
+  return pack_sopp(kRdna4SoppCbranchScc1, static_cast<uint16_t>(offset_dwords));
+}
+
+/// @brief Encode RDNA4 `s_cbranch_vccz`.
+[[nodiscard]] inline constexpr std::optional<uint32_t> build_s_cbranch_vccz(int16_t offset_dwords,
+                                                                            rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch))
+    return std::nullopt;
+  constexpr uint32_t kRdna4SoppCbranchVccz = 35;
+  return pack_sopp(kRdna4SoppCbranchVccz, static_cast<uint16_t>(offset_dwords));
+}
+
+/// @brief Encode RDNA4 `s_cbranch_vccnz`.
+[[nodiscard]] inline constexpr std::optional<uint32_t> build_s_cbranch_vccnz(int16_t offset_dwords,
+                                                                             rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch))
+    return std::nullopt;
+  constexpr uint32_t kRdna4SoppCbranchVccnz = 36;
+  return pack_sopp(kRdna4SoppCbranchVccnz, static_cast<uint16_t>(offset_dwords));
+}
+
+/// @brief Encode RDNA4 `s_cbranch_execz`.
+[[nodiscard]] inline constexpr std::optional<uint32_t> build_s_cbranch_execz(int16_t offset_dwords,
+                                                                             rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch))
+    return std::nullopt;
+  constexpr uint32_t kRdna4SoppCbranchExecz = 0x25;
+  return pack_sopp(kRdna4SoppCbranchExecz, static_cast<uint16_t>(offset_dwords));
+}
+
+/// @brief Encode the RDNA4 workgroup-wide barrier signal/wait pair.
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_s_barrier_signal_all(rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch))
+    return std::nullopt;
+  return pack_sop1(/*s_barrier_signal=*/0x4e, /*sdst=*/0, /*barrier_id=-1=*/0xc1);
+}
+
+[[nodiscard]] inline constexpr std::optional<uint32_t>
+build_s_barrier_wait_all(rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch))
+    return std::nullopt;
+  return pack_sopp(/*s_barrier_wait=*/0x14, /*barrier_id=-1=*/0xffff);
+}
+
+/// @brief Encode RDNA4 `s_cbranch_execnz`.
+[[nodiscard]] inline constexpr std::optional<uint32_t> build_s_cbranch_execnz(int16_t offset_dwords,
+                                                                              rj_code_arch_t arch) {
+  if (!is_rdna4_family_arch(arch))
+    return std::nullopt;
+  constexpr uint32_t kRdna4SoppCbranchExecnz = 0x26;
+  return pack_sopp(kRdna4SoppCbranchExecnz, static_cast<uint16_t>(offset_dwords));
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
@@ -6,7 +6,11 @@
 #include "rocjitsu/code/patch/error_report.h"
 #include "rocjitsu/code/patch/instruction_builder.h"
 
+#include <algorithm>
 #include <cstring>
+#include <limits>
+#include <numeric>
+#include <queue>
 
 namespace rocjitsu {
 
@@ -267,6 +271,401 @@ std::optional<TrampolineBytes> TrampolineBuilder::emit_probe_call(const Trampoli
   emit_plan.after_items.clear();
   emit_plan.emit_original = true;
   return build(emit_plan, error_out);
+}
+
+std::optional<SoppBranchRelayPlan>
+plan_forward_sopp_branch_relays(std::span<const uint64_t> source_offsets,
+                                std::span<const uint64_t> relay_offsets,
+                                std::span<const uint64_t> island_offsets, std::string *error_out) {
+  struct Coordinate {
+    uint64_t offset = 0;
+    uint8_t kind = 0; // 0 = source, 1 = relay, 2 = island.
+    size_t input_index = 0;
+  };
+  std::vector<Coordinate> coordinates;
+  coordinates.reserve(source_offsets.size() + relay_offsets.size() + island_offsets.size());
+  const auto append_coordinates = [&](std::span<const uint64_t> offsets, uint8_t kind) {
+    for (size_t i = 0; i < offsets.size(); ++i)
+      coordinates.push_back({offsets[i], kind, i});
+  };
+  append_coordinates(source_offsets, 0);
+  append_coordinates(relay_offsets, 1);
+  append_coordinates(island_offsets, 2);
+  std::ranges::sort(coordinates, [](const Coordinate &lhs, const Coordinate &rhs) {
+    if (lhs.offset != rhs.offset)
+      return lhs.offset < rhs.offset;
+    if (lhs.kind != rhs.kind)
+      return lhs.kind < rhs.kind;
+    return lhs.input_index < rhs.input_index;
+  });
+  for (size_t i = 0; i < coordinates.size(); ++i) {
+    if (coordinates[i].offset % sizeof(uint32_t) != 0) {
+      report(error_out, "SOPP relay planner: coordinates must be dword aligned");
+      return std::nullopt;
+    }
+    if (i != 0 && coordinates[i - 1].offset == coordinates[i].offset) {
+      report(error_out, "SOPP relay planner: coordinates must be globally unique");
+      return std::nullopt;
+    }
+  }
+
+  struct Edge {
+    size_t to = 0;
+    size_t reverse = 0;
+    uint8_t capacity = 0;
+    bool original = false;
+  };
+  // A relay is split into in/out nodes so its instruction word has capacity
+  // one. Sources and islands already have capacity-one boundary edges.
+  const size_t super_source = 0;
+  const size_t source_base = 1;
+  const size_t relay_in_base = source_base + source_offsets.size();
+  const size_t relay_out_base = relay_in_base + relay_offsets.size();
+  const size_t island_base = relay_out_base + relay_offsets.size();
+  const size_t super_sink = island_base + island_offsets.size();
+  std::vector<std::vector<Edge>> graph(super_sink + 1);
+  const auto add_edge = [&](size_t from, size_t to) {
+    const size_t forward_index = graph[from].size();
+    const size_t reverse_index = graph[to].size();
+    graph[from].push_back({to, reverse_index, 1, true});
+    graph[to].push_back({from, forward_index, 0, false});
+  };
+  const auto can_hop = [](uint64_t from, uint64_t to) {
+    return to > from && compute_sopp_branch_simm16(from, to).has_value();
+  };
+
+  std::vector<size_t> source_order(source_offsets.size());
+  std::iota(source_order.begin(), source_order.end(), 0);
+  std::ranges::sort(source_order, [&](size_t lhs, size_t rhs) {
+    if (source_offsets[lhs] != source_offsets[rhs])
+      return source_offsets[lhs] < source_offsets[rhs];
+    return lhs < rhs;
+  });
+  std::vector<size_t> relay_order(relay_offsets.size());
+  std::iota(relay_order.begin(), relay_order.end(), 0);
+  std::ranges::sort(relay_order, [&](size_t lhs, size_t rhs) {
+    if (relay_offsets[lhs] != relay_offsets[rhs])
+      return relay_offsets[lhs] < relay_offsets[rhs];
+    return lhs < rhs;
+  });
+  std::vector<size_t> island_order(island_offsets.size());
+  std::iota(island_order.begin(), island_order.end(), 0);
+  std::ranges::sort(island_order, [&](size_t lhs, size_t rhs) {
+    if (island_offsets[lhs] != island_offsets[rhs])
+      return island_offsets[lhs] < island_offsets[rhs];
+    return lhs < rhs;
+  });
+
+  for (size_t source : source_order)
+    add_edge(super_source, source_base + source);
+  for (size_t relay : relay_order)
+    add_edge(relay_in_base + relay, relay_out_base + relay);
+  for (size_t island : island_order)
+    add_edge(island_base + island, super_sink);
+  for (size_t source : source_order) {
+    for (size_t relay : relay_order) {
+      if (can_hop(source_offsets[source], relay_offsets[relay]))
+        add_edge(source_base + source, relay_in_base + relay);
+    }
+    for (size_t island : island_order) {
+      if (can_hop(source_offsets[source], island_offsets[island]))
+        add_edge(source_base + source, island_base + island);
+    }
+  }
+  for (size_t relay : relay_order) {
+    for (size_t next : relay_order) {
+      if (can_hop(relay_offsets[relay], relay_offsets[next]))
+        add_edge(relay_out_base + relay, relay_in_base + next);
+    }
+    for (size_t island : island_order) {
+      if (can_hop(relay_offsets[relay], island_offsets[island]))
+        add_edge(relay_out_base + relay, island_base + island);
+    }
+  }
+
+  // Unit-capacity Edmonds-Karp is exact here and bounded by the number of
+  // sources: at most one breadth-first augmentation per admitted route.
+  for (;;) {
+    constexpr size_t kNoNode = std::numeric_limits<size_t>::max();
+    std::vector<size_t> parent_node(graph.size(), kNoNode);
+    std::vector<size_t> parent_edge(graph.size(), kNoNode);
+    std::queue<size_t> queue;
+    parent_node[super_source] = super_source;
+    queue.push(super_source);
+    while (!queue.empty() && parent_node[super_sink] == kNoNode) {
+      const size_t from = queue.front();
+      queue.pop();
+      for (size_t edge_index = 0; edge_index < graph[from].size(); ++edge_index) {
+        const Edge &edge = graph[from][edge_index];
+        if (edge.capacity == 0 || parent_node[edge.to] != kNoNode)
+          continue;
+        parent_node[edge.to] = from;
+        parent_edge[edge.to] = edge_index;
+        queue.push(edge.to);
+      }
+    }
+    if (parent_node[super_sink] == kNoNode)
+      break;
+    for (size_t node = super_sink; node != super_source; node = parent_node[node]) {
+      Edge &edge = graph[parent_node[node]][parent_edge[node]];
+      --edge.capacity;
+      ++graph[node][edge.reverse].capacity;
+    }
+  }
+
+  const auto used_original_edge_to = [&](size_t from) -> std::optional<size_t> {
+    for (const Edge &edge : graph[from]) {
+      if (edge.original && edge.capacity == 0)
+        return edge.to;
+    }
+    return std::nullopt;
+  };
+  SoppBranchRelayPlan plan;
+  {
+    std::vector<bool> reachable(graph.size(), false);
+    std::queue<size_t> queue;
+    reachable[super_source] = true;
+    queue.push(super_source);
+    while (!queue.empty()) {
+      const size_t from = queue.front();
+      queue.pop();
+      for (const Edge &edge : graph[from]) {
+        if (edge.capacity == 0 || reachable[edge.to])
+          continue;
+        reachable[edge.to] = true;
+        queue.push(edge.to);
+      }
+    }
+    const auto node_offset = [&](size_t node) -> std::optional<uint64_t> {
+      if (node >= source_base && node < relay_in_base)
+        return source_offsets[node - source_base];
+      if (node >= relay_in_base && node < relay_out_base)
+        return relay_offsets[node - relay_in_base];
+      if (node >= relay_out_base && node < island_base)
+        return relay_offsets[node - relay_out_base];
+      if (node >= island_base && node < super_sink)
+        return island_offsets[node - island_base];
+      return std::nullopt;
+    };
+    for (size_t relay = 0; relay < relay_offsets.size(); ++relay) {
+      if (reachable[relay_in_base + relay] && !reachable[relay_out_base + relay])
+        plan.min_cut_relay_offsets.push_back(relay_offsets[relay]);
+    }
+    std::ranges::sort(plan.min_cut_relay_offsets);
+    for (size_t from = 0; from < graph.size(); ++from) {
+      if (!reachable[from])
+        continue;
+      for (const Edge &edge : graph[from]) {
+        if (!edge.original || edge.capacity != 0 || reachable[edge.to])
+          continue;
+        const auto from_offset = node_offset(from);
+        const auto to_offset = node_offset(edge.to);
+        if (from_offset && to_offset && *from_offset != *to_offset)
+          plan.min_cut_hops.emplace_back(*from_offset, *to_offset);
+      }
+    }
+    std::ranges::sort(plan.min_cut_hops);
+    plan.min_cut_hops.erase(std::ranges::unique(plan.min_cut_hops).begin(),
+                            plan.min_cut_hops.end());
+  }
+  plan.routes.reserve(std::min(source_offsets.size(), island_offsets.size()));
+  for (size_t source_index = 0; source_index < source_offsets.size(); ++source_index) {
+    bool admitted = false;
+    for (const Edge &edge : graph[super_source]) {
+      if (edge.to != source_base + source_index || edge.capacity != 0)
+        continue;
+      SoppBranchRelayRoute route;
+      route.source_index = source_index;
+      size_t node = source_base + source_index;
+      for (;;) {
+        const auto next = used_original_edge_to(node);
+        if (!next) {
+          report(error_out, "SOPP relay planner: internal flow decomposition failure");
+          return std::nullopt;
+        }
+        node = *next;
+        if (node >= relay_in_base && node < relay_out_base) {
+          const size_t relay = node - relay_in_base;
+          route.relay_offsets.push_back(relay_offsets[relay]);
+          node = relay_out_base + relay;
+          continue;
+        }
+        if (node >= island_base && node < super_sink) {
+          route.island_offset = island_offsets[node - island_base];
+          break;
+        }
+        report(error_out, "SOPP relay planner: internal flow path has an invalid node");
+        return std::nullopt;
+      }
+      plan.routes.push_back(std::move(route));
+      admitted = true;
+      break;
+    }
+    if (!admitted)
+      plan.rejected_source_indices.push_back(source_index);
+  }
+  return plan;
+}
+
+DbiPatchPlacementPlanner::DbiPatchPlacementPlanner(rj_code_arch_t arch, uint64_t original_text_size)
+    : arch_(arch), original_text_size_(original_text_size), appended_cursor_(original_text_size) {}
+
+bool DbiPatchPlacementPlanner::range_is_free(uint64_t begin, uint64_t end) const {
+  if (begin >= end)
+    return false;
+  for (const auto &[occupied_begin, occupied_end] : occupied_ranges_) {
+    if (begin < occupied_end && occupied_begin < end)
+      return false;
+  }
+  return true;
+}
+
+void DbiPatchPlacementPlanner::reserve_range(uint64_t begin, uint64_t end) {
+  occupied_ranges_.emplace_back(begin, end);
+}
+
+bool DbiPatchPlacementPlanner::reserve_existing_range(uint64_t begin, uint64_t size,
+                                                      std::string *error_out) {
+  if (size == 0 || begin > original_text_size_ || size > original_text_size_ - begin ||
+      !range_is_free(begin, begin + size)) {
+    report(error_out,
+           "DBI patch placement: existing range is empty, out of bounds, or overlapping");
+    return false;
+  }
+  reserve_range(begin, begin + size);
+  return true;
+}
+
+bool DbiPatchPlacementPlanner::reserve_appended_prefix(uint64_t size, std::string *error_out) {
+  if (size == 0)
+    return true;
+  if (size > std::numeric_limits<uint64_t>::max() - appended_cursor_) {
+    report(error_out, "DBI patch placement: appended prefix overflows text coordinates");
+    return false;
+  }
+  const uint64_t end = appended_cursor_ + size;
+  if (!range_is_free(appended_cursor_, end)) {
+    report(error_out, "DBI patch placement: appended prefix overlaps an existing reservation");
+    return false;
+  }
+  reserve_range(appended_cursor_, end);
+  appended_cursor_ = end;
+  return true;
+}
+
+std::optional<DbiPatchPlacement>
+DbiPatchPlacementPlanner::plan(const DbiPatchPlacementRequest &request, std::string *error_out) {
+  const auto checked_end = [](uint64_t begin, uint64_t size) -> std::optional<uint64_t> {
+    if (size > std::numeric_limits<uint64_t>::max() - begin)
+      return std::nullopt;
+    return begin + size;
+  };
+  if (arch_ == ROCJITSU_CODE_ARCH_INVALID) {
+    report(error_out, "DBI patch placement: architecture was not set");
+    return std::nullopt;
+  }
+  if (request.original_size < sizeof(uint32_t) || request.original_size % sizeof(uint32_t) != 0 ||
+      request.body_size == 0 || request.body_size % sizeof(uint32_t) != 0) {
+    report(error_out, "DBI patch placement: sizes must be nonzero instruction multiples");
+    return std::nullopt;
+  }
+  const auto anchor_end = checked_end(request.anchor_offset, request.original_size);
+  if (!anchor_end || *anchor_end > original_text_size_) {
+    report(error_out, "DBI patch placement: anchor exceeds original .text");
+    return std::nullopt;
+  }
+
+  if (request.body_size <= request.inline_capacity) {
+    const auto body_end = checked_end(request.anchor_offset, request.body_size);
+    if (body_end && *body_end <= original_text_size_ &&
+        range_is_free(request.anchor_offset, *body_end)) {
+      reserve_range(request.anchor_offset, *body_end);
+      return DbiPatchPlacement{
+          .kind = DbiPatchPlacementKind::Inline,
+          .anchor_offset = request.anchor_offset,
+          .original_size = request.original_size,
+          .body_offset = request.anchor_offset,
+          .body_size = request.body_size,
+          .return_branch_offset = 0,
+          .return_target = *anchor_end,
+      };
+    }
+  }
+
+  const auto try_trampoline = [&](DbiPatchPlacementKind kind, uint64_t body_offset,
+                                  uint64_t capacity) -> std::optional<DbiPatchPlacement> {
+    const auto body_end = checked_end(body_offset, request.body_size);
+    const auto reservation_end = body_end ? checked_end(*body_end, sizeof(uint32_t)) : std::nullopt;
+    if (!body_end || !reservation_end || request.body_size + sizeof(uint32_t) > capacity ||
+        !range_is_free(request.anchor_offset, *anchor_end) ||
+        (kind == DbiPatchPlacementKind::LocalCave &&
+         (!range_is_free(body_offset, *reservation_end) ||
+          *reservation_end > original_text_size_)) ||
+        !compute_sopp_branch_simm16(request.anchor_offset, body_offset) ||
+        !compute_sopp_branch_simm16(*body_end, *anchor_end)) {
+      return std::nullopt;
+    }
+    return DbiPatchPlacement{
+        .kind = kind,
+        .anchor_offset = request.anchor_offset,
+        .original_size = request.original_size,
+        .body_offset = body_offset,
+        .body_size = request.body_size,
+        .return_branch_offset = *body_end,
+        .return_target = *anchor_end,
+    };
+  };
+
+  if (request.local_cave) {
+    if (auto placement = try_trampoline(DbiPatchPlacementKind::LocalCave,
+                                        request.local_cave->offset, request.local_cave->capacity)) {
+      reserve_range(request.anchor_offset, *anchor_end);
+      reserve_range(placement->body_offset, placement->return_branch_offset + sizeof(uint32_t));
+      return placement;
+    }
+  }
+
+  if (request.allow_appended_cave) {
+    if (auto placement = try_trampoline(DbiPatchPlacementKind::AppendedCave, appended_cursor_,
+                                        std::numeric_limits<uint64_t>::max())) {
+      reserve_range(request.anchor_offset, *anchor_end);
+      appended_cursor_ = placement->return_branch_offset + sizeof(uint32_t);
+      return placement;
+    }
+  }
+
+  report(error_out,
+         "DBI patch placement: no nonoverlapping reachable inline, local, or appended placement");
+  return std::nullopt;
+}
+
+std::optional<DbiPatchPlacement>
+DbiPatchPlacementPlanner::plan_indirect_appended(uint64_t anchor_offset, uint32_t original_size,
+                                                 uint64_t body_size, std::string *error_out) {
+  if (arch_ == ROCJITSU_CODE_ARCH_INVALID || original_size < sizeof(uint32_t) ||
+      original_size % sizeof(uint32_t) != 0 || body_size == 0 ||
+      body_size % sizeof(uint32_t) != 0 || anchor_offset > original_text_size_ ||
+      original_size > original_text_size_ - anchor_offset ||
+      body_size > std::numeric_limits<uint64_t>::max() - appended_cursor_ ||
+      !range_is_free(anchor_offset, anchor_offset + original_size)) {
+    report(error_out, "DBI patch placement: invalid or overlapping indirect appended reservation");
+    return std::nullopt;
+  }
+
+  const uint64_t body_offset = appended_cursor_;
+  const uint64_t body_end = body_offset + body_size;
+  reserve_range(anchor_offset, anchor_offset + original_size);
+  reserve_range(body_offset, body_end);
+  appended_cursor_ = body_end;
+  return DbiPatchPlacement{
+      .kind = DbiPatchPlacementKind::AppendedCave,
+      .anchor_offset = anchor_offset,
+      .original_size = original_size,
+      .body_offset = body_offset,
+      .body_size = body_size,
+      .return_branch_offset = 0u,
+      .return_target = anchor_offset + original_size,
+  };
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.h
@@ -21,7 +21,9 @@
 
 #include <cstdint>
 #include <optional>
+#include <span>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace rocjitsu {
@@ -140,6 +142,120 @@ public:
   /// branch-range failure.
   [[nodiscard]] static std::optional<TrampolineBytes>
   emit_probe_call(const TrampolinePlan &plan, std::string *error_out = nullptr);
+};
+
+/// @brief One source admitted by the forward SOPP relay planner.
+///
+/// `relay_offsets` excludes the source and assigned island. Every adjacent
+/// pair in source -> relays -> island is a valid forward s_branch hop.
+struct SoppBranchRelayRoute {
+  size_t source_index = 0;
+  uint64_t island_offset = 0;
+  std::vector<uint64_t> relay_offsets;
+};
+
+/// @brief Maximum-cardinality assignment of sources to interchangeable
+///        islands through capacity-one relay slots.
+struct SoppBranchRelayPlan {
+  std::vector<SoppBranchRelayRoute> routes;
+  std::vector<size_t> rejected_source_indices;
+  /// Saturated residual min-cut hops, expressed as original text coordinates.
+  /// These identify address bands where another relay vertex can increase
+  /// maximum route cardinality.
+  std::vector<std::pair<uint64_t, uint64_t>> min_cut_hops;
+  std::vector<uint64_t> min_cut_relay_offsets;
+};
+
+/// @brief Plan forward-only s_branch routes through one-word relay slots.
+///
+/// Sources and islands are interchangeable only on the island side: every
+/// admitted source is assigned exactly one island, while every relay slot and
+/// island may appear in at most one route. Coordinates are byte offsets and
+/// must be distinct, dword-aligned instruction addresses. An edge exists only
+/// when `compute_sopp_branch_simm16(from, to)` accepts the hop and `to > from`.
+///
+/// The result has maximum possible route cardinality. Ties are deterministic:
+/// coordinates are considered in ascending order, then original input order.
+/// Invalid coordinate sets return std::nullopt without a partial plan.
+[[nodiscard]] std::optional<SoppBranchRelayPlan> plan_forward_sopp_branch_relays(
+    std::span<const uint64_t> source_offsets, std::span<const uint64_t> relay_offsets,
+    std::span<const uint64_t> island_offsets, std::string *error_out = nullptr);
+
+/// @brief Physical placement selected for one DBI patch body.
+enum class DbiPatchPlacementKind : uint8_t {
+  Inline,
+  LocalCave,
+  AppendedCave,
+};
+
+struct DbiPatchLocalCave {
+  uint64_t offset = 0;
+  uint64_t capacity = 0;
+};
+
+struct DbiPatchPlacementRequest {
+  uint64_t anchor_offset = 0;
+  uint32_t original_size = 0;
+  uint64_t body_size = 0;
+  uint64_t inline_capacity = 0;
+  std::optional<DbiPatchLocalCave> local_cave;
+  bool allow_appended_cave = true;
+};
+
+struct DbiPatchPlacement {
+  DbiPatchPlacementKind kind = DbiPatchPlacementKind::Inline;
+  uint64_t anchor_offset = 0;
+  uint32_t original_size = 0;
+  uint64_t body_offset = 0;
+  uint64_t body_size = 0;
+  uint64_t return_branch_offset = 0;
+  uint64_t return_target = 0;
+};
+
+/// @brief Transactional placement allocator shared by DBI probe families.
+///
+/// The planner owns overlap accounting and appended-cave cursor movement. A
+/// successful trampoline reservation includes its four-byte return branch, so
+/// later placements and final emitters use the same coordinates. Failed
+/// requests do not mutate the planner.
+class DbiPatchPlacementPlanner {
+public:
+  DbiPatchPlacementPlanner(rj_code_arch_t arch, uint64_t original_text_size);
+
+  [[nodiscard]] std::optional<DbiPatchPlacement> plan(const DbiPatchPlacementRequest &request,
+                                                      std::string *error_out = nullptr);
+
+  /// Reserve an appended body whose entry and return are implemented by
+  /// caller-supplied indirect control flow. This retains the planner's overlap
+  /// and cursor guarantees without imposing SOPP reachability.
+  [[nodiscard]] std::optional<DbiPatchPlacement>
+  plan_indirect_appended(uint64_t anchor_offset, uint32_t original_size, uint64_t body_size,
+                         std::string *error_out = nullptr);
+
+  /// Seed a range already owned by an earlier probe family in a composed
+  /// transaction. The range must fit the current text image and not overlap a
+  /// prior reservation.
+  [[nodiscard]] bool reserve_existing_range(uint64_t begin, uint64_t size,
+                                            std::string *error_out = nullptr);
+
+  /// Reserve a generated prefix at the current appended cursor. This is used
+  /// for fixed-size veneer banks whose stable addresses must be known before
+  /// any variable-size bodies are placed.
+  [[nodiscard]] bool reserve_appended_prefix(uint64_t size, std::string *error_out = nullptr);
+
+  [[nodiscard]] uint64_t appended_end() const { return appended_cursor_; }
+  [[nodiscard]] std::span<const std::pair<uint64_t, uint64_t>> occupied_ranges() const {
+    return occupied_ranges_;
+  }
+
+private:
+  [[nodiscard]] bool range_is_free(uint64_t begin, uint64_t end) const;
+  void reserve_range(uint64_t begin, uint64_t end);
+
+  rj_code_arch_t arch_ = ROCJITSU_CODE_ARCH_INVALID;
+  uint64_t original_text_size_ = 0;
+  uint64_t appended_cursor_ = 0;
+  std::vector<std::pair<uint64_t, uint64_t>> occupied_ranges_;
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -345,6 +345,7 @@ add_executable(
     analysis/liveness_test.cpp
     patch/spill_manager_test.cpp
     patch/instruction_builder_test.cpp
+    patch/rdna4_instrumentation_builder_test.cpp
     patch/trampoline_builder_test.cpp
     patch/instrumentor_test.cpp
     patch/probe_symbol_test.cpp

--- a/emulation/rocjitsu/tests/patch/rdna4_instrumentation_builder_test.cpp
+++ b/emulation/rocjitsu/tests/patch/rdna4_instrumentation_builder_test.cpp
@@ -1,0 +1,628 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/patch/rdna4_instrumentation_builder.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+
+namespace rocjitsu {
+namespace {
+
+TEST(InstructionBuilder, BuildAddressFreeScratchB32) {
+  const auto store = build_address_free_scratch_store_b32(
+      /*vsrc=*/5, /*byte_offset=*/16, ROCJITSU_CODE_ARCH_RDNA4);
+  const auto load = build_address_free_scratch_load_b32(
+      /*vdst=*/5, /*byte_offset=*/16, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(store);
+  ASSERT_TRUE(load);
+  EXPECT_EQ(*store, (std::array<uint32_t, 3>{0xed06807cu, 0x02800000u, 0x00001000u}));
+  EXPECT_EQ(*load, (std::array<uint32_t, 3>{0xed05007cu, 0x00000005u, 0x00001000u}));
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> store_inst(decoder->decode(store->data()));
+  std::unique_ptr<Instruction> load_inst(decoder->decode(load->data()));
+  ASSERT_NE(store_inst, nullptr);
+  ASSERT_NE(load_inst, nullptr);
+  EXPECT_EQ(store_inst->mnemonic(), "scratch_store_b32");
+  EXPECT_EQ(load_inst->mnemonic(), "scratch_load_b32");
+  EXPECT_EQ(store_inst->size(), 12u);
+  EXPECT_EQ(load_inst->size(), 12u);
+}
+
+TEST(InstructionBuilder, AddressFreeScratchOffsetBoundary) {
+  const auto store = build_address_free_scratch_store_b32(
+      /*vsrc=*/255, kMaxAddressFreeScratchDwordOffset, ROCJITSU_CODE_ARCH_RDNA4);
+  const auto load = build_address_free_scratch_load_b32(
+      /*vdst=*/255, kMaxAddressFreeScratchDwordOffset, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(store);
+  ASSERT_TRUE(load);
+  EXPECT_EQ(*store, (std::array<uint32_t, 3>{0xed06807cu, 0x7f800000u, 0x7ffffc00u}));
+  EXPECT_EQ(*load, (std::array<uint32_t, 3>{0xed05007cu, 0x000000ffu, 0x7ffffc00u}));
+
+  EXPECT_FALSE(build_address_free_scratch_store_b32(0, kMaxAddressFreeScratchPrivateBytes,
+                                                    ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_address_free_scratch_load_b32(0, kMaxAddressFreeScratchPrivateBytes,
+                                                   ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_address_free_scratch_store_b32(0, 2, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_address_free_scratch_load_b32(0, 2, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_address_free_scratch_store_b32(0, 0, ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildSplitScratchWaits) {
+  const auto store_wait = build_s_wait_storecnt0(ROCJITSU_CODE_ARCH_RDNA4);
+  const auto store_ds_wait = build_s_wait_storecnt_dscnt0(ROCJITSU_CODE_ARCH_RDNA4);
+  const auto load_wait = build_s_wait_loadcnt0(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(store_wait);
+  ASSERT_TRUE(store_ds_wait);
+  ASSERT_TRUE(load_wait);
+  EXPECT_EQ(*store_wait, 0xbfc10000u);
+  EXPECT_EQ(*store_ds_wait, 0xbfc90000u);
+  EXPECT_EQ(*load_wait, 0xbfc00000u);
+  EXPECT_FALSE(build_s_wait_storecnt0(ROCJITSU_CODE_ARCH_CDNA4));
+  EXPECT_FALSE(build_s_wait_storecnt_dscnt0(ROCJITSU_CODE_ARCH_CDNA4));
+  EXPECT_FALSE(build_s_wait_loadcnt0(ROCJITSU_CODE_ARCH_CDNA4));
+}
+TEST(InstructionBuilder, BuildVLshrrevB32E32) {
+  const auto word = build_v_lshrrev_b32_e32(/*vdst=*/10, scalar_positive_inline_u32(2),
+                                            /*vsrc1=*/3, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(word);
+  EXPECT_EQ(*word, 0x32000000u | (10u << 17) | (3u << 9) | scalar_positive_inline_u32(2));
+
+  EXPECT_FALSE(build_v_lshrrev_b32_e32(/*vdst=*/256, scalar_positive_inline_u32(2), /*vsrc1=*/3,
+                                       ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(
+      build_v_lshrrev_b32_e32(/*vdst=*/10, /*src0=*/512, /*vsrc1=*/3, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_lshrrev_b32_e32(/*vdst=*/10, scalar_positive_inline_u32(2), /*vsrc1=*/256,
+                                       ROCJITSU_CODE_ARCH_RDNA4));
+}
+
+TEST(InstructionBuilder, BuildVLshlrevB32E32) {
+  const auto word = build_v_lshlrev_b32_e32(/*vdst=*/10, scalar_positive_inline_u32(16),
+                                            /*vsrc1=*/10, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(word);
+  EXPECT_EQ(*word, 0x30141490u);
+
+  EXPECT_FALSE(build_v_lshlrev_b32_e32(/*vdst=*/256, scalar_positive_inline_u32(16),
+                                       /*vsrc1=*/10, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(
+      build_v_lshlrev_b32_e32(/*vdst=*/10, /*src0=*/512, /*vsrc1=*/10, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_lshlrev_b32_e32(/*vdst=*/10, scalar_positive_inline_u32(16),
+                                       /*vsrc1=*/256, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_lshlrev_b32_e32(/*vdst=*/10, scalar_positive_inline_u32(16),
+                                       /*vsrc1=*/10, ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildVReadfirstlaneB32) {
+  const auto word = build_v_readfirstlane_b32(/*sdst=*/20, /*vsrc=*/8, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(word);
+  EXPECT_EQ(*word, 0x7E280508u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(&*word));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(std::string_view(inst->mnemonic()), "v_readfirstlane_b32_e32");
+
+  EXPECT_FALSE(build_v_readfirstlane_b32(/*sdst=*/128, /*vsrc=*/8, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_readfirstlane_b32(/*sdst=*/20, /*vsrc=*/256, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_readfirstlane_b32(/*sdst=*/20, /*vsrc=*/8, ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildSGetregB32) {
+  const auto hwreg = build_hwreg_imm(/*reg_id=*/23, /*offset=*/0, /*size_bits=*/10);
+  ASSERT_TRUE(hwreg);
+  EXPECT_EQ(*hwreg, 0x4817u);
+
+  const auto word = build_s_getreg_b32(/*sdst=*/20, *hwreg, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(word);
+  EXPECT_EQ(*word, 0xB8944817u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(&*word));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(std::string_view(inst->mnemonic()), "s_getreg_b32");
+
+  EXPECT_FALSE(build_hwreg_imm(/*reg_id=*/64, /*offset=*/0, /*size_bits=*/10));
+  EXPECT_FALSE(build_hwreg_imm(/*reg_id=*/23, /*offset=*/32, /*size_bits=*/10));
+  EXPECT_FALSE(build_hwreg_imm(/*reg_id=*/23, /*offset=*/0, /*size_bits=*/0));
+  EXPECT_FALSE(build_hwreg_imm(/*reg_id=*/23, /*offset=*/0, /*size_bits=*/33));
+  EXPECT_FALSE(build_s_getreg_b32(/*sdst=*/128, *hwreg, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_s_getreg_b32(/*sdst=*/20, *hwreg, ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildVMbcntLaneIdSequence) {
+  const auto low = build_v_mbcnt_lo_u32_b32(
+      /*vdst=*/13, /*src0=*/0xC1, scalar_positive_inline_u32(0), ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(low);
+  EXPECT_EQ((*low)[0], 0xD71F000Du);
+  EXPECT_EQ((*low)[1], 0x020100C1u);
+
+  const auto high = build_v_mbcnt_hi_u32_b32(
+      /*vdst=*/13, /*src0=*/0xC1, vector_source_vgpr(13), ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(high);
+  EXPECT_EQ((*high)[0], 0xD720000Du);
+  EXPECT_EQ((*high)[1], 0x02021AC1u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> low_inst(decoder->decode(low->data()));
+  ASSERT_NE(low_inst, nullptr);
+  EXPECT_EQ(std::string_view(low_inst->mnemonic()), "v_mbcnt_lo_u32_b32");
+  std::unique_ptr<Instruction> high_inst(decoder->decode(high->data()));
+  ASSERT_NE(high_inst, nullptr);
+  EXPECT_EQ(std::string_view(high_inst->mnemonic()), "v_mbcnt_hi_u32_b32");
+
+  EXPECT_FALSE(build_v_mbcnt_lo_u32_b32(/*vdst=*/256, /*src0=*/0xC1, scalar_positive_inline_u32(0),
+                                        ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_mbcnt_lo_u32_b32(/*vdst=*/13, /*src0=*/512, scalar_positive_inline_u32(0),
+                                        ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(
+      build_v_mbcnt_hi_u32_b32(/*vdst=*/13, /*src0=*/0xC1, /*src1=*/512, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_mbcnt_hi_u32_b32(/*vdst=*/13, /*src0=*/0xC1, vector_source_vgpr(13),
+                                        ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildVCmpEqU32E32Vcc) {
+  const auto word = build_v_cmp_eq_u32_e32_vcc(scalar_positive_inline_u32(0), /*vsrc1=*/13,
+                                               ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(word);
+  EXPECT_EQ(*word, 0x7C941A80u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(&*word));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(std::string_view(inst->mnemonic()), "v_cmp_eq_u32_e32");
+
+  EXPECT_FALSE(build_v_cmp_eq_u32_e32_vcc(/*src0=*/512, /*vsrc1=*/13, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_cmp_eq_u32_e32_vcc(scalar_positive_inline_u32(0), /*vsrc1=*/256,
+                                          ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_cmp_eq_u32_e32_vcc(scalar_positive_inline_u32(0), /*vsrc1=*/13,
+                                          ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildVAddNcU32E32) {
+  const auto word = build_v_add_nc_u32_e32(/*vdst=*/13, vector_source_vgpr(13), /*vsrc1=*/14,
+                                           ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(word);
+  EXPECT_EQ(*word, 0x4A1A1D0Du);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(&*word));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(std::string_view(inst->mnemonic()), "v_add_nc_u32_e32");
+
+  EXPECT_FALSE(build_v_add_nc_u32_e32(/*vdst=*/256, vector_source_vgpr(13), /*vsrc1=*/14,
+                                      ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(
+      build_v_add_nc_u32_e32(/*vdst=*/13, /*src0=*/512, /*vsrc1=*/14, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_add_nc_u32_e32(/*vdst=*/13, vector_source_vgpr(13), /*vsrc1=*/256,
+                                      ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_add_nc_u32_e32(/*vdst=*/13, vector_source_vgpr(13), /*vsrc1=*/14,
+                                      ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildVAndB32E32) {
+  const auto word =
+      build_v_and_b32_e32(/*vdst=*/3, vector_source_vgpr(4), /*vsrc1=*/5, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(word);
+  EXPECT_EQ(*word, 0x36060B04u);
+
+  const auto literal = build_v_and_b32_e32_literal(/*vdst=*/3, /*literal=*/0x1ff8, /*vsrc1=*/4,
+                                                   ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(literal);
+  EXPECT_EQ((*literal)[0], 0x360608FFu);
+  EXPECT_EQ((*literal)[1], 0x00001FF8u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(&*word));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(std::string_view(inst->mnemonic()), "v_and_b32_e32");
+  std::unique_ptr<Instruction> literal_inst(decoder->decode(literal->data()));
+  ASSERT_NE(literal_inst, nullptr);
+  EXPECT_EQ(std::string_view(literal_inst->mnemonic()), "v_and_b32_e32");
+
+  EXPECT_FALSE(build_v_and_b32_e32(/*vdst=*/256, vector_source_vgpr(4), /*vsrc1=*/5,
+                                   ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(
+      build_v_and_b32_e32(/*vdst=*/3, /*src0=*/512, /*vsrc1=*/5, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_and_b32_e32(/*vdst=*/3, vector_source_vgpr(4), /*vsrc1=*/256,
+                                   ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_and_b32_e32(/*vdst=*/3, vector_source_vgpr(4), /*vsrc1=*/5,
+                                   ROCJITSU_CODE_ARCH_CDNA4));
+  EXPECT_FALSE(build_v_and_b32_e32_literal(/*vdst=*/256, /*literal=*/0x1ff8, /*vsrc1=*/4,
+                                           ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_and_b32_e32_literal(/*vdst=*/3, /*literal=*/0x1ff8, /*vsrc1=*/256,
+                                           ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_and_b32_e32_literal(/*vdst=*/3, /*literal=*/0x1ff8, /*vsrc1=*/4,
+                                           ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildVCmpGtU32E32Vcc) {
+  const auto word = build_v_cmp_gt_u32_e32_vcc(scalar_positive_inline_u32(4), /*vsrc1=*/10,
+                                               ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(word);
+  EXPECT_EQ(*word, 0x7C981484u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(&*word));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(std::string_view(inst->mnemonic()), "v_cmp_gt_u32_e32");
+
+  EXPECT_FALSE(build_v_cmp_gt_u32_e32_vcc(/*src0=*/512, /*vsrc1=*/10, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_cmp_gt_u32_e32_vcc(scalar_positive_inline_u32(4), /*vsrc1=*/256,
+                                          ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_v_cmp_gt_u32_e32_vcc(scalar_positive_inline_u32(4), /*vsrc1=*/10,
+                                          ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildVCmpNeU32E32Vcc) {
+  const auto word =
+      build_v_cmp_ne_u32_e32_vcc(vector_source_vgpr(1), /*vsrc1=*/2, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(word);
+  EXPECT_EQ(*word, 0x7C9A0501u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(&*word));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(std::string_view(inst->mnemonic()), "v_cmp_ne_u32_e32");
+
+  EXPECT_FALSE(build_v_cmp_ne_u32_e32_vcc(/*src0=*/512, /*vsrc1=*/2, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(
+      build_v_cmp_ne_u32_e32_vcc(vector_source_vgpr(1), /*vsrc1=*/256, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(
+      build_v_cmp_ne_u32_e32_vcc(vector_source_vgpr(1), /*vsrc1=*/2, ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildExecNarrowingScalarOps) {
+  const auto save_exec =
+      build_s_and_saveexec_b64(/*sdst=*/30, /*ssrc0=*/106, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(save_exec);
+  EXPECT_EQ(*save_exec, 0xBE9E216Au);
+
+  const auto restore_exec = build_s_mov_b64(/*sdst=*/126, /*ssrc0=*/30, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(restore_exec);
+  EXPECT_EQ(*restore_exec, 0xBEFE011Eu);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> save_inst(decoder->decode(&*save_exec));
+  ASSERT_NE(save_inst, nullptr);
+  EXPECT_EQ(std::string_view(save_inst->mnemonic()), "s_and_saveexec_b64");
+  std::unique_ptr<Instruction> restore_inst(decoder->decode(&*restore_exec));
+  ASSERT_NE(restore_inst, nullptr);
+  EXPECT_EQ(std::string_view(restore_inst->mnemonic()), "s_mov_b64");
+
+  EXPECT_FALSE(build_s_and_saveexec_b64(/*sdst=*/127, /*ssrc0=*/106, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_s_and_saveexec_b64(/*sdst=*/30, /*ssrc0=*/256, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_s_and_saveexec_b64(/*sdst=*/30, /*ssrc0=*/106, ROCJITSU_CODE_ARCH_CDNA4));
+  EXPECT_FALSE(build_s_mov_b64(/*sdst=*/127, /*ssrc0=*/30, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_s_mov_b64(/*sdst=*/126, /*ssrc0=*/256, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_s_mov_b64(/*sdst=*/126, /*ssrc0=*/30, ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildWavePartitionMaskRemoval) {
+  const auto remaining = build_s_xor_b64(
+      /*sdst=*/30, /*ssrc0=*/32, /*ssrc1=*/34, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(remaining);
+  EXPECT_EQ(*remaining, 0x8D9E2220u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(&*remaining));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(std::string_view(inst->mnemonic()), "s_xor_b64");
+
+  EXPECT_FALSE(build_s_xor_b64(/*sdst=*/127, /*ssrc0=*/32, /*ssrc1=*/34, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_s_xor_b64(/*sdst=*/30, /*ssrc0=*/255, /*ssrc1=*/34, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_s_xor_b64(/*sdst=*/30, /*ssrc0=*/32, /*ssrc1=*/255, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_s_xor_b64(/*sdst=*/30, /*ssrc0=*/32, /*ssrc1=*/34, ROCJITSU_CODE_ARCH_CDNA4));
+
+  const auto repeat = build_s_cbranch_execnz(/*offset_dwords=*/-4, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(repeat);
+  EXPECT_EQ(*repeat, 0xBFA6FFFCu);
+  std::unique_ptr<Instruction> branch_inst(decoder->decode(&*repeat));
+  ASSERT_NE(branch_inst, nullptr);
+  EXPECT_EQ(std::string_view(branch_inst->mnemonic()), "s_cbranch_execnz");
+  EXPECT_FALSE(build_s_cbranch_execnz(/*offset_dwords=*/-4, ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildSccSnapshotAndRestoreOps) {
+  const auto save_scc = build_rdna4_s_cselect_b32(
+      /*sdst=*/20, scalar_positive_inline_u32(1), scalar_positive_inline_u32(0),
+      ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(save_scc);
+  EXPECT_EQ(*save_scc, 0x98148081u);
+
+  const auto restore_scc = build_rdna4_s_cmp_lg_u32(
+      /*ssrc0=*/20, scalar_positive_inline_u32(0), ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(restore_scc);
+  EXPECT_EQ(*restore_scc, 0xBF078014u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> save_inst(decoder->decode(&*save_scc));
+  ASSERT_NE(save_inst, nullptr);
+  EXPECT_EQ(std::string_view(save_inst->mnemonic()), "s_cselect_b32");
+  std::unique_ptr<Instruction> restore_inst(decoder->decode(&*restore_scc));
+  ASSERT_NE(restore_inst, nullptr);
+  EXPECT_EQ(std::string_view(restore_inst->mnemonic()), "s_cmp_lg_u32");
+
+  EXPECT_FALSE(build_rdna4_s_cselect_b32(
+      /*sdst=*/128, scalar_positive_inline_u32(1), scalar_positive_inline_u32(0),
+      ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_rdna4_s_cselect_b32(
+      /*sdst=*/20, /*ssrc0=*/256, scalar_positive_inline_u32(0), ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_rdna4_s_cselect_b32(
+      /*sdst=*/20, scalar_positive_inline_u32(1), scalar_positive_inline_u32(0),
+      ROCJITSU_CODE_ARCH_CDNA4));
+  EXPECT_FALSE(build_rdna4_s_cmp_lg_u32(/*ssrc0=*/256, scalar_positive_inline_u32(0),
+                                        ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_rdna4_s_cmp_lg_u32(/*ssrc0=*/20, scalar_positive_inline_u32(0),
+                                        ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildSCbranchVccz) {
+  const auto word = build_s_cbranch_vccz(/*offset_dwords=*/3, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(word);
+  EXPECT_EQ(*word, 0xBFA30003u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(&*word));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(std::string_view(inst->mnemonic()), "s_cbranch_vccz");
+
+  const auto backwards = build_s_cbranch_vccz(/*offset_dwords=*/-1, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(backwards);
+  EXPECT_EQ(*backwards, 0xBFA3FFFFu);
+  EXPECT_FALSE(build_s_cbranch_vccz(/*offset_dwords=*/3, ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildSCbranchVccnz) {
+  const auto word = build_s_cbranch_vccnz(/*offset_dwords=*/3, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(word);
+  EXPECT_EQ(*word, 0xBFA40003u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(&*word));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(std::string_view(inst->mnemonic()), "s_cbranch_vccnz");
+
+  const auto backwards = build_s_cbranch_vccnz(/*offset_dwords=*/-7, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(backwards);
+  EXPECT_EQ(*backwards, 0xBFA4FFF9u);
+  EXPECT_FALSE(build_s_cbranch_vccnz(/*offset_dwords=*/3, ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildRdna4WaveUniformControlFlow) {
+  const auto compare = build_s_cmp_eq_u32(/*ssrc0=*/126, /*ssrc1=*/42, ROCJITSU_CODE_ARCH_RDNA4);
+  const auto forward = build_s_cbranch_scc0(/*offset_dwords=*/17, ROCJITSU_CODE_ARCH_RDNA4);
+  const auto backward = build_s_cbranch_scc0(/*offset_dwords=*/-3, ROCJITSU_CODE_ARCH_RDNA4);
+  const auto continue_loop = build_s_cbranch_scc1(/*offset_dwords=*/-23, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(compare);
+  ASSERT_TRUE(forward);
+  ASSERT_TRUE(backward);
+  ASSERT_TRUE(continue_loop);
+  EXPECT_EQ(*compare, pack_sopc(/*s_cmp_eq_u32=*/6, /*ssrc0=*/126, /*ssrc1=*/42));
+  EXPECT_EQ(*forward, pack_sopp(/*s_cbranch_scc0=*/33, /*simm16=*/17));
+  EXPECT_EQ(*backward, pack_sopp(/*s_cbranch_scc0=*/33, /*simm16=*/0xfffd));
+  EXPECT_EQ(*continue_loop, pack_sopp(/*s_cbranch_scc1=*/34, /*simm16=*/0xffe9));
+  EXPECT_FALSE(build_s_cmp_eq_u32(/*ssrc0=*/256, /*ssrc1=*/42, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_s_cbranch_scc0(/*offset_dwords=*/1, ROCJITSU_CODE_ARCH_CDNA4));
+  EXPECT_FALSE(build_s_cbranch_scc1(/*offset_dwords=*/1, ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildGfx1250MoiBarrierRecordRecipeEncodings) {
+  constexpr auto kArch = ROCJITSU_CODE_ARCH_GFX1250;
+
+  const auto mbcnt_low = build_v_mbcnt_lo_u32_b32(
+      /*vdst=*/13, /*src0=*/0xC1, scalar_positive_inline_u32(0), kArch);
+  const auto mbcnt_high = build_v_mbcnt_hi_u32_b32(
+      /*vdst=*/13, /*src0=*/0xC1, vector_source_vgpr(13), kArch);
+  const auto cmp_eq =
+      build_v_cmp_eq_u32_e32_vcc(scalar_positive_inline_u32(0), /*vsrc1=*/13, kArch);
+  const auto cmp_gt =
+      build_v_cmp_gt_u32_e32_vcc(scalar_positive_inline_u32(4), /*vsrc1=*/10, kArch);
+  const auto mov_literal = build_v_mov_b32_e64_literal(/*vdst=*/13, 0x12345678u, kArch);
+  const auto flat_store = build_flat_store_b32_vaddr_vsrc(/*vaddr=*/8, /*vsrc=*/10, kArch);
+  const auto store_wait = build_s_wait_storecnt0(kArch);
+  const auto load_wait = build_s_wait_loadcnt0(kArch);
+  const auto atomic_add = build_flat_atomic_add_u32_vaddr_vsrc_vdst(
+      /*vaddr=*/8, /*vsrc=*/10, /*vdst=*/10, /*return_old_value=*/true, /*scope=*/2, kArch);
+  const auto save_exec = build_s_and_saveexec_b64(/*sdst=*/30, /*ssrc0=*/106, kArch);
+  const auto restore_exec = build_s_mov_b64(/*sdst=*/126, /*ssrc0=*/30, kArch);
+  const auto save_scc = build_rdna4_s_cselect_b32(
+      /*sdst=*/20, scalar_positive_inline_u32(1), scalar_positive_inline_u32(0), kArch);
+  const auto restore_scc =
+      build_rdna4_s_cmp_lg_u32(/*ssrc0=*/20, scalar_positive_inline_u32(0), kArch);
+  const auto capacity_skip = build_s_cbranch_vccz(/*offset_dwords=*/3, kArch);
+
+  ASSERT_TRUE(mbcnt_low);
+  ASSERT_TRUE(mbcnt_high);
+  ASSERT_TRUE(cmp_eq);
+  ASSERT_TRUE(cmp_gt);
+  ASSERT_TRUE(mov_literal);
+  ASSERT_TRUE(flat_store);
+  ASSERT_TRUE(store_wait);
+  ASSERT_TRUE(load_wait);
+  ASSERT_TRUE(atomic_add);
+  ASSERT_TRUE(save_exec);
+  ASSERT_TRUE(restore_exec);
+  ASSERT_TRUE(save_scc);
+  ASSERT_TRUE(restore_scc);
+  ASSERT_TRUE(capacity_skip);
+  EXPECT_EQ(*mbcnt_low, (std::array<uint32_t, 2>{0xD71F000Du, 0x020100C1u}));
+  EXPECT_EQ(*mbcnt_high, (std::array<uint32_t, 2>{0xD720000Du, 0x02021AC1u}));
+  EXPECT_EQ(*cmp_eq, 0x7C941A80u);
+  EXPECT_EQ(*cmp_gt, 0x7C981484u);
+  EXPECT_EQ(*mov_literal, (std::array<uint32_t, 3>{0xD581000Du, 0x000000FFu, 0x12345678u}));
+  EXPECT_EQ(*flat_store, (std::array<uint32_t, 3>{0xEC06807Cu, 0x05000000u, 0x00000008u}));
+  EXPECT_EQ(*store_wait, 0xBFC10000u);
+  EXPECT_EQ(*load_wait, 0xBFC00000u);
+  EXPECT_EQ(*atomic_add, (std::array<uint32_t, 3>{0xEC0D407Cu, 0x0518000Au, 0x00000008u}));
+  EXPECT_EQ(*save_exec, 0xBE9E216Au);
+  EXPECT_EQ(*restore_exec, 0xBEFE011Eu);
+  EXPECT_EQ(*save_scc, 0x98148081u);
+  EXPECT_EQ(*restore_scc, 0xBF078014u);
+  EXPECT_EQ(*capacity_skip, 0xBFA30003u);
+
+  auto decoder = Decoder::create(kArch);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> save_exec_inst(decoder->decode(&*save_exec));
+  std::unique_ptr<Instruction> mbcnt_inst(decoder->decode(mbcnt_low->data()));
+  std::unique_ptr<Instruction> store_inst(decoder->decode(flat_store->data()));
+  std::unique_ptr<Instruction> atomic_inst(decoder->decode(atomic_add->data()));
+  ASSERT_NE(save_exec_inst, nullptr);
+  ASSERT_NE(mbcnt_inst, nullptr);
+  ASSERT_NE(store_inst, nullptr);
+  ASSERT_NE(atomic_inst, nullptr);
+  EXPECT_EQ(std::string_view(save_exec_inst->mnemonic()), "s_and_saveexec_b64");
+  EXPECT_EQ(std::string_view(mbcnt_inst->mnemonic()), "v_mbcnt_lo_u32_b32");
+  EXPECT_EQ(std::string_view(store_inst->mnemonic()), "flat_store_b32");
+  EXPECT_EQ(std::string_view(atomic_inst->mnemonic()), "flat_atomic_add_u32");
+}
+
+TEST(InstructionBuilder, BuildFlatStoreB32) {
+  const auto words =
+      build_flat_store_b32_vaddr_vsrc(/*vaddr=*/8, /*vsrc=*/10, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(words);
+
+  EXPECT_EQ((*words)[0], 0xEC06807Cu);
+  EXPECT_EQ((*words)[1], 0x05000000u);
+  EXPECT_EQ((*words)[2], 0x00000008u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words->data()));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(std::string_view(inst->mnemonic()), "flat_store_b32");
+
+  EXPECT_FALSE(
+      build_flat_store_b32_vaddr_vsrc(/*vaddr=*/256, /*vsrc=*/10, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(
+      build_flat_store_b32_vaddr_vsrc(/*vaddr=*/8, /*vsrc=*/256, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_flat_store_b32_vaddr_vsrc(/*vaddr=*/8, /*vsrc=*/10, ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildFlatLoadB32) {
+  const auto words =
+      build_flat_load_b32_vaddr_vdst(/*vaddr=*/8, /*vdst=*/10, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(words);
+
+  EXPECT_EQ((*words)[0], 0xEC05007Cu);
+  EXPECT_EQ((*words)[1], 0x0000000Au);
+  EXPECT_EQ((*words)[2], 0x00000008u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words->data()));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(std::string_view(inst->mnemonic()), "flat_load_b32");
+
+  EXPECT_FALSE(
+      build_flat_load_b32_vaddr_vdst(/*vaddr=*/256, /*vdst=*/10, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_flat_load_b32_vaddr_vdst(/*vaddr=*/8, /*vdst=*/256, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_flat_load_b32_vaddr_vdst(/*vaddr=*/8, /*vdst=*/10, ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildFlatAtomicAddU32ReturnDeviceScope) {
+  const auto words = build_flat_atomic_add_u32_vaddr_vsrc_vdst(
+      /*vaddr=*/8, /*vsrc=*/10, /*vdst=*/10, /*return_old_value=*/true, /*scope=*/2,
+      ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(words);
+
+  EXPECT_EQ((*words)[0], 0xEC0D407Cu);
+  EXPECT_EQ((*words)[1], 0x0518000Au);
+  EXPECT_EQ((*words)[2], 0x00000008u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words->data()));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(std::string_view(inst->mnemonic()), "flat_atomic_add_u32");
+
+  EXPECT_FALSE(build_flat_atomic_add_u32_vaddr_vsrc_vdst(
+      /*vaddr=*/256, /*vsrc=*/10, /*vdst=*/10, /*return_old_value=*/true, /*scope=*/2,
+      ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_flat_atomic_add_u32_vaddr_vsrc_vdst(
+      /*vaddr=*/8, /*vsrc=*/256, /*vdst=*/10, /*return_old_value=*/true, /*scope=*/2,
+      ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_flat_atomic_add_u32_vaddr_vsrc_vdst(
+      /*vaddr=*/8, /*vsrc=*/10, /*vdst=*/256, /*return_old_value=*/true, /*scope=*/2,
+      ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_flat_atomic_add_u32_vaddr_vsrc_vdst(
+      /*vaddr=*/8, /*vsrc=*/10, /*vdst=*/10, /*return_old_value=*/true, /*scope=*/4,
+      ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_flat_atomic_add_u32_vaddr_vsrc_vdst(
+      /*vaddr=*/8, /*vsrc=*/10, /*vdst=*/10, /*return_old_value=*/true, /*scope=*/2,
+      ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+TEST(InstructionBuilder, BuildFlatAtomicOrU32ReturnDeviceScope) {
+  const auto words = build_flat_atomic_or_u32_vaddr_vsrc_vdst(
+      /*vaddr=*/8, /*vsrc=*/10, /*vdst=*/10, /*return_old_value=*/true,
+      /*scope=*/2, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(words);
+  EXPECT_EQ(*words, (std::array<uint32_t, 3>{0xEC0F407Cu, 0x0518000Au, 0x00000008u}));
+
+  std::unique_ptr<Decoder> decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(decoder);
+  std::unique_ptr<Instruction> inst(decoder->decode(words->data()));
+  ASSERT_TRUE(inst);
+  EXPECT_EQ(std::string_view(inst->mnemonic()), "flat_atomic_or_b32");
+
+  EXPECT_FALSE(
+      build_flat_atomic_or_u32_vaddr_vsrc_vdst(0, 0, 0, true, 4, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(
+      build_flat_atomic_or_u32_vaddr_vsrc_vdst(0, 0, 0, true, 2, ROCJITSU_CODE_ARCH_RDNA3));
+}
+
+TEST(InstructionBuilder, BuildFlatAtomicSwapB64ReturnDeviceScope) {
+  const auto words = build_flat_atomic_swap_b64_vaddr_vsrc_vdst(
+      /*vaddr=*/8, /*vsrc=*/10, /*vdst=*/12, /*return_old_value=*/true, /*scope=*/2,
+      ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(words);
+
+  EXPECT_EQ((*words)[0], 0xEC10407Cu);
+  EXPECT_EQ((*words)[1], 0x0518000Cu);
+  EXPECT_EQ((*words)[2], 0x00000008u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words->data()));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(std::string_view(inst->mnemonic()), "flat_atomic_swap_b64");
+
+  EXPECT_FALSE(build_flat_atomic_swap_b64_vaddr_vsrc_vdst(
+      /*vaddr=*/255, /*vsrc=*/10, /*vdst=*/12, /*return_old_value=*/true, /*scope=*/2,
+      ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_flat_atomic_swap_b64_vaddr_vsrc_vdst(
+      /*vaddr=*/8, /*vsrc=*/255, /*vdst=*/12, /*return_old_value=*/true, /*scope=*/2,
+      ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_flat_atomic_swap_b64_vaddr_vsrc_vdst(
+      /*vaddr=*/8, /*vsrc=*/10, /*vdst=*/255, /*return_old_value=*/true, /*scope=*/2,
+      ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_flat_atomic_swap_b64_vaddr_vsrc_vdst(
+      /*vaddr=*/8, /*vsrc=*/10, /*vdst=*/12, /*return_old_value=*/true, /*scope=*/4,
+      ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_FALSE(build_flat_atomic_swap_b64_vaddr_vsrc_vdst(
+      /*vaddr=*/8, /*vsrc=*/10, /*vdst=*/12, /*return_old_value=*/true, /*scope=*/2,
+      ROCJITSU_CODE_ARCH_CDNA4));
+}
+
+} // namespace
+} // namespace rocjitsu

--- a/emulation/rocjitsu/tests/patch/trampoline_builder_test.cpp
+++ b/emulation/rocjitsu/tests/patch/trampoline_builder_test.cpp
@@ -313,6 +313,201 @@ TEST(TrampolineBuilder, ReturnSimm16AtNegativeLimitSucceeds) {
             build_s_branch(std::numeric_limits<int16_t>::min(), kArch));
 }
 
+TEST(DbiPatchPlacementPlanner, ReservesSequentialAppendedCavesWithExplicitMappings) {
+  DbiPatchPlacementPlanner planner(ROCJITSU_CODE_ARCH_RDNA4, /*original_text_size=*/256);
+  DbiPatchPlacementRequest first;
+  first.anchor_offset = 16;
+  first.original_size = 8;
+  first.body_size = 40;
+  first.inline_capacity = 8;
+  DbiPatchPlacementRequest second = first;
+  second.anchor_offset = 32;
+  second.body_size = 24;
+
+  const auto first_placement = planner.plan(first);
+  const auto second_placement = planner.plan(second);
+
+  ASSERT_TRUE(first_placement);
+  ASSERT_TRUE(second_placement);
+  EXPECT_EQ(first_placement->kind, DbiPatchPlacementKind::AppendedCave);
+  EXPECT_EQ(first_placement->body_offset, 256u);
+  EXPECT_EQ(first_placement->return_branch_offset, 296u);
+  EXPECT_EQ(first_placement->return_target, 24u);
+  EXPECT_EQ(second_placement->body_offset, 300u);
+  EXPECT_EQ(second_placement->return_branch_offset, 324u);
+  EXPECT_EQ(second_placement->return_target, 40u);
+  EXPECT_EQ(planner.appended_end(), 328u);
+}
+
+TEST(DbiPatchPlacementPlanner, PrefersInlineThenLocalAndRejectsOverlapTransactionally) {
+  DbiPatchPlacementPlanner planner(ROCJITSU_CODE_ARCH_RDNA4, /*original_text_size=*/512);
+  DbiPatchPlacementRequest inline_request;
+  inline_request.anchor_offset = 32;
+  inline_request.original_size = 8;
+  inline_request.body_size = 32;
+  inline_request.inline_capacity = 40;
+  inline_request.local_cave = DbiPatchLocalCave{256, 64};
+  ASSERT_EQ(planner.plan(inline_request)->kind, DbiPatchPlacementKind::Inline);
+
+  DbiPatchPlacementRequest local_request;
+  local_request.anchor_offset = 96;
+  local_request.original_size = 8;
+  local_request.body_size = 40;
+  local_request.inline_capacity = 8;
+  local_request.local_cave = DbiPatchLocalCave{256, 64};
+  const auto local = planner.plan(local_request);
+  ASSERT_TRUE(local);
+  EXPECT_EQ(local->kind, DbiPatchPlacementKind::LocalCave);
+  EXPECT_EQ(local->body_offset, 256u);
+
+  const uint64_t appended_before_failure = planner.appended_end();
+  std::string error;
+  DbiPatchPlacementRequest overlap = local_request;
+  overlap.allow_appended_cave = false;
+  EXPECT_FALSE(planner.plan(overlap, &error));
+  EXPECT_NE(error.find("no nonoverlapping"), std::string::npos);
+  EXPECT_EQ(planner.appended_end(), appended_before_failure);
+}
+
+TEST(DbiPatchPlacementPlanner, SeedsComposedRangesBeforeLaterFamilySelection) {
+  DbiPatchPlacementPlanner planner(ROCJITSU_CODE_ARCH_RDNA4, /*original_text_size=*/512);
+  EXPECT_TRUE(planner.reserve_existing_range(/*begin=*/32, /*size=*/48));
+  EXPECT_TRUE(planner.reserve_existing_range(/*begin=*/256, /*size=*/64));
+  std::string error;
+  EXPECT_FALSE(planner.reserve_existing_range(/*begin=*/64, /*size=*/8, &error));
+  EXPECT_NE(error.find("overlapping"), std::string::npos);
+
+  DbiPatchPlacementRequest request;
+  request.anchor_offset = 96;
+  request.original_size = 4;
+  request.body_size = 8;
+  request.inline_capacity = 0;
+  request.local_cave = DbiPatchLocalCave{/*offset=*/256, /*capacity=*/128};
+  const auto placement = planner.plan(request);
+  ASSERT_TRUE(placement);
+  EXPECT_EQ(placement->kind, DbiPatchPlacementKind::AppendedCave);
+  EXPECT_EQ(placement->body_offset, 512u);
+}
+
+TEST(DbiPatchPlacementPlanner, FailsBeforeReservingUnreachableAppendedMapping) {
+  constexpr uint64_t kTextSize = 1u << 20u;
+  DbiPatchPlacementPlanner planner(ROCJITSU_CODE_ARCH_RDNA4, kTextSize);
+  DbiPatchPlacementRequest request;
+  request.anchor_offset = 0;
+  request.original_size = 4;
+  request.body_size = 16;
+  request.inline_capacity = 4;
+  std::string error;
+
+  EXPECT_FALSE(planner.plan(request, &error));
+  EXPECT_NE(error.find("no nonoverlapping"), std::string::npos);
+  EXPECT_TRUE(planner.occupied_ranges().empty());
+  EXPECT_EQ(planner.appended_end(), kTextSize);
+}
+
+TEST(DbiPatchPlacementPlanner, ReservesIndirectAppendedBodiesWithoutSoppReachability) {
+  constexpr uint64_t kTextSize = 1u << 20u;
+  DbiPatchPlacementPlanner planner(ROCJITSU_CODE_ARCH_RDNA4, kTextSize);
+
+  const auto first = planner.plan_indirect_appended(
+      /*anchor_offset=*/0, /*original_size=*/4, /*body_size=*/28);
+  const auto second = planner.plan_indirect_appended(
+      /*anchor_offset=*/16, /*original_size=*/4, /*body_size=*/12);
+
+  ASSERT_TRUE(first);
+  ASSERT_TRUE(second);
+  EXPECT_EQ(first->body_offset, kTextSize);
+  EXPECT_EQ(first->body_size, 28u);
+  EXPECT_EQ(second->body_offset, kTextSize + 28u);
+  EXPECT_EQ(planner.appended_end(), kTextSize + 40u);
+  EXPECT_FALSE(planner.plan_indirect_appended(
+      /*anchor_offset=*/0, /*original_size=*/4, /*body_size=*/4));
+}
+
+TEST(DbiPatchPlacementPlanner, ReservesStableAppendedPrefixBeforeIndirectBodies) {
+  constexpr uint64_t kTextSize = 4096u;
+  DbiPatchPlacementPlanner planner(ROCJITSU_CODE_ARCH_RDNA4, kTextSize);
+
+  EXPECT_TRUE(planner.reserve_appended_prefix(/*size=*/56));
+  EXPECT_EQ(planner.appended_end(), kTextSize + 56u);
+  const auto body = planner.plan_indirect_appended(
+      /*anchor_offset=*/16, /*original_size=*/8, /*body_size=*/80);
+
+  ASSERT_TRUE(body);
+  EXPECT_EQ(body->body_offset, kTextSize + 56u);
+  EXPECT_EQ(planner.appended_end(), kTextSize + 136u);
+}
+
+TEST(SoppBranchRelayPlanner, AssignsInterchangeableIslandsAtMaximumCardinality) {
+  const std::vector<uint64_t> sources = {16, 0, 32};
+  const std::vector<uint64_t> islands = {96, 80};
+  const auto plan = plan_forward_sopp_branch_relays(sources, {}, islands);
+
+  ASSERT_TRUE(plan);
+  ASSERT_EQ(plan->routes.size(), 2u);
+  EXPECT_EQ(plan->routes[0].source_index, 0u);
+  EXPECT_EQ(plan->routes[0].island_offset, 96u);
+  EXPECT_TRUE(plan->routes[0].relay_offsets.empty());
+  EXPECT_EQ(plan->routes[1].source_index, 1u);
+  EXPECT_EQ(plan->routes[1].island_offset, 80u);
+  EXPECT_EQ(plan->rejected_source_indices, std::vector<size_t>({2}));
+}
+
+TEST(SoppBranchRelayPlanner, ReachesLongTextThroughCapacityOneRelayWords) {
+  constexpr uint64_t kMaximumForwardHop = 4u + 32767u * 4u;
+  const std::vector<uint64_t> sources = {0, 16};
+  const std::vector<uint64_t> relays = {kMaximumForwardHop, kMaximumForwardHop + 16};
+  const std::vector<uint64_t> islands = {2 * kMaximumForwardHop, 2 * kMaximumForwardHop + 16};
+  const auto plan = plan_forward_sopp_branch_relays(sources, relays, islands);
+
+  ASSERT_TRUE(plan);
+  ASSERT_EQ(plan->routes.size(), 2u);
+  EXPECT_TRUE(plan->rejected_source_indices.empty());
+  for (const SoppBranchRelayRoute &route : plan->routes) {
+    ASSERT_EQ(route.relay_offsets.size(), 1u);
+    ASSERT_TRUE(compute_sopp_branch_simm16(sources[route.source_index], route.relay_offsets[0]));
+    EXPECT_TRUE(compute_sopp_branch_simm16(route.relay_offsets[0], route.island_offset));
+  }
+  EXPECT_NE(plan->routes[0].relay_offsets[0], plan->routes[1].relay_offsets[0]);
+  EXPECT_NE(plan->routes[0].island_offset, plan->routes[1].island_offset);
+}
+
+TEST(SoppBranchRelayPlanner, UsesDistinctRelaysToAdmitAllFeasibleSources) {
+  constexpr uint64_t kHop = 4u + 32767u * 4u;
+  const std::vector<uint64_t> sources = {0, 8};
+  const std::vector<uint64_t> relays = {kHop, kHop + 8};
+  const std::vector<uint64_t> islands = {2 * kHop, 2 * kHop + 8};
+  const auto plan = plan_forward_sopp_branch_relays(sources, relays, islands);
+
+  ASSERT_TRUE(plan);
+  EXPECT_EQ(plan->routes.size(), 2u);
+  EXPECT_TRUE(plan->rejected_source_indices.empty());
+}
+
+TEST(SoppBranchRelayPlanner, SharesNeitherRelayNorIslandAcrossRoutes) {
+  constexpr uint64_t kHop = 4u + 32767u * 4u;
+  const std::vector<uint64_t> sources = {0, 8};
+  const std::vector<uint64_t> relays = {kHop};
+  const std::vector<uint64_t> islands = {2 * kHop, 2 * kHop + 4};
+  const auto plan = plan_forward_sopp_branch_relays(sources, relays, islands);
+
+  ASSERT_TRUE(plan);
+  EXPECT_EQ(plan->routes.size(), 1u);
+  EXPECT_EQ(plan->rejected_source_indices.size(), 1u);
+}
+
+TEST(SoppBranchRelayPlanner, RejectsUnalignedOrAliasedCoordinates) {
+  std::string error;
+  EXPECT_FALSE(plan_forward_sopp_branch_relays(std::vector<uint64_t>{2}, {},
+                                               std::vector<uint64_t>{16}, &error));
+  EXPECT_NE(error.find("aligned"), std::string::npos);
+
+  error.clear();
+  EXPECT_FALSE(plan_forward_sopp_branch_relays(std::vector<uint64_t>{0}, std::vector<uint64_t>{16},
+                                               std::vector<uint64_t>{16}, &error));
+  EXPECT_NE(error.find("unique"), std::string::npos);
+}
+
 // NOTE: the inline-nop guardrail used to live in TrampolineBuilder and was
 // tested here. It has been moved to the orchestrator boundary as
 // validate_inline_nop_plan() in instrumentor.h, and the test moved with it


### PR DESCRIPTION
Large native probes cannot assume inline padding or one reachable appended cave. Multiple instrumentation clients also need a common allocator so failed or overlapping placement attempts never partially consume text space.

Add deterministic maximum-cardinality SOPP relay routing, transactional inline/local/appended cave placement, and reusable RDNA4-family instruction builders. Extend patch debug records with trampoline sizes so clients can account for every emitted byte.

Dedicated unit tests pin exact encodings, operand rejection, relay capacity and reachability, overlap rollback, stable prefixes, and sequential cave mappings.

ISSUE ID : #8701
