### PR TITLE
rocr: Replace assert-only error checks with proper error handling

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -625,7 +625,11 @@ void AqlQueue::AllocRegisteredRingBuffer(uint32_t queue_size_pkts) {
         core::MemoryRegion::AllocateExecutable);
   }
 
-  assert(ring_buf_ != NULL && "AQL queue memory allocation failure");
+  if (ring_buf_ == nullptr) {
+    assert(false && "AQL queue memory allocation failure");
+    throw AMD::hsa_exception(HSA_STATUS_ERROR_OUT_OF_RESOURCES,
+                              "AQL queue ring buffer allocation failed.");
+  }
   // Fill the ring buffer with invalid packet headers.
   // Leave packet content uninitialized to help track errors.
   for (uint32_t pkt_id = 0; pkt_id < queue_size_pkts; ++pkt_id)
@@ -1682,7 +1686,10 @@ void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope
 
     if (!in_signal) {
       err = hsa_signal_create(1, 0, NULL, &local_signal);
-      assert(err == HSA_STATUS_SUCCESS);
+      if (err != HSA_STATUS_SUCCESS) {
+        assert(false && "hsa_signal_create failed in ExecutePM4");
+        throw AMD::hsa_exception(err, "Failed to create signal for PM4 execution.");
+      }
     }
 
     constexpr uint32_t AMD_AQL_FORMAT_PM4_IB = 0x1;
