### PR TITLE
ci: PR Bot Reviewer phase3 updates

### DIFF
--- a/.github/workflows/systems-pr-bot.yml
+++ b/.github/workflows/systems-pr-bot.yml
@@ -41,12 +41,12 @@ jobs:
       # guarantees we run OUR policy_check.py / policy.yml — not the fork's.
       # `persist-credentials: false` follows the safer-checkout defaults
       # (https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/).
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.11"
 
@@ -66,7 +66,7 @@ jobs:
       - name: Create GitHub App token
         id: app-token
         if: steps.app-secrets.outputs.available == 'true'
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v3.2.0
         with:
           app-id: ${{ secrets.THEROCK_PR_BOT_APPID }}
           private-key: ${{ secrets.THEROCK_PRBOT_KEY }}

--- a/docs/SYSTEMS_PR_BOT_FAQ.md
+++ b/docs/SYSTEMS_PR_BOT_FAQ.md
@@ -15,6 +15,9 @@ once all policy checks have passed.
 
 This document explains what each policy check means, why it exists, and how to fix a failure.
 
+> **Note:** This is **NOT an AI Bot and does not use any LLMs**. It is a
+> deterministic, rule-based checker driven entirely by `policy.yml`.
+
 ______________________________________________________________________
 
 ## 🌿 Branch Name
@@ -54,45 +57,24 @@ ______________________________________________________________________
 ## 📝 PR Title
 
 **What does it check?**
-The PR title must follow **Conventional Commits** style so the changelog and release notes can be generated automatically.
 
 > **Note:** In the results table, the title and description checks are reported together as a single **PR Title/Description** row. Any title *or* description failure shows up there.
 
-**Required format**
-
-```
-type(optional-scope): short description
-```
-
-**Allowed types**
-
-| Type       | When to use                              |
-| ---------- | ---------------------------------------- |
-| `feat`     | A new feature                            |
-| `fix`      | A bug fix                                |
-| `docs`     | Documentation only changes               |
-| `style`    | Formatting, whitespace — no logic change |
-| `refactor` | Code restructure — no feature or fix     |
-| `perf`     | Performance improvement                  |
-| `test`     | Adding or fixing tests                   |
-| `build`    | Build system or dependency changes       |
-| `ci`       | CI / workflow changes                    |
-| `chore`    | Maintenance tasks                        |
-| `revert`   | Reverting a previous commit              |
-
-**Length rules**
+**Length rules (only)**
 
 - Minimum: **10** characters
-- Maximum: **80** characters
+- Maximum: **100** characters
 
-**Forbidden words** — titles containing `WIP` or `do not merge` are blocked.
+> The title is validated by **length only**. There is no enforced format
+> (e.g. Conventional Commits) and no forbidden-word list — any wording is
+> accepted as long as it is 10–100 characters long.
 
 **How to fix**
-Edit the PR title on GitHub (top of the PR page → pencil icon) to match the format, e.g.:
+Edit the PR title on GitHub (top of the PR page → pencil icon) so it is between 10 and 100 characters, e.g.:
 
 ```
-feat(auth): add token refresh support
-fix(ci): correct codeql workflow trigger
+Add token refresh support
+Correct codeql workflow trigger
 ```
 
 ______________________________________________________________________
@@ -136,15 +118,14 @@ ______________________________________________________________________
 ## 📏 PR Size
 
 **What does it check?**
-Large PRs are hard to review thoroughly. Three limits are enforced:
+Large PRs are hard to review thoroughly.
 
-| Limit                   | Value | Reason                                         |
-| ----------------------- | ----- | ---------------------------------------------- |
-| Max files changed       | 50    | Avoids PRs that touch too many unrelated areas |
-| Max total changes       | 2000  | Keeps the overall diff reviewable              |
-| Max changes in one file | 700   | Flags files that may need splitting            |
+> **Note:** PR size limits are **not currently enforced** by `policy.yml`
+> (there are no `max_files_changed` / `max_total_changes` /
+> `max_single_file_changes` values configured). This section is guidance only
+> and the bot does not fail a PR on size today.
 
-**How to fix**
+**Recommended guidance**
 Split your work into smaller, focused PRs. Each PR should ideally do one thing:
 
 - One feature, one fix, or one refactor — not all three at once.
@@ -195,12 +176,24 @@ PRs that change real source code must include at least one accompanying unit tes
   `.py`, `.cpp`, `.cc`, `.c`, `.h`, `.js`, `.ts`, `.go`, `.java`, it must also
   include changes to a test file (a new test, or edits to an existing one).
 
-**How a test file is recognised**
+**What counts as a test file?**
 
-| Pattern    | Example          |
-| ---------- | ---------------- |
-| `test_*`   | `test_parser.py` |
-| `*_test.*` | `parser_test.py` |
+- Basename matches one of: `test_*`, `testing_*`, `*_test.*`, `*_tests.*`, or `Test*`
+  - ✅ `test_parser.py`, `testing_parser.py`, `parser_test.cpp`, `parser_tests.cpp`, `TestUtils.cpp`
+  - ❌ `test.py` (does NOT have the `test_` prefix)
+
+| Pattern     | Example             |
+| ----------- | ------------------- |
+| `test_*`    | `test_parser.py`    |
+| `testing_*` | `testing_parser.py` |
+| `*_test.*`  | `parser_test.cpp`   |
+| `*_tests.*` | `parser_tests.cpp`  |
+| `Test*`     | `TestUtils.cpp`     |
+
+**Path-based recognition**
+Any file located under a `test/gtest/` directory is also treated as a unit
+test, regardless of its filename — e.g.
+`projects/miopen/test/gtest/unit_conv_solver_ConvWinoRageRxS.cpp`.
 
 **How to fix**
 Add a unit test for the code you changed, named `test_<something>`:
