### PR TITLE
feat(clr): opt-in concurrent cooperative grid.sync via AQL barrier-bit clear

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -5007,21 +5007,33 @@ void VirtualGPU::submitKernel(amd::NDRangeKernelCommand& vcmd) {
 
     // SW grid.sync ASICs with DEBUG_CLR_COOP_CONCURRENT clear the AQL barrier bit
     // so coop grids can overlap; ordering is kept by the AddExternalSignal chain.
-    if (DEBUG_CLR_COOP_CONCURRENT && !dev().settings().gwsInitSupported_) {
+    const bool coop_concurrent =
+        DEBUG_CLR_COOP_CONCURRENT && !dev().settings().gwsInitSupported_;
+    if (coop_concurrent) {
       queue->setAqlHeader(dispatchPacketHeaderNoSync_);
     } else {
       queue->setAqlHeader(dispatchPacketHeader_);
     }
 
-    // Submit kernel to HW
+    // Submit kernel to HW. In concurrent mode attach a completion signal directly to
+    // the dispatch packet so completion can be tracked without a serializing barrier
+    // fence; GetLastSignal() then returns this dispatch's signal for the ordering
+    // dependency added into the user's stream below.
     if (!queue->submitKernelInternal(vcmd.sizes(), vcmd.kernel(), vcmd.parameters(),
                                      static_cast<void*>(as_cl(&vcmd.event())),
-                                     vcmd.sharedMemBytes(), &vcmd)) {
+                                     vcmd.sharedMemBytes(), &vcmd, nullptr,
+                                     /*attach_signal=*/coop_concurrent)) {
       LogError("AQL dispatch failed!");
       vcmd.setStatus(CL_INVALID_OPERATION);
     }
-    // Wait for the execution on the device queue. Keep the current queue in-order
-    queue->releaseGpuMemoryFence(kSkipCpuWait);
+    // In concurrent mode do NOT emit the serializing BARRIER_AND fence between coop
+    // dispatches -- that intervening barrier (barrier bit set) forces the next dispatch
+    // to wait for this one to retire, defeating the overlap CP firmware would otherwise
+    // provide for back-to-back barrier-bit-cleared dispatches.
+    if (!coop_concurrent) {
+      // Wait for the execution on the device queue. Keep the current queue in-order
+      queue->releaseGpuMemoryFence(kSkipCpuWait);
+    }
 
     // Add a dependency into the current queue on the coop queue
     Barriers().AddExternalSignal(queue->Barriers().GetLastSignal());

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -5005,8 +5005,8 @@ void VirtualGPU::submitKernel(amd::NDRangeKernelCommand& vcmd) {
       static_cast<KernelBlitManager&>(queue->blitMgr()).RunGwsInit(workgroups - 1);
     }
 
-    // SW grid.sync ASICs with DEBUG_CLR_COOP_CONCURRENT clear the AQL barrier bit
-    // so coop grids can overlap; ordering is kept by the AddExternalSignal chain.
+    // SW grid.sync ASICs + flag: clear barrier bit so coop grids overlap
+    // (ordering kept by the AddExternalSignal chain below).
     const bool coop_concurrent =
         DEBUG_CLR_COOP_CONCURRENT && !dev().settings().gwsInitSupported_;
     if (coop_concurrent) {
@@ -5015,10 +5015,8 @@ void VirtualGPU::submitKernel(amd::NDRangeKernelCommand& vcmd) {
       queue->setAqlHeader(dispatchPacketHeader_);
     }
 
-    // Submit kernel to HW. In concurrent mode attach a completion signal directly to
-    // the dispatch packet so completion can be tracked without a serializing barrier
-    // fence; GetLastSignal() then returns this dispatch's signal for the ordering
-    // dependency added into the user's stream below.
+    // Concurrent mode: attach a completion signal to the packet so ordering works
+    // without the serializing fence (GetLastSignal() returns this dispatch's signal).
     if (!queue->submitKernelInternal(vcmd.sizes(), vcmd.kernel(), vcmd.parameters(),
                                      static_cast<void*>(as_cl(&vcmd.event())),
                                      vcmd.sharedMemBytes(), &vcmd, nullptr,
@@ -5026,12 +5024,9 @@ void VirtualGPU::submitKernel(amd::NDRangeKernelCommand& vcmd) {
       LogError("AQL dispatch failed!");
       vcmd.setStatus(CL_INVALID_OPERATION);
     }
-    // In concurrent mode do NOT emit the serializing BARRIER_AND fence between coop
-    // dispatches -- that intervening barrier (barrier bit set) forces the next dispatch
-    // to wait for this one to retire, defeating the overlap CP firmware would otherwise
-    // provide for back-to-back barrier-bit-cleared dispatches.
+    // Skip the BARRIER_AND fence in concurrent mode: it would serialize the next
+    // coop dispatch. Legacy path keeps it to hold the queue in-order.
     if (!coop_concurrent) {
-      // Wait for the execution on the device queue. Keep the current queue in-order
       queue->releaseGpuMemoryFence(kSkipCpuWait);
     }
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -5005,8 +5005,13 @@ void VirtualGPU::submitKernel(amd::NDRangeKernelCommand& vcmd) {
       static_cast<KernelBlitManager&>(queue->blitMgr()).RunGwsInit(workgroups - 1);
     }
 
-    // Sync AQL packets
-    queue->setAqlHeader(dispatchPacketHeader_);
+    // SW grid.sync ASICs with DEBUG_CLR_COOP_CONCURRENT clear the AQL barrier bit
+    // so coop grids can overlap; ordering is kept by the AddExternalSignal chain.
+    if (DEBUG_CLR_COOP_CONCURRENT && !dev().settings().gwsInitSupported_) {
+      queue->setAqlHeader(dispatchPacketHeaderNoSync_);
+    } else {
+      queue->setAqlHeader(dispatchPacketHeader_);
+    }
 
     // Submit kernel to HW
     if (!queue->submitKernelInternal(vcmd.sizes(), vcmd.kernel(), vcmd.parameters(),

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -292,6 +292,9 @@ release(uint, DEBUG_CLR_AQL_DEV_QUEUE, 0,                                     \
 release(uint, DEBUG_CLR_USE_MOVDIR64B, 1,                                     \
         "Use MOVDIR64B full-packet writes for AQL + metadata rings"           \
         "(1=enabled (default), 0=non-temporal store path)")                   \
+release(bool, DEBUG_CLR_COOP_CONCURRENT, false,                               \
+        "SW grid.sync ASICs: clear AQL barrier bit on coop dispatches so "     \
+        "independent coop grids can overlap (needs permissive queue scheduling)")
 
 namespace amd {
 

--- a/projects/hip-tests/catch/config/configs/unit/cooperativeGrps.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/cooperativeGrps.yaml
@@ -103,6 +103,17 @@ cooperativeGrps:
   Unit_hipLaunchCooperativeKernel_Basic:
     <<: *level_2
     tags: [cooperative, launch]
+  Unit_ConcurrentCooperativeKernel_GridSync_Correctness:
+    <<: *level_2
+    # Concurrent cooperative grids sized near occupancy; ASAN shrinks occupancy
+    # which can prevent co-residency and deadlock grid.sync().
+    disabled: [asan]
+    tags: [cooperative, launch]
+  Unit_ConcurrentCooperativeKernel_GridSync_SameStreamOrdering:
+    <<: *level_2
+    # Same-stream coop dispatch chain sized near occupancy; ASAN shrinks occupancy.
+    disabled: [asan]
+    tags: [cooperative, launch]
   Unit_hipLaunchCooperativeKernelMultiDevice_Basic:
     <<: *level_2
     # Kernel uses runtime sized shared memory which is not adjusted to handle ASAN extra memory requirements

--- a/projects/hip-tests/catch/unit/cooperativeGrps/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TEST_SRC
   cg_ballot.cc
   cg_any_all.cc
   split_barrier.cc
+  concurrent_grid_sync.cc
 )
 
 set(AMD_TEST_SRC 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/concurrent_grid_sync.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/concurrent_grid_sync.cc
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Coop concurrency tests: grid.sync() must stay correct across streams and when
+// chained on one stream. Overlap (DEBUG_CLR_COOP_CONCURRENT) is INFO, not asserted.
+
+#include <hip_test_common.hh>
+#include <hip/hip_cooperative_groups.h>
+
+#include <chrono>
+
+namespace cg = cooperative_groups;
+
+static constexpr size_t kBufferLen = 1024 * 1024;
+
+// Grid-wide reduction that calls grid.sync() twice per iteration; the iteration
+// loop lengthens the kernel so concurrent overlap (when enabled) is measurable.
+__global__ void reduce_grid_sync(const int* buf, size_t n, unsigned long long* partial,
+                                 unsigned long long* result, int iters) {
+  extern __shared__ unsigned long long sm[];
+
+  cg::thread_block tb = cg::this_thread_block();
+  cg::grid_group gg = cg::this_grid();
+
+  const auto tid = gg.thread_rank();
+  const auto stride = gg.size();
+  const auto local_tid = tb.thread_rank();
+  const auto block_size = tb.size();
+  const auto grid_blocks = gridDim.x;
+
+  for (int it = 0; it < iters; ++it) {
+    unsigned long long sum = 0;
+    for (size_t i = tid; i < n; i += stride) {
+      sum += buf[i];
+    }
+    sm[local_tid] = sum;
+    tb.sync();
+
+    if (local_tid == 0) {
+      unsigned long long block_sum = 0;
+      for (unsigned int t = 0; t < block_size; ++t) {
+        block_sum += sm[t];
+      }
+      partial[blockIdx.x] = block_sum;
+    }
+    gg.sync();
+
+    if (tid == 0) {
+      unsigned long long total = 0;
+      for (unsigned int b = 0; b < grid_blocks; ++b) {
+        total += partial[b];
+      }
+      *result = total;
+    }
+    gg.sync();
+  }
+}
+
+namespace {
+
+struct CoopWork {
+  int* buf_d = nullptr;
+  unsigned long long* partial_d = nullptr;
+  unsigned long long* result_h = nullptr;  // host-visible
+  hipStream_t stream = nullptr;
+  dim3 grid;
+  dim3 block;
+  size_t shmem = 0;
+};
+
+void SetupWork(CoopWork& w, const int* host_buf, size_t buffer_bytes, dim3 grid, dim3 block) {
+  w.grid = grid;
+  w.block = block;
+  w.shmem = block.x * sizeof(unsigned long long);
+  HIP_CHECK(hipMalloc(&w.buf_d, buffer_bytes));
+  HIP_CHECK(hipMemcpy(w.buf_d, host_buf, buffer_bytes, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMalloc(&w.partial_d, grid.x * sizeof(unsigned long long)));
+  HIP_CHECK(hipHostMalloc(&w.result_h, sizeof(unsigned long long)));
+  *w.result_h = 0;
+  HIP_CHECK(hipStreamCreate(&w.stream));
+}
+
+void LaunchWork(CoopWork& w, int iters) {
+  void* params[5];
+  params[0] = reinterpret_cast<void*>(&w.buf_d);
+  params[1] = const_cast<void*>(reinterpret_cast<const void*>(&kBufferLen));
+  params[2] = reinterpret_cast<void*>(&w.partial_d);
+  params[3] = reinterpret_cast<void*>(&w.result_h);
+  params[4] = reinterpret_cast<void*>(&iters);
+  HIP_CHECK(hipLaunchCooperativeKernel(reinterpret_cast<void*>(reduce_grid_sync), w.grid, w.block,
+                                       params, w.shmem, w.stream));
+}
+
+void TeardownWork(CoopWork& w) {
+  HIP_CHECK(hipStreamDestroy(w.stream));
+  HIP_CHECK(hipHostFree(w.result_h));
+  HIP_CHECK(hipFree(w.partial_d));
+  HIP_CHECK(hipFree(w.buf_d));
+}
+
+}  // namespace
+
+// Two cooperative grids on two streams, launched back to back before either is
+// synchronized. Verifies grid.sync() correctness under concurrent submission.
+HIP_TEST_CASE(Unit_ConcurrentCooperativeKernel_GridSync_Correctness) {
+  int device = 0;
+  HIP_CHECK(hipGetDevice(&device));
+
+  hipDeviceProp_t props;
+  HIP_CHECK(hipGetDeviceProperties(&props, device));
+  if (!props.cooperativeLaunch) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
+  }
+
+  const size_t buffer_bytes = kBufferLen * sizeof(int);
+  std::vector<int> host_buf(kBufferLen);
+  for (size_t i = 0; i < kBufferLen; ++i) {
+    host_buf[i] = static_cast<int>(i);
+  }
+  const unsigned long long expected =
+      (static_cast<unsigned long long>(kBufferLen) * (kBufferLen - 1)) / 2;
+
+  const uint32_t block_x = GENERATE(64u, 128u, 256u);
+  const dim3 block(block_x);
+
+  int blocks_per_cu = 0;
+  HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+      &blocks_per_cu, reduce_grid_sync, block.x, block.x * sizeof(unsigned long long)));
+  REQUIRE(blocks_per_cu > 0);
+
+  // Two DIFFERENT grid sizes (full/4, full/2) that together fit in cooperative
+  // occupancy, so each grid.sync() must use its own workgroup count.
+  const int full_blocks = props.multiProcessorCount * blocks_per_cu;
+  const uint32_t grid0_blocks = static_cast<uint32_t>(std::max(1, full_blocks / 4));
+  const uint32_t grid1_blocks = std::min(
+      static_cast<uint32_t>(full_blocks),
+      std::max(grid0_blocks + 1u, static_cast<uint32_t>(full_blocks / 2)));
+  const dim3 grid0(grid0_blocks);
+  const dim3 grid1(grid1_blocks);
+  REQUIRE((grid0.x != grid1.x || full_blocks <= 1));
+
+  const int iters = 32;
+
+  INFO("block=" << block.x << " grid0=" << grid0.x << " grid1=" << grid1.x
+                << " (full coop grid=" << full_blocks << ") iters=" << iters);
+
+  CoopWork w0, w1;
+  SetupWork(w0, host_buf.data(), buffer_bytes, grid0, block);
+  SetupWork(w1, host_buf.data(), buffer_bytes, grid1, block);
+
+  // Launch both before synchronizing so the runtime is free to overlap them.
+  const auto t_start = std::chrono::steady_clock::now();
+  LaunchWork(w0, iters);
+  LaunchWork(w1, iters);
+  HIP_CHECK(hipStreamSynchronize(w0.stream));
+  HIP_CHECK(hipStreamSynchronize(w1.stream));
+  const auto t_concurrent =
+      std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_start).count();
+
+  CHECK(*w0.result_h == expected);
+  CHECK(*w1.result_h == expected);
+
+  // Informational: serialized baseline for the same total work.
+  *w0.result_h = 0;
+  *w1.result_h = 0;
+  const auto s_start = std::chrono::steady_clock::now();
+  LaunchWork(w0, iters);
+  HIP_CHECK(hipStreamSynchronize(w0.stream));
+  LaunchWork(w1, iters);
+  HIP_CHECK(hipStreamSynchronize(w1.stream));
+  const auto t_serial =
+      std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - s_start).count();
+
+  CHECK(*w0.result_h == expected);
+  CHECK(*w1.result_h == expected);
+
+  INFO("concurrent=" << t_concurrent << "ms serialized=" << t_serial << "ms speedup="
+                     << (t_concurrent > 0.0 ? t_serial / t_concurrent : 0.0) << "x");
+  WARN("concurrent=" << t_concurrent << "ms serialized=" << t_serial << "ms speedup="
+                     << (t_concurrent > 0.0 ? t_serial / t_concurrent : 0.0)
+                     << "x (overlap requires DEBUG_CLR_COOP_CONCURRENT=1 on SW grid.sync ASICs)");
+
+  TeardownWork(w0);
+  TeardownWork(w1);
+}
+
+// Read-modify-write accumulate with a grid.sync() each iteration. Correct only if
+// no other grid touches the same elements concurrently.
+__global__ void accumulate_grid_sync(unsigned long long* data, size_t n, int iters) {
+  cg::grid_group gg = cg::this_grid();
+  const auto tid = gg.thread_rank();
+  const auto stride = gg.size();
+  for (int it = 0; it < iters; ++it) {
+    for (size_t i = tid; i < n; i += stride) {
+      data[i] = data[i] + 1ull;  // non-atomic on purpose: races if grids overlap
+    }
+    gg.sync();
+  }
+}
+
+// Same-stream chain of coop dispatches must stay ordered (each sees prior writes).
+// Relaxed ordering would race the RMW and drop updates, failing the exact-sum check.
+HIP_TEST_CASE(Unit_ConcurrentCooperativeKernel_GridSync_SameStreamOrdering) {
+  int device = 0;
+  HIP_CHECK(hipGetDevice(&device));
+
+  hipDeviceProp_t props;
+  HIP_CHECK(hipGetDeviceProperties(&props, device));
+  if (!props.cooperativeLaunch) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
+  }
+
+  const size_t n = 256 * 1024;
+  const dim3 block(128);
+  int blocks_per_cu = 0;
+  HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(&blocks_per_cu, accumulate_grid_sync,
+                                                         block.x, 0));
+  REQUIRE(blocks_per_cu > 0);
+  const int full_blocks = props.multiProcessorCount * blocks_per_cu;
+  const dim3 grid(static_cast<uint32_t>(std::max(1, full_blocks / 2)));
+
+  unsigned long long* data_d = nullptr;
+  HIP_CHECK(hipMalloc(&data_d, n * sizeof(unsigned long long)));
+  HIP_CHECK(hipMemset(data_d, 0, n * sizeof(unsigned long long)));
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  const int kLaunches = 8;
+  const int iters = 8;
+  for (int l = 0; l < kLaunches; ++l) {
+    void* params[3] = {&data_d, const_cast<size_t*>(&n), const_cast<int*>(&iters)};
+    HIP_CHECK(hipLaunchCooperativeKernel(reinterpret_cast<void*>(accumulate_grid_sync), grid, block,
+                                         params, 0, stream));
+  }
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  std::vector<unsigned long long> data_h(n);
+  HIP_CHECK(hipMemcpy(data_h.data(), data_d, n * sizeof(unsigned long long), hipMemcpyDeviceToHost));
+
+  const unsigned long long expected =
+      static_cast<unsigned long long>(kLaunches) * static_cast<unsigned long long>(iters);
+  size_t mismatches = 0;
+  for (size_t i = 0; i < n; ++i) {
+    if (data_h[i] != expected) ++mismatches;
+  }
+  INFO("grid=" << grid.x << " launches=" << kLaunches << " iters=" << iters
+               << " expected=" << expected << " mismatches=" << mismatches);
+  CHECK(mismatches == 0);
+
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipFree(data_d));
+}


### PR DESCRIPTION
## Motivation

Today HIP funnels every `hipLaunchCooperativeKernel` from all streams onto a
single device-internal cooperative queue, and each cooperative dispatch is
submitted with the AQL barrier bit set **and** followed by a runtime-inserted
BARRIER_AND fence. As a result, two independent cooperative grids — even when
each is small enough that both could be co-resident — are forced to run strictly
one after another.

On gfx1201/gfx1250 the grid-wide barrier no longer depends on GWS hardware:
`grid.sync()` uses the software `single_grid_sync` path (`AVOID_GWS()` covers
`__oclc_ISA_version >= 11000` in device-libs `cg.cl`). On these ASICs there is no
hardware-GWS reason to serialize independent cooperative grids, which opens the
door to overlapping them when they fit.

This change adds minimal, opt-in runtime plumbing (off by default) to allow that
overlap, without disturbing the legacy path. It deliberately does **not**
reintroduce multiple cooperative/GWS queues (the original Cooperative Groups
design requires a single GWS-allocated queue per process). It keeps the single
dedicated cooperative queue and relaxes the two runtime-side serialization points
(barrier bit + post-dispatch fence) so the CP can co-schedule grids that fit.

## Technical Details

Gated behind a single release flag, `DEBUG_CLR_COOP_CONCURRENT` (default false),
effective only on software-grid-sync ASICs (`!settings().gwsInitSupported_`).

**CLR (clr)** — `VirtualGPU::submitKernel()` cooperative path, when
`DEBUG_CLR_COOP_CONCURRENT && !gwsInitSupported_`:
1. **Clear the AQL barrier bit** (`dispatchPacketHeaderNoSync_`) so back-to-back
   coop dispatches are not serialized by the CP.
2. **Attach a completion signal directly to the dispatch packet**
   (`submitKernelInternal(..., attach_signal=true)`) so completion is trackable
   without a serializing fence.
3. **Skip the post-dispatch BARRIER_AND fence** (`releaseGpuMemoryFence`). That
   fence is a barrier-bit-set packet; leaving it in forces the next dispatch to
   wait for the current one to retire — clearing the barrier bit alone is **not**
   sufficient.

Same-stream ordering is preserved: `GetLastSignal()` returns this dispatch's
completion signal, which is added into the user's stream via the existing
`AddExternalSignal` dependency chain, so relaxing the barrier bit never reorders
launches within a stream. Every other case (flag off, or any HW-GWS ASIC) keeps
`dispatchPacketHeader_` + the fence, i.e. legacy serialized behavior. Cooperative
launches continue to route through the single `xferQueue()` (unchanged).

`flags.hpp`: adds release flag `DEBUG_CLR_COOP_CONCURRENT` (default false).

**ROCr (rocr-runtime):** no changes.

**Test (hip-tests)** — `catch/unit/cooperativeGrps/concurrent_grid_sync.cc`:
- `Unit_ConcurrentCooperativeKernel_GridSync_Correctness` — two cooperative grids
  on two streams, each sized to half the device's cooperative occupancy so both
  can be co-resident; asserts `grid.sync()` correctness under concurrent submission.
- `Unit_ConcurrentCooperativeKernel_GridSync_SameStreamOrdering` — a same-stream
  chain of cooperative dispatches with a `grid.sync()` per iteration; asserts the
  exact accumulated sum, which only holds if same-stream ordering survives
  clearing the barrier bit + dropping the fence.
- Registered in `cooperativeGrps.yaml` (tags `cooperative`/`launch`,
  `disabled: [asan]` since ASAN shrinks occupancy and could false-deadlock).

## Issue Tracking

JIRA: AIRUNTIME-74


## Test Plan

- `DEBUG_CLR_COOP_CONCURRENT=0/1` correctness:
  `Unit_ConcurrentCooperativeKernel_GridSync_Correctness`,
  `Unit_ConcurrentCooperativeKernel_GridSync_SameStreamOrdering`.
- Performance/behavior characterization with a standalone probe sweeping per-grid
  occupancy % (flag ON vs OFF), plus two controls: regular (non-cooperative)
  dispatch and cooperative dispatch with `grid.sync()` removed.
- Packet-level verification via `AMD_LOG_LEVEL=7`.

## Test Result

Verified on gfx1250 (256 CUs, full cooperative occupancy = 4096 blocks).
Correctness PASS under concurrent launch and same-stream ordering, flag on and off.
Packet log (flag on) confirms both cooperative dispatches issue back-to-back with
barrier bit = 0 and no intervening BARRIER_AND fence.

**Flag ON (concurrent) vs OFF (serial): ratio = T_pair(ON)/T_pair(OFF), lower = faster (5-run avg):**

| grids (g0,g1) | aggregate occ | ratio | result |
|---|---|---|---|
| 25%,25% | 50% | 0.67 | ~33% faster |
| 50%,25% | 75% | 0.78 | ~22% faster |
| 25%,50% | 75% | 0.80 | ~20% faster |
| 75%,25% | 100% | 1.03 | neutral |
| 100%,100% | 200% | 1.01 | neutral (serializes, correct) |
| 50%,50% | 100% | 1.16 | slower |
| 25%,75% | 100% | 1.55 | slower |

Real, repeatable speedup when the grids fit together (aggregate ≤ ~75%): 20–33%.
At/above 100% aggregate the gain disappears (falls back to serialized-like
behavior) but stays correct and deadlock-free, tested to 200% oversubscription.
Dispatch order matters at the margin (larger grid first is better).

**Root-cause controls (T_pair/sum; 0.5 = perfect 2x overlap), 50,50 @ 100% aggregate:**

| mode | T_pair/sum |
|---|---|
| Cooperative + grid.sync (flag on) | 1.15 |
| Cooperative, grid.sync removed (flag on) | 0.51 |
| Regular (non-cooperative) dispatch | 0.52 |

Regular dispatch and cooperative-without-`grid.sync` both overlap near-perfectly
at every split, including 300% oversubscription (~0.51–0.56). The same grid runs
in ~8 ms without `grid.sync` vs ~1020 ms with it. So the cooperative *dispatch
path* (coop queue + relaxed barrier/fence) does not serialize — the software
`grid.sync()` barrier does, and it dominates runtime.

## Deps

Overlap of independent cooperative grids is achieved entirely in the runtime
(userspace): no KFD/MES or ROCr change is required. Concurrency stays
deadlock-free under oversubscription — the CP/firmware serializes when grids do
not fit rather than partially admitting them.

The remaining limiter for the full-occupancy cooperative case is the software
`grid.sync()` implementation itself (it serializes cross-grid progress and
dominates runtime), not the queue, dispatch path, or scheduler — a candidate for
a separate follow-up.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
