### PR TITLE
feat(rocjitsu): Add transactional AMDGPU VGPR spilling for DBI

### DIFF
--- a/emulation/rocjitsu/CONTRIBUTING.md
+++ b/emulation/rocjitsu/CONTRIBUTING.md
@@ -53,7 +53,8 @@ Before writing new infrastructure, check these existing libraries:
 - **Register sets** — `isa/register_set.h` for ISA-independent register
   file modeling (SGPR/VGPR/AccVGPR bitsets).
 - **Spill manager** — `code/patch/spill_manager.h` for scratch layout
-  planning (DBI spill/fill slots).
+  planning and gfx1201 VGPR save/restore sequences. See
+  [docs/spilling.md](docs/spilling.md).
 - **Instruction builder** — `code/patch/instruction_builder.h` for
   encoding common instructions (`s_branch`, `s_nop`, etc.).
 

--- a/emulation/rocjitsu/README.md
+++ b/emulation/rocjitsu/README.md
@@ -117,6 +117,7 @@ See [docs/building.md](docs/building.md) for container setup with PyTorch.
 | [Simdojo Engine](docs/simdojo.md) | PDES simulation framework |
 | [DBT Design](docs/dbt-design.md) | Binary translator architecture |
 | [DBI Design](docs/dbi-design.md) | Binary instrumentation (in progress) |
+| [AMDGPU Register Spilling](docs/spilling.md) | Reusable DBI private-layout and VGPR save/restore backend |
 | [Codegen](docs/codegen.md) | ISA codegen pipeline and regen commands |
 
 ### Reference

--- a/emulation/rocjitsu/docs/dbi-design.md
+++ b/emulation/rocjitsu/docs/dbi-design.md
@@ -4,7 +4,7 @@
 
 The Dynamic Binary Instrumentation (DBI) system patches AMDGPU HSA code objects in-place, before they are loaded into device memory, to inject code at chosen anchor instructions. Patched code objects can be loaded by either the simulated KMD (`SimulatedDriver`) or — eventually — by real ROCR via the HSA tools layer (`HSA_TOOLS_LIB=librocjitsu_hooks.so`). DBI itself is target-agnostic at the layer boundary; per-ISA differences are confined to the instruction builder and decoder.
 
-This document describes the DBI subsystem as currently implemented. Two end-to-end trampoline shapes are in tree: the original *inline-nop* trampoline, and a *probe call* that invokes a copied no-op probe body (`rj_nop_probe`) via `s_swappc_b64` before the relocated original. Multiple instrumentation points per code object are supported. Still future work: per-site failure tolerance, predicate-based anchor selection, EXEC-policy management, `AfterInst` / `BlockEntry` / `BlockExit` kinds, layout/negotiation between the builder and the orchestrator, register **spilling** (non-empty spill sets currently fail closed), and **automatic SGPR-count growth** so the probe's link pair is always granted (see [Probe-call register requirement](#instrumentation-flow-probe-call)).
+This document describes the DBI subsystem as currently implemented. Two end-to-end trampoline shapes are in tree: the original *inline-nop* trampoline, and a *probe call* that invokes a copied no-op probe body (`rj_nop_probe`) via `s_swappc_b64` before the relocated original. Multiple instrumentation points per code object are supported. A reusable gfx1201 VGPR spilling backend is documented in [AMDGPU register spilling](spilling.md), although the legacy probe-call path still fails closed for non-empty spill sets. Still future work for that path includes per-site failure tolerance, predicate-based anchor selection, EXEC-policy management, `AfterInst` / `BlockEntry` / `BlockExit` kinds, layout/negotiation between the builder and the orchestrator, integration with the spill backend, and automatic SGPR-count growth so the probe's link pair is always granted (see [Probe-call register requirement](#instrumentation-flow-probe-call)).
 
 ---
 
@@ -184,19 +184,26 @@ Ordinary SGPRs, VGPRs, and AccVGPRs via `RegisterSet`. `InstDefUse` records expl
 
 **Files:** `code/patch/spill_manager.h`, `code/patch/spill_manager.cpp`
 
-Per-kernel scratch-layout planner for DBI spill/fill slots. Probe-call trampolines will use it to reserve byte offsets within per-lane scratch where saved SGPRs / VGPRs / AccVGPRs go before a probe runs and from which they are restored after. Not consumed by the inline-nop pipeline.
+Per-kernel scratch-layout planner and gfx1201 ordinary-VGPR save/restore backend. DBI clients use it to reserve byte offsets within per-lane scratch, emit fixed-offset or caller-qualified dynamic-stack sequences, and coordinate authoritative kernel-descriptor growth. The legacy probe-call and inline-nop pipelines do not yet consume it. See [AMDGPU register spilling](spilling.md) for the complete contract.
 
 #### Responsibilities
 
 - Reserve a "DBI spill zone" appended above the kernel's existing `private_segment_fixed_size`, aligned to 16 bytes.
 - Hand out stable per-register byte offsets within that zone. Registers cannot get more than one offset.
 - Enforce a hard per-lane scratch cap. Allocations that would push the bumped total past the cap fail; on failure the manager state is unchanged.
-- Compute the bumped `private_segment_fixed_size` that the kernel descriptor patcher will write back.
+- Compute and apply the bumped `private_segment_fixed_size`, including
+  zero-to-nonzero private-segment enablement.
+- Emit fixed-offset and caller-qualified dynamic-stack ordinary-VGPR save and
+  restore sequences for gfx1201.
 
 #### What it is not
 
 - Not a memory allocator. SpillManager only computes layout.
-- Not the code generator. SpillManager hands out offsets; emitting the actual `scratch_store` / `scratch_load` (or equivalents) will be the trampoline builder's job.
+- Not a victim selector. The caller must prove register liveness, ownership,
+  and placement safety.
+- Not a general code generator. The backend emits only its supported gfx1201
+  VGPR sequences; other targets and register classes remain client-visible
+  failures.
 - Not an MFMA-clobber tracker. AccVGPR clobbering by long-latency MFMA is deferred.
 
 #### Public API

