### PR TITLE
refactor(amdsmi): [AILITOOLS-270] Major version deprecation APIs

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -65,6 +65,11 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - New enum: `amdsmi_compute_partition_mem_alloc_mode_t` (`AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING`, `AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL`).
   - Reads/writes sysfs: `/sys/class/drm/cardN/device/compute_partition_mem_alloc_mode`.
 
+- **Added accelerator partition memory allocation mode API**.  
+  - New APIs: `amdsmi_get_gpu_accelerator_partition_mem_alloc_mode()`, `amdsmi_set_gpu_accelerator_partition_mem_alloc_mode()`.
+  - New enum: `amdsmi_accelerator_partition_mem_alloc_mode_t` (`AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING`, `AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL`).
+  - Supersedes the equivalent `compute_partition` memory allocation mode APIs, which are now deprecated.
+
 - **Added `AMDSMI_LINK_TYPE_NUMA` and `AMDSMI_LINK_TYPE_XNUMA` to `amdsmi_link_type_t`**.  
   - Represent NIC-to-GPU links that cross different PCIe switches on the same CPU (NUMA) or across CPUs (XNUMA).
 
@@ -86,6 +91,13 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 - **Deprecated `amdsmi_get_gpu_vram_vendor()` in favor of `amdsmi_get_gpu_vram_info()`**.  
   - `amdsmi_get_gpu_vram_vendor` is slated for removal in a future ROCm release. It now emits a `DeprecationWarning` from the Python interface and functions as a wrapper of `amdsmi_get_gpu_vram_info()`.
+
+- **Deprecated the `compute_partition` APIs in favor of `accelerator_partition` equivalents**.  
+  - `amdsmi_get_gpu_compute_partition()`, `amdsmi_set_gpu_compute_partition()`, `amdsmi_get_gpu_compute_partition_mem_alloc_mode()`, and `amdsmi_set_gpu_compute_partition_mem_alloc_mode()` are slated for removal in a future ROCm release. They now emit a `DeprecationWarning` from the Python interface and delegate to their `accelerator_partition` counterparts.
+  - The `amdsmi_compute_partition_type_t` and `amdsmi_compute_partition_mem_alloc_mode_t` enums are deprecated in favor of `amdsmi_accelerator_partition_type_t` and `amdsmi_accelerator_partition_mem_alloc_mode_t`.
+
+- **Deprecated `amdsmi_set_gpu_memory_partition()` in favor of `amdsmi_set_gpu_memory_partition_mode()`**.  
+  - `amdsmi_set_gpu_memory_partition` is slated for removal in a future ROCm release. It now emits a `DeprecationWarning` from the Python interface and functions as a wrapper of `amdsmi_set_gpu_memory_partition_mode()`.
 
 - **Renamed "AINIC version" to "ionic version" in `amd-smi version` output**.  
   - The label now correctly reflects that it shows the ionic kernel driver version.

--- a/projects/amdsmi/amdsmi_cli/subcommands/set_value.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/set_value.py
@@ -1254,7 +1254,9 @@ class SetValueCommands:
                     memory_partition = amdsmi_interface.AmdSmiMemoryPartitionType[
                         args.memory_partition
                     ]
-                    amdsmi_interface.amdsmi_set_gpu_memory_partition(args.gpu, memory_partition)
+                    amdsmi_interface.amdsmi_set_gpu_memory_partition_mode(
+                        args.gpu, memory_partition
+                    )
                     out = f"Successfully set memory partition to {args.memory_partition}, use `sudo modprobe -r amdgpu && sudo modprobe amdgpu` to reload driver"
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     out = f"[{e.get_error_info(detailed=False)}] Unable to set memory partition to {args.memory_partition}"
@@ -1805,34 +1807,34 @@ class SetValueCommands:
 
         if getattr(args, "compute_partition_mem_alloc_mode", None):
             try:
-                mode = amdsmi_interface.AmdSmiComputePartitionMemAllocModeType[
+                mode = amdsmi_interface.AmdSmiAcceleratorPartitionMemAllocModeType[
                     args.compute_partition_mem_alloc_mode
                 ]
-                amdsmi_interface.amdsmi_set_gpu_compute_partition_mem_alloc_mode(args.gpu, mode)
-                out = f"Successfully set compute partition memory allocation mode to {args.compute_partition_mem_alloc_mode}"
+                amdsmi_interface.amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(args.gpu, mode)
+                out = f"Successfully set accelerator partition memory allocation mode to {args.compute_partition_mem_alloc_mode}"
             except KeyError:
                 out = (
-                    "Invalid compute partition memory allocation mode "
+                    "Invalid accelerator partition memory allocation mode "
                     f"{args.compute_partition_mem_alloc_mode}"
                 )
-                self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
+                self.logger.store_output(args.gpu, "accelerator_partition_mem_alloc_mode", out)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
                 return
             except amdsmi_exception.AmdSmiLibraryException as e:
-                out = f"[{e.get_error_info(detailed=False)}] Unable to set compute partition memory allocation mode to {args.compute_partition_mem_alloc_mode}"
+                out = f"[{e.get_error_info(detailed=False)}] Unable to set accelerator partition memory allocation mode to {args.compute_partition_mem_alloc_mode}"
                 if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
                     out = "[AMDSMI_STATUS_NO_PERM] Command requires elevation"
-                    self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
+                    self.logger.store_output(args.gpu, "accelerator_partition_mem_alloc_mode", out)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
                     raise PermissionError("Command requires elevation") from e
                 else:
-                    self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
+                    self.logger.store_output(args.gpu, "accelerator_partition_mem_alloc_mode", out)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
                     return
-            self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
+            self.logger.store_output(args.gpu, "accelerator_partition_mem_alloc_mode", out)
             self.logger.print_output()
             self.logger.clear_multiple_devices_output()
             return

--- a/projects/amdsmi/amdsmi_cli/subcommands/static.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/static.py
@@ -836,13 +836,13 @@ class StaticCommands:
                     e.get_error_info(),
                 )
             try:
-                mem_alloc_mode = amdsmi_interface.amdsmi_get_gpu_compute_partition_mem_alloc_mode(
-                    args.gpu
+                mem_alloc_mode = (
+                    amdsmi_interface.amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(args.gpu)
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
                 mem_alloc_mode = "N/A"
                 logging.debug(
-                    "Failed to get compute partition mem alloc mode for gpu %s | %s",
+                    "Failed to get accelerator partition mem alloc mode for gpu %s | %s",
                     gpu_id,
                     e.get_error_info(),
                 )

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -5640,7 +5640,7 @@ finally:
     amdsmi.amdsmi_shut_down()
 ```
 
-### amdsmi_get_gpu_compute_partition_mem_alloc_mode
+### amdsmi_get_gpu_accelerator_partition_mem_alloc_mode
 
 Description: Get the compute partition memory allocation mode from the given GPU. Controls how HBM capacity is distributed across XCPs within each memory partition.
 
@@ -5650,7 +5650,7 @@ Input parameters:
 
 Output: String of the memory allocation mode (`"CAPPING"` or `"ALL"`)
 
-Exceptions that can be thrown by `amdsmi_get_gpu_compute_partition_mem_alloc_mode` function:
+Exceptions that can be thrown by `amdsmi_get_gpu_accelerator_partition_mem_alloc_mode` function:
 
 * `AmdSmiLibraryException`
 * `AmdSmiParameterException`
@@ -5674,7 +5674,7 @@ try:
         print("No GPUs on machine")
     else:
         for device in devices:
-            mode = amdsmi.amdsmi_get_gpu_compute_partition_mem_alloc_mode(device)
+            mode = amdsmi.amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(device)
             print(mode)
 except amdsmi.AmdSmiException as e:
     print(e)
@@ -5682,7 +5682,7 @@ finally:
     amdsmi.amdsmi_shut_down()
 ```
 
-### amdsmi_set_gpu_compute_partition_mem_alloc_mode
+### amdsmi_set_gpu_accelerator_partition_mem_alloc_mode
 
 Description: Set the compute partition memory allocation mode for the given GPU. Requires elevated privileges (sudo). Controls whether each XCP is capped to an even share of memory (`CAPPING`) or may use the full partition memory (`ALL`).
 
@@ -5693,7 +5693,7 @@ Input parameters:
 
 Output: None
 
-Exceptions that can be thrown by `amdsmi_set_gpu_compute_partition_mem_alloc_mode` function:
+Exceptions that can be thrown by `amdsmi_set_gpu_accelerator_partition_mem_alloc_mode` function:
 
 * `AmdSmiLibraryException`
 * `AmdSmiParameterException`
@@ -5717,7 +5717,7 @@ try:
         print("No GPUs on machine")
     else:
         for device in devices:
-            amdsmi.amdsmi_set_gpu_compute_partition_mem_alloc_mode(
+            amdsmi.amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(
                 device, amdsmi.AmdSmiComputePartitionMemAllocModeType.CAPPING
             )
 except amdsmi.AmdSmiException as e:
@@ -5804,48 +5804,6 @@ try:
         for device in devices:
             memory_partition_type = amdsmi.amdsmi_get_gpu_memory_partition(device)
             print(memory_partition_type)
-except amdsmi.AmdSmiException as e:
-    print(e)
-finally:
-    amdsmi.amdsmi_shut_down()
-```
-
-### amdsmi_set_gpu_memory_partition
-
-Description: Set the memory partition to the given GPU. This function does not allow any concurrent operations. Devices must be idle and have no workloads when performing set partition operations.
-
-Input parameters:
-
-* `processor_handle` the device handle
-* `memory_partition` the type of memory_partition to set
-
-Output: `None`
-
-Exceptions that can be thrown by `amdsmi_set_gpu_memory_partition` function:
-
-* `AmdSmiLibraryException`
-* `AmdSmiParameterException`
-
-#### Possible Library Exceptions
-
-- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
-- `AMDSMI_STATUS_INVAL` - Invalid parameters
-- `AMDSMI_STATUS_NO_PERM` - Permission Denied
-- `AMDSMI_STATUS_BUSY` - Device is busy, could not acquire resource or mutex
-
-Example:
-
-```python
-import amdsmi
-try:
-    amdsmi.amdsmi_init()
-    memory_partition = amdsmi.AmdSmiMemoryPartitionType.NPS1
-    devices = amdsmi.amdsmi_get_processor_handles()
-    if len(devices) == 0:
-        print("No GPUs on machine")
-    else:
-        for device in devices:
-            amdsmi.amdsmi_set_gpu_memory_partition(device, memory_partition)
 except amdsmi.AmdSmiException as e:
     print(e)
 finally:

--- a/projects/amdsmi/example/amd_smi_drm_example.cc
+++ b/projects/amdsmi/example/amd_smi_drm_example.cc
@@ -370,28 +370,28 @@ static void print_apu_metrics_info(const amdsmi_gpu_metrics_t& smu) {
 }
 
 static const std::string computePartitionString(
-    amdsmi_compute_partition_type_t computeParitionType) {
+    amdsmi_accelerator_partition_type_t computeParitionType) {
   switch (computeParitionType) {
-    case AMDSMI_COMPUTE_PARTITION_SPX:
+    case AMDSMI_ACCELERATOR_PARTITION_SPX:
       return "SPX";
-    case AMDSMI_COMPUTE_PARTITION_DPX:
+    case AMDSMI_ACCELERATOR_PARTITION_DPX:
       return "DPX";
-    case AMDSMI_COMPUTE_PARTITION_TPX:
+    case AMDSMI_ACCELERATOR_PARTITION_TPX:
       return "TPX";
-    case AMDSMI_COMPUTE_PARTITION_QPX:
+    case AMDSMI_ACCELERATOR_PARTITION_QPX:
       return "QPX";
-    case AMDSMI_COMPUTE_PARTITION_CPX:
+    case AMDSMI_ACCELERATOR_PARTITION_CPX:
       return "CPX";
     default:
       return "N/A";
   }
 }
 
-static const std::map<std::string, amdsmi_compute_partition_type_t>
+static const std::map<std::string, amdsmi_accelerator_partition_type_t>
     mapStringToSMIComputePartitionTypes{
-        {"SPX", AMDSMI_COMPUTE_PARTITION_SPX}, {"DPX", AMDSMI_COMPUTE_PARTITION_DPX},
-        {"TPX", AMDSMI_COMPUTE_PARTITION_TPX}, {"QPX", AMDSMI_COMPUTE_PARTITION_QPX},
-        {"CPX", AMDSMI_COMPUTE_PARTITION_CPX}, {"N/A", AMDSMI_COMPUTE_PARTITION_INVALID}};
+        {"SPX", AMDSMI_ACCELERATOR_PARTITION_SPX}, {"DPX", AMDSMI_ACCELERATOR_PARTITION_DPX},
+        {"TPX", AMDSMI_ACCELERATOR_PARTITION_TPX}, {"QPX", AMDSMI_ACCELERATOR_PARTITION_QPX},
+        {"CPX", AMDSMI_ACCELERATOR_PARTITION_CPX}, {"N/A", AMDSMI_ACCELERATOR_PARTITION_INVALID}};
 
 static const std::string memoryPartitionString(amdsmi_memory_partition_type_t memoryParitionType) {
   switch (memoryParitionType) {
@@ -442,7 +442,7 @@ static const std::map<amdsmi_link_type_t, std::string> link_type_map = {
 
 int main() {
   amdsmi_status_t ret;
-  std::vector<amdsmi_compute_partition_type_t> orig_accelerator_partitions;
+  std::vector<amdsmi_accelerator_partition_type_t> orig_accelerator_partitions;
   std::vector<amdsmi_memory_partition_type_t> orig_memory_partitions;
   uint32_t gpu_number = 0;
 
@@ -467,16 +467,16 @@ int main() {
   std::cout << "Total Socket: " << socket_count << std::endl;
 
   // WARNING: Do not put any other settings before/inside/or between these lambda functions
-  //           Required to save/change/reset the compute/accelerator & memory partition settings
+  //           Required to save/change/reset the accelerator & memory partition settings
   // Reason: Modifies total number of gpu count, which will affect other API calls.
   //         Requires amdsmi_shut_down()/amdsmi_init(AMDSMI_INIT_AMD_GPUS) to re-enumerate
   //         total number of GPUs (AKA "processors per socket").
-  //         Changing back to original settings (compute/accelerator & memory partition)
+  //         Changing back to original settings (accelerator & memory partition)
   //         will not modify the GPU count.
   // Save all original partition settings for later
   auto save_original_partitions =
       [socket_count, &ret, sockets](
-          std::vector<amdsmi_compute_partition_type_t>& orig_partitions,
+          std::vector<amdsmi_accelerator_partition_type_t>& orig_partitions,
           std::vector<amdsmi_memory_partition_type_t>& orig_memory_partitions,
           uint32_t& gpu_number) -> void {
     std::cout << "    **Saving Original Compute/Accelerator & Memory Partition Settings**\n";
@@ -525,8 +525,8 @@ int main() {
           std::cout << "\tCompute Partition (original): " << original_compute_partition << "\n\n";
         } else {
           std::cout << "\tamdsmi_get_gpu_compute_partition(" << gpu_number << ", "
-                    << computePartitionString(AMDSMI_COMPUTE_PARTITION_INVALID) << "): " << err_str
-                    << "\n\n";
+                    << computePartitionString(AMDSMI_ACCELERATOR_PARTITION_INVALID)
+                    << "): " << err_str << "\n\n";
         }
 
         // Save the original compute/accelerator partition
@@ -534,7 +534,7 @@ int main() {
           orig_partitions.push_back(
               mapStringToSMIComputePartitionTypes.at(original_compute_partition));
         } else {
-          orig_partitions.push_back(AMDSMI_COMPUTE_PARTITION_INVALID);
+          orig_partitions.push_back(AMDSMI_ACCELERATOR_PARTITION_INVALID);
         }
 
         // Get the original memory partition
@@ -621,15 +621,15 @@ int main() {
           std::cout << "\tCompute Partition (original): " << original_compute_partition << "\n\n";
         } else {
           std::cout << "\tamdsmi_get_gpu_compute_partition(" << gpu_number << ", "
-                    << computePartitionString(AMDSMI_COMPUTE_PARTITION_INVALID) << "): " << err_str
-                    << "\n\n";
+                    << computePartitionString(AMDSMI_ACCELERATOR_PARTITION_INVALID)
+                    << "): " << err_str << "\n\n";
         }
 
         // Iterate through all compute partitions
-        for (int partition = static_cast<int>(AMDSMI_COMPUTE_PARTITION_SPX);
-             partition <= static_cast<int>(AMDSMI_COMPUTE_PARTITION_CPX); partition++) {
-          amdsmi_compute_partition_type_t updatePartition =
-              static_cast<amdsmi_compute_partition_type_t>(partition);
+        for (int partition = static_cast<int>(AMDSMI_ACCELERATOR_PARTITION_SPX);
+             partition <= static_cast<int>(AMDSMI_ACCELERATOR_PARTITION_CPX); partition++) {
+          amdsmi_accelerator_partition_type_t updatePartition =
+              static_cast<amdsmi_accelerator_partition_type_t>(partition);
           amdsmi_status_t ret_set =
               amdsmi_set_gpu_compute_partition(processor_handles[device_index], updatePartition);
           amdsmi_status_code_to_string(ret_set, &err_str);
@@ -639,21 +639,21 @@ int main() {
           std::cout << "\tamdsmi_set_gpu_compute_partition(" << gpu_number << ", "
                     << computePartitionString(updatePartition) << "): " << err_str << "\n\n";
 
-          // Get the current compute partition
+          // Get the current accelerator partition
           char current_compute_partition[AMDSMI_MAX_STRING_LENGTH];
-          ret = amdsmi_get_gpu_compute_partition(processor_handles[device_index],
-                                                 current_compute_partition,
-                                                 static_cast<uint32_t>(AMDSMI_MAX_STRING_LENGTH));
+          ret = amdsmi_get_gpu_accelerator_partition(
+              processor_handles[device_index], current_compute_partition,
+              static_cast<uint32_t>(AMDSMI_MAX_STRING_LENGTH));
           amdsmi_status_code_to_string(ret, &err_str);
           if (ret == AMDSMI_STATUS_SUCCESS) {
             PRINT_AMDSMI_RET(ret)
-            std::cout << "    Output of amdsmi_get_gpu_compute_partition:\n";
-            std::cout << "\tamdsmi_get_gpu_compute_partition(" << gpu_number << ", "
+            std::cout << "    Output of amdsmi_get_gpu_accelerator_partition:\n";
+            std::cout << "\tamdsmi_get_gpu_accelerator_partition(" << gpu_number << ", "
                       << computePartitionString(updatePartition) << "): " << err_str << "\n\n";
             std::cout << "\tCompute Partition (current): " << current_compute_partition << "\n\n";
           } else {
-            std::cout << "\tamdsmi_get_gpu_compute_partition(" << gpu_number << ", "
-                      << computePartitionString(AMDSMI_COMPUTE_PARTITION_INVALID)
+            std::cout << "\tamdsmi_get_gpu_accelerator_partition(" << gpu_number << ", "
+                      << computePartitionString(AMDSMI_ACCELERATOR_PARTITION_INVALID)
                       << "): " << err_str << "\n\n";
           }
         }
@@ -732,14 +732,14 @@ int main() {
             }
             amdsmi_memory_partition_type_t updatePartition =
                 static_cast<amdsmi_memory_partition_type_t>(partition);
-            auto ret_set =
-                amdsmi_set_gpu_memory_partition(processor_handles[device_index], updatePartition);
+            auto ret_set = amdsmi_set_gpu_memory_partition_mode(processor_handles[device_index],
+                                                                updatePartition);
             amdsmi_status_code_to_string(ret_set, &err_str);
             if (ret_set == AMDSMI_STATUS_SUCCESS) {
               PRINT_AMDSMI_RET(ret_set)
-              std::cout << "    Output of amdsmi_set_gpu_memory_partition:\n";
+              std::cout << "    Output of amdsmi_set_gpu_memory_partition_mode:\n";
             }
-            std::cout << "\tamdsmi_set_gpu_memory_partition(" << gpu_number << ", "
+            std::cout << "\tamdsmi_set_gpu_memory_partition_mode(" << gpu_number << ", "
                       << memoryPartitionString(updatePartition) << "): " << err_str << "\n\n";
 
             // Reload only if the memory partition was set successfully
@@ -832,14 +832,14 @@ int main() {
         // Reset to original memory partition settings
         amdsmi_memory_partition_type_t orig_partition = orig_partitions[gpu_number];
         amdsmi_status_t ret_set =
-            amdsmi_set_gpu_memory_partition(processor_handles[device_index], orig_partition);
+            amdsmi_set_gpu_memory_partition_mode(processor_handles[device_index], orig_partition);
         const char* err_str;
         amdsmi_status_code_to_string(ret_set, &err_str);
         if (ret_set == AMDSMI_STATUS_SUCCESS) {
           PRINT_AMDSMI_RET(ret_set)
-          std::cout << "    Output of amdsmi_set_gpu_memory_partition:\n";
+          std::cout << "    Output of amdsmi_set_gpu_memory_partition_mode:\n";
         }
-        std::cout << "\tamdsmi_set_gpu_memory_partition(" << gpu_number << ", "
+        std::cout << "\tamdsmi_set_gpu_memory_partition_mode(" << gpu_number << ", "
                   << memoryPartitionString(orig_partition) << "): " << err_str << "\n\n";
         // Reload only if the memory partition was set successfully
         if (ret_set == AMDSMI_STATUS_SUCCESS) {
@@ -882,7 +882,7 @@ int main() {
 
   auto reset_accelerator_partitions =
       [socket_count, &ret, sockets](
-          const std::vector<amdsmi_compute_partition_type_t>& orig_partitions,
+          const std::vector<amdsmi_accelerator_partition_type_t>& orig_partitions,
           uint32_t& gpu_number) -> void {
     std::cout << "    **Version 1: Memory Partition API Examples**\n";
     std::cout << "    **Resetting Compute/Accelerator Partition Settings**\n";
@@ -915,7 +915,7 @@ int main() {
         std::cout << "\t**GPU Number: " << gpu_number << std::endl;
 
         // Reset to original compute/accelerator partition settings
-        amdsmi_compute_partition_type_t orig_partition = orig_partitions[gpu_number];
+        amdsmi_accelerator_partition_type_t orig_partition = orig_partitions[gpu_number];
         amdsmi_status_t ret_set =
             amdsmi_set_gpu_compute_partition(processor_handles[device_index], orig_partition);
         const char* err_str;
@@ -941,8 +941,8 @@ int main() {
           std::cout << "\tCompute Partition (current): " << current_compute_partition << "\n\n";
         } else {
           std::cout << "\tamdsmi_get_gpu_compute_partition(" << gpu_number << ", "
-                    << computePartitionString(AMDSMI_COMPUTE_PARTITION_INVALID) << "): " << err_str
-                    << "\n\n";
+                    << computePartitionString(AMDSMI_ACCELERATOR_PARTITION_INVALID)
+                    << "): " << err_str << "\n\n";
         }
         gpu_number++;
       }

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -490,6 +490,9 @@ typedef enum {
  * @brief Compute Partition. This enum is used to identify
  * various compute partitioning settings.
  *
+ * @deprecated This enum is slated for removal in a future ROCm release;
+ * use amdsmi_accelerator_partition_type_t instead
+ *
  * @cond @tag{gpu_bm_linux} @tag{guest_windows} @endcond
  */
 typedef enum {
@@ -510,6 +513,9 @@ typedef enum {
  * @brief Compute Partition Memory Allocation Mode. Controls how GPU memory
  * is allocated across XCPs within a memory partition.
  *
+ * @deprecated This enum is slated for removal in a future ROCm release;
+ * use amdsmi_accelerator_partition_mem_alloc_mode_t instead
+ *
  * @cond @tag{gpu_bm_linux} @endcond
  */
 typedef enum {
@@ -518,6 +524,19 @@ typedef enum {
   AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL           //!< Each XCP in the partition may
                                                    //!< use the full partition memory
 } amdsmi_compute_partition_mem_alloc_mode_t;
+
+/**
+ * @brief Accelerator Partition Memory Allocation Mode. Controls how GPU memory
+ * is allocated across XCPs within a memory partition.
+ *
+ * @cond @tag{gpu_bm_linux} @endcond
+ */
+typedef enum {
+  AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_INVALID = 0,  //!< Invalid mode
+  AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING,      //!< Memory is evenly capped per XCP
+  AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL           //!< Each XCP in the partition may
+                                                       //!< use the full partition memory
+} amdsmi_accelerator_partition_mem_alloc_mode_t;
 
 /**
  * @brief Memory Partitions
@@ -6968,6 +6987,9 @@ amdsmi_status_t amdsmi_set_gpu_compute_partition(amdsmi_processor_handle process
  *  @brief Retrieves the current compute partition memory allocation mode
  *  for a desired device.
  *
+ *  @deprecated This API is slated for removal in a future ROCm release;
+ *  ::amdsmi_get_gpu_accelerator_partition_mem_alloc_mode() should be used instead
+ *
  *  @ingroup tagComputePartition
  *
  *  @platform{gpu_bm_linux}
@@ -6976,9 +6998,9 @@ amdsmi_status_t amdsmi_set_gpu_compute_partition(amdsmi_processor_handle process
  *  @p mode, this function will attempt to obtain the device's current
  *  compute partition memory allocation mode. The mode controls how HBM
  *  capacity is distributed across XCPs within each memory partition:
- *  - ::AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING — each XCP is capped
+ *  - ::AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING — each XCP is capped
  *    to an even share.
- *  - ::AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL — each XCP may use the
+ *  - ::AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL — each XCP may use the
  *    full memory partition size (useful when only one XCP is active).
  *
  *  @param[in] processor_handle Device which to query
@@ -6998,7 +7020,43 @@ amdsmi_status_t amdsmi_get_gpu_compute_partition_mem_alloc_mode(
     amdsmi_processor_handle processor_handle, amdsmi_compute_partition_mem_alloc_mode_t* mode);
 
 /**
+ *  @brief Retrieves the current accelerator partition memory allocation mode
+ *  for a desired device.
+ *
+ *  @ingroup tagComputePartition
+ *
+ *  @platform{gpu_bm_linux}
+ *
+ *  @details Given a processor handle @p processor_handle and a pointer
+ *  @p mode, this function will attempt to obtain the device's current
+ *  accelerator partition memory allocation mode. The mode controls how HBM
+ *  capacity is distributed across XCPs within each memory partition:
+ *  - ::AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING — each XCP is capped
+ *    to an even share.
+ *  - ::AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL — each XCP may use the
+ *    full memory partition size (useful when only one XCP is active).
+ *
+ *  @param[in] processor_handle Device which to query
+ *
+ *  @param[out] mode a pointer to an ::amdsmi_accelerator_partition_mem_alloc_mode_t
+ *  variable, into which the device's current memory allocation mode will
+ *  be written.
+ *
+ *  @retval ::AMDSMI_STATUS_SUCCESS call was successful
+ *  @retval ::AMDSMI_STATUS_INVAL the provided arguments are not valid
+ *  @retval ::AMDSMI_STATUS_UNEXPECTED_DATA data provided to function is not valid
+ *  @retval ::AMDSMI_STATUS_FILE_ERROR problem accessing the sysfs file
+ *  @retval ::AMDSMI_STATUS_NOT_SUPPORTED installed software or hardware does not
+ *  support this function
+ */
+amdsmi_status_t amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(
+    amdsmi_processor_handle processor_handle, amdsmi_accelerator_partition_mem_alloc_mode_t* mode);
+
+/**
  *  @brief Modifies a selected device's compute partition memory allocation mode.
+ *
+ *  @deprecated This API is slated for removal in a future ROCm release;
+ *  ::amdsmi_set_gpu_accelerator_partition_mem_alloc_mode() should be used instead
  *
  *  @ingroup tagComputePartition
  *
@@ -7028,6 +7086,38 @@ amdsmi_status_t amdsmi_get_gpu_compute_partition_mem_alloc_mode(
  */
 amdsmi_status_t amdsmi_set_gpu_compute_partition_mem_alloc_mode(
     amdsmi_processor_handle processor_handle, amdsmi_compute_partition_mem_alloc_mode_t mode);
+
+/**
+ *  @brief Modifies a selected device's compute partition memory allocation mode.
+ *
+ *  @ingroup tagComputePartition
+ *
+ *  @platform{gpu_bm_linux}
+ *
+ *  @details Given a processor handle @p processor_handle and a mode
+ *  @p mode, this function will attempt to update the selected device's
+ *  compute partition memory allocation mode. The mode controls how HBM
+ *  capacity is distributed across XCPs within each memory partition:
+ *  - ::AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING — each XCP is capped
+ *    to an even share. This is the default.
+ *  - ::AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL — each XCP may use the
+ *    full memory partition size.
+ *
+ *  @param[in] processor_handle Device which to modify
+ *
+ *  @param[in] mode using enum ::amdsmi_accelerator_partition_mem_alloc_mode_t,
+ *  define what the selected device's memory allocation mode should be
+ *  updated to.
+ *
+ *  @retval ::AMDSMI_STATUS_SUCCESS call was successful
+ *  @retval ::AMDSMI_STATUS_NO_PERM function requires admin/sudo privileges
+ *  @retval ::AMDSMI_STATUS_INVAL the provided arguments are not valid
+ *  @retval ::AMDSMI_STATUS_FILE_ERROR problem accessing the sysfs file
+ *  @retval ::AMDSMI_STATUS_NOT_SUPPORTED installed software or hardware does not
+ *  support this function
+ */
+amdsmi_status_t amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(
+    amdsmi_processor_handle processor_handle, amdsmi_accelerator_partition_mem_alloc_mode_t mode);
 
 /** @} End tagComputePartition */
 
@@ -7075,6 +7165,9 @@ amdsmi_status_t amdsmi_get_gpu_memory_partition(amdsmi_processor_handle processo
 
 /**
  *  @brief Modifies a selected device's current memory partition setting.
+ *
+ *  @deprecated This API is slated for removal in a future ROCm release;
+ *  ::amdsmi_set_gpu_memory_partition_mode() should be used instead
  *
  *  @ingroup tagMemoryPartition
  *
@@ -7868,13 +7961,13 @@ amdsmi_status_t amdsmi_get_gpu_process_list_by_pid(amdsmi_processor_handle* proc
  *  did not reload properly and the user should check dmesg logs.
  *
  *  This function has been created in order to conveniently reload the
- *  AMD GPU driver once `amdsmi_set_gpu_memory_partition()` or
- *  `amdsmi_set_gpu_memory_partition_mode()` successfully has been changed
+ *  AMD GPU driver once `amdsmi_set_gpu_memory_partition_mode()`
+ *  successfully has been changed
  *  on Baremetal systems. Now users can control the reload once all GPU
  *  processes/workloads have been stopped on the AMD GPU driver.
  *  A (AMD GPU) driver reload is REQUIRED to complete changing
  *  to the new memory partition configuration
- *  (`amdsmi_set_gpu_memory_partition()`/`amdsmi_set_gpu_memory_partition_mode()`)
+ *  (`amdsmi_set_gpu_memory_partition_mode()`)
  *  operation MUST be successful. This function WILL EFFECT all GPUs in the
  *  hive to be reconfigured with the specified memory partition configuration.
  *

--- a/projects/amdsmi/py-interface/__init__.py
+++ b/projects/amdsmi/py-interface/__init__.py
@@ -284,13 +284,15 @@ from .amdsmi_interface import amdsmi_get_gpu_compute_partition
 from .amdsmi_interface import amdsmi_set_gpu_compute_partition
 from .amdsmi_interface import amdsmi_get_gpu_compute_partition_mem_alloc_mode
 from .amdsmi_interface import amdsmi_set_gpu_compute_partition_mem_alloc_mode
+from .amdsmi_interface import amdsmi_get_gpu_accelerator_partition_mem_alloc_mode
+from .amdsmi_interface import amdsmi_set_gpu_accelerator_partition_mem_alloc_mode
 from .amdsmi_interface import amdsmi_get_gpu_memory_partition
 from .amdsmi_interface import amdsmi_set_gpu_memory_partition
+from .amdsmi_interface import amdsmi_set_gpu_memory_partition_mode
 from .amdsmi_interface import amdsmi_get_gpu_accelerator_partition_profile
 from .amdsmi_interface import amdsmi_get_gpu_accelerator_partition_profile_config
 from .amdsmi_interface import amdsmi_get_gpu_memory_partition_config
 from .amdsmi_interface import amdsmi_set_gpu_accelerator_partition_profile
-from .amdsmi_interface import amdsmi_set_gpu_memory_partition_mode
 
 # # Individual GPU Metrics Functions
 from .amdsmi_interface import amdsmi_get_gpu_metrics_header_info
@@ -333,6 +335,7 @@ from .amdsmi_interface import AmdSmiVoltageMetric
 from .amdsmi_interface import AmdSmiVoltageType
 from .amdsmi_interface import AmdSmiComputePartitionType
 from .amdsmi_interface import AmdSmiComputePartitionMemAllocModeType
+from .amdsmi_interface import AmdSmiAcceleratorPartitionMemAllocModeType
 from .amdsmi_interface import AmdSmiMemoryPartitionType
 from .amdsmi_interface import AmdSmiPowerProfilePresetMasks
 from .amdsmi_interface import AmdSmiGpuBlock

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -21,6 +21,7 @@ import ctypes
 import math
 import os
 import re
+import warnings
 from collections.abc import Iterable
 from ctypes import POINTER, c_void_p
 from enum import IntEnum, Enum
@@ -565,6 +566,7 @@ class AmdSmiAcceleratorPartitionType(IntEnum):
     INVALID = amdsmi_wrapper.AMDSMI_ACCELERATOR_PARTITION_INVALID
 
 
+# This class is deprecated, use AmdSmiAcceleratorPartitionType instead
 class AmdSmiComputePartitionType(IntEnum):
     SPX = amdsmi_wrapper.AMDSMI_COMPUTE_PARTITION_SPX
     DPX = amdsmi_wrapper.AMDSMI_COMPUTE_PARTITION_DPX
@@ -574,10 +576,17 @@ class AmdSmiComputePartitionType(IntEnum):
     INVALID = amdsmi_wrapper.AMDSMI_COMPUTE_PARTITION_INVALID
 
 
+# This class is deprecated, use AmdSmiAcceleratorPartitionMemAllocModeType instead
 class AmdSmiComputePartitionMemAllocModeType(IntEnum):
     INVALID = amdsmi_wrapper.AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_INVALID
     CAPPING = amdsmi_wrapper.AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING
     ALL = amdsmi_wrapper.AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL
+
+
+class AmdSmiAcceleratorPartitionMemAllocModeType(IntEnum):
+    INVALID = amdsmi_wrapper.AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_INVALID
+    CAPPING = amdsmi_wrapper.AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING
+    ALL = amdsmi_wrapper.AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL
 
 
 class AmdSmiMemoryPartitionType(IntEnum):
@@ -1180,7 +1189,6 @@ def amdsmi_get_cpusocket_handles() -> List[c_void_p]:
     Returns:
         `List[c_void_p]`: List of CPU socket handles (legacy format).
     """
-    import warnings
 
     warnings.warn(
         "amdsmi_get_cpusocket_handles() is deprecated, use amdsmi_get_cpu_handles() instead",
@@ -2478,7 +2486,6 @@ def amdsmi_get_gpu_device_bdf_bdf(
     Returns the raw amdsmi_bdf_t struct for a GPU. The same data is available as a
     formatted string from amdsmi_get_gpu_device_bdf().
     """
-    import warnings
 
     warnings.warn(
         "amdsmi_get_gpu_device_bdf_bdf() is deprecated, use amdsmi_get_gpu_device_bdf() "
@@ -4100,7 +4107,6 @@ def amdsmi_get_gpu_vram_vendor(processor_handle: processor_handle_t):
 
     This API is slated for removal in a future ROCm release.
     """
-    import warnings
 
     warnings.warn(
         "amdsmi_get_gpu_vram_vendor() is deprecated, use amdsmi_get_gpu_vram_info() instead",
@@ -4351,8 +4357,16 @@ def amdsmi_is_P2P_accessible(
 
 
 def amdsmi_get_gpu_compute_partition(processor_handle: processor_handle_t):
+    """Deprecated: use amdsmi_get_gpu_accelerator_partition_profile() instead."""
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
+
+    warnings.warn(
+        "amdsmi_get_gpu_compute_partition() is deprecated, "
+        "use amdsmi_get_gpu_accelerator_partition_profile() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     length = ctypes.c_uint32()
     length.value = _AMDSMI_STRING_LENGTH
@@ -4369,6 +4383,14 @@ def amdsmi_get_gpu_compute_partition(processor_handle: processor_handle_t):
 def amdsmi_set_gpu_compute_partition(
     processor_handle: processor_handle_t, compute_partition: AmdSmiComputePartitionType
 ):
+    """Deprecated: use amdsmi_set_gpu_accelerator_partition_profile() instead."""
+
+    warnings.warn(
+        "amdsmi_set_gpu_compute_partition() is deprecated, "
+        "use amdsmi_set_gpu_accelerator_partition_profile() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
@@ -4380,29 +4402,57 @@ def amdsmi_set_gpu_compute_partition(
 
 
 def amdsmi_get_gpu_compute_partition_mem_alloc_mode(processor_handle: processor_handle_t):
+    """Deprecated: use amdsmi_get_gpu_accelerator_partition_mem_alloc_mode() instead."""
+
+    warnings.warn(
+        "amdsmi_get_gpu_compute_partition_mem_alloc_mode() is deprecated, "
+        "use amdsmi_get_gpu_accelerator_partition_mem_alloc_mode() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    name = amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(processor_handle)
+    return name
+
+
+def amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(processor_handle: processor_handle_t):
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
-    mode = amdsmi_wrapper.amdsmi_compute_partition_mem_alloc_mode_t()
+    mode = amdsmi_wrapper.amdsmi_accelerator_partition_mem_alloc_mode_t()
     _check_res(
-        amdsmi_wrapper.amdsmi_get_gpu_compute_partition_mem_alloc_mode(
+        amdsmi_wrapper.amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(
             processor_handle, ctypes.byref(mode)
         )
     )
-    return AmdSmiComputePartitionMemAllocModeType(mode.value).name
+    return AmdSmiAcceleratorPartitionMemAllocModeType(mode.value).name
 
 
 def amdsmi_set_gpu_compute_partition_mem_alloc_mode(
     processor_handle: processor_handle_t, mode: AmdSmiComputePartitionMemAllocModeType
 ):
+    """Deprecated: use amdsmi_set_gpu_accelerator_partition_mem_alloc_mode() instead."""
+
+    warnings.warn(
+        "amdsmi_set_gpu_compute_partition_mem_alloc_mode() is deprecated, "
+        "use amdsmi_set_gpu_accelerator_partition_mem_alloc_mode() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    acc_mode = AmdSmiAcceleratorPartitionMemAllocModeType(mode)
+    amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(processor_handle, acc_mode)
+
+
+def amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(
+    processor_handle: processor_handle_t, mode: AmdSmiAcceleratorPartitionMemAllocModeType
+):
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
-    if not isinstance(mode, AmdSmiComputePartitionMemAllocModeType):
-        raise AmdSmiParameterException(mode, AmdSmiComputePartitionMemAllocModeType)
+    if not isinstance(mode, AmdSmiAcceleratorPartitionMemAllocModeType):
+        raise AmdSmiParameterException(mode, AmdSmiAcceleratorPartitionMemAllocModeType)
 
     _check_res(
-        amdsmi_wrapper.amdsmi_set_gpu_compute_partition_mem_alloc_mode(processor_handle, mode)
+        amdsmi_wrapper.amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(processor_handle, mode)
     )
 
 
@@ -4474,13 +4524,14 @@ def amdsmi_get_gpu_memory_partition_config(processor_handle: processor_handle_t)
 def amdsmi_set_gpu_memory_partition(
     processor_handle: processor_handle_t, memory_partition: AmdSmiMemoryPartitionType
 ):
-    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
-        raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
+    """Deprecated: Use amdsmi_set_gpu_memory_partition_mode() instead.  Will be deprecated in future ROCM release"""
 
-    if not isinstance(memory_partition, AmdSmiMemoryPartitionType):
-        raise AmdSmiParameterException(memory_partition, AmdSmiMemoryPartitionType)
-
-    _check_res(amdsmi_wrapper.amdsmi_set_gpu_memory_partition(processor_handle, memory_partition))
+    warnings.warn(
+        "amdsmi_set_gpu_memory_partition() is deprecated, use amdsmi_set_gpu_memory_partition_mode() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    amdsmi_set_gpu_memory_partition_mode(processor_handle, memory_partition)
 
 
 def amdsmi_set_gpu_memory_partition_mode(
@@ -4492,7 +4543,9 @@ def amdsmi_set_gpu_memory_partition_mode(
     if not isinstance(memory_partition, AmdSmiMemoryPartitionType):
         raise AmdSmiParameterException(memory_partition, AmdSmiMemoryPartitionType)
 
-    _check_res(amdsmi_wrapper.amdsmi_set_gpu_memory_partition(processor_handle, memory_partition))
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_gpu_memory_partition_mode(processor_handle, memory_partition)
+    )
 
 
 def amdsmi_get_gpu_accelerator_partition_profile(

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -497,6 +497,17 @@ AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING = 1
 AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL = 2
 amdsmi_compute_partition_mem_alloc_mode_t = ctypes.c_uint32 # enum
 
+# values for enumeration 'amdsmi_accelerator_partition_mem_alloc_mode_t'
+amdsmi_accelerator_partition_mem_alloc_mode_t__enumvalues = {
+    0: 'AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_INVALID',
+    1: 'AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING',
+    2: 'AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL',
+}
+AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_INVALID = 0
+AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING = 1
+AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL = 2
+amdsmi_accelerator_partition_mem_alloc_mode_t = ctypes.c_uint32 # enum
+
 # values for enumeration 'amdsmi_memory_partition_type_t'
 amdsmi_memory_partition_type_t__enumvalues = {
     0: 'AMDSMI_MEMORY_PARTITION_UNKNOWN',
@@ -3945,9 +3956,21 @@ try:
 except AttributeError:
     pass
 try:
+    amdsmi_get_gpu_accelerator_partition_mem_alloc_mode = _libraries['libamd_smi.so'].amdsmi_get_gpu_accelerator_partition_mem_alloc_mode
+    amdsmi_get_gpu_accelerator_partition_mem_alloc_mode.restype = amdsmi_status_t
+    amdsmi_get_gpu_accelerator_partition_mem_alloc_mode.argtypes = [amdsmi_processor_handle, ctypes.POINTER(amdsmi_accelerator_partition_mem_alloc_mode_t)]
+except AttributeError:
+    pass
+try:
     amdsmi_set_gpu_compute_partition_mem_alloc_mode = _libraries['libamd_smi.so'].amdsmi_set_gpu_compute_partition_mem_alloc_mode
     amdsmi_set_gpu_compute_partition_mem_alloc_mode.restype = amdsmi_status_t
     amdsmi_set_gpu_compute_partition_mem_alloc_mode.argtypes = [amdsmi_processor_handle, amdsmi_compute_partition_mem_alloc_mode_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_accelerator_partition_mem_alloc_mode = _libraries['libamd_smi.so'].amdsmi_set_gpu_accelerator_partition_mem_alloc_mode
+    amdsmi_set_gpu_accelerator_partition_mem_alloc_mode.restype = amdsmi_status_t
+    amdsmi_set_gpu_accelerator_partition_mem_alloc_mode.argtypes = [amdsmi_processor_handle, amdsmi_accelerator_partition_mem_alloc_mode_t]
 except AttributeError:
     pass
 try:
@@ -4702,6 +4725,9 @@ __all__ = \
     'AMDSMI_ACCELERATOR_PARTITION_DPX',
     'AMDSMI_ACCELERATOR_PARTITION_INVALID',
     'AMDSMI_ACCELERATOR_PARTITION_MAX',
+    'AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL',
+    'AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING',
+    'AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_INVALID',
     'AMDSMI_ACCELERATOR_PARTITION_QPX',
     'AMDSMI_ACCELERATOR_PARTITION_SPX',
     'AMDSMI_ACCELERATOR_PARTITION_TPX', 'AMDSMI_ACCELERATOR_XCC',
@@ -5030,6 +5056,7 @@ __all__ = \
     'AMDSMI_XGMI_STATUS_ERROR', 'AMDSMI_XGMI_STATUS_MULTIPLE_ERRORS',
     'AMDSMI_XGMI_STATUS_NO_ERRORS', 'CLK_LIMIT_MAX', 'CLK_LIMIT_MIN',
     'RD_BW0', 'WR_BW0', 'amd_metrics_table_header_t',
+    'amdsmi_accelerator_partition_mem_alloc_mode_t',
     'amdsmi_accelerator_partition_profile_config_t',
     'amdsmi_accelerator_partition_profile_t',
     'amdsmi_accelerator_partition_resource_profile_t',
@@ -5040,13 +5067,14 @@ __all__ = \
     'amdsmi_board_info_t', 'amdsmi_cache_property_type_t',
     'amdsmi_card_form_factor_t', 'amdsmi_clean_gpu_local_data',
     'amdsmi_clk_info_t', 'amdsmi_clk_limit_type_t',
-    'amdsmi_clk_type_t', 'amdsmi_compute_partition_type_t',
-    'amdsmi_container_types_t', 'amdsmi_counter_command_t',
-    'amdsmi_counter_value_t', 'amdsmi_cper_guid_t',
-    'amdsmi_cper_hdr_t', 'amdsmi_cper_notify_type_t',
-    'amdsmi_cper_sev_t', 'amdsmi_cper_timestamp_t',
-    'amdsmi_cper_valid_bits_t', 'amdsmi_cpu_apb_disable',
-    'amdsmi_cpu_apb_enable', 'amdsmi_cpu_info_t', 'amdsmi_cpu_util_t',
+    'amdsmi_clk_type_t', 'amdsmi_compute_partition_mem_alloc_mode_t',
+    'amdsmi_compute_partition_type_t', 'amdsmi_container_types_t',
+    'amdsmi_counter_command_t', 'amdsmi_counter_value_t',
+    'amdsmi_cper_guid_t', 'amdsmi_cper_hdr_t',
+    'amdsmi_cper_notify_type_t', 'amdsmi_cper_sev_t',
+    'amdsmi_cper_timestamp_t', 'amdsmi_cper_valid_bits_t',
+    'amdsmi_cpu_apb_disable', 'amdsmi_cpu_apb_enable',
+    'amdsmi_cpu_info_t', 'amdsmi_cpu_util_t',
     'amdsmi_cpusocket_handle', 'amdsmi_ddr_bw_metrics_t',
     'amdsmi_dev_perf_level_t', 'amdsmi_dimm_power_t',
     'amdsmi_dimm_thermal_t', 'amdsmi_dpm_level_t',
@@ -5112,6 +5140,7 @@ __all__ = \
     'amdsmi_get_cpu_xgmi_pstate_range', 'amdsmi_get_cpucore_handles',
     'amdsmi_get_energy_count', 'amdsmi_get_esmi_err_msg',
     'amdsmi_get_fabric_telemetry_data', 'amdsmi_get_fw_info',
+    'amdsmi_get_gpu_accelerator_partition_mem_alloc_mode',
     'amdsmi_get_gpu_accelerator_partition_profile',
     'amdsmi_get_gpu_accelerator_partition_profile_config',
     'amdsmi_get_gpu_activity', 'amdsmi_get_gpu_asic_info',
@@ -5238,6 +5267,7 @@ __all__ = \
     'amdsmi_set_cpu_socket_lclk_dpm_level',
     'amdsmi_set_cpu_socket_power_cap',
     'amdsmi_set_cpu_xgmi_pstate_range', 'amdsmi_set_cpu_xgmi_width',
+    'amdsmi_set_gpu_accelerator_partition_mem_alloc_mode',
     'amdsmi_set_gpu_accelerator_partition_profile',
     'amdsmi_set_gpu_clk_limit', 'amdsmi_set_gpu_clk_range',
     'amdsmi_set_gpu_compute_partition',

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -137,6 +137,15 @@ pub const AMDSMI_DATE_FORMAT: &[u8; 35] = b"%04d-%02d-%02d:%02d:%02d:%02d.%03d\0
 pub const AMDSMI_LIB_VERSION_MAJOR: u32 = 26;
 pub const AMDSMI_LIB_VERSION_MINOR: u32 = 5;
 pub const AMDSMI_LIB_VERSION_RELEASE: u32 = 0;
+pub const AMDSMI_MAX_VF_COUNT: u32 = 32;
+pub const AMDSMI_MAX_DRIVER_NUM: u32 = 2;
+pub const AMDSMI_DFC_FW_NUMBER_OF_ENTRIES: u32 = 9;
+pub const AMDSMI_MAX_WHITE_LIST_ELEMENTS: u32 = 16;
+pub const AMDSMI_MAX_BLACK_LIST_ELEMENTS: u32 = 64;
+pub const AMDSMI_MAX_TA_WHITE_LIST_ELEMENTS: u32 = 8;
+pub const AMDSMI_MAX_ERR_RECORDS: u32 = 10;
+pub const AMDSMI_MAX_PROFILE_COUNT: u32 = 16;
+pub const AMDSMI_PF_INDEX: u32 = 31;
 pub const AMDSMI_MAX_DRIVER_INFO_RSVD: u32 = 64;
 pub const AMDSMI_MAX_UUID_ELEMENTS: u32 = 16;
 pub const AMDSMI_MAX_NUM_FREQUENCIES: u32 = 33;
@@ -318,6 +327,13 @@ pub enum AmdsmiComputePartitionMemAllocModeT {
     AmdsmiComputePartitionMemAllocInvalid = 0,
     AmdsmiComputePartitionMemAllocCapping = 1,
     AmdsmiComputePartitionMemAllocAll = 2,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiAcceleratorPartitionMemAllocModeT {
+    AmdsmiAcceleratorPartitionMemAllocInvalid = 0,
+    AmdsmiAcceleratorPartitionMemAllocCapping = 1,
+    AmdsmiAcceleratorPartitionMemAllocAll = 2,
 }
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -4942,9 +4958,21 @@ extern "C" {
     ) -> AmdsmiStatusT;
 }
 extern "C" {
+    pub fn amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(
+        processor_handle: AmdsmiProcessorHandle,
+        mode: *mut AmdsmiAcceleratorPartitionMemAllocModeT,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
     pub fn amdsmi_set_gpu_compute_partition_mem_alloc_mode(
         processor_handle: AmdsmiProcessorHandle,
         mode: AmdsmiComputePartitionMemAllocModeT,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(
+        processor_handle: AmdsmiProcessorHandle,
+        mode: AmdsmiAcceleratorPartitionMemAllocModeT,
     ) -> AmdsmiStatusT;
 }
 extern "C" {

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -3053,6 +3053,7 @@ amdsmi_status_t amdsmi_topo_get_p2p_status(amdsmi_processor_handle processor_han
 }
 
 // Compute Partition functions
+// This API is deprecated, use amdsmi_get_gpu_accelerator_partition_profile() instead
 amdsmi_status_t amdsmi_get_gpu_compute_partition(amdsmi_processor_handle processor_handle,
                                                  char* compute_partition, uint32_t len) {
   AMDSMI_CHECK_INIT();
@@ -3066,6 +3067,7 @@ amdsmi_status_t amdsmi_get_gpu_compute_partition(amdsmi_processor_handle process
   return status;
 }
 
+// This API is deprecated, use amdsmi_set_gpu_accelerator_partition_profile() instead
 amdsmi_status_t amdsmi_set_gpu_compute_partition(
     amdsmi_processor_handle processor_handle, amdsmi_compute_partition_type_t compute_partition) {
   AMDSMI_CHECK_INIT();
@@ -3074,8 +3076,18 @@ amdsmi_status_t amdsmi_set_gpu_compute_partition(
   return ret_resp;
 }
 
+// This API is deprecated, use amdsmi_get_gpu_accelerator_partition_mem_alloc_mode() instead
 amdsmi_status_t amdsmi_get_gpu_compute_partition_mem_alloc_mode(
     amdsmi_processor_handle processor_handle, amdsmi_compute_partition_mem_alloc_mode_t* mode) {
+  amdsmi_accelerator_partition_mem_alloc_mode_t* acc_mode;
+  acc_mode = reinterpret_cast<amdsmi_accelerator_partition_mem_alloc_mode_t*>(mode);
+  amdsmi_status_t status =
+      amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(processor_handle, acc_mode);
+  return status;
+}
+
+amdsmi_status_t amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(
+    amdsmi_processor_handle processor_handle, amdsmi_accelerator_partition_mem_alloc_mode_t* mode) {
   AMDSMI_CHECK_INIT();
   if (mode == nullptr) {
     return AMDSMI_STATUS_INVAL;
@@ -3089,11 +3101,21 @@ amdsmi_status_t amdsmi_get_gpu_compute_partition_mem_alloc_mode(
   return status;
 }
 
+// This API is deprecated, use amdsmi_set_gpu_accelerator_partition_mem_alloc_mode() instead
 amdsmi_status_t amdsmi_set_gpu_compute_partition_mem_alloc_mode(
     amdsmi_processor_handle processor_handle, amdsmi_compute_partition_mem_alloc_mode_t mode) {
+  amdsmi_accelerator_partition_mem_alloc_mode_t acc_mode;
+  acc_mode = static_cast<amdsmi_accelerator_partition_mem_alloc_mode_t>(mode);
+  amdsmi_status_t status =
+      amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(processor_handle, acc_mode);
+  return status;
+}
+
+amdsmi_status_t amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(
+    amdsmi_processor_handle processor_handle, amdsmi_accelerator_partition_mem_alloc_mode_t mode) {
   AMDSMI_CHECK_INIT();
-  if (mode != AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING &&
-      mode != AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL) {
+  if (mode != AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING &&
+      mode != AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL) {
     return AMDSMI_STATUS_INVAL;
   }
   return rsmi_wrapper(rsmi_dev_compute_partition_mem_alloc_mode_set, processor_handle, 0,
@@ -3109,67 +3131,11 @@ amdsmi_status_t amdsmi_get_gpu_memory_partition(amdsmi_processor_handle processo
   return ret;
 }
 
+// This API is deprecated, use amdsmi_set_gpu_memory_partition_mode() instead
 amdsmi_status_t amdsmi_set_gpu_memory_partition(amdsmi_processor_handle processor_handle,
-                                                amdsmi_memory_partition_type_t memory_partition) {
+                                                amdsmi_memory_partition_type_t mode) {
   AMDSMI_CHECK_INIT();
-  if (memory_partition != AMDSMI_MEMORY_PARTITION_UNKNOWN &&
-      memory_partition != AMDSMI_MEMORY_PARTITION_NPS1 &&
-      memory_partition != AMDSMI_MEMORY_PARTITION_NPS2 &&
-      memory_partition != AMDSMI_MEMORY_PARTITION_NPS4 &&
-      memory_partition != AMDSMI_MEMORY_PARTITION_NPS8) {
-    return AMDSMI_STATUS_INVAL;
-  }
-  std::ostringstream ss;
-  std::lock_guard<std::mutex> g(myMutex);
-
-  const uint32_t k256 = 256;
-  char current_partition[k256];
-  std::string current_partition_str = "UNKNOWN";
-  std::string req_user_partition = "UNKNOWN";
-
-  req_user_partition.clear();
-  switch (memory_partition) {
-    case AMDSMI_MEMORY_PARTITION_NPS1:
-      req_user_partition = "NPS1";
-      break;
-    case AMDSMI_MEMORY_PARTITION_NPS2:
-      req_user_partition = "NPS2";
-      break;
-    case AMDSMI_MEMORY_PARTITION_NPS4:
-      req_user_partition = "NPS4";
-      break;
-    case AMDSMI_MEMORY_PARTITION_NPS8:
-      req_user_partition = "NPS8";
-      break;
-    default:
-      req_user_partition = "UNKNOWN";
-      break;
-  }
-  rsmi_memory_partition_type_t rsmi_type;
-  auto it = nps_amdsmi_to_RSMI.find(memory_partition);
-  if (it != nps_amdsmi_to_RSMI.end()) {
-    rsmi_type = it->second;
-  } else if (it == nps_amdsmi_to_RSMI.end()) {
-    return AMDSMI_STATUS_INVAL;
-  }
-
-  amdsmi_status_t ret = rsmi_wrapper(rsmi_dev_memory_partition_set, processor_handle, 0, rsmi_type);
-
-  amdsmi_status_t ret_get =
-      rsmi_wrapper(rsmi_dev_memory_partition_get, processor_handle, 0, current_partition, k256);
-
-  if (ret_get == AMDSMI_STATUS_SUCCESS) {
-    current_partition_str.clear();
-    current_partition_str = current_partition;
-  }
-
-  ss << __PRETTY_FUNCTION__ << " | After attempting to set memory partition to "
-     << req_user_partition << "\n"
-     << " | Current memory partition is " << current_partition_str << "\n"
-     << " | Returning: " << smi_amdgpu_get_status_string(ret, false)
-     << " | User will need to reload driver in order to see a NPS mode change";
-  LOG_INFO(ss);
-  return ret;
+  return amdsmi_set_gpu_memory_partition_mode(processor_handle, mode);
 }
 
 amdsmi_status_t amdsmi_get_gpu_memory_partition_config(amdsmi_processor_handle processor_handle,
@@ -3241,11 +3207,67 @@ amdsmi_status_t amdsmi_get_gpu_memory_partition_config(amdsmi_processor_handle p
   config->partition_caps = flags;
   return status;
 }
-
-amdsmi_status_t amdsmi_set_gpu_memory_partition_mode(amdsmi_processor_handle processor_handle,
-                                                     amdsmi_memory_partition_type_t mode) {
+amdsmi_status_t amdsmi_set_gpu_memory_partition_mode(
+    amdsmi_processor_handle processor_handle, amdsmi_memory_partition_type_t memory_partition) {
   AMDSMI_CHECK_INIT();
-  return amdsmi_set_gpu_memory_partition(processor_handle, mode);
+  if (memory_partition != AMDSMI_MEMORY_PARTITION_UNKNOWN &&
+      memory_partition != AMDSMI_MEMORY_PARTITION_NPS1 &&
+      memory_partition != AMDSMI_MEMORY_PARTITION_NPS2 &&
+      memory_partition != AMDSMI_MEMORY_PARTITION_NPS4 &&
+      memory_partition != AMDSMI_MEMORY_PARTITION_NPS8) {
+    return AMDSMI_STATUS_INVAL;
+  }
+  std::ostringstream ss;
+  std::lock_guard<std::mutex> g(myMutex);
+
+  const uint32_t k256 = 256;
+  char current_partition[k256];
+  std::string current_partition_str = "UNKNOWN";
+  std::string req_user_partition = "UNKNOWN";
+
+  req_user_partition.clear();
+  switch (memory_partition) {
+    case AMDSMI_MEMORY_PARTITION_NPS1:
+      req_user_partition = "NPS1";
+      break;
+    case AMDSMI_MEMORY_PARTITION_NPS2:
+      req_user_partition = "NPS2";
+      break;
+    case AMDSMI_MEMORY_PARTITION_NPS4:
+      req_user_partition = "NPS4";
+      break;
+    case AMDSMI_MEMORY_PARTITION_NPS8:
+      req_user_partition = "NPS8";
+      break;
+    default:
+      req_user_partition = "UNKNOWN";
+      break;
+  }
+  rsmi_memory_partition_type_t rsmi_type;
+  auto it = nps_amdsmi_to_RSMI.find(memory_partition);
+  if (it != nps_amdsmi_to_RSMI.end()) {
+    rsmi_type = it->second;
+  } else if (it == nps_amdsmi_to_RSMI.end()) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  amdsmi_status_t ret = rsmi_wrapper(rsmi_dev_memory_partition_set, processor_handle, 0, rsmi_type);
+
+  amdsmi_status_t ret_get =
+      rsmi_wrapper(rsmi_dev_memory_partition_get, processor_handle, 0, current_partition, k256);
+
+  if (ret_get == AMDSMI_STATUS_SUCCESS) {
+    current_partition_str.clear();
+    current_partition_str = current_partition;
+  }
+
+  ss << __PRETTY_FUNCTION__ << " | After attempting to set memory partition to "
+     << req_user_partition << "\n"
+     << " | Current memory partition is " << current_partition_str << "\n"
+     << " | Returning: " << smi_amdgpu_get_status_string(ret, false)
+     << " | User will need to reload driver in order to see a NPS mode change";
+  LOG_INFO(ss);
+  return ret;
 }
 
 // Accelerator Partition functions

--- a/projects/amdsmi/tests/amd_smi_test/functional/computepartition_memallocmode_read_write.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/computepartition_memallocmode_read_write.cc
@@ -61,11 +61,11 @@ void TestComputePartitionMemAllocModeReadWrite::Close() {
   TestBase::Close();
 }
 
-static std::string memAllocModeString(amdsmi_compute_partition_mem_alloc_mode_t mode) {
+static std::string memAllocModeString(amdsmi_accelerator_partition_mem_alloc_mode_t mode) {
   switch (mode) {
-    case AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING:
+    case AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING:
       return "CAPPING";
-    case AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL:
+    case AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL:
       return "ALL";
     default:
       return "INVALID";
@@ -74,8 +74,8 @@ static std::string memAllocModeString(amdsmi_compute_partition_mem_alloc_mode_t 
 
 void TestComputePartitionMemAllocModeReadWrite::Run(void) {
   amdsmi_status_t ret;
-  amdsmi_compute_partition_mem_alloc_mode_t original_mode;
-  amdsmi_compute_partition_mem_alloc_mode_t current_mode;
+  amdsmi_accelerator_partition_mem_alloc_mode_t original_mode;
+  amdsmi_accelerator_partition_mem_alloc_mode_t current_mode;
 
   if (num_monitor_devs() == 0) {
     return;
@@ -83,37 +83,37 @@ void TestComputePartitionMemAllocModeReadWrite::Run(void) {
 
   // Invalid argument tests (run only when at least one device exists;
   // the handle is validated by SetUp).
-  ret = amdsmi_get_gpu_compute_partition_mem_alloc_mode(processor_handles_[0], nullptr);
+  ret = amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(processor_handles_[0], nullptr);
   EXPECT_EQ(ret, AMDSMI_STATUS_INVAL);
 
-  ret = amdsmi_set_gpu_compute_partition_mem_alloc_mode(processor_handles_[0],
-                                                        AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_INVALID);
+  ret = amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(
+      processor_handles_[0], AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_INVALID);
   EXPECT_EQ(ret, AMDSMI_STATUS_INVAL);
 
-  ret = amdsmi_set_gpu_compute_partition_mem_alloc_mode(
-      processor_handles_[0], static_cast<amdsmi_compute_partition_mem_alloc_mode_t>(99));
+  ret = amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(
+      processor_handles_[0], static_cast<amdsmi_accelerator_partition_mem_alloc_mode_t>(99));
   EXPECT_EQ(ret, AMDSMI_STATUS_INVAL);
 
   const bool isVerbose = (verbosity() > 0);
-  const std::vector<amdsmi_compute_partition_mem_alloc_mode_t> modes_to_test = {
-      AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING,
-      AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL,
+  const std::vector<amdsmi_accelerator_partition_mem_alloc_mode_t> modes_to_test = {
+      AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING,
+      AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL,
   };
 
   for (uint32_t dv_ind = 0; dv_ind < num_monitor_devs(); dv_ind++) {
     PrintDeviceHeader(processor_handles_[dv_ind]);
 
     // Get original mode
-    DISPLAY_AMDSMI_API("amdsmi_get_gpu_compute_partition_mem_alloc_mode",
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_accelerator_partition_mem_alloc_mode",
                        "gpu=" + std::to_string(dv_ind), isVerbose);
-    ret =
-        amdsmi_get_gpu_compute_partition_mem_alloc_mode(processor_handles_[dv_ind], &original_mode);
+    ret = amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(processor_handles_[dv_ind],
+                                                              &original_mode);
     DISPLAY_AMDSMI_STATUS(isVerbose, __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
 
     if (ret == AMDSMI_STATUS_NOT_SUPPORTED) {
       IF_VERB(STANDARD) {
         std::cout << "\t**Device " << dv_ind
-                  << ": compute_partition_mem_alloc_mode not supported; skipping.\n";
+                  << ": accelerator_partition_mem_alloc_mode not supported; skipping.\n";
       }
       continue;
     }
@@ -124,7 +124,7 @@ void TestComputePartitionMemAllocModeReadWrite::Run(void) {
     }
 
     IF_VERB(STANDARD) {
-      std::cout << "\t**Device " << dv_ind << ": original compute_partition_mem_alloc_mode = "
+      std::cout << "\t**Device " << dv_ind << ": original accelerator_partition_mem_alloc_mode = "
                 << memAllocModeString(original_mode) << "\n";
     }
 
@@ -135,10 +135,10 @@ void TestComputePartitionMemAllocModeReadWrite::Run(void) {
                   << "\n";
       }
 
-      DISPLAY_AMDSMI_API("amdsmi_set_gpu_compute_partition_mem_alloc_mode",
+      DISPLAY_AMDSMI_API("amdsmi_set_gpu_accelerator_partition_mem_alloc_mode",
                          "gpu=" + std::to_string(dv_ind) + ", mode=" + memAllocModeString(mode),
                          isVerbose);
-      ret = amdsmi_set_gpu_compute_partition_mem_alloc_mode(processor_handles_[dv_ind], mode);
+      ret = amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(processor_handles_[dv_ind], mode);
       DISPLAY_AMDSMI_STATUS(isVerbose, __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
 
       if (ret == AMDSMI_STATUS_NOT_SUPPORTED) {
@@ -155,10 +155,10 @@ void TestComputePartitionMemAllocModeReadWrite::Run(void) {
       }
 
       // Verify the mode was applied
-      DISPLAY_AMDSMI_API("amdsmi_get_gpu_compute_partition_mem_alloc_mode",
+      DISPLAY_AMDSMI_API("amdsmi_get_gpu_accelerator_partition_mem_alloc_mode",
                          "gpu=" + std::to_string(dv_ind) + " (verify)", isVerbose);
-      ret = amdsmi_get_gpu_compute_partition_mem_alloc_mode(processor_handles_[dv_ind],
-                                                            &current_mode);
+      ret = amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(processor_handles_[dv_ind],
+                                                                &current_mode);
       DISPLAY_AMDSMI_STATUS(isVerbose, __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
       EXPECT_EQ(ret, AMDSMI_STATUS_SUCCESS);
       if (ret == AMDSMI_STATUS_SUCCESS) {
@@ -175,17 +175,17 @@ void TestComputePartitionMemAllocModeReadWrite::Run(void) {
       std::cout << "\t**Device " << dv_ind
                 << ": restoring original mode = " << memAllocModeString(original_mode) << "\n";
     }
-    DISPLAY_AMDSMI_API("amdsmi_set_gpu_compute_partition_mem_alloc_mode",
+    DISPLAY_AMDSMI_API("amdsmi_set_gpu_accelerator_partition_mem_alloc_mode",
                        "gpu=" + std::to_string(dv_ind) +
                            ", mode=" + memAllocModeString(original_mode) + " (restore)",
                        isVerbose);
-    ret =
-        amdsmi_set_gpu_compute_partition_mem_alloc_mode(processor_handles_[dv_ind], original_mode);
+    ret = amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(processor_handles_[dv_ind],
+                                                              original_mode);
     DISPLAY_AMDSMI_STATUS(isVerbose, __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
     EXPECT_EQ(ret, AMDSMI_STATUS_SUCCESS);
     if (ret != AMDSMI_STATUS_SUCCESS) {
       std::cerr << "\t**WARNING: failed to restore device " << dv_ind
-                << " to original compute_partition_mem_alloc_mode = "
+                << " to original accelerator_partition_mem_alloc_mode = "
                 << memAllocModeString(original_mode) << "; device left in modified state.\n";
     }
   }

--- a/projects/amdsmi/tests/amd_smi_test/functional/computepartition_read_write.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/computepartition_read_write.cc
@@ -75,43 +75,45 @@ const uint32_t MAX_QPX_PARTITIONS = 4;
 // const uint32_t MAX_CPX_PARTITIONS = 8;
 
 static const std::string computePartitionString(
-    amdsmi_compute_partition_type_t computeParitionType) {
+    amdsmi_accelerator_partition_type_t computeParitionType) {
   /**
    * typedef enum {
-   *    AMDSMI_COMPUTE_PARTITION_INVALID = 0,
-   *    AMDSMI_COMPUTE_PARTITION_SPX,   //!< Single GPU mode (SPX)- All XCCs work
-   *                                    //!< together with shared memory
-   *    AMDSMI_COMPUTE_PARTITION_DPX,   //!< Dual GPU mode (DPX)- Half XCCs work
-   *                                    //!< together with shared memory
-   *    AMDSMI_COMPUTE_PARTITION_TPX,   //!< Triple GPU mode (TPX)- One-third XCCs
-   *                                    //!< work together with shared memory
-   *    AMDSMI_COMPUTE_PARTITION_QPX,   //!< Quad GPU mode (QPX)- Quarter XCCs
-   *                                    //!< work together with shared memory
-   *    AMDSMI_COMPUTE_PARTITION_CPX,  //!< Core mode (CPX)- Per-chip XCC with
-   *                                   //!< shared memory
-   * } amdsmi_compute_partition_type_t;
+   *    AMDSMI_ACCELERATOR_PARTITION_INVALID = 0,
+   *    AMDSMI_ACCELERATOR_PARTITION_SPX,   //!< Single GPU mode (SPX)- All XCCs work
+   *                                        //!< together with shared memory
+   *    AMDSMI_ACCELERATOR_PARTITION_DPX,   //!< Dual GPU mode (DPX)- Half XCCs work
+   *                                        //!< together with shared memory
+   *    AMDSMI_ACCELERATOR_PARTITION_TPX,   //!< Triple GPU mode (TPX)- One-third XCCs
+   *                                        //!< work together with shared memory
+   *    AMDSMI_ACCELERATOR_PARTITION_QPX,   //!< Quad GPU mode (QPX)- Quarter XCCs
+   *                                        //!< work together with shared memory
+   *    AMDSMI_ACCELERATOR_PARTITION_CPX,   //!< Core mode (CPX)- Per-chip XCC with
+   *                                        //!< shared memory
+   * } amdsmi_accelerator_partition_type_t;
    * */
   switch (computeParitionType) {
-    case AMDSMI_COMPUTE_PARTITION_SPX:
+    case AMDSMI_ACCELERATOR_PARTITION_SPX:
       return "SPX";
-    case AMDSMI_COMPUTE_PARTITION_DPX:
+    case AMDSMI_ACCELERATOR_PARTITION_DPX:
       return "DPX";
-    case AMDSMI_COMPUTE_PARTITION_TPX:
+    case AMDSMI_ACCELERATOR_PARTITION_TPX:
       return "TPX";
-    case AMDSMI_COMPUTE_PARTITION_QPX:
+    case AMDSMI_ACCELERATOR_PARTITION_QPX:
       return "QPX";
-    case AMDSMI_COMPUTE_PARTITION_CPX:
+    case AMDSMI_ACCELERATOR_PARTITION_CPX:
       return "CPX";
     default:
       return "N/A";
   }
 }
 
-static const std::map<std::string, amdsmi_compute_partition_type_t>
-    mapStringToSMIComputePartitionTypes{
-        {"SPX", AMDSMI_COMPUTE_PARTITION_SPX}, {"DPX", AMDSMI_COMPUTE_PARTITION_DPX},
-        {"TPX", AMDSMI_COMPUTE_PARTITION_TPX}, {"QPX", AMDSMI_COMPUTE_PARTITION_QPX},
-        {"CPX", AMDSMI_COMPUTE_PARTITION_CPX}, {"UNKNOWN", AMDSMI_COMPUTE_PARTITION_INVALID}};
+static const std::map<std::string, amdsmi_accelerator_partition_type_t>
+    mapStringToSMIComputePartitionTypes{{"SPX", AMDSMI_ACCELERATOR_PARTITION_SPX},
+                                        {"DPX", AMDSMI_ACCELERATOR_PARTITION_DPX},
+                                        {"TPX", AMDSMI_ACCELERATOR_PARTITION_TPX},
+                                        {"QPX", AMDSMI_ACCELERATOR_PARTITION_QPX},
+                                        {"CPX", AMDSMI_ACCELERATOR_PARTITION_CPX},
+                                        {"UNKNOWN", AMDSMI_ACCELERATOR_PARTITION_INVALID}};
 
 static const std::map<amdsmi_accelerator_partition_resource_type_t, std::string>
     resource_types_map = {
@@ -406,10 +408,10 @@ void TestComputePartitionReadWrite::Run(void) {
     if (ret == AMDSMI_STATUS_NOT_SUPPORTED) {
       continue;
     }
-    for (int partition = static_cast<int>(AMDSMI_COMPUTE_PARTITION_SPX);
-         partition <= static_cast<int>(AMDSMI_COMPUTE_PARTITION_CPX); partition++) {
-      amdsmi_compute_partition_type_t updatePartition =
-          static_cast<amdsmi_compute_partition_type_t>(partition);
+    for (int partition = static_cast<int>(AMDSMI_ACCELERATOR_PARTITION_SPX);
+         partition <= static_cast<int>(AMDSMI_ACCELERATOR_PARTITION_CPX); partition++) {
+      amdsmi_accelerator_partition_type_t updatePartition =
+          static_cast<amdsmi_accelerator_partition_type_t>(partition);
 
       IF_VERB(STANDARD) {
         std::cout << "\t**"
@@ -419,7 +421,9 @@ void TestComputePartitionReadWrite::Run(void) {
 
       DISPLAY_AMDSMI_API("amdsmi_set_gpu_compute_partition", "gpu=" + std::to_string(dv_ind),
                          VERB(STANDARD));
-      auto ret_set = amdsmi_set_gpu_compute_partition(processor_handles_[dv_ind], updatePartition);
+      auto ret_set = amdsmi_set_gpu_compute_partition(
+          processor_handles_[dv_ind],
+          static_cast<amdsmi_compute_partition_type_t>(updatePartition));
       DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret_set,
                             AMDSMI_STATUS_SETTING_UNAVAILABLE, AMDSMI_STATUS_NO_PERM,
                             AMDSMI_STATUS_SUCCESS, AMDSMI_STATUS_BUSY, AMDSMI_STATUS_NOT_SUPPORTED,
@@ -475,11 +479,13 @@ void TestComputePartitionReadWrite::Run(void) {
                                        std::string(current_char_computePartition)));
       }
     }
-    amdsmi_compute_partition_type_t updatePartition = static_cast<amdsmi_compute_partition_type_t>(
-        mapStringToSMIComputePartitionTypes.at(std::string(orig_char_computePartition)));
+    amdsmi_accelerator_partition_type_t updatePartition =
+        static_cast<amdsmi_accelerator_partition_type_t>(
+            mapStringToSMIComputePartitionTypes.at(std::string(orig_char_computePartition)));
     DISPLAY_AMDSMI_API("amdsmi_set_gpu_compute_partition", "gpu=" + std::to_string(dv_ind),
                        VERB(STANDARD));
-    auto ret_set = amdsmi_set_gpu_compute_partition(processor_handles_[dv_ind], updatePartition);
+    auto ret_set = amdsmi_set_gpu_compute_partition(
+        processor_handles_[dv_ind], static_cast<amdsmi_compute_partition_type_t>(updatePartition));
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret_set,
                           AMDSMI_STATUS_SETTING_UNAVAILABLE, AMDSMI_STATUS_NO_PERM,
                           AMDSMI_STATUS_SUCCESS, AMDSMI_STATUS_BUSY, AMDSMI_STATUS_NOT_SUPPORTED,
@@ -964,7 +970,7 @@ void TestComputePartitionReadWrite::Run(void) {
     }
     for (int partition = static_cast<int>(
              mapStringToSMIComputePartitionTypes.at(std::string(orig_char_computePartition)));
-         partition <= static_cast<int>(AMDSMI_COMPUTE_PARTITION_CPX); partition++) {
+         partition <= static_cast<int>(AMDSMI_ACCELERATOR_PARTITION_CPX); partition++) {
       uint32_t device_index2 = 0;
       amdsmi_processor_handle p_handle2 = {};
       smi_amdgpu_get_device_count(&current_num_devices);
@@ -982,10 +988,11 @@ void TestComputePartitionReadWrite::Run(void) {
         std::cout << "\t=========== END INDEX/p_handle DEVICE INFO 2 =============\n";
       }
 
-      amdsmi_compute_partition_type_t updatePartition =
-          static_cast<amdsmi_compute_partition_type_t>(partition);
+      amdsmi_accelerator_partition_type_t updatePartition =
+          static_cast<amdsmi_accelerator_partition_type_t>(partition);
       DISPLAY_AMDSMI_API("amdsmi_set_gpu_compute_partition", "", VERB(STANDARD));
-      auto ret_set = amdsmi_set_gpu_compute_partition(p_handle2, updatePartition);
+      auto ret_set = amdsmi_set_gpu_compute_partition(
+          p_handle2, static_cast<amdsmi_compute_partition_type_t>(updatePartition));
       DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret_set,
                             AMDSMI_STATUS_SETTING_UNAVAILABLE, AMDSMI_STATUS_NO_PERM,
                             AMDSMI_STATUS_SUCCESS, AMDSMI_STATUS_BUSY, AMDSMI_STATUS_NOT_SUPPORTED,
@@ -1047,14 +1054,16 @@ void TestComputePartitionReadWrite::Run(void) {
     smi_amdgpu_get_processor_handle_by_index(dv_ind, &p_handle3);
     smi_amdgpu_get_device_index(p_handle3, &device_index3);
 
-    amdsmi_compute_partition_type_t updatePartition = static_cast<amdsmi_compute_partition_type_t>(
-        mapStringToSMIComputePartitionTypes.at(std::string(orig_char_computePartition)));
+    amdsmi_accelerator_partition_type_t updatePartition =
+        static_cast<amdsmi_accelerator_partition_type_t>(
+            mapStringToSMIComputePartitionTypes.at(std::string(orig_char_computePartition)));
     IF_VERB(STANDARD) {
       std::cout << "\t**ABOUT TO GO BACK TO ORIGINAL PARTITION (" << orig_char_computePartition
                 << ")\n";
     }
     DISPLAY_AMDSMI_API("amdsmi_set_gpu_compute_partition", "", VERB(STANDARD));
-    auto ret_set = amdsmi_set_gpu_compute_partition(p_handle3, updatePartition);
+    auto ret_set = amdsmi_set_gpu_compute_partition(
+        p_handle3, static_cast<amdsmi_compute_partition_type_t>(updatePartition));
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret_set, AMDSMI_STATUS_SUCCESS);
     checkPartitionIdChanges(processor_handles_, dv_ind, std::string(orig_char_computePartition),
                             isVerbose, true);

--- a/projects/amdsmi/tests/amd_smi_test/functional/memorypartition_read_write.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/memorypartition_read_write.cc
@@ -536,7 +536,7 @@ void TestMemoryPartitionReadWrite::Run(void) {
     }
 
     /****************************************/
-    /* amdsmi_set_gpu_memory_partition(...) */
+    /* amdsmi_set_gpu_memory_partition_mode(...) */
     /****************************************/
     // Verify api support checking functionality is working
     amdsmi_memory_partition_type_t null_memory_partition = {};
@@ -544,7 +544,7 @@ void TestMemoryPartitionReadWrite::Run(void) {
                        VERB(STANDARD));
     err = amdsmi_set_gpu_memory_partition_mode(processor_handles_[dv_ind], null_memory_partition);
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_INVAL);
-    std::cout << "\t**amdsmi_set_gpu_memory_partition(amdsmi_set_gpu_memory_partition_mode"
+    std::cout << "\t**amdsmi_set_gpu_memory_partition_mode"
               << "(processor_handles_[" << dv_ind
               << "], nullptr): " << smi_amdgpu_get_status_string(err, false) << "\n";
     // Note: new_memory_partition is not set
@@ -689,8 +689,7 @@ void TestMemoryPartitionReadWrite::Run(void) {
       amdsmi_status_t driver_reload_status = AMDSMI_STATUS_NOT_SUPPORTED;
       if (ret_set == AMDSMI_STATUS_SUCCESS) {  // do not continue trying to reset
         // Now we require a separate call to reload the driver, since this operation
-        // has been removed from the amdsmi_set_gpu_memory_partition_mode and
-        // amdsmi_set_gpu_memory_partition().
+        // has been removed from the amdsmi_set_gpu_memory_partition_mode.
         // This is to allow the user to select the appropriate time to reload the driver
         // since there can be errors if any device has a workload/process running on it.
         std::string reload_message =
@@ -846,21 +845,20 @@ void TestMemoryPartitionReadWrite::Run(void) {
                 << "Returning memory partition to: " << memoryPartitionString(new_memory_partition)
                 << std::endl;
     }
-    DISPLAY_AMDSMI_API("amdsmi_set_gpu_memory_partition", "gpu=" + std::to_string(dv_ind),
+    DISPLAY_AMDSMI_API("amdsmi_set_gpu_memory_partition_mode", "gpu=" + std::to_string(dv_ind),
                        VERB(STANDARD));
-    ret = amdsmi_set_gpu_memory_partition(processor_handles_[dv_ind], new_memory_partition);
+    ret = amdsmi_set_gpu_memory_partition_mode(processor_handles_[dv_ind], new_memory_partition);
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
     IF_VERB(STANDARD) {
       std::cout << "\t**"
-                << "amdsmi_set_gpu_memory_partition(processor_handles_[" << dv_ind << "], "
+                << "amdsmi_set_gpu_memory_partition_mode(processor_handles_[" << dv_ind << "], "
                 << orig_memory_partition << "): " << smi_amdgpu_get_status_string(ret, false)
                 << std::endl;
     }
     CHK_ERR_ASRT(ret)
     if (ret == AMDSMI_STATUS_SUCCESS) {
       // Now we require a separate call to reload the driver, since this operation
-      // has been removed from the amdsmi_set_gpu_memory_partition_mode and
-      // amdsmi_set_gpu_memory_partition().
+      // has been removed from the amdsmi_set_gpu_memory_partition_mode.
       // This is to allow the user to select the appropriate time to reload the driver
       // since there can be errors if any device has a workload/process running on it.
       amdsmi_status_t driver_reload_status = AMDSMI_STATUS_NOT_SUPPORTED;

--- a/projects/amdsmi/tests/python/cli/base.py
+++ b/projects/amdsmi/tests/python/cli/base.py
@@ -88,6 +88,10 @@ class TestCliBase(unittest.TestCase):
         TestCliBase.sub_args = baseline["sub_args"]
         TestCliBase._initialized = True
 
+        # TODO: Remove this condition when CLI supports User automated input
+        # Commands that need User permission to run
+        cls.cmds_need_permission = {"set": ["--fan", "--memory-partition", "--compute-partition"]}
+
     @classmethod
     def _build_baseline(cls):
         baseline = {}
@@ -182,12 +186,12 @@ class TestCliBase(unittest.TestCase):
             "DETERMINISM",
         ]
         self.profile_levels = [
-            "CUSTOM_MASK",
-            "VIDEO_MASK",
-            "POWER_SAVING_MASK",
-            "COMPUTE_MASK",
-            "VR_MASK",
-            "THREE_D_FULL_SCR_MASK",
+            "CUSTOM",
+            "VIDEO",
+            "POWER_SAVING",
+            "COMPUTE",
+            "VR",
+            "3D_FULL_SCREEN",
             "BOOTUP_DEFAULT",
         ]
         self.compute_partition_modes = ["SPX", "DPX", "TPX", "QPX", "CPX"]
@@ -538,7 +542,7 @@ class TestCliBase(unittest.TestCase):
                     if clock_sys != "N/A" and len(clock_sys["frequency_levels"]):
                         num = len(clock_sys["frequency_levels"])
                         level = f"Level {num - 1}"
-                        clock_freq = int(clock_sys["frequency_levels"][level].split()[0].strip())
+                        clock_freq = int(clock_sys["frequency_levels"][level]["value"])
                         cmd = cmd.replace(
                             "{perf_determinism}", f"--perf-determinism {clock_freq + 50}", 1
                         )
@@ -706,6 +710,21 @@ class TestCliBase(unittest.TestCase):
                                 cmd = ""
                                 break
 
+                cmds[index] = (cmd, cond)
+
+        # Remove commands requiring input
+        for index, cmd_cond in enumerate(cmds):
+            cmd, cond = cmd_cond
+            if not cmd:
+                continue
+            items = cmd.split()
+            if len(items) < 3:
+                continue
+            if items[1] == "set":
+                if items[2] in self.cmds_need_permission["set"]:
+                    cmd = ""
+            # Update cmds when cmd has changed
+            if not cmd:
                 cmds[index] = (cmd, cond)
 
         # Remove empty (cmd,cond) arguments

--- a/projects/amdsmi/tests/python/cli/test_set.py
+++ b/projects/amdsmi/tests/python/cli/test_set.py
@@ -41,13 +41,6 @@ class TestSet(TestCliBase):
         msg = f"{self.tab}### amd-smi set"
         self.common.print(msg)
 
-        # TODO allow set commands to be executed
-        if not self.PrintCmdsOnly:
-            if self.common.TODO_SKIP_FAIL:
-                msg = f"{self.tab}Needs input"
-                # self.common.print(msg)
-                self.skipTest(msg)
-
         # Get current settings
         power_profile = {}
         for index, gpu in enumerate(self.common.processors):
@@ -99,7 +92,7 @@ class TestSet(TestCliBase):
             if clock_sys != "N/A":
                 num = len(clock_sys["frequency_levels"])
                 level = f"Level {num - 1}"
-                clock_freq = int(clock_sys["frequency_levels"][level].split()[0].strip())
+                clock_freq = int(clock_sys["frequency_levels"][level]["value"])
                 cmds.append(
                     (f"amd-smi set --perf-determinism {clock_freq} --gpu {index}", self.PASS)
                 )

--- a/projects/amdsmi/tests/python/common/common.py
+++ b/projects/amdsmi/tests/python/common/common.py
@@ -314,13 +314,13 @@ def build_type_lists():
             (member.name, amdsmi.AmdSmiMemoryPartitionType(member.value), cond)
         )
 
-    compute_partition_mem_alloc_mode_types = []
-    for member in amdsmi.AmdSmiComputePartitionMemAllocModeType:
+    accelerator_partition_mem_alloc_mode_types = []
+    for member in amdsmi.AmdSmiAcceleratorPartitionMemAllocModeType:
         cond = PASS
         if member.name in ["INVALID"]:
             cond = FAIL
-        compute_partition_mem_alloc_mode_types.append(
-            (member.name, amdsmi.AmdSmiComputePartitionMemAllocModeType(member.value), cond)
+        accelerator_partition_mem_alloc_mode_types.append(
+            (member.name, amdsmi.AmdSmiAcceleratorPartitionMemAllocModeType(member.value), cond)
         )
 
     freq_inds = []
@@ -375,7 +375,7 @@ def build_type_lists():
         "counter_commands": counter_commands,
         "compute_partition_types": compute_partition_types,
         "memory_partition_types": memory_partition_types,
-        "compute_partition_mem_alloc_mode_types": compute_partition_mem_alloc_mode_types,
+        "accelerator_partition_mem_alloc_mode_types": accelerator_partition_mem_alloc_mode_types,
         "freq_inds": freq_inds,
         "power_profile_preset_masks": power_profile_preset_masks,
         "processor_types": processor_types,
@@ -406,7 +406,9 @@ EVENT_TYPES = _TYPE_LISTS["event_types"]
 COUNTER_COMMANDS = _TYPE_LISTS["counter_commands"]
 COMPUTE_PARTITION_TYPES = _TYPE_LISTS["compute_partition_types"]
 MEMORY_PARTITION_TYPES = _TYPE_LISTS["memory_partition_types"]
-COMPUTE_PARTITION_MEM_ALLOC_MODE_TYPES = _TYPE_LISTS["compute_partition_mem_alloc_mode_types"]
+ACCELERATOR_PARTITION_MEM_ALLOC_MODE_TYPES = _TYPE_LISTS[
+    "accelerator_partition_mem_alloc_mode_types"
+]
 FREQ_INDS = _TYPE_LISTS["freq_inds"]
 POWER_PROFILE_PRESET_MASKS = _TYPE_LISTS["power_profile_preset_masks"]
 PROCESSOR_TYPES = _TYPE_LISTS["processor_types"]

--- a/projects/amdsmi/tests/python/functional/gpu/test_partition.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_partition.py
@@ -277,10 +277,10 @@ class TestGpuPartition(unittest.TestCase):
         )
         return
 
-    def test_get_gpu_compute_partition_mem_alloc_mode(self):
+    def test_get_gpu_accelerator_partition_mem_alloc_mode(self):
         self.common.print_func_name("")
         self.common.Test_API_Per_GPU(
-            amdsmi_get_gpu_compute_partition_mem_alloc_mode=amdsmi.amdsmi_get_gpu_compute_partition_mem_alloc_mode
+            amdsmi_get_gpu_accelerator_partition_mem_alloc_mode=amdsmi.amdsmi_get_gpu_accelerator_partition_mem_alloc_mode
         )
         return
 
@@ -328,7 +328,7 @@ class TestGpuPartition(unittest.TestCase):
         self.common.print_func_name("")
 
         self.common.Test_Per_GPU_With_One_Enum(
-            amdsmi_set_gpu_memory_partition=amdsmi.amdsmi_set_gpu_memory_partition,
+            amdsmi_set_gpu_memory_partition_mode=amdsmi.amdsmi_set_gpu_memory_partition_mode,
             memory_partition_type=common.MEMORY_PARTITION_TYPES,
         )
         return
@@ -347,12 +347,12 @@ class TestGpuPartition(unittest.TestCase):
         )
         return
 
-    def test_set_gpu_compute_partition_mem_alloc_mode(self):
+    def test_set_gpu_accelerator_partition_mem_alloc_mode(self):
         self.common.print_func_name("")
 
         self.common.Test_Per_GPU_With_One_Enum(
-            amdsmi_set_gpu_compute_partition_mem_alloc_mode=amdsmi.amdsmi_set_gpu_compute_partition_mem_alloc_mode,
-            compute_partition_mem_alloc_mode=common.COMPUTE_PARTITION_MEM_ALLOC_MODE_TYPES,
+            amdsmi_set_gpu_accelerator_partition_mem_alloc_mode=amdsmi.amdsmi_set_gpu_accelerator_partition_mem_alloc_mode,
+            accelerator_partition_mem_alloc_mode=common.ACCELERATOR_PARTITION_MEM_ALLOC_MODE_TYPES,
         )
         return
 

--- a/projects/amdsmi/tools/hw_compatibility_status.py
+++ b/projects/amdsmi/tools/hw_compatibility_status.py
@@ -1242,6 +1242,7 @@ def run_tests():
         lambda: amdsmi.amdsmi_get_gpu_memory_partition(gpu_handle),
     )
 
+    # amdsmi_set_gpu_memory_partition deprecated, use amdsmi_set_gpu_memory_partition_mode instead
     test_api(
         "amdsmi_set_gpu_memory_partition",
         None,


### PR DESCRIPTION
## Motivation

AMD SMI historically exposed GPU partitioning under the "compute partition" name, but AMD's terminology has standardized on "accelerator partition" to reflect that these settings govern the whole accelerator, not just its compute engines. The library already had amdsmi_accelerator_partition_* APIs for the profile/type surface, but the memory-allocation-mode getters/setters and the underlying enums were still "compute"-named, leaving the API inconsistent. Additionally, amdsmi_set_gpu_memory_partition() and amdsmi_set_gpu_memory_partition_mode() were redundant entry points for the same operation. This change aligns the naming, removes the redundancy, and does so without breaking existing callers.

## Technical Details

Renames the GPU partition memory-allocation-mode API surface from `compute_partition`
to `accelerator_partition` for terminology consistency, and consolidates the
memory-partition set path — all backward-compatibly via deprecation shims.

**New APIs**
- `amdsmi_get_gpu_accelerator_partition_mem_alloc_mode()`
- `amdsmi_set_gpu_accelerator_partition_mem_alloc_mode()`
- Enum `amdsmi_accelerator_partition_mem_alloc_mode_t`
  (`INVALID` / `CAPPING` / `ALL`)

These now own the implementation and validation. The C declarations, `amd_smi.cc`
definitions, ctypes wrapper, Rust wrapper, and Python interface/`__init__` exports
are all updated.

**Deprecations (retained as delegating shims)**
- `amdsmi_get_gpu_compute_partition()` / `amdsmi_set_gpu_compute_partition()`
- `amdsmi_get_gpu_compute_partition_mem_alloc_mode()` /
  `amdsmi_set_gpu_compute_partition_mem_alloc_mode()`
- `amdsmi_set_gpu_memory_partition()` → forwards to
  `amdsmi_set_gpu_memory_partition_mode()`, which now owns the sysfs write,
  validation, and driver-reload messaging
- Enums `amdsmi_compute_partition_type_t` and
  `amdsmi_compute_partition_mem_alloc_mode_t`

C entry points carry `@deprecated` doxygen; Python wrappers emit
`DeprecationWarning` and delegate to the new functions. No functions or enums are
removed.

**Callers / tests / docs**
- CLI `set` and `static --partition` updated to the accelerator names.
- GTest and Python functional/CLI suites updated to exercise the new names.
- `docs/reference/amdsmi-py-api.md` and `CHANGELOG.md` (Added + Deprecated) updated.

**Behavior change to note**
- CLI JSON output key `compute_partition_mem_alloc_mode` →
  `accelerator_partition_mem_alloc_mode`.

## Issue Tracking

JIRA ID : AILITOOLS-270

## Test Plan

amdsmitst
unit_tests.py
cli_unit_test.py

## Test Result

All tests ran with expected results
