### PR TITLE
feat(hip): enable stream capture for hipStreamWaitValue/WriteValue/Ba…

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -3788,4 +3788,110 @@ hipError_t hipGraphExecBatchMemOpNodeSetParams(hipGraphExec_t hGraphExec, hipGra
   }
   HIP_RETURN(reinterpret_cast<hip::hipGraphBatchMemOpNode*>(clonedNode)->SetParams(nodeParams));
 }
+
+hipError_t capturehipStreamBatchMemOp(hipStream_t& stream, unsigned int& count,
+                                      hipStreamBatchMemOpParams*& paramArray,
+                                      unsigned int& flags) {
+  ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_API,
+          "[hipGraph] Current capture node StreamBatchMemOp on stream : %p", stream);
+  if (!hip::isValid(stream)) {
+    return hipErrorContextIsDestroyed;
+  }
+  if (paramArray == nullptr || count == 0 || count > 256 || flags != 0) {
+    return hipErrorInvalidValue;
+  }
+  hip::Stream* s = reinterpret_cast<hip::Stream*>(stream);
+
+  hipBatchMemOpNodeParams nodeParams{};
+  nodeParams.ctx = reinterpret_cast<hipCtx_t>(hip::getCurrentDevice());
+  nodeParams.count = count;
+  nodeParams.paramArray = paramArray;
+  nodeParams.flags = flags;
+
+  // hipGraphBatchMemOpNode deep-copies paramArray internally.
+  hip::GraphNode* node = new hip::hipGraphBatchMemOpNode(&nodeParams);
+
+  hipError_t status = ihipGraphAddNode(node, s->GetCaptureGraph(),
+                                       s->GetLastCapturedNodes().data(),
+                                       s->GetLastCapturedNodes().size());
+  if (status != hipSuccess) {
+    return status;
+  }
+  s->SetLastCapturedNode(node);
+  return hipSuccess;
+}
+
+// Stream-capture helpers for individual stream memory operations.
+// Each is captured as a single-element BatchMemOp node, matching CUDA behaviour
+// where cuStreamWaitValue32/64 and cuStreamWriteValue32/64 produce
+// CU_GRAPH_NODE_TYPE_BATCH_MEM_OP nodes when captured.
+static hipError_t captureStreamMemOp(hipStream_t stream, hipStreamBatchMemOpParams& op) {
+  if (!hip::isValid(stream)) {
+    return hipErrorContextIsDestroyed;
+  }
+  hip::Stream* s = reinterpret_cast<hip::Stream*>(stream);
+  hipBatchMemOpNodeParams nodeParams{};
+  nodeParams.ctx = reinterpret_cast<hipCtx_t>(hip::getCurrentDevice());
+  nodeParams.count = 1;
+  nodeParams.paramArray = &op;
+  nodeParams.flags = 0;
+
+  hip::GraphNode* node = new hip::hipGraphBatchMemOpNode(&nodeParams);
+  hipError_t status = ihipGraphAddNode(node, s->GetCaptureGraph(),
+                                       s->GetLastCapturedNodes().data(),
+                                       s->GetLastCapturedNodes().size());
+  if (status != hipSuccess) {
+    return status;
+  }
+  s->SetLastCapturedNode(node);
+  return hipSuccess;
+}
+
+hipError_t capturehipStreamWaitValue32(hipStream_t& stream, void*& ptr, uint32_t& value,
+                                       unsigned int& flags, uint32_t& /*mask*/) {
+  ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_API,
+          "[hipGraph] Current capture node StreamWaitValue32 on stream : %p", stream);
+  hipStreamBatchMemOpParams op{};
+  op.operation = hipStreamMemOpWaitValue32;
+  op.waitValue.address = reinterpret_cast<hipDeviceptr_t>(ptr);
+  op.waitValue.value = value;
+  op.waitValue.flags = flags;
+  return captureStreamMemOp(stream, op);
+}
+
+hipError_t capturehipStreamWaitValue64(hipStream_t& stream, void*& ptr, uint64_t& value,
+                                       unsigned int& flags, uint64_t& /*mask*/) {
+  ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_API,
+          "[hipGraph] Current capture node StreamWaitValue64 on stream : %p", stream);
+  hipStreamBatchMemOpParams op{};
+  op.operation = hipStreamMemOpWaitValue64;
+  op.waitValue.address = reinterpret_cast<hipDeviceptr_t>(ptr);
+  op.waitValue.value64 = value;
+  op.waitValue.flags = flags;
+  return captureStreamMemOp(stream, op);
+}
+
+hipError_t capturehipStreamWriteValue32(hipStream_t& stream, void*& ptr, uint32_t& value,
+                                        unsigned int& flags) {
+  ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_API,
+          "[hipGraph] Current capture node StreamWriteValue32 on stream : %p", stream);
+  hipStreamBatchMemOpParams op{};
+  op.operation = hipStreamMemOpWriteValue32;
+  op.writeValue.address = reinterpret_cast<hipDeviceptr_t>(ptr);
+  op.writeValue.value = value;
+  op.writeValue.flags = flags;
+  return captureStreamMemOp(stream, op);
+}
+
+hipError_t capturehipStreamWriteValue64(hipStream_t& stream, void*& ptr, uint64_t& value,
+                                        unsigned int& flags) {
+  ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_API,
+          "[hipGraph] Current capture node StreamWriteValue64 on stream : %p", stream);
+  hipStreamBatchMemOpParams op{};
+  op.operation = hipStreamMemOpWriteValue64;
+  op.writeValue.address = reinterpret_cast<hipDeviceptr_t>(ptr);
+  op.writeValue.value64 = value;
+  op.writeValue.flags = flags;
+  return captureStreamMemOp(stream, op);
+}
 }  // namespace hip

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -3851,6 +3851,9 @@ hipError_t capturehipStreamWaitValue32(hipStream_t& stream, void*& ptr, uint32_t
                                        unsigned int& flags, uint32_t& /*mask*/) {
   ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_API,
           "[hipGraph] Current capture node StreamWaitValue32 on stream : %p", stream);
+  // mask is not captured: hipStreamBatchMemOpParams has no mask field. CUDA ignores
+  // mask universally (cuStreamWaitValue32/64 do not support it — mask is AMD-only).
+  // The non-capture path passes mask to ihipStreamOperation directly.
   hipStreamBatchMemOpParams op{};
   op.operation = hipStreamMemOpWaitValue32;
   op.waitValue.address = reinterpret_cast<hipDeviceptr_t>(ptr);
@@ -3863,6 +3866,9 @@ hipError_t capturehipStreamWaitValue64(hipStream_t& stream, void*& ptr, uint64_t
                                        unsigned int& flags, uint64_t& /*mask*/) {
   ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_API,
           "[hipGraph] Current capture node StreamWaitValue64 on stream : %p", stream);
+  // mask is not captured: hipStreamBatchMemOpParams has no mask field. CUDA ignores
+  // mask universally (cuStreamWaitValue32/64 do not support it — mask is AMD-only).
+  // The non-capture path passes mask to ihipStreamOperation directly.
   hipStreamBatchMemOpParams op{};
   op.operation = hipStreamMemOpWaitValue64;
   op.waitValue.address = reinterpret_cast<hipDeviceptr_t>(ptr);

--- a/projects/clr/hipamd/src/hip_graph_capture.hpp
+++ b/projects/clr/hipamd/src/hip_graph_capture.hpp
@@ -101,4 +101,20 @@ hipError_t capturehipMallocAsync(hipStream_t stream, hipMemPool_t mem_pool, size
                                  void** dev_ptr);
 
 hipError_t capturehipFreeAsync(hipStream_t stream, void* dev_ptr);
