### PR TITLE
fix(clr): Serialize shared HW-ring publish to fix MT hang (AIRUNTIME-2291)

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -238,6 +238,7 @@ Device::~Device() {
       ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE, "Deleting hardware queue %p with refCount 0",
               queue->base_address);
       qIter = it.erase(qIter);
+      EraseRingTurnstile(queue);
       Hsa::queue_destroy(queue);
     }
   }
@@ -3621,9 +3622,32 @@ void Device::releaseQueue(hsa_queue_t* queue, const std::vector<uint32_t>& cuMas
     } else {
       ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting CG enabled hardware queue %p ",
               queue->base_address);
+      EraseRingTurnstile(queue);
       Hsa::queue_destroy(queue);
     }
   }
+}
+
+std::shared_ptr<RingTurnstile> Device::GetOrCreateRingTurnstile(hsa_queue_t* queue) {
+  if (queue == nullptr) {
+    return nullptr;
+  }
+  amd::ScopedLock l(ringTurnstilesLock_);
+  auto it = ringTurnstiles_.find(queue);
+  if (it != ringTurnstiles_.end()) {
+    return it->second;
+  }
+  auto turnstile = std::make_shared<RingTurnstile>();
+  ringTurnstiles_.emplace(queue, turnstile);
+  return turnstile;
+}
+
+void Device::EraseRingTurnstile(hsa_queue_t* queue) {
+  if (queue == nullptr) {
+    return;
+  }
+  amd::ScopedLock l(ringTurnstilesLock_);
+  ringTurnstiles_.erase(queue);
 }
 
 size_t Device::DeferredQueueCount() {
@@ -3641,6 +3665,7 @@ void Device::DrainDeferredQueueDestroys() {
   }
   for (hsa_queue_t* queue : pending) {
     ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting deferred hardware queue %p", queue->base_address);
+    EraseRingTurnstile(queue);
     Hsa::queue_destroy(queue);
   }
 }

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -604,6 +604,15 @@ class Device : public NullDevice {
                                    void** metadata_ring_buffer = nullptr);
   bool ReleaseActiveQueue(hsa_queue_t* queue, amd::CommandQueue::Priority priority);
 
+  //! Return the shared FIFO turnstile for \p queue, creating it on first use.
+  //! Two VirtualGPUs on the same HW ring get the SAME turnstile. Never returns
+  //! nullptr for a non-null queue (keyed on the queue pointer, so it covers
+  //! pooled, dedicated, cooperative and CU-masked queues alike).
+  std::shared_ptr<RingTurnstile> GetOrCreateRingTurnstile(hsa_queue_t* queue);
+
+  //! Drop the turnstile for a ring once it is truly destroyed (refCount 0).
+  void EraseRingTurnstile(hsa_queue_t* queue);
+
   //! Return the pre-computed metadata packet version header bits
   uint32_t MetadataVersionHeader() const { return metadata_version_header_; }
 
