### PR TITLE
[Do not review] Find out why gfx950 workflow rocminfo fails

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -1615,9 +1615,9 @@ def get_gpu_info() -> GPUInfo:
     """Return the GPU information."""
     try:
         rocprof_config = get_rocprof_config()
+        return detect_gpu(rocprof_config.rocm_path)
     except Exception as e:
         pytest.exit(f"{e}")
-    return detect_gpu(rocprof_config.rocm_path)
 
 
 def _run_cleanup() -> None:

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/gpu.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/gpu.py
@@ -133,7 +133,14 @@ def detect_gpu(rocm_path: Optional[Path] = None) -> GPUInfo:
                 text=True,
                 timeout=30,
             )
-            rocminfo_stdout = result.stdout if result.returncode == 0 else None
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"rocminfo ({rocminfo}) failed with return code "
+                    f"{result.returncode}\n"
+                    f"--- stdout ---\n{result.stdout}\n"
+                    f"--- stderr ---\n{result.stderr}"
+                )
+            rocminfo_stdout = result.stdout
             if rocminfo_stdout:
                 # Only match gfx on "Name:"
                 name_gfx_pattern = re.compile(


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

I've noticed some tests being skipped in GFX950 workflow due to no valid GPU. That should be impossible and means rocminfo fails. I had it so that if rocminfo fails, it would assume no GPU.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
