### PR TITLE
[rocjitsu]: Retire idle CP doorbell pollers after the last queue

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -465,19 +465,15 @@ void CommandProcessor::register_queue(HwQueue queue) {
       engine()->primary_release();
       is_primary_ = false;
     }
-    // Start the doorbell poll thread for KFD (host-accessible) queues under the
-    // same lock that guards doorbell_thread_'s companion state. Internal test
-    // queues inject doorbell events directly via schedule_event_now(). Starting the
-    // jthread while holding hw_queue_mutex_ is safe: the new thread's first action
-    // (scan_doorbells) takes hw_queue_mutex_, so it simply blocks until this scope
-    // releases. Holding the lock also removes a data race on doorbell_thread_ if a
-    // second register_queue ever runs concurrently.
-    if (start_poll && !doorbell_thread_.joinable()) {
-      util::Logger::cp(
-          [&](auto &os) { os << std::format("{}: STARTING doorbell thread", name()); });
-      doorbell_thread_ = std::jthread([this](std::stop_token stop) { doorbell_poll_loop(stop); });
-    }
   }
+  // Start (or restart) the doorbell poll thread for KFD (host-accessible) queues
+  // AFTER releasing hw_queue_mutex_. ensure_doorbell_monitor() serializes on its
+  // own doorbell_thread_mutex_ and may join a monitor that self-exited when the
+  // previous last queue was destroyed; joining while holding hw_queue_mutex_ could
+  // deadlock against that exiting monitor's final scan. Internal test queues inject
+  // doorbell events directly via schedule_event_now() and need no monitor.
+  if (start_poll)
+    ensure_doorbell_monitor();
 }
 
 void CommandProcessor::unregister_queue(uint32_t queue_id, uint32_t process_id) {
@@ -515,11 +511,39 @@ void CommandProcessor::set_doorbell_base(uint32_t process_id, void *base) {
   }
 }
 
