### PR TITLE
fix(rocSHMEM): attach the waitcnts to their respective loads

### DIFF
--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -787,31 +787,42 @@ struct AsmAccess<16, LoadPolicy, StorePolicy> {
       type val{};
 #if defined(__gfx942__) || defined(__gfx950__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_dwordx4 %0, %1" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dwordx4 %0, %1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_dwordx4 %0, %1, sc0" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dwordx4 %0, %1, sc0\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::NonTemporal) {
-        asm volatile("flat_load_dwordx4 %0, %1, nt" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dwordx4 %0, %1, nt\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScope) {
-        asm volatile("flat_load_dwordx4 %0, %1, sc0 sc1" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dwordx4 %0, %1, sc0 sc1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScopeNT) {
-        asm volatile("flat_load_dwordx4 %0, %1, sc0 sc1 nt" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dwordx4 %0, %1, sc0 sc1 nt\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
 #elif defined(__gfx90a__) || defined(__gfx1100__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_dwordx4 %0, %1" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dwordx4 %0, %1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_dwordx4 %0, %1, glc" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dwordx4 %0, %1, glc\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_dwordx4 %0, %1, glc slc" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dwordx4 %0, %1, glc slc\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
 #elif defined(__gfx1201__) || defined(__gfx1250__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_b128 %0, %1, scope:SCOPE_SE" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_b128 %0, %1, scope:SCOPE_SE\n"
+                     "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_b128 %0, %1, scope:SCOPE_DEV" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_b128 %0, %1, scope:SCOPE_DEV\n"
+                     "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_b128 %0, %1, scope:SCOPE_SYS" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_b128 %0, %1, scope:SCOPE_SYS\n"
+                     "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       }
 #else
       val = *reinterpret_cast<type*>(src);
@@ -892,31 +903,42 @@ struct AsmAccess<8, LoadPolicy, StorePolicy> {
       type val{};
 #if defined(__gfx942__) || defined(__gfx950__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_dwordx2 %0, %1" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dwordx2 %0, %1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_dwordx2 %0, %1, sc0" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dwordx2 %0, %1, sc0\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::NonTemporal) {
-        asm volatile("flat_load_dwordx2 %0, %1, nt" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dwordx2 %0, %1, nt\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScope) {
-        asm volatile("flat_load_dwordx2 %0, %1, sc0 sc1" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dwordx2 %0, %1, sc0 sc1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScopeNT) {
-        asm volatile("flat_load_dwordx2 %0, %1, sc0 sc1 nt" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dwordx2 %0, %1, sc0 sc1 nt\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
 #elif defined(__gfx90a__) || defined(__gfx1100__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_dwordx2 %0, %1" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dwordx2 %0, %1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_dwordx2 %0, %1, glc" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dwordx2 %0, %1, glc\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_dwordx2 %0, %1, glc slc" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dwordx2 %0, %1, glc slc\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
 #elif defined(__gfx1201__) || defined(__gfx1250__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_b64 %0, %1, scope:SCOPE_SE" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_b64 %0, %1, scope:SCOPE_SE\n"
+                     "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_b64 %0, %1, scope:SCOPE_DEV" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_b64 %0, %1, scope:SCOPE_DEV\n"
+                     "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_b64 %0, %1, scope:SCOPE_SYS" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_b64 %0, %1, scope:SCOPE_SYS\n"
+                     "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       }
 #else
       val = *reinterpret_cast<type*>(src);
@@ -997,31 +1019,42 @@ struct AsmAccess<4, LoadPolicy, StorePolicy> {
       type val{};
 #if defined(__gfx942__) || defined(__gfx950__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_dword %0, %1" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dword %0, %1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_dword %0, %1, sc0" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dword %0, %1, sc0\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::NonTemporal) {
-        asm volatile("flat_load_dword %0, %1, nt" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dword %0, %1, nt\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScope) {
-        asm volatile("flat_load_dword %0, %1, sc0 sc1" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dword %0, %1, sc0 sc1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScopeNT) {
-        asm volatile("flat_load_dword %0, %1, sc0 sc1 nt" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dword %0, %1, sc0 sc1 nt\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
 #elif defined(__gfx90a__) || defined(__gfx1100__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_dword %0, %1" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dword %0, %1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_dword %0, %1, glc" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dword %0, %1, glc\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_dword %0, %1, glc slc" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_dword %0, %1, glc slc\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
 #elif defined(__gfx1201__) || defined(__gfx1250__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_b32 %0, %1, scope:SCOPE_SE" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_b32 %0, %1, scope:SCOPE_SE\n"
+                     "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_b32 %0, %1, scope:SCOPE_DEV" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_b32 %0, %1, scope:SCOPE_DEV\n"
+                     "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_b32 %0, %1, scope:SCOPE_SYS" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_b32 %0, %1, scope:SCOPE_SYS\n"
+                     "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       }
 #else
       val = *reinterpret_cast<type*>(src);
@@ -1103,23 +1136,31 @@ struct AsmAccess<2, LoadPolicy, StorePolicy> {
       int16_t val{};  // Gfx9 supports native 16-bit vector registers
   #if defined(__gfx942__) || defined(__gfx950__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_ushort %0, %1" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_ushort %0, %1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_ushort %0, %1, sc0" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_ushort %0, %1, sc0\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::NonTemporal) {
-        asm volatile("flat_load_ushort %0, %1, nt" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_ushort %0, %1, nt\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScope) {
-        asm volatile("flat_load_ushort %0, %1, sc0 sc1" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_ushort %0, %1, sc0 sc1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScopeNT) {
-        asm volatile("flat_load_ushort %0, %1, sc0 sc1 nt" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_ushort %0, %1, sc0 sc1 nt\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
   #else
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_ushort %0, %1" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_ushort %0, %1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_ushort %0, %1, glc" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_ushort %0, %1, glc\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_ushort %0, %1, glc slc" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_ushort %0, %1, glc slc\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
   #endif
       return val;
@@ -1127,19 +1168,25 @@ struct AsmAccess<2, LoadPolicy, StorePolicy> {
       int32_t val32;  // Gfx11/12 forces 16-bit ops into 32-bit registers
   #if defined(__gfx1100__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_ushort %0, %1" : "=v"(val32) : "v"(src) : "memory");
+        asm volatile("flat_load_ushort %0, %1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val32) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_ushort %0, %1, glc" : "=v"(val32) : "v"(src) : "memory");
+        asm volatile("flat_load_ushort %0, %1, glc\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val32) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_ushort %0, %1, glc slc" : "=v"(val32) : "v"(src) : "memory");
+        asm volatile("flat_load_ushort %0, %1, glc slc\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val32) : "v"(src) : "memory");
       }
   #else
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_u16 %0, %1, scope:SCOPE_SE" : "=v"(val32) : "v"(src) : "memory");
+        asm volatile("flat_load_u16 %0, %1, scope:SCOPE_SE\n"
+                     "s_wait_loadcnt 0x0" : "=&v"(val32) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_u16 %0, %1, scope:SCOPE_DEV" : "=v"(val32) : "v"(src) : "memory");
+        asm volatile("flat_load_u16 %0, %1, scope:SCOPE_DEV\n"
+                     "s_wait_loadcnt 0x0" : "=&v"(val32) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_u16 %0, %1, scope:SCOPE_SYS" : "=v"(val32) : "v"(src) : "memory");
+        asm volatile("flat_load_u16 %0, %1, scope:SCOPE_SYS\n"
+                     "s_wait_loadcnt 0x0" : "=&v"(val32) : "v"(src) : "memory");
       }
   #endif
       return static_cast<type>(val32);
@@ -1236,23 +1283,31 @@ struct AsmAccess<1, LoadPolicy, StorePolicy> {
       int16_t val{};  // Gfx9 loads bytes into 16-bit registers minimum
   #if defined(__gfx942__) || defined(__gfx950__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_ubyte %0, %1" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_ubyte %0, %1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_ubyte %0, %1, sc0" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_ubyte %0, %1, sc0\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::NonTemporal) {
-        asm volatile("flat_load_ubyte %0, %1, nt" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_ubyte %0, %1, nt\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScope) {
-        asm volatile("flat_load_ubyte %0, %1, sc0 sc1" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_ubyte %0, %1, sc0 sc1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScopeNT) {
-        asm volatile("flat_load_ubyte %0, %1, sc0 sc1 nt" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_ubyte %0, %1, sc0 sc1 nt\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
   #else
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_ubyte %0, %1" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_ubyte %0, %1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_ubyte %0, %1, glc" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_ubyte %0, %1, glc\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_ubyte %0, %1, glc slc" : "=v"(val) : "v"(src) : "memory");
+        asm volatile("flat_load_ubyte %0, %1, glc slc\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
   #endif
       return static_cast<type>(val);
@@ -1260,19 +1315,25 @@ struct AsmAccess<1, LoadPolicy, StorePolicy> {
       int32_t val32{};  // Gfx11/12 forces 8-bit ops into 32-bit registers
   #if defined(__gfx1100__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_ubyte %0, %1" : "=v"(val32) : "v"(src) : "memory");
+        asm volatile("flat_load_ubyte %0, %1\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val32) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_ubyte %0, %1, glc" : "=v"(val32) : "v"(src) : "memory");
+        asm volatile("flat_load_ubyte %0, %1, glc\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val32) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_ubyte %0, %1, glc slc" : "=v"(val32) : "v"(src) : "memory");
+        asm volatile("flat_load_ubyte %0, %1, glc slc\n"
+                     "s_waitcnt vmcnt(0)" : "=&v"(val32) : "v"(src) : "memory");
       }
   #else
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_u8 %0, %1, scope:SCOPE_SE" : "=v"(val32) : "v"(src) : "memory");
+        asm volatile("flat_load_u8 %0, %1, scope:SCOPE_SE\n"
+                     "s_wait_loadcnt 0x0" : "=&v"(val32) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_u8 %0, %1, scope:SCOPE_DEV" : "=v"(val32) : "v"(src) : "memory");
+        asm volatile("flat_load_u8 %0, %1, scope:SCOPE_DEV\n"
+                     "s_wait_loadcnt 0x0" : "=&v"(val32) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_u8 %0, %1, scope:SCOPE_SYS" : "=v"(val32) : "v"(src) : "memory");
+        asm volatile("flat_load_u8 %0, %1, scope:SCOPE_SYS\n"
+                     "s_wait_loadcnt 0x0" : "=&v"(val32) : "v"(src) : "memory");
       }
   #endif
       return static_cast<type>(val32);

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -430,9 +430,6 @@ __device__ __noinline__ void copy_bulk(void* dst, void* src,
   // Tail: remaining chunks that don't fill a full unrolled batch
   for (int i = offset + tid; i < n_chunks; i += stride) {
     T val = Acc::load(static_cast<uint8_t*>(src) + i * ChunkSize);
-    if constexpr (LoadPolicy != CachePolicy::Standard) {
-      wait_on_vmem_and_lds(0);
-    }
     Acc::store(static_cast<uint8_t*>(dst) + i * ChunkSize, val);
   }
 }
@@ -448,9 +445,6 @@ __device__ __forceinline__ void copy_remainder(uint8_t* dst,
 
   if (remainder & 1) {
     auto val = AsmAccess<1, LP, SP>::load(src);
-    if constexpr (LP != CachePolicy::Standard) {
-      wait_on_vmem_and_lds(0);
-    }
     AsmAccess<1, LP, SP>::store(dst, val);
     if (remainder == 1) {
       return;
@@ -460,9 +454,6 @@ __device__ __forceinline__ void copy_remainder(uint8_t* dst,
   }
   if (remainder & 2) {
     auto val = AsmAccess<2, LP, SP>::load(src);
-    if constexpr (LP != CachePolicy::Standard) {
-      wait_on_vmem_and_lds(0);
-    }
     AsmAccess<2, LP, SP>::store(dst, val);
     if (remainder == 2) {
       return;
@@ -472,9 +463,6 @@ __device__ __forceinline__ void copy_remainder(uint8_t* dst,
   }
   if (remainder & 4) {
     auto val = AsmAccess<4, LP, SP>::load(src);
-    if constexpr (LP != CachePolicy::Standard) {
-      wait_on_vmem_and_lds(0);
-    }
     AsmAccess<4, LP, SP>::store(dst, val);
     if (remainder == 4) {
       return;
@@ -484,9 +472,6 @@ __device__ __forceinline__ void copy_remainder(uint8_t* dst,
   }
   if (remainder & 8) {
     auto val = AsmAccess<8, LP, SP>::load(src);
-    if constexpr (LP != CachePolicy::Standard) {
-      wait_on_vmem_and_lds(0);
-    }
     AsmAccess<8, LP, SP>::store(dst, val);
   }
 }

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -502,7 +502,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   if (size == 0) return;
 
   constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 8;
+  constexpr int Unroll    = 4;
   // Compile-time bypass policy: cache-bypass in the direction of the remote side.
   constexpr CachePolicy LP = is_put(Kind) ? CachePolicy::Standard    : CachePolicy::SystemScope;
   constexpr CachePolicy SP = is_put(Kind) ? CachePolicy::SystemScope : CachePolicy::Standard;
@@ -548,7 +548,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   if (size == 0) return;
 
   constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 8;
+  constexpr int Unroll    = 4;
 
   constexpr CachePolicy LP =
       is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;
@@ -578,7 +578,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   if (size == 0) return;
 
   constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 8;
+  constexpr int Unroll    = 4;
 
   constexpr CachePolicy LP =
       is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -502,7 +502,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   if (size == 0) return;
 
   constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 4;
+  constexpr int Unroll    = 8;
   // Compile-time bypass policy: cache-bypass in the direction of the remote side.
   constexpr CachePolicy LP = is_put(Kind) ? CachePolicy::Standard    : CachePolicy::SystemScope;
   constexpr CachePolicy SP = is_put(Kind) ? CachePolicy::SystemScope : CachePolicy::Standard;
@@ -548,7 +548,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   if (size == 0) return;
 
   constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 4;
+  constexpr int Unroll    = 8;
 
   constexpr CachePolicy LP =
       is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;
@@ -578,7 +578,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   if (size == 0) return;
 
   constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 4;
+  constexpr int Unroll    = 8;
 
   constexpr CachePolicy LP =
       is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;


### PR DESCRIPTION
# Motivation

`test_typed_int_put_get_wave` deterministically returns corrupted GET data (payload shifted by 8 bytes, garbage in leading elements). This bug showed up after ROCm 7.13.

## Root cause

AsmAccess<N>::load() (src/assembly.hpp) issues its async vector-memory load (flat_load_dwordx4/etc.) and the matching s_waitcnt drain as two separate, unrelated asm volatile blocks. LLVM doesn't recognize a raw inline-asm load as a vector-memory op, so in the new compiler the scheduler just schedules some other load isntructions that consumes the loaded value before the wait, causing the waitcnt to hit the empty bucket and return immediately. I confirmed at the disassembly level. Only the raw-asm scalar load path (copy_bulk tail loop, copy_remainder) was affected; the buffered intrinsic-based path was not.

## Alternatives considered

Compiler atomic builtins were considered too. Currently, there is no way to express the existing NonTemporal/FlatCache hints together in the same instruction except for the assembly solution. So, no.

## Fix

Move the `s_waitcnt/s_wait_loadcnt` into the same asm volatile block as the load, for every non-Standard-policy branch across all AsmAccess types and architectures . The pattern is already the same and it was meant to be like that. `store()` is untouched by design: raw `put/get` carries no ordering guarantee; only fence()/quiet()/wait_until() do. Remove the now-redundant standalone wait calls in util.hpp.

## Testing

Disassembly-confirmed fix; isolated primitive reproduced pass; MPI functional test passed. 

## Issue Tracking

JIRA ID: AIROCSHMEM-440
