### PR TITLE
feat(hotswap): share retarget buffers across loads instead of copying

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -214,12 +214,9 @@ bool ComgrHotswapOptionsApiAvailable() {
 bool ComgrStrictModeApiAvailable() {
   if (!ComgrHotswapOptionsApiAvailable()) return false;
 
-  rocr::hotswap::OwnedElfBuffer rewritten_elf_buffer(nullptr, &std::free);
-  size_t rewritten_elf_size = 0;
   if (rocr::hotswap::RetargetCodeObject(
           kGfx1250MinCo, sizeof(kGfx1250MinCo), kGfx1250B0Isa, kGfx1250B0Isa,
-          &rewritten_elf_buffer, &rewritten_elf_size,
-          false, true)) {
+          false, true) != nullptr) {
     return true;
   }
 
@@ -422,20 +419,16 @@ TEST(HotswapRewrite, GetIsaNameInvalidCodeObject) {
 }
 
 TEST(HotswapRewrite, RetargetRealCodeObject) {
-  rocr::hotswap::OwnedElfBuffer rewritten_elf_buffer(nullptr, &std::free);
-  size_t rewritten_elf_size = 0;
+  const rocr::hotswap::ElfBufferRef rewritten_elf_buffer =
+      rocr::hotswap::RetargetCodeObject(kGfx1250MinCo, sizeof(kGfx1250MinCo),
+                                        kGfx1250Isa, kGfx1250Isa);
 
-  const bool rewritten = rocr::hotswap::RetargetCodeObject(
-      kGfx1250MinCo, sizeof(kGfx1250MinCo), kGfx1250Isa, kGfx1250Isa,
-      &rewritten_elf_buffer, &rewritten_elf_size);
-
-  ASSERT_TRUE(rewritten);
-  ASSERT_NE(rewritten_elf_buffer.get(), nullptr);
-  EXPECT_NE(rewritten_elf_buffer.get(),
+  ASSERT_NE(rewritten_elf_buffer, nullptr);
+  EXPECT_NE(static_cast<const void*>(rewritten_elf_buffer->data()),
             static_cast<const void*>(kGfx1250MinCo));
-  EXPECT_GT(rewritten_elf_size, 0u);
-  EXPECT_EQ(rocr::hotswap::GetCodeObjectIsaName(rewritten_elf_buffer.get(),
-                                                rewritten_elf_size),
+  EXPECT_GT(rewritten_elf_buffer->size(), 0u);
+  EXPECT_EQ(rocr::hotswap::GetCodeObjectIsaName(rewritten_elf_buffer->data(),
+                                                rewritten_elf_buffer->size()),
             kGfx1250Isa);
 }
 
@@ -443,52 +436,32 @@ TEST(HotswapRewrite, RetargetInvalidCodeObjectFails) {
   const unsigned char fake_elf[] = {0x7f, 'E',  'L',  'F',  0x02, 0x01,
                                     0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
                                     0x00, 0x00, 0x00, 0x00};
-  rocr::hotswap::OwnedElfBuffer rewritten_elf_buffer(nullptr, &std::free);
-  size_t rewritten_elf_size = 0;
+  const rocr::hotswap::ElfBufferRef rewritten_elf_buffer =
+      rocr::hotswap::RetargetCodeObject(fake_elf, sizeof(fake_elf), kGfx1250Isa,
+                                        kGfx1250Isa);
 
-  const bool rewritten = rocr::hotswap::RetargetCodeObject(
-      fake_elf, sizeof(fake_elf), kGfx1250Isa, kGfx1250Isa,
-      &rewritten_elf_buffer, &rewritten_elf_size);
-
-  EXPECT_FALSE(rewritten);
-  EXPECT_EQ(rewritten_elf_buffer.get(), nullptr);
-  EXPECT_EQ(rewritten_elf_size, 0u);
-}
-
-TEST(HotswapRewrite, RetargetNullOutputPointers) {
-  const unsigned char fake_elf[] = {0x7f, 'E', 'L', 'F'};
-
-  const bool rewritten = rocr::hotswap::RetargetCodeObject(
-      fake_elf, sizeof(fake_elf), kGfx1250Isa, kGfx1250Isa, nullptr, nullptr);
-
-  EXPECT_FALSE(rewritten);
+  EXPECT_EQ(rewritten_elf_buffer, nullptr);
 }
 
 TEST(HotswapRewrite, RetargetNullInputs) {
-  rocr::hotswap::OwnedElfBuffer rewritten_elf_buffer(nullptr, &std::free);
-  size_t rewritten_elf_size = 0;
+  const rocr::hotswap::ElfBufferRef rewritten_elf_buffer =
+      rocr::hotswap::RetargetCodeObject(nullptr, 0, kGfx1250Isa, kGfx1250Isa);
 
-  const bool rewritten = rocr::hotswap::RetargetCodeObject(
-      nullptr, 0, kGfx1250Isa, kGfx1250Isa, &rewritten_elf_buffer,
-      &rewritten_elf_size);
-
-  EXPECT_FALSE(rewritten);
+  EXPECT_EQ(rewritten_elf_buffer, nullptr);
 }
 
 TEST(HotswapRewrite, RetargetNullSourceOrTarget) {
   const unsigned char fake_elf[] = {0x7f, 'E', 'L', 'F'};
-  rocr::hotswap::OwnedElfBuffer rewritten_elf_buffer(nullptr, &std::free);
-  size_t rewritten_elf_size = 0;
 
-  const bool source_missing_rewritten = rocr::hotswap::RetargetCodeObject(
-      fake_elf, sizeof(fake_elf), nullptr, kGfx1250Isa, &rewritten_elf_buffer,
-      &rewritten_elf_size);
-  const bool target_missing_rewritten = rocr::hotswap::RetargetCodeObject(
-      fake_elf, sizeof(fake_elf), kGfx1250Isa, nullptr, &rewritten_elf_buffer,
-      &rewritten_elf_size);
+  const rocr::hotswap::ElfBufferRef source_missing =
+      rocr::hotswap::RetargetCodeObject(fake_elf, sizeof(fake_elf), nullptr,
+                                        kGfx1250Isa);
+  const rocr::hotswap::ElfBufferRef target_missing =
+      rocr::hotswap::RetargetCodeObject(fake_elf, sizeof(fake_elf), kGfx1250Isa,
+                                        nullptr);
 
-  EXPECT_FALSE(source_missing_rewritten);
-  EXPECT_FALSE(target_missing_rewritten);
+  EXPECT_EQ(source_missing, nullptr);
+  EXPECT_EQ(target_missing, nullptr);
 }
 
 TEST(HotswapRewrite, RuntimeLoadUsesRewrittenCodeObject) {
@@ -780,6 +753,47 @@ TEST(HotswapRewrite, RetargetCacheServesSecondLoadFromCache) {
 
   // Cache size should not have grown (hit, not a new entry).
   EXPECT_EQ(rocr::hotswap::RetargetCacheSizeForTesting(), cache_size_after_first);
+  rocr::hotswap::ClearRetargetCacheForTesting();
+}
+
+TEST(HotswapRewrite, CachedLoadsShareOneBufferNoCopy) {
+  ResetRuntimeTestEnv();
+  if (!ComgrHotswapOptionsApiAvailable()) return;
+  rocr::hotswap::ClearRetargetCacheForTesting();
+  ASSERT_EQ(rocr::hotswap::RetargetCacheSizeForTesting(), 0u);
+
+  // First load populates the cache and records the buffer pointer handed to the
+  // loader. Keep the executable's retained reference alive for the comparison.
+  const hsa_executable_t exec_a = MakeTestExecutable(0x610);
+  LoadRecorder load_a;
+  ASSERT_EQ(rocr::hotswap::LoadAgentCodeObjectWithHotswap(
+                exec_a, MakeTestAgent(), MakeRealCodeObjectView(), nullptr,
+                nullptr, MakeLoadCallbacks(&load_a)),
+            HSA_STATUS_SUCCESS);
+  ASSERT_EQ(load_a.calls.size(), 1u);
+  ASSERT_EQ(load_a.calls[0].path, LoadPath::kRewritten);
+
+  // Second load of the identical code object hits the cache. With zero-copy
+  // sharing the loader must receive the SAME buffer pointer, not a fresh copy.
+  const hsa_executable_t exec_b = MakeTestExecutable(0x611);
+  LoadRecorder load_b;
+  ASSERT_EQ(rocr::hotswap::LoadAgentCodeObjectWithHotswap(
+                exec_b, MakeTestAgent(), MakeRealCodeObjectView(), nullptr,
+                nullptr, MakeLoadCallbacks(&load_b)),
+            HSA_STATUS_SUCCESS);
+  ASSERT_EQ(load_b.calls.size(), 1u);
+  ASSERT_EQ(load_b.calls[0].path, LoadPath::kRewritten);
+
+  // Same underlying buffer (shared, not copied) and equal size.
+  EXPECT_EQ(load_a.calls[0].code_object, load_b.calls[0].code_object);
+  EXPECT_EQ(load_a.calls[0].code_object_size, load_b.calls[0].code_object_size);
+
+  // Both executables retain a reference to that one buffer; it stays valid until
+  // the last executable releases it.
+  EXPECT_EQ(rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(exec_a), 1u);
+  EXPECT_EQ(rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(exec_b), 1u);
+  rocr::hotswap::ReleaseRetainedRewrittenElfBuffers(exec_a);
+  rocr::hotswap::ReleaseRetainedRewrittenElfBuffers(exec_b);
   rocr::hotswap::ClearRetargetCacheForTesting();
 }
 

--- a/projects/rocr-runtime/rocrtst/suites/test_common/test_categories.yaml
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/test_categories.yaml
@@ -31,6 +31,7 @@ test_categories:
       - "rocrtstFunc.AgentProp_UUID"
       - "rocrtstFunc.AgentPropertiesTests"
       - "HotswapRewrite.RetargetCacheServesSecondLoadFromCache"
+      - "HotswapRewrite.CachedLoadsShareOneBufferNoCopy"
       - "HotswapRewrite.RetargetCacheClearResetsCacheSize"
     exclude:
       - "rocrtstFunc.Memory_Max_Mem"
@@ -112,6 +113,7 @@ test_categories:
       - "rocrtstPerf.AQL_Dispatch_Time_Multi_SpinWait"
       - "rocrtstPerf.AQL_Dispatch_Time_Multi_Interrupt"
       - "HotswapRewrite.RetargetCacheServesSecondLoadFromCache"
+      - "HotswapRewrite.CachedLoadsShareOneBufferNoCopy"
       - "HotswapRewrite.RetargetCacheClearResetsCacheSize"
     exclude:
       - "rocrtstFunc.Memory_Max_Mem"
@@ -203,6 +205,7 @@ test_categories:
       - "rocrtstPerf.AQL_Dispatch_Time_Multi_SpinWait"
       - "rocrtstPerf.AQL_Dispatch_Time_Multi_Interrupt"
       - "HotswapRewrite.RetargetCacheServesSecondLoadFromCache"
+      - "HotswapRewrite.CachedLoadsShareOneBufferNoCopy"
       - "HotswapRewrite.RetargetCacheClearResetsCacheSize"
     exclude:
       - "rocrtstFunc.Memory_Max_Mem"
@@ -296,6 +299,7 @@ test_categories:
       - "rocrtstPerf.AQL_Dispatch_Time_Multi_SpinWait"
       - "rocrtstPerf.AQL_Dispatch_Time_Multi_Interrupt"
       - "HotswapRewrite.RetargetCacheServesSecondLoadFromCache"
+      - "HotswapRewrite.CachedLoadsShareOneBufferNoCopy"
       - "HotswapRewrite.RetargetCacheClearResetsCacheSize"
     exclude:
       - "rocrtstFunc.Memory_Max_Mem"

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
@@ -44,10 +44,11 @@
 #define HSA_RUNTIME_CORE_INC_HOTSWAP_HPP_
 
 #include <cstddef>
-#include <cstdlib>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "core/inc/amd_hsa_loader.hpp"
 #include "inc/hsa.h"
@@ -57,7 +58,14 @@ namespace hotswap {
 
 struct AgentGfxRevision;
 
-using OwnedElfBuffer = std::unique_ptr<void, decltype(&std::free)>;
+// Retargeted code objects are shared, not uniquely owned: a single retarget
+// result is handed to every agent that loads the same code object (e.g. all
+// GPUs in a multi-GPU job) and is simultaneously held by the in-memory retarget
+// cache, so consumers reference-count one buffer instead of each holding a
+// private copy. The loader consumes the ELF read-only (it copies segments out
+// into its own memory and applies relocations there), so sharing one immutable
+// buffer across concurrent loads is safe.
+using ElfBufferRef = std::shared_ptr<std::vector<uint8_t>>;
 
 struct CodeObjectView {
   const void* data = nullptr;
@@ -110,19 +118,20 @@ struct LoadAgentCodeObjectCallbacks {
 
 std::string GetCodeObjectIsaName(const void* elf_data, size_t elf_size);
 
-bool RetargetCodeObject(const void* elf_data, size_t elf_size,
-                        const char* source_isa, const char* target_isa,
-                        OwnedElfBuffer* out_elf_buffer, size_t* out_elf_size,
-                        bool request_entry_trampolines = false,
-                        bool request_strict_mode = false);
+// Returns the retargeted ELF as a shared buffer, or nullptr on failure. The
+// size is carried by the buffer itself (ElfBufferRef->size()).
+ElfBufferRef RetargetCodeObject(const void* elf_data, size_t elf_size,
+                                const char* source_isa, const char* target_isa,
+                                bool request_entry_trampolines = false,
+                                bool request_strict_mode = false);
 
 RetargetCodeObjectResult TryRetargetCodeObject(
     const CodeObjectView& code_object, hsa_agent_t agent,
-    OwnedElfBuffer* out_elf_buffer, size_t* out_elf_size);
+    ElfBufferRef* out_elf_buffer);
 
 RetargetCodeObjectResult TryRetargetCodeObject(
     amd::hsa::loader::CodeObjectReaderImpl* reader, hsa_agent_t agent,
-    OwnedElfBuffer* out_elf_buffer, size_t* out_elf_size);
+    ElfBufferRef* out_elf_buffer);
 
 hsa_status_t LoadAgentCodeObjectWithHotswap(
     hsa_executable_t executable, hsa_agent_t agent,
@@ -131,7 +140,7 @@ hsa_status_t LoadAgentCodeObjectWithHotswap(
     const LoadAgentCodeObjectCallbacks& callbacks);
 
 void RetainRewrittenElfBuffer(hsa_executable_t executable,
-                              OwnedElfBuffer elf_buffer);
+                              ElfBufferRef elf_buffer);
 void ReleaseRetainedRewrittenElfBuffers(hsa_executable_t executable);
 
 #ifdef ROCR_HOTSWAP_TESTING

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -70,7 +70,15 @@ namespace hotswap {
 namespace {
 
 std::mutex g_retained_rewritten_elf_buffers_mutex;
-std::unordered_map<uint64_t, std::vector<OwnedElfBuffer>> g_retained_rewritten_elf_buffers;
+std::unordered_map<uint64_t, std::vector<ElfBufferRef>> g_retained_rewritten_elf_buffers;
+
+// Fallback owner for retarget buffers that could not be recorded in the
+// per-executable keepalive map due to allocation failure. The loader holds a
+// raw pointer into the buffer for the executable's lifetime, so on OOM we move
+// the reference here rather than let it drop and dangle. Bounded to genuine
+// keepalive-OOM events; never cleared at runtime.
+std::mutex g_oom_retained_elf_buffers_mutex;
+std::vector<ElfBufferRef> g_oom_retained_elf_buffers;
 #ifdef ROCR_HOTSWAP_TESTING
 std::atomic<bool> g_force_retarget_code_object_failure_for_testing{false};
 #endif
@@ -449,24 +457,22 @@ void LogRequiredRewrittenLoadFailure(hsa_status_t status) {
 
 }  // namespace
 
-bool RetargetCodeObject(const void* elf_data, size_t elf_size, const char* source_isa,
-                        const char* target_isa, OwnedElfBuffer* out_elf_buffer,
-                        size_t* out_elf_size, bool request_entry_trampolines,
-                        bool request_strict_mode) {
+ElfBufferRef RetargetCodeObject(const void* elf_data, size_t elf_size, const char* source_isa,
+                                const char* target_isa, bool request_entry_trampolines,
+                                bool request_strict_mode) {
   ComgrApi* api = GetComgrApi();
-  if (!api || !elf_data || elf_size == 0 || !source_isa || !target_isa || !out_elf_buffer ||
-      !out_elf_size) {
-    return false;
+  if (!api || !elf_data || elf_size == 0 || !source_isa || !target_isa) {
+    return nullptr;
   }
 
   ComgrData input = {};
   if (api->create_data(kComgrDataKindExecutable, &input) != kComgrStatusSuccess) {
-    return false;
+    return nullptr;
   }
 
   if (api->set_data(input, elf_size, static_cast<const char*>(elf_data)) != kComgrStatusSuccess) {
     api->release_data(input);
-    return false;
+    return nullptr;
   }
 
   ComgrData output = {};
@@ -478,7 +484,7 @@ bool RetargetCodeObject(const void* elf_data, size_t elf_size, const char* sourc
     if (!api->hotswap_rewrite_with_options) {
       api->release_data(input);
       HOTSWAP_LOG("hotswap: COMGR rewrite-with-options entry point unavailable\n");
-      return false;
+      return nullptr;
     }
     const ComgrHotswapRewriteOptions options{
         sizeof(ComgrHotswapRewriteOptions),
@@ -492,38 +498,44 @@ bool RetargetCodeObject(const void* elf_data, size_t elf_size, const char* sourc
   if (status != kComgrStatusSuccess) {
     HOTSWAP_LOG("hotswap: COMGR rewrite failed for %s -> %s (rc=%d)\n", source_isa, target_isa,
                 status);
-    return false;
+    return nullptr;
   }
 
   size_t output_size = 0;
   if (api->get_data(output, &output_size, nullptr) != kComgrStatusSuccess || output_size == 0) {
     api->release_data(output);
-    return false;
+    return nullptr;
   }
 
-  OwnedElfBuffer output_buffer(std::malloc(output_size), &std::free);
-  if (!output_buffer) {
+  // The one unavoidable copy: COMGR owns the output across the C ABI, so its
+  // bytes must be copied out into a buffer we own. From here on the buffer is
+  // shared (never copied again) across the cache and every consuming load.
+  ElfBufferRef output_buffer;
+  try {
+    output_buffer = std::make_shared<std::vector<uint8_t>>(output_size);
+  } catch (const std::bad_alloc&) {
     api->release_data(output);
-    return false;
+    return nullptr;
   }
 
   size_t copy_size = output_size;
-  if (api->get_data(output, &copy_size, static_cast<char*>(output_buffer.get())) !=
+  if (api->get_data(output, &copy_size, reinterpret_cast<char*>(output_buffer->data())) !=
       kComgrStatusSuccess) {
     api->release_data(output);
-    return false;
+    return nullptr;
   }
 
   api->release_data(output);
-  *out_elf_buffer = std::move(output_buffer);
-  *out_elf_size = output_size;
-  return true;
+  return output_buffer;
 }
 
 RetargetCodeObjectResult TryRetargetCodeObject(const CodeObjectView& code_object,
                                                hsa_agent_t agent,
-                                               OwnedElfBuffer* out_elf_buffer,
-                                               size_t* out_elf_size) {
+                                               ElfBufferRef* out_elf_buffer) {
+  if (!out_elf_buffer) {
+    return {};
+  }
+  out_elf_buffer->reset();
   if (IsHotswapDisabledByEnv() || !code_object.data || code_object.size == 0) {
     return {};
   }
@@ -583,18 +595,16 @@ RetargetCodeObjectResult TryRetargetCodeObject(const CodeObjectView& code_object
     }
 
     if (cached_bytes) {
-      OwnedElfBuffer buf(std::malloc(cached_bytes->size()), &std::free);
-      if (buf) {
-        std::memcpy(buf.get(), cached_bytes->data(), cached_bytes->size());
-        *out_elf_buffer = std::move(buf);
-        *out_elf_size = cached_bytes->size();
-        HOTSWAP_LOG("hotswap: cache hit (success) src=%s tgt=%s entry_trampolines=%d strict=%d "
-                    "in=%zu out=%zu\n",
-                    decision->source_isa.c_str(), decision->target_isa.c_str(),
-                    decision->request_entry_trampolines, decision->request_strict_mode,
-                    code_object.size, cached_bytes->size());
-        return {RetargetCodeObjectStatus::kRewritten, decision->rewrite_required};
-      }
+      // Hand back the cached buffer itself (refcount++), no copy. The loader
+      // reads it read-only and the ref is retained per-executable, so every
+      // load of this code object shares one buffer.
+      *out_elf_buffer = std::move(cached_bytes);
+      HOTSWAP_LOG("hotswap: cache hit (success) src=%s tgt=%s entry_trampolines=%d strict=%d "
+                  "in=%zu out=%zu\n",
+                  decision->source_isa.c_str(), decision->target_isa.c_str(),
+                  decision->request_entry_trampolines, decision->request_strict_mode,
+                  code_object.size, (*out_elf_buffer)->size());
+      return {RetargetCodeObjectStatus::kRewritten, decision->rewrite_required};
     }
   }
 
@@ -607,16 +617,21 @@ RetargetCodeObjectResult TryRetargetCodeObject(const CodeObjectView& code_object
   } else
 #endif
   {
-    rewritten = RetargetCodeObject(code_object.data, code_object.size,
-                                   decision->source_isa.c_str(), decision->target_isa.c_str(),
-                                   out_elf_buffer, out_elf_size,
-                                   decision->request_entry_trampolines,
-                                   decision->request_strict_mode);
+    *out_elf_buffer = RetargetCodeObject(code_object.data, code_object.size,
+                                         decision->source_isa.c_str(),
+                                         decision->target_isa.c_str(),
+                                         decision->request_entry_trampolines,
+                                         decision->request_strict_mode);
+    rewritten = (*out_elf_buffer != nullptr);
   }
 
   // Cache the result. Only deterministic COMGR outcomes are cached; transient
   // allocation failures and test-forced failures are not, so a later attempt
-  // with the same code object can still succeed.
+  // with the same code object can still succeed. On success the SAME buffer is
+  // stored and returned (no copy) — cache and caller share one refcounted
+  // object. Concurrent cold misses on the same key may each run COMGR and race
+  // to store (first-wins); the loser still returns its own valid buffer, so a
+  // single shared buffer is only guaranteed once an entry is committed.
   if (retarget_attempted) {
     try {
       std::scoped_lock lock(g_retarget_cache_mutex);
@@ -624,8 +639,7 @@ RetargetCodeObjectResult TryRetargetCodeObject(const CodeObjectView& code_object
         CachedRetargetResult entry;
         entry.succeeded = rewritten;
         if (rewritten) {
-          const auto* data = static_cast<const uint8_t*>((*out_elf_buffer).get());
-          entry.elf_bytes = std::make_shared<std::vector<uint8_t>>(data, data + *out_elf_size);
+          entry.elf_bytes = *out_elf_buffer;
         }
         g_retarget_cache.emplace(cache_key, std::move(entry));
         HOTSWAP_LOG("hotswap: cached key=0x%llx src=%s tgt=%s entry_trampolines=%d strict=%d "
@@ -645,8 +659,8 @@ RetargetCodeObjectResult TryRetargetCodeObject(const CodeObjectView& code_object
               "in=%zu out=%zu changed=%d\n",
               decision->source_isa.c_str(), decision->target_isa.c_str(),
               decision->request_entry_trampolines, decision->request_strict_mode,
-              decision->rewrite_required, code_object.size, rewritten ? *out_elf_size : 0,
-              rewritten ? 1 : 0);
+              decision->rewrite_required, code_object.size,
+              rewritten ? (*out_elf_buffer)->size() : 0, rewritten ? 1 : 0);
   if (rewritten) {
     return {RetargetCodeObjectStatus::kRewritten,
             decision->rewrite_required};
@@ -659,7 +673,7 @@ RetargetCodeObjectResult TryRetargetCodeObject(const CodeObjectView& code_object
 
 RetargetCodeObjectResult TryRetargetCodeObject(
     amd::hsa::loader::CodeObjectReaderImpl* reader, hsa_agent_t agent,
-    OwnedElfBuffer* out_elf_buffer, size_t* out_elf_size) {
+    ElfBufferRef* out_elf_buffer) {
   if (!reader) {
     return {};
   }
@@ -668,7 +682,7 @@ RetargetCodeObjectResult TryRetargetCodeObject(
   code_object.data = reader->GetCodeObjectMemory();
   code_object.size = reader->GetCodeObjectSize();
   code_object.uri = reader->GetUri();
-  return TryRetargetCodeObject(code_object, agent, out_elf_buffer, out_elf_size);
+  return TryRetargetCodeObject(code_object, agent, out_elf_buffer);
 }
 
 hsa_status_t LoadAgentCodeObjectWithHotswap(hsa_executable_t executable, hsa_agent_t agent,
@@ -681,15 +695,14 @@ hsa_status_t LoadAgentCodeObjectWithHotswap(hsa_executable_t executable, hsa_age
 
   hsa_code_object_t original_code_object = {reinterpret_cast<uint64_t>(code_object.data)};
 
-  OwnedElfBuffer rewritten_elf_buffer(nullptr, &std::free);
-  size_t rewritten_elf_size = 0;
+  ElfBufferRef rewritten_elf_buffer;
   const RetargetCodeObjectResult retarget_result =
-      TryRetargetCodeObject(code_object, agent, &rewritten_elf_buffer, &rewritten_elf_size);
+      TryRetargetCodeObject(code_object, agent, &rewritten_elf_buffer);
   if (retarget_result.status == RetargetCodeObjectStatus::kRewritten) {
     hsa_code_object_t rewritten_code_object = {
-        reinterpret_cast<uint64_t>(rewritten_elf_buffer.get())};
+        reinterpret_cast<uint64_t>(rewritten_elf_buffer->data())};
     hsa_status_t status = callbacks.load_rewritten_code_object(
-        callbacks.context, agent, rewritten_code_object, rewritten_elf_size, options,
+        callbacks.context, agent, rewritten_code_object, rewritten_elf_buffer->size(), options,
         code_object.uri, loaded_code_object);
     if (status == HSA_STATUS_SUCCESS) {
       RetainRewrittenElfBuffer(executable, std::move(rewritten_elf_buffer));
@@ -710,14 +723,26 @@ hsa_status_t LoadAgentCodeObjectWithHotswap(hsa_executable_t executable, hsa_age
                                              options, code_object.uri, loaded_code_object);
 }
 
-void RetainRewrittenElfBuffer(hsa_executable_t executable, OwnedElfBuffer elf_buffer) {
+void RetainRewrittenElfBuffer(hsa_executable_t executable, ElfBufferRef elf_buffer) {
+  if (!elf_buffer) {
+    return;
+  }
   try {
     std::scoped_lock lock(g_retained_rewritten_elf_buffers_mutex);
     g_retained_rewritten_elf_buffers[executable.handle].push_back(std::move(elf_buffer));
   } catch (const std::bad_alloc&) {
-    // If the keepalive container cannot grow, preserve the loaded code object's
-    // raw ELF pointer by intentionally leaking this allocation.
-    (void)elf_buffer.release();
+    // The per-executable keepalive map could not grow. The loader holds a raw
+    // pointer into this buffer for the executable's lifetime, so the reference
+    // must not drop here. Park it in a global fallback that outlives the
+    // executable rather than leaking it irrecoverably; if even that cannot
+    // grow, the reference is intentionally leaked as a last resort so the
+    // loaded code object's ELF pointer stays valid.
+    try {
+      std::scoped_lock lock(g_oom_retained_elf_buffers_mutex);
+      g_oom_retained_elf_buffers.push_back(std::move(elf_buffer));
+    } catch (const std::bad_alloc&) {
+      new ElfBufferRef(std::move(elf_buffer));  // deliberate last-resort leak
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

The hotswap retarget cache already stores each rewritten code object as a
`shared_ptr<vector<uint8_t>>`, but it handed every load a **private
`malloc`+`memcpy` copy** through a `unique_ptr` (`OwnedElfBuffer`). In a
multi-GPU job, every agent that loads the same code object paid a full copy of
the retargeted ELF — hundreds of MB for large device libraries such as RCCL —
and the buffer's lifetime was duplicated per executable.

This change makes consumers **share the cache's buffer by reference** instead of
copying it:

- Replaces `OwnedElfBuffer` (`unique_ptr<void, &std::free>`) with
  `ElfBufferRef` (`shared_ptr<vector<uint8_t>>`) throughout the hotswap module.
- On a cache hit, the loader is handed the cache's own buffer (refcount++), not
  a fresh copy. The single retarget output is shared by the in-memory cache and
  every executable that loads it, and is freed once the last holder releases it.
- `RetargetCodeObject` now returns the buffer (`nullptr` on failure) with the
  size carried by the buffer itself, replacing the bool + out-param API.

The only remaining copy is the unavoidable copy-out of COMGR's output across the
COMGR C ABI on a cold miss.

## Why this is safe

The loader consumes the retargeted ELF **read-only**: it copies loadable
segments out into its own allocated memory and applies relocations there, never
mutating the source ELF image (`ExecutableImpl::LoadSegmentsV2` copies via
`Segment::Copy`; relocations write into the loaded segment). `InitAsBuffer`
aliases the bytes rather than editing them. Sharing one immutable buffer across
concurrent loads therefore cannot corrupt a shared cache entry.

The per-executable keepalive (needed because the loader holds a raw pointer into
the buffer for the executable's lifetime) is preserved; its OOM path is reworked
from a raw-pointer leak into a bounded global fallback with a last-resort
reference leak.

Note: there is no single-flight, so concurrent cold misses on the same key may
each run COMGR and race to store (first-wins); the loser still returns its own
valid buffer, so a single shared buffer is only guaranteed once an entry is
committed. This matches prior behavior.

## Relationship to other work

Builds on the in-memory retarget cache from #8274 (merged). Independent of the
two-tier disk cache in #8659.

## Test plan

- [x] New unit test `HotswapRewrite.CachedLoadsShareOneBufferNoCopy`: two
  cache-served loads of the same code object receive the **same** buffer pointer
  (proves zero-copy sharing) and both executables retain a reference to it.
- [x] Adapted existing `HotswapRewrite.*` tests to the new return-by-value API.
- [x] Registered the new test across all rocrtst tiers in `test_categories.yaml`.
- [x] Builds clean and full `hotswap_rewrite` suite passes on MI300X (32/32),
  including the new test.