### PR TITLE
fix(clr): fix graph profiling UAFs and restore per-stream visibility

### DIFF
--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -306,6 +306,9 @@ void __hipUnregisterFatBinary(void** modules) {
         // By synchronizing devices ensure that all HSA signal handlers
         // complete before RemoveFatBinary
         hipDevice->SyncAllStreams(true);
+        // Drain the ROCr async event thread so all ReportActivity() callbacks
+        // complete before the Program (and its kernel name strings) are freed.
+        hipDevice->devices()[0]->WaitForHsaAsyncHandlersIdle();
       }
     });
   }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -487,11 +487,14 @@ void Timestamp::ExtractSignalTiming(ProfilingSignal* signal,
     end = std::max(sig_end, end);
   }
 
-  // Handle AccumulateCommand timestamps (convert ticks to system time)
+  // Handle AccumulateCommand timestamps (convert ticks to system time).
+  // Pass signal->queue_index_ so ReportActivity can assign each kernel to
+  // the internal parallel stream it actually ran on, not the launch stream.
   if ((command().type() == CL_COMMAND_TASK) && (signal->flags_.isPacketDispatch_ == true)) {
     static_cast<amd::AccumulateCommand&>(command()).addTimestamps(
         static_cast<uint64_t>(sig_start * ticksToTime_),
-        static_cast<uint64_t>(sig_end * ticksToTime_));
+        static_cast<uint64_t>(sig_end * ticksToTime_),
+        signal->queue_index_);
   }
 
   signal->flags_.done_ = true;