@@ -257,38 +250,84 @@ Common findings include:
 
 ______________________________________________________________________
 
+## 🌿 Bump PRs (Automated Dependency Updates)
+
+**What is a "Bump PR"?**
+
+A **Bump PR** is an automated pull request that updates dependencies (e.g. from Dependabot or a bot like `assistant-librarian`). These PRs are routine, high-volume, and do not follow the standard PR conventions.
+
+**Why did my Bump PR skip policy checks?**
+
+When a PR is detected as a bump update from a configured bot account (e.g. `@assistant-librarian[bot]`), **all policy checks are auto-approved**. This includes:
+
+- Branch name validation
+- PR title (length) check
+- JIRA/ISSUE ID reference requirement
+- Unit test requirement
+- And all other policies
+
+This keeps automated bots from being blocked by human-oriented policy gates and prevents spam of "Not ready to Review" labels.
+
+**How does the bot know it's a Bump PR?**
+
+The PR author's login is checked against a configured list of bump bot accounts. Currently recognized:
+
+- `assistant-librarian` (and `assistant-librarian[bot]`)
+- `systems-assistant` (and `systems-assistant[bot]`)
+
+If a different bot opens dependency-bump PRs in your repo, request that the maintainers add it to `bump_bot_authors` in `policy.yml`.
+
+______________________________________________________________________
+
 ## General Questions
 
-### Why did all checks pass automatically on a "bump" PR?
+**Why did my PR get the "Not ready to Review" label?**
 
-PRs opened by automated dependency-bump bots (e.g. `assistant-librarian`,
-`systems-assistant`) are a **special case**: every row in the results table is
-auto-marked **✅ Pass** and the PR is never gated. These are routine version
-bumps (e.g. *"Bumps ROCm/rocm-systems from a0952b2 to 971dc69"*) and don't need
-the full policy gate. The bot list is configured under `pr.bump_bot_authors` in
-`policy.yml`.
+The label is added when:
 
-### What is the "Not ready to Review" label?
+1. **Unit Test check fails** — your PR changes source code but has no accompanying test file.
+1. **JIRA/ISSUE ID reference is missing** — your PR description does not include a tracking reference.
+
+All other policy failures (branch name, title format, description length, forbidden files, etc.) do not add the label; they are still reported in the table but do not block the PR.
+
+**What is the "Not ready to Review" label?**
 
 When **PR Title/Description**, **Unit Test**, or **Forbidden Files** fails, the bot adds a **`Not ready to Review`** label to the PR so it is clearly gated.
 The label is removed automatically once all policy checks pass.
 Other failures (Branch Name, PR Size, Draft PR, pre-commit, CodeQL) do **not** add the label.
 
-### How are pre-commit and CodeQL shown?
+**How are pre-commit and CodeQL shown?**
 
 These run as separate CI workflows. The bot waits for them and folds their results into the same table — `pre-commit` and a single combined `CodeQL` row. The CodeQL row fails if CodeQL reports any error / critical / high severity alert.
 
-### The bot timed out — what do I do?
+**The bot timed out — what do I do?**
 
 If `pre-commit` or CodeQL takes longer than 15 minutes, the bot times out.
-Push an empty commit to re-trigger the workflow:
+Push an empty commit to re-trigger the workflow or close and reopen PR:
 
 ```bash
 git commit --allow-empty -m "ci: retrigger policy check"
 git push
 ```
 
-### How do I re-run the bot after fixing issues?
+**How do I re-run the bot after fixing issues?**
 
 Push any commit (including `--allow-empty`) to the PR branch.
 The `synchronize` event triggers a fresh policy check automatically.
+
+______________________________________________________________________
+
+## 🙋 Wish to Override the Policy Process and get unblocked?
+
+Contact CODEOWNERS or supporters channel - (DevOps - Support or Help)
+
+## 🙋 For any policy related feedback?
+
+please reach out to the **ROCm Policy Council**.
+
+📧 **Drop a mail to:** `rocm-repo-policy@amd.com` (ROCm Policy Council DLL)
+
+Include your PR link, the check(s) you want overridden, and a short
+justification so the council can review your request.
+
+______________________________________________________________________

--- a/tools/systems_pr_bot/policy.yml
+++ b/tools/systems_pr_bot/policy.yml
@@ -43,14 +43,10 @@ pr:
     - assistant-librarian
     - systems-assistant
 
-  # PR title rules (Conventional Commits style):
-  #   type(optional-scope): short description
-  # Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+  # PR title rules
   title:
-    pattern:
-      - '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9\-]+\))?(!)?: .+'
     title_min_length: 10
-    title_max_length: 80
+    title_max_length: 100
 
   # Require a meaningful description
   description:
@@ -87,6 +83,12 @@ pr:
     issue_reference_patterns:
       - '(?im)^\s*JIRA\s*ID\s*[:\-]?\s*(#?\d+|[A-Z][A-Z0-9]+-\d+|https?:\/\/\S+)'
       - '(?im)^\s*ISSUE\s*ID\s*[:\-]?\s*(#?\d+|[A-Z][A-Z0-9]+-\d+|https?:\/\/\S+)'
