### PR TITLE
fix(clr): internal linkage for bounded builtin index accessors

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
@@ -268,10 +268,24 @@ __DEVICE__ unsigned int __hip_get_grid_dim_z() { return __ockl_get_num_groups(2)
   __declspec(property(get = __get_##DIMENSION)) unsigned int DIMENSION;                            \
   __DEVICE__ unsigned int __get_##DIMENSION(void) { return FUNCTION; }
 
+// Give the (block-size bounded) built-in index accessors internal linkage so
+// that IPSCCP can attach the range() return attribute inferred from the
+// underlying __ockl_get_local_* / workgroup-size builtins. As linkonce_odr the
+// accessors are not exact definitions, so IPSCCP refuses to track their return
+// values; under full device LTO the missing range lets strided GEPs lose
+// inbounds, which blocks offset folding (extra v_lshl_add_u64, higher VGPR
+// pressure, lower occupancy). Only dimensions bounded by the block size
+// (threadIdx, blockDim) use this variant.
+#define __HIP_DEVICE_BUILTIN_INTERNAL(DIMENSION, FUNCTION)                                         \
+  __declspec(property(get = __get_##DIMENSION)) unsigned int DIMENSION;                            \
+  __attribute__((internal_linkage)) __DEVICE__ unsigned int __get_##DIMENSION(void) {              \
+    return FUNCTION;                                                                               \
+  }
+
 struct __hip_builtin_threadIdx_t {
-  __HIP_DEVICE_BUILTIN(x, __hip_get_thread_idx_x());
-  __HIP_DEVICE_BUILTIN(y, __hip_get_thread_idx_y());
-  __HIP_DEVICE_BUILTIN(z, __hip_get_thread_idx_z());
+  __HIP_DEVICE_BUILTIN_INTERNAL(x, __hip_get_thread_idx_x());
+  __HIP_DEVICE_BUILTIN_INTERNAL(y, __hip_get_thread_idx_y());
+  __HIP_DEVICE_BUILTIN_INTERNAL(z, __hip_get_thread_idx_z());
 #ifdef __cplusplus
   __device__ operator dim3() const { return dim3(x, y, z); }
 #endif
@@ -287,9 +301,9 @@ struct __hip_builtin_blockIdx_t {
 };
 
 struct __hip_builtin_blockDim_t {
-  __HIP_DEVICE_BUILTIN(x, __hip_get_block_dim_x());
-  __HIP_DEVICE_BUILTIN(y, __hip_get_block_dim_y());
-  __HIP_DEVICE_BUILTIN(z, __hip_get_block_dim_z());
+  __HIP_DEVICE_BUILTIN_INTERNAL(x, __hip_get_block_dim_x());
+  __HIP_DEVICE_BUILTIN_INTERNAL(y, __hip_get_block_dim_y());
+  __HIP_DEVICE_BUILTIN_INTERNAL(z, __hip_get_block_dim_z());
 #ifdef __cplusplus
   __device__ operator dim3() const { return dim3(x, y, z); }
 #endif
@@ -305,6 +319,7 @@ struct __hip_builtin_gridDim_t {
 };
 
 #undef __HIP_DEVICE_BUILTIN
+#undef __HIP_DEVICE_BUILTIN_INTERNAL
 #pragma pop_macro("__DEVICE__")
 
 extern const __device__ __attribute__((weak)) __hip_builtin_threadIdx_t threadIdx;

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
@@ -275,12 +275,18 @@ __DEVICE__ unsigned int __hip_get_grid_dim_z() { return __ockl_get_num_groups(2)
 // values; under full device LTO the missing range lets strided GEPs lose
 // inbounds, which blocks offset folding (extra v_lshl_add_u64, higher VGPR
 // pressure, lower occupancy). Only dimensions bounded by the block size
-// (threadIdx, blockDim) use this variant.
+// (threadIdx, blockDim) use this variant. Guard the attribute with
+// __has_attribute so that compilers without internal_linkage fall back to the
+// existing accessor definition instead of emitting -Wattributes.
+#if defined(__has_attribute) && __has_attribute(internal_linkage)
 #define __HIP_DEVICE_BUILTIN_INTERNAL(DIMENSION, FUNCTION)                                         \
   __declspec(property(get = __get_##DIMENSION)) unsigned int DIMENSION;                            \
   __attribute__((internal_linkage)) __DEVICE__ unsigned int __get_##DIMENSION(void) {              \
     return FUNCTION;                                                                               \
   }
+#else
+#define __HIP_DEVICE_BUILTIN_INTERNAL(DIMENSION, FUNCTION) __HIP_DEVICE_BUILTIN(DIMENSION, FUNCTION)
+#endif
 
 struct __hip_builtin_threadIdx_t {
   __HIP_DEVICE_BUILTIN_INTERNAL(x, __hip_get_thread_idx_x());

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
@@ -275,10 +275,17 @@ __DEVICE__ unsigned int __hip_get_grid_dim_z() { return __ockl_get_num_groups(2)
 // values; under full device LTO the missing range lets strided GEPs lose
 // inbounds, which blocks offset folding (extra v_lshl_add_u64, higher VGPR
 // pressure, lower occupancy). Only dimensions bounded by the block size
-// (threadIdx, blockDim) use this variant. Guard the attribute with
-// __has_attribute so that compilers without internal_linkage fall back to the
-// existing accessor definition instead of emitting -Wattributes.
-#if defined(__has_attribute) && __has_attribute(internal_linkage)
+// (threadIdx, blockDim) use this variant. Probe internal_linkage with a nested
+// __has_attribute check -- the combined "defined(__has_attribute) &&
+// __has_attribute(...)" form is not portable (see the GCC __has_attribute
+// docs) -- and fall back to the existing accessor when it is unavailable.
+#if defined(__has_attribute)
+#if __has_attribute(internal_linkage)
+#define __HIP_HAS_INTERNAL_LINKAGE 1
+#endif
+#endif
+
+#if defined(__HIP_HAS_INTERNAL_LINKAGE)
 #define __HIP_DEVICE_BUILTIN_INTERNAL(DIMENSION, FUNCTION)                                         \
   __declspec(property(get = __get_##DIMENSION)) unsigned int DIMENSION;                            \
   __attribute__((internal_linkage)) __DEVICE__ unsigned int __get_##DIMENSION(void) {              \
@@ -326,6 +333,7 @@ struct __hip_builtin_gridDim_t {
 
 #undef __HIP_DEVICE_BUILTIN
 #undef __HIP_DEVICE_BUILTIN_INTERNAL
+#undef __HIP_HAS_INTERNAL_LINKAGE
 #pragma pop_macro("__DEVICE__")
 
 extern const __device__ __attribute__((weak)) __hip_builtin_threadIdx_t threadIdx;


### PR DESCRIPTION
Add a __HIP_DEVICE_BUILTIN_INTERNAL macro that marks the accessor with internal_linkage, making it an exact definition IPSCCP can track. Applied only to the block-size bounded accessors (threadIdx, blockDim); blockIdx and gridDim keep the existing macro. NFC for HIP semantics.

## Motivation

GenericBandwidth (and other kernels whose addressing is strided by the block
size) regressed on gfx950 / MI350 under full device LTO.

Root cause is in how the HIP built-in index accessors are emitted. `threadIdx.*`
and `blockDim.*` resolve through small `linkonce_odr` accessor functions. Because
`linkonce_odr` is not an *exact* definition, LLVM's IPSCCP refuses to track their
return values and therefore cannot attach the `range()` return attribute that the
underlying `__ockl_get_local_*` / workgroup-size builtins already carry. With the
range lost, strided GEPs derived from these indices drop `inbounds`, which blocks
address-offset folding in the backend -- extra `v_lshl_add_u64` address math.

## Technical Details

Add a `__HIP_DEVICE_BUILTIN_INTERNAL` variant of the accessor macro that marks the
generated `__get_*` wrapper with `__attribute__((internal_linkage))`. Internal
linkage makes the accessor an exact, non-interposable definition in every TU, so
IPSCCP can propagate the `range(0, 1024)` inferred from the workitem/workgroup
builtins.

Only the accessors that are actually bounded by the block size use the new macro:

- `__hip_builtin_threadIdx_t` (x/y/z)
- `__hip_builtin_blockDim_t` (x/y/z)

`blockIdx` and `gridDim` are not block-size bounded and keep the existing macro.

This is NFC for HIP semantics: the accessor still forwards to the same builtin;
only the linkage of the tiny wrapper changes, restoring the range / `inbounds`
information the optimizer needs.

## Issue Tracking

JIRA ID: SWHIPSDK-47

## Test Plan

No new unit test: this is a device-codegen / performance fix, not a functional or
API change, and cannot be meaningfully exercised by a hip-tests unit test.
Validated on hardware with HIPPerf GenericBandwidth under full device LTO:

- MI300 and MI350 (gfx950).
- Codegen marker: presence of the redundant `v_lshl_add_u64` address arithmetic
  in the generated ISA (proxy for lost `inbounds` / offset folding).
- Throughput: HIPPerf GenericBandwidth bandwidth vs the pre-regression baseline.

## Test Result

- Offset folding restored: the redundant `v_lshl_add_u64` address arithmetic
  disappears from the generated ISA, matching the pre-regression codegen.
- HIPPerf GenericBandwidth recovered to the pre-regression baseline, closing a
  regression of up to ~11% on MI300 and up to ~20% on MI350 (gfx950).
- No codegen / behavioral change on the older (pre-regression) toolchain:
  rebuild clean, ISA unchanged, hip-tests pass, perf stable.
