### PR TITLE
clr/hip-tests: fix half/bfloat16 __hne NaN comparison

### DIFF
--- a/projects/clr/CHANGELOG.md
+++ b/projects/clr/CHANGELOG.md
@@ -15,6 +15,7 @@ Full documentation for HIP is available at [rocm.docs.amd.com](https://rocm.docs
 since it is not available in the dynamic linker search path. Since `rocminfo` already links against `libhsa-runtime64.so`, the runtime now correctly locates and loads the HSA runtime library using `RTLD_NOLOAD` option,
 enabling successful ROCm initialization, HSA agent discovery, and subsequent ROCm operations.
 * Fixed a segmentation fault in HIP queue idle detection caused by referencing a recycled completion signal. Idle state is now derived from a queue-owned signal with a safe lifetime.
+* Resolved incorrect NaN handling in the ordered not-equal comparison intrinsics `__hne` (for `__half`) and `__hne` (for `__hip_bfloat16`), along with their vector forms. Being *ordered* predicates, they now correctly return `false` when either operand is NaN.
 
 ### Optimized
 

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -1288,7 +1288,7 @@ __BF16_HOST_DEVICE_STATIC__ bool __hgeu(const __hip_bfloat16 a, const __hip_bflo
  * \brief Compare two bfloat162 values - not equal
  */
 __BF16_HOST_DEVICE_STATIC__ bool __hne(const __hip_bfloat16 a, const __hip_bfloat16 b) {
-  return (__bf16)a != (__bf16)b;
+  return ((__bf16)a < (__bf16)b) || ((__bf16)a > (__bf16)b);
 }
 
 /**

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
@@ -617,7 +617,8 @@ inline __HOST_DEVICE__ bool __heq(__half x, __half y) {
   return static_cast<__half_raw>(x).data == static_cast<__half_raw>(y).data;
 }
 inline __HOST_DEVICE__ bool __hne(__half x, __half y) {
-  return static_cast<__half_raw>(x).data != static_cast<__half_raw>(y).data;
+  return (static_cast<__half_raw>(x).data < static_cast<__half_raw>(y).data) ||
+         (static_cast<__half_raw>(x).data > static_cast<__half_raw>(y).data);
 }
 inline __HOST_DEVICE__ bool __hle(__half x, __half y) {
   return static_cast<__half_raw>(x).data <= static_cast<__half_raw>(y).data;
@@ -656,7 +657,8 @@ inline __HOST_DEVICE__ __half2 __heq2(__half2 x, __half2 y) {
   return __builtin_convertvector(-r, _Float16_2);
 }
 inline __HOST_DEVICE__ __half2 __hne2(__half2 x, __half2 y) {
-  auto r = static_cast<__half2_raw>(x).data != static_cast<__half2_raw>(y).data;
+  auto r = (static_cast<__half2_raw>(x).data < static_cast<__half2_raw>(y).data) |
+           (static_cast<__half2_raw>(x).data > static_cast<__half2_raw>(y).data);
   return __builtin_convertvector(-r, _Float16_2);
 }
 inline __HOST_DEVICE__ __half2 __hle2(__half2 x, __half2 y) {
@@ -725,12 +727,30 @@ inline __HOST_DEVICE__ bool __hbgt2(__half2 x, __half2 y) {
   auto r = static_cast<__half2_raw>(__hgt2(x, y));
   return r.data.x != 0 && r.data.y != 0;
 }
-inline __HOST_DEVICE__ bool __hbequ2(__half2 x, __half2 y) { return __hbeq2(x, y); }
-inline __HOST_DEVICE__ bool __hbneu2(__half2 x, __half2 y) { return __hbne2(x, y); }
-inline __HOST_DEVICE__ bool __hbleu2(__half2 x, __half2 y) { return __hble2(x, y); }
-inline __HOST_DEVICE__ bool __hbgeu2(__half2 x, __half2 y) { return __hbge2(x, y); }
-inline __HOST_DEVICE__ bool __hbltu2(__half2 x, __half2 y) { return __hblt2(x, y); }
-inline __HOST_DEVICE__ bool __hbgtu2(__half2 x, __half2 y) { return __hbgt2(x, y); }
+inline __HOST_DEVICE__ bool __hbequ2(__half2 x, __half2 y) {
+  auto r = static_cast<__half2_raw>(__hequ2(x, y));
+  return r.data.x != 0 && r.data.y != 0;
+}
+inline __HOST_DEVICE__ bool __hbneu2(__half2 x, __half2 y) {
+  auto r = static_cast<__half2_raw>(__hneu2(x, y));
+  return r.data.x != 0 && r.data.y != 0;
+}
+inline __HOST_DEVICE__ bool __hbleu2(__half2 x, __half2 y) {
+  auto r = static_cast<__half2_raw>(__hleu2(x, y));
+  return r.data.x != 0 && r.data.y != 0;
+}
+inline __HOST_DEVICE__ bool __hbgeu2(__half2 x, __half2 y) {
+  auto r = static_cast<__half2_raw>(__hgeu2(x, y));
+  return r.data.x != 0 && r.data.y != 0;
+}
+inline __HOST_DEVICE__ bool __hbltu2(__half2 x, __half2 y) {
+  auto r = static_cast<__half2_raw>(__hltu2(x, y));
+  return r.data.x != 0 && r.data.y != 0;
+}
+inline __HOST_DEVICE__ bool __hbgtu2(__half2 x, __half2 y) {
+  auto r = static_cast<__half2_raw>(__hgtu2(x, y));
+  return r.data.x != 0 && r.data.y != 0;
+}
 inline __HOST_DEVICE__ bool __hisnan(__half x) {
   __half_raw hr = x;
   return (hr.x & 0x7FFFU) > 0x7C00u;

--- a/projects/hip-tests/catch/config/configs/unit/math.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/math.yaml
@@ -1464,16 +1464,12 @@ math:
     disabled: [amd_windows, amd_wsl]
   Unit_Device___hisinf2_Accuracy_Positive:
     <<: *level_2
-    # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hisnan_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
     disabled: [amd_windows, amd_wsl]
   Unit_Device___hisnan2_Accuracy_Positive:
     <<: *level_2
-    # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___heq_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
@@ -1488,8 +1484,6 @@ math:
     disabled: [amd_windows, amd_wsl]
   Unit_Device___hbequ2_Accuracy_Positive:
     <<: *level_2
-    # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___heq2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
@@ -1500,12 +1494,8 @@ math:
     disabled: [amd_windows, amd_wsl]
   Unit_Device___hne_Accuracy_Positive:
     <<: *level_2
-    # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hbne2_Accuracy_Positive:
     <<: *level_2
-    # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hneu_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
@@ -1516,8 +1506,6 @@ math:
     disabled: [amd_windows, amd_wsl]
   Unit_Device___hne2_Accuracy_Positive:
     <<: *level_2
-    # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hneu2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
@@ -1536,8 +1524,6 @@ math:
     disabled: [amd_windows, amd_wsl]
   Unit_Device___hbgeu2_Accuracy_Positive:
     <<: *level_2
-    # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hge2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
@@ -1560,8 +1546,6 @@ math:
     disabled: [amd_windows, amd_wsl]
   Unit_Device___hbgtu2_Accuracy_Positive:
     <<: *level_2
-    # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hgt2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
@@ -1584,8 +1568,6 @@ math:
     disabled: [amd_windows, amd_wsl]
   Unit_Device___hbleu2_Accuracy_Positive:
     <<: *level_2
-    # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hle2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
@@ -1608,8 +1590,6 @@ math:
     disabled: [amd_windows, amd_wsl]
   Unit_Device___hbltu2_Accuracy_Positive:
     <<: *level_2
-    # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hlt2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24

--- a/projects/hip-tests/catch/unit/deviceLib/bfloat16.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/bfloat16.cc
@@ -155,10 +155,20 @@ __global__ void bf16_compare(float* val, unsigned* res, size_t size) {
   }
 }
 
+// Order of predicates written by bf16_compare_nan(); the host uses the same
+// indices to label failures and look up the expected result.
+enum Bf16NanPredicate {
+  kHeq, kHne, kHlt, kHle, kHgt, kHge,        // ordered scalar   -> false for NaN
+  kHequ, kHneu, kHltu, kHleu, kHgtu, kHgeu,  // unordered scalar -> true for NaN
+  kHbeq2, kHbne2,                            // ordered bool2    -> false for NaN
+  kBf16NanPredicateCount
+};
+
 // Test NaN comparison semantics: for inputs where at least one operand is NaN the
 // ordered predicates (no 'u' suffix) must return false and the unordered predicates
-// ('u' suffix) must return true. Returns 1 only if every relation has the expected
-// result. Each a[i]/b[i] pair must have at least one NaN.
+// ('u' suffix) must return true. Each thread writes one slot per predicate so the
+// host can identify exactly which intrinsic misbehaved. Each a[i]/b[i] pair must
+// have at least one NaN.
 __global__ void bf16_compare_nan(const float* a, const float* b, unsigned* res, size_t size) {
   auto i = threadIdx.x;
   if (i < size) {
@@ -166,17 +176,24 @@ __global__ void bf16_compare_nan(const float* a, const float* b, unsigned* res, 
     const __hip_bfloat16 y = __float2bfloat16(b[i]);
     const __hip_bfloat162 x2{x, x};
     const __hip_bfloat162 y2{y, y};
+    unsigned* out = res + i * kBf16NanPredicateCount;
 
-    // Ordered scalar predicates -> false for NaN.
-    const bool ordered = !__heq(x, y) && !__hne(x, y) && !__hlt(x, y) && !__hle(x, y) &&
-                         !__hgt(x, y) && !__hge(x, y);
-    // Unordered scalar predicates -> true for NaN.
-    const bool unordered = __hequ(x, y) && __hneu(x, y) && __hltu(x, y) && __hleu(x, y) &&
-                           __hgtu(x, y) && __hgeu(x, y);
-    // Ordered bool2 reductions -> false for NaN.
-    const bool ordered_bool2 = !__hbeq2(x2, y2) && !__hbne2(x2, y2);
+    out[kHeq] = bool_to_unsigned(__heq(x, y));
+    out[kHne] = bool_to_unsigned(__hne(x, y));
+    out[kHlt] = bool_to_unsigned(__hlt(x, y));
+    out[kHle] = bool_to_unsigned(__hle(x, y));
+    out[kHgt] = bool_to_unsigned(__hgt(x, y));
+    out[kHge] = bool_to_unsigned(__hge(x, y));
 
-    res[i] = bool_to_unsigned(ordered && unordered && ordered_bool2);
+    out[kHequ] = bool_to_unsigned(__hequ(x, y));
+    out[kHneu] = bool_to_unsigned(__hneu(x, y));
+    out[kHltu] = bool_to_unsigned(__hltu(x, y));
+    out[kHleu] = bool_to_unsigned(__hleu(x, y));
+    out[kHgtu] = bool_to_unsigned(__hgtu(x, y));
+    out[kHgeu] = bool_to_unsigned(__hgeu(x, y));
+
+    out[kHbeq2] = bool_to_unsigned(__hbeq2(x2, y2));
+    out[kHbne2] = bool_to_unsigned(__hbne2(x2, y2));
   }
 }
 
@@ -345,6 +362,19 @@ HIP_TEST_CASE(Unit_bf16_basic) {
   }
 
   SECTION("NaN comparison semantics") {
+    struct PredicateCase {
+      const char* name;
+      unsigned expected;
+    };
+    // Indexed by Bf16NanPredicate; drives both the failure label and the
+    // expected result so the two cannot drift out of alignment.
+    static const PredicateCase kPredicates[kBf16NanPredicateCount] = {
+        {"__heq", 0}, {"__hne", 0}, {"__hlt", 0}, {"__hle", 0},
+        {"__hgt", 0}, {"__hge", 0},
+        {"__hequ", 1}, {"__hneu", 1}, {"__hltu", 1}, {"__hleu", 1},
+        {"__hgtu", 1}, {"__hgeu", 1},
+        {"__hbeq2", 0}, {"__hbne2", 0}};
+
     const float qnan = std::numeric_limits<float>::quiet_NaN();
     constexpr size_t size = 6;
     // Each pair has at least one NaN.
@@ -354,19 +384,22 @@ HIP_TEST_CASE(Unit_bf16_basic) {
     unsigned* d_res;
     HIP_CHECK(hipMalloc(&d_a, sizeof(float) * size));
     HIP_CHECK(hipMalloc(&d_b, sizeof(float) * size));
-    HIP_CHECK(hipMalloc(&d_res, sizeof(unsigned) * size));
+    HIP_CHECK(hipMalloc(&d_res, sizeof(unsigned) * size * kBf16NanPredicateCount));
 
     HIP_CHECK(hipMemcpy(d_a, a, sizeof(float) * size, hipMemcpyHostToDevice));
     HIP_CHECK(hipMemcpy(d_b, b, sizeof(float) * size, hipMemcpyHostToDevice));
 
     bf16_compare_nan<<<1, size>>>(d_a, d_b, d_res, size);
 
-    std::vector<unsigned> res(size, 0);
-    HIP_CHECK(hipMemcpy(res.data(), d_res, sizeof(unsigned) * size, hipMemcpyDeviceToHost));
+    std::vector<unsigned> res(size * kBf16NanPredicateCount, 0);
+    HIP_CHECK(hipMemcpy(res.data(), d_res,
+                        sizeof(unsigned) * res.size(), hipMemcpyDeviceToHost));
 
-    for (size_t i = 0; i < res.size(); i++) {
-      INFO("Index: " << i << " a: " << a[i] << " b: " << b[i] << " output: " << res[i]);
-      REQUIRE(res[i] == 1);
+    for (size_t i = 0; i < size; i++) {
+      for (int p = 0; p < kBf16NanPredicateCount; p++) {
+        CAPTURE(i, a[i], b[i], kPredicates[p].name);
+        CHECK(res[i * kBf16NanPredicateCount + p] == kPredicates[p].expected);
+      }
     }
 
     HIP_CHECK(hipFree(d_a));

--- a/projects/hip-tests/catch/unit/deviceLib/bfloat16.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/bfloat16.cc
@@ -155,6 +155,31 @@ __global__ void bf16_compare(float* val, unsigned* res, size_t size) {
   }
 }
 
+// Test NaN comparison semantics: for inputs where at least one operand is NaN the
+// ordered predicates (no 'u' suffix) must return false and the unordered predicates
+// ('u' suffix) must return true. Returns 1 only if every relation has the expected
+// result. Each a[i]/b[i] pair must have at least one NaN.
+__global__ void bf16_compare_nan(const float* a, const float* b, unsigned* res, size_t size) {
+  auto i = threadIdx.x;
+  if (i < size) {
+    const __hip_bfloat16 x = __float2bfloat16(a[i]);
+    const __hip_bfloat16 y = __float2bfloat16(b[i]);
+    const __hip_bfloat162 x2{x, x};
+    const __hip_bfloat162 y2{y, y};
+
+    // Ordered scalar predicates -> false for NaN.
+    const bool ordered = !__heq(x, y) && !__hne(x, y) && !__hlt(x, y) && !__hle(x, y) &&
+                         !__hgt(x, y) && !__hge(x, y);
+    // Unordered scalar predicates -> true for NaN.
+    const bool unordered = __hequ(x, y) && __hneu(x, y) && __hltu(x, y) && __hleu(x, y) &&
+                           __hgtu(x, y) && __hgeu(x, y);
+    // Ordered bool2 reductions -> false for NaN.
+    const bool ordered_bool2 = !__hbeq2(x2, y2) && !__hbne2(x2, y2);
+
+    res[i] = bool_to_unsigned(ordered && unordered && ordered_bool2);
+  }
+}
+
 // Convert to bits
 __global__ void bf16_conv_bits(float* val, unsigned short* res, size_t size) {
   auto i = threadIdx.x;
@@ -316,6 +341,36 @@ HIP_TEST_CASE(Unit_bf16_basic) {
     }
 
     HIP_CHECK(hipFree(d_in));
+    HIP_CHECK(hipFree(d_res));
+  }
+
+  SECTION("NaN comparison semantics") {
+    const float qnan = std::numeric_limits<float>::quiet_NaN();
+    constexpr size_t size = 6;
+    // Each pair has at least one NaN.
+    float a[size] = {qnan, qnan, 1.0f, qnan, -2.0f, qnan};
+    float b[size] = {qnan, 1.0f, qnan, -3.0f, qnan, 0.0f};
+    float *d_a, *d_b;
+    unsigned* d_res;
+    HIP_CHECK(hipMalloc(&d_a, sizeof(float) * size));
+    HIP_CHECK(hipMalloc(&d_b, sizeof(float) * size));
+    HIP_CHECK(hipMalloc(&d_res, sizeof(unsigned) * size));
+
+    HIP_CHECK(hipMemcpy(d_a, a, sizeof(float) * size, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(d_b, b, sizeof(float) * size, hipMemcpyHostToDevice));
+
+    bf16_compare_nan<<<1, size>>>(d_a, d_b, d_res, size);
+
+    std::vector<unsigned> res(size, 0);
+    HIP_CHECK(hipMemcpy(res.data(), d_res, sizeof(unsigned) * size, hipMemcpyDeviceToHost));
+
+    for (size_t i = 0; i < res.size(); i++) {
+      INFO("Index: " << i << " a: " << a[i] << " b: " << b[i] << " output: " << res[i]);
+      REQUIRE(res[i] == 1);
+    }
+
+    HIP_CHECK(hipFree(d_a));
+    HIP_CHECK(hipFree(d_b));
     HIP_CHECK(hipFree(d_res));
   }
 


### PR DESCRIPTION
## Motivation
 `__hne` (half/bfloat16 ordered not-equal) returns the wrong result for NaN inputs on all architectures: it uses C's `!=`, which is the *unordered* not-equal (NaN→true), when the ordered predicate must  
  return false. This makes `__hne` identical to `__hneu` — they emit the same machine instruction (`v_cmp_neq`). CUDA's `__hne` uses `setp.ne` (ordered, NaN→false).
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
  - **fp16** (`amd_hip_fp16.h`): `__hne`/`__hne2` reimplemented as `(x < y) || (x > y)`, which folds to a single `v_cmp_lg` (the native ordered ne) — zero cost, just the correct opcode. The unordered
  bool2 reductions (`__hbequ2`/`__hbneu2`/`__hbleu2`/`__hbgeu2`/`__hbltu2`/`__hbgtu2`) were aliasing their ordered counterparts; fixed to reduce the unordered vector intrinsics instead.                   
  - **bf16** (`amd_hip_bf16.h`): same `__hne` fix.                                                                                                                                       
  - **Tests**: re-enable the 10 fp16 comparison accuracy tests previously disabled under EXSWHTEC-356. Add NaN-comparison coverage to the existing bf16 `Unit_bf16_basic` test.    
<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking
JIRA ID: ROCM-28334
<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan
  - Ran all fp16 comparison accuracy tests (`__hne`, `__hne2`, `__hbne2`, `__hbequ2`, `__hbgeu2`, `__hbgtu2`, `__hbleu2`, `__hbltu2`, `__hisinf2`, `__hisnan2`): all pass.
  - Ran device test with `(1,1)`, `(1,2)`, `(NaN,1)`, `(1,NaN)`, `(NaN,NaN)` for both fp16 and bf16 `__hne`/`__hneu`: verified `__hne` now differs from `__hneu` on NaN (returns 0 vs 1).                   
  - bf16 NaN-comparison section of `Unit_bf16_basic`: passes with fix, fails without (all 6 NaN pairs).                                                                                  
  - Verified no regression on sibling comparisons (`__heq`, `__hequ`, `__hbneu2`, etc.). 
## Test Result
All comparison tests pass. The fix is a single-opcode swap (`v_cmp_neq` → `v_cmp_lg`), verified on gfx942 — same instruction count, zero performance cost.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
