### PR TITLE
fix(rocSHMEM): alleviate resource usage

### DIFF
--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -194,7 +194,7 @@ if command -v rocminfo >/dev/null 2>&1; then
   if [[ "$GPU_ARCH" =~ ^(gfx1100|gfx1201|gfx1250)$ ]]; then
     WAVE_SIZE=32
   fi
-  if [[ "$GPU_ARCH" == "gfx1201" ]]; then
+  if [[ "$GPU_ARCH" =~ ^(gfx1100|gfx1201)$ ]]; then
     GRID_SYNC_MAX_THREADS=$((32 * 1024))
   fi
 fi

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -181,14 +181,70 @@ else
   USE_SLR=0
 fi
 
-# Detect wavefront size based on GPU architecture
-# gfx1100 and gfx1201 have wavefront size 32, most others have 64
+# Detect wavefront size and grid-sync residency limits based on GPU architecture.
+# gfx1100/gfx1201/gfx1250 have wavefront size 32, most others have 64.
+# GRID_SYNC_MAX_THREADS applies only to functional tests whose kernels use the
+# software grid_barrier occupancy guard. A value of 0 disables driver-side adjustment. 
+# It can be overridden with ROCSHMEM_TEST_GRID_SYNC_MAX_THREADS.
 WAVE_SIZE=64
+GPU_ARCH=""
+GRID_SYNC_MAX_THREADS=0
 if command -v rocminfo >/dev/null 2>&1; then
-  if rocminfo | grep -qE "Name:.*(gfx1100|gfx1201|gfx1250)"; then
+  GPU_ARCH=$(rocminfo 2>/dev/null | grep -m1 -Eo "gfx[0-9a-z]+" || true)
+  if [[ "$GPU_ARCH" =~ ^(gfx1100|gfx1201|gfx1250)$ ]]; then
     WAVE_SIZE=32
   fi
+  if [[ "$GPU_ARCH" == "gfx1201" ]]; then
+    GRID_SYNC_MAX_THREADS=$((32 * 1024))
+  fi
 fi
