### PR TITLE
clr : use IPCEmulated Events for Rocr windows path

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3849,7 +3849,13 @@ void Device::getGlobalCUMask(std::string_view cuMaskStr) {
 device::Signal* Device::createSignal() const { return new roc::Signal(); }
 
 // ================================================================================================
-device::Signal* Device::createIpcSignal() const { return new roc::IpcSignal(); }
+device::Signal* Device::createIpcSignal() const {
+  #if defined(__linux__)
+    return new roc::IpcSignal();
+  #else
+    return nullptr;  // mimic PAL windows path
+  #endif
+}
 
 // ================================================================================================
 static std::string GetLocalHostName() {

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3850,11 +3850,11 @@ device::Signal* Device::createSignal() const { return new roc::Signal(); }
 
 // ================================================================================================
 device::Signal* Device::createIpcSignal() const {
-  #if defined(__linux__)
-    return new roc::IpcSignal();
-  #else
-    return nullptr;  // mimic PAL windows path
-  #endif
+#if defined(__linux__)
+  return new roc::IpcSignal();
+#else
+  return nullptr;  // mimic PAL windows path
+#endif
 }
 
 // ================================================================================================


### PR DESCRIPTION
## Motivation
clr : instantiate IPCEmulated for Rocr windows path
this follows PAL path behaviour

## Technical Details
clr : instantiate IPCEmulated for Rocr windows path
this follows PAL path behaviour. 

IPC requires more work on Windows. So for now following PAL behaviour on ROCr as well

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking
JIRA ID : AIRUNTIME-1992

## Test Plan
All hip-tests pass on both linux (rocr) and windows (PAL and ROCr)
EventTest.exe Unit_hipEventIpc_DestroyNonBlocking -> needs to be skipped similar to PAL

## Test Result
All hip-tests pass on both linux (rocr) and windows (PAL and ROCr)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
