### PR TITLE
feat(rocdbgapi): introduce amd_dbgapi_process_set_wave_launch_trap_on_entry

### DIFF
--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -62,7 +62,7 @@
 
 cmake_minimum_required(VERSION 3.8)
 
-project(amd-dbgapi VERSION 0.80.0)
+project(amd-dbgapi VERSION 0.81.0)
 
 include(CheckIncludeFile)
 include(CheckIncludeFiles)

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -665,6 +665,12 @@ typedef unsigned long amd_dbgapi_DWORD;
  */
 #define AMD_DBGAPI_VERSION_0_80
 
+/**
+ * The function was introduced in version 0.81 of the interface and has the
+ * symbol version string of ``"@AMD_DBGAPI_NAME@_0.81"``.
+ */
+#define AMD_DBGAPI_VERSION_0_81
+
 /** @} */
 
 /** \ingroup callbacks_group
@@ -2197,6 +2203,32 @@ typedef enum
 } amd_dbgapi_wave_creation_t;
 
 /**
+ * The kinds of wave launch trap on entry behavior.
+ *
+ * When enabled, all waves will trap immediately upon launch before executing
+ * any instructions.  This allows the debugger to gain control of waves at
+ * the earliest possible point.  The hardware will report the wave as stopped
+ * with ::AMD_DBGAPI_INSTRUCTION_KIND_TRAP.
+ *
+ * This setting applies to all agents of the specified process and affects all
+ * waves created after the setting is applied.  It has no effect on waves that
+ * have already been created.
+ */
+typedef enum
+{
+  /**
+   * Normal behavior - waves execute immediately upon launch.
+   */
+  AMD_DBGAPI_WAVE_LAUNCH_TRAP_ON_ENTRY_DISABLED = 0,
+  /**
+   * Trap on entry - waves trap immediately upon launch before executing any
+   * instructions.
+   */
+  AMD_DBGAPI_WAVE_LAUNCH_TRAP_ON_ENTRY_ENABLED = 1
+} amd_dbgapi_wave_launch_trap_on_entry_t;
+
+
+/**
  * Set the wave creation mode for a process.
  *
  * The setting applies to all agents of the specified process.
@@ -2227,6 +2259,52 @@ typedef enum
 amd_dbgapi_status_t AMD_DBGAPI amd_dbgapi_process_set_wave_creation (
     amd_dbgapi_process_id_t process_id,
     amd_dbgapi_wave_creation_t creation) AMD_DBGAPI_VERSION_0_76;
+
+/**
+ * Set the wave launch trap on entry mode for a process.
+ *
+ * When enabled, all newly created waves will trap immediately upon launch
+ * before executing any instructions.  This allows the debugger to gain control
+ * of waves at the earliest possible point in their execution.
+ *
+ * The setting applies to all agents of the specified process and takes effect
+ * immediately.  Waves created after enabling this setting will trap on entry.
+ * Waves that have already been created are not affected.
+ *
+ * The setting can be changed at any time, including while waves are executing.
+ *
+ * \param[in] process_id The process being controlled.
+ *
+ * \param[in] trap_on_entry The wave launch trap on entry mode being set.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_SUCCESS The function has been executed
+ * successfully and the wave launch trap on entry mode has been set.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_FATAL A fatal error occurred.  The library is
+ * left uninitialized.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_ERROR_NOT_INITIALIZED The library is not
+ * initialized.  The library is left uninitialized.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_ERROR_INVALID_PROCESS_ID \p process_id is
+ * invalid.  The trap on entry mode setting is not changed.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT \p trap_on_entry is
+ * invalid.  The trap on entry mode setting is not changed.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_ERROR_PROCESS_FROZEN The process is frozen.
+ * The trap on entry mode setting cannot be changed.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_ERROR_NOT_SUPPORTED The requested \p
+ * trap_on_entry is not supported by the architecture of all the
+ * agents of \p process_id.  No configuration is changed.
+ */
+amd_dbgapi_status_t AMD_DBGAPI
+amd_dbgapi_process_set_wave_launch_trap_on_entry (
+    amd_dbgapi_process_id_t process_id,
+    amd_dbgapi_wave_launch_trap_on_entry_t trap_on_entry)
+    AMD_DBGAPI_VERSION_0_81;
+
 
 /** \defgroup coredump_support Generating a core dump of a process
  *

--- a/projects/rocdbgapi/src/architecture.cpp
+++ b/projects/rocdbgapi/src/architecture.cpp
@@ -1508,8 +1508,11 @@ amdgcn_architecture_t::wave_get_state (wave_t &wave) const
   uint32_t ttmp6;
   wave.read_register (amdgpu_regnum_t::ttmp6, &ttmp6);
   const bool is_stopped = (ttmp6 & ttmp6_wave_stopped_mask) != 0;
+  const bool is_halted = wave_get_halt (wave);
 
-  if (!is_stopped)
+  /* The wave may be halted but not stopped.  In that case, still report
+     exceptions.  */
+  if (!is_stopped && !is_halted)
     /* The wave is still running, nothing to do.  */
     return { wave.state (), AMD_DBGAPI_WAVE_STOP_REASON_NONE };
 
