### PR TITLE
feat(rocjitsu): Let HIP tests declare includes and build dependencies

### DIFF
--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -1671,7 +1671,13 @@ if(RJ_ENABLE_HIP_TESTS)
 
     # Helper: build a HIP test binary with amdclang++ + gtest.
     function(rj_add_hip_test TEST_NAME)
-        cmake_parse_arguments(ARG "" "ARCH;SOURCE" "EXTRA_LIBS" ${ARGN})
+        cmake_parse_arguments(
+            ARG
+            ""
+            "ARCH;SOURCE"
+            "EXTRA_LIBS;EXTRA_DEPENDS;INCLUDE_DIRS"
+            ${ARGN}
+        )
         if(NOT ARG_ARCH)
             set(ARG_ARCH ${RJ_HIP_TEST_ARCH})
         endif()
@@ -1681,6 +1687,10 @@ if(RJ_ENABLE_HIP_TESTS)
             set(HIP_TEST_SRC ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_NAME}.cpp)
         endif()
         set(HIP_TEST_BIN ${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME})
+        set(HIP_INCLUDE_FLAGS)
+        foreach(_rj_include_dir IN LISTS ARG_INCLUDE_DIRS)
+            list(APPEND HIP_INCLUDE_FLAGS -I${_rj_include_dir})
+        endforeach()
         set(HIP_EXTRA_LIBS)
         if(ARG_EXTRA_LIBS)
             set(HIP_EXTRA_LIBS -x none ${ARG_EXTRA_LIBS})
@@ -1691,11 +1701,15 @@ if(RJ_ENABLE_HIP_TESTS)
                 ${AMDCXX} -x hip --offload-arch=${ARG_ARCH}
                 --rocm-path=${ROCM_PATH} -std=c++20 -O2
                 ${RJ_HIP_SANITIZER_FLAGS} -isystem ${GTEST_INC}
-                -I${CMAKE_CURRENT_SOURCE_DIR} -o ${HIP_TEST_BIN} ${HIP_TEST_SRC}
-                ${HIP_EXTRA_LIBS} -L${GTEST_LIB_DIR} -lgtest -lpthread
-                -Wl,-rpath,${GTEST_LIB_DIR} -Wl,-rpath,${RJ_HSA_LIBRARY_DIR}
-                ${RJ_HIP_SANITIZER_LINK_FLAGS}
-            DEPENDS ${HIP_TEST_SRC} GTest::gtest GTest::gtest_main
+                -I${CMAKE_CURRENT_SOURCE_DIR} ${HIP_INCLUDE_FLAGS} -o
+                ${HIP_TEST_BIN} ${HIP_TEST_SRC} ${HIP_EXTRA_LIBS}
+                -L${GTEST_LIB_DIR} -lgtest -lpthread -Wl,-rpath,${GTEST_LIB_DIR}
+                -Wl,-rpath,${RJ_HSA_LIBRARY_DIR} ${RJ_HIP_SANITIZER_LINK_FLAGS}
+            DEPENDS
+                ${HIP_TEST_SRC}
+                ${ARG_EXTRA_DEPENDS}
+                GTest::gtest
+                GTest::gtest_main
             COMMENT "Building ${TEST_NAME} with amdclang++ -x hip (${ARG_ARCH})"
             VERBATIM
         )
@@ -1781,6 +1795,41 @@ if(RJ_ENABLE_HIP_TESTS)
         endif()
         rj_add_test(${_test_args})
     endfunction()
+
+    # Compile a generated-header fixture to keep INCLUDE_DIRS and EXTRA_DEPENDS
+    # independently exercised by a non-ConSan caller. The header has no other
+    # build rule consumer: omitting EXTRA_DEPENDS races or fails its generation,
+    # while omitting INCLUDE_DIRS makes the source fail to compile.
+    set(_rj_hip_helper_contract_include_dir
+        "${CMAKE_CURRENT_BINARY_DIR}/hip_test_helper_contract_include"
+    )
+    set(_rj_hip_helper_contract_header
+        "${_rj_hip_helper_contract_include_dir}/hip_test_helper_contract.h"
+    )
+    add_custom_command(
+        OUTPUT "${_rj_hip_helper_contract_header}"
+        COMMAND
+            ${CMAKE_COMMAND} -E make_directory
+            "${_rj_hip_helper_contract_include_dir}"
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_if_different
+            "${CMAKE_CURRENT_SOURCE_DIR}/cmake/hip_test_helper_contract.h"
+            "${_rj_hip_helper_contract_header}"
+        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/hip_test_helper_contract.h"
+        COMMENT "Generating HIP test-helper contract header"
+        VERBATIM
+    )
+    rj_add_hip_test(
+        hip_test_helper_contract
+        SOURCE cmake/hip_test_helper_contract.hip
+        INCLUDE_DIRS "${_rj_hip_helper_contract_include_dir}"
+        EXTRA_DEPENDS "${_rj_hip_helper_contract_header}"
+    )
+    rj_add_test(
+        NAME hip_test_helper_contract
+        COMMAND "${CMAKE_CURRENT_BINARY_DIR}/hip_test_helper_contract"
+        LABELS unit
+    )
 
     if(RJ_HIP_RUNTIME_SUPPORTS_TEST_ARCH)
         rj_add_hip_test(hip_memcpy_test ARCH ${RJ_HIP_TEST_ARCH})

--- a/emulation/rocjitsu/tests/cmake/hip_test_helper_contract.h
+++ b/emulation/rocjitsu/tests/cmake/hip_test_helper_contract.h
@@ -1,0 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+inline constexpr int kHipTestHelperContractValue = 42;

--- a/emulation/rocjitsu/tests/cmake/hip_test_helper_contract.hip
+++ b/emulation/rocjitsu/tests/cmake/hip_test_helper_contract.hip
@@ -1,0 +1,8 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "hip_test_helper_contract.h"
+
+static_assert(kHipTestHelperContractValue == 42);
+
+int main() { return kHipTestHelperContractValue == 42 ? 0 : 1; }


### PR DESCRIPTION
The direct amdclang++ HIP-test helper previously accepted only extra link libraries. A generated test that consumes a project header could neither add its include root nor make rebuilding depend on that header.

Add generic INCLUDE_DIRS and EXTRA_DEPENDS arguments while preserving existing callers and command lines.

Add a standalone contract fixture whose header is generated only through EXTRA_DEPENDS and found only through INCLUDE_DIRS, then compile and run the resulting HIP test executable.

ISSUE ID : #8701