### PR TITLE
[hip-tests] Get hip-tests building with -Werror

### DIFF
--- a/projects/hip-tests/catch/CMakeLists.txt
+++ b/projects/hip-tests/catch/CMakeLists.txt
@@ -33,6 +33,14 @@ option(ENABLE_SPIRV "Build hip-tests for SPIRV" OFF)
 option(ENABLE_YAML_TAGS "Enable YAML tags for test cases" ON)
 option(STANDALONE_TESTS "Generate standalone executable per source file" OFF)
 
+# Build tests with -Wall -Werror. Defaults ON for Linux, OFF elsewhere.
+if(UNIX)
+  set(_hiptests_werror_default ON)
+else()
+  set(_hiptests_werror_default OFF)
+endif()
+option(ENABLE_WERROR "Build tests with -Wall -Werror (Linux default ON)" ${_hiptests_werror_default})
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif()
@@ -250,7 +258,10 @@ if(HIP_PLATFORM STREQUAL "amd")
     # Which results in errors about missing headers etc
     set(win_cxx_standard -std=c++17)
   endif()
-  add_compile_options(${HIP_PATH_OPT} ${win_cxx_standard} -x hip -Wall -Wextra -Wvla -Wno-deprecated -Wno-option-ignored -Wno-unused-parameter ${win_disable_warnings})
+  add_compile_options(${HIP_PATH_OPT} ${win_cxx_standard} -x hip -Wall -Wextra -Wvla -Wno-deprecated ${win_disable_warnings})
+  if(ENABLE_WERROR AND UNIX)
+    add_compile_options(-Werror)
+  endif()
 endif()
 
 # Turn off CMAKE_HIP_ARCHITECTURES Feature if cmake version is 3.21+

--- a/projects/hip-tests/catch/README.md
+++ b/projects/hip-tests/catch/README.md
@@ -34,6 +34,7 @@ Running Subtest: ctest –R “...” (Regex to match the subtest name)
 ## New Features
 - Better CI integration via xunit compatible output
 - hip-tests can be built in SPIRV, where all kernels are compiled in SPIRV, enable with cmake flag `-DENABLE_SPIRV=ON`. By default it's `OFF`.
+- hip-tests can be built with `-Wall -Werror` so that compiler warnings are treated as errors, controlled by the cmake flag `-DENABLE_WERROR`. It defaults to `ON` for Linux and `OFF` otherwise. Disable it with `-DENABLE_WERROR=OFF`. Applies to the AMD platform only.
 
 ## Testing Context
 HIP testing framework gives you a context for each test. This context will have useful information about the environment your test is running.

--- a/projects/hip-tests/catch/hipTestMain/hip_test_listener.cc
+++ b/projects/hip-tests/catch/hipTestMain/hip_test_listener.cc
@@ -104,7 +104,7 @@ public:
      * @brief Called once when the test run begins
      * Initializes TestParameterStore and detects level filter
      */
