### PR TITLE
feat(rocshmem): update UCX HASH used for dependency install

### DIFF
--- a/projects/rocshmem/docker/smoketest-rocm-multiversions/Dockerfile
+++ b/projects/rocshmem/docker/smoketest-rocm-multiversions/Dockerfile
@@ -80,7 +80,7 @@ RUN wget -qO- https://repo.amd.com/rocm/packages/gpg/rocm.gpg \
 ###############################################################################
 # UCX (shared across all ROCm versions, built against the newest)
 ###############################################################################
-ARG UCX_COMMIT=18770fdc1c3b5de202d14a088a14b734d2c4bbf3
+ARG UCX_COMMIT=b6a9d47fccce849c28111f05a7fa8f1c930ff17d
 ARG UCX_INSTALL=/opt/ucx
 RUN git clone https://github.com/ROCm/ucx.git /tmp/ucx \
  && cd /tmp/ucx && git checkout ${UCX_COMMIT} \

--- a/projects/rocshmem/docs/build.rst
+++ b/projects/rocshmem/docs/build.rst
@@ -83,11 +83,11 @@ rocSHMEM requires ROCm-Aware Open MPI and UCX for the RO backend.
 MPI is optional with the IPC and GDA backends.
 Other MPI implementations, such as MPICH, have not been fully tested.
 
-To build and configure ROCm-Aware UCX 1.17.0 or later, run:
+UCX version 1.21.1 or newer is recommended for the RO backend. To build and configure ROCm-Aware UCX, run:
 
 .. code-block:: bash
 
-  git clone https://github.com/ROCm/ucx.git -b v1.17.x
+  git clone https://github.com/ROCm/ucx.git -b v1.21.x
   cd ucx
   ./autogen.sh
   ./configure --prefix=<prefix_dir> --with-rocm=<rocm_path> --enable-mt

--- a/projects/rocshmem/scripts/install_dependencies.sh
+++ b/projects/rocshmem/scripts/install_dependencies.sh
@@ -42,7 +42,7 @@ mkdir -p $_DEPS_SRC_DIR
 #Adjust branches and installation location as necessary
 export _UCX_INSTALL_DIR=${INSTALL_DIR:-$_INSTALL_DIR/ucx}
 export _UCX_REPO=https://github.com/ROCm/ucx.git
-export _UCX_COMMIT_HASH=b6a9d47fccce849c28111f05a7fa8f1c930ff17d
+export _UCX_COMMIT_HASH=b6a9d47fccce849c28111f05a7fa8f1c930ff17d  # UCX 1.21.x
 
 export _OMPI_INSTALL_DIR=${INSTALL_DIR:-$_INSTALL_DIR/ompi}
 export _OMPI_REPO=https://github.com/ROCm/ompi.git

--- a/projects/rocshmem/scripts/install_dependencies.sh
+++ b/projects/rocshmem/scripts/install_dependencies.sh
@@ -42,7 +42,7 @@ mkdir -p $_DEPS_SRC_DIR
 #Adjust branches and installation location as necessary
 export _UCX_INSTALL_DIR=${INSTALL_DIR:-$_INSTALL_DIR/ucx}
 export _UCX_REPO=https://github.com/ROCm/ucx.git
-export _UCX_COMMIT_HASH=18770fdc1c3b5de202d14a088a14b734d2c4bbf3
+export _UCX_COMMIT_HASH=b6a9d47fccce849c28111f05a7fa8f1c930ff17d
 
 export _OMPI_INSTALL_DIR=${INSTALL_DIR:-$_INSTALL_DIR/ompi}
 export _OMPI_REPO=https://github.com/ROCm/ompi.git


### PR DESCRIPTION


## Motivation

use UCX 1.21. based git HASH to support newer distros such as Ubuntu 26.04

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

JIRA ID:  AIROCSHMEM-462

## Test Plan

functional tester with the RO backend has been run, the results are uploaded to the JIRA ticket. All tests that pass with UCX 1.17.x (the version used so far) are also passing with UCX 1.21.0. In addition, most of the get tests are now also passing (which don't pass with 1.17.x)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
