### PR TITLE
hipfile: update CODEOWNERS with hipfile-docs-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -123,5 +123,8 @@
 /projects/rocjpeg/**/*.rst                                            @ROCm/rocjpeg-docs-reviewers
 /projects/rocjpeg/**/.readthedocs.yaml                                @ROCm/rocjpeg-docs-reviewers
 
+/projects/hipfile/**/*.md                                             @ROCm/hipfile-docs-reviewers
+/projects/hipfile/**/*.rst                                            @ROCm/hipfile-docs-reviewers
+/projects/hipfile/**/.readthedocs.yaml                                @ROCm/hipfile-docs-reviewers
 
 /projects/rocprof-trace-decoder/**/*.md                               @ROCm/rocm-devtools-team @ROCm/rocm-documentation


### PR DESCRIPTION
## Motivation

The hipfile project has a new team, hipfile-docs-reviewers, for reviewing documentation. Have added it to the codeowners file so that the members of the team get automatic notifications.