### PR TITLE
refactor(rocprofsys): remove Tim realpath()

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
@@ -9,6 +9,7 @@
 #include <timemory/components/rusage/components.hpp>
 #include <timemory/components/timing/wall_clock.hpp>
 
+#include "common/path.hpp"
 #include "core/demangler.hpp"
 
 #include <spdlog/fmt/ranges.h>
@@ -639,7 +640,6 @@ rocprofsys_get_exe_realpath()
             ROCPROFSYS_ADD_LOG_ENTRY(
                 fmt::format("cmdline:: [ {} ]", fmt::join(_cmd_line, " ")));
             return _cmd_line.front();
-            // return tim::filepath::realpath(_cmd_line.front(), nullptr, false);
         }
         return std::string{};
     }();
@@ -774,7 +774,7 @@ rocprofsys_get_loaded_path(const char* _name, std::vector<int>&& _open_modes)
         dlinfo(_handle, RTLD_DI_LINKMAP, &_link_map);
         if(_link_map != nullptr && !std::string_view{ _link_map->l_name }.empty())
         {
-            return tim::filepath::realpath(_link_map->l_name, nullptr, false);
+            return rocprofsys::path::realpath(_link_map->l_name);
         }
         if(_noload == false) dlclose(_handle);
     }
@@ -807,7 +807,7 @@ rocprofsys_get_origin(const char* _name, std::vector<int>&& _open_modes)
         dlinfo(_handle, RTLD_DI_ORIGIN, _buffer);
         if(strnlen(_buffer, PATH_MAX + 1) <= PATH_MAX)
         {
-            return tim::filepath::realpath(_buffer, nullptr, false);
+            return rocprofsys::path::realpath(_buffer);
         }
         if(_noload == false) dlclose(_handle);
     }
@@ -1038,7 +1038,7 @@ filter_modules(std::vector<module_t*>* app_modules)
 
         auto _module_name = std::string{ get_name(mod) };
         auto _module_base = std::string{ tim::filepath::basename(_module_name) };
-        auto _module_real = tim::filepath::realpath(_module_name, nullptr, false);
+        auto _module_real = rocprofsys::path::realpath(_module_name);
 
         bool _is_excluded = false;
 
@@ -1256,7 +1256,7 @@ process_modules(const std::vector<module_t*>& _app_modules)
     for(auto* itr : symtab_data.modules)
     {
         const auto* _base_name = tim::filepath::basename(itr->fullName());
-        auto        _real_name = tim::filepath::realpath(itr->fullName(), nullptr, false);
+        auto        _real_name = rocprofsys::path::realpath(itr->fullName());
 
         if(!_base_name) continue;
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
@@ -11,6 +11,7 @@
 #include "common/delimit.hpp"
 #include "common/env_vars.hpp"
 #include "common/environment.hpp"
+#include "common/path.hpp"
 #include "core/demangler.hpp"
 #include "core/utility.hpp"
 #include "fwd.hpp"
@@ -42,7 +43,7 @@ using open_modes_vec_t = std::vector<int>;
 auto
 get_exe_realpath()
 {
-    return filepath::realpath("/proc/self/exe", nullptr, false);
+    return rocprofsys::path::realpath("/proc/self/exe");
 }
 
 auto&
@@ -122,7 +123,7 @@ get_linked_path(const char*        _name,
         dlinfo(_handle, RTLD_DI_LINKMAP, &_link_map);
         if(_link_map != nullptr && !std::string_view{ _link_map->l_name }.empty())
         {
-            return filepath::realpath(_link_map->l_name, nullptr, false);
+            return rocprofsys::path::realpath(_link_map->l_name);
         }
     }
 
@@ -153,7 +154,7 @@ get_link_map(const std::string& _lib,
             if(!std::string_view{ _next->l_name }.empty() &&
                std::string_view{ _next->l_name } != _lib)
             {
-                _chain.emplace(filepath::realpath(_next->l_name, nullptr, false));
+                _chain.emplace(rocprofsys::path::realpath(_next->l_name));
             }
             _next = _next->l_next;
         }
@@ -414,7 +415,7 @@ get_internal_libs_data_impl()
     _libs.assign(_libs_v.begin(), _libs_v.end());
 
     auto _rocprofsys_base_path = filepath::dirname(
-        filepath::dirname(filepath::realpath("/proc/self/exe", nullptr, false)));
+        filepath::dirname(rocprofsys::path::realpath("/proc/self/exe")));
     auto _rocprofsys_lib_path = std::string{};
 
     for(const auto* itr : { "lib", "lib64" })