--- a/emulation/rocjitsu/docs/spilling.md
+++ b/emulation/rocjitsu/docs/spilling.md
@@ -1,0 +1,218 @@
+# AMDGPU Register Spilling for DBI
+
+RocJitsu provides a reusable register-spilling backend for post-allocation
+dynamic binary instrumentation (DBI). It reserves per-lane private memory,
+emits save and restore sequences for borrowed VGPRs, and keeps the kernel
+descriptor consistent with any added private storage.
+
+The backend is deliberately smaller than a compiler register allocator. A DBI
+client remains responsible for deciding which registers may be borrowed, where
+the sequence belongs, and which kernels can reach the patched instruction.
+
+## Credit and provenance
+
+This implementation builds on Kunwar Grover's text-relocation work in
+`users/Groverkss/text-relocation-land`. That work established the direction of
+requesting semantic scratch registers, preferring liveness-proven registers,
+assigning stable per-lane spill storage, and bracketing transformed code with
+save and restore sequences.
+
+RocJitsu shares the `PrivateSegmentCursor` range-allocation abstraction with
+that work. The DBI backend adds transactional multi-register reservations,
+RDNA4 save and restore emission, kernel-descriptor updates, and focused tests.
+Kunwar's broader DBT and CDNA3 text-relocation implementation is not a
+dependency of this backend. In particular, both implementations deliberately
+avoid rewriting AMDGPU MessagePack notes for private-storage growth.
+
+## Responsibilities and boundaries
+
+The reusable implementation provides:
+
+- a monotonic allocator for ranges in a kernel private segment;
+- stable, idempotent register-to-slot assignment;
+- transactional reservation of a multi-register window;
+- fixed-offset gfx1201 save and restore sequences for ordinary VGPRs;
+- a gfx1201 site-local dynamic-stack frame sequence;
+- kernel-descriptor private-size updates.
+
+It does not provide:
+
+- register liveness or victim selection;
+- ownership analysis for text shared by multiple kernels;
+- SGPR or AccVGPR save and restore sequences;
+- code-cave placement or control-flow relocation;
+- dispatch-packet rewriting; or
+- a general calling convention for instrumentation bodies.
+
+Callers must fail closed when they cannot prove those surrounding properties.
+
+## Private-segment allocation
+
+`PrivateSegmentCursor` is the policy-free range allocator. Given a byte count,
+power-of-two alignment, and exclusive upper limit, `preview()` computes the
+next allocation without changing state and `allocate()` commits it. A failed
+request does not advance the high-water mark.
+
+`SpillManager` layers stable register identity on that cursor. It appends a
+DBI-owned spill zone after the compiler-owned fixed private segment:
+
+```text
+0                                      original_private_bytes
++-----------------------------------------------------------+
+| guest/compiler private segment                            |
++-----------------------------------------------------------+
+                         align up to 16 bytes
+                         |
+                         v
+                         +--------+--------+--------+
+DBI spill zone           | slot 0 | slot 1 |  ...   |
+                         +--------+--------+--------+
+                           4 B      4 B
+```
+
+Each 32-bit register lane receives one four-byte slot per work-item. A
+multi-lane register window receives consecutive slots. Reallocating the same
+register returns the original offset. `reserve()` and `allocate_slots()` check
+the complete request before committing, so capacity or encoding failure cannot
+leave a partially advanced layout.
+
+For text reachable from multiple kernels, the client must construct one
+compatible layout. A sound policy starts the shared zone at
+`align_up(max(original_private_bytes), 16)` and grows every owning descriptor to
+the resulting common extent. `SpillManager` does not discover those owners.
+
+## Fixed-offset gfx1201 sequences
+
+`build_vgpr_spill_sequence()` supports ordinary B32 VGPR windows on
+RDNA4/gfx1201. It reserves stable slots and returns separate save and restore
+word sequences plus the resulting private-segment size.
+
+Conceptually, the emitted sequence is:
+
+```text
+wait until outstanding guest loads complete
+scratch_store_b32 vN, private_offset_N
+...
+wait until scratch stores complete
+
+instrumentation may clobber vN...
+
+scratch_load_b32 vN, private_offset_N
+...
+wait until scratch loads complete
+resume guest code
+```
+
+The waits are intentionally conservative. The leading wait prevents a late
+guest load from overwriting a saved victim after the save point. The store
+wait ensures the value reaches private memory before instrumentation clobbers
+it, and the load wait ensures restoration completes before guest code consumes
+it.
+
+The instructions execute under the caller's current `EXEC` mask and do not
+change it. Instrumentation that narrows `EXEC` must restore the guest mask
+before the VGPR window is returned.
+
+Address-free gfx1201 scratch instructions impose a target-specific encodable
+private-offset limit. Requests outside that limit return `std::nullopt`
+without changing `SpillManager`.
+
+## Dynamic-stack sequences
+
+`build_dynamic_stack_vgpr_spill_sequence()` emits a site-local frame for a
+kernel whose compiler-generated scratch accesses use a runtime stack. The
+caller supplies the stack-top SGPR, frame-base SGPR, and scalar save registers.
+The sequence:
+
+1. preserves SCC and the incoming frame base;
+2. assigns the frame base from the current stack top;
+3. stores borrowed VGPRs at frame-relative offsets;
+4. advances the stack top by the temporary frame size;
+5. restores the VGPRs; and
+6. restores the stack top, frame base, and SCC state.
+
+This helper encodes a mechanism, not an ABI discovery policy. A client may use
+it only after proving the target kernel follows the supplied convention and
+that the scalar save registers are safe. Mixed conventions or unknown owners
+must be rejected.
+
+Dynamic-stack accesses remain frame-relative, but the runtime still needs
+enough backing storage for the maximum additional depth. The descriptor update
+therefore records the compiler maximum plus the instrumentation frame depth.
+
+## Descriptor and runtime updates
+
+`update_kernel_descriptor_for_spills()` grows one named kernel descriptor's
+private requirement and enables private-segment support when a kernel grows
+from zero private bytes. It preserves unrelated descriptor fields and does not
+shrink an existing allocation.
+
+ROCR derives the loaded kernel symbol's private size from
+`kernel_descriptor_t::private_segment_fixed_size`; it does not use the
+duplicated `.private_segment_fixed_size` value in the AMDGPU MessagePack note.
+That note is not a runtime authority and may be absent, stale, contradictory,
+or malformed. The spilling backend therefore neither reads nor rewrites it.
+
+The descriptor helper mutates the supplied image. A DBI client should perform
+register, layout, encoding, descriptor, and text-placement validation before
+committing its final code-object image. If text growth can move later ELF
+contents, resolve descriptors by stable kernel identity rather than retaining
+stale file offsets across mutations.
+
+The HSA dispatch packet also carries a private-segment size. Updating it is a
+runtime integration responsibility because the static spill backend does not
+intercept kernel loads or dispatches.
+
+## Supported boundary
+
+| Capability | Current state |
+|---|---|
+| Stable private slots | SGPR, VGPR, and AccVGPR identities can be assigned storage. |
+| Fixed-offset save/restore | Ordinary B32 VGPR windows on gfx1201. |
+| Dynamic-stack save/restore | Ordinary B32 VGPR windows on gfx1201, with caller-proven stack convention and scalar saves. |
+| Descriptor growth | Fixed and dynamic private backing, including zero-to-nonzero growth. |
+| AMDGPU metadata notes | Deliberately untouched; they are not a ROCR runtime authority. |
+| SGPR save/restore | Not implemented. |
+| AccVGPR save/restore | Not implemented. |
+| Other GPU targets | Not implemented by this backend. |
+
+Slot assignment for a register class does not imply a save and restore emitter
+exists for that class.
+
+## Failure contract
+
+The backend reports failure instead of emitting a partial sequence for:
+
+- an unsupported architecture or register class;
+- an invalid or overflowing register window;
+- private-size or scratch-offset overflow;
+- exhaustion of the caller-provided per-lane limit;
+- an invalid kernel descriptor;
+- an invalid dynamic-stack register recipe.
+
+Callers should preserve this distinction through their own diagnostics. A
+backend rejection is different from successfully instrumenting a kernel and
+observing no event.
+
+## Source and tests
+
+The implementation is in:
+
+- `lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.h`;
+- `lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.cpp`;
+- `lib/rocjitsu/src/rocjitsu/code/patch/rdna4_instrumentation_builder.h`.
+
+Focused tests are in `tests/patch/spill_manager_test.cpp`, with instruction
+encoding coverage in `tests/patch/rdna4_instrumentation_builder_test.cpp` and
+integration coverage in `tests/patch/trampoline_builder_test.cpp`.
+
+Run the focused host tests with:
+
+```sh
+"$ROCJITSU_BUILD_DIR/tests/rocjitsu_tests" \
+  --gtest_filter='PrivateSegmentCursor.*:SpillManager.*:InstructionBuilder.*'
+```
+
+See [DBI design](dbi-design.md) for the surrounding patch pipeline. Individual
+DBI clients should document their victim-selection, ownership, dispatch, and
+runtime policies separately.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.cpp
@@ -3,10 +3,20 @@
 
 #include "rocjitsu/code/patch/spill_manager.h"
 
