### PR TITLE
[rocjitsu] Generate architecture traits from ISA profiles (NFC)

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -849,6 +849,11 @@ class _AmdgpuProfileBase(IsaProfile):
         return 256
 
     @property
+    def descriptor_sgpr_count_encoded(self) -> bool:
+        """Whether zero SGPR granule fields still use descriptor encoding."""
+        return True
+
+    @property
     def has_acc_vgpr(self) -> bool:
         """True if this ISA has AccVGPRs (CDNA2/3/4 only)."""
         return False
@@ -1239,6 +1244,10 @@ class Rdna1Profile(_AmdgpuProfileBase):
         return True
 
     @property
+    def descriptor_sgpr_count_encoded(self) -> bool:
+        return False
+
+    @property
     def waitcnt_family(self) -> str:
         return 'gfx10'
 
@@ -1355,6 +1364,10 @@ class Rdna3Profile(_AmdgpuProfileBase):
     @property
     def supports_wgp_mode(self) -> bool:
         return True
+
+    @property
+    def descriptor_sgpr_count_encoded(self) -> bool:
+        return False
 
     @property
     def waitcnt_family(self) -> str:
@@ -1496,6 +1509,10 @@ class Rdna4Profile(_AmdgpuProfileBase):
     @property
     def uses_ttmp_workgroup_ids(self) -> bool:
         return True
+
+    @property
+    def descriptor_sgpr_count_encoded(self) -> bool:
+        return False
 
     @property
     def waitcnt_family(self) -> str:

--- a/emulation/rocjitsu/lib/python/amdisa/isa_properties_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_properties_codegen.py
@@ -34,6 +34,9 @@ def emit_isa_properties(output_dir: str, specs) -> Path:
             continue
         enum_name = name.upper()
         supports_wgp_mode = 'true' if profile.supports_wgp_mode else 'false'
