### PR TITLE
clr: Fix missing else-branches in is_invocable guards

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_device_functions.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_device_functions.h
@@ -652,7 +652,10 @@ __device__ inline __attribute__((always_inline)) long long int clock() { return 
 
 // hip.amdgcn.bc - named sync
 __device__ inline void __named_sync() {
-  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_s_barrier)) __builtin_amdgcn_s_barrier();
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_s_barrier))
+    __builtin_amdgcn_s_barrier();
+  else
+    __builtin_trap();
 }
 
 #endif  // __HIP_DEVICE_COMPILE__
@@ -683,16 +686,22 @@ __device__ inline __hip_uint64_t __lanemask_eq() {
 __device__ inline static void __threadfence() {
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fence))
     __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "agent");
+  else
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
 }
 
 __device__ inline static void __threadfence_block() {
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fence))
     __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "workgroup");
+  else
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
 }
 
 __device__ inline static void __threadfence_system() {
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fence))
     __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "");
+  else
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
 }
 __device__ inline static void __work_group_barrier(__cl_mem_fence_flags flags) {
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fence) &&
@@ -712,6 +721,8 @@ __device__ inline static void __work_group_barrier(__cl_mem_fence_flags flags) {
     } else {
       __builtin_amdgcn_s_barrier();
     }
+  } else {
+    __builtin_trap();
   }
 }
 

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_atomic.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_atomic.h
@@ -599,13 +599,27 @@ __device__ inline double atomicMax_system(double* addr, double val) {
 __device__ inline unsigned int atomicInc(unsigned int* address, unsigned int val) {
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_atomic_inc32))
     return __builtin_amdgcn_atomic_inc32(address, val, __ATOMIC_RELAXED, "agent");
-  return 0;
+
+  unsigned int old = __hip_atomic_load(address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+  unsigned int newval;
+  do {
+    newval = (old >= val) ? 0 : (old + 1);
+  } while (!__hip_atomic_compare_exchange_weak(address, &old, newval,
+           __ATOMIC_RELAXED, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT));
+  return old;
 }
 
 __device__ inline unsigned int atomicDec(unsigned int* address, unsigned int val) {
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_atomic_dec32))
     return __builtin_amdgcn_atomic_dec32(address, val, __ATOMIC_RELAXED, "agent");
-  return 0;
+
+  unsigned int old = __hip_atomic_load(address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+  unsigned int newval;
+  do {
+    newval = (old == 0 || old > val) ? val : (old - 1);
+  } while (!__hip_atomic_compare_exchange_weak(address, &old, newval,
+           __ATOMIC_RELAXED, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT));
+  return old;
 }
 
 __device__ inline int atomicAnd(int* address, int val) {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -1941,10 +1941,11 @@ __BF16_DEVICE_STATIC__ __hip_bfloat162 unsafeAtomicAdd(__hip_bfloat162* address,
     __hip_bfloat162_raw bf162_raw;
     vec_short2 vs2;
   } u{static_cast<__hip_bfloat162_raw>(value)};
-  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fadd_v2bf16))
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fadd_v2bf16)) {
     u.vs2 = __builtin_amdgcn_flat_atomic_fadd_v2bf16((vec_short2*)address, u.vs2);
-  return static_cast<__hip_bfloat162>(u.bf162_raw);
-#else
+    return static_cast<__hip_bfloat162>(u.bf162_raw);
+  }
+#endif
   static_assert(sizeof(unsigned int) == sizeof(__hip_bfloat162_raw));
   union u_hold {
     __hip_bfloat162_raw h2r;
@@ -1959,7 +1960,6 @@ __BF16_DEVICE_STATIC__ __hip_bfloat162 unsafeAtomicAdd(__hip_bfloat162* address,
                                                  __ATOMIC_RELAXED, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT));
   return old_val.h2r;
-#endif
 }
 __BF16_DEVICE_STATIC__ __hip_bfloat16 unsafeAtomicAdd(__hip_bfloat16* address,
                                                       __hip_bfloat16 value) {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -661,10 +661,10 @@ class coalesced_group : public thread_group {
  *  on Microsoft Windows.
  */
 __CG_QUALIFIER__ coalesced_group coalesced_threads() {
-  return cooperative_groups::coalesced_group(
-      __builtin_amdgcn_is_invocable(__builtin_amdgcn_read_exec)
-          ? __builtin_amdgcn_read_exec()
-          : 0);
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_read_exec))
+    return cooperative_groups::coalesced_group(__builtin_amdgcn_read_exec());
+  __builtin_trap();
+  return cooperative_groups::coalesced_group(0);
 }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups_memcpy.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups_memcpy.h
