### PR TITLE
fix(rocr): emit compacted SDMA indirect-copy packet (fix 0x0 page fault)

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -2797,47 +2797,60 @@ void BlitSdma<useGCR, scopeFields>::BuildWaitSignalIndirectCopyCommand(
   const bool do_wait = (wait_signal != nullptr);
   const bool do_signal = (signal_signal != nullptr);
 
-  SDMA_PKT_COPY_LINEAR_WAITSIGNAL_INDIRECT_GFX1250* pkt =
-      reinterpret_cast<SDMA_PKT_COPY_LINEAR_WAITSIGNAL_INDIRECT_GFX1250*>(cmd_addr);
-  memset(pkt, 0, sizeof(SDMA_PKT_COPY_LINEAR_WAITSIGNAL_INDIRECT_GFX1250));
+  // Build into a scratch packet, then emit only the present DW blocks (below).
+  SDMA_PKT_COPY_LINEAR_WAITSIGNAL_INDIRECT_GFX1250 pkt;
+  memset(&pkt, 0, sizeof(pkt));
 
-  pkt->HEADER_UNION.op = SDMA_OP_COPY;
-  pkt->HEADER_UNION.sub_op = SDMA_SUBOP_COPY_INDIRECT;
-  pkt->HEADER_UNION.indirect_src = indirect_src ? 1 : 0;
-  pkt->HEADER_UNION.indirect_dst = indirect_dst ? 1 : 0;
-  pkt->HEADER_UNION.wait = do_wait ? 1 : 0;
-  pkt->HEADER_UNION.signal = do_signal ? 1 : 0;
+  pkt.HEADER_UNION.op = SDMA_OP_COPY;
+  pkt.HEADER_UNION.sub_op = SDMA_SUBOP_COPY_INDIRECT;
+  pkt.HEADER_UNION.indirect_src = indirect_src ? 1 : 0;
+  pkt.HEADER_UNION.indirect_dst = indirect_dst ? 1 : 0;
+  pkt.HEADER_UNION.wait = do_wait ? 1 : 0;
+  pkt.HEADER_UNION.signal = do_signal ? 1 : 0;
 
   if (do_wait) {
-    pkt->WAIT_FUNCTION_UNION.wait_function = 0x3;  // Equal
+    pkt.WAIT_FUNCTION_UNION.wait_function = 0x3;  // Equal
     void* wait_addr = const_cast<core::Signal*>(wait_signal)->ValueLocation();
-    pkt->WAIT_ADDR_LO_UNION.wait_addr_31_3 = ptrlow32(wait_addr) >> 3;
-    pkt->WAIT_ADDR_HI_UNION.wait_addr_63_32 = ptrhigh32(wait_addr);
-    pkt->WAIT_REFERENCE_LO_UNION.wait_reference_31_0 = 0;
-    pkt->WAIT_REFERENCE_HI_UNION.wait_reference_63_32 = 0;
-    pkt->WAIT_MASK_LO_UNION.wait_mask_31_0 = 0xffffffff;
-    pkt->WAIT_MASK_HI_UNION.wait_mask_63_32 = 0xffffffff;
+    pkt.WAIT_ADDR_LO_UNION.wait_addr_31_3 = ptrlow32(wait_addr) >> 3;
+    pkt.WAIT_ADDR_HI_UNION.wait_addr_63_32 = ptrhigh32(wait_addr);
+    pkt.WAIT_REFERENCE_LO_UNION.wait_reference_31_0 = 0;
+    pkt.WAIT_REFERENCE_HI_UNION.wait_reference_63_32 = 0;
+    pkt.WAIT_MASK_LO_UNION.wait_mask_31_0 = 0xffffffff;
+    pkt.WAIT_MASK_HI_UNION.wait_mask_63_32 = 0xffffffff;
   }
 
-  pkt->COPY_COUNT_UNION.copy_count = static_cast<uint32_t>(size) - 1;
-  pkt->COPY_PARAMETER_UNION.copy_dst_scope = SDMA_MEMORY_SCOPE_SYS;
-  pkt->COPY_PARAMETER_UNION.copy_src_scope = SDMA_MEMORY_SCOPE_SYS;
-  pkt->COPY_PARAMETER_UNION.indirect_addr_scope = SDMA_MEMORY_SCOPE_SYS;
+  pkt.COPY_COUNT_UNION.copy_count = static_cast<uint32_t>(size) - 1;
+  pkt.COPY_PARAMETER_UNION.copy_dst_scope = SDMA_MEMORY_SCOPE_SYS;
+  pkt.COPY_PARAMETER_UNION.copy_src_scope = SDMA_MEMORY_SCOPE_SYS;
+  pkt.COPY_PARAMETER_UNION.indirect_addr_scope = SDMA_MEMORY_SCOPE_SYS;
 
-  pkt->SRC_ADDR_LO_UNION.copy_src_addr_31_0 = ptrlow32(src);
-  pkt->SRC_ADDR_HI_UNION.copy_src_addr_63_32 = ptrhigh32(src);
-  pkt->DST_ADDR_LO_UNION.copy_dst_addr_31_0 = ptrlow32(dst);
-  pkt->DST_ADDR_HI_UNION.copy_dst_addr_63_32 = ptrhigh32(dst);
+  pkt.SRC_ADDR_LO_UNION.copy_src_addr_31_0 = ptrlow32(src);
+  pkt.SRC_ADDR_HI_UNION.copy_src_addr_63_32 = ptrhigh32(src);
+  pkt.DST_ADDR_LO_UNION.copy_dst_addr_31_0 = ptrlow32(dst);
+  pkt.DST_ADDR_HI_UNION.copy_dst_addr_63_32 = ptrhigh32(dst);
 
   if (do_signal) {
-    pkt->SIGNAL_OPERATION_UNION.signal_operation = 0x70;  // 64b sub
-    pkt->SIGNAL_OPERATION_UNION.signal_scope = SDMA_MEMORY_SCOPE_SYS;
+    pkt.SIGNAL_OPERATION_UNION.signal_operation = 0x70;  // 64b sub
+    pkt.SIGNAL_OPERATION_UNION.signal_scope = SDMA_MEMORY_SCOPE_SYS;
     void* sig_addr = signal_signal->ValueLocation();
-    pkt->SIGNAL_ADDR_LO_UNION.signal_addr_31_3 = ptrlow32(sig_addr) >> 3;
-    pkt->SIGNAL_ADDR_HI_UNION.signal_addr_63_32 = ptrhigh32(sig_addr);
-    pkt->SIGNAL_DATA_LO_UNION.signal_data_31_0 = 1;
-    pkt->SIGNAL_DATA_HI_UNION.signal_data_63_32 = 0;
+    pkt.SIGNAL_ADDR_LO_UNION.signal_addr_31_3 = ptrlow32(sig_addr) >> 3;
+    pkt.SIGNAL_ADDR_HI_UNION.signal_addr_63_32 = ptrhigh32(sig_addr);
+    pkt.SIGNAL_DATA_LO_UNION.signal_data_31_0 = 1;
+    pkt.SIGNAL_DATA_HI_UNION.signal_data_63_32 = 0;
   }
+
+  // Emit compacted, matching the sibling WaitSignal builders and the caller's
+  // per_pkt_dws = 1 + wait_dws + 6 + 5. The SDMA engine parses these packets as
+  // variable length; absent wait/signal blocks must NOT be reserved. Writing the
+  // fixed full-struct layout left the copy block at DW8 while the engine (wait=0)
+  // reads it at DW1 -> SRC_ADDR=0 -> indirect_src deref of 0x0 -> SDMA fault.
+  const uint32_t* pkt_dw = reinterpret_cast<const uint32_t*>(&pkt);
+  uint32_t* out_dw = reinterpret_cast<uint32_t*>(cmd_addr);
+  uint32_t n = 0;
+  out_dw[n++] = pkt_dw[0];                                              // header
+  if (do_wait)   for (uint32_t d = 1;  d <= 7;  ++d) out_dw[n++] = pkt_dw[d];  // wait   (7)
+  for (uint32_t d = 8;  d <= 13; ++d) out_dw[n++] = pkt_dw[d];          // copy   (6)
+  if (do_signal) for (uint32_t d = 14; d <= 18; ++d) out_dw[n++] = pkt_dw[d];  // signal (5)
 }
 
 template <bool useGCR, bool scopeFields>


