### PR TITLE
docs(amdsmi): add pressure-testing-skills skill and mechanizable skill checks

### DIFF
--- a/projects/amdsmi/.claude/rules/project-layout.md
+++ b/projects/amdsmi/.claude/rules/project-layout.md
@@ -19,26 +19,50 @@ description: "Use when: reviewing API changes, adding/modifying amdsmi_* functio
 
 # API Cascade
 
-Changes to the public C API must propagate through all layers in order:
+## What Triggers the Cascade
+
+The full cascade applies when you **add or change a public function** (a new
+`amdsmi_*` signature, or a changed one). That is what the name-grep below can
+track across layers.
+
+Non-function public-API edits do **not** all cascade the same way:
+
+| Change | Cascade path |
+|--------|--------------|
+| New / changed `amdsmi_*` **function** | Full path below (name is grep-able in every name-bearing layer) |
+| New **enum value / struct field / macro** in `amdsmi.h` | Header + impl + regenerate wrapper; interface/CLI only if user-facing. Not name-grep-able per layer |
+| Bug fix or behavior change inside an existing function | Impl + tests; docs/changelog if user-visible. No new wrapper/CLI entry |
+| Doxygen / comment-only edit | Header (or docs) only |
+
+Changes to a **function** propagate through all layers in order:
 
 1. `include/amd_smi/amdsmi.h` — C header declaration
 2. `src/amd_smi/amd_smi.cc` — C++ implementation
-3. `tools/generator.py` — wrapper generator (parses header)
+3. `tools/generator.py` — wrapper generator (parses header; no per-function edit — verify by regenerating)
 4. `py-interface/amdsmi_wrapper.py` — **auto-generated, never edit manually**
 5. `py-interface/amdsmi_interface.py` — Python API
-6. `amdsmi_cli/amdsmi_commands.py` — CLI commands
+6. `amdsmi_cli/amdsmi_commands.py` — CLI commands (if user-facing)
 7. `docs/` — documentation
+8. `rust-interface/` and `goamdsmi_shim/` — bind `amdsmi_*` directly; update if the new function must reach Rust/Go consumers
 
 Regenerate the wrapper with `tools/update_wrapper.sh`
 
 ## Quick Check
 
+Greps only the five **name-bearing** layers. Layer 3 (`generator.py`) is a
+generic parser with no per-function entry (verify it instead by regenerating the
+wrapper), and layer 7 (`docs/`) is prose — check both separately, they are NOT
+covered by this grep.
+
 ```bash
 FUNC="amdsmi_get_gpu_new_feature"
-grep -n "$FUNC" include/amd_smi/amdsmi.h src/amd_smi/*.cc py-interface/amdsmi_wrapper.py py-interface/amdsmi_interface.py amdsmi_cli/*.py
+grep -n "$FUNC" include/amd_smi/amdsmi.h src/amd_smi/*.cc \
+  py-interface/amdsmi_wrapper.py py-interface/amdsmi_interface.py amdsmi_cli/*.py \
+  rust-interface/src/*.rs goamdsmi_shim/smiwrapper/*
 ```
 
-Missing results = cascade gap.
+Missing results in a name-bearing layer = cascade gap. A clean grep does **not**
+prove layers 3 and 7 are done.
 
 ## Per-Layer Checklist
 
@@ -51,6 +75,8 @@ Missing results = cascade gap.
 | `amdsmi_interface.py` | Python function exists, raises `AmdSmiException` on error |
 | `amdsmi_commands.py` | CLI exposes data if user-facing, JSON output includes field |
 | `docs/` | API reference updated |
+| `rust-interface/` | `pub fn amdsmi_*` binding added if the function must reach Rust consumers |
+| `goamdsmi_shim/` | `amdsmi_*` call added if the function must reach the Go shim |
 
 # Tools (`tools/`)
 

--- a/projects/amdsmi/.claude/skills/amdsmi-commit-and-pr-conventions/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-commit-and-pr-conventions/SKILL.md
@@ -24,7 +24,7 @@ correctly.
 |------|-------|
 | Type | One of `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert` |
 | Scope | `(amdsmi)` by default; a narrower lowercase scope is fine (`fix(cli): …`, `feat(fabric): …`) |
