### PR TITLE
rocclr: flush image read to system scope for pinned host dst

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -1935,6 +1935,10 @@ bool KernelBlitManager::readImage(device::Memory& srcMemory, void* dstHost,
     // Get device memory for this virtual device
     Memory* dstMemory = dev().getRocMemory(amdMemory);
 
+    // Make the copy system-scoped so the pinned host buffer is CPU-visible
+    // when the blocking read returns, like readBuffer does.
+    gpu().addSystemScope();
+
     // Copy image to buffer
     result = copyImageToBuffer(srcMemory, *dstMemory, origin, dstOrigin, size, entire, rowPitch,
                                slicePitch, copyMetadata);


### PR DESCRIPTION
##Motivation
Kernel dispatches use agent-scope release fences by default
(`AMD_OPT_FLUSH=1`). A blocking `clEnqueueReadImage` into a user host pointer
pins that buffer and fills it with a blit kernel (`copyImageToBuffer`), but the
agent-scope fence only flushes to device scope. So the read can return before
the data is actually visible to the CPU.

This breaks the common pattern of reading an image, modifying the buffer on the
CPU, and writing it back (with no flush in between): the write races with the
still-draining read and the image ends up keeping its old contents.

It shows up as `ocltst OCLCreateImage` failures 

## Fix
Promote the read's copy dispatch to system scope in `readImage`, matching what
`readBuffer` already does.

## Test Plan
- Read/modify/write repros now return correct data at all sizes (previously
  wrong for <=256x256).
- `ocltst OCLCreateImage` passes 5/5 (was 3/5).
- Forcing `AMD_OPT_FLUSH=0` upstream gives the same correct behavior.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
ROCM-26081
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->



<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
