### PR TITLE
hip-tests: zero-initialize host atomics buffer before __atomic_fetch_add onto it

### DIFF
--- a/projects/hip-tests/catch/unit/atomics/arithmetic_common.hh
+++ b/projects/hip-tests/catch/unit/atomics/arithmetic_common.hh
@@ -11,6 +11,8 @@
 #include <resource_guards.hh>
 #include <cmd_options.hh>
 
+#include <cstring>
+
 namespace cg = cooperative_groups;
 
 // Atomic operations for which the tests in this file apply for
@@ -435,6 +437,9 @@ void TestCore(const TestParams& p) {
 
   // Launch Host Threads
   mem_devs.emplace_back(LinearAllocs::hipHostMalloc, mem_alloc_size);
+  // hipHostMalloc does not guarantee zeroed memory. The buffer is only touched by
+  // host threads, so zero it host-side
+  std::memset(mem_devs[p.num_devices].host_ptr(), 0, mem_alloc_size);
   PerformHostAtomicOperation<TestType, operation>(p, mem_devs[p.num_devices].host_ptr(), old_vals.data());
 
   for (auto i = 0; i < p.num_devices; ++i) {


### PR DESCRIPTION
hipHostMalloc does not guarantee zeroed memory. The host competitor buffer
in the *_Host_And_GPU atomics tests was used uninitialized.

## Motivation

The `atomicAdd/Sub/CAS_system_Positive_Host_And_GPU` tests allocate the
host competitor buffer with `hipHostMalloc` and immediately run host
`__atomic_fetch_add` on it — without initializing to zero. The device
buffers are `hipMemset`'d, but the host buffer is not. Since `hipHostMalloc`
does not guarantee zeroed memory (same as `malloc`), the test accumulates
onto undefined contents and fails the final comparison.

## Technical Details

One-line fix in `arithmetic_common.hh` `TestCore()`: add
`std::memset(host_ptr, 0, size)` after `hipHostMalloc`, before host
threads run. Uses host-side `memset` (not `hipMemset`) since the buffer
is only touched by host threads.

## Issue Tracking

JIRA ID : ROCM-28378

## Test Plan

Ran all affected tests: `atomicAdd_system_Positive_Host_And_GPU` (6 type
sections), `atomicSub_system_Positive_Host_And_GPU`,
`atomicCAS_system_Positive_Host_And_GPU` (4 type variants) — all pass.
Tests using other common headers (atomicExch, And/Or/Xor, Min/Max) are
not affected.

## Test Result

All pass. No regressions.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
