### PR TITLE
[rocjitsu]: RAII-own dispatch resources for queue-first teardown

### DIFF
--- a/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
@@ -1067,7 +1067,7 @@ void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const Dis
 
   if (observed)
     *observed = std::move(o_host);
-  // Resources released by HsaDispatchResources::~ (queue first).
+  // Resources released by HsaDispatchResources destructor (queue first).
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
@@ -914,7 +914,7 @@ void run_buffer_async_triton_matmul(const std::vector<uint8_t> &elf_bytes,
 
   if (observed)
     *observed = std::move(c_host);
-  // Resources released by HsaDispatchResources::~ (queue first).
+  // Resources released by HsaDispatchResources destructor (queue first).
 }
 
 void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const DispatchTarget &target,

--- a/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
@@ -568,7 +568,7 @@ void run_dynamic_copy_loop(const std::vector<uint8_t> &elf_bytes, const Dispatch
     }
     EXPECT_EQ(mismatches, 0u) << mismatches << " mismatches for N=" << n;
   }
-  // Resources released by HsaDispatchResources::~ (queue first).
+  // Resources released by HsaDispatchResources destructor (queue first).
 }
 
 void translate_triton_fixture(const char *name, uint32_t mach, std::vector<uint8_t> &elf_bytes,

--- a/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
@@ -362,20 +362,51 @@ struct HsaShutdownGuard {
   ~HsaShutdownGuard() { hsa_shut_down(); }
 };
 
-struct HsaMatmulResources {
+/// @brief RAII owner for one raw-HSA dispatch's resources.
+/// @details Every dispatch helper builds the same object graph (code-object
+/// reader, executable, device/kernarg pool allocations, queue, completion
+/// signal) and must tear it down in a fixed order even when a mid-helper
+/// ASSERT/timeout returns early. Manual tail cleanup is skipped on any early
+/// return, which leaks the queue and — worse — leaves a live simulator dispatch
+/// referencing freed packet operands when hsa_shut_down() later runs, turning a
+/// lost/timed-out dispatch into a confusing exit-time crash instead of a clean
+/// test failure. This owner destroys the queue FIRST (stopping execution) before
+/// releasing anything an in-flight AQL packet can reference.
+struct HsaDispatchResources {
   hsa_code_object_reader_t reader{};
   hsa_executable_t executable{};
   hsa_queue_t *queue = nullptr;
   hsa_signal_t signal{};
   void *kernarg = nullptr;
-  void *a = nullptr;
-  void *b = nullptr;
-  void *c = nullptr;
+  std::vector<void *>
+      device_allocs; ///< Device global-pool blocks (from alloc_device) freed in dtor.
   bool reader_created = false;
   bool executable_created = false;
   bool signal_created = false;
 
-  ~HsaMatmulResources() {
+  HsaDispatchResources() = default;
+  // Sole-owner of raw HSA handles/allocations: copying would duplicate them and
+  // double-free/destroy in the dtor. Every call site uses this as a local, so
+  // deleting copy and move (rather than defining a move) is sufficient and safest.
+  HsaDispatchResources(const HsaDispatchResources &) = delete;
+  HsaDispatchResources &operator=(const HsaDispatchResources &) = delete;
+  HsaDispatchResources(HsaDispatchResources &&) = delete;
+  HsaDispatchResources &operator=(HsaDispatchResources &&) = delete;
+
+  /// @brief Allocate a global-pool block and record it for destruction.
+  /// @param[out] out Receives the allocated pointer (nullptr on failure).
+  /// @returns The hsa_status_t so callers can ASSERT on the specific failure
+  /// (OOM, invalid pool) rather than only observing a null pointer.
+  [[nodiscard]] hsa_status_t alloc_device(hsa_amd_memory_pool_t pool, size_t bytes, void **out) {
+    void *ptr = nullptr;
+    hsa_status_t st = hsa_amd_memory_pool_allocate(pool, bytes, 0, &ptr);
+    if (st == HSA_STATUS_SUCCESS && ptr)
+      device_allocs.push_back(ptr);
+    *out = (st == HSA_STATUS_SUCCESS) ? ptr : nullptr;
+    return st;
+  }
+
+  ~HsaDispatchResources() {
     // Stop queue execution before releasing anything referenced by an AQL
     // packet. This also makes an assertion after a dispatch timeout safe: the
     // test must not leave a live simulator dispatch for hsa_shut_down().
@@ -385,12 +416,8 @@ struct HsaMatmulResources {
       hsa_signal_destroy(signal);
     if (kernarg)
       hsa_amd_memory_pool_free(kernarg);
-    if (a)
-      hsa_amd_memory_pool_free(a);
-    if (b)
-      hsa_amd_memory_pool_free(b);
-    if (c)
-      hsa_amd_memory_pool_free(c);
+    for (void *ptr : device_allocs)
+      hsa_amd_memory_pool_free(ptr);
     if (executable_created)
       hsa_executable_destroy(executable);
     if (reader_created)
@@ -402,22 +429,25 @@ void run_dynamic_copy_loop(const std::vector<uint8_t> &elf_bytes, const Dispatch
   hsa_agent_t cpu = find_cpu_agent();
   ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
 
-  hsa_code_object_reader_t reader{};
-  auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(), &reader);
+  HsaDispatchResources resources;
+  auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(),
+                                                      &resources.reader);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  resources.reader_created = true;
 
-  hsa_executable_t executable{};
   st = hsa_executable_create_alt(HSA_PROFILE_FULL, HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT, nullptr,
-                                 &executable);
+                                 &resources.executable);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
-  st = hsa_executable_load_agent_code_object(executable, target.agent, reader, nullptr, nullptr);
+  resources.executable_created = true;
+  st = hsa_executable_load_agent_code_object(resources.executable, target.agent, resources.reader,
+                                             nullptr, nullptr);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
-  st = hsa_executable_freeze(executable, nullptr);
+  st = hsa_executable_freeze(resources.executable, nullptr);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
 
   hsa_executable_symbol_t symbol{};
-  st =
-      hsa_executable_get_symbol_by_name(executable, "dynamic_copy_loop.kd", &target.agent, &symbol);
+  st = hsa_executable_get_symbol_by_name(resources.executable, "dynamic_copy_loop.kd",
+                                         &target.agent, &symbol);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
 
   uint64_t kernel_object = 0;
@@ -432,14 +462,12 @@ void run_dynamic_copy_loop(const std::vector<uint8_t> &elf_bytes, const Dispatch
 
   auto gpu_pool = find_pool(target.agent, HSA_AMD_SEGMENT_GLOBAL);
   ASSERT_NE(gpu_pool.handle, 0u);
-  uint32_t *src_dev = nullptr;
-  uint32_t *dst_dev = nullptr;
-  ASSERT_EQ(
-      hsa_amd_memory_pool_allocate(gpu_pool, kMaxBytes, 0, reinterpret_cast<void **>(&src_dev)),
-      HSA_STATUS_SUCCESS);
-  ASSERT_EQ(
-      hsa_amd_memory_pool_allocate(gpu_pool, kMaxBytes, 0, reinterpret_cast<void **>(&dst_dev)),
-      HSA_STATUS_SUCCESS);
+  void *src_raw = nullptr;
+  ASSERT_EQ(resources.alloc_device(gpu_pool, kMaxBytes, &src_raw), HSA_STATUS_SUCCESS);
+  auto *src_dev = static_cast<uint32_t *>(src_raw);
+  void *dst_raw = nullptr;
+  ASSERT_EQ(resources.alloc_device(gpu_pool, kMaxBytes, &dst_raw), HSA_STATUS_SUCCESS);
+  auto *dst_dev = static_cast<uint32_t *>(dst_raw);
 
   hsa_agent_t both[] = {cpu, target.agent};
   ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, src_dev), HSA_STATUS_SUCCESS);
@@ -447,8 +475,9 @@ void run_dynamic_copy_loop(const std::vector<uint8_t> &elf_bytes, const Dispatch
 
   auto kernarg_pool = find_pool(cpu, HSA_AMD_SEGMENT_GLOBAL, true);
   ASSERT_NE(kernarg_pool.handle, 0u);
-  void *kernarg = nullptr;
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(kernarg_pool, 256, 0, &kernarg), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(kernarg_pool, 256, 0, &resources.kernarg),
+            HSA_STATUS_SUCCESS);
+  void *kernarg = resources.kernarg;
   ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, kernarg), HSA_STATUS_SUCCESS);
   std::memset(kernarg, 0, 256);
 
@@ -467,15 +496,16 @@ void run_dynamic_copy_loop(const std::vector<uint8_t> &elf_bytes, const Dispatch
   args->workgroup_size = kWorkgroupSize;
   args->stride = kDispatchWorkItems;
 
-  hsa_queue_t *queue = nullptr;
   uint32_t queue_size = 0;
   hsa_agent_get_info(target.agent, HSA_AGENT_INFO_QUEUE_MAX_SIZE, &queue_size);
   st = hsa_queue_create(target.agent, queue_size, HSA_QUEUE_TYPE_SINGLE, nullptr, nullptr,
-                        UINT32_MAX, UINT32_MAX, &queue);
+                        UINT32_MAX, UINT32_MAX, &resources.queue);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  hsa_queue_t *queue = resources.queue;
 
-  hsa_signal_t signal{};
-  ASSERT_EQ(hsa_signal_create(1, 0, nullptr, &signal), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_signal_create(1, 0, nullptr, &resources.signal), HSA_STATUS_SUCCESS);
+  resources.signal_created = true;
+  hsa_signal_t signal = resources.signal;
 
   const std::array<uint32_t, 12> shapes = {0, 1, 17, 63, 64, 65, 255, 256, 257, 1024, 4097, kMaxN};
   std::vector<uint32_t> src_host(kMaxN);
@@ -538,14 +568,7 @@ void run_dynamic_copy_loop(const std::vector<uint8_t> &elf_bytes, const Dispatch
     }
     EXPECT_EQ(mismatches, 0u) << mismatches << " mismatches for N=" << n;
   }