@@ -425,7 +426,7 @@ get_internal_libs_data_impl()
             auto _libpath = fmt::format("{}/{}/{}", _rocprofsys_base_path, itr, litr);
             if(filepath::exists(_libpath))
             {
-                _libs.emplace_back(filepath::realpath(_libpath, nullptr, false));
+                _libs.emplace_back(rocprofsys::path::realpath(_libpath));
             }
         }
     }
@@ -436,7 +437,7 @@ get_internal_libs_data_impl()
     auto _data = library_module_map_t{};
     for(const auto& itr : _libs)
     {
-        auto _fpath = filepath::realpath(itr, nullptr, false);
+        auto _fpath = rocprofsys::path::realpath(itr);
         // allow the user to request this library be considered for instrumentation
         if(check_regex_restrictions(strvec_t{ itr, _fpath }, file_internal_include))
             continue;

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.cpp
@@ -3,6 +3,7 @@
 
 #include "module_function.hpp"
 #include "InstructionCategories.h"
+#include "common/path.hpp"
 #include "fwd.hpp"
 #include "internal_libs.hpp"
 #include "log.hpp"
@@ -416,9 +417,7 @@ module_function::is_internal_constrained() const
     auto _basename = [](std::string_view _v) {
         return std::string{ tim::filepath::basename(_v) };
     };
-    auto _realpath = [](const std::string& _v) {
-        return tim::filepath::realpath(_v, nullptr, false);
-    };
+    auto _realpath = [](const std::string& _v) { return rocprofsys::path::realpath(_v); };
 
     auto _report = [&](const string_t& _action, const std::string& _type,
                        const string_t& _reason, int _lvl) {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.cpp
@@ -417,7 +417,6 @@ module_function::is_internal_constrained() const
     auto _basename = [](std::string_view _v) {
         return std::string{ tim::filepath::basename(_v) };
     };
-    auto _realpath = [](const std::string& _v) { return rocprofsys::path::realpath(_v); };
 
     auto _report = [&](const string_t& _action, const std::string& _type,
                        const string_t& _reason, int _lvl) {
@@ -428,7 +427,7 @@ module_function::is_internal_constrained() const
     const auto& _gnu_libs = get_internal_libs_data();
 
     auto _module_base = _basename(module_name);
-    auto _module_real = _realpath(module_name);
+    auto _module_real = rocprofsys::path::realpath(module_name);
 
     if(std::regex_search(module_name,
                          std::regex{ "lib(rocprof-sys|rocprofsys|timemory|perfetto)" }))

--- a/projects/rocprofiler-systems/source/lib/binary/analysis.cpp
+++ b/projects/rocprofiler-systems/source/lib/binary/analysis.cpp
@@ -13,6 +13,7 @@
 
 #include "analysis.hpp"
 #include "binary_info.hpp"
+#include "common/path.hpp"
 #include "core/binary/address_range.hpp"
 #include "core/binary/fwd.hpp"
 #include "core/common.hpp"
@@ -136,7 +137,7 @@ get_binary_info(const std::vector<std::string>&  _files,
     // and do not process the libraries outside of the binary scope
     auto _filter = [&_satisfies_binary_filter](const procfs::maps& _v) {
         if(_v.pathname.empty()) return false;
-        auto _path = filepath::realpath(_v.pathname, nullptr, false);
+        auto _path = path::realpath(_v.pathname);
         return (filepath::exists(_path) && _satisfies_binary_filter(_path));
     };
 
@@ -146,7 +147,7 @@ get_binary_info(const std::vector<std::string>&  _files,
         auto _exists = std::set<std::string>{};
         for(const auto& itr : _files)
         {
-            auto _filename = filepath::realpath(itr, nullptr, false);
+            auto _filename = path::realpath(itr);
             if(filepath::exists(_filename) && _satisfies_binary_filter(_filename) &&
                _exists.find(_filename) == _exists.end())
             {
@@ -206,7 +207,7 @@ lookup_ipaddr_entry(uintptr_t _addr, unw_context_t* _context_p,
             auto _insert_exclude_range = [&_maps,
                                           &_exclude_range_v](const std::string& _v) {
                 auto _base_v = std::string_view{ filepath::basename(_v) };
-                auto _real_v = filepath::realpath(_v);
+                auto _real_v = path::realpath(_v);
                 for(const auto& mitr : _maps)
                 {
                     if(std::string_view{ filepath::basename(mitr.pathname) } == _base_v ||

--- a/projects/rocprofiler-systems/source/lib/binary/dwarf_entry.cpp
+++ b/projects/rocprofiler-systems/source/lib/binary/dwarf_entry.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "dwarf_entry.hpp"
+#include "common/path.hpp"
 #include "core/binary/fwd.hpp"
 #include "core/timemory.hpp"
 #include "core/utility.hpp"
@@ -101,7 +102,7 @@ get_dwarf_entry(Dwarf_Die* _die)
                 if(_lineno > 0) itr.line = _lineno;
                 const auto* _file = dwarf_linesrc(_line, nullptr, nullptr);
                 if(!_file) _file = dwarf_diename(_die);
-                itr.file = filepath::realpath(_file, nullptr, false);
+                itr.file = path::realpath(_file);
             }
         }
     }

--- a/projects/rocprofiler-systems/source/lib/binary/link_map.cpp
+++ b/projects/rocprofiler-systems/source/lib/binary/link_map.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "link_map.hpp"
+#include "common/path.hpp"
 #include "core/common.hpp"
 #include "core/config.hpp"
 #include "core/timemory.hpp"
@@ -49,7 +50,7 @@ get_linked_path(const char* _name, open_modes_vec_t&& _open_modes)
         dlinfo(_handle, RTLD_DI_LINKMAP, &_link_map);
         if(_link_map != nullptr && !std::string_view{ _link_map->l_name }.empty())
         {
-            return filepath::realpath(_link_map->l_name, nullptr, false);
+            return path::realpath(_link_map->l_name);
         }
         if(_noload == false) dlclose(_handle);
     }
@@ -155,7 +156,7 @@ link_file::base() const
 std::string
 link_file::real() const
 {
-    return filepath::realpath(name, nullptr, false);
+    return path::realpath(name);
 }
 }  // namespace binary
 }  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/binary/symbol.cpp
+++ b/projects/rocprofiler-systems/source/lib/binary/symbol.cpp
@@ -31,6 +31,7 @@ typedef Elf64_Xword Elf64_Relr;
 #include <elfutils/libdw.h>
 #include <libcoff.h>
 
+#include "common/path.hpp"
 #include "core/binary/fwd.hpp"
 #include "core/demangler.hpp"
 #include "core/timemory.hpp"
@@ -59,8 +60,7 @@ read_inliner_info(bfd* _inp)
         if(bfd_find_inliner_info(_inp, &_file, &_func, &_line) != 0)
         {
             if(_file && _func && _line > 0)
-                _data.emplace_back(inlined_symbol{
-                    _line, filepath::realpath(_file, nullptr, false), _func });
+                _data.emplace_back(inlined_symbol{ _line, path::realpath(_file), _func });
         }
         else
         {
@@ -242,7 +242,7 @@ symbol::read_bfd_line_info(bfd_file& _bfd)
                 file = bfd_get_filename(_inp);
             if(!func.empty())
             {
-                file    = filepath::realpath(file, nullptr, false);
+                file    = path::realpath(file);
                 line    = _line;
                 inlines = read_inliner_info(_inp);
                 return true;

--- a/projects/rocprofiler-systems/source/lib/common/path.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/path.hpp
@@ -94,7 +94,7 @@ find_path(const std::string& _path, int _verbose,
 inline std::string
 dirname(const std::string& _fname) ROCPROFSYS_INTERNAL_API;
 
-inline std::string
+[[nodiscard]] inline std::string
 realpath(const std::string& path) ROCPROFSYS_INTERNAL_API;
 
 inline bool
@@ -281,7 +281,7 @@ readlink(const std::string& _path)
     return _path;
 }
 
-std::string
+[[nodiscard]] std::string
 realpath(const std::string& path)
 {
     std::error_code error;

--- a/projects/rocprofiler-systems/source/lib/common/path.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/path.hpp
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <dlfcn.h>
+#include <filesystem>
 #include <fstream>
 #include <link.h>
 #include <linux/limits.h>
@@ -94,8 +95,7 @@ inline std::string
 dirname(const std::string& _fname) ROCPROFSYS_INTERNAL_API;
 
 inline std::string
-realpath(const std::string& _relpath,
-         std::string*       _resolved = nullptr) ROCPROFSYS_INTERNAL_API;
+realpath(const std::string& path) ROCPROFSYS_INTERNAL_API;
 
 inline bool
 is_text_file(const std::string& filename) ROCPROFSYS_INTERNAL_API;
@@ -282,29 +282,11 @@ readlink(const std::string& _path)
 }
 
 std::string
-realpath(const std::string& _relpath, std::string* _resolved)
+realpath(const std::string& path)
 {
-    constexpr size_t MaxLen = PATH_MAX;
-    auto             _len   = std::min<size_t>(_relpath.length(), MaxLen);
-
-    char        _buffer[MaxLen] = { '\0' };
-    const char* _result         = _buffer;
-
-    if(::realpath(_relpath.c_str(), _buffer) == nullptr)
-    {
-        _result = _relpath.data();
-    }
-
-    if(_resolved)
-    {
-        _resolved->clear();
-        _len = strnlen(_result, MaxLen);
-        _resolved->resize(_len);
-        for(size_t i = 0; i < _len; ++i)
-            (*_resolved)[i] = _result[i];
-    }
-
-    return (_resolved) ? *_resolved : std::string{ _result };
+    std::error_code error;
+    auto            canon = std::filesystem::canonical(path, error);
+    return (error) ? path : canon.string();
 }
 
 bool

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
@@ -192,15 +192,6 @@ TEST_F(PathTest, Realpath_NonexistentPath)
     EXPECT_EQ(resolved, nonexistent);
 }
 
-TEST_F(PathTest, Realpath_WithResolvedOutput)
-{
-    std::string file_path = create_file("resolved_output_test.txt");
-    std::string resolved_output;
-    std::string result = realpath(file_path, &resolved_output);
-    EXPECT_EQ(result, file_path);
-    EXPECT_EQ(resolved_output, file_path);
-}
-
 TEST_F(PathTest, IsTextFile_TextFile)
 {
     std::string text_content = "This is a text file\nwith multiple lines\n";

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -7,6 +7,7 @@
 #include "common/delimit.hpp"
 #include "common/env_vars.hpp"
 #include "common/environment.hpp"
+#include "common/path.hpp"
 #include "common/static_object.hpp"
 #include "constraint.hpp"
 #include "gpu.hpp"
@@ -1368,7 +1369,7 @@ configure_settings(bool _init)
     auto _cmd_env = rocprofsys::get_env<std::string>(env_vars::COMMAND_LINE, "");
     if(!_cmd_env.empty()) _cmd = rocprofsys::delimit(_cmd_env, " ");
     auto _exe          = (_cmd.empty()) ? "exe" : _cmd.front();
-    get_exe_realpath() = filepath::realpath(_exe, nullptr, false);
+    get_exe_realpath() = path::realpath(_exe);
     auto _pos          = _exe.find_last_of('/');
     if(_pos < _exe.length() - 1) _exe = _exe.substr(_pos + 1);
     get_exe_name() = _exe;
@@ -2127,8 +2128,7 @@ get_exe_realpath()
 {
     static std::string _v = []() {
         auto _cmd_line = tim::read_command_line(process::get_id());
-        if(!_cmd_line.empty())
-            return filepath::realpath(_cmd_line.front(), nullptr, false);
+        if(!_cmd_line.empty()) return path::realpath(_cmd_line.front());
         return std::string{};
     }();
     return _v;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
@@ -8,6 +8,7 @@
 #include "binary/link_map.hpp"
 #include "binary/scope_filter.hpp"
 #include "common/env_vars.hpp"
+#include "common/path.hpp"
 #include "common/units.hpp"
 #include "core/binary/fwd.hpp"
 #include "core/config.hpp"
@@ -810,8 +811,7 @@ sample_selection(size_t _nitr, size_t _wait_ns)
             {
                 auto _location =
                     (_dl_info.location)
-                        ? filepath::realpath(std::string{ _dl_info.location.name },
-                                             nullptr, false)
+                        ? path::realpath(std::string{ _dl_info.location.name })
                         : std::string{};
                 for(const auto& itr : linfo)
                 {


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This PR is a part of PR series to remove dependency on Timemory `filepath` utilities.
This particular PR: 
- replaces `tim::filepath::realpath()` with existing in-tree `path::realpath()`
- refactors the mentioned in-tree `path::realpath()` to use modern `std::filesystem` approach

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Existing in-tree `path.hpp:realpath()` function is simplified using non-throwing overload of `std::filesystem::canonical()`.
Behavior is unchanged: return result on success, return original input on error.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

JIRA ID : AIPROFSYST-528

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Existing CTest suite should pass

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
