### PR TITLE
feat(rocjitsu): partition execution across XCDs

### DIFF
--- a/emulation/mirage/rocjitsu_sys/src/lib.rs
+++ b/emulation/mirage/rocjitsu_sys/src/lib.rs
@@ -622,8 +622,10 @@ mod tests {
 
     #[test]
     fn status_codes_match_c_api() {
-        const C_STATUS_HEADER: &str =
-            include_str!("../../../rocjitsu/lib/rocjitsu/include/rocjitsu/base/rj_status.h");
+        const C_STATUS_HEADER: &str = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../rocjitsu/lib/rocjitsu/include/rocjitsu/base/rj_status.h"
+        ));
         let c_statuses: Vec<String> = C_STATUS_HEADER
             .lines()
             .map(str::trim)

--- a/emulation/mirage/rocjitsu_sys/src/lib.rs
+++ b/emulation/mirage/rocjitsu_sys/src/lib.rs
@@ -40,6 +40,8 @@ pub const ROCJITSU_STATUS_OUT_OF_RESOURCES: RjStatus = 3;
 pub const ROCJITSU_STATUS_INVALID_CODE_OBJECT: RjStatus = 4;
 /// A required file could not be opened or read.
 pub const ROCJITSU_STATUS_INVALID_FILE: RjStatus = 5;
+/// The requested operation is not supported by this configuration.
+pub const ROCJITSU_STATUS_UNSUPPORTED: RjStatus = 6;
 
 /// Platform-specific handle type (`rj_handle_t`); an fd on Linux.
 pub type RjHandle = c_int;
@@ -616,6 +618,29 @@ mod tests {
         assert_eq!(RjDaemonStatus::Stopped as i32, 0);
         assert_eq!(RjDaemonStatus::Running as i32, 2);
         assert_eq!(RjDaemonStatus::Error as i32, 4);
+    }
+
+    #[test]
+    fn status_codes_match_c_api() {
+        const C_STATUS_HEADER: &str =
+            include_str!("../../../rocjitsu/lib/rocjitsu/include/rocjitsu/base/rj_status.h");
+        let c_statuses: Vec<String> = C_STATUS_HEADER
+            .lines()
+            .map(str::trim)
+            .filter(|line| line.starts_with("ROCJITSU_STATUS_"))
+            .map(|line| line.trim_end_matches(',').to_owned())
+            .collect();
+        let rust_statuses = vec![
+            format!("ROCJITSU_STATUS_SUCCESS = {ROCJITSU_STATUS_SUCCESS}"),
+            format!("ROCJITSU_STATUS_ERROR = {ROCJITSU_STATUS_ERROR}"),
+            format!("ROCJITSU_STATUS_INVALID_ARGUMENT = {ROCJITSU_STATUS_INVALID_ARGUMENT}"),
+            format!("ROCJITSU_STATUS_OUT_OF_RESOURCES = {ROCJITSU_STATUS_OUT_OF_RESOURCES}"),
+            format!("ROCJITSU_STATUS_INVALID_CODE_OBJECT = {ROCJITSU_STATUS_INVALID_CODE_OBJECT}"),
+            format!("ROCJITSU_STATUS_INVALID_FILE = {ROCJITSU_STATUS_INVALID_FILE}"),
+            format!("ROCJITSU_STATUS_UNSUPPORTED = {ROCJITSU_STATUS_UNSUPPORTED}"),
+        ];
+
+        assert_eq!(c_statuses, rust_statuses);
     }
 
     #[test]

--- a/emulation/rocjitsu/docs/configuration.md
+++ b/emulation/rocjitsu/docs/configuration.md
@@ -55,9 +55,18 @@ The example above is intentionally minimal and single-threaded.
 | Field | Type | Description |
 |---|---|---|
 | `max_ticks` | int | Maximum simulation ticks (0 = unlimited) |
-| `num_threads` | int | Number of PDES engine partitions/worker threads. |
+| `num_threads` | int | Simdojo engine partitions (one per XCD when partitioned) |
 | `exec_mode` | string | `"functional"` or `"cycle"` |
 | `vm.arch` | string | Architecture: `cdna3`, `cdna4`, etc. |
+
+### Simulation threading
+
+`num_threads` controls Simdojo engine partitions and their worker threads.
+The value is clamped to the number of XCDs visible to the VM. With
+`num_threads: 1`, all XCDs stay in one engine partition. With
+`num_threads: 4` on the 8-XCD CDNA4 configs, whole XCD subtrees are assigned
+round-robin to four partitions; with `num_threads: 8`, each XCD gets its own
+partition. A single XCD is never split across partitions.
 
 ### Topology
 

--- a/emulation/rocjitsu/docs/configuration.md
+++ b/emulation/rocjitsu/docs/configuration.md
@@ -68,6 +68,12 @@ The value is clamped to the number of XCDs visible to the VM. With
 round-robin to four partitions; with `num_threads: 8`, each XCD gets its own
 partition. A single XCD is never split across partitions.
 
+For multi-GPU VMs, clamping uses the aggregate XCD count across all SoCs.
+Partition assignment follows one global XCD ordering across the SoCs and is
+deliberately locality-agnostic. For example, two 8-XCD GPUs permit up to 16
+partitions, while `num_threads: 4` assigns XCDs from both GPUs to each
+partition.
+
 ### Topology
 
 Components are defined hierarchically under `topology.root`. Range

--- a/emulation/rocjitsu/docs/simdojo.md
+++ b/emulation/rocjitsu/docs/simdojo.md
@@ -285,6 +285,7 @@ engine.topology().set_root(std::move(root));
 engine.topology().add_link(pipe_req_port, mem_req_port, /*latency=*/10);
 engine.topology().add_link(mem_resp_port, pipe_resp_port, /*latency=*/5);
 
+engine.topology().partition_balanced(4);
 engine.create();
 auto exit = engine.run();
 ```
@@ -515,16 +516,18 @@ empty but primaries are registered, returns true so the caller can poll.
 SimulationEngine engine({.max_ticks = 10000, .num_threads = 4});
 engine.topology().set_root(std::move(my_model));
 engine.topology().add_link(src_port, dst_port, latency);
-engine.create();       // partitions, initializes components
+engine.topology().partition_balanced(4);
+engine.create();       // validates partitions, initializes components
 // (user enqueues work via CP)
 auto exit = engine.run();   // starts up components, runs to completion
 engine.shutdown();    // called automatically by destructor if needed
 ```
 
-`create()` partitions the topology and calls `initialize()` on all
-components. `run()` calls `startup()` on all components and enters the
-event loop. `shutdown()` is called automatically by the destructor if the
-engine is still built.
+For multi-threaded engines, callers select a partition policy before
+`create()`. `create()` validates the selected partitions and calls
+`initialize()` on all components. `run()` calls `startup()` on all components
+and enters the event loop. `shutdown()` is called automatically by the
+destructor if the engine is still built.
 
 ## References
 

--- a/emulation/rocjitsu/docs/simdojo.md
+++ b/emulation/rocjitsu/docs/simdojo.md
@@ -262,9 +262,12 @@ its own incoming queues at the start of each barrier epoch (Phase 1).
 
 ## Topology and Partitioning
 
-The `Topology` owns the entire simulation graph: the root composite, all
-links, clock domains, and partition assignments. It serves as the single
-entry point for building and wiring a model.
+The `Topology` owns the component tree reachable from the root composite,
+all links, clock domains, and partition assignments. Link-endpoint owners
+outside the root tree are borrowed. Those external components and their ports
+must remain alive through every repartition and engine create, run, and
+shutdown operation that retains them. It serves as the single entry point for
+building and wiring a model.
 
 ### Building a Model
 

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/base/rj_status.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/base/rj_status.h
@@ -27,7 +27,9 @@ typedef enum rj_status_e {
   /// @brief The supplied code object is malformed or unsupported.
   ROCJITSU_STATUS_INVALID_CODE_OBJECT = 4,
   /// @brief A required file could not be opened or read.
-  ROCJITSU_STATUS_INVALID_FILE = 5
+  ROCJITSU_STATUS_INVALID_FILE = 5,
+  /// @brief The requested operation is not supported by this configuration.
+  ROCJITSU_STATUS_UNSUPPORTED = 6
 } rj_status_t;
 
 /// @}

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/vm/rj_vm.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/vm/rj_vm.h
@@ -206,11 +206,15 @@ RJ_API_EXPORT void rj_vm_destroy(rj_vm_t *vm);
 /// @brief Step the entire VM by one tick.
 ///
 /// @details Processes all simulation events at the next timestamp, advancing the
-/// simulation by one tick.
+/// simulation by one tick. Stepping is supported only for single-partition VMs;
+/// use rj_vm_run() when the configuration has multiple engine partitions.
 /// @param[in] vm VM handle.
-/// @param[out] active Non-zero if any wavefront is still executing.
+/// @param[out] active Non-zero if any wavefront is still executing. Written only
+/// on success.
 /// @retval ROCJITSU_STATUS_SUCCESS Step completed successfully.
 /// @retval ROCJITSU_STATUS_INVALID_ARGUMENT @p vm is NULL.
+/// @retval ROCJITSU_STATUS_ERROR The VM has no SoC.
+/// @retval ROCJITSU_STATUS_UNSUPPORTED The VM has multiple engine partitions.
 RJ_API_EXPORT rj_status_t rj_vm_step(rj_vm_t *vm, int *active);
 
 /// @brief Run the VM to completion or until max_ticks is reached.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.h