@@ -41,6 +41,8 @@ __CG_STATIC_QUALIFIER__ void accelerated_memcpy_global_to_lds(TyElem* __restrict
         __builtin_amdgcn_global_load_async_to_lds_b128(
             (__attribute__((address_space(1))) vint4*)c_src,
             (__attribute__((address_space(3))) vint4*)c_dst, 0 /* offset */, 0 /* cache policy */);
+      else
+        __builtin_trap();
       bytes_left -= 16;
       c_src += 16;
       c_dst += 16;
@@ -49,6 +51,8 @@ __CG_STATIC_QUALIFIER__ void accelerated_memcpy_global_to_lds(TyElem* __restrict
         __builtin_amdgcn_global_load_async_to_lds_b64(
             (__attribute__((address_space(1))) vint2*)c_src,
             (__attribute__((address_space(3))) vint2*)c_dst, 0 /* offset */, 0 /* cache policy */);
+      else
+        __builtin_trap();
       bytes_left -= 8;
       c_src += 8;
       c_dst += 8;
@@ -57,6 +61,8 @@ __CG_STATIC_QUALIFIER__ void accelerated_memcpy_global_to_lds(TyElem* __restrict
         __builtin_amdgcn_global_load_async_to_lds_b32(
             (__attribute__((address_space(1))) int*)c_src,
             (__attribute__((address_space(3))) int*)c_dst, 0 /* offset */, 0 /* cache policy */);
+      else
+        __builtin_trap();
       bytes_left -= 4;
       c_src += 4;
       c_dst += 4;
@@ -65,6 +71,8 @@ __CG_STATIC_QUALIFIER__ void accelerated_memcpy_global_to_lds(TyElem* __restrict
         __builtin_amdgcn_global_load_async_to_lds_b8(
             (__attribute__((address_space(1))) char*)c_src,
             (__attribute__((address_space(3))) char*)c_dst, 0 /* offset */, 0 /* cache policy */);
+      else
+        __builtin_trap();
       bytes_left--;
       c_src++;
       c_dst++;
@@ -90,6 +98,8 @@ __CG_STATIC_QUALIFIER__ void accelerated_memcpy_lds_to_global(TyElem* __restrict
         __builtin_amdgcn_global_store_async_from_lds_b128(
             (__attribute__((address_space(1))) vint4*)c_dst,
             (__attribute__((address_space(3))) vint4*)c_src, 0 /* offset */, 0 /* cache policy */);
+      else
+        __builtin_trap();
       bytes_left -= 16;
       c_src += 16;
       c_dst += 16;
@@ -98,6 +108,8 @@ __CG_STATIC_QUALIFIER__ void accelerated_memcpy_lds_to_global(TyElem* __restrict
         __builtin_amdgcn_global_store_async_from_lds_b64(
             (__attribute__((address_space(1))) vint2*)c_dst,
             (__attribute__((address_space(3))) vint2*)c_src, 0 /* offset */, 0 /* cache policy */);
+      else
+        __builtin_trap();
       bytes_left -= 8;
       c_src += 8;
       c_dst += 8;
@@ -106,6 +118,8 @@ __CG_STATIC_QUALIFIER__ void accelerated_memcpy_lds_to_global(TyElem* __restrict
         __builtin_amdgcn_global_store_async_from_lds_b32(
             (__attribute__((address_space(1))) int*)c_dst,
             (__attribute__((address_space(3))) int*)c_src, 0 /* offset */, 0 /* cache policy */);
+      else
+        __builtin_trap();
       bytes_left -= 4;
       c_src += 4;
       c_dst += 4;
@@ -114,6 +128,8 @@ __CG_STATIC_QUALIFIER__ void accelerated_memcpy_lds_to_global(TyElem* __restrict
         __builtin_amdgcn_global_store_async_from_lds_b8(
             (__attribute__((address_space(1))) char*)c_dst,
             (__attribute__((address_space(3))) char*)c_src, 0 /* offset */, 0 /* cache policy */);
+      else
+        __builtin_trap();
       bytes_left--;
       c_src++;
       c_dst++;

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
@@ -899,10 +899,11 @@ inline __device__ __half2 unsafeAtomicAdd(__half2* address, __half2 value) {
     __half2_raw h2r;
     vec_fp162 fp16;
   } u{static_cast<__half2_raw>(value)};
-  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fadd_v2f16))
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fadd_v2f16)) {
     u.fp16 = __builtin_amdgcn_flat_atomic_fadd_v2f16((vec_fp162*)address, u.fp16);
-  return static_cast<__half2>(u.h2r);
-#else
+    return static_cast<__half2>(u.h2r);
+  }
+#endif
   static_assert(sizeof(__half2_raw) == sizeof(unsigned int));
   union u_hold {
     __half2_raw h2r;
@@ -917,7 +918,6 @@ inline __device__ __half2 unsafeAtomicAdd(__half2* address, __half2 value) {
                                                  __ATOMIC_RELAXED, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT));
   return old_val.h2r;
-#endif
 }
 
 inline __device__ __half unsafeAtomicAdd(__half* address, __half value) {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp4.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp4.h
@@ -45,6 +45,8 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4_storage_t __hip_cvt_bfloat16raw_to_fp4(
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_bf16))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_bf16(
         u.ui32, internal::hipbf162_to_bf16x2(__hip_bfloat162{x, 0}), 1.0f /* scale */, 0);
+  else
+    __builtin_trap();
   return u.fp4[0];
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
   union {
@@ -74,6 +76,8 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4x2_storage_t __hip_cvt_bfloat16raw2_to_fp4x2
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_bf16))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_bf16(u.ui32, internal::hipbf162_to_bf16x2(x),
                                                        1.0f /* scale */, 0);
+  else
+    __builtin_trap();
   return u.fp4x2[0];
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
   auto bf16x2 = internal::hipbf162_to_bf16x2(x);
@@ -103,6 +107,8 @@ __hip_cvt_double_to_fp4(const double x, const __hip_fp4_interpretation_t /* fp4_
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_f32))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(u.ui32, float(x), 0.0f, 1.0f /* scale */, 0);
+  else
+    __builtin_trap();
   return u.fp4[0];
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
   __amd_floatx8_storage_t fp32x8{float(x), float(x), float(x), float(x),
@@ -127,6 +133,8 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4x2_storage_t __hip_cvt_double2_to_fp4x2(
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_f32))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(u.ui32, float(x.x), float(x.y),
                                                       1.0f /* scale */, 0);
+  else
+    __builtin_trap();
   return u.fp4x2[0];
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
   __amd_floatx8_storage_t fp32x8{float(x.x), float(x.y), float(x.x), float(x.y),
@@ -152,6 +160,8 @@ __hip_cvt_float_to_fp4(const float x, const __hip_fp4_interpretation_t /* fp4_in
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_f32))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(u.ui32, x, 0.0f, 1.0f /* scale */, 0);
+  else
+    __builtin_trap();
   return u.fp4[0];
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
   __amd_floatx8_storage_t fp32x8{x, x, x, x, x, x, x, x};
@@ -174,6 +184,8 @@ __hip_cvt_float2_to_fp4x2(const float2 x, const __hip_fp4_interpretation_t /* fp
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_f32))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(u.ui32, x.x, x.y, 1.0f /* scale */, 0);
+  else
+    __builtin_trap();
   return u.fp4x2[0];
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
   __amd_floatx8_storage_t fp32x8{x.x, x.y, x.x, x.y, x.x, x.y, x.x, x.y};
@@ -195,7 +207,7 @@ __FP4_HOST_DEVICE_STATIC__ __half_raw __hip_cvt_fp4_to_halfraw(
   ret.data =
       __amd_fp16x2_storage_t{__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_f16_fp4)
                                  ? __builtin_amdgcn_cvt_scalef32_pk_f16_fp4(x, 0, 0)
-                                 : __amd_fp16x2_storage_t{}};
+                                 : (__builtin_trap(), __amd_fp16x2_storage_t{})};
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
   static_assert(sizeof(__amd_fp16x2_storage_t[4]) == sizeof(__amd_fp16x8_storage_t));
   static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
@@ -227,7 +239,7 @@ __FP4_HOST_DEVICE_STATIC__ __half2_raw __hip_cvt_fp4x2_to_halfraw2(
   ret.data =
       __amd_fp16x2_storage_t{__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_f16_fp4)
                                  ? __builtin_amdgcn_cvt_scalef32_pk_f16_fp4(x, 0, 0)
-                                 : __amd_fp16x2_storage_t{}};
+                                 : (__builtin_trap(), __amd_fp16x2_storage_t{})};
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
   static_assert(sizeof(__amd_fp16x2_storage_t[4]) == sizeof(__amd_fp16x8_storage_t));
   static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
@@ -263,6 +275,8 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4_storage_t __hip_cvt_halfraw_to_fp4(
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_f16))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_f16(
         u.ui32, internal::half2_to_f16x2(__half2{x, 0}), 1.0f /* scale */, 0);
