### PR TITLE
perf(rccl): port #8451 LL128/scratch reduction improvements to June drop (behavior-neutral)

### DIFF
--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -64,7 +64,10 @@ message(STATUS "Device Linker: GPU targets = ${DL_GPU_TARGETS}")
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
   set(DL_OPT_FLAGS -O1 -g)
 else()
-  set(DL_OPT_FLAGS -O3)
+  # -DNDEBUG matches the host Release build: device asserts otherwise force the
+  # compiler to preserve live registers around every __assert_fail call, which
+  # inflates the private (scratch) segment on register-heavy reduce kernels.
+  set(DL_OPT_FLAGS -O3 -DNDEBUG)
 endif()
 
 # ---------------------------------------------------------------------------

--- a/projects/rccl/cmake/scripts/extract_metadata.cmake
+++ b/projects/rccl/cmake/scripts/extract_metadata.cmake
@@ -18,64 +18,35 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-set(EXTRACT_TIMEOUT 5 CACHE STRING "Timeout in seconds for llvm-readobj and llvm-objcopy calls")
+## Extract the per-architecture offload bundles from librccl.so.
+## `llvm-objdump --offloading` writes each embedded bundle (host + every gfx
+## arch) out as a sibling file, which is the artifact we want.
+##
+## This script is run via `cmake -P`, so it has no access to the build's cache
+## variables; resolve ROCM_PATH from the environment and locate llvm-objdump,
+## falling back to PATH.
+if(NOT DEFINED ROCM_PATH AND DEFINED ENV{ROCM_PATH})
+    set(ROCM_PATH "$ENV{ROCM_PATH}")
+endif()
 
-## List the objects for each gfx architecture
-execute_process( COMMAND llvm-readobj --offloading librccl.so
+find_program(LLVM_OBJDUMP
+    NAMES llvm-objdump
+    HINTS "${ROCM_PATH}/llvm/bin" "${ROCM_PATH}/bin"
+)
+if(NOT LLVM_OBJDUMP)
+    set(LLVM_OBJDUMP llvm-objdump)
+endif()
+
+execute_process( COMMAND ${LLVM_OBJDUMP} --offloading librccl.so
     RESULT_VARIABLE list_result
     OUTPUT_VARIABLE cmd_output
     ERROR_VARIABLE cmd_error
     OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_STRIP_TRAILING_WHITESPACE
-    TIMEOUT ${EXTRACT_TIMEOUT}
-)
+    ERROR_STRIP_TRAILING_WHITESPACE)
 
 if(list_result EQUAL 0)
-    ## Convert cmd output to list of lines
-    string(REGEX REPLACE "\n$" "" cmd_output "${cmd_output}")
-    string(REPLACE "\n" ";" cmd_output "${cmd_output}")
-
-    ## Extract file paths for the selected gfx archs
-    foreach(line ${cmd_output})
-        if(line MATCHES "(gfx90a|gfx942|gfx950)")
-            string(REGEX MATCH "\\file://(.*)" file_match ${line})
-            if(file_match)
-                list(APPEND file_paths ${file_match})
-            endif()
-        endif()
-    endforeach()
-
-    ## Extract objects from files
-    foreach(file ${file_paths})
-        execute_process(
-          COMMAND llvm-objcopy --dump-offload-bundle=${file}
-          RESULT_VARIABLE extraction_result
-          ERROR_VARIABLE extraction_error
-          OUTPUT_STRIP_TRAILING_WHITESPACE
-          ERROR_STRIP_TRAILING_WHITESPACE
-          TIMEOUT ${EXTRACT_TIMEOUT}
-        )
-        if(extraction_result STREQUAL "TIMEOUT")
-          message(
-            WARNING
-              "[Timeout] Extraction of '${file}' did not finish within ${EXTRACT_TIMEOUT}s. stderr: ${extraction_error}.
-                    Timeouts have been known to happen as a result of mismatched ROCm versions/executables/etc."
-          )
-        elseif(NOT extraction_result EQUAL 0)
-          message(
-            WARNING
-              "[Error ${extraction_result}] Could not extract objects from '${file}'. stderr: ${extraction_error}"
-          )
-        endif()
-    endforeach()
-
-elseif(list_result STREQUAL "TIMEOUT")
-  message(
-    WARNING
-      "[Timeout] llvm-readobj/llvm-objcopy did not finish within ${EXTRACT_TIMEOUT}s. stderr: ${cmd_error}.
-                     Timeouts have been known to happen as a result of mismatched ROCm versions/executables/etc"
-  )
+    message(STATUS "Extracted offload bundles from librccl.so:\n${cmd_output}")
 else()
