### PR TITLE
ci(rocprofiler-systems): Enable remaining selective-region tests

### DIFF
--- a/.github/workflows/rocprofiler-systems-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-systems-continuous-integration.yml
@@ -57,7 +57,7 @@ env:
   ROCPROFSYS_TMPDIR: "%env{PWD}%/testing-tmp"
   ROCM_PATH: "/opt/rocm"
 
-  EXCLUDED_TESTS: "fork.*|jacobi-usm-sys-run|jacobi-roctx.*|jpeg-decode-.*|selective-region-region-1-filter.*|selective-region-region-2-and-3.*|selective-region-no-marker-region-1-filter.*|kfd-.*|unified-memory-output-sys-run|rccl-alltoall-perf-sys-run"
+  EXCLUDED_TESTS: "fork.*|jacobi-usm-sys-run|jacobi-roctx.*|jpeg-decode-.*|kfd-.*|unified-memory-output-sys-run|rccl-alltoall-perf-sys-run"
   EXCLUDED_LABELS: "thread_limit"
 
 jobs:

--- a/projects/rocprofiler-systems/tests/test_categories.yaml
+++ b/projects/rocprofiler-systems/tests/test_categories.yaml
@@ -39,9 +39,6 @@ _common_therock_regex_excludes: &_common_therock_regex_excludes
   - "jpeg-decode.*"
   - "matrix-exponential.*"
   - "scratch-memory.*"
-  - "selective-region-region-1-filter.*"
-  - "selective-region-region-2-and-3.*"
-  - "selective-region-no-marker-region-1-filter.*"
   - "shmem-pingpong.*"
   - "video-decode.*"
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

`ROCprofiler-SDK`'s #6276 has made a CI warning that would previously crash some `selective-region` tests non-fatal.
Now we can re-enable the remaining tests.

## Technical Details

Remove the following from the common TheRock exclusion list on `gfx950` workflow AND `test_categories.yaml`:
```
selective-region-region-1-filter.*
selective-region-region-2-and-3.*
selective-region-no-marker-region-1-filter.*
```

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

Jira ID: AIPROFSYST-521

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Workflows + TheRock CI

## Test Result

<!-- Briefly summarize test outcomes. -->

`gfx950` tests pass: https://github.com/ROCm/rocm-systems/actions/runs/29582264277/job/87890685718?pr=8759

