### PR TITLE
fix(rocjitsu): Reject AMDGPU s_clause trampoline anchors

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -18,6 +18,7 @@
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
 
+#include <algorithm>
 #include <array>
 #include <cstring>
 #include <optional>
@@ -55,6 +56,22 @@ constexpr std::string_view kRfePrefix = "s_rfe_";
   if (mnemonic.size() >= kRfePrefix.size() && mnemonic.substr(0, kRfePrefix.size()) == kRfePrefix)
     return true;
   return false;
+}
+
+[[nodiscard]] bool is_s_clause(const Instruction &inst) { return inst.mnemonic() == "s_clause"; }
+
+[[nodiscard]] uint32_t s_clause_following_instruction_count(const Instruction &inst) {
+  if (!is_s_clause(inst) || inst.size() != sizeof(uint32_t) || inst.num_src_operands() != 1)
+    return 0;
+
+  const Operand *clause = inst.src_operand(0);
+  if (clause == nullptr)
+    return 0;
+
+  // The decoded OPR_CLAUSE retains the packed SIMM16 value. SIMM16[5:0]
+  // encodes one less than the number of following instructions; bits 8:11 are
+  // BREAK_SPAN and are not part of the count.
+  return (static_cast<uint32_t>(clause->encoding_value()) & 0x3fu) + 1u;
 }
 
 // Per-site result of Instrumentor::patch's preflight: the chosen trampoline
@@ -179,6 +196,10 @@ bool is_relocatable_anchor(const Instruction &anchor, uint64_t anchor_offset,
   }
   if (is_denylisted_mnemonic(anchor.mnemonic())) {
     report(error_out, "anchor mnemonic is in the PC-relative denylist");
+    return false;
+  }
+  if (is_s_clause(anchor)) {
+    report(error_out, "anchor mnemonic is s_clause");
     return false;
   }
   return true;
@@ -330,10 +351,20 @@ bool Instrumentor::ensure_blocks_built(std::string *error_out) {
   }
   decoder_ = std::move(decoder);
   blocks_ = BasicBlock::build(obj_, *decoder_, arch_);
+  // BasicBlock::build returns blocks in .text order. Keep clause state across
+  // block boundaries because a branch target may split the linear instruction
+  // stream in the middle of a clause.
+  uint32_t clause_remaining = 0;
   for (const auto &block : blocks_) {
     uint64_t cur = block->start_offset();
     for (const Instruction &inst : block->instructions()) {
+      if (clause_remaining > 0) {
+        clause_blocked_offsets_.insert(cur);
+        --clause_remaining;
+      }
       offset_to_inst_.emplace(cur, &inst);
+      if (is_s_clause(inst))
+        clause_remaining = std::max(clause_remaining, s_clause_following_instruction_count(inst));
       cur += static_cast<uint64_t>(inst.size());
     }
   }
@@ -412,6 +443,12 @@ Instrumentor::ResolvedPoints Instrumentor::resolve_points() {
     auto site = validate_anchor(*anchor, pt.anchor_offset, text_bytes, pt, arch_, &perr);
     if (!site) {
       out.errors.push_back(std::move(perr));
+      continue;
+    }
+
+    if (clause_blocked_offsets_.contains(pt.anchor_offset)) {
+      out.errors.emplace_back("anchor is inside an s_clause run, anchor_offset = " +
+                              std::to_string(pt.anchor_offset));
       continue;
     }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
@@ -51,6 +51,7 @@
 #include <span>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace rocjitsu {
@@ -172,6 +173,9 @@ struct InstrumentedCodeObjectDebug : InstrumentedCodeObject {
 ///     program terminator, and branch_offset_bytes() is nullopt.
 ///   - anchor.mnemonic() is not in the small PC-relative denylist
 ///     (s_getpc_b64, s_call_b64, s_setpc_b64, s_swappc_b64, s_rfe_*).
+///   - anchor is not s_clause. Because this predicate has no surrounding
+///     instruction-stream context, Instrumentor additionally rejects anchors
+///     among the following instructions covered by an s_clause.
 ///
 /// @p arch is accepted now so a future denylist can grow ISA-specific entries
 /// without an API change; today's checks are uniform across all AMDGPU ISAs.
@@ -368,6 +372,10 @@ private:
   // blocks_ so find_instruction_at_offset is O(1). Pointers are stable for
   // the lifetime of blocks_ (BasicBlock owns the Instructions via unique_ptr).
   std::unordered_map<uint64_t, const Instruction *> offset_to_inst_;
+  // .text-relative byte offsets that cannot be trampoline anchors because they
+  // are among the following instructions covered by an s_clause. The s_clause
+  // instruction itself is rejected by is_relocatable_anchor().
+  std::unordered_set<uint64_t> clause_blocked_offsets_;
   bool blocks_built_ = false;
 
   // Returns false if no decoder exists for arch_ (RV32I/RV64I/INVALID/etc.);

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -271,6 +271,17 @@ TEST(Validator, RejectsDenylistedMnemonic) {
   }
 }
 
+TEST(Validator, RejectsSClauseAnchor) {
+  static constexpr uint32_t kRaw = 0xBF850001u;
+  TestInstruction anchor("s_clause", 4, /*flags=*/0, std::nullopt, &kRaw);
+  auto text = dummy_text();
+  InstrumentationPoint pt;
+
+  std::string err;
+  EXPECT_FALSE(validate_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_RDNA4, &err).has_value());
+  EXPECT_NE(err.find("s_clause"), std::string::npos) << "error was: " << err;
+}
+
 // Instruction::size() is a signed int; the `size != 4 && size != 8` check must
 // reject negative sizes (which decoders never emit in practice) rather than let
 // them through to the later cast to unsigned, where they would wrap.