-| Mood | Imperative ("add", "fix", "remove" — not "added"/"fixes"/"fixing") |
+| Mood | Imperative, verb-first ("add", "fix", "remove" — not "added"/"fixes"/"fixing", and not a noun phrase like "More cleanup" or "status-string tests") |
 | Length | PR title 10–80 chars (bot limit); keep commit subjects ≤ 72 (git norm, safely under the cap) |
 | Punctuation | No trailing period |
 | Breaking | Append `!` before the colon (`feat(amdsmi)!: …`) for an ABI/behavior break |
@@ -34,6 +34,19 @@ Bad: `[AMD-SMI] Fixed the partition bug.` (legacy tag, past tense, period)
 
 **No `[AMD-SMI]` / `[ROCM-NNNNN]` tag** — the `[…]` form fails the bot's title
 regex. Ticket references live only in the PR's `JIRA ID` section (below).
+
+Self-check a subject (structure + length) before committing:
+
+```bash
+SUBJECT="fix(amdsmi): reject nullptr mode pointer in compute-partition getter"
+printf '%s' "$SUBJECT" | grep -qP '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z][a-z0-9_/-]*\))?!?: .+[^.]$' \
+  && [ "${#SUBJECT}" -le 72 ] && echo OK || echo 'FAIL: not type(scope): imperative, or ends in a period, or >72 chars'
+```
+
+The regex enforces the type list, a lowercase scope, no trailing period, and a
+body after the colon; the length test enforces the ≤ 72 cap. It cannot judge
+mood — a subject can pass the regex and still be past-tense or a noun phrase, so
+read the verb by eye (see the Mood row).
 
 ## Commit Message Body
 
@@ -128,6 +141,7 @@ of the bot's label logic above.
 |---------|-----|
 | Legacy `[AMD-SMI]` / `[ROCM-NNNNN]` tag in the title | Conventional Commits `type(amdsmi): …` (the `[…]` form fails the bot) |
 | Past-tense subject ("Fixed…", "Added…") | Imperative ("fix", "add") |
+| Noun-phrase subject ("More cleanup", "status-string tests") | Start with a verb ("clean up…", "add…") |
 | `ROCM-NNNNN` in commit body or code comment | PR `JIRA ID` section only |
 | Source change with no `test_*` / `*_test.*` file | Add a test in the same PR (bot blocks otherwise) |
 | `Resolves ROCM-NNNNN` as the only ticket ref | Use `JIRA ID: ROCM-NNNNN` or `Closes #N` (bot needs the prefix or `#`) |

