### PR TITLE
[rocjitsu] Return NaN for E4M3 overflow in gfx1250 conversions

### DIFF
--- a/emulation/rocjitsu/lib/util/include/util/data_types.h
+++ b/emulation/rocjitsu/lib/util/include/util/data_types.h
@@ -444,7 +444,7 @@ inline uint8_t f32_to_fp8_e4m3_rne(float val) {
   int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
   uint32_t f_mant = f & 0x7FFFFF;
   if (f_exp == 0xFF)
-    return static_cast<uint8_t>(sign | 0x7E);
+    return static_cast<uint8_t>(sign | 0x7F);
   int32_t exp = f_exp - 127 + 7;
   if (exp <= 0) {
     if (exp < -3)
@@ -463,7 +463,7 @@ inline uint8_t f32_to_fp8_e4m3_rne(float val) {
     return static_cast<uint8_t>(sign | (result & 0x7));
   }
   if (exp > 15)
-    return static_cast<uint8_t>(sign | 0x7E);
+    return static_cast<uint8_t>(sign | 0x7F);
   uint32_t round_bit = (f_mant >> 19) & 1;
   uint32_t sticky = (f_mant & 0x7FFFF) ? 1 : 0;
   uint32_t mant = (f_mant >> 20) & 0x7;
@@ -472,8 +472,10 @@ inline uint8_t f32_to_fp8_e4m3_rne(float val) {
     mant = 0;
     exp += 1;
   }
+  // OCP non-saturating E4M3 produces a signed NaN when the rounded
+  // magnitude exceeds the maximum finite value.
   if (exp > 15 || (exp == 15 && mant >= 7))
-    return static_cast<uint8_t>(sign | 0x7E);
+    return static_cast<uint8_t>(sign | 0x7F);
   return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 3) | mant);
 }
 
@@ -485,7 +487,7 @@ inline uint8_t f32_to_fp8_e4m3_sr(float val, uint32_t seed) {
   int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
   uint32_t f_mant = f & 0x7FFFFF;
   if (f_exp == 0xFF)
-    return static_cast<uint8_t>(sign | 0x7E);
+    return static_cast<uint8_t>(sign | 0x7F);
   int32_t exp = f_exp - 127 + 7;
   if (exp <= 0) {
     uint32_t full_mant = f_mant | 0x800000;
@@ -503,7 +505,7 @@ inline uint8_t f32_to_fp8_e4m3_sr(float val, uint32_t seed) {
     return static_cast<uint8_t>(sign | (result & 0x7));
   }
   if (exp > 15)
-    return static_cast<uint8_t>(sign | 0x7E);
+    return static_cast<uint8_t>(sign | 0x7F);
   uint32_t trunc_bits = f_mant & 0xFFFFF;
   uint32_t random_add = seed >> 12;
   uint32_t mant = (f_mant >> 20) & 0x7;
@@ -515,7 +517,7 @@ inline uint8_t f32_to_fp8_e4m3_sr(float val, uint32_t seed) {
     }
   }
   if (exp > 15 || (exp == 15 && mant >= 7))
-    return static_cast<uint8_t>(sign | 0x7E);
+    return static_cast<uint8_t>(sign | 0x7F);
   return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 3) | mant);
 }
 

--- a/emulation/rocjitsu/tests/data_types_test.cpp
+++ b/emulation/rocjitsu/tests/data_types_test.cpp
@@ -273,11 +273,13 @@ TEST(Fp8E4M3Fnuz, SrNarrow) {
 
 TEST(Fp8E4M3, RneNarrow) {
   EXPECT_EQ(util::f32_to_fp8_e4m3_rne(std::numeric_limits<float>::quiet_NaN()), 0x7F);
-  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(std::numeric_limits<float>::infinity()), 0x7E);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(std::numeric_limits<float>::infinity()), 0x7F);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(-std::numeric_limits<float>::infinity()), 0xFF);
   EXPECT_EQ(util::f32_to_fp8_e4m3_rne(0.0f), 0x00);
   EXPECT_EQ(util::f32_to_fp8_e4m3_rne(1.0f), 0x38);
   EXPECT_EQ(util::f32_to_fp8_e4m3_rne(448.0f), 0x7E);
-  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(500.0f), 0x7E);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(500.0f), 0x7F);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(-500.0f), 0xFF);
   // Denorm overflow: largest denorm (code 7 = 7*2^-9) rounds up to
   // smallest normal (code 8 = 2^-6) for values just above midpoint.
   float largest_denorm = util::fp8_e4m3_to_f32(0x07);