@@ -1522,7 +1525,8 @@ amdgcn_architecture_t::wave_get_state (wave_t &wave) const
      fill the stop_reason with the exceptions that have caused the wave to
      enter the trap handler.  */
 
-  if (park_stopped_waves (wave.process ().runtime_rdebug_version ()))
+  if (is_stopped
+      && park_stopped_waves (wave.process ().runtime_rdebug_version ()))
     wave.write_register (amdgpu_regnum_t::pc, saved_parked_pc (wave));
 
   amd_dbgapi_wave_stop_reasons_t stop_reason
@@ -1586,7 +1590,8 @@ amdgcn_architecture_t::wave_get_state (wave_t &wave) const
      raising a bit in the trapsts register, some don't, and in the absence of
      any other stop reason, a single-step is assumed.  */
 
-  return { AMD_DBGAPI_WAVE_STATE_STOP, stop_reason };
+  return { is_stopped ? AMD_DBGAPI_WAVE_STATE_STOP : AMD_DBGAPI_WAVE_STATE_RUN,
+           stop_reason };
 }
 
 void

--- a/projects/rocdbgapi/src/architecture.cpp
+++ b/projects/rocdbgapi/src/architecture.cpp
@@ -295,6 +295,8 @@ public:
   bool is_address_class_supported (
     const address_class_t &address_class) const override;
 
+  bool trap_on_entry_supported () const override { return false; }
+
   std::vector<os_watch_id_t>
   triggered_watchpoints (const wave_t &wave) const override;
 
@@ -3913,6 +3915,7 @@ protected:
 
   bool can_halt_at_endpgm () const override { return true; }
   bool has_architected_flat_scratch () const override { return true; };
+  bool trap_on_entry_supported () const override { return true; }
 };
 
 amdgcn_architecture_t::exception_mask_t
@@ -5610,6 +5613,7 @@ public:
            && r_version > 8;
   }
   bool has_architected_flat_scratch () const override { return true; };
+  bool trap_on_entry_supported () const override { return true; }
 };
 
 amdgcn_architecture_t::exception_mask_t

--- a/projects/rocdbgapi/src/architecture.h
+++ b/projects/rocdbgapi/src/architecture.h
@@ -307,6 +307,8 @@ public:
   is_address_class_supported (const address_class_t &address_class) const
     = 0;
 
+  virtual bool trap_on_entry_supported () const = 0;
+
   virtual std::vector<agent_t::aperture_t>
   get_apertures (const os_agent_info_t &os) const = 0;
 

--- a/projects/rocdbgapi/src/exportmap.in
+++ b/projects/rocdbgapi/src/exportmap.in
@@ -105,3 +105,7 @@ global:	amd_dbgapi_address_dependency;
 @AMD_DBGAPI_NAME@_0.80 {
 global: amd_dbgapi_process_get_info;
 } @AMD_DBGAPI_NAME@_0.79;
+
+@AMD_DBGAPI_NAME@_0.81 {
+global: amd_dbgapi_process_set_wave_launch_trap_on_entry;
+} @AMD_DBGAPI_NAME@_0.80;

--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -562,6 +562,20 @@ process_t::set_precise_alu_exceptions (bool enabled)
                  to_cstring (status));
 }
 
