### PR TITLE
fix(amdsmi): write enabled/disabled to ptl_enable sysfs node

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -115,6 +115,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Resolved Issues
 
+- **Fixed `amd-smi set --ptl-status` silently failing to change PTL state**.  
+  - The set path wrote `"1"`/`"0"` to the `ptl/ptl_enable` sysfs node, which only accepts `"enabled"`/`"disabled"`; the driver ignored the numeric write while the API still reported success. The state now changes as expected, and a rejected write returns a real error instead of a generic success.
+
 - **Fixed `amd-smi set --power-cap` rejecting the minimum allowed value**.  
   - The lower bound is now inclusive, so setting the power cap to the exact minimum of the reported range (e.g. `210` when the range is 210-300W) succeeds instead of failing validation, matching the inclusive range shown in the error message.
 

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -8,6 +8,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Resolved Issues
 
+- **Fixed `amd-smi set --ptl-status` silently failing to change PTL state**.  
+  - The set path wrote `"1"`/`"0"` to the `ptl/ptl_enable` sysfs node, which only accepts `"enabled"`/`"disabled"`; the driver ignored the numeric write while the API still reported success. The state now changes as expected, and a rejected write returns a real error instead of a generic success.
+
 - **Fixed `amd-smi process` hiding compute processes owned by other users**.  
   - A caller without permission to read another process's `/proc/<pid>/fd` was misdetected as running in a separate PID namespace, which caused the whole compute-process list to come back empty. Such processes are now listed with a redacted (`N/A`) name instead of being dropped.
 
@@ -114,9 +117,6 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Removed the unused `amdsmi_nic_link_type_t` enum from the public header**. No API or struct referenced it; NIC link types are reported through `amdsmi_link_type_t`, which gains `AMDSMI_LINK_TYPE_NUMA` and `AMDSMI_LINK_TYPE_XNUMA` in this release.
 
 ### Resolved Issues
-
-- **Fixed `amd-smi set --ptl-status` silently failing to change PTL state**.  
-  - The set path wrote `"1"`/`"0"` to the `ptl/ptl_enable` sysfs node, which only accepts `"enabled"`/`"disabled"`; the driver ignored the numeric write while the API still reported success. The state now changes as expected, and a rejected write returns a real error instead of a generic success.
 
 - **Fixed `amd-smi set --power-cap` rejecting the minimum allowed value**.  
   - The lower bound is now inclusive, so setting the power cap to the exact minimum of the reported range (e.g. `210` when the range is 210-300W) succeeds instead of failing validation, matching the inclusive range shown in the error message.

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
@@ -5852,15 +5852,16 @@ rsmi_status_t rsmi_get_gpu_ptl_state(uint32_t dv_ind, bool* enabled);
  *  @platform{gpu_bm_linux} @platform{host}
  *
  *  @details This function enables or disables PTL (Peak Tops Limiter) operation.
- *  Use rsmi_set_gpu_ptl_enable_with_formats()
+ *  Use rsmi_set_gpu_ptl_formats()
  *  for more control over the preferred data formats when enabling.
  *
- *  @param[in] processor_handle Device to configure
+ *  @param[in] dv_ind a device index
  *
- *  @param[in] enable Boolean flag: true to enable PTL with default formats,
+ *  @param[in] enabled Boolean flag: true to enable PTL with default formats,
  *  false to disable PTL
  *