@@ -48,12 +48,18 @@ struct TopologyBuildResult {
 ///
 /// Contains the engine configuration and the built component tree. Provides
 /// convenience accessors for the SoC and GPU memory. After loading, wire
-/// the topology into a SimulationEngine:
+/// the topology into a SimulationEngine. Multi-threaded rocjitsu topologies
+/// use the XCD-aware policy from rocjitsu/vm/amdgpu/partitioning.h:
 /// @code
 ///   auto loaded = load_config("config.json", kEmbeddedSchema);
-///   SimulationEngine engine(loaded.engine_config);
+///   auto *soc = loaded.soc();
+///   simdojo::SimulationEngine engine(loaded.engine_config);
 ///   engine.topology().set_root(loaded.take_root());
 ///   loaded.wire_links(engine.topology());
+///   if (loaded.engine_config.num_threads > 1 &&
+///       !amdgpu::partition_topology_by_xcds(
+///           engine.topology(), soc, loaded.engine_config.num_threads))
+///     throw std::invalid_argument("multi-threaded topology requires an XCD");
 ///   engine.create();
 /// @endcode
 struct LoadedConfig {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.h
@@ -51,13 +51,18 @@ struct TopologyBuildResult {
 /// the topology into a SimulationEngine. Multi-threaded rocjitsu topologies
 /// use the XCD-aware policy from rocjitsu/vm/amdgpu/partitioning.h:
 /// @code
+///   #include "rocjitsu/vm/amdgpu/partitioning.h"
+///
 ///   auto loaded = load_config("config.json", kEmbeddedSchema);
 ///   auto *soc = loaded.soc();
+///   loaded.engine_config.num_threads =
+///       rocjitsu::amdgpu::clamp_xcd_partition_count(
+///           soc, loaded.engine_config.num_threads);
 ///   simdojo::SimulationEngine engine(loaded.engine_config);
 ///   engine.topology().set_root(loaded.take_root());
 ///   loaded.wire_links(engine.topology());
 ///   if (loaded.engine_config.num_threads > 1 &&
-///       !amdgpu::partition_topology_by_xcds(
+///       !rocjitsu::amdgpu::partition_topology_by_xcds(
 ///           engine.topology(), soc, loaded.engine_config.num_threads))
 ///     throw std::invalid_argument("multi-threaded topology requires an XCD");
 ///   engine.create();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/CMakeLists.txt
@@ -5,6 +5,7 @@ rj_add_object_library(rocjitsu_vm
     soc.cpp
     virtual_machine.cpp
     rj_vm.cpp
+    amdgpu/partitioning.cpp
 )
 
 # rj_vm.cpp uses config and checkpoint APIs which depend on FlatBuffers.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -475,10 +475,9 @@ void CommandProcessor::startup() {
   // thread). on_cu_idle() dispatches inline and calls ComputeUnitCore::schedule_work()
   // on those CUs, which mutates their non-atomic executing_/tick_event_ and pushes to
   // the partition event queue without synchronization — safe only same-partition. The
-  // recursive-bisection partitioner (topology.partition(), run in the engine's
-  // create() before startup) could in principle split a CP from a CU under
-  // num_threads > 1; assert here (after partitioning, before the run loop) so any such
-  // split fails loudly rather than silently racing.
+  // generic balanced partitioner could in principle split a CP from a CU under
+  // num_threads > 1; assert here (after partitioning, before the run loop) so any
+  // such split fails loudly rather than silently racing.
   for ([[maybe_unused]] const auto *cu : cus_)
     assert(cu->partition_id() == partition_id() &&
            "CommandProcessor and its compute units must share one partition");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.cpp
@@ -4,6 +4,7 @@
 #include "rocjitsu/vm/amdgpu/partitioning.h"
 
 #include <array>
+#include <cassert>
 #include <unordered_map>
 
 namespace rocjitsu {
@@ -29,11 +30,15 @@ bool partition_topology_by_xcds(simdojo::Topology &topology, std::span<SoC *> so
     return false;
 
   topology.partition_manual(num_partitions, [&](simdojo::Component *component) {
-    for (auto *candidate = component; candidate != nullptr;
-         candidate = static_cast<simdojo::Component *>(candidate->parent())) {
+    for (auto *candidate = component; candidate != nullptr;) {
       auto it = xcd_partitions.find(candidate);
       if (it != xcd_partitions.end())
         return it->second;
+
+      auto *parent = candidate->parent();
+      candidate = dynamic_cast<simdojo::Component *>(parent);
+      assert((parent == nullptr || candidate != nullptr) &&
+             "component parents must also be components");
     }
     return simdojo::PartitionID{0};
   });

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/amdgpu/partitioning.h"
+
+#include <array>
+#include <unordered_map>
+
+namespace rocjitsu {
+namespace amdgpu {
+
+bool partition_topology_by_xcds(simdojo::Topology &topology, std::span<SoC *> socs,
+                                uint32_t num_partitions) {
+  if (num_partitions == 0)
+    return false;
+
+  std::unordered_map<simdojo::Component *, simdojo::PartitionID> xcd_partitions;
+  uint32_t global_xcd_index = 0;
+  for (auto *soc : socs) {
+    if (!soc)
+      continue;
+    for (uint32_t xcd_index = 0; xcd_index < soc->num_xcds(); ++xcd_index) {
+      xcd_partitions[soc->xcd(xcd_index)] = global_xcd_index % num_partitions;
+      ++global_xcd_index;
+    }
+  }
+
+  if (xcd_partitions.empty())
+    return false;
+
+  topology.partition_manual(num_partitions, [&](simdojo::Component *component) {
+    for (auto *candidate = component; candidate != nullptr;
+         candidate = static_cast<simdojo::Component *>(candidate->parent())) {
+      auto it = xcd_partitions.find(candidate);
+      if (it != xcd_partitions.end())
+        return it->second;
+    }
+    return simdojo::PartitionID{0};
+  });
+  return true;
+}
+
+bool partition_topology_by_xcds(simdojo::Topology &topology, SoC *soc, uint32_t num_partitions) {
+  std::array<SoC *, 1> socs = {soc};
+  return partition_topology_by_xcds(topology, std::span<SoC *>(socs), num_partitions);
+}
+
+} // namespace amdgpu
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.cpp
@@ -13,7 +13,7 @@ namespace amdgpu {
 
 uint32_t clamp_xcd_partition_count(std::span<SoC *> socs, uint32_t requested_partitions) {
   uint32_t num_xcds = 0;
-  for (auto *soc : socs) {
+  for (SoC *soc : socs) {
     if (soc)
       num_xcds += soc->num_xcds();
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.cpp
@@ -3,12 +3,28 @@
 
 #include "rocjitsu/vm/amdgpu/partitioning.h"
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <unordered_map>
 
 namespace rocjitsu {
 namespace amdgpu {
+
+uint32_t clamp_xcd_partition_count(std::span<SoC *> socs, uint32_t requested_partitions) {
+  uint32_t num_xcds = 0;
+  for (auto *soc : socs) {
+    if (soc)
+      num_xcds += soc->num_xcds();
+  }
+
+  return std::clamp(requested_partitions, 1u, std::max(num_xcds, 1u));
+}
+
+uint32_t clamp_xcd_partition_count(SoC *soc, uint32_t requested_partitions) {
+  std::array<SoC *, 1> socs = {soc};
+  return clamp_xcd_partition_count(std::span<SoC *>(socs), requested_partitions);
+}
 
 bool partition_topology_by_xcds(simdojo::Topology &topology, std::span<SoC *> socs,
                                 uint32_t num_partitions) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.cpp
@@ -7,6 +7,8 @@
 #include <array>
 #include <cassert>
 #include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -31,13 +33,19 @@ bool partition_topology_by_xcds(simdojo::Topology &topology, std::span<SoC *> so
   if (num_partitions == 0)
     return false;
 
+  const std::vector<simdojo::Component *> components = topology.collect_all_components();
+  const std::unordered_set<simdojo::Component *> topology_components(components.begin(),
+                                                                     components.end());
   std::unordered_map<simdojo::Component *, simdojo::PartitionID> xcd_partitions;
   uint32_t global_xcd_index = 0;
-  for (auto *soc : socs) {
+  for (SoC *soc : socs) {
     if (!soc)
       continue;
     for (uint32_t xcd_index = 0; xcd_index < soc->num_xcds(); ++xcd_index) {
-      xcd_partitions[soc->xcd(xcd_index)] = global_xcd_index % num_partitions;
+      simdojo::Component *xcd = soc->xcd(xcd_index);
+      if (!topology_components.contains(xcd))
+        return false;
+      xcd_partitions[xcd] = global_xcd_index % num_partitions;
       ++global_xcd_index;
     }
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.h
@@ -35,7 +35,8 @@ namespace amdgpu {
 /// assigned to global_xcd_index % num_partitions. Components outside XCD
 /// subtrees stay in partition 0.
 /// @returns true when a manual partition was installed; false when
-/// @p num_partitions is zero or no XCDs are present.
+/// @p num_partitions is zero, no XCDs are present, or any supplied XCD is not
+/// a member of @p topology. Failure leaves existing partition state unchanged.
 [[nodiscard]] bool partition_topology_by_xcds(simdojo::Topology &topology, std::span<SoC *> socs,
                                               uint32_t num_partitions);
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file partitioning.h
+/// @brief Deterministic AMDGPU simulator topology partitioning helpers.
+
+#ifndef ROCJITSU_VM_AMDGPU_PARTITIONING_H_
+#define ROCJITSU_VM_AMDGPU_PARTITIONING_H_
+
+#include "rocjitsu/vm/soc.h"
+
+#include "simdojo/sim/topology.h"
+
+#include <cstdint>
+#include <span>
+
+namespace rocjitsu {
+namespace amdgpu {
+
+/// @brief Partition an AMDGPU topology by whole XCD subtrees.
+///
+/// @details If @p num_partitions is nonzero and at least one XCD is present,
+/// this installs a manual topology partition where each XCD subtree is
+/// assigned to global_xcd_index % num_partitions. Components outside XCD
+/// subtrees stay in partition 0.
+/// @returns true when a manual partition was installed; false when
+/// @p num_partitions is zero or no XCDs are present.
+bool partition_topology_by_xcds(simdojo::Topology &topology, std::span<SoC *> socs,
+                                uint32_t num_partitions);
+
+/// @brief Convenience overload for a single SoC.
+bool partition_topology_by_xcds(simdojo::Topology &topology, SoC *soc, uint32_t num_partitions);
+
+} // namespace amdgpu
+} // namespace rocjitsu
+
+#endif // ROCJITSU_VM_AMDGPU_PARTITIONING_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.h
@@ -25,11 +25,12 @@ namespace amdgpu {
 /// subtrees stay in partition 0.
 /// @returns true when a manual partition was installed; false when
 /// @p num_partitions is zero or no XCDs are present.
-bool partition_topology_by_xcds(simdojo::Topology &topology, std::span<SoC *> socs,
-                                uint32_t num_partitions);
+[[nodiscard]] bool partition_topology_by_xcds(simdojo::Topology &topology, std::span<SoC *> socs,
+                                              uint32_t num_partitions);
 
 /// @brief Convenience overload for a single SoC.
-bool partition_topology_by_xcds(simdojo::Topology &topology, SoC *soc, uint32_t num_partitions);
+[[nodiscard]] bool partition_topology_by_xcds(simdojo::Topology &topology, SoC *soc,
+                                              uint32_t num_partitions);
 
 } // namespace amdgpu
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/partitioning.h
@@ -17,6 +17,17 @@
 namespace rocjitsu {
 namespace amdgpu {
 
+/// @brief Clamp a requested partition count to the visible XCD count.
+///
+/// @details Counts XCDs across all non-null SoCs and clamps
+/// @p requested_partitions to the inclusive range [1, max(total XCDs, 1)].
+/// @returns The usable partition count.
+[[nodiscard]] uint32_t clamp_xcd_partition_count(std::span<SoC *> socs,
+                                                 uint32_t requested_partitions);
+
+/// @brief Convenience overload for a single SoC.
+[[nodiscard]] uint32_t clamp_xcd_partition_count(SoC *soc, uint32_t requested_partitions);
+
 /// @brief Partition an AMDGPU topology by whole XCD subtrees.
 ///
 /// @details If @p num_partitions is nonzero and at least one XCD is present,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
@@ -18,7 +18,6 @@ RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "linux/uapi/kfd_ioctl.h"
 RJ_DIAGNOSTIC_POP
 
-#include <algorithm>
 #include <cerrno>
 #include <cstring>
 #include <memory>
@@ -43,18 +42,19 @@ rj_status_t create_from_loaded(config::LoadedConfig &loaded, rj_vm_mode_t mode, 
   auto s = std::make_unique<rj_vm_t>();
   s->soc = loaded.soc();
   auto num_xcds = s->soc->num_xcds();
-  uint32_t num_xcds_available = num_xcds;
+  std::vector<SoC *> partition_socs;
+  partition_socs.reserve(loaded.extra_gpu_builds.size() + 1);
+  partition_socs.push_back(s->soc);
   if (loaded.num_gpus > 1) {
     for (auto &eb : loaded.extra_gpu_builds) {
       if (auto *extra_soc = dynamic_cast<SoC *>(eb.root.get()))
-        num_xcds_available += extra_soc->num_xcds();
+        partition_socs.push_back(extra_soc);
     }
   }
   // XCD partitions (config num_threads): run each XCD on its own engine
   // partition/thread so the XCDs execute concurrently across their separate L2s.
-  const uint32_t num_threads_available = std::max(num_xcds_available, 1u);
   const uint32_t num_threads_used =
-      std::clamp<uint32_t>(loaded.engine_config.num_threads, 1u, num_threads_available);
+      amdgpu::clamp_xcd_partition_count(partition_socs, loaded.engine_config.num_threads);
   loaded.engine_config.num_threads = num_threads_used;
 
   bool serve = (mode == RJ_VM_MODE_LOCAL || mode == RJ_VM_MODE_DAEMON);
@@ -66,17 +66,14 @@ rj_status_t create_from_loaded(config::LoadedConfig &loaded, rj_vm_mode_t mode, 
 
   s->engine_config = loaded.engine_config;
   s->engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
-  std::vector<SoC *> partition_socs;
 
   if (loaded.num_gpus > 1 && !loaded.extra_gpu_builds.empty()) {
     std::vector<std::unique_ptr<SoC>> socs;
     std::vector<uint32_t> gpu_ids;
-    partition_socs.reserve(loaded.extra_gpu_builds.size() + 1);
 
     auto root0 = loaded.take_root();
     root0.release();
     socs.push_back(std::unique_ptr<SoC>(s->soc));
-    partition_socs.push_back(s->soc);
     gpu_ids.push_back(loaded.devices.empty() ? 0 : loaded.devices[0].gpu_id);
 
     for (size_t i = 0; i < loaded.extra_gpu_builds.size(); ++i) {
@@ -86,7 +83,6 @@ rj_status_t create_from_loaded(config::LoadedConfig &loaded, rj_vm_mode_t mode, 
         continue;
       eb.root.release();
       socs.push_back(std::unique_ptr<SoC>(extra_soc));
-      partition_socs.push_back(extra_soc);
       gpu_ids.push_back(i + 1 < loaded.devices.size() ? loaded.devices[i + 1].gpu_id : 0);
     }
 
@@ -119,7 +115,6 @@ rj_status_t create_from_loaded(config::LoadedConfig &loaded, rj_vm_mode_t mode, 
     s->engine->topology().set_root(std::move(vm_ptr));
     loaded.wire_links(s->engine->topology());
     s->soc->wire_backing(s->engine->topology());
-    partition_socs.push_back(s->soc);
   }
   if (num_threads_used > 1 && !amdgpu::partition_topology_by_xcds(
                                   s->engine->topology(), partition_socs, num_threads_used)) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
@@ -6,6 +6,7 @@
 #include "embedded_schema.h"
 #include "rocjitsu/config/checkpoint.h"
 #include "rocjitsu/kmd/linux/simulated_kfd.h"
+#include "rocjitsu/vm/amdgpu/partitioning.h"
 #include "rocjitsu/vm/plugins/plugin_loader.h"
 #include "rocjitsu/vm/rj_vm_impl.h"
 #include "rocjitsu/vm/soc.h"
@@ -16,12 +17,15 @@ RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "linux/uapi/kfd_ioctl.h"
 RJ_DIAGNOSTIC_POP
 
+#include <algorithm>
 #include <cerrno>
 #include <cstring>
 #include <memory>
+#include <span>
 #include <stdexcept>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <vector>
 
 using namespace rocjitsu;
 
@@ -39,6 +43,19 @@ rj_status_t create_from_loaded(config::LoadedConfig &loaded, rj_vm_mode_t mode, 
   auto s = std::make_unique<rj_vm_t>();
   s->soc = loaded.soc();
   auto num_xcds = s->soc->num_xcds();
+  uint32_t num_xcds_available = num_xcds;
+  if (loaded.num_gpus > 1) {
+    for (auto &eb : loaded.extra_gpu_builds) {
+      if (auto *extra_soc = dynamic_cast<SoC *>(eb.root.get()))
+        num_xcds_available += extra_soc->num_xcds();
+    }
+  }
+  // XCD partitions (config num_threads): run each XCD on its own engine
+  // partition/thread so the XCDs execute concurrently across their separate L2s.
+  const uint32_t num_threads_available = std::max(num_xcds_available, 1u);
+  const uint32_t num_threads_used =
+      std::clamp<uint32_t>(loaded.engine_config.num_threads, 1u, num_threads_available);
+  loaded.engine_config.num_threads = num_threads_used;
 
   bool serve = (mode == RJ_VM_MODE_LOCAL || mode == RJ_VM_MODE_DAEMON);
   bool daemon = (mode == RJ_VM_MODE_DAEMON);
@@ -49,14 +66,17 @@ rj_status_t create_from_loaded(config::LoadedConfig &loaded, rj_vm_mode_t mode, 
 
   s->engine_config = loaded.engine_config;
   s->engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
+  std::vector<SoC *> partition_socs;
 
   if (loaded.num_gpus > 1 && !loaded.extra_gpu_builds.empty()) {
     std::vector<std::unique_ptr<SoC>> socs;
     std::vector<uint32_t> gpu_ids;
+    partition_socs.reserve(loaded.extra_gpu_builds.size() + 1);
 
     auto root0 = loaded.take_root();
     root0.release();
     socs.push_back(std::unique_ptr<SoC>(s->soc));
+    partition_socs.push_back(s->soc);
     gpu_ids.push_back(loaded.devices.empty() ? 0 : loaded.devices[0].gpu_id);
 
     for (size_t i = 0; i < loaded.extra_gpu_builds.size(); ++i) {
@@ -66,6 +86,7 @@ rj_status_t create_from_loaded(config::LoadedConfig &loaded, rj_vm_mode_t mode, 
         continue;
       eb.root.release();
       socs.push_back(std::unique_ptr<SoC>(extra_soc));
+      partition_socs.push_back(extra_soc);
       gpu_ids.push_back(i + 1 < loaded.devices.size() ? loaded.devices[i + 1].gpu_id : 0);
     }
 
@@ -98,7 +119,12 @@ rj_status_t create_from_loaded(config::LoadedConfig &loaded, rj_vm_mode_t mode, 
     s->engine->topology().set_root(std::move(vm_ptr));
     loaded.wire_links(s->engine->topology());
     s->soc->wire_backing(s->engine->topology());
+    partition_socs.push_back(s->soc);
   }
+  if (num_threads_used > 1)
+    amdgpu::partition_topology_by_xcds(
+        s->engine->topology(), std::span<SoC *>(partition_socs.data(), partition_socs.size()),
+        num_threads_used);
   s->engine->create();
 
   if (serve) {
@@ -222,6 +248,8 @@ rj_status_t rj_vm_step(rj_vm_t *vm, int *active) {
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
   if (!vm->soc)
     return ROCJITSU_STATUS_ERROR;
+  if (vm->engine_config.num_threads != 1)
+    return ROCJITSU_STATUS_UNSUPPORTED;
 
   bool any_active = vm->engine->step();
   if (active)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
@@ -53,8 +53,12 @@ rj_status_t create_from_loaded(config::LoadedConfig &loaded, rj_vm_mode_t mode, 
   }
   // XCD partitions (config num_threads): run each XCD on its own engine
   // partition/thread so the XCDs execute concurrently across their separate L2s.
+  const uint32_t num_threads_requested = loaded.engine_config.num_threads;
   const uint32_t num_threads_used =
-      amdgpu::clamp_xcd_partition_count(partition_socs, loaded.engine_config.num_threads);
+      amdgpu::clamp_xcd_partition_count(partition_socs, num_threads_requested);
+  if (num_threads_used != num_threads_requested)
+    util::Logger::warn("num_threads clamped: requested=", num_threads_requested,
+                       ", effective=", num_threads_used);
   loaded.engine_config.num_threads = num_threads_used;
 
   bool serve = (mode == RJ_VM_MODE_LOCAL || mode == RJ_VM_MODE_DAEMON);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
@@ -12,6 +12,7 @@
 #include "rocjitsu/vm/soc.h"
 
 #include "rocjitsu/base/rj_compiler.h"
+#include "util/log.h"
 RJ_DIAGNOSTIC_PUSH
 RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "linux/uapi/kfd_ioctl.h"
@@ -21,7 +22,6 @@ RJ_DIAGNOSTIC_POP
 #include <cerrno>
 #include <cstring>
 #include <memory>
-#include <span>
 #include <stdexcept>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
@@ -121,10 +121,10 @@ rj_status_t create_from_loaded(config::LoadedConfig &loaded, rj_vm_mode_t mode, 
     s->soc->wire_backing(s->engine->topology());
     partition_socs.push_back(s->soc);
   }
-  if (num_threads_used > 1)
-    amdgpu::partition_topology_by_xcds(
-        s->engine->topology(), std::span<SoC *>(partition_socs.data(), partition_socs.size()),
-        num_threads_used);
+  if (num_threads_used > 1 && !amdgpu::partition_topology_by_xcds(
+                                  s->engine->topology(), partition_socs, num_threads_used)) {
+    throw std::invalid_argument("multi-threaded VM requires at least one XCD");
+  }
   s->engine->create();
 
   if (serve) {
@@ -189,7 +189,8 @@ rj_status_t rj_vm_create(const char *json_path, rj_vm_mode_t mode, rj_vm_t **vm)
   try {
     auto loaded = config::load_config(json_path, rocjitsu::kEmbeddedSchema);
     return create_from_loaded(loaded, mode, vm);
-  } catch (const std::exception &) {
+  } catch (const std::exception &e) {
+    util::Logger::warn("rj_vm_create failed: ", e.what());
     return ROCJITSU_STATUS_INVALID_FILE;
   }
 }
@@ -200,7 +201,8 @@ rj_status_t rj_vm_create_from_string(const char *json, rj_vm_mode_t mode, rj_vm_
   try {
     auto loaded = config::load_config_from_string(json, rocjitsu::kEmbeddedSchema);
     return create_from_loaded(loaded, mode, vm);
-  } catch (const std::exception &) {
+  } catch (const std::exception &e) {
+    util::Logger::warn("rj_vm_create_from_string failed: ", e.what());
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
   }
 }

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/simulation.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/simulation.h
@@ -105,12 +105,13 @@ private:
 ///
 /// Typical usage:
 /// @code
+///   SimulationEngine::Config config{.num_threads = 4};
 ///   SimulationEngine engine(config);
 ///   engine.topology().set_root(std::move(my_model));
-///   engine.create(); // partitions, initializes components
+///   engine.topology().partition_balanced(config.num_threads);
+///   engine.create(); // validates the partition policy and initializes components
 ///   // (user enqueues work via CP)
 ///   auto exit = engine.run(); // starts up components, runs to completion
-///   // OR: while (engine.step()) {} // starts up on first call, one tick per call
 /// @endcode
 class SimulationEngine {
 public:

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/simulation.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/simulation.h
@@ -136,14 +136,19 @@ public:
   SimulationEngine(SimulationEngine &&) = delete;
   SimulationEngine &operator=(SimulationEngine &&) = delete;
 
-  /// @brief Partition the topology, initialize components, and prepare for execution.
+  /// @brief Initialize the topology and prepare for execution.
   ///
   /// @details Required after the Config-only constructor once the topology is
-  /// populated. Also used to rebuild after shutdown(). Calls
-  /// initialize_components() so that components can set up ports and handlers
-  /// before run() or step() starts them. Event self-scheduling is deferred: the
-  /// Clocked/Functional mixins enqueue their first event in startup() (invoked by the
-  /// first run()/step() call), not here, so no events exist until execution begins.
+  /// populated. Multi-threaded engines require the caller to choose an explicit
+  /// topology partition policy before calling create(); single-threaded engines
+  /// create their sole partition automatically. Also used to rebuild after
+  /// shutdown(). Calls initialize_components() so that components can set up
+  /// ports and handlers before run() or step() starts them. Event
+  /// self-scheduling is deferred: the Clocked/Functional mixins enqueue their
+  /// first event in startup() (invoked by the first run()/step() call), not
+  /// here, so no events exist until execution begins.
+  /// @throws std::invalid_argument if the worker count, partition count, or
+  /// cross-partition link configuration is invalid.
   void create();
 
   /// @brief Tear down engine state (shutdown components, join workers).

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/topology.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/topology.h
@@ -72,9 +72,12 @@ public:
 
 /// @brief The simulation compound graph.
 ///
-/// @details Topology owns all components (via the root CompositeComponent), all links,
-/// and all partitions. It provides component creation, link creation,
-/// graph traversal, and partitioning into sub-graphs for parallel execution.
+/// @details Topology owns the component tree reachable from the root
+/// CompositeComponent, all links, and all partitions. Link-endpoint owners
+/// outside the root tree are borrowed; they and their ports must remain alive
+/// through every repartition and SimulationEngine create/run/shutdown operation
+/// that retains them. Topology provides component creation, link creation, graph
+/// traversal, and partitioning into sub-graphs for parallel execution.
 class Topology {
 public:
   Topology() = default;
@@ -88,6 +91,11 @@ public:
   CompositeComponent *root() const { return root_.get(); }
 
   /// @brief Create a link between two ports with a given latency.
+  ///
+  /// @details Topology owns the link but borrows @p src, @p dst, and their
+  /// owners. An endpoint owner outside the root component tree and its ports
+  /// must remain alive through every repartition and SimulationEngine
+  /// create/run/shutdown operation that retains them.
   /// @param src Source port.
   /// @param dst Destination port.
   /// @param latency Propagation delay in simulation ticks.
@@ -100,7 +108,10 @@ public:
   /// @details Topology owns links, so topology builders use this factory when
   /// bounded-capacity transport is required. Queued links may only connect
   /// components in the same topology partition. SimulationEngine::create()
-  /// rejects cross-partition queued links.
+  /// rejects cross-partition queued links. Topology borrows @p src, @p dst,
+  /// and their owners; an endpoint owner outside the root component tree and
+  /// its ports must remain alive through every repartition and SimulationEngine
+  /// create/run/shutdown operation that retains them.
   /// @param src Source port.
   /// @param dst Destination port.
   /// @param latency Propagation delay in simulation ticks.
@@ -113,7 +124,8 @@ public:
   /// @brief Create two unidirectional links for bidirectional communication.
   ///
   /// @details Wires a_out -> b_in (forward, fwd_latency) and b_out -> a_in (reverse,
-  /// rev_latency). Equivalent to calling add_link() twice.
+  /// rev_latency). Equivalent to calling add_link() twice, including its
+  /// endpoint-owner lifetime requirements.
   /// @param a_out Output port on component A.
   /// @param b_in Input port on component B.
   /// @param b_out Output port on component B.
@@ -165,6 +177,9 @@ public:
   ///
   /// @details This invokes the generic Fiduccia-Mattheyses partitioner. Callers
   /// with hardware or ownership constraints should use partition_manual().
+  /// External link-endpoint owners retained in the resulting partitions are
+  /// borrowed and must remain alive through every subsequent repartition and
+  /// SimulationEngine create/run/shutdown operation that retains them.
   /// @param num_partitions Number of partitions to create (one per thread).
   /// @throws std::invalid_argument if @p num_partitions is zero.
   void partition_balanced(uint32_t num_partitions);
@@ -183,7 +198,10 @@ public:
   /// @details Bypasses the FM partitioner. The caller's callback assigns every
   /// component in the topology tree and every external link-endpoint owner.
   /// This is the explicit policy entry point for hardware or ownership
-  /// constraints and deterministic partition layouts.
+  /// constraints and deterministic partition layouts. External endpoint owners
+  /// retained in the resulting partitions are borrowed and must remain alive
+  /// through every subsequent repartition and SimulationEngine
+  /// create/run/shutdown operation that retains them.
   /// @param num_partitions Number of partitions to create.
   /// @param assigner Callback returning the partition ID for each component.
   /// @throws std::invalid_argument if @p num_partitions is zero or @p assigner

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/topology.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/topology.h
@@ -96,6 +96,11 @@ public:
   Link *add_link(Port *src, Port *dst, Tick latency, uint32_t weight = 1);
 
   /// @brief Create a queued link between two ports.
+  ///
+  /// @details Topology owns links, so topology builders use this factory when
+  /// bounded-capacity transport is required. Queued links may only connect
+  /// components in the same topology partition. SimulationEngine::create()
+  /// rejects cross-partition queued links.
   /// @param src Source port.
   /// @param dst Destination port.
   /// @param latency Propagation delay in simulation ticks.

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/topology.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/topology.h
@@ -34,7 +34,10 @@ struct LinkSpec {
 /// @brief A partition of the simulation topology.
 ///
 /// @details Each Partition holds the set of components assigned to a single
-/// worker thread, along with the links internal to and crossing this partition.
+/// event queue, along with the links internal to and crossing this partition.
+/// Membership determines scheduled-event ownership and link classification;
+/// it does not dispatch direct component calls or lifecycle hooks to the
+/// partition's worker thread.
 struct Partition {
   PartitionID id = 0;                  ///< Partition identifier.
   std::vector<Component *> components; ///< Components assigned to this partition.
@@ -92,6 +95,16 @@ public:
   /// @returns Raw pointer to the created link.
   Link *add_link(Port *src, Port *dst, Tick latency, uint32_t weight = 1);
 
+  /// @brief Create a queued link between two ports.
+  /// @param src Source port.
+  /// @param dst Destination port.
+  /// @param latency Propagation delay in simulation ticks.
+  /// @param capacity Maximum number of buffered messages.
+  /// @param weight Partitioning cut weight for this link.
+  /// @returns Raw pointer to the created queued link.
+  QueuedLink *add_queued_link(Port *src, Port *dst, Tick latency, size_t capacity,
+                              uint32_t weight = 1);
+
   /// @brief Create two unidirectional links for bidirectional communication.
   ///
   /// @details Wires a_out -> b_in (forward, fwd_latency) and b_out -> a_in (reverse,
@@ -143,9 +156,13 @@ public:
   /// @returns Const reference to the clock domain vector.
   const std::vector<std::unique_ptr<ClockDomain>> &clock_domains() const { return clock_domains_; }
 
-  /// @brief Partition the topology for parallel execution.
+  /// @brief Balance the topology across partitions for parallel execution.
+  ///
+  /// @details This invokes the generic Fiduccia-Mattheyses partitioner. Callers
+  /// with hardware or ownership constraints should use partition_manual().
   /// @param num_partitions Number of partitions to create (one per thread).
-  void partition(uint32_t num_partitions);
+  /// @throws std::invalid_argument if @p num_partitions is zero.
+  void partition_balanced(uint32_t num_partitions);
 
   /// @brief Resolve a dotted path (e.g., "xcd0.se1.cu3") to a Component.
   Component *resolve_component(const std::string &path) const;
@@ -163,9 +180,15 @@ public:
   /// deterministic partition layouts.
   /// @param num_partitions Number of partitions to create.
   /// @param assigner Callback returning the partition ID for each component.
+  /// @throws std::invalid_argument if @p num_partitions is zero or @p assigner
+  /// returns an out-of-range partition ID.
   void partition_manual(uint32_t num_partitions, std::function<PartitionID(Component *)> assigner);
 
 private:
+  /// @brief Append unique owners of registered link endpoints.
+  /// @param components Existing component list to extend without duplicates.
+  void append_link_endpoint_owners(std::vector<Component *> &components) const;
+
   /// @brief Classify links as internal or boundary for each partition.
   void classify_links();
 

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/topology.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/topology.h
@@ -180,9 +180,10 @@ public:
 
   /// @brief Partition the topology with explicit partition assignments.
   ///
-  /// @details Bypasses the FM partitioner. Each component is assigned a
-  /// partition ID by the caller's callback. Used by tests that need
-  /// deterministic partition layouts.
+  /// @details Bypasses the FM partitioner. The caller's callback assigns every
+  /// component in the topology tree and every external link-endpoint owner.
+  /// This is the explicit policy entry point for hardware or ownership
+  /// constraints and deterministic partition layouts.
   /// @param num_partitions Number of partitions to create.
   /// @param assigner Callback returning the partition ID for each component.
   /// @throws std::invalid_argument if @p num_partitions is zero or @p assigner

--- a/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
+++ b/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
@@ -6,8 +6,17 @@
 #include <algorithm>
 #include <cassert>
 #include <stdexcept>
+#include <string>
 
 namespace simdojo {
+
+namespace {
+
+std::string link_endpoints(const Link &link) {
+  return link.src()->full_path() + " -> " + link.dst()->full_path();
+}
+
+} // namespace
 
 void PartitionContext::drain_incoming() {
   for (auto &queue : incoming)
@@ -84,12 +93,12 @@ void SimulationEngine::setup_partitions() {
   for (auto &link : topology_.links()) {
     if (link->is_cross_partition()) {
       if (link->latency() == 0) {
-        throw std::invalid_argument(
-            "SimulationEngine cross-partition links require positive latency");
+        throw std::invalid_argument("SimulationEngine cross-partition link " +
+                                    link_endpoints(*link) + " requires positive latency");
       }
       if (dynamic_cast<QueuedLink *>(link.get()) != nullptr) {
-        throw std::invalid_argument(
-            "SimulationEngine QueuedLinks must not cross partition boundaries");
+        throw std::invalid_argument("SimulationEngine QueuedLink " + link_endpoints(*link) +
+                                    " must not cross partition boundaries");
       }
     }
   }

--- a/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
+++ b/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <stdexcept>
 
 namespace simdojo {
 
@@ -23,8 +24,16 @@ SimulationEngine::~SimulationEngine() {
 
 void SimulationEngine::create() {
   assert(!created_ && "create() called twice without shutdown()");
-  if (topology_.partitions().empty())
-    topology_.partition(config_.num_threads);
+  if (config_.num_threads == 0)
+    throw std::invalid_argument("SimulationEngine requires at least one worker thread");
+
+  if (topology_.partitions().empty()) {
+    if (config_.num_threads > 1) {
+      throw std::invalid_argument(
+          "multi-threaded SimulationEngine requires an explicit topology partition policy");
+    }
+    topology_.partition_balanced(1);
+  }
   setup_partitions();
 
   done_.store(false, std::memory_order_release);
@@ -66,8 +75,24 @@ void SimulationEngine::shutdown() {
 
 void SimulationEngine::setup_partitions() {
   const uint32_t num_threads = config_.num_threads;
-  assert(num_threads > 0);
-  assert(topology_.partitions().size() == num_threads);
+  if (topology_.partitions().size() != num_threads) {
+    throw std::invalid_argument(
+        "SimulationEngine topology partition count must match the worker thread count");
+  }
+
+  // Validate cross-partition link constraints.
+  for (auto &link : topology_.links()) {
+    if (link->is_cross_partition()) {
+      if (link->latency() == 0) {
+        throw std::invalid_argument(
+            "SimulationEngine cross-partition links require positive latency");
+      }
+      if (dynamic_cast<QueuedLink *>(link.get()) != nullptr) {
+        throw std::invalid_argument(
+            "SimulationEngine QueuedLinks must not cross partition boundaries");
+      }
+    }
+  }
 
   contexts_.reserve(num_threads);
   for (uint32_t i = 0; i < num_threads; ++i)
@@ -76,15 +101,6 @@ void SimulationEngine::setup_partitions() {
   async_queues_.reserve(num_threads);
   for (uint32_t i = 0; i < num_threads; ++i)
     async_queues_.push_back(std::make_unique<AsyncQueue>());
-
-  // Validate cross-partition link constraints.
-  for (auto &link : topology_.links()) {
-    if (link->is_cross_partition()) {
-      assert(link->latency() > 0 && "cross-partition links require positive latency for LBTS");
-      assert(dynamic_cast<QueuedLink *>(link.get()) == nullptr &&
-             "QueuedLinks must not cross partition boundaries (they bypass the LBTS protocol)");
-    }
-  }
 
   // Set engine pointer on all components.
   for (auto &part : topology_.partitions()) {

--- a/emulation/rocjitsu/lib/simdojo/src/topology.cpp
+++ b/emulation/rocjitsu/lib/simdojo/src/topology.cpp
@@ -9,6 +9,7 @@
 #include <random>
 #include <stdexcept>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace simdojo {
 
@@ -113,6 +114,27 @@ Link *Topology::add_link(Port *src, Port *dst, Tick latency, uint32_t weight) {
   return raw;
 }
 
+QueuedLink *Topology::add_queued_link(Port *src, Port *dst, Tick latency, size_t capacity,
+                                      uint32_t weight) {
+  // Validate port protocol compatibility (UNTYPED matches anything).
+  assert((src->protocol() == PortProtocol::UNTYPED || dst->protocol() == PortProtocol::UNTYPED ||
+          src->protocol() == dst->protocol()) &&
+         "link endpoints must have compatible protocols");
+  // Validate port direction: link goes from OUT to IN (or UNTYPED).
+  assert((src->direction() == PortDirection::OUT || src->protocol() == PortProtocol::UNTYPED) &&
+         "link source must be an OUT port");
+  assert((dst->direction() == PortDirection::IN || dst->protocol() == PortProtocol::UNTYPED) &&
+         "link destination must be an IN port");
+
+  auto link = std::make_unique<QueuedLink>(next_link_id_++, src, dst, latency, capacity);
+  link->set_weight(weight);
+  src->set_link(link.get());
+  dst->set_link(link.get());
+  QueuedLink *raw = link.get();
+  links_.push_back(std::move(link));
+  return raw;
+}
+
 std::pair<Link *, Link *> Topology::add_bidirectional_link(Port *a_out, Port *b_in, Port *b_out,
                                                            Port *a_in, Tick fwd_latency,
                                                            Tick rev_latency, uint32_t weight) {
@@ -126,6 +148,16 @@ std::vector<Component *> Topology::collect_all_components() const {
   if (root_ != nullptr)
     root_->collect_components(result);
   return result;
+}
+
+void Topology::append_link_endpoint_owners(std::vector<Component *> &components) const {
+  std::unordered_set<Component *> collected(components.begin(), components.end());
+  for (const auto &link : links_) {
+    for (Component *owner : {link->src()->owner(), link->dst()->owner()}) {
+      if (owner && collected.insert(owner).second)
+        components.push_back(owner);
+    }
+  }
 }
 
 uint32_t Topology::num_components() const {
@@ -184,10 +216,14 @@ void Topology::dfs_visit(std::function<void(Component *, uint32_t)> visitor) con
   }
 }
 
-void Topology::partition(uint32_t num_partitions) {
-  auto components = collect_all_components();
+void Topology::partition_balanced(uint32_t num_partitions) {
+  if (num_partitions == 0)
+    throw std::invalid_argument("partition_balanced: num_partitions must be nonzero");
 
-  if (num_partitions <= 1) {
+  auto components = collect_all_components();
+  append_link_endpoint_owners(components);
+
+  if (num_partitions == 1) {
     Partition part;
     part.id = 0;
     part.components = std::move(components);
@@ -213,21 +249,50 @@ void Topology::partition(uint32_t num_partitions) {
 
 void Topology::partition_manual(uint32_t num_partitions,
                                 std::function<PartitionID(Component *)> assigner) {
+  if (num_partitions == 0)
+    throw std::invalid_argument("partition_manual: num_partitions must be nonzero");
+
   auto components = collect_all_components();
+  const size_t num_tree_components = components.size();
 
-  partitions_.clear();
-  partitions_.resize(num_partitions);
-  for (uint32_t i = 0; i < num_partitions; ++i)
-    partitions_[i].id = i;
-
+  std::vector<PartitionID> assignments;
+  assignments.reserve(num_tree_components);
   for (auto *comp : components) {
     PartitionID pid = assigner(comp);
-    assert(pid < num_partitions && "partition_manual: assigner returned out-of-range ID");
-    comp->set_partition_id(pid);
-    partitions_[pid].components.push_back(comp);
-    partitions_[pid].total_weight += comp->weight();
+    if (pid >= num_partitions)
+      throw std::invalid_argument("partition_manual: assigner returned out-of-range ID");
+    assignments.push_back(pid);
   }
 
+  std::vector<Partition> partitions(num_partitions);
+  for (uint32_t i = 0; i < num_partitions; ++i)
+    partitions[i].id = i;
+
+  for (size_t i = 0; i < components.size(); ++i) {
+    auto *comp = components[i];
+    PartitionID pid = assignments[i];
+    partitions[pid].components.push_back(comp);
+    partitions[pid].total_weight += comp->weight();
+  }
+
+  // A link endpoint may be owned by a component that is not part of the topology
+  // tree (e.g. a standalone backing controller wired in after construction).
+  // Include each external owner once on partition 0 on every rebuild,
+  // regardless of a stale partition ID from a previous partition_manual()
+  // call.
+  append_link_endpoint_owners(components);
+  for (size_t i = num_tree_components; i < components.size(); ++i) {
+    auto *owner = components[i];
+    partitions[0].components.push_back(owner);
+    partitions[0].total_weight += owner->weight();
+  }
+
+  for (size_t i = 0; i < num_tree_components; ++i)
+    components[i]->set_partition_id(assignments[i]);
+  for (size_t i = num_tree_components; i < components.size(); ++i)
+    components[i]->set_partition_id(0);
+
+  partitions_ = std::move(partitions);
   classify_links();
 }
 

--- a/emulation/rocjitsu/lib/simdojo/src/topology.cpp
+++ b/emulation/rocjitsu/lib/simdojo/src/topology.cpp
@@ -84,6 +84,18 @@ Port *resolve_port_impl(CompositeComponent *root, const std::string &path) {
   return find_or_create_port(comp, pn);
 }
 
+void validate_link_ports([[maybe_unused]] Port *src, [[maybe_unused]] Port *dst) {
+  // Validate port protocol compatibility (UNTYPED matches anything).
+  assert((src->protocol() == PortProtocol::UNTYPED || dst->protocol() == PortProtocol::UNTYPED ||
+          src->protocol() == dst->protocol()) &&
+         "link endpoints must have compatible protocols");
+  // Validate port direction: link goes from OUT to IN (or UNTYPED).
+  assert((src->direction() == PortDirection::OUT || src->protocol() == PortProtocol::UNTYPED) &&
+         "link source must be an OUT port");
+  assert((dst->direction() == PortDirection::IN || dst->protocol() == PortProtocol::UNTYPED) &&
+         "link destination must be an IN port");
+}
+
 } // namespace
 
 ClockDomain *Topology::add_clock_domain(std::string name, uint64_t frequency_hz,
@@ -95,15 +107,7 @@ ClockDomain *Topology::add_clock_domain(std::string name, uint64_t frequency_hz,
 }
 
 Link *Topology::add_link(Port *src, Port *dst, Tick latency, uint32_t weight) {
-  // Validate port protocol compatibility (UNTYPED matches anything).
-  assert((src->protocol() == PortProtocol::UNTYPED || dst->protocol() == PortProtocol::UNTYPED ||
-          src->protocol() == dst->protocol()) &&
-         "link endpoints must have compatible protocols");
-  // Validate port direction: link goes from OUT to IN (or UNTYPED).
-  assert((src->direction() == PortDirection::OUT || src->protocol() == PortProtocol::UNTYPED) &&
-         "link source must be an OUT port");
-  assert((dst->direction() == PortDirection::IN || dst->protocol() == PortProtocol::UNTYPED) &&
-         "link destination must be an IN port");
+  validate_link_ports(src, dst);
 
   auto link = std::make_unique<Link>(next_link_id_++, src, dst, latency);
   link->set_weight(weight);
@@ -116,15 +120,7 @@ Link *Topology::add_link(Port *src, Port *dst, Tick latency, uint32_t weight) {
 
 QueuedLink *Topology::add_queued_link(Port *src, Port *dst, Tick latency, size_t capacity,
                                       uint32_t weight) {
-  // Validate port protocol compatibility (UNTYPED matches anything).
-  assert((src->protocol() == PortProtocol::UNTYPED || dst->protocol() == PortProtocol::UNTYPED ||
-          src->protocol() == dst->protocol()) &&
-         "link endpoints must have compatible protocols");
-  // Validate port direction: link goes from OUT to IN (or UNTYPED).
-  assert((src->direction() == PortDirection::OUT || src->protocol() == PortProtocol::UNTYPED) &&
-         "link source must be an OUT port");
-  assert((dst->direction() == PortDirection::IN || dst->protocol() == PortProtocol::UNTYPED) &&
-         "link destination must be an IN port");
+  validate_link_ports(src, dst);
 
   auto link = std::make_unique<QueuedLink>(next_link_id_++, src, dst, latency, capacity);
   link->set_weight(weight);

--- a/emulation/rocjitsu/lib/simdojo/src/topology.cpp
+++ b/emulation/rocjitsu/lib/simdojo/src/topology.cpp
@@ -249,10 +249,10 @@ void Topology::partition_manual(uint32_t num_partitions,
     throw std::invalid_argument("partition_manual: num_partitions must be nonzero");
 
   auto components = collect_all_components();
-  const size_t num_tree_components = components.size();
+  append_link_endpoint_owners(components);
 
   std::vector<PartitionID> assignments;
-  assignments.reserve(num_tree_components);
+  assignments.reserve(components.size());
   for (auto *comp : components) {
     PartitionID pid = assigner(comp);
     if (pid >= num_partitions)
@@ -271,22 +271,8 @@ void Topology::partition_manual(uint32_t num_partitions,
     partitions[pid].total_weight += comp->weight();
   }
 
-  // A link endpoint may be owned by a component that is not part of the topology
-  // tree (e.g. a standalone backing controller wired in after construction).
-  // Include each external owner once on partition 0 on every rebuild,
-  // regardless of a stale partition ID from a previous partition_manual()
-  // call.
-  append_link_endpoint_owners(components);
-  for (size_t i = num_tree_components; i < components.size(); ++i) {
-    auto *owner = components[i];
-    partitions[0].components.push_back(owner);
-    partitions[0].total_weight += owner->weight();
-  }
-
-  for (size_t i = 0; i < num_tree_components; ++i)
+  for (size_t i = 0; i < components.size(); ++i)
     components[i]->set_partition_id(assignments[i]);
-  for (size_t i = num_tree_components; i < components.size(); ++i)
-    components[i]->set_partition_id(0);
 
   partitions_ = std::move(partitions);
   classify_links();

--- a/emulation/rocjitsu/schemas/simulation_config.fbs
+++ b/emulation/rocjitsu/schemas/simulation_config.fbs
@@ -234,7 +234,7 @@ table TopologyDef {
 /// Top-level simulation configuration.
 table SimulationConfig {
   max_ticks: uint64;             // Maximum simulation ticks before halting.
-  num_threads: uint32;           // Number of simulation threads (partitions).
+  num_threads: uint32;           // Number of simulation engine partitions (one per XCD when partitioned).
   exec_mode: string;             // Execution mode: "functional" (default) or "clocked".
   vm: VirtualMachineConfig;      // Virtual machine hardware model. Omit for dbt_guest-only configs.
   topology: TopologyDef;         // Declarative topology. Omit for dbt_guest-only configs.

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -374,6 +374,7 @@ add_executable(
     l2_cache_test.cpp
     sparse_memory_test.cpp
     simdojo_sim_test.cpp
+    partitioning_test.cpp
     simulated_kfd_test.cpp
     decode_smoke_test.cpp
     buffer_operand_test.cpp

--- a/emulation/rocjitsu/tests/matmul_test.cpp
+++ b/emulation/rocjitsu/tests/matmul_test.cpp
@@ -12,6 +12,7 @@
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/partitioning.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "rocjitsu/vm/soc.h"
 
@@ -31,7 +32,6 @@ RJ_DIAGNOSTIC_POP
 #include <cstring>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #ifdef HAS_DEVICE_KERNELS
@@ -120,10 +120,10 @@ struct KernelExecFixture {
     engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
     engine->topology().set_root(loaded.take_root());
     loaded.wire_links(engine->topology());
-    if (num_threads > 1)
-      partition_by_xcd(num_threads);
-    else
-      engine->create();
+    if (num_threads > 1) {
+      ASSERT_TRUE(amdgpu::partition_topology_by_xcds(engine->topology(), soc, num_threads));
+    }
+    engine->create();
 
     Executable exec(kernel_path(kernel_name));
     ASSERT_TRUE(exec.is_valid());
@@ -135,28 +135,6 @@ struct KernelExecFixture {
     co->load_to_memory(mem(), KD_ADDR);
     kernel_object = KD_ADDR + co->kernel_descriptor_offset(kernel_name);
     ASSERT_NE(kernel_object, KD_ADDR) << "Kernel descriptor symbol not found";
-  }
-
-  /// Partition so that each XCD's components stay in the same partition.
-  /// Components not under any XCD (SoC, VM, IODs) go to partition 0.
-  void partition_by_xcd(uint32_t num_partitions) {
-    // Build a map from Xcd pointer to partition ID.
-    std::unordered_map<simdojo::Component *, simdojo::PartitionID> xcd_map;
-    for (uint32_t i = 0; i < soc->num_xcds(); ++i)
-      xcd_map[soc->xcd(i)] = i % num_partitions;
-
-    engine->topology().partition_manual(
-        num_partitions, [&](simdojo::Component *c) -> simdojo::PartitionID {
-          // Walk up the parent chain looking for an XCD ancestor.
-          for (auto *p = static_cast<simdojo::Component *>(c); p != nullptr;
-               p = static_cast<simdojo::Component *>(p->parent())) {
-            auto it = xcd_map.find(p);
-            if (it != xcd_map.end())
-              return it->second;
-          }
-          return 0; // Top-level components → partition 0.
-        });
-    engine->create();
   }
 
   amdgpu::GpuMemory *mem() { return gpu_mem; }
@@ -445,20 +423,7 @@ TEST(MatmulStressTest, Cdna4TopologyDispatchAndHalt_MultiThreaded) {
   engine->topology().set_root(loaded.take_root());
   loaded.wire_links(engine->topology());
 
-  // Partition by XCD so each XCD's components stay on one thread.
-  std::unordered_map<simdojo::Component *, simdojo::PartitionID> xcd_map;
-  for (uint32_t i = 0; i < soc->num_xcds(); ++i)
-    xcd_map[soc->xcd(i)] = i;
-  engine->topology().partition_manual(
-      TOTAL_XCDS, [&](simdojo::Component *c) -> simdojo::PartitionID {
-        for (auto *p = static_cast<simdojo::Component *>(c); p != nullptr;
-             p = static_cast<simdojo::Component *>(p->parent())) {
-          auto it = xcd_map.find(p);
-          if (it != xcd_map.end())
-            return it->second;
-        }
-        return 0;
-      });
+  ASSERT_TRUE(amdgpu::partition_topology_by_xcds(engine->topology(), soc, TOTAL_XCDS));
   engine->create();
 
   using namespace rocr::llvm::amdhsa;

--- a/emulation/rocjitsu/tests/partitioning_test.cpp
+++ b/emulation/rocjitsu/tests/partitioning_test.cpp
@@ -103,6 +103,25 @@ TEST(XcdPartitioningTest, FourThreadsDistributesCdna4XcdsRoundRobinWithoutSplits
     expect_subtree_partition(topology.soc->xcd(i), i % 4);
 }
 
+TEST(XcdPartitioningTest, ClampPartitionCountUsesAllNonNullSocs) {
+  auto loaded = config::load_config(CONFIG_2GPU_PATH, rocjitsu::kEmbeddedSchema);
+  ASSERT_EQ(loaded.extra_gpu_builds.size(), 1u);
+
+  auto *soc0 = loaded.soc();
+  auto *soc1 = dynamic_cast<SoC *>(loaded.extra_gpu_builds[0].root.get());
+  ASSERT_NE(soc0, nullptr);
+  ASSERT_NE(soc1, nullptr);
+  ASSERT_EQ(soc0->num_xcds(), 8u);
+  ASSERT_EQ(soc1->num_xcds(), 8u);
+
+  std::array<SoC *, 3> socs = {soc0, nullptr, soc1};
+  EXPECT_EQ(amdgpu::clamp_xcd_partition_count(std::span<SoC *>(socs), 0), 1u);
+  EXPECT_EQ(amdgpu::clamp_xcd_partition_count(std::span<SoC *>(socs), 4), 4u);
+  EXPECT_EQ(amdgpu::clamp_xcd_partition_count(std::span<SoC *>(socs), 64), 16u);
+  EXPECT_EQ(amdgpu::clamp_xcd_partition_count(soc0, 64), 8u);
+  EXPECT_EQ(amdgpu::clamp_xcd_partition_count(static_cast<SoC *>(nullptr), 64), 1u);
+}
+
 TEST(XcdPartitioningTest, ZeroPartitionsIsNoopWithoutManualPartitions) {
   auto loaded = config::load_config(CONFIG_PATH, rocjitsu::kEmbeddedSchema);
   auto *soc = loaded.soc();
@@ -201,6 +220,20 @@ TEST(XcdPartitioningTest, VmStepRejectsMultipleEnginePartitions) {
   EXPECT_EQ(rj_vm_run(vm.get(), &ticks_executed), ROCJITSU_STATUS_SUCCESS);
 }
 
+TEST(XcdPartitioningTest, VmStepSucceedsWithSingleEnginePartition) {
+  auto json = config_json_with_num_threads(CONFIG_1XCD_PATH, 1);
+
+  rj_vm_t *raw_vm = nullptr;
+  ASSERT_EQ(rj_vm_create_from_string(json.c_str(), RJ_VM_MODE_DEFAULT, &raw_vm),
+            ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(raw_vm, nullptr);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> vm(raw_vm, &rj_vm_destroy);
+
+  int active = 7;
+  EXPECT_EQ(rj_vm_step(vm.get(), &active), ROCJITSU_STATUS_SUCCESS);
+  EXPECT_EQ(active, 0);
+}
+
 TEST(XcdPartitioningTest, CApiClampsZeroThreadsToOne) {
   auto json = config_json_with_num_threads(CONFIG_1XCD_PATH, 0);
 
@@ -237,6 +270,18 @@ TEST(XcdPartitioningTest, CApiClampsMultiGpuThreadsToTotalXcdCountAndRuns) {
   std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> vm(raw_vm, &rj_vm_destroy);
 
   EXPECT_EQ(vm->engine_config.num_threads, 16u);
+  ASSERT_NE(vm->vm, nullptr);
+  ASSERT_EQ(vm->vm->num_socs(), 2u);
+
+  uint32_t global_xcd_index = 0;
+  for (uint32_t gpu = 0; gpu < vm->vm->num_socs(); ++gpu) {
+    auto *soc = vm->vm->soc(gpu);
+    ASSERT_NE(soc, nullptr);
+    ASSERT_EQ(soc->num_xcds(), 8u);
+    for (uint32_t i = 0; i < soc->num_xcds(); ++i, ++global_xcd_index)
+      expect_subtree_partition(soc->xcd(i), global_xcd_index % vm->engine_config.num_threads);
+  }
+
   EXPECT_EQ(rj_vm_run(vm.get(), nullptr), ROCJITSU_STATUS_SUCCESS);
 }
 

--- a/emulation/rocjitsu/tests/partitioning_test.cpp
+++ b/emulation/rocjitsu/tests/partitioning_test.cpp
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "embedded_schema.h"
+#include "rocjitsu/config/config_loader.h"
+#include "rocjitsu/vm/amdgpu/partitioning.h"
+#include "rocjitsu/vm/rj_vm.h"
+#include "rocjitsu/vm/rj_vm_impl.h"
+#include "rocjitsu/vm/soc.h"
+
+#include "simdojo/sim/component.h"
+#include "simdojo/sim/simulation.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <fstream>
+#include <iterator>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+const std::string CONFIG_PATH = std::string(CONFIG_DIR) + "/gfx950_cdna4.json";
+const std::string CONFIG_2GPU_PATH = std::string(CONFIG_DIR) + "/gfx950_cdna4_kmd_2gpu.json";
+const std::string CONFIG_1XCD_PATH = std::string(CONFIG_DIR) + "/gfx1100_w7900.json";
+
+std::string config_json_with_num_threads(const std::string &path, uint32_t num_threads) {
+  std::ifstream input(path);
+  if (!input.is_open())
+    throw std::runtime_error("Failed to open config: " + path);
+
+  std::string json((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+  const std::string configured_threads = "\"num_threads\": 1";
+  const auto num_threads_pos = json.find(configured_threads);
+  if (num_threads_pos == std::string::npos)
+    throw std::runtime_error("Config does not have the expected num_threads field: " + path);
+
+  std::string replacement = "\"num_threads\": " + std::to_string(num_threads);
+  json.replace(num_threads_pos, configured_threads.size(), replacement);
+  return json;
+}
+
+struct PartitionedTopology {
+  config::LoadedConfig loaded;
+  SoC *soc = nullptr;
+  simdojo::Component *memory = nullptr;
+  std::unique_ptr<simdojo::SimulationEngine> engine;
+  bool partitioned = false;
+};
+
+PartitionedTopology build_partitioned_topology(uint32_t num_threads) {
+  auto loaded = config::load_config(CONFIG_PATH, rocjitsu::kEmbeddedSchema);
+  auto *soc = loaded.soc();
+  auto *memory = loaded.memory();
+  loaded.engine_config.num_threads = num_threads;
+
+  auto engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
+  engine->topology().set_root(loaded.take_root());
+  loaded.wire_links(engine->topology());
+  bool partitioned = amdgpu::partition_topology_by_xcds(engine->topology(), soc, num_threads);
+  engine->create();
+
+  return {std::move(loaded), soc, memory, std::move(engine), partitioned};
+}
+
+void expect_subtree_partition(simdojo::Component *component, simdojo::PartitionID expected) {
+  ASSERT_NE(component, nullptr);
+  EXPECT_EQ(component->partition_id(), expected) << component->full_path();
+
+  auto *composite = dynamic_cast<simdojo::CompositeComponent *>(component);
+  if (!composite)
+    return;
+
+  for (const auto &child : composite->children())
+    expect_subtree_partition(child.get(), expected);
+}
+
+TEST(XcdPartitioningTest, EightThreadsMapsEachCdna4XcdToItsOwnPartition) {
+  auto topology = build_partitioned_topology(8);
+
+  ASSERT_TRUE(topology.partitioned);
+  ASSERT_EQ(topology.engine->topology().partitions().size(), 8u);
+  ASSERT_EQ(topology.soc->num_xcds(), 8u);
+
+  for (uint32_t i = 0; i < topology.soc->num_xcds(); ++i)
+    expect_subtree_partition(topology.soc->xcd(i), i);
+}
+
+TEST(XcdPartitioningTest, FourThreadsDistributesCdna4XcdsRoundRobinWithoutSplits) {
+  auto topology = build_partitioned_topology(4);
+
+  ASSERT_TRUE(topology.partitioned);
+  ASSERT_EQ(topology.engine->topology().partitions().size(), 4u);
+  ASSERT_EQ(topology.soc->num_xcds(), 8u);
+
+  for (uint32_t i = 0; i < topology.soc->num_xcds(); ++i)
+    expect_subtree_partition(topology.soc->xcd(i), i % 4);
+}
+
+TEST(XcdPartitioningTest, ZeroPartitionsIsNoopWithoutManualPartitions) {
+  auto loaded = config::load_config(CONFIG_PATH, rocjitsu::kEmbeddedSchema);
+  auto *soc = loaded.soc();
+  simdojo::Topology topology;
+  topology.set_root(loaded.take_root());
+  loaded.wire_links(topology);
+
+  EXPECT_FALSE(amdgpu::partition_topology_by_xcds(topology, soc, 0));
+  EXPECT_TRUE(topology.partitions().empty());
+  EXPECT_EQ(soc->partition_id(), simdojo::INVALID_PARTITION_ID);
+  for (uint32_t i = 0; i < soc->num_xcds(); ++i)
+    EXPECT_EQ(soc->xcd(i)->partition_id(), simdojo::INVALID_PARTITION_ID);
+}
+
+TEST(XcdPartitioningTest, SinglePartitionAssignsAllComponentsToZero) {
+  auto loaded = config::load_config(CONFIG_PATH, rocjitsu::kEmbeddedSchema);
+  auto *soc = loaded.soc();
+  simdojo::Topology topology;
+  topology.set_root(loaded.take_root());
+  loaded.wire_links(topology);
+
+  ASSERT_TRUE(amdgpu::partition_topology_by_xcds(topology, soc, 1));
+  ASSERT_EQ(topology.partitions().size(), 1u);
+  for (auto *component : topology.collect_all_components())
+    EXPECT_EQ(component->partition_id(), 0u) << component->full_path();
+}
+
+TEST(XcdPartitioningTest, ThreeThreadsDistributesCdna4XcdsRoundRobinWithoutSplits) {
+  auto topology = build_partitioned_topology(3);
+
+  ASSERT_TRUE(topology.partitioned);
+  ASSERT_EQ(topology.engine->topology().partitions().size(), 3u);
+  ASSERT_EQ(topology.soc->num_xcds(), 8u);
+
+  for (uint32_t i = 0; i < topology.soc->num_xcds(); ++i)
+    expect_subtree_partition(topology.soc->xcd(i), i % 3);
+}
+
+TEST(XcdPartitioningTest, SpanOverMultipleSocsUsesGlobalXcdIndex) {
+  auto loaded = config::load_config(CONFIG_2GPU_PATH, rocjitsu::kEmbeddedSchema);
+  ASSERT_EQ(loaded.extra_gpu_builds.size(), 1u);
+
+  auto root = std::make_unique<simdojo::CompositeComponent>("system");
+  auto *soc0 = dynamic_cast<SoC *>(root->add_child(loaded.take_root()));
+  auto *soc1 = dynamic_cast<SoC *>(root->add_child(std::move(loaded.extra_gpu_builds[0].root)));
+  ASSERT_NE(soc0, nullptr);
+  ASSERT_NE(soc1, nullptr);
+
+  simdojo::Topology topology;
+  topology.set_root(std::move(root));
+  std::array<SoC *, 2> socs = {soc0, soc1};
+  ASSERT_TRUE(amdgpu::partition_topology_by_xcds(topology, std::span<SoC *>(socs), 3));
+  ASSERT_EQ(topology.partitions().size(), 3u);
+
+  uint32_t global_xcd_index = 0;
+  for (auto *soc : socs) {
+    ASSERT_EQ(soc->num_xcds(), 8u);
+    for (uint32_t i = 0; i < soc->num_xcds(); ++i, ++global_xcd_index)
+      expect_subtree_partition(soc->xcd(i), global_xcd_index % 3);
+  }
+}
+
+TEST(XcdPartitioningTest, NonXcdComponentsStayOnPartitionZero) {
+  auto topology = build_partitioned_topology(8);
+
+  ASSERT_TRUE(topology.partitioned);
+  EXPECT_EQ(topology.soc->partition_id(), 0u);
+  EXPECT_EQ(topology.memory->partition_id(), 0u);
+
+  for (uint32_t i = 0; i < topology.soc->num_iods(); ++i)
+    expect_subtree_partition(topology.soc->iod(i), 0);
+}
+
+TEST(XcdPartitioningTest, VmStepRejectsMultipleEnginePartitions) {
+  auto json = config_json_with_num_threads(CONFIG_PATH, 2);
+
+  rj_vm_t *raw_vm = nullptr;
+  ASSERT_EQ(rj_vm_create_from_string(json.c_str(), RJ_VM_MODE_DEFAULT, &raw_vm),
+            ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(raw_vm, nullptr);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> vm(raw_vm, &rj_vm_destroy);
+
+  int active = 7;
+  EXPECT_EQ(rj_vm_step(vm.get(), &active), ROCJITSU_STATUS_UNSUPPORTED);
+  EXPECT_EQ(active, 7);
+
+  uint64_t ticks_executed = 0;
+  EXPECT_EQ(rj_vm_run(vm.get(), &ticks_executed), ROCJITSU_STATUS_SUCCESS);
+}
+
+TEST(XcdPartitioningTest, CApiClampsZeroThreadsToOne) {
+  auto json = config_json_with_num_threads(CONFIG_1XCD_PATH, 0);
+
+  rj_vm_t *raw_vm = nullptr;
+  ASSERT_EQ(rj_vm_create_from_string(json.c_str(), RJ_VM_MODE_DEFAULT, &raw_vm),
+            ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(raw_vm, nullptr);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> vm(raw_vm, &rj_vm_destroy);
+
+  EXPECT_EQ(vm->engine_config.num_threads, 1u);
+  EXPECT_EQ(rj_vm_run(vm.get(), nullptr), ROCJITSU_STATUS_SUCCESS);
+}
+
+TEST(XcdPartitioningTest, CApiClampsSingleGpuThreadsToXcdCount) {
+  auto json = config_json_with_num_threads(CONFIG_PATH, 64);
+
+  rj_vm_t *raw_vm = nullptr;
+  ASSERT_EQ(rj_vm_create_from_string(json.c_str(), RJ_VM_MODE_DEFAULT, &raw_vm),
+            ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(raw_vm, nullptr);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> vm(raw_vm, &rj_vm_destroy);
+
+  EXPECT_EQ(vm->engine_config.num_threads, 8u);
+  EXPECT_EQ(rj_vm_run(vm.get(), nullptr), ROCJITSU_STATUS_SUCCESS);
+}
+
+TEST(XcdPartitioningTest, CApiClampsMultiGpuThreadsToTotalXcdCountAndRuns) {
+  auto json = config_json_with_num_threads(CONFIG_2GPU_PATH, 64);
+
+  rj_vm_t *raw_vm = nullptr;
+  ASSERT_EQ(rj_vm_create_from_string(json.c_str(), RJ_VM_MODE_DEFAULT, &raw_vm),
+            ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(raw_vm, nullptr);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> vm(raw_vm, &rj_vm_destroy);
+
+  EXPECT_EQ(vm->engine_config.num_threads, 16u);
+  EXPECT_EQ(rj_vm_run(vm.get(), nullptr), ROCJITSU_STATUS_SUCCESS);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/partitioning_test.cpp
+++ b/emulation/rocjitsu/tests/partitioning_test.cpp
@@ -117,6 +117,14 @@ TEST(XcdPartitioningTest, ZeroPartitionsIsNoopWithoutManualPartitions) {
     EXPECT_EQ(soc->xcd(i)->partition_id(), simdojo::INVALID_PARTITION_ID);
 }
 
+TEST(XcdPartitioningTest, NoXcdsIsNoopWithoutManualPartitions) {
+  simdojo::Topology topology;
+
+  EXPECT_FALSE(amdgpu::partition_topology_by_xcds(topology, std::span<SoC *>{}, 1));
+  EXPECT_FALSE(amdgpu::partition_topology_by_xcds(topology, static_cast<SoC *>(nullptr), 1));
+  EXPECT_TRUE(topology.partitions().empty());
+}
+
 TEST(XcdPartitioningTest, SinglePartitionAssignsAllComponentsToZero) {
   auto loaded = config::load_config(CONFIG_PATH, rocjitsu::kEmbeddedSchema);
   auto *soc = loaded.soc();

--- a/emulation/rocjitsu/tests/partitioning_test.cpp
+++ b/emulation/rocjitsu/tests/partitioning_test.cpp
@@ -192,6 +192,28 @@ TEST(XcdPartitioningTest, SpanOverMultipleSocsUsesGlobalXcdIndex) {
   }
 }
 
+TEST(XcdPartitioningTest, RejectsSocOutsideTopologyWithoutChangingPartitionState) {
+  auto loaded = config::load_config(CONFIG_2GPU_PATH, rocjitsu::kEmbeddedSchema);
+  ASSERT_EQ(loaded.extra_gpu_builds.size(), 1u);
+
+  auto *soc0 = loaded.soc();
+  auto *soc1 = dynamic_cast<SoC *>(loaded.extra_gpu_builds[0].root.get());
+  ASSERT_NE(soc0, nullptr);
+  ASSERT_NE(soc1, nullptr);
+
+  simdojo::Topology topology;
+  topology.set_root(loaded.take_root());
+  std::array<SoC *, 2> socs = {soc0, soc1};
+  EXPECT_FALSE(amdgpu::partition_topology_by_xcds(topology, std::span<SoC *>(socs), 16));
+
+  EXPECT_TRUE(topology.partitions().empty());
+  for (SoC *soc : socs) {
+    EXPECT_EQ(soc->partition_id(), simdojo::INVALID_PARTITION_ID);
+    for (uint32_t i = 0; i < soc->num_xcds(); ++i)
+      EXPECT_EQ(soc->xcd(i)->partition_id(), simdojo::INVALID_PARTITION_ID);
+  }
+}
+
 TEST(XcdPartitioningTest, NonXcdComponentsStayOnPartitionZero) {
   auto topology = build_partitioned_topology(8);
 
@@ -251,13 +273,30 @@ TEST(XcdPartitioningTest, CApiClampsSingleGpuThreadsToXcdCount) {
   auto json = config_json_with_num_threads(CONFIG_PATH, 64);
 
   rj_vm_t *raw_vm = nullptr;
-  ASSERT_EQ(rj_vm_create_from_string(json.c_str(), RJ_VM_MODE_DEFAULT, &raw_vm),
-            ROCJITSU_STATUS_SUCCESS);
+  testing::internal::CaptureStderr();
+  const rj_status_t status = rj_vm_create_from_string(json.c_str(), RJ_VM_MODE_DEFAULT, &raw_vm);
+  const std::string warning = testing::internal::GetCapturedStderr();
+  ASSERT_EQ(status, ROCJITSU_STATUS_SUCCESS);
   ASSERT_NE(raw_vm, nullptr);
   std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> vm(raw_vm, &rj_vm_destroy);
 
+  EXPECT_NE(warning.find("num_threads clamped: requested=64, effective=8"), std::string::npos);
   EXPECT_EQ(vm->engine_config.num_threads, 8u);
   EXPECT_EQ(rj_vm_run(vm.get(), nullptr), ROCJITSU_STATUS_SUCCESS);
+}
+
+TEST(XcdPartitioningTest, CApiDoesNotWarnWhenThreadCountIsUnchanged) {
+  auto json = config_json_with_num_threads(CONFIG_1XCD_PATH, 1);
+
+  rj_vm_t *raw_vm = nullptr;
+  testing::internal::CaptureStderr();
+  const rj_status_t status = rj_vm_create_from_string(json.c_str(), RJ_VM_MODE_DEFAULT, &raw_vm);
+  const std::string warning = testing::internal::GetCapturedStderr();
+  ASSERT_EQ(status, ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(raw_vm, nullptr);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> vm(raw_vm, &rj_vm_destroy);
+
+  EXPECT_EQ(warning.find("num_threads clamped"), std::string::npos);
 }
 
 TEST(XcdPartitioningTest, CApiClampsMultiGpuThreadsToTotalXcdCountAndRuns) {

--- a/emulation/rocjitsu/tests/scaling_test.cpp
+++ b/emulation/rocjitsu/tests/scaling_test.cpp
@@ -12,6 +12,7 @@
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/partitioning.h"
 
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
@@ -29,7 +30,6 @@ RJ_DIAGNOSTIC_POP
 #include <iostream>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #ifdef HAS_DEVICE_KERNELS
@@ -77,21 +77,8 @@ double run_kernel(const char *kernel_name, uint32_t N, uint32_t num_threads) {
   engine->topology().set_root(loaded.take_root());
   loaded.wire_links(engine->topology());
 
-  if (num_threads > 1) {
-    std::unordered_map<simdojo::Component *, simdojo::PartitionID> xcd_map;
-    for (uint32_t i = 0; i < soc->num_xcds(); ++i)
-      xcd_map[soc->xcd(i)] = i % num_threads;
-    engine->topology().partition_manual(
-        num_threads, [&](simdojo::Component *c) -> simdojo::PartitionID {
-          for (auto *p = static_cast<simdojo::Component *>(c); p != nullptr;
-               p = static_cast<simdojo::Component *>(p->parent())) {
-            auto it = xcd_map.find(p);
-            if (it != xcd_map.end())
-              return it->second;
-          }
-          return 0;
-        });
-  }
+  if (num_threads > 1 && !amdgpu::partition_topology_by_xcds(engine->topology(), soc, num_threads))
+    return -1;
   engine->create();
 
   memory->load_image(reinterpret_cast<const uint8_t *>(co->image_data()), co->image_size(),

--- a/emulation/rocjitsu/tests/simdojo_sim_test.cpp
+++ b/emulation/rocjitsu/tests/simdojo_sim_test.cpp
@@ -199,6 +199,7 @@ PartitionID partition_by_name_suffix(Component *comp) {
 } // namespace
 
 TEST(TopologyPartitionTest, RepartitionRetainsExternalLinkOwnerOnce) {
+  ProducerComponent external("external", 0, 1, false);
   Topology topology;
   auto root = std::make_unique<CompositeComponent>("root");
   auto consumer = std::make_unique<ConsumerComponent>("consumer");
@@ -206,7 +207,6 @@ TEST(TopologyPartitionTest, RepartitionRetainsExternalLinkOwnerOnce) {
   root->add_child(std::move(consumer));
   topology.set_root(std::move(root));
 
-  ProducerComponent external("external", 0, 1, false);
   topology.add_link(external.out_port(), consumer_ptr->in_port(), 1);
 
   for (int pass = 0; pass < 2; ++pass) {
@@ -220,6 +220,7 @@ TEST(TopologyPartitionTest, RepartitionRetainsExternalLinkOwnerOnce) {
 }
 
 TEST(TopologyPartitionTest, BalancedSinglePartitionIncludesExternalLinkOwner) {
+  ProducerComponent external("external", 0, 1, false);
   Topology topology;
   auto root = std::make_unique<CompositeComponent>("root");
   auto consumer = std::make_unique<ConsumerComponent>("consumer");
@@ -227,7 +228,6 @@ TEST(TopologyPartitionTest, BalancedSinglePartitionIncludesExternalLinkOwner) {
   root->add_child(std::move(consumer));
   topology.set_root(std::move(root));
 
-  ProducerComponent external("external", 0, 1, false);
   topology.add_link(external.out_port(), consumer_ptr->in_port(), 1);
 
   topology.partition_balanced(1);
@@ -240,6 +240,7 @@ TEST(TopologyPartitionTest, BalancedSinglePartitionIncludesExternalLinkOwner) {
 }
 
 TEST(TopologyPartitionTest, BalancedRepartitionRetainsExternalLinkOwnerOnce) {
+  ProducerComponent external("external", 0, 1, false);
   Topology topology;
   auto root = std::make_unique<CompositeComponent>("root");
   auto consumer = std::make_unique<ConsumerComponent>("consumer");
@@ -247,7 +248,6 @@ TEST(TopologyPartitionTest, BalancedRepartitionRetainsExternalLinkOwnerOnce) {
   root->add_child(std::move(consumer));
   topology.set_root(std::move(root));
 
-  ProducerComponent external("external", 0, 1, false);
   topology.add_link(external.out_port(), consumer_ptr->in_port(), 1);
 
   for (int pass = 0; pass < 2; ++pass) {
@@ -336,7 +336,15 @@ TEST(TopologyPartitionTest, EngineRejectsZeroLatencyCrossPartitionLink) {
   engine.topology().add_link(producer_ptr->out_port(), consumer_ptr->in_port(), 0);
   engine.topology().partition_manual(2, partition_by_name_suffix);
 
-  EXPECT_THROW(engine.create(), std::invalid_argument);
+  try {
+    engine.create();
+    FAIL() << "expected invalid cross-partition latency";
+  } catch (const std::invalid_argument &e) {
+    const std::string message = e.what();
+    EXPECT_NE(message.find("root.producer0.out"), std::string::npos);
+    EXPECT_NE(message.find("root.consumer1.in"), std::string::npos);
+    EXPECT_NE(message.find("positive latency"), std::string::npos);
+  }
   EXPECT_FALSE(engine.is_created());
 }
 
@@ -353,7 +361,15 @@ TEST(TopologyPartitionTest, EngineRejectsCrossPartitionQueuedLink) {
   engine.topology().add_queued_link(producer_ptr->out_port(), consumer_ptr->in_port(), 1, 4);
   engine.topology().partition_manual(2, partition_by_name_suffix);
 
-  EXPECT_THROW(engine.create(), std::invalid_argument);
+  try {
+    engine.create();
+    FAIL() << "expected cross-partition QueuedLink rejection";
+  } catch (const std::invalid_argument &e) {
+    const std::string message = e.what();
+    EXPECT_NE(message.find("root.producer0.out"), std::string::npos);
+    EXPECT_NE(message.find("root.consumer1.in"), std::string::npos);
+    EXPECT_NE(message.find("QueuedLink"), std::string::npos);
+  }
   EXPECT_FALSE(engine.is_created());
 }
 

--- a/emulation/rocjitsu/tests/simdojo_sim_test.cpp
+++ b/emulation/rocjitsu/tests/simdojo_sim_test.cpp
@@ -199,6 +199,7 @@ PartitionID partition_by_name_suffix(Component *comp) {
 } // namespace
 
 TEST(TopologyPartitionTest, RepartitionRetainsExternalLinkOwnerOnce) {
+  // Topology borrows external endpoint owners, so external must outlive topology.
   ProducerComponent external("external", 0, 1, false);
   Topology topology;
   auto root = std::make_unique<CompositeComponent>("root");
@@ -220,6 +221,7 @@ TEST(TopologyPartitionTest, RepartitionRetainsExternalLinkOwnerOnce) {
 }
 
 TEST(TopologyPartitionTest, ManualPartitionRunsExternalProducerOnAssignedPartition) {
+  // SimulationEngine borrows external endpoint owners, so external must outlive engine.
   ProducerComponent external("external", 3);
   SimulationEngine engine({.num_threads = 2});
   auto root = std::make_unique<CompositeComponent>("root");
@@ -244,6 +246,7 @@ TEST(TopologyPartitionTest, ManualPartitionRunsExternalProducerOnAssignedPartiti
 }
 
 TEST(TopologyPartitionTest, BalancedSinglePartitionIncludesExternalLinkOwner) {
+  // Topology borrows external endpoint owners, so external must outlive topology.
   ProducerComponent external("external", 0, 1, false);
   Topology topology;
   auto root = std::make_unique<CompositeComponent>("root");
@@ -264,6 +267,7 @@ TEST(TopologyPartitionTest, BalancedSinglePartitionIncludesExternalLinkOwner) {
 }
 
 TEST(TopologyPartitionTest, BalancedRepartitionRetainsExternalLinkOwnerOnce) {
+  // Topology borrows external endpoint owners, so external must outlive topology.
   ProducerComponent external("external", 0, 1, false);
   Topology topology;
   auto root = std::make_unique<CompositeComponent>("root");

--- a/emulation/rocjitsu/tests/simdojo_sim_test.cpp
+++ b/emulation/rocjitsu/tests/simdojo_sim_test.cpp
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -196,6 +197,165 @@ PartitionID partition_by_name_suffix(Component *comp) {
 }
 
 } // namespace
+
+TEST(TopologyPartitionTest, RepartitionRetainsExternalLinkOwnerOnce) {
+  Topology topology;
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto consumer = std::make_unique<ConsumerComponent>("consumer");
+  auto *consumer_ptr = consumer.get();
+  root->add_child(std::move(consumer));
+  topology.set_root(std::move(root));
+
+  ProducerComponent external("external", 0, 1, false);
+  topology.add_link(external.out_port(), consumer_ptr->in_port(), 1);
+
+  for (int pass = 0; pass < 2; ++pass) {
+    SCOPED_TRACE(::testing::Message() << "pass=" << pass);
+    topology.partition_manual(2, [](Component *) { return PartitionID{0}; });
+    EXPECT_EQ(external.partition_id(), 0u);
+    EXPECT_EQ(std::count(topology.partitions()[0].components.begin(),
+                         topology.partitions()[0].components.end(), &external),
+              1);
+  }
+}
+
+TEST(TopologyPartitionTest, BalancedSinglePartitionIncludesExternalLinkOwner) {
+  Topology topology;
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto consumer = std::make_unique<ConsumerComponent>("consumer");
+  auto *consumer_ptr = consumer.get();
+  root->add_child(std::move(consumer));
+  topology.set_root(std::move(root));
+
+  ProducerComponent external("external", 0, 1, false);
+  topology.add_link(external.out_port(), consumer_ptr->in_port(), 1);
+
+  topology.partition_balanced(1);
+
+  ASSERT_EQ(topology.partitions().size(), 1u);
+  EXPECT_EQ(external.partition_id(), 0u);
+  EXPECT_EQ(std::count(topology.partitions()[0].components.begin(),
+                       topology.partitions()[0].components.end(), &external),
+            1);
+}
+
+TEST(TopologyPartitionTest, BalancedRepartitionRetainsExternalLinkOwnerOnce) {
+  Topology topology;
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto consumer = std::make_unique<ConsumerComponent>("consumer");
+  auto *consumer_ptr = consumer.get();
+  root->add_child(std::move(consumer));
+  topology.set_root(std::move(root));
+
+  ProducerComponent external("external", 0, 1, false);
+  topology.add_link(external.out_port(), consumer_ptr->in_port(), 1);
+
+  for (int pass = 0; pass < 2; ++pass) {
+    SCOPED_TRACE(::testing::Message() << "pass=" << pass);
+    topology.partition_balanced(2);
+    ASSERT_EQ(topology.partitions().size(), 2u);
+    EXPECT_LT(external.partition_id(), 2u);
+
+    size_t occurrences = 0;
+    for (const auto &partition : topology.partitions())
+      occurrences +=
+          std::count(partition.components.begin(), partition.components.end(), &external);
+    EXPECT_EQ(occurrences, 1u);
+  }
+}
+
+TEST(TopologyPartitionTest, MultiThreadedEngineRequiresExplicitPolicy) {
+  SimulationEngine engine({.num_threads = 2});
+  auto root = std::make_unique<CompositeComponent>("root");
+  root->add_child(std::make_unique<CounterComponent>("counter0", 0));
+  root->add_child(std::make_unique<CounterComponent>("counter1", 0));
+  engine.topology().set_root(std::move(root));
+
+  EXPECT_THROW(engine.create(), std::invalid_argument);
+}
+
+TEST(TopologyPartitionTest, RejectsZeroPartitionCount) {
+  Topology topology;
+
+  EXPECT_THROW(topology.partition_balanced(0), std::invalid_argument);
+  EXPECT_TRUE(topology.partitions().empty());
+
+  EXPECT_THROW(topology.partition_manual(0, [](Component *) { return PartitionID{0}; }),
+               std::invalid_argument);
+  EXPECT_TRUE(topology.partitions().empty());
+}
+
+TEST(TopologyPartitionTest, OutOfRangeManualAssignmentLeavesExistingStateIntact) {
+  Topology topology;
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto *counter0 = root->add_child(std::make_unique<CounterComponent>("counter0", 0));
+  auto *counter1 = root->add_child(std::make_unique<CounterComponent>("counter1", 0));
+  topology.set_root(std::move(root));
+  topology.partition_manual(1, [](Component *) { return PartitionID{0}; });
+
+  ASSERT_EQ(topology.partitions().size(), 1u);
+  ASSERT_EQ(counter0->partition_id(), 0u);
+  ASSERT_EQ(counter1->partition_id(), 0u);
+
+  EXPECT_THROW(topology.partition_manual(2, [](Component *) { return PartitionID{2}; }),
+               std::invalid_argument);
+  EXPECT_EQ(topology.partitions().size(), 1u);
+  EXPECT_EQ(counter0->partition_id(), 0u);
+  EXPECT_EQ(counter1->partition_id(), 0u);
+}
+
+TEST(TopologyPartitionTest, EngineRejectsZeroWorkerThreads) {
+  SimulationEngine engine({.num_threads = 0});
+
+  EXPECT_THROW(engine.create(), std::invalid_argument);
+  EXPECT_FALSE(engine.is_created());
+  EXPECT_TRUE(engine.topology().partitions().empty());
+}
+
+TEST(TopologyPartitionTest, EngineRejectsPartitionCountMismatch) {
+  SimulationEngine engine({.num_threads = 2});
+  auto root = std::make_unique<CompositeComponent>("root");
+  root->add_child(std::make_unique<CounterComponent>("counter0", 0));
+  engine.topology().set_root(std::move(root));
+  engine.topology().partition_manual(1, [](Component *) { return PartitionID{0}; });
+
+  EXPECT_THROW(engine.create(), std::invalid_argument);
+  EXPECT_FALSE(engine.is_created());
+}
+
+TEST(TopologyPartitionTest, EngineRejectsZeroLatencyCrossPartitionLink) {
+  SimulationEngine engine({.num_threads = 2});
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto producer = std::make_unique<ProducerComponent>("producer0", 0, 1, false);
+  auto consumer = std::make_unique<ConsumerComponent>("consumer1");
+  auto *producer_ptr = producer.get();
+  auto *consumer_ptr = consumer.get();
+  root->add_child(std::move(producer));
+  root->add_child(std::move(consumer));
+  engine.topology().set_root(std::move(root));
+  engine.topology().add_link(producer_ptr->out_port(), consumer_ptr->in_port(), 0);
+  engine.topology().partition_manual(2, partition_by_name_suffix);
+
+  EXPECT_THROW(engine.create(), std::invalid_argument);
+  EXPECT_FALSE(engine.is_created());
+}
+
+TEST(TopologyPartitionTest, EngineRejectsCrossPartitionQueuedLink) {
+  SimulationEngine engine({.num_threads = 2});
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto producer = std::make_unique<ProducerComponent>("producer0", 0, 1, false);
+  auto consumer = std::make_unique<ConsumerComponent>("consumer1");
+  auto *producer_ptr = producer.get();
+  auto *consumer_ptr = consumer.get();
+  root->add_child(std::move(producer));
+  root->add_child(std::move(consumer));
+  engine.topology().set_root(std::move(root));
+  engine.topology().add_queued_link(producer_ptr->out_port(), consumer_ptr->in_port(), 1, 4);
+  engine.topology().partition_manual(2, partition_by_name_suffix);
+
+  EXPECT_THROW(engine.create(), std::invalid_argument);
+  EXPECT_FALSE(engine.is_created());
+}
 
 // ============================================================================
 // Area 5: PacingController Unit Tests
@@ -470,6 +630,7 @@ TEST(TerminationTest, RequestExitWakesAllPartitions) {
   for (int i = 0; i < 4; ++i)
     root->add_child(std::make_unique<InfiniteComponent>("inf" + std::to_string(i)));
   engine.topology().set_root(std::move(root));
+  engine.topology().partition_balanced(4);
   engine.create();
 
   ExitStatus exit_status;
@@ -706,6 +867,7 @@ TEST(StressTest, AsyncInjectionDuringActiveSimulation) {
   root->add_child(std::make_unique<InfiniteComponent>("inf0"));
   root->add_child(std::make_unique<InfiniteComponent>("inf1"));
   engine.topology().set_root(std::move(root));
+  engine.topology().partition_balanced(2);
   engine.create();
 
   std::atomic<uint32_t> async_processed{0};

--- a/emulation/rocjitsu/tests/simdojo_sim_test.cpp
+++ b/emulation/rocjitsu/tests/simdojo_sim_test.cpp
@@ -219,6 +219,30 @@ TEST(TopologyPartitionTest, RepartitionRetainsExternalLinkOwnerOnce) {
   }
 }
 
+TEST(TopologyPartitionTest, ManualPartitionRunsExternalProducerOnAssignedPartition) {
+  ProducerComponent external("external", 3);
+  SimulationEngine engine({.num_threads = 2});
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto consumer_component = std::make_unique<ConsumerComponent>("consumer");
+  auto *consumer = consumer_component.get();
+  root->add_child(std::move(consumer_component));
+  engine.topology().set_root(std::move(root));
+  engine.topology().add_link(external.out_port(), consumer->in_port(), 0);
+
+  engine.topology().partition_manual(2, [](Component *) { return PartitionID{1}; });
+
+  ASSERT_EQ(external.partition_id(), 1u);
+  ASSERT_EQ(consumer->partition_id(), 1u);
+  engine.create();
+  auto exit = engine.run();
+
+  EXPECT_EQ(exit.reason, ExitReason::COMPLETED);
+  EXPECT_EQ(external.sent_, 3u);
+  ASSERT_EQ(consumer->received.size(), 3u);
+  for (size_t i = 0; i < consumer->received.size(); ++i)
+    EXPECT_EQ(consumer->received[i].second, i);
+}
+
 TEST(TopologyPartitionTest, BalancedSinglePartitionIncludesExternalLinkOwner) {
   ProducerComponent external("external", 0, 1, false);
   Topology topology;

--- a/emulation/rocjitsu/tests/vector_add_test.cpp
+++ b/emulation/rocjitsu/tests/vector_add_test.cpp
@@ -17,6 +17,7 @@
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/partitioning.h"
 
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
@@ -36,7 +37,6 @@ RJ_DIAGNOSTIC_POP
 #include <cstring>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #ifdef HAS_DEVICE_KERNELS
@@ -156,20 +156,7 @@ TEST(VectorAddStressTest, AllCUsGoldenReference_MultiThreaded) {
   engine->topology().set_root(loaded.take_root());
   loaded.wire_links(engine->topology());
 
-  // Partition by XCD so each XCD's components stay on one thread.
-  std::unordered_map<simdojo::Component *, simdojo::PartitionID> xcd_map;
-  for (uint32_t i = 0; i < soc->num_xcds(); ++i)
-    xcd_map[soc->xcd(i)] = i;
-  engine->topology().partition_manual(
-      TOTAL_XCDS, [&](simdojo::Component *c) -> simdojo::PartitionID {
-        for (auto *p = static_cast<simdojo::Component *>(c); p != nullptr;
-             p = static_cast<simdojo::Component *>(p->parent())) {
-          auto it = xcd_map.find(p);
-          if (it != xcd_map.end())
-            return it->second;
-        }
-        return 0;
-      });
+  ASSERT_TRUE(amdgpu::partition_topology_by_xcds(engine->topology(), soc, TOTAL_XCDS));
   engine->create();
 
   co->load_to_memory(memory, KD_ADDR);


### PR DESCRIPTION
# feat(rocjitsu): partition execution across XCDs

ISSUE ID: #6447

## Summary

Partition simulation topology along complete XCD ownership boundaries while
preserving the existing single-partition behavior.

- Clamp requested engine partitions to the number of XCDs visible to the VM.
- Assign complete XCD subtrees round-robin across single- and multi-GPU VMs.
- Keep topology components outside XCD subtrees on partition zero.
- Keep the generic FM partitioner as explicit opt-in `partition_balanced()`;
  multi-threaded engines must choose a partition policy before `create()`.
- Return `ROCJITSU_STATUS_UNSUPPORTED` when `rj_vm_step()` is used with
  multiple engine partitions; `rj_vm_run()` remains the parallel path.
- Document the threading and public API constraints.

The independent checkpoint restore fix was split into #9370.

## Safety constraints

- A single XCD subtree is never split across engine partitions.
- CUs sharing an XCD-local L2 cache remain on the same engine thread.
- External link owners used by manual topologies are retained once on
  partition zero.

## Validation

- Rebased as one commit onto current `origin/develop`
  (`5d3ca048215e6d15106581827ad16a46ba621fe9`).
- Built `rocjitsu_tests` and `scaling_test` in Release mode.
- Passed 21 focused C API, XCD partitioning, explicit-policy, termination,
  stress, and multithreaded workload tests.
- Completed the full 1–8 thread `scaling_test` sweep.
- Passed the full branch-diff pre-commit sweep.
