### PR TITLE
test(net): add per-rank Net device-count mismatch MPI test

### DIFF
--- a/projects/rccl/docs/api-reference/env-variables.rst
+++ b/projects/rccl/docs/api-reference/env-variables.rst
@@ -193,6 +193,24 @@ in the following table.
         | ``AF_INET6``: Force IPv6
         | Unset: Use first available
 
+    * - | ``NCCL_IGNORE_NET_MISMATCH``
+        | Controls what happens when ranks report a different number of local
+          network (NET) devices during communicator initialization. RCCL gathers
+          each rank's local NET device count and compares the minimum and maximum
+          across the communicator. A mismatch usually means the job was launched
+          with an inconsistent NIC selection (for example, an uneven
+          ``NCCL_SOCKET_IFNAME``/``NCCL_IB_HCA`` per rank, or nodes with different
+          NIC counts), which otherwise surfaces later as obscure transport
+          failures. See :ref:`heterogeneous-nic-counts`.
+      - | ``1``: Detect and continue, logging the mismatch at ``INFO`` level (default).
+        | ``0``: Fail initialization with ``ncclSystemError`` and a warning on the mismatch.
+
+    * - | ``NCCL_IGNORE_COLLNET_MISMATCH``
+        | Same as ``NCCL_IGNORE_NET_MISMATCH`` but for the number of local CollNet
+          devices reported by each rank.
+      - | ``0``: Fail initialization with ``ncclSystemError`` and a warning on the mismatch (default).
+        | ``1``: Detect and continue, logging the mismatch at ``INFO`` level.
+
     * - | ``NCCL_NET_MERGE_LEVEL``
         | Controls network device merging behavior.
       - | Integer value specifying merge level

--- a/projects/rccl/docs/how-to/troubleshooting-rccl.rst
+++ b/projects/rccl/docs/how-to/troubleshooting-rccl.rst
@@ -249,3 +249,40 @@ RCCL and NCCL comparisons
 If you are also using NVIDIA hardware or NCCL and notice a performance gap between the two systems,
 collect the system and performance data on the NVIDIA platform. 
 Provide both sets of data to the support team.
+
+.. _heterogeneous-nic-counts:
+
+Ranks with different NIC counts
+===============================
+
+On multi-NIC systems, a job can end up with an inconsistent number of network
+(NET) devices per rank, for example when ranks are launched with different
+``NCCL_SOCKET_IFNAME`` or ``NCCL_IB_HCA`` values, or when nodes in the job have a
+different number of NICs. Historically this only became visible much later during
+transport setup as an obscure connection or timeout failure.
+
+During communicator initialization RCCL now gathers each rank's local NET device
+count and compares them. When they differ, rank 0 logs the offending ranks and
+the min/max counts, for example:
+
+.. code:: shell
+
+   NCCL INFO Local Net device counts across ranks: min 1 max 2
+   NCCL INFO Rank 1 has 1 local Net devices (max 2).
+
+The reaction is controlled by ``NCCL_IGNORE_NET_MISMATCH`` (and the CollNet
+equivalent ``NCCL_IGNORE_COLLNET_MISMATCH``):
+
+*  ``NCCL_IGNORE_NET_MISMATCH=1`` (the default) continues, logging the mismatch at ``INFO`` level::
+
+      NCCL INFO Detected mixed local Net device counts across ranks (min 1, max 2). Ignoring due to NCCL_IGNORE_NET_MISMATCH.
+
+*  ``NCCL_IGNORE_NET_MISMATCH=0`` fails initialization with ``ncclSystemError``
+   so the misconfiguration is caught immediately::
+
+      NCCL WARN Detected mixed local Net device counts across ranks (min 1, max 2). Set NCCL_IGNORE_NET_MISMATCH=1 to continue.
+
+If you hit this warning, verify that every rank selects the same set of NICs
+(consistent ``NCCL_SOCKET_IFNAME`` / ``NCCL_IB_HCA``) and that all nodes expose
+the same NIC count. Set ``NCCL_IGNORE_NET_MISMATCH=0`` in CI or bring-up to turn a
+heterogeneous-NIC misconfiguration into an immediate, explicit failure.

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -430,6 +430,7 @@ if(BUILD_TESTS)
       GinNcclTimeoutMPITests.cpp
       SymmetricKernelMPITests.cpp
       SymmetricWindowMPITests.cpp