+  else
+    __builtin_trap();
   return u.fp4[0];
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
   auto val = internal::half2_to_f16x2(__half2{x, x});
@@ -288,6 +302,8 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4x2_storage_t __hip_cvt_halfraw2_to_fp4x2(
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_f16))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_f16(u.ui32, internal::half2_to_f16x2(x),
                                                       1.0f /* scale */, 0);
+  else
+    __builtin_trap();
   return u.fp4x2[0];
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
   auto val = internal::half2_to_f16x2(x);
@@ -365,6 +381,8 @@ struct __hip_fp4_e2m1 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_bf16_fp4))
       u.bf16x2 = __builtin_amdgcn_cvt_scalef32_pk_bf16_fp4(__x, 1.0f /* scale */, 0);
+    else
+      __builtin_trap();
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     static_assert(sizeof(__amd_bf16x2_storage_t[4]) == sizeof(__amd_bf16x8_storage_t));
     static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
@@ -393,7 +411,7 @@ struct __hip_fp4_e2m1 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     auto ret = __builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_f32_fp4)
                    ? __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(__x, 1.0f /* scale */, 0)
-                   : __amd_floatx2_storage_t{};
+                   : (__builtin_trap(), __amd_floatx2_storage_t{});
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     union {
       unsigned int ui32;
@@ -450,6 +468,8 @@ struct __hip_fp4x2_e2m1 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_bf16_fp4))
       u.bf16x2 = __builtin_amdgcn_cvt_scalef32_pk_bf16_fp4(__x, 1.0f /* scale */, 0);
+    else
+      __builtin_trap();
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     static_assert(sizeof(__amd_bf16x2_storage_t[4]) == sizeof(__amd_bf16x8_storage_t));
     static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
@@ -479,7 +499,7 @@ struct __hip_fp4x2_e2m1 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     auto fp32x2 = __builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_f32_fp4)
                       ? __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(__x, 1.0f /* scale */, 0)
-                      : __amd_floatx2_storage_t{};
+                      : (__builtin_trap(), __amd_floatx2_storage_t{});
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     union {
       unsigned int ui32;
@@ -503,7 +523,7 @@ struct __hip_fp4x2_e2m1 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     auto fp32x2 = __builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_f32_fp4)
                       ? __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(__x, 1.0f /* scale */, 0)
-                      : __amd_floatx2_storage_t{};
+                      : (__builtin_trap(), __amd_floatx2_storage_t{});
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     union {
       unsigned int ui32;
@@ -554,10 +574,10 @@ struct __hip_fp4x4_e2m1 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     auto fp32x2_1 = __builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_f32_fp4)
                         ? __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(__x & 0xFFu, 1.0f /* scale */, 0)
-                        : __amd_floatx2_storage_t{};
+                        : (__builtin_trap(), __amd_floatx2_storage_t{});
     auto fp32x2_2 = __builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_f32_fp4)
                         ? __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(__x >> 8, 1.0f /* scale */, 0)
-                        : __amd_floatx2_storage_t{};
+                        : (__builtin_trap(), __amd_floatx2_storage_t{});
     return float4{fp32x2_1[0], fp32x2_1[1], fp32x2_2[0], fp32x2_2[1]};
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     union {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp6.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp6.h
@@ -49,9 +49,13 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6_storage_t __hip_cvt_bfloat16raw_to_fp6(
   if (fp6_interpretation == __HIP_E2M3) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_fp6_bf16))
       out = __builtin_amdgcn_cvt_scalef32_pk32_fp6_bf16(in, 1.0f /* scale */);
+    else
+      __builtin_trap();
   } else if (fp6_interpretation == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf6_bf16))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf6_bf16(in, 1.0f /* scale */);
+    else
+      __builtin_trap();
   }
   u.ui32 = out[0];
   return u.fp6[0];
@@ -93,9 +97,13 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6x2_storage_t __hip_cvt_bfloat16raw2_to_fp6x2
   if (fp6_interpretation == __HIP_E2M3) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_fp6_bf16))
       out = __builtin_amdgcn_cvt_scalef32_pk32_fp6_bf16(in, 1.0f /* scale */);
+    else
+      __builtin_trap();
   } else if (fp6_interpretation == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf6_bf16))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf6_bf16(in, 1.0f /* scale */);
+    else
+      __builtin_trap();
   }
   u.ui32 = out[0];
   return u.fp6x2[0];
@@ -144,9 +152,13 @@ __hip_cvt_double_to_fp6(const double x, const __hip_fp6_interpretation_t fp6_int
   if (fp6_interpretation_t == __HIP_E2M3) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_2xpk16_fp6_f32))
       out = __builtin_amdgcn_cvt_scalef32_2xpk16_fp6_f32(in1, in2, 1.0f /* scale */);
+    else
+      __builtin_trap();
   } else if (fp6_interpretation_t == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32))
       out = __builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32(in1, in2, 1.0f /* scale */);
+    else
+      __builtin_trap();
   }
   u.ui32 = out[0];
   return u.fp6[0];
