### PR TITLE
feat(rocjitsu): Type HSA queue interception in the minimal API mirror

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa_api_trace_minimal.h
+++ b/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa_api_trace_minimal.h
@@ -77,8 +77,8 @@ struct AmdExtTable {
   void *hsa_amd_ipc_signal_create_fn;
   void *hsa_amd_ipc_signal_attach_fn;
   void *hsa_amd_register_system_event_handler_fn;
-  void *hsa_amd_queue_intercept_create_fn;
-  void *hsa_amd_queue_intercept_register_fn;
+  hsa_amd_queue_intercept_create_fn_t hsa_amd_queue_intercept_create_fn;
+  hsa_amd_queue_intercept_register_fn_t hsa_amd_queue_intercept_register_fn;
   void *hsa_amd_queue_set_priority_fn;
   hsa_amd_memory_async_copy_rect_fn_t hsa_amd_memory_async_copy_rect_fn;
   void *hsa_amd_runtime_queue_create_register_fn;

--- a/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa_ext_amd_minimal.h
+++ b/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa_ext_amd_minimal.h
@@ -23,6 +23,17 @@ using hsa_amd_sdma_engine_id_t = uint32_t;
 using hsa_amd_pointer_type_t = uint32_t;
 using hsa_amd_copy_direction_t = uint32_t;
 
+using hsa_amd_queue_intercept_packet_writer_t = void (*)(const void *packets,
+                                                         uint64_t packet_count);
+using hsa_amd_queue_intercept_handler_t = void (*)(const void *packets, uint64_t packet_count,
+                                                   uint64_t user_packet_index, void *data,
+                                                   hsa_amd_queue_intercept_packet_writer_t writer);
+using hsa_amd_queue_intercept_create_fn_t = hsa_status_t(HSA_API *)(
+    hsa_agent_t, uint32_t, hsa_queue_type32_t, void (*)(hsa_status_t, hsa_queue_t *, void *),
+    void *, uint32_t, uint32_t, hsa_queue_t **);
+using hsa_amd_queue_intercept_register_fn_t =
+    hsa_status_t(HSA_API *)(hsa_queue_t *, hsa_amd_queue_intercept_handler_t, void *);
+
 /// @brief Minimal profiling dispatch-time result mirror.
 struct hsa_amd_profiling_dispatch_time_t {
   uint64_t start;

--- a/emulation/rocjitsu/tests/dbt/hsa_hooks_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hooks_unit_test.cpp
@@ -13,6 +13,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <type_traits>
 #include <unistd.h>
 #include <vector>
 
@@ -24,6 +25,34 @@ extern "C" bool OnLoad(HsaApiTable *table, uint64_t runtime_version, uint64_t fa
 extern "C" void OnUnload();
 
 namespace {
+
+using ExpectedQueueInterceptPacketWriter = void (*)(const void *, uint64_t);
+using ExpectedQueueInterceptHandler = void (*)(const void *, uint64_t, uint64_t, void *,
+                                               ExpectedQueueInterceptPacketWriter);
+using ExpectedQueueInterceptCreate = hsa_status_t(HSA_API *)(
+    hsa_agent_t, uint32_t, hsa_queue_type32_t, void (*)(hsa_status_t, hsa_queue_t *, void *),
+    void *, uint32_t, uint32_t, hsa_queue_t **);
+using ExpectedQueueInterceptRegister = hsa_status_t(HSA_API *)(hsa_queue_t *,
+                                                               ExpectedQueueInterceptHandler,
+                                                               void *);
+
+static_assert(
+    std::is_same_v<hsa_amd_queue_intercept_packet_writer_t, ExpectedQueueInterceptPacketWriter>);
+static_assert(std::is_same_v<hsa_amd_queue_intercept_handler_t, ExpectedQueueInterceptHandler>);
+static_assert(std::is_same_v<hsa_amd_queue_intercept_create_fn_t, ExpectedQueueInterceptCreate>);
+static_assert(
+    std::is_same_v<hsa_amd_queue_intercept_register_fn_t, ExpectedQueueInterceptRegister>);
+static_assert(std::is_same_v<decltype(AmdExtTable::hsa_amd_queue_intercept_create_fn),
+                             ExpectedQueueInterceptCreate>);
+static_assert(std::is_same_v<decltype(AmdExtTable::hsa_amd_queue_intercept_register_fn),
+                             ExpectedQueueInterceptRegister>);
+
+TEST(HsaHooksUnitTest, QueueInterceptionEntriesUsePublicAbiSignatures) {
+  EXPECT_TRUE((std::is_same_v<decltype(AmdExtTable::hsa_amd_queue_intercept_create_fn),
+                              ExpectedQueueInterceptCreate>));
+  EXPECT_TRUE((std::is_same_v<decltype(AmdExtTable::hsa_amd_queue_intercept_register_fn),
+                              ExpectedQueueInterceptRegister>));
+}
 
 constexpr hsa_agent_t kGuestAgent{1};
 constexpr hsa_agent_t kHostAgent{2};


### PR DESCRIPTION
The minimal HSA extension table in rocJITsu represented the queue-interception entries as void pointers and omitted their callback signatures. Tools therefore could not wrap those standard extension entry points without maintaining private casts and duplicate declarations.

Add the packet-writer, interception-handler, create, and register function types and use them in AmdExtTable. The declarations mirror the public HSA ABI and introduce no runtime behavior.

Pin all four independently spelled signatures and both extension-table member types with compile-time assertions in the HSA hooks unit test.

ISSUE ID : #8701
