### PR TITLE
test(rccl): added AsyncSignal test

### DIFF
--- a/projects/rccl/test/HostApiMPITests.cpp
+++ b/projects/rccl/test/HostApiMPITests.cpp
@@ -63,10 +63,24 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <chrono>
 
 using namespace MPITestConstants;
 using namespace RCCLTestGuards;
 using namespace RCCLHostApiHelpers;
+
+// ---------------------------------------------------------------------------
+// busy wait kernel
+// ---------------------------------------------------------------------------
+__global__ void hostApiSpinKernel(unsigned long long cycles, volatile int* sink)
+{
+    unsigned long long start = clock64();
+    int                acc   = 0;
+    while(static_cast<unsigned long long>(clock64() - start) < cycles)
+        acc++;
+    if(sink)
+        *sink = acc;
+}
 
 namespace RcclUnitTesting
 {
@@ -134,6 +148,21 @@ inline int winMode()
         cumem_ = e ? (atoi(e) != 0) : true; 
     }
     return cumem_ ? NCCL_WIN_COLL_SYMMETRIC : NCCL_WIN_DEFAULT;
+}
+
+// Calibrate how many clock64() cycles approximate targetMs of GPU busy wait.
+inline unsigned long long calibrateSpinCycles(hipStream_t s, volatile int* sink,
+                                              double targetMs)
+{
+    const unsigned long long probe = 1500000ULL * 1000ULL; // ~1 ms @ 1.5 GHz guess
+    auto t0 = std::chrono::steady_clock::now();
+    hipLaunchKernelGGL(hostApiSpinKernel, dim3(1), dim3(1), 0, s, probe, sink);
+    (void)hipStreamSynchronize(s);
+    auto t1 = std::chrono::steady_clock::now();
+    double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    if(ms < 1e-3)
+        ms = 1e-3;
+    return static_cast<unsigned long long>((probe / ms) * targetMs);
 }
 } // namespace
 
@@ -248,6 +277,99 @@ TEST_F(HostApiTest, SinglePutRank0ToRank1)
     ASSERT_MPI_TRUE(ok);
 
     TEST_INFO("P1 rank %d: SinglePutRank0ToRank1 passed.", myRank);
+}
+
+// ============================================================================
+// A1 — PutSignalEnqueueIsAsync
+// ============================================================================
+/**
+ * @test HostApiTest.PutSignalEnqueueIsAsync
+ * @brief ncclPutSignal host-side enqueue must be asynchronous (no implicit
+ *        CPU-GPU synchronization) even while the target stream is busy.
+ *
+ * Regression test:
+ * defect was an implicit stream synchronization inside the CE / putSignal
+ * enqueue path caused by staging the signal value through a pageable host
+ * memcpy.
+ */
+TEST_F(HostApiTest, PutSignalEnqueueIsAsync)
+{
+    constexpr double kSpinMs        = 80.0;  // how long the busy wait kernel runs
+    constexpr double kBlockFraction = 0.5;   // host-return >= this*kSpinMs => blocked
+    constexpr int    kAsyncNumPuts  = 16;    // puts issued per measurement
+    constexpr size_t kAsyncPutElems = 256;   // uint8 elements per put (small)
+
+    if(!validateTestPrerequisites(/*min=*/2, /*max=*/2))
+    {
+        GTEST_SKIP() << "Need exactly 2 MPI processes";
+    }
+
+    const int   myRank = rank();
+    ncclComm_t  comm   = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+
+    const int    peer     = (myRank + 1) % 2;
+    const size_t winBytes = static_cast<size_t>(kAsyncNumPuts) * kAsyncPutElems;
+
+    void* winBuf = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess, allocFineGrainBuffer(&winBuf, winBytes));
+    auto winBufGuard = makeScopeGuard([&]() { freeFineGrainBuffer(winBuf); });
+
+    ncclWindow_t win = nullptr;
+    NcclWindowGuard wg(comm, winBuf, winBytes, &win, winMode());
+    ASSERT_MPI_NE(win, nullptr);
+    ASSERT_MPI_EQ(ncclSuccess, wg.initResult());
+
+    // Sink for the busy wait kernel (device scratch).
+    void* sink = nullptr;
+    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&sink, sizeof(int)));
+    auto sinkGuard = makeScopeGuard([&]() { if(sink) (void)hipFree(sink); });
+
+    // Warm up the putSignal machinery once.
+    ncclResult_t warmRes = ncclPutSignal(
+        winBuf, kAsyncPutElems, ncclUint8, peer, win, /*peerWinOffset=*/0,
+        kSigIdx, kCtx, kFlags, comm, stream);
+    ASSERT_MPI_EQ(ncclSuccess, warmRes);
+    {
+        ncclWaitSignalDesc_t d{/*opCnt=*/1, /*peer=*/peer, kSigIdx, kCtx};
+        ASSERT_MPI_EQ(ncclSuccess, ncclWaitSignal(1, &d, comm, stream));
+    }
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    const unsigned long long spinCycles =
+        calibrateSpinCycles(stream, static_cast<volatile int*>(sink), kSpinMs);
+
+    // Measurement: occupy the stream, then time a batch of putSignal enqueues.
+    MPI_Barrier(MPI_COMM_WORLD);
+    hipLaunchKernelGGL(hostApiSpinKernel, dim3(1), dim3(1), 0, stream,
+                       spinCycles, static_cast<volatile int*>(sink));
+
+    auto t0 = std::chrono::steady_clock::now();
+    ncclResult_t putRes = ncclSuccess;
+    for(int i = 0; i < kAsyncNumPuts && putRes == ncclSuccess; ++i)
+    {
+        size_t off = static_cast<size_t>(i) * kAsyncPutElems;
+        putRes = ncclPutSignal(
+            static_cast<uint8_t*>(winBuf) + off, kAsyncPutElems, ncclUint8,
+            peer, win, off, kSigIdx, kCtx, kFlags, comm, stream);
+    }
+    auto t1 = std::chrono::steady_clock::now();
+    const double hostMs = std::chrono::duration<double, std::milli>(t1 - t0).count();
+
+    ASSERT_MPI_EQ(ncclSuccess, putRes);
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    const double blockThresholdMs = kSpinMs * kBlockFraction;
+    const bool   async            = hostMs < blockThresholdMs;
+
+    TEST_INFO("A1 rank %d -> peer %d: %d putSignal enqueues host-return %.3f ms "
+              "(stream busy ~%.1f ms) => %s",
+              myRank, peer, kAsyncNumPuts, hostMs, kSpinMs,
+              async ? "async" : "BLOCKED (implicit sync)");
+
+    ASSERT_MPI_TRUE(async);
 }
 
 // ============================================================================