-
-  hsa_signal_destroy(signal);
-  hsa_queue_destroy(queue);
-  hsa_amd_memory_pool_free(kernarg);
-  hsa_amd_memory_pool_free(src_dev);
-  hsa_amd_memory_pool_free(dst_dev);
-  hsa_executable_destroy(executable);
-  hsa_code_object_reader_destroy(reader);
+  // Resources released by HsaDispatchResources::~ (queue first).
 }
 
 void translate_triton_fixture(const char *name, uint32_t mach, std::vector<uint8_t> &elf_bytes,
@@ -575,7 +598,7 @@ void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const DispatchTarg
   hsa_agent_t cpu = find_cpu_agent();
   ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
 
-  HsaMatmulResources resources;
+  HsaDispatchResources resources;
   auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(),
                                                       &resources.reader);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
@@ -618,12 +641,15 @@ void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const DispatchTarg
 
   auto gpu_pool = find_pool(target.agent, HSA_AMD_SEGMENT_GLOBAL);
   ASSERT_NE(gpu_pool.handle, 0u);
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kABytes, 0, &resources.a), HSA_STATUS_SUCCESS);
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kBBytes, 0, &resources.b), HSA_STATUS_SUCCESS);
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kCBytes, 0, &resources.c), HSA_STATUS_SUCCESS);
-  auto *a_dev = static_cast<uint16_t *>(resources.a);
-  auto *b_dev = static_cast<uint16_t *>(resources.b);
-  auto *c_dev = static_cast<float *>(resources.c);
+  void *a_raw = nullptr;
+  ASSERT_EQ(resources.alloc_device(gpu_pool, kABytes, &a_raw), HSA_STATUS_SUCCESS);
+  auto *a_dev = static_cast<uint16_t *>(a_raw);
+  void *b_raw = nullptr;
+  ASSERT_EQ(resources.alloc_device(gpu_pool, kBBytes, &b_raw), HSA_STATUS_SUCCESS);
+  auto *b_dev = static_cast<uint16_t *>(b_raw);
+  void *c_raw = nullptr;
+  ASSERT_EQ(resources.alloc_device(gpu_pool, kCBytes, &c_raw), HSA_STATUS_SUCCESS);
+  auto *c_dev = static_cast<float *>(c_raw);
 
   hsa_agent_t both[] = {cpu, target.agent};
   ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, a_dev), HSA_STATUS_SUCCESS);
