### PR TITLE
fix(rocjitsu): initialize gfx1250 clustered launch identity

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -2772,6 +2772,12 @@ class CodeGenerator:
             )
         if ib_sts2_id is not None:
             constexprs.append(f'constexpr uint32_t HW_REG_IB_STS2 = {ib_sts2_id};')
+            constexprs.extend(
+                [
+                    'constexpr uint32_t HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT = 21;',
+                    'constexpr uint32_t HW_REG_IB_STS2_WG_IN_CLUSTER_MASK = 0xFu;',
+                ]
+            )
 
         read_cases = []
         if mode_id is not None:
@@ -2807,7 +2813,10 @@ class CodeGenerator:
             )
         if ib_sts2_id is not None:
             read_cases.append(
-                '  case HW_REG_IB_STS2:\n' '    reg_val = 0;\n' '    return true;'
+                '  case HW_REG_IB_STS2:\n'
+                '    reg_val = (wf.cluster_rank() & HW_REG_IB_STS2_WG_IN_CLUSTER_MASK)\n'
+                '              << HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT;\n'
+                '    return true;'
             )
 
         write_cases = []

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -2057,6 +2057,8 @@ def test_gfx1250_helper_blocks_emit_hwreg_and_scaled_wmma_hooks():
     assert 'wf.set_wave_sched_mode_raw' in hwreg
     assert '[[maybe_unused]] bool read_hwreg' in hwreg
     assert '[[maybe_unused]] bool write_hwreg' in hwreg
+    assert 'HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT = 21' in hwreg
+    assert 'wf.cluster_rank() & HW_REG_IB_STS2_WG_IN_CLUSTER_MASK' in hwreg
 
     assert codegen._supports_gfx1250_scaled_wmma_vop3px2()
     assert 'VWmmaScaleF32Vop3px2' in (codegen._emit_gfx1250_scaled_wmma_vop3px2_class())

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/sopk.cpp
@@ -29,6 +29,8 @@ constexpr uint32_t HW_REG_GPR_ALLOC = 6;
 constexpr uint32_t HW_REG_VGPR_ALLOC = 7;
 constexpr uint32_t HW_REG_WAVE_SCHED_MODE = 26;
 constexpr uint32_t HW_REG_IB_STS2 = 28;
