### PR TITLE
fix(rocshmem): require ROCm 7.2 for HIP VMM allocators

### DIFF
--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -114,8 +114,8 @@ rocm_setup_version(VERSION ${VERSION_STRING})
 # VALIDATE VMM POSIX ALLOCATOR OPTION
 #############################################################################
 if(USE_HEAP_DEVICE_VMM_POSIX)
-  if(${ROCM_MAJOR_VERSION} LESS 7)
-    message(FATAL_ERROR "USE_HEAP_DEVICE_VMM_POSIX requires ROCm 7.0 or newer. Current ROCm version: ${ROCM_MAJOR_VERSION}.${ROCM_MINOR_VERSION}")
+  if(${ROCM_MAJOR_VERSION} LESS 7 OR (${ROCM_MAJOR_VERSION} EQUAL 7 AND ${ROCM_MINOR_VERSION} LESS 2))
+    message(FATAL_ERROR "USE_HEAP_DEVICE_VMM_POSIX requires ROCm 7.2 or newer. Current ROCm version: ${ROCM_MAJOR_VERSION}.${ROCM_MINOR_VERSION}")
   endif()
 endif()
 
@@ -171,8 +171,8 @@ endif()
 # VALIDATE VMM FABRIC ALLOCATOR OPTION
 #############################################################################
 if(USE_HEAP_DEVICE_VMM_FABRIC)
-  if(${ROCM_MAJOR_VERSION} LESS 7)
-    message(FATAL_ERROR "USE_HEAP_DEVICE_VMM_FABRIC requires ROCm 7.next or newer. Current ROCm version: ${ROCM_MAJOR_VERSION}.${ROCM_MINOR_VERSION}")
+  if(${ROCM_MAJOR_VERSION} LESS 7 OR (${ROCM_MAJOR_VERSION} EQUAL 7 AND ${ROCM_MINOR_VERSION} LESS 2))
+    message(FATAL_ERROR "USE_HEAP_DEVICE_VMM_FABRIC requires ROCm 7.2 or newer. Current ROCm version: ${ROCM_MAJOR_VERSION}.${ROCM_MINOR_VERSION}")
   endif()
 
   # VMM Fabric allocator requires both AMD SMI fabric info and HIP fabric handle support

--- a/projects/rocshmem/examples/CMakeLists.txt
+++ b/projects/rocshmem/examples/CMakeLists.txt
@@ -51,8 +51,14 @@ set(EXAMPLE_SOURCES
 
 if (MPI_CXX_FOUND)
   list(APPEND EXAMPLE_SOURCES
-    rocshmem_init_attr_test.cc
-    rocshmem_user_mem_symm_test.cc)
+    rocshmem_init_attr_test.cc)
+
+  # rocshmem_user_mem_symm_test.cc exercises HIP VMM APIs
+  if(${ROCM_MAJOR_VERSION} GREATER 7 OR (${ROCM_MAJOR_VERSION} EQUAL 7 AND ${ROCM_MINOR_VERSION} GREATER_EQUAL 2))
+    list(APPEND EXAMPLE_SOURCES rocshmem_user_mem_symm_test.cc)
+  else()
+    message(STATUS "Skipping rocshmem_user_mem_symm_test: requires ROCm 7.2 or newer (found ${ROCM_MAJOR_VERSION}.${ROCM_MINOR_VERSION})")
+  endif()
 
   add_subdirectory(LL_MoE)
 endif()

