### PR TITLE
fix(hip-tests): run fp8 tests on gfx950

### DIFF
--- a/projects/hip-tests/catch/unit/deviceLib/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/deviceLib/CMakeLists.txt
@@ -99,7 +99,7 @@ set(AMD_GFX940_SPEC_TEST_SRC
     fp8_fnuz.cc
 )
 
-set(AMD_GFX1200_SPEC_TEST_SRC
+set(AMD_OCP_TEST_SRC
     fp8_ocp.cc
 )
 
@@ -186,11 +186,11 @@ set_property(GLOBAL APPEND PROPERTY G_INSTALL_CUSTOM_TARGETS ${CMAKE_CURRENT_BIN
 # Accepted archs to compile this cmake file
 set(ACCEPTED_OFFLOAD_ARCHS gfx90a gfx942)
 set(ACCEPTED_GFX940_ARCH gfx942)
-set(ACCEPTED_GFX1200_ARCH gfx1200 gfx1201)
+set(ACCEPTED_OCP_ARCH gfx1200 gfx1201 gfx950)
 function(CheckAcceptedArchs OFFLOAD_ARCH_STR_LOCAL)
   set(ARCH_CHECK -1 PARENT_SCOPE)
   set(ARCH_GFX940 -1 PARENT_SCOPE)
-  set(ARCH_GFX1200 -1 PARENT_SCOPE)
+  set(ARCH_OCP -1 PARENT_SCOPE)
   string(REGEX MATCHALL "--offload-arch=gfx[0-9a-z]+" OFFLOAD_ARCH_LIST ${OFFLOAD_ARCH_STR_LOCAL})
   foreach(OFFLOAD_ARCH IN LISTS OFFLOAD_ARCH_LIST)
     string(REGEX MATCHALL "--offload-arch=(gfx[0-9a-z]+)" matches ${OFFLOAD_ARCH})
@@ -201,8 +201,8 @@ function(CheckAcceptedArchs OFFLOAD_ARCH_STR_LOCAL)
       if (CMAKE_MATCH_1 IN_LIST ACCEPTED_GFX940_ARCH)
         set(ARCH_GFX940 1 PARENT_SCOPE)
       endif()
-      if (CMAKE_MATCH_1 IN_LIST ACCEPTED_GFX1200_ARCH)
-        set(ARCH_GFX1200 1 PARENT_SCOPE)
+      if (CMAKE_MATCH_1 IN_LIST ACCEPTED_OCP_ARCH)
+        set(ARCH_OCP 1 PARENT_SCOPE)
       endif()
     endif()        # CMAKE_MATCH_COUNT
   endforeach()   # OFFLOAD_ARCH_LIST
@@ -217,7 +217,7 @@ if(HIP_PLATFORM MATCHES "amd")
   else()
     set(ARCH_CHECK -1)
     set(ARCH_GFX940 -1)
-    set(ARCH_GFX1200 -1)
+    set(ARCH_OCP -1)
   endif()
   set(TEST_SRC ${TEST_SRC} ${AMD_TEST_SRC})
   set_source_files_properties(bfloat16.cc PROPERTIES COMPILE_FLAGS "-DHIP_ENABLE_WARP_SYNC_BUILTINS")
@@ -240,8 +240,8 @@ if(HIP_PLATFORM MATCHES "amd")
   if(${ARCH_GFX940} GREATER_EQUAL 0)
     set(TEST_SRC ${TEST_SRC} ${AMD_GFX940_SPEC_TEST_SRC})
   endif()
-  if(${ARCH_GFX1200} GREATER_EQUAL 0)
-    set(TEST_SRC ${TEST_SRC} ${AMD_GFX1200_SPEC_TEST_SRC})
+  if(${ARCH_OCP} GREATER_EQUAL 0)
+    set(TEST_SRC ${TEST_SRC} ${AMD_OCP_TEST_SRC})
   endif()
   hip_add_exe_to_target(NAME UnitDeviceTests
                       TEST_SRC ${TEST_SRC}

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_ocp.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_ocp.cc
@@ -34,7 +34,7 @@ std::string arch_type() {
 #define FP8_OCP_SKIP_TEST                                                                          \
   std::string gfxName = arch_type();                                                               \
   if (!(OCP_SUPPORTED_ARCH(gfxName))) {                                                            \
-    HIP_SKIP_TEST("this test requires GFX1200.");                                                  \
+    HIP_SKIP_TEST("this test requires gfx950, gfx1200, or gfx1201 architecture.");                   \
   }
 
 #define __FP8_DEVICE__ __device__ static inline

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_ocp.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_ocp.cc
@@ -13,7 +13,7 @@
 
 /*
  * This catch test is meant for FP8 OCP conversions
- * tests only supported on gfx1200 and gfx1201 archs
+ * tests only supported on gfx950, gfx1200 and gfx1201 archs
  */
 
 static_assert(sizeof(unsigned int) == sizeof(float));
@@ -27,19 +27,20 @@ std::string arch_type() {
   return gfxName;
 }
 
-#define ARCH_TYPE_GFX1200(name)                                                                    \
-  (name.find("gfx1200") != std::string::npos) || (name.find("gfx1201") != std::string::npos)
+#define OCP_SUPPORTED_ARCH(name)                                                                   \
+  (name.find("gfx1200") != std::string::npos) || (name.find("gfx1201") != std::string::npos) ||    \
+      (name.find("gfx950") != std::string::npos)
 
 #define FP8_OCP_SKIP_TEST                                                                          \
   std::string gfxName = arch_type();                                                               \
-  if (!(ARCH_TYPE_GFX1200(gfxName))) {                                                             \
+  if (!(OCP_SUPPORTED_ARCH(gfxName))) {                                                            \
     HIP_SKIP_TEST("this test requires GFX1200.");                                                  \
   }
 
 #define __FP8_DEVICE__ __device__ static inline
 
 template <typename T> __FP8_DEVICE__ void e4m3_ocp_device(T* val) {
-#if (defined(__gfx1200__) || defined(__gfx1201__)) && __HIP_DEVICE_COMPILE__
+#if (defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx950__)) && __HIP_DEVICE_COMPILE__
   __hip_fp8_e4m3 tmp(*val);
   *val = tmp;
 #else
@@ -48,7 +49,7 @@ template <typename T> __FP8_DEVICE__ void e4m3_ocp_device(T* val) {
 }
 
 template <typename T> __FP8_DEVICE__ void e5m2_ocp_device(T* val) {
-#if (defined(__gfx1200__) || defined(__gfx1201__)) && __HIP_DEVICE_COMPILE__
+#if (defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx950__)) && __HIP_DEVICE_COMPILE__
   __hip_fp8_e5m2 tmp(*val);
   *val = tmp;
 #else
@@ -130,7 +131,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_fp8_ocp_compare_host_device, float, double) {
 }
 
 __FP8_DEVICE__ void e4m3_fp8x2_ocp_device(float2* val) {
-#if (defined(__gfx1200__) || defined(__gfx1201__)) && __HIP_DEVICE_COMPILE__
+#if (defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx950__)) && __HIP_DEVICE_COMPILE__
   __hip_fp8x2_e4m3 tmp(*val);
   *val = tmp;
 #else
@@ -139,7 +140,7 @@ __FP8_DEVICE__ void e4m3_fp8x2_ocp_device(float2* val) {
 }
 
 __FP8_DEVICE__ void e5m2_fp8x2_ocp_device(float2* val) {
-#if (defined(__gfx1200__) || defined(__gfx1201__)) && __HIP_DEVICE_COMPILE__
+#if (defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx950__)) && __HIP_DEVICE_COMPILE__
   __hip_fp8x2_e5m2 tmp(*val);
   *val = tmp;
 #else
@@ -282,7 +283,7 @@ HIP_TEST_CASE(Unit_fp8x2_ocp_split_compare) {
 }
 
 __FP8_DEVICE__ void e4m3_fp8x4_ocp_device(float4* val) {
-#if (defined(__gfx1200__) || defined(__gfx1201__)) && __HIP_DEVICE_COMPILE__
+#if (defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx950__)) && __HIP_DEVICE_COMPILE__
   __hip_fp8x4_e4m3 tmp(*val);
   *val = tmp;
 #else
@@ -291,7 +292,7 @@ __FP8_DEVICE__ void e4m3_fp8x4_ocp_device(float4* val) {
 }
 
 __FP8_DEVICE__ void e5m2_fp8x4_ocp_device(float4* val) {
-#if (defined(__gfx1200__) || defined(__gfx1201__)) && __HIP_DEVICE_COMPILE__
+#if (defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx950__)) && __HIP_DEVICE_COMPILE__
   __hip_fp8x4_e5m2 tmp(*val);
   *val = tmp;
 #else
@@ -384,7 +385,7 @@ HIP_TEST_CASE(Unit_fp8x4_ocp_split_compare) {
 __FP8_DEVICE__ bool e4m3_bool_ocp_device(float val) {
   bool x = false;
   float y = val;
-#if (defined(__gfx1200__) || defined(__gfx1201__)) && __HIP_DEVICE_COMPILE__
+#if (defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx950__)) && __HIP_DEVICE_COMPILE__
   __hip_fp8_e4m3 tmp(y);
   x = tmp;
 #else
@@ -396,7 +397,7 @@ __FP8_DEVICE__ bool e4m3_bool_ocp_device(float val) {
 __FP8_DEVICE__ bool e5m2_bool_ocp_device(float val) {
   bool x = false;
   float y = val;
-#if (defined(__gfx1200__) || defined(__gfx1201__)) && __HIP_DEVICE_COMPILE__
+#if (defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx950__)) && __HIP_DEVICE_COMPILE__
   __hip_fp8_e5m2 tmp(y);
   x = tmp;
 #else
@@ -487,7 +488,7 @@ std::vector<__hip_fp8_storage_t> get_all_fp8_nums(bool is_e4m3_ocp) {
 __FP8_DEVICE__ __hip_fp8_storage_t e4m3_ocp_fp8_device(float val) {
   __hip_fp8_storage_t x = 0;
   float y = val;
-#if (defined(__gfx1200__) || defined(__gfx1201__)) && __HIP_DEVICE_COMPILE__
+#if (defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx950__)) && __HIP_DEVICE_COMPILE__
   __hip_fp8_e4m3 tmp(y);
   x = tmp.__x;
 #else
@@ -499,7 +500,7 @@ __FP8_DEVICE__ __hip_fp8_storage_t e4m3_ocp_fp8_device(float val) {
 __FP8_DEVICE__ __hip_fp8_storage_t e5m2_ocp_fp8_device(float val) {
   __hip_fp8_storage_t x = 0;
   float y = val;
-#if (defined(__gfx1200__) || defined(__gfx1201__)) && __HIP_DEVICE_COMPILE__
+#if (defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx950__)) && __HIP_DEVICE_COMPILE__
   __hip_fp8_e5m2 tmp(y);
   x = tmp.__x;
 #else
@@ -585,7 +586,7 @@ HIP_TEST_CASE(Unit_all_fp8_ocp_cvt) {
 
   for (size_t i = 0; i < final_res.size(); i++) {
     INFO("Checking: " << f_vals[i] << " for: " << (is_e4m3_ocp ? "e4m3_ocp" : "e5m2_ocp")
-                      << " original: " << (int)all_vals[i]
+                      << " index: " << i << " original: " << (int)all_vals[i]
                       << " convert back: " << (int)final_res[i]);
     float gpu_cvt_res = 0.0f, cpu_cvt_res = 0.0f;
     if (is_e4m3_ocp) {
@@ -614,7 +615,7 @@ HIP_TEST_CASE(Unit_all_fp8_ocp_cvt) {
 
 template <typename T> __FP8_DEVICE__ void e4m3_ocp_fp8_cvt(T val, float* cvt1, float* cvt2) {
   T y = val;
-#if (defined(__gfx1200__) || defined(__gfx1201__)) && __HIP_DEVICE_COMPILE__
+#if (defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx950__)) && __HIP_DEVICE_COMPILE__
   __hip_fp8_e4m3 tmp(y);
   *cvt1 = tmp;
 
@@ -632,7 +633,7 @@ template <typename T> __FP8_DEVICE__ void e4m3_ocp_fp8_cvt(T val, float* cvt1, f
 
 template <typename T> __FP8_DEVICE__ void e5m2_ocp_fp8_cvt(T val, float* cvt1, float* cvt2) {
   T y = val;
-#if (defined(__gfx1200__) || defined(__gfx1201__)) && __HIP_DEVICE_COMPILE__
+#if (defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx950__)) && __HIP_DEVICE_COMPILE__
   __hip_fp8_e5m2 tmp(y);
   *cvt1 = tmp;
 


### PR DESCRIPTION
## Motivation

run fp8 tests on gfx950

## Technical Details

gfx950 supports ocp fp8 types, we should run the tests on that arch.

## Issue Tracking

NA

## Test Plan

This test should pass on gfx950

## Test Result

test passes locally.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