--- a/projects/amdsmi/.claude/skills/pressure-testing-skills/SKILL.md
+++ b/projects/amdsmi/.claude/skills/pressure-testing-skills/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: pressure-testing-skills
+description: "Use when validating or hardening a SKILL.md, prompt, rule, or any agent-followed document — when you need proof it actually works, not just that it reads well. Runs a fresh subagent that follows the doc literally on a known-answer fixture, captures friction, and iterates to determinism before minimizing. Use after writing-skills produces a draft, or whenever a skill 'looks right' but hasn't been proven under an agent."
+---
+
+# Pressure-Testing Skills — amd-smi
+
+Empirically prove a skill (or prompt/rule/checklist) works by making a fresh
+subagent follow it **literally** on a fixture whose answers you already know, then
+iterate on the failures until the run is deterministic. Reading a skill tells you
+it's plausible. Only a literal run by a naive agent tells you it's correct.
+
+**Iron Law: A SKILL IS NOT DONE UNTIL A FRESH SUBAGENT, FOLLOWING IT VERBATIM ON
+A KNOWN-ANSWER FIXTURE, CATCHES EVERY PLANTED ISSUE WITH ZERO GUESSING AND NO
+BLOCKING FRICTION — WITHOUT INVENTING STEPS THE SKILL DIDN'T GIVE.**
+
+If the agent got the right answer by adding its own check, the skill failed —
+that check belongs in the skill. If it "ran clean" but missed a planted issue,
+the skill failed. If it had to guess which value to use, the skill failed.
+
+**REQUIRED BACKGROUND:** you must understand `writing-skills` (structure, CSO,
+token budget) and `dispatching-parallel-agents` (how to run subagents) first.
+
+## Why Literal + Naive + Known-Answer
+
+The whole method rests on three constraints — drop any one and the test lies:
+
+| Constraint | Drop it and… |
+|-----------|--------------|
+| **Literal** — agent runs the documented commands verbatim, invents nothing | A clever agent papers over gaps with its own reasoning; you ship a skill only experts can follow |
+| **Naive** — fresh subagent, no prior context, no domain memory | Your own knowledge leaks in and the skill looks clearer than it is |
+| **Known-answer** — fixture with a pre-written answer key | You can't tell "caught everything" from "got lucky / ran clean" |
+
+## The Loop
+
+```
+0. Build the fixture + answer key (the hardest and most important step)
+1. Snapshot the skill to a stable temp path  (vN)
+2. Dispatch a FRESH, correctly-tooled subagent — follow vN verbatim, invent nothing
+3. Collect: issues-caught-vs-answer-key  AND  friction log
+4. Fix the ROOT CAUSE of each miss / friction  → snapshot v(N+1)
+5. Repeat 2–4 until GREEN (stop condition below)
+6. Minimize: cut redundancy, re-test after EACH cut, revert any regression
+```
+
+### 0. Fixture + answer key
+
+You cannot grade a test with no answer key. Before iterating, write down every
+issue the fixture contains and the exact evidence that should surface it.
+
+- **Best fixture:** a real artifact with known defects (e.g. a `CHANGELOG.md`
+  on `develop` you already audited by hand). Real fixtures expose real ambiguity.
+- **Answer key:** a list like "F1: entry X is misfiled → commit `abc` merged after
+  pin `def`; F2: `### Fixed` is a disallowed heading; F3: deprecation under the
+  wrong section." Grade every run against it.
+- A skill with no fixture cannot be pressure-tested. If you can't build one, the
+  skill is probably too vague to be useful — fix that first.
+- **Prefer the LIVE state; historical replays carry time-anchored traps.** If the
+  skill resolves any bound from "now" (current tags, `origin/develop`, HEAD), a
+  checked-out *past* state gives meaningless results — the bound is anchored to the
+  present, not the fixture's era. In one run, auditing a pre-release commit bounded
+  a section by a pin that didn't exist yet, and the untagged-release fallback
+  (`origin/develop`) pointed at *today's* tip, so the "too new" check could never
+  fire and the audit ran clean while proving nothing. Use the live artifact as the
+  fixture, or freeze the time-relative inputs too — otherwise you test a mirage.
+- **Grade coverage against what the real task touches, not what the skill looks
+  at.** If the fixture's defects span the whole file but the skill only inspects
+  the top section, a literal run reports "clean" and is structurally blind to most
+  of the answer key. A scope mismatch between skill and task is itself a finding.
+
+### 1. Snapshot to a stable path
+
+Copy the skill under test to a temp path (`/tmp/<skill>-test/SKILL-vN.md`) and
+point the subagent at ONLY that path. Never point it at the file you're editing
+or an installed copy — a stale `.claude/skills/` copy will silently override your
+work. Tell the agent explicitly: "ignore any installed copy; use only this path."
+
+### 2. Dispatch a correctly-tooled, fresh subagent
+
+- **Tools must match what the skill's commands need.** A skill full of `git`/`gh`
+  shell commands tested by a no-terminal agent proves nothing — it will only catch
+  surface issues (headings, wording) and give false confidence on the real logic.
+  Use a terminal-capable general subagent for shell-based skills.
+- **Fresh context every iteration** so prior runs don't inflate apparent clarity.
+- Give it the fixture setup, the snapshot path, and the literal-follow rules.
+
+### 3. Collect two distinct signals
+
+Grade every run on both — they fail independently:
+
+| Signal | Question | A gap here means |
+|--------|----------|------------------|
+| **Coverage** | Did it catch every answer-key issue, using only documented commands? | The skill is missing a check → add it |
+| **Determinism** | Did it have to guess, interpret, or invent anything? | The skill is ambiguous → spell it out |
+
+"Ran clean with no errors" is **not** success. A command can exit 0, leak a
+swallowed traceback, and still produce a plausible-but-wrong bound. Ask for the
+friction log: every command that failed, was ambiguous, leaked an error, or forced
+a guess — quoted with its **exact command and actual output**. The friction log,
+not the verdict, is what drives the next iteration.
+
+**Absence of output is not proof.** A clean pass and a silently-broken run look
+identical — both print nothing. A check that greps a section and finds no problems,
+and a check that ran on *zero* input (wrong path, empty range, swallowed error),
+are indistinguishable from the outside. Make the skill emit a positive count
+("N items checked, 0 flagged"), and have the test agent confirm the check ran on
+real input, not an empty set, before trusting a clean result.
+
+### 4. Fix root causes, not symptoms
+
+Each friction item points at a real defect. Fix the cause:
+
+| Real example from a changelog-skill loop | Root-cause fix |
+|------------------------------------------|----------------|
+| Audit loop checked only the lower bound → false "all clear" | Check both bounds of the range |
+| `<V>`=`7.14.0` built tag `therock-7.14.0` (404) → silent `origin/develop` fallback | Document that tags drop the patch component |
+| `2>/dev/null` on `gh` didn't cover the `python3` in the pipe → leaked traceback | Move error handling to cover the whole pipe |
+| Agent doubted a correct verdict and nearly overrode it | Add the *why* so a skeptic trusts it (persuasion, not just rules) |
+| A clean placement audit and one that ran on zero commits looked identical | Emit a positive count ("N checked, 0 flagged") so a real pass is distinguishable |
+| Skill inspected only the top section; the task spanned the whole file | Match the skill's scope to the task, or make the scope an explicit choice |
+| Every rule was prose; the agent had to hand-derive a regex for each check | Give an enforced rule a copy-paste command/regex, not just a description |
+| A shortcut grep covered 5 of the 7 layers the doc listed, but read as complete | Make the shortcut cover every item the doc enumerates, or name what it skips |
+| "When X, do Y" with X ("changes to the public API") undefined → agent over-applied it | Define the trigger precisely; give the boundary cases (function vs enum vs comment) |
+| Fixture body was truncated with `...`, so whole body-rule classes couldn't be graded | Give the agent the COMPLETE artifact, never a paraphrase or excerpt |
+
+Silent-failure traps (`|| fallback`, `2>/dev/null`) are the most dangerous:
+they turn a wrong answer into a confident one. Make failures loud or document them.
+
+### 5. Stop condition (loop for REAL improvements, optimally)
+
+Stop when a literal run **catches every answer-key issue, with zero guessing, no
+blocking friction, and no invented steps.** Not before — "ran clean" is a trap.
+Not after — once it's deterministic and complete, more iterations just gold-plate.
+Each iteration must fix a concrete failure a subagent actually hit; if you can't
+name the failure, stop.
+
+### 6. Minimize last, and guard against regressions
+
+Only after GREEN, cut for size — and **re-test after every cut**, because a cut or
+a "cleaner" rewrite can regress:
+
+- Cut redundant tables, checklists, and restated conventions.
+- Self-verify cheap mechanical changes locally (run the new regex/command on the
+  fixture) before spending a subagent.
+- **A proven heuristic beats theoretical completeness.** In one loop a "more
+  correct" regex added false positives on the real fixture; the terse original had
+  zero. Reverting was the fix. Validate every change against the fixture; revert
+  anything that regresses, even if it looks smarter.
+
+## Test-Agent Prompt Template
+
+Reuse this skeleton for every iteration (fill the bracketed parts):
+
+```
+Follow this skill LITERALLY and run its commands verbatim. Do NOT use prior
+knowledge of [domain]. Do NOT add checks the skill doesn't instruct.
+
+Skill under test (ONLY source of truth): /tmp/<skill>-test/SKILL-vN.md
+Ignore any copy at .claude/skills/... — use only the path above.
+
+Setup: [worktree / fixture commands]
+Task:  [what to audit/produce using only the skill's documented procedure]
+
+Report back:
+1. Judgment calls — did you have to guess or interpret ANYTHING? (KEY QUESTION)
+2. Every issue found: exact text, responsible commit/line, which skill step
+   flagged it, the fix.
+3. Friction log — every command that failed, leaked an error, produced wrong
+   output, or was ambiguous. Quote exact command + actual output. Say so
+   explicitly if it ran clean with zero guessing. (MOST IMPORTANT)
+4. Verbatim key outputs.
+5. Exact commands run, trimmed. Then clean up: [worktree remove].
+Read-only. Do NOT edit the fixture or the skill.
+```
+
+The "KEY QUESTION" and "MOST IMPORTANT" labels matter — without them agents
+report a tidy verdict and bury the friction that you actually need.
+
+## Common Mistakes
+
+| Mistake | Why it breaks the test |
+|---------|------------------------|
+| Testing a shell-heavy skill with a no-terminal agent | Only surface issues surface; core logic untested → false pass |
+| No fixture / no answer key | Can't distinguish "caught everything" from "ran clean" |
+| Pointing the agent at the file you're editing or an installed copy | Stale copy silently overrides; you test the wrong text |
+| Accepting the verdict, skipping the friction log | You miss the ambiguities that make the next reader fail |
+| Treating "exit 0 / no errors" as success | Swallowed failures produce confident wrong answers |
+| Letting the agent invent its own checks and calling it a pass | The check isn't in the skill — the next agent won't have it |
+| Minimizing before it's correct, or not re-testing each cut | You shrink a broken skill, or a cut regresses silently |
+| Looping forever / gold-plating after GREEN | Diminishing returns; stop when deterministic and complete |
+| Using a historical/checked-out-past fixture for a skill with "now"-anchored bounds | Time-relative inputs resolve to the present → clean-but-meaningless run |
+| Trusting empty output as a pass | Clean pass and silently-broken run are indistinguishable without a positive count |
+| Grading only what the skill inspects, not what the task touches | Scope mismatch hides most of the answer key behind a "clean" verdict |
+| Feeding the agent a truncated or paraphrased fixture | Rules that need the full artifact (body wording, trailing lines) can't be graded |
+| Assuming a stated rule is enforceable without a command | Prose-only rules force the agent to invent a check; two agents check differently |
+| Trusting a shortcut check that lists fewer items than the doc | It reads as complete while silently skipping layers the doc enumerated |

