### PR TITLE
refactor(simdojo): add concurrent memory primitives

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -49,24 +49,30 @@ jobs:
       options: --user 0:0
       env:
         DEBIAN_FRONTEND: noninteractive
-    continue-on-error: true
+    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: release
+            allow_failure: true
+            test_regex: ''
             build_type: Release
             enable_asan: 0
             enable_ubsan: 0
             enable_tsan: 0
             enable_msan: 0
           - name: asan-ubsan
+            allow_failure: true
+            test_regex: ''
             build_type: RelWithDebInfo
             enable_asan: 1
             enable_ubsan: 1
             enable_tsan: 0
             enable_msan: 0
           - name: asan-ubsan-gcc
+            allow_failure: true
+            test_regex: ''
             build_type: RelWithDebInfo
             enable_asan: 1
             enable_ubsan: 1
@@ -74,6 +80,17 @@ jobs:
             enable_msan: 0
             c_compiler: gcc
             cxx_compiler: g++
+          - name: tsan-sparse-memory
+            allow_failure: false
+            # The simulator-wide stress tests exceed TSan's fixed 128-lock
+            # deadlock-tracker capacity; keep the race gate on this change's
+            # concurrent SparseMemory surface.
+            test_regex: '^SparseMemory(Threading)?Test\.'
+            build_type: RelWithDebInfo
+            enable_asan: 0
+            enable_ubsan: 0
+            enable_tsan: 1
+            enable_msan: 0
 
     steps:
       - name: Install base dependencies
@@ -188,7 +205,12 @@ jobs:
           WORKERS="$(( ($(nproc) + 1) / 2 ))"
           cmake --build "${ROCJITSU_BUILD_DIR}" -j "${WORKERS}"
 
+          CTEST_SELECTION=()
+          if [[ -n "${{ matrix.test_regex }}" ]]; then
+            CTEST_SELECTION=(-R "${{ matrix.test_regex }}")
+          fi
           ctest --test-dir "${ROCJITSU_BUILD_DIR}" \
+            "${CTEST_SELECTION[@]}" \
             -E "${EXCLUDED_TESTS}" \
             --output-on-failure \
             -j "${WORKERS}"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1060,9 +1060,10 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
 
   std::string kernel_sym;
   if (host_accessible && memory_) {
-    auto [range_base, range_size] = memory_->find_host_range(pkt.kernel_object);
-    if (range_base != 0) {
-      auto *ko = reinterpret_cast<const uint8_t *>(pkt.kernel_object);
+    auto [range_base, range_size] = memory_->find_host_range(pkt.kernel_object, queue.process_id);
+    auto *mapped_page = memory_->resolve_host_ptr(pkt.kernel_object, queue.process_id);
+    if (range_base != 0 && mapped_page) {
+      auto *ko = mapped_page + (pkt.kernel_object & GpuMemory::PAGE_MASK);
       auto *range_start = reinterpret_cast<const uint8_t *>(range_base);
       auto *elf = find_elf_base(ko, range_start);
       if (elf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -143,6 +143,56 @@ public:
 
   uint8_t *translate_debug(uint64_t addr, uint32_t vmid) const { return translate(addr, vmid); }
 
+  /// @brief Find the contiguous host range containing a VMID-scoped GPU VA.
+  /// @details KFD dispatches use per-process page tables. Kernel-symbol
+  /// resolution needs a daemon-accessible host pointer range so it can scan
+  /// backward from the kernel descriptor to the loaded ELF header.
+  std::pair<uint64_t, uint64_t> find_host_range(uint64_t addr, uint32_t vmid) const {
+    if (vmid == 0) {
+      auto *host = translate(addr, vmid);
+      if (!host)
+        return {0, 0};
+      return {reinterpret_cast<uint64_t>(host), PAGE_SIZE};
+    }
+
+    std::shared_lock vmid_lock(vmid_mutex_);
+    auto vmid_entry = vmid_table_.find(vmid);
+    if (vmid_entry == vmid_table_.end())
+      return {0, 0};
+
+    auto &entry = vmid_entry->second;
+    std::shared_lock page_table_lock(*entry.mutex);
+    const uint64_t page = addr >> PAGE_SHIFT;
+    auto page_entry = entry.page_table->find(page);
+    if (page_entry == entry.page_table->end())
+      return {0, 0};
+
+    uint64_t first_page = page;
+    uint8_t *first_host_page = page_entry->second.host_ptr;
+    while (first_page > 0) {
+      auto previous_page_entry = entry.page_table->find(first_page - 1);
+      if (previous_page_entry == entry.page_table->end() ||
+          previous_page_entry->second.host_ptr + PAGE_SIZE != first_host_page)
+        break;
+      --first_page;
+      first_host_page = previous_page_entry->second.host_ptr;
+    }
+
+    uint64_t last_page = page;
+    uint8_t *last_host_page = page_entry->second.host_ptr;
+    while (true) {
+      auto next_page_entry = entry.page_table->find(last_page + 1);
+      if (next_page_entry == entry.page_table->end() ||
+          next_page_entry->second.host_ptr != last_host_page + PAGE_SIZE)
+        break;
+      ++last_page;
+      last_host_page = next_page_entry->second.host_ptr;
+    }
+
+    const uint64_t range_size = ((last_page - first_page) + 1) << PAGE_SHIFT;
+    return {reinterpret_cast<uint64_t>(first_host_page), range_size};
+  }
+
   std::string debug_page_table_info(uint32_t vmid, uint64_t page_key) const {
     std::shared_lock lk(vmid_mutex_);
     auto it = vmid_table_.find(vmid);

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/components/cache.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/components/cache.h
@@ -99,6 +99,11 @@ public:
   static constexpr uint64_t SET_MASK = NumSets - 1;
   static constexpr uint32_t TOTAL_SIZE = LINE_SIZE * NumSets * Associativity;
 
+  struct Allocation {
+    CacheTag *tag = nullptr;
+    uint8_t *data = nullptr;
+  };
+
   Cache()
       : tags_(static_cast<size_t>(NumSets) * Associativity),
         data_(static_cast<size_t>(LINE_SIZE) * NumSets * Associativity, 0) {
@@ -137,6 +142,15 @@ public:
   /// @returns Pointer to the allocated tag entry.
   CacheTag *allocate(uint64_t addr, uint32_t vmid = 0, CacheTag *evicted_tag = nullptr,
                      uint8_t *evicted_data = nullptr) {
+    return allocate_with_data(addr, vmid, evicted_tag, evicted_data).tag;
+  }
+
+  /// @brief Allocate a cache line and return both tag and data pointers.
+  ///
+  /// @details Used by cache controllers that fill a newly allocated line
+  /// directly from a backing level, avoiding a second tag scan in fill_line().
+  Allocation allocate_with_data(uint64_t addr, uint32_t vmid = 0, CacheTag *evicted_tag = nullptr,
+                                uint8_t *evicted_data = nullptr) {
     uint32_t set = set_index(addr);
     uint64_t tag = tag_bits(addr);
 
@@ -150,7 +164,9 @@ public:
         t.dirty = false;
         t.coherence = CoherenceState::INVALID;
         policy_.access(set, w);
-        return &t;
+        if (evicted_tag)
+          *evicted_tag = {};
+        return {&t, line_data(set, w)};
       }
     }
 
@@ -168,7 +184,7 @@ public:
     vt.dirty = false;
     vt.coherence = CoherenceState::INVALID;
     policy_.access(set, victim_way);
-    return &vt;
+    return {&vt, line_data(set, victim_way)};
   }
 
   /// @brief Invalidate the cache line for an address (if present).
@@ -184,6 +200,21 @@ public:
         t.dirty = false;
         t.coherence = CoherenceState::INVALID;
         return;
+      }
+    }
+  }
+
+  /// @brief Invalidate all cache lines for an address across all address spaces.
+  /// @param addr The memory address whose cache line to invalidate.
+  void invalidate_all_vmids(uint64_t addr) {
+    uint32_t set = set_index(addr);
+    uint64_t tag = tag_bits(addr);
+    for (uint32_t w = 0; w < Associativity; ++w) {
+      auto &t = tag_at(set, w);
+      if (t.valid && t.tag == tag) {
+        t.valid = false;
+        t.dirty = false;
+        t.coherence = CoherenceState::INVALID;
       }
     }
   }
@@ -215,6 +246,23 @@ public:
       }
     }
     assert(false && "read_line called on a miss");
