### PR TITLE
fix(rocdecode): fixes the memory leak reported in ASAN build issue #ROCM28034

### DIFF
--- a/projects/rocdecode/samples/videoDecodeRGB/videodecrgb.cpp
+++ b/projects/rocdecode/samples/videoDecodeRGB/videodecrgb.cpp
@@ -70,7 +70,7 @@ std::queue<int> frame_indices_q;
 uint8_t* frame_buffers[frame_buffers_size] = {0};
 
 void ColorSpaceConversionThread(std::atomic<bool>& continue_processing, bool convert_to_rgb, Dim *p_resize_dim, OutputSurfaceInfo **surf_info, OutputSurfaceInfo **res_surf_info,
-        OutputFormatEnum e_output_format, uint8_t *p_rgb_dev_mem, uint8_t *p_resize_dev_mem, bool dump_output_frames,
+        OutputFormatEnum e_output_format, uint8_t *&p_rgb_dev_mem, uint8_t *&p_resize_dev_mem, bool dump_output_frames,
         std::string &output_file_path, RocVideoDecoder &viddec, VideoPostProcess &post_proc, MD5Generator *md5_gen_handle, bool b_generate_md5, int device_id, hipStream_t hip_stream, int col_standard) {
 
     size_t rgb_image_size, resize_image_size;


### PR DESCRIPTION
## Motivation

This PR fixes the memory leak in videodecodeRGB sample reported by ROCM issue #28034

## Technical Details

The issue was caused by not freeing the hipMemory allocated for RGB output.
The earlier code frees the memory, but because the pointer was passed by value the memory pointer ended up not freed in calling function

## Issue Tracking

 JIRA ID: ROCM-28034

## Test Plan

All tests in the existing test suite should pass

## Test Result

./videodecodergb -i ../../../data/videos/AMD_driving_virtual_20-H265.mp4 -o out.rgb -of rgb -f 10
info: Using GPU device 0 AMD Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
info: decoding started, please wait!
Input Video Information
        Codec        : H.265/HEVC
        Frame rate   : 30000/1001 = 29.97 fps
        Sequence     : Progressive
        Coded size   : [2048, 1024]
        Display area : [0, 0, 2048, 1024]
        Chroma       : YUV 420
        Bit depth    : 8
Video Decoding Params:
        Num Surfaces : 7
        Crop         : [0, 0, 2048, 1024]
        Resize       : 2048x1024

info: Total frame decoded: 10

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
