### PR TITLE
ci(rccl): add placeholder therock-rccl coverage/mnctl workflows

### DIFF
--- a/.github/workflows/therock-rccl-code-coverage.yml
+++ b/.github/workflows/therock-rccl-code-coverage.yml
@@ -1,0 +1,19 @@
+# PLACEHOLDER (no-op). Registers this workflow path on the default branch so
+# `workflow_dispatch` becomes selectable in the Actions UI; you can then pick a
+# feature branch to run the real implementation from that branch. The donothing
+# job never executes (`if: false`).
+# See ROCm/TheRock#1740 for the same pattern.
+name: TheRock Code Coverage for rccl
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  donothing:
+    runs-on: ubuntu-latest
+    if: false
+    steps:
+      - run: echo "Placeholder - real implementation lives on the feature branch"

--- a/.github/workflows/therock-rccl-mnctl-run.yml
+++ b/.github/workflows/therock-rccl-mnctl-run.yml
@@ -1,0 +1,18 @@
+# PLACEHOLDER (no-op). Registers this reusable workflow's path on the default
+# branch so the real implementation on a feature branch can be referenced/
+# dispatched. The donothing job never executes (`if: false`).
+# See ROCm/TheRock#1740 for the same pattern.
+name: TheRock mnctl workload run for rccl
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  donothing:
+    runs-on: ubuntu-latest
+    if: false
+    steps:
+      - run: echo "Placeholder - real implementation lives on the feature branch"

--- a/.github/workflows/therock-rccl-mnctl-run.yml
+++ b/.github/workflows/therock-rccl-mnctl-run.yml
@@ -1,6 +1,6 @@
-# PLACEHOLDER (no-op). Registers this reusable workflow's path on the default
-# branch so the real implementation on a feature branch can be referenced/
-# dispatched. The donothing job never executes (`if: false`).
+# PLACEHOLDER (no-op). Registers this workflow path on the default branch so the real
+# implementation on a feature branch can be selected/dispatched. The donothing job
+# never executes (`if: false`).
 # See ROCm/TheRock#1740 for the same pattern.
 name: TheRock mnctl workload run for rccl
 


### PR DESCRIPTION
## Motivation

No-op placeholders (if: false) at the monorepo root .github/workflows using the therock-rccl-* naming convention. Merging these to the default branch registers workflow_dispatch in the Actions UI so the real implementation on feature branch can be run by selecting that branch. Follows the ROCm/TheRock#1740 pattern.

## Technical Details

Added placeholder pipelines

## Issue Tracking

JIRA ID : AICOMRCCL-1559

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
