### PR TITLE
refactor(rocprofiler-sdk): migrate SPM off the per-queue callback registry

### DIFF
--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
@@ -315,4 +315,26 @@ rocprofiler_spm_configure_buffer_dispatch_service(
     rocprofiler_spm_dispatch_counting_service_cb_t callback,
     void* callback_data_args) ROCPROFILER_API ROCPROFILER_NONNULL(3);
 
+/**
+ * @brief (experimental) Restrict an SPM dispatch counting service to a set of GPU agents.
+ *
+ *        By default an SPM dispatch service applies to every GPU agent. This function narrows
+ *        the service so that agents outside @p agents are neither instrumented nor serialized.
+ *        Restricting the agent set also relaxes the SPM context conflict: two contexts may each
+ *        configure an SPM dispatch service and be active at the same time provided their agent
+ *        sets are disjoint.
+ *
+ *        Must be called after an SPM dispatch service has been configured on @p context_id and
+ *        before the context is started. Passing @p num_agents of zero restores all agents.
+ *
+ * @param [in] context_id context id with a configured SPM dispatch service
+ * @param [in] agents array of GPU agent ids to restrict collection to
+ * @param [in] num_agents number of entries in @p agents
+ * @return ::rocprofiler_status_t
+ */
+ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_status_t
+rocprofiler_spm_dispatch_counting_service_set_agents(rocprofiler_context_id_t      context_id,
+                                                     const rocprofiler_agent_id_t* agents,
+                                                     size_t num_agents) ROCPROFILER_API;
+
 ROCPROFILER_EXTERN_C_FINI

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -368,24 +368,26 @@ stop_context(rocprofiler_context_id_t idx)
         const context* _expected = itr.load(std::memory_order_acquire);
         if(_expected && _expected->context_idx == idx.handle)
         {
+            // Stop queue-interposed services while the context is still in the active list so
+            // write_hook can coordinate serialized->unserialized transitions during drain.
+            if(_expected->dispatch_counter_collection)
+            {
+                rocprofiler::counters::stop_context(const_cast<context*>(_expected));
+            }
+
+            if(_expected->dispatch_spm)
+                rocprofiler::spm::stop_context(const_cast<context*>(_expected));
+
+            if(_expected->device_thread_trace) _expected->device_thread_trace->stop_context();
+            if(_expected->dispatch_thread_trace)
+                _expected->dispatch_thread_trace->stop_context();
+
             bool success = itr.compare_exchange_strong(_expected, nullptr);
 
             if(success)
             {
                 auto nactive = get_num_active_contexts().load(std::memory_order_acquire);
                 if(nactive > 0) get_num_active_contexts().fetch_sub(1, std::memory_order_release);
-
-                if(_expected->dispatch_counter_collection)
-                {
-                    rocprofiler::counters::stop_context(const_cast<context*>(_expected));
-                }
-
-                if(_expected->dispatch_spm)
-                    rocprofiler::spm::stop_context(const_cast<context*>(_expected));
-
-                if(_expected->device_thread_trace) _expected->device_thread_trace->stop_context();
-                if(_expected->dispatch_thread_trace)
-                    _expected->dispatch_thread_trace->stop_context();
 
                 rocprofiler::hsa::queue_interposition::
                     notify_queue_interposition_consumer_context_stopped(_expected);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -368,8 +368,11 @@ stop_context(rocprofiler_context_id_t idx)
         const context* _expected = itr.load(std::memory_order_acquire);
         if(_expected && _expected->context_idx == idx.handle)
         {
-            // Stop queue-interposed services while the context is still in the active list so
-            // write_hook can coordinate serialized->unserialized transitions during drain.
+            // Stop queue-interposed services before clearing the active slot so
+            // disable_serialization() always runs before dispatches stop being instrumented.
+            // Clearing the slot first opens the opposite window, in which write_hook sees no
+            // active context and a dispatch is submitted without serializer packets while the
+            // serializer is still enabled.
             if(_expected->dispatch_counter_collection)
             {
                 rocprofiler::counters::stop_context(const_cast<context*>(_expected));

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -106,6 +106,20 @@ get_active_contexts_impl()
 }
 }  // namespace
 
+bool
+spm_dispatch_counter_collection_service::intersects(
+    const spm_dispatch_counter_collection_service& rhs) const
+{
+    if(agents.empty() || rhs.agents.empty()) return true;
+    const auto& small = (agents.size() < rhs.agents.size()) ? agents : rhs.agents;
+    const auto& large = (agents.size() < rhs.agents.size()) ? rhs.agents : agents;
+    for(const auto& agent_id : small)
+    {
+        if(large.count(agent_id) > 0) return true;
+    }
+    return false;
+}
+
 context_array_t&
 get_registered_contexts(context_array_t& data, context_filter_t filter)
 {
@@ -292,6 +306,13 @@ start_context(rocprofiler_context_id_t context_id)
         else if(cfg->dispatch_counter_collection && itr->dispatch_counter_collection)
         {
             // conflicting context
+            return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
+        }
+        else if(cfg->dispatch_spm && itr->dispatch_spm &&
+                cfg->dispatch_spm->intersects(*itr->dispatch_spm))
+        {
+            // Two SPM dispatch contexts can run concurrently as long as they target disjoint
+            // sets of GPU agents. A context with no agent restriction claims every agent.
             return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
         }
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -403,8 +403,7 @@ stop_context(rocprofiler_context_id_t idx)
                 rocprofiler::spm::stop_context(const_cast<context*>(_expected));
 
             if(_expected->device_thread_trace) _expected->device_thread_trace->stop_context();
-            if(_expected->dispatch_thread_trace)
-                _expected->dispatch_thread_trace->stop_context();
+            if(_expected->dispatch_thread_trace) _expected->dispatch_thread_trace->stop_context();
 
             bool success = itr.compare_exchange_strong(_expected, nullptr);
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.hpp
@@ -35,6 +35,8 @@
 
 #include <rocprofiler-sdk/fwd.h>
 #include <rocprofiler-sdk/registration.h>
+#include <rocprofiler-sdk/cxx/hash.hpp>
+#include <rocprofiler-sdk/cxx/operators.hpp>
 
 #include <array>
 #include <cstddef>
@@ -42,6 +44,7 @@
 #include <memory>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace rocprofiler
 {
@@ -94,10 +97,23 @@ struct spm_dispatch_counter_collection_service
     // Contains callback information along with other data needed to collect/process
     // SPM counters.
     std::vector<std::shared_ptr<spm::spm_counter_callback_info>> callbacks{};
+    // GPU agents this context collects on. An empty set means every GPU agent, which is what a
+    // plain configure_{buffer,callback}_dispatch call produces;
+    // rocprofiler_spm_dispatch_counting_service_set_agents narrows it. The set is read on the
+    // dispatch path and when scoping serialization, so it is fixed at configure time and never
+    // mutated once the context is started.
+    std::unordered_set<rocprofiler_agent_id_t> agents{};
     // A flag to state whether or not the counter set is currently enabled. This is primarily
     // to protect against multithreaded calls to enable a context (and enabling already enabled
     // counters).
     common::Synchronized<bool> enabled{false};
+
+    bool collects_on(rocprofiler_agent_id_t agent_id) const
+    {
+        return agents.empty() || agents.count(agent_id) > 0;
+    }
+
+    bool intersects(const spm_dispatch_counter_collection_service& rhs) const;
 };
 
 struct device_counting_service

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/CMakeLists.txt
@@ -39,3 +39,4 @@ target_sources(rocprofiler-sdk-object-library PRIVATE ${ROCPROFILER_LIB_HSA_SOUR
                                                       ${ROCPROFILER_LIB_HSA_HEADERS})
 
 add_subdirectory(details)
+add_subdirectory(queue_hooks)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -40,6 +40,7 @@
 #include "lib/rocprofiler-sdk/pc_sampling/hsa_adapter.hpp"
 #include "lib/rocprofiler-sdk/pc_sampling/service.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
+#include "lib/rocprofiler-sdk/spm/queue_hooks.hpp"
 #include "lib/rocprofiler-sdk/tracing/tracing.hpp"
 
 #include <rocprofiler-sdk/callback_tracing.h>
@@ -167,6 +168,15 @@ AsyncSignalHandler(hsa_signal_value_t /*signal_v*/, void* data)
                                           dispatch_time);
             }
         });
+
+        // SPM completion is migrated off the callback registry (see WriteInterceptor); invoke
+        // it explicitly here.
+        spm::signal_completion_hook(queue_info_session.queue,
+                                    packet.kernel_packet,
+                                    _session,
+                                    packet,
+                                    packet.instrumentation_packets,
+                                    dispatch_time);
 
         if(packet.is_serialized)
         {
@@ -305,8 +315,10 @@ WriteInterceptor(const void* packets,
 
     auto*      gls                 = ::rocprofiler::hip::graph::current_launch_state();
     const bool graph_launch_active = (gls != nullptr);
+    // SPM no longer registers a queue-controller callback, so it does not count toward
+    // get_notifiers(); detect it explicitly so an SPM-only run still enters the interceptor.
     const bool no_real_consumers =
-        (queue.get_notifiers() == 0 &&
+        (queue.get_notifiers() == 0 && !spm::is_any_active() &&
          context::get_active_contexts(full_packet_instrumentation_context_filter).empty());
 
     if(pkt_count == 0 || (no_real_consumers && !graph_launch_active))
@@ -617,6 +629,18 @@ WriteInterceptor(const void* packets,
                 }
             });
 
+            // SPM is migrated off the per-queue callback registry: call its hook explicitly
+            // (the other services still flow through signal_callback above).
+            spm::write_hook(queue,
+                            kernel_packet,
+                            kernel_id,
+                            dispatch_id,
+                            &_packet_data.user_data,
+                            _packet_data.tracing_data.external_correlation_ids,
+                            corr_id,
+                            _packet_data.instrumentation_packets,
+                            _packet_data.is_serialized);
+
             bool inserted_before = false;
             if(_packet_data.is_serialized)
             {
@@ -750,6 +774,9 @@ WriteInterceptor(const void* packets,
             }
         }
     });
