### PR TITLE
ci: add gfx125x to TheRock CI defaults

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -17,7 +17,7 @@ on:
         description: "Insert space-separated list of projects to test or 'all' to test all projects. ex: 'projects/clr projects/rocminfo'"
       linux_amdgpu_families:
         type: string
-        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx950"
+        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx950, gfx125x"
         default: ""
       windows_amdgpu_families:
         type: string
@@ -124,7 +124,7 @@ jobs:
       - name: Fetch Linux targets for build and test
         env:
           THEROCK_PACKAGE_PLATFORM: "linux"
-          AMDGPU_FAMILIES: ${{ inputs.linux_amdgpu_families || 'gfx94X, gfx950' }}
+          AMDGPU_FAMILIES: ${{ inputs.linux_amdgpu_families || 'gfx94X, gfx950, gfx125x' }}
           CI_CONFIG_PATH: ci-config
         id: configure_linux
         run: python ./TheRock/build_tools/github_actions/fetch_package_targets.py


### PR DESCRIPTION
## Summary
- add gfx125x to the default Linux GPU families for the normal rocm-systems TheRock CI workflow
- update the workflow_dispatch help text to show gfx125x as an example

This adds gfx125X-dcgpu to the normal build matrix once the family is available from the shared TheRock CI config. The existing temporary MI455 build/test jobs are left intact, and the RCCL-specific matrix is intentionally unchanged because that path still has explicit test-runner assumptions for gfx94X/gfx950.

Depends on ROCm/therock-ci-config#14.

## Testing
- parsed .github/workflows/therock-ci.yml, .github/workflows/therock-ci-linux.yml, and .github/workflows/therock-build-linux.yml with PyYAML
- git diff --check