### PR TITLE
fix(rocr): Fix ROCr DXG Linux memory import and fork handling

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
@@ -537,6 +537,11 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtRegisterGraphicsHandleToNodesExt(HSAuint64 Graphic
 #if defined(__linux__)
   if (is_ipc_sysmemfd(GraphicsResourceHandle)) {
     GraphicsResourceInfo->NodeId = dxg_runtime->default_node;
+
+    struct stat st;
+    if (fstat(static_cast<int>(GraphicsResourceHandle), &st) == 0)
+      GraphicsResourceInfo->SizeInBytes = st.st_size;
+
     pr_info("skip register sysmemfd. It would be released in next step\n");
     return HSAKMT_STATUS_SUCCESS;
   }
@@ -1099,7 +1104,8 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtReturnAsanHeaderPage(void *addr) {
 HSAKMT_STATUS HSAKMTAPI hsaKmtHandleImport(const HsaHandleImportDesc* import_desc,
     					HsaHandleImportResult* import_res, HsaHandleImportFlags* flags)
 {
-	CHECK_DXG_OPEN();
+  CHECK_DXG_OPEN();
+#ifdef WIN32
   if (import_desc->mem != nullptr) {
     void *memaddr = import_desc->mem;
     auto phys_mem = GetGpuMemoryFromAddress(memaddr);
@@ -1116,6 +1122,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtHandleImport(const HsaHandleImportDesc* import_des
       return HSAKMT_STATUS_SUCCESS;
     }
   }
+#endif
 
   if (import_desc->type != HSA_EXTERNAL_HANDLE_DMA_BUF) {
     assert(!"not supported\n");
@@ -1186,6 +1193,15 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMemoryVaMap(HsaMemoryObjectHandle Handle,
   (void)NodeId;
   wsl::thunk::GpuMemory* gpu_mem = reinterpret_cast<wsl::thunk::GpuMemory*>(Handle);
   assert(gpu_mem != nullptr);
+
+  if (gpu_mem->GpuAddress() == addr) {
+    pr_info("bo is mapped already\n");
+    return HSAKMT_STATUS_SUCCESS;
+  } else if (gpu_mem->GpuAddress()) {
+    pr_err("amdgpu_bo_va_op: GPU memory already mapped at %p, but requested to map at %p\n",
+           reinterpret_cast<void*>(gpu_mem->GpuAddress()), reinterpret_cast<void*>(addr));
+    return HSAKMT_STATUS_ERROR;
+  }
 
   auto code = gpu_mem->MapGpuVirtualAddress(static_cast<gpusize>(addr), size, offset);
   if (code != ErrorCode::Success)

--- a/projects/rocr-runtime/libhsakmt/src/dxg/openclose.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/openclose.cpp
@@ -41,6 +41,7 @@
 #include <cstring>
 #include <cassert>
 #include <mutex>
+#include <new>
 #include <algorithm>
 #include "util/os.h"
 #include "util/utils.h"
@@ -506,6 +507,19 @@ static void prepare_fork_handler(void) { dxg_runtime->hsakmt_mutex.lock(); }
 static void parent_fork_handler(void) { dxg_runtime->hsakmt_mutex.unlock(); }
 static void child_fork_handler(void) {
   dxg_runtime->is_forked = true;
+
+  /* prepare_fork_handler() locked hsakmt_mutex right before fork() so that
+   * no other thread would be mid-operation during the fork snapshot. In the
+   * child only this one thread survives, and its TID differs from whichever
+   * thread performed the lock in the parent, so the mutex's internal
+   * owner/lock state inherited via fork() is stale and can never be
+   * legitimately released by calling unlock() here. Reset it in place so
+   * the child starts with a fresh, unlocked mutex - otherwise the next
+   * hsaKmtOpenKFD() call in the child deadlocks forever waiting on a lock
+   * nobody in this process can release.
+   */
+  dxg_runtime->hsakmt_mutex.~recursive_mutex();
+  new (&dxg_runtime->hsakmt_mutex) std::recursive_mutex();
 }
 
 /* Call this from the child process after fork. This will clear all

--- a/projects/rocr-runtime/libhsakmt/src/dxg/openclose.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/openclose.cpp
@@ -588,6 +588,9 @@ static HSAKMT_STATUS init_vars_from_env(void) {
   if ((envvar = getenv("ROCR_USE_PM4")) != nullptr) {
     dxg_runtime->use_pm4_ = safe_env_to_int(envvar, 0);
   }
+#ifdef __linux__
+  dxg_runtime->use_pm4_ = 1;  // Force PM4 usage on Linux for now
+#endif
 
   // Disable wait timeout if ROCR_DISABLE_WAIT_TIMEOUT is set.
   if ((envvar = getenv("ROCR_DISABLE_WAIT_TIMEOUT")) != nullptr) {

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/gpu_memory.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/gpu_memory.cpp
@@ -734,6 +734,11 @@ ErrorCode GpuMemory::ImportPhysicalAllocHandle(const GpuMemoryCreateInfo& create
     // corrupt importer-side flag state (e.g. is_shared, is_queue_referenced).
     desc_.mem_flags = shared_info_ptr->mem_flags;
     desc_.adapter_luid = shared_info_ptr->adapter_luid;
+#ifdef __linux__
+    GpuMemoryDescFlags exporter_flags{};
+    exporter_flags.reserved = shared_info_ptr->flags;
+    desc_.flags.is_shared = exporter_flags.is_shared;
+#endif
 
     if (desc_.size == 0) {
       pr_err("import failed: could not determine allocation size from shared handle\n");


### PR DESCRIPTION
## Motivation

Fix ROCr DXG Linux path issues around memory import, PM4 enablement, and fork child reinitialization.

## Technical Details

- Reset the inherited `hsakmt_mutex` in the fork child to avoid deadlock on the next `hsaKmtOpenKFD()` call.
- Fix DXG memory import handling by preserving imported shared memory flags.
- Report sysmem fd size during graphics handle registration.
- Avoid duplicate GPU VA mappings during imported memory mapping.
- Force PM4 usage on Linux for the DXG path.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

rocrtst64 --gtest_filter=rocrtstFunc.IPC
rocrtst64 --gtest_filter=rocrtstFunc.VirtMemory_Basic_Test
rocrtst64 --gtest_filter=rocrtstFunc.VirtMemory_Interprocess_DevicePool_Test


## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