--- a/projects/amdsmi/.claude/skills/writing-skills/SKILL.md
+++ b/projects/amdsmi/.claude/skills/writing-skills/SKILL.md
@@ -115,6 +115,11 @@ Run `wc -w SKILL.md` before committing.
 2. **GREEN:** Write the minimal skill addressing those specific failures. Re-run — agent should now comply.
 3. **REFACTOR:** Find new rationalizations, add explicit counters (rationalization table, red-flags list). Repeat until bulletproof.
 
+For a **technique/reference skill whose commands an agent must run** (not just a
+discipline rule), the single-pass RED-GREEN-REFACTOR above is not enough — iterate
+it as a loop against a known-answer fixture until a literal run is deterministic,
+then minimize. Use the `pressure-testing-skills` skill for that method.
+
 ## Discipline-Skill Hardening
 
 If the skill enforces a rule (TDD, verification, root-cause-first), add:


### PR DESCRIPTION
## Motivation

Consolidates three agent-documentation improvements produced while pressure-testing amd-smi's skills into a single reviewable change. Each commit is one idea.

## Technical Details

- **Add the `pressure-testing-skills` skill**. Validates a SKILL.md, prompt, or rule by running a fresh subagent that follows the doc literally on a known-answer fixture, captures friction, and iterates to determinism before minimizing. Cross-references `writing-skills`.
- **Scope the API-cascade trigger in `project-layout.md`**. Defines what triggers the cascade (new or changed function), adds a table for non-function edits, notes that the Quick Check grep only covers the five name-bearing layers, and adds `rust-interface` and `goamdsmi_shim` as cascade consumers.
- **Add mechanizable checks to the commit/PR skill**. A copy-paste title regex plus length test for the Conventional Commits structure and 72-char cap, plus a clarified imperative-mood rule that rejects noun-phrase subjects.

Docs-only: touches `.claude/` skill and rule files, with no library, CLI, or test code changed.

## Issue Tracking

JIRA ID : AILITOOLS-278

## Test Plan

Not applicable to runtime. The `pressure-testing-skills` skill itself is the validation method: each edited skill or rule was exercised by a fresh subagent on a fixture during development.

## Test Result

Skill and rule docs render correctly, and no code paths are affected.

## Submission Checklist

- [x] Docs-only change to `.claude/` agent files, with no code or ABI impact.