@@ -740,21 +766,24 @@ void run_buffer_async_triton_matmul(const std::vector<uint8_t> &elf_bytes,
   hsa_agent_t cpu = find_cpu_agent();
   ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
 
-  hsa_code_object_reader_t reader{};
-  auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(), &reader);
+  HsaDispatchResources resources;
+  auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(),
+                                                      &resources.reader);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  resources.reader_created = true;
 
-  hsa_executable_t executable{};
   st = hsa_executable_create_alt(HSA_PROFILE_FULL, HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT, nullptr,
-                                 &executable);
+                                 &resources.executable);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
-  st = hsa_executable_load_agent_code_object(executable, target.agent, reader, nullptr, nullptr);
+  resources.executable_created = true;
+  st = hsa_executable_load_agent_code_object(resources.executable, target.agent, resources.reader,
+                                             nullptr, nullptr);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
-  st = hsa_executable_freeze(executable, nullptr);
+  st = hsa_executable_freeze(resources.executable, nullptr);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
 
   hsa_executable_symbol_t symbol{};
-  st = hsa_executable_get_symbol_by_name(executable, "matmul_async_buffer_load_lds.kd",
+  st = hsa_executable_get_symbol_by_name(resources.executable, "matmul_async_buffer_load_lds.kd",
                                          &target.agent, &symbol);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
 
@@ -783,15 +812,15 @@ void run_buffer_async_triton_matmul(const std::vector<uint8_t> &elf_bytes,
 
   auto gpu_pool = find_pool(target.agent, HSA_AMD_SEGMENT_GLOBAL);
   ASSERT_NE(gpu_pool.handle, 0u);
-  uint16_t *a_dev = nullptr;
-  uint16_t *b_dev = nullptr;
-  float *c_dev = nullptr;
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kABytes, 0, reinterpret_cast<void **>(&a_dev)),
-            HSA_STATUS_SUCCESS);
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kBBytes, 0, reinterpret_cast<void **>(&b_dev)),
-            HSA_STATUS_SUCCESS);
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kCBytes, 0, reinterpret_cast<void **>(&c_dev)),
-            HSA_STATUS_SUCCESS);
+  void *a_raw = nullptr;
+  ASSERT_EQ(resources.alloc_device(gpu_pool, kABytes, &a_raw), HSA_STATUS_SUCCESS);
+  auto *a_dev = static_cast<uint16_t *>(a_raw);
+  void *b_raw = nullptr;
+  ASSERT_EQ(resources.alloc_device(gpu_pool, kBBytes, &b_raw), HSA_STATUS_SUCCESS);
+  auto *b_dev = static_cast<uint16_t *>(b_raw);
+  void *c_raw = nullptr;
+  ASSERT_EQ(resources.alloc_device(gpu_pool, kCBytes, &c_raw), HSA_STATUS_SUCCESS);
+  auto *c_dev = static_cast<float *>(c_raw);
 
   hsa_agent_t both[] = {cpu, target.agent};
   ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, a_dev), HSA_STATUS_SUCCESS);
