### PR TITLE
feat(rccl): Share QPs between PAT ReduceScatter and AllGather

### DIFF
--- a/projects/rccl/src/device/all_gather.h
+++ b/projects/rccl/src/device/all_gather.h
@@ -181,7 +181,8 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_PAT, NCCL_PROTO_SIMPLE
 
     if (tid == nworkers) { // Algo computation thread
       PatAGAlgorithm<T> patAlgo(chunkCount * sizeof(T), NCCL_STEPS, NCCL_PAT_NWORKERS / WARP_SIZE, channelOffset,
-                                channelOffset + channelCount, count, chunkCount, rank, nranks);
+                                channelOffset + channelCount, count, chunkCount, rank, nranks,
+                                ncclShmem.comm.patSharedQps);
       int parallelFactor = shmem->parallelFactor = patAlgo.getParallelFactor();
       (void)parallelFactor;// unused variable - compiler warning
       int step = 0;

--- a/projects/rccl/src/device/prims_simple.h
+++ b/projects/rccl/src/device/prims_simple.h
@@ -739,8 +739,10 @@ public:
     if (tid < 32 && ((1UL << tid) < nranks)) {
       int rank = ncclShmem.comm.rank;
       uint32_t delta = 1 << tid;
+      // When sharing, RS and AG both recv from rank-delta and send to rank+delta; otherwise AG mirrors RS.
+      const bool shared = ncclShmem.comm.patSharedQps != 0;
       // Load recv peer
-      int recvPeer = mode == primsModePatRs ? (rank - delta + nranks) % nranks : (rank + delta) % nranks;
+      int recvPeer = (shared || mode == primsModePatRs) ? (rank - delta + nranks) % nranks : (rank + delta) % nranks;
       struct ncclPatPeer* peer = ((struct ncclPatPeer*)recvPeers) + tid;
       struct ncclConnInfo* conn = peer->conn = channel->peers[recvPeer]->recv + connIndexRecv;
       peer->step = conn->step;
@@ -750,7 +752,7 @@ public:
       peer->accSize = 0;
       peer->connStepSize = conn->stepSize / sizeof(T);
       // Load send peer
-      int sendPeer = mode == primsModePatAg ? (rank - delta + nranks) % nranks : (rank + delta) % nranks;
+      int sendPeer = (!shared && mode == primsModePatAg) ? (rank - delta + nranks) % nranks : (rank + delta) % nranks;
       peer = ((struct ncclPatPeer*)sendPeers) + tid;
       conn = peer->conn = channel->peers[sendPeer]->send + connIndexSend;
       peer->step = conn->step;

--- a/projects/rccl/src/include/collectives.h
+++ b/projects/rccl/src/include/collectives.h
@@ -713,6 +713,7 @@ public:
   }
 };
 
