### PR TITLE
feat(rocr): Add LOADER_ENABLE_TRAMPOLINE_PREFETCH_B8 gfx125x trampoline variant

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -120,6 +120,7 @@ public:
 
   bool TrampolineEnabled() const { return trampoline_enabled_; }
   bool TrampolineNoWaEnabled() const { return trampoline_no_wa_enabled_; }
+  bool TrampolineScopeSeEnabled() const { return trampoline_scope_se_enabled_; }
 
   bool ParseOptions(const std::string& options);
   void Reset();
@@ -142,6 +143,7 @@ private:
   amd::options::OptionParser option_parser;
   bool trampoline_enabled_ = false;
   bool trampoline_no_wa_enabled_ = false;
+  bool trampoline_scope_se_enabled_ = false;
 };
 
 LoaderOptions::LoaderOptions(std::ostream& error) :
@@ -173,6 +175,13 @@ LoaderOptions::LoaderOptions(std::ostream& error) :
   const char* enable_trampoline_no_wa = getenv("LOADER_ENABLE_TRAMPOLINE_NO_WA");
   if (enable_trampoline_no_wa && std::strcmp(enable_trampoline_no_wa, "1") == 0) {
     trampoline_no_wa_enabled_ = true;
+  }
+  // LOADER_ENABLE_TRAMPOLINE_PREFETCH_B8=1: trampolines whose leading workaround
+  // instruction is a global_prefetch_b8 (scope:SCOPE_SE, th:TH_LOAD_RT) instead
+  // of global_wb (scope:SCOPE_CU).
+  const char* enable_trampoline_scope_se = getenv("LOADER_ENABLE_TRAMPOLINE_PREFETCH_B8");
+  if (enable_trampoline_scope_se && std::strcmp(enable_trampoline_scope_se, "1") == 0) {
+    trampoline_scope_se_enabled_ = true;
   }
 }
 
@@ -271,6 +280,34 @@ static void BuildTrampolineGfx1250NoWa(uint8_t* buf, uint64_t target) {
   w[3] = static_cast<uint32_t>(target >> 32);
   w[4] = 0xBE804864;  // s_set_pc_i64 s[100:101]
   for (size_t i = 5; i < kTrampolineStubStride / sizeof(uint32_t); ++i)
+    w[i] = 0xBF9F0000;  // s_code_end (prefetch-safe padding)
+}
+
+// Alternate leading workaround instruction (LOADER_ENABLE_TRAMPOLINE_PREFETCH_B8):
+//   global_prefetch_b8 v0, [s0, s1] scope:SCOPE_SE th:TH_LOAD_RT
+// gfx1250 encoding (llvm-mc --mcpu=gfx1250 --show-encoding), 3 dwords. TH_LOAD_RT
+// is the default TH (0); SCOPE_SE sets bit 0x04 in the third encoding byte.
+static constexpr uint32_t kGfx1250ScopeSePrefetch[3] = {
+    0xEE174000,  // global_prefetch_b8 v0, s[0:1] ...
+    0x00040000,  // ... scope:SCOPE_SE th:TH_LOAD_RT
+    0x00000000,  // :
+};
+
+// Like BuildTrampolineGfx1250 but leads with global_prefetch_b8 (scope:SCOPE_SE)
+// in place of global_wb (scope:SCOPE_CU); the v_nop and jump are unchanged.
+static void BuildTrampolineGfx1250ScopeSe(uint8_t* buf, uint64_t target) {
+  auto* w = reinterpret_cast<uint32_t*>(buf);
+
+  w[0] = kGfx1250ScopeSePrefetch[0];  // global_prefetch_b8 v0, s[0:1]
+  w[1] = kGfx1250ScopeSePrefetch[1];  //   scope:SCOPE_SE th:TH_LOAD_RT
+  w[2] = kGfx1250ScopeSePrefetch[2];  // :
+  w[3] = 0x7E000000;  // v_nop (padding)
+  w[4] = 0xBEE400FF;  // s_mov_b32 s100, target_lo
+  w[5] = static_cast<uint32_t>(target);
+  w[6] = 0xBEE500FF;  // s_mov_b32 s101, target_hi
+  w[7] = static_cast<uint32_t>(target >> 32);
+  w[8] = 0xBE804864;  // s_set_pc_i64 s[100:101]
+  for (size_t i = 9; i < kTrampolineStubStride / sizeof(uint32_t); ++i)
     w[i] = 0xBF9F0000;  // s_code_end (prefetch-safe padding)
 }
 
