### PR TITLE
fix(rocprofiler-sdk):  fix tracing-plus-counter-collection test failure on gfx1250

### DIFF
--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
@@ -7559,6 +7559,9 @@ rocprofiler-sdk:
             - gfx942
             - gfx950
           expression: reduce(TA_TA_BUSY,avr)
+        - architectures:
+            - gfx1250
+          expression: reduce(TX_VCA_VCA_BUSY,avr)
     - name: TA_BUSY_max
       description: TA block is busy. Max over TA instances.
       properties: []


### PR DESCRIPTION
## Motivation
On gfx1250, the tracing-plus-counter-collection pmc_3 test fails with FileNotFoundError because TA_BUSY_avr was not enabled.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Enabled TA_BUSY_avr for gfx1250 in config.yaml by adding a gfx1250-specific definition using the equivalent counter expression.
<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking
JIRA ID: AIPROFSDK-987
<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan
Run tracing-plus-counter-collection tests on gfx1250.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Test: tests.integration.execute.rocprofv3-test-tracing-plus-counter-collection -> Passed
Test: tests.integration.validate.rocprofv3-test-tracing-plus-counter-collection-pmc_3.test_validate_counter_collection_plus_tracing -> Passed
Test: tests.integration.validate.rocprofv3-test-tracing-plus-counter-collection-pmc_3.test_validate_counter_collection_plus_tracing_dispatch_data -> Passed
Test: tests.integration.validate.rocprofv3-test-tracing-plus-counter-collection-pmc_3.test_perfetto_data -> Passed

100% tests passed, 0 tests failed out of 4

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