+// When sharedConns is set, AllGather reuses PatRSAlgorithm's peer directions, so its data blocks are indexed rank-s.
 template <typename T>
 class PatAGAlgorithm {
   size_t offset;
@@ -722,6 +723,7 @@ class PatAGAlgorithm {
   int nelem;
   int rank;
   int nranks;
+  int sharedConns;
   int nrPow2;
   int postFreq;
   int lastA;
@@ -806,8 +808,9 @@ class PatAGAlgorithm {
 
 public:
   __device__ __host__ PatAGAlgorithm(int stepSize, int stepDepth, int maxParallelFactor, size_t offset, size_t end,
-                                     size_t count, int chunkCount, int rank, int nranks)
-    : offset(offset), end(end), count(count), chunkCount(chunkCount), rank(rank), nranks(nranks) {
+                                     size_t count, int chunkCount, int rank, int nranks, int sharedConns)
+    : offset(offset), end(end), count(count), chunkCount(chunkCount), rank(rank), nranks(nranks),
+      sharedConns(sharedConns) {
     parallelFactor = maxParallelFactor;
     aggDelta = nrPow2 = (1 << log2Up(nranks));
 
@@ -844,7 +847,8 @@ public:
     } else if (phase == 0) {
       int s = a * aggDelta + as;
       if (s >= nranks) skip = 1;
-      int recvDataRank = (rank + s) % nranks;
+      // C++ % truncates toward zero, so (rank - s + nranks) % nranks is still negative when s > rank + nranks.
+      int recvDataRank = sharedConns ? ((rank - s) % nranks + nranks) % nranks : (rank + s) % nranks;
       ps->outIx = recvDataRank * count + offset;
       ps->sendDim = -1;
       ps->recvDim = 0;
@@ -859,7 +863,7 @@ public:
       if (s >= nranks) skip = 1;
       ps->sendDim = firstBitSet(s, nrPow2);
       s -= (1 << ps->sendDim);
-      int sendDataRank = (rank + nranks + s) % nranks;
+      int sendDataRank = sharedConns ? ((rank - s) % nranks + nranks) % nranks : (rank + nranks + s) % nranks;
       ps->outIx = sendDataRank * count + offset;
       ps->recvDim = s ? firstBitSet(s, nrPow2) : -1;
       ps->sendOffset = ps->recvOffset = (a % postFreq) * nelem;
@@ -895,7 +899,7 @@ public:
       s -= (1 << ps->sendDim);
       ps->sendOffset = (a % postFreq) * nelem;
       ps->stepOffset = a / postFreq;
-      int sendDataRank = (rank + nranks + s) % nranks;
+      int sendDataRank = sharedConns ? ((rank - s) % nranks + nranks) % nranks : (rank + nranks + s) % nranks;
       ps->outIx = sendDataRank * count + offset;
       ps->recvDim = s ? firstBitSet(s, nrPow2) : -1;
       if (ps->recvDim == -1) {

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -706,6 +706,9 @@ struct ncclComm {
   // Force PAT algorithm for this communicator
   bool forcePatEnable;
 
+  // PAT ReduceScatter and AllGather share one connection set; must match on every rank
+  bool patSharedQps;
+
   // MNNVL: Multi-Node NVLink
   int MNNVL; // true when MNNVL is available
   struct cliqueInfo clique; // Our MNNVL clique information

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -616,6 +616,7 @@ struct ncclKernelComm {
   int isAllNvlink;
   int p2pnChannelsPerPeer;
   int cheapPostSendFenceOff; // RCCL: true if cheap post-peer fence is disabled (comm-global)
+  int patSharedQps; // true if PAT ReduceScatter and AllGather share one connection set
   int p2pChannelShiftSize; // [RCCL] Modifies how parts are mapped to p2p channels
   int* collNetDenseToUserRank;
 

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -119,6 +119,10 @@ NCCL_PARAM(CommBlocking, "COMM_BLOCKING", NCCL_CONFIG_UNDEF_INT);
 NCCL_PARAM(RuntimeConnect, "RUNTIME_CONNECT", 0);
 // When enabled (default), defer PAT QP creation until PAT is first selected by an AG/RS; NCCL_PAT_LAZY_INIT=0 restores eager connect at init.
 NCCL_PARAM(PatLazyInit, "PAT_LAZY_INIT", 1);
+// When enabled (default), PAT ReduceScatter and AllGather share one connection set.
+// RCCL_PAT_SHARED_QPS=0 restores a separate set per collective. The value must be identical on
+// every rank, otherwise peers disagree on direction and the first PAT collective hangs.
+RCCL_PARAM(PatSharedQps, "PAT_SHARED_QPS", 1);
 NCCL_PARAM(WinEnable, "WIN_ENABLE", 1);
 NCCL_PARAM(CollnetEnable, "COLLNET_ENABLE", NCCL_CONFIG_UNDEF_INT);
 NCCL_PARAM(CtaPolicy, "CTA_POLICY", NCCL_CONFIG_UNDEF_INT);
@@ -710,6 +714,7 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   comm->hierarchicalTempBuffer = nullptr;
   // Enable PAT for interComm hierarchical collectives
   comm->forcePatEnable = (parent != nullptr) ? parent->forcePatEnable : false;
+  comm->patSharedQps = rcclParamPatSharedQps() != 0;
 
   // Try to create a CUDA object right away. If there is something wrong with
   // the device we're on (failure cause #1) , better know it early.
@@ -891,6 +896,7 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
   tmpCommAndChans.comm.isAllNvlink = comm->isAllNvlink;
   tmpCommAndChans.comm.p2pnChannelsPerPeer = comm->p2pnChannelsPerPeer;
   tmpCommAndChans.comm.cheapPostSendFenceOff = comm->cheapPostSendFenceOff;
+  tmpCommAndChans.comm.patSharedQps = comm->patSharedQps ? 1 : 0;
   for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     tmpCommAndChans.comm.buffSizes[p] = comm->buffSizes[p];
   }

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -750,7 +750,9 @@ ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* op, bool
       const ssize_t size = op->nbytes / comm->nRanks;
       const int rank = comm->rank, nranks = comm->nRanks;
       int *nstepsSend = NULL, *nstepsRecv = NULL;
-      PatAGAlgorithm<char> algo(op->chunkSize, NCCL_STEPS, 16, 0, size, size, op->chunkSize, rank, nranks);
+      const int sharedConns = comm->patSharedQps ? 1 : 0;
+      PatAGAlgorithm<char> algo(op->chunkSize, NCCL_STEPS, 16, 0, size, size, op->chunkSize, rank, nranks,
+                                sharedConns);
       struct ncclPatStep ps = {0};
       NCCLCHECKGOTO(ncclCalloc(&nstepsSend, log2Up(nranks)), result, exit_pat_down);
       NCCLCHECKGOTO(ncclCalloc(&nstepsRecv, log2Up(nranks)), result, exit_pat_down);
@@ -761,14 +763,15 @@ ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* op, bool
         if (ps.recvDim != -1 && ps.postRecv) nstepsRecv[ps.recvDim]++;
         if (ps.sendDim != -1 && ps.postSend) nstepsSend[ps.sendDim]++;
       } while (ps.last != 2);
+      // When sharing, these match ncclPatternPatUp so AllGather and ReduceScatter use one connection set.
       for (int i = 0; i < log2Up(nranks); i++) {
         if (nstepsSend[i]) {
-          int sendPeer = (rank - (1 << i) + nranks) % nranks;
+          int sendPeer = sharedConns ? (rank + (1 << i)) % nranks : (rank - (1 << i) + nranks) % nranks;
           op->nsteps = nstepsSend[i];
           NCCLCHECKGOTO(SaveProxy(comm, channel, proxySend, sendPeer, op, 0, justInquire), result, exit_pat_down);
         }
         if (nstepsRecv[i]) {
-          int recvPeer = (rank + (1 << i)) % nranks;
+          int recvPeer = sharedConns ? (rank - (1 << i) + nranks) % nranks : (rank + (1 << i)) % nranks;
           op->nsteps = nstepsRecv[i];
           NCCLCHECKGOTO(SaveProxy(comm, channel, proxyRecv, recvPeer, op, 0, justInquire), result, exit_pat_down);
         }

--- a/projects/rccl/src/transport/generic.cc
+++ b/projects/rccl/src/transport/generic.cc
@@ -72,16 +72,21 @@ ncclResult_t ncclTransportPatConnect(struct ncclComm* comm) {
     for (int mask = 1; mask < comm->nRanks; mask <<= 1) {
       int prevPeer = (comm->rank + mask) % comm->nRanks;
       int nextPeer = (comm->rank + comm->nRanks - mask) % comm->nRanks;
-      for (int c = 0; c < comm->nChannels; c++) {
-        NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &prevPeer, 1, &nextPeer, 0), ret, fail); // ReduceScatter
+      if (!comm->patSharedQps) {
+        // AllGather keeps its own mirrored connection set, connected first as it was before sharing.
+        for (int c = 0; c < comm->nChannels; c++) {
+          NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &prevPeer, 1, &nextPeer, 0), ret, fail);
+        }
+        NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_TREE], 0), ret, fail);
       }
-      NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_TREE], 0), ret, fail);
+      // When sharing, RS and AG both recv from nextPeer and send to prevPeer, so one pass connects both.
       for (int c = 0; c < comm->nChannels; c++) {
-        NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &nextPeer, 1, &prevPeer, 0), ret, fail); // AllGather
+        NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &nextPeer, 1, &prevPeer, 0), ret, fail);
       }
       NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_TREE], 0), ret, fail);
     }