+
+    // SPM requires per-packet mode; it no longer participates in the registry above.
+    if(spm::is_any_active()) should_batch_packets = false;
 
     if(should_batch_packets)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -483,8 +483,7 @@ QueueController::update_serialization(const agent_handle_set_t& agents, bool ena
                 {
                     auto itr = was_enabled.find(agent_id);
                     if(itr == was_enabled.end()) continue;
-                    if(itr->second != state.enabled(agent_id))
-                        transitioned.emplace_back(agent_id);
+                    if(itr->second != state.enabled(agent_id)) transitioned.emplace_back(agent_id);
                 }
             });
 
@@ -543,8 +542,7 @@ bool
 QueueController::is_serialization_enabled(rocprofiler_agent_id_t agent_id) const
 {
     bool enabled = false;
-    _serialization_refcount.rlock(
-        [&](const auto& state) { enabled = state.enabled(agent_id); });
+    _serialization_refcount.rlock([&](const auto& state) { enabled = state.enabled(agent_id); });
     return enabled;
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -391,10 +391,19 @@ common::Synchronized<hsa::profiler_serializer>&
 QueueController::serializer(const Queue* queue)
 {
     CHECK(queue);
+    const auto agent_id = queue->get_agent().get_rocp_agent()->id;
+
+    // Read the refcount before taking the serializer lock: update_serialization() acquires
+    // them in that order, and reversing it here would deadlock. A concurrent enable/disable
+    // for this agent can therefore race with the creation below, exactly as the previous
+    // _serialized_enabled load could, and is resolved the same way -- the next transition
+    // through update_serialization() reaches the entry once it is in the map.
+    const bool should_serialize = is_serialization_enabled(agent_id);
+
     common::Synchronized<hsa::profiler_serializer>* ret = nullptr;
     _profiler_serializer.ulock(
         [&](const auto& m) {
-            if(auto ptr = m.find(queue->get_agent().get_rocp_agent()->id); ptr != m.end())
+            if(auto ptr = m.find(agent_id); ptr != m.end())
             {
                 ret = ptr->second.get();
                 return true;
@@ -402,10 +411,10 @@ QueueController::serializer(const Queue* queue)
             return false;
         },
         [&](auto& m) {
-            ret = m.emplace(queue->get_agent().get_rocp_agent()->id,
+            ret = m.emplace(agent_id,
                             std::make_shared<common::Synchronized<hsa::profiler_serializer>>())
                       .first->second.get();
-            if(_serialized_enabled.load() == true)
+            if(should_serialize)
             {
                 ret->wlock([&](auto& serializer) { serializer.enable({}); });
             }
@@ -429,47 +438,114 @@ per_dev_map(const QueueController::queue_map_t& _queues_v)
 };  // namespace
 
 void
-QueueController::disable_serialization()
+QueueController::update_serialization(const agent_handle_set_t& agents, bool enable)
 {
     _queues.rlock([&](const queue_map_t& _queues_v) {
-        _serialized_enabled.store(false);
         auto pd_map = per_dev_map(_queues_v);
-        _profiler_serializer.wlock([&](auto& m) {
-            for(auto& [k, v] : m)
+
+        // Agents whose effective refcount crossed zero in this call; only those get their
+        // serializer toggled. Collected under the refcount lock, applied under the serializer
+        // lock.
+        auto transitioned = std::vector<rocprofiler_agent_id_t>{};
+        bool any_enabled  = false;
+
+        _serialization_refcount.wlock([&](auto& state) {
+            // An agent can be covered by `all` and by an explicit entry at the same time, so
+            // the transition has to be decided by comparing effective counts across the
+            // update rather than by watching a single counter hit zero.
+            auto was_enabled = std::unordered_map<rocprofiler_agent_id_t, bool>{};
+            _profiler_serializer.rlock([&](const auto& serializers) {
+                for(const auto& [agent_id, _] : serializers)
+                    was_enabled.emplace(agent_id, state.enabled(agent_id));
+            });
+
+            if(agents.empty())
             {
-                if(auto it = pd_map.find(k); it != pd_map.end())
+                if(enable)
+                    ++state.all;
+                else if(state.all > 0)
+                    --state.all;
+            }
+            else
+            {
+                for(const auto& agent_id : agents)
                 {
-                    v->wlock([&](auto& serializer) { serializer.disable(it->second); });
+                    auto& count = state.per_agent[agent_id];
+                    if(enable)
+                        ++count;
+                    else if(count > 0)
+                        --count;
                 }
-                else
+            }
+
+            _profiler_serializer.rlock([&](const auto& serializers) {
+                for(const auto& [agent_id, _] : serializers)
                 {
-                    v->wlock([&](auto& serializer) { serializer.disable({}); });
+                    auto itr = was_enabled.find(agent_id);
+                    if(itr == was_enabled.end()) continue;
+                    if(itr->second != state.enabled(agent_id))
+                        transitioned.emplace_back(agent_id);
                 }
+            });
+
+            any_enabled = state.any();
+        });
+
+        _serialized_enabled.store(any_enabled);
+
+        if(transitioned.empty()) return;
+
+        _profiler_serializer.wlock([&](auto& m) {
+            for(const auto& agent_id : transitioned)
+            {
+                auto itr = m.find(agent_id);
+                if(itr == m.end() || !itr->second) continue;
+
+                auto queues = hsa_barrier::queue_map_ptr_t{};
+                if(auto it = pd_map.find(agent_id); it != pd_map.end()) queues = it->second;
+
+                itr->second->wlock([&](auto& serializer) {
+                    if(enable)
+                        serializer.enable(queues);
+                    else
+                        serializer.disable(queues);
+                });
             }
         });
     });
 }
 
 void
+QueueController::disable_serialization()
+{
+    update_serialization({}, false);
+}
+
+void
 QueueController::enable_serialization()
 {
-    _queues.rlock([&](const queue_map_t& _queues_v) {
-        _serialized_enabled.store(true);
-        auto pd_map = per_dev_map(_queues_v);
-        _profiler_serializer.wlock([&](auto& m) {
-            for(auto& [k, v] : m)
-            {
-                if(auto it = pd_map.find(k); it != pd_map.end())
-                {
-                    v->wlock([&](auto& serializer) { serializer.enable(it->second); });
-                }
-                else
-                {
-                    v->wlock([&](auto& serializer) { serializer.enable({}); });
-                }
-            }
-        });
-    });
+    update_serialization({}, true);
+}
+
+void
+QueueController::disable_serialization(const agent_handle_set_t& agents)
+{
+    update_serialization(agents, false);
+}
+
+void
+QueueController::enable_serialization(const agent_handle_set_t& agents)
+{
+    update_serialization(agents, true);
+}
+
+bool
+QueueController::is_serialization_enabled(rocprofiler_agent_id_t agent_id) const
+{
+    bool enabled = false;
+    _serialization_refcount.rlock(
+        [&](const auto& state) { enabled = state.enabled(agent_id); });
+    return enabled;
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -443,10 +443,12 @@ QueueController::update_serialization(const agent_handle_set_t& agents, bool ena
     _queues.rlock([&](const queue_map_t& _queues_v) {
         auto pd_map = per_dev_map(_queues_v);
 
-        // Agents whose effective refcount crossed zero in this call; only those get their
-        // serializer toggled. Collected under the refcount lock, applied under the serializer
-        // lock.
-        auto transitioned = std::vector<rocprofiler_agent_id_t>{};
+        // Agents whose effective state changed in this call; only those get their serializer
+        // toggled. Each entry stores the agent id together with its new effective state so
+        // that the serializer action is derived from the post-update refcount rather than
+        // from the caller's `enable` flag (which could be stale if another thread races
+        // between the refcount unlock and the serializer lock).
+        auto transitioned = std::vector<std::pair<rocprofiler_agent_id_t, bool>>{};
         bool any_enabled  = false;
 
         _serialization_refcount.wlock([&](auto& state) {
@@ -483,7 +485,9 @@ QueueController::update_serialization(const agent_handle_set_t& agents, bool ena
                 {
                     auto itr = was_enabled.find(agent_id);
                     if(itr == was_enabled.end()) continue;
-                    if(itr->second != state.enabled(agent_id)) transitioned.emplace_back(agent_id);
+                    bool now_enabled = state.enabled(agent_id);
+                    if(itr->second != now_enabled)
+                        transitioned.emplace_back(agent_id, now_enabled);
                 }
             });
 
@@ -495,7 +499,7 @@ QueueController::update_serialization(const agent_handle_set_t& agents, bool ena
         if(transitioned.empty()) return;
 
         _profiler_serializer.wlock([&](auto& m) {
-            for(const auto& agent_id : transitioned)
+            for(const auto& [agent_id, now_enabled] : transitioned)
             {
                 auto itr = m.find(agent_id);
                 if(itr == m.end() || !itr->second) continue;
@@ -504,7 +508,7 @@ QueueController::update_serialization(const agent_handle_set_t& agents, bool ena
                 if(auto it = pd_map.find(agent_id); it != pd_map.end()) queues = it->second;
 
                 itr->second->wlock([&](auto& serializer) {
-                    if(enable)
+                    if(now_enabled)
                         serializer.enable(queues);
                     else
                         serializer.disable(queues);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
@@ -29,11 +29,13 @@
 
 #include <rocprofiler-sdk/fwd.h>
 #include <rocprofiler-sdk/cxx/hash.hpp>
+#include <rocprofiler-sdk/cxx/operators.hpp>
 
 #include <cstdint>
 #include <functional>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace rocprofiler
@@ -89,13 +91,27 @@ public:
 
     common::Synchronized<hsa::profiler_serializer>& serializer(const Queue*);
 
+    // An empty set means every GPU agent.
+    using agent_handle_set_t = std::unordered_set<rocprofiler_agent_id_t>;
+
     /**
-     * Disable serialization for QueueController, has no effect if counter collection
-     * is not in use (which defaults to no serialization mechanism). Should only be used for
-     * testing.
+     * Enable/disable serialization for QueueController, has no effect if counter collection
+     * is not in use (which defaults to no serialization mechanism).
+     *
+     * Serialization is reference counted per agent. Counter collection, thread trace and SPM
+     * each enable it independently, so an agent stays serialized until every subsystem that
+     * asked for it has released it -- otherwise whichever service stops first would silently
+     * unserialize the ones still running. The no-argument overloads apply to every GPU agent,
+     * which is the behavior every caller had before agents could be scoped.
      */
     void enable_serialization();
     void disable_serialization();
+    void enable_serialization(const agent_handle_set_t& agents);
+    void disable_serialization(const agent_handle_set_t& agents);
+
+    // Whether the given agent currently has serialization enabled. Exposed for tests and for
+    // callers that need to reason about scope rather than trigger a transition.
+    bool is_serialization_enabled(rocprofiler_agent_id_t agent_id) const;
 
     // Prints current state of signals for queues, used for debugging. Only prints
     // serialization related signals if not compiled in debug mode.
@@ -121,6 +137,39 @@ private:
         std::unordered_map<rocprofiler_agent_id_t,
                            std::shared_ptr<common::Synchronized<hsa::profiler_serializer>>>>
         _profiler_serializer;
+    // How many subsystems currently want serialization, per agent. `all` counts the callers
+    // that asked for every agent; it is kept separate from `per_agent` because an agent's
+    // serializer is created lazily on first use and an unscoped request has to cover agents
+    // that do not exist yet.
+    struct serialization_refcount
+    {
+        int64_t all = 0;
+        std::unordered_map<rocprofiler_agent_id_t, int64_t> per_agent = {};
+
+        int64_t count(rocprofiler_agent_id_t agent_id) const
+        {
+            auto itr = per_agent.find(agent_id);
+            return all + ((itr == per_agent.end()) ? 0 : itr->second);
+        }
+
+        bool enabled(rocprofiler_agent_id_t agent_id) const { return count(agent_id) > 0; }
+
+        bool any() const
+        {
+            if(all > 0) return true;
+            for(const auto& [agent_id, count] : per_agent)
+            {
+                if(count > 0) return true;
+            }
+            return false;
+        }
+    };
+
+    common::Synchronized<serialization_refcount> _serialization_refcount;
+
+    // Applies a +1/-1 to the refcount of each agent in `agents` (empty == all GPU agents) and
+    // toggles only the serializers whose effective count crossed zero.
+    void update_serialization(const agent_handle_set_t& agents, bool enable);
 };
 
 QueueController*

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
@@ -143,7 +143,7 @@ private:
     // that do not exist yet.
     struct serialization_refcount
     {
-        int64_t all = 0;
+        int64_t                                             all       = 0;
         std::unordered_map<rocprofiler_agent_id_t, int64_t> per_agent = {};
 
         int64_t count(rocprofiler_agent_id_t agent_id) const

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_hooks/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_hooks/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Shared, header-only client-id tags used by the per-service queue hooks.
+#
+set(ROCPROFILER_LIB_HSA_QUEUE_HOOKS_SOURCES)
+set(ROCPROFILER_LIB_HSA_QUEUE_HOOKS_HEADERS client_ids.hpp)
+
+target_sources(
+    rocprofiler-sdk-object-library PRIVATE ${ROCPROFILER_LIB_HSA_QUEUE_HOOKS_SOURCES}
+                                           ${ROCPROFILER_LIB_HSA_QUEUE_HOOKS_HEADERS})

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp
@@ -1,0 +1,43 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include <cstdint>
+
+namespace rocprofiler
+{
+namespace hsa
+{
+namespace queue_hooks
+{
+// Tags identifying the producer subsystem of each inst_pkt_t entry.
+// Only distinctness matters; values are fixed for test-order stability.
+// Services are migrated off the per-queue callback registry one at a time; the
+// unused ids are reserved so the tag values stay stable across those PRs.
+constexpr int64_t COUNTERS_CLIENT_ID     = 1;
+constexpr int64_t THREAD_TRACE_CLIENT_ID = 2;
+constexpr int64_t PC_SAMPLING_CLIENT_ID  = 3;
+constexpr int64_t SPM_CLIENT_ID          = 4;
+}  // namespace queue_hooks
+}  // namespace hsa
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(ROCPROFILER_LIB_SPM_SOURCES core.cpp service.cpp decode.cpp interface.cpp
-                                dispatch_handlers.cpp)
-set(ROCPROFILER_LIB_SPM_HEADERS core.hpp interface.hpp decode.hpp dispatch_handlers.hpp)
+                                dispatch_handlers.cpp queue_hooks.cpp)
+set(ROCPROFILER_LIB_SPM_HEADERS core.hpp interface.hpp decode.hpp dispatch_handlers.hpp
+                                queue_hooks.hpp)
 target_sources(rocprofiler-sdk-object-library PRIVATE ${ROCPROFILER_LIB_SPM_SOURCES}
                                                       ${ROCPROFILER_LIB_SPM_HEADERS})
 if(ROCPROFILER_BUILD_TESTS)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
@@ -290,23 +290,28 @@ stop_context(const context::context* ctx)
 
     if(controller)
     {
-        // No GPU drain here. The sync this replaced existed to (a) avoid dangling callback
-        // pointers once the per-queue callbacks were unregistered and (b) let in-flight
-        // dispatches complete. (a) no longer applies -- nothing is registered, and
-        // signal_completion_hook resolves contexts at completion time. (b) is handled by that
-        // hook routing over registered rather than active contexts. Neither the serializer
-        // transition nor anything else in this function requires an idle GPU:
-        // profiler_serializer::disable() pushes an hsa_barrier carrying the previous state, so
-        // in-flight serialized dispatches are reconciled GPU-side.
+        // Drain in-flight dispatches, then disable serialization. The review of #8887 asked for
+        // this sync to be kept and for SPM to stay visible to the enter hook and to serialization
+        // through a "draining" window until both this and disable_serialization() complete.
         //
-        // This is a deliberate divergence from one review of #8887, which asked instead for the
-        // sync to be kept and the service held visible to the enter hook through an explicit
-        // "draining" state until sync and disable_serialization complete. The serialization window
-        // that state would protect is closed differently here: context::stop_context now runs this
-        // function before clearing the active slot, so disable_serialization happens while the
-        // enter hook can still see the context, and no dispatch is submitted unserialized while the
-        // serializer is enabled. Recorded here because the two approaches are not obviously
-        // equivalent and the choice should be revisited if that ordering changes.
+        // The visibility half comes from ordering rather than a separate flag:
+        // context::stop_context calls this function while the context is still in the active list,
+        // so for the duration of the drain the enter hook still reaches pre_kernel_call, whose
+        // disabled path deliberately returns serialize=true to coordinate the
+        // serialized->unserialized transition. Only once this function returns does the active slot
+        // get cleared. Introducing a draining flag as well would duplicate that guarantee, but the
+        // ordering is load-bearing: if the slot were cleared first, the enter hook would go blind
+        // before disable_serialization() ran and a dispatch could be submitted unserialized while
+        // the serializer was still enabled.
+        //
+        // A removal of this sync was considered on the grounds that its two original purposes --
+        // avoiding dangling callback pointers once the per-queue callbacks were unregistered, and
+        // letting in-flight dispatches complete -- are both addressed by the migration and by
+        // routing completions over registered contexts. The first is genuinely gone. The second is
+        // weaker than it looks: provenance routing ensures a completion that arrives is delivered,
+        // whereas the drain bounds when completions arrive at all, which is what the rest of the
+        // teardown depends on. Keeping it.
+        hsa::queue_controller_sync();
         controller->disable_serialization();
         // No per-queue callback to remove; spm::write_hook no-ops once dispatch_spm is
         // disabled above.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
@@ -298,6 +298,15 @@ stop_context(const context::context* ctx)
         // transition nor anything else in this function requires an idle GPU:
         // profiler_serializer::disable() pushes an hsa_barrier carrying the previous state, so
         // in-flight serialized dispatches are reconciled GPU-side.
+        //
+        // This is a deliberate divergence from one review of #8887, which asked instead for the
+        // sync to be kept and the service held visible to the enter hook through an explicit
+        // "draining" state until sync and disable_serialization complete. The serialization window
+        // that state would protect is closed differently here: context::stop_context now runs this
+        // function before clearing the active slot, so disable_serialization happens while the
+        // enter hook can still see the context, and no dispatch is submitted unserialized while the
+        // serializer is enabled. Recorded here because the two approaches are not obviously
+        // equivalent and the choice should be revisited if that ordering changes.
         controller->disable_serialization();
         // No per-queue callback to remove; spm::write_hook no-ops once dispatch_spm is
         // disabled above.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
@@ -290,7 +290,14 @@ stop_context(const context::context* ctx)
 
     if(controller)
     {
-        hsa::queue_controller_sync();
+        // No GPU drain here. The sync this replaced existed to (a) avoid dangling callback
+        // pointers once the per-queue callbacks were unregistered and (b) let in-flight
+        // dispatches complete. (a) no longer applies -- nothing is registered, and
+        // signal_completion_hook resolves contexts at completion time. (b) is handled by that
+        // hook routing over registered rather than active contexts. Neither the serializer
+        // transition nor anything else in this function requires an idle GPU:
+        // profiler_serializer::disable() pushes an hsa_barrier carrying the previous state, so
+        // in-flight serialized dispatches are reconciled GPU-side.
         controller->disable_serialization();
         // No per-queue callback to remove; spm::write_hook no-ops once dispatch_spm is
         // disabled above.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
@@ -260,56 +260,14 @@ start_context(const context::context* ctx)
 
     auto* controller = hsa::get_queue_controller();
 
-    bool already_enabled = true;
     CHECK_NOTNULL(controller)->enable_serialization();
     ctx->dispatch_spm->enabled.wlock([&](auto& enabled) {
         if(enabled) return;
-        already_enabled = false;
-        enabled         = true;
+        enabled = true;
     });
 
-    if(!already_enabled)
-    {
-        // Insert our callbacks into HSA Interceptor. This
-        // turns on counter instrumentation.
-        for(auto& cb : ctx->dispatch_spm->callbacks)
-        {
-            if(cb->queue_id != rocprofiler::hsa::ClientID{-1}) continue;
-            cb->queue_id = controller->add_callback(
-                std::nullopt,
-                hsa::queue_callbacks_t{
-                    .batch_packets = []() { return false; },
-                    .write_interceptor =
-                        [=](const hsa::Queue&              q,
-                            const hsa::rocprofiler_packet& kern_pkt,
-                            rocprofiler_kernel_id_t        kernel_id,
-                            rocprofiler_dispatch_id_t      dispatch_id,
-                            rocprofiler_user_data_t*       user_data,
-                            const hsa::queue_info_session_t::external_corr_id_map_t&
-                                                           extern_corr_ids,
-                            const context::correlation_id* correlation_id) {
-                            return pre_kernel_call(ctx,
-                                                   cb,
-                                                   q,
-                                                   kern_pkt,
-                                                   kernel_id,
-                                                   dispatch_id,
-                                                   user_data,
-                                                   extern_corr_ids,
-                                                   correlation_id);
-                        },
-                    .signal_completion =
-                        [=](const hsa::Queue& /* q */,
-                            const hsa::rocprofiler_packet& /* kern_pkt */,
-                            std::shared_ptr<hsa::queue_info_session_t>& session,
-                            hsa::packet_data_t& /* pkt_data */,
-                            inst_pkt_t&                     aql,
-                            kernel_dispatch::profiling_time dispatch_time) {
-                            post_kernel_call(ctx, cb, session, aql, dispatch_time);
-                        }});
-        }
-    }
-
+    // SPM no longer registers a per-queue callback with the queue controller; the HSA write
+    // interceptor calls spm::write_hook / signal_completion_hook directly (see hsa/queue.cpp).
     return ROCPROFILER_STATUS_SUCCESS;
 }
 
@@ -334,14 +292,8 @@ stop_context(const context::context* ctx)
     {
         hsa::queue_controller_sync();
         controller->disable_serialization();
-        for(auto& cb : ctx->dispatch_spm->callbacks)
-        {
-            if(cb->queue_id != rocprofiler::hsa::ClientID{-1})
-            {
-                controller->remove_callback(cb->queue_id);
-                cb->queue_id = rocprofiler::hsa::ClientID{-1};
-            }
-        }
+        // No per-queue callback to remove; spm::write_hook no-ops once dispatch_spm is
+        // disabled above.
     }
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
@@ -22,6 +22,7 @@
 
 #include "lib/rocprofiler-sdk/spm/core.hpp"
 #include "lib/common/utility.hpp"
+#include "lib/rocprofiler-sdk/agent.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
 #include "lib/rocprofiler-sdk/counters/metrics.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
@@ -32,6 +33,7 @@
 #include <atomic>
 #include <cstdint>
 #include <stdexcept>
+#include <unordered_set>
 #include <vector>
 
 namespace rocprofiler
@@ -260,7 +262,9 @@ start_context(const context::context* ctx)
 
     auto* controller = hsa::get_queue_controller();
 
-    CHECK_NOTNULL(controller)->enable_serialization();
+    // Scope serialization to the agents this context collects on. An empty set still means
+    // every agent, so an unrestricted context serializes the whole machine as before.
+    CHECK_NOTNULL(controller)->enable_serialization(ctx->dispatch_spm->agents);
     ctx->dispatch_spm->enabled.wlock([&](auto& enabled) {
         if(enabled) return;
         enabled = true;
@@ -312,10 +316,42 @@ stop_context(const context::context* ctx)
         // whereas the drain bounds when completions arrive at all, which is what the rest of the
         // teardown depends on. Keeping it.
         hsa::queue_controller_sync();
-        controller->disable_serialization();
+        controller->disable_serialization(ctx->dispatch_spm->agents);
         // No per-queue callback to remove; spm::write_hook no-ops once dispatch_spm is
         // disabled above.
     }
+}
+
+rocprofiler_status_t
+set_dispatch_agents(rocprofiler_context_id_t      context_id,
+                    const rocprofiler_agent_id_t* agents,
+                    size_t                        num_agents)
+{
+    if(num_agents > 0 && agents == nullptr) return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
+
+    auto* ctx_p = context::get_mutable_registered_context(context_id);
+    if(!ctx_p) return ROCPROFILER_STATUS_ERROR_CONTEXT_INVALID;
+    if(!ctx_p->dispatch_spm) return ROCPROFILER_STATUS_ERROR_CONTEXT_NOT_FOUND;
+
+    for(const auto* itr : context::get_active_contexts())
+    {
+        if(itr && itr->context_idx == ctx_p->context_idx)
+            return ROCPROFILER_STATUS_ERROR_CONFIGURATION_LOCKED;
+    }
+
+    auto selected = std::unordered_set<rocprofiler_agent_id_t>{};
+    selected.reserve(num_agents);
+    for(size_t i = 0; i < num_agents; ++i)
+    {
+        const auto* agent = rocprofiler::agent::get_agent(agents[i]);
+        if(!agent || agent->type != ROCPROFILER_AGENT_TYPE_GPU)
+            return ROCPROFILER_STATUS_ERROR_AGENT_NOT_FOUND;
+        selected.emplace(agents[i]);
+    }
+
+    ctx_p->dispatch_spm->agents = std::move(selected);
+
+    return ROCPROFILER_STATUS_SUCCESS;
 }
 
 }  // namespace spm

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.hpp
@@ -75,9 +75,6 @@ struct spm_counter_callback_info
     void*                                          callback_args{nullptr};
     // Link to the context this is associated with
     rocprofiler_context_id_t context{.handle = 0};
-    // HSA Queue ClientID. This is an ID we get when we insert a callback into the
-    // HSA queue interceptor. This ID can be used to disable the callback.
-    rocprofiler::hsa::ClientID queue_id{-1};
     // Buffer to use for storing counter data. Used if callback is not set.
     std::optional<rocprofiler_buffer_id_t> buffer;
     // Link to the internal context this is associated with

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.hpp
@@ -121,5 +121,10 @@ start_context(const context::context*);
 void
 stop_context(const context::context*);
 
+rocprofiler_status_t
+set_dispatch_agents(rocprofiler_context_id_t      context_id,
+                    const rocprofiler_agent_id_t* agents,
+                    size_t                        num_agents);
+
 }  // namespace spm
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.cpp
@@ -31,7 +31,7 @@ namespace spm
 namespace
 {
 auto
-active_spm_contexts_filter()
+spm_contexts_filter()
 {
     return [](const context::context* ctx) -> bool { return ctx && ctx->dispatch_spm != nullptr; };
 }
@@ -48,7 +48,7 @@ write_hook(const hsa::Queue&                                        queue,
            hsa::inst_pkt_t&                                         inst_pkt,
            bool&                                                    is_serialized)
 {
-    auto active = context::get_active_contexts(active_spm_contexts_filter());
+    auto active = context::get_active_contexts(spm_contexts_filter());
     for(const auto* ctx : active)
     {
         for(auto& cb : ctx->dispatch_spm->callbacks)
@@ -76,8 +76,11 @@ signal_completion_hook(const hsa::Queue& /*queue*/,
                        hsa::inst_pkt_t&                inst_pkt,
                        kernel_dispatch::profiling_time dispatch_time)
 {
-    auto active = context::get_active_contexts(active_spm_contexts_filter());
-    for(const auto* ctx : active)
+    // Route by packet provenance, not current activeness: post_kernel_call self-filters via
+    // packet_return_map, so in-flight dispatches still complete after stop_context removes the
+    // context from the active list.
+    auto contexts = context::get_registered_contexts(spm_contexts_filter());
+    for(const auto* ctx : contexts)
     {
         for(auto& cb : ctx->dispatch_spm->callbacks)
         {
@@ -89,7 +92,7 @@ signal_completion_hook(const hsa::Queue& /*queue*/,
 bool
 is_any_active()
 {
-    return !context::get_active_contexts(active_spm_contexts_filter()).empty();
+    return !context::get_active_contexts(spm_contexts_filter()).empty();
 }
 }  // namespace spm
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.cpp
@@ -78,7 +78,14 @@ signal_completion_hook(const hsa::Queue& /*queue*/,
 {
     // Route by packet provenance, not current activeness: post_kernel_call self-filters via
     // packet_return_map, so in-flight dispatches still complete after stop_context removes the
-    // context from the active list.
+    // context from the active list. Without this, a dispatch in flight at stop skips the
+    // DISPATCH_END record, kfd_stop() and the barrier-signal cleanup, and leaks its map entry.
+    //
+    // Iterating registered contexts widens the candidate set, but routing stays per-origin because
+    // each context's post_kernel_call only claims packets present in its own packet_return_map.
+    // That matters because there is no conflict guard rejecting a second concurrent dispatch_spm
+    // context, unlike dispatch_counter_collection, so more than one SPM context can be registered
+    // at once.
     auto contexts = context::get_registered_contexts(spm_contexts_filter());
     for(const auto* ctx : contexts)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.cpp
@@ -1,0 +1,95 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "lib/rocprofiler-sdk/spm/queue_hooks.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp"
+#include "lib/rocprofiler-sdk/spm/dispatch_handlers.hpp"
+
+namespace rocprofiler
+{
+namespace spm
+{
+namespace
+{
+auto
+active_spm_contexts_filter()
+{
+    return [](const context::context* ctx) -> bool { return ctx && ctx->dispatch_spm != nullptr; };
+}
+}  // namespace
+
+void
+write_hook(const hsa::Queue&                                        queue,
+           const hsa::rocprofiler_packet&                           kernel_packet,
+           rocprofiler_kernel_id_t                                  kernel_id,
+           rocprofiler_dispatch_id_t                                dispatch_id,
+           rocprofiler_user_data_t*                                 user_data,
+           const hsa::queue_info_session_t::external_corr_id_map_t& ext_corr_ids,
+           const context::correlation_id*                           correlation_id,
+           hsa::inst_pkt_t&                                         inst_pkt,
+           bool&                                                    is_serialized)
+{
+    auto active = context::get_active_contexts(active_spm_contexts_filter());
+    for(const auto* ctx : active)
+    {
+        for(auto& cb : ctx->dispatch_spm->callbacks)
+        {
+            auto [packet, bSerial] = pre_kernel_call(ctx,
+                                                     cb,
+                                                     queue,
+                                                     kernel_packet,
+                                                     kernel_id,
+                                                     dispatch_id,
+                                                     user_data,
+                                                     ext_corr_ids,
+                                                     correlation_id);
+            if(packet) inst_pkt.emplace_back(std::move(packet), hsa::queue_hooks::SPM_CLIENT_ID);
+            is_serialized |= bSerial;
+        }
+    }
+}
+
+void
+signal_completion_hook(const hsa::Queue& /*queue*/,
+                       const hsa::rocprofiler_packet& /*kernel_packet*/,
+                       std::shared_ptr<hsa::queue_info_session_t>& session,
+                       hsa::packet_data_t& /*packet*/,
+                       hsa::inst_pkt_t&                inst_pkt,
+                       kernel_dispatch::profiling_time dispatch_time)
+{
+    auto active = context::get_active_contexts(active_spm_contexts_filter());
+    for(const auto* ctx : active)
+    {
+        for(auto& cb : ctx->dispatch_spm->callbacks)
+        {
+            post_kernel_call(ctx, cb, session, inst_pkt, dispatch_time);
+        }
+    }
+}
+
+bool
+is_any_active()
+{
+    return !context::get_active_contexts(active_spm_contexts_filter()).empty();
+}
+}  // namespace spm
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.cpp
@@ -21,6 +21,8 @@
 // THE SOFTWARE.
 
 #include "lib/rocprofiler-sdk/spm/queue_hooks.hpp"
+#include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp"
 #include "lib/rocprofiler-sdk/spm/dispatch_handlers.hpp"
 
@@ -48,9 +50,13 @@ write_hook(const hsa::Queue&                                        queue,
            hsa::inst_pkt_t&                                         inst_pkt,
            bool&                                                    is_serialized)
 {
+    const auto agent_id = CHECK_NOTNULL(queue.get_agent().get_rocp_agent())->id;
+
     auto active = context::get_active_contexts(spm_contexts_filter());
     for(const auto* ctx : active)
     {
+        if(!ctx->dispatch_spm->collects_on(agent_id)) continue;
+
         for(auto& cb : ctx->dispatch_spm->callbacks)
         {
             auto [packet, bSerial] = pre_kernel_call(ctx,
@@ -83,9 +89,7 @@ signal_completion_hook(const hsa::Queue& /*queue*/,
     //
     // Iterating registered contexts widens the candidate set, but routing stays per-origin because
     // each context's post_kernel_call only claims packets present in its own packet_return_map.
-    // That matters because there is no conflict guard rejecting a second concurrent dispatch_spm
-    // context, unlike dispatch_counter_collection, so more than one SPM context can be registered
-    // at once.
+    // Disjoint agent sets allow multiple concurrent SPM contexts when scoped via set_agents().
     auto contexts = context::get_registered_contexts(spm_contexts_filter());
     for(const auto* ctx : contexts)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.hpp
@@ -49,8 +49,10 @@ write_hook(const hsa::Queue&                                        queue,
            hsa::inst_pkt_t&                                         inst_pkt,
            bool&                                                    is_serialized);
 
-// Explicit replacement for the SPM completion callback. Iterates active
-// dispatch_spm contexts and calls each callback's post_kernel_call.
+// Explicit replacement for the SPM completion callback. Iterates registered
+// dispatch_spm contexts (not only active ones) and calls each callback's
+// post_kernel_call; post_kernel_call self-filters via packet_return_map so
+// in-flight dispatches still complete after stop_context.
 void
 signal_completion_hook(const hsa::Queue&                           queue,
                        const hsa::rocprofiler_packet&              kernel_packet,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.hpp
@@ -1,0 +1,66 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_info_session.hpp"
+#include "lib/rocprofiler-sdk/hsa/rocprofiler_packet.hpp"
+#include "lib/rocprofiler-sdk/kernel_dispatch/profiling_time.hpp"
+
+#include <memory>
+
+namespace rocprofiler
+{
+namespace spm
+{
+// Explicit replacement for the SPM per-queue callback that used to be registered
+// with the HSA queue controller. Iterates active dispatch_spm contexts and calls
+// each callback's pre_kernel_call; appends produced packets to inst_pkt,
+// OR-folding each callback's serialize flag into is_serialized.
+void
+write_hook(const hsa::Queue&                                        queue,
+           const hsa::rocprofiler_packet&                           kernel_packet,
+           rocprofiler_kernel_id_t                                  kernel_id,
+           rocprofiler_dispatch_id_t                                dispatch_id,
+           rocprofiler_user_data_t*                                 user_data,
+           const hsa::queue_info_session_t::external_corr_id_map_t& ext_corr_ids,
+           const context::correlation_id*                           correlation_id,
+           hsa::inst_pkt_t&                                         inst_pkt,
+           bool&                                                    is_serialized);
+
+// Explicit replacement for the SPM completion callback. Iterates active
+// dispatch_spm contexts and calls each callback's post_kernel_call.
+void
+signal_completion_hook(const hsa::Queue&                           queue,
+                       const hsa::rocprofiler_packet&              kernel_packet,
+                       std::shared_ptr<hsa::queue_info_session_t>& session,
+                       hsa::packet_data_t&                         packet,
+                       hsa::inst_pkt_t&                            inst_pkt,
+                       kernel_dispatch::profiling_time             dispatch_time);
+
+// True if any context currently has dispatch SPM active.
+bool
+is_any_active();
+}  // namespace spm
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/service.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/service.cpp
@@ -148,6 +148,17 @@ rocprofiler_spm_configure_callback_dispatch_service(
                                                              record_callback_args);
 }
 
+rocprofiler_status_t
+rocprofiler_spm_dispatch_counting_service_set_agents(rocprofiler_context_id_t      context_id,
+                                                     const rocprofiler_agent_id_t* agents,
+                                                     size_t                        num_agents)
+{
+    if(!rocprofiler::spm::is_spm_explicitly_enabled())
+        return ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED;
+
+    return rocprofiler::spm::set_dispatch_agents(context_id, agents, num_agents);
+}
+
 /**
  * @brief Query Agent Counters Availability.
  *

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/CMakeLists.txt
@@ -14,7 +14,8 @@ find_program(
 set(_ROCPROFILER_SHARE_DIR
     "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME}")
 
-set(ROCPROFILER_LIB_SPM_COUNTER_TEST_SOURCES core.cpp spm_memory_pool_test.cpp)
+set(ROCPROFILER_LIB_SPM_COUNTER_TEST_SOURCES core.cpp spm_memory_pool_test.cpp
+                                             queue_hooks_test.cpp)
 
 add_executable(spm-counter-test)
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
@@ -29,12 +29,12 @@
 #include "lib/rocprofiler-sdk/hsa/hsa.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp"
 #include "lib/rocprofiler-sdk/kernel_dispatch/profiling_time.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
 #include "lib/rocprofiler-sdk/spm/decode.hpp"
 #include "lib/rocprofiler-sdk/spm/dispatch_handlers.hpp"
 #include "lib/rocprofiler-sdk/spm/queue_hooks.hpp"
-#include "lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp"
 
 #include <rocprofiler-sdk/dispatch_counting_service.h>
 #include <rocprofiler-sdk/experimental/spm.h>
@@ -930,7 +930,7 @@ TEST(spm_core, stop_context_removes_callbacks)
     ASSERT_TRUE(ctx.dispatch_spm);
     ASSERT_EQ(ctx.dispatch_spm->callbacks.size(), 1);
 
-    // Stop disables collection and tears the context down (no GPU drain; see spm::stop_context).
+    // Stop disables collection, drains in-flight dispatches, then tears the context down.
     ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
 
     bool enabled = true;
@@ -971,7 +971,7 @@ TEST(spm_core, stop_context_sync_and_restart)
 
     ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
 
-    // Restart to verify the queue controller is in a clean state after teardown
+    // Restart to verify the queue controller is in a clean state after drain + teardown
     ROCPROFILER_CALL(rocprofiler_start_context(get_client_ctx()), "restart context");
 
     bool enabled = false;
@@ -988,7 +988,8 @@ TEST(spm_core, stop_context_sync_and_restart)
 
 // Regression for callback-registry removal (#8887): a dispatch enqueued while the SPM context
 // is active must still complete (and drain packet_return_map) when stop_context runs before the
-// GPU completion callback. Exercises the queue_hooks routing layer, not pre/post_kernel_call directly.
+// GPU completion callback. Exercises the queue_hooks routing layer, not pre/post_kernel_call
+// directly.
 TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
 {
     rocprofiler::common::set_env("ROCPROFILER_SPM_BETA_ENABLED", true);
@@ -1000,12 +1001,10 @@ TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
     context::push_client(1);
 
     ROCPROFILER_CALL(rocprofiler_create_context(&get_client_ctx()), "context creation failed");
-    ROCPROFILER_CALL(rocprofiler_spm_configure_callback_dispatch_service(get_client_ctx(),
-                                                                         user_dispatch_cb,
-                                                                         nullptr,
-                                                                         null_record_callback,
-                                                                         nullptr),
-                     "Could not setup SPM service");
+    ROCPROFILER_CALL(
+        rocprofiler_spm_configure_callback_dispatch_service(
+            get_client_ctx(), user_dispatch_cb, nullptr, null_record_callback, nullptr),
+        "Could not setup SPM service");
     ROCPROFILER_CALL(rocprofiler_start_context(get_client_ctx()), "start context");
 
     auto* ctx_p = context::get_mutable_registered_context(get_client_ctx());
@@ -1025,15 +1024,15 @@ TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
         if(!is_spm_supported_arch(agent)) continue;
 
         found_spm_agent = true;
-        auto metrics = getSPMMetrics(agent);
+        auto metrics    = getSPMMetrics(agent);
         for(auto& metric : metrics)
         {
             if(!metric.expression().empty()) continue;
 
-            expected_dispatch expected = {};
-            rocprofiler_counter_id_t id = {.handle = metric.id()};
+            expected_dispatch                          expected = {};
+            rocprofiler_counter_id_t                   id       = {.handle = metric.id()};
             std::vector<rocprofiler_spm_parameters_t*> input_params{};
-            rocprofiler_spm_parameters_t param{
+            rocprofiler_spm_parameters_t               param{
                 .size  = sizeof(rocprofiler_spm_parameters_t),
                 .type  = ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES,
                 .value = 1200};
@@ -1048,10 +1047,10 @@ TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
                              "Unable to create profile");
             cb_info->callback_args = &expected;
 
-            rocprofiler_queue_id_t qid = {.handle = 1};
-            hsa::FakeQueue         fq(agent, qid);
-            hsa::rocprofiler_packet  pkt{};
-            context::correlation_id  corr_id{.internal = 99};
+            rocprofiler_queue_id_t  qid = {.handle = 1};
+            hsa::FakeQueue          fq(agent, qid);
+            hsa::rocprofiler_packet pkt{};
+            context::correlation_id corr_id{.internal = 99};
 
             expected.queue_id    = qid;
             expected.agent_id    = agent.get_rocp_agent()->id;
@@ -1078,7 +1077,8 @@ TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
             ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
             EXPECT_FALSE(rocprofiler::spm::is_any_active());
 
-            auto sess = std::make_shared<hsa::queue_info_session_t>(hsa::queue_info_session_t{.queue = fq});
+            auto sess =
+                std::make_shared<hsa::queue_info_session_t>(hsa::queue_info_session_t{.queue = fq});
             sess->correlation_id = &corr_id;
 
             spm::inst_pkt_t inst_pkt;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
@@ -33,6 +33,8 @@
 #include "lib/rocprofiler-sdk/registration.hpp"
 #include "lib/rocprofiler-sdk/spm/decode.hpp"
 #include "lib/rocprofiler-sdk/spm/dispatch_handlers.hpp"
+#include "lib/rocprofiler-sdk/spm/queue_hooks.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp"
 
 #include <rocprofiler-sdk/dispatch_counting_service.h>
 #include <rocprofiler-sdk/experimental/spm.h>
@@ -982,4 +984,130 @@ TEST(spm_core, stop_context_sync_and_restart)
     registration::finalize();
     context::pop_client(1);
     set_client_ctx(get_client_ctx());
+}
+
+// Regression for callback-registry removal (#8887): a dispatch enqueued while the SPM context
+// is active must still complete (and drain packet_return_map) when stop_context runs before the
+// GPU completion callback. Exercises the queue_hooks routing layer, not pre/post_kernel_call directly.
+TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
+{
+    rocprofiler::common::set_env("ROCPROFILER_SPM_BETA_ENABLED", true);
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    registration::init_logging();
+    registration::set_init_status(-1);
+    context::push_client(1);
+
+    ROCPROFILER_CALL(rocprofiler_create_context(&get_client_ctx()), "context creation failed");
+    ROCPROFILER_CALL(rocprofiler_spm_configure_callback_dispatch_service(get_client_ctx(),
+                                                                         user_dispatch_cb,
+                                                                         nullptr,
+                                                                         null_record_callback,
+                                                                         nullptr),
+                     "Could not setup SPM service");
+    ROCPROFILER_CALL(rocprofiler_start_context(get_client_ctx()), "start context");
+
+    auto* ctx_p = context::get_mutable_registered_context(get_client_ctx());
+    ASSERT_TRUE(ctx_p);
+    ASSERT_TRUE(ctx_p->dispatch_spm);
+    auto cb_info = ctx_p->dispatch_spm->callbacks.front();
+
+    ASSERT_TRUE(hsa::get_queue_controller() != nullptr);
+    auto agents = hsa::get_queue_controller()->get_supported_agents();
+    ASSERT_GT(agents.size(), 0);
+
+    bool found_spm_agent = false;
+    for(const auto& [_, agent] : agents)
+    {
+        auto rocp_agent = CHECK_NOTNULL(agent.get_rocp_agent());
+        if(!rocp_agent->runtime_visibility.hsa || !rocp_agent->runtime_visibility.hip) continue;
+        if(!is_spm_supported_arch(agent)) continue;
+
+        found_spm_agent = true;
+        auto metrics = getSPMMetrics(agent);
+        for(auto& metric : metrics)
+        {
+            if(!metric.expression().empty()) continue;
+
+            expected_dispatch expected = {};
+            rocprofiler_counter_id_t id = {.handle = metric.id()};
+            std::vector<rocprofiler_spm_parameters_t*> input_params{};
+            rocprofiler_spm_parameters_t param{
+                .size  = sizeof(rocprofiler_spm_parameters_t),
+                .type  = ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES,
+                .value = 1200};
+            input_params.push_back(&param);
+
+            ROCPROFILER_CALL(rocprofiler_spm_create_counter_config(agent.get_rocp_agent()->id,
+                                                                   &id,
+                                                                   1,
+                                                                   input_params.data(),
+                                                                   input_params.size(),
+                                                                   &expected.id),
+                             "Unable to create profile");
+            cb_info->callback_args = &expected;
+
+            rocprofiler_queue_id_t qid = {.handle = 1};
+            hsa::FakeQueue         fq(agent, qid);
+            hsa::rocprofiler_packet  pkt{};
+            context::correlation_id  corr_id{.internal = 99};
+
+            expected.queue_id    = qid;
+            expected.agent_id    = agent.get_rocp_agent()->id;
+            expected.kernel_id   = 42;
+            expected.dispatch_id = 7;
+
+            auto user_data = rocprofiler_user_data_t{.value = corr_id.internal};
+            auto ret_pkt   = spm::pre_kernel_call(ctx_p,
+                                                cb_info,
+                                                fq,
+                                                pkt,
+                                                expected.kernel_id,
+                                                expected.dispatch_id,
+                                                &user_data,
+                                                {},
+                                                &corr_id);
+            if(!ret_pkt.packet) continue;
+
+            size_t map_size_before_stop = 0;
+            cb_info->packet_return_map.rlock(
+                [&](const auto& data) { map_size_before_stop = data.size(); });
+            if(map_size_before_stop == 0) continue;
+
+            ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
+            EXPECT_FALSE(rocprofiler::spm::is_any_active());
+
+            auto sess = std::make_shared<hsa::queue_info_session_t>(hsa::queue_info_session_t{.queue = fq});
+            sess->correlation_id = &corr_id;
+
+            spm::inst_pkt_t inst_pkt;
+            inst_pkt.emplace_back(
+                std::make_pair(std::move(ret_pkt.packet), hsa::queue_hooks::SPM_CLIENT_ID));
+
+            spm::signal_completion_hook(fq,
+                                        pkt,
+                                        sess,
+                                        sess->packet_data.emplace_back(),
+                                        inst_pkt,
+                                        kernel_dispatch::profiling_time{});
+
+            size_t map_size_after_completion = 1;
+            cb_info->packet_return_map.rlock(
+                [&](const auto& data) { map_size_after_completion = data.size(); });
+            EXPECT_EQ(map_size_after_completion, 0U)
+                << "packet_return_map must drain via signal_completion_hook after stop_context";
+
+            ROCPROFILER_CALL(rocprofiler_spm_destroy_counter_config(expected.id),
+                             "Could not delete profile id");
+            registration::set_init_status(1);
+            registration::finalize();
+            context::pop_client(1);
+            set_client_ctx(get_client_ctx());
+            return;
+        }
+    }
+
+    if(!found_spm_agent) GTEST_SKIP() << "SPM unavailable";
+    FAIL() << "Could not exercise SPM in-flight completion hook path";
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
@@ -930,7 +930,7 @@ TEST(spm_core, stop_context_removes_callbacks)
     ASSERT_TRUE(ctx.dispatch_spm);
     ASSERT_EQ(ctx.dispatch_spm->callbacks.size(), 1);
 
-    // Stop exercises queue_controller_sync + context teardown.
+    // Stop disables collection and tears the context down (no GPU drain; see spm::stop_context).
     ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
 
     bool enabled = true;
@@ -971,7 +971,7 @@ TEST(spm_core, stop_context_sync_and_restart)
 
     ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
 
-    // Restart to verify queue controller is in a clean state after sync + teardown
+    // Restart to verify the queue controller is in a clean state after teardown
     ROCPROFILER_CALL(rocprofiler_start_context(get_client_ctx()), "restart context");
 
     bool enabled = false;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
@@ -591,17 +591,10 @@ TEST(spm_core, start_stop_callback_ctx)
     EXPECT_EQ(ctx.dispatch_spm->callbacks.at(0)->record_callback_args, (void*) 0x54321);
     EXPECT_EQ(ctx.dispatch_spm->callbacks.at(0)->context.handle, get_client_ctx().handle);
 
+    // #8730-style: SPM no longer registers a per-queue callback; activeness is observable via
+    // the context enabled flag (and spm::is_any_active()).
     bool found = false;
     ctx.dispatch_spm->enabled.rlock([&](const auto& data) { found = data; });
-    EXPECT_TRUE(found);
-
-    found = false;
-    hsa::get_queue_controller()->iterate_callbacks([&](auto cid, const auto&) {
-        if(cid == ctx.dispatch_spm->callbacks.at(0)->queue_id)
-        {
-            found = true;
-        }
-    });
     EXPECT_TRUE(found);
 
     /**
@@ -659,17 +652,10 @@ TEST(spm_core, start_stop_buffered_ctx)
     ASSERT_TRUE(ctx.dispatch_spm->callbacks.at(0)->buffer);
     EXPECT_EQ(ctx.dispatch_spm->callbacks.at(0)->buffer->handle, opt_buff_id.handle);
 
+    // #8730-style: SPM no longer registers a per-queue callback; activeness is observable via
+    // the context enabled flag (and spm::is_any_active()).
     bool found = false;
     ctx.dispatch_spm->enabled.rlock([&](const auto& data) { found = data; });
-    EXPECT_TRUE(found);
-
-    found = false;
-    hsa::get_queue_controller()->iterate_callbacks([&](auto cid, const auto&) {
-        if(cid == ctx.dispatch_spm->callbacks.at(0)->queue_id)
-        {
-            found = true;
-        }
-    });
     EXPECT_TRUE(found);
 
     /**
@@ -942,28 +928,12 @@ TEST(spm_core, stop_context_removes_callbacks)
     ASSERT_TRUE(ctx.dispatch_spm);
     ASSERT_EQ(ctx.dispatch_spm->callbacks.size(), 1);
 
-    auto pre_stop_queue_id = ctx.dispatch_spm->callbacks.at(0)->queue_id;
-    bool found             = false;
-    hsa::get_queue_controller()->iterate_callbacks([&](auto cid, const auto&) {
-        if(cid == pre_stop_queue_id) found = true;
-    });
-    EXPECT_TRUE(found) << "Callback should be registered after start";
-
-    // Stop exercises queue_controller_sync + remove_callback
+    // Stop exercises queue_controller_sync + context teardown.
     ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
 
     bool enabled = true;
     ctx.dispatch_spm->enabled.rlock([&](const auto& data) { enabled = data; });
     EXPECT_FALSE(enabled);
-
-    EXPECT_EQ(ctx.dispatch_spm->callbacks.at(0)->queue_id, hsa::ClientID{-1})
-        << "queue_id should be reset to -1 after stop";
-
-    found = false;
-    hsa::get_queue_controller()->iterate_callbacks([&](auto cid, const auto&) {
-        if(cid == pre_stop_queue_id) found = true;
-    });
-    EXPECT_FALSE(found) << "Callback should be removed from queue controller after stop";
 
     registration::set_init_status(1);
     registration::finalize();
@@ -997,8 +967,6 @@ TEST(spm_core, stop_context_sync_and_restart)
     auto& ctx = *ctx_p;
     ASSERT_TRUE(ctx.dispatch_spm);
 
-    auto pre_stop_queue_id = ctx.dispatch_spm->callbacks.at(0)->queue_id;
-
     ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
 
     // Restart to verify queue controller is in a clean state after sync + teardown
@@ -1007,18 +975,6 @@ TEST(spm_core, stop_context_sync_and_restart)
     bool enabled = false;
     ctx.dispatch_spm->enabled.rlock([&](const auto& data) { enabled = data; });
     EXPECT_TRUE(enabled) << "Context should be enabled after restart";
-
-    auto post_restart_queue_id = ctx.dispatch_spm->callbacks.at(0)->queue_id;
-    EXPECT_NE(post_restart_queue_id, hsa::ClientID{-1})
-        << "Restarted context should have a valid queue_id";
-    EXPECT_NE(post_restart_queue_id, pre_stop_queue_id)
-        << "Restarted context should get a fresh callback ID";
-
-    bool found = false;
-    hsa::get_queue_controller()->iterate_callbacks([&](auto cid, const auto&) {
-        if(cid == post_restart_queue_id) found = true;
-    });
-    EXPECT_TRUE(found) << "New callback should be registered after restart";
 
     ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context final");
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
@@ -1067,12 +1067,22 @@ TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
                                                 &user_data,
                                                 {},
                                                 &corr_id);
-            if(!ret_pkt.packet) continue;
+            if(!ret_pkt.packet)
+            {
+                ROCPROFILER_CALL(rocprofiler_spm_destroy_counter_config(expected.id),
+                                 "Could not delete profile id");
+                continue;
+            }
 
             size_t map_size_before_stop = 0;
             cb_info->packet_return_map.rlock(
                 [&](const auto& data) { map_size_before_stop = data.size(); });
-            if(map_size_before_stop == 0) continue;
+            if(map_size_before_stop == 0)
+            {
+                ROCPROFILER_CALL(rocprofiler_spm_destroy_counter_config(expected.id),
+                                 "Could not delete profile id");
+                continue;
+            }
 
             ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
             EXPECT_FALSE(rocprofiler::spm::is_any_active());

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
@@ -1050,7 +1050,10 @@ TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
             rocprofiler_queue_id_t  qid = {.handle = 1};
             hsa::FakeQueue          fq(agent, qid);
             hsa::rocprofiler_packet pkt{};
-            context::correlation_id corr_id{.internal = 99};
+            // correlation_id declares constructors and holds private ref counters, so it is not an
+            // aggregate and cannot take a designated initializer.
+            context::correlation_id corr_id{};
+            corr_id.internal = 99;
 
             expected.queue_id    = qid;
             expected.agent_id    = agent.get_rocp_agent()->id;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
@@ -1124,3 +1124,182 @@ TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
     if(!found_spm_agent) GTEST_SKIP() << "SPM unavailable";
     FAIL() << "Could not exercise SPM in-flight completion hook path";
 }
+
+// Verify that rocprofiler_spm_dispatch_counting_service_set_agents restricts serialization
+// and write_hook filtering to the configured agents.
+TEST(spm_core, set_agents_restricts_collection)
+{
+    rocprofiler::common::set_env("ROCPROFILER_SPM_BETA_ENABLED", true);
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    registration::init_logging();
+    registration::set_init_status(-1);
+    context::push_client(1);
+    registration::set_fini_status(0);
+
+    auto agents = hsa::get_queue_controller()->get_supported_agents();
+    ASSERT_GT(agents.size(), 0);
+
+    // Pick the first SPM-capable agent to scope the context to.
+    const rocprofiler::hsa::AgentCache* target_agent = nullptr;
+    for(const auto& [_, agent] : agents)
+    {
+        auto rocp_agent = agent.get_rocp_agent();
+        if(!rocp_agent) continue;
+        if(!rocp_agent->runtime_visibility.hsa || !rocp_agent->runtime_visibility.hip) continue;
+        if(!is_spm_supported_arch(agent)) continue;
+        target_agent = &agent;
+        break;
+    }
+
+    if(!target_agent) GTEST_SKIP() << "SPM unavailable";
+
+    rocprofiler_context_id_t ctx_id{};
+    ROCPROFILER_CALL(rocprofiler_create_context(&ctx_id), "context creation failed");
+
+    ROCPROFILER_CALL(rocprofiler_spm_configure_callback_dispatch_service(ctx_id,
+                                                                         null_dispatch_callback,
+                                                                         nullptr,
+                                                                         null_record_callback,
+                                                                         nullptr),
+                     "Could not setup counting service");
+
+    // Scope the context to target_agent only.
+    rocprofiler_agent_id_t target_id = target_agent->get_rocp_agent()->id;
+    ROCPROFILER_CALL(
+        rocprofiler_spm_dispatch_counting_service_set_agents(ctx_id, &target_id, 1),
+        "Could not set agents on SPM context");
+
+    // Verify that the agent set was recorded correctly before starting the context.
+    auto* ctx_p = context::get_mutable_registered_context(ctx_id);
+    ASSERT_TRUE(ctx_p && ctx_p->dispatch_spm);
+
+    EXPECT_TRUE(ctx_p->dispatch_spm->collects_on(target_id))
+        << "Context should collect on the configured agent";
+
+    // For every other GPU agent the context must NOT collect.
+    for(const auto& [_, agent] : agents)
+    {
+        auto rocp_agent = agent.get_rocp_agent();
+        if(!rocp_agent) continue;
+        if(rocp_agent->id.handle == target_id.handle) continue;
+        if(rocp_agent->type != ROCPROFILER_AGENT_TYPE_GPU) continue;
+        EXPECT_FALSE(ctx_p->dispatch_spm->collects_on(rocp_agent->id))
+            << "Context must not collect on an agent that was not configured";
+    }
+
+    ROCPROFILER_CALL(rocprofiler_start_context(ctx_id), "start context");
+
+    bool enabled = false;
+    ctx_p->dispatch_spm->enabled.rlock([&](const auto& data) { enabled = data; });
+    EXPECT_TRUE(enabled);
+
+    ROCPROFILER_CALL(rocprofiler_stop_context(ctx_id), "stop context");
+
+    registration::set_init_status(1);
+    registration::finalize();
+    context::pop_client(1);
+    set_client_ctx(get_client_ctx());
+}
+
+// Verify that two SPM dispatch contexts with disjoint agent sets can start concurrently,
+// while two contexts that share an agent cannot.
+TEST(spm_core, disjoint_contexts_no_conflict)
+{
+    rocprofiler::common::set_env("ROCPROFILER_SPM_BETA_ENABLED", true);
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    registration::init_logging();
+    registration::set_init_status(-1);
+    context::push_client(1);
+    registration::set_fini_status(0);
+
+    auto agents = hsa::get_queue_controller()->get_supported_agents();
+    ASSERT_GT(agents.size(), 0);
+
+    // Collect SPM-capable agents.
+    std::vector<rocprofiler_agent_id_t> spm_agents;
+    for(const auto& [_, agent] : agents)
+    {
+        auto rocp_agent = agent.get_rocp_agent();
+        if(!rocp_agent) continue;
+        if(!rocp_agent->runtime_visibility.hsa || !rocp_agent->runtime_visibility.hip) continue;
+        if(!is_spm_supported_arch(agent)) continue;
+        spm_agents.push_back(rocp_agent->id);
+    }
+
+    if(spm_agents.empty()) GTEST_SKIP() << "SPM unavailable";
+
+    // ---- Single-agent case: two contexts claiming the same agent must conflict ----
+    {
+        rocprofiler_context_id_t ctx_a{};
+        rocprofiler_context_id_t ctx_b{};
+
+        ROCPROFILER_CALL(rocprofiler_create_context(&ctx_a), "create ctx_a");
+        ROCPROFILER_CALL(rocprofiler_create_context(&ctx_b), "create ctx_b");
+
+        ROCPROFILER_CALL(
+            rocprofiler_spm_configure_callback_dispatch_service(
+                ctx_a, null_dispatch_callback, nullptr, null_record_callback, nullptr),
+            "configure ctx_a");
+        ROCPROFILER_CALL(
+            rocprofiler_spm_configure_callback_dispatch_service(
+                ctx_b, null_dispatch_callback, nullptr, null_record_callback, nullptr),
+            "configure ctx_b");
+
+        // Point both contexts at the same (first) agent.
+        ROCPROFILER_CALL(
+            rocprofiler_spm_dispatch_counting_service_set_agents(ctx_a, &spm_agents[0], 1),
+            "set agents ctx_a");
+        ROCPROFILER_CALL(
+            rocprofiler_spm_dispatch_counting_service_set_agents(ctx_b, &spm_agents[0], 1),
+            "set agents ctx_b");
+
+        ROCPROFILER_CALL(rocprofiler_start_context(ctx_a), "start ctx_a");
+        auto status_b = rocprofiler_start_context(ctx_b);
+        EXPECT_EQ(status_b, ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT)
+            << "Two SPM contexts covering the same agent must conflict";
+
+        ROCPROFILER_CALL(rocprofiler_stop_context(ctx_a), "stop ctx_a");
+    }
+
+    // ---- Two-agent case: contexts covering disjoint agents must coexist ----
+    if(spm_agents.size() >= 2)
+    {
+        rocprofiler_context_id_t ctx_a{};
+        rocprofiler_context_id_t ctx_b{};
+
+        ROCPROFILER_CALL(rocprofiler_create_context(&ctx_a), "create ctx_a (disjoint)");
+        ROCPROFILER_CALL(rocprofiler_create_context(&ctx_b), "create ctx_b (disjoint)");
+
+        ROCPROFILER_CALL(
+            rocprofiler_spm_configure_callback_dispatch_service(
+                ctx_a, null_dispatch_callback, nullptr, null_record_callback, nullptr),
+            "configure ctx_a (disjoint)");
+        ROCPROFILER_CALL(
+            rocprofiler_spm_configure_callback_dispatch_service(
+                ctx_b, null_dispatch_callback, nullptr, null_record_callback, nullptr),
+            "configure ctx_b (disjoint)");
+
+        ROCPROFILER_CALL(
+            rocprofiler_spm_dispatch_counting_service_set_agents(ctx_a, &spm_agents[0], 1),
+            "set agents ctx_a (disjoint)");
+        ROCPROFILER_CALL(
+            rocprofiler_spm_dispatch_counting_service_set_agents(ctx_b, &spm_agents[1], 1),
+            "set agents ctx_b (disjoint)");
+
+        ROCPROFILER_CALL(rocprofiler_start_context(ctx_a), "start ctx_a (disjoint)");
+        ROCPROFILER_CALL(rocprofiler_start_context(ctx_b),
+                         "start ctx_b (disjoint) — must not conflict with ctx_a");
+
+        ROCPROFILER_CALL(rocprofiler_stop_context(ctx_a), "stop ctx_a (disjoint)");
+        ROCPROFILER_CALL(rocprofiler_stop_context(ctx_b), "stop ctx_b (disjoint)");
+    }
+
+    registration::set_init_status(1);
+    registration::finalize();
+    context::pop_client(1);
+    set_client_ctx(get_client_ctx());
+}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/queue_hooks_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/queue_hooks_test.cpp
@@ -1,0 +1,37 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "lib/rocprofiler-sdk/spm/queue_hooks.hpp"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+// is_any_active replaces the queue.get_notifiers() signal that the old per-queue
+// callback registration used to provide to the HSA write interceptor gate. With
+// no SPM context active, it must report inactive. This requires no GPU / HSA
+// runtime.
+TEST(spm_queue_hooks, is_any_active_false_when_no_context_active)
+{
+    EXPECT_FALSE(rocprofiler::spm::is_any_active());
+}
+}  // namespace


### PR DESCRIPTION
## Motivation

The purpose of this PR is to isolate the SPM slice of the callback-removal effort (reference PRs #8730 / #8586) into a small, single-service change, per review guidance to land callback removal one service at a time. This is independent of the kernel replay feature in PR #7960 but it aids it.

### Underlying Problem

Dispatch SPM currently registers a `queue_callbacks_t` on every HSA queue. That hides “is this service active?” inside a per-queue map, makes enqueue and completion the same walk, and serializes every GPU while any SPM context is active.

This PR:

1. **Stops registering** SPM with that map. The write interceptor and async signal handler call explicit free functions instead (`spm::write_hook`, `signal_completion_hook`, `is_any_active`).
2. **Routes completions by provenance** — enter iterates active contexts, exit iterates registered contexts so in-flight dispatches still complete after stop.
3. **Scopes SPM to GPU agents** via `rocprofiler_spm_dispatch_counting_service_set_agents`, with GPU drain on stop and per-agent serialization refcounting.

The per-queue callback registry remains for counters, thread trace, and PC sampling until those services land in their own PRs.

### Notes on Bigger Picture

Aids PR #7960 and the kernel replay work tracked under AIPROFSDK-68. This PR also helps other features that require removing the SPM per-queue callback registry, but does not depend on kernel replay landing first.

Sibling migrations: thread trace (#8790), counter collection (#8891), PC sampling (#8895).

## Technical Details

**Enter = active, exit = registered.** Exit self-filters via `packet_return_map` so in-flight dispatches complete after stop.

```mermaid
flowchart LR
  WriteInterceptor --> WriteHook["spm::write_hook: active + collects_on"]
  AsyncSignalHandler --> CompletionHook["signal_completion_hook: registered"]
  ContextStop --> Drain["enabled=false, queue_controller_sync, unserialize, clear slot"]
```

Permalinks pin to `758072b`.

### Hooks and call sites

- Declarations: [queue_hooks.hpp](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.hpp)
- Enter: [queue_hooks.cpp#L42-L75](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.cpp#L42-L75)
- Exit (registered / provenance): [queue_hooks.cpp#L77-L101](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.cpp#L77-L101)
- `is_any_active`: [queue_hooks.cpp#L103-L107](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.cpp#L103-L107)
- `no_real_consumers` gate: [queue.cpp#L318-L322](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp#L318-L322)
- Enter call site: [queue.cpp#L632-L642](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp#L632-L642)
- Exit call site: [queue.cpp#L172-L179](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp#L172-L179)
- Batching disabled while active: [queue.cpp#L778-L779](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp#L778-L779)
- `start_context` (no `add_callback`): [core.cpp#L258-L276](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp#L258-L276)
- Stop (`enabled` → drain → unserialize): [core.cpp#L283-L323](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp#L283-L323)
- Stop services **before** active-slot CAS: [context.cpp#L392-L408](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp#L392-L408)
- Conflict uses `intersects`: [context.cpp#L311-L317](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp#L311-L317)
- `set_agents` API: [spm.h#L318-L338](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h#L318-L338)
- Producer tag: [client_ids.hpp#L37-L40](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp#L37-L40)

### Reviewer Guide

1. Confirm enter = active, exit = registered ([queue_hooks.cpp](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.cpp)).
2. SPM-only runs still enter `WriteInterceptor` ([queue.cpp#L318-L322](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp#L318-L322)).
3. `start_context` does **not** call `add_callback` ([core.cpp#L258-L276](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp#L258-L276)).
4. `context::stop_context` stops SPM **before** the active-slot CAS ([context.cpp#L392-L408](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp#L392-L408)).
5. `spm::stop_context` keeps `queue_controller_sync` ([core.cpp#L283-L323](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp#L283-L323)) — drain bounds when completions arrive; provenance routing bounds delivery.
6. In-flight regression: `spm_core` test `stop_context_in_flight_completion_routes_via_hook_path` ([core.cpp#L990+](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp#L990)) — `packet_return_map` drains via `signal_completion_hook` after stop.
7. Per-agent: `set_agents_restricts_collection`, disjoint SPM contexts ([core.cpp#L1128+](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp#L1128)).
8. Gate-only unit test: [queue_hooks_test.cpp#L33-L36](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/queue_hooks_test.cpp#L33-L36).

**Questions to Answer:** 

- In-flight SPM dispatch still gets `DISPATCH_END` / `kfd_stop` after stop? `packet_return_map` empty? 

- GPU-1-only SPM leave GPU-0 alone?

**Out of scope:** deleting `Queue::_callbacks`; other service migrations.

## Issue Tracking

JIRA ticket: AIPROFSDK-1018

Related JIRA ticket on kernel replay: AIPROFSDK-68. The kernel replay PR is #7960.

## Test Plan

- [is_any_active](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/queue_hooks_test.cpp#L33-L36)
- In-flight + per-agent tests in [spm/tests/core.cpp](https://github.com/ROCm/rocm-systems/blob/758072b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp)
- Existing start/stop / sync / restart tests updated off callback iteration

## Test Result

Intended coverage listed above. Treat the Checks tab as source of truth for CI.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.





