### PR TITLE
fix(rocprofiler-systems): Add missing label_excludes for full test category

### DIFF
--- a/projects/rocprofiler-systems/tests/test_categories.yaml
+++ b/projects/rocprofiler-systems/tests/test_categories.yaml
@@ -101,6 +101,7 @@ test_categories:
     regex_includes:
       - ".*"
     regex_excludes: *_common_therock_regex_excludes
+    label_excludes: *_common_therock_labels_exclude
     added_supplementary_labels:
       - "full"
       - "all"


### PR DESCRIPTION
## Motivation

Fixes #8904 

When running TheRock CI (on TheRock) under `test_filter:full`, `thread-limit` tests ran. This should not be the case under any circumstance as they will fail.

Investigation shows that the `full` label was missing `common_therock_label_excludes`.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Add `common_therock_label_excludes` to the `full` test category.
Note that this category is meant for TheRock CI.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

N/A (local `TheRock CI` runs `standard` test type, which has the label. IIRC, only weeklies run `full`).
This must be fixed before then just incase.

## Test Result

<!-- Briefly summarize test outcomes. -->

N/A (see section above)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