-    INFO(NCCL_INIT, "Connected binomial trees");
+    INFO(NCCL_INIT, "Connected binomial trees%s",
+         comm->patSharedQps ? "" : " with separate ReduceScatter and AllGather connections");
   }
 exit:
   return ret;

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -488,6 +488,7 @@ if(BUILD_TESTS)
       PluginCompatV10_test.cpp
       PluginCompatV11_test.cpp
       ProxyTests.cpp
+      PatAlgorithmTests.cpp
       RcclWrapTests.cpp
       SocketPollTests.cpp
       TransportTests.cpp

--- a/projects/rccl/test/CommMPITests.cpp
+++ b/projects/rccl/test/CommMPITests.cpp
@@ -172,6 +172,498 @@ TEST_F(PatLazyInitMPITest, DefersConnectionUntilFirstCollective)
     ASSERT_MPI_TRUE(collective_log.find("Connected binomial trees") != std::string::npos);
 }
 
+// The environment every PAT test below needs, bundled so each test spends one line on it.
+// Hierarchical AllGather has to be off or it intercepts ncclAllGather before PAT sees it, which
+// would let a PAT test pass without ever running PAT.
+struct PatTestEnv
+{
+    MPIHelpers::MpiEnvGuard pat_enable{"NCCL_PAT_ENABLE", "1"};
+    MPIHelpers::MpiEnvGuard pat_lazy{"NCCL_PAT_LAZY_INIT", "1"};
+    MPIHelpers::MpiEnvGuard algorithm{"NCCL_ALGO", "PAT"};
+    MPIHelpers::MpiEnvGuard protocol{"NCCL_PROTO", "SIMPLE"};
+    MPIHelpers::MpiEnvGuard cumem{"NCCL_CUMEM_ENABLE", "0"};
+    MPIHelpers::MpiEnvGuard hag{"RCCL_HIERARCHICAL_ALLGATHER", "0"};
+};
+
+class PatSharedConnectionMPITest : public MPITestBase
+{
+protected:
+    // Returns the decision rather than skipping here, because GTEST_SKIP() in a helper does not
+    // stop the calling test.
+    bool oneRankPerNode()
+    {
+        MPI_Comm local_comm;
+        if(MPI_Comm_split_type(
+               MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &local_comm) != MPI_SUCCESS)
+        {
+            return false;
+        }
+        int local_size = 0;
+        MPI_Comm_size(local_comm, &local_size);
+        MPI_Comm_free(&local_comm);
+        return local_size == 1;
+    }
+
+    // Null means the topology can run PAT. Otherwise a skip reason for the caller to GTEST_SKIP().
+    const char* patSkipReason()
+    {
+        if(!validateTestPrerequisites(/*min_processes=*/4))
+        {
+            return "PAT sharing tests need at least 4 MPI ranks";
+        }
+        if(!oneRankPerNode())
+        {
+            return "PAT requires exactly one MPI rank per node";
+        }
+        return nullptr;
+    }
+};
+
+/**
+ * ReduceScatter and AllGather address the same binomial neighbors, so PAT builds one
+ * connection per neighbor and direction instead of a mirrored pair. Lazy init defers that
+ * work to the first PAT collective, which lets the test separate the PAT connections from
+ * the ring and tree connections already established during ncclCommInitRank.
+ *
+ * Below four ranks the mask set is closed under mask -> nranks-mask, so both connect passes
+ * target the same peers and there is nothing to distinguish.
+ *
+ * RCCL_PARAM caches into a process-lifetime static, so the first communicator built in this
+ * binary fixes RCCL_PAT_SHARED_QPS for every later one. This test therefore skips rather than
+ * fails when the kill switch was set before launch, and its counterpart below does the reverse.
+ */
+TEST_F(PatSharedConnectionMPITest, AllGatherReusesReduceScatterConnections)
+{
+    if(const char* why = patSkipReason())
+    {
+        GTEST_SKIP() << why;
+    }
+
+    PatTestEnv env;
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_MPI_TRUE(comm != nullptr);
+    if(!comm->patSharedQps)
+    {
+        GTEST_SKIP() << "RCCL_PAT_SHARED_QPS is disabled for this process, so PAT builds the "
+                        "mirrored connection set; run without it to exercise sharing";
+    }
+    ASSERT_MPI_FALSE(comm->initAlgoChannels[NCCL_ALGO_PAT]);
+
+    const int rank = comm->rank;
+    const int nranks = comm->nRanks;
+    const int nchannels = comm->nChannels;
+
+    std::vector<int> send_before(static_cast<size_t>(nchannels) * nranks, 0);
+    std::vector<int> recv_before(static_cast<size_t>(nchannels) * nranks, 0);
+    for(int channel = 0; channel < nchannels; ++channel)
+    {
+        for(int peer = 0; peer < nranks; ++peer)
+        {
+            const size_t index = static_cast<size_t>(channel) * nranks + peer;
+            send_before[index] = comm->channels[channel].peers[peer]->send[0].connected;
+            recv_before[index] = comm->channels[channel].peers[peer]->recv[0].connected;
+        }
+    }
+
+    void* send_buffer = nullptr;
+    void* recv_buffer = nullptr;
+    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&send_buffer, sizeof(uint8_t)));
+    auto send_guard = makeDeviceBufferAutoGuard(send_buffer);
+    ASSERT_MPI_EQ(hipSuccess,
+                  hipMalloc(&recv_buffer, sizeof(uint8_t) * MPIEnvironment::world_size));
+    auto recv_guard = makeDeviceBufferAutoGuard(recv_buffer);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclAllGather(send_buffer,
+                                recv_buffer,
+                                1,
+                                ncclUint8,
+                                comm,
+                                getActiveStream()));
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+    ASSERT_MPI_TRUE(comm->initAlgoChannels[NCCL_ALGO_PAT]);
+
+    // The connections PAT is allowed to add, i.e. ReduceScatter's directions. The two-pass
+    // connect also built the mirror of every entry, which is what this test rules out.
+    std::vector<char> expect_recv(nranks, 0);
+    std::vector<char> expect_send(nranks, 0);
+    for(int mask = 1; mask < nranks; mask <<= 1)
+    {
+        expect_recv[(rank - mask + nranks) % nranks] = 1;
+        expect_send[(rank + mask) % nranks] = 1;
+    }
+
+    for(int channel = 0; channel < nchannels; ++channel)
+    {
+        for(int peer = 0; peer < nranks; ++peer)
+        {
+            const size_t index = static_cast<size_t>(channel) * nranks + peer;
+            const int recv_now = comm->channels[channel].peers[peer]->recv[0].connected;
+            const int send_now = comm->channels[channel].peers[peer]->send[0].connected;
+
+            if(expect_recv[peer])
+            {
+                ASSERT_MPI_TRUE(recv_now);
+            }
+            else
+            {
+                ASSERT_MPI_EQ(recv_before[index], recv_now);
+            }
+
+            if(expect_send[peer])
+            {
+                ASSERT_MPI_TRUE(send_now);
+            }
+            else
+            {
+                ASSERT_MPI_EQ(send_before[index], send_now);
+            }
+        }
+    }
+}
+
+/**
+ * RCCL_PAT_SHARED_QPS=0 restores the mirrored connection set AllGather used before sharing.
+ * Asserting the mirror is present keeps that fallback path from decaying unnoticed, and the
+ * AllGather payload check covers the device primitives and PatAGAlgorithm still agreeing with
+ * the proxy on peer direction when sharing is off.
+ *
+ * The MpiEnvGuard below only takes effect when this test builds the first communicator in the
+ * process, because RCCL_PARAM caches. Launch with RCCL_PAT_SHARED_QPS=0 already in the
+ * environment to run it alongside other communicator tests; otherwise it skips.
+ */
+TEST_F(PatSharedConnectionMPITest, SeparateConnectionsWhenSharingDisabled)
+{
+    if(const char* why = patSkipReason())
+    {
+        GTEST_SKIP() << why;
+    }
+
+    PatTestEnv              env;
+    MPIHelpers::MpiEnvGuard pat_shared("RCCL_PAT_SHARED_QPS", "0");
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_MPI_TRUE(comm != nullptr);
+    if(comm->patSharedQps)
+    {
+        GTEST_SKIP() << "RCCL_PAT_SHARED_QPS was already cached as enabled by an earlier "
+                        "communicator in this process; set it to 0 before launch to run this test";
+    }
+
+    const int rank = comm->rank;
+    const int nranks = comm->nRanks;
+    const int nchannels = comm->nChannels;
+
+    const uint8_t expected_byte = static_cast<uint8_t>(rank);
+    void* send_buffer = nullptr;
+    void* recv_buffer = nullptr;
+    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&send_buffer, sizeof(uint8_t)));
+    auto send_guard = makeDeviceBufferAutoGuard(send_buffer);
+    ASSERT_MPI_EQ(hipSuccess,
+                  hipMalloc(&recv_buffer, sizeof(uint8_t) * MPIEnvironment::world_size));
+    auto recv_guard = makeDeviceBufferAutoGuard(recv_buffer);
+    ASSERT_MPI_EQ(hipSuccess,
+                  hipMemcpy(send_buffer, &expected_byte, sizeof(uint8_t), hipMemcpyHostToDevice));
+
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclAllGather(send_buffer,
+                                recv_buffer,
+                                1,
+                                ncclUint8,
+                                comm,
+                                getActiveStream()));
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+    std::vector<uint8_t> gathered(static_cast<size_t>(nranks), 0);
+    ASSERT_MPI_EQ(hipSuccess,
+                  hipMemcpy(gathered.data(),
+                            recv_buffer,
+                            sizeof(uint8_t) * nranks,
+                            hipMemcpyDeviceToHost));
+    for(int peer = 0; peer < nranks; ++peer)
+    {
+        ASSERT_MPI_EQ(static_cast<uint8_t>(peer), gathered[static_cast<size_t>(peer)]);
+    }
+
+    // Without sharing, every mask connects both its own direction and the mirror.
+    for(int mask = 1; mask < nranks; mask <<= 1)
+    {
+        const int next_peer = (rank - mask + nranks) % nranks;
+        const int prev_peer = (rank + mask) % nranks;
+        for(int channel = 0; channel < nchannels; ++channel)
+        {
+            ASSERT_MPI_TRUE(comm->channels[channel].peers[next_peer]->recv[0].connected);
+            ASSERT_MPI_TRUE(comm->channels[channel].peers[next_peer]->send[0].connected);
+            ASSERT_MPI_TRUE(comm->channels[channel].peers[prev_peer]->recv[0].connected);
+            ASSERT_MPI_TRUE(comm->channels[channel].peers[prev_peer]->send[0].connected);
+        }
+    }
+}
+
+/**
+ * Sharing puts ReduceScatter and AllGather on the same connections, so they now also share that
+ * connection's ring buffer and its persistent step counter (ncclConnInfo::step). A disagreement
+ * between the two about how many steps an operation consumes cannot show up while only one of
+ * them runs; it shows up on whichever collective runs next, and small drift only after several
+ * rounds. Hence one communicator, both collectives, repeatedly.
+ *
+ * Lazy init makes the ordering meaningful: the first ReduceScatter builds the PAT connections and
+ * every AllGather afterwards has to be satisfied by what that single shared pass created.
+ *
+ * The two are chained, so the pair is an AllReduce: every rank must end each iteration holding
+ * nranks times its input. The intermediate ReduceScatter block and final AllGather vector are
+ * validated independently. Values are distinct across the whole vector, so a wrong data-block
+ * index surfaces as a permutation rather than as garbage, and they change every iteration, so a
+ * collective that silently did nothing surfaces as stale values.
+ *
+ * Runs in both modes. Under RCCL_PAT_SHARED_QPS=0 it validates the fallback path unchanged.
+ */
+TEST_F(PatSharedConnectionMPITest, AlternatingReduceScatterAndAllGatherOnOneCommunicator)
+{
+    if(const char* why = patSkipReason())
+    {
+        GTEST_SKIP() << why;
+    }
+
+    PatTestEnv env;
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_MPI_TRUE(comm != nullptr);
+    ASSERT_MPI_FALSE(comm->initAlgoChannels[NCCL_ALGO_PAT]);
+
+    // Doubles because the check below needs nranks * value to be exact, and the values have to
+    // stay distinct across a buffer far larger than float can index exactly.
+    constexpr int    kIterations   = 16;
+    constexpr size_t kCountPerRank = 65536;
+    const size_t     nranks        = static_cast<size_t>(comm->nRanks);
+    const size_t     total         = kCountPerRank * nranks;
+    const size_t     rank_offset   = static_cast<size_t>(comm->rank) * kCountPerRank;
+
+    void* whole = nullptr;
+    void* part  = nullptr;
+    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&whole, total * sizeof(double)));
+    auto whole_guard = makeDeviceBufferAutoGuard(whole);
+    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&part, kCountPerRank * sizeof(double)));
+    auto part_guard = makeDeviceBufferAutoGuard(part);
+
+    std::vector<double> input(total);
+    std::vector<double> reduce_scatter_result(kCountPerRank);
+    std::vector<double> all_gather_result(total);
+
+    // Only prints under NCCL_DEBUG=INFO; it is how a log can confirm the shape actually run.
+    TEST_INFO("alternating RS+AG: %d iterations, %zu ranks, %zu KiB/collective",
+              kIterations,
+              nranks,
+              total * sizeof(double) / 1024);
+
+    for(int iter = 0; iter < kIterations; ++iter)
+    {
+        SCOPED_TRACE("iteration " + std::to_string(iter));
+
+        for(size_t i = 0; i < total; ++i)
+        {
+            input[i] = static_cast<double>(static_cast<size_t>(iter) * total + i + 1);
+        }
+        ASSERT_MPI_EQ(
+            hipSuccess,
+            hipMemcpy(whole, input.data(), total * sizeof(double), hipMemcpyHostToDevice));
+
+        ASSERT_MPI_EQ(ncclSuccess,
+                      ncclReduceScatter(whole,
+                                        part,
+                                        kCountPerRank,
+                                        ncclDouble,
+                                        ncclSum,
+                                        comm,
+                                        getActiveStream()));
+        if(iter == 0)
+        {
+            // Enqueue, not execution, does the lazy connect, so this holds without a sync and
+            // proves the AllGather below runs on connections ReduceScatter created.
+            ASSERT_MPI_TRUE(comm->initAlgoChannels[NCCL_ALGO_PAT]);
+        }
+        ASSERT_MPI_EQ(
+            ncclSuccess,
+            ncclAllGather(part, whole, kCountPerRank, ncclDouble, comm, getActiveStream()));
+        ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+        ASSERT_MPI_EQ(
+            hipSuccess,
+            hipMemcpy(reduce_scatter_result.data(),
+                      part,
+                      kCountPerRank * sizeof(double),
+                      hipMemcpyDeviceToHost));
+        ASSERT_MPI_EQ(
+            hipSuccess,
+            hipMemcpy(all_gather_result.data(),
+                      whole,
+                      total * sizeof(double),
+                      hipMemcpyDeviceToHost));
+
+        // Counted rather than asserted per element: ASSERT_MPI_EQ costs an MPI_Allreduce.
+        size_t reduce_scatter_mismatches = 0;
+        for(size_t i = 0; i < kCountPerRank; ++i)
+        {
+            const double expected = input[rank_offset + i] * static_cast<double>(nranks);
+            if(reduce_scatter_result[i] != expected)
+            {
+                ++reduce_scatter_mismatches;
+            }
+        }
+        ASSERT_MPI_EQ(size_t{0}, reduce_scatter_mismatches);
+
+        size_t all_gather_mismatches = 0;
+        for(size_t i = 0; i < total; ++i)
+        {
+            if(all_gather_result[i] != input[i] * static_cast<double>(nranks))
+            {
+                ++all_gather_mismatches;
+            }
+        }
+        ASSERT_MPI_EQ(size_t{0}, all_gather_mismatches);
+    }
+}
+
+/**
+ * Alternating covers sequential launches. Sharing also lets ReduceScatter and AllGather
+ * queue proxy ops onto the same connection and step counter inside one ncclGroupStart/End,
+ * before either kernel runs. That is a different interleaving than back-to-back launches.
+ *
+ * The two collectives use independent buffers so a group launch cannot race a producer-consumer
+ * dependency. Values are distinct so a wrong data-block index still shows up as a permutation.
+ * Runs in both sharing modes.
+ */
+TEST_F(PatSharedConnectionMPITest, GroupedReduceScatterAndAllGatherOnOneCommunicator)
+{
+    if(const char* why = patSkipReason())
+    {
+        GTEST_SKIP() << why;
+    }
+
+    PatTestEnv env;
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_MPI_TRUE(comm != nullptr);
+    ASSERT_MPI_FALSE(comm->initAlgoChannels[NCCL_ALGO_PAT]);
+
+    constexpr int    kIterations   = 8;
+    constexpr size_t kCountPerRank = 1024;
+    const size_t     nranks        = static_cast<size_t>(comm->nRanks);
+    const size_t     total         = kCountPerRank * nranks;
+    const size_t     rank_offset   = static_cast<size_t>(comm->rank) * kCountPerRank;
+
+    void* rs_send = nullptr;
+    void* rs_recv = nullptr;
+    void* ag_send = nullptr;
+    void* ag_recv = nullptr;
+    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&rs_send, total * sizeof(double)));
+    auto rs_send_guard = makeDeviceBufferAutoGuard(rs_send);
+    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&rs_recv, kCountPerRank * sizeof(double)));
+    auto rs_recv_guard = makeDeviceBufferAutoGuard(rs_recv);
+    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&ag_send, kCountPerRank * sizeof(double)));
+    auto ag_send_guard = makeDeviceBufferAutoGuard(ag_send);
+    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&ag_recv, total * sizeof(double)));
+    auto ag_recv_guard = makeDeviceBufferAutoGuard(ag_recv);
+
+    std::vector<double> rs_input(total);
+    std::vector<double> rs_result(kCountPerRank);
+    std::vector<double> ag_input(kCountPerRank);
+    std::vector<double> ag_result(total);
+
+    TEST_INFO("grouped RS+AG: %d iterations, %zu ranks, %zu KiB/collective",
+              kIterations,
+              nranks,
+              total * sizeof(double) / 1024);
+
+    for(int iter = 0; iter < kIterations; ++iter)
+    {
+        SCOPED_TRACE("iteration " + std::to_string(iter));
+
+        for(size_t i = 0; i < total; ++i)
+        {
+            rs_input[i] = static_cast<double>(static_cast<size_t>(iter) * total + i + 1);
+        }
+        for(size_t i = 0; i < kCountPerRank; ++i)
+        {
+            ag_input[i] = static_cast<double>(
+                (static_cast<size_t>(iter) + 1) * total + rank_offset + i + 1);
+        }
+        ASSERT_MPI_EQ(
+            hipSuccess,
+            hipMemcpy(rs_send, rs_input.data(), total * sizeof(double), hipMemcpyHostToDevice));
+        ASSERT_MPI_EQ(
+            hipSuccess,
+            hipMemcpy(ag_send, ag_input.data(), kCountPerRank * sizeof(double), hipMemcpyHostToDevice));
+
+        ASSERT_MPI_EQ(ncclSuccess, ncclGroupStart());
+        ASSERT_MPI_EQ(ncclSuccess,
+                      ncclReduceScatter(rs_send,
+                                        rs_recv,
+                                        kCountPerRank,
+                                        ncclDouble,
+                                        ncclSum,
+                                        comm,
+                                        getActiveStream()));
+        ASSERT_MPI_EQ(
+            ncclSuccess,
+            ncclAllGather(ag_send, ag_recv, kCountPerRank, ncclDouble, comm, getActiveStream()));
+        ASSERT_MPI_EQ(ncclSuccess, ncclGroupEnd());
+        ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+        if(iter == 0)
+        {
+            ASSERT_MPI_TRUE(comm->initAlgoChannels[NCCL_ALGO_PAT]);
+        }
+
+        ASSERT_MPI_EQ(
+            hipSuccess,
+            hipMemcpy(rs_result.data(),
+                      rs_recv,
+                      kCountPerRank * sizeof(double),
+                      hipMemcpyDeviceToHost));
+        ASSERT_MPI_EQ(
+            hipSuccess,
+            hipMemcpy(ag_result.data(), ag_recv, total * sizeof(double), hipMemcpyDeviceToHost));
+
+        size_t rs_mismatches = 0;
+        for(size_t i = 0; i < kCountPerRank; ++i)
+        {
+            const double expected = rs_input[rank_offset + i] * static_cast<double>(nranks);
+            if(rs_result[i] != expected)
+            {
+                ++rs_mismatches;
+            }
+        }
+        ASSERT_MPI_EQ(size_t{0}, rs_mismatches);
+
+        size_t ag_mismatches = 0;
+        for(int peer = 0; peer < comm->nRanks; ++peer)
+        {
+            for(size_t i = 0; i < kCountPerRank; ++i)
+            {
+                const double expected = static_cast<double>(
+                    (static_cast<size_t>(iter) + 1) * total
+                    + static_cast<size_t>(peer) * kCountPerRank + i + 1);
+                if(ag_result[static_cast<size_t>(peer) * kCountPerRank + i] != expected)
+                {
+                    ++ag_mismatches;
+                }
+            }
+        }
+        ASSERT_MPI_EQ(size_t{0}, ag_mismatches);
+    }
+}
+
 /**
  * @class TrafficClassMPITest
  * @brief Test fixture for Traffic Class (QoS) configuration via ncclConfig_t.

--- a/projects/rccl/test/PatAlgorithmTests.cpp
+++ b/projects/rccl/test/PatAlgorithmTests.cpp
@@ -1,0 +1,54 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include "collectives.h"
+#include "gtest/gtest.h"
+
+namespace RcclUnitTesting
+{
+
+// PatAGAlgorithm::getNextOp is __host__ as well as __device__, so the shared-conn
+// data-block index can be checked here without MPI or a GPU. The skip=1 case
+// (s >= nranks) is what used to feed C++ a negative dividend.
+TEST(PatAGAlgorithmTests, SharedDataRankStaysInRangeOnSkippedSteps)
+{
+    constexpr size_t kCount = 1024;
+    constexpr int    kChunk = 1024;
+    const int        ranks[] = {3, 4, 5, 6, 7, 8, 9, 15, 16, 17};
+
+    for(int nranks : ranks)
+    {
+        for(int rank = 0; rank < nranks; ++rank)
+        {
+            for(int shared = 0; shared <= 1; ++shared)
+            {
+                PatAGAlgorithm<char> algo(/*stepSize=*/4096,
+                                          NCCL_STEPS,
+                                          /*maxParallelFactor=*/16,
+                                          /*offset=*/0,
+                                          /*end=*/kCount,
+                                          kCount,
+                                          kChunk,
+                                          rank,
+                                          nranks,
+                                          shared);
+                struct ncclPatStep ps    = {};
+                int                steps = 0;
+                do
+                {
+                    algo.getNextOp(&ps);
+                    // outIx is size_t: a negative recvDataRank wraps to a huge offset.
+                    EXPECT_LE(ps.outIx, static_cast<size_t>(nranks - 1) * kCount)
+                        << "nranks=" << nranks << " rank=" << rank << " shared=" << shared
+                        << " step=" << steps;
+                    ASSERT_LT(++steps, 100000) << "getNextOp did not terminate";
+                } while(ps.last != 2);
+            }
+        }
+    }
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/test_categories_fixtures_debug.yaml
+++ b/projects/rccl/test/test_categories_fixtures_debug.yaml
@@ -17,6 +17,7 @@ test_categories:
       - "ParameterApiTests.*"
       - "EnqueueTests.*"
       - "ProxyTests.*"
