### PR TITLE
[hipFile/Python] Add missing fake async classes/functions

### DIFF
--- a/projects/hipfile/python/tests/conftest.py
+++ b/projects/hipfile/python/tests/conftest.py
@@ -120,6 +120,23 @@ _FAKE_PROPS = {
 }
 
 
+class _FakeAsyncIOHandle:  # pylint: disable=too-few-public-methods
+    """Stand-in for the real ``AsyncIOHandle`` cdef class.
+
+    The real class owns C storage the driver fills in when the async op
+    completes; here we just mirror its constructor and attribute surface
+    (``bytes_done`` read-only, ``size`` / ``file_offset`` / ``buffer_offset``
+    read-write) so ``file.py``'s ``read_async`` / ``write_async`` construct and
+    inspect it without a compiled extension.
+    """
+
+    def __init__(self, size, file_offset, buffer_offset):
+        self.size = size
+        self.file_offset = file_offset
+        self.buffer_offset = buffer_offset
+        self.bytes_done = 0
+
+
 def _build_fake_hipfile():
     """Create a fake ``hipfile._hipfile`` module.
 
@@ -170,6 +187,14 @@ def _build_fake_hipfile():
         size,
         0,
     )
+
+    # Asynchronous I/O -- default: full transfer, no error.
+    mod.AsyncIOHandle = _FakeAsyncIOHandle
+    mod.hipFileReadAsync = lambda handle, buffer_base, io, stream_handle: (0, 0)
+    mod.hipFileWriteAsync = lambda handle, buffer_base, io, stream_handle: (0, 0)
+    mod.hipFileStreamRegister = lambda stream_handle, flags=0: (0, 0)
+    mod.hipFileStreamDeregister = lambda stream_handle: (0, 0)
+    mod.supports_async = lambda: True
 
     # Error strings.
     mod.hipFileGetOpErrorString = lambda status: f"fake-op-error-{status}"


### PR DESCRIPTION
## Motivation

The hipFile Python test suite has been broken at collection since the async I/O
bindings (#7386): that PR added `AsyncIOHandle` and the async/stream callables to
the extension and imported them in `file.py`, but never updated the fake in
`conftest.py`. Every test importing `hipfile` errored during collection. Missed
because CI wasn't re-run after the unit tests (#8725) landed.

## Technical Details

Add the missing async names to the fake extension in `conftest.py`: a
`_FakeAsyncIOHandle` stand-in plus success-shaped `hipFileReadAsync` /
`hipFileWriteAsync` / `hipFileStreamRegister` / `hipFileStreamDeregister` /
`supports_async`. Tests-only change.

## Issue Tracking

JIRA ID: AIHIPFILE-171

## Test Plan

- Run the hipFile Python binding suite: `pytest projects/hipfile/python/tests/`.
- Lint the changed file: `black --check` and `pylint` on `conftest.py`.

## Test Result

- `42 passed` (previously: 5 collection errors, suite could not run).
- `black --check`: file left unchanged. `pylint`: rated 10.00/10.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
