### PR TITLE
refactor(rocprofiler-sdk): migrate thread trace off the per-queue callback registry

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -294,6 +294,18 @@ start_context(rocprofiler_context_id_t context_id)
             // conflicting context
             return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
         }
+        else if(cfg->dispatch_thread_trace && itr->dispatch_thread_trace)
+        {
+            // Single-context-only is a hard invariant for dispatch thread trace, and it now needs
+            // enforcing. Previously it held by accident: the per-queue callback registry registered
+            // one global client, so a second concurrent ATT context silently did nothing. With the
+            // registry gone the hooks iterate every active ATT context, and
+            // DispatchThreadTracer::post_kernel_call identifies packets by dynamic_cast plus agent
+            // lookup with no per-context ownership check, decrementing post_move_data before it
+            // verifies agent ownership -- so two ATT contexts on one agent would cross-talk and
+            // mis-refcount rather than one being ignored.
+            return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
+        }
     }
 
     uint64_t rocp_tot_contexts = get_registered_contexts_impl()->size();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -294,16 +294,11 @@ start_context(rocprofiler_context_id_t context_id)
             // conflicting context
             return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
         }
-        else if(cfg->dispatch_thread_trace && itr->dispatch_thread_trace)
+        else if(cfg->dispatch_thread_trace && itr->dispatch_thread_trace &&
+                cfg->dispatch_thread_trace->intersects(*itr->dispatch_thread_trace))
         {
-            // Single-context-only is a hard invariant for dispatch thread trace, and it now needs
-            // enforcing. Previously it held by accident: the per-queue callback registry registered
-            // one global client, so a second concurrent ATT context silently did nothing. With the
-            // registry gone the hooks iterate every active ATT context, and
-            // DispatchThreadTracer::post_kernel_call identifies packets by dynamic_cast plus agent
-            // lookup with no per-context ownership check, decrementing post_move_data before it
-            // verifies agent ownership -- so two ATT contexts on one agent would cross-talk and
-            // mis-refcount rather than one being ignored.
+            // Two dispatch ATT contexts can run concurrently as long as they target disjoint
+            // sets of GPU agents. Overlapping agent sets would cross-talk in post_kernel_call.
             return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
         }
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/CMakeLists.txt
@@ -39,3 +39,4 @@ target_sources(rocprofiler-sdk-object-library PRIVATE ${ROCPROFILER_LIB_HSA_SOUR
                                                       ${ROCPROFILER_LIB_HSA_HEADERS})
 
 add_subdirectory(details)
+add_subdirectory(queue_hooks)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -40,6 +40,7 @@
 #include "lib/rocprofiler-sdk/pc_sampling/hsa_adapter.hpp"
 #include "lib/rocprofiler-sdk/pc_sampling/service.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
+#include "lib/rocprofiler-sdk/thread_trace/queue_hooks.hpp"
 #include "lib/rocprofiler-sdk/tracing/tracing.hpp"
 
 #include <rocprofiler-sdk/callback_tracing.h>
@@ -167,6 +168,15 @@ AsyncSignalHandler(hsa_signal_value_t /*signal_v*/, void* data)
                                           dispatch_time);
             }
         });
+
+        // Thread trace completion is migrated off the callback registry (see WriteInterceptor);
+        // invoke it explicitly here.
+        thread_trace::signal_completion_hook(queue_info_session.queue,
+                                             packet.kernel_packet,
+                                             _session,
+                                             packet,
+                                             packet.instrumentation_packets,
+                                             dispatch_time);
 
         if(packet.is_serialized)
         {
@@ -305,8 +315,10 @@ WriteInterceptor(const void* packets,
 
     auto*      gls                 = ::rocprofiler::hip::graph::current_launch_state();
     const bool graph_launch_active = (gls != nullptr);
+    // Thread trace no longer registers a queue-controller callback, so it does not count toward
+    // get_notifiers(); detect it explicitly so an ATT-only run still enters the interceptor.
     const bool no_real_consumers =
-        (queue.get_notifiers() == 0 &&
+        (queue.get_notifiers() == 0 && !thread_trace::is_any_active() &&
          context::get_active_contexts(full_packet_instrumentation_context_filter).empty());
 
     if(pkt_count == 0 || (no_real_consumers && !graph_launch_active))
@@ -617,6 +629,18 @@ WriteInterceptor(const void* packets,
                 }
             });
 
+            // Thread trace is migrated off the per-queue callback registry: call its hook
+            // explicitly (the other services still flow through signal_callback above).
+            thread_trace::write_hook(queue,
+                                     kernel_packet,
+                                     kernel_id,
+                                     dispatch_id,
+                                     &_packet_data.user_data,
+                                     _packet_data.tracing_data.external_correlation_ids,
+                                     corr_id,
+                                     _packet_data.instrumentation_packets,
+                                     _packet_data.is_serialized);
+
             bool inserted_before = false;
             if(_packet_data.is_serialized)
             {
@@ -750,6 +774,9 @@ WriteInterceptor(const void* packets,
             }
         }
     });
+
+    // Thread trace requires per-packet mode; it no longer participates in the registry above.
+    if(thread_trace::is_any_active()) should_batch_packets = false;
 
     if(should_batch_packets)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -483,8 +483,7 @@ QueueController::update_serialization(const agent_handle_set_t& agents, bool ena
                 {
                     auto itr = was_enabled.find(agent_id);
                     if(itr == was_enabled.end()) continue;
-                    if(itr->second != state.enabled(agent_id))
-                        transitioned.emplace_back(agent_id);
+                    if(itr->second != state.enabled(agent_id)) transitioned.emplace_back(agent_id);
                 }
             });
 