+      - "PatAGAlgorithmTests.*"
       - "Rcclwrap.*"
       - "TransportTest.*"
       - "ArgCheckTest.*"

--- a/projects/rccl/test/test_categories_mpi.yaml
+++ b/projects/rccl/test/test_categories_mpi.yaml
@@ -40,6 +40,8 @@ test_categories:
       - "UBR_ConcurrentRegHang.*SHOULD_WORK"
       - "GraphCapture_AllToAll.MultiNode"
       - "GraphCapture_AllReduce.MultiNode"
+      - "PatLazyInitMPITest.*"
+      - "PatSharedConnectionMPITest.*"
     exclude_windows: &mpi_exclude_windows
       - "*"
     labels:
@@ -180,6 +182,18 @@ test_categories:
       - "NCCL_LAUNCH_MODE=GROUP"
       - "NCCL_DMABUF_ENABLE=1"
       - "RCCL_MPI_LOG_ALL_RANKS=1"
+  quick_env_pat_shared_qps_off:
+    description: "PAT shared-QP kill switch. RCCL_PARAM caches the flag for the process lifetime, so SeparateConnectionsWhenSharingDisabled only runs when RCCL_PAT_SHARED_QPS=0 is set before launch."
+    test_patterns:
+      - "PatSharedConnectionMPITest.SeparateConnectionsWhenSharingDisabled"
+      - "PatSharedConnectionMPITest.AlternatingReduceScatterAndAllGatherOnOneCommunicator"
+      - "PatSharedConnectionMPITest.GroupedReduceScatterAndAllGatherOnOneCommunicator"
+    exclude_windows: *mpi_exclude_windows
+    labels: *mpi_quick_labels
+    env_variables:
+      - "NCCL_DEBUG=INFO"
+      - "NCCL_LAUNCH_MODE=GROUP"
+      - "RCCL_PAT_SHARED_QPS=0"
   standard:
     description: "MPI regression — all transport / IB / implicit-launch / UBR / graph-capture suites (same patterns as comprehensive; lighter env)."
     test_patterns: &mpi_all_patterns
