### PR TITLE
refactor(rocprofiler-sdk): migrate PC sampling off the per-queue callback registry

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -38,6 +38,7 @@
 #include "lib/rocprofiler-sdk/kernel_dispatch/profiling_time.hpp"
 #include "lib/rocprofiler-sdk/kernel_dispatch/tracing.hpp"
 #include "lib/rocprofiler-sdk/pc_sampling/hsa_adapter.hpp"
+#include "lib/rocprofiler-sdk/pc_sampling/queue_hooks.hpp"
 #include "lib/rocprofiler-sdk/pc_sampling/service.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
 #include "lib/rocprofiler-sdk/tracing/tracing.hpp"
@@ -167,6 +168,15 @@ AsyncSignalHandler(hsa_signal_value_t /*signal_v*/, void* data)
                                           dispatch_time);
             }
         });
+
+        // PC sampling completion is no longer routed through the per-queue
+        // callback registry; invoke its hook explicitly.
+        pc_sampling::signal_completion_hook(queue_info_session.queue,
+                                            packet.kernel_packet,
+                                            _session,
+                                            packet,
+                                            packet.instrumentation_packets,
+                                            dispatch_time);
 
         if(packet.is_serialized)
         {
@@ -307,6 +317,7 @@ WriteInterceptor(const void* packets,
     const bool graph_launch_active = (gls != nullptr);
     const bool no_real_consumers =
         (queue.get_notifiers() == 0 &&
+         !pc_sampling::is_configured_on_agent(queue.get_agent().get_rocp_agent()->id) &&
          context::get_active_contexts(full_packet_instrumentation_context_filter).empty());
 
     if(pkt_count == 0 || (no_real_consumers && !graph_launch_active))

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/CMakeLists.txt
@@ -4,6 +4,12 @@
 #
 add_subdirectory(parser)
 
+# queue_hooks provides always-linkable shims (is_configured_on_agent /
+# signal_completion_hook) that the HSA queue interceptor calls unconditionally, so it must
+# compile even when PC sampling HSA support is unavailable (its body is guarded by
+# ROCPROFILER_SDK_HSA_PC_SAMPLING). Add it before the early return.
+target_sources(rocprofiler-sdk-object-library PRIVATE queue_hooks.cpp queue_hooks.hpp)
+
 if(hsa-runtime64_VERSION AND hsa-runtime64_VERSION VERSION_LESS 1.14.0)
     return()
 endif()

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/hsa_adapter.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/hsa_adapter.cpp
@@ -123,8 +123,12 @@ amd_intercept_marker_handler_callback(const struct amd_aql_intercept_marker_s* p
     parser->newDispatch(dispatch_pkt);
 }
 
+}  // namespace
+
 /**
- * Callback called by HSA interceptor when the kernel has completed.
+ * Callback called by HSA interceptor when the kernel has completed. Declared in
+ * hsa_adapter.hpp and invoked from pc_sampling::signal_completion_hook (see
+ * pc_sampling/queue_hooks.cpp), so it lives outside the anonymous namespace.
  */
 void
 kernel_completion_cb(const rocprofiler_agent_t* rocp_agent,
@@ -145,6 +149,8 @@ kernel_completion_cb(const rocprofiler_agent_t* rocp_agent,
     agent_session->cid_manager->cid_async_activity_completed(session.correlation_id);
 }
 
+namespace
+{
 void
 data_ready_callback(void*                                client_callback_data,
                     size_t                               data_size,
@@ -345,34 +351,11 @@ pc_sampling_service_finish_configuration(context::pc_sampling_service* service)
         }
     }
 
-    using external_corr_id_map_t = ::rocprofiler::hsa::queue_info_session_t::external_corr_id_map_t;
-
-    // Register callbacks for the HSA's queue interceptor.
-    // TODO: should we store callback ID in the service?
-    rocprofiler::hsa::get_queue_controller()->add_callback(
-        std::nullopt,
-        ::rocprofiler::hsa::queue_callbacks_t{
-            .batch_packets = []() { return true; },
-            .write_interceptor =
-                [](const rocprofiler::hsa::Queue&,
-                   const rocprofiler::hsa::rocprofiler_packet&,
-                   rocprofiler_kernel_id_t /*kernel_id*/,
-                   rocprofiler_dispatch_id_t /*dispatch_id*/,
-                   rocprofiler_user_data_t*,
-                   const external_corr_id_map_t&,
-                   const context::correlation_id*) {
-                    return rocprofiler::hsa::write_packet_t{nullptr, false};
-                },
-            // Completion CB
-            .signal_completion =
-                [](const rocprofiler::hsa::Queue&                           q,
-                   rocprofiler::hsa::rocprofiler_packet                     kern_pkt,
-                   std::shared_ptr<rocprofiler::hsa::queue_info_session_t>& session,
-                   rocprofiler::hsa::packet_data_t& /*packet*/,
-                   rocprofiler::hsa::inst_pkt_t&,
-                   kernel_dispatch::profiling_time) {
-                    kernel_completion_cb(q.get_agent().get_rocp_agent(), kern_pkt, *session);
-                }});
+    // PC sampling no longer registers a per-queue callback with the HSA queue
+    // controller. Kernel completion is delivered explicitly via
+    // pc_sampling::signal_completion_hook, called from the HSA async signal
+    // handler (see hsa/queue.cpp). The marker packet is still injected directly
+    // in the write interceptor, gated by pc_sampling::is_configured_on_agent.
 }
 
 rocprofiler_status_t

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/hsa_adapter.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/hsa_adapter.hpp
@@ -54,6 +54,14 @@ pc_sampling_service_stop(context::pc_sampling_service* service);
 void
 pc_sampling_service_finish_configuration(context::pc_sampling_service* service);
 
+// Notifies the CID manager that the kernel's correlation ID has completed.
+// Invoked from pc_sampling::signal_completion_hook (pc_sampling/queue_hooks.cpp),
+// which is called by the HSA async signal handler in hsa/queue.cpp.
+void
+kernel_completion_cb(const rocprofiler_agent_t*                    rocp_agent,
+                     rocprofiler::hsa::rocprofiler_packet&         kernel_pkt,
+                     const rocprofiler::hsa::queue_info_session_t& session);
+
 rocprofiler_status_t
 flush_internal_agent_buffers(const PCSAgentSession* agent_session);
 }  // namespace hsa

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/queue_hooks.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/queue_hooks.cpp
@@ -1,0 +1,68 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "lib/rocprofiler-sdk/pc_sampling/queue_hooks.hpp"
+
+#include "lib/rocprofiler-sdk/pc_sampling/defines.hpp"
+
+#if ROCPROFILER_SDK_HSA_PC_SAMPLING > 0
+#    include "lib/rocprofiler-sdk/pc_sampling/hsa_adapter.hpp"
+#    include "lib/rocprofiler-sdk/pc_sampling/service.hpp"
+#endif
+
+namespace rocprofiler
+{
+namespace pc_sampling
+{
+bool
+is_configured_on_agent(rocprofiler_agent_id_t agent_id)
+{
+#if ROCPROFILER_SDK_HSA_PC_SAMPLING > 0
+    return is_pc_sample_service_configured(agent_id);
+#else
+    (void) agent_id;
+    return false;
+#endif
+}
+
+void
+signal_completion_hook(const ::rocprofiler::hsa::Queue&                           queue,
+                       const ::rocprofiler::hsa::rocprofiler_packet&              kernel_packet,
+                       std::shared_ptr<::rocprofiler::hsa::queue_info_session_t>& session,
+                       ::rocprofiler::hsa::packet_data_t& /*packet*/,
+                       ::rocprofiler::hsa::inst_pkt_t& /*inst_pkt*/,
+                       kernel_dispatch::profiling_time /*dispatch_time*/)
+{
+#if ROCPROFILER_SDK_HSA_PC_SAMPLING > 0
+    if(!session) return;
+    // kernel_completion_cb takes a mutable reference to the kernel packet even
+    // though it does not modify it; copy to bind a non-const lvalue.
+    auto kern_pkt = kernel_packet;
+    hsa::kernel_completion_cb(queue.get_agent().get_rocp_agent(), kern_pkt, *session);
+#else
+    (void) queue;
+    (void) kernel_packet;
+    (void) session;
+#endif
+}
+}  // namespace pc_sampling
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/queue_hooks.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/queue_hooks.hpp
@@ -1,0 +1,58 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "lib/rocprofiler-sdk/hsa/queue.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_info_session.hpp"
+#include "lib/rocprofiler-sdk/hsa/rocprofiler_packet.hpp"
+#include "lib/rocprofiler-sdk/kernel_dispatch/profiling_time.hpp"
+
+#include <rocprofiler-sdk/fwd.h>
+
+#include <memory>
+
+namespace rocprofiler
+{
+namespace pc_sampling
+{
+// True if the PC sampling service is configured on the given agent. Always
+// linkable: returns false when PC sampling HSA support is unavailable. Used by
+// the HSA write interceptor gate (in place of the per-queue callback that used
+// to keep queue.get_notifiers() > 0) to decide whether a marker packet must be
+// injected for this dispatch.
+bool
+is_configured_on_agent(rocprofiler_agent_id_t agent_id);
+
+// Explicit replacement for the PC-sampling per-queue completion callback that
+// used to be registered with the HSA queue controller. Notifies the CID manager
+// that the kernel's correlation ID has completed. No-op when PC sampling HSA
+// support is unavailable or when the service is not configured on the agent.
+void
+signal_completion_hook(const ::rocprofiler::hsa::Queue&                           queue,
+                       const ::rocprofiler::hsa::rocprofiler_packet&              kernel_packet,
+                       std::shared_ptr<::rocprofiler::hsa::queue_info_session_t>& session,
+                       ::rocprofiler::hsa::packet_data_t&                         packet,
+                       ::rocprofiler::hsa::inst_pkt_t&                            inst_pkt,
+                       kernel_dispatch::profiling_time                            dispatch_time);
+}  // namespace pc_sampling
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/tests/CMakeLists.txt
@@ -8,7 +8,8 @@ set(ROCPROFILER_LIB_PC_SAMPLING_TEST_SOURCES
     # samples_processing.cpp
     pc_sampling_vs_counter_collection.cpp
     query_configuration.cpp
-    multiple_contexts_one_per_agent.cpp)
+    multiple_contexts_one_per_agent.cpp
+    queue_hooks_test.cpp)
 set(ROCPROFILER_LIB_PC_SAMPLING_TEST_HEADERS pc_sampling_internals.hpp)
 
 add_executable(pcs-test)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/tests/queue_hooks_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/tests/queue_hooks_test.cpp
@@ -1,0 +1,40 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "lib/rocprofiler-sdk/pc_sampling/queue_hooks.hpp"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+// is_configured_on_agent replaces the queue.get_notifiers() signal that the old
+// per-queue callback registration used to provide to the HSA write interceptor
+// gate. With no PC sampling service configured, any agent id must report as not
+// configured. This is always linkable regardless of HSA PC sampling support and
+// requires no GPU / HSA runtime.
+TEST(pc_sampling_queue_hooks, is_configured_on_agent_unconfigured)
+{
+    rocprofiler_agent_id_t agent_id;
+    agent_id.handle = 123456;
+    EXPECT_FALSE(rocprofiler::pc_sampling::is_configured_on_agent(agent_id));
+}
+}  // namespace

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/types.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/types.hpp
@@ -57,7 +57,6 @@ struct PCSAgentSession
 #if ROCPROFILER_SDK_HSA_PC_SAMPLING > 0
     hsa_ven_amd_pcs_t hsa_pc_sampling = {};
 #endif
