### PR TITLE
docs(rocjitsu): add ISA gap audit guide

### DIFF
--- a/emulation/rocjitsu/README.md
+++ b/emulation/rocjitsu/README.md
@@ -124,6 +124,7 @@ See [docs/building.md](docs/building.md) for container setup with PyTorch.
 | Document | Description |
 |---|---|
 | [Utilities](lib/util/README.md) | Shared utility library (`lib/util/`) |
+| [ISA Gap Audit](docs/isa-gap-audit.md) | Workflow for auditing manual, XML, and rocjitsu ISA semantic gaps |
 | [rj_dbt_translate](docs/rj_dbt_translate.md) | Standalone DBT translation tool |
 | [CHANGELOG](CHANGELOG.md) | Release history |
 

--- a/emulation/rocjitsu/docs/isa-gap-audit.md
+++ b/emulation/rocjitsu/docs/isa-gap-audit.md
@@ -1,13 +1,13 @@
 # ISA Gap Audit Guide
 
-Use this agent workflow when auditing gaps between AMDGPU ISA manuals, the
+Use this agent workflow when auditing gaps between AMDGPU ISA handbooks, the
 machine-readable ISA XML, and rocjitsu's generated decoder and execution
 support. The goal is to find semantic information that is missing from
 structured inputs or missing from rocjitsu.
 
 ## Inputs
 
