### PR TITLE
refactor(rocprofsys): Remove Timemory dirname()

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
@@ -414,8 +414,8 @@ get_internal_libs_data_impl()
     auto _libs   = std::vector<std::string>{};
     _libs.assign(_libs_v.begin(), _libs_v.end());
 
-    auto _rocprofsys_base_path = filepath::dirname(
-        filepath::dirname(rocprofsys::path::realpath("/proc/self/exe")));
+    auto _rocprofsys_base_path =
+        rocprofsys::path::parent_path(rocprofsys::path::realpath("/proc/self/exe"), 2);
     auto _rocprofsys_lib_path = std::string{};
 
     for(const auto* itr : { "lib", "lib64" })

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -279,12 +279,6 @@ auto _activate =
                                 sys_signal::FileSize, sys_signal::CPUtime }),
      true);
 
-auto
-find(const std::string& itr, const strvec_t& _data)
-{
-    return std::any_of(_data.begin(), _data.end(),
-                       [itr](const auto& _v) { return (itr == _v); });
-}
 }  // namespace
 
 //======================================================================================//
@@ -319,10 +313,9 @@ main(int argc, char** argv)
     if(!exists(_rocprofsys_exe_filepath))
         _rocprofsys_exe_filepath =
             path::realpath(get_absolute_exe_filepath(rocprofsys_get_exe_realpath()));
-    bin_search_paths.emplace_back(filepath::dirname(_rocprofsys_exe_filepath));
+    bin_search_paths.emplace_back(path::parent_path(_rocprofsys_exe_filepath));
 
-    auto _rocprofsys_lib_path =
-        filepath::dirname(filepath::dirname(_rocprofsys_exe_filepath)) + "/lib";
+    auto _rocprofsys_lib_path = path::parent_path(_rocprofsys_exe_filepath, 2) + "/lib";
     bin_search_paths.emplace_back(_rocprofsys_lib_path + "/rocprofiler-systems");
     bin_search_paths.emplace_back(_rocprofsys_lib_path + "/rocprofiler-systems/bin");
 
@@ -332,8 +325,7 @@ main(int argc, char** argv)
     lib_search_paths.emplace_back(_rocprofsys_lib_path + "/rocprofiler-systems/lib64");
 
     auto _rocprofsys_internal_libexec_path =
-        filepath::dirname(filepath::dirname(_rocprofsys_exe_filepath)) +
-        "/libexec/rocprofiler-systems";
+        path::parent_path(_rocprofsys_exe_filepath, 2) + "/libexec/rocprofiler-systems";
 
     ROCPROFSYS_ADD_LOG_ENTRY(argv[0],
                              "::", "rocprofsys bin path: ", _rocprofsys_exe_filepath);
@@ -342,21 +334,29 @@ main(int argc, char** argv)
     ROCPROFSYS_ADD_LOG_ENTRY(
         argv[0], "::", "rocprofsys libexec path: ", _rocprofsys_internal_libexec_path);
 
