### PR TITLE
[roctjisu] Fix cluster launch identity

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -2952,6 +2952,8 @@ class CodeGenerator:
             constexprs.append(f'constexpr uint32_t HW_REG_IB_STS2 = {ib_sts2_id};')
             constexprs.extend(
                 [
+                    'constexpr uint32_t HW_REG_IB_STS2_CLUSTER_ID_SHIFT = 6;',
+                    'constexpr uint32_t HW_REG_IB_STS2_CLUSTER_ID_MASK = 0xFu;',
                     'constexpr uint32_t HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT = 21;',
                     'constexpr uint32_t HW_REG_IB_STS2_WG_IN_CLUSTER_MASK = 0xFu;',
                 ]
@@ -2992,8 +2994,11 @@ class CodeGenerator:
         if ib_sts2_id is not None:
             read_cases.append(
                 '  case HW_REG_IB_STS2:\n'
-                '    reg_val = (wf.cluster_rank() & HW_REG_IB_STS2_WG_IN_CLUSTER_MASK)\n'
-                '              << HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT;\n'
+                '    reg_val =\n'
+                '        (((wf.cluster_size() > 1 ? 1u : 0u) & HW_REG_IB_STS2_CLUSTER_ID_MASK)\n'
+                '         << HW_REG_IB_STS2_CLUSTER_ID_SHIFT) |\n'
+                '        ((wf.cluster_rank() & HW_REG_IB_STS2_WG_IN_CLUSTER_MASK)\n'
+                '         << HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT);\n'
                 '    return true;'
             )
 

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -2950,6 +2950,12 @@ class CodeGenerator:
             )
         if ib_sts2_id is not None:
             constexprs.append(f'constexpr uint32_t HW_REG_IB_STS2 = {ib_sts2_id};')
+            constexprs.extend(
+                [
+                    'constexpr uint32_t HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT = 21;',
+                    'constexpr uint32_t HW_REG_IB_STS2_WG_IN_CLUSTER_MASK = 0xFu;',
+                ]
+            )
 
         read_cases = []
         if mode_id is not None:
@@ -2985,7 +2991,10 @@ class CodeGenerator:
             )
         if ib_sts2_id is not None:
             read_cases.append(
-                '  case HW_REG_IB_STS2:\n' '    reg_val = 0;\n' '    return true;'
+                '  case HW_REG_IB_STS2:\n'
+                '    reg_val = (wf.cluster_rank() & HW_REG_IB_STS2_WG_IN_CLUSTER_MASK)\n'
+                '              << HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT;\n'
+                '    return true;'
             )
 
         write_cases = []

--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -834,6 +834,16 @@ class _AmdgpuProfileBase(IsaProfile):
         return False
 
     @property
+    def uses_ttmp_workgroup_ids(self) -> bool:
+        """Whether dispatch workgroup IDs are carried in TTMP registers."""
+        return False
+
+    @property
+    def uses_cluster_ttmp_workgroup_ids(self) -> bool:
+        """Whether the TTMP workgroup-ID payload uses cluster coordinates."""
+        return False
+
+    @property
     def max_addressable_vgprs_per_wf(self) -> int:
         """Maximum VGPR index space addressable by one wavefront."""
         return 256
@@ -1484,6 +1494,10 @@ class Rdna4Profile(_AmdgpuProfileBase):
         return True
 
     @property
+    def uses_ttmp_workgroup_ids(self) -> bool:
+        return True
+
+    @property
     def waitcnt_family(self) -> str:
         return 'gfx12'
 
@@ -1630,6 +1644,10 @@ class Gfx1250Profile(Rdna4Profile):
     @property
     def supports_wgp_mode(self) -> bool:
         return False
+
+    @property
+    def uses_cluster_ttmp_workgroup_ids(self) -> bool:
+        return True
 
     @property
     def max_addressable_vgprs_per_wf(self) -> int:

--- a/emulation/rocjitsu/lib/python/amdisa/isa_properties_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_properties_codegen.py
@@ -34,13 +34,18 @@ def emit_isa_properties(output_dir: str, specs) -> Path:
             continue
         enum_name = name.upper()
         supports_wgp_mode = 'true' if profile.supports_wgp_mode else 'false'
