### PR TITLE
fix(rocshmem) Make hsakmt compile on rocm 7.13/14 despite errors in hsakmt-config.cmake 

### DIFF
--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -314,6 +314,21 @@ if (NOT BUILD_TESTS_ONLY)
 
   if (USE_SDMA)
     find_package(hsakmt REQUIRED)
+    # Workaround for RoCM 7.13/14
+    # hsakmtTargets.cmake contains paths baked in from the ROCm RHEL CI build:
+    #   /usr/lib64/libc.so      — bare libc path instead of -lc (always implicit)
+    #   -L/__w/rockrel/...      — hardcoded CI search path for libdrm/libdrm_amdgpu
+    # Strip both and inject the correct search path for libdrm.
+    get_target_property(_hsakmt_iface_libs hsakmt::hsakmt INTERFACE_LINK_LIBRARIES)
+    list(FILTER _hsakmt_iface_libs EXCLUDE REGEX "(/libc\\.so|/__w/)")
+    find_library(_DRM_LIB drm HINTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
+    if(_DRM_LIB)
+      get_filename_component(_drm_dir "${_DRM_LIB}" DIRECTORY)
+      list(PREPEND _hsakmt_iface_libs "-L${_drm_dir}")
+      unset(_drm_dir)
+    endif()
+    set_target_properties(hsakmt::hsakmt PROPERTIES INTERFACE_LINK_LIBRARIES "${_hsakmt_iface_libs}")
+    unset(_hsakmt_iface_libs)
   endif()
 
   set(CMAKE_THREAD_PREFER_PTHREAD TRUE)


### PR DESCRIPTION
## Motivation

rocSHMEM with -DUSE_SDMA=ON will not compile on theRock 7.13 and 7.14 because the hsakmt cmake package imports RHEL specific paths. 

## Technical Details

Workaround: remove the offending paths from the imported target, and make sure we search for hsakmt dependencies in the right place instead.


## Issue Tracking

JIRA ID: AIROCSHMEM-464

## Test Plan

Builds and run SDMA on both rocm-7.13 and rocm-7.14. Still builds on older rocm.

## Test Result

Builds and run with both, installed as deb packages on Ubuntu. Tested still functional on 7.2.1.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
