### PR TITLE
rocr/coredump: fix void* pointer arithmetic in debug_print

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
@@ -321,8 +321,9 @@ static hsa_status_t build_lightweight_coredump_ranges(MemoryRegionFilter& filter
       // Same goes for the ring buffer.
       debug_print("Added ring buffer range: %#p - %#p (size: %zu)\n",
                   aql_queue->amd_queue_.hsa_queue.base_address,
-                  static_cast<void*>(aql_queue->amd_queue_.hsa_queue.base_address)
-                    + aql_queue->amd_queue_.hsa_queue.size * sizeof(hsa_kernel_dispatch_packet_t),
+                  reinterpret_cast<void*>(
+                    reinterpret_cast<uint64_t>(aql_queue->amd_queue_.hsa_queue.base_address)
+                    + aql_queue->amd_queue_.hsa_queue.size * sizeof(hsa_kernel_dispatch_packet_t)),
                   aql_queue->amd_queue_.hsa_queue.size * sizeof(hsa_kernel_dispatch_packet_t));
       filter.add_range(reinterpret_cast<uint64_t>(aql_queue->amd_queue_.hsa_queue.base_address),
                        aql_queue->amd_queue_.hsa_queue.size * sizeof(hsa_kernel_dispatch_packet_t));
@@ -336,7 +337,8 @@ static hsa_status_t build_lightweight_coredump_ranges(MemoryRegionFilter& filter
 
       debug_print("Added CWSR area range: %#p - %#p (size: %zu)\n",
                   queue_info.SaveAreaHeader,
-                  static_cast<void*>(queue_info.SaveAreaHeader) + queue_info.SaveAreaSizeInBytes,
+                  reinterpret_cast<void*>(
+                    reinterpret_cast<uint64_t>(queue_info.SaveAreaHeader) + queue_info.SaveAreaSizeInBytes),
                   queue_info.SaveAreaSizeInBytes);
       filter.add_range(reinterpret_cast<uint64_t>(queue_info.SaveAreaHeader),
                        queue_info.SaveAreaSizeInBytes);


### PR DESCRIPTION
## Problem

`#7502` (`rocr: Fix coredump generation to pipes, and to file on lustrefs`, merged to `develop`) introduced arithmetic directly on a `void*` in `amd_core_dump.cpp`. This is a GNU extension that GCC accepts but **Clang rejects as a hard error**:

```
amd_core_dump.cpp:325:21: error: arithmetic on a pointer to void
amd_core_dump.cpp:339:65: error: arithmetic on a pointer to void
```

This breaks any Clang build of rocr-runtime. It surfaced in the SPIRV-LLVM-Translator CI, which builds rocr-runtime with the AMD Clang it just built (`ROCm/SPIRV-LLVM-Translator` Linux CI, which checks out `rocm-systems` `develop`).

## Fix

Both sites compute an end pointer (`base + size`) passed to a `%#p` `debug_print` argument. Compute the end address via `reinterpret_cast<uint64_t>` — the same idiom already used by the adjacent `filter.add_range(...)` calls and the scratch-range print just above — and cast the result back to `void*` for the `%#p` specifier. No behavior change.

## Notes

- Only diagnostic `debug_print` output is affected; runtime behavior is unchanged.
- These were the only two `void*`-arithmetic sites in the file.