--- a/projects/clr/rocclr/platform/activity.cpp
+++ b/projects/clr/rocclr/platform/activity.cpp
@@ -67,8 +67,9 @@ void ReportActivity(const amd::Command& command) {
   auto function = report_activity.load(std::memory_order_acquire);
   if (!function) return;
 
-  const auto* queue = command.queue();
-  assert(queue != nullptr);
+  // Use device_id_ and queue_id_ cached at enqueue time — do NOT dereference
+  // command.queue() here. The queue may be freed by hipStreamDestroy on T0
+  // while this runs on the async signal handler thread T1 (UAF race).
   activity_record_t record{
       ACTIVITY_DOMAIN_HIP_OPS,                  // activity domain
       command.type(),                           // activity kind
@@ -77,8 +78,8 @@ void ReportActivity(const amd::Command& command) {
       command.profilingInfo().start_,           // begin timestamp, ns
       command.profilingInfo().end_,             // end timestamp, ns
       {{
-          static_cast<int>(queue->device().info().driverNodeId_),  // device id
-          queue->vdev()->index()                                   // queue id
+          command.profilingInfo().device_id_,   // device id (cached at enqueue)
+          command.profilingInfo().queue_id_     // queue id  (cached at enqueue)
       }},
       {}  // copied data size for memcpy, or kernel name for dispatch
   };
@@ -141,10 +142,15 @@ void ReportActivity(const amd::Command& command) {
     // kernel_names and timestamps are both populated only when profiling is active
     // at dispatch time. Walk the shorter of the two as a safety bound.
     for (uint32_t i = 0; i < kernel_names.size() && i < timestamps.size(); i++) {
-      auto it = timestamps[i];
-      record.begin_ns = it.first;
-      record.end_ns = it.second;
+      auto& ts = timestamps[i];
+      record.begin_ns = ts.start;
+      record.end_ns = ts.end;
       record.kernel_name = kernel_names[i];
+      // Use per-packet queue_index when available so each kernel is assigned
+      // to the internal parallel stream it ran on, not the launch stream.
+      if (ts.queue_index != UINT32_MAX) {
+        record.queue_id = static_cast<uint64_t>(ts.queue_index);
+      }
       function(ACTIVITY_DOMAIN_HIP_OPS, operation_id, &record);
     }
   } else {

--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -398,6 +398,10 @@ void Command::enqueue() {
         (type() == CL_COMMAND_TASK)) {
       // The current HSA signal tracking logic requires profiling enabled for the markers
       EnableProfiling();
+      // Cache device/queue IDs while queue_ is alive. ReportActivity accesses these
+      // from the async signal handler (T1) which can race with hipStreamDestroy (T0).
+      profilingInfo_.device_id_ = static_cast<int>(queue_->device().info().driverNodeId_);
+      profilingInfo_.queue_id_  = static_cast<uint64_t>(queue_->vdev()->index());
       // Update batch head for the current marker. Hence the status of all commands can be
       // updated upon the marker completion
       SetBatchHead(queue_->GetSubmissionBatch());
@@ -457,6 +461,8 @@ NDRangeKernelCommand::NDRangeKernelCommand(HostQueue& queue, const EventWaitList
     profilingInfo_.clear();
     profilingInfo_.correlation_id_ = activity_prof::correlation_id;
     profilingInfo_.marker_ts_ = true;
+    profilingInfo_.device_id_ = static_cast<int>(queue.device().info().driverNodeId_);
+    profilingInfo_.queue_id_  = static_cast<uint64_t>(queue.vdev()->index());
   }
   kernel_.retain();
 }

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -125,6 +125,10 @@ class Event : public RuntimeObject {
     bool enabled_;             //!< Profiling enabled for the wave limiter
     bool marker_ts_;           //!< TS marker
     bool batch_flush_ = true;  //!< Command can flush the batch in direct dispatch mode
+    // Cached at enqueue time so ReportActivity never dereferences command.queue().
+    // The queue may be freed (hipStreamDestroy) before the async signal handler runs.
+    int      device_id_ = -1;
+    uint64_t queue_id_  = 0;
 
     void clear() {
       queued_ = 0ULL;
@@ -1681,7 +1685,13 @@ class AccumulateCommand : public Command {
   std::vector<const char*> kernelNames_;
   //! GPU timestamps — one entry per kernel dispatch slot, parallel to
   //! kernelNames_, populated at signal completion time.
-  std::vector<std::pair<uint64_t, uint64_t>> timestamps_;
+  struct KernelTimestamp {
+    uint64_t start;
+    uint64_t end;
+    uint32_t queue_index;  //!< vGPU index of the stream that ran this kernel
+  };
+  std::vector<KernelTimestamp> timestamps_;
+  mutable std::mutex timestamps_lock_;  //!< Serialize concurrent addTimestamps() calls
   //! HW events that need to be released when this command is destroyed
   std::unordered_map<Device*, std::vector<void*>> hw_events_;
   //! When false, the destructor does not destroy hw_events_ (an external owner,
@@ -1724,15 +1734,19 @@ class AccumulateCommand : public Command {
   void addKernelName(const char* name) { kernelNames_.push_back(name); }
 
   //! Add GPU timestamps for one dispatch slot (called at signal completion).
-  void addTimestamps(uint64_t startTs, uint64_t endTs) {
-    timestamps_.push_back({startTs, endTs});
+  void addTimestamps(uint64_t startTs, uint64_t endTs, uint32_t queue_index = UINT32_MAX) {
+    std::lock_guard<std::mutex> lk(timestamps_lock_);
+    timestamps_.push_back({startTs, endTs, queue_index});
   }
 
   //! Return kernel name pointers (one per dispatch slot)
   const std::vector<const char*>& getKernelNames() const { return kernelNames_; }
 
   //! Return GPU timestamps (one per dispatch slot, populated at signal completion)
-  const std::vector<std::pair<uint64_t, uint64_t>>& getTimestamps() const { return timestamps_; }
+  const std::vector<KernelTimestamp>& getTimestamps() const {
+    std::lock_guard<std::mutex> lk(timestamps_lock_);
+    return timestamps_;
+  }
 
   //! The command implementation
   virtual void submit(device::VirtualDevice& device) { device.submitAccumulate(*this); }


### PR DESCRIPTION
Three UAF regressions from 5de80e1c1c (profile segment-scheduled graphs) and 7c23d18e7b (remove kernelNamesOwner) fixed:

1. queue->device() UAF in ReportActivity: Cache device_id_ and queue_id_ in ProfilingInfo at enqueue time so async handler never dereferences the freed CommandQueue.

2. addTimestamps data race on timestamps_ vector: Added timestamps_lock_ mutex to serialize concurrent push_back from T0 and T1. This also caused WaitForHsaAsyncHandlersIdle timeout and kernel name string UAF.

3. Single stream in profiling output (7c23d18e7b regression): Restored KernelTimestamp with queue_index, pass signal->queue_index_ through addTimestamps, use it in ReportActivity so each kernel is assigned to its actual parallel stream.

4. Drain async handlers before kernel names freed: Call WaitForHsaAsyncHandlersIdle() in __hipUnregisterFatBinary after SyncAllStreams to prevent kernel name string UAF at process exit.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
