### PR TITLE
fix(rocprofiler-sdk): Address review feedback on hsa_amd_queue_create…

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/queue_registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/queue_registration.cpp
@@ -227,6 +227,14 @@ create_queue(hsa_agent_t        agent,
 // NOTE: the InterceptQueue is created via the classic hsa_queue_create path, so the descriptor's
 // device-memory ring-buffer flag is not honored while the queue is being profiled; the queue falls
 // back to a system-memory ring.
+//
+// KNOWN LIMITATION (late attach): This wrapper bypasses the real hsa_amd_queue_create
+// implementation for compute descriptors, so the runtime's descriptor validation (version,
+// reserved fields, size, priority, CU-mask constraints) and partial-batch-success semantics are
+// not applied.  Late attach is excluded from the supported configuration for this PR; a
+// descriptor-aware attach implementation that delegates to the real runtime for validation and
+// then intercepts the resulting queue is needed before late attach can be re-enabled with the new
+// queue creation API.
 hsa_status_t
 create_amd_queue(hsa_agent_t agent, hsa_amd_queue_create_desc_t* descs, uint32_t num_descs)
 {
@@ -251,8 +259,8 @@ create_amd_queue(hsa_agent_t agent, hsa_amd_queue_create_desc_t* descs, uint32_t
         }
 
         const auto&    compute_params = descs[desc_idx].engine.compute;
-        const uint32_t ring_packets   = static_cast<uint32_t>(
-            descs[desc_idx].queue_size_bytes / sizeof(hsa_kernel_dispatch_packet_t));
+        const uint32_t ring_packets   = static_cast<uint32_t>(descs[desc_idx].queue_size_bytes /
+                                                            sizeof(hsa_kernel_dispatch_packet_t));
 
         hsa_queue_t* new_queue = nullptr;
         ROCP_ATTACH_HSA_TABLE_CALL(
@@ -411,8 +419,8 @@ queue_registration_init(HsaApiTable* table)
 #if defined(HSA_AMD_EXT_API_TABLE_STEP_VERSION) && HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x10
     // Save the real hsa_amd_queue_create before overwriting it, so non-compute queue requests can
     // be forwarded, then intercept descriptor-based queue creation.
-    registration->hsa_amd_queue_create_fn      = *table->amd_ext_->hsa_amd_queue_create_fn;
-    table->amd_ext_->hsa_amd_queue_create_fn   = create_amd_queue;
+    registration->hsa_amd_queue_create_fn    = *table->amd_ext_->hsa_amd_queue_create_fn;
+    table->amd_ext_->hsa_amd_queue_create_fn = create_amd_queue;
 #endif
 
     registration->hsa_amd_queue_intercept_create_fn =

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -114,14 +114,15 @@ destroy_queue(hsa_queue_t* hsa_queue)
 
 #if defined(HSA_AMD_EXT_API_TABLE_STEP_VERSION) && HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x10
 hsa_status_t
-create_amd_queue(hsa_agent_t                  agent,
-                 hsa_amd_queue_create_desc_t* descs,
-                 uint32_t                     num_descs)
+create_amd_queue(hsa_agent_t agent, hsa_amd_queue_create_desc_t* descs, uint32_t num_descs)
 {
     auto* controller = CHECK_NOTNULL(get_queue_controller());
     auto  status     = controller->get_ext_table().hsa_amd_queue_create_fn(agent, descs, num_descs);
-    if(status != HSA_STATUS_SUCCESS) return status;
 
+    // hsa_amd_queue_create permits partial batch success: it may return an error for the first
+    // failing descriptor while leaving earlier descs[i].queue entries valid.  Process every
+    // non-null queue so those successful queues are still registered with rocprofiler-sdk (Queue,
+    // serializer entry, QueueState).  The original status is returned afterward.
     const bool inline_intercept = queue_interposition::supports_queue_interposition();
 
     for(uint32_t desc_idx = 0; desc_idx < num_descs; ++desc_idx)
@@ -160,9 +161,18 @@ create_amd_queue(hsa_agent_t                  agent,
                 // the descriptor's device-memory ring-buffer flag is not honored while a
                 // non-inline profiling context (e.g. --sys-trace / HIP graph tracing) is active;
                 // the queue falls back to a system-memory ring.
-                ROCP_INFO << "[queue-intercept] registering hsa_amd_queue_create queue via "
-                             "LEGACY path (InterceptQueue) for agent "
-                          << agent.handle;
+                //
+                // Known limitation: the replacement InterceptQueue does not preserve the
+                // descriptor's priority or CU-mask settings. A CU-partitioned or high-priority
+                // stream may behave differently while profiled. Passing these attributes through
+                // (e.g. via SetPriority / SetCUMasking on the replacement queue) is deferred to a
+                // follow-up change.
+                ROCP_WARNING
+                    << "[queue-intercept] device-memory ring-buffer requested but profiling "
+                       "requires system-memory InterceptQueue; falling back to system-memory "
+                       "ring for agent "
+                    << agent.handle
+                    << " (priority and CU-mask from the descriptor are not preserved)";
 
                 const auto&    compute_params = descs[desc_idx].engine.compute;
                 const uint32_t ring_packets   = static_cast<uint32_t>(
@@ -194,7 +204,9 @@ create_amd_queue(hsa_agent_t                  agent,
             else
             {
                 // Non-compute engines (e.g. SDMA) do not dispatch kernels; keep the plain queue
-                // and register it without a packet interceptor.
+                // and register it without a packet interceptor.  Skip inline QueueState
+                // registration because SDMA queue sizes are byte counts and use a different
+                // packet format incompatible with AQL interposition.
                 ROCP_INFO << "[queue-intercept] registering non-compute hsa_amd_queue_create "
                              "queue (no packet interception) for agent "
                           << agent.handle;
@@ -205,16 +217,17 @@ create_amd_queue(hsa_agent_t                  agent,
                                                     [](write_interceptor_t, void*) {});
             }
 
+            const bool is_compute = (descs[desc_idx].engine_type == HSA_AMD_QUEUE_ENGINE_COMPUTE);
             controller->serializer(new_queue.get()).wlock([&](auto& serializer) {
                 serializer.add_queue(&queue, *new_queue);
             });
-            controller->add_queue(queue, std::move(new_queue));
+            controller->add_queue(queue, std::move(new_queue), is_compute);
             ROCP_INFO << "created queue (hsa_amd_queue_create) for HSA agent handle "
                       << agent.handle;
             break;
         }
     }
-    return HSA_STATUS_SUCCESS;
+    return status;
 }
 #endif
 
@@ -351,7 +364,9 @@ queue_controller_load_attach_queues()
 }  // namespace
 
 void
-QueueController::add_queue(hsa_queue_t* id, std::unique_ptr<Queue> queue)
+QueueController::add_queue(hsa_queue_t*           id,
+                           std::unique_ptr<Queue> queue,
+                           bool                   create_interposition_state)
 {
     CHECK(queue);
     const auto agent_id = queue->get_agent().get_rocp_agent()->id;
@@ -370,8 +385,10 @@ QueueController::add_queue(hsa_queue_t* id, std::unique_ptr<Queue> queue)
         });
     });
 
