### PR TITLE
[ci] Extend/dedup path filters in therock_configure_ci.py

### DIFF
--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -187,14 +187,15 @@ class ConfigureCITest(unittest.TestCase):
         # None input
         self.assertFalse(therock_configure_ci.check_for_non_skippable_path(None))
 
-    @patch("subprocess.run")
-    def test_docs_only_change_returns_empty_list(self, mock_run):
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_docs_only_change_returns_empty_list(self, mock_get_modified):
         args = {"is_pull_request": True, "base_ref": "HEAD^"}
 
-        # Mock git diff to return only doc files
-        mock_process = MagicMock()
-        mock_process.stdout = "README.md\ndocs/guide.rst\nprojects/rocprim/docs/api.md"
-        mock_run.return_value = mock_process
+        mock_get_modified.return_value = [
+            "README.md",
+            "docs/guide.rst",
+            "projects/rocprim/docs/api.md",
+        ]
 
         project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)

--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -117,75 +117,69 @@ class ConfigureCITest(unittest.TestCase):
         self.assertGreaterEqual(len(project_to_run), 1)
 
     def test_is_path_skippable(self):
-        # Test skippable patterns
-        self.assertTrue(therock_configure_ci.is_path_skippable("README.md"))
-        self.assertTrue(therock_configure_ci.is_path_skippable("docs/guide.rst"))
-        self.assertTrue(
-            therock_configure_ci.is_path_skippable("projects/rocminfo/README.md")
-        )
-        self.assertTrue(
-            therock_configure_ci.is_path_skippable("projects/rocminfo/docs/api.rst")
-        )
-        self.assertTrue(therock_configure_ci.is_path_skippable(".gitignore"))
-        self.assertTrue(therock_configure_ci.is_path_skippable(".github/labeler.yml"))
-        self.assertTrue(therock_configure_ci.is_path_skippable(".github/labels.yml"))
-        self.assertTrue(
-            therock_configure_ci.is_path_skippable(".github/workflows/labeler.yml")
-        )
-
-        # Workflow/script files unrelated to TheRock CI are skippable without
-        # needing to be enumerated (issue #7849).
-        self.assertTrue(
-            therock_configure_ci.is_path_skippable(".github/workflows/rdc-ci.yml")
-        )
-        self.assertTrue(
-            therock_configure_ci.is_path_skippable(
-                ".github/workflows/amdsmi-manylinux-build.yml"
-            )
-        )
-        self.assertTrue(
-            therock_configure_ci.is_path_skippable(
-                ".github/workflows/rocjitsu-corpus-tests.yml"
-            )
-        )
-
-        # Test non-skippable patterns
-        self.assertFalse(
-            therock_configure_ci.is_path_skippable("projects/rocminfo/src/main.cpp")
-        )
-        self.assertFalse(therock_configure_ci.is_path_skippable("CMakeLists.txt"))
-        self.assertFalse(
-            therock_configure_ci.is_path_skippable("projects/rocminfo/test/test.cpp")
-        )
-
-        # TheRock CI workflow and script files are non-skippable so changes to
-        # them still trigger CI.
-        self.assertFalse(
-            therock_configure_ci.is_path_skippable(".github/workflows/therock-ci.yml")
-        )
-        self.assertFalse(
-            therock_configure_ci.is_path_skippable(
-                ".github/scripts/therock_configure_ci.py"
-            )
-        )
-
-    def test_check_for_non_skippable_path(self):
-        # All skippable paths
+        # SKIPPABLE_PATH_PATTERNS contains abstract fnmatch patterns. These
+        # cases make the intended matches concrete and verify how patterns
+        # behave with paths containing nested directories.
         skippable_paths = [
             "README.md",
             "docs/guide.rst",
-            "projects/rocminfo/docs/api.md",
+            "projects/rocminfo/README.md",
+            "projects/rocminfo/docs/api.rst",
+            ".gitignore",
+            "projects/rocminfo/.gitignore",
+            "projects/amdsmi/.pre-commit-config.yaml",
+            "projects/amdsmi/.github/CODEOWNERS",
+            "projects/amdsmi/LICENSE",
+            # A few source files that would normally trigger CI but are
+            # excluded based on which directory they are in.
+            "tools/systems_pr_bot/policy_check.py",
+            "experimental/perf-dkms/CMakeLists.txt",
+            "projects/rocr-runtime/libhsakmt/src/dxg/dxgmodule.c",
+            # Workflow and action files unrelated to TheRock CI are skippable.
+            ".github/labeler.yml",
+            ".github/labels.yml",
+            ".github/actions/rocprofiler-sdk-util/action.yml",
+            ".github/workflows/labeler.yml",
+            ".github/workflows/rdc-ci.yml",
+            ".github/workflows/amdsmi-manylinux-build.yml",
+            ".github/workflows/rocjitsu-corpus-tests.yml",
         ]
+        for path in skippable_paths:
+            with self.subTest(path=path):
+                self.assertTrue(therock_configure_ci.is_path_skippable(path))
+
+        non_skippable_paths = [
+            "projects/rocminfo/src/main.cpp",
+            "CMakeLists.txt",
+            "projects/rocminfo/test/test.cpp",
+            # TheRock CI workflow, action, and script files are non-skippable so
+            # changes to them still trigger CI.
+            ".github/workflows/therock-ci.yml",
+            ".github/actions/therock-something/action.yml",
+            ".github/scripts/therock_configure_ci.py",
+        ]
+        for path in non_skippable_paths:
+            with self.subTest(path=path):
+                self.assertFalse(therock_configure_ci.is_path_skippable(path))
+
+    def test_check_for_non_skippable_path(self):
+        all_skippable = ["README.md", "docs/guide.rst"]
         self.assertFalse(
-            therock_configure_ci.check_for_non_skippable_path(skippable_paths)
+            therock_configure_ci.check_for_non_skippable_path(all_skippable)
         )
 