+GRID_SYNC_MAX_THREADS=${ROCSHMEM_TEST_GRID_SYNC_MAX_THREADS:-$GRID_SYNC_MAX_THREADS}
+
+IsGridBarrierOccupancyLimitedTest() {
+  case "$1" in
+    get|getnbi|put|putnbi|p|g|\
+    defaultctxget|defaultctxgetnbi|defaultctxput|defaultctxputnbi|defaultctxp|defaultctxg|\
+    teamctxget|teamctxgetnbi|teamctxput|teamctxputnbi|\
+    waveget|wavegetnbi|waveput|waveputnbi|\
+    wgget|wggetnbi|wgput|wgputnbi|\
+    flood_add|flood_fadd|flood_waitadd)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+AdjustGridBarrierProblemSize() {
+  local test_name=$1
+  local num_wg=$2
+  local num_threads=$3
+
+  if (( GRID_SYNC_MAX_THREADS <= 0 )); then
+    echo "$num_wg"
+    return
+  fi
+
+  if ! IsGridBarrierOccupancyLimitedTest "$test_name"; then
+    echo "$num_wg"
+    return
+  fi
+
+  local requested_threads=$((num_wg * num_threads))
+  if (( requested_threads <= GRID_SYNC_MAX_THREADS )); then
+    echo "$num_wg"
+    return
+  fi
+
+  local adjusted_wg=$((GRID_SYNC_MAX_THREADS / num_threads))
+  if (( adjusted_wg < 1 )); then
+    adjusted_wg=1
+  fi
+
+  echo "Adjust: $test_name workgroups $num_wg -> $adjusted_wg for ${GPU_ARCH:-unknown GPU} grid_barrier residency limit (${GRID_SYNC_MAX_THREADS} threads, -z $num_threads)" >&2
+  echo "$adjusted_wg"
+}
 
 # Router function - dispatches to appropriate implementation
 ExecTest() {
@@ -232,6 +288,8 @@ ExecTest_SLR() {
     DRIVER_RETURN_STATUS=1
     return
   fi
+
+  NUM_WG=$(AdjustGridBarrierProblemSize "$TEST_NAME" "$NUM_WG" "$NUM_THREADS")
 
   if [[ "" == "$ROCSHMEM_MAX_NUM_CONTEXTS" ]]
   then
@@ -362,6 +420,8 @@ ExecTest_MPI() {
     DRIVER_RETURN_STATUS=1
     return
   fi
+
+  NUM_WG=$(AdjustGridBarrierProblemSize "$TEST_NAME" "$NUM_WG" "$NUM_THREADS")
 
   if [[ "" == "$ROCSHMEM_MAX_NUM_CONTEXTS" ]]
   then

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -402,7 +402,7 @@ constexpr bool is_blocking(MemcpyKind k) {
 }
 
 template <int ChunkSize, CachePolicy LoadPolicy, CachePolicy StorePolicy, int Unroll>
-__device__ __attribute__((noinline)) void copy_bulk(void* dst, void* src,
+__device__ __noinline__ void copy_bulk(void* dst, void* src,
                                           int n_chunks, int tid, int stride) {
   using Acc = AsmAccess<ChunkSize, LoadPolicy, StorePolicy>;
   using T = typename Acc::type;

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -402,7 +402,7 @@ constexpr bool is_blocking(MemcpyKind k) {
 }
 
 template <int ChunkSize, CachePolicy LoadPolicy, CachePolicy StorePolicy, int Unroll>
-__device__ __forceinline__ void copy_bulk(void* dst, void* src,
+__device__ __attribute__((noinline)) void copy_bulk(void* dst, void* src,
                                           int n_chunks, int tid, int stride) {
   using Acc = AsmAccess<ChunkSize, LoadPolicy, StorePolicy>;
   using T = typename Acc::type;
@@ -502,7 +502,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   if (size == 0) return;
 
   constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 4;
+  constexpr int Unroll    = 8;
   // Compile-time bypass policy: cache-bypass in the direction of the remote side.
   constexpr CachePolicy LP = is_put(Kind) ? CachePolicy::Standard    : CachePolicy::SystemScope;
   constexpr CachePolicy SP = is_put(Kind) ? CachePolicy::SystemScope : CachePolicy::Standard;
@@ -548,7 +548,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   if (size == 0) return;
 
   constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 4;
+  constexpr int Unroll    = 8;
 
   constexpr CachePolicy LP =
       is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;
@@ -578,7 +578,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   if (size == 0) return;
 
   constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 4;
+  constexpr int Unroll    = 8;
 
   constexpr CachePolicy LP =
       is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -502,7 +502,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   if (size == 0) return;
 
   constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 8;
+  constexpr int Unroll    = 4;
   // Compile-time bypass policy: cache-bypass in the direction of the remote side.
   constexpr CachePolicy LP = is_put(Kind) ? CachePolicy::Standard    : CachePolicy::SystemScope;
   constexpr CachePolicy SP = is_put(Kind) ? CachePolicy::SystemScope : CachePolicy::Standard;
@@ -548,7 +548,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   if (size == 0) return;
 
   constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 8;
+  constexpr int Unroll    = 4;
 
   constexpr CachePolicy LP =
       is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;
@@ -578,7 +578,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   if (size == 0) return;
 
   constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 8;
+  constexpr int Unroll    = 4;
 
   constexpr CachePolicy LP =
       is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -502,7 +502,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   if (size == 0) return;
 
   constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 16;
+  constexpr int Unroll    = 8;
   // Compile-time bypass policy: cache-bypass in the direction of the remote side.
   constexpr CachePolicy LP = is_put(Kind) ? CachePolicy::Standard    : CachePolicy::SystemScope;
   constexpr CachePolicy SP = is_put(Kind) ? CachePolicy::SystemScope : CachePolicy::Standard;
@@ -548,7 +548,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   if (size == 0) return;
 
   constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 16;
+  constexpr int Unroll    = 8;
 
   constexpr CachePolicy LP =
       is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;
@@ -578,7 +578,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   if (size == 0) return;
 
   constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 16;
+  constexpr int Unroll    = 8;
 
   constexpr CachePolicy LP =
       is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -402,7 +402,7 @@ constexpr bool is_blocking(MemcpyKind k) {
 }
 
 template <int ChunkSize, CachePolicy LoadPolicy, CachePolicy StorePolicy, int Unroll>
-__device__ __forceinline__ void copy_bulk(void* dst, void* src,
+__device__ __attribute__((noinline)) void copy_bulk(void* dst, void* src,
                                           int n_chunks, int tid, int stride) {
   using Acc = AsmAccess<ChunkSize, LoadPolicy, StorePolicy>;
   using T = typename Acc::type;

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -402,7 +402,7 @@ constexpr bool is_blocking(MemcpyKind k) {
 }
 
 template <int ChunkSize, CachePolicy LoadPolicy, CachePolicy StorePolicy, int Unroll>
-__device__ __attribute__((noinline)) void copy_bulk(void* dst, void* src,
+__device__ __forceinline__ void copy_bulk(void* dst, void* src,
                                           int n_chunks, int tid, int stride) {
   using Acc = AsmAccess<ChunkSize, LoadPolicy, StorePolicy>;
   using T = typename Acc::type;


### PR DESCRIPTION
## Motivation

Temporary fix the resource over-usage in rocSHMEM IPC backend.

## Technical Details

Either marking `copy_bulk` as `no_inline` or setting Unrolling factor from 16 to 8 can temporarily silence the CI issues. 

## Issue Tracking

JIRA ID: AIROCSHMEM-455
