### PR TITLE
[rocjitsu] Report unsupported AQL packet errors

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/vm/rj_vm.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/vm/rj_vm.h
@@ -35,6 +35,16 @@ typedef int rj_handle_t;
 /// platform width of a process ID.
 typedef int32_t rj_client_pid_t;
 
+/// @brief One daemon-to-client store into client-owned signal memory.
+/// @details Queue exception signals live in ROCr's private address space and
+/// cannot be written by a sibling daemon under normal ptrace restrictions.
+/// The daemon returns these stores with an ioctl response for the client stub
+/// to publish before it reports the corresponding KFD event.
+typedef struct rj_vm_signal_write_t {
+  uint64_t address; ///< Client virtual address of the 64-bit signal field.
+  uint64_t value;   ///< Value to publish with release ordering.
+} rj_vm_signal_write_t;
+
 /// @brief VM creation mode.
 typedef enum rj_vm_mode_t {
   /// @brief Standalone simulation. Engine runs with configured tick limit.
@@ -236,6 +246,18 @@ RJ_API_EXPORT rj_status_t rj_vm_execute(rj_vm_t *vm, rj_vm_cmd_t *cmd);
 /// @param[in] process_id The target process ID.
 /// @param[in,out] cmd Command descriptor.
 RJ_API_EXPORT rj_status_t rj_vm_execute_as(rj_vm_t *vm, uint32_t process_id, rj_vm_cmd_t *cmd);
+
+/// @brief Drain pending daemon-to-client signal stores for a process.
+/// @param[in] vm VM handle.
+/// @param[in] process_id The target process ID.
+/// @param[out] writes Caller-owned output array.
+/// @param[in] capacity Number of entries available in @p writes. Pass zero
+///   with @p writes set to NULL to query the pending count without draining it.
+/// @param[out] count Number of entries written. Any excess remains pending for
+///   the next call.
+RJ_API_EXPORT rj_status_t rj_vm_take_signal_writes_as(rj_vm_t *vm, uint32_t process_id,
+                                                      rj_vm_signal_write_t *writes, size_t capacity,
+                                                      size_t *count);
 
 /// @brief Open the VM's simulated device and create (or reuse) a KFD process.
 /// @param[in] vm VM handle.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
@@ -7,7 +7,15 @@
 #include "rocjitsu/kmd/linux/remote_driver.h"
 #include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
 #include "rocjitsu/kmd/linux/rpc.h"
+#include "util/log.h"
 
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "hsa/amd_hsa_queue.h"
+RJ_DIAGNOSTIC_POP
+
+#include <atomic>
 #include <cassert>
 #include <cerrno>
 #include <chrono>
@@ -35,6 +43,7 @@ namespace {
 
 constexpr bool has_embedded_pointers(unsigned long request) {
   switch (canonical_ioctl_request(request)) {
+  case AMDKFD_IOC_CREATE_QUEUE:
   case AMDKFD_IOC_WAIT_EVENTS:
   case AMDKFD_IOC_MAP_MEMORY_TO_GPU:
   case AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU:
@@ -48,6 +57,50 @@ constexpr bool has_embedded_pointers(unsigned long request) {
   default:
     return false;
   }
+}
+
+template <typename T> T read_client_value(uint64_t address) {
+  T value{};
+  std::memcpy(&value, reinterpret_cast<const void *>(address), sizeof(value));
+  return value;
+}
+
+RpcQueueErrorState queue_error_state(const kfd_ioctl_create_queue_args &args) {
+  RpcQueueErrorState state{};
+  if (args.queue_type != KFD_IOC_QUEUE_TYPE_COMPUTE_AQL)
+    return state;
+
+  // HsaUserContextSaveAreaHeader fields used by ROCr's queue exception path.
+  constexpr uint64_t kErrorReasonOffset = 24;
+  constexpr uint64_t kErrorEventIdOffset = 32;
+  if (args.ctx_save_restore_address != 0) {
+    state.signal_value_address =
+        read_client_value<uint64_t>(args.ctx_save_restore_address + kErrorReasonOffset);
+    state.event_id =
+        read_client_value<uint32_t>(args.ctx_save_restore_address + kErrorEventIdOffset);
+  }
+
+  // Older runtimes use amd_queue_t::queue_inactive_signal instead.
+  if (state.signal_value_address == 0 && args.write_pointer_address != 0) {
+    const uint64_t queue_address =
+        args.write_pointer_address - offsetof(amd_queue_t, write_dispatch_id);
+    const uint64_t signal_address =
+        read_client_value<uint64_t>(queue_address + offsetof(amd_queue_t, queue_inactive_signal));
+    if (signal_address != 0) {
+      constexpr uint64_t kSignalValueOffset = 8;
+      state.signal_value_address = signal_address + kSignalValueOffset;
+      state.flags |= RPC_QUEUE_ERROR_USES_LEGACY_MASK;
+    }
+  }
+
+  if (state.signal_value_address != 0) {
+    // amd_signal_t fields relative to value: event_mailbox at +8, event_id at
+    // +16. A nonzero CWSR event ID takes precedence over the signal fallback.
+    state.event_mailbox_address = read_client_value<uint64_t>(state.signal_value_address + 8);
+    if (state.event_id == 0)
+      state.event_id = read_client_value<uint32_t>(state.signal_value_address + 16);
+  }
+  return state;
 }
 
 /// @brief Safe wrapper around syscall(SYS_mmap, ...) that avoids UB from
@@ -378,8 +431,13 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
   uint32_t saved_dbg_rinfo_size = 0;
   uint64_t saved_dbg_snapshot_ptr = 0;
   size_t saved_dbg_snapshot_cap = 0;
+  uint64_t saved_ctx_save_restore_address = 0;
   if (has_embedded_pointers(request)) {
     switch (request) {
+    case AMDKFD_IOC_CREATE_QUEUE:
+      saved_ctx_save_restore_address =
+          static_cast<kfd_ioctl_create_queue_args *>(arg)->ctx_save_restore_address;
+      break;
     case AMDKFD_IOC_WAIT_EVENTS:
       saved_events_ptr = static_cast<kfd_ioctl_wait_events_args *>(arg)->events_ptr;
       break;
@@ -422,6 +480,13 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
   if (has_embedded_pointers(request)) {
     auto *args_base = buf.data() + prefix;
     switch (request) {
+    case AMDKFD_IOC_CREATE_QUEUE: {
+      const auto state = queue_error_state(*static_cast<kfd_ioctl_create_queue_args *>(arg));
+      const size_t inline_offset = buf.size();
+      buf.resize(inline_offset + sizeof(state));
+      std::memcpy(buf.data() + inline_offset, &state, sizeof(state));
+      break;
+    }
     case AMDKFD_IOC_WAIT_EVENTS: {
       auto *wait_args = reinterpret_cast<kfd_ioctl_wait_events_args *>(args_base);
       size_t inline_size = wait_args->num_events * sizeof(kfd_event_data);
@@ -479,6 +544,7 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
   auto *ireq = reinterpret_cast<RpcIoctlRequest *>(buf.data() + sizeof(RpcHeader));
   ireq->ioctl_cmd = static_cast<uint32_t>(request);
   ireq->args_bytes = static_cast<uint32_t>(buf.size() - prefix);
+  const size_t wire_args_size = ireq->args_bytes;
 
   // For DBG_TRAP ENABLE, hand the debugger's notifier pipe write-end to the
   // daemon as an SCM_RIGHTS fd. The daemon substitutes it into the ioctl's
@@ -527,6 +593,10 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
     // daemon's response (daemon rewrites them to point at its own buffer).
     if (has_embedded_pointers(request)) {
       switch (request) {
+      case AMDKFD_IOC_CREATE_QUEUE:
+        static_cast<kfd_ioctl_create_queue_args *>(arg)->ctx_save_restore_address =
+            saved_ctx_save_restore_address;
+        break;
       case AMDKFD_IOC_WAIT_EVENTS:
         static_cast<kfd_ioctl_wait_events_args *>(arg)->events_ptr = saved_events_ptr;
         break;
@@ -556,6 +626,28 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
       default:
         break;
       }
+    }
+
+    // Queue exception signal values and mailboxes are private client memory.
+    // The daemon appends release-ordered stores after the echoed ioctl bytes so
+    // they are visible before this call reports the corresponding event ready.
+    if (payload.size() < wire_args_size)
+      return -EPROTO;
+    const size_t writes_bytes = payload.size() - wire_args_size;
+    if (writes_bytes % sizeof(RpcSignalWrite) != 0)
+      return -EPROTO;
+    for (size_t offset = 0; offset < writes_bytes; offset += sizeof(RpcSignalWrite)) {
+      RpcSignalWrite write{};
+      std::memcpy(&write, payload.data() + wire_args_size + offset, sizeof(write));
+      if (write.address == 0)
+        continue;
+      if ((write.address & (alignof(uint64_t) - 1)) != 0) {
+        util::Logger::warn("Ignoring misaligned RPC signal write address: 0x", std::hex,
+                           write.address);
+        continue;
+      }
+      auto *target = reinterpret_cast<uint64_t *>(write.address);
+      std::atomic_ref<uint64_t>(*target).store(write.value, std::memory_order_release);
     }
 
     if (has_embedded_pointers(request) && resp->payload_bytes > arg_size) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/rpc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/rpc.h
@@ -49,7 +49,7 @@ struct RpcHeader {
 };
 
 /// @brief RPC protocol version. Increment when making breaking changes.
-inline constexpr uint32_t kRpcProtocolVersion = 3;
+inline constexpr uint32_t kRpcProtocolVersion = 4;
 
 /// @brief Fixed-size GPU metadata sent during daemon handshake.
 using RpcGpuInfo = ::rj_vm_gpu_info_t;
@@ -70,6 +70,29 @@ struct RpcIoctlRequest {
   uint32_t ioctl_cmd;  ///< AMDKFD_IOC_* ioctl number.
   uint32_t args_bytes; ///< Size in bytes of the ioctl args (and any inlined arrays) that follow.
 };
+
+/// @brief Client-side queue-error metadata inlined after CREATE_QUEUE args.
+/// @details The CWSR header and legacy queue signal are private ROCr memory, so
+/// the client resolves them while serializing the ioctl. The daemon retains
+/// only the addresses and event metadata needed when a packet later faults.
+struct RpcQueueErrorState {
+  uint64_t signal_value_address;  ///< amd_signal_t::value address.
+  uint64_t event_mailbox_address; ///< Optional amd_signal_t event mailbox.
+  uint32_t event_id;              ///< KFD signal event to wake.
+  uint32_t flags;                 ///< RpcQueueErrorFlags bitmask.
+};
+
+enum RpcQueueErrorFlags : uint32_t {
+  RPC_QUEUE_ERROR_USES_LEGACY_MASK = 1u << 0,
+};
+
+/// @brief Signal stores appended after the echoed ioctl arguments in a response.
+/// @details The start offset is RpcIoctlRequest::args_bytes, so no count header
+/// is needed; all remaining response bytes are an array of these records. Stores
+/// remain pending until the process issues another ioctl and receives its response.
+/// Any variable-length ioctl output must reserve the same inline space in its
+/// request; otherwise response-only bytes would be interpreted as signal writes.
+using RpcSignalWrite = ::rj_vm_signal_write_t;
 
 /// @brief mmap request payload (when opcode == RPC_MMAP).
 struct RpcMmapRequest {
@@ -95,6 +118,8 @@ static_assert(sizeof(RpcHeader) == 16);
 static_assert(sizeof(RpcGpuInfo) == 312);
 static_assert(sizeof(RpcHandshakeResponse) == 328);
 static_assert(sizeof(RpcIoctlRequest) == 8);
+static_assert(sizeof(RpcQueueErrorState) == 24);
+static_assert(sizeof(RpcSignalWrite) == 16);
 static_assert(sizeof(RpcMmapRequest) == 32);
 static_assert(sizeof(RpcMmapResponse) == 8);
 static_assert(sizeof(RpcMunmapRequest) == 16);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -4,6 +4,7 @@
 #include "rocjitsu/kmd/linux/simulated_kfd.h"
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
 #include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
+#include "rocjitsu/kmd/linux/rpc.h"
 #include "rocjitsu/vm/amdgpu/command_processor.h"
 
 #include "rocjitsu/base/rj_compiler.h"
@@ -253,6 +254,28 @@ void SimulatedKfd::init_command_processors_locked() {
                            " found=false");
         }
       });
+      if (daemon_mode_) {
+        cp->set_remote_queue_error_callback([this](uint32_t process_id, uint64_t signal_value_va,
+                                                   uint64_t mailbox_va, uint32_t event_id,
+                                                   uint64_t value) {
+          std::lock_guard<std::mutex> ilk(interrupt_mutex_);
+          auto event = event_dispatch_.find(process_id);
+          if (event == event_dispatch_.end()) {
+            util::Logger::warn("Dropping remote queue error for closed process: pid=", process_id,
+                               " event_id=", event_id);
+            return true;
+          }
+
+          auto &writes = pending_signal_writes_[process_id];
+          writes.push_back({signal_value_va, value});
+          if (mailbox_va != 0)
+            writes.push_back({mailbox_va, event_id});
+
+          if (event_id != 0)
+            event->second->signal_interrupt(event_id);
+          return true;
+        });
+      }
       cp->set_scratch_backing_resolver([this](uint32_t process_id) -> uint64_t {
         std::lock_guard<std::mutex> plk(process_mutex_);
         for (auto &[fd, proc] : processes_) {
@@ -472,6 +495,7 @@ int SimulatedKfd::close(uint32_t process_id) {
   {
     std::lock_guard<std::mutex> ilk(interrupt_mutex_);
     event_dispatch_.erase(process_id);
+    pending_signal_writes_.erase(process_id);
   }
 
   for (auto &g : gpus_) {
@@ -1418,12 +1442,35 @@ int SimulatedKfd::create_queue_ioctl(KfdProcess &proc, void *arg) {
     hw.doorbell_base = gs.doorbell_page;
     hw.last_doorbell = ~uint64_t(0);
     hw.host_accessible = true;
-    hw.is_sdma = (args->queue_type == 1 /*KFD_IOC_QUEUE_TYPE_SDMA*/ ||
-                  args->queue_type == 3 /*KFD_IOC_QUEUE_TYPE_SDMA_XGMI*/ ||
-                  args->queue_type == 4 /*KFD_IOC_QUEUE_TYPE_SDMA_BY_ENG_ID*/);
+    hw.is_sdma = args->queue_type == KFD_IOC_QUEUE_TYPE_SDMA ||
+                 args->queue_type == KFD_IOC_QUEUE_TYPE_SDMA_XGMI ||
+                 args->queue_type == KFD_IOC_QUEUE_TYPE_SDMA_BY_ENG_ID;
+    const bool is_aql = args->queue_type == KFD_IOC_QUEUE_TYPE_COMPUTE_AQL;
     // amd_queue_t base: write_pointer_address points to write_dispatch_id.
-    if (!hw.is_sdma)
+    if (is_aql)
       hw.queue_desc_va = args->write_pointer_address - offsetof(amd_queue_t, write_dispatch_id);
+    if (is_aql && daemon_mode_ && args->ctx_save_restore_address != 0) {
+      const auto *state =
+          reinterpret_cast<const RpcQueueErrorState *>(args->ctx_save_restore_address);
+      hw.error_reason_va = state->signal_value_address;
+      hw.error_mailbox_va = state->event_mailbox_address;
+      hw.error_event_id = state->event_id;
+      hw.remote_error_metadata = true;
+      hw.uses_legacy_error_mask = (state->flags & RPC_QUEUE_ERROR_USES_LEGACY_MASK) != 0;
+    } else if (is_aql && args->ctx_save_restore_address != 0) {
+      // HsaUserContextSaveAreaHeader stores the exception signal value pointer
+      // and its shared KFD event ID at ABI offsets 24 and 32. CP firmware writes
+      // the exception bitmask through these fields for ROCr's async queue-error
+      // handler.
+      constexpr uint64_t kErrorReasonOffset = 24;
+      constexpr uint64_t kErrorEventIdOffset = 32;
+      if (auto *memory = gpu->soc->memory()) {
+        hw.error_reason_va =
+            memory->read64(args->ctx_save_restore_address + kErrorReasonOffset, proc.process_id());
+        hw.error_event_id =
+            memory->read32(args->ctx_save_restore_address + kErrorEventIdOffset, proc.process_id());
+      }
+    }
     if (hw.is_sdma && !daemon_mode_) {
       auto *wptr = reinterpret_cast<uint64_t *>(args->write_pointer_address);
       auto *rptr = reinterpret_cast<uint64_t *>(args->read_pointer_address);
@@ -1448,6 +1495,28 @@ int SimulatedKfd::create_queue_ioctl(KfdProcess &proc, void *arg) {
   // Register with the CP OUTSIDE alloc_mutex_ (see note above).
   target_cp->register_queue(std::move(hw));
   return 0;
+}
+
+std::vector<SimulatedKfd::SignalWrite> SimulatedKfd::take_signal_writes(uint32_t process_id,
+                                                                        size_t capacity) {
+  std::lock_guard<std::mutex> ilk(interrupt_mutex_);
+  auto it = pending_signal_writes_.find(process_id);
+  if (it == pending_signal_writes_.end() || capacity == 0)
+    return {};
+
+  auto &pending = it->second;
+  const size_t count = std::min(capacity, pending.size());
+  std::vector<SignalWrite> result(pending.begin(), pending.begin() + count);
+  pending.erase(pending.begin(), pending.begin() + count);
+  if (pending.empty())
+    pending_signal_writes_.erase(it);
+  return result;
+}
+
+size_t SimulatedKfd::signal_write_count(uint32_t process_id) const {
+  std::lock_guard<std::mutex> ilk(interrupt_mutex_);
+  auto it = pending_signal_writes_.find(process_id);
+  return it == pending_signal_writes_.end() ? 0 : it->second.size();
 }
 
 int SimulatedKfd::update_queue_ioctl(KfdProcess &proc, void *arg) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
@@ -106,6 +106,14 @@ public:
   int munmap(uint32_t process_id, void *addr, size_t length);
   int close(uint32_t process_id);
   [[nodiscard]] int get_mmap_memfd(uint32_t process_id, off_t offset) const;
+
+  struct SignalWrite {
+    uint64_t address = 0;
+    uint64_t value = 0;
+  };
+  /// @brief Drain up to @p capacity stores destined for client-owned signals.
+  std::vector<SignalWrite> take_signal_writes(uint32_t process_id, size_t capacity);
+  [[nodiscard]] size_t signal_write_count(uint32_t process_id) const;
   /// @}
 
   /// @brief Local-mode get_mmap_memfd (uses local process).
@@ -282,6 +290,7 @@ private:
   /// to avoid ABBA deadlocks with hw_queue_mutex_ in the CP doorbell thread.
   mutable std::mutex interrupt_mutex_;
   std::unordered_map<uint32_t, EventState *> event_dispatch_;
+  std::unordered_map<uint32_t, std::vector<SignalWrite>> pending_signal_writes_;
 
   /// @brief Process ID for local-mode (interposer). Set once in open().
   uint32_t local_process_id_ = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -44,6 +44,11 @@ namespace {
 constexpr uint32_t kMaxClusterWorkgroups = kClusterMulticastMaskBits;
 static_assert(kMaxClusterWorkgroups <= kClusterMulticastMaskBits);
 
+constexpr uint32_t kPacketUnsupportedExceptionCode = 20;
+constexpr uint32_t kVendorPacketUnsupportedExceptionCode = 23;
+constexpr uint64_t kLegacyPacketUnsupportedMask = 32;
+constexpr uint64_t kLegacyVendorPacketUnsupportedMask = 256;
+
 struct PlannedWorkgroup {
   uint32_t local_wg_id = 0;
   uint32_t global_wg_id = 0;
@@ -481,6 +486,79 @@ void CommandProcessor::write_gpu_block(uint64_t va, const void *src, size_t size
   auto *p = static_cast<const uint8_t *>(src);
   for (size_t i = 0; i < size; ++i)
     memory_->write8(va + i, p[i], vmid);
+}
+
+void CommandProcessor::signal_kfd_event(uint32_t process_id, uint64_t signal_value_va,
+                                        uint32_t event_id, uint64_t value) {
+  if (!memory_ || signal_value_va == 0)
+    return;
+
+  // amd_signal_t::value is at offset 8. The mailbox pointer and event ID follow
+  // it at relative offsets 8 and 16, respectively. Publish the payload before
+  // waking the event so ROCr's async handler observes the new value.
+  auto store_release = [&](uint64_t va, uint64_t payload) {
+    if (auto *page = memory_->resolve_host_ptr(va, process_id);
+        page && (va & (alignof(uint64_t) - 1)) == 0 && (va & 0xFFF) + sizeof(uint64_t) <= 0x1000) {
+      auto *ptr = reinterpret_cast<uint64_t *>(page + (va & 0xFFF));
+      std::atomic_ref<uint64_t>(*ptr).store(payload, std::memory_order_release);
+    } else {
+      // Daemon mode may only be able to reach client memory through
+      // process_vm_writev, which GpuMemory::write64 handles for us.
+      memory_->write64(va, payload, process_id);
+    }
+  };
+  store_release(signal_value_va, value);
+
+  if (event_id == 0)
+    event_id = read_gpu_u32(signal_value_va + 16, process_id);
+
+  const uint64_t mailbox_va = read_gpu_u64(signal_value_va + 8, process_id);
+  if (mailbox_va != 0)
+    store_release(mailbox_va, event_id);
+
+  if (interrupt_cb_ && event_id != 0)
+    interrupt_cb_(process_id, event_id);
+}
+
+void CommandProcessor::report_queue_error(HwQueue &queue, uint32_t exception_code,
+                                          uint64_t legacy_error_mask) {
+  if (queue.faulted)
+    return;
+  queue.faulted = true;
+
+  // Newer KFD interfaces expose the per-queue exception signal through the
+  // CWSR header. Exception codes use the hardware bit numbering consumed by
+  // ROCr's AqlQueue::ExceptionHandler.
+  if (queue.error_reason_va != 0) {
+    if (exception_code == 0 || exception_code > 64) {
+      util::Logger::warn("Unable to report invalid queue exception code: ", exception_code);
+      return;
+    }
+    const uint64_t exception_mask = uint64_t{1} << (exception_code - 1);
+    const uint64_t signal_value = queue.uses_legacy_error_mask ? legacy_error_mask : exception_mask;
+    if (queue.remote_error_metadata && remote_queue_error_cb_ &&
+        remote_queue_error_cb_(queue.process_id, queue.error_reason_va, queue.error_mailbox_va,
+                               queue.error_event_id, signal_value))
+      return;
+    signal_kfd_event(queue.process_id, queue.error_reason_va, queue.error_event_id, signal_value);
+    return;
+  }
+
+  // Older runtimes multiplex queue errors onto queue_inactive_signal. Preserve
+  // that path for configurations without a CWSR exception signal.
+  if (queue.queue_desc_va != 0) {
+    constexpr uint64_t kQueueInactiveSignalOffset = offsetof(amd_queue_t, queue_inactive_signal);
+    const uint64_t signal_base =
+        read_gpu_u64(queue.queue_desc_va + kQueueInactiveSignalOffset, queue.process_id);
+    if (signal_base != 0) {
+      constexpr uint64_t kSignalValueOffset = 8;
+      signal_kfd_event(queue.process_id, signal_base + kSignalValueOffset, 0, legacy_error_mask);
+      return;
+    }
+  }
+
+  util::Logger::warn("Unable to report queue error: pid=", queue.process_id,
+                     " qid=", queue.queue_id, " exception=", exception_code);
 }
 
 /// @brief Scan all HW queues for doorbell changes; return true if any changed.
@@ -1124,6 +1202,8 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
 void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
   if (!memory_)
     return;
+  if (queue.faulted)
+    return;
   if (queue.host_accessible ? (queue.doorbell_base == nullptr) : (queue.doorbell_va == 0))
     return;
 
@@ -1365,9 +1445,21 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
 
         qs.entries.push_back(std::move(dp));
       } else {
-        throw std::runtime_error("Unsupported AMD vendor-specific AQL packet format: " +
-                                 std::to_string(ext.amd_format));
+        // EC_QUEUE_PACKET_VENDOR_UNSUPPORTED. Leave the packet unconsumed and
+        // let ROCr translate the exception into
+        // HSA_STATUS_ERROR_INVALID_PACKET_FORMAT for the queue callback.
+        report_queue_error(queue, kVendorPacketUnsupportedExceptionCode,
+                           kLegacyVendorPacketUnsupportedMask);
+        process_limit = read_idx;
+        break;
       }
+    } else {
+      // EC_QUEUE_PACKET_UNSUPPORTED. This covers agent-dispatch and reserved
+      // packet types that rocJITsu cannot execute; consuming them as no-ops
+      // would falsely report forward progress.
+      report_queue_error(queue, kPacketUnsupportedExceptionCode, kLegacyPacketUnsupportedMask);
+      process_limit = read_idx;
+      break;
     }
 
     ++read_idx;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -70,6 +70,12 @@ struct HwQueue {
   bool host_accessible = false;
   bool is_sdma = false;
   uint64_t queue_desc_va = 0;
+  uint64_t error_reason_va = 0;
+  uint64_t error_mailbox_va = 0;
+  uint32_t error_event_id = 0;
+  bool remote_error_metadata = false;
+  bool uses_legacy_error_mask = false;
+  bool faulted = false;
 };
 
 enum class SdmaPacketDialect {
@@ -114,6 +120,16 @@ public:
 
   using InterruptCallback = std::function<void(uint32_t process_id, uint32_t event_id)>;
   void set_interrupt_callback(InterruptCallback cb) { interrupt_cb_ = std::move(cb); }
+
+  /// @brief Publish a queue error that targets client-private signal memory.
+  /// @returns true when the callback queued the signal stores and interrupt,
+  /// allowing the CP to skip direct memory access from daemon mode.
+  using RemoteQueueErrorCallback =
+      std::function<bool(uint32_t process_id, uint64_t signal_value_va, uint64_t mailbox_va,
+                         uint32_t event_id, uint64_t value)>;
+  void set_remote_queue_error_callback(RemoteQueueErrorCallback cb) {
+    remote_queue_error_cb_ = std::move(cb);
+  }
 
   using ScratchBackingResolver = std::function<uint64_t(uint32_t process_id)>;
   void set_scratch_backing_resolver(ScratchBackingResolver cb) {
@@ -184,6 +200,13 @@ private:
 
   /// @brief Fetch AQL packets from a single HW queue.
   void fetch_from_queue(HwQueue &queue, HwQueueState &qs);
+
+  /// @brief Stop a malformed queue and report its hardware exception to ROCr.
+  void report_queue_error(HwQueue &queue, uint32_t exception_code, uint64_t legacy_error_mask);
+
+  /// @brief Publish a signal value and wake the associated KFD event.
+  void signal_kfd_event(uint32_t process_id, uint64_t signal_value_va, uint32_t event_id,
+                        uint64_t value);
 
   /// @brief Process SDMA packets from an SDMA queue's ring buffer.
   void process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint64_t write_idx);
@@ -320,6 +343,7 @@ private:
   bool scan_doorbells();
 
   InterruptCallback interrupt_cb_;
+  RemoteQueueErrorCallback remote_queue_error_cb_;
   ScratchBackingResolver scratch_resolver_;
   ScratchBackingAllocator scratch_allocator_;
   std::unique_ptr<CompletionTracker> completion_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
@@ -102,6 +102,11 @@ void reconstruct_embedded_pointers(uint32_t cmd, void *arg, size_t arg_size, siz
     return;
   auto *extra = static_cast<uint8_t *>(arg) + arg_size;
   switch (cmd) {
+  case AMDKFD_IOC_CREATE_QUEUE: {
+    auto *args = static_cast<kfd_ioctl_create_queue_args *>(arg);
+    args->ctx_save_restore_address = reinterpret_cast<uint64_t>(extra);
+    break;
+  }
   case AMDKFD_IOC_WAIT_EVENTS: {
     auto *args = static_cast<kfd_ioctl_wait_events_args *>(arg);
     args->events_ptr = reinterpret_cast<uint64_t>(extra);
@@ -303,6 +308,24 @@ rj_status_t rj_vm_execute_as(rj_vm_t *vm, uint32_t process_id, rj_vm_cmd_t *cmd)
   if (!vm || !cmd || !vm->vm || !vm->vm->driver())
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
   return execute_impl(vm->vm->driver(), process_id, cmd);
+}
+
+rj_status_t rj_vm_take_signal_writes_as(rj_vm_t *vm, uint32_t process_id,
+                                        rj_vm_signal_write_t *writes, size_t capacity,
+                                        size_t *count) {
+  if (!vm || !count || (capacity != 0 && !writes) || !vm->vm || !vm->vm->driver())
+    return ROCJITSU_STATUS_INVALID_ARGUMENT;
+  if (capacity == 0) {
+    *count = vm->vm->driver()->signal_write_count(process_id);
+    return ROCJITSU_STATUS_SUCCESS;
+  }
+  auto pending = vm->vm->driver()->take_signal_writes(process_id, capacity);
+  for (size_t i = 0; i < pending.size(); ++i) {
+    writes[i].address = pending[i].address;
+    writes[i].value = pending[i].value;
+  }
+  *count = pending.size();
+  return ROCJITSU_STATUS_SUCCESS;
 }
 
 rj_status_t rj_vm_device_open(rj_vm_t *vm, rj_client_pid_t client_pid, uint32_t *process_id) {

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -1074,6 +1074,39 @@ if(HSA_RUNTIME64)
                 "--gtest_filter=HsaTest.${_hsa_test}"
         )
     endforeach()
+
+    add_executable(hsa_invalid_packet_test hsa_invalid_packet_test.cpp)
+    target_include_directories(
+        hsa_invalid_packet_test
+        PRIVATE ${RJ_HSA_INCLUDE_DIR} ${HSA_INCLUDE_DIR}
+    )
+    target_link_libraries(hsa_invalid_packet_test PRIVATE ${HSA_RUNTIME64})
+    target_link_options(
+        hsa_invalid_packet_test
+        PRIVATE -Wl,-rpath,${RJ_HSA_LIBRARY_DIR}
+    )
+    add_dependencies(hsa_invalid_packet_test rocjitsu_bin rocjitsu_shared)
+    rj_configure_target(hsa_invalid_packet_test TEST)
+    if(RJ_INSTALL_TESTS)
+        rj_install_test_target(hsa_invalid_packet_test)
+    endif()
+    rj_add_test(
+        NAME HsaInvalidPacketTest.LocalModeReportsQueueError
+        COMMAND
+            ${RJ_CLI}
+            --config
+            ${RJ_CDNA4_KMD_CONFIG}
+            --
+            $<TARGET_FILE:hsa_invalid_packet_test>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        TIMEOUT 30
+        INSTALL_COMMAND
+            "\${RJ_INSTALLED_BINDIR}/rocjitsu"
+            "--config"
+            "\${RJ_INSTALLED_CONFIG_DIR}/${RJ_CDNA4_KMD_CONFIG_NAME}"
+            "--"
+            "bin/hsa_invalid_packet_test"
+    )
     message(STATUS "HSA init test enabled (found ${HSA_RUNTIME64})")
 
     # --- HSA translate test: CDNA4→RDNA4 on-device verification ---
@@ -1799,6 +1832,7 @@ if(RJ_ENABLE_HIP_TESTS)
                 RJ_HIP_VECTOR_ADD_BIN="${CMAKE_CURRENT_BINARY_DIR}/hip_vector_add_test"
                 RJ_HIP_MEMCPY_BIN="${CMAKE_CURRENT_BINARY_DIR}/hip_memcpy_test"
                 RJ_HIP_RCCL_BIN="${CMAKE_CURRENT_BINARY_DIR}/hip_rccl_test"
+                RJ_HSA_INVALID_PACKET_BIN="$<TARGET_FILE:hsa_invalid_packet_test>"
                 RJ_INTERPOSER_DUP_BIN="$<TARGET_FILE:interposer_dup_test>"
                 RJ_INSTALLED_DAEMON_BIN="${_rj_installed_rocjitsu_bin}"
                 RJ_INSTALLED_DAEMON_CONFIG="${_rj_installed_daemon_config}"
@@ -1807,6 +1841,7 @@ if(RJ_ENABLE_HIP_TESTS)
                 RJ_INSTALLED_HIP_VECTOR_ADD_BIN="hip_vector_add_test"
                 RJ_INSTALLED_HIP_MEMCPY_BIN="hip_memcpy_test"
                 RJ_INSTALLED_HIP_RCCL_BIN="hip_rccl_test"
+                RJ_INSTALLED_HSA_INVALID_PACKET_BIN="hsa_invalid_packet_test"
                 RJ_INSTALLED_INTERPOSER_DUP_BIN="interposer_dup_test"
         )
         target_link_libraries(daemon_test PRIVATE GTest::gtest_main)
@@ -1815,6 +1850,7 @@ if(RJ_ENABLE_HIP_TESTS)
             rocjitsu_bin
             hip_vector_add_test_target
             hip_memcpy_test_target
+            hsa_invalid_packet_test
             interposer_dup_test
         )
         if(RJ_INSTALL_TESTS)
@@ -1825,6 +1861,7 @@ if(RJ_ENABLE_HIP_TESTS)
             DaemonTest.HipMemcpyRoundTripFloat
             DaemonTest.HipMemcpyRoundTripInt
             DaemonTest.HipMemcpyDeviceToDevice
+            DaemonTest.UnsupportedPacketReportsQueueError
             DaemonTest.TwoIndependentClients
             DaemonTest.InterposerDupReopenAfterPrimaryOverwriteRemote
             DaemonTest.InterposerDupSerializedReopenUnderContentionRemote

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -21,6 +21,7 @@
 RJ_DIAGNOSTIC_PUSH
 RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "hsa/AMDHSAKernelDescriptor.h"
+#include "hsa/amd_hsa_queue.h"
 RJ_DIAGNOSTIC_POP
 
 #include <gtest/gtest.h>
@@ -875,22 +876,145 @@ TEST_P(IsaTest, NonKernelBarrierPacketsOrderQueueEntries) {
   }
 }
 
-TEST_P(IsaTest, VendorSpecificRejectsUnsupportedFormats) {
-  constexpr std::array<uint8_t, 2> unsupported_formats{0, 200};
+TEST_P(IsaTest, VendorSpecificReportsUnsupportedFormatsWithoutConsumption) {
+  constexpr std::array<uint8_t, 3> unsupported_formats{0, 200, 255};
 
   for (const auto amd_format : unsupported_formats) {
     SCOPED_TRACE(static_cast<unsigned>(amd_format));
     VmFixture f(arch(), 1, 8);
 
+    constexpr uint64_t kErrorReason = 0x7000;
+    constexpr uint64_t kCompletionSignal = 0x7100;
+    constexpr uint64_t kSignalValueOffset = 8;
+    constexpr uint32_t kErrorEventId = 17;
+    constexpr uint64_t kVendorUnsupported = uint64_t{1} << (23 - 1);
+    f.mem()->write64(kCompletionSignal + kSignalValueOffset, 1);
+
+    uint32_t interrupted_process = 0;
+    uint32_t interrupted_event = 0;
+    uint32_t interrupt_count = 0;
+    f.cp()->set_interrupt_callback([&](uint32_t process_id, uint32_t event_id) {
+      interrupted_process = process_id;
+      interrupted_event = event_id;
+      ++interrupt_count;
+    });
+
     amdgpu::AmdExtKernelDispatchPacket packet{};
     packet.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
     packet.amd_format = amd_format;
+    packet.completion_signal.handle = kCompletionSignal;
 
-    test::AqlQueue queue(f.mem(), f.cp());
+    test::AqlQueue queue(
+        f.mem(), f.cp(), test::AqlQueue::DEFAULT_RING_ADDR, test::AqlQueue::DEFAULT_RING_SIZE,
+        test::AqlQueue::DEFAULT_READ_PTR_ADDR, test::AqlQueue::DEFAULT_WRITE_PTR_ADDR,
+        test::AqlQueue::DEFAULT_DOORBELL_ADDR, /*process_id=*/9, kErrorReason, kErrorEventId);
     queue.submit(packet);
 
-    EXPECT_THROW((void)f.engine->step(), std::runtime_error);
+    EXPECT_NO_THROW((void)f.engine->step());
     EXPECT_EQ(f.mem()->read64(test::AqlQueue::DEFAULT_READ_PTR_ADDR), 0u);
+    EXPECT_EQ(f.mem()->read64(kCompletionSignal + kSignalValueOffset), 1u);
+    EXPECT_EQ(f.mem()->read64(kErrorReason), kVendorUnsupported);
+    EXPECT_EQ(interrupted_process, 9u);
+    EXPECT_EQ(interrupted_event, kErrorEventId);
+    EXPECT_EQ(interrupt_count, 1u);
+
+    f.cp()->engine()->schedule_event_now(f.cp()->doorbell_event());
+    EXPECT_NO_THROW((void)f.engine->step());
+    EXPECT_EQ(interrupt_count, 1u);
+  }
+}
+
+TEST_P(IsaTest, UnsupportedStandardPacketReportsQueueErrorWithoutConsumption) {
+  VmFixture f(arch(), 1, 8);
+
+  constexpr uint64_t kErrorReason = 0x7000;
+  constexpr uint64_t kCompletionSignal = 0x7100;
+  constexpr uint64_t kSignalValueOffset = 8;
+  constexpr uint32_t kErrorEventId = 23;
+  constexpr uint64_t kPacketUnsupported = uint64_t{1} << (20 - 1);
+  f.mem()->write64(kCompletionSignal + kSignalValueOffset, 1);
+  uint32_t interrupted_event = 0;
+  uint32_t interrupt_count = 0;
+  f.cp()->set_interrupt_callback([&](uint32_t, uint32_t event_id) {
+    interrupted_event = event_id;
+    ++interrupt_count;
+  });
+
+  hsa_kernel_dispatch_packet_t packet{};
+  packet.header = HSA_PACKET_TYPE_AGENT_DISPATCH;
+  packet.completion_signal.handle = kCompletionSignal;
+
+  test::AqlQueue queue(
+      f.mem(), f.cp(), test::AqlQueue::DEFAULT_RING_ADDR, test::AqlQueue::DEFAULT_RING_SIZE,
+      test::AqlQueue::DEFAULT_READ_PTR_ADDR, test::AqlQueue::DEFAULT_WRITE_PTR_ADDR,
+      test::AqlQueue::DEFAULT_DOORBELL_ADDR, /*process_id=*/11, kErrorReason, kErrorEventId);
+  queue.submit(packet);
+
+  EXPECT_NO_THROW((void)f.engine->step());
+  EXPECT_EQ(f.mem()->read64(test::AqlQueue::DEFAULT_READ_PTR_ADDR), 0u);
+  EXPECT_EQ(f.mem()->read64(kCompletionSignal + kSignalValueOffset), 1u);
+  EXPECT_EQ(f.mem()->read64(kErrorReason), kPacketUnsupported);
+  EXPECT_EQ(interrupted_event, kErrorEventId);
+  EXPECT_EQ(interrupt_count, 1u);
+
+  f.cp()->engine()->schedule_event_now(f.cp()->doorbell_event());
+  EXPECT_NO_THROW((void)f.engine->step());
+  EXPECT_EQ(interrupt_count, 1u);
+}
+
+TEST_P(IsaTest, UnsupportedPacketsUseLegacyQueueInactiveSignalMasks) {
+  constexpr uint64_t kQueueDesc = 0x7000;
+  constexpr uint64_t kSignal = 0x7200;
+  constexpr uint64_t kMailbox = 0x7400;
+  constexpr uint64_t kSignalValueOffset = 8;
+  constexpr uint32_t kErrorEventId = 29;
+  struct LegacyPacketCase {
+    uint16_t packet_type;
+    uint8_t amd_format;
+    uint64_t expected_mask;
+  };
+  constexpr std::array cases{
+      LegacyPacketCase{HSA_PACKET_TYPE_VENDOR_SPECIFIC, 255, 256},
+      LegacyPacketCase{HSA_PACKET_TYPE_AGENT_DISPATCH, 0, 32},
+  };
+
+  for (const auto &test_case : cases) {
+    SCOPED_TRACE(test_case.packet_type);
+    VmFixture f(arch(), 1, 8);
+
+    f.mem()->write64(kQueueDesc + offsetof(amd_queue_t, queue_inactive_signal), kSignal);
+    f.mem()->write64(kSignal + kSignalValueOffset, 1);
+    f.mem()->write64(kSignal + kSignalValueOffset + 8, kMailbox);
+    f.mem()->write32(kSignal + kSignalValueOffset + 16, kErrorEventId);
+
+    uint32_t interrupted_event = 0;
+    uint32_t interrupt_count = 0;
+    f.cp()->set_interrupt_callback([&](uint32_t, uint32_t event_id) {
+      interrupted_event = event_id;
+      ++interrupt_count;
+    });
+
+    hsa_kernel_dispatch_packet_t packet{};
+    packet.header = test_case.packet_type;
+    packet.setup = test_case.amd_format;
+
+    test::AqlQueue queue(
+        f.mem(), f.cp(), test::AqlQueue::DEFAULT_RING_ADDR, test::AqlQueue::DEFAULT_RING_SIZE,
+        test::AqlQueue::DEFAULT_READ_PTR_ADDR, test::AqlQueue::DEFAULT_WRITE_PTR_ADDR,
+        test::AqlQueue::DEFAULT_DOORBELL_ADDR, /*process_id=*/13, /*error_reason_va=*/0,
+        /*error_event_id=*/0, kQueueDesc);
+    queue.submit(packet);
+
+    EXPECT_NO_THROW((void)f.engine->step());
+    EXPECT_EQ(f.mem()->read64(test::AqlQueue::DEFAULT_READ_PTR_ADDR), 0u);
+    EXPECT_EQ(f.mem()->read64(kSignal + kSignalValueOffset), test_case.expected_mask);
+    EXPECT_EQ(f.mem()->read64(kMailbox), kErrorEventId);
+    EXPECT_EQ(interrupted_event, kErrorEventId);
+    EXPECT_EQ(interrupt_count, 1u);
+
+    f.cp()->engine()->schedule_event_now(f.cp()->doorbell_event());
+    EXPECT_NO_THROW((void)f.engine->step());
+    EXPECT_EQ(interrupt_count, 1u);
   }
 }
 

--- a/emulation/rocjitsu/tests/aql_queue.h
+++ b/emulation/rocjitsu/tests/aql_queue.h
@@ -40,7 +40,8 @@ public:
            uint64_t ring_addr = DEFAULT_RING_ADDR, uint32_t ring_size = DEFAULT_RING_SIZE,
            uint64_t read_ptr_addr = DEFAULT_READ_PTR_ADDR,
            uint64_t write_ptr_addr = DEFAULT_WRITE_PTR_ADDR,
-           uint64_t doorbell_addr = DEFAULT_DOORBELL_ADDR)
+           uint64_t doorbell_addr = DEFAULT_DOORBELL_ADDR, uint32_t process_id = 0,
+           uint64_t error_reason_va = 0, uint32_t error_event_id = 0, uint64_t queue_desc_va = 0)
       : memory_(memory), cp_(cp), ring_addr_(ring_addr), ring_size_(ring_size),
         read_ptr_addr_(read_ptr_addr), write_ptr_addr_(write_ptr_addr),
         doorbell_addr_(doorbell_addr) {
@@ -50,12 +51,16 @@ public:
     memory_->load_image(reinterpret_cast<const uint8_t *>(&zero), 8, doorbell_addr_);
 
     amdgpu::HwQueue hw{};
+    hw.process_id = process_id;
     hw.queue_id = 1;
     hw.ring_base_va = ring_addr_;
     hw.ring_size = ring_size_;
     hw.read_ptr_va = read_ptr_addr_;
     hw.write_ptr_va = write_ptr_addr_;
     hw.doorbell_va = doorbell_addr_;
+    hw.error_reason_va = error_reason_va;
+    hw.error_event_id = error_event_id;
+    hw.queue_desc_va = queue_desc_va;
     cp_->register_queue(std::move(hw));
   }
 

--- a/emulation/rocjitsu/tests/daemon_test.cpp
+++ b/emulation/rocjitsu/tests/daemon_test.cpp
@@ -55,6 +55,7 @@ struct TestPaths {
   std::string hip_vector_add_bin = RJ_HIP_VECTOR_ADD_BIN;
   std::string hip_memcpy_bin = RJ_HIP_MEMCPY_BIN;
   std::string hip_rccl_bin = RJ_HIP_RCCL_BIN;
+  std::string hsa_invalid_packet_bin = RJ_HSA_INVALID_PACKET_BIN;
   std::string interposer_dup_bin = RJ_INTERPOSER_DUP_BIN;
 };
 
@@ -86,6 +87,7 @@ bool installed_paths_exist(const TestPaths &paths) {
          std::filesystem::exists(paths.preload_lib) &&
          std::filesystem::exists(paths.hip_vector_add_bin) &&
          std::filesystem::exists(paths.hip_memcpy_bin) &&
+         std::filesystem::exists(paths.hsa_invalid_packet_bin) &&
          std::filesystem::exists(paths.interposer_dup_bin);
 }
 
@@ -98,6 +100,7 @@ TestPaths installed_paths(const std::filesystem::path &exe_dir) {
       resolve_relative_to_exe(exe_dir, RJ_INSTALLED_HIP_VECTOR_ADD_BIN).string(),
       resolve_relative_to_exe(exe_dir, RJ_INSTALLED_HIP_MEMCPY_BIN).string(),
       resolve_relative_to_exe(exe_dir, RJ_INSTALLED_HIP_RCCL_BIN).string(),
+      resolve_relative_to_exe(exe_dir, RJ_INSTALLED_HSA_INVALID_PACKET_BIN).string(),
       resolve_relative_to_exe(exe_dir, RJ_INSTALLED_INTERPOSER_DUP_BIN).string(),
   };
 }
@@ -128,6 +131,8 @@ const char *hip_vector_add_bin() { return test_paths().hip_vector_add_bin.c_str(
 const char *hip_memcpy_bin() { return test_paths().hip_memcpy_bin.c_str(); }
 
 const char *hip_rccl_bin() { return test_paths().hip_rccl_bin.c_str(); }
+
+const char *hsa_invalid_packet_bin() { return test_paths().hsa_invalid_packet_bin.c_str(); }
 
 const char *interposer_dup_bin() { return test_paths().interposer_dup_bin.c_str(); }
 
@@ -295,6 +300,11 @@ TEST_F(DaemonTest, HipMemcpyRoundTripInt) {
 
 TEST_F(DaemonTest, HipMemcpyDeviceToDevice) {
   auto r = run_hip_test(hip_memcpy_bin(), "HipMemcpyTest.DeviceToDevice");
+  EXPECT_EQ(r.exit_code, 0) << r.output;
+}
+
+TEST_F(DaemonTest, UnsupportedPacketReportsQueueError) {
+  auto r = run_hip_test(hsa_invalid_packet_bin(), nullptr);
   EXPECT_EQ(r.exit_code, 0) << r.output;
 }
 

--- a/emulation/rocjitsu/tests/hsa_invalid_packet_test.cpp
+++ b/emulation/rocjitsu/tests/hsa_invalid_packet_test.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file hsa_invalid_packet_test.cpp
+/// @brief End-to-end ROCr queue callback test for an unsupported AQL packet.
+
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include <hsa/hsa.h>
+RJ_DIAGNOSTIC_POP
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <thread>
+
+namespace {
+
+struct alignas(64) UnknownVendorPacket {
+  uint16_t header;
+  uint8_t amd_format;
+  uint8_t reserved[53];
+  hsa_signal_t completion_signal;
+};
+static_assert(sizeof(UnknownVendorPacket) == 64);
+static_assert(offsetof(UnknownVendorPacket, completion_signal) == 56);
+
+std::atomic<uint32_t> callback_count{0};
+std::atomic<hsa_status_t> callback_status{HSA_STATUS_SUCCESS};
+
+hsa_status_t find_gpu(hsa_agent_t agent, void *data) {
+  hsa_device_type_t type{};
+  if (hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &type) == HSA_STATUS_SUCCESS &&
+      type == HSA_DEVICE_TYPE_GPU)
+    *static_cast<hsa_agent_t *>(data) = agent;
+  return HSA_STATUS_SUCCESS;
+}
+
+void queue_error(hsa_status_t status, hsa_queue_t *, void *) {
+  callback_status.store(status, std::memory_order_relaxed);
+  callback_count.fetch_add(1, std::memory_order_release);
+}
+
+} // namespace
+
+int main() {
+  if (hsa_init() != HSA_STATUS_SUCCESS)
+    return 1;
+
+  hsa_agent_t gpu{};
+  if (hsa_iterate_agents(find_gpu, &gpu) != HSA_STATUS_SUCCESS || gpu.handle == 0)
+    return 2;
+
+  uint32_t queue_size = 0;
+  if (hsa_agent_get_info(gpu, HSA_AGENT_INFO_QUEUE_MAX_SIZE, &queue_size) != HSA_STATUS_SUCCESS)
+    return 3;
+
+  hsa_queue_t *queue = nullptr;
+  if (hsa_queue_create(gpu, queue_size, HSA_QUEUE_TYPE_MULTI, queue_error, nullptr, UINT32_MAX,
+                       UINT32_MAX, &queue) != HSA_STATUS_SUCCESS)
+    return 4;
+
+  hsa_signal_t completion{};
+  if (hsa_signal_create(1, 0, nullptr, &completion) != HSA_STATUS_SUCCESS)
+    return 5;
+
+  const uint64_t index = hsa_queue_add_write_index_relaxed(queue, 1);
+  auto *packet =
+      static_cast<UnknownVendorPacket *>(queue->base_address) + (index & (queue->size - 1));
+  std::memset(packet, 0, sizeof(*packet));
+  packet->amd_format = 0xff;
+  packet->completion_signal = completion;
+  uint16_t header = HSA_PACKET_TYPE_VENDOR_SPECIFIC << HSA_PACKET_HEADER_TYPE;
+  header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE;
+  header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE;
+  __atomic_store_n(reinterpret_cast<uint16_t *>(packet), header, __ATOMIC_RELEASE);
+  hsa_signal_store_relaxed(queue->doorbell_signal, index);
+
+  for (uint32_t i = 0; i < 500 && callback_count.load(std::memory_order_acquire) == 0; ++i)
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+  const bool passed =
+      callback_count.load(std::memory_order_acquire) == 1 &&
+      callback_status.load(std::memory_order_relaxed) == HSA_STATUS_ERROR_INVALID_PACKET_FORMAT &&
+      hsa_signal_load_scacquire(completion) == 1 &&
+      hsa_queue_load_read_index_scacquire(queue) == index;
+  hsa_queue_destroy(queue);
+  hsa_signal_destroy(completion);
+  hsa_shut_down();
+  return passed ? 0 : 6;
+}

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -13,6 +13,12 @@
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
 #include "simdojo/sim/simulation.h"
 
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "hsa/amd_hsa_queue.h"
+RJ_DIAGNOSTIC_POP
+
 #include <gtest/gtest.h>
 
 #include <cerrno>
@@ -600,6 +606,117 @@ TEST_F(KfdIoctlTest, DbgTrapEnableUndersizedRuntimeInfoTruncates) {
   EXPECT_EQ(en.enable.rinfo_size, sizeof(kfd_runtime_info)); // full size reported
   for (size_t i = kSmall; i < buf.size(); ++i)
     EXPECT_EQ(buf[i], kSentinel) << "runtime-info copy overran the undersized buffer at byte " << i;
+}
+
+TEST(RemoteDriverQueueErrorTest, MarshalsCwsrStateAndAppliesReturnedSignalWrites) {
+  int sv[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << strerror(errno);
+
+  alignas(8) std::array<uint8_t, 40> cwsr_header{};
+  alignas(8) std::array<uint64_t, 4> signal{};
+  alignas(8) uint64_t mailbox = 0;
+  constexpr uint32_t kEventId = 37;
+  constexpr uint64_t kExceptionMask = uint64_t{1} << (23 - 1);
+  const uint64_t signal_value_address = reinterpret_cast<uint64_t>(&signal[1]);
+  const uint64_t mailbox_address = reinterpret_cast<uint64_t>(&mailbox);
+  std::memcpy(cwsr_header.data() + 24, &signal_value_address, sizeof(signal_value_address));
+  std::memcpy(cwsr_header.data() + 32, &kEventId, sizeof(kEventId));
+  signal[2] = mailbox_address;
+
+  std::atomic<bool> metadata_ok{false};
+  std::jthread server([&, server_fd = sv[1]] {
+    rocjitsu::RpcHeader hdr{};
+    if (!rocjitsu::rpc_recv_exact(server_fd, &hdr, sizeof(hdr)))
+      return;
+    std::vector<uint8_t> request(hdr.payload_bytes);
+    if (!rocjitsu::rpc_recv_exact(server_fd, request.data(), request.size()))
+      return;
+
+    auto *ireq = reinterpret_cast<rocjitsu::RpcIoctlRequest *>(request.data());
+    const size_t arg_size = sizeof(kfd_ioctl_create_queue_args);
+    rocjitsu::RpcQueueErrorState state{};
+    if (ireq->ioctl_cmd == AMDKFD_IOC_CREATE_QUEUE &&
+        ireq->args_bytes == arg_size + sizeof(state)) {
+      std::memcpy(&state, request.data() + sizeof(*ireq) + arg_size, sizeof(state));
+      metadata_ok.store(state.signal_value_address == signal_value_address &&
+                            state.event_mailbox_address == mailbox_address &&
+                            state.event_id == kEventId && state.flags == 0,
+                        std::memory_order_release);
+    }
+
+    const std::array<rocjitsu::RpcSignalWrite, 2> writes{{
+        {signal_value_address, kExceptionMask},
+        {mailbox_address, kEventId},
+    }};
+    rocjitsu::RpcHeader response{};
+    response.opcode = rocjitsu::RPC_IOCTL;
+    response.request_id = hdr.request_id;
+    response.payload_bytes = ireq->args_bytes + static_cast<uint32_t>(sizeof(writes));
+    rocjitsu::rpc_send_exact(server_fd, &response, sizeof(response));
+    rocjitsu::rpc_send_exact(server_fd, request.data() + sizeof(*ireq), ireq->args_bytes);
+    rocjitsu::rpc_send_exact(server_fd, writes.data(), sizeof(writes));
+    ::close(server_fd);
+  });
+
+  amd_queue_t queue{};
+  kfd_ioctl_create_queue_args args{};
+  args.queue_type = KFD_IOC_QUEUE_TYPE_COMPUTE_AQL;
+  args.write_pointer_address = reinterpret_cast<uint64_t>(&queue.write_dispatch_id);
+  args.ctx_save_restore_address = reinterpret_cast<uint64_t>(cwsr_header.data());
+  const uint64_t original_cwsr_address = args.ctx_save_restore_address;
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+  ASSERT_EQ(driver.ioctl(AMDKFD_IOC_CREATE_QUEUE, &args), 0);
+  EXPECT_TRUE(metadata_ok.load(std::memory_order_acquire));
+  EXPECT_EQ(args.ctx_save_restore_address, original_cwsr_address);
+  EXPECT_EQ(signal[1], kExceptionMask);
+  EXPECT_EQ(mailbox, kEventId);
+}
+
+TEST(RemoteDriverQueueErrorTest, LeavesNonAqlComputeQueueMetadataEmpty) {
+  int sv[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << strerror(errno);
+
+  alignas(8) std::array<uint64_t, 4> signal{};
+  amd_queue_t fake_aql_layout{};
+  fake_aql_layout.queue_inactive_signal.handle = reinterpret_cast<uint64_t>(signal.data());
+  std::atomic<bool> metadata_empty{false};
+
+  std::jthread server([&, server_fd = sv[1]] {
+    rocjitsu::RpcHeader hdr{};
+    if (!rocjitsu::rpc_recv_exact(server_fd, &hdr, sizeof(hdr)))
+      return;
+    std::vector<uint8_t> request(hdr.payload_bytes);
+    if (!rocjitsu::rpc_recv_exact(server_fd, request.data(), request.size()))
+      return;
+
+    auto *ireq = reinterpret_cast<rocjitsu::RpcIoctlRequest *>(request.data());
+    rocjitsu::RpcQueueErrorState state{};
+    const size_t arg_size = sizeof(kfd_ioctl_create_queue_args);
+    if (ireq->ioctl_cmd == AMDKFD_IOC_CREATE_QUEUE &&
+        ireq->args_bytes == arg_size + sizeof(state)) {
+      std::memcpy(&state, request.data() + sizeof(*ireq) + arg_size, sizeof(state));
+      metadata_empty.store(state.signal_value_address == 0 && state.event_mailbox_address == 0 &&
+                               state.event_id == 0 && state.flags == 0,
+                           std::memory_order_release);
+    }
+
+    rocjitsu::RpcHeader response{};
+    response.opcode = rocjitsu::RPC_IOCTL;
+    response.request_id = hdr.request_id;
+    response.payload_bytes = ireq->args_bytes;
+    rocjitsu::rpc_send_exact(server_fd, &response, sizeof(response));
+    rocjitsu::rpc_send_exact(server_fd, request.data() + sizeof(*ireq), ireq->args_bytes);
+    ::close(server_fd);
+  });
+
+  kfd_ioctl_create_queue_args args{};
+  args.queue_type = KFD_IOC_QUEUE_TYPE_COMPUTE;
+  args.write_pointer_address = reinterpret_cast<uint64_t>(&fake_aql_layout.write_dispatch_id);
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+  ASSERT_EQ(driver.ioctl(AMDKFD_IOC_CREATE_QUEUE, &args), 0);
+  EXPECT_TRUE(metadata_empty.load(std::memory_order_acquire));
 }
 
 // Exercises the RemoteDriver client stub against an in-process server that runs

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -213,23 +213,42 @@ void handle_client(int client_fd, rj_vm_t *vm, pid_t client_pid, std::stop_token
       if (cmd.in_handle >= 0)
         ::close(cmd.in_handle);
 
+      // Queue exception payloads target ROCr-private signal memory. Drain the
+      // daemon's pending stores into this response; RemoteDriver publishes them
+      // before returning the ioctl that reports the event ready.
+      size_t signal_write_count = 0;
+      rj_vm_take_signal_writes_as(vm, process_id, nullptr, 0, &signal_write_count);
+      std::vector<rj_vm_signal_write_t> signal_writes(signal_write_count);
+      if (!signal_writes.empty()) {
+        rj_vm_take_signal_writes_as(vm, process_id, signal_writes.data(), signal_writes.size(),
+                                    &signal_write_count);
+        signal_writes.resize(signal_write_count);
+      }
+
       RpcHeader resp{};
       resp.opcode = RPC_IOCTL;
       resp.request_id = hdr.request_id;
       resp.result = cmd.result;
-      resp.payload_bytes = static_cast<uint32_t>(cmd.buf_size);
+      resp.payload_bytes =
+          static_cast<uint32_t>(cmd.buf_size + signal_writes.size() * sizeof(rj_vm_signal_write_t));
 
       if (cmd.shared_handle >= 0) {
-        std::vector<uint8_t> response_buffer(sizeof(resp) + cmd.buf_size);
+        std::vector<uint8_t> response_buffer(sizeof(resp) + resp.payload_bytes);
         std::memcpy(response_buffer.data(), &resp, sizeof(resp));
         if (cmd.buf_size > 0)
           std::memcpy(response_buffer.data() + sizeof(resp), cmd.buf, cmd.buf_size);
+        if (!signal_writes.empty())
+          std::memcpy(response_buffer.data() + sizeof(resp) + cmd.buf_size, signal_writes.data(),
+                      signal_writes.size() * sizeof(rj_vm_signal_write_t));
         rpc_send_msg(client_fd, response_buffer.data(), response_buffer.size(), &cmd.shared_handle,
                      1);
       } else {
         rpc_send_exact(client_fd, &resp, sizeof(resp));
         if (cmd.buf_size > 0)
           rpc_send_exact(client_fd, cmd.buf, cmd.buf_size);
+        if (!signal_writes.empty())
+          rpc_send_exact(client_fd, signal_writes.data(),
+                         signal_writes.size() * sizeof(rj_vm_signal_write_t));
       }
       break;
     }


### PR DESCRIPTION
## Motivation

Reject unsupported standard and AMD vendor AQL packets without consuming them, fault the queue through ROCr-compatible error signaling, and carry queue-error writes across daemon RPC. Add local, daemon, legacy-mask, and metadata-marshalling coverage.

## Technical Details

Rocjitsu incorrectly consumed unsupported AQL packets as successful no-ops. In particular, an unknown AMD vendor packet format advanced the queue read index and decremented its completion signal without reporting an error.

Match physical GPU behavior by leaving invalid packets unconsumed and reporting `HSA_STATUS_ERROR_INVALID_PACKET_FORMAT` through the queue error callback

## Issue Tracking

Issue: https://gist.github.com/benvanik/f54edc521e112e5b3c58ced494e410a1

## Test Plan

Unit tests.

## Test Result

OK

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