### PR DESCRIPTION
## Motivation

`hipMemcpyBatchAsync` with the indirect-pointer flags (`hipMemcpyFlagExtOpIndirectSrc` /
`hipMemcpyFlagExtOpIndirectDst`) faults on gfx1250. The API returns `hipSuccess`, but at execution
the copy hits an illegal memory access — a no-retry GPU page fault at address `0x0` (client SDMA0) —
surfacing to the app as `hipErrorIllegalAddress` (Code 700). Two hip-tests fail:
`Unit_hipMemcpyBatchAsync_IndirectSrc` and `Unit_hipMemcpyBatchAsync_IndirectDst`. This PR fixes the
SDMA packet emission so indirect batch copies execute correctly.

## Technical Details

On gfx1250 the SDMA WaitSignal copy packets are **variable length**: `header (1 DW)` + optional
`wait (7 DW)` + `copy (6 DW)` + optional `signal (5 DW)`. The engine reads the header and, from its
`wait`/`signal` bits, expects the present blocks packed contiguously (an absent wait block is not
reserved). The copy/swap builders emit compacted this way and the caller advances by the compacted
size `per_pkt_dws = 1 + wait_dws + 6 + 5`.

`BuildWaitSignalIndirectCopyCommand` (`amd_blit_sdma.cpp`) was still writing the packet as a **fixed
full-struct layout** (copy block always at DW8, after a full 7-DW wait slot). For an indirect batch
copy there is no dependent wait signal, so `do_wait = false`: the engine reads the copy block at DW1
(the zeroed wait region) → `SRC_ADDR = 0`, and because it is an indirect-src copy it dereferences
`*(0x0)` to fetch the real source pointer → SDMA page fault at `0x0`.