+      # JIRA ID on a separate line — allows trailing spaces/tabs after the
+      # label and any number of blank lines before the key
+      # (e.g. "JIRA ID  \n\nAIRUNTIME-2352").
+      - '(?im)^[ \t]*JIRA[ \t]+ID[ \t]*\r?\n[ \t\r\n]*([A-Z][A-Z0-9]+-\d+)'
+      # ISSUE ID on a separate line — same flexibility as above.
+      - '(?im)^[ \t]*ISSUE[ \t]+ID[ \t]*\r?\n[ \t\r\n]*([A-Z][A-Z0-9]+-\d+|\d+)'
       - '(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s*(?:[A-Za-z0-9._\-]+\/[A-Za-z0-9._\-]+)?#\d+'
       # Bare GitHub issue reference, e.g. #123
       - '(?m)(?:^|\s)#\d+\b'
@@ -117,10 +119,19 @@ pr:
       - .rb
       - .rs
     # A changed file is treated as a unit test if its basename matches one of
-    # these glob patterns (e.g. test_parser.py, parser_test.cpp).
+    # these glob patterns (e.g. test_parser.py, parser_test.cpp, testing_x.py).
+    # Patterns that contain a '/' are matched against the FULL path instead of
+    # the basename, so entire test directories can be recognised
+    # (e.g. anything under a 'test/gtest/' folder).
     test_file_patterns:
       - 'test_*'
+      - 'testing_*'
       - '*_test.*'
+      - '*_tests.*'
+      - 'Test*'
+      # Path-based: any file under a 'test/gtest/' directory is a unit test
+      # (e.g. projects/miopen/test/gtest/unit_conv_solver_ConvWinoRageRxS.cpp).
+      - '**/test/gtest/**'
     # Unit tests are required for source code ANYWHERE in the repository — there
     # are NO folder-based exemptions. A test file may also live in any folder;
     # it is recognised by its name (test_* / *_test.*), not its location.