@@ -800,8 +829,9 @@ void run_buffer_async_triton_matmul(const std::vector<uint8_t> &elf_bytes,
 
   auto kernarg_pool = find_pool(cpu, HSA_AMD_SEGMENT_GLOBAL, true);
   ASSERT_NE(kernarg_pool.handle, 0u);
-  void *kernarg = nullptr;
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(kernarg_pool, 64, 0, &kernarg), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(kernarg_pool, 64, 0, &resources.kernarg),
+            HSA_STATUS_SUCCESS);
+  void *kernarg = resources.kernarg;
   ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, kernarg), HSA_STATUS_SUCCESS);
   std::memset(kernarg, 0, 64);
 
@@ -841,15 +871,16 @@ void run_buffer_async_triton_matmul(const std::vector<uint8_t> &elf_bytes,
   ASSERT_EQ(hsa_memory_copy(b_dev, b_host.data(), kBBytes), HSA_STATUS_SUCCESS);
   ASSERT_EQ(hsa_memory_copy(c_dev, c_init.data(), kCBytes), HSA_STATUS_SUCCESS);
 
-  hsa_queue_t *queue = nullptr;
   uint32_t queue_size = 0;
   hsa_agent_get_info(target.agent, HSA_AGENT_INFO_QUEUE_MAX_SIZE, &queue_size);
   st = hsa_queue_create(target.agent, queue_size, HSA_QUEUE_TYPE_SINGLE, nullptr, nullptr,
-                        UINT32_MAX, UINT32_MAX, &queue);
+                        UINT32_MAX, UINT32_MAX, &resources.queue);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  hsa_queue_t *queue = resources.queue;
 