@@ -198,6 +212,8 @@ test_categories:
       - "UBR_ConcurrentRegHang.*SHOULD_WORK"
       - "GraphCapture_AllToAll.*"
       - "GraphCapture_AllReduce.*"
+      - "PatLazyInitMPITest.*"
+      - "PatSharedConnectionMPITest.*"
     exclude_windows: *mpi_exclude_windows
     labels:
       - "rccl"
@@ -383,6 +399,7 @@ execution_settings:
     quick_env_net_graph_register: 1200
     quick_env_netib_xfer_trace: 1200
     quick_env_netib_xfer_log_ranks: 1200
+    quick_env_pat_shared_qps_off: 1200
     standard: 1200
     comprehensive: 1200
     comprehensive_disable_env: 1200


### PR DESCRIPTION
## Motivation

PAT walks the same binomial neighbors for ReduceScatter and AllGather, but the two collectives used
opposite peer directions on them: ReduceScatter received from `rank-delta` and sent to `rank+delta`,
AllGather did the mirror. Connections are directional, so every neighbor link existed twice, each
copy carrying its own queue pairs and ring buffers. `ncclTransportPatConnect` ran two
`ncclTransportP2pConnect` passes per binomial mask per channel, and a communicator paid for both
sets whether or not it ever issued both collectives.