@@ -783,6 +792,14 @@ class Device : public NullDevice {
   //! a vector for keeping Pool of HSA queues with low, normal and high priorities for recycling
   std::vector<std::map<hsa_queue_t*, QueueInfo, QueueCompare>> queuePool_;
   amd::Monitor active_queue_access_;            //!< Lock to serialise virtual gpu list access
+
+  //! One FIFO turnstile per physical HW ring, keyed on the hsa_queue_t*. Shared
+  //! (shared_ptr) so a VirtualGPU can cache it and keep it alive across a submit
+  //! even if the ring is released from the pool concurrently. The map itself is
+  //! guarded by ringTurnstilesLock_ (only for lookup/insert; the turnstile's own
+  //! atomics carry the per-submit ordering, held no map lock during submission).
+  std::map<hsa_queue_t*, std::shared_ptr<RingTurnstile>> ringTurnstiles_;
+  amd::Monitor ringTurnstilesLock_;            //!< Protects ringTurnstiles_ lookups/inserts
   std::atomic<uint32_t> num_queues_[QueuePriority::Total] = {};  //!< Per-priority queue counters
 
   //! Use dynamic queues mode to get a queue from pool

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -610,7 +610,9 @@ class Device : public NullDevice {
   //! pooled, dedicated, cooperative and CU-masked queues alike).
   std::shared_ptr<RingTurnstile> GetOrCreateRingTurnstile(hsa_queue_t* queue);
 
-  //! Drop the turnstile for a ring once it is truly destroyed (refCount 0).
+  //! Remove the map entry for \p queue at a queue-destroy site. Any VirtualGPU
+  //! still holding a shared_ptr keeps the turnstile alive past this call —
+  //! lifetime is refcounted by shared_ptr, not by a check here.
   void EraseRingTurnstile(hsa_queue_t* queue);
 
   //! Return the pre-computed metadata packet version header bits

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1233,6 +1233,12 @@ bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address para
 // ================================================================================================
 void VirtualGPU::SetGpuQueue(hsa_queue_t* queue, void* metadata_ring_buffer) {
   gpu_queue_ = queue;
+  // Bind the per-ring FIFO turnstile so submissions on a multiplexed HW ring
+  // serialize against other VirtualGPUs sharing it. This is the ONLY site that
+  // assigns gpu_queue_ a non-null value, so ring_turnstile_ always tracks the
+  // current ring. GetOrCreateRingTurnstile never returns null for a non-null
+  // queue, so the guard can never silently degrade to a no-op on a real ring.
+  ring_turnstile_ = roc_device_.GetOrCreateRingTurnstile(queue);
   cached_read_dispatch_id_ = 0;
   // The cached queue-progress state belongs to the previously assigned HW queue. When the HW
   // queue changes (released back to / reacquired from the shared dynamic-queue pool), that state
@@ -1377,6 +1383,15 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
   const uint32_t queueMask = queueSize - 1;
   const uint32_t sw_queue_size = queueMask;
 
+  // Serialize reserve->write->publish->doorbell against other VirtualGPUs sharing
+  // this ring. Enter the FIFO turnstile BEFORE the write-index reservation so the
+  // reservation order equals the publish/doorbell order: the GPU can never be
+  // advanced past a slot whose header is not yet published. Left before the
+  // blocking wait below. No-op only when the ring is unbound.
+  RingTurnstile* ring = ring_turnstile_.get();
+  uint64_t ticket = 0;
+  if (ring != nullptr) ticket = ring->enter();
+
   // Check for queue full and wait if needed.
   uint64_t index = Hsa::queue_add_write_index_screlease(gpu_queue_, 1);
   adjustHeader(header);
@@ -1447,6 +1462,11 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
   } else {
     ++skippedDispatches_;
   }
+
+  // Publication + doorbell are complete and contiguous; hand the turn to the next
+  // producer before any blocking wait so a peer VirtualGPU on this ring can make
+  // progress (and so we never hold the turn across a GPU-completion wait).
+  if (ring != nullptr) ring->leave(ticket);
 
   // Mark the flag indicating if a dispatch is outstanding.
   // We are not waiting after every dispatch.
@@ -1605,6 +1625,16 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
   }
 
   uint8_t* queueBase = static_cast<uint8_t*>(gpu_queue_->base_address);
+
+  // Serialize reserve->write->publish->doorbell against other VirtualGPUs sharing
+  // this ring. Entered after dispatchBlockingWait above (which may recursively
+  // dispatch barrier packets through the same turnstile) and before the
+  // write-index reservation, so the whole batch publishes contiguously and the
+  // GPU is never advanced past an unpublished slot. Left after the chunk loop and
+  // before any blocking wait.
+  RingTurnstile* ring = ring_turnstile_.get();
+  uint64_t ticket = 0;
+  if (ring != nullptr) ticket = ring->enter();
 
   // Reserve ALL slots with a single wptr bump, then submit in kPeriod-sized chunks.
   // Per-chunk: yield if the queue is full (handles graphs larger than the queue), then
@@ -1818,6 +1848,10 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
 
   TrackQueueProgress(*finalLastSlot, startIndex + numPackets - 1, pre_patched);
 
+  // All chunks published and doorbelled contiguously; hand the turn to the next
+  // producer before any blocking wait so peers on this ring can proceed.
+  if (ring != nullptr) ring->leave(ticket);
+
   if (blocking) {
     LogInfo("Running serialized as blocking is requested");
     if (!Barriers().WaitCurrent()) {
@@ -1878,6 +1912,14 @@ void VirtualGPU::dispatchBarrierPacket(uint16_t packetHeader, bool skipSignal,
     }
   }
 
+  // Serialize reserve->write->publish->doorbell against other VirtualGPUs sharing
+  // this ring. Entered AFTER the recursive barrier flush above (each nested call
+  // enters/leaves the turnstile on its own, so there is no re-entrancy held here)
+  // and before the reservation, so publication stays contiguous.
+  RingTurnstile* ring = ring_turnstile_.get();
+  uint64_t ticket = 0;
+  if (ring != nullptr) ticket = ring->enter();
+
   uint64_t index = Hsa::queue_add_write_index_screlease(gpu_queue_, 1);
 
   setFenceDirty(true);
@@ -1910,6 +1952,7 @@ void VirtualGPU::dispatchBarrierPacket(uint16_t packetHeader, bool skipSignal,
   packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), packetHeader, 0);
 
   Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
+  if (ring != nullptr) ring->leave(ticket);
   if (IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) {
     logAqlBarrierPacket(roc_device_, gpu_queue_, packetHeader, &barrier_packet_, index, priority_);
   }
@@ -1979,6 +2022,13 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
     setFenceDirty(false);
   }
 
