### PR TITLE
fix(rccl-tests): correct NCCL_CTA_POLICY_ZERO version guard to 2.28.0

### DIFF
--- a/projects/rccl-tests/src/common.cu
+++ b/projects/rccl-tests/src/common.cu
@@ -1111,8 +1111,8 @@ testResult_t TimeTest(struct threadArgs* args, ncclDataType_t type, const char* 
           const char* algoName = NULL;
           const char* protoName = NULL;
           bool fromSymk = false;
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2,27,0)
-          if (test_ncclVersion >= NCCL_VERSION(2,27,0) && local_register == SYMMETRIC_REGISTER && ctaPolicy != NCCL_CTA_POLICY_ZERO && rcclTestsGetSymkInfo) {
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2,28,0)
+          if (test_ncclVersion >= NCCL_VERSION(2,28,0) && local_register == SYMMETRIC_REGISTER && ctaPolicy != NCCL_CTA_POLICY_ZERO && rcclTestsGetSymkInfo) {
             if (args->collTest->getSymkInfo) {
               TESTCHECK(args->collTest->getSymkInfo(args->comms[0], args->nbytes / wordSize(type), type, op, &algo, &proto, &nchannels));
               fromSymk = true;


### PR DESCRIPTION
The getSymkInfo block in common.cu references NCCL_CTA_POLICY_ZERO, which is only defined in RCCL/NCCL 2.28+. The guard introduced in #8104 used NCCL_VERSION(2,27,0), so when building against RCCL 2.27.x (shipped in ROCm 7.1/7.2) the block is compiled but the symbol is undefined:

    error: use of undeclared identifier 'NCCL_CTA_POLICY_ZERO'

## Motivation

To build cleanly against RCCL 2.27.7.

## Technical Details

Bump both the compile-time guard and the matching runtime check to 2.28.0. On 2.27.x the block is compiled out and execution falls through to the existing !fromSymk path, which is the correct behavior for a pre-2.28 library. 

## Issue Tracking

JIRA ID: ROCM-28278

## Test Plan

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
