### PR TITLE
kmd_driver_t: reject Windows multi-GPU configuration at attach time

### DIFF
--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -1323,6 +1323,15 @@ kmd_driver_t::check_version () const
         }
     }
 
+  /* Multi-GPU configurations are not supported on Windows.  */
+  if (m_agents.size () > 1)
+    {
+      warning ("GPU debugging on Windows supports only a single AMD GPU "
+	       "debug agent; %zu agents were detected.  GPU debugging will "
+	       "not be available.", m_agents.size ());
+      return AMD_DBGAPI_STATUS_ERROR_RESTRICTION;
+    }
+
   return AMD_DBGAPI_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
Multi-GPU configurations on Windows are a documented known limitation of the HIP SDK Debugger.  Rather than crash mid-session with an opaque fatal_error_t, detect the unsupported topology at the earliest opportunity (check_version(), called before enable_debug() and any GPU interaction) and return AMD_DBGAPI_STATUS_ERROR_RESTRICTION with a clear diagnostic.

ROCgdb already handles ERROR_RESTRICTION gracefully: it emits a warning and continues with CPU-only debugging.

Fixes: ROCM-9233

