### PR TITLE
fix(rocjitsu): Retain owners for borrowed C API handles

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
@@ -120,6 +120,8 @@ rj_status_t rj_code_executable_get_code_object(const rj_code_executable_t *exec,
 
   *obj = new rj_code_object_t{};
   (*obj)->co = co;
+  (*obj)->parent_exec = const_cast<rj_code_executable_t *>(exec);
+  (*obj)->parent_exec->retain();
   (*obj)->retain();
   return ROCJITSU_STATUS_SUCCESS;
 }
@@ -246,6 +248,8 @@ rj_status_t rj_code_basic_block_list_get(const rj_code_basic_block_list_t *list,
 
   *block = new rj_code_basic_block_t{};
   (*block)->block = list->blocks[index].get();
+  (*block)->parent_list = const_cast<rj_code_basic_block_list_t *>(list);
+  (*block)->parent_list->retain();
   (*block)->retain();
   return ROCJITSU_STATUS_SUCCESS;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code_internal.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code_internal.h
@@ -20,8 +20,14 @@ struct rj_code_executable_t : rocjitsu::RefCounted {
 };
 
 struct rj_code_object_t : rocjitsu::RefCounted {
+  ~rj_code_object_t() {
+    if (parent_exec && parent_exec->release())
+      delete parent_exec;
+  }
+
   rocjitsu::AmdGpuCodeObject *co = nullptr;
   std::unique_ptr<rocjitsu::AmdGpuCodeObject> owned_co;
+  rj_code_executable_t *parent_exec = nullptr;
 };
 
 struct rj_code_inst_list_t : rocjitsu::RefCounted {
@@ -34,5 +40,11 @@ struct rj_code_basic_block_list_t : rocjitsu::RefCounted {
 };
 
 struct rj_code_basic_block_t : rocjitsu::RefCounted {
+  ~rj_code_basic_block_t() {
+    if (parent_list && parent_list->release())
+      delete parent_list;
+  }
+
   rocjitsu::BasicBlock *block = nullptr;
+  rj_code_basic_block_list_t *parent_list = nullptr;
 };

--- a/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
+++ b/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
@@ -157,20 +157,31 @@ void expect_c_api_accepts_target(uint32_t mach_flag, rj_code_target_id_t target)
   ASSERT_EQ(rj_code_executable_get_code_object(exec, target, 0, &obj), ROCJITSU_STATUS_SUCCESS);
   ASSERT_NE(obj, nullptr);
 
+  // The returned code-object handle must keep its executable storage alive.
+  rj_code_executable_destroy(exec);
+
   rj_code_basic_block_list_t *blocks = nullptr;
   EXPECT_EQ(rj_code_basic_block_list_create(obj, target, &blocks), ROCJITSU_STATUS_SUCCESS)
       << "rj_code_basic_block_list_create must succeed for a target whose decoder is wired in";
-  EXPECT_NE(blocks, nullptr);
+  ASSERT_NE(blocks, nullptr);
+
+  rj_code_basic_block_t *block = nullptr;
+  ASSERT_EQ(rj_code_basic_block_list_get(blocks, 0, &block), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(block, nullptr);
+
+  // Likewise, a returned block must keep its list and decoded instructions alive.
+  rj_code_basic_block_list_destroy(blocks);
+  EXPECT_EQ(rj_code_basic_block_start_offset(block), 0u);
+  EXPECT_EQ(rj_code_basic_block_num_instructions(block), 2u);
 
   // Cleanup follows the refcount discipline in refcount.h:
-  //   - blocks came from _create()   -> refcount 0 -> destroy only.
+  //   - block  came from _get()      -> refcount 1 -> destroy + release.
   //   - obj    came from _get_code_object() -> refcount 1 -> destroy + release.
-  //   - exec   came from _create()   -> refcount 0 -> destroy only.
-  if (blocks)
-    rj_code_basic_block_list_destroy(blocks);
+  // Their destroyed parents are released automatically with the child handles.
+  rj_code_basic_block_destroy(block);
+  rj_code_basic_block_release(block);
   rj_code_object_destroy(obj);
   rj_code_object_release(obj);
-  rj_code_executable_destroy(exec);
 
   std::error_code ec;
   std::filesystem::remove(tmp, ec); // best-effort


### PR DESCRIPTION
## Summary

- retain an executable while a borrowed code-object handle references its storage
- retain a basic-block list while a borrowed block handle references its storage
- test parent-before-child destruction for every supported AMDGPU target

## Testing

- clean Release build of `rocjitsu_tests` and `rocjitsu_shared`
- `GfxCodeObjectTargets.*`: 13/13 passed
- repository pre-commit hooks passed for both commits

Fixes #8983.
Fixes #8984.