@@ -188,9 +200,13 @@ __hip_cvt_double2_to_fp6x2(const double2 x, const __hip_fp6_interpretation_t fp6
   if (fp6_interpretation_t == __HIP_E2M3) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_2xpk16_fp6_f32))
       out = __builtin_amdgcn_cvt_scalef32_2xpk16_fp6_f32(in1, in2, 1.0f /* scale */);
+    else
+      __builtin_trap();
   } else if (fp6_interpretation_t == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32))
       out = __builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32(in1, in2, 1.0f /* scale */);
+    else
+      __builtin_trap();
   }
   u.ui32 = out[0] & 0x3Fu;
   u.ui32 |= ((out[0] & 0xFC0u) << 2);
@@ -239,9 +255,13 @@ __hip_cvt_float_to_fp6(const float x, const __hip_fp6_interpretation_t fp6_inter
   if (fp6_interpretation_t == __HIP_E2M3) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_2xpk16_fp6_f32))
       out = __builtin_amdgcn_cvt_scalef32_2xpk16_fp6_f32(in1, in2, 1.0f /* scale */);
+    else
+      __builtin_trap();
   } else if (fp6_interpretation_t == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32))
       out = __builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32(in1, in2, 1.0f /* scale */);
+    else
+      __builtin_trap();
   }
   u.ui32 = out[0];
   return u.fp6[0];
@@ -282,9 +302,13 @@ __hip_cvt_float2_to_fp6x2(const float2 x, const __hip_fp6_interpretation_t fp6_i
   if (fp6_interpretation_t == __HIP_E2M3) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_2xpk16_fp6_f32))
       out = __builtin_amdgcn_cvt_scalef32_2xpk16_fp6_f32(in1, in2, 1.0f /* scale */);
+    else
+      __builtin_trap();
   } else if (fp6_interpretation_t == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32))
       out = __builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32(in1, in2, 1.0f /* scale */);
+    else
+      __builtin_trap();
   }
   u.ui32 = out[0] & 0x3Fu;
   u.ui32 |= ((out[0] & 0xFC0u) << 2);
@@ -327,9 +351,13 @@ __FP6_HOST_DEVICE_STATIC__ __half_raw __hip_cvt_fp6_to_halfraw(
   if (fp6_interpretation_t == __HIP_E2M3) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f16_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f16_fp6(in, 1.0f);
+    else
+      __builtin_trap();
   } else if (fp6_interpretation_t == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f16_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f16_bf6(in, 1.0f);
+    else
+      __builtin_trap();
   }
   ret.data = out[0];
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
@@ -365,9 +393,13 @@ __FP6_HOST_DEVICE_STATIC__ __half2_raw __hip_cvt_fp6x2_to_halfraw2(
   if (fp6_interpretation_t == __HIP_E2M3) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f16_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f16_fp6(in, 1.0f);
+    else
+      __builtin_trap();
   } else if (fp6_interpretation_t == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f16_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f16_bf6(in, 1.0f);
+    else
+      __builtin_trap();
   }
   ret.data = {out[0], out[1]};
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
@@ -411,9 +443,13 @@ __hip_cvt_halfraw_to_fp6(const __half_raw x, const __hip_fp6_interpretation_t fp
   if (fp6_interpretation_t == __HIP_E2M3) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_fp6_f16))
       out = __builtin_amdgcn_cvt_scalef32_pk32_fp6_f16(in, 1.0f);
+    else
+      __builtin_trap();
   } else if (fp6_interpretation_t == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf6_f16))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf6_f16(in, 1.0f);
+    else
+      __builtin_trap();
   }
   u.ui32 = out[0];
   return u.fp6[0];
@@ -456,9 +492,13 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6x2_storage_t __hip_cvt_halfraw2_to_fp6x2(
   if (fp6_interpretation_t == __HIP_E2M3) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_fp6_f16))
       out = __builtin_amdgcn_cvt_scalef32_pk32_fp6_f16(in, 1.0f);
+    else
+      __builtin_trap();
   } else if (fp6_interpretation_t == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf6_f16))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf6_f16(in, 1.0f);
+    else
+      __builtin_trap();
   }
   u.ui32 = out[0] & 0x3Fu;
   u.ui32 |= ((out[0] & 0xFC0u) << 2);
