### PR TITLE
fix(rocr): Enable profiling on internal blit copy queues

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1585,7 +1585,22 @@ hsa_status_t AqlQueue::GetCUMasking(uint32_t num_cu_mask_count, uint32_t* cu_mas
 }
 
 void AqlQueue::SetProfiling(bool enabled) {
+  bool need_update = false;
+  const bool cur = AMD_HSA_BITS_GET(amd_queue_.queue_properties,
+    AMD_QUEUE_PROPERTIES_ENABLE_PROFILING) != 0;
+
+  if (cur != enabled && LoadWriteIndexRelaxed() != 0) {
+    // If the queue is already enabled/disabled, we need to update the queue properties and we have already submitted packets,
+    // then we need to unmap and remap the queue for CP FW to re-read the queue properties.
+    need_update = true;
+  }
+
   Queue::SetProfiling(enabled);
+
+  if (need_update) {
+    Suspend();
+    Resume();
+  }
 
   if (enabled) agent_->CheckClockTicks();
   return;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -908,10 +908,21 @@ void GpuAgent::InitDma() {
     return queue;
   };
 
+  // Enable profiling on the internal blit copy queues right after creation so that
+  // copy completion timestamps are always available regardless of when async-copy
+  // profiling is later turned on (e.g. a profiler attaching after copies have run).
   // Dedicated compute queue for host-to-device blits.
-  queues_[QueueBlitOnly].reset(queue_lambda);
+  queues_[QueueBlitOnly].reset([queue_lambda]() {
+    auto queue = queue_lambda();
+    queue->SetProfiling(true);
+    return queue;
+  });
   // Share utility queue with device-to-host blits.
-  queues_[QueueUtility].reset(queue_lambda);
+  queues_[QueueUtility].reset([queue_lambda]() {
+    auto queue = queue_lambda();
+    queue->SetProfiling(true);
+    return queue;
+  });
 
   // Dedicated compute queue for PC Sampling CP-DMA commands. We need a dedicated queue that runs at
   // highest priority because we do not want the CP-DMA commands to be delayed/blocked due to

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -908,10 +908,10 @@ void GpuAgent::InitDma() {
     return queue;
   };
 
-  // Enable profiling on the internal blit copy queues right after creation so that
-  // copy completion timestamps are always available regardless of when async-copy
-  // profiling is later turned on (e.g. a profiler attaching after copies have run).
-  // Dedicated compute queue for host-to-device blits.
+  // Enable profiling on the internal blit copy queues right after creation to avoid
+  // having to unmap and remap the queue for CP FW to re-read the queue properties when
+  // profiling is later turned on. If profiling is disabled later on these queues, then
+  // the queue unmap and remap will be triggered.
   queues_[QueueBlitOnly].reset([queue_lambda]() {
     auto queue = queue_lambda();
     queue->SetProfiling(true);


### PR DESCRIPTION
## Summary

The command processor latches `amd_queue_.queue_properties` (including the `ENABLE_PROFILING` bit) at a queue's **first dispatch** and does not re-read the in-memory value afterwards. When async-copy profiling is toggled *after* an internal blit copy queue has already run copies (e.g. a profiler attaching late), changing the bit has no effect: blit-kernel copy completion timestamps (`amd_signal_t.start_ts`/`end_ts`) silently remain `0` even though `queue_properties` shows the bit set (`0xa`).

This PR fixes it in two complementary ways:

1. **Enable profiling on the internal blit copy queues right after creation** (`QueueBlitOnly` and the shared `QueueUtility`), before their first dispatch, so the common case (profiling enabled before/at first use) reliably latches `ENABLE_PROFILING` on with no runtime overhead.

2. **Re-latch on change via queue remap.** `AqlQueue::SetProfiling` now detects when the `ENABLE_PROFILING` bit actually changes on a queue that has already submitted packets (`write index != 0`) and unmaps/remaps the queue (`Suspend()`/`Resume()`) so the CP FW re-reads the queue properties. This makes enabling **and disabling** (and re-enabling) profiling take effect at any point in a queue's lifetime, not just before the first dispatch.

Together these ensure copy completion timestamps are populated whenever profiling is on, regardless of when it is toggled. They are only surfaced to callers when profiling is actually enabled, since `hsa_amd_profiling_get_async_copy_time` gates on `async_copy_agent()`.

This also addresses the earlier review question about the disable path: `hsa_amd_profiling_async_copy_enable(false)` now genuinely takes effect (the queue is remapped and the CP stops writing timestamps), and a later re-enable works again.

Notes:
- Scope is limited to the two internal blit-copy queues; `QueuePCSampling`, GWS/counted queues, and all user-created queues are unaffected.
- The remap only happens when the bit actually changes on a queue that has already dispatched (`write index != 0`); `write_dispatch_id` is a monotonic 64-bit counter and never wraps back to `0`, so the guard is safe.
- SDMA copies use a separate timestamp mechanism and are unaffected.

## JIRA ID

JIRA ID : ROCM-28243

## Test plan

- [x] Late-enable repro (H2D/D2H via `hsa_amd_memory_async_copy`, `HSA_ENABLE_SDMA=0`, profiling enabled *after* warm-up copies): timestamps were `0` before, valid non-zero after — verified on **gfx1250**.
- [x] Disable-then-re-enable toggle: after packets have been dispatched, disable profiling, run copies, re-enable, and confirm timestamps are non-zero again — verified on **gfx1250**. A/B: fails (all-zero) on stock runtime, passes with this change.
- [x] Regression: profiling enabled *before* first copy still returns valid timestamps (no change).

Made with [Cursor](https://cursor.com)