@@ -412,7 +423,9 @@ uint64_t align_up_for_test(uint64_t value, uint64_t alignment) {
 // Build a minimal gfx950 ELF whose .text holds @p words verbatim. Lets a test
 // embed a real multi-word instruction (e.g. an 8-byte SOP1 + literal) rather
 // than only s_nop fillers.
-std::vector<uint8_t> make_gfx950_elf_with_text_words(const std::vector<uint32_t> &words) {
+std::vector<uint8_t>
+make_gfx950_elf_with_text_words(const std::vector<uint32_t> &words,
+                                uint32_t machine_flags = EF_AMDGPU_MACH_AMDGCN_GFX950) {
   const uint64_t text_offset = 0x100;
   const uint64_t text_size = words.size() * sizeof(uint32_t);
   const uint64_t rodata_size = 4;
@@ -437,7 +450,7 @@ std::vector<uint8_t> make_gfx950_elf_with_text_words(const std::vector<uint32_t>
   ehdr.e_machine = EM_AMDGPU;
   ehdr.e_version = 1;
   ehdr.e_shoff = shoff;
-  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX950;
+  ehdr.e_flags = machine_flags;
   ehdr.e_ehsize = sizeof(Elf64_Ehdr);
   ehdr.e_shentsize = sizeof(Elf64_Shdr);
   ehdr.e_shnum = section_count;
@@ -696,6 +709,105 @@ TEST(Instrumentor, RejectsOffsetInteriorToMultiWordInstruction) {
   ASSERT_FALSE(result.errors.empty());
   EXPECT_NE(result.errors.front().find("no decoded instruction"), std::string::npos)
       << "error was: " << result.errors.front();
+}
+
+TEST(Instrumentor, UsesGfx12SClauseCountAndAcceptsFirstInstructionAfterRun) {
+  const std::vector<uint32_t> words = {
+      0xBF850A01u,              // s_clause 1, BREAK_SPAN=0xa: covers two instructions.
+      0xF4002200u, 0xF8000020u, // s_load_b64 s[8:9], s[0:1], 0x20
+      0xF4006000u, 0xF8000000u, // s_load_b256 s[0:7], s[0:1], 0x0
+      0x06040F06u,              // v_add_f32_e32 v2, v6, v7
+  };
+  auto image = make_gfx950_elf_with_text_words(words, EF_AMDGPU_MACH_AMDGCN_GFX1201);
+  AmdGpuCodeObject obj(image.data(), image.size());
+  ASSERT_TRUE(obj.is_valid());
+
+  Instrumentor covered(obj, ROCJITSU_CODE_ARCH_RDNA4);
+  covered.add_point_by_offset(/*anchor_offset=*/12);
+
+  auto covered_result = covered.validate_points();
+  EXPECT_TRUE(covered_result.sites.empty());
+  ASSERT_FALSE(covered_result.errors.empty());
+  EXPECT_NE(covered_result.errors.front().find("inside an s_clause run"), std::string::npos)
+      << "error was: " << covered_result.errors.front();
+
+  Instrumentor after(obj, ROCJITSU_CODE_ARCH_RDNA4);
+  after.add_point_by_offset(/*anchor_offset=*/20);
+  auto after_result = after.validate_points();
+  EXPECT_TRUE(after_result.errors.empty())
+      << (after_result.errors.empty() ? std::string{} : after_result.errors.front());
+  ASSERT_EQ(after_result.sites.size(), 1u);
+  EXPECT_EQ(after_result.sites.front().anchor_offset, 20u);
+}
+
+TEST(Instrumentor, CarriesSClauseCoverageAcrossBasicBlockBoundary) {
+  const std::vector<uint32_t> words = {
+      0xBF850001u,              // s_clause 1: covers the next two instructions.
+      0xF4002200u, 0xF8000020u, // s_load_b64 s[8:9], s[0:1], 0x20
+      0xF4006000u, 0xF8000000u, // s_load_b256 s[0:7], s[0:1], 0x0; branch target.
+      0x06040F06u,              // v_add_f32_e32 v2, v6, v7
+      0xBF82FFFCu,              // s_branch from 0x18 back to 0x0c.
+  };
+  auto image = make_gfx950_elf_with_text_words(words, EF_AMDGPU_MACH_AMDGCN_GFX1201);
+  AmdGpuCodeObject obj(image.data(), image.size());
+  ASSERT_TRUE(obj.is_valid());
+
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_RDNA4);
+  instrumentor.add_point_by_offset(/*anchor_offset=*/12);
+
+  auto result = instrumentor.validate_points();
+  EXPECT_TRUE(result.sites.empty());
+  ASSERT_FALSE(result.errors.empty());
+  EXPECT_NE(result.errors.front().find("inside an s_clause run"), std::string::npos)
+      << "error was: " << result.errors.front();
+}
+
+TEST(Instrumentor, RejectsAvailableInstructionInTruncatedSClauseRun) {
+  const std::vector<uint32_t> words = {
+      0xBF85003Fu, // s_clause 63: claims 64 following instructions.
+      0x06040F06u, // only one following instruction is present.
+  };
+  auto image = make_gfx950_elf_with_text_words(words, EF_AMDGPU_MACH_AMDGCN_GFX1201);
+  AmdGpuCodeObject obj(image.data(), image.size());
+  ASSERT_TRUE(obj.is_valid());
+
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_RDNA4);
+  instrumentor.add_point_by_offset(/*anchor_offset=*/4);
+  auto result = instrumentor.validate_points();
+  EXPECT_TRUE(result.sites.empty());
+  ASSERT_FALSE(result.errors.empty());
+  EXPECT_NE(result.errors.front().find("inside an s_clause run"), std::string::npos)
+      << "error was: " << result.errors.front();
+}
+
+TEST(Instrumentor, PreservesOuterCoverageAcrossOverlappingSClauses) {
+  const std::vector<uint32_t> words = {
+      0xBF850003u, // s_clause 3: covers the next four instructions.
+      0xBF850000u, // s_clause 0: covers only the next instruction.
+      0x06040F06u, // v_add_f32_e32 v2, v6, v7
+      0x06040F06u, // remains covered by the outer clause.
+      0x06040F06u, // final instruction covered by the outer clause.
+      0x06040F06u, // first instruction after both clauses.
+  };
+  auto image = make_gfx950_elf_with_text_words(words, EF_AMDGPU_MACH_AMDGCN_GFX1201);
+  AmdGpuCodeObject obj(image.data(), image.size());
+  ASSERT_TRUE(obj.is_valid());
+
+  Instrumentor covered(obj, ROCJITSU_CODE_ARCH_RDNA4);
+  covered.add_point_by_offset(/*anchor_offset=*/16);
+  auto covered_result = covered.validate_points();
+  EXPECT_TRUE(covered_result.sites.empty());
+  ASSERT_FALSE(covered_result.errors.empty());
+  EXPECT_NE(covered_result.errors.front().find("inside an s_clause run"), std::string::npos)
+      << "error was: " << covered_result.errors.front();
+
+  Instrumentor after(obj, ROCJITSU_CODE_ARCH_RDNA4);
+  after.add_point_by_offset(/*anchor_offset=*/20);
+  auto after_result = after.validate_points();
+  EXPECT_TRUE(after_result.errors.empty())
+      << (after_result.errors.empty() ? std::string{} : after_result.errors.front());
+  ASSERT_EQ(after_result.sites.size(), 1u);
+  EXPECT_EQ(after_result.sites.front().anchor_offset, 20u);
 }
 
 TEST(Instrumentor, UnsupportedArchReportsErrorInsteadOfCrashing) {


### PR DESCRIPTION
Restacked replacement for #8694, which GitHub marked merged into a feature branch during stack reordering; this PR targets develop directly.\n\nAn s_clause instruction groups the following memory operations for scheduling. Relocating the clause or any covered instruction into an out-of-line trampoline breaks that grouping and can change program semantics.\n\nTeach the native instrumentor to reject both the s_clause instruction and every instruction in its declared run. Add focused tests for a direct clause anchor and an interior covered instruction.\n\nISSUE ID : #8701