### PR TITLE
fix(rocm-smi-lib): restore writeDevInfoStr bool parameter for ABI stability

### DIFF
--- a/projects/rocm-smi-lib/include/rocm_smi/rocm_smi_device.h
+++ b/projects/rocm-smi-lib/include/rocm_smi/rocm_smi_device.h
@@ -265,7 +265,7 @@ class Device {
   int readDevInfoStr(DevInfoTypes type, std::string* retStr);
   int readDevInfoMultiLineStr(DevInfoTypes type, std::vector<std::string>* retVec);
   int readDevInfoBinary(DevInfoTypes type, std::size_t b_size, void* p_binary_data);
-  int writeDevInfoStr(DevInfoTypes type, std::string valStr);
+  int writeDevInfoStr(DevInfoTypes type, std::string valStr, bool returnWriteErr = false);
   rsmi_status_t run_amdgpu_property_reinforcement_query(
       const AMDGpuPropertyQuery_t& amdgpu_property_query);
 

--- a/projects/rocm-smi-lib/src/rocm_smi_device.cc
+++ b/projects/rocm-smi-lib/src/rocm_smi_device.cc
@@ -777,7 +777,10 @@ int Device::readDevInfoStr(DevInfoTypes type, std::string* retStr) {
   return 0;
 }
 
-int Device::writeDevInfoStr(DevInfoTypes type, std::string valStr) {
+// The returnWriteErr parameter is unused: this implementation always surfaces
+// the underlying errno on write failure. It is retained solely to preserve the
+// exported symbol's ABI, which included this argument in earlier releases.
+int Device::writeDevInfoStr(DevInfoTypes type, std::string valStr, bool /* returnWriteErr */) {
   auto sysfs_path = path_;
   sysfs_path += "/device/";
   sysfs_path += kDevAttribNameMap.at(type);

--- a/projects/rocm-smi-lib/tests/rocm_smi_test/abi_stability_test.cc
+++ b/projects/rocm-smi-lib/tests/rocm_smi_test/abi_stability_test.cc
@@ -1,0 +1,83 @@
+/*
+ * =============================================================================
+ *   ROC Runtime Conformance Release License
+ * =============================================================================
+ * The University of Illinois/NCSA
+ * Open Source License (NCSA)
+ *
+ * Copyright (c) 2026, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Developed by:
+ *
+ *                 AMD Research and AMD ROC Software Development
+ *
+ *                 Advanced Micro Devices, Inc.
+ *
+ *                 www.amd.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal with the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimers.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimers in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the names of <Name of Development Group, Name of Institution>,
+ *    nor the names of its contributors may be used to endorse or promote
+ *    products derived from this Software without specific prior written
+ *    permission.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS WITH THE SOFTWARE.
+ *
+ */
+
+// This test guards the exported C++ ABI of the rocm_smi library.
+//
+// amd::smi::Device::writeDevInfoStr historically exported a three-argument
+// overload whose final parameter is a `bool`. Dropping that parameter silently
+// changes the mangled symbol name and breaks binary compatibility for consumers
+// that were linked against an earlier release. The test below pins the exported
+// symbol so that any future change to the signature is caught here rather than
+// by downstream ABI tooling.
+
+#include <dlfcn.h>
+
+#include "gtest/gtest.h"
+
+namespace {
+
+// Mangled name of
+//   amd::smi::Device::writeDevInfoStr(amd::smi::DevInfoTypes, std::string, bool)
+constexpr char kWriteDevInfoStrBoolSymbol[] =
+    "_ZN3amd3smi6Device15writeDevInfoStrENS0_12DevInfoTypesENSt7__cxx1112basic_"
+    "stringIcSt11char_traitsIcESaIcEEEb";
+
+}  // namespace
+
+TEST(RsmiAbiStability, WriteDevInfoStrRetainsBoolParameter) {
+  // rsmitst links librocm_smi64, so the library's exported symbols are part of
+  // the process' global symbol scope and can be resolved by name.
+  void* global_scope = dlopen(nullptr, RTLD_NOW | RTLD_GLOBAL);
+  ASSERT_NE(global_scope, nullptr) << dlerror();
+
+  void* symbol = dlsym(global_scope, kWriteDevInfoStrBoolSymbol);
+  EXPECT_NE(symbol, nullptr)
+      << "amd::smi::Device::writeDevInfoStr(DevInfoTypes, std::string, bool) is "
+         "missing from the exported ABI. Removing the trailing bool parameter "
+         "breaks binary compatibility with consumers linked against earlier "
+         "releases.";
+
+  dlclose(global_scope);
+}

--- a/projects/rocm-smi-lib/tests/rocm_smi_test/abi_stability_test.cc
+++ b/projects/rocm-smi-lib/tests/rocm_smi_test/abi_stability_test.cc
@@ -52,6 +52,11 @@
 // symbol so that any future change to the signature is caught here rather than
 // by downstream ABI tooling.
 
+// RTLD_DEFAULT is a GNU extension exposed by <dlfcn.h> under _GNU_SOURCE.
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <dlfcn.h>
 
 #include "gtest/gtest.h"
@@ -68,16 +73,16 @@ constexpr char kWriteDevInfoStrBoolSymbol[] =
 
 TEST(RsmiAbiStability, WriteDevInfoStrRetainsBoolParameter) {
   // rsmitst links librocm_smi64, so the library's exported symbols are part of
-  // the process' global symbol scope and can be resolved by name.
-  void* global_scope = dlopen(nullptr, RTLD_NOW | RTLD_GLOBAL);
-  ASSERT_NE(global_scope, nullptr) << dlerror();
+  // the process' global symbol scope. Resolve the symbol directly from that
+  // scope and use the standard dlerror() pattern to detect lookup failures.
+  dlerror();  // Clear any stale error state.
+  void* symbol = dlsym(RTLD_DEFAULT, kWriteDevInfoStrBoolSymbol);
+  const char* error = dlerror();
 
-  void* symbol = dlsym(global_scope, kWriteDevInfoStrBoolSymbol);
+  EXPECT_EQ(error, nullptr) << "dlsym failed to resolve the writeDevInfoStr symbol: " << error;
   EXPECT_NE(symbol, nullptr)
       << "amd::smi::Device::writeDevInfoStr(DevInfoTypes, std::string, bool) is "
          "missing from the exported ABI. Removing the trailing bool parameter "
          "breaks binary compatibility with consumers linked against earlier "
          "releases.";
-
-  dlclose(global_scope);
 }


### PR DESCRIPTION
## Summary

`amd::smi::Device::writeDevInfoStr` lost its trailing `bool` parameter between releases, which changed the function's mangled (exported) symbol and broke binary compatibility. Binaries linked against the older 3-argument symbol fail to resolve it against the newer library.

- Old (compatible) symbol: `writeDevInfoStr(DevInfoTypes, std::string, bool)`
- New (breaking) symbol: `writeDevInfoStr(DevInfoTypes, std::string)`

Both `librocm_smi64` and `liboam` embed this source and export the symbol with default visibility, so both libraries are affected.

## Root cause

The trailing `bool returnWriteErr` argument was removed as an incidental cleanup in an earlier change that (correctly) made `writeDevInfoStr` always return the underlying `errno` on write failure. The behavior change was intentional; the signature change was not, and it broke the ABI.

## Fix

Restore the third parameter (`bool returnWriteErr = false`) so the previously exported symbol is preserved. Runtime behavior is unchanged — the implementation still always returns the real `errno` on write failure — so the parameter is intentionally unused and retained purely for ABI stability.

## Test

Add `abi_stability_test.cc` to the `rsmitst` suite. It resolves the expected 3-argument mangled symbol through the dynamic loader and fails if the parameter is dropped again. Verified locally that it passes when the 3-argument symbol is present and fails when only the 2-argument symbol is exported. The test needs no GPU.

## Verification

Compiling the translation unit before/after the fix and inspecting the exported dynamic symbol confirms the 3-argument symbol is restored (matches the pre-break ABI). Builds clean under `-Wall -Wextra -Werror`; pre-commit hooks pass.

Closes #8797