-    // Register queue state for SDK-level write pointer interception
-    queue_interposition::create_queue_state(id);
+    if(create_interposition_state)
+    {
+        queue_interposition::create_queue_state(id);
+    }
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
@@ -60,8 +60,11 @@ public:
     // HSA has been inited.
     void init(CoreApiTable& core_table, AmdExtTable& ext_table);
 
-    // Called to add a queue that was created by the user program
-    void add_queue(hsa_queue_t*, std::unique_ptr<Queue>);
+    // Called to add a queue that was created by the user program.
+    // When |create_interposition_state| is false, the queue is registered in the queue map and
+    // serializer but no inline QueueState is created.  Use this for non-compute queues (e.g. SDMA)
+    // whose packet format and queue-size semantics are incompatible with AQL interposition.
+    void add_queue(hsa_queue_t*, std::unique_ptr<Queue>, bool create_interposition_state = true);
     void destroy_queue(hsa_queue_t*);
 
     // Add callback to queues associated with the agent. Returns a client

--- a/projects/rocprofiler-sdk/tests/async-copy-tracing/validate.py
+++ b/projects/rocprofiler-sdk/tests/async-copy-tracing/validate.py
@@ -113,7 +113,7 @@ def test_data_structure(input_data):
     node_exists("names", sdk_data["callback_records"])
     node_exists("code_objects", sdk_data["callback_records"])
     node_exists("kernel_symbols", sdk_data["callback_records"])
