### PR TITLE
fix(clr): Use rocr backend for HIP/OCL by default

### DIFF
--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -844,16 +844,15 @@ bool Device::init() {
   // Bug fix: atoi("") returns 0, but empty string should mean "use platform default"
   if (gpu_enable_pal_is_empty_string) {
     if (IS_WINDOWS) {
-      // Windows default: PAL path
-      GPU_ENABLE_PAL = 1;
+      // Windows default: Rocr path
+      GPU_ENABLE_PAL = 0;
     } else {
       // Linux default: ROCr path
       GPU_ENABLE_PAL = 0;
     }
   } else if (IS_WINDOWS && flagIsDefault(GPU_ENABLE_PAL)) {
-    // On Windows by default keep PAL path for now, until we completely switch to ROCr backend
-    // Without this, roc::Device::init() returns true & disables PAL path in below code
-    GPU_ENABLE_PAL = 1;
+    // default Rocr path
+    GPU_ENABLE_PAL = 0;
   }
 
 // IMPORTANT: Note that we are initialiing HSA stack first and then

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -846,14 +846,14 @@ bool Device::init() {
   // Bug fix: atoi("") returns 0, but empty string should mean "use platform default"
   if (gpu_enable_pal_is_empty_string) {
     if (IS_WINDOWS) {
-      // Windows default: Rocr path
+      // Windows default: ROCr path
       GPU_ENABLE_PAL = 0;
     } else {
       // Linux default: ROCr path
       GPU_ENABLE_PAL = 0;
     }
   } else if (IS_WINDOWS && flagIsDefault(GPU_ENABLE_PAL)) {
-    // default Rocr path
+    // default ROCr path
     GPU_ENABLE_PAL = 0;
   }
 

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -846,16 +846,15 @@ bool Device::init() {
   // Bug fix: atoi("") returns 0, but empty string should mean "use platform default"
   if (gpu_enable_pal_is_empty_string) {
     if (IS_WINDOWS) {
-      // Windows default: PAL path
-      GPU_ENABLE_PAL = 1;
+      // Windows default: Rocr path
+      GPU_ENABLE_PAL = 0;
     } else {
       // Linux default: ROCr path
       GPU_ENABLE_PAL = 0;
     }
   } else if (IS_WINDOWS && flagIsDefault(GPU_ENABLE_PAL)) {
-    // On Windows by default keep PAL path for now, until we completely switch to ROCr backend
-    // Without this, roc::Device::init() returns true & disables PAL path in below code
-    GPU_ENABLE_PAL = 1;
+    // default Rocr path
+    GPU_ENABLE_PAL = 0;
   }
 
 // IMPORTANT: Note that we are initialiing HSA stack first and then

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -844,14 +844,14 @@ bool Device::init() {
   // Bug fix: atoi("") returns 0, but empty string should mean "use platform default"
   if (gpu_enable_pal_is_empty_string) {
     if (IS_WINDOWS) {
-      // Windows default: Rocr path
+      // Windows default: ROCr path
       GPU_ENABLE_PAL = 0;
     } else {
       // Linux default: ROCr path
       GPU_ENABLE_PAL = 0;
     }
   } else if (IS_WINDOWS && flagIsDefault(GPU_ENABLE_PAL)) {
-    // default Rocr path
+    // default ROCr path
     GPU_ENABLE_PAL = 0;
   }
 

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -102,7 +102,7 @@ release(bool, HSA_ENABLE_DTIF_FAST_COPY, false,                               \
         "Flag plain device allocations as HostMemoryDirectAccess")            \
 release(bool, GPU_MIPMAP, true,                                               \
         "Enables GPU mipmap extension")                                       \
-release(uint, GPU_ENABLE_PAL, 2,                                              \
+release(uint, GPU_ENABLE_PAL, 0,                                              \
         "Enables PAL backend. 0 - ROC, 1 - PAL, 2 - ROC or PAL")              \
 release(bool, DISABLE_DEFERRED_ALLOC, false,                                  \
         "Disables deferred memory allocation on device")                      \

--- a/projects/hip-tests/catch/unit/env/hipEnvGpuEnablePal.cc
+++ b/projects/hip-tests/catch/unit/env/hipEnvGpuEnablePal.cc
@@ -22,8 +22,8 @@
  * ----------------
  * GPU_ENABLE_PAL | Windows | Linux
  * ---------------|---------|-------
- * Not set        | PAL (1) | ROCr (0)
- * "" (empty)     | PAL (1) | ROCr (0)
+ * Not set        | ROCr (0) | ROCr (0)
+ * "" (empty)     | ROCr (0) | ROCr (0)
  * "0"            | ROCr (0)| ROCr (0)
  * "1"            | PAL (1) | PAL (1)
  * "2"            | Auto (2)| Auto (2)
@@ -59,9 +59,9 @@ HIP_TEST_CASE(Unit_hipEnvGpuEnablePal_Default_UsesPlatformDefault) {
   bool rocrInitialized = (output.find("] ROCr backend initialized") != std::string::npos);
 
 #if defined(_WIN32)
-  // Windows: default should use PAL
-  REQUIRE(palInitialized == true);
-  REQUIRE(rocrInitialized == false);
+  // Windows: default should use ROCr
+  REQUIRE(rocrInitialized == true);
+  REQUIRE(palInitialized == false);
 #else
   // Linux: default should use ROCr
   REQUIRE(rocrInitialized == true);
@@ -98,9 +98,9 @@ HIP_TEST_CASE(Unit_hipEnvGpuEnablePal_EmptyString_UsesPlatformDefault) {
   bool rocrInitialized = (output.find("] ROCr backend initialized") != std::string::npos);
 
 #if defined(_WIN32)
-  // Windows: empty string should use PAL (platform default)
-  REQUIRE(palInitialized == true);
-  REQUIRE(rocrInitialized == false);
+  // Windows: empty string should use ROCr (platform default)
+  REQUIRE(rocrInitialized == true);
+  REQUIRE(palInitialized == false);
 #else
   // Linux: empty string should use ROCr (platform default)
   REQUIRE(rocrInitialized == true);


### PR DESCRIPTION
## Motivation
Use rocr by default to see if we pass all tests

## Technical Details
Use rocr by default to see if we pass all tests

## Issue Tracking
JIRA ID: ROCM-20431

## Test Plan
hip-tests with GPU_ENABLE_PAL=0 passing and all component tests on Rock pass

## Test Result
hip-tests with GPU_ENABLE_PAL=0 passing and all component tests on Rock pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
