### PR TITLE
fix(runtime, rocrtst) fix for device memory ring buffer queue timeouts.

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/queue_create.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/queue_create.cc
@@ -188,6 +188,16 @@ void QueueCreateTest::SystemMemQueueTest() {
   ASSERT_SUCCESS(hsa_queue_destroy(desc.queue));
 }
 
+void QueueCreateTest::DestroyQueues(hsa_amd_queue_create_desc_t* descs, uint32_t num_descs) {
+  for (uint32_t i = 0; i < num_descs; i++) {
+    if (descs[i].queue != nullptr) {
+      hsa_status_t status = hsa_queue_destroy(descs[i].queue);
+      ASSERT_SUCCESS(status);
+      descs[i].queue = nullptr;
+    }
+  }
+}
+
 void QueueCreateTest::DeviceMemRingBufQueueTest() {
   ASSERT_SUCCESS(rocrtst::SetDefaultAgents(this));
   ASSERT_SUCCESS(rocrtst::SetPoolsTypical(this));
@@ -256,11 +266,7 @@ void QueueCreateTest::BatchQueueCreateTest() {
   hsa_status_t status = hsa_amd_queue_create(*gpu_device1(), descs, kNumQueues);
   if (status == HSA_STATUS_ERROR_INVALID_ARGUMENT ||
       status == HSA_STATUS_ERROR_INVALID_QUEUE_CREATION) {
-    for (int i = 0; i < kNumQueues; i++) {
-      if (descs[i].queue != nullptr) {
-        hsa_queue_destroy(descs[i].queue);
-      }
-    }
+    DestroyQueues(descs, kNumQueues);
     printf("  BatchQueueCreateTest: SKIPPED (agent does not support "
            "device-memory flags or Large BAR is unavailable)\n");
     return;
@@ -276,9 +282,7 @@ void QueueCreateTest::BatchQueueCreateTest() {
     DispatchAndVerify(descs[i].queue, labels[i]);
   }
 
-  for (int i = 0; i < kNumQueues; i++) {
-    ASSERT_SUCCESS(hsa_queue_destroy(descs[i].queue));
-  }
+  DestroyQueues(descs, kNumQueues);
 }
 
 void QueueCreateTest::SdmaQueueCreateDestroyTest() {

--- a/projects/rocr-runtime/rocrtst/suites/functional/queue_create.h
+++ b/projects/rocr-runtime/rocrtst/suites/functional/queue_create.h
@@ -41,6 +41,7 @@ class QueueCreateTest : public TestBase {
 
  private:
   void DispatchAndVerify(hsa_queue_t* queue, const char* test_label);
+  void DestroyQueues(hsa_amd_queue_create_desc_t* descs, uint32_t num_descs);
 };
 
 #endif  // ROCRTST_SUITES_FUNCTIONAL_QUEUE_CREATE_H

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -606,11 +606,16 @@ void AqlQueue::AllocRegisteredRingBuffer(uint32_t queue_size_pkts) {
                                 "Trying to allocate an AQL ring buffer in device memory without "
                                 "large BAR PCIe enabled.");
     }
-    // Device-memory ring buffers use the region's default CPU mapping; callers
-    // that select this path are responsible for the required packet-store ordering.
+    // GFX10/GFX11 need uncached memory - GPU L2 doesn't snoop PCIe BAR writes to local VRAM.
+    // GFX12+ has improved cache coherency and can use cached memory for better performance.
+    core::MemoryRegion::AllocateFlags alloc_flags = core::MemoryRegion::AllocateExecutable;
+    if (agent_->supported_isas()[0]->GetMajorVersion() < 12) {
+      alloc_flags = static_cast<core::MemoryRegion::AllocateFlags>(
+          alloc_flags | core::MemoryRegion::AllocateUncached);
+    }
     ring_buf_ = agent_->coarsegrain_allocator()(
         ring_buf_alloc_bytes_ + ring_buf_metadata_alloc_bytes_,
-        core::MemoryRegion::AllocateExecutable);
+        alloc_flags);
   } else {
     ring_buf_ = agent_->system_allocator()(
         ring_buf_alloc_bytes_ + ring_buf_metadata_alloc_bytes_, 0x1000,


### PR DESCRIPTION
    ## Motivation

    This PR fixes the failure that were inroduced by the rocrtst case
     Queue_Create_DeviceMem_RingBuf_Test & Queue_Create_Batch_Test
     on gfx 10/11 only

    ## Technical Details
     The reason for the failures is that GPU L2 cache doesn't snoop CPU
     writes to VRAM via PCIe BAR on GFX10/GFX11. Though it works on GFX12
     the hardware has cache coherency that automatically invalidates L2 when
     CPU writes via BAR.

    ## JIRA ID
    ROCM-27336

    ## Test Result
     All rocrtsts pass.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