--- a/projects/rccl/test/HostApiMPITests.cpp
+++ b/projects/rccl/test/HostApiMPITests.cpp
@@ -342,6 +342,7 @@ TEST_F(HostApiTest, PutSignalEnqueueIsAsync)
 
     // Measurement: occupy the stream, then time a batch of putSignal enqueues.
     MPI_Barrier(MPI_COMM_WORLD);
+    // NOTE: sink value and winBuf have no meaningfull values, thus should not be checked
     hipLaunchKernelGGL(hostApiSpinKernel, dim3(1), dim3(1), 0, stream,
                        spinCycles, static_cast<volatile int*>(sink));
 

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -583,6 +583,7 @@
       "tests": [
         {"name": "HostApi_WindowRegisterDeregister", "description": "Host API: window register/deregister", "test_filter": "HostApiTest.WindowRegisterDeregister"},
         {"name": "HostApi_SinglePutRank0ToRank1", "description": "Host API: single put rank0 to rank1", "test_filter": "HostApiTest.SinglePutRank0ToRank1"},
+        {"name": "HostApi_PutSignalEnqueueIsAsync", "description": "Host API: putSignal enqueue is async", "test_filter": "HostApiTest.PutSignalEnqueueIsAsync"},
         {"name": "HostApi_PutWithNonZeroOffset", "description": "Host API: put with non-zero offset", "test_filter": "HostApiTest.PutWithNonZeroOffset"},
         {"name": "HostApi_PutMultipleDataTypes", "description": "Host API: put multiple data types", "test_filter": "HostApiTest.PutMultipleDataTypes"},
         {"name": "HostApi_SignalOnlyNoData", "description": "Host API: signal only, no data", "test_filter": "HostApiTest.SignalOnlyNoData"},


### PR DESCRIPTION
Adds HostApiTest.PutSignalEnqueueIsAsync, an MPI regression test asserting that ncclPutSignal host-side enqueue stays asynchronous (returns in microseconds) while the target stream is kept busy by a spin kernel, rather than blocking for the full stream duration. It guards against the implicit CPU-GPU synchronization regression on the putSignal/CE path caused by staging the signal value through a pageable host memcpy. Fixes AICOMRCCL-1517

## Motivation

Fixes AICOMRCCL-1517

## Issue Tracking

AICOMRCCL-1517

## Test Plan

Validated manually.
Test enabled in CI.

## Test Result
Manual test: PASSED

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
