### PR TITLE
build(rocr): Fix debug builds with clang

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
@@ -312,16 +312,17 @@ static hsa_status_t build_lightweight_coredump_ranges(MemoryRegionFilter& filter
       AMD::AqlQueue* aql_queue = static_cast<AMD::AqlQueue*>(q);
 
       // We need to capture the queue amd_queue_t for the debugger.
-      debug_print("Added aql_queue_t range: %#p - %#p (size: %zu)\n",
-                  &aql_queue->amd_queue_, &aql_queue->amd_queue_ + 1,
+      debug_print("Added aql_queue_t range: %#" PRIx64 " - %#" PRIx64 " (size: %zu)\n",
+                  reinterpret_cast<uint64_t>(&aql_queue->amd_queue_),
+                  reinterpret_cast<uint64_t>(&aql_queue->amd_queue_ + 1),
                   sizeof(aql_queue->amd_queue_));
       filter.add_range(reinterpret_cast<uint64_t>(&aql_queue->amd_queue_),
                        sizeof(aql_queue->amd_queue_));
 
       // Same goes for the ring buffer.
-      debug_print("Added ring buffer range: %#p - %#p (size: %zu)\n",
-                  aql_queue->amd_queue_.hsa_queue.base_address,
-                  static_cast<void*>(aql_queue->amd_queue_.hsa_queue.base_address)
+      debug_print("Added ring buffer range: %#" PRIx64 " - %#" PRIx64 " (size: %zu)\n",
+                  reinterpret_cast<uint64_t>(aql_queue->amd_queue_.hsa_queue.base_address),
+                  reinterpret_cast<uint64_t>(aql_queue->amd_queue_.hsa_queue.base_address)
                     + aql_queue->amd_queue_.hsa_queue.size * sizeof(hsa_kernel_dispatch_packet_t),
                   aql_queue->amd_queue_.hsa_queue.size * sizeof(hsa_kernel_dispatch_packet_t));
       filter.add_range(reinterpret_cast<uint64_t>(aql_queue->amd_queue_.hsa_queue.base_address),
@@ -334,9 +335,9 @@ static hsa_status_t build_lightweight_coredump_ranges(MemoryRegionFilter& filter
         return HSA_STATUS_ERROR;
       }
 
-      debug_print("Added CWSR area range: %#p - %#p (size: %zu)\n",
-                  queue_info.SaveAreaHeader,
-                  static_cast<void*>(queue_info.SaveAreaHeader) + queue_info.SaveAreaSizeInBytes,
+      debug_print("Added CWSR area range: %#" PRIx64 " - %#" PRIx64 " (size: %zu)\n",
+                  reinterpret_cast<uint64_t>(queue_info.SaveAreaHeader),
+                  reinterpret_cast<uint64_t>(queue_info.SaveAreaHeader) + queue_info.SaveAreaSizeInBytes,
                   queue_info.SaveAreaSizeInBytes);
       filter.add_range(reinterpret_cast<uint64_t>(queue_info.SaveAreaHeader),
                        queue_info.SaveAreaSizeInBytes);


### PR DESCRIPTION
## Motivation

When creating debuild build with clang, we have build failures introduced by 99a0be1e16 "rocr/coredump: Extend list of required memory ranges for lightweight cores":

    .../libamdhsacode/lnx/amd_core_dump.cpp:315:46: warning: flag '#' results in undefined
          behavior with 'p' conversion specifier [-Wformat]
      315 |       debug_print("Added aql_queue_t range: %#p - %#p (size: %zu)\n",
          |                                             ~^~
    .../core/util/utils.h:161:21: note: expanded from macro 'debug_print'
      161 |     fprintf(stderr, fmt, ##__VA_ARGS__);                                                           \
          |                     ^~~
    .../libamdhsacode/lnx/amd_core_dump.cpp:315:52: warning: flag '#' results in undefined
          behavior with 'p' conversion specifier [-Wformat]
      315 |       debug_print("Added aql_queue_t range: %#p - %#p (size: %zu)\n",
          |                                                   ~^~
    .../core/util/utils.h:161:21: note: expanded from macro 'debug_print'
      161 |     fprintf(stderr, fmt, ##__VA_ARGS__);                                                           \
          |                     ^~~
    .../libamdhsacode/lnx/amd_core_dump.cpp:325:21: error: arithmetic on a pointer to void
      324 |                   static_cast<void*>(aql_queue->amd_queue_.hsa_queue.base_address)
          |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      325 |                     + aql_queue->amd_queue_.hsa_queue.size * sizeof(hsa_kernel_dispatch_packet_t),
          |                     ^
    .../core/util/utils.h:161:28: note: expanded from macro 'debug_print'
      161 |     fprintf(stderr, fmt, ##__VA_ARGS__);                                                           \
          |                            ^~~~~~~~~~~
    .../libamdhsacode/lnx/amd_core_dump.cpp:339:65: error: arithmetic on a pointer to void
      339 |                   static_cast<void*>(queue_info.SaveAreaHeader) + queue_info.SaveAreaSizeInBytes,
          |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
    .../core/util/utils.h:161:28: note: expanded from macro 'debug_print'
      161 |     fprintf(stderr, fmt, ##__VA_ARGS__);                                                           \
          |                            ^~~~~~~~~~~
    2 warnings and 2 errors generated.

This issue does not affect release build, and is not raised by GCC on debug builds either.

This patch fixes those build issues.

## Technical Details

Do not use `+` on `void *` pointers.  Instead, convert the `void *` into a `uint64_t`, and then do math on this.  Also adjust the printf format to support uint64_t.

## Issue Tracking



## Test Plan

Produce a debug build.

## Test Result

PASS.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
