### PR TITLE
fix(clr): Adding one more condition for VMM vadalition

### DIFF
--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -268,10 +268,12 @@ hipError_t DynCO::populateDynGlobalFuncs() {
     // if symbols are init/fini, we trim them out
     // These are ASAN specific symbols and we do not bubble them up to the user
     // This means something like count of kernels in code object remains the same.
-#if defined(__clang__) && __has_feature(address_sanitizer)
+#if defined(__clang__)
+#if __has_feature(address_sanitizer)
     if (elem == "amdgcn.device.init" || elem == "amdgcn.device.fini") {
       continue;
     }
+#endif
 #endif
     functions_.insert(std::make_pair(elem, new Function(elem)));
   }

--- a/projects/clr/hipamd/src/hip_mempool_impl.hpp
+++ b/projects/clr/hipamd/src/hip_mempool_impl.hpp
@@ -252,7 +252,7 @@ class MemoryPool : public amd::ReferenceCountedObject, amd::VmHeapArray {
     }
     state_.interprocess_ = properties_.handleTypes != hipMemHandleTypeNone;
     // Check if VM heap can be enabled
-    if (DEBUG_HIP_MEM_POOL_VMHEAP && AMD_DIRECT_DISPATCH &&
+    if (DEBUG_HIP_MEM_POOL_VMHEAP && AMD_DIRECT_DISPATCH && HIP_MEM_POOL_USE_VM &&
         !state_.phys_mem_ && !state_.interprocess_) {
       state_.use_vm_heap_ = true;
       busy_heap_.EnableVmHeap();


### PR DESCRIPTION
## Motivation

To fix the hip sub-test failure Unit_hipGraphMemFreeNodeGetParams_ValidArgs

## Technical Details

JIRA ID: ROCM-27686, Add one more condition for validation for VMM.
Besides, fix a build error on Ubuntu 22.04 caused by combination of compiler flags.

## Issue Tracking

ROCM-27686

## Test Plan

Run hip catch unit sub-test: ctest -R Unit_hipGraphMemFreeNodeGetParams_ValidArgs

## Test Result

Should pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