@@ -541,6 +581,8 @@ struct __hip_fp6_e2m3 {
     in[0] = (uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf16_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf16_fp6(in, 1.0f /* scale */);
+    else
+      __builtin_trap();
     u.bf16 = out[0];
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     __amd_fp6x16_storage_t in{};
@@ -562,6 +604,8 @@ struct __hip_fp6_e2m3 {
     in[0] = (uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_fp6(in, 1.0f /* scale */);
+    else
+      __builtin_trap();
     auto ret = out[0];
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     __amd_fp6x16_storage_t in{};
@@ -626,6 +670,8 @@ struct __hip_fp6_e3m2 {
     in[0] = (uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf16_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf16_bf6(in, 1.0f /* scale */);
+    else
+      __builtin_trap();
     u.bf16 = out[0];
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     __amd_fp6x16_storage_t in{};
@@ -647,6 +693,8 @@ struct __hip_fp6_e3m2 {
     in[0] = (uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_bf6(in, 1.0f /* scale */);
+    else
+      __builtin_trap();
     auto ret = out[0];
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     __amd_fp6x16_storage_t in{};
@@ -695,6 +743,8 @@ struct __hip_fp6x2_e2m3 {
     in[0] |= (__x & 0x3F00u) >> 2;  // next 6 bits
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf16_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf16_fp6(in, 1.0f /* scale */);
+    else
+      __builtin_trap();
     u.bf16x2 = {out[0], out[1]};
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     __amd_fp6x16_storage_t in{};
@@ -720,6 +770,8 @@ struct __hip_fp6x2_e2m3 {
     in[0] |= (__x & 0x3F00u) >> 2;  // next 6 bits
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_fp6(in, 1.0f /* scale */);
+    else
+      __builtin_trap();
     __amd_floatx2_storage_t fp32x2 = {out[0], out[1]};
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     __amd_fp6x16_storage_t in{};
@@ -773,6 +825,8 @@ struct __hip_fp6x2_e3m2 {
     in[0] |= (__x & 0x3F00u) >> 2;  // next 6 bits
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf16_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf16_bf6(in, 1.0f /* scale */);
+    else
+      __builtin_trap();
     u.bf16x2 = {out[0], out[1]};
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     __amd_fp6x16_storage_t in{};
@@ -798,6 +852,8 @@ struct __hip_fp6x2_e3m2 {
     in[0] |= (__x & 0x3F00u) >> 2;  // next 6 bits
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_bf6(in, 1.0f /* scale */);
+    else
+      __builtin_trap();
     __amd_floatx2_storage_t fp32x2 = {out[0], out[1]};
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     __amd_fp6x16_storage_t in{};
@@ -850,6 +906,8 @@ struct __hip_fp6x4_e2m3 {
     in[0] |= ((__x >> 24) & 0x3Fu) << 18;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_fp6(in, 1.0f /* scale */);
+    else
+      __builtin_trap();
     __amd_floatx2_storage_t fp32x2_1 = {out[0], out[1]};
     __amd_floatx2_storage_t fp32x2_2 = {out[2], out[3]};
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
@@ -910,6 +968,8 @@ struct __hip_fp6x4_e3m2 {
     in[0] |= ((__x >> 24) & 0x3Fu) << 18;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_bf6(in, 1.0f /* scale */);
+    else
+      __builtin_trap();
     __amd_floatx2_storage_t fp32x2_1 = {out[0], out[1]};
     __amd_floatx2_storage_t fp32x2_2 = {out[2], out[3]};
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -546,16 +546,22 @@ static __device__ __hip_fp8_storage_t cast_to_f8_from_f32(float v, bool saturate
       if ((val.i32val & 0x7F800000) != 0x7F800000) {  /// propagate NAN/INF, no clipping
         if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fmed3f))
           val.fval = __builtin_amdgcn_fmed3f(val.fval, 240.0, -240.0);
+        else
+          val.fval = val.fval > 240.0f ? 240.0f : (val.fval < -240.0f ? -240.0f : val.fval);
       }
     } else if (interpret == __HIP_E4M3) {             // OCP type
       if ((val.i32val & 0x7F800000) != 0x7F800000) {  /// propagate NAN/INF, no clipping
         if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fmed3f))
           val.fval = __builtin_amdgcn_fmed3f(val.fval, 448.0, -448.0);
+        else
+          val.fval = val.fval > 448.0f ? 448.0f : (val.fval < -448.0f ? -448.0f : val.fval);
       }
     } else {
       if ((val.i32val & 0x7F800000) != 0x7F800000) {  /// propagate NAN/INF, no clipping
         if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fmed3f))
           val.fval = __builtin_amdgcn_fmed3f(val.fval, 57344.0, -57344.0);
+        else
+          val.fval = val.fval > 57344.0f ? 57344.0f : (val.fval < -57344.0f ? -57344.0f : val.fval);
       }
     }
   }
@@ -564,20 +570,20 @@ static __device__ __hip_fp8_storage_t cast_to_f8_from_f32(float v, bool saturate
     ival = (interpret == __HIP_E4M3_FNUZ) || (interpret == __HIP_E4M3)
                ? (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_sr_fp8_f32)
                       ? __builtin_amdgcn_cvt_sr_fp8_f32(val.fval, rng, ival, 0)
-                      : 0u)
+                      : (__builtin_trap(), 0u))
                : (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_sr_bf8_f32)
                       ? __builtin_amdgcn_cvt_sr_bf8_f32(val.fval, rng, ival, 0)
-                      : 0u);  // 0 pos
+                      : (__builtin_trap(), 0u));  // 0 pos
     val.i32val = ival;
     i8data = val.i8val[0];  // little endian
   } else {                  // RNE CVT
     ival = (interpret == __HIP_E4M3_FNUZ) || (interpret == __HIP_E4M3)
                ? (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_pk_fp8_f32)
                       ? __builtin_amdgcn_cvt_pk_fp8_f32(val.fval, val.fval, ival, false)
-                      : 0u)
+                      : (__builtin_trap(), 0u))
                : (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_pk_bf8_f32)
                       ? __builtin_amdgcn_cvt_pk_bf8_f32(val.fval, val.fval, ival, false)
-                      : 0u);  // false -> WORD0
+                      : (__builtin_trap(), 0u));  // false -> WORD0
     val.i32val = ival;
     i8data = val.i8val[0];
   }
@@ -601,28 +607,40 @@ cast_to_f8x2_from_f32x2(float2 v, bool saturate, __hip_fp8_interpretation_t inte
       if ((f2val.i32val[0] & 0x7F800000) != 0x7F800000) {
         if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fmed3f))
           f2val.fval.x = __builtin_amdgcn_fmed3f(f2val.fval.x, 240.0, -240.0);
+        else
+          f2val.fval.x = f2val.fval.x > 240.0f ? 240.0f : (f2val.fval.x < -240.0f ? -240.0f : f2val.fval.x);
       }
       if ((f2val.i32val[1] & 0x7F800000) != 0x7F800000) {
         if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fmed3f))
           f2val.fval.y = __builtin_amdgcn_fmed3f(f2val.fval.y, 240.0, -240.0);
+        else
+          f2val.fval.y = f2val.fval.y > 240.0f ? 240.0f : (f2val.fval.y < -240.0f ? -240.0f : f2val.fval.y);
       }
     } else if (interpret == __HIP_E4M3) {
       if ((f2val.i32val[0] & 0x7F800000) != 0x7F800000) {
         if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fmed3f))
           f2val.fval.x = __builtin_amdgcn_fmed3f(f2val.fval.x, 448.0, -448.0);
+        else
+          f2val.fval.x = f2val.fval.x > 448.0f ? 448.0f : (f2val.fval.x < -448.0f ? -448.0f : f2val.fval.x);
       }
       if ((f2val.i32val[1] & 0x7F800000) != 0x7F800000) {
         if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fmed3f))
           f2val.fval.y = __builtin_amdgcn_fmed3f(f2val.fval.y, 448.0, -448.0);
+        else
+          f2val.fval.y = f2val.fval.y > 448.0f ? 448.0f : (f2val.fval.y < -448.0f ? -448.0f : f2val.fval.y);
       }
     } else {
       if ((f2val.i32val[0] & 0x7F800000) != 0x7F800000) {
         if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fmed3f))
           f2val.fval.x = __builtin_amdgcn_fmed3f(f2val.fval.x, 57344.0, -57344.0);
