### PR TITLE
test(rccl): Validate and document env plugin feature

### DIFF
--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 
 # RCCL project
 #==================================================================================================
-project(rccl CXX)
+project(rccl C CXX)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set(NCCL_OS_WINDOWS ON)
@@ -755,6 +755,8 @@ if(BUILD_TESTS)
     add_subdirectory(plugins/tuner/example)
     add_subdirectory(plugins/profiler/example)
     add_subdirectory(plugins/profiler/proxytrace)
+    add_subdirectory(plugins/env/example)
+    add_subdirectory(plugins/env/json)
   endif()
   add_subdirectory(test)
 

--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -84,7 +84,7 @@ option(BUILD_BFD                               "Enable custom backtrace (if bfd.
 option(BUILD_LOCAL_GPU_TARGET_ONLY             "Build only for GPUs detected on this machine"  OFF)
 option(BUILD_SHARED_LIBS                       "Build as shared library"                       ON)
 option(BUILD_TESTS                             "Build unit test programs"                      OFF)
-option(BUILD_EXT_EXAMPLES                      "Build ext-{net,tuner,profiler} example plugins" OFF)
+option(BUILD_EXT_EXAMPLES                      "Build ext-{net,tuner,profiler,env} example plugins" OFF)
 option(DUMP_ASM                                "Disassemble and dump"                          OFF)
 option(ENABLE_CODE_COVERAGE                    "Enable code coverage"                          OFF)
 option(ENABLE_IFC                              "Enable indirect function call"                 OFF)

--- a/projects/rccl/docs/api-reference/env-variables.rst
+++ b/projects/rccl/docs/api-reference/env-variables.rst
@@ -62,6 +62,18 @@ in the following table.
       - | Positive integer (values ``<= 0`` are ignored).
         | Default: unset (uses the RCCL default).
 
+    * - | ``NCCL_ENV_PLUGIN``
+        | Loads an external environment plugin that intercepts all RCCL parameter
+          lookups. See :ref:`using-rccl-env-plugin` for full details.
+      - | Absolute path to a plugin ``.so`` file, or ``none`` to disable.
+        | Default: unset (reads from process environment).
+
+    * - | ``NCCL_ENV_JSON_FILE``
+        | Path to a JSON configuration file used by ``librccl-env-json.so``.
+          Has no effect unless ``NCCL_ENV_PLUGIN`` points to that plugin.
+      - | Absolute path to a flat JSON file mapping variable names to string values.
+        | Default: unset (falls back to ``getenv()`` for all lookups).
+
 Logging and debugging
 =====================
 

--- a/projects/rccl/docs/how-to/using-rccl-env-plugin-api.rst
+++ b/projects/rccl/docs/how-to/using-rccl-env-plugin-api.rst
@@ -1,0 +1,303 @@
+.. meta::
+   :description: How to use the RCCL environment plugin API
+   :keywords: RCCL, ROCm, library, API, environment, plugin, NCCL_ENV_PLUGIN, JSON
+
+.. _using-rccl-env-plugin:
+
+***********************************
+Using the RCCL environment plugin API
+***********************************
+
+The RCCL environment plugin API lets deployments supply NCCL/RCCL configuration
+parameters from a custom source — such as a centralized configuration database,
+a secrets manager, or a JSON file — without relying on process-level environment
+variables. The active plugin intercepts every internal ``ncclGetEnv()`` call, so
+all RCCL parameters that are normally read from the environment are transparently
+routed through the plugin.
+
+Overview
+========
+
+By default RCCL reads parameters directly from the process environment via
+``getenv()``. When ``NCCL_ENV_PLUGIN`` is set to a shared library path, RCCL
+loads that library at initialization time and delegates all environment lookups
+to the plugin's ``getEnv`` function.
+
+This is useful in the following scenarios:
+
+* **Centralized configuration** — a cluster operator wants to push RCCL parameters
+  to all jobs from a single source of truth without requiring users to set environment
+  variables in their job scripts.
+* **Secret management** — sensitive values (for example, authentication tokens used
+  by a custom net plugin) can be fetched from a secrets manager at runtime instead
+  of being stored in plain-text environment variables.
+* **Per-job configuration files** — a JSON file packaged with the job can override
+  specific parameters without polluting the process environment.
+
+Environment variables
+=====================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - **Environment variable**
+     - **Description**
+
+   * - | ``NCCL_ENV_PLUGIN``
+       | Path to the env plugin shared library, or ``none`` to disable
+         external plugin loading.
+     - | String: absolute path to a ``.so`` file, or the literal string ``none``.
+       | Default: unset (RCCL reads directly from the process environment).
+       | Example: ``export NCCL_ENV_PLUGIN=/opt/rccl-plugins/librccl-env-json.so``
+
+Lookup precedence
+-----------------
+
+When a plugin is loaded, RCCL routes all ``ncclGetEnv()`` calls to the plugin's
+``getEnv`` function. The plugin is responsible for deciding the precedence between
+its own source and the process environment. The reference JSON plugin (described
+below) uses the following order:
+
+1. Value from the JSON file (if the key is present).
+2. Value from the process environment (``getenv()``).
+3. ``NULL`` if the key is not found in either source.
+
+API description
+===============
+
+To build a custom env plugin, implement and export the ``ncclEnvPlugin_v1``
+symbol of type ``ncclEnv_v1_t``.
+
+Structure: ``ncclEnv_v1_t``
+---------------------------
+
+.. code-block:: c
+
+   typedef struct {
+     const char* name;
+     ncclResult_t (*init)(uint8_t ncclMajor, uint8_t ncclMinor,
+                          uint8_t ncclPatch, const char* suffix);
+     ncclResult_t (*finalize)(void);
+     const char*  (*getEnv)(const char* name);
+   } ncclEnv_v1_t;
+
+**Fields**
+
+* ``name``
+
+  * **Type**: ``const char*``
+  * **Description**: Human-readable plugin name, used in RCCL log output when
+    ``NCCL_DEBUG=INFO`` and ``NCCL_DEBUG_SUBSYS=ENV`` are set.
+
+**Functions**
+
+* ``init`` (called once during RCCL initialization)
+
+  Sets up any plugin state, opens configuration sources, and prepares for
+  subsequent ``getEnv`` calls.
+
+  * **Parameters**:
+
+    * ``ncclMajor``, ``ncclMinor``, ``ncclPatch`` (``uint8_t``): RCCL version
+      numbers, allowing version-specific behavior in the plugin.
+    * ``suffix`` (``const char*``): RCCL version suffix string (for example,
+      ``"rc1"``).
+
+  * **Return**: ``ncclResult_t`` — return ``ncclSuccess`` on success.
+
+* ``finalize`` (called during RCCL teardown)
+
+  Releases all resources allocated by the plugin.
+
+  * **Return**: ``ncclResult_t`` — return ``ncclSuccess`` on success.
+
+* ``getEnv`` (called for every RCCL parameter lookup)
+
+  Returns the value of the named variable, or ``NULL`` if the variable is not
+  found. The returned pointer must remain valid until RCCL calls ``finalize``
+  or calls ``getEnv`` again for the same variable name. Modifying the variable
+  via ``setenv``/``putenv`` after returning a pointer to it is undefined behavior.
+
+  * **Parameters**:
+
+    * ``name`` (``const char*``): The name of the variable to look up, for example
+      ``"NCCL_DEBUG"`` or ``"NCCL_ALGO"``.
+
+  * **Return**: ``const char*`` — pointer to the value string, or ``NULL``.
+
+Plugin symbol
+-------------
+
+The plugin shared library must export the following symbol at the top level
+(not ``static``):
+
+.. code-block:: c
+
+   const ncclEnv_v1_t ncclEnvPlugin_v1 = {
+     .name     = "myPlugin",
+     .init     = myInit,
+     .finalize = myFinalize,
+     .getEnv   = myGetEnv,
+   };
+
+The required headers are available under
+``plugins/env/example/nccl/`` in the RCCL source tree.
+
+Reference JSON plugin
+=====================
+
+RCCL ships a reference implementation at ``plugins/env/json/plugin.c`` that
+reads parameters from a flat JSON file. It can be used directly in deployments
+or as a starting point for a custom plugin.
+
+JSON file format
+----------------
+
+The JSON file must be a single flat object mapping variable names to string
+values:
+
+.. code-block:: json
+
+   {
+     "NCCL_DEBUG": "INFO",
+     "NCCL_ALGO": "Ring",
+     "NCCL_DEBUG_SUBSYS": "ENV,INIT"
+   }
+
+.. note::
+
+   Only flat string values are supported. Nested objects, arrays, numbers,
+   and booleans are not valid. Keys and values must not exceed 255 and 4095
+   characters respectively. Files larger than 1 MB are not supported.
+
+Usage
+-----
+
+#. Build the JSON plugin by configuring RCCL with ``-DBUILD_TESTS=ON -DBUILD_EXT_EXAMPLES=ON``:
+
+   .. code-block:: shell
+
+      cmake /path/to/rccl -DBUILD_TESTS=ON -DBUILD_EXT_EXAMPLES=ON
+      make rccl-env-json
+
+   The plugin is built as ``librccl-env-json.so`` in the build output under
+   ``test/unit/plugins/``.
+
+#. Create a JSON configuration file:
+
+   .. code-block:: shell
+
+      cat > /etc/rccl/config.json << 'EOF'
+      {
+        "NCCL_DEBUG": "WARN",
+        "NCCL_SOCKET_IFNAME": "eth0"
+      }
+      EOF
+
+#. Set the two environment variables before launching your workload:
+
+   .. code-block:: shell
+
+      export NCCL_ENV_PLUGIN=/path/to/librccl-env-json.so
+      export NCCL_ENV_JSON_FILE=/etc/rccl/config.json
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 40 60
+
+      * - **Environment variable**
+        - **Description**
+
+      * - | ``NCCL_ENV_JSON_FILE``
+          | Path to the JSON configuration file used by ``librccl-env-json.so``.
+        - | String: absolute path to a JSON file.
+          | Default: unset (plugin falls back to ``getenv()`` for all lookups).
+
+.. note::
+
+   ``NCCL_ENV_PLUGIN`` and ``NCCL_ENV_JSON_FILE`` must be set in the process
+   environment before RCCL is initialized. They are read during plugin load
+   and are not re-read after initialization.
+
+Building a custom plugin
+========================
+
+#. Copy the reference headers from ``plugins/env/example/nccl/`` into your
+   project.
+
+#. Implement the ``ncclEnv_v1_t`` interface and export ``ncclEnvPlugin_v1``:
+
+   .. code-block:: c
+
+      #include "nccl/env.h"
+
+      static ncclResult_t myInit(uint8_t major, uint8_t minor,
+                                  uint8_t patch, const char* suffix) {
+        /* open your configuration source here */
+        return ncclSuccess;
+      }
+
+      static ncclResult_t myFinalize(void) {
+        /* release resources here */
+        return ncclSuccess;
+      }
+
+      static const char* myGetEnv(const char* name) {
+        /* look up name in your configuration source;
+           return NULL if not found */
+        return getenv(name); /* minimal fallback */
+      }
+
+      const ncclEnv_v1_t ncclEnvPlugin_v1 = {
+        .name     = "myPlugin",
+        .init     = myInit,
+        .finalize = myFinalize,
+        .getEnv   = myGetEnv,
+      };
+
+#. Build as a shared library:
+
+   .. code-block:: shell
+
+      cc -shared -fPIC -o librccl-env-myplugin.so plugin.c
+
+#. Set ``NCCL_ENV_PLUGIN`` to the absolute path of the resulting ``.so`` file.
+
+Fallback behavior
+=================
+
+If ``NCCL_ENV_PLUGIN`` is unset, set to ``none``, or points to a library that
+cannot be loaded (for example, wrong path or missing symbol ``ncclEnvPlugin_v1``),
+RCCL silently falls back to reading parameters directly from the process
+environment via ``getenv()``. No error is raised and the application continues
+to run normally.
+
+Setting ``NCCL_ENV_PLUGIN=none`` is always a safe rollback path.
+
+Troubleshooting
+===============
+
+Set ``NCCL_DEBUG=INFO`` and ``NCCL_DEBUG_SUBSYS=ENV,INIT`` to see plugin load
+messages:
+
+.. code-block:: shell
+
+   export NCCL_DEBUG=INFO
+   export NCCL_DEBUG_SUBSYS=ENV,INIT
+   export NCCL_ENV_PLUGIN=/path/to/librccl-env-json.so
+
+Expected output on successful load:
+
+.. code-block:: text
+
+   NCCL INFO NCCL_ENV_PLUGIN set by environment to /path/to/librccl-env-json.so
+   NCCL INFO ENV/Plugin: Using ncclEnvJson (v1)
+   NCCL INFO Successfully loaded external env plugin /path/to/librccl-env-json.so
+
+If the plugin fails to load (wrong path or missing ``ncclEnvPlugin_v1`` symbol):
+
+.. code-block:: text
+
+   NCCL INFO NCCL_ENV_PLUGIN set by environment to /path/to/librccl-env-json.so
+   NCCL INFO External env plugin /path/to/librccl-env-json.so is unsupported

--- a/projects/rccl/docs/index.rst
+++ b/projects/rccl/docs/index.rst
@@ -27,6 +27,7 @@ The RCCL public repository is located within the rocm-systems repo at `<https://
   .. grid-item-card:: How to
 
     * :doc:`Using the RCCL Tuner plugin <./how-to/using-rccl-tuner-plugin-api>`
+    * :doc:`Using the RCCL environment plugin <./how-to/using-rccl-env-plugin-api>`
     * :doc:`Using the NCCL Net plugin <./how-to/using-nccl>`
     * :doc:`Fault tolerance in RCCL <./how-to/fault-tolerance>`
     * :doc:`Troubleshoot RCCL <./how-to/troubleshooting-rccl>`

--- a/projects/rccl/plugins/env/json/CMakeLists.txt
+++ b/projects/rccl/plugins/env/json/CMakeLists.txt
@@ -7,14 +7,14 @@ set(SRC_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/plugin.c
 )
 
-add_library(nccl-env-json SHARED ${SRC_FILES})
+add_library(rccl-env-json SHARED ${SRC_FILES})
 
-target_include_directories(nccl-env-json PRIVATE
+target_include_directories(rccl-env-json PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/../example
 )
 
-set_target_properties(nccl-env-json PROPERTIES
-  OUTPUT_NAME "nccl-env-json"
+set_target_properties(rccl-env-json PROPERTIES
+  OUTPUT_NAME "rccl-env-json"
   PREFIX "lib"
   POSITION_INDEPENDENT_CODE ON
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test/unit/plugins

--- a/projects/rccl/plugins/env/json/CMakeLists.txt
+++ b/projects/rccl/plugins/env/json/CMakeLists.txt
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+
+set(SRC_FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/plugin.c
+)
+
+add_library(nccl-env-json SHARED ${SRC_FILES})
+
+target_include_directories(nccl-env-json PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/../example
+)
+
+set_target_properties(nccl-env-json PROPERTIES
+  OUTPUT_NAME "nccl-env-json"
+  PREFIX "lib"
+  POSITION_INDEPENDENT_CODE ON
+  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test/unit/plugins
+)

--- a/projects/rccl/plugins/env/json/plugin.c
+++ b/projects/rccl/plugins/env/json/plugin.c
@@ -6,7 +6,7 @@
  * JSON file instead of (or in addition to) process-level env vars.
  *
  * Usage:
- *   export NCCL_ENV_PLUGIN=/path/to/libnccl-env-json.so
+ *   export NCCL_ENV_PLUGIN=/path/to/librccl-env-json.so
  *   export NCCL_ENV_JSON_FILE=/path/to/config.json
  *
  * The JSON file is a flat object mapping NCCL/RCCL variable names to
@@ -69,7 +69,10 @@ static int loadJsonFile(const char *path) {
   if (!buf) { fclose(f); return -1; }
 
   size_t n = fread(buf, 1, MAX_FILE_SIZE - 1, f);
+  int readErr = ferror(f);
+  int truncated = !feof(f);
   fclose(f);
+  if (readErr || truncated) { free(buf); return -1; }
   buf[n] = '\0';
 
   numEntries = 0;
@@ -81,26 +84,28 @@ static int loadJsonFile(const char *path) {
   while (numEntries < MAX_ENTRIES) {
     skipWhitespace(&p);
     if (*p == '}') break;
-    if (*p == ',') { p++; continue; }
+    if (*p == ',' && numEntries > 0) { p++; continue; }
 
-    char key[MAX_KEY_LEN], val[MAX_VAL_LEN];
-    if (parseString(&p, key, MAX_KEY_LEN) != 0) break;
+    if (parseString(&p, entries[numEntries].key, MAX_KEY_LEN) != 0) {
+      free(buf);
+      return -1;
+    }
 
     skipWhitespace(&p);
-    if (*p != ':') break;
+    if (*p != ':') { free(buf); return -1; }
     p++;
 
-    if (parseString(&p, val, MAX_VAL_LEN) != 0) break;
+    if (parseString(&p, entries[numEntries].value, MAX_VAL_LEN) != 0) {
+      free(buf);
+      return -1;
+    }
 
-    strncpy(entries[numEntries].key, key, MAX_KEY_LEN - 1);
-    entries[numEntries].key[MAX_KEY_LEN - 1] = '\0';
-    strncpy(entries[numEntries].value, val, MAX_VAL_LEN - 1);
-    entries[numEntries].value[MAX_VAL_LEN - 1] = '\0';
     numEntries++;
   }
 
+  int ok = (*p == '}') ? 0 : -1;
   free(buf);
-  return 0;
+  return ok;
 }
 
 static ncclResult_t ncclEnvJsonInit(uint8_t ncclMajor, uint8_t ncclMinor,

--- a/projects/rccl/plugins/env/json/plugin.c
+++ b/projects/rccl/plugins/env/json/plugin.c
@@ -1,0 +1,139 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Reference NCCL/RCCL environment plugin that reads parameters from a
+ * JSON file instead of (or in addition to) process-level env vars.
+ *
+ * Usage:
+ *   export NCCL_ENV_PLUGIN=/path/to/libnccl-env-json.so
+ *   export NCCL_ENV_JSON_FILE=/path/to/config.json
+ *
+ * The JSON file is a flat object mapping NCCL/RCCL variable names to
+ * string values, e.g.:
+ *   { "NCCL_DEBUG": "INFO", "NCCL_ALGO": "Ring" }
+ *
+ * Lookup precedence: JSON file value > process environment (getenv).
+ * If NCCL_ENV_JSON_FILE is unset or the file cannot be read, the
+ * plugin falls back to getenv() for all lookups.
+ *************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include "nccl/env.h"
+
+#define MAX_ENTRIES  256
+#define MAX_KEY_LEN  256
+#define MAX_VAL_LEN  4096
+#define MAX_FILE_SIZE (1 << 20)
+
+typedef struct {
+  char key[MAX_KEY_LEN];
+  char value[MAX_VAL_LEN];
+} EnvEntry;
+
+static EnvEntry entries[MAX_ENTRIES];
+static int      numEntries = 0;
+static int      jsonLoaded = 0;
+
+static void skipWhitespace(const char **p) {
+  while (**p && isspace((unsigned char)**p)) (*p)++;
+}
+
+static int parseString(const char **p, char *out, int maxLen) {
+  skipWhitespace(p);
+  if (**p != '"') return -1;
+  (*p)++;
+  int i = 0;
+  while (**p && **p != '"' && i < maxLen - 1) {
+    if (**p == '\\') {
+      (*p)++;
+      if (!**p) return -1;
+    }
+    out[i++] = **p;
+    (*p)++;
+  }
+  out[i] = '\0';
+  if (**p == '"') (*p)++;
+  else return -1;
+  return 0;
+}
+
+static int loadJsonFile(const char *path) {
+  FILE *f = fopen(path, "r");
+  if (!f) return -1;
+
+  char *buf = (char *)malloc(MAX_FILE_SIZE);
+  if (!buf) { fclose(f); return -1; }
+
+  size_t n = fread(buf, 1, MAX_FILE_SIZE - 1, f);
+  fclose(f);
+  buf[n] = '\0';
+
+  numEntries = 0;
+  const char *p = buf;
+  skipWhitespace(&p);
+  if (*p != '{') { free(buf); return -1; }
+  p++;
+
+  while (numEntries < MAX_ENTRIES) {
+    skipWhitespace(&p);
+    if (*p == '}') break;
+    if (*p == ',') { p++; continue; }
+
+    char key[MAX_KEY_LEN], val[MAX_VAL_LEN];
+    if (parseString(&p, key, MAX_KEY_LEN) != 0) break;
+
+    skipWhitespace(&p);
+    if (*p != ':') break;
+    p++;
+
+    if (parseString(&p, val, MAX_VAL_LEN) != 0) break;
+
+    strncpy(entries[numEntries].key, key, MAX_KEY_LEN - 1);
+    entries[numEntries].key[MAX_KEY_LEN - 1] = '\0';
+    strncpy(entries[numEntries].value, val, MAX_VAL_LEN - 1);
+    entries[numEntries].value[MAX_VAL_LEN - 1] = '\0';
+    numEntries++;
+  }
+
+  free(buf);
+  return 0;
+}
+
+static ncclResult_t ncclEnvJsonInit(uint8_t ncclMajor, uint8_t ncclMinor,
+                                     uint8_t ncclPatch, const char *suffix) {
+  const char *jsonPath = getenv("NCCL_ENV_JSON_FILE");
+  if (jsonPath && strlen(jsonPath) > 0) {
+    if (loadJsonFile(jsonPath) == 0) {
+      jsonLoaded = 1;
+    }
+  }
+  return ncclSuccess;
+}
+
+static ncclResult_t ncclEnvJsonFinalize(void) {
+  numEntries = 0;
+  jsonLoaded = 0;
+  return ncclSuccess;
+}
+
+static const char *ncclEnvJsonGetEnv(const char *name) {
+  if (jsonLoaded) {
+    for (int i = 0; i < numEntries; i++) {
+      if (strcmp(entries[i].key, name) == 0) {
+        return entries[i].value;
+      }
+    }
+  }
+  return getenv(name);
+}
+
+const ncclEnv_v1_t ncclEnvPlugin_v1 = {
+    .name     = "ncclEnvJson",
+    .init     = ncclEnvJsonInit,
+    .finalize = ncclEnvJsonFinalize,
+    .getEnv   = ncclEnvJsonGetEnv,
+};

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -337,7 +337,6 @@ if(BUILD_TESTS)
     set(TEST_FIXTURE_DEBUG_SOURCE_FILES
       AllocTests.cpp
       ParamTests.cpp
-
       ParameterApiTests.cpp
       EnvPluginTests.cpp
       ArgCheckTests.cpp
@@ -369,13 +368,6 @@ if(BUILD_TESTS)
     # so they can build the path.
     target_compile_definitions(rccl-UnitTestsFixturesDebug PRIVATE
       RCCL_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
-
-    add_custom_command(TARGET rccl-UnitTestsFixturesDebug POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "${CMAKE_CURRENT_SOURCE_DIR}/EnvPluginTestsConfFile.txt"
-        "$<TARGET_FILE_DIR:rccl-UnitTestsFixturesDebug>/EnvPluginTestsConfFile.txt"
-      COMMENT "Copying EnvPluginTestsConfFile.txt to test output directory"
-    )
   endif()
 
   # rccl-UnitTestsAltRsmi: Compiles alt_rsmi.cc directly (not via librccl.so) with

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -337,7 +337,9 @@ if(BUILD_TESTS)
     set(TEST_FIXTURE_DEBUG_SOURCE_FILES
       AllocTests.cpp
       ParamTests.cpp
+
       ParameterApiTests.cpp
+      EnvPluginTests.cpp
       ArgCheckTests.cpp
       BootstrapBidirTests.cpp
       DdaAlltoAllThresholdTests.cpp
@@ -367,6 +369,13 @@ if(BUILD_TESTS)
     # so they can build the path.
     target_compile_definitions(rccl-UnitTestsFixturesDebug PRIVATE
       RCCL_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+
+    add_custom_command(TARGET rccl-UnitTestsFixturesDebug POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${CMAKE_CURRENT_SOURCE_DIR}/EnvPluginTestsConfFile.txt"
+        "$<TARGET_FILE_DIR:rccl-UnitTestsFixturesDebug>/EnvPluginTestsConfFile.txt"
+      COMMENT "Copying EnvPluginTestsConfFile.txt to test output directory"
+    )
   endif()
 
   # rccl-UnitTestsAltRsmi: Compiles alt_rsmi.cc directly (not via librccl.so) with

--- a/projects/rccl/test/EnvPluginTests.cpp
+++ b/projects/rccl/test/EnvPluginTests.cpp
@@ -14,6 +14,9 @@
 #include <cstdio>
 #include <filesystem>
 #include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 namespace RcclUnitTesting {
 
@@ -94,19 +97,6 @@ TEST(EnvPluginTests, PluginInitialized_ReportsTrue) {
       {{"NCCL_ENV_PLUGIN", "none"}});
 }
 
-TEST(EnvPluginTests, ConfFile_LoadedBeforePlugin) {
-  RUN_ISOLATED_TEST_WITH_ENV(
-      "ConfFile_LoadedBeforePlugin",
-      []() {
-        initEnv();
-        const char* val = ncclGetEnv("RCCL_CONF_TEST_KEY");
-        ASSERT_NE(val, nullptr);
-        ASSERT_STREQ(val, "conf_value");
-      },
-      {{"NCCL_ENV_PLUGIN", "none"},
-       {"NCCL_CONF_FILE", "EnvPluginTestsConfFile.txt"}});
-}
-
 // ---------------------------------------------------------------------------
 // External-plugin tests (Goal 3): exercise the full dlopen path
 //
@@ -147,7 +137,7 @@ TEST(EnvPluginTests, ExternalPlugin_ExamplePlugin_Loaded) {
       });
 }
 
-// Verifies that libnccl-env-json.so is dlopened and that a value present in
+// Verifies that librccl-env-json.so is dlopened and that a value present in
 // the JSON config file overrides the same key set in the process environment.
 // This is the strongest proof that the external plugin — not the internal
 // getenv() fallback — handled the lookup.
@@ -155,9 +145,9 @@ TEST(EnvPluginTests, ExternalPlugin_JsonPlugin_OverridesGetenv) {
   RUN_ISOLATED_TEST(
       "ExternalPlugin_JsonPlugin_OverridesGetenv",
       []() {
-        std::string pluginPath = getTestPluginPath("libnccl-env-json.so");
+        std::string pluginPath = getTestPluginPath("librccl-env-json.so");
         if (!std::filesystem::exists(pluginPath)) {
-          GTEST_SKIP() << "libnccl-env-json.so not found at " << pluginPath
+          GTEST_SKIP() << "librccl-env-json.so not found at " << pluginPath
                        << " — rebuild with -DBUILD_EXT_EXAMPLES=ON";
         }
 
@@ -185,15 +175,15 @@ TEST(EnvPluginTests, ExternalPlugin_JsonPlugin_OverridesGetenv) {
       });
 }
 
-// Verifies that libnccl-env-json.so falls back to getenv() for a key that is
+// Verifies that librccl-env-json.so falls back to getenv() for a key that is
 // absent from the JSON file.
 TEST(EnvPluginTests, ExternalPlugin_JsonPlugin_FallsBackToGetenv) {
   RUN_ISOLATED_TEST(
       "ExternalPlugin_JsonPlugin_FallsBackToGetenv",
       []() {
-        std::string pluginPath = getTestPluginPath("libnccl-env-json.so");
+        std::string pluginPath = getTestPluginPath("librccl-env-json.so");
         if (!std::filesystem::exists(pluginPath)) {
-          GTEST_SKIP() << "libnccl-env-json.so not found at " << pluginPath
+          GTEST_SKIP() << "librccl-env-json.so not found at " << pluginPath
                        << " — rebuild with -DBUILD_EXT_EXAMPLES=ON";
         }
 
@@ -220,15 +210,15 @@ TEST(EnvPluginTests, ExternalPlugin_JsonPlugin_FallsBackToGetenv) {
       });
 }
 
-// Verifies that libnccl-env-json.so returns nullptr for a key absent from
+// Verifies that librccl-env-json.so returns nullptr for a key absent from
 // both the JSON file and the process environment.
 TEST(EnvPluginTests, ExternalPlugin_JsonPlugin_UnsetKeyReturnsNull) {
   RUN_ISOLATED_TEST(
       "ExternalPlugin_JsonPlugin_UnsetKeyReturnsNull",
       []() {
-        std::string pluginPath = getTestPluginPath("libnccl-env-json.so");
+        std::string pluginPath = getTestPluginPath("librccl-env-json.so");
         if (!std::filesystem::exists(pluginPath)) {
-          GTEST_SKIP() << "libnccl-env-json.so not found at " << pluginPath
+          GTEST_SKIP() << "librccl-env-json.so not found at " << pluginPath
                        << " — rebuild with -DBUILD_EXT_EXAMPLES=ON";
         }
 
@@ -248,6 +238,113 @@ TEST(EnvPluginTests, ExternalPlugin_JsonPlugin_UnsetKeyReturnsNull) {
         ASSERT_TRUE(ncclEnvPluginInitialized());
         ASSERT_EQ(val, nullptr);
 
+        remove(jsonPath.c_str());
+      });
+}
+
+// Verifies that librccl-env-json.so treats a malformed JSON file as a load
+// failure (loadJsonFile returns -1, jsonLoaded stays 0) and falls back to
+// getenv() for all lookups.
+TEST(EnvPluginTests, ExternalPlugin_JsonPlugin_MalformedJson_FallsBackToGetenv) {
+  RUN_ISOLATED_TEST(
+      "ExternalPlugin_JsonPlugin_MalformedJson_FallsBackToGetenv",
+      []() {
+        std::string pluginPath = getTestPluginPath("librccl-env-json.so");
+        if (!std::filesystem::exists(pluginPath)) {
+          GTEST_SKIP() << "librccl-env-json.so not found at " << pluginPath
+                       << " — rebuild with -DBUILD_EXT_EXAMPLES=ON";
+        }
+
+        std::string jsonPath = std::string("/tmp/rccl_test_json_malformed_") +
+                               std::to_string(getpid()) + ".json";
+        FILE* f = fopen(jsonPath.c_str(), "w");
+        ASSERT_NE(f, nullptr) << "Failed to create temp JSON file: " << jsonPath;
+        // Missing quotes around key — parseString returns -1, loadJsonFile returns -1.
+        fprintf(f, "{badkey: \"value\"}");
+        fclose(f);
+
+        setenv("NCCL_TEST_JSON_MALFORMED", "from_getenv", 1);
+        setenv("NCCL_ENV_PLUGIN", pluginPath.c_str(), 1);
+        setenv("NCCL_ENV_JSON_FILE", jsonPath.c_str(), 1);
+
+        initEnv();
+        // jsonLoaded must be 0 (load failed) so getenv fallback is used.
+        const char* val = ncclGetEnv("NCCL_TEST_JSON_MALFORMED");
+        ASSERT_NE(val, nullptr);
+        ASSERT_STREQ(val, "from_getenv");
+
+        unsetenv("NCCL_TEST_JSON_MALFORMED");
+        remove(jsonPath.c_str());
+      });
+}
+
+// Verifies that librccl-env-json.so treats a JSON file whose root is not an
+// object (e.g. an array) as a load failure and falls back to getenv().
+// Covers the `*p != '{'` branch in loadJsonFile.
+TEST(EnvPluginTests, ExternalPlugin_JsonPlugin_NotAnObject_FallsBackToGetenv) {
+  RUN_ISOLATED_TEST(
+      "ExternalPlugin_JsonPlugin_NotAnObject_FallsBackToGetenv",
+      []() {
+        std::string pluginPath = getTestPluginPath("librccl-env-json.so");
+        if (!std::filesystem::exists(pluginPath)) {
+          GTEST_SKIP() << "librccl-env-json.so not found at " << pluginPath
+                       << " — rebuild with -DBUILD_EXT_EXAMPLES=ON";
+        }
+
+        std::string jsonPath = std::string("/tmp/rccl_test_json_notobj_") +
+                               std::to_string(getpid()) + ".json";
+        FILE* f = fopen(jsonPath.c_str(), "w");
+        ASSERT_NE(f, nullptr) << "Failed to create temp JSON file: " << jsonPath;
+        fprintf(f, "[\"NCCL_ALGO\", \"Ring\"]");
+        fclose(f);
+
+        setenv("NCCL_TEST_JSON_NOTOBJ", "from_getenv", 1);
+        setenv("NCCL_ENV_PLUGIN", pluginPath.c_str(), 1);
+        setenv("NCCL_ENV_JSON_FILE", jsonPath.c_str(), 1);
+
+        initEnv();
+        const char* val = ncclGetEnv("NCCL_TEST_JSON_NOTOBJ");
+        ASSERT_NE(val, nullptr);
+        ASSERT_STREQ(val, "from_getenv");
+
+        unsetenv("NCCL_TEST_JSON_NOTOBJ");
+        remove(jsonPath.c_str());
+      });
+}
+
+// Verifies that librccl-env-json.so falls back to getenv() when
+// NCCL_ENV_JSON_FILE points to a file that cannot be opened (fopen returns
+// NULL).  Covers the `!f` branch in loadJsonFile.
+TEST(EnvPluginTests, ExternalPlugin_JsonPlugin_UnreadableFile_FallsBackToGetenv) {
+  RUN_ISOLATED_TEST(
+      "ExternalPlugin_JsonPlugin_UnreadableFile_FallsBackToGetenv",
+      []() {
+        std::string pluginPath = getTestPluginPath("librccl-env-json.so");
+        if (!std::filesystem::exists(pluginPath)) {
+          GTEST_SKIP() << "librccl-env-json.so not found at " << pluginPath
+                       << " — rebuild with -DBUILD_EXT_EXAMPLES=ON";
+        }
+
+        std::string jsonPath = std::string("/tmp/rccl_test_json_noperm_") +
+                               std::to_string(getpid()) + ".json";
+        FILE* f = fopen(jsonPath.c_str(), "w");
+        ASSERT_NE(f, nullptr) << "Failed to create temp JSON file: " << jsonPath;
+        fprintf(f, "{\"NCCL_TEST_JSON_NOPERM\": \"from_json\"}");
+        fclose(f);
+        chmod(jsonPath.c_str(), 0000);
+
+        setenv("NCCL_TEST_JSON_NOPERM", "from_getenv", 1);
+        setenv("NCCL_ENV_PLUGIN", pluginPath.c_str(), 1);
+        setenv("NCCL_ENV_JSON_FILE", jsonPath.c_str(), 1);
+
+        initEnv();
+        // fopen fails → loadJsonFile returns -1 → jsonLoaded=0 → getenv used.
+        const char* val = ncclGetEnv("NCCL_TEST_JSON_NOPERM");
+        ASSERT_NE(val, nullptr);
+        ASSERT_STREQ(val, "from_getenv");
+
+        unsetenv("NCCL_TEST_JSON_NOPERM");
+        chmod(jsonPath.c_str(), 0644);
         remove(jsonPath.c_str());
       });
 }

--- a/projects/rccl/test/EnvPluginTests.cpp
+++ b/projects/rccl/test/EnvPluginTests.cpp
@@ -1,0 +1,255 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Functional tests for the NCCL_ENV_PLUGIN environment plugin feature.
+// Validates that RCCL correctly loads external env plugins, falls back
+// to the internal default, and routes ncclGetEnv() through the active plugin.
+
+#include "env.h"
+#include "param.h"
+#include <gtest/gtest.h>
+#include <rccl/rccl.h>
+#include "common/ProcessIsolatedTestRunner.hpp"
+
+#include <cstdio>
+#include <filesystem>
+#include <string>
+
+namespace RcclUnitTesting {
+
+// Returns the absolute path to a plugin .so located next to the test binary
+// in the standard output subdirectory:  <binary_dir>/unit/plugins/<soName>
+// Returns an empty string if /proc/self/exe cannot be resolved.
+static std::string getTestPluginPath(const char* soName) {
+  namespace fs = std::filesystem;
+  std::error_code ec;
+  fs::path exe = fs::read_symlink("/proc/self/exe", ec);
+  if (ec) return "";
+  return (exe.parent_path() / "unit" / "plugins" / soName).string();
+}
+
+TEST(EnvPluginTests, InternalPlugin_FallbackOnNone) {
+  RUN_ISOLATED_TEST_WITH_ENV(
+      "InternalPlugin_FallbackOnNone",
+      []() {
+        setenv("RCCL_TEST_ENV_VAR", "hello_from_env", 1);
+        initEnv();
+        const char* val = ncclGetEnv("RCCL_TEST_ENV_VAR");
+        ASSERT_NE(val, nullptr);
+        ASSERT_STREQ(val, "hello_from_env");
+        unsetenv("RCCL_TEST_ENV_VAR");
+      },
+      {{"NCCL_ENV_PLUGIN", "none"}});
+}
+
+TEST(EnvPluginTests, InternalPlugin_ReturnsNullForUnset) {
+  RUN_ISOLATED_TEST_WITH_ENV(
+      "InternalPlugin_ReturnsNullForUnset",
+      []() {
+        unsetenv("RCCL_TEST_NONEXISTENT_12345");
+        initEnv();
+        const char* val = ncclGetEnv("RCCL_TEST_NONEXISTENT_12345");
+        ASSERT_EQ(val, nullptr);
+      },
+      {{"NCCL_ENV_PLUGIN", "none"}});
+}
+
+TEST(EnvPluginTests, InternalPlugin_GetEnvUsedByParamMacro) {
+  RUN_ISOLATED_TEST_WITH_ENV(
+      "InternalPlugin_GetEnvUsedByParamMacro",
+      []() {
+        setenv("NCCL_DEBUG", "INFO", 1);
+        initEnv();
+        const char* val = ncclGetEnv("NCCL_DEBUG");
+        ASSERT_NE(val, nullptr);
+        ASSERT_STREQ(val, "INFO");
+        unsetenv("NCCL_DEBUG");
+      },
+      {{"NCCL_ENV_PLUGIN", "none"}});
+}
+
+TEST(EnvPluginTests, GracefulFallback_NonexistentPlugin) {
+  RUN_ISOLATED_TEST_WITH_ENV(
+      "GracefulFallback_NonexistentPlugin",
+      []() {
+        setenv("RCCL_TEST_FALLBACK", "works", 1);
+        initEnv();
+        const char* val = ncclGetEnv("RCCL_TEST_FALLBACK");
+        ASSERT_NE(val, nullptr);
+        ASSERT_STREQ(val, "works");
+        unsetenv("RCCL_TEST_FALLBACK");
+      },
+      {{"NCCL_ENV_PLUGIN", "/nonexistent/path/libfake-env.so"}});
+}
+
+TEST(EnvPluginTests, PluginInitialized_ReportsTrue) {
+  RUN_ISOLATED_TEST_WITH_ENV(
+      "PluginInitialized_ReportsTrue",
+      []() {
+        ASSERT_FALSE(ncclEnvPluginInitialized());
+        initEnv();
+        (void)ncclGetEnv("NCCL_DEBUG");
+        ASSERT_TRUE(ncclEnvPluginInitialized());
+      },
+      {{"NCCL_ENV_PLUGIN", "none"}});
+}
+
+TEST(EnvPluginTests, ConfFile_LoadedBeforePlugin) {
+  RUN_ISOLATED_TEST_WITH_ENV(
+      "ConfFile_LoadedBeforePlugin",
+      []() {
+        initEnv();
+        const char* val = ncclGetEnv("RCCL_CONF_TEST_KEY");
+        ASSERT_NE(val, nullptr);
+        ASSERT_STREQ(val, "conf_value");
+      },
+      {{"NCCL_ENV_PLUGIN", "none"},
+       {"NCCL_CONF_FILE", "EnvPluginTestsConfFile.txt"}});
+}
+
+// ---------------------------------------------------------------------------
+// External-plugin tests (Goal 3): exercise the full dlopen path
+//
+// Each test:
+//   1. Resolves the plugin .so path from /proc/self/exe at runtime.
+//   2. Sets NCCL_ENV_PLUGIN to the absolute path so ncclEnvPluginLoad()
+//      performs a real dlopen() + dlsym(ncclEnvPlugin_v1).
+//   3. Calls ncclGetEnv() to drive ncclInitEnv() -> ncclEnvPluginInit()
+//      -> ncclEnvPluginLoad() and verify the returned value.
+//
+// Tests are skipped (not failed) when BUILD_EXT_EXAMPLES=ON was not used.
+// ---------------------------------------------------------------------------
+
+// Verifies that libnccl-env-example.so is dlopened successfully and that
+// ncclGetEnv() returns process-environment values through it.
+TEST(EnvPluginTests, ExternalPlugin_ExamplePlugin_Loaded) {
+  RUN_ISOLATED_TEST(
+      "ExternalPlugin_ExamplePlugin_Loaded",
+      []() {
+        std::string pluginPath = getTestPluginPath("libnccl-env-example.so");
+        if (!std::filesystem::exists(pluginPath)) {
+          GTEST_SKIP() << "libnccl-env-example.so not found at " << pluginPath
+                       << " — rebuild with -DBUILD_EXT_EXAMPLES=ON";
+        }
+
+        setenv("NCCL_ENV_PLUGIN", pluginPath.c_str(), 1);
+        setenv("RCCL_TEST_EXAMPLE_KEY", "example_via_ext_plugin", 1);
+
+        initEnv();
+        ASSERT_FALSE(ncclEnvPluginInitialized());
+
+        const char* val = ncclGetEnv("RCCL_TEST_EXAMPLE_KEY");
+        ASSERT_TRUE(ncclEnvPluginInitialized());
+        ASSERT_NE(val, nullptr);
+        ASSERT_STREQ(val, "example_via_ext_plugin");
+
+        unsetenv("RCCL_TEST_EXAMPLE_KEY");
+      });
+}
+
+// Verifies that libnccl-env-json.so is dlopened and that a value present in
+// the JSON config file overrides the same key set in the process environment.
+// This is the strongest proof that the external plugin — not the internal
+// getenv() fallback — handled the lookup.
+TEST(EnvPluginTests, ExternalPlugin_JsonPlugin_OverridesGetenv) {
+  RUN_ISOLATED_TEST(
+      "ExternalPlugin_JsonPlugin_OverridesGetenv",
+      []() {
+        std::string pluginPath = getTestPluginPath("libnccl-env-json.so");
+        if (!std::filesystem::exists(pluginPath)) {
+          GTEST_SKIP() << "libnccl-env-json.so not found at " << pluginPath
+                       << " — rebuild with -DBUILD_EXT_EXAMPLES=ON";
+        }
+
+        std::string jsonPath = std::string("/tmp/rccl_test_json_override_") +
+                               std::to_string(getpid()) + ".json";
+        FILE* f = fopen(jsonPath.c_str(), "w");
+        ASSERT_NE(f, nullptr) << "Failed to create temp JSON file: " << jsonPath;
+        fprintf(f, "{\"NCCL_TEST_JSON_KEY\": \"json_value\"}");
+        fclose(f);
+
+        // Intentionally set a different value in the process env.
+        // The JSON plugin must return "json_value" (JSON wins over getenv).
+        setenv("NCCL_TEST_JSON_KEY", "process_value", 1);
+        setenv("NCCL_ENV_PLUGIN", pluginPath.c_str(), 1);
+        setenv("NCCL_ENV_JSON_FILE", jsonPath.c_str(), 1);
+
+        initEnv();
+        const char* val = ncclGetEnv("NCCL_TEST_JSON_KEY");
+        ASSERT_TRUE(ncclEnvPluginInitialized());
+        ASSERT_NE(val, nullptr);
+        ASSERT_STREQ(val, "json_value");
+
+        unsetenv("NCCL_TEST_JSON_KEY");
+        remove(jsonPath.c_str());
+      });
+}
+
+// Verifies that libnccl-env-json.so falls back to getenv() for a key that is
+// absent from the JSON file.
+TEST(EnvPluginTests, ExternalPlugin_JsonPlugin_FallsBackToGetenv) {
+  RUN_ISOLATED_TEST(
+      "ExternalPlugin_JsonPlugin_FallsBackToGetenv",
+      []() {
+        std::string pluginPath = getTestPluginPath("libnccl-env-json.so");
+        if (!std::filesystem::exists(pluginPath)) {
+          GTEST_SKIP() << "libnccl-env-json.so not found at " << pluginPath
+                       << " — rebuild with -DBUILD_EXT_EXAMPLES=ON";
+        }
+
+        std::string jsonPath = std::string("/tmp/rccl_test_json_fallback_") +
+                               std::to_string(getpid()) + ".json";
+        FILE* f = fopen(jsonPath.c_str(), "w");
+        ASSERT_NE(f, nullptr) << "Failed to create temp JSON file: " << jsonPath;
+        // JSON has a different key; the test key must be served by getenv().
+        fprintf(f, "{\"OTHER_KEY\": \"other_value\"}");
+        fclose(f);
+
+        setenv("NCCL_TEST_JSON_FALLBACK", "process_value", 1);
+        setenv("NCCL_ENV_PLUGIN", pluginPath.c_str(), 1);
+        setenv("NCCL_ENV_JSON_FILE", jsonPath.c_str(), 1);
+
+        initEnv();
+        const char* val = ncclGetEnv("NCCL_TEST_JSON_FALLBACK");
+        ASSERT_TRUE(ncclEnvPluginInitialized());
+        ASSERT_NE(val, nullptr);
+        ASSERT_STREQ(val, "process_value");
+
+        unsetenv("NCCL_TEST_JSON_FALLBACK");
+        remove(jsonPath.c_str());
+      });
+}
+
+// Verifies that libnccl-env-json.so returns nullptr for a key absent from
+// both the JSON file and the process environment.
+TEST(EnvPluginTests, ExternalPlugin_JsonPlugin_UnsetKeyReturnsNull) {
+  RUN_ISOLATED_TEST(
+      "ExternalPlugin_JsonPlugin_UnsetKeyReturnsNull",
+      []() {
+        std::string pluginPath = getTestPluginPath("libnccl-env-json.so");
+        if (!std::filesystem::exists(pluginPath)) {
+          GTEST_SKIP() << "libnccl-env-json.so not found at " << pluginPath
+                       << " — rebuild with -DBUILD_EXT_EXAMPLES=ON";
+        }
+
+        std::string jsonPath = std::string("/tmp/rccl_test_json_null_") +
+                               std::to_string(getpid()) + ".json";
+        FILE* f = fopen(jsonPath.c_str(), "w");
+        ASSERT_NE(f, nullptr) << "Failed to create temp JSON file: " << jsonPath;
+        fprintf(f, "{\"OTHER_KEY\": \"other_value\"}");
+        fclose(f);
+
+        unsetenv("NCCL_TEST_JSON_MISSING_12345");
+        setenv("NCCL_ENV_PLUGIN", pluginPath.c_str(), 1);
+        setenv("NCCL_ENV_JSON_FILE", jsonPath.c_str(), 1);
+
+        initEnv();
+        const char* val = ncclGetEnv("NCCL_TEST_JSON_MISSING_12345");
+        ASSERT_TRUE(ncclEnvPluginInitialized());
+        ASSERT_EQ(val, nullptr);
+
+        remove(jsonPath.c_str());
+      });
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/EnvPluginTestsConfFile.txt
+++ b/projects/rccl/test/EnvPluginTestsConfFile.txt
@@ -1,2 +1,0 @@
-# Conf file for EnvPluginTests::ConfFile_LoadedBeforePlugin
-RCCL_CONF_TEST_KEY=conf_value

--- a/projects/rccl/test/EnvPluginTestsConfFile.txt
+++ b/projects/rccl/test/EnvPluginTestsConfFile.txt
@@ -1,0 +1,2 @@
+# Conf file for EnvPluginTests::ConfFile_LoadedBeforePlugin
+RCCL_CONF_TEST_KEY=conf_value

--- a/projects/rccl/test/test_categories_fixtures_debug.yaml
+++ b/projects/rccl/test/test_categories_fixtures_debug.yaml
@@ -14,7 +14,6 @@ test_categories:
     test_patterns:
       - "Alloc.*"
       - "ParamTests.*"
-
       - "ParameterApiTests.*"
       - "EnvPluginTests.*"
       - "EnqueueTests.*"

--- a/projects/rccl/test/test_categories_fixtures_debug.yaml
+++ b/projects/rccl/test/test_categories_fixtures_debug.yaml
@@ -14,7 +14,9 @@ test_categories:
     test_patterns:
       - "Alloc.*"
       - "ParamTests.*"
+
       - "ParameterApiTests.*"
+      - "EnvPluginTests.*"
       - "EnqueueTests.*"
       - "ProxyTests.*"
       - "Rcclwrap.*"


### PR DESCRIPTION
## Motivation

AICOMRCCL-1176 requires validating the NCCL_ENV_PLUGIN feature (introduced in NCCL 2.28.7), writing tests, and adding user-facing documentation.

## Technical Details

**Plugin fixes** (`plugins/env/json/plugin.c`):
- Check `ferror(f)` before `fclose` to catch I/O errors on `fread`
- Detect file truncation (> 1 MB) via `!feof(f)` and return `-1` instead of treating a partial read as success
- Return `-1` on JSON parse errors instead of silently succeeding with partial data (`jsonLoaded=1`)
- Reject leading/stray commas in JSON parser (`numEntries > 0` guard)
- Parse directly into `entries[]` eliminating redundant intermediate stack buffers
- Rename output `libnccl-env-json.so` → `librccl-env-json.so` (AMD naming convention)
- Extend `BUILD_EXT_EXAMPLES` CMake option description to include `env`

**Tests** (`test/EnvPluginTests.cpp`): 12 tests covering internal plugin fallback, external plugin dlopen, JSON override/fallback/null precedence, and 3 error-path tests:
- `JsonPlugin_MalformedJson_FallsBackToGetenv` — regression guard for the parse-error fix
- `JsonPlugin_NotAnObject_FallsBackToGetenv` — `*p != '{'` branch in `loadJsonFile`
- `JsonPlugin_UnreadableFile_FallsBackToGetenv` — `fopen` failure branch
- Added missing POSIX headers (`<sys/stat.h>`, `<sys/types.h>`, `<unistd.h>`)

**Docs**:
- `docs/how-to/using-rccl-env-plugin-api.rst`: full user-facing how-to covering API, JSON plugin usage, custom plugin guide, fallback behavior, and troubleshooting
- `docs/api-reference/env-variables.rst`: added `NCCL_ENV_PLUGIN` and `NCCL_ENV_JSON_FILE` entries
- `docs/index.rst`: linked new how-to page

## JIRA ID

JIRA ID: AICOMRCCL-1176

## Test Plan

- Tested with DBUILD_EXT_EXAMPLES=ON` build
- All documented behaviors verified end-to-end via `all_reduce_perf` (plugin load, JSON override, fallback, `NCCL_ENV_PLUGIN=none`, bad plugin path)
- Troubleshooting log lines in docs verified to match actual RCCL output character-for-character

## Test Result

All 12 tests pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.