### PR TITLE
fix(rocjitsu): make shared GPU state concurrency-safe

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -97,9 +97,9 @@ jobs:
             allow_failure: false
             run_static_asan_launch: true
             # The simulator-wide stress tests exceed TSan's fixed 128-lock
-            # deadlock-tracker capacity; keep the race gate on this change's
-            # concurrent SparseMemory surface.
-            test_regex: '^(SparseMemory(Threading)?Test|GpuMemoryThreadingTest)\.'
+            # deadlock-tracker capacity; keep the race gate focused on the
+            # concurrent memory surfaces hardened by this change.
+            test_regex: '^(SparseMemory(Threading)?Test|GpuMemoryThreadingTest|L2CacheThreadingTest)\.'
             build_type: RelWithDebInfo
             enable_asan: 0
             enable_ubsan: 0

--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -99,7 +99,7 @@ jobs:
             # The simulator-wide stress tests exceed TSan's fixed 128-lock
             # deadlock-tracker capacity; keep the race gate on this change's
             # concurrent SparseMemory surface.
-            test_regex: '^SparseMemory(Threading)?Test\.'
+            test_regex: '^(SparseMemory(Threading)?Test|GpuMemoryThreadingTest)\.'
             build_type: RelWithDebInfo
             enable_asan: 0
             enable_ubsan: 0

--- a/docs/superpowers/specs/2026-07-24-msc-atomic-alias-coherence-design.md
+++ b/docs/superpowers/specs/2026-07-24-msc-atomic-alias-coherence-design.md
@@ -1,0 +1,94 @@
+# MSC Atomic Alias Coherence Design
+
+## Context
+
+`L2Cache::atomic_rmw` acquires the device-wide atomic boundary before accessing
+backing memory. The boundary flushes every registered L2 and then advances the
+global coherence epoch while holding the L2 maintenance locks.
+
+The direct-memory path therefore observes the flushed value. The linked-port
+path instead reads through `MemorySideCache` (MSC). MSC is write-through and
+keys clean cache lines by `(VMID, GPU virtual address)`. If two such keys alias
+the same host storage, a clean line under one key can remain stale after another
+key publishes dirty L2 data. An atomic RMW through the stale key can consequently
+use the old value.
+
+## Goals
+
+- Make linked-port atomic RMWs observe the authoritative value after all L2
+  dirty data has been published.
+- Ensure stale MSC aliases are not visible after a coherence epoch change.
+- Preserve the existing device-wide atomic serialization and L2 locking model.
+- Avoid scanning or invalidating the entire 128 MiB MSC on every atomic.
+- Add regression coverage for two L2s sharing one MSC and HBM through aliased
+  VMID/virtual-address mappings.
+- Remove the unused `register_cache` helper so there is one L2 registration
+  implementation and one ordering invariant.
+
+## Design
+
+Each MSC cache tag will record the device-coherence epoch at which its line was
+filled or refreshed. MSC already protects tag lookup and replacement with the
+corresponding stripe lock, so the epoch metadata will use that same protection.
+
+On an MSC access:
+
+1. Look up the `(VMID, GPU virtual address)` cache line under its stripe lock.
+2. Compare the tag's recorded epoch with
+   `DeviceCacheCoherence::current_epoch()`.
+3. If the epochs differ, require the old entry to be clean, invalidate it, and
+   refill the line from backing HBM.
+4. Stamp a newly filled or refreshed entry with the current epoch.
+5. Continue the requested read or write.
+
+The atomic boundary's existing order remains unchanged:
+
+1. Acquire the global exclusive coherence lock.
+2. Lock every registered L2 maintenance mutex in sorted address order.
+3. Flush dirty L2 data through MSC to HBM.
+4. Advance the global coherence epoch.
+5. Perform the linked-port RMW while the boundary remains held.
+
+After step 4, any MSC alias retained from an earlier epoch is stale. The RMW
+read therefore invalidates and refills that alias from HBM, where step 3
+published the authoritative value. Other old aliases are invalidated lazily on
+their next access.
+
+MSC is write-through, so an epoch-stale entry is expected to be clean and can
+be discarded without losing data. No MSC registration or new global lock is
+needed.
+
+## Alternatives
+
+### Eagerly flush and invalidate the entire MSC
+
+Registering MSC with the atomic boundary and calling `flush_all()` would be
+simple, but it scans 1,048,576 tags and locks all 256 stripes for every atomic.
+That cost is disproportionate to an individual RMW.
+
+### Bypass MSC only for atomic backing accesses
+
+Sending the RMW directly to HBM would obtain the correct operand, but clean MSC
+aliases could remain stale and be returned after the atomic. A generation or
+invalidation mechanism would still be required, while the backing protocol
+would become more complex.
+
+## Validation
+
+Add a regression with two L2 caches linked to one MSC and HBM controller:
+
+1. Map different `(VMID, GPU virtual address)` pairs to the same host word.
+2. Read through the second alias to retain a clean MSC value of `0`.
+3. Dirty `40` through the first L2 without immediately publishing it.
+4. Increment through the second L2's atomic RMW.
+5. Verify the callback observes `40`, the atomic result and host word are `41`,
+   and subsequent reads through both aliases return `41`.
+
+Run the focused L2/MSC tests in Release and under TSan, followed by the relevant
+non-benchmark test suite.
+
+Measure end-to-end performance against commit `b685943638` using representative
+large kernels from `rocjitsu-test-corpus`, including a large softmax, a large
+pack/unpack case, and a large matrix multiplication. Use the same pinned-CPU,
+alternating-run methodology as the previously published PR benchmark where the
+harness permits it.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -199,6 +199,7 @@ public:
     auto *base = static_cast<uint8_t *>(host_ptr);
     for (size_t off = 0; off < size; off += kPageSize)
       page_table_[(gpu_va + off) >> kPageShift] = {base + off, mtype};
+    page_table_generation_.fetch_add(1, std::memory_order_release);
   }
 
   /// @brief Unmap pages from this process's GPU page table.
@@ -206,10 +207,17 @@ public:
     std::unique_lock lock(page_table_mutex_);
     for (size_t off = 0; off < size; off += kPageSize)
       page_table_.erase((gpu_va + off) >> kPageShift);
+    page_table_generation_.fetch_add(1, std::memory_order_release);
   }
 
   mutable std::shared_mutex page_table_mutex_;
   PageTable page_table_;
+
+  /// @brief Page table version counter, bumped (release) on every map/unmap.
+  /// @details GpuMemory keeps per-thread TLB-like translation caches keyed by
+  ///          this generation; a mismatch on load (acquire) invalidates the
+  ///          cached entry and forces a fresh page-table walk.
+  std::atomic<uint64_t> page_table_generation_{1};
 
   // -- Per-process state --
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -252,7 +252,7 @@ public:
   }
 
   /// @brief Return the mutation counter used by GpuMemory translation caches.
-  std::atomic<uint64_t> *page_table_generation() { return &page_table_generation_; }
+  const uint64_t *page_table_generation() const { return &page_table_generation_; }
 
   mutable std::shared_mutex page_table_mutex_;
   PageTable page_table_;
@@ -302,15 +302,13 @@ public:
   DebugSession debug_session_;
 
 private:
-  void publish_page_table_mutation_locked() {
-    page_table_generation_.fetch_add(1, std::memory_order_release);
-  }
+  void publish_page_table_mutation_locked() { ++page_table_generation_; }
 
-  /// @brief Page table version counter, bumped (release) on every PTE mutation.
+  /// @brief Page table version counter, bumped on every PTE mutation.
   /// @details GpuMemory keeps per-thread TLB-like translation caches keyed by
-  ///          this generation; a mismatch on load (acquire) invalidates the
-  ///          cached entry and forces a fresh page-table walk.
-  std::atomic<uint64_t> page_table_generation_{1};
+  ///          this generation; all reads and writes occur while holding
+  ///          page_table_mutex_, so the counter itself does not need atomics.
+  uint64_t page_table_generation_{1};
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -202,7 +202,7 @@ public:
     // Keep publication in the page-table critical section. Cached readers
     // validate this generation while holding the shared side of the same lock;
     // publishing after unlock would permit a stale-cache hit in between.
-    page_table_generation_.fetch_add(1, std::memory_order_release);
+    publish_page_table_mutation_locked();
   }
 
   /// @brief Unmap pages from this process's GPU page table.
@@ -212,7 +212,43 @@ public:
       page_table_.erase((gpu_va + off) >> kPageShift);
     // See map_pages(): the mutation and generation publication are one
     // page-table critical section by design.
-    page_table_generation_.fetch_add(1, std::memory_order_release);
+    publish_page_table_mutation_locked();
+  }
+
+  /// @brief Replace mapped host pages while preserving their other PTE fields.
+  /// @details The mutation and cache-generation publication occur under one
+  /// page-table critical section. Only entries still pointing at the expected
+  /// old page are changed.
+  void remap_page_host_ptrs(uint64_t gpu_va, void *old_host_ptr, void *new_host_ptr, size_t size) {
+    std::unique_lock lock(page_table_mutex_);
+    auto *old_base = static_cast<uint8_t *>(old_host_ptr);
+    auto *new_base = static_cast<uint8_t *>(new_host_ptr);
+    bool changed = false;
+    for (size_t off = 0; off < size; off += kPageSize) {
+      auto it = page_table_.find((gpu_va + off) >> kPageShift);
+      if (it != page_table_.end() && it->second.host_ptr == old_base + off &&
+          it->second.host_ptr != new_base + off) {
+        it->second.host_ptr = new_base + off;
+        changed = true;
+      }
+    }
+    if (changed)
+      publish_page_table_mutation_locked();
+  }
+
+  /// @brief Update the MTYPE of mapped pages and invalidate cached PTE copies.
+  void set_page_mtype(uint64_t gpu_va, size_t size, amdgpu::Mtype mtype) {
+    std::unique_lock lock(page_table_mutex_);
+    bool changed = false;
+    for (size_t off = 0; off < size; off += kPageSize) {
+      auto it = page_table_.find((gpu_va + off) >> kPageShift);
+      if (it != page_table_.end() && it->second.mtype != mtype) {
+        it->second.mtype = mtype;
+        changed = true;
+      }
+    }
+    if (changed)
+      publish_page_table_mutation_locked();
   }
 
   /// @brief Return the mutation counter used by GpuMemory translation caches.
@@ -266,7 +302,11 @@ public:
   DebugSession debug_session_;
 
 private:
-  /// @brief Page table version counter, bumped (release) on every map/unmap.
+  void publish_page_table_mutation_locked() {
+    page_table_generation_.fetch_add(1, std::memory_order_release);
+  }
+
+  /// @brief Page table version counter, bumped (release) on every PTE mutation.
   /// @details GpuMemory keeps per-thread TLB-like translation caches keyed by
   ///          this generation; a mismatch on load (acquire) invalidates the
   ///          cached entry and forces a fresh page-table walk.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -199,6 +199,9 @@ public:
     auto *base = static_cast<uint8_t *>(host_ptr);
     for (size_t off = 0; off < size; off += kPageSize)
       page_table_[(gpu_va + off) >> kPageShift] = {base + off, mtype};
+    // Keep publication in the page-table critical section. Cached readers
+    // validate this generation while holding the shared side of the same lock;
+    // publishing after unlock would permit a stale-cache hit in between.
     page_table_generation_.fetch_add(1, std::memory_order_release);
   }
 
@@ -207,17 +210,16 @@ public:
     std::unique_lock lock(page_table_mutex_);
     for (size_t off = 0; off < size; off += kPageSize)
       page_table_.erase((gpu_va + off) >> kPageShift);
+    // See map_pages(): the mutation and generation publication are one
+    // page-table critical section by design.
     page_table_generation_.fetch_add(1, std::memory_order_release);
   }
 
+  /// @brief Return the mutation counter used by GpuMemory translation caches.
+  std::atomic<uint64_t> *page_table_generation() { return &page_table_generation_; }
+
   mutable std::shared_mutex page_table_mutex_;
   PageTable page_table_;
-
-  /// @brief Page table version counter, bumped (release) on every map/unmap.
-  /// @details GpuMemory keeps per-thread TLB-like translation caches keyed by
-  ///          this generation; a mismatch on load (acquire) invalidates the
-  ///          cached entry and forces a fresh page-table walk.
-  std::atomic<uint64_t> page_table_generation_{1};
 
   // -- Per-process state --
 
@@ -264,6 +266,11 @@ public:
   DebugSession debug_session_;
 
 private:
+  /// @brief Page table version counter, bumped (release) on every map/unmap.
+  /// @details GpuMemory keeps per-thread TLB-like translation caches keyed by
+  ///          this generation; a mismatch on load (acquire) invalidates the
+  ///          cached entry and forces a fresh page-table walk.
+  std::atomic<uint64_t> page_table_generation_{1};
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -370,7 +370,8 @@ int SimulatedKfd::open() {
   proc->event_state_.reset();
   for (auto &g : gpus_) {
     if (auto *mem = g.soc ? g.soc->memory() : nullptr) {
-      mem->register_process(pid, &proc->page_table_, &proc->page_table_mutex_);
+      mem->register_process(pid, &proc->page_table_, &proc->page_table_mutex_,
+                            &proc->page_table_generation_);
       if (!daemon_mode_)
         mem->set_passthrough(true);
     }
@@ -431,7 +432,8 @@ uint32_t SimulatedKfd::open_process(pid_t client_pid) {
     proc->event_state_.reset();
     for (auto &g : gpus_) {
       if (auto *mem = g.soc ? g.soc->memory() : nullptr) {
-        mem->register_process(pid, &proc->page_table_, &proc->page_table_mutex_);
+        mem->register_process(pid, &proc->page_table_, &proc->page_table_mutex_,
+                              &proc->page_table_generation_);
         if (client_pid > 0)
           mem->set_process_client_pid(pid, client_pid);
       }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -371,7 +371,7 @@ int SimulatedKfd::open() {
   for (auto &g : gpus_) {
     if (auto *mem = g.soc ? g.soc->memory() : nullptr) {
       mem->register_process(pid, &proc->page_table_, &proc->page_table_mutex_,
-                            &proc->page_table_generation_);
+                            proc->page_table_generation());
       if (!daemon_mode_)
         mem->set_passthrough(true);
     }
@@ -433,7 +433,7 @@ uint32_t SimulatedKfd::open_process(pid_t client_pid) {
     for (auto &g : gpus_) {
       if (auto *mem = g.soc ? g.soc->memory() : nullptr) {
         mem->register_process(pid, &proc->page_table_, &proc->page_table_mutex_,
-                              &proc->page_table_generation_);
+                              proc->page_table_generation());
         if (client_pid > 0)
           mem->set_process_client_pid(pid, client_pid);
       }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -1769,17 +1769,7 @@ int SimulatedKfd::ipc_export_handle_ioctl(KfdProcess &proc, void *arg) {
                          "true sharing)");
       }
 
-      {
-        std::unique_lock ptlk(proc.page_table_mutex_);
-        auto *old_base = static_cast<uint8_t *>(alloc.host_ptr);
-        auto *new_base = static_cast<uint8_t *>(new_host_ptr);
-        for (size_t off = 0; off < alloc.size; off += KfdProcess::kPageSize) {
-          uint64_t page_num = (alloc.gpu_va + off) >> KfdProcess::kPageShift;
-          auto pt_it = proc.page_table_.find(page_num);
-          if (pt_it != proc.page_table_.end() && pt_it->second.host_ptr == old_base + off)
-            pt_it->second.host_ptr = new_base + off;
-        }
-      }
+      proc.remap_page_host_ptrs(alloc.gpu_va, alloc.host_ptr, new_host_ptr, alloc.size);
 
       if (alloc.host_ptr_owned)
         libc_passthrough().munmap(alloc.host_ptr, alloc.size);
@@ -1810,15 +1800,7 @@ int SimulatedKfd::ipc_export_handle_ioctl(KfdProcess &proc, void *arg) {
     // the local GPU sees writes from the importing GPU.  On real hardware
     // xGMI snoops handle this; in the simulator CC forces L2 invalidate
     // before every refetch, emulating the cross-GPU coherence protocol.
-    {
-      std::unique_lock ptlk(proc.page_table_mutex_);
-      for (size_t off = 0; off < alloc.size; off += KfdProcess::kPageSize) {
-        uint64_t page_num = (alloc.gpu_va + off) >> KfdProcess::kPageShift;
-        auto pt_it = proc.page_table_.find(page_num);
-        if (pt_it != proc.page_table_.end())
-          pt_it->second.mtype = amdgpu::Mtype::CC;
-      }
-    }
+    proc.set_page_mtype(alloc.gpu_va, alloc.size, amdgpu::Mtype::CC);
 
     alloc_size = alloc.size;
     alloc_flags = alloc.flags;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/CMakeLists.txt
@@ -11,6 +11,7 @@ rj_add_object_library(rocjitsu_vm_amdgpu
     shader_engine.cpp
     xcd.cpp
     iod.cpp
+    device_cache_coherence.cpp
     l1_scalar_cache.cpp
     l1_vector_cache.cpp
     l2_cache.cpp

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -2001,16 +2001,11 @@ bool sdma_compare_u64(uint32_t func, uint64_t value, uint64_t reference) {
 } // namespace
 
 void CommandProcessor::flush_gpu_caches() {
-  // Write back dirty scalar L1 (K$) lines into L2 first, then flush L2 to
-  // backing, so a dirty K$ line overlapping an SDMA destination is published
-  // before the direct write (which happens after this helper returns) rather
-  // than being written out over it by a later K$ flush. Each line is written
-  // back under its own owning vmid. Vector L1 (V$) is write-through, so it only
-  // needs invalidation. Ordering: K$ -> L2 -> backing, then invalidate V$.
-  for (auto *cu : cus_) {
-    cu->l1_scalar().writeback_all();
+  // Both L1 caches are write-through, so discard their clean snapshots around
+  // direct backing writes. Flush dirty L2 data before the direct write so a
+  // later L2 flush cannot overwrite it.
+  for (auto *cu : cus_)
     cu->l1_scalar().invalidate_all();
-  }
   for (auto *l2 : l2_caches_)
     l2->flush_all();
   for (auto *cu : cus_)
@@ -2152,8 +2147,8 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         // caches. Real SDMA does not snoop GL2; coherence is re-established by
         // the consuming kernel's acquire fence at dispatch. We model that with a
         // coarse writeback+invalidate that runs BEFORE the direct write: the
-        // writeback publishes any dirty L2 lines (e.g. from K$ writeback) so
-        // they are not lost, and — critically — a dirty line overlapping the
+        // writeback publishes any dirty L2 lines so they are not lost, and —
+        // critically — a dirty line overlapping the
         // destination is written back first, so the subsequent SDMA write
         // supersedes it instead of being clobbered by a later flush. After the
         // flush the caches are empty, so the destination re-reads fresh backing.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -226,17 +226,15 @@ private:
   ///
   /// @warning Drops dirty L2 lines without writeback. Only use after a direct
   /// backing write whose destination is the only stale region; otherwise use
-  /// flush_gpu_caches() so K$-writeback dirty lines are published, not lost.
+  /// flush_gpu_caches() so dirty L2 lines are published, not lost.
   void invalidate_gpu_caches();
 
   /// @brief Coarse writeback+invalidate of the GPU data caches (L1 K$/V$ + L2).
   /// @details Like invalidate_gpu_caches(), but publishes dirty data instead of
-  /// dropping it. Ordering is load-bearing: dirty scalar L1 (K$) lines are
-  /// written back into L2 first, then L2 is flushed to backing, so a dirty K$ or
-  /// L2 line overlapping an SDMA destination reaches backing before the direct
-  /// SDMA write (which runs after this returns) rather than being written out
-  /// over it by a later K$/L2 flush. Each line is written back under its own
-  /// owning vmid. Vector L1 (V$) is write-through, so it only needs invalidation.
+  /// dropping it. Scalar and vector L1 are write-through and only need
+  /// invalidation. Dirty L2 data is flushed to backing before the direct SDMA
+  /// write (which runs after this returns), so a later L2 flush cannot overwrite
+  /// the direct result. Each L2 line is written back under its owning VMID.
   void flush_gpu_caches();
 
   /// @brief Parse an AQL dispatch packet, read its kernel descriptor, and create a DispatchEntry.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -287,8 +287,8 @@ public:
 
   /// @brief Flush all per-CU caches and the shared L2 to backing store.
   ///
-  /// @details L1 V$ uses write-through, so flush just invalidates. L2 flushes
-  /// all dirty lines to the backing MemoryInterface (MSC or HBM).
+  /// @details Both L1 caches use write-through, so flush just invalidates. L2
+  /// flushes all dirty lines to the backing MemoryInterface (MSC or HBM).
   /// Note: prefer flush_l1() + per-XCD L2 flush to avoid redundant L2 flushes
   /// when multiple CUs share the same L2.
   void flush_all(uint32_t vmid = 0) {
@@ -298,14 +298,13 @@ public:
                           reinterpret_cast<uintptr_t>(this), l1_vector_.store_count(),
                           l1_vector_.store_active_count(), l1_vector_.store_l2_writes());
     });
-    l1_scalar_.writeback_all(vmid);
     l1_scalar_.invalidate_all();
     l1_vector_.flush_all();
     l2_->flush_all(vmid);
   }
 
   void flush_l1(uint32_t vmid = 0) {
-    l1_scalar_.writeback_all(vmid);
+    (void)vmid;
     l1_scalar_.invalidate_all();
     l1_vector_.flush_all();
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/device_cache_coherence.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/device_cache_coherence.cpp
@@ -13,15 +13,6 @@ namespace rocjitsu {
 namespace amdgpu {
 namespace {
 
-template <typename T> void register_cache(std::vector<T *> &caches, T *cache) {
-  assert(cache != nullptr);
-  const auto it = std::find(caches.begin(), caches.end(), cache);
-  assert(it == caches.end());
-  if (it != caches.end())
-    return;
-  caches.push_back(cache);
-}
-
 template <typename T> void unregister_cache(std::vector<T *> &caches, T *cache) {
   auto it = std::find(caches.begin(), caches.end(), cache);
   assert(it != caches.end());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/device_cache_coherence.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/device_cache_coherence.cpp
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/amdgpu/device_cache_coherence.h"
+
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+
+#include <algorithm>
+#include <cassert>
+#include <functional>
+
+namespace rocjitsu {
+namespace amdgpu {
+namespace {
+
+template <typename T> void register_cache(std::vector<T *> &caches, T *cache) {
+  assert(cache != nullptr);
+  const auto it = std::find(caches.begin(), caches.end(), cache);
+  assert(it == caches.end());
+  if (it != caches.end())
+    return;
+  caches.push_back(cache);
+}
+
+template <typename T> void unregister_cache(std::vector<T *> &caches, T *cache) {
+  auto it = std::find(caches.begin(), caches.end(), cache);
+  assert(it != caches.end());
+  if (it != caches.end())
+    caches.erase(it);
+}
+
+} // namespace
+
+DeviceCacheCoherence &DeviceCacheCoherence::instance() {
+  // Cache components can be destroyed during static teardown. A process-lifetime
+  // coordinator avoids singleton destruction-order dependencies.
+  static auto *coherence = new DeviceCacheCoherence;
+  return *coherence;
+}
+
+DeviceCacheCoherence::AtomicBoundary::AtomicBoundary(AtomicBoundary &&other) noexcept
+    : owner_(std::exchange(other.owner_, nullptr)),
+      locked_l2_count_(std::exchange(other.locked_l2_count_, 0)),
+      atomic_lock_(std::move(other.atomic_lock_)),
+      coherence_lock_(std::move(other.coherence_lock_)) {}
+
+DeviceCacheCoherence::AtomicBoundary::~AtomicBoundary() {
+  if (owner_)
+    owner_->release_l2_locks(locked_l2_count_);
+}
+
+DeviceCacheCoherence::L1AccessGuard DeviceCacheCoherence::acquire_l1_access() {
+  return L1AccessGuard(mutex_);
+}
+
+DeviceCacheCoherence::AtomicBoundary DeviceCacheCoherence::acquire_atomic_boundary() {
+  std::unique_lock atomic_lock(atomic_mutex_);
+  std::unique_lock coherence_lock(mutex_);
+
+  size_t locked_l2_count = 0;
+  try {
+    // l2_caches_ is maintained in pointer order while mutex_ is held, so the
+    // boundary needs neither a registry copy nor a per-atomic allocation.
+    for (L2Cache *cache : l2_caches_) {
+      cache->maintenance_mutex_.lock();
+      ++locked_l2_count;
+    }
+
+    for (L2Cache *cache : l2_caches_)
+      cache->flush_dirty_locked();
+
+    // Eagerly walking every cache tag makes lane-level atomics prohibitively
+    // expensive. Advancing the epoch makes all extant clean lines logically
+    // stale; each cache discards them once, on its next ordinary access.
+    [[maybe_unused]] const uint64_t next_epoch = epoch_.fetch_add(1, std::memory_order_release) + 1;
+    assert(next_epoch != 0 && "device cache coherence epoch wrapped");
+  } catch (...) {
+    release_l2_locks(locked_l2_count);
+    throw;
+  }
+
+  return AtomicBoundary(this, locked_l2_count, std::move(atomic_lock), std::move(coherence_lock));
+}
+
+void DeviceCacheCoherence::release_l2_locks(size_t locked_l2_count) noexcept {
+  while (locked_l2_count != 0) {
+    --locked_l2_count;
+    l2_caches_[locked_l2_count]->maintenance_mutex_.unlock();
+  }
+}
+
+void DeviceCacheCoherence::register_l2_cache(L2Cache *cache) {
+  std::unique_lock lock(mutex_);
+  assert(cache != nullptr);
+  const auto it =
+      std::lower_bound(l2_caches_.begin(), l2_caches_.end(), cache, std::less<L2Cache *>());
+  assert(it == l2_caches_.end() || *it != cache);
+  if (it == l2_caches_.end() || *it != cache)
+    l2_caches_.insert(it, cache);
+}
+
+void DeviceCacheCoherence::unregister_l2_cache(L2Cache *cache) {
+  std::unique_lock lock(mutex_);
+  unregister_cache(l2_caches_, cache);
+}
+
+} // namespace amdgpu
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/device_cache_coherence.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/device_cache_coherence.h
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_VM_AMDGPU_DEVICE_CACHE_COHERENCE_H_
+#define ROCJITSU_VM_AMDGPU_DEVICE_CACHE_COHERENCE_H_
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <shared_mutex>
+#include <utility>
+#include <vector>
+
+namespace rocjitsu {
+namespace amdgpu {
+
+class L2Cache;
+
+/// @brief Coordinates functional cache state at device-wide atomic boundaries.
+///
+/// Normal L1 operations hold a shared guard. An atomic RMW holds the exclusive
+/// guard while dirty L2 state is published and the coherence epoch is
+/// advanced, preventing stale writeback or stale post-atomic hits.
+class DeviceCacheCoherence {
+public:
+  using L1AccessGuard = std::shared_lock<std::shared_mutex>;
+
+  /// @brief RAII guard for a fully prepared device-wide atomic boundary.
+  ///
+  /// Destruction releases all L2 maintenance locks before the device guard.
+  class AtomicBoundary {
+  public:
+    AtomicBoundary(AtomicBoundary &&other) noexcept;
+    AtomicBoundary &operator=(AtomicBoundary &&) = delete;
+    AtomicBoundary(const AtomicBoundary &) = delete;
+    AtomicBoundary &operator=(const AtomicBoundary &) = delete;
+    ~AtomicBoundary();
+
+  private:
+    friend class DeviceCacheCoherence;
+
+    AtomicBoundary(DeviceCacheCoherence *owner, size_t locked_l2_count,
+                   std::unique_lock<std::mutex> atomic_lock,
+                   std::unique_lock<std::shared_mutex> coherence_lock)
+        : owner_(owner), locked_l2_count_(locked_l2_count), atomic_lock_(std::move(atomic_lock)),
+          coherence_lock_(std::move(coherence_lock)) {}
+
+    DeviceCacheCoherence *owner_ = nullptr;
+    size_t locked_l2_count_ = 0;
+    std::unique_lock<std::mutex> atomic_lock_;
+    std::unique_lock<std::shared_mutex> coherence_lock_;
+  };
+
+  static DeviceCacheCoherence &instance();
+
+  [[nodiscard]] L1AccessGuard acquire_l1_access();
+  [[nodiscard]] AtomicBoundary acquire_atomic_boundary();
+  uint64_t current_epoch() const { return epoch_.load(std::memory_order_acquire); }
+
+  void register_l2_cache(L2Cache *cache);
+  void unregister_l2_cache(L2Cache *cache);
+
+private:
+  DeviceCacheCoherence() = default;
+  void release_l2_locks(size_t locked_l2_count) noexcept;
+
+  std::mutex atomic_mutex_;
+  std::shared_mutex mutex_;
+  std::atomic<uint64_t> epoch_{1};
+  std::vector<L2Cache *> l2_caches_;
+};
+
+} // namespace amdgpu
+} // namespace rocjitsu
+
+#endif // ROCJITSU_VM_AMDGPU_DEVICE_CACHE_COHERENCE_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -16,12 +16,14 @@
 #include <atomic>
 #include <cstring>
 #include <format>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <span>
 #include <string>
 #include <sys/uio.h>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 
@@ -39,6 +41,8 @@ class GpuMemory : public simdojo::SparseMemory {
 public:
   explicit GpuMemory(std::string name)
       : simdojo::SparseMemory(std::move(name)),
+        // A monotonic lifetime token prevents a thread-local cache from
+        // matching a different GpuMemory later constructed at the same address.
         instance_id_(next_instance_id_.fetch_add(1, std::memory_order_relaxed)) {
     cpl_ = add_port(std::make_unique<simdojo::Port>("cpl", 0, this, simdojo::PortDirection::IN,
                                                     simdojo::PortProtocol::MEMORY));
@@ -95,7 +99,10 @@ public:
   /// mapping and is only valid when simulator and target share an address space.
   void set_passthrough(bool v) { passthrough_ = v; }
 
-  /// @brief Resolve a GPU VA to a host pointer via the given VMID's page table.
+  /// @brief Resolve a GPU VA to a borrowed host-page pointer.
+  /// @details The returned pointer is only valid while page-table remapping and
+  /// process teardown are quiesced. Normal memory operations use an internal
+  /// callback that keeps the page-table shared lock held through the copy.
   uint8_t *resolve_host_ptr(uint64_t addr, uint32_t vmid = 0) const {
     return translate(addr, vmid);
   }
@@ -104,52 +111,10 @@ public:
   Mtype pte_mtype(uint64_t addr, uint32_t vmid = 0) const {
     if (vmid == 0)
       return Mtype::RW;
-    const uint64_t page_key = addr >> PAGE_SHIFT;
-    struct MtypeCache {
-      const GpuMemory *memory = nullptr;
-      uint64_t memory_instance = 0;
-      uint32_t vmid = 0;
-      uint64_t table_generation = 0;
-      uint64_t page_key = 0;
-      uint64_t generation = 0;
-      Mtype mtype = Mtype::RW;
-      KfdProcess::PageTable *page_table = nullptr;
-      std::shared_mutex *mutex = nullptr;
-      std::atomic<uint64_t> *generation_ptr = nullptr;
-    };
-    static thread_local MtypeCache cache;
-
-    {
-      std::shared_lock lk(vmid_mutex_);
-      uint64_t table_generation = vmid_table_generation_.load(std::memory_order_acquire);
-      if (cache.memory == this && cache.memory_instance == instance_id_ && cache.vmid == vmid &&
-          cache.table_generation == table_generation && cache.generation_ptr) {
-        uint64_t generation = cache.generation_ptr->load(std::memory_order_acquire);
-        if (cache.generation == generation && cache.page_key == page_key)
-          return cache.mtype;
-        if (cache.generation == generation && cache.page_table && cache.mutex) {
-          std::shared_lock pt_lk(*cache.mutex);
-          auto pt_it = cache.page_table->find(page_key);
-          cache.page_key = page_key;
-          cache.mtype = pt_it != cache.page_table->end() ? pt_it->second.mtype : Mtype::RW;
-          return cache.mtype;
-        }
-      }
-
-      auto it = vmid_table_.find(vmid);
-      if (it != vmid_table_.end()) {
-        auto &entry = it->second;
-        uint64_t generation =
-            entry.generation ? entry.generation->load(std::memory_order_acquire) : 0;
-        std::shared_lock pt_lk(*entry.mutex);
-        auto pt_it = entry.page_table->find(page_key);
-        Mtype mtype = pt_it != entry.page_table->end() ? pt_it->second.mtype : Mtype::RW;
-        cache = {this,  instance_id_,     vmid,        table_generation, page_key, generation,
-                 mtype, entry.page_table, entry.mutex, entry.generation};
-        return mtype;
-      }
-    }
-    return Mtype::RW;
+    static thread_local PteCache cache;
+    return cached_walk(addr, vmid, cache, [](const KfdProcess::PageTableEntry *pte) {
+      return pte ? pte->mtype : Mtype::RW;
+    });
   }
 
   uint32_t fetch32(uint64_t addr, uint32_t vmid = 0) const { return read32(addr, vmid); }
@@ -160,10 +125,8 @@ public:
   void read_block(uint64_t addr, std::span<uint8_t> dst, uint32_t vmid = 0) const {
     for_each_page_chunk(addr, dst.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
       auto out = dst.subspan(offset, chunk);
-      if (auto *p = translate(ea, vmid)) {
-        std::memcpy(out.data(), p + (ea & PAGE_MASK), chunk);
+      if (read_mapped(ea, out.data(), chunk, vmid))
         return;
-      }
       if (vmid > 0 && read_client_memory(ea, out.data(), chunk, vmid))
         return;
       for (size_t i = 0; i < chunk; ++i)
@@ -177,10 +140,8 @@ public:
   void write_block(uint64_t addr, std::span<const uint8_t> src, uint32_t vmid = 0) {
     for_each_page_chunk(addr, src.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
       auto in = src.subspan(offset, chunk);
-      if (auto *p = translate(ea, vmid)) {
-        std::memcpy(p + (ea & PAGE_MASK), in.data(), chunk);
+      if (write_mapped(ea, in.data(), chunk, vmid))
         return;
-      }
       if (vmid > 0 && write_client_memory(ea, in.data(), chunk, vmid))
         return;
       for (size_t i = 0; i < chunk; ++i)
@@ -251,7 +212,7 @@ public:
     if (pt_it != entry.page_table->end())
       return "page_found";
     std::string result = "page_missing pt_size=" + std::to_string(entry.page_table->size());
-    uint64_t lo = UINT64_MAX, hi = 0;
+    uint64_t lo = std::numeric_limits<uint64_t>::max(), hi = 0;
     for (auto &[k, v] : *entry.page_table) {
       if (k < lo)
         lo = k;
@@ -263,85 +224,68 @@ public:
   }
 
   uint8_t read8(uint64_t addr, uint32_t vmid = 0) const {
-    if (auto *p = translate(addr, vmid))
-      return p[addr & PAGE_MASK];
     uint8_t val = 0;
+    if (read_mapped(addr, &val, sizeof(val), vmid))
+      return val;
     if (vmid > 0 && read_client_memory(addr, &val, 1, vmid))
       return val;
     return SparseMemory::read8(addr);
   }
 
   uint16_t read16(uint64_t addr, uint32_t vmid = 0) const {
-    if (auto *p = translate(addr, vmid); p && (addr & PAGE_MASK) + 2 <= PAGE_SIZE) {
-      uint16_t val;
-      std::memcpy(&val, p + (addr & PAGE_MASK), 2);
-      return val;
-    }
     uint16_t val = 0;
+    if (read_mapped(addr, &val, sizeof(val), vmid))
+      return val;
     if (vmid > 0 && read_client_memory(addr, &val, 2, vmid))
       return val;
     return SparseMemory::read16(addr);
   }
 
   uint32_t read32(uint64_t addr, uint32_t vmid = 0) const {
-    if (auto *p = translate(addr, vmid); p && (addr & PAGE_MASK) + 4 <= PAGE_SIZE) {
-      uint32_t val;
-      std::memcpy(&val, p + (addr & PAGE_MASK), 4);
-      return val;
-    }
     uint32_t val = 0;
+    if (read_mapped(addr, &val, sizeof(val), vmid))
+      return val;
     if (vmid > 0 && read_client_memory(addr, &val, 4, vmid))
       return val;
     return SparseMemory::read32(addr);
   }
 
   uint64_t read64(uint64_t addr, uint32_t vmid = 0) const {
-    if (auto *p = translate(addr, vmid); p && (addr & PAGE_MASK) + 8 <= PAGE_SIZE) {
-      uint64_t val;
-      std::memcpy(&val, p + (addr & PAGE_MASK), 8);
-      return val;
-    }
     uint64_t val = 0;
+    if (read_mapped(addr, &val, sizeof(val), vmid))
+      return val;
     if (vmid > 0 && read_client_memory(addr, &val, 8, vmid))
       return val;
     return SparseMemory::read64(addr);
   }
 
   void write8(uint64_t addr, uint8_t val, uint32_t vmid = 0) {
-    if (auto *p = translate(addr, vmid)) {
-      p[addr & PAGE_MASK] = val;
+    if (write_mapped(addr, &val, sizeof(val), vmid))
       return;
-    }
     if (vmid > 0 && write_client_memory(addr, &val, 1, vmid))
       return;
     SparseMemory::write8(addr, val);
   }
 
   void write16(uint64_t addr, uint16_t val, uint32_t vmid = 0) {
-    if (auto *p = translate(addr, vmid); p && (addr & PAGE_MASK) + 2 <= PAGE_SIZE) {
-      std::memcpy(p + (addr & PAGE_MASK), &val, 2);
+    if (write_mapped(addr, &val, sizeof(val), vmid))
       return;
-    }
     if (vmid > 0 && write_client_memory(addr, &val, 2, vmid))
       return;
     SparseMemory::write16(addr, val);
   }
 
   void write32(uint64_t addr, uint32_t val, uint32_t vmid = 0) {
-    if (auto *p = translate(addr, vmid); p && (addr & PAGE_MASK) + 4 <= PAGE_SIZE) {
-      std::memcpy(p + (addr & PAGE_MASK), &val, 4);
+    if (write_mapped(addr, &val, sizeof(val), vmid))
       return;
-    }
     if (vmid > 0 && write_client_memory(addr, &val, 4, vmid))
       return;
     SparseMemory::write32(addr, val);
   }
 
   void write64(uint64_t addr, uint64_t val, uint32_t vmid = 0) {
-    if (auto *p = translate(addr, vmid); p && (addr & PAGE_MASK) + 8 <= PAGE_SIZE) {
-      std::memcpy(p + (addr & PAGE_MASK), &val, 8);
+    if (write_mapped(addr, &val, sizeof(val), vmid))
       return;
-    }
     if (vmid > 0 && write_client_memory(addr, &val, 8, vmid))
       return;
     SparseMemory::write64(addr, val);
@@ -360,8 +304,6 @@ private:
 
   static constexpr uint64_t kUserSpaceLimit = 0x800000000000ULL;
 
-  // Thread-local translation caches keep these pointers only while the simulated
-  // process is active; driver teardown unregisters after GPU work is drained.
   struct VmidEntry {
     KfdProcess::PageTable *page_table = nullptr;
     std::shared_mutex *mutex = nullptr;
@@ -369,66 +311,108 @@ private:
     std::atomic<uint64_t> *generation = nullptr;
   };
 
-  uint8_t *translate(uint64_t addr, uint32_t vmid) const {
-    if (vmid == 0)
-      return passthrough_ ? reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK) : nullptr;
+  struct PteCache {
+    const GpuMemory *memory = nullptr;
+    uint64_t memory_instance = 0;
+    uint32_t vmid = 0;
+    uint64_t table_generation = 0;
+    uint64_t page_key = 0;
+    uint64_t generation = 0;
+    bool found = false;
+    KfdProcess::PageTableEntry pte;
+    KfdProcess::PageTable *page_table = nullptr;
+    std::shared_mutex *mutex = nullptr;
+    std::atomic<uint64_t> *generation_ptr = nullptr;
+  };
+
+  /// @brief Walk a VMID page table with a generation-keyed thread-local cache.
+  /// @details The callback runs while both VMID registration and the selected
+  /// page table are shared-locked. This keeps a cached host pointer alive for
+  /// the whole copy and makes translate() and pte_mtype() share one invalidation
+  /// protocol.
+  template <typename F>
+  auto cached_walk(uint64_t addr, uint32_t vmid, PteCache &cache,
+                   F &&fn) const -> std::invoke_result_t<F, const KfdProcess::PageTableEntry *> {
     const uint64_t page_key = addr >> PAGE_SHIFT;
-    struct TranslationCache {
-      const GpuMemory *memory = nullptr;
-      uint64_t memory_instance = 0;
-      uint32_t vmid = 0;
-      uint64_t table_generation = 0;
-      uint64_t page_key = 0;
-      uint64_t generation = 0;
-      uint8_t *host_ptr = nullptr;
-      KfdProcess::PageTable *page_table = nullptr;
-      std::shared_mutex *mutex = nullptr;
-      std::atomic<uint64_t> *generation_ptr = nullptr;
-    };
-    static thread_local TranslationCache cache;
+    std::shared_lock vmid_lock(vmid_mutex_);
+    const uint64_t table_generation = vmid_table_generation_.load(std::memory_order_acquire);
 
-    {
-      std::shared_lock lk(vmid_mutex_);
-      uint64_t table_generation = vmid_table_generation_.load(std::memory_order_acquire);
-      if (cache.memory == this && cache.memory_instance == instance_id_ && cache.vmid == vmid &&
-          cache.table_generation == table_generation && cache.generation_ptr) {
-        uint64_t generation = cache.generation_ptr->load(std::memory_order_acquire);
-        if (cache.generation == generation && cache.page_key == page_key)
-          return cache.host_ptr;
-        if (cache.generation == generation && cache.page_table && cache.mutex) {
-          std::shared_lock pt_lk(*cache.mutex);
-          auto pt_it = cache.page_table->find(page_key);
-          uint8_t *host_ptr = nullptr;
-          if (pt_it != cache.page_table->end())
-            host_ptr = pt_it->second.host_ptr;
-          else if (passthrough_ && addr < kUserSpaceLimit)
-            host_ptr = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
-          cache.page_key = page_key;
-          cache.host_ptr = host_ptr;
-          return host_ptr;
-        }
-      }
-
+    const bool cached_table = cache.memory == this && cache.memory_instance == instance_id_ &&
+                              cache.vmid == vmid && cache.table_generation == table_generation &&
+                              cache.page_table && cache.mutex;
+    if (!cached_table) {
       auto it = vmid_table_.find(vmid);
-      if (it != vmid_table_.end()) {
-        auto &entry = it->second;
-        uint64_t generation =
-            entry.generation ? entry.generation->load(std::memory_order_acquire) : 0;
-        std::shared_lock pt_lk(*entry.mutex);
-        auto pt_it = entry.page_table->find(page_key);
-        uint8_t *host_ptr = nullptr;
-        if (pt_it != entry.page_table->end())
-          host_ptr = pt_it->second.host_ptr;
-        else if (passthrough_ && addr < kUserSpaceLimit)
-          host_ptr = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
-        cache = {this,     instance_id_,     vmid,        table_generation, page_key, generation,
-                 host_ptr, entry.page_table, entry.mutex, entry.generation};
-        return host_ptr;
+      if (it == vmid_table_.end()) {
+        cache = {};
+        return fn(nullptr);
       }
+      cache.memory = this;
+      cache.memory_instance = instance_id_;
+      cache.vmid = vmid;
+      cache.table_generation = table_generation;
+      cache.page_table = it->second.page_table;
+      cache.mutex = it->second.mutex;
+      cache.generation_ptr = it->second.generation;
+      cache.found = false;
     }
-    if (passthrough_ && addr < kUserSpaceLimit)
-      return reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
-    return nullptr;
+
+    std::shared_lock page_table_lock(*cache.mutex);
+    const uint64_t generation =
+        cache.generation_ptr ? cache.generation_ptr->load(std::memory_order_acquire) : 0;
+    const bool cached_page = cached_table && cache.generation_ptr &&
+                             cache.generation == generation && cache.page_key == page_key;
+    if (!cached_page) {
+      auto it = cache.page_table->find(page_key);
+      cache.page_key = page_key;
+      cache.generation = generation;
+      cache.found = it != cache.page_table->end();
+      if (cache.found)
+        cache.pte = it->second;
+    }
+
+    return fn(cache.found ? &cache.pte : nullptr);
+  }
+
+  template <typename F> bool with_host_ptr(uint64_t addr, uint32_t vmid, F &&fn) const {
+    if (vmid == 0) {
+      if (!passthrough_)
+        return false;
+      fn(reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK));
+      return true;
+    }
+
+    static thread_local PteCache cache;
+    return cached_walk(addr, vmid, cache, [&](const KfdProcess::PageTableEntry *pte) {
+      if (pte) {
+        fn(pte->host_ptr);
+        return true;
+      }
+      if (passthrough_ && addr < kUserSpaceLimit) {
+        fn(reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK));
+        return true;
+      }
+      return false;
+    });
+  }
+
+  bool read_mapped(uint64_t addr, void *dst, size_t len, uint32_t vmid) const {
+    if ((addr & PAGE_MASK) + len > PAGE_SIZE)
+      return false;
+    return with_host_ptr(
+        addr, vmid, [&](const uint8_t *page) { std::memcpy(dst, page + (addr & PAGE_MASK), len); });
+  }
+
+  bool write_mapped(uint64_t addr, const void *src, size_t len, uint32_t vmid) {
+    if ((addr & PAGE_MASK) + len > PAGE_SIZE)
+      return false;
+    return with_host_ptr(addr, vmid,
+                         [&](uint8_t *page) { std::memcpy(page + (addr & PAGE_MASK), src, len); });
+  }
+
+  uint8_t *translate(uint64_t addr, uint32_t vmid) const {
+    uint8_t *host_ptr = nullptr;
+    with_host_ptr(addr, vmid, [&](uint8_t *page) { host_ptr = page; });
+    return host_ptr;
   }
 
   pid_t client_pid_for_vmid(uint32_t vmid) const {
@@ -468,6 +452,8 @@ private:
   }
 
   simdojo::Port *cpl_ = nullptr;
+  // fetch_add is intentional: every object lifetime needs a distinct token;
+  // resetting this atomic would let an address-reused object match stale TLS.
   inline static std::atomic<uint64_t> next_instance_id_{1};
   const uint64_t instance_id_;
   mutable std::shared_mutex vmid_mutex_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -13,6 +13,7 @@
 #include "util/log.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cstring>
 #include <format>
 #include <memory>
@@ -36,7 +37,9 @@ namespace amdgpu {
 /// issuing wave through the memory hierarchy.
 class GpuMemory : public simdojo::SparseMemory {
 public:
-  explicit GpuMemory(std::string name) : simdojo::SparseMemory(std::move(name)) {
+  explicit GpuMemory(std::string name)
+      : simdojo::SparseMemory(std::move(name)),
+        instance_id_(next_instance_id_.fetch_add(1, std::memory_order_relaxed)) {
     cpl_ = add_port(std::make_unique<simdojo::Port>("cpl", 0, this, simdojo::PortDirection::IN,
                                                     simdojo::PortProtocol::MEMORY));
     cpl_->recv_event()->set_handler([this](simdojo::Tick, simdojo::Message *msg) {
@@ -54,11 +57,15 @@ public:
   simdojo::Port *cpl_port() { return cpl_; }
 
   /// @brief Register a process's page table in the VMID table.
-  void register_process(uint32_t pid, KfdProcess::PageTable *pt, std::shared_mutex *mu) {
+  /// @param generation Optional mutation counter used by translation caches.
+  ///        Omitting it disables the per-thread fast path for this page table.
+  void register_process(uint32_t pid, KfdProcess::PageTable *pt, std::shared_mutex *mu,
+                        std::atomic<uint64_t> *generation = nullptr) {
     util::Logger::cp("VMID_REG pid=", pid, " mem=0x", std::hex, reinterpret_cast<uintptr_t>(this),
                      std::dec, " pt_size=", pt->size());
     std::unique_lock lk(vmid_mutex_);
-    vmid_table_[pid] = {pt, mu};
+    vmid_table_[pid] = {pt, mu, 0, generation};
+    vmid_table_generation_.fetch_add(1, std::memory_order_release);
   }
 
   /// @brief Unregister a process from the VMID table.
@@ -66,7 +73,13 @@ public:
     util::Logger::cp("VMID_UNREG pid=", pid, " mem=0x", std::hex, reinterpret_cast<uintptr_t>(this),
                      std::dec);
     std::unique_lock lk(vmid_mutex_);
-    vmid_table_.erase(pid);
+    auto it = vmid_table_.find(pid);
+    if (it == vmid_table_.end())
+      return;
+    if (it->second.generation)
+      it->second.generation->fetch_add(1, std::memory_order_release);
+    vmid_table_.erase(it);
+    vmid_table_generation_.fetch_add(1, std::memory_order_release);
   }
 
   void set_process_client_pid(uint32_t pid, pid_t client_pid) {
@@ -91,15 +104,49 @@ public:
   Mtype pte_mtype(uint64_t addr, uint32_t vmid = 0) const {
     if (vmid == 0)
       return Mtype::RW;
+    const uint64_t page_key = addr >> PAGE_SHIFT;
+    struct MtypeCache {
+      const GpuMemory *memory = nullptr;
+      uint64_t memory_instance = 0;
+      uint32_t vmid = 0;
+      uint64_t table_generation = 0;
+      uint64_t page_key = 0;
+      uint64_t generation = 0;
+      Mtype mtype = Mtype::RW;
+      KfdProcess::PageTable *page_table = nullptr;
+      std::shared_mutex *mutex = nullptr;
+      std::atomic<uint64_t> *generation_ptr = nullptr;
+    };
+    static thread_local MtypeCache cache;
+
     {
       std::shared_lock lk(vmid_mutex_);
+      uint64_t table_generation = vmid_table_generation_.load(std::memory_order_acquire);
+      if (cache.memory == this && cache.memory_instance == instance_id_ && cache.vmid == vmid &&
+          cache.table_generation == table_generation && cache.generation_ptr) {
+        uint64_t generation = cache.generation_ptr->load(std::memory_order_acquire);
+        if (cache.generation == generation && cache.page_key == page_key)
+          return cache.mtype;
+        if (cache.generation == generation && cache.page_table && cache.mutex) {
+          std::shared_lock pt_lk(*cache.mutex);
+          auto pt_it = cache.page_table->find(page_key);
+          cache.page_key = page_key;
+          cache.mtype = pt_it != cache.page_table->end() ? pt_it->second.mtype : Mtype::RW;
+          return cache.mtype;
+        }
+      }
+
       auto it = vmid_table_.find(vmid);
       if (it != vmid_table_.end()) {
         auto &entry = it->second;
+        uint64_t generation =
+            entry.generation ? entry.generation->load(std::memory_order_acquire) : 0;
         std::shared_lock pt_lk(*entry.mutex);
-        auto pt_it = entry.page_table->find(addr >> PAGE_SHIFT);
-        if (pt_it != entry.page_table->end())
-          return pt_it->second.mtype;
+        auto pt_it = entry.page_table->find(page_key);
+        Mtype mtype = pt_it != entry.page_table->end() ? pt_it->second.mtype : Mtype::RW;
+        cache = {this,  instance_id_,     vmid,        table_generation, page_key, generation,
+                 mtype, entry.page_table, entry.mutex, entry.generation};
+        return mtype;
       }
     }
     return Mtype::RW;
@@ -311,27 +358,74 @@ private:
     }
   }
 
+  static constexpr uint64_t kUserSpaceLimit = 0x800000000000ULL;
+
+  // Thread-local translation caches keep these pointers only while the simulated
+  // process is active; driver teardown unregisters after GPU work is drained.
   struct VmidEntry {
     KfdProcess::PageTable *page_table = nullptr;
     std::shared_mutex *mutex = nullptr;
     pid_t client_pid = 0;
+    std::atomic<uint64_t> *generation = nullptr;
   };
 
   uint8_t *translate(uint64_t addr, uint32_t vmid) const {
     if (vmid == 0)
       return passthrough_ ? reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK) : nullptr;
+    const uint64_t page_key = addr >> PAGE_SHIFT;
+    struct TranslationCache {
+      const GpuMemory *memory = nullptr;
+      uint64_t memory_instance = 0;
+      uint32_t vmid = 0;
+      uint64_t table_generation = 0;
+      uint64_t page_key = 0;
+      uint64_t generation = 0;
+      uint8_t *host_ptr = nullptr;
+      KfdProcess::PageTable *page_table = nullptr;
+      std::shared_mutex *mutex = nullptr;
+      std::atomic<uint64_t> *generation_ptr = nullptr;
+    };
+    static thread_local TranslationCache cache;
+
     {
       std::shared_lock lk(vmid_mutex_);
+      uint64_t table_generation = vmid_table_generation_.load(std::memory_order_acquire);
+      if (cache.memory == this && cache.memory_instance == instance_id_ && cache.vmid == vmid &&
+          cache.table_generation == table_generation && cache.generation_ptr) {
+        uint64_t generation = cache.generation_ptr->load(std::memory_order_acquire);
+        if (cache.generation == generation && cache.page_key == page_key)
+          return cache.host_ptr;
+        if (cache.generation == generation && cache.page_table && cache.mutex) {
+          std::shared_lock pt_lk(*cache.mutex);
+          auto pt_it = cache.page_table->find(page_key);
+          uint8_t *host_ptr = nullptr;
+          if (pt_it != cache.page_table->end())
+            host_ptr = pt_it->second.host_ptr;
+          else if (passthrough_ && addr < kUserSpaceLimit)
+            host_ptr = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
+          cache.page_key = page_key;
+          cache.host_ptr = host_ptr;
+          return host_ptr;
+        }
+      }
+
       auto it = vmid_table_.find(vmid);
       if (it != vmid_table_.end()) {
         auto &entry = it->second;
+        uint64_t generation =
+            entry.generation ? entry.generation->load(std::memory_order_acquire) : 0;
         std::shared_lock pt_lk(*entry.mutex);
-        auto pt_it = entry.page_table->find(addr >> PAGE_SHIFT);
+        auto pt_it = entry.page_table->find(page_key);
+        uint8_t *host_ptr = nullptr;
         if (pt_it != entry.page_table->end())
-          return pt_it->second.host_ptr;
+          host_ptr = pt_it->second.host_ptr;
+        else if (passthrough_ && addr < kUserSpaceLimit)
+          host_ptr = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
+        cache = {this,     instance_id_,     vmid,        table_generation, page_key, generation,
+                 host_ptr, entry.page_table, entry.mutex, entry.generation};
+        return host_ptr;
       }
     }
-    static constexpr uint64_t kUserSpaceLimit = 0x800000000000ULL;
     if (passthrough_ && addr < kUserSpaceLimit)
       return reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
     return nullptr;
@@ -374,8 +468,11 @@ private:
   }
 
   simdojo::Port *cpl_ = nullptr;
+  inline static std::atomic<uint64_t> next_instance_id_{1};
+  const uint64_t instance_id_;
   mutable std::shared_mutex vmid_mutex_;
   std::unordered_map<uint32_t, VmidEntry> vmid_table_;
+  mutable std::atomic<uint64_t> vmid_table_generation_ = 1;
   bool passthrough_ = false;
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -421,20 +421,26 @@ private:
 
   template <typename F> bool with_host_ptr(uint64_t addr, uint32_t vmid, F &&fn) const {
     if (vmid == 0) {
-      if (!passthrough_ || addr >= kUserSpaceLimit)
+      auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
+      if (!passthrough_ || addr >= kUserSpaceLimit || page == nullptr)
         return false;
-      fn(reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK));
+      fn(page);
       return true;
     }
 
     static thread_local PteCache cache;
     return cached_walk(addr, vmid, cache, [&](const KfdProcess::PageTableEntry *pte) {
       if (pte) {
+        if (pte->host_ptr == nullptr)
+          return false;
         fn(pte->host_ptr);
         return true;
       }
       if (passthrough_ && addr < kUserSpaceLimit) {
-        fn(reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK));
+        auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
+        if (page == nullptr)
+          return false;
+        fn(page);
         return true;
       }
       return false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -43,8 +43,9 @@ class GpuMemory : public simdojo::SparseMemory {
 public:
   explicit GpuMemory(std::string name)
       : simdojo::SparseMemory(std::move(name)),
-        // A monotonic lifetime token prevents a thread-local cache from
-        // matching a different GpuMemory later constructed at the same address.
+        // Function-static TLS translation caches may outlive a GpuMemory on a
+        // long-lived host thread. A lifetime token prevents one of those caches
+        // from matching an object later reconstructed at the same address.
         instance_id_(next_instance_id_.fetch_add(1, std::memory_order_relaxed)) {
     cpl_ = add_port(std::make_unique<simdojo::Port>("cpl", 0, this, simdojo::PortDirection::IN,
                                                     simdojo::PortProtocol::MEMORY));
@@ -66,12 +67,19 @@ public:
   /// @param generation Optional mutation counter used by translation caches.
   ///        Omitting it disables the per-thread fast path for this page table.
   void register_process(uint32_t pid, KfdProcess::PageTable *pt, std::shared_mutex *mu,
-                        std::atomic<uint64_t> *generation = nullptr) {
+                        const uint64_t *generation = nullptr) {
     util::Logger::cp("VMID_REG pid=", pid, " mem=0x", std::hex, reinterpret_cast<uintptr_t>(this),
                      std::dec, " pt_size=", pt->size());
     std::unique_lock lk(vmid_mutex_);
-    vmid_table_[pid] = {pt, mu, 0, generation};
-    vmid_table_generation_.fetch_add(1, std::memory_order_release);
+    vmid_table_[pid] = {
+        .page_table = pt,
+        .mutex = mu,
+        .client_pid = 0,
+        .generation = generation,
+    };
+    // The VMID may now select a different page table even though neither page
+    // table changed. Invalidate TLS entries that cached the old registration.
+    ++vmid_registry_generation_;
   }
 
   /// @brief Unregister a process from the VMID table.
@@ -82,10 +90,8 @@ public:
     auto it = vmid_table_.find(pid);
     if (it == vmid_table_.end())
       return;
-    if (it->second.generation)
-      it->second.generation->fetch_add(1, std::memory_order_release);
     vmid_table_.erase(it);
-    vmid_table_generation_.fetch_add(1, std::memory_order_release);
+    ++vmid_registry_generation_;
   }
 
   void set_process_client_pid(uint32_t pid, pid_t client_pid) {
@@ -175,7 +181,7 @@ public:
     const pid_t client_pid = client_pid_for_vmid(vmid);
     uintptr_t key = static_cast<uintptr_t>(addr ^ (addr >> 32));
     if (client_pid > 0) {
-      key ^= static_cast<uintptr_t>(client_pid) * 0x9e3779b97f4a7c15ULL;
+      key ^= static_cast<uintptr_t>(client_pid) * kClientPidHashSalt;
     } else {
       key ^= reinterpret_cast<uintptr_t>(this);
     }
@@ -330,11 +336,24 @@ public:
   }
 
 private:
+  // The largest supported atomic is eight bytes, so discard the three byte
+  // offset bits before choosing a lock stripe.
+  static constexpr unsigned kBackingAtomicGranuleShift = 3;
+  // Fold high address bits into the low stripe-index bits before masking.
+  static constexpr unsigned kBackingAtomicHashFoldShift1 = 17;
+  static constexpr unsigned kBackingAtomicHashFoldShift2 = 31;
+  // Bound mutex storage while keeping collisions low for common GPU workloads.
+  static constexpr size_t kBackingAtomicLockStripes = 4096;
+  // The 64-bit golden-ratio hash constant scatters adjacent client PIDs.
+  static constexpr uintptr_t kClientPidHashSalt = static_cast<uintptr_t>(0x9e3779b97f4a7c15ULL);
+  static_assert((kBackingAtomicLockStripes & (kBackingAtomicLockStripes - 1)) == 0,
+                "atomic lock stripe count must be a power of two");
+
   static std::mutex &backing_atomic_mutex(uintptr_t key) {
-    static std::array<std::mutex, 4096> mutexes;
-    key >>= 3;
-    key ^= key >> 17;
-    key ^= key >> 31;
+    static std::array<std::mutex, kBackingAtomicLockStripes> mutexes;
+    key >>= kBackingAtomicGranuleShift;
+    key ^= key >> kBackingAtomicHashFoldShift1;
+    key ^= key >> kBackingAtomicHashFoldShift2;
     return mutexes[key & (mutexes.size() - 1)];
   }
 
@@ -354,21 +373,21 @@ private:
     KfdProcess::PageTable *page_table = nullptr;
     std::shared_mutex *mutex = nullptr;
     pid_t client_pid = 0;
-    std::atomic<uint64_t> *generation = nullptr;
+    const uint64_t *generation = nullptr;
   };
 
   struct PteCache {
     const GpuMemory *memory = nullptr;
     uint64_t memory_instance = 0;
     uint32_t vmid = 0;
-    uint64_t table_generation = 0;
+    uint64_t registry_generation = 0;
     uint64_t page_key = 0;
     uint64_t generation = 0;
     bool found = false;
     KfdProcess::PageTableEntry pte;
     KfdProcess::PageTable *page_table = nullptr;
     std::shared_mutex *mutex = nullptr;
-    std::atomic<uint64_t> *generation_ptr = nullptr;
+    const uint64_t *generation_ptr = nullptr;
   };
 
   /// @brief Walk a VMID page table with a generation-keyed thread-local cache.
@@ -377,15 +396,15 @@ private:
   /// the whole copy and makes translate() and pte_mtype() share one invalidation
   /// protocol.
   template <typename F>
-  auto cached_walk(uint64_t addr, uint32_t vmid, PteCache &cache,
-                   F &&fn) const -> std::invoke_result_t<F, const KfdProcess::PageTableEntry *> {
+  auto cached_walk(uint64_t addr, uint32_t vmid, PteCache &cache, F &&fn) const
+      -> std::invoke_result_t<F, const KfdProcess::PageTableEntry *> {
     const uint64_t page_key = addr >> PAGE_SHIFT;
     std::shared_lock vmid_lock(vmid_mutex_);
-    const uint64_t table_generation = vmid_table_generation_.load(std::memory_order_acquire);
+    const uint64_t registry_generation = vmid_registry_generation_;
 
-    const bool cached_table = cache.memory == this && cache.memory_instance == instance_id_ &&
-                              cache.vmid == vmid && cache.table_generation == table_generation &&
-                              cache.page_table && cache.mutex;
+    const bool cached_table =
+        cache.memory == this && cache.memory_instance == instance_id_ && cache.vmid == vmid &&
+        cache.registry_generation == registry_generation && cache.page_table && cache.mutex;
     if (!cached_table) {
       auto it = vmid_table_.find(vmid);
       if (it == vmid_table_.end()) {
@@ -395,7 +414,7 @@ private:
       cache.memory = this;
       cache.memory_instance = instance_id_;
       cache.vmid = vmid;
-      cache.table_generation = table_generation;
+      cache.registry_generation = registry_generation;
       cache.page_table = it->second.page_table;
       cache.mutex = it->second.mutex;
       cache.generation_ptr = it->second.generation;
@@ -403,8 +422,7 @@ private:
     }
 
     std::shared_lock page_table_lock(*cache.mutex);
-    const uint64_t generation =
-        cache.generation_ptr ? cache.generation_ptr->load(std::memory_order_acquire) : 0;
+    const uint64_t generation = cache.generation_ptr ? *cache.generation_ptr : 0;
     const bool cached_page = cached_table && cache.generation_ptr &&
                              cache.generation == generation && cache.page_key == page_key;
     if (!cached_page) {
@@ -504,13 +522,14 @@ private:
   }
 
   simdojo::Port *cpl_ = nullptr;
-  // fetch_add is intentional: every object lifetime needs a distinct token;
-  // resetting this atomic would let an address-reused object match stale TLS.
+  // Every object lifetime needs a distinct token because the function-static
+  // TLS caches can survive destruction on long-lived host threads.
   inline static std::atomic<uint64_t> next_instance_id_{1};
   const uint64_t instance_id_;
   mutable std::shared_mutex vmid_mutex_;
   std::unordered_map<uint32_t, VmidEntry> vmid_table_;
-  mutable std::atomic<uint64_t> vmid_table_generation_ = 1;
+  // Version of VMID-to-page-table bindings, accessed only under vmid_mutex_.
+  uint64_t vmid_registry_generation_ = 1;
   bool passthrough_ = false;
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -13,7 +13,9 @@
 #include "util/log.h"
 
 #include <algorithm>
+#include <array>
 #include <atomic>
+#include <cassert>
 #include <cstring>
 #include <format>
 #include <limits>
@@ -147,6 +149,42 @@ public:
       for (size_t i = 0; i < chunk; ++i)
         simdojo::SparseMemory::write8(ea + i, in[i]);
     });
+  }
+
+  /// @brief Perform an atomic read-modify-write on resolved backing storage.
+  /// @details Mapped aliases rendezvous on a process-wide lock stripe selected
+  /// from the resolved host address. The page-table shared lock remains held
+  /// through the callback, so remapping cannot change or retire the target
+  /// during the operation. Unmapped sparse/client accesses use a stable
+  /// address-space key instead.
+  /// @param addr GPU virtual address of the target.
+  /// @param size Access size in bytes (4 or 8).
+  /// @param fn Callback invoked with a pointer to the target bytes.
+  /// @param vmid Process VMID used for address translation.
+  template <typename F> void atomic_rmw(uint64_t addr, uint32_t size, F &&fn, uint32_t vmid = 0) {
+    assert((size == 4 || size == 8) && (addr & PAGE_MASK) + size <= PAGE_SIZE);
+
+    const bool mapped = with_host_ptr(addr, vmid, [&](uint8_t *page) {
+      uint8_t *target = page + (addr & PAGE_MASK);
+      std::lock_guard lock(backing_atomic_mutex(reinterpret_cast<uintptr_t>(target)));
+      fn(target);
+    });
+    if (mapped)
+      return;
+
+    const pid_t client_pid = client_pid_for_vmid(vmid);
+    uintptr_t key = static_cast<uintptr_t>(addr ^ (addr >> 32));
+    if (client_pid > 0) {
+      key ^= static_cast<uintptr_t>(client_pid) * 0x9e3779b97f4a7c15ULL;
+    } else {
+      key ^= reinterpret_cast<uintptr_t>(this);
+    }
+
+    std::lock_guard lock(backing_atomic_mutex(key));
+    std::array<uint8_t, sizeof(uint64_t)> value{};
+    read_block(addr, std::span<uint8_t>(value.data(), size), vmid);
+    fn(value.data());
+    write_block(addr, std::span<const uint8_t>(value.data(), size), vmid);
   }
 
   uint8_t *translate_debug(uint64_t addr, uint32_t vmid) const { return translate(addr, vmid); }
@@ -292,6 +330,14 @@ public:
   }
 
 private:
+  static std::mutex &backing_atomic_mutex(uintptr_t key) {
+    static std::array<std::mutex, 4096> mutexes;
+    key >>= 3;
+    key ^= key >> 17;
+    key ^= key >> 31;
+    return mutexes[key & (mutexes.size() - 1)];
+  }
+
   template <typename F> static void for_each_page_chunk(uint64_t addr, size_t len, F &&fn) {
     size_t offset = 0;
     while (offset < len) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -375,7 +375,7 @@ private:
 
   template <typename F> bool with_host_ptr(uint64_t addr, uint32_t vmid, F &&fn) const {
     if (vmid == 0) {
-      if (!passthrough_)
+      if (!passthrough_ || addr >= kUserSpaceLimit)
         return false;
       fn(reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK));
       return true;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -158,11 +158,10 @@ public:
   }
 
   /// @brief Perform an atomic read-modify-write on resolved backing storage.
-  /// @details Mapped aliases rendezvous on a process-wide lock stripe selected
-  /// from the resolved host address. The page-table shared lock remains held
-  /// through the callback, so remapping cannot change or retire the target
-  /// during the operation. Unmapped sparse/client accesses use a stable
-  /// address-space key instead.
+  /// @details Storage classification and the page-table shared lock remain
+  /// stable through the callback. Mapped aliases rendezvous on a process-wide
+  /// host-address stripe; unmapped sparse/client accesses use an address-space
+  /// stripe instead.
   /// @param addr GPU virtual address of the target.
   /// @param size Access size in bytes (4 or 8).
   /// @param fn Callback invoked with a pointer to the target bytes.
@@ -170,27 +169,30 @@ public:
   template <typename F> void atomic_rmw(uint64_t addr, uint32_t size, F &&fn, uint32_t vmid = 0) {
     assert((size == 4 || size == 8) && (addr & PAGE_MASK) + size <= PAGE_SIZE);
 
-    const bool mapped = with_host_ptr(addr, vmid, [&](uint8_t *page) {
-      uint8_t *target = page + (addr & PAGE_MASK);
-      std::lock_guard lock(backing_atomic_mutex(reinterpret_cast<uintptr_t>(target)));
-      fn(target);
-    });
-    if (mapped)
+    if (vmid == 0) {
+      atomic_rmw_unmapped(addr, size, 0, fn);
       return;
-
-    const pid_t client_pid = client_pid_for_vmid(vmid);
-    uintptr_t key = static_cast<uintptr_t>(addr ^ (addr >> 32));
-    if (client_pid > 0) {
-      key ^= static_cast<uintptr_t>(client_pid) * kClientPidHashSalt;
-    } else {
-      key ^= reinterpret_cast<uintptr_t>(this);
     }
 
-    std::lock_guard lock(backing_atomic_mutex(key));
-    std::array<uint8_t, sizeof(uint64_t)> value{};
-    read_block(addr, std::span<uint8_t>(value.data(), size), vmid);
-    fn(value.data());
-    write_block(addr, std::span<const uint8_t>(value.data(), size), vmid);
+    std::shared_lock vmid_lock(vmid_mutex_);
+    auto vmid_entry = vmid_table_.find(vmid);
+    if (vmid_entry == vmid_table_.end()) {
+      atomic_rmw_unmapped(addr, size, 0, fn);
+      return;
+    }
+
+    auto &entry = vmid_entry->second;
+    std::shared_lock page_table_lock(*entry.mutex);
+    auto pte = entry.page_table->find(addr >> PAGE_SHIFT);
+    if (pte != entry.page_table->end()) {
+      if (pte->second.host_ptr != nullptr)
+        atomic_rmw_mapped(addr, pte->second.host_ptr, fn);
+      else
+        atomic_rmw_fallback(addr, size, entry.client_pid, fn);
+      return;
+    }
+
+    atomic_rmw_unmapped(addr, size, entry.client_pid, fn);
   }
 
   uint8_t *translate_debug(uint64_t addr, uint32_t vmid) const { return translate(addr, vmid); }
@@ -357,6 +359,48 @@ private:
     return mutexes[key & (mutexes.size() - 1)];
   }
 
+  template <typename F> static void atomic_rmw_mapped(uint64_t addr, uint8_t *page, F &fn) {
+    uint8_t *target = page + (addr & PAGE_MASK);
+    std::lock_guard lock(backing_atomic_mutex(reinterpret_cast<uintptr_t>(target)));
+    fn(target);
+  }
+
+  template <typename F>
+  void atomic_rmw_unmapped(uint64_t addr, uint32_t size, pid_t client_pid, F &fn) {
+    auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
+    if (passthrough_ && addr < kUserSpaceLimit && page != nullptr)
+      atomic_rmw_mapped(addr, page, fn);
+    else
+      atomic_rmw_fallback(addr, size, client_pid, fn);
+  }
+
+  template <typename F>
+  void atomic_rmw_fallback(uint64_t addr, uint32_t size, pid_t client_pid, F &fn) {
+    uintptr_t key = static_cast<uintptr_t>(addr ^ (addr >> 32));
+    if (client_pid > 0)
+      key ^= static_cast<uintptr_t>(client_pid) * kClientPidHashSalt;
+    else
+      key ^= reinterpret_cast<uintptr_t>(this);
+
+    std::lock_guard lock(backing_atomic_mutex(key));
+    std::array<uint8_t, sizeof(uint64_t)> value{};
+    const bool client_storage =
+        client_pid > 0 && read_client_memory_for_pid(addr, value.data(), size, client_pid);
+    if (!client_storage) {
+      for (uint32_t i = 0; i < size; ++i)
+        value[i] = simdojo::SparseMemory::read8(addr + i);
+    }
+
+    fn(value.data());
+
+    if (client_storage) {
+      write_client_memory_for_pid(addr, value.data(), size, client_pid);
+      return;
+    }
+    for (uint32_t i = 0; i < size; ++i)
+      simdojo::SparseMemory::write8(addr + i, value[i]);
+  }
+
   template <typename F> static void for_each_page_chunk(uint64_t addr, size_t len, F &&fn) {
     size_t offset = 0;
     while (offset < len) {
@@ -396,8 +440,8 @@ private:
   /// the whole copy and makes translate() and pte_mtype() share one invalidation
   /// protocol.
   template <typename F>
-  auto cached_walk(uint64_t addr, uint32_t vmid, PteCache &cache, F &&fn) const
-      -> std::invoke_result_t<F, const KfdProcess::PageTableEntry *> {
+  auto cached_walk(uint64_t addr, uint32_t vmid, PteCache &cache,
+                   F &&fn) const -> std::invoke_result_t<F, const KfdProcess::PageTableEntry *> {
     const uint64_t page_key = addr >> PAGE_SHIFT;
     std::shared_lock vmid_lock(vmid_mutex_);
     const uint64_t registry_generation = vmid_registry_generation_;
@@ -492,7 +536,10 @@ private:
   }
 
   bool read_client_memory(uint64_t addr, void *dst, size_t len, uint32_t vmid) const {
-    pid_t pid = client_pid_for_vmid(vmid);
+    return read_client_memory_for_pid(addr, dst, len, client_pid_for_vmid(vmid));
+  }
+
+  static bool read_client_memory_for_pid(uint64_t addr, void *dst, size_t len, pid_t pid) {
     if (pid <= 0)
       return false;
     iovec local{dst, len};
@@ -507,7 +554,10 @@ private:
   }
 
   bool write_client_memory(uint64_t addr, const void *src, size_t len, uint32_t vmid) {
-    pid_t pid = client_pid_for_vmid(vmid);
+    return write_client_memory_for_pid(addr, src, len, client_pid_for_vmid(vmid));
+  }
+
+  static bool write_client_memory_for_pid(uint64_t addr, const void *src, size_t len, pid_t pid) {
     if (pid <= 0)
       return false;
     iovec local{const_cast<void *>(src), len};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.cpp
@@ -3,6 +3,7 @@
 
 #include "rocjitsu/vm/amdgpu/l1_scalar_cache.h"
 
+#include "rocjitsu/vm/amdgpu/device_cache_coherence.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
 
@@ -13,7 +14,24 @@
 namespace rocjitsu {
 namespace amdgpu {
 
-void L1ScalarCache::ensure_line(uint64_t addr, uint32_t vmid) {
+L1ScalarCache::L1ScalarCache(L2Cache *l2)
+    : l2_(l2), coherence_epoch_(DeviceCacheCoherence::instance().current_epoch()) {}
+
+L1ScalarCache::~L1ScalarCache() = default;
+
+void L1ScalarCache::set_l2(L2Cache *l2) {
+  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
+  synchronize_epoch_locked();
+  l2_ = l2;
+}
+
+void L1ScalarCache::set_memory(GpuMemory *mem) {
+  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
+  synchronize_epoch_locked();
+  memory_ = mem;
+}
+
+void L1ScalarCache::ensure_line_locked(uint64_t addr, uint32_t vmid) {
   if (cache_.lookup(addr, nullptr, vmid))
     return;
 
@@ -29,6 +47,8 @@ void L1ScalarCache::ensure_line(uint64_t addr, uint32_t vmid) {
 }
 
 void L1ScalarCache::store(uint64_t addr, uint32_t num_dwords, const uint32_t *src, uint32_t vmid) {
+  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
+  synchronize_epoch_locked();
   for (uint32_t i = 0; i < num_dwords; ++i) {
     uint64_t ea = addr + i * 4;
     uint8_t buf[4];
@@ -45,24 +65,24 @@ void L1ScalarCache::store(uint64_t addr, uint32_t num_dwords, const uint32_t *sr
         mtype = memory_->pte_mtype(chunk_addr, vmid);
 
       if (mtype == Mtype::UC) {
-        flush_line(chunk_addr, vmid);
+        flush_line_locked(chunk_addr, vmid);
         l2_->write(chunk_addr, buf + copied, chunk, Mtype::UC, vmid);
         copied += chunk;
         continue;
       }
 
       if (mtype == Mtype::CC) {
-        flush_line(chunk_addr, vmid);
+        flush_line_locked(chunk_addr, vmid);
         l2_->write(chunk_addr, buf + copied, chunk, Mtype::CC, vmid);
         copied += chunk;
         continue;
       }
 
-      ensure_line(chunk_addr, vmid); // read-allocate on miss
+      ensure_line_locked(chunk_addr, vmid); // read-allocate on miss
 
       simdojo::CacheTag *tag = nullptr;
       cache_.lookup(chunk_addr, &tag, vmid);
-      assert(tag != nullptr && "ensure_line must guarantee hit");
+      assert(tag != nullptr && "ensure_line_locked must guarantee hit");
 
       cache_.write_line(chunk_addr, buf + copied, line_offset, chunk, vmid);
       l2_->write(chunk_addr, buf + copied, chunk, mtype, vmid);
@@ -77,7 +97,23 @@ void L1ScalarCache::writeback_all(uint32_t vmid) {
   (void)vmid;
 }
 
-void L1ScalarCache::flush_line(uint64_t addr, uint32_t vmid) {
+void L1ScalarCache::invalidate_all() {
+  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
+  synchronize_epoch_locked();
+  invalidate_all_locked();
+}
+
+void L1ScalarCache::invalidate_all_locked() { cache_.invalidate_all(); }
+
+void L1ScalarCache::synchronize_epoch_locked() {
+  const uint64_t current_epoch = DeviceCacheCoherence::instance().current_epoch();
+  if (coherence_epoch_ == current_epoch)
+    return;
+  invalidate_all_locked();
+  coherence_epoch_ = current_epoch;
+}
+
+void L1ScalarCache::flush_line_locked(uint64_t addr, uint32_t vmid) {
   simdojo::CacheTag *tag = nullptr;
   if (!cache_.lookup(addr, &tag, vmid))
     return;
@@ -87,6 +123,8 @@ void L1ScalarCache::flush_line(uint64_t addr, uint32_t vmid) {
 }
 
 void L1ScalarCache::load(uint64_t addr, uint32_t num_dwords, uint32_t *dst, uint32_t vmid) {
+  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
+  synchronize_epoch_locked();
   for (uint32_t i = 0; i < num_dwords; ++i) {
     uint64_t ea = addr + i * 4;
     uint8_t buf[4]{};
@@ -102,13 +140,13 @@ void L1ScalarCache::load(uint64_t addr, uint32_t num_dwords, uint32_t *dst, uint
         mtype = memory_->pte_mtype(chunk_addr, vmid);
 
       if (mtype == Mtype::UC) {
-        flush_line(chunk_addr, vmid);
+        flush_line_locked(chunk_addr, vmid);
         l2_->read(chunk_addr, buf + copied, chunk, Mtype::UC, vmid);
       } else if (mtype == Mtype::CC) {
-        flush_line(chunk_addr, vmid);
+        flush_line_locked(chunk_addr, vmid);
         l2_->read(chunk_addr, buf + copied, chunk, Mtype::CC, vmid);
       } else {
-        ensure_line(chunk_addr, vmid);
+        ensure_line_locked(chunk_addr, vmid);
         cache_.read_line(chunk_addr, buf + copied, line_offset, chunk, vmid);
       }
       copied += chunk;
@@ -118,6 +156,8 @@ void L1ScalarCache::load(uint64_t addr, uint32_t num_dwords, uint32_t *dst, uint
 }
 
 void L1ScalarCache::load_bytes(uint64_t addr, uint32_t num_bytes, uint8_t *dst, uint32_t vmid) {
+  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
+  synchronize_epoch_locked();
   uint32_t copied = 0;
   while (copied < num_bytes) {
     uint64_t ea = addr + copied;
@@ -129,13 +169,13 @@ void L1ScalarCache::load_bytes(uint64_t addr, uint32_t num_bytes, uint8_t *dst, 
       mtype = memory_->pte_mtype(ea, vmid);
 
     if (mtype == Mtype::UC) {
-      flush_line(ea, vmid);
+      flush_line_locked(ea, vmid);
       l2_->read(ea, dst + copied, chunk, Mtype::UC, vmid);
     } else if (mtype == Mtype::CC) {
-      flush_line(ea, vmid);
+      flush_line_locked(ea, vmid);
       l2_->read(ea, dst + copied, chunk, Mtype::CC, vmid);
     } else {
-      ensure_line(ea, vmid);
+      ensure_line_locked(ea, vmid);
       cache_.read_line(ea, dst + copied, line_offset, chunk, vmid);
     }
     copied += chunk;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cstring>
 
 namespace rocjitsu {
@@ -18,16 +19,9 @@ void L1ScalarCache::ensure_line(uint64_t addr, uint32_t vmid) {
 
   uint64_t line_addr = CacheStore::line_address(addr);
   simdojo::CacheTag evicted;
-  uint8_t evicted_data[CacheStore::LINE_SIZE];
-  cache_.allocate(addr, vmid, &evicted, evicted_data);
+  cache_.allocate(addr, vmid, &evicted);
 
-  if (evicted.valid && evicted.dirty) {
-    constexpr uint32_t set_bits = 6; // log2(NUM_SETS=64)
-    uint64_t evicted_line_addr =
-        (evicted.tag << (LINE_SIZE_BITS + set_bits)) |
-        (static_cast<uint64_t>(CacheStore::set_index(addr)) << LINE_SIZE_BITS);
-    l2_->write(evicted_line_addr, evicted_data, CacheStore::LINE_SIZE, Mtype::RW, evicted.vmid);
-  }
+  assert(!evicted.dirty && "L1 K$ is write-through; lines should never be dirty");
 
   uint8_t line_buf[CacheStore::LINE_SIZE];
   l2_->read(line_addr, line_buf, CacheStore::LINE_SIZE, Mtype::RW, vmid);
@@ -71,23 +65,16 @@ void L1ScalarCache::store(uint64_t addr, uint32_t num_dwords, const uint32_t *sr
       assert(tag != nullptr && "ensure_line must guarantee hit");
 
       cache_.write_line(chunk_addr, buf + copied, line_offset, chunk, vmid);
-      tag->dirty = true;
+      l2_->write(chunk_addr, buf + copied, chunk, mtype, vmid);
+      tag->dirty = false;
       copied += chunk;
     }
   }
 }
 
 void L1ScalarCache::writeback_all(uint32_t vmid) {
-  // Each dirty line is written back under its own owning vmid (recorded in the
-  // tag), not the caller's vmid. A CU can retain dirty K$ lines from process A
-  // and then be flushed while processing process B; using the caller vmid would
-  // install A's line into L2 under B's page table and corrupt another process's
-  // VA. The eviction path in ensure_line() uses evicted.vmid for the same reason.
+  // K$ is write-through, so all stored bytes have already reached L2.
   (void)vmid;
-  cache_.for_each_dirty([this](simdojo::CacheTag &tag, uint64_t line_addr, uint8_t *data) {
-    l2_->write(line_addr, data, CacheStore::LINE_SIZE, Mtype::RW, tag.vmid);
-    tag.dirty = false;
-  });
 }
 
 void L1ScalarCache::flush_line(uint64_t addr, uint32_t vmid) {
@@ -95,12 +82,7 @@ void L1ScalarCache::flush_line(uint64_t addr, uint32_t vmid) {
   if (!cache_.lookup(addr, &tag, vmid))
     return;
 
-  if (tag->dirty) {
-    uint8_t line_buf[CacheStore::LINE_SIZE];
-    cache_.read_line(addr, line_buf, 0, CacheStore::LINE_SIZE, vmid);
-    l2_->write(CacheStore::line_address(addr), line_buf, CacheStore::LINE_SIZE, Mtype::RW,
-               tag->vmid);
-  }
+  assert(!tag->dirty && "L1 K$ is write-through; lines should never be dirty");
   cache_.invalidate(addr, vmid);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.h
@@ -33,14 +33,20 @@ public:
 
   using CacheStore = simdojo::Cache<LINE_SIZE_BITS, NUM_SETS, ASSOCIATIVITY>;
 
-  explicit L1ScalarCache(L2Cache *l2 = nullptr) : l2_(l2) {}
+  explicit L1ScalarCache(L2Cache *l2 = nullptr);
+  ~L1ScalarCache();
+
+  L1ScalarCache(const L1ScalarCache &) = delete;
+  L1ScalarCache &operator=(const L1ScalarCache &) = delete;
+  L1ScalarCache(L1ScalarCache &&) = delete;
+  L1ScalarCache &operator=(L1ScalarCache &&) = delete;
 
   /// @brief Set (or replace) the backing L2 cache.
   /// @param l2 New L2 cache (not owned).
-  void set_l2(L2Cache *l2) { l2_ = l2; }
+  void set_l2(L2Cache *l2);
 
   /// @brief Set the memory subsystem for PTE MTYPE lookups.
-  void set_memory(GpuMemory *mem) { memory_ = mem; }
+  void set_memory(GpuMemory *mem);
 
   /// @brief Scalar load: read num_dwords contiguous dwords from addr.
   ///
@@ -62,15 +68,18 @@ public:
   void writeback_all(uint32_t vmid = 0);
 
   /// @brief Invalidate all clean K$ lines (s_dcache_inv).
-  void invalidate_all() { cache_.invalidate_all(); }
+  void invalidate_all();
 
 private:
-  void ensure_line(uint64_t addr, uint32_t vmid = 0);
-  void flush_line(uint64_t addr, uint32_t vmid = 0);
+  void ensure_line_locked(uint64_t addr, uint32_t vmid = 0);
+  void flush_line_locked(uint64_t addr, uint32_t vmid = 0);
+  void invalidate_all_locked();
+  void synchronize_epoch_locked();
 
   CacheStore cache_;
   L2Cache *l2_;
   GpuMemory *memory_ = nullptr;
+  uint64_t coherence_epoch_ = 0;
 };
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.h
@@ -19,10 +19,10 @@ class L2Cache;
 /// @brief L1 Scalar Cache (K$) controller for SMEM instructions.
 ///
 /// 16KB, 64-byte lines, 4-way set-associative with LRU. Supports both
-/// scalar loads and stores. Scalar stores allocate in K$ and mark lines
-/// dirty; dirty lines are written back to L2 on eviction or when
-/// `s_dcache_wb` is executed. `s_dcache_inv` invalidates all lines
-/// without writeback.
+/// scalar loads and stores. Cacheable scalar stores allocate in K$, update the
+/// resident bytes, and write those bytes through to L2. K$ lines remain clean,
+/// so eviction and `s_dcache_wb` never publish a cached full line.
+/// `s_dcache_inv` invalidates all resident lines.
 ///
 /// CDNA3 K$ geometry: 64B lines, 64 sets, 4-way = 16KB.
 class L1ScalarCache {
@@ -52,15 +52,16 @@ public:
   void load_bytes(uint64_t addr, uint32_t num_bytes, uint8_t *dst, uint32_t vmid = 0);
 
   /// @brief Scalar store: write num_dwords contiguous dwords to addr.
+  ///
+  /// Cacheable stores read-allocate and write through each modified byte range
+  /// to L2. UC and CC stores bypass K$.
   void store(uint64_t addr, uint32_t num_dwords, const uint32_t *src, uint32_t vmid = 0);
 
-  /// @brief Write back all dirty K$ lines to L2 (s_dcache_wb).
-  /// @param vmid Ignored. Each dirty line is written back under its own owning
-  /// vmid (recorded in the line tag), so a caller-supplied vmid cannot be
-  /// correct for a bulk writeback. Retained only for call-site signature symmetry.
+  /// @brief Handle s_dcache_wb; a no-op because K$ is write-through.
+  /// @param vmid Ignored. Retained only for call-site signature symmetry.
   void writeback_all(uint32_t vmid = 0);
 
-  /// @brief Invalidate all K$ lines without writeback (s_dcache_inv).
+  /// @brief Invalidate all clean K$ lines (s_dcache_inv).
   void invalidate_all() { cache_.invalidate_all(); }
 
 private:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
@@ -3,6 +3,7 @@
 
 #include "rocjitsu/vm/amdgpu/l1_vector_cache.h"
 
+#include "rocjitsu/vm/amdgpu/device_cache_coherence.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
 #include "util/log.h"
@@ -43,6 +44,23 @@ uint32_t for_each_coalesced_lane_run(const uint64_t *addrs, uint64_t lane_mask, 
 }
 
 } // namespace
+
+L1VectorCache::L1VectorCache(L2Cache *l2)
+    : l2_(l2), coherence_epoch_(DeviceCacheCoherence::instance().current_epoch()) {}
+
+L1VectorCache::~L1VectorCache() = default;
+
+void L1VectorCache::set_l2(L2Cache *l2) {
+  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
+  synchronize_epoch_locked();
+  l2_ = l2;
+}
+
+void L1VectorCache::set_memory(GpuMemory *mem) {
+  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
+  synchronize_epoch_locked();
+  memory_ = mem;
+}
 
 void L1VectorCache::ensure_line(uint64_t addr, uint32_t vmid) {
   if (cache_.lookup(addr, nullptr, vmid))
@@ -176,6 +194,8 @@ void L1VectorCache::write_bytes(uint64_t addr, const uint8_t *src, uint32_t size
 void L1VectorCache::load(const uint64_t *addrs, uint64_t lane_mask, uint32_t elem_size,
                          uint32_t num_elems, uint8_t *dst, Mtype mtype, bool non_temporal,
                          bool request_l1_bypass, uint32_t wf_size, uint32_t vmid) {
+  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
+  synchronize_epoch_locked();
   uint32_t stride = num_elems * elem_size;
   for_each_coalesced_lane_run(
       addrs, lane_mask, wf_size, stride, [&](uint32_t first_lane, uint32_t run_lanes) {
@@ -187,6 +207,8 @@ void L1VectorCache::load(const uint64_t *addrs, uint64_t lane_mask, uint32_t ele
 void L1VectorCache::store(const uint64_t *addrs, uint64_t lane_mask, uint32_t elem_size,
                           uint32_t num_elems, const uint8_t *src, Mtype mtype, bool non_temporal,
                           uint32_t wf_size, uint32_t vmid) {
+  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
+  synchronize_epoch_locked();
   uint32_t stride = num_elems * elem_size;
   const uint32_t active_lanes = std::popcount(lane_mask);
   ++store_count_;
@@ -199,7 +221,33 @@ void L1VectorCache::store(const uint64_t *addrs, uint64_t lane_mask, uint32_t el
       });
 }
 
-void L1VectorCache::flush_all() { cache_.invalidate_all(); }
+void L1VectorCache::invalidate(uint64_t addr, uint32_t vmid) {
+  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
+  synchronize_epoch_locked();
+  cache_.invalidate(addr, vmid);
+}
+
+void L1VectorCache::invalidate_all() {
+  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
+  synchronize_epoch_locked();
+  invalidate_all_locked();
+}
+
+void L1VectorCache::flush_all() {
+  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
+  synchronize_epoch_locked();
+  invalidate_all_locked();
+}
+
+void L1VectorCache::invalidate_all_locked() { cache_.invalidate_all(); }
+
+void L1VectorCache::synchronize_epoch_locked() {
+  const uint64_t current_epoch = DeviceCacheCoherence::instance().current_epoch();
+  if (coherence_epoch_ == current_epoch)
+    return;
+  invalidate_all_locked();
+  coherence_epoch_ = current_epoch;
+}
 
 } // namespace amdgpu
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.h
@@ -31,10 +31,16 @@ public:
   using CacheStore = simdojo::Cache<LINE_SIZE_BITS, NUM_SETS, ASSOCIATIVITY>;
   static constexpr uint32_t LINE_SIZE = CacheStore::LINE_SIZE;
 
-  explicit L1VectorCache(L2Cache *l2 = nullptr) : l2_(l2) {}
+  explicit L1VectorCache(L2Cache *l2 = nullptr);
+  ~L1VectorCache();
 
-  void set_l2(L2Cache *l2) { l2_ = l2; }
-  void set_memory(GpuMemory *mem) { memory_ = mem; }
+  L1VectorCache(const L1VectorCache &) = delete;
+  L1VectorCache &operator=(const L1VectorCache &) = delete;
+  L1VectorCache(L1VectorCache &&) = delete;
+  L1VectorCache &operator=(L1VectorCache &&) = delete;
+
+  void set_l2(L2Cache *l2);
+  void set_memory(GpuMemory *mem);
   void load(const uint64_t *addrs, uint64_t lane_mask, uint32_t elem_size, uint32_t num_elems,
             uint8_t *dst, Mtype mtype, bool non_temporal, bool request_l1_bypass, uint32_t wf_size,
             uint32_t vmid = 0);
@@ -43,8 +49,8 @@ public:
              const uint8_t *src, Mtype mtype, bool non_temporal, uint32_t wf_size,
              uint32_t vmid = 0);
 
-  void invalidate(uint64_t addr, uint32_t vmid = 0) { cache_.invalidate(addr, vmid); }
-  void invalidate_all() { cache_.invalidate_all(); }
+  void invalidate(uint64_t addr, uint32_t vmid = 0);
+  void invalidate_all();
   void flush_all();
 
   uint64_t store_count() const { return store_count_; }
@@ -52,6 +58,8 @@ public:
   uint64_t store_l2_writes() const { return store_l2_writes_; }
 
 private:
+  void invalidate_all_locked();
+  void synchronize_epoch_locked();
   void read_bytes(uint64_t addr, uint8_t *dst, uint32_t size, Mtype mtype, bool non_temporal,
                   bool request_l1_bypass, uint32_t vmid);
   void write_bytes(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtype, bool non_temporal,
@@ -61,6 +69,7 @@ private:
   CacheStore cache_;
   L2Cache *l2_;
   GpuMemory *memory_ = nullptr;
+  uint64_t coherence_epoch_ = 0;
   uint64_t store_count_ = 0;
   uint64_t store_active_count_ = 0;
   uint64_t store_l2_writes_ = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
@@ -256,7 +256,7 @@ void L2Cache::flush_all(uint32_t vmid) {
   cache_.invalidate_all();
 }
 
-void L2Cache::invalidate_range(uint64_t addr, uint32_t size) {
+void L2Cache::invalidate_range(uint64_t addr, uint32_t size, uint32_t vmid) {
   if (size == 0)
     return;
   std::shared_lock maintenance_lock(maintenance_mutex_);
@@ -267,8 +267,27 @@ void L2Cache::invalidate_range(uint64_t addr, uint32_t size) {
       (std::numeric_limits<uint64_t>::max() - line_start) / LINE_SIZE + 1;
   const uint64_t line_count = std::min(requested_lines, addressable_lines);
   auto locks = lock_sets_for_range(line_start, line_count);
-  for (uint64_t i = 0; i < line_count; ++i)
-    cache_.invalidate_all_vmids(line_start + i * LINE_SIZE);
+  uint64_t remaining = size;
+  for (uint64_t i = 0; i < line_count; ++i) {
+    const uint64_t line_addr = line_start + i * LINE_SIZE;
+    const uint32_t line_offset = i == 0 ? CacheStore::line_offset(addr) : 0;
+    const uint32_t chunk =
+        static_cast<uint32_t>(std::min<uint64_t>(remaining, LINE_SIZE - line_offset));
+
+    simdojo::CacheTag *tag = nullptr;
+    if (cache_.lookup(line_addr, &tag, vmid)) {
+      const bool partial_line = line_offset != 0 || chunk != LINE_SIZE;
+      if (tag->dirty && partial_line) {
+        std::array<uint8_t, LINE_SIZE> merged{};
+        cache_.read_line(line_addr, merged.data(), 0, LINE_SIZE, vmid);
+        send_backing(line_addr + line_offset, merged.data() + line_offset, chunk,
+                     simdojo::MessageOp::READ, vmid);
+        send_backing(line_addr, merged.data(), LINE_SIZE, simdojo::MessageOp::WRITE, vmid);
+      }
+      cache_.invalidate(line_addr, vmid);
+    }
+    remaining -= chunk;
+  }
 }
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
@@ -259,14 +259,26 @@ void L2Cache::flush_all(uint32_t vmid) {
 void L2Cache::invalidate_range(uint64_t addr, uint32_t size, uint32_t vmid) {
   if (size == 0)
     return;
-  std::shared_lock maintenance_lock(maintenance_mutex_);
   const uint64_t line_start = CacheStore::line_address(addr);
   const uint64_t requested_lines =
       (static_cast<uint64_t>(CacheStore::line_offset(addr)) + size + LINE_SIZE - 1) / LINE_SIZE;
   const uint64_t addressable_lines =
       (std::numeric_limits<uint64_t>::max() - line_start) / LINE_SIZE + 1;
   const uint64_t line_count = std::min(requested_lines, addressable_lines);
-  auto locks = lock_sets_for_range(line_start, line_count);
+
+  if (line_count <= MAX_INVALIDATE_RANGE_SET_LOCKS) {
+    std::shared_lock maintenance_lock(maintenance_mutex_);
+    auto locks = lock_sets_for_range(line_start, line_count);
+    invalidate_range_locked(addr, size, vmid, line_start, line_count);
+    return;
+  }
+
+  std::unique_lock maintenance_lock(maintenance_mutex_);
+  invalidate_range_locked(addr, size, vmid, line_start, line_count);
+}
+
+void L2Cache::invalidate_range_locked(uint64_t addr, uint32_t size, uint32_t vmid,
+                                      uint64_t line_start, uint64_t line_count) {
   uint64_t remaining = size;
   for (uint64_t i = 0; i < line_count; ++i) {
     const uint64_t line_addr = line_start + i * LINE_SIZE;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
@@ -75,6 +75,7 @@ void L2Cache::ensure_line(uint64_t addr, uint32_t vmid) {
 }
 
 void L2Cache::read(uint64_t addr, uint8_t *dst, uint32_t size, Mtype mtype, uint32_t vmid) {
+  std::shared_lock maintenance_lock(maintenance_mutex_);
   uint32_t copied = 0;
   if (mtype == Mtype::UC) {
     while (copied < size) {
@@ -82,7 +83,8 @@ void L2Cache::read(uint64_t addr, uint8_t *dst, uint32_t size, Mtype mtype, uint
       const uint32_t line_offset = CacheStore::line_offset(ea);
       const uint32_t chunk = std::min(size - copied, LINE_SIZE - line_offset);
 
-      flush_line(ea, vmid);
+      std::lock_guard set_lock(set_mutex(ea));
+      flush_line_locked(ea, vmid);
       send_backing(ea, dst + copied, chunk, simdojo::MessageOp::READ, vmid);
       copied += chunk;
     }
@@ -110,6 +112,7 @@ void L2Cache::read(uint64_t addr, uint8_t *dst, uint32_t size, Mtype mtype, uint
 }
 
 void L2Cache::write(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtype, uint32_t vmid) {
+  std::shared_lock maintenance_lock(maintenance_mutex_);
   uint32_t copied = 0;
   if (mtype == Mtype::UC) {
     while (copied < size) {
@@ -117,7 +120,8 @@ void L2Cache::write(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtyp
       const uint32_t line_offset = CacheStore::line_offset(ea);
       const uint32_t chunk = std::min(size - copied, LINE_SIZE - line_offset);
 
-      flush_line(ea, vmid);
+      std::lock_guard set_lock(set_mutex(ea));
+      flush_line_locked(ea, vmid);
       send_backing(ea, const_cast<uint8_t *>(src + copied), chunk, simdojo::MessageOp::WRITE, vmid);
       copied += chunk;
     }
@@ -154,6 +158,7 @@ void L2Cache::write(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtyp
 }
 
 void L2Cache::fetch_line(uint64_t addr, uint8_t *line_buf, uint32_t vmid) {
+  std::shared_lock maintenance_lock(maintenance_mutex_);
   std::lock_guard set_lock(set_mutex(addr));
   uint64_t line_addr = CacheStore::line_address(addr);
   const uint8_t *line = cache_.line_data_for_read(line_addr, vmid);
@@ -177,6 +182,7 @@ void L2Cache::fetch_line(uint64_t addr, uint8_t *line_buf, uint32_t vmid) {
 }
 
 void L2Cache::writeback_line(uint64_t line_addr, const uint8_t *data, Mtype mtype, uint32_t vmid) {
+  std::shared_lock maintenance_lock(maintenance_mutex_);
   std::lock_guard set_lock(set_mutex(line_addr));
   simdojo::CacheTag *tag = nullptr;
   if (cache_.lookup(line_addr, &tag, vmid)) {
@@ -223,13 +229,14 @@ void L2Cache::flush_line_locked(uint64_t addr, uint32_t vmid) {
 }
 
 void L2Cache::flush_line(uint64_t addr, uint32_t vmid) {
+  std::shared_lock maintenance_lock(maintenance_mutex_);
   std::lock_guard set_lock(set_mutex(addr));
   flush_line_locked(addr, vmid);
 }
 
 void L2Cache::flush_all(uint32_t vmid) {
   (void)vmid;
-  auto locks = lock_all_sets();
+  std::unique_lock maintenance_lock(maintenance_mutex_);
   uint32_t dirty_count = 0;
   uint64_t min_addr = std::numeric_limits<uint64_t>::max(), max_addr = 0;
   cache_.for_each_dirty([this, &dirty_count, &min_addr,
@@ -252,6 +259,7 @@ void L2Cache::flush_all(uint32_t vmid) {
 void L2Cache::invalidate_range(uint64_t addr, uint32_t size) {
   if (size == 0)
     return;
+  std::shared_lock maintenance_lock(maintenance_mutex_);
   const uint64_t line_start = CacheStore::line_address(addr);
   const uint64_t requested_lines =
       (static_cast<uint64_t>(CacheStore::line_offset(addr)) + size + LINE_SIZE - 1) / LINE_SIZE;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
@@ -9,6 +9,7 @@
 #include <bit>
 #include <cassert>
 #include <cstring>
+#include <limits>
 #include <span>
 
 namespace rocjitsu {
@@ -251,11 +252,15 @@ void L2Cache::flush_all(uint32_t vmid) {
 void L2Cache::invalidate_range(uint64_t addr, uint32_t size) {
   if (size == 0)
     return;
-  uint64_t line_start = CacheStore::line_address(addr);
-  uint64_t end = addr + size;
-  auto locks = lock_sets_for_range(line_start, end);
-  for (uint64_t la = line_start; la < end; la += LINE_SIZE)
-    cache_.invalidate_all_vmids(la);
+  const uint64_t line_start = CacheStore::line_address(addr);
+  const uint64_t requested_lines =
+      (static_cast<uint64_t>(CacheStore::line_offset(addr)) + size + LINE_SIZE - 1) / LINE_SIZE;
+  const uint64_t addressable_lines =
+      (std::numeric_limits<uint64_t>::max() - line_start) / LINE_SIZE + 1;
+  const uint64_t line_count = std::min(requested_lines, addressable_lines);
+  auto locks = lock_sets_for_range(line_start, line_count);
+  for (uint64_t i = 0; i < line_count; ++i)
+    cache_.invalidate_all_vmids(line_start + i * LINE_SIZE);
 }
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
@@ -231,7 +231,7 @@ void L2Cache::flush_all(uint32_t vmid) {
   (void)vmid;
   auto locks = lock_all_sets();
   uint32_t dirty_count = 0;
-  uint64_t min_addr = UINT64_MAX, max_addr = 0;
+  uint64_t min_addr = std::numeric_limits<uint64_t>::max(), max_addr = 0;
   cache_.for_each_dirty([this, &dirty_count, &min_addr,
                          &max_addr](simdojo::CacheTag &tag, uint64_t line_addr, uint8_t *data) {
     // Each dirty line is written back under its own owning vmid.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
@@ -6,7 +6,6 @@
 #include "util/log.h"
 
 #include <algorithm>
-#include <atomic>
 #include <bit>
 #include <cassert>
 #include <cstring>
@@ -23,10 +22,9 @@ void L2Cache::send_backing(uint64_t addr, uint8_t *data, uint32_t size, simdojo:
     backing_read_transactions_.fetch_add(1, std::memory_order_relaxed);
   if (backing_memory_) {
     if (op == simdojo::MessageOp::WRITE) {
-      static std::atomic<uint64_t> wb_count{0};
-      const uint64_t count = wb_count.fetch_add(1, std::memory_order_relaxed) + 1;
-      if (count <= 3)
-        util::Logger::vm("L2 writeback(backing) #", count, " addr=0x", std::hex, addr,
+      thread_local uint64_t wb_count = 0;
+      if (++wb_count <= 3)
+        util::Logger::vm("L2 writeback(backing) #", wb_count, " addr=0x", std::hex, addr,
                          " size=", std::dec, size);
       backing_memory_->write_block(addr, std::span<const uint8_t>(data, size), vmid);
     } else {
@@ -95,12 +93,13 @@ void L2Cache::read(uint64_t addr, uint8_t *dst, uint32_t size, Mtype mtype, uint
     const uint64_t ea = addr + copied;
     const uint32_t line_offset = CacheStore::line_offset(ea);
     const uint32_t chunk = std::min(size - copied, LINE_SIZE - line_offset);
+    std::lock_guard set_lock(set_mutex(ea));
 
     if (mtype == Mtype::CC) {
       // Coherently Cacheable: invalidate L2 line before refetch, mirroring
       // the L1 CC behavior. This ensures cross-XCD store visibility when
       // different L2s share a backing store. Dirty data is flushed first.
-      flush_line(ea, vmid);
+      flush_line_locked(ea, vmid);
     }
 
     ensure_line(ea, vmid);
@@ -129,6 +128,7 @@ void L2Cache::write(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtyp
     const uint64_t ea = addr + copied;
     const uint32_t line_offset = CacheStore::line_offset(ea);
     const uint32_t chunk = std::min(size - copied, LINE_SIZE - line_offset);
+    std::lock_guard set_lock(set_mutex(ea));
 
     ensure_line(ea, vmid);
     cache_.write_line(ea, src + copied, line_offset, chunk, vmid);
@@ -147,18 +147,36 @@ void L2Cache::write(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtyp
         (mtype == Mtype::CC) ? simdojo::CoherenceState::SHARED : simdojo::CoherenceState::EXCLUSIVE;
     tag->dirty = false;
 
-    ++write_count_;
+    write_count_.fetch_add(1, std::memory_order_relaxed);
     copied += chunk;
   }
 }
 
 void L2Cache::fetch_line(uint64_t addr, uint8_t *line_buf, uint32_t vmid) {
+  std::lock_guard set_lock(set_mutex(addr));
   uint64_t line_addr = CacheStore::line_address(addr);
-  ensure_line(line_addr, vmid);
-  cache_.read_line(line_addr, line_buf, 0, LINE_SIZE, vmid);
+  const uint8_t *line = cache_.line_data_for_read(line_addr, vmid);
+  if (!line) {
+    simdojo::CacheTag evicted;
+    uint8_t evicted_data[LINE_SIZE];
+    auto allocated = cache_.allocate_with_data(line_addr, vmid, &evicted, evicted_data);
+
+    if (evicted.valid && evicted.dirty) {
+      static constexpr uint32_t SET_INDEX_BITS = std::bit_width(NUM_SETS - 1);
+      uint64_t evicted_addr =
+          (evicted.tag << (LINE_SIZE_BITS + SET_INDEX_BITS)) |
+          (static_cast<uint64_t>(CacheStore::set_index(line_addr)) << LINE_SIZE_BITS);
+      send_backing(evicted_addr, evicted_data, LINE_SIZE, simdojo::MessageOp::WRITE, evicted.vmid);
+    }
+
+    send_backing(line_addr, allocated.data, LINE_SIZE, simdojo::MessageOp::READ, vmid);
+    line = allocated.data;
+  }
+  std::memcpy(line_buf, line, LINE_SIZE);
 }
 
 void L2Cache::writeback_line(uint64_t line_addr, const uint8_t *data, Mtype mtype, uint32_t vmid) {
+  std::lock_guard set_lock(set_mutex(line_addr));
   simdojo::CacheTag *tag = nullptr;
   if (cache_.lookup(line_addr, &tag, vmid)) {
     cache_.write_line(line_addr, data, 0, LINE_SIZE, vmid);
@@ -189,7 +207,7 @@ void L2Cache::writeback_line(uint64_t line_addr, const uint8_t *data, Mtype mtyp
   }
 }
 
-void L2Cache::flush_line(uint64_t addr, uint32_t vmid) {
+void L2Cache::flush_line_locked(uint64_t addr, uint32_t vmid) {
   simdojo::CacheTag *tag = nullptr;
   if (!cache_.lookup(addr, &tag, vmid))
     return;
@@ -203,8 +221,14 @@ void L2Cache::flush_line(uint64_t addr, uint32_t vmid) {
   cache_.invalidate(addr, vmid);
 }
 
+void L2Cache::flush_line(uint64_t addr, uint32_t vmid) {
+  std::lock_guard set_lock(set_mutex(addr));
+  flush_line_locked(addr, vmid);
+}
+
 void L2Cache::flush_all(uint32_t vmid) {
   (void)vmid;
+  auto locks = lock_all_sets();
   uint32_t dirty_count = 0;
   uint64_t min_addr = UINT64_MAX, max_addr = 0;
   cache_.for_each_dirty([this, &dirty_count, &min_addr,
@@ -219,8 +243,19 @@ void L2Cache::flush_all(uint32_t vmid) {
       max_addr = line_addr;
   });
   util::Logger::vm("L2 flush: ", dirty_count, " dirty lines [0x", std::hex, min_addr, "-0x",
-                   max_addr, "]", std::dec, " total_writes=", write_count_);
+                   max_addr, "]", std::dec,
+                   " total_writes=", write_count_.load(std::memory_order_relaxed));
   cache_.invalidate_all();
+}
+
+void L2Cache::invalidate_range(uint64_t addr, uint32_t size) {
+  if (size == 0)
+    return;
+  uint64_t line_start = CacheStore::line_address(addr);
+  uint64_t end = addr + size;
+  auto locks = lock_sets_for_range(line_start, end);
+  for (uint64_t la = line_start; la < end; la += LINE_SIZE)
+    cache_.invalidate_all_vmids(la);
 }
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
@@ -15,6 +15,107 @@
 namespace rocjitsu {
 namespace amdgpu {
 
+L2Cache::L2Cache(std::string name) : simdojo::Component(std::move(name)) {
+  req_port_ = add_port(std::make_unique<simdojo::Port>("req", 0, this, simdojo::PortDirection::OUT,
+                                                       simdojo::PortProtocol::MEMORY));
+  coherence_epoch_ = DeviceCacheCoherence::instance().current_epoch();
+  DeviceCacheCoherence::instance().register_l2_cache(this);
+}
+
+L2Cache::~L2Cache() { DeviceCacheCoherence::instance().unregister_l2_cache(this); }
+
+std::shared_lock<std::shared_mutex> L2Cache::acquire_cache_access() {
+  for (;;) {
+    std::shared_lock access_lock(maintenance_mutex_);
+    if (coherence_epoch_ == DeviceCacheCoherence::instance().current_epoch())
+      return access_lock;
+
+    access_lock.unlock();
+    std::unique_lock maintenance_lock(maintenance_mutex_);
+    synchronize_epoch_locked();
+  }
+}
+
+std::unique_lock<std::shared_mutex> L2Cache::acquire_cache_maintenance() {
+  std::unique_lock maintenance_lock(maintenance_mutex_);
+  synchronize_epoch_locked();
+  return maintenance_lock;
+}
+
+void L2Cache::synchronize_epoch_locked() {
+  const uint64_t current_epoch = DeviceCacheCoherence::instance().current_epoch();
+  if (coherence_epoch_ == current_epoch)
+    return;
+  cache_.invalidate_all();
+  clear_all_dirty_bytes();
+  coherence_epoch_ = current_epoch;
+}
+
+void L2Cache::mark_dirty_bytes(uint64_t line_addr, uint32_t offset, uint32_t size, uint32_t vmid) {
+  assert(offset < LINE_SIZE && size != 0 && size <= LINE_SIZE - offset);
+  std::lock_guard lock(dirty_bytes_mutex_);
+  DirtyMask &mask = dirty_bytes_[{vmid, line_addr}];
+  for (uint32_t byte = offset; byte < offset + size; ++byte)
+    mask[byte / 64] |= uint64_t{1} << (byte % 64);
+  has_dirty_lines_.store(true, std::memory_order_relaxed);
+}
+
+bool L2Cache::clear_dirty_bytes(uint64_t line_addr, uint32_t offset, uint32_t size, uint32_t vmid) {
+  assert(offset < LINE_SIZE && size != 0 && size <= LINE_SIZE - offset);
+  std::lock_guard lock(dirty_bytes_mutex_);
+  const auto key = std::pair{vmid, line_addr};
+  const auto it = dirty_bytes_.find(key);
+  if (it == dirty_bytes_.end())
+    return false;
+
+  for (uint32_t byte = offset; byte < offset + size; ++byte)
+    it->second[byte / 64] &= ~(uint64_t{1} << (byte % 64));
+
+  const bool line_remains_dirty =
+      std::ranges::any_of(it->second, [](uint64_t word) { return word != 0; });
+  if (!line_remains_dirty)
+    dirty_bytes_.erase(it);
+  has_dirty_lines_.store(!dirty_bytes_.empty(), std::memory_order_relaxed);
+  return line_remains_dirty;
+}
+
+void L2Cache::publish_dirty_bytes(uint64_t line_addr, const uint8_t *data, uint32_t vmid,
+                                  uint32_t discard_offset, uint32_t discard_size) {
+  assert(discard_offset <= LINE_SIZE && discard_size <= LINE_SIZE - discard_offset);
+  DirtyMask mask{};
+  {
+    std::lock_guard lock(dirty_bytes_mutex_);
+    const auto it = dirty_bytes_.find({vmid, line_addr});
+    assert(it != dirty_bytes_.end() && "dirty L2 line must have a byte mask");
+    if (it == dirty_bytes_.end())
+      return;
+    mask = it->second;
+    dirty_bytes_.erase(it);
+    has_dirty_lines_.store(!dirty_bytes_.empty(), std::memory_order_relaxed);
+  }
+
+  for (uint32_t byte = discard_offset; byte < discard_offset + discard_size; ++byte)
+    mask[byte / 64] &= ~(uint64_t{1} << (byte % 64));
+
+  uint32_t offset = 0;
+  while (offset < LINE_SIZE) {
+    while (offset < LINE_SIZE && (mask[offset / 64] & (uint64_t{1} << (offset % 64))) == 0)
+      ++offset;
+    const uint32_t start = offset;
+    while (offset < LINE_SIZE && (mask[offset / 64] & (uint64_t{1} << (offset % 64))) != 0)
+      ++offset;
+    if (start != offset)
+      send_backing(line_addr + start, const_cast<uint8_t *>(data + start), offset - start,
+                   simdojo::MessageOp::WRITE, vmid);
+  }
+}
+
+void L2Cache::clear_all_dirty_bytes() {
+  std::lock_guard lock(dirty_bytes_mutex_);
+  dirty_bytes_.clear();
+  has_dirty_lines_.store(false, std::memory_order_relaxed);
+}
+
 void L2Cache::send_backing(uint64_t addr, uint8_t *data, uint32_t size, simdojo::MessageOp op,
                            uint32_t vmid) {
   if (op == simdojo::MessageOp::WRITE)
@@ -66,7 +167,7 @@ void L2Cache::ensure_line(uint64_t addr, uint32_t vmid) {
     // The evicted line is written back under its own owning vmid, which may
     // differ from the current request's vmid when two processes alias the
     // same GPU VA in different ways of the same set.
-    send_backing(evicted_addr, evicted_data, LINE_SIZE, simdojo::MessageOp::WRITE, evicted.vmid);
+    publish_dirty_bytes(evicted_addr, evicted_data, evicted.vmid);
   }
 
   uint8_t line_buf[LINE_SIZE];
@@ -75,7 +176,7 @@ void L2Cache::ensure_line(uint64_t addr, uint32_t vmid) {
 }
 
 void L2Cache::read(uint64_t addr, uint8_t *dst, uint32_t size, Mtype mtype, uint32_t vmid) {
-  std::shared_lock maintenance_lock(maintenance_mutex_);
+  auto maintenance_lock = acquire_cache_access();
   uint32_t copied = 0;
   if (mtype == Mtype::UC) {
     while (copied < size) {
@@ -112,7 +213,7 @@ void L2Cache::read(uint64_t addr, uint8_t *dst, uint32_t size, Mtype mtype, uint
 }
 
 void L2Cache::write(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtype, uint32_t vmid) {
-  std::shared_lock maintenance_lock(maintenance_mutex_);
+  auto maintenance_lock = acquire_cache_access();
   uint32_t copied = 0;
   if (mtype == Mtype::UC) {
     while (copied < size) {
@@ -148,9 +249,10 @@ void L2Cache::write(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtyp
     // in L2 as dirty lines and never reach the host-visible pages, causing
     // stale reads on D2H copy.
     send_backing(ea, const_cast<uint8_t *>(src + copied), chunk, simdojo::MessageOp::WRITE, vmid);
-    tag->coherence =
-        (mtype == Mtype::CC) ? simdojo::CoherenceState::SHARED : simdojo::CoherenceState::EXCLUSIVE;
-    tag->dirty = false;
+    tag->dirty = clear_dirty_bytes(CacheStore::line_address(ea), line_offset, chunk, vmid);
+    tag->coherence = tag->dirty ? simdojo::CoherenceState::MODIFIED
+                                : (mtype == Mtype::CC ? simdojo::CoherenceState::SHARED
+                                                      : simdojo::CoherenceState::EXCLUSIVE);
 
     write_count_.fetch_add(1, std::memory_order_relaxed);
     copied += chunk;
@@ -158,7 +260,7 @@ void L2Cache::write(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtyp
 }
 
 void L2Cache::fetch_line(uint64_t addr, uint8_t *line_buf, uint32_t vmid) {
-  std::shared_lock maintenance_lock(maintenance_mutex_);
+  auto maintenance_lock = acquire_cache_access();
   std::lock_guard set_lock(set_mutex(addr));
   uint64_t line_addr = CacheStore::line_address(addr);
   const uint8_t *line = cache_.line_data_for_read(line_addr, vmid);
@@ -172,7 +274,7 @@ void L2Cache::fetch_line(uint64_t addr, uint8_t *line_buf, uint32_t vmid) {
       uint64_t evicted_addr =
           (evicted.tag << (LINE_SIZE_BITS + SET_INDEX_BITS)) |
           (static_cast<uint64_t>(CacheStore::set_index(line_addr)) << LINE_SIZE_BITS);
-      send_backing(evicted_addr, evicted_data, LINE_SIZE, simdojo::MessageOp::WRITE, evicted.vmid);
+      publish_dirty_bytes(evicted_addr, evicted_data, evicted.vmid);
     }
 
     send_backing(line_addr, allocated.data, LINE_SIZE, simdojo::MessageOp::READ, vmid);
@@ -182,33 +284,30 @@ void L2Cache::fetch_line(uint64_t addr, uint8_t *line_buf, uint32_t vmid) {
 }
 
 void L2Cache::writeback_line(uint64_t line_addr, const uint8_t *data, Mtype mtype, uint32_t vmid) {
-  std::shared_lock maintenance_lock(maintenance_mutex_);
+  writeback_line(line_addr, data, 0, LINE_SIZE, mtype, vmid);
+}
+
+void L2Cache::writeback_line(uint64_t line_addr, const uint8_t *data, uint32_t dirty_offset,
+                             uint32_t dirty_size, Mtype mtype, uint32_t vmid) {
+  assert(CacheStore::line_address(line_addr) == line_addr && "writeback address must be aligned");
+  assert(dirty_offset < LINE_SIZE && dirty_size != 0 && dirty_size <= LINE_SIZE - dirty_offset &&
+         "dirty range must fit in one L2 line");
+  auto maintenance_lock = acquire_cache_access();
   std::lock_guard set_lock(set_mutex(line_addr));
+  ensure_line(line_addr, vmid);
   simdojo::CacheTag *tag = nullptr;
-  if (cache_.lookup(line_addr, &tag, vmid)) {
-    cache_.write_line(line_addr, data, 0, LINE_SIZE, vmid);
-  } else {
-    simdojo::CacheTag evicted;
-    uint8_t evicted_data[LINE_SIZE];
-    cache_.allocate(line_addr, vmid, &evicted, evicted_data);
-
-    if (evicted.valid && evicted.dirty) {
-      static constexpr uint32_t SET_INDEX_BITS = std::bit_width(NUM_SETS - 1);
-      uint64_t evicted_addr =
-          (evicted.tag << (LINE_SIZE_BITS + SET_INDEX_BITS)) |
-          (static_cast<uint64_t>(CacheStore::set_index(line_addr)) << LINE_SIZE_BITS);
-      send_backing(evicted_addr, evicted_data, LINE_SIZE, simdojo::MessageOp::WRITE, evicted.vmid);
-    }
-
-    cache_.fill_line(line_addr, data, vmid);
-    cache_.lookup(line_addr, &tag, vmid);
-  }
+  cache_.lookup(line_addr, &tag, vmid);
+  assert(tag != nullptr && "ensure_line must guarantee hit");
+  cache_.write_line(line_addr, data + dirty_offset, dirty_offset, dirty_size, vmid);
 
   if (mtype == Mtype::CC) {
-    send_backing(line_addr, const_cast<uint8_t *>(data), LINE_SIZE, simdojo::MessageOp::WRITE,
-                 vmid);
-    tag->coherence = simdojo::CoherenceState::SHARED;
+    send_backing(line_addr + dirty_offset, const_cast<uint8_t *>(data + dirty_offset), dirty_size,
+                 simdojo::MessageOp::WRITE, vmid);
+    tag->dirty = clear_dirty_bytes(line_addr, dirty_offset, dirty_size, vmid);
+    tag->coherence =
+        tag->dirty ? simdojo::CoherenceState::MODIFIED : simdojo::CoherenceState::SHARED;
   } else {
+    mark_dirty_bytes(line_addr, dirty_offset, dirty_size, vmid);
     tag->dirty = true;
     tag->coherence = simdojo::CoherenceState::MODIFIED;
   }
@@ -223,26 +322,35 @@ void L2Cache::flush_line_locked(uint64_t addr, uint32_t vmid) {
     uint8_t line_buf[LINE_SIZE];
     cache_.read_line(addr, line_buf, 0, LINE_SIZE, vmid);
     uint64_t line_addr = CacheStore::line_address(addr);
-    send_backing(line_addr, line_buf, LINE_SIZE, simdojo::MessageOp::WRITE, vmid);
+    publish_dirty_bytes(line_addr, line_buf, vmid);
   }
   cache_.invalidate(addr, vmid);
 }
 
 void L2Cache::flush_line(uint64_t addr, uint32_t vmid) {
-  std::shared_lock maintenance_lock(maintenance_mutex_);
+  auto maintenance_lock = acquire_cache_access();
   std::lock_guard set_lock(set_mutex(addr));
   flush_line_locked(addr, vmid);
 }
 
 void L2Cache::flush_all(uint32_t vmid) {
   (void)vmid;
-  std::unique_lock maintenance_lock(maintenance_mutex_);
+  auto maintenance_lock = acquire_cache_maintenance();
+  flush_dirty_locked();
+  cache_.invalidate_all();
+  clear_all_dirty_bytes();
+}
+
+void L2Cache::flush_dirty_locked() {
+  if (!has_dirty_lines_.load(std::memory_order_relaxed))
+    return;
+
   uint32_t dirty_count = 0;
   uint64_t min_addr = std::numeric_limits<uint64_t>::max(), max_addr = 0;
   cache_.for_each_dirty([this, &dirty_count, &min_addr,
                          &max_addr](simdojo::CacheTag &tag, uint64_t line_addr, uint8_t *data) {
     // Each dirty line is written back under its own owning vmid.
-    send_backing(line_addr, data, LINE_SIZE, simdojo::MessageOp::WRITE, tag.vmid);
+    publish_dirty_bytes(line_addr, data, tag.vmid);
     tag.dirty = false;
     ++dirty_count;
     if (line_addr < min_addr)
@@ -250,10 +358,11 @@ void L2Cache::flush_all(uint32_t vmid) {
     if (line_addr > max_addr)
       max_addr = line_addr;
   });
-  util::Logger::vm("L2 flush: ", dirty_count, " dirty lines [0x", std::hex, min_addr, "-0x",
-                   max_addr, "]", std::dec,
-                   " total_writes=", write_count_.load(std::memory_order_relaxed));
-  cache_.invalidate_all();
+  clear_all_dirty_bytes();
+  if (dirty_count != 0)
+    util::Logger::vm("L2 flush: ", dirty_count, " dirty lines [0x", std::hex, min_addr, "-0x",
+                     max_addr, "]", std::dec,
+                     " total_writes=", write_count_.load(std::memory_order_relaxed));
 }
 
 void L2Cache::invalidate_range(uint64_t addr, uint32_t size, uint32_t vmid) {
@@ -267,13 +376,13 @@ void L2Cache::invalidate_range(uint64_t addr, uint32_t size, uint32_t vmid) {
   const uint64_t line_count = std::min(requested_lines, addressable_lines);
 
   if (line_count <= MAX_INVALIDATE_RANGE_SET_LOCKS) {
-    std::shared_lock maintenance_lock(maintenance_mutex_);
+    auto maintenance_lock = acquire_cache_access();
     auto locks = lock_sets_for_range(line_start, line_count);
     invalidate_range_locked(addr, size, vmid, line_start, line_count);
     return;
   }
 
-  std::unique_lock maintenance_lock(maintenance_mutex_);
+  auto maintenance_lock = acquire_cache_maintenance();
   invalidate_range_locked(addr, size, vmid, line_start, line_count);
 }
 
@@ -288,13 +397,12 @@ void L2Cache::invalidate_range_locked(uint64_t addr, uint32_t size, uint32_t vmi
 
     simdojo::CacheTag *tag = nullptr;
     if (cache_.lookup(line_addr, &tag, vmid)) {
-      const bool partial_line = line_offset != 0 || chunk != LINE_SIZE;
-      if (tag->dirty && partial_line) {
-        std::array<uint8_t, LINE_SIZE> merged{};
-        cache_.read_line(line_addr, merged.data(), 0, LINE_SIZE, vmid);
-        send_backing(line_addr + line_offset, merged.data() + line_offset, chunk,
-                     simdojo::MessageOp::READ, vmid);
-        send_backing(line_addr, merged.data(), LINE_SIZE, simdojo::MessageOp::WRITE, vmid);
+      if (tag->dirty) {
+        std::array<uint8_t, LINE_SIZE> dirty_data{};
+        cache_.read_line(line_addr, dirty_data.data(), 0, LINE_SIZE, vmid);
+        // The invalidated bytes are authoritative in backing memory. Publish
+        // only dirty bytes outside that range before discarding the line.
+        publish_dirty_bytes(line_addr, dirty_data.data(), vmid, line_offset, chunk);
       }
       cache_.invalidate(line_addr, vmid);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
@@ -187,9 +187,11 @@ public:
   }
 
   /// @brief Invalidate L2 lines covering an address range.
-  /// @details Used after host/SDMA writes to ensure GPU reads reload from
-  /// backing store. No writeback: the backing store already has latest data.
-  void invalidate_range(uint64_t addr, uint32_t size);
+  /// @details Used after a host/SDMA write has completed. Bytes inside the
+  /// range are authoritative in backing memory. Dirty bytes outside a partial
+  /// line update are preserved before the target VMID's line is invalidated.
+  /// @param vmid Owning process address space to invalidate.
+  void invalidate_range(uint64_t addr, uint32_t size, uint32_t vmid);
 
   /// @brief Flush all dirty L2 lines to HBM and invalidate.
   /// @param vmid Ignored. Each dirty line is written back under its own owning

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
@@ -49,7 +49,8 @@ namespace amdgpu {
 /// but do not invalidate other aliases; CC/UC access or explicit cache
 /// maintenance is required before an alias refetches that data. Dirty lines are
 /// written back through their owning VMID. Atomic RMW is intentionally stronger:
-/// GpuMemory resolves mapped aliases to one backing identity for serialization.
+/// L2Cache serializes dirty writeback and the backing RMW process-wide, above
+/// GPU-VA-to-host mapping differences.
 ///
 /// Serves as the backing store for both L1 Scalar (K$) and L1 Vector (V$).
 ///
@@ -135,11 +136,10 @@ public:
 
   /// @brief Perform an atomic read-modify-write on a cache line.
   ///
-  /// @details Invalidates the local line, then delegates the RMW to GpuMemory,
-  /// which serializes by resolved backing address across all L2 instances.
-  /// Port-only configurations use one conservative process-wide lock. This
-  /// models device-wide atomic arbitration when multiple XCD-local L2s or VMID
-  /// aliases share backing memory.
+  /// @details Serializes process-wide before flushing the local dirty line,
+  /// then delegates the RMW to GpuMemory. Holding the same lock through local
+  /// tag cleanup models device-wide atomic arbitration when multiple XCD-local
+  /// L2s or VMID aliases share backing memory, including port-only setups.
   ///
   /// @param addr The memory address of the atomic target.
   /// @param size Access size in bytes (4 or 8).
@@ -148,6 +148,7 @@ public:
   template <typename F> void atomic_rmw(uint64_t addr, uint32_t size, F &&fn, uint32_t vmid = 0) {
     std::shared_lock maintenance_lock(maintenance_mutex_);
     std::lock_guard set_lock(set_mutex(addr));
+    std::lock_guard atomic_lock(device_atomic_mutex());
     flush_line_locked(addr, vmid);
 
     if (backing_memory_) {
@@ -155,7 +156,6 @@ public:
       backing_write_transactions_.fetch_add(1, std::memory_order_relaxed);
       backing_memory_->atomic_rmw(addr, size, [&](uint8_t *target) { fn(target, 0); }, vmid);
     } else {
-      std::lock_guard atomic_lock(fallback_atomic_mutex());
       ensure_line(addr, vmid);
       uint32_t offset = CacheStore::line_offset(addr);
       uint8_t *line = cache_.line_data_for_write(addr, vmid);
@@ -220,11 +220,15 @@ public:
   const std::vector<simdojo::Port *> &cpl_ports() const { return cpl_ports_; }
 
 private:
+  friend class L2CacheTestAccess;
+
+  static constexpr uint64_t MAX_INVALIDATE_RANGE_SET_LOCKS = 64;
+
   std::mutex &set_mutex(uint64_t addr) const { return set_mutexes_[CacheStore::set_index(addr)]; }
 
-  static std::mutex &fallback_atomic_mutex() {
-    // Port-only configurations cannot expose a resolved backing identity.
-    // Serialize their atomics conservatively rather than keying by GPU VA.
+  static std::mutex &device_atomic_mutex() {
+    // Different host mappings can name the same backing object. Serialize
+    // above address translation so dirty writeback and the RMW stay one unit.
     static std::mutex mutex;
     return mutex;
   }
@@ -281,6 +285,8 @@ private:
 
   void ensure_line(uint64_t addr, uint32_t vmid = 0);
   void flush_line_locked(uint64_t addr, uint32_t vmid = 0);
+  void invalidate_range_locked(uint64_t addr, uint32_t size, uint32_t vmid, uint64_t line_start,
+                               uint64_t line_count);
   void send_backing(uint64_t addr, uint8_t *data, uint32_t size, simdojo::MessageOp op,
                     uint32_t vmid = 0);
 
@@ -291,8 +297,8 @@ private:
   GpuMemory *backing_memory_ = nullptr; ///< Direct writeback path (functional mode).
   std::vector<simdojo::Port *> cpl_ports_;
   std::atomic<uint64_t> write_count_ = 0; ///< Debug: total L2 writes (for trace).
-  // Relaxed atomics: backing-address-striped atomic_rmw() calls can update
-  // these concurrently.
+  // Relaxed atomics: independent cache operations can update these counters
+  // concurrently; the values are diagnostic only.
   std::atomic<uint64_t> backing_read_transactions_{0};
   std::atomic<uint64_t> backing_write_transactions_{0};
 };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
@@ -7,6 +7,7 @@
 #ifndef ROCJITSU_VM_AMDGPU_L2_CACHE_H_
 #define ROCJITSU_VM_AMDGPU_L2_CACHE_H_
 
+#include "rocjitsu/vm/amdgpu/device_cache_coherence.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/mtype.h"
 #include "simdojo/components/cache.h"
@@ -19,6 +20,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
@@ -49,8 +51,8 @@ namespace amdgpu {
 /// but do not invalidate other aliases; CC/UC access or explicit cache
 /// maintenance is required before an alias refetches that data. Dirty lines are
 /// written back through their owning VMID. Atomic RMW is intentionally stronger:
-/// L2Cache serializes dirty writeback and the backing RMW process-wide, above
-/// GPU-VA-to-host mapping differences.
+/// L2Cache coordinates all registered device caches before the backing RMW,
+/// above GPU-VA-to-host mapping differences.
 ///
 /// Serves as the backing store for both L1 Scalar (K$) and L1 Vector (V$).
 ///
@@ -77,10 +79,13 @@ public:
 
   /// @brief Construct an L2Cache component.
   /// @param name Human-readable name (e.g., "xcd0.l2").
-  explicit L2Cache(std::string name) : simdojo::Component(std::move(name)) {
-    req_port_ = add_port(std::make_unique<simdojo::Port>(
-        "req", 0, this, simdojo::PortDirection::OUT, simdojo::PortProtocol::MEMORY));
-  }
+  explicit L2Cache(std::string name);
+  ~L2Cache() override;
+
+  L2Cache(const L2Cache &) = delete;
+  L2Cache &operator=(const L2Cache &) = delete;
+  L2Cache(L2Cache &&) = delete;
+  L2Cache &operator=(L2Cache &&) = delete;
 
   /// @brief Set the requester port used to reach the backing store.
   /// @param port The OUT port connected to the MSC or HBM controller.
@@ -134,41 +139,41 @@ public:
   void writeback_line(uint64_t line_addr, const uint8_t *data, Mtype mtype = Mtype::RW,
                       uint32_t vmid = 0);
 
+  /// @brief Write back only the modified bytes from a full L1 line snapshot.
+  /// @param line_addr Line-aligned address.
+  /// @param[in] data Full cache line data (LINE_SIZE bytes).
+  /// @param dirty_offset First modified byte within the line.
+  /// @param dirty_size Number of modified bytes.
+  /// @param mtype Memory type for caching policy.
+  /// @param vmid Owning process address space.
+  void writeback_line(uint64_t line_addr, const uint8_t *data, uint32_t dirty_offset,
+                      uint32_t dirty_size, Mtype mtype = Mtype::RW, uint32_t vmid = 0);
+
   /// @brief Perform an atomic read-modify-write on a cache line.
   ///
-  /// @details Serializes process-wide before flushing the local dirty line,
-  /// then delegates the RMW to GpuMemory. Holding the same lock through local
-  /// tag cleanup models device-wide atomic arbitration when multiple XCD-local
-  /// L2s or VMID aliases share backing memory, including port-only setups.
+  /// @details Establishes a process-wide device coherence boundary: dirty
+  /// scalar and L2 state is published, the device coherence epoch is advanced,
+  /// and every L2 remains quiescent through the backing RMW. Cached clean lines
+  /// are discarded lazily on their next ordinary access.
   ///
   /// @param addr The memory address of the atomic target.
   /// @param size Access size in bytes (4 or 8).
   /// @param fn Callback: fn(line_data_ptr, line_offset). Must read the
   ///           old value, compute the new value, and write it in place.
   template <typename F> void atomic_rmw(uint64_t addr, uint32_t size, F &&fn, uint32_t vmid = 0) {
-    std::shared_lock maintenance_lock(maintenance_mutex_);
-    std::lock_guard set_lock(set_mutex(addr));
-    std::lock_guard atomic_lock(device_atomic_mutex());
-    flush_line_locked(addr, vmid);
+    [[maybe_unused]] auto boundary = DeviceCacheCoherence::instance().acquire_atomic_boundary();
 
     if (backing_memory_) {
       backing_read_transactions_.fetch_add(1, std::memory_order_relaxed);
       backing_write_transactions_.fetch_add(1, std::memory_order_relaxed);
       backing_memory_->atomic_rmw(addr, size, [&](uint8_t *target) { fn(target, 0); }, vmid);
     } else {
-      ensure_line(addr, vmid);
-      uint32_t offset = CacheStore::line_offset(addr);
-      uint8_t *line = cache_.line_data_for_write(addr, vmid);
-      assert(line != nullptr && "ensure_line must guarantee hit");
-      fn(line, offset);
-      send_backing(addr, line + offset, size, simdojo::MessageOp::WRITE, vmid);
-    }
-
-    simdojo::CacheTag *ctag = nullptr;
-    cache_.lookup(addr, &ctag, vmid);
-    if (ctag) {
-      ctag->coherence = simdojo::CoherenceState::MODIFIED;
-      ctag->dirty = false;
+      assert((size == sizeof(uint32_t) || size == sizeof(uint64_t)) &&
+             "L2 atomic size must be 4 or 8 bytes");
+      std::array<uint8_t, sizeof(uint64_t)> target{};
+      send_backing(addr, target.data(), size, simdojo::MessageOp::READ, vmid);
+      fn(target.data(), 0);
+      send_backing(addr, target.data(), size, simdojo::MessageOp::WRITE, vmid);
     }
   }
 
@@ -182,8 +187,9 @@ public:
 
   /// @brief Invalidate all L2 lines.
   void invalidate_all() {
-    std::unique_lock maintenance_lock(maintenance_mutex_);
+    auto maintenance_lock = acquire_cache_maintenance();
     cache_.invalidate_all();
+    clear_all_dirty_bytes();
   }
 
   /// @brief Invalidate L2 lines covering an address range.
@@ -220,18 +226,11 @@ public:
   const std::vector<simdojo::Port *> &cpl_ports() const { return cpl_ports_; }
 
 private:
-  friend class L2CacheTestAccess;
+  friend class DeviceCacheCoherence;
 
   static constexpr uint64_t MAX_INVALIDATE_RANGE_SET_LOCKS = 64;
 
   std::mutex &set_mutex(uint64_t addr) const { return set_mutexes_[CacheStore::set_index(addr)]; }
-
-  static std::mutex &device_atomic_mutex() {
-    // Different host mappings can name the same backing object. Serialize
-    // above address translation so dirty writeback and the RMW stay one unit.
-    static std::mutex mutex;
-    return mutex;
-  }
 
   class SetRangeLocks {
   public:
@@ -283,8 +282,18 @@ private:
     return SetRangeLocks(set_mutexes_, line_start, line_count);
   }
 
+  std::shared_lock<std::shared_mutex> acquire_cache_access();
+  std::unique_lock<std::shared_mutex> acquire_cache_maintenance();
+  void synchronize_epoch_locked();
   void ensure_line(uint64_t addr, uint32_t vmid = 0);
   void flush_line_locked(uint64_t addr, uint32_t vmid = 0);
+  void flush_dirty_locked();
+  using DirtyMask = std::array<uint64_t, LINE_SIZE / 64>;
+  void mark_dirty_bytes(uint64_t line_addr, uint32_t offset, uint32_t size, uint32_t vmid);
+  bool clear_dirty_bytes(uint64_t line_addr, uint32_t offset, uint32_t size, uint32_t vmid);
+  void publish_dirty_bytes(uint64_t line_addr, const uint8_t *data, uint32_t vmid,
+                           uint32_t discard_offset = 0, uint32_t discard_size = 0);
+  void clear_all_dirty_bytes();
   void invalidate_range_locked(uint64_t addr, uint32_t size, uint32_t vmid, uint64_t line_start,
                                uint64_t line_count);
   void send_backing(uint64_t addr, uint8_t *data, uint32_t size, simdojo::MessageOp op,
@@ -295,6 +304,10 @@ private:
   mutable std::array<std::mutex, NUM_SETS> set_mutexes_;
   simdojo::Port *req_port_ = nullptr;
   GpuMemory *backing_memory_ = nullptr; ///< Direct writeback path (functional mode).
+  uint64_t coherence_epoch_ = 0;
+  std::mutex dirty_bytes_mutex_;
+  std::map<std::pair<uint32_t, uint64_t>, DirtyMask> dirty_bytes_;
+  std::atomic<bool> has_dirty_lines_{false};
   std::vector<simdojo::Port *> cpl_ports_;
   std::atomic<uint64_t> write_count_ = 0; ///< Debug: total L2 writes (for trace).
   // Relaxed atomics: independent cache operations can update these counters

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
@@ -53,7 +53,9 @@ class GpuMemory; // Forward declaration for backing store writeback.
 /// per-set mutex so CPU dispatch workers sharing an XCD-local L2 can make
 /// progress on independent cache sets. Whole-cache maintenance takes all set
 /// mutexes in address-set order to exclude concurrent set operations without
-/// adding a global lock to every cache hit.
+/// adding a global lock to every cache hit. Each line operation is atomic with
+/// respect to other operations on that set; a request spanning multiple lines
+/// is intentionally not an atomic snapshot of the full range.
 class L2Cache : public simdojo::Component {
 public:
   static constexpr uint32_t LINE_SIZE_BITS = 7; // 128 bytes
@@ -205,6 +207,9 @@ private:
   std::mutex &set_mutex(uint64_t addr) const { return set_mutexes_[CacheStore::set_index(addr)]; }
 
   static std::mutex &global_atomic_mutex(uint64_t addr) {
+    // Deliberately process-wide rather than per-L2: separate XCD-local L2s can
+    // target the same backing address, so device-wide atomics must rendezvous
+    // on the same striped lock even when they originate from different L2s.
     static std::array<std::mutex, NUM_SETS> mutexes;
     return mutexes[CacheStore::set_index(addr)];
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
@@ -7,6 +7,7 @@
 #ifndef ROCJITSU_VM_AMDGPU_L2_CACHE_H_
 #define ROCJITSU_VM_AMDGPU_L2_CACHE_H_
 
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/mtype.h"
 #include "simdojo/components/cache.h"
 #include "simdojo/sim/component.h"
@@ -20,13 +21,12 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <utility>
 
 namespace rocjitsu {
 namespace amdgpu {
-
-class GpuMemory; // Forward declaration for backing store writeback.
 
 /// @brief L2 cache component shared per Accelerator Complex Die (XCD).
 ///
@@ -50,12 +50,13 @@ class GpuMemory; // Forward declaration for backing store writeback.
 ///
 /// @par Thread safety
 /// Public cache operations are thread-safe. Normal line operations take a
-/// per-set mutex so CPU dispatch workers sharing an XCD-local L2 can make
-/// progress on independent cache sets. Whole-cache maintenance takes all set
-/// mutexes in address-set order to exclude concurrent set operations without
-/// adding a global lock to every cache hit. Each line operation is atomic with
-/// respect to other operations on that set; a request spanning multiple lines
-/// is intentionally not an atomic snapshot of the full range.
+/// shared maintenance lock followed by a per-set mutex, so CPU dispatch workers
+/// sharing an XCD-local L2 can make progress on independent cache sets.
+/// Whole-cache maintenance takes the maintenance lock exclusively, avoiding
+/// both concurrent set access and TSan's fixed lock-tracker limit. Each line
+/// operation is atomic with respect to other operations on that set; a request
+/// spanning multiple lines is intentionally not an atomic snapshot of the full
+/// range.
 class L2Cache : public simdojo::Component {
 public:
   static constexpr uint32_t LINE_SIZE_BITS = 7; // 128 bytes
@@ -126,29 +127,34 @@ public:
 
   /// @brief Perform an atomic read-modify-write on a cache line.
   ///
-  /// @details Serializes through a process-wide striped lock shared by all L2
-  /// instances, refetches the line from backing memory, then calls the provided
-  /// function with a pointer to the line data and the byte offset within the
-  /// line. This models device-wide atomic arbitration when multiple XCD-local
-  /// L2s share backing memory.
+  /// @details Invalidates the local line, then delegates the RMW to GpuMemory,
+  /// which serializes by resolved backing address across all L2 instances.
+  /// Port-only configurations use one conservative process-wide lock. This
+  /// models device-wide atomic arbitration when multiple XCD-local L2s or VMID
+  /// aliases share backing memory.
   ///
   /// @param addr The memory address of the atomic target.
   /// @param size Access size in bytes (4 or 8).
   /// @param fn Callback: fn(line_data_ptr, line_offset). Must read the
   ///           old value, compute the new value, and write it in place.
   template <typename F> void atomic_rmw(uint64_t addr, uint32_t size, F &&fn, uint32_t vmid = 0) {
-    std::lock_guard atomic_lock(global_atomic_mutex(addr));
+    std::shared_lock maintenance_lock(maintenance_mutex_);
     std::lock_guard set_lock(set_mutex(addr));
     flush_line_locked(addr, vmid);
-    ensure_line(addr, vmid);
 
-    uint32_t offset = CacheStore::line_offset(addr);
-    uint8_t *line = cache_.line_data_for_write(addr, vmid);
-    assert(line != nullptr && "ensure_line must guarantee hit");
-
-    fn(line, offset);
-
-    send_backing(addr, line + offset, size, simdojo::MessageOp::WRITE, vmid);
+    if (backing_memory_) {
+      backing_read_transactions_.fetch_add(1, std::memory_order_relaxed);
+      backing_write_transactions_.fetch_add(1, std::memory_order_relaxed);
+      backing_memory_->atomic_rmw(addr, size, [&](uint8_t *target) { fn(target, 0); }, vmid);
+    } else {
+      std::lock_guard atomic_lock(fallback_atomic_mutex());
+      ensure_line(addr, vmid);
+      uint32_t offset = CacheStore::line_offset(addr);
+      uint8_t *line = cache_.line_data_for_write(addr, vmid);
+      assert(line != nullptr && "ensure_line must guarantee hit");
+      fn(line, offset);
+      send_backing(addr, line + offset, size, simdojo::MessageOp::WRITE, vmid);
+    }
 
     simdojo::CacheTag *ctag = nullptr;
     cache_.lookup(addr, &ctag, vmid);
@@ -168,7 +174,7 @@ public:
 
   /// @brief Invalidate all L2 lines.
   void invalidate_all() {
-    auto locks = lock_all_sets();
+    std::unique_lock maintenance_lock(maintenance_mutex_);
     cache_.invalidate_all();
   }
 
@@ -206,44 +212,12 @@ public:
 private:
   std::mutex &set_mutex(uint64_t addr) const { return set_mutexes_[CacheStore::set_index(addr)]; }
 
-  static std::mutex &global_atomic_mutex(uint64_t addr) {
-    // Deliberately process-wide rather than per-L2: separate XCD-local L2s can
-    // target the same backing address, so device-wide atomics must rendezvous
-    // on the same striped lock even when they originate from different L2s.
-    static std::array<std::mutex, NUM_SETS> mutexes;
-    return mutexes[CacheStore::set_index(addr)];
+  static std::mutex &fallback_atomic_mutex() {
+    // Port-only configurations cannot expose a resolved backing identity.
+    // Serialize their atomics conservatively rather than keying by GPU VA.
+    static std::mutex mutex;
+    return mutex;
   }
-
-  class AllSetLocks {
-  public:
-    explicit AllSetLocks(std::array<std::mutex, NUM_SETS> &mutexes) : mutexes_(mutexes) {
-      try {
-        for (auto &mutex : mutexes_) {
-          mutex.lock();
-          ++locked_;
-        }
-      } catch (...) {
-        unlock_all();
-        throw;
-      }
-    }
-
-    AllSetLocks(const AllSetLocks &) = delete;
-    AllSetLocks &operator=(const AllSetLocks &) = delete;
-
-    ~AllSetLocks() { unlock_all(); }
-
-  private:
-    void unlock_all() {
-      while (locked_ > 0) {
-        --locked_;
-        mutexes_[locked_].unlock();
-      }
-    }
-
-    std::array<std::mutex, NUM_SETS> &mutexes_;
-    size_t locked_ = 0;
-  };
 
   class SetRangeLocks {
   public:
@@ -291,7 +265,6 @@ private:
     size_t locked_ = 0;
   };
 
-  AllSetLocks lock_all_sets() const { return AllSetLocks(set_mutexes_); }
   SetRangeLocks lock_sets_for_range(uint64_t line_start, uint64_t line_count) const {
     return SetRangeLocks(set_mutexes_, line_start, line_count);
   }
@@ -302,12 +275,14 @@ private:
                     uint32_t vmid = 0);
 
   CacheStore cache_;
+  mutable std::shared_mutex maintenance_mutex_;
   mutable std::array<std::mutex, NUM_SETS> set_mutexes_;
   simdojo::Port *req_port_ = nullptr;
   GpuMemory *backing_memory_ = nullptr; ///< Direct writeback path (functional mode).
   std::vector<simdojo::Port *> cpl_ports_;
   std::atomic<uint64_t> write_count_ = 0; ///< Debug: total L2 writes (for trace).
-  // Relaxed atomics: striped atomic_rmw() calls can update these concurrently.
+  // Relaxed atomics: backing-address-striped atomic_rmw() calls can update
+  // these concurrently.
   std::atomic<uint64_t> backing_read_transactions_{0};
   std::atomic<uint64_t> backing_write_transactions_{0};
 };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
@@ -12,8 +12,10 @@
 #include "simdojo/sim/component.h"
 #include "simdojo/sim/message.h"
 
+#include <algorithm>
 #include <array>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -46,17 +48,12 @@ class GpuMemory; // Forward declaration for backing store writeback.
 /// Provides structural ports for the topology graph (IN for CU L1 miss
 /// requests, OUT for HBM/fabric traffic).
 ///
-/// THREAD SAFETY: The L2's read(), write(), fetch_line(), writeback_line(),
-/// ensure_line(), and flush_line() methods are NOT thread-safe. They operate on
-/// the underlying CacheStore without locking. Only atomic_rmw() is protected
-/// (via striped mutexes for cross-CU atomics to the same L2).
-///
-/// All CUs sharing an L2 instance MUST be assigned to the same simulation
-/// partition. This invariant ensures that only one worker thread accesses the
-/// L2's non-atomic paths at any given time. Violating this constraint (e.g.,
-/// placing CUs connected to the same L2 in different partitions) will cause
-/// data races on the cache data structure. The partitioner must enforce this
-/// constraint.
+/// @par Thread safety
+/// Public cache operations are thread-safe. Normal line operations take a
+/// per-set mutex so CPU dispatch workers sharing an XCD-local L2 can make
+/// progress on independent cache sets. Whole-cache maintenance takes all set
+/// mutexes in address-set order to exclude concurrent set operations without
+/// adding a global lock to every cache hit.
 class L2Cache : public simdojo::Component {
 public:
   static constexpr uint32_t LINE_SIZE_BITS = 7; // 128 bytes
@@ -108,6 +105,8 @@ public:
   void write(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtype = Mtype::RW,
              uint32_t vmid = 0);
 
+  uint64_t write_count() const { return write_count_.load(std::memory_order_relaxed); }
+
   /// @brief Fetch an entire cache line into the given buffer.
   ///
   /// Convenience method for L1 fills. Returns a full LINE_SIZE-byte line
@@ -125,20 +124,20 @@ public:
 
   /// @brief Perform an atomic read-modify-write on a cache line.
   ///
-  /// @details Ensures the line is present in L2, then calls the provided
-  /// function with a pointer to the line data and the byte offset within
-  /// the line. The entire operation is serialized under a mutex so that
-  /// concurrent atomic RMWs (from different simulation threads in
-  /// multi-threaded mode) are correctly ordered, matching real hardware
-  /// L2 arbitration.
+  /// @details Serializes through a process-wide striped lock shared by all L2
+  /// instances, refetches the line from backing memory, then calls the provided
+  /// function with a pointer to the line data and the byte offset within the
+  /// line. This models device-wide atomic arbitration when multiple XCD-local
+  /// L2s share backing memory.
   ///
   /// @param addr The memory address of the atomic target.
   /// @param size Access size in bytes (4 or 8).
   /// @param fn Callback: fn(line_data_ptr, line_offset). Must read the
   ///           old value, compute the new value, and write it in place.
   template <typename F> void atomic_rmw(uint64_t addr, uint32_t size, F &&fn, uint32_t vmid = 0) {
-    uint32_t stripe = (addr >> LINE_SIZE_BITS) & (ATOMIC_STRIPE_COUNT - 1);
-    std::lock_guard<std::mutex> lock(atomic_stripes_[stripe]);
+    std::lock_guard atomic_lock(global_atomic_mutex(addr));
+    std::lock_guard set_lock(set_mutex(addr));
+    flush_line_locked(addr, vmid);
     ensure_line(addr, vmid);
 
     uint32_t offset = CacheStore::line_offset(addr);
@@ -166,7 +165,15 @@ public:
   void flush_line(uint64_t addr, uint32_t vmid = 0);
 
   /// @brief Invalidate all L2 lines.
-  void invalidate_all() { cache_.invalidate_all(); }
+  void invalidate_all() {
+    auto locks = lock_all_sets();
+    cache_.invalidate_all();
+  }
+
+  /// @brief Invalidate L2 lines covering an address range.
+  /// @details Used after host/SDMA writes to ensure GPU reads reload from
+  /// backing store. No writeback: the backing store already has latest data.
+  void invalidate_range(uint64_t addr, uint32_t size);
 
   /// @brief Flush all dirty L2 lines to HBM and invalidate.
   /// @param vmid Ignored. Each dirty line is written back under its own owning
@@ -195,21 +202,104 @@ public:
   const std::vector<simdojo::Port *> &cpl_ports() const { return cpl_ports_; }
 
 private:
+  std::mutex &set_mutex(uint64_t addr) const { return set_mutexes_[CacheStore::set_index(addr)]; }
+
+  static std::mutex &global_atomic_mutex(uint64_t addr) {
+    static std::array<std::mutex, NUM_SETS> mutexes;
+    return mutexes[CacheStore::set_index(addr)];
+  }
+
+  class AllSetLocks {
+  public:
+    explicit AllSetLocks(std::array<std::mutex, NUM_SETS> &mutexes) : mutexes_(mutexes) {
+      try {
+        for (auto &mutex : mutexes_) {
+          mutex.lock();
+          ++locked_;
+        }
+      } catch (...) {
+        unlock_all();
+        throw;
+      }
+    }
+
+    AllSetLocks(const AllSetLocks &) = delete;
+    AllSetLocks &operator=(const AllSetLocks &) = delete;
+
+    ~AllSetLocks() { unlock_all(); }
+
+  private:
+    void unlock_all() {
+      while (locked_ > 0) {
+        --locked_;
+        mutexes_[locked_].unlock();
+      }
+    }
+
+    std::array<std::mutex, NUM_SETS> &mutexes_;
+    size_t locked_ = 0;
+  };
+
+  class SetRangeLocks {
+  public:
+    SetRangeLocks(std::array<std::mutex, NUM_SETS> &mutexes, uint64_t line_start, uint64_t end)
+        : mutexes_(mutexes) {
+      std::array<bool, NUM_SETS> seen{};
+      for (uint64_t line_addr = line_start; line_addr < end; line_addr += LINE_SIZE) {
+        uint32_t set = CacheStore::set_index(line_addr);
+        if (!seen[set]) {
+          seen[set] = true;
+          sets_[count_++] = set;
+        }
+      }
+
+      std::sort(sets_.begin(), sets_.begin() + count_);
+      try {
+        for (size_t i = 0; i < count_; ++i) {
+          mutexes_[sets_[i]].lock();
+          ++locked_;
+        }
+      } catch (...) {
+        unlock_all();
+        throw;
+      }
+    }
+
+    SetRangeLocks(const SetRangeLocks &) = delete;
+    SetRangeLocks &operator=(const SetRangeLocks &) = delete;
+
+    ~SetRangeLocks() { unlock_all(); }
+
+  private:
+    void unlock_all() {
+      while (locked_ > 0) {
+        --locked_;
+        mutexes_[sets_[locked_]].unlock();
+      }
+    }
+
+    std::array<std::mutex, NUM_SETS> &mutexes_;
+    std::array<uint32_t, NUM_SETS> sets_{};
+    size_t count_ = 0;
+    size_t locked_ = 0;
+  };
+
+  AllSetLocks lock_all_sets() const { return AllSetLocks(set_mutexes_); }
+  SetRangeLocks lock_sets_for_range(uint64_t line_start, uint64_t end) const {
+    return SetRangeLocks(set_mutexes_, line_start, end);
+  }
+
   void ensure_line(uint64_t addr, uint32_t vmid = 0);
+  void flush_line_locked(uint64_t addr, uint32_t vmid = 0);
   void send_backing(uint64_t addr, uint8_t *data, uint32_t size, simdojo::MessageOp op,
                     uint32_t vmid = 0);
 
-  static constexpr uint32_t ATOMIC_STRIPE_COUNT = 64;
-
   CacheStore cache_;
+  mutable std::array<std::mutex, NUM_SETS> set_mutexes_;
   simdojo::Port *req_port_ = nullptr;
   GpuMemory *backing_memory_ = nullptr; ///< Direct writeback path (functional mode).
-  /// @brief Striped locks for atomic RMW serialization. Each stripe covers
-  /// a range of cache lines, allowing atomics to different lines to proceed
-  /// in parallel (matching real L2 arbitration behavior).
-  std::array<std::mutex, ATOMIC_STRIPE_COUNT> atomic_stripes_;
   std::vector<simdojo::Port *> cpl_ports_;
-  uint64_t write_count_ = 0; ///< Debug: total L2 writes (for trace).
+  std::atomic<uint64_t> write_count_ = 0; ///< Debug: total L2 writes (for trace).
   // Relaxed atomics: striped atomic_rmw() calls can update these concurrently.
   std::atomic<uint64_t> backing_read_transactions_{0};
   std::atomic<uint64_t> backing_write_transactions_{0};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
@@ -247,10 +247,12 @@ private:
 
   class SetRangeLocks {
   public:
-    SetRangeLocks(std::array<std::mutex, NUM_SETS> &mutexes, uint64_t line_start, uint64_t end)
+    SetRangeLocks(std::array<std::mutex, NUM_SETS> &mutexes, uint64_t line_start,
+                  uint64_t line_count)
         : mutexes_(mutexes) {
       std::array<bool, NUM_SETS> seen{};
-      for (uint64_t line_addr = line_start; line_addr < end; line_addr += LINE_SIZE) {
+      for (uint64_t i = 0; i < line_count; ++i) {
+        const uint64_t line_addr = line_start + i * LINE_SIZE;
         uint32_t set = CacheStore::set_index(line_addr);
         if (!seen[set]) {
           seen[set] = true;
@@ -290,8 +292,8 @@ private:
   };
 
   AllSetLocks lock_all_sets() const { return AllSetLocks(set_mutexes_); }
-  SetRangeLocks lock_sets_for_range(uint64_t line_start, uint64_t end) const {
-    return SetRangeLocks(set_mutexes_, line_start, end);
+  SetRangeLocks lock_sets_for_range(uint64_t line_start, uint64_t line_count) const {
+    return SetRangeLocks(set_mutexes_, line_start, line_count);
   }
 
   void ensure_line(uint64_t addr, uint32_t vmid = 0);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
@@ -43,6 +43,14 @@ namespace amdgpu {
 ///            the backing store so completed dispatches are globally visible.
 ///   - NT: Allocate in L2 (L1 is bypassed, but L2 still caches).
 ///
+/// Ordinary cache entries are keyed by (VMID, GPU virtual line), not resolved
+/// backing identity. Different aliases of the same backing line therefore keep
+/// independent cached copies. Functional write() stores update backing memory
+/// but do not invalidate other aliases; CC/UC access or explicit cache
+/// maintenance is required before an alias refetches that data. Dirty lines are
+/// written back through their owning VMID. Atomic RMW is intentionally stronger:
+/// GpuMemory resolves mapped aliases to one backing identity for serialization.
+///
 /// Serves as the backing store for both L1 Scalar (K$) and L1 Vector (V$).
 ///
 /// Provides structural ports for the topology graph (IN for CU L1 miss

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -315,9 +315,9 @@ uint32_t atomic_source_stride(const VectorMemState &d) {
 
 /// @brief Perform a per-lane atomic RMW through L2.
 ///
-/// Reads old value from L2, applies the atomic operation, writes new value
-/// back. Invalidates the L1 line to prevent stale reads. Old values are
-/// stored in response_data for GLC return.
+/// Reads the old value through L2's backing-memory atomic path, applies the
+/// operation, and writes the new value back. The L1 line is invalidated to
+/// prevent stale reads. Old values are stored in response_data for GLC return.
 void execute_atomic_rmw(VectorMemState &d, L2Cache *l2, L1VectorCache *l1, uint32_t vmid) {
   const uint32_t esz = d.elem_size;
   d.response_data.resize(d.wf_size * esz);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -316,9 +316,10 @@ uint32_t atomic_source_stride(const VectorMemState &d) {
 /// @brief Perform a per-lane atomic RMW through L2.
 ///
 /// Reads the old value through L2's backing-memory atomic path, applies the
-/// operation, and writes the new value back. The L1 line is invalidated to
-/// prevent stale reads. Old values are stored in response_data for GLC return.
-void execute_atomic_rmw(VectorMemState &d, L2Cache *l2, L1VectorCache *l1, uint32_t vmid) {
+/// operation, and writes the new value back. The device coherence epoch makes
+/// cached L1/L2 lines stale at the atomic boundary. Old values are stored in
+/// response_data for GLC return.
+void execute_atomic_rmw(VectorMemState &d, L2Cache *l2, uint32_t vmid) {
   const uint32_t esz = d.elem_size;
   d.response_data.resize(d.wf_size * esz);
   const bool uses_two_sources =
@@ -380,9 +381,6 @@ void execute_atomic_rmw(VectorMemState &d, L2Cache *l2, L1VectorCache *l1, uint3
           }
         },
         vmid);
-
-    // Invalidate stale L1 line.
-    l1->invalidate(ea, vmid);
   }
 }
 
@@ -487,7 +485,7 @@ void GlobalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
   }
 
   if (d.atomic_op != AtomicOp::NONE) {
-    execute_atomic_rmw(d, l2_, l1_, wf.process_id());
+    execute_atomic_rmw(d, l2_, wf.process_id());
     return;
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.cpp
@@ -3,6 +3,8 @@
 
 #include "rocjitsu/vm/amdgpu/memory_side_cache.h"
 
+#include "rocjitsu/vm/amdgpu/device_cache_coherence.h"
+
 #include <algorithm>
 #include <bit>
 #include <cassert>
@@ -25,13 +27,19 @@ void MemorySideCache::send_backing(uint64_t addr, uint8_t *data, uint32_t size,
 }
 
 void MemorySideCache::ensure_line(uint64_t addr, uint32_t vmid) {
-  if (cache_.lookup(addr, nullptr, vmid))
-    return;
+  const uint64_t current_epoch = DeviceCacheCoherence::instance().current_epoch();
+  simdojo::CacheTag *resident = nullptr;
+  if (cache_.lookup(addr, &resident, vmid)) {
+    if (resident->coherence_epoch == current_epoch)
+      return;
+    assert(!resident->dirty && "stale write-through MSC line must be clean");
+    cache_.invalidate(addr, vmid);
+  }
 
   uint64_t line_addr = CacheStore::line_address(addr);
   simdojo::CacheTag evicted;
   uint8_t evicted_data[LINE_SIZE];
-  cache_.allocate(addr, vmid, &evicted, evicted_data);
+  simdojo::CacheTag *allocated = cache_.allocate(addr, vmid, &evicted, evicted_data);
 
   if (evicted.valid && evicted.dirty) {
     static constexpr uint32_t SET_INDEX_BITS = std::bit_width(NUM_SETS - 1);
@@ -43,6 +51,7 @@ void MemorySideCache::ensure_line(uint64_t addr, uint32_t vmid) {
   uint8_t line_buf[LINE_SIZE];
   send_backing(line_addr, line_buf, LINE_SIZE, simdojo::MessageOp::READ, vmid);
   cache_.fill_line(addr, line_buf, vmid);
+  allocated->coherence_epoch = current_epoch;
 }
 
 void MemorySideCache::read(uint64_t addr, uint8_t *dst, uint32_t size, uint32_t vmid) {

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/components/cache.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/components/cache.h
@@ -73,6 +73,7 @@ enum class CoherenceState : uint8_t {
 /// are per-process and may alias across processes.
 struct CacheTag {
   uint64_t tag = 0;
+  uint64_t coherence_epoch = 0; ///< Controller-defined lazy-invalidation generation.
   uint32_t vmid = 0;
   bool valid = false;
   bool dirty = false;
@@ -159,6 +160,7 @@ public:
       auto &t = tag_at(set, w);
       if (!t.valid) {
         t.tag = tag;
+        t.coherence_epoch = 0;
         t.vmid = vmid;
         t.valid = true;
         t.dirty = false;
@@ -179,6 +181,7 @@ public:
       std::memcpy(evicted_data, line_data(set, victim_way), LINE_SIZE);
 
     vt.tag = tag;
+    vt.coherence_epoch = 0;
     vt.vmid = vmid;
     vt.valid = true;
     vt.dirty = false;
@@ -196,6 +199,7 @@ public:
     for (uint32_t w = 0; w < Associativity; ++w) {
       auto &t = tag_at(set, w);
       if (t.valid && t.tag == tag && t.vmid == vmid) {
+        t.coherence_epoch = 0;
         t.valid = false;
         t.dirty = false;
         t.coherence = CoherenceState::INVALID;
@@ -212,6 +216,7 @@ public:
     for (uint32_t w = 0; w < Associativity; ++w) {
       auto &t = tag_at(set, w);
       if (t.valid && t.tag == tag) {
+        t.coherence_epoch = 0;
         t.valid = false;
         t.dirty = false;
         t.coherence = CoherenceState::INVALID;
@@ -222,6 +227,7 @@ public:
   /// @brief Invalidate all cache lines.
   void invalidate_all() {
     for (auto &t : tags_) {
+      t.coherence_epoch = 0;
       t.valid = false;
       t.dirty = false;
       t.coherence = CoherenceState::INVALID;

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -340,6 +340,7 @@ add_executable(
     matmul_test.cpp
     vector_add_test.cpp
     gfx1250_sim_test.cpp
+    l2_cache_test.cpp
     sparse_memory_test.cpp
     simdojo_sim_test.cpp
     simulated_kfd_test.cpp

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -559,6 +559,109 @@ TEST(GpuMemoryTest, ReusedMemoryInstanceInvalidatesThreadLocalTranslationCaches)
   second_memory->~GpuMemory();
 }
 
+TEST(GpuMemoryThreadingTest, AtomicRmwKeepsStorageIdentityAcrossConcurrentMap) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kVmid = 17;
+
+  void *raw_mapping = mmap(nullptr, KfdProcess::kPageSize, PROT_READ | PROT_WRITE,
+                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw_mapping, MAP_FAILED);
+  struct Mapping {
+    uint8_t *data;
+    ~Mapping() { munmap(data, KfdProcess::kPageSize); }
+  } mapping{static_cast<uint8_t *>(raw_mapping)};
+
+  KfdProcess process(kVmid);
+  memory.register_process(kVmid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+  memory.set_process_client_pid(kVmid, getpid());
+
+  // Mirror GpuMemory's private stripe selection to force the mapped and
+  // fallback identities onto different mutexes.
+  auto atomic_stripe = [](uintptr_t key) {
+    constexpr unsigned kGranuleShift = 3;
+    constexpr unsigned kHashFoldShift1 = 17;
+    constexpr unsigned kHashFoldShift2 = 31;
+    constexpr size_t kLockStripes = 4096;
+    key >>= kGranuleShift;
+    key ^= key >> kHashFoldShift1;
+    key ^= key >> kHashFoldShift2;
+    return key & (kLockStripes - 1);
+  };
+  constexpr uintptr_t kClientPidHashSalt = static_cast<uintptr_t>(0x9e3779b97f4a7c15ULL);
+
+  uint32_t *target = nullptr;
+  for (size_t offset = 64; offset + sizeof(uint32_t) <= KfdProcess::kPageSize; offset += 8) {
+    auto *candidate = reinterpret_cast<uint32_t *>(mapping.data + offset);
+    const uintptr_t mapped_key = reinterpret_cast<uintptr_t>(candidate);
+    uintptr_t fallback_key = mapped_key ^ (mapped_key >> 32);
+    fallback_key ^= static_cast<uintptr_t>(getpid()) * kClientPidHashSalt;
+    if (atomic_stripe(mapped_key) != atomic_stripe(fallback_key)) {
+      target = candidate;
+      break;
+    }
+  }
+  ASSERT_NE(target, nullptr);
+  *target = 0;
+
+  std::barrier first_atomic_has_read(2);
+  std::barrier allow_first_atomic_to_write(2);
+  std::thread first_atomic([&] {
+    memory.atomic_rmw(
+        reinterpret_cast<uint64_t>(target), sizeof(*target),
+        [&](uint8_t *storage) {
+          uint32_t value = 0;
+          std::memcpy(&value, storage, sizeof(value));
+          ++value;
+          std::memcpy(storage, &value, sizeof(value));
+          first_atomic_has_read.arrive_and_wait();
+          allow_first_atomic_to_write.arrive_and_wait();
+        },
+        kVmid);
+  });
+
+  first_atomic_has_read.arrive_and_wait();
+
+  // The fixed path keeps the page-table shared lock through the fallback RMW,
+  // so mapping waits for the first atomic. The old path lets the map and a
+  // differently locked mapped atomic overtake its write.
+  const bool mapping_can_proceed = process.page_table_mutex_.try_lock();
+  if (mapping_can_proceed)
+    process.page_table_mutex_.unlock();
+
+  if (mapping_can_proceed) {
+    process.map_pages(reinterpret_cast<uint64_t>(mapping.data), mapping.data,
+                      KfdProcess::kPageSize);
+    memory.atomic_rmw(
+        reinterpret_cast<uint64_t>(target), sizeof(*target),
+        [](uint8_t *storage) {
+          uint32_t value = 0;
+          std::memcpy(&value, storage, sizeof(value));
+          ++value;
+          std::memcpy(storage, &value, sizeof(value));
+        },
+        kVmid);
+    allow_first_atomic_to_write.arrive_and_wait();
+    first_atomic.join();
+  } else {
+    allow_first_atomic_to_write.arrive_and_wait();
+    first_atomic.join();
+    process.map_pages(reinterpret_cast<uint64_t>(mapping.data), mapping.data,
+                      KfdProcess::kPageSize);
+    memory.atomic_rmw(
+        reinterpret_cast<uint64_t>(target), sizeof(*target),
+        [](uint8_t *storage) {
+          uint32_t value = 0;
+          std::memcpy(&value, storage, sizeof(value));
+          ++value;
+          std::memcpy(storage, &value, sizeof(value));
+        },
+        kVmid);
+  }
+
+  EXPECT_EQ(*target, 2u);
+}
+
 TEST(GpuMemoryThreadingTest, ReadersRemainSafeWhilePagesAreRemapped) {
   amdgpu::GpuMemory memory("memory");
   constexpr uint32_t kPid = 7;

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -472,6 +472,32 @@ TEST(GpuMemoryTest, UnregisterInvalidatesThreadLocalTranslationCaches) {
   EXPECT_EQ(memory.pte_mtype(kAddr, kPid), amdgpu::Mtype::RW);
 }
 
+TEST(GpuMemoryTest, PageTableEntryMutationsInvalidateCachedPtes) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr uint64_t kOffset = 0x123;
+  constexpr uint64_t kAddr = kBaseVa + kOffset;
+
+  KfdProcess process(kPid);
+  std::array<uint8_t, KfdProcess::kPageSize> old_page{};
+  std::array<uint8_t, KfdProcess::kPageSize> new_page{};
+  old_page[kOffset] = 0x11;
+  new_page[kOffset] = 0x22;
+  process.map_pages(kBaseVa, old_page.data(), old_page.size(), amdgpu::Mtype::UC);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  ASSERT_EQ(memory.read8(kAddr, kPid), old_page[kOffset]);
+  ASSERT_EQ(memory.pte_mtype(kAddr, kPid), amdgpu::Mtype::UC);
+
+  process.remap_page_host_ptrs(kBaseVa, old_page.data(), new_page.data(), new_page.size());
+  EXPECT_EQ(memory.read8(kAddr, kPid), new_page[kOffset]);
+
+  process.set_page_mtype(kBaseVa, new_page.size(), amdgpu::Mtype::CC);
+  EXPECT_EQ(memory.pte_mtype(kAddr, kPid), amdgpu::Mtype::CC);
+}
+
 TEST(GpuMemoryTest, ReusedMemoryInstanceInvalidatesThreadLocalTranslationCaches) {
   constexpr uint32_t kPid = 7;
   constexpr uint64_t kBaseVa = 0x40000000;

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -583,6 +583,16 @@ TEST(GpuMemoryTest, RegisteredVmidPassthroughMissRespectsUserSpaceLimit) {
   EXPECT_EQ(memory.resolve_host_ptr(0x4000, kPid), reinterpret_cast<uint8_t *>(0x4000));
 }
 
+TEST(GpuMemoryTest, UnregisteredVmidPassthroughRespectsUserSpaceLimit) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint64_t kUserSpaceLimit = 0x800000000000ULL;
+
+  EXPECT_EQ(memory.resolve_host_ptr(kUserSpaceLimit), nullptr);
+  EXPECT_EQ(memory.resolve_host_ptr(kUserSpaceLimit + 0x123), nullptr);
+  EXPECT_EQ(memory.resolve_host_ptr(0x4000), reinterpret_cast<uint8_t *>(0x4000));
+}
+
 TEST(GpuMemoryTest, RegisteredVmidBlockMissUsesClientMemory) {
   amdgpu::GpuMemory memory("memory");
   constexpr uint32_t kPid = 7;

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -30,6 +30,8 @@ RJ_DIAGNOSTIC_POP
 
 #include <algorithm>
 #include <array>
+#include <atomic>
+#include <barrier>
 #include <bit>
 #include <chrono>
 #include <cstdint>
@@ -43,6 +45,7 @@ RJ_DIAGNOSTIC_POP
 #include <string_view>
 #include <thread>
 #include <sys/mman.h>
+#include <thread>
 #include <unistd.h>
 #include <vector>
 
@@ -457,7 +460,7 @@ TEST(GpuMemoryTest, UnregisterInvalidatesThreadLocalTranslationCaches) {
   page[kOffset] = 0x5a;
   process.map_pages(kBaseVa, page.data(), page.size(), amdgpu::Mtype::UC);
   memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
-                          &process.page_table_generation_);
+                          process.page_table_generation());
 
   EXPECT_EQ(memory.resolve_host_ptr(kAddr, kPid), page.data());
   EXPECT_EQ(memory.read8(kAddr, kPid), page[kOffset]);
@@ -483,7 +486,7 @@ TEST(GpuMemoryTest, ReusedMemoryInstanceInvalidatesThreadLocalTranslationCaches)
 
   auto *first_memory = new (storage) amdgpu::GpuMemory("memory");
   first_memory->register_process(kPid, &first_process.page_table_, &first_process.page_table_mutex_,
-                                 &first_process.page_table_generation_);
+                                 first_process.page_table_generation());
   EXPECT_EQ(first_memory->read8(kAddr, kPid), first_page[kOffset]);
   EXPECT_EQ(first_memory->pte_mtype(kAddr, kPid), amdgpu::Mtype::UC);
   first_memory->~GpuMemory();
@@ -496,10 +499,72 @@ TEST(GpuMemoryTest, ReusedMemoryInstanceInvalidatesThreadLocalTranslationCaches)
   auto *second_memory = new (storage) amdgpu::GpuMemory("memory");
   second_memory->register_process(kPid, &second_process.page_table_,
                                   &second_process.page_table_mutex_,
-                                  &second_process.page_table_generation_);
+                                  second_process.page_table_generation());
   EXPECT_EQ(second_memory->read8(kAddr, kPid), second_page[kOffset]);
   EXPECT_EQ(second_memory->pte_mtype(kAddr, kPid), amdgpu::Mtype::CC);
   second_memory->~GpuMemory();
+}
+
+TEST(GpuMemoryThreadingTest, ReadersRemainSafeWhilePagesAreRemapped) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kAddr = 0x40000000;
+  constexpr uint32_t kValuePrefix = 0xa5a50000;
+  constexpr uint32_t kReaders = 4;
+  constexpr uint32_t kRemaps = 2000;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  auto initial_page = std::make_unique<uint32_t>(kValuePrefix);
+  process.map_pages(kAddr, initial_page.get(), sizeof(*initial_page));
+  std::barrier start(kReaders + 1);
+  std::barrier initial_read(kReaders + 1);
+  std::atomic<bool> stop{false};
+  std::atomic<uint64_t> mapped_reads{0};
+  std::atomic<uint64_t> invalid_reads{0};
+  std::vector<std::thread> readers;
+  readers.reserve(kReaders);
+  for (uint32_t i = 0; i < kReaders; ++i) {
+    readers.emplace_back([&] {
+      start.arrive_and_wait();
+      const uint32_t initial_value = memory.read32(kAddr, kPid);
+      if ((initial_value & 0xffff0000) == kValuePrefix)
+        mapped_reads.fetch_add(1, std::memory_order_relaxed);
+      else
+        invalid_reads.fetch_add(1, std::memory_order_relaxed);
+      initial_read.arrive_and_wait();
+      while (!stop.load(std::memory_order_acquire)) {
+        const uint32_t value = memory.read32(kAddr, kPid);
+        if (value == 0)
+          continue;
+        if ((value & 0xffff0000) == kValuePrefix)
+          mapped_reads.fetch_add(1, std::memory_order_relaxed);
+        else
+          invalid_reads.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+  }
+
+  start.arrive_and_wait();
+  initial_read.arrive_and_wait();
+  process.unmap_pages(kAddr, sizeof(*initial_page));
+  initial_page.reset();
+  for (uint32_t i = 0; i < kRemaps; ++i) {
+    auto page = std::make_unique<uint32_t>(kValuePrefix | (i & 0xffff));
+    process.map_pages(kAddr, page.get(), sizeof(*page));
+    std::this_thread::yield();
+    process.unmap_pages(kAddr, sizeof(*page));
+    page.reset();
+  }
+  stop.store(true, std::memory_order_release);
+
+  for (auto &reader : readers)
+    reader.join();
+
+  EXPECT_GT(mapped_reads.load(std::memory_order_relaxed), 0u);
+  EXPECT_EQ(invalid_reads.load(std::memory_order_relaxed), 0u);
 }
 
 TEST(GpuMemoryTest, RegisteredVmidPassthroughMissRespectsUserSpaceLimit) {
@@ -510,7 +575,7 @@ TEST(GpuMemoryTest, RegisteredVmidPassthroughMissRespectsUserSpaceLimit) {
 
   KfdProcess process(kPid);
   memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
-                          &process.page_table_generation_);
+                          process.page_table_generation());
 
   EXPECT_EQ(memory.resolve_host_ptr(kUserSpaceLimit + 0x123, kPid), nullptr);
   EXPECT_EQ(memory.resolve_host_ptr(kUserSpaceLimit + KfdProcess::kPageSize + 0x123, kPid),
@@ -540,7 +605,7 @@ TEST(GpuMemoryTest, RegisteredVmidBlockMissUsesClientMemory) {
 
   KfdProcess process(kPid);
   memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
-                          &process.page_table_generation_);
+                          process.page_table_generation());
   memory.set_process_client_pid(kPid, getpid());
 
   constexpr size_t kAccessOffset = KfdProcess::kPageSize - 8;
@@ -2369,9 +2434,9 @@ TEST(L1ScalarCacheVmidTest, WritebackAllUsesLineOwnerVmidNotCaller) {
   proc_a.map_pages(kSharedVa, backing_a.data(), backing_a.size());
   proc_b.map_pages(kSharedVa, backing_b.data(), backing_b.size());
   mem.register_process(kVmidA, &proc_a.page_table_, &proc_a.page_table_mutex_,
-                       &proc_a.page_table_generation_);
+                       proc_a.page_table_generation());
   mem.register_process(kVmidB, &proc_b.page_table_, &proc_b.page_table_mutex_,
-                       &proc_b.page_table_generation_);
+                       proc_b.page_table_generation());
 
   amdgpu::L2Cache l2("test.l2");
   l2.set_backing_memory(&mem);

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -471,6 +471,35 @@ TEST(GpuMemoryTest, UnregisterInvalidatesThreadLocalTranslationCaches) {
   EXPECT_EQ(memory.pte_mtype(kAddr, kPid), amdgpu::Mtype::RW);
 }
 
+TEST(GpuMemoryTest, ReregisterProcessInvalidatesThreadLocalTranslationCaches) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr uint64_t kOffset = 0x123;
+  constexpr uint64_t kAddr = kBaseVa + kOffset;
+
+  KfdProcess first_process(kPid);
+  KfdProcess second_process(kPid);
+  std::array<uint8_t, KfdProcess::kPageSize> first_page{};
+  std::array<uint8_t, KfdProcess::kPageSize> second_page{};
+  first_page[kOffset] = 0x11;
+  second_page[kOffset] = 0x22;
+  first_process.map_pages(kBaseVa, first_page.data(), first_page.size(), amdgpu::Mtype::UC);
+  second_process.map_pages(kBaseVa, second_page.data(), second_page.size(), amdgpu::Mtype::CC);
+
+  memory.register_process(kPid, &first_process.page_table_, &first_process.page_table_mutex_,
+                          first_process.page_table_generation());
+  ASSERT_EQ(memory.resolve_host_ptr(kAddr, kPid), first_page.data());
+  ASSERT_EQ(memory.read8(kAddr, kPid), first_page[kOffset]);
+  ASSERT_EQ(memory.pte_mtype(kAddr, kPid), amdgpu::Mtype::UC);
+
+  memory.register_process(kPid, &second_process.page_table_, &second_process.page_table_mutex_,
+                          second_process.page_table_generation());
+  EXPECT_EQ(memory.resolve_host_ptr(kAddr, kPid), second_page.data());
+  EXPECT_EQ(memory.read8(kAddr, kPid), second_page[kOffset]);
+  EXPECT_EQ(memory.pte_mtype(kAddr, kPid), amdgpu::Mtype::CC);
+}
+
 TEST(GpuMemoryTest, PageTableEntryMutationsInvalidateCachedPtes) {
   amdgpu::GpuMemory memory("memory");
   constexpr uint32_t kPid = 7;

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -576,32 +576,7 @@ TEST(GpuMemoryThreadingTest, AtomicRmwKeepsStorageIdentityAcrossConcurrentMap) {
                           process.page_table_generation());
   memory.set_process_client_pid(kVmid, getpid());
 
-  // Mirror GpuMemory's private stripe selection to force the mapped and
-  // fallback identities onto different mutexes.
-  auto atomic_stripe = [](uintptr_t key) {
-    constexpr unsigned kGranuleShift = 3;
-    constexpr unsigned kHashFoldShift1 = 17;
-    constexpr unsigned kHashFoldShift2 = 31;
-    constexpr size_t kLockStripes = 4096;
-    key >>= kGranuleShift;
-    key ^= key >> kHashFoldShift1;
-    key ^= key >> kHashFoldShift2;
-    return key & (kLockStripes - 1);
-  };
-  constexpr uintptr_t kClientPidHashSalt = static_cast<uintptr_t>(0x9e3779b97f4a7c15ULL);
-
-  uint32_t *target = nullptr;
-  for (size_t offset = 64; offset + sizeof(uint32_t) <= KfdProcess::kPageSize; offset += 8) {
-    auto *candidate = reinterpret_cast<uint32_t *>(mapping.data + offset);
-    const uintptr_t mapped_key = reinterpret_cast<uintptr_t>(candidate);
-    uintptr_t fallback_key = mapped_key ^ (mapped_key >> 32);
-    fallback_key ^= static_cast<uintptr_t>(getpid()) * kClientPidHashSalt;
-    if (atomic_stripe(mapped_key) != atomic_stripe(fallback_key)) {
-      target = candidate;
-      break;
-    }
-  }
-  ASSERT_NE(target, nullptr);
+  auto *target = reinterpret_cast<uint32_t *>(mapping.data + 64);
   *target = 0;
 
   std::barrier first_atomic_has_read(2);
@@ -622,42 +597,25 @@ TEST(GpuMemoryThreadingTest, AtomicRmwKeepsStorageIdentityAcrossConcurrentMap) {
 
   first_atomic_has_read.arrive_and_wait();
 
-  // The fixed path keeps the page-table shared lock through the fallback RMW,
-  // so mapping waits for the first atomic. The old path lets the map and a
-  // differently locked mapped atomic overtake its write.
-  const bool mapping_can_proceed = process.page_table_mutex_.try_lock();
-  if (mapping_can_proceed)
+  const bool acquired_page_table_exclusively = process.page_table_mutex_.try_lock();
+  if (acquired_page_table_exclusively)
     process.page_table_mutex_.unlock();
+  EXPECT_FALSE(acquired_page_table_exclusively)
+      << "fallback atomic must retain the page-table shared lock during its callback";
 
-  if (mapping_can_proceed) {
-    process.map_pages(reinterpret_cast<uint64_t>(mapping.data), mapping.data,
-                      KfdProcess::kPageSize);
-    memory.atomic_rmw(
-        reinterpret_cast<uint64_t>(target), sizeof(*target),
-        [](uint8_t *storage) {
-          uint32_t value = 0;
-          std::memcpy(&value, storage, sizeof(value));
-          ++value;
-          std::memcpy(storage, &value, sizeof(value));
-        },
-        kVmid);
-    allow_first_atomic_to_write.arrive_and_wait();
-    first_atomic.join();
-  } else {
-    allow_first_atomic_to_write.arrive_and_wait();
-    first_atomic.join();
-    process.map_pages(reinterpret_cast<uint64_t>(mapping.data), mapping.data,
-                      KfdProcess::kPageSize);
-    memory.atomic_rmw(
-        reinterpret_cast<uint64_t>(target), sizeof(*target),
-        [](uint8_t *storage) {
-          uint32_t value = 0;
-          std::memcpy(&value, storage, sizeof(value));
-          ++value;
-          std::memcpy(storage, &value, sizeof(value));
-        },
-        kVmid);
-  }
+  allow_first_atomic_to_write.arrive_and_wait();
+  first_atomic.join();
+
+  process.map_pages(reinterpret_cast<uint64_t>(mapping.data), mapping.data, KfdProcess::kPageSize);
+  memory.atomic_rmw(
+      reinterpret_cast<uint64_t>(target), sizeof(*target),
+      [](uint8_t *storage) {
+        uint32_t value = 0;
+        std::memcpy(&value, storage, sizeof(value));
+        ++value;
+        std::memcpy(storage, &value, sizeof(value));
+      },
+      kVmid);
 
   EXPECT_EQ(*target, 2u);
 }

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -43,7 +43,6 @@ RJ_DIAGNOSTIC_POP
 #include <stdexcept>
 #include <string>
 #include <string_view>
-#include <thread>
 #include <sys/mman.h>
 #include <thread>
 #include <unistd.h>
@@ -617,6 +616,33 @@ TEST(GpuMemoryTest, UnregisteredVmidPassthroughRespectsUserSpaceLimit) {
   EXPECT_EQ(memory.resolve_host_ptr(kUserSpaceLimit), nullptr);
   EXPECT_EQ(memory.resolve_host_ptr(kUserSpaceLimit + 0x123), nullptr);
   EXPECT_EQ(memory.resolve_host_ptr(0x4000), reinterpret_cast<uint8_t *>(0x4000));
+}
+
+TEST(GpuMemoryTest, ZeroPassthroughAddressUsesFallbackStorage) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+
+  constexpr uint32_t kValue = 0xc001d00d;
+  memory.write32(0, kValue);
+
+  EXPECT_EQ(memory.read32(0), kValue);
+}
+
+TEST(GpuMemoryTest, NullBackedPteDoesNotInvokeMappedCallback) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kAddr = 0x4000;
+  constexpr uint32_t kValue = 0x12345678;
+
+  KfdProcess process(kPid);
+  process.page_table_[kAddr >> KfdProcess::kPageShift] = {};
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  ASSERT_EQ(memory.resolve_host_ptr(kAddr, kPid), nullptr);
+  memory.write32(kAddr, kValue, kPid);
+  EXPECT_EQ(memory.read32(kAddr, kPid), kValue);
 }
 
 TEST(GpuMemoryTest, RegisteredVmidBlockMissUsesClientMemory) {

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -2562,15 +2562,10 @@ TEST(DsTransposeTest, ReadB64TrB16_AccBit) {
                           << " should contain LDS data, not the VGPR sentinel";
 }
 
-// L1ScalarCache::writeback_all() must write each dirty K$ line back under its
-// own owning vmid (from the line tag), not the caller-supplied vmid. A CU can
-// retain dirty K$ lines from process A and then be flushed while processing
-// process B (e.g. from an acquire fence or SDMA path). If the bulk writeback
-// used the caller vmid, A's dirty line would be published through B's page
-// table and corrupt B's address space. Two page tables map the same GPU VA to
-// different host pages; a store under VMID 7 followed by writeback_all(8) must
-// land in VMID 7's backing, not VMID 8's.
-TEST(L1ScalarCacheVmidTest, WritebackAllUsesLineOwnerVmidNotCaller) {
+// Write-through scalar stores must use the store's VMID. Two page tables map
+// the same GPU VA to different host pages; a store under VMID 7 followed by the
+// no-op writeback_all(8) must land only in VMID 7's backing.
+TEST(L1ScalarCacheVmidTest, WriteThroughStoreUsesStoreVmid) {
   constexpr uint32_t kVmidA = 7;
   constexpr uint32_t kVmidB = 8;
   constexpr uint64_t kSharedVa = 0x40000; // page-aligned, aliased across procs.
@@ -2596,18 +2591,21 @@ TEST(L1ScalarCacheVmidTest, WritebackAllUsesLineOwnerVmidNotCaller) {
   amdgpu::L1ScalarCache k_cache(&l2);
   k_cache.set_memory(&mem);
 
-  // Store a dword under VMID A, leaving a dirty K$ line owned by VMID A.
+  // Store a dword under VMID A. Write-through must publish it immediately
+  // through VMID A's page table.
   k_cache.store(kSharedVa, /*num_dwords=*/1, &kStoreWord, kVmidA);
+  EXPECT_EQ(mem.read32(kSharedVa, kVmidA), kStoreWord);
+  EXPECT_NE(mem.read32(kSharedVa, kVmidB), kStoreWord);
 
-  // Flush the K$ as if servicing VMID B, then flush L2 to backing. The line
-  // must be published through VMID A's page table (its owner), not B's.
+  // A writeback request from another process is harmless because K$ has no
+  // dirty data to publish.
   k_cache.writeback_all(kVmidB);
   l2.flush_all();
 
   EXPECT_EQ(mem.read32(kSharedVa, kVmidA), kStoreWord)
-      << "dirty K$ line must be written back under its owner VMID A";
+      << "write-through store must remain in VMID A";
   EXPECT_NE(mem.read32(kSharedVa, kVmidB), kStoreWord)
-      << "line must NOT leak into VMID B's address space";
+      << "store must NOT leak into VMID B's address space";
 
   mem.unregister_process(kVmidA);
   mem.unregister_process(kVmidB);

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -28,16 +28,22 @@ RJ_DIAGNOSTIC_POP
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <bit>
 #include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <memory>
+#include <new>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 #include <thread>
+#include <sys/mman.h>
+#include <unistd.h>
 #include <vector>
 
 namespace {
@@ -437,6 +443,120 @@ TEST(GpuMemoryTest, VmidMappedKernelSymbolUsesTranslatedHostPointer) {
             "vmid_kernel");
 
   mem.unregister_process(process.process_id());
+}
+
+TEST(GpuMemoryTest, UnregisterInvalidatesThreadLocalTranslationCaches) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr uint64_t kOffset = 0x123;
+  constexpr uint64_t kAddr = kBaseVa + kOffset;
+
+  KfdProcess process(kPid);
+  std::array<uint8_t, KfdProcess::kPageSize> page{};
+  page[kOffset] = 0x5a;
+  process.map_pages(kBaseVa, page.data(), page.size(), amdgpu::Mtype::UC);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          &process.page_table_generation_);
+
+  EXPECT_EQ(memory.resolve_host_ptr(kAddr, kPid), page.data());
+  EXPECT_EQ(memory.read8(kAddr, kPid), page[kOffset]);
+  EXPECT_EQ(memory.pte_mtype(kAddr, kPid), amdgpu::Mtype::UC);
+
+  memory.unregister_process(kPid);
+
+  EXPECT_EQ(memory.resolve_host_ptr(kAddr, kPid), nullptr);
+  EXPECT_EQ(memory.pte_mtype(kAddr, kPid), amdgpu::Mtype::RW);
+}
+
+TEST(GpuMemoryTest, ReusedMemoryInstanceInvalidatesThreadLocalTranslationCaches) {
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr uint64_t kOffset = 0x123;
+  constexpr uint64_t kAddr = kBaseVa + kOffset;
+  alignas(amdgpu::GpuMemory) unsigned char storage[sizeof(amdgpu::GpuMemory)];
+
+  KfdProcess first_process(kPid);
+  std::array<uint8_t, KfdProcess::kPageSize> first_page{};
+  first_page[kOffset] = 0x11;
+  first_process.map_pages(kBaseVa, first_page.data(), first_page.size(), amdgpu::Mtype::UC);
+
+  auto *first_memory = new (storage) amdgpu::GpuMemory("memory");
+  first_memory->register_process(kPid, &first_process.page_table_, &first_process.page_table_mutex_,
+                                 &first_process.page_table_generation_);
+  EXPECT_EQ(first_memory->read8(kAddr, kPid), first_page[kOffset]);
+  EXPECT_EQ(first_memory->pte_mtype(kAddr, kPid), amdgpu::Mtype::UC);
+  first_memory->~GpuMemory();
+
+  KfdProcess second_process(kPid);
+  std::array<uint8_t, KfdProcess::kPageSize> second_page{};
+  second_page[kOffset] = 0x22;
+  second_process.map_pages(kBaseVa, second_page.data(), second_page.size(), amdgpu::Mtype::CC);
+
+  auto *second_memory = new (storage) amdgpu::GpuMemory("memory");
+  second_memory->register_process(kPid, &second_process.page_table_,
+                                  &second_process.page_table_mutex_,
+                                  &second_process.page_table_generation_);
+  EXPECT_EQ(second_memory->read8(kAddr, kPid), second_page[kOffset]);
+  EXPECT_EQ(second_memory->pte_mtype(kAddr, kPid), amdgpu::Mtype::CC);
+  second_memory->~GpuMemory();
+}
+
+TEST(GpuMemoryTest, RegisteredVmidPassthroughMissRespectsUserSpaceLimit) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kUserSpaceLimit = 0x800000000000ULL;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          &process.page_table_generation_);
+
+  EXPECT_EQ(memory.resolve_host_ptr(kUserSpaceLimit + 0x123, kPid), nullptr);
+  EXPECT_EQ(memory.resolve_host_ptr(kUserSpaceLimit + KfdProcess::kPageSize + 0x123, kPid),
+            nullptr);
+  EXPECT_EQ(memory.resolve_host_ptr(0x4000, kPid), reinterpret_cast<uint8_t *>(0x4000));
+}
+
+TEST(GpuMemoryTest, RegisteredVmidBlockMissUsesClientMemory) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr size_t kMappingSize = KfdProcess::kPageSize * 2;
+
+  void *raw_mapping =
+      mmap(nullptr, kMappingSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw_mapping, MAP_FAILED);
+  struct Mapping {
+    uint8_t *data = nullptr;
+    size_t size = 0;
+    ~Mapping() {
+      if (data)
+        munmap(data, size);
+    }
+  } mapping{static_cast<uint8_t *>(raw_mapping), kMappingSize};
+
+  for (size_t i = 0; i < kMappingSize; ++i)
+    mapping.data[i] = static_cast<uint8_t>((i * 17 + 3) & 0xff);
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          &process.page_table_generation_);
+  memory.set_process_client_pid(kPid, getpid());
+
+  constexpr size_t kAccessOffset = KfdProcess::kPageSize - 8;
+  constexpr size_t kAccessSize = 32;
+  const uint64_t addr = reinterpret_cast<uint64_t>(mapping.data + kAccessOffset);
+
+  std::array<uint8_t, kAccessSize> actual{};
+  memory.read_block(addr, std::span<uint8_t>(actual), kPid);
+  EXPECT_TRUE(std::equal(actual.begin(), actual.end(), mapping.data + kAccessOffset));
+
+  std::array<uint8_t, kAccessSize> replacement{};
+  for (size_t i = 0; i < replacement.size(); ++i)
+    replacement[i] = static_cast<uint8_t>(0xa0 + i);
+
+  memory.write_block(addr, std::span<const uint8_t>(replacement), kPid);
+  EXPECT_TRUE(std::equal(replacement.begin(), replacement.end(), mapping.data + kAccessOffset));
 }
 
 TEST(VmLifecycleTest, CreateAndDestroy) {
@@ -2248,8 +2368,10 @@ TEST(L1ScalarCacheVmidTest, WritebackAllUsesLineOwnerVmidNotCaller) {
   alignas(4096) std::array<uint8_t, 4096> backing_b{};
   proc_a.map_pages(kSharedVa, backing_a.data(), backing_a.size());
   proc_b.map_pages(kSharedVa, backing_b.data(), backing_b.size());
-  mem.register_process(kVmidA, &proc_a.page_table_, &proc_a.page_table_mutex_);
-  mem.register_process(kVmidB, &proc_b.page_table_, &proc_b.page_table_mutex_);
+  mem.register_process(kVmidA, &proc_a.page_table_, &proc_a.page_table_mutex_,
+                       &proc_a.page_table_generation_);
+  mem.register_process(kVmidB, &proc_b.page_table_, &proc_b.page_table_mutex_,
+                       &proc_b.page_table_generation_);
 
   amdgpu::L2Cache l2("test.l2");
   l2.set_backing_memory(&mem);

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -702,8 +702,7 @@ TEST(Gfx1250SdmaTest, GcrPacketSizeMatchesDialectAndKeepsRingInSync) {
 }
 
 // SDMA writes go straight to backing while L2 may still hold a dirty line that
-// overlaps the destination (e.g. left by a prior K$ writeback). The post-write
-// cache maintenance must not write that stale line back over the SDMA result.
+// overlaps the destination. Seed that state explicitly with writeback_line().
 // The fix flushes the caches before the direct write, so the dirty line is
 // published first and the SDMA data supersedes it. Regression for that ordering.
 TEST(Gfx1250SdmaTest, ConstFillSupersedesOverlappingDirtyL2Line) {
@@ -738,12 +737,10 @@ TEST(Gfx1250SdmaTest, ConstFillSupersedesOverlappingDirtyL2Line) {
   EXPECT_NE(sim.memory->read32(queue.dst_va(), kProcessId), kStaleWord);
 }
 
-// Same ordering hazard as above, but for a dirty scalar L1 (K$) line rather than
-// an L2 line. A CU can hold a dirty K$ line overlapping an SDMA destination. The
-// pre-write maintenance must write the K$ line back (through L2 to backing)
-// before the direct SDMA write, so the SDMA result is not later clobbered when
-// the stale scalar line is flushed. Regression for K$ inclusion in the flush.
-TEST(Gfx1250SdmaTest, ConstFillSupersedesOverlappingDirtyScalarL1Line) {
+// A scalar L1 (K$) can retain a clean snapshot overlapping an SDMA destination.
+// The pre-write maintenance invalidates that snapshot, and later K$ maintenance
+// must not publish it over the direct SDMA result.
+TEST(Gfx1250SdmaTest, ConstFillSupersedesOverlappingScalarL1Line) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();
   ASSERT_NE(cu, nullptr);
@@ -753,8 +750,8 @@ TEST(Gfx1250SdmaTest, ConstFillSupersedesOverlappingDirtyScalarL1Line) {
   constexpr uint32_t kStaleWord = 0x11111111u;
   constexpr uint32_t kFillWord = 0x22222222u;
 
-  // Dirty a K$ line overlapping the SDMA destination via a scalar store. This
-  // leaves the line dirty in K$ (write-back), not yet in L2 or backing.
+  // Populate a K$ line overlapping the SDMA destination via a write-through
+  // scalar store. K$ retains a clean snapshot of the pre-fill value.
   cu->l1_scalar().store(queue.dst_va(), /*num_dwords=*/1, &kStaleWord, kProcessId);
 
   // CONST_FILL the destination line with a different pattern.
@@ -767,9 +764,14 @@ TEST(Gfx1250SdmaTest, ConstFillSupersedesOverlappingDirtyScalarL1Line) {
   queue.submit(5);
   ASSERT_TRUE(sim.engine->step());
 
-  // Force any still-resident dirty K$ line out to backing, mimicking a later
-  // acquire/release flush. With the fix the K$ line was already published and
-  // invalidated before the SDMA write, so this does not resurrect stale data.
+  // The SDMA pre-write maintenance must have invalidated the old K$ snapshot,
+  // so the first scalar reload observes the fill rather than kStaleWord.
+  uint32_t scalar_value = 0;
+  cu->l1_scalar().load(queue.dst_va(), /*num_dwords=*/1, &scalar_value, kProcessId);
+  EXPECT_EQ(scalar_value, kFillWord);
+
+  // Mimic later acquire/release maintenance. The clean K$ snapshot must not
+  // resurrect stale data over the SDMA fill.
   cu->flush_l1(kProcessId);
   if (auto *l2 = sim.xcd()->l2_cache())
     l2->flush_all();

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -275,7 +275,7 @@ class TranslatedSdmaQueueForTest {
 public:
   explicit TranslatedSdmaQueueForTest(Gfx1250Sim &sim) : sim_(sim), process_(kProcessId) {
     sim_.memory->register_process(kProcessId, &process_.page_table_, &process_.page_table_mutex_,
-                                  &process_.page_table_generation_);
+                                  process_.page_table_generation());
     process_.map_pages(kRingVa, ring_.data(), ring_.size() * sizeof(ring_[0]));
     process_.map_pages(kQueueStateVa, queue_state_.data(),
                        queue_state_.size() * sizeof(queue_state_[0]));

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -274,7 +274,8 @@ private:
 class TranslatedSdmaQueueForTest {
 public:
   explicit TranslatedSdmaQueueForTest(Gfx1250Sim &sim) : sim_(sim), process_(kProcessId) {
-    sim_.memory->register_process(kProcessId, &process_.page_table_, &process_.page_table_mutex_);
+    sim_.memory->register_process(kProcessId, &process_.page_table_, &process_.page_table_mutex_,
+                                  &process_.page_table_generation_);
     process_.map_pages(kRingVa, ring_.data(), ring_.size() * sizeof(ring_[0]));
     process_.map_pages(kQueueStateVa, queue_state_.data(),
                        queue_state_.size() * sizeof(queue_state_[0]));

--- a/emulation/rocjitsu/tests/l2_cache_test.cpp
+++ b/emulation/rocjitsu/tests/l2_cache_test.cpp
@@ -66,6 +66,42 @@ TEST(L2CacheThreadingTest, ConcurrentDifferentSetWritesArePreserved) {
   }
 }
 
+TEST(L2CacheThreadingTest, ConcurrentSameSetAccessesPreserveLines) {
+  GpuMemory memory("memory");
+  L2Cache l2("l2");
+  l2.set_backing_memory(&memory);
+
+  constexpr uint32_t kThreads = 8;
+  constexpr uint32_t kIterations = 256;
+  constexpr uint64_t kBase = 0x180000;
+  constexpr uint64_t kSetStride = static_cast<uint64_t>(L2Cache::NUM_SETS) * L2Cache::LINE_SIZE;
+
+  std::barrier start(kThreads);
+  std::atomic<uint64_t> mismatches{0};
+  std::vector<std::thread> workers;
+  workers.reserve(kThreads);
+  for (uint32_t tid = 0; tid < kThreads; ++tid) {
+    workers.emplace_back([&, tid] {
+      const uint64_t addr = kBase + tid * kSetStride;
+      std::array<uint8_t, L2Cache::LINE_SIZE> line{};
+      std::array<uint8_t, L2Cache::LINE_SIZE> actual{};
+      start.arrive_and_wait();
+      for (uint32_t iteration = 0; iteration < kIterations; ++iteration) {
+        line.fill(static_cast<uint8_t>((tid << 4) ^ iteration));
+        l2.write(addr, line.data(), line.size());
+        l2.read(addr, actual.data(), actual.size());
+        if (actual != line)
+          mismatches.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+  }
+
+  for (auto &worker : workers)
+    worker.join();
+
+  EXPECT_EQ(mismatches.load(std::memory_order_relaxed), 0u);
+}
+
 TEST(L2CacheThreadingTest, ConcurrentAtomicRmwSameLineIsSerialized) {
   GpuMemory memory("memory");
   L2Cache l2("l2");

--- a/emulation/rocjitsu/tests/l2_cache_test.cpp
+++ b/emulation/rocjitsu/tests/l2_cache_test.cpp
@@ -177,6 +177,62 @@ TEST(L2CacheThreadingTest, CrossL2AtomicRmwSameAddressIsSerialized) {
   EXPECT_EQ(memory.read32(kTarget), kThreads * kIterations);
 }
 
+TEST(L2CacheThreadingTest, CrossL2AtomicRmwAliasedVasIsSerialized) {
+  GpuMemory memory("memory");
+  L2Cache l2a("l2a");
+  L2Cache l2b("l2b");
+  l2a.set_backing_memory(&memory);
+  l2b.set_backing_memory(&memory);
+
+  constexpr uint32_t kVmidA = 7;
+  constexpr uint32_t kVmidB = 8;
+  constexpr uint64_t kVaA = 0x100000;
+  constexpr uint64_t kVaB = 0x201000;
+  constexpr uint64_t kOffset = 64;
+  constexpr uint32_t kThreads = 8;
+  constexpr uint32_t kIterations = 1000;
+
+  rocjitsu::KfdProcess process_a(kVmidA);
+  rocjitsu::KfdProcess process_b(kVmidB);
+  std::array<uint8_t, GpuMemory::PAGE_SIZE> backing{};
+  process_a.map_pages(kVaA, backing.data(), backing.size());
+  process_b.map_pages(kVaB, backing.data(), backing.size());
+  memory.register_process(kVmidA, &process_a.page_table_, &process_a.page_table_mutex_,
+                          process_a.page_table_generation());
+  memory.register_process(kVmidB, &process_b.page_table_, &process_b.page_table_mutex_,
+                          process_b.page_table_generation());
+
+  std::barrier start(kThreads);
+  std::vector<std::thread> workers;
+  workers.reserve(kThreads);
+  for (uint32_t tid = 0; tid < kThreads; ++tid) {
+    workers.emplace_back([&, tid] {
+      L2Cache &l2 = (tid & 1) ? l2b : l2a;
+      const uint64_t addr = ((tid & 1) ? kVaB : kVaA) + kOffset;
+      const uint32_t vmid = (tid & 1) ? kVmidB : kVmidA;
+      start.arrive_and_wait();
+      for (uint32_t i = 0; i < kIterations; ++i) {
+        l2.atomic_rmw(
+            addr, sizeof(uint32_t),
+            [](uint8_t *line, uint32_t offset) {
+              uint32_t value = 0;
+              std::memcpy(&value, line + offset, sizeof(value));
+              ++value;
+              std::memcpy(line + offset, &value, sizeof(value));
+            },
+            vmid);
+      }
+    });
+  }
+
+  for (auto &worker : workers)
+    worker.join();
+
+  uint32_t actual = 0;
+  std::memcpy(&actual, backing.data() + kOffset, sizeof(actual));
+  EXPECT_EQ(actual, kThreads * kIterations);
+}
+
 TEST(L2CacheThreadingTest, ConcurrentFlushAllPreservesDirtyWritebacks) {
   GpuMemory memory("memory");
   L2Cache l2("l2");
@@ -263,6 +319,41 @@ TEST(L2CacheTest, InvalidateRangeClampsAtAddressSpaceEnd) {
   l2.read(kLineAddr, actual.data(), actual.size());
 
   EXPECT_EQ(actual, replacement);
+}
+
+TEST(L2CacheTest, InvalidateRangeRefreshesOnlyCoveredSetsAndZeroSizeIsNoOp) {
+  GpuMemory memory("memory");
+  L2Cache l2("l2");
+  l2.set_backing_memory(&memory);
+
+  constexpr uint64_t kBase = 0x400000;
+  constexpr uint32_t kLines = 5;
+  std::array<std::array<uint8_t, L2Cache::LINE_SIZE>, kLines> initial{};
+  std::array<std::array<uint8_t, L2Cache::LINE_SIZE>, kLines> replacement{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> actual{};
+
+  for (uint32_t line = 0; line < kLines; ++line) {
+    initial[line].fill(static_cast<uint8_t>(0x10 + line));
+    replacement[line].fill(static_cast<uint8_t>(0x80 + line));
+    const uint64_t addr = kBase + static_cast<uint64_t>(line) * L2Cache::LINE_SIZE;
+    memory.write_block(addr, std::span<const uint8_t>(initial[line]));
+    l2.read(addr, actual.data(), actual.size());
+    ASSERT_EQ(actual, initial[line]);
+    memory.write_block(addr, std::span<const uint8_t>(replacement[line]));
+  }
+
+  l2.invalidate_range(kBase + L2Cache::LINE_SIZE + 32, 2 * L2Cache::LINE_SIZE);
+
+  for (uint32_t line = 0; line < kLines; ++line) {
+    const uint64_t addr = kBase + static_cast<uint64_t>(line) * L2Cache::LINE_SIZE;
+    l2.read(addr, actual.data(), actual.size());
+    const auto &expected = (line >= 1 && line <= 3) ? replacement[line] : initial[line];
+    EXPECT_EQ(actual, expected) << "line=" << line;
+  }
+
+  l2.invalidate_range(kBase, 0);
+  l2.read(kBase, actual.data(), actual.size());
+  EXPECT_EQ(actual, initial[0]);
 }
 
 

--- a/emulation/rocjitsu/tests/l2_cache_test.cpp
+++ b/emulation/rocjitsu/tests/l2_cache_test.cpp
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/hbm_controller.h"
 #include "rocjitsu/vm/amdgpu/l1_scalar_cache.h"
 #include "rocjitsu/vm/amdgpu/l1_vector_cache.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/memory_side_cache.h"
+#include "simdojo/sim/exec_mode.h"
 
 #include <gtest/gtest.h>
 
@@ -33,9 +36,11 @@
 namespace {
 
 using rocjitsu::amdgpu::GpuMemory;
+using rocjitsu::amdgpu::HbmController;
 using rocjitsu::amdgpu::L1ScalarCache;
 using rocjitsu::amdgpu::L1VectorCache;
 using rocjitsu::amdgpu::L2Cache;
+using rocjitsu::amdgpu::MemorySideCache;
 using rocjitsu::amdgpu::Mtype;
 
 void increment_u32(uint8_t *line, uint32_t offset) {
@@ -818,6 +823,79 @@ TEST(L2CacheTest, FunctionalLinkedPortAtomicRmwUpdatesBacking) {
   EXPECT_EQ(backing.read32(kAddr), 42u);
   EXPECT_EQ(backing.read8(kAddr - 1), 0xA5);
   EXPECT_EQ(backing.read8(kAddr + sizeof(uint32_t)), 0x5A);
+}
+
+TEST(L2CacheTest, LinkedPortAtomicRmwRefreshesStaleMemorySideAlias) {
+  constexpr uint32_t kVmidA = 41;
+  constexpr uint32_t kVmidB = 42;
+  constexpr uint64_t kVaA = 0xC10000;
+  constexpr uint64_t kVaB = 0xD20000;
+  constexpr uint32_t kOffset = 64;
+  constexpr uint32_t kPublishedValue = 40;
+
+  rocjitsu::KfdProcess process_a(kVmidA);
+  rocjitsu::KfdProcess process_b(kVmidB);
+  std::array<uint8_t, GpuMemory::PAGE_SIZE> backing{};
+  process_a.map_pages(kVaA, backing.data(), backing.size(), Mtype::RW);
+  process_b.map_pages(kVaB, backing.data(), backing.size(), Mtype::RW);
+
+  GpuMemory memory("memory");
+  memory.register_process(kVmidA, &process_a.page_table_, &process_a.page_table_mutex_,
+                          process_a.page_table_generation());
+  memory.register_process(kVmidB, &process_b.page_table_, &process_b.page_table_mutex_,
+                          process_b.page_table_generation());
+
+  HbmController hbm("hbm", &memory);
+  MemorySideCache msc("msc");
+  L2Cache l2a("l2a");
+  L2Cache l2b("l2b");
+
+  simdojo::Port *l2a_msc_port = msc.create_cpl_port("l2a");
+  simdojo::Port *l2b_msc_port = msc.create_cpl_port("l2b");
+  simdojo::Link msc_hbm_link(/*id=*/0, msc.req_port(), hbm.cpl_port(), /*latency=*/0);
+  simdojo::Link l2a_msc_link(/*id=*/1, l2a.req_port(), l2a_msc_port, /*latency=*/0);
+  simdojo::Link l2b_msc_link(/*id=*/2, l2b.req_port(), l2b_msc_port, /*latency=*/0);
+  for (simdojo::Link *link : {&msc_hbm_link, &l2a_msc_link, &l2b_msc_link})
+    link->set_exec_mode(simdojo::ExecMode::FUNCTIONAL);
+  msc.req_port()->set_link(&msc_hbm_link);
+  hbm.cpl_port()->set_link(&msc_hbm_link);
+  l2a.req_port()->set_link(&l2a_msc_link);
+  l2a_msc_port->set_link(&l2a_msc_link);
+  l2b.req_port()->set_link(&l2b_msc_link);
+  l2b_msc_port->set_link(&l2b_msc_link);
+
+  uint32_t stale_value = 1;
+  l2b.read(kVaB + kOffset, reinterpret_cast<uint8_t *>(&stale_value), sizeof(stale_value),
+           Mtype::RW, kVmidB);
+  ASSERT_EQ(stale_value, 0u);
+
+  std::array<uint8_t, L2Cache::LINE_SIZE> dirty_line{};
+  std::memcpy(dirty_line.data() + kOffset, &kPublishedValue, sizeof(kPublishedValue));
+  l2a.writeback_line(kVaA, dirty_line.data(), kOffset, sizeof(kPublishedValue), Mtype::RW, kVmidA);
+
+  uint32_t callback_old_value = 0;
+  l2b.atomic_rmw(
+      kVaB + kOffset, sizeof(uint32_t),
+      [&](uint8_t *target, uint32_t offset) {
+        std::memcpy(&callback_old_value, target + offset, sizeof(callback_old_value));
+        const uint32_t replacement = callback_old_value + 1;
+        std::memcpy(target + offset, &replacement, sizeof(replacement));
+      },
+      kVmidB);
+
+  EXPECT_EQ(callback_old_value, kPublishedValue);
+  uint32_t host_value = 0;
+  std::memcpy(&host_value, backing.data() + kOffset, sizeof(host_value));
+  EXPECT_EQ(host_value, kPublishedValue + 1);
+
+  uint32_t alias_a_value = 0;
+  uint32_t alias_b_value = 0;
+  l2a.read(kVaA + kOffset, reinterpret_cast<uint8_t *>(&alias_a_value), sizeof(alias_a_value),
+           Mtype::RW, kVmidA);
+  l2b.read(kVaB + kOffset, reinterpret_cast<uint8_t *>(&alias_b_value), sizeof(alias_b_value),
+           Mtype::RW, kVmidB);
+  EXPECT_EQ(alias_a_value, kPublishedValue + 1);
+  EXPECT_EQ(alias_b_value, kPublishedValue + 1);
 }
 
 TEST(L2CacheTest, AliasedVasRequireCoherenceBoundary) {

--- a/emulation/rocjitsu/tests/l2_cache_test.cpp
+++ b/emulation/rocjitsu/tests/l2_cache_test.cpp
@@ -10,18 +10,191 @@
 #include <array>
 #include <atomic>
 #include <barrier>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <iomanip>
+#include <iostream>
 #include <limits>
+#include <linux/memfd.h>
 #include <span>
+#include <string_view>
+#include <sys/mman.h>
+#include <sys/syscall.h>
 #include <thread>
+#include <unistd.h>
 #include <vector>
+
+namespace rocjitsu::amdgpu {
+
+class L2CacheTestAccess {
+public:
+  static std::mutex &device_atomic_mutex() { return L2Cache::device_atomic_mutex(); }
+  static std::mutex &set_mutex(L2Cache &l2, uint64_t addr) { return l2.set_mutex(addr); }
+};
+
+} // namespace rocjitsu::amdgpu
 
 namespace {
 
 using rocjitsu::amdgpu::GpuMemory;
 using rocjitsu::amdgpu::L2Cache;
 using rocjitsu::amdgpu::Mtype;
+
+void increment_u32(uint8_t *line, uint32_t offset) {
+  uint32_t value = 0;
+  std::memcpy(&value, line + offset, sizeof(value));
+  ++value;
+  std::memcpy(line + offset, &value, sizeof(value));
+}
+
+void report_benchmark(std::string_view name, uint64_t operations,
+                      std::chrono::steady_clock::duration elapsed) {
+  const double total_ns = std::chrono::duration<double, std::nano>(elapsed).count();
+  std::cout << "ROCJITSU_BENCHMARK" << " name=" << name << " operations=" << operations
+            << " total_ns=" << static_cast<uint64_t>(total_ns) << " ns_per_op=" << std::fixed
+            << std::setprecision(3) << total_ns / static_cast<double>(operations) << '\n';
+}
+
+void run_cross_l2_atomic_benchmark(std::string_view name, bool same_address) {
+  GpuMemory memory("memory");
+  L2Cache l2a("l2a");
+  L2Cache l2b("l2b");
+  l2a.set_backing_memory(&memory);
+  l2b.set_backing_memory(&memory);
+
+  constexpr uint32_t kThreads = 8;
+  constexpr uint32_t kIterations = 25'000;
+  constexpr uint64_t kBase = 0x800000;
+  constexpr uint64_t kOperations = static_cast<uint64_t>(kThreads) * kIterations;
+
+  for (uint32_t tid = 0; tid < kThreads; ++tid)
+    memory.write32(kBase + static_cast<uint64_t>(tid) * L2Cache::LINE_SIZE, 0);
+
+  std::barrier ready(kThreads + 1);
+  std::barrier start(kThreads + 1);
+  std::barrier done(kThreads + 1);
+  std::array<L2Cache *, 2> l2s = {&l2a, &l2b};
+  std::vector<std::thread> workers;
+  workers.reserve(kThreads);
+  for (uint32_t tid = 0; tid < kThreads; ++tid) {
+    workers.emplace_back([&, tid] {
+      L2Cache *l2 = l2s[tid % l2s.size()];
+      const uint64_t target =
+          kBase + (same_address ? 0 : static_cast<uint64_t>(tid) * L2Cache::LINE_SIZE);
+      ready.arrive_and_wait();
+      start.arrive_and_wait();
+      for (uint32_t iteration = 0; iteration < kIterations; ++iteration)
+        l2->atomic_rmw(target, sizeof(uint32_t), increment_u32);
+      done.arrive_and_wait();
+    });
+  }
+
+  ready.arrive_and_wait();
+  const auto begin = std::chrono::steady_clock::now();
+  start.arrive_and_wait();
+  done.arrive_and_wait();
+  const auto end = std::chrono::steady_clock::now();
+  for (auto &worker : workers)
+    worker.join();
+
+  if (same_address) {
+    EXPECT_EQ(memory.read32(kBase), kOperations);
+  } else {
+    uint64_t observed_operations = 0;
+    for (uint32_t tid = 0; tid < kThreads; ++tid) {
+      const uint32_t observed =
+          memory.read32(kBase + static_cast<uint64_t>(tid) * L2Cache::LINE_SIZE);
+      EXPECT_EQ(observed, kIterations) << "thread=" << tid;
+      observed_operations += observed;
+    }
+    EXPECT_EQ(observed_operations, kOperations);
+  }
+  report_benchmark(name, kOperations, end - begin);
+}
+
+void run_invalidate_range_benchmark(std::string_view name, uint32_t lines, uint32_t iterations) {
+  GpuMemory memory("memory");
+  L2Cache l2("l2");
+  l2.set_backing_memory(&memory);
+
+  constexpr uint64_t kBase = 0xa00000;
+  std::array<uint8_t, L2Cache::LINE_SIZE> replacement{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> actual{};
+  for (uint32_t line = 0; line < lines; ++line) {
+    const uint64_t address = kBase + static_cast<uint64_t>(line) * L2Cache::LINE_SIZE;
+    replacement.fill(static_cast<uint8_t>(line + 0x40));
+    memory.write_block(address, std::span<const uint8_t>(replacement));
+  }
+
+  std::chrono::steady_clock::duration elapsed{};
+  uint64_t refill_checksum = 0;
+  uint64_t expected_refill_checksum = 0;
+  for (uint32_t line = 0; line < lines; ++line)
+    expected_refill_checksum += static_cast<uint8_t>(line + 0x40);
+  expected_refill_checksum *= iterations;
+
+  for (uint32_t iteration = 0; iteration < iterations; ++iteration) {
+    // Refill outside the timed interval so every measured call invalidates
+    // resident lines rather than repeatedly walking an empty cache.
+    for (uint32_t line = 0; line < lines; ++line) {
+      const uint64_t address = kBase + static_cast<uint64_t>(line) * L2Cache::LINE_SIZE;
+      l2.read(address, actual.data(), actual.size());
+      refill_checksum += actual.front();
+    }
+
+    const auto begin = std::chrono::steady_clock::now();
+    l2.invalidate_range(kBase, static_cast<uint64_t>(lines) * L2Cache::LINE_SIZE, 0);
+    elapsed += std::chrono::steady_clock::now() - begin;
+  }
+
+  uint64_t checksum = 0;
+  uint64_t expected_checksum = 0;
+  for (uint32_t line = 0; line < lines; ++line) {
+    const uint64_t address = kBase + static_cast<uint64_t>(line) * L2Cache::LINE_SIZE;
+    replacement.fill(static_cast<uint8_t>(line + 0x40));
+    l2.read(address, actual.data(), actual.size());
+    EXPECT_EQ(actual, replacement) << "line=" << line;
+    checksum += actual.front();
+    expected_checksum += replacement.front();
+  }
+  EXPECT_EQ(refill_checksum, expected_refill_checksum);
+  EXPECT_EQ(checksum, expected_checksum);
+  report_benchmark(name, iterations, elapsed);
+}
+
+class ScopedFd {
+public:
+  explicit ScopedFd(int fd) : fd_(fd) {}
+  ScopedFd(const ScopedFd &) = delete;
+  ScopedFd &operator=(const ScopedFd &) = delete;
+  ~ScopedFd() {
+    if (fd_ >= 0)
+      close(fd_);
+  }
+
+  int get() const { return fd_; }
+
+private:
+  int fd_;
+};
+
+class ScopedMapping {
+public:
+  ScopedMapping(void *address, size_t size) : address_(address), size_(size) {}
+  ScopedMapping(const ScopedMapping &) = delete;
+  ScopedMapping &operator=(const ScopedMapping &) = delete;
+  ~ScopedMapping() {
+    if (address_ != MAP_FAILED)
+      munmap(address_, size_);
+  }
+
+  uint8_t *data() const { return static_cast<uint8_t *>(address_); }
+
+private:
+  void *address_;
+  size_t size_;
+};
 
 TEST(L2CacheThreadingTest, ConcurrentDifferentSetWritesArePreserved) {
   GpuMemory memory("memory");
@@ -233,6 +406,110 @@ TEST(L2CacheThreadingTest, CrossL2AtomicRmwAliasedVasIsSerialized) {
   EXPECT_EQ(actual, kThreads * kIterations);
 }
 
+TEST(L2CacheThreadingTest, CrossL2AtomicRmwDistinctSharedMappingsIncludesDirtyWriteback) {
+  constexpr size_t kMappingSize = GpuMemory::PAGE_SIZE;
+  const int raw_fd = static_cast<int>(syscall(SYS_memfd_create, "l2_atomic_alias", MFD_CLOEXEC));
+  ASSERT_GE(raw_fd, 0);
+  ScopedFd fd(raw_fd);
+  ASSERT_EQ(ftruncate(fd.get(), static_cast<off_t>(kMappingSize)), 0);
+
+  void *raw_mapping_a =
+      mmap(nullptr, kMappingSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd.get(), 0);
+  ASSERT_NE(raw_mapping_a, MAP_FAILED);
+  ScopedMapping mapping_a(raw_mapping_a, kMappingSize);
+  void *raw_mapping_b =
+      mmap(nullptr, kMappingSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd.get(), 0);
+  ASSERT_NE(raw_mapping_b, MAP_FAILED);
+  ScopedMapping mapping_b(raw_mapping_b, kMappingSize);
+  ASSERT_NE(mapping_a.data(), mapping_b.data());
+
+  constexpr uint32_t kVmidA = 17;
+  constexpr uint32_t kVmidB = 18;
+  constexpr uint64_t kVaA = 0x310000;
+  constexpr uint64_t kVaB = 0x420000;
+  constexpr uint32_t kOffset = 64;
+  rocjitsu::KfdProcess process_a(kVmidA);
+  rocjitsu::KfdProcess process_b(kVmidB);
+  process_a.map_pages(kVaA, mapping_a.data(), kMappingSize, Mtype::CC);
+  process_b.map_pages(kVaB, mapping_b.data(), kMappingSize, Mtype::CC);
+
+  GpuMemory memory("memory");
+  memory.register_process(kVmidA, &process_a.page_table_, &process_a.page_table_mutex_,
+                          process_a.page_table_generation());
+  memory.register_process(kVmidB, &process_b.page_table_, &process_b.page_table_mutex_,
+                          process_b.page_table_generation());
+  L2Cache l2a("l2a");
+  L2Cache l2b("l2b");
+  l2a.set_backing_memory(&memory);
+  l2b.set_backing_memory(&memory);
+
+  std::array<uint8_t, L2Cache::LINE_SIZE> dirty_line{};
+  constexpr uint32_t kDirtyValue = 40;
+  std::memcpy(dirty_line.data() + kOffset, &kDirtyValue, sizeof(kDirtyValue));
+  l2a.writeback_line(kVaA, dirty_line.data(), Mtype::RW, kVmidA);
+
+  std::barrier first_atomic_has_read(2);
+  std::barrier allow_first_atomic_to_write(2);
+  std::atomic<uint32_t> first_observed{0};
+  auto increment = [](uint8_t *line, uint32_t offset) {
+    uint32_t value = 0;
+    std::memcpy(&value, line + offset, sizeof(value));
+    ++value;
+    std::memcpy(line + offset, &value, sizeof(value));
+  };
+
+  auto &atomic_mutex = rocjitsu::amdgpu::L2CacheTestAccess::device_atomic_mutex();
+  std::unique_lock atomic_lock(atomic_mutex);
+  std::thread first_atomic([&] {
+    l2a.atomic_rmw(
+        kVaA + kOffset, sizeof(uint32_t),
+        [&](uint8_t *line, uint32_t offset) {
+          uint32_t value = 0;
+          std::memcpy(&value, line + offset, sizeof(value));
+          first_observed.store(value, std::memory_order_relaxed);
+          ++value;
+          first_atomic_has_read.arrive_and_wait();
+          allow_first_atomic_to_write.arrive_and_wait();
+          std::memcpy(line + offset, &value, sizeof(value));
+        },
+        kVmidA);
+  });
+
+  auto wait_until_locked = [](std::mutex &mutex) {
+    constexpr uint32_t kMaxAttempts = 1'000'000;
+    for (uint32_t attempt = 0; attempt < kMaxAttempts; ++attempt) {
+      if (!mutex.try_lock())
+        return true;
+      mutex.unlock();
+      std::this_thread::yield();
+    }
+    return false;
+  };
+
+  auto &first_set_mutex = rocjitsu::amdgpu::L2CacheTestAccess::set_mutex(l2a, kVaA + kOffset);
+  EXPECT_TRUE(wait_until_locked(first_set_mutex));
+  uint32_t backing_before_flush = 0;
+  std::memcpy(&backing_before_flush, mapping_a.data() + kOffset, sizeof(backing_before_flush));
+  EXPECT_EQ(backing_before_flush, 0u);
+
+  atomic_lock.unlock();
+  first_atomic_has_read.arrive_and_wait();
+  EXPECT_EQ(first_observed.load(std::memory_order_relaxed), kDirtyValue);
+
+  std::thread second_atomic(
+      [&] { l2b.atomic_rmw(kVaB + kOffset, sizeof(uint32_t), increment, kVmidB); });
+  auto &second_set_mutex = rocjitsu::amdgpu::L2CacheTestAccess::set_mutex(l2b, kVaB + kOffset);
+  EXPECT_TRUE(wait_until_locked(second_set_mutex));
+  allow_first_atomic_to_write.arrive_and_wait();
+
+  first_atomic.join();
+  second_atomic.join();
+
+  uint32_t actual = 0;
+  std::memcpy(&actual, mapping_a.data() + kOffset, sizeof(actual));
+  EXPECT_EQ(actual, 42u);
+}
+
 TEST(L2CacheTest, AliasedVasRequireCoherenceBoundary) {
   GpuMemory memory("memory");
   L2Cache l2("l2");
@@ -409,6 +686,37 @@ TEST(L2CacheTest, InvalidateRangeRefreshesOnlyCoveredSetsAndZeroSizeIsNoOp) {
   EXPECT_EQ(actual, initial[0]);
 }
 
+TEST(L2CacheTest, InvalidateRangeOver128LinesUsesExclusiveMaintenance) {
+  GpuMemory memory("memory");
+  L2Cache l2("l2");
+  l2.set_backing_memory(&memory);
+
+  constexpr uint64_t kBase = 0x700000;
+  constexpr uint32_t kLines = 129;
+  std::array<uint8_t, L2Cache::LINE_SIZE> initial{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> replacement{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> actual{};
+
+  for (uint32_t line = 0; line < kLines; ++line) {
+    const uint64_t addr = kBase + static_cast<uint64_t>(line) * L2Cache::LINE_SIZE;
+    initial.fill(static_cast<uint8_t>(line));
+    replacement.fill(static_cast<uint8_t>(line + 0x40));
+    memory.write_block(addr, std::span<const uint8_t>(initial));
+    l2.read(addr, actual.data(), actual.size());
+    ASSERT_EQ(actual, initial) << "line=" << line;
+    memory.write_block(addr, std::span<const uint8_t>(replacement));
+  }
+
+  l2.invalidate_range(kBase, kLines * L2Cache::LINE_SIZE, 0);
+
+  for (uint32_t line = 0; line < kLines; ++line) {
+    const uint64_t addr = kBase + static_cast<uint64_t>(line) * L2Cache::LINE_SIZE;
+    replacement.fill(static_cast<uint8_t>(line + 0x40));
+    l2.read(addr, actual.data(), actual.size());
+    EXPECT_EQ(actual, replacement) << "line=" << line;
+  }
+}
+
 TEST(L2CacheTest, InvalidateRangeOnlyAffectsRequestedVmid) {
   GpuMemory memory("memory");
   L2Cache l2("l2");
@@ -486,6 +794,22 @@ TEST(L2CacheTest, InvalidateRangePreservesDirtyBytesOutsidePartialWrite) {
   EXPECT_EQ(actual, expected);
   l2.read(kAddr, actual.data(), actual.size());
   EXPECT_EQ(actual, expected);
+}
+
+TEST(L2CacheBenchmark, CrossL2SameAddress) {
+  run_cross_l2_atomic_benchmark("cross_l2_same_address", true);
+}
+
+TEST(L2CacheBenchmark, CrossL2IndependentAddresses) {
+  run_cross_l2_atomic_benchmark("cross_l2_independent_addresses", false);
+}
+
+TEST(L2CacheBenchmark, InvalidateThreeLines) {
+  run_invalidate_range_benchmark("invalidate_3_lines", 3, 200'000);
+}
+
+TEST(L2CacheBenchmark, Invalidate129Lines) {
+  run_invalidate_range_benchmark("invalidate_129_lines", 129, 5'000);
 }
 
 TEST(GpuMemoryTest, BlockAccessHandlesPageBoundaries) {

--- a/emulation/rocjitsu/tests/l2_cache_test.cpp
+++ b/emulation/rocjitsu/tests/l2_cache_test.cpp
@@ -368,7 +368,7 @@ TEST(L2CacheTest, InvalidateRangeClampsAtAddressSpaceEnd) {
   ASSERT_EQ(actual, initial);
 
   memory.write_block(kLineAddr, std::span<const uint8_t>(replacement));
-  l2.invalidate_range(kRangeAddr, L2Cache::LINE_SIZE);
+  l2.invalidate_range(kRangeAddr, L2Cache::LINE_SIZE, 0);
   l2.read(kLineAddr, actual.data(), actual.size());
 
   EXPECT_EQ(actual, replacement);
@@ -395,7 +395,7 @@ TEST(L2CacheTest, InvalidateRangeRefreshesOnlyCoveredSetsAndZeroSizeIsNoOp) {
     memory.write_block(addr, std::span<const uint8_t>(replacement[line]));
   }
 
-  l2.invalidate_range(kBase + L2Cache::LINE_SIZE + 32, 2 * L2Cache::LINE_SIZE);
+  l2.invalidate_range(kBase + L2Cache::LINE_SIZE + 32, 2 * L2Cache::LINE_SIZE, 0);
 
   for (uint32_t line = 0; line < kLines; ++line) {
     const uint64_t addr = kBase + static_cast<uint64_t>(line) * L2Cache::LINE_SIZE;
@@ -404,11 +404,89 @@ TEST(L2CacheTest, InvalidateRangeRefreshesOnlyCoveredSetsAndZeroSizeIsNoOp) {
     EXPECT_EQ(actual, expected) << "line=" << line;
   }
 
-  l2.invalidate_range(kBase, 0);
+  l2.invalidate_range(kBase, 0, 0);
   l2.read(kBase, actual.data(), actual.size());
   EXPECT_EQ(actual, initial[0]);
 }
 
+TEST(L2CacheTest, InvalidateRangeOnlyAffectsRequestedVmid) {
+  GpuMemory memory("memory");
+  L2Cache l2("l2");
+  l2.set_backing_memory(&memory);
+
+  constexpr uint32_t kVmidA = 7;
+  constexpr uint32_t kVmidB = 8;
+  constexpr uint64_t kAddr = 0x500000;
+  rocjitsu::KfdProcess process_a(kVmidA);
+  rocjitsu::KfdProcess process_b(kVmidB);
+  std::array<uint8_t, GpuMemory::PAGE_SIZE> backing_a{};
+  std::array<uint8_t, GpuMemory::PAGE_SIZE> backing_b{};
+  process_a.map_pages(kAddr, backing_a.data(), backing_a.size());
+  process_b.map_pages(kAddr, backing_b.data(), backing_b.size());
+  memory.register_process(kVmidA, &process_a.page_table_, &process_a.page_table_mutex_,
+                          process_a.page_table_generation());
+  memory.register_process(kVmidB, &process_b.page_table_, &process_b.page_table_mutex_,
+                          process_b.page_table_generation());
+
+  std::array<uint8_t, L2Cache::LINE_SIZE> initial_a{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> initial_b{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> dirty_a{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> replacement_b{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> actual{};
+  initial_a.fill(0x11);
+  initial_b.fill(0x22);
+  dirty_a.fill(0x33);
+  replacement_b.fill(0x44);
+
+  memory.write_block(kAddr, std::span<const uint8_t>(initial_a), kVmidA);
+  memory.write_block(kAddr, std::span<const uint8_t>(initial_b), kVmidB);
+  l2.read(kAddr, actual.data(), actual.size(), Mtype::RW, kVmidA);
+  ASSERT_EQ(actual, initial_a);
+  l2.read(kAddr, actual.data(), actual.size(), Mtype::RW, kVmidB);
+  ASSERT_EQ(actual, initial_b);
+  l2.writeback_line(kAddr, dirty_a.data(), Mtype::RW, kVmidA);
+
+  memory.write_block(kAddr, std::span<const uint8_t>(replacement_b), kVmidB);
+  l2.invalidate_range(kAddr, L2Cache::LINE_SIZE, kVmidB);
+  l2.read(kAddr, actual.data(), actual.size(), Mtype::RW, kVmidB);
+  EXPECT_EQ(actual, replacement_b);
+
+  l2.flush_line(kAddr, kVmidA);
+  memory.read_block(kAddr, std::span<uint8_t>(actual), kVmidA);
+  EXPECT_EQ(actual, dirty_a);
+}
+
+TEST(L2CacheTest, InvalidateRangePreservesDirtyBytesOutsidePartialWrite) {
+  GpuMemory memory("memory");
+  L2Cache l2("l2");
+  l2.set_backing_memory(&memory);
+
+  constexpr uint64_t kAddr = 0x600000;
+  constexpr uint32_t kOffset = 32;
+  std::array<uint8_t, L2Cache::LINE_SIZE> initial{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> dirty{};
+  std::array<uint8_t, 16> host_write{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> expected{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> actual{};
+  initial.fill(0x11);
+  dirty.fill(0x22);
+  host_write.fill(0x33);
+  expected = dirty;
+  std::memcpy(expected.data() + kOffset, host_write.data(), host_write.size());
+
+  memory.write_block(kAddr, std::span<const uint8_t>(initial));
+  l2.read(kAddr, actual.data(), actual.size());
+  ASSERT_EQ(actual, initial);
+  l2.writeback_line(kAddr, dirty.data());
+
+  memory.write_block(kAddr + kOffset, std::span<const uint8_t>(host_write));
+  l2.invalidate_range(kAddr + kOffset, host_write.size(), 0);
+
+  memory.read_block(kAddr, std::span<uint8_t>(actual));
+  EXPECT_EQ(actual, expected);
+  l2.read(kAddr, actual.data(), actual.size());
+  EXPECT_EQ(actual, expected);
+}
 
 TEST(GpuMemoryTest, BlockAccessHandlesPageBoundaries) {
   GpuMemory memory("memory");

--- a/emulation/rocjitsu/tests/l2_cache_test.cpp
+++ b/emulation/rocjitsu/tests/l2_cache_test.cpp
@@ -233,6 +233,59 @@ TEST(L2CacheThreadingTest, CrossL2AtomicRmwAliasedVasIsSerialized) {
   EXPECT_EQ(actual, kThreads * kIterations);
 }
 
+TEST(L2CacheTest, AliasedVasRequireCoherenceBoundary) {
+  GpuMemory memory("memory");
+  L2Cache l2("l2");
+  l2.set_backing_memory(&memory);
+
+  constexpr uint32_t kVmidA = 7;
+  constexpr uint32_t kVmidB = 8;
+  constexpr uint64_t kVaA = 0x100000;
+  constexpr uint64_t kVaB = 0x201000;
+
+  rocjitsu::KfdProcess process_a(kVmidA);
+  rocjitsu::KfdProcess process_b(kVmidB);
+  std::array<uint8_t, GpuMemory::PAGE_SIZE> backing{};
+  process_a.map_pages(kVaA, backing.data(), backing.size());
+  process_b.map_pages(kVaB, backing.data(), backing.size());
+  memory.register_process(kVmidA, &process_a.page_table_, &process_a.page_table_mutex_,
+                          process_a.page_table_generation());
+  memory.register_process(kVmidB, &process_b.page_table_, &process_b.page_table_mutex_,
+                          process_b.page_table_generation());
+
+  std::array<uint8_t, L2Cache::LINE_SIZE> initial{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> replacement{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> dirty{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> actual{};
+  initial.fill(0x11);
+  replacement.fill(0x22);
+  dirty.fill(0x33);
+
+  memory.write_block(kVaA, std::span<const uint8_t>(initial), kVmidA);
+  l2.read(kVaA, actual.data(), actual.size(), Mtype::RW, kVmidA);
+  ASSERT_EQ(actual, initial);
+  l2.read(kVaB, actual.data(), actual.size(), Mtype::RW, kVmidB);
+  ASSERT_EQ(actual, initial);
+
+  l2.write(kVaB, replacement.data(), replacement.size(), Mtype::RW, kVmidB);
+  l2.read(kVaA, actual.data(), actual.size(), Mtype::RW, kVmidA);
+  EXPECT_EQ(actual, initial);
+  l2.read(kVaA, actual.data(), actual.size(), Mtype::CC, kVmidA);
+  EXPECT_EQ(actual, replacement);
+
+  l2.writeback_line(kVaA, dirty.data(), Mtype::RW, kVmidA);
+  memory.read_block(kVaB, std::span<uint8_t>(actual), kVmidB);
+  EXPECT_EQ(actual, replacement);
+  l2.flush_line(kVaA, kVmidA);
+  memory.read_block(kVaB, std::span<uint8_t>(actual), kVmidB);
+  EXPECT_EQ(actual, dirty);
+
+  l2.read(kVaB, actual.data(), actual.size(), Mtype::RW, kVmidB);
+  EXPECT_EQ(actual, replacement);
+  l2.read(kVaB, actual.data(), actual.size(), Mtype::CC, kVmidB);
+  EXPECT_EQ(actual, dirty);
+}
+
 TEST(L2CacheThreadingTest, ConcurrentFlushAllPreservesDirtyWritebacks) {
   GpuMemory memory("memory");
   L2Cache l2("l2");

--- a/emulation/rocjitsu/tests/l2_cache_test.cpp
+++ b/emulation/rocjitsu/tests/l2_cache_test.cpp
@@ -12,6 +12,7 @@
 #include <barrier>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <span>
 #include <thread>
 #include <vector>
@@ -237,6 +238,31 @@ TEST(L2CacheThreadingTest, ConcurrentFlushAllPreservesDirtyWritebacks) {
       EXPECT_EQ(actual, expected) << "addr=0x" << std::hex << addr;
     }
   }
+}
+
+TEST(L2CacheTest, InvalidateRangeClampsAtAddressSpaceEnd) {
+  GpuMemory memory("memory");
+  L2Cache l2("l2");
+  l2.set_backing_memory(&memory);
+
+  constexpr uint64_t kLineAddr = std::numeric_limits<uint64_t>::max() - (L2Cache::LINE_SIZE - 1);
+  constexpr uint64_t kRangeAddr =
+      std::numeric_limits<uint64_t>::max() - (L2Cache::LINE_SIZE / 2 - 1);
+  std::array<uint8_t, L2Cache::LINE_SIZE> initial{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> replacement{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> actual{};
+  initial.fill(0x11);
+  replacement.fill(0x22);
+
+  memory.write_block(kLineAddr, std::span<const uint8_t>(initial));
+  l2.read(kLineAddr, actual.data(), actual.size());
+  ASSERT_EQ(actual, initial);
+
+  memory.write_block(kLineAddr, std::span<const uint8_t>(replacement));
+  l2.invalidate_range(kRangeAddr, L2Cache::LINE_SIZE);
+  l2.read(kLineAddr, actual.data(), actual.size());
+
+  EXPECT_EQ(actual, replacement);
 }
 
 

--- a/emulation/rocjitsu/tests/l2_cache_test.cpp
+++ b/emulation/rocjitsu/tests/l2_cache_test.cpp
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <barrier>
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using rocjitsu::amdgpu::GpuMemory;
+using rocjitsu::amdgpu::L2Cache;
+using rocjitsu::amdgpu::Mtype;
+
+TEST(L2CacheThreadingTest, ConcurrentDifferentSetWritesArePreserved) {
+  GpuMemory memory("memory");
+  L2Cache l2("l2");
+  l2.set_backing_memory(&memory);
+
+  constexpr uint32_t kThreads = 8;
+  constexpr uint32_t kLinesPerThread = 128;
+  constexpr uint64_t kBase = 0x100000;
+
+  std::barrier start(kThreads);
+  std::vector<std::thread> workers;
+  workers.reserve(kThreads);
+
+  for (uint32_t tid = 0; tid < kThreads; ++tid) {
+    workers.emplace_back([&, tid] {
+      std::array<uint8_t, L2Cache::LINE_SIZE> line{};
+      start.arrive_and_wait();
+      for (uint32_t i = 0; i < kLinesPerThread; ++i) {
+        const uint64_t addr =
+            kBase + (static_cast<uint64_t>(i) * kThreads + tid) * L2Cache::LINE_SIZE;
+        for (uint32_t b = 0; b < line.size(); ++b)
+          line[b] = static_cast<uint8_t>((tid << 4) ^ i ^ b);
+        l2.write(addr, line.data(), line.size());
+      }
+    });
+  }
+
+  for (auto &worker : workers)
+    worker.join();
+
+  std::array<uint8_t, L2Cache::LINE_SIZE> expected{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> actual{};
+  for (uint32_t tid = 0; tid < kThreads; ++tid) {
+    for (uint32_t i = 0; i < kLinesPerThread; ++i) {
+      const uint64_t addr =
+          kBase + (static_cast<uint64_t>(i) * kThreads + tid) * L2Cache::LINE_SIZE;
+      for (uint32_t b = 0; b < expected.size(); ++b)
+        expected[b] = static_cast<uint8_t>((tid << 4) ^ i ^ b);
+      l2.read(addr, actual.data(), actual.size());
+      EXPECT_EQ(actual, expected) << "addr=0x" << std::hex << addr;
+    }
+  }
+}
+
+TEST(L2CacheThreadingTest, ConcurrentAtomicRmwSameLineIsSerialized) {
+  GpuMemory memory("memory");
+  L2Cache l2("l2");
+  l2.set_backing_memory(&memory);
+
+  constexpr uint32_t kThreads = 8;
+  constexpr uint32_t kIterations = 1000;
+  constexpr uint64_t kTarget = 0x200000;
+
+  memory.write32(kTarget, 0);
+
+  std::barrier start(kThreads);
+  std::vector<std::thread> workers;
+  workers.reserve(kThreads);
+
+  for (uint32_t tid = 0; tid < kThreads; ++tid) {
+    workers.emplace_back([&] {
+      start.arrive_and_wait();
+      for (uint32_t i = 0; i < kIterations; ++i) {
+        l2.atomic_rmw(kTarget, sizeof(uint32_t), [](uint8_t *line, uint32_t offset) {
+          uint32_t value = 0;
+          std::memcpy(&value, line + offset, sizeof(value));
+          ++value;
+          std::memcpy(line + offset, &value, sizeof(value));
+        });
+      }
+    });
+  }
+
+  for (auto &worker : workers)
+    worker.join();
+
+  EXPECT_EQ(memory.read32(kTarget), kThreads * kIterations);
+}
+
+TEST(L2CacheThreadingTest, CrossL2AtomicRmwSameAddressIsSerialized) {
+  GpuMemory memory("memory");
+  L2Cache l2a("l2a");
+  L2Cache l2b("l2b");
+  l2a.set_backing_memory(&memory);
+  l2b.set_backing_memory(&memory);
+
+  constexpr uint32_t kThreads = 8;
+  constexpr uint32_t kIterations = 1000;
+  constexpr uint64_t kTarget = 0x280000;
+
+  memory.write32(kTarget, 0);
+
+  std::array<L2Cache *, 2> l2s = {&l2a, &l2b};
+  std::barrier start(kThreads);
+  std::vector<std::thread> workers;
+  workers.reserve(kThreads);
+
+  for (uint32_t tid = 0; tid < kThreads; ++tid) {
+    workers.emplace_back([&, tid] {
+      auto *l2 = l2s[tid % l2s.size()];
+      start.arrive_and_wait();
+      for (uint32_t i = 0; i < kIterations; ++i) {
+        l2->atomic_rmw(kTarget, sizeof(uint32_t), [](uint8_t *line, uint32_t offset) {
+          uint32_t value = 0;
+          std::memcpy(&value, line + offset, sizeof(value));
+          ++value;
+          std::memcpy(line + offset, &value, sizeof(value));
+        });
+      }
+    });
+  }
+
+  for (auto &worker : workers)
+    worker.join();
+
+  EXPECT_EQ(memory.read32(kTarget), kThreads * kIterations);
+}
+
+TEST(L2CacheThreadingTest, ConcurrentFlushAllPreservesDirtyWritebacks) {
+  GpuMemory memory("memory");
+  L2Cache l2("l2");
+  l2.set_backing_memory(&memory);
+
+  constexpr uint32_t kWriterThreads = 4;
+  constexpr uint32_t kLinesPerThread = 8;
+  constexpr uint32_t kIterations = 64;
+  constexpr uint64_t kBase = 0x300000;
+
+  std::atomic<uint32_t> active_writers{0};
+  std::barrier start(kWriterThreads + 1);
+  std::vector<std::thread> workers;
+  workers.reserve(kWriterThreads);
+
+  for (uint32_t tid = 0; tid < kWriterThreads; ++tid) {
+    workers.emplace_back([&, tid] {
+      std::array<uint8_t, L2Cache::LINE_SIZE> line{};
+      start.arrive_and_wait();
+      active_writers.fetch_add(1, std::memory_order_release);
+      for (uint32_t iteration = 0; iteration < kIterations; ++iteration) {
+        for (uint32_t i = 0; i < kLinesPerThread; ++i) {
+          const uint64_t addr =
+              kBase + (static_cast<uint64_t>(i) * kWriterThreads + tid) * L2Cache::LINE_SIZE;
+          for (uint32_t b = 0; b < line.size(); ++b)
+            line[b] = static_cast<uint8_t>((tid << 5) ^ iteration ^ i ^ b);
+          l2.writeback_line(addr, line.data());
+        }
+        std::this_thread::yield();
+      }
+    });
+  }
+
+  std::thread flusher([&] {
+    start.arrive_and_wait();
+    while (active_writers.load(std::memory_order_acquire) < kWriterThreads)
+      std::this_thread::yield();
+    for (uint32_t i = 0; i < 4; ++i) {
+      l2.flush_all();
+      std::this_thread::yield();
+    }
+  });
+
+  for (auto &worker : workers)
+    worker.join();
+  flusher.join();
+
+  l2.flush_all();
+
+  std::array<uint8_t, L2Cache::LINE_SIZE> expected{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> actual{};
+  for (uint32_t tid = 0; tid < kWriterThreads; ++tid) {
+    for (uint32_t i = 0; i < kLinesPerThread; ++i) {
+      const uint64_t addr =
+          kBase + (static_cast<uint64_t>(i) * kWriterThreads + tid) * L2Cache::LINE_SIZE;
+      for (uint32_t b = 0; b < expected.size(); ++b)
+        expected[b] = static_cast<uint8_t>((tid << 5) ^ (kIterations - 1) ^ i ^ b);
+      memory.read_block(addr, std::span<uint8_t>(actual));
+      EXPECT_EQ(actual, expected) << "addr=0x" << std::hex << addr;
+    }
+  }
+}
+
+
+TEST(GpuMemoryTest, BlockAccessHandlesPageBoundaries) {
+  GpuMemory memory("memory");
+
+  constexpr uint64_t kAddr = 0x3ff0;
+  std::array<uint8_t, 64> input{};
+  std::array<uint8_t, 64> output{};
+  for (uint32_t i = 0; i < input.size(); ++i)
+    input[i] = static_cast<uint8_t>(i * 3);
+
+  memory.write_block(kAddr, std::span<const uint8_t>(input));
+  memory.read_block(kAddr, std::span<uint8_t>(output));
+
+  EXPECT_EQ(output, input);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/l2_cache_test.cpp
+++ b/emulation/rocjitsu/tests/l2_cache_test.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l1_scalar_cache.h"
+#include "rocjitsu/vm/amdgpu/l1_vector_cache.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
 
 #include <gtest/gtest.h>
@@ -11,13 +13,16 @@
 #include <atomic>
 #include <barrier>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <limits>
 #include <linux/memfd.h>
+#include <memory>
 #include <span>
+#include <string>
 #include <string_view>
 #include <sys/mman.h>
 #include <sys/syscall.h>
@@ -25,19 +30,11 @@
 #include <unistd.h>
 #include <vector>
 
-namespace rocjitsu::amdgpu {
-
-class L2CacheTestAccess {
-public:
-  static std::mutex &device_atomic_mutex() { return L2Cache::device_atomic_mutex(); }
-  static std::mutex &set_mutex(L2Cache &l2, uint64_t addr) { return l2.set_mutex(addr); }
-};
-
-} // namespace rocjitsu::amdgpu
-
 namespace {
 
 using rocjitsu::amdgpu::GpuMemory;
+using rocjitsu::amdgpu::L1ScalarCache;
+using rocjitsu::amdgpu::L1VectorCache;
 using rocjitsu::amdgpu::L2Cache;
 using rocjitsu::amdgpu::Mtype;
 
@@ -111,6 +108,74 @@ void run_cross_l2_atomic_benchmark(std::string_view name, bool same_address) {
     EXPECT_EQ(observed_operations, kOperations);
   }
   report_benchmark(name, kOperations, end - begin);
+}
+
+void run_atomic_hierarchy_benchmark(std::string_view name, uint32_t hierarchy_count) {
+  GpuMemory memory("memory");
+  std::vector<std::unique_ptr<L2Cache>> l2s;
+  std::vector<std::unique_ptr<L1ScalarCache>> scalar_l1s;
+  std::vector<std::unique_ptr<L1VectorCache>> vector_l1s;
+  for (uint32_t i = 0; i < hierarchy_count; ++i) {
+    auto l2 = std::make_unique<L2Cache>("l2_" + std::to_string(i));
+    l2->set_backing_memory(&memory);
+    scalar_l1s.push_back(std::make_unique<L1ScalarCache>(l2.get()));
+    vector_l1s.push_back(std::make_unique<L1VectorCache>(l2.get()));
+    l2s.push_back(std::move(l2));
+  }
+
+  constexpr uint64_t kAddr = 0x880000;
+  constexpr uint32_t kIterations = 100'000;
+  memory.write32(kAddr, 0);
+  const auto begin = std::chrono::steady_clock::now();
+  for (uint32_t i = 0; i < kIterations; ++i)
+    l2s.front()->atomic_rmw(kAddr, sizeof(uint32_t), increment_u32);
+  const auto end = std::chrono::steady_clock::now();
+
+  EXPECT_EQ(memory.read32(kAddr), kIterations);
+  report_benchmark(name, kIterations, end - begin);
+}
+
+void run_scalar_l1_hit_benchmark() {
+  GpuMemory memory("memory");
+  L2Cache l2("l2");
+  l2.set_backing_memory(&memory);
+  L1ScalarCache l1(&l2);
+  constexpr uint64_t kAddr = 0x890000;
+  constexpr uint32_t kIterations = 1'000'000;
+  memory.write32(kAddr, 17);
+  uint32_t value = 0;
+  l1.load(kAddr, 1, &value);
+
+  const auto begin = std::chrono::steady_clock::now();
+  for (uint32_t i = 0; i < kIterations; ++i)
+    l1.load(kAddr, 1, &value);
+  const auto end = std::chrono::steady_clock::now();
+
+  EXPECT_EQ(value, 17u);
+  report_benchmark("scalar_l1_hit", kIterations, end - begin);
+}
+
+void run_vector_l1_hit_benchmark() {
+  GpuMemory memory("memory");
+  L2Cache l2("l2");
+  l2.set_backing_memory(&memory);
+  L1VectorCache l1(&l2);
+  constexpr uint64_t kAddr = 0x8A0000;
+  constexpr uint32_t kIterations = 500'000;
+  memory.write32(kAddr, 23);
+  const uint64_t addrs[1] = {kAddr};
+  std::array<uint8_t, sizeof(uint32_t)> value{};
+  l1.load(addrs, 1, sizeof(uint32_t), 1, value.data(), Mtype::RW, false, false, 1);
+
+  const auto begin = std::chrono::steady_clock::now();
+  for (uint32_t i = 0; i < kIterations; ++i)
+    l1.load(addrs, 1, sizeof(uint32_t), 1, value.data(), Mtype::RW, false, false, 1);
+  const auto end = std::chrono::steady_clock::now();
+
+  uint32_t observed = 0;
+  std::memcpy(&observed, value.data(), sizeof(observed));
+  EXPECT_EQ(observed, 23u);
+  report_benchmark("vector_l1_hit", kIterations, end - begin);
 }
 
 void run_invalidate_range_benchmark(std::string_view name, uint32_t lines, uint32_t iterations) {
@@ -194,6 +259,59 @@ public:
 private:
   void *address_;
   size_t size_;
+};
+
+class FunctionalMemoryPort : public simdojo::Component {
+public:
+  FunctionalMemoryPort(std::string name, uint64_t base, size_t size)
+      : simdojo::Component(std::move(name)), base_(base), bytes_(size) {
+    port_ = add_port(std::make_unique<simdojo::Port>("memory", 0, this, simdojo::PortDirection::IN,
+                                                     simdojo::PortProtocol::MEMORY));
+    port_->set_handler([this](simdojo::Tick, simdojo::Message *message) {
+      assert(message != nullptr);
+      const auto &header = message->header();
+      assert(header.addr >= base_);
+      const uint64_t offset = header.addr - base_;
+      assert(offset + header.size_bytes <= bytes_.size());
+      auto *payload = reinterpret_cast<uint8_t *>(message->payload());
+      assert(payload != nullptr);
+      if (header.op == simdojo::MessageOp::READ) {
+        std::memcpy(payload, bytes_.data() + offset, header.size_bytes);
+      } else {
+        assert(header.op == simdojo::MessageOp::WRITE);
+        std::memcpy(bytes_.data() + offset, payload, header.size_bytes);
+      }
+    });
+  }
+
+  simdojo::Port *port() { return port_; }
+
+  void write32(uint64_t addr, uint32_t value) {
+    assert(addr >= base_ && addr - base_ + sizeof(value) <= bytes_.size());
+    std::memcpy(bytes_.data() + (addr - base_), &value, sizeof(value));
+  }
+
+  uint32_t read32(uint64_t addr) const {
+    assert(addr >= base_ && addr - base_ + sizeof(uint32_t) <= bytes_.size());
+    uint32_t value = 0;
+    std::memcpy(&value, bytes_.data() + (addr - base_), sizeof(value));
+    return value;
+  }
+
+  uint8_t read8(uint64_t addr) const {
+    assert(addr >= base_ && addr - base_ < bytes_.size());
+    return bytes_[addr - base_];
+  }
+
+  void write8(uint64_t addr, uint8_t value) {
+    assert(addr >= base_ && addr - base_ < bytes_.size());
+    bytes_[addr - base_] = value;
+  }
+
+private:
+  uint64_t base_;
+  std::vector<uint8_t> bytes_;
+  simdojo::Port *port_ = nullptr;
 };
 
 TEST(L2CacheThreadingTest, ConcurrentDifferentSetWritesArePreserved) {
@@ -448,9 +566,6 @@ TEST(L2CacheThreadingTest, CrossL2AtomicRmwDistinctSharedMappingsIncludesDirtyWr
   std::memcpy(dirty_line.data() + kOffset, &kDirtyValue, sizeof(kDirtyValue));
   l2a.writeback_line(kVaA, dirty_line.data(), Mtype::RW, kVmidA);
 
-  std::barrier first_atomic_has_read(2);
-  std::barrier allow_first_atomic_to_write(2);
-  std::atomic<uint32_t> first_observed{0};
   auto increment = [](uint8_t *line, uint32_t offset) {
     uint32_t value = 0;
     std::memcpy(&value, line + offset, sizeof(value));
@@ -458,49 +573,19 @@ TEST(L2CacheThreadingTest, CrossL2AtomicRmwDistinctSharedMappingsIncludesDirtyWr
     std::memcpy(line + offset, &value, sizeof(value));
   };
 
-  auto &atomic_mutex = rocjitsu::amdgpu::L2CacheTestAccess::device_atomic_mutex();
-  std::unique_lock atomic_lock(atomic_mutex);
+  // Both virtual addresses resolve to the same MAP_SHARED bytes. The first
+  // atomic boundary to enter must publish l2a's dirty line before either RMW,
+  // and both RMWs must remain serialized across the distinct L2 objects.
+  std::barrier start(3);
   std::thread first_atomic([&] {
-    l2a.atomic_rmw(
-        kVaA + kOffset, sizeof(uint32_t),
-        [&](uint8_t *line, uint32_t offset) {
-          uint32_t value = 0;
-          std::memcpy(&value, line + offset, sizeof(value));
-          first_observed.store(value, std::memory_order_relaxed);
-          ++value;
-          first_atomic_has_read.arrive_and_wait();
-          allow_first_atomic_to_write.arrive_and_wait();
-          std::memcpy(line + offset, &value, sizeof(value));
-        },
-        kVmidA);
+    start.arrive_and_wait();
+    l2a.atomic_rmw(kVaA + kOffset, sizeof(uint32_t), increment, kVmidA);
   });
-
-  auto wait_until_locked = [](std::mutex &mutex) {
-    constexpr uint32_t kMaxAttempts = 1'000'000;
-    for (uint32_t attempt = 0; attempt < kMaxAttempts; ++attempt) {
-      if (!mutex.try_lock())
-        return true;
-      mutex.unlock();
-      std::this_thread::yield();
-    }
-    return false;
-  };
-
-  auto &first_set_mutex = rocjitsu::amdgpu::L2CacheTestAccess::set_mutex(l2a, kVaA + kOffset);
-  EXPECT_TRUE(wait_until_locked(first_set_mutex));
-  uint32_t backing_before_flush = 0;
-  std::memcpy(&backing_before_flush, mapping_a.data() + kOffset, sizeof(backing_before_flush));
-  EXPECT_EQ(backing_before_flush, 0u);
-
-  atomic_lock.unlock();
-  first_atomic_has_read.arrive_and_wait();
-  EXPECT_EQ(first_observed.load(std::memory_order_relaxed), kDirtyValue);
-
-  std::thread second_atomic(
-      [&] { l2b.atomic_rmw(kVaB + kOffset, sizeof(uint32_t), increment, kVmidB); });
-  auto &second_set_mutex = rocjitsu::amdgpu::L2CacheTestAccess::set_mutex(l2b, kVaB + kOffset);
-  EXPECT_TRUE(wait_until_locked(second_set_mutex));
-  allow_first_atomic_to_write.arrive_and_wait();
+  std::thread second_atomic([&] {
+    start.arrive_and_wait();
+    l2b.atomic_rmw(kVaB + kOffset, sizeof(uint32_t), increment, kVmidB);
+  });
+  start.arrive_and_wait();
 
   first_atomic.join();
   second_atomic.join();
@@ -508,6 +593,231 @@ TEST(L2CacheThreadingTest, CrossL2AtomicRmwDistinctSharedMappingsIncludesDirtyWr
   uint32_t actual = 0;
   std::memcpy(&actual, mapping_a.data() + kOffset, sizeof(actual));
   EXPECT_EQ(actual, 42u);
+}
+
+TEST(DeviceCacheCoherenceTest, ScalarWriteThroughSurvivesAliasedRemoteAtomic) {
+  constexpr size_t kMappingSize = GpuMemory::PAGE_SIZE;
+  const int raw_fd =
+      static_cast<int>(syscall(SYS_memfd_create, "scalar_atomic_alias", MFD_CLOEXEC));
+  ASSERT_GE(raw_fd, 0);
+  ScopedFd fd(raw_fd);
+  ASSERT_EQ(ftruncate(fd.get(), static_cast<off_t>(kMappingSize)), 0);
+
+  void *raw_scalar_mapping =
+      mmap(nullptr, kMappingSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd.get(), 0);
+  ASSERT_NE(raw_scalar_mapping, MAP_FAILED);
+  ScopedMapping scalar_mapping(raw_scalar_mapping, kMappingSize);
+  void *raw_atomic_mapping =
+      mmap(nullptr, kMappingSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd.get(), 0);
+  ASSERT_NE(raw_atomic_mapping, MAP_FAILED);
+  ScopedMapping atomic_mapping(raw_atomic_mapping, kMappingSize);
+  ASSERT_NE(scalar_mapping.data(), atomic_mapping.data());
+
+  constexpr uint32_t kScalarVmid = 21;
+  constexpr uint32_t kAtomicVmid = 22;
+  constexpr uint64_t kScalarVa = 0x510000;
+  constexpr uint64_t kAtomicVa = 0x620000;
+  constexpr uint64_t kLineOffset = L2Cache::LINE_SIZE;
+  constexpr uint64_t kAtomicAddr = kAtomicVa + kLineOffset;
+  constexpr uint64_t kScalarAddr = kScalarVa + kLineOffset + sizeof(uint32_t);
+  constexpr uint32_t kScalarValue = 0xA5A5A5A5;
+
+  rocjitsu::KfdProcess scalar_process(kScalarVmid);
+  rocjitsu::KfdProcess atomic_process(kAtomicVmid);
+  scalar_process.map_pages(kScalarVa, scalar_mapping.data(), kMappingSize, Mtype::RW);
+  atomic_process.map_pages(kAtomicVa, atomic_mapping.data(), kMappingSize, Mtype::RW);
+
+  GpuMemory memory("memory");
+  memory.register_process(kScalarVmid, &scalar_process.page_table_,
+                          &scalar_process.page_table_mutex_,
+                          scalar_process.page_table_generation());
+  memory.register_process(kAtomicVmid, &atomic_process.page_table_,
+                          &atomic_process.page_table_mutex_,
+                          atomic_process.page_table_generation());
+  L2Cache scalar_l2("scalar_l2");
+  L2Cache atomic_l2("atomic_l2");
+  rocjitsu::amdgpu::L1ScalarCache scalar_l1(&scalar_l2);
+  scalar_l2.set_backing_memory(&memory);
+  atomic_l2.set_backing_memory(&memory);
+
+  scalar_l1.store(kScalarAddr, /*num_dwords=*/1, &kScalarValue, kScalarVmid);
+  atomic_l2.atomic_rmw(kAtomicAddr, sizeof(uint32_t), increment_u32, kAtomicVmid);
+  scalar_l1.writeback_all(kScalarVmid);
+
+  uint32_t atomic_value = 0;
+  uint32_t scalar_value = 0;
+  std::memcpy(&atomic_value, scalar_mapping.data() + kLineOffset, sizeof(atomic_value));
+  std::memcpy(&scalar_value, scalar_mapping.data() + kLineOffset + sizeof(uint32_t),
+              sizeof(scalar_value));
+  EXPECT_EQ(atomic_value, 1u);
+  EXPECT_EQ(scalar_value, kScalarValue);
+}
+
+TEST(DeviceCacheCoherenceTest, DisjointDirtyL2AliasesSurviveRemoteAtomic) {
+  constexpr size_t kMappingSize = GpuMemory::PAGE_SIZE;
+  const int raw_fd =
+      static_cast<int>(syscall(SYS_memfd_create, "l2_dirty_atomic_alias", MFD_CLOEXEC));
+  ASSERT_GE(raw_fd, 0);
+  ScopedFd fd(raw_fd);
+  ASSERT_EQ(ftruncate(fd.get(), static_cast<off_t>(kMappingSize)), 0);
+
+  void *raw_mapping_a =
+      mmap(nullptr, kMappingSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd.get(), 0);
+  ASSERT_NE(raw_mapping_a, MAP_FAILED);
+  ScopedMapping mapping_a(raw_mapping_a, kMappingSize);
+  void *raw_mapping_b =
+      mmap(nullptr, kMappingSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd.get(), 0);
+  ASSERT_NE(raw_mapping_b, MAP_FAILED);
+  ScopedMapping mapping_b(raw_mapping_b, kMappingSize);
+  void *raw_mapping_atomic =
+      mmap(nullptr, kMappingSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd.get(), 0);
+  ASSERT_NE(raw_mapping_atomic, MAP_FAILED);
+  ScopedMapping mapping_atomic(raw_mapping_atomic, kMappingSize);
+  ASSERT_NE(mapping_a.data(), mapping_b.data());
+  ASSERT_NE(mapping_a.data(), mapping_atomic.data());
+  ASSERT_NE(mapping_b.data(), mapping_atomic.data());
+
+  constexpr uint32_t kVmidA = 31;
+  constexpr uint32_t kVmidB = 32;
+  constexpr uint32_t kAtomicVmid = 33;
+  constexpr uint64_t kVaA = 0x710000;
+  constexpr uint64_t kVaB = 0x820000;
+  constexpr uint64_t kAtomicVa = 0x930000;
+  constexpr uint64_t kLineOffset = L2Cache::LINE_SIZE;
+  constexpr uint32_t kValueA = 0x11112222;
+  constexpr uint32_t kValueB = 0x33334444;
+  constexpr uint32_t kOffsetA = sizeof(uint32_t);
+  constexpr uint32_t kOffsetB = 2 * sizeof(uint32_t);
+
+  rocjitsu::KfdProcess process_a(kVmidA);
+  rocjitsu::KfdProcess process_b(kVmidB);
+  rocjitsu::KfdProcess atomic_process(kAtomicVmid);
+  process_a.map_pages(kVaA, mapping_a.data(), kMappingSize, Mtype::RW);
+  process_b.map_pages(kVaB, mapping_b.data(), kMappingSize, Mtype::RW);
+  atomic_process.map_pages(kAtomicVa, mapping_atomic.data(), kMappingSize, Mtype::RW);
+
+  GpuMemory memory("memory");
+  memory.register_process(kVmidA, &process_a.page_table_, &process_a.page_table_mutex_,
+                          process_a.page_table_generation());
+  memory.register_process(kVmidB, &process_b.page_table_, &process_b.page_table_mutex_,
+                          process_b.page_table_generation());
+  memory.register_process(kAtomicVmid, &atomic_process.page_table_,
+                          &atomic_process.page_table_mutex_,
+                          atomic_process.page_table_generation());
+  L2Cache l2a("l2a");
+  L2Cache l2b("l2b");
+  L2Cache atomic_l2("atomic_l2");
+  l2a.set_backing_memory(&memory);
+  l2b.set_backing_memory(&memory);
+  atomic_l2.set_backing_memory(&memory);
+
+  std::array<uint8_t, L2Cache::LINE_SIZE> line_a{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> line_b{};
+  std::memcpy(line_a.data() + kOffsetA, &kValueA, sizeof(kValueA));
+  std::memcpy(line_b.data() + kOffsetB, &kValueB, sizeof(kValueB));
+  l2a.writeback_line(kVaA + kLineOffset, line_a.data(), kOffsetA, sizeof(kValueA), Mtype::RW,
+                     kVmidA);
+  l2b.writeback_line(kVaB + kLineOffset, line_b.data(), kOffsetB, sizeof(kValueB), Mtype::RW,
+                     kVmidB);
+
+  atomic_l2.atomic_rmw(kAtomicVa + kLineOffset, sizeof(uint32_t), increment_u32, kAtomicVmid);
+
+  uint32_t atomic_value = 0;
+  uint32_t value_a = 0;
+  uint32_t value_b = 0;
+  std::memcpy(&atomic_value, mapping_a.data() + kLineOffset, sizeof(atomic_value));
+  std::memcpy(&value_a, mapping_a.data() + kLineOffset + kOffsetA, sizeof(value_a));
+  std::memcpy(&value_b, mapping_a.data() + kLineOffset + kOffsetB, sizeof(value_b));
+  EXPECT_EQ(atomic_value, 1u);
+  EXPECT_EQ(value_a, kValueA);
+  EXPECT_EQ(value_b, kValueB);
+}
+
+TEST(DeviceCacheCoherenceTest, ConcurrentScalarLoadsTrackRepeatedAtomicEpochs) {
+  GpuMemory memory("memory");
+  L2Cache scalar_l2("scalar_l2");
+  L2Cache atomic_l2("atomic_l2");
+  rocjitsu::amdgpu::L1ScalarCache scalar_l1(&scalar_l2);
+  scalar_l2.set_backing_memory(&memory);
+  atomic_l2.set_backing_memory(&memory);
+
+  constexpr uint64_t kAddr = 0xA600;
+  constexpr uint32_t kAtomicIterations = 256;
+  constexpr uint32_t kLoadIterations = 2048;
+  memory.write32(kAddr, 0);
+  uint32_t initially_cached = 1;
+  scalar_l1.load(kAddr, /*num_dwords=*/1, &initially_cached);
+  ASSERT_EQ(initially_cached, 0u);
+
+  std::mutex start_mutex;
+  std::condition_variable start_cv;
+  bool atomic_ready = false;
+  bool scalar_ready = false;
+  std::atomic<bool> synchronization_failed{false};
+  std::atomic<bool> nonmonotonic_load{false};
+
+  auto wait_for_peer = [&](bool &self_ready, const bool &peer_ready) {
+    std::unique_lock lock(start_mutex);
+    self_ready = true;
+    start_cv.notify_all();
+    if (!start_cv.wait_for(lock, std::chrono::seconds(1), [&] { return peer_ready; }))
+      synchronization_failed.store(true, std::memory_order_relaxed);
+  };
+
+  std::thread atomic([&] {
+    wait_for_peer(atomic_ready, scalar_ready);
+    for (uint32_t iteration = 0; iteration < kAtomicIterations; ++iteration) {
+      atomic_l2.atomic_rmw(kAddr, sizeof(uint32_t), increment_u32);
+      std::this_thread::yield();
+    }
+  });
+  std::thread scalar([&] {
+    wait_for_peer(scalar_ready, atomic_ready);
+    uint32_t previous = 0;
+    for (uint32_t iteration = 0; iteration < kLoadIterations; ++iteration) {
+      uint32_t observed = 0;
+      scalar_l1.load(kAddr, /*num_dwords=*/1, &observed);
+      if (observed < previous || observed > kAtomicIterations)
+        nonmonotonic_load.store(true, std::memory_order_relaxed);
+      previous = observed;
+      std::this_thread::yield();
+    }
+  });
+  atomic.join();
+  scalar.join();
+
+  EXPECT_FALSE(synchronization_failed.load(std::memory_order_relaxed));
+  EXPECT_FALSE(nonmonotonic_load.load(std::memory_order_relaxed));
+  uint32_t final_value = 0;
+  scalar_l1.load(kAddr, /*num_dwords=*/1, &final_value);
+  EXPECT_EQ(final_value, kAtomicIterations);
+}
+
+TEST(L2CacheTest, FunctionalLinkedPortAtomicRmwUpdatesBacking) {
+  constexpr uint64_t kBase = 0xB00000;
+  constexpr uint64_t kAddr = kBase + 20;
+  L2Cache l2("l2");
+  FunctionalMemoryPort backing("backing", kBase, 2 * L2Cache::LINE_SIZE);
+  simdojo::Link link(/*id=*/0, l2.req_port(), backing.port(), /*latency=*/0);
+  link.set_exec_mode(simdojo::ExecMode::FUNCTIONAL);
+  l2.req_port()->set_link(&link);
+  backing.port()->set_link(&link);
+
+  backing.write8(kAddr - 1, 0xA5);
+  backing.write32(kAddr, 41);
+  backing.write8(kAddr + sizeof(uint32_t), 0x5A);
+  uint32_t callback_old_value = 0;
+  l2.atomic_rmw(kAddr, sizeof(uint32_t), [&](uint8_t *target, uint32_t offset) {
+    EXPECT_EQ(offset, 0u);
+    std::memcpy(&callback_old_value, target, sizeof(callback_old_value));
+    const uint32_t replacement = callback_old_value + 1;
+    std::memcpy(target, &replacement, sizeof(replacement));
+  });
+
+  EXPECT_EQ(callback_old_value, 41u);
+  EXPECT_EQ(backing.read32(kAddr), 42u);
+  EXPECT_EQ(backing.read8(kAddr - 1), 0xA5);
+  EXPECT_EQ(backing.read8(kAddr + sizeof(uint32_t)), 0x5A);
 }
 
 TEST(L2CacheTest, AliasedVasRequireCoherenceBoundary) {
@@ -803,6 +1113,26 @@ TEST(L2CacheBenchmark, CrossL2SameAddress) {
 TEST(L2CacheBenchmark, CrossL2IndependentAddresses) {
   run_cross_l2_atomic_benchmark("cross_l2_independent_addresses", false);
 }
+
+TEST(L2CacheBenchmark, AtomicOneHierarchy) {
+  run_atomic_hierarchy_benchmark("atomic_hierarchies_1", 1);
+}
+
+TEST(L2CacheBenchmark, AtomicTwoHierarchies) {
+  run_atomic_hierarchy_benchmark("atomic_hierarchies_2", 2);
+}
+
+TEST(L2CacheBenchmark, AtomicFourHierarchies) {
+  run_atomic_hierarchy_benchmark("atomic_hierarchies_4", 4);
+}
+
+TEST(L2CacheBenchmark, AtomicEightHierarchies) {
+  run_atomic_hierarchy_benchmark("atomic_hierarchies_8", 8);
+}
+
+TEST(L2CacheBenchmark, ScalarL1Hit) { run_scalar_l1_hit_benchmark(); }
+
+TEST(L2CacheBenchmark, VectorL1Hit) { run_vector_l1_hit_benchmark(); }
 
 TEST(L2CacheBenchmark, InvalidateThreeLines) {
   run_invalidate_range_benchmark("invalidate_3_lines", 3, 200'000);

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -77,6 +77,7 @@
 #include <algorithm>
 #include <array>
 #include <bit>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <memory>
@@ -1268,6 +1269,216 @@ TEST(L1ScalarCacheTest, UcAndCcFlushDoNotClobberAtomicAtDisjointAddress) {
     EXPECT_EQ(mem.read32(kVa + sizeof(uint32_t), kVmid), kScalarValue);
     mem.unregister_process(kVmid);
   }
+}
+
+TEST(DeviceCacheCoherenceTest, ScalarWriteThroughCannotClobberRemoteAtomic) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache scalar_l2("scalar_l2");
+  amdgpu::L2Cache atomic_l2("atomic_l2");
+  amdgpu::L1ScalarCache scalar_l1(&scalar_l2);
+  scalar_l2.set_backing_memory(&mem);
+  atomic_l2.set_backing_memory(&mem);
+
+  constexpr uint64_t kLine = 0xA000;
+  constexpr uint64_t kAtomicAddr = kLine;
+  constexpr uint64_t kScalarAddr = kLine + sizeof(uint32_t);
+  constexpr uint32_t kScalarValue = 0xA5A5A5A5;
+  mem.write32(kAtomicAddr, 0);
+  mem.write32(kScalarAddr, 0);
+
+  // The scalar store read-allocates the atomic dword's old value into the same
+  // K$ line. The store must update only its target bytes, and the atomic must
+  // invalidate the stale clean snapshot.
+  scalar_l1.store(kScalarAddr, /*num_dwords=*/1, &kScalarValue);
+  atomic_l2.atomic_rmw(kAtomicAddr, sizeof(uint32_t), [](uint8_t *line, uint32_t offset) {
+    uint32_t value = 0;
+    std::memcpy(&value, line + offset, sizeof(value));
+    ++value;
+    std::memcpy(line + offset, &value, sizeof(value));
+  });
+  scalar_l1.writeback_all();
+
+  EXPECT_EQ(mem.read32(kAtomicAddr), 1u);
+  EXPECT_EQ(mem.read32(kScalarAddr), kScalarValue);
+}
+
+TEST(DeviceCacheCoherenceTest, DisjointScalarWriteThroughStoresSurviveRemoteAtomic) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache first_scalar_l2("first_scalar_l2");
+  amdgpu::L2Cache second_scalar_l2("second_scalar_l2");
+  amdgpu::L2Cache atomic_l2("atomic_l2");
+  amdgpu::L1ScalarCache first_scalar_l1(&first_scalar_l2);
+  amdgpu::L1ScalarCache second_scalar_l1(&second_scalar_l2);
+  first_scalar_l2.set_backing_memory(&mem);
+  second_scalar_l2.set_backing_memory(&mem);
+  atomic_l2.set_backing_memory(&mem);
+
+  constexpr uint64_t kLine = 0xA080;
+  constexpr uint64_t kAtomicAddr = kLine;
+  constexpr uint64_t kFirstScalarAddr = kLine + sizeof(uint32_t);
+  constexpr uint64_t kSecondScalarAddr = kLine + 2 * sizeof(uint32_t);
+  constexpr uint32_t kFirstScalarValue = 0x11112222;
+  constexpr uint32_t kSecondScalarValue = 0x33334444;
+  mem.write32(kAtomicAddr, 0);
+  mem.write32(kFirstScalarAddr, 0);
+  mem.write32(kSecondScalarAddr, 0);
+
+  // Both K$ instances fill the same old line. Their disjoint write-through
+  // stores must merge without either cached snapshot replacing the other.
+  first_scalar_l1.store(kFirstScalarAddr, /*num_dwords=*/1, &kFirstScalarValue);
+  second_scalar_l1.store(kSecondScalarAddr, /*num_dwords=*/1, &kSecondScalarValue);
+  atomic_l2.atomic_rmw(kAtomicAddr, sizeof(uint32_t), [](uint8_t *line, uint32_t offset) {
+    uint32_t value = 0;
+    std::memcpy(&value, line + offset, sizeof(value));
+    ++value;
+    std::memcpy(line + offset, &value, sizeof(value));
+  });
+  first_scalar_l1.writeback_all();
+  second_scalar_l1.writeback_all();
+
+  EXPECT_EQ(mem.read32(kAtomicAddr), 1u);
+  EXPECT_EQ(mem.read32(kFirstScalarAddr), kFirstScalarValue);
+  EXPECT_EQ(mem.read32(kSecondScalarAddr), kSecondScalarValue);
+}
+
+TEST(DeviceCacheCoherenceTest, RemoteAtomicInvalidatesScalarCachedRead) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache scalar_l2("scalar_l2");
+  amdgpu::L2Cache atomic_l2("atomic_l2");
+  amdgpu::L1ScalarCache scalar_l1(&scalar_l2);
+  scalar_l2.set_backing_memory(&mem);
+  atomic_l2.set_backing_memory(&mem);
+
+  constexpr uint64_t kAddr = 0xA100;
+  mem.write32(kAddr, 10);
+  uint32_t value = 0;
+  scalar_l1.load(kAddr, /*num_dwords=*/1, &value);
+  ASSERT_EQ(value, 10u);
+
+  atomic_l2.atomic_rmw(kAddr, sizeof(uint32_t), [](uint8_t *line, uint32_t offset) {
+    uint32_t current = 0;
+    std::memcpy(&current, line + offset, sizeof(current));
+    ++current;
+    std::memcpy(line + offset, &current, sizeof(current));
+  });
+
+  value = 0;
+  scalar_l1.load(kAddr, /*num_dwords=*/1, &value);
+  EXPECT_EQ(value, 11u);
+}
+
+TEST(DeviceCacheCoherenceTest, RemoteAtomicInvalidatesVectorCachedRead) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache vector_l2("vector_l2");
+  amdgpu::L2Cache atomic_l2("atomic_l2");
+  amdgpu::L1VectorCache vector_l1(&vector_l2);
+  vector_l2.set_backing_memory(&mem);
+  atomic_l2.set_backing_memory(&mem);
+
+  constexpr uint64_t kAddr = 0xA200;
+  mem.write32(kAddr, 10);
+  uint64_t addrs[cdna3::Isa::WF_SIZE] = {};
+  addrs[0] = kAddr;
+  std::array<uint8_t, cdna3::Isa::WF_SIZE * sizeof(uint32_t)> bytes{};
+  auto load_value = [&] {
+    bytes.fill(0);
+    vector_l1.load(addrs, /*lane_mask=*/1, /*elem_size=*/sizeof(uint32_t),
+                   /*num_elems=*/1, bytes.data(), amdgpu::Mtype::RW,
+                   /*non_temporal=*/false, /*request_l1_bypass=*/false, cdna3::Isa::WF_SIZE);
+    uint32_t value = 0;
+    std::memcpy(&value, bytes.data(), sizeof(value));
+    return value;
+  };
+  ASSERT_EQ(load_value(), 10u);
+
+  atomic_l2.atomic_rmw(kAddr, sizeof(uint32_t), [](uint8_t *line, uint32_t offset) {
+    uint32_t current = 0;
+    std::memcpy(&current, line + offset, sizeof(current));
+    ++current;
+    std::memcpy(line + offset, &current, sizeof(current));
+  });
+
+  EXPECT_EQ(load_value(), 11u);
+}
+
+TEST(DeviceCacheCoherenceTest, AtomicConsumesScalarWriteThroughTarget) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache scalar_l2("scalar_l2");
+  amdgpu::L2Cache atomic_l2("atomic_l2");
+  amdgpu::L1ScalarCache scalar_l1(&scalar_l2);
+  scalar_l2.set_backing_memory(&mem);
+  atomic_l2.set_backing_memory(&mem);
+
+  constexpr uint64_t kAddr = 0xA300;
+  constexpr uint32_t kStoredValue = 40;
+  mem.write32(kAddr, 0);
+  scalar_l1.store(kAddr, /*num_dwords=*/1, &kStoredValue);
+
+  atomic_l2.atomic_rmw(kAddr, sizeof(uint32_t), [](uint8_t *line, uint32_t offset) {
+    uint32_t current = 0;
+    std::memcpy(&current, line + offset, sizeof(current));
+    ++current;
+    std::memcpy(line + offset, &current, sizeof(current));
+  });
+
+  EXPECT_EQ(mem.read32(kAddr), 41u);
+  uint32_t reloaded = 0;
+  scalar_l1.load(kAddr, /*num_dwords=*/1, &reloaded);
+  EXPECT_EQ(reloaded, 41u);
+}
+
+TEST(DeviceCacheCoherenceTest, DestroyedCachesAreRemovedFromRegistry) {
+  amdgpu::GpuMemory mem("test_mem");
+  constexpr uint64_t kAddr = 0xA400;
+
+  struct alignas(amdgpu::L2Cache) L2Storage {
+    std::byte data[sizeof(amdgpu::L2Cache)];
+  };
+  struct alignas(amdgpu::L1ScalarCache) ScalarStorage {
+    std::byte data[sizeof(amdgpu::L1ScalarCache)];
+  };
+  struct alignas(amdgpu::L1VectorCache) VectorStorage {
+    std::byte data[sizeof(amdgpu::L1VectorCache)];
+  };
+
+  auto l2_storage = std::make_unique<L2Storage>();
+  auto scalar_storage = std::make_unique<ScalarStorage>();
+  auto vector_storage = std::make_unique<VectorStorage>();
+  auto *transient_l2 =
+      std::construct_at(reinterpret_cast<amdgpu::L2Cache *>(l2_storage->data), "transient_l2");
+  auto *transient_scalar = std::construct_at(
+      reinterpret_cast<amdgpu::L1ScalarCache *>(scalar_storage->data), transient_l2);
+  auto *transient_vector = std::construct_at(
+      reinterpret_cast<amdgpu::L1VectorCache *>(vector_storage->data), transient_l2);
+  transient_l2->set_backing_memory(&mem);
+
+  constexpr uint32_t kDirty = 7;
+  transient_scalar->store(kAddr + sizeof(uint32_t), /*num_dwords=*/1, &kDirty);
+  uint64_t addrs[cdna3::Isa::WF_SIZE] = {};
+  addrs[0] = kAddr;
+  std::array<uint8_t, cdna3::Isa::WF_SIZE * sizeof(uint32_t)> bytes{};
+  transient_vector->load(addrs, /*lane_mask=*/1, /*elem_size=*/sizeof(uint32_t),
+                         /*num_elems=*/1, bytes.data(), amdgpu::Mtype::RW,
+                         /*non_temporal=*/false, /*request_l1_bypass=*/false, cdna3::Isa::WF_SIZE);
+
+  std::destroy_at(transient_vector);
+  std::destroy_at(transient_scalar);
+  std::destroy_at(transient_l2);
+  std::memset(vector_storage->data, 0xA5, sizeof(vector_storage->data));
+  std::memset(scalar_storage->data, 0xA5, sizeof(scalar_storage->data));
+  std::memset(l2_storage->data, 0xA5, sizeof(l2_storage->data));
+
+  amdgpu::L2Cache survivor("survivor");
+  EXPECT_NE(static_cast<const void *>(&survivor), static_cast<const void *>(transient_l2));
+  survivor.set_backing_memory(&mem);
+  mem.write32(kAddr, 0);
+  survivor.atomic_rmw(kAddr, sizeof(uint32_t), [](uint8_t *line, uint32_t offset) {
+    uint32_t value = 0;
+    std::memcpy(&value, line + offset, sizeof(value));
+    ++value;
+    std::memcpy(line + offset, &value, sizeof(value));
+  });
+  EXPECT_EQ(mem.read32(kAddr), 1u);
 }
 
 TEST(L1VectorCacheTest, UcReadInvalidatesResidentLine) {

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -812,7 +812,7 @@ TEST(L2CacheTest, UcWriteCrossingLineBoundaryFlushesBothDirtyResidentLines) {
       << "dirty byte outside the second-line UC store should be preserved";
 }
 
-TEST(L1ScalarCacheTest, UcReadFlushesDirtyResidentLine) {
+TEST(L1ScalarCacheTest, UcReadInvalidatesResidentWriteThroughLine) {
   amdgpu::GpuMemory mem("test_mem");
   amdgpu::L2Cache l2("test_l2");
   amdgpu::L1ScalarCache l1(&l2);
@@ -822,7 +822,7 @@ TEST(L1ScalarCacheTest, UcReadFlushesDirtyResidentLine) {
   constexpr uint32_t kVmid = 1;
   constexpr uint64_t kAddr = 0x5000;
   constexpr uint32_t kBackingValue = 0x11111111;
-  constexpr uint32_t kDirtyValue = 0x22222222;
+  constexpr uint32_t kStoredValue = 0x22222222;
   constexpr uint32_t kReloadValue = 0x33333333;
 
   std::array<uint8_t, KfdProcess::kPageSize> backing{};
@@ -832,7 +832,7 @@ TEST(L1ScalarCacheTest, UcReadFlushesDirtyResidentLine) {
   mem.register_process(kVmid, &page_table, &page_table_mutex);
 
   mem.write32(kAddr, kBackingValue, kVmid);
-  l1.store(kAddr, /*num_dwords=*/1, &kDirtyValue, kVmid);
+  l1.store(kAddr, /*num_dwords=*/1, &kStoredValue, kVmid);
 
   {
     std::unique_lock lock(page_table_mutex);
@@ -841,8 +841,8 @@ TEST(L1ScalarCacheTest, UcReadFlushesDirtyResidentLine) {
   uint32_t read_value = 0;
   l1.load(kAddr, /*num_dwords=*/1, &read_value, kVmid);
 
-  EXPECT_EQ(read_value, kDirtyValue);
-  EXPECT_EQ(mem.read32(kAddr, kVmid), kDirtyValue);
+  EXPECT_EQ(read_value, kStoredValue);
+  EXPECT_EQ(mem.read32(kAddr, kVmid), kStoredValue);
 
   l2.write(kAddr, reinterpret_cast<const uint8_t *>(&kReloadValue), sizeof(kReloadValue),
            amdgpu::Mtype::RW, kVmid);
@@ -856,7 +856,7 @@ TEST(L1ScalarCacheTest, UcReadFlushesDirtyResidentLine) {
   EXPECT_EQ(read_value, kReloadValue);
 }
 
-TEST(L1ScalarCacheTest, UcLoadBytesFlushesDirtyResidentLine) {
+TEST(L1ScalarCacheTest, UcLoadBytesInvalidatesResidentWriteThroughLine) {
   amdgpu::GpuMemory mem("test_mem");
   amdgpu::L2Cache l2("test_l2");
   amdgpu::L1ScalarCache l1(&l2);
@@ -866,7 +866,7 @@ TEST(L1ScalarCacheTest, UcLoadBytesFlushesDirtyResidentLine) {
   constexpr uint32_t kVmid = 4;
   constexpr uint64_t kAddr = 0x5400;
   constexpr uint32_t kBackingValue = 0x11111111;
-  constexpr uint32_t kDirtyValue = 0x44332211;
+  constexpr uint32_t kStoredValue = 0x44332211;
   constexpr uint32_t kReloadValue = 0x88776655;
 
   std::array<uint8_t, KfdProcess::kPageSize> backing{};
@@ -876,7 +876,7 @@ TEST(L1ScalarCacheTest, UcLoadBytesFlushesDirtyResidentLine) {
   mem.register_process(kVmid, &page_table, &page_table_mutex);
 
   mem.write32(kAddr, kBackingValue, kVmid);
-  l1.store(kAddr, /*num_dwords=*/1, &kDirtyValue, kVmid);
+  l1.store(kAddr, /*num_dwords=*/1, &kStoredValue, kVmid);
 
   {
     std::unique_lock lock(page_table_mutex);
@@ -888,7 +888,7 @@ TEST(L1ScalarCacheTest, UcLoadBytesFlushesDirtyResidentLine) {
 
   EXPECT_EQ(read_bytes[0], 0x22);
   EXPECT_EQ(read_bytes[1], 0x33);
-  EXPECT_EQ(mem.read32(kAddr, kVmid), kDirtyValue);
+  EXPECT_EQ(mem.read32(kAddr, kVmid), kStoredValue);
 
   l2.write(kAddr, reinterpret_cast<const uint8_t *>(&kReloadValue), sizeof(kReloadValue),
            amdgpu::Mtype::RW, kVmid);
@@ -903,7 +903,7 @@ TEST(L1ScalarCacheTest, UcLoadBytesFlushesDirtyResidentLine) {
   EXPECT_EQ(read_bytes[1], 0x77);
 }
 
-TEST(L1ScalarCacheTest, CcReadFlushesDirtyResidentLine) {
+TEST(L1ScalarCacheTest, CcReadInvalidatesResidentWriteThroughLine) {
   amdgpu::GpuMemory mem("test_mem");
   amdgpu::L2Cache l2("test_l2");
   amdgpu::L1ScalarCache l1(&l2);
@@ -913,7 +913,7 @@ TEST(L1ScalarCacheTest, CcReadFlushesDirtyResidentLine) {
   constexpr uint32_t kVmid = 5;
   constexpr uint64_t kAddr = 0x5800;
   constexpr uint32_t kBackingValue = 0x11111111;
-  constexpr uint32_t kDirtyValue = 0x22222222;
+  constexpr uint32_t kStoredValue = 0x22222222;
   constexpr uint32_t kReloadValue = 0x33333333;
 
   std::array<uint8_t, KfdProcess::kPageSize> backing{};
@@ -923,7 +923,7 @@ TEST(L1ScalarCacheTest, CcReadFlushesDirtyResidentLine) {
   mem.register_process(kVmid, &page_table, &page_table_mutex);
 
   mem.write32(kAddr, kBackingValue, kVmid);
-  l1.store(kAddr, /*num_dwords=*/1, &kDirtyValue, kVmid);
+  l1.store(kAddr, /*num_dwords=*/1, &kStoredValue, kVmid);
 
   {
     std::unique_lock lock(page_table_mutex);
@@ -932,8 +932,8 @@ TEST(L1ScalarCacheTest, CcReadFlushesDirtyResidentLine) {
   uint32_t read_value = 0;
   l1.load(kAddr, /*num_dwords=*/1, &read_value, kVmid);
 
-  EXPECT_EQ(read_value, kDirtyValue);
-  EXPECT_EQ(mem.read32(kAddr, kVmid), kDirtyValue);
+  EXPECT_EQ(read_value, kStoredValue);
+  EXPECT_EQ(mem.read32(kAddr, kVmid), kStoredValue);
 
   l2.write(kAddr, reinterpret_cast<const uint8_t *>(&kReloadValue), sizeof(kReloadValue),
            amdgpu::Mtype::RW, kVmid);
@@ -947,7 +947,7 @@ TEST(L1ScalarCacheTest, CcReadFlushesDirtyResidentLine) {
   EXPECT_EQ(read_value, kReloadValue);
 }
 
-TEST(L1ScalarCacheTest, CcLoadBytesFlushesDirtyResidentLine) {
+TEST(L1ScalarCacheTest, CcLoadBytesInvalidatesResidentWriteThroughLine) {
   amdgpu::GpuMemory mem("test_mem");
   amdgpu::L2Cache l2("test_l2");
   amdgpu::L1ScalarCache l1(&l2);
@@ -957,7 +957,7 @@ TEST(L1ScalarCacheTest, CcLoadBytesFlushesDirtyResidentLine) {
   constexpr uint32_t kVmid = 6;
   constexpr uint64_t kAddr = 0x5C00;
   constexpr uint32_t kBackingValue = 0x11111111;
-  constexpr uint32_t kDirtyValue = 0x44332211;
+  constexpr uint32_t kStoredValue = 0x44332211;
   constexpr uint32_t kReloadValue = 0x88776655;
 
   std::array<uint8_t, KfdProcess::kPageSize> backing{};
@@ -967,7 +967,7 @@ TEST(L1ScalarCacheTest, CcLoadBytesFlushesDirtyResidentLine) {
   mem.register_process(kVmid, &page_table, &page_table_mutex);
 
   mem.write32(kAddr, kBackingValue, kVmid);
-  l1.store(kAddr, /*num_dwords=*/1, &kDirtyValue, kVmid);
+  l1.store(kAddr, /*num_dwords=*/1, &kStoredValue, kVmid);
 
   {
     std::unique_lock lock(page_table_mutex);
@@ -979,7 +979,7 @@ TEST(L1ScalarCacheTest, CcLoadBytesFlushesDirtyResidentLine) {
 
   EXPECT_EQ(read_bytes[0], 0x22);
   EXPECT_EQ(read_bytes[1], 0x33);
-  EXPECT_EQ(mem.read32(kAddr, kVmid), kDirtyValue);
+  EXPECT_EQ(mem.read32(kAddr, kVmid), kStoredValue);
 
   l2.write(kAddr, reinterpret_cast<const uint8_t *>(&kReloadValue), sizeof(kReloadValue),
            amdgpu::Mtype::RW, kVmid);
@@ -994,7 +994,7 @@ TEST(L1ScalarCacheTest, CcLoadBytesFlushesDirtyResidentLine) {
   EXPECT_EQ(read_bytes[1], 0x77);
 }
 
-TEST(L1ScalarCacheTest, UcWriteFlushesDirtyResidentLineBeforeBypassStore) {
+TEST(L1ScalarCacheTest, UcWriteInvalidatesResidentLineBeforeBypassStore) {
   amdgpu::GpuMemory mem("test_mem");
   amdgpu::L2Cache l2("test_l2");
   amdgpu::L1ScalarCache l1(&l2);
@@ -1004,8 +1004,8 @@ TEST(L1ScalarCacheTest, UcWriteFlushesDirtyResidentLineBeforeBypassStore) {
   constexpr uint32_t kVmid = 2;
   constexpr uint64_t kBase = 0x6000;
   constexpr uint64_t kStoreAddr = kBase + 4;
-  constexpr uint32_t kDirtyOutsideValue = 0x11111111;
-  constexpr uint32_t kDirtyTargetValue = 0x22222222;
+  constexpr uint32_t kStoredOutsideValue = 0x11111111;
+  constexpr uint32_t kStoredTargetValue = 0x22222222;
   constexpr uint32_t kUcStoreValue = 0x33333333;
 
   std::array<uint8_t, KfdProcess::kPageSize> backing{};
@@ -1014,8 +1014,8 @@ TEST(L1ScalarCacheTest, UcWriteFlushesDirtyResidentLineBeforeBypassStore) {
   page_table[kBase >> KfdProcess::kPageShift] = {backing.data(), amdgpu::Mtype::RW};
   mem.register_process(kVmid, &page_table, &page_table_mutex);
 
-  const uint32_t dirty_values[] = {kDirtyOutsideValue, kDirtyTargetValue};
-  l1.store(kBase, /*num_dwords=*/2, dirty_values, kVmid);
+  const uint32_t stored_values[] = {kStoredOutsideValue, kStoredTargetValue};
+  l1.store(kBase, /*num_dwords=*/2, stored_values, kVmid);
 
   {
     std::unique_lock lock(page_table_mutex);
@@ -1024,11 +1024,11 @@ TEST(L1ScalarCacheTest, UcWriteFlushesDirtyResidentLineBeforeBypassStore) {
   l1.store(kStoreAddr, /*num_dwords=*/1, &kUcStoreValue, kVmid);
   l1.writeback_all(kVmid);
 
-  EXPECT_EQ(mem.read32(kBase, kVmid), kDirtyOutsideValue);
+  EXPECT_EQ(mem.read32(kBase, kVmid), kStoredOutsideValue);
   EXPECT_EQ(mem.read32(kStoreAddr, kVmid), kUcStoreValue);
 }
 
-TEST(L1ScalarCacheTest, CcWriteFlushesDirtyResidentLineBeforeBypassStore) {
+TEST(L1ScalarCacheTest, CcWriteInvalidatesResidentLineBeforeBypassStore) {
   amdgpu::GpuMemory mem("test_mem");
   amdgpu::L2Cache l2("test_l2");
   amdgpu::L1ScalarCache l1(&l2);
@@ -1040,8 +1040,8 @@ TEST(L1ScalarCacheTest, CcWriteFlushesDirtyResidentLineBeforeBypassStore) {
   constexpr uint64_t kStoreAddr = kBase + 4;
   constexpr uint32_t kBackingOutsideValue = 0x01010101;
   constexpr uint32_t kBackingTargetValue = 0x02020202;
-  constexpr uint32_t kDirtyOutsideValue = 0x11111111;
-  constexpr uint32_t kDirtyTargetValue = 0x22222222;
+  constexpr uint32_t kStoredOutsideValue = 0x11111111;
+  constexpr uint32_t kStoredTargetValue = 0x22222222;
   constexpr uint32_t kCcStoreValue = 0x33333333;
 
   std::array<uint8_t, KfdProcess::kPageSize> backing{};
@@ -1052,8 +1052,8 @@ TEST(L1ScalarCacheTest, CcWriteFlushesDirtyResidentLineBeforeBypassStore) {
 
   mem.write32(kBase, kBackingOutsideValue, kVmid);
   mem.write32(kStoreAddr, kBackingTargetValue, kVmid);
-  const uint32_t dirty_values[] = {kDirtyOutsideValue, kDirtyTargetValue};
-  l1.store(kBase, /*num_dwords=*/2, dirty_values, kVmid);
+  const uint32_t stored_values[] = {kStoredOutsideValue, kStoredTargetValue};
+  l1.store(kBase, /*num_dwords=*/2, stored_values, kVmid);
 
   {
     std::unique_lock lock(page_table_mutex);
@@ -1061,11 +1061,11 @@ TEST(L1ScalarCacheTest, CcWriteFlushesDirtyResidentLineBeforeBypassStore) {
   }
   l1.store(kStoreAddr, /*num_dwords=*/1, &kCcStoreValue, kVmid);
 
-  EXPECT_EQ(mem.read32(kBase, kVmid), kDirtyOutsideValue);
+  EXPECT_EQ(mem.read32(kBase, kVmid), kStoredOutsideValue);
   EXPECT_EQ(mem.read32(kStoreAddr, kVmid), kCcStoreValue);
 }
 
-TEST(L1ScalarCacheTest, DirtyEvictionAndWritebackAllReachBacking) {
+TEST(L1ScalarCacheTest, WriteThroughStoresAndCleanEvictionReachBacking) {
   amdgpu::GpuMemory mem("test_mem");
   amdgpu::L2Cache l2("test_l2");
   amdgpu::L1ScalarCache l1(&l2);
@@ -1084,15 +1084,190 @@ TEST(L1ScalarCacheTest, DirtyEvictionAndWritebackAllReachBacking) {
     values[i] = 0x11110000u + i;
   }
 
-  for (uint32_t i = 0; i < 4; ++i)
+  for (uint32_t i = 0; i < 4; ++i) {
     l1.store(addrs[i], /*num_dwords=*/1, &values[i]);
+    EXPECT_EQ(mem.read32(addrs[i]), values[i]) << "line " << i;
+  }
 
   l1.store(addrs[4], /*num_dwords=*/1, &values[4]);
-  EXPECT_EQ(mem.read32(addrs[0]), values[0]);
+  EXPECT_EQ(mem.read32(addrs[4]), values[4]);
 
   l1.writeback_all();
-  for (uint32_t i = 1; i < addrs.size(); ++i)
+  for (uint32_t i = 0; i < addrs.size(); ++i)
     EXPECT_EQ(mem.read32(addrs[i]), values[i]) << "line " << i;
+}
+
+TEST(L1ScalarCacheTest, CacheableStoresWriteThroughBeforeWriteback) {
+  constexpr uint32_t kVmid = 9;
+  constexpr uint64_t kAddr = 0x6800;
+
+  for (const auto mtype : {amdgpu::Mtype::RW, amdgpu::Mtype::WB, amdgpu::Mtype::NT}) {
+    SCOPED_TRACE(static_cast<int>(mtype));
+    amdgpu::GpuMemory mem("test_mem");
+    amdgpu::L2Cache l2("test_l2");
+    amdgpu::L1ScalarCache l1(&l2);
+    l2.set_backing_memory(&mem);
+    l1.set_memory(&mem);
+
+    std::array<uint8_t, KfdProcess::kPageSize> backing{};
+    KfdProcess::PageTable page_table;
+    std::shared_mutex page_table_mutex;
+    page_table[kAddr >> KfdProcess::kPageShift] = {backing.data(), mtype};
+    mem.register_process(kVmid, &page_table, &page_table_mutex);
+
+    const uint32_t value = 0xCAFE0000u + static_cast<uint32_t>(mtype);
+    l1.store(kAddr, /*num_dwords=*/1, &value, kVmid);
+    EXPECT_EQ(mem.read32(kAddr, kVmid), value);
+
+    l1.writeback_all(kVmid);
+    EXPECT_EQ(mem.read32(kAddr, kVmid), value);
+    mem.unregister_process(kVmid);
+  }
+}
+
+TEST(L1ScalarCacheTest, UnalignedStoreCrossingLineWritesThroughExactBytes) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache l2("test_l2");
+  amdgpu::L1ScalarCache l1(&l2);
+  l2.set_backing_memory(&mem);
+  l1.set_memory(&mem);
+
+  constexpr uint32_t kVmid = 10;
+  constexpr uint64_t kPageBase = 0x7000;
+  constexpr uint64_t kAddr = kPageBase + (uint64_t{1} << amdgpu::L1ScalarCache::LINE_SIZE_BITS) - 2;
+  constexpr uint32_t kValue = 0x44332211;
+
+  std::array<uint8_t, KfdProcess::kPageSize> backing{};
+  backing.fill(0xA5);
+  KfdProcess::PageTable page_table;
+  std::shared_mutex page_table_mutex;
+  page_table[kPageBase >> KfdProcess::kPageShift] = {backing.data(), amdgpu::Mtype::RW};
+  mem.register_process(kVmid, &page_table, &page_table_mutex);
+
+  l1.store(kAddr, /*num_dwords=*/1, &kValue, kVmid);
+
+  std::array<uint8_t, sizeof(kValue)> expected{};
+  std::memcpy(expected.data(), &kValue, sizeof(kValue));
+  const size_t backing_offset = kAddr - kPageBase;
+  EXPECT_EQ(backing[backing_offset - 1], 0xA5);
+  for (size_t i = 0; i < expected.size(); ++i)
+    EXPECT_EQ(backing[backing_offset + i], expected[i]) << "byte " << i;
+  EXPECT_EQ(backing[backing_offset + expected.size()], 0xA5);
+
+  l1.writeback_all(kVmid);
+  for (size_t i = 0; i < expected.size(); ++i)
+    EXPECT_EQ(backing[backing_offset + i], expected[i]) << "byte after writeback " << i;
+  mem.unregister_process(kVmid);
+}
+
+TEST(L1ScalarCacheTest, ScalarWritebackDoesNotClobberAtomicAtDisjointAddress) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache l2a("l2a");
+  amdgpu::L2Cache l2b("l2b");
+  l2a.set_backing_memory(&mem);
+  l2b.set_backing_memory(&mem);
+  amdgpu::L1ScalarCache l1(&l2a);
+  l1.set_memory(&mem);
+
+  constexpr uint32_t kVmid = 17;
+  constexpr uint64_t kVa = 0x500000;
+  constexpr uint32_t kScalarValue = 0x5A5A5A5A;
+  std::array<uint8_t, KfdProcess::kPageSize> backing{};
+  KfdProcess::PageTable page_table;
+  std::shared_mutex page_table_mutex;
+  page_table[kVa >> KfdProcess::kPageShift] = {backing.data(), amdgpu::Mtype::RW};
+  mem.register_process(kVmid, &page_table, &page_table_mutex);
+
+  l1.store(kVa + sizeof(uint32_t), /*num_dwords=*/1, &kScalarValue, kVmid);
+  l2b.atomic_rmw(
+      kVa, sizeof(uint32_t),
+      [](uint8_t *storage, uint32_t offset) {
+        uint32_t value = 0;
+        std::memcpy(&value, storage + offset, sizeof(value));
+        ++value;
+        std::memcpy(storage + offset, &value, sizeof(value));
+      },
+      kVmid);
+
+  l1.writeback_all(kVmid);
+  EXPECT_EQ(mem.read32(kVa, kVmid), 1u);
+  EXPECT_EQ(mem.read32(kVa + sizeof(uint32_t), kVmid), kScalarValue);
+  mem.unregister_process(kVmid);
+}
+
+TEST(L1ScalarCacheTest, CleanEvictionDoesNotClobberAtomicAtDisjointAddress) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache l2a("l2a");
+  amdgpu::L2Cache l2b("l2b");
+  l2a.set_backing_memory(&mem);
+  l2b.set_backing_memory(&mem);
+  amdgpu::L1ScalarCache l1(&l2a);
+
+  constexpr uint64_t kBase = 0x600000;
+  constexpr uint64_t kSetStride = uint64_t{1}
+                                  << (amdgpu::L1ScalarCache::LINE_SIZE_BITS +
+                                      std::bit_width(amdgpu::L1ScalarCache::NUM_SETS - 1));
+  constexpr uint32_t kScalarValue = 0x6B6B6B6B;
+  l1.store(kBase + sizeof(uint32_t), /*num_dwords=*/1, &kScalarValue);
+  l2b.atomic_rmw(kBase, sizeof(uint32_t), [](uint8_t *storage, uint32_t offset) {
+    uint32_t value = 0;
+    std::memcpy(&value, storage + offset, sizeof(value));
+    ++value;
+    std::memcpy(storage + offset, &value, sizeof(value));
+  });
+
+  for (uint32_t i = 1; i <= amdgpu::L1ScalarCache::ASSOCIATIVITY; ++i) {
+    uint32_t ignored = 0;
+    l1.load(kBase + i * kSetStride, /*num_dwords=*/1, &ignored);
+  }
+
+  EXPECT_EQ(mem.read32(kBase), 1u);
+  EXPECT_EQ(mem.read32(kBase + sizeof(uint32_t)), kScalarValue);
+}
+
+TEST(L1ScalarCacheTest, UcAndCcFlushDoNotClobberAtomicAtDisjointAddress) {
+  constexpr uint32_t kVmid = 18;
+  constexpr uint64_t kVa = 0x700000;
+  constexpr uint32_t kScalarValue = 0x7C7C7C7C;
+
+  for (const auto mtype : {amdgpu::Mtype::UC, amdgpu::Mtype::CC}) {
+    SCOPED_TRACE(static_cast<int>(mtype));
+    amdgpu::GpuMemory mem("test_mem");
+    amdgpu::L2Cache l2a("l2a");
+    amdgpu::L2Cache l2b("l2b");
+    l2a.set_backing_memory(&mem);
+    l2b.set_backing_memory(&mem);
+    amdgpu::L1ScalarCache l1(&l2a);
+    l1.set_memory(&mem);
+
+    std::array<uint8_t, KfdProcess::kPageSize> backing{};
+    KfdProcess::PageTable page_table;
+    std::shared_mutex page_table_mutex;
+    page_table[kVa >> KfdProcess::kPageShift] = {backing.data(), amdgpu::Mtype::RW};
+    mem.register_process(kVmid, &page_table, &page_table_mutex);
+
+    l1.store(kVa + sizeof(uint32_t), /*num_dwords=*/1, &kScalarValue, kVmid);
+    l2b.atomic_rmw(
+        kVa, sizeof(uint32_t),
+        [](uint8_t *storage, uint32_t offset) {
+          uint32_t value = 0;
+          std::memcpy(&value, storage + offset, sizeof(value));
+          ++value;
+          std::memcpy(storage + offset, &value, sizeof(value));
+        },
+        kVmid);
+
+    {
+      std::unique_lock lock(page_table_mutex);
+      page_table[kVa >> KfdProcess::kPageShift].mtype = mtype;
+    }
+    uint32_t ignored = 0;
+    l1.load(kVa + 2 * sizeof(uint32_t), /*num_dwords=*/1, &ignored, kVmid);
+
+    EXPECT_EQ(mem.read32(kVa, kVmid), 1u);
+    EXPECT_EQ(mem.read32(kVa + sizeof(uint32_t), kVmid), kScalarValue);
+    mem.unregister_process(kVmid);
+  }
 }
 
 TEST(L1VectorCacheTest, UcReadInvalidatesResidentLine) {


### PR DESCRIPTION
# fix(rocjitsu): make shared GPU state concurrency-safe

ISSUE ID: #6447

> [!IMPORTANT]
> This is **PR 2 of 6** in the parallel CPU simulation stack.
> It depends on the concurrent Simdojo primitives in
> `users/lialan/rocjitsu_parallel_cpu_01_simdojo`.
>
> Review only
> `users/lialan/rocjitsu_parallel_cpu_01_simdojo...users/lialan/rocjitsu_parallel_cpu_02_gpu_state`
> for this layer.

## Stack

| # | Layer | Branch | PR |
|---|---|---|---|
| 1 | Concurrent Simdojo memory primitives | `users/lialan/rocjitsu_parallel_cpu_01_simdojo` | #8702 |
| **2** | **Shared Rocjitsu GPU-state concurrency** | `users/lialan/rocjitsu_parallel_cpu_02_gpu_state` | **this PR** |
| 3 | XCD execution partitioning | `users/lialan/rocjitsu_parallel_cpu_03_xcd` | #8705 |
| 4 | Compositional plugin threading policy | `users/lialan/rocjitsu_parallel_cpu_04_plugins` | #8706 |
| 5 | Functional CU dispatch pool | `users/lialan/rocjitsu_threadpool_cpu` | #6962 |
| 6 | Functional-mode performance work | `users/lialan/rocjitsu_parallel_cpu_06_perf` | #8965 |

## Summary

Make GPU state shared by concurrent execution paths safe to access.

- Track KFD page-table generations and invalidate stale translations.
- Make `GpuMemory` translation and memory-type caches concurrency-safe.
- Synchronize shared L2 state across concurrent CPU execution.
- Add GPU-memory and cache concurrency regressions.

## Why

The XCD and CU-dispatch layers above this one execute against shared GPU state.
Their correctness depends on cache, memory, and address-translation state being
safe before any worker policy is enabled.

## Validation

- Built normal and TSan `rocjitsu_tests`.
- Passed focused `GpuMemory`, `GpuMemoryThreading`, `SparseMemory`,
  `SparseMemoryThreading`, `L2Cache`, and `L2CacheThreading` tests.
- Passed the full memory-threading TSan gate: 11 tests.
- Passed the full non-benchmark `rocjitsu_tests` suite: 1,473 passed with one
  pre-existing skip.
- Passed the layer-range pre-commit sweep.