- *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
+ *          ::RSMI_STATUS_NOT_SUPPORTED is returned in case the sysfs fails
  */
 rsmi_status_t rsmi_set_gpu_ptl_state(uint32_t dv_ind, bool enabled);
 

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
@@ -1025,10 +1025,8 @@ int Device::writeDevInfo(DevInfoTypes type, uint64_t val) {
       break;
 
     case kDevPtlStatus:
-      // The sysfs node accepts the strings "enabled"/"disabled" (and reports
-      // the same on read); writing "1"/"0" is silently ignored by the driver,
-      // leaving the state unchanged. Pass returnWriteErr=true so a rejected
-      // write surfaces the real errno instead of a generic status.
+      // The sysfs node only accepts "enabled"/"disabled"; writing "1"/"0" is
+      // silently ignored. returnWriteErr=true surfaces errno on a rejected write.
       return writeDevInfoStr(type, val ? "enabled" : "disabled", true);
       break;
 

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
@@ -1021,8 +1021,15 @@ int Device::writeDevInfo(DevInfoTypes type, uint64_t val) {
     case kDevOverDriveLevel:  // integer between 0 and 20
     case kDevPowerODVoltage:
     case kDevPowerProfileMode:
-    case kDevPtlStatus:
       return writeDevInfoStr(type, std::to_string(val));
+      break;
+
+    case kDevPtlStatus:
+      // The sysfs node accepts the strings "enabled"/"disabled" (and reports
+      // the same on read); writing "1"/"0" is silently ignored by the driver,
+      // leaving the state unchanged. Pass returnWriteErr=true so a rejected
+      // write surfaces the real errno instead of a generic status.
+      return writeDevInfoStr(type, val ? "enabled" : "disabled", true);
       break;
 
     case kDevPerfLevel:  // string: "auto", "low", "high", "manual", ...

--- a/projects/amdsmi/tests/python/functional/gpu/test_ptl.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_ptl.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""GPU PTL (PCIe telemetry logging): enable/disable set + read-back round-trip."""
+
+import unittest
+
+import common.common as common
+from common.common import amdsmi
+
+
+class TestGpuPtl(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.common = common.Common(common.verbose)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            amdsmi.amdsmi_shut_down()
+        except amdsmi.AmdSmiLibraryException:
+            pass
+
+    def setUp(self):
+        self.raise_exception = None
+        self.common.amdsmi_smart_init()
+        self.common.processors = amdsmi.amdsmi_get_processor_handles()
+
+    def tearDown(self):
+        amdsmi.amdsmi_shut_down()
+
+    def test_set_gpu_ptl_state(self):
+        """Setting PTL state must actually change the reported state.
+
+        Regression guard: the set path used to write "1"/"0" to the
+        ptl/ptl_enable sysfs node, which only accepts "enabled"/"disabled".
+        The driver silently ignored the numeric write, so the state never
+        changed even though the API reported success. GPUs that do not
+        support PTL return a not-supported status and are skipped.
+        """
+        self.common.print_func_name("")
+
+        mismatches = []
+        for i, gpu in enumerate(self.common.processors):
+            self.common.print_device_header(i)
+
+            # Read the original state; GPUs without PTL support are skipped
+            # (check_ret treats not-supported codes as a non-failure).
+            msg = f"\t### amdsmi_get_gpu_ptl_state(gpu={i}):"
+            try:
+                original = amdsmi.amdsmi_get_gpu_ptl_state(gpu)
+                self.common.print(msg, original)
+                self.common.check_ret("", "", self.common.PASS)
+            except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
+                if self.common.check_ret(msg, e, self.common.PASS):
+                    self.raise_exception = e
+                continue
+
+            # Drive each state and confirm the read-back matches what was set.
+            for desired in (True, False):
+                set_msg = f"\t### amdsmi_set_gpu_ptl_state(gpu={i}, enable={desired}):"
+                try:
+                    amdsmi.amdsmi_set_gpu_ptl_state(gpu, int(desired))
+                    self.common.print(set_msg, "")
+                    self.common.check_ret("", "", self.common.PASS)
+                except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
+                    if self.common.check_ret(set_msg, e, self.common.PASS):
+                        self.raise_exception = e
+                    continue
+
+                read_back = amdsmi.amdsmi_get_gpu_ptl_state(gpu)
+                self.common.print(f"\t### amdsmi_get_gpu_ptl_state(gpu={i}) after set:", read_back)
+                if read_back != desired:
+                    mismatches.append(
+                        f"gpu({i}): set PTL state to {desired} but read back {read_back}"
+                    )
+
+            # Best-effort restore of the original state.
+            try:
+                amdsmi.amdsmi_set_gpu_ptl_state(gpu, int(original))
+            except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
+                self.common.print(f"\t### restore amdsmi_set_gpu_ptl_state(gpu={i}) failed:", e)
+
+        if mismatches:
+            self.fail("PTL set did not take effect:\n  " + "\n  ".join(mismatches))
+        if self.raise_exception:
+            raise self.raise_exception
+        return
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/amdsmi/tests/python/functional/gpu/test_ptl.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_ptl.py
@@ -58,6 +58,7 @@ class TestGpuPtl(unittest.TestCase):
         self.common.print_func_name("")
 
         mismatches = []
+        tested = 0
         for i, gpu in enumerate(self.common.processors):
             self.common.print_device_header(i)
 
@@ -73,6 +74,8 @@ class TestGpuPtl(unittest.TestCase):
                     self.raise_exception = e
                 continue
 
+            tested += 1
+
             # Drive each state and confirm the read-back matches what was set.
             for desired in (True, False):
                 set_msg = f"\t### amdsmi_set_gpu_ptl_state(gpu={i}, enable={desired}):"
@@ -87,22 +90,28 @@ class TestGpuPtl(unittest.TestCase):
 
                 read_back = amdsmi.amdsmi_get_gpu_ptl_state(gpu)
                 self.common.print(f"\t### amdsmi_get_gpu_ptl_state(gpu={i}) after set:", read_back)
+                self.common.check_ret("", "", self.common.PASS)
                 if read_back != desired:
                     mismatches.append(
                         f"gpu({i}): set PTL state to {desired} but read back {read_back}"
                     )
 
-            # Best-effort restore of the original state.
+            # Restore the original state; a genuine failure (not merely
+            # not-supported) fails the test instead of being swallowed.
+            restore_msg = f"\t### restore amdsmi_set_gpu_ptl_state(gpu={i}):"
             try:
                 amdsmi.amdsmi_set_gpu_ptl_state(gpu, int(original))
+                self.common.check_ret("", "", self.common.PASS)
             except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                self.common.print(f"\t### restore amdsmi_set_gpu_ptl_state(gpu={i}) failed:", e)
+                if self.common.check_ret(restore_msg, e, self.common.PASS):
+                    self.raise_exception = e
 
-        if mismatches:
-            self.fail("PTL set did not take effect:\n  " + "\n  ".join(mismatches))
         if self.raise_exception:
             raise self.raise_exception
-        return
+        if mismatches:
+            self.fail("PTL set did not take effect:\n  " + "\n  ".join(mismatches))
+        if tested == 0:
+            self.skipTest("No PTL-capable GPUs found")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`sudo amd-smi set --ptl-status 1` reports *"Successfully set PTL state to Enabled"* on every GPU, but the state still reads `Disabled` afterwards, with no error and no reboot fixing it. The write was silently a no-op.

## Technical Details

The `device/ptl/ptl_enable` sysfs node accepts — and reports on read — the strings `"enabled"`/`"disabled"`. `rsmi_set_gpu_ptl_state()` routes through `Device::writeDevInfo(DevInfoTypes, uint64_t)`, which wrote `std::to_string(val)`, i.e. `"1"`/`"0"`. The driver's `store` handler doesn't recognize `"1"`, silently ignores it, and returns success for the `write()`, so:

1. the `write()` syscall succeeds → no error is generated;
2. `rsmi_set_gpu_ptl_state()` returns `SUCCESS` → the CLI prints "Successfully set…";
3. the state never changes → the next read still shows `Disabled`.

The read path (`rsmi_get_gpu_ptl_state()`) already compares against `"enabled"`/`"disabled"`, and the in-tree rdc PTL guard reads/writes those same strings, so the write path was the sole inconsistency.

This change writes `"enabled"`/`"disabled"` for `kDevPtlStatus`, and passes `returnWriteErr=true` so a genuinely rejected write surfaces the real errno instead of being masked as a generic status. The CLI interface (`--ptl-status 0|1`) is unchanged.

## Issue Tracking

Closes #8924

## Test Plan

- `clang-format --Werror` on the changed file.
- `-fsyntax-only` compile of the translation unit using `compile_commands.json`.
- Direct sysfs check on a PTL-capable box:
  ```
  P=/sys/class/drm/card0/device/ptl/ptl_enable
  echo 1       | sudo tee $P; cat $P   # old behavior -> stays "disabled"
  echo enabled | sudo tee $P; cat $P   # new behavior -> "enabled"
  ```

## Test Result

- clang-format: clean.
- Syntax-only compile: exit 0 (only pre-existing, unrelated warnings).
- Existing CLI tests exercise the `--ptl-status 0|1` interface, which is unchanged.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