-- ISA manual prose for the target architecture (for example, a PDF or
+- ISA handbook prose for the target architecture (for example, a PDF or
   equivalent Markdown).
 - The matching checked-in MR ISA XML under
   `shared/machine-readable-isa/isa/`.
@@ -16,12 +16,12 @@ structured inputs or missing from rocjitsu.
 
 ## Audit workflow
 
-1. Compare manual prose to MR ISA XML, one small section at a time. Record
+1. Compare handbook prose to MR ISA XML, one small section at a time. Record
    fields, flags, semantic tables, register bits, selector behavior, instruction
-   notes, and hardware-state-dependent behavior that are present in the manual
+   notes, and hardware-state-dependent behavior that are present in the handbook
    but not inferable from XML.
 
-2. Compare rocjitsu behavior to the manual, using the manual-vs-XML notes as a
+2. Compare rocjitsu behavior to the handbook, using the handbook-vs-XML notes as a
    starting point. Check decoders, operand classes, generated execute bodies,
    helper functions, tests, and handwritten architecture hooks. This pass can
    expose both XML gaps and rocjitsu-specific modeling gaps.
@@ -38,16 +38,16 @@ The following prompt is a reusable starting point for an agent-assisted audit:
 
 ```text
 /goal Audit rocjitsu ISA decode and generated components for gaps against ISA
-manual prose.
+handbook prose.
 
-For each target architecture, compare each small manual section against the
-matching MR ISA XML. Record information that appears in the manual but is not
+For each target architecture, compare each small handbook section against the
+matching MR ISA XML. Record information that appears in the handbook but is not
 inferable from XML, such as missing flags, undocumented encoding bits,
 descriptor or mode bits, semantic tables, selector exceptions, and
 hardware-state-dependent behavior.
 
 Then audit the corresponding rocjitsu decoder, generated execute code, helper
-functions, operand handling, and tests against the manual. Work chapter by
+functions, operand handling, and tests against the handbook. Work chapter by
 chapter or instruction family by instruction family. Prioritize careful
 cross-references over speed. Subagents may be used when the section boundaries
 are clean.
@@ -56,12 +56,12 @@ are clean.
 
 Produce two markdown reports per architecture:
 
-- `<arch>-manual-vs-xml.md`: manual information not inferable from XML.
-- `<arch>-rocjitsu-gaps.md`: gaps between rocjitsu behavior and the manual.
+- `<arch>-handbook-vs-xml.md`: handbook information not inferable from XML.
+- `<arch>-rocjitsu-gaps.md`: gaps between rocjitsu behavior and the handbook.
 
 Split each report by ISA chapter, instruction family, or another stable section
 that makes follow-up patches easy to scope. Each finding should include the
-manual location, XML location or absence, rocjitsu file or test references when
+handbook location, XML location or absence, rocjitsu file or test references when
 applicable, and a short note about confidence or validation.
 
 ## Architecture Order
@@ -85,8 +85,8 @@ For each finding in: SOURCE_REPORT
 1. Verify the finding against provided XML and PDF/MD.
    After verification, select one primary DISPOSITION from this controlled
    vocabulary:
-   - **Confirmed.** A valid, in-scope XML/manual gap or conflict.
-   - **Scope caveat.** Real manual-only information that is internal-only,
+   - **Confirmed.** A valid, in-scope XML/handbook gap or conflict.
+   - **Scope caveat.** Real handbook-only information that is internal-only,
      hardware-only, compiler guidance, performance guidance, host/runtime ABI,
      microarchitecture, or otherwise outside ordinary instruction-XML scope.
    - **Qualified.** The sources differ, but authority, legality, naming, product
@@ -97,14 +97,14 @@ For each finding in: SOURCE_REPORT
 
    ### GFXNNN-XML-NNN: Title
    - Verdict: **DISPOSITION.** Concise evidence-backed conclusion.
-   - Source: Exact manual section/table/page and XML records.
+   - Source: Exact handbook section/table/page and XML records.
    - Fails: Concrete consequence, or “No demonstrated gap.”
    - Need: Required correction, clarification, or “None.”
 
 3. Run a completion audit proving:
    - all original IDs are represented once;
    - every entry has one Verdict, Source, Fails, and Need field;
-   - citations point to the correct manual pages;
+   - citations point to the correct handbook pages;
    - concrete inventory claims match the exact archive member;
    - unsupported and unclear claims are visibly classified;
    - whitespace validation passes.

--- a/emulation/rocjitsu/docs/isa-gap-audit.md
+++ b/emulation/rocjitsu/docs/isa-gap-audit.md
@@ -7,30 +7,34 @@ structured inputs or missing from rocjitsu.
 
 ## Inputs
 
-- ISA manual prose for the target architecture. (IE pdf or equivalent markdown)
+- ISA manual prose for the target architecture (for example, a PDF or
+  equivalent Markdown).
 - The matching checked-in MR ISA XML under
   `shared/machine-readable-isa/isa/`.
 - Rocjitsu generated and handwritten ISA support under
   `emulation/rocjitsu/lib/`.
 
-## Audit Workflow
+## Audit workflow
 
-1. Compare manual prose to MR ISA XML, one small section at a time.
-   Record fields, flags, semantic tables, register bits, selector behavior,
-   instruction notes, and hardware-state-dependent behavior that are present in
-   the manual but not inferable from XML.
+1. Compare manual prose to MR ISA XML, one small section at a time. Record
+   fields, flags, semantic tables, register bits, selector behavior, instruction
+   notes, and hardware-state-dependent behavior that are present in the manual
+   but not inferable from XML.
 
 2. Compare rocjitsu behavior to the manual, using the manual-vs-XML notes as a
-   starting point.
-   Check decoders, operand classes, generated execute bodies, helper functions,
-   tests, and handwritten architecture hooks. This pass can expose both XML gaps
-   and rocjitsu-specific modeling gaps.
+   starting point. Check decoders, operand classes, generated execute bodies,
+   helper functions, tests, and handwritten architecture hooks. This pass can
+   expose both XML gaps and rocjitsu-specific modeling gaps.
 
-This will take around a day for all archs, as of codex gpt-5.5
+3. Format, condense, sort by priority, and remove obvious false positives.
 
-## CODEX Agent Prompt
+As of Codex GPT-5.5, auditing all architectures takes approximately one day.
+
+## Codex agent prompt example
 
 The following prompt is a reusable starting point for an agent-assisted audit:
+
+### Step 1
 
 ```text
 /goal Audit rocjitsu ISA decode and generated components for gaps against ISA
@@ -60,11 +64,54 @@ that makes follow-up patches easy to scope. Each finding should include the
 manual location, XML location or absence, rocjitsu file or test references when
 applicable, and a short note about confidence or validation.
 
-## Suggested Architecture Order
+## Architecture Order
 
 1. RDNA4
 2. CDNA4
 3. CDNA3
 4. RDNA3
-5. Other architectures
+```
+
+### Step 2
+
+This step should be done with a different agent. The sample below will not
+remove any flagged incorrect findings on its own.
+
+```text
+/goal: Audit and Condense SOURCE_REPORT
+
+For each finding in: SOURCE_REPORT
+
+1. Verify the finding against provided XML and PDF/MD.
+   After verification, select one primary DISPOSITION from this controlled
+   vocabulary:
+   - **Confirmed.** A valid, in-scope XML/manual gap or conflict.
+   - **Scope caveat.** Real manual-only information that is internal-only,
+     hardware-only, compiler guidance, performance guidance, host/runtime ABI,
+     microarchitecture, or otherwise outside ordinary instruction-XML scope.
+   - **Qualified.** The sources differ, but authority, legality, naming, product
+     scope, or intended behavior is unresolved.
+   - **Incorrect.** The source pair does not support the original claim.
+
+2. Rewrite each entry into exactly this shape:
+
+   ### GFXNNN-XML-NNN: Title
+   - Verdict: **DISPOSITION.** Concise evidence-backed conclusion.
+   - Source: Exact manual section/table/page and XML records.
+   - Fails: Concrete consequence, or “No demonstrated gap.”
+   - Need: Required correction, clarification, or “None.”
+
+3. Run a completion audit proving:
+   - all original IDs are represented once;
+   - every entry has one Verdict, Source, Fails, and Need field;
+   - citations point to the correct manual pages;
+   - concrete inventory claims match the exact archive member;
+   - unsupported and unclear claims are visibly classified;
+   - whitespace validation passes.
+
+## Deliverables
+
+Write the result to:
+
+CONDENSED
 ```

--- a/emulation/rocjitsu/docs/isa-gap-audit.md
+++ b/emulation/rocjitsu/docs/isa-gap-audit.md
@@ -1,0 +1,70 @@
+# ISA Gap Audit Guide
+
+Use this agent workflow when auditing gaps between AMDGPU ISA manuals, the
+machine-readable ISA XML, and rocjitsu's generated decoder and execution
+support. The goal is to find semantic information that is missing from
+structured inputs or missing from rocjitsu.
+
+## Inputs
+
+- ISA manual prose for the target architecture. (IE pdf or equivalent markdown)
+- The matching checked-in MR ISA XML under
+  `shared/machine-readable-isa/isa/`.
+- Rocjitsu generated and handwritten ISA support under
+  `emulation/rocjitsu/lib/`.
+
+## Audit Workflow
+
+1. Compare manual prose to MR ISA XML, one small section at a time.
+   Record fields, flags, semantic tables, register bits, selector behavior,
+   instruction notes, and hardware-state-dependent behavior that are present in
+   the manual but not inferable from XML.
+
+2. Compare rocjitsu behavior to the manual, using the manual-vs-XML notes as a
+   starting point.
+   Check decoders, operand classes, generated execute bodies, helper functions,
+   tests, and handwritten architecture hooks. This pass can expose both XML gaps
+   and rocjitsu-specific modeling gaps.
+
+This will take around a day for all archs, as of codex gpt-5.5
+
+## CODEX Agent Prompt
+
+The following prompt is a reusable starting point for an agent-assisted audit:
+
+```text
+/goal Audit rocjitsu ISA decode and generated components for gaps against ISA
+manual prose.
+
+For each target architecture, compare each small manual section against the
+matching MR ISA XML. Record information that appears in the manual but is not
+inferable from XML, such as missing flags, undocumented encoding bits,
+descriptor or mode bits, semantic tables, selector exceptions, and
+hardware-state-dependent behavior.
+
+Then audit the corresponding rocjitsu decoder, generated execute code, helper
+functions, operand handling, and tests against the manual. Work chapter by
+chapter or instruction family by instruction family. Prioritize careful
+cross-references over speed. Subagents may be used when the section boundaries
+are clean.
+
+## Deliverables
+
+Produce two markdown reports per architecture:
+
+- `<arch>-manual-vs-xml.md`: manual information not inferable from XML.
+- `<arch>-rocjitsu-gaps.md`: gaps between rocjitsu behavior and the manual.
+
+Split each report by ISA chapter, instruction family, or another stable section
+that makes follow-up patches easy to scope. Each finding should include the
+manual location, XML location or absence, rocjitsu file or test references when
+applicable, and a short note about confidence or validation.
+
+## Suggested Architecture Order
+
+1. RDNA4
+2. CDNA4
+3. CDNA3
+4. RDNA3
+5. Other architectures
+```


### PR DESCRIPTION
## Motivation

Add developer documentation to reproduce ISA audits. (See [https://github.com/ROCm/rocm-systems/tree/users/lua1235/decoder-gaps/emulation/rocjitsu/audits/decoder-gaps](https://github.com/ROCm/rocm-systems/tree/users/lua1235/decoder-gaps/emulation/rocjitsu/audits/decoder-gaps) for example output)

## Technical Details

Added developer doc

## Issue Tracking

N/A

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