-void CommandProcessor::stop_doorbell_monitor() {
+void CommandProcessor::ensure_doorbell_monitor() {
+  std::lock_guard<std::mutex> lock(doorbell_thread_mutex_);
+  // A monitor is already servicing this CP's queues — nothing to do. (The
+  // register→ring window is fine: the live monitor scans every registered queue
+  // each pass, so it will pick up the queue this call just added.)
+  if (doorbell_running_)
+    return;
+  // No monitor is running. If a previous one self-exited (it saw the last
+  // host-accessible queue destroyed) its jthread is joinable-but-finished; join it
+  // here before launching a fresh one so the handle does not leak. request_stop()
+  // is harmless on an already-returned thread and makes the join immediate.
   if (doorbell_thread_.joinable()) {
     doorbell_thread_.request_stop();
     doorbell_thread_.join();
   }
+  util::Logger::cp([&](auto &os) { os << std::format("{}: STARTING doorbell thread", name()); });
+  // Construct the thread BEFORE setting doorbell_running_: if the jthread
+  // constructor throws (std::system_error on thread-creation failure) the flag
+  // must stay false so a later ensure_doorbell_monitor() retries instead of
+  // no-oping forever. We still hold doorbell_thread_mutex_, and the loop's
+  // self-exit path only clears the flag under a TRY-lock of that mutex, so the
+  // new thread cannot observe or clear doorbell_running_ until we release here.
+  doorbell_thread_ = std::jthread([this](std::stop_token stop) { doorbell_poll_loop(stop); });
+  doorbell_running_ = true;
+}
+
+void CommandProcessor::stop_doorbell_monitor() {
+  std::lock_guard<std::mutex> lock(doorbell_thread_mutex_);
+  if (doorbell_thread_.joinable()) {
+    doorbell_thread_.request_stop();
+    doorbell_thread_.join();
+  }
+  doorbell_running_ = false;
 }
 
 uint64_t CommandProcessor::read_gpu_u64(uint64_t va, uint32_t vmid) const {
@@ -593,6 +617,53 @@ void CommandProcessor::doorbell_poll_loop(std::stop_token stop) {
   // flag re-read on some iterations (an early continue before the retry check) would
   // reintroduce a lost-wakeup.
   while (!stop.stop_requested()) {
+    // Self-exit once this CP owns no host-accessible queue. Destroying the last
+    // such queue does NOT join this thread (that join could deadlock against a
+    // monitor mid-iteration inside engine/event code), so the monitor must retire
+    // itself instead of idling forever at the 100us cadence.
+    //
+    // Acquire doorbell_thread_mutex_ with TRY-lock, never a blocking lock: a
+    // concurrent stop_doorbell_monitor() holds that mutex while it join()s this very
+    // thread, so a blocking acquire here would deadlock (it waits for the mutex; the
+    // joiner waits for us to return). A failed try means another lifecycle path owns
+    // the mutex right now — either stop_doorbell_monitor() (which has already issued
+    // request_stop(), so the top-of-loop stop check retires us next turn) or
+    // ensure_doorbell_monitor() (which is only inspecting/starting the monitor). In
+    // both cases deferring this exit check one 100us iteration is harmless. When the
+    // try succeeds and the queue set has no host-accessible queue and no retry is
+    // pending (a stall/invalid retry is still in-flight work), clear doorbell_running_
+    // and return; the lock releases as the stack unwinds. A later
+    // ensure_doorbell_monitor() reaps this exited jthread and starts a fresh one.
+    {
+      std::unique_lock<std::mutex> tlock(doorbell_thread_mutex_, std::try_to_lock);
+      if (tlock.owns_lock()) {
+        // has_kfd_queues() is the dominant exit guard: it is read under
+        // hw_queue_mutex_, atomically with the queue vector that register_queue()/
+        // unregister_queue() mutate, so the monitor never retires while a
+        // host-accessible queue is live. The two retry flags are a conservative
+        // backstop read in the same critical section. Their SETTERS run under
+        // hw_queue_mutex_ (invalid_pending_ in fetch_from_queue; stall_pending_ via
+        // arm_stall_recheck, itself gated on has_kfd_queues()), but handle_doorbell
+        // CLEARS them at entry without the lock, so a flag read here is not perfectly
+        // serialized against a clear. That is harmless: while any queue is live the
+        // has_kfd_queues() term keeps should_exit false regardless of the flags, and
+        // once no host-accessible queue remains no further retry can be armed, so
+        // dropping a stale pending flag at exit forfeits nothing real.
+        bool should_exit;
+        {
+          std::lock_guard<std::recursive_mutex> qlock(hw_queue_mutex_);
+          should_exit = !has_kfd_queues() && !invalid_pending_.load(std::memory_order_acquire) &&
+                        !stall_pending_.load(std::memory_order_acquire);
+        }
+        if (should_exit) {
+          util::Logger::cp([&](auto &os) {
+            os << std::format("{}: doorbell monitor self-exit (no KFD queues)", name());
+          });
+          doorbell_running_ = false;
+          return;
+        }
+      }
+    }
     bool doorbell_changed = scan_doorbells();
     // Retry on a pending INVALID packet (the runtime has not finished writing it
     // yet) OR a pending barrier/dependency stall (waiting on a signal a peer rank

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -181,6 +181,17 @@ public:
   std::vector<ClusterLdsTarget> cluster_lds_targets(uint32_t dispatch_id, uint32_t wg_id,
                                                     uint32_t mcast_mask);
 
+  /// @brief Test-only view of the doorbell monitor lifecycle flag.
+  ///
+  /// @details Exposes doorbell_running_ so a regression test can observe the
+  /// monitor retiring after the last host-accessible queue is destroyed and
+  /// restarting when a new one registers. Read under doorbell_thread_mutex_ so it
+  /// never races the loop's self-exit or ensure_doorbell_monitor().
+  [[nodiscard]] bool doorbell_monitor_running_for_test() {
+    std::lock_guard<std::mutex> lock(doorbell_thread_mutex_);
+    return doorbell_running_;
+  }
+
 private:
   /// @brief Initialize a wavefront's registers per the AMDHSA ABI.
   void init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf, const DispatchEntry &entry,
@@ -341,6 +352,13 @@ private:
   void write_gpu_block(uint64_t va, const void *src, size_t size, uint32_t vmid);
 
   void stop_doorbell_monitor();
+  /// @brief Start the doorbell monitor if one is not already running, reaping a
+  /// previously self-exited thread first. Serialized by doorbell_thread_mutex_.
+  /// @details Caller MUST NOT hold hw_queue_mutex_: this may join a monitor that
+  /// self-exited, and that monitor's final self-exit check takes hw_queue_mutex_,
+  /// so joining under it would deadlock. This also fixes the lock order to
+  /// doorbell_thread_mutex_ -> hw_queue_mutex_ (never the reverse).
+  void ensure_doorbell_monitor();
   bool scan_doorbells();
 
   InterruptCallback interrupt_cb_;
@@ -362,6 +380,20 @@ private:
   std::atomic<bool> stall_pending_{false};
 
   void doorbell_poll_loop(std::stop_token stop);
+
+  // The doorbell monitor's lifecycle is serialized by its OWN mutex, deliberately
+  // distinct from hw_queue_mutex_. An empty monitor exits itself when it observes
+  // the last host-accessible queue gone (so unregister_queue never has to join a
+  // thread that may be mid-iteration inside engine/event code — that join could
+  // deadlock, which is why queue destruction only removes queue state). A later
+  // register_queue reaps the already-exited jthread and starts a fresh one. Taking
+  // doorbell_thread_mutex_ (never nested under hw_queue_mutex_) keeps concurrent
+  // register/unregister from racing on doorbell_thread_ and doorbell_running_.
+  std::mutex doorbell_thread_mutex_;
+  // True while a monitor is running or about to run. The monitor clears it under
+  // doorbell_thread_mutex_ just before returning, so ensure_doorbell_monitor() can
+  // tell a live monitor from a self-exited one that still needs joining.
+  bool doorbell_running_ = false;
   std::jthread doorbell_thread_;
 };
 

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -28,12 +28,14 @@ RJ_DIAGNOSTIC_POP
 
 #include <array>
 #include <bit>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <limits>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 namespace {
@@ -2175,6 +2177,48 @@ TEST(L1ScalarCacheVmidTest, WritebackAllUsesLineOwnerVmidNotCaller) {
 
   mem.unregister_process(kVmidA);
   mem.unregister_process(kVmidB);
+}
+
+TEST(DoorbellMonitorLifecycle, RetiresAfterLastQueueAndRestartsOnNewQueue) {
+  // Regression for the leaked idle CP doorbell poller: the monitor must self-exit
+  // once the last host-accessible (KFD) queue is destroyed, and a later queue
+  // registration must start a fresh monitor. Uses only the queue-registration
+  // lifecycle (no dispatch), so the monitor thread runs on its own and its state
+  // is observed through the test-only accessor.
+  VmFixture f("cdna4", /*num_cus=*/1);
+  amdgpu::CommandProcessor *cp = f.cp();
+
+  auto wait_for_monitor = [&](bool expected) {
+    // The loop retires on a 100us cadence; allow generous slack for CI load.
+    for (int i = 0; i < 2000 && cp->doorbell_monitor_running_for_test() != expected; ++i)
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    return cp->doorbell_monitor_running_for_test();
+  };
+
+  EXPECT_FALSE(cp->doorbell_monitor_running_for_test())
+      << "no monitor should run before any host-accessible queue is registered";
+
+  amdgpu::HwQueue queue{};
+  queue.process_id = 1;
+  queue.queue_id = 7;
+  queue.host_accessible = true;
+  cp->register_queue(queue);
+  EXPECT_TRUE(wait_for_monitor(true)) << "registering a KFD queue must start the monitor";
+
+  cp->unregister_queue(queue.queue_id, queue.process_id);
+  EXPECT_FALSE(wait_for_monitor(false))
+      << "monitor must self-exit after the last host-accessible queue is destroyed";
+
+  // A new queue landing on a CP whose monitor retired must get polling back.
+  amdgpu::HwQueue queue2{};
+  queue2.process_id = 1;
+  queue2.queue_id = 8;
+  queue2.host_accessible = true;
+  cp->register_queue(queue2);
+  EXPECT_TRUE(wait_for_monitor(true)) << "a new KFD queue must restart a retired monitor";
+
+  cp->unregister_queue(queue2.queue_id, queue2.process_id);
+  EXPECT_FALSE(wait_for_monitor(false)) << "monitor must retire again after the last queue";
 }
 
 } // namespace


### PR DESCRIPTION
## Motivation

Each CommandProcessor starts one doorbell_poll_loop thread when it receives its
first host-accessible (KFD) queue, but nothing stopped that thread when the last
such queue was destroyed. unregister_queue deliberately does not join the monitor
-- the join can deadlock a poller that is mid-iteration inside engine or event
code holding other locks -- and no other path retired it before VM shutdown. Every
CP that ever serviced a queue therefore kept an idle poller alive for the rest of
the process, each waking roughly every 100us to scan an empty queue set.

The leak is bounded by command-processor count, not queue count (SoC round-robins
queues across XCD CPs), so it plateaus rather than growing without limit, but
long-lived processes that touch several CPs carry a fixed set of otherwise-idle
workers that add host scheduling and power overhead when no HSA queues exist.
Reported as issue https://github.com/ROCm/rocm-systems/issues/8813.

## Technical details

Give the monitor an asynchronous self-exit and serialize its reap/restart on a
mutex distinct from the queue-state lock, so queue destruction never has to join a
running thread:

- Add doorbell_thread_mutex_ (guarding doorbell_running_ and doorbell_thread_),
  deliberately never nested under hw_queue_mutex_, so monitor lifecycle and
  queue-state operations cannot deadlock.
- doorbell_poll_loop() now checks at the top of each iteration whether the CP owns
  any host-accessible queue and has no pending invalid/stall retry; if not, it
  clears doorbell_running_ and returns. It acquires doorbell_thread_mutex_ with a
  TRY-lock, never a blocking lock: stop_doorbell_monitor() holds that mutex while
  it joins this very thread, so a blocking acquire would deadlock. A failed try
  just defers the exit check to the next 100us iteration.
- Add ensure_doorbell_monitor(), called from register_queue() AFTER hw_queue_mutex_
  is released. Under doorbell_thread_mutex_ it no-ops when a monitor is already
  running, otherwise reaps a previously self-exited jthread (join is immediate
  since it already returned) and launches a fresh one. This is how a CP whose
  monitor retired gets polling back when a new queue lands on it.
- ensure_doorbell_monitor() constructs the jthread BEFORE setting doorbell_running_,
  so a thread-creation failure (std::system_error from the jthread constructor)
  leaves the flag false and a later call retries, rather than latching the flag
  true with no running monitor and no-oping forever.
- stop_doorbell_monitor() now also takes doorbell_thread_mutex_ and clears
  doorbell_running_, keeping the destructor/teardown path consistent with the new
  lifecycle flag.

Correctness of the self-exit vs. register race rests on two invariants: the queue
is added to hw_queues_ before ensure_doorbell_monitor() runs, and the monitor
evaluates has_kfd_queues() under hw_queue_mutex_ while holding
doorbell_thread_mutex_. Every interleaving either keeps a live monitor (it now
sees the new queue) or leaves doorbell_running_ false for ensure_doorbell_monitor()
to reap and restart -- so whenever a host-accessible queue exists, a monitor is
running or the registering call starts one.

## Issue Tracking

#8813

## Test Plan

Run CI tests
Run issue #8813 reproducer

## Test Result

- Standalone reproducer (32 queues x 3 create/destroy rounds, counting /proc/self/task): pre-fix plateaus at 12 threads and never recedes; with the fix the count returns to baseline after every round while still climbing to 12 with live queues, confirming the monitor restarts each round.
- Issue #8813 doorbell reproducer still passes (queue destroy/recreate dispatches correctly with the monitor now churning): 80/80.
- Queue-lifecycle suites (SimulatedKfd/KfdIoctl/Daemon/Interposer/GuestKfd/ Cdna4ToCdna3): 105/105.
- Full suite: 1582/1582.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
