### PR TITLE
ci(rocjitsu): Reduce concurrency level on CI

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -191,6 +191,7 @@ jobs:
 
           ctest --test-dir "${ROCJITSU_BUILD_DIR}" \
             -E "${EXCLUDED_TESTS}" \
+            -j "${WORKERS}" \
             --output-on-failure
 
           echo "${ROCJITSU_BUILD_DIR}/tools/rocjitsu" >> "${GITHUB_PATH}"

--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -190,8 +190,7 @@ jobs:
 
           ctest --test-dir "${ROCJITSU_BUILD_DIR}" \
             -E "${EXCLUDED_TESTS}" \
-            --output-on-failure \
-            -j "${WORKERS}"
+            --output-on-failure
 
           echo "${ROCJITSU_BUILD_DIR}/tools/rocjitsu" >> "${GITHUB_PATH}"
           echo "CXXFLAGS=" >> "${GITHUB_ENV}"

--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -186,6 +186,7 @@ jobs:
 
           # Set a conservative number of workers to avoid OOM and excessive system load.
           WORKERS="$(( ($(nproc) + 1) / 2 ))"
+          echo "WORKERS=${WORKERS}"
           cmake --build "${ROCJITSU_BUILD_DIR}" -j "${WORKERS}"
 
           ctest --test-dir "${ROCJITSU_BUILD_DIR}" \

--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -185,7 +185,7 @@ jobs:
             -DRJ_ENABLE_MSAN=${{ matrix.enable_msan }}
 
           # Set a conservative number of workers to avoid OOM and excessive system load.
-          WORKERS="$(( ($(nproc) + 1) / 2 ))"
+          WORKERS="$(( ($(nproc) + 1) / 3 ))"
           echo "WORKERS=${WORKERS}"
           cmake --build "${ROCJITSU_BUILD_DIR}" -j "${WORKERS}"
 


### PR DESCRIPTION
## Motivation

We are seeing possible OOM errors on CI during Cdna4ToCdna3SimulatedDispatchTest.

## Technical Details

Reduce level of parallelism 

## Issue Tracking

Closes https://github.com/ROCm/rocm-systems/issues/8773

## Test Plan

* Ran possibly high level of concurrency twice and saw one failure.
* Ran serially five times (+ this one = 6) and saw no failures. https://github.com/ROCm/rocm-systems/actions/workflows/rocjitsu-corpus-tests.yml?query=branch%3Ausers%2Famd-eochoalo%2F2027-07-17%2Fparallel-hypothesis

## Test Result

* Test results indicate we should lower the concurrency level.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
