### PR TITLE
feat(rocr): Skip gfx125x entry trampoline when unclaused-VMEM prologue already present

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -232,13 +232,25 @@ static constexpr size_t kTrampolineStubStride =
 // and readable, which the allocation's zero-fill already guarantees.
 static constexpr size_t kInstPrefUnitBytes = 128;  // GFX11+ CP I$ prefetch line size
 
+// The GFX1250 unclaused-VMEM workaround prologue (llvm PR #208467). The compiler
+// emits these 4 dwords -- global_wb <scope:SCOPE_CU> followed by v_nop -- at every
+// hardware kernel entry so the first VMEM instruction is unclaused. It is exactly
+// the sequence the entry trampoline itself prepends, so when a kernel's entry
+// already begins with it the trampoline would only duplicate the workaround.
+static constexpr uint32_t kGfx1250UnclausedVmemPrologue[4] = {
+    0xEE0B007C,  // global_wb <scope:SCOPE_CU>
+    0x00000000,  // :
+    0x00000000,  // :
+    0x7E000000,  // v_nop
+};
+
 static void BuildTrampolineGfx1250(uint8_t* buf, uint64_t target) {
   auto* w = reinterpret_cast<uint32_t*>(buf);
 
-  w[0] = 0xEE0B007C;  // global_wb <scope:SCOPE_CU>
-  w[1] = 0x00000000;  // :
-  w[2] = 0x00000000;  // :
-  w[3] = 0x7E000000;  // v_nop (padding)
+  w[0] = kGfx1250UnclausedVmemPrologue[0];  // global_wb <scope:SCOPE_CU>
+  w[1] = kGfx1250UnclausedVmemPrologue[1];  // :
+  w[2] = kGfx1250UnclausedVmemPrologue[2];  // :
+  w[3] = kGfx1250UnclausedVmemPrologue[3];  // v_nop (padding)
   w[4] = 0xBEE400FF;  // s_mov_b32 s100, target_lo
   w[5] = static_cast<uint32_t>(target);
   w[6] = 0xBEE500FF;  // s_mov_b32 s101, target_hi
@@ -1582,8 +1594,42 @@ hsa_status_t ExecutableImpl::LoadSegmentV2(const code::Segment *data_segment,
   return HSA_STATUS_SUCCESS;
 }
 
+// Returns true if the kernel entry at entry_vaddr already begins with the GFX1250
+// unclaused-VMEM workaround prologue (see kGfx1250UnclausedVmemPrologue). The check
+// reads the post-relocation host shadow of the code segment (valid pre-Freeze).
+static bool KernelEntryHasUnclausedVmemPrologue(Context* context, Segment* code_seg,
+                                                uint64_t entry_vaddr) {
+  static constexpr size_t kPrologueBytes = sizeof(kGfx1250UnclausedVmemPrologue);
+  if (!code_seg->IsAddressInSegment(entry_vaddr) ||
+      !code_seg->IsAddressInSegment(entry_vaddr + kPrologueBytes - 1)) {
+    return false;
+  }
+  void* host = context->SegmentHostAddress(code_seg->ElfSegment(), code_seg->Agent(),
+                                           code_seg->Ptr(), code_seg->Offset(entry_vaddr));
+  if (host == nullptr) return false;
+  const uint32_t* w = reinterpret_cast<const uint32_t*>(host);
+  return w[0] == kGfx1250UnclausedVmemPrologue[0] &&
+         w[1] == kGfx1250UnclausedVmemPrologue[1] &&
+         w[2] == kGfx1250UnclausedVmemPrologue[2] &&
+         w[3] == kGfx1250UnclausedVmemPrologue[3];
+}
+
 hsa_status_t ExecutableImpl::InstallTrampolinesGfx125x(hsa_agent_t agent) {
-  const size_t n = kd_fixups_.size();
+  // Skip kernels whose entry already carries the compiler-inserted unclaused-VMEM
+  // workaround prologue (llvm PR #208467): a trampoline would only duplicate the
+  // global_wb/v_nop that is already there, so dispatch can go straight to the real
+  // entry. Kernels still needing the workaround keep their trampoline.
+  std::vector<KdFixup> fixups;
+  fixups.reserve(kd_fixups_.size());
+  for (const auto& f : kd_fixups_) {
+    if (KernelEntryHasUnclausedVmemPrologue(context_, f.code_seg, f.kd_vaddr + f.entry_off)) {
+      continue;
+    }
+    fixups.push_back(f);
+  }
+  if (fixups.empty()) return HSA_STATUS_SUCCESS;
+
+  const size_t n = fixups.size();
 
   // Size the trailing prefetch guard from the largest CP instruction-prefetch
   // window among this pool's kernels (INST_PREF_SIZE lines * 128 B). The forward
@@ -1592,7 +1638,7 @@ hsa_status_t ExecutableImpl::InstallTrampolinesGfx125x(hsa_agent_t agent) {
   // remainder, (INST_PREF_SIZE*128 - stub_size), can spill past the pool and needs
   // a guard. (Clamp to 0 when the window fits within a stub slot.)
   uint32_t max_pref_lines = 0;
-  for (const auto& f : kd_fixups_) max_pref_lines = std::max(max_pref_lines, f.inst_pref);
+  for (const auto& f : fixups) max_pref_lines = std::max(max_pref_lines, f.inst_pref);
   const size_t pref_bytes = static_cast<size_t>(max_pref_lines) * kInstPrefUnitBytes;
   const size_t guard = pref_bytes > kTrampolineStubStride ? pref_bytes - kTrampolineStubStride : 0;
   const size_t pool = n * kTrampolineStubStride + guard;
@@ -1611,7 +1657,7 @@ hsa_status_t ExecutableImpl::InstallTrampolinesGfx125x(hsa_agent_t agent) {
   trampoline_segments_.push_back(tramp);  // frozen in ExecutableImpl::Freeze
 
   for (size_t i = 0; i < n; ++i) {
-    const KdFixup& f = kd_fixups_[i];
+    const KdFixup& f = fixups[i];
     const uint64_t stub_off = i * kTrampolineStubStride;
     // Device addresses are valid pre-Freeze (RegionMemory::ptr_ is set at alloc).
     const uint64_t kd_dev = reinterpret_cast<uint64_t>(f.code_seg->Address(f.kd_vaddr));
@@ -1626,6 +1672,9 @@ hsa_status_t ExecutableImpl::InstallTrampolinesGfx125x(hsa_agent_t agent) {
       BuildTrampolineGfx1250(blob, entry_dev);
     }
     tramp->Copy(stub_off, blob, sizeof(blob));  // -> trampoline host shadow
+
+    // Gated by LOADER_ENABLE_LOGGING=1 (see Logger).
+    logger_ << "Loader: injecting gfx125x entry trampoline for kernel " << f.name << "\n";
 
     // Redirect dispatch onto the stub: kernel_object(kd_dev) + new_off == stub.
     int64_t new_off = static_cast<int64_t>(stub_dev) - static_cast<int64_t>(kd_dev);
@@ -1693,8 +1742,8 @@ hsa_status_t ExecutableImpl::LoadDefinitionSymbol(hsa_agent_t agent,
       // entry; captured here to size the trampoline's prefetch guard.
       uint32_t inst_pref = AMDHSA_BITS_GET(
           kd.compute_pgm_rsrc3, rocr::llvm::amdhsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE);
-      kd_fixups_.push_back(
-          {SymbolSegment(agent, sym), sym->VAddr(), kd.kernel_code_entry_byte_offset, inst_pref});
+      kd_fixups_.push_back({SymbolSegment(agent, sym), sym->VAddr(),
+                            kd.kernel_code_entry_byte_offset, inst_pref, sym->GetSymbolName()});
     }
 
     uint32_t kernarg_segment_size = kd.kernarg_size; // FIXME: If 0 then the compiler is not specifying the size.

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -119,6 +119,7 @@ public:
   const amd::options::PrefixOption* Substitute() const { return &substitute; }
 
   bool TrampolineEnabled() const { return trampoline_enabled_; }
+  bool TrampolineNoWaEnabled() const { return trampoline_no_wa_enabled_; }
 
   bool ParseOptions(const std::string& options);
   void Reset();
@@ -140,6 +141,7 @@ private:
   amd::options::PrefixOption substitute;
   amd::options::OptionParser option_parser;
   bool trampoline_enabled_ = false;
+  bool trampoline_no_wa_enabled_ = false;
 };
 
 LoaderOptions::LoaderOptions(std::ostream& error) :
@@ -161,10 +163,16 @@ LoaderOptions::LoaderOptions(std::ostream& error) :
   option_parser.AddOption(&substitute);
 
   // LOADER_ENABLE_TRAMPOLINE=1: enable gfx125x kernel-entry trampolines.
-  // Trampolines are disabled by default; this env var is for testing only.
+  // LOADER_ENABLE_TRAMPOLINE_NO_WA=1: enable trampolines without the global_wb
+  // cache-writeback workaround (s_mov + s_set_pc only). Trampolines are disabled
+  // by default; these env vars are for testing only.
   const char* enable_trampoline = getenv("LOADER_ENABLE_TRAMPOLINE");
   if (enable_trampoline && std::strcmp(enable_trampoline, "1") == 0) {
     trampoline_enabled_ = true;
+  }
+  const char* enable_trampoline_no_wa = getenv("LOADER_ENABLE_TRAMPOLINE_NO_WA");
+  if (enable_trampoline_no_wa && std::strcmp(enable_trampoline_no_wa, "1") == 0) {
+    trampoline_no_wa_enabled_ = true;
   }
 }
 
@@ -237,6 +245,20 @@ static void BuildTrampolineGfx1250(uint8_t* buf, uint64_t target) {
   w[7] = static_cast<uint32_t>(target >> 32);
   w[8] = 0xBE804864;  // s_set_pc_i64 s[100:101]
   for (size_t i = 9; i < kTrampolineStubStride / sizeof(uint32_t); ++i)
+    w[i] = 0xBF9F0000;  // s_code_end (prefetch-safe padding)
+}
+
+// Minimal stub: load the 64-bit entry address into s[100:101] and set PC, with no
+// global_wb / v_nop cache-writeback workaround.
+static void BuildTrampolineGfx1250NoWa(uint8_t* buf, uint64_t target) {
+  auto* w = reinterpret_cast<uint32_t*>(buf);
+
+  w[0] = 0xBEE400FF;  // s_mov_b32 s100, target_lo
+  w[1] = static_cast<uint32_t>(target);
+  w[2] = 0xBEE500FF;  // s_mov_b32 s101, target_hi
+  w[3] = static_cast<uint32_t>(target >> 32);
+  w[4] = 0xBE804864;  // s_set_pc_i64 s[100:101]
+  for (size_t i = 5; i < kTrampolineStubStride / sizeof(uint32_t); ++i)
     w[i] = 0xBF9F0000;  // s_code_end (prefetch-safe padding)
 }
 
@@ -1340,9 +1362,12 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
   }
 
   // Kernel-entry trampolines (gfx125x). Disabled by default for gfx125x.
-  // Set LOADER_ENABLE_TRAMPOLINE=1 to enable (for testing only).
+  // Set LOADER_ENABLE_TRAMPOLINE=1 or LOADER_ENABLE_TRAMPOLINE_NO_WA=1 to enable
+  // (for testing only). NO_WA selects the minimal stub without global_wb.
+  trampoline_no_wa_gfx125x_ = loaderOptions.TrampolineNoWaEnabled();
   trampoline_enabled_gfx125x_ =
-      loaderOptions.TrampolineEnabled() && CodeObjectIsaIsGfx125Family(codeIsa);
+      (loaderOptions.TrampolineEnabled() || trampoline_no_wa_gfx125x_) &&
+      CodeObjectIsaIsGfx125Family(codeIsa);
   kd_fixups_.clear();
 
   uint32_t majorVersion, minorVersion;
@@ -1595,7 +1620,11 @@ hsa_status_t ExecutableImpl::InstallTrampolinesGfx125x(hsa_agent_t agent) {
     const uint64_t stub_dev = reinterpret_cast<uint64_t>(tramp->Address(stub_off));
 
     uint8_t blob[kTrampolineStubStride];
-    BuildTrampolineGfx1250(blob, entry_dev);    // stub jumps to the real entry
+    if (trampoline_no_wa_gfx125x_) {
+      BuildTrampolineGfx1250NoWa(blob, entry_dev);
+    } else {
+      BuildTrampolineGfx1250(blob, entry_dev);
+    }
     tramp->Copy(stub_off, blob, sizeof(blob));  // -> trampoline host shadow
 
     // Redirect dispatch onto the stub: kernel_object(kd_dev) + new_off == stub.

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
@@ -652,6 +652,7 @@ private:
     uint32_t inst_pref;
   };
   bool trampoline_enabled_gfx125x_ = false;
+  bool trampoline_no_wa_gfx125x_ = false;
   std::vector<KdFixup> kd_fixups_;
   std::vector<std::shared_ptr<Segment>> trampoline_segments_;
 };

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
@@ -650,6 +650,7 @@ private:
     uint64_t kd_vaddr;
     int64_t entry_off;
     uint32_t inst_pref;
+    std::string name;  // kernel/shader symbol name (for logging)
   };
   bool trampoline_enabled_gfx125x_ = false;
   bool trampoline_no_wa_gfx125x_ = false;