+      CommNetMismatchMPITests.cpp
     )
 
     add_executable(rccl-UnitTestsMPI ${MPI_TEST_SOURCE_FILES})

--- a/projects/rccl/test/CommNetMismatchMPITests.cpp
+++ b/projects/rccl/test/CommNetMismatchMPITests.cpp
@@ -1,0 +1,286 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+/**
+ * @file CommNetMismatchMPITests.cpp
+ * @brief MPI test for per-rank Net device-count mismatch handling (AICOMRCCL-1213).
+ *
+ * Feature under test: during communicator init, RCCL AllGathers each rank's
+ * @c localNetDeviceCount (the number of NET devices reported by the active net
+ * plugin, i.e. @c ncclNet->devices()) inside the @c allGatherInfo struct. Rank 0
+ * compares the min/max across ranks and, on a mismatch, either continues with a
+ * warning or fails init with @c ncclSystemError depending on
+ * @c NCCL_IGNORE_NET_MISMATCH (default 1 = ignore). Multi-NIC nodes with an
+ * unequal NIC count per rank previously failed later with obscure transport
+ * errors; this guard turns that into an explicit signal (see src/init.cc).
+ *
+ * The test synthesizes a mismatch on a SINGLE node without special hardware by
+ * forcing the built-in socket net (NCCL_IB_DISABLE=1, NCCL_NET=Socket) and
+ * giving each rank a different NCCL_SOCKET_IFNAME list so the socket net's
+ * devices() returns a different count per rank:
+ *   - rank 0   -> two interfaces (localNetDeviceCount = 2)
+ *   - rank !=0 -> one interface  (localNetDeviceCount = 1)
+ *
+ * The expected behavior is selected by NCCL_IGNORE_NET_MISMATCH in the
+ * environment:
+ *   - NCCL_IGNORE_NET_MISMATCH=1 (or unset): init SUCCEEDS on every rank.
+ *   - NCCL_IGNORE_NET_MISMATCH=0            : init FAILS on rank 0 with
+ *                                             ncclSystemError.
+ *
+ * IMPORTANT: NCCL_PARAM values (NCCL_IGNORE_NET_MISMATCH) and the socket net's
+ * interface list are cached per process, so the two modes must each run in their
+ * OWN process. The test_runner configs launch this filter twice (once per mode,
+ * each a separate mpirun), which satisfies that; see
+ * tools/scripts/test_runner/configs/*.json (net_device_count_mismatch).
+ *
+ * Init is done non-blocking (ncclConfig_t.blocking = 0) with a bounded wait so
+ * that a rank which never receives the abort signal (the mismatch check runs only
+ * on rank 0, mirroring upstream NCCL) times out and aborts locally instead of
+ * hanging the job.
+ */
+
+#ifdef MPI_TESTS_ENABLED
+
+#include "MPIEnvironment.hpp"
+#include "TestChecks.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <string>
+#include <vector>
+
+#include <dirent.h>
+#include <unistd.h>
+
+namespace
+{
+
+// Bounded wait (seconds) for a non-blocking init to resolve before we treat the
+// rank as stuck and abort it locally. Comfortably above bootstrap latency but
+// short enough that a rank-0-only abort does not stall the job.
+constexpr double kInitTimeoutSec = 25.0;
+
+double nowSec()
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return static_cast<double>(ts.tv_sec) + static_cast<double>(ts.tv_nsec) * 1e-9;
+}
+
+bool startsWithAny(const std::string& name, const std::vector<std::string>& prefixes)
+{
+    for(const auto& p : prefixes)
+    {
+        if(name.rfind(p, 0) == 0)
+            return true;
+    }
+    return false;
+}
+
+// Discover usable network interfaces for the socket net: skip loopback and the
+// usual virtual/bridge devices, and require operstate "up". Allows an override
+// via RCCL_MISMATCH_IFACES ("eth0 eth1").
+std::vector<std::string> discoverInterfaces()
+{
+    if(const char* override_ifaces = getenv("RCCL_MISMATCH_IFACES"))
+    {
+        std::vector<std::string> out;
+        std::string              s(override_ifaces);
+        size_t                   pos = 0;
+        while(pos < s.size())
+        {
+            size_t sp = s.find_first_of(" ,", pos);
+            if(sp == std::string::npos)
+                sp = s.size();
+            if(sp > pos)
+                out.emplace_back(s.substr(pos, sp - pos));
+            pos = sp + 1;
+        }
+        return out;
+    }
+
+    static const std::vector<std::string> kSkipPrefixes
+        = {"lo", "docker", "veth", "virbr", "br-", "br0", "cni", "flannel", "tun", "tap"};
+
+    std::vector<std::string> names;
+    if(DIR* dir = opendir("/sys/class/net"))
+    {
+        while(struct dirent* ent = readdir(dir))
+        {
+            std::string name = ent->d_name;
+            if(name == "." || name == "..")
+                continue;
+            if(startsWithAny(name, kSkipPrefixes))
+                continue;
+            names.push_back(name);
+        }
+        closedir(dir);
+    }
+
+    // Deterministic ordering so all ranks agree on which iface is shared.
+    std::sort(names.begin(), names.end());
+
+    std::vector<std::string> out;
+    for(const auto& name : names)
+    {
+        std::string path  = "/sys/class/net/" + name + "/operstate";
+        bool        is_up = false;
+        if(FILE* f = fopen(path.c_str(), "r"))
+        {
+            char state[32] = {0};
+            if(fgets(state, sizeof(state), f))
+                is_up = (strncmp(state, "up", 2) == 0);
+            fclose(f);
+        }
+        if(is_up)
+            out.push_back(name);
+    }
+    return out;
+}
+
+const char* stateStr(ncclResult_t r)
+{
+    switch(r)
+    {
+    case ncclSuccess: return "ncclSuccess";
+    case ncclInProgress: return "ncclInProgress(timeout)";
+    case ncclSystemError: return "ncclSystemError";
+    default: return ncclGetErrorString(r);
+    }
+}
+
+} // namespace
+
+// Forces a per-rank Net device-count mismatch over the socket net and verifies
+// the NCCL_IGNORE_NET_MISMATCH behavior. Rank 0 (which runs the mismatch check)
+// gates the result; peer ranks are informational because the abort is rank-0
+// only (matches upstream NCCL). Run once per mode (separate process each).
+TEST(CommNetMismatchMPITest, NetDeviceCountMismatch)
+{
+    const int world_rank = MPIEnvironment::world_rank;
+    const int world_size = MPIEnvironment::world_size;
+
+    if(world_size < 2)
+        GTEST_SKIP() << "Net device-count mismatch test requires at least 2 ranks";
+
+    // Force the built-in socket net so NCCL_SOCKET_IFNAME controls the per-rank
+    // Net device count. Set before any RCCL entry point.
+    setenv("NCCL_IB_DISABLE", "1", 1);
+    setenv("NCCL_NET", "Socket", 1);
+
+    const std::vector<std::string> ifaces = discoverInterfaces();
+    if(ifaces.size() < 2)
+        GTEST_SKIP() << "need >= 2 usable network interfaces to synthesize a mismatch";
+
+    // rank 0 sees two interfaces (count 2); every other rank sees one (count 1),
+    // sharing ifaces[0] so bootstrap can still connect. This creates the mismatch.
+    const std::string ifname
+        = (world_rank == 0) ? (ifaces[0] + "," + ifaces[1]) : ifaces[0];
+    setenv("NCCL_SOCKET_IFNAME", ifname.c_str(), 1);
+
+    const char* ignore_env = getenv("NCCL_IGNORE_NET_MISMATCH");
+    // Mirror the RCCL default (IGNORE_NET_MISMATCH defaults to 1 = ignore).
+    const bool expect_ignore = (ignore_env == nullptr) || (atoi(ignore_env) != 0);
+
+    ncclUniqueId id;
+    if(world_rank == 0)
+        ASSERT_EQ(ncclGetUniqueId(&id), ncclSuccess);
+    ASSERT_EQ(MPI_Bcast(&id, sizeof(id), MPI_BYTE, 0, MPI_COMM_WORLD), MPI_SUCCESS);
+
+    // Non-blocking init so a rank that never receives the abort signal can time
+    // out locally instead of hanging.
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    config.blocking     = 0;
+
+    ncclComm_t   comm  = nullptr;
+    ncclResult_t res   = ncclCommInitRankConfig(&comm, world_size, id, world_rank, &config);
+    ncclResult_t state = res;
+
+    if((res == ncclSuccess || res == ncclInProgress) && comm != nullptr)
+    {
+        const double start = nowSec();
+        while(true)
+        {
+            ncclResult_t async = ncclInProgress;
+            ncclCommGetAsyncError(comm, &async);
+            if(async != ncclInProgress)
+            {
+                state = async;
+                break;
+            }
+            if(nowSec() - start > kInitTimeoutSec)
+            {
+                state = ncclInProgress; // treat as timeout
+                break;
+            }
+            usleep(20 * 1000);
+        }
+    }
+
+    // Clean up: a fully-initialized comm is destroyed; anything else is aborted.
+    if(comm != nullptr)
+    {
+        if(state == ncclSuccess)
+        {
+            // Prove the tolerated comm is actually usable with a tiny AllReduce.
+            int*        buf    = nullptr;
+            hipStream_t stream = nullptr;
+            if(hipMalloc(&buf, sizeof(int)) == hipSuccess
+               && hipStreamCreate(&stream) == hipSuccess)
+            {
+                int one = 1;
+                (void)hipMemcpy(buf, &one, sizeof(int), hipMemcpyHostToDevice);
+                ncclResult_t ar = ncclAllReduce(buf, buf, 1, ncclInt, ncclSum, comm, stream);
+                if(ar == ncclSuccess || ar == ncclInProgress)
+                    (void)hipStreamSynchronize(stream);
+                else
+                    state = ar;
+            }
+            if(stream)
+                (void)hipStreamDestroy(stream);
+            if(buf)
+                (void)hipFree(buf);
+            ncclCommDestroy(comm);
+        }
+        else
+        {
+            ncclCommAbort(comm);
+        }
+    }
+
+    // Re-synchronize before returning. In abort mode rank 0 fails fast while
+    // peer ranks wait out the bounded init timeout (the abort is rank-0 only),
+    // so without this the ranks reach the harness teardown badly out of sync and
+    // its barrier times out. This barrier makes them leave the test together.
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Only rank 0 runs the mismatch check, so it gates the verdict. Peer ranks
+    // are informational (the abort is not broadcast in upstream NCCL either).
+    if(world_rank == 0)
+    {
+        TEST_INFO("NetDeviceCountMismatch mode=%s ifname=%s state=%s",
+                  expect_ignore ? "ignore" : "abort",
+                  ifname.c_str(),
+                  stateStr(state));
+        if(expect_ignore)
+            EXPECT_EQ(state, ncclSuccess)
+                << "with NCCL_IGNORE_NET_MISMATCH=1 the mismatch must be tolerated";
+        else
+            EXPECT_EQ(state, ncclSystemError)
+                << "with NCCL_IGNORE_NET_MISMATCH=0 rank 0 init must fail on the mismatch";
+    }
+    else
+    {
+        TEST_INFO("NetDeviceCountMismatch (peer) rank=%d ifname=%s state=%s",
+                  world_rank,
+                  ifname.c_str(),
+                  stateStr(state));
+    }
+}
+
+#endif // MPI_TESTS_ENABLED

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -40,6 +40,34 @@
         "NCCL_DEBUG": "INFO"
       }
     },