+#include "rocjitsu/base/rj_compiler.h"
+#include "rocjitsu/code/patch/instruction_builder.h"
+#include "rocjitsu/code/patch/rdna4_instrumentation_builder.h"
 #include "util/bit.h"
 
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "hsa/AMDHSAKernelDescriptor.h"
+RJ_DIAGNOSTIC_POP
+
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstring>
 #include <limits>
 #include <utility> // for std::pair
 
@@ -33,8 +43,8 @@ namespace {
 } // namespace
 
 SpillManager::SpillManager(uint32_t original_private_bytes, uint32_t per_lane_scratch_limit)
-    : base_offset_(util::align_up(original_private_bytes, kDbiZoneAlignment)),
-      total_bytes_(base_offset_), limit_(per_lane_scratch_limit), next_offset_(base_offset_) {}
+    : limit_(per_lane_scratch_limit),
+      slots_(util::align_up(original_private_bytes, kDbiZoneAlignment)) {}
 
 std::optional<uint32_t> SpillManager::allocate_slot(RegisterRef reg) {
   // Reject indices past the per-class hardware bound (or unsupported classes
@@ -49,14 +59,10 @@ std::optional<uint32_t> SpillManager::allocate_slot(RegisterRef reg) {
   if (reg.index >= per_class_max(reg.cls)) {
     return std::nullopt;
   }
-  // Overflow-safe equivalent of `next_offset_ + kSlotBytes > limit_`.
-  if (static_cast<uint64_t>(next_offset_) + kSlotBytes > limit_) {
+  auto offset = slots_.allocate(kSlotBytes, kSlotBytes, limit_);
+  if (!offset)
     return std::nullopt;
-  }
-  const uint32_t offset = next_offset_;
-  next_offset_ += kSlotBytes;
-  total_bytes_ = next_offset_;
-  reg_to_offset_.emplace(key, offset);
+  reg_to_offset_.emplace(key, *offset);
   return offset;
 }
 
@@ -95,7 +101,7 @@ bool SpillManager::reserve(const RegisterSet &set) {
     if (!reg_to_offset_.contains(key))
       ++num_new;
   });