+void
+process_t::set_trap_on_entry (bool enabled)
+{
+  if (!m_supports_trap_on_entry)
+    throw api_error_t (AMD_DBGAPI_STATUS_ERROR_NOT_SUPPORTED);
+
+  if (enabled)
+    set_wave_launch_trap_override (os_wave_launch_trap_mask_t::wave_start,
+                                   os_wave_launch_trap_mask_t::wave_start);
+  else
+    set_wave_launch_trap_override (os_wave_launch_trap_mask_t::none,
+                                   os_wave_launch_trap_mask_t::wave_start);
+}
+
 std::vector<process_t *>
 process_t::match (amd_dbgapi_process_id_t process_id)
 {
@@ -649,6 +663,7 @@ process_t::update_agents ()
 
   std::optional<bool> precise_memory_supported;
   std::optional<bool> precise_alu_exceptions_supported;
+  std::optional<bool> trap_on_entry_supported;
 
   /* Add new agents to the process.  */
   for (auto &&agent_info : agent_infos)
@@ -690,6 +705,10 @@ process_t::update_agents ()
           precise_alu_exceptions_supported
             = precise_alu_exceptions_supported.value_or (true)
               && agent_info.precise_alu_exceptions_supported;
+
+          trap_on_entry_supported
+            = trap_on_entry_supported.value_or (true)
+              && agent->architecture ()->trap_on_entry_supported ();
         }
     }
 
@@ -712,6 +731,7 @@ process_t::update_agents ()
   m_supports_precise_memory = precise_memory_supported.value_or (false);
   m_supports_precise_alu_exceptions
     = precise_alu_exceptions_supported.value_or (false);
+  m_supports_trap_on_entry = trap_on_entry_supported.value_or (false);
 }
 
 void
@@ -1663,6 +1683,9 @@ process_t::runtime_enable (os_runtime_info_t runtime_info)
     fatal_error ("Could not set the wave launch trap override for %s (%s).",
                  to_cstring (id ()), to_cstring (status));
 
+  if ((m_wave_trap_mask & os_wave_launch_trap_mask_t::wave_start) != 0)
+    supported_wave_trap_mask |= os_wave_launch_trap_mask_t::wave_start;
+
   if ((m_wave_trap_mask & ~supported_wave_trap_mask) != 0)
     fatal_error ("Unsupported wave trap mask (%s) requested for %s",
                  to_cstring (m_wave_trap_mask & ~supported_wave_trap_mask),
@@ -2564,6 +2587,36 @@ amd_dbgapi_process_unfreeze (amd_dbgapi_process_id_t process_id)
          AMD_DBGAPI_STATUS_ERROR_INVALID_PROCESS_ID,
          AMD_DBGAPI_STATUS_ERROR_PROCESS_NOT_FROZEN,
          AMD_DBGAPI_STATUS_ERROR_NOT_IMPLEMENTED);
+  TRACE_END ();
+}
+
+amd_dbgapi_status_t AMD_DBGAPI
+amd_dbgapi_process_set_wave_launch_trap_on_entry (
+  amd_dbgapi_process_id_t process_id,
+  amd_dbgapi_wave_launch_trap_on_entry_t trap_on_entry)
+{
+  TRACE_BEGIN (param_in (process_id), param_in (trap_on_entry));
+  TRY
+  {
+    if (!detail::is_initialized)
+      THROW (AMD_DBGAPI_STATUS_ERROR_NOT_INITIALIZED);
+
+    process_t *process = process_t::find (process_id);
+
+    if (process == nullptr)
+      THROW (AMD_DBGAPI_STATUS_ERROR_INVALID_PROCESS_ID);
+
+    if (process->is_frozen ())
+      THROW (AMD_DBGAPI_STATUS_ERROR_PROCESS_FROZEN);
+
+    process->set_trap_on_entry (
+      trap_on_entry == AMD_DBGAPI_WAVE_LAUNCH_TRAP_ON_ENTRY_ENABLED);
+  }
+  CATCH (AMD_DBGAPI_STATUS_ERROR_NOT_INITIALIZED,
+         AMD_DBGAPI_STATUS_ERROR_INVALID_PROCESS_ID,
+         AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT,
+         AMD_DBGAPI_STATUS_ERROR_PROCESS_FROZEN,
+         AMD_DBGAPI_STATUS_ERROR_NOT_SUPPORTED);
   TRACE_END ();
 }
 

