### PR TITLE
Restore Unit_hipExtModuleLaunchKernel_AnyOrder test.

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/module.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/module.yaml
@@ -306,6 +306,9 @@ module:
     # SWDEV-438524: Below tests causing TDR & machine down in stress test on 15/12/23
     disabled: [amd_windows, amd_wsl]
     tags: [launch]
+  Unit_hipExtModuleLaunchKernel_AnyOrder:
+    <<: *level_2
+    tags: [launch]
   Unit_hipFuncGetAttributes_basic:
     <<: *level_2
     tags: [function]

--- a/projects/hip-tests/catch/unit/module/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/module/CMakeLists.txt
@@ -277,6 +277,17 @@ if(HIP_PLATFORM MATCHES "amd")
                   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/copyKernel.cc
                   COMMENT "Compiling copyKernelGenericTargetCompressed.code")
   add_custom_target(copyKernelGenericTargetCompressed_code DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/copyKernelGenericTargetCompressed.code)
+
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/anyOrderLaunch.code
+                  COMMAND ${CMAKE_HIP_COMPILER} ${HIP_DEVICE_BUILD_FLAGS_NO_ARCH} ${OFFLOAD_ARCH_LIST} -mcode-object-version=5 --cuda-device-only
+                  -x hip ${CMAKE_CURRENT_SOURCE_DIR}/anyOrderLaunch.cc
+                  -o ${CMAKE_CURRENT_BINARY_DIR}/anyOrderLaunch.code
+                  -I${HIP_INCLUDE_DIR} ${HIP_PATH_OPT}
+                  -I${CMAKE_CURRENT_SOURCE_DIR}/../../include
+                  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/anyOrderLaunch.cc
+                  COMMENT "Compiling anyOrderLaunch.code")
+  add_custom_target(anyOrderLaunch_code DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/anyOrderLaunch.code)
+
   set_property(GLOBAL APPEND PROPERTY G_INSTALL_CUSTOM_TARGETS
   ${CMAKE_CURRENT_BINARY_DIR}/copyKernel.code
   ${CMAKE_CURRENT_BINARY_DIR}/copyKernel.s
@@ -284,6 +295,7 @@ if(HIP_PLATFORM MATCHES "amd")
   ${CMAKE_CURRENT_BINARY_DIR}/copyKernelCompressed.code
   ${CMAKE_CURRENT_BINARY_DIR}/copyKernelGenericTarget.code
   ${CMAKE_CURRENT_BINARY_DIR}/copyKernelGenericTargetCompressed.code
+  ${CMAKE_CURRENT_BINARY_DIR}/anyOrderLaunch.code
 )
 
   if(UNIX)
@@ -409,6 +421,7 @@ if(HIP_PLATFORM MATCHES "amd")
   add_dependencies(ModuleTest copyKernelCompressed_code)
   add_dependencies(ModuleTest copyKernelGenericTarget_code)
   add_dependencies(ModuleTest copyKernelGenericTargetCompressed_code)
