### PR TITLE
refactor(rocprofiler-systems): Remove Timemory readlink()

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
@@ -408,19 +408,16 @@ get_internal_libs_data_impl()
     auto _libs   = std::vector<std::string>{};
     _libs.assign(_libs_v.begin(), _libs_v.end());
 
-    auto _rocprofsys_base_path =
-        rocprofsys::path::parent_path(rocprofsys::path::realpath("/proc/self/exe"), 2);
-    auto _rocprofsys_lib_path = std::string{};
-
-    for(const auto* itr : { "lib", "lib64" })
+    auto rocprofsys_root = rocprofsys::path::get_rocprofsys_root();
+    for(const auto* lib_dir : { "lib", "lib64" })
     {
-        for(const auto* litr :
+        for(const auto* lib_fname :
             { "librocprof-sys-dl.so", "librocprof-sys-user.so", "librocprof-sys-rt.so" })
         {
-            auto _libpath = fmt::format("{}/{}/{}", _rocprofsys_base_path, itr, litr);
-            if(filepath::exists(_libpath))
+            auto libpath = fmt::format("{}/{}/{}", rocprofsys_root, lib_dir, lib_fname);
+            if(filepath::exists(libpath))
             {
-                _libs.emplace_back(rocprofsys::path::realpath(_libpath));
+                _libs.emplace_back(rocprofsys::path::realpath(libpath));
             }
         }
     }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
@@ -40,12 +40,6 @@ using strview_init_t   = std::initializer_list<std::string_view>;
 using strview_set_t    = std::set<std::string_view>;
 using open_modes_vec_t = std::vector<int>;
 
-auto
-get_exe_realpath()
-{
-    return rocprofsys::path::realpath("/proc/self/exe");
-}
-
 auto&
 get_symtab_file_cache()
 {

--- a/projects/rocprofiler-systems/source/lib/common/path.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/path.hpp
@@ -257,7 +257,6 @@ parent_path(std::string_view fpath, std::uint16_t levels)
     return result.string();
 }
 
-
 /** @brief Read the symbolic link target.
  *  @param path The filesystem path to inspect.
  *  @return The link target as a string, or @p path unchanged if @p path is not

--- a/projects/rocprofiler-systems/source/lib/common/path.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/path.hpp
@@ -101,9 +101,6 @@ realpath(const std::string& path) ROCPROFSYS_INTERNAL_API;
 inline bool
 is_text_file(const std::string& filename) ROCPROFSYS_INTERNAL_API;
 
-inline bool
-is_link(const std::string& _path) ROCPROFSYS_INTERNAL_API;
-
 [[nodiscard]] inline std::string
 read_symlink(const std::string& path) ROCPROFSYS_INTERNAL_API;
 
@@ -260,13 +257,6 @@ parent_path(std::string_view fpath, std::uint16_t levels)
     return result.string();
 }
 
-bool
-is_link(const std::string& _path)
-{
-    struct stat _buffer;
-    if(lstat(_path.c_str(), &_buffer) == 0) return (S_ISLNK(_buffer.st_mode) != 0);
-    return false;
-}
 
 /** @brief Read the symbolic link target.
  *  @param path The filesystem path to inspect.

--- a/projects/rocprofiler-systems/source/lib/common/path.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/path.hpp
@@ -104,8 +104,8 @@ is_text_file(const std::string& filename) ROCPROFSYS_INTERNAL_API;
 inline bool
 is_link(const std::string& _path) ROCPROFSYS_INTERNAL_API;
 
-inline std::string
-readlink(const std::string& _path) ROCPROFSYS_INTERNAL_API;
+[[nodiscard]] inline std::string
+read_symlink(const std::string& path) ROCPROFSYS_INTERNAL_API;
 
 inline std::string
 get_rocprofsys_root() ROCPROFSYS_INTERNAL_API;
@@ -268,32 +268,17 @@ is_link(const std::string& _path)
     return false;
 }
 
-std::string
-readlink(const std::string& _path)
+/** @brief Read the symbolic link target.
+ *  @param path The filesystem path to inspect.
+ *  @return The link target as a string, or @p path unchanged if @p path is not
+ *          a symbolic link or if any filesystem error occurs.
+ */
+[[nodiscard]] std::string
+read_symlink(const std::string& path)
 {
-    constexpr size_t MaxLen = PATH_MAX;
-    // if not a symbolic link, just return the path
-    if(!is_link(_path)) return _path;
-
-    char    _buffer[MaxLen];
-    ssize_t _buffer_len = MaxLen;
-    _buffer_len         = ::readlink(_path.c_str(), _buffer, _buffer_len);
-    if(_buffer_len < 0 || _buffer_len == (MaxLen))
-    {
-        auto* _path_rp = ::realpath(_path.c_str(), nullptr);
-        if(_path_rp)
-        {
-            auto _ret = std::string{ _path_rp };
-            free(_path_rp);
-            return _ret;
-        }
-    }
-    else
-    {
-        _buffer[_buffer_len] = '\0';
-        return _buffer;
-    }
-    return _path;
+    std::error_code error;
+    auto            target = std::filesystem::read_symlink(path, error);
+    return (error) ? path : target.string();
 }
 
 /**

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_discover_llvm_libdir.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_discover_llvm_libdir.cpp
@@ -369,7 +369,7 @@ TEST_F(DiscoverLlvmLibdirTest, SymlinkToLibomptarget)
 
     create_directory(llvm_lib);
     std::string link_path = llvm_lib + "/libomptarget.so";
-    symlink(actual_file.c_str(), link_path.c_str());
+    EXPECT_EQ(symlink(actual_file.c_str(), link_path.c_str()), 0);
 
     set_rocm_path(rocm_path);
     clear_rocmv_dir();

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
@@ -135,23 +135,29 @@ TEST_F(PathTest, IsLink_SymbolicLink)
 
 TEST_F(PathTest, IsLink_NonexistentPath) { EXPECT_FALSE(is_link("/nonexistent/path")); }
 
-TEST_F(PathTest, Readlink_SymbolicLink)
+TEST_F(PathTest, ReadSymlink_SymbolicLink)
 {
-    std::string target    = create_file("readlink_target.txt");
-    std::string link_path = create_symlink(target, "readlink_link");
-    EXPECT_EQ(readlink(link_path), target);
+    std::string target    = create_file("read_symlink_target.txt");
+    std::string link_path = create_symlink(target, "read_symlink_link");
+    EXPECT_EQ(read_symlink(link_path), target);
 }
 
-TEST_F(PathTest, Readlink_NotALink)
+TEST_F(PathTest, ReadSymlink_NotALink)
 {
     std::string file_path = create_file("not_a_link.txt");
-    EXPECT_EQ(readlink(file_path), file_path);
+    EXPECT_EQ(read_symlink(file_path), file_path);
 }
 
-TEST_F(PathTest, Readlink_NonexistentPath)
+TEST_F(PathTest, ReadSymlink_NonexistentPath)
 {
     std::string path = "/nonexistent/path";
-    EXPECT_EQ(readlink(path), path);
+    EXPECT_EQ(read_symlink(path), path);
+}
+
+TEST_F(PathTest, ReadSymlink_BrokenSymlink)
+{
+    std::string link_path = create_symlink("/nonexistent/target", "broken_read_symlink");
+    EXPECT_EQ(read_symlink(link_path), "/nonexistent/target");
 }
 
 TEST_F(PathTest, Realpath_RelativePath)

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
@@ -118,23 +118,6 @@ TEST_F(PathTest, Exists_BrokenSymlink)
 
 TEST_F(PathTest, Exists_EmptyPath) { EXPECT_FALSE(exists("")); }
 
-TEST_F(PathTest, IsLink_RegularFile)
-{
-    std::string file_path = create_file("regular.txt");
-    EXPECT_FALSE(is_link(file_path));
-}
-
-TEST_F(PathTest, IsLink_Directory) { EXPECT_FALSE(is_link(m_test_dir)); }
-
-TEST_F(PathTest, IsLink_SymbolicLink)
-{
-    std::string target    = create_file("target.txt");
-    std::string link_path = create_symlink(target, "symbolic_link");
-    EXPECT_TRUE(is_link(link_path));
-}
-
-TEST_F(PathTest, IsLink_NonexistentPath) { EXPECT_FALSE(is_link("/nonexistent/path")); }
-
 TEST_F(PathTest, ReadSymlink_SymbolicLink)
 {
     std::string target    = create_file("read_symlink_target.txt");
@@ -328,8 +311,11 @@ TEST_F(PathTest, ChainedSymlinks)
     std::string link2_path = m_test_dir + "/chain_link2";
     symlink("chain_link1", link2_path.c_str());
 
-    EXPECT_TRUE(is_link(link1));
-    EXPECT_TRUE(is_link(link2_path));
+    // Verify that link1 and link2_path are actual links:
+    // read_symlink() returns link target for real links
+    // and unchanged input for non-links
+    EXPECT_NE(read_symlink(link1), link1);
+    EXPECT_NE(read_symlink(link2_path), link2_path);
 
     std::string resolved = realpath(link2_path);
     EXPECT_EQ(resolved, target);

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
@@ -312,8 +312,7 @@ TEST_F(PathTest, ChainedSymlinks)
     EXPECT_EQ(symlink("chain_link1", link2_path.c_str()), 0);
 
     // Verify that link1 and link2_path are actual links:
-    // read_symlink() returns link target for real links
-    // and unchanged input for non-links
+    // for a non-link read_symlink() would return unchanged input
     EXPECT_NE(read_symlink(link1), link1);
     EXPECT_NE(read_symlink(link2_path), link2_path);
 

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
@@ -48,7 +48,7 @@ protected:
     std::string create_symlink(const std::string& target, const std::string& link_name)
     {
         std::string link_path = m_test_dir + "/" + link_name;
-        symlink(target.c_str(), link_path.c_str());
+        EXPECT_EQ(symlink(target.c_str(), link_path.c_str()), 0);
         return link_path;
     }
 
@@ -309,7 +309,7 @@ TEST_F(PathTest, ChainedSymlinks)
     std::string target     = create_file("chain_target.txt");
     std::string link1      = create_symlink(target, "chain_link1");
     std::string link2_path = m_test_dir + "/chain_link2";
-    symlink("chain_link1", link2_path.c_str());
+    EXPECT_EQ(symlink("chain_link1", link2_path.c_str()), 0);
 
     // Verify that link1 and link2_path are actual links:
     // read_symlink() returns link target for real links

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
@@ -24,7 +24,6 @@
 #include "rocprofiler-systems/types.h"
 
 #include <spdlog/fmt/fmt.h>
-#include <timemory/utility/filepath.hpp>
 
 #include <cassert>
 #include <gnu/libc-version.h>
@@ -1240,7 +1239,7 @@ rocprofsys_postinit(std::string _exe)
         case InstrumentMode::ProcessCreate:
         {
             if(_exe.empty())
-                _exe = tim::filepath::readlink(fmt::format("/proc/{}/exe", getpid()));
+                _exe = path::read_symlink(fmt::format("/proc/{}/exe", getpid()));
 
             rocprofsys_init_tooling();
             if(_exe.empty())


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This PR is part of a PR series to remove the dependency on Timemory filepath utilities. This particular PR replaces Timemory readlink() function with in-tree implementation based on std::filesystem::read_symlink().

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

  - replaced the in-tree path::readlink() and the external tim::filepath::readlink() with a new path::read_symlink() built on std::filesystem::read_symlink
  - removed the now-dead path::is_link() helper, which was only used internally by the old readlink() implementation
  - updated the one production call site in rocprof-sys-dl/dl.cpp and removed the #include <timemory/utility/filepath.hpp>
  - replaced the old Readlink_* and IsLink_* unit tests with ReadSymlink_* tests, adding a new broken-symlink case
  - Behavior is unchanged: returns the raw symlink target on success, returns the original input on any filesystem error (including non-symlink paths and nonexistent paths).
  - Added 3 checks for symlink() value in unit tests to fix compilation warnings
  - Removed unused get_exe_realpath() from internal_libs.cpp

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

JIRA ID : AIPROFSYST-528

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Existing CTest suite and new tests should pass

## Test Result

<!-- Briefly summarize test outcomes. -->

Existing and new tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
