### PR TITLE
[ci] Fix therock_configure_ci_test.py and run it continuously

### DIFF
--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -10,6 +10,15 @@ import therock_configure_ci
 
 
 class ConfigureCITest(unittest.TestCase):
+    def setUp(self):
+        # Runner selection imports utilities from a sibling TheRock checkout,
+        # which is not required to run these rocm-systems unit tests.
+        select_build_runner_patcher = patch(
+            "therock_configure_ci.select_build_runner", return_value=""
+        )
+        self.addCleanup(select_build_runner_patcher.stop)
+        select_build_runner_patcher.start()
+
     @patch("subprocess.run")
     def test_pull_request(self, mock_run):
         args = {"is_pull_request": True, "base_ref": "HEAD^"}
@@ -18,7 +27,7 @@ class ConfigureCITest(unittest.TestCase):
         mock_process.stdout = "projects/rocminfo/src/main.cpp"
         mock_run.return_value = mock_process
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertGreaterEqual(len(project_to_run), 1)
 
     @patch("subprocess.run")
@@ -29,7 +38,7 @@ class ConfigureCITest(unittest.TestCase):
         mock_process.stdout = ""
         mock_run.return_value = mock_process
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         # Empty modified_paths should return empty list (no changes = no CI)
         self.assertEqual(len(project_to_run), 0)
 
@@ -45,7 +54,7 @@ class ConfigureCITest(unittest.TestCase):
         mock_process.stdout = "projects/rocminfo/src/main.cpp"
         mock_run.return_value = mock_process
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertGreaterEqual(len(project_to_run), 1)
 
     @patch("subprocess.run")
@@ -60,7 +69,7 @@ class ConfigureCITest(unittest.TestCase):
         mock_process.stdout = "projects/rocminfo/src/main.cpp"
         mock_run.return_value = mock_process
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
 
     @patch("subprocess.run")
@@ -75,7 +84,7 @@ class ConfigureCITest(unittest.TestCase):
         mock_process.stdout = "projects/rocminfo/src/main.cpp"
         mock_run.return_value = mock_process
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertGreaterEqual(len(project_to_run), 1)
 
     @patch("subprocess.run")
@@ -86,14 +95,15 @@ class ConfigureCITest(unittest.TestCase):
         mock_process.stdout = "projects/rocminfo/src/main.cpp"
         mock_run.return_value = mock_process
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
 
     def test_scheduled_run(self):
         args = {"is_nightly": True, "input_projects": "", "base_ref": "HEAD^"}
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, test_type = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 1)
+        self.assertEqual(test_type, "comprehensive")
 
     @patch("subprocess.run")
     def test_is_push(self, mock_run):
@@ -103,7 +113,7 @@ class ConfigureCITest(unittest.TestCase):
         mock_process.stdout = "projects/rocminfo/src/main.cpp"
         mock_run.return_value = mock_process
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertGreaterEqual(len(project_to_run), 1)
 
     def test_is_path_skippable(self):
@@ -186,7 +196,7 @@ class ConfigureCITest(unittest.TestCase):
         mock_process.stdout = "README.md\ndocs/guide.rst\nprojects/rocprim/docs/api.md"
         mock_run.return_value = mock_process
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
 
     @patch("therock_configure_ci.get_modified_paths")
@@ -206,7 +216,7 @@ class ConfigureCITest(unittest.TestCase):
             "projects/hipother/hello/test.cpp",
         ]
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
 
     @patch("therock_configure_ci.get_modified_paths")
@@ -228,7 +238,7 @@ class ConfigureCITest(unittest.TestCase):
             ".github/workflows/therock-ci.yml",  # contains windows CI trigger
         ]
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 1)
 
     @patch("therock_configure_ci.get_modified_paths")
@@ -254,7 +264,7 @@ class ConfigureCITest(unittest.TestCase):
             ".github/scripts/therock_matrix.py",
         ]
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
 
         self.assertEqual(len(project_to_run), 1)
         cmake_options = project_to_run[0]["cmake_options"]