-  if (num_new > 0 && static_cast<uint64_t>(next_offset_) + kSlotBytes * num_new > limit_) {
+  if (num_new > 0 && !slots_.preview(kSlotBytes * num_new, kSlotBytes, limit_)) {
     return false;
   }
 
@@ -116,6 +122,147 @@ std::optional<uint32_t> SpillManager::offset_for(RegisterRef reg) const {
     return std::nullopt;
   }
   return it->second;
+}
+
+std::optional<VgprSpillSequence> build_vgpr_spill_sequence(SpillManager &manager,
+                                                           uint16_t vgpr_base, uint16_t vgpr_count,
+                                                           rj_code_arch_t arch) {
+  if (arch != ROCJITSU_CODE_ARCH_RDNA4 || vgpr_count == 0 ||
+      static_cast<uint32_t>(vgpr_base) + vgpr_count > REGISTER_SET_MAX_VGPRS) {
+    return std::nullopt;
+  }
+
+  SpillManager planned_manager = manager;
+  const auto first_offset =
+      planned_manager.allocate_slots(RegisterRef{RegClass::VGPR, vgpr_base, 1}, vgpr_count);
+  if (!first_offset || planned_manager.total_private_bytes() > kMaxAddressFreeScratchPrivateBytes) {
+    return std::nullopt;
+  }
+
+  const auto wait_store = build_s_wait_storecnt0(arch);
+  const auto wait_load = build_s_wait_loadcnt0(arch);
+  if (!wait_store || !wait_load)
+    return std::nullopt;
+
+  VgprSpillSequence sequence;
+  sequence.vgpr_base = vgpr_base;
+  sequence.vgpr_count = vgpr_count;
+  sequence.slot_offsets.reserve(vgpr_count);
+  // A live VGPR can still have an outstanding asynchronous definition at the
+  // patch point. Drain loads before observing spill victims; otherwise the
+  // later definition can complete after the save and the restore will write
+  // the stale pre-definition value over it. Probe bodies already drain these
+  // counters, so making the drain explicit before the save preserves the
+  // guest value without introducing an additional ordering boundary.
+  sequence.save_words.reserve(static_cast<size_t>(vgpr_count) * 3u + 2u);
+  sequence.restore_words.reserve(static_cast<size_t>(vgpr_count) * 3u + 1u);
+  sequence.save_words.push_back(*wait_load);
+  for (uint16_t i = 0; i < vgpr_count; ++i) {
+    const uint16_t vgpr = static_cast<uint16_t>(vgpr_base + i);
+    const auto offset = planned_manager.offset_for(RegisterRef{RegClass::VGPR, vgpr, 1});
+    if (!offset)
+      return std::nullopt;
+    const auto store = build_address_free_scratch_store_b32(vgpr, *offset, arch);
+    const auto load = build_address_free_scratch_load_b32(vgpr, *offset, arch);
+    if (!store || !load)
+      return std::nullopt;
+    sequence.slot_offsets.push_back(*offset);
+    sequence.save_words.insert(sequence.save_words.end(), store->begin(), store->end());
+    sequence.restore_words.insert(sequence.restore_words.end(), load->begin(), load->end());
+  }
+  sequence.save_words.push_back(*wait_store);
+  sequence.restore_words.push_back(*wait_load);
+  sequence.total_private_bytes = planned_manager.total_private_bytes();
+  manager = std::move(planned_manager);
+  return sequence;
+}
+
+std::optional<VgprSpillSequence> build_dynamic_stack_vgpr_spill_sequence(
+    uint16_t vgpr_base, uint16_t vgpr_count, uint16_t stack_top_sgpr, uint16_t frame_base_sgpr,
+    uint16_t saved_frame_base_sgpr, uint16_t saved_scc_sgpr, rj_code_arch_t arch) {
+  if (arch != ROCJITSU_CODE_ARCH_RDNA4 || vgpr_count == 0 ||
+      static_cast<uint32_t>(vgpr_base) + vgpr_count > REGISTER_SET_MAX_VGPRS ||
+      stack_top_sgpr > 127 || frame_base_sgpr > 127 || saved_frame_base_sgpr > 127 ||
+      saved_scc_sgpr > 127 || saved_frame_base_sgpr == stack_top_sgpr ||
+      saved_frame_base_sgpr == frame_base_sgpr || saved_scc_sgpr == stack_top_sgpr ||
+      saved_scc_sgpr == frame_base_sgpr || saved_scc_sgpr == saved_frame_base_sgpr) {
+    return std::nullopt;
+  }
+
+  const uint32_t frame_bytes = static_cast<uint32_t>(vgpr_count) * SpillManager::kSlotBytes;
+  if (frame_bytes > kMaxAddressFreeScratchPrivateBytes)
+    return std::nullopt;
+  const auto wait_store = build_s_wait_storecnt0(arch);
+  const auto wait_load = build_s_wait_loadcnt0(arch);
+  const auto capture_scc = build_rdna4_s_cselect_b32(saved_scc_sgpr, scalar_positive_inline_u32(1),
+                                                     scalar_positive_inline_u32(0), arch);
+  const auto advance_stack =
+      build_rdna4_s_add_u32(stack_top_sgpr, stack_top_sgpr, /*literal source=*/255u, arch);
+  const auto restore_scc =
+      build_rdna4_s_cmp_lg_u32(saved_scc_sgpr, scalar_positive_inline_u32(0), arch);
+  if (!wait_store || !wait_load || !capture_scc || !advance_stack || !restore_scc)
+    return std::nullopt;
+
+  VgprSpillSequence sequence;
+  sequence.vgpr_base = vgpr_base;
+  sequence.vgpr_count = vgpr_count;
+  sequence.uses_dynamic_stack_frame = true;
+  sequence.slot_offsets.reserve(vgpr_count);
+  sequence.save_words.reserve(static_cast<size_t>(vgpr_count) * 3u + 8u);
+  sequence.restore_words.reserve(static_cast<size_t>(vgpr_count) * 3u + 3u);
+  sequence.save_words.push_back(*wait_load);
+  sequence.save_words.push_back(*capture_scc);
+  sequence.save_words.push_back(build_s_mov_b32(saved_frame_base_sgpr, frame_base_sgpr, arch));
+  sequence.save_words.push_back(build_s_mov_b32(frame_base_sgpr, stack_top_sgpr, arch));
+  for (uint16_t i = 0; i < vgpr_count; ++i) {
+    const uint16_t vgpr = static_cast<uint16_t>(vgpr_base + i);
+    const uint32_t offset = static_cast<uint32_t>(i) * SpillManager::kSlotBytes;
+    const auto store = build_scratch_store_b32_saddr(vgpr, frame_base_sgpr, offset, arch);
+    const auto load = build_scratch_load_b32_saddr(vgpr, frame_base_sgpr, offset, arch);
+    if (!store || !load)
+      return std::nullopt;
+    sequence.slot_offsets.push_back(offset);
+    sequence.save_words.insert(sequence.save_words.end(), store->begin(), store->end());
+    sequence.restore_words.insert(sequence.restore_words.end(), load->begin(), load->end());
+  }
+  sequence.save_words.push_back(*wait_store);
+  sequence.save_words.push_back(*advance_stack);
+  sequence.save_words.push_back(frame_bytes);
+  sequence.save_words.push_back(*restore_scc);
+  sequence.restore_words.push_back(*wait_load);
+  sequence.restore_words.push_back(build_s_mov_b32(stack_top_sgpr, frame_base_sgpr, arch));
+  sequence.restore_words.push_back(build_s_mov_b32(frame_base_sgpr, saved_frame_base_sgpr, arch));
+  return sequence;
+}
+
+SpillDescriptorUpdate update_kernel_descriptor_for_spills(std::span<uint8_t> image,
+                                                          uint64_t descriptor_file_offset,
+                                                          uint32_t required_private_bytes,
+                                                          bool uses_dynamic_stack) {
+  using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
+  namespace kd = rocr::llvm::amdhsa;
+  (void)uses_dynamic_stack;
+  if (required_private_bytes == 0 || required_private_bytes > kMaxAddressFreeScratchPrivateBytes) {
+    return SpillDescriptorUpdate::InvalidPrivateSize;
+  }
+  if (descriptor_file_offset > image.size() || sizeof(KD) > image.size() - descriptor_file_offset) {
+    return SpillDescriptorUpdate::InvalidDescriptor;
+  }
+
+  KD descriptor{};
+  std::memcpy(&descriptor, image.data() + descriptor_file_offset, sizeof(descriptor));
+  const uint32_t grown_private_bytes =
+      std::max(descriptor.private_segment_fixed_size, required_private_bytes);
+  const bool private_segment_enabled =
+      AMDHSA_BITS_GET(descriptor.compute_pgm_rsrc2, kd::COMPUTE_PGM_RSRC2_ENABLE_PRIVATE_SEGMENT) !=
+      0;
+  if (grown_private_bytes == descriptor.private_segment_fixed_size && private_segment_enabled)
+    return SpillDescriptorUpdate::Unchanged;
+
+  descriptor.private_segment_fixed_size = grown_private_bytes;
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc2, kd::COMPUTE_PGM_RSRC2_ENABLE_PRIVATE_SEGMENT, 1u);
+  std::memcpy(image.data() + descriptor_file_offset, &descriptor, sizeof(descriptor));
+  return SpillDescriptorUpdate::Updated;
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.h
@@ -7,15 +7,67 @@
 #ifndef ROCJITSU_CODE_PATCH_SPILL_MANAGER_H_
 #define ROCJITSU_CODE_PATCH_SPILL_MANAGER_H_
 