This is inherited from upstream NCCL, where the two-pass connect has been unchanged since PAT was
added in 2.23.4. That is why the change ships behind an opt-out.

## Technical Details

AllGather is flipped onto ReduceScatter's peer directions so both collectives address one
connection set. Four sites independently spell out that direction and all four have to agree:

| File | Change |
|---|---|
| `src/transport/generic.cc` | one connect pass per mask instead of two |
| `src/device/prims_simple.h` | both PAT modes use `recv = rank-delta`, `send = rank+delta` |
| `src/include/collectives.h` | `PatAGAlgorithm` data-block rank re-indexed to `(rank - s + nranks) % nranks` |
| `src/proxy.cc` | `ncclPatternPatDown` peers match `PatUp` |

If the transport and proxy disagree the run hangs; if only `PatAGAlgorithm` disagrees the payload is
wrong. Both are covered by the unit tests.

**Opt-out.** `RCCL_PAT_SHARED_QPS` (default `1`); `0` restores the original two-pass behavior. The
flag has to reach device code, so it is read in `commAlloc`, carried through
`ncclKernelComm::patSharedQps`, and read on device from `ncclShmem.comm.patSharedQps`.
`PatAGAlgorithm` gained a required `sharedConns` parameter with no default, so a missed call site is
a compile error rather than a silent mismatch. The mirror pass is emitted before the shared pass so
the disabled path reproduces the original connect order exactly, and the `Connected binomial trees`
init message gains a suffix only when sharing is off.