-    ## We don't want to stop building unit-tests if this command fails.
-    message(WARNING "[Error ${list_result}] llvm-readobj --offloading failed. stderr: ${cmd_error}")
+    ## Don't fail the build if extraction fails; just report it.
+    message(WARNING "[Error ${list_result}] '${LLVM_OBJDUMP} --offloading' failed. stderr: ${cmd_error}")
 endif()

--- a/projects/rccl/src/device/all_gather.h
+++ b/projects/rccl/src/device/all_gather.h
@@ -11,10 +11,10 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto, bool isNetOffload = false>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
-#else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+#if defined(ENABLE_NPKIT)
+    const int bid = ncclShmem.channelId - work->channelLo;
+    int npKitCtxIdx = bid; // unused variable - compiler warning
 #endif
 #ifdef ENABLE_WARP_SPEED
     int warp = threadIdx.x / WARP_SIZE;

--- a/projects/rccl/src/device/all_reduce.h
+++ b/projects/rccl/src/device/all_reduce.h
@@ -11,11 +11,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto, int RCCLMetadata>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
-#else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
-#endif
 #ifdef ENABLE_WARP_SPEED
     int warp = threadIdx.x / WARP_SIZE;
     ncclRing *ring = ncclShmem.warpComm
@@ -106,10 +102,10 @@ namespace {
   }
 
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__ void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work) {
-#else
-  __device__ __attribute__((noinline)) void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work) {
+#if defined(ENABLE_NPKIT)
+    const int bid = ncclShmem.channelId - work->channelLo;
+    int npKitCtxIdx = bid; // unused variable - compiler warning
 #endif
     ncclTree *tree = &ncclShmem.channel.tree;
     size_t size;
@@ -179,10 +175,9 @@ namespace {
   }
 
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__ void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work) {
-#else
-  __device__ __attribute__((noinline)) void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work) {
+#if defined(ENABLE_NPKIT)
+    const int bid = ncclShmem.channelId - work->channelLo; // unused variable - compiler warning
 #endif
     ncclTree *tree = &ncclShmem.channel.tree;
     size_t size;

--- a/projects/rccl/src/device/alltoall_pivot.h
+++ b/projects/rccl/src/device/alltoall_pivot.h
@@ -10,11 +10,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
-#else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
-#endif
     const int bid = ncclShmem.channelId - work->channelLo;
     const int nranks = ncclShmem.comm.nRanks;
     size_t count, partOffset, partCount, chunkCount;

--- a/projects/rccl/src/device/broadcast.h
+++ b/projects/rccl/src/device/broadcast.h
@@ -11,10 +11,10 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
-#else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+#if defined(ENABLE_NPKIT)
+    const int bid = ncclShmem.channelId - work->channelLo;
+    int npKitCtxIdx = bid; // unused variable - compiler warning
 #endif
 #ifdef ENABLE_WARP_SPEED
     int warp = threadIdx.x / WARP_SIZE;

--- a/projects/rccl/src/device/common_kernel.h
+++ b/projects/rccl/src/device/common_kernel.h
@@ -450,7 +450,6 @@ __device__ __forceinline__ void reduceCopyPacksWithBias(
   uintptr_t minSrcs[MinSrcs + !MinSrcs];
   uintptr_t minDsts[MinDsts + !MinDsts];
   uintptr_t accPtr = cvta_to_global(accPtrFn()) + threadBytesBehind;
-  BytePack<BytePerPack> bias[Unroll];
 
   #pragma unroll
   for (int s=0; s < MinSrcs; s++) {
@@ -479,9 +478,6 @@ __device__ __forceinline__ void reduceCopyPacksWithBias(
         } else {
           // Use volatile loads in case credits are polled for with volatile (instead of acquire).
           acc[u] = ld_volatile_global<BytePerPack>(minSrcs[0]);
-            // coverity[dead_error_condition]
-          bias[u] = ld_volatile_global<BytePerPack>(accPtr);
-          accPtr += WARP_SIZE*BytePerPack;
           if (0 < PreOpSrcs) acc[u] = applyPreOp(redFn, acc[u]);
         }
         minSrcs[0] += WARP_SIZE*BytePerPack;
@@ -492,42 +488,39 @@ __device__ __forceinline__ void reduceCopyPacksWithBias(
     for (int s=1; s < MinSrcs; s++) {
       // Yes, for some template arguments this code will be unreachable.  That's fine.
       // coverity[dead_error_begin]
-      BytePack<BytePerPack> tmp[Unroll];
+      // Fuse the load and reduce of each pack so only a single tmp pack is live
+      // at a time instead of tmp[Unroll].
       #pragma unroll Unroll
       for (int u=0; u < Unroll; u++) {
+        BytePack<BytePerPack> tmp;
         if (s < MultimemSrcs) {
           // applyLoadMultimem uses relaxed semantics for same reason we use volatile below.
           // coverity[dead_error_line]
-          tmp[u] = applyLoadMultimem<RedFn, BytePerPack>(redFn, minSrcs[s]);
+          tmp = applyLoadMultimem<RedFn, BytePerPack>(redFn, minSrcs[s]);
         } else {
           // Use volatile loads in case credits are polled for with volatile (instead of acquire).
-          tmp[u] = ld_volatile_global<BytePerPack>(minSrcs[s]);
+          tmp = ld_volatile_global<BytePerPack>(minSrcs[s]);
         }
         minSrcs[s] += WARP_SIZE*BytePerPack;
-      }
-      #pragma unroll Unroll
-      for (int u=0; u < Unroll; u++) {
         // coverity[dead_error_line]
-        if (s < PreOpSrcs) tmp[u] = applyPreOp(redFn, tmp[u]);
-        acc[u] = applyReduce(redFn, acc[u], tmp[u]);
+        if (s < PreOpSrcs) tmp = applyPreOp(redFn, tmp);
+        acc[u] = applyReduce(redFn, acc[u], tmp);
       }
     }
 
     for (int s=MinSrcs; (MinSrcs < MaxSrcs) && (s < MaxSrcs) && (s < nSrcs); s++) {
       uintptr_t src = cvta_to_global(srcPtrFn(s)) + threadBytesBehind;
-      BytePack<BytePerPack> tmp[Unroll];
+      // Fuse load+reduce per pack (see MinSrcs loop above): keeps only one tmp
+      // pack live instead of tmp[Unroll], reducing scratch on useAcc kernels.
       #pragma unroll Unroll
       for (int u=0; u < Unroll; u++) {
         // Use volatile loads in case credits are polled for with volatile (instead of acquire).
-        tmp[u] = ld_volatile_global<BytePerPack>(src);
+        BytePack<BytePerPack> tmp = ld_volatile_global<BytePerPack>(src);
         src += WARP_SIZE*BytePerPack;
-      }
-      #pragma unroll Unroll
-      for (int u=0; u < Unroll; u++) {
         // Yes, for some template arguments this code will be unreachable.  That's fine.
         // coverity[dead_error_line]
-        if (s < PreOpSrcs) tmp[u] = applyPreOp(redFn, tmp[u]);
-        acc[u] = applyReduce(redFn, acc[u], tmp[u]);
+        if (s < PreOpSrcs) tmp = applyPreOp(redFn, tmp);
+        acc[u] = applyReduce(redFn, acc[u], tmp);
       }
     }
 
@@ -547,9 +540,12 @@ __device__ __forceinline__ void reduceCopyPacksWithBias(
         if (d < MultimemDsts) {
           multimem_st_global(minDsts[d], acc[u]);
         } else {
-          if (d == 0)
-            st_global<BytePerPack>(minDsts[d], applyReduce(redFn, acc[u], bias[u]));
-          else
+          if (d == 0) {
+            // Load the bias/accumulator pack here, at the point of use, rather
+            // than up front.
+            BytePack<BytePerPack> b = ld_volatile_global<BytePerPack>(accPtr + u*WARP_SIZE*BytePerPack);
+            st_global<BytePerPack>(minDsts[d], applyReduce(redFn, acc[u], b));
+          } else
             st_global<BytePerPack>(minDsts[d], acc[u]);
         }
         minDsts[d] += WARP_SIZE*BytePerPack;
@@ -576,7 +572,8 @@ __device__ __forceinline__ void reduceCopyPacksWithBias(
     for (int d=0; d < MinDsts; d++) {
       minDsts[d] += (nWarps-1)*BytePerHunk;
     }
-    accPtr += (nWarps-1)*BytePerHunk;
+    // advance the full hunk here to stay in sync with minSrcs/minDsts.
+    accPtr += nWarps*BytePerHunk;
     threadBytesBehind += nWarps*BytePerHunk;
     threadBytesAhead -= nWarps*BytePerHunk;
     nHunksAhead -= nWarps;

--- a/projects/rccl/src/device/prims_ll128.h
+++ b/projects/rccl/src/device/prims_ll128.h
@@ -97,6 +97,16 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
         if (checkAbort(abort, 1, spins)) break;
       }
       if (sendConnFifo) {
+        // Index the send FIFO by sendStep[wid], matching upstream NCCL.
+        // A previous RCCL change used the scalar sendConnHead here (equal to
+        // sendStep[wid] at this point for the connection-owning lane) to let
+        // SROA scalarize sendStep and registerize the Primitives object. A
+        // gfx950 A/B static analysis showed that win does NOT reach the
+        // launched kernels: the 3 Generic_* kernels are byte-identical either
+        // way (same VGPR/AGPR/SGPR/scratch), because the reduce work runs in
+        // indirectly-called device functions whose frames are dynamic. With no
+        // static benefit, we keep the code identical to NCCL to ease future
+        // upstream syncs.
         sendConnFifo[sendStep[wid]%NCCL_STEPS].size = nbytes;
       }
       sendConnHead += 1;

--- a/projects/rccl/src/device/reduce.h
+++ b/projects/rccl/src/device/reduce.h
@@ -11,11 +11,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
-#else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
-#endif
 #ifdef ENABLE_WARP_SPEED
     int warp = threadIdx.x / WARP_SIZE;
     ncclRing *ring = ncclShmem.warpComm

--- a/projects/rccl/src/device/reduce_scatter.h
+++ b/projects/rccl/src/device/reduce_scatter.h
@@ -11,11 +11,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
-#else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
-#endif
     // Step 0: Setup
     size_t msgSize = work->count * sizeof(T) * ncclShmem.comm.nRanks;
     if (work->enableDirectReduceScatter &&

--- a/projects/rccl/src/device/sendrecv.h
+++ b/projects/rccl/src/device/sendrecv.h
@@ -53,11 +53,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 
   }
 
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__  void run() {
-#else
-  __device__  __attribute__((noinline)) void run() {
-#endif
     const int tid = threadIdx.x;
     const int tn = blockDim.x;
     const int wid = tid/WARP_SIZE;

--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #define RCCL_COMMON_H_
 #include "nccl_common.h"
 #include "nccl.h"
+#include "nccl_tuner.h" // NCCL_NUM_ALGORITHMS / NCCL_NUM_PROTOCOLS
 #include "param.h"
 #include "core.h"
 

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -20,6 +20,7 @@
 #include "shm.h"
 #include "compiler.h"
 #include <atomic>
+#include <map>
 #include <assert.h>
 #include "graph.h"
 #include "graph/topo.h"


### PR DESCRIPTION
## Summary

Ports the **behavior-neutral** subset of #8451 onto the June drop (`rccl/drop_2026-06-25`, tip `df2d9d40` = #6323). Codegen/build-only: reduces LL128 register spills and scratch-segment usage on gfx942/gfx950 without changing any numerical results. All fp8 arithmetic changes and unit tests from #8451 are intentionally excluded.

The base is the drop-branch tip, so the diff is exactly the single port commit.

## Changes

- **`cmake/DeviceLinker.cmake`** — build device code with `-DNDEBUG` in Release, matching the host Release build. Device asserts otherwise pin live registers around every `__assert_fail`, inflating the private (scratch) segment on register-heavy reduce kernels.
- **`src/device/common_kernel.h`** — in `reduceCopyPacksWithBias`, fuse each pack's load+reduce so only one temporary pack is live (instead of `tmp[Unroll]`), and defer the bias/acc load to its point of use; advance `accPtr` by the full hunk to compensate. (Uses this base's `applyPreOp(redFn, ...)` convention, matching #8451 upstream.)
- **`src/device/{all_reduce,all_gather,broadcast,reduce,reduce_scatter,alltoall_pivot,sendrecv}.h`** — drop the `noinline` attribute on `runRing`/`runTree*`/`run` for gfx942/gfx950 so they inline (codegen-only; no behavior change).
- **`src/device/prims_ll128.h`** — comment only: document why the send FIFO stays indexed by `sendStep[wid]` (NCCL parity; no functional change).
- **`cmake/scripts/extract_metadata.cmake`** — replace the multi-step metadata extraction with a single `llvm-objdump --offloading` call.
- **`src/include/rccl_common.h`, `src/transport/net.cc`** — supporting includes.

## Not included (vs #8451)

- All fp8/bf8 packed-arithmetic helper changes (reverted per Meta's overflow-semantics feedback) and the associated fp8 reduce unit tests.
- The `src/ipc_init.cu` debug include — not applicable at this base.

## Test plan

- [x] Clean gfx950 build in the ROCm 7.0.2.1-22 container (device linker enabled; 0 errors).
- [ ] RCCL unit tests on gfx950.
- [ ] (optional) Compare device scratch/VGPR from `*.resources.json` before/after to confirm the scratch reduction.

Made with [Cursor](https://cursor.com)