@@ -1726,13 +1733,16 @@ void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope
 
     if (in_signal) hsa_signal_store_screlease(*in_signal, 0);
   } else if (!in_signal) {
-    // On gfx9 and newer, if in_signal is not provided, we block and wait for own signal
-    hsa_signal_value_t ret;
-    ret = hsa_signal_wait_scacquire(local_signal, HSA_SIGNAL_CONDITION_LT, 1, (uint64_t)-1,
-                                    HSA_WAIT_STATE_ACTIVE);
+    // On gfx9 and newer, if in_signal is not provided, we block and wait for own signal.
+    // Use do/while loop since hsa_signal_wait_scacquire may return spuriously.
+    // Break condition matches wait condition: HSA_SIGNAL_CONDITION_LT with compare value 1.
+    do {
+      hsa_signal_value_t ret = hsa_signal_wait_scacquire(
+          local_signal, HSA_SIGNAL_CONDITION_LT, 1, (uint64_t)-1, HSA_WAIT_STATE_ACTIVE);
+      if (ret < 1) break;
+    } while (true);
     err = hsa_signal_destroy(local_signal);
-    assert(ret == 0 && err == HSA_STATUS_SUCCESS);
-    (void)ret;
+    assert(err == HSA_STATUS_SUCCESS && "hsa_signal_destroy failed");
   }
   (void)err;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -123,8 +123,8 @@ uint32_t BlitSdma<useGCR, scopeFields>::gcr_command_size() {
 
 template <bool useGCR, bool scopeFields>
 BlitSdma<useGCR, scopeFields>::BlitSdma()
-    : agent_(NULL),
-      queue_start_addr_(NULL),
+    : agent_(nullptr),
+      queue_start_addr_(nullptr),
       bytes_queued_(0),
       parity_(false),
       cached_reserve_index_(0),
@@ -155,7 +155,7 @@ template <bool useGCR, bool scopeFields> BlitSdma<useGCR, scopeFields>::~BlitSdm
 template <bool useGCR, bool scopeFields>
 hsa_status_t BlitSdma<useGCR, scopeFields>::Initialize(const core::Agent& agent, bool use_xgmi,
                                           size_t linear_copy_size_override, int rec_eng) {
-  if (queue_start_addr_ != NULL) {
+  if (queue_start_addr_ != nullptr) {
     // Already initialized.
     return HSA_STATUS_SUCCESS;
   }
@@ -221,7 +221,7 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::Initialize(const core::Agent& agent,
   queue_start_addr_ =
       (char*)agent_->system_allocator()(kQueueSize, 0x1000, core::MemoryRegion::AllocateExecutable);
 
-  if (queue_start_addr_ == NULL) {
+  if (queue_start_addr_ == nullptr) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
   MAKE_NAMED_SCOPE_GUARD(cleanupOnException, [&]() { Destroy(); };);
@@ -285,17 +285,19 @@ template <bool useGCR, bool scopeFields> hsa_status_t BlitSdma<useGCR, scopeFiel
   if (queue_resource_.QueueId != 0) {
     // Release queue resources from the kernel
     auto err = agent_->driver().DestroyQueue(queue_resource_.QueueId);
-    assert(err == HSA_STATUS_SUCCESS);
-    (void)err;
+    if (err != HSA_STATUS_SUCCESS) {
+      assert(false && "DestroyQueue failed");
+      // Continue cleanup even on failure
+    }
     memset(&queue_resource_, 0, sizeof(queue_resource_));
   }
 
-  if (queue_start_addr_ != NULL) {
+  if (queue_start_addr_ != nullptr) {
     // Release queue buffer.
     agent_->system_deallocator()(queue_start_addr_);
   }
 
-  queue_start_addr_ = NULL;
+  queue_start_addr_ = nullptr;
   cached_reserve_index_ = 0;
   cached_commit_index_ = 0;
 
@@ -2087,7 +2089,10 @@ template <bool useGCR, bool scopeFields> bool BlitSdma<useGCR, scopeFields>::Can
 template <bool useGCR, bool scopeFields>
 void BlitSdma<useGCR, scopeFields>::BuildFenceCommand(char* fence_command_addr, uint32_t* fence,
                                          uint32_t fence_value) {
-  assert(fence_command_addr != NULL);
+  if (fence_command_addr == nullptr) {
+    assert(false && "fence_command_addr is NULL");
+    abort();  // Unrecoverable: null command addr would submit garbage to SDMA ring
+  }
 
   // GFX12 or later use a different packet format that is incompatible (fields changed in size and location).
   if (agent_->supported_isas()[0]->GetMajorVersion() >= 12) {
@@ -2975,13 +2980,19 @@ template <bool useGCR, bool scopeFields> void BlitSdma<useGCR, scopeFields>::Bui
 }
 
 template <bool useGCR, bool scopeFields> void BlitSdma<useGCR, scopeFields>::BuildHdpFlushCommand(char* cmd_addr) {
-  assert(cmd_addr != NULL);
+  if (cmd_addr == nullptr) {
+    assert(false && "cmd_addr is NULL in BuildHdpFlushCommand");
+    abort();  // Unrecoverable: null command addr would submit garbage to SDMA ring
+  }
   SDMA_PKT_POLL_REGMEM* addr = reinterpret_cast<SDMA_PKT_POLL_REGMEM*>(cmd_addr);
   memcpy(addr, &hdp_flush_cmd, flush_command_size_);
 }
 
 template <bool useGCR, bool scopeFields> void BlitSdma<useGCR, scopeFields>::BuildGCRCommand(char* cmd_addr, bool invalidate) {
-  assert(cmd_addr != NULL);
+  if (cmd_addr == nullptr) {
+    assert(false && "cmd_addr is NULL in BuildGCRCommand");
+    abort();  // Unrecoverable: null command addr would submit garbage to SDMA ring
+  }
   assert(useGCR && "Unsupported SDMA command - GCR.");
 
   if (is_gfx125plus_) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -199,7 +199,11 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
                              node_props.EngineId.ui32.Stepping), sramecc, xnack);
   }
 
-  assert(isa != nullptr && "ISA registry inconsistency.");
+  if (isa == nullptr) {
+    assert(false && "ISA registry inconsistency.");
+    throw AMD::hsa_exception(HSA_STATUS_ERROR_INVALID_ISA,
+                              "ISA registry inconsistency: could not find ISA for GPU.");
+  }
 
   supported_isas_.push_back(isa);
   if (!supported_isas_[0]->GetIsaGeneric().empty()) {
@@ -425,7 +429,11 @@ void GpuAgent::AssembleShader(const char* func_name, AssembleTarget assemble_tar
 
   code_buf = system_allocator()(code_buf_size, 0x1000,
     core::MemoryRegion::AllocateExecutable | core::MemoryRegion::AllocateExecutableBlitKernelObject);
-  assert(code_buf != NULL && "Code buffer allocation failed");
+  if (code_buf == nullptr) {
+    assert(false && "Code buffer allocation failed");
+    throw AMD::hsa_exception(HSA_STATUS_ERROR_OUT_OF_RESOURCES,
+                              "Failed to allocate code buffer for shader.");
+  }
 
   memset(code_buf, 0, code_buf_size);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_topology.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_topology.cpp
@@ -310,8 +310,10 @@ void SurfaceGpuList(std::vector<int32_t>& gpu_list, bool xnack_mode, bool enable
 
       // Obtain properties of the node
       hsa_status_t ret = gpu_driver->GetNodeProperties(node_prop, gpu_list[idx]);
-      assert(ret == HSA_STATUS_SUCCESS && "Error in getting Node Properties");
-      (void)ret;
+      if (ret != HSA_STATUS_SUCCESS) {
+        assert(false && "Error in getting Node Properties");
+        throw AMD::hsa_exception(ret, "Failed to get node properties during GPU enumeration.");
+      }
 
       // disable interrupt signal for DTIF platform
       if (core::Runtime::runtime_singleton_->flag().enable_dtif())

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
@@ -760,7 +760,10 @@ hsa_status_t hsa_queue_create(
                               group_segment_size, true, &cmd_queue);
   if (status != HSA_STATUS_SUCCESS) return status;
 
-  assert(cmd_queue != nullptr && "Queue not returned but status was success.\n");
+  if (cmd_queue == nullptr) {
+    assert(false && "Queue not returned but status was success.");
+    return HSA_STATUS_ERROR;
+  }
   *queue = core::Queue::Convert(cmd_queue);
   return status;
 
@@ -790,7 +793,10 @@ hsa_status_t hsa_soft_queue_create(hsa_region_t region, uint32_t size,
   void* shared_queue = nullptr;
   hsa_status_t err = HSA::hsa_memory_allocate(region, sizeof(core::SharedQueue), &shared_queue);
   if (err != HSA_STATUS_SUCCESS) return err;
-  assert(shared_queue && "Queue struct is NULL when creating host queue.");
+  if (shared_queue == nullptr) {
+    assert(false && "Queue struct is NULL when creating host queue.");
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
 
   core::HostQueue* host_queue = new core::HostQueue(static_cast<core::SharedQueue*>(shared_queue),
                                                     region, size, type, features, doorbell_signal);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/svm_profiler.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/svm_profiler.cpp
@@ -150,15 +150,32 @@ void SvmProfileControl::PollSmi() {
       HSA_SMI_EVENT_MASK_FROM_INDEX(HSA_SMI_EVENT_QUEUE_RESTORE) |
       HSA_SMI_EVENT_MASK_FROM_INDEX(HSA_SMI_EVENT_UNMAP_FROM_GPU);
 
+  // Track how many fds we've opened for cleanup on error
+  int opened_fds = 0;
+  auto cleanup_fds = [&]() {
+    for (int j = 1; j <= opened_fds; j++) {
+      close(files[j].fd);
+    }
+  };
+
   for (int i = 0; i < core::Runtime::runtime_singleton_->gpu_agents().size(); i++) {
     auto gpu_agent = core::Runtime::runtime_singleton_->gpu_agents()[i];
     auto err = gpu_agent->driver().OpenSMI(gpu_agent->node_id(), &files[i + 1].fd);
-    assert(err == HSA_STATUS_SUCCESS);
+    if (err != HSA_STATUS_SUCCESS) {
+      assert(false && "OpenSMI failed");
+      cleanup_fds();
+      return;  // Log and return instead of throwing to avoid process termination
+    }
+    opened_fds++;
     files[i + 1].events = POLLIN;
     files[i + 1].revents = 0;
     // Enable collecting masked events.
     auto wrote = write(files[i + 1].fd, &events, sizeof(events));
-    assert(wrote == sizeof(events));
+    if (wrote != sizeof(events)) {
+      assert(false && "write to SMI fd failed");
+      cleanup_fds();
+      return;  // Log and return instead of throwing to avoid process termination
+    }
   }
   MAKE_NAMED_SCOPE_GUARD(smiGuard, [&]() {
     for (int i = 1; i < files.size(); i++) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/blit_kernel.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/blit_kernel.cpp
@@ -262,7 +262,10 @@ hsa_status_t BlitKernel::CopyBufferToImage(
     return status;
   }
 
-  assert(dst_image_view != NULL);
+  if (dst_image_view == nullptr) {
+    assert(false && "dst_image_view is NULL");
+    return HSA_STATUS_ERROR;
+  }
 
   hsa_kernel_dispatch_packet_t packet = { };
 
@@ -292,7 +295,10 @@ hsa_status_t BlitKernel::CopyBufferToImage(
   };
 
   KernelArgs* args = (KernelArgs*)Allocate(dst_image_view->component, sizeof(KernelArgs));
-  assert(args != NULL);
+  if (args == nullptr) {
+    assert(false && "Failed to allocate kernel args");
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
   memset(args, 0, sizeof(KernelArgs));
   args->buffer = src_memory;
   for(auto& img : args->image)
@@ -363,14 +369,17 @@ hsa_status_t BlitKernel::CopyImageToBuffer(
     return HSA::hsa_memory_copy(dst_memory, src_memory, size);
   }
 
-  const Image* src_image_view = NULL;
+  const Image* src_image_view = nullptr;
 
   hsa_status_t status = ConvertImage(src_image, &src_image_view);
   if (HSA_STATUS_SUCCESS != status) {
     return status;
   }
 
-  assert(src_image_view != NULL);
+  if (src_image_view == nullptr) {
+    assert(false && "src_image_view is NULL");
+    return HSA_STATUS_ERROR;
+  }
 
   hsa_kernel_dispatch_packet_t packet = { };
 
@@ -400,7 +409,10 @@ hsa_status_t BlitKernel::CopyImageToBuffer(
   };
 
   KernelArgs* args = (KernelArgs*)Allocate(src_image_view->component, sizeof(KernelArgs));
-  assert(args != NULL);
+  if (args == nullptr) {
+    assert(false && "Failed to allocate kernel args");
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
   memset(args, 0, sizeof(KernelArgs));
   for(auto &img : args->image)
     img = src_image_view->Convert();
@@ -461,7 +473,7 @@ hsa_status_t BlitKernel::CopyImage(
 
   const Image* src_image_view = &src_image;
   const Image* dst_image_view = &dst_image;
-  const BlitCodeInfo* blit_code = NULL;
+  const BlitCodeInfo* blit_code = nullptr;
 
   if (copy_type == KERNEL_OP_COPY_IMAGE_DEFAULT) {
     // Linear to linear image copy.
@@ -471,14 +483,20 @@ hsa_status_t BlitKernel::CopyImage(
       return status;
     }
 
-    assert(src_image_view != NULL);
+    if (src_image_view == nullptr) {
+      assert(false && "src_image_view is NULL");
+      return HSA_STATUS_ERROR;
+    }
 
     status = ConvertImage(dst_image, &dst_image_view);
     if (HSA_STATUS_SUCCESS != status) {
       return status;
     }
 
-    assert(dst_image_view != NULL);
+    if (dst_image_view == nullptr) {
+      assert(false && "dst_image_view is NULL");
+      return HSA_STATUS_ERROR;
+    }
 
     const hsa_ext_image_geometry_t src_geometry = src_image_view->desc.geometry;
     const hsa_ext_image_geometry_t dst_geometry = dst_image_view->desc.geometry;
@@ -517,7 +535,10 @@ hsa_status_t BlitKernel::CopyImage(
   };
 
   KernelArgs* args = (KernelArgs*)Allocate(dst_image_view->component, sizeof(KernelArgs));
-  assert(args != NULL);
+  if (args == nullptr) {
+    assert(false && "Failed to allocate kernel args");
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
   memset(args, 0, sizeof(KernelArgs));
 
   for(auto& img : args->src)
@@ -579,7 +600,10 @@ hsa_status_t BlitKernel::FillImage(
   };
 
   KernelArgs* args = (KernelArgs*)Allocate(image.component, sizeof(KernelArgs));
-  assert(args != NULL);
+  if (args == nullptr) {
+    assert(false && "Failed to allocate kernel args");
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
   memset(args, 0, sizeof(KernelArgs));
 
   for(auto &img : args->image)

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager.cpp
@@ -79,43 +79,51 @@ Image* Image::Create(hsa_agent_t agent) {
 }
 
 void Image::Destroy(const Image* image) {
-  assert(image != NULL);
+  if (image == nullptr) {
+    assert(false && "Image::Destroy called with NULL image");
+    return;
+  }
   image->~Image();
 
   hsa_status_t status = AMD::hsa_amd_memory_pool_free(const_cast<Image*>(image));
-
-  assert(status == HSA_STATUS_SUCCESS);
+  if (status != HSA_STATUS_SUCCESS) {
+    assert(false && "hsa_amd_memory_pool_free failed for Image");
+  }
 }
 
 Sampler* Sampler::Create(hsa_agent_t agent) {
   hsa_amd_memory_pool_t pool = ImageRuntime::instance()->kernarg_pool();
 
-  Sampler* sampler = NULL;
+  Sampler* sampler = nullptr;
 
   hsa_status_t status = AMD::hsa_amd_memory_pool_allocate(pool, sizeof(Sampler), 0,
                                                           reinterpret_cast<void**>(&sampler));
 
-  if (status != HSA_STATUS_SUCCESS) return NULL;
+  if (status != HSA_STATUS_SUCCESS) return nullptr;
 
   new (sampler) Sampler();
 
-  status = AMD::hsa_amd_agents_allow_access(1, &agent, NULL, sampler);
+  status = AMD::hsa_amd_agents_allow_access(1, &agent, nullptr, sampler);
 
   if (status != HSA_STATUS_SUCCESS) {
     Sampler::Destroy(sampler);
-    return NULL;
+    return nullptr;
   }
 
   return sampler;
 }
 
 void Sampler::Destroy(const Sampler* sampler) {
-  assert(sampler != NULL);
+  if (sampler == nullptr) {
+    assert(false && "Sampler::Destroy called with NULL sampler");
+    return;
+  }
   sampler->~Sampler();
 
   hsa_status_t status = AMD::hsa_amd_memory_pool_free(const_cast<Sampler*>(sampler));
-
-  assert(status == HSA_STATUS_SUCCESS);
+  if (status != HSA_STATUS_SUCCESS) {
+    assert(false && "hsa_amd_memory_pool_free failed for Sampler");
+  }
 }
 
 MipmappedArray* MipmappedArray::Create(hsa_agent_t agent) {
@@ -142,12 +150,17 @@ MipmappedArray* MipmappedArray::Create(hsa_agent_t agent) {
 }
 
 void MipmappedArray::Destroy(const MipmappedArray* mipmapped_array) {
-  assert(mipmapped_array != NULL);
+  if (mipmapped_array == nullptr) {
+    assert(false && "MipmappedArray::Destroy called with NULL mipmapped_array");
+    return;
+  }
   mipmapped_array->~MipmappedArray();
 
   hsa_status_t status = AMD::hsa_amd_memory_pool_free(
                         const_cast<MipmappedArray*>(mipmapped_array));
-  assert(status == HSA_STATUS_SUCCESS);
+  if (status != HSA_STATUS_SUCCESS) {
+    assert(false && "hsa_amd_memory_pool_free failed for MipmappedArray");
+  }
 }
 
 ImageManager::ImageManager() {}

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_runtime.cpp
@@ -153,7 +153,10 @@ hsa_status_t ImageRuntime::GetMipmapArraySizeAndAlignment(
 }
 
 hsa_status_t FindKernelArgPool(hsa_amd_memory_pool_t pool, void* data) {
-  assert(data != nullptr);
+  if (data == nullptr) {
+    assert(false && "FindKernelArgPool: data is nullptr");
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
 
   hsa_status_t err;
   hsa_amd_segment_t segment;
@@ -161,16 +164,25 @@ hsa_status_t FindKernelArgPool(hsa_amd_memory_pool_t pool, void* data) {
   size_t size;
 
   err = AMD::hsa_amd_memory_pool_get_info(pool, HSA_AMD_MEMORY_POOL_INFO_SEGMENT, &segment);
-  assert(err == HSA_STATUS_SUCCESS);
+  if (err != HSA_STATUS_SUCCESS) {
+    assert(false && "hsa_amd_memory_pool_get_info SEGMENT failed");
+    return err;
+  }
 
   if (segment != HSA_AMD_SEGMENT_GLOBAL) return HSA_STATUS_SUCCESS;
 
   err = AMD::hsa_amd_memory_pool_get_info(
       pool, HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS, &flag);
-  assert(err == HSA_STATUS_SUCCESS);
+  if (err != HSA_STATUS_SUCCESS) {
+    assert(false && "hsa_amd_memory_pool_get_info GLOBAL_FLAGS failed");
+    return err;
+  }
 
   err = AMD::hsa_amd_memory_pool_get_info(pool, HSA_AMD_MEMORY_POOL_INFO_SIZE, &size);
-  assert(err == HSA_STATUS_SUCCESS);
+  if (err != HSA_STATUS_SUCCESS) {
+    assert(false && "hsa_amd_memory_pool_get_info SIZE failed");
+    return err;
+  }
 
   if (((HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_KERNARG_INIT & flag) == 1) && (size != 0)) {
     *(reinterpret_cast<hsa_amd_memory_pool_t*>(data)) = pool;


### PR DESCRIPTION
In release builds (NDEBUG defined), assert() expands to nothing. Multiple code paths used assert() as the ONLY check for critical operations, causing crashes with no diagnostic information.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