@@ -1393,12 +1430,26 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
   }
 
   // Kernel-entry trampolines (gfx125x). Disabled by default for gfx125x.
-  // Set LOADER_ENABLE_TRAMPOLINE=1 or LOADER_ENABLE_TRAMPOLINE_NO_WA=1 to enable
-  // (for testing only). NO_WA selects the minimal stub without global_wb.
+  // Set LOADER_ENABLE_TRAMPOLINE=1, LOADER_ENABLE_TRAMPOLINE_NO_WA=1, or
+  // LOADER_ENABLE_TRAMPOLINE_PREFETCH_B8=1 to enable (for testing only). NO_WA selects
+  // the minimal stub without global_wb; PREFETCH_B8 leads with global_prefetch_b8
+  // (scope:SCOPE_SE) instead of global_wb. Precedence: PREFETCH_B8 > NO_WA > full.
   trampoline_no_wa_gfx125x_ = loaderOptions.TrampolineNoWaEnabled();
+  trampoline_scope_se_gfx125x_ = loaderOptions.TrampolineScopeSeEnabled();
   trampoline_enabled_gfx125x_ =
-      (loaderOptions.TrampolineEnabled() || trampoline_no_wa_gfx125x_) &&
+      (loaderOptions.TrampolineEnabled() || trampoline_no_wa_gfx125x_ ||
+       trampoline_scope_se_gfx125x_) &&
       CodeObjectIsaIsGfx125Family(codeIsa);
+  if (trampoline_no_wa_gfx125x_) {
+    // Gated by LOADER_ENABLE_LOGGING=1 (see Logger).
+    logger_ << "Loader: LOADER_ENABLE_TRAMPOLINE_NO_WA=1 -- gfx125x entry trampolines "
+               "use the minimal stub without the global_wb/v_nop workaround\n";
+  }
+  if (trampoline_scope_se_gfx125x_) {
+    // Gated by LOADER_ENABLE_LOGGING=1 (see Logger).
+    logger_ << "Loader: LOADER_ENABLE_TRAMPOLINE_PREFETCH_B8=1 -- gfx125x entry trampolines "
+               "lead with global_prefetch_b8 (scope:SCOPE_SE) instead of global_wb\n";
+  }
   kd_fixups_.clear();
 
   uint32_t majorVersion, minorVersion;