@@ -285,7 +295,7 @@ class ConfigureCITest(unittest.TestCase):
             "projects/rocprofiler-compute/src/compute.cpp",
         ]
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
 
         # Windows CI must not be skipped for an explicit workflow_dispatch selection
         self.assertEqual(len(project_to_run), 1)
@@ -308,7 +318,7 @@ class ConfigureCITest(unittest.TestCase):
             ".github/scripts/therock_configure_ci.py",
         ]
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertGreaterEqual(len(project_to_run), 1)
 
     @patch("therock_configure_ci.get_modified_paths")
@@ -325,7 +335,7 @@ class ConfigureCITest(unittest.TestCase):
 
         mock_get_modified.return_value = []
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
 
     @patch("therock_configure_ci.get_modified_paths")
@@ -451,7 +461,6 @@ class ConfigureCITest(unittest.TestCase):
         self.assertGreaterEqual(len(projects), 1)
         self.assertEqual(outputs["run_linux_rccl_ci"], "false")
 
-
     @patch("therock_configure_ci.get_modified_paths")
     def test_hipfile_pr_triggers_storage_libs_linux_ci(self, mock_get_modified):
         """PR with hipfile changes should trigger storage_libs build with THEROCK_ENABLE_STORAGE_LIBS=ON."""
@@ -466,7 +475,7 @@ class ConfigureCITest(unittest.TestCase):
             "projects/hipfile/include/hipfile.h",
         ]
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 1)
         cmake_options = project_to_run[0]["cmake_options"]
         self.assertIn("DTHEROCK_ENABLE_STORAGE_LIBS=ON", cmake_options)
@@ -486,7 +495,7 @@ class ConfigureCITest(unittest.TestCase):
             "projects/hipfile/include/hipfile.h",
         ]
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
 
 

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -23,11 +23,6 @@ import time
 from typing import List, Mapping, Optional, Iterable
 import os
 
-# Add TheRock's github_actions to path for shared utilities
-THEROCK_ACTIONS_PATH = Path("TheRock") / "build_tools" / "github_actions"
-sys.path.insert(0, str(THEROCK_ACTIONS_PATH))
-from amdgpu_family_matrix import get_build_runner_labels, select_weighted_label
-
 # Valid test types in order of comprehensiveness (least to most)
 VALID_TEST_TYPES = ["quick", "standard", "comprehensive", "full"]
 
@@ -221,8 +216,7 @@ def check_hip_rocr_changes(modified_paths: Optional[Iterable[str]]) -> bool:
 
     # Check for HIP/ROCR code changes (excluding ignored files)
     return any(
-        is_hip_rocr_code(path) and not is_ignored(path)
-        for path in modified_paths
+        is_hip_rocr_code(path) and not is_ignored(path) for path in modified_paths
     )
 
 
@@ -296,7 +290,9 @@ def retrieve_projects(args):
 
         # Change in CI workflow triggers full subtree evaluation with quick tests
         if check_for_workflow_file_related_to_ci(modified_paths):
-            logging.info("CI workflow files changed, evaluating all subtrees with quick tests")
+            logging.info(
+                "CI workflow files changed, evaluating all subtrees with quick tests"
+            )
             subtrees = list(subtree_to_project_map.keys())
             test_type = "quick"
         elif matched_subtrees:
@@ -332,7 +328,9 @@ def retrieve_projects(args):
 
         # Change in CI workflow triggers full subtree evaluation with quick tests
         if check_for_workflow_file_related_to_ci(modified_paths):
-            logging.info("CI workflow files changed, evaluating all subtrees with quick tests")
+            logging.info(
+                "CI workflow files changed, evaluating all subtrees with quick tests"
+            )
             subtrees = list(subtree_to_project_map.keys())
             test_type = "quick"
 
@@ -434,6 +432,14 @@ def retrieve_projects(args):
 
 def select_build_runner(platform: str) -> str:
     """Select a build runner label based on platform and build variant."""