+        descriptor_sgpr_count_encoded = (
+            'true' if profile.descriptor_sgpr_count_encoded else 'false'
+        )
         uses_ttmp_workgroup_ids = 'true' if profile.uses_ttmp_workgroup_ids else 'false'
         uses_cluster_ttmp_workgroup_ids = (
             'true' if profile.uses_cluster_ttmp_workgroup_ids else 'false'
@@ -44,8 +47,9 @@ def emit_isa_properties(output_dir: str, specs) -> Path:
         )
         cases += [
             f'  case ROCJITSU_CODE_ARCH_{enum_name}:',
-            f'    return {{{supports_wgp_mode}, {uses_ttmp_workgroup_ids}, '
-            f'{uses_cluster_ttmp_workgroup_ids}, {addressable_vgprs}}};',
+            f'    return {{{supports_wgp_mode}, {descriptor_sgpr_count_encoded}, '
+            f'{uses_ttmp_workgroup_ids}, {uses_cluster_ttmp_workgroup_ids}, '
+            f'{addressable_vgprs}}};',
         ]
 
     lines = [
@@ -66,6 +70,7 @@ def emit_isa_properties(output_dir: str, specs) -> Path:
         '',
         'struct IsaProperties {',
         '  bool supports_wgp_mode = false;',
+        '  bool descriptor_sgpr_count_encoded = true;',
         '  bool uses_ttmp_workgroup_ids = false;',
         '  bool uses_cluster_ttmp_workgroup_ids = false;',
         '  uint32_t max_addressable_vgprs_per_wf = 0;',

--- a/emulation/rocjitsu/lib/python/amdisa/isa_properties_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_properties_codegen.py
@@ -47,9 +47,13 @@ def emit_isa_properties(output_dir: str, specs) -> Path:
         )
         cases += [
             f'  case ROCJITSU_CODE_ARCH_{enum_name}:',
-            f'    return {{{supports_wgp_mode}, {descriptor_sgpr_count_encoded}, '
-            f'{uses_ttmp_workgroup_ids}, {uses_cluster_ttmp_workgroup_ids}, '
-            f'{addressable_vgprs}}};',
+            '    return {',
+            f'        .supports_wgp_mode = {supports_wgp_mode},',
+            f'        .descriptor_sgpr_count_encoded = {descriptor_sgpr_count_encoded},',
+            f'        .uses_ttmp_workgroup_ids = {uses_ttmp_workgroup_ids},',
+            f'        .uses_cluster_ttmp_workgroup_ids = {uses_cluster_ttmp_workgroup_ids},',
+            f'        .max_addressable_vgprs_per_wf = {addressable_vgprs},',
+            '    };',
         ]
 
     lines = [

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
@@ -53,6 +53,20 @@ def test_ttmp_workgroup_id_properties(profile, uses_ttmp, uses_cluster_ttmp):
 @pytest.mark.parametrize(
     ('profile', 'expected'),
     [
+        (CdnaProfile(), True),
+        (Rdna1Profile(), False),
+        (Rdna3Profile(), False),
+        (Rdna4Profile(), False),
+        (Gfx1250Profile(), False),
+    ],
+)
+def test_descriptor_sgpr_count_encoded(profile, expected):
+    assert profile.descriptor_sgpr_count_encoded is expected
+
+
+@pytest.mark.parametrize(
+    ('profile', 'expected'),
+    [
         (CdnaProfile(), 256),
         (Rdna4Profile(), 256),
         (Gfx1250Profile(), 1024),
@@ -94,13 +108,15 @@ def test_isa_properties_codegen_uses_profile_values(tmp_path):
     assert 'uint32_t max_addressable_vgprs_per_wf = 0;' in output
     assert 'MAX_SUPPORTED_ADDRESSABLE_VGPRS_PER_WF = 1024;' in output
     assert (
-        'case ROCJITSU_CODE_ARCH_CDNA3:\n' '    return {false, false, false, 256};'
+        'case ROCJITSU_CODE_ARCH_CDNA3:\n'
+        '    return {false, true, false, false, 256};'
     ) in output
     assert (
-        'case ROCJITSU_CODE_ARCH_RDNA4:\n' '    return {true, true, false, 256};'
+        'case ROCJITSU_CODE_ARCH_RDNA4:\n' '    return {true, false, true, false, 256};'
     ) in output
     assert (
-        'case ROCJITSU_CODE_ARCH_GFX1250:\n' '    return {false, true, true, 1024};'
+        'case ROCJITSU_CODE_ARCH_GFX1250:\n'
+        '    return {false, false, true, true, 1024};'
     ) in output
 
 

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
@@ -109,14 +109,33 @@ def test_isa_properties_codegen_uses_profile_values(tmp_path):
     assert 'MAX_SUPPORTED_ADDRESSABLE_VGPRS_PER_WF = 1024;' in output
     assert (
         'case ROCJITSU_CODE_ARCH_CDNA3:\n'
-        '    return {false, true, false, false, 256};'
+        '    return {\n'
+        '        .supports_wgp_mode = false,\n'
+        '        .descriptor_sgpr_count_encoded = true,\n'
+        '        .uses_ttmp_workgroup_ids = false,\n'
+        '        .uses_cluster_ttmp_workgroup_ids = false,\n'
+        '        .max_addressable_vgprs_per_wf = 256,\n'
+        '    };'
     ) in output
     assert (
-        'case ROCJITSU_CODE_ARCH_RDNA4:\n' '    return {true, false, true, false, 256};'
+        'case ROCJITSU_CODE_ARCH_RDNA4:\n'
+        '    return {\n'
+        '        .supports_wgp_mode = true,\n'
+        '        .descriptor_sgpr_count_encoded = false,\n'
+        '        .uses_ttmp_workgroup_ids = true,\n'
+        '        .uses_cluster_ttmp_workgroup_ids = false,\n'
+        '        .max_addressable_vgprs_per_wf = 256,\n'
+        '    };'
     ) in output
     assert (
         'case ROCJITSU_CODE_ARCH_GFX1250:\n'
-        '    return {false, false, true, true, 1024};'
+        '    return {\n'
+        '        .supports_wgp_mode = false,\n'
+        '        .descriptor_sgpr_count_encoded = false,\n'
+        '        .uses_ttmp_workgroup_ids = true,\n'
+        '        .uses_cluster_ttmp_workgroup_ids = true,\n'
+        '        .max_addressable_vgprs_per_wf = 1024,\n'
+        '    };'
     ) in output
 
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/isa_properties.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/isa_properties.h
@@ -15,6 +15,7 @@ namespace rocjitsu {
 
 struct IsaProperties {
   bool supports_wgp_mode = false;
+  bool descriptor_sgpr_count_encoded = true;
   bool uses_ttmp_workgroup_ids = false;
   bool uses_cluster_ttmp_workgroup_ids = false;
   uint32_t max_addressable_vgprs_per_wf = 0;
@@ -25,25 +26,25 @@ inline constexpr uint32_t MAX_SUPPORTED_ADDRESSABLE_VGPRS_PER_WF = 1024;
 [[nodiscard]] constexpr IsaProperties isa_properties(rj_code_arch_t arch) {
   switch (arch) {
   case ROCJITSU_CODE_ARCH_CDNA1:
-    return {false, false, false, 256};
+    return {false, true, false, false, 256};
   case ROCJITSU_CODE_ARCH_CDNA2:
-    return {false, false, false, 256};
+    return {false, true, false, false, 256};
   case ROCJITSU_CODE_ARCH_CDNA3:
-    return {false, false, false, 256};
+    return {false, true, false, false, 256};
   case ROCJITSU_CODE_ARCH_CDNA4:
-    return {false, false, false, 256};
+    return {false, true, false, false, 256};
   case ROCJITSU_CODE_ARCH_RDNA1:
-    return {true, false, false, 256};
+    return {true, false, false, false, 256};
   case ROCJITSU_CODE_ARCH_RDNA2:
-    return {true, false, false, 256};
+    return {true, false, false, false, 256};
   case ROCJITSU_CODE_ARCH_RDNA3:
-    return {true, false, false, 256};
+    return {true, false, false, false, 256};
   case ROCJITSU_CODE_ARCH_RDNA3_5:
-    return {true, false, false, 256};
+    return {true, false, false, false, 256};
   case ROCJITSU_CODE_ARCH_RDNA4:
-    return {true, true, false, 256};
+    return {true, false, true, false, 256};
   case ROCJITSU_CODE_ARCH_GFX1250:
-    return {false, true, true, 1024};
+    return {false, false, true, true, 1024};
   default:
     return {};
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/isa_properties.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/isa_properties.h
@@ -26,25 +26,85 @@ inline constexpr uint32_t MAX_SUPPORTED_ADDRESSABLE_VGPRS_PER_WF = 1024;
 [[nodiscard]] constexpr IsaProperties isa_properties(rj_code_arch_t arch) {
   switch (arch) {
   case ROCJITSU_CODE_ARCH_CDNA1:
-    return {false, true, false, false, 256};
+    return {
+        .supports_wgp_mode = false,
+        .descriptor_sgpr_count_encoded = true,
+        .uses_ttmp_workgroup_ids = false,
+        .uses_cluster_ttmp_workgroup_ids = false,
+        .max_addressable_vgprs_per_wf = 256,
+    };
   case ROCJITSU_CODE_ARCH_CDNA2:
-    return {false, true, false, false, 256};
+    return {
+        .supports_wgp_mode = false,
+        .descriptor_sgpr_count_encoded = true,
+        .uses_ttmp_workgroup_ids = false,
+        .uses_cluster_ttmp_workgroup_ids = false,
+        .max_addressable_vgprs_per_wf = 256,
+    };
   case ROCJITSU_CODE_ARCH_CDNA3:
-    return {false, true, false, false, 256};
+    return {
+        .supports_wgp_mode = false,
+        .descriptor_sgpr_count_encoded = true,
+        .uses_ttmp_workgroup_ids = false,
+        .uses_cluster_ttmp_workgroup_ids = false,
+        .max_addressable_vgprs_per_wf = 256,
+    };
   case ROCJITSU_CODE_ARCH_CDNA4:
-    return {false, true, false, false, 256};
+    return {
+        .supports_wgp_mode = false,
+        .descriptor_sgpr_count_encoded = true,
+        .uses_ttmp_workgroup_ids = false,
+        .uses_cluster_ttmp_workgroup_ids = false,
+        .max_addressable_vgprs_per_wf = 256,
+    };
   case ROCJITSU_CODE_ARCH_RDNA1:
-    return {true, false, false, false, 256};
+    return {
+        .supports_wgp_mode = true,
+        .descriptor_sgpr_count_encoded = false,
+        .uses_ttmp_workgroup_ids = false,
+        .uses_cluster_ttmp_workgroup_ids = false,
+        .max_addressable_vgprs_per_wf = 256,
+    };
   case ROCJITSU_CODE_ARCH_RDNA2:
-    return {true, false, false, false, 256};
+    return {
+        .supports_wgp_mode = true,
+        .descriptor_sgpr_count_encoded = false,
+        .uses_ttmp_workgroup_ids = false,
+        .uses_cluster_ttmp_workgroup_ids = false,
+        .max_addressable_vgprs_per_wf = 256,
+    };
   case ROCJITSU_CODE_ARCH_RDNA3:
-    return {true, false, false, false, 256};
+    return {
+        .supports_wgp_mode = true,
+        .descriptor_sgpr_count_encoded = false,
+        .uses_ttmp_workgroup_ids = false,
+        .uses_cluster_ttmp_workgroup_ids = false,
+        .max_addressable_vgprs_per_wf = 256,
+    };
   case ROCJITSU_CODE_ARCH_RDNA3_5:
-    return {true, false, false, false, 256};
+    return {
+        .supports_wgp_mode = true,
+        .descriptor_sgpr_count_encoded = false,
+        .uses_ttmp_workgroup_ids = false,
+        .uses_cluster_ttmp_workgroup_ids = false,
+        .max_addressable_vgprs_per_wf = 256,
+    };
   case ROCJITSU_CODE_ARCH_RDNA4:
-    return {true, false, true, false, 256};
+    return {
+        .supports_wgp_mode = true,
+        .descriptor_sgpr_count_encoded = false,
+        .uses_ttmp_workgroup_ids = true,
+        .uses_cluster_ttmp_workgroup_ids = false,
+        .max_addressable_vgprs_per_wf = 256,
+    };
   case ROCJITSU_CODE_ARCH_GFX1250:
-    return {false, false, true, true, 1024};
+    return {
+        .supports_wgp_mode = false,
+        .descriptor_sgpr_count_encoded = false,
+        .uses_ttmp_workgroup_ids = true,
+        .uses_cluster_ttmp_workgroup_ids = true,
+        .max_addressable_vgprs_per_wf = 1024,
+    };
   default:
     return {};
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -177,22 +177,7 @@ bool plan_cluster_workgroups(const DispatchEntry &entry, uint32_t cluster_base_l
 bool sgpr_count_is_descriptor_encoded(rj_code_arch_t arch, uint32_t sgpr_gran) {
   if (sgpr_gran != 0)
     return true;
-
-  /*
-   * \NPI new ISA family: classify the new arch for CP-visible behavior here \
-   * (RDNA-style encodings return false; CDNA-style fall through to the default).
-   */
-  switch (arch) {
-  case ROCJITSU_CODE_ARCH_RDNA1:
-  case ROCJITSU_CODE_ARCH_RDNA2:
-  case ROCJITSU_CODE_ARCH_RDNA3:
-  case ROCJITSU_CODE_ARCH_RDNA3_5:
-  case ROCJITSU_CODE_ARCH_RDNA4:
-  case ROCJITSU_CODE_ARCH_GFX1250:
-    return false;
-  default:
-    return true;
-  }
+  return isa_properties(arch).descriptor_sgpr_count_encoded;
 }
 
 } // namespace
@@ -309,7 +294,6 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
     if (pkt.enable_wg_id_z)
       cu->write_sgpr(sbase + sys_idx++, wg_id_z);
   }
-
   const auto properties = isa_properties(cu->arch());
   if (properties.uses_ttmp_workgroup_ids) {
     // The simulator aliases TTMP scalar selectors into the wavefront SGPR


### PR DESCRIPTION
Replace hardcoded RDNA/gfx1250 checks in the command processor with isa_properties queries.

## Motivation

Code refactoring to make more code generated from isa_profile.py.

## Technical Details

Adds descriptor_sgpr_count_encoded and uses_ttmp_workgroup_id_payload to isa_profile.py

## Issue Tracking

#8858

## Test Plan

Add code generation amdisa python tests.

## Test Result

Tests pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