TheRock CI tests pass: https://github.com/ROCm/rocm-systems/actions/runs/29584647543/job/87915973657?pr=8759
```
        Start 488: selective-region-no-filter-start-stop-sys-run
355/473 Test #488: selective-region-no-filter-start-stop-sys-run ...................................................................................................................................   Passed    6.85 sec
        Start 489: selective-region-no-filter-start-stop-sampling
356/473 Test #489: selective-region-no-filter-start-stop-sampling ..................................................................................................................................   Passed    6.80 sec
        Start 490: selective-region-no-filter-push-pop-sys-run
357/473 Test #490: selective-region-no-filter-push-pop-sys-run .....................................................................................................................................   Passed    6.82 sec
        Start 491: selective-region-no-filter-push-pop-sampling
358/473 Test #491: selective-region-no-filter-push-pop-sampling ....................................................................................................................................   Passed    6.82 sec
        Start 492: selective-region-region-1-filter-start-stop-sys-run
359/473 Test #492: selective-region-region-1-filter-start-stop-sys-run .............................................................................................................................   Passed    6.09 sec
        Start 493: selective-region-region-1-filter-start-stop-sampling
360/473 Test #493: selective-region-region-1-filter-start-stop-sampling ............................................................................................................................   Passed    6.11 sec
        Start 494: selective-region-region-1-filter-push-pop-sys-run
361/473 Test #494: selective-region-region-1-filter-push-pop-sys-run ...............................................................................................................................   Passed    6.12 sec
        Start 495: selective-region-region-1-filter-push-pop-sampling
362/473 Test #495: selective-region-region-1-filter-push-pop-sampling ..............................................................................................................................   Passed    6.12 sec
        Start 496: selective-region-region-2-and-3-filter-start-stop-sys-run
363/473 Test #496: selective-region-region-2-and-3-filter-start-stop-sys-run .......................................................................................................................   Passed    5.93 sec
        Start 497: selective-region-region-2-and-3-filter-start-stop-sampling
364/473 Test #497: selective-region-region-2-and-3-filter-start-stop-sampling ......................................................................................................................   Passed    5.94 sec
        Start 498: selective-region-region-2-and-3-filter-push-pop-sys-run
365/473 Test #498: selective-region-region-2-and-3-filter-push-pop-sys-run .........................................................................................................................   Passed    5.93 sec
        Start 499: selective-region-region-2-and-3-filter-push-pop-sampling
366/473 Test #499: selective-region-region-2-and-3-filter-push-pop-sampling ........................................................................................................................   Passed    5.95 sec
        Start 500: selective-region-pause-no-filter-inside-start-stop-sys-run
367/473 Test #500: selective-region-pause-no-filter-inside-start-stop-sys-run ......................................................................................................................   Passed    4.79 sec
        Start 501: selective-region-pause-no-filter-inside-start-stop-sampling
368/473 Test #501: selective-region-pause-no-filter-inside-start-stop-sampling .....................................................................................................................   Passed    4.76 sec
        Start 502: selective-region-pause-no-filter-inside-push-pop-sys-run
369/473 Test #502: selective-region-pause-no-filter-inside-push-pop-sys-run ........................................................................................................................   Passed    4.80 sec
        Start 503: selective-region-pause-no-filter-inside-push-pop-sampling
370/473 Test #503: selective-region-pause-no-filter-inside-push-pop-sampling .......................................................................................................................   Passed    4.80 sec
        Start 504: selective-region-pause-no-filter-before-start-stop-sys-run
371/473 Test #504: selective-region-pause-no-filter-before-start-stop-sys-run ......................................................................................................................   Passed    4.80 sec
        Start 505: selective-region-pause-no-filter-before-start-stop-sampling
372/473 Test #505: selective-region-pause-no-filter-before-start-stop-sampling .....................................................................................................................   Passed    4.81 sec
        Start 506: selective-region-pause-no-filter-before-push-pop-sys-run
373/473 Test #506: selective-region-pause-no-filter-before-push-pop-sys-run ........................................................................................................................   Passed    4.79 sec
        Start 507: selective-region-pause-no-filter-before-push-pop-sampling
374/473 Test #507: selective-region-pause-no-filter-before-push-pop-sampling .......................................................................................................................   Passed    4.79 sec
        Start 508: selective-region-pause-no-filter-outside-start-stop-sys-run
375/473 Test #508: selective-region-pause-no-filter-outside-start-stop-sys-run .....................................................................................................................   Passed    4.81 sec
        Start 509: selective-region-pause-no-filter-outside-start-stop-sampling
376/473 Test #509: selective-region-pause-no-filter-outside-start-stop-sampling ....................................................................................................................   Passed    4.77 sec
        Start 510: selective-region-pause-no-filter-outside-push-pop-sys-run
377/473 Test #510: selective-region-pause-no-filter-outside-push-pop-sys-run .......................................................................................................................   Passed    4.82 sec
        Start 511: selective-region-pause-no-filter-outside-push-pop-sampling
378/473 Test #511: selective-region-pause-no-filter-outside-push-pop-sampling ......................................................................................................................   Passed    4.81 sec
        Start 512: selective-region-pause-filtered-inside-start-stop-sys-run
379/473 Test #512: selective-region-pause-filtered-inside-start-stop-sys-run .......................................................................................................................   Passed    4.55 sec
        Start 513: selective-region-pause-filtered-inside-start-stop-sampling
380/473 Test #513: selective-region-pause-filtered-inside-start-stop-sampling ......................................................................................................................   Passed    4.67 sec
        Start 514: selective-region-pause-filtered-inside-push-pop-sys-run
381/473 Test #514: selective-region-pause-filtered-inside-push-pop-sys-run .........................................................................................................................   Passed    4.55 sec
        Start 515: selective-region-pause-filtered-inside-push-pop-sampling
382/473 Test #515: selective-region-pause-filtered-inside-push-pop-sampling ........................................................................................................................   Passed    4.54 sec
        Start 516: selective-region-pause-filtered-before-start-stop-sys-run
383/473 Test #516: selective-region-pause-filtered-before-start-stop-sys-run .......................................................................................................................   Passed    4.53 sec
        Start 517: selective-region-pause-filtered-before-start-stop-sampling
384/473 Test #517: selective-region-pause-filtered-before-start-stop-sampling ......................................................................................................................   Passed    4.57 sec
        Start 518: selective-region-pause-filtered-before-push-pop-sys-run
385/473 Test #518: selective-region-pause-filtered-before-push-pop-sys-run .........................................................................................................................   Passed    4.53 sec
        Start 519: selective-region-pause-filtered-before-push-pop-sampling
386/473 Test #519: selective-region-pause-filtered-before-push-pop-sampling ........................................................................................................................   Passed    4.68 sec
        Start 520: selective-region-pause-filtered-outside-start-stop-sys-run
387/473 Test #520: selective-region-pause-filtered-outside-start-stop-sys-run ......................................................................................................................   Passed    4.53 sec
        Start 521: selective-region-pause-filtered-outside-start-stop-sampling
388/473 Test #521: selective-region-pause-filtered-outside-start-stop-sampling .....................................................................................................................   Passed    4.56 sec
        Start 522: selective-region-pause-filtered-outside-push-pop-sys-run
389/473 Test #522: selective-region-pause-filtered-outside-push-pop-sys-run ........................................................................................................................   Passed    4.55 sec
        Start 523: selective-region-pause-filtered-outside-push-pop-sampling
390/473 Test #523: selective-region-pause-filtered-outside-push-pop-sampling .......................................................................................................................   Passed    4.52 sec
        Start 524: selective-region-pause-no-marker-inside-start-stop-sys-run
391/473 Test #524: selective-region-pause-no-marker-inside-start-stop-sys-run ......................................................................................................................   Passed    3.37 sec
        Start 525: selective-region-pause-no-marker-inside-start-stop-sampling
392/473 Test #525: selective-region-pause-no-marker-inside-start-stop-sampling .....................................................................................................................   Passed    3.46 sec
        Start 526: selective-region-pause-no-marker-inside-push-pop-sys-run
393/473 Test #526: selective-region-pause-no-marker-inside-push-pop-sys-run ........................................................................................................................   Passed    3.35 sec
        Start 527: selective-region-pause-no-marker-inside-push-pop-sampling
394/473 Test #527: selective-region-pause-no-marker-inside-push-pop-sampling .......................................................................................................................   Passed    3.52 sec
        Start 528: selective-region-pause-no-marker-before-start-stop-sys-run
395/473 Test #528: selective-region-pause-no-marker-before-start-stop-sys-run ......................................................................................................................   Passed    3.40 sec
        Start 529: selective-region-pause-no-marker-before-start-stop-sampling
396/473 Test #529: selective-region-pause-no-marker-before-start-stop-sampling .....................................................................................................................   Passed    3.36 sec
        Start 530: selective-region-pause-no-marker-before-push-pop-sys-run
397/473 Test #530: selective-region-pause-no-marker-before-push-pop-sys-run ........................................................................................................................   Passed    3.37 sec
        Start 531: selective-region-pause-no-marker-before-push-pop-sampling
398/473 Test #531: selective-region-pause-no-marker-before-push-pop-sampling .......................................................................................................................   Passed    3.36 sec
        Start 532: selective-region-pause-no-marker-outside-start-stop-sys-run
399/473 Test #532: selective-region-pause-no-marker-outside-start-stop-sys-run .....................................................................................................................   Passed    3.35 sec
        Start 533: selective-region-pause-no-marker-outside-start-stop-sampling
400/473 Test #533: selective-region-pause-no-marker-outside-start-stop-sampling ....................................................................................................................   Passed    3.39 sec
        Start 534: selective-region-pause-no-marker-outside-push-pop-sys-run
401/473 Test #534: selective-region-pause-no-marker-outside-push-pop-sys-run .......................................................................................................................   Passed    3.49 sec
        Start 535: selective-region-pause-no-marker-outside-push-pop-sampling
402/473 Test #535: selective-region-pause-no-marker-outside-push-pop-sampling ......................................................................................................................   Passed    3.51 sec
        Start 536: selective-region-no-marker-region-1-filter-start-stop-sys-run
403/473 Test #536: selective-region-no-marker-region-1-filter-start-stop-sys-run ...................................................................................................................   Passed    4.81 sec
        Start 537: selective-region-no-marker-region-1-filter-start-stop-sampling
404/473 Test #537: selective-region-no-marker-region-1-filter-start-stop-sampling ..................................................................................................................   Passed    4.82 sec
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