+#include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/register_set.h"
+#include "util/bit.h"
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <optional>
+#include <span>
 #include <unordered_map>
 #include <utility> // for std::pair
+#include <vector>
 
 namespace rocjitsu {
+
+/// @brief Monotonic byte-range allocator for one kernel's private segment.
+///
+/// @details This deliberately knows nothing about register identity or spill
+/// lifetime. DBI layers stable register-to-slot mapping on top; semantic DBT
+/// creates short-lived frames on top. Keeping the common range arithmetic next
+/// to SpillManager avoids a separate one-struct allocator header while both
+/// users retain their independent allocation policies.
+class PrivateSegmentCursor final {
+public:
+  /// @brief Begin allocation at the first byte not owned by an earlier policy.
+  explicit PrivateSegmentCursor(uint32_t first_byte) : cursor_(first_byte) {}
+
+  /// @brief Compute the next aligned allocation without advancing the cursor.
+  /// @param byte_count Number of contiguous bytes requested.
+  /// @param alignment Required power-of-two byte alignment for the returned base.
+  /// @param limit Exclusive upper bound for the allocation.
+  /// @returns The aligned base, or std::nullopt for an invalid or overflowing range.
+  [[nodiscard]] std::optional<uint32_t>
+  preview(uint32_t byte_count, uint32_t alignment,
+          uint32_t limit = std::numeric_limits<uint32_t>::max()) const {
+    if (byte_count == 0 || alignment == 0)
+      return std::nullopt;
+    const uint64_t base =
+        util::align_up(static_cast<uint64_t>(cursor_), static_cast<uint64_t>(alignment));
+    if (base + byte_count > limit)
+      return std::nullopt;
+    return static_cast<uint32_t>(base);
+  }
+
+  /// @brief Allocate the next aligned range and advance the high-water mark.
+  [[nodiscard]] std::optional<uint32_t>
+  allocate(uint32_t byte_count, uint32_t alignment,
+           uint32_t limit = std::numeric_limits<uint32_t>::max()) {
+    auto base = preview(byte_count, alignment, limit);
+    if (!base)
+      return std::nullopt;
+    cursor_ = *base + byte_count;
+    return base;
+  }
+
+  /// @brief One-past-end byte of all successfully allocated ranges.
+  [[nodiscard]] uint32_t high_water_mark() const { return cursor_; }
+
+private:
+  uint32_t cursor_ = 0;
+};
 
 /// @brief Per-kernel scratch reservation for DBI spill/fill slots.
 ///
@@ -75,7 +127,7 @@ public:
   [[nodiscard]] bool reserve(const RegisterSet &set);
 
   /// @returns The bumped total per-lane scratch bytes.
-  [[nodiscard]] uint32_t total_private_bytes() const { return total_bytes_; }
+  [[nodiscard]] uint32_t total_private_bytes() const { return slots_.high_water_mark(); }
 
   /// @returns Slot offset previously allocated for @p reg, or nullopt.
   [[nodiscard]] std::optional<uint32_t> offset_for(RegisterRef reg) const;
@@ -89,12 +141,68 @@ private:
     }
   };
 
-  uint32_t base_offset_; ///< First DBI slot. align_up(orig, 16).
-  uint32_t total_bytes_; ///< Bumped private_segment_fixed_size.
-  uint32_t limit_;       ///< Hard per-lane scratch cap (inclusive: offset+kSlotBytes <= limit OK).
-  uint32_t next_offset_; ///< Next free byte within DBI zone.
+  uint32_t limit_;             ///< Hard per-lane scratch cap (end <= limit is valid).
+  PrivateSegmentCursor slots_; ///< Shared range arithmetic; DBI owns stable slot identity.
   std::unordered_map<std::pair<RegClass, uint16_t>, uint32_t, RegKeyHash> reg_to_offset_;
 };
+
+/// @brief Standalone save/restore program for one ordinary VGPR window.
+///
+/// @details Each register receives one stable B32 per-lane slot. Save and
+/// restore end in zero-threshold waits so callers can safely clobber the
+/// window after save and resume guest code after restore. The instructions
+/// run under the caller's current EXEC mask and do not modify EXEC. These
+/// conservative waits also drain older wave scratch stores/loads; relaxing
+/// that ordering requires a hardware-backed same-address ordering proof.
+struct VgprSpillSequence {
+  uint16_t vgpr_base = 0;
+  uint16_t vgpr_count = 0;
+  std::vector<uint32_t> slot_offsets;
+  std::vector<uint32_t> save_words;
+  std::vector<uint32_t> restore_words;
+  uint32_t total_private_bytes = 0;
+  bool uses_dynamic_stack_frame = false;
+};
+
+/// @brief Reserve slots and encode a gfx1201 VGPR spill/fill sequence.
+///
+/// @returns A complete sequence, or nullopt for an unsupported architecture,
+/// invalid VGPR range, unencodable slot, or capacity failure. On failure
+/// @p manager is unchanged.
+[[nodiscard]] std::optional<VgprSpillSequence> build_vgpr_spill_sequence(SpillManager &manager,
+                                                                         uint16_t vgpr_base,
+                                                                         uint16_t vgpr_count,
+                                                                         rj_code_arch_t arch);
+
+/// @brief Encode a site-local dynamic-stack frame around one VGPR spill window.
+///
+/// @details Follows the AMDGPU callable-function convention used by dynamic
+/// stack kernels: save the current frame base, set it to the stack top,
+/// advance the top by the temporary frame size, then reverse those operations
+/// after filling the VGPRs. The SCC value is restored before guest code runs.
+/// No descriptor growth is needed because the loader already
+/// allocates the kernel's dynamic stack.
+[[nodiscard]] std::optional<VgprSpillSequence> build_dynamic_stack_vgpr_spill_sequence(
+    uint16_t vgpr_base, uint16_t vgpr_count, uint16_t stack_top_sgpr, uint16_t frame_base_sgpr,
+    uint16_t saved_frame_base_sgpr, uint16_t saved_scc_sgpr, rj_code_arch_t arch);
+
+enum class SpillDescriptorUpdate : uint8_t {
+  Updated,
+  Unchanged,
+  InvalidDescriptor,
+  InvalidPrivateSize,
+  DynamicStack,
+};
+
+/// @brief Grow one kernel descriptor's fixed private segment for spill slots.
+///
+/// @details Sets ENABLE_PRIVATE_SEGMENT when needed and preserves all other
+/// descriptor fields. For a dynamic-stack spill frame, @p required_private_bytes
+/// is the compiler maximum plus the instrumentation frame depth; the emitted
+/// accesses remain relative to the runtime frame base.
+[[nodiscard]] SpillDescriptorUpdate
+update_kernel_descriptor_for_spills(std::span<uint8_t> image, uint64_t descriptor_file_offset,
+                                    uint32_t required_private_bytes, bool uses_dynamic_stack);
 
 } // namespace rocjitsu
 