+        else
+          f2val.fval.x = f2val.fval.x > 57344.0f ? 57344.0f : (f2val.fval.x < -57344.0f ? -57344.0f : f2val.fval.x);
       }
       if ((f2val.i32val[1] & 0x7F800000) != 0x7F800000) {
         if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fmed3f))
           f2val.fval.y = __builtin_amdgcn_fmed3f(f2val.fval.y, 57344.0, -57344.0);
+        else
+          f2val.fval.y = f2val.fval.y > 57344.0f ? 57344.0f : (f2val.fval.y < -57344.0f ? -57344.0f : f2val.fval.y);
       }
     }
   }
@@ -630,10 +648,10 @@ cast_to_f8x2_from_f32x2(float2 v, bool saturate, __hip_fp8_interpretation_t inte
   f2val.i32val[0] = (interpret == __HIP_E4M3_FNUZ) || (interpret == __HIP_E4M3)
                         ? (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_pk_fp8_f32)
                                ? __builtin_amdgcn_cvt_pk_fp8_f32(v.x, v.y, 0, false)
-                               : 0u)
+                               : (__builtin_trap(), 0u))
                         : (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_pk_bf8_f32)
                                ? __builtin_amdgcn_cvt_pk_bf8_f32(v.x, v.y, 0, false)
-                               : 0u);
+                               : (__builtin_trap(), 0u));
 
   return static_cast<__hip_fp8x2_storage_t>(f2val.i16val[0]);
 }
@@ -649,10 +667,10 @@ static __device__ float cast_to_f32_from_f8(__hip_fp8_storage_t v,
   float fval = (interpret == __HIP_E4M3_FNUZ) || (interpret == __HIP_E4M3)
                    ? (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_f32_fp8)
                           ? __builtin_amdgcn_cvt_f32_fp8(val.i32val, 0)
-                          : 0.0f)
+                          : (__builtin_trap(), 0.0f))
                    : (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_f32_bf8)
                           ? __builtin_amdgcn_cvt_f32_bf8(val.i32val, 0)
-                          : 0.0f);
+                          : (__builtin_trap(), 0.0f));
   return fval;
 }
 
@@ -667,10 +685,10 @@ static __device__ float2 cast_to_f32x2_from_f8x2(__hip_fp8x2_storage_t v,
   auto f2 = (interpret == __HIP_E4M3_FNUZ) || (interpret == __HIP_E4M3)
                 ? (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_pk_f32_fp8)
                        ? __builtin_amdgcn_cvt_pk_f32_fp8(val.i32val, false)
-                       : __amd_floatx2_storage_t{})
+                       : (__builtin_trap(), __amd_floatx2_storage_t{}))
                 : (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_pk_f32_bf8)
                        ? __builtin_amdgcn_cvt_pk_f32_bf8(val.i32val, false)
-                       : __amd_floatx2_storage_t{});
+                       : (__builtin_trap(), __amd_floatx2_storage_t{}));
   return float2{f2[0], f2[1]};
 }
 #endif  // HIP_FP8_CVT_FAST_PATH

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_unsafe_atomics.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_unsafe_atomics.h
@@ -49,7 +49,6 @@ __device__ inline float unsafeAtomicAdd(float* addr, float value) {
   if (__builtin_amdgcn_is_shared((const __attribute__((address_space(0))) void*)addr)) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_ds_atomic_fadd_f32))
       return __builtin_amdgcn_ds_atomic_fadd_f32(addr, value);
-    return 0.0f;
   } else if (__builtin_amdgcn_is_private((const __attribute__((address_space(0))) void*)addr)) {
     float temp = *addr;
     *addr = temp + value;
@@ -57,9 +56,9 @@ __device__ inline float unsafeAtomicAdd(float* addr, float value) {
   } else {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_atomic_fadd_f32))
       return __builtin_amdgcn_global_atomic_fadd_f32(addr, value);
-    return 0.0f;
   }
-#elif __has_builtin(__hip_atomic_fetch_add)
+#endif
+#if __has_builtin(__hip_atomic_fetch_add)
   __HIP_ATOMICS_IGNORE_DENORMAL_MODE {
     return __hip_atomic_fetch_add(addr, value, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
   }
@@ -172,8 +171,8 @@ __device__ inline double unsafeAtomicAdd(double* addr, double value) {
 #if defined(__gfx90a__) && __has_builtin(__builtin_amdgcn_flat_atomic_fadd_f64)
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fadd_f64))
     return __builtin_amdgcn_flat_atomic_fadd_f64(addr, value);
-  return 0.0;
-#elif __has_builtin(__hip_atomic_fetch_add)
+#endif
+#if __has_builtin(__hip_atomic_fetch_add)
   __HIP_ATOMICS_IGNORE_DENORMAL_MODE {
     return __hip_atomic_fetch_add(addr, value, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
   }
@@ -213,8 +212,7 @@ __device__ inline double unsafeAtomicMax(double* addr, double val) {
     __has_builtin(__builtin_amdgcn_flat_atomic_fmax_f64)
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fmax_f64))
     return __builtin_amdgcn_flat_atomic_fmax_f64(addr, val);
-  return 0.0;
-#else
+#endif
 #if __has_builtin(__hip_atomic_load) && __has_builtin(__hip_atomic_compare_exchange_strong)
   __HIP_ATOMICS_IGNORE_DENORMAL_MODE {
     double value = __hip_atomic_load(addr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
@@ -234,7 +232,6 @@ __device__ inline double unsafeAtomicMax(double* addr, double val) {
                                        __ATOMIC_RELAXED, __ATOMIC_RELAXED);
   }
   return __longlong_as_double(value);
-#endif
 #endif
 }
 
@@ -269,8 +266,7 @@ __device__ inline double unsafeAtomicMin(double* addr, double val) {
     __has_builtin(__builtin_amdgcn_flat_atomic_fmin_f64)
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fmin_f64))
     return __builtin_amdgcn_flat_atomic_fmin_f64(addr, val);