-    void testRunStarting(Catch::TestRunInfo const& testRunInfo) override {
+    void testRunStarting(Catch::TestRunInfo const&) override {
         TestParameterStore::instance().initialize();
         
         // Detect level filter from environment or command-line
@@ -178,7 +178,7 @@ public:
      * @brief Called when test run ends
      * Cleanup resources
      */
-    void testRunEnded(Catch::TestRunStats const& testRunStats) override {
+    void testRunEnded(Catch::TestRunStats const&) override {
         TestParameterStore::instance().clear();
     }
 };

--- a/projects/hip-tests/catch/multiproc/childMalloc.cc
+++ b/projects/hip-tests/catch/multiproc/childMalloc.cc
@@ -50,13 +50,13 @@ bool testMallocFromChild() {
       testResult = false;
 
     if (A_d != nullptr) {
-      hipFree(A_d);
+      HIP_CHECK(hipFree(A_d));
     }
 
     // send the value on the write-descriptor:
     write(fd[1], &testResult, sizeof(testResult));
 
-    hipFree(A_d);
+    HIP_CHECK(hipFree(A_d));
     // close the write descriptor:
     close(fd[1]);
     exit(0);

--- a/projects/hip-tests/catch/multiproc/childMalloc.cc
+++ b/projects/hip-tests/catch/multiproc/childMalloc.cc
@@ -49,14 +49,12 @@ bool testMallocFromChild() {
     else
       testResult = false;
 
-    if (A_d != nullptr) {
-      HIP_CHECK(hipFree(A_d));
-    }
-
     // send the value on the write-descriptor:
     write(fd[1], &testResult, sizeof(testResult));
 
-    HIP_CHECK(hipFree(A_d));
+    if (A_d != nullptr) {
+      HIP_CHECK(hipFree(A_d));
+    }
     // close the write descriptor:
     close(fd[1]);
     exit(0);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -843,9 +843,7 @@ void runAggregationRandomForType(AggregationType aggType, dim3 blockDim)
 }
 
 template <bool Coalesced, class T, int WarpSize, class Op = void>
-void runAggregationRandomForOps(AggregationType aggType, const std::tuple<>)
-{
-}
+void runAggregationRandomForOps(AggregationType, const std::tuple<>) {}
 
 template <bool Coalesced, class T, int WarpSize, class Op, class... Ops>
 void runAggregationRandomForOps(AggregationType aggType, const std::tuple<Op, Ops...>)

--- a/projects/hip-tests/catch/unit/deviceLib/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/deviceLib/CMakeLists.txt
@@ -83,6 +83,11 @@ set(AMD_TEST_SRC
 # until the header is made portable.
 if(NOT WIN32)
   list(APPEND AMD_TEST_SRC ext_ocp_fp6.cc ext_ocp_fp8.cc ext_ocp_fp4.cc)
+  # The OCP host reference returns wide vector types (__amd_floatx32_storage_t)
+  # by value. Without AVX-512 enabled this triggers -Wpsabi ABI-change notes,
+  # which are inherent to the type and not a real defect, so suppress them here.
+  set_source_files_properties(ext_ocp_fp6.cc ext_ocp_fp8.cc ext_ocp_fp4.cc
+                              PROPERTIES COMPILE_OPTIONS "-Wno-psabi")
 endif()
 
 set(AMD_ARCH_SPEC_TEST_SRC

--- a/projects/hip-tests/catch/unit/env/hipSetEnv_helper.cc
+++ b/projects/hip-tests/catch/unit/env/hipSetEnv_helper.cc
@@ -65,16 +65,6 @@ static int initializeHIP() {
   return 0;
 }
 
-// Test GPU_ENABLE_PAL - logs which backend initialized
-static int checkGpuEnablePal(const char* value) {
-  return initializeHIP();
-}
-
-// Test generic environment variable
-static int testEnvironmentVariable(const std::string& envName, const char* value) {
-  return initializeHIP();
-}
-
 int main(int argc, char** argv) {
   if (argc != 3) {
     std::cerr << "Usage: " << argv[0] << " <env_var_name> <env_var_value>" << std::endl;
@@ -95,13 +85,7 @@ int main(int argc, char** argv) {
     }
   }
 
-  // Run the test
-  int result;
-  if (envName == "GPU_ENABLE_PAL") {
-    result = checkGpuEnablePal(envValue);
-  } else {
-    result = testEnvironmentVariable(envName, envValue);
-  }
-
-  return result;
+  // Initialize HIP so the runtime logs which backend was selected; the parent
+  // process inspects stdout to verify the expected backend.
+  return initializeHIP();
 }

--- a/projects/hip-tests/catch/unit/gl_interop/hipGLImageDataVerification.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGLImageDataVerification.cc
@@ -40,8 +40,10 @@
 // ---------------------------------------------------------------------------
 
 /* Read every texel of a surface and copy it to a flat device buffer. */
-__global__ void kernel_read_surface(hipSurfaceObject_t surf, uint32_t* out,
-                                    unsigned int width, unsigned int height) {
+__global__ void kernel_read_surface([[maybe_unused]] hipSurfaceObject_t surf,
+                                    [[maybe_unused]] uint32_t* out,
+                                    [[maybe_unused]] unsigned int width,
+                                    [[maybe_unused]] unsigned int height) {
 #if !__HIP_NO_IMAGE_SUPPORT
   unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
   unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
@@ -58,9 +60,13 @@ __global__ void kernel_read_surface(hipSurfaceObject_t surf, uint32_t* out,
 }
 
 /* Write a solid color to every texel. */
-__global__ void kernel_fill_surface(hipSurfaceObject_t surf, uint8_t r,
-                                    uint8_t g, uint8_t b, uint8_t a,
-                                    unsigned int width, unsigned int height) {
+__global__ void kernel_fill_surface([[maybe_unused]] hipSurfaceObject_t surf,
+                                    [[maybe_unused]] uint8_t r,
+                                    [[maybe_unused]] uint8_t g,
+                                    [[maybe_unused]] uint8_t b,
+                                    [[maybe_unused]] uint8_t a,
+                                    [[maybe_unused]] unsigned int width,
+                                    [[maybe_unused]] unsigned int height) {
 #if !__HIP_NO_IMAGE_SUPPORT
   unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
   unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
@@ -71,8 +77,9 @@ __global__ void kernel_fill_surface(hipSurfaceObject_t surf, uint8_t r,
 }
 
 /* Invert all four channels (255 - value) of every texel. */
-__global__ void kernel_invert_surface(hipSurfaceObject_t surf,
-                                      unsigned int width, unsigned int height) {
+__global__ void kernel_invert_surface([[maybe_unused]] hipSurfaceObject_t surf,
+                                      [[maybe_unused]] unsigned int width,
+                                      [[maybe_unused]] unsigned int height) {
 #if !__HIP_NO_IMAGE_SUPPORT
   unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
   unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
@@ -89,9 +96,9 @@ __global__ void kernel_invert_surface(hipSurfaceObject_t surf,
 }
 
 /* Write R=x, G=y, B=x^y, A=0xFF unique-per-pixel to every texel. */
-__global__ void kernel_write_unique_surface(hipSurfaceObject_t surf,
-                                            unsigned int width,
-                                            unsigned int height) {
+__global__ void kernel_write_unique_surface([[maybe_unused]] hipSurfaceObject_t surf,
+                                            [[maybe_unused]] unsigned int width,
+                                            [[maybe_unused]] unsigned int height) {
 #if !__HIP_NO_IMAGE_SUPPORT
   unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
   unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
@@ -104,9 +111,9 @@ __global__ void kernel_write_unique_surface(hipSurfaceObject_t surf,
 }
 
 /* Add (x+y) mod 256 to the R, G, B channels; leave alpha unchanged. */
-__global__ void kernel_transform_surface(hipSurfaceObject_t surf,
-                                         unsigned int width,
-                                         unsigned int height) {
+__global__ void kernel_transform_surface([[maybe_unused]] hipSurfaceObject_t surf,
+                                         [[maybe_unused]] unsigned int width,
+                                         [[maybe_unused]] unsigned int height) {
 #if !__HIP_NO_IMAGE_SUPPORT
   unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
   unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
@@ -236,7 +243,7 @@ static void dispatch2d(dim3& grid, dim3& block,
 HIP_TEST_CASE(Unit_GLHIPImageData_Positive_GLWrite_HIPRead_SolidColor) {
   CHECK_IMAGE_SUPPORT;
   GLContextScopeGuard gl_context;
-  hipGetLastError(); // reset previous err
+  (void)hipGetLastError(); // reset previous err
   const uint8_t R = 0xDE, G = 0xAD, B = 0xBE, A = 0xEF;
   const uint32_t expected_pixel = pack_rgba(R, G, B, A);
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNode1D_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNode1D_old.cc
@@ -76,10 +76,10 @@ static void validateMemcpyNode1DArray(bool peerAccess,
   hipError_t graphInstStatus = hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0);
   if (peerAccess && graphInstStatus == hipErrorNotSupported) {
     HIP_CHECK(hipSetDevice(0));
-    hipGraphDestroy(graph);
-    hipStreamDestroy(streamForGraph);
-    hipFree(devArray1);
-    hipFree(devArray2);
+    HIP_CHECK(hipGraphDestroy(graph));
+    HIP_CHECK(hipStreamDestroy(streamForGraph));
+    HIP_CHECK(hipFree(devArray1));
+    HIP_CHECK(hipFree(devArray2));
     SKIP("Multi-device graph instantiation not supported (hipErrorNotSupported)");
   }
   HIP_CHECK(graphInstStatus);

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParams.cc
@@ -215,7 +215,7 @@ HIP_TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParams_Negative_Parameters) {
  *    - HIP_VERSION >= 5.2
  */
 HIP_TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Direction) {
-  int *host, *dev, *src, *dst;
+  int *host, *dev, *src = nullptr, *dst = nullptr;
   HIP_CHECK(hipHostMalloc(&host, sizeof(int)));
   HIP_CHECK(hipMalloc(&dev, sizeof(int)));
 

--- a/projects/hip-tests/catch/unit/hrr/hrr_workload_test.cc
+++ b/projects/hip-tests/catch/unit/hrr/hrr_workload_test.cc
@@ -26,12 +26,6 @@
 #include <filesystem>
 #include <fstream>
 
-#define HIPRTC_CHECK(expr)                                                    \
-  do {                                                                        \
-    hiprtcResult _r = (expr);                                                 \
-    REQUIRE(_r == HIPRTC_SUCCESS);                                            \
-  } while (0)
-
 // ---------------------------------------------------------------------------
 // Workload parameters
 // ---------------------------------------------------------------------------
@@ -600,7 +594,7 @@ TEST_CASE("Unit_HRR_AllApis_Direct", "[.][hrr-direct]") {
   // =========================================================================
   {
     int supportsImages = 0;
-    hipDeviceGetAttribute(&supportsImages, hipDeviceAttributeImageSupport, 0);
+    HIP_CHECK(hipDeviceGetAttribute(&supportsImages, hipDeviceAttributeImageSupport, 0));
     if (supportsImages) {
       HIP_ARRAY_DESCRIPTOR desc1d{};
       desc1d.Width       = static_cast<size_t>(N);
@@ -1271,8 +1265,8 @@ TEST_CASE("Unit_HRR_Occupancy_Direct", "[.][hrr-direct]") {
 TEST_CASE("Unit_HRR_HostAliases_Direct", "[.][hrr-direct]") {
   // Drain any GPU errors left by earlier tests; this test mixes array + 3D
   // alloc with regular device memory — on Windows the driver needs a clean slate.
-  hipDeviceSynchronize();
-  hipGetLastError();
+  (void)hipDeviceSynchronize();
+  (void)hipGetLastError();
   HIP_CHECK(hipSetDevice(0));
   constexpr int N = 256;
   constexpr size_t SZ = N * sizeof(int);
@@ -1343,8 +1337,8 @@ TEST_CASE("Unit_HRR_HostAliases_Direct", "[.][hrr-direct]") {
 
   // D2H blob (value = 8)
   // Drain any pending GPU errors from earlier tests before D2H.
-  hipDeviceSynchronize();
-  hipGetLastError();
+  (void)hipDeviceSynchronize();
+  (void)hipGetLastError();
   int* d = nullptr; int* h = new int[N]();
   HIP_CHECK(hipMalloc(&d, SZ));
   hipStream_t s;
@@ -1601,7 +1595,7 @@ TEST_CASE("Unit_HRR_MemcpyExtra_Direct", "[.][hrr-direct]") {
   // Requires image support — skip on GPUs that don't support texture arrays.
   {
     int supportsImages = 0;
-    hipDeviceGetAttribute(&supportsImages, hipDeviceAttributeImageSupport, 0);
+    HIP_CHECK(hipDeviceGetAttribute(&supportsImages, hipDeviceAttributeImageSupport, 0));
     if (supportsImages) {
       hipChannelFormatDesc desc = hipCreateChannelDesc(32, 0, 0, 0, hipChannelFormatKindFloat);
       hipArray_t arr = nullptr;
@@ -2645,8 +2639,8 @@ TEST_CASE("Unit_HRR_ChevronLaunch_Direct", "[.][hrr][direct]") {
   HIP_CHECK(hipStreamCreate(&s));
 
   // Drain any pending GPU errors from earlier tests before the <<<>>> launch.
-  hipDeviceSynchronize();
-  hipGetLastError();
+  (void)hipDeviceSynchronize();
+  (void)hipGetLastError();
 
   int blocks = (N + 255) / 256;
   // Triple-chevron launch — goes through __hipPushCallConfiguration + hipLaunchByPtr

--- a/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
+++ b/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
@@ -1447,7 +1447,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
     REQUIRE(hostMem != nullptr);
     fillHostArray(hostMem, N, value);
 
-    hipStream_t stream[Ns];
+    std::vector<hipStream_t> stream(Ns);
     for (int s = 0; s < Ns; s++) {
       HIP_CHECK(hipStreamCreate(&stream[s]));
     }
@@ -1481,7 +1481,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
     REQUIRE(devMem != nullptr);
     fillDeviceArray(devMem, N, value);
 
-    hipStream_t stream[Ns];
+    std::vector<hipStream_t> stream(Ns);
     for (int s = 0; s < Ns; s++) {
       HIP_CHECK(hipStreamCreate(&stream[s]));
     }
@@ -1515,7 +1515,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
     REQUIRE(devMem != nullptr);
     fillDeviceArray(devMem, N, value);
 
-    hipStream_t stream[Ns];
+    std::vector<hipStream_t> stream(Ns);
     for (int s = 0; s < Ns; s++) {
       HIP_CHECK(hipStreamCreate(&stream[s]));
     }
@@ -1552,7 +1552,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(hostMem != nullptr);
       fillHostArray(hostMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1585,7 +1585,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(hostMem != nullptr);
       fillHostArray(hostMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1619,7 +1619,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1653,7 +1653,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1688,7 +1688,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1722,7 +1722,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(hostMem != nullptr);
       fillHostArray(hostMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1755,7 +1755,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(hostMem != nullptr);
       fillHostArray(hostMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1789,7 +1789,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1823,7 +1823,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1861,7 +1861,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(hostMem != nullptr);
       fillHostArray(hostMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1894,7 +1894,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(hostMem != nullptr);
       fillHostArray(hostMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1928,7 +1928,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1962,7 +1962,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -1997,7 +1997,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -2032,7 +2032,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(hostMem != nullptr);
       fillHostArray(hostMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -2065,7 +2065,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(hostMem != nullptr);
       fillHostArray(hostMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -2099,7 +2099,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -2133,7 +2133,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
       REQUIRE(devMem != nullptr);
       fillDeviceArray(devMem, N, value);
 
-      hipStream_t stream[Ns];
+      std::vector<hipStream_t> stream(Ns);
       for (int s = 0; s < Ns; s++) {
         HIP_CHECK(hipStreamCreate(&stream[s]));
       }
@@ -2294,7 +2294,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemset) {
     HIP_CHECK(hipMalloc(&devMem, Nbytes));
     REQUIRE(devMem != nullptr);
 
-    hipStream_t stream[Ns];
+    std::vector<hipStream_t> stream(Ns);
     for (int s = 0; s < Ns; s++) {
       HIP_CHECK(hipStreamCreate(&stream[s]));
     }
@@ -2332,7 +2332,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemset) {
     HIP_CHECK(hipMalloc(&devMem, Nbytes));
     REQUIRE(devMem != nullptr);
 
-    hipStream_t stream[Ns];
+    std::vector<hipStream_t> stream(Ns);
     for (int s = 0; s < Ns; s++) {
       HIP_CHECK(hipStreamCreate(&stream[s]));
     }
@@ -2370,7 +2370,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemset) {
     HIP_CHECK(hipMalloc(&devMem, Nbytes));
     REQUIRE(devMem != nullptr);
 
-    hipStream_t stream[Ns];
+    std::vector<hipStream_t> stream(Ns);
     for (int s = 0; s < Ns; s++) {
       HIP_CHECK(hipStreamCreate(&stream[s]));
     }
@@ -2429,7 +2429,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemset) {
     HIP_CHECK(hipMalloc(&devMem, Nbytes));
     REQUIRE(devMem != nullptr);
 
-    hipStream_t stream[Ns];
+    std::vector<hipStream_t> stream(Ns);
     for (int s = 0; s < Ns; s++) {
       HIP_CHECK(hipStreamCreate(&stream[s]));
     }
@@ -2541,7 +2541,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemset2D3D) {
     HIP_CHECK(dyn_hipMemset2DAsync_ptr(devMem, pitch, 5, width, height, 0));
     HIP_CHECK(hipStreamSynchronize(0));
 
-    hipStream_t stream[Ns];
+    std::vector<hipStream_t> stream(Ns);
     for (int s = 0; s < Ns; s++) {
       HIP_CHECK(hipStreamCreate(&stream[s]));
     }

--- a/projects/hip-tests/catch/unit/memory/hipMallocFromPoolAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocFromPoolAsync.cc
@@ -434,37 +434,6 @@ static void threadQAsyncCommands(streamMemAllocTest* testObj, hipStream_t strm, 
   testObj->freeDevBuf(strm);
 }
 
-static void thread_Test1(hipStream_t stream, int N, enum eTestValue testtype, int threadNum) {
-  thread_results[threadNum] = checkMaximumAndDefaultThreshold(stream, N, testtype, 0);
-}
-
-static bool test_hipMallocFromPoolAsync_MThread(enum eTestValue testtype) {
-  // create a stream
-  constexpr int N = 1 << 20;
-  std::vector<std::thread> tests;
-  hipStream_t stream[NUMBER_OF_THREADS];
-  // Initialize and create streams
-  for (int idx = 0; idx < NUMBER_OF_THREADS; idx++) {
-    thread_results[idx] = false;
-    HIP_CHECK(hipStreamCreate(&stream[idx]));
-  }
-  // Spawn the test threads
-  for (int idx = 0; idx < NUMBER_OF_THREADS; idx++) {
-    tests.push_back(std::thread(thread_Test1, stream[idx], N, testtype, idx));
-  }
-  // Wait for all threads to complete
-  for (std::thread& t : tests) {
-    t.join();
-  }
-  // Wait for thread and destroy stream
-  bool status = true;
-  for (int idx = 0; idx < NUMBER_OF_THREADS; idx++) {
-    status = status & thread_results[idx];
-    HIP_CHECK(hipStreamDestroy(stream[idx]));
-  }
-  return status;
-}
-
 static void thread_Test2(hipMemPool_t mempool, hipStream_t stream, int N, int threadNum) {
   streamMemAllocTest testObj(N, true);
   // Create host buffer with test data

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_old.cc
@@ -203,7 +203,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyAsync_hipMultiMemcpyMultiThread, int, float
   HIP_CHECK(hipStreamCreateWithFlags(&mystream, hipStreamNonBlocking));
   HIP_CHECK(hipMemcpyAsync(A_d, A_h, Nbytes, hipMemcpyHostToDevice, mystream));
 
-  std::thread T[NUM_THREADS];
+  std::vector<std::thread> T(NUM_THREADS);
   for (int i = 0; i < NUM_THREADS; i++) {
     T[i] = std::thread(Thread_func<TestType>, A_d, B_d, C_d, C_h, Nbytes, mystream);
   }
@@ -233,7 +233,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyAsync_hipMultiMemcpyMultiThread, int, float
 HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyAsync_hipMultiMemcpyMultiThreadMultiStream, int, float,
                    double) {
   const int NUM_THREADS = isQuickLevel() ? 4 : 16;
-  std::thread T[NUM_THREADS];
+  std::vector<std::thread> T(NUM_THREADS);
   for (int i = 0; i < NUM_THREADS; i++) {
     T[i] = std::thread(Thread_func_MultiStream<TestType>);
   }

--- a/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
@@ -759,7 +759,7 @@ void testIncrementDecrementMultiStreamMultiDevice(uint32_t operationFlag) {
     }
   }
 
-  TestType expected_value;
+  TestType expected_value{};
   switch (operationFlag) {
     case hipExtStreamWriteValueIncrement: {
       expected_value =

--- a/projects/hip-tests/catch/unit/synchronization/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/synchronization/CMakeLists.txt
@@ -42,6 +42,6 @@ endif()
 hip_add_exe_to_target(NAME synchronizationTests
                       TEST_SRC ${TEST_SRC}
                       TEST_TARGET_NAME build_tests
-                      COMPILE_OPTIONS -std=c++14)
+                      COMPILE_OPTIONS -std=c++17)
 
 add_dependencies(synchronizationTests memcpyInt_hsaco)


### PR DESCRIPTION
## Motivation

Improve the quality of code in the hip-test repository by making -Werror and -Wall default. This build has warnings as errors for hip-tests built for Linux

## Technical Details

  - New ENABLE_WERROR option (catch/CMakeLists.txt): defaults ON on Linux (UNIX), OFF elsewhere. When enabled it adds -Wall -Werror within the existing
  AMD-platform flag block (leaving the nvidia/nvcc path untouched). Removed the -Wno-unused-parameter suppression so unused params are now caught;
  -Wno-deprecated is retained. Disable with -DENABLE_WERROR=OFF.
  - README (catch/README.md): documented the new flag alongside ENABLE_SPIRV.

  Warning fixes (so -Werror passes)

  - C++17 standard mismatch — unit/synchronization/CMakeLists.txt forced -std=c++14, which clashed with C++17 inline variables in hip_test_common.hh (57
  errors). Changed to -std=c++17.
  - VLAs → std::vector — hipGetProcAddressMemoryApis.cc (hipStream_t stream[Ns]) and hipMemcpyAsync_old.cc (std::thread T[NUM_THREADS]), where the sizes are
   runtime values.
  - Unused parameters — dropped names on override/base-case/dispatch signatures (hip_test_listener.cc, thread_block_tile.cc); [[maybe_unused]] on the
  image-support-gated GL surface kernels (hipGLImageDataVerification.cc).
  - Ignored [[nodiscard]] hipError_t — wrapped real calls in HIP_CHECK; explicit (void) only for intentional error-drain/reset idioms (hrr_workload_test.cc,
   hipGLImageDataVerification.cc).
  - -Wpsabi — per-file -Wno-psabi for the OCP fp4/6/8 tests (unit/deviceLib/CMakeLists.txt); the AVX wide-vector return type is inherent, not a defect.
  - Uninitialized-on-default-path (real latent bugs) — zero/nullptr-init expected_value (hipStreamValue.cc) and src/dst
  (hipGraphExecMemcpyNodeSetParams.cc).
  - Macro redefinition — removed the redundant local HIPRTC_CHECK in hrr_workload_test.cc (framework already provides it).

  Dead-code cleanup (uncovered while fixing -Wunused-function)

  - Removed test_hipMallocFromPoolAsync_MThread + its worker thread_Test1 (hipMallocFromPoolAsync.cc) — the old non-thread-safe MThread helper, orphaned
  when Unit_hipMallocFromPoolAsync_MThread_{Default,Max}Thresh moved to the thread-safe runMThreadReleaseThresholdTest.
  - Collapsed the identical checkGpuEnablePal/testEnvironmentVariable stubs in hipSetEnv_helper.cc into a direct initializeHIP() call in main.

## Issue Tracking

JIRA ID : AIRUNTIME-2507

## Test Plan

Updates existing testing to improve code quality

## Test Result

N/A-->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