-  hsa_signal_t signal{};
-  ASSERT_EQ(hsa_signal_create(1, 0, nullptr, &signal), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_signal_create(1, 0, nullptr, &resources.signal), HSA_STATUS_SUCCESS);
+  resources.signal_created = true;
+  hsa_signal_t signal = resources.signal;
   hsa_signal_store_relaxed(signal, 1);
 
   const uint64_t write_idx = hsa_queue_add_write_index_relaxed(queue, 1);
@@ -883,15 +914,7 @@ void run_buffer_async_triton_matmul(const std::vector<uint8_t> &elf_bytes,
 
   if (observed)
     *observed = std::move(c_host);
-
-  hsa_signal_destroy(signal);
-  hsa_queue_destroy(queue);
-  hsa_amd_memory_pool_free(kernarg);
-  hsa_amd_memory_pool_free(a_dev);
-  hsa_amd_memory_pool_free(b_dev);
-  hsa_amd_memory_pool_free(c_dev);
-  hsa_executable_destroy(executable);
-  hsa_code_object_reader_destroy(reader);
+  // Resources released by HsaDispatchResources::~ (queue first).
 }
 
 void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const DispatchTarget &target,
@@ -903,21 +926,24 @@ void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const Dis
   ASSERT_LE(shared_bytes, 65536u)
       << "gfx942 dispatch must stay within the 64 KiB LDS limit until LDS virtualization exists";
 
-  hsa_code_object_reader_t reader{};
-  auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(), &reader);
+  HsaDispatchResources resources;
+  auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(),
+                                                      &resources.reader);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  resources.reader_created = true;
 
-  hsa_executable_t executable{};
   st = hsa_executable_create_alt(HSA_PROFILE_FULL, HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT, nullptr,
-                                 &executable);
+                                 &resources.executable);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
-  st = hsa_executable_load_agent_code_object(executable, target.agent, reader, nullptr, nullptr);
+  resources.executable_created = true;
+  st = hsa_executable_load_agent_code_object(resources.executable, target.agent, resources.reader,
+                                             nullptr, nullptr);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
-  st = hsa_executable_freeze(executable, nullptr);
+  st = hsa_executable_freeze(resources.executable, nullptr);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
 
   hsa_executable_symbol_t symbol{};
