### PR TITLE
docs(amdsmi): correct 7.14.0 changelog and move items to 7.15.0

### DIFF
--- a/projects/amdsmi/.claude/skills/amdsmi-changelog-automation/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-changelog-automation/SKILL.md
@@ -9,7 +9,49 @@ Verifies changelog entries exist for meaningful changes and helps generate them.
 
 ## Changelog Location
 
-`CHANGELOG.md` in the workspace root.
+`CHANGELOG.md` in the workspace root. Entries are grouped under
+`## amd_smi_lib for ROCm <MAJOR>.<MINOR>.<PATCH>` headings, **not** a
+`## [Unreleased]` heading. The topmost heading is the release currently being
+accumulated.
+
+## Which Release Does an Entry Belong To?
+
+**Never assume the topmost heading is correct for a new entry.** A ROCm release
+is cut at a specific `rocm-systems` commit (the "release point"). Anything merged
+**after** that commit belongs to the **next** release, even if the current top
+heading still names the released version.
+
+The release point is not a tag in `rocm-systems` — it is the `rocm-systems`
+submodule commit that [ROCm/TheRock](https://github.com/ROCm/TheRock/releases)
+pins for that release. Resolve it like this:
+
+```bash
+# 1. Find the rocm-systems submodule commit pinned by the TheRock release tag.
+#    (therock-<ver> tags map 1:1 to ROCm releases.)
+PIN=$(gh api repos/ROCm/TheRock/git/trees/therock-7.14 \
+  | python3 -c "import sys,json;print(next(t['sha'] for t in json.load(sys.stdin)['tree'] if t['path']=='rocm-systems'))")
+
+# 2. Make sure the pin is fetched locally.
+git fetch origin "$PIN"
+
+# 3. A commit belongs to 7.14 iff it is an ancestor of the pin; otherwise it
+#    belongs to the next release (7.15).
+git merge-base --is-ancestor <commit> "$PIN" && echo "7.14" || echo "7.15+"
+```
+
+To audit an entire section, blame its lines and classify each contributing
+commit against the pin:
+
+```bash
+git blame -L <start>,<end> -s CHANGELOG.md | awk '{print $1}' | sort -u \
+  | while read h; do h=${h#^};
+      git merge-base --is-ancestor "$h" "$PIN" 2>/dev/null \
+        || echo "AFTER-PIN (move to next release): $h"; done
+```
+
+Any `AFTER-PIN` commit's entry must move to a new `## amd_smi_lib for ROCm
+<next-version>` section at the top of the file. Keep the same section headings
+(Added / Changed / Removed / Resolved Issues) in the new release block.
 
 ## When a Changelog Entry is Required
 
@@ -61,10 +103,10 @@ Follow [Keep a Changelog](https://keepachangelog.com/) format:
 When reviewing a PR, check:
 
 - [ ] `CHANGELOG.md` updated if change is user-visible
-- [ ] Entry is in the correct section (Added/Fixed/Changed/Removed)
+- [ ] Entry is in the correct section (Added/Changed/Removed/Resolved Issues)
 - [ ] Entry describes the **impact**, not the implementation
 - [ ] Breaking changes have migration notes
-- [ ] Entry is under `## [Unreleased]` (not a version number)
+- [ ] Entry is under the correct release heading — verify against the TheRock release pin, not just the topmost heading (see "Which Release Does an Entry Belong To?")
 - [ ] Bolded headline bullets end with two trailing spaces (Sphinx hard break)
 
 ## Severity
@@ -75,4 +117,5 @@ When reviewing a PR, check:
 | Missing changelog for breaking change | ❌ BLOCKING |
 | Missing changelog for bug fix | ⚠️ IMPORTANT |
 | Changelog entry in wrong section | 💡 SUGGESTION |
+| Changelog entry under the wrong release (merged after the release pin) | ⚠️ IMPORTANT |
 | Missing changelog for internal-only change | Not a finding |

--- a/projects/amdsmi/.claude/skills/amdsmi-changelog-automation/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-changelog-automation/SKILL.md
@@ -55,14 +55,22 @@ Any `AFTER-PIN` commit's entry must move to a new `## amd_smi_lib for ROCm
 
 ## When a Changelog Entry is Required
 
+The repo uses these section headings under each release (matching the ROCm
+release-notes taxonomy): **Added**, **Changed**, **Removed**, **Optimized**,
+**Resolved Issues**, **Upcoming Changes**, **Known Issues**. There is no `Fixed`
+section — bug fixes go under **Resolved Issues**, deprecations under **Upcoming
+Changes**.
+
 | Change Type | Required? | Section |
 |------------|-----------|---------|
 | New public API function | ✅ Yes | Added |
-| Bug fix | ✅ Yes | Fixed |
-| Breaking API change | ✅ Yes | Changed (+ migration note) |
-| Performance improvement | ✅ Yes | Changed |
 | New CLI flag/subcommand | ✅ Yes | Added |
-| Build system fix | ⚠️ If user-visible | Fixed |
+| Bug fix | ✅ Yes | Resolved Issues |
+| Build system fix | ⚠️ If user-visible | Resolved Issues |
+| Breaking API change | ✅ Yes | Changed (+ migration note) |
+| Behavior/output change (non-fix) | ✅ Yes | Changed |
+| Performance / tooling improvement | ✅ Yes | Optimized |
+| Deprecation (still functional) | ✅ Yes | Upcoming Changes |
 | Internal refactor (no behavior change) | ❌ No | — |
 | Test-only changes | ❌ No | — |
 | Documentation-only changes | ❌ No | — |
@@ -70,27 +78,34 @@ Any `AFTER-PIN` commit's entry must move to a new `## amd_smi_lib for ROCm
 
 ## Entry Format
 
-Follow [Keep a Changelog](https://keepachangelog.com/) format:
+Entries follow [Keep a Changelog](https://keepachangelog.com/) conventions but
+under ROCm-version headings, not `## [Unreleased]`:
 
 ```markdown
-## [Unreleased]
+## amd_smi_lib for ROCm <MAJOR>.<MINOR>.<PATCH>
 
 ### Added
-- New `amdsmi_get_gpu_<feature>()` API for querying <feature>
-
-### Fixed
-- Fixed `amd-smi metric` crash when NIC device not present
+- **New `amdsmi_get_gpu_<feature>()` API for querying <feature>**.··
 
 ### Changed
-- `amdsmi_get_gpu_temperature()` now returns temperature in millidegrees (breaking change)
+- **`amdsmi_get_gpu_temperature()` now returns millidegrees (breaking change)**.··
+
+### Optimized
+- **Improved `amd-smi metric` refresh path**.··
+
+### Resolved Issues
+- **Fixed `amd-smi metric` crash when NIC device not present**.··
+
+### Upcoming Changes
+- **`amdsmi_get_gpu_vram_vendor()` is deprecated in favor of `amdsmi_get_gpu_vram_info()`**.··
 ```
 
 ### Rules
 - One bullet per logical change (not per file)
 - Start with the affected component: API name, CLI subcommand, or module
 - For breaking changes: include migration guidance
-- Use past tense for fixes ("Fixed"), present tense for additions ("New")
-- Reference the JIRA/issue if available: `[SWDEV-XXXXXX]`
+- Bug fixes go under **Resolved Issues**, not a `Fixed` section (this repo has none)
+- Reference the JIRA/issue only in the PR `JIRA ID` section, never in the entry text
 - **Bolded headline bullets must end with two trailing spaces** (Markdown hard line break) so Sphinx renders the headline and its sub-bullets on separate lines. Example:
   ```markdown
   - **Fixed `amd-smi static` hang on gfx1153**.··

--- a/projects/amdsmi/.claude/skills/amdsmi-changelog-automation/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-changelog-automation/SKILL.md
@@ -5,159 +5,97 @@ description: "Check and generate changelog entries for amd-smi. Use when: review
 
 # Changelog Automation — amd-smi
 
-Verifies changelog entries exist for meaningful changes and helps generate them.
+## Location & Headings
 
-## Changelog Location
-
-`CHANGELOG.md` in the workspace root. Entries are grouped under
-`## amd_smi_lib for ROCm <MAJOR>.<MINOR>.<PATCH>` headings, **not** a
-`## [Unreleased]` heading. The topmost heading is the release currently being
-accumulated.
+`CHANGELOG.md` at the amd-smi project root. Entries group under
+`## amd_smi_lib for ROCm <MAJOR>.<MINOR>.<PATCH>` headings (no `## [Unreleased]`).
+Allowed subsection headings — anything else is a violation (e.g. `### Fixed`,
+which this repo does not use): **Added, Changed, Removed, Optimized, Resolved
+Issues, Upcoming Changes, Known Issues.** Bug fixes go under **Resolved Issues**,
+deprecations under **Upcoming Changes**.
 
 ## Which Release Does an Entry Belong To?
 
-**A release's changelog is the diff between two consecutive ROCm release
-points.** Everything merged after release `N`'s point and up to release `N+1`'s
-point belongs to `N+1` — regardless of which heading currently sits at the top
-of the file. Never assume the topmost heading is correct for a new entry.
+**An entry belongs to release `V` if its authoring commit is in the range
+`pin(V-1)..pin(V)`** — the diff between two consecutive ROCm release points, not
+the heading it currently sits under.
 
-A release point is not a tag in `rocm-systems`; it is the `rocm-systems`
-submodule commit that [ROCm/TheRock](https://github.com/ROCm/TheRock/releases)
-pins for that release (the `therock-<ver>` tags map 1:1 to ROCm releases).
-
-Resolve the two bracketing pins dynamically — do not hard-code versions:
+A "pin" is the `rocm-systems` commit that
+[ROCm/TheRock](https://github.com/ROCm/TheRock/releases) records for a release.
+TheRock tags drop the patch component: section `7.14.0` → tag `therock-7.14`
+(confirm exact names with `gh release list --repo ROCm/TheRock`; `V-1` is the tag
+immediately below `V`).
 
 ```bash
-# PREV = the last shipped release, CURR = the one being accumulated.
-# List tags with: gh release list --repo ROCm/TheRock
-PREV_TAG=therock-<prev>     # e.g. the newest tag that is already released
-CURR_TAG=therock-<curr>     # the next tag, if it exists yet
-
-pin() {  # resolve the rocm-systems submodule commit pinned by a TheRock tag
-  gh api "repos/ROCm/TheRock/git/trees/$1" \
-    | python3 -c "import sys,json;print(next(t['sha'] for t in json.load(sys.stdin)['tree'] if t['path']=='rocm-systems'))"
+pin() {  # rocm-systems commit pinned by a TheRock tag; origin/develop if the tag is absent
+  gh api "repos/ROCm/TheRock/git/trees/$1" 2>/dev/null \
+    | python3 -c "import sys,json;d=json.load(sys.stdin);print(next(t['sha'] for t in d.get('tree',[]) if t['path']=='rocm-systems'))" 2>/dev/null \
+    || echo origin/develop
 }
-
-PREV_PIN=$(pin "$PREV_TAG")
-git fetch origin "$PREV_PIN"
-# If CURR_TAG is not tagged yet, the current release is still open: use HEAD
-# (origin/develop) as its upper bound instead of a pin.
-CURR_PIN=$(pin "$CURR_TAG" 2>/dev/null || echo origin/develop)
-git fetch origin "$CURR_PIN" 2>/dev/null || true
 ```
 
-The set of commits that belong to the release being accumulated is exactly the
-range `PREV_PIN..CURR_PIN`:
+A tagged release is **frozen at its pin**: `pin(therock-<V>)` is the exact state
+that shipped as ROCm `<V>`. A commit merged after the pin did not ship in `<V>`
+and belongs to the next release — even when `<V>` is still the top heading and no
+`<next>` section exists yet (create it and move the entry). `TOO NEW` (below)
+against a tagged section is always a real misfile.
+
+## Auditing a Section
+
+Bound the section by **its own version** — `HIGH=pin(therock-<V>)`, never
+`origin/develop` by default (`pin()` returns `origin/develop` itself if `<V>`
+isn't tagged yet). Flag any blamed commit outside `pin(<V-1>)..pin(<V>)`; checking
+only one bound misses entries merged after `V` shipped.
 
 ```bash
-git log --oneline "$PREV_PIN..$CURR_PIN"     # everything that must be documented
+git fetch origin >/dev/null 2>&1
+LOW=$(pin therock-<MAJOR.MINOR of V-1>)
+HIGH=$(pin therock-<MAJOR.MINOR of V>)
+read START END < <(awk '/^## amd_smi_lib for ROCm/{n++; if(n==1)s=NR; else if(n==2){print s, NR-1; exit}}' CHANGELOG.md)
+
+# placement — flag commits outside pin(V-1)..pin(V)
+git blame -L "$START,$END" -s CHANGELOG.md | awk '{print $1}' | sed 's/^\^//' | sort -u \
+  | while read h; do
+      git merge-base --is-ancestor "$h" "$LOW"  2>/dev/null && { echo "TOO OLD (earlier release): $h"; continue; }
+      git merge-base --is-ancestor "$h" "$HIGH" 2>/dev/null || echo "TOO NEW (later release): $h"
+    done
+
+# taxonomy — flag disallowed section headings
+sed -n "${START},${END}p" CHANGELOG.md | grep -nE '^### ' \
+  | grep -vE '### (Added|Changed|Removed|Optimized|Resolved Issues|Upcoming Changes|Known Issues)'
+
+# format — bold headline bullets must end with two trailing spaces; JIRA IDs never in entry text
+sed -n "${START},${END}p" CHANGELOG.md | grep -nP '^- \*\*.*\*\*[^ ]*$'         # any match = a headline bullet missing its two trailing spaces
+sed -n "${START},${END}p" CHANGELOG.md | grep -nE 'ROCM-[0-9]+|SWDEV-[0-9]+'    # JIRA belongs only in the PR JIRA ID section
 ```
 
-## Verifying an Entry Lands in the Right Release
+- **TOO OLD** — commit shipped in an earlier release; the entry is a misfile/duplicate.
+- **TOO NEW** — commit merged after `V`'s pin; move the entry to the next
+  release's section (create a new top `## amd_smi_lib for ROCm <next>` block if none exists).
+- **Entry type vs heading** — no command catches this: read each entry's wording
+  against the change-type table below. A valid heading can still hold a wrong-type
+  entry (e.g. a deprecation filed under `### Changed` instead of Upcoming Changes).
 
-Once the bracketing pins are known, classify any commit with
-`git merge-base --is-ancestor` — the same check the PR-history walk uses:
+## Section for Each Change Type
 
-```bash
-# Ancestor of PREV_PIN  -> already shipped, belongs to a PRIOR release
-# Otherwise             -> belongs to the release currently being accumulated
-git merge-base --is-ancestor <commit> "$PREV_PIN" && echo "prior release" || echo "current release"
-```
+| Change | Section | Entry needed? |
+|--------|---------|---------------|
+| New public API / new CLI flag or subcommand | Added | Yes |
+| Bug fix (incl. user-visible build fix) | Resolved Issues | Yes |
+| Breaking API change | Changed (+ migration note) | Yes |
+| Other behavior/output change | Changed | Yes |
+| Performance / tooling improvement | Optimized | Yes |
+| Deprecation (still functional) | Upcoming Changes | Yes |
+| Internal refactor / test-only / docs-only / style-only | — | No |
 
-To audit an entire changelog section, blame its lines and flag any contributing
-commit that is *not* newer than the previous release point (i.e. was already
-shipped and is filed under the wrong heading):
+## Entry Rules
 
-```bash
-git blame -L <start>,<end> -s CHANGELOG.md | awk '{print $1}' | sort -u \
-  | while read h; do h=${h#^};
-      git merge-base --is-ancestor "$h" "$PREV_PIN" 2>/dev/null \
-        && echo "ALREADY-SHIPPED (belongs to a prior release): $h"; done
-```
-
-Any flagged commit's entry must move to the correct
-`## amd_smi_lib for ROCm <version>` section (creating a new top section when the
-entry actually belongs to the next, not-yet-tagged release). Keep the same
-section headings in whichever release block the entry moves to.
-
-## When a Changelog Entry is Required
-
-The repo uses these section headings under each release (matching the ROCm
-release-notes taxonomy): **Added**, **Changed**, **Removed**, **Optimized**,
-**Resolved Issues**, **Upcoming Changes**, **Known Issues**. There is no `Fixed`
-section — bug fixes go under **Resolved Issues**, deprecations under **Upcoming
-Changes**.
-
-| Change Type | Required? | Section |
-|------------|-----------|---------|
-| New public API function | ✅ Yes | Added |
-| New CLI flag/subcommand | ✅ Yes | Added |
-| Bug fix | ✅ Yes | Resolved Issues |
-| Build system fix | ⚠️ If user-visible | Resolved Issues |
-| Breaking API change | ✅ Yes | Changed (+ migration note) |
-| Behavior/output change (non-fix) | ✅ Yes | Changed |
-| Performance / tooling improvement | ✅ Yes | Optimized |
-| Deprecation (still functional) | ✅ Yes | Upcoming Changes |
-| Internal refactor (no behavior change) | ❌ No | — |
-| Test-only changes | ❌ No | — |
-| Documentation-only changes | ❌ No | — |
-| Style/formatting-only changes | ❌ No | — |
-
-## Entry Format
-
-Entries follow [Keep a Changelog](https://keepachangelog.com/) conventions but
-under ROCm-version headings, not `## [Unreleased]`:
-
-```markdown
-## amd_smi_lib for ROCm <MAJOR>.<MINOR>.<PATCH>
-
-### Added
-- **New `amdsmi_get_gpu_<feature>()` API for querying <feature>**.··
-
-### Changed
-- **`amdsmi_get_gpu_temperature()` now returns millidegrees (breaking change)**.··
-
-### Optimized
-- **Improved `amd-smi metric` refresh path**.··
-
-### Resolved Issues
-- **Fixed `amd-smi metric` crash when NIC device not present**.··
-
-### Upcoming Changes
-- **`amdsmi_get_gpu_vram_vendor()` is deprecated in favor of `amdsmi_get_gpu_vram_info()`**.··
-```
-
-### Rules
-- One bullet per logical change (not per file)
-- Start with the affected component: API name, CLI subcommand, or module
-- For breaking changes: include migration guidance
-- Bug fixes go under **Resolved Issues**, not a `Fixed` section (this repo has none)
-- Reference the JIRA/issue only in the PR `JIRA ID` section, never in the entry text
-- **Bolded headline bullets must end with two trailing spaces** (Markdown hard line break) so Sphinx renders the headline and its sub-bullets on separate lines. Example:
+- One bullet per logical change, starting with the affected component (API name, CLI subcommand, or module).
+- Breaking changes include migration guidance.
+- JIRA/issue refs only in the PR `JIRA ID` section, never in entry text.
+- Bold headline bullets must end with **two trailing spaces** (`··`) so Sphinx
+  keeps the headline and its sub-bullets on separate lines:
   ```markdown
   - **Fixed `amd-smi static` hang on gfx1153**.··
     - Added 60-second timeout to `amdsmi_init()`.
   ```
-  (`··` = two literal trailing spaces.) Without them, Sphinx collapses the headline into the first sub-bullet. Verify with `grep -nP '^- \*\*.*\*\*[^ ]*$' CHANGELOG.md` — any match is missing the trailing whitespace.
-
-## Review Checklist
-
-When reviewing a PR, check:
-
-- [ ] `CHANGELOG.md` updated if change is user-visible
-- [ ] Entry is in the correct section (Added/Changed/Removed/Resolved Issues)
-- [ ] Entry describes the **impact**, not the implementation
-- [ ] Breaking changes have migration notes
-- [ ] Entry is under the correct release heading — verify against the TheRock release pin, not just the topmost heading (see "Which Release Does an Entry Belong To?")
-- [ ] Bolded headline bullets end with two trailing spaces (Sphinx hard break)
-
-## Severity
-
-| Finding | Severity |
-|---------|----------|
-| Missing changelog for new public API | ⚠️ IMPORTANT |
-| Missing changelog for breaking change | ❌ BLOCKING |
-| Missing changelog for bug fix | ⚠️ IMPORTANT |
-| Changelog entry in wrong section | 💡 SUGGESTION |
-| Changelog entry under the wrong release (merged after the release pin) | ⚠️ IMPORTANT |
-| Missing changelog for internal-only change | Not a finding |

--- a/projects/amdsmi/.claude/skills/amdsmi-changelog-automation/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-changelog-automation/SKILL.md
@@ -16,42 +16,69 @@ accumulated.
 
 ## Which Release Does an Entry Belong To?
 
-**Never assume the topmost heading is correct for a new entry.** A ROCm release
-is cut at a specific `rocm-systems` commit (the "release point"). Anything merged
-**after** that commit belongs to the **next** release, even if the current top
-heading still names the released version.
+**A release's changelog is the diff between two consecutive ROCm release
+points.** Everything merged after release `N`'s point and up to release `N+1`'s
+point belongs to `N+1` — regardless of which heading currently sits at the top
+of the file. Never assume the topmost heading is correct for a new entry.
 
-The release point is not a tag in `rocm-systems` — it is the `rocm-systems`
+A release point is not a tag in `rocm-systems`; it is the `rocm-systems`
 submodule commit that [ROCm/TheRock](https://github.com/ROCm/TheRock/releases)
-pins for that release. Resolve it like this:
+pins for that release (the `therock-<ver>` tags map 1:1 to ROCm releases).
+
+Resolve the two bracketing pins dynamically — do not hard-code versions:
 
 ```bash
-# 1. Find the rocm-systems submodule commit pinned by the TheRock release tag.
-#    (therock-<ver> tags map 1:1 to ROCm releases.)
-PIN=$(gh api repos/ROCm/TheRock/git/trees/therock-7.14 \
-  | python3 -c "import sys,json;print(next(t['sha'] for t in json.load(sys.stdin)['tree'] if t['path']=='rocm-systems'))")
+# PREV = the last shipped release, CURR = the one being accumulated.
+# List tags with: gh release list --repo ROCm/TheRock
+PREV_TAG=therock-<prev>     # e.g. the newest tag that is already released
+CURR_TAG=therock-<curr>     # the next tag, if it exists yet
 
-# 2. Make sure the pin is fetched locally.
-git fetch origin "$PIN"
+pin() {  # resolve the rocm-systems submodule commit pinned by a TheRock tag
+  gh api "repos/ROCm/TheRock/git/trees/$1" \
+    | python3 -c "import sys,json;print(next(t['sha'] for t in json.load(sys.stdin)['tree'] if t['path']=='rocm-systems'))"
+}
 
-# 3. A commit belongs to 7.14 iff it is an ancestor of the pin; otherwise it
-#    belongs to the next release (7.15).
-git merge-base --is-ancestor <commit> "$PIN" && echo "7.14" || echo "7.15+"
+PREV_PIN=$(pin "$PREV_TAG")
+git fetch origin "$PREV_PIN"
+# If CURR_TAG is not tagged yet, the current release is still open: use HEAD
+# (origin/develop) as its upper bound instead of a pin.
+CURR_PIN=$(pin "$CURR_TAG" 2>/dev/null || echo origin/develop)
+git fetch origin "$CURR_PIN" 2>/dev/null || true
 ```
 
-To audit an entire section, blame its lines and classify each contributing
-commit against the pin:
+The set of commits that belong to the release being accumulated is exactly the
+range `PREV_PIN..CURR_PIN`:
+
+```bash
+git log --oneline "$PREV_PIN..$CURR_PIN"     # everything that must be documented
+```
+
+## Verifying an Entry Lands in the Right Release
+
+Once the bracketing pins are known, classify any commit with
+`git merge-base --is-ancestor` — the same check the PR-history walk uses:
+
+```bash
+# Ancestor of PREV_PIN  -> already shipped, belongs to a PRIOR release
+# Otherwise             -> belongs to the release currently being accumulated
+git merge-base --is-ancestor <commit> "$PREV_PIN" && echo "prior release" || echo "current release"
+```
+
+To audit an entire changelog section, blame its lines and flag any contributing
+commit that is *not* newer than the previous release point (i.e. was already
+shipped and is filed under the wrong heading):
 
 ```bash
 git blame -L <start>,<end> -s CHANGELOG.md | awk '{print $1}' | sort -u \
   | while read h; do h=${h#^};
-      git merge-base --is-ancestor "$h" "$PIN" 2>/dev/null \
-        || echo "AFTER-PIN (move to next release): $h"; done
+      git merge-base --is-ancestor "$h" "$PREV_PIN" 2>/dev/null \
+        && echo "ALREADY-SHIPPED (belongs to a prior release): $h"; done
 ```
 
-Any `AFTER-PIN` commit's entry must move to a new `## amd_smi_lib for ROCm
-<next-version>` section at the top of the file. Keep the same section headings
-(Added / Changed / Removed / Resolved Issues) in the new release block.
+Any flagged commit's entry must move to the correct
+`## amd_smi_lib for ROCm <version>` section (creating a new top section when the
+entry actually belongs to the next, not-yet-tagged release). Keep the same
+section headings in whichever release block the entry moves to.
 
 ## When a Changelog Entry is Required
 

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -17,6 +17,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Fixed compute processes being reported on every GPU**.  
   - A process was attributed to a GPU whenever it had a KFD context on that GPU, so a job with queues on a single GPU appeared under every GPU. Attribution now uses the process's active KFD queues plus any GPU where it holds a non-zero VRAM allocation, so a process is listed only against the GPUs it actually uses.
 
+- **Fixed `amd-smi` hanging in `amdsmi_init()` on UALink systems when the IFoE driver is unresponsive**.  
+  - `AMDSmiGPUDevice` opened the per-GPU IFoE/UALoE generic-netlink session in its constructor, so `amdsmi_init(AMDSMI_INIT_AMD_GPUS)` (and every CLI verb) blocked in an uninterruptible netlink wait when the Broadcom IFoE driver was wedged, even for queries that never use fabric data.
+  - The UALoE session is now opened lazily on the first fabric query via `get_ualoe_handle()`, so initialization and non-fabric queries no longer touch the IFoE driver.
+
 ## amd_smi_lib for ROCm 7.14.0
 
 ### Added

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -4,6 +4,19 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ***All information listed below is for reference and subject to change.***
 
+## amd_smi_lib for ROCm 7.15.0
+
+### Resolved Issues
+
+- **Fixed `amd-smi process` hiding compute processes owned by other users**.  
+  - A caller without permission to read another process's `/proc/<pid>/fd` was misdetected as running in a separate PID namespace, which caused the whole compute-process list to come back empty. Such processes are now listed with a redacted (`N/A`) name instead of being dropped.
+
+- **Fixed CU%/SDMA column alignment in the `amd-smi` process table**.  
+  - The `SDMA` header no longer sits a column left of its values, and valid `CU %`/`SDMA` values are no longer truncated.
+
+- **Fixed compute processes being reported on every GPU**.  
+  - A process was attributed to a GPU whenever it had a KFD context on that GPU, so a job with queues on a single GPU appeared under every GPU. Attribution now uses the process's active KFD queues plus any GPU where it holds a non-zero VRAM allocation, so a process is listed only against the GPUs it actually uses.
+
 ## amd_smi_lib for ROCm 7.14.0
 
 ### Added
@@ -97,15 +110,6 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Removed the unused `amdsmi_nic_link_type_t` enum from the public header**. No API or struct referenced it; NIC link types are reported through `amdsmi_link_type_t`, which gains `AMDSMI_LINK_TYPE_NUMA` and `AMDSMI_LINK_TYPE_XNUMA` in this release.
 
 ### Resolved Issues
-
-- **Fixed `amd-smi process` hiding compute processes owned by other users**.  
-  - A caller without permission to read another process's `/proc/<pid>/fd` was misdetected as running in a separate PID namespace, which caused the whole compute-process list to come back empty. Such processes are now listed with a redacted (`N/A`) name instead of being dropped.
-
-- **Fixed CU%/SDMA column alignment in the `amd-smi` process table**.  
-  - The `SDMA` header no longer sits a column left of its values, and valid `CU %`/`SDMA` values are no longer truncated.
-
-- **Fixed compute processes being reported on every GPU**.  
-  - A process was attributed to a GPU whenever it had a KFD context on that GPU, so a job with queues on a single GPU appeared under every GPU. Attribution now uses the process's active KFD queues plus any GPU where it holds a non-zero VRAM allocation, so a process is listed only against the GPUs it actually uses.
 
 - **Fixed `amd-smi set --power-cap` rejecting the minimum allowed value**.  
   - The lower bound is now inclusive, so setting the power cap to the exact minimum of the reported range (e.g. `210` when the range is 210-300W) succeeds instead of failing validation, matching the inclusive range shown in the error message.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -90,7 +90,13 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Renamed "AINIC version" to "ionic version" in `amd-smi version` output**.  
   - The label now correctly reflects that it shows the ionic kernel driver version.
 
-### Fixed
+### Removed
+
+- **Removed the non-functional `--decode` flag from `amd-smi ras`**. Out-of-band CPER decoding is available via `amd-smi ras --afid --cper-file <path>` or `--afid --folder <DIR>`.
+
+- **Removed the unused `amdsmi_nic_link_type_t` enum from the public header**. No API or struct referenced it; NIC link types are reported through `amdsmi_link_type_t`, which gains `AMDSMI_LINK_TYPE_NUMA` and `AMDSMI_LINK_TYPE_XNUMA` in this release.
+
+### Resolved Issues
 
 - **Fixed `amd-smi process` hiding compute processes owned by other users**.  
   - A caller without permission to read another process's `/proc/<pid>/fd` was misdetected as running in a separate PID namespace, which caused the whole compute-process list to come back empty. Such processes are now listed with a redacted (`N/A`) name instead of being dropped.
@@ -100,18 +106,6 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 - **Fixed compute processes being reported on every GPU**.  
   - A process was attributed to a GPU whenever it had a KFD context on that GPU, so a job with queues on a single GPU appeared under every GPU. Attribution now uses the process's active KFD queues plus any GPU where it holds a non-zero VRAM allocation, so a process is listed only against the GPUs it actually uses.
-
-### Removed
-
-- **Removed the non-functional `--decode` flag from `amd-smi ras`**. Out-of-band CPER decoding is available via `amd-smi ras --afid --cper-file <path>` or `--afid --folder <DIR>`.
-
-- **Removed the unused `amdsmi_nic_link_type_t` enum from the public header**. No API or struct referenced it; NIC link types are reported through `amdsmi_link_type_t`, which gains `AMDSMI_LINK_TYPE_NUMA` and `AMDSMI_LINK_TYPE_XNUMA` in this release.
-
-### Resolved Issues
-
-- **Fixed `amd-smi` hanging in `amdsmi_init()` on UALink systems when the IFoE driver is unresponsive**.  
-  - `AMDSmiGPUDevice` opened the per-GPU IFoE/UALoE generic-netlink session in its constructor, so `amdsmi_init(AMDSMI_INIT_AMD_GPUS)` (and every CLI verb) blocked in an uninterruptible netlink wait when the Broadcom IFoE driver was wedged, even for queries that never use fabric data.
-  - The UALoE session is now opened lazily on the first fabric query via `get_ualoe_handle()`, so initialization and non-fabric queries no longer touch the IFoE driver.
 
 - **Fixed `amd-smi set --power-cap` rejecting the minimum allowed value**.  
   - The lower bound is now inclusive, so setting the power cap to the exact minimum of the reported range (e.g. `210` when the range is 210-300W) succeeds instead of failing validation, matching the inclusive range shown in the error message.
@@ -347,7 +341,7 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
     Several items were misaligned in the default output, and this change ensures a consistent left-aligned format across all fields.
   - *This change is purely cosmetic and does not affect any functionality.*
 
-- **Fixed `amd-smi static -C` reporting `N/A` for SYS/MEM/DF/SOC/DCEF clocks at idle on gfx1151-class APUs (ROCM-21057)**.
+- **Fixed `amd-smi static -C` reporting `N/A` for SYS/MEM/DF/SOC/DCEF clocks at idle on gfx1151-class APUs**.  
   - `get_frequencies()` in the rsmi backend no longer discards a parsed `pp_dpm_*` DPM table with `STATUS_UNEXPECTED_DATA` when the kernel omits the `*` current-level marker (which happens whenever the SMU power-gates the domain at idle). The supported frequency table is now returned and `current` is reported as `-1` (unknown) until the marker reappears, so `amdsmi_get_clk_freq()` and all callers see the table at idle as well as under load.
 
 ## amd_smi_lib for ROCm 7.12.0


### PR DESCRIPTION
## Motivation

Two problems in the 7.14.0 changelog block:

1. Three bug-fix bullets from PR #8396 (process visibility, per-GPU attribution, CU%/SDMA table alignment) were filed under **7.14.0**, but that PR merged on 2026-07-16 — after the 7.14 release point. The 7.14 release pins `rocm-systems` at `2b22ab0` (via the `therock-7.14` tag, dated 2026-07-09), so those fixes belong in **7.15.0**.
2. A stray `(ROCM-21057)` JIRA reference in a 7.13.0 headline, which was also missing the Sphinx hard-break trailing spaces.

## Technical Details

**Changelog** (`CHANGELOG.md`):
- Add a new `## amd_smi_lib for ROCm 7.15.0` section at the top with a `### Resolved Issues` block holding the three PR #8396 process/table-alignment bullets
- Remove those bullets and the now-redundant `### Fixed` heading from 7.14.0 (7.14.0 keeps the Added/Changed/Removed/Resolved-Issues layout of prior releases)
- Remove the `(ROCM-21057)` ticket reference from the gfx1151 idle-clock headline and add the trailing double-space for the Sphinx hard break

**Skill** (`.claude/skills/amdsmi-changelog-automation/SKILL.md`):
- Document how to attribute an entry to the correct release: resolve the `rocm-systems` submodule commit pinned by the matching `therock-<ver>` TheRock release, then classify each entry's commit with `git merge-base --is-ancestor` against that pin. Anything after the pin moves to the next release.

## JIRA ID

N/A (changelog cleanup)

## Test Plan

- Resolve the 7.14 pin: `gh api repos/ROCm/TheRock/git/trees/therock-7.14` → `rocm-systems` = `2b22ab0`
- Classify every 7.14 section commit with `git merge-base --is-ancestor <commit> 2b22ab0` — only PR #8396 (`d7fc3d2`) is after the pin
- `grep -nP '^- \*\*.*\*\*[^ ]*$' CHANGELOG.md` — no bolded headline missing the trailing double-space
- `grep -nE 'ROCM-[0-9]+|SWDEV-[0-9]+|AILITOOLS-[0-9]+' CHANGELOG.md` — no ticket refs remain

## Test Result

- Only `d7fc3d2` (PR #8396) classified as after-pin; its three bullets now sit under 7.15.0.
- Both greps return no matches.

## Submission Checklist

- [x] Docs-only change; no source or tests affected