**Scale of the saving.** One pass instead of two does not halve a job's queue pairs: ring and tree
connections are unaffected, and the `delta = nRanks/2` mask is its own mirror and was never
doubled. Whole-communicator reduction is 25% at 8 nodes rising to 36.65% at 64; measured against
PAT's own connections it is a steady 45-47%.

## Issue Tracking

JIRA ID: AICOMRCCL-1538

## Test Plan

1 rank per node with Direct PAT forced (`NCCL_PAT_ENABLE=1`, `NCCL_ALGO=PAT`,
`RCCL_HIERARCHICAL_ALLGATHER=0`), 32KiB to 1GiB.

1. Queue-pair counts from `NCCL_DEBUG_SUBSYS=INIT,NET` logs, compared against a closed-form
   prediction, at 8/16/32/64 nodes and at ten non-power-of-two rank counts.
2. Correctness asserted on every run (`Out of bounds values : 0 OK`), together with a non-zero PAT
   row count so a run that silently fell back to Ring cannot be counted as a pass.
3. Opt-out validated with three arms rather than two: the pre-sharing parent commit, the flag build
   with sharing off, and the same library with sharing on. The load-bearing assertion is that the
   flag-off count equals the parent count exactly.
4. gtest MPI fixtures at 4 and 8 ranks covering both the shared path and the fallback.
5. Everything re-run after rebasing onto current develop.