+  add_dependencies(ModuleTest anyOrderLaunch_code)
 
   if(UNIX)
     add_dependencies(ModuleTest copiousArgKernel_code copiousArgKernel0_code copiousArgKernel1_code copiousArgKernel2_code

--- a/projects/hip-tests/catch/unit/module/anyOrderLaunch.cc
+++ b/projects/hip-tests/catch/unit/module/anyOrderLaunch.cc
@@ -19,7 +19,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-#include"hip/hip_runtime.h"
+#include <hip/hip_runtime.h>
 
 __device__ int data = 0;
 extern "C" __global__ void first(int* res, int ticks_for_100us) {

--- a/projects/hip-tests/catch/unit/module/anyOrderLaunch.cc
+++ b/projects/hip-tests/catch/unit/module/anyOrderLaunch.cc
@@ -1,0 +1,38 @@
+/*
+Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#include"hip/hip_runtime.h"
+
+__device__ int data = 0;
+extern "C" __global__ void first(int* res, int ticks_for_100us) {
+  uint64_t start = wall_clock64();
+  while (__hip_atomic_load(&data, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT) != 1) {
+    __builtin_amdgcn_s_sleep(10);
+    if (wall_clock64() - start >= ticks_for_100us) {
+      *res = 2;
+      return;
+    }
+  }
+  *res = 1;
+}
+extern "C" __global__ void second() {
+  atomicAdd(&data, 1);
+}

--- a/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
@@ -764,11 +764,10 @@ TEST_CASE("Unit_hipExtModuleLaunchKernel_AnyOrder") {
   hipDeviceProp_t props{};
   HIP_CHECK(hipGetDevice(&device));
   HIP_CHECK(hipGetDeviceProperties(&props, device));
-  std::string arch = std::string(props.gcnArchName);
-  auto pos = arch.find("gfx9");
-  // skip for all gfx9xx, Meant to run on gfx11xx & gfx12xx.
-  if (pos != std::string::npos) {
-    HIP_SKIP_TEST("Not supported on gfx9xx. Skipping test ...");
+  const std::string arch(props.gcnArchName);
+  // Meant to run on gfx11xx & gfx12xx only.
+  if (!(arch.rfind("gfx11", 0) == 0 || arch.rfind("gfx12", 0) == 0)) {
+    HIP_SKIP_TEST("Any-order launch supported only on gfx11xx/gfx12xx. Skipping test ...");
     return;
   }
   int ticks_per_ms = 0;

--- a/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
@@ -771,7 +771,7 @@ TEST_CASE("Unit_hipExtModuleLaunchKernel_AnyOrder") {
     return;
   }
   int ticks_per_ms = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&ticks_per_ms, hipDeviceAttributeWallClockRate, 0));
+  HIP_CHECK(hipDeviceGetAttribute(&ticks_per_ms, hipDeviceAttributeWallClockRate, device));
   //TODO: Remove this once we gets correct wall clock rate from ROCR/KFD.
   if (ticks_per_ms == 0) {
     ticks_per_ms = 1000000;

--- a/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
@@ -777,8 +777,10 @@ TEST_CASE("Unit_hipExtModuleLaunchKernel_AnyOrder") {
     ticks_per_ms = 1000000;
   }
   // wait in first kernel.
-  int ticks_per_100us = ticks_per_ms; //(ticks_per_ms / 1000) * 100;
-  hipModule_t module;
+  int ticks_per_100us = ticks_per_ms / 10;
+  if (ticks_per_100us == 0) {
+    ticks_per_100us = 1;
+  }
   hipFunction_t first;
   hipFunction_t second;
   HIP_CHECK(hipModuleLoad(&module, "anyOrderLaunch.code"));

--- a/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
@@ -786,7 +786,7 @@ TEST_CASE("Unit_hipExtModuleLaunchKernel_AnyOrder") {
   HIP_CHECK(hipModuleGetFunction(&second, module, "second"));
 
   int* res;
-  HIP_CHECK(hipHostMalloc(&res, sizeof(int), hipHostAllocMapped));
+  HIP_CHECK(hipHostMalloc(reinterpret_cast<void**>(&res), sizeof(int), hipHostAllocMapped));
   *res = 0;
 
   int *dres;

--- a/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
@@ -758,6 +758,66 @@ HIP_TEST_CASE(Unit_hipExtModuleLaunchKernel_Functional) {
     REQUIRE(testStatus == true);
   }
 }
+
+TEST_CASE("Unit_hipExtModuleLaunchKernel_AnyOrder") {
+  int device = -1;
+  hipDeviceProp_t props{};
+  HIP_CHECK(hipGetDevice(&device));
+  HIP_CHECK(hipGetDeviceProperties(&props, device));
+  std::string arch = std::string(props.gcnArchName);
+  auto pos = arch.find("gfx9");
+  // skip for all gfx9xx, Meant to run on gfx11xx & gfx12xx.
+  if (pos != std::string::npos) {
+    HIP_SKIP_TEST("Not supported on gfx9xx. Skipping test ...");
+    return;
+  }
+  int ticks_per_ms = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&ticks_per_ms, hipDeviceAttributeWallClockRate, 0));
+  //TODO: Remove this once we gets correct wall clock rate from ROCR/KFD.
+  if (ticks_per_ms == 0) {
+    ticks_per_ms = 1000000;
+  }
+  // wait in first kernel.
+  int ticks_per_100us = ticks_per_ms; //(ticks_per_ms / 1000) * 100;
+  hipModule_t module;
+  hipFunction_t first;
+  hipFunction_t second;
+  HIP_CHECK(hipModuleLoad(&module, "anyOrderLaunch.code"));
+  HIP_CHECK(hipModuleGetFunction(&first, module, "first"));
+  HIP_CHECK(hipModuleGetFunction(&second, module, "second"));
+
+  int* res;
+  HIP_CHECK(hipHostMalloc(&res, sizeof(int), hipHostAllocMapped));
+  *res = 0;
+
+  int *dres;
+  HIP_CHECK(hipHostGetDevicePointer(reinterpret_cast<void**>(&dres), res, 0));
+
+  struct {
+    int* _res;
+    int _ticks_per_100us;
+  } args;
+
+  args._res = dres;
+  args._ticks_per_100us = ticks_per_100us;
+
+  size_t size = sizeof(args);
+  void* config1[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args, HIP_LAUNCH_PARAM_BUFFER_SIZE, &size,
+                    HIP_LAUNCH_PARAM_END};
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+  HIP_CHECK(hipExtModuleLaunchKernel(first, 1, 1, 1, 1, 1, 1, 0, stream, nullptr,
+                                    reinterpret_cast<void**>(&config1), 0, 0,
+                                    hipExtAnyOrderLaunch));
+  HIP_CHECK(hipExtModuleLaunchKernel(second, 1, 1, 1, 1, 1, 1, 0, stream, nullptr,
+                                    nullptr, 0, 0,
+                                    hipExtAnyOrderLaunch));
+  HIP_CHECK(hipStreamSynchronize(stream));
+  REQUIRE(*res == 1);
+  HIP_CHECK(hipModuleUnload(module));
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipHostFree(res));
+}
 /**
  * End doxygen group KernelTest.
  * @}

--- a/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
@@ -783,6 +783,7 @@ TEST_CASE("Unit_hipExtModuleLaunchKernel_AnyOrder") {
   }
   hipFunction_t first;
   hipFunction_t second;
+  hipModule_t module;
   HIP_CHECK(hipModuleLoad(&module, "anyOrderLaunch.code"));
   HIP_CHECK(hipModuleGetFunction(&first, module, "first"));
   HIP_CHECK(hipModuleGetFunction(&second, module, "second"));


### PR DESCRIPTION
## Motivation

Unit_hipExtModuleLaunchKernel_AnyOrder test is developed to validate concurrent anyorder kernel feature for capable ASIC. It has been removed from records.

## Technical Details

Restore Unit_hipExtModuleLaunchKernel_AnyOrder.

## Issue Tracking

Restore Unit_hipExtModuleLaunchKernel_AnyOrder

## Test Plan

Run Unit_hipExtModuleLaunchKernel_AnyOrder on gfx1250.

## Test Result

Unit_hipExtModuleLaunchKernel_AnyOrder pass. 
Note : TODO : KFD/ROCr returns 0 wall clock for gfx1250 (https://ontrack-internal.amd.com/browse/SWDEV-580031) and hence masked it with 1000000 if it is still 0 in test code.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