--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -450,8 +450,18 @@ process_t::set_wave_launch_mode (os_wave_launch_mode_t wave_launch_mode)
         if (wave.visibility ()
             == wave_t::visibility_t::hidden_halted_at_launch)
           {
-            wave.set_state (AMD_DBGAPI_WAVE_STATE_RUN);
-            wave.set_visibility (wave_t::visibility_t::visible);
+            if (wave.stop_reason () != AMD_DBGAPI_WAVE_STOP_REASON_NONE)
+              {
+                /* keep state as stop, make visible and report exceptions  */
+                wave.report_stop_at_launch ();
+              }
+            else
+              {
+                /* The wave was halted at launch with no exception, it can now
+                   be resumed and reported to the client.  */
+                wave.set_state (AMD_DBGAPI_WAVE_STATE_RUN);
+                wave.set_visibility (wave_t::visibility_t::visible);
+              }
           }
 
       /* Changing the launch mode before resuming the queues ensures that none

--- a/projects/rocdbgapi/src/process.h
+++ b/projects/rocdbgapi/src/process.h
@@ -116,6 +116,8 @@ private:
 
   bool m_supports_precise_alu_exceptions{ false };
 
+  bool m_supports_trap_on_entry{ false };
+
   os_process_flags_t m_process_flags{};
 
   bool m_forward_progress_needed{ true };
@@ -286,6 +288,8 @@ public:
   void set_precise_memory (bool enabled);
 
   void set_precise_alu_exceptions (bool enabled);
+
+  void set_trap_on_entry (bool enabled);
 
   /* Suspend/resume a list of queues.  Queues may become invalid as a result of
      suspension/resumption, but not destroyed.  Queues made invalid will

--- a/projects/rocdbgapi/src/queue.cpp
+++ b/projects/rocdbgapi/src/queue.cpp
@@ -354,7 +354,7 @@ compute_queue_t::update_waves ()
        changed since the queue was last suspended (or the wave is new).  */
     wave->update (std::move (cwsr_record));
 
-    if (wave->state () != AMD_DBGAPI_WAVE_STATE_STOP)
+    if (wave->state () != AMD_DBGAPI_WAVE_STATE_STOP && ! wave->is_halted ())
       ++*m_waves_running;
 
     /* Hide new waves halted at launch until the process' wave creation mode is
@@ -370,8 +370,16 @@ compute_queue_t::update_waves ()
         log_verbose ("%s is halted at launch", to_cstring (wave->id ()));
 
         wave->set_visibility (wave_t::visibility_t::hidden_halted_at_launch);
-        wave->set_halted (false);
-        wave->set_state (AMD_DBGAPI_WAVE_STATE_STOP);
+
+        /* The wave may be spawned with exceptions, in which case we do not
+           want to report them.  The process will trigger
+           wave_t::report_stop_at_launch () when resuming a wave that is hidden
+           at launch.  */
+        if (wave->stop_reason () == AMD_DBGAPI_WAVE_STOP_REASON_NONE)
+          {
+            wave->set_halted (false);
+            wave->set_state (AMD_DBGAPI_WAVE_STATE_STOP);
+          }
       }
 
     /* This was the last wave in the group. Make sure we have a new group

--- a/projects/rocdbgapi/src/wave.cpp
+++ b/projects/rocdbgapi/src/wave.cpp
@@ -1040,6 +1040,24 @@ wave_t::get_info (amd_dbgapi_wave_info_t query, size_t value_size,
   throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT);
 }
 
+void
+wave_t::report_stop_at_launch ()
+{
+  dbgapi_assert (state () == AMD_DBGAPI_WAVE_STATE_RUN);
+  dbgapi_assert (visibility () != visibility_t::visible);
+  dbgapi_assert (m_stop_reason != AMD_DBGAPI_WAVE_STOP_REASON_NONE);
+
+  /* set_state (STOP) clears the stop reason, so save and restore it.  */
+  auto stop_reason = m_stop_reason;
+
+  set_halted (false);                     /* drop the launch halt */
+  set_state (AMD_DBGAPI_WAVE_STATE_STOP); /* hidden => no event */
+  m_stop_reason = stop_reason;
+
+  set_visibility (visibility_t::visible);
+  raise_event (AMD_DBGAPI_EVENT_KIND_WAVE_STOP);
+}
+
 } /* namespace amd::dbgapi */
 
 using namespace amd::dbgapi;

--- a/projects/rocdbgapi/src/wave.h
+++ b/projects/rocdbgapi/src/wave.h
@@ -239,6 +239,10 @@ public:
                        amd_dbgapi_lane_id_t lane_id, void *read,
                        const void *write, size_t size);
 
+  /* Raises an event to notify the client of a stopped wave at launch.  May
+     only be called if the wave had pending exceptions when created.   */
+  void report_stop_at_launch ();
+
   void get_info (amd_dbgapi_wave_info_t query, size_t value_size,
                  void *value) const;
 


### PR DESCRIPTION
## Motivation

This commit implements the new 'trap_on_entry' feature. Users can now request all new wavefronts to trap before executing any instructions from the kernel code.

## Technical Details

This exposes the `set_wave_launch_trap_override` method for clients to request waves to trap on entry.

## Test Plan

Testing provided with the ROCgdb PR.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
