### PR TITLE
fix(rocshmem): reenable flood_get tests

### DIFF
--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -922,13 +922,12 @@ TestOther() {
   ExecTest  "flood_putnbi"     8       64           1024
   ExecTest  "flood_p"          8       64           1024
 
-  # Temporarily disabled flood_get tests
-  # ExecTest  "flood_get"        2       64           1024
-  # ExecTest  "flood_get"        8       64           1024
-  # ExecTest  "flood_getnbi"     8       64           1024
-  # if [[ $TEST != gda* ]]; then #AIROCSHMEM-162
-  # ExecTest  "flood_g"          8       64           1024
-  # else echo "Skip:   flood_g (AIROCSHMEM-162: GDA _g not implemented)"; fi
+  ExecTest  "flood_get"        2       64           1024
+  ExecTest  "flood_get"        8       64           1024
+  ExecTest  "flood_getnbi"     8       64           1024
+  if [[ $TEST != gda* ]]; then #AIROCSHMEM-162
+  ExecTest  "flood_g"          8       64           1024
+  else echo "Skip:   flood_g (AIROCSHMEM-162: GDA _g not implemented)"; fi
 
   ExecTest  "flood_add"        2       64           1024
   ExecTest  "flood_add"        8       64           1024

--- a/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
+++ b/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
@@ -1163,8 +1163,6 @@ function(add_other_tests)
         add_rocshmem_functional_test(NAME flood_getnbi RANKS 8 WORKGROUPS 64 THREADS 1024)
     end_test_group()
 
-    Temporarily disabled flood_g test
-    flood_g - only works with IPC (not GDA, not RO)
     begin_test_group(CATEGORY "FLOOD;RMA;GET" TIER full BACKENDS "ipc" GPUS "all")
         add_rocshmem_functional_test(NAME flood_g RANKS 8 WORKGROUPS 64 THREADS 1024)
     end_test_group()

--- a/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
+++ b/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
@@ -1157,18 +1157,17 @@ function(add_other_tests)
         add_rocshmem_functional_test(NAME flood_p RANKS 8 WORKGROUPS 64 THREADS 1024)
     end_test_group()
 
-    # Temporarily disabled flood_get tests
-    # begin_test_group(CATEGORY "FLOOD;RMA;GET" TIER full BACKENDS "ipc;gda" GPUS "all")
-    #     add_rocshmem_functional_test(NAME flood_get RANKS 2 WORKGROUPS 64 THREADS 1024)
-    #     add_rocshmem_functional_test(NAME flood_get RANKS 8 WORKGROUPS 64 THREADS 1024)
-    #     add_rocshmem_functional_test(NAME flood_getnbi RANKS 8 WORKGROUPS 64 THREADS 1024)
-    # end_test_group()
+    begin_test_group(CATEGORY "FLOOD;RMA;GET" TIER full BACKENDS "ipc;gda" GPUS "all")
+        add_rocshmem_functional_test(NAME flood_get RANKS 2 WORKGROUPS 64 THREADS 1024)
+        add_rocshmem_functional_test(NAME flood_get RANKS 8 WORKGROUPS 64 THREADS 1024)
+        add_rocshmem_functional_test(NAME flood_getnbi RANKS 8 WORKGROUPS 64 THREADS 1024)
+    end_test_group()
 
-    # Temporarily disabled flood_g test
-    # flood_g - only works with IPC (not GDA, not RO)
-    # begin_test_group(CATEGORY "FLOOD;RMA;GET" TIER full BACKENDS "ipc" GPUS "all")
-    #     add_rocshmem_functional_test(NAME flood_g RANKS 8 WORKGROUPS 64 THREADS 1024)
-    # end_test_group()
+    Temporarily disabled flood_g test
+    flood_g - only works with IPC (not GDA, not RO)
+    begin_test_group(CATEGORY "FLOOD;RMA;GET" TIER full BACKENDS "ipc" GPUS "all")
+        add_rocshmem_functional_test(NAME flood_g RANKS 8 WORKGROUPS 64 THREADS 1024)
+    end_test_group()
 
     begin_test_group(CATEGORY "FLOOD;AMO" TIER full BACKENDS "ipc;gda" GPUS "all")
         add_rocshmem_functional_test(NAME flood_add RANKS 2 WORKGROUPS 64 THREADS 1024)


### PR DESCRIPTION
reenable the flood_get tests, since the problems on the gfx950 platform have been resolved.


## Issue Tracking

JIRA ID: AIROCSHMEM-340

(note: using the JIRA ticket for theRock CI as a general placeholder in this case, this is a generic CI feature)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
