### PR TITLE
fix(rocr): PC Sampling: fix lost-wakeup race in consumer notification

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -1028,10 +1028,10 @@ class GpuAgent : public GpuAgentInt {
 
     /* Consumer thread for aggregated callback delivery */
     std::thread consumer_thread;            // Aggregates data and delivers callbacks
-    std::mutex consumer_mutex;              // Protects consumer_cv and pending_flush_count
+    std::mutex consumer_mutex;              // Protects consumer_cv, pending_flush_count, consumer_exit (for notify)
     std::condition_variable consumer_cv;    // Wakes consumer when XCC threads have new data
-    std::atomic<bool> consumer_exit;        // Signal consumer thread to exit
-    std::atomic<uint32_t> pending_flush_count;  // How many XCCs have notified consumer
+    std::atomic<bool> consumer_exit;        // Signal consumer thread to exit (atomic for lockless loop check)
+    uint32_t pending_flush_count;           // How many XCCs have notified consumer (protected by consumer_mutex)
     std::mutex delivery_mutex;              // Serializes callback delivery (consumer vs Flush)
 
     pcs::PcsRuntime::PcSamplingSession* session;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -4317,8 +4317,11 @@ hsa_status_t GpuAgent::PcSamplingStart(pcs::PcsRuntime::PcSamplingSession& sessi
   pcs_data->session->stop();
 
   // Stop consumer thread first
-  pcs_data->consumer_exit.store(true, std::memory_order_release);
-  pcs_data->consumer_cv.notify_one();
+  {
+    std::lock_guard<std::mutex> lock(pcs_data->consumer_mutex);
+    pcs_data->consumer_exit.store(true, std::memory_order_release);
+    pcs_data->consumer_cv.notify_one();
+  }
   if (pcs_data->consumer_thread.joinable()) {
     pcs_data->consumer_thread.join();
   }
@@ -4380,8 +4383,11 @@ hsa_status_t GpuAgent::PcSamplingStop(pcs::PcsRuntime::PcSamplingSession& sessio
   // 2. Consumer may have unprocessed notifications - that's OK, Flush handles it
   // 3. Stopping consumer first avoids wasteful concurrent access (both use same buffers/mutexes)
   // 4. Final flush reads all data from host buffers and delivers via callback
-  pcs_data->consumer_exit.store(true, std::memory_order_release);
-  pcs_data->consumer_cv.notify_one();
+  {
+    std::lock_guard<std::mutex> lock(pcs_data->consumer_mutex);
+    pcs_data->consumer_exit.store(true, std::memory_order_release);
+    pcs_data->consumer_cv.notify_one();
+  }
   if (pcs_data->consumer_thread.joinable()) {
     pcs_data->consumer_thread.join();
   }
@@ -4825,8 +4831,12 @@ void GpuAgent::PcSamplingThreadPerXCC(pcs_data_t& pcs_data, uint32_t xcc_id,
 
       if (val == -1) {
         // Exit signal received - notify consumer and exit
-        pcs_data.pending_flush_count.fetch_add(1, std::memory_order_release);
-        pcs_data.consumer_cv.notify_one();
+        // fetch_add + notify_one must be under same lock to prevent lost-wakeup race
+        {
+          std::lock_guard<std::mutex> lock(pcs_data.consumer_mutex);
+          pcs_data.pending_flush_count.fetch_add(1, std::memory_order_release);
+          pcs_data.consumer_cv.notify_one();
+        }
         break;
       } else if (val != 0) {
         // Spurious wakeup - continue waiting
@@ -4851,8 +4861,15 @@ void GpuAgent::PcSamplingThreadPerXCC(pcs_data_t& pcs_data, uint32_t xcc_id,
       }
 
       // Notify consumer thread that new data is available
-      pcs_data.pending_flush_count.fetch_add(1, std::memory_order_release);
-      pcs_data.consumer_cv.notify_one();
+      // fetch_add + notify_one must be under same lock to prevent lost-wakeup race.
+      // The consumer's wait() predicate checks pending_flush_count under this same lock, so either:
+      // 1. Consumer is waiting: we increment, then notify wakes it up
+      // 2. Consumer checks predicate: it sees our incremented count and doesn't wait
+      {
+        std::lock_guard<std::mutex> lock(pcs_data.consumer_mutex);
+        pcs_data.pending_flush_count.fetch_add(1, std::memory_order_release);
+        pcs_data.consumer_cv.notify_one();
+      }
     }
 
     debug_print("%s (XCC %u)::Exiting\n", thread_name, xcc_id);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -4220,8 +4220,8 @@ hsa_status_t GpuAgent::PcSamplingStart(pcs::PcsRuntime::PcSamplingSession& sessi
     HSA::hsa_signal_store_screlease(pcs_data->xcc_data[xcc_id].done_sig1, 1);
     pcs_data->xcc_data[xcc_id].which_buffer = 0;
   }
-  pcs_data->consumer_exit.store(false, std::memory_order_release);
-  pcs_data->pending_flush_count.store(0, std::memory_order_release);
+  pcs_data->consumer_exit.store(false, std::memory_order_relaxed);
+  pcs_data->pending_flush_count = 0;
 
   struct ThreadData {
     GpuAgent* agent;
@@ -4316,10 +4316,14 @@ hsa_status_t GpuAgent::PcSamplingStart(pcs::PcsRuntime::PcSamplingSession& sessi
   debug_print("Failed to start PC sampling session with thunkId:%d\n", session.ThunkId());
   pcs_data->session->stop();
 
-  // Stop consumer thread first
+  // Stop consumer thread first.
+  // Store + notify must be under same lock to prevent lost-wakeup race.
+  // The consumer's wait() predicate checks consumer_exit under this same lock, so either:
+  // 1. Consumer is waiting: we set exit flag, then notify wakes it up
+  // 2. Consumer checks predicate: it sees exit=true and doesn't wait
   {
     std::lock_guard<std::mutex> lock(pcs_data->consumer_mutex);
-    pcs_data->consumer_exit.store(true, std::memory_order_release);
+    pcs_data->consumer_exit.store(true, std::memory_order_relaxed);
     pcs_data->consumer_cv.notify_one();
   }
   if (pcs_data->consumer_thread.joinable()) {
@@ -4383,9 +4387,14 @@ hsa_status_t GpuAgent::PcSamplingStop(pcs::PcsRuntime::PcSamplingSession& sessio
   // 2. Consumer may have unprocessed notifications - that's OK, Flush handles it
   // 3. Stopping consumer first avoids wasteful concurrent access (both use same buffers/mutexes)
   // 4. Final flush reads all data from host buffers and delivers via callback
+  //
+  // Store + notify must be under same lock to prevent lost-wakeup race.
+  // The consumer's wait() predicate checks consumer_exit under this same lock, so either:
+  // 1. Consumer is waiting: we set exit flag, then notify wakes it up
+  // 2. Consumer checks predicate: it sees exit=true and doesn't wait
   {
     std::lock_guard<std::mutex> lock(pcs_data->consumer_mutex);
-    pcs_data->consumer_exit.store(true, std::memory_order_release);
+    pcs_data->consumer_exit.store(true, std::memory_order_relaxed);
     pcs_data->consumer_cv.notify_one();
   }
   if (pcs_data->consumer_thread.joinable()) {
@@ -4830,11 +4839,14 @@ void GpuAgent::PcSamplingThreadPerXCC(pcs_data_t& pcs_data, uint32_t xcc_id,
           done_sig[which_buffer], HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_BLOCKED);
 
       if (val == -1) {
-        // Exit signal received - notify consumer and exit
-        // fetch_add + notify_one must be under same lock to prevent lost-wakeup race
+        // Exit signal received - notify consumer and exit.
+        // Increment + notify must be under same lock to prevent lost-wakeup race.
+        // The consumer's wait() predicate checks pending_flush_count under this same lock, so either:
+        // 1. Consumer is waiting: we increment, then notify wakes it up
+        // 2. Consumer checks predicate: it sees our incremented count and doesn't wait
         {
           std::lock_guard<std::mutex> lock(pcs_data.consumer_mutex);
-          pcs_data.pending_flush_count.fetch_add(1, std::memory_order_release);
+          pcs_data.pending_flush_count++;
           pcs_data.consumer_cv.notify_one();
         }
         break;
@@ -4860,14 +4872,14 @@ void GpuAgent::PcSamplingThreadPerXCC(pcs_data_t& pcs_data, uint32_t xcc_id,
         }
       }
 
-      // Notify consumer thread that new data is available
-      // fetch_add + notify_one must be under same lock to prevent lost-wakeup race.
+      // Notify consumer thread that new data is available.
+      // Increment + notify must be under same lock to prevent lost-wakeup race.
       // The consumer's wait() predicate checks pending_flush_count under this same lock, so either:
       // 1. Consumer is waiting: we increment, then notify wakes it up
       // 2. Consumer checks predicate: it sees our incremented count and doesn't wait
       {
         std::lock_guard<std::mutex> lock(pcs_data.consumer_mutex);
-        pcs_data.pending_flush_count.fetch_add(1, std::memory_order_release);
+        pcs_data.pending_flush_count++;
         pcs_data.consumer_cv.notify_one();
       }
     }
@@ -4965,11 +4977,13 @@ void GpuAgent::PcSamplingConsumerThread(pcs_data_t& pcs_data) {
       {
         std::unique_lock<std::mutex> lock(pcs_data.consumer_mutex);
         pcs_data.consumer_cv.wait(lock, [&pcs_data]() {
-          return pcs_data.pending_flush_count.load(std::memory_order_acquire) > 0 ||
-                 pcs_data.consumer_exit.load(std::memory_order_acquire);
+          // pending_flush_count is protected by consumer_mutex, plain read is safe.
+          // consumer_exit uses relaxed because the mutex provides synchronization.
+          return pcs_data.pending_flush_count > 0 ||
+                 pcs_data.consumer_exit.load(std::memory_order_relaxed);
         });
         // Reset pending count - we'll check all XCCs
-        pcs_data.pending_flush_count.store(0, std::memory_order_release);
+        pcs_data.pending_flush_count = 0;
       }
 
       if (pcs_data.consumer_exit.load(std::memory_order_acquire)) {


### PR DESCRIPTION
Wrap pending_flush_count.fetch_add() and consumer_cv.notify_one() inside the consumer_mutex lock at both the exit path and normal flush path. This ensures the increment and the consumer's wait() predicate check are mutually exclusive, eliminating the lost-wakeup race condition.

The race occurred because:
1. Consumer evaluates pending_flush_count == 0 (under lock)
2. Consumer releases lock, about to enter futex wait
3. Producer increments pending_flush_count - OUTSIDE lock
4. Producer calls notify_one()
5. Consumer enters futex wait - MISSES notification

On MI300X with 8 XCCs flushing simultaneously, all producers could
complete fetch_add + notify_one before the consumer entered wait(),
causing permanent hang since no subsequent traps would fire.

With the fix, either:
- Consumer is already waiting: increment + notify wakes it
- Consumer checks predicate: sees incremented count, doesn't wait

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
