### PR TITLE
fix(rocprofiler-sdk): validate Perfetto buffer size limits

### DIFF
--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -42,6 +42,16 @@ CONST_VERSION_INFO = {
     "rocm_version": "@rocm_version_FULL_VERSION@",
 }
 
+# Perfetto's TraceConfig BufferConfig.size_kb field is a uint32_t, and the
+# tracing service allocates size_kb * 1024 bytes and rejects the config when
+# that byte count does not fit in a uint32_t. So although the option is named
+# in "KB", the value is treated as KiB (multiplied by 1024). The usable range
+# is 1 KiB up to floor((2^32 - 1) / 1024) = 4,194,303 KiB. These bounds mirror
+# the C++ limits (defaults::perfetto_buffer_size_{min,max}_kb in
+# source/lib/output/output_config.hpp) so both validation paths agree.
+PERFETTO_BUFFER_SIZE_KB_MIN = 1
+PERFETTO_BUFFER_SIZE_KB_MAX = ((1 << 32) - 1) // 1024
+
 
 class dotdict(dict):
     """dot.notation access to dictionary attributes"""
@@ -122,6 +132,24 @@ def strtobool(val):
     else:
         val_type = type(val).__name__
         raise ValueError(f"invalid truth value {val} (type={val_type})")
+
+
+def perfetto_buffer_size_kb(val):
+    if isinstance(val, bool) or not isinstance(val, (int, str)):
+        raise argparse.ArgumentTypeError(f"invalid integer value: {val}")
+
+    try:
+        value = int(val)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(f"invalid integer value: {val}")
+
+    if not PERFETTO_BUFFER_SIZE_KB_MIN <= value <= PERFETTO_BUFFER_SIZE_KB_MAX:
+        raise argparse.ArgumentTypeError(
+            f"must be between {PERFETTO_BUFFER_SIZE_KB_MIN} and "
+            f"{PERFETTO_BUFFER_SIZE_KB_MAX} KB"
+        )
+
+    return value
 
 
 def get_mpi_rank_and_size(custom_rank_env=None, custom_size_env=None):