+  }
+
+  /// @brief Return a const pointer to the data for a cache line.
+  ///
+  /// @param addr The memory address identifying the cache line.
+  /// @returns Pointer to the line data, or nullptr if not found.
+  const uint8_t *line_data_for_read(uint64_t addr, uint32_t vmid = 0) {
+    uint32_t set = set_index(addr);
+    uint64_t tag = tag_bits(addr);
+    for (uint32_t w = 0; w < Associativity; ++w) {
+      auto &t = tag_at(set, w);
+      if (t.valid && t.tag == tag && t.vmid == vmid) {
+        policy_.access(set, w);
+        return line_data(set, w);
+      }
+    }
+    return nullptr;
   }
 
   /// @brief Write to a cache line (must be a hit - caller ensures via lookup/allocate).

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/components/sparse_memory.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/components/sparse_memory.h
@@ -15,9 +15,11 @@
 #include <cstring>
 #include <mutex>
 #include <shared_mutex>
+#include <span>
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 namespace simdojo {
 
@@ -27,8 +29,6 @@ namespace simdojo {
 /// and doubleword access plus bulk image loading and page iteration for
 /// serialization.
 ///
-/// Host ranges are tracked as a page-indexed map (page_number → host_ptr)
-/// for O(1) lookup per access, mirroring real IOMMU page table structure.
 class SparseMemory : public Component {
 public:
   static constexpr size_t PAGE_SIZE = 4096;
@@ -44,33 +44,17 @@ public:
   /// @param addr Memory address to read from.
   /// @returns The byte at the given address (0 if page not yet allocated).
   uint8_t read8(uint64_t addr) const {
-    {
-      std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-      auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-      if (it != host_page_map_.end())
-        return it->second[addr & PAGE_MASK];
-    }
-    std::shared_lock<std::shared_mutex> lock(mutex_);
-    auto it = pages_.find(addr & ~PAGE_MASK);
-    return (it != pages_.end()) ? it->second[addr & PAGE_MASK] : 0;
+    uint8_t val = 0;
+    read_block(addr, std::span<uint8_t>(&val, 1));
+    return val;
   }
 
   /// @brief Read a 16-bit value from the given address (little-endian).
   /// @param addr Memory address to read from.
   /// @returns The 16-bit value at the given address.
   uint16_t read16(uint64_t addr) const {
-    {
-      std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-      auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-      if (it != host_page_map_.end() && (addr & PAGE_MASK) + 2 <= PAGE_SIZE) {
-        uint16_t val = 0;
-        std::memcpy(&val, it->second + (addr & PAGE_MASK), 2);
-        return val;
-      }
-    }
-    std::shared_lock<std::shared_mutex> lock(mutex_);
     uint16_t val = 0;
-    read_bytes(addr, &val, 2);
+    read_block(addr, std::span<uint8_t>(reinterpret_cast<uint8_t *>(&val), sizeof(val)));
     return val;
   }
 
@@ -78,18 +62,8 @@ public:
   /// @param addr Memory address to read from.
   /// @returns The 32-bit value at the given address.
   uint32_t read32(uint64_t addr) const {
-    {
-      std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-      auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-      if (it != host_page_map_.end() && (addr & PAGE_MASK) + 4 <= PAGE_SIZE) {
-        uint32_t val = 0;
-        std::memcpy(&val, it->second + (addr & PAGE_MASK), 4);
-        return val;
-      }
-    }
-    std::shared_lock<std::shared_mutex> lock(mutex_);
     uint32_t val = 0;
-    read_bytes(addr, &val, 4);
+    read_block(addr, std::span<uint8_t>(reinterpret_cast<uint8_t *>(&val), sizeof(val)));
     return val;
   }
 
@@ -97,83 +71,74 @@ public:
   /// @param addr Memory address to read from.
   /// @returns The 64-bit value at the given address.
   uint64_t read64(uint64_t addr) const {
-    {
-      std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-      auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-      if (it != host_page_map_.end() && (addr & PAGE_MASK) + 8 <= PAGE_SIZE) {
-        uint64_t val = 0;
-        std::memcpy(&val, it->second + (addr & PAGE_MASK), 8);
-        return val;
-      }
-    }
-    std::shared_lock<std::shared_mutex> lock(mutex_);
     uint64_t val = 0;
-    read_bytes(addr, &val, 8);
+    read_block(addr, std::span<uint8_t>(reinterpret_cast<uint8_t *>(&val), sizeof(val)));
     return val;
+  }
+
+  /// @brief Read a block of bytes from sparse memory.
+  /// @details Thread-safe with page-granular synchronization. A read contained
+  /// within one sparse page is atomic with respect to writers of that page. A
+  /// read spanning multiple pages is not atomic as one transaction and may
+  /// observe different pages before and after a concurrent multi-page write.
+  /// @param addr Starting memory address.
+  /// @param dst Destination buffer.
+  void read_block(uint64_t addr, std::span<uint8_t> dst) const {
+    size_t copied = 0;
+    while (copied < dst.size()) {
+      const uint64_t ea = addr + copied;
+      const size_t page_off = ea & PAGE_MASK;
+      const size_t chunk = std::min(dst.size() - copied, PAGE_SIZE - page_off);
+      read_sparse_chunk(ea, dst.data() + copied, chunk);
+      copied += chunk;
+    }
   }
 
   /// @brief Write an 8-bit value to the given address.
   /// @param addr Memory address to write to.
   /// @param val Value to write.
-  void write8(uint64_t addr, uint8_t val) {
-    {
-      std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-      auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-      if (it != host_page_map_.end()) {
-        it->second[addr & PAGE_MASK] = val;
-        return;
-      }
-    }
-    std::unique_lock<std::shared_mutex> lock(mutex_);
-    get_page(addr)[addr & PAGE_MASK] = val;
-  }
+  void write8(uint64_t addr, uint8_t val) { write_block(addr, std::span<const uint8_t>(&val, 1)); }
 
   /// @brief Write a 16-bit value to the given address (little-endian).
   /// @param addr Memory address to write to.
   /// @param val Value to write.
   void write16(uint64_t addr, uint16_t val) {
-    {
-      std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-      auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-      if (it != host_page_map_.end() && (addr & PAGE_MASK) + 2 <= PAGE_SIZE) {
-        std::memcpy(it->second + (addr & PAGE_MASK), &val, 2);
-        return;
-      }
-    }
-    std::unique_lock<std::shared_mutex> lock(mutex_);
-    write_bytes(addr, &val, sizeof(val));
+    write_block(addr,
+                std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(&val), sizeof(val)));
   }
 
   /// @brief Write a 32-bit value to the given address (little-endian).
   /// @param addr Memory address to write to.
   /// @param val Value to write.
   void write32(uint64_t addr, uint32_t val) {
-    {
-      std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-      auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-      if (it != host_page_map_.end() && (addr & PAGE_MASK) + 4 <= PAGE_SIZE) {
-        std::memcpy(it->second + (addr & PAGE_MASK), &val, 4);
-        return;
-      }
-    }
-    std::unique_lock<std::shared_mutex> lock(mutex_);
-    write_bytes(addr, &val, sizeof(val));
+    write_block(addr,
+                std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(&val), sizeof(val)));
   }
 
   /// @brief Write a 64-bit value to the given address (little-endian).
   /// @param addr Memory address to write to.
   /// @param val Value to write.
   void write64(uint64_t addr, uint64_t val) {
-    {
-      std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-      auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-      if (it != host_page_map_.end() && (addr & PAGE_MASK) + 8 <= PAGE_SIZE) {
-        std::memcpy(it->second + (addr & PAGE_MASK), &val, 8);
-        return;
-      }
+    write_block(addr,
+                std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(&val), sizeof(val)));
+  }
+
+  /// @brief Write a block of bytes to sparse memory.
+  /// @details Thread-safe with page-granular synchronization. A write contained
+  /// within one sparse page is atomic with respect to other accesses to that
+  /// page. A write spanning multiple pages is not atomic as one transaction;
+  /// concurrent overlapping multi-page operations may interleave by page.
+  /// @param addr Starting memory address.
+  /// @param src Source buffer.
+  void write_block(uint64_t addr, std::span<const uint8_t> src) {
+    size_t copied = 0;
+    while (copied < src.size()) {
+      const uint64_t ea = addr + copied;
+      const size_t page_off = ea & PAGE_MASK;
+      const size_t chunk = std::min(src.size() - copied, PAGE_SIZE - page_off);
+      write_sparse_chunk(ea, src.data() + copied, chunk);
+      copied += chunk;
     }
-    std::unique_lock<std::shared_mutex> lock(mutex_);
-    write_bytes(addr, &val, sizeof(val));
   }
 
   /// @brief Instruction fetch - read a 32-bit word (little-endian).
@@ -186,145 +151,89 @@ public:
   /// @param size Size of the image in bytes.
   /// @param base_addr Starting address to load the image at.
   void load_image(const uint8_t *data, size_t size, uint64_t base_addr) {
-    size_t offset = 0;
-    while (offset < size) {
-      uint64_t addr = base_addr + offset;
-      uint64_t page_off = addr & PAGE_MASK;
-      size_t chunk = std::min(PAGE_SIZE - page_off, size - offset);
-      {
-        std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-        auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-        if (it != host_page_map_.end()) {
-          std::memcpy(it->second + page_off, data + offset, chunk);
-          offset += chunk;
-          continue;
-        }
-      }
-      {
-        std::unique_lock<std::shared_mutex> lock(mutex_);
-        std::memcpy(&get_page(addr)[page_off], data + offset, chunk);
-      }
-      offset += chunk;
-    }
+    write_block(base_addr, std::span<const uint8_t>(data, size));
   }
 
   /// @brief Iterate over all allocated pages for checkpoint serialization.
+  /// @details Copies one stripe at a time before invoking callbacks, so callbacks
+  /// run without page-stripe locks held. The iteration is thread-safe but is not
+  /// a globally atomic snapshot across all stripes.
   /// @tparam F Callable with signature void(uint64_t page_addr, const Page&).
   /// @param fn Callback invoked for each allocated page.
   template <typename F> void for_each_page(F &&fn) const {
-    std::shared_lock<std::shared_mutex> lock(mutex_);
-    for (const auto &[addr, page] : pages_)
-      fn(addr, page);
+    for (const auto &stripe : page_stripes_) {
+      std::vector<std::pair<uint64_t, Page>> pages;
+      {
+        std::shared_lock<std::shared_mutex> lock(stripe.mutex);
+        pages.reserve(stripe.pages.size());
+        for (const auto &[addr, page] : stripe.pages)
+          pages.emplace_back(addr, page);
+      }
+      for (const auto &[addr, page] : pages)
+        fn(addr, page);
+    }
   }
 
   /// @brief Return the number of allocated pages.
+  /// @details Counts one stripe at a time. The result is thread-safe but is not
+  /// a globally atomic snapshot if pages are allocated concurrently.
   /// @returns Count of allocated pages.
   size_t num_pages() const {
-    std::shared_lock<std::shared_mutex> lock(mutex_);
-    return pages_.size();
-  }
-
-  /// @brief Map host pages as the backing store for a GPU VA range.
-  /// @details After this call, read/write to addresses in [gpu_va, gpu_va+size)
-  /// access the host memory at [host_ptr, host_ptr+size) directly. Both the host
-  /// CPU and the simulated GPU see the same data — no copy needed.
-  ///
-  /// Internally stored as one entry per 4KB page (page_number → host_ptr),
-  /// giving O(1) lookup per memory access instead of O(n) range scan.
-  /// @param gpu_va Start of the GPU virtual address range (page-aligned).
-  /// @param host_ptr Host pointer to the backing pages (page-aligned).
-  /// @param size Size of the mapping in bytes (page-aligned).
-  void map_host_pages(uint64_t gpu_va, void *host_ptr, size_t size) {
-    auto *hp = static_cast<uint8_t *>(host_ptr);
-    std::lock_guard<std::shared_mutex> lock(host_range_mutex_);
-    for (uint64_t off = 0; off < size; off += PAGE_SIZE)
-      host_page_map_[(gpu_va + off) >> PAGE_SHIFT] = hp + off;
-  }
-
-  bool is_host_mapped(uint64_t gpu_va) const {
-    std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-    return host_page_map_.count(gpu_va >> PAGE_SHIFT) > 0;
-  }
-
-  /// @brief Find the base and size of the contiguous host-mapped region containing addr.
-  /// @details Scans backward and forward through host_page_map_ to find the
-  /// full contiguous range. Returns {0, 0} if addr is not host-mapped.
-  std::pair<uint64_t, uint64_t> find_host_range(uint64_t addr) const {
-    std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-    uint64_t page = addr >> PAGE_SHIFT;
-    if (host_page_map_.count(page) == 0)
-      return {0, 0};
-    uint64_t lo = page;
-    while (lo > 0 && host_page_map_.count(lo - 1))
-      --lo;
-    uint64_t hi = page;
-    while (host_page_map_.count(hi + 1))
-      ++hi;
-    return {lo << PAGE_SHIFT, ((hi - lo) + 1) << PAGE_SHIFT};
-  }
-
-  void unmap_host_pages(uint64_t gpu_va, size_t size) {
-    std::lock_guard<std::shared_mutex> lock(host_range_mutex_);
-    for (uint64_t off = 0; off < size; off += PAGE_SIZE)
-      host_page_map_.erase((gpu_va + off) >> PAGE_SHIFT);
+    size_t count = 0;
+    for (const auto &stripe : page_stripes_) {
+      std::shared_lock<std::shared_mutex> lock(stripe.mutex);
+      count += stripe.pages.size();
+    }
+    return count;
   }
 
 private:
-  mutable std::shared_mutex mutex_;
-  mutable std::unordered_map<uint64_t, Page> pages_;
+  static constexpr size_t NUM_PAGE_STRIPES = 1024;
 
-  /// @brief Page-indexed host range map. Key = page_number (gpu_va >> 12),
-  /// value = host_ptr for the start of that page. O(1) lookup per access.
-  mutable std::shared_mutex host_range_mutex_;
-  std::unordered_map<uint64_t, uint8_t *> host_page_map_;
+  struct PageStripe {
+    mutable std::shared_mutex mutex;
+    mutable std::unordered_map<uint64_t, Page> pages;
+  };
+
+  static size_t stripe_index(uint64_t addr) {
+    constexpr uint64_t kMul = 11400714819323198485ull;
+    const uint64_t page_number = addr >> PAGE_SHIFT;
+    const uint64_t product = page_number * kMul;
+    const uint64_t mixed = product ^ (product >> 32);
+    return static_cast<size_t>(mixed & (NUM_PAGE_STRIPES - 1));
+  }
+
+  PageStripe &page_stripe(uint64_t addr) const { return page_stripes_[stripe_index(addr)]; }
+
+  void read_sparse_chunk(uint64_t addr, uint8_t *dst, size_t size) const {
+    auto &stripe = page_stripe(addr);
+    std::shared_lock<std::shared_mutex> lock(stripe.mutex);
+    auto it = stripe.pages.find(addr & ~PAGE_MASK);
+    if (it != stripe.pages.end()) {
+      std::memcpy(dst, &it->second[addr & PAGE_MASK], size);
+    } else {
+      std::memset(dst, 0, size);
+    }
+  }
+
+  void write_sparse_chunk(uint64_t addr, const uint8_t *src, size_t size) {
+    auto &stripe = page_stripe(addr);
+    std::unique_lock<std::shared_mutex> lock(stripe.mutex);
+    std::memcpy(&get_page_locked(stripe, addr)[addr & PAGE_MASK], src, size);
+  }
+
+  mutable std::array<PageStripe, NUM_PAGE_STRIPES> page_stripes_;
 
   // Returns a reference to the 4KB page containing addr, allocating if needed.
-  // Caller must hold exclusive lock on mutex_.
-  Page &get_page(uint64_t addr) const {
+  // Caller must hold exclusive lock on the page stripe.
+  Page &get_page_locked(PageStripe &stripe, uint64_t addr) const {
     uint64_t page_addr = addr & ~PAGE_MASK;
-    auto it = pages_.find(page_addr);
-    if (it == pages_.end()) {
-      auto [inserted, _] = pages_.emplace(page_addr, Page{});
+    auto it = stripe.pages.find(page_addr);
+    if (it == stripe.pages.end()) {
+      auto [inserted, _] = stripe.pages.emplace(page_addr, Page{});
       return inserted->second;
     }
     return it->second;
-  }
-
-  uint8_t *get_byte_ptr(uint64_t addr) const { return &get_page(addr)[addr & PAGE_MASK]; }
-
-  /// @brief Read N bytes from sparse pages, handling cross-page boundary access.
-  /// @note Caller must hold shared_lock on mutex_. Does NOT allocate pages;
-  ///       unallocated addresses read as zero.
-  void read_bytes(uint64_t addr, void *dst, size_t n) const {
-    // Note: caller holds shared_lock on mutex_.
-    size_t off = addr & PAGE_MASK;
-    if (off + n <= PAGE_SIZE) {
-      auto it = pages_.find(addr & ~PAGE_MASK);
-      if (it != pages_.end())
-        std::memcpy(dst, &it->second[off], n);
-      else
-        std::memset(dst, 0, n);
-    } else {
-      auto *out = static_cast<uint8_t *>(dst);
-      for (size_t i = 0; i < n; ++i) {
-        uint64_t a = addr + i;
-        auto it = pages_.find(a & ~PAGE_MASK);
-        out[i] = (it != pages_.end()) ? it->second[a & PAGE_MASK] : 0;
-      }
-    }
-  }
-
-  /// @brief Write N bytes, handling cross-page boundary access.
-  /// @note Caller must hold unique_lock on mutex_. Allocates pages as needed.
-  void write_bytes(uint64_t addr, const void *src, size_t n) {
-    size_t offset = addr & PAGE_MASK;
-    if (offset + n <= PAGE_SIZE) {
-      std::memcpy(&get_page(addr)[offset], src, n);
-    } else {
-      const auto *in = static_cast<const uint8_t *>(src);
-      for (size_t i = 0; i < n; ++i)
-        *get_byte_ptr(addr + i) = in[i];
-    }
   }
 };
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -334,6 +334,7 @@ add_executable(
     matmul_test.cpp
     vector_add_test.cpp
     gfx1250_sim_test.cpp
+    sparse_memory_test.cpp
     simdojo_sim_test.cpp
     simulated_kfd_test.cpp
     decode_smoke_test.cpp

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -184,6 +184,48 @@ TEST(GpuMemoryTest, SparsePages) {
   EXPECT_EQ(mem->read32(0x50000), 0u);
 }
 
+TEST(GpuMemoryTest, FindHostRangeUsesVmidPageTable) {
+  amdgpu::GpuMemory mem("vmid_range_mem");
+  KfdProcess process(/*process_id=*/123);
+  alignas(4096) std::array<uint8_t, 3 * amdgpu::GpuMemory::PAGE_SIZE> backing{};
+  constexpr uint64_t kGpuVa = 0x100000;
+
+  mem.register_process(process.process_id(), &process.page_table_, &process.page_table_mutex_);
+  process.map_pages(kGpuVa, backing.data(), backing.size());
+
+  auto [host_base, size] =
+      mem.find_host_range(kGpuVa + amdgpu::GpuMemory::PAGE_SIZE + 0x123, process.process_id());
+  EXPECT_EQ(host_base, reinterpret_cast<uint64_t>(backing.data()));
+  EXPECT_EQ(size, backing.size());
+
+  mem.unregister_process(process.process_id());
+}
+
+TEST(GpuMemoryTest, FindHostRangeStopsAtNonContiguousVmidHostPages) {
+  amdgpu::GpuMemory mem("vmid_noncontiguous_range_mem");
+  KfdProcess process(/*process_id=*/124);
+  alignas(4096) std::array<uint8_t, 3 * amdgpu::GpuMemory::PAGE_SIZE> backing{};
+  constexpr uint64_t kGpuVa = 0x200000;
+
+  mem.register_process(process.process_id(), &process.page_table_, &process.page_table_mutex_);
+  process.map_pages(kGpuVa, backing.data(), amdgpu::GpuMemory::PAGE_SIZE);
+  process.map_pages(kGpuVa + amdgpu::GpuMemory::PAGE_SIZE,
+                    backing.data() + 2 * amdgpu::GpuMemory::PAGE_SIZE,
+                    amdgpu::GpuMemory::PAGE_SIZE);
+
+  auto [first_host_base, first_size] = mem.find_host_range(kGpuVa, process.process_id());
+  EXPECT_EQ(first_host_base, reinterpret_cast<uint64_t>(backing.data()));
+  EXPECT_EQ(first_size, amdgpu::GpuMemory::PAGE_SIZE);
+
+  auto [second_host_base, second_size] =
+      mem.find_host_range(kGpuVa + amdgpu::GpuMemory::PAGE_SIZE, process.process_id());
+  EXPECT_EQ(second_host_base,
+            reinterpret_cast<uint64_t>(backing.data() + 2 * amdgpu::GpuMemory::PAGE_SIZE));
+  EXPECT_EQ(second_size, amdgpu::GpuMemory::PAGE_SIZE);
+
+  mem.unregister_process(process.process_id());
+}
+
 TEST(RdnaDispatchTest, WgpModeCombinesSiblingCuLdsCapacity) {
   constexpr uint32_t kPerCuLdsBytes = 64 * 1024;
   constexpr uint32_t kWgpLdsBytes = 2 * kPerCuLdsBytes;

--- a/emulation/rocjitsu/tests/simdojo_sim_test.cpp
+++ b/emulation/rocjitsu/tests/simdojo_sim_test.cpp
@@ -12,6 +12,8 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
@@ -803,4 +805,60 @@ TEST(CacheVmidTest, InvalidatePerVmidLeavesOtherVmidIntact) {
   EXPECT_FALSE(cache.lookup(kAddr, nullptr, /*vmid=*/1));
   EXPECT_TRUE(cache.lookup(kAddr, nullptr, /*vmid=*/2));
   EXPECT_EQ(read_line_word(cache, kAddr, /*vmid=*/2), 0x22222222u);
+}
+
+TEST(CacheVmidTest, AllocateWithDataReturnsWritableLineAndEvictedBytes) {
+  TestCache cache;
+  constexpr uint64_t kSetStride = static_cast<uint64_t>(TestCache::LINE_SIZE) * 4;
+  constexpr uint64_t kAddrA = 0x1000;
+  constexpr uint64_t kAddrB = kAddrA + kSetStride;
+  constexpr uint64_t kAddrC = kAddrB + kSetStride;
+
+  auto first = cache.allocate_with_data(kAddrA, /*vmid=*/7);
+  ASSERT_NE(first.tag, nullptr);
+  ASSERT_NE(first.data, nullptr);
+  first.tag->dirty = true;
+  std::fill_n(first.data, TestCache::LINE_SIZE, 0xA5);
+  cache.allocate(kAddrB, /*vmid=*/8);
+
+  CacheTag evicted;
+  std::array<uint8_t, TestCache::LINE_SIZE> evicted_data{};
+  auto replacement = cache.allocate_with_data(kAddrC, /*vmid=*/9, &evicted, evicted_data.data());
+
+  ASSERT_NE(replacement.tag, nullptr);
+  ASSERT_NE(replacement.data, nullptr);
+  EXPECT_TRUE(evicted.valid);
+  EXPECT_TRUE(evicted.dirty);
+  EXPECT_EQ(evicted.vmid, 7u);
+  EXPECT_TRUE(std::all_of(evicted_data.begin(), evicted_data.end(),
+                          [](uint8_t byte) { return byte == 0xA5; }));
+}
+
+TEST(CacheVmidTest, InvalidateAllVmidsRemovesEveryAliasedLine) {
+  TestCache cache;
+  constexpr uint64_t kAddr = 0xC000;
+
+  fill_line_word(cache, kAddr, /*vmid=*/1, 0x11111111u);
+  fill_line_word(cache, kAddr, /*vmid=*/2, 0x22222222u);
+
+  cache.invalidate_all_vmids(kAddr);
+
+  EXPECT_FALSE(cache.lookup(kAddr, nullptr, /*vmid=*/1));
+  EXPECT_FALSE(cache.lookup(kAddr, nullptr, /*vmid=*/2));
+}
+
+TEST(CacheVmidTest, LineDataForReadReturnsMatchingVmidData) {
+  TestCache cache;
+  constexpr uint64_t kAddr = 0x10000;
+
+  auto allocation = cache.allocate_with_data(kAddr, /*vmid=*/4);
+  ASSERT_NE(allocation.data, nullptr);
+  for (uint32_t i = 0; i < TestCache::LINE_SIZE; ++i)
+    allocation.data[i] = static_cast<uint8_t>(i ^ 0x5A);
+
+  const uint8_t *line = cache.line_data_for_read(kAddr, /*vmid=*/4);
+  ASSERT_NE(line, nullptr);
+  for (uint32_t i = 0; i < TestCache::LINE_SIZE; ++i)
+    EXPECT_EQ(line[i], static_cast<uint8_t>(i ^ 0x5A));
+  EXPECT_EQ(cache.line_data_for_read(kAddr, /*vmid=*/5), nullptr);
 }

--- a/emulation/rocjitsu/tests/sparse_memory_test.cpp
+++ b/emulation/rocjitsu/tests/sparse_memory_test.cpp
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "simdojo/components/sparse_memory.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <barrier>
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <thread>
+#include <vector>
+
+namespace {
+
+TEST(SparseMemoryThreadingTest, ConcurrentDifferentPageWritesArePreserved) {
+  simdojo::SparseMemory memory("memory");
+
+  constexpr uint32_t kThreads = 8;
+  constexpr uint32_t kPagesPerThread = 64;
+  constexpr uint64_t kBase = 0x800000;
+
+  std::barrier start(kThreads);
+  std::vector<std::thread> workers;
+  workers.reserve(kThreads);
+
+  for (uint32_t tid = 0; tid < kThreads; ++tid) {
+    workers.emplace_back([&, tid] {
+      std::array<uint8_t, simdojo::SparseMemory::PAGE_SIZE> page{};
+      start.arrive_and_wait();
+      for (uint32_t i = 0; i < kPagesPerThread; ++i) {
+        const uint64_t addr =
+            kBase + (static_cast<uint64_t>(i) * kThreads + tid) * simdojo::SparseMemory::PAGE_SIZE;
+        for (uint32_t b = 0; b < page.size(); ++b)
+          page[b] = static_cast<uint8_t>((tid << 4) ^ i ^ b);
+        memory.write_block(addr, page);
+      }
+    });
+  }
+
+  for (auto &worker : workers)
+    worker.join();
+
+  EXPECT_EQ(memory.num_pages(), kThreads * kPagesPerThread);
+
+  std::array<uint8_t, simdojo::SparseMemory::PAGE_SIZE> expected{};
+  std::array<uint8_t, simdojo::SparseMemory::PAGE_SIZE> actual{};
+  for (uint32_t tid = 0; tid < kThreads; ++tid) {
+    for (uint32_t i = 0; i < kPagesPerThread; ++i) {
+      const uint64_t addr =
+          kBase + (static_cast<uint64_t>(i) * kThreads + tid) * simdojo::SparseMemory::PAGE_SIZE;
+      for (uint32_t b = 0; b < expected.size(); ++b)
+        expected[b] = static_cast<uint8_t>((tid << 4) ^ i ^ b);
+      memory.read_block(addr, actual);
+      EXPECT_EQ(actual, expected) << "addr=0x" << std::hex << addr;
+      uint32_t expected_word = 0;
+      std::memcpy(&expected_word, expected.data(), sizeof(expected_word));
+      EXPECT_EQ(memory.read32(addr), expected_word);
+    }
+  }
+}
+
+TEST(SparseMemoryThreadingTest, ConcurrentSamePageWritesArePreserved) {
+  simdojo::SparseMemory memory("memory");
+
+  constexpr uint32_t kThreads = 8;
+  constexpr size_t kBytesPerThread = simdojo::SparseMemory::PAGE_SIZE / kThreads;
+  constexpr uint64_t kBase = 0x900000;
+
+  std::barrier start(kThreads);
+  std::vector<std::thread> workers;
+  workers.reserve(kThreads);
+
+  for (uint32_t tid = 0; tid < kThreads; ++tid) {
+    workers.emplace_back([&, tid] {
+      std::array<uint8_t, kBytesPerThread> bytes{};
+      std::fill(bytes.begin(), bytes.end(), static_cast<uint8_t>(0x20 + tid));
+      start.arrive_and_wait();
+      for (uint32_t iteration = 0; iteration < 64; ++iteration)
+        memory.write_block(kBase + tid * kBytesPerThread, bytes);
+    });
+  }
+
+  for (auto &worker : workers)
+    worker.join();
+
+  std::array<uint8_t, simdojo::SparseMemory::PAGE_SIZE> actual{};
+  memory.read_block(kBase, actual);
+  for (uint32_t tid = 0; tid < kThreads; ++tid) {
+    const auto begin = actual.begin() + tid * kBytesPerThread;
+    const auto end = begin + kBytesPerThread;
+    EXPECT_TRUE(std::all_of(
+        begin, end, [tid](uint8_t byte) { return byte == static_cast<uint8_t>(0x20 + tid); }));
+  }
+}
+
+TEST(SparseMemoryTest, UnalignedBlockRoundTripCrossesPageBoundary) {
+  simdojo::SparseMemory memory("memory");
+
+  constexpr uint64_t kAddr = simdojo::SparseMemory::PAGE_SIZE - 37;
+  std::array<uint8_t, 128> input{};
+  for (size_t i = 0; i < input.size(); ++i)
+    input[i] = static_cast<uint8_t>((i * 17) ^ 0xA5);
+
+  memory.write_block(kAddr, input);
+
+  std::array<uint8_t, input.size()> output{};
+  memory.read_block(kAddr, output);
+  EXPECT_EQ(output, input);
+  EXPECT_EQ(memory.num_pages(), 2u);
+}
+
+TEST(SparseMemoryThreadingTest, ConcurrentOverlappingBlocksRemainAtomicPerPage) {
+  simdojo::SparseMemory memory("memory");
+
+  constexpr uint64_t kBase = 0xA00000;
+  constexpr size_t kBlockSize = 2 * simdojo::SparseMemory::PAGE_SIZE;
+  std::array<uint8_t, kBlockSize> first{};
+  std::array<uint8_t, kBlockSize> second{};
+  first.fill(0x3C);
+  second.fill(0xC3);
+
+  std::barrier start(2);
+  std::thread first_writer([&] {
+    start.arrive_and_wait();
+    for (uint32_t iteration = 0; iteration < 128; ++iteration)
+      memory.write_block(kBase, first);
+  });
+  std::thread second_writer([&] {
+    start.arrive_and_wait();
+    for (uint32_t iteration = 0; iteration < 128; ++iteration)
+      memory.write_block(kBase, second);
+  });
+
+  first_writer.join();
+  second_writer.join();
+
+  std::array<uint8_t, kBlockSize> actual{};
+  memory.read_block(kBase, actual);
+  for (size_t page = 0; page < 2; ++page) {
+    const auto bytes = std::span<const uint8_t>(actual).subspan(
+        page * simdojo::SparseMemory::PAGE_SIZE, simdojo::SparseMemory::PAGE_SIZE);
+    const bool is_first =
+        std::all_of(bytes.begin(), bytes.end(), [](uint8_t byte) { return byte == 0x3C; });
+    const bool is_second =
+        std::all_of(bytes.begin(), bytes.end(), [](uint8_t byte) { return byte == 0xC3; });
+    EXPECT_TRUE(is_first || is_second) << "page=" << page;
+  }
+}
+
+} // namespace


### PR DESCRIPTION
# refactor(simdojo): add concurrent memory primitives

ISSUE ID: #6447

> [!IMPORTANT]
> This is **PR 1 of 6** in the parallel CPU simulation stack.
> It is based on `develop`; the next layer is
> `users/lialan/rocjitsu_parallel_cpu_02_gpu_state`.
>
> Review only `develop...users/lialan/rocjitsu_parallel_cpu_01_simdojo` for
> this layer.

## Stack

| # | Layer | Branch | PR |
|---|---|---|---|
| **1** | **Concurrent Simdojo memory primitives** | `users/lialan/rocjitsu_parallel_cpu_01_simdojo` | **this PR** |
| 2 | Shared Rocjitsu GPU-state concurrency | `users/lialan/rocjitsu_parallel_cpu_02_gpu_state` | #8703 |
| 3 | XCD execution partitioning | `users/lialan/rocjitsu_parallel_cpu_03_xcd` | #8705 |
| 4 | Compositional plugin threading policy | `users/lialan/rocjitsu_parallel_cpu_04_plugins` | #8706 |
| 5 | Functional CU dispatch pool | `users/lialan/rocjitsu_threadpool_cpu` | #6962 |
| 6 | Functional-mode performance work | `users/lialan/rocjitsu_parallel_cpu_06_perf` | TBD |

## Summary

Add generic concurrency primitives to Simdojo without changing Rocjitsu
dispatch policy.

- Protect sparse memory with striped synchronization.
- Add block read and write operations.
- Add generic cache-line access and invalidation helpers.
- Add focused concurrent sparse-memory coverage.

## Why

Later Rocjitsu worker and engine parallelism needs thread-safe shared storage.
Keeping these generic primitives in the bottom layer makes that foundation
reviewable independently of GPU-specific policy.

## Validation

- Built `rocjitsu_tests`.
- Passed `SparseMemoryThreadingTest.ConcurrentDifferentPageWritesArePreserved`.
- Passed the layer-range pre-commit sweep.
