### PR TITLE
rocjitsu: Own the local-VM driver by reference count in the interposer

### DIFF
--- a/emulation/rocjitsu/cmake/rj_generate_installed_gtest_ctest.cmake
+++ b/emulation/rocjitsu/cmake/rj_generate_installed_gtest_ctest.cmake
@@ -12,8 +12,18 @@
 #   TEST_EXECUTABLE      Build-tree executable used for --gtest_list_tests.
 #   INSTALLED_EXECUTABLE Path CTest should run from the installed test dir.
 #   OUTPUT_FILE          Generated CTest fragment path.
+#
+# Optional variables:
+#   TEST_FILTER          --gtest_filter for discovery. Must be the SAME filter the
+#                        build tree uses, or a case excluded there is discovered here
+#                        and collides with its own manual registration.
 function(rj_generate_installed_gtest_ctest)
-    set(oneValueArgs TEST_EXECUTABLE INSTALLED_EXECUTABLE OUTPUT_FILE)
+    set(oneValueArgs
+        TEST_EXECUTABLE
+        INSTALLED_EXECUTABLE
+        OUTPUT_FILE
+        TEST_FILTER
+    )
     cmake_parse_arguments(ARG "" "${oneValueArgs}" "" ${ARGN})
 
     if(NOT ARG_TEST_EXECUTABLE)
@@ -26,12 +36,17 @@ function(rj_generate_installed_gtest_ctest)
         message(FATAL_ERROR "OUTPUT_FILE is required")
     endif()
 
-    # RequestExitWakesAllPartitions is registered manually with a short
-    # timeout because its expected regression mode is a deadlocked process.
+    # Tests whose expected regression mode is a deadlocked process are registered
+    # manually with a short timeout, so discovery must exclude them here exactly as
+    # it does in the build tree. The caller passes that one filter through; only a
+    # target that registers nothing manually falls back to dropping benchmarks.
+    if(NOT ARG_TEST_FILTER)
+        set(ARG_TEST_FILTER "-*Benchmark*")
+    endif()
     execute_process(
         COMMAND
             "${ARG_TEST_EXECUTABLE}" --gtest_list_tests
-            "--gtest_filter=-*Benchmark*:*RequestExitWakesAllPartitions*"
+            "--gtest_filter=${ARG_TEST_FILTER}"
         RESULT_VARIABLE _result
         OUTPUT_VARIABLE _tests
         ERROR_VARIABLE _errors
@@ -96,4 +111,5 @@ rj_generate_installed_gtest_ctest(
     TEST_EXECUTABLE "${TEST_EXECUTABLE}"
     INSTALLED_EXECUTABLE "${INSTALLED_EXECUTABLE}"
     OUTPUT_FILE "${OUTPUT_FILE}"
+    TEST_FILTER "${TEST_FILTER}"
 )

--- a/emulation/rocjitsu/docs/rocjitsu-cli.md
+++ b/emulation/rocjitsu/docs/rocjitsu-cli.md
@@ -15,6 +15,34 @@ the simulated GPU. It operates in two modes:
 Daemon mode supports vLLM's multiprocessing spawn, torchrun, torch.distributed,
 and NCCL --- workloads where multiple processes share a single simulated GPU.
 
+### The fork boundary in local mode
+
+In local mode the simulated GPU belongs to the process that was `execve`d under
+the interposer. A child created with `fork()` or `vfork()` does **not** inherit
+usable GPU access: until it `exec`s, it does not own the interposer state, and
+opening a rocJITsu GPU endpoint --- `/dev/kfd` or a `/dev/dri/renderD*` node ---
+fails with `ENODEV`.
+
+**Forked children must `exec` before using local mode.** After `exec` the
+interposer re-initializes in the new process, which then owns its own state and
+can open the simulated device normally. The common `fork()` + `exec()` pattern,
+including `posix_spawn()` and Python's `subprocess`, is therefore fine; what does
+not work is touching the GPU in the window between the two.
+
+This is deliberate rather than a gap. rocJITsu registers no `pthread_atfork`
+handlers, so a pre-exec child holds locks whose owning threads no longer exist
+and containers that a vanished thread was mid-mutation on --- none of it is safe
+to touch. Failing the open is also safer than the alternative: passing through to
+libc would open the *host's* real `/dev/kfd` when one exists, silently moving the
+child off the emulator and onto real hardware. Note that this is a cooperative,
+API-level contract, not a security boundary; a child issuing raw syscalls or
+receiving a descriptor over a Unix socket is not stopped by interposition.
+
+**If child processes need GPU access, use daemon mode** (`--daemon`). There the
+simulated GPU lives in a separate daemon process and each client attaches over
+RPC, so multiple processes --- forked, spawned, or unrelated --- can share one
+simulated GPU.
+
 ## Command-Line Options
 
 ```

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.cpp
@@ -32,30 +32,30 @@ void write_event_slot(void *page, size_t page_size, uint32_t event_id, uint64_t 
 } // namespace
 
 EventState::~EventState() {
-  if (memfd >= 0)
-    libc_passthrough().close(memfd);
+  if (memfd_ >= 0)
+    libc_passthrough().close(memfd_);
 }
 
 void EventState::adopt_page(void *ptr, size_t size) {
   assert(ptr && "adopt_page called with null pointer");
   assert(size > 0 && "adopt_page called with zero size");
   std::lock_guard<std::mutex> lock(mutex_);
-  if (page)
+  if (page_)
     return;
-  page = ptr;
-  page_size = size;
+  page_ = ptr;
+  page_size_ = size;
   for (const auto &[id, ev] : events_) {
     if (ev.signaled)
-      write_event_slot(page, page_size, id, ev.event_age);
+      write_event_slot(page_, page_size_, id, ev.event_age);
   }
 }
 
 bool EventState::release_page(void *ptr) {
   std::lock_guard<std::mutex> lock(mutex_);
-  if (page != ptr)
+  if (page_ != ptr)
     return false;
-  page = nullptr;
-  page_size = 0;
+  page_ = nullptr;
+  page_size_ = 0;
   return true;
 }
 
@@ -71,7 +71,7 @@ void EventState::signal_interrupt(uint32_t event_id) {
         ev.signaled = !ev.auto_reset || ev.waiters.empty();
         if (!(++ev.event_age))
           ev.event_age = 2;
-        write_event_slot(page, page_size, id, ev.event_age);
+        write_event_slot(page_, page_size_, id, ev.event_age);
         util::Logger::cp("SIGNAL_BROADCAST: event_id=", id, " age=", ev.event_age,
                          " waiters=", ev.waiters.size());
         for (auto *cv : ev.waiters)
@@ -85,9 +85,9 @@ void EventState::signal_interrupt(uint32_t event_id) {
     it->second.signaled = !it->second.auto_reset || it->second.waiters.empty();
     if (!(++it->second.event_age))
       it->second.event_age = 2;
-    write_event_slot(page, page_size, event_id, it->second.event_age);
+    write_event_slot(page_, page_size_, event_id, it->second.event_age);
     util::Logger::cp("SIGNAL_INTERRUPT: event_id=", event_id, " age=", it->second.event_age,
-                     " waiters=", it->second.waiters.size(), " page=", page ? "valid" : "null");
+                     " waiters=", it->second.waiters.size(), " page=", page_ ? "valid" : "null");
     for (auto *cv : it->second.waiters)
       cv->notify_one();
   } else {
@@ -108,17 +108,60 @@ void EventState::notify_closing() {
 
 /// @brief Write KFD_SIGNAL_EVENT_LIMIT to all event page slots.
 void EventState::signal_page_shutdown() {
-  if (!page)
+  // Hold mutex_ across the page_ read+write: release_page() (called from munmap)
+  // clears page_/page_size_ under the SAME lock and then unmaps the mapping, so
+  // without this an unmap could race in and leave us writing through a freed
+  // pointer (and racing page_/page_size_). This is the same discipline the CP
+  // interrupt path (signal_interrupt) uses to touch the mapping safely.
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (!page_)
     return;
-  auto *slots = static_cast<uint64_t *>(page);
-  size_t count = page_size / sizeof(uint64_t);
+  auto *slots = static_cast<uint64_t *>(page_);
+  size_t count = page_size_ / sizeof(uint64_t);
   for (size_t i = 0; i < count; ++i)
     std::atomic_ref<uint64_t>(slots[i]).store(KFD_SIGNAL_EVENT_LIMIT, std::memory_order_release);
 }
 
-void EventState::reset() { closing_.store(false, std::memory_order_release); }
+/// @brief Release parked waiters without mutating any event or page state.
+void EventState::begin_wait_cancel() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  wait_cancelled_.store(true, std::memory_order_release);
+  for (auto &[id, ev] : events_) {
+    for (auto *cv : ev.waiters)
+      cv->notify_one();
+  }
+}
+
+void EventState::reset() {
+  closing_.store(false, std::memory_order_release);
+  wait_cancelled_.store(false, std::memory_order_release);
+}
 
 bool EventState::is_closing() const { return closing_.load(std::memory_order_acquire); }
+
+int EventState::ensure_backing(size_t length, const std::function<int(size_t)> &create_backing) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (memfd_ >= 0)
+    return memfd_;
+  memfd_ = create_backing(length);
+  return memfd_;
+}
+
+int EventState::backing_fd() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return memfd_;
+}
+
+size_t EventState::waiter_count(uint32_t event_id) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = events_.find(event_id);
+  return it == events_.end() ? 0 : it->second.waiters.size();
+}
+
+bool EventState::has_page() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return page_ != nullptr;
+}
 
 /// @brief Allocate a new KFD event and return its ID and slot index.
 int EventState::create_event(void *arg, uint32_t gpu_id) {
@@ -126,8 +169,8 @@ int EventState::create_event(void *arg, uint32_t gpu_id) {
   auto *args = static_cast<kfd_ioctl_create_event_args *>(arg);
   std::lock_guard<std::mutex> lock(mutex_);
 
-  uint32_t max_slots =
-      page_size > 0 ? static_cast<uint32_t>(page_size / sizeof(uint64_t)) : KFD_SIGNAL_EVENT_LIMIT;
+  uint32_t max_slots = page_size_ > 0 ? static_cast<uint32_t>(page_size_ / sizeof(uint64_t))
+                                      : KFD_SIGNAL_EVENT_LIMIT;
   if (next_event_id_ >= std::min(max_slots, static_cast<uint32_t>(KFD_SIGNAL_EVENT_LIMIT)))
     return -ENOSPC;
 
@@ -156,16 +199,18 @@ int EventState::create_event(void *arg, uint32_t gpu_id) {
 int EventState::destroy_event(void *arg) {
   assert(arg && "destroy_event called with null arg");
   auto *args = static_cast<kfd_ioctl_destroy_event_args *>(arg);
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    auto it = events_.find(args->event_id);
-    if (it != events_.end()) {
-      for (auto *cv : it->second.waiters)
-        cv->notify_one();
-      events_.erase(it);
-    }
+  // The slot write stays UNDER mutex_ with the erase. release_page() (from munmap)
+  // clears page_/page_size_ under this same lock and then unmaps; writing after
+  // dropping it could store through a freed pointer, and would race page_/page_size_
+  // besides. Same discipline as signal_interrupt()/signal_page_shutdown().
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = events_.find(args->event_id);
+  if (it != events_.end()) {
+    for (auto *cv : it->second.waiters)
+      cv->notify_one();
+    events_.erase(it);
   }
-  write_event_slot(page, page_size, args->event_id, KFD_SIGNAL_EVENT_LIMIT);
+  write_event_slot(page_, page_size_, args->event_id, KFD_SIGNAL_EVENT_LIMIT);
   return 0;
 }
 
@@ -183,7 +228,7 @@ int EventState::set_event(void *arg) {
   it->second.signaled = !it->second.auto_reset || it->second.waiters.empty();
   if (!(++it->second.event_age))
     it->second.event_age = 2;
-  write_event_slot(page, page_size, args->event_id, it->second.event_age);
+  write_event_slot(page_, page_size_, args->event_id, it->second.event_age);
   util::Logger::cp("SET_EVENT: event_id=", args->event_id, " age=", it->second.event_age,
                    " waiters=", it->second.waiters.size());
   for (auto *cv : it->second.waiters)
@@ -200,7 +245,7 @@ int EventState::reset_event(void *arg) {
   if (it == events_.end())
     return -EINVAL;
   it->second.signaled = false;
-  write_event_slot(page, page_size, args->event_id, KFD_SIGNAL_EVENT_LIMIT);
+  write_event_slot(page_, page_size_, args->event_id, KFD_SIGNAL_EVENT_LIMIT);
   return 0;
 }
 
@@ -210,6 +255,20 @@ int EventState::wait_events(void *arg, uint32_t process_id) {
   auto *args = static_cast<kfd_ioctl_wait_events_args *>(arg);
   auto *ev_data = reinterpret_cast<kfd_event_data *>(args->events_ptr);
   const bool wait_all = args->wait_for_all != 0;
+  // A zero-event wait is vacuously satisfied, matching the kernel: with
+  // num_events == 0, kfd_wait_on_events() allocates a zero-length waiter array
+  // (kcalloc returns ZERO_SIZE_PTR, so no -ENOMEM), runs no init loop, and
+  // test_event_condition() reports COMPLETE because activated_count == num_events
+  // is 0 == 0 -- so the ioctl returns 0. Answering it here rather than falling into
+  // the wait below is ALSO what keeps the teardown wake total: such a call
+  // registers no condition variable for begin_wait_cancel() to notify, and (with
+  // wait_for_all == 0) its readiness predicate would be false forever, so it must
+  // never be allowed to block: it would hold the interposer's driver snapshot
+  // forever, and the object could then never be destroyed.
+  if (args->num_events == 0) {
+    args->wait_result = KFD_IOC_WAIT_RESULT_COMPLETE;
+    return 0;
+  }
   util::Logger::cp([&](auto &os) {
     os << "WAIT_EVENTS: pid=" << process_id << " num=" << args->num_events
        << " timeout=" << args->timeout << " wait_all=" << wait_all;
@@ -246,7 +305,7 @@ int EventState::wait_events(void *arg, uint32_t process_id) {
   };
 
   auto is_ready = [&]() -> bool {
-    if (closing_)
+    if (closing_ || wait_cancelled_)
       return true;
     bool all_satisfied = true;
     bool any_satisfied = false;
@@ -265,7 +324,7 @@ int EventState::wait_events(void *arg, uint32_t process_id) {
   bool is_poll = (args->timeout == 0);
   if (is_poll) {
     // Poll mode.
-  } else if (args->timeout >= 0xFFFFFFFEu) {
+  } else if (args->timeout == kWaitEventsInfiniteMs) {
     my_cv.wait(lock, is_ready);
   } else {
     my_cv.wait_for(lock, std::chrono::milliseconds(args->timeout), is_ready);
@@ -275,6 +334,21 @@ int EventState::wait_events(void *arg, uint32_t process_id) {
 
   if (closing_)
     return -EBADF;
+
+  // Teardown released us early (begin_wait_cancel). Report a benign timeout rather
+  // than -EBADF so the caller unwinds through the re-poll path it already has for a
+  // timeout, instead of meeting an error it never sees from a healthy driver; the
+  // fd itself is still open at this point, so -EBADF would also be a lie. This is a
+  // ONE-WAY latch for this process's lifetime -- teardown is committed before
+  // begin_local_shutdown() is called, and reset() only ever runs on a freshly created
+  // KfdProcess, never on the reuse path -- so every later
+  // wait on this process returns TIMEOUT too, which is what keeps a caller polling
+  // rather than blocking while the driver goes away. Checked before the per-event
+  // scan so the answer does not depend on events partially satisfied mid-cancel.
+  if (wait_cancelled_) {
+    args->wait_result = KFD_IOC_WAIT_RESULT_TIMEOUT;
+    return 0;
+  }
 
   bool any_ready = false;
   bool any_destroyed = false;
@@ -293,7 +367,7 @@ int EventState::wait_events(void *arg, uint32_t process_id) {
       if (it->second.auto_reset) {
         it->second.signaled = false;
         if (it->second.event_type == 0)
-          write_event_slot(page, page_size, it->second.event_id, KFD_SIGNAL_EVENT_LIMIT);
+          write_event_slot(page_, page_size_, it->second.event_id, KFD_SIGNAL_EVENT_LIMIT);
       }
     } else {
       all_ready = false;
@@ -342,7 +416,7 @@ int EventState::wait_events(void *arg, uint32_t process_id) {
 ///          delegating to EventState.
 int SimulatedKfd::create_event_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_create_event_args *>(arg);
-  if (args->event_page_offset != 0 && !proc.event_state_.page) {
+  if (args->event_page_offset != 0 && !proc.event_state_.has_page()) {
     uint64_t raw = static_cast<uint64_t>(args->event_page_offset);
     std::lock_guard<std::mutex> alock(proc.alloc_mutex_);
     auto it = proc.allocations_.find(raw >> 12);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.h
@@ -20,6 +20,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <cstdint>
+#include <functional>
 #include <mutex>
 #include <unordered_map>
 #include <vector>
@@ -74,9 +75,9 @@ public:
   /// @details Idempotent, subsequent calls after the first are no-ops.
   void adopt_page(void *ptr, size_t size);
 
-  /// @brief If @p ptr is the adopted event page, clear page/page_size and return true.
+  /// @brief If @p ptr is the adopted event page, clear page_/page_size_ and return true.
   /// @details Clears the fields under mutex_ so the CP interrupt thread (which
-  /// reads page/page_size under the same lock in signal_interrupt) can never race
+  /// reads page_/page_size_ under the same lock in signal_interrupt) can never race
   /// a concurrent munmap tearing the mapping down.
   [[nodiscard]] bool release_page(void *ptr);
 
@@ -93,8 +94,21 @@ public:
 
   /// @brief Write sentinel values to all event page slots for shutdown.
   /// @details Writes KFD_SIGNAL_EVENT_LIMIT to every slot, allowing ROCR's
-  ///          userspace polling to detect that events will no longer fire.
+  ///          userspace polling to detect that events will no longer fire. Takes
+  ///          mutex_ so it cannot race a concurrent release_page()/munmap tearing
+  ///          the mapping down.
   void signal_page_shutdown();
+
+  /// @brief Non-destructively release parked waiters so their caller can unwind.
+  /// @details The teardown-probe counterpart of notify_closing(): sets a
+  ///          cancellation flag and wakes every registered waiter, so a blocking
+  ///          WAIT_EVENTS returns a benign KFD_IOC_WAIT_RESULT_TIMEOUT (rc 0) and
+  ///          drops the driver snapshot that would otherwise keep the object alive.
+  ///          Mutates NO event, slot, or page state. A spurious TIMEOUT is a
+  ///          legal KFD outcome every caller already re-polls on; -EBADF (which
+  ///          notify_closing() causes) is not, which is why teardown probing must
+  ///          use this and only real teardown may close. Idempotent.
+  void begin_wait_cancel();
 
   /// @brief Reset closing state for driver re-open.
   void reset();
@@ -102,11 +116,34 @@ public:
   /// @brief Check if the driver is shutting down.
   bool is_closing() const;
 
-  int memfd = -1;       ///< memfd backing the KFD signal event page.
-  void *page = nullptr; ///< Mapped signal page (libhsakmt polls slots here).
-  size_t page_size = 0; ///< Size of the mapped event page in bytes.
+  /// @brief Return the stable event-page backing fd, creating it exactly once.
+  /// @details The check-and-create runs under mutex_, so concurrent event-page
+  /// mmaps cannot each build a backing and hand different fds to different callers
+  /// — which would leave one polling an object that never receives event updates.
+  /// @param length Size to pass to @p create_backing.
+  /// @param create_backing Builds the backing and returns its fd, or -1 on failure.
+  ///        Called at most once per EventState, with mutex_ held.
+  /// @returns The backing fd, or -1 if creation failed.
+  int ensure_backing(size_t length, const std::function<int(size_t)> &create_backing);
+
+  /// @brief The backing fd, or -1 if none has been created. Takes mutex_.
+  [[nodiscard]] int backing_fd() const;
+
+  /// @brief Number of waiters currently registered on @p event_id.
+  /// @details Test seam for deterministically observing that a waiter has parked,
+  /// so a test need not sleep and hope. Takes mutex_.
+  [[nodiscard]] size_t waiter_count(uint32_t event_id) const;
+
+  /// @brief True if an event page is currently adopted.
+  /// @details Takes mutex_, so it cannot race a concurrent release_page()/munmap
+  /// the way a direct read of the `page_` field can.
+  [[nodiscard]] bool has_page() const;
 
 private:
+  int memfd_ = -1;       ///< memfd backing the KFD signal event page.
+  void *page_ = nullptr; ///< Mapped signal page (libhsakmt polls slots here).
+  size_t page_size_ = 0; ///< Size of the mapped event page in bytes.
+
   /// @brief Internal event representation.
   struct GpuEvent {
     uint32_t event_id = 0;   ///< KFD event ID (1-based, matches slot index).
@@ -117,10 +154,12 @@ private:
     std::vector<std::condition_variable *> waiters; ///< Per-event waiter list (kernel wait_queue).
   };
 
-  std::mutex mutex_;                              ///< Protects all mutable event state.
+  mutable std::mutex mutex_;                      ///< Protects all mutable event state.
   std::unordered_map<uint32_t, GpuEvent> events_; ///< Event table keyed by event_id.
   uint32_t next_event_id_ = 1;                    ///< Next event ID to allocate.
   std::atomic<bool> closing_{false};              ///< Set by notify_closing() for shutdown.
+  /// @brief Set by begin_wait_cancel() to release waiters without closing.
+  std::atomic<bool> wait_cancelled_{false};
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
@@ -12,11 +12,14 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cassert>
 #include <cerrno>
 #include <charconv>
+#include <chrono>
 #include <cstdio>
 #include <dirent.h>
+#include <exception>
 #include <fcntl.h>
 #include <filesystem>
 #include <new>
@@ -359,9 +362,6 @@ public:
   /// @brief Remove generated overlay directories.
   void cleanup();
 
-  /// @brief Drop inherited overlay ownership without removing parent-owned paths.
-  void release_after_fork();
-
   /// @brief Generated KFD topology root.
   [[nodiscard]] const std::string &topology_path() const { return topology_dir_; }
 
@@ -530,13 +530,6 @@ void GuestKfd::TopologyOverlay::cleanup() {
   guest_sysfs_.cleanup();
 }
 
-void GuestKfd::TopologyOverlay::release_after_fork() {
-  topology_dir_.clear();
-  guest_drm_dir_.clear();
-  guest_node_id_ = 0;
-  guest_sysfs_.release_after_fork();
-}
-
 GuestKfd::GuestKfd(config::DbtGuestConfig config, LinuxKfd *execution_driver)
     : config_(std::move(config)), execution_driver_(execution_driver),
       overlay_(std::make_unique<TopologyOverlay>()),
@@ -552,30 +545,16 @@ GuestKfd::GuestKfd(config::DbtGuestConfig config, LinuxKfd *execution_driver)
 }
 
 GuestKfd::~GuestKfd() {
+  // The synthetic descriptor is this object's own; nothing else closes it once the
+  // driver is gone.
+  const int synthetic = app_fd_.exchange(-1, std::memory_order_acq_rel);
+  if (synthetic >= 0)
+    libc_passthrough().close(synthetic);
   int kfd_fd = real_kfd_fd_.load(std::memory_order_acquire);
   if (execution_driver_ && owns_execution_driver_open_)
     execution_driver_->close();
   else if (kfd_fd >= 0 && !execution_driver_)
     libc_passthrough().close(kfd_fd);
-}
-
-void GuestKfd::reset_after_fork() {
-  // After fork() only the calling thread survives. If another parent thread was
-  // in an ioctl or close path, mutex_ may be inherited as permanently locked in
-  // the child. Reinitialize it in-place before touching ordinary members; the
-  // child is single-threaded here and the interposer destroys this copy next.
-  new (&mutex_) std::mutex();
-  ready_.store(false, std::memory_order_release);
-  int kfd_fd = real_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
-  if (kfd_fd >= 0 && !execution_driver_)
-    libc_passthrough().close(kfd_fd);
-  owns_execution_driver_open_ = false;
-  execution_driver_ = nullptr;
-  open_refs_ = 0;
-  overlay_->release_after_fork();
-  synthetic_handles_.clear();
-  synthetic_mmap_offsets_.clear();
-  next_synthetic_handle_ = kSyntheticHandleBase;
 }
 
 bool GuestKfd::ensure_real_kfd_locked() {
@@ -608,6 +587,10 @@ bool GuestKfd::ensure_real_kfd_locked() {
   int fd = libc_passthrough().openat(AT_FDCWD, "/dev/kfd", O_RDWR | O_CLOEXEC, 0);
   if (fd < 0)
     return false;
+  // Remember which device this is. The fd number alone is not identity: it can be
+  // closed and recycled onto an unrelated file, so anything that holds the
+  // descriptor across a window re-checks against this before using it.
+  record_kfd_identity(fd);
   real_kfd_fd_.store(fd, std::memory_order_release);
   return true;
 }
@@ -662,6 +645,16 @@ bool GuestKfd::ensure_ready_locked() {
 
 bool GuestKfd::prepare_for_discovery() { return ensure_ready(); }
 
+bool GuestKfd::ensure_app_fd_locked() {
+  if (app_fd_.load(std::memory_order_acquire) >= 0)
+    return true;
+  const int minted = memfd_create("rocjitsu_guest_kfd", MFD_CLOEXEC);
+  if (minted < 0)
+    return false;
+  app_fd_.store(minted, std::memory_order_release);
+  return true;
+}
+
 int GuestKfd::open() {
   std::lock_guard lock(mutex_);
   if (!ensure_ready_locked())
@@ -687,11 +680,29 @@ int GuestKfd::open() {
     return -1;
   }
 
-  // Keep the real /dev/kfd fd internal to the driver. Applications receive
-  // ordinary dup fds, so close(fd) releases that fd number immediately while
-  // the hidden real fd keeps host-KFD forwarding alive until the last
-  // app-facing open/dup reference is closed.
-  const int app_fd = libc_passthrough().fcntl(kfd_fd, F_DUPFD_CLOEXEC, 0);
+  // Applications receive a DISTINCT descriptor per open, duplicated from a
+  // synthetic memfd -- never from the real /dev/kfd. Two properties matter and both
+  // are load-bearing:
+  //
+  //   * Synthetic. A real duplicate would let a forked child -- whose calls the
+  //     interposer passes straight to libc under the fork-then-exec contract --
+  //     operate real hardware through the inherited fd, and dup2() it without
+  //     FD_CLOEXEC to carry that authority across exec. A memfd dup is inert.
+  //   * Distinct. Real KFD returns a fresh descriptor per open, and callers close
+  //     them independently; handing the same number to concurrent openers would let
+  //     one thread's close() invalidate another's live fd.
+  //
+  // The real fd stays in real_kfd_fd_, private to this object, and every forwarded
+  // operation uses it from there.
+  if (!ensure_app_fd_locked()) {
+    if (opened_execution_driver) {
+      execution_driver_->close();
+      owns_execution_driver_open_ = false;
+    }
+    return -1;
+  }
+  const int app_fd =
+      libc_passthrough().fcntl(app_fd_.load(std::memory_order_acquire), F_DUPFD_CLOEXEC, 0);
   if (app_fd < 0) {
     if (opened_execution_driver) {
       execution_driver_->close();
@@ -712,10 +723,42 @@ bool GuestKfd::retain_local_open() {
   return false;
 }
 
+uint32_t GuestKfd::local_open_ref_count() const {
+  std::lock_guard lock(mutex_);
+  return open_refs_;
+}
+
+void GuestKfd::begin_local_shutdown() {
+  // Release any parked WAIT_EVENTS so it returns and drops the driver snapshot that
+  // would otherwise keep this object alive. Snapshot execution_driver_ under
+  // mutex_, then call with the lock released (its begin_local_shutdown() takes the
+  // simulator's own process mutex; holding GuestKfd::mutex_ across it is
+  // unnecessary). A simulator-backed guest forwards to that driver. A hardware-
+  // backed guest has no execution_driver_ and forwards WAIT_EVENTS to the real
+  // kernel as bounded polls (forward_wait_events_bounded), so set hw_closing_ to
+  // cancel an in-flight poll loop instead.
+  LinuxKfd *execution_driver = nullptr;
+  {
+    std::lock_guard lock(mutex_);
+    execution_driver = execution_driver_;
+  }
+  if (execution_driver)
+    execution_driver->begin_local_shutdown();
+  else
+    hw_closing_.store(true, std::memory_order_release);
+}
+
 LinuxKfd::PrimaryInvalidation GuestKfd::invalidate_primary_fd(int fd) {
   if (fd < 0)
     return PrimaryInvalidation::kNotPrimary;
   std::lock_guard lock(mutex_);
+  // The synthetic backing memfd is internal, like the real fd: app-facing dups
+  // carry the counted references, so an overwrite of this number must NOT release
+  // one. A later open() re-mints the backing.
+  int expected_app = fd;
+  if (app_fd_.compare_exchange_strong(expected_app, -1, std::memory_order_acq_rel))
+    return PrimaryInvalidation::kClearedKeepRefs;
+
   // Compare-and-clear the hidden real fd number. Do NOT close it: dup2/dup3
   // already atomically replaced whatever this number named, so closing it here
   // would close the app's replacement. A concurrent overwrite that already
@@ -743,10 +786,37 @@ LinuxKfd::PrimaryInvalidation GuestKfd::invalidate_primary_fd(int fd) {
   return PrimaryInvalidation::kClearedKeepRefs;
 }
 
+GuestKfd::FinalCloseWork
+GuestKfd::begin_final_close_locked(std::unique_ptr<TopologyOverlay> fresh_overlay) {
+  FinalCloseWork work;
+  close_deferred_ = false;
+  work.kfd_fd = real_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
+  if (execution_driver_ && owns_execution_driver_open_) {
+    work.execution_driver = execution_driver_;
+    owns_execution_driver_open_ = false;
+  }
+  ready_.store(false, std::memory_order_release);
+  synthetic_handles_.clear();
+  synthetic_mmap_offsets_.clear();
+  next_synthetic_handle_ = kSyntheticHandleBase;
+  // Removing copied sysfs trees can block on filesystem work. Swap the overlay object
+  // while serialized, then perform the actual remove_all after releasing mutex_ so
+  // concurrent ioctl/redirect callers are not stalled.
+  work.overlay = std::move(overlay_);
+  overlay_ = std::move(fresh_overlay);
+  return work;
+}
+
+void GuestKfd::finish_final_close(FinalCloseWork work) {
+  work.overlay.reset();
+  if (work.execution_driver)
+    work.execution_driver->close();
+  else if (work.kfd_fd >= 0 && !execution_driver_)
+    libc_passthrough().close(work.kfd_fd);
+}
+
 int GuestKfd::close() {
-  int kfd_fd = -1;
-  LinuxKfd *execution_driver_to_close = nullptr;
-  std::unique_ptr<TopologyOverlay> overlay_to_cleanup;
+  FinalCloseWork work;
   auto fresh_overlay = std::make_unique<TopologyOverlay>();
   {
     std::lock_guard lock(mutex_);
@@ -756,52 +826,294 @@ int GuestKfd::close() {
     if (open_refs_ != 0)
       return 0;
 
-    // The app sees a real KFD fd, but the interposer owns close ordering so
-    // dup'd descriptors can keep the process KFD connection alive. Only the
-    // final open reference closes the primary real fd and tears down discovery
-    // state; the close hook separately closes any dup fd that triggered this.
-    kfd_fd = real_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
-    if (execution_driver_ && owns_execution_driver_open_) {
-      execution_driver_to_close = execution_driver_;
-      owns_execution_driver_open_ = false;
+    // The app sees only the synthetic descriptor; the interposer owns close
+    // ordering so app-facing references keep the host KFD connection alive. Only
+    // the final open reference closes the private real fd and tears down discovery
+    // state; the close hook separately closes the app fd that triggered this.
+    //
+    // The synthetic BACKING memfd is deliberately retained across close/reopen
+    // epochs and released only in the destructor. Clearing it here without closing
+    // leaked one descriptor per epoch; closing it here instead would need the close
+    // to happen outside mutex_, and there is nothing to gain -- the backing is
+    // inert, private, and reused by the next open().
+    //
+    // Unless a caller-visible WAIT_EVENTS is being served right now. That one call is
+    // many bounded ioctls, so clearing the connection here would fail it ENODEV on its
+    // next slice -- an operation the kernel had already started, revoked partway, which
+    // a native blocking ioctl is never subject to. Hand the close to whichever lease
+    // drains last instead. close() itself must not wait for that: an indefinite wait
+    // would then block close() for as long as it runs. The deferred branch drops
+    // readiness like any other close, but the DRAIN is what runs the transition for
+    // real, because readiness can be republished while the close is pending.
+    if (wait_leases_ > 0) {
+      close_deferred_ = true;
+      // Hand the replacement overlay over NOW. The drain runs from a destructor, which
+      // is noexcept, so an allocation there would turn a bad_alloc into a terminate on
+      // the way out of an ioctl -- and it would put an allocate/free on every wait.
+      deferred_overlay_ = std::move(fresh_overlay);
+      ready_.store(false, std::memory_order_release);
+    } else {
+      deferred_overlay_.reset();
+      work = begin_final_close_locked(std::move(fresh_overlay));
     }
-    ready_.store(false, std::memory_order_release);
-    synthetic_handles_.clear();
-    synthetic_mmap_offsets_.clear();
-    next_synthetic_handle_ = kSyntheticHandleBase;
-    // Removing copied sysfs trees can block on filesystem work. Swap the
-    // overlay object while serialized, then perform the actual remove_all after
-    // releasing mutex_ so concurrent ioctl/redirect callers are not stalled.
-    overlay_to_cleanup = std::move(overlay_);
-    overlay_ = std::move(fresh_overlay);
   }
-  overlay_to_cleanup.reset();
-  if (execution_driver_to_close)
-    execution_driver_to_close->close();
-  else if (kfd_fd >= 0 && !execution_driver_)
-    libc_passthrough().close(kfd_fd);
+  finish_final_close(std::move(work));
   return 0;
+}
+
+bool GuestKfd::acquire_wait_lease() {
+  std::lock_guard lock(mutex_);
+  // Validating the reference, establishing readiness and taking the lease is ONE critical
+  // section on purpose. Split across two, a final close lands in the gap: arriving after
+  // readiness it revokes a wait that was already cleared to run, and arriving before it
+  // lets a wait with no application reference behind it republish a connection that then
+  // outlives every open. Requiring a live reference here is what closes the second: a
+  // wait is always issued on an application descriptor, so no reference means the wait
+  // has already lost its claim on the connection.
+  if (open_refs_ == 0) {
+    errno = ENODEV;
+    return false;
+  }
+  if (!ensure_ready_locked()) {
+    if (errno == 0)
+      errno = ENODEV;
+    return false;
+  }
+  if (real_kfd_fd_.load(std::memory_order_acquire) < 0) {
+    errno = ENODEV;
+    return false;
+  }
+  ++wait_leases_;
+  return true;
+}
+
+int GuestKfd::wait_events(unsigned long request, void *arg) {
+  // The lease covers the whole caller-visible wait, for BOTH backends: a final close
+  // releases the simulator's backend open exactly as it retires a host connection, and
+  // the simulated wait that was already running would then return EBADF.
+  WaitLease lease(*this);
+  if (!lease.held())
+    return -(errno != 0 ? errno : ENODEV);
+
+  int rc = 0;
+  std::exception_ptr failure;
+  try {
+    // Forward a null arg unchanged rather than dereferencing it for the timeout: the
+    // kernel answers it with EFAULT/EINVAL, and the interposer must reproduce that
+    // failure instead of segfaulting inside the caller's ioctl().
+    //
+    // The simulator serves the wait itself and begin_local_shutdown() can wake it, so it
+    // takes ONE ordinary blocking forward -- slicing it would add repolling that buys
+    // nothing. Only the kernel, which nothing in this process can interrupt, needs the
+    // wait broken into cancellable slices.
+    if (!arg || execution_driver_)
+      rc = forward_ioctl(request, arg);
+    else
+      rc = forward_wait_events_bounded(request, arg);
+  } catch (...) {
+    failure = std::current_exception();
+  }
+
+  // EVERY exit drops the lease here, never on the way out through ~WaitLease -- including
+  // the exceptional one, which is why a throw is caught and held rather than allowed to
+  // unwind through it. Dropping the last lease can run a deferred final close, and tearing
+  // a backend down allocates; a destructor is implicitly noexcept, so a bad_alloc there
+  // terminates the process rather than propagating, and under unwinding it would do so
+  // with a first exception already in flight. The result is captured by now, so nothing
+  // this does can disturb it.
+  lease.release();
+  if (failure)
+    std::rethrow_exception(failure);
+  return rc;
+}
+
+void GuestKfd::release_wait_lease() {
+  FinalCloseWork work;
+  {
+    std::lock_guard lock(mutex_);
+    assert(wait_leases_ > 0);
+    // Only the LAST lease to drain executes a deferred close, and only while there is
+    // still no open reference: a reopen in the meantime ADOPTS the connection this was
+    // holding open (KFD binds one process context per mm, so it is the same connection
+    // a reopen would have produced), and closing it then would turn the deferral into
+    // the very revocation it exists to prevent.
+    //
+    // This runs the WHOLE final-close transition, not just the fd close. Anything that
+    // calls ensure_ready() during the deferral -- an ioctl arriving at zero references,
+    // or an open that publishes readiness and then fails to hand out its descriptor --
+    // republishes readiness against the connection being held open. Closing the fd and
+    // leaving readiness set would wedge a hardware guest permanently: ensure_ready()
+    // short-circuits on the stale flag, so it would never reopen, and every later call
+    // would find no host fd and fail ENODEV. The simulator backend hides this because
+    // its own open() re-mints a connection; hardware has no such second path.
+    //
+    // The exchange inside is what makes this safe against a dup2 that landed on the
+    // hidden number: invalidate_primary_fd() already cleared it WITHOUT closing, so this
+    // finds -1 and closes nothing rather than closing the app's file.
+    if (--wait_leases_ == 0 && close_deferred_ && open_refs_ == 0)
+      work = begin_final_close_locked(std::move(deferred_overlay_));
+  }
+  finish_final_close(std::move(work));
 }
 
 int GuestKfd::forward_ioctl(unsigned long request, void *arg) {
   if (execution_driver_)
     return execution_driver_->ioctl(request, arg);
 
-  int kfd_fd = fd();
+  int kfd_fd = host_fd();
   if (kfd_fd < 0) {
     errno = ENODEV;
     return -1;
   }
   int ret = libc_passthrough().ioctl(kfd_fd, request, arg);
-  if (ret < 0) {
-    // GuestKfd forwards to the real kernel ABI here. Preserve errno and return
-    // -1 so callers that check for libc ioctl failure semantics behave the same
-    // whether an ioctl was handled locally or forwarded to /dev/kfd.
-    const int saved_errno = errno != 0 ? errno : EIO;
-    errno = saved_errno;
-    return -1;
-  }
+  if (ret < 0)
+    // A Driver returns the KERNEL convention, -errno, and the interposer's single
+    // conversion turns that into libc's -1/errno for the application. libc's ioctl gives
+    // this path the libc convention instead, so translate rather than pass it through:
+    // returning -1 would be read as -EPERM, which is how an interrupted wait reached the
+    // runtime as EPERM and defeated its EINTR retry.
+    return -(errno != 0 ? errno : EIO);
   return ret;
+}
+
+int GuestKfd::forward_wait_events_bounded(unsigned long request, void *arg) {
+  if (host_fd() < 0)
+    return -ENODEV;
+  auto *wait_args = static_cast<kfd_ioctl_wait_events_args *>(arg);
+
+  // Each slice re-loads the hidden descriptor and re-checks its identity rather than
+  // holding a private duplicate across the wait.
+  //
+  // A duplicate looks like the obvious answer -- a native blocking ioctl holds its file
+  // description for the whole call, and slicing reopens a window between slices. It is
+  // the wrong answer here, because the duplicate would be an ordinary numeric fd that
+  // the interposer does not track. A dup2 onto its number would redirect a later slice
+  // unnoticed, and, worse, OWNING that number means the RAII close at the end of the
+  // wait would close whatever now sits there -- the application's own descriptor.
+  // Detecting the swap does not help: detection does not relinquish numeric ownership.
+  // Holding an uncoordinated descriptor across an indefinite wait trades a slice that
+  // fails ENODEV for closing a file we do not own, which is strictly worse.
+  //
+  // So: own nothing. Re-load per slice, confirm the number is still the device we
+  // opened before issuing at it, and let the wait end if it is not. That leaves the
+  // load/use split every other forwarded path here already has, and no new ownership.
+  // Closing it for real needs a descriptor-lifecycle protocol this driver does not have
+  // yet: a private fd that the interposer REGISTERS, and that the dup2/dup3 transaction
+  // relocates before it mutates the fd table, rather than one validated after the fact.
+  // That is a change to the interposer/LinuxKfd boundary and belongs in its own review.
+  //
+  // Zero-timeout requests come through here too: "non-blocking" removes the wait, not
+  // the load/use race, and wait_events_poll_loop issues them unsliced anyway.
+  return wait_events_poll_loop(*wait_args, hw_closing_, [&] {
+    const int slice_fd = host_fd();
+    if (slice_fd < 0 || !fd_is_expected_kfd(slice_fd))
+      return -ENODEV;
+    int ret = libc_passthrough().ioctl(slice_fd, request, arg);
+    if (ret < 0)
+      return -(errno != 0 ? errno : EIO);
+    return ret;
+  });
+}
+
+void GuestKfd::record_kfd_identity(int kfd_fd) {
+  auto &real = libc_passthrough();
+  struct stat st {};
+  if (real.fstat_fn && real.fstat_fn(kfd_fd, &st) == 0 && S_ISCHR(st.st_mode))
+    real_kfd_rdev_.store(st.st_rdev, std::memory_order_release);
+  else
+    real_kfd_rdev_.store(0, std::memory_order_release);
+}
+
+bool GuestKfd::fd_is_expected_kfd(int fd) const {
+  const dev_t expected = real_kfd_rdev_.load(std::memory_order_acquire);
+  if (expected == 0)
+    return false; // identity was never established: fail closed rather than guess.
+  auto &real = libc_passthrough();
+  if (!real.fstat_fn)
+    return false;
+  struct stat st {};
+  if (real.fstat_fn(fd, &st) != 0)
+    return false;
+  return S_ISCHR(st.st_mode) && st.st_rdev == expected;
+}
+
+int GuestKfd::wait_events_poll_loop(kfd_ioctl_wait_events_args &args,
+                                    const std::atomic<bool> &cancelled,
+                                    const std::function<int()> &poll) {
+  const uint32_t original_timeout = args.timeout;
+
+  // A zero-timeout poll already returns promptly; forward it unchanged.
+  if (original_timeout == 0)
+    return poll();
+
+  // Break a long/indefinite wait into short kernel polls, re-checking the
+  // cancellation flag between iterations so begin_local_shutdown() can cancel it
+  // and the caller's driver snapshot drops. The per-poll timeout bounds how long a
+  // single blocking syscall can hold it. Mirrors RemoteDriver's client-side
+  // WAIT_EVENTS loop.
+  //
+  // Deliberately NOT how the real stack waits: the thunk issues one blocking
+  // WAIT_EVENTS and re-enters only for EINTR/EAGAIN, because a kernel wait is
+  // interruptible by a signal and needs no cancellation flag. Nothing here can
+  // interrupt a poll already inside the driver, so the wait is sliced instead.
+  // Collapsing this back to a single blocking call would match the thunk and
+  // reintroduce the teardown stall it exists to avoid.
+  constexpr uint32_t kPollMs = 5;
+  const bool indefinite = original_timeout == kWaitEventsInfiniteMs;
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(original_timeout);
+
+  for (;;) {
+    if (cancelled.load(std::memory_order_acquire)) {
+      // Report a benign timeout so the caller re-polls (and observes the driver
+      // going away) rather than treating the cancellation as an event completion.
+      args.timeout = original_timeout;
+      args.wait_result = KFD_IOC_WAIT_RESULT_TIMEOUT;
+      return 0;
+    }
+    // Clamp the slice to what the caller actually has left, so a short wait is not
+    // rounded UP to kPollMs (WAIT_EVENTS(timeout=1) must not block 5 ms). The
+    // deadline is only re-tested after a poll returns, so without this the first
+    // poll alone can overshoot the whole budget.
+    args.timeout = kPollMs;
+    if (!indefinite) {
+      // Round the remainder UP, and never to zero. A zero timeout is
+      // KFD_EVENT_TIMEOUT_IMMEDIATE, which is a poll that returns at once, so a
+      // sub-millisecond remainder truncated to zero would busy-spin issuing
+      // immediate polls until the deadline passed. Rounding up is also what the
+      // driver does with the millisecond timeout it is handed -- it ceilings the
+      // conversion to jiffies and then adds one -- so a nonzero request never
+      // becomes a zero-length sleep there either. Overshoot stays under a
+      // millisecond because the loop still stops at the deadline below.
+      const auto remaining_ms =
+          std::chrono::ceil<std::chrono::milliseconds>(deadline - std::chrono::steady_clock::now())
+              .count();
+      args.timeout = static_cast<uint32_t>(std::clamp<int64_t>(remaining_ms, 1, kPollMs));
+    }
+    int rc = poll();
+    if (rc != 0) {
+      // Report what is LEFT of the caller's budget, not what they asked for. This is
+      // the ioctl-restart path: the driver reduces the timeout in place so a caller
+      // that re-issues on EINTR continues the same wait instead of starting a fresh
+      // one. Restoring the original here would let a stream of signals extend a
+      // finite wait without bound, since each retry recomputes the deadline. Zero is
+      // a legal remainder -- it means poll once -- and an indefinite wait has no
+      // remainder to report.
+      if (!indefinite) {
+        const auto left_ms = std::chrono::ceil<std::chrono::milliseconds>(
+                                 deadline - std::chrono::steady_clock::now())
+                                 .count();
+        args.timeout = static_cast<uint32_t>(std::clamp<int64_t>(left_ms, 0, original_timeout));
+      } else {
+        args.timeout = original_timeout;
+      }
+      return rc;
+    }
+    args.timeout = original_timeout;
+    if (args.wait_result != KFD_IOC_WAIT_RESULT_TIMEOUT)
+      return 0;
+    if (!indefinite && std::chrono::steady_clock::now() >= deadline)
+      return 0; // real timeout: leave wait_result == TIMEOUT
+  }
 }
 
 int GuestKfd::get_process_apertures_ioctl(void *arg) {
@@ -1010,8 +1322,13 @@ int GuestKfd::unmap_memory_ioctl(void *arg) {
 }
 
 int GuestKfd::ioctl(unsigned long request, void *arg) {
+  // WAIT_EVENTS establishes readiness and takes its operation lease as one locked step,
+  // so it must not come through the generic ensure_ready() first -- that would reopen
+  // the very gap the single step exists to close.
+  if (canonical_ioctl_request(request) == AMDKFD_IOC_WAIT_EVENTS)
+    return wait_events(request, arg);
   if (!ensure_ready())
-    return -1;
+    return -(errno != 0 ? errno : ENODEV);
 
   switch (canonical_ioctl_request(request)) {
   case AMDKFD_IOC_GET_PROCESS_APERTURES_NEW:
@@ -1047,7 +1364,7 @@ int GuestKfd::ioctl(unsigned long request, void *arg) {
 void *GuestKfd::mmap(void *addr, size_t length, int prot, int flags, off_t offset) {
   if (!ensure_ready())
     return MAP_FAILED;
-  int kfd_fd = fd();
+  int kfd_fd = host_fd();
   if (kfd_fd < 0) {
     errno = ENODEV;
     return MAP_FAILED;
@@ -1078,12 +1395,16 @@ int GuestKfd::munmap(void *addr, size_t length) {
 bool GuestKfd::owns_fd(int fd) const {
   if (fd < 0)
     return false;
+  if (fd == app_fd_.load(std::memory_order_acquire))
+    return true;
   if (fd == real_kfd_fd_.load(std::memory_order_acquire))
     return true;
   return execution_driver_ && execution_driver_->owns_fd(fd);
 }
 
 int GuestKfd::fd() const { return real_kfd_fd_.load(std::memory_order_acquire); }
+
+int GuestKfd::host_fd() const { return real_kfd_fd_.load(std::memory_order_acquire); }
 
 std::string GuestKfd::redirect_sysfs_path(const char *path) const {
   if (!path)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
@@ -8,6 +8,7 @@
 #define ROCJITSU_KMD_LINUX_GUEST_KFD_H_
 
 #include "rocjitsu/config/config_loader.h"
+#include "rocjitsu/kmd/linux/libc_passthrough.h"
 #include "rocjitsu/kmd/linux/linux_kfd.h"
 #include "rocjitsu/kmd/linux/sysfs.h"
 
@@ -19,12 +20,16 @@ RJ_DIAGNOSTIC_POP
 
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_set>
+#include <utility>
 
 namespace rocjitsu {
+
+class GuestKfdTestAccess;
 
 /// @brief KFD driver that exposes a guest GPU for DBT while forwarding host GPU work.
 ///
@@ -89,9 +94,6 @@ public:
   /// @brief Return the simulated host DRM root, or empty for hardware execution.
   [[nodiscard]] std::string drm_path() const override;
 
-  /// @brief Detach inherited child-process state before destroying this copy.
-  void reset_after_fork() override;
-
   /// @brief Prepare guest discovery without retaining an application open fd.
   bool prepare_for_discovery();
 
@@ -99,6 +101,26 @@ public:
   /// @retval true A reference was added.
   /// @retval false No live guest process to retain.
   [[nodiscard]] bool retain_local_open() override;
+
+  /// @brief Number of app-facing KFD descriptor references still live.
+  /// @details Only application-visible dup fds are counted — the internal real
+  /// /dev/kfd fd is not — so this driver's count is zero at publication and its
+  /// teardown baseline is zero.
+  [[nodiscard]] uint32_t local_open_ref_count() const override;
+
+  /// @brief Release blocking calls before teardown so their driver snapshot drops.
+  /// @details Two distinct backends, one contract — in both cases a parked
+  /// WAIT_EVENTS returns a benign KFD_IOC_WAIT_RESULT_TIMEOUT and nothing else is
+  /// mutated:
+  /// - Simulator execution: WAIT_EVENTS is served by the SimulatedKfd execution
+  ///   driver, so this DELEGATES to it and its local process's waiters are
+  ///   released.
+  /// - Hardware execution: WAIT_EVENTS is forwarded to the real kernel, which this
+  ///   process cannot interrupt. Instead this sets hw_closing_, which
+  ///   forward_wait_events_bounded()'s poll loop observes between its short kernel
+  ///   polls and returns on — CANCELLING the wait rather than waking it.
+  /// Idempotent.
+  void begin_local_shutdown() override;
 
   /// @brief Stop classifying the hidden real /dev/kfd fd number as KFD after a
   /// dup2/dup3 overwrote it.
@@ -115,7 +137,30 @@ public:
   [[nodiscard]] PrimaryInvalidation invalidate_primary_fd(int fd) override;
 
 private:
+  friend class GuestKfdTestAccess;
+
   class TopologyOverlay;
+
+  /// @brief Work a final close hands back to be destroyed with mutex_ released.
+  struct FinalCloseWork {
+    int kfd_fd = -1;
+    LinuxKfd *execution_driver = nullptr;
+    std::unique_ptr<TopologyOverlay> overlay;
+  };
+
+  /// @brief Run the whole final-close state transition. Caller holds mutex_.
+  /// @details Shared by close() and release_wait_lease() so a close that was deferred
+  /// behind a wait lease performs the SAME transition when it finally runs, rather than
+  /// only closing the descriptor. Readiness and epoch state can be republished while a
+  /// close is pending, so the drain has to retire them again; leaving readiness set with
+  /// no host fd wedges a hardware guest permanently, because ensure_ready() short-
+  /// circuits on the flag and never reopens.
+  /// @returns The descriptor, backend open and overlay to destroy outside mutex_.
+  [[nodiscard]] FinalCloseWork
+  begin_final_close_locked(std::unique_ptr<TopologyOverlay> fresh_overlay);
+
+  /// @brief Destroy what begin_final_close_locked() returned, with mutex_ released.
+  void finish_final_close(FinalCloseWork work);
 
   /// @brief Open real KFD, generate topology, and select the host GPU.
   bool ensure_ready();
@@ -128,6 +173,98 @@ private:
 
   /// @brief Forward one ioctl to the real /dev/kfd fd.
   int forward_ioctl(unsigned long request, void *arg);
+
+  /// @brief Forward WAIT_EVENTS to the real kernel as bounded, cancellable polls.
+  /// @details A hardware-backed guest has no simulator wait to wake, and the real
+  /// kernel WAIT_EVENTS can block indefinitely. The interposer dispatches this
+  /// ioctl while holding a driver snapshot, so an indefinite kernel wait
+  /// would keep that pin held and deadlock teardown (begin_local_shutdown() cannot
+  /// wake a kernel syscall, and closing the fd does not cancel an in-flight wait).
+  /// This breaks a long/indefinite wait into short kernel polls that re-check
+  /// hw_closing_ between iterations, so begin_local_shutdown() can cancel it and the
+  /// pin drains promptly. Mirrors the RemoteDriver client-side WAIT_EVENTS loop.
+  int forward_wait_events_bounded(unsigned long request, void *arg);
+
+  /// @brief The bounded-poll algorithm behind forward_wait_events_bounded().
+  /// @details Split out and fully injected so its five outcomes — zero-timeout
+  /// pass-through, cancellation (with the caller's timeout restored), indefinite
+  /// polling until an event completes, finite-deadline expiry, and a failed poll —
+  /// are unit testable without a real /dev/kfd. @p poll performs ONE short kernel
+  /// poll, reading and writing @p args (the loop has already set args.timeout to the
+  /// per-poll slice) and returning the ioctl result. @p cancelled is the flag
+  /// begin_local_shutdown() sets; it is re-read between polls, never inside one.
+  /// @returns The ioctl result to hand back to the caller. args.timeout is restored
+  /// to the caller's original value on every path EXCEPT a failed poll of a finite
+  /// wait, where what REMAINS of the budget is reported instead: that is the driver's
+  /// restart convention, so a caller retrying on EINTR continues this wait rather
+  /// than starting a fresh one. Zero is a legal remainder and means poll-once.
+  static int wait_events_poll_loop(kfd_ioctl_wait_events_args &args,
+                                   const std::atomic<bool> &cancelled,
+                                   const std::function<int()> &poll);
+
+  /// @brief Take a lease that keeps the host connection open for one whole wait.
+  /// @details A caller-visible WAIT_EVENTS is served as MANY bounded ioctls, which puts
+  /// descriptor-lifetime boundaries inside what the caller issued as one call. The
+  /// kernel gives a native blocking ioctl a file reference for the entire syscall, so a
+  /// concurrent close cannot revoke an operation already running; a sliced wait has no
+  /// such protection, and the final close would otherwise clear the connection out from
+  /// under a wait that had already started, failing it ENODEV partway instead of letting
+  /// it complete with an event or a timeout. A lease makes that close DEFER: close()
+  /// still returns immediately, as it must -- an indefinite wait cannot be allowed to
+  /// block it -- and the last lease to drain performs the close that close() handed off.
+  /// Cancellation is unaffected: begin_local_shutdown() sets its cancellation flag
+  /// first, so shutdown still ends the wait promptly and only then drains.
+  /// @retval false There is no host connection to lease; the caller must fail closed.
+  [[nodiscard]] bool acquire_wait_lease();
+
+  /// @brief Serve WAIT_EVENTS under a lease held for the caller-visible duration.
+  /// @details The single entry point for both backends, so neither can bypass the lease.
+  /// It also owns the choice between them: the simulator takes one ordinary blocking
+  /// forward, since it serves the wait itself and begin_local_shutdown() can wake it;
+  /// only the kernel needs the wait broken into cancellable slices.
+  int wait_events(unsigned long request, void *arg);
+
+  /// @brief Drop a wait lease, performing a close that close() deferred.
+  /// @details The overlay it installs was prepared when the close was deferred, so this
+  /// adds no allocation of its own. It can still reach a full backend teardown, which
+  /// allocates, so callers drop the lease explicitly (WaitLease::release()) rather than
+  /// leaving it to the destructor.
+  void release_wait_lease();
+
+  /// @brief RAII holder for acquire_wait_lease()/release_wait_lease().
+  /// @details Callers should release() on the normal path. Dropping the LAST lease can
+  /// run a deferred final close, and a backend teardown there allocates -- from a
+  /// destructor, which is implicitly noexcept, that turns a bad_alloc into a terminate on
+  /// the way out of an ioctl. Releasing explicitly keeps that work off the noexcept path
+  /// and leaves the destructor as the unwind-only fallback it should be.
+  class WaitLease {
+  public:
+    explicit WaitLease(GuestKfd &owner) : owner_(owner.acquire_wait_lease() ? &owner : nullptr) {}
+    WaitLease(const WaitLease &) = delete;
+    WaitLease &operator=(const WaitLease &) = delete;
+    ~WaitLease() { release(); }
+
+    /// @brief True if the lease was granted.
+    [[nodiscard]] bool held() const { return owner_ != nullptr; }
+
+    /// @brief Drop the lease now. Idempotent.
+    void release() {
+      if (owner_ != nullptr)
+        std::exchange(owner_, nullptr)->release_wait_lease();
+    }
+
+  private:
+    GuestKfd *owner_ = nullptr;
+  };
+
+  /// @brief Remember the device @p kfd_fd was opened on, for later identity checks.
+  void record_kfd_identity(int kfd_fd);
+
+  /// @brief True if @p fd is still the KFD character device we opened.
+  /// @details An fd number is not identity. Anything holding a descriptor across a
+  /// window where a concurrent close could recycle that number checks this before
+  /// using it, so a recycled number fails closed rather than receiving driver traffic.
+  [[nodiscard]] bool fd_is_expected_kfd(int fd) const;
 
   /// @brief Return real process apertures plus one synthetic guest aperture.
   int get_process_apertures_ioctl(void *arg) override;
@@ -175,7 +312,21 @@ private:
   std::unique_ptr<TopologyOverlay> overlay_;
   mutable std::mutex mutex_;
   std::atomic<int> real_kfd_fd_{-1};
+  /// @brief st_rdev of the device real_kfd_fd_ was opened on, or 0 if unknown.
+  /// @details The fd NUMBER is loaded separately from any use of it, so a concurrent
+  /// close plus a recycling open can put an unrelated file behind that number. Anything
+  /// that re-loads the number across a window -- every slice of a sliced WAIT_EVENTS --
+  /// compares the device identity against this before issuing a KFD ioctl, so a recycled
+  /// number fails closed instead of silently receiving driver traffic.
+  std::atomic<dev_t> real_kfd_rdev_{0};
   uint32_t open_refs_ = 0;
+  /// @brief Caller-visible WAIT_EVENTS calls currently being served as sliced polls.
+  uint32_t wait_leases_ = 0;
+  /// @brief close() found a live wait lease and handed its close off to the drain.
+  bool close_deferred_ = false;
+  /// @brief Replacement overlay prepared for a deferred close, so the drain can install
+  /// it without allocating.
+  std::unique_ptr<TopologyOverlay> deferred_overlay_;
   bool owns_execution_driver_open_ = false;
   uint32_t host_gpu_id_ = 0;
   static constexpr uint64_t kSyntheticHandleBase = 1ULL << 63;
@@ -183,6 +334,50 @@ private:
   std::unordered_set<uint64_t> synthetic_handles_;
   std::unordered_set<uint64_t> synthetic_mmap_offsets_;
   std::atomic<bool> ready_{false};
+  /// @brief Set by begin_local_shutdown() for a hardware-backed guest so an
+  /// in-flight bounded WAIT_EVENTS poll loop returns and drops its driver snapshot
+  /// before teardown.
+  std::atomic<bool> hw_closing_{false};
+  /// @brief The synthetic descriptor applications receive from open().
+  /// @details A memfd, NEVER a duplicate of the real /dev/kfd, mirroring what
+  /// SimulatedKfd hands out. This is a security boundary, not a convenience: a
+  /// forked child inherits the parent's descriptor table, and under the
+  /// fork-then-exec contract the interposer passes a child's ioctl/dup/dup2/fcntl
+  /// straight to libc. Had the app-facing fd been a real KFD duplicate, that child
+  /// could drive real hardware through it and dup2() it to clear FD_CLOEXEC and
+  /// carry it across the exec that was supposed to sanitize the process. A memfd
+  /// carries no such authority: inherited, it is inert.
+  std::atomic<int> app_fd_{-1};
+
+  /// @brief Create the synthetic app-facing descriptor once. Caller holds mutex_.
+  bool ensure_app_fd_locked();
+
+  /// @brief The PRIVATE real /dev/kfd descriptor used for host forwarding.
+  /// @details Never returned to an application; see app_fd_.
+  [[nodiscard]] int host_fd() const;
+};
+
+/// @brief Test-only handle to GuestKfd internals a real /dev/kfd would otherwise gate.
+/// @details Both members below belong to the hardware-backed path, which needs a real
+/// device to reach through GuestKfd::ioctl(); exposing them lets their contracts be
+/// tested on any host. Nothing outside tests may use this.
+class GuestKfdTestAccess {
+public:
+  /// @brief The bounded-wait algorithm: a pure function of its poll and cancel flag.
+  static int wait_events_poll_loop(kfd_ioctl_wait_events_args &args,
+                                   const std::atomic<bool> &cancelled,
+                                   const std::function<int()> &poll) {
+    return GuestKfd::wait_events_poll_loop(args, cancelled, poll);
+  }
+
+  /// @brief The lease a sliced wait holds for its whole caller-visible duration.
+  /// @details What it guards is backend-independent -- close() must hand its work to the
+  /// drain rather than revoke a wait already running -- so driving it directly tests that
+  /// contract without a device, and without a wait long enough to race by hand.
+  [[nodiscard]] static bool acquire_wait_lease(GuestKfd &guest) {
+    return guest.acquire_wait_lease();
+  }
+  static void release_wait_lease(GuestKfd &guest) { guest.release_wait_lease(); }
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -80,6 +80,7 @@ RJ_DIAGNOSTIC_POP
 #include <sys/sysmacros.h>
 #include <sys/uio.h>
 #include <sys/un.h>
+#include <system_error>
 #include <thread>
 #include <unistd.h>
 #include <unordered_map>
@@ -311,12 +312,44 @@ public:
   enum class DupBackend : uint8_t { Local, Remote };
 
   static inline thread_local bool in_construction = false;
+
+  /// @brief Hold in_construction for a scope, restoring it on every exit path.
+  ///
+  /// @details Clearing the flag by hand is a fail-OPEN hazard rather than a leak:
+  /// while it is set this thread bypasses path redirection entirely, so a throw that
+  /// skipped a clear would leave the thread opening the HOST's real device nodes for
+  /// the rest of its life -- the exact outcome the child gate exists to prevent.
+  /// Restores the previous value rather than clearing, so a nested construction
+  /// cannot end the outer one's scope early.
+  class ConstructionScope {
+  public:
+    ConstructionScope() : previous_(in_construction) { in_construction = true; }
+    ~ConstructionScope() { in_construction = previous_; }
+    ConstructionScope(const ConstructionScope &) = delete;
+    ConstructionScope &operator=(const ConstructionScope &) = delete;
+
+  private:
+    bool previous_;
+  };
+
   static rocjitsu::LibcPassthrough &real() { return rocjitsu::libc_passthrough(); }
   static InterposerContext &ctx;
 
   static void init() {
     new (storage_) InterposerContext();
     ctx.owner_pid_ = getpid();
+    // Record the HOST KFD device identity once, here, while single-threaded and
+    // before real().resolve() flips the gate. A forked child compares a resolved
+    // open target against this to decide whether it is about to touch real GPU
+    // hardware. Captured as an immutable dev_t rather than a pathname because only
+    // identity survives symlinks, chained aliases, dirfd-relative spellings and
+    // bind mounts; a name comparison does not. Absent host KFD leaves it 0, which
+    // matches nothing.
+    {
+      struct stat kfd_st {};
+      if (::stat("/dev/kfd", &kfd_st) == 0 && S_ISCHR(kfd_st.st_mode))
+        ctx.host_kfd_rdev_ = kfd_st.st_rdev;
+    }
     // Resolve the per-invocation runtime directory once here, in the library
     // constructor: this runs single-threaded before any app code (and thus before
     // any app fork). Writing it once here keeps invocation_runtime_dir() an
@@ -343,115 +376,159 @@ public:
       ctx.invocation_runtime_dir_ = dir;
     else
       ctx.invocation_runtime_dir_ = rocjitsu::rpc_invocation_runtime_dir(getpid());
-    // Reset child state on ANY glibc fork-family primitive, not just the
-    // interposed fork() symbol. system()/popen()/posix_spawn() and libraries that
-    // call fork() through a path that doesn't bind to our exported fork() would
-    // otherwise leave the child with mutexes locked-by-a-dead-thread and a live
-    // remote_ aliasing the parent's daemon connection — the next interposed
-    // open()/ioctl()/close() in that child would then deadlock or corrupt the
-    // parent's connection. pthread_atfork's child handler runs inside libc fork,
-    // covering every fork that goes through glibc. vfork/posix_spawn children run
-    // no atfork handlers; interposed close() detects that window by owner PID and
-    // avoids mutating the parent-shared context. reset_after_fork() is idempotent. It is
-    // NOT strictly async-signal-safe — container clear()/destructors call free() and it
-    // closes the child's dmabuf-dup fds — so it relies on the standard fork-then-exec /
-    // single-threaded-fork assumption (the same one the remote_ handling documents
-    // below); a multithreaded fork from a signal handler is out of scope.
-    pthread_atfork(nullptr, nullptr, &InterposerContext::atfork_child);
+    // NO pthread_atfork handlers, deliberately. rocJITsu's local mode keeps the
+    // simulator's state -- the VM, its engine thread, the driver objects and their
+    // private mutexes -- inside this address space, and a driver call holds those
+    // private locks for its whole duration, sometimes across a blocking wait. A
+    // prepare handler therefore cannot drain them: waiting on a lock held by a
+    // thread parked in an indefinite WAIT_EVENTS would hang fork() itself. The
+    // allocator-style "lock everything in prepare" pattern only works when no lock
+    // is ever held across a blocking call, which is false here.
+    //
+    // So local mode takes the same contract as every comparable in-process GPU
+    // runtime (CUDA, HSA/ROCr) and as ThreadSanitizer: rocJITsu services are
+    // UNAVAILABLE between fork/vfork and exec. Enforcement is owner_pid_, compared
+    // at the top of every interposed entry point before any inherited lock,
+    // container, driver or shared_ptr is touched, so a child can never reach state a
+    // vanished parent thread was mutating. That is a structural guarantee rather
+    // than a narrowed race, and it needs no child-side cleanup at all.
     real().resolve();
   }
 
-  /// @brief pthread_atfork child handler: reset interposer state in the child.
-  static void atfork_child() { ctx.reset_after_fork(); }
-
-  /// @brief Reset interposer state in a forked child process.
-  /// @details After fork(), the child inherits the parent's address space but
-  /// the engine thread is dead (only the calling thread survives). Mutexes may
-  /// be locked by threads that no longer exist. We reinitialize everything so
-  /// the next open("/dev/kfd") creates a fresh connection.
-  void reset_after_fork() {
-    owner_pid_ = getpid();
-    active_driver_.store(nullptr, std::memory_order_release);
-    rj_vm_ = nullptr;
-    if (guest_driver_)
-      guest_driver_->reset_after_fork();
-    guest_driver_.reset();
-    // Drop the child's reference to the inherited RemoteDriver. Storing nullptr
-    // releases this shared_ptr; if it was the last reference in the child, the
-    // child's ~RemoteDriver runs and closes only the child's inherited (dup'd)
-    // fds — it does not send RPC_CLOSE and cannot invalidate the parent's live
-    // connection, so this is safe in a forked child.
-    //
-    // Unlike the plain mutexes below, remote_ is NOT reinitialized via
-    // placement-new: re-constructing a live object over itself ends the current
-    // object's lifetime without running its destructor, which is UB for a
-    // non-trivial type like std::atomic<std::shared_ptr<>> (it leaks/By-passes the
-    // control-block bookkeeping). A plain store(nullptr) is the correct way to
-    // release it.
-    //
-    // Caveat: std::atomic<std::shared_ptr<>> may serialize on a libstdc++-internal
-    // pool spinlock. If a parent thread was mid remote_.load()/store() at fork(),
-    // the child inherits that lock held-by-a-dead-thread and this store() could
-    // block. reset_after_fork() therefore assumes no in-flight remote_ atomic
-    // access at the fork point (the common fork-then-exec / single-threaded-fork
-    // case) — placement-new would not sidestep this deadlock either (still UB),
-    // and leaving remote_ non-null would wrongly reuse the parent's connection.
-    remote_.store(nullptr, std::memory_order_relaxed);
-    remote_kfd_fd_.store(-1, std::memory_order_relaxed);
-    remote_open_refs_.store(0, std::memory_order_relaxed);
-    new (&init_mutex_) std::mutex();
-    new (&fd_mutex_) std::mutex();
-    new (&drm_fd_lifecycle_mutex_) std::mutex();
-    new (&remote_mutex_) std::mutex();
-    sysfs_fds_.clear();
-    drm_fds_.clear();
-    kfd_dup_fds_.clear();
-    // Drop GEM bookkeeping WITHOUT munmapping cpu_ptr or unmapping PTEs: those host
-    // pages and the parent's page table belong to the parent process and the child
-    // must not touch them. The child re-initializes a fresh driver; any GEM mappings
-    // it needs are re-created via EXPORT/PRIME/GEM_VA. (Deliberate, like the remote_
-    // and mutex handling above — not an oversight.)
-    //
-    // DO close each entry's private dmabuf dup though: it was created with
-    // F_DUPFD_CLOEXEC (closes on exec, NOT on fork), so a fork-without-exec child
-    // inherits these descriptors and clearing the map without closing them leaks a
-    // child-local fd per live GEM handle. The fd is the child's own copy — closing it
-    // touches no parent state. (real().close() is not async-signal-safe, but this runs
-    // under the same fork-then-exec / single-threaded-fork assumption as the remote_
-    // handling above.)
-    for (auto &[handle, gem] : gem_entries_)
-      if (gem.owns_dmabuf_fd && gem.dmabuf_fd >= 0)
-        real().close(gem.dmabuf_fd);
-    gem_entries_.clear();
-    // Also drop the transient EXPORT_DMABUF fd->flags handoffs: they key on the
-    // parent's dmabuf fd numbers, so a child that reuses one of those fd numbers
-    // before a fresh EXPORT could otherwise fold a stale parent MTYPE hint into its
-    // own PRIME import.
-    pending_gem_flags_.clear();
-    in_construction = false;
+  std::shared_ptr<LinuxKfd> driver() const {
+    std::lock_guard lock(publish_mutex_);
+    return active_driver_;
+  }
+  void publish_driver(std::shared_ptr<LinuxKfd> driver) {
+    // Let the displaced driver die AFTER the lock is dropped. If the swap ever drops
+    // the last reference, its deleter runs -- for the guest driver that is engine
+    // exit, thread join and VM destroy -- and publish_mutex_ is the innermost lock,
+    // taken by every reader. Today the callers always keep a second owner alive
+    // across the swap, but that is an invariant of the call sites rather than of
+    // this function, and it is cheaper to not depend on it.
+    std::shared_ptr<LinuxKfd> displaced;
+    {
+      std::lock_guard lock(publish_mutex_);
+      displaced = std::exchange(active_driver_, std::move(driver));
+    }
+  }
+  /// @brief Publish (or clear) the active remote driver.
+  /// @details Caller MUST hold remote_mutex_. That is what makes the compound
+  /// create+open and teardown sequences atomic with respect to every reader that
+  /// takes remote_mutex_; publish_mutex_ alone would only make the pointer swap
+  /// itself safe. Both call sites -- get_or_create_remote() and
+  /// teardown_remote_locked() -- hold it.
+  void publish_remote(std::shared_ptr<RemoteDriver> remote) {
+    std::shared_ptr<RemoteDriver> displaced;
+    {
+      std::lock_guard lock(publish_mutex_);
+      displaced = std::exchange(remote_, std::move(remote));
+    }
+    // Destroyed here, outside publish_mutex_, for the reason publish_driver() gives.
   }
 
-  LinuxKfd *driver() { return active_driver_.load(std::memory_order_acquire); }
   /// @brief True if the active driver is the local SimulatedKfd (not remote/guest).
-  bool driver_is_simulated() { return dynamic_cast<SimulatedKfd *>(driver()) != nullptr; }
+  bool driver_is_simulated() { return dynamic_cast<SimulatedKfd *>(driver().get()) != nullptr; }
+  /// @brief The active local driver's primary fd, or -1 if none.
   int driver_fd() {
-    auto *d = driver();
+    auto d = driver();
     return d ? d->fd() : -1;
   }
-  bool initialized() const {
-    return active_driver_.load(std::memory_order_acquire) != nullptr ||
-           remote_.load(std::memory_order_acquire) != nullptr;
+  bool initialized() const { return driver() != nullptr || remote() != nullptr; }
+
+  /// @brief Record a process-exit shutdown request from the DSO finalizer.
+  /// @details As an LD_PRELOAD library, librocjitsu.so can be finalized before HIP
+  /// and ROCR. If they still hold app-facing KFD descriptors, this request stays
+  /// pending and the VM is kept alive; their later close paths complete it. If the
+  /// simulator is already idle, this tears the VM down now.
+  void request_local_vm_shutdown() {
+    // Declared before the lock so it is destroyed AFTER the lock is dropped; see
+    // DoomedLocalVm.
+    DoomedLocalVm doomed;
+    {
+      std::lock_guard lock(init_mutex_);
+      shutdown_requested_ = true;
+      doomed = shutdown_local_vm_if_idle_locked();
+    }
+  }
+
+  /// @brief Create-if-needed and open the local backend as ONE atomic operation.
+  /// @details Holds init_mutex_ across backend creation, driver->open(), and the fd
+  /// bookkeeping. That is required, not merely tidy: the shutdown decision runs
+  /// under this same lock, so splitting create from open would let the finalizer
+  /// observe the driver at its baseline reference count and retire it in the window
+  /// after get_or_create() returns and before the application's reference exists —
+  /// handing the caller an fd whose backend is already being destroyed. The remote
+  /// path (get_or_create_remote) is combined for the same reason.
+  /// @returns The app-visible fd, or -1 with errno set.
+  struct LocalOpen {
+    int fd = -1;
+    bool clear_dups_needed = false;
+  };
+  LocalOpen open_local() {
+    std::lock_guard lock(init_mutex_);
+    auto drv = get_or_create_locked();
+    if (!drv) {
+      errno = ENODEV;
+      return {};
+    }
+    LocalOpen result;
+    result.fd = drv->open();
+    if (result.fd < 0)
+      return result;
+    if (result.fd != drv->fd())
+      track_open_fd(result.fd);
+    result.clear_dups_needed = !drv->owns_fd(drv->fd());
+    return result;
+  }
+
+  /// @brief Release one app-facing local KFD reference (the close/dup teardown path).
+  /// @details Drops the driver's counted reference and, if a process-exit shutdown
+  /// is pending and the simulator is now idle, tears the VM down — all under
+  /// init_mutex_. The close() and the destroy MUST be in one critical section: the
+  /// active driver is a raw pointer owned by state a concurrent
+  /// request_local_vm_shutdown()/release_local_open() can free, so dropping the
+  /// lock between close() and the idle check would let another thread destroy the
+  /// VM and leave this thread calling into freed memory. init_mutex_ is only ever
+  /// taken by the construction/shutdown paths (never by the engine or ioctl paths),
+  /// so holding it across the driver close() introduces no lock-order inversion.
+  void release_local_open() {
+    // Declared before the lock so it is destroyed AFTER the lock is dropped; see
+    // DoomedLocalVm.
+    DoomedLocalVm doomed;
+    {
+      std::lock_guard lock(init_mutex_);
+      auto active_driver = driver();
+      // Cancel BEFORE the close, not after. This close may be the last app reference,
+      // and the driver's own close() then tears the process down -- after which
+      // begin_local_shutdown() has nothing left to find. A thread parked in
+      // WAIT_EVENTS would be woken by the destructive path with -EBADF instead of the
+      // benign timeout its caller re-polls on, and a thread parked on the debugger
+      // handshake would not be released at all and would hold its driver snapshot for
+      // the whole handshake deadline. Gated on shutdown_requested_, which is only ever
+      // set and never cleared, so an ordinary close is untouched: cancelling early is
+      // sound exactly when the process is already on its way out.
+      if (active_driver && shutdown_requested_)
+        active_driver->begin_local_shutdown();
+      if (active_driver)
+        active_driver->close();
+      if (shutdown_requested_)
+        doomed = shutdown_local_vm_if_idle_locked();
+    }
   }
 
   /// @brief Take a lifetime-extending snapshot of the active remote driver.
   /// @details The returned shared_ptr keeps the RemoteDriver alive for as long as
   /// the caller holds it, even if a concurrent teardown_remote() clears remote_.
-  std::shared_ptr<RemoteDriver> remote() { return remote_.load(std::memory_order_acquire); }
+  std::shared_ptr<RemoteDriver> remote() const {
+    std::lock_guard lock(publish_mutex_);
+    return remote_;
+  }
 
   int remote_kfd_fd() const { return remote_kfd_fd_.load(std::memory_order_acquire); }
 
   std::shared_ptr<RemoteDriver> remote_lookup(int fd) {
-    auto active_remote = remote_.load(std::memory_order_acquire);
+    auto active_remote = remote();
     return (fd >= 0 && fd == remote_kfd_fd_.load(std::memory_order_acquire) && active_remote)
                ? active_remote
                : nullptr;
@@ -460,11 +537,13 @@ public:
   /// @brief The per-invocation runtime directory for this process image.
   /// @details Populated once in init() before any thread or app fork, so this is
   /// a lock-free immutable read. A forked app child inherits the parent's value
-  /// (reset_after_fork() intentionally does not clear it) and thus reconnects to
+  /// (the child never mutates it) and thus would reconnect to
   /// the same daemon rather than recomputing a dir under its own PID.
   const std::string &invocation_runtime_dir() const { return invocation_runtime_dir_; }
 
   bool owned_by_current_process() const { return owner_pid_ == getpid(); }
+  /// @brief st_rdev of the host's real KFD, or 0 when the host has none.
+  [[nodiscard]] dev_t host_kfd_rdev() const { return host_kfd_rdev_; }
 
   // No lock needed: the snapshot keeps the RemoteDriver alive, and its handshake
   // metadata (topology/drm paths, gpu_info) is immutable after open() — close()
@@ -473,7 +552,7 @@ public:
   // remote() snapshot and read both from it (see redirect_sysfs_path), so the two
   // paths can't come from different RemoteDrivers across a teardown/reconnect.
   std::string remote_drm_path() {
-    auto active_remote = remote_.load(std::memory_order_acquire);
+    auto active_remote = remote();
     return active_remote ? std::string(active_remote->drm_path()) : std::string{};
   }
 
@@ -481,11 +560,12 @@ public:
   /// @details Combined check-and-retain under remote_mutex_ so a concurrent
   /// last-release+teardown cannot slip between "is a remote live?" and the
   /// increment and resurrect a torn-down connection. Returns true if a reference
-  /// was added (i.e. a remote is active). Mirrors the local path, which does the
-  /// same check-and-retain under process_mutex_.
+  /// was added (i.e. a remote is active). Mirrors the local path, where
+  /// reserve_dup_backend() runs the classify+retain under init_mutex_, so a
+  /// concurrent teardown cannot interleave with it.
   bool retain_remote_open_if_active() {
     std::lock_guard lock(remote_mutex_);
-    if (!remote_.load(std::memory_order_acquire))
+    if (!remote())
       return false;
     remote_open_refs_.fetch_add(1, std::memory_order_acq_rel);
     return true;
@@ -536,7 +616,7 @@ public:
 
   RemoteOpenResult get_or_create_remote() {
     std::lock_guard lock(remote_mutex_);
-    auto active_remote = remote_.load(std::memory_order_acquire);
+    auto active_remote = remote();
     if (active_remote) {
       // The connection is already live: retain a reference and reuse it. Never
       // re-open() a live RemoteDriver — that would re-handshake and leak a fresh
@@ -583,22 +663,25 @@ public:
     remote_kfd_fd_.store(fd, std::memory_order_release);
     // The primary remote KFD fd holds the first open reference.
     remote_open_refs_.store(1, std::memory_order_release);
-    remote_.store(active_remote, std::memory_order_release);
+    publish_remote(active_remote);
     return {active_remote, fd};
   }
 
-  LinuxKfd *lookup(int fd) {
-    auto *d = driver();
+  /// @brief The active local driver if @p fd is its primary fd, else null.
+  /// @details Returns a snapshot, so the caller's dereference is lifetime-safe on
+  /// its own — no separate guard to remember.
+  std::shared_ptr<LinuxKfd> lookup(int fd) {
+    auto d = driver();
     return (d && fd >= 0 && fd == d->fd()) ? d : nullptr;
   }
 
   bool owns_fd(int fd) {
-    auto *d = driver();
+    auto d = driver();
     return d && d->owns_fd(fd);
   }
 
   std::string redirect(const char *path) {
-    auto *d = driver();
+    auto d = driver();
     return d ? d->redirect_sysfs_path(path) : std::string{};
   }
 
@@ -621,11 +704,11 @@ public:
     // teardown/reconnect between the two reads cannot combine a topology path from
     // one RemoteDriver with a drm path from another (or an empty one). The
     // metadata is immutable-after-open, so a single live snapshot is consistent.
-    if (auto remote = remote_.load(std::memory_order_acquire)) {
-      std::string remote_topology(remote->topology_path());
+    if (auto active_remote = remote()) {
+      std::string remote_topology(active_remote->topology_path());
       if (!remote_topology.empty()) {
         std::string redirected = LinuxKfd::redirect_sysfs_root_path(
-            path, remote_topology, std::string(remote->drm_path()));
+            path, remote_topology, std::string(active_remote->drm_path()));
         if (!redirected.empty())
           return redirected;
       }
@@ -642,8 +725,6 @@ public:
     std::lock_guard lock(fd_mutex_);
     return kfd_dup_fds_.count(fd) != 0;
   }
-
-  bool is_kfd_tracked(int fd) { return is_kfd_primary(fd) || is_kfd_dup(fd); }
 
   void track_open_fd(int fd) {
     if (fd < 0 || is_kfd_primary(fd))
@@ -680,12 +761,14 @@ public:
   /// @brief Retain one open reference on a specific backend.
   /// @returns true if a reference was acquired; false if that backend is no
   /// longer active (local VM gone, or remote torn down). Mirrors release_backend.
+  /// @details The Local branch dereferences the driver; the caller
+  /// (reserve_dup_backend) runs under init_mutex_ across this call, so a
+  /// concurrent teardown cannot free the driver between the load and
+  /// retain_local_open(). retain_local_open() reports false if the local process
+  /// was already torn down (a racing last-close).
   bool retain_backend(DupBackend backend) {
     if (backend == DupBackend::Local) {
-      auto *d = driver();
-      // retain_local_open() reports false if the local process was already torn
-      // down (a racing last-close), so a dup of a dying local fd is not falsely
-      // treated as retained.
+      auto d = driver();
       return d && d->retain_local_open();
     }
     return retain_remote_open_if_active();
@@ -697,8 +780,7 @@ public:
   /// remote reference is live, so a release that races a teardown is harmless.
   void release_backend(DupBackend backend) {
     if (backend == DupBackend::Local) {
-      if (auto *d = driver())
-        d->close();
+      release_local_open();
     } else {
       release_remote_open();
     }
@@ -719,6 +801,24 @@ public:
   /// MUST consume the reservation exactly once: commit_dup() on syscall success,
   /// or release_backend() on syscall failure.
   [[nodiscard]] std::optional<DupBackend> reserve_dup_backend(int src_fd) {
+    // Classify once WITHOUT init_mutex_ first, purely to get out of the way. Every
+    // dup/dup2/dup3/fcntl(F_DUPFD*) in the process reaches here, on any descriptor,
+    // and init_mutex_ is held for the whole of VM bring-up and teardown -- so taking
+    // it unconditionally would queue an unrelated socket dup behind a simulator
+    // lifecycle, while that dup holds drm_fd_lifecycle_mutex_ and thereby blocks
+    // every close() too. kfd_backend_of() is safe to call unlocked: it snapshots the
+    // driver internally and takes only the fd table's own lock.
+    if (!kfd_backend_of(src_fd))
+      return std::nullopt;
+
+    // Now the authoritative classify+retain, under init_mutex_ -- the SAME lock
+    // shutdown_local_vm_if_idle_locked() makes its idle decision under. That mutual
+    // exclusion is what removes the retain-vs-teardown race at the root: this either
+    // completes first (and teardown's idle check observes the new reference) or runs
+    // after teardown unpublished (and finds no driver, failing closed). Neither side
+    // needs to re-check the other or undo anything. The unlocked probe above is only
+    // a filter; it is deliberately re-done here rather than trusted.
+    std::lock_guard lock(init_mutex_);
     auto backend = kfd_backend_of(src_fd);
     if (!backend)
       return std::nullopt;
@@ -730,7 +830,15 @@ public:
   /// @brief Record a dup fd whose backend reference was already reserved via
   /// reserve_dup_backend(). Consumes exactly that one reserved reference.
   void commit_dup(int fd, DupBackend backend) {
-    if (fd < 0 || is_kfd_primary(fd)) {
+    // Classify first, then release_backend(): the classification only reads the
+    // driver, while release_backend() may drop the last reference and free it.
+    bool aliases_primary = false;
+    if (fd < 0) {
+      aliases_primary = true;
+    } else {
+      aliases_primary = is_kfd_primary(fd);
+    }
+    if (aliases_primary) {
       // Cannot track this as a dup (invalid, or the number aliases a primary).
       // Release the reserved reference to stay balanced.
       release_backend(backend);
@@ -796,16 +904,22 @@ public:
     //     internal and NOT counted in the open-reference bookkeeping (e.g.
     //     GuestKfd's hidden real fd, kept alive by app dups) — do NOT close();
     //   - kNotPrimary: fall through to dup tracking.
-    if (auto *d = driver()) {
-      switch (d->invalidate_primary_fd(fd)) {
-      case LinuxKfd::PrimaryInvalidation::kClearedDropRef:
-        d->close(); // drop the primary open reference
-        return;
-      case LinuxKfd::PrimaryInvalidation::kClearedKeepRefs:
-        return; // classification cleared; no counted reference to drop
-      case LinuxKfd::PrimaryInvalidation::kNotPrimary:
-        break; // fall through to dup handling
-      }
+    // The driver snapshot keeps the object alive across invalidate_primary_fd();
+    // it is released before release_local_open() only so the object can actually be
+    // freed there when this was the last reference.
+    LinuxKfd::PrimaryInvalidation invalidation = LinuxKfd::PrimaryInvalidation::kNotPrimary;
+    {
+      if (auto d = driver())
+        invalidation = d->invalidate_primary_fd(fd);
+    }
+    switch (invalidation) {
+    case LinuxKfd::PrimaryInvalidation::kClearedDropRef:
+      release_local_open(); // drop the primary open reference
+      return;
+    case LinuxKfd::PrimaryInvalidation::kClearedKeepRefs:
+      return; // classification cleared; no counted reference to drop
+    case LinuxKfd::PrimaryInvalidation::kNotPrimary:
+      break; // fall through to dup handling
     }
     // Otherwise, a tracked dup (or nothing).
     untrack_dup(fd);
@@ -871,14 +985,14 @@ public:
   /// @returns The extracted RemoteDriver so the caller can run the (blocking)
   /// RPC_CLOSE shutdown OUTSIDE remote_mutex_; the shared_ptr keeps it alive.
   [[nodiscard]] std::shared_ptr<RemoteDriver> teardown_remote_locked() {
-    auto active_remote = remote_.load(std::memory_order_acquire);
+    auto active_remote = remote();
     if (!active_remote)
       return nullptr;
     // Clear the published pointer first so no new reader can pick this driver up.
     // The RemoteDriver is destroyed by the last shared_ptr: if a racing reader
     // still holds a snapshot mid-ioctl/mmap, destruction (and socket close in
     // ~RemoteDriver) is deferred until it releases, so there is no use-after-free.
-    remote_.store(nullptr, std::memory_order_release);
+    publish_remote(nullptr);
     // Reset the refcount to 0 under the lock. A concurrent
     // retain_remote_open_if_active() serializes on remote_mutex_ and, seeing
     // remote_ == nullptr, refuses to add a reference, so it cannot resurrect this
@@ -923,9 +1037,111 @@ public:
     uint64_t signaled_point = 0;
   };
 
+  /// @brief Move-only operational reference to the backend serving a DRM file.
+  /// @details Distinct from a plain shared_ptr, which only prevents deallocation:
+  /// a GuestKfd whose last KFD reference is dropped clears readiness and its
+  /// synthetic mappings while the object still exists, and a RemoteDriver's RPC
+  /// connection is closed on its last reference. A DRM file outlives neither, so it
+  /// holds an actual open reference for its whole life. Releasing a LOCAL lease
+  /// routes through release_local_open(), the same path a KFD close takes, which is
+  /// what lets a final DRM close complete a pending process-exit shutdown.
+  class DrmBackendLease {
+  public:
+    DrmBackendLease() : context_(nullptr) {}
+    DrmBackendLease(InterposerContext *context, std::shared_ptr<LinuxKfd> local)
+        : context_(context), local_(std::move(local)) {}
+    DrmBackendLease(InterposerContext *context, std::shared_ptr<RemoteDriver> remote)
+        : context_(context), remote_(std::move(remote)) {}
+
+    DrmBackendLease(DrmBackendLease &&other) noexcept : context_(nullptr) {
+      *this = std::move(other);
+    }
+    DrmBackendLease &operator=(DrmBackendLease &&other) noexcept {
+      if (this != &other) {
+        release();
+        context_ = std::exchange(other.context_, nullptr);
+        local_ = std::move(other.local_);
+        other.local_.reset();
+        remote_ = std::move(other.remote_);
+        other.remote_.reset();
+      }
+      return *this;
+    }
+    DrmBackendLease(const DrmBackendLease &) = delete;
+    DrmBackendLease &operator=(const DrmBackendLease &) = delete;
+    ~DrmBackendLease() { release(); }
+
+    /// @brief The leased local driver, or null when this lease is remote/absent.
+    /// @details This is the file's ROUTING AUTHORITY, not merely a lifetime pin.
+    /// The lease is an OPERATIONAL reference -- it keeps the backend open, not just
+    /// allocated -- and it is fixed for the file's whole life. Routing through it
+    /// means a file's GEM/VM work always reaches the backend that owns its page
+    /// table, decided once at creation, instead of being re-derived on each call
+    /// from a published pointer that teardown can change underneath it.
+    [[nodiscard]] const std::shared_ptr<LinuxKfd> &local() const { return local_; }
+    /// @brief The leased remote driver, or null when this lease is local/absent.
+    [[nodiscard]] const std::shared_ptr<RemoteDriver> &remote() const { return remote_; }
+    [[nodiscard]] bool is_remote() const { return remote_ != nullptr; }
+    explicit operator bool() const { return local_ != nullptr || remote_ != nullptr; }
+
+    /// @brief Drop the reference. MUST NOT run with an interposer lock held: the
+    /// local path takes init_mutex_ and can complete a pending teardown.
+    void release() {
+      if (!context_)
+        return;
+      auto *context = std::exchange(context_, nullptr);
+      const bool was_remote = remote_ != nullptr;
+      local_.reset();
+      remote_.reset();
+      if (was_remote)
+        context->release_remote_open();
+      else
+        context->release_local_open();
+    }
+
+  private:
+    InterposerContext *context_;
+    std::shared_ptr<LinuxKfd> local_;
+    std::shared_ptr<RemoteDriver> remote_;
+  };
+
+  /// @brief Take an operational lease on whichever backend serves @p render_minor.
+  /// @details The retain and the shutdown decision both run under init_mutex_ (local)
+  /// or remote_mutex_ (remote), so a finalizer cannot retire the backend between the
+  /// "who handles this node?" question and the reference that answers it.
+  /// @returns An engaged lease, or a disengaged one if no backend can serve it.
+  DrmBackendLease acquire_drm_backend_lease(uint32_t render_minor) {
+    {
+      std::lock_guard lock(init_mutex_);
+      auto drv = driver();
+      if (drv && drv->handles_drm_render_minor(render_minor) && drv->retain_local_open())
+        return DrmBackendLease(this, std::move(drv));
+    }
+    {
+      std::lock_guard lock(remote_mutex_);
+      // Through the accessor, not the field: publish_mutex_ is the innermost lock
+      // and every other reader goes this way, so a raw read here would be the one
+      // access a reviewer has to re-derive the safety of.
+      if (auto active_remote = remote()) {
+        remote_open_refs_.fetch_add(1, std::memory_order_acq_rel);
+        return DrmBackendLease(this, std::move(active_remote));
+      }
+    }
+    return {};
+  }
+
   struct DrmFileState {
     uint64_t id = 0;
     uint32_t render_minor = 128;
+    /// @brief Operational reference to the backend this DRM file belongs to.
+    /// @details A synthetic render fd owns GEM mappings whose teardown
+    /// (reap_gem_for_drm_file -> gem_va_unmap) must reach the driver that installed
+    /// the page-table entries, and DRM ioctls served from this file need that
+    /// backend to still be OPEN, not merely allocated. The lease therefore holds a
+    /// real open reference -- the SAME one a KFD descriptor holds -- so DRM files
+    /// and KFD fds are counted by one mechanism and the shutdown policy needs no
+    /// DRM-specific bookkeeping.
+    DrmBackendLease backend_lease;
     // Guarded by InterposerContext::fd_mutex_. Reservations and tracked fds both
     // contribute one reference, so the state and its namespaces remain live while
     // an ioctl or duplication operation holds a token.
@@ -945,47 +1161,104 @@ public:
   /// @details The lock may cover only metadata operations and calls through the
   /// real-libc passthrough table. Backend teardown, RPC, GEM cleanup, and any
   /// interposed libc entry point must run after this lock is released.
+  ///
+  /// LOCK ORDER: init_mutex_ must NEVER be acquired while this lock is held. The
+  /// reverse edge exists and cannot be removed -- driver code runs under init_mutex_
+  /// (open_local, release_local_open) and can reach the interposed close() hook,
+  /// which takes this lock for every descriptor -- so acquiring them in this order
+  /// anywhere would close an ABBA cycle between a dup and a close. That is why the
+  /// dup paths reserve their backend, which takes init_mutex_, BEFORE this scope.
   std::unique_lock<std::mutex> lock_drm_fd_lifecycle() {
     return std::unique_lock(drm_fd_lifecycle_mutex_);
   }
 
-  struct DrmUntrackResult {
-    bool tracked = false;
-    std::optional<uint64_t> closed_file_id;
+  /// @brief What a final DRM-file release still owes, handed back to the caller.
+  /// @details The GEM entries must be reaped while the backend is STILL open, and
+  /// the lease must then be released with no interposer lock held (its local path
+  /// takes init_mutex_ and can complete a pending teardown). Returning both makes
+  /// that order structural instead of something each of the four release sites has
+  /// to reproduce: reap `file_id`, then let `lease` destruct.
+  struct DrmFinalRelease {
+    std::optional<uint64_t> file_id;
+    DrmBackendLease lease;
   };
 
   /// @brief Drop one fd or reservation reference while fd_mutex_ is held.
-  /// @returns The DRM-file identity when the final reference was removed.
-  std::optional<uint64_t> release_drm_file_locked(const DrmFileToken &state) {
+  /// @returns The identity and lease of the file when its final reference went.
+  [[nodiscard]] DrmFinalRelease release_drm_file_locked(const DrmFileToken &state) {
     if (!state)
-      return std::nullopt;
+      return {};
     if (state->open_fds == 0) {
       util::Logger::warn("DRM file refcount underflow, id=", state->id);
-      return std::nullopt;
+      return {};
     }
     --state->open_fds;
-    return state->open_fds == 0 ? std::optional(state->id) : std::nullopt;
+    if (state->open_fds != 0)
+      return {};
+    return {state->id, std::move(state->backend_lease)};
+  }
+
+  struct DrmUntrackResult {
+    bool tracked = false;
+    DrmFinalRelease release;
+  };
+
+  /// @brief Finish a final DRM release: reap GEM, then drop the backend lease.
+  /// @details Must run with NO interposer lock held.
+  void complete_drm_release(DrmFinalRelease release) {
+    if (release.file_id)
+      reap_gem_for_drm_file(*release.file_id);
+    // release.lease destructs here, dropping the open reference. For a local
+    // backend that routes through release_local_open(), which completes a pending
+    // process-exit shutdown exactly as the last KFD close would.
   }
 
   /// @brief Track a newly opened synthetic DRM fd.
   /// @returns The identity of a stale displaced DRM file whose final reference
   /// was removed, if any. The caller reaps it after releasing the lifecycle lock.
-  [[nodiscard]] std::optional<uint64_t> track_drm(int fd, uint32_t render_minor = 128) {
+  /// @param lease Taken by reference and moved in LAST, after every operation that can
+  /// throw. Owning it here across an allocation failure would destroy it during the
+  /// unwind -- while the CALLER still holds the fd-lifecycle lock, since callee objects
+  /// die first -- and releasing a lease reaches release_local_open() and so init_mutex_,
+  /// which is the one order lock_drm_fd_lifecycle() forbids. Leaving it with the caller
+  /// means a failure releases it at the caller's scope exit, after that lock is gone.
+  [[nodiscard]] DrmFinalRelease track_drm(int fd, uint32_t render_minor, DrmBackendLease &lease) {
     auto state = std::make_shared<DrmFileState>();
     state->render_minor = render_minor;
     state->open_fds = 1;
-    std::optional<uint64_t> closed_file_id;
+    DrmFinalRelease displaced;
     {
       std::lock_guard lock(fd_mutex_);
       state->id = next_drm_file_id_++;
       if (auto stale = drm_fds_.find(fd); stale != drm_fds_.end()) {
-        closed_file_id = release_drm_file_locked(stale->second);
+        displaced = release_drm_file_locked(stale->second);
+        state->backend_lease = std::move(lease); // noexcept, after the throwing work
         stale->second = std::move(state);
       } else {
-        drm_fds_.emplace(fd, std::move(state));
+        auto [it, inserted] = drm_fds_.emplace(fd, state); // may throw; lease not ours yet
+        static_cast<void>(inserted);
+        it->second->backend_lease = std::move(lease);
       }
     }
-    return closed_file_id;
+    return displaced;
+  }
+
+  /// @brief True if @p file's leased backend is a local SimulatedKfd.
+  /// @details Routing question, so it consults the FILE's immutable lease rather
+  /// than the mutable published driver. GEM/VM work belongs to the page table of the
+  /// backend that owns the file.
+  bool drm_file_is_simulated(const DrmFileToken &file) {
+    if (!file)
+      return false;
+    const auto &local = file->backend_lease.local();
+    return dynamic_cast<SimulatedKfd *>(local.get()) != nullptr;
+  }
+
+  /// @brief The SimulatedKfd serving @p file, or null.
+  SimulatedKfd *drm_file_simulated(const DrmFileToken &file) {
+    if (!file)
+      return nullptr;
+    return dynamic_cast<SimulatedKfd *>(file->backend_lease.local().get());
   }
 
   /// @brief Pin the DRM file currently tracked at @p fd.
@@ -1007,13 +1280,15 @@ public:
   void release_drm_file_reservation(const DrmFileToken &state) {
     if (!state)
       return;
-    std::optional<uint64_t> closed_file_id;
+    DrmFinalRelease release;
     {
       std::lock_guard lock(fd_mutex_);
-      closed_file_id = release_drm_file_locked(state);
+      release = release_drm_file_locked(state);
     }
-    if (closed_file_id)
-      reap_gem_for_drm_file(*closed_file_id);
+    // A reservation CAN be the final reference (a racing close dropped the fd's own
+    // reference first), so this must run the same completion as close(): reap, then
+    // drop the lease, which re-evaluates a pending shutdown.
+    complete_drm_release(std::move(release));
   }
 
   /// @brief Scoped ioctl reservation that preserves the ioctl's final errno.
@@ -1053,10 +1328,10 @@ public:
   /// @returns The identity of a displaced DRM file whose final reference was
   /// removed, if any. The caller performs GEM cleanup after releasing the
   /// lifecycle lock.
-  [[nodiscard]] std::optional<uint64_t> commit_drm_dup(int fd, const DrmFileToken &state) {
+  [[nodiscard]] DrmFinalRelease commit_drm_dup(int fd, const DrmFileToken &state) {
     if (fd < 0)
-      return std::nullopt;
-    std::optional<uint64_t> closed_file_id;
+      return {};
+    DrmFinalRelease displaced_release;
     {
       std::lock_guard lock(fd_mutex_);
       if (auto stale = drm_fds_.find(fd); stale != drm_fds_.end()) {
@@ -1065,12 +1340,12 @@ public:
           stale->second = state;
         else
           drm_fds_.erase(stale);
-        closed_file_id = release_drm_file_locked(displaced);
+        displaced_release = release_drm_file_locked(displaced);
       } else if (state) {
         drm_fds_.emplace(fd, state);
       }
     }
-    return closed_file_id;
+    return displaced_release;
   }
 
   bool is_drm(int fd) {
@@ -1096,7 +1371,7 @@ public:
       return {};
     auto state = std::move(it->second);
     drm_fds_.erase(it);
-    return {.tracked = true, .closed_file_id = release_drm_file_locked(state)};
+    return {.tracked = true, .release = release_drm_file_locked(state)};
   }
 
   /// @brief Allocate a syncobj handle in @p file's private namespace.
@@ -1301,34 +1576,150 @@ public:
       util::Logger::debug_print("rocjitsu: failed to create VM from ", config_path);
       return false;
     }
-    rj_vm_ = created_vm;
-    if (!rj_vm_->vm || !rj_vm_->vm->driver() || rj_vm_->vm->driver()->fd() < 0) {
+    // The deleter IS the teardown sequence: stop the engine, join its thread, free
+    // the VM. Nothing else may destroy a VM, so the order cannot be got wrong at a
+    // call site and cannot be skipped on an unwind path. It runs when the last
+    // reference goes away — which is why it must never run ON the engine thread
+    // (it would join itself); the engine never takes a driver snapshot, and
+    // assert_not_engine_thread() enforces that.
+    local_vm_ = std::shared_ptr<rj_vm_t>(created_vm, [this, owner = getpid()](rj_vm_t *vm) {
+      if (!vm)
+        return;
+      if (getpid() != owner) {
+        // A forked child inherited this reference. The engine thread does not exist
+        // here, so joining it would hang, and the VM belongs to the parent, so
+        // destroying it would free state the parent still owns. Abandon it.
+        //
+        // A child never reaches this deleter under the fork-then-exec contract
+        // (owner_pid_ gates every entry point), but the guard is kept because the
+        // cost is one comparison and the failure mode -- a child joining a thread
+        // that does not exist -- is an unrecoverable hang.
+        return;
+      }
+      assert_not_engine_thread();
+      if (local_vm_thread_) {
+        rj_vm_request_exit(vm, "interposer VM destruction");
+        local_vm_thread_->join();
+        local_vm_thread_.reset();
+      }
+      rj_vm_destroy(vm);
+    });
+    // soc is validated alongside vm because rj_vm_run() rejects a null soc BEFORE
+    // entering engine->run(); catching it here fails the open with ENODEV instead
+    // of relying on the engine thread's readiness backstop.
+    if (!local_vm_->vm || !local_vm_->soc || !local_vm_->vm->driver() ||
+        local_vm_->vm->driver()->fd() < 0) {
       util::Logger::debug_print("rocjitsu: local VM did not acquire a KFD open");
-      rj_vm_destroy(rj_vm_);
-      rj_vm_ = nullptr;
+      local_vm_.reset();
       return false;
     }
 
     std::string config_json = read_file_passthrough(config_path.c_str());
-    if (rj_vm_load_plugins(rj_vm_, config_json.c_str(), nullptr) != ROCJITSU_STATUS_SUCCESS) {
+    if (rj_vm_load_plugins(local_vm_.get(), config_json.c_str(), nullptr) !=
+        ROCJITSU_STATUS_SUCCESS) {
       util::Logger::debug_print("rocjitsu: failed to configure execution plugins");
-      rj_vm_destroy(rj_vm_);
-      rj_vm_ = nullptr;
+      local_vm_.reset();
       return false;
     }
     return true;
   }
 
-  void destroy_local_vm() {
-    if (!rj_vm_)
-      return;
-    rj_vm_destroy(rj_vm_);
-    rj_vm_ = nullptr;
+  /// @brief Abort if called on the local VM engine thread.
+  /// @details The VM deleter joins that thread, so running it there would deadlock
+  /// on self-join. This holds because the engine never takes a driver snapshot; the
+  /// assert is what keeps it true as the engine grows.
+  void assert_not_engine_thread() const {
+    assert((!local_vm_thread_ || local_vm_thread_->get_id() != std::this_thread::get_id()) &&
+           "local VM teardown must not run on the engine thread (its deleter joins it)");
   }
 
-  void start_local_vm() {
-    assert(rj_vm_ != nullptr);
-    std::thread([vm = rj_vm_]() { rj_vm_run(vm, nullptr); }).detach();
+  /// @brief Publish a fully-ready local driver. Caller holds init_mutex_.
+  /// @details The sole site that stores a non-null active_driver_. Only call after
+  /// the engine has started successfully (see get_or_create) so no reader can
+  /// observe a half-started device.
+  void publish_local_driver_locked(std::shared_ptr<LinuxKfd> driver) {
+    // Capture the driver's own internal references (the local VM's bootstrap open
+    // for SimulatedKfd; none for GuestKfd) as the "idle" watermark. Nothing
+    // app-facing can exist yet: the driver is not published, so no interposed path
+    // can have reached it. See local_driver_is_idle_locked().
+    local_open_ref_baseline_ = driver ? driver->local_open_ref_count() : 0;
+    publish_driver(std::move(driver));
+  }
+
+  /// @brief The published SimulatedKfd as an ALIASING snapshot on local_vm_.
+  /// @details Shares the VM's control block while pointing at the driver the VM
+  /// owns by unique_ptr, so the driver is kept alive by, and cannot outlive, its
+  /// VM — without VirtualMachine having to change its ownership at all.
+  std::shared_ptr<LinuxKfd> simulated_driver_alias() const {
+    return std::shared_ptr<LinuxKfd>(local_vm_, local_vm_->vm->driver());
+  }
+
+  /// @brief The owners a local-VM teardown drops, moved out so they can be destroyed
+  /// OUTSIDE init_mutex_.
+  /// @details Their destruction runs the deleters: the guest's first, because it
+  /// captures local_vm_, then the VM's engine stop/join/destroy. None of that may
+  /// happen under init_mutex_, which the fd paths wait on. Ordering does not come
+  /// from the declaration order of these members -- it comes from the guest deleter
+  /// holding its own reference to the VM.
+  struct DoomedLocalVm {
+    std::shared_ptr<GuestKfd> guest;
+    std::shared_ptr<rj_vm_t> vm;
+  };
+
+  /// @brief Release the interposer's own references to the local backend.
+  /// @details Caller holds init_mutex_. This does NOT free anything directly: it
+  /// unpublishes and drops our references, and whoever holds the last one runs the
+  /// deleters (guest first, because its deleter captures local_vm_, then the VM's
+  /// engine stop/join/destroy). A reader still inside a call keeps its snapshot
+  /// alive and frees on its way out, so there is no window in which an in-flight
+  /// dereference can touch freed state.
+  void destroy_local_vm() {
+    publish_driver(nullptr);
+    guest_driver_.reset();
+    local_vm_.reset();
+  }
+
+  /// @brief Launch the local VM engine on an owned (joinable) thread and wait for
+  /// component startup to complete before returning.
+  /// @returns false if the engine thread could not be created OR a component's
+  /// startup() failed (caller unwinds).
+  /// @details The thread is owned (not detached) so process teardown can join it
+  /// before destroying VM/driver state it reaches. wait_until_started() closes the
+  /// window where a short-lived caller could publish and then tear down a device
+  /// whose components are still in startup() — the race that faulted the engine in
+  /// CommandProcessor::startup() against C++ finalizers. If startup() threw, the
+  /// engine already returned an error and stopped, so join the thread and report
+  /// failure rather than leaving a published-but-dead device.
+  [[nodiscard]] bool start_local_vm() {
+    assert(local_vm_ != nullptr);
+    assert(!local_vm_thread_);
+    try {
+      // make_unique/std::thread can throw system_error (resource exhaustion) or
+      // bad_alloc; treat any failure to launch as a start failure so the caller
+      // unwinds and never publishes a device with no engine behind it.
+      // Latch readiness from the THREAD, not just from inside engine->run(): the
+      // wait below happens under init_mutex_, so any rj_vm_run() path that returns
+      // without reaching run() (e.g. its own argument validation) would otherwise
+      // strand this wait forever AND hold init_mutex_ forever — deadlocking every
+      // later interposed open/close and the DSO finalizer itself. The engine's own
+      // in-band latch wins; this only fires if nothing latched.
+      local_vm_thread_ = std::make_unique<std::thread>([vm = local_vm_.get()]() {
+        rj_vm_run(vm, nullptr);
+        vm->engine->latch_startup_if_unlatched(/*failed=*/true);
+      });
+    } catch (const std::exception &e) {
+      util::Logger::debug_print("rocjitsu: failed to start local VM engine thread: ", e.what());
+      return false;
+    }
+    if (!local_vm_->engine->wait_until_started()) {
+      // A component's startup() threw; the engine thread already returned. Join it
+      // so the caller can safely destroy the VM on the unwind path.
+      local_vm_thread_->join();
+      local_vm_thread_.reset();
+      util::Logger::debug_print("rocjitsu: local VM engine failed during component startup");
+      return false;
+    }
+    return true;
   }
 
   /// @brief A GEM buffer object synthesized from a prime (dmabuf) fd.
@@ -1356,8 +1747,9 @@ public:
   /// (e.g. a remote/DBT-guest backend is active, or — in a forked child — before the
   /// driver is recreated), so teardown unmaps through `owner` only while it is still
   /// the active driver, and skips the unmap otherwise (that page table is gone).
-  /// The local driver is a process-lifetime singleton (see get_or_create), so
-  /// `owner` never points at a freed-and-replaced driver.
+  /// The local driver is created at most once per process and is never recreated
+  /// after a shutdown request (see get_or_create), so `owner` can never come to
+  /// point at a DIFFERENT driver that reused the address.
   struct GemMapping {
     uint64_t va_address = 0;
     uint64_t map_size = 0;
@@ -1478,7 +1870,7 @@ public:
     auto timeline = lookup_syncobj_locked(file, timeline_handle);
     if (timeline_handle != 0 && !timeline)
       return -ENOENT;
-    auto *drv = dynamic_cast<SimulatedKfd *>(driver());
+    auto *drv = drm_file_simulated(file);
     if (!drv)
       return -ENODEV;
     auto it = gem_entries_.find(handle);
@@ -1524,10 +1916,10 @@ public:
     // Record which SimulatedKfd's page table receives these PTEs so GEM_CLOSE (or a
     // DRM-file-close reap) unmaps through the driver that installed them, never a
     // replacement one. Set the owner on the first mapping and keep it: all ranges of
-    // one BO install into the same driver's page table. The local driver is a
-    // process-lifetime singleton (created once, never destroyed except in the fork
-    // child, which also clears gem_entries_), so the owner never dangles and every
-    // subsequent map observes the same driver.
+    // one BO install into the same driver's page table. The local driver is created
+    // at most once per process and never recreated after a shutdown request,
+    // so the owner can never come to name a different driver; teardown additionally
+    // compares it against the live driver before unmapping.
     if (gem.installed_vas.empty())
       gem.owner = drv;
     else
@@ -1566,7 +1958,7 @@ public:
     auto timeline = lookup_syncobj_locked(file, timeline_handle);
     if (timeline_handle != 0 && !timeline)
       return -ENOENT;
-    auto *drv = dynamic_cast<SimulatedKfd *>(driver());
+    auto *drv = drm_file_simulated(file);
     if (!drv)
       return -ENODEV;
     auto it = gem_entries_.find(handle);
@@ -1606,7 +1998,7 @@ public:
     auto timeline = lookup_syncobj_locked(file, timeline_handle);
     if (timeline_handle != 0 && !timeline)
       return -ENOENT;
-    auto *drv = dynamic_cast<SimulatedKfd *>(driver());
+    auto *drv = drm_file_simulated(file);
     if (!drv)
       return -ENODEV;
     if (!evict_range_locked(drv, file->id, GemMapping{va_address, map_size},
@@ -1655,10 +2047,28 @@ public:
     return 0;
   }
 
-  LinuxKfd *get_or_create() {
+  std::shared_ptr<LinuxKfd> get_or_create() {
     std::lock_guard lock(init_mutex_);
-    if (active_driver_.load(std::memory_order_acquire) == nullptr) {
-      in_construction = true;
+    return get_or_create_locked();
+  }
+
+  /// @brief get_or_create() with init_mutex_ already held by the caller.
+  /// @details Split out so open_local() can hold one lock across creation AND the
+  /// application's open(), which is what keeps the shutdown policy from retiring a
+  /// backend in between.
+  std::shared_ptr<LinuxKfd> get_or_create_locked() {
+    if (driver() == nullptr) {
+      // Fail closed once process-exit shutdown has been requested: the local VM is
+      // a one-shot per process. Recreating it after the finalizer ran would start
+      // an engine no later close would ever retire (the DSO finalizer fires once),
+      // reintroducing the live-engine-at-teardown condition this change removes —
+      // and would leave stale generation-bound state (e.g. GemEntry::owner) from
+      // the destroyed VM. A late sysfs/DRM probe therefore gets no local driver.
+      if (shutdown_requested_) {
+        util::Logger::debug_print("rocjitsu: local VM creation refused after shutdown request");
+        return nullptr;
+      }
+      ConstructionScope construction_scope;
       // Config-path discovery mirrors load_dbt_guest_config_from_runtime_config()'s
       // reader precedence exactly, probing tiers in order and using the first whose
       // config_path handoff actually exists:
@@ -1690,7 +2100,6 @@ public:
       }
       if (!handoff) {
         util::Logger::debug_print("rocjitsu: no child config path");
-        in_construction = false;
         return nullptr;
       }
 
@@ -1704,34 +2113,42 @@ public:
             const std::string host_config_path = rocjitsu::config::resolve_dbt_host_config_path(
                 handoff->config_path, dbt_guest.host.simulator_config_path);
             if (!create_local_vm(host_config_path)) {
-              in_construction = false;
               return nullptr;
             }
-            execution_driver = rj_vm_->vm->driver();
+            execution_driver = local_vm_->vm->driver();
             rocjitsu::config::validate_dbt_simulator_device_limits(dbt_guest,
-                                                                   rj_vm_->loaded.device);
+                                                                   local_vm_->loaded.device);
           }
 
-          auto guest_driver = std::make_unique<GuestKfd>(std::move(dbt_guest), execution_driver);
+          // The deleter captures local_vm_, so the guest is destroyed BEFORE the VM
+          // whose bootstrap open it holds. That ordering is now a property of the
+          // object graph rather than a rule two unwind paths have to follow.
+          auto guest_driver =
+              std::shared_ptr<GuestKfd>(new GuestKfd(std::move(dbt_guest), execution_driver),
+                                        [vm = local_vm_](GuestKfd *g) { delete g; });
           if (!guest_driver->prepare_for_discovery()) {
-            // GuestKfd owns the simulator's bootstrap open, so destroy it while
-            // the VM and execution driver are still alive.
             guest_driver.reset();
             destroy_local_vm();
-            in_construction = false;
             return nullptr;
           }
-          auto *driver = guest_driver.get();
+          auto driver = std::static_pointer_cast<LinuxKfd>(guest_driver);
           guest_driver_ = std::move(guest_driver);
-          active_driver_.store(driver, std::memory_order_release);
-          if (simulator_backend)
-            start_local_vm();
-          in_construction = false;
+          // Start the engine and wait for readiness BEFORE publishing, so no
+          // concurrent interposed call can observe a driver whose components are
+          // still starting (or whose startup will fail). On failure nothing was
+          // published; destroy_local_vm() unpublishes (no-op) + frees, and
+          // guest_driver_ is reset first because it owns the simulator bootstrap
+          // open.
+          if (simulator_backend && !start_local_vm()) {
+            driver.reset();
+            destroy_local_vm();
+            return nullptr;
+          }
+          publish_local_driver_locked(driver);
           return driver;
         }
 
         if (!create_local_vm(handoff->config_path)) {
-          in_construction = false;
           return nullptr;
         }
       } catch (const std::exception &e) {
@@ -1741,20 +2158,21 @@ public:
         // default build the way the hook layer's equivalent refusal already is.
         util::Logger::warn("rocjitsu: failed to load child config: ", e.what());
         destroy_local_vm();
-        in_construction = false;
         return nullptr;
       }
 
-      // Publish the fully-constructed, not-yet-running driver BEFORE starting the
-      // engine thread: the release-store of active_driver_ pairs with acquire
-      // loads in driver()/initialized(), so any reader that observes the driver
-      // also observes all of the setup above (config, plugin group, sinks).
-      // Starting rj_vm_run() before the store would let the detached engine
-      // thread begin mutating the VM before it is published.
-      LinuxKfd *driver = rj_vm_->vm->driver();
-      active_driver_.store(driver, std::memory_order_release);
-      start_local_vm();
-      in_construction = false;
+      // Start the engine and wait for component startup to SUCCEED before
+      // publishing active_driver_. Publishing earlier would let a concurrent
+      // interposed call observe a half-started (or about-to-fail) device — the
+      // race this branch removes. On failure nothing was published; destroy_local_vm
+      // frees the VM.
+      if (!start_local_vm()) {
+        destroy_local_vm();
+        return nullptr;
+      }
+      // The release-store pairs with acquire loads in driver()/initialized() so any
+      // reader that observes the driver also observes all setup above.
+      publish_local_driver_locked(simulated_driver_alias());
     }
     return driver();
   }
@@ -1805,20 +2223,141 @@ public:
   }
 
 private:
+  /// @brief PID of the process that constructed this context. Set once in init()
+  /// and NEVER mutated, including in a forked child: a child must be able to detect
+  /// that it does not own this state, and a writable marker would be a mutation of
+  /// the parent's memory in the vfork window.
   pid_t owner_pid_ = 0;
-  rj_vm_t *rj_vm_ = nullptr;
-  std::unique_ptr<GuestKfd> guest_driver_;
-  std::atomic<LinuxKfd *> active_driver_{nullptr};
+  /// @brief st_rdev of the host's real /dev/kfd, or 0 if none exists.
+  /// @details Immutable after init(). Used only by the forked-child classifier.
+  dev_t host_kfd_rdev_ = 0;
+
+  /// @brief True if the published local driver holds no app-facing KFD reference.
+  /// @details Caller holds init_mutex_. This is a POLICY question (has the
+  /// application finished with the device?), deliberately separate from the
+  /// lifetime question (is anyone mid-call?), which active_driver_'s shared_ptr
+  /// answers on its own. "Idle" means the driver's reference count is back to the
+  /// baseline captured at publication, i.e. every reference the APPLICATION added
+  /// is gone. Comparing against a captured baseline rather than a per-class
+  /// constant keeps this backend-agnostic and keeps the VM-level fact "the local VM
+  /// holds one bootstrap open" out of SimulatedKfd. A null or non-ref-tracking
+  /// driver reports 0 and is idle.
+  bool local_driver_is_idle_locked() {
+    auto active_driver = driver();
+    if (!active_driver)
+      return true;
+    // Synthetic DRM files are counted here too: each holds a real open reference on
+    // the backend (DrmBackendLease), the same one a KFD descriptor holds, so this
+    // single comparison covers both and needs no DRM-specific term.
+    return active_driver->local_open_ref_count() <= local_open_ref_baseline_;
+  }
+
+  /// @brief Tear the local backend down iff a shutdown was requested and no
+  /// app-facing KFD reference remains. Caller holds init_mutex_.
+  /// @details Two steps, both under init_mutex_, and that is the whole algorithm:
+  ///
+  ///   1. If not idle, return. The DSO finalizer reaches here while HIP/ROCr may
+  ///      still hold KFD descriptors; their later closes call back in through
+  ///      release_local_open() and complete the request then.
+  ///   2. If idle, release any parked blocking call (begin_local_shutdown) so its
+  ///      caller returns and drops its driver snapshot, then unpublish and drop our
+  ///      references. Whoever holds the last snapshot runs the deleters.
+  ///
+  /// There is no post-decision re-check and nothing to roll back. retain_local_open()
+  /// also runs under init_mutex_, so a racing dup either completes before this call
+  /// (and the idle check sees its reference) or after it (and finds no published
+  /// driver, failing closed). The decision is made once, under one lock.
+  [[nodiscard]] DoomedLocalVm shutdown_local_vm_if_idle_locked() {
+    DoomedLocalVm doomed;
+    // Hardware DBT mode leaves local_vm_ == nullptr but still publishes
+    // guest_driver_, so a guest-only backend must not be skipped here.
+    if (!local_vm_ && !guest_driver_)
+      return doomed;
+    if (!local_driver_is_idle_locked())
+      return doomed;
+
+    // Release any parked blocking call so its caller returns and drops the driver
+    // snapshot that would otherwise keep the object alive past this point. Only the
+    // driver can do this; closing an fd does not cancel an in-flight kernel wait.
+    if (auto active_driver = driver())
+      active_driver->begin_local_shutdown();
+
+    // Unpublish here, but hand the OWNERS back so they die after the caller drops
+    // init_mutex_. Destroying them runs the VM deleter -- engine exit, thread join,
+    // rj_vm_destroy -- and doing that under init_mutex_ makes every dup() of a
+    // tracked KFD fd wait out the whole teardown while itself holding
+    // drm_fd_lifecycle_mutex_, which blocks close() process-wide. Recreation in the
+    // gap is not a concern: both callers set shutdown_requested_ under this same
+    // lock first, and creation is refused while it is set.
+    publish_driver(nullptr);
+    doomed.guest = std::move(guest_driver_);
+    doomed.vm = std::move(local_vm_);
+    guest_driver_.reset();
+    local_vm_.reset();
+    return doomed;
+  }
+
+  /// @brief Owner of the local VM, or null when no local VM exists.
+  /// @details A shared_ptr whose DELETER performs the entire engine teardown:
+  /// rj_vm_request_exit(), join the engine thread, rj_vm_destroy(). Teardown is
+  /// therefore not a sequence anyone has to remember to run in order — it is what
+  /// happens when the last reference goes away.
+  std::shared_ptr<rj_vm_t> local_vm_;
+  /// @brief Owner of the local VM engine loop; null when no local VM is running.
+  /// @details Deliberately unique_ptr<std::thread>, NOT std::jthread: a jthread
+  /// destructor always request_stop()+join()s, which would deadlock in the fork
+  /// child (the thread does not exist there, so join hangs). A raw-owned
+  /// std::thread keeps that abandonment expressible. Do not switch this to
+  /// jthread.
+  std::unique_ptr<std::thread> local_vm_thread_;
+  /// @brief Set once the interposer DSO finalizer has requested process-exit
+  /// shutdown; the VM is torn down as soon as it is also idle.
+  bool shutdown_requested_ = false;
+  /// @brief Reference count the published driver had before any application
+  /// reference existed. Written by publish_local_driver_locked(), read by
+  /// local_driver_is_idle_locked(); both under init_mutex_.
+  uint32_t local_open_ref_baseline_ = 0;
+  /// @brief Owner of the hardware/guest DBT driver, or null when unused.
+  /// @details Its deleter captures local_vm_, so the guest is destroyed BEFORE the
+  /// VM it borrows the simulator bootstrap open from. That ordering is expressed by
+  /// the capture rather than by a comment two call sites have to honour.
+  std::shared_ptr<GuestKfd> guest_driver_;
+  /// @brief The published local driver, or null when none is active.
+  /// @details Published under publish_mutex_, exactly like remote_ below, so a
+  /// reader simply takes a lifetime-extending snapshot: whoever holds one keeps the
+  /// object alive,
+  /// and the last release destroys it. That removes the need for any lifetime lock
+  /// on this pointer, and with it the whole class of "did every dereference remember
+  /// to take the pin, exactly once, and never above init_mutex_?" bugs.
+  ///
+  /// For the simulator this is an ALIASING shared_ptr built on local_vm_: it shares
+  /// the VM's control block but points at vm->driver(), so the SimulatedKfd cannot
+  /// outlive, and does not need to be separately owned by, the VM that contains it.
+  /// VirtualMachine keeps its plain unique_ptr and is untouched. For DBT the guest
+  /// driver is published directly.
+  std::shared_ptr<LinuxKfd> active_driver_;
   /// @brief Active daemon-mode remote driver, or nullptr in local mode.
-  /// @details Held as an atomic shared_ptr so lock-free readers (`remote()`,
-  /// `remote_lookup()`, `initialized()`, the AMDKFD ioctl fallback, the mmap
-  /// path) each take a lifetime-extending snapshot: a racing `teardown_remote()`
-  /// that stores nullptr cannot free the object while another thread still holds
-  /// a snapshot in `remote->ioctl()`/`remote->mmap()`. The object is destroyed by
-  /// the last shared_ptr, not by a manual delete, so there is no use-after-free.
-  /// `remote_mutex_` still serializes the compound create+open and clear
-  /// sequences; the atomic makes the pointer swap data-race-free.
-  std::atomic<std::shared_ptr<RemoteDriver>> remote_{nullptr};
+  /// @details Read and written ONLY through `remote()` / `publish_remote()`, which
+  /// hold `publish_mutex_`. Readers (`remote()`, `remote_lookup()`, `initialized()`,
+  /// the AMDKFD ioctl fallback, the mmap path) each take a lifetime-extending
+  /// snapshot: a racing `teardown_remote()` that publishes nullptr cannot free the
+  /// object while another thread still holds a snapshot in
+  /// `remote->ioctl()`/`remote->mmap()`. The object is destroyed by the last
+  /// shared_ptr, not by a manual delete, so there is no use-after-free.
+  ///
+  /// `remote_mutex_` is the OUTER lock: both publishers (`get_or_create_remote()`
+  /// and `teardown_remote_locked()`) hold it across the whole create+open or
+  /// clear sequence, so a reader that holds it -- as
+  /// `acquire_drm_backend_lease()` does -- is serialized against every write, not
+  /// merely against a torn pointer.
+  std::shared_ptr<RemoteDriver> remote_;
+  /// @brief Leaf mutex guarding the two published backend pointers.
+  /// @details Deliberately a mutex WE own rather than std::atomic<std::shared_ptr>.
+  /// libstdc++ implements that with a process-wide pool of spinlocks keyed by
+  /// address. Owning the lock keeps the publication path's synchronization visible
+  /// and auditable here rather than hidden in a library-internal pool. Innermost in
+  /// the lock order, held only for a pointer copy.
+  mutable std::mutex publish_mutex_;
   std::atomic<int> remote_kfd_fd_{-1};
   /// @brief Open-reference count for the remote (daemon-mode) KFD connection.
   /// @details The primary remote fd and every dup of it each hold one
@@ -1867,7 +2406,7 @@ private:
   /// table is already gone with it, so the PTE removal is skipped (never applied to
   /// a different, replacement driver).
   void teardown_gem_entry_locked(GemEntry &gem) {
-    if (gem.owner && gem.owner == dynamic_cast<SimulatedKfd *>(driver())) {
+    if (gem.owner && gem.owner == dynamic_cast<SimulatedKfd *>(driver().get())) {
       // The owning driver is still active; remove its PTEs. gem_va_unmap only fails
       // if the local process already vanished, in which case the page table is gone
       // and there is nothing to remove — either way the range must not remain
@@ -1963,9 +2502,11 @@ private:
   alignas(16) static uint8_t storage_[];
 };
 
-// Storage for the singleton is never destructed. Using aligned raw storage
-// avoids __cxa_finalize destroying the object while the detached engine
-// thread is still running.
+// Storage for the singleton is explicitly shut down (rj_interposer_shutdown →
+// request_local_vm_shutdown, which stops and joins the engine once idle) but never
+// destructed. Aligned raw storage keeps interposed libc entry points from reaching
+// a destroyed context during late process teardown, while the phase-aware shutdown
+// still gives the local VM engine thread a bounded, joined lifetime.
 alignas(16) uint8_t InterposerContext::storage_[sizeof(InterposerContext)];
 InterposerContext &InterposerContext::ctx =
     *reinterpret_cast<InterposerContext *>(InterposerContext::storage_);
@@ -1979,6 +2520,8 @@ extern "C" {
 static std::string redirect_sysfs_path(const char *path);
 static std::string redirect_sys_dev_char(const char *path);
 static std::optional<Sysfs::GpuInfo> interposer_gpu_info(uint32_t render_minor);
+static std::optional<Sysfs::GpuInfo>
+interposer_gpu_info_for(const InterposerContext::DrmFileToken &file);
 
 struct SyntheticDrmOpenResult {
   bool handled = false;
@@ -2028,26 +2571,33 @@ static SyntheticDrmOpenResult open_synthetic_drm_fd(const char *path) {
   // stable signal that a daemon connection can service this render node, even if
   // a dup2/dup3 cleared the primary fd number while other refs keep it alive.
   auto remote = InterposerContext::ctx.remote();
-  if (InterposerContext::ctx.driver_fd() < 0 && !remote)
-    return {};
 
-  std::string drm_base;
-  if (auto *drv = InterposerContext::ctx.driver())
-    drm_base = drv->drm_path();
-  else
-    drm_base = InterposerContext::ctx.remote_drm_path();
-
-  // HIP/libdrm may open the generated dev_dri node after following redirected
-  // sysfs metadata instead of opening the literal /dev/dri/renderD* path.
-  // Treat both path forms as the same synthetic DRM render node.
+  // Snapshot the driver for the driver_fd()/drm_path()/handles_drm_render_minor()
+  // reads below.
   uint32_t render_minor = 0;
-  if (!render_minor_from_drm_node_path(path, drm_base.c_str(), &render_minor))
-    return {};
+  {
+    if (InterposerContext::ctx.driver_fd() < 0 && !remote)
+      return {};
 
-  auto *drv = InterposerContext::ctx.driver();
-  const bool local_handles_render = drv && drv->handles_drm_render_minor(render_minor);
-  const bool remote_handles_render = static_cast<bool>(remote);
-  if (!local_handles_render && !remote_handles_render)
+    std::string drm_base;
+    if (auto drv = InterposerContext::ctx.driver())
+      drm_base = drv->drm_path();
+    else
+      drm_base = InterposerContext::ctx.remote_drm_path();
+
+    // HIP/libdrm may open the generated dev_dri node after following redirected
+    // sysfs metadata instead of opening the literal /dev/dri/renderD* path.
+    // Treat both path forms as the same synthetic DRM render node.
+    if (!render_minor_from_drm_node_path(path, drm_base.c_str(), &render_minor))
+      return {};
+  }
+
+  // Acquire the operational lease BEFORE creating the fd. The retain and the
+  // shutdown decision share init_mutex_, so the backend cannot be retired between
+  // "who serves this node?" and the reference that answers it — the window the raw
+  // snapshot left open.
+  auto backend_lease = InterposerContext::ctx.acquire_drm_backend_lease(render_minor);
+  if (!backend_lease)
     return {};
 
   auto raw_drm_fd = InterposerContext::real().memfd_create("rocjitsu_drm", MFD_CLOEXEC);
@@ -2065,19 +2615,306 @@ static SyntheticDrmOpenResult open_synthetic_drm_fd(const char *path) {
     return {true, -1};
   }
 
-  std::optional<uint64_t> closed_file_id;
+  InterposerContext::DrmFinalRelease displaced;
   try {
     auto drm_lifecycle = InterposerContext::ctx.lock_drm_fd_lifecycle();
-    closed_file_id = InterposerContext::ctx.track_drm(high_fd, render_minor);
-  } catch (const std::bad_alloc &) {
+    // backend_lease stays OURS across this call: on a throw it is released at this
+    // function's scope exit, by which point drm_lifecycle is gone. See track_drm().
+    displaced = InterposerContext::ctx.track_drm(high_fd, render_minor, backend_lease);
+  } catch (const std::exception &) {
+    // Not just bad_alloc: unique_lock's constructor can throw system_error, and this
+    // is an extern "C" entry point -- letting anything escape into a C caller frame
+    // is undefined.
     const int saved_errno = ENOMEM;
     InterposerContext::real().close(high_fd);
     errno = saved_errno;
     return {true, -1};
   }
-  if (closed_file_id)
-    InterposerContext::ctx.reap_gem_for_drm_file(*closed_file_id);
+  InterposerContext::ctx.complete_drm_release(std::move(displaced));
   return {true, high_fd};
+}
+
+/// @brief True if @p st describes a device rocJITsu emulates.
+/// @details Pure identity: the host KFD's recorded st_rdev, or DRM's fixed major.
+/// No pathname inspection at all -- a name can lie (a chained alias, a dirfd-relative
+/// spelling, or an unrelated node whose name merely contains "kfd"), a dev_t cannot.
+[[nodiscard]] inline bool rj_is_gpu_device_stat(const struct stat &st) {
+  if (!S_ISCHR(st.st_mode))
+    return false;
+  constexpr unsigned kDrmMajor = 226;
+  if (major(st.st_rdev) == kDrmMajor)
+    return true;
+  const dev_t host_kfd = InterposerContext::ctx.host_kfd_rdev();
+  return host_kfd != 0 && st.st_rdev == host_kfd;
+}
+
+/// @brief Append @p src_len bytes of @p src to @p out, bounded.
+/// @returns False if the result would not fit, leaving @p out unusable.
+[[nodiscard]] inline bool rj_path_append(char *out, size_t out_size, size_t *len, const char *src,
+                                         size_t src_len) {
+  if (*len + src_len + 1 > out_size)
+    return false;
+  std::memcpy(out + *len, src, src_len);
+  *len += src_len;
+  out[*len] = '\0';
+  return true;
+}
+
+/// @brief Resolve an open-like (dirfd, path) pair to an absolute path.
+/// @details Fixed buffers and no allocation. A child forked from a multithreaded
+/// parent can inherit a held malloc arena lock, so this is as barred from allocating
+/// as it is from taking a mutex; that also rules out snprintf's %s machinery, hence
+/// the hand-built descriptor path.
+/// @returns False when the pair cannot be resolved into @p out_size bytes.
+[[nodiscard]] inline bool rj_child_absolute_path(int dirfd, const char *path, char *out,
+                                                 size_t out_size) {
+  if (out_size == 0)
+    return false;
+  out[0] = '\0';
+  size_t len = 0;
+
+  if (path[0] != '/') {
+    if (dirfd == AT_FDCWD) {
+      if (!::getcwd(out, out_size))
+        return false;
+      len = std::strlen(out);
+    } else if (dirfd >= 0) {
+      char link[sizeof("/proc/self/fd/") + 20];
+      static constexpr char kPrefix[] = "/proc/self/fd/";
+      size_t n = sizeof(kPrefix) - 1;
+      std::memcpy(link, kPrefix, n);
+      char digits[20];
+      size_t d = 0;
+      unsigned v = static_cast<unsigned>(dirfd);
+      do {
+        digits[d++] = static_cast<char>('0' + v % 10);
+        v /= 10;
+      } while (v > 0 && d < sizeof(digits));
+      while (d > 0)
+        link[n++] = digits[--d];
+      link[n] = '\0';
+
+      auto &real = InterposerContext::real();
+      if (!real.readlink_fn)
+        return false;
+      const ssize_t got = real.readlink_fn(link, out, out_size - 1);
+      if (got <= 0)
+        return false;
+      out[got] = '\0';
+      len = static_cast<size_t>(got);
+    } else {
+      return false;
+    }
+    if (!rj_path_append(out, out_size, &len, "/", 1))
+      return false;
+  }
+  return rj_path_append(out, out_size, &len, path, std::strlen(path));
+}
+
+/// @brief Collapse repeated separators, "." and ".." in place, lexically.
+/// @details Lexical is exactly right for the one caller: it runs only when the
+/// target does not exist, so there is no final component left for a symlink to
+/// redirect. @p p must be absolute.
+inline void rj_path_normalize(char *p) {
+  p[0] = '/';
+  char *out = p + 1;
+  const char *in = p + 1;
+  while (*in == '/')
+    ++in;
+  while (*in) {
+    const char *start = in;
+    while (*in && *in != '/')
+      ++in;
+    const size_t seg = static_cast<size_t>(in - start);
+    if (seg == 1 && start[0] == '.') {
+      // "." names the directory already written.
+    } else if (seg == 2 && start[0] == '.' && start[1] == '.') {
+      if (out > p + 1) {
+        while (out > p + 1 && out[-1] != '/')
+          --out;
+        if (out > p + 1)
+          --out; // and off the separator that preceded it
+      }
+    } else {
+      // The separator goes BEFORE the segment, never after it. Writing a trailing
+      // one would land on the NUL the read cursor is about to reach, and the
+      // separator skip below would then walk `in` off the end of the string.
+      if (out > p + 1)
+        *out++ = '/';
+      std::memmove(out, start, seg);
+      out += seg;
+    }
+    while (*in == '/')
+      ++in;
+  }
+  *out = '\0';
+}
+
+/// @brief True if @p p is an endpoint rocJITsu serves from the emulator.
+/// @details Mirrors what the PARENT matches on: open() compares "/dev/kfd" exactly
+/// and open_synthetic_drm_fd() matches the "/dev/dri/renderD" prefix. Both are
+/// spellings, not device identities, so both hold whether or not the host has a
+/// matching node. @p p must already be normalized.
+[[nodiscard]] inline bool rj_path_names_emulated_endpoint(const char *p) {
+  if (std::strcmp(p, "/dev/kfd") == 0)
+    return true;
+  static constexpr char kRenderPrefix[] = "/dev/dri/renderD";
+  constexpr size_t kRenderPrefixLen = sizeof(kRenderPrefix) - 1;
+  if (std::strncmp(p, kRenderPrefix, kRenderPrefixLen) != 0 || p[kRenderPrefixLen] == '\0')
+    return false;
+  for (const char *d = p + kRenderPrefixLen; *d; ++d)
+    if (*d < '0' || *d > '9')
+      return false;
+  return true;
+}
+
+/// @brief True if an open-like call would land on a GPU device node.
+/// @details Used ONLY by the forked-child gate, so it must classify without touching
+/// any inherited interposer state -- no mutexes, no containers, no driver pointers.
+///
+/// Identity FIRST: it stat()s the resolved target and compares the device
+/// major/minor, so "/dev//kfd", "/dev/./kfd", a symlink, a cwd-relative path and
+/// openat(dirfd, "kfd", ...) are all caught, where a string compare catches only the
+/// literal form. The stat goes through the pass-through table, never our own hook.
+///
+/// Spelling SECOND, and only when there is no node to identify. Identity is the
+/// stronger test, but it needs something to stat, and a host with no GPU device nodes
+/// -- CI, and any pure-emulation deployment -- has nothing to offer it. The parent
+/// still serves those endpoints from the emulator there, because it matches on
+/// spelling, so the child has to recognize the same spellings or its contract would
+/// silently depend on the box having hardware.
+///
+/// Fails CLOSED: if the target cannot be classified it is treated as a GPU endpoint,
+/// because the cost of a false positive (a child gets ENODEV on some unrelated node)
+/// is far below the cost of a false negative (a child silently acquires real
+/// hardware). Character devices only, so ordinary files are never refused.
+[[nodiscard]] inline bool rj_child_open_hits_gpu_device(int dirfd, const char *path) {
+  // Not a classification failure: there is no target to classify. open(nullptr) is
+  // the caller's own bug and libc answers it with EFAULT, which this path has to
+  // reproduce rather than convert into ENODEV.
+  if (!path)
+    return false;
+  auto &real = InterposerContext::real();
+  // Unresolved pass-through table: nothing here can classify anything, so this IS
+  // the "cannot be classified" case and fails closed like the rest. Refusing is
+  // also the only safe answer available -- the non-refused path forwards through
+  // real.openat, which is one of the symbols missing here.
+  if (!real.fstat_fn || !real.openat || !real.close)
+    return true;
+
+  // O_PATH resolves symlink chains and relative components against dirfd WITHOUT
+  // opening the device, so classification has no side effects on real hardware.
+  int probe = real.openat(dirfd, path, O_PATH | O_CLOEXEC, 0);
+  if (probe < 0) {
+    // No node there to identify -- but the interposer synthesizes GPU endpoints by
+    // SPELLING (open() compares "/dev/kfd" exactly; open_synthetic_drm_fd() matches
+    // the render-node prefix), so the parent would have served this open from the
+    // emulator regardless of what the host has under /dev. Identity classification
+    // is inert on such a host: host_kfd_rdev() stays 0 with nothing to record, and
+    // there is no node to stat. Falling through would hand the child a plain ENOENT
+    // for an endpoint its parent holds open, making the contract depend on whether
+    // the box happens to have hardware -- so match the parent's own rule instead.
+    char resolved[PATH_MAX];
+    // Unresolvable pair (readlink failed, or the joined path exceeds PATH_MAX):
+    // the spelling cannot be compared either, so both classifiers have now come up
+    // empty and the documented fail-closed rule applies.
+    if (!rj_child_absolute_path(dirfd, path, resolved, sizeof(resolved)))
+      return true;
+    rj_path_normalize(resolved);
+    return rj_path_names_emulated_endpoint(resolved);
+  }
+  struct stat st {};
+  const int rc = real.fstat_fn(probe, &st);
+  real.close(probe);
+  if (rc != 0)
+    return true; // Unclassifiable: fail closed.
+  return rj_is_gpu_device_stat(st);
+}
+
+/// @brief True if @p fd currently refers to a real GPU device.
+/// @details Lock-free and state-free: one passthrough fstat, no interposer mutex,
+/// container or pointer. That is what makes it usable from a forked child, where
+/// every inherited lock is suspect.
+[[nodiscard]] inline bool rj_fd_is_real_gpu(int fd) {
+  if (fd < 0)
+    return false;
+  auto &real = InterposerContext::real();
+  if (!real.fstat_fn)
+    return false;
+  struct stat st {};
+  if (real.fstat_fn(fd, &st) != 0)
+    return false;
+  return rj_is_gpu_device_stat(st);
+}
+
+/// @brief Refuse an operation a forked child aimed at an inherited real GPU fd.
+/// @details Hardware-backed GuestKfd holds a real /dev/kfd descriptor, and fork()
+/// copies the whole descriptor table, so making the APPLICATION-facing fd synthetic
+/// does not stop a child from finding the real one (e.g. by walking /proc/self/fd)
+/// and using or laundering it across exec. Child pass-through paths therefore check
+/// the descriptor's identity, not just the path used to obtain it.
+///
+/// This is a COOPERATIVE, API-level contract, not a security boundary: it defends
+/// against a child that inherits hardware by accident, which is the realistic
+/// failure, but interposition cannot stop a child that issues raw syscalls or
+/// receives a descriptor over a unix socket. A hard guarantee requires hardware KFD
+/// ownership to live outside the process (daemon mode), which is tracked separately.
+[[nodiscard]] inline bool rj_child_refuses_fd(int fd) {
+  if (!rj_fd_is_real_gpu(fd))
+    return false;
+  errno = ENODEV;
+  return true;
+}
+
+/// @brief Pass an open through to libc, then VERIFY what was actually opened.
+/// @details Closes the classify-then-reopen window: the O_PATH probe and the real
+/// open resolve the path twice, so a target swapped in between could slip a real GPU
+/// node past classification. Re-checking the descriptor we actually got makes the
+/// decision depend on the object opened rather than on the name resolved earlier. A
+/// GPU node that arrives this way is closed immediately, so the child never retains
+/// a usable real-hardware descriptor.
+[[nodiscard]] inline int rj_child_open_verified(int dirfd, const char *path, int flags,
+                                                mode_t mode) {
+  auto &real = InterposerContext::real();
+  int fd = real.openat(dirfd, path, flags, mode);
+  if (fd < 0)
+    return fd;
+  struct stat st {};
+  if (real.fstat_fn && real.fstat_fn(fd, &st) == 0 && rj_is_gpu_device_stat(st)) {
+    real.close(fd);
+    errno = ENODEV;
+    return -1;
+  }
+  return fd;
+}
+
+/// @brief Handle an open-like call to a GPU endpoint from a forked child.
+/// @details Deliberately FAILS instead of passing through to libc. Passing through
+/// would open the HOST's real /dev/kfd or render node when one exists, silently
+/// moving the child off the emulator and onto real hardware -- a far worse outcome
+/// than an error, and one that could corrupt real GPU state. ENODEV matches what the
+/// interposer already returns when no backend can serve a request.
+[[nodiscard]] inline bool rj_child_must_refuse_open(int dirfd, const char *path, int *out_errno) {
+  if (!rj_child_open_hits_gpu_device(dirfd, path))
+    return false;
+  *out_errno = ENODEV;
+  return true;
+}
+
+/// @brief True when this process owns the interposer state and may touch it.
+/// @details False in a process that inherited this address space through fork/vfork
+/// and has not yet exec'd. rocJITsu registers NO atfork handlers (see
+/// InterposerContext::init()), so such a child may hold locks whose owners no longer
+/// exist and containers a vanished thread was mid-mutation on. Every interposed entry
+/// point must therefore test this BEFORE in_construction, any driver or remote
+/// snapshot, fd classification, path redirection, logging that reaches context state,
+/// or any mutex -- i.e. before touching anything inherited at all.
+///
+/// Callers must already have confirmed real().ready(); this deliberately does not
+/// re-test it, because the not-ready early path differs per hook (raw syscall or
+/// dlsym) and must run first.
+[[nodiscard]] inline bool rj_owns_interposer_state() {
+  return InterposerContext::ctx.owned_by_current_process();
 }
 
 RJ_INTERPOSER_EXPORT int open(const char *path, int flags, ...) {
@@ -2090,6 +2927,19 @@ RJ_INTERPOSER_EXPORT int open(const char *path, int flags, ...) {
   }
 
   assert(InterposerContext::real().ready());
+  // ready() first, as openat() and every other entry point does. owner_pid_ is zero
+  // until init() runs, so before the constructor rj_owns_interposer_state() is false
+  // for the OWNER too -- taking the child branch there would fail closed on an
+  // unresolved passthrough table and turn every open() in that window, GPU endpoint
+  // or not, into ENODEV.
+  if (InterposerContext::real().ready() && !rj_owns_interposer_state()) {
+    int refuse_errno = 0;
+    if (rj_child_must_refuse_open(AT_FDCWD, path, &refuse_errno)) {
+      errno = refuse_errno;
+      return -1;
+    }
+    return rj_child_open_verified(AT_FDCWD, path, flags, mode);
+  }
   auto *volatile p = path;
   if (!p || InterposerContext::in_construction)
     return InterposerContext::real().openat(AT_FDCWD, path, flags, mode);
@@ -2107,19 +2957,17 @@ RJ_INTERPOSER_EXPORT int open(const char *path, int flags, ...) {
     if (auto remote = InterposerContext::ctx.get_or_create_remote())
       return remote.fd;
 
-    auto *drv = InterposerContext::ctx.get_or_create();
-    if (!drv) {
-      errno = ENODEV;
-      return -1;
-    }
-    int kfd_fd = drv->open();
-    if (kfd_fd < 0)
-      return kfd_fd;
-    if (kfd_fd != drv->fd())
-      InterposerContext::ctx.track_open_fd(kfd_fd);
-    if (!drv->owns_fd(drv->fd()))
+    // ONE combined operation under init_mutex_: creating the backend and taking the
+    // application's reference on it must not be separable, or the shutdown policy
+    // can retire the backend in between and hand back a dead fd.
+    auto opened = InterposerContext::ctx.open_local();
+    if (opened.fd < 0)
+      return opened.fd;
+    // clear_dups() routes through release_local_open() (init_mutex_), so it must run
+    // after open_local() has released it.
+    if (opened.clear_dups_needed)
       InterposerContext::ctx.clear_dups();
-    return kfd_fd;
+    return opened.fd;
   }
 
   std::string redirected = InterposerContext::ctx.redirect_sysfs_path(path);
@@ -2167,6 +3015,14 @@ RJ_INTERPOSER_EXPORT int openat(int dirfd, const char *path, int flags, ...) {
     va_end(ap);
   }
 
+  if (InterposerContext::real().ready() && !rj_owns_interposer_state()) {
+    int refuse_errno = 0;
+    if (rj_child_must_refuse_open(dirfd, path, &refuse_errno)) {
+      errno = refuse_errno;
+      return -1;
+    }
+    return rj_child_open_verified(dirfd, path, flags, mode);
+  }
   auto *volatile p_at = path;
   if (!p_at)
     return InterposerContext::real().openat(dirfd, path, flags, mode);
@@ -2250,24 +3106,62 @@ RJ_INTERPOSER_EXPORT int close(int fd) {
       InterposerContext::real().close(fd);
   }
   if (drm_close.tracked) {
-    if (drm_close.closed_file_id)
-      InterposerContext::ctx.reap_gem_for_drm_file(*drm_close.closed_file_id);
+    // Reaps GEM while the backend is still open, then drops the lease. Releasing a
+    // local lease routes through release_local_open(), so a final DRM close can
+    // complete a pending process-exit shutdown exactly as a final KFD close does.
+    InterposerContext::ctx.complete_drm_release(std::move(drm_close.release));
     return 0;
   }
   if (InterposerContext::ctx.is_kfd_dup(fd)) {
     InterposerContext::ctx.untrack_dup(fd);
     return static_cast<int>(InterposerContext::real().close(fd));
   }
-  if (auto *drv = InterposerContext::ctx.lookup(fd)) {
-    drv->close();
+  // Classify the fd against the local driver, then release the snapshot before
+  // release_local_open() so that call can actually free the driver when this was
+  // the last reference.
+  bool is_primary_local_fd = false;
+  bool is_owned_fd = false;
+  {
+    is_primary_local_fd = InterposerContext::ctx.lookup(fd) != nullptr;
+    if (!is_primary_local_fd)
+      is_owned_fd = InterposerContext::ctx.owns_fd(fd);
+  }
+  if (is_primary_local_fd) {
+    // Route through release_local_open() (not a bare driver close) so the last
+    // app-facing close also completes a pending process-exit shutdown, letting the
+    // local VM be torn down once no KFD reference remains.
+    InterposerContext::ctx.release_local_open();
     return 0;
   }
-  if (InterposerContext::ctx.owns_fd(fd))
+  if (is_owned_fd)
     return 0;
   return static_cast<int>(InterposerContext::real().close(fd));
 }
 
-__attribute__((destructor(101))) void rj_interposer_shutdown() {}
+// Runs at library finalization. As an LD_PRELOAD lib we may finalize before HIP
+// and ROCR, which can still hold KFD descriptors and issue an implicit
+// hsa_shut_down() from THEIR finalizers. So only RECORD the shutdown request here;
+// the VM is destroyed later, when the final KFD client closes and the simulator is
+// idle (via release_local_open()). Destroying it now would make HIP's later scratch
+// release hang against a gone driver.
+//
+// This deferred, reference-counted teardown is what makes cross-library ordering
+// safe — NOT the destructor priority. GCC destructor priorities only order
+// .fini_array entries WITHIN this DSO; the KFD-closing finalizers that matter live
+// in other DSOs (HIP/ROCR) and are ordered relative to librocjitsu.so by dynamic
+// finalization order (an LD_PRELOAD lib finalizes before its dependents), which no
+// attribute here can change. Since this finalizer is now idempotent and only
+// records a request, its priority is immaterial; default priority is used simply
+// because the old destructor(101) special-casing is no longer needed.
+__attribute__((destructor)) void rj_interposer_shutdown() {
+  // PID gate FIRST, before anything else. A forked child that calls exit() instead
+  // of exec() runs this finalizer too, and request_local_vm_shutdown() takes
+  // init_mutex_ -- inherited, possibly locked by a parent thread that does not exist
+  // here. The parent owns this VM's teardown; a child must never attempt it.
+  if (!InterposerContext::ctx.owned_by_current_process())
+    return;
+  InterposerContext::ctx.request_local_vm_shutdown();
+}
 
 RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
   assert(InterposerContext::real().ready());
@@ -2275,6 +3169,11 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
   va_start(ap, request);
   void *arg = va_arg(ap, void *);
   va_end(ap);
+  if (!rj_owns_interposer_state()) {
+    if (rj_child_refuses_fd(fd))
+      return -1;
+    return InterposerContext::real().ioctl(fd, request, arg);
+  }
 
   constexpr unsigned kDrmIoctlType = 'd';
   constexpr unsigned kDrmIoctlNrVersion = 0x00;
@@ -2375,7 +3274,10 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
       //   READ_MMR_REG (gb_addr_cfg is mandatory for all families),
       //   VRAM_GTT, MEMORY. Failures (-1) abort device init.
       auto *info = static_cast<drm_amdgpu_info *>(arg);
-      auto gpu_info = interposer_gpu_info(InterposerContext::ctx.drm_render_minor(drm_file));
+      // Answer from the FILE's own backend rather than re-deriving one from the
+      // published pointer. The file's lease already names the backend that owns this
+      // render node, so this cannot consult a driver that does not.
+      auto gpu_info = interposer_gpu_info_for(drm_file);
       if (!gpu_info) {
         errno = ENODEV;
         return -1;
@@ -2488,14 +3390,10 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
         errno = EINVAL;
         return -1;
       }
-      // GEM_VA page-table installation only applies to the local simulated driver;
-      // there is no such path for a remote (daemon) or DBT-guest backend. Report
-      // failure rather than a phantom success so userspace does not record a mapping
-      // that was never installed and later fault on the GPU page table. gem_map/
-      // gem_unmap do the bookkeeping AND the page-table mutation atomically under
-      // fd_mutex_ (so a concurrent GEM_CLOSE cannot leave dangling PTEs); they
-      // return a kernel-style negative errno on failure.
-      if (!InterposerContext::ctx.driver_is_simulated()) {
+      // Ask THIS FILE's backend, not the globally published one. A remote DRM file
+      // must not install page-table entries into an unrelated local simulator just
+      // because one happens to be published.
+      if (!InterposerContext::ctx.drm_file_is_simulated(drm_file)) {
         errno = ENODEV;
         return -1;
       }
@@ -2554,31 +3452,57 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
   // remote is live". In mixed local+daemon mode a Local-tagged dup must route to
   // the local driver and a Remote-tagged dup to the remote connection; guessing
   // remote would silently switch a local dup's backend.
-  if (auto backend = InterposerContext::ctx.kfd_backend_of(fd)) {
-    if (*backend == InterposerContext::DupBackend::Remote) {
-      // kfd_backend_of() already established this fd is Remote-backed, so route
-      // via the remote snapshot directly rather than remote_lookup(remote_kfd_fd_):
-      // the primary fd number may have been invalidated/reused while a remote
-      // shared_ptr snapshot is still live, and this dup still belongs to it.
-      if (auto remote = InterposerContext::ctx.remote())
-        return kfd_ioctl_ret(remote->ioctl(request, arg));
-    } else if (auto *drv = InterposerContext::ctx.driver()) {
-      int rc = drv->ioctl(request, arg);
-      // Capture the KFD allocation flags for a freshly exported dmabuf fd. The
-      // flags determine the GPU PTE MTYPE when the fd is later mapped via GEM_VA,
-      // and must be recorded now because the allocation may be freed first. Only
-      // the local simulated driver exports dmabufs this path can later map.
-      if (rc == 0 && request == AMDKFD_IOC_EXPORT_DMABUF && arg) {
-        if (auto *sim = dynamic_cast<SimulatedKfd *>(drv)) {
-          auto *export_args = static_cast<kfd_ioctl_export_dmabuf_args *>(arg);
-          // alloc_flags_for_handle locks the process alloc mutex internally, so the
-          // interposer does not reach into driver-private per-process state.
-          InterposerContext::ctx.track_gem_flags(static_cast<int>(export_args->dmabuf_fd),
-                                                 sim->alloc_flags_for_handle(export_args->handle));
+  {
+    // Lifetime here rests on shared_ptr snapshots, not on a lock: publication swaps
+    // the pointer under publish_mutex_ and a reader copies it, so holding a copy is
+    // what keeps a driver alive. Two separate snapshots are involved, and neither
+    // spans the other:
+    //   - the classification, kfd_backend_of() -> driver_fd(), dereferences the local
+    //     driver but takes its OWN snapshot internally, so it is safe on its own and
+    //     needs nothing held around it here;
+    //   - the Local branch takes its own snapshot (drv) and dispatches under it.
+    // This block takes no init_mutex_; it takes fd_mutex_ (track_gem_flags) only
+    // under the Local snapshot, matching the fd_mutex_ order.
+    //
+    // The Remote branch must NOT dispatch while holding a local snapshot:
+    // remote->ioctl() can block indefinitely (e.g. a daemon-side WAIT_EVENTS), which
+    // would keep an idle LOCAL VM alive and stall its teardown on an unrelated remote
+    // operation. So it only CAPTURES the remote snapshot here and dispatches after
+    // the classification scope has closed -- that snapshot keeps the remote alive by
+    // itself.
+    std::shared_ptr<RemoteDriver> remote_dispatch;
+    {
+      if (auto backend = InterposerContext::ctx.kfd_backend_of(fd)) {
+        if (*backend == InterposerContext::DupBackend::Remote) {
+          // kfd_backend_of() already established this fd is Remote-backed, so route
+          // via the remote snapshot directly rather than remote_lookup(remote_kfd_fd_):
+          // the primary fd number may have been invalidated/reused while a remote
+          // shared_ptr snapshot is still live, and this dup still belongs to it.
+          remote_dispatch = InterposerContext::ctx.remote();
+        } else if (auto drv = InterposerContext::ctx.driver()) {
+          int rc = drv->ioctl(request, arg);
+          // Capture the KFD allocation flags for a freshly exported dmabuf fd. The
+          // flags determine the GPU PTE MTYPE when the fd is later mapped via GEM_VA,
+          // and must be recorded now because the allocation may be freed first. Only
+          // the local simulated driver exports dmabufs this path can later map.
+          if (rc == 0 && request == AMDKFD_IOC_EXPORT_DMABUF && arg) {
+            if (auto *sim = dynamic_cast<SimulatedKfd *>(drv.get())) {
+              auto *export_args = static_cast<kfd_ioctl_export_dmabuf_args *>(arg);
+              // alloc_flags_for_handle locks the process alloc mutex internally, so the
+              // interposer does not reach into driver-private per-process state.
+              InterposerContext::ctx.track_gem_flags(
+                  static_cast<int>(export_args->dmabuf_fd),
+                  sim->alloc_flags_for_handle(export_args->handle));
+            }
+          }
+          return kfd_ioctl_ret(rc);
         }
       }
-      return kfd_ioctl_ret(rc);
     }
+    // Classification done and no local snapshot held: dispatch the remote op on the
+    // lifetime-extending snapshot captured above.
+    if (remote_dispatch)
+      return kfd_ioctl_ret(remote_dispatch->ioctl(request, arg));
   }
   // Late-ioctl safety net: an AMDKFD ('K') ioctl may arrive on a tracked KFD fd
   // whose primary remote handle changed underneath it (e.g. a close/dup race in
@@ -2590,8 +3514,18 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
   // tracking removed concurrently), so a type-'K' ioctl is never guessed onto the
   // remote connection.
   if (_IOC_TYPE(request) == AMDKFD_IOCTL_BASE) {
-    auto backend = InterposerContext::ctx.kfd_backend_of(fd);
-    if (backend == InterposerContext::DupBackend::Remote) {
+    // kfd_backend_of() -> driver_fd() dereferences the local driver, but snapshots it
+    // internally, so the classification is lifetime-safe without holding anything
+    // here; the routed remote->ioctl is separately safe via its own snapshot.
+    InterposerContext::DupBackend backend;
+    bool have_backend = false;
+    {
+      if (auto b = InterposerContext::ctx.kfd_backend_of(fd)) {
+        backend = *b;
+        have_backend = true;
+      }
+    }
+    if (have_backend && backend == InterposerContext::DupBackend::Remote) {
       if (auto remote = InterposerContext::ctx.remote())
         return kfd_ioctl_ret(remote->ioctl(request, arg));
     }
@@ -2608,19 +3542,30 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
 
 RJ_INTERPOSER_EXPORT int dup(int oldfd) {
   assert(InterposerContext::real().ready());
+  if (!rj_owns_interposer_state()) {
+    if (rj_child_refuses_fd(oldfd))
+      return -1;
+    return InterposerContext::real().dup(oldfd);
+  }
   std::optional<InterposerContext::DupBackend> reserved;
   InterposerContext::DrmFileToken drm_file;
-  std::optional<uint64_t> closed_file_id;
+  InterposerContext::DrmFinalRelease drm_release;
   int rc;
+  // Reserve the backend BEFORE the DRM lifecycle lock. reserve_dup_backend() takes
+  // init_mutex_ for a tracked KFD fd, while driver code running under init_mutex_
+  // reaches the interposed close() hook, which takes drm_fd_lifecycle_mutex_ --
+  // acquiring them in the other order here would close an ABBA cycle between a dup
+  // and a close. Only "reserve before the syscall" is load-bearing, and it still
+  // holds; the failure path below releases the reservation outside the lock too.
+  reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
   {
     auto drm_lifecycle = InterposerContext::ctx.lock_drm_fd_lifecycle();
     // Keep the source kernel fd and its DRM identity paired until dup() and the
     // tracking update complete. Backend and GEM cleanup run after this scope.
-    reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
     drm_file = InterposerContext::ctx.reserve_drm_file(oldfd);
     rc = InterposerContext::real().dup(oldfd);
     if (rc >= 0)
-      closed_file_id = InterposerContext::ctx.commit_drm_dup(rc, drm_file);
+      drm_release = InterposerContext::ctx.commit_drm_dup(rc, drm_file);
   }
   if (rc < 0) {
     const int saved_errno = errno;
@@ -2634,8 +3579,7 @@ RJ_INTERPOSER_EXPORT int dup(int oldfd) {
     InterposerContext::ctx.commit_dup(rc, *reserved);
   else
     InterposerContext::ctx.untrack_dup(rc);
-  if (closed_file_id)
-    InterposerContext::ctx.reap_gem_for_drm_file(*closed_file_id);
+  InterposerContext::ctx.complete_drm_release(std::move(drm_release));
   return rc;
 }
 
@@ -2654,7 +3598,8 @@ namespace {
 //     routes to the old backend.
 // Then the replacement is recorded on the reserved source backend.
 void reconcile_dup_target(int newfd, std::optional<InterposerContext::DupBackend> reserved,
-                          std::optional<uint64_t> closed_drm_file_id) {
+                          InterposerContext::DrmFinalRelease overwritten_release,
+                          InterposerContext::DrmFinalRelease displaced_release) {
   InterposerContext::ctx.untrack_sysfs(newfd);
   // dup2/dup3 atomically close whatever newfd was, bypassing the close() hook, so
   // every per-fd cleanup close() performs must be mirrored here. Drop any transient
@@ -2663,8 +3608,8 @@ void reconcile_dup_target(int newfd, std::optional<InterposerContext::DupBackend
   // PRIME on the recycled fd number could misapply as the wrong PTE MTYPE. No-op for
   // non-dmabuf fds.
   InterposerContext::ctx.drop_pending_gem_flags(newfd);
-  if (closed_drm_file_id)
-    InterposerContext::ctx.reap_gem_for_drm_file(*closed_drm_file_id);
+  InterposerContext::ctx.complete_drm_release(std::move(overwritten_release));
+  InterposerContext::ctx.complete_drm_release(std::move(displaced_release));
   InterposerContext::ctx.invalidate_overwritten_kfd_fd(newfd);
   if (reserved)
     InterposerContext::ctx.commit_dup(newfd, *reserved);
@@ -2673,25 +3618,35 @@ void reconcile_dup_target(int newfd, std::optional<InterposerContext::DupBackend
 
 RJ_INTERPOSER_EXPORT int dup2(int oldfd, int newfd) {
   assert(InterposerContext::real().ready());
+  if (!rj_owns_interposer_state()) {
+    if (rj_child_refuses_fd(oldfd))
+      return -1;
+    return static_cast<int>(syscall(SYS_dup2, oldfd, newfd));
+  }
   // dup2(fd, fd) is a POSIX no-op that leaves the descriptor live; mutating
   // tracking would drop a still-open ref. Forward without touching tracking.
   if (oldfd == newfd)
     return InterposerContext::real().dup2(oldfd, newfd);
   std::optional<InterposerContext::DupBackend> reserved;
   InterposerContext::DrmFileToken drm_file;
-  std::optional<uint64_t> closed_drm_file_id;
+  InterposerContext::DrmFinalRelease overwritten_release;
+  InterposerContext::DrmFinalRelease displaced_release;
   int rc;
+  // Reserve the backend BEFORE the DRM lifecycle lock. reserve_dup_backend() takes
+  // init_mutex_ for a tracked KFD fd, while driver code running under init_mutex_
+  // reaches the interposed close() hook, which takes drm_fd_lifecycle_mutex_ --
+  // acquiring them in the other order here would close an ABBA cycle between a dup
+  // and a close. Only "reserve before the syscall" is load-bearing, and it still
+  // holds; the failure path below releases the reservation outside the lock too.
+  reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
   {
     auto drm_lifecycle = InterposerContext::ctx.lock_drm_fd_lifecycle();
-    reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
     drm_file = InterposerContext::ctx.reserve_drm_file(oldfd);
     rc = InterposerContext::real().dup2(oldfd, newfd);
     if (rc >= 0) {
       auto drm_close = InterposerContext::ctx.untrack_drm(rc);
-      closed_drm_file_id = drm_close.closed_file_id;
-      auto displaced = InterposerContext::ctx.commit_drm_dup(rc, drm_file);
-      if (displaced)
-        closed_drm_file_id = displaced;
+      overwritten_release = std::move(drm_close.release);
+      displaced_release = InterposerContext::ctx.commit_drm_dup(rc, drm_file);
     }
   }
   if (rc < 0) {
@@ -2702,30 +3657,40 @@ RJ_INTERPOSER_EXPORT int dup2(int oldfd, int newfd) {
     errno = saved_errno;
     return rc;
   }
-  reconcile_dup_target(rc, reserved, closed_drm_file_id);
+  reconcile_dup_target(rc, reserved, std::move(overwritten_release), std::move(displaced_release));
   return rc;
 }
 
 #ifdef SYS_dup3
 RJ_INTERPOSER_EXPORT int dup3(int oldfd, int newfd, int flags) {
   assert(InterposerContext::real().ready());
+  if (!rj_owns_interposer_state()) {
+    if (rj_child_refuses_fd(oldfd))
+      return -1;
+    return static_cast<int>(syscall(SYS_dup3, oldfd, newfd, flags));
+  }
   // dup3(fd, fd, ...) is required to fail with EINVAL without altering the
   // descriptor; do not mutate tracking before the syscall confirms that.
   std::optional<InterposerContext::DupBackend> reserved;
   InterposerContext::DrmFileToken drm_file;
-  std::optional<uint64_t> closed_drm_file_id;
+  InterposerContext::DrmFinalRelease overwritten_release;
+  InterposerContext::DrmFinalRelease displaced_release;
   int rc;
+  // Reserve the backend BEFORE the DRM lifecycle lock. reserve_dup_backend() takes
+  // init_mutex_ for a tracked KFD fd, while driver code running under init_mutex_
+  // reaches the interposed close() hook, which takes drm_fd_lifecycle_mutex_ --
+  // acquiring them in the other order here would close an ABBA cycle between a dup
+  // and a close. Only "reserve before the syscall" is load-bearing, and it still
+  // holds; the failure path below releases the reservation outside the lock too.
+  reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
   {
     auto drm_lifecycle = InterposerContext::ctx.lock_drm_fd_lifecycle();
-    reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
     drm_file = InterposerContext::ctx.reserve_drm_file(oldfd);
     rc = InterposerContext::real().dup3(oldfd, newfd, flags);
     if (rc >= 0) {
       auto drm_close = InterposerContext::ctx.untrack_drm(rc);
-      closed_drm_file_id = drm_close.closed_file_id;
-      auto displaced = InterposerContext::ctx.commit_drm_dup(rc, drm_file);
-      if (displaced)
-        closed_drm_file_id = displaced;
+      overwritten_release = std::move(drm_close.release);
+      displaced_release = InterposerContext::ctx.commit_drm_dup(rc, drm_file);
     }
   }
   if (rc < 0) {
@@ -2736,7 +3701,7 @@ RJ_INTERPOSER_EXPORT int dup3(int oldfd, int newfd, int flags) {
     errno = saved_errno;
     return rc;
   }
-  reconcile_dup_target(rc, reserved, closed_drm_file_id);
+  reconcile_dup_target(rc, reserved, std::move(overwritten_release), std::move(displaced_release));
   return rc;
 }
 #endif
@@ -2806,6 +3771,23 @@ namespace {
 // ABI, so InterposerContext::real().fcntl services both.
 int fcntl_impl(int fd, int cmd, void *ptr_arg, int int_arg) {
   FcntlArgKind kind = fcntl_arg_kind(cmd);
+  // Gate here rather than in fcntl()/fcntl64(): both funnel through this, and the
+  // F_DUPFD paths below touch inherited dup and DRM tracking.
+  if (!rj_owns_interposer_state()) {
+    // Two ways to launder hardware authority past exec, not one: duplicating the
+    // descriptor, OR clearing FD_CLOEXEC on the descriptor already held, which needs
+    // no duplication at all. Ordinary fcntl queries on an inherited fd are harmless
+    // and must keep working, so only these are gated.
+    const bool duplicates = (cmd == F_DUPFD || cmd == F_DUPFD_CLOEXEC);
+    const bool launders_across_exec = (cmd == F_SETFD && (int_arg & FD_CLOEXEC) == 0);
+    if ((duplicates || launders_across_exec) && rj_child_refuses_fd(fd))
+      return -1;
+    if (kind == FcntlArgKind::Ptr)
+      return InterposerContext::real().fcntl(fd, cmd, ptr_arg);
+    if (kind == FcntlArgKind::Int)
+      return InterposerContext::real().fcntl(fd, cmd, int_arg);
+    return InterposerContext::real().fcntl(fd, cmd);
+  }
   // F_DUPFD/F_DUPFD_CLOEXEC create a new fd like dup(); reserve the source
   // backend BEFORE the syscall so a racing last-close cannot tear it down
   // between the dup and tracking the new fd. F_DUPFD does not overwrite an
@@ -2813,7 +3795,6 @@ int fcntl_impl(int fd, int cmd, void *ptr_arg, int int_arg) {
   const bool is_dupfd = (cmd == F_DUPFD || cmd == F_DUPFD_CLOEXEC);
   std::optional<InterposerContext::DupBackend> reserved;
   InterposerContext::DrmFileToken drm_file;
-  std::optional<uint64_t> closed_file_id;
   const auto invoke = [&]() -> long {
     switch (kind) {
     case FcntlArgKind::Int:
@@ -2826,14 +3807,22 @@ int fcntl_impl(int fd, int cmd, void *ptr_arg, int int_arg) {
     }
   };
 
+  InterposerContext::DrmFinalRelease drm_release;
   long rc;
+  // Reserve the backend BEFORE the DRM lifecycle lock. reserve_dup_backend() takes
+  // init_mutex_ for a tracked KFD fd, while driver code running under init_mutex_
+  // reaches the interposed close() hook, which takes drm_fd_lifecycle_mutex_ --
+  // acquiring them in the other order here would close an ABBA cycle between a dup
+  // and a close. Only "reserve before the syscall" is load-bearing, and it still
+  // holds; the failure path below releases the reservation outside the lock too.
+  if (is_dupfd)
+    reserved = InterposerContext::ctx.reserve_dup_backend(fd);
   if (is_dupfd) {
     auto drm_lifecycle = InterposerContext::ctx.lock_drm_fd_lifecycle();
-    reserved = InterposerContext::ctx.reserve_dup_backend(fd);
     drm_file = InterposerContext::ctx.reserve_drm_file(fd);
     rc = invoke();
     if (rc >= 0)
-      closed_file_id = InterposerContext::ctx.commit_drm_dup(static_cast<int>(rc), drm_file);
+      drm_release = InterposerContext::ctx.commit_drm_dup(static_cast<int>(rc), drm_file);
   } else {
     rc = invoke();
   }
@@ -2850,8 +3839,7 @@ int fcntl_impl(int fd, int cmd, void *ptr_arg, int int_arg) {
         InterposerContext::ctx.commit_dup(static_cast<int>(rc), *reserved);
       else
         InterposerContext::ctx.untrack_dup(static_cast<int>(rc));
-      if (closed_file_id)
-        InterposerContext::ctx.reap_gem_for_drm_file(*closed_file_id);
+      InterposerContext::ctx.complete_drm_release(std::move(drm_release));
     }
   }
   return static_cast<int>(rc);
@@ -2891,40 +3879,88 @@ RJ_INTERPOSER_EXPORT int fcntl64(int fd, int cmd, ...) {
   return fcntl_impl(fd, cmd, ptr_arg, int_arg);
 }
 
+// libdrm and any translation unit built with _FILE_OFFSET_BITS=64 bind mmap64, not
+// mmap, exactly as they bind fcntl64 rather than fcntl. Exporting only mmap would let
+// those calls bypass the child real-GPU refusal, local/remote KFD routing, per-file
+// DRM lease routing, and doorbell/daemon shared-memory handling. Both symbols share
+// one implementation so the two can never drift.
+static void *mmap_impl(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
+
 RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, int fd,
                                 off_t offset) {
+  return mmap_impl(addr, length, prot, flags, fd, offset);
+}
+
+RJ_INTERPOSER_EXPORT void *mmap64(void *addr, size_t length, int prot, int flags, int fd,
+                                  off64_t offset) {
+  // off_t is 64-bit on the supported target, so this is a width-preserving forward.
+  // The static_assert makes a narrower off_t a build failure rather than a silent
+  // offset truncation.
+  static_assert(sizeof(off_t) == sizeof(off64_t),
+                "mmap64 would truncate its offset: off_t is narrower than off64_t");
+  return mmap_impl(addr, length, prot, flags, fd, static_cast<off_t>(offset));
+}
+
+static void *mmap_impl(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
   if (!InterposerContext::real().ready() || !InterposerContext::real().mmap)
     return raw_mmap_syscall(addr, length, prot, flags, fd, offset);
+  if (!rj_owns_interposer_state()) {
+    if (rj_child_refuses_fd(fd))
+      return MAP_FAILED;
+    return InterposerContext::real().mmap(addr, length, prot, flags, fd, offset);
+  }
 
   assert(InterposerContext::real().ready());
   if (auto remote = InterposerContext::ctx.remote_lookup(fd))
     return remote->mmap(addr, length, prot, flags, offset);
 
-  if (auto *drv = InterposerContext::ctx.lookup(fd))
-    return drv->mmap(addr, length, prot, flags, offset);
+  // Classify and dispatch the LOCAL branches on a driver snapshot, which keeps the
+  // VM/GuestKfd alive for the duration. For a Remote-backed fd, capture a
+  // lifetime-extending remote snapshot and dispatch that instead.
+  std::shared_ptr<RemoteDriver> remote_mmap;
+  {
 
-  // Dispatch a tracked KFD dup by its RECORDED backend (as ioctl() does), not by
-  // "remote if any remote is live"; otherwise a Local-tagged dup would misroute
-  // to the remote in mixed local+daemon mode. For Remote, route via the remote
-  // snapshot directly so routing still works if the primary fd number changed.
-  if (auto backend = InterposerContext::ctx.kfd_backend_of(fd)) {
-    if (*backend == InterposerContext::DupBackend::Remote) {
-      if (auto remote = InterposerContext::ctx.remote())
-        return remote->mmap(addr, length, prot, flags, offset);
-    } else if (auto *drv = InterposerContext::ctx.driver()) {
+    if (auto drv = InterposerContext::ctx.lookup(fd))
       return drv->mmap(addr, length, prot, flags, offset);
+
+    // Dispatch a tracked KFD dup by its RECORDED backend (as ioctl() does), not by
+    // "remote if any remote is live", so routing follows the reference the dup
+    // actually holds. For Remote, route via the remote snapshot directly so routing
+    // still works if the primary fd number changed.
+    if (auto backend = InterposerContext::ctx.kfd_backend_of(fd)) {
+      if (*backend == InterposerContext::DupBackend::Remote) {
+        remote_mmap = InterposerContext::ctx.remote();
+      } else if (auto drv = InterposerContext::ctx.driver()) {
+        return drv->mmap(addr, length, prot, flags, offset);
+      }
+    }
+
+    // A tracked DRM fd routes by the backend ITS FILE leased, not by "remote if any
+    // remote is live" -- the file's lease is the authority on which backend owns it.
+    // The reservation also keeps that lease alive and the file's identity pinned
+    // across the dispatch, so a racing close cannot retire the backend or detach the
+    // file mid-call.
+    if (!remote_mmap) {
+      if (auto drm_file = InterposerContext::ctx.reserve_drm_file(fd)) {
+        InterposerContext::DrmFileReservation held(InterposerContext::ctx, drm_file);
+        const auto &lease = drm_file->backend_lease;
+        // BOTH branches dispatch inside the reservation. Holding a shared_ptr keeps
+        // the object allocated but not OPERATIONAL: if the reservation were released
+        // first and a racing final close made it the last reference, the lease would
+        // run release_remote_open(), RemoteDriver::close() would drop the RPC
+        // socket, and this mmap would then execute against a closed connection.
+        // Keeping the lease alive across the call is the whole point of it.
+        if (const auto &local = lease.local())
+          return local->mmap(addr, length, prot, flags, offset);
+        if (const auto &remote = lease.remote())
+          return remote->mmap(addr, length, prot, flags, offset);
+      }
     }
   }
-
-  if (InterposerContext::ctx.is_drm(fd)) {
-    // Route via the remote snapshot (not remote_lookup(remote_kfd_fd())): a
-    // dup2/dup3 may have cleared the primary fd number while the connection is
-    // still live via other refs, and this DRM fd still belongs to that remote.
-    if (auto remote = InterposerContext::ctx.remote())
-      return remote->mmap(addr, length, prot, flags, offset);
-    if (auto *drv = InterposerContext::ctx.driver())
-      return drv->mmap(addr, length, prot, flags, offset);
-  }
+  // Pin dropped: dispatch the remote op on the lifetime-extending snapshot so a
+  // stalled daemon cannot block local-VM teardown.
+  if (remote_mmap)
+    return remote_mmap->mmap(addr, length, prot, flags, offset);
 
   if (fd < 0 && (flags & MAP_FIXED) && prot != PROT_NONE && addr) {
     int memfd_out = -1;
@@ -2967,7 +4003,7 @@ RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, 
     }
   }
   if ((flags & MAP_FIXED) && addr) {
-    if (auto *driver = InterposerContext::ctx.driver())
+    if (auto driver = InterposerContext::ctx.driver())
       return driver->mmap_replacing_client_doorbell_views(addr, length, prot, flags, fd, offset);
   }
   return InterposerContext::real().mmap(addr, length, prot, flags, fd, offset);
@@ -2975,27 +4011,37 @@ RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, 
 
 RJ_INTERPOSER_EXPORT int mprotect(void *addr, size_t length, int prot) {
   assert(InterposerContext::real().ready());
-  auto *drv = InterposerContext::ctx.driver();
-  if (drv && drv->is_doorbell_range(addr, length)) {
-    errno = EPERM;
-    return -1;
+  if (!rj_owns_interposer_state())
+    return InterposerContext::real().mprotect(addr, length, prot);
+  {
+    auto drv = InterposerContext::ctx.driver();
+    if (drv && drv->is_doorbell_range(addr, length)) {
+      errno = EPERM;
+      return -1;
+    }
   }
   return InterposerContext::real().mprotect(addr, length, prot);
 }
 
 RJ_INTERPOSER_EXPORT int madvise(void *addr, size_t length, int advice) {
   assert(InterposerContext::real().ready());
+  if (!rj_owns_interposer_state())
+    return InterposerContext::real().madvise(addr, length, advice);
   const bool high_gpu_address = reinterpret_cast<uintptr_t>(addr) >= 0x1000000000ULL;
   if (advice == MADV_HUGEPAGE && high_gpu_address)
     return 0;
-  if (advice == MADV_DONTFORK && high_gpu_address && InterposerContext::ctx.driver_is_simulated())
-    return 0;
+  if (advice == MADV_DONTFORK && high_gpu_address) {
+    if (InterposerContext::ctx.driver_is_simulated())
+      return 0;
+  }
   return InterposerContext::real().madvise(addr, length, advice);
 }
 
 RJ_INTERPOSER_EXPORT int munmap(void *addr, size_t length) {
   if (!InterposerContext::real().ready() || !InterposerContext::real().munmap)
     return raw_munmap_syscall(addr, length);
+  if (!rj_owns_interposer_state())
+    return InterposerContext::real().munmap(addr, length);
 
   assert(InterposerContext::real().ready());
   // Address-based unmap: try the live remote snapshot regardless of whether the
@@ -3006,11 +4052,12 @@ RJ_INTERPOSER_EXPORT int munmap(void *addr, size_t length) {
     if (ret != -ENOENT)
       return ret;
   }
-  auto *drv = InterposerContext::ctx.driver();
-  if (drv) {
-    int ret = drv->munmap(addr, length);
-    if (ret != -ENOENT)
-      return ret;
+  {
+    if (auto drv = InterposerContext::ctx.driver()) {
+      int ret = drv->munmap(addr, length);
+      if (ret != -ENOENT)
+        return ret;
+    }
   }
   return InterposerContext::real().munmap(addr, length);
 }
@@ -3025,6 +4072,30 @@ RJ_INTERPOSER_EXPORT FILE *fopen(const char *path, const char *mode) {
   if (!InterposerContext::real().ready()) {
     auto fn = util::lookup_symbol<FILE *(*)(const char *, const char *)>(RTLD_NEXT, "fopen");
     return fn ? fn(path, mode) : nullptr;
+  }
+  if (!rj_owns_interposer_state()) {
+    int refuse_errno = 0;
+    if (rj_child_must_refuse_open(AT_FDCWD, path, &refuse_errno)) {
+      errno = refuse_errno;
+      return nullptr;
+    }
+    // Call libc's fopen and POST-validate, rather than re-deriving open flags and
+    // using fdopen. Re-deriving loses semantics only libc's own mode parser has: the
+    // 0666 creation mode for "w"/"a", "x" (exclusive -- must fail EEXIST rather than
+    // truncate), and "e" (FD_CLOEXEC). Validating the descriptor afterwards closes
+    // the same path-swap window without reimplementing any of that.
+    FILE *stream = InterposerContext::real().fopen(path, mode);
+    if (!stream)
+      return nullptr;
+    struct stat st {};
+    const int fd = fileno(stream);
+    if (fd >= 0 && InterposerContext::real().fstat_fn &&
+        InterposerContext::real().fstat_fn(fd, &st) == 0 && rj_is_gpu_device_stat(st)) {
+      fclose(stream);
+      errno = ENODEV;
+      return nullptr;
+    }
+    return stream;
   }
   if (!path || !mode)
     return nullptr;
@@ -3054,6 +4125,39 @@ RJ_INTERPOSER_EXPORT FILE *fopen64(const char *path, const char *mode) { return 
 RJ_INTERPOSER_EXPORT FILE *freopen(const char *path, const char *mode, FILE *stream) {
   if (!path || !mode)
     return nullptr;
+  if (InterposerContext::real().ready() && !rj_owns_interposer_state()) {
+    int refuse_errno = 0;
+    if (rj_child_must_refuse_open(AT_FDCWD, path, &refuse_errno)) {
+      // POSIX freopen closes the original stream FIRST and does so even when opening
+      // the replacement fails, so refusing must not leave the caller's descriptor
+      // live -- it would otherwise outlive a failed freopen and survive the exec that
+      // follows. fclose can set errno itself, so restore ours afterwards. Guarded
+      // because the owner path below treats a null stream as reachable too.
+      RJ_DIAGNOSTIC_PUSH
+      RJ_DIAGNOSTIC_IGNORE_NONNULL_COMPARE
+      if (stream)
+        fclose(stream);
+      RJ_DIAGNOSTIC_POP
+      errno = refuse_errno;
+      return nullptr;
+    }
+    // freopen cannot be expressed as fdopen of a pre-validated descriptor -- it must
+    // rebind the caller's stream -- so validate AFTER the fact instead, closing the
+    // classify/reopen window from the other side. A swapped symlink that lands a GPU
+    // device here is closed before the stream is returned.
+    FILE *reopened = InterposerContext::real().freopen(path, mode, stream);
+    if (!reopened)
+      return nullptr;
+    struct stat st {};
+    const int fd = fileno(reopened);
+    if (fd >= 0 && InterposerContext::real().fstat_fn &&
+        InterposerContext::real().fstat_fn(fd, &st) == 0 && rj_is_gpu_device_stat(st)) {
+      fclose(reopened);
+      errno = ENODEV;
+      return nullptr;
+    }
+    return reopened;
+  }
   RJ_DIAGNOSTIC_PUSH
   RJ_DIAGNOSTIC_IGNORE_NONNULL_COMPARE
   if (stream)
@@ -3100,14 +4204,16 @@ static std::string redirect_sys_dev_char(const char *path) {
     return {};
 
   std::string drm_base;
-  auto *drv = InterposerContext::ctx.driver();
-  if (drv) {
-    auto direct = drv->redirect_sysfs_path(path);
-    if (!direct.empty())
-      return direct;
-    drm_base = drv->drm_path();
-  } else {
-    drm_base = InterposerContext::ctx.remote_drm_path();
+  {
+    auto drv = InterposerContext::ctx.driver();
+    if (drv) {
+      auto direct = drv->redirect_sysfs_path(path);
+      if (!direct.empty())
+        return direct;
+      drm_base = drv->drm_path();
+    } else {
+      drm_base = InterposerContext::ctx.remote_drm_path();
+    }
   }
   if (drm_base.empty())
     return {};
@@ -3126,12 +4232,37 @@ static std::string redirect_sys_dev_char(const char *path) {
 // destroyed when this function returns, so a concurrent teardown could free the
 // object while the caller still dereferenced the pointer. A copy is cheap and
 // severs that lifetime dependency.
-static std::optional<Sysfs::GpuInfo> interposer_gpu_info(uint32_t render_minor) {
-  auto *drv = InterposerContext::ctx.driver();
-  if (drv) {
-    if (const Sysfs::GpuInfo *info = drv->gpu_info_for_render_minor(render_minor))
+/// @brief GPU metadata for a DRM file, answered by ITS backend.
+/// @details The file's lease is immutable for its whole life, so this cannot drift
+/// onto another backend the way a global lookup can. Falls back to the global helper
+/// only for a file with no lease (which cannot happen for a synthetic node, but
+/// keeps this total).
+static std::optional<Sysfs::GpuInfo>
+interposer_gpu_info_for(const InterposerContext::DrmFileToken &file) {
+  if (!file)
+    return std::nullopt;
+  const uint32_t render_minor = InterposerContext::ctx.drm_render_minor(file);
+  const auto &lease = file->backend_lease;
+  if (const auto &local = lease.local()) {
+    if (const Sysfs::GpuInfo *info = local->gpu_info_for_render_minor(render_minor))
       return *info;
     return std::nullopt;
+  }
+  if (const auto &remote = lease.remote()) {
+    if (const Sysfs::GpuInfo *info = remote->gpu_info())
+      return *info;
+    return std::nullopt;
+  }
+  return interposer_gpu_info(render_minor);
+}
+
+static std::optional<Sysfs::GpuInfo> interposer_gpu_info(uint32_t render_minor) {
+  {
+    if (auto drv = InterposerContext::ctx.driver()) {
+      if (const Sysfs::GpuInfo *info = drv->gpu_info_for_render_minor(render_minor))
+        return *info;
+      return std::nullopt;
+    }
   }
   if (auto remote = InterposerContext::ctx.remote()) {
     if (const Sysfs::GpuInfo *info = remote->gpu_info())
@@ -3157,14 +4288,16 @@ static std::string redirect_dev_dri(const char *path) {
   if (!is_dir && !is_node)
     return {};
   std::string drm_base;
-  auto *drv = InterposerContext::ctx.driver();
-  if (drv) {
-    auto direct = drv->redirect_sysfs_path(path);
-    if (!direct.empty())
-      return direct;
-    drm_base = drv->drm_path();
-  } else {
-    drm_base = InterposerContext::ctx.remote_drm_path();
+  {
+    auto drv = InterposerContext::ctx.driver();
+    if (drv) {
+      auto direct = drv->redirect_sysfs_path(path);
+      if (!direct.empty())
+        return direct;
+      drm_base = drv->drm_path();
+    } else {
+      drm_base = InterposerContext::ctx.remote_drm_path();
+    }
   }
   if (drm_base.empty())
     return {};
@@ -3178,6 +4311,8 @@ RJ_INTERPOSER_EXPORT int stat(const char *path, struct stat *buf) {
     auto fn = util::lookup_symbol<int (*)(const char *, struct stat *)>(RTLD_NEXT, "stat");
     return fn ? fn(path, buf) : -1;
   }
+  if (!rj_owns_interposer_state())
+    return InterposerContext::real().stat(path, buf);
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
@@ -3193,6 +4328,8 @@ RJ_INTERPOSER_EXPORT int lstat(const char *path, struct stat *buf) {
     auto fn = util::lookup_symbol<int (*)(const char *, struct stat *)>(RTLD_NEXT, "lstat");
     return fn ? fn(path, buf) : -1;
   }
+  if (!rj_owns_interposer_state())
+    return InterposerContext::real().lstat(path, buf);
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
@@ -3208,6 +4345,8 @@ RJ_INTERPOSER_EXPORT int access(const char *path, int mode) {
     auto fn = util::lookup_symbol<int (*)(const char *, int)>(RTLD_NEXT, "access");
     return fn ? fn(path, mode) : -1;
   }
+  if (!rj_owns_interposer_state())
+    return InterposerContext::real().access(path, mode);
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
@@ -3225,6 +4364,8 @@ RJ_INTERPOSER_EXPORT DIR *opendir(const char *name) {
     auto fn = util::lookup_symbol<DIR *(*)(const char *)>(RTLD_NEXT, "opendir");
     return fn ? fn(name) : nullptr;
   }
+  if (!rj_owns_interposer_state())
+    return InterposerContext::real().opendir(name);
   auto *volatile p_od = name;
   if (!p_od) {
     errno = EINVAL;
@@ -3249,6 +4390,8 @@ RJ_INTERPOSER_EXPORT int fstat(int fd, struct stat *buf) {
     auto fn = util::lookup_symbol<int (*)(int, struct stat *)>(RTLD_NEXT, "fstat");
     return fn ? fn(fd, buf) : -1;
   }
+  if (!rj_owns_interposer_state())
+    return InterposerContext::real().fstat_fn(fd, buf);
   int rc = InterposerContext::real().fstat_fn(fd, buf);
   if (rc == 0 && InterposerContext::ctx.is_drm(fd)) {
     uint32_t render_minor = InterposerContext::ctx.drm_render_minor(fd);
@@ -3259,12 +4402,20 @@ RJ_INTERPOSER_EXPORT int fstat(int fd, struct stat *buf) {
 }
 
 RJ_INTERPOSER_EXPORT int fstat64(int fd, struct stat64 *buf) {
-  using fstat64_fn_t = int (*)(int, struct stat64 *);
-  static fstat64_fn_t real_fstat64 = util::lookup_symbol<fstat64_fn_t>(RTLD_NEXT, "fstat64");
-  if (!real_fstat64)
+  auto &real = InterposerContext::real();
+  if (!real.fstat64_fn) {
+    // The alias table is resolved eagerly in init(); a call that lands before
+    // that has no passthrough to use. Fail with an errno rather than -1 alone,
+    // which would leave the caller reading a stale one.
+    errno = ENOSYS;
     return -1;
-  int rc = real_fstat64(fd, buf);
-  if (rc == 0 && InterposerContext::real().ready() && InterposerContext::ctx.is_drm(fd)) {
+  }
+  int rc = real.fstat64_fn(fd, reinterpret_cast<void *>(buf));
+  // Gate BEFORE is_drm(), which takes fd_mutex_. No lazy static above this point:
+  // its initialization guard could be inherited mid-init by a forked child.
+  if (rc != 0 || !real.ready() || !rj_owns_interposer_state())
+    return rc;
+  if (InterposerContext::ctx.is_drm(fd)) {
     uint32_t render_minor = InterposerContext::ctx.drm_render_minor(fd);
     buf->st_rdev = makedev(226, render_minor);
     buf->st_mode = (buf->st_mode & ~S_IFMT) | S_IFCHR;
@@ -3273,12 +4424,20 @@ RJ_INTERPOSER_EXPORT int fstat64(int fd, struct stat64 *buf) {
 }
 
 RJ_INTERPOSER_EXPORT int __fxstat(int ver, int fd, struct stat *buf) {
-  using fxstat_fn_t = int (*)(int, int, struct stat *);
-  static fxstat_fn_t real_fxstat = util::lookup_symbol<fxstat_fn_t>(RTLD_NEXT, "__fxstat");
-  if (!real_fxstat)
+  auto &real = InterposerContext::real();
+  if (!real.fxstat_fn) {
+    // The alias table is resolved eagerly in init(); a call that lands before
+    // that has no passthrough to use. Fail with an errno rather than -1 alone,
+    // which would leave the caller reading a stale one.
+    errno = ENOSYS;
     return -1;
-  int rc = real_fxstat(ver, fd, buf);
-  if (rc == 0 && InterposerContext::real().ready() && InterposerContext::ctx.is_drm(fd)) {
+  }
+  int rc = real.fxstat_fn(ver, fd, buf);
+  // Gate BEFORE is_drm(), which takes fd_mutex_. No lazy static above this point:
+  // its initialization guard could be inherited mid-init by a forked child.
+  if (rc != 0 || !real.ready() || !rj_owns_interposer_state())
+    return rc;
+  if (InterposerContext::ctx.is_drm(fd)) {
     uint32_t render_minor = InterposerContext::ctx.drm_render_minor(fd);
     buf->st_rdev = makedev(226, render_minor);
     buf->st_mode = (buf->st_mode & ~S_IFMT) | S_IFCHR;
@@ -3287,12 +4446,20 @@ RJ_INTERPOSER_EXPORT int __fxstat(int ver, int fd, struct stat *buf) {
 }
 
 RJ_INTERPOSER_EXPORT int __fxstat64(int ver, int fd, struct stat64 *buf) {
-  using fxstat64_fn_t = int (*)(int, int, struct stat64 *);
-  static fxstat64_fn_t real_fxstat64 = util::lookup_symbol<fxstat64_fn_t>(RTLD_NEXT, "__fxstat64");
-  if (!real_fxstat64)
+  auto &real = InterposerContext::real();
+  if (!real.fxstat64_fn) {
+    // The alias table is resolved eagerly in init(); a call that lands before
+    // that has no passthrough to use. Fail with an errno rather than -1 alone,
+    // which would leave the caller reading a stale one.
+    errno = ENOSYS;
     return -1;
-  int rc = real_fxstat64(ver, fd, buf);
-  if (rc == 0 && InterposerContext::real().ready() && InterposerContext::ctx.is_drm(fd)) {
+  }
+  int rc = real.fxstat64_fn(ver, fd, reinterpret_cast<void *>(buf));
+  // Gate BEFORE is_drm(), which takes fd_mutex_. No lazy static above this point:
+  // its initialization guard could be inherited mid-init by a forked child.
+  if (rc != 0 || !real.ready() || !rj_owns_interposer_state())
+    return rc;
+  if (InterposerContext::ctx.is_drm(fd)) {
     uint32_t render_minor = InterposerContext::ctx.drm_render_minor(fd);
     buf->st_rdev = makedev(226, render_minor);
     buf->st_mode = (buf->st_mode & ~S_IFMT) | S_IFCHR;
@@ -3307,6 +4474,8 @@ RJ_INTERPOSER_EXPORT ssize_t readlink(const char *path, char *buf, size_t bufsiz
     auto fn = util::lookup_symbol<ssize_t (*)(const char *, char *, size_t)>(RTLD_NEXT, "readlink");
     return fn ? fn(path, buf, bufsiz) : -1;
   }
+  if (!rj_owns_interposer_state())
+    return InterposerContext::real().readlink_fn(path, buf, bufsiz);
   auto redirected = redirect_sys_dev_char(path);
   if (redirected.empty())
     redirected = redirect_sysfs_path(path);
@@ -3317,92 +4486,147 @@ RJ_INTERPOSER_EXPORT ssize_t readlink(const char *path, char *buf, size_t bufsiz
 // -- stat64/lstat64 interposition (distinct from stat on glibc 2.33+) --
 
 RJ_INTERPOSER_EXPORT int stat64(const char *path, struct stat64 *buf) {
-  using stat64_fn_t = int (*)(const char *, struct stat64 *);
-  static stat64_fn_t real_stat64 = util::lookup_symbol<stat64_fn_t>(RTLD_NEXT, "stat64");
-  if (!real_stat64)
+  auto &real = InterposerContext::real();
+  if (!real.stat64_fn) {
+    // The alias table is resolved eagerly in init(); a call that lands before
+    // that has no passthrough to use. Fail with an errno rather than -1 alone,
+    // which would leave the caller reading a stale one.
+    errno = ENOSYS;
     return -1;
+  }
+  // Gate BEFORE redirect_sysfs_path(), which reaches published driver and fd state.
+  // No lazy static above this point (see LibcPassthrough for why).
+  if (!real.ready() || !rj_owns_interposer_state())
+    return real.stat64_fn(path, reinterpret_cast<void *>(buf));
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
   if (redirected.empty())
     redirected = redirect_dev_dri(path);
-  const char *actual = redirected.empty() ? path : redirected.c_str();
-  return real_stat64(actual, buf);
+  if (redirected.empty())
+    return real.stat64_fn(path, reinterpret_cast<void *>(buf));
+  return real.stat64_fn(redirected.c_str(), reinterpret_cast<void *>(buf));
 }
 
 RJ_INTERPOSER_EXPORT int lstat64(const char *path, struct stat64 *buf) {
-  using lstat64_fn_t = int (*)(const char *, struct stat64 *);
-  static lstat64_fn_t real_lstat64 = util::lookup_symbol<lstat64_fn_t>(RTLD_NEXT, "lstat64");
-  if (!real_lstat64)
+  auto &real = InterposerContext::real();
+  if (!real.lstat64_fn) {
+    // The alias table is resolved eagerly in init(); a call that lands before
+    // that has no passthrough to use. Fail with an errno rather than -1 alone,
+    // which would leave the caller reading a stale one.
+    errno = ENOSYS;
     return -1;
+  }
+  // Gate BEFORE redirect_sysfs_path(), which reaches published driver and fd state.
+  // No lazy static above this point (see LibcPassthrough for why).
+  if (!real.ready() || !rj_owns_interposer_state())
+    return real.lstat64_fn(path, reinterpret_cast<void *>(buf));
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
   if (redirected.empty())
     redirected = redirect_dev_dri(path);
-  const char *actual = redirected.empty() ? path : redirected.c_str();
-  return real_lstat64(actual, buf);
+  if (redirected.empty())
+    return real.lstat64_fn(path, reinterpret_cast<void *>(buf));
+  return real.lstat64_fn(redirected.c_str(), reinterpret_cast<void *>(buf));
 }
 
 RJ_INTERPOSER_EXPORT int __xstat(int ver, const char *path, struct stat *buf) {
-  using xstat_fn_t = int (*)(int, const char *, struct stat *);
-  static xstat_fn_t real_xstat = util::lookup_symbol<xstat_fn_t>(RTLD_NEXT, "__xstat");
-  if (!real_xstat)
+  auto &real = InterposerContext::real();
+  if (!real.xstat_fn) {
+    // The alias table is resolved eagerly in init(); a call that lands before
+    // that has no passthrough to use. Fail with an errno rather than -1 alone,
+    // which would leave the caller reading a stale one.
+    errno = ENOSYS;
     return -1;
+  }
+  // Gate BEFORE redirect_sysfs_path(), which reaches published driver and fd state.
+  // No lazy static above this point (see LibcPassthrough for why).
+  if (!real.ready() || !rj_owns_interposer_state())
+    return real.xstat_fn(ver, path, buf);
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
   if (redirected.empty())
     redirected = redirect_dev_dri(path);
-  const char *actual = redirected.empty() ? path : redirected.c_str();
-  return real_xstat(ver, actual, buf);
+  if (redirected.empty())
+    return real.xstat_fn(ver, path, buf);
+  return real.xstat_fn(ver, redirected.c_str(), buf);
 }
 
 RJ_INTERPOSER_EXPORT int __xstat64(int ver, const char *path, struct stat64 *buf) {
-  using xstat64_fn_t = int (*)(int, const char *, struct stat64 *);
-  static xstat64_fn_t real_xstat64 = util::lookup_symbol<xstat64_fn_t>(RTLD_NEXT, "__xstat64");
-  if (!real_xstat64)
+  auto &real = InterposerContext::real();
+  if (!real.xstat64_fn) {
+    // The alias table is resolved eagerly in init(); a call that lands before
+    // that has no passthrough to use. Fail with an errno rather than -1 alone,
+    // which would leave the caller reading a stale one.
+    errno = ENOSYS;
     return -1;
+  }
+  // Gate BEFORE redirect_sysfs_path(), which reaches published driver and fd state.
+  // No lazy static above this point (see LibcPassthrough for why).
+  if (!real.ready() || !rj_owns_interposer_state())
+    return real.xstat64_fn(ver, path, reinterpret_cast<void *>(buf));
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
   if (redirected.empty())
     redirected = redirect_dev_dri(path);
-  const char *actual = redirected.empty() ? path : redirected.c_str();
-  return real_xstat64(ver, actual, buf);
+  if (redirected.empty())
+    return real.xstat64_fn(ver, path, reinterpret_cast<void *>(buf));
+  return real.xstat64_fn(ver, redirected.c_str(), reinterpret_cast<void *>(buf));
 }
 
 RJ_INTERPOSER_EXPORT int __lxstat(int ver, const char *path, struct stat *buf) {
-  using lxstat_fn_t = int (*)(int, const char *, struct stat *);
-  static lxstat_fn_t real_lxstat = util::lookup_symbol<lxstat_fn_t>(RTLD_NEXT, "__lxstat");
-  if (!real_lxstat)
+  auto &real = InterposerContext::real();
+  if (!real.lxstat_fn) {
+    // The alias table is resolved eagerly in init(); a call that lands before
+    // that has no passthrough to use. Fail with an errno rather than -1 alone,
+    // which would leave the caller reading a stale one.
+    errno = ENOSYS;
     return -1;
+  }
+  // Gate BEFORE redirect_sysfs_path(), which reaches published driver and fd state.
+  // No lazy static above this point (see LibcPassthrough for why).
+  if (!real.ready() || !rj_owns_interposer_state())
+    return real.lxstat_fn(ver, path, buf);
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
   if (redirected.empty())
     redirected = redirect_dev_dri(path);
-  const char *actual = redirected.empty() ? path : redirected.c_str();
-  return real_lxstat(ver, actual, buf);
+  if (redirected.empty())
+    return real.lxstat_fn(ver, path, buf);
+  return real.lxstat_fn(ver, redirected.c_str(), buf);
 }
 
 RJ_INTERPOSER_EXPORT int __lxstat64(int ver, const char *path, struct stat64 *buf) {
-  using lxstat64_fn_t = int (*)(int, const char *, struct stat64 *);
-  static lxstat64_fn_t real_lxstat64 = util::lookup_symbol<lxstat64_fn_t>(RTLD_NEXT, "__lxstat64");
-  if (!real_lxstat64)
+  auto &real = InterposerContext::real();
+  if (!real.lxstat64_fn) {
+    // The alias table is resolved eagerly in init(); a call that lands before
+    // that has no passthrough to use. Fail with an errno rather than -1 alone,
+    // which would leave the caller reading a stale one.
+    errno = ENOSYS;
     return -1;
+  }
+  // Gate BEFORE redirect_sysfs_path(), which reaches published driver and fd state.
+  // No lazy static above this point (see LibcPassthrough for why).
+  if (!real.ready() || !rj_owns_interposer_state())
+    return real.lxstat64_fn(ver, path, reinterpret_cast<void *>(buf));
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
   if (redirected.empty())
     redirected = redirect_dev_dri(path);
-  const char *actual = redirected.empty() ? path : redirected.c_str();
-  return real_lxstat64(ver, actual, buf);
+  if (redirected.empty())
+    return real.lxstat64_fn(ver, path, reinterpret_cast<void *>(buf));
+  return real.lxstat64_fn(ver, redirected.c_str(), reinterpret_cast<void *>(buf));
 }
 
-// fork() is intentionally NOT interposed: the child reset is registered via
-// pthread_atfork() in InterposerContext::init(), which libc runs for every
-// fork-family primitive that goes through glibc (fork/system/popen), not just an
-// interposed fork() symbol. A passthrough wrapper here would double-run the reset.
+// fork() is intentionally NOT interposed, and needs no wrapper: the child performs
+// no rocJITsu work at all. Every interposed entry point compares owner_pid_ first
+// and passes a child straight through to libc, which covers fork-family primitives
+// that never bind our symbols anyway (system/popen/posix_spawn). See
+// InterposerContext::init() for why local mode is fork-then-exec only.
 
 } // extern "C"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -14,6 +14,7 @@
 
 #include "rocjitsu/kmd/linux/events.h"
 #include "rocjitsu/kmd/linux/kfd_topology.h"
+#include "rocjitsu/kmd/linux/libc_passthrough.h"
 #include "rocjitsu/vm/amdgpu/mtype.h"
 #include "util/unique_handle.h"
 
@@ -192,22 +193,22 @@ public:
     /// debug session ends (DISABLE) or the process tears down. Engaged only in
     /// daemon mode; empty in local mode, where @ref dbg_fd is the debugger's own
     /// descriptor and is not owned here. RAII replaces an explicit close.
-    util::UniqueHandle owned_dbg_fd;
+    UniqueDriverFd owned_dbg_fd;
 
     /// @brief Debugger-authorized access to the target's address space.
     /// @details The ptrace parent opens /proc/<target>/mem and transfers it to
     /// the daemon, which cannot use process_vm_readv/process_vm_writev itself.
-    util::UniqueHandle target_mem_fd;
+    UniqueDriverFd target_mem_fd;
 
     /// @brief Pins the target process identity and reports target exit.
     /// @details Prevents a stale session from being mistaken for a later process
     /// that reuses the same numeric pid.
-    util::UniqueHandle target_pidfd;
+    UniqueDriverFd target_pidfd;
 
     /// @brief Pins the target's procfs directory used for ptrace authorization.
     /// @details Status is opened relative to this descriptor so authorization
     /// cannot silently switch to a process that reuses the numeric pid.
-    util::UniqueHandle target_procfd;
+    UniqueDriverFd target_procfd;
 
     /// @brief Mirrors @c kfd_process::debugger_process (stored as pid instead of pointer).
     /// Linux PID of the attached debugger (ptrace parent). 0 when not attached.
@@ -230,7 +231,7 @@ public:
     /// @brief Pins the debugger process identity and reports debugger exit.
     /// @details Mirrors the kernel's debugger-process notifier: the session is
     /// disabled when the debugger task exits, even if the target remains alive.
-    util::UniqueHandle debugger_pidfd;
+    UniqueDriverFd debugger_pidfd;
 
     /// @brief One programmed hardware address-watch register (TCP_WATCH0..3).
     struct AddressWatch {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.cpp
@@ -41,6 +41,17 @@ void LibcPassthrough::resolve() {
   lstat = util::lookup_symbol<decltype(lstat)>(handle, "lstat");
   access = util::lookup_symbol<decltype(access)>(handle, "access");
   fstat_fn = util::lookup_symbol<decltype(fstat_fn)>(handle, "fstat");
+  // Legacy aliases, resolved eagerly so no wrapper needs a lazy static (see the
+  // declarations for why that matters across fork).
+  fstat64_fn = util::lookup_symbol<decltype(fstat64_fn)>(handle, "fstat64");
+  fxstat_fn = util::lookup_symbol<decltype(fxstat_fn)>(handle, "__fxstat");
+  fxstat64_fn = util::lookup_symbol<decltype(fxstat64_fn)>(handle, "__fxstat64");
+  stat64_fn = util::lookup_symbol<decltype(stat64_fn)>(handle, "stat64");
+  lstat64_fn = util::lookup_symbol<decltype(lstat64_fn)>(handle, "lstat64");
+  xstat_fn = util::lookup_symbol<decltype(xstat_fn)>(handle, "__xstat");
+  xstat64_fn = util::lookup_symbol<decltype(xstat64_fn)>(handle, "__xstat64");
+  lxstat_fn = util::lookup_symbol<decltype(lxstat_fn)>(handle, "__lxstat");
+  lxstat64_fn = util::lookup_symbol<decltype(lxstat64_fn)>(handle, "__lxstat64");
   readlink_fn = util::lookup_symbol<decltype(readlink_fn)>(handle, "readlink");
   fork = util::lookup_symbol<decltype(fork)>(handle, "fork");
   // Keep ready() false unless every required interposed libc entry point was

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.h
@@ -7,6 +7,8 @@
 #ifndef ROCJITSU_KMD_LINUX_LIBC_PASSTHROUGH_H_
 #define ROCJITSU_KMD_LINUX_LIBC_PASSTHROUGH_H_
 
+#include "util/unique_handle.h"
+
 #include <cstddef>
 #include <cstdio>
 #include <dirent.h>
@@ -48,6 +50,23 @@ public:
   int (*access)(const char *, int) = nullptr;
   int (*fstat_fn)(int, struct stat *) = nullptr;
   ssize_t (*readlink_fn)(const char *, char *, size_t) = nullptr;
+  /// @brief The nine legacy stat aliases rocJITsu also exports.
+  /// @details Resolved EAGERLY here rather than through a function-local static in
+  /// each wrapper. A lazy static's C++ initialization guard can be inherited
+  /// mid-initialization by a forked child whose initializing thread no longer
+  /// exists, deadlocking the child before it can even reach the owner-PID gate. The
+  /// interposer constructor is single-threaded, so resolving here has no such
+  /// window. struct stat64 is spelled void* to keep this header free of
+  /// _LARGEFILE64_SOURCE ordering constraints; the wrappers cast back.
+  int (*fstat64_fn)(int, void *) = nullptr;
+  int (*fxstat_fn)(int, int, struct stat *) = nullptr;
+  int (*fxstat64_fn)(int, int, void *) = nullptr;
+  int (*stat64_fn)(const char *, void *) = nullptr;
+  int (*lstat64_fn)(const char *, void *) = nullptr;
+  int (*xstat_fn)(int, const char *, struct stat *) = nullptr;
+  int (*xstat64_fn)(int, const char *, void *) = nullptr;
+  int (*lxstat_fn)(int, const char *, struct stat *) = nullptr;
+  int (*lxstat64_fn)(int, const char *, void *) = nullptr;
   pid_t (*fork)() = nullptr;
 
   /// @brief Return true after all required symbols have been resolved.
@@ -62,6 +81,33 @@ private:
 
 /// @brief Return the process-wide libc pass-through table.
 LibcPassthrough &libc_passthrough();
+
+/// @brief UniqueHandle traits that close through the libc pass-through table.
+/// @details The interposer and the drivers link into ONE DSO, and the interposer
+/// exports close() with default visibility, so a bare ::close() from driver code
+/// binds to the interposer's own hook, which classifies the fd against the active
+/// driver and can reach init_mutex_ via release_local_open(). Driver code reached
+/// through an interposed ioctl/mmap would then re-enter the interposer while it is
+/// mid-dispatch, on an fd the interposer knows nothing about. Every fd OWNED BY A
+/// DRIVER therefore uses UniqueDriverFd, never util::UniqueHandle, keeping "the
+/// driver never re-enters the interposer" total. Same rationale as
+/// safe_fstat()/safe_fcntl().
+struct PassthroughFdTraits {
+  using handle_type = int;
+
+  static handle_type invalid() noexcept { return -1; }
+  static bool is_valid(handle_type fd) noexcept { return fd >= 0; }
+  static void close(handle_type fd) noexcept {
+    // The table is unresolved until resolve() runs. These traits are reachable from
+    // any driver TU, so fall back to ::close rather than calling a null pointer;
+    // that path can only be taken before the interposer is live, so it cannot
+    // re-enter the hook this type exists to avoid.
+    auto *real_close = libc_passthrough().close;
+    static_cast<void>(real_close ? real_close(fd) : ::close(fd));
+  }
+};
+
+using UniqueDriverFd = util::BasicUniqueHandle<PassthroughFdTraits>;
 
 } // namespace rocjitsu
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/linux_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/linux_kfd.h
@@ -16,6 +16,18 @@
 
 namespace rocjitsu {
 
+/// @brief The only WAIT_EVENTS timeout the KFD ABI treats as "wait forever".
+///
+/// @details Exactly this value, not a range. The next value down, 0xFFFFFFFE, is
+/// finite -- and it is what ROCr clamps its longest wait to, so it is the large
+/// timeout actually seen in practice. Classifying that as infinite would make it the
+/// one timeout that never expires, which is not what the driver does with it. Treating
+/// it as finite costs nothing: a deadline that far out still polls and still observes
+/// shutdown cancellation, it merely also expires eventually. (Current kernels cap very
+/// large finite waits well below the value asked for, so the real duration is shorter
+/// again -- immaterial here, but it is not the literal millisecond count.)
+inline constexpr uint32_t kWaitEventsInfiniteMs = 0xFFFFFFFFu;
+
 /// @brief KFD mmap offset encoding fields, matching kfd_priv.h.
 inline constexpr uint64_t KFD_MMAP_TYPE_SHIFT = 62;
 inline constexpr uint64_t KFD_MMAP_TYPE_MASK = 0x3ULL << KFD_MMAP_TYPE_SHIFT;
@@ -44,15 +56,43 @@ public:
   /// @brief Return the /dev/kfd fd represented by this driver.
   [[nodiscard]] virtual int fd() const = 0;
 
-  /// @brief Reset inherited child-process state after fork().
-  virtual void reset_after_fork() {}
-
   /// @brief Retain one duplicate open reference, if this driver tracks them.
   /// @retval true A reference was added.
   /// @retval false This driver does not track open references, or there is no
   ///         live local process to retain (e.g. it was already torn down); the
   ///         caller must NOT treat the fd as retained.
   [[nodiscard]] virtual bool retain_local_open() { return false; }
+
+  /// @brief Number of open references this driver currently holds.
+  /// @details The interposer decides when the local backend may be torn down by
+  /// comparing this against the count it observed at publication (see
+  /// InterposerContext::local_open_ref_baseline_), so a driver reports its RAW
+  /// count here and does not need to know which references were app-facing.
+  /// Default 0 for drivers that track no references — they are always idle.
+  [[nodiscard]] virtual uint32_t local_open_ref_count() const { return 0; }
+
+  /// @brief Release any thread blocked in a driver call so it returns and drops
+  /// its driver snapshot, allowing teardown to complete.
+  /// @details Called by the interposer once it has decided to tear the local
+  /// backend down. A thread parked in an indefinite AMDKFD_IOC_WAIT_EVENTS holds a
+  /// snapshot for the whole call, which would keep the driver alive indefinitely;
+  /// only the driver can end that wait, since closing an fd does not cancel an
+  /// in-flight one.
+  ///
+  /// Every blocking call the driver SERVES ITSELF has to be covered, not only the
+  /// event wait: one that also parks a caller elsewhere -- on a debugger
+  /// acknowledgement, say -- would hold teardown behind that call's own deadline
+  /// instead. A driver that FORWARDS a blocking ioctl to a kernel it cannot interrupt
+  /// is a known residual rather than a bug here: nothing in this process can end that
+  /// wait, so teardown waits it out.
+  ///
+  /// Released waiters report a benign result their caller already handles
+  /// (KFD_IOC_WAIT_RESULT_TIMEOUT for an event wait); this mutates no event, page,
+  /// or process state. The destructive part of teardown belongs to close(). By the
+  /// time this is called teardown is committed, so the release is a one-way latch
+  /// for the driver's remaining life rather than something a later retain undoes.
+  /// Default no-op for drivers with no blocking calls. Idempotent.
+  virtual void begin_local_shutdown() {}
 
   /// @brief Outcome of invalidate_primary_fd(), telling the interposer how to
   /// follow up on a dup2/dup3 that overwrote a primary KFD fd number.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
@@ -6,6 +6,7 @@
 
 #include "rocjitsu/kmd/linux/remote_driver.h"
 #include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
+#include "rocjitsu/kmd/linux/linux_kfd.h"
 #include "rocjitsu/kmd/linux/rpc.h"
 #include "util/unique_handle.h"
 
@@ -488,7 +489,7 @@ int RemoteDriver::ioctl(unsigned long request, void *arg) {
     // This avoids both the shutdown ordering deadlock (ROCR joins signal
     // threads before calling close) AND arbitrary time-based workarounds.
     auto deadline =
-        (original_timeout >= 0xFFFFFFFEu)
+        (original_timeout == kWaitEventsInfiniteMs)
             ? std::chrono::steady_clock::time_point::max()
             : std::chrono::steady_clock::now() + std::chrono::milliseconds(original_timeout);
 
@@ -765,6 +766,12 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
   // Owned only for the duration of the send: SCM_RIGHTS installs the daemon's
   // own copies, so ours are released on every path out of here, including the
   // early returns below.
+  //
+  // These remain util::UniqueHandle (closing via ::close, i.e. through the
+  // interposer's own close hook) because RemoteDriver descriptors are the daemon
+  // client's own and the interposer's close hook classifies them as untracked and
+  // passes them through. Driver-owned fds on the LOCAL path use UniqueDriverFd
+  // instead; see PassthroughFdTraits.
   util::UniqueHandle target_mem_fd;
   util::UniqueHandle target_proc_fd;
   if (request == AMDKFD_IOC_DBG_TRAP) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -178,16 +178,6 @@ private:
   size_t size_ = 0;
 };
 
-struct PassthroughFdTraits {
-  using handle_type = int;
-
-  static handle_type invalid() noexcept { return -1; }
-  static bool is_valid(handle_type fd) noexcept { return fd >= 0; }
-  static void close(handle_type fd) noexcept { static_cast<void>(libc_passthrough().close(fd)); }
-};
-
-using UniqueDriverFd = util::BasicUniqueHandle<PassthroughFdTraits>;
-
 /// @brief fstat via the real libc, bypassing the interposer.
 /// @details Like safe_mmap: the interposer exports fstat with default visibility,
 /// so a bare fstat() from this TU binds to our own hook (which takes fd_mutex_ via
@@ -225,13 +215,16 @@ int pidfd_is_exited(int pidfd) {
 /// @retval 0 The target is still running.
 /// @retval <0 Negative errno; the state could not be determined.
 int procfd_is_zombie(int procfd) {
-  const int stat_fd = ::openat(procfd, "stat", O_RDONLY | O_CLOEXEC);
-  if (stat_fd < 0)
+  // Passthrough, not ::openat/::read/::close: these run inside driver ioctls that
+  // the interposer dispatched, so a bare ::close() here would re-enter the
+  // interposer's own close() hook mid-dispatch. See PassthroughFdTraits.
+  UniqueDriverFd stat_fd(libc_passthrough().openat(procfd, "stat", O_RDONLY | O_CLOEXEC, 0));
+  if (stat_fd.get() < 0)
     return errno == ENOENT ? 1 : -errno;
   char buffer[4096];
-  const ssize_t bytes = ::read(stat_fd, buffer, sizeof(buffer) - 1);
+  const ssize_t bytes = libc_passthrough().read(stat_fd.get(), buffer, sizeof(buffer) - 1);
   const int read_error = errno;
-  ::close(stat_fd);
+  stat_fd.reset();
   if (bytes < 0)
     return -read_error;
   buffer[bytes] = '\0';
@@ -241,34 +234,36 @@ int procfd_is_zombie(int procfd) {
   return name_end[2] == 'Z' || name_end[2] == 'X';
 }
 
-int pin_process_identity(pid_t pid, util::UniqueHandle &pidfd, util::UniqueHandle &procfd) {
+int pin_process_identity(pid_t pid, UniqueDriverFd &pidfd, UniqueDriverFd &procfd) {
   const int raw_pidfd = static_cast<int>(::syscall(SYS_pidfd_open, pid, 0));
   if (raw_pidfd < 0)
     return errno == ESRCH ? -ESRCH : -errno;
-  pidfd = util::UniqueHandle(raw_pidfd);
+  pidfd = UniqueDriverFd(raw_pidfd);
 
   const std::string proc_path = "/proc/" + std::to_string(pid);
-  const int raw_procfd = ::open(proc_path.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+  const int raw_procfd =
+      libc_passthrough().openat(AT_FDCWD, proc_path.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC, 0);
   if (raw_procfd < 0) {
     const int open_error = errno;
     const int exited = pidfd_is_exited(pidfd.get());
     return exited == 1 ? -ESRCH : (exited < 0 ? exited : -open_error);
   }
-  procfd = util::UniqueHandle(raw_procfd);
+  procfd = UniqueDriverFd(raw_procfd);
 
   const int exited = pidfd_is_exited(pidfd.get());
   return exited == 0 ? 0 : (exited == 1 ? -ESRCH : exited);
 }
 
 /// @brief Read TracerPid through a procfs directory pinned to the pidfd identity.
-int tracer_pid_of(const util::UniqueHandle &pidfd, const util::UniqueHandle &procfd,
+int tracer_pid_of(const UniqueDriverFd &pidfd, const UniqueDriverFd &procfd,
                   const SimulatedKfd::DebugIdentityValidationHook &validation_hook,
                   pid_t &tracer_pid) {
   int exited = pidfd_is_exited(pidfd.get());
   if (exited != 0)
     return exited == 1 ? -ESRCH : exited;
 
-  util::UniqueHandle status_fd(::openat(procfd.get(), "status", O_RDONLY | O_CLOEXEC));
+  UniqueDriverFd status_fd(
+      libc_passthrough().openat(procfd.get(), "status", O_RDONLY | O_CLOEXEC, 0));
   if (status_fd.get() < 0) {
     const int open_error = errno;
     const int exited = pidfd_is_exited(pidfd.get());
@@ -278,7 +273,7 @@ int tracer_pid_of(const util::UniqueHandle &pidfd, const util::UniqueHandle &pro
   std::string status;
   char buffer[4096];
   for (;;) {
-    const ssize_t count = ::read(status_fd.get(), buffer, sizeof(buffer));
+    const ssize_t count = libc_passthrough().read(status_fd.get(), buffer, sizeof(buffer));
     if (count > 0) {
       status.append(buffer, static_cast<size_t>(count));
       continue;
@@ -736,9 +731,9 @@ int SimulatedKfd::open() {
   auto proc = std::make_shared<KfdProcess>(pid, static_cast<uint32_t>(gpus_.size()));
   // client_pid_ caches getpid() at open() time; DBG_TRAP uses it to resolve a
   // self-debug target, so it must match the caller's live pid. A fork() child
-  // inherits this cache stale, but the interposer's reset_after_fork() drops the
-  // driver so the child re-open()s (and re-caches here) before any ioctl —
-  // DBG_TRAP self-resolution therefore requires a post-fork re-open.
+  // inherits this cache stale, but under the fork-then-exec contract that child
+  // never reaches the driver at all (owner_pid_ gates every interposed entry
+  // point), so the stale value is unobservable until exec replaces the image.
   proc->set_client_pid(static_cast<pid_t>(getpid()));
   proc->event_state_.reset();
   for (auto &g : gpus_) {
@@ -867,6 +862,32 @@ uint32_t SimulatedKfd::local_open_ref_count() const {
     return 0;
   auto it = processes_.find(local_process_id_);
   return it != processes_.end() ? it->second->open_ref_count() : 0;
+}
+
+void SimulatedKfd::begin_local_shutdown() {
+  // Release an indefinite-timeout WAIT_EVENTS on the local process so it returns
+  // and drops the driver snapshot that would otherwise keep this object alive.
+  // Snapshot the process, then fire the wake with process_mutex_ RELEASED:
+  // begin_wait_cancel() takes the process's own event mutex, and WAIT_EVENTS does
+  // not take process_mutex_, so the parked thread can make progress.
+  //
+  // Deliberately NOT notify_closing()/signal_page_shutdown(): those turn live ioctls
+  // into -EBADF/-ESRCH and poison the signal page, which is the caller-visible part
+  // of teardown and belongs to close(). What this does instead is release the
+  // waiters, so the ordering is "wake, then destroy" rather than two half-teardowns.
+  // The wake is one-way for this driver's life: the interposer calls it only after
+  // it has committed to teardown, so nothing clears the flags and every subsequent
+  // wait reports the same benign timeout.
+  if (auto proc = find_local_process()) {
+    proc->event_state_.begin_wait_cancel();
+    // WAIT_EVENTS is not the only call that parks. RUNTIME_ENABLE waits on the
+    // debugger's acknowledgement, and is dispatched outside op_mutex_ precisely
+    // because it blocks -- so that thread holds a driver snapshot for the whole
+    // wait and teardown would sit behind it until the handshake deadline expired.
+    // Cancelling is equally pure: the waiter reports the handshake as cancelled
+    // and no event, page or process state is mutated.
+    cancel_runtime_handshake(proc->client_pid());
+  }
 }
 
 int SimulatedKfd::close() { return close(local_process_id_); }
@@ -1483,46 +1504,52 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
   }
 
   if (type == KFD_MMAP_TYPE_EVENTS) {
-    if (proc.event_state_.memfd < 0) {
+    // Create-or-get the backing as ONE locked operation. Two concurrent event-page
+    // mmaps would otherwise both observe no backing, each build one, and hand
+    // different fds to different callers -- leaving one polling an object that
+    // never receives event updates -- besides racing the field itself.
+    const int events_fd = proc.event_state_.ensure_backing(length, [&](size_t size) -> int {
       auto raw_events_fd = memfd_create("rocjitsu_events", MFD_CLOEXEC | MFD_ALLOW_SEALING);
       if (raw_events_fd < 0)
-        return MAP_FAILED;
-      proc.event_state_.memfd = safe_fcntl(raw_events_fd, F_DUPFD_CLOEXEC, 4096);
-      if (proc.event_state_.memfd < 0)
-        proc.event_state_.memfd = raw_events_fd;
+        return -1;
+      int backing = safe_fcntl(raw_events_fd, F_DUPFD_CLOEXEC, 4096);
+      if (backing < 0)
+        backing = raw_events_fd;
       else
         libc_passthrough().close(raw_events_fd);
       {
         std::lock_guard<std::mutex> lk(owned_fds_mutex_);
-        owned_fds_.insert(proc.event_state_.memfd);
+        owned_fds_.insert(backing);
       }
-      if (ftruncate(proc.event_state_.memfd, static_cast<off_t>(length)) != 0) {
+      if (ftruncate(backing, static_cast<off_t>(size)) != 0) {
         const int ftruncate_errno = errno; // preserve across close() below
         {
           std::lock_guard<std::mutex> lk(owned_fds_mutex_);
-          owned_fds_.erase(proc.event_state_.memfd);
+          owned_fds_.erase(backing);
         }
-        libc_passthrough().close(proc.event_state_.memfd);
-        proc.event_state_.memfd = -1;
+        libc_passthrough().close(backing);
         errno = ftruncate_errno;
-        return MAP_FAILED;
+        return -1;
       }
-      fallocate(proc.event_state_.memfd, 0, 0, static_cast<off_t>(length));
+      fallocate(backing, 0, 0, static_cast<off_t>(size));
       {
-        auto *init_ptr = static_cast<uint8_t *>(
-            safe_mmap(nullptr, length, PROT_WRITE, MAP_SHARED, proc.event_state_.memfd, 0));
+        auto *init_ptr =
+            static_cast<uint8_t *>(safe_mmap(nullptr, size, PROT_WRITE, MAP_SHARED, backing, 0));
         if (init_ptr != MAP_FAILED) {
-          libc_passthrough().madvise(init_ptr, length, MADV_POPULATE_WRITE);
-          std::memset(init_ptr, 0xFF, length);
-          libc_passthrough().munmap(init_ptr, length);
+          libc_passthrough().madvise(init_ptr, size, MADV_POPULATE_WRITE);
+          std::memset(init_ptr, 0xFF, size);
+          libc_passthrough().munmap(init_ptr, size);
         }
       }
-      safe_fcntl(proc.event_state_.memfd, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW);
-    }
+      safe_fcntl(backing, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW);
+      return backing;
+    });
+    if (events_fd < 0)
+      return MAP_FAILED;
     int mflags = MAP_SHARED;
     if (flags & MAP_FIXED)
       mflags |= MAP_FIXED;
-    void *ptr = safe_mmap(addr, length, PROT_READ | PROT_WRITE, mflags, proc.event_state_.memfd, 0);
+    void *ptr = safe_mmap(addr, length, PROT_READ | PROT_WRITE, mflags, events_fd, 0);
     if (ptr != MAP_FAILED)
       proc.event_state_.adopt_page(ptr, length);
     return ptr;
@@ -1709,7 +1736,7 @@ int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
       return 0;
     }
   }
-  // release_page() clears page/page_size under EventState::mutex_, the same lock
+  // release_page() clears page_/page_size_ under EventState::mutex_, the same lock
   // the CP interrupt thread holds when reading them in signal_interrupt, so the
   // munmap below cannot race a concurrent signal writing into the mapping.
   if (proc.event_state_.release_page(addr)) {
@@ -2865,7 +2892,7 @@ bool SimulatedKfd::serialize_queue_debug_waves(uint32_t process_id, uint32_t que
   auto proc = find_process(process_id);
   if (!proc)
     return false;
-  util::UniqueHandle target_mem = duplicate_debug_target_mem(proc->client_pid());
+  UniqueDriverFd target_mem = duplicate_debug_target_mem(proc->client_pid());
   bool publish_ok = true;
   const auto layout = kmd::serialize_queue_cwsr_bulk(
       ctx_base, ctx_size, waves, [&](uint64_t address, std::span<const uint8_t> bytes) {
@@ -3056,13 +3083,13 @@ void SimulatedKfd::notify_debug_event(const std::shared_ptr<KfdProcess> &proc, u
 
   // Duplicate under the session lock so DISABLE/reaping cannot close and reuse
   // the descriptor, then perform notifier I/O without holding a driver lock.
-  util::UniqueHandle notifier;
+  UniqueDriverFd notifier;
   {
     std::lock_guard<std::mutex> lk(debug_sessions_mutex_);
     auto session = debug_sessions_.find(target_pid);
     if (session != debug_sessions_.end() && session->second.dbg_fd >= 0 &&
         (session->second.exception_enable_mask & exception_mask) != 0)
-      notifier = util::UniqueHandle(safe_fcntl(session->second.dbg_fd, F_DUPFD_CLOEXEC, 0));
+      notifier = UniqueDriverFd(safe_fcntl(session->second.dbg_fd, F_DUPFD_CLOEXEC, 0));
   }
   if (notifier.get() >= 0) {
     const uint64_t one = 1;
@@ -3386,12 +3413,12 @@ void SimulatedKfd::set_debug_active_on_all_cus(bool active) {
   }
 }
 
-util::UniqueHandle SimulatedKfd::duplicate_debug_target_mem(pid_t target_pid) const {
+UniqueDriverFd SimulatedKfd::duplicate_debug_target_mem(pid_t target_pid) const {
   std::lock_guard<std::mutex> lock(debug_sessions_mutex_);
   auto session = debug_sessions_.find(target_pid);
   if (session == debug_sessions_.end() || session->second.target_mem_fd.get() < 0)
     return {};
-  return util::UniqueHandle(safe_fcntl(session->second.target_mem_fd.get(), F_DUPFD_CLOEXEC, 0));
+  return UniqueDriverFd(safe_fcntl(session->second.target_mem_fd.get(), F_DUPFD_CLOEXEC, 0));
 }
 
 void SimulatedKfd::apply_cwsr_to_wave(amdgpu::Wavefront &wave, const kmd::CwsrWaveState &state) {
@@ -3553,7 +3580,7 @@ int SimulatedKfd::resume_debug_queues(KfdProcess *proc, uint32_t *queue_ids, uin
           states[index].lds.clear();
       }
       auto *memory = gpu->soc->memory();
-      util::UniqueHandle target_mem = duplicate_debug_target_mem(proc->client_pid());
+      UniqueDriverFd target_mem = duplicate_debug_target_mem(proc->client_pid());
       bool read_ok = true;
       restored = kmd::deserialize_queue_cwsr_bulk(
           context.base, context.size, states, [&](uint64_t address, std::span<uint8_t> bytes) {
@@ -3825,14 +3852,14 @@ int SimulatedKfd::debug_query_event(pid_t target_pid, KfdProcess *target_proc,
 }
 
 void SimulatedKfd::raise_process_debug_event(pid_t target_pid, uint64_t exception_mask) {
-  util::UniqueHandle notifier;
+  UniqueDriverFd notifier;
   {
     std::lock_guard<std::mutex> lk(debug_sessions_mutex_);
     auto session = debug_sessions_.find(target_pid);
     if (session == debug_sessions_.end() || !session->second.enabled)
       return;
     if ((session->second.exception_enable_mask & exception_mask) != 0)
-      notifier = util::UniqueHandle(safe_fcntl(session->second.dbg_fd, F_DUPFD_CLOEXEC, 0));
+      notifier = UniqueDriverFd(safe_fcntl(session->second.dbg_fd, F_DUPFD_CLOEXEC, 0));
   }
   {
     std::lock_guard<std::mutex> lk(debug_events_mutex_);
@@ -4084,8 +4111,8 @@ int SimulatedKfd::debug_trap_ioctl(KfdProcess &caller, void *arg, int *target_me
 
   // Non-ENABLE ops require an active debug session (kernel: EINVAL).
   if (args->op != KFD_IOC_DBG_TRAP_ENABLE && !enabled) {
-    util::UniqueHandle probe_pidfd;
-    util::UniqueHandle probe_procfd;
+    UniqueDriverFd probe_pidfd;
+    UniqueDriverFd probe_procfd;
     const int probe_result = pin_process_identity(target_pid, probe_pidfd, probe_procfd);
     if (probe_result == -ESRCH)
       return -ESRCH;
@@ -4102,10 +4129,10 @@ int SimulatedKfd::debug_trap_ioctl(KfdProcess &caller, void *arg, int *target_me
   // pidfd and the matching procfs directory now. The pidfd liveness checks on
   // both sides of the procfs read ensure a numeric-pid reuse can never authorize
   // a different task.
-  util::UniqueHandle new_target_pidfd;
-  util::UniqueHandle new_target_procfd;
-  util::UniqueHandle *target_pidfd;
-  util::UniqueHandle *target_procfd;
+  UniqueDriverFd new_target_pidfd;
+  UniqueDriverFd new_target_procfd;
+  UniqueDriverFd *target_pidfd;
+  UniqueDriverFd *target_procfd;
   if (enabled) {
     target_pidfd = &session_it->second.target_pidfd;
     target_procfd = &session_it->second.target_procfd;
@@ -4117,8 +4144,8 @@ int SimulatedKfd::debug_trap_ioctl(KfdProcess &caller, void *arg, int *target_me
     target_procfd = &new_target_procfd;
   }
 
-  util::UniqueHandle new_debugger_pidfd;
-  util::UniqueHandle new_debugger_procfd;
+  UniqueDriverFd new_debugger_pidfd;
+  UniqueDriverFd new_debugger_procfd;
   if (args->op == KFD_IOC_DBG_TRAP_ENABLE) {
     const int debugger_pin_result =
         pin_process_identity(caller.client_pid(), new_debugger_pidfd, new_debugger_procfd);
@@ -4332,8 +4359,8 @@ int SimulatedKfd::debug_trap_ioctl(KfdProcess &caller, void *arg, int *target_me
     // descriptor. In local mode dbg_fd is the debugger's own descriptor and
     // nothing is owned here.
     if (daemon_mode_) {
-      sess.owned_dbg_fd = util::UniqueHandle(dbg_fd);
-      sess.target_mem_fd = util::UniqueHandle(*target_mem_fd);
+      sess.owned_dbg_fd = UniqueDriverFd(dbg_fd);
+      sess.target_mem_fd = UniqueDriverFd(*target_mem_fd);
       *target_mem_fd = -1;
     }
     auto [inserted, _] = debug_sessions_.emplace(target_pid, std::move(sess));
@@ -4686,7 +4713,7 @@ int SimulatedKfd::dispatch_get_mmap_memfd(KfdProcess &proc, off_t offset) const 
   uint64_t type = static_cast<uint64_t>(offset) & KFD_MMAP_TYPE_MASK;
 
   if (type == KFD_MMAP_TYPE_EVENTS)
-    return proc.event_state_.memfd;
+    return proc.event_state_.backing_fd();
 
   if (type == KFD_MMAP_TYPE_DOORBELL) {
     uint64_t encoded_gpu =

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
@@ -101,6 +101,15 @@ public:
   /// @retval false No local process to retain (e.g. it was already torn down, or
   ///         daemon/remote mode); the caller must NOT treat the fd as retained.
   [[nodiscard]] bool retain_local_open() override;
+
+  /// @brief Release the local process's parked event waiters so a blocking
+  /// WAIT_EVENTS returns and drops its driver snapshot before teardown.
+  /// @details Fires EventState::begin_wait_cancel() on the local process: waiters
+  /// return a benign KFD_IOC_WAIT_RESULT_TIMEOUT and drop the driver snapshot that
+  /// would otherwise keep the object alive. Mutates no process, event, or
+  /// signal-page state — close() performs the destructive teardown. Idempotent.
+  void begin_local_shutdown() override;
+
   int ioctl(unsigned long request, void *arg) override;
   void *mmap(void *addr, size_t length, int prot, int flags, off_t offset) override;
   int munmap(void *addr, size_t length) override;
@@ -172,9 +181,11 @@ public:
   [[nodiscard]] PrimaryInvalidation invalidate_primary_fd(int fd) override;
 
   /// @brief Open-reference count of the local process, or 0 if none is alive.
-  /// @details Introspection for tests/diagnostics. Each live KFD fd (the primary
-  /// plus every dup) holds one reference; the process is destroyed at zero.
-  [[nodiscard]] uint32_t local_open_ref_count() const;
+  /// @details Each live KFD fd (the primary plus every dup) holds one reference;
+  /// the process is destroyed at zero. In the interposer's local VM this includes
+  /// the VM's own bootstrap open (rj_vm_create), which is why teardown compares
+  /// against a captured baseline rather than against zero.
+  [[nodiscard]] uint32_t local_open_ref_count() const override;
 
   /// @brief Make the next private doorbell-monitor mmap fail with ENOMEM.
   /// @details One-shot test seam for verifying failure atomicity before a
@@ -403,7 +414,7 @@ private:
   void release_debug_checks_if_last_session();
 
   /// @brief Duplicate the authorized target-memory fd for lock-free I/O.
-  util::UniqueHandle duplicate_debug_target_mem(pid_t target_pid) const;
+  UniqueDriverFd duplicate_debug_target_mem(pid_t target_pid) const;
 
   /// @brief Serialize all debug-halted waves of a queue into its CWSR area.
   bool serialize_queue_debug_waves(uint32_t process_id, uint32_t queue_id, uint32_t gpu_id,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
@@ -164,11 +164,6 @@ void Sysfs::cleanup() {
   }
 }
 
-void Sysfs::release_after_fork() {
-  topology_dir_.clear();
-  drm_dir_.clear();
-}
-
 void Sysfs::setup_environment() {}
 
 void Sysfs::write_generation_id() { write_file(topology_dir_ + "/generation_id", "1\n"); }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.h
@@ -150,9 +150,6 @@ public:
   /// @brief Remove the generated directories.
   void cleanup();
 
-  /// @brief Drop ownership of inherited paths without removing them.
-  void release_after_fork();
-
 private:
   std::string topology_dir_;
   std::string drm_dir_;

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/simulation.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/simulation.h
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <barrier>
 #include <cstdint>
+#include <exception>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -182,6 +183,36 @@ public:
   /// @returns An ExitStatus describing why the simulation stopped.
   ExitStatus run();
 
+  /// @brief Block until run() (or step()'s first call) has completed component
+  /// startup.
+  ///
+  /// @details A readiness boundary for embeddings that launch run() on a
+  /// background thread and must not publish the simulated device until every
+  /// component's startup() callback has completed — otherwise a caller can reach
+  /// a half-started device, and short-lived processes can race component startup
+  /// against C++ finalizers. Once observed, readiness stays latched until the next
+  /// create().
+  /// @returns true if startup completed normally; false if a component's startup()
+  /// threw (run() caught it, latched readiness so this call wakes, and returned an
+  /// error ExitStatus). A false return means the engine is NOT running and the
+  /// embedding must unwind rather than publish the device.
+  [[nodiscard]] bool wait_until_started() const;
+
+  /// @brief Latch readiness only if nothing has latched it yet.
+  /// @details Liveness backstop for an embedding that runs the engine on its own
+  /// thread: wait_until_started() blocks until run()/step() latches, so ANY path
+  /// that returns without reaching the latch (a caller-side validation failure
+  /// before run() is entered, an engine that is never run at all) would strand the
+  /// waiter forever. The owning thread calls this after its run() returns so
+  /// readiness becomes a property of the THREAD's completion rather than of run()
+  /// being reached. Must be called from that same thread, after run()/step()
+  /// returns, so it cannot race the in-band latch.
+  /// A failed latch also records the terminal ExitStatus. The flag it sets is what
+  /// run()/step() use as their terminal guard, so latching without a status would
+  /// leave the create() default in place and report a generation that never started
+  /// as a clean run.
+  void latch_startup_if_unlatched(bool failed);
+
   /// @brief Process all events at the next event time (single-threaded only).
   ///
   /// @details On the first call, starts all components (initialization
@@ -314,8 +345,41 @@ private:
   /// @brief Call startup() on all components across all partitions.
   void startup_components();
 
-  /// @brief Call shutdown() on all components across all partitions.
-  void shutdown_components();
+  /// @brief Call shutdown() on every initialized component, in reverse order.
+  /// @details Every callback runs even if an earlier one throws: the generation is
+  /// marked shut down up front, so skipping the rest would strand them with no way
+  /// to retry. Never throws — the first failure is RETURNED so the caller can finish
+  /// its own cleanup before reporting it.
+  /// @returns The first callback exception, or null if all succeeded.
+  [[nodiscard]] std::exception_ptr shutdown_components() noexcept;
+
+  /// @brief Log a captured component-cleanup failure. Never throws.
+  static void report_component_failure(std::exception_ptr failure, const char *phase) noexcept;
+
+  /// @brief Latch startup readiness and wake wait_until_started() observers.
+  /// @details Stores @p failed BEFORE startup_complete_, then notifies — the order
+  /// matters so a waiter that observes complete also observes the correct failed
+  /// state. Centralizes the epilogue used by run()/step() on both the success and
+  /// the throw paths so the ordering cannot drift. A startup throw is terminal for
+  /// the create() generation (see startup_failed()), so this latches failure once and
+  /// the caller must shutdown() + create() before a fresh startup can latch success.
+  void latch_startup(bool failed) {
+    startup_failed_.store(failed, std::memory_order_release);
+    startup_complete_.store(true, std::memory_order_release);
+    startup_complete_.notify_all();
+  }
+
+  /// @brief Common epilogue for a startup_components() throw in run()/step().
+  /// @details Records the terminal failure -- startup_failed_, a failure ExitStatus,
+  /// and done_ so a racing request_exit() cannot overwrite it -- unwinds the started
+  /// components, and only then PUBLISHES readiness via latch_startup(). Publishing
+  /// last is what makes a false return from wait_until_started() mean the generation
+  /// is torn down rather than still running shutdown hooks; it is safe to leave the
+  /// latch until the end because the unwind cannot escape, shutdown_components() and
+  /// report_component_failure() both being noexcept and catching each callback
+  /// individually. Both run() and step() share this so the recorded status and the
+  /// ordering cannot drift apart.
+  void fail_startup(std::string message);
 
   /// @brief Drain all async event buffers into their partition queues (single-threaded).
   void drain_async_events();
@@ -335,6 +399,15 @@ private:
 
   /// @brief Set the exit event (internal helper).
   void set_exit(ExitReason reason, Tick tick, std::string message, int code = 0);
+
+  /// @brief Record a terminal FAILURE status and mark the generation done, atomically.
+  /// @details For terminal failures only, and unlike set_exit() it is last-writer-wins:
+  /// a startup failure outranks an ordinary exit request, including one already
+  /// recorded by a request_exit() issued from inside a startup callback that then
+  /// threw. Keeping first-writer-wins there would let run() report success for a
+  /// generation whose components never started. done_ is stored in the same critical
+  /// section because request_exit() gates its overwrite on reading it under this lock.
+  void set_terminal_exit(ExitReason reason, Tick tick, std::string message, int code);
 
   /// @brief Check if all registered primaries have signaled OK to end.
   /// @retval true All primaries are done (and at least one is registered).
@@ -399,6 +472,33 @@ private:
   ExitStatus exit_status_;                 ///< Exit information from the last run/step.
   bool created_ = false; ///< Whether create() has completed (components initialized).
   bool running_ = false; ///< True while running; also guards step() first-call startup.
+  /// @brief Latched true once startup() has run for every component (or thrown);
+  /// reset by create(). Read by wait_until_started() from an embedding thread.
+  std::atomic<bool> startup_complete_{false};
+  /// @brief Set true if a component's startup() threw; reset by create(). Lets
+  /// wait_until_started() report failure instead of blocking forever, since a
+  /// throwing startup latches startup_complete_ without the engine running.
+  std::atomic<bool> startup_failed_{false};
+
+  /// @brief True once a startup() throw made this create() generation terminal.
+  /// @details Same flag wait_until_started() publishes, reused as run()/step()'s
+  /// terminal guard rather than a second bool: both are set only by latch_startup()
+  /// and cleared only by create(), so a duplicate could only ever drift. Reusing it
+  /// also makes the thread-death backstop (latch_startup_if_unlatched) terminal for
+  /// the generation, which a separate same-thread flag would have missed.
+  ///
+  /// Terminal rather than retryable because a partial attempt leaves the partition,
+  /// async and cross-partition event queues, the primary-registration counters and
+  /// per-component state intact: re-running startup on top of them would
+  /// double-schedule events and double-register primaries. A caller that wants
+  /// another attempt has to shutdown() and create() a fresh generation.
+  bool startup_failed() const { return startup_failed_.load(std::memory_order_acquire); }
+
+  /// @brief True once shutdown_components() has run for this generation, so each
+  /// initialized component's shutdown() fires exactly once even if both the
+  /// startup-failure unwind and the engine shutdown() path reach it. Reset by
+  /// create().
+  bool components_shut_down_ = false;
 
   /// @brief Global lower bound on time stamp, updated by barrier completion.
   std::atomic<Tick> global_lbts_{0};

--- a/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
+++ b/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
@@ -3,8 +3,11 @@
 
 #include "simdojo/sim/simulation.h"
 
+#include "util/log.h"
+
 #include <algorithm>
 #include <cassert>
+#include <exception>
 #include <stdexcept>
 #include <string>
 
@@ -46,6 +49,9 @@ void SimulationEngine::create() {
   setup_partitions();
 
   done_.store(false, std::memory_order_release);
+  startup_complete_.store(false, std::memory_order_release);
+  startup_failed_.store(false, std::memory_order_release);
+  components_shut_down_ = false;
   active_primaries_.store(0, std::memory_order_release);
   has_primaries_.store(false, std::memory_order_release);
   exit_status_ = {};
@@ -70,7 +76,11 @@ void SimulationEngine::shutdown() {
 
   workers_.clear();
   barrier_.reset();
-  shutdown_components();
+  // Capture, do not propagate: engine cleanup below MUST still run, and shutdown()
+  // is reached from ~SimulationEngine(), from rj_vm_run() on the engine's own
+  // background thread, and across the C API — none of which can absorb an
+  // exception. A failing component hook is reported, not thrown.
+  std::exception_ptr component_failure = shutdown_components();
 
   running_ = false;
   {
@@ -83,6 +93,7 @@ void SimulationEngine::shutdown() {
     async_queues_.clear();
   }
   created_ = false;
+  report_component_failure(component_failure, "engine shutdown");
 }
 
 void SimulationEngine::setup_partitions() {
@@ -125,8 +136,44 @@ ExitStatus SimulationEngine::run() {
   assert(created_ && "run() called before create()");
   const uint32_t num_threads = config_.num_threads;
 
-  startup_components();
+  // A component startup() can throw. run() may execute on a background thread
+  // (the LD_PRELOAD interposer's local VM) whose top-level lambda has no catch, so
+  // an escaping exception would call std::terminate AND leave wait_until_started()
+  // blocked forever (startup_complete_ never set). Catch it, latch readiness with a
+  // failure flag so waiters wake and can unwind, and return an error ExitStatus
+  // rather than running the epoch loop against half-started components.
+  // A startup() throw makes this create() generation terminal: partition/async
+  // event queues, primary counters, and per-component state from the partial
+  // attempt are left intact, so re-running startup on top of them would
+  // double-schedule events and double-register primaries. Refuse to re-run and
+  // require shutdown() + create() for a clean generation. Deliberately a RUNTIME
+  // guard with NO paired assert: an assert would abort in assertion-enabled builds
+  // and return in release ones, so the API's behaviour would depend on the build.
+  // Copied under exit_mutex_ like the normal return below: a foreign thread can be
+  // inside request_exit() assigning exit_status_, whose message is a std::string.
+  if (startup_failed()) {
+    std::lock_guard<std::mutex> lock(exit_mutex_);
+    return exit_status_;
+  }
+  try {
+    startup_components();
+  } catch (const std::exception &e) {
+    fail_startup(std::string("component startup failed: ") + e.what());
+  } catch (...) {
+    // The engine may run on a background thread whose lambda has no catch, so a
+    // non-std::exception throw would still call std::terminate. Latch failure and
+    // return an error status for those too, matching step()'s catch (...).
+    fail_startup("component startup failed with a non-standard exception");
+  }
+  if (startup_failed()) {
+    std::lock_guard<std::mutex> lock(exit_mutex_);
+    return exit_status_;
+  }
   running_ = true;
+  // Publish readiness only after every component's startup() has run, so an
+  // embedding that launched run() on a background thread (the LD_PRELOAD
+  // interposer's local VM) does not expose a half-started device.
+  latch_startup(/*failed=*/false);
   pacer_.anchor(0);
 
   if (config_.max_ticks > 0 && num_threads == 1) {
@@ -158,13 +205,86 @@ ExitStatus SimulationEngine::run() {
   return exit_status_;
 }
 
+void SimulationEngine::fail_startup(std::string message) {
+  // Records the status and marks the generation done in ONE critical section, so a
+  // concurrent request_exit() cannot replace this failure with EXIT_REQUEST/code 0 and
+  // report a generation whose components never started as a clean run.
+  set_terminal_exit(ExitReason::INTERRUPTED, current_time_.load(std::memory_order_acquire),
+                    std::move(message), /*code=*/1);
+  // Unwind BEFORE publishing readiness, so a waiter that observes the failure also
+  // observes a generation that is torn down rather than one still running component
+  // shutdown hooks. Nothing here can escape past the latch: shutdown_components()
+  // and report_component_failure() are both noexcept and catch each callback.
+  report_component_failure(shutdown_components(), "startup unwind");
+  latch_startup(/*failed=*/true);
+}
+
+void SimulationEngine::latch_startup_if_unlatched(bool failed) {
+  if (startup_complete_.load(std::memory_order_acquire))
+    return;
+  if (failed) {
+    // Same reasoning as fail_startup(): the flag latched here is run()/step()'s
+    // terminal guard, so it needs a status behind it, recorded together with done_.
+    set_terminal_exit(ExitReason::INTERRUPTED, current_time_.load(std::memory_order_acquire),
+                      "engine thread returned without completing component startup",
+                      /*code=*/1);
+  }
+  latch_startup(failed);
+}
+
+void SimulationEngine::report_component_failure(std::exception_ptr failure,
+                                                const char *phase) noexcept {
+  if (!failure)
+    return;
+  // Outer catch-all: this is the last step of a teardown that must not throw, and
+  // the reporting path itself formats and allocates.
+  try {
+    try {
+      std::rethrow_exception(failure);
+    } catch (const std::exception &e) {
+      util::Logger::warn("SimulationEngine: a component shutdown() threw during ", phase, ": ",
+                         e.what());
+    } catch (...) {
+      util::Logger::warn("SimulationEngine: a component shutdown() threw a non-standard exception "
+                         "during ",
+                         phase);
+    }
+  } catch (...) {
+    // Reporting itself failed; nothing further here is safe or useful.
+  }
+}
+
+bool SimulationEngine::wait_until_started() const {
+  while (!startup_complete_.load(std::memory_order_acquire))
+    startup_complete_.wait(false, std::memory_order_acquire);
+  return !startup_failed_.load(std::memory_order_acquire);
+}
+
 bool SimulationEngine::step() {
   assert(created_ && "step() called before create()");
   assert(config_.num_threads == 1 && "step() requires single-threaded mode");
 
   if (!running_) {
-    startup_components();
+    // A prior startup() throw made this generation terminal (see run()): its
+    // partial event/primary/component state is still live, so re-running startup
+    // would double-schedule events and double-register primaries. Report done;
+    // the caller must shutdown() + create() to retry.
+    if (startup_failed())
+      return false;
+    // step() runs on the foreground caller, so a startup throw propagates to it
+    // (rethrown below) after fail_startup() records the same terminal ExitStatus
+    // run() would, publishes it to wait_until_started() waiters, and unwinds.
+    try {
+      startup_components();
+    } catch (const std::exception &e) {
+      fail_startup(std::string("component startup failed: ") + e.what());
+      throw;
+    } catch (...) {
+      fail_startup("component startup failed with a non-standard exception");
+      throw;
+    }
     running_ = true;
+    latch_startup(/*failed=*/false);
 
     if (config_.max_ticks > 0) {
       max_ticks_event_.set_handler([this](Tick ts, Message *) {
@@ -557,6 +677,23 @@ void SimulationEngine::set_exit(ExitReason reason, Tick tick, std::string messag
   }
 }
 
+void SimulationEngine::set_terminal_exit(ExitReason reason, Tick tick, std::string message,
+                                         int code) {
+  std::lock_guard<std::mutex> lock(exit_mutex_);
+  // Deliberately NOT first-writer-wins, unlike set_exit(). Only terminal failures
+  // reach here, and a terminal failure outranks whatever was recorded before it: a
+  // request_exit() that already stored its default code-0 EXIT_REQUEST -- including
+  // one issued from inside a startup callback that then threw -- would otherwise
+  // survive, and run() would hand back a success status for a generation whose
+  // components never started. done_ is stored in this same critical section for the
+  // mirror-image reason: request_exit() gates its own overwrite on done_ read under
+  // this lock, so releasing before storing it would let a LATER request_exit()
+  // replace this failure.
+  exit_status_ = ExitStatus(reason, tick, std::move(message), code);
+  exit_set_ = true;
+  done_.store(true, std::memory_order_release);
+}
+
 void SimulationEngine::initialize_components() {
   for (auto &part : topology_.partitions()) {
     for (auto *comp : part.components)
@@ -571,11 +708,40 @@ void SimulationEngine::startup_components() {
   }
 }
 
-void SimulationEngine::shutdown_components() {
-  for (auto &part : topology_.partitions()) {
-    for (auto *comp : part.components)
-      comp->shutdown();
+std::exception_ptr SimulationEngine::shutdown_components() noexcept {
+  // shutdown() pairs with initialize() (both run over every component), so it must
+  // shut down every INITIALIZED component in reverse topology order — not only the
+  // ones whose startup() ran. create() initializes all components, so a
+  // create(); shutdown() with no run()/step() still releases their resources, and a
+  // partial-startup unwind still cleans up every initialized component. Guarded so
+  // it runs exactly once per create() generation: both the startup-failure unwind
+  // and the later engine shutdown() reach here, and a component must not be shut
+  // down twice. Reset by create().
+  if (components_shut_down_)
+    return {};
+  components_shut_down_ = true;
+
+  // Iterate in place rather than building a temporary vector: this runs on the
+  // teardown path reached from ~SimulationEngine(), so a bad_alloc from that
+  // temporary would skip EVERY component's cleanup and escape a noexcept
+  // destructor. Reverse partition order, reverse component order within each.
+  //
+  // Each callback is isolated: Component::shutdown() is not noexcept, and the
+  // generation is already marked shut down above, so letting one throw would
+  // permanently skip cleanup for the components after it with no way to retry.
+  std::exception_ptr first_failure;
+  auto &partitions = topology_.partitions();
+  for (auto part = partitions.rbegin(); part != partitions.rend(); ++part) {
+    for (auto comp = part->components.rbegin(); comp != part->components.rend(); ++comp) {
+      try {
+        (*comp)->shutdown();
+      } catch (...) {
+        if (!first_failure)
+          first_failure = std::current_exception();
+      }
+    }
   }
+  return first_failure;
 }
 
 Tick SimulationEngine::compute_async_floor(const PartitionContext &ctx) const {

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -136,12 +136,14 @@ if(RJ_INSTALL_TESTS)
     # an installed CTest fragment like rocjitsu_tests.cmake.
     function(rj_install_gtest_cases target)
         set(_fragment "${CMAKE_CURRENT_BINARY_DIR}/install/${target}.cmake")
+        cmake_parse_arguments(ARG "" "TEST_FILTER" "" ${ARGN})
         add_custom_command(
             OUTPUT "${_fragment}"
             COMMAND
                 ${CMAKE_COMMAND} "-DTEST_EXECUTABLE=$<TARGET_FILE:${target}>"
                 "-DINSTALLED_EXECUTABLE=bin/${target}"
-                "-DOUTPUT_FILE=${_fragment}" -P "${RJ_INSTALL_GTEST_GENERATOR}"
+                "-DTEST_FILTER=${ARG_TEST_FILTER}" "-DOUTPUT_FILE=${_fragment}"
+                -P "${RJ_INSTALL_GTEST_GENERATOR}"
             DEPENDS ${target} "${RJ_INSTALL_GTEST_GENERATOR}"
             COMMENT "Generating installed CTest entries for ${target}"
             VERBATIM
@@ -310,11 +312,17 @@ endfunction()
 # and installed CTest tree. Build-tree discovery delegates to
 # gtest_discover_tests(); installed discovery delegates to rj_install_gtest_cases
 # so parameterized TEST_P cases are expanded from the built executable.
+#
+# TEST_FILTER reaches BOTH paths. It used to reach only the build tree, while the
+# installed generator carried its own hard-coded copy, so a case excluded here to be
+# registered manually was still discovered on the installed side and ended up
+# registered twice under one name.
 function(rj_add_gtest_tests target)
+    cmake_parse_arguments(ARG "" "TEST_FILTER" "" ${ARGN})
     gtest_discover_tests(${target} ${ARGN})
     if(RJ_INSTALL_TESTS)
         rj_install_test_target(${target})
-        rj_install_gtest_cases(${target})
+        rj_install_gtest_cases(${target} TEST_FILTER "${ARG_TEST_FILTER}")
     endif()
 endfunction()
 
@@ -581,10 +589,12 @@ endif()
 # Benchmarks are timing tools, not correctness tests; keep them out of the
 # default ctest run (invoke them directly via
 # ./rocjitsu_tests --gtest_filter='*Benchmark*'). The request-exit stress test
-# is registered separately so CTest can bound a deadlocked child process.
+# and the concurrent-close wait test are registered separately so CTest can
+# bound a deadlocked child process.
 rj_add_gtest_tests(
     rocjitsu_tests
-    TEST_FILTER "-*Benchmark*:*RequestExitWakesAllPartitions*"
+    TEST_FILTER
+        "-*Benchmark*:*RequestExitWakesAllPartitions*:*DispatchedWaitSurvivesAConcurrentFinalClose*"
 )
 
 # RequestExitWakesAllPartitions may require several runs to show regression
@@ -602,6 +612,22 @@ rj_add_test(
         "bin/rocjitsu_tests"
         "--gtest_filter=TerminationTest.RequestExitWakesAllPartitions"
         "--gtest_repeat=30"
+)
+
+# DispatchedWaitSurvivesAConcurrentFinalClose races an indefinite WAIT_EVENTS
+# against a final close. Its in-test recovery wake bounds a close that blocks
+# while releasing the driver mutex, but nothing in-process can bound one that
+# blocks while HOLDING it -- releasing the wait's lease needs that same mutex.
+# CTest is the only backstop there, so register it with an explicit timeout.
+rj_add_test(
+    NAME "SimulatedKfdTest.DispatchedWaitSurvivesAConcurrentFinalClose"
+    COMMAND
+        $<TARGET_FILE:rocjitsu_tests>
+        "--gtest_filter=SimulatedKfdTest.DispatchedWaitSurvivesAConcurrentFinalClose"
+    TIMEOUT 30
+    INSTALL_COMMAND
+        "bin/rocjitsu_tests"
+        "--gtest_filter=SimulatedKfdTest.DispatchedWaitSurvivesAConcurrentFinalClose"
 )
 
 # Exercise the Linux-only model ISA contract in a decoder-only final link.
@@ -1099,22 +1125,22 @@ rj_add_test(
 )
 if(RJ_HAS_GFX1201_GPU)
     add_test(
-        NAME "GuestKfdMultiprocessTest.ForkedChildrenDoNotRemoveParentOverlay"
+        NAME
+            "GuestKfdMultiprocessTest.ForkedChildrenRefuseGpuAndLeaveParentOverlayIntact"
         COMMAND
             ${RJ_CLI} --config
             ${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_gfx1201.json --
             $<TARGET_FILE:guest_kfd_test>
-            --gtest_filter=GuestKfdMultiprocessTest.ForkedChildrenDoNotRemoveParentOverlay
+            --gtest_filter=GuestKfdMultiprocessTest.ForkedChildrenRefuseGpuAndLeaveParentOverlayIntact
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
     add_test(
-        NAME
-            "GuestKfdMultiprocessTest.ForkedChildDropsInheritedGuestDriverBeforeReopen"
+        NAME "GuestKfdMultiprocessTest.ForkedChildCannotUseInheritedGuestDriver"
         COMMAND
             ${RJ_CLI} --config
             ${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_gfx1201.json --
             $<TARGET_FILE:guest_kfd_test>
-            --gtest_filter=GuestKfdMultiprocessTest.ForkedChildDropsInheritedGuestDriverBeforeReopen
+            --gtest_filter=GuestKfdMultiprocessTest.ForkedChildCannotUseInheritedGuestDriver
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
     add_test(
@@ -1154,8 +1180,8 @@ if(RJ_HAS_GFX1201_GPU)
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
     set_tests_properties(
-        "GuestKfdMultiprocessTest.ForkedChildrenDoNotRemoveParentOverlay"
-        "GuestKfdMultiprocessTest.ForkedChildDropsInheritedGuestDriverBeforeReopen"
+        "GuestKfdMultiprocessTest.ForkedChildrenRefuseGpuAndLeaveParentOverlayIntact"
+        "GuestKfdMultiprocessTest.ForkedChildCannotUseInheritedGuestDriver"
         "GuestKfdConcurrencyTest.ConcurrentOpenIoctlAndSysfsRedirect"
         "GuestKfdLifecycleTest.ReopensAfterLastClose"
         "GuestKfdMemoryTest.GuestAllocationMmapOffsetIsRejected"
@@ -1166,8 +1192,8 @@ if(RJ_HAS_GFX1201_GPU)
         _guest_kfd_test
         IN
         ITEMS
-            "GuestKfdMultiprocessTest.ForkedChildrenDoNotRemoveParentOverlay"
-            "GuestKfdMultiprocessTest.ForkedChildDropsInheritedGuestDriverBeforeReopen"
+            "GuestKfdMultiprocessTest.ForkedChildrenRefuseGpuAndLeaveParentOverlayIntact"
+            "GuestKfdMultiprocessTest.ForkedChildCannotUseInheritedGuestDriver"
             "GuestKfdConcurrencyTest.ConcurrentOpenIoctlAndSysfsRedirect"
             "GuestKfdLifecycleTest.ReopensAfterLastClose"
             "GuestKfdMemoryTest.GuestAllocationMmapOffsetIsRejected"
@@ -1448,6 +1474,24 @@ rj_add_interposer_test_suite(
 )
 
 rj_add_interposer_test_suite(
+    InterposerForkTest
+    ChildRefusesGpuEndpointsBeforeExec
+    ChildRefusesEveryGpuEndpointSpelling
+    ChildRefusesAnEmulatedEndpointTheHostDoesNotHave
+    ChildFailsClosedOnAnUnclassifiablePath
+    ChildClassifiesGpuEndpointsByIdentityNotName
+    AppDescriptorCarriesNoRealHardwareAuthority
+    ChildRefusesOperationsOnInheritedRealGpuDescriptors
+    ChildCannotLaunderInheritedGpuFdAcrossExec
+    ChildRefusesMmap64OnInheritedGpuFd
+    ChildRefusesDup3OnInheritedGpuFd
+    ChildFopenPreservesLibcModeSemantics
+    MultithreadedForkExecAlwaysReachesExec
+    SystemAndPopenWorkFromAMultithreadedParent
+    PosixSpawnFromAMultithreadedParent
+)
+
+rj_add_interposer_test_suite(
     InterposerGemTest
     GemNamespaceIsPrivateButSharedByDuplicates
     IndependentDrmFilesRejectOverlappingMappings
@@ -1474,15 +1518,6 @@ set(_rj_interposer_syncobj_tests
     ConcurrentVmUpdatesShareTimeline
     OutOfOrderTimelinePointPreservesWatermark
 )
-# TSan cannot start new threads after a multithreaded fork. This regression
-# intentionally exercises inherited interposer state in that unsupported child,
-# so retain it for regular and ASan builds and omit it from TSan configurations.
-if(NOT RJ_ENABLE_TSAN)
-    list(
-        APPEND _rj_interposer_syncobj_tests
-        ForkedChildReinitializesTimelineFutexState
-    )
-endif()
 rj_add_interposer_test_suite(
     InterposerSyncobjTest
     ${_rj_interposer_syncobj_tests}

--- a/emulation/rocjitsu/tests/guest_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/guest_kfd_test.cpp
@@ -247,38 +247,35 @@ bool read_process_aperture_count(int fd, uint32_t *count) {
   return true;
 }
 
+// Local mode supports fork-then-exec only, so a child must NOT be able to open the
+// emulated KFD before exec -- and must not silently fall through to the host's real
+// one either. Both outcomes are checked here: refusal, with ENODEV.
 int child_process() {
   int fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
-  if (fd < 0)
-    return 2;
-
-  const bool visible = guest_gpu_is_visible();
-  close(fd);
-  return visible ? 0 : 3;
+  if (fd >= 0) {
+    close(fd);
+    return 2; // opened a GPU endpoint before exec.
+  }
+  if (errno != ENODEV)
+    return 3; // refused, but not with the documented error.
+  return 0;
 }
 
+// Under fork-then-exec the child neither reuses the inherited descriptor for
+// rocJITsu work nor re-opens its own. What matters is that it cannot, and that
+// trying leaves the parent untouched.
 int child_reset_process(int inherited_fd, uint32_t expected_reopened_count) {
-  uint32_t inherited_count = 0;
-  if (read_process_aperture_count(inherited_fd, &inherited_count))
-    return 7;
-
+  static_cast<void>(inherited_fd);
+  static_cast<void>(expected_reopened_count);
   int fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
-  if (fd < 0)
+  if (fd >= 0) {
+    close(fd);
     return 2;
-
-  uint32_t reopened_count = 0;
-  const bool count_ok = read_process_aperture_count(fd, &reopened_count);
-  const bool visible_after_reopen = guest_gpu_is_visible();
-  close(fd);
-
-  if (!count_ok)
-    return 5;
-  if (reopened_count < expected_reopened_count)
-    return 6;
-  return visible_after_reopen ? 0 : 3;
+  }
+  return errno == ENODEV ? 0 : 3;
 }
 
-TEST(GuestKfdMultiprocessTest, ForkedChildrenDoNotRemoveParentOverlay) {
+TEST(GuestKfdMultiprocessTest, ForkedChildrenRefuseGpuAndLeaveParentOverlayIntact) {
   if (access(kKfdPath, R_OK | W_OK) != 0)
     GTEST_SKIP() << kKfdPath << " is not available: " << std::strerror(errno);
 
@@ -305,14 +302,15 @@ TEST(GuestKfdMultiprocessTest, ForkedChildrenDoNotRemoveParentOverlay) {
     int status = 0;
     ASSERT_EQ(waitpid(pid, &status, 0), pid);
     ASSERT_TRUE(WIFEXITED(status)) << "child " << pid << " did not exit normally";
-    EXPECT_EQ(WEXITSTATUS(status), 0) << "child " << pid << " failed";
+    EXPECT_EQ(WEXITSTATUS(status), 0)
+        << "child " << pid << ": 2=opened a GPU endpoint before exec, 3=wrong errno";
   }
 
   EXPECT_TRUE(guest_gpu_is_visible()) << "parent guest topology disappeared after forked children";
   close(parent_fd);
 }
 
-TEST(GuestKfdMultiprocessTest, ForkedChildDropsInheritedGuestDriverBeforeReopen) {
+TEST(GuestKfdMultiprocessTest, ForkedChildCannotUseInheritedGuestDriver) {
   if (access(kKfdPath, R_OK | W_OK) != 0)
     GTEST_SKIP() << kKfdPath << " is not available: " << std::strerror(errno);
 
@@ -334,7 +332,8 @@ TEST(GuestKfdMultiprocessTest, ForkedChildDropsInheritedGuestDriverBeforeReopen)
   int status = 0;
   ASSERT_EQ(waitpid(pid, &status, 0), pid);
   ASSERT_TRUE(WIFEXITED(status)) << "child " << pid << " did not exit normally";
-  EXPECT_EQ(WEXITSTATUS(status), 0) << "child " << pid << " did not reset and reopen cleanly";
+  EXPECT_EQ(WEXITSTATUS(status), 0)
+      << "child " << pid << ": 2=opened a GPU endpoint before exec, 3=wrong errno";
 
   uint32_t parent_count_after = 0;
   EXPECT_TRUE(read_process_aperture_count(parent_fd, &parent_count_after));

--- a/emulation/rocjitsu/tests/interposer_dup_test.cpp
+++ b/emulation/rocjitsu/tests/interposer_dup_test.cpp
@@ -14,6 +14,8 @@
 /// these because they exercise the driver object directly, bypassing the fd
 /// tracking that lives in the interposer.
 
+#include "scoped_temp.h"
+
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
 RJ_DIAGNOSTIC_IGNORE_PEDANTIC
@@ -31,19 +33,25 @@ RJ_DIAGNOSTIC_POP
 #include <barrier>
 #include <cerrno>
 #include <chrono>
+#include <climits>
 #include <csignal>
+#include <cstdio>
 #include <cstring>
 #include <fcntl.h>
 #include <fstream>
+#include <spawn.h>
 #include <string>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
+#include <sys/sysmacros.h>
 #include <sys/wait.h>
 #include <thread>
 #include <time.h>
 #include <unistd.h>
+
+extern char **environ;
 
 namespace {
 
@@ -1149,109 +1157,680 @@ TEST(InterposerSyncobjTest, TimelineWaitReturnsEintrForSignal) {
   EXPECT_EQ(close(kfd), 0);
 }
 
-TEST(InterposerSyncobjTest, ForkedChildReinitializesTimelineFutexState) {
+// rocJITsu local mode supports fork-then-exec only: its simulator state lives in
+// this address space, and a driver call holds private driver locks for its whole
+// duration -- sometimes across a blocking wait -- so no atfork prepare handler could
+// drain them without risking hanging fork() itself. Same contract as CUDA, HSA/ROCr
+// and ThreadSanitizer. Enforcement is an immutable owner PID checked at the top of
+// every interposed entry point, before any inherited lock, container or pointer.
+//
+// These cover the contract from a MULTITHREADED parent, which is the case that
+// previously deadlocked: the child must reach exec (or _exit) without ever touching
+// inherited state.
+
+// A forked child must NOT silently fall through to the host's real GPU. If this box
+// has a real /dev/kfd, passing the open through to libc would move the child off the
+// emulator and onto real hardware -- worse than any error. It must fail closed.
+TEST(InterposerForkTest, ChildRefusesGpuEndpointsBeforeExec) {
   int kfd = open_kfd();
   ASSERT_GE(kfd, 0);
   ASSERT_TRUE(kfd_version_ok(kfd));
-  int drm = open_drm_render();
-  if (drm < 0)
-    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
-
-  drm_syncobj_create create{};
-  ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &create), 0);
-  constexpr size_t kBoSize = 0x1000;
-  constexpr uint64_t kVa = 0x1000000000ULL;
-  int dmabuf = make_sized_memfd(kBoSize);
-  ASSERT_GE(dmabuf, 0);
-  uint32_t gem_handle = 0;
-  ASSERT_TRUE(prime_import(drm, dmabuf, &gem_handle));
-
-  uint32_t handles[] = {create.handle};
-  uint64_t points[] = {1};
-  drm_syncobj_timeline_wait wait{};
-  wait.handles = reinterpret_cast<uintptr_t>(handles);
-  wait.points = reinterpret_cast<uintptr_t>(points);
-  wait.count_handles = 1;
-  wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL | DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT;
-  wait.timeout_nsec = monotonic_deadline_after(std::chrono::seconds(2));
-
-  std::barrier ready(2);
-  std::atomic<int> wait_rc{-2};
-  std::thread waiter([&] {
-    ready.arrive_and_wait();
-    wait_rc = ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait);
-  });
-  ready.arrive_and_wait();
-  std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
   const pid_t child = fork();
-  if (child < 0) {
-    const int fork_errno = errno;
-    waiter.join();
-    EXPECT_EQ(gem_close(drm, gem_handle), 0);
-    EXPECT_EQ(close(dmabuf), 0);
-    EXPECT_EQ(close(drm), 0);
-    EXPECT_EQ(close(kfd), 0);
-    FAIL() << "fork failed: " << std::strerror(fork_errno);
-  }
+  ASSERT_GE(child, 0) << "fork failed: " << std::strerror(errno);
   if (child == 0) {
-    alarm(3);
-    int child_kfd = open_kfd();
-    if (child_kfd < 0 || !kfd_version_ok(child_kfd))
-      _exit(1);
-    int child_drm = open_drm_render();
-    if (child_drm < 0)
-      _exit(2);
-    drm_syncobj_create child_create{};
-    if (ioctl(child_drm, DRM_IOCTL_SYNCOBJ_CREATE, &child_create) != 0)
-      _exit(3);
-    int child_dmabuf = make_sized_memfd(kBoSize);
-    uint32_t child_gem_handle = 0;
-    if (child_dmabuf < 0 || !prime_import(child_drm, child_dmabuf, &child_gem_handle))
-      _exit(4);
-    drm_amdgpu_gem_va child_map{};
-    child_map.handle = child_gem_handle;
-    child_map.operation = AMDGPU_VA_OP_MAP;
-    child_map.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
-    child_map.va_address = kVa;
-    child_map.map_size = kBoSize;
-    child_map.vm_timeline_point = 1;
-    child_map.vm_timeline_syncobj_out = child_create.handle;
-    if (ioctl(child_drm, DRM_AMDGPU_GEM_VA_request(), &child_map) != 0)
-      _exit(5);
-    uint32_t child_handles[] = {child_create.handle};
-    uint64_t child_points[] = {1};
-    drm_syncobj_timeline_wait child_wait{};
-    child_wait.handles = reinterpret_cast<uintptr_t>(child_handles);
-    child_wait.points = reinterpret_cast<uintptr_t>(child_points);
-    child_wait.count_handles = 1;
-    child_wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL;
-    child_wait.timeout_nsec = monotonic_deadline_after(std::chrono::seconds(1));
-    _exit(ioctl(child_drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &child_wait) == 0 ? 0 : 6);
+    alarm(10);
+    // Must fail, and must not hand back a real-hardware descriptor.
+    int child_kfd = open("/dev/kfd", O_RDWR | O_CLOEXEC);
+    if (child_kfd >= 0)
+      _exit(10); // opened something -- emulator or host -- both wrong here.
+    if (errno != ENODEV)
+      _exit(11);
+    // Ordinary filesystem work still passes through normally.
+    int devnull = open("/dev/null", O_RDONLY | O_CLOEXEC);
+    if (devnull < 0)
+      _exit(12);
+    close(devnull);
+    _exit(0);
   }
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  ASSERT_TRUE(WIFEXITED(status)) << "child did not exit cleanly";
+  EXPECT_EQ(WEXITSTATUS(status), 0)
+      << "10=GPU endpoint opened in child, 11=wrong errno, 12=ordinary open broken";
+  EXPECT_EQ(close(kfd), 0);
+}
 
-  drm_amdgpu_gem_va map{};
-  map.handle = gem_handle;
-  map.operation = AMDGPU_VA_OP_MAP;
-  map.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
-  map.va_address = kVa;
-  map.map_size = kBoSize;
-  map.vm_timeline_point = 1;
-  map.vm_timeline_syncobj_out = create.handle;
-  EXPECT_EQ(ioctl(drm, DRM_AMDGPU_GEM_VA_request(), &map), 0);
-  waiter.join();
-  EXPECT_EQ(wait_rc.load(), 0);
+// A textual path check is not enough: /dev//kfd, /dev/./kfd, a cwd-relative
+// openat(dirfd, "kfd", ...) and freopen() all reach the same device node by a
+// different spelling. The child-side classifier resolves target IDENTITY instead, so
+// every spelling must be refused. A leak here silently moves the child onto real
+// hardware on any box that has a physical KFD.
+TEST(InterposerForkTest, ChildRefusesEveryGpuEndpointSpelling) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
 
+  const pid_t child = fork();
+  ASSERT_GE(child, 0) << "fork failed: " << std::strerror(errno);
+  if (child == 0) {
+    alarm(10);
+    auto refused = [](int fd) {
+      if (fd >= 0) {
+        close(fd);
+        return false;
+      }
+      return errno == ENODEV;
+    };
+    if (!refused(open("/dev/kfd", O_RDWR | O_CLOEXEC)))
+      _exit(20);
+    if (!refused(open("/dev//kfd", O_RDWR | O_CLOEXEC)))
+      _exit(21);
+    if (!refused(open("/dev/./kfd", O_RDWR | O_CLOEXEC)))
+      _exit(22);
+    int devdir = open("/dev", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (devdir < 0)
+      _exit(23);
+    if (!refused(openat(devdir, "kfd", O_RDWR | O_CLOEXEC)))
+      _exit(24);
+    close(devdir);
+    // A refused freopen must still CLOSE the caller's original stream. POSIX freopen
+    // closes it first and does so even when opening the replacement fails, so
+    // returning ENODEV while leaving it live would keep a descriptor alive past a
+    // failed freopen -- and past the exec that follows. Use a throwaway stream rather
+    // than stdin so the check is observable.
+    FILE *victim = fopen("/dev/null", "r");
+    if (!victim)
+      _exit(25);
+    const int victim_fd = fileno(victim);
+    errno = 0;
+    if (freopen("/dev/kfd", "r", victim) != nullptr)
+      _exit(26);
+    if (errno != ENODEV)
+      _exit(27);
+    if (fcntl(victim_fd, F_GETFD) >= 0)
+      _exit(28); // original descriptor outlived a failed freopen.
+    // Ordinary character devices must still work -- the classifier refuses GPU
+    // nodes, not every device.
+    int devnull = open("/dev/null", O_RDONLY | O_CLOEXEC);
+    if (devnull < 0)
+      _exit(29);
+    close(devnull);
+    _exit(0);
+  }
   int status = 0;
   ASSERT_EQ(waitpid(child, &status, 0), child);
   ASSERT_TRUE(WIFEXITED(status));
-  EXPECT_EQ(WEXITSTATUS(status), 0);
-
-  EXPECT_EQ(gem_close(drm, gem_handle), 0);
-  EXPECT_EQ(close(dmabuf), 0);
-  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(WEXITSTATUS(status), 0)
+      << "20-24=a GPU endpoint spelling was not refused, 25=setup, 26/27=freopen "
+      << "leaked, 28=refused freopen left the original stream open, 29=ordinary "
+      << "device open broken";
   EXPECT_EQ(close(kfd), 0);
 }
+
+// Both tests above only prove anything on a box that HAS the device node they name:
+// the child-side classifier resolved identity by stat()ing the target, so on a host
+// with no /dev/kfd and no render nodes -- CI, and any pure-emulation deployment --
+// it classified nothing and every spelling fell through to libc with ENOENT. The
+// parent does not work that way: it synthesizes GPU endpoints by spelling, so it
+// serves an emulated endpoint whether or not the host has a matching node, and the
+// child's contract must not quietly depend on the box having hardware.
+//
+// Pin that with an endpoint this host does NOT have, which reaches the same branch
+// on every box rather than only on bare ones.
+TEST(InterposerForkTest, ChildRefusesAnEmulatedEndpointTheHostDoesNotHave) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+
+  // First render minor with no node on this host. DRM allocates them from 128.
+  std::string absent;
+  for (unsigned minor = 128; minor < 256; ++minor) {
+    std::string candidate = "/dev/dri/renderD" + std::to_string(minor);
+    struct stat st {};
+    if (stat(candidate.c_str(), &st) != 0) {
+      absent = std::move(candidate);
+      break;
+    }
+  }
+  if (absent.empty())
+    GTEST_SKIP() << "every render minor 128-255 exists on this host";
+
+  const std::string node = absent.substr(absent.rfind('/') + 1);
+  // The same node reached by every spelling ChildRefusesEveryGpuEndpointSpelling
+  // uses, so the absent-node path is held to the same contract as the present one.
+  // With no node to resolve, the classifier has to normalize these itself, and that
+  // normalization is only reachable here.
+  const std::string doubled = "/dev/dri//" + node;
+  const std::string dotted = "/dev/dri/./" + node;
+  const std::string parented = "/dev/dri/../dri/" + node;
+
+  const pid_t child = fork();
+  ASSERT_GE(child, 0) << "fork failed: " << std::strerror(errno);
+  if (child == 0) {
+    alarm(10);
+    auto refused = [](int fd) {
+      if (fd >= 0) {
+        close(fd);
+        return false;
+      }
+      return errno == ENODEV;
+    };
+    if (!refused(open(absent.c_str(), O_RDWR | O_CLOEXEC)))
+      _exit(30);
+    if (!refused(open(doubled.c_str(), O_RDWR | O_CLOEXEC)))
+      _exit(31);
+    if (!refused(open(dotted.c_str(), O_RDWR | O_CLOEXEC)))
+      _exit(32);
+    if (!refused(open(parented.c_str(), O_RDWR | O_CLOEXEC)))
+      _exit(33);
+    int dridir = open("/dev/dri", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (dridir >= 0) {
+      // Relative to a dirfd there is no absolute name to inspect at all, so this
+      // is the spelling that proves the classifier resolves rather than matches.
+      if (!refused(openat(dridir, node.c_str(), O_RDWR | O_CLOEXEC)))
+        _exit(34);
+      close(dridir);
+    }
+    // A path that merely does not exist must still report ENOENT: the fallback
+    // matches the endpoints the parent synthesizes, not everything absent.
+    if (open("/dev/dri/definitely-not-a-render-node", O_RDWR | O_CLOEXEC) >= 0)
+      _exit(35);
+    if (errno != ENOENT)
+      _exit(36);
+    _exit(0);
+  }
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  ASSERT_TRUE(WIFEXITED(status)) << "child did not exit cleanly";
+  EXPECT_EQ(WEXITSTATUS(status), 0)
+      << "30-34=an absent GPU endpoint spelling was not refused with ENODEV, "
+      << "35/36=an ordinary missing path stopped reporting ENOENT";
+  EXPECT_EQ(close(kfd), 0);
+}
+
+// The classifier's stated rule is that an unclassifiable target is treated AS a GPU
+// endpoint -- a child getting ENODEV on some unrelated node costs far less than a
+// child silently acquiring real hardware. Both classifiers have a give-up path, and
+// a give-up that answered "not a GPU endpoint" would be a silent fail-OPEN.
+//
+// A path too long to resolve reaches exactly that: no node to stat, and no absolute
+// spelling to compare, so neither classifier can decide. libc alone would answer
+// ENAMETOOLONG; the contract says refuse instead.
+TEST(InterposerForkTest, ChildFailsClosedOnAnUnclassifiablePath) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+
+  // Well past PATH_MAX, so resolution cannot produce a comparable absolute path.
+  const std::string overlong = "/" + std::string(PATH_MAX + 64, 'x');
+
+  const pid_t child = fork();
+  ASSERT_GE(child, 0) << "fork failed: " << std::strerror(errno);
+  if (child == 0) {
+    alarm(10);
+    int fd = open(overlong.c_str(), O_RDWR | O_CLOEXEC);
+    if (fd >= 0) {
+      close(fd);
+      _exit(40);
+    }
+    if (errno != ENODEV)
+      _exit(41);
+    // ...and a path that IS classifiable still reports its own error, so failing
+    // closed has not swallowed ordinary errno reporting.
+    if (open("/tmp/rocjitsu-no-such-file-here", O_RDONLY | O_CLOEXEC) >= 0)
+      _exit(42);
+    if (errno != ENOENT)
+      _exit(43);
+    _exit(0);
+  }
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  ASSERT_TRUE(WIFEXITED(status)) << "child did not exit cleanly";
+  EXPECT_EQ(WEXITSTATUS(status), 0)
+      << "40=an unclassifiable path was opened, 41=it was not refused with ENODEV "
+      << "(fail-open), 42/43=a classifiable missing path stopped reporting ENOENT";
+  EXPECT_EQ(close(kfd), 0);
+}
+
+// The descriptor an application receives must carry NO real-hardware authority.
+// Under fork-then-exec the interposer passes a child's ioctl/dup/dup2/fcntl straight
+// to libc, so if the app fd were a real /dev/kfd duplicate a child could drive real
+// hardware through it -- and dup2() it to a fresh number, clearing FD_CLOEXEC, to
+// carry that authority across the exec that was supposed to sanitize the process.
+// Both drivers therefore hand out synthetic descriptors and keep any real device fd
+// strictly private.
+TEST(InterposerForkTest, AppDescriptorCarriesNoRealHardwareAuthority) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+
+  auto is_real_gpu = [](int fd) {
+    struct stat st {};
+    if (::fstat(fd, &st) != 0 || !S_ISCHR(st.st_mode))
+      return false;
+    struct stat kfd_st {};
+    if (::stat("/dev/kfd", &kfd_st) == 0 && st.st_rdev == kfd_st.st_rdev)
+      return true;
+    return major(st.st_rdev) == 226u;
+  };
+
+  EXPECT_FALSE(is_real_gpu(kfd))
+      << "the application-facing KFD descriptor must be synthetic, not a real device";
+
+  const pid_t child = fork();
+  ASSERT_GE(child, 0) << "fork failed: " << std::strerror(errno);
+  if (child == 0) {
+    alarm(10);
+    // Laundering the inherited descriptor must not produce hardware authority.
+    int laundered = dup2(kfd, 200);
+    if (laundered >= 0) {
+      struct stat st {};
+      if (::fstat(200, &st) == 0 && S_ISCHR(st.st_mode)) {
+        struct stat kfd_st {};
+        if ((::stat("/dev/kfd", &kfd_st) == 0 && st.st_rdev == kfd_st.st_rdev) ||
+            major(st.st_rdev) == 226u)
+          _exit(40); // real GPU authority survived into the child.
+      }
+    }
+    _exit(0);
+  }
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  ASSERT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(WEXITSTATUS(status), 0)
+      << "40=a real GPU descriptor was inherited and laundered across dup2";
+  EXPECT_EQ(close(kfd), 0);
+}
+
+// Making the APPLICATION-facing descriptor synthetic is not enough on its own:
+// fork() copies the whole descriptor table, so a hardware-backed guest's PRIVATE
+// real /dev/kfd is inherited too, and a child can find it by walking /proc/self/fd.
+// Child pass-through paths therefore check descriptor IDENTITY, refusing operations
+// on any real GPU fd rather than trusting the path used to obtain it.
+//
+// This is a cooperative, API-level contract, not a security boundary -- a child
+// issuing raw syscalls is out of reach of interposition -- but it stops the
+// realistic failure: inheriting hardware by accident and laundering it across exec.
+TEST(InterposerForkTest, ChildRefusesOperationsOnInheritedRealGpuDescriptors) {
+  // card0 is a real DRM device the interposer does not synthesize, so the parent
+  // genuinely hands real GPU authority to the child -- the same shape as a hardware
+  // guest's private KFD descriptor.
+  int real_gpu = ::open("/dev/dri/card0", O_RDWR | O_CLOEXEC);
+  if (real_gpu < 0)
+    GTEST_SKIP() << "no real DRM device available to inherit";
+
+  const pid_t child = fork();
+  ASSERT_GE(child, 0) << "fork failed: " << std::strerror(errno);
+  if (child == 0) {
+    alarm(10);
+    auto refused = [](int rc) { return rc < 0 && errno == ENODEV; };
+    if (!refused(ioctl(real_gpu, 0, 0)))
+      _exit(50); // operated real hardware through an inherited descriptor.
+    if (!refused(dup(real_gpu)))
+      _exit(51);
+    if (!refused(dup2(real_gpu, 210)))
+      _exit(52); // dup2 also strips FD_CLOEXEC, so this is the exec-laundering route.
+    if (!refused(fcntl(real_gpu, F_DUPFD_CLOEXEC, 0)))
+      _exit(53);
+    _exit(0);
+  }
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  ASSERT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(WEXITSTATUS(status), 0)
+      << "50=ioctl, 51=dup, 52=dup2, 53=F_DUPFD each allowed on an inherited real "
+      << "GPU descriptor";
+  EXPECT_EQ(close(real_gpu), 0);
+}
+
+// Duplication is not the only way to launder an inherited descriptor past exec:
+// clearing FD_CLOEXEC on the descriptor already held does it with no dup at all.
+// The child gate must cover both, while leaving harmless fcntl use working.
+TEST(InterposerForkTest, ChildCannotLaunderInheritedGpuFdAcrossExec) {
+  int real_gpu = ::open("/dev/dri/card0", O_RDWR | O_CLOEXEC);
+  if (real_gpu < 0)
+    GTEST_SKIP() << "no real DRM device available to inherit";
+
+  const pid_t child = fork();
+  ASSERT_GE(child, 0) << "fork failed: " << std::strerror(errno);
+  if (child == 0) {
+    alarm(10);
+    // Clearing FD_CLOEXEC is the no-duplication laundering route.
+    if (!(fcntl(real_gpu, F_SETFD, 0) < 0 && errno == ENODEV))
+      _exit(60);
+    // Setting it is harmless and must still be permitted.
+    if (fcntl(real_gpu, F_SETFD, FD_CLOEXEC) != 0)
+      _exit(61);
+    // Ordinary queries must keep working.
+    if (fcntl(real_gpu, F_GETFD) < 0)
+      _exit(62);
+    _exit(0);
+  }
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  ASSERT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(WEXITSTATUS(status), 0)
+      << "60=F_SETFD cleared FD_CLOEXEC on a real GPU fd, 61=setting FD_CLOEXEC was "
+      << "wrongly refused, 62=an ordinary fcntl query was wrongly refused";
+  EXPECT_EQ(close(real_gpu), 0);
+}
+
+// dup3 is gated on the same path as dup2 but is worth its own case: it takes an
+// explicit flags argument, so the laundering shape (flags without O_CLOEXEC) is
+// expressed differently, and a future refactor could plausibly gate one and not the
+// other. Both flag forms must be refused on a real GPU fd -- a child has no business
+// operating real hardware whether or not the copy would survive exec -- while dup3
+// on an ordinary descriptor must keep working.
+TEST(InterposerForkTest, ChildRefusesDup3OnInheritedGpuFd) {
+  int real_gpu = ::open("/dev/dri/card0", O_RDWR | O_CLOEXEC);
+  if (real_gpu < 0)
+    GTEST_SKIP() << "no real DRM device available to inherit";
+  int ordinary = ::open("/dev/null", O_RDONLY | O_CLOEXEC);
+  ASSERT_GE(ordinary, 0);
+
+  const pid_t child = fork();
+  ASSERT_GE(child, 0) << "fork failed: " << std::strerror(errno);
+  if (child == 0) {
+    alarm(10);
+    // Without O_CLOEXEC the copy would survive exec -- the laundering route.
+    if (!(dup3(real_gpu, 220, 0) < 0 && errno == ENODEV))
+      _exit(90);
+    // With O_CLOEXEC it would not survive exec, but the child still must not get a
+    // usable real-hardware descriptor.
+    if (!(dup3(real_gpu, 221, O_CLOEXEC) < 0 && errno == ENODEV))
+      _exit(91);
+    // Ordinary descriptors are unaffected.
+    if (dup3(ordinary, 222, O_CLOEXEC) < 0)
+      _exit(92);
+    _exit(0);
+  }
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  ASSERT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(WEXITSTATUS(status), 0)
+      << "90=dup3 laundered a real GPU fd, 91=dup3 with O_CLOEXEC still handed one "
+      << "over, 92=dup3 on an ordinary fd was wrongly refused";
+  EXPECT_EQ(close(ordinary), 0);
+  EXPECT_EQ(close(real_gpu), 0);
+}
+
+// mmap64 is a distinct exported symbol, and _FILE_OFFSET_BITS=64 redirects even a
+// source-level mmap() call to it. Exporting only mmap would let those calls bypass
+// the child refusal and all emulator routing, exactly as would have happened for
+// fcntl64. Call it explicitly so the test cannot be silently re-bound.
+extern "C" void *mmap64(void *, size_t, int, int, int, __off64_t);
+
+TEST(InterposerForkTest, ChildRefusesMmap64OnInheritedGpuFd) {
+  int real_gpu = ::open("/dev/dri/card0", O_RDWR | O_CLOEXEC);
+  if (real_gpu < 0)
+    GTEST_SKIP() << "no real DRM device available to inherit";
+
+  const pid_t child = fork();
+  ASSERT_GE(child, 0) << "fork failed: " << std::strerror(errno);
+  if (child == 0) {
+    alarm(10);
+    void *p = mmap64(nullptr, 4096, PROT_READ, MAP_SHARED, real_gpu, 0);
+    if (!(p == MAP_FAILED && errno == ENODEV))
+      _exit(70);
+    _exit(0);
+  }
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  ASSERT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(WEXITSTATUS(status), 0) << "70=mmap64 bypassed the child GPU-fd refusal";
+  EXPECT_EQ(close(real_gpu), 0);
+}
+
+// The child's fopen must keep libc's own mode parser. An earlier version re-derived
+// open flags and used fdopen, which silently lost the 0666 creation mode for "w"/"a"
+// (files came out mode 0000) and the "x" exclusive modifier (truncating instead of
+// failing EEXIST).
+TEST(InterposerForkTest, ChildFopenPreservesLibcModeSemantics) {
+  rocjitsu::test::ScopedTempDirectory tmp("rj_fopen_");
+  const std::string target = tmp.path() + "/created";
+
+  const pid_t child = fork();
+  ASSERT_GE(child, 0) << "fork failed: " << std::strerror(errno);
+  if (child == 0) {
+    alarm(10);
+    // Pin the umask so the expected mode is exact. Without this the assertion has to
+    // weaken to "some bit is set", which would accept genuinely wrong modes -- and
+    // would wrongly fail under an ambient umask of 0777, where 0000 is correct.
+    ::umask(0);
+
+    FILE *w = fopen(target.c_str(), "w");
+    if (!w)
+      _exit(80);
+    fclose(w);
+    struct stat st {};
+    if (::stat(target.c_str(), &st) != 0)
+      _exit(81);
+    if ((st.st_mode & 07777) != 0666)
+      _exit(82); // must be exactly 0666 & ~umask(0); mode 0000 was the old bug.
+
+    // Seed content so "wx" failing is distinguishable from "wx" truncating and then
+    // failing -- a null return alone does not prove the file was left alone.
+    FILE *seed = fopen(target.c_str(), "w");
+    if (!seed)
+      _exit(83);
+    fputs("SENTINEL", seed);
+    fclose(seed);
+
+    errno = 0;
+    FILE *excl = fopen(target.c_str(), "wx");
+    const int excl_errno = errno;
+    if (excl != nullptr) {
+      fclose(excl);
+      _exit(84); // "x" must refuse an existing file.
+    }
+    if (excl_errno != EEXIST)
+      _exit(85);
+    char buf[32] = {};
+    FILE *rd = fopen(target.c_str(), "r");
+    if (!rd)
+      _exit(86);
+    const char *got = fgets(buf, sizeof(buf), rd);
+    fclose(rd);
+    if (!got || std::strcmp(buf, "SENTINEL") != 0)
+      _exit(87); // truncated despite failing: the destructive-then-fail shape.
+    _exit(0);
+  }
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  ASSERT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(WEXITSTATUS(status), 0)
+      << "80/81=fopen(\"w\") failed, 82=creation mode was not 0666 under umask(0), "
+      << "83=seeding failed, 84=\"wx\" opened an existing file, 85=wrong errno, "
+      << "86/87=\"wx\" truncated the file before failing";
+}
+
+// Names lie; device identity does not. A symlink can point at the real KFD under any
+// name, a chain can hide it another level down, and an unrelated node can be *named*
+// like KFD without being one. The child classifier resolves the target and compares
+// st_rdev against the host KFD recorded at init, so all three must come out right --
+// including the reverse case, which a substring check would wrongly refuse.
+TEST(InterposerForkTest, ChildClassifiesGpuEndpointsByIdentityNotName) {
+  struct stat kfd_st {};
+  if (::stat("/dev/kfd", &kfd_st) != 0 || !S_ISCHR(kfd_st.st_mode))
+    GTEST_SKIP() << "host has no real /dev/kfd to alias";
+
+  rocjitsu::test::ScopedTempDirectory tmp("rj_alias_");
+  const std::string aliased = tmp.path() + "/gpu";          // -> /dev/kfd
+  const std::string chained = tmp.path() + "/chained";      // -> gpu -> /dev/kfd
+  const std::string lookalike = tmp.path() + "/kfd_shaped"; // -> /dev/null
+  ASSERT_EQ(symlink("/dev/kfd", aliased.c_str()), 0);
+  ASSERT_EQ(symlink("gpu", chained.c_str()), 0);
+  ASSERT_EQ(symlink("/dev/null", lookalike.c_str()), 0);
+
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+
+  const pid_t child = fork();
+  ASSERT_GE(child, 0) << "fork failed: " << std::strerror(errno);
+  if (child == 0) {
+    alarm(10);
+    auto refused = [](const std::string &p) {
+      int fd = open(p.c_str(), O_RDWR | O_CLOEXEC);
+      if (fd >= 0) {
+        close(fd);
+        return false;
+      }
+      return errno == ENODEV;
+    };
+    if (!refused(aliased))
+      _exit(30); // differently named alias leaked real hardware.
+    if (!refused(chained))
+      _exit(31); // chained alias leaked real hardware.
+    int ok = open(lookalike.c_str(), O_RDONLY | O_CLOEXEC);
+    if (ok < 0)
+      _exit(32); // a node merely NAMED like KFD must not be refused.
+    close(ok);
+    _exit(0);
+  }
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  ASSERT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(WEXITSTATUS(status), 0)
+      << "30=named alias leaked, 31=chained alias leaked, 32=false positive on a "
+      << "non-GPU node whose name resembles KFD";
+  EXPECT_EQ(close(kfd), 0);
+}
+
+// The case that used to deadlock: fork racing threads that are inside interposed
+// calls. Under the PID gate the child touches nothing inherited, so it must always
+// reach exec. The alarm in the child is the liveness assertion.
+TEST(InterposerForkTest, MultithreadedForkExecAlwaysReachesExec) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+
+  std::atomic<bool> stop{false};
+  std::vector<std::thread> churn;
+  for (int i = 0; i < 4; ++i) {
+    churn.emplace_back([&] {
+      while (!stop.load(std::memory_order_acquire)) {
+        int d = dup(kfd);
+        if (d >= 0)
+          close(d);
+      }
+    });
+  }
+  for (int i = 0; i < 2; ++i) {
+    churn.emplace_back([&] {
+      while (!stop.load(std::memory_order_acquire)) {
+        struct stat st {};
+        stat("/sys/class/kfd/kfd/topology/nodes/0/properties", &st);
+      }
+    });
+  }
+
+  for (int round = 0; round < 24; ++round) {
+    const pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork failed: " << std::strerror(errno);
+    if (child == 0) {
+      alarm(10);
+      execl("/bin/true", "true", static_cast<char *>(nullptr));
+      _exit(127); // exec failed
+    }
+    int status = 0;
+    ASSERT_EQ(waitpid(child, &status, 0), child);
+    ASSERT_TRUE(WIFEXITED(status))
+        << "round " << round << ": child never reached exec (a fork racing an "
+        << "interposed call must not be able to block on inherited state)";
+    EXPECT_EQ(WEXITSTATUS(status), 0) << "round " << round;
+  }
+
+  stop.store(true, std::memory_order_release);
+  for (auto &t : churn)
+    t.join();
+  EXPECT_EQ(close(kfd), 0);
+}
+
+// system() and popen() fork internally without going through our exported fork(),
+// so they exercise the same child path via a route we do not control.
+TEST(InterposerForkTest, SystemAndPopenWorkFromAMultithreadedParent) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+
+  std::atomic<bool> stop{false};
+  std::vector<std::thread> churn;
+  for (int i = 0; i < 4; ++i) {
+    churn.emplace_back([&] {
+      while (!stop.load(std::memory_order_acquire)) {
+        int d = dup(kfd);
+        if (d >= 0)
+          close(d);
+      }
+    });
+  }
+
+  for (int round = 0; round < 8; ++round) {
+    EXPECT_EQ(system("/bin/true"), 0) << "round " << round;
+    FILE *pipe = popen("/bin/echo rocjitsu", "r");
+    ASSERT_NE(pipe, nullptr) << "round " << round;
+    char buf[64] = {};
+    EXPECT_NE(fgets(buf, sizeof(buf), pipe), nullptr);
+    EXPECT_STREQ(buf, "rocjitsu\n");
+    EXPECT_EQ(pclose(pipe), 0) << "round " << round;
+  }
+
+  stop.store(true, std::memory_order_release);
+  for (auto &t : churn)
+    t.join();
+  EXPECT_EQ(close(kfd), 0);
+}
+
+// posix_spawn uses vfork/CLONE_VFORK internally, where the child shares the parent's
+// address space until exec. The gate must not mutate anything in that window.
+TEST(InterposerForkTest, PosixSpawnFromAMultithreadedParent) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+
+  std::atomic<bool> stop{false};
+  std::vector<std::thread> churn;
+  for (int i = 0; i < 4; ++i) {
+    churn.emplace_back([&] {
+      while (!stop.load(std::memory_order_acquire)) {
+        int d = dup(kfd);
+        if (d >= 0)
+          close(d);
+      }
+    });
+  }
+
+  for (int round = 0; round < 8; ++round) {
+    pid_t spawned = -1;
+    char prog[] = "/bin/true";
+    char *const argv[] = {prog, nullptr};
+    ASSERT_EQ(posix_spawn(&spawned, prog, nullptr, nullptr, argv, environ), 0) << "round " << round;
+    int status = 0;
+    ASSERT_EQ(waitpid(spawned, &status, 0), spawned);
+    EXPECT_TRUE(WIFEXITED(status)) << "round " << round;
+    EXPECT_EQ(WEXITSTATUS(status), 0) << "round " << round;
+  }
+
+  stop.store(true, std::memory_order_release);
+  for (auto &t : churn)
+    t.join();
+  // The parent's own KFD routing must be untouched by all that spawning.
+  EXPECT_TRUE(kfd_version_ok(kfd));
+  EXPECT_EQ(close(kfd), 0);
+}
+
+// RETIRED: this exercised fork-WITHOUT-exec in local mode -- the child re-opened
+// KFD/DRM and ran GEM + syncobj work with no intervening exec. That contradicts the
+// contract local mode can actually honour (see InterposerForkTest above): the
+// simulator lives in this address space and its driver locks cannot be drained by an
+// atfork handler. The capability is only supportable where the state is NOT in the
+// forking address space, i.e. daemon mode -- and re-homing it there needs its own
+// design first, because a daemon-mode child still inherits the client-side context,
+// RemoteDriver, fd maps and shared_ptr control blocks. Being out-of-process removes
+// the simulator from the child, not the proxy. Tracked separately; do not simply
+// move this test.
 
 TEST(InterposerSyncobjTest, ConcurrentVmUpdatesShareTimeline) {
   int kfd = open_kfd();

--- a/emulation/rocjitsu/tests/simdojo_sim_test.cpp
+++ b/emulation/rocjitsu/tests/simdojo_sim_test.cpp
@@ -177,6 +177,93 @@ private:
   Event timer_event_{this, EventType::TIMER_CALLBACK};
 };
 
+/// Component that counts initialize()/startup()/shutdown() calls. Used to verify
+/// that shutdown() cleanup fires exactly once per initialized component, on both
+/// the normal shutdown path and the startup-failure unwind path. When given a
+/// shared order log, records its own name on shutdown() so tests can assert the
+/// reverse-topology-order shutdown contract.
+class LifecycleCountingComponent : public Component {
+public:
+  explicit LifecycleCountingComponent(std::string name,
+                                      std::vector<std::string> *shutdown_order = nullptr)
+      : Component(std::move(name)), shutdown_order_(shutdown_order) {}
+
+  void initialize() override { ++initializes; }
+  void startup() override { ++startups; }
+  void shutdown() override {
+    ++shutdowns;
+    if (shutdown_order_)
+      shutdown_order_->push_back(name());
+  }
+
+  uint32_t initializes = 0;
+  uint32_t startups = 0;
+  uint32_t shutdowns = 0;
+
+private:
+  std::vector<std::string> *shutdown_order_;
+};
+
+/// Component whose startup() requests an ordinary exit and only then throws.
+///
+/// @details Pins the precedence between the two terminal writers. The exit request
+/// records a code-0 status FIRST, so unless the failure outranks it, run() hands back
+/// success for a generation whose components never started.
+class ExitThenThrowStartupComponent : public Component {
+public:
+  explicit ExitThenThrowStartupComponent(std::string name) : Component(std::move(name)) {}
+
+  void startup() override {
+    engine()->request_exit("ordinary exit request from startup", /*code=*/0);
+    throw std::runtime_error("startup failed after requesting exit");
+  }
+};
+
+/// Component whose startup() throws the first N times it is called, then
+/// succeeds. Also counts shutdown() so tests can assert unwind cleanup.
+class FlakyStartupComponent : public Component {
+public:
+  FlakyStartupComponent(std::string name, uint32_t throws_before_success)
+      : Component(std::move(name)), remaining_throws_(throws_before_success) {}
+
+  void startup() override {
+    if (remaining_throws_ > 0) {
+      --remaining_throws_;
+      throw std::runtime_error("startup deliberately failing");
+    }
+    ++successful_startups;
+  }
+
+  void shutdown() override { ++shutdowns; }
+
+  uint32_t successful_startups = 0;
+  uint32_t shutdowns = 0;
+
+private:
+  uint32_t remaining_throws_;
+};
+
+/// Component whose startup() AND shutdown() both throw. Component::shutdown() is
+/// not noexcept, so the startup-failure unwind must survive a throwing shutdown
+/// hook without escaping the engine or stranding wait_until_started().
+class DoublyThrowingComponent : public Component {
+public:
+  explicit DoublyThrowingComponent(std::string name) : Component(std::move(name)) {}
+
+  void startup() override {
+    ++startups;
+    throw std::runtime_error("startup deliberately failing");
+  }
+
+  void shutdown() override {
+    ++shutdowns;
+    throw std::runtime_error("shutdown deliberately failing");
+  }
+
+  uint32_t startups = 0;
+  uint32_t shutdowns = 0;
+};
+
 /// Helper: build engine with manual partition assignment.
 /// assigner maps component name → partition ID.
 void build_with_manual_partitions(SimulationEngine &engine, uint32_t num_partitions,
@@ -665,6 +752,253 @@ TEST(TerminationTest, MaxTicksSentinel) {
 
   EXPECT_EQ(exit.reason, ExitReason::COMPLETED);
   EXPECT_NE(exit.message.find("max ticks"), std::string::npos);
+}
+
+TEST(StartupReadinessTest, CleanStartupReportsReady) {
+  // A clean startup must make wait_until_started() return true without hanging.
+  SimulationEngine engine({.max_ticks = 5, .num_threads = 1});
+  auto root = std::make_unique<CompositeComponent>("root");
+  root->add_child(std::make_unique<LifecycleCountingComponent>("c0"));
+  engine.topology().set_root(std::move(root));
+  engine.create();
+
+  engine.step();
+  EXPECT_TRUE(engine.wait_until_started());
+}
+
+TEST(StartupReadinessTest, StartupFailureOutranksAnEarlierExitRequest) {
+  // The failure is recorded SECOND here, after an ordinary code-0 exit request that
+  // the same startup() issued. Whoever wrote first must not win: a generation whose
+  // components never started has to report failure, or the C API maps code 0 to
+  // success and a dead VM looks like a clean run.
+  SimulationEngine engine({.max_ticks = 10, .num_threads = 1});
+  auto root = std::make_unique<CompositeComponent>("root");
+  root->add_child(std::make_unique<ExitThenThrowStartupComponent>("exit_then_throw0"));
+  engine.topology().set_root(std::move(root));
+  engine.create();
+
+  auto exit = engine.run();
+
+  EXPECT_EQ(exit.reason, ExitReason::INTERRUPTED);
+  EXPECT_EQ(exit.code, 1) << "a startup failure must not be reported as a clean exit";
+  EXPECT_FALSE(engine.wait_until_started());
+  EXPECT_EQ(engine.last_exit().code, 1);
+}
+
+TEST(StartupReadinessTest, StartupFailureIsTerminalForTheGeneration) {
+  // A startup() throw leaves the partial attempt's event/primary/component state
+  // intact, so the create() generation is terminal: step() rethrows once, latches
+  // failure, and a same-generation retry must NOT re-run startup (it returns done).
+  // A clean retry requires shutdown() + create().
+  SimulationEngine engine({.max_ticks = 10, .num_threads = 1});
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto *flaky = root->add_child(std::make_unique<FlakyStartupComponent>("flaky0", 1));
+  engine.topology().set_root(std::move(root));
+  engine.create();
+
+  // First step(): startup throws, wait_until_started() observes failure.
+  EXPECT_THROW(engine.step(), std::runtime_error);
+  EXPECT_FALSE(engine.wait_until_started());
+
+  // step() must record the SAME failure ExitStatus run() would. Without it the
+  // create() default {COMPLETED, 0} survives and the terminal guard below hands
+  // back a success-looking status for a generation that never started.
+  EXPECT_EQ(engine.last_exit().reason, ExitReason::INTERRUPTED);
+  EXPECT_EQ(engine.last_exit().code, 1);
+
+  // Same-generation retry: startup is NOT re-run (generation is terminal), so the
+  // component's startup() never succeeds and step() reports done.
+  EXPECT_FALSE(engine.step());
+  EXPECT_EQ(static_cast<FlakyStartupComponent *>(flaky)->successful_startups, 0u);
+
+  // A run() after the failed step() goes through the same terminal guard and must
+  // report the recorded failure, not the create() default.
+  auto after_failed_step = engine.run();
+  EXPECT_EQ(after_failed_step.reason, ExitReason::INTERRUPTED);
+  EXPECT_EQ(after_failed_step.code, 1);
+  EXPECT_EQ(static_cast<FlakyStartupComponent *>(flaky)->successful_startups, 0u);
+
+  // A fresh generation (shutdown + create) starts cleanly and succeeds.
+  engine.shutdown();
+  engine.create();
+  engine.step();
+  EXPECT_TRUE(engine.wait_until_started());
+  EXPECT_EQ(static_cast<FlakyStartupComponent *>(flaky)->successful_startups, 1u);
+}
+
+TEST(StartupReadinessTest, ThrowingShutdownDuringStartupUnwindStillPublishesFailure) {
+  // Component::shutdown() is not noexcept. If the startup-failure unwind ran
+  // BEFORE the readiness latch, a throwing shutdown hook would escape the catch
+  // path — terminating the interposer's background run() thread — while
+  // wait_until_started() stayed blocked forever. The failure must therefore be
+  // published first and the unwind caught separately.
+  SimulationEngine engine({.max_ticks = 10, .num_threads = 1});
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto *doubly = root->add_child(std::make_unique<DoublyThrowingComponent>("doubly0"));
+  engine.topology().set_root(std::move(root));
+  engine.create();
+
+  // run() must return the terminal status rather than letting the shutdown throw
+  // propagate out of the engine.
+  auto exit = engine.run();
+  EXPECT_EQ(exit.reason, ExitReason::INTERRUPTED);
+  EXPECT_EQ(exit.code, 1);
+  EXPECT_FALSE(engine.wait_until_started());
+
+  auto *comp = static_cast<DoublyThrowingComponent *>(doubly);
+  EXPECT_EQ(comp->startups, 1u);
+  EXPECT_EQ(comp->shutdowns, 1u) << "the unwind must still attempt the shutdown hook";
+
+  // The engine's own shutdown() must also survive the throwing hook (it is guarded
+  // against a second invocation, so this asserts no rethrow escapes destruction).
+  EXPECT_NO_THROW(engine.shutdown());
+}
+
+TEST(StartupReadinessTest, ThrowingShutdownDuringStepUnwindRethrowsOnlyTheStartupError) {
+  // step() rethrows to its foreground caller. The exception it propagates must be
+  // the STARTUP failure, not whatever the best-effort unwind's shutdown hook threw
+  // on top of it, and readiness must still be published as failed.
+  SimulationEngine engine({.max_ticks = 10, .num_threads = 1});
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto *doubly = root->add_child(std::make_unique<DoublyThrowingComponent>("doubly0"));
+  engine.topology().set_root(std::move(root));
+  engine.create();
+
+  try {
+    engine.step();
+    ADD_FAILURE() << "step() must rethrow the startup failure";
+  } catch (const std::runtime_error &e) {
+    EXPECT_STREQ(e.what(), "startup deliberately failing")
+        << "the unwind's shutdown throw must not replace the startup error";
+  }
+
+  EXPECT_FALSE(engine.wait_until_started());
+  EXPECT_EQ(engine.last_exit().reason, ExitReason::INTERRUPTED);
+  EXPECT_EQ(engine.last_exit().code, 1);
+
+  auto *comp = static_cast<DoublyThrowingComponent *>(doubly);
+  EXPECT_EQ(comp->startups, 1u);
+  EXPECT_EQ(comp->shutdowns, 1u);
+}
+
+TEST(StartupReadinessTest, RunAfterFailedStartupFailsClosedWithoutRerun) {
+  // run()'s terminal-generation guard must be a RUNTIME check, not just an
+  // assert: under -DNDEBUG a second run() after a startup throw must fail closed
+  // (return the terminal INTERRUPTED status) instead of re-entering
+  // startup_components() on the dirty generation. This runs regardless of build
+  // type, so it covers the release path.
+  SimulationEngine engine({.max_ticks = 10, .num_threads = 1});
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto *flaky = root->add_child(std::make_unique<FlakyStartupComponent>("flaky0", 1));
+  engine.topology().set_root(std::move(root));
+  engine.create();
+
+  // First run(): startup throws; run() catches, latches failure, returns INTERRUPTED.
+  auto first = engine.run();
+  EXPECT_EQ(first.reason, ExitReason::INTERRUPTED);
+  EXPECT_EQ(first.code, 1);
+  EXPECT_FALSE(engine.wait_until_started());
+  EXPECT_EQ(static_cast<FlakyStartupComponent *>(flaky)->successful_startups, 0u);
+
+  // Second run() on the same (dirty) generation must NOT re-run startup — it
+  // returns the terminal status. Without the runtime guard this would re-enter
+  // startup_components() on already-scheduled/registered state.
+  auto second = engine.run();
+  EXPECT_EQ(second.reason, ExitReason::INTERRUPTED);
+  EXPECT_EQ(second.code, 1);
+  EXPECT_EQ(static_cast<FlakyStartupComponent *>(flaky)->successful_startups, 0u);
+}
+
+TEST(StartupReadinessTest, StartupFailureUnwindsEveryInitializedComponentOnce) {
+  // A throwing component partway through startup must not leave earlier components'
+  // resources dangling: shutdown() pairs with initialize(), so the unwind shuts
+  // down EVERY initialized component (not only the started prefix) exactly once —
+  // including the component that threw and the one after it that never started.
+  std::vector<std::string> shutdown_order;
+  SimulationEngine engine({.max_ticks = 10, .num_threads = 1});
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto *before =
+      root->add_child(std::make_unique<LifecycleCountingComponent>("before", &shutdown_order));
+  auto *flaky = root->add_child(std::make_unique<FlakyStartupComponent>("flaky", 1));
+  auto *after =
+      root->add_child(std::make_unique<LifecycleCountingComponent>("after", &shutdown_order));
+  engine.topology().set_root(std::move(root));
+  engine.create();
+
+  EXPECT_THROW(engine.step(), std::runtime_error);
+
+  auto *before_c = static_cast<LifecycleCountingComponent *>(before);
+  auto *after_c = static_cast<LifecycleCountingComponent *>(after);
+  EXPECT_EQ(before_c->initializes, 1u);
+  EXPECT_EQ(before_c->startups, 1u);
+  EXPECT_EQ(before_c->shutdowns, 1u); // started, then unwound
+  EXPECT_EQ(after_c->initializes, 1u);
+  EXPECT_EQ(after_c->startups, 0u);  // never reached
+  EXPECT_EQ(after_c->shutdowns, 1u); // initialized, so still cleaned up
+  EXPECT_EQ(static_cast<FlakyStartupComponent *>(flaky)->shutdowns, 1u);
+
+  // shutdown() runs in reverse topology order. "flaky" has no counting log, but
+  // the two counting components bracket it, so "after" must be shut down before
+  // "before".
+  ASSERT_EQ(shutdown_order.size(), 2u);
+  EXPECT_EQ(shutdown_order[0], "after");
+  EXPECT_EQ(shutdown_order[1], "before");
+
+  // The engine's own shutdown() must not double-shut-down the already-unwound
+  // components.
+  engine.shutdown();
+  EXPECT_EQ(before_c->shutdowns, 1u);
+  EXPECT_EQ(after_c->shutdowns, 1u);
+}
+
+TEST(StartupReadinessTest, ThrowingShutdownStillCleansUpRemainingComponents) {
+  // shutdown_components() marks the generation shut down before invoking any
+  // callback, so a callback that throws must not be allowed to skip the components
+  // after it — there is no second chance to clean them up. Each callback is
+  // isolated; the first failure is reported once the rest have run.
+  std::vector<std::string> shutdown_order;
+  SimulationEngine engine({.max_ticks = 10, .num_threads = 1});
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto *first =
+      root->add_child(std::make_unique<LifecycleCountingComponent>("first", &shutdown_order));
+  auto *thrower = root->add_child(std::make_unique<DoublyThrowingComponent>("thrower"));
+  auto *last =
+      root->add_child(std::make_unique<LifecycleCountingComponent>("last", &shutdown_order));
+  engine.topology().set_root(std::move(root));
+  engine.create();
+
+  // Reverse order is last -> thrower -> first, so the throw lands between them.
+  // shutdown() must NOT propagate it: it is reached from ~SimulationEngine(), from
+  // the engine's own background thread, and across the C API, none of which can
+  // absorb an exception.
+  EXPECT_NO_THROW(engine.shutdown());
+  EXPECT_FALSE(engine.is_created()) << "engine cleanup must complete despite a throwing hook";
+
+  EXPECT_EQ(static_cast<DoublyThrowingComponent *>(thrower)->shutdowns, 1u);
+  EXPECT_EQ(static_cast<LifecycleCountingComponent *>(last)->shutdowns, 1u);
+  EXPECT_EQ(static_cast<LifecycleCountingComponent *>(first)->shutdowns, 1u)
+      << "a throwing callback must not skip cleanup for the components after it";
+  ASSERT_EQ(shutdown_order.size(), 2u);
+  EXPECT_EQ(shutdown_order[0], "last");
+  EXPECT_EQ(shutdown_order[1], "first");
+}
+
+TEST(StartupReadinessTest, CreateThenShutdownRunsComponentCleanup) {
+  // create() initializes every component; shutting the engine down before any
+  // run()/step() must still invoke shutdown() on each initialized component
+  // exactly once (shutdown() pairs with initialize(), not startup()).
+  SimulationEngine engine({.max_ticks = 10, .num_threads = 1});
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto *comp = root->add_child(std::make_unique<LifecycleCountingComponent>("comp"));
+  engine.topology().set_root(std::move(root));
+  engine.create();
+
+  auto *counting = static_cast<LifecycleCountingComponent *>(comp);
+  EXPECT_EQ(counting->initializes, 1u);
+  EXPECT_EQ(counting->startups, 0u);
+
+  engine.shutdown();
+  EXPECT_EQ(counting->shutdowns, 1u);
 }
 
 TEST(TerminationTest, RequestExitWakesAllPartitions) {

--- a/emulation/rocjitsu/tests/simulated_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/simulated_kfd_test.cpp
@@ -31,6 +31,7 @@ RJ_DIAGNOSTIC_POP
 #include <array>
 #include <atomic>
 #include <cerrno>
+#include <chrono>
 #include <cstdlib>
 #include <filesystem>
 #include <thread>
@@ -634,6 +635,9 @@ TEST_F(SimulatedKfdTest, GuestOpenSurvivesExecutionPrimaryOverwrite) {
 
   const int reopened_fd = guest.open();
   ASSERT_GE(reopened_fd, 0);
+  // Each open() yields a DISTINCT descriptor, as real KFD does -- duplicated from
+  // the synthetic backing, never from a real device.
+  EXPECT_NE(reopened_fd, app_fd);
   EXPECT_EQ(execution_driver->local_open_ref_count(), 1u)
       << "re-minting the simulator primary must not leak another backend open";
   EXPECT_EQ(execution_driver->local_process_id(), process_id);
@@ -649,6 +653,242 @@ TEST_F(SimulatedKfdTest, GuestOpenSurvivesExecutionPrimaryOverwrite) {
   EXPECT_EQ(::close(pipefd[1]), 0);
 }
 
+// A caller-visible WAIT_EVENTS on the hardware path is served as MANY bounded ioctls.
+// That is invisible to the caller until a final close lands between two slices: the
+// connection the wait had already started on would be gone, and the next slice would
+// fail ENODEV -- an operation revoked partway, which a native blocking ioctl is never
+// subject to, since the kernel holds a file reference for the whole syscall. A lease
+// held for the caller-visible duration makes that close DEFER instead.
+//
+// Driving the lease directly rather than through a real sliced wait is deliberate: what
+// it guards is backend-independent, so the contract is provable here with no device and
+// no timing race. The observable is the simulator backend's open reference, which the
+// final close is what normally releases.
+TEST_F(SimulatedKfdTest, FinalCloseUnderAWaitLeaseDefersUntilTheLeaseDrains) {
+  rj_vm_t *raw_vm = nullptr;
+  ASSERT_EQ(rj_vm_create(CONFIG_PATH.c_str(), RJ_VM_MODE_LOCAL, &raw_vm), ROCJITSU_STATUS_SUCCESS);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> vm(raw_vm, &rj_vm_destroy);
+  ASSERT_NE(vm->vm, nullptr);
+  auto *execution_driver = vm->vm->driver();
+  ASSERT_NE(execution_driver, nullptr);
+
+  rocjitsu::config::DbtGuestConfig config;
+  config.enabled = true;
+  config.guest_isa = "gfx950";
+  config.host.isa = "gfx950";
+  config.host.gpu_id = execution_driver->gpu_id();
+  config.host.backend = rocjitsu::config::DbtExecutionBackend::Simulator;
+  config.guest_device = vm->loaded.device;
+  config.guest_device.gpu_id += 1;
+  config.guest_device.drm_render_minor += 1;
+
+  rocjitsu::GuestKfd guest(std::move(config), execution_driver);
+  ASSERT_TRUE(guest.prepare_for_discovery());
+  const int app_fd = guest.open();
+  ASSERT_GE(app_fd, 0);
+  ASSERT_EQ(execution_driver->local_open_ref_count(), 1u);
+
+  ASSERT_TRUE(rocjitsu::GuestKfdTestAccess::acquire_wait_lease(guest));
+
+  EXPECT_EQ(::close(app_fd), 0);
+  EXPECT_EQ(guest.close(), 0);
+  EXPECT_EQ(execution_driver->local_open_ref_count(), 1u)
+      << "the final close must not tear the connection out from under a live wait";
+
+  // Still usable, which is the point: the wait would have issued its next slice here.
+  kfd_ioctl_get_version_args version{};
+  EXPECT_EQ(guest.ioctl(AMDKFD_IOC_GET_VERSION, &version), 0);
+
+  rocjitsu::GuestKfdTestAccess::release_wait_lease(guest);
+  EXPECT_EQ(execution_driver->local_open_ref_count(), 0u)
+      << "the draining lease must perform the close that close() handed off";
+
+  // The ioctl above republished readiness against the connection the lease was holding
+  // open, at zero open references. A drain that closed the descriptor but left that flag
+  // set would wedge the driver: ensure_ready() short-circuits on it, so nothing would
+  // ever reopen and every later call would find no host fd. This is what proves the
+  // drain runs the WHOLE close transition rather than only the descriptor close, and it
+  // has to hold for a hardware guest, which -- unlike the simulator backend -- has no
+  // second open() path that would repair the state by accident.
+  EXPECT_EQ(guest.fd(), -1) << "the drain must have retired the connection";
+  EXPECT_TRUE(guest.prepare_for_discovery());
+  EXPECT_GE(guest.fd(), 0)
+      << "the drain left stale readiness behind: discovery short-circuits on the flag, "
+         "so the connection is never reacquired and every later call fails ENODEV";
+}
+
+// The production path: a real guest.ioctl(WAIT_EVENTS) racing a real final close. The
+// tests above drive the lease directly, so they prove what the lease does but not that
+// dispatch actually takes one -- and the simulator backend used to reach the wait through
+// a route that took no lease at all, so a final close released the backend, marked its
+// event state closing, and the already-running wait came back EBADF.
+TEST_F(SimulatedKfdTest, DispatchedWaitSurvivesAConcurrentFinalClose) {
+  rj_vm_t *raw_vm = nullptr;
+  ASSERT_EQ(rj_vm_create(CONFIG_PATH.c_str(), RJ_VM_MODE_LOCAL, &raw_vm), ROCJITSU_STATUS_SUCCESS);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> vm(raw_vm, &rj_vm_destroy);
+  ASSERT_NE(vm->vm, nullptr);
+  auto *execution_driver = vm->vm->driver();
+  ASSERT_NE(execution_driver, nullptr);
+
+  rocjitsu::config::DbtGuestConfig config;
+  config.enabled = true;
+  config.guest_isa = "gfx950";
+  config.host.isa = "gfx950";
+  config.host.gpu_id = execution_driver->gpu_id();
+  config.host.backend = rocjitsu::config::DbtExecutionBackend::Simulator;
+  config.guest_device = vm->loaded.device;
+  config.guest_device.gpu_id += 1;
+  config.guest_device.drm_render_minor += 1;
+
+  rocjitsu::GuestKfd guest(std::move(config), execution_driver);
+  ASSERT_TRUE(guest.prepare_for_discovery());
+  const int app_fd = guest.open();
+  ASSERT_GE(app_fd, 0);
+
+  auto proc = execution_driver->find_process(execution_driver->local_process_id());
+  ASSERT_NE(proc, nullptr);
+  constexpr size_t kSlots = 64;
+  std::vector<uint64_t> page(kSlots, 0);
+  proc->event_state_.adopt_page(page.data(), page.size() * sizeof(uint64_t));
+
+  kfd_ioctl_create_event_args create{};
+  ASSERT_EQ(guest.ioctl(AMDKFD_IOC_CREATE_EVENT, &create), 0);
+
+  // INDEFINITE, so the waiter's registration cannot lapse under a descheduled test thread
+  // and the wait cannot quietly expire before the close -- either of which would let this
+  // pass without the deferral ever being exercised. It also sharpens the close assertion:
+  // a close that waited for this wait would never return at all.
+  kfd_event_data event{};
+  event.event_id = create.event_id;
+  kfd_ioctl_wait_events_args wait_args{};
+  wait_args.events_ptr = reinterpret_cast<uint64_t>(&event);
+  wait_args.num_events = 1;
+  wait_args.wait_for_all = 1;
+  wait_args.timeout = 0xFFFFFFFFu;
+
+  int wait_rc = 0;
+  std::thread waiter([&] { wait_rc = guest.ioctl(AMDKFD_IOC_WAIT_EVENTS, &wait_args); });
+
+  // Synchronize on the waiter being REGISTERED, not on a flag it sets before entering the
+  // ioctl: a descheduled waiter would let the close land first, the wait would then be
+  // correctly refused, and the race under test would never run.
+  bool registered = false;
+  const auto registered_by = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (std::chrono::steady_clock::now() < registered_by) {
+    if (proc->event_state_.waiter_count(create.event_id) != 0) {
+      registered = true;
+      break;
+    }
+    std::this_thread::yield();
+  }
+
+  // Close on its OWN thread, with a bounded wait for it to finish. The defect this test
+  // exists to catch is a close that waits for the lease instead of handing off, and the
+  // wait it would be waiting on is indefinite -- so doing the close inline would never
+  // reach the wake below and would hang the whole suite rather than fail one test. The
+  // controlling thread keeps an independent recovery wake in hand instead.
+  std::atomic<bool> close_done{false};
+  uint32_t refs_during_wait = 0;
+  int app_close_rc = -1;
+  int guest_close_rc = -1;
+  std::thread closer;
+  bool closed_before_wake = false;
+  if (registered) {
+    closer = std::thread([&] {
+      app_close_rc = ::close(app_fd);
+      guest_close_rc = guest.close();
+      refs_during_wait = execution_driver->local_open_ref_count();
+      close_done.store(true, std::memory_order_release);
+    });
+    const auto close_by = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!close_done.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < close_by)
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    closed_before_wake = close_done.load(std::memory_order_acquire);
+  }
+
+  // Wake and join BEFORE any fatal assertion: a joinable std::thread destroyed on the way
+  // out of a failing test terminates the binary, hiding the failure it should report.
+  // This is also the recovery wake that bounds a close which blocked -- but only one that
+  // blocked with the driver mutex RELEASED. A close that blocked while holding it stalls
+  // this wake too, and releasing the wait's lease needs that same mutex, so nothing
+  // in-process can recover. CMakeLists registers this test with its own CTest timeout for
+  // exactly that case.
+  guest.begin_local_shutdown();
+  if (closer.joinable())
+    closer.join();
+  waiter.join();
+
+  ASSERT_TRUE(registered) << "the waiter never registered";
+  EXPECT_TRUE(closed_before_wake)
+      << "close() blocked behind the running wait; it must hand its close off, not wait";
+  EXPECT_EQ(app_close_rc, 0);
+  EXPECT_EQ(guest_close_rc, 0);
+  EXPECT_EQ(refs_during_wait, 1u)
+      << "the final close must not release the backend under a running wait";
+  EXPECT_EQ(wait_rc, 0) << "the dispatched wait was revoked mid-flight: " << wait_rc;
+  EXPECT_EQ(wait_args.wait_result, static_cast<uint32_t>(KFD_IOC_WAIT_RESULT_TIMEOUT));
+  EXPECT_EQ(execution_driver->local_open_ref_count(), 0u)
+      << "the draining wait must perform the close that close() handed off";
+
+  // A Driver returns the KERNEL convention, -errno; the interposer performs the single
+  // conversion to libc's -1/errno. Returning a bare -1 from here would be read as -EPERM,
+  // which is how an interrupted hardware wait reached the runtime as EPERM and defeated
+  // its EINTR retry. Reached here with no reference left, which is the one wait failure
+  // that needs no device to provoke.
+  kfd_ioctl_wait_events_args orphaned = wait_args;
+  EXPECT_EQ(guest.ioctl(AMDKFD_IOC_WAIT_EVENTS, &orphaned), -ENODEV)
+      << "a failed wait must report -errno, not libc's -1";
+}
+
+// A reopen that lands while a deferred close is still pending ADOPTS the connection.
+// Without cancelling the deferral the draining wait would then close a connection the
+// new epoch had already started using -- the deferral turning into the very revocation
+// it exists to prevent.
+TEST_F(SimulatedKfdTest, ReopenDuringADeferredCloseCancelsTheDeferral) {
+  rj_vm_t *raw_vm = nullptr;
+  ASSERT_EQ(rj_vm_create(CONFIG_PATH.c_str(), RJ_VM_MODE_LOCAL, &raw_vm), ROCJITSU_STATUS_SUCCESS);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> vm(raw_vm, &rj_vm_destroy);
+  ASSERT_NE(vm->vm, nullptr);
+  auto *execution_driver = vm->vm->driver();
+  ASSERT_NE(execution_driver, nullptr);
+
+  rocjitsu::config::DbtGuestConfig config;
+  config.enabled = true;
+  config.guest_isa = "gfx950";
+  config.host.isa = "gfx950";
+  config.host.gpu_id = execution_driver->gpu_id();
+  config.host.backend = rocjitsu::config::DbtExecutionBackend::Simulator;
+  config.guest_device = vm->loaded.device;
+  config.guest_device.gpu_id += 1;
+  config.guest_device.drm_render_minor += 1;
+
+  rocjitsu::GuestKfd guest(std::move(config), execution_driver);
+  ASSERT_TRUE(guest.prepare_for_discovery());
+  const int app_fd = guest.open();
+  ASSERT_GE(app_fd, 0);
+
+  ASSERT_TRUE(rocjitsu::GuestKfdTestAccess::acquire_wait_lease(guest));
+  EXPECT_EQ(::close(app_fd), 0);
+  EXPECT_EQ(guest.close(), 0);
+
+  const int reopened_fd = guest.open();
+  ASSERT_GE(reopened_fd, 0);
+  EXPECT_EQ(execution_driver->local_open_ref_count(), 1u);
+
+  rocjitsu::GuestKfdTestAccess::release_wait_lease(guest);
+  EXPECT_EQ(execution_driver->local_open_ref_count(), 1u)
+      << "a drained lease must not close a connection the reopen adopted";
+
+  kfd_ioctl_get_version_args version{};
+  EXPECT_EQ(guest.ioctl(AMDKFD_IOC_GET_VERSION, &version), 0)
+      << "the adopted connection must still serve the new epoch";
+
+  EXPECT_EQ(::close(reopened_fd), 0);
+  EXPECT_EQ(guest.close(), 0);
+  EXPECT_EQ(execution_driver->local_open_ref_count(), 0u);
+}
+
 TEST_F(SimulatedKfdTest, TopologyDirectoryExists) {
   auto t = create_test_vm();
   ASSERT_NE(t.driver(), nullptr);
@@ -659,6 +899,182 @@ TEST_F(SimulatedKfdTest, TopologyDirectoryExists) {
   EXPECT_TRUE(std::filesystem::exists(path + "/generation_id"));
   EXPECT_TRUE(std::filesystem::exists(path + "/nodes/0/properties"));
   EXPECT_TRUE(std::filesystem::exists(path + "/nodes/1/properties"));
+}
+
+// begin_local_shutdown() releases parked waiters so their callers drop the driver
+// snapshot that keeps the object alive. It must do ONLY that: an earlier version
+// also marked the driver closing and poisoned every event-page slot with
+// KFD_SIGNAL_EVENT_LIMIT, which turned a live consumer's ioctls into -EBADF and
+// destroyed the ages it was polling. This asserts the wake disturbs neither the
+// page nor the closing flag, so a driver that survives it keeps serving.
+TEST_F(SimulatedKfdTest, BeginLocalShutdownLeavesSignaledEventPageIntact) {
+  auto t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  auto *drv = t.driver();
+
+  ASSERT_GE(drv->open(), 0);
+  auto proc = drv->find_process(drv->local_process_id());
+  ASSERT_NE(proc, nullptr);
+
+  // Provide a real event page and adopt it, mirroring the CREATE_EVENT mmap path.
+  constexpr size_t kSlots = 64;
+  std::vector<uint64_t> page(kSlots, 0);
+  proc->event_state_.adopt_page(page.data(), page.size() * sizeof(uint64_t));
+
+  // Create a signal event and signal it, so its page slot holds a real (non-zero,
+  // non-sentinel) age.
+  kfd_ioctl_create_event_args create{};
+  create.event_type = 0; // signal event
+  ASSERT_EQ(drv->ioctl(AMDKFD_IOC_CREATE_EVENT, &create), 0);
+
+  kfd_ioctl_set_event_args set{};
+  set.event_id = create.event_id;
+  ASSERT_EQ(drv->ioctl(AMDKFD_IOC_SET_EVENT, &set), 0);
+
+  const uint64_t signaled_age = page[create.event_id];
+  ASSERT_NE(signaled_age, 0u);
+  ASSERT_NE(signaled_age, static_cast<uint64_t>(KFD_SIGNAL_EVENT_LIMIT));
+
+  drv->begin_local_shutdown();
+  EXPECT_EQ(page[create.event_id], signaled_age)
+      << "begin_local_shutdown must not disturb the event page";
+  EXPECT_FALSE(proc->event_state_.is_closing())
+      << "begin_local_shutdown must not mark the driver closing: that turns a live "
+         "consumer's ioctls into -EBADF/-ESRCH and cannot be undone faithfully";
+
+  // A wait issued after the wake is released rather than failed: it reports a
+  // benign timeout (rc 0), never -EBADF. That distinction is why the wake must not
+  // set closing_ — an in-flight caller must be able to unwind normally while
+  // teardown drains, and -EBADF is not a legal answer from a still-published driver.
+  kfd_event_data ev{};
+  ev.event_id = create.event_id;
+  kfd_ioctl_wait_events_args wait{};
+  wait.events_ptr = reinterpret_cast<uint64_t>(&ev);
+  wait.num_events = 1;
+  wait.wait_for_all = 1;
+  wait.timeout = 0;
+  EXPECT_EQ(drv->ioctl(AMDKFD_IOC_WAIT_EVENTS, &wait), 0)
+      << "a wait after the wake must not fail the caller";
+
+  EXPECT_EQ(drv->close(), 0);
+}
+
+// An AUTO-RESET event that was signaled while a waiter was parked is the state the
+// old speculative-shutdown design lost: signaling advances and publishes the age but
+// deliberately leaves signaled == false, so a rollback that rebuilt the page from
+// `signaled` events alone replaced a real pending completion with the unsignaled
+// sentinel. The wake must therefore leave the page alone even in this state. There is
+// no rollback any more, but the property is what makes that safe, so pin it.
+TEST_F(SimulatedKfdTest, WakeDoesNotDisturbPendingAutoResetEventPage) {
+  auto t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  auto *drv = t.driver();
+  ASSERT_GE(drv->open(), 0);
+  auto proc = drv->find_process(drv->local_process_id());
+  ASSERT_NE(proc, nullptr);
+
+  constexpr size_t kSlots = 64;
+  std::vector<uint64_t> page(kSlots, 0);
+  proc->event_state_.adopt_page(page.data(), page.size() * sizeof(uint64_t));
+
+  kfd_ioctl_create_event_args create{};
+  create.event_type = 0;
+  create.auto_reset = 1;
+  ASSERT_EQ(drv->ioctl(AMDKFD_IOC_CREATE_EVENT, &create), 0);
+
+  // Register a waiter deterministically: poll the event's waiter count rather than
+  // sleeping, so the SET_EVENT below is guaranteed to take the "waiters present"
+  // auto-reset path (which advances and publishes the age while deliberately
+  // leaving signaled == false).
+  std::atomic<int> wait_rc{-1};
+  std::atomic<uint32_t> wait_result{0};
+  std::thread waiter([&] {
+    kfd_event_data ev{};
+    ev.event_id = create.event_id;
+    kfd_ioctl_wait_events_args wait{};
+    wait.events_ptr = reinterpret_cast<uint64_t>(&ev);
+    wait.num_events = 1;
+    wait.wait_for_all = 1;
+    wait.timeout = 0xFFFFFFFFu;
+    wait_rc.store(drv->ioctl(AMDKFD_IOC_WAIT_EVENTS, &wait), std::memory_order_release);
+    wait_result.store(wait.wait_result, std::memory_order_release);
+  });
+  while (proc->event_state_.waiter_count(create.event_id) == 0)
+    std::this_thread::yield();
+
+  kfd_ioctl_set_event_args set{};
+  set.event_id = create.event_id;
+  ASSERT_EQ(drv->ioctl(AMDKFD_IOC_SET_EVENT, &set), 0);
+  const uint64_t pending_age =
+      std::atomic_ref<uint64_t>(page[create.event_id]).load(std::memory_order_acquire);
+  ASSERT_NE(pending_age, 0u);
+  ASSERT_NE(pending_age, static_cast<uint64_t>(KFD_SIGNAL_EVENT_LIMIT));
+
+  drv->begin_local_shutdown();
+  waiter.join();
+
+  // The slot is written with atomic_ref by the driver, so read it the same way.
+  EXPECT_EQ(std::atomic_ref<uint64_t>(page[create.event_id]).load(std::memory_order_acquire),
+            pending_age)
+      << "the wake must not overwrite a pending auto-reset completion whose event is "
+         "not flagged signaled; that is the lost signal the old page rollback caused";
+  EXPECT_EQ(wait_rc.load(std::memory_order_acquire), 0)
+      << "the released waiter must not fail its caller";
+
+  EXPECT_EQ(drv->close(), 0);
+}
+
+// The wake exists to release an INDEFINITE WAIT_EVENTS so its caller drops the
+// driver snapshot that would otherwise keep the object alive forever. Assert that
+// directly: a thread parked with an infinite timeout must be released, and it must
+// come back as a benign timeout (rc 0) rather than -EBADF, which is not a legal
+// answer for a driver that is still serving.
+TEST_F(SimulatedKfdTest, BeginLocalShutdownReleasesIndefiniteWaitAsTimeout) {
+  auto t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  auto *drv = t.driver();
+
+  ASSERT_GE(drv->open(), 0);
+  auto proc = drv->find_process(drv->local_process_id());
+  ASSERT_NE(proc, nullptr);
+
+  constexpr size_t kSlots = 64;
+  std::vector<uint64_t> page(kSlots, 0);
+  proc->event_state_.adopt_page(page.data(), page.size() * sizeof(uint64_t));
+
+  kfd_ioctl_create_event_args create{};
+  create.event_type = 0;
+  ASSERT_EQ(drv->ioctl(AMDKFD_IOC_CREATE_EVENT, &create), 0);
+
+  std::atomic<bool> parked{false};
+  int wait_rc = -1;
+  uint32_t wait_result = 0;
+  std::thread waiter([&] {
+    kfd_event_data ev{};
+    ev.event_id = create.event_id;
+    kfd_ioctl_wait_events_args wait{};
+    wait.events_ptr = reinterpret_cast<uint64_t>(&ev);
+    wait.num_events = 1;
+    wait.wait_for_all = 1;
+    wait.timeout = 0xFFFFFFFFu; // indefinite
+    parked.store(true, std::memory_order_release);
+    wait_rc = drv->ioctl(AMDKFD_IOC_WAIT_EVENTS, &wait);
+    wait_result = wait.wait_result;
+  });
+
+  while (!parked.load(std::memory_order_acquire))
+    std::this_thread::yield();
+  // Give the waiter a moment to actually park inside the condition variable.
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  drv->begin_local_shutdown();
+  waiter.join();
+
+  EXPECT_EQ(wait_rc, 0) << "a cancelled wait must not fail the caller's ioctl";
+  EXPECT_EQ(wait_result, static_cast<uint32_t>(KFD_IOC_WAIT_RESULT_TIMEOUT))
+      << "a cancelled wait must report a benign timeout, not a completion";
+
+  EXPECT_EQ(drv->close(), 0);
 }
 
 // Regression test for the close()-vs-in-flight-ioctl teardown race. ioctl()
@@ -731,6 +1147,147 @@ TEST_F(SimulatedKfdTest, ConcurrentIoctlAndCloseIsRaceFree) {
       w.join();
     EXPECT_EQ(bad.load(), 0) << "round " << round << ": ioctl saw invalid state during close";
   }
+}
+
+// GuestKfd's hardware path cannot wake a blocking kernel WAIT_EVENTS, so it forwards
+// the wait as short, cancellable polls instead. That loop is the contract the
+// interposer's phase-2 teardown wake depends on for a hardware-backed guest, but
+// reaching it through GuestKfd::ioctl() needs a real /dev/kfd. These drive the
+// algorithm directly with an injected poll, covering all five of its outcomes.
+
+// A zero-timeout poll is already prompt, so it must be forwarded verbatim: exactly
+// one poll, with the caller's timeout untouched (no kPollMs slice substituted).
+TEST(GuestKfdWaitPollLoopTest, ZeroTimeoutForwardsUnchanged) {
+  std::atomic<bool> cancelled{false};
+  kfd_ioctl_wait_events_args args{};
+  args.timeout = 0;
+
+  int polls = 0;
+  uint32_t observed_timeout = 0xDEADBEEF;
+  int rc = rocjitsu::GuestKfdTestAccess::wait_events_poll_loop(args, cancelled, [&] {
+    ++polls;
+    observed_timeout = args.timeout;
+    args.wait_result = KFD_IOC_WAIT_RESULT_TIMEOUT;
+    return 0;
+  });
+
+  EXPECT_EQ(rc, 0);
+  EXPECT_EQ(polls, 1) << "a zero-timeout poll must not be split into slices";
+  EXPECT_EQ(observed_timeout, 0u) << "a zero-timeout poll must be forwarded verbatim";
+  EXPECT_EQ(args.timeout, 0u);
+}
+
+// Cancellation (begin_local_shutdown) must end the loop with a benign timeout and
+// leave the caller's timeout field as they passed it. The caller is unwinding
+// through the re-poll path it already has for a timeout -- teardown is committed by
+// the time this fires, so the re-poll finds the driver gone rather than resuming.
+TEST(GuestKfdWaitPollLoopTest, CancellationReportsTimeoutAndRestoresTheTimeout) {
+  std::atomic<bool> cancelled{false};
+  kfd_ioctl_wait_events_args args{};
+  args.timeout = 0xFFFFFFFFu; // indefinite
+  args.wait_result = KFD_IOC_WAIT_RESULT_COMPLETE;
+
+  int polls = 0;
+  int rc = rocjitsu::GuestKfdTestAccess::wait_events_poll_loop(args, cancelled, [&] {
+    ++polls;
+    EXPECT_NE(args.timeout, 0xFFFFFFFFu) << "each kernel poll must use the short slice";
+    cancelled.store(true, std::memory_order_release);
+    args.wait_result = KFD_IOC_WAIT_RESULT_TIMEOUT;
+    return 0;
+  });
+
+  EXPECT_EQ(rc, 0) << "cancellation must not fail the caller's ioctl";
+  EXPECT_EQ(args.wait_result, static_cast<uint32_t>(KFD_IOC_WAIT_RESULT_TIMEOUT));
+  EXPECT_EQ(args.timeout, 0xFFFFFFFFu) << "the caller's timeout must be restored";
+  EXPECT_EQ(polls, 1);
+}
+
+// An indefinite wait must keep polling across timeouts and return as soon as an
+// event completes, never expiring on its own.
+TEST(GuestKfdWaitPollLoopTest, IndefiniteWaitPollsUntilCompletion) {
+  std::atomic<bool> cancelled{false};
+  kfd_ioctl_wait_events_args args{};
+  args.timeout = 0xFFFFFFFFu;
+
+  int polls = 0;
+  int rc = rocjitsu::GuestKfdTestAccess::wait_events_poll_loop(args, cancelled, [&] {
+    ++polls;
+    args.wait_result = (polls < 4) ? KFD_IOC_WAIT_RESULT_TIMEOUT : KFD_IOC_WAIT_RESULT_COMPLETE;
+    return 0;
+  });
+
+  EXPECT_EQ(rc, 0);
+  EXPECT_EQ(polls, 4) << "an indefinite wait must re-poll until an event completes";
+  EXPECT_EQ(args.wait_result, static_cast<uint32_t>(KFD_IOC_WAIT_RESULT_COMPLETE));
+  EXPECT_EQ(args.timeout, 0xFFFFFFFFu);
+}
+
+// A finite wait whose events never fire must expire on its own deadline (not spin
+// forever), reporting the caller-visible timeout and restoring the timeout field.
+TEST(GuestKfdWaitPollLoopTest, FiniteDeadlineExpiresWithTimeout) {
+  std::atomic<bool> cancelled{false};
+  kfd_ioctl_wait_events_args args{};
+  args.timeout = 20; // ms
+
+  int polls = 0;
+  const auto started = std::chrono::steady_clock::now();
+  int rc = rocjitsu::GuestKfdTestAccess::wait_events_poll_loop(args, cancelled, [&] {
+    ++polls;
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    args.wait_result = KFD_IOC_WAIT_RESULT_TIMEOUT;
+    return 0;
+  });
+  const auto elapsed = std::chrono::steady_clock::now() - started;
+
+  EXPECT_EQ(rc, 0);
+  EXPECT_EQ(args.wait_result, static_cast<uint32_t>(KFD_IOC_WAIT_RESULT_TIMEOUT));
+  EXPECT_EQ(args.timeout, 20u) << "the caller's timeout must be restored";
+  EXPECT_GE(polls, 1);
+  EXPECT_GE(elapsed, std::chrono::milliseconds(20)) << "must not return before its deadline";
+}
+
+// A failing kernel poll must propagate immediately and must never leave the internal
+// slice value in the returned args. This covers the indefinite case, which reports the
+// caller's original timeout back; a finite wait instead reports what is LEFT of the
+// budget, so an EINTR retry continues it rather than restarting it.
+TEST(GuestKfdWaitPollLoopTest, PollFailurePropagatesWithTheTimeoutRestored) {
+  std::atomic<bool> cancelled{false};
+  kfd_ioctl_wait_events_args args{};
+  args.timeout = 0xFFFFFFFFu;
+
+  int polls = 0;
+  int rc = rocjitsu::GuestKfdTestAccess::wait_events_poll_loop(args, cancelled, [&] {
+    ++polls;
+    return -1;
+  });
+
+  EXPECT_EQ(rc, -1);
+  EXPECT_EQ(polls, 1);
+  EXPECT_EQ(args.timeout, 0xFFFFFFFFu);
+}
+
+// The restart convention for a FINITE wait: a failed poll reports what is left of the
+// caller's budget, never the original. Restoring the original would let a caller that
+// retries on EINTR restart the wait each time and never reach its deadline.
+TEST(GuestKfdWaitPollLoopTest, PollFailureOnAFiniteWaitReportsTheRemainingBudget) {
+  std::atomic<bool> cancelled{false};
+  constexpr uint32_t kBudgetMs = 500;
+  kfd_ioctl_wait_events_args args{};
+  args.timeout = kBudgetMs;
+
+  int polls = 0;
+  int rc = rocjitsu::GuestKfdTestAccess::wait_events_poll_loop(args, cancelled, [&] {
+    ++polls;
+    // Burn a little of the budget so the remainder is strictly smaller, without
+    // getting anywhere near the deadline.
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    return -1;
+  });
+
+  EXPECT_EQ(rc, -1);
+  EXPECT_EQ(polls, 1);
+  EXPECT_LT(args.timeout, kBudgetMs) << "a failed finite poll must not restart the budget";
+  EXPECT_GT(args.timeout, 0u) << "most of the budget was still left";
 }
 
 } // namespace


### PR DESCRIPTION
## Motivation

The interposer ran the local VM engine on a detached thread and published the KFD driver before component startup() finished, so a short-lived process could report success and enter C++ teardown while the simulator was still starting: engine threads outlived rocJITsu's finalizer and parallel short-process stress faulted in CommandProcessor::startup() after a passing result. Joining from the finalizer is not an option either, because an LD_PRELOAD library finalizes before HIP/ROCr, which
still hold KFD descriptors. The deeper defect was ownership: active_driver_ was a raw pointer to state owned by the VM or the guest driver, so every fast path (ioctl/mmap/munmap/mprotect/madvise/dup/close/sysfs) dereferenced an object a concurrent teardown could free underneath it.

## Technical details

active_driver_ is now a shared_ptr behind one leaf publication mutex, so a reader takes a lifetime-extending snapshot and the last release destroys. The simulator driver is published as an ALIASING shared_ptr on the VM, so it cannot outlive its owner while VirtualMachine keeps its unique_ptr; the guest driver's deleter captures the VM; and the VM's own deleter performs engine stop, join and destroy, so teardown cannot be misordered or skipped on an unwind path. Because the driver carries its own lifetime there is no lifetime lock, no pin discipline, no phased teardown and no rollback: retain, the app-visible open, and the idle decision all run under init_mutex_, so teardown either observes a racing reference or the racing caller finds no published driver and fails closed. Each synthetic DRM file holds an immutable local-or-remote backend lease that is both its operational reference and its routing authority, so metadata, mmap and GEM/VM work execute against the backend that owns the file rather than whichever is globally published. Local mode adopts the fork-then-exec contract every comparable in-process GPU runtime uses: a driver call holds private driver locks for its whole duration, sometimes across a blocking wait, so no atfork handler could drain them without risking hanging fork()
itself. An immutable owner PID is compared at the top of every interposed entry point and the DSO finalizer, before any inherited lock, container or pointer, which also required resolving the legacy stat aliases eagerly so no lazy-static guard can be inherited mid-initialization. A child's open of a GPU endpoint is refused by resolved device identity rather than pathname, and verified again on the descriptor actually obtained so a swapped symlink cannot slip past. Identity needs a node to stat, though, and a host with no GPU device files at all -- CI, and any pure-emulation deployment -- offers it
none, while the parent goes on serving those endpoints because it matches on spelling; the child therefore falls back to the same spellings the parent synthesizes, normalizing the path itself, so the contract does not quietly depend on the box having hardware. fopen and freopen keep libc's own mode parser and post-validate instead, with a refused freopen still closing the caller's stream as POSIX requires. Because fork copies the descriptor table, making app-facing descriptors synthetic is necessary but not sufficient: child ioctl, mmap/mmap64, dup, dup2, dup3 and the laundering fcntl commands
(F_DUPFD, F_DUPFD_CLOEXEC, and F_SETFD clearing FD_CLOEXEC) additionally refuse any descriptor whose identity is a real GPU device. That is a cooperative API contract, documented as such -- it stops hardware being inherited by accident and carried across exec, but interposition cannot defend against raw syscalls, for which hardware ownership must move out of process. SimulationEngine gains wait_until_started(), a startup failure that is terminal for the create() generation and published before a separately caught, non-throwing component unwind, and latch_startup_if_unlatched() so readiness is a property of the engine thread rather than of run() being reached.

## Issue Tracking

- Closes #8817.

## Test Plan

- Full rocjitsu unit suite in Release, serial.
- ThreadSanitizer build over the interposer/dup fd-reuse paths.
- #8817 reproducer + independent ELF-finalization auditor, plus concurrent
  short-process stress.

## Test Result

- Release suite: passes
- TSan: clean on interposer paths — no data race, no deadlock.
- Auditor: pre-fix FAILs with leftover engine threads (status=86); post-fix PASSes with only the application thread (status=0); concurrent short-process runs pass with no post-success crash.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
