### PR TITLE
fix(clr): split the preprocessor check

### DIFF
--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -268,10 +268,12 @@ hipError_t DynCO::populateDynGlobalFuncs() {
     // if symbols are init/fini, we trim them out
     // These are ASAN specific symbols and we do not bubble them up to the user
     // This means something like count of kernels in code object remains the same.
-#if defined(__clang__) && __has_feature(address_sanitizer)
+#if defined(__clang__)
+#if __has_feature(address_sanitizer)
     if (elem == "amdgcn.device.init" || elem == "amdgcn.device.fini") {
       continue;
     }
+#endif
 #endif
     functions_.insert(std::make_pair(elem, new Function(elem)));
   }


### PR DESCRIPTION
## Motivation

Fix the build issues seen with gcc

## Technical Details

g++ has no understanding of `__has_feature`. This causes error when users build clr with gcc compiler. Split the check which fixes the build

## Issue Tracking

NA

## Test Plan

Build should pass with gcc

## Test Result

Build passes locally with gcc

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
