### PR TITLE
ci(rocprofiler-systems): Prevent no-log timeouts for the rocprofiler-systems-pytest-config test

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -1364,20 +1364,31 @@ def _generate_rocprofsys_config_header() -> list[str]:
     an immediate non-zero exit (see :func:`_config_timeout_handler`).
     """
     _watchdog_active = hasattr(signal, "SIGALRM")  # False on non-POSIX platforms
+    _previous_handler = None
     if _watchdog_active:
-        _previous_handler = signal.signal(signal.SIGALRM, _config_timeout_handler)
-        signal.alarm(CONFIG_TIMEOUT)
+        try:
+            _previous_handler = signal.signal(signal.SIGALRM, _config_timeout_handler)
+            signal.alarm(CONFIG_TIMEOUT)
+        except ValueError:
+            # signal handlers can only be installed from the main thread of the main
+            # interpreter; if config probing runs elsewhere, skip the watchdog rather
+            # than crash the probe.
+            _watchdog_active = False
 
-    def _cancel_watchdog() -> None:
+    try:
+        return _build_rocprofsys_config_header()
+    finally:
         if _watchdog_active:
             signal.alarm(0)
             signal.signal(signal.SIGALRM, _previous_handler)
 
+
+def _build_rocprofsys_config_header() -> list[str]:
+    """Collect system configuration and format it as printable header lines."""
     try:
         rocprof_config = get_rocprof_config()
         cap = rocprof_config.capabilities
     except Exception as e:
-        _cancel_watchdog()
         return [f"{e}"]
 
     gpu_info = get_gpu_info()
@@ -1541,7 +1552,6 @@ def _generate_rocprofsys_config_header() -> list[str]:
     for key, value in environment.fundamental_system_environment().items():
         header.append(_row(f"{key}:", value))
     header.extend(["=" * 70, ""])
-    _cancel_watchdog()
     return header
 
 

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -16,6 +16,8 @@ import re
 import os
 import sys
 import shutil
+import signal
+import traceback
 
 try:
     import yaml
@@ -74,6 +76,10 @@ SKIP_RETURN_CODE = 77
 # CTests set their timeout to DEFAULT_TIMEOUT + CTEST_TIMEOUT_BUFFER
 DEFAULT_TIMEOUT = 300
 CTEST_TIMEOUT_BUFFER = 30  # Not overridable
+
+# Timeouts for the "rocprofiler-systems-pytest-config" prerequisite test
+CONFIG_TIMEOUT = 15
+CONFIG_TIMEOUT_BUFFER = 5
 
 # Accepted runner types when using parametrized "mode" marker
 ROCPROFSYS_RUNNER_CLASSES = {
@@ -1084,7 +1090,7 @@ def _emit_prerequisite_block() -> list[str]:
         'set_tests_properties("rocprofiler-systems-pytest-config" PROPERTIES',
         '    FIXTURES_SETUP "rocprofsys-global-tmp-files"',
         '    LABELS "prerequisite;global"',
-        "    TIMEOUT 10",
+        f"    TIMEOUT {CONFIG_TIMEOUT + CONFIG_TIMEOUT_BUFFER}",
         ")",
         "",
     ]
@@ -1332,11 +1338,46 @@ def _standardize_test_name(
     item.extra_keyword_matches.add(formatted_name.lower())
 
 
+def _config_timeout_handler(signum, frame):
+    """SIGALRM handler for ``--show-config-only``: dump where we hung, then hard-exit."""
+    sys.stderr.write(
+        "\n" + "=" * 70 + "\n"
+        f"[rocprofiler-systems-pytest-config] ERROR: configuration probing exceeded "
+        f"{CONFIG_TIMEOUT}s and was aborted.\n"
+        "Stack trace at the point of timeout:\n" + "-" * 70 + "\n"
+    )
+    traceback.print_stack(frame, file=sys.stderr)
+    sys.stderr.write("=" * 70 + "\n")
+    sys.stderr.flush()
+    # os._exit avoids re-entering the (possibly blocked) interpreter state and ensures
+    # the process actually dies even if we interrupted an uninterruptible-looking call.
+    os._exit(2)
+
+
 def _generate_rocprofsys_config_header() -> list[str]:
+    """Generate the config header under an internal SIGALRM watchdog.
+
+    The system probes below (rocminfo, GPU detection, MPI/oshrun version, AMD-SMI/PAPI)
+    can block indefinitely. Without a guard a hang would surface as a silent CTest
+    ``***Timeout``; the watchdog instead prints a diagnostic stack trace and hard-exits.
+    A plain exception would be swallowed by a blocking syscall, so the handler forces
+    an immediate non-zero exit (see :func:`_config_timeout_handler`).
+    """
+    _watchdog_active = hasattr(signal, "SIGALRM")  # False on non-POSIX platforms
+    if _watchdog_active:
+        _previous_handler = signal.signal(signal.SIGALRM, _config_timeout_handler)
+        signal.alarm(CONFIG_TIMEOUT)
+
+    def _cancel_watchdog() -> None:
+        if _watchdog_active:
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, _previous_handler)
+
     try:
         rocprof_config = get_rocprof_config()
         cap = rocprof_config.capabilities
     except Exception as e:
+        _cancel_watchdog()
         return [f"{e}"]
 
     gpu_info = get_gpu_info()
@@ -1500,6 +1541,7 @@ def _generate_rocprofsys_config_header() -> list[str]:
     for key, value in environment.fundamental_system_environment().items():
         header.append(_row(f"{key}:", value))
     header.extend(["=" * 70, ""])
+    _cancel_watchdog()
     return header
 
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

TheRock bump PR (https://github.com/ROCm/TheRock/pull/6688) failed (see https://github.com/ROCm/TheRock/actions/runs/29743540973/job/88374809145?pr=6688) as `rocprofiler-systems-pytest-config` timed out. Debugging was impossible as no logs were printed. 

This PR aims to change this by printing a stack trace and explicitly having the test fail.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

 - Increase timeout for `rocprofiler-systems-pytest-config` to 15 seconds (up from 10)
 - Have a watchdog print out the stack trace.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

Jira ID: AIPROFSYST-649

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Local.

## Test Result

<!-- Briefly summarize test outcomes. -->

Locally, when I simulate a hang, I now see:
```
Start testing: Jul 20 13:02 EDT
----------------------------------------------------------
1/621 Testing: rocprofiler-systems-pytest-config
1/621 Test: rocprofiler-systems-pytest-config
Command: "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/.venv/bin/pytest" "" "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/rocprof-sys-build/tests/../share/rocprofiler-systems/tests/pytest/" "--show-config-only"
Directory: /home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/rocprof-sys-build/tests
"rocprofiler-systems-pytest-config" start time: Jul 20 13:02 EDT
Output:
----------------------------------------------------------

======================================================================
[rocprofiler-systems-pytest-config] ERROR: configuration probing exceeded 10s and was aborted.
Stack trace at the point of timeout:
----------------------------------------------------------------------
  File "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/.venv/bin/pytest", line 8, in <module>
    sys.exit(_console_main())
  File "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py", line 253, in _console_main
    code = _main(prog=_get_prog_name(sys.argv))
  File "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py", line 229, in _main
    ret: ExitCode | int = config.hook.pytest_cmdline_main(config=config)
  File "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/.venv/lib/python3.12/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/.venv/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/.venv/lib/python3.12/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/.venv/lib/python3.12/site-packages/_pytest/main.py", line 377, in pytest_cmdline_main
    return wrap_session(config, _main)
  File "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/.venv/lib/python3.12/site-packages/_pytest/main.py", line 326, in wrap_session
    config._do_configure()
  File "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py", line 1205, in _do_configure
    self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
  File "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/.venv/lib/python3.12/site-packages/pluggy/_hooks.py", line 534, in call_historic
    res = self._hookexec(self.name, self._hookimpls.copy(), kwargs, False)
  File "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/.venv/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/.venv/lib/python3.12/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/rocprof-sys-build/share/rocprofiler-systems/tests/pytest/conftest.py", line 158, in pytest_configure
    header = _generate_config_header_with_timeout()
  File "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/rocprof-sys-build/share/rocprofiler-systems/tests/pytest/conftest.py", line 1370, in _generate_config_header_with_timeout
    return _generate_rocprofsys_config_header()
  File "/home/rocm/rocm-systems-branches/fix-timeout-tests/projects/rocprofiler-systems/rocprof-sys-build/share/rocprofiler-systems/tests/pytest/conftest.py", line 1390, in _generate_rocprofsys_config_header
    time.sleep(_hang_seconds)
======================================================================
```
Which corretly prints out the manual `time.sleep(_hang_seconds)`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
