### PR TITLE
fix(rocprof-trace-decoder): handle and table lifetime after main

### DIFF
--- a/projects/rocprof-trace-decoder/source/cow_ptr.hpp
+++ b/projects/rocprof-trace-decoder/source/cow_ptr.hpp
@@ -22,7 +22,9 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
+#include <new>
 #include <utility>
 
 template <typename T> class CowPtr
@@ -50,8 +52,9 @@ public:
 private:
     static const T& empty()
     {
-        static const T value{};
-        return value;
+        alignas(T) static std::byte storage[sizeof(T)];
+        static const T* value = ::new (static_cast<void*>(storage)) T{};
+        return *value;
     }
 
     std::shared_ptr<const T> ptr_{};

--- a/projects/rocprof-trace-decoder/source/gfx10/gfx10wave.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx10/gfx10wave.cpp
@@ -31,6 +31,9 @@
 #include "mi400/mi400wave.h"
 #include "segment.hpp"
 
+#include <cstddef>
+#include <new>
+
 #define INST_JUMP_TYPE 5
 #define INST_TRAP_TYPE 6
 #define INST_RFE_TYPE  117
@@ -129,7 +132,11 @@ enum EINST
     einst_final
 };
 
-static std::unordered_map<int, mapped_inst_t> table_map_to_common_type{
+// clang-format off
+using InstructionTable = std::unordered_map<int, mapped_inst_t>;
+alignas(InstructionTable) static std::byte table_map_to_common_type_storage[sizeof(InstructionTable)];
+static InstructionTable& table_map_to_common_type =
+    *::new (static_cast<void*>(table_map_to_common_type_storage)) InstructionTable{
     {(int) EINST::salu,              {WaveInstCategory::SALU, 1} },
     {(int) EINST::smem_rd,           {WaveInstCategory::SMEM, 1} },
     {(int) EINST::smem_wr,           {WaveInstCategory::SMEM, 1} },
@@ -209,6 +216,7 @@ static std::unordered_map<int, mapped_inst_t> table_map_to_common_type{
     {(int) EINST::subv_loop_begin,   {WaveInstCategory::SALU, 1} },
     {(int) EINST::subv_loop_end,     {WaveInstCategory::SALU, 1} }
 };
+// clang-format on
 
 mapped_inst_t map_to_common_type(int einst, int dprate, int derate)
 {

--- a/projects/rocprof-trace-decoder/source/gfx10/gfx10wave.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx10/gfx10wave.cpp
@@ -21,18 +21,19 @@
 // SOFTWARE.
 
 #include "gfx10wave.h"
+
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <map>
+#include <new>
 #include <utility>
 #include <vector>
+
 #include "gfx11/gfx11wave.h"
 #include "gfx12/gfx12wave.h"
 #include "mi400/mi400wave.h"
 #include "segment.hpp"
-
-#include <cstddef>
-#include <new>
 
 #define INST_JUMP_TYPE 5
 #define INST_TRAP_TYPE 6
@@ -133,10 +134,10 @@ enum EINST
 };
 
 // clang-format off
-using InstructionTable = std::unordered_map<int, mapped_inst_t>;
-alignas(InstructionTable) static std::byte table_map_to_common_type_storage[sizeof(InstructionTable)];
-static InstructionTable& table_map_to_common_type =
-    *::new (static_cast<void*>(table_map_to_common_type_storage)) InstructionTable{
+using instruction_table_t = std::unordered_map<int, mapped_inst_t>;
+alignas(instruction_table_t) static std::byte table_map_to_common_type_storage[sizeof(instruction_table_t)];
+static instruction_table_t& table_map_to_common_type =
+    *::new (static_cast<void*>(table_map_to_common_type_storage)) instruction_table_t{
     {(int) EINST::salu,              {WaveInstCategory::SALU, 1} },
     {(int) EINST::smem_rd,           {WaveInstCategory::SMEM, 1} },
     {(int) EINST::smem_wr,           {WaveInstCategory::SMEM, 1} },

--- a/projects/rocprof-trace-decoder/source/gfx11/gfx11wave.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx11/gfx11wave.cpp
@@ -26,6 +26,9 @@
 #include <utility>
 #include <vector>
 
+#include <cstddef>
+#include <new>
+
 typedef gfx10::Token Token;
 
 namespace gfx11
@@ -148,7 +151,11 @@ enum EINST
     einst_final
 };
 
-static const std::unordered_map<int, mapped_inst_t> table_map_to_common_type{
+// clang-format off
+using InstructionTable = std::unordered_map<int, mapped_inst_t>;
+alignas(InstructionTable) static std::byte table_map_to_common_type_storage[sizeof(InstructionTable)];
+static const InstructionTable& table_map_to_common_type =
+    *::new (static_cast<void*>(table_map_to_common_type_storage)) InstructionTable{
     {(int) EINST::salu,               {WaveInstCategory::SALU, 1}            },
     {(int) EINST::smem_rd,            {WaveInstCategory::SMEM, 1}            },
     {(int) EINST::smem_wr,            {WaveInstCategory::SMEM, 1}            },
@@ -260,6 +267,7 @@ static const std::unordered_map<int, mapped_inst_t> table_map_to_common_type{
     {(int) EINST::vmem_other_simd_11, {WaveInstCategory::VMEM_OTHER_SIMD, 11}},
     {(int) EINST::vmem_other_simd_12, {WaveInstCategory::VMEM_OTHER_SIMD, 12}}
 };
+// clang-format on
 
 mapped_inst_t map_to_common_type(int einst, int dprate, int derate)
 {

--- a/projects/rocprof-trace-decoder/source/gfx11/gfx11wave.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx11/gfx11wave.cpp
@@ -21,13 +21,13 @@
 // SOFTWARE.
 
 #include "gfx11wave.h"
+
 #include <algorithm>
 #include <cassert>
-#include <utility>
-#include <vector>
-
 #include <cstddef>
 #include <new>
+#include <utility>
+#include <vector>
 
 typedef gfx10::Token Token;
 
@@ -152,10 +152,10 @@ enum EINST
 };
 
 // clang-format off
-using InstructionTable = std::unordered_map<int, mapped_inst_t>;
-alignas(InstructionTable) static std::byte table_map_to_common_type_storage[sizeof(InstructionTable)];
-static const InstructionTable& table_map_to_common_type =
-    *::new (static_cast<void*>(table_map_to_common_type_storage)) InstructionTable{
+using instruction_table_t = std::unordered_map<int, mapped_inst_t>;
+alignas(instruction_table_t) static std::byte table_map_to_common_type_storage[sizeof(instruction_table_t)];
+static const instruction_table_t& table_map_to_common_type =
+    *::new (static_cast<void*>(table_map_to_common_type_storage)) instruction_table_t{
     {(int) EINST::salu,               {WaveInstCategory::SALU, 1}            },
     {(int) EINST::smem_rd,            {WaveInstCategory::SMEM, 1}            },
     {(int) EINST::smem_wr,            {WaveInstCategory::SMEM, 1}            },

--- a/projects/rocprof-trace-decoder/source/gfx12/gfx12wave.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx12/gfx12wave.cpp
@@ -26,6 +26,9 @@
 #include <utility>
 #include <vector>
 
+#include <cstddef>
+#include <new>
+
 typedef gfx10::Token Token;
 
 namespace gfx12
@@ -151,7 +154,11 @@ enum EINST
     einst_final
 };
 
-static const std::unordered_map<int, mapped_inst_t> table_map_to_common_type{
+// clang-format off
+using InstructionTable = std::unordered_map<int, mapped_inst_t>;
+alignas(InstructionTable) static std::byte table_map_to_common_type_storage[sizeof(InstructionTable)];
+static const InstructionTable& table_map_to_common_type =
+    *::new (static_cast<void*>(table_map_to_common_type_storage)) InstructionTable{
     {(int) EINST::salu,              {WaveInstCategory::SALU, 1}           },
     {(int) EINST::smem_rd,           {WaveInstCategory::SMEM, 1}           },
     {(int) EINST::smem_wr,           {WaveInstCategory::SMEM, 1}           },
@@ -270,6 +277,7 @@ static const std::unordered_map<int, mapped_inst_t> table_map_to_common_type{
     {(int) EINST::flat_other_simd_5, {WaveInstCategory::FLAT_OTHER_SIMD, 5}},
     {(int) EINST::flat_other_simd_6, {WaveInstCategory::FLAT_OTHER_SIMD, 6}}
 };
+// clang-format on
 
 mapped_inst_t map_to_common_type(int einst, int dprate, int derate)
 {

--- a/projects/rocprof-trace-decoder/source/gfx12/gfx12wave.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx12/gfx12wave.cpp
@@ -21,13 +21,13 @@
 // SOFTWARE.
 
 #include "gfx12wave.h"
+
 #include <algorithm>
 #include <cassert>
-#include <utility>
-#include <vector>
-
 #include <cstddef>
 #include <new>
+#include <utility>
+#include <vector>
 
 typedef gfx10::Token Token;
 
@@ -155,10 +155,10 @@ enum EINST
 };
 
 // clang-format off
-using InstructionTable = std::unordered_map<int, mapped_inst_t>;
-alignas(InstructionTable) static std::byte table_map_to_common_type_storage[sizeof(InstructionTable)];
-static const InstructionTable& table_map_to_common_type =
-    *::new (static_cast<void*>(table_map_to_common_type_storage)) InstructionTable{
+using instruction_table_t = std::unordered_map<int, mapped_inst_t>;
+alignas(instruction_table_t) static std::byte table_map_to_common_type_storage[sizeof(instruction_table_t)];
+static const instruction_table_t& table_map_to_common_type =
+    *::new (static_cast<void*>(table_map_to_common_type_storage)) instruction_table_t{
     {(int) EINST::salu,              {WaveInstCategory::SALU, 1}           },
     {(int) EINST::smem_rd,           {WaveInstCategory::SMEM, 1}           },
     {(int) EINST::smem_wr,           {WaveInstCategory::SMEM, 1}           },

--- a/projects/rocprof-trace-decoder/source/handle.hpp
+++ b/projects/rocprof-trace-decoder/source/handle.hpp
@@ -25,9 +25,12 @@
 
 #include <array>
 #include <condition_variable>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <new>
+#include <shared_mutex>
 #include <unordered_map>
 
 #ifndef ROCPROF_TRACE_DECODER_COMGR_DISABLED
@@ -132,8 +135,10 @@ public:
 
     static std::unordered_map<uint64_t, std::shared_ptr<HandleData>>& get_map()
     {
-        static std::unordered_map<uint64_t, std::shared_ptr<HandleData>> map;
-        return map;
+        using Map = std::unordered_map<uint64_t, std::shared_ptr<HandleData>>;
+        alignas(Map) static std::byte storage[sizeof(Map)];
+        static Map* map = ::new (static_cast<void*>(storage)) Map{};
+        return *map;
     }
 
     static ReadLock<HandleData> get_read_handle(rocprof_trace_decoder_handle_t handle)

--- a/projects/rocprof-trace-decoder/source/handle.hpp
+++ b/projects/rocprof-trace-decoder/source/handle.hpp
@@ -135,9 +135,9 @@ public:
 
     static std::unordered_map<uint64_t, std::shared_ptr<HandleData>>& get_map()
     {
-        using Map = std::unordered_map<uint64_t, std::shared_ptr<HandleData>>;
-        alignas(Map) static std::byte storage[sizeof(Map)];
-        static Map* map = ::new (static_cast<void*>(storage)) Map{};
+        using handle_data_map_t = std::unordered_map<uint64_t, std::shared_ptr<HandleData>>;
+        alignas(handle_data_map_t) static std::byte storage[sizeof(handle_data_map_t)];
+        static handle_data_map_t* map = ::new (static_cast<void*>(storage)) handle_data_map_t{};
         return *map;
     }
 

--- a/projects/rocprof-trace-decoder/source/mi400/mi400wave.cpp
+++ b/projects/rocprof-trace-decoder/source/mi400/mi400wave.cpp
@@ -26,6 +26,9 @@
 #include <utility>
 #include <vector>
 
+#include <cstddef>
+#include <new>
+
 typedef gfx10::Token Token;
 
 namespace mi400
@@ -205,7 +208,11 @@ enum EINST
     einst_final
 };
 
-static std::unordered_map<int, mapped_inst_t> table_map_to_common_type{
+// clang-format off
+using InstructionTable = std::unordered_map<int, mapped_inst_t>;
+alignas(InstructionTable) static std::byte table_map_to_common_type_storage[sizeof(InstructionTable)];
+static InstructionTable& table_map_to_common_type =
+    *::new (static_cast<void*>(table_map_to_common_type_storage)) InstructionTable{
     {(int) EINST::salu,                   {WaveInstCategory::SALU, 1}           },
     {(int) EINST::smem_rd,                {WaveInstCategory::SMEM, 1}           },
     {(int) EINST::smem_wr,                {WaveInstCategory::SMEM, 1}           },
@@ -347,6 +354,7 @@ static std::unordered_map<int, mapped_inst_t> table_map_to_common_type{
     {(int) EINST::reserved_valu_16,       {WaveInstCategory::VALU, 16}          },
     {(int) EINST::reserved_valu_32,       {WaveInstCategory::VALU, 32}          }
 };
+// clang-format on
 
 mapped_inst_t map_to_common_type(int einst, int trans2)
 {

--- a/projects/rocprof-trace-decoder/source/mi400/mi400wave.cpp
+++ b/projects/rocprof-trace-decoder/source/mi400/mi400wave.cpp
@@ -21,13 +21,13 @@
 // SOFTWARE.
 
 #include "mi400wave.h"
+
 #include <algorithm>
 #include <cassert>
-#include <utility>
-#include <vector>
-
 #include <cstddef>
 #include <new>
+#include <utility>
+#include <vector>
 
 typedef gfx10::Token Token;
 
@@ -209,10 +209,10 @@ enum EINST
 };
 
 // clang-format off
-using InstructionTable = std::unordered_map<int, mapped_inst_t>;
-alignas(InstructionTable) static std::byte table_map_to_common_type_storage[sizeof(InstructionTable)];
-static InstructionTable& table_map_to_common_type =
-    *::new (static_cast<void*>(table_map_to_common_type_storage)) InstructionTable{
+using instruction_table_t = std::unordered_map<int, mapped_inst_t>;
+alignas(instruction_table_t) static std::byte table_map_to_common_type_storage[sizeof(instruction_table_t)];
+static instruction_table_t& table_map_to_common_type =
+    *::new (static_cast<void*>(table_map_to_common_type_storage)) instruction_table_t{
     {(int) EINST::salu,                   {WaveInstCategory::SALU, 1}           },
     {(int) EINST::smem_rd,                {WaveInstCategory::SMEM, 1}           },
     {(int) EINST::smem_wr,                {WaveInstCategory::SMEM, 1}           },

--- a/projects/rocprof-trace-decoder/source/trie.cpp
+++ b/projects/rocprof-trace-decoder/source/trie.cpp
@@ -22,9 +22,18 @@
 
 #include "trie.h"
 
-Trie Trie::root_trie;
+#include <cstddef>
+#include <new>
 
-static const std::unordered_map<std::string, InstCategory> type_dict = {
+namespace
+{
+struct TrieEntry
+{
+    std::string_view instruction;
+    InstCategory type;
+};
+
+constexpr TrieEntry type_dict[] = {
     {"s_waitcnt",        InstCategory::IMMED},
     {"s_wait_idle",      InstCategory::IMMED},
     {"s_wait_dep",       InstCategory::SKIP },
@@ -147,25 +156,22 @@ static const std::unordered_map<std::string, InstCategory> type_dict = {
     {"image_m",          InstCategory::VMEM },
     {"image_g",          InstCategory::VMEM },
 };
+} // namespace
 
-InstCategory Trie::type_from_trie(const std::string_view inst)
+Trie::Trie()
+{
+    for (const auto& entry : type_dict) add_type(entry.instruction, entry.type);
+}
+
+InstCategory Trie::type_from_trie(const std::string_view inst) const
 {
     if (inst.find("v_") == 0) return InstCategory::VALU;
 
-    if (!bInit)
-    {
-        bInit = true;
-        for (auto& p : type_dict) add_type(p.first, p.second);
-    }
-
-    Trie* trie = this;
+    const Node* trie = &root;
     for (char c : inst)
     {
-        if (trie->paths.find(c) != trie->paths.end())
-        {
-            assert(trie != nullptr);
-            trie = trie->paths[c];
-        }
+        auto it = trie->paths.find(c);
+        if (it != trie->paths.end()) trie = it->second.get();
         if (trie->type != InstCategory::LAST) return trie->type;
     }
 
@@ -174,28 +180,21 @@ InstCategory Trie::type_from_trie(const std::string_view inst)
     return InstCategory::DONT_KNOW;
 }
 
-void Trie::add_type(const std::string& inst_header, InstCategory type)
+void Trie::add_type(std::string_view inst_header, InstCategory type)
 {
-    Trie* trie = this;
+    Node* trie = &root;
     for (char c : inst_header)
     {
-        assert(trie != nullptr);
-        if (trie->paths.find(c) == trie->paths.end())
-        {
-            Trie* new_trie = new Trie();
-            trie->paths[c] = new_trie;
-            trie = new_trie;
-        }
-        else { trie = trie->paths[c]; }
+        auto [it, inserted] = trie->paths.try_emplace(c);
+        if (inserted) it->second = std::make_unique<Node>();
+        trie = it->second.get();
     }
     trie->type = type;
 }
 
-Trie::~Trie()
+Trie& get_instruction_trie()
 {
-    for (auto& p : paths)
-    {
-        if (p.second != nullptr) delete p.second;
-        p.second = nullptr;
-    }
+    alignas(Trie) static std::byte storage[sizeof(Trie)];
+    static Trie* trie = ::new (static_cast<void*>(storage)) Trie{};
+    return *trie;
 }

--- a/projects/rocprof-trace-decoder/source/trie.h
+++ b/projects/rocprof-trace-decoder/source/trie.h
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <regex>
 #include <string>
 #include <string_view>
@@ -59,21 +60,21 @@ enum class InstCategory
 inline bool operator==(const InstCategory& cat, uint64_t value) { return static_cast<uint64_t>(cat) == value; }
 inline bool operator==(uint64_t value, const InstCategory& cat) { return static_cast<uint64_t>(cat) == value; }
 
+class Trie;
+Trie& get_instruction_trie();
+
 class Trie
 {
 public:
-    Trie() = default;
-    ~Trie();
+    Trie();
 
-    InstCategory type_from_trie(const std::string_view inst);
-
-    static Trie root_trie;
+    InstCategory type_from_trie(const std::string_view inst) const;
 
     static InstCategory inst_type(const std::string_view line, int gfxip)
     {
         if (line.find("branch") != std::string::npos) return InstCategory::BRANCH;
 
-        InstCategory type = root_trie.type_from_trie(line);
+        InstCategory type = get_instruction_trie().type_from_trie(line);
 
         if (type == InstCategory::VALU)
         {
@@ -96,9 +97,13 @@ public:
     }
 
 private:
-    void add_type(const std::string& inst_header, InstCategory type);
+    struct Node
+    {
+        InstCategory type = InstCategory::LAST;
+        std::unordered_map<char, std::unique_ptr<Node>> paths;
+    };
 
-    bool bInit = false;
-    InstCategory type = InstCategory::LAST;
-    std::unordered_map<char, Trie*> paths; //  Change to smart pointer
+    void add_type(std::string_view inst_header, InstCategory type);
+
+    Node root;
 };

--- a/projects/rocprof-trace-decoder/test/unit/CMakeLists.txt
+++ b/projects/rocprof-trace-decoder/test/unit/CMakeLists.txt
@@ -192,6 +192,10 @@ add_executable(unit_tests_logging rdna_logging_test.cpp)
 target_include_directories(unit_tests_logging PRIVATE ${SRC_DIR} ${INC_DIR})
 target_link_libraries(unit_tests_logging PRIVATE rocprof-trace-decoder-static GTest::gtest_main GTest::gmock_main)
 
+add_executable(api_lifetime_test api_lifetime_test.cpp)
+target_include_directories(api_lifetime_test PRIVATE ${SRC_DIR} ${INC_DIR})
+target_link_libraries(api_lifetime_test PRIVATE rocprof-trace-decoder-static)
+
 if(BUILD_MARKERS)
     find_package(LLVM REQUIRED CONFIG)
 
@@ -243,6 +247,9 @@ gtest_discover_tests(
     unit_tests_logging
     PROPERTIES LABELS "unit-tests;regular;logging" ENVIRONMENT "SQTT_LOGGING=1"
     TEST_PREFIX "logging/")
+
+add_test(NAME api-lifetime COMMAND api_lifetime_test)
+set_tests_properties(api-lifetime PROPERTIES LABELS "unit-tests;regular;lifetime")
 
 if(BUILD_MARKERS)
     gtest_discover_tests(

--- a/projects/rocprof-trace-decoder/test/unit/api_lifetime_test.cpp
+++ b/projects/rocprof-trace-decoder/test/unit/api_lifetime_test.cpp
@@ -1,0 +1,152 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "rocprof_trace_decoder/rocprof_trace_decoder.h"
+#include "trie.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <thread>
+
+namespace
+{
+rocprof_trace_decoder_handle_t global_handle{};
+int pre_main_status = 0;
+bool main_completed = false;
+
+uint64_t no_data(uint8_t** buffer, uint64_t* buffer_size, void*)
+{
+    *buffer = nullptr;
+    *buffer_size = 0;
+    return 0;
+}
+
+rocprofiler_thread_trace_decoder_status_t
+accept_trace(rocprofiler_thread_trace_decoder_record_type_t, void*, uint64_t, void*)
+{
+    return ROCPROFILER_THREAD_TRACE_DECODER_STATUS_SUCCESS;
+}
+
+rocprofiler_thread_trace_decoder_status_t
+empty_isa(char*, uint64_t* memory_size, uint64_t* isa_size, rocprofiler_thread_trace_decoder_pc_t, void*)
+{
+    *memory_size = 4;
+    *isa_size = 0;
+    return ROCPROFILER_THREAD_TRACE_DECODER_STATUS_SUCCESS;
+}
+
+bool exercise_handle(rocprof_trace_decoder_handle_t handle)
+{
+    if (rocprof_trace_decoder_set_isa_callback(handle, empty_isa, nullptr) !=
+        ROCPROFILER_THREAD_TRACE_DECODER_STATUS_SUCCESS)
+        return false;
+
+    if (rocprof_trace_decoder_set_se_data_callback(handle, no_data, nullptr) !=
+        ROCPROFILER_THREAD_TRACE_DECODER_STATUS_SUCCESS)
+        return false;
+
+    return rocprof_trace_decoder_parse(handle, nullptr, 0, accept_trace, nullptr) ==
+           ROCPROFILER_THREAD_TRACE_DECODER_STATUS_SUCCESS;
+}
+
+bool exercise_v1()
+{
+    return rocprof_trace_decoder_parse_data(no_data, accept_trace, empty_isa, nullptr) ==
+           ROCPROFILER_THREAD_TRACE_DECODER_STATUS_SUCCESS;
+}
+
+bool exercise_trie() { return Trie::inst_type("s_waitcnt vmcnt(0)", 10) == InstCategory::IMMED; }
+
+[[noreturn]] void fail_after_main(int status) { std::_Exit(status); }
+
+// Constructed before PreMainInitializer, so this destructor is registered
+// before any function-local decoder state initialized by PreMainInitializer.
+// It therefore runs after that ordinary static state would have been destroyed.
+struct PostMainVerifier
+{
+    ~PostMainVerifier()
+    {
+        if (!main_completed) fail_after_main(20);
+        if (!exercise_trie()) fail_after_main(21);
+        if (!exercise_handle(global_handle)) fail_after_main(22);
+        if (rocprof_trace_decoder_destroy_handle(global_handle) != ROCPROFILER_THREAD_TRACE_DECODER_STATUS_SUCCESS)
+            fail_after_main(23);
+
+        if (!exercise_v1()) fail_after_main(24);
+        if (!exercise_v1()) fail_after_main(25);
+
+        int worker_status = 0;
+        std::thread worker(
+            [&]()
+            {
+                rocprof_trace_decoder_handle_t new_handle{};
+                if (rocprof_trace_decoder_create_handle(&new_handle) != ROCPROFILER_THREAD_TRACE_DECODER_STATUS_SUCCESS)
+                {
+                    worker_status = 26;
+                    return;
+                }
+                if (!exercise_handle(new_handle))
+                {
+                    worker_status = 27;
+                    return;
+                }
+                if (rocprof_trace_decoder_destroy_handle(new_handle) != ROCPROFILER_THREAD_TRACE_DECODER_STATUS_SUCCESS)
+                    worker_status = 28;
+            }
+        );
+        worker.join();
+        if (worker_status != 0) fail_after_main(worker_status);
+    }
+};
+
+PostMainVerifier post_main_verifier{};
+
+struct PreMainInitializer
+{
+    PreMainInitializer()
+    {
+        if (rocprof_trace_decoder_create_handle(&global_handle) != ROCPROFILER_THREAD_TRACE_DECODER_STATUS_SUCCESS)
+        {
+            pre_main_status = 10;
+            return;
+        }
+        if (!exercise_handle(global_handle))
+        {
+            pre_main_status = 11;
+            return;
+        }
+        if (!exercise_v1()) pre_main_status = 12;
+        if (!exercise_trie()) pre_main_status = 13;
+    }
+};
+
+PreMainInitializer pre_main_initializer{};
+} // namespace
+
+int main()
+{
+    if (pre_main_status != 0) return pre_main_status;
+    if (!exercise_handle(global_handle)) return 14;
+
+    main_completed = true;
+    return 0;
+}


### PR DESCRIPTION
## Motivation

Rocprof-trace-decoder does not handle well functions called both before/after main() due to lifetime issues of static objects.
This PR addresses it.

JIRA ID : AIPROFSDK-1001

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