@@ -1687,7 +1738,9 @@ hsa_status_t ExecutableImpl::InstallTrampolinesGfx125x(hsa_agent_t agent) {
     const uint64_t stub_dev = reinterpret_cast<uint64_t>(tramp->Address(stub_off));
 
     uint8_t blob[kTrampolineStubStride];
-    if (trampoline_no_wa_gfx125x_) {
+    if (trampoline_scope_se_gfx125x_) {
+      BuildTrampolineGfx1250ScopeSe(blob, entry_dev);
+    } else if (trampoline_no_wa_gfx125x_) {
       BuildTrampolineGfx1250NoWa(blob, entry_dev);
     } else {
       BuildTrampolineGfx1250(blob, entry_dev);
@@ -1695,7 +1748,9 @@ hsa_status_t ExecutableImpl::InstallTrampolinesGfx125x(hsa_agent_t agent) {
     tramp->Copy(stub_off, blob, sizeof(blob));  // -> trampoline host shadow
 
     // Gated by LOADER_ENABLE_LOGGING=1 (see Logger).
-    logger_ << "Loader: injecting gfx125x entry trampoline for kernel " << f.name << "\n";
+    logger_ << "Loader: injecting gfx125x entry trampoline for kernel " << f.name
+            << (trampoline_scope_se_gfx125x_ ? " (global_prefetch_b8 scope:SCOPE_SE)" : "")
+            << "\n";
 
     // Redirect dispatch onto the stub: kernel_object(kd_dev) + new_off == stub.
     int64_t new_off = static_cast<int64_t>(stub_dev) - static_cast<int64_t>(kd_dev);

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
@@ -661,6 +661,7 @@ private:
   };
   bool trampoline_enabled_gfx125x_ = false;
   bool trampoline_no_wa_gfx125x_ = false;
+  bool trampoline_scope_se_gfx125x_ = false;
   std::vector<KdFixup> kd_fixups_;
   std::vector<std::shared_ptr<Segment>> trampoline_segments_;
 };


### PR DESCRIPTION
## Summary

Add a third env-var-controlled gfx125x kernel-entry trampoline mode for experimentation. `LOADER_ENABLE_TRAMPOLINE_PREFETCH_B8=1` emits a trampoline stub that leads with `global_prefetch_b8 v0, [s0, s1] scope:SCOPE_SE th:TH_LOAD_RT` in place of the `global_wb <scope:SCOPE_CU>` used by the full trampoline path; the `v_nop` padding and the `s_mov`/`s_set_pc_i64` jump are unchanged.

Builds on the existing gfx125x entry-trampoline work:
- `LOADER_ENABLE_TRAMPOLINE=1` — full stub (`global_wb` scope:SCOPE_CU + `v_nop` + jump)
- `LOADER_ENABLE_TRAMPOLINE_NO_WA=1` — minimal stub (jump only)
- `LOADER_ENABLE_TRAMPOLINE_PREFETCH_B8=1` — full stub but leading with `global_prefetch_b8` (scope:SCOPE_SE) **(new)**
- Precedence when multiple are set: `PREFETCH_B8 > NO_WA > full`

Implementation notes:
- New `kGfx1250ScopeSePrefetch` constant holds the 3-dword `global_prefetch_b8` encoding, verified with `llvm-mc --mcpu=gfx1250 --show-encoding` (`TH_LOAD_RT` is the default TH=0; `scope:SCOPE_SE` sets bit `0x04`).
- New `BuildTrampolineGfx1250ScopeSe()` builder; stub selection updated in `InstallTrampolinesGfx125x`.
- Logging (gated by `LOADER_ENABLE_LOGGING=1`): a one-time banner when the mode is active, and a per-kernel injection line annotated with `(global_prefetch_b8 scope:SCOPE_SE)`.
- The existing unclaused-VMEM prologue detection still applies: kernels already carrying the compiler workaround are skipped in all modes.

## JIRA ID

JIRA ID : LCOMPILER-2448

## Test plan

- [x] Build `libhsa-runtime64` against a gfx1250 TheRock toolchain (built on the target host, since the usual build box was unavailable)
- [x] `LOADER_ENABLE_TRAMPOLINE_PREFETCH_B8=1` emits the `global_prefetch_b8` stub; banner + per-kernel annotation appear under `LOADER_ENABLE_LOGGING=1`
- [x] `LOADER_ENABLE_TRAMPOLINE=1` and `LOADER_ENABLE_TRAMPOLINE_NO_WA=1` still work; disabled when no env var is set
- [x] Kernel compiled WITH the compiler workaround (patched clang) is skipped in every mode; kernel compiled WITHOUT it gets a trampoline
- [x] gfx1250 HIP test runs to completion in all modes (default / TRAMPOLINE / NO_WA / PREFETCH_B8) for both binaries

Made with [Cursor](https://cursor.com)
