### PR TITLE
fix(rocprofiler-sdk): rocpd schema version backwards compatability

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/csv.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/csv.py
@@ -442,12 +442,15 @@ def write_csv(importData, config):
 
     write_agent_info_csv(importData, config)
     write_counters_csv(importData, config)
-    write_graph_launch_csv(importData, config)
     write_kernel_csv(importData, config)
     write_memory_allocation_csv(importData, config)
     write_memory_copy_csv(importData, config)
     write_region_csv(importData, config)
     write_scratch_memory_csv(importData, config)
+
+    # graph launch was not introduced until schema version 3.0.2
+    if importData.schema_version >= libpyrocpd.schema_version(3, 0, 2):
+        write_graph_launch_csv(importData, config)
 
 
 def execute(input, config=None, **kwargs):

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/importer.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/importer.py
@@ -50,8 +50,9 @@ def internal_init(_input, _output, skip_auto_merge, automerge_limit):
     _connection = libpyrocpd.connect(_output)
     _connection.execute("PRAGMA foreign_keys = ON")
     _table_info = _create_temp_views(_connection, _input)
-    _create_meta_views(_connection)
-    return (_connection, _input, _table_info)
+    _version = _fetch_version_info(_connection)
+    _create_meta_views(_connection, _version)
+    return (_connection, _input, _table_info, _version)
 
 
 class RocpdImportData(libpyrocpd.RocpdImportData):
@@ -67,6 +68,7 @@ class RocpdImportData(libpyrocpd.RocpdImportData):
         if isinstance(input, RocpdImportData):
             super(RocpdImportData, self).__init__(input)
             self.table_info = input.table_info
+            self.schema_version = input.schema_version
         else:
 
             if isinstance(input, sqlite3.Connection):
@@ -76,10 +78,11 @@ class RocpdImportData(libpyrocpd.RocpdImportData):
             elif isinstance(input, str) or (
                 isinstance(input, list) and len(input) > 0 and isinstance(input[0], str)
             ):
-                _connection, _filenames, _table_info = internal_init(
+                _connection, _filenames, _table_info, _version = internal_init(
                     input, dbname, skip_auto_merge, automerge_limit
                 )
                 self.table_info = _table_info
+                self.schema_version = _version
             else:
                 raise ValueError(
                     f"input is unsupported type. Expected sqlite3.Connection, string, or (non-empty) list of strings. type={type(input).__name__}"
@@ -199,7 +202,23 @@ def _create_temp_views(connection, input):
     return all_tables
 
 
-def _create_meta_views(connection):
-    schema = RocpdSchema()
+def _create_meta_views(connection, schema_version):
+    schema = RocpdSchema(version=str(schema_version))
     sql_script = schema.views.replace("CREATE VIEW", "CREATE TEMPORARY VIEW")
     execute_statement(connection, sql_script, is_script=True)
+
+
+def _fetch_version_info(connection):
+    _versions = [
+        itr[0]
+        for itr in execute_statement(
+            connection,
+            "SELECT value FROM rocpd_metadata WHERE tag='schema_version'",
+        ).fetchall()
+    ]
+
+    _versions = list(set(_versions))
+    if len(_versions) != 1:
+        raise ValueError(f"Expected exactly one schema version, found: {_versions}")
+
+    return libpyrocpd.schema_version(_versions[0]) if _versions else None

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/libpyrocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/libpyrocpd.cpp
@@ -180,6 +180,44 @@ struct jinja_variables
 };
 }  // namespace rocpd
 
+bool
+operator==(rocpd_version_triplet_t lhs, rocpd_version_triplet_t rhs)
+{
+    return std::tie(lhs.major, lhs.minor, lhs.patch) == std::tie(rhs.major, rhs.minor, rhs.patch);
+}
+
+bool
+operator<(rocpd_version_triplet_t lhs, rocpd_version_triplet_t rhs)
+{
+    auto lhs_v = ROCPROFILER_SDK_COMPUTE_VERSION_VALUE(1000, lhs.major, lhs.minor, lhs.patch);
+    auto rhs_v = ROCPROFILER_SDK_COMPUTE_VERSION_VALUE(1000, rhs.major, rhs.minor, rhs.patch);
+    return (lhs_v < rhs_v);
+}
+
+bool
+operator!=(rocpd_version_triplet_t lhs, rocpd_version_triplet_t rhs)
+{
+    return !(lhs == rhs);
+}
+
+bool
+operator<=(rocpd_version_triplet_t lhs, rocpd_version_triplet_t rhs)
+{
+    return (lhs < rhs) || (lhs == rhs);
+}
+
+bool
+operator>(rocpd_version_triplet_t lhs, rocpd_version_triplet_t rhs)
+{
+    return !(lhs <= rhs);
+}
+
+bool
+operator>=(rocpd_version_triplet_t lhs, rocpd_version_triplet_t rhs)
+{
+    return !(lhs < rhs);
+}
+
 PYBIND11_MODULE(libpyrocpd, pyrocpd)
 {
     // namespace sdk  = ::rocprofiler::sdk;
@@ -354,9 +392,19 @@ PYBIND11_MODULE(libpyrocpd, pyrocpd)
              [](const rocpd_version_triplet_t& v) {
                  return fmt::format("{}.{}.{}", v.major, v.minor, v.patch);
              })
-        .def("__repr__", [](const rocpd_version_triplet_t& v) {
-            return fmt::format("schema_version({}, {}, {})", v.major, v.minor, v.patch);
-        });
+        .def("__repr__",
+             [](const rocpd_version_triplet_t& v) {
+                 return fmt::format("schema_version({}, {}, {})", v.major, v.minor, v.patch);
+             })
+        // NOLINTBEGIN(misc-redundant-expression)
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+        .def(py::self < py::self)
+        .def(py::self > py::self)
+        .def(py::self <= py::self)
+        .def(py::self >= py::self)
+        // NOLINTEND(misc-redundant-expression)
+        ;
 
     py::class_<rocpd::RocpdImportData>(pyrocpd, "RocpdImportData", "RocPD database(s) instances")
         .def(py::init<>())


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
- Introduce handling of schema versions in rocpd

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- `RocpdImportData` Python class includes a `schema_version` member of type `libpyrocpd.schema_version`
- Add comparison operators for `libpyrocpd.schema_version`
- Protect writing CSV launch data depending on the schema version

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
