### PR TITLE
docs(hipfile): Updated CODEOWNERS to add the docs reviewer team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -123,5 +123,8 @@
 /projects/rocjpeg/**/*.rst                                            @ROCm/rocjpeg-docs-reviewers
 /projects/rocjpeg/**/.readthedocs.yaml                                @ROCm/rocjpeg-docs-reviewers
 
+/projects/hipfile/**/*.md                                             @ROCm/hipfile-docs-reviewers
+/projects/hipfile/**/*.rst                                            @ROCm/hipfile-docs-reviewers
+/projects/hipfile/**/.readthedocs.yaml                                @ROCm/hipfile-docs-reviewers
 
 /projects/rocprof-trace-decoder/**/*.md                               @ROCm/rocm-devtools-team @ROCm/rocm-documentation


### PR DESCRIPTION
## Motivation

The docs reviewer team was added to ensure that the doc team is notified quickly and consistently. 

JIRA ID : AIROCDOC-4108