-  return 0.0;
-#else
+#endif
 #if __has_builtin(__hip_atomic_load) && __has_builtin(__hip_atomic_compare_exchange_strong)
   __HIP_ATOMICS_IGNORE_DENORMAL_MODE {
     double value = __hip_atomic_load(addr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
@@ -290,7 +286,6 @@ __device__ inline double unsafeAtomicMin(double* addr, double val) {
                                        __ATOMIC_RELAXED, __ATOMIC_RELAXED);
   }
   return __longlong_as_double(value);
-#endif
 #endif
 }
 

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_warp_functions.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_warp_functions.h
@@ -24,10 +24,12 @@ __device__ static inline unsigned __hip_ds_bpermute(int index, unsigned src) {
     float f;
   } tmp;
   tmp.u = src;
-  tmp.i = __builtin_amdgcn_is_invocable(__builtin_amdgcn_ds_bpermute)
-              ? __builtin_amdgcn_ds_bpermute(index, tmp.i)
-              : 0;
-  return tmp.u;
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_ds_bpermute)) {
+    tmp.i = __builtin_amdgcn_ds_bpermute(index, tmp.i);
+    return tmp.u;
+  }
+  __builtin_trap();
+  return 0;
 }
 
 __device__ static inline float __hip_ds_bpermutef(int index, float src) {
@@ -37,10 +39,12 @@ __device__ static inline float __hip_ds_bpermutef(int index, float src) {
     float f;
   } tmp;
   tmp.f = src;
-  tmp.i = __builtin_amdgcn_is_invocable(__builtin_amdgcn_ds_bpermute)
-              ? __builtin_amdgcn_ds_bpermute(index, tmp.i)
-              : 0;
-  return tmp.f;
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_ds_bpermute)) {
+    tmp.i = __builtin_amdgcn_ds_bpermute(index, tmp.i);
+    return tmp.f;
+  }
+  __builtin_trap();
+  return 0.0f;
 }
 
 __device__ static inline unsigned __hip_ds_permute(int index, unsigned src) {
@@ -50,10 +54,12 @@ __device__ static inline unsigned __hip_ds_permute(int index, unsigned src) {
     float f;
   } tmp;
   tmp.u = src;
-  tmp.i = __builtin_amdgcn_is_invocable(__builtin_amdgcn_ds_permute)
-              ? __builtin_amdgcn_ds_permute(index, tmp.i)
-              : 0;
-  return tmp.u;
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_ds_permute)) {
+    tmp.i = __builtin_amdgcn_ds_permute(index, tmp.i);
+    return tmp.u;
+  }
+  __builtin_trap();
+  return 0;
 }
 
 __device__ static inline float __hip_ds_permutef(int index, float src) {
@@ -63,10 +69,12 @@ __device__ static inline float __hip_ds_permutef(int index, float src) {
     float f;
   } tmp;
   tmp.f = src;
-  tmp.i = __builtin_amdgcn_is_invocable(__builtin_amdgcn_ds_permute)
-              ? __builtin_amdgcn_ds_permute(index, tmp.i)
-              : 0;
-  return tmp.f;
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_ds_permute)) {
+    tmp.i = __builtin_amdgcn_ds_permute(index, tmp.i);
+    return tmp.f;
+  }
+  __builtin_trap();
+  return 0.0f;
 }
 
 #define __hip_ds_swizzle(src, pattern) __hip_ds_swizzle_N<(pattern)>((src))
@@ -79,10 +87,12 @@ template <int pattern> __device__ static inline unsigned __hip_ds_swizzle_N(unsi
     float f;
   } tmp;
   tmp.u = src;
-  tmp.i = __builtin_amdgcn_is_invocable(__builtin_amdgcn_ds_swizzle)
-              ? __builtin_amdgcn_ds_swizzle(tmp.i, pattern)
-              : 0;
-  return tmp.u;
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_ds_swizzle)) {
+    tmp.i = __builtin_amdgcn_ds_swizzle(tmp.i, pattern);
+    return tmp.u;
+  }
+  __builtin_trap();
+  return 0;
 }
 
 template <int pattern> __device__ static inline float __hip_ds_swizzlef_N(float src) {
@@ -92,10 +102,12 @@ template <int pattern> __device__ static inline float __hip_ds_swizzlef_N(float 
     float f;
   } tmp;
   tmp.f = src;
-  tmp.i = __builtin_amdgcn_is_invocable(__builtin_amdgcn_ds_swizzle)
-              ? __builtin_amdgcn_ds_swizzle(tmp.i, pattern)
-              : 0;
-  return tmp.f;
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_ds_swizzle)) {
+    tmp.i = __builtin_amdgcn_ds_swizzle(tmp.i, pattern);
+    return tmp.f;
+  }
+  __builtin_trap();
+  return 0.0f;
 }
 
 #define __hip_move_dpp(src, dpp_ctrl, row_mask, bank_mask, bound_ctrl)                             \

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
@@ -86,14 +86,13 @@ template <typename T> __device__ inline T __hip_readfirstlane(T val) {
   u.d = val;
   // NOTE: The builtin returns int, so we first cast it to unsigned int and only
   // then extend it to 64 bits.
-  unsigned long long lower = (unsigned)(
-      __builtin_amdgcn_is_invocable(__builtin_amdgcn_readfirstlane)
-          ? __builtin_amdgcn_readfirstlane(u.l)
-          : 0);
-  unsigned long long upper = (unsigned)(
-      __builtin_amdgcn_is_invocable(__builtin_amdgcn_readfirstlane)
-          ? __builtin_amdgcn_readfirstlane(u.l >> 32)
-          : 0);
+  unsigned long long lower, upper;
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_readfirstlane)) {
+    lower = (unsigned)__builtin_amdgcn_readfirstlane(u.l);
+    upper = (unsigned)__builtin_amdgcn_readfirstlane(u.l >> 32);
+  } else {
+    __builtin_trap();
+  }
   u.l = (upper << 32) | lower;
   return u.d;
 }
@@ -167,10 +166,16 @@ template <typename T> __device__ inline T __hip_readfirstlane(T val) {
 __device__ inline void __syncwarp() {
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fence))
     __builtin_amdgcn_fence(__ATOMIC_RELEASE, "wavefront");
+  else
+    __atomic_thread_fence(__ATOMIC_RELEASE);
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_wave_barrier))
     __builtin_amdgcn_wave_barrier();
+  else
+    __builtin_trap();
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fence))
     __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "wavefront");
