### PR TITLE
POC: remove SparseMemory host page map

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1060,9 +1060,10 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
 
   std::string kernel_sym;
   if (host_accessible && memory_) {
-    auto [range_base, range_size] = memory_->find_host_range(pkt.kernel_object);
-    if (range_base != 0) {
-      auto *ko = reinterpret_cast<const uint8_t *>(pkt.kernel_object);
+    auto [range_base, range_size] = memory_->find_host_range(pkt.kernel_object, queue.process_id);
+    auto *mapped_page = memory_->resolve_host_ptr(pkt.kernel_object, queue.process_id);
+    if (range_base != 0 && mapped_page) {
+      auto *ko = mapped_page + (pkt.kernel_object & GpuMemory::PAGE_MASK);
       auto *range_start = reinterpret_cast<const uint8_t *>(range_base);
       auto *elf = find_elf_base(ko, range_start);
       if (elf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -143,6 +143,56 @@ public:
 
   uint8_t *translate_debug(uint64_t addr, uint32_t vmid) const { return translate(addr, vmid); }
 
+  /// @brief Find the contiguous host range containing a VMID-scoped GPU VA.
+  /// @details KFD dispatches use per-process page tables. Kernel-symbol
+  /// resolution needs a daemon-accessible host pointer range so it can scan
+  /// backward from the kernel descriptor to the loaded ELF header.
+  std::pair<uint64_t, uint64_t> find_host_range(uint64_t addr, uint32_t vmid) const {
+    if (vmid == 0) {
+      auto *host = translate(addr, vmid);
+      if (!host)
+        return {0, 0};
+      return {reinterpret_cast<uint64_t>(host), PAGE_SIZE};
+    }
+
+    std::shared_lock vmid_lock(vmid_mutex_);
+    auto vmid_entry = vmid_table_.find(vmid);
+    if (vmid_entry == vmid_table_.end())
+      return {0, 0};
+
+    auto &entry = vmid_entry->second;
+    std::shared_lock page_table_lock(*entry.mutex);
+    uint64_t page = addr >> PAGE_SHIFT;
+    auto page_entry = entry.page_table->find(page);
+    if (page_entry == entry.page_table->end())
+      return {0, 0};
+
+    uint64_t first_page = page;
+    uint8_t *first_host_page = page_entry->second.host_ptr;
+    while (first_page > 0) {
+      auto previous_page_entry = entry.page_table->find(first_page - 1);
+      if (previous_page_entry == entry.page_table->end() ||
+          previous_page_entry->second.host_ptr + PAGE_SIZE != first_host_page)
+        break;
+      --first_page;
+      first_host_page = previous_page_entry->second.host_ptr;
+    }
+
+    uint64_t last_page = page;
+    uint8_t *last_host_page = page_entry->second.host_ptr;
+    while (true) {
+      auto next_page_entry = entry.page_table->find(last_page + 1);
+      if (next_page_entry == entry.page_table->end() ||
+          next_page_entry->second.host_ptr != last_host_page + PAGE_SIZE)
+        break;
+      ++last_page;
+      last_host_page = next_page_entry->second.host_ptr;
+    }
+
+    uint64_t range_size = ((last_page - first_page) + 1) << PAGE_SHIFT;
+    return {reinterpret_cast<uint64_t>(first_host_page), range_size};
+  }
+
   std::string debug_page_table_info(uint32_t vmid, uint64_t page_key) const {
     std::shared_lock lk(vmid_mutex_);
     auto it = vmid_table_.find(vmid);

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/components/sparse_memory.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/components/sparse_memory.h
@@ -26,9 +26,6 @@ namespace simdojo {
 /// Little-endian, 4KB pages allocated on first access. Provides byte, word,
 /// and doubleword access plus bulk image loading and page iteration for
 /// serialization.
-///
-/// Host ranges are tracked as a page-indexed map (page_number → host_ptr)
-/// for O(1) lookup per access, mirroring real IOMMU page table structure.
 class SparseMemory : public Component {
 public:
   static constexpr size_t PAGE_SIZE = 4096;
@@ -44,12 +41,6 @@ public:
   /// @param addr Memory address to read from.
   /// @returns The byte at the given address (0 if page not yet allocated).
   uint8_t read8(uint64_t addr) const {
-    {
-      std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-      auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-      if (it != host_page_map_.end())
-        return it->second[addr & PAGE_MASK];
-    }
     std::shared_lock<std::shared_mutex> lock(mutex_);
     auto it = pages_.find(addr & ~PAGE_MASK);
     return (it != pages_.end()) ? it->second[addr & PAGE_MASK] : 0;
@@ -59,15 +50,6 @@ public:
   /// @param addr Memory address to read from.
   /// @returns The 16-bit value at the given address.
   uint16_t read16(uint64_t addr) const {
-    {
-      std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-      auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-      if (it != host_page_map_.end() && (addr & PAGE_MASK) + 2 <= PAGE_SIZE) {
-        uint16_t val = 0;
-        std::memcpy(&val, it->second + (addr & PAGE_MASK), 2);
-        return val;
-      }
-    }
     std::shared_lock<std::shared_mutex> lock(mutex_);
     uint16_t val = 0;
     read_bytes(addr, &val, 2);
@@ -78,15 +60,6 @@ public:
   /// @param addr Memory address to read from.
   /// @returns The 32-bit value at the given address.
   uint32_t read32(uint64_t addr) const {
-    {
-      std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-      auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-      if (it != host_page_map_.end() && (addr & PAGE_MASK) + 4 <= PAGE_SIZE) {
-        uint32_t val = 0;
-        std::memcpy(&val, it->second + (addr & PAGE_MASK), 4);
-        return val;
-      }
-    }
     std::shared_lock<std::shared_mutex> lock(mutex_);
     uint32_t val = 0;
     read_bytes(addr, &val, 4);
@@ -97,15 +70,6 @@ public:
   /// @param addr Memory address to read from.
   /// @returns The 64-bit value at the given address.
   uint64_t read64(uint64_t addr) const {
-    {
-      std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-      auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-      if (it != host_page_map_.end() && (addr & PAGE_MASK) + 8 <= PAGE_SIZE) {
-        uint64_t val = 0;
-        std::memcpy(&val, it->second + (addr & PAGE_MASK), 8);
-        return val;
-      }
-    }
     std::shared_lock<std::shared_mutex> lock(mutex_);
     uint64_t val = 0;
     read_bytes(addr, &val, 8);
@@ -116,14 +80,6 @@ public:
   /// @param addr Memory address to write to.
   /// @param val Value to write.
   void write8(uint64_t addr, uint8_t val) {
-    {
-      std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-      auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-      if (it != host_page_map_.end()) {
-        it->second[addr & PAGE_MASK] = val;
-        return;
-      }
-    }
     std::unique_lock<std::shared_mutex> lock(mutex_);
     get_page(addr)[addr & PAGE_MASK] = val;
   }
@@ -132,14 +88,6 @@ public:
   /// @param addr Memory address to write to.
   /// @param val Value to write.
   void write16(uint64_t addr, uint16_t val) {
-    {
-      std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-      auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-      if (it != host_page_map_.end() && (addr & PAGE_MASK) + 2 <= PAGE_SIZE) {
-        std::memcpy(it->second + (addr & PAGE_MASK), &val, 2);
-        return;
-      }
-    }
     std::unique_lock<std::shared_mutex> lock(mutex_);
     write_bytes(addr, &val, sizeof(val));
   }
@@ -148,14 +96,6 @@ public:
   /// @param addr Memory address to write to.
   /// @param val Value to write.
   void write32(uint64_t addr, uint32_t val) {
-    {
-      std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-      auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-      if (it != host_page_map_.end() && (addr & PAGE_MASK) + 4 <= PAGE_SIZE) {
-        std::memcpy(it->second + (addr & PAGE_MASK), &val, 4);
-        return;
-      }
-    }
     std::unique_lock<std::shared_mutex> lock(mutex_);
     write_bytes(addr, &val, sizeof(val));
   }
@@ -164,14 +104,6 @@ public:
   /// @param addr Memory address to write to.
   /// @param val Value to write.
   void write64(uint64_t addr, uint64_t val) {
-    {
-      std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-      auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-      if (it != host_page_map_.end() && (addr & PAGE_MASK) + 8 <= PAGE_SIZE) {
-        std::memcpy(it->second + (addr & PAGE_MASK), &val, 8);
-        return;
-      }
-    }
     std::unique_lock<std::shared_mutex> lock(mutex_);
     write_bytes(addr, &val, sizeof(val));
   }
@@ -191,15 +123,6 @@ public:
       uint64_t addr = base_addr + offset;
       uint64_t page_off = addr & PAGE_MASK;
       size_t chunk = std::min(PAGE_SIZE - page_off, size - offset);
-      {
-        std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-        auto it = host_page_map_.find(addr >> PAGE_SHIFT);
-        if (it != host_page_map_.end()) {
-          std::memcpy(it->second + page_off, data + offset, chunk);
-          offset += chunk;
-          continue;
-        }
-      }
       {
         std::unique_lock<std::shared_mutex> lock(mutex_);
         std::memcpy(&get_page(addr)[page_off], data + offset, chunk);
@@ -224,59 +147,9 @@ public:
     return pages_.size();
   }
 
-  /// @brief Map host pages as the backing store for a GPU VA range.
-  /// @details After this call, read/write to addresses in [gpu_va, gpu_va+size)
-  /// access the host memory at [host_ptr, host_ptr+size) directly. Both the host
-  /// CPU and the simulated GPU see the same data — no copy needed.
-  ///
-  /// Internally stored as one entry per 4KB page (page_number → host_ptr),
-  /// giving O(1) lookup per memory access instead of O(n) range scan.
-  /// @param gpu_va Start of the GPU virtual address range (page-aligned).
-  /// @param host_ptr Host pointer to the backing pages (page-aligned).
-  /// @param size Size of the mapping in bytes (page-aligned).
-  void map_host_pages(uint64_t gpu_va, void *host_ptr, size_t size) {
-    auto *hp = static_cast<uint8_t *>(host_ptr);
-    std::lock_guard<std::shared_mutex> lock(host_range_mutex_);
-    for (uint64_t off = 0; off < size; off += PAGE_SIZE)
-      host_page_map_[(gpu_va + off) >> PAGE_SHIFT] = hp + off;
-  }
-
-  bool is_host_mapped(uint64_t gpu_va) const {
-    std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-    return host_page_map_.count(gpu_va >> PAGE_SHIFT) > 0;
-  }
-
-  /// @brief Find the base and size of the contiguous host-mapped region containing addr.
-  /// @details Scans backward and forward through host_page_map_ to find the
-  /// full contiguous range. Returns {0, 0} if addr is not host-mapped.
-  std::pair<uint64_t, uint64_t> find_host_range(uint64_t addr) const {
-    std::shared_lock<std::shared_mutex> lock(host_range_mutex_);
-    uint64_t page = addr >> PAGE_SHIFT;
-    if (host_page_map_.count(page) == 0)
-      return {0, 0};
-    uint64_t lo = page;
-    while (lo > 0 && host_page_map_.count(lo - 1))
-      --lo;
-    uint64_t hi = page;
-    while (host_page_map_.count(hi + 1))
-      ++hi;
-    return {lo << PAGE_SHIFT, ((hi - lo) + 1) << PAGE_SHIFT};
-  }
-
-  void unmap_host_pages(uint64_t gpu_va, size_t size) {
-    std::lock_guard<std::shared_mutex> lock(host_range_mutex_);
-    for (uint64_t off = 0; off < size; off += PAGE_SIZE)
-      host_page_map_.erase((gpu_va + off) >> PAGE_SHIFT);
-  }
-
 private:
   mutable std::shared_mutex mutex_;
   mutable std::unordered_map<uint64_t, Page> pages_;
-
-  /// @brief Page-indexed host range map. Key = page_number (gpu_va >> 12),
-  /// value = host_ptr for the start of that page. O(1) lookup per access.
-  mutable std::shared_mutex host_range_mutex_;
-  std::unordered_map<uint64_t, uint8_t *> host_page_map_;
 
   // Returns a reference to the 4KB page containing addr, allocating if needed.
   // Caller must hold exclusive lock on mutex_.

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -184,6 +184,48 @@ TEST(GpuMemoryTest, SparsePages) {
   EXPECT_EQ(mem->read32(0x50000), 0u);
 }
 
+TEST(GpuMemoryTest, FindHostRangeUsesVmidPageTable) {
+  amdgpu::GpuMemory mem("vmid_range_mem");
+  KfdProcess process(/*process_id=*/123);
+  alignas(4096) std::array<uint8_t, 3 * amdgpu::GpuMemory::PAGE_SIZE> backing{};
+  constexpr uint64_t kGpuVa = 0x100000;
+
+  mem.register_process(process.process_id(), &process.page_table_, &process.page_table_mutex_);
+  process.map_pages(kGpuVa, backing.data(), backing.size());
+
+  auto [host_base, size] =
+      mem.find_host_range(kGpuVa + amdgpu::GpuMemory::PAGE_SIZE + 0x123, process.process_id());
+  EXPECT_EQ(host_base, reinterpret_cast<uint64_t>(backing.data()));
+  EXPECT_EQ(size, backing.size());
+
+  mem.unregister_process(process.process_id());
+}
+
+TEST(GpuMemoryTest, FindHostRangeStopsAtNonContiguousVmidHostPages) {
+  amdgpu::GpuMemory mem("vmid_noncontiguous_range_mem");
+  KfdProcess process(/*process_id=*/124);
+  alignas(4096) std::array<uint8_t, 3 * amdgpu::GpuMemory::PAGE_SIZE> backing{};
+  constexpr uint64_t kGpuVa = 0x200000;
+
+  mem.register_process(process.process_id(), &process.page_table_, &process.page_table_mutex_);
+  process.map_pages(kGpuVa, backing.data(), amdgpu::GpuMemory::PAGE_SIZE);
+  process.map_pages(kGpuVa + amdgpu::GpuMemory::PAGE_SIZE,
+                    backing.data() + 2 * amdgpu::GpuMemory::PAGE_SIZE,
+                    amdgpu::GpuMemory::PAGE_SIZE);
+
+  auto [first_host_base, first_size] = mem.find_host_range(kGpuVa, process.process_id());
+  EXPECT_EQ(first_host_base, reinterpret_cast<uint64_t>(backing.data()));
+  EXPECT_EQ(first_size, amdgpu::GpuMemory::PAGE_SIZE);
+
+  auto [second_host_base, second_size] =
+      mem.find_host_range(kGpuVa + amdgpu::GpuMemory::PAGE_SIZE, process.process_id());
+  EXPECT_EQ(second_host_base,
+            reinterpret_cast<uint64_t>(backing.data() + 2 * amdgpu::GpuMemory::PAGE_SIZE));
+  EXPECT_EQ(second_size, amdgpu::GpuMemory::PAGE_SIZE);
+
+  mem.unregister_process(process.process_id());
+}
+
 TEST(RdnaDispatchTest, WgpModeCombinesSiblingCuLdsCapacity) {
   constexpr uint32_t kPerCuLdsBytes = 64 * 1024;
   constexpr uint32_t kWgpLdsBytes = 2 * kPerCuLdsBytes;


### PR DESCRIPTION
# POC: remove SparseMemory host page map

Reference POC for review discussion around #8702.

## Summary

This explores removing the VMID-less host-page mapping path from
`simdojo::SparseMemory`.

Current KFD/HIP mappings appear to go through `KfdProcess::page_table_` and
`GpuMemory::translate()`, and I do not see live callers of
`SparseMemory::map_host_pages()` in the current tree. This suggests
`SparseMemory::host_page_map_` may be legacy.

This POC:

- removes `SparseMemory::host_page_map_` and related APIs;
- makes `SparseMemory` a pure sparse byte store;
- adds VMID-aware host-range lookup in `GpuMemory`;
- updates command processor kernel-symbol lookup to use the `GpuMemory` path;
- adds focused `GpuMemory` host-range tests.

## Context

PR #8702 adds an optimization for the empty `host_page_map_` case. This POC asks
whether the cleaner answer is to remove that legacy path instead.

This overlaps conceptually with #7906, which already moves kernel-symbol lookup
toward VMID-aware `GpuMemory` translation. If #7906 lands first, this POC should
become mostly deletion.

## Validation

- Built `rocjitsu_tests`.
- Passed focused `GpuMemory`, checkpoint, L1/L2 cache, dispatch, and vector-add tests.
- `git diff --check` passed.

## Caveat

This is a reference POC, not a merge-ready PR. The main open question is whether
any intended external Simdojo users still need `SparseMemory::map_host_pages()`.