### PR TITLE
feat(hotswap): add lazy per-kernel presentation mode

### DIFF
--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -468,9 +468,9 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
   // HotSwap: also request supported source ISAs for forwarding (skipped when forcing SPIRV).
   if (amd::hotswap::Enabled() && !HIP_FORCE_SPIRV_CODEOBJECT) {
     for (auto device : devices) {
-      const std::string target_gfx = device->devices()[0]->isa().processorName();
-      for (const amd::hotswap::SourceTargetPair& p : amd::hotswap::kSupportedPairs) {
-        if (target_gfx == p.target) {
+      const std::string presented_gfx = device->devices()[0]->isa().processorName();
+      for (const amd::hotswap::SourcePresentedPair& p : amd::hotswap::kSourceForwardingPairs) {
+        if (amd::hotswap::IsSourceForwardingPair(p.source, presented_gfx)) {
           unique_isa_names.insert(std::string("amdgcn-amd-amdhsa--") + p.source);
         }
       }
@@ -506,9 +506,9 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
       // HotSwap: pick the first supported source bundle for this device's target.
       auto hotswap_co = code_obj_map.end();
       if (amd::hotswap::Enabled() && !HIP_FORCE_SPIRV_CODEOBJECT) {
-        const std::string target_gfx = device->devices()[0]->isa().processorName();
-        for (const amd::hotswap::SourceTargetPair& p : amd::hotswap::kSupportedPairs) {
-          if (target_gfx != p.target) {
+        const std::string presented_gfx = device->devices()[0]->isa().processorName();
+        for (const amd::hotswap::SourcePresentedPair& p : amd::hotswap::kSourceForwardingPairs) {
+          if (!amd::hotswap::IsSourceForwardingPair(p.source, presented_gfx)) {
             continue;
           }
           for (auto it = code_obj_map.begin(); it != code_obj_map.end(); ++it) {

--- a/projects/clr/hipamd/src/hip_library.cpp
+++ b/projects/clr/hipamd/src/hip_library.cpp
@@ -372,7 +372,7 @@ hipError_t hipKernelGetAttribute(int* pi, hipFunction_attribute attrib, hipKerne
       break;
     case HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES: {
       int maxDynamicSharedSizeBytes = static_cast<int>(wrkGrpInfo.maxDynamicSharedSizeBytes_);
-      const int alignmentSize = device.isa().ldsAlignment();
+      const int alignmentSize = device.executionIsa().ldsAlignment();
       *pi = amd::alignDown(maxDynamicSharedSizeBytes, alignmentSize);
       break;
     }

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -44,9 +44,9 @@ hipError_t ihipOccupancyMaxActiveBlocksPerMultiprocessor(
   
   // Find wave occupancy per CU => simd_per_cu * GPR usage
   // Limited by SPI 32 per CU, hence 8 per SIMD
-  const size_t MaxWavesPerSimd = (device.isa().versionMajor() <= 9) ? 8 : 16;
+  const size_t MaxWavesPerSimd = (device.executionIsa().versionMajor() <= 9) ? 8 : 16;
   const size_t wavefrontSize = wrkGrpInfo->wavefrontSize_;
-  const bool adjust_for_wave64 = device.isa().versionMajor() >= 10 && wavefrontSize == 64;
+  const bool adjust_for_wave64 = device.executionIsa().versionMajor() >= 10 && wavefrontSize == 64;
   const uint32_t VgprGranularity = adjust_for_wave64
       ? device.info().vgprAllocGranularity_ >> 1
       : device.info().vgprAllocGranularity_;
@@ -72,8 +72,8 @@ hipError_t ihipOccupancyMaxActiveBlocksPerMultiprocessor(
   // on kernel metadata, multiply the number of SIMDs by 2, to account for
   // 2CUs in 1 WGP.
   const uint32_t simdPerCU = wrkGrpInfo->isWGPMode_
-      ? device.isa().simdPerCU() * 2
-      : device.isa().simdPerCU();
+      ? device.executionIsa().simdPerCU() * 2
+      : device.executionIsa().simdPerCU();
 
   const size_t alu_occupancy = simdPerCU * std::min(MaxWavesPerSimd, GprWaves);
   const int alu_limited_threads = static_cast<int>(alu_occupancy * wavefrontSize);
@@ -487,7 +487,7 @@ hipError_t hipOccupancyAvailableDynamicSMemPerBlock(size_t* dynamicSmemSize, con
       staticSharedMemoryUsage * std::min(numBlocks, maxNumBlocks);
   const int maxDynamicSmemSize = std::min(maxSharedMemoryPerMultiProcessor / maxNumBlocks,
                                           maxDynamicSharedSizeBytes);
-  const int alignmentSize = device.isa().ldsAlignment();
+  const int alignmentSize = device.executionIsa().ldsAlignment();
 
   const int dynamic_smem_size = std::max(maxDynamicSmemSize,
                                          std::min(maxSharedMemoryPerMultiProcessor / numBlocks,
@@ -723,7 +723,7 @@ hipError_t ihipLaunchKernel(const void* hostFunction, dim3 gridDim, dim3 blockDi
 
   constexpr auto gridDimYZmax = static_cast<uint64_t>(std::numeric_limits<uint16_t>::max()) + 1;
   const amd::Device* device = g_devices[deviceId]->devices()[0];
-  if (device->isa().versionMajor() >= 12 &&
+  if (device->executionIsa().versionMajor() >= 12 &&
       (gridDim.y > gridDimYZmax || gridDim.z > gridDimYZmax)) {
     return hipErrorInvalidConfiguration;
   }

--- a/projects/clr/rocclr/cmake/ROCclrHSA.cmake
+++ b/projects/clr/rocclr/cmake/ROCclrHSA.cmake
@@ -49,6 +49,28 @@ else()
         cmake/hsa-runtime64
         lib/cmake/hsa-runtime64
         lib64/cmake/hsa-runtime64)
+    if(DEFINED ROCR_RUNTIME_INCLUDE_DIR)
+      get_target_property(_HSA_RUNTIME_INCLUDE_DIRS hsa-runtime64::hsa-runtime64
+        INTERFACE_INCLUDE_DIRECTORIES)
+      get_filename_component(_ROCR_RUNTIME_INCLUDE_DIR_ABS
+        "${ROCR_RUNTIME_INCLUDE_DIR}" ABSOLUTE)
+      set(_ROCR_RUNTIME_INCLUDE_MATCH FALSE)
+      foreach(_HSA_RUNTIME_INCLUDE_DIR ${_HSA_RUNTIME_INCLUDE_DIRS})
+        get_filename_component(_HSA_RUNTIME_INCLUDE_DIR_ABS
+          "${_HSA_RUNTIME_INCLUDE_DIR}" ABSOLUTE)
+        if("${_ROCR_RUNTIME_INCLUDE_DIR_ABS}" STREQUAL "${_HSA_RUNTIME_INCLUDE_DIR_ABS}" OR
+           "${_ROCR_RUNTIME_INCLUDE_DIR_ABS}" STREQUAL "${_HSA_RUNTIME_INCLUDE_DIR_ABS}/hsa")
+          set(_ROCR_RUNTIME_INCLUDE_MATCH TRUE)
+        endif()
+      endforeach()
+      if(NOT _ROCR_RUNTIME_INCLUDE_MATCH)
+        message(FATAL_ERROR
+          "ROCR_RUNTIME_INCLUDE_DIR must come from the same hsa-runtime64 package "
+          "that ROCclr links")
+      endif()
+      target_include_directories(rocclr BEFORE PUBLIC ${ROCR_RUNTIME_INCLUDE_DIR})
+      target_include_directories(rocclr BEFORE PUBLIC ${ROCR_RUNTIME_INCLUDE_DIR}/..)
+    endif()
   else()
     find_package(hsa-runtime64 1.11 REQUIRED CONFIG
       PATHS

--- a/projects/clr/rocclr/cmake/ROCclrLC.cmake
+++ b/projects/clr/rocclr/cmake/ROCclrLC.cmake
@@ -2,22 +2,26 @@
 #
 # SPDX-License-Identifier: MIT
 
-find_package(amd_comgr 2.9 CONFIG
-  PATHS
-    ${ROCM_PATH}
-    ${ROCM_INSTALL_PATH}
-  PATH_SUFFIXES
-    cmake/amd_comgr
-    lib/cmake/amd_comgr)
-
-if (NOT amd_comgr_FOUND)
-  find_package(amd_comgr 3.0 REQUIRED CONFIG
+if(DEFINED amd_comgr_DIR)
+  find_package(amd_comgr REQUIRED CONFIG)
+else()
+  find_package(amd_comgr 2.9 CONFIG
     PATHS
       ${ROCM_PATH}
       ${ROCM_INSTALL_PATH}
     PATH_SUFFIXES
       cmake/amd_comgr
       lib/cmake/amd_comgr)
+
+  if (NOT amd_comgr_FOUND)
+    find_package(amd_comgr 3.0 REQUIRED CONFIG
+      PATHS
+        ${ROCM_PATH}
+        ${ROCM_INSTALL_PATH}
+      PATH_SUFFIXES
+        cmake/amd_comgr
+        lib/cmake/amd_comgr)
+  endif()
 endif()
 
 get_target_property(_amd_comgr_lib_type amd_comgr TYPE)

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -938,6 +938,8 @@ Device::Device()
       heap_buffer_(nullptr),
       initial_heap_buffer_(nullptr),
       arena_mem_obj_(nullptr),
+      isa_(nullptr),
+      executionIsa_(nullptr),
       vaCacheAccess_(nullptr),
       vaCacheMap_(nullptr),
       index_(0) {
@@ -1000,6 +1002,9 @@ size_t GetMaxStackSize(const std::string& procName) {
 bool Device::create(const Isa& isa) {
   assert(!vaCacheAccess_ && !vaCacheMap_);
   isa_ = &isa;
+  if (executionIsa_ == nullptr) {
+    executionIsa_ = &isa;
+  }
   // VA Cache Ops Lock
   vaCacheAccess_ = new std::recursive_mutex();
   if (nullptr == vaCacheAccess_) {
@@ -1013,7 +1018,7 @@ bool Device::create(const Isa& isa) {
   if (!amd::IS_HIP) {
     stack_size_ = 16 * Ki;
   }
-  maxStackSize_ = GetMaxStackSize(isa_->processorName());
+  maxStackSize_ = GetMaxStackSize(executionIsa_->processorName());
   return true;
 }
 

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -2288,6 +2288,14 @@ class Device : public RuntimeObject {
     return *isa_;
   }
 
+  //! Returns the ISA used for hardware-adjacent ROCr decisions.
+  const Isa& executionIsa() const {
+    assert(executionIsa_);
+    return *executionIsa_;
+  }
+
+  void setExecutionIsa(const Isa& isa) { executionIsa_ = &isa; }
+
   //! Return a non-zero uint64_t value that uniquely identifies the device.
   //! This can be used when a scalar value handle to the device is require.
   static uint64_t toHandle(const Device* device) {
@@ -2494,7 +2502,8 @@ class Device : public RuntimeObject {
   std::unordered_map<amd::CommandQueue*, bool> activeQueues;  //!< The set of active queues
   uint8_t group_mem_carveout_hint_{0}; //!< LDS carveout percentage (0 = no preference)
  private:
-  const Isa* isa_;  //!< Device isa
+  const Isa* isa_;           //!< Presented/code-selection device isa
+  const Isa* executionIsa_;  //!< Hardware-adjacent device isa
   bool IsTypeMatching(cl_device_type type, bool offlineDevices);
 
 #if defined(WITH_HSA_DEVICE)

--- a/projects/clr/rocclr/device/devprogram.cpp
+++ b/projects/clr/rocclr/device/devprogram.cpp
@@ -41,6 +41,15 @@ inline static std::vector<std::string> splitSpaceSeparatedString(const char* str
   return vec;
 }
 
+inline static bool shouldUseWavefrontSize64Option(const amd::Device& device) {
+  if (!device.settings().lcWavefrontSize64_) {
+    return false;
+  }
+  // In presentation mode the selected code object follows the presented ISA.
+  // Keep the existing wave64 option behavior everywhere else.
+  return !amd::hotswap::PresentationEnabled() || device.isa().versionMajor() < 10;
+}
+
 // ================================================================================================
 Program::Program(amd::Device& device, amd::Program& owner)
     : device_(device),
@@ -533,7 +542,7 @@ bool Program::compileImpl(const std::string& sourceCode,
     driverOptions.push_back("-mcumode");
   }
 
-  if (device().settings().lcWavefrontSize64_) {
+  if (shouldUseWavefrontSize64Option(device())) {
     driverOptions.push_back("-mwavefrontsize64");
   }
   driverOptions.push_back("-mcode-object-version=" +
@@ -800,7 +809,7 @@ bool Program::linkImpl(amd::option::Options* options) {
     if (options->oVariables->UnsafeMathOpt || options->oVariables->FastRelaxedMath) {
       linkOptions.push_back("unsafe_math");
     }
-    if (device().settings().lcWavefrontSize64_) {
+    if (shouldUseWavefrontSize64Option(device())) {
       linkOptions.push_back("wavefrontsize64");
     }
     linkOptions.push_back("code_object_v" +
@@ -866,7 +875,7 @@ bool Program::linkImpl(amd::option::Options* options) {
     codegenOptions.push_back("-mcumode");
   }
 
-  if (device().settings().lcWavefrontSize64_) {
+  if (shouldUseWavefrontSize64Option(device())) {
     codegenOptions.push_back("-mwavefrontsize64");
   }
   codegenOptions.push_back("-mcode-object-version=" +
@@ -1751,6 +1760,8 @@ ComgrBinaryData::~ComgrBinaryData() {
 }
 
 bool Program::createKernelMetadataMap(void* binary, size_t binSize) {
+  hotSwapSource_ = false;
+
   ComgrBinaryData binaryData;
   if (!binaryData.create(AMD_COMGR_DATA_KIND_EXECUTABLE, binary, binSize)) {
     buildLog_ += "Error: COMGR failed to create code object data object.\n";
@@ -1780,20 +1791,23 @@ bool Program::createKernelMetadataMap(void* binary, size_t binSize) {
       return false;
     }
 
-    if (!amd::Isa::isCompatible(*binaryIsa, device().isa())) {
-      // HotSwap: let a supported foreign source ISA past the gate; loader transpiles downstream.
-      const std::string binaryIsaNameStr(binaryIsaName.data());
-      const bool hotswap_ok =
-          amd::hotswap::Enabled() &&
-          amd::hotswap::IsSupportedPair(binaryIsa->processorName(),
-                                        device().isa().processorName());
-      if (!hotswap_ok) {
-        buildLog_ += "Error: The program ISA " + binaryIsaNameStr;
-        buildLog_ += " is not compatible with the device ISA " + device().isa().isaName() + "\n";
-        return false;
-      }
-      buildLog_ += "HotSwap: allowing foreign program ISA " + binaryIsaNameStr +
-                   " for transpilation to " + device().isa().isaName() + "\n";
+    const bool compatibleWithPresentedIsa =
+        binaryIsa != nullptr && amd::Isa::isCompatible(*binaryIsa, device().isa());
+    const bool compatibleWithExecutionIsa =
+        binaryIsa != nullptr && amd::Isa::isCompatible(*binaryIsa, device().executionIsa());
+    // In presentation mode the binary matches the presented ISA but not the physical
+    // execution ISA; admit it as a HotSwap source so the HSA loader can translate it.
+    // COMGR refuses translations it cannot perform, so no static pair allowlist is needed.
+    hotSwapSource_ = binaryIsa != nullptr && amd::hotswap::Enabled() &&
+                     compatibleWithPresentedIsa && !compatibleWithExecutionIsa;
+    if (!compatibleWithPresentedIsa && !hotSwapSource_) {
+      buildLog_ += "Error: The program ISA " + std::string(binaryIsaName.data());
+      buildLog_ += " is not compatible with the device ISA " + device().isa().isaName() + "\n";
+      return false;
+    } else if (hotSwapSource_) {
+      buildLog_ += "HotSwap: allowing source ISA " + std::string(binaryIsaName.data());
+      buildLog_ +=
+          " to reach HSA loader for execution ISA " + device().executionIsa().isaName() + "\n";
     }
   }
 

--- a/projects/clr/rocclr/device/devprogram.hpp
+++ b/projects/clr/rocclr/device/devprogram.hpp
@@ -107,6 +107,7 @@ class Program {
       uint32_t isHIP_ : 1;            //!< Determine if the program is for HIP
       uint32_t coLoaded_ : 1;         //!< Has the code objected been loaded
       uint32_t trapHandler_ : 1;      //!< It is a trap handler for debugger
+      uint32_t hotSwapSource_ : 1;    //!< HotSwap source object awaiting per-kernel translation
     };
     uint32_t flags_;  //!< Program flags
   };
@@ -226,6 +227,9 @@ class Program {
 
   //! Returns TRUE if the program is a trap handler for debugger support
   bool isTrapHandler() const { return trapHandler_; }
+
+  //! Returns TRUE if this is a HotSwap source object loaded for lazy translation
+  bool isHotSwapSource() const { return hotSwapSource_; }
 
   amd_comgr_metadata_node_t metadata() const { return metadata_; }
 

--- a/projects/clr/rocclr/device/hotswap.hpp
+++ b/projects/clr/rocclr/device/hotswap.hpp
@@ -28,36 +28,58 @@
 namespace amd {
 namespace hotswap {
 
-inline bool Enabled() {
-  const char* disable = std::getenv("HSA_HOTSWAP_DISABLE");
-  if (disable == nullptr || disable[0] == '\0') {
-    return true;
-  }
+// On when this tool is loaded via HSA_TOOLS_LIB (name must match ROCR LoadTools).
+inline constexpr const char* kHotswapToolLib = "libamd_comgr_hotswap_tool.so";
 
-  std::string value(disable);
-  std::transform(value.begin(), value.end(), value.begin(),
+inline bool EnvEnabled(const char* name) {
+  const char* value = std::getenv(name);
+  if (!value || !value[0]) return false;
+  std::string normalized(value);
+  std::transform(normalized.begin(), normalized.end(), normalized.begin(),
                  [](unsigned char c) { return std::tolower(c); });
-  return value == "0" || value == "off" || value == "false" ||
-         value == "no" || value == "n" || value == "f";
+  return normalized != "0" && normalized != "off" && normalized != "false" &&
+         normalized != "no" && normalized != "n" && normalized != "f";
 }
 
-// Allowlist of (source -> device) gfx pairs native HotSwap handles; only these
-// are forwarded. gfx1250 -> gfx1250 selects the B0 gfx1250 bundle; ROCR leaves
-// it on the normal loader path for B0-on-B0 and rewrites it only for B0-to-A0.
-struct SourceTargetPair {
-  const char* source;  // gfx processor, e.g. "gfx1250"
-  const char* target;  // gfx processor, e.g. "gfx950"
+inline bool Disabled() { return EnvEnabled("HSA_HOTSWAP_DISABLE"); }
+
+inline const char* PresentedIsaEnv() { return std::getenv("HSA_HOTSWAP_PRESENT_ISA"); }
+
+inline const char* TargetIsaEnv() {
+  const char* target = std::getenv("HSA_HOTSWAP_TARGET");
+  if (!target || !target[0]) target = std::getenv("HSA_HOTSWAP_ISA_OVERRIDE");
+  return target;
+}
+
+inline bool PresentationEnabled() {
+  return EnvEnabled("HSA_HOTSWAP_PRESENT_ISA") && !Disabled();
+}
+
+inline bool ToolLoaded() {
+  const char* tools_lib = std::getenv("HSA_TOOLS_LIB");
+  return tools_lib != nullptr &&
+         std::string(tools_lib).find(kHotswapToolLib) != std::string::npos;
+}
+
+inline bool Enabled() { return PresentationEnabled() || (!Disabled() && ToolLoaded()); }
+
+// Allowlist for forwarding source-ISA fatbin bundles to a CLR-visible device ISA.
+// In presentation mode the visible ISA is the presented source ISA; the physical
+// execution ISA is resolved later by ROCr from HSA_HOTSWAP_TARGET.
+struct SourcePresentedPair {
+  const char* source;     // bundle gfx processor, e.g. "gfx1250"
+  const char* presented;  // CLR-visible gfx processor, e.g. "gfx1250"
 };
 
-inline constexpr SourceTargetPair kSupportedPairs[] = {
+inline constexpr SourcePresentedPair kSourceForwardingPairs[] = {
     {"gfx1250", "gfx1250"},
 };
 
-// True if (source_gfx -> target_gfx) is a supported pair.
-inline bool IsSupportedPair(const std::string& source_gfx,
-                            const std::string& target_gfx) {
-  for (const SourceTargetPair& p : kSupportedPairs) {
-    if (source_gfx == p.source && target_gfx == p.target) {
+// True if `source_gfx` may be forwarded for a device presented as `presented_gfx`.
+inline bool IsSourceForwardingPair(const std::string& source_gfx,
+                                   const std::string& presented_gfx) {
+  for (const SourcePresentedPair& p : kSourceForwardingPairs) {
+    if (source_gfx == p.source && presented_gfx == p.presented) {
       return true;
     }
   }

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -1390,7 +1390,7 @@ bool KernelBlitManager::copyBufferToImageKernel(
   amd::Image* srcImage = static_cast<amd::Image*>(srcMemory.owner());
   amd::Image::Format newFormat(dstImage->getImageFormat());
   bool swapLayer =
-      (dstImage->getType() == CL_MEM_OBJECT_IMAGE1D_ARRAY) && (dev().isa().versionMajor() >= 10);
+      (dstImage->getType() == CL_MEM_OBJECT_IMAGE1D_ARRAY) && (dev().executionIsa().versionMajor() >= 10);
 
   // Find unsupported formats
   for (uint i = 0; i < RejectedFormatDataTotal; ++i) {
@@ -1577,7 +1577,7 @@ bool KernelBlitManager::copyImageToBufferKernel(
   amd::Image* srcImage = static_cast<amd::Image*>(srcMemory.owner());
   amd::Image::Format newFormat(srcImage->getImageFormat());
   bool swapLayer =
-      (srcImage->getType() == CL_MEM_OBJECT_IMAGE1D_ARRAY) && (dev().isa().versionMajor() >= 10);
+      (srcImage->getType() == CL_MEM_OBJECT_IMAGE1D_ARRAY) && (dev().executionIsa().versionMajor() >= 10);
 
   // Find unsupported formats
   for (uint i = 0; i < RejectedFormatDataTotal; ++i) {
@@ -1839,14 +1839,14 @@ bool KernelBlitManager::copyImage(device::Memory& srcMemory, device::Memory& dst
 
   // Program source origin
   int32_t srcOrg[4] = {(int32_t)srcOrigin[0], (int32_t)srcOrigin[1], (int32_t)srcOrigin[2], 0};
-  if ((srcImage->getType() == CL_MEM_OBJECT_IMAGE1D_ARRAY) && (dev().isa().versionMajor() >= 10)) {
+  if ((srcImage->getType() == CL_MEM_OBJECT_IMAGE1D_ARRAY) && (dev().executionIsa().versionMajor() >= 10)) {
     srcOrg[3] = 1;
   }
   setArgument(kernels_[blitType], 2, sizeof(srcOrg), srcOrg);
 
   // Program destinaiton origin
   int32_t dstOrg[4] = {(int32_t)dstOrigin[0], (int32_t)dstOrigin[1], (int32_t)dstOrigin[2], 0};
-  if ((dstImage->getType() == CL_MEM_OBJECT_IMAGE1D_ARRAY) && (dev().isa().versionMajor() >= 10)) {
+  if ((dstImage->getType() == CL_MEM_OBJECT_IMAGE1D_ARRAY) && (dev().executionIsa().versionMajor() >= 10)) {
     dstOrg[3] = 1;
   }
   setArgument(kernels_[blitType], 3, sizeof(dstOrg), dstOrg);
@@ -3332,7 +3332,7 @@ bool KernelBlitManager::fillImage(device::Memory& memory, const void* pattern,
   amd::Image* image = static_cast<amd::Image*>(memory.owner());
   amd::Image::Format newFormat(image->getImageFormat());
   bool swapLayer =
-      (image->getType() == CL_MEM_OBJECT_IMAGE1D_ARRAY) && (dev().isa().versionMajor() >= 10);
+      (image->getType() == CL_MEM_OBJECT_IMAGE1D_ARRAY) && (dev().executionIsa().versionMajor() >= 10);
 
   // Program the kernels workload depending on the fill dimensions
   fillType = FillImage;

--- a/projects/clr/rocclr/device/rocm/roccounters.cpp
+++ b/projects/clr/rocclr/device/rocm/roccounters.cpp
@@ -418,7 +418,7 @@ PerfCounter::PerfCounter(
   info_.eventIndex_ = eventIndex;      // Counter Event Selection (counter_id)
 
   // these block indices are valid for the SI (Gfx8) & Gfx9 devices
-  switch (roc_device_.isa().versionMajor()) {
+  switch (roc_device_.executionIsa().versionMajor()) {
     case (9):
       gfxVersion_ = ROC_GFX9;
       if (blockIndex < gfx9BlockIdOrcaToRocrSize) {

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -17,6 +17,7 @@
 
 #include "vdi_common.hpp"
 #include "device/comgrctx.hpp"
+#include "device/hotswap.hpp"
 #include "device/devhostcall.hpp"
 #include "device/rocm/rocdevice.hpp"
 #include "device/rocm/rocblit.hpp"
@@ -49,6 +50,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cinttypes>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -84,6 +86,62 @@ std::vector<hsa_agent_t> roc::Device::gpu_agents_;
 std::vector<AgentInfo> roc::Device::cpu_agents_;
 
 address Device::mg_sync_ = nullptr;
+
+namespace {
+
+std::string canonicalIsaName(const char* isa) {
+  std::string isaName(isa ? isa : "");
+  if (!isaName.empty() && isaName.rfind("amdgcn-amd-amdhsa--", 0) != 0) {
+    isaName = "amdgcn-amd-amdhsa--" + isaName;
+  }
+  return isaName;
+}
+
+std::string processorNameFromHotSwapEnv(const char* value) {
+  std::string isaName = canonicalIsaName(value);
+  const amd::Isa* isa = amd::Isa::findIsa(isaName.c_str());
+  return isa ? isa->processorName() : std::string();
+}
+
+const amd::Isa* settingsIsaForHotSwap(const amd::Isa& presentedIsa) {
+  const char* presented = amd::hotswap::PresentedIsaEnv();
+  if (!amd::hotswap::PresentationEnabled()) return &presentedIsa;
+
+  const std::string presentedProcessor = processorNameFromHotSwapEnv(presented);
+  if (presentedProcessor.empty() || presentedProcessor != presentedIsa.processorName()) {
+    LogPrintfError("HSA_HOTSWAP_PRESENT_ISA (%s) must match the presented device ISA %s",
+                   presented, presentedIsa.isaName().c_str());
+    return nullptr;
+  }
+
+  const char* target = amd::hotswap::TargetIsaEnv();
+  if (!target || !target[0] || std::strcmp(target, "0") == 0 ||
+      std::strcmp(target, "1") == 0) {
+    LogError("HSA_HOTSWAP_TARGET must name the execution ISA when HSA_HOTSWAP_PRESENT_ISA is set");
+    return nullptr;
+  }
+
+  std::string isaName = canonicalIsaName(target);
+  const std::string targetProcessor = processorNameFromHotSwapEnv(target);
+  if (targetProcessor.empty()) {
+    LogPrintfError("HSA_HOTSWAP_TARGET does not resolve to a known ISA: %s", isaName.c_str());
+    return nullptr;
+  }
+  if (targetProcessor == presentedProcessor) {
+    LogError("HSA_HOTSWAP_TARGET must differ from HSA_HOTSWAP_PRESENT_ISA");
+    return nullptr;
+  }
+  const amd::Isa* targetIsa = amd::Isa::findIsa(isaName.c_str());
+  if (!targetIsa) {
+    LogPrintfError("HSA_HOTSWAP_TARGET does not resolve to a known ISA: %s", isaName.c_str());
+    return nullptr;
+  }
+  // Any distinct, resolvable execution ISA is accepted here; the COMGR HotSwap
+  // path refuses translations it cannot perform at load/dispatch time.
+  return targetIsa;
+}
+
+}  // namespace
 
 bool NullDevice::create(const amd::Isa& isa) {
   if (!isa.runtimeRocSupported()) {
@@ -643,9 +701,11 @@ bool Device::create() {
   assert(!settings_);
   roc::Settings* hsaSettings = new roc::Settings();
   settings_ = hsaSettings;
-  if (!hsaSettings || !hsaSettings->create((agent_profile_ == HSA_PROFILE_FULL), *isa,
-                                           isa->xnack() == amd::Isa::Feature::Enabled, coop_groups,
-                                           isXgmi_)) {
+  const amd::Isa* settingsIsa = settingsIsaForHotSwap(*isa);
+  if (!settingsIsa) return false;
+  if (!hsaSettings || !hsaSettings->create((agent_profile_ == HSA_PROFILE_FULL), *settingsIsa,
+                                           settingsIsa->xnack() == amd::Isa::Feature::Enabled,
+                                           coop_groups, isXgmi_)) {
     LogPrintfError("Unable to create settings for HSA device %s (PCI ID %x)", agent_name,
                    pciDeviceId_);
     return false;
@@ -657,6 +717,7 @@ bool Device::create() {
     return false;
   }
 
+  setExecutionIsa(*settingsIsa);
   if (!amd::Device::create(*isa)) {
     LogPrintfError("Unable to setup device for HSA device %s (PCI ID %x)", agent_name,
                    pciDeviceId_);
@@ -1098,8 +1159,8 @@ bool Device::populateOCLDeviceConstants() {
   }
 
   if (info_.globalMemCacheLineSize_ < 256 &&
-      (isa().versionMajor() >= 13 ||
-       (isa().versionMajor() == 12 && isa().versionMinor() >= 5))) {
+      (executionIsa().versionMajor() >= 13 ||
+       (executionIsa().versionMajor() == 12 && executionIsa().versionMinor() >= 5))) {
     info_.globalMemCacheLineSize_ = 256;
   }
 
@@ -1566,15 +1627,15 @@ bool Device::populateOCLDeviceConstants() {
       info_.svmCapabilities_ |= CL_DEVICE_SVM_FINE_GRAIN_SYSTEM;
     }
     if (amd::IS_HIP) {
-      if (info_.iommuv2_ || isa().versionMajor() >= 8) {
+      if (info_.iommuv2_ || executionIsa().versionMajor() >= 8) {
         info_.svmCapabilities_ |= CL_DEVICE_SVM_ATOMICS;
       }
     }
   }
 
   if (settings().checkExtension(ClAmdDeviceAttributeQuery)) {
-    info_.simdWidth_ = isa().simdWidth();
-    info_.simdInstructionWidth_ = isa().simdInstructionWidth();
+    info_.simdWidth_ = executionIsa().simdWidth();
+    info_.simdInstructionWidth_ = executionIsa().simdInstructionWidth();
     if (HSA_STATUS_SUCCESS !=
         Hsa::agent_get_info(bkendDevice_, HSA_AGENT_INFO_WAVEFRONT_SIZE, &info_.wavefrontWidth_)) {
       return false;
@@ -1637,9 +1698,9 @@ bool Device::populateOCLDeviceConstants() {
     info_.l2CacheSize_ = cache_sizes[1];
     info_.timeStampFrequency_ = 1000000;
     info_.globalMemChannelBanks_ = 4;
-    info_.globalMemChannelBankWidth_ = isa().memChannelBankWidth();
-    info_.localMemSizePerCU_ = isa().localMemSizePerCU();
-    info_.localMemBanks_ = isa().localMemBanks();
+    info_.globalMemChannelBankWidth_ = executionIsa().memChannelBankWidth();
+    info_.localMemSizePerCU_ = executionIsa().localMemSizePerCU();
+    info_.localMemBanks_ = executionIsa().localMemBanks();
     info_.numAsyncQueues_ = kMaxAsyncQueues;
     info_.numRTQueues_ = info_.numAsyncQueues_;
     info_.numRTCUs_ = info_.maxComputeUnits_;
@@ -1666,7 +1727,7 @@ bool Device::populateOCLDeviceConstants() {
   info_.maxOnDeviceEvents_ = settings().numDeviceEvents_;
 
   std::string addressableNumVGPRs, totalNumVGPRs, vGPRAllocGranule;
-  std::string isaName = isa().isaName();
+  std::string isaName = executionIsa().isaName();
   info_.availableVGPRs_ =
       amd::device::getValueFromIsaMeta(isaName, "AddressableNumVGPRs", addressableNumVGPRs)
       ? atoi(addressableNumVGPRs.c_str())
@@ -1790,9 +1851,9 @@ bool Device::populateOCLDeviceConstants() {
   info_.gpuDirectRdmaWithHipVmmSupported_ =
       info_.virtualMemoryManagement_ && info_.dmabufSupported_;
 
-  if (isa().versionMajor() < 8) {
+  if (executionIsa().versionMajor() < 8) {
     info_.sgprsPerSimd_ = 512;
-  } else if (isa().versionMajor() < 10) {
+  } else if (executionIsa().versionMajor() < 10) {
     info_.sgprsPerSimd_ = 800;
   } else {
     info_.sgprsPerSimd_ =
@@ -2452,7 +2513,7 @@ void* Device::deviceLocalAlloc(size_t size, const AllocationFlags& flags, bool a
   if (flags.executable_) {
     hsa_mem_flags |= HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG;
   }
-  if (flags.uncached_ && isa().versionMajor() == 12) {
+  if (flags.uncached_ && executionIsa().versionMajor() == 12) {
     hsa_mem_flags |= HSA_AMD_MEMORY_POOL_UNCACHED_FLAG;
   }
 

--- a/projects/clr/rocclr/device/rocm/rockernel.cpp
+++ b/projects/clr/rocclr/device/rocm/rockernel.cpp
@@ -70,10 +70,36 @@ bool Kernel::postLoad() {
     return false;
   }
 
+  uint32_t hsaPrivateSegmentSize = 0;
+  hsaStatus = Hsa::executable_symbol_get_info(
+      symbol, HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_PRIVATE_SEGMENT_SIZE, &hsaPrivateSegmentSize);
+  if (hsaStatus != HSA_STATUS_SUCCESS) {
+    ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN,
+             " Cannot Get Private Segment Size for %s, failed with hsa_status: %d \n ",
+             symbolName().c_str(), hsaStatus);
+    return false;
+  }
+
+  uint32_t hsaGroupSegmentSize = 0;
+  hsaStatus = Hsa::executable_symbol_get_info(
+      symbol, HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_GROUP_SEGMENT_SIZE, &hsaGroupSegmentSize);
+  if (hsaStatus != HSA_STATUS_SUCCESS) {
+    ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN,
+             " Cannot Get Group Segment Size for %s, failed with hsa_status: %d \n ",
+             symbolName().c_str(), hsaStatus);
+    return false;
+  }
+  const bool hotSwapSource = program()->isHotSwapSource();
+  if (hsaGroupSegmentSize > workGroupInfo_.availableLDSSize_ && !hotSwapSource) {
+    ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN,
+             " Group Segment Size %u exceeds available LDS size %zu for %s \n ",
+             hsaGroupSegmentSize, workGroupInfo_.availableLDSSize_, symbolName().c_str());
+    return false;
+  }
   if (!RuntimeHandle().empty()) {
     hsa_executable_symbol_t kernelSymbol;
-    int variable_size;
-    uint64_t variable_address;
+    uint32_t variable_size = 0;
+    uint64_t variable_address = 0;
 
     // Only kernels that could be enqueued by another kernel has the RuntimeHandle metadata. The
     // RuntimeHandle metadata is a string that represents a variable from which the library code can
@@ -96,6 +122,12 @@ bool Kernel::postLoad() {
           "[ROC][Kernel] Cannot get Kernel Symbol Info, failed with hsa_status: %d \n", hsaStatus);
       return false;
     }
+    if (variable_size != sizeof(struct RuntimeHandle)) {
+      ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN,
+              "[ROC][Kernel] Runtime handle symbol %s has unexpected size %u, expected %zu \n",
+              RuntimeHandle().c_str(), variable_size, sizeof(struct RuntimeHandle));
+      return false;
+    }
 
     hsaStatus = Hsa::executable_symbol_get_info(
         kernelSymbol, HSA_EXECUTABLE_SYMBOL_INFO_VARIABLE_ADDRESS, &variable_address);
@@ -107,9 +139,9 @@ bool Kernel::postLoad() {
     }
 
     const struct RuntimeHandle runtime_handle = {
-        kernelCodeHandle_, WorkitemPrivateSegmentByteSize(), WorkgroupGroupSegmentByteSize()};
-    hsaStatus =
-        Hsa::memory_copy(reinterpret_cast<void*>(variable_address), &runtime_handle, variable_size);
+        kernelCodeHandle_, hsaPrivateSegmentSize, hsaGroupSegmentSize};
+    hsaStatus = Hsa::memory_copy(reinterpret_cast<void*>(variable_address), &runtime_handle,
+                                 sizeof(runtime_handle));
 
     if (hsaStatus != HSA_STATUS_SUCCESS) {
       ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN,
@@ -118,6 +150,9 @@ bool Kernel::postLoad() {
       return false;
     }
   }
+
+  SetWorkitemPrivateSegmentByteSize(hsaPrivateSegmentSize);
+  SetWorkgroupGroupSegmentByteSize(hsaGroupSegmentSize);
 
   // This can be set in code object and the value might be different than what HSA reports
   // For example on Navi GPUs someone using -mwavefrontsize64
@@ -135,16 +170,22 @@ bool Kernel::postLoad() {
 
   workGroupInfo_.availableVGPRs_ = device().info().availableVGPRs_;
   workGroupInfo_.availableSGPRs_ = device().info().availableSGPRs_;
-  workGroupInfo_.privateMemSize_ = workitemPrivateSegmentByteSize_;
-  workGroupInfo_.localMemSize_ = workgroupGroupSegmentByteSize_;
-  workGroupInfo_.usedLDSSize_ = workgroupGroupSegmentByteSize_;
+  workGroupInfo_.privateMemSize_ = hsaPrivateSegmentSize;
+  // Keep the source packet's fixed LDS size intact for ROCr's lazy
+  // source-to-target delta calculation, but do not let pre-translation
+  // metadata inflate CLR's dynamic LDS capacity.
+  const uint64_t accountedGroupSegmentSize =
+      hotSwapSource ? std::min<uint64_t>(hsaGroupSegmentSize, workGroupInfo_.availableLDSSize_)
+                    : hsaGroupSegmentSize;
+  workGroupInfo_.localMemSize_ = accountedGroupSegmentSize;
+  workGroupInfo_.usedLDSSize_ = accountedGroupSegmentSize;
   workGroupInfo_.preferredSizeMultiple_ = wavefront_size;
   workGroupInfo_.usedStackSize_ = kernelHasDynamicCallStack_;
   workGroupInfo_.wavefrontPerSIMD_ =
       program()->rocDevice().info().maxWorkItemSizes_[0] / wavefront_size;
   workGroupInfo_.constMemSize_ = 0;
   workGroupInfo_.maxDynamicSharedSizeBytes_ =
-      static_cast<int>(workGroupInfo_.availableLDSSize_ - workGroupInfo_.localMemSize_);
+      workGroupInfo_.availableLDSSize_ - accountedGroupSegmentSize;
   if (workGroupInfo_.size_ == 0) {
     return false;
   }

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -1440,7 +1440,7 @@ bool Image::createInteropImage() {
 
   // Set cubemap face if GL cubemap
   if (glObj && glObj->getGLTarget() == GL_TEXTURE_CUBE_MAP) {
-    desc.setFace(glObj->getCubemapFace(), dev().isa().versionMajor());
+    desc.setFace(glObj->getCubemapFace(), dev().executionIsa().versionMajor());
   }
 
   hsa_status_t err =

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -9,20 +9,22 @@
 #include <mutex>
 #include "top.hpp"
 
-#if defined(ROCR_DYN_DLL) || defined(ROCR_STATIC_OPEN)
+#if __has_include("hsa.h")
 #include "hsa.h"
 #include "hsa_ext_image.h"
 #include "hsa_ext_amd.h"
 #include "amd_hsa_signal.h"
 #include "hsa_ven_amd_loader.h"
 #include "hsa_ven_amd_aqlprofile.h"
-#else
+#elif __has_include("hsa/hsa.h")
 #include "hsa/hsa.h"
 #include "hsa/hsa_ext_image.h"
 #include "hsa/hsa_ext_amd.h"
 #include "hsa/amd_hsa_signal.h"
 #include "hsa/hsa_ven_amd_loader.h"
 #include "hsa/hsa_ven_amd_aqlprofile.h"
+#else
+#error "ROCr HSA headers were not found"
 #endif
 
 typedef hsa_status_t HSA_API hsa_amd_queue_create_fn(

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -2237,7 +2237,7 @@ VirtualGPU::VirtualGPU(Device& device, bool profiling, bool cooperative,
                                             << HSA_PACKET_HEADER_TYPE);
 
   if (device.settings().fenceScopeAgent_) {
-    const auto& isa = device.isa();
+    const auto& isa = device.executionIsa();
     const bool isGfx12 = (isa.versionMajor() == 12) && (isa.versionMinor() == 0) &&
                          (isa.versionStepping() == 0 || isa.versionStepping() == 1);
 
@@ -2347,7 +2347,7 @@ bool VirtualGPU::create() {
                                        dedicated_queue_));
   if (!gpu_queue_) return false;
 
-  if (dev().isa().versionMajor() == 12 && dev().isa().versionMinor() >= 5) {
+  if (dev().executionIsa().versionMajor() == 12 && dev().executionIsa().versionMinor() >= 5) {
     metadata_preloader_.SetLaunchDescriptorVersion(AMD_LAUNCH_DESCRIPTOR_VERSION_GFX1250);
   }
 
@@ -4740,6 +4740,12 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
                                             gpuKernel.KernargSegmentAlignment(), dev().index());
       command_->SetKernelName(gpuKernel.getDemangledName());
     } else {
+      ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN,
+              "Kernel name = %s, argSize = %zu, "
+              "KernargSegmentByteSize = %lu "
+              "KernargSegmentAlignment = %lu",
+              gpuKernel.getDemangledName().c_str(), argSize,
+              gpuKernel.KernargSegmentByteSize(), gpuKernel.KernargSegmentAlignment());
       argBuffer = reinterpret_cast<address>(
           allocKernArg(gpuKernel.KernargSegmentByteSize(), gpuKernel.KernargSegmentAlignment()));
     }
@@ -4831,7 +4837,7 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
       auto& dispatchPacketExt = dispatchPacketUnion.extKernelDispatch;
       // Encodings [1, 127] represent a range from 0% (no group memory) to 100% (maximum
       // group memory)
-      if (dev().isa().versionMajor() == 12 && dev().isa().versionMinor() == 5) {
+      if (dev().executionIsa().versionMajor() == 12 && dev().executionIsa().versionMinor() == 5) {
         dispatchPacketExt.perf_hint.group_mem_carveout = 127;
       } else {
         dispatchPacketExt.perf_hint.group_mem_carveout = (percent + 1) * 1.26F;

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -16,7 +16,15 @@
 #include "rocsched.hpp"
 #include "device/device.hpp"
 #include "os/os.hpp"
+
+#if __has_include("hsa_ext_amd.h")
 #include "hsa_ext_amd.h"
+#elif __has_include("hsa/hsa_ext_amd.h")
+#include "hsa/hsa_ext_amd.h"
+#else
+#error "ROCr HSA extension header was not found"
+#endif
+
 #include <atomic>
 #include <condition_variable>
 #include <mutex>

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -16,6 +16,7 @@
 #include "rocsched.hpp"
 #include "device/device.hpp"
 #include "os/os.hpp"
+#include "hsa_ext_amd.h"
 #include <atomic>
 #include <condition_variable>
 #include <mutex>

--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -247,7 +247,7 @@ bool Event::awaitCompletion() {
     ClPrint(LOG_DETAIL_DEBUG, LOG_WAIT, "Waiting for event %p to complete, current status %d",
             this, status());
     auto* queue = command().queue();
-    if ((queue != nullptr) && queue->vdev()->ActiveWait()) {
+    if ((queue != nullptr) && queue->vdev() != nullptr && queue->vdev()->ActiveWait()) {
       while (status() > CL_COMPLETE) {
         amd::Os::yield();
       }
@@ -372,6 +372,11 @@ void Command::enqueue() {
   // update will occur later after flush() with a wait
   if (AMD_DIRECT_DISPATCH) {
     setStatus(CL_QUEUED);
+    if (queue_->vdev() == nullptr) {
+      LogError("Command enqueue failed: command queue has no virtual device");
+      setStatus(CL_INVALID_OPERATION);
+      return;
+    }
 
     // Notify all commands about the waiter. Barrier will be sent in order to obtain
     // HSA signal for a wait on the current queue

--- a/projects/clr/rocclr/platform/commandqueue.cpp
+++ b/projects/clr/rocclr/platform/commandqueue.cpp
@@ -160,6 +160,9 @@ void HostQueue::finish(bool cpu_wait) {
   Command* command = nullptr;
   size_t minBatchSize = 0;
 
+  auto* virtualDevice = vdev();
+  guarantee(virtualDevice != nullptr, "HostQueue has no virtual device");
+
   if (IS_HIP) {
     minBatchSize = DEBUG_CLR_BATCH_CPU_SYNC_SIZE;
 
@@ -176,7 +179,7 @@ void HostQueue::finish(bool cpu_wait) {
 
     // Force blocking wait if requested. That allows to avoid a build up of unreleased CPU commands
     if ((DEBUG_HIP_BLOCK_SYNC > 0) &&
-        (vdev()->QueuedAsyncHandlers().load() > DEBUG_HIP_BLOCK_SYNC)) {
+        (virtualDevice->QueuedAsyncHandlers().load() > DEBUG_HIP_BLOCK_SYNC)) {
       cpu_wait = true;
     }
   } else {
@@ -188,10 +191,10 @@ void HostQueue::finish(bool cpu_wait) {
   ClPrint(LOG_DETAIL_DEBUG, LOG_CMD,
           "finish() called with batch size: %zu, cpu_wait: %d, "
           "fence dirty: %d",
-          batchSize, cpu_wait, vdev()->isFenceDirty());
+          batchSize, cpu_wait, virtualDevice->isFenceDirty());
 
   // Force marker if the batch wasn't sent for CPU update or fence is dirty
-  if (nullptr == command || (batchSize != 0)|| vdev()->isFenceDirty()) {
+  if (nullptr == command || (batchSize != 0)|| virtualDevice->isFenceDirty()) {
     if (nullptr != command) {
       command->release();
     }
@@ -356,9 +359,11 @@ bool HostQueue::isEmpty() {
 
 Command* HostQueue::getLastQueuedCommand(bool retain) {
   if (AMD_DIRECT_DISPATCH) {
+    auto* virtualDevice = vdev();
+    guarantee(virtualDevice != nullptr, "HostQueue has no virtual device");
     // The batch update must be lock protected to avoid a race condition
     // when multiple threads submit/flush/update the batch at the same time
-    std::scoped_lock sl(vdev()->execution());
+    std::scoped_lock sl(virtualDevice->execution());
     // Since the lastCmdLock_ is acquired, it is safe to read and retain the lastEnqueueCommand.
     // It is guaranteed that the pointer will not change.
     if (retain && lastEnqueueCommand_ != nullptr) {

--- a/projects/clr/rocclr/platform/commandqueue.hpp
+++ b/projects/clr/rocclr/platform/commandqueue.hpp
@@ -249,7 +249,9 @@ class HostQueue : public CommandQueue {
 
   //! Get the current batch size
   size_t GetSubmissionBatchSize() const {
-    std::scoped_lock sl(vdev()->execution());
+    auto* virtualDevice = vdev();
+    guarantee(virtualDevice != nullptr, "HostQueue has no virtual device");
+    std::scoped_lock sl(virtualDevice->execution());
     return size_;
   }
 
@@ -301,7 +303,11 @@ class HostQueue : public CommandQueue {
   //! Set the force destory to terminate queue without checking last command
   void SetForceDestroy(bool forceDestroy) { forceDestroy_ = forceDestroy; }
 
-  uint64_t getQueueID() { return thread_.vdev()->getQueueID(); }
+  uint64_t getQueueID() {
+    auto* virtualDevice = thread_.vdev();
+    guarantee(virtualDevice != nullptr, "HostQueue has no virtual device");
+    return virtualDevice->getQueueID();
+  }
 
   //! Returns Synchronization Policy for the current stream
   amd::SyncPolicy GetSyncPolicy() const { return sync_policy_; }

--- a/projects/rocr-runtime/runtime/docs/data/env_variables.rst
+++ b/projects/rocr-runtime/runtime/docs/data/env_variables.rst
@@ -99,6 +99,19 @@
       - | 0, ``false``, ``off``, ``no``, ``n``, or ``f``: Allow HotSwap on supported GPU and ASIC revisions.
         | Any other non-empty value: Disable HotSwap and use the original code object load path.
 
+    * - | ``HSA_HOTSWAP_PRESENT_ISA``
+        | Presents a source ISA to applications while HotSwap translates code objects to the physical execution ISA. Requires a runtime built with the HotSwap COMGR adapter and an explicit execution target.
+        | Presentation mode currently requires a homogeneous GPU system. Runtime initialization fails if any GPU agent constructed by ROCr does not match the configured target.
+      - None
+      - A supported source ISA or target ID, for example ``gfx1250``.
+
+    * - | ``HSA_HOTSWAP_TARGET``
+        | Declares the expected physical execution ISA for presentation mode. ROCr validates this canonical target ID against every GPU agent it constructs; translation uses the agent's physical execution ISA.
+        | The processor and any explicitly specified XNACK or SRAMECC features must match the physical agent. Omitted features accept either setting.
+        | For compatibility, ``HSA_HOTSWAP_ISA_OVERRIDE`` is used only when ``HSA_HOTSWAP_TARGET`` is unset.
+      - None
+      - A supported canonical target ID, for example ``gfx942``.
+
     * - | ``HSA_HOTSWAP_VERBOSE``
         | Enables HotSwap diagnostic logging to stderr.
       - ``0``

--- a/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
+++ b/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
@@ -263,6 +263,37 @@ set ( SRCS core/driver/driver.cpp
            libamdhsacode/amd_options.cpp
            libamdhsacode/amd_hsa_code.cpp)
 
+## Optional: HotSwap lazy per-kernel ISA translation through COMGR.
+option(ROCR_ENABLE_HOTSWAP_COMGR_ADAPTER
+  "Enable ROCr loader integration with COMGR HotSwap transpilation" OFF)
+if(ROCR_ENABLE_HOTSWAP_COMGR_ADAPTER)
+  find_package(amd_comgr REQUIRED CONFIG)
+  target_link_libraries(${CORE_RUNTIME_TARGET} PRIVATE amd_comgr)
+  target_compile_definitions(${CORE_RUNTIME_TARGET} PRIVATE
+    ROCR_HOTSWAP_COMGR_ADAPTER=1)
+endif()
+
+option(ROCR_BUILD_HOTSWAP_UNIT_TESTS
+  "Build ROCr HotSwap runtime unit tests"
+  ${ROCR_ENABLE_HOTSWAP_COMGR_ADAPTER})
+if(ROCR_BUILD_HOTSWAP_UNIT_TESTS)
+  add_executable(hotswap-runtime-unit-tests
+    tests/hotswap_runtime_test.cpp)
+  target_include_directories(hotswap-runtime-unit-tests PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../libhsakmt/include)
+  target_compile_definitions(hotswap-runtime-unit-tests PRIVATE
+    "${HSA_COMMON_DEFS}" __linux__ HSA_DEPRECATED=
+    ROCR_HOTSWAP_COMGR_ADAPTER=1)
+  target_compile_options(hotswap-runtime-unit-tests PRIVATE ${HSA_CXX_FLAGS})
+  if(UNIX)
+    target_link_libraries(hotswap-runtime-unit-tests PRIVATE pthread rt)
+  endif()
+  enable_testing()
+  add_test(NAME hotswap-runtime-unit-tests
+           COMMAND hotswap-runtime-unit-tests)
+endif()
+
 if(UNIX)
   set(SRC_OS core/util/lnx/os_linux.cpp
 	     libamdhsacode/lnx/amd_core_dump.cpp)

--- a/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
+++ b/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
@@ -278,6 +278,7 @@ option(ROCR_BUILD_HOTSWAP_UNIT_TESTS
   ${ROCR_ENABLE_HOTSWAP_COMGR_ADAPTER})
 if(ROCR_BUILD_HOTSWAP_UNIT_TESTS)
   add_executable(hotswap-runtime-unit-tests
+    core/runtime/isa.cpp
     tests/hotswap_runtime_test.cpp)
   target_include_directories(hotswap-runtime-unit-tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/agent.h
@@ -347,6 +347,10 @@ class Agent : public Checked<0xF6BC25EB17E6F917> {
   // and AIE agents, this list will be empty.
   virtual const std::vector<const core::Isa *>& supported_isas() const = 0;
 
+  virtual const std::vector<const core::Isa *>& execution_isas() const {
+    return supported_isas();
+  }
+
   virtual uint64_t HiveId() const { return 0; }
 
   // @brief Returns the device type (CPU/GPU/Others).

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -371,12 +371,19 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   // CU mask lock
   std::mutex mask_lock_;
 
+  // Serializes HotSwap dispatch intercept packet inspection/rewrite before the
+  // doorbell is rung.
+  std::mutex hotswap_dispatch_lock_;
+
   // Mutex to prevent AsyncReclaimScratch and HandleInsufficientScratch from
   // happening at the same time.
   std::mutex scratch_lock_;
 
   // Current CU mask
   std::vector<uint32_t> cu_mask_;
+
+  uint64_t last_doorbell_value_;
+  std::vector<uint64_t> hotswap_patched_generations_;
 
   class metadata_prefetch_pkt_version {
     public:

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -96,6 +96,22 @@ class GpuAgentInt : public core::Agent {
 
    virtual void ReleaseResources() = 0;
 
+   // @brief Invoke the user provided callback for each region accessible by
+   // this agent.
+   //
+   // @param [in] include_peer If true, the callback will be also invoked on
+   // each peer memory region accessible by this agent. If false, only invoke
+   // the callback on memory region owned by this agent.
+   // @param [in] callback User provided callback function.
+   // @param [in] data User provided pointer as input for @p callback.
+   //
+   // @retval ::HSA_STATUS_SUCCESS if the callback function for each traversed
+   // region returns ::HSA_STATUS_SUCCESS.
+   virtual hsa_status_t
+   VisitRegion(bool include_peer,
+               hsa_status_t (*callback)(hsa_region_t region, void *data),
+               void *data) const = 0;
+
    // @brief Carve scratch memory for main from scratch pool.
    //
    // @param [in,out] scratch Structure to be populated with the carved memory
@@ -423,6 +439,11 @@ class GpuAgent : public GpuAgentInt {
   const std::vector<const core::Isa *>& supported_isas() const override {
                                                       return supported_isas_;}
 
+  const std::vector<const core::Isa *>& execution_isas() const override {
+                                                      return supported_isas_;}
+
+  __forceinline const core::Isa *execution_isa() const { return isa_; }
+
   // @brief Override from AMD::GpuAgentInt.
   __forceinline hsa_profile_t profile() const override { return profile_; }
 
@@ -486,8 +507,8 @@ class GpuAgent : public GpuAgentInt {
   const size_t MAX_SCRATCH_APERTURE_PER_XCC_GFX12 = (2ULL << 32); // 8GB
   __forceinline size_t MaxScratchDevice() const {
     return properties_.NumXcc *
-          (supported_isas()[0]->GetMajorVersion() >= 12 ? MAX_SCRATCH_APERTURE_PER_XCC_GFX12 :
-                                                           MAX_SCRATCH_APERTURE_PER_XCC);
+        (execution_isa()->GetMajorVersion() >= 12 ? MAX_SCRATCH_APERTURE_PER_XCC_GFX12
+                                                  : MAX_SCRATCH_APERTURE_PER_XCC);
   }
 
   void ReserveScratch();
@@ -503,9 +524,9 @@ class GpuAgent : public GpuAgentInt {
     if (!core::Runtime::runtime_singleton_->flag().enable_scratch_async_reclaim())
       return false;
 
-    switch (supported_isas()[0]->GetMajorVersion()) {
+    switch (execution_isa()->GetMajorVersion()) {
       case 9:
-        switch (supported_isas()[0]->GetMinorVersion()) {
+        switch (execution_isa()->GetMinorVersion()) {
           case 4:
             return (properties_.EngineId.ui32.uCode >= GFX94X_MIN_CP_FW_VERSION_REQUIRED);
           case 5:
@@ -515,7 +536,7 @@ class GpuAgent : public GpuAgentInt {
         }
         break;
       case 12:
-        return (supported_isas()[0]->GetMinorVersion() >= 5);
+        return (execution_isa()->GetMinorVersion() >= 5);
       default:
         break;
     }
@@ -762,6 +783,12 @@ class GpuAgent : public GpuAgentInt {
   // @brief Enumeration index
   uint32_t enum_index_;
 
+ private:
+  const core::Isa* isa_;
+  const core::Isa* presented_isa_;
+  std::vector<const core::Isa*> presented_isas_;
+
+ protected:
   // @brief HDP flush registers
   hsa_amd_hdp_flush_t HDP_flush_ = {nullptr, nullptr};
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap_env.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap_env.hpp
@@ -1,0 +1,37 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// The University of Illinois/NCSA
+// Open Source License (NCSA)
+//
+// Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef HSA_RUNTIME_CORE_INC_HOTSWAP_ENV_HPP_
+#define HSA_RUNTIME_CORE_INC_HOTSWAP_ENV_HPP_
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <string>
+
+namespace rocr {
+namespace hotswap {
+
+inline bool IsEnvFlagEnabled(const char* name) {
+  const char* raw_value = std::getenv(name);
+  if (!raw_value) return false;
+
+  std::string value(raw_value);
+  if (value.empty()) return false;
+
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return value != "0" && value != "off" && value != "false" &&
+         value != "no" && value != "n" && value != "f";
+}
+
+}  // namespace hotswap
+}  // namespace rocr
+
+#endif  // HSA_RUNTIME_CORE_INC_HOTSWAP_ENV_HPP_

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap_env.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap_env.hpp
@@ -32,6 +32,14 @@ inline bool IsEnvFlagEnabled(const char* name) {
   return IsEnvFlagValueEnabled(os::GetEnvVar(env_name));
 }
 
+inline bool IsPresentationModeEnabled() {
+  static const bool Enabled = [] {
+    if (IsEnvFlagEnabled("HSA_HOTSWAP_DISABLE")) return false;
+    return IsEnvFlagEnabled("HSA_HOTSWAP_PRESENT_ISA");
+  }();
+  return Enabled;
+}
+
 }  // namespace hotswap
 }  // namespace rocr
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap_env.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap_env.hpp
@@ -7,6 +7,9 @@
 #ifndef HSA_RUNTIME_CORE_INC_HOTSWAP_ENV_HPP_
 #define HSA_RUNTIME_CORE_INC_HOTSWAP_ENV_HPP_
 
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+#include "core/inc/isa.h"
+#endif
 #include "core/util/os.h"
 
 #include <algorithm>
@@ -39,6 +42,46 @@ inline bool IsPresentationModeEnabled() {
   }();
   return Enabled;
 }
+
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+inline bool ValidateHotSwapPresentationTarget(
+    const std::string& target_env, const std::string& override_env,
+    const core::Isa& execution_isa, std::string& failure) {
+  const std::string& configured_target =
+      target_env.empty() ? override_env : target_env;
+  if (configured_target.empty() || configured_target == "0" ||
+      configured_target == "1") {
+    failure =
+        "HSA_HOTSWAP_TARGET must name the execution ISA when "
+        "HSA_HOTSWAP_PRESENT_ISA is set";
+    return false;
+  }
+
+  std::string configured_name(configured_target);
+  if (configured_name.rfind("amdgcn-amd-amdhsa--", 0) != 0)
+    configured_name = "amdgcn-amd-amdhsa--" + configured_name;
+  const core::Isa* configured_isa = core::IsaRegistry::GetIsa(configured_name);
+  if (!configured_isa) {
+    failure = "configured HotSwap target ISA '" + configured_name +
+              "' is not recognized by ROCr";
+    return false;
+  }
+
+  // Require the same processor; IsCompatible applies target-ID "any"
+  // semantics to omitted features and rejects explicitly mismatched features.
+  if (configured_isa->GetProcessorName() != execution_isa.GetProcessorName() ||
+      !core::Isa::IsCompatible(*configured_isa, execution_isa, 0)) {
+    failure = "configured HotSwap target ISA '" +
+              configured_isa->GetIsaName() +
+              "' does not match physical execution ISA '" +
+              execution_isa.GetIsaName() + "'";
+    return false;
+  }
+
+  failure.clear();
+  return true;
+}
+#endif
 
 }  // namespace hotswap
 }  // namespace rocr

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap_env.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap_env.hpp
@@ -1,11 +1,8 @@
-////////////////////////////////////////////////////////////////////////////////
-//
-// The University of Illinois/NCSA
-// Open Source License (NCSA)
-//
-// Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
-//
-////////////////////////////////////////////////////////////////////////////////
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 #ifndef HSA_RUNTIME_CORE_INC_HOTSWAP_ENV_HPP_
 #define HSA_RUNTIME_CORE_INC_HOTSWAP_ENV_HPP_

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap_env.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap_env.hpp
@@ -10,25 +10,29 @@
 #ifndef HSA_RUNTIME_CORE_INC_HOTSWAP_ENV_HPP_
 #define HSA_RUNTIME_CORE_INC_HOTSWAP_ENV_HPP_
 
+#include "core/util/os.h"
+
 #include <algorithm>
 #include <cctype>
-#include <cstdlib>
 #include <string>
 
 namespace rocr {
 namespace hotswap {
 
-inline bool IsEnvFlagEnabled(const char* name) {
-  const char* raw_value = std::getenv(name);
-  if (!raw_value) return false;
-
-  std::string value(raw_value);
+inline bool IsEnvFlagValueEnabled(std::string value) {
   if (value.empty()) return false;
 
   std::transform(value.begin(), value.end(), value.begin(),
                  [](unsigned char c) { return std::tolower(c); });
   return value != "0" && value != "off" && value != "false" &&
          value != "no" && value != "n" && value != "f";
+}
+
+inline bool IsEnvFlagEnabled(const char* name) {
+  std::string env_name(name);
+  if (!os::IsEnvVarSet(env_name)) return false;
+
+  return IsEnvFlagValueEnabled(os::GetEnvVar(env_name));
 }
 
 }  // namespace hotswap

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -497,7 +497,7 @@ uint64_t AqlQueue::AddWriteIndexRelease(uint64_t value) {
 
 void AqlQueue::StoreRelaxed(hsa_signal_value_t value) {
 #ifdef ROCR_HOTSWAP_COMGR_ADAPTER
-  if (value >= 0 && rocr::amd::hsa::loader::ShouldCheckHotSwapDispatchKernelObjects()) {
+  if (rocr::amd::hsa::loader::ShouldCheckHotSwapDispatchKernelObjects()) {
     std::lock_guard<std::mutex> lock(hotswap_dispatch_lock_);
     // HotSwap's dispatch intercept relies on seeing every published dispatch
     // before the CP does. It is only valid for producers that ring the doorbell

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -72,11 +72,25 @@
 #include "core/inc/amd_gpu_pm4.h"
 #include "core/inc/hsa_amd_tool_int.hpp"
 #include "core/inc/amd_core_dump.hpp"
+#include "loader/AMDHSAKernelDescriptor.h"
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+#include "core/runtime/hotswap_aql_patch.h"
+#include "loader/executable.hpp"
+#endif
 
 namespace rocr {
 namespace AMD {
 
 #define SCRATCH_ALT_RATIO 4
+
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+// This file already uses x86 sfence for hardware doorbell ordering. Keep the
+// HotSwap packet-body fence on the same host target set.
+#if !defined(__x86_64__) && !defined(_M_X64)
+#error "ROCR_HOTSWAP_COMGR_ADAPTER packet fencing requires x86 sfence support"
+#endif
+static void HotSwapPacketBodyFence() { _mm_sfence(); }
+#endif
 
 AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_size_pkts,
                    HSAuint32 node_id, ScratchInfo& scratch, core::HsaEventCallback callback,
@@ -100,7 +114,8 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
       exceptionState(0),
       suspended_(false),
       priority_(HSA::HSA_AMD_QUEUE_PRIORITY_NORMAL),
-      exception_signal_(nullptr) {
+      exception_signal_(nullptr),
+      last_doorbell_value_(UINT64_MAX) {
 
   // Queue size is a function of several restrictions.
   const uint32_t min_pkts = ComputeRingBufferMinPkts();
@@ -118,8 +133,8 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
 
   if (core::Runtime::runtime_singleton_->KfdVersion().supports_metadata_prefetch &&
       metadata_prefetch &&
-      agent_->supported_isas()[0]->GetMajorVersion() == 12
-      && agent_->supported_isas()[0]->GetMinorVersion() >= 5) {
+      agent_->execution_isas()[0]->GetMajorVersion() == 12
+      && agent_->execution_isas()[0]->GetMinorVersion() >= 5) {
     /* First valid version of meta data prefetch - Version is 0.0 */
     dispatch_version_.set_version(0, 0);
     barrier_version_.set_version(0, 0);
@@ -128,6 +143,7 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
   // Allocate the AQL packet ring buffer.
   AllocRegisteredRingBuffer(queue_size_pkts);
   if (ring_buf_ == nullptr) throw std::bad_alloc();
+  hotswap_patched_generations_.assign(queue_size_pkts, UINT64_MAX);
   MAKE_NAMED_SCOPE_GUARD(RingGuard, [&]() { FreeQueueMemory(); });
 
   // Zero the amd_queue_ structure to clear RPTR/WPTR before queue attach.
@@ -199,7 +215,7 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
     assert(amd_queue_.private_segment_aperture_base_hi != 0 && "No private region found.");
   }
 
-  if (agent_->supported_isas()[0]->GetMajorVersion() >= 11)
+  if (agent_->execution_isas()[0]->GetMajorVersion() >= 11)
     queue_scratch_.mem_alignment_size = 256;
   else
     queue_scratch_.mem_alignment_size = 1024;
@@ -480,6 +496,51 @@ uint64_t AqlQueue::AddWriteIndexRelease(uint64_t value) {
 }
 
 void AqlQueue::StoreRelaxed(hsa_signal_value_t value) {
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+  if (value >= 0 && rocr::amd::hsa::loader::ShouldCheckHotSwapDispatchKernelObjects()) {
+    std::lock_guard<std::mutex> lock(hotswap_dispatch_lock_);
+    // HotSwap's dispatch intercept relies on seeing every published dispatch
+    // before the CP does. It is only valid for producers that ring the doorbell
+    // for each submitted range; a producer that publishes write_dispatch_id
+    // without ringing this signal cannot use presentation-mode HotSwap safely.
+    core::AqlPacket* packets =
+        reinterpret_cast<core::AqlPacket*>(amd_queue_.hsa_queue.base_address);
+    const uint64_t end = static_cast<uint64_t>(value);
+    const uint64_t queue_size = amd_queue_.hsa_queue.size;
+    uint64_t first = 0;
+    bool has_work = false;
+    const char* failure_reason = nullptr;
+    if (!rocr::AMD::hotswap::lazy::ComputeDoorbellPatchRange(
+            last_doorbell_value_, end, queue_size, first, has_work,
+            failure_reason)) {
+      fprintf(stderr, "hotswap: refusing doorbell patch: %s\n",
+              failure_reason ? failure_reason : "invalid AQL doorbell range");
+      std::abort();
+    }
+
+    for (uint64_t index = first; has_work && index <= end; ++index) {
+      const uint64_t slot = index % queue_size;
+      if (hotswap_patched_generations_[slot] == index) continue;
+      core::AqlPacket& packet = packets[slot];
+      // The producer has already published a valid packet header by the time
+      // the doorbell signal reaches us. Hide the packet while HotSwap resolves
+      // and rewrites the body, then republish the original header with release
+      // ordering before ringing the hardware doorbell below. Lazy translation
+      // is synchronous here: the COMGR/loader path must not submit work to this
+      // queue while its packet is hidden behind this doorbell.
+      if (!rocr::AMD::hotswap::lazy::PatchPublishedKernelDispatchPacket(
+              packet, rocr::amd::hsa::loader::PrepareHotSwapDispatchKernelObject,
+              IsDeviceMemRingBuf() && needsPcieOrdering()
+                  ? HotSwapPacketBodyFence
+                  : nullptr))
+        continue;
+      hotswap_patched_generations_[slot] = index;
+    }
+    if (last_doorbell_value_ == UINT64_MAX || end > last_doorbell_value_)
+      last_doorbell_value_ = end;
+  }
+#endif
+
   if (core::Runtime::runtime_singleton_->thunkLoader()->IsDTIF() ||
         core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) {
     HSAKMT_CALL(hsaKmtQueueRingDoorbell(queue_id_, value));
@@ -1097,7 +1158,7 @@ void AqlQueue::HandleInsufficientScratch(hsa_signal_value_t& error_code,
 
     // For gfx10+ devices we must attempt to assign the smaller of 256 lanes or 16 groups to each
     // engine.
-    if (agent_->supported_isas()[0]->GetMajorVersion() >= 10 &&
+    if (agent_->execution_isas()[0]->GetMajorVersion() >= 10 &&
         maxGroupsPerEngine < 16 &&
                               lanes_per_group * maxGroupsPerEngine < 256) {
       uint64_t groups_per_interleave = (256 + lanes_per_group - 1) / lanes_per_group;
@@ -1221,7 +1282,7 @@ void AqlQueue::HandleInsufficientScratch(hsa_signal_value_t& error_code,
   if (scratch.large) {
     amd_queue_.queue_properties |= AMD_QUEUE_PROPERTIES_USE_SCRATCH_ONCE;
     // Set system release fence to flush scratch stores with older firmware versions.
-    if ((agent_->supported_isas()[0]->GetMajorVersion() == 8) && (agent_->GetMicrocodeVersion() < 729)) {
+    if ((agent_->execution_isas()[0]->GetMajorVersion() == 8) && (agent_->GetMicrocodeVersion() < 729)) {
       pkt->dispatch.header &=
           ~(((1 << HSA_PACKET_HEADER_WIDTH_SCRELEASE_FENCE_SCOPE) - 1)
             << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
@@ -1470,8 +1531,8 @@ bool AqlQueue::ExceptionHandler(hsa_signal_value_t error_code, void* arg) {
   // dump is generated by hsa-runtime.
   std::vector<AMD::AqlQueue*> suspended_queues;
   if (!core::Runtime::runtime_singleton_->KfdVersion().supports_core_dump &&
-                !(queue->agent_->supported_isas()[0]->GetMajorVersion() == 11
-                  && queue->agent_->supported_isas()[0]->GetMinorVersion() < 5)) {
+                !(queue->agent_->execution_isas()[0]->GetMajorVersion() == 11
+                  && queue->agent_->execution_isas()[0]->GetMinorVersion() < 5)) {
 
     if (pcs::PcsRuntime::instance()->SessionsActive())
       fprintf(stderr, "GPU core dump skipped because PC Sampling active\n");
@@ -1547,9 +1608,9 @@ hsa_status_t AqlQueue::SetCUMasking(uint32_t num_cu_mask_count, const uint32_t* 
 
     // Devices with WGPs must conform to even-indexed contiguous pairwise CU enablement.
     // Disable WGP mode check for gfx1250
-    if (agent_->supported_isas()[0]->GetMajorVersion() >= 10 &&
-        !(agent_->supported_isas()[0]->GetMajorVersion() == 12 &&
-          agent_->supported_isas()[0]->GetMinorVersion() >= 5)) {
+    if (agent_->execution_isa()->GetMajorVersion() >= 10 &&
+        !(agent_->execution_isa()->GetMajorVersion() == 12 &&
+          agent_->execution_isa()->GetMinorVersion() >= 5)) {
       for (int i = 0; i < mask.size() * 32; i += 2) {
         uint32_t cu_pair = (mask[i / 32] >> (i % 32)) & 0x3;
         if (cu_pair && cu_pair != 0x3) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
@@ -1618,7 +1679,7 @@ void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope
 
   uint32_t ib_jump_cmd[ib_jump_size_dw] = {
       PM4_HDR(PM4_HDR_IT_OPCODE_INDIRECT_BUFFER, ib_jump_size_dw,
-                              agent_->supported_isas()[0]->GetMajorVersion()),
+                              agent_->execution_isas()[0]->GetMajorVersion()),
       PM4_INDIRECT_BUFFER_DW1_IB_BASE_LO(uint32_t(uintptr_t(pm4_ib_buf_) >> 2)),
       PM4_INDIRECT_BUFFER_DW2_IB_BASE_HI(uint32_t(uintptr_t(pm4_ib_buf_) >> 32)),
       (PM4_INDIRECT_BUFFER_DW3_IB_SIZE(uint32_t(cmd_size_b / sizeof(uint32_t))) |
@@ -1630,7 +1691,7 @@ void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope
   hsa_signal_t local_signal = {0};
   hsa_status_t err = HSA_STATUS_SUCCESS;
 
-  if (agent_->supported_isas()[0]->GetMajorVersion() <= 8) {
+  if (agent_->execution_isas()[0]->GetMajorVersion() <= 8) {
     // Construct a set of PM4 to fit inside the AQL packet slot.
     uint32_t slot_dw_idx = 0;
 
@@ -1642,7 +1703,7 @@ void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope
     slot_dw_idx += nop_pad_size_dw;
 
     nop_pad[0] = PM4_HDR(PM4_HDR_IT_OPCODE_NOP, nop_pad_size_dw,
-                              agent_->supported_isas()[0]->GetMajorVersion());
+                              agent_->execution_isas()[0]->GetMajorVersion());
 
     for (uint32_t i = 1; i < nop_pad_size_dw; ++i) {
       nop_pad[i] = 0;
@@ -1662,14 +1723,14 @@ void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope
     uint32_t* rel_mem = &slot_data[slot_dw_idx];
 
     rel_mem[0] = PM4_HDR(PM4_HDR_IT_OPCODE_RELEASE_MEM, rel_mem_size_dw,
-                              agent_->supported_isas()[0]->GetMajorVersion());
+                              agent_->execution_isas()[0]->GetMajorVersion());
     rel_mem[1] = PM4_RELEASE_MEM_DW1_EVENT_INDEX(PM4_RELEASE_MEM_EVENT_INDEX_AQL);
     rel_mem[2] = 0;
     rel_mem[3] = 0;
     rel_mem[4] = 0;
     rel_mem[5] = 0;
     rel_mem[6] = 0;
-  } else if (agent_->supported_isas()[0]->GetMajorVersion() >= 9) {
+  } else if (agent_->execution_isas()[0]->GetMajorVersion() >= 9) {
     // Construct an AQL packet to jump to the PM4 IB.
     struct amd_aql_pm4_ib {
       uint16_t header;
@@ -1720,7 +1781,7 @@ void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope
   doorbell->StoreRelease(write_idx);
 
   // Wait for the packet to be consumed.
-  if (agent_->supported_isas()[0]->GetMajorVersion() <= 8) {
+  if (agent_->execution_isas()[0]->GetMajorVersion() <= 8) {
     while (queue->LoadReadIndexRelaxed() <= write_idx)
       os::YieldThread();
 
@@ -2003,7 +2064,7 @@ void AqlQueue::FillComputeTmpRingSize_Gfx12() {
 // @brief Define the Scratch Buffer Descriptor and related parameters
 // that enable kernel access scratch memory
 void AqlQueue::InitScratchSRD() {
-  switch (agent_->supported_isas()[0]->GetMajorVersion()) {
+  switch (agent_->execution_isas()[0]->GetMajorVersion()) {
     case 12:
       FillBufRsrcWord0();
       FillBufRsrcWord1_Gfx11();

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
@@ -50,6 +50,7 @@
 #include "core/inc/amd_gpu_agent.h"
 #include "core/inc/hsa_internal.h"
 #include "core/util/utils.h"
+#include "loader/executable.hpp"
 
 namespace rocr {
 namespace AMD {
@@ -577,6 +578,14 @@ hsa_status_t BlitKernel::Initialize(const core::Agent& agent) {
     KernelCode& kernel = kernels_[kernel_name.first];
     gpuAgent->AssembleShader(kernel_name.second, AMD::GpuAgent::AssembleTarget::AQL, kernel.code_buf_,
                             kernel.code_buf_size_);
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+    std::string target_gfx = "<unknown>";
+    if (!agent_->execution_isas().empty() && agent_->execution_isas()[0])
+      target_gfx = agent_->execution_isas()[0]->GetProcessorName();
+    rocr::amd::hsa::loader::RegisterHotSwapRocrBlitTargetKernelObject(
+        reinterpret_cast<uint64_t>(kernel.code_buf_), kernel.code_buf_size_,
+        target_gfx.c_str());
+#endif
   }
 
   if (agent_->profiling_enabled()) {
@@ -592,6 +601,10 @@ hsa_status_t BlitKernel::Destroy() {
   const AMD::GpuAgent* gpuAgent = static_cast<const AMD::GpuAgent*>(agent_);
 
   for (auto kernel_pair : kernels_) {
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+    rocr::amd::hsa::loader::UnregisterHotSwapRocrBlitTargetKernelObject(
+        reinterpret_cast<uint64_t>(kernel_pair.second.code_buf_));
+#endif
     gpuAgent->ReleaseShader(kernel_pair.second.code_buf_,
                            kernel_pair.second.code_buf_size_);
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -172,10 +172,10 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::Initialize(const core::Agent& agent,
   }
 
   // Cache ISA version for capability detection below.
-  const auto isa_version = agent_->supported_isas()[0]->GetVersion();
-  const auto major = agent_->supported_isas()[0]->GetMajorVersion();
-  const auto minor = agent_->supported_isas()[0]->GetMinorVersion();
-  const auto stepping = agent_->supported_isas()[0]->GetStepping();
+  const auto isa_version = agent_->execution_isas()[0]->GetVersion();
+  const auto major = agent_->execution_isas()[0]->GetMajorVersion();
+  const auto minor = agent_->execution_isas()[0]->GetMinorVersion();
+  const auto stepping = agent_->execution_isas()[0]->GetStepping();
 
   // Some GFX9 devices require a minimum of 64 DWORDS per ring buffer submission.
   if (isa_version >= core::Isa::Version(9, 0, 0) &&
@@ -261,9 +261,9 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::Initialize(const core::Agent& agent,
 
   // Cache gfx90x SW poll workaround flag to avoid static-local guard overhead
   // on every SubmitCommand call.
-  sw_poll_workaround_ = agent_->supported_isas()[0]->GetMajorVersion() == 9 &&
-                        agent_->supported_isas()[0]->GetMinorVersion() == 0 &&
-                        agent_->supported_isas()[0]->GetStepping() != 10;
+  sw_poll_workaround_ = agent_->execution_isas()[0]->GetMajorVersion() == 9 &&
+                        agent_->execution_isas()[0]->GetMinorVersion() == 0 &&
+                        agent_->execution_isas()[0]->GetStepping() != 10;
 
   if (core::g_use_interrupt_wait) {
     signals_[0].reset(new core::InterruptSignal(0));
@@ -1872,7 +1872,7 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitCopyRectCommand(
 
   // GFX12 or later use a different packet format that is incompatible (fields changed in size and location).
   const bool isGFX12Plus =
-                        (agent_->supported_isas()[0]->GetMajorVersion() >= 12);
+                        (agent_->execution_isas()[0]->GetMajorVersion() >= 12);
 
   // Common and GFX12 packet must match in size to use same code for vector/append.
   static_assert(sizeof(SDMA_PKT_COPY_LINEAR_RECT) == sizeof(SDMA_PKT_COPY_LINEAR_RECT_GFX12), "");
@@ -2090,7 +2090,7 @@ void BlitSdma<useGCR, scopeFields>::BuildFenceCommand(char* fence_command_addr, 
   assert(fence_command_addr != NULL);
 
   // GFX12 or later use a different packet format that is incompatible (fields changed in size and location).
-  if (agent_->supported_isas()[0]->GetMajorVersion() >= 12) {
+  if (agent_->execution_isas()[0]->GetMajorVersion() >= 12) {
     SDMA_PKT_FENCE_GFX12* packet_addr =
       reinterpret_cast<SDMA_PKT_FENCE_GFX12*>(fence_command_addr);
 
@@ -2117,7 +2117,7 @@ void BlitSdma<useGCR, scopeFields>::BuildFenceCommand(char* fence_command_addr, 
 
     packet_addr->HEADER_UNION.op = SDMA_OP_FENCE;
 
-    if (agent_->supported_isas()[0]->GetMajorVersion() >= 10) {
+    if (agent_->execution_isas()[0]->GetMajorVersion() >= 10) {
       packet_addr->HEADER_UNION.mtype = 3;
     }
 
@@ -2454,7 +2454,7 @@ void BlitSdma<useGCR, scopeFields>::BuildCopyRectCommand(const std::function<voi
 
   // GFX12 or later use a different packet format that is incompatible (fields changed in size and location).
   const bool isGFX12Plus =
-                      (agent_->supported_isas()[0]->GetMajorVersion() >= 12);
+                      (agent_->execution_isas()[0]->GetMajorVersion() >= 12);
 
   // Limits in terms of element count
   const uint32_t max_pitch = 1    << (isGFX12Plus ? SDMA_PKT_COPY_LINEAR_RECT_GFX12::pitch_bits   : SDMA_PKT_COPY_LINEAR_RECT::pitch_bits);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -64,6 +64,7 @@
 #include "core/inc/default_signal.h"
 #include "core/inc/interrupt_signal.h"
 #include "core/inc/isa.h"
+#include "core/inc/hotswap_env.hpp"
 #include "core/inc/runtime.h"
 #include "core/util/os.h"
 #include "core/util/atomic_helpers.h"
@@ -74,6 +75,10 @@
 #include "core/inc/amd_trap_handler_v1.h"
 #include "core/inc/amd_blit_shaders.h"
 #include "core/inc/hsa_api_trace_int.h"
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+#include "loader/executable.hpp"
+#include "loader/hotswap_kernel_registry.h"
+#endif
 // Generated header
 #include "amd_trap_handler_v2.h"
 #include "amd_blit_shaders_v2.h"
@@ -113,6 +118,8 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
       memory_bus_width_(0),
       memory_max_frequency_(0),
       enum_index_(index),
+      isa_(nullptr),
+      presented_isa_(nullptr),
       ape1_base_(0),
       pending_copy_req_ref_(0),
       pending_copy_stat_check_ref_(0),
@@ -187,36 +194,69 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
                       : core::IsaFeature::Disabled;
   }
 
-  const core::Isa* isa;
   if (node_props.OverrideEngineId.Value != 0) {
-    isa = core::IsaRegistry::GetIsa(
+    isa_ = core::IsaRegistry::GetIsa(
           core::Isa::Version(node_props.OverrideEngineId.ui32.Major, node_props.OverrideEngineId.ui32.Minor,
                              node_props.OverrideEngineId.ui32.Stepping), sramecc, xnack);
   } else {
   // Set instruction set architecture via node property, only on GPU device.
-    isa = core::IsaRegistry::GetIsa(
+    isa_ = core::IsaRegistry::GetIsa(
           core::Isa::Version(node_props.EngineId.ui32.Major, node_props.EngineId.ui32.Minor,
                              node_props.EngineId.ui32.Stepping), sramecc, xnack);
   }
 
-  assert(isa != nullptr && "ISA registry inconsistency.");
+  assert(isa_ != nullptr && "ISA registry inconsistency.");
 
-  supported_isas_.push_back(isa);
+  supported_isas_.push_back(isa_);
   if (!supported_isas_[0]->GetIsaGeneric().empty()) {
     supported_isas_.push_back(core::IsaRegistry::GetIsa(supported_isas_[0]->GetIsaGeneric()));
   }
 
-  if (supported_isas_[0]->GetMajorVersion() == 12 && supported_isas_[0]->GetMinorVersion() >= 5) {
+  const char *PresentIsa = std::getenv("HSA_HOTSWAP_PRESENT_ISA");
+  const bool PresentIsaRequested =
+      !rocr::hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_DISABLE") &&
+      rocr::hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_PRESENT_ISA");
+#ifndef ROCR_HOTSWAP_COMGR_ADAPTER
+  if (PresentIsaRequested) {
+    throw AMD::hsa_exception(
+        HSA_STATUS_ERROR_INVALID_ISA,
+        "Agent creation failed.\n"
+        "HSA_HOTSWAP_PRESENT_ISA requires ROCR_HOTSWAP_COMGR_ADAPTER.\n");
+  }
+#else
+  if (PresentIsaRequested) {
+    std::string PresentName(PresentIsa);
+    if (PresentName.rfind("amdgcn-amd-amdhsa--", 0) != 0)
+      PresentName = "amdgcn-amd-amdhsa--" + PresentName;
+    presented_isa_ = core::IsaRegistry::GetIsa(PresentName);
+    if (!presented_isa_) {
+      throw AMD::hsa_exception(
+          HSA_STATUS_ERROR_INVALID_ISA,
+          "Agent creation failed.\nHSA_HOTSWAP_PRESENT_ISA is not supported.\n");
+    }
+    presented_isas_.push_back(presented_isa_);
+    if (!presented_isa_->GetIsaGeneric().empty()) {
+      const core::Isa *GenericIsa = core::IsaRegistry::GetIsa(presented_isa_->GetIsaGeneric());
+      if (GenericIsa)
+        presented_isas_.push_back(GenericIsa);
+    }
+  }
+#endif
+
+  if (isa_->GetMajorVersion() == 12 && isa_->GetMinorVersion() >= 5) {
     extended_aql_dispatch_supported_ = true;
     workgroup_clusters_supported_ = true;
   }
+
+  if (isa_->GetMajorVersion() >= 12)
+    kern_cluster_max_dim_ = { UINT32_MAX, UINT16_MAX, UINT16_MAX };
 
   if (workgroup_clusters_supported_) {
     const uint64_t num_cu_per_se = properties_.NumArrays * properties_.NumCUPerArray;
     cluster_max_dim_ = { num_cu_per_se, num_cu_per_se, num_cu_per_se };
   }
 
-  max_wave_scratch_ = (supported_isas_[0]->GetMajorVersion() >= 12) ? MAX_WAVE_SCRATCH_GFX12 : MAX_WAVE_SCRATCH;
+  max_wave_scratch_ = (isa_->GetMajorVersion() >= 12) ? MAX_WAVE_SCRATCH_GFX12 : MAX_WAVE_SCRATCH;
 
   current_coherency_type((profile_ == HSA_PROFILE_FULL)
                              ? HSA_AMD_COHERENCY_TYPE_COHERENT
@@ -380,7 +420,7 @@ void GpuAgent::AssembleShader(const char* func_name, AssembleTarget assemble_tar
 
   ASICShader* asic_shader = NULL;
 
-  switch (supported_isas()[0]->GetMajorVersion()) {
+  switch (isa_->GetMajorVersion()) {
     case 7:
       asic_shader = &compiled_shader_it->second.compute_7;
       break;
@@ -388,28 +428,28 @@ void GpuAgent::AssembleShader(const char* func_name, AssembleTarget assemble_tar
       asic_shader = &compiled_shader_it->second.compute_8;
       break;
     case 9:
-      if((supported_isas()[0]->GetMinorVersion() == 0) && (supported_isas()[0]->GetStepping() == 10)) {
+      if ((isa_->GetMinorVersion() == 0) && (isa_->GetStepping() == 10)) {
         asic_shader = &compiled_shader_it->second.compute_90a;
-      } else if(supported_isas()[0]->GetMinorVersion() == 4 || supported_isas()[0]->GetMinorVersion() == 5) {
+      } else if (isa_->GetMinorVersion() == 4 || isa_->GetMinorVersion() == 5) {
         asic_shader = &compiled_shader_it->second.compute_942;
       } else {
         asic_shader = &compiled_shader_it->second.compute_9;
       }
       break;
     case 10:
-      if(supported_isas()[0]->GetMinorVersion() == 1)
+      if (isa_->GetMinorVersion() == 1)
         asic_shader = &compiled_shader_it->second.compute_1010;
       else
         asic_shader = &compiled_shader_it->second.compute_10;
       break;
     case 11:
-        asic_shader = &compiled_shader_it->second.compute_11;
+      asic_shader = &compiled_shader_it->second.compute_11;
       break;
     case 12:
-        if(supported_isas()[0]->GetMinorVersion() >= 5)
-          asic_shader = &compiled_shader_it->second.compute_1250;
-        else
-          asic_shader = &compiled_shader_it->second.compute_12;
+      if (isa_->GetMinorVersion() >= 5)
+        asic_shader = &compiled_shader_it->second.compute_1250;
+      else
+        asic_shader = &compiled_shader_it->second.compute_12;
       break;
     default:
       assert(false && "Precompiled shader unavailable for target");
@@ -450,7 +490,7 @@ void GpuAgent::AssembleShader(const char* func_name, AssembleTarget assemble_tar
     // ENABLE_WAVEFRONT_SIZE32 must match the wavefront size used to compile blit shaders.
     AMD_HSA_BITS_SET(header->kernel_code_properties,
                      AMD_KERNEL_CODE_PROPERTIES_ENABLE_WAVEFRONT_SIZE32,
-                     supported_isas()[0]->GetWavefront().IsWavefrontSize64() ? 0 : 1);
+                     isa_->GetWavefront().IsWavefrontSize64() ? 0 : 1);
     AMD_HSA_BITS_SET(header->compute_pgm_rsrc1,
                      AMD_COMPUTE_PGM_RSRC_ONE_GRANULATED_WAVEFRONT_SGPR_COUNT,
                      gran_sgprs);
@@ -467,9 +507,9 @@ void GpuAgent::AssembleShader(const char* func_name, AssembleTarget assemble_tar
                      AMD_COMPUTE_PGM_RSRC_TWO_ENABLE_SGPR_WORKGROUP_ID_X, 1);
 
     // gfx90a, gfx942, gfx950
-    if ((supported_isas()[0]->GetMajorVersion() == 9) &&
-        (((supported_isas()[0]->GetMinorVersion() == 0) && (supported_isas()[0]->GetStepping() == 10)) ||
-        (supported_isas()[0]->GetMinorVersion() == 4 || supported_isas()[0]->GetMinorVersion() == 5))) {
+    if ((isa_->GetMajorVersion() == 9) &&
+        (((isa_->GetMinorVersion() == 0) && (isa_->GetStepping() == 10)) ||
+        (isa_->GetMinorVersion() == 4 || isa_->GetMinorVersion() == 5))) {
       // Program COMPUTE_PGM_RSRC3.ACCUM_OFFSET for 0 ACC VGPRs on gfx90a.
       // FIXME: Assemble code objects from source at build time
       int gran_accvgprs = ((gran_vgprs + 1) * 8) / 4 - 1;
@@ -514,7 +554,7 @@ void GpuAgent::InitRegionList() {
 
           if (region->IsLocalMemory()) {
             // Extended Fine-Grain memory
-            if (!(supported_isas()[0]->GetMajorVersion() == 12 && supported_isas()[0]->GetMinorVersion() == 0))
+            if (!(isa_->GetMajorVersion() == 12 && isa_->GetMinorVersion() == 0))
               regions_.push_back(
                   std::make_shared<MemoryRegion>(false, false, false, true, true, this, mem_props[mem_idx]));
 
@@ -725,7 +765,9 @@ hsa_status_t GpuAgent::IterateSupportedIsas(
                     hsa_status_t (*callback)(hsa_isa_t isa, void* data),
                                                           void* data) const {
   AMD::callback_t<decltype(callback)> call(callback);
-  for (const auto& isa : supported_isas()) {
+  const auto& PublicIsas =
+      presented_isas_.empty() ? supported_isas_ : presented_isas_;
+  for (const auto& isa : PublicIsas) {
     hsa_status_t stat = call(core::Isa::Handle(isa), data);
     if (stat != HSA_STATUS_SUCCESS) return stat;
   }
@@ -817,23 +859,23 @@ core::Blit* GpuAgent::CreateBlitSdma(bool use_xgmi, int rec_eng) {
    */
   auto isDXG = core::Runtime::runtime_singleton_->thunkLoader()->IsDXG();
 
-  switch (supported_isas()[0]->GetMajorVersion()) {
+  switch (isa_->GetMajorVersion()) {
     case 9:
       sdma = new BlitSdmaV4();
-      copy_size_override = (supported_isas()[0]->GetMinorVersion() >= 4 ||
-                            (supported_isas()[0]->GetMinorVersion() == 0 && supported_isas()[0]->GetStepping() == 10)) ?
+      copy_size_override = (isa_->GetMinorVersion() >= 4 ||
+                            (isa_->GetMinorVersion() == 0 && isa_->GetStepping() == 10)) ?
                             copy_size_overrides[1] : copy_size_overrides[0];
       break;
     case 10:
       sdma = (isDXG ? static_cast<BlitSdmaBase*>(new BlitSdmaV4()) : static_cast<BlitSdmaBase*>(new BlitSdmaV5()));
-      copy_size_override = supported_isas()[0]->GetMinorVersion() < 3 ? copy_size_overrides[0] :
+      copy_size_override = isa_->GetMinorVersion() < 3 ? copy_size_overrides[0] :
                                                          copy_size_overrides[1];
       break;
     case 11:
     case 12:
       if (core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) {
         sdma = static_cast<BlitSdmaBase*>(new BlitSdmaV4());
-      } else if (supported_isas()[0]->GetMinorVersion() >= 5) {
+      } else if (isa_->GetMinorVersion() >= 5) {
         sdma = static_cast<BlitSdmaBase*>(new BlitSdmaV6());
       } else {
         sdma = static_cast<BlitSdmaBase*>(new BlitSdmaV5());
@@ -923,19 +965,19 @@ void GpuAgent::InitDma() {
 
     // User SDMA queues are unstable on gfx8 and unsupported on gfx1013.
     bool use_sdma =
-        ((supported_isas()[0]->GetMajorVersion() != 8) && (supported_isas()[0]->GetVersion() != std::make_tuple(10, 1, 3)));
+        ((isa_->GetMajorVersion() != 8) && (isa_->GetVersion() != std::make_tuple(10, 1, 3)));
     if (sdma_override != Flag::SDMA_DEFAULT) use_sdma = (sdma_override == Flag::SDMA_ENABLE);
 
     if (use_sdma && (HSA_PROFILE_BASE == profile_)) {
       // On gfx90a ensure that HostToDevice queue is created first and so is placed on SDMA0.
-      if ((!prefer_xgmi) && (!isHostToDev) && (supported_isas()[0]->GetMajorVersion() == 9) &&
-          (supported_isas()[0]->GetMinorVersion() == 0) && (supported_isas()[0]->GetStepping() == 10)) {
+      if ((!prefer_xgmi) && (!isHostToDev) && (isa_->GetMajorVersion() == 9) &&
+          (isa_->GetMinorVersion() == 0) && (isa_->GetStepping() == 10)) {
         GetBlitObject(BlitHostToDev);
         *blits_[BlitHostToDev];
       }
 
       // gfx94x is more efficient with reverse order of SDMA0/1 for host<->device copies
-      if (!prefer_xgmi && supported_isas()[0]->GetMajorVersion() == 9 && supported_isas()[0]->GetMinorVersion() >= 4)
+      if (!prefer_xgmi && isa_->GetMajorVersion() == 9 && isa_->GetMinorVersion() >= 4)
         rec_eng = (rec_eng + 1) % properties_.NumSdmaEngines;
 
       // Check support for targeted SDMA engines
@@ -947,8 +989,8 @@ void GpuAgent::InitDma() {
 
       // Observing strange behavior when fixing host<->device engines
       // on GFX9 devices older than GFX90a, so bypass engine fix.
-      if (!prefer_xgmi && supported_isas()[0]->GetMajorVersion() == 9 && supported_isas()[0]->GetMinorVersion() == 0
-          && supported_isas()[0]->GetStepping() < 10)
+      if (!prefer_xgmi && isa_->GetMajorVersion() == 9 && isa_->GetMinorVersion() == 0
+          && isa_->GetStepping() < 10)
         rec_eng = -1;
 
       // devices without dedicated xGMI SDMA engines should not target specific
@@ -1140,7 +1182,7 @@ void GpuAgent::RegisterRecSdmaEngIdMaskPeer(core::Agent& peer, uint32_t rec_sdma
   uses_rec_sdma_eng_id_mask_ = (kfd_version.KernelInterfaceMajorVersion > 1 ||
                                  (kfd_version.KernelInterfaceMajorVersion == 1 &&
                                   kfd_version.KernelInterfaceMinorVersion >= 17)) &&
-                               supported_isas()[0]->GetMajorVersion() == 9 && supported_isas()[0]->GetMinorVersion() >= 4 &&
+                               isa_->GetMajorVersion() == 9 && isa_->GetMinorVersion() >= 4 &&
                                IsPowerOfTwo(rec_sdma_eng_id_mask) && rec_eng_enabled;
 
   rec_sdma_eng_id_peers_info_[peer.public_handle().handle] = uses_rec_sdma_eng_id_mask_ ?
@@ -1306,7 +1348,7 @@ hsa_status_t GpuAgent::DmaCopyOnEngine(void* dst, core::Agent& dst_agent,
     // Due to a RAS issue, GFX90a can only support H2D copies on SDMA0
     bool is_h2d_blit = (src_agent.device_type() == core::Agent::kAmdCpuDevice &&
       dst_agent.device_type() == core::Agent::kAmdGpuDevice);
-    bool limit_h2d_blit = supported_isas()[0]->GetVersion() == core::Isa::Version(9, 0, 10);
+    bool limit_h2d_blit = isa_->GetVersion() == core::Isa::Version(9, 0, 10);
 
     // Ensure engine selection is within proper range based on transfer type
     if ((p2p_engine_is_mandatory && !rec_sdma_eng_override_ && engine_offset <= num_h2d_d2h_engines_) ||
@@ -1390,7 +1432,7 @@ hsa_status_t GpuAgent::DmaCopyStatus(core::Agent& dst_agent, core::Agent& src_ag
     bool is_h2d_blit = (src_agent.device_type() == core::Agent::kAmdCpuDevice &&
       dst_agent.device_type() == core::Agent::kAmdGpuDevice);
     // Due to a RAS issue, GFX90a can only support H2D copies on SDMA0
-    bool limit_h2d_blit = supported_isas()[0]->GetVersion() == core::Isa::Version(9, 0, 10);
+    bool limit_h2d_blit = isa_->GetVersion() == core::Isa::Version(9, 0, 10);
 
     // Check if H2D is free
     if (DmaEngineIsFree(BlitHostToDev)) {
@@ -1418,16 +1460,24 @@ hsa_status_t GpuAgent::DmaCopyStatus(core::Agent& dst_agent, core::Agent& src_ag
 
 hsa_status_t GpuAgent::DmaPreferredEngine(core::Agent& dst_agent, core::Agent& src_agent,
                                           uint32_t *recommended_ids_mask) {
-  // gfx125+: all SDMA engines are equivalent — return all engines regardless of direction.
-  if (supported_isas()[0]->GetMajorVersion() == 12 && supported_isas()[0]->GetMinorVersion() >= 5) {
-    uint32_t total = num_h2d_d2h_engines_ + num_p2p_engines_;
-    *recommended_ids_mask = (1u << total) - 1;
+  // gfx1250+: all SDMA engines are equivalent and there are no XGMI engines, we prefer first 2 engines
+  // for h2d/d2h and remaining for p2p.
+  if (isa_->GetMajorVersion() == 12 && isa_->GetMinorVersion() >= 5) {
+    bool is_p2p = (src_agent.device_type() == core::Agent::kAmdGpuDevice &&
+                  dst_agent.device_type() == core::Agent::kAmdGpuDevice);
+
+    if (is_p2p) {
+      *recommended_ids_mask = ((1u << num_p2p_engines_) - 1) << (DefaultBlitCount - 1);
+    } else {
+      *recommended_ids_mask = (1u << num_h2d_d2h_engines_) - 1;
+    }
+
     return HSA_STATUS_SUCCESS;
   }
 
   // From the collected data, gfx94x performance is better only for first 3 SDMA engines
-  bool isGfx94x = (supported_isas()[0]->GetMajorVersion() == 9 &&
-                  (supported_isas()[0]->GetMinorVersion() == 4 || supported_isas()[0]->GetMinorVersion() == 5));
+  bool isGfx94x = (isa_->GetMajorVersion() == 9 &&
+                  (isa_->GetMinorVersion() == 4 || isa_->GetMinorVersion() == 5));
 
   if (isGfx94x &&
       ((src_agent.device_type() == core::Agent::kAmdCpuDevice &&
@@ -2131,7 +2181,7 @@ hsa_status_t GpuAgent::DmaCopyRect(const hsa_pitched_ptr_t* dst, const hsa_dim3_
                                    const hsa_dim3_t* range, hsa_amd_copy_direction_t dir,
                                    std::vector<core::Signal*>& dep_signals,
                                    core::Signal& out_signal) {
-  if (supported_isas()[0]->GetMajorVersion() < 9) return HSA_STATUS_ERROR_INVALID_AGENT;
+  if (isa_->GetMajorVersion() < 9) return HSA_STATUS_ERROR_INVALID_AGENT;
 
   SetCopyRequestRefCount(true);
   MAKE_SCOPE_GUARD([&]() { SetCopyRequestRefCount(false); });
@@ -2211,7 +2261,8 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
 
   switch (attribute_u) {
     case HSA_AGENT_INFO_NAME: {
-      const std::string& name = supported_isas()[0]->GetProcessorName();
+      const core::Isa *InfoIsa = presented_isa_ ? presented_isa_ : isa_;
+      const std::string& name = InfoIsa->GetProcessorName();
       const size_t n = std::min(name.size(), hsa_name_size);
       std::memset(value, 0, hsa_name_size + 1);
       std::memcpy(value, name.data(), n);
@@ -2237,7 +2288,7 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
           HSA_DEFAULT_FLOAT_ROUNDING_MODE_NEAR;
       break;
     case HSA_AGENT_INFO_FAST_F16_OPERATION:
-      if (supported_isas()[0]->GetMajorVersion() >= 8) {
+      if (isa_->GetMajorVersion() >= 8) {
         *((bool*)value) = true;
       } else {
         *((bool*)value) = false;
@@ -2247,7 +2298,9 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
       *((hsa_profile_t*)value) = profile_;
       break;
     case HSA_AGENT_INFO_WAVEFRONT_SIZE:
-      *((uint32_t*)value) = properties_.WaveFrontSize;
+      *((uint32_t*)value) =
+          presented_isa_ ? (presented_isa_->GetWavefront().IsWavefrontSize64() ? 64 : 32)
+                         : properties_.WaveFrontSize;
       break;
     case HSA_AGENT_INFO_WORKGROUP_MAX_DIM: {
       // TODO: must be per-device
@@ -2319,7 +2372,8 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
       }
     } break;
     case HSA_AGENT_INFO_ISA:
-      *((hsa_isa_t*)value) = core::Isa::Handle(supported_isas()[0]);
+      *((hsa_isa_t*)value) =
+          core::Isa::Handle(presented_isa_ ? presented_isa_ : isa_);
       break;
     case HSA_AGENT_INFO_EXTENSIONS: {
       memset(value, 0, sizeof(uint8_t) * 128);
@@ -2335,7 +2389,8 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
         setFlag(HSA_EXTENSION_FINALIZER);
       }
 
-      if (core::hsa_internal_api_table().image_api.hsa_ext_image_create_fn != NULL) {
+      if (core::hsa_internal_api_table().image_api.hsa_ext_image_create_fn != NULL &&
+          (!presented_isa_ || presented_isa_->HasImageSupport())) {
         setFlag(HSA_EXTENSION_IMAGES);
       }
 
@@ -2366,23 +2421,23 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
     case HSA_EXT_AGENT_INFO_IMAGE_2DADEPTH_MAX_ELEMENTS:
     case HSA_EXT_AGENT_INFO_IMAGE_3D_MAX_ELEMENTS:
     case HSA_EXT_AGENT_INFO_IMAGE_ARRAY_MAX_LAYERS:
-      if (!supported_isas()[0]->HasImageSupport())
+      if (!(presented_isa_ ? presented_isa_ : isa_)->HasImageSupport())
         *((uint32_t*)value) = 0;
       else
         return hsa_amd_image_get_info_max_dim(public_handle(), attribute, value);
       break;
     case HSA_EXT_AGENT_INFO_MAX_IMAGE_RD_HANDLES:
       // TODO: hardcode based on OCL constants.
-      *((uint32_t*)value) = supported_isas()[0]->HasImageSupport() ? 128 : 0;
+      *((uint32_t*)value) = (presented_isa_ ? presented_isa_ : isa_)->HasImageSupport() ? 128 : 0;
       break;
     case HSA_EXT_AGENT_INFO_MAX_IMAGE_RORW_HANDLES:
-      *((uint32_t*)value) = supported_isas()[0]->HasImageSupport() ? 64 : 0;
+      *((uint32_t*)value) = (presented_isa_ ? presented_isa_ : isa_)->HasImageSupport() ? 64 : 0;
       break;
     case HSA_EXT_AGENT_INFO_MAX_SAMPLER_HANDLERS:
-      *((uint32_t*)value) = supported_isas()[0]->HasImageSupport() ? 16 : 0;
+      *((uint32_t*)value) = (presented_isa_ ? presented_isa_ : isa_)->HasImageSupport() ? 16 : 0;
       break;
     case HSA_EXT_AGENT_INFO_IMAGE_SUPPORT:
-      *((uint32_t*)value) = supported_isas()[0]->HasImageSupport();
+      *((uint32_t*)value) = (presented_isa_ ? presented_isa_ : isa_)->HasImageSupport();
       break;
     case HSA_AMD_AGENT_INFO_CHIP_ID:
       *((uint32_t*)value) = properties_.DeviceId;
@@ -2489,8 +2544,8 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
       }
 
       if (core::Runtime::runtime_singleton_->flag().coop_cu_count() &&
-          (supported_isas()[0]->GetMajorVersion() == 9) && (supported_isas()[0]->GetMinorVersion() == 0) &&
-          (supported_isas()[0]->GetStepping() == 10)) {
+          (isa_->GetMajorVersion() == 9) && (isa_->GetMinorVersion() == 0) &&
+          (isa_->GetStepping() == 10)) {
         uint32_t count = 0;
         [[maybe_unused]] hsa_status_t cu_err =
             GetInfo((hsa_agent_info_t)HSA_AMD_AGENT_INFO_COMPUTE_UNIT_COUNT, &count);
@@ -2613,7 +2668,7 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
       *((uint64_t*)value) = cluster_max_dim_.x;
       break;
     case HSA_AMD_AGENT_INFO_MAX_DATA_PREFETCH_REGIONS:
-      if (supported_isas()[0]->GetMajorVersion() == 12 && supported_isas()[0]->GetMinorVersion() >= 5) {
+      if (isa_->GetMajorVersion() == 12 && isa_->GetMinorVersion() >= 5) {
         *((uint32_t*)value) = AMD_LAUNCH_DESCRIPTOR_MAX_PREFETCH_REGIONS;
       } else {
         *((uint32_t*)value) = 0;
@@ -2634,6 +2689,13 @@ hsa_status_t GpuAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type, u
                                    core::HsaEventCallback event_callback, void* data,
                                    uint32_t private_segment_size, uint32_t group_segment_size,
                                    bool metadata_queue, core::Queue** queue) {
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+  if (rocr::amd::hsa::loader::ShouldCheckHotSwapDispatchKernelObjects() &&
+      !rocr::amd::hsa::loader::IsHotSwapQueueTypeSupported(queue_type)) {
+    return HSA_STATUS_ERROR_INVALID_QUEUE_CREATION;
+  }
+#endif
+
   // Handle GWS queues.
   if (queue_type == HSA_QUEUE_TYPE_COOPERATIVE) {
     std::lock_guard<std::mutex> lock(gws_queue_.lock_);
@@ -2777,7 +2839,7 @@ void GpuAgent::UnregisterAqlQueue(core::Queue* queue) {
 void GpuAgent::AcquireQueueMainScratch(ScratchInfo& scratch) {
   assert(scratch.main_queue_base == nullptr &&
          "AcquireQueueMainScratch called while holding scratch.");
-  bool need_queue_scratch_base = (supported_isas()[0]->GetMajorVersion() > 8);
+  bool need_queue_scratch_base = (isa_->GetMajorVersion() > 8);
 
   if (scratch.main_size == 0) {
     scratch.main_size = queue_scratch_len_;
@@ -2824,7 +2886,7 @@ void GpuAgent::AcquireQueueMainScratch(ScratchInfo& scratch) {
             ((scratch_pool_.size() - scratch_pool_.remaining() - scratch_cache_.free_bytes() +
              scratch.main_size) > small_limit));
 
-  if ((supported_isas()[0]->GetMajorVersion() < 8) ||
+  if ((isa_->GetMajorVersion() < 8) ||
       core::Runtime::runtime_singleton_->flag().no_scratch_reclaim()) {
     large = false;
     use_reclaim = false;
@@ -3283,7 +3345,7 @@ hsa_status_t GpuAgent::UpdateTrapHandlerWithPCS(pcs_sampling_data_t* pcs_hosttra
 }
 
 void GpuAgent::BindTrapHandler() {
-  if (supported_isas()[0]->GetMajorVersion() == 7) {
+  if (isa_->GetMajorVersion() == 7) {
     // No trap handler support on Gfx7, soft error.
     return;
   }
@@ -3296,11 +3358,11 @@ void GpuAgent::BindTrapHandler() {
     AssembleShader("TrapHandlerKfdExceptions", AssembleTarget::ISA, trap_code_buf_,
                    trap_code_buf_size_);
   } else {
-    if (supported_isas()[0]->GetMajorVersion() >= 11 ||
-       (supported_isas()[0]->GetMajorVersion() == 9 &&
-        (supported_isas()[0]->GetMinorVersion() == 4 || supported_isas()[0]->GetMinorVersion() == 5)) ||
-       (supported_isas()[0]->GetMajorVersion() == 10 && supported_isas()[0]->GetMinorVersion() == 3 &&
-        supported_isas()[0]->GetStepping() == 6)) {
+    if (isa_->GetMajorVersion() >= 11 ||
+       (isa_->GetMajorVersion() == 9 &&
+        (isa_->GetMinorVersion() == 4 || isa_->GetMinorVersion() == 5)) ||
+       (isa_->GetMajorVersion() == 10 && isa_->GetMinorVersion() == 3 &&
+        isa_->GetStepping() == 6)) {
       // No trap handler support without exception handling, soft error.
       // gfx1036 (Granite Ridge iGPU): KMD does not support the trap handler escape.
       return;
@@ -3332,17 +3394,17 @@ void GpuAgent::BindTrapHandler() {
 void GpuAgent::InvalidateCodeCaches(void *ptr, size_t size) {
   // Check for microcode cache invalidation support.
   // This is deprecated in later microcode builds.
-  if (supported_isas()[0]->GetMajorVersion() == 7) {
+  if (isa_->GetMajorVersion() == 7) {
     if (properties_.EngineId.ui32.uCode < 420) {
       // Microcode is handling code cache invalidation.
       return;
     }
-  } else if (supported_isas()[0]->GetMajorVersion() == 8 && supported_isas()[0]->GetMinorVersion() == 0) {
+  } else if (isa_->GetMajorVersion() == 8 && isa_->GetMinorVersion() == 0) {
     if (properties_.EngineId.ui32.uCode < 685) {
       // Microcode is handling code cache invalidation.
       return;
     }
-  } else if (supported_isas()[0]->GetMajorVersion() > 12) {
+  } else if (isa_->GetMajorVersion() > 12) {
     assert(false && "Code cache invalidation not implemented for this agent");
   }
 
@@ -3355,7 +3417,7 @@ void GpuAgent::InvalidateCodeCaches(void *ptr, size_t size) {
   uint32_t cache_inv[8] = {0};
   uint32_t cache_inv_size_dw;
 
-  if (supported_isas()[0]->GetMajorVersion() < 10) {
+  if (isa_->GetMajorVersion() < 10) {
       cache_inv[1] = PM4_ACQUIRE_MEM_DW1_COHER_CNTL(
           PM4_ACQUIRE_MEM_COHER_CNTL_SH_ICACHE_ACTION_ENA |
           PM4_ACQUIRE_MEM_COHER_CNTL_SH_KCACHE_ACTION_ENA |
@@ -3375,7 +3437,7 @@ void GpuAgent::InvalidateCodeCaches(void *ptr, size_t size) {
   }
 
   cache_inv[0] = PM4_HDR(PM4_HDR_IT_OPCODE_ACQUIRE_MEM, cache_inv_size_dw,
-             supported_isas()[0]->GetMajorVersion());
+             isa_->GetMajorVersion());
 
   if (ptr) {
     size_t size_granule = (size + 0xFF) >> 8;
@@ -4617,7 +4679,7 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
   memset(cmd_data, 0, cmd_data_sz);
 
   // ATOMIC_MEM: Atomically swap buf_write_val, return old value
-  cmd_data[i++] = PM4_HDR(PM4_HDR_IT_OPCODE_ATOMIC_MEM, atomic_ex_cmd_sz, supported_isas()[0]->GetMajorVersion());
+  cmd_data[i++] = PM4_HDR(PM4_HDR_IT_OPCODE_ATOMIC_MEM, atomic_ex_cmd_sz, isa_->GetMajorVersion());
   cmd_data[i++] = PM4_ATOMIC_MEM_DW1_ATOMIC(PM4_ATOMIC_MEM_GL2_OP_ATOMIC_SWAP_RTN_64);
   cmd_data[i++] = PM4_ATOMIC_MEM_DW2_ADDR_LO(buf_write_val_addr);
   cmd_data[i++] = PM4_ATOMIC_MEM_DW3_ADDR_HI(buf_write_val_addr >> 32);
@@ -4626,7 +4688,7 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
   i += 3;  // Reserved DWORDs
 
   // COPY_DATA: Copy atomic return value to host-accessible old_val
-  cmd_data[i++] = PM4_HDR(PM4_HDR_IT_OPCODE_COPY_DATA, copy_data_cmd_sz, supported_isas()[0]->GetMajorVersion());
+  cmd_data[i++] = PM4_HDR(PM4_HDR_IT_OPCODE_COPY_DATA, copy_data_cmd_sz, isa_->GetMajorVersion());
   cmd_data[i++] =
       PM4_COPY_DATA_DW1(PM4_COPY_DATA_SRC_SEL_ATOMIC_RETURN_DATA | PM4_COPY_DATA_DST_SEL_TC_12 |
                         PM4_COPY_DATA_COUNT_SEL | PM4_COPY_DATA_WR_CONFIRM);
@@ -4643,7 +4705,7 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
   // 2. Each XCC thread submits to the shared queue independently (no lock contention)
   // 3. The per-XCC threading model still provides parallelism at the thread level
   if (properties_.NumXcc > 1) {
-    cmd_data[0] = PM4_HDR(PM4_HDR_IT_OPCODE_PRED_EXEC, pred_exec_cmd_sz, supported_isas()[0]->GetMajorVersion());
+    cmd_data[0] = PM4_HDR(PM4_HDR_IT_OPCODE_PRED_EXEC, pred_exec_cmd_sz, isa_->GetMajorVersion());
     cmd_data[1] = PM4_PRED_EXEC_DW2_EXEC_COUNT(i - pred_exec_cmd_sz) |
                   PM4_PRED_EXEC_DW2_VIRTUALXCCID_SELECT(0x1);
   }
@@ -4719,7 +4781,7 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
 
   // WAIT_REG_MEM: Wait for trap handler to finish writing samples
   cmd_data[i++] =
-      PM4_HDR(PM4_HDR_IT_OPCODE_WAIT_REG_MEM, wait_reg_mem_cmd_sz, supported_isas()[0]->GetMajorVersion());
+      PM4_HDR(PM4_HDR_IT_OPCODE_WAIT_REG_MEM, wait_reg_mem_cmd_sz, isa_->GetMajorVersion());
   cmd_data[i++] = PM4_WAIT_REG_MEM_DW1(PM4_WAIT_REG_MEM_FUNCTION_EQUAL_TO_REFERENCE |
                                        PM4_WAIT_REG_MEM_MEM_SPACE_MEMORY_SPACE |
                                        PM4_WAIT_REG_MEM_OPERATION_WAIT_REG_MEM);
@@ -4731,10 +4793,10 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
                                        PM4_WAIT_REG_MEM_OPTIMIZE_ACE_OFFLOAD_MODE);
 
   // ACQUIRE_MEM: Flush L2 cache for GFX12 before DMA copy
-  if (supported_isas()[0]->GetMajorVersion() == 12 &&
-      (supported_isas()[0]->GetMinorVersion() == 0 || supported_isas()[0]->GetMinorVersion() == 5)) {
+  if (isa_->GetMajorVersion() == 12 &&
+      (isa_->GetMinorVersion() == 0 || isa_->GetMinorVersion() == 5)) {
     cmd_data[i++] =
-        PM4_HDR(PM4_HDR_IT_OPCODE_ACQUIRE_MEM, acquire_mem_cmd_sz, supported_isas()[0]->GetMajorVersion());
+        PM4_HDR(PM4_HDR_IT_OPCODE_ACQUIRE_MEM, acquire_mem_cmd_sz, isa_->GetMajorVersion());
     cmd_data[i++] = 0;                                // DW1: COHER_CNTL
     cmd_data[i++] = 0;                                // DW2: COHER_SIZE
     cmd_data[i++] = 0;                                // DW3: COHER_SIZE_HI
@@ -4756,7 +4818,7 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
   auto emit_dma_data = [&](uint8_t* src, uint8_t* dst, size_t bytes, bool is_last) {
     while (bytes > 0) {
       uint32_t chunk = std::min(bytes, (size_t)CP_DMA_DATA_TRANSFER_CNT_MAX);
-      cmd_data[i++] = PM4_HDR(PM4_HDR_IT_OPCODE_DMA_DATA, dma_data_cmd_sz, supported_isas()[0]->GetMajorVersion());
+      cmd_data[i++] = PM4_HDR(PM4_HDR_IT_OPCODE_DMA_DATA, dma_data_cmd_sz, isa_->GetMajorVersion());
       cmd_data[i++] = PM4_DMA_DATA_DW1(PM4_DMA_DATA_DST_SEL_DST_ADDR_USING_L2 |
                                        PM4_DMA_DATA_SRC_SEL_SRC_ADDR_USING_L2);
       cmd_data[i++] = PM4_DMA_DATA_DW2_SRC_ADDR_LO((uint64_t)src);
@@ -4786,7 +4848,7 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
   }
 
   // WRITE_DATA: Reset buf_written_val for next cycle
-  cmd_data[i++] = PM4_HDR(PM4_HDR_IT_OPCODE_WRITE_DATA, write_data_cmd_sz, supported_isas()[0]->GetMajorVersion());
+  cmd_data[i++] = PM4_HDR(PM4_HDR_IT_OPCODE_WRITE_DATA, write_data_cmd_sz, isa_->GetMajorVersion());
   cmd_data[i++] = PM4_WRITE_DATA_DW1(PM4_WRITE_DATA_DST_SEL_TC_L2 |
                                      PM4_WRITE_DATA_WR_CONFIRM_WAIT_CONFIRMATION);
   cmd_data[i++] = PM4_WRITE_DATA_DW2_DST_MEM_ADDR_LO(buf_written_val_addr[which_buffer]);
@@ -4795,7 +4857,7 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
 
   // Add PRED_EXEC wrapper for multi-XCC (see atomic swap comment for rationale)
   if (properties_.NumXcc > 1) {
-    cmd_data[0] = PM4_HDR(PM4_HDR_IT_OPCODE_PRED_EXEC, pred_exec_cmd_sz, supported_isas()[0]->GetMajorVersion());
+    cmd_data[0] = PM4_HDR(PM4_HDR_IT_OPCODE_PRED_EXEC, pred_exec_cmd_sz, isa_->GetMajorVersion());
     cmd_data[1] = PM4_PRED_EXEC_DW2_EXEC_COUNT(i - pred_exec_cmd_sz) |
                   PM4_PRED_EXEC_DW2_VIRTUALXCCID_SELECT(0x1);
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -104,6 +104,17 @@ namespace rocr {
 namespace AMD {
 const uint64_t CP_DMA_DATA_TRANSFER_CNT_MAX = (1 << 26);
 
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+static void RejectHotSwapPresentation(const std::string& reason) {
+  const std::string description =
+      "HotSwap presentation initialization failed: " + reason + ".";
+  fprintf(stderr, "HSA Error: %s\n", description.c_str());
+  // INVALID_ISA only skips this agent. Emit the diagnostic here and use a
+  // generic error to fail initialization globally.
+  throw AMD::hsa_exception(HSA_STATUS_ERROR, "");
+}
+#endif
+
 GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xnack_mode,
                    uint32_t index, core::DriverType driver_type)
     : GpuAgentInt(node, driver_type),
@@ -225,6 +236,14 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
   }
 #else
   if (PresentIsaRequested) {
+    const std::string target_env = os::GetEnvVar("HSA_HOTSWAP_TARGET");
+    const std::string override_env =
+        os::GetEnvVar("HSA_HOTSWAP_ISA_OVERRIDE");
+    std::string target_failure;
+    if (!rocr::hotswap::ValidateHotSwapPresentationTarget(
+            target_env, override_env, *isa_, target_failure))
+      RejectHotSwapPresentation(target_failure);
+
     std::string PresentName(PresentIsa);
     if (PresentName.rfind("amdgcn-amd-amdhsa--", 0) != 0)
       PresentName = "amdgcn-amd-amdhsa--" + PresentName;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_loader_context.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_loader_context.cpp
@@ -393,36 +393,15 @@ hsa_isa_t LoaderContext::IsaFromName(const char *name) {
 bool LoaderContext::IsaSupportedByAgent(hsa_agent_t agent,
                                         hsa_isa_t code_object_isa,
                                         unsigned codeGenericVersion) {
-  struct callBackData {
-    std::pair<hsa_isa_t, bool> comparison_data;
-    const unsigned int codeGenericV;
-  } cbData = {{code_object_isa, false}, codeGenericVersion};
+  const core::Agent *AgentObject = core::Agent::Convert(agent);
+  const core::Isa *CodeObjectIsa = core::Isa::Object(code_object_isa);
+  if (!AgentObject || !CodeObjectIsa) return false;
 
-  auto IsIsaEquivalent = [](hsa_isa_t agent_isa_h, void *data) {
-    assert(data);
-
-    struct callBackData *inOutCB = reinterpret_cast<decltype(&cbData)>(data);
-
-    std::pair<hsa_isa_t, bool> *data_pair = &inOutCB->comparison_data;
-    const unsigned int codeGenericV = inOutCB->codeGenericV;
-
-    assert(data_pair);
-    assert(!data_pair->second);
-
-    const core::Isa *agent_isa = core::Isa::Object(agent_isa_h);
-    assert(agent_isa);
-    const core::Isa *code_object_isa = core::Isa::Object(data_pair->first);
-    assert(code_object_isa);
-
-    data_pair->second = core::Isa::IsCompatible(*code_object_isa, *agent_isa, codeGenericV);
-    return data_pair->second ? HSA_STATUS_INFO_BREAK : HSA_STATUS_SUCCESS;
-  };
-
-  hsa_status_t status = HSA::hsa_agent_iterate_isas(agent, IsIsaEquivalent, &cbData);
-  if (status != HSA_STATUS_SUCCESS && status != HSA_STATUS_INFO_BREAK) {
-    return false;
+  for (const core::Isa *AgentIsa : AgentObject->execution_isas()) {
+    if (AgentIsa && core::Isa::IsCompatible(*CodeObjectIsa, *AgentIsa, codeGenericVersion))
+      return true;
   }
-  return cbData.comparison_data.second;
+  return false;
 }
 
 void* LoaderContext::SegmentAlloc(amdgpu_hsa_elf_segment_t segment,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_topology.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_topology.cpp
@@ -161,11 +161,11 @@ GpuAgent* DiscoverGpu(HSAuint32 node_id, HsaNodeProperties& node_prop, bool xnac
 
     // Check for sramecc incompatibility due to sramecc not being reported correctly in kfd before
     // 1.4.
-    if (gpu->supported_isas()[0]->IsSrameccSupported() &&
+    if (gpu->execution_isas()[0]->IsSrameccSupported() &&
          (kfd_version.KernelInterfaceMajorVersion <= 1 &&
               kfd_version.KernelInterfaceMinorVersion < 4)) {
       // gfx906 has both sramecc modes in use.  Suppress the device.
-      if ((gpu->supported_isas()[0]->GetProcessorName() == "gfx906") &&
+      if ((gpu->execution_isas()[0]->GetProcessorName() == "gfx906") &&
           core::Runtime::runtime_singleton_->flag().check_sramecc_validity()) {
         char name[64];
         gpu->GetInfo((hsa_agent_info_t)HSA_AMD_AGENT_INFO_PRODUCT_NAME, name);
@@ -178,7 +178,7 @@ GpuAgent* DiscoverGpu(HSAuint32 node_id, HsaNodeProperties& node_prop, bool xnac
       }
 
       // gfx908 always has sramecc set to on in vbios.  Set mode bit to on and recreate the device.
-      if (gpu->supported_isas()[0]->GetProcessorName() == "gfx908") {
+      if (gpu->execution_isas()[0]->GetProcessorName() == "gfx908") {
         node_prop.Capability.ui32.SRAM_EDCSupport = 1;
         delete gpu;
         gpu = new GpuAgent(node_id, node_prop, xnack_mode,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -41,10 +41,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "core/inc/hotswap.hpp"
+#include "core/inc/hotswap_env.hpp"
 
-#include <algorithm>
 #include <atomic>
-#include <cctype>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -128,22 +127,6 @@ enum class Gfx1250Stepping {
   kB0,
   kA0,
 };
-
-bool IsEnvFlagEnabled(const char* name) {
-  if (!os::IsEnvVarSet(name)) {
-    return false;
-  }
-
-  std::string value = os::GetEnvVar(name);
-  if (value.empty()) {
-    return false;
-  }
-
-  std::transform(value.begin(), value.end(), value.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
-  return value != "0" && value != "off" && value != "false" && value != "no" && value != "n" &&
-      value != "f";
-}
 
 bool IsHotswapDisabledByEnv() { return IsEnvFlagEnabled("HSA_HOTSWAP_DISABLE"); }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap_aql_patch.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap_aql_patch.h
@@ -1,44 +1,8 @@
-////////////////////////////////////////////////////////////////////////////////
-//
-// The University of Illinois/NCSA
-// Open Source License (NCSA)
-//
-// Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
-//
-// Developed by:
-//
-//                 AMD Research and AMD HSA Software Development
-//
-//                 Advanced Micro Devices, Inc.
-//
-//                 www.amd.com
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to
-// deal with the Software without restriction, including without limitation
-// the rights to use, copy, modify, merge, publish, distribute, sublicense,
-// and/or sell copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following conditions:
-//
-//  - Redistributions of source code must retain the above copyright notice,
-//    this list of conditions and the following disclaimers.
-//  - Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimers in
-//    the documentation and/or other materials provided with the distribution.
-//  - Neither the names of Advanced Micro Devices, Inc,
-//    nor the names of its contributors may be used to endorse or promote
-//    products derived from this Software without specific prior written
-//    permission.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-// DEALINGS WITH THE SOFTWARE.
-//
-////////////////////////////////////////////////////////////////////////////////
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 #ifndef HSA_RUNTIME_CORE_RUNTIME_HOTSWAP_AQL_PATCH_H_
 #define HSA_RUNTIME_CORE_RUNTIME_HOTSWAP_AQL_PATCH_H_

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap_aql_patch.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap_aql_patch.h
@@ -1,0 +1,135 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// The University of Illinois/NCSA
+// Open Source License (NCSA)
+//
+// Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Developed by:
+//
+//                 AMD Research and AMD HSA Software Development
+//
+//                 Advanced Micro Devices, Inc.
+//
+//                 www.amd.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+//  - Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimers.
+//  - Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimers in
+//    the documentation and/or other materials provided with the distribution.
+//  - Neither the names of Advanced Micro Devices, Inc,
+//    nor the names of its contributors may be used to endorse or promote
+//    products derived from this Software without specific prior written
+//    permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS WITH THE SOFTWARE.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef HSA_RUNTIME_CORE_RUNTIME_HOTSWAP_AQL_PATCH_H_
+#define HSA_RUNTIME_CORE_RUNTIME_HOTSWAP_AQL_PATCH_H_
+
+#include <cstdio>
+#include <cstdlib>
+
+#include "core/inc/queue.h"
+
+namespace rocr {
+namespace AMD {
+namespace hotswap {
+namespace lazy {
+
+using PrepareDispatchKernelObjectCallback = bool (*)(uint64_t*,
+                                                     uint32_t*,
+                                                     uint32_t*);
+using PacketBodyFenceCallback = void (*)();
+
+inline bool ComputeDoorbellPatchRange(uint64_t last_doorbell, uint64_t end,
+                                      uint64_t queue_size, uint64_t& first,
+                                      bool& has_work,
+                                      const char*& failure_reason) {
+  has_work = false;
+  failure_reason = nullptr;
+  if (queue_size == 0) {
+    failure_reason = "queue size is zero";
+    return false;
+  }
+
+  if (last_doorbell != UINT64_MAX && end <= last_doorbell) {
+    first = end + 1;
+    return true;
+  }
+
+  first = last_doorbell == UINT64_MAX ? 0 : last_doorbell + 1;
+  if (end - first >= queue_size) {
+    failure_reason = "doorbell range aliases the AQL ring";
+    return false;
+  }
+  has_work = true;
+  return true;
+}
+
+inline bool PatchPublishedKernelDispatchPacket(
+    core::AqlPacket& packet,
+    PrepareDispatchKernelObjectCallback prepare_kernel_object,
+    PacketBodyFenceCallback packet_body_fence) {
+  const uint16_t header =
+      __atomic_load_n(reinterpret_cast<uint16_t*>(&packet.packet.header),
+                      __ATOMIC_ACQUIRE);
+  const hsa_packet_type_t type =
+      static_cast<hsa_packet_type_t>((header >> HSA_PACKET_HEADER_TYPE) & 0xff);
+  uint64_t* kernel_object = nullptr;
+  uint32_t* private_segment_size = nullptr;
+  uint32_t* group_segment_size = nullptr;
+  if (type == HSA_PACKET_TYPE_KERNEL_DISPATCH) {
+    kernel_object = &packet.dispatch.kernel_object;
+    private_segment_size = &packet.dispatch.private_segment_size;
+    group_segment_size = &packet.dispatch.group_segment_size;
+  } else if (type == HSA_PACKET_TYPE_VENDOR_SPECIFIC &&
+             packet.ext_dispatch.amd_format ==
+                 HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH) {
+    kernel_object = &packet.ext_dispatch.kernel_object;
+    private_segment_size = &packet.ext_dispatch.private_segment_size;
+    group_segment_size = &packet.ext_dispatch.group_segment_size;
+  } else {
+    return false;
+  }
+
+  const uint16_t invalid_header =
+      HSA_PACKET_TYPE_INVALID << HSA_PACKET_HEADER_TYPE;
+  __atomic_store_n(reinterpret_cast<uint16_t*>(&packet.packet.header),
+                   invalid_header, __ATOMIC_RELEASE);
+
+  if (!prepare_kernel_object ||
+      !prepare_kernel_object(kernel_object, private_segment_size,
+                             group_segment_size)) {
+    fprintf(stderr, "hotswap: refusing kernel dispatch: packet patch failed\n");
+    std::abort();
+  }
+
+  if (packet_body_fence) packet_body_fence();
+  __atomic_store_n(reinterpret_cast<uint16_t*>(&packet.packet.header), header,
+                   __ATOMIC_RELEASE);
+  return true;
+}
+
+}  // namespace lazy
+}  // namespace hotswap
+}  // namespace AMD
+}  // namespace rocr
+
+#endif  // HSA_RUNTIME_CORE_RUNTIME_HOTSWAP_AQL_PATCH_H_

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
@@ -65,6 +65,7 @@
 #include "inc/hsa_ven_amd_aqlprofile.h"
 #include "core/inc/hsa_ext_amd_impl.h"
 #include "core/inc/hotswap.hpp"
+#include "core/inc/hotswap_env.hpp"
 #include "core/util/os.h"
 
 namespace rocr {
@@ -2145,6 +2146,11 @@ hsa_status_t LoadSizedCodeObject(
                               uri, loaded_code_object);
 }
 
+bool HotswapPresentationModeEnabled() {
+  if (hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_DISABLE")) return false;
+  return hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_PRESENT_ISA");
+}
+
 } // namespace anonymous
 
 hsa_status_t hsa_code_object_reader_create_from_file(
@@ -2366,6 +2372,12 @@ hsa_status_t hsa_executable_load_agent_code_object(
   code_object.data = reader->GetCodeObjectMemory();
   code_object.size = reader->GetCodeObjectSize();
   code_object.uri = reader->GetUri();
+
+  if (HotswapPresentationModeEnabled()) {
+    return exec->LoadCodeObject(
+        agent, {reinterpret_cast<uint64_t>(code_object.data)}, code_object.size,
+        options, code_object.uri, loaded_code_object);
+  }
 
   hotswap::LoadAgentCodeObjectCallbacks callbacks;
   callbacks.context = exec;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
@@ -2147,8 +2147,7 @@ hsa_status_t LoadSizedCodeObject(
 }
 
 bool HotswapPresentationModeEnabled() {
-  if (hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_DISABLE")) return false;
-  return hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_PRESENT_ISA");
+  return hotswap::IsPresentationModeEnabled();
 }
 
 } // namespace anonymous

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -2247,14 +2247,21 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
   const std::string presentedGfx = EnvGfxName("HSA_HOTSWAP_PRESENT_ISA");
   const bool presentationMode =
       !rocr::hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_DISABLE") && !presentedGfx.empty();
+  const std::string executionGfx = ExecutionGfxName(agent);
   std::string hotswapTargetGfx;
-  std::string hotswapTargetFailure;
-  if (!ResolveHotSwapPresentationTarget(
-          presentationMode, EnvGfxName("HSA_HOTSWAP_TARGET"),
-          EnvGfxName("HSA_HOTSWAP_ISA_OVERRIDE"), ExecutionGfxName(agent),
-          hotswapTargetGfx, hotswapTargetFailure)) {
-    logger_ << "LoaderError: " << hotswapTargetFailure << "\n";
-    return HSA_STATUS_ERROR_INVALID_ISA_NAME;
+  if (presentationMode) {
+    if (executionGfx.empty()) {
+      logger_ << "LoaderError: HotSwap target agent has no physical execution ISA\n";
+      return HSA_STATUS_ERROR_INVALID_ISA_NAME;
+    }
+    // The physical agent, not mutable environment state, is authoritative.
+    hotswapTargetGfx = executionGfx;
+  } else {
+    hotswapTargetGfx = EnvGfxName("HSA_HOTSWAP_TARGET");
+    if (hotswapTargetGfx.empty())
+      hotswapTargetGfx = EnvGfxName("HSA_HOTSWAP_ISA_OVERRIDE");
+    if (hotswapTargetGfx.empty() || hotswapTargetGfx == "1")
+      hotswapTargetGfx = executionGfx;
   }
 
   if (CurrentHotSwapLoadingTranslatedTarget) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -199,8 +199,9 @@ void RegisterHotSwapRocrBlitTargetKernelObject(uint64_t address,
   std::shared_ptr<HotSwapKernelRecord> Record =
       HotSwapKernelRegistryInstance().RegisterRocrBlitTargetKernelObject(
           address, size, TargetGfx, Reason, InvalidReason);
-  const bool HasTargetIsa =
-      Record->Kind == HotSwapKernelKind::RuntimeTargetInternal;
+  const HotSwapKernelKind Kind =
+      Record->Kind.load(std::memory_order_acquire);
+  const bool HasTargetIsa = Kind == HotSwapKernelKind::RuntimeTargetInternal;
 
   std::ostringstream proof;
   proof << "\"event\":\"hotswap_runtime_target_internal_registered\""
@@ -887,6 +888,7 @@ static bool LoadLazyTranslatedKernel(std::shared_ptr<HotSwapKernelRecord> record
         HotSwapRuntimeLifetimeTranslatedExecutablesMutex());
     HotSwapRuntimeLifetimeTranslatedExecutables().push_back(std::move(targetExec));
   }
+  record->Kind.store(HotSwapKernelKind::Translated, std::memory_order_release);
   if (comgrResult.handle) {
     AppendHotSwapComgrProof("hotswap_result", comgrResult, targetBytes.size());
     amd_comgr_destroy_hotswap_transpile_result(comgrResult);
@@ -922,6 +924,31 @@ static bool LoadLazyTranslatedKernel(std::shared_ptr<HotSwapKernelRecord> record
   std::abort();
 }
 
+// Applies the translated-target rewrite at dispatch time and preserves the
+// existing fail-closed diagnostics and proof logging on any patch failure.
+static void PatchHotSwapDispatchToTargetOrAbort(
+    const std::shared_ptr<HotSwapKernelRecord>& record, uint64_t* address,
+    uint32_t* private_segment_size, uint32_t* group_segment_size,
+    HotSwapKernelKind kind) {
+  const uint64_t sourceKernelObject = *address;
+  std::string segmentFailure;
+  if (!PatchHotSwapTranslatedDispatch(
+          *record, *address, *private_segment_size, *group_segment_size,
+          segmentFailure))
+    FatalHotSwapDispatch(sourceKernelObject, record->Name, kind, segmentFailure);
+
+  std::ostringstream proof;
+  proof << "\"event\":\"hotswap_lazy_dispatch_patch\""
+        << ",\"kernel_name\":\"" << JsonEscape(record->Name) << "\""
+        << ",\"source_kernel_object\":\"0x" << std::hex << sourceKernelObject
+        << "\""
+        << ",\"target_kernel_object\":\"0x" << record->TargetKernelObject
+        << "\"" << std::dec
+        << ",\"private_segment_size\":" << *private_segment_size
+        << ",\"group_segment_size\":" << *group_segment_size;
+  AppendHotSwapProofJson(proof.str());
+}
+
 // Dispatch-time hook invoked by the AQL doorbell intercept for each dispatched
 // kernel. Given the packet's kernel_object it looks up the HotSwap record and, on
 // success, rewrites *address (and the segment sizes) to the translated target
@@ -941,13 +968,17 @@ bool PrepareHotSwapDispatchKernelObject(uint64_t* address,
     FatalHotSwapDispatch(*address, "", HotSwapKernelKind::Untranslated,
                          "unregistered kernel object");
 
-  if (record->Kind == HotSwapKernelKind::Translated) {
+  HotSwapKernelKind kind = record->Kind.load(std::memory_order_acquire);
+  if (kind == HotSwapKernelKind::Translated) {
+    if (record->TargetKernelObject != 0)
+      PatchHotSwapDispatchToTargetOrAbort(record, address, private_segment_size,
+                                          group_segment_size, kind);
     return true;
   }
 
-  if (record->Kind == HotSwapKernelKind::RuntimeTargetInternal) {
+  if (kind == HotSwapKernelKind::RuntimeTargetInternal) {
     if (!record->IsRegisteredRocrBlit(*address))
-      FatalHotSwapDispatch(*address, record->Name, record->Kind,
+      FatalHotSwapDispatch(*address, record->Name, kind,
                            "runtime target-internal kernel is not a registered ROCR blit shader",
                            record->SourceKind, record->TargetGfx);
 
@@ -967,8 +998,8 @@ bool PrepareHotSwapDispatchKernelObject(uint64_t* address,
     return true;
   }
 
-  if (record->Kind != HotSwapKernelKind::LazySource)
-    FatalHotSwapDispatch(*address, record->Name, record->Kind,
+  if (kind != HotSwapKernelKind::LazySource)
+    FatalHotSwapDispatch(*address, record->Name, kind,
                          record->Failure.empty()
                              ? "kernel object is not translated"
                              : record->Failure,
@@ -983,37 +1014,18 @@ bool PrepareHotSwapDispatchKernelObject(uint64_t* address,
     // than letting a bad dispatch escape to hardware.
     if (!LoadLazyTranslatedKernel(record, failure)) {
       record->Failure = failure;
-      FatalHotSwapDispatch(*address, record->Name, record->Kind, failure);
+      FatalHotSwapDispatch(*address, record->Name, kind, failure);
     }
   }
   if (!record->TranslationSucceeded || record->TargetKernelObject == 0)
-    FatalHotSwapDispatch(*address, record->Name, record->Kind,
+    FatalHotSwapDispatch(*address, record->Name, kind,
                          record->Failure.empty()
                              ? "lazy translation did not produce a target kernel"
                              : record->Failure);
 
-  uint32_t patchedPrivateSegmentSize = 0;
-  uint32_t patchedGroupSegmentSize = 0;
-  std::string segmentFailure;
-  if (!ComputeHotSwapPatchedSegmentSizes(
-          *record, *private_segment_size, *group_segment_size,
-          patchedPrivateSegmentSize, patchedGroupSegmentSize, segmentFailure))
-    FatalHotSwapDispatch(*address, record->Name, record->Kind, segmentFailure);
-
-  const uint64_t sourceKernelObject = *address;
-  *address = record->TargetKernelObject;
-  *private_segment_size = patchedPrivateSegmentSize;
-  *group_segment_size = patchedGroupSegmentSize;
-
-  std::ostringstream proof;
-  proof << "\"event\":\"hotswap_lazy_dispatch_patch\""
-        << ",\"kernel_name\":\"" << JsonEscape(record->Name) << "\""
-        << ",\"source_kernel_object\":\"0x" << std::hex << sourceKernelObject << "\""
-        << ",\"target_kernel_object\":\"0x" << record->TargetKernelObject << "\""
-        << std::dec
-        << ",\"private_segment_size\":" << *private_segment_size
-        << ",\"group_segment_size\":" << *group_segment_size;
-  AppendHotSwapProofJson(proof.str());
+  kind = record->Kind.load(std::memory_order_acquire);
+  PatchHotSwapDispatchToTargetOrAbort(record, address, private_segment_size,
+                                      group_segment_size, kind);
 
   return true;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -246,11 +246,7 @@ static void UpdateHotSwapKernelObjectLaunchMetadata(uint64_t address,
 // (HSA_HOTSWAP_PRESENT_ISA set and HotSwap not disabled). When false every
 // HotSwap check below short-circuits and the runtime behaves as it does today.
 bool ShouldCheckHotSwapDispatchKernelObjects() {
-  static const bool Enabled = [] {
-    if (rocr::hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_DISABLE")) return false;
-    return rocr::hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_PRESENT_ISA");
-  }();
-  return Enabled;
+  return rocr::hotswap::IsPresentationModeEnabled();
 }
 
 #endif

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -51,14 +51,20 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdlib>
 #include <cstring>
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <atomic>
 #include <fstream>
+#include <mutex>
 #include "inc/amd_hsa_elf.h"
 #include "inc/amd_hsa_kernel_code.h"
+#include "core/inc/agent.h"
 #include "core/inc/amd_hsa_code.hpp"
+#include "core/inc/amd_loader_context.hpp"
+#include "core/inc/hotswap_env.hpp"
 #include "amd_hsa_code_util.hpp"
 #include "amd_options.hpp"
 #include "core/util/utils.h"
@@ -66,6 +72,11 @@
 #include "executable.hpp"
 
 #include "AMDHSAKernelDescriptor.h"
+
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+#include "amd_comgr.h"
+#include "hotswap_kernel_registry.h"
+#endif
 
 using namespace rocr::amd::hsa;
 using namespace rocr::amd::hsa::common;
@@ -105,6 +116,144 @@ void _loader_debug_state() {
 namespace amd {
 namespace hsa {
 namespace loader {
+
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+static std::string JsonEscape(const std::string& s);
+static void AppendHotSwapProofJson(const std::string& fields);
+static void RegisterHotSwapKernelObject(uint64_t address, const std::string& name,
+                                        HotSwapKernelKind kind);
+
+// A source-ISA code object whose translation is deferred until first dispatch.
+// It retains everything COMGR needs to translate an individual kernel later:
+// the source ELF, the source/target ISA names, and the target agent/profile.
+struct HotSwapLazyCodeObject {
+  std::vector<uint8_t> SourceElf;
+  std::string SourceIsa;
+  std::string TargetIsa;
+  std::string SourceGfx;
+  std::string TargetGfx;
+  uint8_t SourceMach = 0;
+  hsa_agent_t Agent = {};
+  hsa_profile_t Profile = HSA_PROFILE_FULL;
+};
+
+namespace {
+
+HotSwapKernelRegistry& HotSwapKernelRegistryInstance() {
+  static auto* Registry = new HotSwapKernelRegistry();
+  return *Registry;
+}
+
+std::vector<std::shared_ptr<ExecutableImpl>>&
+HotSwapRuntimeLifetimeTranslatedExecutables() {
+  // Translated one-kernel code objects back AQL packet kernel descriptors.
+  // Queue packets and runtime teardown can outlive the source loaded-code-object
+  // destruction point, so these private target code objects are owned for the
+  // runtime lifetime instead of by source-symbol registry entries.
+  static auto* Executables = new std::vector<std::shared_ptr<ExecutableImpl>>();
+  return *Executables;
+}
+
+std::mutex& HotSwapRuntimeLifetimeTranslatedExecutablesMutex() {
+  static auto* Mutex = new std::mutex();
+  return *Mutex;
+}
+
+// Lazy target executables are owned by HotSwap's runtime-lifetime list, not by
+// AmdHsaCodeLoader::executables, so give them an ID outside the loader index
+// namespace.
+constexpr size_t HotSwapRuntimeTranslatedExecutableId = static_cast<size_t>(-1);
+
+thread_local HotSwapKernelKind CurrentHotSwapKernelKind =
+    HotSwapKernelKind::Untranslated;
+thread_local std::shared_ptr<HotSwapLazyCodeObject> CurrentHotSwapLazyCodeObject;
+thread_local bool CurrentHotSwapLoadingTranslatedTarget = false;
+
+void RegisterHotSwapLoadedKernelObject(uint64_t address,
+                                       const std::string& name) {
+  if (!ShouldCheckHotSwapDispatchKernelObjects()) return;
+  RegisterHotSwapKernelObject(address, name, CurrentHotSwapKernelKind);
+}
+
+}  // namespace
+
+static void RegisterHotSwapKernelObject(uint64_t address, const std::string& name,
+                                        HotSwapKernelKind kind) {
+  HotSwapKernelRegistryInstance().RegisterKernelObject(
+      address, name, kind, CurrentHotSwapLazyCodeObject);
+}
+
+// Registers ROCr's own blit shaders, which are already built for the execution
+// ISA, as target kernels so the dispatch intercept passes them through unchanged
+// instead of trying to translate them.
+void RegisterHotSwapRocrBlitTargetKernelObject(uint64_t address,
+                                               size_t size,
+                                               const char* target_gfx) {
+  if (!ShouldCheckHotSwapDispatchKernelObjects()) return;
+  std::string TargetGfx = target_gfx ? std::string(target_gfx) : std::string();
+  const std::string Name = "rocr_blit";
+  const std::string SourceKind = "rocr_blit";
+  const std::string Reason = "embedded_rocr_target_blit_shader";
+  const std::string InvalidReason =
+      "rocr_blit target ISA or allocation could not be identified";
+  std::shared_ptr<HotSwapKernelRecord> Record =
+      HotSwapKernelRegistryInstance().RegisterRocrBlitTargetKernelObject(
+          address, size, TargetGfx, Reason, InvalidReason);
+  const bool HasTargetIsa =
+      Record->Kind == HotSwapKernelKind::RuntimeTargetInternal;
+
+  std::ostringstream proof;
+  proof << "\"event\":\"hotswap_runtime_target_internal_registered\""
+        << ",\"kernel_name\":\"" << JsonEscape(Name) << "\""
+        << ",\"kernel_object\":\"0x" << std::hex << address << "\""
+        << std::dec
+        << ",\"object_size\":" << size
+        << ",\"kind\":\"" << HotSwapKernelKindName(
+                                 HasTargetIsa ? HotSwapKernelKind::RuntimeTargetInternal
+                                              : HotSwapKernelKind::Untranslated)
+        << "\""
+        << ",\"source_kind\":\"" << JsonEscape(SourceKind) << "\"";
+  if (!TargetGfx.empty())
+    proof << ",\"target_gfx\":\"" << JsonEscape(TargetGfx) << "\"";
+  proof << ",\"reason\":\""
+        << JsonEscape(HasTargetIsa ? Reason
+                                   : InvalidReason)
+        << "\"";
+  AppendHotSwapProofJson(proof.str());
+}
+
+void UnregisterHotSwapRocrBlitTargetKernelObject(uint64_t address) {
+  if (!ShouldCheckHotSwapDispatchKernelObjects()) return;
+  HotSwapKernelRegistryInstance().UnregisterRocrBlitTargetKernelObject(address);
+}
+
+static void UnregisterHotSwapKernelObject(uint64_t address) {
+  HotSwapKernelRegistryInstance().UnregisterLoadedKernelObject(address);
+}
+
+static std::shared_ptr<HotSwapKernelRecord> LookupHotSwapKernelRecord(uint64_t address) {
+  return HotSwapKernelRegistryInstance().Lookup(address);
+}
+
+static void UpdateHotSwapKernelObjectLaunchMetadata(uint64_t address,
+                                                    uint32_t groupSegmentSize,
+                                                    uint32_t privateSegmentSize) {
+  HotSwapKernelRegistryInstance().UpdateLaunchMetadata(
+      address, groupSegmentSize, privateSegmentSize);
+}
+
+// Master gate for the dispatch-time intercept: true only in presentation mode
+// (HSA_HOTSWAP_PRESENT_ISA set and HotSwap not disabled). When false every
+// HotSwap check below short-circuits and the runtime behaves as it does today.
+bool ShouldCheckHotSwapDispatchKernelObjects() {
+  static const bool Enabled = [] {
+    if (rocr::hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_DISABLE")) return false;
+    return rocr::hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_PRESENT_ISA");
+  }();
+  return Enabled;
+}
+
+#endif
 
 class LoaderOptions {
 public:
@@ -280,6 +429,606 @@ static bool CodeObjectIsaIsGfx125Family(const std::string& codeIsa) {
   if (codeIsa.find("gfx12-5-generic") != std::string::npos) return true;
   return codeIsa.find("gfx125") != std::string::npos;
 }
+
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+static std::string JsonEscape(const std::string& s) {
+  std::ostringstream os;
+  for (char c : s) {
+    switch (c) {
+      case '\\':
+        os << "\\\\";
+        break;
+      case '"':
+        os << "\\\"";
+        break;
+      case '\n':
+        os << "\\n";
+        break;
+      case '\r':
+        os << "\\r";
+        break;
+      case '\t':
+        os << "\\t";
+        break;
+      default:
+        if (static_cast<unsigned char>(c) < 0x20) {
+          os << "\\u" << std::hex << std::setw(4) << std::setfill('0')
+             << static_cast<unsigned>(static_cast<unsigned char>(c)) << std::dec
+             << std::setfill(' ');
+        } else {
+          os << c;
+        }
+    }
+  }
+  return os.str();
+}
+
+// Appends one JSON object (the given comma-separated fields) as a line to the
+// file named by HSA_HOTSWAP_PROOF_LOG. Best-effort and inert when unset; used to
+// prove which kernels were translated/dispatched during a run.
+static void AppendHotSwapProofJson(const std::string& jsonFields) {
+  const char* path = std::getenv("HSA_HOTSWAP_PROOF_LOG");
+  if (!path || !path[0]) return;
+  static std::mutex ProofLogMutex;
+  std::lock_guard<std::mutex> Guard(ProofLogMutex);
+  std::ofstream out(path, std::ios::app);
+  if (!out) {
+    std::cerr << "hotswap: failed to open proof log '" << path << "' for append\n";
+    return;
+  }
+  out << "{" << jsonFields << "}\n";
+  if (!out) {
+    std::cerr << "hotswap: failed to write proof log '" << path << "'\n";
+  }
+}
+
+// Returns the trailing gfx processor token (e.g. "gfx1250") from an ISA name, or
+// "" if none is present.
+static std::string ExtractGfxName(const std::string& isa) {
+  size_t pos = isa.rfind("gfx");
+  if (pos == std::string::npos) return "";
+  size_t end = pos + 3;
+  while (end < isa.size() &&
+         ((isa[end] >= '0' && isa[end] <= '9') || (isa[end] >= 'a' && isa[end] <= 'z'))) {
+    ++end;
+  }
+  return isa.substr(pos, end - pos);
+}
+
+// Returns the gfx name of the agent's physical execution ISA (what the hardware
+// actually runs), which may differ from the ISA presented to the application.
+static std::string ExecutionGfxName(hsa_agent_t agent) {
+  if (agent.handle == 0) return "";
+  const rocr::core::Agent* agent_object = rocr::core::Agent::Convert(agent);
+  if (!agent_object || agent_object->execution_isas().empty()) return "";
+  return agent_object->execution_isas()[0]->GetProcessorName();
+}
+
+// Reports the target agent's per-workgroup LDS (group segment) capacity so a
+// translated kernel's group-segment usage can be validated before dispatch.
+// Returns false with a reason in `failure` if it cannot be determined.
+static bool GetAgentGroupSegmentLimit(hsa_agent_t agent, uint32_t& limit,
+                                      std::string& failure) {
+  limit = 0;
+  if (agent.handle == 0) {
+    failure = "translated HotSwap kernel has no target agent";
+    return false;
+  }
+  const rocr::core::Agent* agent_object = rocr::core::Agent::Convert(agent);
+  if (!agent_object) {
+    failure = "translated HotSwap target agent is invalid";
+    return false;
+  }
+  // HSA exposes the per-workgroup LDS capacity as the agent's group segment.
+  for (const auto& region : agent_object->regions()) {
+    if (!region) continue;
+    hsa_region_segment_t segment = HSA_REGION_SEGMENT_READONLY;
+    if (region->GetInfo(HSA_REGION_INFO_SEGMENT, &segment) != HSA_STATUS_SUCCESS ||
+        segment != HSA_REGION_SEGMENT_GROUP)
+      continue;
+    size_t size = 0;
+    if (region->GetInfo(HSA_REGION_INFO_SIZE, &size) == HSA_STATUS_SUCCESS) {
+      limit = size > UINT32_MAX ? UINT32_MAX : static_cast<uint32_t>(size);
+      return true;
+    }
+  }
+  failure = "translated HotSwap target agent has no LDS region";
+  return false;
+}
+
+static std::string EnvGfxName(const char* name) {
+  const char* env = std::getenv(name);
+  if (!env || !env[0] || std::strcmp(env, "0") == 0) return "";
+  if (std::strcmp(env, "1") == 0) return "1";
+  std::string gfx = ExtractGfxName(env);
+  if (gfx.empty() && std::strncmp(env, "gfx", 3) == 0) gfx = env;
+  return gfx;
+}
+
+// Debug aid: writes each incoming (pre-translation) code object to
+// HSA_HOTSWAP_INPUT_DUMP_DIR. Inert unless that variable is set.
+static void DumpHotSwapInputCodeObject(const void* elfData, size_t elfSize, uint32_t codeNum,
+                                       const std::string& codeIsa) {
+  const char* DumpDir = std::getenv("HSA_HOTSWAP_INPUT_DUMP_DIR");
+  if (!DumpDir || !DumpDir[0] || !elfData || elfSize == 0) return;
+
+  std::string Gfx = ExtractGfxName(codeIsa);
+  if (Gfx.empty()) Gfx = "unknown";
+  std::ostringstream Path;
+  Path << DumpDir << "/hotswap_input_" << std::setfill('0') << std::setw(5) << codeNum << "_" << Gfx
+       << ".co";
+  std::ofstream Out(Path.str(), std::ios::binary | std::ios::trunc);
+  if (!Out) return;
+  Out.write(reinterpret_cast<const char*>(elfData), elfSize);
+}
+
+static const char* LookupStatusString(amd_comgr_hotswap_cache_lookup_status_t status) {
+  switch (status) {
+    case AMD_COMGR_HOTSWAP_CACHE_LOOKUP_DISABLED:
+      return "disabled";
+    case AMD_COMGR_HOTSWAP_CACHE_LOOKUP_BYPASSED:
+      return "bypassed";
+    case AMD_COMGR_HOTSWAP_CACHE_LOOKUP_MISS:
+      return "miss";
+    case AMD_COMGR_HOTSWAP_CACHE_LOOKUP_HIT:
+      return "hit";
+    case AMD_COMGR_HOTSWAP_CACHE_LOOKUP_INVALID:
+      return "invalid";
+  }
+  return "invalid";
+}
+
+static const char* WriteStatusString(amd_comgr_hotswap_cache_write_status_t status) {
+  switch (status) {
+    case AMD_COMGR_HOTSWAP_CACHE_WRITE_NOT_ATTEMPTED:
+      return "not_attempted";
+    case AMD_COMGR_HOTSWAP_CACHE_WRITE_SUCCESS:
+      return "success";
+    case AMD_COMGR_HOTSWAP_CACHE_WRITE_FAILED:
+      return "failed";
+  }
+  return "failed";
+}
+
+static bool GetComgrResultString(amd_comgr_hotswap_transpile_result_t result,
+                                 amd_comgr_hotswap_transpile_result_string_t field,
+                                 std::string& out) {
+  size_t size = 0;
+  amd_comgr_status_t status =
+      amd_comgr_hotswap_transpile_result_get_string(result, field, &size, nullptr);
+  if (status != AMD_COMGR_STATUS_SUCCESS) return false;
+  out.assign(size, '\0');
+  status = amd_comgr_hotswap_transpile_result_get_string(result, field, &size, out.data());
+  if (status != AMD_COMGR_STATUS_SUCCESS) return false;
+  if (!out.empty() && out.back() == '\0') out.pop_back();
+  return true;
+}
+
+template <typename T>
+static bool GetComgrResultInfo(amd_comgr_hotswap_transpile_result_t result,
+                               amd_comgr_hotswap_transpile_result_info_t info, T& value) {
+  return amd_comgr_hotswap_transpile_result_get_info(result, info, &value) ==
+      AMD_COMGR_STATUS_SUCCESS;
+}
+
+static void AppendHotSwapComgrProof(const char* event, amd_comgr_hotswap_transpile_result_t result,
+                                    size_t elfSize = 0, const char* overrideFailReason = nullptr,
+                                    const char* overrideFailDetail = nullptr) {
+  const char* path = std::getenv("HSA_HOTSWAP_PROOF_LOG");
+  if (!path || !path[0]) return;
+
+  bool success = false;
+  bool cacheHit = false;
+  int64_t lifted = 0;
+  int64_t total = 0;
+  amd_comgr_hotswap_cache_lookup_status_t lookupStatus = AMD_COMGR_HOTSWAP_CACHE_LOOKUP_DISABLED;
+  amd_comgr_hotswap_cache_write_status_t writeStatus = AMD_COMGR_HOTSWAP_CACHE_WRITE_NOT_ATTEMPTED;
+  std::string backend, sourceGfx, targetGfx, cacheKey, cacheDetail, kernelName;
+  std::string cacheMetadata, cacheObject, failReason, failDetail;
+
+  if (!GetComgrResultInfo(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_SUCCESS, success) ||
+      !GetComgrResultInfo(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_CACHE_HIT, cacheHit) ||
+      !GetComgrResultInfo(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_CACHE_LOOKUP, lookupStatus) ||
+      !GetComgrResultInfo(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_CACHE_WRITE, writeStatus) ||
+      !GetComgrResultInfo(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_LIFTED_COUNT, lifted) ||
+      !GetComgrResultInfo(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_TOTAL_COUNT, total) ||
+      !GetComgrResultString(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_BACKEND, backend) ||
+      !GetComgrResultString(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_SOURCE_GFX, sourceGfx) ||
+      !GetComgrResultString(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_TARGET_GFX, targetGfx) ||
+      !GetComgrResultString(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_CACHE_KEY, cacheKey) ||
+      !GetComgrResultString(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_CACHE_DETAIL, cacheDetail) ||
+      !GetComgrResultString(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_CACHE_METADATA_PATH,
+                            cacheMetadata) ||
+      !GetComgrResultString(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_CACHE_OBJECT_PATH,
+                            cacheObject) ||
+      !GetComgrResultString(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_FAIL_REASON, failReason) ||
+      !GetComgrResultString(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_FAIL_DETAIL, failDetail) ||
+      !GetComgrResultString(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_KERNEL_NAME,
+                            kernelName)) {
+    std::cerr << "hotswap: failed to query COMGR result metadata\n";
+    return;
+  }
+
+  if (overrideFailReason) {
+    success = false;
+    failReason = overrideFailReason;
+    failDetail = overrideFailDetail ? overrideFailDetail : "";
+  }
+
+  std::ostringstream proof;
+  proof << "\"event\":\"" << event << "\""
+        << ",\"backend\":\"" << JsonEscape(backend) << "\""
+        << ",\"source_gfx\":\"" << JsonEscape(sourceGfx) << "\""
+        << ",\"target_gfx\":\"" << JsonEscape(targetGfx) << "\""
+        << ",\"success\":" << (success ? "true" : "false")
+        << ",\"cache_hit\":" << (cacheHit ? "true" : "false") << ",\"cache_status\":\""
+        << LookupStatusString(lookupStatus) << "\""
+        << ",\"cache_write_status\":\"" << WriteStatusString(writeStatus) << "\""
+        << ",\"lifted_count\":" << lifted << ",\"total_count\":" << total;
+  if (elfSize > 0) proof << ",\"elf_size\":" << elfSize;
+  if (!cacheKey.empty()) proof << ",\"cache_key\":\"" << JsonEscape(cacheKey) << "\"";
+  if (!cacheMetadata.empty())
+    proof << ",\"cache_metadata\":\"" << JsonEscape(cacheMetadata) << "\"";
+  if (!cacheObject.empty()) proof << ",\"cache_object\":\"" << JsonEscape(cacheObject) << "\"";
+  if (!cacheDetail.empty()) proof << ",\"cache_detail\":\"" << JsonEscape(cacheDetail) << "\"";
+  if (!kernelName.empty()) proof << ",\"kernel_name\":\"" << JsonEscape(kernelName) << "\"";
+  if (!failReason.empty()) proof << ",\"fail_reason\":\"" << JsonEscape(failReason) << "\"";
+  if (!failDetail.empty()) proof << ",\"fail_detail\":\"" << JsonEscape(failDetail) << "\"";
+  AppendHotSwapProofJson(proof.str());
+}
+
+static void LogComgrCacheDebug(amd_comgr_hotswap_transpile_result_t result) {
+  const char* cacheDebug = std::getenv("HSA_HOTSWAP_CACHE_DEBUG");
+  if (!cacheDebug || !cacheDebug[0]) return;
+  amd_comgr_hotswap_cache_lookup_status_t lookupStatus = AMD_COMGR_HOTSWAP_CACHE_LOOKUP_DISABLED;
+  std::string sourceGfx, targetGfx;
+  if (!GetComgrResultInfo(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_CACHE_LOOKUP, lookupStatus) ||
+      !GetComgrResultString(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_SOURCE_GFX, sourceGfx) ||
+      !GetComgrResultString(result, AMD_COMGR_HOTSWAP_TRANSPILE_RESULT_TARGET_GFX, targetGfx))
+    return;
+  std::cerr << "hotswap_cache: " << LookupStatusString(lookupStatus) << " (" << sourceGfx << " -> "
+            << targetGfx << ")\n";
+}
+
+static bool LoadLazyTranslatedKernel(std::shared_ptr<HotSwapKernelRecord> record,
+                                     std::string& failure) {
+  std::shared_ptr<HotSwapLazyCodeObject> lazy = record->LazyCodeObject;
+  if (!lazy) {
+    failure = "lazy source record has no source code object";
+    return false;
+  }
+
+  amd_comgr_data_t comgrInput = {0};
+  amd_comgr_status_t comgrStatus =
+      amd_comgr_create_data(AMD_COMGR_DATA_KIND_EXECUTABLE, &comgrInput);
+  if (comgrStatus != AMD_COMGR_STATUS_SUCCESS) {
+    failure = "COMGR failed to create HotSwap input data";
+    return false;
+  }
+
+  comgrStatus = amd_comgr_set_data(
+      comgrInput, lazy->SourceElf.size(),
+      reinterpret_cast<const char*>(lazy->SourceElf.data()));
+  if (comgrStatus != AMD_COMGR_STATUS_SUCCESS) {
+    amd_comgr_release_data(comgrInput);
+    failure = "COMGR failed to set HotSwap input data";
+    return false;
+  }
+
+  amd_comgr_data_t comgrOutput = {0};
+  amd_comgr_hotswap_transpile_result_t comgrResult = {0};
+  amd_comgr_hotswap_transpile_options_v2_t comgrOptions = {};
+  const std::string lazyCacheDir = ResolveLazyHotSwapCacheDir(
+      std::getenv("HSA_HOTSWAP_LAZY_CACHE_DIR"),
+      std::getenv("HSA_HOTSWAP_CACHE_DIR"));
+  comgrOptions.version = AMD_COMGR_HOTSWAP_TRANSPILE_OPTIONS_VERSION_2;
+  comgrOptions.cache_directory = lazyCacheDir.empty() ? nullptr : lazyCacheDir.c_str();
+  comgrOptions.cache_skip_kernels = std::getenv("HSA_HOTSWAP_CACHE_SKIP_KERNELS");
+  comgrOptions.hotswap_rules_path = std::getenv("HSA_HOTSWAP_RULES");
+  comgrOptions.kernel_name = record->Name.c_str();
+  comgrOptions.flags |= AMD_COMGR_HOTSWAP_TRANSPILE_OPTIONS_V2_USE_KERNEL_NAME;
+  if (rocr::hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_CACHE_DISABLE"))
+    comgrOptions.flags |= AMD_COMGR_HOTSWAP_TRANSPILE_OPTIONS_V2_CACHE_DISABLE;
+  if (rocr::hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_CACHE_READONLY"))
+    comgrOptions.flags |= AMD_COMGR_HOTSWAP_TRANSPILE_OPTIONS_V2_CACHE_READONLY;
+  if (rocr::hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_STRICT"))
+    comgrOptions.flags |= AMD_COMGR_HOTSWAP_TRANSPILE_OPTIONS_V2_STRICT;
+  if (rocr::hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_ASSUME_GLOBAL_OFFSET_ZERO") ||
+      rocr::hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_ASSUME_HIP_GLOBAL_OFFSET_ZERO"))
+    comgrOptions.flags |=
+        AMD_COMGR_HOTSWAP_TRANSPILE_OPTIONS_V2_ASSUME_HIP_GLOBAL_OFFSET_ZERO;
+  comgrStatus = amd_comgr_hotswap_transpile_with_options_v2(
+      comgrInput, lazy->SourceIsa.c_str(), lazy->TargetIsa.c_str(), &comgrOptions,
+      &comgrOutput, &comgrResult);
+  amd_comgr_release_data(comgrInput);
+
+  if (comgrResult.handle) {
+    AppendHotSwapComgrProof("hotswap_cache", comgrResult);
+    LogComgrCacheDebug(comgrResult);
+  }
+
+  if (comgrStatus != AMD_COMGR_STATUS_SUCCESS) {
+    failure = "COMGR HotSwap per-kernel transpilation failed for " + record->Name;
+    if (comgrResult.handle) {
+      AppendHotSwapComgrProof("hotswap_result", comgrResult);
+      amd_comgr_destroy_hotswap_transpile_result(comgrResult);
+    }
+    if (comgrOutput.handle) amd_comgr_release_data(comgrOutput);
+    return false;
+  }
+
+  size_t comgrOutputSize = 0;
+  comgrStatus = amd_comgr_get_data(comgrOutput, &comgrOutputSize, nullptr);
+  if (comgrStatus != AMD_COMGR_STATUS_SUCCESS || comgrOutputSize == 0) {
+    amd_comgr_release_data(comgrOutput);
+    if (comgrResult.handle) {
+      AppendHotSwapComgrProof("hotswap_result", comgrResult, 0,
+                              "comgr_empty_output",
+                              "COMGR produced no translated HSACO bytes");
+      amd_comgr_destroy_hotswap_transpile_result(comgrResult);
+    }
+    failure = "COMGR produced no translated HSACO bytes for " + record->Name;
+    return false;
+  }
+
+  std::vector<uint8_t> targetBytes(comgrOutputSize, 0);
+  comgrStatus = amd_comgr_get_data(
+      comgrOutput, &comgrOutputSize, reinterpret_cast<char*>(targetBytes.data()));
+  amd_comgr_release_data(comgrOutput);
+  if (comgrStatus != AMD_COMGR_STATUS_SUCCESS) {
+    if (comgrResult.handle) {
+      AppendHotSwapComgrProof("hotswap_result", comgrResult, 0,
+                              "comgr_read_output",
+                              "COMGR translated HSACO read failed");
+      amd_comgr_destroy_hotswap_transpile_result(comgrResult);
+    }
+    failure = "failed to read COMGR translated HSACO for " + record->Name;
+    return false;
+  }
+
+  auto targetExec = std::make_shared<ExecutableImpl>(
+      lazy->Profile, std::make_unique<rocr::amd::LoaderContext>(),
+      HotSwapRuntimeTranslatedExecutableId,
+      HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT);
+  hsa_code_object_t targetCodeObject = {
+      reinterpret_cast<uint64_t>(targetBytes.data())};
+  const bool previousTargetLoad = CurrentHotSwapLoadingTranslatedTarget;
+  CurrentHotSwapLoadingTranslatedTarget = true;
+  hsa_status_t status = targetExec->LoadCodeObject(
+      lazy->Agent, targetCodeObject, nullptr, "hotswap-lazy-kernel", nullptr);
+  CurrentHotSwapLoadingTranslatedTarget = previousTargetLoad;
+  if (status != HSA_STATUS_SUCCESS) {
+    failure = "ROCR failed to load translated HotSwap kernel " + record->Name;
+    if (comgrResult.handle) {
+      AppendHotSwapComgrProof("hotswap_result", comgrResult, targetBytes.size(),
+                              "target_load_failed", failure.c_str());
+      amd_comgr_destroy_hotswap_transpile_result(comgrResult);
+    }
+    return false;
+  }
+  status = targetExec->Freeze(nullptr);
+  if (status != HSA_STATUS_SUCCESS) {
+    failure = "ROCR failed to freeze translated HotSwap kernel " + record->Name;
+    if (comgrResult.handle) {
+      AppendHotSwapComgrProof("hotswap_result", comgrResult, targetBytes.size(),
+                              "target_freeze_failed", failure.c_str());
+      amd_comgr_destroy_hotswap_transpile_result(comgrResult);
+    }
+    return false;
+  }
+
+  std::string targetSymbolName = record->Name + ".kd";
+  Symbol* symbol = targetExec->GetSymbol(targetSymbolName.c_str(), &lazy->Agent);
+  if (!symbol) {
+    failure = "translated HotSwap kernel symbol not found: " + targetSymbolName;
+    if (comgrResult.handle) {
+      AppendHotSwapComgrProof("hotswap_result", comgrResult, targetBytes.size(),
+                              "target_symbol_missing", failure.c_str());
+      amd_comgr_destroy_hotswap_transpile_result(comgrResult);
+    }
+    return false;
+  }
+
+  uint64_t targetKernelObject = 0;
+  uint32_t targetPrivateSegmentSize = 0;
+  uint32_t targetGroupSegmentSize = 0;
+  if (!symbol->GetInfo(HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_OBJECT,
+                       &targetKernelObject) ||
+      !symbol->GetInfo(HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_PRIVATE_SEGMENT_SIZE,
+                       &targetPrivateSegmentSize) ||
+      !symbol->GetInfo(HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_GROUP_SEGMENT_SIZE,
+                       &targetGroupSegmentSize) ||
+      targetKernelObject == 0) {
+    failure = "translated HotSwap kernel metadata missing: " + record->Name;
+    if (comgrResult.handle) {
+      AppendHotSwapComgrProof("hotswap_result", comgrResult, targetBytes.size(),
+                              "target_metadata_missing", failure.c_str());
+      amd_comgr_destroy_hotswap_transpile_result(comgrResult);
+    }
+    return false;
+  }
+
+  uint32_t targetGroupSegmentLimit = 0;
+  if (!GetAgentGroupSegmentLimit(lazy->Agent, targetGroupSegmentLimit, failure)) {
+    if (comgrResult.handle) {
+      AppendHotSwapComgrProof("hotswap_result", comgrResult, targetBytes.size(),
+                              "target_lds_limit_missing", failure.c_str());
+      amd_comgr_destroy_hotswap_transpile_result(comgrResult);
+    }
+    return false;
+  }
+
+  record->TargetKernelObject = targetKernelObject;
+  record->TargetPrivateSegmentSize = targetPrivateSegmentSize;
+  record->TargetGroupSegmentSize = targetGroupSegmentSize;
+  record->TargetGroupSegmentLimit = targetGroupSegmentLimit;
+  record->TranslationSucceeded = true;
+  {
+    std::lock_guard<std::mutex> Guard(
+        HotSwapRuntimeLifetimeTranslatedExecutablesMutex());
+    HotSwapRuntimeLifetimeTranslatedExecutables().push_back(std::move(targetExec));
+  }
+  if (comgrResult.handle) {
+    AppendHotSwapComgrProof("hotswap_result", comgrResult, targetBytes.size());
+    amd_comgr_destroy_hotswap_transpile_result(comgrResult);
+  }
+  return true;
+}
+
+[[noreturn]] static void FatalHotSwapDispatch(uint64_t address,
+                                              const std::string& name,
+                                              HotSwapKernelKind kind,
+                                              const std::string& reason,
+                                              const std::string& sourceKind = "",
+                                              const std::string& targetGfx = "") {
+  std::ostringstream proof;
+  proof << "\"event\":\"hotswap_lazy_dispatch_reject\""
+        << ",\"kernel_name\":\"" << JsonEscape(name.empty() ? "<unknown>" : name)
+        << "\""
+        << ",\"kernel_object\":\"0x" << std::hex << address << "\""
+        << std::dec
+        << ",\"kind\":\"" << HotSwapKernelKindName(kind) << "\"";
+  if (!sourceKind.empty())
+    proof << ",\"source_kind\":\"" << JsonEscape(sourceKind) << "\"";
+  if (!targetGfx.empty())
+    proof << ",\"target_gfx\":\"" << JsonEscape(targetGfx) << "\"";
+  proof << ",\"reason\":\"" << JsonEscape(reason) << "\"";
+  AppendHotSwapProofJson(proof.str());
+  std::cerr << "hotswap: refusing kernel dispatch";
+  if (!name.empty()) std::cerr << " for " << name;
+  std::cerr << " (kind=" << HotSwapKernelKindName(kind)
+            << (sourceKind.empty() ? "" : ", source_kind=") << sourceKind
+            << (targetGfx.empty() ? "" : ", target_gfx=") << targetGfx
+            << "): " << reason << "\n";
+  std::abort();
+}
+
+// Dispatch-time hook invoked by the AQL doorbell intercept for each dispatched
+// kernel. Given the packet's kernel_object it looks up the HotSwap record and, on
+// success, rewrites *address (and the segment sizes) to the translated target
+// kernel: already-translated kernels pass through, lazy-source kernels are
+// translated via COMGR on first use and cached, and anything unsupported or
+// unregistered aborts the dispatch. Returns true once the packet is safe to run.
+bool PrepareHotSwapDispatchKernelObject(uint64_t* address,
+                                        uint32_t* private_segment_size,
+                                        uint32_t* group_segment_size) {
+  if (!address || !private_segment_size || !group_segment_size)
+    FatalHotSwapDispatch(0, "", HotSwapKernelKind::Untranslated,
+                         "invalid dispatch packet pointer");
+
+  std::shared_ptr<HotSwapKernelRecord> record =
+      LookupHotSwapKernelRecord(*address);
+  if (!record)
+    FatalHotSwapDispatch(*address, "", HotSwapKernelKind::Untranslated,
+                         "unregistered kernel object");
+
+  if (record->Kind == HotSwapKernelKind::Translated) {
+    return true;
+  }
+
+  if (record->Kind == HotSwapKernelKind::RuntimeTargetInternal) {
+    if (!record->IsRegisteredRocrBlit(*address))
+      FatalHotSwapDispatch(*address, record->Name, record->Kind,
+                           "runtime target-internal kernel is not a registered ROCR blit shader",
+                           record->SourceKind, record->TargetGfx);
+
+    std::ostringstream proof;
+    proof << "\"event\":\"hotswap_runtime_target_internal_dispatch\""
+          << ",\"kernel_name\":\"" << JsonEscape(record->Name) << "\""
+          << ",\"kernel_object\":\"0x" << std::hex << *address << "\""
+          << std::dec
+          << ",\"kind\":\"runtime_target_internal\"";
+    if (!record->SourceKind.empty())
+      proof << ",\"source_kind\":\"" << JsonEscape(record->SourceKind) << "\"";
+    if (!record->TargetGfx.empty())
+      proof << ",\"target_gfx\":\"" << JsonEscape(record->TargetGfx) << "\"";
+    if (!record->Failure.empty())
+      proof << ",\"reason\":\"" << JsonEscape(record->Failure) << "\"";
+    AppendHotSwapProofJson(proof.str());
+    return true;
+  }
+
+  if (record->Kind != HotSwapKernelKind::LazySource)
+    FatalHotSwapDispatch(*address, record->Name, record->Kind,
+                         record->Failure.empty()
+                             ? "kernel object is not translated"
+                             : record->Failure,
+                         record->SourceKind, record->TargetGfx);
+
+  std::lock_guard<std::mutex> Guard(record->Mutex);
+  if (!record->TranslationAttempted) {
+    record->TranslationAttempted = true;
+    std::string failure;
+    // Submitting the source kernel object would execute foreign-ISA code.
+    // Treat unsupported lazy translation as a fail-closed process abort rather
+    // than letting a bad dispatch escape to hardware.
+    if (!LoadLazyTranslatedKernel(record, failure)) {
+      record->Failure = failure;
+      FatalHotSwapDispatch(*address, record->Name, record->Kind, failure);
+    }
+  }
+  if (!record->TranslationSucceeded || record->TargetKernelObject == 0)
+    FatalHotSwapDispatch(*address, record->Name, record->Kind,
+                         record->Failure.empty()
+                             ? "lazy translation did not produce a target kernel"
+                             : record->Failure);
+
+  uint32_t patchedPrivateSegmentSize = 0;
+  uint32_t patchedGroupSegmentSize = 0;
+  std::string segmentFailure;
+  if (!ComputeHotSwapPatchedSegmentSizes(
+          *record, *private_segment_size, *group_segment_size,
+          patchedPrivateSegmentSize, patchedGroupSegmentSize, segmentFailure))
+    FatalHotSwapDispatch(*address, record->Name, record->Kind, segmentFailure);
+
+  const uint64_t sourceKernelObject = *address;
+  *address = record->TargetKernelObject;
+  *private_segment_size = patchedPrivateSegmentSize;
+  *group_segment_size = patchedGroupSegmentSize;
+
+  std::ostringstream proof;
+  proof << "\"event\":\"hotswap_lazy_dispatch_patch\""
+        << ",\"kernel_name\":\"" << JsonEscape(record->Name) << "\""
+        << ",\"source_kernel_object\":\"0x" << std::hex << sourceKernelObject << "\""
+        << ",\"target_kernel_object\":\"0x" << record->TargetKernelObject << "\""
+        << std::dec
+        << ",\"private_segment_size\":" << *private_segment_size
+        << ",\"group_segment_size\":" << *group_segment_size;
+  AppendHotSwapProofJson(proof.str());
+
+  return true;
+}
+
+struct HotSwapGfxMach {
+  const char* name;
+  uint32_t mach;
+};
+
+// AMDGPU e_flags processor values are the only target identity available before
+// the ROCR code object parser accepts a presented-source object. Keep this table
+// limited to the gfx names supported by the HotSwap presentation mode.
+static constexpr HotSwapGfxMach kHotSwapGfxMachMap[] = {
+    {"gfx900", 0x02c},  {"gfx902", 0x02d},  {"gfx904", 0x02e},  {"gfx906", 0x02f},
+    {"gfx908", 0x030},  {"gfx909", 0x031},  {"gfx90a", 0x03f},  {"gfx90c", 0x032},
+    {"gfx942", 0x04c},  {"gfx950", 0x04f},  {"gfx1010", 0x033}, {"gfx1011", 0x034},
+    {"gfx1012", 0x035}, {"gfx1030", 0x036}, {"gfx1031", 0x037}, {"gfx1032", 0x038},
+    {"gfx1033", 0x039}, {"gfx1034", 0x03e}, {"gfx1035", 0x03d}, {"gfx1100", 0x041},
+    {"gfx1101", 0x046}, {"gfx1102", 0x047}, {"gfx1103", 0x044}, {"gfx1150", 0x043},
+    {"gfx1151", 0x04a}, {"gfx1200", 0x048}, {"gfx1201", 0x04e}, {"gfx1250", 0x049},
+    {"gfx1251", 0x05a}, {nullptr, 0},
+};
+
+static bool HotSwapMachFromGfxName(const std::string& gfx, uint32_t& mach) {
+  for (const HotSwapGfxMach* entry = kHotSwapGfxMachMap; entry->name; ++entry) {
+    if (gfx == entry->name) {
+      mach = entry->mach;
+      return true;
+    }
+  }
+  return false;
+}
+
+#endif
 
 Loader* Loader::Create(Context* context)
 {
@@ -868,6 +1617,21 @@ void Segment::Destroy()
   owner->context()->SegmentFree(segment, agent, ptr, size);
 }
 
+void LoadedCodeObjectImpl::Destroy() {
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+  for (uint64_t address : hotswap_kernel_objects_) {
+    UnregisterHotSwapKernelObject(address);
+  }
+  hotswap_kernel_objects_.clear();
+#endif
+}
+
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+void LoadedCodeObjectImpl::RecordHotSwapKernelObject(uint64_t address) {
+  hotswap_kernel_objects_.push_back(address);
+}
+#endif
+
 //===----------------------------------------------------------------------===//
 // ExecutableImpl.                                                                //
 //===----------------------------------------------------------------------===//
@@ -1391,6 +2155,20 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
     logger_ << "LoaderError: failed to determine code object's ISA\n";
     return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
   }
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+  DumpHotSwapInputCodeObject(code->ElfData(), code->ElfSize(), codeNum, codeIsa);
+#endif
+
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+  if (std::getenv("HSA_HOTSWAP_PROOF_LOG")) {
+    std::ostringstream proof;
+    proof << "\"event\":\"hsa_load_code_object\""
+          << ",\"code_isa\":\"" << JsonEscape(codeIsa) << "\""
+          << ",\"source_gfx\":\"" << JsonEscape(ExtractGfxName(codeIsa)) << "\""
+          << ",\"elf_size\":" << code->ElfSize();
+    AppendHotSwapProofJson(proof.str());
+  }
+#endif
 
   // Kernel-entry trampolines (gfx125x). Disabled by default for gfx125x.
   // Set LOADER_ENABLE_TRAMPOLINE=1 or LOADER_ENABLE_TRAMPOLINE_NO_WA=1 to enable
@@ -1429,25 +2207,186 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
     return HSA_STATUS_ERROR_INCOMPATIBLE_ARGUMENTS;
   }
 
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+  std::vector<uint8_t> ownedCodeObject;
+  bool ownsCodeObject = false;
+  bool translatedInThisCall = CurrentHotSwapLoadingTranslatedTarget;
+  bool lazySourceInThisCall = false;
+  std::shared_ptr<HotSwapLazyCodeObject> lazyCodeObjectForThisCall;
+  const std::string presentedGfx = EnvGfxName("HSA_HOTSWAP_PRESENT_ISA");
+  const bool presentationMode =
+      !rocr::hotswap::IsEnvFlagEnabled("HSA_HOTSWAP_DISABLE") && !presentedGfx.empty();
+  std::string hotswapTargetGfx;
+  std::string hotswapTargetFailure;
+  if (!ResolveHotSwapPresentationTarget(
+          presentationMode, EnvGfxName("HSA_HOTSWAP_TARGET"),
+          EnvGfxName("HSA_HOTSWAP_ISA_OVERRIDE"), ExecutionGfxName(agent),
+          hotswapTargetGfx, hotswapTargetFailure)) {
+    logger_ << "LoaderError: " << hotswapTargetFailure << "\n";
+    return HSA_STATUS_ERROR_INVALID_ISA_NAME;
+  }
+
+  if (CurrentHotSwapLoadingTranslatedTarget) {
+    ownedCodeObject.assign(reinterpret_cast<const uint8_t*>(code->ElfData()),
+                           reinterpret_cast<const uint8_t*>(code->ElfData()) +
+                               code->ElfSize());
+    code = std::make_unique<code::AmdHsaCode>();
+    if (!code->InitAsBuffer(ownedCodeObject.data(), ownedCodeObject.size())) {
+      logger_ << "LoaderError: lazy translated HotSwap HSACO failed to initialize\n";
+      return HSA_STATUS_ERROR_INCOMPATIBLE_ARGUMENTS;
+    }
+    ownsCodeObject = true;
+  }
+
+  if (presentationMode) {
+    std::string targetGfx = hotswapTargetGfx;
+
+    if (!targetGfx.empty()) {
+      std::string sourceGfx;
+      uint8_t sourceMach = 0;
+      const std::string codeGfx = ExtractGfxName(codeIsa);
+      bool presentationInterceptForHotSwap = false;
+
+      if (!codeGfx.empty() && codeGfx == presentedGfx && codeGfx != targetGfx) {
+        uint32_t autoSourceMach = 0;
+        if (HotSwapMachFromGfxName(codeGfx, autoSourceMach)) {
+          sourceGfx = codeGfx;
+          sourceMach = static_cast<uint8_t>(autoSourceMach & 0xffu);
+          presentationInterceptForHotSwap = true;
+        }
+      } else if (!codeGfx.empty() && codeGfx != targetGfx) {
+        std::ostringstream proof;
+        proof << "\"event\":\"hotswap_skip\""
+              << ",\"backend\":\"comgr\""
+              << ",\"reason\":\"not_presented_source\""
+              << ",\"source_gfx\":\"" << JsonEscape(codeGfx) << "\""
+              << ",\"target_gfx\":\"" << JsonEscape(targetGfx) << "\""
+              << ",\"elf_size\":" << code->ElfSize();
+        AppendHotSwapProofJson(proof.str());
+      }
+      if (presentationInterceptForHotSwap && sourceGfx != targetGfx) {
+        const std::string sourceIsa = std::string("amdgcn-amd-amdhsa--") + sourceGfx;
+        const std::string targetIsa = std::string("amdgcn-amd-amdhsa--") + targetGfx;
+
+        {
+          std::ostringstream proof;
+          proof << "\"event\":\"transpile_decision\""
+                << ",\"source\":\"presented_source\""
+                << ",\"source_gfx\":\"" << JsonEscape(sourceGfx) << "\""
+                << ",\"target_gfx\":\"" << JsonEscape(targetGfx) << "\""
+                << ",\"orig_mach\":\"0x" << std::hex << static_cast<unsigned>(sourceMach)
+                << std::dec << "\""
+                << ",\"code_isa\":\"" << JsonEscape(codeIsa) << "\"";
+          AppendHotSwapProofJson(proof.str());
+        }
+
+        std::vector<uint8_t> comgrSource(
+            reinterpret_cast<const uint8_t*>(code->ElfData()),
+            reinterpret_cast<const uint8_t*>(code->ElfData()) + code->ElfSize());
+
+        ownedCodeObject = std::move(comgrSource);
+        code = std::make_unique<code::AmdHsaCode>();
+        if (!code->InitAsBuffer(ownedCodeObject.data(), ownedCodeObject.size())) {
+          logger_ << "LoaderError: HotSwap source HSACO failed to initialize\n";
+          return HSA_STATUS_ERROR_INCOMPATIBLE_ARGUMENTS;
+        }
+        ownsCodeObject = true;
+        lazySourceInThisCall = true;
+        lazyCodeObjectForThisCall = std::make_shared<HotSwapLazyCodeObject>();
+        lazyCodeObjectForThisCall->SourceElf = ownedCodeObject;
+        lazyCodeObjectForThisCall->SourceIsa = sourceIsa;
+        lazyCodeObjectForThisCall->TargetIsa = targetIsa;
+        lazyCodeObjectForThisCall->SourceGfx = sourceGfx;
+        lazyCodeObjectForThisCall->TargetGfx = targetGfx;
+        lazyCodeObjectForThisCall->SourceMach = sourceMach;
+        lazyCodeObjectForThisCall->Agent = agent;
+        lazyCodeObjectForThisCall->Profile = profile();
+        if (!code->GetIsa(codeIsa, &genericVersion)) {
+          logger_ << "LoaderError: failed to determine HotSwap source code object's ISA\n";
+          return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+        }
+        if (!code->GetCodeObjectVersion(&majorVersion, &minorVersion)) {
+          logger_ << "LoaderError: failed to determine HotSwap source code object's version\n";
+          return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+        }
+        std::ostringstream proof;
+        proof << "\"event\":\"hotswap_lazy_source_registered\""
+              << ",\"backend\":\"comgr\""
+              << ",\"source_gfx\":\"" << JsonEscape(sourceGfx) << "\""
+              << ",\"target_gfx\":\"" << JsonEscape(targetGfx) << "\""
+              << ",\"elf_size\":" << ownedCodeObject.size();
+        AppendHotSwapProofJson(proof.str());
+      }
+    }
+  }
+#endif
+
   hsa_isa_t objectsIsa = context_->IsaFromName(codeIsa.c_str());
   if (!objectsIsa.handle) {
     logger_ << "LoaderError: code object's ISA (" << codeIsa.c_str() << ") is invalid\n";
     return HSA_STATUS_ERROR_INVALID_ISA_NAME;
   }
 
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+  if (presentationMode && agent.handle != 0) {
+    const std::string codeGfx = ExtractGfxName(codeIsa);
+    const bool targetObject = !hotswapTargetGfx.empty() && codeGfx == hotswapTargetGfx;
+    if (targetObject && !translatedInThisCall) {
+      logger_ << "LoaderError: target-ISA code object (" << codeIsa.c_str()
+              << ") was not produced by HotSwap in this load call\n";
+      return HSA_STATUS_ERROR_INCOMPATIBLE_ARGUMENTS;
+    }
+  }
+#endif
+
   if (agent.handle != 0 && !context_->IsaSupportedByAgent(agent, objectsIsa, genericVersion)) {
-    logger_ << "LoaderError: code object's ISA (" << codeIsa.c_str() << ") is not supported by the agent\n";
-    return HSA_STATUS_ERROR_INCOMPATIBLE_ARGUMENTS;
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+    if (lazySourceInThisCall) {
+      std::ostringstream proof;
+      proof << "\"event\":\"hotswap_lazy_source_isa_bypass\""
+            << ",\"backend\":\"comgr\""
+            << ",\"code_isa\":\"" << JsonEscape(codeIsa) << "\""
+            << ",\"source_gfx\":\"" << JsonEscape(ExtractGfxName(codeIsa)) << "\""
+            << ",\"target_gfx\":\"" << JsonEscape(hotswapTargetGfx) << "\""
+            << ",\"reason\":\"lazy_source_requires_dispatch_translation\"";
+      AppendHotSwapProofJson(proof.str());
+    } else
+#endif
+    {
+      logger_ << "LoaderError: code object's ISA (" << codeIsa.c_str()
+              << ") is not supported by the agent\n";
+      return HSA_STATUS_ERROR_INCOMPATIBLE_ARGUMENTS;
+    }
   }
 
   hsa_status_t status;
 
-  objects.push_back(std::make_shared<LoadedCodeObjectImpl>(this, agent, code->ElfData(), code->ElfSize()));
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+  if (ownsCodeObject) {
+    objects.push_back(
+        std::make_shared<LoadedCodeObjectImpl>(this, agent, std::move(ownedCodeObject)));
+  } else
+#endif
+  {
+    objects.push_back(
+        std::make_shared<LoadedCodeObjectImpl>(this, agent, code->ElfData(), code->ElfSize()));
+  }
   loaded_code_objects.push_back(std::static_pointer_cast<LoadedCodeObjectImpl>(objects.back()));
 
   status = LoadSegments(agent, code.get(), majorVersion);
   if (status != HSA_STATUS_SUCCESS) return status;
 
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+  HotSwapKernelKind PreviousHotSwapKernelKind = CurrentHotSwapKernelKind;
+  std::shared_ptr<HotSwapLazyCodeObject> PreviousHotSwapLazyCodeObject =
+      CurrentHotSwapLazyCodeObject;
+  CurrentHotSwapKernelKind = translatedInThisCall
+      ? HotSwapKernelKind::Translated
+      : (lazySourceInThisCall ? HotSwapKernelKind::LazySource
+                              : HotSwapKernelKind::Untranslated);
+  CurrentHotSwapLazyCodeObject =
+      lazySourceInThisCall ? lazyCodeObjectForThisCall : nullptr;
+#endif
   for (size_t i = 0; i < code->SymbolCount(); ++i) {
     if (majorVersion >= 2 &&
         code->GetSymbol(i)->elfSym()->type() != STT_AMDGPU_HSA_KERNEL &&
@@ -1455,8 +2394,18 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
       continue;
 
     status = LoadSymbol(agent, code->GetSymbol(i), majorVersion);
-    if (status != HSA_STATUS_SUCCESS) { return status; }
+    if (status != HSA_STATUS_SUCCESS) {
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+      CurrentHotSwapKernelKind = PreviousHotSwapKernelKind;
+      CurrentHotSwapLazyCodeObject = PreviousHotSwapLazyCodeObject;
+#endif
+      return status;
+    }
   }
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+  CurrentHotSwapKernelKind = PreviousHotSwapKernelKind;
+  CurrentHotSwapLazyCodeObject = PreviousHotSwapLazyCodeObject;
+#endif
 
   status = ApplyRelocations(agent, code.get());
   if (status != HSA_STATUS_SUCCESS) { return status; }
@@ -1790,6 +2739,22 @@ hsa_status_t ExecutableImpl::LoadDefinitionSymbol(hsa_agent_t agent,
                                     64,
                                     uses_wave32 ? 32 : 64,
                                     address);
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+    if (ShouldCheckHotSwapDispatchKernelObjects()) {
+      std::string KernelName;
+      std::string KernelNameFailure;
+      if (!DeriveHotSwapKernelRecordName(kernel_symbol->symbol_name, true,
+                                         KernelName, KernelNameFailure)) {
+        logger_ << "LoaderError: " << KernelNameFailure << ": "
+                << kernel_symbol->symbol_name << "\n";
+        return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+      }
+      RegisterHotSwapLoadedKernelObject(address, KernelName);
+      UpdateHotSwapKernelObjectLaunchMetadata(address, group_segment_size,
+                                              private_segment_size);
+      loaded_code_objects.back()->RecordHotSwapKernelObject(address);
+    }
+#endif
     symbol = kernel_symbol;
   } else if (sym->IsVariableSymbol()) {
     symbol = std::make_shared<VariableSymbol>(true,
@@ -1845,6 +2810,22 @@ hsa_status_t ExecutableImpl::LoadDefinitionSymbol(hsa_agent_t agent,
       kernel_symbol->debug_info.elf_size = code->ElfSize();
       kernel_symbol->debug_info.kernel_name = kernel_symbol->full_name.c_str();
       kernel_symbol->debug_info.owning_segment = (void*)SymbolSegment(agent, sym)->Address(sym->GetSection()->addr());
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+    if (ShouldCheckHotSwapDispatchKernelObjects()) {
+      std::string KernelName;
+      std::string KernelNameFailure;
+      if (!DeriveHotSwapKernelRecordName(kernel_symbol->full_name, false,
+                                         KernelName, KernelNameFailure)) {
+        logger_ << "LoaderError: " << KernelNameFailure << ": "
+                << kernel_symbol->full_name << "\n";
+        return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+      }
+      RegisterHotSwapLoadedKernelObject(address, KernelName);
+      UpdateHotSwapKernelObjectLaunchMetadata(address, group_segment_size,
+                                              private_segment_size);
+      loaded_code_objects.back()->RecordHotSwapKernelObject(address);
+    }
+#endif
       symbol = kernel_symbol;
 
       // \todo kzhuravl 10/15/15 This is a debugger backdoor: needs to be

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -459,22 +459,46 @@ static std::string JsonEscape(const std::string& s) {
   return os.str();
 }
 
+// Proof logging is a process-run decision: cache the selected path so all proof
+// emission uses the same destination even if the environment changes later.
+static const std::string& HotSwapProofLogPath() {
+  static const std::string Path = [] {
+    constexpr char EnvName[] = "HSA_HOTSWAP_PROOF_LOG";
+    if (!rocr::os::IsEnvVarSet(EnvName)) return std::string();
+    return rocr::os::GetEnvVar(EnvName);
+  }();
+  return Path;
+}
+
+// Keep call sites cheap and explicit without repeating the path lookup rule.
+static bool HotSwapProofLogEnabled() {
+  return !HotSwapProofLogPath().empty();
+}
+
 // Appends one JSON object (the given comma-separated fields) as a line to the
 // file named by HSA_HOTSWAP_PROOF_LOG. Best-effort and inert when unset; used to
 // prove which kernels were translated/dispatched during a run.
 static void AppendHotSwapProofJson(const std::string& jsonFields) {
-  const char* path = std::getenv("HSA_HOTSWAP_PROOF_LOG");
-  if (!path || !path[0]) return;
+  const std::string& Path = HotSwapProofLogPath();
+  if (Path.empty()) return;
   static std::mutex ProofLogMutex;
   std::lock_guard<std::mutex> Guard(ProofLogMutex);
-  std::ofstream out(path, std::ios::app);
-  if (!out) {
-    std::cerr << "hotswap: failed to open proof log '" << path << "' for append\n";
+  static std::ofstream Out;
+  if (!Out.is_open()) {
+    Out.clear();
+    Out.open(Path, std::ios::app);
+  }
+  if (!Out) {
+    std::cerr << "hotswap: failed to open proof log '" << Path
+              << "' for append\n";
     return;
   }
-  out << "{" << jsonFields << "}\n";
-  if (!out) {
-    std::cerr << "hotswap: failed to write proof log '" << path << "'\n";
+  Out << "{" << jsonFields << "}\n";
+  Out.flush();
+  if (!Out) {
+    std::cerr << "hotswap: failed to write proof log '" << Path << "'\n";
+    Out.close();
+    Out.clear();
   }
 }
 
@@ -610,8 +634,7 @@ static bool GetComgrResultInfo(amd_comgr_hotswap_transpile_result_t result,
 static void AppendHotSwapComgrProof(const char* event, amd_comgr_hotswap_transpile_result_t result,
                                     size_t elfSize = 0, const char* overrideFailReason = nullptr,
                                     const char* overrideFailDetail = nullptr) {
-  const char* path = std::getenv("HSA_HOTSWAP_PROOF_LOG");
-  if (!path || !path[0]) return;
+  if (!HotSwapProofLogEnabled()) return;
 
   bool success = false;
   bool cacheHit = false;
@@ -2156,7 +2179,7 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
 #endif
 
 #ifdef ROCR_HOTSWAP_COMGR_ADAPTER
-  if (std::getenv("HSA_HOTSWAP_PROOF_LOG")) {
+  if (HotSwapProofLogEnabled()) {
     std::ostringstream proof;
     proof << "\"event\":\"hsa_load_code_object\""
           << ",\"code_isa\":\"" << JsonEscape(codeIsa) << "\""

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
@@ -143,6 +143,17 @@ class KernelSymbol;
 class VariableSymbol;
 class ExecutableImpl;
 
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+void RegisterHotSwapRocrBlitTargetKernelObject(uint64_t address,
+                                               size_t size,
+                                               const char* target_gfx);
+void UnregisterHotSwapRocrBlitTargetKernelObject(uint64_t address);
+bool ShouldCheckHotSwapDispatchKernelObjects();
+bool PrepareHotSwapDispatchKernelObject(uint64_t* address,
+                                        uint32_t* private_segment_size,
+                                        uint32_t* group_segment_size);
+#endif
+
 //===----------------------------------------------------------------------===//
 // SymbolImpl.                                                                //
 //===----------------------------------------------------------------------===//
@@ -365,13 +376,23 @@ private:
   LoadedCodeObjectImpl(const LoadedCodeObjectImpl&);
   LoadedCodeObjectImpl& operator=(const LoadedCodeObjectImpl&);
 
+  std::vector<uint8_t> owned_elf_data;
   const void *elf_data;
   const size_t elf_size;
   std::vector<Segment*> loaded_segments;
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+  std::vector<uint64_t> hotswap_kernel_objects_;
+#endif
 
 public:
   LoadedCodeObjectImpl(ExecutableImpl *owner_, hsa_agent_t agent_, const void *elf_data_, size_t elf_size_)
     : ExecutableObject(owner_, agent_), elf_data(elf_data_), elf_size(elf_size_) {
+      memset(&r_debug_info, 0, sizeof(r_debug_info));
+    }
+
+  LoadedCodeObjectImpl(ExecutableImpl *owner_, hsa_agent_t agent_, std::vector<uint8_t> elf_data_)
+    : ExecutableObject(owner_, agent_), owned_elf_data(std::move(elf_data_)),
+      elf_data(owned_elf_data.data()), elf_size(owned_elf_data.size()) {
       memset(&r_debug_info, 0, sizeof(r_debug_info));
     }
 
@@ -389,7 +410,11 @@ public:
 
   void Print(std::ostream& out) override;
 
-  void Destroy() override {}
+  void Destroy() override;
+
+#ifdef ROCR_HOTSWAP_COMGR_ADAPTER
+  void RecordHotSwapKernelObject(uint64_t address);
+#endif
 
   hsa_agent_t getAgent() const override;
   hsa_executable_t getExecutable() const override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/hotswap_kernel_registry.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/hotswap_kernel_registry.h
@@ -167,32 +167,6 @@ inline bool PatchHotSwapTranslatedDispatch(
   return true;
 }
 
-// Resolves the execution (target) gfx to translate toward. In presentation mode
-// an explicit HSA_HOTSWAP_TARGET/ISA_OVERRIDE is required; otherwise it defaults
-// to the device's physical execution ISA.
-inline bool ResolveHotSwapPresentationTarget(
-    bool presentation_mode, const std::string& target_env,
-    const std::string& override_env, const std::string& execution_gfx,
-    std::string& target_gfx, std::string& failure) {
-  target_gfx = !target_env.empty() ? target_env : override_env;
-  if (presentation_mode) {
-    if (target_gfx.empty() || target_gfx == "0" || target_gfx == "1") {
-      failure =
-          "HSA_HOTSWAP_TARGET must name the execution ISA when "
-          "HSA_HOTSWAP_PRESENT_ISA is set";
-      target_gfx.clear();
-      return false;
-    }
-    failure.clear();
-    return true;
-  }
-
-  if (target_gfx.empty() || target_gfx == "0" || target_gfx == "1")
-    target_gfx = execution_gfx;
-  failure.clear();
-  return true;
-}
-
 inline std::string ResolveLazyHotSwapCacheDir(const char* lazy_cache_dir,
                                               const char* shared_cache_dir) {
   if (lazy_cache_dir && lazy_cache_dir[0]) return lazy_cache_dir;

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/hotswap_kernel_registry.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/hotswap_kernel_registry.h
@@ -1,44 +1,8 @@
-////////////////////////////////////////////////////////////////////////////////
-//
-// The University of Illinois/NCSA
-// Open Source License (NCSA)
-//
-// Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
-//
-// Developed by:
-//
-//                 AMD Research and AMD HSA Software Development
-//
-//                 Advanced Micro Devices, Inc.
-//
-//                 www.amd.com
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to
-// deal with the Software without restriction, including without limitation
-// the rights to use, copy, modify, merge, publish, distribute, sublicense,
-// and/or sell copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following conditions:
-//
-//  - Redistributions of source code must retain the above copyright notice,
-//    this list of conditions and the following disclaimers.
-//  - Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimers in
-//    the documentation and/or other materials provided with the distribution.
-//  - Neither the names of Advanced Micro Devices, Inc,
-//    nor the names of its contributors may be used to endorse or promote
-//    products derived from this Software without specific prior written
-//    permission.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-// DEALINGS WITH THE SOFTWARE.
-//
-////////////////////////////////////////////////////////////////////////////////
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 #ifndef HSA_RUNTIME_LOADER_HOTSWAP_KERNEL_REGISTRY_H_
 #define HSA_RUNTIME_LOADER_HOTSWAP_KERNEL_REGISTRY_H_

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/hotswap_kernel_registry.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/hotswap_kernel_registry.h
@@ -8,6 +8,7 @@
 #define HSA_RUNTIME_LOADER_HOTSWAP_KERNEL_REGISTRY_H_
 
 #include <algorithm>
+#include <atomic>
 #include <cstdio>
 #include <cstdlib>
 #include <cstdint>
@@ -39,7 +40,9 @@ struct HotSwapLazyCodeObject;
 // How a registered kernel object should be treated at dispatch:
 //   Untranslated          - not a HotSwap kernel; must not reach the hardware.
 //   LazySource            - source-ISA kernel to translate via COMGR on first use.
-//   Translated            - already translated to the execution ISA; pass through.
+//   Translated            - already translated to the execution ISA; pass
+//                           through target records or rewrite promoted source
+//                           records to their target kernel object.
 //   RuntimeTargetInternal - runtime-owned kernel already built for the execution
 //                           ISA (e.g. ROCr blit shaders); pass through.
 enum class HotSwapKernelKind {
@@ -65,10 +68,12 @@ inline const char* HotSwapKernelKindName(HotSwapKernelKind Kind) {
 
 // Per-kernel-object state: identity and kind, the retained lazy source (until
 // translated), the resulting target kernel object, and the source/target segment
-// sizes used to patch each dispatch packet. Guarded by Mutex during translation.
+// sizes used to patch each dispatch packet. Kind is atomic so a successful lazy
+// translation can publish a terminal Translated state after target metadata is
+// complete; the other mutable translation fields are guarded by Mutex.
 struct HotSwapKernelRecord {
   std::string Name;
-  HotSwapKernelKind Kind = HotSwapKernelKind::Untranslated;
+  std::atomic<HotSwapKernelKind> Kind{HotSwapKernelKind::Untranslated};
   std::string SourceKind;
   std::string TargetGfx;
   std::shared_ptr<HotSwapLazyCodeObject> LazyCodeObject;
@@ -86,7 +91,8 @@ struct HotSwapKernelRecord {
   uint32_t TargetGroupSegmentLimit = UINT32_MAX;
 
   bool IsRegisteredRocrBlit(uint64_t address) const {
-    return Kind == HotSwapKernelKind::RuntimeTargetInternal &&
+    return Kind.load(std::memory_order_acquire) ==
+               HotSwapKernelKind::RuntimeTargetInternal &&
            SourceKind == "rocr_blit" && address >= SourceKernelObject &&
            address - SourceKernelObject < ObjectSize;
   }
@@ -132,6 +138,32 @@ inline bool ComputeHotSwapPatchedSegmentSizes(
     failure = "patched group segment size exceeds target LDS limit";
     return false;
   }
+  return true;
+}
+
+// Rewrites a source-ISA dispatch packet to the translated target kernel while
+// preserving any dynamic segment-size deltas carried by the packet.
+inline bool PatchHotSwapTranslatedDispatch(
+    const HotSwapKernelRecord& record, uint64_t& address,
+    uint32_t& private_segment_size, uint32_t& group_segment_size,
+    std::string& failure) {
+  if (record.TargetKernelObject == 0) {
+    failure = "translated kernel object is missing";
+    return false;
+  }
+
+  uint32_t patched_private_segment_size = 0;
+  uint32_t patched_group_segment_size = 0;
+  if (!ComputeHotSwapPatchedSegmentSizes(record, private_segment_size,
+                                         group_segment_size,
+                                         patched_private_segment_size,
+                                         patched_group_segment_size, failure))
+    return false;
+
+  address = record.TargetKernelObject;
+  private_segment_size = patched_private_segment_size;
+  group_segment_size = patched_group_segment_size;
+  failure.clear();
   return true;
 }
 
@@ -226,7 +258,7 @@ class HotSwapKernelRegistry {
       ReportHotSwapRegistryError("duplicate kernel object address");
     auto record = std::make_shared<HotSwapKernelRecord>();
     record->Name = name;
-    record->Kind = kind;
+    record->Kind.store(kind, std::memory_order_relaxed);
     record->SourceKernelObject = address;
     record->LazyCodeObject = std::move(lazy_code_object);
     records_[address] = record;
@@ -242,8 +274,9 @@ class HotSwapKernelRegistry {
     std::lock_guard<std::mutex> guard(mutex_);
     auto record = std::make_shared<HotSwapKernelRecord>();
     record->Name = "rocr_blit";
-    record->Kind = valid ? HotSwapKernelKind::RuntimeTargetInternal
-                         : HotSwapKernelKind::Untranslated;
+    record->Kind.store(valid ? HotSwapKernelKind::RuntimeTargetInternal
+                             : HotSwapKernelKind::Untranslated,
+                       std::memory_order_relaxed);
     record->SourceKind = "rocr_blit";
     record->TargetGfx = target_gfx;
     record->Failure = valid ? reason : invalid_reason;

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/hotswap_kernel_registry.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/hotswap_kernel_registry.h
@@ -7,6 +7,7 @@
 #ifndef HSA_RUNTIME_LOADER_HOTSWAP_KERNEL_REGISTRY_H_
 #define HSA_RUNTIME_LOADER_HOTSWAP_KERNEL_REGISTRY_H_
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <cstdint>
@@ -14,6 +15,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 // Bookkeeping for the HotSwap dispatch intercept. The loader records every
 // kernel object it loads here so the dispatch-time hook can, given a packet's
@@ -209,10 +211,9 @@ inline bool DeriveHotSwapKernelRecordName(const std::string& symbol_name,
   return true;
 }
 
-// Thread-safe map from kernel object address to its HotSwapKernelRecord. Owned by
-// the loader; entries are added as kernels load and removed as code objects are
-// destroyed. Lookups also match addresses that fall within a registered ROCr blit
-// object's range.
+// Thread-safe registry from exact kernel object address to its HotSwap record.
+// ROCr blit shaders are also tracked in a small side list so range fallback only
+// scans runtime-owned blit records, not every user kernel loaded in the process.
 class HotSwapKernelRegistry {
  public:
   std::shared_ptr<HotSwapKernelRecord> RegisterKernelObject(
@@ -252,6 +253,7 @@ class HotSwapKernelRegistry {
     if (records_.find(address) != records_.end())
       ReportHotSwapRegistryError("duplicate ROCR blit kernel object address");
     records_[address] = record;
+    rocr_blit_records_.push_back(record);
     return record;
   }
 
@@ -267,6 +269,12 @@ class HotSwapKernelRegistry {
     auto it = records_.find(address);
     if (it == records_.end() || it->second->SourceKind != "rocr_blit")
       return false;
+    auto blit_it =
+        std::find(rocr_blit_records_.begin(), rocr_blit_records_.end(),
+                  it->second);
+    if (blit_it == rocr_blit_records_.end())
+      ReportHotSwapRegistryError("missing ROCR blit range record");
+    rocr_blit_records_.erase(blit_it);
     records_.erase(it);
     return true;
   }
@@ -275,8 +283,8 @@ class HotSwapKernelRegistry {
     std::lock_guard<std::mutex> guard(mutex_);
     auto it = records_.find(address);
     if (it != records_.end()) return it->second;
-    for (const auto& entry : records_) {
-      if (entry.second->IsRegisteredRocrBlit(address)) return entry.second;
+    for (const auto& record : rocr_blit_records_) {
+      if (record->IsRegisteredRocrBlit(address)) return record;
     }
     return nullptr;
   }
@@ -298,6 +306,7 @@ class HotSwapKernelRegistry {
  private:
   mutable std::mutex mutex_;
   std::unordered_map<uint64_t, std::shared_ptr<HotSwapKernelRecord>> records_;
+  std::vector<std::shared_ptr<HotSwapKernelRecord>> rocr_blit_records_;
 };
 
 }  // namespace loader

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/hotswap_kernel_registry.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/hotswap_kernel_registry.h
@@ -1,0 +1,344 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// The University of Illinois/NCSA
+// Open Source License (NCSA)
+//
+// Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Developed by:
+//
+//                 AMD Research and AMD HSA Software Development
+//
+//                 Advanced Micro Devices, Inc.
+//
+//                 www.amd.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+//  - Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimers.
+//  - Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimers in
+//    the documentation and/or other materials provided with the distribution.
+//  - Neither the names of Advanced Micro Devices, Inc,
+//    nor the names of its contributors may be used to endorse or promote
+//    products derived from this Software without specific prior written
+//    permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS WITH THE SOFTWARE.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef HSA_RUNTIME_LOADER_HOTSWAP_KERNEL_REGISTRY_H_
+#define HSA_RUNTIME_LOADER_HOTSWAP_KERNEL_REGISTRY_H_
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+// Bookkeeping for the HotSwap dispatch intercept. The loader records every
+// kernel object it loads here so the dispatch-time hook can, given a packet's
+// kernel_object, decide whether to pass it through, translate it, or reject it,
+// and can compute the correct segment sizes for the translated kernel. All state
+// is header-only and inert unless presentation mode is active.
+namespace rocr {
+namespace amd {
+namespace hsa {
+namespace loader {
+
+struct HotSwapLazyCodeObject;
+
+// Registry invariants must never be violated at runtime; abort loudly if they are
+// (rather than silently corrupting dispatch), so the failure is caught in testing.
+[[noreturn]] inline void ReportHotSwapRegistryError(const char* reason) {
+  std::fprintf(stderr, "hotswap: registry invariant violation: %s\n", reason);
+  std::abort();
+}
+
+// How a registered kernel object should be treated at dispatch:
+//   Untranslated          - not a HotSwap kernel; must not reach the hardware.
+//   LazySource            - source-ISA kernel to translate via COMGR on first use.
+//   Translated            - already translated to the execution ISA; pass through.
+//   RuntimeTargetInternal - runtime-owned kernel already built for the execution
+//                           ISA (e.g. ROCr blit shaders); pass through.
+enum class HotSwapKernelKind {
+  Untranslated,
+  LazySource,
+  Translated,
+  RuntimeTargetInternal,
+};
+
+inline const char* HotSwapKernelKindName(HotSwapKernelKind Kind) {
+  switch (Kind) {
+    case HotSwapKernelKind::Untranslated:
+      return "untranslated";
+    case HotSwapKernelKind::LazySource:
+      return "lazy_source";
+    case HotSwapKernelKind::Translated:
+      return "translated";
+    case HotSwapKernelKind::RuntimeTargetInternal:
+      return "runtime_target_internal";
+  }
+  return "untranslated";
+}
+
+// Per-kernel-object state: identity and kind, the retained lazy source (until
+// translated), the resulting target kernel object, and the source/target segment
+// sizes used to patch each dispatch packet. Guarded by Mutex during translation.
+struct HotSwapKernelRecord {
+  std::string Name;
+  HotSwapKernelKind Kind = HotSwapKernelKind::Untranslated;
+  std::string SourceKind;
+  std::string TargetGfx;
+  std::shared_ptr<HotSwapLazyCodeObject> LazyCodeObject;
+  std::mutex Mutex;
+  bool TranslationAttempted = false;
+  bool TranslationSucceeded = false;
+  std::string Failure;
+  uint64_t SourceKernelObject = 0;
+  uint64_t ObjectSize = 0;
+  uint64_t TargetKernelObject = 0;
+  uint32_t SourcePrivateSegmentSize = 0;
+  uint32_t SourceGroupSegmentSize = 0;
+  uint32_t TargetPrivateSegmentSize = 0;
+  uint32_t TargetGroupSegmentSize = 0;
+  uint32_t TargetGroupSegmentLimit = UINT32_MAX;
+
+  bool IsRegisteredRocrBlit(uint64_t address) const {
+    return Kind == HotSwapKernelKind::RuntimeTargetInternal &&
+           SourceKind == "rocr_blit" && address >= SourceKernelObject &&
+           address - SourceKernelObject < ObjectSize;
+  }
+};
+
+// Translates a dispatch packet's segment sizes from the source kernel to the
+// translated target kernel: preserves any caller-supplied dynamic (runtime)
+// portion while substituting the target's fixed sizes. Fails if the packet is
+// smaller than the source fixed size, on overflow, or if the result exceeds the
+// target's LDS limit.
+inline bool ComputeHotSwapPatchedSegmentSizes(
+    const HotSwapKernelRecord& record, uint32_t packet_private_segment_size,
+    uint32_t packet_group_segment_size, uint32_t& patched_private_segment_size,
+    uint32_t& patched_group_segment_size, std::string& failure) {
+  if (packet_group_segment_size < record.SourceGroupSegmentSize) {
+    failure = "dispatch group segment size is below source fixed size";
+    return false;
+  }
+  if (packet_private_segment_size < record.SourcePrivateSegmentSize) {
+    failure = "dispatch private segment size is below source fixed size";
+    return false;
+  }
+
+  const uint32_t dynamic_group_segment_size =
+      packet_group_segment_size - record.SourceGroupSegmentSize;
+  const uint32_t dynamic_private_segment_size =
+      packet_private_segment_size - record.SourcePrivateSegmentSize;
+  if (dynamic_private_segment_size >
+      UINT32_MAX - record.TargetPrivateSegmentSize) {
+    failure = "patched private segment size overflows";
+    return false;
+  }
+  if (dynamic_group_segment_size > UINT32_MAX - record.TargetGroupSegmentSize) {
+    failure = "patched group segment size overflows";
+    return false;
+  }
+
+  patched_private_segment_size =
+      record.TargetPrivateSegmentSize + dynamic_private_segment_size;
+  patched_group_segment_size =
+      record.TargetGroupSegmentSize + dynamic_group_segment_size;
+  if (patched_group_segment_size > record.TargetGroupSegmentLimit) {
+    failure = "patched group segment size exceeds target LDS limit";
+    return false;
+  }
+  return true;
+}
+
+// Resolves the execution (target) gfx to translate toward. In presentation mode
+// an explicit HSA_HOTSWAP_TARGET/ISA_OVERRIDE is required; otherwise it defaults
+// to the device's physical execution ISA.
+inline bool ResolveHotSwapPresentationTarget(
+    bool presentation_mode, const std::string& target_env,
+    const std::string& override_env, const std::string& execution_gfx,
+    std::string& target_gfx, std::string& failure) {
+  target_gfx = !target_env.empty() ? target_env : override_env;
+  if (presentation_mode) {
+    if (target_gfx.empty() || target_gfx == "0" || target_gfx == "1") {
+      failure =
+          "HSA_HOTSWAP_TARGET must name the execution ISA when "
+          "HSA_HOTSWAP_PRESENT_ISA is set";
+      target_gfx.clear();
+      return false;
+    }
+    failure.clear();
+    return true;
+  }
+
+  if (target_gfx.empty() || target_gfx == "0" || target_gfx == "1")
+    target_gfx = execution_gfx;
+  failure.clear();
+  return true;
+}
+
+inline std::string ResolveLazyHotSwapCacheDir(const char* lazy_cache_dir,
+                                              const char* shared_cache_dir) {
+  if (lazy_cache_dir && lazy_cache_dir[0]) return lazy_cache_dir;
+  if (!shared_cache_dir || !shared_cache_dir[0]) return "";
+
+  std::string dir(shared_cache_dir);
+  while (!dir.empty() && dir.back() == '/') dir.pop_back();
+  if (dir.empty()) return "";
+  return dir + "/lazy-v2";
+}
+
+// The dispatch intercept only supports MULTI queues; single-producer queues do
+// not guarantee the doorbell-per-range ordering the intercept relies on.
+inline bool IsHotSwapQueueTypeSupported(hsa_queue_type32_t queue_type) {
+  return queue_type == HSA_QUEUE_TYPE_MULTI;
+}
+
+// Derives the canonical kernel name used as a registry/record key from a symbol
+// name, stripping the ".kd" descriptor suffix so the descriptor and kernel
+// symbols map to the same record.
+inline bool DeriveHotSwapKernelRecordName(const std::string& symbol_name,
+                                          bool descriptor_symbol,
+                                          std::string& record_name,
+                                          std::string& failure) {
+  constexpr const char* DescriptorSuffix = ".kd";
+  constexpr size_t DescriptorSuffixSize = 3;
+  if (descriptor_symbol) {
+    if (symbol_name.size() <= DescriptorSuffixSize ||
+        symbol_name.compare(symbol_name.size() - DescriptorSuffixSize,
+                            DescriptorSuffixSize, DescriptorSuffix) != 0) {
+      failure = "kernel descriptor symbol does not end in .kd";
+      record_name.clear();
+      return false;
+    }
+    record_name = symbol_name.substr(0, symbol_name.size() - DescriptorSuffixSize);
+  } else {
+    record_name = symbol_name;
+    if (record_name.size() > DescriptorSuffixSize &&
+        record_name.compare(record_name.size() - DescriptorSuffixSize,
+                            DescriptorSuffixSize, DescriptorSuffix) == 0)
+      record_name.resize(record_name.size() - DescriptorSuffixSize);
+  }
+  if (record_name.empty()) {
+    failure = "kernel symbol name is empty";
+    return false;
+  }
+  failure.clear();
+  return true;
+}
+
+// Thread-safe map from kernel object address to its HotSwapKernelRecord. Owned by
+// the loader; entries are added as kernels load and removed as code objects are
+// destroyed. Lookups also match addresses that fall within a registered ROCr blit
+// object's range.
+class HotSwapKernelRegistry {
+ public:
+  std::shared_ptr<HotSwapKernelRecord> RegisterKernelObject(
+      uint64_t address, const std::string& name, HotSwapKernelKind kind,
+      std::shared_ptr<HotSwapLazyCodeObject> lazy_code_object) {
+    if (address == 0)
+      ReportHotSwapRegistryError("kernel object address is zero");
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (records_.find(address) != records_.end())
+      ReportHotSwapRegistryError("duplicate kernel object address");
+    auto record = std::make_shared<HotSwapKernelRecord>();
+    record->Name = name;
+    record->Kind = kind;
+    record->SourceKernelObject = address;
+    record->LazyCodeObject = std::move(lazy_code_object);
+    records_[address] = record;
+    return record;
+  }
+
+  std::shared_ptr<HotSwapKernelRecord> RegisterRocrBlitTargetKernelObject(
+      uint64_t address, uint64_t size, const std::string& target_gfx,
+      const std::string& reason, const std::string& invalid_reason) {
+    const bool valid =
+        address != 0 && size != 0 && !target_gfx.empty() &&
+        target_gfx != "<unknown>";
+    std::lock_guard<std::mutex> guard(mutex_);
+    auto record = std::make_shared<HotSwapKernelRecord>();
+    record->Name = "rocr_blit";
+    record->Kind = valid ? HotSwapKernelKind::RuntimeTargetInternal
+                         : HotSwapKernelKind::Untranslated;
+    record->SourceKind = "rocr_blit";
+    record->TargetGfx = target_gfx;
+    record->Failure = valid ? reason : invalid_reason;
+    record->SourceKernelObject = address;
+    record->ObjectSize = size;
+    if (!valid) return record;
+    if (records_.find(address) != records_.end())
+      ReportHotSwapRegistryError("duplicate ROCR blit kernel object address");
+    records_[address] = record;
+    return record;
+  }
+
+  void UnregisterLoadedKernelObject(uint64_t address) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    auto it = records_.find(address);
+    if (it == records_.end()) return;
+    records_.erase(it);
+  }
+
+  bool UnregisterRocrBlitTargetKernelObject(uint64_t address) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    auto it = records_.find(address);
+    if (it == records_.end() || it->second->SourceKind != "rocr_blit")
+      return false;
+    records_.erase(it);
+    return true;
+  }
+
+  std::shared_ptr<HotSwapKernelRecord> Lookup(uint64_t address) const {
+    std::lock_guard<std::mutex> guard(mutex_);
+    auto it = records_.find(address);
+    if (it != records_.end()) return it->second;
+    for (const auto& entry : records_) {
+      if (entry.second->IsRegisteredRocrBlit(address)) return entry.second;
+    }
+    return nullptr;
+  }
+
+  void UpdateLaunchMetadata(uint64_t address, uint32_t group_segment_size,
+                            uint32_t private_segment_size) {
+    std::shared_ptr<HotSwapKernelRecord> record;
+    {
+      std::lock_guard<std::mutex> guard(mutex_);
+      auto it = records_.find(address);
+      if (it == records_.end()) return;
+      record = it->second;
+    }
+    std::lock_guard<std::mutex> record_guard(record->Mutex);
+    record->SourceGroupSegmentSize = group_segment_size;
+    record->SourcePrivateSegmentSize = private_segment_size;
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  std::unordered_map<uint64_t, std::shared_ptr<HotSwapKernelRecord>> records_;
+};
+
+}  // namespace loader
+}  // namespace hsa
+}  // namespace amd
+}  // namespace rocr
+
+#endif  // HSA_RUNTIME_LOADER_HOTSWAP_KERNEL_REGISTRY_H_

--- a/projects/rocr-runtime/runtime/hsa-runtime/tests/hotswap_runtime_test.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/tests/hotswap_runtime_test.cpp
@@ -1,44 +1,8 @@
-////////////////////////////////////////////////////////////////////////////////
-//
-// The University of Illinois/NCSA
-// Open Source License (NCSA)
-//
-// Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
-//
-// Developed by:
-//
-//                 AMD Research and AMD HSA Software Development
-//
-//                 Advanced Micro Devices, Inc.
-//
-//                 www.amd.com
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to
-// deal with the Software without restriction, including without limitation
-// the rights to use, copy, modify, merge, publish, distribute, sublicense,
-// and/or sell copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following conditions:
-//
-//  - Redistributions of source code must retain the above copyright notice,
-//    this list of conditions and the following disclaimers.
-//  - Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimers in
-//    the documentation and/or other materials provided with the distribution.
-//  - Neither the names of Advanced Micro Devices, Inc,
-//    nor the names of its contributors may be used to endorse or promote
-//    products derived from this Software without specific prior written
-//    permission.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-// DEALINGS WITH THE SOFTWARE.
-//
-////////////////////////////////////////////////////////////////////////////////
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 #include "core/runtime/hotswap_aql_patch.h"
 #include "core/inc/hotswap_env.hpp"

--- a/projects/rocr-runtime/runtime/hsa-runtime/tests/hotswap_runtime_test.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/tests/hotswap_runtime_test.cpp
@@ -1,0 +1,563 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// The University of Illinois/NCSA
+// Open Source License (NCSA)
+//
+// Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Developed by:
+//
+//                 AMD Research and AMD HSA Software Development
+//
+//                 Advanced Micro Devices, Inc.
+//
+//                 www.amd.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+//  - Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimers.
+//  - Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimers in
+//    the documentation and/or other materials provided with the distribution.
+//  - Neither the names of Advanced Micro Devices, Inc,
+//    nor the names of its contributors may be used to endorse or promote
+//    products derived from this Software without specific prior written
+//    permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS WITH THE SOFTWARE.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "core/runtime/hotswap_aql_patch.h"
+#include "core/inc/hotswap_env.hpp"
+#include "loader/hotswap_kernel_registry.h"
+
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace {
+
+int Failures = 0;
+bool PrepareCalled = false;
+bool FenceCalled = false;
+uint16_t HeaderDuringPrepare = 0;
+uint64_t KernelObjectDuringFence = 0;
+rocr::core::AqlPacket* PacketUnderPatch = nullptr;
+
+void Expect(bool condition, const char* expression, int line) {
+  if (condition) return;
+  std::cerr << "hotswap-runtime-unit-tests:" << line
+            << ": check failed: " << expression << "\n";
+  ++Failures;
+}
+
+#define EXPECT_TRUE(expr) Expect((expr), #expr, __LINE__)
+#define EXPECT_FALSE(expr) Expect(!(expr), "!(" #expr ")", __LINE__)
+#define EXPECT_EQ(lhs, rhs) Expect(((lhs) == (rhs)), #lhs " == " #rhs, __LINE__)
+#define EXPECT_NE(lhs, rhs) Expect(((lhs) != (rhs)), #lhs " != " #rhs, __LINE__)
+
+uint16_t KernelDispatchHeader() {
+  return (HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE) |
+         (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE) |
+         (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+}
+
+uint16_t ExtDispatchHeader() {
+  return (HSA_PACKET_TYPE_VENDOR_SPECIFIC << HSA_PACKET_HEADER_TYPE) |
+         (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE) |
+         (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+}
+
+bool PreparePatchSuccess(uint64_t* kernel_object,
+                         uint32_t* private_segment_size,
+                         uint32_t* group_segment_size) {
+  PrepareCalled = true;
+  if (PacketUnderPatch)
+    HeaderDuringPrepare = PacketUnderPatch->packet.header;
+  *kernel_object = 0x2000;
+  *private_segment_size = 64;
+  *group_segment_size = 128;
+  return true;
+}
+
+bool PreparePatchFailure(uint64_t*, uint32_t*, uint32_t*) { return false; }
+
+void PacketBodyFence() {
+  FenceCalled = true;
+  if (PacketUnderPatch) {
+    KernelObjectDuringFence =
+        PacketUnderPatch->ext_dispatch.amd_format ==
+                HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH
+            ? PacketUnderPatch->ext_dispatch.kernel_object
+            : PacketUnderPatch->dispatch.kernel_object;
+  }
+}
+
+rocr::core::AqlPacket MakeKernelDispatchPacket() {
+  rocr::core::AqlPacket packet = {};
+  packet.dispatch.header = KernelDispatchHeader();
+  packet.dispatch.setup = 1;
+  packet.dispatch.kernel_object = 0x1000;
+  packet.dispatch.private_segment_size = 4;
+  packet.dispatch.group_segment_size = 8;
+  return packet;
+}
+
+rocr::core::AqlPacket MakeExtDispatchPacket() {
+  rocr::core::AqlPacket packet = {};
+  packet.ext_dispatch.header = ExtDispatchHeader();
+  packet.ext_dispatch.amd_format = HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH;
+  packet.ext_dispatch.setup = 1;
+  packet.ext_dispatch.kernel_object = 0x1000;
+  packet.ext_dispatch.private_segment_size = 4;
+  packet.ext_dispatch.group_segment_size = 8;
+  return packet;
+}
+
+void TestPatchPublishedKernelDispatchPacket() {
+  PrepareCalled = false;
+  FenceCalled = false;
+  HeaderDuringPrepare = 0;
+  KernelObjectDuringFence = 0;
+  rocr::core::AqlPacket packet = MakeKernelDispatchPacket();
+  PacketUnderPatch = &packet;
+
+  const bool patched = rocr::AMD::hotswap::lazy::PatchPublishedKernelDispatchPacket(
+      packet, PreparePatchSuccess, PacketBodyFence);
+  PacketUnderPatch = nullptr;
+
+  EXPECT_TRUE(patched);
+  EXPECT_TRUE(PrepareCalled);
+  EXPECT_TRUE(FenceCalled);
+  EXPECT_EQ(HeaderDuringPrepare,
+            static_cast<uint16_t>(HSA_PACKET_TYPE_INVALID
+                                  << HSA_PACKET_HEADER_TYPE));
+  EXPECT_EQ(KernelObjectDuringFence, 0x2000u);
+  EXPECT_EQ(packet.dispatch.header, KernelDispatchHeader());
+  EXPECT_EQ(packet.dispatch.kernel_object, 0x2000u);
+  EXPECT_EQ(packet.dispatch.private_segment_size, 64u);
+  EXPECT_EQ(packet.dispatch.group_segment_size, 128u);
+}
+
+void TestPatchPublishedExtKernelDispatchPacket() {
+  PrepareCalled = false;
+  FenceCalled = false;
+  HeaderDuringPrepare = 0;
+  KernelObjectDuringFence = 0;
+  rocr::core::AqlPacket packet = MakeExtDispatchPacket();
+  PacketUnderPatch = &packet;
+
+  const bool patched = rocr::AMD::hotswap::lazy::PatchPublishedKernelDispatchPacket(
+      packet, PreparePatchSuccess, PacketBodyFence);
+  PacketUnderPatch = nullptr;
+
+  EXPECT_TRUE(patched);
+  EXPECT_TRUE(PrepareCalled);
+  EXPECT_TRUE(FenceCalled);
+  EXPECT_EQ(HeaderDuringPrepare,
+            static_cast<uint16_t>(HSA_PACKET_TYPE_INVALID
+                                  << HSA_PACKET_HEADER_TYPE));
+  EXPECT_EQ(KernelObjectDuringFence, 0x2000u);
+  EXPECT_EQ(packet.ext_dispatch.header, ExtDispatchHeader());
+  EXPECT_EQ(packet.ext_dispatch.kernel_object, 0x2000u);
+  EXPECT_EQ(packet.ext_dispatch.private_segment_size, 64u);
+  EXPECT_EQ(packet.ext_dispatch.group_segment_size, 128u);
+}
+
+void TestPatchSkipsNonKernelPacket() {
+  PrepareCalled = false;
+  FenceCalled = false;
+  PacketUnderPatch = nullptr;
+  rocr::core::AqlPacket packet = {};
+  packet.barrier_and.header = HSA_PACKET_TYPE_BARRIER_AND
+                              << HSA_PACKET_HEADER_TYPE;
+
+  const bool patched = rocr::AMD::hotswap::lazy::PatchPublishedKernelDispatchPacket(
+      packet, PreparePatchSuccess, PacketBodyFence);
+
+  EXPECT_FALSE(patched);
+  EXPECT_FALSE(PrepareCalled);
+  EXPECT_FALSE(FenceCalled);
+  EXPECT_EQ(packet.barrier_and.header,
+            HSA_PACKET_TYPE_BARRIER_AND << HSA_PACKET_HEADER_TYPE);
+}
+
+void TestDoorbellPatchRangeMonotonic() {
+  uint64_t first = 0;
+  bool hasWork = false;
+  const char* failure = nullptr;
+  EXPECT_TRUE(rocr::AMD::hotswap::lazy::ComputeDoorbellPatchRange(
+      UINT64_MAX, 3, 8, first, hasWork, failure));
+  EXPECT_TRUE(hasWork);
+  EXPECT_EQ(first, 0u);
+  EXPECT_TRUE(failure == nullptr);
+
+  EXPECT_TRUE(rocr::AMD::hotswap::lazy::ComputeDoorbellPatchRange(
+      3, 5, 8, first, hasWork, failure));
+  EXPECT_TRUE(hasWork);
+  EXPECT_EQ(first, 4u);
+  EXPECT_TRUE(failure == nullptr);
+}
+
+void TestDoorbellPatchRangeSkipsReplayedDoorbell() {
+  uint64_t first = 42;
+  bool hasWork = true;
+  const char* failure = nullptr;
+  EXPECT_TRUE(rocr::AMD::hotswap::lazy::ComputeDoorbellPatchRange(
+      7, 7, 8, first, hasWork, failure));
+  EXPECT_FALSE(hasWork);
+  EXPECT_EQ(first, 8u);
+  EXPECT_TRUE(failure == nullptr);
+}
+
+void TestDoorbellPatchRangeRefusesAliasingRange() {
+  uint64_t first = 0;
+  bool hasWork = false;
+  const char* failure = nullptr;
+  EXPECT_FALSE(rocr::AMD::hotswap::lazy::ComputeDoorbellPatchRange(
+      50, 99, 8, first, hasWork, failure));
+  EXPECT_FALSE(hasWork);
+  EXPECT_TRUE(failure != nullptr);
+}
+
+void TestPatchFailureAborts() {
+  const pid_t child = fork();
+  if (child == 0) {
+    rocr::core::AqlPacket packet = MakeKernelDispatchPacket();
+    rocr::AMD::hotswap::lazy::PatchPublishedKernelDispatchPacket(
+        packet, PreparePatchFailure, nullptr);
+    _exit(0);
+  }
+
+  EXPECT_NE(child, static_cast<pid_t>(-1));
+  int status = 0;
+  EXPECT_EQ(waitpid(child, &status, 0), child);
+  EXPECT_TRUE(WIFSIGNALED(status));
+  EXPECT_EQ(WTERMSIG(status), SIGABRT);
+}
+
+void TestRocrBlitRegistryRangeAndLifetime() {
+  rocr::amd::hsa::loader::HotSwapKernelRegistry registry;
+  auto record = registry.RegisterRocrBlitTargetKernelObject(
+      0x1000, 0x80, "gfx942", "embedded_rocr_target_blit_shader",
+      "invalid");
+
+  EXPECT_EQ(record->Kind,
+            rocr::amd::hsa::loader::HotSwapKernelKind::RuntimeTargetInternal);
+  EXPECT_TRUE(record->IsRegisteredRocrBlit(0x1000));
+  EXPECT_TRUE(record->IsRegisteredRocrBlit(0x107f));
+  EXPECT_FALSE(record->IsRegisteredRocrBlit(0x0fff));
+  EXPECT_FALSE(record->IsRegisteredRocrBlit(0x1080));
+  EXPECT_TRUE(registry.Lookup(0x1000).get() == record.get());
+  EXPECT_TRUE(registry.Lookup(0x107f).get() == record.get());
+
+  EXPECT_TRUE(registry.UnregisterRocrBlitTargetKernelObject(0x1000));
+  EXPECT_FALSE(registry.Lookup(0x1000));
+}
+
+void TestInvalidRocrBlitRegistrationIsNotAllowed() {
+  rocr::amd::hsa::loader::HotSwapKernelRegistry registry;
+  auto record = registry.RegisterRocrBlitTargetKernelObject(
+      0, 0x80, "<unknown>", "embedded_rocr_target_blit_shader", "invalid");
+
+  EXPECT_EQ(record->Kind,
+            rocr::amd::hsa::loader::HotSwapKernelKind::Untranslated);
+  EXPECT_EQ(record->Failure, std::string("invalid"));
+  EXPECT_FALSE(record->IsRegisteredRocrBlit(0));
+  EXPECT_FALSE(registry.Lookup(0));
+}
+
+void TestHotSwapKernelRecordNameDerivation() {
+  std::string recordName;
+  std::string failure;
+  EXPECT_TRUE(rocr::amd::hsa::loader::DeriveHotSwapKernelRecordName(
+      "kernel.kd", true, recordName, failure));
+  EXPECT_EQ(recordName, std::string("kernel"));
+  EXPECT_TRUE(failure.empty());
+
+  EXPECT_TRUE(rocr::amd::hsa::loader::DeriveHotSwapKernelRecordName(
+      "legacy_kernel", false, recordName, failure));
+  EXPECT_EQ(recordName, std::string("legacy_kernel"));
+  EXPECT_TRUE(failure.empty());
+
+  EXPECT_FALSE(rocr::amd::hsa::loader::DeriveHotSwapKernelRecordName(
+      "bad", true, recordName, failure));
+  EXPECT_TRUE(failure.find(".kd") != std::string::npos);
+}
+
+void TestDuplicateKernelObjectRegistrationAborts() {
+  const pid_t child = fork();
+  if (child == 0) {
+    rocr::amd::hsa::loader::HotSwapKernelRegistry registry;
+    registry.RegisterKernelObject(
+        0x1800, "kernel", rocr::amd::hsa::loader::HotSwapKernelKind::LazySource,
+        nullptr);
+    registry.RegisterKernelObject(
+        0x1800, "kernel2",
+        rocr::amd::hsa::loader::HotSwapKernelKind::LazySource, nullptr);
+    _exit(0);
+  }
+
+  EXPECT_NE(child, static_cast<pid_t>(-1));
+  int status = 0;
+  EXPECT_EQ(waitpid(child, &status, 0), child);
+  EXPECT_TRUE(WIFSIGNALED(status));
+  EXPECT_EQ(WTERMSIG(status), SIGABRT);
+}
+
+void TestInvalidRocrBlitDuplicateAddressAborts() {
+  const pid_t child = fork();
+  if (child == 0) {
+    rocr::amd::hsa::loader::HotSwapKernelRegistry registry;
+    registry.RegisterKernelObject(
+        0x1850, "kernel", rocr::amd::hsa::loader::HotSwapKernelKind::LazySource,
+        nullptr);
+    registry.RegisterRocrBlitTargetKernelObject(
+        0x1850, 0x80, "gfx942", "embedded_rocr_target_blit_shader",
+        "invalid");
+    _exit(0);
+  }
+
+  EXPECT_NE(child, static_cast<pid_t>(-1));
+  int status = 0;
+  EXPECT_EQ(waitpid(child, &status, 0), child);
+  EXPECT_TRUE(WIFSIGNALED(status));
+  EXPECT_EQ(WTERMSIG(status), SIGABRT);
+}
+
+void TestRocrBlitUnregisterDoesNotRemoveOtherKinds() {
+  rocr::amd::hsa::loader::HotSwapKernelRegistry registry;
+  auto source = registry.RegisterKernelObject(
+      0x1900, "kernel", rocr::amd::hsa::loader::HotSwapKernelKind::LazySource,
+      nullptr);
+
+  EXPECT_FALSE(registry.UnregisterRocrBlitTargetKernelObject(0x1900));
+  EXPECT_TRUE(registry.Lookup(0x1900).get() == source.get());
+}
+
+void TestLoadedKernelUnregisterKeepsPinnedTranslatedTarget() {
+  rocr::amd::hsa::loader::HotSwapKernelRegistry registry;
+  auto source = registry.RegisterKernelObject(
+      0x2000, "kernel", rocr::amd::hsa::loader::HotSwapKernelKind::LazySource,
+      nullptr);
+  registry.RegisterKernelObject(
+      0x3000, "kernel", rocr::amd::hsa::loader::HotSwapKernelKind::Translated,
+      nullptr);
+  source->TargetKernelObject = 0x3000;
+
+  registry.UnregisterLoadedKernelObject(0x2000);
+
+  EXPECT_FALSE(registry.Lookup(0x2000));
+  EXPECT_TRUE(registry.Lookup(0x3000) != nullptr);
+}
+
+void TestLaunchMetadataUpdate() {
+  rocr::amd::hsa::loader::HotSwapKernelRegistry registry;
+  auto record = registry.RegisterKernelObject(
+      0x4000, "kernel", rocr::amd::hsa::loader::HotSwapKernelKind::LazySource,
+      nullptr);
+
+  registry.UpdateLaunchMetadata(0x4000, 32, 16);
+
+  EXPECT_EQ(record->SourceGroupSegmentSize, 32u);
+  EXPECT_EQ(record->SourcePrivateSegmentSize, 16u);
+}
+
+void TestSegmentSizePatchAddsDynamicDelta() {
+  rocr::amd::hsa::loader::HotSwapKernelRecord record;
+  record.SourcePrivateSegmentSize = 16;
+  record.SourceGroupSegmentSize = 32;
+  record.TargetPrivateSegmentSize = 64;
+  record.TargetGroupSegmentSize = 128;
+  record.TargetGroupSegmentLimit = 256;
+
+  uint32_t patchedPrivate = 0;
+  uint32_t patchedGroup = 0;
+  std::string failure;
+  EXPECT_TRUE(rocr::amd::hsa::loader::ComputeHotSwapPatchedSegmentSizes(
+      record, 20, 40, patchedPrivate, patchedGroup, failure));
+  EXPECT_EQ(patchedPrivate, 68u);
+  EXPECT_EQ(patchedGroup, 136u);
+  EXPECT_TRUE(failure.empty());
+}
+
+void TestSegmentSizePatchRefusesUnderflow() {
+  rocr::amd::hsa::loader::HotSwapKernelRecord record;
+  record.SourcePrivateSegmentSize = 16;
+  record.SourceGroupSegmentSize = 32;
+  record.TargetPrivateSegmentSize = 64;
+  record.TargetGroupSegmentSize = 128;
+  record.TargetGroupSegmentLimit = 256;
+
+  uint32_t patchedPrivate = 0;
+  uint32_t patchedGroup = 0;
+  std::string failure;
+  EXPECT_FALSE(rocr::amd::hsa::loader::ComputeHotSwapPatchedSegmentSizes(
+      record, 16, 31, patchedPrivate, patchedGroup, failure));
+  EXPECT_TRUE(failure.find("group segment size") != std::string::npos);
+
+  failure.clear();
+  EXPECT_FALSE(rocr::amd::hsa::loader::ComputeHotSwapPatchedSegmentSizes(
+      record, 15, 32, patchedPrivate, patchedGroup, failure));
+  EXPECT_TRUE(failure.find("private segment size") != std::string::npos);
+}
+
+void TestSegmentSizePatchRefusesTargetLdsOverflow() {
+  rocr::amd::hsa::loader::HotSwapKernelRecord record;
+  record.SourcePrivateSegmentSize = 0;
+  record.SourceGroupSegmentSize = 32;
+  record.TargetPrivateSegmentSize = 0;
+  record.TargetGroupSegmentSize = 96;
+  record.TargetGroupSegmentLimit = 100;
+
+  uint32_t patchedPrivate = 0;
+  uint32_t patchedGroup = 0;
+  std::string failure;
+  EXPECT_FALSE(rocr::amd::hsa::loader::ComputeHotSwapPatchedSegmentSizes(
+      record, 0, 40, patchedPrivate, patchedGroup, failure));
+  EXPECT_TRUE(failure.find("target LDS limit") != std::string::npos);
+}
+
+void TestPresentationTargetRequiresExplicitTarget() {
+  std::string target;
+  std::string failure;
+  EXPECT_FALSE(rocr::amd::hsa::loader::ResolveHotSwapPresentationTarget(
+      true, "", "", "gfx942", target, failure));
+  EXPECT_TRUE(target.empty());
+  EXPECT_TRUE(failure.find("HSA_HOTSWAP_TARGET") != std::string::npos);
+
+  failure.clear();
+  EXPECT_FALSE(rocr::amd::hsa::loader::ResolveHotSwapPresentationTarget(
+      true, "", "1", "gfx942", target, failure));
+  EXPECT_TRUE(target.empty());
+  EXPECT_TRUE(failure.find("HSA_HOTSWAP_TARGET") != std::string::npos);
+}
+
+void TestPresentationTargetUsesExplicitTarget() {
+  std::string target;
+  std::string failure;
+  EXPECT_TRUE(rocr::amd::hsa::loader::ResolveHotSwapPresentationTarget(
+      true, "gfx942", "", "gfx950", target, failure));
+  EXPECT_EQ(target, std::string("gfx942"));
+  EXPECT_TRUE(failure.empty());
+
+  EXPECT_TRUE(rocr::amd::hsa::loader::ResolveHotSwapPresentationTarget(
+      true, "", "gfx950", "gfx942", target, failure));
+  EXPECT_EQ(target, std::string("gfx950"));
+  EXPECT_TRUE(failure.empty());
+}
+
+void TestNonPresentationTargetCanUseExecutionFallback() {
+  std::string target;
+  std::string failure;
+  EXPECT_TRUE(rocr::amd::hsa::loader::ResolveHotSwapPresentationTarget(
+      false, "", "", "gfx942", target, failure));
+  EXPECT_EQ(target, std::string("gfx942"));
+  EXPECT_TRUE(failure.empty());
+}
+
+void TestLazyCacheDirUsesDedicatedOverride() {
+  EXPECT_EQ(rocr::amd::hsa::loader::ResolveLazyHotSwapCacheDir(
+                "/tmp/lazy", "/tmp/eager"),
+            std::string("/tmp/lazy"));
+}
+
+void TestLazyCacheDirUsesSharedSubdirectory() {
+  EXPECT_EQ(rocr::amd::hsa::loader::ResolveLazyHotSwapCacheDir(
+                "", "/tmp/hotswap-cache"),
+            std::string("/tmp/hotswap-cache/lazy-v2"));
+  EXPECT_EQ(rocr::amd::hsa::loader::ResolveLazyHotSwapCacheDir(
+                nullptr, "/tmp/hotswap-cache///"),
+            std::string("/tmp/hotswap-cache/lazy-v2"));
+}
+
+void TestLazyCacheDirCanRemainDisabled() {
+  EXPECT_TRUE(rocr::amd::hsa::loader::ResolveLazyHotSwapCacheDir(
+                  nullptr, nullptr).empty());
+  EXPECT_TRUE(rocr::amd::hsa::loader::ResolveLazyHotSwapCacheDir(
+                  "", "").empty());
+}
+
+void TestHotSwapQueueTypeSupport() {
+  EXPECT_TRUE(rocr::amd::hsa::loader::IsHotSwapQueueTypeSupported(HSA_QUEUE_TYPE_MULTI));
+  EXPECT_FALSE(rocr::amd::hsa::loader::IsHotSwapQueueTypeSupported(HSA_QUEUE_TYPE_SINGLE));
+  EXPECT_FALSE(rocr::amd::hsa::loader::IsHotSwapQueueTypeSupported(HSA_QUEUE_TYPE_COOPERATIVE));
+}
+
+void TestHotSwapEnvFlagParsing() {
+  constexpr const char* kName = "HSA_HOTSWAP_UNIT_TEST_FLAG";
+  unsetenv(kName);
+  EXPECT_FALSE(rocr::hotswap::IsEnvFlagEnabled(kName));
+
+  setenv(kName, "", 1);
+  EXPECT_FALSE(rocr::hotswap::IsEnvFlagEnabled(kName));
+  setenv(kName, "0", 1);
+  EXPECT_FALSE(rocr::hotswap::IsEnvFlagEnabled(kName));
+  setenv(kName, "off", 1);
+  EXPECT_FALSE(rocr::hotswap::IsEnvFlagEnabled(kName));
+  setenv(kName, "FALSE", 1);
+  EXPECT_FALSE(rocr::hotswap::IsEnvFlagEnabled(kName));
+  setenv(kName, "no", 1);
+  EXPECT_FALSE(rocr::hotswap::IsEnvFlagEnabled(kName));
+
+  setenv(kName, "1", 1);
+  EXPECT_TRUE(rocr::hotswap::IsEnvFlagEnabled(kName));
+  setenv(kName, "gfx1250", 1);
+  EXPECT_TRUE(rocr::hotswap::IsEnvFlagEnabled(kName));
+  unsetenv(kName);
+}
+
+}  // namespace
+
+int main() {
+  TestPatchPublishedKernelDispatchPacket();
+  TestPatchPublishedExtKernelDispatchPacket();
+  TestPatchSkipsNonKernelPacket();
+  TestDoorbellPatchRangeMonotonic();
+  TestDoorbellPatchRangeSkipsReplayedDoorbell();
+  TestDoorbellPatchRangeRefusesAliasingRange();
+  TestPatchFailureAborts();
+  TestRocrBlitRegistryRangeAndLifetime();
+  TestInvalidRocrBlitRegistrationIsNotAllowed();
+  TestHotSwapKernelRecordNameDerivation();
+  TestDuplicateKernelObjectRegistrationAborts();
+  TestInvalidRocrBlitDuplicateAddressAborts();
+  TestRocrBlitUnregisterDoesNotRemoveOtherKinds();
+  TestLoadedKernelUnregisterKeepsPinnedTranslatedTarget();
+  TestLaunchMetadataUpdate();
+  TestSegmentSizePatchAddsDynamicDelta();
+  TestSegmentSizePatchRefusesUnderflow();
+  TestSegmentSizePatchRefusesTargetLdsOverflow();
+  TestPresentationTargetRequiresExplicitTarget();
+  TestPresentationTargetUsesExplicitTarget();
+  TestNonPresentationTargetCanUseExecutionFallback();
+  TestLazyCacheDirUsesDedicatedOverride();
+  TestLazyCacheDirUsesSharedSubdirectory();
+  TestLazyCacheDirCanRemainDisabled();
+  TestHotSwapQueueTypeSupport();
+  TestHotSwapEnvFlagParsing();
+
+  if (Failures != 0) {
+    std::cerr << Failures << " HotSwap runtime unit test checks failed\n";
+    return EXIT_FAILURE;
+  }
+  std::cout << "HotSwap runtime unit tests passed\n";
+  return EXIT_SUCCESS;
+}

--- a/projects/rocr-runtime/runtime/hsa-runtime/tests/hotswap_runtime_test.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/tests/hotswap_runtime_test.cpp
@@ -436,41 +436,71 @@ void TestSegmentSizePatchRefusesTargetLdsOverflow() {
 }
 
 void TestPresentationTargetRequiresExplicitTarget() {
-  std::string target;
+  const rocr::core::Isa* executionIsa = rocr::core::IsaRegistry::GetIsa(
+      "amdgcn-amd-amdhsa--gfx942:sramecc+:xnack-");
+  EXPECT_TRUE(executionIsa != nullptr);
+  if (!executionIsa) return;
+
   std::string failure;
-  EXPECT_FALSE(rocr::amd::hsa::loader::ResolveHotSwapPresentationTarget(
-      true, "", "", "gfx942", target, failure));
-  EXPECT_TRUE(target.empty());
+  EXPECT_FALSE(rocr::hotswap::ValidateHotSwapPresentationTarget(
+      "", "", *executionIsa, failure));
   EXPECT_TRUE(failure.find("HSA_HOTSWAP_TARGET") != std::string::npos);
 
-  failure.clear();
-  EXPECT_FALSE(rocr::amd::hsa::loader::ResolveHotSwapPresentationTarget(
-      true, "", "1", "gfx942", target, failure));
-  EXPECT_TRUE(target.empty());
+  EXPECT_FALSE(rocr::hotswap::ValidateHotSwapPresentationTarget(
+      "1", "", *executionIsa, failure));
   EXPECT_TRUE(failure.find("HSA_HOTSWAP_TARGET") != std::string::npos);
 }
 
-void TestPresentationTargetUsesExplicitTarget() {
-  std::string target;
+void TestPresentationTargetMustMatchPhysicalExecutionIsa() {
+  const rocr::core::Isa* gfx942 = rocr::core::IsaRegistry::GetIsa(
+      "amdgcn-amd-amdhsa--gfx942:sramecc+:xnack-");
+  const rocr::core::Isa* gfx950 = rocr::core::IsaRegistry::GetIsa(
+      "amdgcn-amd-amdhsa--gfx950:sramecc+:xnack-");
+  EXPECT_TRUE(gfx942 != nullptr);
+  EXPECT_TRUE(gfx950 != nullptr);
+  if (!gfx942 || !gfx950) return;
+
   std::string failure;
-  EXPECT_TRUE(rocr::amd::hsa::loader::ResolveHotSwapPresentationTarget(
-      true, "gfx942", "", "gfx950", target, failure));
-  EXPECT_EQ(target, std::string("gfx942"));
+  EXPECT_TRUE(rocr::hotswap::ValidateHotSwapPresentationTarget(
+      "amdgcn-amd-amdhsa--gfx942:sramecc+:xnack-", "", *gfx942,
+      failure));
   EXPECT_TRUE(failure.empty());
 
-  EXPECT_TRUE(rocr::amd::hsa::loader::ResolveHotSwapPresentationTarget(
-      true, "", "gfx950", "gfx942", target, failure));
-  EXPECT_EQ(target, std::string("gfx950"));
+  EXPECT_TRUE(rocr::hotswap::ValidateHotSwapPresentationTarget(
+      "", "gfx942", *gfx942, failure));
   EXPECT_TRUE(failure.empty());
+
+  // A single configured target cannot match both physical processors.
+  EXPECT_FALSE(rocr::hotswap::ValidateHotSwapPresentationTarget(
+      "gfx942", "", *gfx950, failure));
+  EXPECT_TRUE(failure.find("gfx942") != std::string::npos);
+  EXPECT_TRUE(failure.find("gfx950") != std::string::npos);
 }
 
-void TestNonPresentationTargetCanUseExecutionFallback() {
-  std::string target;
+void TestPresentationTargetRejectsInvalidIsa() {
+  const rocr::core::Isa* executionIsa = rocr::core::IsaRegistry::GetIsa(
+      "amdgcn-amd-amdhsa--gfx942:sramecc+:xnack-");
+  EXPECT_TRUE(executionIsa != nullptr);
+  if (!executionIsa) return;
+
   std::string failure;
-  EXPECT_TRUE(rocr::amd::hsa::loader::ResolveHotSwapPresentationTarget(
-      false, "", "", "gfx942", target, failure));
-  EXPECT_EQ(target, std::string("gfx942"));
-  EXPECT_TRUE(failure.empty());
+  EXPECT_FALSE(rocr::hotswap::ValidateHotSwapPresentationTarget(
+      "not-an-isa", "", *executionIsa, failure));
+  EXPECT_TRUE(failure.find("not-an-isa") != std::string::npos);
+  EXPECT_TRUE(failure.find("not recognized") != std::string::npos);
+}
+
+void TestPresentationTargetRejectsFeatureMismatch() {
+  const rocr::core::Isa* executionIsa = rocr::core::IsaRegistry::GetIsa(
+      "amdgcn-amd-amdhsa--gfx942:sramecc+:xnack-");
+  EXPECT_TRUE(executionIsa != nullptr);
+  if (!executionIsa) return;
+
+  std::string failure;
+  EXPECT_FALSE(rocr::hotswap::ValidateHotSwapPresentationTarget(
+      "gfx942:sramecc+:xnack+", "", *executionIsa, failure));
+  EXPECT_TRUE(failure.find("gfx942:sramecc+:xnack+") != std::string::npos);
+  EXPECT_TRUE(failure.find("gfx942:sramecc+:xnack-") != std::string::npos);
 }
 
 void TestLazyCacheDirUsesDedicatedOverride() {
@@ -539,8 +569,9 @@ int main() {
   TestSegmentSizePatchRefusesUnderflow();
   TestSegmentSizePatchRefusesTargetLdsOverflow();
   TestPresentationTargetRequiresExplicitTarget();
-  TestPresentationTargetUsesExplicitTarget();
-  TestNonPresentationTargetCanUseExecutionFallback();
+  TestPresentationTargetMustMatchPhysicalExecutionIsa();
+  TestPresentationTargetRejectsInvalidIsa();
+  TestPresentationTargetRejectsFeatureMismatch();
   TestLazyCacheDirUsesDedicatedOverride();
   TestLazyCacheDirUsesSharedSubdirectory();
   TestLazyCacheDirCanRemainDisabled();

--- a/projects/rocr-runtime/runtime/hsa-runtime/tests/hotswap_runtime_test.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/tests/hotswap_runtime_test.cpp
@@ -223,7 +223,7 @@ void TestRocrBlitRegistryRangeAndLifetime() {
       0x1000, 0x80, "gfx942", "embedded_rocr_target_blit_shader",
       "invalid");
 
-  EXPECT_EQ(record->Kind,
+  EXPECT_EQ(record->Kind.load(),
             rocr::amd::hsa::loader::HotSwapKernelKind::RuntimeTargetInternal);
   EXPECT_TRUE(record->IsRegisteredRocrBlit(0x1000));
   EXPECT_TRUE(record->IsRegisteredRocrBlit(0x107f));
@@ -242,7 +242,7 @@ void TestInvalidRocrBlitRegistrationIsNotAllowed() {
   auto record = registry.RegisterRocrBlitTargetKernelObject(
       0, 0x80, "<unknown>", "embedded_rocr_target_blit_shader", "invalid");
 
-  EXPECT_EQ(record->Kind,
+  EXPECT_EQ(record->Kind.load(),
             rocr::amd::hsa::loader::HotSwapKernelKind::Untranslated);
   EXPECT_EQ(record->Failure, std::string("invalid"));
   EXPECT_FALSE(record->IsRegisteredRocrBlit(0));
@@ -373,6 +373,28 @@ void TestSegmentSizePatchAddsDynamicDelta() {
       record, 20, 40, patchedPrivate, patchedGroup, failure));
   EXPECT_EQ(patchedPrivate, 68u);
   EXPECT_EQ(patchedGroup, 136u);
+  EXPECT_TRUE(failure.empty());
+}
+
+void TestTranslatedDispatchPatchRewritesSourcePacket() {
+  rocr::amd::hsa::loader::HotSwapKernelRecord record;
+  record.Kind.store(rocr::amd::hsa::loader::HotSwapKernelKind::Translated);
+  record.SourcePrivateSegmentSize = 16;
+  record.SourceGroupSegmentSize = 32;
+  record.TargetKernelObject = 0x5000;
+  record.TargetPrivateSegmentSize = 64;
+  record.TargetGroupSegmentSize = 128;
+  record.TargetGroupSegmentLimit = 256;
+
+  uint64_t kernelObject = 0x1000;
+  uint32_t privateSegmentSize = 20;
+  uint32_t groupSegmentSize = 40;
+  std::string failure;
+  EXPECT_TRUE(rocr::amd::hsa::loader::PatchHotSwapTranslatedDispatch(
+      record, kernelObject, privateSegmentSize, groupSegmentSize, failure));
+  EXPECT_EQ(kernelObject, 0x5000u);
+  EXPECT_EQ(privateSegmentSize, 68u);
+  EXPECT_EQ(groupSegmentSize, 136u);
   EXPECT_TRUE(failure.empty());
 }
 
@@ -513,6 +535,7 @@ int main() {
   TestLoadedKernelUnregisterKeepsPinnedTranslatedTarget();
   TestLaunchMetadataUpdate();
   TestSegmentSizePatchAddsDynamicDelta();
+  TestTranslatedDispatchPatchRewritesSourcePacket();
   TestSegmentSizePatchRefusesUnderflow();
   TestSegmentSizePatchRefusesTargetLdsOverflow();
   TestPresentationTargetRequiresExplicitTarget();

--- a/projects/rocr-runtime/runtime/hsa-runtime/tests/hotswap_runtime_test.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/tests/hotswap_runtime_test.cpp
@@ -234,6 +234,7 @@ void TestRocrBlitRegistryRangeAndLifetime() {
 
   EXPECT_TRUE(registry.UnregisterRocrBlitTargetKernelObject(0x1000));
   EXPECT_FALSE(registry.Lookup(0x1000));
+  EXPECT_FALSE(registry.Lookup(0x107f));
 }
 
 void TestInvalidRocrBlitRegistrationIsNotAllowed() {
@@ -314,6 +315,19 @@ void TestRocrBlitUnregisterDoesNotRemoveOtherKinds() {
 
   EXPECT_FALSE(registry.UnregisterRocrBlitTargetKernelObject(0x1900));
   EXPECT_TRUE(registry.Lookup(0x1900).get() == source.get());
+}
+
+void TestRocrBlitRangeDoesNotHideExactKernelObject() {
+  rocr::amd::hsa::loader::HotSwapKernelRegistry registry;
+  auto blit = registry.RegisterRocrBlitTargetKernelObject(
+      0x2000, 0x100, "gfx942", "embedded_rocr_target_blit_shader",
+      "invalid");
+  auto source = registry.RegisterKernelObject(
+      0x2080, "kernel", rocr::amd::hsa::loader::HotSwapKernelKind::LazySource,
+      nullptr);
+
+  EXPECT_TRUE(registry.Lookup(0x207f).get() == blit.get());
+  EXPECT_TRUE(registry.Lookup(0x2080).get() == source.get());
 }
 
 void TestLoadedKernelUnregisterKeepsPinnedTranslatedTarget() {
@@ -495,6 +509,7 @@ int main() {
   TestDuplicateKernelObjectRegistrationAborts();
   TestInvalidRocrBlitDuplicateAddressAborts();
   TestRocrBlitUnregisterDoesNotRemoveOtherKinds();
+  TestRocrBlitRangeDoesNotHideExactKernelObject();
   TestLoadedKernelUnregisterKeepsPinnedTranslatedTarget();
   TestLaunchMetadataUpdate();
   TestSegmentSizePatchAddsDynamicDelta();

--- a/projects/rocr-runtime/runtime/hsa-runtime/tests/hotswap_runtime_test.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/tests/hotswap_runtime_test.cpp
@@ -502,26 +502,17 @@ void TestHotSwapQueueTypeSupport() {
 }
 
 void TestHotSwapEnvFlagParsing() {
-  constexpr const char* kName = "HSA_HOTSWAP_UNIT_TEST_FLAG";
-  unsetenv(kName);
-  EXPECT_FALSE(rocr::hotswap::IsEnvFlagEnabled(kName));
+  EXPECT_FALSE(rocr::hotswap::IsEnvFlagValueEnabled(""));
+  EXPECT_FALSE(rocr::hotswap::IsEnvFlagValueEnabled("0"));
+  EXPECT_FALSE(rocr::hotswap::IsEnvFlagValueEnabled("off"));
+  EXPECT_FALSE(rocr::hotswap::IsEnvFlagValueEnabled("FALSE"));
+  EXPECT_FALSE(rocr::hotswap::IsEnvFlagValueEnabled("no"));
+  EXPECT_FALSE(rocr::hotswap::IsEnvFlagValueEnabled("n"));
+  EXPECT_FALSE(rocr::hotswap::IsEnvFlagValueEnabled("f"));
 
-  setenv(kName, "", 1);
-  EXPECT_FALSE(rocr::hotswap::IsEnvFlagEnabled(kName));
-  setenv(kName, "0", 1);
-  EXPECT_FALSE(rocr::hotswap::IsEnvFlagEnabled(kName));
-  setenv(kName, "off", 1);
-  EXPECT_FALSE(rocr::hotswap::IsEnvFlagEnabled(kName));
-  setenv(kName, "FALSE", 1);
-  EXPECT_FALSE(rocr::hotswap::IsEnvFlagEnabled(kName));
-  setenv(kName, "no", 1);
-  EXPECT_FALSE(rocr::hotswap::IsEnvFlagEnabled(kName));
-
-  setenv(kName, "1", 1);
-  EXPECT_TRUE(rocr::hotswap::IsEnvFlagEnabled(kName));
-  setenv(kName, "gfx1250", 1);
-  EXPECT_TRUE(rocr::hotswap::IsEnvFlagEnabled(kName));
-  unsetenv(kName);
+  EXPECT_TRUE(rocr::hotswap::IsEnvFlagValueEnabled("1"));
+  EXPECT_TRUE(rocr::hotswap::IsEnvFlagValueEnabled("true"));
+  EXPECT_TRUE(rocr::hotswap::IsEnvFlagValueEnabled("gfx1250"));
 }
 
 }  // namespace


### PR DESCRIPTION
## Motivation

HotSwap translates AMD GPU machine code from one ISA to another, so a kernel built for one AMD GPU can run on a different one.

The immediate driver is upcoming GPUs, whose code objects often work well before the silicon is widely available. HotSwap lets us develop against that software --frameworks, libraries, and their kernels-- and run it in CI on current hardware, giving early signal on whether it loads, dispatches, and produces correct results instead of waiting for scarce or unavailable silicon.

## Technical details

The translation itself is being added to COMGR (`amd_comgr_hotswap_transpile`) as separate, in-progress work. This PR is the runtime integration that drives it and generates no code itself. It is an early proposal, brought for guidance rather than as a finished design.

Frameworks and libraries pick which code objects to load based on the GPU they see, so with this patch the runtime presents a source ISA that differs from the device's physical execution ISA, and tracks both. The stack loads source-ISA code objects, and ROCclr admits them instead of rejecting them as incompatible. The first time a source-ISA kernel is dispatched, ROCr translates it through COMGR and caches the result for reuse. The dispatch path then rewrites the AQL packet's kernel_object to the translated kernel before it reaches hardware. This is transparent to the application and looks like an ordinary dispatch.

Translation is lazy because a code object may hold many kernels while a workload dispatches only a few. Anything we can't handle safely, e.g. an unsupported translation, is refused. We are currently translating code objects from gfx1250 to gfx942 or gfx950 (e.g. running MI450 kernels on MI350), but the mechanism is not tied to those.

The features in this patch are controlled at runtime by `HSA_HOTSWAP_PRESENT_ISA`. With it unset, the runtime runs exactly as it does today: the new checks all short-circuit, so no kernel is translated and no dispatch is rewritten. The rest is inert too -- `execution_isas()` returns the device's usual ISA and the presented-ISA fields fall back to it. So this PR with the variable should behave like a build without it.

## Discussion

We'd like guidance from the runtime owners on:

- how you see the overall approach of presenting one ISA while executing another, and whether this capability belongs in ROCr/ROCclr or elsewhere
- whether the presented-ISA / execution-ISA split sits in the right place across ROCr and ROCclr
- how you'd want it staged for review across queue/dispatch, loader/kernel-object tracking, and ROCclr device presentation.

JIRA ID: ROCM-28199