-    hsa::ClientID intercept_cb_id = -1;
     // ioctl relevant information
     uint32_t ioctl_pcs_id = 0;
     // PC sampling parser


### PR DESCRIPTION

## Motivation

The purpose of this PR is to isolate the PC-sampling slice of the callback-removal effort (reference PRs #8730 / #8586) into a small, single-service change, per review guidance to land callback removal one service at a time. Helps toward but independent of the kernel replay feature in #7960.

### Underlying Problem

PC sampling currently registers a per-queue completion callback with the HSA queue controller so kernel completions reach the CID manager. That ties completion delivery to the shared per-queue callback registry even though marker-packet injection was never registry-based.

This PR:

1. **Removes the registry registration** from `pc_sampling_service_finish_configuration` and delivers completion explicitly via `pc_sampling::signal_completion_hook` from the async signal handler.
2. **Replaces the `get_notifiers()` gate** with `is_configured_on_agent()` so PC-only runs still enter the write interceptor and receive marker packets on configured agents.

PC sampling has **no enqueue hook** — marker injection stays inline in `WriteInterceptor`. This is the smallest migration: completion-only, no batching change. The per-queue callback registry remains for counters, thread trace, and SPM until those services land in their own PRs.

### Notes on Bigger Picture

Sibling migrations: thread trace (#8790), SPM (#8887), counter collection (#8891).

Kernel replay (#7960) benefits from callback removal but this PR is independent and behavior-preserving on its own.

## Technical Details

```mermaid
flowchart LR
  WriteInterceptor --> Marker["generate_marker_packet_for_kernel if configured on agent"]
  AsyncSignalHandler --> CompletionHook["pc_sampling::signal_completion_hook"]
  CompletionHook --> CID["kernel_completion_cb → cid_manager"]
```

Permalinks pin to `ec87a2f`.

### Hooks and call sites

- Declarations: [queue_hooks.hpp](https://github.com/ROCm/rocm-systems/blob/ec87a2f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/queue_hooks.hpp)
- `is_configured_on_agent`: [queue_hooks.cpp#L36-L45](https://github.com/ROCm/rocm-systems/blob/ec87a2f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/queue_hooks.cpp#L36-L45)
- `signal_completion_hook` → `kernel_completion_cb`: [queue_hooks.cpp#L47-L66](https://github.com/ROCm/rocm-systems/blob/ec87a2f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/queue_hooks.cpp#L47-L66), [hsa_adapter.cpp#L133-L150](https://github.com/ROCm/rocm-systems/blob/ec87a2f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/hsa_adapter.cpp#L133-L150)
- `no_real_consumers` gate (per-agent, not global): [queue.cpp#L318-L321](https://github.com/ROCm/rocm-systems/blob/ec87a2f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp#L318-L321)
- Exit call site: [queue.cpp#L172-L179](https://github.com/ROCm/rocm-systems/blob/ec87a2f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp#L172-L179)
- Registration removed from configure path: [hsa_adapter.cpp#L354-L358](https://github.com/ROCm/rocm-systems/blob/ec87a2f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/hsa_adapter.cpp#L354-L358)
- `queue_id` removed from PC sampling types ([types.hpp](https://github.com/ROCm/rocm-systems/blob/ec87a2f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/types.hpp))

PC sampling does not use `client_ids.hpp` producer tags on this branch (marker injection is unchanged). No `is_any_active()` — the gate is per-agent configuration state.

### Reviewer Guide

1. Confirm **no** `add_callback` / `remove_callback` in [hsa_adapter.cpp configure path](https://github.com/ROCm/rocm-systems/blob/ec87a2f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/hsa_adapter.cpp#L354-L358).
2. `AsyncSignalHandler` calls `pc_sampling::signal_completion_hook` after registry walk ([queue.cpp#L172-L179](https://github.com/ROCm/rocm-systems/blob/ec87a2f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp#L172-L179)).
3. `no_real_consumers` uses `is_configured_on_agent(agent)` per dispatch queue's agent ([queue.cpp#L318-L321](https://github.com/ROCm/rocm-systems/blob/ec87a2f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp#L318-L321)) — PC-sampling-only on one GPU must still intercept that GPU's dispatches.
4. Marker injection path unchanged except gate rename to `is_configured_on_agent` ([queue.cpp](https://github.com/ROCm/rocm-systems/blob/ec87a2f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp)).
5. `kernel_completion_cb` still guards on `is_pc_sample_service_configured` and correlation id ([hsa_adapter.cpp#L138-L149](https://github.com/ROCm/rocm-systems/blob/ec87a2f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/hsa_adapter.cpp#L138-L149)).
6. `#if ROCPROFILER_SDK_HSA_PC_SAMPLING` — hook stubs must link when support is off ([queue_hooks.cpp](https://github.com/ROCm/rocm-systems/blob/ec87a2f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/queue_hooks.cpp)).
7. Unit test: [queue_hooks_test.cpp#L34-L39](https://github.com/ROCm/rocm-systems/blob/ec87a2f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/tests/queue_hooks_test.cpp#L34-L39).

**Questions to answer:** 

- With PC sampling configured on GPU-0 only, does GPU-0 still get marker injection and completion CID retirement? 

- With no PC sampling configured, does `is_configured_on_agent` return false for all agents?

**Out of scope:** enqueue hook extraction; `client_ids.hpp` tagging; per-agent scoping API; deleting `Queue::_callbacks`.

## Issue Tracking
JIRA ticket: 
AIPROFSDK-1019

## Test Plan

- [is_configured_on_agent unconfigured](https://github.com/ROCm/rocm-systems/blob/ec87a2f/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/tests/queue_hooks_test.cpp#L34-L39)
- Existing PC sampling integration / rocprofv3 PC sampling tests

## Test Result

Unit gate test as above. Treat the Checks tab as source of truth for CI.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.


