### PR TITLE
refactor(amdsmi): [AILITOOLS-270] Removed previously deprecated

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -6,6 +6,13 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ## amd_smi_lib for ROCm 7.15.0
 
+### Added
+
+- **Added accelerator partition memory allocation mode API**.  
+  - New APIs: `amdsmi_get_gpu_accelerator_partition_mem_alloc_mode()`, `amdsmi_set_gpu_accelerator_partition_mem_alloc_mode()`.
+  - New enum: `amdsmi_accelerator_partition_mem_alloc_mode_t` (`AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING`, `AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL`).
+  - Supersedes the equivalent `compute_partition` memory allocation mode APIs, which are now deprecated.
+
 ### Changed
 
 - **Bumped the library major version to 27.0.0** (breaking).  
@@ -26,6 +33,17 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 - **Prefixed public preprocessor macros with `AMDSMI_` in `amdsmi.h`** (breaking).  
   - `MAX_SVI3_RAIL_INDEX`, `MAX_SVI3_RAIL_SELECTION`, `POWER_EFFICIENCY_MODE_4`, `POWER_EFFICIENCY_MODE_5`, and `MAX_NUMBER_OF_AFIDS_PER_RECORD` are now `AMDSMI_MAX_SVI3_RAIL_INDEX`, `AMDSMI_MAX_SVI3_RAIL_SELECTION`, `AMDSMI_POWER_EFFICIENCY_MODE_4`, `AMDSMI_POWER_EFFICIENCY_MODE_5`, and `AMDSMI_MAX_NUMBER_OF_AFIDS_PER_RECORD`. The unused `CENTRIGRADE_TO_MILLI_CENTIGRADE` macro was removed. Update references to the new names.
+
+- **Deprecated the `compute_partition` APIs in favor of `accelerator_partition` equivalents**.  
+  - `amdsmi_get_gpu_compute_partition()`, `amdsmi_set_gpu_compute_partition()`, `amdsmi_get_gpu_compute_partition_mem_alloc_mode()`, and `amdsmi_set_gpu_compute_partition_mem_alloc_mode()` are slated for removal in a future ROCm release. They now emit a `DeprecationWarning` from the Python interface and delegate to their `accelerator_partition` counterparts.
+  - The `amdsmi_compute_partition_type_t` and `amdsmi_compute_partition_mem_alloc_mode_t` enums are deprecated in favor of `amdsmi_accelerator_partition_type_t` and `amdsmi_accelerator_partition_mem_alloc_mode_t`.
+
+- **Deprecated `amdsmi_set_gpu_memory_partition()` in favor of `amdsmi_set_gpu_memory_partition_mode()`**.  
+  - `amdsmi_set_gpu_memory_partition` is slated for removal in a future ROCm release. It now emits a `DeprecationWarning` from the Python interface and functions as a wrapper of `amdsmi_set_gpu_memory_partition_mode()`.
+
+- **Namespaced `amdsmi_clk_limit_type_t` and `amdsmi_io_bw_encoding_t` enumerators with an `AMDSMI_` prefix**.  
+  - Added `AMDSMI_CLK_LIMIT_MIN`/`AMDSMI_CLK_LIMIT_MAX` and `AMDSMI_AGG_BW0`/`AMDSMI_RD_BW0`/`AMDSMI_WR_BW0`.
+  - The unprefixed names (`CLK_LIMIT_MIN`, `CLK_LIMIT_MAX`, `AGG_BW0`, `RD_BW0`, `WR_BW0`) are retained as deprecated aliases with unchanged values and are slated for removal in a future ROCm release.
 
 - **Removed the `amdsmi_gpu_driver_reload()` API and its Python binding** (breaking).  
   - Reload the amdgpu driver out of band with `sudo modprobe -r amdgpu && sudo modprobe amdgpu` to apply memory partition changes instead.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -159,13 +159,22 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 - **Fixed `amd-smi static --clock` CSV and human-readable formatting to output frequency levels as strings instead of dictionary objects**.  
 
-- **Deprecated `amdsmi_get_gpu_vram_vendor()` in favor of `amdsmi_get_gpu_vram_info()`**.  
-  - `amdsmi_get_gpu_vram_vendor` is slated for removal in a future ROCm release. It now emits a `DeprecationWarning` from the Python interface and functions as a wrapper of `amdsmi_get_gpu_vram_info()`.
+- **Renamed `amdsmi_get_gpu_ecc_enabled()` to `amdsmi_get_gpu_ecc_supported()`**.  
+  - The new name better reflects that the API reports the ECC-supported block bit-mask. `amdsmi_get_gpu_ecc_enabled()` is retained as a deprecated shim that forwards to `amdsmi_get_gpu_ecc_supported()` and emits a `DeprecationWarning` from the Python interface.
+
+- **Prefixed public preprocessor macros with `AMDSMI_` in `amdsmi.h`** (breaking).  
+  - `MAX_SVI3_RAIL_INDEX`, `MAX_SVI3_RAIL_SELECTION`, `POWER_EFFICIENCY_MODE_4`, `POWER_EFFICIENCY_MODE_5`, and `MAX_NUMBER_OF_AFIDS_PER_RECORD` are now `AMDSMI_MAX_SVI3_RAIL_INDEX`, `AMDSMI_MAX_SVI3_RAIL_SELECTION`, `AMDSMI_POWER_EFFICIENCY_MODE_4`, `AMDSMI_POWER_EFFICIENCY_MODE_5`, and `AMDSMI_MAX_NUMBER_OF_AFIDS_PER_RECORD`. The unused `CENTRIGRADE_TO_MILLI_CENTIGRADE` macro was removed. Update references to the new names.
 
 - **Renamed "AINIC version" to "ionic version" in `amd-smi version` output**.  
   - The label now correctly reflects that it shows the ionic kernel driver version.
 
 ### Removed
+
+- **Removed `amdsmi_get_gpu_vram_vendor()`** (breaking). Use `amdsmi_get_gpu_vram_info()` and read the `vram_vendor` field instead.
+
+- **Removed `amdsmi_get_cpusocket_handles()` from the Python interface** (breaking). Use `amdsmi_get_cpu_handles()` instead.
+
+- **Removed the `plpds` key from `amdsmi_get_xgmi_plpd()` Python output** (breaking). Use the `policies` key instead.
 
 - **Removed the non-functional `--decode` flag from `amd-smi ras`**. Out-of-band CPER decoding is available via `amd-smi ras --afid --cper-file <path>` or `--afid --folder <DIR>`.
 

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -159,9 +159,6 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 - **Fixed `amd-smi static --clock` CSV and human-readable formatting to output frequency levels as strings instead of dictionary objects**.  
 
-- **Renamed `amdsmi_get_gpu_ecc_enabled()` to `amdsmi_get_gpu_ecc_supported()`**.  
-  - The new name better reflects that the API reports the ECC-supported block bit-mask. `amdsmi_get_gpu_ecc_enabled()` is retained as a deprecated shim that forwards to `amdsmi_get_gpu_ecc_supported()` and emits a `DeprecationWarning` from the Python interface.
-
 - **Prefixed public preprocessor macros with `AMDSMI_` in `amdsmi.h`** (breaking).  
   - `MAX_SVI3_RAIL_INDEX`, `MAX_SVI3_RAIL_SELECTION`, `POWER_EFFICIENCY_MODE_4`, `POWER_EFFICIENCY_MODE_5`, and `MAX_NUMBER_OF_AFIDS_PER_RECORD` are now `AMDSMI_MAX_SVI3_RAIL_INDEX`, `AMDSMI_MAX_SVI3_RAIL_SELECTION`, `AMDSMI_POWER_EFFICIENCY_MODE_4`, `AMDSMI_POWER_EFFICIENCY_MODE_5`, and `AMDSMI_MAX_NUMBER_OF_AFIDS_PER_RECORD`. The unused `CENTRIGRADE_TO_MILLI_CENTIGRADE` macro was removed. Update references to the new names.
 

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -40,6 +40,8 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 - **Removed the `plpds` key from `amdsmi_get_xgmi_plpd()` Python output** (breaking). Use the `policies` key instead.
 
+- **Removed `amdsmi_set_gpu_clk_range()`** (breaking). Use `amdsmi_set_gpu_clk_limit()` instead.
+
 - **Restructured AMD SMI C++ tests into unit and functional suites**.  
   - The `amdsmitst` source tree now separates unit tests from hardware-backed functional tests under `tests/amd_smi_test/unit/` and `tests/amd_smi_test/functional/`.
   - GTest suite names now follow a `<Component><Type>[<Operation>]` scheme: functional tests are `<Component>FunctionalReadOnly`/`<Component>FunctionalReadWrite` (e.g. `GpuFunctionalReadOnly`) and unit tests are `<Component>Unit` (e.g. `GpuUnit`). This replaces the old `amdsmitstReadOnly`/`amdsmitstReadWrite` and `AmdSmiDynamicMetricTest` names.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -24,12 +24,21 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - Field access simplifies from `fabric_info.fabric_version.v1.<field>` to `fabric_info.v1.<field>`, and `fabric_info.version` becomes `fabric_version`.
   - The change is ABI-preserving: field offsets and the overall structure size are unchanged. The Python `amdsmi_get_gpu_fabric_info()` dictionary keys are also unchanged.
 
+- **Prefixed public preprocessor macros with `AMDSMI_` in `amdsmi.h`** (breaking).  
+  - `MAX_SVI3_RAIL_INDEX`, `MAX_SVI3_RAIL_SELECTION`, `POWER_EFFICIENCY_MODE_4`, `POWER_EFFICIENCY_MODE_5`, and `MAX_NUMBER_OF_AFIDS_PER_RECORD` are now `AMDSMI_MAX_SVI3_RAIL_INDEX`, `AMDSMI_MAX_SVI3_RAIL_SELECTION`, `AMDSMI_POWER_EFFICIENCY_MODE_4`, `AMDSMI_POWER_EFFICIENCY_MODE_5`, and `AMDSMI_MAX_NUMBER_OF_AFIDS_PER_RECORD`. The unused `CENTRIGRADE_TO_MILLI_CENTIGRADE` macro was removed. Update references to the new names.
+
 - **Removed the `amdsmi_gpu_driver_reload()` API and its Python binding** (breaking).  
   - Reload the amdgpu driver out of band with `sudo modprobe -r amdgpu && sudo modprobe amdgpu` to apply memory partition changes instead.
 
 - **Removed unused public macros and a duplicate fabric telemetry enumerator to match the unified ABI** (breaking).  
   - Dropped the `AMDSMI_MAX_VF_COUNT`, `AMDSMI_MAX_DRIVER_NUM`, `AMDSMI_DFC_FW_NUMBER_OF_ENTRIES`, `AMDSMI_MAX_WHITE_LIST_ELEMENTS`, `AMDSMI_MAX_BLACK_LIST_ELEMENTS`, `AMDSMI_MAX_TA_WHITE_LIST_ELEMENTS`, `AMDSMI_MAX_ERR_RECORDS`, and `AMDSMI_MAX_PROFILE_COUNT` defines, which were unreferenced by any API or struct.
   - Removed the redundant `AMDSMI_FABRIC_TELEMETRY_CATEGORY_UNKNOWN` enumerator from `amdsmi_fabric_telemetry_category_t`; `AMDSMI_FABRIC_TELEMETRY_CATEGORY_INVALID` carries the same `0xFFFFFFFF` value.
+
+- **Removed `amdsmi_get_gpu_vram_vendor()`** (breaking). Use `amdsmi_get_gpu_vram_info()` and read the `vram_vendor` field instead.
+
+- **Removed `amdsmi_get_cpusocket_handles()` from the Python interface** (breaking). Use `amdsmi_get_cpu_handles()` instead.
+
+- **Removed the `plpds` key from `amdsmi_get_xgmi_plpd()` Python output** (breaking). Use the `policies` key instead.
 
 - **Restructured AMD SMI C++ tests into unit and functional suites**.  
   - The `amdsmitst` source tree now separates unit tests from hardware-backed functional tests under `tests/amd_smi_test/unit/` and `tests/amd_smi_test/functional/`.
@@ -47,7 +56,6 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Optimized `amdsmi_get_gpu_process_list()` to skip redundant KFD topology discovery**.  
   - The per-process KFD lookup rebuilt the entire KFD node topology (an expensive sysfs walk) on every call just to translate the device BDF into its KFD GPU id.
   - The caller already knows this value, so it is now passed through to `gpuvsmi_get_pid_info()`, eliminating one full topology discovery per process per refresh. Falls back to the original discovery path when the id is unavailable.
-
 
 ### Resolved Issues
 
@@ -159,19 +167,13 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 - **Fixed `amd-smi static --clock` CSV and human-readable formatting to output frequency levels as strings instead of dictionary objects**.  
 
-- **Prefixed public preprocessor macros with `AMDSMI_` in `amdsmi.h`** (breaking).  
-  - `MAX_SVI3_RAIL_INDEX`, `MAX_SVI3_RAIL_SELECTION`, `POWER_EFFICIENCY_MODE_4`, `POWER_EFFICIENCY_MODE_5`, and `MAX_NUMBER_OF_AFIDS_PER_RECORD` are now `AMDSMI_MAX_SVI3_RAIL_INDEX`, `AMDSMI_MAX_SVI3_RAIL_SELECTION`, `AMDSMI_POWER_EFFICIENCY_MODE_4`, `AMDSMI_POWER_EFFICIENCY_MODE_5`, and `AMDSMI_MAX_NUMBER_OF_AFIDS_PER_RECORD`. The unused `CENTRIGRADE_TO_MILLI_CENTIGRADE` macro was removed. Update references to the new names.
+- **Deprecated `amdsmi_get_gpu_vram_vendor()` in favor of `amdsmi_get_gpu_vram_info()`**.  
+  - `amdsmi_get_gpu_vram_vendor` is slated for removal in a future ROCm release. It now emits a `DeprecationWarning` from the Python interface and functions as a wrapper of `amdsmi_get_gpu_vram_info()`.
 
 - **Renamed "AINIC version" to "ionic version" in `amd-smi version` output**.  
   - The label now correctly reflects that it shows the ionic kernel driver version.
 
 ### Removed
-
-- **Removed `amdsmi_get_gpu_vram_vendor()`** (breaking). Use `amdsmi_get_gpu_vram_info()` and read the `vram_vendor` field instead.
-
-- **Removed `amdsmi_get_cpusocket_handles()` from the Python interface** (breaking). Use `amdsmi_get_cpu_handles()` instead.
-
-- **Removed the `plpds` key from `amdsmi_get_xgmi_plpd()` Python output** (breaking). Use the `policies` key instead.
 
 - **Removed the non-functional `--decode` flag from `amd-smi ras`**. Out-of-band CPER decoding is available via `amd-smi ras --afid --cper-file <path>` or `--afid --folder <DIR>`.
 

--- a/projects/amdsmi/amdsmi_cli/subcommands/set_value.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/set_value.py
@@ -1254,7 +1254,9 @@ class SetValueCommands:
                     memory_partition = amdsmi_interface.AmdSmiMemoryPartitionType[
                         args.memory_partition
                     ]
-                    amdsmi_interface.amdsmi_set_gpu_memory_partition(args.gpu, memory_partition)
+                    amdsmi_interface.amdsmi_set_gpu_memory_partition_mode(
+                        args.gpu, memory_partition
+                    )
                     out = f"Successfully set memory partition to {args.memory_partition}, use `sudo modprobe -r amdgpu && sudo modprobe amdgpu` to reload driver"
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     out = f"[{e.get_error_info(detailed=False)}] Unable to set memory partition to {args.memory_partition}"
@@ -1805,34 +1807,34 @@ class SetValueCommands:
 
         if getattr(args, "compute_partition_mem_alloc_mode", None):
             try:
-                mode = amdsmi_interface.AmdSmiComputePartitionMemAllocModeType[
+                mode = amdsmi_interface.AmdSmiAcceleratorPartitionMemAllocModeType[
                     args.compute_partition_mem_alloc_mode
                 ]
-                amdsmi_interface.amdsmi_set_gpu_compute_partition_mem_alloc_mode(args.gpu, mode)
-                out = f"Successfully set compute partition memory allocation mode to {args.compute_partition_mem_alloc_mode}"
+                amdsmi_interface.amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(args.gpu, mode)
+                out = f"Successfully set accelerator partition memory allocation mode to {args.compute_partition_mem_alloc_mode}"
             except KeyError:
                 out = (
-                    "Invalid compute partition memory allocation mode "
+                    "Invalid accelerator partition memory allocation mode "
                     f"{args.compute_partition_mem_alloc_mode}"
                 )
-                self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
+                self.logger.store_output(args.gpu, "accelerator_partition_mem_alloc_mode", out)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
                 return
             except amdsmi_exception.AmdSmiLibraryException as e:
-                out = f"[{e.get_error_info(detailed=False)}] Unable to set compute partition memory allocation mode to {args.compute_partition_mem_alloc_mode}"
+                out = f"[{e.get_error_info(detailed=False)}] Unable to set accelerator partition memory allocation mode to {args.compute_partition_mem_alloc_mode}"
                 if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
                     out = "[AMDSMI_STATUS_NO_PERM] Command requires elevation"
-                    self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
+                    self.logger.store_output(args.gpu, "accelerator_partition_mem_alloc_mode", out)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
                     raise PermissionError("Command requires elevation") from e
                 else:
-                    self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
+                    self.logger.store_output(args.gpu, "accelerator_partition_mem_alloc_mode", out)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
                     return
-            self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
+            self.logger.store_output(args.gpu, "accelerator_partition_mem_alloc_mode", out)
             self.logger.print_output()
             self.logger.clear_multiple_devices_output()
             return

--- a/projects/amdsmi/amdsmi_cli/subcommands/static.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/static.py
@@ -836,13 +836,13 @@ class StaticCommands:
                     e.get_error_info(),
                 )
             try:
-                mem_alloc_mode = amdsmi_interface.amdsmi_get_gpu_compute_partition_mem_alloc_mode(
-                    args.gpu
+                mem_alloc_mode = (
+                    amdsmi_interface.amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(args.gpu)
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
                 mem_alloc_mode = "N/A"
                 logging.debug(
-                    "Failed to get compute partition mem alloc mode for gpu %s | %s",
+                    "Failed to get accelerator partition mem alloc mode for gpu %s | %s",
                     gpu_id,
                     e.get_error_info(),
                 )

--- a/projects/amdsmi/docs/conceptual/ras.md
+++ b/projects/amdsmi/docs/conceptual/ras.md
@@ -70,7 +70,7 @@ See {ref}`ECC information <tagECCInfo>` and {ref}`RAS information <tagRasInfo>` 
 See related APIs:
 
 - [](/reference/amdsmi-py-api.md#amdsmi_get_gpu_ecc_count)
-- [](/reference/amdsmi-py-api.md#amdsmi_get_gpu_ecc_supported)
+- [](/reference/amdsmi-py-api.md#amdsmi_get_gpu_ecc_enabled)
 - [](/reference/amdsmi-py-api.md#amdsmi_get_gpu_ecc_status)
 - [](/reference/amdsmi-py-api.md#amdsmi_get_gpu_total_ecc_count)
 - [](/reference/amdsmi-py-api.md#amdsmi_get_gpu_cper_entries)

--- a/projects/amdsmi/docs/conceptual/ras.md
+++ b/projects/amdsmi/docs/conceptual/ras.md
@@ -70,7 +70,7 @@ See {ref}`ECC information <tagECCInfo>` and {ref}`RAS information <tagRasInfo>` 
 See related APIs:
 
 - [](/reference/amdsmi-py-api.md#amdsmi_get_gpu_ecc_count)
-- [](/reference/amdsmi-py-api.md#amdsmi_get_gpu_ecc_enabled)
+- [](/reference/amdsmi-py-api.md#amdsmi_get_gpu_ecc_supported)
 - [](/reference/amdsmi-py-api.md#amdsmi_get_gpu_ecc_status)
 - [](/reference/amdsmi-py-api.md#amdsmi_get_gpu_total_ecc_count)
 - [](/reference/amdsmi-py-api.md#amdsmi_get_gpu_cper_entries)

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -5603,7 +5603,7 @@ finally:
     amdsmi.amdsmi_shut_down()
 ```
 
-### amdsmi_get_gpu_compute_partition_mem_alloc_mode
+### amdsmi_get_gpu_accelerator_partition_mem_alloc_mode
 
 Description: Get the compute partition memory allocation mode from the given GPU. Controls how HBM capacity is distributed across XCPs within each memory partition.
 
@@ -5613,7 +5613,7 @@ Input parameters:
 
 Output: String of the memory allocation mode (`"CAPPING"` or `"ALL"`)
 
-Exceptions that can be thrown by `amdsmi_get_gpu_compute_partition_mem_alloc_mode` function:
+Exceptions that can be thrown by `amdsmi_get_gpu_accelerator_partition_mem_alloc_mode` function:
 
 * `AmdSmiLibraryException`
 * `AmdSmiParameterException`
@@ -5637,7 +5637,7 @@ try:
         print("No GPUs on machine")
     else:
         for device in devices:
-            mode = amdsmi.amdsmi_get_gpu_compute_partition_mem_alloc_mode(device)
+            mode = amdsmi.amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(device)
             print(mode)
 except amdsmi.AmdSmiException as e:
     print(e)
@@ -5645,7 +5645,7 @@ finally:
     amdsmi.amdsmi_shut_down()
 ```
 
-### amdsmi_set_gpu_compute_partition_mem_alloc_mode
+### amdsmi_set_gpu_accelerator_partition_mem_alloc_mode
 
 Description: Set the compute partition memory allocation mode for the given GPU. Requires elevated privileges (sudo). Controls whether each XCP is capped to an even share of memory (`CAPPING`) or may use the full partition memory (`ALL`).
 
@@ -5656,7 +5656,7 @@ Input parameters:
 
 Output: None
 
-Exceptions that can be thrown by `amdsmi_set_gpu_compute_partition_mem_alloc_mode` function:
+Exceptions that can be thrown by `amdsmi_set_gpu_accelerator_partition_mem_alloc_mode` function:
 
 * `AmdSmiLibraryException`
 * `AmdSmiParameterException`
@@ -5680,7 +5680,7 @@ try:
         print("No GPUs on machine")
     else:
         for device in devices:
-            amdsmi.amdsmi_set_gpu_compute_partition_mem_alloc_mode(
+            amdsmi.amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(
                 device, amdsmi.AmdSmiComputePartitionMemAllocModeType.CAPPING
             )
 except amdsmi.AmdSmiException as e:
@@ -5767,48 +5767,6 @@ try:
         for device in devices:
             memory_partition_type = amdsmi.amdsmi_get_gpu_memory_partition(device)
             print(memory_partition_type)
-except amdsmi.AmdSmiException as e:
-    print(e)
-finally:
-    amdsmi.amdsmi_shut_down()
-```
-
-### amdsmi_set_gpu_memory_partition
-
-Description: Set the memory partition to the given GPU. This function does not allow any concurrent operations. Devices must be idle and have no workloads when performing set partition operations.
-
-Input parameters:
-
-* `processor_handle` the device handle
-* `memory_partition` the type of memory_partition to set
-
-Output: `None`
-
-Exceptions that can be thrown by `amdsmi_set_gpu_memory_partition` function:
-
-* `AmdSmiLibraryException`
-* `AmdSmiParameterException`
-
-#### Possible Library Exceptions
-
-- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
-- `AMDSMI_STATUS_INVAL` - Invalid parameters
-- `AMDSMI_STATUS_NO_PERM` - Permission Denied
-- `AMDSMI_STATUS_BUSY` - Device is busy, could not acquire resource or mutex
-
-Example:
-
-```python
-import amdsmi
-try:
-    amdsmi.amdsmi_init()
-    memory_partition = amdsmi.AmdSmiMemoryPartitionType.NPS1
-    devices = amdsmi.amdsmi_get_processor_handles()
-    if len(devices) == 0:
-        print("No GPUs on machine")
-    else:
-        for device in devices:
-            amdsmi.amdsmi_set_gpu_memory_partition(device, memory_partition)
 except amdsmi.AmdSmiException as e:
     print(e)
 finally:

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -4663,7 +4663,7 @@ finally:
     amdsmi.amdsmi_shut_down()
 ```
 
-### amdsmi_get_gpu_ecc_supported
+### amdsmi_get_gpu_ecc_enabled
 
 Description: Retrieve the enabled ECC bit-mask. It is not supported on virtual
 machine guest.
@@ -4683,7 +4683,7 @@ Input parameters:
 
 Output: Enabled ECC bit-mask
 
-Exceptions that can be thrown by `amdsmi_get_gpu_ecc_supported` function:
+Exceptions that can be thrown by `amdsmi_get_gpu_ecc_enabled` function:
 
 * `AmdSmiLibraryException`
 * `AmdSmiParameterException`
@@ -4707,7 +4707,7 @@ try:
         print("No GPUs on machine")
     else:
         for device in devices:
-            enabled =  amdsmi.amdsmi_get_gpu_ecc_supported(device)
+            enabled =  amdsmi.amdsmi_get_gpu_ecc_enabled(device)
             print(enabled)
 except amdsmi.AmdSmiException as e:
     print(e)

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -2317,51 +2317,6 @@ finally:
     amdsmi.amdsmi_shut_down()
 ```
 
-### amdsmi_set_gpu_clk_range
-
-Description: This function sets the clock range information.
-It is not supported on virtual machine guest
-
-Input parameters:
-
-* `processor_handle` handle for the given device
-* `min_clk_value` minimum clock value for desired clock range
-* `max_clk_value` maximum clock value for desired clock range
-* `clk_type` SYS | MEM range type
-
-Output: None
-
-Exceptions that can be thrown by `amdsmi_set_gpu_clk_range` function:
-
-* `AmdSmiLibraryException`
-* `AmdSmiParameterException`
-
-#### Possible Library Exceptions
-
-- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
-- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
-- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
-- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
-- `AMDSMI_STATUS_INVAL` - Invalid parameters
-
-Example:
-
-```python
-import amdsmi
-try:
-    amdsmi.amdsmi_init()
-    devices = amdsmi.amdsmi_get_processor_handles()
-    if len(devices) == 0:
-        print("No GPUs on machine")
-    else:
-        for device in devices:
-            amdsmi.amdsmi_set_gpu_clk_range(device, 0, 1000, amdsmi.AmdSmiClkType.SYS)
-except amdsmi.AmdSmiException as e:
-    print(e)
-finally:
-    amdsmi.amdsmi_shut_down()
-```
-
 ### amdsmi_get_gpu_bdf_id
 
 Description: Get the unique PCI device identifier associated for a device

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -4575,7 +4575,7 @@ Field | Description
 ---|---
 `num_supported` | The number of supported policies
 `current_id` | The current policy index
-`policies` | List of policies. (`plpds` marked for deprecation in next major release)
+`policies` | List of policies.
 
 Exceptions that can be thrown by `amdsmi_get_xgmi_plpd` function:
 
@@ -4708,7 +4708,7 @@ finally:
     amdsmi.amdsmi_shut_down()
 ```
 
-### amdsmi_get_gpu_ecc_enabled
+### amdsmi_get_gpu_ecc_supported
 
 Description: Retrieve the enabled ECC bit-mask. It is not supported on virtual
 machine guest.
@@ -4728,7 +4728,7 @@ Input parameters:
 
 Output: Enabled ECC bit-mask
 
-Exceptions that can be thrown by `amdsmi_get_gpu_ecc_enabled` function:
+Exceptions that can be thrown by `amdsmi_get_gpu_ecc_supported` function:
 
 * `AmdSmiLibraryException`
 * `AmdSmiParameterException`
@@ -4752,7 +4752,7 @@ try:
         print("No GPUs on machine")
     else:
         for device in devices:
-            enabled =  amdsmi.amdsmi_get_gpu_ecc_enabled(device)
+            enabled =  amdsmi.amdsmi_get_gpu_ecc_supported(device)
             print(enabled)
 except amdsmi.AmdSmiException as e:
     print(e)
@@ -5145,48 +5145,6 @@ try:
         for device in devices:
             dev_id = amdsmi.amdsmi_get_gpu_id(device)
             print(dev_id)
-except amdsmi.AmdSmiException as e:
-    print(e)
-finally:
-    amdsmi.amdsmi_shut_down()
-```
-
-### amdsmi_get_gpu_vram_vendor
-
-Description: **Deprecated** (slated for removal in a future ROCm release; use `amdsmi_get_gpu_vram_info()` instead). Get the vram vendor string of a gpu device.
-
-Input parameters:
-
-* `processor_handle` device which to query
-
-Output: vram vendor
-
-Exceptions that can be thrown by `amdsmi_get_gpu_vram_vendor` function:
-
-* `AmdSmiLibraryException`
-* `AmdSmiParameterException`
-
-#### Possible Library Exceptions
-
-- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
-- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
-- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
-- `AMDSMI_STATUS_INVAL` - Invalid parameters
-- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
-
-Example:
-
-```python
-import amdsmi
-try:
-    amdsmi.amdsmi_init()
-    devices = amdsmi.amdsmi_get_processor_handles()
-    if len(devices) == 0:
-        print("No GPUs on machine")
-    else:
-        for device in devices:
-            vram_vendor = amdsmi.amdsmi_get_gpu_vram_vendor(device)
-            print(vram_vendor)
 except amdsmi.AmdSmiException as e:
     print(e)
 finally:

--- a/projects/amdsmi/example/amd_smi_drm_example.cc
+++ b/projects/amdsmi/example/amd_smi_drm_example.cc
@@ -369,29 +369,23 @@ static void print_apu_metrics_info(const amdsmi_gpu_metrics_t& smu) {
   }
 }
 
-static const std::string computePartitionString(
-    amdsmi_compute_partition_type_t computeParitionType) {
-  switch (computeParitionType) {
-    case AMDSMI_COMPUTE_PARTITION_SPX:
+static const std::string acceleratorPartitionString(
+    amdsmi_accelerator_partition_type_t acceleratorParitionType) {
+  switch (acceleratorParitionType) {
+    case AMDSMI_ACCELERATOR_PARTITION_SPX:
       return "SPX";
-    case AMDSMI_COMPUTE_PARTITION_DPX:
+    case AMDSMI_ACCELERATOR_PARTITION_DPX:
       return "DPX";
-    case AMDSMI_COMPUTE_PARTITION_TPX:
+    case AMDSMI_ACCELERATOR_PARTITION_TPX:
       return "TPX";
-    case AMDSMI_COMPUTE_PARTITION_QPX:
+    case AMDSMI_ACCELERATOR_PARTITION_QPX:
       return "QPX";
-    case AMDSMI_COMPUTE_PARTITION_CPX:
+    case AMDSMI_ACCELERATOR_PARTITION_CPX:
       return "CPX";
     default:
       return "N/A";
   }
 }
-
-static const std::map<std::string, amdsmi_compute_partition_type_t>
-    mapStringToSMIComputePartitionTypes{
-        {"SPX", AMDSMI_COMPUTE_PARTITION_SPX}, {"DPX", AMDSMI_COMPUTE_PARTITION_DPX},
-        {"TPX", AMDSMI_COMPUTE_PARTITION_TPX}, {"QPX", AMDSMI_COMPUTE_PARTITION_QPX},
-        {"CPX", AMDSMI_COMPUTE_PARTITION_CPX}, {"N/A", AMDSMI_COMPUTE_PARTITION_INVALID}};
 
 static const std::string memoryPartitionString(amdsmi_memory_partition_type_t memoryParitionType) {
   switch (memoryParitionType) {
@@ -442,7 +436,7 @@ static const std::map<amdsmi_link_type_t, std::string> link_type_map = {
 
 int main() {
   amdsmi_status_t ret;
-  std::vector<amdsmi_compute_partition_type_t> orig_accelerator_partitions;
+  std::vector<uint32_t> orig_accelerator_partitions;
   std::vector<amdsmi_memory_partition_type_t> orig_memory_partitions;
   uint32_t gpu_number = 0;
 
@@ -467,19 +461,19 @@ int main() {
   std::cout << "Total Socket: " << socket_count << std::endl;
 
   // WARNING: Do not put any other settings before/inside/or between these lambda functions
-  //           Required to save/change/reset the compute/accelerator & memory partition settings
+  //           Required to save/change/reset the accelerator & memory partition settings
   // Reason: Modifies total number of gpu count, which will affect other API calls.
   //         Requires amdsmi_shut_down()/amdsmi_init(AMDSMI_INIT_AMD_GPUS) to re-enumerate
   //         total number of GPUs (AKA "processors per socket").
-  //         Changing back to original settings (compute/accelerator & memory partition)
+  //         Changing back to original settings (accelerator & memory partition)
   //         will not modify the GPU count.
   // Save all original partition settings for later
   auto save_original_partitions =
       [socket_count, &ret, sockets](
-          std::vector<amdsmi_compute_partition_type_t>& orig_partitions,
+          std::vector<uint32_t>& orig_partitions,
           std::vector<amdsmi_memory_partition_type_t>& orig_memory_partitions,
           uint32_t& gpu_number) -> void {
-    std::cout << "    **Saving Original Compute/Accelerator & Memory Partition Settings**\n";
+    std::cout << "    **Saving Original Accelerator & Memory Partition Settings**\n";
 
     // For each socket, get identifier and devices
     for (uint32_t i = 0; i < socket_count; i++) {
@@ -508,33 +502,34 @@ int main() {
         std::cout << "\t**Device Handle: " << processor_handles[device_index] << std::endl;
         std::cout << "\t**GPU Number: " << gpu_number << std::endl;
 
-        // Get the original compute partition
-        char original_compute_partition[AMDSMI_MAX_STRING_LENGTH];
-        ret = amdsmi_get_gpu_compute_partition(processor_handles[device_index],
-                                               original_compute_partition,
-                                               static_cast<uint32_t>(AMDSMI_MAX_STRING_LENGTH));
+        // Get the original accelerator partition
+        amdsmi_accelerator_partition_profile_t profile;
+        uint32_t partition_id[AMDSMI_MAX_ACCELERATOR_PROFILE];
+        ret = amdsmi_get_gpu_accelerator_partition_profile(processor_handles[device_index],
+                                                           &profile, partition_id);
+        std::string original_accelerator_partition =
+            acceleratorPartitionString(profile.profile_type);
 
         const char* err_str;
         amdsmi_status_code_to_string(ret, &err_str);
         if (ret == AMDSMI_STATUS_SUCCESS) {
           PRINT_AMDSMI_RET(ret)
-          std::cout << "    Output of amdsmi_get_gpu_compute_partition:\n";
-          std::cout << "\tamdsmi_get_gpu_compute_partition(" << gpu_number << ", "
-                    << mapStringToSMIComputePartitionTypes.at(original_compute_partition)
-                    << "): " << err_str << "\n\n";
-          std::cout << "\tCompute Partition (original): " << original_compute_partition << "\n\n";
-        } else {
-          std::cout << "\tamdsmi_get_gpu_compute_partition(" << gpu_number << ", "
-                    << computePartitionString(AMDSMI_COMPUTE_PARTITION_INVALID) << "): " << err_str
+          std::cout << "    Output of amdsmi_get_gpu_accelerator_partition:\n";
+          std::cout << "\tamdsmi_get_gpu_accelerator_partition_profile(" << gpu_number << ", "
+                    << profile.profile_type << "): " << err_str << "\n\n";
+          std::cout << "\tAccelerator Partition (original): " << original_accelerator_partition
                     << "\n\n";
+        } else {
+          std::cout << "\tamdsmi_get_gpu_accelerator_partition_profile(" << gpu_number << ", "
+                    << acceleratorPartitionString(AMDSMI_ACCELERATOR_PARTITION_INVALID)
+                    << "): " << err_str << "\n\n";
         }
 
-        // Save the original compute/accelerator partition
+        // Save the original accelerator partition
         if (ret == AMDSMI_STATUS_SUCCESS) {
-          orig_partitions.push_back(
-              mapStringToSMIComputePartitionTypes.at(original_compute_partition));
+          orig_partitions.push_back(profile.profile_index);
         } else {
-          orig_partitions.push_back(AMDSMI_COMPUTE_PARTITION_INVALID);
+          orig_partitions.push_back(0);
         }
 
         // Get the original memory partition
@@ -569,13 +564,13 @@ int main() {
     // Reset GPU number for the next loop
     gpu_number = 0;
   };
-  // Save the original compute/accelerator & memory partition settings
+  // Save the original accelerator & memory partition settings
   save_original_partitions(orig_accelerator_partitions, orig_memory_partitions, gpu_number);
 
-  std::cout << "    **Version 1: Accelerator/Compute Partition & memory API Examples**\n";
+  std::cout << "    **Version 1: Accelerator Partition & memory API Examples**\n";
   auto process_accelerator_partitions = [socket_count, &ret,
                                          sockets](uint32_t& gpu_number) -> void {
-    std::cout << "    **Process Compute/Accelerator & Memory Partition Settings**\n";
+    std::cout << "    **Process Accelerator & Memory Partition Settings**\n";
 
     // For each socket, get identifier and devices
     for (uint32_t i = 0; i < socket_count; i++) {
@@ -604,56 +599,63 @@ int main() {
         std::cout << "\t**Device Handle: " << processor_handles[device_index] << std::endl;
         std::cout << "\t**GPU Number: " << gpu_number << std::endl;
 
-        // Get the original compute partition
-        char original_compute_partition[AMDSMI_MAX_STRING_LENGTH];
-        ret = amdsmi_get_gpu_compute_partition(processor_handles[device_index],
-                                               original_compute_partition,
-                                               static_cast<uint32_t>(AMDSMI_MAX_STRING_LENGTH));
+        // Get the original accelerator partition
+        amdsmi_accelerator_partition_profile_t profile;
+        uint32_t partition_id[AMDSMI_MAX_ACCELERATOR_PROFILE];
+        ret = amdsmi_get_gpu_accelerator_partition_profile(processor_handles[device_index],
+                                                           &profile, partition_id);
+        std::string original_accelerator_partition =
+            acceleratorPartitionString(profile.profile_type);
 
         const char* err_str;
         amdsmi_status_code_to_string(ret, &err_str);
         if (ret == AMDSMI_STATUS_SUCCESS) {
           PRINT_AMDSMI_RET(ret)
-          std::cout << "    Output of amdsmi_get_gpu_compute_partition:\n";
-          std::cout << "\tamdsmi_get_gpu_compute_partition(" << gpu_number << ", "
-                    << mapStringToSMIComputePartitionTypes.at(original_compute_partition)
-                    << "): " << err_str << "\n\n";
-          std::cout << "\tCompute Partition (original): " << original_compute_partition << "\n\n";
-        } else {
-          std::cout << "\tamdsmi_get_gpu_compute_partition(" << gpu_number << ", "
-                    << computePartitionString(AMDSMI_COMPUTE_PARTITION_INVALID) << "): " << err_str
+          std::cout << "    Output of amdsmi_get_gpu_accelerator_partition:\n";
+          std::cout << "\tamdsmi_get_gpu_accelerator_partition_profile(" << gpu_number << ", "
+                    << profile.profile_type << "): " << err_str << "\n\n";
+          std::cout << "\tAccelerator Partition (original): " << original_accelerator_partition
                     << "\n\n";
+        } else {
+          std::cout << "\tamdsmi_get_gpu_accelerator_partition_profile(" << gpu_number << ", "
+                    << acceleratorPartitionString(AMDSMI_ACCELERATOR_PARTITION_INVALID)
+                    << "): " << err_str << "\n\n";
         }
 
-        // Iterate through all compute partitions
-        for (int partition = static_cast<int>(AMDSMI_COMPUTE_PARTITION_SPX);
-             partition <= static_cast<int>(AMDSMI_COMPUTE_PARTITION_CPX); partition++) {
-          amdsmi_compute_partition_type_t updatePartition =
-              static_cast<amdsmi_compute_partition_type_t>(partition);
-          amdsmi_status_t ret_set =
-              amdsmi_set_gpu_compute_partition(processor_handles[device_index], updatePartition);
+        // Iterate through all available accelerator partition profiles
+        amdsmi_accelerator_partition_profile_config_t profile_config;
+        ret = amdsmi_get_gpu_accelerator_partition_profile_config(processor_handles[device_index],
+                                                                  &profile_config);
+        for (uint32_t profile_idx = 0; profile_idx < profile_config.num_profiles; profile_idx++) {
+          amdsmi_accelerator_partition_type_t updatePartition =
+              profile_config.profiles[profile_idx].profile_type;
+          amdsmi_status_t ret_set = amdsmi_set_gpu_accelerator_partition_profile(
+              processor_handles[device_index], profile_idx);
           amdsmi_status_code_to_string(ret_set, &err_str);
           if (ret_set == AMDSMI_STATUS_SUCCESS) {
             PRINT_AMDSMI_RET(ret_set)
           }
-          std::cout << "\tamdsmi_set_gpu_compute_partition(" << gpu_number << ", "
-                    << computePartitionString(updatePartition) << "): " << err_str << "\n\n";
+          std::cout << "\tamdsmi_set_gpu_accelerator_partition_profile(" << gpu_number << ", "
+                    << acceleratorPartitionString(updatePartition) << "): " << err_str << "\n\n";
 
-          // Get the current compute partition
-          char current_compute_partition[AMDSMI_MAX_STRING_LENGTH];
-          ret = amdsmi_get_gpu_compute_partition(processor_handles[device_index],
-                                                 current_compute_partition,
-                                                 static_cast<uint32_t>(AMDSMI_MAX_STRING_LENGTH));
+          // Get the current accelerator partition
+          amdsmi_accelerator_partition_profile_t profile;
+          uint32_t partition_id[AMDSMI_MAX_ACCELERATOR_PROFILE];
+          ret = amdsmi_get_gpu_accelerator_partition_profile(processor_handles[device_index],
+                                                             &profile, partition_id);
+          std::string current_accelerator_partition =
+              acceleratorPartitionString(profile.profile_type);
           amdsmi_status_code_to_string(ret, &err_str);
           if (ret == AMDSMI_STATUS_SUCCESS) {
             PRINT_AMDSMI_RET(ret)
-            std::cout << "    Output of amdsmi_get_gpu_compute_partition:\n";
-            std::cout << "\tamdsmi_get_gpu_compute_partition(" << gpu_number << ", "
-                      << computePartitionString(updatePartition) << "): " << err_str << "\n\n";
-            std::cout << "\tCompute Partition (current): " << current_compute_partition << "\n\n";
+            std::cout << "    Output of amdsmi_get_gpu_accelerator_partition:\n";
+            std::cout << "\tamdsmi_get_gpu_accelerator_partition_profile(" << gpu_number << ", "
+                      << profile.profile_type << "): " << err_str << "\n\n";
+            std::cout << "\tAccelerator Partition (current): " << current_accelerator_partition
+                      << "\n\n";
           } else {
-            std::cout << "\tamdsmi_get_gpu_compute_partition(" << gpu_number << ", "
-                      << computePartitionString(AMDSMI_COMPUTE_PARTITION_INVALID)
+            std::cout << "\tamdsmi_get_gpu_accelerator_partition_profile(" << gpu_number << ", "
+                      << acceleratorPartitionString(AMDSMI_ACCELERATOR_PARTITION_INVALID)
                       << "): " << err_str << "\n\n";
           }
         }
@@ -716,7 +718,7 @@ int main() {
         }
 
         // Since memory partition effects entire GPU hive (and modifies current
-        // compute/accelerator partition), we'll default to only changing the
+        // accelerator partition), we'll default to only changing the
         // first device for the first socket (GPU #0)
         // Note: Any device can be requested to change memory partition,
         //       but for simplicity, we will only change GPU #0.
@@ -732,14 +734,14 @@ int main() {
             }
             amdsmi_memory_partition_type_t updatePartition =
                 static_cast<amdsmi_memory_partition_type_t>(partition);
-            auto ret_set =
-                amdsmi_set_gpu_memory_partition(processor_handles[device_index], updatePartition);
+            auto ret_set = amdsmi_set_gpu_memory_partition_mode(processor_handles[device_index],
+                                                                updatePartition);
             amdsmi_status_code_to_string(ret_set, &err_str);
             if (ret_set == AMDSMI_STATUS_SUCCESS) {
               PRINT_AMDSMI_RET(ret_set)
-              std::cout << "    Output of amdsmi_set_gpu_memory_partition:\n";
+              std::cout << "    Output of amdsmi_set_gpu_memory_partition_mode:\n";
             }
-            std::cout << "\tamdsmi_set_gpu_memory_partition(" << gpu_number << ", "
+            std::cout << "\tamdsmi_set_gpu_memory_partition_mode(" << gpu_number << ", "
                       << memoryPartitionString(updatePartition) << "): " << err_str << "\n\n";
 
             if (ret_set == AMDSMI_STATUS_SUCCESS) {
@@ -810,7 +812,7 @@ int main() {
         std::cout << "\t**Device Handle: " << processor_handles[device_index] << std::endl;
         std::cout << "\t**GPU Number: " << gpu_number << std::endl;
         // Since memory partition effects entire GPU hive (and modifies current
-        // compute/accelerator partition), we'll default to only changing the
+        // accelerator partition), we'll default to only changing the
         // first device for the first socket (GPU #0)
         // Note: Any device can be requested to change memory partition,
         //       but for simplicity, we will only change GPU #0.
@@ -823,14 +825,14 @@ int main() {
         // Reset to original memory partition settings
         amdsmi_memory_partition_type_t orig_partition = orig_partitions[gpu_number];
         amdsmi_status_t ret_set =
-            amdsmi_set_gpu_memory_partition(processor_handles[device_index], orig_partition);
+            amdsmi_set_gpu_memory_partition_mode(processor_handles[device_index], orig_partition);
         const char* err_str;
         amdsmi_status_code_to_string(ret_set, &err_str);
         if (ret_set == AMDSMI_STATUS_SUCCESS) {
           PRINT_AMDSMI_RET(ret_set)
-          std::cout << "    Output of amdsmi_set_gpu_memory_partition:\n";
+          std::cout << "    Output of amdsmi_set_gpu_memory_partition_mode:\n";
         }
-        std::cout << "\tamdsmi_set_gpu_memory_partition(" << gpu_number << ", "
+        std::cout << "\tamdsmi_set_gpu_memory_partition_mode(" << gpu_number << ", "
                   << memoryPartitionString(orig_partition) << "): " << err_str << "\n\n";
         if (ret_set == AMDSMI_STATUS_SUCCESS) {
           std::cout << "\t** Memory partition staged. Run to apply:\n"
@@ -862,12 +864,11 @@ int main() {
   // Reset to original memory partition settings
   reset_memory_partitions(orig_memory_partitions, gpu_number);
 
-  auto reset_accelerator_partitions =
-      [socket_count, &ret, sockets](
-          const std::vector<amdsmi_compute_partition_type_t>& orig_partitions,
-          uint32_t& gpu_number) -> void {
+  auto reset_accelerator_partitions = [socket_count, &ret, sockets](
+                                          const std::vector<uint32_t>& orig_partitions,
+                                          uint32_t& gpu_number) -> void {
     std::cout << "    **Version 1: Memory Partition API Examples**\n";
-    std::cout << "    **Resetting Compute/Accelerator Partition Settings**\n";
+    std::cout << "    **Resetting Accelerator Partition Settings**\n";
 
     // For each socket, get identifier and devices
     for (uint32_t i = 0; i < socket_count; i++) {
@@ -896,35 +897,38 @@ int main() {
         std::cout << "\t**Device Handle: " << processor_handles[device_index] << std::endl;
         std::cout << "\t**GPU Number: " << gpu_number << std::endl;
 
-        // Reset to original compute/accelerator partition settings
-        amdsmi_compute_partition_type_t orig_partition = orig_partitions[gpu_number];
-        amdsmi_status_t ret_set =
-            amdsmi_set_gpu_compute_partition(processor_handles[device_index], orig_partition);
+        // Reset to original accelerator partition settings
+        uint32_t orig_partition = orig_partitions[gpu_number];
+        amdsmi_status_t ret_set = amdsmi_set_gpu_accelerator_partition_profile(
+            processor_handles[device_index], orig_partition);
         const char* err_str;
         amdsmi_status_code_to_string(ret_set, &err_str);
         if (ret_set == AMDSMI_STATUS_SUCCESS) {
           PRINT_AMDSMI_RET(ret_set)
-          std::cout << "    Output of amdsmi_set_gpu_compute_partition:\n";
+          std::cout << "    Output of amdsmi_set_gpu_accelerator_partition_profile:\n";
         }
-        std::cout << "\tamdsmi_set_gpu_compute_partition(" << gpu_number << ", "
-                  << computePartitionString(orig_partition) << "): " << err_str << "\n\n";
+        std::cout << "\tamdsmi_set_gpu_accelerator_partition_profile(" << gpu_number << ", "
+                  << orig_partition << "): " << err_str << "\n\n";
 
-        // Get the current compute/accelerator partition
-        char current_compute_partition[AMDSMI_MAX_STRING_LENGTH];
-        ret = amdsmi_get_gpu_compute_partition(processor_handles[device_index],
-                                               current_compute_partition,
-                                               static_cast<uint32_t>(AMDSMI_MAX_STRING_LENGTH));
+        // Get the current accelerator partition
+        amdsmi_accelerator_partition_profile_t profile;
+        uint32_t partition_id[AMDSMI_MAX_ACCELERATOR_PROFILE];
+        ret = amdsmi_get_gpu_accelerator_partition_profile(processor_handles[device_index],
+                                                           &profile, partition_id);
+        std::string current_accelerator_partition =
+            acceleratorPartitionString(profile.profile_type);
         amdsmi_status_code_to_string(ret, &err_str);
         if (ret == AMDSMI_STATUS_SUCCESS) {
           PRINT_AMDSMI_RET(ret)
-          std::cout << "    Output of amdsmi_get_gpu_compute_partition:\n";
-          std::cout << "\tamdsmi_get_gpu_compute_partition(" << gpu_number << ", "
-                    << computePartitionString(orig_partition) << "): " << err_str << "\n\n";
-          std::cout << "\tCompute Partition (current): " << current_compute_partition << "\n\n";
-        } else {
-          std::cout << "\tamdsmi_get_gpu_compute_partition(" << gpu_number << ", "
-                    << computePartitionString(AMDSMI_COMPUTE_PARTITION_INVALID) << "): " << err_str
+          std::cout << "    Output of amdsmi_get_gpu_accelerator_partition:\n";
+          std::cout << "\tamdsmi_get_gpu_accelerator_partition_profile(" << gpu_number << ", "
+                    << profile.profile_type << "): " << err_str << "\n\n";
+          std::cout << "\tAccelerator Partition (current): " << current_accelerator_partition
                     << "\n\n";
+        } else {
+          std::cout << "\tamdsmi_get_gpu_accelerator_partition_profile(" << gpu_number << ", "
+                    << acceleratorPartitionString(AMDSMI_ACCELERATOR_PARTITION_INVALID)
+                    << "): " << err_str << "\n\n";
         }
         gpu_number++;
       }
@@ -932,15 +936,15 @@ int main() {
     // Reset GPU number for the next loop
     gpu_number = 0;
   };
-  // Reset to original compute/accelerator partition settings
+  // Reset to original accelerator partition settings
   reset_accelerator_partitions(orig_accelerator_partitions, gpu_number);
 
   // WARNING: Do not put any other settings before/inside/or between these lambda functions
-  //           Required to save/change/reset the compute/accelerator & memory partition settings
+  //           Required to save/change/reset the accelerator & memory partition settings
   // Reason: Modifies total number of gpu count, which will affect other API calls.
   //         Requires amdsmi_shut_down()/amdsmi_init(AMDSMI_INIT_AMD_GPUS) to re-enumerate
   //         total number of GPUs (AKA "processors per socket").
-  //         Changing back to original settings (compute/accelerator & memory partition)
+  //         Changing back to original settings (accelerator & memory partition)
   //         will not modify the GPU count.
   //  Add new functionality below this line!
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -473,6 +473,9 @@ typedef enum {
  * @brief Compute Partition. This enum is used to identify
  * various compute partitioning settings.
  *
+ * @deprecated This enum is slated for removal in a future ROCm release;
+ * use amdsmi_accelerator_partition_type_t instead
+ *
  * @cond @tag{gpu_bm_linux} @tag{guest_windows} @endcond
  */
 typedef enum {
@@ -493,6 +496,9 @@ typedef enum {
  * @brief Compute Partition Memory Allocation Mode. Controls how GPU memory
  * is allocated across XCPs within a memory partition.
  *
+ * @deprecated This enum is slated for removal in a future ROCm release;
+ * use amdsmi_accelerator_partition_mem_alloc_mode_t instead
+ *
  * @cond @tag{gpu_bm_linux} @endcond
  */
 typedef enum {
@@ -501,6 +507,19 @@ typedef enum {
   AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL           //!< Each XCP in the partition may
                                                    //!< use the full partition memory
 } amdsmi_compute_partition_mem_alloc_mode_t;
+
+/**
+ * @brief Accelerator Partition Memory Allocation Mode. Controls how GPU memory
+ * is allocated across XCPs within a memory partition.
+ *
+ * @cond @tag{gpu_bm_linux} @endcond
+ */
+typedef enum {
+  AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_INVALID = 0,  //!< Invalid mode
+  AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING,      //!< Memory is evenly capped per XCP
+  AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL           //!< Each XCP in the partition may
+                                                       //!< use the full partition memory
+} amdsmi_accelerator_partition_mem_alloc_mode_t;
 
 /**
  * @brief Memory Partitions
@@ -1773,8 +1792,10 @@ typedef enum {
  * @cond @tag{gpu_bm_linux} @endcond
  */
 typedef enum {
-  CLK_LIMIT_MIN,  //!< Min Clock value in MHz
-  CLK_LIMIT_MAX   //!< Max Clock value in MHz
+  AMDSMI_CLK_LIMIT_MIN,                  //!< Min Clock value in MHz
+  AMDSMI_CLK_LIMIT_MAX,                  //!< Max Clock value in MHz
+  CLK_LIMIT_MIN = AMDSMI_CLK_LIMIT_MIN,  //!< Deprecated, use AMDSMI_CLK_LIMIT_MIN instead
+  CLK_LIMIT_MAX = AMDSMI_CLK_LIMIT_MAX   //!< Deprecated, use AMDSMI_CLK_LIMIT_MAX instead
 } amdsmi_clk_limit_type_t;
 
 /**
@@ -2759,9 +2780,12 @@ typedef struct {
  * @cond @tag{cpu_bm} @endcond
  */
 typedef enum {
-  AGG_BW0 = 1,  //!< Aggregate Bandwidth
-  RD_BW0 = 2,   //!< Read Bandwidth
-  WR_BW0 = 4    //!< Write Bandwidth
+  AMDSMI_AGG_BW0 = 1,        //!< Aggregate Bandwidth
+  AMDSMI_RD_BW0 = 2,         //!< Read Bandwidth
+  AMDSMI_WR_BW0 = 4,         //!< Write Bandwidth
+  AGG_BW0 = AMDSMI_AGG_BW0,  //!< Deprecated, use AMDSMI_AGG_BW0 instead
+  RD_BW0 = AMDSMI_RD_BW0,    //!< Deprecated, use AMDSMI_RD_BW0 instead
+  WR_BW0 = AMDSMI_WR_BW0     //!< Deprecated, use AMDSMI_WR_BW0 instead
 } amdsmi_io_bw_encoding_t;
 
 /**
@@ -6844,13 +6868,16 @@ amdsmi_status_t amdsmi_topo_get_p2p_status(amdsmi_processor_handle processor_han
 /**
  *  @brief Retrieves the current compute partitioning for a desired device
  *
+ *  @deprecated This API is slated for removal in a future ROCm release;
+ *  ::amdsmi_get_gpu_accelerator_partition_profile() should be used instead
+ *
  *  @ingroup tagComputePartition
  *
  *  @platform{gpu_bm_linux}
  *
  *  @details
- *  Given a processor handle @p processor_handle and a string @p compute_partition ,
- *  and uint32 @p len , this function will attempt to obtain the device's
+ *  Given a processor handle @p processor_handle and a string @p compute_partition,
+ *  and uint32 @p len, this function will attempt to obtain the device's
  *  current compute partition setting string. Upon successful retrieval,
  *  the obtained device's compute partition settings string shall be stored in
  *  the passed @p compute_partition char string variable.
@@ -6878,6 +6905,9 @@ amdsmi_status_t amdsmi_get_gpu_compute_partition(amdsmi_processor_handle process
 
 /**
  *  @brief Modifies a selected device's compute partition setting.
+ *
+ *  @deprecated This API is slated for removal in a future ROCm release;
+ *  ::amdsmi_set_gpu_accelerator_partition_profile() should be used instead
  *
  *  @ingroup tagComputePartition
  *
@@ -6910,6 +6940,9 @@ amdsmi_status_t amdsmi_set_gpu_compute_partition(amdsmi_processor_handle process
  *  @brief Retrieves the current compute partition memory allocation mode
  *  for a desired device.
  *
+ *  @deprecated This API is slated for removal in a future ROCm release;
+ *  ::amdsmi_get_gpu_accelerator_partition_mem_alloc_mode() should be used instead
+ *
  *  @ingroup tagComputePartition
  *
  *  @platform{gpu_bm_linux}
@@ -6918,9 +6951,9 @@ amdsmi_status_t amdsmi_set_gpu_compute_partition(amdsmi_processor_handle process
  *  @p mode, this function will attempt to obtain the device's current
  *  compute partition memory allocation mode. The mode controls how HBM
  *  capacity is distributed across XCPs within each memory partition:
- *  - ::AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING — each XCP is capped
+ *  - ::AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING — each XCP is capped
  *    to an even share.
- *  - ::AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL — each XCP may use the
+ *  - ::AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL — each XCP may use the
  *    full memory partition size (useful when only one XCP is active).
  *
  *  @param[in] processor_handle Device which to query
@@ -6940,7 +6973,43 @@ amdsmi_status_t amdsmi_get_gpu_compute_partition_mem_alloc_mode(
     amdsmi_processor_handle processor_handle, amdsmi_compute_partition_mem_alloc_mode_t* mode);
 
 /**
+ *  @brief Retrieves the current accelerator partition memory allocation mode
+ *  for a desired device.
+ *
+ *  @ingroup tagComputePartition
+ *
+ *  @platform{gpu_bm_linux}
+ *
+ *  @details Given a processor handle @p processor_handle and a pointer
+ *  @p mode, this function will attempt to obtain the device's current
+ *  accelerator partition memory allocation mode. The mode controls how HBM
+ *  capacity is distributed across XCPs within each memory partition:
+ *  - ::AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING — each XCP is capped
+ *    to an even share.
+ *  - ::AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL — each XCP may use the
+ *    full memory partition size (useful when only one XCP is active).
+ *
+ *  @param[in] processor_handle Device which to query
+ *
+ *  @param[out] mode a pointer to an ::amdsmi_accelerator_partition_mem_alloc_mode_t
+ *  variable, into which the device's current memory allocation mode will
+ *  be written.
+ *
+ *  @retval ::AMDSMI_STATUS_SUCCESS call was successful
+ *  @retval ::AMDSMI_STATUS_INVAL the provided arguments are not valid
+ *  @retval ::AMDSMI_STATUS_UNEXPECTED_DATA data provided to function is not valid
+ *  @retval ::AMDSMI_STATUS_FILE_ERROR problem accessing the sysfs file
+ *  @retval ::AMDSMI_STATUS_NOT_SUPPORTED installed software or hardware does not
+ *  support this function
+ */
+amdsmi_status_t amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(
+    amdsmi_processor_handle processor_handle, amdsmi_accelerator_partition_mem_alloc_mode_t* mode);
+
+/**
  *  @brief Modifies a selected device's compute partition memory allocation mode.
+ *
+ *  @deprecated This API is slated for removal in a future ROCm release;
+ *  ::amdsmi_set_gpu_accelerator_partition_mem_alloc_mode() should be used instead
  *
  *  @ingroup tagComputePartition
  *
@@ -6971,6 +7040,38 @@ amdsmi_status_t amdsmi_get_gpu_compute_partition_mem_alloc_mode(
 amdsmi_status_t amdsmi_set_gpu_compute_partition_mem_alloc_mode(
     amdsmi_processor_handle processor_handle, amdsmi_compute_partition_mem_alloc_mode_t mode);
 
+/**
+ *  @brief Modifies a selected device's compute partition memory allocation mode.
+ *
+ *  @ingroup tagComputePartition
+ *
+ *  @platform{gpu_bm_linux}
+ *
+ *  @details Given a processor handle @p processor_handle and a mode
+ *  @p mode, this function will attempt to update the selected device's
+ *  compute partition memory allocation mode. The mode controls how HBM
+ *  capacity is distributed across XCPs within each memory partition:
+ *  - ::AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING — each XCP is capped
+ *    to an even share. This is the default.
+ *  - ::AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL — each XCP may use the
+ *    full memory partition size.
+ *
+ *  @param[in] processor_handle Device which to modify
+ *
+ *  @param[in] mode using enum ::amdsmi_accelerator_partition_mem_alloc_mode_t,
+ *  define what the selected device's memory allocation mode should be
+ *  updated to.
+ *
+ *  @retval ::AMDSMI_STATUS_SUCCESS call was successful
+ *  @retval ::AMDSMI_STATUS_NO_PERM function requires admin/sudo privileges
+ *  @retval ::AMDSMI_STATUS_INVAL the provided arguments are not valid
+ *  @retval ::AMDSMI_STATUS_FILE_ERROR problem accessing the sysfs file
+ *  @retval ::AMDSMI_STATUS_NOT_SUPPORTED installed software or hardware does not
+ *  support this function
+ */
+amdsmi_status_t amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(
+    amdsmi_processor_handle processor_handle, amdsmi_accelerator_partition_mem_alloc_mode_t mode);
+
 /** @} End tagComputePartition */
 
 /*****************************************************************************/
@@ -6988,8 +7089,8 @@ amdsmi_status_t amdsmi_set_gpu_compute_partition_mem_alloc_mode(
  *  @platform{gpu_bm_linux}
  *
  *  @details
- *  Given a processor handle @p processor_handle and a string @p memory_partition ,
- *  and uint32 @p len , this function will attempt to obtain the device's
+ *  Given a processor handle @p processor_handle and a string @p memory_partition,
+ *  and uint32 @p len, this function will attempt to obtain the device's
  *  memory partition string. Upon successful retrieval, the obtained device's
  *  memory partition string shall be stored in the passed @p memory_partition
  *  char string variable.
@@ -6999,7 +7100,7 @@ amdsmi_status_t amdsmi_set_gpu_compute_partition_mem_alloc_mode(
  *  @param[inout] memory_partition a pointer to a char string variable,
  *  which the device's memory partition will be written to.
  *
- *  @param[in] len the length of the caller provided buffer @p memory_partition ,
+ *  @param[in] len the length of the caller provided buffer @p memory_partition,
  *  suggested length is 5 or greater.
  *
  *  @retval ::AMDSMI_STATUS_SUCCESS call was successful
@@ -7017,6 +7118,9 @@ amdsmi_status_t amdsmi_get_gpu_memory_partition(amdsmi_processor_handle processo
 
 /**
  *  @brief Modifies a selected device's current memory partition setting.
+ *
+ *  @deprecated This API is slated for removal in a future ROCm release;
+ *  ::amdsmi_set_gpu_memory_partition_mode() should be used instead
  *
  *  @ingroup tagMemoryPartition
  *

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -5065,37 +5065,6 @@ amdsmi_status_t amdsmi_get_gpu_reg_table_info(amdsmi_processor_handle processor_
                                               uint32_t* num_of_metrics);
 
 /**
- *  @brief This function sets the clock range information. It is not supported on virtual
- *  machine guest
- *
- *  @deprecated ::amdsmi_set_gpu_clk_limit() should be used, with an
- *  interface that set the min_value and then max_value.
- *
- *  @ingroup tagClkPowerPerfQuery
- *
- *  @platform{gpu_bm_linux}
- *
- *  @details Given a processor handle @p processor_handle, a minimum clock value @p minclkvalue,
- *  a maximum clock value @p maxclkvalue and a clock type @p clkType this function
- *  will set the sclk|mclk range
- *
- *  @param[in] processor_handle a processor handle
- *
- *  @param[in] minclkvalue value to apply to the clock range. Frequency values
- *  are in MHz.
- *
- *  @param[in] maxclkvalue value to apply to the clock range. Frequency values
- *  are in MHz.
- *
- *  @param[in] clkType AMDSMI_CLK_TYPE_SYS | AMDSMI_CLK_TYPE_MEM range type
- *
- *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
- */
-amdsmi_status_t amdsmi_set_gpu_clk_range(amdsmi_processor_handle processor_handle,
-                                         uint64_t minclkvalue, uint64_t maxclkvalue,
-                                         amdsmi_clk_type_t clkType);
-
-/**
  *  @brief This function sets the clock sets the clock min/max level
  *
  *  @ingroup tagClkPowerPerfQuery

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -84,13 +84,6 @@ typedef enum {
  */
 
 /**
- * @brief Unit conversion factor for HBM temperatures
- *
- * @cond @tag{gpu_bm_linux} @endcond
- */
-#define CENTRIGRADE_TO_MILLI_CENTIGRADE 1000
-
-/**
  * @brief This should match NUM_HBM_INSTANCES
  *
  * @cond @tag{gpu_bm_linux} @endcond
@@ -196,7 +189,7 @@ typedef enum {
  *
  * @cond @tag{gpu_bm_linux} @tag{host} @endcond
  */
-#define MAX_NUMBER_OF_AFIDS_PER_RECORD 12  //!< Maximum AFIDs per CPER record
+#define AMDSMI_MAX_NUMBER_OF_AFIDS_PER_RECORD 12  //!< Maximum AFIDs per CPER record
 
 /**
  * @brief Introduced in gpu metrics v1.9+
@@ -316,10 +309,10 @@ typedef struct {
 #define AMDSMI_MAX_SPD_REG_OFFSET 0x7FF        //!< Maximum SPD register offset [22:12]
 #define AMDSMI_MAX_SPD_REG_SPACE 0x1           //!< Maximum SPD register space [23]
 #define AMDSMI_MAX_SPD_WRITE_DATA 0xFF         //!< Maximum SPD write data [31:24]
-#define MAX_SVI3_RAIL_INDEX 4                  //!< Maximum SVI3 rail index
-#define MAX_SVI3_RAIL_SELECTION 1              //!< Maximum SVI3 rail selection
-#define POWER_EFFICIENCY_MODE_4 0x4            //!< Power Efficiency mode selection
-#define POWER_EFFICIENCY_MODE_5 0x5            //!< Power Efficiency mode selection
+#define AMDSMI_MAX_SVI3_RAIL_INDEX 4           //!< Maximum SVI3 rail index
+#define AMDSMI_MAX_SVI3_RAIL_SELECTION 1       //!< Maximum SVI3 rail selection
+#define AMDSMI_POWER_EFFICIENCY_MODE_4 0x4     //!< Power Efficiency mode selection
+#define AMDSMI_POWER_EFFICIENCY_MODE_5 0x5     //!< Power Efficiency mode selection
 #define AMDSMI_MAX_POWER_EFFICIENCY_UTIL 0x7F  //!< [9:3]=Balanced core mode utilization point(%)
 #define AMDSMI_MAX_POWER_EFFICIENCY_PPTLIMIT 0x1FFFFF  //!< [30:10]=Balanced core mode PPT limit(mW)
 #define AMDSMI_RAIL_INDEX_NONE 0xFFFFFFFF  //!< Rail Index value defined as maximum when not passed
@@ -3685,38 +3678,6 @@ amdsmi_status_t amdsmi_get_gpu_vendor_name(amdsmi_processor_handle processor_han
                                            size_t len);
 
 /**
- *  @brief Get the vram vendor string of a device.
- *
- *  @deprecated This API is slated for removal in a future ROCm release;
- *  ::amdsmi_get_gpu_vram_info() should be used instead
- *
- *  @ingroup tagIdentQuery
- *
- *  @platform{gpu_bm_linux}
- *
- *  @details This function retrieves the vram vendor name given a processor handle
- *  @p processor_handle, a pointer to a caller provided
- *  char buffer @p brand, and a length of this buffer @p len, this function
- *  will write the vram vendor of the device (up to @p len characters) to the
- *  buffer @p brand.
- *
- *  If the vram vendor for the device is not found as one of the values
- *  contained within amdsmi_get_gpu_vram_vendor, then this function will return
- *  the string 'unknown' instead of the vram vendor.
- *
- *  @param[in] processor_handle a processor handle
- *
- *  @param[in,out] brand a pointer to a caller provided char buffer to which the
- *  vram vendor will be written
- *
- *  @param[in] len the length of the caller provided buffer @p brand.
- *
- *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
- */
-amdsmi_status_t amdsmi_get_gpu_vram_vendor(amdsmi_processor_handle processor_handle, char* brand,
-                                           uint32_t len);
-
-/**
  *  @brief Get the subsystem device id associated with the device with
  *  provided processor handle.
  *
@@ -5950,6 +5911,8 @@ amdsmi_status_t amdsmi_get_gpu_ecc_count(amdsmi_processor_handle processor_handl
  *  documentation)](https://docs.kernel.org/gpu/amdgpu/ras.html#ras-error-count-sysfs-interface)
  *  to learn how these error counts are accessed.
  *
+ *  @deprecated ::amdsmi_get_gpu_ecc_supported() should be used
+ *
  *  @ingroup tagECCInfo
  *
  *  @platform{gpu_bm_linux} @platform{host}
@@ -5977,6 +5940,41 @@ amdsmi_status_t amdsmi_get_gpu_ecc_count(amdsmi_processor_handle processor_handl
  */
 amdsmi_status_t amdsmi_get_gpu_ecc_enabled(amdsmi_processor_handle processor_handle,
                                            uint64_t* enabled_blocks);
+
+/**
+ *  @brief Retrieve the enabled ECC bit-mask. It is not supported on virtual machine guest
+ *
+ *  See [RAS Error Count sysfs Interface (AMDGPU RAS Support - Linux Kernel
+ *  documentation)](https://docs.kernel.org/gpu/amdgpu/ras.html#ras-error-count-sysfs-interface)
+ *  to learn how these error counts are accessed.
+ *
+ *  @ingroup tagECCInfo
+ *
+ *  @platform{gpu_bm_linux} @platform{host}
+ *
+ *  @details Given a processor handle @p processor_handle, and a pointer to a uint64_t @p
+ *  enabled_mask, this function will write bits to memory pointed to by
+ *  @p enabled_blocks. Upon a successful call, @p enabled_blocks can then be
+ *  AND'd with elements of the ::amdsmi_gpu_block_t ennumeration to determine if
+ *  the corresponding block has ECC enabled.
+ *
+ *  @note Whether a block has ECC enabled or not in the device is independent
+ *  of whether there is kernel support for error counting for that block.
+ *  Although a block may be enabled, but there may not be kernel support for
+ *  reading error counters for that block.
+ *
+ *  @param[in] processor_handle a processor handle
+ *
+ *  @param[in,out] enabled_blocks A pointer to a uint64_t to which the enabled
+ *  blocks bits will be written.
+ *  If this parameter is nullptr, this function will return ::AMDSMI_STATUS_INVAL
+ *  if the function is supported with the provided arguments and ::AMDSMI_STATUS_NOT_SUPPORTED
+ *  if it is not supported with the provided arguments.
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_get_gpu_ecc_supported(amdsmi_processor_handle processor_handle,
+                                             uint64_t* enabled_blocks);
 
 /**
  *  @brief Returns the total number of ECC errors (correctable,
@@ -6082,8 +6080,8 @@ typedef struct {
  *  uint64_t that may be safely written to the memory pointed to by @p afids. This is the limit
  *  on how many AF IDs will be written to @p afids. On return, @p num_afids will contain the
  *  number of AF IDs written to @p afids, or the number of AF IDs that could have been written
- *  if enough memory had been provided. It is suggest to pass MAX_NUMBER_OF_AFIDS_PER_RECORD for all
- *  AF Ids.
+ *  if enough memory had been provided. It is suggest to pass AMDSMI_MAX_NUMBER_OF_AFIDS_PER_RECORD
+ * for all AF Ids.
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -5880,8 +5880,6 @@ amdsmi_status_t amdsmi_get_gpu_ecc_count(amdsmi_processor_handle processor_handl
  *  documentation)](https://docs.kernel.org/gpu/amdgpu/ras.html#ras-error-count-sysfs-interface)
  *  to learn how these error counts are accessed.
  *
- *  @deprecated ::amdsmi_get_gpu_ecc_supported() should be used
- *
  *  @ingroup tagECCInfo
  *
  *  @platform{gpu_bm_linux} @platform{host}

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -5909,41 +5909,6 @@ amdsmi_status_t amdsmi_get_gpu_ecc_enabled(amdsmi_processor_handle processor_han
                                            uint64_t* enabled_blocks);
 
 /**
- *  @brief Retrieve the enabled ECC bit-mask. It is not supported on virtual machine guest
- *
- *  See [RAS Error Count sysfs Interface (AMDGPU RAS Support - Linux Kernel
- *  documentation)](https://docs.kernel.org/gpu/amdgpu/ras.html#ras-error-count-sysfs-interface)
- *  to learn how these error counts are accessed.
- *
- *  @ingroup tagECCInfo
- *
- *  @platform{gpu_bm_linux} @platform{host}
- *
- *  @details Given a processor handle @p processor_handle, and a pointer to a uint64_t @p
- *  enabled_mask, this function will write bits to memory pointed to by
- *  @p enabled_blocks. Upon a successful call, @p enabled_blocks can then be
- *  AND'd with elements of the ::amdsmi_gpu_block_t ennumeration to determine if
- *  the corresponding block has ECC enabled.
- *
- *  @note Whether a block has ECC enabled or not in the device is independent
- *  of whether there is kernel support for error counting for that block.
- *  Although a block may be enabled, but there may not be kernel support for
- *  reading error counters for that block.
- *
- *  @param[in] processor_handle a processor handle
- *
- *  @param[in,out] enabled_blocks A pointer to a uint64_t to which the enabled
- *  blocks bits will be written.
- *  If this parameter is nullptr, this function will return ::AMDSMI_STATUS_INVAL
- *  if the function is supported with the provided arguments and ::AMDSMI_STATUS_NOT_SUPPORTED
- *  if it is not supported with the provided arguments.
- *
- *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
- */
-amdsmi_status_t amdsmi_get_gpu_ecc_supported(amdsmi_processor_handle processor_handle,
-                                             uint64_t* enabled_blocks);
-
-/**
  *  @brief Returns the total number of ECC errors (correctable,
  *         uncorrectable and deferred) in the given GPU. It is not supported on
  *         virtual machine guest

--- a/projects/amdsmi/py-interface/__init__.py
+++ b/projects/amdsmi/py-interface/__init__.py
@@ -281,13 +281,15 @@ from .amdsmi_interface import amdsmi_get_gpu_compute_partition
 from .amdsmi_interface import amdsmi_set_gpu_compute_partition
 from .amdsmi_interface import amdsmi_get_gpu_compute_partition_mem_alloc_mode
 from .amdsmi_interface import amdsmi_set_gpu_compute_partition_mem_alloc_mode
+from .amdsmi_interface import amdsmi_get_gpu_accelerator_partition_mem_alloc_mode
+from .amdsmi_interface import amdsmi_set_gpu_accelerator_partition_mem_alloc_mode
 from .amdsmi_interface import amdsmi_get_gpu_memory_partition
 from .amdsmi_interface import amdsmi_set_gpu_memory_partition
+from .amdsmi_interface import amdsmi_set_gpu_memory_partition_mode
 from .amdsmi_interface import amdsmi_get_gpu_accelerator_partition_profile
 from .amdsmi_interface import amdsmi_get_gpu_accelerator_partition_profile_config
 from .amdsmi_interface import amdsmi_get_gpu_memory_partition_config
 from .amdsmi_interface import amdsmi_set_gpu_accelerator_partition_profile
-from .amdsmi_interface import amdsmi_set_gpu_memory_partition_mode
 
 # # Individual GPU Metrics Functions
 from .amdsmi_interface import amdsmi_get_gpu_metrics_header_info
@@ -330,6 +332,7 @@ from .amdsmi_interface import AmdSmiVoltageMetric
 from .amdsmi_interface import AmdSmiVoltageType
 from .amdsmi_interface import AmdSmiComputePartitionType
 from .amdsmi_interface import AmdSmiComputePartitionMemAllocModeType
+from .amdsmi_interface import AmdSmiAcceleratorPartitionMemAllocModeType
 from .amdsmi_interface import AmdSmiMemoryPartitionType
 from .amdsmi_interface import AmdSmiPowerProfilePresetMasks
 from .amdsmi_interface import AmdSmiGpuBlock

--- a/projects/amdsmi/py-interface/__init__.py
+++ b/projects/amdsmi/py-interface/__init__.py
@@ -180,7 +180,6 @@ from .amdsmi_interface import amdsmi_gpu_validate_ras_eeprom
 from .amdsmi_interface import amdsmi_set_gpu_pci_bandwidth
 from .amdsmi_interface import amdsmi_set_power_cap
 from .amdsmi_interface import amdsmi_set_gpu_power_profile
-from .amdsmi_interface import amdsmi_set_gpu_clk_range
 from .amdsmi_interface import amdsmi_set_gpu_clk_limit
 from .amdsmi_interface import amdsmi_set_gpu_od_clk_info
 from .amdsmi_interface import amdsmi_set_gpu_od_volt_info

--- a/projects/amdsmi/py-interface/__init__.py
+++ b/projects/amdsmi/py-interface/__init__.py
@@ -230,7 +230,6 @@ from .amdsmi_interface import amdsmi_get_gpu_available_counters
 # # Error Query
 from .amdsmi_interface import amdsmi_get_gpu_ecc_count
 from .amdsmi_interface import amdsmi_get_gpu_ecc_enabled
-from .amdsmi_interface import amdsmi_get_gpu_ecc_supported
 from .amdsmi_interface import amdsmi_get_gpu_ecc_status
 from .amdsmi_interface import amdsmi_status_code_to_string
 

--- a/projects/amdsmi/py-interface/__init__.py
+++ b/projects/amdsmi/py-interface/__init__.py
@@ -38,7 +38,6 @@ from .amdsmi_interface import amdsmi_get_npm_info
 # ESMI Dependent Functions
 try:
     from .amdsmi_interface import amdsmi_get_cpu_handles
-    from .amdsmi_interface import amdsmi_get_cpusocket_handles  # Deprecate in 8.0
     from .amdsmi_interface import amdsmi_get_cpucore_handles
     from .amdsmi_interface import amdsmi_get_cpu_hsmp_proto_ver
     from .amdsmi_interface import amdsmi_get_cpu_smu_fw_version
@@ -232,6 +231,7 @@ from .amdsmi_interface import amdsmi_get_gpu_available_counters
 # # Error Query
 from .amdsmi_interface import amdsmi_get_gpu_ecc_count
 from .amdsmi_interface import amdsmi_get_gpu_ecc_enabled
+from .amdsmi_interface import amdsmi_get_gpu_ecc_supported
 from .amdsmi_interface import amdsmi_get_gpu_ecc_status
 from .amdsmi_interface import amdsmi_status_code_to_string
 
@@ -264,7 +264,6 @@ from .amdsmi_interface import AmdSmiEventReader
 # # Device Identification information
 from .amdsmi_interface import amdsmi_get_gpu_vendor_name
 from .amdsmi_interface import amdsmi_get_gpu_id
-from .amdsmi_interface import amdsmi_get_gpu_vram_vendor
 from .amdsmi_interface import amdsmi_get_gpu_subsystem_id
 from .amdsmi_interface import amdsmi_get_gpu_subsystem_name
 

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -6392,16 +6392,8 @@ def amdsmi_get_gpu_ecc_count(
 
 
 def amdsmi_get_gpu_ecc_enabled(processor_handle: processor_handle_t) -> int:
-    """Deprecated: use amdsmi_get_gpu_ecc_supported() instead."""
-
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
-
-    warnings.warn(
-        "amdsmi_get_gpu_ecc_enabled() is deprecated, use amdsmi_get_gpu_ecc_supported() instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
 
     blocks = amdsmi_get_gpu_ecc_supported(processor_handle)
     return blocks

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -6395,16 +6395,8 @@ def amdsmi_get_gpu_ecc_enabled(processor_handle: processor_handle_t) -> int:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
-    blocks = amdsmi_get_gpu_ecc_supported(processor_handle)
-    return blocks
-
-
-def amdsmi_get_gpu_ecc_supported(processor_handle: processor_handle_t) -> int:
-    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
-        raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
-
     blocks = ctypes.c_uint64(0)
-    _check_res(amdsmi_wrapper.amdsmi_get_gpu_ecc_supported(processor_handle, ctypes.byref(blocks)))
+    _check_res(amdsmi_wrapper.amdsmi_get_gpu_ecc_enabled(processor_handle, ctypes.byref(blocks)))
 
     return blocks.value
 

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -265,8 +265,8 @@ class AmdSmiClkType(IntEnum):
 
 
 class AmdSmiClkLimitType(IntEnum):
-    MIN = amdsmi_wrapper.CLK_LIMIT_MIN
-    MAX = amdsmi_wrapper.CLK_LIMIT_MAX
+    MIN = amdsmi_wrapper.AMDSMI_CLK_LIMIT_MIN
+    MAX = amdsmi_wrapper.AMDSMI_CLK_LIMIT_MAX
 
 
 class AmdSmiTemperatureType(IntEnum):
@@ -564,6 +564,7 @@ class AmdSmiAcceleratorPartitionType(IntEnum):
     INVALID = amdsmi_wrapper.AMDSMI_ACCELERATOR_PARTITION_INVALID
 
 
+# This class is deprecated, use AmdSmiAcceleratorPartitionType instead
 class AmdSmiComputePartitionType(IntEnum):
     SPX = amdsmi_wrapper.AMDSMI_COMPUTE_PARTITION_SPX
     DPX = amdsmi_wrapper.AMDSMI_COMPUTE_PARTITION_DPX
@@ -573,10 +574,17 @@ class AmdSmiComputePartitionType(IntEnum):
     INVALID = amdsmi_wrapper.AMDSMI_COMPUTE_PARTITION_INVALID
 
 
+# This class is deprecated, use AmdSmiAcceleratorPartitionMemAllocModeType instead
 class AmdSmiComputePartitionMemAllocModeType(IntEnum):
     INVALID = amdsmi_wrapper.AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_INVALID
     CAPPING = amdsmi_wrapper.AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING
     ALL = amdsmi_wrapper.AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL
+
+
+class AmdSmiAcceleratorPartitionMemAllocModeType(IntEnum):
+    INVALID = amdsmi_wrapper.AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_INVALID
+    CAPPING = amdsmi_wrapper.AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING
+    ALL = amdsmi_wrapper.AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL
 
 
 class AmdSmiMemoryPartitionType(IntEnum):
@@ -2459,7 +2467,6 @@ def amdsmi_get_gpu_device_bdf_bdf(
     Returns the raw amdsmi_bdf_t struct for a GPU. The same data is available as a
     formatted string from amdsmi_get_gpu_device_bdf().
     """
-    import warnings
 
     warnings.warn(
         "amdsmi_get_gpu_device_bdf_bdf() is deprecated, use amdsmi_get_gpu_device_bdf() "
@@ -4307,8 +4314,16 @@ def amdsmi_is_P2P_accessible(
 
 
 def amdsmi_get_gpu_compute_partition(processor_handle: processor_handle_t):
+    """Deprecated: use amdsmi_get_gpu_accelerator_partition_profile() instead."""
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
+
+    warnings.warn(
+        "amdsmi_get_gpu_compute_partition() is deprecated, "
+        "use amdsmi_get_gpu_accelerator_partition_profile() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     length = ctypes.c_uint32()
     length.value = AMDSMI_MAX_STRING_LENGTH
@@ -4325,6 +4340,14 @@ def amdsmi_get_gpu_compute_partition(processor_handle: processor_handle_t):
 def amdsmi_set_gpu_compute_partition(
     processor_handle: processor_handle_t, compute_partition: AmdSmiComputePartitionType
 ):
+    """Deprecated: use amdsmi_set_gpu_accelerator_partition_profile() instead."""
+
+    warnings.warn(
+        "amdsmi_set_gpu_compute_partition() is deprecated, "
+        "use amdsmi_set_gpu_accelerator_partition_profile() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
@@ -4336,29 +4359,57 @@ def amdsmi_set_gpu_compute_partition(
 
 
 def amdsmi_get_gpu_compute_partition_mem_alloc_mode(processor_handle: processor_handle_t):
+    """Deprecated: use amdsmi_get_gpu_accelerator_partition_mem_alloc_mode() instead."""
+
+    warnings.warn(
+        "amdsmi_get_gpu_compute_partition_mem_alloc_mode() is deprecated, "
+        "use amdsmi_get_gpu_accelerator_partition_mem_alloc_mode() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    name = amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(processor_handle)
+    return name
+
+
+def amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(processor_handle: processor_handle_t):
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
-    mode = amdsmi_wrapper.amdsmi_compute_partition_mem_alloc_mode_t()
+    mode = amdsmi_wrapper.amdsmi_accelerator_partition_mem_alloc_mode_t()
     _check_res(
-        amdsmi_wrapper.amdsmi_get_gpu_compute_partition_mem_alloc_mode(
+        amdsmi_wrapper.amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(
             processor_handle, ctypes.byref(mode)
         )
     )
-    return AmdSmiComputePartitionMemAllocModeType(mode.value).name
+    return AmdSmiAcceleratorPartitionMemAllocModeType(mode.value).name
 
 
 def amdsmi_set_gpu_compute_partition_mem_alloc_mode(
     processor_handle: processor_handle_t, mode: AmdSmiComputePartitionMemAllocModeType
 ):
+    """Deprecated: use amdsmi_set_gpu_accelerator_partition_mem_alloc_mode() instead."""
+
+    warnings.warn(
+        "amdsmi_set_gpu_compute_partition_mem_alloc_mode() is deprecated, "
+        "use amdsmi_set_gpu_accelerator_partition_mem_alloc_mode() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    acc_mode = AmdSmiAcceleratorPartitionMemAllocModeType(mode)
+    amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(processor_handle, acc_mode)
+
+
+def amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(
+    processor_handle: processor_handle_t, mode: AmdSmiAcceleratorPartitionMemAllocModeType
+):
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
-    if not isinstance(mode, AmdSmiComputePartitionMemAllocModeType):
-        raise AmdSmiParameterException(mode, AmdSmiComputePartitionMemAllocModeType)
+    if not isinstance(mode, AmdSmiAcceleratorPartitionMemAllocModeType):
+        raise AmdSmiParameterException(mode, AmdSmiAcceleratorPartitionMemAllocModeType)
 
     _check_res(
-        amdsmi_wrapper.amdsmi_set_gpu_compute_partition_mem_alloc_mode(processor_handle, mode)
+        amdsmi_wrapper.amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(processor_handle, mode)
     )
 
 
@@ -4430,13 +4481,14 @@ def amdsmi_get_gpu_memory_partition_config(processor_handle: processor_handle_t)
 def amdsmi_set_gpu_memory_partition(
     processor_handle: processor_handle_t, memory_partition: AmdSmiMemoryPartitionType
 ):
-    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
-        raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
+    """Deprecated: Use amdsmi_set_gpu_memory_partition_mode() instead.  Will be deprecated in future ROCM release"""
 
-    if not isinstance(memory_partition, AmdSmiMemoryPartitionType):
-        raise AmdSmiParameterException(memory_partition, AmdSmiMemoryPartitionType)
-
-    _check_res(amdsmi_wrapper.amdsmi_set_gpu_memory_partition(processor_handle, memory_partition))
+    warnings.warn(
+        "amdsmi_set_gpu_memory_partition() is deprecated, use amdsmi_set_gpu_memory_partition_mode() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    amdsmi_set_gpu_memory_partition_mode(processor_handle, memory_partition)
 
 
 def amdsmi_set_gpu_memory_partition_mode(
@@ -4448,7 +4500,9 @@ def amdsmi_set_gpu_memory_partition_mode(
     if not isinstance(memory_partition, AmdSmiMemoryPartitionType):
         raise AmdSmiParameterException(memory_partition, AmdSmiMemoryPartitionType)
 
-    _check_res(amdsmi_wrapper.amdsmi_set_gpu_memory_partition(processor_handle, memory_partition))
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_gpu_memory_partition_mode(processor_handle, memory_partition)
+    )
 
 
 def amdsmi_get_gpu_accelerator_partition_profile(
@@ -5089,9 +5143,9 @@ def amdsmi_set_gpu_clk_limit(
         raise AmdSmiParameterException(f"Unsupported clock type: {clk_type}", str)
 
     if limit_type.lower() == "min":
-        limit_type_conversion = amdsmi_wrapper.CLK_LIMIT_MIN
+        limit_type_conversion = amdsmi_wrapper.AMDSMI_CLK_LIMIT_MIN
     elif limit_type.lower() == "max":
-        limit_type_conversion = amdsmi_wrapper.CLK_LIMIT_MAX
+        limit_type_conversion = amdsmi_wrapper.AMDSMI_CLK_LIMIT_MAX
     else:
         raise AmdSmiParameterException(f"Unsupported limit type: {limit_type}", str)
     _check_res(

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -5068,34 +5068,6 @@ def amdsmi_get_energy_count(processor_handle: processor_handle_t):
     }
 
 
-def amdsmi_set_gpu_clk_range(
-    processor_handle: processor_handle_t,
-    min_clk_value: int,
-    max_clk_value: int,
-    clk_type: AmdSmiClkType,
-) -> None:
-    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
-        raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
-
-    if not isinstance(min_clk_value, int):
-        raise AmdSmiParameterException(min_clk_value, int)
-
-    if not isinstance(max_clk_value, int):
-        raise AmdSmiParameterException(min_clk_value, int)
-
-    if not isinstance(clk_type, AmdSmiClkType):
-        raise AmdSmiParameterException(clk_type, AmdSmiClkType)
-
-    _check_res(
-        amdsmi_wrapper.amdsmi_set_gpu_clk_range(
-            processor_handle,
-            ctypes.c_uint64(min_clk_value),
-            ctypes.c_uint64(max_clk_value),
-            clk_type,
-        )
-    )
-
-
 def amdsmi_set_gpu_clk_limit(
     processor_handle: processor_handle_t, clk_type: str, limit_type: str, value: int
 ) -> None:

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -21,6 +21,7 @@ import ctypes
 import math
 import os
 import re
+import warnings
 from collections.abc import Iterable
 from ctypes import POINTER, c_void_p
 from enum import IntEnum, Enum
@@ -61,7 +62,7 @@ AMDSMI_MAX_NUM_XCC = 8
 AMDSMI_MAX_NUM_XCP = 8
 
 # max num afids per cper record
-MAX_NUMBER_OF_AFIDS_PER_RECORD = 12
+AMDSMI_MAX_NUMBER_OF_AFIDS_PER_RECORD = 12
 
 # Max number of DPM policies
 AMDSMI_MAX_NUM_PM_POLICIES = 32
@@ -1169,24 +1170,6 @@ def amdsmi_get_cpu_handles() -> Dict[str, Any]:
         for sock_idx in range(cpu_count.value)
     ]
     return {"cpu_count": len(cpu_handles), "processor_handles": cpu_handles}
-
-
-def amdsmi_get_cpusocket_handles() -> List[c_void_p]:
-    """Deprecated: Use amdsmi_get_cpu_handles() instead.\
-        Will be deprecated in Rocm 8.0.
-
-    Returns:
-        `List[c_void_p]`: List of CPU socket handles (legacy format).
-    """
-    import warnings
-
-    warnings.warn(
-        "amdsmi_get_cpusocket_handles() is deprecated, use amdsmi_get_cpu_handles() instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    result = amdsmi_get_cpu_handles()
-    return result["processor_handles"]
 
 
 def amdsmi_get_socket_info(socket_handle):
@@ -3576,8 +3559,8 @@ def amdsmi_get_afids_from_cper(cper_afid_data: bytes) -> Tuple[List[int], int]:
         buf = ctypes.create_string_buffer(raw_bytes, record_size)
         buf_ptr = ctypes.cast(buf, POINTER(ctypes.c_char))
 
-        afid_array = (ctypes.c_uint64 * MAX_NUMBER_OF_AFIDS_PER_RECORD)()
-        num_afids_ct = ctypes.c_uint32(MAX_NUMBER_OF_AFIDS_PER_RECORD)
+        afid_array = (ctypes.c_uint64 * AMDSMI_MAX_NUMBER_OF_AFIDS_PER_RECORD)()
+        num_afids_ct = ctypes.c_uint32(AMDSMI_MAX_NUMBER_OF_AFIDS_PER_RECORD)
 
         # Call the wrapper function
         status = amdsmi_wrapper.amdsmi_get_afids_from_cper(
@@ -4091,31 +4074,6 @@ def amdsmi_get_gpu_id(processor_handle: processor_handle_t):
     _check_res(amdsmi_wrapper.amdsmi_get_gpu_id(processor_handle, ctypes.byref(gpu_id_16)))
 
     return gpu_id_16.value
-
-
-def amdsmi_get_gpu_vram_vendor(processor_handle: processor_handle_t):
-    """Deprecated: use amdsmi_get_gpu_vram_info() instead.
-
-    This API is slated for removal in a future ROCm release.
-    """
-    import warnings
-
-    warnings.warn(
-        "amdsmi_get_gpu_vram_vendor() is deprecated, use amdsmi_get_gpu_vram_info() instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
-        raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
-
-    length = ctypes.c_uint32()
-    length.value = AMDSMI_MAX_STRING_LENGTH
-
-    vram_vendor = ctypes.create_string_buffer(AMDSMI_MAX_STRING_LENGTH)
-
-    _check_res(amdsmi_wrapper.amdsmi_get_gpu_vram_vendor(processor_handle, vram_vendor, length))
-
-    return vram_vendor.value.decode("utf-8")
 
 
 def amdsmi_get_gpu_subsystem_id(processor_handle: processor_handle_t):
@@ -5534,7 +5492,6 @@ def amdsmi_get_xgmi_plpd(processor_handle: processor_handle_t) -> Dict[str, Any]
     return {
         "num_supported": policy.num_supported,
         "current_id": current_id,
-        "plpds": policies,  # Marked for deprecation
         "policies": policies,  # Correct field name
     }
 
@@ -6463,11 +6420,27 @@ def amdsmi_get_gpu_ecc_count(
 
 
 def amdsmi_get_gpu_ecc_enabled(processor_handle: processor_handle_t) -> int:
+    """Deprecated: use amdsmi_get_gpu_ecc_supported() instead."""
+
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
+
+    warnings.warn(
+        "amdsmi_get_gpu_ecc_enabled() is deprecated, use amdsmi_get_gpu_ecc_supported() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    blocks = amdsmi_get_gpu_ecc_supported(processor_handle)
+    return blocks
+
+
+def amdsmi_get_gpu_ecc_supported(processor_handle: processor_handle_t) -> int:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
     blocks = ctypes.c_uint64(0)
-    _check_res(amdsmi_wrapper.amdsmi_get_gpu_ecc_enabled(processor_handle, ctypes.byref(blocks)))
+    _check_res(amdsmi_wrapper.amdsmi_get_gpu_ecc_supported(processor_handle, ctypes.byref(blocks)))
 
     return blocks.value
 

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -570,6 +570,17 @@ AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING = 1
 AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL = 2
 amdsmi_compute_partition_mem_alloc_mode_t = ctypes.c_uint32 # enum
 
+# values for enumeration 'amdsmi_accelerator_partition_mem_alloc_mode_t'
+amdsmi_accelerator_partition_mem_alloc_mode_t__enumvalues = {
+    0: 'AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_INVALID',
+    1: 'AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING',
+    2: 'AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL',
+}
+AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_INVALID = 0
+AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING = 1
+AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL = 2
+amdsmi_accelerator_partition_mem_alloc_mode_t = ctypes.c_uint32 # enum
+
 # values for enumeration 'amdsmi_memory_partition_type_t'
 amdsmi_memory_partition_type_t__enumvalues = {
     0: 'AMDSMI_MEMORY_PARTITION_UNKNOWN',
@@ -1993,9 +2004,13 @@ amdsmi_gpu_block_t = ctypes.c_uint64 # enum
 
 # values for enumeration 'amdsmi_clk_limit_type_t'
 amdsmi_clk_limit_type_t__enumvalues = {
+    0: 'AMDSMI_CLK_LIMIT_MIN',
+    1: 'AMDSMI_CLK_LIMIT_MAX',
     0: 'CLK_LIMIT_MIN',
     1: 'CLK_LIMIT_MAX',
 }
+AMDSMI_CLK_LIMIT_MIN = 0
+AMDSMI_CLK_LIMIT_MAX = 1
 CLK_LIMIT_MIN = 0
 CLK_LIMIT_MAX = 1
 amdsmi_clk_limit_type_t = ctypes.c_uint32 # enum
@@ -2776,10 +2791,16 @@ amdsmi_dimm_thermal_t = struct_amdsmi_dimm_thermal_t
 
 # values for enumeration 'amdsmi_io_bw_encoding_t'
 amdsmi_io_bw_encoding_t__enumvalues = {
+    1: 'AMDSMI_AGG_BW0',
+    2: 'AMDSMI_RD_BW0',
+    4: 'AMDSMI_WR_BW0',
     1: 'AGG_BW0',
     2: 'RD_BW0',
     4: 'WR_BW0',
 }
+AMDSMI_AGG_BW0 = 1
+AMDSMI_RD_BW0 = 2
+AMDSMI_WR_BW0 = 4
 AGG_BW0 = 1
 RD_BW0 = 2
 WR_BW0 = 4
@@ -4109,9 +4130,21 @@ try:
 except AttributeError:
     pass
 try:
+    amdsmi_get_gpu_accelerator_partition_mem_alloc_mode = _libraries['libamd_smi.so'].amdsmi_get_gpu_accelerator_partition_mem_alloc_mode
+    amdsmi_get_gpu_accelerator_partition_mem_alloc_mode.restype = amdsmi_status_t
+    amdsmi_get_gpu_accelerator_partition_mem_alloc_mode.argtypes = [amdsmi_processor_handle, ctypes.POINTER(amdsmi_accelerator_partition_mem_alloc_mode_t)]
+except AttributeError:
+    pass
+try:
     amdsmi_set_gpu_compute_partition_mem_alloc_mode = _libraries['libamd_smi.so'].amdsmi_set_gpu_compute_partition_mem_alloc_mode
     amdsmi_set_gpu_compute_partition_mem_alloc_mode.restype = amdsmi_status_t
     amdsmi_set_gpu_compute_partition_mem_alloc_mode.argtypes = [amdsmi_processor_handle, amdsmi_compute_partition_mem_alloc_mode_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_accelerator_partition_mem_alloc_mode = _libraries['libamd_smi.so'].amdsmi_set_gpu_accelerator_partition_mem_alloc_mode
+    amdsmi_set_gpu_accelerator_partition_mem_alloc_mode.restype = amdsmi_status_t
+    amdsmi_set_gpu_accelerator_partition_mem_alloc_mode.argtypes = [amdsmi_processor_handle, amdsmi_accelerator_partition_mem_alloc_mode_t]
 except AttributeError:
     pass
 try:
@@ -4863,17 +4896,21 @@ __all__ = \
     'AMDSMI_ACCELERATOR_PARTITION_DPX',
     'AMDSMI_ACCELERATOR_PARTITION_INVALID',
     'AMDSMI_ACCELERATOR_PARTITION_MAX',
+    'AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL',
+    'AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING',
+    'AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_INVALID',
     'AMDSMI_ACCELERATOR_PARTITION_QPX',
     'AMDSMI_ACCELERATOR_PARTITION_SPX',
     'AMDSMI_ACCELERATOR_PARTITION_TPX', 'AMDSMI_ACCELERATOR_XCC',
     'AMDSMI_AFFINITY_SCOPE_NODE', 'AMDSMI_AFFINITY_SCOPE_SOCKET',
-    'AMDSMI_CACHE_PROPERTY_CPU_CACHE',
+    'AMDSMI_AGG_BW0', 'AMDSMI_CACHE_PROPERTY_CPU_CACHE',
     'AMDSMI_CACHE_PROPERTY_DATA_CACHE',
     'AMDSMI_CACHE_PROPERTY_ENABLED',
     'AMDSMI_CACHE_PROPERTY_INST_CACHE',
     'AMDSMI_CACHE_PROPERTY_SIMD_CACHE', 'AMDSMI_CARD_FORM_FACTOR_CEM',
     'AMDSMI_CARD_FORM_FACTOR_OAM', 'AMDSMI_CARD_FORM_FACTOR_PCIE',
-    'AMDSMI_CARD_FORM_FACTOR_UNKNOWN', 'AMDSMI_CLK_TYPE_DCEF',
+    'AMDSMI_CARD_FORM_FACTOR_UNKNOWN', 'AMDSMI_CLK_LIMIT_MAX',
+    'AMDSMI_CLK_LIMIT_MIN', 'AMDSMI_CLK_TYPE_DCEF',
     'AMDSMI_CLK_TYPE_DCLK0', 'AMDSMI_CLK_TYPE_DCLK1',
     'AMDSMI_CLK_TYPE_DF', 'AMDSMI_CLK_TYPE_FIRST',
     'AMDSMI_CLK_TYPE_GFX', 'AMDSMI_CLK_TYPE_MEM',
@@ -5059,7 +5096,7 @@ __all__ = \
     'AMDSMI_RAS_ERR_STATE_INVALID', 'AMDSMI_RAS_ERR_STATE_LAST',
     'AMDSMI_RAS_ERR_STATE_MULT_UC', 'AMDSMI_RAS_ERR_STATE_NONE',
     'AMDSMI_RAS_ERR_STATE_PARITY', 'AMDSMI_RAS_ERR_STATE_POISON',
-    'AMDSMI_RAS_ERR_STATE_SING_C', 'AMDSMI_REG_PCIE',
+    'AMDSMI_RAS_ERR_STATE_SING_C', 'AMDSMI_RD_BW0', 'AMDSMI_REG_PCIE',
     'AMDSMI_REG_USR', 'AMDSMI_REG_USR1', 'AMDSMI_REG_WAFL',
     'AMDSMI_REG_XGMI', 'AMDSMI_STATUS_ADDRESS_FAULT',
     'AMDSMI_STATUS_AMDGPU_RESTART_ERR', 'AMDSMI_STATUS_API_FAILED',
@@ -5185,11 +5222,13 @@ __all__ = \
     'AMDSMI_VRAM_TYPE_HBM2E', 'AMDSMI_VRAM_TYPE_HBM3',
     'AMDSMI_VRAM_TYPE_HBM3E', 'AMDSMI_VRAM_TYPE_LPDDR4',
     'AMDSMI_VRAM_TYPE_LPDDR5', 'AMDSMI_VRAM_TYPE_UNKNOWN',
-    'AMDSMI_VRAM_TYPE__MAX', 'AMDSMI_XGMI_LINK_DISABLE',
-    'AMDSMI_XGMI_LINK_DOWN', 'AMDSMI_XGMI_LINK_UP',
-    'AMDSMI_XGMI_STATUS_ERROR', 'AMDSMI_XGMI_STATUS_MULTIPLE_ERRORS',
+    'AMDSMI_VRAM_TYPE__MAX', 'AMDSMI_WR_BW0',
+    'AMDSMI_XGMI_LINK_DISABLE', 'AMDSMI_XGMI_LINK_DOWN',
+    'AMDSMI_XGMI_LINK_UP', 'AMDSMI_XGMI_STATUS_ERROR',
+    'AMDSMI_XGMI_STATUS_MULTIPLE_ERRORS',
     'AMDSMI_XGMI_STATUS_NO_ERRORS', 'CLK_LIMIT_MAX', 'CLK_LIMIT_MIN',
     'RD_BW0', 'WR_BW0', 'amd_metrics_table_header_t',
+    'amdsmi_accelerator_partition_mem_alloc_mode_t',
     'amdsmi_accelerator_partition_profile_config_t',
     'amdsmi_accelerator_partition_profile_t',
     'amdsmi_accelerator_partition_resource_profile_t',
@@ -5273,6 +5312,7 @@ __all__ = \
     'amdsmi_get_cpu_xgmi_pstate_range', 'amdsmi_get_cpucore_handles',
     'amdsmi_get_energy_count', 'amdsmi_get_esmi_err_msg',
     'amdsmi_get_fabric_telemetry_data', 'amdsmi_get_fw_info',
+    'amdsmi_get_gpu_accelerator_partition_mem_alloc_mode',
     'amdsmi_get_gpu_accelerator_partition_profile',
     'amdsmi_get_gpu_accelerator_partition_profile_config',
     'amdsmi_get_gpu_activity', 'amdsmi_get_gpu_asic_info',
@@ -5399,6 +5439,7 @@ __all__ = \
     'amdsmi_set_cpu_socket_lclk_dpm_level',
     'amdsmi_set_cpu_socket_power_cap',
     'amdsmi_set_cpu_xgmi_pstate_range', 'amdsmi_set_cpu_xgmi_width',
+    'amdsmi_set_gpu_accelerator_partition_mem_alloc_mode',
     'amdsmi_set_gpu_accelerator_partition_profile',
     'amdsmi_set_gpu_clk_limit', 'amdsmi_set_gpu_compute_partition',
     'amdsmi_set_gpu_compute_partition_mem_alloc_mode',

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -3217,12 +3217,6 @@ try:
 except AttributeError:
     pass
 try:
-    amdsmi_get_gpu_vram_vendor = _libraries['libamd_smi.so'].amdsmi_get_gpu_vram_vendor
-    amdsmi_get_gpu_vram_vendor.restype = amdsmi_status_t
-    amdsmi_get_gpu_vram_vendor.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_char), uint32_t]
-except AttributeError:
-    pass
-try:
     amdsmi_get_gpu_subsystem_id = _libraries['libamd_smi.so'].amdsmi_get_gpu_subsystem_id
     amdsmi_get_gpu_subsystem_id.restype = amdsmi_status_t
     amdsmi_get_gpu_subsystem_id.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint16)]
@@ -3863,6 +3857,12 @@ try:
     amdsmi_get_gpu_ecc_enabled = _libraries['libamd_smi.so'].amdsmi_get_gpu_ecc_enabled
     amdsmi_get_gpu_ecc_enabled.restype = amdsmi_status_t
     amdsmi_get_gpu_ecc_enabled.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_ecc_supported = _libraries['libamd_smi.so'].amdsmi_get_gpu_ecc_supported
+    amdsmi_get_gpu_ecc_supported.restype = amdsmi_status_t
+    amdsmi_get_gpu_ecc_supported.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64)]
 except AttributeError:
     pass
 try:
@@ -5300,7 +5300,8 @@ __all__ = \
     'amdsmi_get_gpu_cper_entries', 'amdsmi_get_gpu_device_bdf',
     'amdsmi_get_gpu_device_uuid', 'amdsmi_get_gpu_driver_info',
     'amdsmi_get_gpu_ecc_count', 'amdsmi_get_gpu_ecc_enabled',
-    'amdsmi_get_gpu_ecc_status', 'amdsmi_get_gpu_enumeration_info',
+    'amdsmi_get_gpu_ecc_status', 'amdsmi_get_gpu_ecc_supported',
+    'amdsmi_get_gpu_enumeration_info',
     'amdsmi_get_gpu_event_notification', 'amdsmi_get_gpu_fabric_info',
     'amdsmi_get_gpu_fan_rpms', 'amdsmi_get_gpu_fan_speed',
     'amdsmi_get_gpu_fan_speed_max', 'amdsmi_get_gpu_id',
@@ -5332,8 +5333,8 @@ __all__ = \
     'amdsmi_get_gpu_vendor_name',
     'amdsmi_get_gpu_virtualization_mode',
     'amdsmi_get_gpu_volt_metric', 'amdsmi_get_gpu_vram_info',
-    'amdsmi_get_gpu_vram_usage', 'amdsmi_get_gpu_vram_vendor',
-    'amdsmi_get_gpu_xcd_counter', 'amdsmi_get_gpu_xgmi_link_status',
+    'amdsmi_get_gpu_vram_usage', 'amdsmi_get_gpu_xcd_counter',
+    'amdsmi_get_gpu_xgmi_link_status',
     'amdsmi_get_hsmp_metrics_table',
     'amdsmi_get_hsmp_metrics_table_version', 'amdsmi_get_lib_version',
     'amdsmi_get_link_metrics', 'amdsmi_get_link_topology_nearest',

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -3512,12 +3512,6 @@ try:
 except AttributeError:
     pass
 try:
-    amdsmi_set_gpu_clk_range = _libraries['libamd_smi.so'].amdsmi_set_gpu_clk_range
-    amdsmi_set_gpu_clk_range.restype = amdsmi_status_t
-    amdsmi_set_gpu_clk_range.argtypes = [amdsmi_processor_handle, uint64_t, uint64_t, amdsmi_clk_type_t]
-except AttributeError:
-    pass
-try:
     amdsmi_set_gpu_clk_limit = _libraries['libamd_smi.so'].amdsmi_set_gpu_clk_limit
     amdsmi_set_gpu_clk_limit.restype = amdsmi_status_t
     amdsmi_set_gpu_clk_limit.argtypes = [amdsmi_processor_handle, amdsmi_clk_type_t, amdsmi_clk_limit_type_t, uint64_t]
@@ -5413,8 +5407,7 @@ __all__ = \
     'amdsmi_set_cpu_socket_power_cap',
     'amdsmi_set_cpu_xgmi_pstate_range', 'amdsmi_set_cpu_xgmi_width',
     'amdsmi_set_gpu_accelerator_partition_profile',
-    'amdsmi_set_gpu_clk_limit', 'amdsmi_set_gpu_clk_range',
-    'amdsmi_set_gpu_compute_partition',
+    'amdsmi_set_gpu_clk_limit', 'amdsmi_set_gpu_compute_partition',
     'amdsmi_set_gpu_compute_partition_mem_alloc_mode',
     'amdsmi_set_gpu_event_notification_mask',
     'amdsmi_set_gpu_fan_speed', 'amdsmi_set_gpu_memory_partition',

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -3854,12 +3854,6 @@ try:
 except AttributeError:
     pass
 try:
-    amdsmi_get_gpu_ecc_supported = _libraries['libamd_smi.so'].amdsmi_get_gpu_ecc_supported
-    amdsmi_get_gpu_ecc_supported.restype = amdsmi_status_t
-    amdsmi_get_gpu_ecc_supported.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64)]
-except AttributeError:
-    pass
-try:
     amdsmi_get_gpu_total_ecc_count = _libraries['libamd_smi.so'].amdsmi_get_gpu_total_ecc_count
     amdsmi_get_gpu_total_ecc_count.restype = amdsmi_status_t
     amdsmi_get_gpu_total_ecc_count.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_error_count_t)]
@@ -5294,8 +5288,7 @@ __all__ = \
     'amdsmi_get_gpu_cper_entries', 'amdsmi_get_gpu_device_bdf',
     'amdsmi_get_gpu_device_uuid', 'amdsmi_get_gpu_driver_info',
     'amdsmi_get_gpu_ecc_count', 'amdsmi_get_gpu_ecc_enabled',
-    'amdsmi_get_gpu_ecc_status', 'amdsmi_get_gpu_ecc_supported',
-    'amdsmi_get_gpu_enumeration_info',
+    'amdsmi_get_gpu_ecc_status', 'amdsmi_get_gpu_enumeration_info',
     'amdsmi_get_gpu_event_notification', 'amdsmi_get_gpu_fabric_info',
     'amdsmi_get_gpu_fan_rpms', 'amdsmi_get_gpu_fan_speed',
     'amdsmi_get_gpu_fan_speed_max', 'amdsmi_get_gpu_id',

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -3456,7 +3456,8 @@ rsmi_status_t rsmi_dev_temp_metric_get(uint32_t dv_ind, uint32_t sensor_type,
       return RSMI_STATUS_NOT_SUPPORTED;
     }
 
-    *temperature = static_cast<int64_t>(val_ui16) * CENTRIGRADE_TO_MILLI_CENTIGRADE;
+    // Multiple by 1000 to convert from Centigrade to mCentigrade
+    *temperature = static_cast<int64_t>(val_ui16) * 1000;
 
     ss << __PRETTY_FUNCTION__ << " | ======= end ======= "
        << " | Success "

--- a/projects/amdsmi/rust-interface/README.md
+++ b/projects/amdsmi/rust-interface/README.md
@@ -72,15 +72,15 @@ fn main() {
                 Err(e) => eprintln!("Failed to get GPU revision: {}", e),
             }
 
-            // Get GPU vendor info using the processor handle
-            match amdsmi_get_gpu_vendor_info(processor_handle) {
-                Ok(gpu_vendor_info) => println!("GPU Vendor Info: {}", gpu_vendor_info),
-                Err(e) => eprintln!("Failed to get GPU vendor info: {}", e),
+            // Get GPU vendor name using the processor handle
+            match amdsmi_get_gpu_vendor_name(processor_handle) {
+                Ok(gpu_vendor_name) => println!("GPU Vendor Name: {}", gpu_vendor_name),
+                Err(e) => eprintln!("Failed to get GPU vendor name: {}", e),
             }
 
-            // Get GPU VRAM vendor using the processor handle
+            // Get GPU VRAM info using the processor handle
             match amdsmi_get_gpu_vram_info(processor_handle) {
-                Ok(gpu_vram_vendor) => println!("GPU VRAM Vendor: {}", gpu_vram_info),
+                Ok(gpu_vram_info) => println!("GPU VRAM Info: {:?}", gpu_vram_info),
                 Err(e) => eprintln!("Failed to get GPU VRAM info: {}", e),
             }
 

--- a/projects/amdsmi/rust-interface/README.md
+++ b/projects/amdsmi/rust-interface/README.md
@@ -72,16 +72,16 @@ fn main() {
                 Err(e) => eprintln!("Failed to get GPU revision: {}", e),
             }
 
-            // Get GPU vendor name using the processor handle
-            match amdsmi_get_gpu_vendor_name(processor_handle) {
-                Ok(gpu_vendor_name) => println!("GPU Vendor Name: {}", gpu_vendor_name),
-                Err(e) => eprintln!("Failed to get GPU vendor name: {}", e),
+            // Get GPU vendor info using the processor handle
+            match amdsmi_get_gpu_vendor_info(processor_handle) {
+                Ok(gpu_vendor_info) => println!("GPU Vendor Info: {}", gpu_vendor_info),
+                Err(e) => eprintln!("Failed to get GPU vendor info: {}", e),
             }
 
             // Get GPU VRAM vendor using the processor handle
-            match amdsmi_get_gpu_vram_vendor(processor_handle) {
-                Ok(gpu_vram_vendor) => println!("GPU VRAM Vendor: {}", gpu_vram_vendor),
-                Err(e) => eprintln!("Failed to get GPU VRAM vendor: {}", e),
+            match amdsmi_get_gpu_vram_info(processor_handle) {
+                Ok(gpu_vram_vendor) => println!("GPU VRAM Vendor: {}", gpu_vram_info),
+                Err(e) => eprintln!("Failed to get GPU VRAM info: {}", e),
             }
 
             // Get GPU BDF using the processor handle

--- a/projects/amdsmi/rust-interface/examples/amdsmi_get_gpu_info.rs
+++ b/projects/amdsmi/rust-interface/examples/amdsmi_get_gpu_info.rs
@@ -69,12 +69,6 @@ fn main() {
                 Err(e) => eprintln!("Failed to get GPU vendor name: {}", e),
             }
 
-            // Get GPU VRAM vendor using the processor handle
-            match amdsmi_get_gpu_vram_vendor(processor_handle) {
-                Ok(gpu_vram_vendor) => println!("GPU VRAM Vendor: {}", gpu_vram_vendor),
-                Err(e) => eprintln!("Failed to get GPU VRAM vendor: {}", e),
-            }
-
             // Get GPU subsystem ID using the processor handle
             match amdsmi_get_gpu_subsystem_id(processor_handle) {
                 Ok(gpu_subsystem_id) => println!("GPU Subsystem ID: {}", gpu_subsystem_id),

--- a/projects/amdsmi/rust-interface/src/amdsmi.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi.rs
@@ -511,55 +511,6 @@ pub fn amdsmi_get_gpu_vendor_name(processor_handle: AmdsmiProcessorHandle) -> Am
     Ok(cstr_to_string!(name))
 }
 
-/// Retrieves the GPU VRAM vendor name for a given processor handle.
-///
-/// This function returns the GPU VRAM vendor name associated with the specified processor handle.
-/// The VRAM vendor name provides information about the manufacturer of the GPU's VRAM.
-///
-/// # Arguments
-///
-/// * `processor_handle` - A handle to the processor for which the GPU VRAM vendor name is being queried.
-///
-/// # Returns
-///
-/// * `AmdsmiResult<String>` - Returns `Ok(String)` containing the GPU VRAM vendor name if successful, or an error if it fails.
-///
-/// # Example
-///
-/// ```rust
-/// # use amdsmi::*;
-/// #
-/// # fn main() {
-/// #   // Initialize the AMD SMI library
-/// #   amdsmi_init(AmdsmiInitFlagsT::AmdsmiInitAmdGpus).expect("Failed to initialize AMD SMI");
-/// #
-///     // Example processor_handle, assuming the number of processors is greater than zero
-///     let processor_handle = amdsmi_get_processor_handles!()[0];
-///
-///     // Retrieve the GPU VRAM vendor name
-///     match amdsmi_get_gpu_vram_vendor(processor_handle) {
-///         Ok(vram_vendor_name) => println!("GPU VRAM Vendor Name: {}", vram_vendor_name),
-///         Err(e) => panic!("Failed to get GPU VRAM vendor name: {}", e),
-///     }
-/// #
-/// #   // Shut down the AMD SMI library
-/// #   amdsmi_shut_down().expect("Failed to shut down AMD SMI");
-/// # }
-/// ```
-///
-/// # Errors
-///
-/// This function will return the error in [`AmdsmiStatusT`] if the underlying `amdsmi_wrapper::amdsmi_get_gpu_vram_vendor` call fails.
-pub fn amdsmi_get_gpu_vram_vendor(processor_handle: AmdsmiProcessorHandle) -> AmdsmiResult<String> {
-    let (mut brand, len) = define_cstr!(amdsmi_wrapper::AMDSMI_MAX_STRING_LENGTH);
-    call_unsafe!(amdsmi_wrapper::amdsmi_get_gpu_vram_vendor(
-        processor_handle,
-        brand.as_mut_ptr(),
-        len as u32,
-    ));
-    Ok(cstr_to_string!(brand))
-}
-
 /// Retrieves the GPU subsystem ID for a given processor handle.
 ///
 /// This function returns the GPU subsystem ID associated with the specified processor handle.
@@ -2683,69 +2634,6 @@ pub fn amdsmi_get_gpu_reg_table_info(
     }
 
     Ok(reg_metrics)
-}
-
-/// Set the GPU clock range of the device with the specified processor handle, minimum clock value, maximum clock value, and clock type.
-///
-/// Given a processor handle `processor_handle`, a minimum clock value `minclkvalue`, a maximum clock value `maxclkvalue`, and a clock type `clk_type`,
-/// this function sets the GPU clock range for the specified processor.
-///
-/// # Arguments
-///
-/// * `processor_handle` - A handle to the processor for which the GPU clock range is being set.
-/// * `minclkvalue` - The minimum clock value to set.
-/// * `maxclkvalue` - The maximum clock value to set.
-/// * `clk_type` - The type of the clock to set.
-///
-/// # Returns
-///
-/// * `AmdsmiResult<()>` - Returns `Ok(())` if successful, or an error if it fails.
-///
-/// # Example
-///
-/// ```rust
-/// # use amdsmi::*;
-/// #
-/// # fn main() {
-/// #   // Initialize the AMD SMI library
-/// #   amdsmi_init(AmdsmiInitFlagsT::AmdsmiInitAmdGpus).expect("Failed to initialize AMD SMI");
-/// #
-///     // Example processor_handle, assuming the number of processors is greater than zero
-///     let processor_handle = amdsmi_get_processor_handles!()[0];
-///
-///     // Example clock values and clock type
-///     let minclkvalue = 500; // Set minimum clock value to 500 MHz
-///     let maxclkvalue = 1500; // Set maximum clock value to 1500 MHz
-///     let clk_type = AmdsmiClkTypeT::AmdsmiClkTypeGfx;
-///
-///     // Set the GPU clock range
-///     match amdsmi_set_gpu_clk_range(processor_handle, minclkvalue, maxclkvalue, clk_type) {
-///         Ok(()) => println!("GPU clock range set successfully"),
-///         Err(AmdsmiStatusT::AmdsmiStatusNotSupported) => println!("amdsmi_set_gpu_clk_range() not supported on this device"),
-///         Err(e) => panic!("Failed to set GPU clock range: {}", e),
-///     }
-/// #
-/// #   // Shut down the AMD SMI library
-/// #   amdsmi_shut_down().expect("Failed to shut down AMD SMI");
-/// # }
-/// ```
-///
-/// # Errors
-///
-/// This function will return the error in [`AmdsmiStatusT`] if the underlying `amdsmi_wrapper::amdsmi_set_gpu_clk_range` call fails.
-pub fn amdsmi_set_gpu_clk_range(
-    processor_handle: AmdsmiProcessorHandle,
-    minclkvalue: u64,
-    maxclkvalue: u64,
-    clk_type: AmdsmiClkTypeT,
-) -> AmdsmiResult<()> {
-    call_unsafe!(amdsmi_wrapper::amdsmi_set_gpu_clk_range(
-        processor_handle,
-        minclkvalue,
-        maxclkvalue,
-        clk_type
-    ));
-    Ok(())
 }
 
 /// Set the GPU clock limit of the device with the specified processor handle, clock type, limit type, and clock value.

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -127,6 +127,7 @@ pub const AMDSMI_APU_MAX_CORES: u32 = 16;
 pub const AMDSMI_APU_V24_CORES: u32 = 8;
 pub const AMDSMI_APU_MAX_L3: u32 = 2;
 pub const AMDSMI_APU_MAX_IPU: u32 = 8;
+pub const AMDSMI_MAX_NUMBER_OF_AFIDS_PER_RECORD: u32 = 12;
 pub const AMDSMI_MAX_NUM_HBM_STACKS: u32 = 12;
 pub const AMDSMI_MAX_NUM_AID: u32 = 2;
 pub const AMDSMI_MAX_NUM_MID: u32 = 2;
@@ -3845,13 +3846,6 @@ extern "C" {
     ) -> AmdsmiStatusT;
 }
 extern "C" {
-    pub fn amdsmi_get_gpu_vram_vendor(
-        processor_handle: AmdsmiProcessorHandle,
-        brand: *mut ::std::os::raw::c_char,
-        len: u32,
-    ) -> AmdsmiStatusT;
-}
-extern "C" {
     pub fn amdsmi_get_gpu_subsystem_id(
         processor_handle: AmdsmiProcessorHandle,
         id: *mut u16,
@@ -4168,14 +4162,6 @@ extern "C" {
         reg_type: AmdsmiRegTypeT,
         reg_metrics: *mut *mut AmdsmiNameValueT,
         num_of_metrics: *mut u32,
-    ) -> AmdsmiStatusT;
-}
-extern "C" {
-    pub fn amdsmi_set_gpu_clk_range(
-        processor_handle: AmdsmiProcessorHandle,
-        minclkvalue: u64,
-        maxclkvalue: u64,
-        clkType: AmdsmiClkTypeT,
     ) -> AmdsmiStatusT;
 }
 extern "C" {
@@ -4543,6 +4529,12 @@ extern "C" {
 }
 extern "C" {
     pub fn amdsmi_get_gpu_ecc_enabled(
+        processor_handle: AmdsmiProcessorHandle,
+        enabled_blocks: *mut u64,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_get_gpu_ecc_supported(
         processor_handle: AmdsmiProcessorHandle,
         enabled_blocks: *mut u64,
     ) -> AmdsmiStatusT;

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -331,6 +331,13 @@ pub enum AmdsmiComputePartitionMemAllocModeT {
 }
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiAcceleratorPartitionMemAllocModeT {
+    AmdsmiAcceleratorPartitionMemAllocInvalid = 0,
+    AmdsmiAcceleratorPartitionMemAllocCapping = 1,
+    AmdsmiAcceleratorPartitionMemAllocAll = 2,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum AmdsmiMemoryPartitionTypeT {
     AmdsmiMemoryPartitionUnknown = 0,
     AmdsmiMemoryPartitionNps1 = 1,
@@ -2257,11 +2264,17 @@ pub enum AmdsmiGpuBlockT {
     AmdsmiGpuBlockMpio = 262144,
     AmdsmiGpuBlockReserved = 9223372036854775808,
 }
+impl AmdsmiClkLimitTypeT {
+    pub const ClkLimitMin: AmdsmiClkLimitTypeT = AmdsmiClkLimitTypeT::AmdsmiClkLimitMin;
+}
+impl AmdsmiClkLimitTypeT {
+    pub const ClkLimitMax: AmdsmiClkLimitTypeT = AmdsmiClkLimitTypeT::AmdsmiClkLimitMax;
+}
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum AmdsmiClkLimitTypeT {
-    ClkLimitMin = 0,
-    ClkLimitMax = 1,
+    AmdsmiClkLimitMin = 0,
+    AmdsmiClkLimitMax = 1,
 }
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -4931,9 +4944,21 @@ extern "C" {
     ) -> AmdsmiStatusT;
 }
 extern "C" {
+    pub fn amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(
+        processor_handle: AmdsmiProcessorHandle,
+        mode: *mut AmdsmiAcceleratorPartitionMemAllocModeT,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
     pub fn amdsmi_set_gpu_compute_partition_mem_alloc_mode(
         processor_handle: AmdsmiProcessorHandle,
         mode: AmdsmiComputePartitionMemAllocModeT,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(
+        processor_handle: AmdsmiProcessorHandle,
+        mode: AmdsmiAcceleratorPartitionMemAllocModeT,
     ) -> AmdsmiStatusT;
 }
 extern "C" {

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -4534,12 +4534,6 @@ extern "C" {
     ) -> AmdsmiStatusT;
 }
 extern "C" {
-    pub fn amdsmi_get_gpu_ecc_supported(
-        processor_handle: AmdsmiProcessorHandle,
-        enabled_blocks: *mut u64,
-    ) -> AmdsmiStatusT;
-}
-extern "C" {
     pub fn amdsmi_get_gpu_total_ecc_count(
         processor_handle: AmdsmiProcessorHandle,
         ec: *mut AmdsmiErrorCountT,

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -4428,21 +4428,6 @@ amdsmi_status_t amdsmi_set_gpu_od_volt_info(amdsmi_processor_handle processor_ha
   return rsmi_wrapper(rsmi_dev_od_volt_info_set, processor_handle, 0, vpoint, clkvalue, voltvalue);
 }
 
-amdsmi_status_t amdsmi_set_gpu_clk_range(amdsmi_processor_handle processor_handle,
-                                         uint64_t minclkvalue, uint64_t maxclkvalue,
-                                         amdsmi_clk_type_t clkType) {
-  // Bare Metal and passthrough only feature
-  amdsmi_virtualization_mode_t virt_mode;
-  if (amdsmi_get_gpu_virtualization_mode(processor_handle, &virt_mode) == AMDSMI_STATUS_SUCCESS) {
-    if (virt_mode == AMDSMI_VIRTUALIZATION_MODE_GUEST) {
-      return AMDSMI_STATUS_NOT_SUPPORTED;
-    }
-  }
-
-  return rsmi_wrapper(rsmi_dev_clk_range_set, processor_handle, 0, minclkvalue, maxclkvalue,
-                      static_cast<rsmi_clk_type_t>(clkType));
-}
-
 amdsmi_status_t amdsmi_set_gpu_clk_limit(amdsmi_processor_handle processor_handle,
                                          amdsmi_clk_type_t clk_type,
                                          amdsmi_clk_limit_type_t limit_type, uint64_t clk_value) {

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -2651,20 +2651,6 @@ amdsmi_status_t amdsmi_get_gpu_vendor_name(amdsmi_processor_handle processor_han
   return rsmi_wrapper(rsmi_dev_vendor_name_get, processor_handle, 0, name, len);
 }
 
-amdsmi_status_t amdsmi_get_gpu_vram_vendor(amdsmi_processor_handle processor_handle, char* brand,
-                                           uint32_t len) {
-  if (brand == nullptr) {
-    return AMDSMI_STATUS_INVAL;
-  }
-  amdsmi_vram_info_t info = {};
-  amdsmi_status_t r = amdsmi_get_gpu_vram_info(processor_handle, &info);
-  if (r != AMDSMI_STATUS_SUCCESS) {
-    return r;
-  }
-  snprintf(brand, len, "%s", info.vram_vendor);
-  return r;
-}
-
 amdsmi_status_t amdsmi_get_gpu_vram_info(amdsmi_processor_handle processor_handle,
                                          amdsmi_vram_info_t* info) {
   AMDSMI_CHECK_INIT();
@@ -2692,7 +2678,7 @@ amdsmi_status_t amdsmi_get_gpu_vram_info(amdsmi_processor_handle processor_handl
   // --- sysfs first: vendor + total size (no DRM dependency) ---
   // The vendor string is only exposed via sysfs (mem_info_vram_vendor); the DRM
   // ioctl carries no vendor field. Read it before attempting the ioctl so callers
-  // (e.g. amdsmi_get_gpu_vram_vendor) still get the vendor when DRM is unavailable.
+  // (e.g. amdsmi_get_gpu_vram_info) still get the vendor when DRM is unavailable.
   char brand[256] = {'\0'};
   amdsmi_status_t vendor_status =
       rsmi_wrapper(rsmi_dev_vram_vendor_get, processor_handle, 0, brand, 255);
@@ -3974,13 +3960,22 @@ amdsmi_status_t amdsmi_get_gpu_ecc_count(amdsmi_processor_handle processor_handl
                       static_cast<rsmi_gpu_block_t>(block),
                       reinterpret_cast<rsmi_error_count_t*>(ec));
 }
+
+// Deprecated API, use amdsmi_get_gpu_ecc_supported() instead
 amdsmi_status_t amdsmi_get_gpu_ecc_enabled(amdsmi_processor_handle processor_handle,
                                            uint64_t* enabled_blocks) {
+  amdsmi_status_t ret = amdsmi_get_gpu_ecc_supported(processor_handle, enabled_blocks);
+  return ret;
+}
+
+amdsmi_status_t amdsmi_get_gpu_ecc_supported(amdsmi_processor_handle processor_handle,
+                                             uint64_t* enabled_blocks) {
   AMDSMI_CHECK_INIT();
   // nullptr api supported
 
   return rsmi_wrapper(rsmi_dev_ecc_enabled_get, processor_handle, 0, enabled_blocks);
 }
+
 amdsmi_status_t amdsmi_get_gpu_ecc_status(amdsmi_processor_handle processor_handle,
                                           amdsmi_gpu_block_t block, amdsmi_ras_err_state_t* state) {
   AMDSMI_CHECK_INIT();
@@ -6702,8 +6697,8 @@ amdsmi_status_t amdsmi_set_cpu_pwr_efficiency_mode(amdsmi_processor_handle proce
   pwreffmode_util = *utilization;
   pwreffmode_pptlimit = *ppt_limit;
 
-  if ((power_efficiency_mode == POWER_EFFICIENCY_MODE_4) ||
-      (power_efficiency_mode == POWER_EFFICIENCY_MODE_5)) {
+  if ((power_efficiency_mode == AMDSMI_POWER_EFFICIENCY_MODE_4) ||
+      (power_efficiency_mode == AMDSMI_POWER_EFFICIENCY_MODE_5)) {
     uint32_t cpu_family;
     uint32_t cpu_model;
     // cpu_family and cpu_model are only needed for mode 4/5 validation
@@ -7834,14 +7829,14 @@ amdsmi_status_t amdsmi_get_cpu_svi3_vr_controller_temp(amdsmi_processor_handle p
   sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
 
   // Validate input parameters
-  if ((*rail_selection) > MAX_SVI3_RAIL_SELECTION) {
+  if ((*rail_selection) > AMDSMI_MAX_SVI3_RAIL_SELECTION) {
     return AMDSMI_STATUS_INVAL;
   }
 
   // Prepare ESMI SVI3 structure with input parameters
   svi3_info_.m_svi3_info_inarg.info.svi3_rail_selection = ((*rail_selection) & 0x1);
-  if ((*rail_selection) == MAX_SVI3_RAIL_SELECTION) {
-    if ((*rail_index) > MAX_SVI3_RAIL_INDEX) {
+  if ((*rail_selection) == AMDSMI_MAX_SVI3_RAIL_SELECTION) {
+    if ((*rail_index) > AMDSMI_MAX_SVI3_RAIL_INDEX) {
       return AMDSMI_STATUS_INVAL;
     }
     svi3_info_.m_svi3_info_inarg.info.svi3_rail_index = ((*rail_index) & 0x7);

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -3961,7 +3961,6 @@ amdsmi_status_t amdsmi_get_gpu_ecc_count(amdsmi_processor_handle processor_handl
                       reinterpret_cast<rsmi_error_count_t*>(ec));
 }
 
-// Deprecated API, use amdsmi_get_gpu_ecc_supported() instead
 amdsmi_status_t amdsmi_get_gpu_ecc_enabled(amdsmi_processor_handle processor_handle,
                                            uint64_t* enabled_blocks) {
   amdsmi_status_t ret = amdsmi_get_gpu_ecc_supported(processor_handle, enabled_blocks);

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -3963,12 +3963,6 @@ amdsmi_status_t amdsmi_get_gpu_ecc_count(amdsmi_processor_handle processor_handl
 
 amdsmi_status_t amdsmi_get_gpu_ecc_enabled(amdsmi_processor_handle processor_handle,
                                            uint64_t* enabled_blocks) {
-  amdsmi_status_t ret = amdsmi_get_gpu_ecc_supported(processor_handle, enabled_blocks);
-  return ret;
-}
-
-amdsmi_status_t amdsmi_get_gpu_ecc_supported(amdsmi_processor_handle processor_handle,
-                                             uint64_t* enabled_blocks) {
   AMDSMI_CHECK_INIT();
   // nullptr api supported
 

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -3038,6 +3038,7 @@ amdsmi_status_t amdsmi_topo_get_p2p_status(amdsmi_processor_handle processor_han
 }
 
 // Compute Partition functions
+// This API is deprecated, use amdsmi_get_gpu_accelerator_partition_profile() instead
 amdsmi_status_t amdsmi_get_gpu_compute_partition(amdsmi_processor_handle processor_handle,
                                                  char* compute_partition, uint32_t len) {
   AMDSMI_CHECK_INIT();
@@ -3051,6 +3052,7 @@ amdsmi_status_t amdsmi_get_gpu_compute_partition(amdsmi_processor_handle process
   return status;
 }
 
+// This API is deprecated, use amdsmi_set_gpu_accelerator_partition_profile() instead
 amdsmi_status_t amdsmi_set_gpu_compute_partition(
     amdsmi_processor_handle processor_handle, amdsmi_compute_partition_type_t compute_partition) {
   AMDSMI_CHECK_INIT();
@@ -3059,8 +3061,18 @@ amdsmi_status_t amdsmi_set_gpu_compute_partition(
   return ret_resp;
 }
 
+// This API is deprecated, use amdsmi_get_gpu_accelerator_partition_mem_alloc_mode() instead
 amdsmi_status_t amdsmi_get_gpu_compute_partition_mem_alloc_mode(
     amdsmi_processor_handle processor_handle, amdsmi_compute_partition_mem_alloc_mode_t* mode) {
+  amdsmi_accelerator_partition_mem_alloc_mode_t* acc_mode;
+  acc_mode = reinterpret_cast<amdsmi_accelerator_partition_mem_alloc_mode_t*>(mode);
+  amdsmi_status_t status =
+      amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(processor_handle, acc_mode);
+  return status;
+}
+
+amdsmi_status_t amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(
+    amdsmi_processor_handle processor_handle, amdsmi_accelerator_partition_mem_alloc_mode_t* mode) {
   AMDSMI_CHECK_INIT();
   if (mode == nullptr) {
     return AMDSMI_STATUS_INVAL;
@@ -3074,11 +3086,21 @@ amdsmi_status_t amdsmi_get_gpu_compute_partition_mem_alloc_mode(
   return status;
 }
 
+// This API is deprecated, use amdsmi_set_gpu_accelerator_partition_mem_alloc_mode() instead
 amdsmi_status_t amdsmi_set_gpu_compute_partition_mem_alloc_mode(
     amdsmi_processor_handle processor_handle, amdsmi_compute_partition_mem_alloc_mode_t mode) {
+  amdsmi_accelerator_partition_mem_alloc_mode_t acc_mode;
+  acc_mode = static_cast<amdsmi_accelerator_partition_mem_alloc_mode_t>(mode);
+  amdsmi_status_t status =
+      amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(processor_handle, acc_mode);
+  return status;
+}
+
+amdsmi_status_t amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(
+    amdsmi_processor_handle processor_handle, amdsmi_accelerator_partition_mem_alloc_mode_t mode) {
   AMDSMI_CHECK_INIT();
-  if (mode != AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING &&
-      mode != AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL) {
+  if (mode != AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING &&
+      mode != AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL) {
     return AMDSMI_STATUS_INVAL;
   }
   return rsmi_wrapper(rsmi_dev_compute_partition_mem_alloc_mode_set, processor_handle, 0,
@@ -3094,67 +3116,11 @@ amdsmi_status_t amdsmi_get_gpu_memory_partition(amdsmi_processor_handle processo
   return ret;
 }
 
+// This API is deprecated, use amdsmi_set_gpu_memory_partition_mode() instead
 amdsmi_status_t amdsmi_set_gpu_memory_partition(amdsmi_processor_handle processor_handle,
-                                                amdsmi_memory_partition_type_t memory_partition) {
+                                                amdsmi_memory_partition_type_t mode) {
   AMDSMI_CHECK_INIT();
-  if (memory_partition != AMDSMI_MEMORY_PARTITION_UNKNOWN &&
-      memory_partition != AMDSMI_MEMORY_PARTITION_NPS1 &&
-      memory_partition != AMDSMI_MEMORY_PARTITION_NPS2 &&
-      memory_partition != AMDSMI_MEMORY_PARTITION_NPS4 &&
-      memory_partition != AMDSMI_MEMORY_PARTITION_NPS8) {
-    return AMDSMI_STATUS_INVAL;
-  }
-  std::ostringstream ss;
-  std::lock_guard<std::mutex> g(myMutex);
-
-  const uint32_t k256 = 256;
-  char current_partition[k256];
-  std::string current_partition_str = "UNKNOWN";
-  std::string req_user_partition = "UNKNOWN";
-
-  req_user_partition.clear();
-  switch (memory_partition) {
-    case AMDSMI_MEMORY_PARTITION_NPS1:
-      req_user_partition = "NPS1";
-      break;
-    case AMDSMI_MEMORY_PARTITION_NPS2:
-      req_user_partition = "NPS2";
-      break;
-    case AMDSMI_MEMORY_PARTITION_NPS4:
-      req_user_partition = "NPS4";
-      break;
-    case AMDSMI_MEMORY_PARTITION_NPS8:
-      req_user_partition = "NPS8";
-      break;
-    default:
-      req_user_partition = "UNKNOWN";
-      break;
-  }
-  rsmi_memory_partition_type_t rsmi_type;
-  auto it = nps_amdsmi_to_RSMI.find(memory_partition);
-  if (it != nps_amdsmi_to_RSMI.end()) {
-    rsmi_type = it->second;
-  } else if (it == nps_amdsmi_to_RSMI.end()) {
-    return AMDSMI_STATUS_INVAL;
-  }
-
-  amdsmi_status_t ret = rsmi_wrapper(rsmi_dev_memory_partition_set, processor_handle, 0, rsmi_type);
-
-  amdsmi_status_t ret_get =
-      rsmi_wrapper(rsmi_dev_memory_partition_get, processor_handle, 0, current_partition, k256);
-
-  if (ret_get == AMDSMI_STATUS_SUCCESS) {
-    current_partition_str.clear();
-    current_partition_str = current_partition;
-  }
-
-  ss << __PRETTY_FUNCTION__ << " | After attempting to set memory partition to "
-     << req_user_partition << "\n"
-     << " | Current memory partition is " << current_partition_str << "\n"
-     << " | Returning: " << smi_amdgpu_get_status_string(ret, false)
-     << " | User will need to reload driver in order to see a NPS mode change";
-  LOG_INFO(ss);
-  return ret;
+  return amdsmi_set_gpu_memory_partition_mode(processor_handle, mode);
 }
 
 amdsmi_status_t amdsmi_get_gpu_memory_partition_config(amdsmi_processor_handle processor_handle,
@@ -3226,11 +3192,67 @@ amdsmi_status_t amdsmi_get_gpu_memory_partition_config(amdsmi_processor_handle p
   config->partition_caps = flags;
   return status;
 }
-
-amdsmi_status_t amdsmi_set_gpu_memory_partition_mode(amdsmi_processor_handle processor_handle,
-                                                     amdsmi_memory_partition_type_t mode) {
+amdsmi_status_t amdsmi_set_gpu_memory_partition_mode(
+    amdsmi_processor_handle processor_handle, amdsmi_memory_partition_type_t memory_partition) {
   AMDSMI_CHECK_INIT();
-  return amdsmi_set_gpu_memory_partition(processor_handle, mode);
+  if (memory_partition != AMDSMI_MEMORY_PARTITION_UNKNOWN &&
+      memory_partition != AMDSMI_MEMORY_PARTITION_NPS1 &&
+      memory_partition != AMDSMI_MEMORY_PARTITION_NPS2 &&
+      memory_partition != AMDSMI_MEMORY_PARTITION_NPS4 &&
+      memory_partition != AMDSMI_MEMORY_PARTITION_NPS8) {
+    return AMDSMI_STATUS_INVAL;
+  }
+  std::ostringstream ss;
+  std::lock_guard<std::mutex> g(myMutex);
+
+  const uint32_t k256 = 256;
+  char current_partition[k256];
+  std::string current_partition_str = "UNKNOWN";
+  std::string req_user_partition = "UNKNOWN";
+
+  req_user_partition.clear();
+  switch (memory_partition) {
+    case AMDSMI_MEMORY_PARTITION_NPS1:
+      req_user_partition = "NPS1";
+      break;
+    case AMDSMI_MEMORY_PARTITION_NPS2:
+      req_user_partition = "NPS2";
+      break;
+    case AMDSMI_MEMORY_PARTITION_NPS4:
+      req_user_partition = "NPS4";
+      break;
+    case AMDSMI_MEMORY_PARTITION_NPS8:
+      req_user_partition = "NPS8";
+      break;
+    default:
+      req_user_partition = "UNKNOWN";
+      break;
+  }
+  rsmi_memory_partition_type_t rsmi_type;
+  auto it = nps_amdsmi_to_RSMI.find(memory_partition);
+  if (it != nps_amdsmi_to_RSMI.end()) {
+    rsmi_type = it->second;
+  } else if (it == nps_amdsmi_to_RSMI.end()) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  amdsmi_status_t ret = rsmi_wrapper(rsmi_dev_memory_partition_set, processor_handle, 0, rsmi_type);
+
+  amdsmi_status_t ret_get =
+      rsmi_wrapper(rsmi_dev_memory_partition_get, processor_handle, 0, current_partition, k256);
+
+  if (ret_get == AMDSMI_STATUS_SUCCESS) {
+    current_partition_str.clear();
+    current_partition_str = current_partition;
+  }
+
+  ss << __PRETTY_FUNCTION__ << " | After attempting to set memory partition to "
+     << req_user_partition << "\n"
+     << " | Current memory partition is " << current_partition_str << "\n"
+     << " | Returning: " << smi_amdgpu_get_status_string(ret, false)
+     << " | User will need to reload driver in order to see a NPS mode change";
+  LOG_INFO(ss);
+  return ret;
 }
 
 // Accelerator Partition functions

--- a/projects/amdsmi/src/rocm_smi_properties.cc
+++ b/projects/amdsmi/src/rocm_smi_properties.cc
@@ -125,7 +125,6 @@ const AMDGpuVerbList_t amdgpu_verb_check_list{
     {AMDGpuVerbTypes_t::kSetGpuPciBandwidth, "amdsmi_set_gpu_pci_bandwidth"},
     {AMDGpuVerbTypes_t::kSetPowerCap, "amdsmi_set_power_cap"},
     {AMDGpuVerbTypes_t::kSetGpuPowerProfile, "amdsmi_set_gpu_power_profile"},
-    {AMDGpuVerbTypes_t::kSetGpuClkRange, "amdsmi_set_gpu_clk_range"},
     {AMDGpuVerbTypes_t::kSetGpuOdClkInfo, "amdsmi_set_gpu_od_clk_info"},
     {AMDGpuVerbTypes_t::kSetGpuOdVoltInfo, "amdsmi_set_gpu_od_volt_info"},
     {AMDGpuVerbTypes_t::kSetGpuPerfLevelV1, "amdsmi_set_gpu_perf_level_v1"},

--- a/projects/amdsmi/tests/amd_smi_test/functional/gpu/clock/clock_limit_read_write.h
+++ b/projects/amdsmi/tests/amd_smi_test/functional/gpu/clock/clock_limit_read_write.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TESTS_AMD_SMI_TEST_FUNCTIONAL_CLOCK_LIMIT_READ_WRITE_H_
+#define TESTS_AMD_SMI_TEST_FUNCTIONAL_CLOCK_LIMIT_READ_WRITE_H_
+
+#include "test_base.h"
+
+class TestClockLimitReadWrite : public TestBase {
+ public:
+  TestClockLimitReadWrite();
+
+  // @Brief: Destructor for test case of TestClockLimitReadWrite
+  virtual ~TestClockLimitReadWrite();
+
+  // @Brief: Setup the environment for measurement
+  virtual void SetUp();
+
+  // @Brief: Core measurement execution
+  virtual void Run();
+
+  // @Brief: Clean up and retrieve the resource
+  virtual void Close();
+
+  // @Brief: Display  results
+  virtual void DisplayResults() const;
+
+  // @Brief: Display information about what this test does
+  virtual void DisplayTestInfo(void);
+};
+
+#endif  // TESTS_AMD_SMI_TEST_FUNCTIONAL_CLOCK_LIMIT_READ_WRITE_H_

--- a/projects/amdsmi/tests/amd_smi_test/functional/gpu/clock/clock_limit_read_write_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/gpu/clock/clock_limit_read_write_test.cc
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "clock_limit_read_write.h"
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+#include "test_common.h"
+#include "amd_smi/amdsmi.h"
+
+TestClockLimitReadWrite::TestClockLimitReadWrite() : TestBase() {
+  set_title("AMDSMI Clock Limit Read/Write Test");
+  set_description(
+      "The Clock Limit Read/Write test verifies that the sclk/mclk minimum "
+      "and maximum frequency limits can be set through "
+      "amdsmi_set_gpu_clk_limit() and restored to their original values.");
+}
+
+TestClockLimitReadWrite::~TestClockLimitReadWrite(void) {}
+
+void TestClockLimitReadWrite::SetUp(void) {
+  TestBase::SetUp();
+
+  return;
+}
+
+void TestClockLimitReadWrite::DisplayTestInfo(void) { TestBase::DisplayTestInfo(); }
+
+void TestClockLimitReadWrite::DisplayResults(void) const {
+  TestBase::DisplayResults();
+  return;
+}
+
+void TestClockLimitReadWrite::Close() {
+  // This will close handles opened within rsmitst utility calls and call
+  // amdsmi_shut_down(), so it should be done after other hsa cleanup
+  TestBase::Close();
+}
+
+// amdsmi_get_clk_freq() reports frequencies in Hz; amdsmi_set_gpu_clk_limit()
+// expects MHz.
+static uint64_t hz_to_mhz(uint64_t hz) { return hz / 1000000ULL; }
+
+void TestClockLimitReadWrite::Run(void) {
+  amdsmi_status_t ret;
+  amdsmi_frequencies_t f;
+
+  TestBase::Run();
+  PRINT_VERBOSITY();
+  if (setup_failed_) {
+    std::cout << "** SetUp Failed for this test. Skipping.**" << std::endl;
+    return;
+  }
+
+  // amdsmi_set_gpu_clk_limit() only operates on the SYS (gfx) and MEM clocks.
+  const amdsmi_clk_type_t clk_types[] = {AMDSMI_CLK_TYPE_SYS, AMDSMI_CLK_TYPE_MEM};
+
+  for (uint32_t dv_ind = 0; dv_ind < num_monitor_devs(); ++dv_ind) {
+    PrintDeviceHeader(processor_handles_[dv_ind]);
+
+    for (auto clk : clk_types) {
+      const char* name = FreqEnumToStr(clk);
+
+      // Read the supported frequency table to derive safe min/max values.
+      DISPLAY_AMDSMI_API("amdsmi_get_clk_freq", "gpu=" + std::to_string(dv_ind), VERB(STANDARD));
+      ret = amdsmi_get_clk_freq(processor_handles_[dv_ind], clk, &f);
+      DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
+
+      if (ret == AMDSMI_STATUS_NOT_SUPPORTED || ret == AMDSMI_STATUS_NOT_YET_IMPLEMENTED) {
+        IF_VERB(STANDARD) {
+          std::cout << "\t**" << name << ": Not supported on this machine" << std::endl;
+        }
+        continue;
+      }
+
+      if (ret == AMDSMI_STATUS_UNEXPECTED_DATA) {
+        std::cerr << "WARN: Clock [" << name << "] on device [" << dv_ind
+                  << "] returned unexpected data. Likely a driver issue!" << std::endl;
+        continue;
+      }
+
+      CHK_ERR_ASRT(ret)
+
+      // Deep sleep (index 0 when present) is not a real DPM level; the lowest
+      // selectable level follows it.
+      uint32_t lowest_idx = (f.has_deep_sleep && f.num_supported > 0) ? 1 : 0;
+      if (f.num_supported <= lowest_idx) {
+        IF_VERB(STANDARD) {
+          std::cout << "\t**" << name << ": No selectable DPM levels, skipping." << std::endl;
+        }
+        continue;
+      }
+
+      uint64_t orig_min_mhz = hz_to_mhz(f.frequency[lowest_idx]);
+      uint64_t orig_max_mhz = hz_to_mhz(f.frequency[f.num_supported - 1]);
+
+      IF_VERB(STANDARD) {
+        std::cout << "\t**" << name << ": original min=" << orig_min_mhz
+                  << " MHz, max=" << orig_max_mhz << " MHz" << std::endl;
+      }
+
+      // ASSERT_*/CHK_ERR_ASRT expand to a bare "return;", so this helper must
+      // return void; it reports "not testable" through the captured flag.
+      bool limit_supported = true;
+      auto set_limit = [&](amdsmi_clk_limit_type_t limit_type, uint64_t mhz, const char* label) {
+        limit_supported = true;
+        DISPLAY_AMDSMI_API("amdsmi_set_gpu_clk_limit",
+                           "gpu=" + std::to_string(dv_ind) + ", clk_type=" + std::string(name) +
+                               ", clk_limit=" + std::string(label) +
+                               ", value=" + std::to_string(mhz),
+                           VERB(STANDARD));
+        ret = amdsmi_set_gpu_clk_limit(processor_handles_[dv_ind], clk, limit_type, mhz);
+        DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS,
+                              AMDSMI_STATUS_NOT_SUPPORTED, AMDSMI_STATUS_NO_PERM);
+        // Some ASICs reject clock-limit changes even with root. Treat those
+        // as "not testable here" rather than a defect.
+        if (ret == AMDSMI_STATUS_NOT_SUPPORTED ||
+            (ret == AMDSMI_STATUS_NO_PERM && geteuid() == 0)) {
+          IF_VERB(STANDARD) {
+            std::cout << "\t**" << name << " set " << label
+                      << ": Not supported on this machine. Skipping..." << std::endl;
+          }
+          limit_supported = false;
+          return;
+        }
+        CHK_ERR_ASRT(ret)
+        IF_VERB(STANDARD) {
+          std::cout << "\t**" << name << " set " << label << " -> " << mhz << " MHz: OK"
+                    << std::endl;
+        }
+      };
+
+      // Exercise both limit types with their original values, then confirm the
+      // range is restored. Using the original min/max keeps the device in a
+      // safe, unchanged state after the test.
+      set_limit(AMDSMI_CLK_LIMIT_MAX, orig_max_mhz, "max");
+      if (!limit_supported) {
+        continue;
+      }
+      set_limit(AMDSMI_CLK_LIMIT_MIN, orig_min_mhz, "min");
+
+      // Setting a clock limit switches the perf level to MANUAL; return the
+      // device to automatic control so later tests start from a clean state.
+      DISPLAY_AMDSMI_API("amdsmi_set_gpu_perf_level", "gpu=" + std::to_string(dv_ind),
+                         VERB(STANDARD));
+      ret = amdsmi_set_gpu_perf_level(processor_handles_[dv_ind], AMDSMI_DEV_PERF_LEVEL_AUTO);
+      DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS,
+                            AMDSMI_STATUS_NOT_SUPPORTED);
+
+      // Verify the restored range via a fresh read.
+      DISPLAY_AMDSMI_API("amdsmi_get_clk_freq", "gpu=" + std::to_string(dv_ind), VERB(STANDARD));
+      ret = amdsmi_get_clk_freq(processor_handles_[dv_ind], clk, &f);
+      DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
+      if (ret == AMDSMI_STATUS_SUCCESS) {
+        ASSERT_GT(f.num_supported, 0u);
+      }
+    }
+  }
+}

--- a/projects/amdsmi/tests/amd_smi_test/functional/gpu/identity/id_info_read_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/gpu/identity/id_info_read_test.cc
@@ -125,19 +125,6 @@ void TestIdInfoRead::Run(void) {
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_SUCCESS);
     CHK_ERR_ASRT(err)
 
-    DISPLAY_AMDSMI_API("amdsmi_get_gpu_vram_vendor", "gpu=" + std::to_string(i), VERB(STANDARD));
-    err = amdsmi_get_gpu_vram_vendor(processor_handles_[i], buffer, kBufferLen);
-    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_SUCCESS);
-    if (err == AMDSMI_STATUS_NOT_SUPPORTED) {
-      DISPLAY_AMDSMI_API("amdsmi_get_gpu_vram_vendor", "gpu=" + std::to_string(i), VERB(STANDARD));
-      err = amdsmi_get_gpu_vram_vendor(processor_handles_[i], nullptr, kBufferLen);
-      DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_INVAL);
-      ASSERT_EQ(err, AMDSMI_STATUS_NOT_SUPPORTED);
-    } else {
-      CHK_ERR_ASRT(err)
-      IF_VERB(STANDARD) { std::cout << "\t**Device Vram Vendor name: " << buffer << std::endl; }
-    }
-
     amdsmi_vram_info_t vram_info;
     DISPLAY_AMDSMI_API("amdsmi_get_gpu_vram_info", "gpu=" + std::to_string(i), VERB(STANDARD));
     err = amdsmi_get_gpu_vram_info(processor_handles_[i], &vram_info);

--- a/projects/amdsmi/tests/amd_smi_test/functional/gpu/partition/computepartition_memallocmode_read_write_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/gpu/partition/computepartition_memallocmode_read_write_test.cc
@@ -61,11 +61,11 @@ void TestComputePartitionMemAllocModeReadWrite::Close() {
   TestBase::Close();
 }
 
-static std::string memAllocModeString(amdsmi_compute_partition_mem_alloc_mode_t mode) {
+static std::string memAllocModeString(amdsmi_accelerator_partition_mem_alloc_mode_t mode) {
   switch (mode) {
-    case AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING:
+    case AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING:
       return "CAPPING";
-    case AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL:
+    case AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL:
       return "ALL";
     default:
       return "INVALID";
@@ -74,8 +74,8 @@ static std::string memAllocModeString(amdsmi_compute_partition_mem_alloc_mode_t 
 
 void TestComputePartitionMemAllocModeReadWrite::Run(void) {
   amdsmi_status_t ret;
-  amdsmi_compute_partition_mem_alloc_mode_t original_mode;
-  amdsmi_compute_partition_mem_alloc_mode_t current_mode;
+  amdsmi_accelerator_partition_mem_alloc_mode_t original_mode;
+  amdsmi_accelerator_partition_mem_alloc_mode_t current_mode;
 
   if (num_monitor_devs() == 0) {
     return;
@@ -83,37 +83,37 @@ void TestComputePartitionMemAllocModeReadWrite::Run(void) {
 
   // Invalid argument tests (run only when at least one device exists;
   // the handle is validated by SetUp).
-  ret = amdsmi_get_gpu_compute_partition_mem_alloc_mode(processor_handles_[0], nullptr);
+  ret = amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(processor_handles_[0], nullptr);
   EXPECT_EQ(ret, AMDSMI_STATUS_INVAL);
 
-  ret = amdsmi_set_gpu_compute_partition_mem_alloc_mode(processor_handles_[0],
-                                                        AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_INVALID);
+  ret = amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(
+      processor_handles_[0], AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_INVALID);
   EXPECT_EQ(ret, AMDSMI_STATUS_INVAL);
 
-  ret = amdsmi_set_gpu_compute_partition_mem_alloc_mode(
-      processor_handles_[0], static_cast<amdsmi_compute_partition_mem_alloc_mode_t>(99));
+  ret = amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(
+      processor_handles_[0], static_cast<amdsmi_accelerator_partition_mem_alloc_mode_t>(99));
   EXPECT_EQ(ret, AMDSMI_STATUS_INVAL);
 
   const bool isVerbose = (verbosity() > 0);
-  const std::vector<amdsmi_compute_partition_mem_alloc_mode_t> modes_to_test = {
-      AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING,
-      AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL,
+  const std::vector<amdsmi_accelerator_partition_mem_alloc_mode_t> modes_to_test = {
+      AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING,
+      AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL,
   };
 
   for (uint32_t dv_ind = 0; dv_ind < num_monitor_devs(); dv_ind++) {
     PrintDeviceHeader(processor_handles_[dv_ind]);
 
     // Get original mode
-    DISPLAY_AMDSMI_API("amdsmi_get_gpu_compute_partition_mem_alloc_mode",
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_accelerator_partition_mem_alloc_mode",
                        "gpu=" + std::to_string(dv_ind), isVerbose);
-    ret =
-        amdsmi_get_gpu_compute_partition_mem_alloc_mode(processor_handles_[dv_ind], &original_mode);
+    ret = amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(processor_handles_[dv_ind],
+                                                              &original_mode);
     DISPLAY_AMDSMI_STATUS(isVerbose, __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
 
     if (ret == AMDSMI_STATUS_NOT_SUPPORTED) {
       IF_VERB(STANDARD) {
         std::cout << "\t**Device " << dv_ind
-                  << ": compute_partition_mem_alloc_mode not supported; skipping.\n";
+                  << ": accelerator_partition_mem_alloc_mode not supported; skipping.\n";
       }
       continue;
     }
@@ -124,7 +124,7 @@ void TestComputePartitionMemAllocModeReadWrite::Run(void) {
     }
 
     IF_VERB(STANDARD) {
-      std::cout << "\t**Device " << dv_ind << ": original compute_partition_mem_alloc_mode = "
+      std::cout << "\t**Device " << dv_ind << ": original accelerator_partition_mem_alloc_mode = "
                 << memAllocModeString(original_mode) << "\n";
     }
 
@@ -135,10 +135,10 @@ void TestComputePartitionMemAllocModeReadWrite::Run(void) {
                   << "\n";
       }
 
-      DISPLAY_AMDSMI_API("amdsmi_set_gpu_compute_partition_mem_alloc_mode",
+      DISPLAY_AMDSMI_API("amdsmi_set_gpu_accelerator_partition_mem_alloc_mode",
                          "gpu=" + std::to_string(dv_ind) + ", mode=" + memAllocModeString(mode),
                          isVerbose);
-      ret = amdsmi_set_gpu_compute_partition_mem_alloc_mode(processor_handles_[dv_ind], mode);
+      ret = amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(processor_handles_[dv_ind], mode);
       DISPLAY_AMDSMI_STATUS(isVerbose, __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
 
       if (ret == AMDSMI_STATUS_NOT_SUPPORTED) {
@@ -155,10 +155,10 @@ void TestComputePartitionMemAllocModeReadWrite::Run(void) {
       }
 
       // Verify the mode was applied
-      DISPLAY_AMDSMI_API("amdsmi_get_gpu_compute_partition_mem_alloc_mode",
+      DISPLAY_AMDSMI_API("amdsmi_get_gpu_accelerator_partition_mem_alloc_mode",
                          "gpu=" + std::to_string(dv_ind) + " (verify)", isVerbose);
-      ret = amdsmi_get_gpu_compute_partition_mem_alloc_mode(processor_handles_[dv_ind],
-                                                            &current_mode);
+      ret = amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(processor_handles_[dv_ind],
+                                                                &current_mode);
       DISPLAY_AMDSMI_STATUS(isVerbose, __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
       EXPECT_EQ(ret, AMDSMI_STATUS_SUCCESS);
       if (ret == AMDSMI_STATUS_SUCCESS) {
@@ -175,17 +175,17 @@ void TestComputePartitionMemAllocModeReadWrite::Run(void) {
       std::cout << "\t**Device " << dv_ind
                 << ": restoring original mode = " << memAllocModeString(original_mode) << "\n";
     }
-    DISPLAY_AMDSMI_API("amdsmi_set_gpu_compute_partition_mem_alloc_mode",
+    DISPLAY_AMDSMI_API("amdsmi_set_gpu_accelerator_partition_mem_alloc_mode",
                        "gpu=" + std::to_string(dv_ind) +
                            ", mode=" + memAllocModeString(original_mode) + " (restore)",
                        isVerbose);
-    ret =
-        amdsmi_set_gpu_compute_partition_mem_alloc_mode(processor_handles_[dv_ind], original_mode);
+    ret = amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(processor_handles_[dv_ind],
+                                                              original_mode);
     DISPLAY_AMDSMI_STATUS(isVerbose, __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
     EXPECT_EQ(ret, AMDSMI_STATUS_SUCCESS);
     if (ret != AMDSMI_STATUS_SUCCESS) {
       std::cerr << "\t**WARNING: failed to restore device " << dv_ind
-                << " to original compute_partition_mem_alloc_mode = "
+                << " to original accelerator_partition_mem_alloc_mode = "
                 << memAllocModeString(original_mode) << "; device left in modified state.\n";
     }
   }

--- a/projects/amdsmi/tests/amd_smi_test/functional/gpu/partition/computepartition_read_write_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/gpu/partition/computepartition_read_write_test.cc
@@ -75,43 +75,45 @@ const uint32_t MAX_QPX_PARTITIONS = 4;
 // const uint32_t MAX_CPX_PARTITIONS = 8;
 
 static const std::string computePartitionString(
-    amdsmi_compute_partition_type_t computeParitionType) {
+    amdsmi_accelerator_partition_type_t computeParitionType) {
   /**
    * typedef enum {
-   *    AMDSMI_COMPUTE_PARTITION_INVALID = 0,
-   *    AMDSMI_COMPUTE_PARTITION_SPX,   //!< Single GPU mode (SPX)- All XCCs work
-   *                                    //!< together with shared memory
-   *    AMDSMI_COMPUTE_PARTITION_DPX,   //!< Dual GPU mode (DPX)- Half XCCs work
-   *                                    //!< together with shared memory
-   *    AMDSMI_COMPUTE_PARTITION_TPX,   //!< Triple GPU mode (TPX)- One-third XCCs
-   *                                    //!< work together with shared memory
-   *    AMDSMI_COMPUTE_PARTITION_QPX,   //!< Quad GPU mode (QPX)- Quarter XCCs
-   *                                    //!< work together with shared memory
-   *    AMDSMI_COMPUTE_PARTITION_CPX,  //!< Core mode (CPX)- Per-chip XCC with
-   *                                   //!< shared memory
-   * } amdsmi_compute_partition_type_t;
+   *    AMDSMI_ACCELERATOR_PARTITION_INVALID = 0,
+   *    AMDSMI_ACCELERATOR_PARTITION_SPX,   //!< Single GPU mode (SPX)- All XCCs work
+   *                                        //!< together with shared memory
+   *    AMDSMI_ACCELERATOR_PARTITION_DPX,   //!< Dual GPU mode (DPX)- Half XCCs work
+   *                                        //!< together with shared memory
+   *    AMDSMI_ACCELERATOR_PARTITION_TPX,   //!< Triple GPU mode (TPX)- One-third XCCs
+   *                                        //!< work together with shared memory
+   *    AMDSMI_ACCELERATOR_PARTITION_QPX,   //!< Quad GPU mode (QPX)- Quarter XCCs
+   *                                        //!< work together with shared memory
+   *    AMDSMI_ACCELERATOR_PARTITION_CPX,   //!< Core mode (CPX)- Per-chip XCC with
+   *                                        //!< shared memory
+   * } amdsmi_accelerator_partition_type_t;
    * */
   switch (computeParitionType) {
-    case AMDSMI_COMPUTE_PARTITION_SPX:
+    case AMDSMI_ACCELERATOR_PARTITION_SPX:
       return "SPX";
-    case AMDSMI_COMPUTE_PARTITION_DPX:
+    case AMDSMI_ACCELERATOR_PARTITION_DPX:
       return "DPX";
-    case AMDSMI_COMPUTE_PARTITION_TPX:
+    case AMDSMI_ACCELERATOR_PARTITION_TPX:
       return "TPX";
-    case AMDSMI_COMPUTE_PARTITION_QPX:
+    case AMDSMI_ACCELERATOR_PARTITION_QPX:
       return "QPX";
-    case AMDSMI_COMPUTE_PARTITION_CPX:
+    case AMDSMI_ACCELERATOR_PARTITION_CPX:
       return "CPX";
     default:
       return "N/A";
   }
 }
 
-static const std::map<std::string, amdsmi_compute_partition_type_t>
-    mapStringToSMIComputePartitionTypes{
-        {"SPX", AMDSMI_COMPUTE_PARTITION_SPX}, {"DPX", AMDSMI_COMPUTE_PARTITION_DPX},
-        {"TPX", AMDSMI_COMPUTE_PARTITION_TPX}, {"QPX", AMDSMI_COMPUTE_PARTITION_QPX},
-        {"CPX", AMDSMI_COMPUTE_PARTITION_CPX}, {"UNKNOWN", AMDSMI_COMPUTE_PARTITION_INVALID}};
+static const std::map<std::string, amdsmi_accelerator_partition_type_t>
+    mapStringToSMIComputePartitionTypes{{"SPX", AMDSMI_ACCELERATOR_PARTITION_SPX},
+                                        {"DPX", AMDSMI_ACCELERATOR_PARTITION_DPX},
+                                        {"TPX", AMDSMI_ACCELERATOR_PARTITION_TPX},
+                                        {"QPX", AMDSMI_ACCELERATOR_PARTITION_QPX},
+                                        {"CPX", AMDSMI_ACCELERATOR_PARTITION_CPX},
+                                        {"UNKNOWN", AMDSMI_ACCELERATOR_PARTITION_INVALID}};
 
 static const std::map<amdsmi_accelerator_partition_resource_type_t, std::string>
     resource_types_map = {
@@ -406,10 +408,10 @@ void TestComputePartitionReadWrite::Run(void) {
     if (ret == AMDSMI_STATUS_NOT_SUPPORTED) {
       continue;
     }
-    for (int partition = static_cast<int>(AMDSMI_COMPUTE_PARTITION_SPX);
-         partition <= static_cast<int>(AMDSMI_COMPUTE_PARTITION_CPX); partition++) {
-      amdsmi_compute_partition_type_t updatePartition =
-          static_cast<amdsmi_compute_partition_type_t>(partition);
+    for (int partition = static_cast<int>(AMDSMI_ACCELERATOR_PARTITION_SPX);
+         partition <= static_cast<int>(AMDSMI_ACCELERATOR_PARTITION_CPX); partition++) {
+      amdsmi_accelerator_partition_type_t updatePartition =
+          static_cast<amdsmi_accelerator_partition_type_t>(partition);
 
       IF_VERB(STANDARD) {
         std::cout << "\t**"
@@ -419,7 +421,9 @@ void TestComputePartitionReadWrite::Run(void) {
 
       DISPLAY_AMDSMI_API("amdsmi_set_gpu_compute_partition", "gpu=" + std::to_string(dv_ind),
                          VERB(STANDARD));
-      auto ret_set = amdsmi_set_gpu_compute_partition(processor_handles_[dv_ind], updatePartition);
+      auto ret_set = amdsmi_set_gpu_compute_partition(
+          processor_handles_[dv_ind],
+          static_cast<amdsmi_compute_partition_type_t>(updatePartition));
       DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret_set,
                             AMDSMI_STATUS_SETTING_UNAVAILABLE, AMDSMI_STATUS_NO_PERM,
                             AMDSMI_STATUS_SUCCESS, AMDSMI_STATUS_BUSY, AMDSMI_STATUS_NOT_SUPPORTED,
@@ -475,11 +479,13 @@ void TestComputePartitionReadWrite::Run(void) {
                                        std::string(current_char_computePartition)));
       }
     }
-    amdsmi_compute_partition_type_t updatePartition = static_cast<amdsmi_compute_partition_type_t>(
-        mapStringToSMIComputePartitionTypes.at(std::string(orig_char_computePartition)));
+    amdsmi_accelerator_partition_type_t updatePartition =
+        static_cast<amdsmi_accelerator_partition_type_t>(
+            mapStringToSMIComputePartitionTypes.at(std::string(orig_char_computePartition)));
     DISPLAY_AMDSMI_API("amdsmi_set_gpu_compute_partition", "gpu=" + std::to_string(dv_ind),
                        VERB(STANDARD));
-    auto ret_set = amdsmi_set_gpu_compute_partition(processor_handles_[dv_ind], updatePartition);
+    auto ret_set = amdsmi_set_gpu_compute_partition(
+        processor_handles_[dv_ind], static_cast<amdsmi_compute_partition_type_t>(updatePartition));
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret_set,
                           AMDSMI_STATUS_SETTING_UNAVAILABLE, AMDSMI_STATUS_NO_PERM,
                           AMDSMI_STATUS_SUCCESS, AMDSMI_STATUS_BUSY, AMDSMI_STATUS_NOT_SUPPORTED,
@@ -964,7 +970,7 @@ void TestComputePartitionReadWrite::Run(void) {
     }
     for (int partition = static_cast<int>(
              mapStringToSMIComputePartitionTypes.at(std::string(orig_char_computePartition)));
-         partition <= static_cast<int>(AMDSMI_COMPUTE_PARTITION_CPX); partition++) {
+         partition <= static_cast<int>(AMDSMI_ACCELERATOR_PARTITION_CPX); partition++) {
       uint32_t device_index2 = 0;
       amdsmi_processor_handle p_handle2 = {};
       smi_amdgpu_get_device_count(&current_num_devices);
@@ -982,10 +988,11 @@ void TestComputePartitionReadWrite::Run(void) {
         std::cout << "\t=========== END INDEX/p_handle DEVICE INFO 2 =============\n";
       }
 
-      amdsmi_compute_partition_type_t updatePartition =
-          static_cast<amdsmi_compute_partition_type_t>(partition);
+      amdsmi_accelerator_partition_type_t updatePartition =
+          static_cast<amdsmi_accelerator_partition_type_t>(partition);
       DISPLAY_AMDSMI_API("amdsmi_set_gpu_compute_partition", "", VERB(STANDARD));
-      auto ret_set = amdsmi_set_gpu_compute_partition(p_handle2, updatePartition);
+      auto ret_set = amdsmi_set_gpu_compute_partition(
+          p_handle2, static_cast<amdsmi_compute_partition_type_t>(updatePartition));
       DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret_set,
                             AMDSMI_STATUS_SETTING_UNAVAILABLE, AMDSMI_STATUS_NO_PERM,
                             AMDSMI_STATUS_SUCCESS, AMDSMI_STATUS_BUSY, AMDSMI_STATUS_NOT_SUPPORTED,
@@ -1047,14 +1054,16 @@ void TestComputePartitionReadWrite::Run(void) {
     smi_amdgpu_get_processor_handle_by_index(dv_ind, &p_handle3);
     smi_amdgpu_get_device_index(p_handle3, &device_index3);
 
-    amdsmi_compute_partition_type_t updatePartition = static_cast<amdsmi_compute_partition_type_t>(
-        mapStringToSMIComputePartitionTypes.at(std::string(orig_char_computePartition)));
+    amdsmi_accelerator_partition_type_t updatePartition =
+        static_cast<amdsmi_accelerator_partition_type_t>(
+            mapStringToSMIComputePartitionTypes.at(std::string(orig_char_computePartition)));
     IF_VERB(STANDARD) {
       std::cout << "\t**ABOUT TO GO BACK TO ORIGINAL PARTITION (" << orig_char_computePartition
                 << ")\n";
     }
     DISPLAY_AMDSMI_API("amdsmi_set_gpu_compute_partition", "", VERB(STANDARD));
-    auto ret_set = amdsmi_set_gpu_compute_partition(p_handle3, updatePartition);
+    auto ret_set = amdsmi_set_gpu_compute_partition(
+        p_handle3, static_cast<amdsmi_compute_partition_type_t>(updatePartition));
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret_set, AMDSMI_STATUS_SUCCESS);
     checkPartitionIdChanges(processor_handles_, dv_ind, std::string(orig_char_computePartition),
                             isVerbose, true);

--- a/projects/amdsmi/tests/amd_smi_test/functional/gpu/partition/memorypartition_read_write_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/gpu/partition/memorypartition_read_write_test.cc
@@ -460,7 +460,7 @@ void TestMemoryPartitionReadWrite::Run(void) {
     }
 
     /****************************************/
-    /* amdsmi_set_gpu_memory_partition(...) */
+    /* amdsmi_set_gpu_memory_partition_mode(...) */
     /****************************************/
     // Verify api support checking functionality is working
     amdsmi_memory_partition_type_t null_memory_partition = {};
@@ -468,7 +468,7 @@ void TestMemoryPartitionReadWrite::Run(void) {
                        VERB(STANDARD));
     err = amdsmi_set_gpu_memory_partition_mode(processor_handles_[dv_ind], null_memory_partition);
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_INVAL);
-    std::cout << "\t**amdsmi_set_gpu_memory_partition(amdsmi_set_gpu_memory_partition_mode"
+    std::cout << "\t**amdsmi_set_gpu_memory_partition_mode"
               << "(processor_handles_[" << dv_ind
               << "], nullptr): " << smi_amdgpu_get_status_string(err, false) << "\n";
     // Note: new_memory_partition is not set
@@ -665,13 +665,13 @@ void TestMemoryPartitionReadWrite::Run(void) {
                 << "Returning memory partition to: " << memoryPartitionString(new_memory_partition)
                 << std::endl;
     }
-    DISPLAY_AMDSMI_API("amdsmi_set_gpu_memory_partition", "gpu=" + std::to_string(dv_ind),
+    DISPLAY_AMDSMI_API("amdsmi_set_gpu_memory_partition_mode", "gpu=" + std::to_string(dv_ind),
                        VERB(STANDARD));
-    ret = amdsmi_set_gpu_memory_partition(processor_handles_[dv_ind], new_memory_partition);
+    ret = amdsmi_set_gpu_memory_partition_mode(processor_handles_[dv_ind], new_memory_partition);
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
     IF_VERB(STANDARD) {
       std::cout << "\t**"
-                << "amdsmi_set_gpu_memory_partition(processor_handles_[" << dv_ind << "], "
+                << "amdsmi_set_gpu_memory_partition_mode(processor_handles_[" << dv_ind << "], "
                 << orig_memory_partition << "): " << smi_amdgpu_get_status_string(ret, false)
                 << std::endl;
     }

--- a/projects/amdsmi/tests/amd_smi_test/functional/gpu/ras/err_cnt_read_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/gpu/ras/err_cnt_read_test.cc
@@ -74,15 +74,14 @@ void TestErrCntRead::Run(void) {
     for (uint32_t i = 0; i < num_monitor_devs(); ++i) {
       PrintDeviceHeader(processor_handles_[i]);
 
-      DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_supported", "gpu=" + std::to_string(i),
-                         VERB(STANDARD));
-      err = amdsmi_get_gpu_ecc_supported(processor_handles_[i], &enabled_mask);
+      DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_enabled", "gpu=" + std::to_string(i), VERB(STANDARD));
+      err = amdsmi_get_gpu_ecc_enabled(processor_handles_[i], &enabled_mask);
       DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_SUCCESS);
       if (err == AMDSMI_STATUS_NOT_SUPPORTED) {
         // Verify api support checking functionality is working
-        DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_supported", "gpu=" + std::to_string(i),
+        DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_enabled", "gpu=" + std::to_string(i),
                            VERB(STANDARD));
-        err = amdsmi_get_gpu_ecc_supported(processor_handles_[i], nullptr);
+        err = amdsmi_get_gpu_ecc_enabled(processor_handles_[i], nullptr);
         DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_INVAL);
         ASSERT_EQ(err, AMDSMI_STATUS_NOT_SUPPORTED);
         continue;
@@ -90,9 +89,9 @@ void TestErrCntRead::Run(void) {
         CHK_ERR_ASRT(err)
 
         // Verify api support checking functionality is working
-        DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_supported", "gpu=" + std::to_string(i),
+        DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_enabled", "gpu=" + std::to_string(i),
                            VERB(STANDARD));
-        err = amdsmi_get_gpu_ecc_supported(processor_handles_[i], nullptr);
+        err = amdsmi_get_gpu_ecc_enabled(processor_handles_[i], nullptr);
         DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_INVAL);
         ASSERT_EQ(err, AMDSMI_STATUS_INVAL);
 

--- a/projects/amdsmi/tests/amd_smi_test/functional/gpu/ras/err_cnt_read_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/gpu/ras/err_cnt_read_test.cc
@@ -74,14 +74,15 @@ void TestErrCntRead::Run(void) {
     for (uint32_t i = 0; i < num_monitor_devs(); ++i) {
       PrintDeviceHeader(processor_handles_[i]);
 
-      DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_enabled", "gpu=" + std::to_string(i), VERB(STANDARD));
-      err = amdsmi_get_gpu_ecc_enabled(processor_handles_[i], &enabled_mask);
+      DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_supported", "gpu=" + std::to_string(i),
+                         VERB(STANDARD));
+      err = amdsmi_get_gpu_ecc_supported(processor_handles_[i], &enabled_mask);
       DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_SUCCESS);
       if (err == AMDSMI_STATUS_NOT_SUPPORTED) {
         // Verify api support checking functionality is working
-        DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_enabled", "gpu=" + std::to_string(i),
+        DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_supported", "gpu=" + std::to_string(i),
                            VERB(STANDARD));
-        err = amdsmi_get_gpu_ecc_enabled(processor_handles_[i], nullptr);
+        err = amdsmi_get_gpu_ecc_supported(processor_handles_[i], nullptr);
         DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_INVAL);
         ASSERT_EQ(err, AMDSMI_STATUS_NOT_SUPPORTED);
         continue;
@@ -89,9 +90,9 @@ void TestErrCntRead::Run(void) {
         CHK_ERR_ASRT(err)
 
         // Verify api support checking functionality is working
-        DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_enabled", "gpu=" + std::to_string(i),
+        DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_supported", "gpu=" + std::to_string(i),
                            VERB(STANDARD));
-        err = amdsmi_get_gpu_ecc_enabled(processor_handles_[i], nullptr);
+        err = amdsmi_get_gpu_ecc_supported(processor_handles_[i], nullptr);
         DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_INVAL);
         ASSERT_EQ(err, AMDSMI_STATUS_INVAL);
 

--- a/projects/amdsmi/tests/amd_smi_test/functional/ifoe/identity/ifoe_info_read_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/ifoe/identity/ifoe_info_read_test.cc
@@ -127,21 +127,6 @@ void TestIfoeInfoRead::Run(void) {
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_SUCCESS);
     CHK_ERR_ASRT(err)
 
-    DISPLAY_AMDSMI_API("amdsmi_get_gpu_vram_vendor", "gpu=" + std::to_string(i), VERB(STANDARD));
-    err = amdsmi_get_gpu_vram_vendor(processor_handles_[i], buffer, kBufferLen);
-    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_SUCCESS);
-    if (err == AMDSMI_STATUS_NOT_SUPPORTED) {
-      std::cout << "\t**Vram Vendor string not supported on this system." << std::endl;
-      DISPLAY_AMDSMI_API("amdsmi_get_gpu_vram_vendor(nullptr check)", "gpu=" + std::to_string(i),
-                         VERB(STANDARD));
-      err = amdsmi_get_gpu_vram_vendor(processor_handles_[i], nullptr, kBufferLen);
-      DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_NOT_SUPPORTED);
-      ASSERT_EQ(err, AMDSMI_STATUS_NOT_SUPPORTED);
-    } else {
-      CHK_ERR_ASRT(err)
-      IF_VERB(STANDARD) { std::cout << "\t**Device Vram Vendor name: " << buffer << std::endl; }
-    }
-
     amdsmi_vram_info_t vram_info;
     DISPLAY_AMDSMI_API("amdsmi_get_gpu_vram_info", "gpu=" + std::to_string(i), VERB(STANDARD));
     err = amdsmi_get_gpu_vram_info(processor_handles_[i], &vram_info);

--- a/projects/amdsmi/tests/amd_smi_test/functional/system/mutual_exclusion_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/system/mutual_exclusion_test.cc
@@ -375,8 +375,9 @@ void TestMutualExclusion::Run(void) {
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
 
-    DISPLAY_AMDSMI_API("amdsmi_get_gpu_vram_vendor", "0", VERB(STANDARD));
-    ret = amdsmi_get_gpu_vram_vendor(processor_handles_[0], dmy_str, 10);
+    amdsmi_vram_info_t vram_info;
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_vram_info", "0", VERB(STANDARD));
+    ret = amdsmi_get_gpu_vram_info(processor_handles_[0], &vram_info);
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
 
@@ -469,8 +470,8 @@ void TestMutualExclusion::Run(void) {
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
 
-    DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_enabled", "0", VERB(STANDARD));
-    ret = amdsmi_get_gpu_ecc_enabled(processor_handles_[0], &dmy_ui64);
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_supported", "0", VERB(STANDARD));
+    ret = amdsmi_get_gpu_ecc_supported(processor_handles_[0], &dmy_ui64);
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
 
@@ -488,7 +489,7 @@ void TestMutualExclusion::Run(void) {
     amdsmi_dev_firmware_version_get
     amdsmi_dev_name_get
     amdsmi_dev_brand_get
-    amdsmi_get_gpu_vram_vendor
+    amdsmi_get_gpu_vram_info
     amdsmi_get_gpu_subsystem_name
     amdsmi_get_gpu_vendor_name
     amdsmi_get_gpu_pci_bandwidth

--- a/projects/amdsmi/tests/amd_smi_test/functional/system/mutual_exclusion_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/system/mutual_exclusion_test.cc
@@ -470,8 +470,8 @@ void TestMutualExclusion::Run(void) {
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
 
-    DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_supported", "0", VERB(STANDARD));
-    ret = amdsmi_get_gpu_ecc_supported(processor_handles_[0], &dmy_ui64);
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_enabled", "0", VERB(STANDARD));
+    ret = amdsmi_get_gpu_ecc_enabled(processor_handles_[0], &dmy_ui64);
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
 

--- a/projects/amdsmi/tests/amd_smi_test/main.cc
+++ b/projects/amdsmi/tests/amd_smi_test/main.cc
@@ -24,6 +24,7 @@
 #include <cstdlib>
 
 #include "amd_smi/impl/amd_smi_utils.h"
+#include "functional/gpu/clock/clock_limit_read_write.h"
 #include "functional/gpu/clock/frequencies_read.h"
 #include "functional/gpu/clock/frequencies_read_write.h"
 #include "functional/gpu/events/evt_notif_read_write.h"
@@ -173,6 +174,12 @@ TEST(GpuFunctionalReadWrite, TestFrequenciesReadWrite) {
   if (std::getenv("AMDSMI_NON_PRIVILEGED")) GTEST_SKIP_("Skipped in non-privileged mode");
   if (!amd::smi::is_sudo_user()) GTEST_SKIP_("Invalid permission - Must run as super user");
   TestFrequenciesReadWrite tst;
+  RunGenericTest(&tst);
+}
+TEST(GpuFunctionalReadWrite, TestClockLimitReadWrite) {
+  if (std::getenv("AMDSMI_NON_PRIVILEGED")) GTEST_SKIP_("Skipped in non-privileged mode");
+  if (!amd::smi::is_sudo_user()) GTEST_SKIP_("Invalid permission - Must run as super user");
+  TestClockLimitReadWrite tst;
   RunGenericTest(&tst);
 }
 TEST(GpuFunctionalReadWrite, TestPciReadWrite) {

--- a/projects/amdsmi/tests/python/cli/base.py
+++ b/projects/amdsmi/tests/python/cli/base.py
@@ -88,6 +88,10 @@ class TestCliBase(unittest.TestCase):
         TestCliBase.sub_args = baseline["sub_args"]
         TestCliBase._initialized = True
 
+        # TODO: Remove this condition when CLI supports User automated input
+        # Commands that need User permission to run
+        cls.cmds_need_permission = {"set": ["--fan", "--memory-partition", "--compute-partition"]}
+
     @classmethod
     def _build_baseline(cls):
         baseline = {}
@@ -182,12 +186,12 @@ class TestCliBase(unittest.TestCase):
             "DETERMINISM",
         ]
         self.profile_levels = [
-            "CUSTOM_MASK",
-            "VIDEO_MASK",
-            "POWER_SAVING_MASK",
-            "COMPUTE_MASK",
-            "VR_MASK",
-            "THREE_D_FULL_SCR_MASK",
+            "CUSTOM",
+            "VIDEO",
+            "POWER_SAVING",
+            "COMPUTE",
+            "VR",
+            "3D_FULL_SCREEN",
             "BOOTUP_DEFAULT",
         ]
         self.compute_partition_modes = ["SPX", "DPX", "TPX", "QPX", "CPX"]
@@ -538,7 +542,7 @@ class TestCliBase(unittest.TestCase):
                     if clock_sys != "N/A" and len(clock_sys["frequency_levels"]):
                         num = len(clock_sys["frequency_levels"])
                         level = f"Level {num - 1}"
-                        clock_freq = int(clock_sys["frequency_levels"][level].split()[0].strip())
+                        clock_freq = int(clock_sys["frequency_levels"][level]["value"])
                         cmd = cmd.replace(
                             "{perf_determinism}", f"--perf-determinism {clock_freq + 50}", 1
                         )
@@ -706,6 +710,21 @@ class TestCliBase(unittest.TestCase):
                                 cmd = ""
                                 break
 
+                cmds[index] = (cmd, cond)
+
+        # Remove commands requiring input
+        for index, cmd_cond in enumerate(cmds):
+            cmd, cond = cmd_cond
+            if not cmd:
+                continue
+            items = cmd.split()
+            if len(items) < 3:
+                continue
+            if items[1] == "set":
+                if items[2] in self.cmds_need_permission["set"]:
+                    cmd = ""
+            # Update cmds when cmd has changed
+            if not cmd:
                 cmds[index] = (cmd, cond)
 
         # Remove empty (cmd,cond) arguments

--- a/projects/amdsmi/tests/python/cli/test_set.py
+++ b/projects/amdsmi/tests/python/cli/test_set.py
@@ -41,13 +41,6 @@ class TestSet(TestCliBase):
         msg = f"{self.tab}### amd-smi set"
         self.common.print(msg)
 
-        # TODO allow set commands to be executed
-        if not self.PrintCmdsOnly:
-            if self.common.TODO_SKIP_FAIL:
-                msg = f"{self.tab}Needs input"
-                # self.common.print(msg)
-                self.skipTest(msg)
-
         # Get current settings
         power_profile = {}
         for index, gpu in enumerate(self.common.processors):
@@ -99,7 +92,7 @@ class TestSet(TestCliBase):
             if clock_sys != "N/A":
                 num = len(clock_sys["frequency_levels"])
                 level = f"Level {num - 1}"
-                clock_freq = int(clock_sys["frequency_levels"][level].split()[0].strip())
+                clock_freq = int(clock_sys["frequency_levels"][level]["value"])
                 cmds.append(
                     (f"amd-smi set --perf-determinism {clock_freq} --gpu {index}", self.PASS)
                 )

--- a/projects/amdsmi/tests/python/common/common.py
+++ b/projects/amdsmi/tests/python/common/common.py
@@ -327,13 +327,13 @@ def build_type_lists():
             (member.name, amdsmi.AmdSmiMemoryPartitionType(member.value), cond)
         )
 
-    compute_partition_mem_alloc_mode_types = []
-    for member in amdsmi.AmdSmiComputePartitionMemAllocModeType:
+    accelerator_partition_mem_alloc_mode_types = []
+    for member in amdsmi.AmdSmiAcceleratorPartitionMemAllocModeType:
         cond = PASS
         if member.name in ["INVALID"]:
             cond = FAIL
-        compute_partition_mem_alloc_mode_types.append(
-            (member.name, amdsmi.AmdSmiComputePartitionMemAllocModeType(member.value), cond)
+        accelerator_partition_mem_alloc_mode_types.append(
+            (member.name, amdsmi.AmdSmiAcceleratorPartitionMemAllocModeType(member.value), cond)
         )
 
     freq_inds = []
@@ -388,7 +388,7 @@ def build_type_lists():
         "counter_commands": counter_commands,
         "compute_partition_types": compute_partition_types,
         "memory_partition_types": memory_partition_types,
-        "compute_partition_mem_alloc_mode_types": compute_partition_mem_alloc_mode_types,
+        "accelerator_partition_mem_alloc_mode_types": accelerator_partition_mem_alloc_mode_types,
         "freq_inds": freq_inds,
         "power_profile_preset_masks": power_profile_preset_masks,
         "processor_types": processor_types,
@@ -419,7 +419,9 @@ EVENT_TYPES = _TYPE_LISTS["event_types"]
 COUNTER_COMMANDS = _TYPE_LISTS["counter_commands"]
 COMPUTE_PARTITION_TYPES = _TYPE_LISTS["compute_partition_types"]
 MEMORY_PARTITION_TYPES = _TYPE_LISTS["memory_partition_types"]
-COMPUTE_PARTITION_MEM_ALLOC_MODE_TYPES = _TYPE_LISTS["compute_partition_mem_alloc_mode_types"]
+ACCELERATOR_PARTITION_MEM_ALLOC_MODE_TYPES = _TYPE_LISTS[
+    "accelerator_partition_mem_alloc_mode_types"
+]
 FREQ_INDS = _TYPE_LISTS["freq_inds"]
 POWER_PROFILE_PRESET_MASKS = _TYPE_LISTS["power_profile_preset_masks"]
 PROCESSOR_TYPES = _TYPE_LISTS["processor_types"]

--- a/projects/amdsmi/tests/python/functional/gpu/test_benchmark.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_benchmark.py
@@ -3335,46 +3335,6 @@ class TestGpuBenchmark(unittest.TestCase):
 
         self._log_performance_summary("amdsmi_set_gpu_clk_limit", "Processors", "set_gpu_clk_limit")
 
-    def test_performance_set_gpu_clk_range(self):
-        self.common.print_func_name("")
-
-        # Use TODO placeholder values like original test
-        min_clk_value = 100
-        max_clk_value = 200
-
-        for i, processor in enumerate(self.processors):
-            for clk_type_name, clk_type, clk_cond in common.CLK_TYPES:
-                self._log_test_start(
-                    "amdsmi_set_gpu_clk_range",
-                    "Processor",
-                    i,
-                    min_clk_value=min_clk_value,
-                    max_clk_value=max_clk_value,
-                    clk_type=clk_type_name,
-                )
-
-                stats = self._measure_api_performance(
-                    amdsmi.amdsmi_set_gpu_clk_range,
-                    f"set_gpu_clk_range_processor_{i}_clk_{clk_type_name}",
-                    processor,
-                    min_clk_value,
-                    max_clk_value,
-                    clk_type,
-                )
-
-                self.perf_results[f"set_gpu_clk_range_processor_{i}_clk_{clk_type_name}"] = stats
-
-                if stats["successful_runs"] > 0:
-                    self._print_performance_results(stats)
-                else:
-                    self.common.print(
-                        f"  Processor {i} clk={clk_type_name}: All calls failed - {stats['errors'][0]['error_info'] if stats['errors'] else 'Unknown'}"
-                    )
-
-                self._log_test_completion("Processor", i, f"clk_type={clk_type_name}")
-
-        self._log_performance_summary("amdsmi_set_gpu_clk_range", "Processors", "set_gpu_clk_range")
-
     def test_performance_set_gpu_compute_partition(self):
         self.common.print_func_name("")
 

--- a/projects/amdsmi/tests/python/functional/gpu/test_benchmark.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_benchmark.py
@@ -916,12 +916,12 @@ class TestGpuBenchmark(unittest.TestCase):
         self.common.print_func_name("")
 
         for i, processor in enumerate(self.processors):
-            self._log_test_start("amdsmi_get_gpu_ecc_supported", "Processor", i)
+            self._log_test_start("amdsmi_get_gpu_ecc_enabled", "Processor", i)
 
-            self._print_api_result(amdsmi.amdsmi_get_gpu_ecc_supported, i, processor)
+            self._print_api_result(amdsmi.amdsmi_get_gpu_ecc_enabled, i, processor)
 
             stats = self._measure_api_performance(
-                amdsmi.amdsmi_get_gpu_ecc_supported, f"get_gpu_ecc_enabled_gpu_{i}", processor
+                amdsmi.amdsmi_get_gpu_ecc_enabled, f"get_gpu_ecc_enabled_gpu_{i}", processor
             )
 
             self.perf_results[f"get_gpu_ecc_enabled_gpu_{i}"] = stats
@@ -936,7 +936,7 @@ class TestGpuBenchmark(unittest.TestCase):
             self._log_test_completion("Processor", i)
 
         self._log_performance_summary(
-            "amdsmi_get_gpu_ecc_supported", "Processors", "get_gpu_ecc_supported"
+            "amdsmi_get_gpu_ecc_enabled", "Processors", "get_gpu_ecc_enabled"
         )
 
     def test_performance_get_gpu_ecc_status(self):

--- a/projects/amdsmi/tests/python/functional/gpu/test_benchmark.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_benchmark.py
@@ -916,12 +916,12 @@ class TestGpuBenchmark(unittest.TestCase):
         self.common.print_func_name("")
 
         for i, processor in enumerate(self.processors):
-            self._log_test_start("amdsmi_get_gpu_ecc_enabled", "Processor", i)
+            self._log_test_start("amdsmi_get_gpu_ecc_supported", "Processor", i)
 
-            self._print_api_result(amdsmi.amdsmi_get_gpu_ecc_enabled, i, processor)
+            self._print_api_result(amdsmi.amdsmi_get_gpu_ecc_supported, i, processor)
 
             stats = self._measure_api_performance(
-                amdsmi.amdsmi_get_gpu_ecc_enabled, f"get_gpu_ecc_enabled_gpu_{i}", processor
+                amdsmi.amdsmi_get_gpu_ecc_supported, f"get_gpu_ecc_enabled_gpu_{i}", processor
             )
 
             self.perf_results[f"get_gpu_ecc_enabled_gpu_{i}"] = stats
@@ -936,7 +936,7 @@ class TestGpuBenchmark(unittest.TestCase):
             self._log_test_completion("Processor", i)
 
         self._log_performance_summary(
-            "amdsmi_get_gpu_ecc_enabled", "Processors", "get_gpu_ecc_enabled"
+            "amdsmi_get_gpu_ecc_supported", "Processors", "get_gpu_ecc_supported"
         )
 
     def test_performance_get_gpu_ecc_status(self):
@@ -2052,33 +2052,6 @@ class TestGpuBenchmark(unittest.TestCase):
 
         self._log_performance_summary(
             "amdsmi_get_gpu_vram_usage", "Processors", "get_gpu_vram_usage"
-        )
-
-    def test_performance_get_gpu_vram_vendor(self):
-        self.common.print_func_name("")
-
-        for i, processor in enumerate(self.processors):
-            self._log_test_start("amdsmi_get_gpu_vram_vendor", "Processor", i)
-
-            self._print_api_result(amdsmi.amdsmi_get_gpu_vram_vendor, i, processor)
-
-            stats = self._measure_api_performance(
-                amdsmi.amdsmi_get_gpu_vram_vendor, f"get_gpu_vram_vendor_gpu_{i}", processor
-            )
-
-            self.perf_results[f"get_gpu_vram_vendor_gpu_{i}"] = stats
-
-            if stats["successful_runs"] > 0:
-                self._print_performance_results(stats)
-            else:
-                self.common.print(
-                    f"  Processor {i}: All calls failed - {stats['errors'][0]['error_info'] if stats['errors'] else 'Unknown'}"
-                )
-
-            self._log_test_completion("Processor", i)
-
-        self._log_performance_summary(
-            "amdsmi_get_gpu_vram_vendor", "Processors", "get_gpu_vram_vendor"
         )
 
     def test_performance_get_gpu_xcd_counter(self):

--- a/projects/amdsmi/tests/python/functional/gpu/test_identity.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_identity.py
@@ -137,11 +137,6 @@ class TestGpuIdentity(unittest.TestCase):
         self.common.Test_API_Per_GPU(amdsmi_get_gpu_vram_info=amdsmi.amdsmi_get_gpu_vram_info)
         return
 
-    def test_get_gpu_vram_vendor(self):
-        self.common.print_func_name("")
-        self.common.Test_API_Per_GPU(amdsmi_get_gpu_vram_vendor=amdsmi.amdsmi_get_gpu_vram_vendor)
-        return
-
     def test_get_lib_version(self):
         self.common.print_func_name("")
         self.common.Test_API(amdsmi_get_lib_version=amdsmi.amdsmi_get_lib_version)

--- a/projects/amdsmi/tests/python/functional/gpu/test_overdrive.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_overdrive.py
@@ -239,31 +239,6 @@ class TestGpuOverdrive(unittest.TestCase):
             raise self.raise_exception
         return
 
-    # out of order; min_clk_value, max_clk_value then clk_type
-
-    def test_set_gpu_clk_range(self):
-        self.common.print_func_name("")
-
-        # TODO Find better way to set min_clk_value, max_clk_value
-        min_clk_value = 100
-        max_clk_value = 200
-
-        for i, gpu in enumerate(self.common.processors):
-            self.common.print_device_header(i)
-            for _, clk_type, clk_cond in common.CLK_TYPES:
-                msg = f"\t### amdsmi_set_gpu_clk_range(gpu={i}, min_clk_value={min_clk_value}, max_clk_value={max_clk_value}, clk_type={clk_type}):"
-                try:
-                    amdsmi.amdsmi_set_gpu_clk_range(gpu, min_clk_value, max_clk_value, clk_type)
-                    self.common.print(msg, "")
-                    self.common.check_ret("", "", self.common.PASS)
-                except amdsmi.AmdSmiLibraryException as e:
-                    if self.common.check_ret(msg, e, clk_cond):
-                        self.raise_exception = e
-                self.common.print("")
-        if self.raise_exception:
-            raise self.raise_exception
-        return
-
     def test_set_gpu_od_clk_info(self):
         self.common.print_func_name("")
 

--- a/projects/amdsmi/tests/python/functional/gpu/test_partition.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_partition.py
@@ -277,10 +277,10 @@ class TestGpuPartition(unittest.TestCase):
         )
         return
 
-    def test_get_gpu_compute_partition_mem_alloc_mode(self):
+    def test_get_gpu_accelerator_partition_mem_alloc_mode(self):
         self.common.print_func_name("")
         self.common.Test_API_Per_GPU(
-            amdsmi_get_gpu_compute_partition_mem_alloc_mode=amdsmi.amdsmi_get_gpu_compute_partition_mem_alloc_mode
+            amdsmi_get_gpu_accelerator_partition_mem_alloc_mode=amdsmi.amdsmi_get_gpu_accelerator_partition_mem_alloc_mode
         )
         return
 
@@ -328,83 +328,11 @@ class TestGpuPartition(unittest.TestCase):
         """Verify that set accepts supported modes and rejects unsupported ones."""
         self.common.print_func_name("")
 
-        NPS_NAME_TO_TYPE = {
-            "NPS1": amdsmi.AmdSmiMemoryPartitionType.NPS1,
-            "NPS2": amdsmi.AmdSmiMemoryPartitionType.NPS2,
-            "NPS4": amdsmi.AmdSmiMemoryPartitionType.NPS4,
-            "NPS8": amdsmi.AmdSmiMemoryPartitionType.NPS8,
-        }
-
-        raise_exception = None
-        for i, gpu in enumerate(self.common.processors):
-            self.common.print_device_header(i)
-
-            # Read current partition for restore.
-            original_partition = None
-            msg = f"\t### amdsmi_get_gpu_memory_partition(gpu={i}):"
-            try:
-                original_partition = amdsmi.amdsmi_get_gpu_memory_partition(gpu)
-                self.common.print(msg, original_partition)
-            except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                if self.common.check_ret(msg, e, self.common.PASS):
-                    raise_exception = e
-                continue
-
-            # Read hardware capabilities to build per-GPU condition map.
-            supported_modes = set()
-            msg = f"\t### amdsmi_get_gpu_memory_partition_config(gpu={i}):"
-            try:
-                config = amdsmi.amdsmi_get_gpu_memory_partition_config(gpu)
-                caps = config.get("partition_caps", [])
-                self.common.print(msg, caps)
-                supported_modes = {c for c in caps if c in NPS_NAME_TO_TYPE}
-            except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                # Older kernels may not support config query; fall through with empty set.
-                self.common.print(msg, e)
-
-            # Attempt each NPS mode; condition is driven by hardware capabilities.
-            for mode_name, mode_type in NPS_NAME_TO_TYPE.items():
-                cond = self.common.PASS if mode_name in supported_modes else self.common.FAIL
-                msg = f"\t### amdsmi_set_gpu_memory_partition(gpu={i}, mode={mode_name}):"
-                try:
-                    amdsmi.amdsmi_set_gpu_memory_partition(gpu, mode_type)
-                    self.common.print(msg, "SUCCESS")
-                    if cond == self.common.FAIL:
-                        self.common.print(
-                            f"\t   TEST FAILURE: expected failure for {mode_name} but call succeeded",
-                            "",
-                        )
-                        raise_exception = amdsmi.AmdSmiLibraryException(0)
-                    else:
-                        self.common.check_ret("", "", self.common.PASS)
-                    self.common.print(
-                        f"\t   [info] Staged {mode_name}. Apply with: "
-                        "sudo modprobe -r amdgpu && sudo modprobe amdgpu",
-                        "",
-                    )
-                except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                    if self.common.check_ret(msg, e, cond):
-                        raise_exception = e
-
-            # Restore original partition (stages the write; driver reload applies it).
-            if original_partition and original_partition in NPS_NAME_TO_TYPE:
-                msg = f"\t### amdsmi_set_gpu_memory_partition restore(gpu={i}, mode={original_partition}):"
-                try:
-                    amdsmi.amdsmi_set_gpu_memory_partition(
-                        gpu, NPS_NAME_TO_TYPE[original_partition]
-                    )
-                    self.common.print(msg, "SUCCESS")
-                    self.common.print(
-                        f"\t   [info] Restore staged to {original_partition}. Apply with: "
-                        "sudo modprobe -r amdgpu && sudo modprobe amdgpu",
-                        "",
-                    )
-                except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                    if self.common.check_ret(msg, e, self.common.PASS):
-                        raise_exception = e
-
-        if raise_exception:
-            raise raise_exception
+        self.common.Test_Per_GPU_With_One_Enum(
+            amdsmi_set_gpu_memory_partition_mode=amdsmi.amdsmi_set_gpu_memory_partition_mode,
+            memory_partition_type=common.MEMORY_PARTITION_TYPES,
+        )
+        return
 
     def test_set_gpu_memory_partition_idempotent(self):
         """Setting the current partition mode must succeed and leave the read-back unchanged."""
@@ -480,12 +408,12 @@ class TestGpuPartition(unittest.TestCase):
         )
         return
 
-    def test_set_gpu_compute_partition_mem_alloc_mode(self):
+    def test_set_gpu_accelerator_partition_mem_alloc_mode(self):
         self.common.print_func_name("")
 
         self.common.Test_Per_GPU_With_One_Enum(
-            amdsmi_set_gpu_compute_partition_mem_alloc_mode=amdsmi.amdsmi_set_gpu_compute_partition_mem_alloc_mode,
-            compute_partition_mem_alloc_mode=common.COMPUTE_PARTITION_MEM_ALLOC_MODE_TYPES,
+            amdsmi_set_gpu_accelerator_partition_mem_alloc_mode=amdsmi.amdsmi_set_gpu_accelerator_partition_mem_alloc_mode,
+            accelerator_partition_mem_alloc_mode=common.ACCELERATOR_PARTITION_MEM_ALLOC_MODE_TYPES,
         )
         return
 

--- a/projects/amdsmi/tests/python/functional/gpu/test_ras.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_ras.py
@@ -63,9 +63,7 @@ class TestGpuRas(unittest.TestCase):
 
     def test_get_gpu_ecc_enabled(self):
         self.common.print_func_name("")
-        self.common.Test_API_Per_GPU(
-            amdsmi_get_gpu_ecc_supported=amdsmi.amdsmi_get_gpu_ecc_supported
-        )
+        self.common.Test_API_Per_GPU(amdsmi_get_gpu_ecc_enabled=amdsmi.amdsmi_get_gpu_ecc_enabled)
         return
 
     def test_get_gpu_ecc_status(self):

--- a/projects/amdsmi/tests/python/functional/gpu/test_ras.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_ras.py
@@ -63,7 +63,9 @@ class TestGpuRas(unittest.TestCase):
 
     def test_get_gpu_ecc_enabled(self):
         self.common.print_func_name("")
-        self.common.Test_API_Per_GPU(amdsmi_get_gpu_ecc_enabled=amdsmi.amdsmi_get_gpu_ecc_enabled)
+        self.common.Test_API_Per_GPU(
+            amdsmi_get_gpu_ecc_supported=amdsmi.amdsmi_get_gpu_ecc_supported
+        )
         return
 
     def test_get_gpu_ecc_status(self):

--- a/projects/amdsmi/tools/hw_compatibility_status.py
+++ b/projects/amdsmi/tools/hw_compatibility_status.py
@@ -342,7 +342,7 @@ def run_tests():
 
     # Get CPU socket handles (for CPU APIs)
     try:
-        cpu_socket_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        cpu_socket_handles = amdsmi.amdsmi_get_cpu_handles()
     except:
         cpu_socket_handles = []
 
@@ -515,8 +515,6 @@ def run_tests():
     test_api("amdsmi_get_gpu_vendor_name", lambda: amdsmi.amdsmi_get_gpu_vendor_name(gpu_handle))
 
     test_api("amdsmi_get_gpu_id", lambda: amdsmi.amdsmi_get_gpu_id(gpu_handle))
-
-    test_api("amdsmi_get_gpu_vram_vendor", lambda: amdsmi.amdsmi_get_gpu_vram_vendor(gpu_handle))
 
     test_api(
         "amdsmi_get_gpu_drm_render_minor",
@@ -978,7 +976,9 @@ def run_tests():
         lambda: amdsmi.amdsmi_get_gpu_ecc_count(gpu_handle, need("AmdSmiGpuBlock").UMC),
     )
 
-    test_api("amdsmi_get_gpu_ecc_enabled", lambda: amdsmi.amdsmi_get_gpu_ecc_enabled(gpu_handle))
+    test_api(
+        "amdsmi_get_gpu_ecc_supported", lambda: amdsmi.amdsmi_get_gpu_ecc_supported(gpu_handle)
+    )
 
     test_api(
         "amdsmi_get_gpu_ecc_status",
@@ -1429,7 +1429,7 @@ def run_tests():
     cpu_socket = cpu_socket_handles[0] if cpu_socket_handles else None
     cpu_core = cpu_core_handles[0] if cpu_core_handles else None
 
-    test_api("amdsmi_get_cpusocket_handles", lambda: amdsmi.amdsmi_get_cpusocket_handles())
+    test_api("amdsmi_get_cpu_handles", lambda: amdsmi.amdsmi_get_cpu_handles())
 
     test_api("amdsmi_get_cpucore_handles", lambda: amdsmi.amdsmi_get_cpucore_handles())
 

--- a/projects/amdsmi/tools/hw_compatibility_status.py
+++ b/projects/amdsmi/tools/hw_compatibility_status.py
@@ -708,12 +708,6 @@ def run_tests():
         lambda: amdsmi.amdsmi_get_gpu_target_frequency_range(gpu_handle),
     )
 
-    test_api(
-        "amdsmi_set_gpu_clk_range",
-        lambda: amdsmi.amdsmi_set_gpu_clk_range(gpu_handle, 500, 2500, need("AmdSmiClkType").GFX),
-        requires_root=True,
-    )
-
     # set_gpu_clk_limit takes (handle, clk_type, limit_type, value).
     # Read the current target range and replay max as a no-op-ish write.
     def _set_clk_limit_noop():

--- a/projects/amdsmi/tools/hw_compatibility_status.py
+++ b/projects/amdsmi/tools/hw_compatibility_status.py
@@ -970,9 +970,7 @@ def run_tests():
         lambda: amdsmi.amdsmi_get_gpu_ecc_count(gpu_handle, need("AmdSmiGpuBlock").UMC),
     )
 
-    test_api(
-        "amdsmi_get_gpu_ecc_supported", lambda: amdsmi.amdsmi_get_gpu_ecc_supported(gpu_handle)
-    )
+    test_api("amdsmi_get_gpu_ecc_enabled", lambda: amdsmi.amdsmi_get_gpu_ecc_enabled(gpu_handle))
 
     test_api(
         "amdsmi_get_gpu_ecc_status",

--- a/projects/amdsmi/tools/hw_compatibility_status.py
+++ b/projects/amdsmi/tools/hw_compatibility_status.py
@@ -1228,6 +1228,7 @@ def run_tests():
         lambda: amdsmi.amdsmi_get_gpu_memory_partition(gpu_handle),
     )
 
+    # amdsmi_set_gpu_memory_partition deprecated, use amdsmi_set_gpu_memory_partition_mode instead
     test_api(
         "amdsmi_set_gpu_memory_partition",
         None,


### PR DESCRIPTION
## Motivation
Standardize the public API namespace and retire long-deprecated surface: prefix bare `amdsmi.h` macros with `AMDSMI_` to avoid collisions, and remove the previously deprecated `amdsmi_get_gpu_vram_vendor()`, `amdsmi_set_gpu_clk_range()`, `amdsmi_get_cpusocket_handles()`, and the redundant `plpds` key.


## Technical Details

**Header** (`include/amd_smi/amdsmi.h`):
- Prefix public macros with `AMDSMI_`: `MAX_SVI3_RAIL_INDEX`, `MAX_SVI3_RAIL_SELECTION`, `POWER_EFFICIENCY_MODE_4/5`, `MAX_NUMBER_OF_AFIDS_PER_RECORD`; drop the unused `CENTRIGRADE_TO_MILLI_CENTIGRADE`
- Remove the deprecated `amdsmi_get_gpu_vram_vendor()` and `amdsmi_set_gpu_clk_range()` declarations

**Public API** (`src/amd_smi/amd_smi.cc`):
- Delete the `amdsmi_get_gpu_vram_vendor()` and `amdsmi_set_gpu_clk_range()` implementations
- Update macro references to the `AMDSMI_`-prefixed names

**ROCm SMI compat** (`rocm_smi/src/rocm_smi.cc`):
- Inline the removed `CENTRIGRADE_TO_MILLI_CENTIGRADE` as a literal `1000` conversion

**Python interface** (`py-interface/amdsmi_interface.py`, `__init__.py`):
- Remove `amdsmi_get_gpu_vram_vendor()`, `amdsmi_get_cpusocket_handles()`, and `amdsmi_set_gpu_clk_range()`
- Drop the redundant `plpds` key from `amdsmi_get_xgmi_plpd()`
- Consolidate string-length constants onto `AMDSMI_MAX_STRING_LENGTH` and rename `MAX_NUMBER_OF_AFIDS_PER_RECORD`

**Wrapper** (`py-interface/amdsmi_wrapper.py`):
- Regenerate via `tools/update_wrapper.sh` to drop `amdsmi_get_gpu_vram_vendor` and `amdsmi_set_gpu_clk_range`

**Rust interface** (`rust-interface/`):
- Regenerate bindings and drop the removed getters from the example and README

**Tests** (`tests/amd_smi_test/functional/*.cc`, `tests/python/functional/gpu/*.py`):
- Point VRAM tests at the `vram_info` API; remove tests for the deleted functions

**Docs / Changelog** (`docs/`, `CHANGELOG.md`):
- Update the API reference and add Changed/Removed changelog entries with migration notes

## Issue Tracking

JIRA ID : AILITOOLS-270

## Test Plan

amdsmitst
unit_test.py
integration_test.py
cli_unit_test.py

## Test Result

All tests passed as expected.