@@ -908,9 +936,9 @@ For attachment profiling of running processes:
     )
     perfetto_options.add_argument(
         "--perfetto-buffer-size",
-        help="Size of buffer for perfetto output in KB. default: 1 GB",
+        help=f"Size of buffer for perfetto output in KB ({PERFETTO_BUFFER_SIZE_KB_MIN}-{PERFETTO_BUFFER_SIZE_KB_MAX}). default: 1 GB",
         default=None,
-        type=int,
+        type=perfetto_buffer_size_kb,
         metavar="KB",
     )
     perfetto_options.add_argument(
@@ -1323,6 +1351,12 @@ def has_set_attr(obj, key):
 
 def patch_args(data):
     """Used to handle certain fields which might be specified as a string instead of an array or vice-versa"""
+
+    if hasattr(data, "perfetto_buffer_size") and data.perfetto_buffer_size is not None:
+        try:
+            data.perfetto_buffer_size = perfetto_buffer_size_kb(data.perfetto_buffer_size)
+        except argparse.ArgumentTypeError as err:
+            fatal_error(f"Invalid perfetto_buffer_size: {err}")
 
     if hasattr(data, "kernel_iteration_range") and isinstance(
         data.kernel_iteration_range, str

--- a/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
@@ -102,7 +102,7 @@ write_perfetto(
     auto buffer_size_kb  = ocfg.perfetto_buffer_size;
 
     auto* buffer_config = cfg.add_buffers();
-    buffer_config->set_size_kb(buffer_size_kb);
+    buffer_config->set_size_kb(static_cast<uint32_t>(buffer_size_kb));
 
     if(ocfg.perfetto_buffer_fill_policy == "discard" || ocfg.perfetto_buffer_fill_policy.empty())
         buffer_config->set_fill_policy(

--- a/projects/rocprofiler-sdk/source/lib/output/output_config.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/output_config.cpp
@@ -22,16 +22,29 @@
 
 #include "output_config.hpp"
 
+#include <cstdint>
+#include <limits>
+
 namespace rocprofiler
 {
 namespace tool
 {
 namespace defaults
 {
+// Perfetto's TraceConfig BufferConfig.size_kb is a uint32_t; the tracing service
+// allocates size_kb * 1024 bytes and rejects the config when that byte count
+// exceeds uint32_t. The value is therefore effectively KiB, bounded by 1 up to
+// floor((2^32 - 1) / 1024). Mirrors PERFETTO_BUFFER_SIZE_KB_{MIN,MAX} in
+// source/bin/rocprofv3.py. Kept here rather than the header because only this
+// translation unit validates the value.
+constexpr auto perfetto_buffer_size_min_kb = size_t{1};
+constexpr auto perfetto_buffer_size_max_kb =
+    static_cast<size_t>(std::numeric_limits<uint32_t>::max()) / common::units::KiB;
+
 void
 validate_perfetto_buffer_size(size_t value)
 {
-    LOG_IF(FATAL, !is_valid_perfetto_buffer_size(value))
+    LOG_IF(FATAL, value < perfetto_buffer_size_min_kb || value > perfetto_buffer_size_max_kb)
         << "Invalid Perfetto buffer size: " << value << " KB. Expected a value from "
         << perfetto_buffer_size_min_kb << " to " << perfetto_buffer_size_max_kb << " KB";
 }

--- a/projects/rocprofiler-sdk/source/lib/output/output_config.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/output_config.cpp
@@ -26,6 +26,17 @@ namespace rocprofiler
 {
 namespace tool
 {
+namespace defaults
+{
+void
+validate_perfetto_buffer_size(size_t value)
+{
+    LOG_IF(FATAL, !is_valid_perfetto_buffer_size(value))
+        << "Invalid Perfetto buffer size: " << value << " KB. Expected a value from "
+        << perfetto_buffer_size_min_kb << " to " << perfetto_buffer_size_max_kb << " KB";
+}
+}  // namespace defaults
+
 output_config
 output_config::load_from_env()
 {
@@ -57,6 +68,7 @@ output_config::parse_env()
     perfetto_shmem_size_hint =
         common::get_env("ROCPROF_PERFETTO_SHMEM_SIZE_HINT_KB", perfetto_shmem_size_hint);
     perfetto_buffer_size = common::get_env("ROCPROF_PERFETTO_BUFFER_SIZE_KB", perfetto_buffer_size);
+    defaults::validate_perfetto_buffer_size(perfetto_buffer_size);
 
     output_path    = common::get_env("ROCPROF_OUTPUT_PATH", output_path);
     output_file    = common::get_env("ROCPROF_OUTPUT_FILE_NAME", output_file);

--- a/projects/rocprofiler-sdk/source/lib/output/output_config.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/output_config.hpp
@@ -35,6 +35,8 @@
 
 #include <fmt/format.h>
 
+#include <cstdint>
+#include <limits>
 #include <set>
 #include <sstream>
 #include <string>
@@ -49,6 +51,23 @@ namespace defaults
 {
 constexpr auto perfetto_buffer_size_kb     = (1 * common::units::GiB) / common::units::KiB;
 constexpr auto perfetto_shmem_size_hint_kb = 64;
+constexpr auto perfetto_buffer_size_min_kb = size_t{1};
+constexpr auto perfetto_buffer_size_max_kb =
+    static_cast<size_t>(std::numeric_limits<uint32_t>::max()) / common::units::KiB;
+
+constexpr bool
+is_valid_perfetto_buffer_size(size_t value)
+{
+    return value >= perfetto_buffer_size_min_kb && value <= perfetto_buffer_size_max_kb;
+}
+
+// Aborts (LOG(FATAL)) when value is outside the Perfetto buffer-size contract.
+// Centralizes the diagnostic so both assignment paths emit the same message: the
+// CLI/YAML/env path (output_config::parse_env) and the rocpd programmatic path
+// (rocpd::output::PerfettoSession, which sets perfetto_buffer_size directly via
+// the pybind binding and never runs parse_env).
+void
+validate_perfetto_buffer_size(size_t value);
 }  // namespace defaults
 
 struct output_config

--- a/projects/rocprofiler-sdk/source/lib/output/output_config.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/output_config.hpp
@@ -36,7 +36,6 @@
 #include <fmt/format.h>
 
 #include <cstdint>
-#include <limits>
 #include <set>
 #include <sstream>
 #include <string>
@@ -51,19 +50,12 @@ namespace defaults
 {
 constexpr auto perfetto_buffer_size_kb     = (1 * common::units::GiB) / common::units::KiB;
 constexpr auto perfetto_shmem_size_hint_kb = 64;
-constexpr auto perfetto_buffer_size_min_kb = size_t{1};
-constexpr auto perfetto_buffer_size_max_kb =
-    static_cast<size_t>(std::numeric_limits<uint32_t>::max()) / common::units::KiB;
 
-constexpr bool
-is_valid_perfetto_buffer_size(size_t value)
-{
-    return value >= perfetto_buffer_size_min_kb && value <= perfetto_buffer_size_max_kb;
-}
-
-// Aborts (LOG(FATAL)) when value is outside the Perfetto buffer-size contract.
-// Centralizes the diagnostic so both assignment paths emit the same message: the
-// CLI/YAML/env path (output_config::parse_env) and the rocpd programmatic path
+// Aborts (LOG(FATAL)) when value is outside the Perfetto buffer-size contract
+// (the exact bounds live next to the definition in output_config.cpp, since only
+// that translation unit validates the value). Centralizes the diagnostic so both
+// assignment paths emit the same message: the CLI/YAML/env path
+// (output_config::parse_env) and the rocpd programmatic path
 // (rocpd::output::PerfettoSession, which sets perfetto_buffer_size directly via
 // the pybind binding and never runs parse_env).
 void

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
@@ -85,8 +85,13 @@ PerfettoSession::PerfettoSession(const tool::output_config& output_cfg, sqlite3*
     auto shmem_size_hint = config.perfetto_shmem_size_hint;
     auto buffer_size_kb  = config.perfetto_buffer_size;
 
+    // The rocpd path sets perfetto_buffer_size directly through the pybind binding
+    // and never runs output_config::parse_env(), so validate here before narrowing
+    // to Perfetto's uint32_t size_kb.
+    tool::defaults::validate_perfetto_buffer_size(buffer_size_kb);
+
     auto* buffer_config = cfg.add_buffers();
-    buffer_config->set_size_kb(buffer_size_kb);
+    buffer_config->set_size_kb(static_cast<uint32_t>(buffer_size_kb));
 
     args.supports_multiple_data_source_instances = true;
     // track_event_cfg.clear_disabled_categories();


### PR DESCRIPTION
## Motivation

The --perfetto-buffer-size argument accepted a unrestricted python integer which was later converted to C++ uint32_t causing overflow/underflows for out of bound integer values like -5,0,4194304 which caused hang in the profiler.

This PR adds proper error handling when such arguments are being passed.

Perfetto represents BufferConfig::size_kb as uint32_t, but the tracing service converts the configured value to bytes and requires the resulting buffer size to fit in uint32_t. This limits the accepted range to:

    1 <= size_kb <= floor(UINT32_MAX / 1024) = 4194303


## Technical Details

Added consistent validation across the supported configuration paths:

- validate --perfetto-buffer-size during argparse processing
- validate values loaded from YAML and JSON after argument merging
- validate parsed ROCPROF_PERFETTO_BUFFER_SIZE_KB values in C++
- guard both the rocprofv3 and rocpd Perfetto emitters
- explicitly narrow to uint32_t only after successful validation


## Issue Tracking

JIRA ID: AIPROFSDK-992

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
