### PR TITLE
fix(rocprofiler-sdk): fix GPU hang when device thread trace starts before hsa_init()

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -1345,6 +1345,10 @@ rocprofiler_set_api_table(const char* name,
                     hsa_api_table->core_, enable_queue_interposition);
         }
 
+        // Replay device thread trace contexts started before hsa_init(). Must run
+        // after queue_controller_init + interposition; starting SQTT earlier hangs the GPU.
+        rocprofiler::thread_trace::start_active_contexts();
+
 #if ROCPROFILER_SDK_HSA_PC_SAMPLING > 0
         // Initialize PC sampling service if configured
         if(runtime_pc_sampling_table)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -76,7 +76,7 @@ struct cbdata_t
 common::Synchronized<std::optional<int64_t>> client;
 
 // True once the HSA runtime is registered. Gates start_context() so pre-init
-// start requests are deferred and replayed by initialize().
+// start requests are deferred and replayed by start_active_contexts().
 std::atomic<bool>&
 hsa_inited()
 {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -583,7 +583,7 @@ void
 DeviceThreadTracer::start_context()
 {
     // Per-agent resources don't exist until HSA is registered; the request is
-    // cached in the active-context array and replayed by initialize().
+    // cached in the active-context array and replayed by start_active_contexts().
     if(!hsa_inited().load())
     {
         ROCP_INFO << "Device thread trace start requested before hsa_init; deferring";
@@ -650,12 +650,17 @@ initialize(HsaApiTable* table)
         if(ctx->device_thread_trace) ctx->device_thread_trace->resource_init();
         if(ctx->dispatch_thread_trace) ctx->dispatch_thread_trace->resource_init();
     }
+}
 
+void
+start_active_contexts()
+{
     // HSA resources now exist; allow start_context() to program the hardware.
     hsa_inited().store(true);
 
     // Replay device contexts started before hsa_init() (their start_context()
-    // returned early above). Dispatch mode needs no replay.
+    // returned early). Must run after the queue infrastructure is initialized
+    // (see registration.cpp); starting the SQTT hardware earlier hangs the GPU.
     for(auto& ctx : context::get_active_contexts())
     {
         if(ctx->device_thread_trace) ctx->device_thread_trace->start_context();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
@@ -224,9 +224,16 @@ private:
     std::shared_ptr<std::atomic<int>> worker_flag{nullptr};
 };
 
-/// Install the thread trace service for newly created contexts.
+/// Install the thread trace service for newly created contexts (builds per-agent
+/// resources; does not program hardware).
 void
 initialize(HsaApiTable* table);
+
+/// Replay start_context() for device thread trace contexts requested before
+/// hsa_init(). Must be called after the HSA queue infrastructure is initialized
+/// (see registration.cpp), not from initialize().
+void
+start_active_contexts();
 
 /// Tear down shared resources when the runtime shuts down.
 void


### PR DESCRIPTION
## Motivation

PR #8007 (AIPROFSDK-887) allows a device thread trace context to be started before `hsa_init()` by deferring the request and replaying it once HSA is registered. On `develop`, the new `thread-trace-api-agent-before-hsa-init-test` intermittently hangs the GPU (`HW Exception ... reason :GPU Hang`) because the deferred start programs the thread trace (SQTT) hardware too early during HSA initialization. This PR fixes the hang while keeping the deferred-start feature.

## Technical Details

The deferred-start replay ran inside `thread_trace::initialize()`, which executes during HSA table registration before `queue_controller_init()` and queue interposition are set up. Programming the SQTT hardware at that point intermittently wedges the GPU command processor. The replay is moved out of `initialize()` (now only builds per-agent resources) into a new `thread_trace::start_active_contexts()`, invoked at the end of the HSA registration path after `queue_controller_init()` and queue interposition. This matches the deferred-start ordering already used by device counting (`device_counting_service_hsa_registration`) and PC sampling (`post_hsa_init_start_active_service`). Changed files: `thread_trace/core.cpp`, `thread_trace/core.hpp`, `registration.cpp`.

## Test Plan

Reproduced on MI300X (gfx942, 8 GPUs) using the CI test environment (`ATT_START_BEFORE_HSA_INIT=1`), which hung within a few runs. After the fix: ran the failing test 100x in a loop, ran `thread-trace-api-agent-before-hsa-init-test` and `thread-trace-api-agent-start-stop-before-hsa-init-test` 25x each under `ctest --repeat until-fail`, ran the full thread-trace integration suite, and confirmed trace data is still collected end-to-end with the trace decoder (latency validated, identical to the normal agent test).

## Test Result

Before: GPU hang within 2-4 runs (~25%). After: 100/100 loop runs clean, both before-hsa-init tests pass 25/25 under ctest, full thread-trace suite passes (10/10, 2 disabled), and the decoder confirms trace data is collected. No regressions.

## Submission Checklist

- [V] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.