+  // Serialize reserve->write->publish->doorbell against other VirtualGPUs sharing
+  // this ring. Entered AFTER any recursive barrier flush above and before the
+  // reservation, so publication stays contiguous.
+  RingTurnstile* ring = ring_turnstile_.get();
+  uint64_t ticket = 0;
+  if (ring != nullptr) ticket = ring->enter();
+
   uint64_t index = Hsa::queue_add_write_index_screlease(gpu_queue_, 1);
 
   TrackQueueProgress(barrier_value_packet_, index, external_signal);
@@ -1990,6 +2040,7 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
   metadata_preloader_.Set(&barrier_value_packet_, packetHeader, index & queueMask);
   packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), packetHeader, rest);
   Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
+  if (ring != nullptr) ring->leave(ticket);
 
   if (IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) {
     logAqlBarrierValuePacket(roc_device_, gpu_queue_, packetHeader, &barrier_value_packet_, index,

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -32,6 +32,33 @@ class Timestamp;
 //! True while the calling thread is inside HsaAmdSignalHandler (async-events thread).
 bool InAsyncSignalHandler();
 
+//! Fair FIFO turnstile that serializes the reserve->write->publish->doorbell
+//! sequence of every VirtualGPU mapped to one physical HW ring. A producer draws
+//! a ticket, cooperatively yields until it is being served, submits, then hands
+//! the turn to the next ticket. This guarantees the GPU never observes a
+//! published frontier with an unpublished slot below it, without a blocking mutex
+//! (waiters yield instead of sleeping). Defined here (included early, before
+//! rocdevice.hpp completes Device) so both rocdevice and rocvirtual can use it.
+struct RingTurnstile {
+  std::atomic<uint64_t> next_ticket_{0};  //!< Next ticket handed out (drawn with fetch_add)
+  std::atomic<uint64_t> now_serving_{0};  //!< Ticket currently allowed to submit
+
+  //! Draw a ticket and wait (yield-spin) until it is our turn. Returns the
+  //! ticket, which must be passed to leave().
+  uint64_t enter() {
+    const uint64_t ticket = next_ticket_.fetch_add(1, std::memory_order_relaxed);
+    while (now_serving_.load(std::memory_order_acquire) != ticket) {
+      amd::Os::yield();
+    }
+    return ticket;
+  }
+
+  //! Hand the turn to the next ticket. Must be called exactly once per enter().
+  void leave(uint64_t ticket) {
+    now_serving_.store(ticket + 1, std::memory_order_release);
+  }
+};
+
 // Initial HSA signal value
 constexpr static hsa_signal_value_t kInitSignalValueOne = 1;
 
@@ -826,6 +853,12 @@ class VirtualGPU : public device::VirtualDevice {
   void* last_barrier_hw_event_ = nullptr;
   hsa_agent_t gpu_device_;  //!< Physical device
   hsa_queue_t* gpu_queue_;  //!< Active queue associated with a vgpu
+  //! FIFO turnstile for gpu_queue_'s ring, shared across every VirtualGPU mapped
+  //! to the same HW ring. Cached in SetGpuQueue so it always tracks gpu_queue_.
+  //! Producers serialize their reserve->write->publish->doorbell span through it
+  //! (yield-spin, not a blocking lock) so the GPU never sees a published frontier
+  //! with an unpublished slot below it. nullptr only while gpu_queue_ is nullptr.
+  std::shared_ptr<RingTurnstile> ring_turnstile_;
   hsa_barrier_and_packet_t barrier_packet_ {};
   hsa_amd_barrier_value_packet_t barrier_value_packet_ {};
 

--- a/projects/hip-tests/catch/config/configs/unit/multiThread.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/multiThread.yaml
@@ -4,7 +4,7 @@ multiThread:
     <<: *level_2
     tags: [memory]
     # AIRUNTIME-2291: temporarily disabled (hangs in CI 942)
-    disabled: [amd_windows, amd_wsl, amd_linux]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipMultiThreadDevice_Streams:
     <<: *level_2
     tags: [device_mgmt]


### PR DESCRIPTION
## Motivation
`Unit_hipMemsetAsync_QueueJobsMultithreaded` intermittently hangs on MI300X (gfx942) — observed across many unrelated CI runs, always shard 2, killed after 120 min. Tracked in **AIRUNTIME-2291**, which mitigated CI impact by temporarily disabling the test. This PR fixes the root cause.

The hang is a runtime defect, not a test bug. The test spawns many threads, each driving its own stream with an independent memset → memcpy → event sequence — a fully supported HIP pattern with no shared state between threads. HIP streams are multiplexed onto a small pool of shared hardware AQL rings, capped by `GPU_MAX_HW_QUEUES` (default **4**). When more streams are live than the cap, multiple `VirtualGPU`s share one physical `hsa_queue_t` ring. Each VGPU serialized ring writes only against its **own** per-VGPU `execution_` mutex — there was **no serialization bound to the ring itself**.

The atomic write-index reservation advances the GPU's consume horizon **before** the slot's header is published. With no cross-producer serialization, a second producer can publish its own (later) slot and ring the doorbell while an earlier slot is still unpublished. The in-order command processor then reaches the unpublished slot and either:

- parks on it (`HSA_PACKET_TYPE_INVALID`) → silent hang, all threads stuck in `CpuWaitForSignal` (clean dmesg, no KGD detection — the GPU is legitimately idle-waiting on an unpublished slot, which is the correct HW behavior), or
- consumes it torn → `HSA_STATUS_ERROR_INVALID_CODE_OBJECT` abort on `__amd_rocclr_copyBuffer` (the rarer, ~2s fault variant of the same race).
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Bind a fair **FIFO turnstile** to each physical ring. A producer draws a ticket, cooperatively yields until it is being served, runs its whole reserve→write→publish→doorbell span, then hands the turn to the next ticket. The consume horizon therefore only ever advances over contiguously-published slots, so the GPU can never reach an unpublished slot. This keeps queue pooling at its efficient default while making sharing correct.

Files changed:
- `projects/clr/rocclr/device/rocm/rocdevice.hpp` / `.cpp`
- `projects/clr/rocclr/device/rocm/rocvirtual.hpp` / `.cpp`

| Component | Change |
|---|---|
| `RingTurnstile` (rocvirtual.hpp) | Two-atomic ticket lock (`next_ticket_` / `now_serving_`), `enter()`/`leave()`. Defined at namespace scope in rocvirtual.hpp because it is included before `Device` completes in rocdevice.hpp. |
| `ringTurnstiles_` map + `GetOrCreateRingTurnstile` / `EraseRingTurnstile` (rocdevice.hpp/.cpp) | One turnstile per physical ring, keyed on `hsa_queue_t*`, created on demand under `ringTurnstilesLock_`. **Never returns null for a real ring**, so the guard cannot silently degrade to a no-op. Erased at the three queue-destroy sites so a recycled `hsa_queue_t*` cannot alias a stale turnstile. |
| `VirtualGPU::ring_turnstile_` (rocvirtual.hpp) | Cached per-VGPU handle, set in `SetGpuQueue` — the sole non-null `gpu_queue_` assignment, so it always tracks the current ring. |
| 4 dispatch paths (rocvirtual.cpp) | `enter()`/`leave()` around the reserve→doorbell span. |
<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking
AIRUNTIME-2291 (partial — resolves the `QueueJobsMultithreaded` hang only)
<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan
- [x] MI300X: `Unit_hipMemsetAsync_QueueJobsMultithreaded` repro loop never hangs at default `GPU_MAX_HW_QUEUES`.
- [x] Both `DEBUG_HIP_DYNAMIC_QUEUES=0` and `=1`.
- [x] `GPU_MAX_HW_QUEUES=64` control still clean (no regression).
- [x] gfx1101 default + forced `GPU_MAX_HW_QUEUES=1` (exercises the shared-ring path): no deadlock/leak/stall.
- [ ] hip-tests shard 2 green in CI.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Hang is no longer seen on MI300x machine.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