-    for(const auto& itr : rocprofsys_get_link_map(nullptr))
+    const auto libs_regex =
+        std::regex{ "lib(dyninstAPI|stackwalk|pcontrol|patchAPI|parseAPI|"
+                    "instructionAPI|symtabAPI|dynDwarf|common|dynElf|tbb|tbbmalloc|"
+                    "tbbmalloc_proxy|gotcha|libunwind|hsa-runtime|amdhip|"
+                    "amd_comgr|amd_smi|rocprofiler-register|"
+                    "rocprofiler-sdk|rocprofiler-sdk-roctx)\\.(so|a)" };
+
+    auto is_instrumentation_lib = [&libs_regex](const std::string& lib_path) {
+        return lib_path.find("rocprofsys") != std::string::npos ||
+               lib_path.find("rocprof-sys") != std::string::npos ||
+               lib_path.find("rocprofiler-systems") != std::string::npos ||
+               std::regex_search(lib_path, libs_regex);
+    };
+
+    for(const auto& lib_path : rocprofsys_get_link_map(nullptr))
     {
-        if(itr.find("rocprofsys") != std::string::npos ||
-           itr.find("rocprof-sys") != std::string::npos ||
-           itr.find("rocprofiler-systems") != std::string::npos ||
-           std::regex_search(
-               itr, std::regex{
-                        "lib(dyninstAPI|stackwalk|pcontrol|patchAPI|parseAPI|"
-                        "instructionAPI|symtabAPI|dynDwarf|common|dynElf|tbb|tbbmalloc|"
-                        "tbbmalloc_proxy|gotcha|libunwind|hsa-runtime|amdhip|"
-                        "amd_comgr|amd_smi|rocprofiler-register|"
-                        "rocprofiler-sdk|rocprofiler-sdk-roctx)\\.(so|a)" }))
+        if(!is_instrumentation_lib(lib_path)) continue;
+
+        auto lib_dir = path::parent_path(lib_path);
+        if(std::find(lib_search_paths.begin(), lib_search_paths.end(), lib_dir) ==
+           lib_search_paths.end())
         {
-            if(!find(filepath::dirname(itr), lib_search_paths))
-                lib_search_paths.emplace_back(filepath::dirname(itr));
+            lib_search_paths.emplace_back(std::move(lib_dir));
         }
     }
 
@@ -1184,7 +1184,7 @@ main(int argc, char** argv)
                        !parser.exists("min-instructions") &&
                            !parser.exists("min-address-range-loop"));
 
-    auto _rocprofsys_exe_path = tim::dirname(path::realpath("/proc/self/exe"));
+    auto _rocprofsys_exe_path = path::parent_path(path::realpath("/proc/self/exe"));
     verbprintf(4, "rocprof-sys exe path: %s\n", _rocprofsys_exe_path.c_str());
 
     if(_cmdv && _cmdv[0] && strlen(_cmdv[0]) > 0)
@@ -1363,7 +1363,7 @@ main(int argc, char** argv)
     for(const auto& itr : _dyn_api_rt_paths)
     {
         lib_search_paths.emplace_back(itr);
-        lib_search_paths.emplace_back(filepath::dirname(itr));
+        lib_search_paths.emplace_back(path::parent_path(itr));
     }
 
     find_dyn_api_rt();
@@ -2767,7 +2767,7 @@ get_absolute_filepath(std::string _name, const strvec_t& _search_paths)
         auto _orig = _name;
         for(auto itr : _search_paths)
         {
-            if(!is_directory(itr) || is_file(itr)) itr = filepath::dirname(itr);
+            if(!is_directory(itr) || is_file(itr)) itr = path::parent_path(itr);
 
             auto _exists = false;
             ROCPROFSYS_ADD_LOG_ENTRY("searching", itr, "for", _name);
@@ -2886,8 +2886,6 @@ get_cwd()
 #endif
 }
 