Fix: emit the indirect packet **compacted**, identical to the sibling `BuildWaitSignalCopyCommand` /
`BuildWaitSignalSwapCommand` — build into a scratch packet, then copy only the present DW blocks
(header, optional wait, copy, optional signal) contiguously, matching the caller's `per_pkt_dws`.
This places the copy block where the engine reads it, so `SRC_ADDR` is the real slot pointer and the
indirect dereference resolves correctly. The change is confined to `BuildWaitSignalIndirectCopyCommand`,
which is only called from the two `is_indirect` code paths; non-indirect copies are untouched.

Regressing change: `4a0c9b797a` ("rocr: gfx1250 SDMA fused WaitSignal path - chunking,
single-reservation") introduced the compacted variable-length WaitSignal emission for copy/swap but
left the indirect builder writing the full-struct layout. Confirmed by build-bisect: the feature
passes at its parent and faults at that commit.

## Issue Tracking

ROCM-28259

## Test Plan

- MI450 / gfx1250, hotswap trampolines enabled (`AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1`).
- Build ROCr with the fix; run the `hipMemcpyBatchAsync` hip-tests family:
  `ctest -R "hipMemcpyBatchAsync"`.
- Targeted: `Unit_hipMemcpyBatchAsync_IndirectSrc`, `Unit_hipMemcpyBatchAsync_IndirectDst`.
- Regression bisect: build ROCr at `4a0c9b797a^` vs `4a0c9b797a` (same test binary/CLR/SDK, swap only
  `libhsa-runtime64`) and compare.

## Test Result

- Before fix: `Unit_hipMemcpyBatchAsync_IndirectSrc` / `IndirectDst` → illegal memory access
  (Code 700); dmesg shows a no-retry page fault at `0x0`, client SDMA0.
- After fix: both pass (1024 assertions each); full `hipMemcpyBatchAsync` family 100% (14/14).
- Build-bisect: `4a0c9b797a^` passes, `4a0c9b797a` faults — confirms the regression point.
- Non-indirect copy paths unaffected (separate builders; change is isolated to the indirect path).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