+constexpr uint32_t HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT = 21;
+constexpr uint32_t HW_REG_IB_STS2_WG_IN_CLUSTER_MASK = 0xFu;
 
 [[maybe_unused]] uint32_t insert_hwreg_field(uint32_t reg_val, uint32_t src, uint32_t offset,
                                              uint32_t mask) {
@@ -59,7 +61,8 @@ constexpr uint32_t HW_REG_IB_STS2 = 28;
     reg_val = wf.wave_sched_mode_raw();
     return true;
   case HW_REG_IB_STS2:
-    reg_val = 0;
+    reg_val = (wf.cluster_rank() & HW_REG_IB_STS2_WG_IN_CLUSTER_MASK)
+              << HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT;
     return true;
   default:
     return false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -44,6 +44,17 @@ namespace {
 constexpr uint32_t kMaxClusterWorkgroups = kClusterMulticastMaskBits;
 static_assert(kMaxClusterWorkgroups <= kClusterMulticastMaskBits);
 
+// GFX12 launch-state scalar selectors used by compiler-generated workgroup
+// and cluster identity sequences.
+constexpr uint32_t kGfx12Ttmp6 = 114;
+constexpr uint32_t kGfx12Ttmp7 = 115;
+constexpr uint32_t kGfx12Ttmp9 = 117;
+
+constexpr uint32_t kGfx12Ttmp6ClusterLocalXShift = 0;
+constexpr uint32_t kGfx12Ttmp6ClusterLocalYShift = 4;
+constexpr uint32_t kGfx12Ttmp6ClusterLocalZShift = 8;
+constexpr uint32_t kGfx12Ttmp6ClusterMaxFlatIdShift = 24;
+
 struct PlannedWorkgroup {
   uint32_t local_wg_id = 0;
   uint32_t global_wg_id = 0;
@@ -285,16 +296,30 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
   }
 
   if (cu->arch() == ROCJITSU_CODE_ARCH_GFX1250 || cu->arch() == ROCJITSU_CODE_ARCH_RDNA4) {
-    constexpr uint32_t ttmp7 = 115;
-    constexpr uint32_t ttmp9 = 117;
     // The simulator aliases TTMP scalar selectors into the wavefront SGPR
     // block, so the block must include slots through TTMP9.
-    if (cu->config().sgprs_per_wf <= ttmp9) {
+    if (cu->config().sgprs_per_wf <= kGfx12Ttmp9) {
       throw std::runtime_error("RDNA4/gfx1250 TTMP launch payload requires at least 118 SGPR "
                                "slots per wavefront");
     }
-    cu->write_sgpr(sbase + ttmp7, ((wg_id_z & 0xFFFFu) << 16) | (wg_id_y & 0xFFFFu));
-    cu->write_sgpr(sbase + ttmp9, grid_wg_id_x);
+
+    const uint32_t cluster_size_x = nonzero_or_one(pkt.cluster_size_x);
+    const uint32_t cluster_size_y = nonzero_or_one(pkt.cluster_size_y);
+    const uint32_t cluster_size_z = nonzero_or_one(pkt.cluster_size_z);
+    const uint32_t cluster_local_x = grid_wg_id_x % cluster_size_x;
+    const uint32_t cluster_local_y = wg_id_y % cluster_size_y;
+    const uint32_t cluster_local_z = wg_id_z % cluster_size_z;
+    const uint32_t cluster_max_flat_id = cluster_size_x * cluster_size_y * cluster_size_z - 1;
+
+    const uint32_t ttmp6 = (cluster_local_x << kGfx12Ttmp6ClusterLocalXShift) |
+                           (cluster_local_y << kGfx12Ttmp6ClusterLocalYShift) |
+                           (cluster_local_z << kGfx12Ttmp6ClusterLocalZShift) |
+                           (cluster_max_flat_id << kGfx12Ttmp6ClusterMaxFlatIdShift);
+    const uint32_t ttmp7 = ((wg_id_z / cluster_size_z) << 16) | (wg_id_y / cluster_size_y);
+    const uint32_t ttmp9 = grid_wg_id_x / cluster_size_x;
+    cu->write_sgpr(sbase + kGfx12Ttmp6, ttmp6);
+    cu->write_sgpr(sbase + kGfx12Ttmp7, ttmp7);
+    cu->write_sgpr(sbase + kGfx12Ttmp9, ttmp9);
   }
 
   // Workitem IDs per AMDHSA ABI. The SPI decomposes the flat thread index

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -3717,6 +3717,74 @@ TEST(Gfx1250SimulationTest, TtmpWorkgroupIdsUseGridCoordinatesFor2DDispatch) {
   EXPECT_EQ(target_cu->read_sgpr(sbase + 115), 1u);
 }
 
+TEST(Gfx1250SimulationTest, ClusterLaunchStateMatchesCompilerAbiForThreeDimensionalGrid) {
+  constexpr uint32_t S_GETREG_CLUSTER_RANK_S2 = 0xB8821D5Cu;
+  const uint32_t code[] = {S_GETREG_CLUSTER_RANK_S2, S_ENDPGM_GFX12};
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code), 128);
+
+  amdgpu::AmdExtKernelDispatchPacket pkt{};
+  pkt.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
+  pkt.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
+  pkt.setup = 3;
+  pkt.workgroup_size_x = 32;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.cluster_count_x = 2;
+  pkt.cluster_count_y = 2;
+  pkt.cluster_count_z = 2;
+  pkt.cluster_size_x = 2;
+  pkt.cluster_size_y = 2;
+  pkt.cluster_size_z = 2;
+  pkt.kernel_object = kernel_object;
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.submit(pkt);
+  step_until_xcd_halted(sim);
+
+  struct LaunchState {
+    uint32_t workgroup_id;
+    uint32_t ttmp6;
+    uint32_t ttmp7;
+    uint32_t ttmp9;
+    uint32_t cluster_rank;
+  };
+  std::vector<LaunchState> states;
+  for (uint32_t se_idx = 0; se_idx < sim.xcd()->num_shader_engines(); ++se_idx) {
+    auto *se = sim.xcd()->shader_engine(se_idx);
+    for (uint32_t cu_idx = 0; cu_idx < se->num_compute_units(); ++cu_idx) {
+      auto *cu = se->compute_unit(cu_idx);
+      for (uint32_t wf_idx = 0; wf_idx < cu->num_wf_slots(); ++wf_idx) {
+        auto *wf = cu->wf(wf_idx);
+        if (!wf || wf->sgpr_alloc().count == 0)
+          continue;
+        const uint32_t sbase = wf->sgpr_alloc().base;
+        states.push_back({wf->wg_id(), cu->read_sgpr(sbase + 114), cu->read_sgpr(sbase + 115),
+                          cu->read_sgpr(sbase + 117), cu->read_sgpr(sbase + 2)});
+      }
+    }
+  }
+  std::sort(states.begin(), states.end(), [](const LaunchState &lhs, const LaunchState &rhs) {
+    return lhs.workgroup_id < rhs.workgroup_id;
+  });
+
+  ASSERT_EQ(states.size(), 64u);
+  for (uint32_t workgroup_id = 0; workgroup_id < states.size(); ++workgroup_id) {
+    const uint32_t workgroup_x = workgroup_id % 4;
+    const uint32_t workgroup_y = (workgroup_id / 4) % 4;
+    const uint32_t workgroup_z = workgroup_id / 16;
+    const uint32_t local_x = workgroup_x % 2;
+    const uint32_t local_y = workgroup_y % 2;
+    const uint32_t local_z = workgroup_z % 2;
+    EXPECT_EQ(states[workgroup_id].workgroup_id, workgroup_id);
+    EXPECT_EQ(states[workgroup_id].ttmp6, 0x07000000u | local_x | (local_y << 4) | (local_z << 8));
+    EXPECT_EQ(states[workgroup_id].ttmp7, ((workgroup_z / 2) << 16) | (workgroup_y / 2));
+    EXPECT_EQ(states[workgroup_id].ttmp9, workgroup_x / 2);
+    EXPECT_EQ(states[workgroup_id].cluster_rank, local_x + 2 * (local_y + 2 * local_z));
+  }
+}
+
 TEST(Gfx1250SimulationTest, SGetPcI64ReturnsNextInstructionAddress) {
   constexpr uint64_t kKernelAddr = 0x10000;
   const uint32_t code[] = {


### PR DESCRIPTION
## Motivation

Compiler-generated gfx1250 clustered kernels reconstruct global workgroup
coordinates from cluster coordinates in TTMP7/TTMP9 and within-cluster
coordinates in TTMP6. They read the flat within-cluster rank from IB_STS2.
rocJITsu instead populated TTMP7/TTMP9 with ordinary workgroup coordinates,
left TTMP6 unset, and returned zero for IB_STS2. A 2x1x1 cluster consequently
reported `{rank=0, workgroup_x=2}` for its second workgroup instead of
`{rank=1, workgroup_x=1}`.

## Technical Details

- Pack the local x/y/z coordinates and maximum flat local ID into TTMP6, and
  place the cluster x/y/z coordinates in TTMP9/TTMP7.
- Return `Wavefront::cluster_rank()` through the gfx1250 IB_STS2 hardware
  register implementation and keep the generated ISA source in sync.
- Exercise the actual `s_getreg_b32` path over a 4x4x4 workgroup grid formed
  from 2x2x2 clusters, checking every TTMP field and all ranks 0 through 7.

## Issue Tracking

Fixes #8824.

## Test Plan

- Run the complete rocJITsu CTest suite.
- Run the public standalone ROCm SDK reproducer against the resulting shared
  library.

## Test Result

- All 1,558 registered rocJITsu tests passed; one race-hook test was
  intentionally skipped by its fixture.
- The standalone reproducer reports ranks 0/1 and workgroup X coordinates 0/1
  for the two workgroups in a 2x1x1 cluster.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