-using tim::dirname;
-
 void
 find_dyn_api_rt()
 {
@@ -2909,7 +2907,8 @@ find_dyn_api_rt()
     {
         rocprofsys::set_env<string_t>("DYNINSTAPI_RT_LIB", _dyn_api_rt_abs, 1);
         rocprofsys::set_env<string_t>("DYNINST_REWRITER_PATHS",
-                                      fmt::format("{}:{}", dirname(_dyn_api_rt_abs),
+                                      fmt::format("{}:{}",
+                                                  path::parent_path(_dyn_api_rt_abs),
                                                   fmt::join(lib_search_paths, ":")),
                                       1);
     }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -292,21 +292,26 @@ main(int argc, char** argv)
 {
     argv0 = argv[0];
 
-    auto rocprofsys_root = rocprofsys::get_env<std::string>(
+    auto rocprofsys_root_from_env = rocprofsys::get_env<std::string>(
         "rocprofiler_systems_ROOT",
         rocprofsys::get_env<std::string>(rocprofsys::env_vars::ROOT, ""));
-    if(!rocprofsys_root.empty() && exists(rocprofsys_root))
+    if(!rocprofsys_root_from_env.empty() && exists(rocprofsys_root_from_env))
     {
-        bin_search_paths.emplace_back(rocprofsys_root + "/bin");
-        bin_search_paths.emplace_back(rocprofsys_root + "/lib/rocprofiler-systems");
-        bin_search_paths.emplace_back(rocprofsys_root + "/lib/rocprofiler-systems/bin");
+        bin_search_paths.emplace_back(rocprofsys_root_from_env + "/bin");
+        bin_search_paths.emplace_back(rocprofsys_root_from_env +
+                                      "/lib/rocprofiler-systems");
+        bin_search_paths.emplace_back(rocprofsys_root_from_env +
+                                      "/lib/rocprofiler-systems/bin");
 
-        lib_search_paths.emplace_back(rocprofsys_root + "/lib");
-        lib_search_paths.emplace_back(rocprofsys_root + "/lib/rocprofiler-systems");
-        lib_search_paths.emplace_back(rocprofsys_root + "/lib/rocprofiler-systems/lib");
-        lib_search_paths.emplace_back(rocprofsys_root + "/lib/rocprofiler-systems/lib64");
+        lib_search_paths.emplace_back(rocprofsys_root_from_env + "/lib");
+        lib_search_paths.emplace_back(rocprofsys_root_from_env +
+                                      "/lib/rocprofiler-systems");
+        lib_search_paths.emplace_back(rocprofsys_root_from_env +
+                                      "/lib/rocprofiler-systems/lib");
+        lib_search_paths.emplace_back(rocprofsys_root_from_env +
+                                      "/lib/rocprofiler-systems/lib64");
         ROCPROFSYS_ADD_LOG_ENTRY(
-            argv[0], "::", "rocprofiler-systems root path: ", rocprofsys_root);
+            argv[0], "::", "rocprofiler-systems root path: ", rocprofsys_root_from_env);
     }
 
     auto _rocprofsys_exe_filepath = path::realpath(get_absolute_exe_filepath(argv[0]));
@@ -315,7 +320,10 @@ main(int argc, char** argv)
             path::realpath(get_absolute_exe_filepath(rocprofsys_get_exe_realpath()));
     bin_search_paths.emplace_back(path::parent_path(_rocprofsys_exe_filepath));
 
-    auto _rocprofsys_lib_path = path::parent_path(_rocprofsys_exe_filepath, 2) + "/lib";
+    // Strip 2 levels from exe filepath <root>/bin/<exe> to reach <root>
+    auto rocprofsys_root_from_exe = path::parent_path(_rocprofsys_exe_filepath, 2);
+
+    auto _rocprofsys_lib_path = rocprofsys_root_from_exe + "/lib";
     bin_search_paths.emplace_back(_rocprofsys_lib_path + "/rocprofiler-systems");
     bin_search_paths.emplace_back(_rocprofsys_lib_path + "/rocprofiler-systems/bin");
 
@@ -325,7 +333,7 @@ main(int argc, char** argv)
     lib_search_paths.emplace_back(_rocprofsys_lib_path + "/rocprofiler-systems/lib64");
 
     auto _rocprofsys_internal_libexec_path =
-        path::parent_path(_rocprofsys_exe_filepath, 2) + "/libexec/rocprofiler-systems";
+        rocprofsys_root_from_exe + "/libexec/rocprofiler-systems";
 
     ROCPROFSYS_ADD_LOG_ENTRY(argv[0],
                              "::", "rocprofsys bin path: ", _rocprofsys_exe_filepath);

--- a/projects/rocprofiler-systems/source/lib/common/path.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/path.hpp
@@ -294,6 +294,15 @@ readlink(const std::string& _path)
     return _path;
 }
 
+/**
+ * Resolve @p path to its canonical absolute form.
+ * Filesystem operation: follows symlinks and collapses '.'/'..'; the path
+ * must exist. On any error (missing path, permission denied) @p path is
+ * returned unchanged.
+ * @code realpath("/a/./b/../c") @endcode returns "/a/c" (when it exists).
+ * @param path the path to canonicalize
+ * @return the canonical absolute path, or @p path unchanged on error
+ */
 [[nodiscard]] std::string
 realpath(const std::string& path)
 {

--- a/projects/rocprofiler-systems/source/lib/common/path.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/path.hpp
@@ -251,9 +251,11 @@ find_path(const std::string& _path, int _verbose, const std::string& _search_pat
 parent_path(std::string_view fpath, std::uint16_t levels)
 {
     std::filesystem::path result{ fpath };
-    for(auto i = 0; i < levels; ++i)
+    for(std::uint16_t i = 0; i < levels; ++i)
     {
-        result = result.parent_path();
+        auto parent = result.parent_path();
+        if(parent == result) break;  // reached root ("/") or relative bottom ("")
+        result = std::move(parent);
     }
     return result.string();
 }
@@ -413,10 +415,8 @@ get_origin(const std::string& _filename, std::vector<int>&& _open_modes)
 std::string
 get_rocprofsys_root()
 {
-    auto _exe_rp  = realpath("/proc/self/exe");
-    auto _exe_dir = parent_path(_exe_rp);
-    if(_exe_dir.empty()) _exe_dir = "./";
-    return fmt::format("{}/{}", _exe_dir, "..");
+    // strip 2 levels from exe filepath to reach root
+    return parent_path(realpath("/proc/self/exe"), 2);
 }
 
 std::string

--- a/projects/rocprofiler-systems/source/lib/common/path.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/path.hpp
@@ -9,6 +9,7 @@
 #include "common/environment.hpp"
 #include <spdlog/fmt/fmt.h>
 
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <dlfcn.h>
@@ -91,8 +92,8 @@ inline std::string
 find_path(const std::string& _path, int _verbose,
           const std::string& _search_paths = {}) ROCPROFSYS_INTERNAL_API;
 
-inline std::string
-dirname(const std::string& _fname) ROCPROFSYS_INTERNAL_API;
+[[nodiscard]] inline std::string
+parent_path(std::string_view fpath, std::uint16_t levels = 1) ROCPROFSYS_INTERNAL_API;
 
 [[nodiscard]] inline std::string
 realpath(const std::string& path) ROCPROFSYS_INTERNAL_API;
@@ -215,11 +216,11 @@ find_path(const std::string& _path, int _verbose, const std::string& _search_pat
     {
         if(std::string_view{ ::basename(itr.c_str()) }.find("lib") ==
                std::string_view::npos &&
-           !dirname(itr).empty())
+           !parent_path(itr).empty())
         {
             for(const auto* sitr : { "lib", "lib64", "../lib", "../lib64" })
             {
-                auto _f = fmt::format("{}/{}/{}", dirname(itr), sitr, _path);
+                auto _f = fmt::format("{}/{}/{}", parent_path(itr), sitr, _path);
                 ROCPROFSYS_PATH_LOG(_verbose >= _verbose_lvl + 1,
                                     "searching for '%s' in '%s' ...\n", _path.c_str(),
                                     fmt::format("{}/{}", itr, sitr).c_str());
@@ -237,12 +238,24 @@ find_path(const std::string& _path, int _verbose, const std::string& _search_pat
     return _path;
 }
 
-std::string
-dirname(const std::string& _fname)
+/**
+ * Get parent directory of @p fpath, walking up @p levels times.
+ * Pure lexical operation: no filesystem access and no '.'/'..' resolution.
+ * Absolute paths clamp at "/"; relative paths bottom out at "".
+ * @code parent_path("/a/b/c", 2) @endcode returns "/a".
+ * @param fpath  the path to take the parent of
+ * @param levels number of components to strip (0 returns @p fpath unchanged)
+ * @return the parent path, or "" / "/" at the relative / absolute limit
+ */
+[[nodiscard]] std::string
+parent_path(std::string_view fpath, std::uint16_t levels)
 {
-    if(_fname.find('/') != std::string::npos)
-        return _fname.substr(0, _fname.find_last_of('/'));
-    return std::string{};
+    std::filesystem::path result{ fpath };
+    for(auto i = 0; i < levels; ++i)
+    {
+        result = result.parent_path();
+    }
+    return result.string();
 }
 
 bool
@@ -392,7 +405,7 @@ std::string
 get_rocprofsys_root()
 {
     auto _exe_rp  = realpath("/proc/self/exe");
-    auto _exe_dir = dirname(_exe_rp);
+    auto _exe_dir = parent_path(_exe_rp);
     if(_exe_dir.empty()) _exe_dir = "./";
     return fmt::format("{}/{}", _exe_dir, "..");
 }

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
@@ -244,17 +244,11 @@ TEST_F(PathTest, PathType_Nonexistent)
     EXPECT_FALSE(static_cast<bool>(pt));
 }
 
-TEST_F(PathTest, GetRocprofsysRoot_ReturnsNonEmpty)
+TEST_F(PathTest, GetRocprofsysRoot_ReturnsNonEmptyAbsolute)
 {
     std::string root = get_rocprofsys_root();
     EXPECT_FALSE(root.empty());
-}
-
-TEST_F(PathTest, GetRocprofsysRoot_EndsWithParentDir)
-{
-    std::string root = get_rocprofsys_root();
-    EXPECT_TRUE(root.length() >= 2);
-    EXPECT_EQ(root.substr(root.length() - 2), "..");
+    EXPECT_EQ(root.front(), '/');
 }
 
 TEST_F(PathTest, GetInternalLibdir_ContainsLib)
@@ -379,6 +373,19 @@ TEST_F(PathTest, ParentPath_Relative_OneLevel) { EXPECT_EQ(parent_path("a/b", 1)
 TEST_F(PathTest, ParentPath_Relative_Overwalk) { EXPECT_EQ(parent_path("a/b", 5), ""); }
 
 TEST_F(PathTest, ParentPath_Identity) { EXPECT_EQ(parent_path("/a/b/c", 0), "/a/b/c"); }
+
+TEST_F(PathTest, ParentPath_Identity_RedundantSlashesVerbatim)
+{
+    EXPECT_EQ(parent_path("/a//b", 0), "/a//b");
+    EXPECT_EQ(parent_path("/a/b//", 0), "/a/b//");
+}
+
+TEST_F(PathTest, ParentPath_NegativeArgWrapsAndClamps)
+{
+    // -1 converts to uint16_t max (65535); loop clamps at the root / relative bottom
+    EXPECT_EQ(parent_path("/a/b/c", -1), "/");
+    EXPECT_EQ(parent_path("a/b/c", -1), "");
+}
 
 TEST_F(PathTest, ParentPath_TrailingSlash_Redundant)
 {

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
@@ -62,27 +62,27 @@ protected:
     std::string m_test_dir;
 };
 
-TEST_F(PathTest, Dirname_StandardPath)
+TEST_F(PathTest, ParentPath_StandardPath)
 {
-    EXPECT_EQ(dirname("/usr/local/bin/program"), "/usr/local/bin");
+    EXPECT_EQ(parent_path("/usr/local/bin/program"), "/usr/local/bin");
 }
 
-TEST_F(PathTest, Dirname_SingleLevel) { EXPECT_EQ(dirname("/usr/file"), "/usr"); }
+TEST_F(PathTest, ParentPath_SingleLevel) { EXPECT_EQ(parent_path("/usr/file"), "/usr"); }
 
-TEST_F(PathTest, Dirname_RootFile) { EXPECT_EQ(dirname("/file"), ""); }
+TEST_F(PathTest, ParentPath_RootFile) { EXPECT_EQ(parent_path("/file"), "/"); }
 
-TEST_F(PathTest, Dirname_NoSlash) { EXPECT_EQ(dirname("filename"), ""); }
+TEST_F(PathTest, ParentPath_NoSlash) { EXPECT_EQ(parent_path("filename"), ""); }
 
-TEST_F(PathTest, Dirname_EmptyString) { EXPECT_EQ(dirname(""), ""); }
+TEST_F(PathTest, ParentPath_EmptyString) { EXPECT_EQ(parent_path(""), ""); }
 
-TEST_F(PathTest, Dirname_TrailingSlash)
+TEST_F(PathTest, ParentPath_TrailingSlash)
 {
-    EXPECT_EQ(dirname("/usr/local/"), "/usr/local");
+    EXPECT_EQ(parent_path("/usr/local/"), "/usr/local");
 }
 
-TEST_F(PathTest, Dirname_MultipleSlashes)
+TEST_F(PathTest, ParentPath_MultipleSlashes)
 {
-    EXPECT_EQ(dirname("/a/b/c/d/e"), "/a/b/c/d");
+    EXPECT_EQ(parent_path("/a/b/c/d/e"), "/a/b/c/d");
 }
 
 TEST_F(PathTest, Exists_ExistingFile)
@@ -315,9 +315,9 @@ TEST_F(PathTest, FindPath_InSearchPath)
     EXPECT_EQ(result, file_path);
 }
 
-TEST_F(PathTest, Dirname_ComplexPath)
+TEST_F(PathTest, ParentPath_ComplexPath)
 {
-    EXPECT_EQ(dirname("/opt/rocm/lib/rocprofiler-systems/librocprof-sys.so"),
+    EXPECT_EQ(parent_path("/opt/rocm/lib/rocprofiler-systems/librocprof-sys.so"),
               "/opt/rocm/lib/rocprofiler-systems");
 }
 
@@ -341,10 +341,10 @@ TEST_F(PathTest, Exists_SpecialCharactersInPath)
     EXPECT_TRUE(exists(file_path));
 }
 
-TEST_F(PathTest, Dirname_RocprofsysTypicalPath)
+TEST_F(PathTest, ParentPath_RocprofsysTypicalPath)
 {
     std::string path   = "/opt/rocm-6.0.0/lib/rocprofiler-systems/librocprof-sys-dl.so";
-    std::string result = dirname(path);
+    std::string result = parent_path(path);
     EXPECT_EQ(result, "/opt/rocm-6.0.0/lib/rocprofiler-systems");
 }
 
@@ -360,6 +360,63 @@ TEST_F(PathTest, NestedDirectories)
     EXPECT_TRUE(exists(subdir2));
     EXPECT_TRUE(exists(subdir3));
 
-    EXPECT_EQ(dirname(subdir3), subdir2);
-    EXPECT_EQ(dirname(subdir2), subdir1);
+    EXPECT_EQ(parent_path(subdir3), subdir2);
+    EXPECT_EQ(parent_path(subdir2), subdir1);
+}
+
+TEST_F(PathTest, ParentPath_TwoLevels)
+{
+    EXPECT_EQ(parent_path("/a/b/c", 2), "/a");
+}
+
+TEST_F(PathTest, ParentPath_ThreeLevels)
+{
+    EXPECT_EQ(parent_path("/a/b/c", 3), "/");
+}
+
+TEST_F(PathTest, ParentPath_RootClamp_OneComponent)
+{
+    EXPECT_EQ(parent_path("/a"), "/");
+}
+
+TEST_F(PathTest, ParentPath_RootClamp_Overwalk)
+{
+    EXPECT_EQ(parent_path("/a", 5), "/");
+}
+
+TEST_F(PathTest, ParentPath_RootClamp_Root)
+{
+    EXPECT_EQ(parent_path("/", 1), "/");
+}
+
+TEST_F(PathTest, ParentPath_Relative_OneLevel)
+{
+    EXPECT_EQ(parent_path("a/b", 1), "a");
+}
+
+TEST_F(PathTest, ParentPath_Relative_Overwalk)
+{
+    EXPECT_EQ(parent_path("a/b", 5), "");
+}
+
+TEST_F(PathTest, ParentPath_Identity)
+{
+    EXPECT_EQ(parent_path("/a/b/c", 0), "/a/b/c");
+}
+
+TEST_F(PathTest, ParentPath_TrailingSlash_Redundant)
+{
+    EXPECT_EQ(parent_path("/a/b//"), "/a/b");
+}
+
+TEST_F(PathTest, ParentPath_InteriorRedundantSlash)
+{
+    EXPECT_EQ(parent_path("/a//b"), "/a");
+}
+
+TEST_F(PathTest, ParentPath_RealExe_TwoLevels)
+{
+    std::string result = parent_path(realpath("/proc/self/exe"), 2);
+    EXPECT_FALSE(result.empty());
+    EXPECT_EQ(result.front(), '/');
 }

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
@@ -382,7 +382,7 @@ TEST_F(PathTest, ParentPath_Identity_RedundantSlashesVerbatim)
 
 TEST_F(PathTest, ParentPath_NegativeArgWrapsAndClamps)
 {
-    // -1 converts to uint16_t max (65535); loop clamps at the root / relative bottom
+    // -1 converts to uint16 max (65535): should clamp at the root / relative bottom
     EXPECT_EQ(parent_path("/a/b/c", -1), "/");
     EXPECT_EQ(parent_path("a/b/c", -1), "");
 }

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
@@ -364,45 +364,21 @@ TEST_F(PathTest, NestedDirectories)
     EXPECT_EQ(parent_path(subdir2), subdir1);
 }
 
-TEST_F(PathTest, ParentPath_TwoLevels)
-{
-    EXPECT_EQ(parent_path("/a/b/c", 2), "/a");
-}
+TEST_F(PathTest, ParentPath_TwoLevels) { EXPECT_EQ(parent_path("/a/b/c", 2), "/a"); }
 
-TEST_F(PathTest, ParentPath_ThreeLevels)
-{
-    EXPECT_EQ(parent_path("/a/b/c", 3), "/");
-}
+TEST_F(PathTest, ParentPath_ThreeLevels) { EXPECT_EQ(parent_path("/a/b/c", 3), "/"); }
 
-TEST_F(PathTest, ParentPath_RootClamp_OneComponent)
-{
-    EXPECT_EQ(parent_path("/a"), "/");
-}
+TEST_F(PathTest, ParentPath_RootClamp_OneComponent) { EXPECT_EQ(parent_path("/a"), "/"); }
 
-TEST_F(PathTest, ParentPath_RootClamp_Overwalk)
-{
-    EXPECT_EQ(parent_path("/a", 5), "/");
-}
+TEST_F(PathTest, ParentPath_RootClamp_Overwalk) { EXPECT_EQ(parent_path("/a", 5), "/"); }
 
-TEST_F(PathTest, ParentPath_RootClamp_Root)
-{
-    EXPECT_EQ(parent_path("/", 1), "/");
-}
+TEST_F(PathTest, ParentPath_RootClamp_Root) { EXPECT_EQ(parent_path("/", 1), "/"); }
 
-TEST_F(PathTest, ParentPath_Relative_OneLevel)
-{
-    EXPECT_EQ(parent_path("a/b", 1), "a");
-}
+TEST_F(PathTest, ParentPath_Relative_OneLevel) { EXPECT_EQ(parent_path("a/b", 1), "a"); }
 
-TEST_F(PathTest, ParentPath_Relative_Overwalk)
-{
-    EXPECT_EQ(parent_path("a/b", 5), "");
-}
+TEST_F(PathTest, ParentPath_Relative_Overwalk) { EXPECT_EQ(parent_path("a/b", 5), ""); }
 
-TEST_F(PathTest, ParentPath_Identity)
-{
-    EXPECT_EQ(parent_path("/a/b/c", 0), "/a/b/c");
-}
+TEST_F(PathTest, ParentPath_Identity) { EXPECT_EQ(parent_path("/a/b/c", 0), "/a/b/c"); }
 
 TEST_F(PathTest, ParentPath_TrailingSlash_Redundant)
 {

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -132,9 +132,9 @@ add_ld_preload(parser_data& _data)
 parser_data&
 add_ld_library_path(parser_data& _data)
 {
-    auto _libdir = filepath::dirname(_data.env.dl_libpath);
-    if(filepath::exists(_libdir))
-        update_env(_data, "LD_LIBRARY_PATH", _libdir, update_mode::APPEND);
+    auto libdir = path::parent_path(_data.env.dl_libpath);
+    if(filepath::exists(libdir))
+        update_env(_data, "LD_LIBRARY_PATH", libdir, update_mode::APPEND);
     return _data;
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -3076,7 +3076,7 @@ get_ump_absolute_path()
         (get_use_rocpd() && !get_caching_perfetto())
             ? get_database_absolute_path("rocpd", std::to_string(process::get_id()))
             : get_perfetto_output_filename();
-    return tim::filepath::dirname(source);
+    return path::parent_path(source);
 }
 
 bool&

--- a/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
@@ -3,6 +3,7 @@
 
 #include "perfetto.hpp"
 #include "common/env_vars.hpp"
+#include "common/path.hpp"
 #include "common/units.hpp"
 #include "config.hpp"
 #include "library/runtime.hpp"
@@ -277,7 +278,7 @@ post_process(tim::manager* _timemory_manager, bool& _perfetto_output_error,
     if(dmp::rank() == 0 &&
        config::output_filtering::is_file_output_enabled_for_current_mpi_rank())
     {
-        auto _output_folder = filepath::dirname(_filename);
+        auto _output_folder = path::parent_path(_filename);
         auto _script_path   = std::string{ "rocprof-sys-merge-output.sh" };
         auto _script_dir    = get_env(env_vars::SCRIPT_PATH, std::string{});
 

--- a/projects/rocprofiler-systems/source/lib/core/rocpd/data_storage/database.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/rocpd/data_storage/database.cpp
@@ -3,6 +3,7 @@
 
 #include "database.hpp"
 #include "common/md5sum.hpp"
+#include "common/path.hpp"
 #include "node_info.hpp"
 #include <cstdint>
 
@@ -59,10 +60,10 @@ namespace
 void
 create_directory_for_database_file(const std::string& db_file)
 {
-    auto _db_dirname = tim::filepath::dirname(db_file);
-    if(!tim::filepath::direxists(_db_dirname))
+    auto db_dirname = rocprofsys::path::parent_path(db_file);
+    if(!tim::filepath::direxists(db_dirname))
     {
-        tim::filepath::makedir(_db_dirname);
+        tim::filepath::makedir(db_dirname);
     }
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/discovery.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/discovery.cpp
@@ -4,6 +4,7 @@
 #include "core/trace_cache/discovery.hpp"
 
 #include "common/env_vars.hpp"
+#include "common/path.hpp"
 #include "core/config.hpp"
 #include "core/timemory.hpp"
 #include "core/trace_cache/cacheable.hpp"
@@ -142,7 +143,7 @@ merge_perfetto_files()
     if(cached_mpi_rank != 0) return;
 
     auto _filename      = config::get_perfetto_output_filename();
-    auto _output_folder = tim::filepath::dirname(_filename);
+    auto _output_folder = path::parent_path(_filename);
     auto _script_path   = std::string{ "rocprof-sys-merge-output.sh" };
     auto _script_dir    = get_env(env_vars::SCRIPT_PATH, std::string{});
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
@@ -215,8 +215,8 @@ struct ROCPROFSYS_INTERNAL_API indirect
             ROCPROFSYS_COMMON_LIBRARY_LOG_END
         }
 
-        auto _search_paths = fmt::format("{}:{}", common::path::dirname(_omnilib),
-                                         common::path::dirname(_dllib));
+        auto _search_paths =
+            fmt::format("{}:{}", path::parent_path(_omnilib), path::parent_path(_dllib));
         common::setup_environ(_rocprofsys_dl_verbose, _search_paths, _omnilib, _dllib);
 
         m_omnihandle = open(m_omnilib);


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This PR is a part of PR series to remove dependency on Timemory filepath utilities.
This particular PR:

- refactors and renames existing `path.hpp:dirname()` function into `parent_path()` function. This new `parent_path()` has a `level` parameter that allows to strip specific number of components from the path. This simplifies previous nested usages like `dirname(dirname(x))` to clear and readable `parent_path(x, 2)`
- replaces tim::filepath::dirname() with above-described path::parent_path()
- refactors some confusing logic in rocprof-sys-instrument.cpp for readability and efficiency without change of behavior
- adds new unit tests for the new parent_path() functionality
- get_rocprofsys_root() simplified using the new parent_path()
- existing tests adjusted

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- The new parent_path() function is implemented with `std::filesystem::parent_path()`.
- Behavior is unchanged: return result on success, return original input on error.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

JIRA ID : AIPROFSYST-528

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Existing CTest suite and new tests should pass

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
