### PR TITLE
feat(ci): enable KPACK_SPLIT_ARTIFACTS to test multi-arch packaging

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -89,7 +89,7 @@ jobs:
         env:
           amdgpu_families: ${{ env.AMDGPU_FAMILIES }}
           package_version: ${{ inputs.package_version }}
-          extra_cmake_options: "-DTHEROCK_ROCM_SYSTEMS_SOURCE_DIR=../ -DTHEROCK_ENABLE_RCCL=OFF ${{ inputs.cmake_options }}"
+          extra_cmake_options: "-DTHEROCK_ROCM_SYSTEMS_SOURCE_DIR=../ -DTHEROCK_ENABLE_RCCL=OFF -DTHEROCK_FLAG_KPACK_SPLIT_ARTIFACTS=ON ${{ inputs.cmake_options }}"
           BUILD_DIR: build
         run: |
           python TheRock/build_tools/github_actions/build_configure.py

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -107,7 +107,7 @@ jobs:
           cmake_preset: windows-release
           amdgpu_families: ${{ env.AMDGPU_FAMILIES }}
           package_version: ${{ inputs.package_version }}
-          extra_cmake_options: "-DTHEROCK_ROCM_SYSTEMS_SOURCE_DIR=../ -DTHEROCK_ENABLE_ML_LIBS=OFF ${{ inputs.cmake_options }}"
+          extra_cmake_options: "-DTHEROCK_ROCM_SYSTEMS_SOURCE_DIR=../ -DTHEROCK_ENABLE_ML_LIBS=OFF -DTHEROCK_FLAG_KPACK_SPLIT_ARTIFACTS=ON ${{ inputs.cmake_options }}"
         run: |
           # clear cache before build and after download
           ccache -z


### PR DESCRIPTION
Enable the kpack split artifacts flag to see what breaks in non-multi-arch CI. This separates host code from device kernels for better build sharding.

Related: https://github.com/ROCm/TheRock/issues/4769