### PR TITLE
fix(rocjitsu): Use shared ownership for C API child backing storage

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/rj_code_translate.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/rj_code_translate.cpp
@@ -21,14 +21,13 @@ rj_status_t rj_code_translate(const rj_code_object_t *source, const rj_code_dbt_
   if (result.elf_bytes.empty() || !result.dispatchable())
     return ROCJITSU_STATUS_ERROR;
 
-  auto owned = std::make_unique<rocjitsu::AmdGpuCodeObject>(result.elf_bytes.data(),
+  auto owned = std::make_shared<rocjitsu::AmdGpuCodeObject>(result.elf_bytes.data(),
                                                             result.elf_bytes.size());
   if (!owned->is_valid())
     return ROCJITSU_STATUS_ERROR;
 
   auto *obj = new rj_code_object_t{};
-  obj->co = owned.get();
-  obj->owned_co = std::move(owned);
+  obj->co = std::move(owned);
   *translated = obj;
   return ROCJITSU_STATUS_SUCCESS;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
@@ -73,7 +73,7 @@ rj_status_t rj_code_executable_create(const char *path, rj_code_executable_t **e
   if (!path || !exec)
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
 
-  auto executable = std::make_unique<Executable>(path);
+  auto executable = std::make_shared<Executable>(path);
   if (!executable->is_valid())
     return ROCJITSU_STATUS_INVALID_CODE_OBJECT;
 
@@ -114,12 +114,12 @@ rj_status_t rj_code_executable_get_code_object(const rj_code_executable_t *exec,
   if (!exec || !exec->exec || !obj)
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
 
-  auto *co = const_cast<Executable *>(exec->exec.get())->code_object(target, index);
+  auto *co = exec->exec->code_object(target, index);
   if (!co)
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
 
   *obj = new rj_code_object_t{};
-  (*obj)->co = co;
+  (*obj)->co = std::shared_ptr<AmdGpuCodeObject>(exec->exec, co);
   (*obj)->retain();
   return ROCJITSU_STATUS_SUCCESS;
 }
@@ -208,7 +208,8 @@ rj_status_t rj_code_basic_block_list_create(rj_code_object_t *obj, rj_code_targe
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
 
   auto owned = std::make_unique<rj_code_basic_block_list_t>();
-  owned->blocks = BasicBlock::build(*obj->co, *decoder, arch);
+  owned->blocks = std::make_shared<rj_code_basic_block_list_t::Storage>(
+      BasicBlock::build(*obj->co, *decoder, arch));
 
   *list = owned.release();
   return ROCJITSU_STATUS_SUCCESS;
@@ -234,18 +235,18 @@ void rj_code_basic_block_list_destroy(rj_code_basic_block_list_t *list) {
 }
 
 uint32_t rj_code_basic_block_list_size(const rj_code_basic_block_list_t *list) {
-  if (!list)
+  if (!list || !list->blocks)
     return 0;
-  return static_cast<uint32_t>(list->blocks.size());
+  return static_cast<uint32_t>(list->blocks->size());
 }
 
 rj_status_t rj_code_basic_block_list_get(const rj_code_basic_block_list_t *list, uint32_t index,
                                          rj_code_basic_block_t **block) {
-  if (!list || !block || index >= list->blocks.size())
+  if (!list || !list->blocks || !block || index >= list->blocks->size())
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
 
   *block = new rj_code_basic_block_t{};
-  (*block)->block = list->blocks[index].get();
+  (*block)->block = std::shared_ptr<BasicBlock>(list->blocks, (*list->blocks)[index].get());
   (*block)->retain();
   return ROCJITSU_STATUS_SUCCESS;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code_internal.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code_internal.h
@@ -16,12 +16,11 @@
 #include <vector>
 
 struct rj_code_executable_t : rocjitsu::RefCounted {
-  std::unique_ptr<rocjitsu::Executable> exec;
+  std::shared_ptr<rocjitsu::Executable> exec;
 };
 
 struct rj_code_object_t : rocjitsu::RefCounted {
-  rocjitsu::AmdGpuCodeObject *co = nullptr;
-  std::unique_ptr<rocjitsu::AmdGpuCodeObject> owned_co;
+  std::shared_ptr<rocjitsu::AmdGpuCodeObject> co;
 };
 
 struct rj_code_inst_list_t : rocjitsu::RefCounted {
@@ -30,9 +29,10 @@ struct rj_code_inst_list_t : rocjitsu::RefCounted {
 };
 
 struct rj_code_basic_block_list_t : rocjitsu::RefCounted {
-  std::vector<std::unique_ptr<rocjitsu::BasicBlock>> blocks;
+  using Storage = std::vector<std::unique_ptr<rocjitsu::BasicBlock>>;
+  std::shared_ptr<Storage> blocks;
 };
 
 struct rj_code_basic_block_t : rocjitsu::RefCounted {
-  rocjitsu::BasicBlock *block = nullptr;
+  std::shared_ptr<rocjitsu::BasicBlock> block;
 };

--- a/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
+++ b/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
@@ -157,20 +157,31 @@ void expect_c_api_accepts_target(uint32_t mach_flag, rj_code_target_id_t target)
   ASSERT_EQ(rj_code_executable_get_code_object(exec, target, 0, &obj), ROCJITSU_STATUS_SUCCESS);
   ASSERT_NE(obj, nullptr);
 
+  // The returned code-object handle must keep its executable storage alive.
+  rj_code_executable_destroy(exec);
+
   rj_code_basic_block_list_t *blocks = nullptr;
   EXPECT_EQ(rj_code_basic_block_list_create(obj, target, &blocks), ROCJITSU_STATUS_SUCCESS)
       << "rj_code_basic_block_list_create must succeed for a target whose decoder is wired in";
-  EXPECT_NE(blocks, nullptr);
+  ASSERT_NE(blocks, nullptr);
+
+  rj_code_basic_block_t *block = nullptr;
+  ASSERT_EQ(rj_code_basic_block_list_get(blocks, 0, &block), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(block, nullptr);
+
+  // Likewise, a returned block must keep its list and decoded instructions alive.
+  rj_code_basic_block_list_destroy(blocks);
+  EXPECT_EQ(rj_code_basic_block_start_offset(block), 0u);
+  EXPECT_EQ(rj_code_basic_block_num_instructions(block), 2u);
 
   // Cleanup follows the refcount discipline in refcount.h:
-  //   - blocks came from _create()   -> refcount 0 -> destroy only.
+  //   - block  came from _get()      -> refcount 1 -> destroy + release.
   //   - obj    came from _get_code_object() -> refcount 1 -> destroy + release.
-  //   - exec   came from _create()   -> refcount 0 -> destroy only.
-  if (blocks)
-    rj_code_basic_block_list_destroy(blocks);
+  // Releasing each child also releases its shared ownership of the backing storage.
+  rj_code_basic_block_destroy(block);
+  rj_code_basic_block_release(block);
   rj_code_object_destroy(obj);
   rj_code_object_release(obj);
-  rj_code_executable_destroy(exec);
 
   std::error_code ec;
   std::filesystem::remove(tmp, ec); // best-effort


### PR DESCRIPTION
## Summary
- keep executable and decoded-block backing storage alive with `std::shared_ptr`
- use aliasing `std::shared_ptr` instances for borrowed code-object and basic-block handles
- remove raw parent-handle pointers and manual parent `retain()`/`release()` coupling
- preserve the opaque public C ABI and existing handle refcount semantics
- test child handles after destroying their parents for every supported target

This is a modern C++ alternative to #8985.

## Validation
- clean amdclang++ Release build of `rocjitsu_shared` and `rocjitsu_tests`
- `GfxCodeObjectTargets.*`: 13/13 passed
- clean GCC 13 ASan+UBSan build
- sanitizer `GfxCodeObjectTargets.*`: 13/13 passed, including leak detection
- repository pre-commit hooks passed

Fixes #8983
Fixes #8984