+        uses_ttmp_workgroup_ids = 'true' if profile.uses_ttmp_workgroup_ids else 'false'
+        uses_cluster_ttmp_workgroup_ids = (
+            'true' if profile.uses_cluster_ttmp_workgroup_ids else 'false'
+        )
         addressable_vgprs = profile.max_addressable_vgprs_per_wf
         max_addressable_vgprs_per_wf = max(
             max_addressable_vgprs_per_wf, addressable_vgprs
         )
         cases += [
             f'  case ROCJITSU_CODE_ARCH_{enum_name}:',
-            f'    return {{{supports_wgp_mode}, {addressable_vgprs}}};',
+            f'    return {{{supports_wgp_mode}, {uses_ttmp_workgroup_ids}, '
+            f'{uses_cluster_ttmp_workgroup_ids}, {addressable_vgprs}}};',
         ]
 
     lines = [
@@ -61,6 +66,8 @@ def emit_isa_properties(output_dir: str, specs) -> Path:
         '',
         'struct IsaProperties {',
         '  bool supports_wgp_mode = false;',
+        '  bool uses_ttmp_workgroup_ids = false;',
+        '  bool uses_cluster_ttmp_workgroup_ids = false;',
         '  uint32_t max_addressable_vgprs_per_wf = 0;',
         '};',
         '',

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -2186,6 +2186,8 @@ def test_gfx1250_helper_blocks_emit_hwreg_and_scaled_wmma_hooks():
     assert 'wf.set_wave_sched_mode_raw' in hwreg
     assert '[[maybe_unused]] bool read_hwreg' in hwreg
     assert '[[maybe_unused]] bool write_hwreg' in hwreg
+    assert 'HW_REG_IB_STS2_CLUSTER_ID_SHIFT = 6' in hwreg
+    assert 'wf.cluster_size() > 1 ? 1u : 0u' in hwreg
     assert 'HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT = 21' in hwreg
     assert 'wf.cluster_rank() & HW_REG_IB_STS2_WG_IN_CLUSTER_MASK' in hwreg
 

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -2186,6 +2186,8 @@ def test_gfx1250_helper_blocks_emit_hwreg_and_scaled_wmma_hooks():
     assert 'wf.set_wave_sched_mode_raw' in hwreg
     assert '[[maybe_unused]] bool read_hwreg' in hwreg
     assert '[[maybe_unused]] bool write_hwreg' in hwreg
+    assert 'HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT = 21' in hwreg
+    assert 'wf.cluster_rank() & HW_REG_IB_STS2_WG_IN_CLUSTER_MASK' in hwreg
 
     assert codegen._supports_gfx1250_scaled_wmma_vop3px2()
     assert 'VWmmaScaleF32Vop3px2' in (codegen._emit_gfx1250_scaled_wmma_vop3px2_class())

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
@@ -38,6 +38,19 @@ def test_supports_wgp_mode(profile, expected):
 
 
 @pytest.mark.parametrize(
+    ('profile', 'uses_ttmp', 'uses_cluster_ttmp'),
+    [
+        (CdnaProfile(), False, False),
+        (Rdna4Profile(), True, False),
+        (Gfx1250Profile(), True, True),
+    ],
+)
+def test_ttmp_workgroup_id_properties(profile, uses_ttmp, uses_cluster_ttmp):
+    assert profile.uses_ttmp_workgroup_ids is uses_ttmp
+    assert profile.uses_cluster_ttmp_workgroup_ids is uses_cluster_ttmp
+
+
+@pytest.mark.parametrize(
     ('profile', 'expected'),
     [
         (CdnaProfile(), 256),
@@ -80,9 +93,15 @@ def test_isa_properties_codegen_uses_profile_values(tmp_path):
 
     assert 'uint32_t max_addressable_vgprs_per_wf = 0;' in output
     assert 'MAX_SUPPORTED_ADDRESSABLE_VGPRS_PER_WF = 1024;' in output
-    assert 'case ROCJITSU_CODE_ARCH_CDNA3:\n    return {false, 256};' in output
-    assert 'case ROCJITSU_CODE_ARCH_RDNA4:\n    return {true, 256};' in output
-    assert 'case ROCJITSU_CODE_ARCH_GFX1250:\n    return {false, 1024};' in output
+    assert (
+        'case ROCJITSU_CODE_ARCH_CDNA3:\n' '    return {false, false, false, 256};'
+    ) in output
+    assert (
+        'case ROCJITSU_CODE_ARCH_RDNA4:\n' '    return {true, true, false, 256};'
+    ) in output
+    assert (
+        'case ROCJITSU_CODE_ARCH_GFX1250:\n' '    return {false, true, true, 1024};'
+    ) in output
 
 
 @pytest.mark.parametrize(

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/sopk.cpp
@@ -29,6 +29,8 @@ constexpr uint32_t HW_REG_GPR_ALLOC = 6;
 constexpr uint32_t HW_REG_VGPR_ALLOC = 7;
 constexpr uint32_t HW_REG_WAVE_SCHED_MODE = 26;
 constexpr uint32_t HW_REG_IB_STS2 = 28;
+constexpr uint32_t HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT = 21;
+constexpr uint32_t HW_REG_IB_STS2_WG_IN_CLUSTER_MASK = 0xFu;
 
 [[maybe_unused]] uint32_t insert_hwreg_field(uint32_t reg_val, uint32_t src, uint32_t offset,
                                              uint32_t mask) {
@@ -59,7 +61,8 @@ constexpr uint32_t HW_REG_IB_STS2 = 28;
     reg_val = wf.wave_sched_mode_raw();
     return true;
   case HW_REG_IB_STS2:
-    reg_val = 0;
+    reg_val = (wf.cluster_rank() & HW_REG_IB_STS2_WG_IN_CLUSTER_MASK)
+              << HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT;
     return true;
   default:
     return false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/sopk.cpp
@@ -29,6 +29,8 @@ constexpr uint32_t HW_REG_GPR_ALLOC = 6;
 constexpr uint32_t HW_REG_VGPR_ALLOC = 7;
 constexpr uint32_t HW_REG_WAVE_SCHED_MODE = 26;
 constexpr uint32_t HW_REG_IB_STS2 = 28;
+constexpr uint32_t HW_REG_IB_STS2_CLUSTER_ID_SHIFT = 6;
+constexpr uint32_t HW_REG_IB_STS2_CLUSTER_ID_MASK = 0xFu;
 constexpr uint32_t HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT = 21;
 constexpr uint32_t HW_REG_IB_STS2_WG_IN_CLUSTER_MASK = 0xFu;
 
@@ -61,8 +63,10 @@ constexpr uint32_t HW_REG_IB_STS2_WG_IN_CLUSTER_MASK = 0xFu;
     reg_val = wf.wave_sched_mode_raw();
     return true;
   case HW_REG_IB_STS2:
-    reg_val = (wf.cluster_rank() & HW_REG_IB_STS2_WG_IN_CLUSTER_MASK)
-              << HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT;
+    reg_val = (((wf.cluster_size() > 1 ? 1u : 0u) & HW_REG_IB_STS2_CLUSTER_ID_MASK)
+               << HW_REG_IB_STS2_CLUSTER_ID_SHIFT) |
+              ((wf.cluster_rank() & HW_REG_IB_STS2_WG_IN_CLUSTER_MASK)
+               << HW_REG_IB_STS2_WG_IN_CLUSTER_SHIFT);
     return true;
   default:
     return false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/isa_properties.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/isa_properties.h
@@ -15,6 +15,8 @@ namespace rocjitsu {
 
 struct IsaProperties {
   bool supports_wgp_mode = false;
+  bool uses_ttmp_workgroup_ids = false;
+  bool uses_cluster_ttmp_workgroup_ids = false;
   uint32_t max_addressable_vgprs_per_wf = 0;
 };
 
@@ -23,25 +25,25 @@ inline constexpr uint32_t MAX_SUPPORTED_ADDRESSABLE_VGPRS_PER_WF = 1024;
 [[nodiscard]] constexpr IsaProperties isa_properties(rj_code_arch_t arch) {
   switch (arch) {
   case ROCJITSU_CODE_ARCH_CDNA1:
-    return {false, 256};
+    return {false, false, false, 256};
   case ROCJITSU_CODE_ARCH_CDNA2:
-    return {false, 256};
+    return {false, false, false, 256};
   case ROCJITSU_CODE_ARCH_CDNA3:
-    return {false, 256};
+    return {false, false, false, 256};
   case ROCJITSU_CODE_ARCH_CDNA4:
-    return {false, 256};
+    return {false, false, false, 256};
   case ROCJITSU_CODE_ARCH_RDNA1:
-    return {true, 256};
+    return {true, false, false, 256};
   case ROCJITSU_CODE_ARCH_RDNA2:
-    return {true, 256};
+    return {true, false, false, 256};
   case ROCJITSU_CODE_ARCH_RDNA3:
-    return {true, 256};
+    return {true, false, false, 256};
   case ROCJITSU_CODE_ARCH_RDNA3_5:
-    return {true, 256};
+    return {true, false, false, 256};
   case ROCJITSU_CODE_ARCH_RDNA4:
-    return {true, 256};
+    return {true, true, false, 256};
   case ROCJITSU_CODE_ARCH_GFX1250:
-    return {false, 1024};
+    return {false, true, true, 1024};
   default:
     return {};
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -42,6 +42,8 @@ namespace {
 // The supported cluster size must fit the M0 multicast mask captured at issue time.
 constexpr uint32_t kMaxClusterWorkgroups = kClusterMulticastMaskBits;
 static_assert(kMaxClusterWorkgroups <= kClusterMulticastMaskBits);
+static_assert(kMaxClusterWorkgroups <= 16,
+              "TTMP6 cluster max and max-flat-ID fields are 4 bits wide");
 
 // GFX12 launch-state scalar selectors used by compiler-generated workgroup
 // and cluster identity sequences.
@@ -49,10 +51,17 @@ constexpr uint32_t kGfx12Ttmp6 = 114;
 constexpr uint32_t kGfx12Ttmp7 = 115;
 constexpr uint32_t kGfx12Ttmp9 = 117;
 
+// LLVM's gfx1250 architected-SGPR ABI maps TTMP6 as seven 4-bit fields:
+// cluster-local XYZ, cluster-max XYZ, and max-flat-ID from low to high bits.
+// TTMP7 holds 16-bit cluster-grid Y/Z IDs, while TTMP9 holds cluster-grid X.
 constexpr uint32_t kGfx12Ttmp6ClusterLocalXShift = 0;
 constexpr uint32_t kGfx12Ttmp6ClusterLocalYShift = 4;
 constexpr uint32_t kGfx12Ttmp6ClusterLocalZShift = 8;
+constexpr uint32_t kGfx12Ttmp6ClusterMaxXShift = 12;
+constexpr uint32_t kGfx12Ttmp6ClusterMaxYShift = 16;
+constexpr uint32_t kGfx12Ttmp6ClusterMaxZShift = 20;
 constexpr uint32_t kGfx12Ttmp6ClusterMaxFlatIdShift = 24;
+constexpr uint32_t kGfx12Ttmp7ClusterGridDimensionMask = 0xFFFFu;
 
 struct PlannedWorkgroup {
   uint32_t local_wg_id = 0;
@@ -86,6 +95,7 @@ void validate_cluster_shape(const DispatchEntry &dp) {
     return;
   auto cluster_size =
       static_cast<uint64_t>(dp.cluster_size_x) * dp.cluster_size_y * dp.cluster_size_z;
+  // This also keeps every TTMP6 cluster dimension/max field within 4 bits.
   if (cluster_size == 0 || cluster_size > kMaxClusterWorkgroups) {
     throw std::runtime_error(
         std::format("unsupported workgroup cluster size {}x{}x{} ({} workgroups)",
@@ -96,6 +106,13 @@ void validate_cluster_shape(const DispatchEntry &dp) {
         "workgroup cluster shape {}x{}x{} count {}x{}x{} does not cover grid {}x{}x{} exactly",
         dp.cluster_size_x, dp.cluster_size_y, dp.cluster_size_z, dp.cluster_count_x,
         dp.cluster_count_y, dp.cluster_count_z, dp.grid_wgs_x, dp.grid_wgs_y, dp.grid_wgs_z));
+  }
+  const uint64_t rank_period = dp.cluster_rank_period();
+  if (dp.workgroup_id_offset % rank_period != 0) {
+    throw std::runtime_error(std::format(
+        "clustered workgroup ID offset {} does not preserve cluster-local ranks; expected a "
+        "multiple of {}",
+        dp.workgroup_id_offset, rank_period));
   }
 }
 
@@ -293,28 +310,45 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
       cu->write_sgpr(sbase + sys_idx++, wg_id_z);
   }
 
-  if (cu->arch() == ROCJITSU_CODE_ARCH_GFX1250 || cu->arch() == ROCJITSU_CODE_ARCH_RDNA4) {
+  const auto properties = isa_properties(cu->arch());
+  if (properties.uses_ttmp_workgroup_ids) {
     // The simulator aliases TTMP scalar selectors into the wavefront SGPR
     // block, so the block must include slots through TTMP9.
     if (cu->config().sgprs_per_wf <= kGfx12Ttmp9) {
-      throw std::runtime_error("RDNA4/gfx1250 TTMP launch payload requires at least 118 SGPR "
+      throw std::runtime_error("TTMP workgroup-ID launch payload requires at least 118 SGPR "
                                "slots per wavefront");
     }
 
-    const uint32_t cluster_size_x = nonzero_or_one(pkt.cluster_size_x);
-    const uint32_t cluster_size_y = nonzero_or_one(pkt.cluster_size_y);
-    const uint32_t cluster_size_z = nonzero_or_one(pkt.cluster_size_z);
-    const uint32_t cluster_local_x = grid_wg_id_x % cluster_size_x;
-    const uint32_t cluster_local_y = wg_id_y % cluster_size_y;
-    const uint32_t cluster_local_z = wg_id_z % cluster_size_z;
-    const uint32_t cluster_max_flat_id = cluster_size_x * cluster_size_y * cluster_size_z - 1;
+    // The ordinary TTMP ABI uses grid coordinates. Targets advertising the
+    // clustered extension reinterpret these fields below.
+    uint32_t ttmp6 = 0;
+    uint32_t ttmp7 = ((wg_id_z & kGfx12Ttmp7ClusterGridDimensionMask) << 16) |
+                     (wg_id_y & kGfx12Ttmp7ClusterGridDimensionMask);
+    uint32_t ttmp9 = grid_wg_id_x;
+    if (properties.uses_cluster_ttmp_workgroup_ids) {
+      const uint32_t cluster_size_x = nonzero_or_one(pkt.cluster_size_x);
+      const uint32_t cluster_size_y = nonzero_or_one(pkt.cluster_size_y);
+      const uint32_t cluster_size_z = nonzero_or_one(pkt.cluster_size_z);
+      const WorkgroupCoord cluster_local = pkt.cluster_local_wg_coord_for_flat_wg_id(global_wg_id);
+      const uint32_t cluster_max_x = cluster_size_x - 1;
+      const uint32_t cluster_max_y = cluster_size_y - 1;
+      const uint32_t cluster_max_z = cluster_size_z - 1;
+      const uint32_t cluster_max_flat_id = cluster_size_x * cluster_size_y * cluster_size_z - 1;
 
-    const uint32_t ttmp6 = (cluster_local_x << kGfx12Ttmp6ClusterLocalXShift) |
-                           (cluster_local_y << kGfx12Ttmp6ClusterLocalYShift) |
-                           (cluster_local_z << kGfx12Ttmp6ClusterLocalZShift) |
-                           (cluster_max_flat_id << kGfx12Ttmp6ClusterMaxFlatIdShift);
-    const uint32_t ttmp7 = ((wg_id_z / cluster_size_z) << 16) | (wg_id_y / cluster_size_y);
-    const uint32_t ttmp9 = grid_wg_id_x / cluster_size_x;
+      ttmp6 = (cluster_local.x << kGfx12Ttmp6ClusterLocalXShift) |
+              (cluster_local.y << kGfx12Ttmp6ClusterLocalYShift) |
+              (cluster_local.z << kGfx12Ttmp6ClusterLocalZShift) |
+              (cluster_max_x << kGfx12Ttmp6ClusterMaxXShift) |
+              (cluster_max_y << kGfx12Ttmp6ClusterMaxYShift) |
+              (cluster_max_z << kGfx12Ttmp6ClusterMaxZShift) |
+              (cluster_max_flat_id << kGfx12Ttmp6ClusterMaxFlatIdShift);
+      const uint32_t cluster_grid_y =
+          (wg_id_y / cluster_size_y) & kGfx12Ttmp7ClusterGridDimensionMask;
+      const uint32_t cluster_grid_z =
+          (wg_id_z / cluster_size_z) & kGfx12Ttmp7ClusterGridDimensionMask;
+      ttmp7 = (cluster_grid_z << 16) | cluster_grid_y;
+      ttmp9 = grid_wg_id_x / cluster_size_x;
+    }
     cu->write_sgpr(sbase + kGfx12Ttmp6, ttmp6);
     cu->write_sgpr(sbase + kGfx12Ttmp7, ttmp7);
     cu->write_sgpr(sbase + kGfx12Ttmp9, ttmp9);
@@ -687,7 +721,7 @@ void CommandProcessor::register_cluster_workgroup(const DispatchEntry &entry, ui
   placement.cu = cu;
   placement.lds_base = lds_base;
   placement.cluster_key = cluster_key;
-  placement.cluster_rank = entry.cluster_rank_for_local_wg(local_wg_id);
+  placement.cluster_rank = entry.cluster_rank_for_flat_wg_id(global_wg_id);
   placement.cluster_size = entry.cluster_size();
   placement.peer_wg_ids.reserve(placement.cluster_size);
   for (uint32_t rank = 0; rank < placement.cluster_size; ++rank) {
@@ -867,7 +901,7 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
       wf->set_dispatch_id(entry.dispatch_id);
       wf->set_process_id(entry.process_id);
       wf->set_exec(initial_exec_mask_for_wave(entry, global_wg_id, w, cu->wf_size()));
-      wf->set_cluster_info(entry.cluster_rank_for_local_wg(local_wg_id), entry.cluster_size());
+      wf->set_cluster_info(entry.cluster_rank_for_flat_wg_id(global_wg_id), entry.cluster_size());
       try {
         init_wavefront_regs(cu, wf, entry, global_wg_id, w);
       } catch (...) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -43,6 +43,17 @@ namespace {
 constexpr uint32_t kMaxClusterWorkgroups = kClusterMulticastMaskBits;
 static_assert(kMaxClusterWorkgroups <= kClusterMulticastMaskBits);
 
+// GFX12 launch-state scalar selectors used by compiler-generated workgroup
+// and cluster identity sequences.
+constexpr uint32_t kGfx12Ttmp6 = 114;
+constexpr uint32_t kGfx12Ttmp7 = 115;
+constexpr uint32_t kGfx12Ttmp9 = 117;
+
+constexpr uint32_t kGfx12Ttmp6ClusterLocalXShift = 0;
+constexpr uint32_t kGfx12Ttmp6ClusterLocalYShift = 4;
+constexpr uint32_t kGfx12Ttmp6ClusterLocalZShift = 8;
+constexpr uint32_t kGfx12Ttmp6ClusterMaxFlatIdShift = 24;
+
 struct PlannedWorkgroup {
   uint32_t local_wg_id = 0;
   uint32_t global_wg_id = 0;
@@ -283,16 +294,30 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
   }
 
   if (cu->arch() == ROCJITSU_CODE_ARCH_GFX1250 || cu->arch() == ROCJITSU_CODE_ARCH_RDNA4) {
-    constexpr uint32_t ttmp7 = 115;
-    constexpr uint32_t ttmp9 = 117;
     // The simulator aliases TTMP scalar selectors into the wavefront SGPR
     // block, so the block must include slots through TTMP9.
-    if (cu->config().sgprs_per_wf <= ttmp9) {
+    if (cu->config().sgprs_per_wf <= kGfx12Ttmp9) {
       throw std::runtime_error("RDNA4/gfx1250 TTMP launch payload requires at least 118 SGPR "
                                "slots per wavefront");
     }
-    cu->write_sgpr(sbase + ttmp7, ((wg_id_z & 0xFFFFu) << 16) | (wg_id_y & 0xFFFFu));
-    cu->write_sgpr(sbase + ttmp9, grid_wg_id_x);
+
+    const uint32_t cluster_size_x = nonzero_or_one(pkt.cluster_size_x);
+    const uint32_t cluster_size_y = nonzero_or_one(pkt.cluster_size_y);
+    const uint32_t cluster_size_z = nonzero_or_one(pkt.cluster_size_z);
+    const uint32_t cluster_local_x = grid_wg_id_x % cluster_size_x;
+    const uint32_t cluster_local_y = wg_id_y % cluster_size_y;
+    const uint32_t cluster_local_z = wg_id_z % cluster_size_z;
+    const uint32_t cluster_max_flat_id = cluster_size_x * cluster_size_y * cluster_size_z - 1;
+
+    const uint32_t ttmp6 = (cluster_local_x << kGfx12Ttmp6ClusterLocalXShift) |
+                           (cluster_local_y << kGfx12Ttmp6ClusterLocalYShift) |
+                           (cluster_local_z << kGfx12Ttmp6ClusterLocalZShift) |
+                           (cluster_max_flat_id << kGfx12Ttmp6ClusterMaxFlatIdShift);
+    const uint32_t ttmp7 = ((wg_id_z / cluster_size_z) << 16) | (wg_id_y / cluster_size_y);
+    const uint32_t ttmp9 = grid_wg_id_x / cluster_size_x;
+    cu->write_sgpr(sbase + kGfx12Ttmp6, ttmp6);
+    cu->write_sgpr(sbase + kGfx12Ttmp7, ttmp7);
+    cu->write_sgpr(sbase + kGfx12Ttmp9, ttmp9);
   }
 
   // Workitem IDs per AMDHSA ABI. The SPI decomposes the flat thread index

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -126,15 +126,31 @@ struct DispatchEntry {
     return coord.x + gx * (coord.y + gy * coord.z);
   }
 
-  uint32_t cluster_rank_for_local_wg(uint32_t local_wg_id) const {
-    WorkgroupCoord coord = local_wg_coord(local_wg_id);
+  WorkgroupCoord cluster_local_wg_coord_for_flat_wg_id(uint32_t flat_wg_id) const {
+    WorkgroupCoord coord = local_wg_coord(flat_wg_id);
     uint32_t sx = cluster_size_x == 0 ? 1 : cluster_size_x;
     uint32_t sy = cluster_size_y == 0 ? 1 : cluster_size_y;
     uint32_t sz = cluster_size_z == 0 ? 1 : cluster_size_z;
-    uint32_t local_x = coord.x % sx;
-    uint32_t local_y = coord.y % sy;
-    uint32_t local_z = coord.z % sz;
-    return local_x + sx * (local_y + sy * local_z);
+    return {coord.x % sx, coord.y % sy, coord.z % sz};
+  }
+
+  uint32_t cluster_rank_for_flat_wg_id(uint32_t flat_wg_id) const {
+    WorkgroupCoord local = cluster_local_wg_coord_for_flat_wg_id(flat_wg_id);
+    uint32_t sx = cluster_size_x == 0 ? 1 : cluster_size_x;
+    uint32_t sy = cluster_size_y == 0 ? 1 : cluster_size_y;
+    return local.x + sx * (local.y + sy * local.z);
+  }
+
+  uint64_t cluster_rank_period() const {
+    assert(cluster_grid_is_complete() && "cluster rank period requires a complete cluster grid");
+    // A complete grid makes the highest active axis period a multiple of all
+    // lower-axis periods, so one alignment check preserves the full rank.
+    uint64_t period = cluster_size_x;
+    if (cluster_size_y > 1 || cluster_size_z > 1)
+      period = static_cast<uint64_t>(grid_wgs_x) * cluster_size_y;
+    if (cluster_size_z > 1)
+      period = static_cast<uint64_t>(grid_wgs_x) * grid_wgs_y * cluster_size_z;
+    return period;
   }
 
   uint32_t cluster_base_local_wg_id(uint32_t local_wg_id) const {

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -1009,6 +1009,50 @@ TEST(ClusterDispatchTest, ReclaimsLdsBetweenClusterWaves) {
   EXPECT_FALSE(f.cu(1)->has_active_wfs());
 }
 
+TEST(ClusterDispatchTest, Rdna4ExtendedDispatchKeepsOrdinaryTtmpWorkgroupIds) {
+  VmFixture f("rdna4", 1, 8, /*lds_size_kb=*/64, /*sgprs_per_wf=*/128);
+  auto *snap = f.capture_halts();
+
+  const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
+  uint64_t ko = f.write_kernel(0x1000, code, sizeof(code), /*sgprs=*/128);
+
+  amdgpu::AmdExtKernelDispatchPacket ext{};
+  ext.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
+  ext.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
+  ext.setup = 3;
+  ext.workgroup_size_x = 32;
+  ext.workgroup_size_y = 1;
+  ext.workgroup_size_z = 1;
+  ext.cluster_count_x = 1;
+  ext.cluster_count_y = 1;
+  ext.cluster_count_z = 1;
+  ext.cluster_size_x = 2;
+  ext.cluster_size_y = 2;
+  ext.cluster_size_z = 2;
+  ext.kernel_object = ko;
+
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.submit(ext);
+  step_until_halted(*f.engine, {f.cu()});
+
+  ASSERT_EQ(snap->snapshots().size(), 8u);
+  std::array<bool, 8> seen{};
+  for (const auto &wf : snap->snapshots()) {
+    const uint32_t workgroup_id = wf.wg_id;
+    ASSERT_LT(workgroup_id, seen.size());
+    seen[workgroup_id] = true;
+
+    const uint32_t workgroup_x = workgroup_id % 2;
+    const uint32_t workgroup_y = (workgroup_id / 2) % 2;
+    const uint32_t workgroup_z = workgroup_id / 4;
+    EXPECT_EQ(wf.sgpr(114), 0u);
+    EXPECT_EQ(wf.sgpr(115), (workgroup_z << 16) | workgroup_y);
+    EXPECT_EQ(wf.sgpr(117), workgroup_x);
+  }
+  for (bool was_seen : seen)
+    EXPECT_TRUE(was_seen);
+}
+
 TEST(ClusterDispatchTest, RejectsExtKernelDispatchWithZeroClusterShape) {
   VmFixture f("cdna3", 1, 8);
 

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -3676,6 +3676,74 @@ TEST(Gfx1250SimulationTest, TtmpWorkgroupIdsUseGridCoordinatesFor2DDispatch) {
   EXPECT_EQ(target->sgpr(115), 1u);
 }
 
+TEST(Gfx1250SimulationTest, ClusterLaunchStateMatchesCompilerAbiForThreeDimensionalGrid) {
+  constexpr uint32_t S_GETREG_CLUSTER_RANK_S2 = 0xB8821D5Cu;
+  const uint32_t code[] = {S_GETREG_CLUSTER_RANK_S2, S_ENDPGM_GFX12};
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code), 128);
+
+  amdgpu::AmdExtKernelDispatchPacket pkt{};
+  pkt.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
+  pkt.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
+  pkt.setup = 3;
+  pkt.workgroup_size_x = 32;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.cluster_count_x = 2;
+  pkt.cluster_count_y = 2;
+  pkt.cluster_count_z = 2;
+  pkt.cluster_size_x = 2;
+  pkt.cluster_size_y = 2;
+  pkt.cluster_size_z = 2;
+  pkt.kernel_object = kernel_object;
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.submit(pkt);
+  step_until_xcd_halted(sim);
+
+  struct LaunchState {
+    uint32_t workgroup_id;
+    uint32_t ttmp6;
+    uint32_t ttmp7;
+    uint32_t ttmp9;
+    uint32_t cluster_rank;
+  };
+  std::vector<LaunchState> states;
+  for (uint32_t se_idx = 0; se_idx < sim.xcd()->num_shader_engines(); ++se_idx) {
+    auto *se = sim.xcd()->shader_engine(se_idx);
+    for (uint32_t cu_idx = 0; cu_idx < se->num_compute_units(); ++cu_idx) {
+      auto *cu = se->compute_unit(cu_idx);
+      for (uint32_t wf_idx = 0; wf_idx < cu->num_wf_slots(); ++wf_idx) {
+        auto *wf = cu->wf(wf_idx);
+        if (!wf || wf->sgpr_alloc().count == 0)
+          continue;
+        const uint32_t sbase = wf->sgpr_alloc().base;
+        states.push_back({wf->wg_id(), cu->read_sgpr(sbase + 114), cu->read_sgpr(sbase + 115),
+                          cu->read_sgpr(sbase + 117), cu->read_sgpr(sbase + 2)});
+      }
+    }
+  }
+  std::sort(states.begin(), states.end(), [](const LaunchState &lhs, const LaunchState &rhs) {
+    return lhs.workgroup_id < rhs.workgroup_id;
+  });
+
+  ASSERT_EQ(states.size(), 64u);
+  for (uint32_t workgroup_id = 0; workgroup_id < states.size(); ++workgroup_id) {
+    const uint32_t workgroup_x = workgroup_id % 4;
+    const uint32_t workgroup_y = (workgroup_id / 4) % 4;
+    const uint32_t workgroup_z = workgroup_id / 16;
+    const uint32_t local_x = workgroup_x % 2;
+    const uint32_t local_y = workgroup_y % 2;
+    const uint32_t local_z = workgroup_z % 2;
+    EXPECT_EQ(states[workgroup_id].workgroup_id, workgroup_id);
+    EXPECT_EQ(states[workgroup_id].ttmp6, 0x07000000u | local_x | (local_y << 4) | (local_z << 8));
+    EXPECT_EQ(states[workgroup_id].ttmp7, ((workgroup_z / 2) << 16) | (workgroup_y / 2));
+    EXPECT_EQ(states[workgroup_id].ttmp9, workgroup_x / 2);
+    EXPECT_EQ(states[workgroup_id].cluster_rank, local_x + 2 * (local_y + 2 * local_z));
+  }
+}
+
 TEST(Gfx1250SimulationTest, SGetPcI64ReturnsNextInstructionAddress) {
   constexpr uint64_t kKernelAddr = 0x10000;
   const uint32_t code[] = {

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -1591,6 +1591,18 @@ TEST(Gfx1250ExecutionTest, GlobalStoreAsyncFromLdsKeepsIoffsetOnGlobalDestinatio
 }
 
 TEST(Gfx1250ExecutionTest, DispatchEntryClusterMathCoversMultiDimensionalShapes) {
+  auto expect_rank_period = [](const amdgpu::DispatchEntry &candidate, uint64_t expected_period) {
+    ASSERT_TRUE(candidate.cluster_grid_is_complete());
+    EXPECT_EQ(candidate.cluster_rank_period(), expected_period);
+    const uint32_t workgroup_count =
+        candidate.grid_wgs_x * candidate.grid_wgs_y * candidate.grid_wgs_z;
+    for (uint32_t flat_wg_id = 0; flat_wg_id < workgroup_count; ++flat_wg_id) {
+      EXPECT_EQ(candidate.cluster_rank_for_flat_wg_id(flat_wg_id),
+                candidate.cluster_rank_for_flat_wg_id(
+                    flat_wg_id + static_cast<uint32_t>(candidate.cluster_rank_period())));
+    }
+  };
+
   amdgpu::DispatchEntry entry{};
   entry.grid_wgs_x = 4;
   entry.grid_wgs_y = 4;
@@ -1604,9 +1616,10 @@ TEST(Gfx1250ExecutionTest, DispatchEntryClusterMathCoversMultiDimensionalShapes)
 
   EXPECT_TRUE(entry.cluster_grid_is_complete());
   EXPECT_EQ(entry.cluster_size(), 8u);
-  EXPECT_EQ(entry.cluster_rank_for_local_wg(0), 0u);
-  EXPECT_EQ(entry.cluster_rank_for_local_wg(5), 3u);
-  EXPECT_EQ(entry.cluster_rank_for_local_wg(21), 7u);
+  expect_rank_period(entry, 32u);
+  EXPECT_EQ(entry.cluster_rank_for_flat_wg_id(0), 0u);
+  EXPECT_EQ(entry.cluster_rank_for_flat_wg_id(5), 3u);
+  EXPECT_EQ(entry.cluster_rank_for_flat_wg_id(21), 7u);
   EXPECT_EQ(entry.cluster_peer_local_wg_id(0, 0), 0u);
   EXPECT_EQ(entry.cluster_peer_local_wg_id(0, 1), 1u);
   EXPECT_EQ(entry.cluster_peer_local_wg_id(0, 2), 4u);
@@ -1619,6 +1632,30 @@ TEST(Gfx1250ExecutionTest, DispatchEntryClusterMathCoversMultiDimensionalShapes)
   EXPECT_EQ(entry.cluster_base_local_wg_id_for_ordinal(1), 2u);
   EXPECT_EQ(entry.cluster_base_local_wg_id_for_ordinal(2), 8u);
   EXPECT_EQ(entry.cluster_base_local_wg_id_for_ordinal(4), 32u);
+
+  amdgpu::DispatchEntry one_dimensional{};
+  one_dimensional.grid_wgs_x = 8;
+  one_dimensional.grid_wgs_y = 1;
+  one_dimensional.grid_wgs_z = 1;
+  one_dimensional.cluster_count_x = 2;
+  one_dimensional.cluster_count_y = 1;
+  one_dimensional.cluster_count_z = 1;
+  one_dimensional.cluster_size_x = 4;
+  one_dimensional.cluster_size_y = 1;
+  one_dimensional.cluster_size_z = 1;
+  expect_rank_period(one_dimensional, 4u);
+
+  amdgpu::DispatchEntry two_dimensional{};
+  two_dimensional.grid_wgs_x = 8;
+  two_dimensional.grid_wgs_y = 6;
+  two_dimensional.grid_wgs_z = 1;
+  two_dimensional.cluster_count_x = 2;
+  two_dimensional.cluster_count_y = 2;
+  two_dimensional.cluster_count_z = 1;
+  two_dimensional.cluster_size_x = 4;
+  two_dimensional.cluster_size_y = 3;
+  two_dimensional.cluster_size_z = 1;
+  expect_rank_period(two_dimensional, 24u);
 
   entry.grid_wgs_x = 3;
   entry.grid_wgs_y = 2;
@@ -2239,6 +2276,20 @@ TEST(Gfx1250SimulationTest, RejectsUnsupportedClusterSize) {
   test::AqlQueue queue(sim.memory, sim.cp());
   queue.dispatch_clustered(kernel_object, /*cluster_count_x=*/1,
                            /*cluster_size_x=*/amdgpu::kClusterMulticastMaskBits + 1,
+                           /*workgroup_size_x=*/32);
+
+  EXPECT_THROW((void)sim.engine->step(), std::runtime_error);
+}
+
+TEST(Gfx1250SimulationTest, RejectsMisalignedClusteredWorkgroupIdOffset) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code), 128);
+  sim.cp()->set_workgroup_id_offset(1);
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch_clustered(kernel_object, /*cluster_count_x=*/1, /*cluster_size_x=*/2,
                            /*workgroup_size_x=*/32);
 
   EXPECT_THROW((void)sim.engine->step(), std::runtime_error);
@@ -3676,12 +3727,109 @@ TEST(Gfx1250SimulationTest, TtmpWorkgroupIdsUseGridCoordinatesFor2DDispatch) {
   EXPECT_EQ(target->sgpr(115), 1u);
 }
 
-TEST(Gfx1250SimulationTest, ClusterLaunchStateMatchesCompilerAbiForThreeDimensionalGrid) {
-  constexpr uint32_t S_GETREG_CLUSTER_RANK_S2 = 0xB8821D5Cu;
-  const uint32_t code[] = {S_GETREG_CLUSTER_RANK_S2, S_ENDPGM_GFX12};
+TEST(Gfx1250SimulationTest, Ttmp7ClusterGridYDoesNotBleedIntoZAt16BitBoundary) {
+  const uint32_t code[] = {S_ENDPGM_GFX12};
 
   Gfx1250Sim sim;
   uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code), 128);
+  constexpr uint32_t kWorkgroupIdOffset = 0x10000;
+  sim.cp()->set_workgroup_id_offset(kWorkgroupIdOffset);
+
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 2;
+  pkt.workgroup_size_x = 32;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = 32;
+  pkt.grid_size_y = 0x10001;
+  pkt.grid_size_z = 1;
+  pkt.kernel_object = kernel_object;
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.submit(pkt);
+  ASSERT_TRUE(sim.engine->step());
+
+  amdgpu::Wavefront *target = nullptr;
+  amdgpu::ComputeUnitCore *target_cu = nullptr;
+  for (uint32_t se_idx = 0; se_idx < sim.xcd()->num_shader_engines(); ++se_idx) {
+    auto *se = sim.xcd()->shader_engine(se_idx);
+    for (uint32_t cu_idx = 0; cu_idx < se->num_compute_units(); ++cu_idx) {
+      auto *cu = se->compute_unit(cu_idx);
+      for (uint32_t wf_idx = 0; wf_idx < cu->num_wf_slots(); ++wf_idx) {
+        auto *wf = cu->wf(wf_idx);
+        if (wf && wf->sgpr_alloc().count > 0 && wf->wg_id() == kWorkgroupIdOffset) {
+          target = wf;
+          target_cu = cu;
+          break;
+        }
+      }
+      if (target)
+        break;
+    }
+    if (target)
+      break;
+  }
+
+  ASSERT_NE(target, nullptr);
+  ASSERT_NE(target_cu, nullptr);
+  EXPECT_EQ(target_cu->read_sgpr(target->sgpr_alloc().base + 115), 0u);
+}
+
+TEST(Gfx1250SimulationTest, IbSts2ClusterFieldsAreZeroForOrdinaryDispatch) {
+  const uint32_t code[] = {
+      0xB882199Cu, // s_getreg_b32 s2, hwreg(IB_STS2, 6, 4)
+      0xB8831D5Cu, // s_getreg_b32 s3, hwreg(IB_STS2, 21, 4)
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code), 128);
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch(kernel_object, /*grid_size_x=*/32, /*workgroup_size_x=*/32);
+  step_until_halted(*sim.engine, *sim.cu());
+
+  auto *wf = sim.cu()->wf(0);
+  ASSERT_NE(wf, nullptr);
+  const uint32_t sbase = wf->sgpr_alloc().base;
+  EXPECT_EQ(sim.cu()->read_sgpr(sbase + 2), 0u);
+  EXPECT_EQ(sim.cu()->read_sgpr(sbase + 3), 0u);
+}
+
+TEST(Gfx1250SimulationTest, DynamicClusterLaunchStateMatchesCompilerAbiWithAlignedOffset) {
+  // Scalar workgroup-ID reconstruction emitted by clang 23 when cluster
+  // dimensions are not fixed by an amdgpu-cluster-dims attribute.
+  const uint32_t code[] = {
+      0x9302FF72u,    0x0004000Cu, // s_bfe_u32 s2, ttmp6, 0x4000c
+      0x9305FF72u,    0x00040010u, // s_bfe_u32 s5, ttmp6, 0x40010
+      0x9309FF72u,    0x00040014u, // s_bfe_u32 s9, ttmp6, 0x40014
+      0x81038102u,                 // s_add_co_i32 s3, s2, 1
+      0x8B06FF73u,    0x0000FFFFu, // s_and_b32 s6, ttmp7, 0xffff
+      0x81078105u,                 // s_add_co_i32 s7, s5, 1
+      0x850A9073u,                 // s_lshr_b32 s10, ttmp7, 16
+      0x810B8109u,                 // s_add_co_i32 s11, s9, 1
+      0x8B048F72u,                 // s_and_b32 s4, ttmp6, 15
+      0x96030375u,                 // s_mul_i32 s3, ttmp9, s3
+      0x96070706u,                 // s_mul_i32 s7, s6, s7
+      0x9308FF72u,    0x00040004u, // s_bfe_u32 s8, ttmp6, 0x40004
+      0x960B0B0Au,                 // s_mul_i32 s11, s10, s11
+      0x930CFF72u,    0x00040008u, // s_bfe_u32 s12, ttmp6, 0x40008
+      0xB88D199Cu,                 // s_getreg_b32 s13, hwreg(IB_STS2, 6, 4)
+      0x81030304u,                 // s_add_co_i32 s3, s4, s3
+      0x81070708u,                 // s_add_co_i32 s7, s8, s7
+      0x810B0B0Cu,                 // s_add_co_i32 s11, s12, s11
+      0xBF06800Du,                 // s_cmp_eq_u32 s13, 0
+      0x980A0B0Au,                 // s_cselect_b32 s10, s10, s11
+      0x98030375u,                 // s_cselect_b32 s3, ttmp9, s3
+      0x98060706u,                 // s_cselect_b32 s6, s6, s7
+      0xB8821D5Cu,                 // s_getreg_b32 s2, hwreg(IB_STS2, 21, 4)
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code), 128);
+  constexpr uint32_t kWorkgroupIdOffset = 16;
+  sim.cp()->set_workgroup_id_offset(kWorkgroupIdOffset);
 
   amdgpu::AmdExtKernelDispatchPacket pkt{};
   pkt.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
@@ -3693,9 +3841,9 @@ TEST(Gfx1250SimulationTest, ClusterLaunchStateMatchesCompilerAbiForThreeDimensio
   pkt.cluster_count_x = 2;
   pkt.cluster_count_y = 2;
   pkt.cluster_count_z = 2;
-  pkt.cluster_size_x = 2;
+  pkt.cluster_size_x = 4;
   pkt.cluster_size_y = 2;
-  pkt.cluster_size_z = 2;
+  pkt.cluster_size_z = 1;
   pkt.kernel_object = kernel_object;
 
   test::AqlQueue queue(sim.memory, sim.cp());
@@ -3708,39 +3856,38 @@ TEST(Gfx1250SimulationTest, ClusterLaunchStateMatchesCompilerAbiForThreeDimensio
     uint32_t ttmp7;
     uint32_t ttmp9;
     uint32_t cluster_rank;
+    uint32_t global_x;
+    uint32_t global_y;
+    uint32_t global_z;
+    uint32_t cluster_id;
   };
   std::vector<LaunchState> states;
-  for (uint32_t se_idx = 0; se_idx < sim.xcd()->num_shader_engines(); ++se_idx) {
-    auto *se = sim.xcd()->shader_engine(se_idx);
-    for (uint32_t cu_idx = 0; cu_idx < se->num_compute_units(); ++cu_idx) {
-      auto *cu = se->compute_unit(cu_idx);
-      for (uint32_t wf_idx = 0; wf_idx < cu->num_wf_slots(); ++wf_idx) {
-        auto *wf = cu->wf(wf_idx);
-        if (!wf || wf->sgpr_alloc().count == 0)
-          continue;
-        const uint32_t sbase = wf->sgpr_alloc().base;
-        states.push_back({wf->wg_id(), cu->read_sgpr(sbase + 114), cu->read_sgpr(sbase + 115),
-                          cu->read_sgpr(sbase + 117), cu->read_sgpr(sbase + 2)});
-      }
-    }
-  }
+  for (const auto &wf : sim.snapshot->snapshots())
+    states.push_back({wf.wg_id, wf.sgpr(114), wf.sgpr(115), wf.sgpr(117), wf.sgpr(2), wf.sgpr(3),
+                      wf.sgpr(6), wf.sgpr(10), wf.sgpr(13)});
   std::sort(states.begin(), states.end(), [](const LaunchState &lhs, const LaunchState &rhs) {
     return lhs.workgroup_id < rhs.workgroup_id;
   });
 
   ASSERT_EQ(states.size(), 64u);
-  for (uint32_t workgroup_id = 0; workgroup_id < states.size(); ++workgroup_id) {
-    const uint32_t workgroup_x = workgroup_id % 4;
-    const uint32_t workgroup_y = (workgroup_id / 4) % 4;
-    const uint32_t workgroup_z = workgroup_id / 16;
-    const uint32_t local_x = workgroup_x % 2;
+  for (uint32_t local_workgroup_id = 0; local_workgroup_id < states.size(); ++local_workgroup_id) {
+    const uint32_t workgroup_id = local_workgroup_id + kWorkgroupIdOffset;
+    const uint32_t workgroup_x = workgroup_id % 8;
+    const uint32_t workgroup_y = (workgroup_id / 8) % 4;
+    const uint32_t workgroup_z = workgroup_id / 32;
+    const uint32_t local_x = workgroup_x % 4;
     const uint32_t local_y = workgroup_y % 2;
-    const uint32_t local_z = workgroup_z % 2;
-    EXPECT_EQ(states[workgroup_id].workgroup_id, workgroup_id);
-    EXPECT_EQ(states[workgroup_id].ttmp6, 0x07000000u | local_x | (local_y << 4) | (local_z << 8));
-    EXPECT_EQ(states[workgroup_id].ttmp7, ((workgroup_z / 2) << 16) | (workgroup_y / 2));
-    EXPECT_EQ(states[workgroup_id].ttmp9, workgroup_x / 2);
-    EXPECT_EQ(states[workgroup_id].cluster_rank, local_x + 2 * (local_y + 2 * local_z));
+    const uint32_t local_z = workgroup_z % 1;
+    const auto &state = states[local_workgroup_id];
+    EXPECT_EQ(state.workgroup_id, workgroup_id);
+    EXPECT_EQ(state.ttmp6, 0x07013000u | local_x | (local_y << 4) | (local_z << 8));
+    EXPECT_EQ(state.ttmp7, (workgroup_z << 16) | (workgroup_y / 2));
+    EXPECT_EQ(state.ttmp9, workgroup_x / 4);
+    EXPECT_EQ(state.cluster_rank, local_x + 4 * local_y);
+    EXPECT_EQ(state.global_x, workgroup_x);
+    EXPECT_EQ(state.global_y, workgroup_y);
+    EXPECT_EQ(state.global_z, workgroup_z);
+    EXPECT_EQ(state.cluster_id, 1u);
   }
 }
 

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -112,6 +112,11 @@ static_assert(!HasMonolithicWaitcnt<rdna4::Isa>);
 static_assert(!isa_properties(ROCJITSU_CODE_ARCH_CDNA3).supports_wgp_mode);
 static_assert(isa_properties(ROCJITSU_CODE_ARCH_RDNA4).supports_wgp_mode);
 static_assert(!isa_properties(ROCJITSU_CODE_ARCH_GFX1250).supports_wgp_mode);
+static_assert(!isa_properties(ROCJITSU_CODE_ARCH_CDNA3).uses_ttmp_workgroup_ids);
+static_assert(isa_properties(ROCJITSU_CODE_ARCH_RDNA4).uses_ttmp_workgroup_ids);
+static_assert(!isa_properties(ROCJITSU_CODE_ARCH_RDNA4).uses_cluster_ttmp_workgroup_ids);
+static_assert(isa_properties(ROCJITSU_CODE_ARCH_GFX1250).uses_ttmp_workgroup_ids);
+static_assert(isa_properties(ROCJITSU_CODE_ARCH_GFX1250).uses_cluster_ttmp_workgroup_ids);
 
 // RDNA3/3.5 retain monolithic S_WAITCNT (GFX11 layout).
 static_assert(HasMonolithicWaitcnt<rdna3::Isa>);


### PR DESCRIPTION
## Motivation

Compiler-generated gfx1250 clustered kernels reconstruct global workgroup
coordinates from cluster coordinates in TTMP7/TTMP9 and within-cluster
coordinates in TTMP6. They read the flat within-cluster rank from IB_STS2.
rocJITsu instead populated TTMP7/TTMP9 with ordinary workgroup coordinates,
left TTMP6 unset, and returned zero for IB_STS2. A 2x1x1 cluster consequently
reported `{rank=0, workgroup_x=2}` for its second workgroup instead of
`{rank=1, workgroup_x=1}`.

This is a fixup to https://github.com/ROCm/rocm-systems/pull/8826 by Ben with the review comments resolved.

## Technical Details

- Pack the local x/y/z coordinates and maximum flat local ID into TTMP6, and
  place the cluster x/y/z coordinates in TTMP9/TTMP7.
- Return `Wavefront::cluster_rank()` through the gfx1250 IB_STS2 hardware
  register implementation and keep the generated ISA source in sync.
- Exercise the actual `s_getreg_b32` path over a 4x4x4 workgroup grid formed
  from 2x2x2 clusters, checking every TTMP field and all ranks 0 through 7.

## Issue Tracking

Fixes #8824.

## Test Plan

- Run the complete rocJITsu CTest suite.
- Run the public standalone ROCm SDK reproducer against the resulting shared
  library.

## Test Result

- All 1,558 registered rocJITsu tests passed; one race-hook test was
  intentionally skipped by its fixture.
- The standalone reproducer reports ranks 0/1 and workgroup X coordinates 0/1
  for the two workgroups in a 2x1x1 cluster.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