+    "net_device_count_mismatch": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "description": "AICOMRCCL-1213: per-rank Net device-count mismatch handling (localNetDeviceCount AllGather + NCCL_IGNORE_NET_MISMATCH abort). The test forces the socket net and a different NCCL_SOCKET_IFNAME per rank so ncclNet->devices() differs across ranks; rank 0 gates the verdict. Each mode runs in its own process (NCCL_PARAM is cached per process).",
+      "tests": [
+        {
+          "name": "NetDeviceCountMismatch_Ignore",
+          "description": "NCCL_IGNORE_NET_MISMATCH=1 (default): mismatch detected and tolerated, init succeeds on all ranks",
+          "test_filter": "CommNetMismatchMPITest.NetDeviceCountMismatch",
+          "env_variables": {
+            "NCCL_IGNORE_NET_MISMATCH": "1"
+          }
+        },
+        {
+          "name": "NetDeviceCountMismatch_Abort",
+          "description": "NCCL_IGNORE_NET_MISMATCH=0: mismatch detected, rank 0 fails init with ncclSystemError",
+          "test_filter": "CommNetMismatchMPITest.NetDeviceCountMismatch",
+          "env_variables": {
+            "NCCL_IGNORE_NET_MISMATCH": "0"
+          }
+        }
+      ]
+    },
     "shm_comprehensive": {
       "extends": "default",
       "is_gtest": true,
@@ -3167,6 +3195,12 @@
     }
   },
   "test_suites": [
+    {
+      "name": "NET - Device Count Mismatch (AICOMRCCL-1213)",
+      "description": "Per-rank Net device-count mismatch detection and NCCL_IGNORE_NET_MISMATCH abort (single node, 2 ranks)",
+      "config": "net_device_count_mismatch",
+      "enabled": true
+    },
     {
       "name": "SHM Tests - Complete Suite",
       "description": "All shared memory transport tests (single node)",


### PR DESCRIPTION
## Motivation

During communicator initialization RCCL AllGathers each rank's
**`localNetDeviceCount`** (the number of NET devices the active net plugin
reports via `ncclNet->devices()`) and, on rank 0, compares the min/max across
the communicator. When ranks disagree — e.g. multi-NIC nodes with an uneven NIC
count per rank, or an inconsistent `NCCL_SOCKET_IFNAME` / `NCCL_IB_HCA` — the
job otherwise fails much later with obscure transport errors. The guard turns
that into an explicit signal controlled by `NCCL_IGNORE_NET_MISMATCH`
(default `1` = ignore, log at `INFO`; `0` = fail init with `ncclSystemError`).

The mismatch-detection logic already lives on `develop`
(`projects/rccl/src/init.cc`), but there was no test guarding the behavior and
the environment variables were undocumented. This PR adds the regression test,
wires it into CI, and documents the variables.

## Technical Details

- New test `projects/rccl/test/CommNetMismatchMPITests.cpp`:
  - Adds an MPI GoogleTest `CommNetMismatchMPITest.NetDeviceCountMismatch`
    inside `rccl-UnitTestsMPI` that synthesizes a per-rank Net device-count
    mismatch on a **single node with no special hardware**: it forces the
    built-in socket net (`NCCL_IB_DISABLE=1`, `NCCL_NET=Socket`) and gives each
    rank a different `NCCL_SOCKET_IFNAME` so `ncclNet->devices()` returns a
    different count per rank (rank 0 → 2 interfaces, peers → 1).
  - Init is **non-blocking** (`ncclConfig_t.blocking = 0`) with a bounded wait
    so a rank that never receives the rank-0-only abort times out locally
    instead of hanging; an `MPI_Barrier` re-synchronizes the ranks before the
    verdict. Rank 0 gates the result:
    - `NCCL_IGNORE_NET_MISMATCH=1`: init succeeds on all ranks.
    - `NCCL_IGNORE_NET_MISMATCH=0`: rank 0 init fails with `ncclSystemError`.
- `projects/rccl/test/CMakeLists.txt`:
  - Registers `CommNetMismatchMPITests.cpp` in `MPI_TEST_SOURCE_FILES` (part of
    the existing `rccl-UnitTestsMPI` target).
- `projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json`:
  - Adds a `net_device_count_mismatch` gtest group (`rccl-UnitTestsMPI`, 2
    ranks / 2 GPUs) that runs the same filter twice — once per mode — because
    `NCCL_PARAM` and the socket net interface list are cached per process, so
    each mode must run in its own process.
- Docs:
  - `docs/api-reference/env-variables.rst`: documents
    `NCCL_IGNORE_NET_MISMATCH` and `NCCL_IGNORE_COLLNET_MISMATCH` (defaults and
    behavior aligned with the implementation).
  - `docs/how-to/troubleshooting-rccl.rst`: adds a heterogeneous-NIC-count
    troubleshooting section with example log lines.

## JIRA ID

JIRA ID : AICOMRCCL-1213

## Test Plan

Built RCCL + the MPI unit tests and ran the new test on 2 ranks / 2 GPUs of an
AMD MI300X node under OpenMPI, once per mode (separate process each):

```
mpirun -np 2 -x NCCL_IGNORE_NET_MISMATCH=1 ./rccl-UnitTestsMPI \
    --gtest_filter=CommNetMismatchMPITest.NetDeviceCountMismatch
mpirun -np 2 -x NCCL_IGNORE_NET_MISMATCH=0 ./rccl-UnitTestsMPI \
    --gtest_filter=CommNetMismatchMPITest.NetDeviceCountMismatch
```

The test is also registered in the `mi300x_mellanox_ib` test-runner config so it
executes in CI.

## Test Result

```
Test Suite: NET - Device Count Mismatch (AICOMRCCL-1213)
  NetDeviceCountMismatch_Ignore   PASSED    6.97 s
  NetDeviceCountMismatch_Abort    PASSED   65.94 s
Total: 2 | Passed: 2 | Failed: 0 | Skipped: 0 | Timeout: 0
RUNNER_EXIT=0
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.