### PR TITLE
[rocjitsu] Vendor minimal AMD HSA ABI. NFC.

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/amd_ext_aql_packet.h
+++ b/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/amd_ext_aql_packet.h
@@ -1,26 +1,22 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
-#ifndef ROCJITSU_VM_AMDGPU_AMD_EXT_AQL_PACKET_H_
-#define ROCJITSU_VM_AMDGPU_AMD_EXT_AQL_PACKET_H_
+/// @file amd_ext_aql_packet.h
+/// @brief Minimal AMD vendor-specific AQL packet ABI mirror.
+///
+/// @details The source of truth for the public packet layouts and format values is
+/// `projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h`. Keep this mirror limited to the
+/// packet ABI consumed by RocJITsu and update the layout assertions whenever that header changes.
 
-#ifndef HSA_LARGE_MODEL
-#define HSA_LARGE_MODEL 1
-#endif
+#pragma once
 
-#include "rocjitsu/base/rj_compiler.h"
-RJ_DIAGNOSTIC_PUSH
-RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "hsa/hsa.h"
-RJ_DIAGNOSTIC_POP
 
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
 
 namespace rocjitsu::amdgpu {
-
-// AMD vendor-specific packet format 0 is unassigned; 200 is reserved and unreleased.
 
 /// ROCR-internal PM4 indirect-buffer packet format.
 constexpr uint8_t kAmdAqlFormatPm4Ib = 1;
@@ -31,19 +27,22 @@ constexpr uint8_t kHsaAmdPacketTypeBarrierValue = 2;
 /// AMD vendor-specific packet format selector for extended kernel dispatch.
 constexpr uint8_t kHsaAmdPacketTypeExtKernelDispatch = 3;
 
+/// Reserved, unreleased AMD vendor-specific packet format.
+constexpr uint8_t kHsaAmdPacketTypeReserved200 = 200;
+
 /// @brief AMD vendor-specific barrier-value packet layout.
 ///
-/// @details Processing stops until `(signal_value & mask) cond value` is true.
-/// This mirrors hsa_amd_barrier_value_packet_t without depending on the ROCr
-/// extension-header version installed on the host.
+/// @details Processing stops until `(signal_value & mask) cond value` is true. This mirrors
+/// `hsa_amd_barrier_value_packet_t` without depending on an ROCr extension header installed on the
+/// host.
 struct AmdBarrierValuePacket {
   uint16_t header;
   uint8_t amd_format;
   uint8_t reserved_header;
   uint32_t reserved0;
   hsa_signal_t signal;
-  int64_t value;
-  int64_t mask;
+  hsa_signal_value_t value;
+  hsa_signal_value_t mask;
   uint32_t condition;
   uint32_t reserved1;
   uint64_t reserved2;
@@ -61,8 +60,8 @@ static_assert(offsetof(AmdBarrierValuePacket, completion_signal) == 56);
 
 /// @brief AMD vendor-specific extended kernel dispatch packet layout.
 ///
-/// @details This mirrors the 64-byte wire packet consumed from an AQL ring for
-/// clustered dispatch. Keep the field order and size stable; tests and runtime
+/// @details This mirrors `hsa_amd_ext_kernel_dispatch_packet_t`, the 64-byte wire packet consumed
+/// from an AQL ring for clustered dispatch. Keep the field order and size stable; tests and runtime
 /// queue code copy this type directly into packet slots.
 struct AmdExtKernelDispatchPacket {
   uint16_t header;
@@ -99,5 +98,3 @@ static_assert(offsetof(AmdExtKernelDispatchPacket, dep_signal) == 48);
 static_assert(offsetof(AmdExtKernelDispatchPacket, completion_signal) == 56);
 
 } // namespace rocjitsu::amdgpu
-
-#endif // ROCJITSU_VM_AMDGPU_AMD_EXT_AQL_PACKET_H_

--- a/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa_ext_amd_minimal.h
+++ b/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa_ext_amd_minimal.h
@@ -3,6 +3,10 @@
 
 /// @file hsa_ext_amd_minimal.h
 /// @brief Minimal AMD HSA extension ABI mirror used by rocjitsu hooks.
+///
+/// @details The source of truth is
+/// `projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h`. Keep this mirror limited to the
+/// handles, structures, constants, and function signatures used by RocJITsu's HSA tools hooks.
 
 #pragma once
 
@@ -177,8 +181,9 @@ using hsa_amd_memory_async_copy_on_engine_fn_t =
                             const hsa_signal_t *, hsa_signal_t, hsa_amd_sdma_engine_id_t, bool);
 using hsa_amd_memory_copy_engine_status_fn_t = hsa_status_t(HSA_API *)(hsa_agent_t, hsa_agent_t,
                                                                        uint32_t *);
-using hsa_amd_memory_get_preferred_copy_engine_fn_t =
-    hsa_status_t(HSA_API *)(hsa_agent_t, hsa_agent_t, hsa_amd_sdma_engine_id_t *);
+using hsa_amd_memory_get_preferred_copy_engine_fn_t = hsa_status_t(HSA_API *)(hsa_agent_t,
+                                                                              hsa_agent_t,
+                                                                              uint32_t *);
 using hsa_amd_memory_lock_fn_t = hsa_status_t(HSA_API *)(void *, size_t, hsa_agent_t *, int,
                                                          void **);
 using hsa_amd_memory_fill_fn_t = hsa_status_t(HSA_API *)(void *, uint32_t, size_t);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
@@ -718,7 +718,7 @@ hsa_status_t HSA_API rj_amd_memory_copy_engine_status(hsa_agent_t dst_agent, hsa
 /// @brief Query preferred copy engines using mapped host agents.
 hsa_status_t HSA_API rj_amd_memory_get_preferred_copy_engine(hsa_agent_t dst_agent,
                                                              hsa_agent_t src_agent,
-                                                             hsa_amd_sdma_engine_id_t *engine_id);
+                                                             uint32_t *engine_ids_mask);
 
 /// @brief Map agent arrays before locking host memory for GPU access.
 hsa_status_t HSA_API rj_amd_memory_lock(void *host_ptr, size_t size, hsa_agent_t *agents,
@@ -2279,12 +2279,12 @@ hsa_status_t HSA_API rj_amd_memory_copy_engine_status(hsa_agent_t dst_agent, hsa
 
 hsa_status_t HSA_API rj_amd_memory_get_preferred_copy_engine(hsa_agent_t dst_agent,
                                                              hsa_agent_t src_agent,
-                                                             hsa_amd_sdma_engine_id_t *engine_id) {
+                                                             uint32_t *engine_ids_mask) {
   auto *original = layer().amd_memory_get_preferred_copy_engine();
   if (!original)
     return HSA_STATUS_ERROR;
   return forward_amd_call(original, mapped_agent_arg(dst_agent), mapped_agent_arg(src_agent),
-                          engine_id);
+                          engine_ids_mask);
 }
 
 hsa_status_t HSA_API rj_amd_memory_lock(void *host_ptr, size_t size, hsa_agent_t *agents,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -4,13 +4,13 @@
 #include "rocjitsu/vm/amdgpu/command_processor.h"
 #include "rocjitsu/code/kernel_symbol.h"
 #include "rocjitsu/isa/arch/amdgpu/isa_properties.h"
-#include "rocjitsu/vm/amdgpu/amd_ext_aql_packet.h"
 #include "rocjitsu/vm/amdgpu/hsa_clock.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
 
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
 RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "hsa/amd_ext_aql_packet.h"
 #include "hsa/amd_hsa_queue.h"
 RJ_DIAGNOSTIC_POP
 

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -876,7 +876,7 @@ TEST_P(IsaTest, NonKernelBarrierPacketsOrderQueueEntries) {
 }
 
 TEST_P(IsaTest, VendorSpecificRejectsUnsupportedFormats) {
-  constexpr std::array<uint8_t, 2> unsupported_formats{0, 200};
+  constexpr std::array<uint8_t, 2> unsupported_formats{0, amdgpu::kHsaAmdPacketTypeReserved200};
 
   for (const auto amd_format : unsupported_formats) {
     SCOPED_TRACE(static_cast<unsigned>(amd_format));

--- a/emulation/rocjitsu/tests/aql_queue.h
+++ b/emulation/rocjitsu/tests/aql_queue.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "rocjitsu/vm/amdgpu/amd_ext_aql_packet.h"
 #include "rocjitsu/vm/amdgpu/command_processor.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 
@@ -14,6 +13,7 @@
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
 RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "hsa/amd_ext_aql_packet.h"
 #include "hsa/hsa.h"
 RJ_DIAGNOSTIC_POP
 


### PR DESCRIPTION
## Motivation

Move the AMD AQL packet ABI mirror under external_headers, document the canonical ROCr source for both minimal mirrors, and correct the preferred-copy-engine mask signature without importing the complete extension header dependency graph.

## Technical Details

Suggested by Tony in https://github.com/ROCm/rocm-systems/pull/8691#discussion_r3596676376.

## Issue Tracking

N/A

## Test Plan

ctest

## Test Result

OK

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