-  st = hsa_executable_get_symbol_by_name(executable, symbol_name, &target.agent, &symbol);
+  st = hsa_executable_get_symbol_by_name(resources.executable, symbol_name, &target.agent, &symbol);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
 
   uint64_t kernel_object = 0;
@@ -936,18 +962,18 @@ void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const Dis
 
   auto gpu_pool = find_pool(target.agent, HSA_AMD_SEGMENT_GLOBAL);
   ASSERT_NE(gpu_pool.handle, 0u);
-  uint16_t *q_dev = nullptr;
-  uint16_t *k_dev = nullptr;
-  uint16_t *v_dev = nullptr;
-  float *o_dev = nullptr;
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kQBytes, 0, reinterpret_cast<void **>(&q_dev)),
-            HSA_STATUS_SUCCESS);
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kKVBytes, 0, reinterpret_cast<void **>(&k_dev)),
-            HSA_STATUS_SUCCESS);
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kKVBytes, 0, reinterpret_cast<void **>(&v_dev)),
-            HSA_STATUS_SUCCESS);
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kOBytes, 0, reinterpret_cast<void **>(&o_dev)),
-            HSA_STATUS_SUCCESS);
+  void *q_raw = nullptr;
+  ASSERT_EQ(resources.alloc_device(gpu_pool, kQBytes, &q_raw), HSA_STATUS_SUCCESS);
+  auto *q_dev = static_cast<uint16_t *>(q_raw);
+  void *k_raw = nullptr;
+  ASSERT_EQ(resources.alloc_device(gpu_pool, kKVBytes, &k_raw), HSA_STATUS_SUCCESS);
+  auto *k_dev = static_cast<uint16_t *>(k_raw);
+  void *v_raw = nullptr;
+  ASSERT_EQ(resources.alloc_device(gpu_pool, kKVBytes, &v_raw), HSA_STATUS_SUCCESS);
+  auto *v_dev = static_cast<uint16_t *>(v_raw);
+  void *o_raw = nullptr;
+  ASSERT_EQ(resources.alloc_device(gpu_pool, kOBytes, &o_raw), HSA_STATUS_SUCCESS);
+  auto *o_dev = static_cast<float *>(o_raw);
 
   hsa_agent_t both[] = {cpu, target.agent};
   ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, q_dev), HSA_STATUS_SUCCESS);
@@ -957,8 +983,9 @@ void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const Dis
 
   auto kernarg_pool = find_pool(cpu, HSA_AMD_SEGMENT_GLOBAL, true);
   ASSERT_NE(kernarg_pool.handle, 0u);
-  void *kernarg = nullptr;
-  ASSERT_EQ(hsa_amd_memory_pool_allocate(kernarg_pool, 64, 0, &kernarg), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(kernarg_pool, 64, 0, &resources.kernarg),
+            HSA_STATUS_SUCCESS);
+  void *kernarg = resources.kernarg;
   ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, kernarg), HSA_STATUS_SUCCESS);
   std::memset(kernarg, 0, 64);
 
@@ -997,15 +1024,16 @@ void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const Dis
   ASSERT_EQ(hsa_memory_copy(v_dev, v_host.data(), kKVBytes), HSA_STATUS_SUCCESS);
   ASSERT_EQ(hsa_memory_copy(o_dev, o_init.data(), kOBytes), HSA_STATUS_SUCCESS);
 
-  hsa_queue_t *queue = nullptr;
   uint32_t queue_size = 0;
   hsa_agent_get_info(target.agent, HSA_AGENT_INFO_QUEUE_MAX_SIZE, &queue_size);
   st = hsa_queue_create(target.agent, queue_size, HSA_QUEUE_TYPE_SINGLE, nullptr, nullptr,
-                        UINT32_MAX, UINT32_MAX, &queue);
+                        UINT32_MAX, UINT32_MAX, &resources.queue);
   ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  hsa_queue_t *queue = resources.queue;
 
