### PR TITLE
docs(hip): Add link to Cooperative Groups double-buffered tile example

### DIFF
--- a/projects/hip/docs/tutorial/cooperative_groups_tutorial.rst
+++ b/projects/hip/docs/tutorial/cooperative_groups_tutorial.rst
@@ -237,9 +237,9 @@ The kernel launch is done with the ``hipLaunchCooperativeKernel`` of the  cooper
 Conclusion
 ==========
 
-With cooperative groups, you can easily use custom partitions to create custom tiles for custom solutions. You can find the complete code at `cooperative groups ROCm example. <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/cooperative_groups>`_
+With cooperative groups, you can use custom partitions to create custom tiles for custom solutions. For complete code, see the `cooperative groups ROCm example. <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/cooperative_groups>`_.
 
-Additional cooperative groups examples demonstrate more recent features of the API:
+The following supplementary cooperative groups examples demonstrate additional API features:
 
 - `double-buffered tile <https://github.com/ROCm/rocm-examples/tree/amd-staging/HIP-Basic/cooperative_groups_double_buffered_tile>`_ combines ``memcpy_async`` with a split barrier.
 - `prefix sum <https://github.com/ROCm/rocm-examples/tree/amd-staging/HIP-Basic/cooperative_groups_prefix_sum>`_ showcases a parallel prefix sum implementation using ``inclusive_scan`` and ``exclusive_scan``.

--- a/projects/hip/docs/tutorial/cooperative_groups_tutorial.rst
+++ b/projects/hip/docs/tutorial/cooperative_groups_tutorial.rst
@@ -242,4 +242,4 @@ With cooperative groups, you can easily use custom partitions to create custom t
 Additional cooperative groups examples demonstrate more recent features of the API:
 
 - `double-buffered tile <https://github.com/ROCm/rocm-examples/tree/amd-staging/HIP-Basic/cooperative_groups_double_buffered_tile>`_ combines ``memcpy_async`` with a split barrier.
-- `prefix sum <https://github.com/ROCm/rocm-examples/tree/amd-staging/HIP-Basic/cooperative_groups_prefix_sum>`_ demonstrates a parallel prefix sum implementation using ``inclusive_scan`` and ``exclusive_scan``.
+- `prefix sum <https://github.com/ROCm/rocm-examples/tree/amd-staging/HIP-Basic/cooperative_groups_prefix_sum>`_ showcases a parallel prefix sum implementation using ``inclusive_scan`` and ``exclusive_scan``.

--- a/projects/hip/docs/tutorial/cooperative_groups_tutorial.rst
+++ b/projects/hip/docs/tutorial/cooperative_groups_tutorial.rst
@@ -238,3 +238,8 @@ Conclusion
 ==========
 
 With cooperative groups, you can easily use custom partitions to create custom tiles for custom solutions. You can find the complete code at `cooperative groups ROCm example. <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/cooperative_groups>`_
+
+Additional cooperative groups examples demonstrate more recent features of the API:
+
+- `double-buffered tile <https://github.com/ROCm/rocm-examples/tree/amd-staging/HIP-Basic/cooperative_groups_double_buffered_tile>`_ combines ``memcpy_async`` with a split barrier.
+- `prefix sum <https://github.com/ROCm/rocm-examples/tree/amd-staging/HIP-Basic/cooperative_groups_prefix_sum>`_ demonstrates a parallel prefix sum implementation using ``inclusive_scan`` and ``exclusive_scan``.


### PR DESCRIPTION
## Motivation

https://github.com/ROCm/rocm-examples/pull/486 adds a new example for Cooperative Groups. The documentation should point to this demonstration of a new feature.

## Technical Details

Adds a link. **Must be merged after the PR linked above.**

## Issue Tracking

AIROCDOC-4087

## Test Plan

n/a

## Test Result

n/a

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