--- a/projects/rocshmem/src/backend_bc.cpp
+++ b/projects/rocshmem/src/backend_bc.cpp
@@ -420,7 +420,7 @@ void Backend::buffer_unregister_all() {
 
 int Backend::buffer_register_symmetric(void *addr, size_t length,
                                        void **registered_addr) {
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
   if (registered_addr == nullptr) {
     return ROCSHMEM_ERROR;
   }
@@ -498,7 +498,7 @@ int Backend::buffer_register_symmetric(void *addr, size_t length,
 }
 
 int Backend::buffer_unregister_symmetric(void *addr) {
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
   if (addr == nullptr) {
     return ROCSHMEM_ERROR;
   }
@@ -537,7 +537,7 @@ void Backend::symm_allgather(void* inout, size_t bytes_per_pe) {
 
 hipError_t Backend::create_symm_alias(void *addr, size_t length,
                                       void **alias) {
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
   return heap.get_allocator()->MapLocalAlias(addr, length, alias);
 #else
   (void)addr;
@@ -548,7 +548,7 @@ hipError_t Backend::create_symm_alias(void *addr, size_t length,
 }
 
 void Backend::destroy_symm_alias(void *alias, size_t length) {
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
   (void)heap.get_allocator()->UnmapLocalAlias(alias, length);
 #else
   (void)alias;

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -513,7 +513,7 @@ void IPCBackend::setup_fence_buffer() {
 }
 
 void IPCBackend::setup_symm_registration() {
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
   /* The table alloc is shared with other backends (see Backend). */
   alloc_ipc_symm_table();
 #else
@@ -522,7 +522,7 @@ void IPCBackend::setup_symm_registration() {
 }
 
 void IPCBackend::cleanup_symm_registration() {
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
   /*
    * Unregister anything the user left registered. buffer_unregister_symmetric
    * mutates ipc_symm_records_, so iterate over a snapshot of the keys.
@@ -543,7 +543,7 @@ void IPCBackend::cleanup_symm_registration() {
 int IPCBackend::buffer_register_symmetric([[maybe_unused]] void *addr,
                                           [[maybe_unused]] size_t length,
                                           [[maybe_unused]] void **registered_addr) {
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
   if (registered_addr == nullptr) {
     return ROCSHMEM_ERROR;
   }
@@ -602,8 +602,8 @@ int IPCBackend::buffer_register_symmetric([[maybe_unused]] void *addr,
 }
 
 int IPCBackend::buffer_unregister_symmetric([[maybe_unused]] void *addr) {
-#if HIP_VERSION >= 70000000
-  if (addr == nullptr) {
+#if HIP_VERSION >= 70200000
+  if (addr == nullptr || ipcImpl.symm_table == nullptr) {
     return ROCSHMEM_ERROR;
   }
 

--- a/projects/rocshmem/src/memory/default_allocator.hpp
+++ b/projects/rocshmem/src/memory/default_allocator.hpp
@@ -57,19 +57,19 @@ using HIPDefaultFinegrainedAllocator = rocshmem::HIPAllocatorUncached;
 #endif
 
 #if defined USE_HEAP_DEVICE_VMM_POSIX
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
 using HIPDefaultFinegrainedAllocator = rocshmem::HIPAllocatorVMMPosixFd;
 #else
-#error "USE_HEAP_DEVICE_VMM_POSIX requires ROCm 7.0 or newer (HIP_VERSION >= 70000000)"
+#error "USE_HEAP_DEVICE_VMM_POSIX requires ROCm 7.2 or newer (HIP_VERSION >= 70200000)"
 #endif
 #endif
 
 #if defined USE_HEAP_DEVICE_VMM_FABRIC
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
 using HIPDefaultFinegrainedAllocator = rocshmem::HIPAllocatorVMMFabric;
 #else
 // Precise ROCm version required for Fabric allocator to be adjusted
-#error "USE_HEAP_DEVICE_VMM_FABRIC requires ROCm 7.0 or newer (HIP_VERSION >= 70000000)"
+#error "USE_HEAP_DEVICE_VMM_FABRIC requires ROCm 7.2 or newer (HIP_VERSION >= 70200000)"
 #endif
 #endif
 
@@ -114,12 +114,12 @@ namespace rocshmem {
 #endif
 #endif
 #if defined USE_HEAP_DEVICE_VMM_POSIX
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
     default_allocator_ = new HIPAllocatorVMMPosixFd();
 #endif
 #endif
 #if defined USE_HEAP_DEVICE_VMM_FABRIC
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
     default_allocator_ = new HIPAllocatorVMMFabric();
 #endif
 #endif

--- a/projects/rocshmem/src/memory/hip_allocator.hpp
+++ b/projects/rocshmem/src/memory/hip_allocator.hpp
@@ -57,7 +57,7 @@ enum HIPIpcHandleType {
   HandleTypeLast
 };
 
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
 struct HIPIpcMemHandlePosix_t {
   uint64_t fd;
   uint32_t pid;
@@ -89,7 +89,7 @@ protected:
 
 };
 
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
 class HIPIpcHandlePosixVec : public HIPIpcHandleVec {
 public:
   friend class HIPAllocatorVMMPosixFd;
@@ -143,7 +143,7 @@ class HIPAllocator : public MemoryAllocator {
     return sizeof(hipIpcMemHandle_t);
   }
 
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
   /**
    * @brief HIP VMM handle type used by this allocator's symmetric heap.
    *
@@ -417,7 +417,7 @@ class HIPAllocatorUncached : public HIPAllocator {
 };
 #endif
 
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
 class HIPAllocatorVMMPosixFd : public HIPAllocator {
  private:
   struct VMMAllocationInfo {
@@ -453,7 +453,7 @@ class HIPAllocatorVMMPosixFd : public HIPAllocator {
     return hipMemHandleTypePosixFileDescriptor;
   }
 };
-#endif  // HIP_VERSION >= 70000000
+#endif  // HIP_VERSION >= 70200000
 
 #ifdef HAVE_AMDSMI_GPU_FABRIC_INFO
 /**

--- a/projects/rocshmem/src/memory/hip_allocator_vmm_common.hpp
+++ b/projects/rocshmem/src/memory/hip_allocator_vmm_common.hpp
@@ -25,7 +25,7 @@
 #ifndef LIBRARY_SRC_MEMORY_HIP_ALLOCATOR_VMM_COMMON_HPP_
 #define LIBRARY_SRC_MEMORY_HIP_ALLOCATOR_VMM_COMMON_HPP_
 
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
 
 #include <hip/hip_runtime_api.h>
 #include <hip/hip_version.h>
@@ -53,11 +53,7 @@ struct VMMCommonAllocationInfo {
  */
 inline size_t VMMQueryGranularity(hipMemAllocationHandleType handle_type) {
   hipMemAllocationProp prop = {};
-#if HIP_VERSION < 70200000
-  prop.type = hipMemAllocationTypePinned;
-#else
   prop.type = hipMemAllocationTypeUncached;
-#endif
   prop.location.type = hipMemLocationTypeDevice;
 
   int device_id = 0;
@@ -94,11 +90,7 @@ inline hipError_t VMMAllocCommon(void** ptr, size_t size, hipMemAllocationHandle
   hipMemGenericAllocationHandle_t handle;
   hipMemAllocationProp prop = {};
 
-#if HIP_VERSION < 70200000
-  prop.type = hipMemAllocationTypePinned;
-#else
   prop.type = hipMemAllocationTypeUncached;
-#endif
   prop.location.type = hipMemLocationTypeDevice;
 
   // Get current device ID
@@ -246,6 +238,6 @@ inline hipError_t VMMGetDmabufHandleCommon(void *dev_ptr, size_t size,
 
 }  // namespace rocshmem
 
-#endif  // HIP_VERSION >= 70000000
+#endif  // HIP_VERSION >= 70200000
 
 #endif  // LIBRARY_SRC_MEMORY_HIP_ALLOCATOR_VMM_COMMON_HPP_

--- a/projects/rocshmem/src/memory/hip_allocator_vmm_fabric.cpp
+++ b/projects/rocshmem/src/memory/hip_allocator_vmm_fabric.cpp
@@ -26,7 +26,7 @@
 #include "log.hpp"
 #include "hip_allocator_vmm_common.hpp"
 
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
 
 #include <cstring>
 
@@ -323,4 +323,4 @@ hipError_t HIPAllocatorVMMFabric::GetDmabufHandle(void *dev_ptr, size_t size, in
 
 }  // namespace rocshmem
 
-#endif  // HIP_VERSION >= 70000000
+#endif  // HIP_VERSION >= 70200000

--- a/projects/rocshmem/src/memory/hip_allocator_vmm_posix.cpp
+++ b/projects/rocshmem/src/memory/hip_allocator_vmm_posix.cpp
@@ -26,7 +26,7 @@
 #include "log.hpp"
 #include "hip_allocator_vmm_common.hpp"
 
-#if HIP_VERSION >= 70000000
+#if HIP_VERSION >= 70200000
 
 #include <cstring>
 #include <cerrno>
@@ -428,4 +428,4 @@ hipError_t HIPAllocatorVMMPosixFd::GetDmabufHandle(void *dev_ptr, size_t size, i
 
 }  // namespace rocshmem
 
-#endif  // HIP_VERSION >= 70000000
+#endif  // HIP_VERSION >= 70200000


### PR DESCRIPTION
## Motivation

rocSHMEM's HIP VMM allocator backs the symmetric heap, which must be accessible from both host and device. HIP only exposes `hipMemLocationTypeHost` (needed to grant host access to a VMM allocation) starting in ROCm 7.2, but the VMM allocator code was gated at `HIP_VERSION >= 7.0`.

## Technical Details

- Bump the `HIP_VERSION >= 70000000` guard to `>= 70200000`
- Skip building the VMM-only `rocshmem_user_mem_symm_test` example
  when ROCm is older than 7.2.

## Test Plan

Built rocSHMEM with the GDA MLX5 config (`scripts/build_configs/gda_mlx5`) on node with ROCm/HIP version below 7.2, using `develop` branch and this branch.

## Test Result

- `develop`: build fails — `hipMemLocationTypeHost` is undeclared in `hip_allocator_vmm_common.hpp`/`hip_allocator.hpp` on ROCm 7.0.2.
- This branch: builds and installs cleanly end-to-end (library, device bitcode for gfx90a/gfx942/gfx950/gfx1100/gfx1201, unit tests, functional tests).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.