+  else
+    __atomic_thread_fence(__ATOMIC_ACQUIRE);
 }
 
 template <typename MaskT> __device__ inline void __syncwarp(MaskT mask) {

--- a/projects/clr/hipamd/include/hip/amd_detail/hip_cooperative_groups_helper.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/hip_cooperative_groups_helper.h
@@ -230,6 +230,8 @@ __CG_STATIC_QUALIFIER__ dim3 block_dim() {
 __CG_STATIC_QUALIFIER__ void barrier_arrive() {
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fence))
     __builtin_amdgcn_fence(__ATOMIC_RELEASE, "workgroup");
+  else
+    __atomic_thread_fence(__ATOMIC_RELEASE);
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_s_barrier_signal))
     __builtin_amdgcn_s_barrier_signal(-1);  // -1 is workgroup barriers
 }
@@ -239,8 +241,12 @@ __CG_STATIC_QUALIFIER__ void barrier_wait() {
     __builtin_amdgcn_s_barrier_wait(-1);
   else if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_s_barrier))
     __builtin_amdgcn_s_barrier();
+  else
+    __builtin_trap();
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fence))
     __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "workgroup");
+  else
+    __atomic_thread_fence(__ATOMIC_ACQUIRE);
 }
 }  // namespace workgroup
 
@@ -250,6 +256,8 @@ namespace tiled_group {
 __CG_STATIC_QUALIFIER__ void sync() {
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fence))
     __builtin_amdgcn_fence(__ATOMIC_ACQ_REL, "wavefront");
+  else
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
 }
 
 }  // namespace tiled_group
@@ -260,6 +268,8 @@ namespace coalesced_group {
 __CG_STATIC_QUALIFIER__ void sync() {
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fence))
     __builtin_amdgcn_fence(__ATOMIC_ACQ_REL, "wavefront");
+  else
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
 }
 
 // Masked bit count
@@ -289,18 +299,26 @@ namespace cluster {
 __CG_STATIC_QUALIFIER__ void sync() {
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fence))
     __builtin_amdgcn_fence(__ATOMIC_RELEASE, "cluster");
+  else
+    __atomic_thread_fence(__ATOMIC_RELEASE);
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_s_cluster_barrier))
     // Generates a signal + wait combination for cluster barrier
     __builtin_amdgcn_s_cluster_barrier();
   else if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_s_barrier))
     __builtin_amdgcn_s_barrier();  // fallback to s_barrier if device does not support clusters
+  else
+    __builtin_trap();
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fence))
     __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "cluster");
+  else
+    __atomic_thread_fence(__ATOMIC_ACQUIRE);
 }
 
 __CG_STATIC_QUALIFIER__ void barrier_arrive() {
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fence))
     __builtin_amdgcn_fence(__ATOMIC_RELEASE, "cluster");
+  else
+    __atomic_thread_fence(__ATOMIC_RELEASE);
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_s_barrier_signal) &&
       __builtin_amdgcn_is_invocable(__builtin_amdgcn_s_barrier_wait)) {
     bool isfirst = __builtin_amdgcn_is_invocable(__builtin_amdgcn_s_barrier_signal_isfirst)
@@ -312,6 +330,8 @@ __CG_STATIC_QUALIFIER__ void barrier_arrive() {
       // Signal the cluster barrier, -3 means user cluster barrier
       __builtin_amdgcn_s_barrier_signal(-3);
     }
+  } else {
+    __builtin_trap();
   }
 }
 
@@ -321,8 +341,12 @@ __CG_STATIC_QUALIFIER__ void barrier_wait() {
     __builtin_amdgcn_s_barrier_wait(-3);
   else if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_s_barrier))
     __builtin_amdgcn_s_barrier();  // Fall back to s_barrier
+  else
+    __builtin_trap();
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_fence))
     __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "cluster");
+  else
+    __atomic_thread_fence(__ATOMIC_ACQUIRE);
 }
 
 __CG_STATIC_QUALIFIER__ dim3 block_index() {


### PR DESCRIPTION
## Motivation

Some `__builtin_amdgcn_*` calls with `__builtin_amdgcn_is_invocable` guards present two classes of bugs by not handling the case where `is_invocable` returns false at runtime:

1. Existing fallback made unreachable. In files like amd_hip_fp16.h and amd_hip_bf16.h, a CAS-loop fallback existed under `#else` for when `__has_builtin` is false. The builtin call is wrapped inside an `if (is_invocable)` but left the return statement outside the if, making the `#else CAS fallback` dead code. On SPIR-V targets, `__has_builtin` is true (the compiler knows the builtin) but `is_invocable` might return false at runtime (the hardware doesn't support it), so the function returns the original value without performing the atomic, resulting in a silent no-op.
2. No fallback added. In files like amd_hip_cooperative_groups_memcpy.h and amd_warp_functions.h, some builtin calls are wrapped with `if (is_invocable)` without adding an else branch. When `is_invocable` is false, the operation is silently skipped. As an example, for the memcpy case, this means pointer arithmetic advances without any data actually being copied.

## Technical Details

There are different types of fixes depending on the affected builtin:

- When a CAS-loop fallback is available (amd_hip_fp16.h, amd_hip_bf16.h, amd_hip_unsafe_atomics.h, amd_hip_atomic.h): restructured the preprocessor/runtime flow so the CAS loop is reachable when `is_invocable` is false.
- When a fence fallback is available (amd_device_functions.h, amd_warp_sync_functions.h, hip_cooperative_groups_helper.h): added `__atomic_thread_fence` as the else-branch for `__builtin_amdgcn_fence guards`.
- When a software clamp fallback mechanism is available (amd_hip_fp8.h): added min/max software saturation as the else-branch for fmed3f guards.
- When there is no software equivalent (amd_warp_functions.h, amd_hip_cooperative_groups.h, amd_hip_cooperative_groups_memcpy.h, amd_hip_fp4.h, amd_hip_fp6.h): added `__builtin_trap()` to abort loudly rather than silently producing wrong results (e.g. no op).

In general, the philosophy is use a fallback when possible, otherwise produce an error rather than a silent no-op/wrong result.

## Issue Tracking
N/A

## Test Plan
Build and HeCBench/f16atomic-hip test, which was the test that uncovered the issue for `unsafeAtomicAdd`.

## Test Result
HeCBench/f16atomic-hip test calls `unsafeAtomicAdd` which was silently no-op'ing, resulting in wrong validation. With this patch, the result validates correctly.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
