### PR TITLE
fix(rocprofiler-sdk): device_counting test failure in gfx1250 

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
@@ -82,7 +82,7 @@ target_link_libraries(
             GTest::gtest_main)
 
 set(_ROCPROFILER_SHARE_DIR
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME}")
+    "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME}")
 
 # unstable counter collection test: Generates HW exception leading to GPU hang or memory
 # access fault

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
@@ -6691,6 +6691,7 @@ rocprofiler-sdk:
             - gfx12
             - gfx1200
             - gfx1201
+            - gfx1250
             - gfx9
             - gfx900
             - gfx906


### PR DESCRIPTION
## Motivation

- Add gfx1250 to the supported architectures list for the SQ_WAVES_sum metric in config.yaml.
- Update counters unit tests to set ROCPROFILER_METRICS_PATH to the build-tree share directory (where config.yaml is generated via configure_file), avoiding reliance on an installed prefix.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

AIPROFSDK-986

## Test Plan

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