--- a/emulation/rocjitsu/tests/patch/spill_manager_test.cpp
+++ b/emulation/rocjitsu/tests/patch/spill_manager_test.cpp
@@ -4,12 +4,21 @@
 #include "rocjitsu/code/patch/spill_manager.h"
 
 #include "rocjitsu/analysis/liveness.h"
+#include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/basic_block.h"
 #include "rocjitsu/code/code_object.h"
+#include "rocjitsu/code/patch/instruction_builder.h"
+#include "rocjitsu/code/patch/rdna4_instrumentation_builder.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/operand.h"
 #include "rocjitsu/isa/register_set.h"
+
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "hsa/AMDHSAKernelDescriptor.h"
+RJ_DIAGNOSTIC_POP
 
 #include <gtest/gtest.h>
 
@@ -28,10 +37,73 @@ namespace rocjitsu {
 namespace {
 
 constexpr uint32_t kBigLimit = 16384;
+constexpr uint64_t kAdversarialDescriptorOffset = 0x80;
+constexpr uint64_t kMetadataNoteOffset = 0x100;
 
 RegisterRef sgpr(uint16_t i) { return RegisterRef{RegClass::SGPR, i, 1}; }
 RegisterRef vgpr(uint16_t i) { return RegisterRef{RegClass::VGPR, i, 1}; }
 RegisterRef accvgpr(uint16_t i) { return RegisterRef{RegClass::ACC_VGPR, i, 1}; }
+
+TEST(PrivateSegmentCursor, PreviewIsAlignedAndNonMutating) {
+  PrivateSegmentCursor cursor(/*first_byte=*/18);
+  EXPECT_EQ(cursor.preview(/*byte_count=*/8, /*alignment=*/16, /*limit=*/64), 32u);
+  EXPECT_EQ(cursor.high_water_mark(), 18u);
+
+  EXPECT_EQ(cursor.allocate(/*byte_count=*/8, /*alignment=*/16, /*limit=*/64), 32u);
+  EXPECT_EQ(cursor.high_water_mark(), 40u);
+}
+
+TEST(PrivateSegmentCursor, FailedAllocationDoesNotAdvance) {
+  PrivateSegmentCursor cursor(/*first_byte=*/60);
+  EXPECT_EQ(cursor.allocate(/*byte_count=*/8, /*alignment=*/4, /*limit=*/64), std::nullopt);
+  EXPECT_EQ(cursor.high_water_mark(), 60u);
+  EXPECT_EQ(cursor.allocate(/*byte_count=*/4, /*alignment=*/4, /*limit=*/64), 60u);
+  EXPECT_EQ(cursor.high_water_mark(), 64u);
+}
+
+std::vector<uint8_t> make_metadata_note_elf() {
+  std::vector<uint8_t> payload;
+  auto append_string = [&](std::string_view value) {
+    EXPECT_LE(value.size(), 31u);
+    payload.push_back(static_cast<uint8_t>(0xa0u | value.size()));
+    payload.insert(payload.end(), value.begin(), value.end());
+  };
+  payload.push_back(0x81u); // root map(1)
+  append_string("amdhsa.kernels");
+  payload.push_back(0x92u); // array(2)
+  for (std::string_view name : {std::string_view("target"), std::string_view("other")}) {
+    payload.push_back(0x82u); // kernel map(2)
+    append_string(".name");
+    append_string(name);
+    append_string(".private_segment_fixed_size");
+    payload.push_back(0u);
+  }
+
+  constexpr std::array<uint8_t, 8> kNoteName = {'A', 'M', 'D', 'G', 'P', 'U', 0, 0};
+  const uint64_t note_size = sizeof(Elf64_Nhdr) + kNoteName.size() + ((payload.size() + 3u) & ~3u);
+  std::vector<uint8_t> image(kMetadataNoteOffset + note_size, 0);
+  Elf64_Ehdr header{};
+  std::memcpy(header.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
+  header.e_phoff = sizeof(Elf64_Ehdr);
+  header.e_phentsize = sizeof(Elf64_Phdr);
+  header.e_phnum = 1;
+  std::memcpy(image.data(), &header, sizeof(header));
+  Elf64_Phdr program_header{};
+  program_header.p_type = PT_NOTE;
+  program_header.p_offset = kMetadataNoteOffset;
+  program_header.p_filesz = note_size;
+  std::memcpy(image.data() + header.e_phoff, &program_header, sizeof(program_header));
+  Elf64_Nhdr note{};
+  note.n_namesz = 7;
+  note.n_descsz = static_cast<uint32_t>(payload.size());
+  note.n_type = NT_AMDGPU_METADATA;
+  std::memcpy(image.data() + kMetadataNoteOffset, &note, sizeof(note));
+  std::memcpy(image.data() + kMetadataNoteOffset + sizeof(note), kNoteName.data(),
+              kNoteName.size());
+  std::memcpy(image.data() + kMetadataNoteOffset + sizeof(note) + kNoteName.size(), payload.data(),
+              payload.size());
+  return image;
+}
 
 // Minimal synthetic Operand/Instruction/CodeObject/Decoder for integration
 // tests. Mirrors the pattern in tests/analysis/liveness_test.cpp;
@@ -381,8 +453,8 @@ TEST(SpillManager, AllocateSlotsRollsBackOnPartialOverflow) {
   EXPECT_EQ(m.offset_for(sgpr(6)), std::nullopt);
   EXPECT_EQ(m.offset_for(sgpr(7)), std::nullopt);
 
-  // Proves next_offset_ was actually rewound (not just total_bytes_): a
-  // subsequent single-slot allocation lands at the rolled-back cursor.
+  // Proves the allocation cursor was not advanced: a subsequent single-slot
+  // allocation lands at the original high-water mark.
   auto recovered = m.allocate_slot(sgpr(6));
   ASSERT_TRUE(recovered.has_value());
   EXPECT_EQ(*recovered, 8u);
@@ -513,6 +585,192 @@ TEST(SpillManager, ConstructorOverLimitFailsAllAllocations) {
   RegisterSet set;
   set.expand(sgpr(2));
   EXPECT_FALSE(m.reserve(set));
+}
+
+TEST(SpillManager, BuildsGfx1201VgprSaveRestoreSequence) {
+  SpillManager manager(/*original_private_bytes=*/0, kMaxAddressFreeScratchPrivateBytes);
+  const auto sequence = build_vgpr_spill_sequence(manager, /*vgpr_base=*/10, /*vgpr_count=*/3,
+                                                  ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(sequence);
+  EXPECT_EQ(sequence->slot_offsets, (std::vector<uint32_t>{0, 4, 8}));
+  EXPECT_EQ(sequence->total_private_bytes, 12u);
+  EXPECT_EQ(manager.total_private_bytes(), 12u);
+  ASSERT_EQ(sequence->save_words.size(), 11u);
+  ASSERT_EQ(sequence->restore_words.size(), 10u);
+  // Pending guest VMEM definitions must complete before any victim is read.
+  EXPECT_EQ(sequence->save_words[0], 0xbfc00000u);
+  EXPECT_EQ(sequence->save_words[1], 0xed06807cu);
+  EXPECT_EQ(sequence->save_words[2], 10u << 23u);
+  EXPECT_EQ(sequence->save_words[3], 0u);
+  EXPECT_EQ(sequence->save_words[10], 0xbfc10000u);
+  EXPECT_EQ(sequence->restore_words[0], 0xed05007cu);
+  EXPECT_EQ(sequence->restore_words[1], 10u);
+  EXPECT_EQ(sequence->restore_words[2], 0u);
+  EXPECT_EQ(sequence->restore_words[9], 0xbfc00000u);
+}
+
+TEST(SpillManager, BuildsSccPreservingDynamicStackVgprFrame) {
+  const auto sequence = build_dynamic_stack_vgpr_spill_sequence(
+      /*vgpr_base=*/10, /*vgpr_count=*/3, /*stack_top_sgpr=*/32,
+      /*frame_base_sgpr=*/33, /*saved_frame_base_sgpr=*/80, /*saved_scc_sgpr=*/66,
+      ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(sequence);
+  EXPECT_TRUE(sequence->uses_dynamic_stack_frame);
+  EXPECT_EQ(sequence->slot_offsets, (std::vector<uint32_t>{0, 4, 8}));
+  EXPECT_EQ(sequence->total_private_bytes, 0u);
+  ASSERT_EQ(sequence->save_words.size(), 17u);
+  ASSERT_EQ(sequence->restore_words.size(), 12u);
+  EXPECT_EQ(sequence->save_words[0], *build_s_wait_loadcnt0(ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_EQ(sequence->save_words[1],
+            *build_rdna4_s_cselect_b32(66, scalar_positive_inline_u32(1),
+                                       scalar_positive_inline_u32(0), ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_EQ(sequence->save_words[2], build_s_mov_b32(80, 33, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_EQ(sequence->save_words[3], build_s_mov_b32(33, 32, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_EQ(sequence->save_words[4], 0xed068021u);
+  EXPECT_EQ(sequence->save_words[5], 10u << 23u);
+  EXPECT_EQ(sequence->save_words[6], 0u);
+  EXPECT_EQ(sequence->save_words[13], *build_s_wait_storecnt0(ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_EQ(sequence->save_words[14],
+            *build_rdna4_s_add_u32(32, 32, /*literal source=*/255u, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_EQ(sequence->save_words[15], 12u);
+  EXPECT_EQ(sequence->save_words[16],
+            *build_rdna4_s_cmp_lg_u32(66, scalar_positive_inline_u32(0), ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_EQ(sequence->restore_words[0], 0xed050021u);
+  EXPECT_EQ(sequence->restore_words[1], 10u);
+  EXPECT_EQ(sequence->restore_words[9], *build_s_wait_loadcnt0(ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_EQ(sequence->restore_words[10], build_s_mov_b32(32, 33, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_EQ(sequence->restore_words[11], build_s_mov_b32(33, 80, ROCJITSU_CODE_ARCH_RDNA4));
+}
+
+TEST(SpillManager, VgprSequenceAppendsAfterOriginalPrivateSegment) {
+  SpillManager manager(/*original_private_bytes=*/20, kMaxAddressFreeScratchPrivateBytes);
+  const auto sequence = build_vgpr_spill_sequence(manager, /*vgpr_base=*/7, /*vgpr_count=*/2,
+                                                  ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(sequence);
+  EXPECT_EQ(sequence->slot_offsets, (std::vector<uint32_t>{32, 36}));
+  EXPECT_EQ(sequence->total_private_bytes, 40u);
+
+  const auto repeated = build_vgpr_spill_sequence(manager, /*vgpr_base=*/7, /*vgpr_count=*/2,
+                                                  ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(repeated);
+  EXPECT_EQ(repeated->slot_offsets, sequence->slot_offsets);
+  EXPECT_EQ(manager.total_private_bytes(), 40u);
+}
+
+TEST(SpillManager, VgprSequenceFailureRollsBack) {
+  SpillManager capacity_limited(/*original_private_bytes=*/0, /*limit=*/8);
+  EXPECT_FALSE(build_vgpr_spill_sequence(capacity_limited, 10, 3, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_EQ(capacity_limited.total_private_bytes(), 0u);
+  EXPECT_EQ(capacity_limited.offset_for(vgpr(10)), std::nullopt);
+
+  SpillManager unencodable(/*original_private_bytes=*/kMaxAddressFreeScratchPrivateBytes,
+                           /*limit=*/kMaxAddressFreeScratchPrivateBytes + 4u);
+  EXPECT_FALSE(build_vgpr_spill_sequence(unencodable, 10, 1, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_EQ(unencodable.offset_for(vgpr(10)), std::nullopt);
+
+  SpillManager unsupported(/*original_private_bytes=*/0, /*limit=*/16);
+  EXPECT_FALSE(build_vgpr_spill_sequence(unsupported, 10, 1, ROCJITSU_CODE_ARCH_CDNA4));
+  EXPECT_FALSE(build_vgpr_spill_sequence(unsupported, 255, 2, ROCJITSU_CODE_ARCH_RDNA4));
+  EXPECT_EQ(unsupported.total_private_bytes(), 0u);
+}
+
+TEST(SpillManager, DescriptorGrowthEnablesPrivateSegmentAndIsKernelLocal) {
+  using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
+  namespace kd = rocr::llvm::amdhsa;
+  std::array<uint8_t, 2 * sizeof(KD)> image{};
+  KD first{};
+  first.compute_pgm_rsrc1 = 0x12345678u;
+  first.compute_pgm_rsrc2 = 0x87654000u;
+  first.kernel_code_entry_byte_offset = -0x1000;
+  first.group_segment_fixed_size = 96;
+  KD second{};
+  second.compute_pgm_rsrc1 = 0xa5a5a5a5u;
+  second.compute_pgm_rsrc2 = 0x5a5a5a5au;
+  second.private_segment_fixed_size = 64;
+  std::memcpy(image.data(), &first, sizeof(first));
+  std::memcpy(image.data() + sizeof(KD), &second, sizeof(second));
+  const std::array<uint8_t, sizeof(KD)> second_before = [&] {
+    std::array<uint8_t, sizeof(KD)> bytes{};
+    std::memcpy(bytes.data(), image.data() + sizeof(KD), sizeof(KD));
+    return bytes;
+  }();
+
+  EXPECT_EQ(update_kernel_descriptor_for_spills(image, /*descriptor_file_offset=*/0,
+                                                /*required_private_bytes=*/12,
+                                                /*uses_dynamic_stack=*/false),
+            SpillDescriptorUpdate::Updated);
+  KD patched{};
+  std::memcpy(&patched, image.data(), sizeof(patched));
+  EXPECT_EQ(patched.private_segment_fixed_size, 12u);
+  EXPECT_EQ(
+      AMDHSA_BITS_GET(patched.compute_pgm_rsrc2, kd::COMPUTE_PGM_RSRC2_ENABLE_PRIVATE_SEGMENT), 1u);
+  EXPECT_EQ(patched.compute_pgm_rsrc1, first.compute_pgm_rsrc1);
+  EXPECT_EQ(patched.kernel_code_entry_byte_offset, first.kernel_code_entry_byte_offset);
+  EXPECT_EQ(patched.group_segment_fixed_size, first.group_segment_fixed_size);
+  EXPECT_TRUE(std::equal(second_before.begin(), second_before.end(), image.begin() + sizeof(KD)));
+}
+
+TEST(SpillManager, DescriptorGrowthHandlesFixedAndDynamicStackBacking) {
+  using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
+  namespace kd = rocr::llvm::amdhsa;
+  KD descriptor{};
+  descriptor.private_segment_fixed_size = 32;
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc2, kd::COMPUTE_PGM_RSRC2_ENABLE_PRIVATE_SEGMENT, 1u);
+  std::array<uint8_t, sizeof(KD)> image{};
+  std::memcpy(image.data(), &descriptor, sizeof(descriptor));
+
+  EXPECT_EQ(update_kernel_descriptor_for_spills(image, 0, 16, false),
+            SpillDescriptorUpdate::Unchanged);
+  EXPECT_EQ(update_kernel_descriptor_for_spills(image, 0, 48, false),
+            SpillDescriptorUpdate::Updated);
+  KD grown{};
+  std::memcpy(&grown, image.data(), sizeof(grown));
+  EXPECT_EQ(grown.private_segment_fixed_size, 48u);
+  EXPECT_EQ(update_kernel_descriptor_for_spills(image, 0, 64, true),
+            SpillDescriptorUpdate::Updated);
+  std::memcpy(&grown, image.data(), sizeof(grown));
+  EXPECT_EQ(grown.private_segment_fixed_size, 64u);
+  const auto before_invalid = image;
+  EXPECT_EQ(
+      update_kernel_descriptor_for_spills(image, 0, kMaxAddressFreeScratchPrivateBytes + 1u, false),
+      SpillDescriptorUpdate::InvalidPrivateSize);
+  EXPECT_EQ(update_kernel_descriptor_for_spills(image, image.size(), 48, false),
+            SpillDescriptorUpdate::InvalidDescriptor);
+  EXPECT_EQ(image, before_invalid);
+}
+
+TEST(SpillManager, DescriptorGrowthIgnoresAndPreservesMetadataNotes) {
+  using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
+
+  std::vector<std::pair<std::string_view, std::vector<uint8_t>>> cases;
+  cases.emplace_back(
+      "absent", std::vector<uint8_t>(kAdversarialDescriptorOffset + sizeof(KD), uint8_t{0x5a}));
+  cases.emplace_back("contradictory", make_metadata_note_elf());
+  auto malformed = make_metadata_note_elf();
+  malformed[kMetadataNoteOffset + sizeof(Elf64_Nhdr) + 8u] = 0xc1u;
+  cases.emplace_back("malformed", std::move(malformed));
+
+  for (auto &[name, image] : cases) {
+    SCOPED_TRACE(name);
+    KD descriptor{};
+    descriptor.private_segment_fixed_size = 16;
+    descriptor.compute_pgm_rsrc1 = 0xa5a55a5au;
+    std::memcpy(image.data() + kAdversarialDescriptorOffset, &descriptor, sizeof(descriptor));
+    const std::vector<uint8_t> before = image;
+
+    EXPECT_EQ(update_kernel_descriptor_for_spills(image, kAdversarialDescriptorOffset, 128,
+                                                  /*uses_dynamic_stack=*/false),
+              SpillDescriptorUpdate::Updated);
+
+    KD patched{};
+    std::memcpy(&patched, image.data() + kAdversarialDescriptorOffset, sizeof(patched));
+    EXPECT_EQ(patched.private_segment_fixed_size, 128u);
+    EXPECT_EQ(patched.compute_pgm_rsrc1, descriptor.compute_pgm_rsrc1);
+    EXPECT_TRUE(
+        std::equal(before.begin(), before.begin() + kAdversarialDescriptorOffset, image.begin()));
+    EXPECT_TRUE(std::equal(before.begin() + kAdversarialDescriptorOffset + sizeof(KD), before.end(),
+                           image.begin() + kAdversarialDescriptorOffset + sizeof(KD)));
+  }
 }
 
 // End-to-end smoke test: feed a real LivenessAnalysis result into SpillManager.


### PR DESCRIPTION
Post-register-allocation instrumentation must acquire temporary registers even when no dead or descriptor-growth window exists. Rejecting those kernels makes otherwise generic DBI clients unusable on register-dense production code.

Extend the initial spill-slot allocator derived from Kunwar Grover's text-relocation work into complete gfx1201 save/restore transactions. Support fixed-private and site-local dynamic-stack frames, update kernel descriptors and AMDGPU MessagePack metadata coherently, preserve wait and scalar-condition state, and fail without partial allocation or image mutation.

Add append-only PT_NOTE relocation for metadata rewrites that outgrow their original note payload without moving any loadable byte. Tests cover capacity rollback, stable slots, exact instruction sequences, fixed and dynamic stacks, descriptor/metadata updates, malformed inputs, and load-image-preserving note relocation.

ISSUE ID : #8701