-        # Mixed paths (has non-skippable)
-        mixed_paths = ["README.md", "src/main.cpp"]
-        self.assertTrue(therock_configure_ci.check_for_non_skippable_path(mixed_paths))
+        some_skippable = ["README.md", "projects/rocminfo/src/main.cpp"]
+        self.assertTrue(
+            therock_configure_ci.check_for_non_skippable_path(some_skippable)
+        )
 
-        # None input
-        self.assertFalse(therock_configure_ci.check_for_non_skippable_path(None))
+        none_skippable = [
+            "CMakeLists.txt",
+            "projects/rocminfo/src/main.cpp",
+        ]
+        self.assertTrue(
+            therock_configure_ci.check_for_non_skippable_path(none_skippable)
+        )
 
     @patch("therock_configure_ci.get_modified_paths")
     def test_docs_only_change_returns_empty_list(self, mock_get_modified):

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -84,12 +84,19 @@ GITHUB_WORKFLOWS_CI_PATTERNS = [
 
 
 def is_path_workflow_file_related_to_ci(path: str) -> bool:
-    return any(
-        fnmatch.fnmatch(path, ".github/workflows/" + pattern)
-        for pattern in GITHUB_WORKFLOWS_CI_PATTERNS
-    ) or any(
-        fnmatch.fnmatch(path, ".github/scripts/" + pattern)
-        for pattern in GITHUB_WORKFLOWS_CI_PATTERNS
+    return (
+        any(
+            fnmatch.fnmatch(path, ".github/workflows/" + pattern)
+            for pattern in GITHUB_WORKFLOWS_CI_PATTERNS
+        )
+        or any(
+            fnmatch.fnmatch(path, ".github/scripts/" + pattern)
+            for pattern in GITHUB_WORKFLOWS_CI_PATTERNS
+        )
+        or any(
+            fnmatch.fnmatch(path, ".github/actions/" + pattern)
+            for pattern in GITHUB_WORKFLOWS_CI_PATTERNS
+        )
     )
 
 
@@ -128,7 +135,7 @@ SKIPPABLE_PATH_PATTERNS = [
     # Miscellaneous git/github files
     "*.gitignore",
     "*.pre-commit-config.*",
-    ".github/*.yml",
+    ".github/label*.yml",
     "*CODEOWNERS",
     "*LICENSE",
     "*/.markdownlint-ci2.yaml",
@@ -152,11 +159,10 @@ SKIPPABLE_PATH_PATTERNS = [
 
 def is_path_skippable(path: str) -> bool:
     """Determines if a given relative path to a file matches any skippable patterns."""
-    # A .github/workflows/ file only affects TheRock CI when it matches the
-    # CI-related patterns. Treat every other workflow file as skippable so
-    # unrelated workflows never trigger CI and don't need to be enumerated one
-    # by one.
-    if path.startswith(".github/workflows/"):
+    # A workflow or action file only affects TheRock CI when it matches the
+    # CI-related patterns. Treat other workflow and action files as skippable so
+    # they don't need to be enumerated one by one.
+    if path.startswith((".github/workflows/", ".github/actions/")):
         return not is_path_workflow_file_related_to_ci(path)
     return any(fnmatch.fnmatch(path, pattern) for pattern in SKIPPABLE_PATH_PATTERNS)
 

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -125,23 +125,28 @@ def check_trigger_windows_ci_for_subtree(subtree: str) -> bool:
 # build or test workflows so any related jobs can be skipped if all paths
 # modified by a commit/PR match a pattern in this list.
 SKIPPABLE_PATH_PATTERNS = [
+    # Miscellaneous git/github files
+    "*.gitignore",
+    "*.pre-commit-config.*",
+    ".github/*.yml",
+    "*CODEOWNERS",
+    "*LICENSE",
+    "*/.markdownlint-ci2.yaml",
+    "tools/systems_pr_bot/*",
+    # Documentation files
     "docs/*",
-    ".gitignore",
     "*.md",
     "*.rtf",
     "*.rst",
-    "*/.markdownlint-ci2.yaml",
     "*/.readthedocs.yaml",
     "*/.spellcheck.local.yaml",
     "*/.wordlist.txt",
     "projects/*/docs/*",
-    "projects/*/.gitignore",
-    "projects/rocr-runtime/libhsakmt/src/dxg/*",
     "shared/*/docs/*",
-    "shared/*/.gitignore",
-    "experimental/python/perfxpert/*",
-    ".github/CODEOWNERS",
-    ".github/label*.yml",
+    # Changes to experimental code do not run standard build/test workflows.
+    "experimental/*",
+    # WSL support files (should these still be excluded?)
+    "projects/rocr-runtime/libhsakmt/src/dxg/*",
 ]
 
 


### PR DESCRIPTION
## Motivation

The `SKIPPABLE_PATH_PATTERNS` list that controls which paths can be modified without triggering the full "TheRock CI" workflows had a few overlapping patterns like `*.gitignore` and `projects/*/.gitignore` and was missing patterns for some newly added directories like `tools/systems_pr_bot/*` (see https://github.com/ROCm/rocm-systems/issues/7842).

## Technical Details

I (well, with some nudging by Codex) decided to also restructure the `test_is_path_skippable` test case to make new subtests easier to add.

## Test Plan

New + existing unit tests (now running/passing thanks to https://github.com/ROCm/rocm-systems/pull/8882)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