+
+hipError_t capturehipStreamBatchMemOp(hipStream_t& stream, unsigned int& count,
+                                      hipStreamBatchMemOpParams*& paramArray,
+                                      unsigned int& flags);
+
+hipError_t capturehipStreamWaitValue32(hipStream_t& stream, void*& ptr, uint32_t& value,
+                                       unsigned int& flags, uint32_t& mask);
+
+hipError_t capturehipStreamWaitValue64(hipStream_t& stream, void*& ptr, uint64_t& value,
+                                       unsigned int& flags, uint64_t& mask);
+
+hipError_t capturehipStreamWriteValue32(hipStream_t& stream, void*& ptr, uint32_t& value,
+                                        unsigned int& flags);
+
+hipError_t capturehipStreamWriteValue64(hipStream_t& stream, void*& ptr, uint64_t& value,
+                                        unsigned int& flags);
 }  // namespace hip

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -3601,6 +3601,8 @@ class hipGraphBatchMemOpNode : public GraphNode {
 
   GraphNode* clone() const override { return new hipGraphBatchMemOpNode(*this); }
 
+  virtual bool GraphCaptureEnabled() override { return true; }
+
   hipError_t CreateCommand(hip::Stream* stream) override {
     hipError_t status = GraphNode::CreateCommand(stream);
     if (status != hipSuccess) {

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -3569,19 +3569,32 @@ class hipGraphExternalSemWaitNode : public GraphNode {
 class hipGraphBatchMemOpNode : public GraphNode {
   hipBatchMemOpNodeParams batchMemOpNodeParam_;
 
+  void copyParams(const hipBatchMemOpNodeParams* src) {
+    delete[] batchMemOpNodeParam_.paramArray;
+    batchMemOpNodeParam_ = *src;
+    if (src->paramArray && src->count > 0) {
+      // Deep-copy paramArray — caller's array may be freed before graph replay.
+      batchMemOpNodeParam_.paramArray = new hipStreamBatchMemOpParams[src->count];
+      std::memcpy(batchMemOpNodeParam_.paramArray, src->paramArray,
+                  src->count * sizeof(hipStreamBatchMemOpParams));
+    }
+  }
+
  protected:
   // Copy constructor is needed for cloning the node, but it should not be used for any other
   // purpose. To prevent accidental misuse, the copy-assignment operator is deleted.
   hipGraphBatchMemOpNode(const hipGraphBatchMemOpNode& rhs) : GraphNode(rhs) {
-    batchMemOpNodeParam_ = rhs.batchMemOpNodeParam_;
+    batchMemOpNodeParam_.paramArray = nullptr;
+    copyParams(&rhs.batchMemOpNodeParam_);
   }
 
  public:
   hipGraphBatchMemOpNode(const hipBatchMemOpNodeParams* pNodeParams)
       : GraphNode(hipGraphNodeTypeBatchMemOp, "solid", "rectangle", "BATCH_MEM_OP_NODE") {
-    batchMemOpNodeParam_ = *pNodeParams;
+    batchMemOpNodeParam_.paramArray = nullptr;
+    copyParams(pNodeParams);
   }
-  ~hipGraphBatchMemOpNode() {}
+  ~hipGraphBatchMemOpNode() { delete[] batchMemOpNodeParam_.paramArray; }
 
   // Delete copy-assignment operator to prevent accidental copies causing unexpected behaviors.
   hipGraphBatchMemOpNode& operator=(const hipGraphBatchMemOpNode&) = delete;
@@ -3607,7 +3620,7 @@ class hipGraphBatchMemOpNode : public GraphNode {
   }
 
   hipError_t SetParams(const hipBatchMemOpNodeParams* pNodeParams) {
-    std::memcpy(&batchMemOpNodeParam_, pNodeParams, sizeof(hipBatchMemOpNodeParams));
+    copyParams(pNodeParams);
     return hipSuccess;
   }
 };

--- a/projects/clr/hipamd/src/hip_stream_ops.cpp
+++ b/projects/clr/hipamd/src/hip_stream_ops.cpp
@@ -126,7 +126,8 @@ hipError_t ihipStreamOperation(hipStream_t stream, cl_command_type cmdType, void
 hipError_t hipStreamWaitValue32(hipStream_t stream, void* ptr, uint32_t value, unsigned int flags,
                                 uint32_t mask) {
   HIP_INIT_API(hipStreamWaitValue32, stream, ptr, value, mask, flags);
-  // NOTE: ptr corresponds to a HSA Signal memeory which is 64 bits.
+  STREAM_CAPTURE(hipStreamWaitValue32, stream, ptr, value, flags, mask);
+  // NOTE: ptr corresponds to a HSA Signal memory which is 64 bits.
   // 32 bit value and mask are converted to 64-bit values.
   HIP_RETURN_DURATION(ihipStreamOperation(stream, ROCCLR_COMMAND_STREAM_WAIT_VALUE, ptr, value,
                                           mask, flags, sizeof(uint32_t)));
@@ -135,6 +136,7 @@ hipError_t hipStreamWaitValue32(hipStream_t stream, void* ptr, uint32_t value, u
 hipError_t hipStreamWaitValue64(hipStream_t stream, void* ptr, uint64_t value, unsigned int flags,
                                 uint64_t mask) {
   HIP_INIT_API(hipStreamWaitValue64, stream, ptr, value, mask, flags);
+  STREAM_CAPTURE(hipStreamWaitValue64, stream, ptr, value, flags, mask);
   HIP_RETURN_DURATION(ihipStreamOperation(stream, ROCCLR_COMMAND_STREAM_WAIT_VALUE, ptr, value,
                                           mask, flags, sizeof(uint64_t)));
 }
@@ -142,8 +144,9 @@ hipError_t hipStreamWaitValue64(hipStream_t stream, void* ptr, uint64_t value, u
 hipError_t hipStreamWriteValue32(hipStream_t stream, void* ptr, uint32_t value,
                                  unsigned int flags) {
   HIP_INIT_API(hipStreamWriteValue32, stream, ptr, value, flags);
+  STREAM_CAPTURE(hipStreamWriteValue32, stream, ptr, value, flags);
   HIP_RETURN_DURATION(ihipStreamOperation(stream, ROCCLR_COMMAND_STREAM_WRITE_VALUE, ptr, value,
-                                          0,      // mask un-used set it to 0
+                                          0,      // mask unused
                                           flags,
                                           sizeof(uint32_t)));
 }
@@ -151,8 +154,9 @@ hipError_t hipStreamWriteValue32(hipStream_t stream, void* ptr, uint32_t value,
 hipError_t hipStreamWriteValue64(hipStream_t stream, void* ptr, uint64_t value,
                                  unsigned int flags) {
   HIP_INIT_API(hipStreamWriteValue64, stream, ptr, value, flags);
+  STREAM_CAPTURE(hipStreamWriteValue64, stream, ptr, value, flags);
   HIP_RETURN_DURATION(ihipStreamOperation(stream, ROCCLR_COMMAND_STREAM_WRITE_VALUE, ptr, value,
-                                          0,      // mask un-used set it to 0
+                                          0,      // mask unused
                                           flags,
                                           sizeof(uint64_t)));
 }
@@ -160,6 +164,7 @@ hipError_t hipStreamWriteValue64(hipStream_t stream, void* ptr, uint64_t value,
 hipError_t hipStreamBatchMemOp(hipStream_t stream, unsigned int count,
                                hipStreamBatchMemOpParams* paramArray, unsigned int flags) {
   HIP_INIT_API(hipStreamBatchMemOp, count, paramArray, flags);
+  STREAM_CAPTURE(hipStreamBatchMemOp, stream, count, paramArray, flags);
   HIP_RETURN_DURATION(
       ihipBatchMemOperation(stream, ROCCLR_COMMAND_BATCH_STREAM, count, paramArray, flags));
 }

--- a/projects/clr/rocclr/device/blitcl.cpp
+++ b/projects/clr/rocclr/device/blitcl.cpp
@@ -195,27 +195,59 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
     // TODO: Once the sequential for-loop fix lands in llvm-project/amd/device-libs/opencl/src/misc/amdblit.cl
     // (replacing get_global_id(0) with a for loop), revert this back to:
     //   __amd_batchMemOp(params, count);
+    //
+    // Local definitions mirroring BatchMemOpType and BatchMemOpParams from
+    // amd/device-libs/opencl/src/misc/amdblit.cl. Defined here because blitcl.cpp
+    // kernels are JIT-compiled by COMGR in OpenCL C 1.x mode, which does not have
+    // access to amdblit.cl's types. Values match hipStreamBatchMemOpType in hip_runtime_api.h.
+    typedef enum {
+      ROCCLR_STREAM_WAIT_VALUE_32  = 0x1,
+      ROCCLR_STREAM_WRITE_VALUE_32 = 0x2,
+      ROCCLR_STREAM_WAIT_VALUE_64  = 0x4,
+      ROCCLR_STREAM_WRITE_VALUE_64 = 0x5,
+    } RocclrBatchMemOpType;
+
+    // Mirrors BatchMemOpParams in amdblit.cl — uses __global ulong* instead of
+    // atomic_ulong* since atomic_ulong requires OpenCL C 2.0 unavailable here.
+    typedef union {
+      RocclrBatchMemOpType operation;
+      struct {
+        RocclrBatchMemOpType  operation;
+        __global ulong*       address;
+        union { uint value; ulong value64; };
+        uint                  flags;
+        __global ulong*       alias;
+      } waitValue;
+      struct {
+        RocclrBatchMemOpType  operation;
+        __global ulong*       address;
+        union { uint value; ulong value64; };
+        uint                  flags;
+        __global ulong*       alias;
+      } writeValue;
+      ulong pad[6];
+    } RocclrBatchMemOpParams;
     __kernel void __amd_rocclr_batchMemOp(__global void* params, uint count) {
-      __global BatchMemOpParams* p = (__global BatchMemOpParams*)params;
+      __global RocclrBatchMemOpParams* param = (__global RocclrBatchMemOpParams*)params;
       for (uint i = 0; i < count; i++) {
-        switch (p[i].operation) {
-          case STREAM_WAIT_VALUE_32:
-            __amd_streamOpsWait((__global atomic_uint*)p[i].waitValue.address, NULL,
-                                (uint)p[i].waitValue.value, (uint)p[i].waitValue.flags,
+        switch (param[i].operation) {
+          case ROCCLR_STREAM_WAIT_VALUE_32:
+            __amd_streamOpsWait((__global uint*)param[i].waitValue.address, NULL,
+                                (uint)param[i].waitValue.value, (uint)param[i].waitValue.flags,
                                 (ulong)~0UL);
             break;
-          case STREAM_WRITE_VALUE_32:
-            __amd_streamOpsWrite((__global atomic_uint*)p[i].writeValue.address, NULL,
-                                 (uint)p[i].writeValue.value);
+          case ROCCLR_STREAM_WRITE_VALUE_32:
+            __amd_streamOpsWrite((__global uint*)param[i].writeValue.address, NULL,
+                                 (uint)param[i].writeValue.value);
             break;
-          case STREAM_WAIT_VALUE_64:
-            __amd_streamOpsWait(NULL, (__global atomic_ulong*)p[i].waitValue.address,
-                                (ulong)p[i].waitValue.value64, (uint)p[i].waitValue.flags,
-                                (ulong)~0UL);
+          case ROCCLR_STREAM_WAIT_VALUE_64:
+            __amd_streamOpsWait(NULL, (__global ulong*)param[i].waitValue.address,
+                                param[i].waitValue.value64,
+                                (uint)param[i].waitValue.flags, (ulong)~0UL);
             break;
-          case STREAM_WRITE_VALUE_64:
-            __amd_streamOpsWrite(NULL, (__global atomic_ulong*)p[i].writeValue.address,
-                                 (ulong)p[i].writeValue.value64);
+          case ROCCLR_STREAM_WRITE_VALUE_64:
+            __amd_streamOpsWrite(NULL, (__global ulong*)param[i].writeValue.address,
+                                 param[i].writeValue.value64);
             break;
           default:
             break;

--- a/projects/clr/rocclr/device/blitcl.cpp
+++ b/projects/clr/rocclr/device/blitcl.cpp
@@ -192,8 +192,35 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
       __amd_copyBufferRectAligned(src, dst, srcRect, dstRect, size);
     }
 
+    // TODO: Once the sequential for-loop fix lands in llvm-project/amd/device-libs/opencl/src/misc/amdblit.cl
+    // (replacing get_global_id(0) with a for loop), revert this back to:
+    //   __amd_batchMemOp(params, count);
     __kernel void __amd_rocclr_batchMemOp(__global void* params, uint count) {
-      __amd_batchMemOp(params, count);
+      __global BatchMemOpParams* p = (__global BatchMemOpParams*)params;
+      for (uint i = 0; i < count; i++) {
+        switch (p[i].operation) {
+          case STREAM_WAIT_VALUE_32:
+            __amd_streamOpsWait((__global atomic_uint*)p[i].waitValue.address, NULL,
+                                (uint)p[i].waitValue.value, (uint)p[i].waitValue.flags,
+                                (ulong)~0UL);
+            break;
+          case STREAM_WRITE_VALUE_32:
+            __amd_streamOpsWrite((__global atomic_uint*)p[i].writeValue.address, NULL,
+                                 (uint)p[i].writeValue.value);
+            break;
+          case STREAM_WAIT_VALUE_64:
+            __amd_streamOpsWait(NULL, (__global atomic_ulong*)p[i].waitValue.address,
+                                (ulong)p[i].waitValue.value64, (uint)p[i].waitValue.flags,
+                                (ulong)~0UL);
+            break;
+          case STREAM_WRITE_VALUE_64:
+            __amd_streamOpsWrite(NULL, (__global atomic_ulong*)p[i].writeValue.address,
+                                 (ulong)p[i].writeValue.value64);
+            break;
+          default:
+            break;
+        }
+      }
     });
 
 const char* HipExtraSourceCode = BLIT_KERNELS(

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -3576,7 +3576,9 @@ bool KernelBlitManager::batchMemOps(const void* paramArray, size_t paramSize,
   size_t dim = 1;
 
   size_t globalWorkOffset[1] = {0};
-  size_t globalWorkSize[1] = {count};
+  // Launch a single work-item; the kernel loops over all ops sequentially.
+  // CUDA spec: ops execute in array order — globalWorkSize=1 enforces this.
+  size_t globalWorkSize[1] = {1};
   size_t localWorkSize[1] = {1};
 
   // Get constant buffer and copy the array of parameters

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -3581,9 +3581,14 @@ bool KernelBlitManager::batchMemOps(const void* paramArray, size_t paramSize,
   size_t globalWorkSize[1] = {1};
   size_t localWorkSize[1] = {1};
 
-  // Get constant buffer and copy the array of parameters
+  // During graph packet capture, allocate from the graph's stable kernarg pool so the
+  // address baked into the captured AQL packet remains valid on re-launch.
   constexpr bool kDirectVa = true;
-  auto constBuf = gpu().allocKernArg((count * paramSize), kCBAlignment);
+  bool isGraphPktCapturing =
+      gpu().command() != nullptr && gpu().command()->getPktCapturingState();
+  auto constBuf = isGraphPktCapturing
+      ? gpu().command()->getGraphKernArg(count * paramSize, kCBAlignment, dev().index())
+      : gpu().allocKernArg(count * paramSize, kCBAlignment);
   memcpy(constBuf, paramArray, (count * paramSize));
 
   setArgument(kernels_[blitType], 0, sizeof(cl_mem), constBuf, 0, nullptr, kDirectVa);

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -825,6 +825,9 @@ graph:
   Unit_hipGraphAddBatchMemOpNode_NegativeTsts:
     <<: *level_2
     tags: [node]
+  Unit_hipGraphBatchMemOpNode_AQLCapture:
+    <<: *level_2
+    tags: [node]
   Unit_hipGraphBatchMemOpNodeSetParams_NegativeTsts:
     <<: *level_2
     tags: [node]

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -825,8 +825,9 @@ graph:
   Unit_hipGraphAddBatchMemOpNode_NegativeTsts:
     <<: *level_2
     tags: [node]
-  Unit_hipGraphBatchMemOpNode_AQLCapture:
+  Unit_hipGraphBatchMemOpNode_WriteAndWait:
     <<: *level_2
+    disabled: [amd_windows, amd_wsl, nvidia]
     tags: [node]
   Unit_hipGraphBatchMemOpNodeSetParams_NegativeTsts:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/stream.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/stream.yaml
@@ -415,6 +415,10 @@ stream:
   Unit_hipStreamBatchMemOp_Negative_Tests:
     <<: *level_2
     tags: [memory]
+  Unit_hipStreamBatchMemOp_SequentialOrdering:
+    <<: *level_2
+    disabled: [amd_windows, amd_wsl, nvidia]
+    tags: [synchronization, memory]
   Unit_hipStreamWaitWriteValue32_Capture:
     <<: *level_2
     disabled: [amd_windows, amd_wsl, nvidia]

--- a/projects/hip-tests/catch/config/configs/unit/stream.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/stream.yaml
@@ -419,6 +419,10 @@ stream:
     <<: *level_2
     disabled: [amd_windows, amd_wsl, nvidia]
     tags: [synchronization, memory]
+  Unit_hipStreamBatchMemOp_SequentialOrdering_MultiGPU:
+    <<: *level_2
+    disabled: [amd_windows, amd_wsl, nvidia]
+    tags: [synchronization, memory, multigpu]
   Unit_hipStreamWaitWriteValue32_Capture:
     <<: *level_2
     disabled: [amd_windows, amd_wsl, nvidia]

--- a/projects/hip-tests/catch/config/configs/unit/stream.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/stream.yaml
@@ -415,6 +415,15 @@ stream:
   Unit_hipStreamBatchMemOp_Negative_Tests:
     <<: *level_2
     tags: [memory]
+  Unit_hipStreamWaitWriteValue32_Capture:
+    <<: *level_2
+    tags: [synchronization]
+  Unit_hipStreamWaitWriteValue64_Capture:
+    <<: *level_2
+    tags: [synchronization]
+  Unit_hipStreamBatchMemOp_Capture:
+    <<: *level_2
+    tags: [synchronization, memory]
   Unit_hipStreamSetAttribute_hipStreamGetAttribute_Basic:
     <<: *level_2
     tags: [properties]

--- a/projects/hip-tests/catch/config/configs/unit/stream.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/stream.yaml
@@ -417,12 +417,15 @@ stream:
     tags: [memory]
   Unit_hipStreamWaitWriteValue32_Capture:
     <<: *level_2
+    disabled: [amd_windows, amd_wsl, nvidia]
     tags: [synchronization]
   Unit_hipStreamWaitWriteValue64_Capture:
     <<: *level_2
+    disabled: [amd_windows, amd_wsl, nvidia]
     tags: [synchronization]
   Unit_hipStreamBatchMemOp_Capture:
     <<: *level_2
+    disabled: [amd_windows, amd_wsl, nvidia]
     tags: [synchronization, memory]
   Unit_hipStreamSetAttribute_hipStreamGetAttribute_Basic:
     <<: *level_2

--- a/projects/hip-tests/catch/unit/graph/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/graph/CMakeLists.txt
@@ -64,6 +64,7 @@ set(TEST_SRC
   hipGraphExecBatchMemOpNodeSetParams.cc
   hipGraphAddBatchMemOpNode.cc
   hipGraphBatchMemOpNodeSetParams.cc
+  hipGraphBatchMemOpNodeCapture.cc
   hipDrvGraphExecMemcpyNodeSetParams.cc
   hipDrvGraphAddMemFreeNode.cc
   hipGraphAddNodeConcurrent.cc)

--- a/projects/hip-tests/catch/unit/graph/hipGraphBatchMemOpNodeCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphBatchMemOpNodeCapture.cc
@@ -40,7 +40,11 @@ HIP_TEST_CASE(Unit_hipGraphBatchMemOpNode_WriteAndWait) {
   if (attrErr != hipSuccess || waitValueSupport == 0) {
     HIP_SKIP_TEST("hipStreamWaitValue is not supported on this device.");
   }
-
+#if !HT_AMD
+  // hipMallocSignalMemory is AMD/ROCr-only; skip at runtime on non-AMD backends
+  // so that devPtr=0 is never passed to hipMemset/hipMemcpy.
+  HIP_SKIP_TEST("hipMallocSignalMemory is not supported on non-AMD backends.");
+#endif
   hipCtx_t ctx;
   HIP_CHECK(hipCtxCreate(&ctx, 0, device));
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphBatchMemOpNodeCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphBatchMemOpNodeCapture.cc
@@ -20,11 +20,8 @@
 /**
  * Test Description
  * ------------------------
- * - Verify that hipGraphBatchMemOpNode (WriteValue32 + WaitValue32) is AQL-captured
- *   during hipGraphInstantiate and produces the correct result after hipGraphLaunch.
- *   This validates that GraphCaptureEnabled() returns true for hipGraphBatchMemOpNode
- *   so the blit kernel packet is pre-built at instantiation time and dispatched via
- *   the flat AQL packet path at launch.
+ * - Verify that hipGraphBatchMemOpNode with WriteValue32 + WaitValue32 produces the
+ *   correct result after hipGraphInstantiate and hipGraphLaunch.
  * Test source
  * ------------------------
  *    - unit/graph/hipGraphBatchMemOpNodeCapture.cc
@@ -32,7 +29,7 @@
  * ------------------------
  *    - HIP_VERSION >= 6.4
  */
-HIP_TEST_CASE(Unit_hipGraphBatchMemOpNode_AQLCapture) {
+HIP_TEST_CASE(Unit_hipGraphBatchMemOpNode_WriteAndWait) {
   hipDevice_t device;
   HIP_CHECK(hipDeviceGet(&device, 0));
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphBatchMemOpNodeCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphBatchMemOpNodeCapture.cc
@@ -46,8 +46,10 @@ HIP_TEST_CASE(Unit_hipGraphBatchMemOpNode_WriteAndWait) {
 
   // Allocate signal memory required for wait-value operations on AMD
   hipDeviceptr_t devPtr = 0;
+#if HT_AMD
   HIP_CHECK(hipExtMallocWithFlags(reinterpret_cast<void**>(&devPtr), sizeof(uint64_t),
                                   hipMallocSignalMemory));
+#endif
   HIP_CHECK(hipMemset(reinterpret_cast<void*>(devPtr), 0, sizeof(uint64_t)));
 
   // Build batch: WriteValue32(1000) then WaitValue32(== 1000)
@@ -93,7 +95,9 @@ HIP_TEST_CASE(Unit_hipGraphBatchMemOpNode_WriteAndWait) {
   HIP_CHECK(hipGraphExecDestroy(graphExec));
   HIP_CHECK(hipGraphDestroy(graph));
   HIP_CHECK(hipStreamDestroy(stream));
+#if HT_AMD
   HIP_CHECK(hipFree(reinterpret_cast<void*>(devPtr)));
+#endif
   HIP_CHECK(hipCtxPopCurrent(&ctx));
   HIP_CHECK(hipCtxDestroy(ctx));
 }

--- a/projects/hip-tests/catch/unit/graph/hipGraphBatchMemOpNodeCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphBatchMemOpNodeCapture.cc
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip_test_common.hh>
+#include <hip_test_defgroups.hh>
+
+/**
+ * @addtogroup hipGraphAddBatchMemOpNode hipGraphAddBatchMemOpNode
+ * @{
+ * @ingroup GraphTest
+ * `hipError_t hipGraphAddBatchMemOpNode(hipGraphNode_t *phGraphNode, hipGraph_t
+ hGraph, const hipGraphNode_t *dependencies, size_t numDependencies, const
+ hipBatchMemOpNodeParams* nodeParams);`
+ * - Creates a batch memory operation node and adds it to a graph
+ */
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verify that hipGraphBatchMemOpNode (WriteValue32 + WaitValue32) is AQL-captured
+ *   during hipGraphInstantiate and produces the correct result after hipGraphLaunch.
+ *   This validates that GraphCaptureEnabled() returns true for hipGraphBatchMemOpNode
+ *   so the blit kernel packet is pre-built at instantiation time and dispatched via
+ *   the flat AQL packet path at launch.
+ * Test source
+ * ------------------------
+ *    - unit/graph/hipGraphBatchMemOpNodeCapture.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 6.4
+ */
+HIP_TEST_CASE(Unit_hipGraphBatchMemOpNode_AQLCapture) {
+  hipDevice_t device;
+  HIP_CHECK(hipDeviceGet(&device, 0));
+
+  // StreamWaitValue / SignalMemory not supported on all backends (e.g. Windows PAL)
+  int waitValueSupport = 0;
+  auto attrErr = hipDeviceGetAttribute(&waitValueSupport,
+                                       hipDeviceAttributeCanUseStreamWaitValue, 0);
+  if (attrErr != hipSuccess || waitValueSupport == 0) {
+    HIP_SKIP_TEST("hipStreamWaitValue is not supported on this device.");
+  }
+
+  hipCtx_t ctx;
+  HIP_CHECK(hipCtxCreate(&ctx, 0, device));
+
+  // Allocate signal memory required for wait-value operations on AMD
+  hipDeviceptr_t devPtr = 0;
+  HIP_CHECK(hipExtMallocWithFlags(reinterpret_cast<void**>(&devPtr), sizeof(uint64_t),
+                                  hipMallocSignalMemory));
+  HIP_CHECK(hipMemset(reinterpret_cast<void*>(devPtr), 0, sizeof(uint64_t)));
+
+  // Build batch: WriteValue32(1000) then WaitValue32(== 1000)
+  hipStreamBatchMemOpParams params[2] = {};
+  params[0].operation          = hipStreamMemOpWriteValue32;
+  params[0].writeValue.address = devPtr;
+  params[0].writeValue.value   = 1000;
+  params[0].writeValue.flags   = hipStreamWriteValueDefault;
+
+  params[1].operation          = hipStreamMemOpWaitValue32;
+  params[1].waitValue.address  = devPtr;
+  params[1].waitValue.value    = 1000;
+  params[1].waitValue.flags    = hipStreamWaitValueEq;
+
+  hipBatchMemOpNodeParams nodeParams = {};
+  nodeParams.ctx        = ctx;
+  nodeParams.count      = 2;
+  nodeParams.paramArray = params;
+  nodeParams.flags      = 0;
+
+  // Build graph with single BatchMemOp node
+  hipGraph_t graph;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  hipGraphNode_t node;
+  HIP_CHECK(hipGraphAddBatchMemOpNode(&node, graph, nullptr, 0, &nodeParams));
+
+  // Instantiate — AQL packet for batchMemOp blit kernel pre-built here
+  hipGraphExec_t graphExec;
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  // Launch and verify
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+  HIP_CHECK(hipGraphLaunch(graphExec, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  uint32_t result = 0;
+  HIP_CHECK(hipMemcpy(&result, reinterpret_cast<void*>(devPtr), sizeof(uint32_t),
+                      hipMemcpyDeviceToHost));
+  REQUIRE(result == 1000);
+
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipFree(reinterpret_cast<void*>(devPtr)));
+  HIP_CHECK(hipCtxPopCurrent(&ctx));
+  HIP_CHECK(hipCtxDestroy(ctx));
+}
+
+/**
+ * End doxygen group GraphTest.
+ * @}
+ */

--- a/projects/hip-tests/catch/unit/stream/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/stream/CMakeLists.txt
@@ -37,6 +37,7 @@ if(HIP_PLATFORM MATCHES "amd")
                hipStreamQuery_spt.cc
                hipStreamSynchronize_spt.cc
                hipStreamBatchMemOp.cc
+               hipStreamValueCapture.cc
                hipStreamPriorityAqlLog.cc
                # disabled on NVIDIA due to lack of hipStreamGetCaptureInfo_v2 in cuda 13.0+
                 hipStreamLegacy.cc

--- a/projects/hip-tests/catch/unit/stream/hipStreamBatchMemOp.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamBatchMemOp.cc
@@ -92,6 +92,73 @@ HIP_TEST_CASE(Unit_hipStreamBatchMemOp_Negative_Tests) {
   HIP_CHECK(hipStreamDestroy(stream));
 }
 /**
+ * Test Description
+ * ------------------------
+ * - Verify that hipStreamBatchMemOp executes ops sequentially in array order.
+ *   A write-after-wait dependency in the same batch (Write flag=1, Wait flag==1,
+ *   Write flag=0) must not race: the wait must observe the write before the reset.
+ *   This validates the globalWorkSize=1 fix in batchMemOps() that prevents
+ *   parallel work-items from racing writes against waits in the same batch.
+ * Test source
+ * ------------------------
+ *    - unit/stream/hipStreamBatchMemOp.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 6.4
+ */
+HIP_TEST_CASE(Unit_hipStreamBatchMemOp_SequentialOrdering) {
+  if (!streamWaitValueSupported()) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+  }
+
+  hipCtx_t ctx;
+  hipDevice_t device;
+  HIP_CHECK(hipDeviceGet(&device, 0));
+  HIP_CHECK(hipCtxCreate(&ctx, 0, device));
+
+  hipDeviceptr_t devPtr = 0;
+  HIP_CHECK(hipExtMallocWithFlags(reinterpret_cast<void**>(&devPtr), sizeof(uint64_t),
+                                  hipMallocSignalMemory));
+  *reinterpret_cast<uint64_t*>(devPtr) = 0;
+  HIP_CHECK(hipDeviceSynchronize());
+
+  // Batch: Write(1), Wait(==1), Write(0)
+  // If ops run in parallel, Write(0) can race ahead of Wait(==1) causing a deadlock.
+  // Sequential execution guarantees Write(1) completes before Wait(==1) is evaluated,
+  // and Wait(==1) completes before Write(0) resets the flag.
+  hipStreamBatchMemOpParams params[3] = {};
+  params[0].operation          = hipStreamMemOpWriteValue32;
+  params[0].writeValue.address = devPtr;
+  params[0].writeValue.value   = 1;
+  params[0].writeValue.flags   = hipStreamWriteValueDefault;
+
+  params[1].operation         = hipStreamMemOpWaitValue32;
+  params[1].waitValue.address = devPtr;
+  params[1].waitValue.value   = 1;
+  params[1].waitValue.flags   = hipStreamWaitValueEq;
+
+  params[2].operation          = hipStreamMemOpWriteValue32;
+  params[2].writeValue.address = devPtr;
+  params[2].writeValue.value   = 0;
+  params[2].writeValue.flags   = hipStreamWriteValueDefault;
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+  HIP_CHECK(hipStreamBatchMemOp(stream, 3, params, 0));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  uint32_t result = 0;
+  HIP_CHECK(hipMemcpy(&result, reinterpret_cast<void*>(devPtr), sizeof(uint32_t),
+                      hipMemcpyDeviceToHost));
+  REQUIRE(result == 0);
+
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipFree(reinterpret_cast<void*>(devPtr)));
+  HIP_CHECK(hipCtxPopCurrent(&ctx));
+  HIP_CHECK(hipCtxDestroy(ctx));
+}
+
+/**
  * End doxygen group StreamTest.
  * @}
  */

--- a/projects/hip-tests/catch/unit/stream/hipStreamBatchMemOp.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamBatchMemOp.cc
@@ -6,6 +6,20 @@
 
 #include <hip_test_common.hh>
 #include <hip_test_defgroups.hh>
+
+static bool streamWaitValueSupported() {
+  int device_num = 0;
+  HIP_CHECK(hipGetDeviceCount(&device_num));
+  for (int device_id = 0; device_id < device_num; ++device_id) {
+    HIP_CHECK(hipSetDevice(device_id));
+    int waitValueSupport = 0;
+    auto getAttributeError = hipDeviceGetAttribute(
+        &waitValueSupport, hipDeviceAttributeCanUseStreamWaitValue, device_id);
+    if (getAttributeError != hipSuccess) return false;
+    if (waitValueSupport == 1) return true;
+  }
+  return false;
+}
 /**
  * @addtogroup hipStreamBatchMemOp hipStreamBatchMemOp
  * @{
@@ -126,6 +140,8 @@ HIP_TEST_CASE(Unit_hipStreamBatchMemOp_SequentialOrdering) {
   // If ops run in parallel, Write(0) can race ahead of Wait(==1) causing a deadlock.
   // Sequential execution guarantees Write(1) completes before Wait(==1) is evaluated,
   // and Wait(==1) completes before Write(0) resets the flag.
+  // Run many iterations to stress the race — reproduces reliably on both SGPU and MGPU
+  // without the globalWorkSize=1 fix.
   hipStreamBatchMemOpParams params[3] = {};
   params[0].operation          = hipStreamMemOpWriteValue32;
   params[0].writeValue.address = devPtr;
@@ -144,18 +160,111 @@ HIP_TEST_CASE(Unit_hipStreamBatchMemOp_SequentialOrdering) {
 
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
-  HIP_CHECK(hipStreamBatchMemOp(stream, 3, params, 0));
-  HIP_CHECK(hipStreamSynchronize(stream));
 
-  uint32_t result = 0;
-  HIP_CHECK(hipMemcpy(&result, reinterpret_cast<void*>(devPtr), sizeof(uint32_t),
-                      hipMemcpyDeviceToHost));
-  REQUIRE(result == 0);
+  constexpr int kIterations = 100;
+  for (int i = 0; i < kIterations; i++) {
+    *reinterpret_cast<uint32_t*>(devPtr) = 0;
+    HIP_CHECK(hipStreamBatchMemOp(stream, 3, params, 0));
+    HIP_CHECK(hipStreamSynchronize(stream));
+
+    uint32_t result = 0;
+    HIP_CHECK(hipMemcpy(&result, reinterpret_cast<void*>(devPtr), sizeof(uint32_t),
+                        hipMemcpyDeviceToHost));
+    REQUIRE(result == 0);
+  }
 
   HIP_CHECK(hipStreamDestroy(stream));
   HIP_CHECK(hipFree(reinterpret_cast<void*>(devPtr)));
   HIP_CHECK(hipCtxPopCurrent(&ctx));
   HIP_CHECK(hipCtxDestroy(ctx));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verify that hipStreamBatchMemOp executes ops sequentially across multiple GPUs.
+ *   Each GPU runs the same Write(1)/Wait(==1)/Write(0) batch on its own signal memory.
+ *   This mirrors the original RCCL multi-GPU reproducer where the race caused hangs.
+ * Test source
+ * ------------------------
+ *    - unit/stream/hipStreamBatchMemOp.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 6.4
+ *    - At least 2 GPUs
+ */
+HIP_TEST_CASE(Unit_hipStreamBatchMemOp_SequentialOrdering_MultiGPU) {
+  if (!streamWaitValueSupported()) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+  }
+
+  int deviceCount = 0;
+  HIP_CHECK(hipGetDeviceCount(&deviceCount));
+  if (deviceCount < 2) {
+    HIP_SKIP_TEST("Test requires at least 2 GPUs");
+  }
+
+  // Fewer iterations than SGPU test — each iteration runs on all GPUs simultaneously
+  // so the race is triggered more frequently per iteration.
+  constexpr int kIterations = 100;
+
+  std::vector<hipDeviceptr_t> devPtrs(deviceCount, 0);
+  std::vector<hipStream_t> streams(deviceCount, nullptr);
+  std::vector<hipCtx_t> ctxs(deviceCount, nullptr);
+
+  for (int d = 0; d < deviceCount; d++) {
+    HIP_CHECK(hipSetDevice(d));
+    hipDevice_t device;
+    HIP_CHECK(hipDeviceGet(&device, d));
+    HIP_CHECK(hipCtxCreate(&ctxs[d], 0, device));
+    HIP_CHECK(hipExtMallocWithFlags(reinterpret_cast<void**>(&devPtrs[d]), sizeof(uint64_t),
+                                    hipMallocSignalMemory));
+    *reinterpret_cast<uint64_t*>(devPtrs[d]) = 0;
+    HIP_CHECK(hipStreamCreate(&streams[d]));
+  }
+  HIP_CHECK(hipDeviceSynchronize());
+
+  for (int i = 0; i < kIterations; i++) {
+    for (int d = 0; d < deviceCount; d++) {
+      HIP_CHECK(hipSetDevice(d));
+      *reinterpret_cast<uint32_t*>(devPtrs[d]) = 0;
+
+      hipStreamBatchMemOpParams params[3] = {};
+      params[0].operation          = hipStreamMemOpWriteValue32;
+      params[0].writeValue.address = devPtrs[d];
+      params[0].writeValue.value   = 1;
+      params[0].writeValue.flags   = hipStreamWriteValueDefault;
+
+      params[1].operation         = hipStreamMemOpWaitValue32;
+      params[1].waitValue.address = devPtrs[d];
+      params[1].waitValue.value   = 1;
+      params[1].waitValue.flags   = hipStreamWaitValueEq;
+
+      params[2].operation          = hipStreamMemOpWriteValue32;
+      params[2].writeValue.address = devPtrs[d];
+      params[2].writeValue.value   = 0;
+      params[2].writeValue.flags   = hipStreamWriteValueDefault;
+
+      HIP_CHECK(hipStreamBatchMemOp(streams[d], 3, params, 0));
+    }
+
+    for (int d = 0; d < deviceCount; d++) {
+      HIP_CHECK(hipSetDevice(d));
+      HIP_CHECK(hipStreamSynchronize(streams[d]));
+      uint32_t result = 0;
+      HIP_CHECK(hipMemcpy(&result, reinterpret_cast<void*>(devPtrs[d]), sizeof(uint32_t),
+                          hipMemcpyDeviceToHost));
+      REQUIRE(result == 0);
+    }
+  }
+
+  for (int d = 0; d < deviceCount; d++) {
+    HIP_CHECK(hipSetDevice(d));
+    HIP_CHECK(hipStreamDestroy(streams[d]));
+    HIP_CHECK(hipFree(reinterpret_cast<void*>(devPtrs[d])));
+    HIP_CHECK(hipCtxPopCurrent(&ctxs[d]));
+    HIP_CHECK(hipCtxDestroy(ctxs[d]));
+  }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/stream/hipStreamBatchMemOp.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamBatchMemOp.cc
@@ -258,12 +258,13 @@ HIP_TEST_CASE(Unit_hipStreamBatchMemOp_SequentialOrdering_MultiGPU) {
     }
   }
 
-  for (int d = 0; d < deviceCount; d++) {
+for (int d = deviceCount - 1; d >= 0; d--) {
     HIP_CHECK(hipSetDevice(d));
     HIP_CHECK(hipStreamDestroy(streams[d]));
     HIP_CHECK(hipFree(reinterpret_cast<void*>(devPtrs[d])));
-    HIP_CHECK(hipCtxPopCurrent(&ctxs[d]));
-    HIP_CHECK(hipCtxDestroy(ctxs[d]));
+    hipCtx_t popped = nullptr;
+    HIP_CHECK(hipCtxPopCurrent(&popped));
+    HIP_CHECK(hipCtxDestroy(popped]));
   }
 }
 

--- a/projects/hip-tests/catch/unit/stream/hipStreamBatchMemOp.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamBatchMemOp.cc
@@ -264,7 +264,7 @@ for (int d = deviceCount - 1; d >= 0; d--) {
     HIP_CHECK(hipFree(reinterpret_cast<void*>(devPtrs[d])));
     hipCtx_t popped = nullptr;
     HIP_CHECK(hipCtxPopCurrent(&popped));
-    HIP_CHECK(hipCtxDestroy(popped]));
+    HIP_CHECK(hipCtxDestroy(popped));
   }
 }
 

--- a/projects/hip-tests/catch/unit/stream/hipStreamValueCapture.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamValueCapture.cc
@@ -7,6 +7,22 @@
 #include <hip_test_common.hh>
 #include <hip_test_defgroups.hh>
 
+static bool streamWaitValueSupported() {
+  int device_num = 0;
+  HIP_CHECK(hipGetDeviceCount(&device_num));
+  for (int device_id = 0; device_id < device_num; ++device_id) {
+    HIP_CHECK(hipSetDevice(device_id));
+    int waitValueSupport = 0;
+    auto getAttributeError = hipDeviceGetAttribute(
+        &waitValueSupport, hipDeviceAttributeCanUseStreamWaitValue, device_id);
+    if (getAttributeError != hipSuccess) {
+      return false;
+    }
+    if (waitValueSupport == 1) return true;
+  }
+  return false;
+}
+
 /**
  * @addtogroup hipStreamWaitValue32 hipStreamWaitValue32
  * @{
@@ -37,7 +53,8 @@ HIP_TEST_CASE(Unit_hipStreamWaitWriteValue32_Capture) {
   hipDeviceptr_t devPtr = 0;
   HIP_CHECK(hipExtMallocWithFlags(reinterpret_cast<void**>(&devPtr), sizeof(uint64_t),
                                   hipMallocSignalMemory));
-  HIP_CHECK(hipMemset(reinterpret_cast<void*>(devPtr), 0, sizeof(uint64_t)));
+  *reinterpret_cast<uint64_t*>(devPtr) = 0;
+  HIP_CHECK(hipDeviceSynchronize());
 
   hipStream_t captureStream;
   HIP_CHECK(hipStreamCreate(&captureStream));
@@ -92,7 +109,8 @@ HIP_TEST_CASE(Unit_hipStreamWaitWriteValue64_Capture) {
   hipDeviceptr_t devPtr = 0;
   HIP_CHECK(hipExtMallocWithFlags(reinterpret_cast<void**>(&devPtr), sizeof(uint64_t),
                                   hipMallocSignalMemory));
-  HIP_CHECK(hipMemset(reinterpret_cast<void*>(devPtr), 0, sizeof(uint64_t)));
+  *reinterpret_cast<uint64_t*>(devPtr) = 0;
+  HIP_CHECK(hipDeviceSynchronize());
 
   hipStream_t captureStream;
   HIP_CHECK(hipStreamCreate(&captureStream));
@@ -152,7 +170,8 @@ HIP_TEST_CASE(Unit_hipStreamBatchMemOp_Capture) {
   hipDeviceptr_t devPtr = 0;
   HIP_CHECK(hipExtMallocWithFlags(reinterpret_cast<void**>(&devPtr), sizeof(uint64_t),
                                   hipMallocSignalMemory));
-  HIP_CHECK(hipMemset(reinterpret_cast<void*>(devPtr), 0, sizeof(uint64_t)));
+  *reinterpret_cast<uint64_t*>(devPtr) = 0;
+  HIP_CHECK(hipDeviceSynchronize());
 
   // Batch: WriteValue32(0x1234) then WaitValue32(== 0x1234)
   hipStreamBatchMemOpParams params[2] = {};

--- a/projects/hip-tests/catch/unit/stream/hipStreamValueCapture.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamValueCapture.cc
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip_test_common.hh>
+#include <hip_test_defgroups.hh>
+
+/**
+ * @addtogroup hipStreamWaitValue32 hipStreamWaitValue32
+ * @{
+ * @ingroup StreamTest
+ * `hipError_t hipStreamWaitValue32(hipStream_t stream, void* ptr, uint32_t value,
+ *                                  unsigned int flags, uint32_t mask);`
+ * - Enqueues a wait on a memory location in the stream.
+ */
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verify that hipStreamWriteValue32 followed by hipStreamWaitValue32 are captured
+ *   as BatchMemOp graph nodes during stream capture and produce the correct result
+ *   after hipGraphLaunch.
+ * Test source
+ * ------------------------
+ *    - unit/stream/hipStreamValueCapture.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 6.4
+ */
+HIP_TEST_CASE(Unit_hipStreamWaitWriteValue32_Capture) {
+  if (!streamWaitValueSupported()) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+  }
+
+  hipDeviceptr_t devPtr = 0;
+  HIP_CHECK(hipExtMallocWithFlags(reinterpret_cast<void**>(&devPtr), sizeof(uint64_t),
+                                  hipMallocSignalMemory));
+  HIP_CHECK(hipMemset(reinterpret_cast<void*>(devPtr), 0, sizeof(uint64_t)));
+
+  hipStream_t captureStream;
+  HIP_CHECK(hipStreamCreate(&captureStream));
+
+  // Capture: write 0x42, then wait for 0x42
+  HIP_CHECK(hipStreamBeginCapture(captureStream, hipStreamCaptureModeGlobal));
+  HIP_CHECK(hipStreamWriteValue32(captureStream, reinterpret_cast<void*>(devPtr), 0x42,
+                                  hipStreamWriteValueDefault));
+  HIP_CHECK(hipStreamWaitValue32(captureStream, reinterpret_cast<void*>(devPtr), 0x42,
+                                 hipStreamWaitValueEq, 0xFFFFFFFF));
+  hipGraph_t graph;
+  HIP_CHECK(hipStreamEndCapture(captureStream, &graph));
+
+  hipGraphExec_t graphExec;
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  hipStream_t launchStream;
+  HIP_CHECK(hipStreamCreate(&launchStream));
+  HIP_CHECK(hipGraphLaunch(graphExec, launchStream));
+  HIP_CHECK(hipStreamSynchronize(launchStream));
+
+  uint32_t result = 0;
+  HIP_CHECK(hipMemcpy(&result, reinterpret_cast<void*>(devPtr), sizeof(uint32_t),
+                      hipMemcpyDeviceToHost));
+  REQUIRE(result == 0x42);
+
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipStreamDestroy(launchStream));
+  HIP_CHECK(hipStreamDestroy(captureStream));
+  HIP_CHECK(hipFree(reinterpret_cast<void*>(devPtr)));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verify that hipStreamWriteValue64 followed by hipStreamWaitValue64 are captured
+ *   as BatchMemOp graph nodes during stream capture and produce the correct result
+ *   after hipGraphLaunch.
+ * Test source
+ * ------------------------
+ *    - unit/stream/hipStreamValueCapture.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 6.4
+ */
+HIP_TEST_CASE(Unit_hipStreamWaitWriteValue64_Capture) {
+  if (!streamWaitValueSupported()) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+  }
+
+  hipDeviceptr_t devPtr = 0;
+  HIP_CHECK(hipExtMallocWithFlags(reinterpret_cast<void**>(&devPtr), sizeof(uint64_t),
+                                  hipMallocSignalMemory));
+  HIP_CHECK(hipMemset(reinterpret_cast<void*>(devPtr), 0, sizeof(uint64_t)));
+
+  hipStream_t captureStream;
+  HIP_CHECK(hipStreamCreate(&captureStream));
+
+  HIP_CHECK(hipStreamBeginCapture(captureStream, hipStreamCaptureModeGlobal));
+  HIP_CHECK(hipStreamWriteValue64(captureStream, reinterpret_cast<void*>(devPtr),
+                                  0xCAFEBABECAFEBABEULL, hipStreamWriteValueDefault));
+  HIP_CHECK(hipStreamWaitValue64(captureStream, reinterpret_cast<void*>(devPtr),
+                                 0xCAFEBABECAFEBABEULL, hipStreamWaitValueEq,
+                                 0xFFFFFFFFFFFFFFFFULL));
+  hipGraph_t graph;
+  HIP_CHECK(hipStreamEndCapture(captureStream, &graph));
+
+  hipGraphExec_t graphExec;
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  hipStream_t launchStream;
+  HIP_CHECK(hipStreamCreate(&launchStream));
+  HIP_CHECK(hipGraphLaunch(graphExec, launchStream));
+  HIP_CHECK(hipStreamSynchronize(launchStream));
+
+  uint64_t result = 0;
+  HIP_CHECK(hipMemcpy(&result, reinterpret_cast<void*>(devPtr), sizeof(uint64_t),
+                      hipMemcpyDeviceToHost));
+  REQUIRE(result == 0xCAFEBABECAFEBABEULL);
+
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipStreamDestroy(launchStream));
+  HIP_CHECK(hipStreamDestroy(captureStream));
+  HIP_CHECK(hipFree(reinterpret_cast<void*>(devPtr)));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verify that hipStreamBatchMemOp (WriteValue32 + WaitValue32) is captured
+ *   as a BatchMemOpNode during stream capture and produces the correct result
+ *   after hipGraphLaunch, with ops executing sequentially in array order.
+ * Test source
+ * ------------------------
+ *    - unit/stream/hipStreamValueCapture.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 6.4
+ */
+HIP_TEST_CASE(Unit_hipStreamBatchMemOp_Capture) {
+  if (!streamWaitValueSupported()) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+  }
+
+  hipCtx_t ctx;
+  hipDevice_t device;
+  HIP_CHECK(hipDeviceGet(&device, 0));
+  HIP_CHECK(hipCtxCreate(&ctx, 0, device));
+
+  hipDeviceptr_t devPtr = 0;
+  HIP_CHECK(hipExtMallocWithFlags(reinterpret_cast<void**>(&devPtr), sizeof(uint64_t),
+                                  hipMallocSignalMemory));
+  HIP_CHECK(hipMemset(reinterpret_cast<void*>(devPtr), 0, sizeof(uint64_t)));
+
+  // Batch: WriteValue32(0x1234) then WaitValue32(== 0x1234)
+  hipStreamBatchMemOpParams params[2] = {};
+  params[0].operation          = hipStreamMemOpWriteValue32;
+  params[0].writeValue.address = devPtr;
+  params[0].writeValue.value   = 0x1234;
+  params[0].writeValue.flags   = hipStreamWriteValueDefault;
+
+  params[1].operation         = hipStreamMemOpWaitValue32;
+  params[1].waitValue.address = devPtr;
+  params[1].waitValue.value   = 0x1234;
+  params[1].waitValue.flags   = hipStreamWaitValueEq;
+
+  hipStream_t captureStream;
+  HIP_CHECK(hipStreamCreate(&captureStream));
+
+  HIP_CHECK(hipStreamBeginCapture(captureStream, hipStreamCaptureModeGlobal));
+  HIP_CHECK(hipStreamBatchMemOp(captureStream, 2, params, 0));
+  hipGraph_t graph;
+  HIP_CHECK(hipStreamEndCapture(captureStream, &graph));
+
+  hipGraphExec_t graphExec;
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  hipStream_t launchStream;
+  HIP_CHECK(hipStreamCreate(&launchStream));
+  HIP_CHECK(hipGraphLaunch(graphExec, launchStream));
+  HIP_CHECK(hipStreamSynchronize(launchStream));
+
+  uint32_t result = 0;
+  HIP_CHECK(hipMemcpy(&result, reinterpret_cast<void*>(devPtr), sizeof(uint32_t),
+                      hipMemcpyDeviceToHost));
+  REQUIRE(result == 0x1234);
+
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipStreamDestroy(launchStream));
+  HIP_CHECK(hipStreamDestroy(captureStream));
+  HIP_CHECK(hipFree(reinterpret_cast<void*>(devPtr)));
+  HIP_CHECK(hipCtxPopCurrent(&ctx));
+  HIP_CHECK(hipCtxDestroy(ctx));
+}
+
+/**
+ * End doxygen group StreamTest.
+ * @}
+ */


### PR DESCRIPTION
…tchMemOp

- Add STREAM_CAPTURE hooks to hipStreamWaitValue32/64, hipStreamWriteValue32/64, and hipStreamBatchMemOp so they record BatchMemOp graph nodes during capture instead of executing immediately.
- Declare and implement capture handlers in hip_graph_capture.hpp/hip_graph.cpp.
- Fix hipGraphBatchMemOpNode to deep-copy paramArray to prevent dangling pointer on graph replay.
- Fix batchMemOps() globalWorkSize from count to 1 so ops execute sequentially in array order per CUDA spec.
- Inline sequential for-loop in __amd_rocclr_batchMemOp in blitcl.cpp to be self-contained until the fix lands in upstream llvm-project amdblit.cl.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

JIRA ID: AIRUNTIME-2528
<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
