### PR TITLE
feat(ci): add skip-therockci label support to skip CI

### DIFF
--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -20,7 +20,7 @@ from therock_matrix import (
     windows_only_subtrees,
 )
 import time
-from typing import Mapping, Optional, Iterable
+from typing import List, Mapping, Optional, Iterable
 import os
 
 # Add TheRock's github_actions to path for shared utilities
@@ -168,6 +168,15 @@ def check_for_non_skippable_path(paths: Optional[Iterable[str]]) -> bool:
     return any(not is_path_skippable(p) for p in paths)
 
 
+def get_pr_labels(args) -> List[str]:
+    """Gets a list of labels applied to a pull request."""
+    data = json.loads(args.get("pr_labels", "{}"))
+    labels = []
+    for label in data.get("labels", []):
+        labels.append(label["name"])
+    return labels
+
+
 def check_rccl_changes(modified_paths: Optional[Iterable[str]]) -> bool:
     """Returns true if any files under projects/rccl/ were modified."""
     if modified_paths is None:
@@ -273,6 +282,13 @@ def retrieve_projects(args):
         if not check_for_non_skippable_path(modified_paths):
             logging.info("Only skippable paths were modified, skipping CI")
             return [], test_type
+
+        # Check for ci:skip label on PRs
+        if args.get("is_pull_request"):
+            pr_labels = get_pr_labels(args)
+            if "ci:skip" in pr_labels:
+                logging.info("`ci:skip` label was added, skipping CI")
+                return [], test_type
 
     # Push event → check which subtrees were modified
     if args.get("is_push"):
@@ -498,6 +514,8 @@ if __name__ == "__main__":
 
     input_projects = os.getenv("PROJECTS", "")
     args["input_projects"] = input_projects
+
+    args["pr_labels"] = os.environ.get("PR_LABELS", '{"labels": []}')
 
     input_platform = os.getenv("PLATFORM")
     args["platform"] = input_platform

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -10,6 +10,7 @@ on:
       - opened
       - synchronize
       - reopened
+      - labeled
   workflow_dispatch:
     inputs:
       projects:
@@ -97,6 +98,14 @@ jobs:
             --repo "${{ github.repository }}" \
             --pr "${{ github.event.pull_request.number }}" \
             --config ".github/repos-config.json"
+
+      - name: Set PR_LABELS variable with labels assigned to pull request
+        if: ${{ github.event.pull_request }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo "PR_LABELS=$(gh pr view ${PR_NUMBER} --json labels)" >> $GITHUB_ENV
 
       - name: Determine Linux projects to run
         id: linux_projects


### PR DESCRIPTION
Add support for the `skip-therockci` label to skip TheRock CI on PRs. When this label is applied to a pull request, both Linux and Windows CI jobs will be skipped.

This matches the behavior in rocm-libraries.