-    node_exists("host_functions", sdk_data["callback_records"], 0)
+    node_exists("host_functions", sdk_data["callback_records"])
     node_exists("hsa_api_traces", sdk_data["callback_records"])
     node_exists("hip_api_traces", sdk_data["callback_records"], 0)
     node_exists("marker_api_traces", sdk_data["callback_records"])

--- a/projects/rocprofiler-sdk/tests/hip-graph-tracing/validate.py
+++ b/projects/rocprofiler-sdk/tests/hip-graph-tracing/validate.py
@@ -56,7 +56,7 @@ def test_data_structure(input_data):
     node_exists("names", sdk_data["callback_records"])
     node_exists("code_objects", sdk_data["callback_records"])
     node_exists("kernel_symbols", sdk_data["callback_records"])
-    node_exists("host_functions", sdk_data["callback_records"], 0)
+    node_exists("host_functions", sdk_data["callback_records"])
     node_exists("hip_api_traces", sdk_data["callback_records"])
     node_exists("kernel_dispatch", sdk_data["callback_records"])
 

--- a/projects/rocprofiler-sdk/tests/kernel-tracing/validate.py
+++ b/projects/rocprofiler-sdk/tests/kernel-tracing/validate.py
@@ -64,7 +64,7 @@ def test_data_structure(input_data):
     node_exists("names", sdk_data["callback_records"])
     node_exists("code_objects", sdk_data["callback_records"])
     node_exists("kernel_symbols", sdk_data["callback_records"])
-    node_exists("host_functions", sdk_data["callback_records"], 0)
+    node_exists("host_functions", sdk_data["callback_records"])
     node_exists("hsa_api_traces", sdk_data["callback_records"])
     node_exists("hip_api_traces", sdk_data["callback_records"], 0)
     node_exists("marker_api_traces", sdk_data["callback_records"])

--- a/projects/rocprofiler-sdk/tests/scratch-memory-tracing/validate.py
+++ b/projects/rocprofiler-sdk/tests/scratch-memory-tracing/validate.py
@@ -60,7 +60,7 @@ def test_data_structure(input_data):
     node_exists("names", sdk_data["callback_records"])
     node_exists("code_objects", sdk_data["callback_records"])
     node_exists("kernel_symbols", sdk_data["callback_records"])
-    node_exists("host_functions", sdk_data["callback_records"], 0)
+    node_exists("host_functions", sdk_data["callback_records"])
     node_exists("hsa_api_traces", sdk_data["callback_records"])
     node_exists("hip_api_traces", sdk_data["callback_records"], 0)
     # Each scratch allocation produces a phase-enter and phase-exit callback record.


### PR DESCRIPTION
… interception

- Handle partial batch success: process all non-null descs[i].queue entries and return the original status instead of bailing early.
- Emit ROCP_WARNING when device-memory queue falls back to system-memory InterceptQueue; document priority/CU-mask loss as known limitation.
- Skip QueueState registration for non-compute queues (SDMA) whose packet format is incompatible with AQL interposition.
- Document late-attach as unsupported for descriptor-based queue creation.
- Revert host_functions test relaxation in 4 validate.py files.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

JIRA ID : AIRUNTIME-0

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