-  hsa_signal_t signal{};
-  ASSERT_EQ(hsa_signal_create(1, 0, nullptr, &signal), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_signal_create(1, 0, nullptr, &resources.signal), HSA_STATUS_SUCCESS);
+  resources.signal_created = true;
+  hsa_signal_t signal = resources.signal;
   hsa_signal_store_relaxed(signal, 1);
 
   const uint64_t write_idx = hsa_queue_add_write_index_relaxed(queue, 1);
@@ -1039,16 +1067,7 @@ void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const Dis
 
   if (observed)
     *observed = std::move(o_host);
-
-  hsa_signal_destroy(signal);
-  hsa_queue_destroy(queue);
-  hsa_amd_memory_pool_free(kernarg);
-  hsa_amd_memory_pool_free(q_dev);
-  hsa_amd_memory_pool_free(k_dev);
-  hsa_amd_memory_pool_free(v_dev);
-  hsa_amd_memory_pool_free(o_dev);
-  hsa_executable_destroy(executable);
-  hsa_code_object_reader_destroy(reader);
+  // Resources released by HsaDispatchResources::~ (queue first).
 }
 
 } // namespace


### PR DESCRIPTION
## Motivation

Issue https://github.com/ROCm/rocm-systems/issues/8818 (recycled doorbell can lose or falsely complete replacement queue work) had two halves: a runtime doorbell bug and a test-lifetime weakness that masked its symptoms. The runtime fix landed in https://github.com/ROCm/rocm-systems/pull/8672. This change addresses the test-lifetime half.

In the CDNA4->CDNA3 dispatch tests, a lost or timed-out dispatch did not surface as a clean test failure. It appeared as a confusing exit-time segmentation fault, because the affected helpers only released their queue and packet-referenced
resources on the success path. When a dispatch failed, the queue was left alive with a pending simulator dispatch that still referenced freed packet operands, and hsa_shut_down() then tore into that live state. That misdirection cost real debugging time while diagnosing https://github.com/ROCm/rocm-systems/issues/8818, so the tests must fail cleanly and deterministically regardless of dispatch outcome.

Three helpers in cdna4_to_cdna3_dispatch_test.cpp — run_dynamic_copy_loop, run_buffer_async_triton_matmul, and run_flash_attention_triton — created a code-object reader, executable, device/kernarg pool allocations, a queue, and a
completion signal, then released them via manual cleanup at the function tail, AFTER the ASSERT_EQ on the completion-signal wait (and after the result-verifying assertions). Any early return — a dispatch timeout, a signal-wait mismatch, or a
verification failure — skipped that cleanup entirely, leaking the queue and leaving a live dispatch for hsa_shut_down() to trip over. Only run_triton_matmul already used an RAII owner (HsaMatmulResources).

## Technical Details

- Generalize HsaMatmulResources into a single reusable HsaDispatchResources. It replaces the fixed a/b/c buffer members with a device_allocs vector plus an alloc_device(pool, bytes, out) helper that allocates a global-pool block, records it for destruction, and returns the hsa_status_t so a failed allocation reports the actual OOM/invalid-pool error rather than only a null pointer. It covers helpers with two, three, or four device buffers uniformly.
- Its destructor destroys the queue FIRST, stopping queue execution before releasing anything an in-flight AQL packet can reference, then the completion signal, kernarg, recorded device allocations, executable, and reader. Because
  it is a stack RAII owner, this ordering runs on every exit path — success, assertion, or timeout.
- Mark HsaDispatchResources non-copyable and non-movable (deleted copy/move constructors and assignment): it is the sole owner of raw HSA handles and allocation pointers, so an accidental copy would double-free/destroy in the dtor. All call sites use it as a local, so deleting copy and move is sufficient.
- Convert all four helpers to HsaDispatchResources and delete their manual tail-cleanup blocks. Callers keep local typed pointers (a_dev, q_dev, etc.) into the recorded allocations for packet setup and verification; ownership lives
  in the resources object.

## Issue Tracking

#8818

## Test Plan

Run all CI tests

## Test Result

All CI tests: PASSED

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
