### PR TITLE
ci(rocprofiler-compute): fix Docker image tags in tarball and RHEL

### DIFF
--- a/.github/workflows/rocprofiler-compute-rhel-8.yml
+++ b/.github/workflows/rocprofiler-compute-rhel-8.yml
@@ -37,6 +37,7 @@ concurrency:
 
 env:
   ROCM_VERSION: "7.2.0"
+  CONTAINER_ROCM_VERSION: "7.2"
 
 jobs:
   build-rhel:
@@ -44,7 +45,7 @@ jobs:
     # Using rocprofiler-systems images and later installing rocm, the official rocm images for al8 red hat variant are too large- this is a workaround.
     runs-on: ubuntu-latest
     container:
-      image: dgaliffiamd/rocprofiler-systems:ci-base-rhel-${{ matrix.os-release }}
+      image: dgaliffiamd/rocprofiler-systems:ci-rocm-${{ env.CONTAINER_ROCM_VERSION }}-rhel-${{ matrix.os-release }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rocprofiler-compute-tarball.yml
+++ b/.github/workflows/rocprofiler-compute-tarball.yml
@@ -36,12 +36,13 @@ concurrency:
 
 env:
   ROCM_VERSION: "7.1.0"
+  CONTAINER_ROCM_VERSION: "7.1"
 
 jobs:
   distbuild:
     runs-on: ubuntu-latest
     container:
-      image: dgaliffiamd/rocprofiler-systems:ci-base-ubuntu-24.04
+      image: dgaliffiamd/rocprofiler-systems:ci-rocm-${{ env.CONTAINER_ROCM_VERSION }}-ubuntu-24.04
     name: Create distribution tarball
     env:
       INSTALL_DIR: /tmp/foo1
@@ -106,7 +107,7 @@ jobs:
   disttest:
     runs-on: ubuntu-latest
     container:
-      image: dgaliffiamd/rocprofiler-systems:ci-base-ubuntu-24.04
+      image: dgaliffiamd/rocprofiler-systems:ci-rocm-${{ env.CONTAINER_ROCM_VERSION }}-ubuntu-24.04
     needs: [distbuild]
     name: Tarball tests
     env:


### PR DESCRIPTION
## Motivation

This PR updates the image references to use the `ci-rocm-*` tag format.
Adding `CONTAINER_ROCM_VERSION` env var for version reference.

## Technical Details

This PR updates the image references to use the `ci-rocm-*` tag format.
Adding `CONTAINER_ROCM_VERSION` env var for version reference.

## Issue Tracking

JIRA ID: AIPROFCOMP-540
(to unblock the above PR from failing CI)

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