@@ -543,8 +542,7 @@ bool
 QueueController::is_serialization_enabled(rocprofiler_agent_id_t agent_id) const
 {
     bool enabled = false;
-    _serialization_refcount.rlock(
-        [&](const auto& state) { enabled = state.enabled(agent_id); });
+    _serialization_refcount.rlock([&](const auto& state) { enabled = state.enabled(agent_id); });
     return enabled;
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -391,10 +391,19 @@ common::Synchronized<hsa::profiler_serializer>&
 QueueController::serializer(const Queue* queue)
 {
     CHECK(queue);
+    const auto agent_id = queue->get_agent().get_rocp_agent()->id;
+
+    // Read the refcount before taking the serializer lock: update_serialization() acquires
+    // them in that order, and reversing it here would deadlock. A concurrent enable/disable
+    // for this agent can therefore race with the creation below, exactly as the previous
+    // _serialized_enabled load could, and is resolved the same way -- the next transition
+    // through update_serialization() reaches the entry once it is in the map.
+    const bool should_serialize = is_serialization_enabled(agent_id);
+
     common::Synchronized<hsa::profiler_serializer>* ret = nullptr;
     _profiler_serializer.ulock(
         [&](const auto& m) {
-            if(auto ptr = m.find(queue->get_agent().get_rocp_agent()->id); ptr != m.end())
+            if(auto ptr = m.find(agent_id); ptr != m.end())
             {
                 ret = ptr->second.get();
                 return true;
@@ -402,10 +411,10 @@ QueueController::serializer(const Queue* queue)
             return false;
         },
         [&](auto& m) {
-            ret = m.emplace(queue->get_agent().get_rocp_agent()->id,
+            ret = m.emplace(agent_id,
                             std::make_shared<common::Synchronized<hsa::profiler_serializer>>())
                       .first->second.get();
-            if(_serialized_enabled.load() == true)
+            if(should_serialize)
             {
                 ret->wlock([&](auto& serializer) { serializer.enable({}); });
             }
@@ -429,47 +438,114 @@ per_dev_map(const QueueController::queue_map_t& _queues_v)
 };  // namespace
 
 void
-QueueController::disable_serialization()
+QueueController::update_serialization(const agent_handle_set_t& agents, bool enable)
 {
     _queues.rlock([&](const queue_map_t& _queues_v) {
-        _serialized_enabled.store(false);
         auto pd_map = per_dev_map(_queues_v);
-        _profiler_serializer.wlock([&](auto& m) {
-            for(auto& [k, v] : m)
+
+        // Agents whose effective refcount crossed zero in this call; only those get their
+        // serializer toggled. Collected under the refcount lock, applied under the serializer
+        // lock.
+        auto transitioned = std::vector<rocprofiler_agent_id_t>{};
+        bool any_enabled  = false;
+
+        _serialization_refcount.wlock([&](auto& state) {
+            // An agent can be covered by `all` and by an explicit entry at the same time, so
+            // the transition has to be decided by comparing effective counts across the
+            // update rather than by watching a single counter hit zero.
+            auto was_enabled = std::unordered_map<rocprofiler_agent_id_t, bool>{};
+            _profiler_serializer.rlock([&](const auto& serializers) {
+                for(const auto& [agent_id, _] : serializers)
+                    was_enabled.emplace(agent_id, state.enabled(agent_id));
+            });
+
+            if(agents.empty())
             {
-                if(auto it = pd_map.find(k); it != pd_map.end())
+                if(enable)
+                    ++state.all;
+                else if(state.all > 0)
+                    --state.all;
+            }
+            else
+            {
+                for(const auto& agent_id : agents)
                 {
-                    v->wlock([&](auto& serializer) { serializer.disable(it->second); });
+                    auto& count = state.per_agent[agent_id];
+                    if(enable)
+                        ++count;
+                    else if(count > 0)
+                        --count;
                 }
-                else
+            }
+
+            _profiler_serializer.rlock([&](const auto& serializers) {
+                for(const auto& [agent_id, _] : serializers)
                 {
-                    v->wlock([&](auto& serializer) { serializer.disable({}); });
+                    auto itr = was_enabled.find(agent_id);
+                    if(itr == was_enabled.end()) continue;
+                    if(itr->second != state.enabled(agent_id))
+                        transitioned.emplace_back(agent_id);
                 }
+            });
+
+            any_enabled = state.any();
+        });
+
+        _serialized_enabled.store(any_enabled);
+
+        if(transitioned.empty()) return;
+
+        _profiler_serializer.wlock([&](auto& m) {
+            for(const auto& agent_id : transitioned)
+            {
+                auto itr = m.find(agent_id);
+                if(itr == m.end() || !itr->second) continue;
+
+                auto queues = hsa_barrier::queue_map_ptr_t{};
+                if(auto it = pd_map.find(agent_id); it != pd_map.end()) queues = it->second;
+
+                itr->second->wlock([&](auto& serializer) {
+                    if(enable)
+                        serializer.enable(queues);
+                    else
+                        serializer.disable(queues);
+                });
             }
         });
     });
 }
 
 void
+QueueController::disable_serialization()
+{
+    update_serialization({}, false);
+}
+
+void
 QueueController::enable_serialization()
 {
-    _queues.rlock([&](const queue_map_t& _queues_v) {
-        _serialized_enabled.store(true);
-        auto pd_map = per_dev_map(_queues_v);
-        _profiler_serializer.wlock([&](auto& m) {
-            for(auto& [k, v] : m)
-            {
-                if(auto it = pd_map.find(k); it != pd_map.end())
-                {
-                    v->wlock([&](auto& serializer) { serializer.enable(it->second); });
-                }
-                else
-                {
-                    v->wlock([&](auto& serializer) { serializer.enable({}); });
-                }
-            }
-        });
-    });
+    update_serialization({}, true);
+}
+
+void
+QueueController::disable_serialization(const agent_handle_set_t& agents)
+{
+    update_serialization(agents, false);
+}
+
+void
+QueueController::enable_serialization(const agent_handle_set_t& agents)
+{
+    update_serialization(agents, true);
+}
+
+bool
+QueueController::is_serialization_enabled(rocprofiler_agent_id_t agent_id) const
+{
+    bool enabled = false;
+    _serialization_refcount.rlock(
+        [&](const auto& state) { enabled = state.enabled(agent_id); });
+    return enabled;
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
@@ -29,11 +29,13 @@
 
 #include <rocprofiler-sdk/fwd.h>
 #include <rocprofiler-sdk/cxx/hash.hpp>
+#include <rocprofiler-sdk/cxx/operators.hpp>
 
 #include <cstdint>
 #include <functional>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace rocprofiler
@@ -89,13 +91,27 @@ public:
 
     common::Synchronized<hsa::profiler_serializer>& serializer(const Queue*);
 
+    // An empty set means every GPU agent.
+    using agent_handle_set_t = std::unordered_set<rocprofiler_agent_id_t>;
+
     /**
-     * Disable serialization for QueueController, has no effect if counter collection
-     * is not in use (which defaults to no serialization mechanism). Should only be used for
-     * testing.
+     * Enable/disable serialization for QueueController, has no effect if counter collection
+     * is not in use (which defaults to no serialization mechanism).
+     *
+     * Serialization is reference counted per agent. Counter collection, thread trace and SPM
+     * each enable it independently, so an agent stays serialized until every subsystem that
+     * asked for it has released it -- otherwise whichever service stops first would silently
+     * unserialize the ones still running. The no-argument overloads apply to every GPU agent,
+     * which is the behavior every caller had before agents could be scoped.
      */
     void enable_serialization();
     void disable_serialization();
+    void enable_serialization(const agent_handle_set_t& agents);
+    void disable_serialization(const agent_handle_set_t& agents);
+
+    // Whether the given agent currently has serialization enabled. Exposed for tests and for
+    // callers that need to reason about scope rather than trigger a transition.
+    bool is_serialization_enabled(rocprofiler_agent_id_t agent_id) const;
 
     // Prints current state of signals for queues, used for debugging. Only prints
     // serialization related signals if not compiled in debug mode.
@@ -121,6 +137,39 @@ private:
         std::unordered_map<rocprofiler_agent_id_t,
                            std::shared_ptr<common::Synchronized<hsa::profiler_serializer>>>>
         _profiler_serializer;
+    // How many subsystems currently want serialization, per agent. `all` counts the callers
+    // that asked for every agent; it is kept separate from `per_agent` because an agent's
+    // serializer is created lazily on first use and an unscoped request has to cover agents
+    // that do not exist yet.
+    struct serialization_refcount
+    {
+        int64_t all = 0;
+        std::unordered_map<rocprofiler_agent_id_t, int64_t> per_agent = {};
+
+        int64_t count(rocprofiler_agent_id_t agent_id) const
+        {
+            auto itr = per_agent.find(agent_id);
+            return all + ((itr == per_agent.end()) ? 0 : itr->second);
+        }
+
+        bool enabled(rocprofiler_agent_id_t agent_id) const { return count(agent_id) > 0; }
+
+        bool any() const
+        {
+            if(all > 0) return true;
+            for(const auto& [agent_id, count] : per_agent)
+            {
+                if(count > 0) return true;
+            }
+            return false;
+        }
+    };
+
+    common::Synchronized<serialization_refcount> _serialization_refcount;
+
+    // Applies a +1/-1 to the refcount of each agent in `agents` (empty == all GPU agents) and
+    // toggles only the serializers whose effective count crossed zero.
+    void update_serialization(const agent_handle_set_t& agents, bool enable);
 };
 
 QueueController*

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
@@ -143,7 +143,7 @@ private:
     // that do not exist yet.
     struct serialization_refcount
     {
-        int64_t all = 0;
+        int64_t                                             all       = 0;
         std::unordered_map<rocprofiler_agent_id_t, int64_t> per_agent = {};
 
         int64_t count(rocprofiler_agent_id_t agent_id) const

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_hooks/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_hooks/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Shared, header-only client-id tags used by the per-service queue hooks.
+#
+set(ROCPROFILER_LIB_HSA_QUEUE_HOOKS_SOURCES)
+set(ROCPROFILER_LIB_HSA_QUEUE_HOOKS_HEADERS client_ids.hpp)
+
+target_sources(
+    rocprofiler-sdk-object-library PRIVATE ${ROCPROFILER_LIB_HSA_QUEUE_HOOKS_SOURCES}
+                                           ${ROCPROFILER_LIB_HSA_QUEUE_HOOKS_HEADERS})

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp
@@ -1,0 +1,43 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include <cstdint>
+
+namespace rocprofiler
+{
+namespace hsa
+{
+namespace queue_hooks
+{
+// Tags identifying the producer subsystem of each inst_pkt_t entry.
+// Only distinctness matters; values are fixed for test-order stability.
+// Services are migrated off the per-queue callback registry one at a time; the
+// unused ids are reserved so the tag values stay stable across those PRs.
+constexpr int64_t COUNTERS_CLIENT_ID     = 1;
+constexpr int64_t THREAD_TRACE_CLIENT_ID = 2;
+constexpr int64_t PC_SAMPLING_CLIENT_ID  = 3;
+constexpr int64_t SPM_CLIENT_ID          = 4;
+}  // namespace queue_hooks
+}  // namespace hsa
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/CMakeLists.txt
@@ -1,7 +1,8 @@
-set(ROCPROFILER_LIB_THREAD_TRACE_SOURCES core.cpp service.cpp code_object.cpp decode.cpp
-                                         dl.cpp threading.cpp hsa_util.cpp)
+set(ROCPROFILER_LIB_THREAD_TRACE_SOURCES
+    core.cpp service.cpp code_object.cpp decode.cpp dl.cpp threading.cpp hsa_util.cpp
+    queue_hooks.cpp)
 set(ROCPROFILER_LIB_THREAD_TRACE_HEADERS core.hpp code_object.hpp dl.hpp threading.hpp
-                                         hsa_util.hpp trace_decoder_api.h)
+                                         hsa_util.hpp trace_decoder_api.h queue_hooks.hpp)
 target_sources(
     rocprofiler-sdk-object-library PRIVATE ${ROCPROFILER_LIB_THREAD_TRACE_SOURCES}
                                            ${ROCPROFILER_LIB_THREAD_TRACE_HEADERS})

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -71,10 +71,6 @@ struct cbdata_t
     uint64_t                                        next_chunk = 0;
 };
 
-// Keeps track of a single client registering for serialized thread trace
-// operations so we can gate new traces while one is active.
-common::Synchronized<std::optional<int64_t>> client;
-
 // True once the HSA runtime is registered. Gates start_context() so pre-init
 // start requests are deferred and replayed by initialize().
 std::atomic<bool>&

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -489,41 +489,11 @@ DispatchThreadTracer::post_kernel_call(DispatchThreadTracer::inst_pkt_t& aql,
 void
 DispatchThreadTracer::start_context()
 {
-    using corr_id_map_t = hsa::queue_info_session_t::external_corr_id_map_t;
-
-    // Only installs queue-controller callbacks (cached and applied to queues as
-    // they are created), so this is safe to call before hsa_init.
+    // Thread trace no longer registers a per-queue callback with the queue controller; the
+    // HSA write interceptor now calls thread_trace::write_hook / signal_completion_hook
+    // directly (see hsa/queue.cpp). We only need to enable kernel serialization here. This is
+    // safe to call before hsa_init.
     CHECK_NOTNULL(hsa::get_queue_controller())->enable_serialization();
-
-    // Only one thread should be attempting to enable/disable this context
-    client.wlock([&](auto& client_id) {
-        if(client_id) return;
-
-        auto&& _callbacks = hsa::queue_callbacks_t{
-            .batch_packets = []() { return false; },
-            .write_interceptor =
-                [=](const hsa::Queue& q,
-                    const hsa::rocprofiler_packet& /* kern_pkt */,
-                    rocprofiler_kernel_id_t   kernel_id,
-                    rocprofiler_dispatch_id_t dispatch_id,
-                    rocprofiler_user_data_t*  user_data,
-                    const corr_id_map_t& /* extern_corr_ids */,
-                    const context::correlation_id* corr_id) {
-                    return this->pre_kernel_call(q, kernel_id, dispatch_id, user_data, corr_id);
-                },
-            .signal_completion =
-                [=](const hsa::Queue& /* q */,
-                    hsa::rocprofiler_packet /* kern_pkt */,
-                    std::shared_ptr<hsa::queue_info_session_t>& session,
-                    hsa::packet_data_t&                         packet_data,
-                    inst_pkt_t&                                 aql,
-                    kernel_dispatch::profiling_time) {
-                    this->post_kernel_call(aql, *session, packet_data);
-                }};
-
-        client_id = CHECK_NOTNULL(hsa::get_queue_controller())
-                        ->add_callback(std::nullopt, std::move(_callbacks));
-    });
 }
 
 void
@@ -532,14 +502,8 @@ DispatchThreadTracer::stop_context()  // NOLINT(readability-convert-member-funct
     auto* controller = hsa::get_queue_controller();
     if(!controller) return;
 
-    client.wlock([&](auto& client_id) {
-        if(!client_id) return;
-
-        // Remove our callbacks from HSA's queue controller
-        controller->remove_callback(*client_id);
-        client_id = std::nullopt;
-    });
-
+    // Thread trace no longer registers a per-queue callback (see start_context); there is
+    // nothing to remove from the queue controller here.
     controller->disable_serialization();
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -482,14 +482,44 @@ DispatchThreadTracer::post_kernel_call(DispatchThreadTracer::inst_pkt_t& aql,
     }
 }
 
+std::unordered_set<rocprofiler_agent_id_t>
+DispatchThreadTracer::configured_agents() const
+{
+    auto result = std::unordered_set<rocprofiler_agent_id_t>{};
+    std::shared_lock<std::shared_mutex> lk(agents_map_mut);
+    for(const auto& [agent_id, _] : params)
+        result.insert(agent_id);
+    return result;
+}
+
+bool
+DispatchThreadTracer::collects_on(rocprofiler_agent_id_t agent_id) const
+{
+    std::shared_lock<std::shared_mutex> lk(agents_map_mut);
+    return params.count(agent_id) > 0;
+}
+
+bool
+DispatchThreadTracer::intersects(const DispatchThreadTracer& rhs) const
+{
+    std::shared_lock<std::shared_mutex>       lk(agents_map_mut);
+    std::shared_lock<std::shared_mutex>       lk_rhs(rhs.agents_map_mut);
+    for(const auto& [agent_id, _] : params)
+    {
+        if(rhs.params.count(agent_id) > 0) return true;
+    }
+    return false;
+}
+
 void
 DispatchThreadTracer::start_context()
 {
     // Thread trace no longer registers a per-queue callback with the queue controller; the
     // HSA write interceptor now calls thread_trace::write_hook / signal_completion_hook
-    // directly (see hsa/queue.cpp). We only need to enable kernel serialization here. This is
-    // safe to call before hsa_init.
-    CHECK_NOTNULL(hsa::get_queue_controller())->enable_serialization();
+    // directly (see hsa/queue.cpp). Scope serialization to the agents configured on this
+    // context. An empty set still means every agent.
+    const auto agents = configured_agents();
+    CHECK_NOTNULL(hsa::get_queue_controller())->enable_serialization(agents);
 }
 
 void
@@ -498,9 +528,8 @@ DispatchThreadTracer::stop_context()  // NOLINT(readability-convert-member-funct
     auto* controller = hsa::get_queue_controller();
     if(!controller) return;
 
-    // Thread trace no longer registers a per-queue callback (see start_context); there is
-    // nothing to remove from the queue controller here.
-    controller->disable_serialization();
+    const auto agents = configured_agents();
+    controller->disable_serialization(agents);
 }
 
 DeviceThreadTracer::DeviceThreadTracer()

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -485,7 +485,7 @@ DispatchThreadTracer::post_kernel_call(DispatchThreadTracer::inst_pkt_t& aql,
 std::unordered_set<rocprofiler_agent_id_t>
 DispatchThreadTracer::configured_agents() const
 {
-    auto result = std::unordered_set<rocprofiler_agent_id_t>{};
+    auto                                result = std::unordered_set<rocprofiler_agent_id_t>{};
     std::shared_lock<std::shared_mutex> lk(agents_map_mut);
     for(const auto& [agent_id, _] : params)
         result.insert(agent_id);
@@ -502,8 +502,8 @@ DispatchThreadTracer::collects_on(rocprofiler_agent_id_t agent_id) const
 bool
 DispatchThreadTracer::intersects(const DispatchThreadTracer& rhs) const
 {
-    std::shared_lock<std::shared_mutex>       lk(agents_map_mut);
-    std::shared_lock<std::shared_mutex>       lk_rhs(rhs.agents_map_mut);
+    std::shared_lock<std::shared_mutex> lk(agents_map_mut);
+    std::shared_lock<std::shared_mutex> lk_rhs(rhs.agents_map_mut);
     for(const auto& [agent_id, _] : params)
     {
         if(rhs.params.count(agent_id) > 0) return true;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -518,8 +518,8 @@ DispatchThreadTracer::start_context()
     // HSA write interceptor now calls thread_trace::write_hook / signal_completion_hook
     // directly (see hsa/queue.cpp). Scope serialization to the agents configured on this
     // context. An empty set still means every agent.
-    const auto agents = configured_agents();
-    CHECK_NOTNULL(hsa::get_queue_controller())->enable_serialization(agents);
+    const auto serialization_agents = configured_agents();
+    CHECK_NOTNULL(hsa::get_queue_controller())->enable_serialization(serialization_agents);
 }
 
 void
@@ -528,8 +528,8 @@ DispatchThreadTracer::stop_context()  // NOLINT(readability-convert-member-funct
     auto* controller = hsa::get_queue_controller();
     if(!controller) return;
 
-    const auto agents = configured_agents();
-    controller->disable_serialization(agents);
+    const auto serialization_agents = configured_agents();
+    controller->disable_serialization(serialization_agents);
 }
 
 DeviceThreadTracer::DeviceThreadTracer()

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
@@ -43,9 +43,9 @@
 #include <mutex>
 #include <shared_mutex>
 #include <string>
-#include <unordered_set>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace rocprofiler
@@ -184,8 +184,8 @@ private:
     std::unordered_map<hsa_agent_t, std::unique_ptr<ThreadTracerAgent>>     agents{};
     std::unordered_map<rocprofiler_agent_id_t, thread_trace_parameter_pack> params{};
 
-    std::shared_mutex agents_map_mut{};
-    std::atomic<int>  post_move_data{0};
+    mutable std::shared_mutex agents_map_mut{};
+    std::atomic<int>          post_move_data{0};
 };
 
 class DeviceThreadTracer

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
@@ -43,6 +43,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include <string>
+#include <unordered_set>
 #include <tuple>
 #include <unordered_map>
 #include <vector>
@@ -157,6 +158,9 @@ public:
     void resource_init();
     void resource_deinit();
 
+    bool collects_on(rocprofiler_agent_id_t agent_id) const;
+    bool intersects(const DispatchThreadTracer& rhs) const;
+
     void add_agent(rocprofiler_agent_id_t agent, thread_trace_parameter_pack pack)
     {
         auto lk       = std::unique_lock{agents_map_mut};
@@ -173,6 +177,8 @@ public:
                                  const hsa::queue_info_session_t& session,
                                  const hsa::packet_data_t&        packet_data);
     const auto& get_agents() const { return agents; }
+
+    std::unordered_set<rocprofiler_agent_id_t> configured_agents() const;
 
 private:
     std::unordered_map<hsa_agent_t, std::unique_ptr<ThreadTracerAgent>>     agents{};

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/queue_hooks.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/queue_hooks.cpp
@@ -1,0 +1,87 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "lib/rocprofiler-sdk/thread_trace/queue_hooks.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp"
+#include "lib/rocprofiler-sdk/thread_trace/core.hpp"
+
+namespace rocprofiler
+{
+namespace thread_trace
+{
+namespace
+{
+auto
+active_thread_trace_contexts_filter()
+{
+    return [](const context::context* ctx) -> bool {
+        return ctx && ctx->dispatch_thread_trace != nullptr;
+    };
+}
+}  // namespace
+
+void
+write_hook(const hsa::Queue& queue,
+           const hsa::rocprofiler_packet& /*kernel_packet*/,
+           rocprofiler_kernel_id_t   kernel_id,
+           rocprofiler_dispatch_id_t dispatch_id,
+           rocprofiler_user_data_t*  user_data,
+           const hsa::queue_info_session_t::external_corr_id_map_t& /*ext_corr_ids*/,
+           const context::correlation_id* correlation_id,
+           hsa::inst_pkt_t&               inst_pkt,
+           bool&                          is_serialized)
+{
+    auto active = context::get_active_contexts(active_thread_trace_contexts_filter());
+    for(auto* ctx : active)
+    {
+        auto& tracer = *ctx->dispatch_thread_trace;
+        auto [packet, bSerial] =
+            tracer.pre_kernel_call(queue, kernel_id, dispatch_id, user_data, correlation_id);
+        if(packet)
+            inst_pkt.emplace_back(std::move(packet), hsa::queue_hooks::THREAD_TRACE_CLIENT_ID);
+        is_serialized |= bSerial;
+    }
+}
+
+void
+signal_completion_hook(const hsa::Queue& /*queue*/,
+                       const hsa::rocprofiler_packet& /*kernel_packet*/,
+                       std::shared_ptr<hsa::queue_info_session_t>& session,
+                       hsa::packet_data_t&                         packet_data,
+                       hsa::inst_pkt_t&                            inst_pkt,
+                       kernel_dispatch::profiling_time /*dispatch_time*/)
+{
+    auto active = context::get_active_contexts(active_thread_trace_contexts_filter());
+    for(auto* ctx : active)
+    {
+        auto& tracer = *ctx->dispatch_thread_trace;
+        tracer.post_kernel_call(inst_pkt, *session, packet_data);
+    }
+}
+
+bool
+is_any_active()
+{
+    return !context::get_active_contexts(active_thread_trace_contexts_filter()).empty();
+}
+}  // namespace thread_trace
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/queue_hooks.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/queue_hooks.cpp
@@ -21,6 +21,8 @@
 // THE SOFTWARE.
 
 #include "lib/rocprofiler-sdk/thread_trace/queue_hooks.hpp"
+#include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/core.hpp"
 
@@ -50,10 +52,14 @@ write_hook(const hsa::Queue& queue,
            hsa::inst_pkt_t&               inst_pkt,
            bool&                          is_serialized)
 {
+    const auto agent_id = CHECK_NOTNULL(queue.get_agent().get_rocp_agent())->id;
+
     auto active = context::get_active_contexts(active_thread_trace_contexts_filter());
     for(auto* ctx : active)
     {
         auto& tracer = *ctx->dispatch_thread_trace;
+        if(!tracer.collects_on(agent_id)) continue;
+
         auto [packet, bSerial] =
             tracer.pre_kernel_call(queue, kernel_id, dispatch_id, user_data, correlation_id);
         if(packet)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/queue_hooks.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/queue_hooks.hpp
@@ -1,0 +1,66 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_info_session.hpp"
+#include "lib/rocprofiler-sdk/hsa/rocprofiler_packet.hpp"
+#include "lib/rocprofiler-sdk/kernel_dispatch/profiling_time.hpp"
+
+#include <memory>
+
+namespace rocprofiler
+{
+namespace thread_trace
+{
+// Explicit replacement for the thread-trace per-queue callback that used to be
+// registered with the HSA queue controller. Iterates active dispatch_thread_trace
+// contexts and calls each tracer's pre_kernel_call; appends produced packets to
+// inst_pkt, OR-folding each tracer's serialize flag into is_serialized.
+void
+write_hook(const hsa::Queue&                                        queue,
+           const hsa::rocprofiler_packet&                           kernel_packet,
+           rocprofiler_kernel_id_t                                  kernel_id,
+           rocprofiler_dispatch_id_t                                dispatch_id,
+           rocprofiler_user_data_t*                                 user_data,
+           const hsa::queue_info_session_t::external_corr_id_map_t& ext_corr_ids,
+           const context::correlation_id*                           correlation_id,
+           hsa::inst_pkt_t&                                         inst_pkt,
+           bool&                                                    is_serialized);
+
+// Explicit replacement for the thread-trace completion callback. Iterates active
+// dispatch_thread_trace contexts and calls each tracer's post_kernel_call.
+void
+signal_completion_hook(const hsa::Queue&                           queue,
+                       const hsa::rocprofiler_packet&              kernel_packet,
+                       std::shared_ptr<hsa::queue_info_session_t>& session,
+                       hsa::packet_data_t&                         packet,
+                       hsa::inst_pkt_t&                            inst_pkt,
+                       kernel_dispatch::profiling_time             dispatch_time);
+
+// True if any context currently has dispatch thread trace active.
+bool
+is_any_active();
+}  // namespace thread_trace
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/CMakeLists.txt
@@ -69,3 +69,31 @@ rocprofiler_add_unit_test(
         "ROCPROFILER_METRICS_PATH=${_ROCPROFILER_SHARE_DIR}"
         "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:/opt/rocm/lib:/opt/rocm/llvm/lib:$ENV{LD_LIBRARY_PATH}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
+set(ROCPROFILER_THREAD_TRACE_QUEUE_HOOKS_TEST_SOURCES "queue_hooks_test.cpp")
+
+add_executable(thread-trace-queue-hooks-test)
+target_sources(thread-trace-queue-hooks-test
+               PRIVATE ${ROCPROFILER_THREAD_TRACE_QUEUE_HOOKS_TEST_SOURCES})
+
+target_link_libraries(
+    thread-trace-queue-hooks-test
+    PRIVATE rocprofiler-sdk::rocprofiler-sdk-static-library
+            rocprofiler-sdk::rocprofiler-sdk-abseil
+            rocprofiler-sdk::rocprofiler-sdk-hsa-runtime
+            rocprofiler-sdk::rocprofiler-sdk-hip
+            rocprofiler-sdk::rocprofiler-sdk-common-library
+            GTest::gtest
+            GTest::gtest_main
+            rocprofiler-sdk::counter-test-constants)
+
+rocprofiler_add_unit_test(
+    TARGET thread-trace-queue-hooks-test
+    SOURCES ${ROCPROFILER_THREAD_TRACE_QUEUE_HOOKS_TEST_SOURCES}
+    TEST_LIST thread-trace-test_TESTS
+    TIMEOUT 10
+    LABELS "unittests"
+    ENVIRONMENT
+        "ROCPROFILER_METRICS_PATH=${_ROCPROFILER_SHARE_DIR}"
+        "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/CMakeLists.txt
@@ -97,3 +97,31 @@ rocprofiler_add_unit_test(
         "ROCPROFILER_METRICS_PATH=${_ROCPROFILER_SHARE_DIR}"
         "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
+set(ROCPROFILER_THREAD_TRACE_PER_AGENT_TEST_SOURCES "per_agent_scoping_test.cpp")
+
+add_executable(thread-trace-per-agent-test)
+target_sources(thread-trace-per-agent-test
+               PRIVATE ${ROCPROFILER_THREAD_TRACE_PER_AGENT_TEST_SOURCES})
+
+target_link_libraries(
+    thread-trace-per-agent-test
+    PRIVATE rocprofiler-sdk::rocprofiler-sdk-static-library
+            rocprofiler-sdk::rocprofiler-sdk-abseil
+            rocprofiler-sdk::rocprofiler-sdk-hsa-runtime
+            rocprofiler-sdk::rocprofiler-sdk-hip
+            rocprofiler-sdk::rocprofiler-sdk-common-library
+            GTest::gtest
+            GTest::gtest_main
+            rocprofiler-sdk::counter-test-constants)
+
+rocprofiler_add_unit_test(
+    TARGET thread-trace-per-agent-test
+    SOURCES ${ROCPROFILER_THREAD_TRACE_PER_AGENT_TEST_SOURCES}
+    TEST_LIST thread-trace-test_TESTS
+    TIMEOUT 45
+    LABELS "unittests"
+    ENVIRONMENT
+        "ROCPROFILER_METRICS_PATH=${_ROCPROFILER_SHARE_DIR}"
+        "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/per_agent_scoping_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/per_agent_scoping_test.cpp
@@ -1,0 +1,259 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/rocprofiler-sdk/agent.hpp"
+#include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/counters/tests/hsa_tables.hpp"
+#include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
+#include "lib/rocprofiler-sdk/registration.hpp"
+#include "lib/rocprofiler-sdk/thread_trace/core.hpp"
+#include "lib/rocprofiler-sdk/thread_trace/queue_hooks.hpp"
+
+#include <rocprofiler-sdk/experimental/thread_trace.h>
+#include <rocprofiler-sdk/rocprofiler.h>
+
+#include <gtest/gtest.h>
+#include <hsa/hsa.h>
+
+using namespace rocprofiler::counters::test_constants;
+using namespace rocprofiler;
+
+namespace rocprofiler
+{
+namespace hsa
+{
+class PerAgentFakeQueue : public Queue
+{
+public:
+    PerAgentFakeQueue(const AgentCache& a, rocprofiler_queue_id_t id)
+    : Queue(a, get_api_table())
+    , _agent(a)
+    , _id(id)
+    {}
+    const AgentCache&      get_agent() const final { return _agent; };
+    rocprofiler_queue_id_t get_id() const final { return _id; };
+
+    ~PerAgentFakeQueue() override = default;
+
+private:
+    const AgentCache&      _agent;
+    rocprofiler_queue_id_t _id = {};
+};
+}  // namespace hsa
+}  // namespace rocprofiler
+
+namespace
+{
+struct agent_pair
+{
+    const hsa::AgentCache* first  = nullptr;
+    const hsa::AgentCache* second = nullptr;
+};
+
+void
+test_init()
+{
+    static bool _initialized = false;
+    if(_initialized) return;
+    _initialized = true;
+
+    HsaApiTable table;
+    table.amd_ext_ = &get_ext_table();
+    table.core_    = &get_api_table();
+    agent::construct_agent_cache(&table);
+    ASSERT_TRUE(hsa::get_queue_controller() != nullptr);
+    hsa::get_queue_controller()->init(get_api_table(), get_ext_table());
+    registration::init_logging();
+    registration::set_init_status(-1);
+    context::push_client(1);
+}
+
+agent_pair
+get_two_agents()
+{
+    auto  result = agent_pair{};
+    auto& agents = hsa::get_queue_controller()->get_supported_agents();
+    for(const auto& [_, agent] : agents)
+    {
+        if(!agent.get_rocp_agent()) continue;
+        if(!result.first)
+            result.first = &agent;
+        else if(!result.second)
+            result.second = &agent;
+        else
+            break;
+    }
+    return result;
+}
+
+rocprofiler_thread_trace_control_flags_t
+noop_dispatch_cb(rocprofiler_agent_id_t,
+                 rocprofiler_queue_id_t,
+                 rocprofiler_async_correlation_id_t,
+                 rocprofiler_kernel_id_t,
+                 rocprofiler_dispatch_id_t,
+                 void*,
+                 rocprofiler_user_data_t*)
+{
+    return ROCPROFILER_THREAD_TRACE_CONTROL_NONE;
+}
+
+void
+noop_shader_cb(rocprofiler_thread_trace_shader_data_t, rocprofiler_user_data_t)
+{}
+
+rocprofiler_context_id_t
+make_att_context(rocprofiler_agent_id_t agent_id)
+{
+    auto ctx = rocprofiler_context_id_t{0};
+    EXPECT_EQ(rocprofiler_create_context(&ctx), ROCPROFILER_STATUS_SUCCESS);
+    EXPECT_EQ(rocprofiler_configure_dispatch_thread_trace_service(
+                  ctx, agent_id, nullptr, 0, noop_dispatch_cb, noop_shader_cb, nullptr),
+              ROCPROFILER_STATUS_SUCCESS);
+    return ctx;
+}
+
+TEST(thread_trace_per_agent, collects_on_and_intersects_match_configured_agents)
+{
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    auto agents = get_two_agents();
+    if(!agents.second) GTEST_SKIP() << "fewer than two GPU agents available";
+
+    auto agent_a = agents.first->get_rocp_agent()->id;
+    auto agent_b = agents.second->get_rocp_agent()->id;
+
+    auto left  = thread_trace::DispatchThreadTracer{};
+    auto right = thread_trace::DispatchThreadTracer{};
+    left.add_agent(agent_a, {});
+    right.add_agent(agent_b, {});
+
+    EXPECT_TRUE(left.collects_on(agent_a));
+    EXPECT_FALSE(left.collects_on(agent_b));
+    EXPECT_FALSE(left.intersects(right));
+
+    right.add_agent(agent_a, {});
+    EXPECT_TRUE(left.intersects(right));
+
+    auto configured = left.configured_agents();
+    EXPECT_EQ(configured.size(), 1U);
+    EXPECT_EQ(configured.count(agent_a), 1U);
+}
+
+TEST(thread_trace_per_agent, disjoint_agent_contexts_can_be_active_together)
+{
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    auto agents = get_two_agents();
+    if(!agents.second) GTEST_SKIP() << "fewer than two GPU agents available";
+
+    auto ctx_a = make_att_context(agents.first->get_rocp_agent()->id);
+    auto ctx_b = make_att_context(agents.second->get_rocp_agent()->id);
+
+    EXPECT_EQ(rocprofiler_start_context(ctx_a), ROCPROFILER_STATUS_SUCCESS);
+    EXPECT_EQ(rocprofiler_start_context(ctx_b), ROCPROFILER_STATUS_SUCCESS);
+
+    EXPECT_EQ(rocprofiler_stop_context(ctx_b), ROCPROFILER_STATUS_SUCCESS);
+    EXPECT_EQ(rocprofiler_stop_context(ctx_a), ROCPROFILER_STATUS_SUCCESS);
+}
+
+TEST(thread_trace_per_agent, overlapping_agent_contexts_still_conflict)
+{
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    auto agents = get_two_agents();
+    if(!agents.first) GTEST_SKIP() << "no GPU agent available";
+
+    auto agent_a = agents.first->get_rocp_agent()->id;
+    auto ctx_a   = make_att_context(agent_a);
+    auto ctx_b   = make_att_context(agent_a);
+
+    ASSERT_EQ(rocprofiler_start_context(ctx_a), ROCPROFILER_STATUS_SUCCESS);
+    EXPECT_EQ(rocprofiler_start_context(ctx_b), ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT);
+    ASSERT_EQ(rocprofiler_stop_context(ctx_a), ROCPROFILER_STATUS_SUCCESS);
+}
+
+TEST(thread_trace_per_agent, serialization_is_scoped_to_the_contexts_agents)
+{
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    auto agents = get_two_agents();
+    if(!agents.second) GTEST_SKIP() << "fewer than two GPU agents available";
+
+    auto  agent_a    = agents.first->get_rocp_agent()->id;
+    auto  agent_b    = agents.second->get_rocp_agent()->id;
+    auto* controller = hsa::get_queue_controller();
+
+    auto queue_a = hsa::PerAgentFakeQueue{*agents.first, {.handle = 501}};
+    auto queue_b = hsa::PerAgentFakeQueue{*agents.second, {.handle = 502}};
+    controller->serializer(&queue_a);
+    controller->serializer(&queue_b);
+
+    auto ctx = make_att_context(agent_b);
+    ASSERT_EQ(rocprofiler_start_context(ctx), ROCPROFILER_STATUS_SUCCESS);
+
+    EXPECT_TRUE(controller->is_serialization_enabled(agent_b));
+    EXPECT_FALSE(controller->is_serialization_enabled(agent_a));
+
+    ASSERT_EQ(rocprofiler_stop_context(ctx), ROCPROFILER_STATUS_SUCCESS);
+    EXPECT_FALSE(controller->is_serialization_enabled(agent_b));
+}
+
+TEST(thread_trace_per_agent, write_hook_ignores_dispatches_on_other_agents)
+{
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    auto agents = get_two_agents();
+    if(!agents.second) GTEST_SKIP() << "fewer than two GPU agents available";
+
+    auto ctx = make_att_context(agents.second->get_rocp_agent()->id);
+    ASSERT_EQ(rocprofiler_start_context(ctx), ROCPROFILER_STATUS_SUCCESS);
+
+    auto packet      = hsa::rocprofiler_packet{};
+    auto corr_id     = context::correlation_id{};
+    corr_id.internal = 4242;
+
+    {
+        auto queue_a       = hsa::PerAgentFakeQueue{*agents.first, {.handle = 601}};
+        auto inst_pkt      = hsa::inst_pkt_t{};
+        bool is_serialized = false;
+        auto user_data     = rocprofiler_user_data_t{.value = corr_id.internal};
+
+        thread_trace::write_hook(
+            queue_a, packet, 42, 1, &user_data, {}, &corr_id, inst_pkt, is_serialized);
+
+        EXPECT_FALSE(is_serialized)
+            << "a dispatch on an agent outside the context must not be serialized";
+        EXPECT_TRUE(inst_pkt.empty())
+            << "a dispatch on an agent outside the context must not be instrumented";
+    }
+
+    ASSERT_EQ(rocprofiler_stop_context(ctx), ROCPROFILER_STATUS_SUCCESS);
+}
+}  // namespace

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/queue_hooks_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/queue_hooks_test.cpp
@@ -1,0 +1,38 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "lib/rocprofiler-sdk/thread_trace/queue_hooks.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp"
+
+#include <gtest/gtest.h>
+
+// Positive-path coverage (active tracer + write/completion hooks) is provided
+// by the rocprofv3 --att integration smoke; standalone DispatchThreadTracer
+// activation requires full HSA queue plumbing unavailable in unit tests.
+
+namespace
+{
+TEST(ThreadTraceQueueHooks, IsAnyActiveReturnsFalseWhenNoContextActive)
+{
+    EXPECT_FALSE(rocprofiler::thread_trace::is_any_active());
+}
+}  // namespace


### PR DESCRIPTION
## Motivation

This PR isolates the thread-trace slice of the callback-removal effort (reference PRs #8730 / #8586) into a small, single-service change, per review guidance to land callback removal one service at a time.

### Underlying Problem

Dispatch thread trace (ATT) currently registers a `queue_callbacks_t` on every HSA queue. That hides “is this service active?” inside a per-queue map, makes enqueue and completion the same walk, and serializes every GPU while any dispatch ATT context is active.

This PR:

1. **Stops registering** dispatch ATT with that map. The write interceptor and async signal handler call explicit free functions instead (`thread_trace::write_hook`, `signal_completion_hook`, `is_any_active`).
2. **Scopes dispatch ATT to configured GPU agents** so disjoint agent sets can be active together; serialization is refcounted per agent and overlapping contexts conflict via `intersects()`.

Device thread trace is unchanged in its hook wiring; only dispatch ATT migrates here. The per-queue callback registry remains for counters, PC sampling, and SPM until those services land in their own PRs.

### Notes on Bigger Picture

Sibling migrations: counter collection (#8891), SPM (#8887), PC sampling (#8895).

Kernel replay (#7960, #8622) benefits from callback removal but this PR is independent and behavior-preserving on its own.

## Technical Details

**Both hooks iterate active contexts** (not registered). `post_kernel_call` self-filters by finding `THREAD_TRACE_CLIENT_ID`-tagged packets in `inst_pkt` via `dynamic_cast`, so routing differs from counter/SPM provenance via `packet_return_map`.

```mermaid
flowchart LR
  WriteInterceptor --> WriteHook["thread_trace::write_hook: active + collects_on"]
  AsyncSignalHandler --> CompletionHook["signal_completion_hook: active"]
  StartContext --> Serialize["enable_serialization(configured agents)"]
  StopContext --> Unserialize["disable_serialization(configured agents)"]
```

Permalinks pin to `d39785f`.

### Hooks and call sites

- Declarations: [queue_hooks.hpp](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/queue_hooks.hpp)
- Enter (`collects_on`, `THREAD_TRACE_CLIENT_ID`): [queue_hooks.cpp#L44-L69](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/queue_hooks.cpp#L44-L69)
- Exit (active contexts): [queue_hooks.cpp#L71-L85](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/queue_hooks.cpp#L71-L85)
- `is_any_active`: [queue_hooks.cpp#L87-L91](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/queue_hooks.cpp#L87-L91)
- `no_real_consumers` gate: [queue.cpp#L318-L322](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp#L318-L322)
- Enter call site: [queue.cpp#L632-L642](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp#L632-L642)
- Exit call site: [queue.cpp#L172-L179](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp#L172-L179)
- Batching disabled while active: [queue.cpp#L778-L779](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp#L778-L779)
- `start_context` / `stop_context` (no `add_callback`; serialization only): [core.cpp#L514-L533](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp#L514-L533)
- `collects_on` / `intersects`: [core.cpp#L495-L512](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp#L495-L512)
- Context conflict uses `intersects`: [context.cpp#L297-L303](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp#L297-L303)
- Producer tag: [client_ids.hpp#L37-L40](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp#L37-L40)

Per-agent scoping is configured via `rocprofiler_configure_dispatch_thread_trace_service` agent params (not a separate `set_agents` API). Agents are fixed at configure time.

### Reviewer Guide

1. Confirm **both** hooks use `get_active_contexts` ([queue_hooks.cpp#L57-L84](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/queue_hooks.cpp#L57-L84)). This differs from counters/SPM exit routing.
2. ATT-only runs still enter `WriteInterceptor` via `thread_trace::is_any_active()` ([queue.cpp#L318-L322](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp#L318-L322)).
3. `DispatchThreadTracer::start_context` does **not** call `add_callback` ([core.cpp#L514-L523](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp#L514-L523)).
4. **`context::stop_context` clears the active slot before calling service stop** ([context.cpp#L378-L395](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp#L378-L395)). Verify this is safe given active-only completion routing — does `post_kernel_call` still reach in-flight work?
5. No GPU drain in ATT stop; only `disable_serialization` ([core.cpp#L526-L533](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp#L526-L533)).
6. `collects_on` before `pre_kernel_call` ([queue_hooks.cpp#L60-L61](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/queue_hooks.cpp#L60-L61)).
7. Disjoint ATT contexts: [per_agent_scoping_test.cpp](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/per_agent_scoping_test.cpp) — `intersects`, disjoint start, serialization scope, write_hook agent filter.
8. Hook unit test is gate-only ([queue_hooks_test.cpp#L34-L37](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/queue_hooks_test.cpp#L34-L37)); positive path relies on rocprofv3 ATT integration smoke.

**Questions to Answer:** 

- Does ATT-only profiling still intercept dispatches? 
- Does a GPU-1-only context leave GPU-0 unserialized? 
- Can two disjoint ATT contexts start together? 
- Is in-flight ATT completion safe after stop given active-only exit routing?

**Out of scope:** device ATT hook migration; deleting `Queue::_callbacks`; counters/SPM/PC-sampling migrations.

## Issue Tracking

AIPROFSDK-1016

## Test Plan

- [is_any_active gate](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/queue_hooks_test.cpp#L34-L37)
- Per-agent unit tests ([per_agent_scoping_test.cpp](https://github.com/ROCm/rocm-systems/blob/d39785f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/per_agent_scoping_test.cpp))
- rocprofv3 ATT integration smoke (positive hook path)

## Test Result

Unit coverage as above. Treat the Checks tab as source of truth for CI.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.