+    # TheRock is checked out alongside this repository in therock-ci.yml, but it
+    # is not available in a standalone rocm-systems checkout. Keep this import
+    # local so the rest of this module, including its unit tests, can run without
+    # TheRock.
+    therock_actions_path = Path("TheRock") / "build_tools" / "github_actions"
+    sys.path.insert(0, str(therock_actions_path))
+    from amdgpu_family_matrix import get_build_runner_labels, select_weighted_label
+
     build_runner_labels = get_build_runner_labels()
     if platform not in build_runner_labels:
         # Platform not configured for weighted selection, return default
@@ -484,7 +490,9 @@ def run(args):
         if args.get("is_pull_request"):
             base_ref = args.get("base_ref")
             modified_paths = get_modified_paths(base_ref)
-            if check_for_workflow_file_related_to_ci(modified_paths) or check_hip_rocr_changes(modified_paths):
+            if check_for_workflow_file_related_to_ci(
+                modified_paths
+            ) or check_hip_rocr_changes(modified_paths):
                 outputs["run_mi455_test"] = "true"
             else:
                 outputs["run_mi455_test"] = "false"

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -37,27 +37,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  therock_ci_unit_tests:
-    name: TheRock CI unit tests
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          sparse-checkout: .github
-          sparse-checkout-cone-mode: true
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: "3.12"
-
-      - name: Install pytest
-        run: python -m pip install pytest
-
-      - name: Run TheRock CI unit tests
-        run: python -m pytest .github/scripts/tests/therock_configure_ci_test.py
-
   setup:
     name: "Setup"
     runs-on: ubuntu-24.04
@@ -84,6 +63,19 @@ jobs:
           sparse-checkout-cone-mode: true
           fetch-depth: 2
 
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pydantic pytest requests
+
+      - name: Run TheRock CI unit tests
+        run: python -m pytest .github/scripts/tests/therock_configure_ci_test.py
+
       - name: Checkout TheRock repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -98,16 +90,6 @@ jobs:
           ref: main
           path: ci-config
         continue-on-error: true
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: "3.12"
-
-      - name: Install python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pydantic requests
 
       - name: Detect changed subtrees
         id: detect

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -37,6 +37,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  therock_ci_unit_tests:
+    name: TheRock CI unit tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: true
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pytest
+        run: python -m pip install pytest
+
+      - name: Run TheRock CI unit tests
+        run: python -m pytest .github/scripts/tests/therock_configure_ci_test.py
+
   setup:
     name: "Setup"
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Motivation

The tests in `.github/scripts/tests/therock_configure_ci_test.py` are not running as part of any workflows and were recently broken. This fixes them and starts running them as part of `therock-ci.yml`

Follow-up to:
* https://github.com/ROCm/rocm-systems/pull/6954#discussion_r3617222497
* https://github.com/ROCm/rocm-systems/pull/7723#discussion_r3617390551

Getting these unit tests passing will make it easier to apply adjustments to the filters that run CI and to roll out review policy changes / enforcement as part of https://github.com/ROCm/rocm-systems/issues/7842.

## Technical Details

I considered adding a new dedicated unit_tests job but there is only a single test file right now, so it seemed simpler to extend the existing setup job which always runs and is already part of a required check. We could later add a more dedicated home for such quick unit tests that operate on just the repository sources themselves without needing any subproject source builds.

## Test Plan

* `pytest .github\scripts\tests\therock_configure_ci_test.py` newly passes
* new workflow step runs and passes:
    ```
    Run python -m pytest .github/scripts/tests/therock_configure_ci_test.py
      
    ============================= test session starts ==============================
    platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
    rootdir: /home/runner/work/rocm-systems/rocm-systems
    collected 28 items
    
    .github/scripts/tests/therock_configure_ci_test.py ..................... [ 75%]
    .......                                                                  [100%]
    
    ============================== 28 passed in 0.61s ==============================
    ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