### PR DESCRIPTION
## Summary

Detect the GFX1250 unclaused-VMEM workaround prologue at kernel entry and skip the entry trampoline when it is already present, plus a minimal (no-workaround) trampoline mode for testing.

### 1. Skip the trampoline when the compiler workaround is already present
Detect the GFX1250 unclaused-VMEM workaround prologue (`global_wb <scope:SCOPE_CU>` + `v_nop`, from llvm PR #208467) at each kernel entry in `ExecutableImpl::InstallTrampolinesGfx125x`. When a kernel's entry already begins with that 16-byte prologue, the trampoline would only duplicate the workaround, so the kernel is filtered out and dispatch goes straight to the real entry. Kernels lacking the prologue still get a trampoline.

- Detection reads the post-relocation host shadow of the code segment (valid pre-Freeze) and compares the first 4 dwords at the kernel entry.
- The prologue is captured in a shared `kGfx1250UnclausedVmemPrologue` constant, reused by `BuildTrampolineGfx1250`.
- Each trampoline injection is logged with the kernel symbol name (gated by `LOADER_ENABLE_LOGGING=1`); `KdFixup` carries the name for this.

### 2. Minimal (no-workaround) trampoline mode for testing
`LOADER_ENABLE_TRAMPOLINE_NO_WA=1` makes the loader emit a minimal stub that loads the real kernel entry address into `s[100:101]` and jumps via `s_set_pc_i64`, omitting the `global_wb` / `v_nop` cache-writeback workaround used by the full trampoline path (`LOADER_ENABLE_TRAMPOLINE=1`).

- `LOADER_ENABLE_TRAMPOLINE=1` — full stub with `global_wb` + `v_nop` + `s_mov` + `s_set_pc`
- `LOADER_ENABLE_TRAMPOLINE_NO_WA=1` — minimal stub with `s_mov` + `s_set_pc` only
- If both are set, the NO_WA variant takes precedence

## JIRA ID

JIRA ID : LCOMPILER-2448

## Test plan

- [x] Build rocr-runtime with the change (gfx1250 TheRock toolchain)
- [x] Kernel compiled WITH the compiler workaround (patched clang): entry has `global_wb`/`v_nop`, and `InstallTrampolinesGfx125x` skips it (no injection log for that kernel)
- [x] Kernel compiled WITHOUT the workaround (original compiler from the 7.14 gfx1250 tarball): trampoline is injected as before, and the run succeeds
- [x] Verified on a gfx1250 system: both binaries run correctly; injection log lists only the kernels that actually receive a trampoline
- [x] `LOADER_ENABLE_TRAMPOLINE_NO_WA=1` emits the minimal stub; `LOADER_ENABLE_TRAMPOLINE=1` emits the full stub; disabled when neither is set

Made with [Cursor](https://cursor.com)