@@ -300,9 +302,14 @@ TEST(Fp8E4M3, RneExp15) {
   EXPECT_EQ(util::f32_to_fp8_e4m3_rne(280.0f), 0x79);
   // 304.0 is midpoint between 288 (m=1) and 320 (m=2) — RNE to even (m=2)
   EXPECT_EQ(util::f32_to_fp8_e4m3_rne(304.0f), 0x7A);
-  // Values above 448 saturate to 0x7E (max finite, not NaN 0x7F)
+  // Overflow is classified after rounding. The midpoint between max finite
+  // 448 and the reserved 480 encoding ties to even, so it stays finite.
   EXPECT_EQ(util::f32_to_fp8_e4m3_rne(449.0f), 0x7E);
-  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(1000.0f), 0x7E);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(464.0f), 0x7E);
+  EXPECT_EQ(
+      util::f32_to_fp8_e4m3_rne(std::nextafter(464.0f, std::numeric_limits<float>::infinity())),
+      0x7F);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(1000.0f), 0x7F);
 }
 
 TEST(Fp8E4M3, SrExp15) {
@@ -312,16 +319,23 @@ TEST(Fp8E4M3, SrExp15) {
     uint8_t code = 0x78 | m;
     EXPECT_EQ(util::f32_to_fp8_e4m3_sr(kExp15Values[m], 0), code) << "sr m=" << m;
   }
-  // Values above max saturate to 0x7E
-  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(500.0f, 0), 0x7E);
-  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(500.0f, 0xFFFFFFFF), 0x7E);
+  // Near max finite, stochastic rounding can either remain finite or round
+  // into the reserved NaN encoding depending on the seed.
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(449.0f, 0), 0x7E);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(449.0f, 0xFFFFFFFF), 0x7F);
+  // Deep overflow produces NaN for every seed.
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(500.0f, 0), 0x7F);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(500.0f, 0xFFFFFFFF), 0x7F);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(-500.0f, 0), 0xFF);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(-500.0f, 0xFFFFFFFF), 0xFF);
 }
 
 TEST(Fp8E4M3, SrNarrow) {
   uint8_t r = util::f32_to_fp8_e4m3_sr(1.0f, 0);
   EXPECT_EQ(r, 0x38);
   EXPECT_EQ(util::f32_to_fp8_e4m3_sr(std::numeric_limits<float>::quiet_NaN(), 0), 0x7F);
-  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(std::numeric_limits<float>::infinity(), 0), 0x7E);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(std::numeric_limits<float>::infinity(), 0), 0x7F);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(-std::numeric_limits<float>::infinity(), 0), 0xFF);
 }
 
 TEST(Fp8E4M3, SrDenormRoundTrip) {

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -3186,6 +3186,44 @@ TEST(Gfx1250CvtFp8Test, F32DecodeVop3UsesSelectedByte) {
   cu->reset_all_wf();
 }
 
+TEST(Gfx1250CvtFp8Test, E4M3OverflowProducesNaN) {
+  amdgpu::GpuMemory gpu_mem("gfx1250_cvt_fp8_overflow_mem");
+  amdgpu::L2Cache l2("gfx1250_cvt_fp8_overflow_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_GFX1250;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+
+  auto cu = amdgpu::ComputeUnitCore::create("gfx1250", cfg, &gpu_mem, &l2);
+  ASSERT_NE(cu, nullptr);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+
+  auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1);
+
+  const uint32_t vb = wf->vgpr_alloc().base;
+  const uint32_t sb = wf->sgpr_alloc().base;
+  cu->write_sgpr(sb + 5, std::bit_cast<uint32_t>(768.0f));
+  cu->write_sgpr(sb + 6, std::bit_cast<uint32_t>(-768.0f));
+  cu->write_vgpr(vb + 2, 0, 0xA5A5BEEFu);
+
+  // v_cvt_pk_fp8_f32 v2.l, s5, s6
+  const uint32_t words[] = {0xD7690002U, 0x02000C05U};
+  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cvt_pk_fp8_f32");
+  cu->execute_instruction(inst.get(), *wf);
+  EXPECT_EQ(cu->read_vgpr(vb + 2, 0), 0xA5A5FF7Fu);
+
+  cu->reset_all_wf();
+}
+
 TEST(Gfx1250CvtFp8Test, E5M3ClampSelectsUnsignedFp8Format) {
   amdgpu::GpuMemory gpu_mem("gfx1250_cvt_fp8_e5m3_mem");
   amdgpu::L2Cache l2("gfx1250_cvt_fp8_e5m3_l2");


### PR DESCRIPTION
## Motivation

Our gfx1250 FP32-to-E4M3 conversion returned the maximum finite value for overflow instead of the signed NaN encoding. This caused incorrect results in workloads using `v_cvt_pk_fp8_f32`.

## Technical Details

Return signed E4M3 NaN (`0x7F`/`0xFF`) for non-saturating overflow and infinity in both round-to-nearest-even and stochastic-rounding conversions.  Expand helper-level coverage for signed NaNs, infinities, overflow boundaries, and stochastic rounding.

## Issue Tracking

N/A

## Test Plan

ctest + iree e2e tests for gfx1250

## Test Result

OK

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
