### PR TITLE
feat(rccl): default unroll 32 for gfx1250, guard ungenerated unroll factors

### DIFF
--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -230,10 +230,9 @@ def calc_unroll_and_pipeline_for_local_arch():
     elif "gfx908" == gfx_name or ("gfx942" == gfx_name and cu_count > 80):
       return (["2"], all_pipelines)
     elif "gfx1250" == gfx_name:
-      # gfx1250 (MI450) benefits from larger unrolls; keep 4 as the safe default
-      # and additionally build 8/16/32 so RCCL_UNROLL_FACTOR=3, =4 or =5 is
-      # usable without falling off into empty ncclDevFuncTable_8/_16/_32 slots.
-      return (["4", "8", "16", "32"], all_pipelines)
+      # gfx1250 (MI450) benefits from larger unrolls; build only 16 and 32
+      # (32 is the default, see commSetUnrollFactor).
+      return (["16", "32"], all_pipelines)
     else:
       return (["4"], all_pipelines)
   else:
@@ -536,6 +535,17 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
         key = ((coll_idx & 0x3F))
       
       out(f'  {{{key}, {fn_id}}}, {comment}\n')
+  out("};\n")
+
+  # Which unroll-factor tables were actually generated for this build. The host
+  # (commSetUnrollFactor) uses this to reject an RCCL_UNROLL_FACTOR that maps to
+  # an empty ncclDevFuncTable_* / NCCL_CALL_FUNCTIONS_* slot, which would
+  # otherwise dispatch to a nullptr and segfault on the device.
+  out("\n")
+  out("// Indexed by unroll-factor enum (NCCL_UNROLL_1 .. NCCL_UNROLL_32).\n")
+  out("bool const ncclDevFuncUnrollGenerated[NCCL_NUM_UNROLLS] = {\n")
+  for u in all_unrolls:
+    out("  %s, // unroll %s\n" % ("true" if u in local_unroll else "false", u))
   out("};\n")
 
 # Maps to .cu filename which implements this func. The only constraint is that

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -786,6 +786,10 @@ inline bool ncclNvlsSupported(int devRedOp, int type) {
 // Map the uint64_t key to funcIdx
 extern std::unordered_map<uint64_t, int> ncclDevFuncNameToId;
 
+// Which unroll-factor tables were generated in this build, indexed by the
+// NCCL_UNROLL_* enum. Generated in host_table.cpp by generate.py.
+extern bool const ncclDevFuncUnrollGenerated[NCCL_NUM_UNROLLS];
+
 // `ncclDevFuncId()` needs to be in sync with 'all_colls' in generate.py
 inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto, int acc = 0, int pipeline = 0) {
   int row = -1;

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -900,6 +900,12 @@ ncclResult_t commSetUnrollFactor(struct ncclComm* comm) {
       WARN("Invalid RCCL_UNROLL_FACTOR %d specified. Valid values are 0 to %d corresponding to unroll factors of 1, 2, 4, 8, 16, and 32 respectively.", comm->unroll, NCCL_NUM_UNROLLS - 1);
       return ncclInvalidArgument;
     }
+    if(!ncclDevFuncUnrollGenerated[comm->unroll]) {
+      WARN("RCCL_UNROLL_FACTOR %d (unroll %d) was not built for arch %s; its device function table is empty and dispatching to it would crash. "
+           "Rebuild with this unroll factor, or select one that was generated for this build.",
+           comm->unroll, (int) (pow(2.0, (double)comm->unroll)), comm->archName);
+      return ncclInvalidArgument;
+    }
     INFO(NCCL_INIT, "RCCL Unroll Factor (user set): %d", (int) (pow(2.0, (double)comm->unroll)));
     return ncclSuccess;
   }
@@ -911,8 +917,26 @@ ncclResult_t commSetUnrollFactor(struct ncclComm* comm) {
   }
   else if(IsArchMatch(comm->archName, "gfx908") || ((IsArchMatch(comm->archName, "gfx942") && comm->cuCount > 80)))
     comm->unroll = NCCL_UNROLL_2;
+  else if(IsArchMatch(comm->archName, "gfx1250"))
+    comm->unroll = NCCL_UNROLL_32;
   else
     comm->unroll = NCCL_UNROLL_4;
+
+  // Guard against a default that wasn't built for this arch (e.g. the generation
+  // matrix was narrowed). Fall back to any generated unroll rather than segfault.
+  if(!ncclDevFuncUnrollGenerated[comm->unroll]) {
+    int fallback = -1;
+    for(int u = NCCL_NUM_UNROLLS - 1; u >= NCCL_UNROLL_1; u--) {
+      if(ncclDevFuncUnrollGenerated[u]) { fallback = u; break; }
+    }
+    if(fallback < 0) {
+      WARN("No unroll-factor device function tables were generated for arch %s.", comm->archName);
+      return ncclInvalidUsage;
+    }
+    WARN("Default RCCL unroll factor %d was not built for arch %s; falling back to %d. Set RCCL_UNROLL_FACTOR to override.",
+         (int) (pow(2.0, (double)comm->unroll)), comm->archName, (int) (pow(2.0, (double)fallback)));
+    comm->unroll = fallback;
+  }
 
   INFO(NCCL_INIT, "RCCL Unroll Factor (pre-set): %d", (int) (pow(2.0, (double)comm->unroll)));
   return ncclSuccess;


### PR DESCRIPTION
## Motivation

gfx1250 (MI450) benefits from larger unroll factors. Default the unroll factor to 32 and only generate unroll 16/32 for gfx1250. Selecting an unroll factor that was not generated previously segfaulted on the device (dispatch through a nullptr table slot).

## Technical Details

- `generate.py`: gfx1250 local build now generates only unroll 16 and 32; emit `ncclDevFuncUnrollGenerated[]` in `host_table.cpp` recording which unroll tables were built.
- `commSetUnrollFactor`: default to `NCCL_UNROLL_32` on gfx1250; reject a user-set `RCCL_UNROLL_FACTOR` that was not generated (WARN + `ncclInvalidArgument`) and fall back for the default path instead of crashing.
- `device.h`: declare the new table.

## Issue Tracking

JIRA ID: AICOMRCCL-1563

## Test Plan

Built for gfx1250; verified default unroll resolves to 32 and an ungenerated `RCCL_UNROLL_FACTOR` now fails at init with a warning instead of segfaulting.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.