## Test Result

Queue pairs per communicator, baseline versus shared. The totals are summed over every rank in the
communicator; the per-rank columns are what a single process opens on its own NIC, which is the
number that matters against a device queue-pair budget:

| Nodes | Total baseline | Total shared | Per rank baseline | Per rank shared | Reduction |
|---:|---:|---:|---:|---:|---:|
| 8 | 960 | 720 | 120 | 90 | 25.00% |
| 16 | 2688 | 1872 | 168 | 117 | 30.36% |
| 32 | 6912 | 4560 | 216 | 142 | 34.03% |
| 64 | 16896 | 10704 | 264 | 167 | 36.65% |

Every measured count matches the closed-form prediction. Per-rank figures are averages; the shared
count is not perfectly uniform across ranks, and the busiest rank is the relevant one for a device
limit: 100 at 8 nodes, 124 at 16, 148 at 32 and 172 at 64.

Queue pairs also scale linearly with channel count, so `NCCL_MIN_NCHANNELS` /
`NCCL_MAX_NCHANNELS` and `NCCL_IB_QPS_PER_CONNECTION` move these numbers proportionally. All
figures above are at the Ruby default of 8 channels with one queue pair per connection.

Non-power-of-two rank counts 5, 6, 7, 9, 12, 15, 17, 24 and 31 all reduce, by 12.5% to 40.3%. At 3
ranks the count is unchanged, which is correct rather than a miss: the mask set `{1,2}` is closed
under `d -> nRanks-d`, so the existing dedup in `transport.cc` already collapsed the second pass.
This holds only for 2 and 3 ranks.

With `RCCL_PAT_SHARED_QPS=0` the count reproduced the parent commit exactly at all 13 scales
tested, powers of two and not, and the separate-connections log marker appeared on every rank with
the flag off and never with it on.

Both unit tests pass at 4 and 8 ranks.
`PatSharedConnectionMPITest.AllGatherReusesReduceScatterConnections` snapshots each channel's
connected flags after `ncclCommInitRank` and asserts the set a PAT AllGather adds is exactly the
shared set; `SeparateConnectionsWhenSharingDisabled` asserts the mirrored connections do exist with
the flag off, so the fallback cannot bit-rot unnoticed. `NCCL_PARAM` caches into a process-lifetime
static, so the two cannot run in one invocation; each skips with an actionable message when the
cached value is wrong, and the fallback runs in a second invocation.

AllGather and ReduceScatter were correct at every scale in every arm, with no regression against
the baseline. All counts after the rebase are identical to those before it.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
- [x] Validated at 8, 16, 32 and 64 nodes and at ten non-power-of-two rank counts.
- [x] Opt-out provided and proven to restore the original connection set exactly.
- [x] Unit tests cover both the shared path and the fallback.
- [x] Rebased onto current develop and revalidated.