--- a/tools/systems_pr_bot/policy_check.py
+++ b/tools/systems_pr_bot/policy_check.py
@@ -72,7 +72,6 @@ TABLE_ORDER = [
     "Unit Test",
     "pre-commit",
     "Draft PR",
-    "PR Size",
     "Feature Flag",
     "Code Coverage",
     "therock-pr-bot",
@@ -100,7 +99,6 @@ class CheckResult:
 @dataclass(frozen=True)
 class Policy:
     branch_patterns: List[re.Pattern[str]]
-    title_patterns: List[re.Pattern[str]]
     title_min_length: int
     title_max_length: int
     description_min_length: int
@@ -108,9 +106,6 @@ class Policy:
     description_checklist_patterns: List[re.Pattern[str]]
     block_draft: bool
     forbidden_title_patterns: List[re.Pattern[str]]
-    max_files_changed: int
-    max_total_changes: int
-    max_single_file_changes: int
     forbidden_paths: List[str]
     unit_test_code_extensions: List[str]
     unit_test_patterns: List[str]
@@ -140,8 +135,6 @@ def load_policy(policy_path: Path) -> Policy:
 
     # PR title rules now live under the nested `title:` mapping.
     title_cfg = pr.get("title", {}) or {}
-    title_patterns_raw = title_cfg.get("pattern", []) or []
-    title_patterns = [re.compile(str(p)) for p in title_patterns_raw]
     title_min_length = int(title_cfg.get("title_min_length", 0) or 0)
     title_max_length = int(title_cfg.get("title_max_length", 0) or 0)
 
@@ -161,11 +154,6 @@ def load_policy(policy_path: Path) -> Policy:
     block_draft = bool(pr.get("block_draft", False))
     forbidden_title_raw = pr.get("forbidden_title_patterns", []) or []
     forbidden_title_patterns = [re.compile(str(p)) for p in forbidden_title_raw]
-
-    # PR "reviewable shape" limits live under the diff: section.
-    max_files_changed = int(diff.get("max_files_changed", 0) or 0)
-    max_total_changes = int(diff.get("max_total_changes", 0) or 0)
-    max_single_file_changes = int(diff.get("max_single_file_changes", 0) or 0)
 
     forbidden_paths = [str(p) for p in (diff.get("forbidden_paths", []) or [])]
 
@@ -194,7 +182,6 @@ def load_policy(policy_path: Path) -> Policy:
 
     return Policy(
         branch_patterns=branch_patterns,
-        title_patterns=title_patterns,
         title_min_length=title_min_length,
         title_max_length=title_max_length,
         description_min_length=description_min_length,
@@ -202,9 +189,6 @@ def load_policy(policy_path: Path) -> Policy:
         description_checklist_patterns=description_checklist_patterns,
         block_draft=block_draft,
         forbidden_title_patterns=forbidden_title_patterns,
-        max_files_changed=max_files_changed,
-        max_total_changes=max_total_changes,
-        max_single_file_changes=max_single_file_changes,
         forbidden_paths=forbidden_paths,
         unit_test_code_extensions=unit_test_code_extensions,
         unit_test_patterns=unit_test_patterns,
@@ -333,10 +317,10 @@ def _short(value: str, limit: int = 80) -> str:
 
 
 def ensure_pr_title(policy: Policy, title: str, errors: List[str]) -> None:
-    """Validate the PR title (length, Conventional Commits style, forbidden words).
+    """Validate the PR title (length and forbidden words).
 
-    Appends a structured Error/Expected/Desired-format message to `errors` for
-    each rule that fails.
+    Appends a structured Error/Expected message to `errors` for each rule that
+    fails.
     """
     title = (title or "").strip()
     fmt = "**Desired format:** `type(optional-scope): short description`"
@@ -352,15 +336,6 @@ def ensure_pr_title(policy: Policy, title: str, errors: List[str]) -> None:
         errors.append(
             f"**Error:** Title is too long ({len(title)} characters).\n"
             f"**Expected:** at most {policy.title_max_length} characters.\n"
-            f"{fmt}"
-        )
-
-    if policy.title_patterns and not any(
-        p.search(title) for p in policy.title_patterns
-    ):
-        errors.append(
-            "**Error:** Title does not follow Conventional Commits style.\n"
-            "**Expected:** start with a valid type (feat, fix, docs, …).\n"
             f"{fmt}"
         )
 
@@ -416,9 +391,13 @@ def ensure_pr_description(policy: Policy, body: str, errors: List[str]) -> None:
             "• `JIRA ID : TESTAUTO-6039`\n"
             "• `JIRA ID - #330`\n"
             "• `JIRA ID #330`\n"
+            "• `JIRA ID` (on separate line)\n"
+            "  `ROCM-25757`\n"
             "• `ISSUE ID : TESTUTO-3334`\n"
             "• `ISSUE ID #3334`\n"
             "• `ISSUE ID - TESTAUTO-3433`\n"
+            "• `ISSUE ID` (on separate line)\n"
+            "  `AIRUNTIME-2352`\n"
             "• `ISSUE ID : https://github.com/<org_name>/<repo_name>/issues/1234`\n"
             "• `Closes #10`\n"
             "• `Fixes octo-org/octo-repo#100`\n"
@@ -451,6 +430,24 @@ def _matches_forbidden(filename: str, pattern: str) -> bool:
     # Allow '**/<x>' patterns to also match root-level files (e.g. '.env').
     if pattern.startswith("**/") and fnmatch.fnmatch(filename, pattern[3:]):
         return True
+    return False
+
+
+def _is_test_file(filename: str, patterns: Iterable[str]) -> bool:
+    """Return True if `filename` is recognised as a test file.
+
+    Patterns that contain a '/' are treated as FULL-PATH globs (e.g.
+    '**/test/gtest/**' matches any file under a test/gtest/ directory).
+    Patterns without a '/' are matched against the BASENAME only
+    (e.g. 'test_*', '*_test.*').
+    """
+    base = Path(filename).name
+    for pat in patterns:
+        if "/" in pat:
+            if _matches_forbidden(filename, pat):
+                return True
+        elif fnmatch.fnmatch(base, pat):
+            return True
     return False
 
 
@@ -513,7 +510,7 @@ def ensure_unit_tests(
         ext = Path(filename).suffix.lower()
 
         # A test file satisfies the requirement.
-        if any(fnmatch.fnmatch(base, pat) for pat in policy.unit_test_patterns):
+        if _is_test_file(filename, policy.unit_test_patterns):
             has_test = True
             continue
 
@@ -551,56 +548,11 @@ def pr_has_code_files(policy: Policy, pr_files: Iterable[Dict[str, Any]]) -> boo
             continue
         base = Path(filename).name
         ext = Path(filename).suffix.lower()
-        if any(fnmatch.fnmatch(base, pat) for pat in policy.unit_test_patterns):
+        if _is_test_file(filename, policy.unit_test_patterns):
             continue
         if ext in policy.unit_test_code_extensions:
             return True
     return False
-
-
-def ensure_pr_reviewable(
-    policy: Policy, pr_files: List[Dict[str, Any]], errors: List[str]
-) -> None:
-    """Keep PRs small enough to review: file count, total churn, per-file churn."""
-    if not (
-        policy.max_files_changed
-        or policy.max_total_changes
-        or policy.max_single_file_changes
-    ):
-        return
-
-    num_files = len(pr_files)
-    total_changes = 0
-
-    for f in pr_files:
-        additions = int(f.get("additions") or 0)
-        deletions = int(f.get("deletions") or 0)
-        changes = int(f.get("changes") or (additions + deletions))
-        total_changes += changes
-
-        filename = Path(str(f.get("filename") or "")).as_posix()
-        if policy.max_single_file_changes and changes > policy.max_single_file_changes:
-            errors.append(
-                "**Error:** A single file changes too much to review easily.\n"
-                f"**Expected:** at most {policy.max_single_file_changes} changes "
-                "in one file.\n"
-                f"**Current:** `{filename}` has {changes} changes"
-            )
-
-    if policy.max_files_changed and num_files > policy.max_files_changed:
-        errors.append(
-            "**Error:** Too many files changed in one PR.\n"
-            f"**Expected:** at most {policy.max_files_changed} files.\n"
-            f"**Current:** {num_files} files changed"
-        )
-
-    if policy.max_total_changes and total_changes > policy.max_total_changes:
-        errors.append(
-            "**Error:** Total diff is too large to review easily.\n"
-            f"**Expected:** at most {policy.max_total_changes} total "
-            "additions + deletions.\n"
-            f"**Current:** {total_changes} total changes"
-        )
 
 
 def summarize_required_checks(
@@ -1044,7 +996,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     if is_bump_pr(policy, author):
         marker = "<!-- therock-pr-bot-policy-check -->"
         note = (
-            f"> 🤖 **Bump PR detected** (author `@{author}`). All policy checks "
+            f"🤖 **Bump PR detected** (author `@{author}`). All policy checks "
             "are auto-approved for automated dependency bumps."
         )
         upsert_comment(
@@ -1053,9 +1005,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             pr_number,
             token,  # type: ignore[arg-type]
             marker,
-            build_policy_table_comment(
-                build_bump_pr_results(policy), marker, ready=True, note=note
-            ),
+            note,
         )
         remove_label(owner, repo, pr_number, token, NOT_READY_LABEL)  # type: ignore[arg-type]
         update_comment_if_exists(

--- a/tools/systems_pr_bot/test_policy_check_ut.py
+++ b/tools/systems_pr_bot/test_policy_check_ut.py
@@ -1,0 +1,524 @@
+"""
+Unit + integration tests for policy_check.py.
+
+These let us iterate on policies WITHOUT pushing branches or running workflows:
+  • Unit tests   — exercise individual validators / regex patterns.
+  • Integration  — feed blobs of [branch, title, description, files] through
+                   the higher-level ensure_* functions.
+"""
+
+import re
+import sys
+import unittest
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Make `policy_check` importable regardless of the working directory.
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(THIS_DIR))
+
+import policy_check as pc  # noqa: E402
+
+
+# ----------------------------- helpers ---------------------------------------
+
+_ISSUE_PATTERNS = [
+    r"(?im)^\s*JIRA\s*ID\s*[:\-]?\s*(#?\d+|[A-Z][A-Z0-9]+-\d+|https?:\/\/\S+)",
+    r"(?im)^\s*ISSUE\s*ID\s*[:\-]?\s*(#?\d+|[A-Z][A-Z0-9]+-\d+|https?:\/\/\S+)",
+    # JIRA/ISSUE ID on a separate line (blank lines + trailing spaces allowed).
+    r"(?im)^[ \t]*JIRA[ \t]+ID[ \t]*\r?\n[ \t\r\n]*([A-Z][A-Z0-9]+-\d+)",
+    r"(?im)^[ \t]*ISSUE[ \t]+ID[ \t]*\r?\n[ \t\r\n]*([A-Z][A-Z0-9]+-\d+|\d+)",
+    r"(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s*"
+    r"(?:[A-Za-z0-9._\-]+\/[A-Za-z0-9._\-]+)?#\d+",
+    # Bare GitHub issue reference, e.g. #123
+    r"(?m)(?:^|\s)#\d+\b",
+    # GitHub issue URL
+    r"(?i)https?:\/\/github\.com\/[^\/\s]+\/[^\/\s]+\/issues\/\d+",
+]
+
+_CHECKLIST_PATTERNS = [
+    r"(?im)^\s*-\s*\[[xX]\]\s*.*contributing guidelines",
+]
+
+
+def make_policy(**overrides: Any) -> pc.Policy:
+    """Build a Policy with sensible defaults; override any field per-test.
+
+    Independent of policy.yml so regex/validator behaviour can be pinned even
+    if the shipped config changes.
+    """
+    defaults: Dict[str, Any] = dict(
+        branch_patterns=[
+            re.compile(r"^users\/[A-Za-z0-9][A-Za-z0-9\-]*\/.+"),
+            re.compile(r"^shared\/.+"),
+            re.compile(r"^[A-Za-z0-9][A-Za-z0-9\-_]*$"),
+            re.compile(r"^dependabot\/.+"),
+            re.compile(r"^revert-[0-9]+-.+"),
+        ],
+        title_min_length=10,
+        title_max_length=80,
+        description_min_length=30,
+        description_issue_patterns=[re.compile(p) for p in _ISSUE_PATTERNS],
+        description_checklist_patterns=[re.compile(p) for p in _CHECKLIST_PATTERNS],
+        block_draft=True,
+        forbidden_title_patterns=[re.compile(r"(?i)\bWIP\b")],
+        max_files_changed=50,
+        max_total_changes=2000,
+        max_single_file_changes=700,
+        forbidden_paths=["**/*.pem", "**/.env", "**/id_rsa"],
+        unit_test_code_extensions=[".py", ".cpp"],
+        unit_test_patterns=[
+            "test_*",
+            "testing_*",
+            "*_test.*",
+            "*_tests.*",
+            "**/test/gtest/**",
+        ],
+        unit_test_exempt_paths=[],
+        bump_bot_authors=["assistant-librarian", "systems-assistant"],
+        required_checks=["pre-commit"],
+        precommit_failure_comment=None,
+    )
+    defaults.update(overrides)
+    return pc.Policy(**defaults)
+
+
+def make_file(
+    filename: str,
+    status: str = "modified",
+    additions: int = 0,
+    deletions: int = 0,
+    changes: Optional[int] = None,
+) -> Dict[str, Any]:
+    return {
+        "filename": filename,
+        "status": status,
+        "additions": additions,
+        "deletions": deletions,
+        "changes": changes if changes is not None else additions + deletions,
+    }
+
+
+# ----------------------------- branch name -----------------------------------
+
+
+class BranchNameTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = make_policy()
+
+    def _errs(self, branch: str) -> List[str]:
+        e: List[str] = []
+        pc.ensure_branch_name(self.policy, branch, e)
+        return e
+
+    def test_valid_branches(self) -> None:
+        for branch in [
+            "users/chi/ucicd_setup_visible_devices",
+            # Nested namespace/feature after the username is allowed.
+            "users/dgaliffi/fix/remove-build-boost-option",
+            # Uppercase letters are allowed (acronyms / module names).
+            "users/frepaul/ROCm-end-user-project-workflow",
+            "users/agunashe/hipModuleGetLoadingMode_test",
+            "compiler-ww-24-SMP-2",
+            "ZIP-packaging-RFC",
+            "shared/add-runner-health",
+            "shared/team/feature",
+            "bump-rocm-libraries-936a6c7",
+            "dependabot/github_actions/github-actions-3dfd2199fc",
+            "revert-5217-users/derobins/add_hipfile_support",
+        ]:
+            with self.subTest(branch=branch):
+                self.assertEqual(self._errs(branch), [])
+
+    def test_invalid_branches(self) -> None:
+        # "Feature/Bad" -> unknown prefix; "users//missing"/"users/" -> empty
+        # segments; "bad branch name" -> spaces are not allowed.
+        for branch in ["Feature/Bad", "users//missing", "bad branch name", "users/"]:
+            with self.subTest(branch=branch):
+                self.assertTrue(self._errs(branch))
+
+    def test_fork_pr_branch_name_is_enforced(self) -> None:
+        # All policies — including branch name — are enforced for fork PRs too.
+        # The validator always runs; there is no fork-based skip.
+        policy = make_policy()
+        e: List[str] = []
+        pc.ensure_branch_name(policy, "BadBranch", e)
+        self.assertTrue(e, "Branch name must be validated for fork PRs too")
+
+        # A valid branch name passes for both same-repo and fork PRs.
+        e = []
+        pc.ensure_branch_name(policy, "users/sam/my-feature", e)
+        self.assertEqual(e, [])
+
+
+# ----------------------------- PR title --------------------------------------
+
+
+class TitleTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = make_policy()
+
+    def _errs(self, title: str) -> List[str]:
+        e: List[str] = []
+        pc.ensure_pr_title(self.policy, title, e)
+        return e
+
+    def test_valid_title(self) -> None:
+        self.assertEqual(self._errs("feat(auth): add token refresh support"), [])
+
+    def test_too_short(self) -> None:
+        self.assertTrue(any("too short" in x for x in self._errs("fix: a")))
+
+    def test_too_long(self) -> None:
+        long_title = "feat: " + ("x" * 90)
+        self.assertTrue(any("too long" in x for x in self._errs(long_title)))
+
+    def test_forbidden_word(self) -> None:
+        self.assertTrue(
+            any("forbidden" in x.lower() for x in self._errs("feat: WIP add things"))
+        )
+
+
+# ----------------------------- PR description --------------------------------
+
+
+class DescriptionTests(unittest.TestCase):
+    def test_too_short(self) -> None:
+        policy = make_policy()
+        e: List[str] = []
+        pc.ensure_pr_description(policy, "short", e)
+        self.assertTrue(any("too short" in x for x in e))
+
+    def test_missing_issue_reference(self) -> None:
+        # No checklist patterns so only the reference check fires.
+        policy = make_policy(description_checklist_patterns=[])
+        e: List[str] = []
+        pc.ensure_pr_description(policy, "A long enough description with no ref.", e)
+        self.assertTrue(any("must reference a JIRA ID" in x for x in e))
+
+    def test_issue_reference_variants_pass(self) -> None:
+        # Isolate reference detection (skip min-length and checklist).
+        policy = make_policy(
+            description_min_length=0, description_checklist_patterns=[]
+        )
+        for body in [
+            "JIRA ID : TESTAUTO-6039",
+            "JIRA ID - #330",
+            "JIRA ID #330",
+            "ISSUE ID : TESTUTO-3334",
+            "ISSUE ID - TESTAUTO-3433",
+            "ISSUE ID : https://github.com/org/repo/issues/1234",
+            # Multiline format with JIRA ID
+            "JIRA ID\nROCM-25757",
+            "JIRA ID\n\nROCM-25757",
+            "jira id\nROCM-25757",  # case-insensitive
+            # Trailing spaces after label + blank line before key
+            "JIRA ID  \n\nAIRUNTIME-2352",
+            "JIRA ID\t\n\n\nROCM-25757",
+            "JIRA ID  \r\n\r\nROCM-25757",  # CRLF line endings
+            # Multiline format with ISSUE ID
+            "ISSUE ID\nAIRUNTIME-2352",
+            "ISSUE ID\n\nAIRUNTIME-2352",
+            "issue id\nAIRUNTIME-2352",  # case-insensitive
+            "ISSUE ID  \n\nAIRUNTIME-2352",  # trailing spaces + blank line
+        ]:
+            with self.subTest(body=body):
+                e: List[str] = []
+                pc.ensure_pr_description(policy, body, e)
+                self.assertEqual(e, [])
+
+    def test_closing_keyword_variants_pass(self) -> None:
+        # GitHub closing keywords are also accepted as a tracking ref.
+        policy = make_policy(
+            description_min_length=0, description_checklist_patterns=[]
+        )
+        for body in [
+            "Closes #10",
+            "Fixes octo-org/octo-repo#100",
+            "Resolves #10",
+            "resolves #123",
+            "resolves octo-org/octo-repo#100",
+            "Closes: #10",
+            "CLOSES #10",
+            "CLOSES: #10",
+            "This change fixes the bug.\nFixes #4321\n",
+        ]:
+            with self.subTest(body=body):
+                e: List[str] = []
+                pc.ensure_pr_description(policy, body, e)
+                self.assertEqual(e, [])
+
+    def test_plain_github_issue_refs_pass(self) -> None:
+        # Bare '#<number>' and GitHub issue URLs are accepted without a keyword.
+        policy = make_policy(
+            description_min_length=0, description_checklist_patterns=[]
+        )
+        for body in [
+            "Related to #123",
+            "#4321",
+            "See https://github.com/ROCm/TheRock/issues/6043",
+        ]:
+            with self.subTest(body=body):
+                e: List[str] = []
+                pc.ensure_pr_description(policy, body, e)
+                self.assertEqual(e, [])
+
+    def test_reference_inside_larger_body(self) -> None:
+        policy = make_policy(description_checklist_patterns=[])
+        body = "This change fixes the parser.\n\nISSUE ID : TESTUTO-3334\n"
+        e: List[str] = []
+        pc.ensure_pr_description(policy, body, e)
+        self.assertEqual(e, [])
+
+    def test_checklist_ticked_passes(self) -> None:
+        policy = make_policy(description_min_length=0, description_issue_patterns=[])
+        body = "- [x] Look over the contributing guidelines at https://..."
+        e: List[str] = []
+        pc.ensure_pr_description(policy, body, e)
+        self.assertEqual(e, [])
+
+    def test_checklist_unticked_fails(self) -> None:
+        policy = make_policy(description_min_length=0, description_issue_patterns=[])
+        body = "- [ ] Look over the contributing guidelines at https://..."
+        e: List[str] = []
+        pc.ensure_pr_description(policy, body, e)
+        self.assertTrue(any("Checklist" in x or "checklist" in x for x in e))
+
+
+# ----------------------------- forbidden files -------------------------------
+
+
+class ForbiddenFileTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = make_policy()
+
+    def _errs(self, files: List[Dict[str, Any]]) -> List[str]:
+        e: List[str] = []
+        pc.ensure_no_forbidden_files(self.policy, files, e)
+        return e
+
+    def test_flags_secret_files(self) -> None:
+        for name in ["secret.pem", "config/.env", "deploy/id_rsa"]:
+            with self.subTest(name=name):
+                self.assertTrue(self._errs([make_file(name)]))
+
+    def test_allows_normal_files(self) -> None:
+        files = [make_file("src/app.py"), make_file("README.md")]
+        self.assertEqual(self._errs(files), [])
+
+    def test_removed_forbidden_file_is_ignored(self) -> None:
+        self.assertEqual(self._errs([make_file("secret.pem", status="removed")]), [])
+
+
+# ----------------------------- unit tests check ------------------------------
+
+
+class UnitTestRuleTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = make_policy()
+
+    def _errs(self, files: List[Dict[str, Any]]) -> List[str]:
+        e: List[str] = []
+        pc.ensure_unit_tests(self.policy, files, e)
+        return e
+
+    def test_code_without_test_fails(self) -> None:
+        self.assertTrue(self._errs([make_file("src/module.py")]))
+
+    def test_code_with_test_passes(self) -> None:
+        files = [make_file("src/module.py"), make_file("tests/test_module.py")]
+        self.assertEqual(self._errs(files), [])
+
+    def test_docs_only_passes(self) -> None:
+        files = [make_file("README.md"), make_file("config/settings.yml")]
+        self.assertEqual(self._errs(files), [])
+
+    def test_source_anywhere_requires_test(self) -> None:
+        # Unit tests are required for source code placed ANYWHERE in the repo —
+        # no folder is special. Each non-test source file, on its own, fails.
+        for src in [
+            "policy_check.py",
+            "src/app.py",
+            "deep/nested/dir/module.py",
+            ".github/therock_pr_bot/policy_check.py",
+            "lib/foo.cpp",
+            # 'test.py' is NOT a test file — 'test_*' needs the 'test_' prefix.
+            "test.py",
+        ]:
+            with self.subTest(src=src):
+                self.assertTrue(self._errs([make_file(src)]))
+
+    def test_test_file_anywhere_satisfies_requirement(self) -> None:
+        # A real test_* file in ANY folder satisfies the requirement.
+        for test_path in [
+            "tests/test_module.py",
+            "deep/nested/test_module.py",
+            "any/where/module_test.py",
+        ]:
+            with self.subTest(test_path=test_path):
+                files = [make_file("src/module.py"), make_file(test_path)]
+                self.assertEqual(self._errs(files), [])
+
+
+# ----------------------------- draft + bump ----------------------------------
+
+
+class DraftAndBumpTests(unittest.TestCase):
+    def test_draft_blocked_when_enabled(self) -> None:
+        policy = make_policy(block_draft=True)
+        e: List[str] = []
+        pc.ensure_pr_not_draft(policy, True, e)
+        self.assertTrue(e)
+
+    def test_draft_allowed_when_not_draft(self) -> None:
+        policy = make_policy(block_draft=True)
+        e: List[str] = []
+        pc.ensure_pr_not_draft(policy, False, e)
+        self.assertEqual(e, [])
+
+    def test_bump_author_detection(self) -> None:
+        policy = make_policy()
+        self.assertTrue(pc.is_bump_pr(policy, "assistant-librarian"))
+        self.assertTrue(pc.is_bump_pr(policy, "assistant-librarian[bot]"))
+        self.assertTrue(pc.is_bump_pr(policy, "SYSTEMS-ASSISTANT"))
+        self.assertFalse(pc.is_bump_pr(policy, "some-human"))
+        self.assertFalse(pc.is_bump_pr(policy, ""))
+
+
+# ----------------------------- integration -----------------------------------
+
+
+class IntegrationBlobTests(unittest.TestCase):
+    """Feed full [branch, title, description, files] blobs through validators."""
+
+    def setUp(self) -> None:
+        self.policy = make_policy()
+
+    def _evaluate(
+        self, *, branch: str, title: str, body: str, files: List[Dict[str, Any]]
+    ) -> Dict[str, List[str]]:
+        out: Dict[str, List[str]] = {}
+
+        e: List[str] = []
+        pc.ensure_branch_name(self.policy, branch, e)
+        out["branch"] = e
+
+        e = []
+        pc.ensure_pr_title(self.policy, title, e)
+        pc.ensure_pr_description(self.policy, body, e)
+        out["title_desc"] = e
+
+        e = []
+        pc.ensure_no_forbidden_files(self.policy, files, e)
+        out["forbidden"] = e
+
+        e = []
+        pc.ensure_unit_tests(self.policy, files, e)
+        out["unit"] = e
+        return out
+
+    def test_fully_compliant_pr(self) -> None:
+        result = self._evaluate(
+            branch="users/sam/add-feature",
+            title="feat(ci): add policy unit tests",
+            body=(
+                "Adds unit tests for the policy checker.\n"
+                "ISSUE ID : TESTUTO-3334\n"
+                "- [x] Look over the contributing guidelines at https://..."
+            ),
+            files=[make_file("src/feature.py"), make_file("tests/test_feature.py")],
+        )
+        for key, errs in result.items():
+            with self.subTest(check=key):
+                self.assertEqual(errs, [])
+
+    def test_fully_noncompliant_pr(self) -> None:
+        result = self._evaluate(
+            branch="BadBranch",
+            title="wip",
+            body="too short",
+            files=[make_file("secret.pem"), make_file("src/module.py")],
+        )
+        self.assertTrue(result["branch"])
+        self.assertTrue(result["title_desc"])
+        self.assertTrue(result["forbidden"])
+        self.assertTrue(result["unit"])
+
+    def test_docs_only_pr_is_compliant(self) -> None:
+        result = self._evaluate(
+            branch="shared/update-docs",
+            title="docs: clarify contributing guide",
+            body=(
+                "Improves the contributing docs.\n"
+                "JIRA ID : DOCS-42\n"
+                "- [x] Look over the contributing guidelines at https://..."
+            ),
+            files=[make_file("docs/CONTRIBUTING.md"), make_file("README.md")],
+        )
+        for key, errs in result.items():
+            with self.subTest(check=key):
+                self.assertEqual(errs, [])
+
+
+# ----------------------------- load_policy -----------------------------------
+
+
+class LoadPolicyTests(unittest.TestCase):
+    """Smoke-test the shipped policy.yml so config drift is caught."""
+
+    def test_load_shipped_policy(self) -> None:
+        policy_path = THIS_DIR / "policy.yml"
+        if not policy_path.exists():
+            self.skipTest("policy.yml not present next to tests")
+        policy = pc.load_policy(policy_path)
+        self.assertGreater(len(policy.branch_patterns), 0)
+        self.assertIn("pre-commit", policy.required_checks)
+        self.assertGreaterEqual(policy.title_max_length, policy.title_min_length)
+
+    def test_multiline_jira_issue_patterns_loaded(self) -> None:
+        """Verify multiline JIRA/ISSUE ID patterns are in the loaded policy."""
+        policy_path = THIS_DIR / "policy.yml"
+        if not policy_path.exists():
+            self.skipTest("policy.yml not present next to tests")
+        policy = pc.load_policy(policy_path)
+
+        # Should have at least 5 issue reference patterns (inline + multiline + closing keywords + bare refs + urls)
+        self.assertGreaterEqual(len(policy.description_issue_patterns), 5)
+
+        # Verify multiline patterns work by testing them directly
+        multiline_jira_pattern = None
+        multiline_issue_pattern = None
+
+        for pat in policy.description_issue_patterns:
+            if pat.search("JIRA ID\nROCM-25757"):
+                multiline_jira_pattern = pat
+            if pat.search("ISSUE ID\nAIRUNTIME-2352"):
+                multiline_issue_pattern = pat
+
+        self.assertIsNotNone(
+            multiline_jira_pattern, "Multiline JIRA ID pattern not found in policy"
+        )
+        self.assertIsNotNone(
+            multiline_issue_pattern, "Multiline ISSUE ID pattern not found in policy"
+        )
+
+    def test_unit_test_patterns_exclude_unit_glob(self) -> None:
+        """Verify 'unit/**' pattern is NOT in the loaded unit_test_patterns."""
+        policy_path = THIS_DIR / "policy.yml"
+        if not policy_path.exists():
+            self.skipTest("policy.yml not present next to tests")
+        policy = pc.load_policy(policy_path)
+
+        # Per team lead request, 'unit/**' was removed from unit_test_patterns.
+        # Test files are now recognized ONLY by basename (test_*, *_test.*, Test*).
+        self.assertNotIn("unit/**", policy.unit_test_patterns)
+        # Verify the three allowed patterns ARE present.
+        self.assertIn("test_*", policy.unit_test_patterns)
+        self.assertIn("*_test.*", policy.unit_test_patterns)
+        self.assertIn("*_tests.*", policy.unit_test_patterns)
+        self.assertIn("Test*", policy.unit_test_patterns)
+        self.assertIn("**/test/gtest/**", policy.unit_test_patterns)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **Motivation**

TheRock-pr-bot tool to add policy based checks on PRs.
right now we are adding label "not ready for review" for PRs that does
not have issue/jira linked and PRs that has zero unit test to it. We
have other checks at place around forbidden files, pre-commit failure,
branch name convention. and more checks marked as soon to enabled.

### **Technical Details**

The checks are purely based on config file named policy.yml based PR
BOT. this is not a llm/AI based bot. This is using code to
deterministically provide checks.

**Updation in current PR?**
1.therock-pr-bot.yml checkout branch updations to latest.(As per David Galiffi comments - https://github.com/ROCm/rocm-systems/issues/7872)
2.Title max length updated to 100 from 80.
3.JIRA ID and ISSUE ID identification on splitted lines in Description.
4.'testing_' , '_tests.', 'Test', '/test/gtest/' new unittest file formats supports added.
5.Ignore PR BOT table format for bumped PR and just pass a message like autopass.
6.UnitTest script added for PR Bot.

### **Test Plan**
This PR initially raised on TheRock post that it will extend to rocm-systems and rocm-libraries.

**### ISSUE ID**
https://github.com/ROCm/rocm-systems/issues/8792