### PR TITLE
[rocjitsu] checked private-spill arithmetic and multi-producer db rewriting

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1359,11 +1359,21 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       scope.translation->virtual_lds_lowering.base_sgpr_spill_per_use =
           virtual_lds_base->spill_per_use;
       if (virtual_lds_base->spill_per_use) {
-        const uint32_t pointer_spill = kernel_context.reserve_persistent_semantic_spill_dwords(2);
+        const auto pointer_spill = kernel_context.reserve_persistent_semantic_spill_dwords(2);
+        if (!pointer_spill) {
+          auto failure = make_kernel_failure(
+              DiagnosticKind::ResourceLimit,
+              "virtual LDS backing-pointer spill offset overflows the 32-bit private segment",
+              layout.source_entry);
+          if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
+                                  text_relocations_begin, data_relocations_begin))
+            continue;
+          return leave_unchanged();
+        }
         kernel_context.virtual_lds_base_pointer_spilled = true;
-        kernel_context.virtual_lds_base_pointer_spill_offset = pointer_spill;
+        kernel_context.virtual_lds_base_pointer_spill_offset = *pointer_spill;
         scope.translation->virtual_lds_lowering.base_pointer_spilled = true;
-        scope.translation->virtual_lds_lowering.base_pointer_spill_offset = pointer_spill;
+        scope.translation->virtual_lds_lowering.base_pointer_spill_offset = *pointer_spill;
       }
       if (!append_virtual_lds_entry_prologue(*scope.translation, guest_arch_, host_arch_)) {
         auto failure = make_kernel_failure(

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
@@ -832,10 +832,20 @@ translate_one_descriptor(rj_code_arch_t guest_arch, rj_code_arch_t host_arch,
   // descriptor advertises zero fixed LDS so the launch can fit on gfx942; all
   // LDS accesses in the kernel body must then be lowered to a backing buffer
   // supplied by the dispatch path.
-  result.target_private_size =
-      src.private_segment_fixed_size + options.private_segment_fixed_size_addend;
-  const uint32_t requested_lds_size =
-      src.group_segment_fixed_size + options.group_segment_fixed_size_addend;
+  // The source private/group sizes come from the guest descriptor and can be
+  // near UINT32_MAX; adding a lowering addend in 32 bits could wrap to a tiny
+  // size and silently under-allocate. Use checked addition and fail the
+  // descriptor translation on overflow.
+  const auto target_private_size =
+      util::checked_add(src.private_segment_fixed_size, options.private_segment_fixed_size_addend);
+  if (!target_private_size)
+    append_descriptor_error(result, "private segment size plus lowering addend overflows 32 bits");
+  result.target_private_size = target_private_size.value_or(0);
+  const auto requested_lds_size_checked =
+      util::checked_add(src.group_segment_fixed_size, options.group_segment_fixed_size_addend);
+  if (!requested_lds_size_checked)
+    append_descriptor_error(result, "group segment size plus lowering addend overflows 32 bits");
+  const uint32_t requested_lds_size = requested_lds_size_checked.value_or(0);
   if (options.virtualize_lds) {
     result.target_lds_size = 0;
     result.lds_overflow_size = requested_lds_size;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_cdna3_virtual_lds.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_cdna3_virtual_lds.cpp
@@ -233,9 +233,14 @@ choose_virtual_lds_temp_range(TranslationContext &context,
 /// @details Returns the first byte after the assigned temp slots so callers can
 /// reserve adjacent extra words for non-temp state, such as saved SGPR-pair
 /// values or a saved high address VGPR.
-uint32_t assign_virtual_lds_spill_offsets(TranslationContext &context,
-                                          const std::vector<VirtualLdsAddressTemp *> &temps,
-                                          uint32_t extra_dwords = 0) {
+///
+/// @returns The first byte past the assigned slots, or std::nullopt if the spill
+/// reservation overflows the 32-bit private segment (the caller must fail the
+/// lowering rather than emit save/restore at a wrapped offset).
+std::optional<uint32_t>
+assign_virtual_lds_spill_offsets(TranslationContext &context,
+                                 const std::vector<VirtualLdsAddressTemp *> &temps,
+                                 uint32_t extra_dwords = 0) {
   uint32_t spilled_count = 0;
   for (const VirtualLdsAddressTemp *temp : temps) {
     if (temp != nullptr && temp->spilled)
@@ -243,17 +248,19 @@ uint32_t assign_virtual_lds_spill_offsets(TranslationContext &context,
   }
   const uint32_t total_dwords = spilled_count + extra_dwords;
   if (total_dwords == 0)
-    return 0;
+    return 0u;
 
-  const uint32_t base_offset = context.reserve_semantic_spill_dwords(total_dwords);
+  const auto base_offset = context.reserve_semantic_spill_dwords(total_dwords);
+  if (!base_offset)
+    return std::nullopt;
   uint32_t index = 0;
   for (VirtualLdsAddressTemp *temp : temps) {
     if (temp == nullptr || !temp->spilled)
       continue;
-    temp->spill_offset = base_offset + index * sizeof(uint32_t);
+    temp->spill_offset = *base_offset + index * sizeof(uint32_t);
     ++index;
   }
-  return base_offset + spilled_count * sizeof(uint32_t);
+  return *base_offset + spilled_count * sizeof(uint32_t);
 }
 
 /// @brief Emit a CDNA3 flat-scratch store used to preserve a borrowed VGPR temp.
@@ -1202,8 +1209,13 @@ lower_cdna4_to_cdna3_virtual_lds_ds_instruction(const Instruction &inst,
       spill_temps.push_back(&(*base_spill_temps)[0]);
       spill_temps.push_back(&(*base_spill_temps)[1]);
     }
-    const uint32_t extra_spill_base_offset =
+    const auto extra_spill_base_offset_opt =
         assign_virtual_lds_spill_offsets(context, spill_temps, extra_spill_dwords);
+    if (!extra_spill_base_offset_opt)
+      return ExpandResult::failed(
+          std::string(inst.mnemonic()) +
+          ": virtual-LDS spill offset overflows the 32-bit private segment");
+    const uint32_t extra_spill_base_offset = *extra_spill_base_offset_opt;
     const uint32_t base_sgpr_save_offset = extra_spill_base_offset;
     uint32_t addr_high_spill_offset = 0;
     if (restore_addr_high) {
@@ -1431,8 +1443,13 @@ lower_cdna4_to_cdna3_virtual_lds_ds_instruction(const Instruction &inst,
       spill_temps.push_back(&(*base_spill_temps)[0]);
       spill_temps.push_back(&(*base_spill_temps)[1]);
     }
-    const uint32_t extra_spill_base_offset =
+    const auto extra_spill_base_offset_opt =
         assign_virtual_lds_spill_offsets(context, spill_temps, base_sgpr_spill_dwords + 1u);
+    if (!extra_spill_base_offset_opt)
+      return ExpandResult::failed(
+          std::string(inst.mnemonic()) +
+          ": virtual-LDS spill offset overflows the 32-bit private segment");
+    const uint32_t extra_spill_base_offset = *extra_spill_base_offset_opt;
     const uint32_t base_sgpr_save_offset = extra_spill_base_offset;
     const uint32_t addr_high_spill_offset =
         extra_spill_base_offset + base_sgpr_spill_dwords * sizeof(uint32_t);
@@ -1672,8 +1689,12 @@ lower_cdna4_to_cdna3_virtual_lds_ds_instruction(const Instruction &inst,
     spill_temps.push_back(&(*base_spill_temps)[0]);
     spill_temps.push_back(&(*base_spill_temps)[1]);
   }
-  const uint32_t extra_spill_base_offset =
+  const auto extra_spill_base_offset_opt =
       assign_virtual_lds_spill_offsets(context, spill_temps, extra_spill_dwords);
+  if (!extra_spill_base_offset_opt)
+    return ExpandResult::failed(std::string(inst.mnemonic()) +
+                                ": virtual-LDS spill offset overflows the 32-bit private segment");
+  const uint32_t extra_spill_base_offset = *extra_spill_base_offset_opt;
   const uint32_t base_sgpr_save_offset = extra_spill_base_offset;
   // Save the source high half before any spill-per-use SGPR setup can borrow it
   // as a temporary. It is restored only after the borrowed SGPR pair is restored.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_rule.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_rule.h
@@ -22,8 +22,12 @@
 
 #pragma once
 
+#include "util/bit.h"
+
 #include <compare>
 #include <cstdint>
+#include <limits>
+#include <optional>
 #include <span>
 #include <string>
 #include <utility>
@@ -150,14 +154,20 @@ struct KernelResourceRequirements {
   /// @details Persistent semantic spill slots hold values across multiple
   /// replacement sequences. They are allocated before the reusable temp window
   /// so later per-instruction spills cannot overwrite them.
-  [[nodiscard]] uint32_t reserve_persistent_semantic_spill_dwords(uint32_t dwords) {
-    constexpr uint32_t kSpillAlignment = 16;
-    const uint32_t base =
-        (semantic_spill_persistent_end + kSpillAlignment - 1u) & ~(kSpillAlignment - 1u);
-    const uint32_t required = base + dwords * 4u;
-    semantic_spill_persistent_end = required;
-    require_private_segment_bytes(required);
-    return base;
+  ///
+  /// @returns The per-lane byte offset of the reserved slots, or std::nullopt if
+  /// aligning/extending the private segment would exceed the 32-bit private-size
+  /// field. The private segment is initialized from the guest descriptor's
+  /// private size, which can be near UINT32_MAX, so unchecked 32-bit arithmetic
+  /// here could wrap to a low offset and corrupt guest scratch. Callers must
+  /// treat nullopt as a kernel translation failure.
+  [[nodiscard]] std::optional<uint32_t> reserve_persistent_semantic_spill_dwords(uint32_t dwords) {
+    const auto reservation = semantic_spill_reservation(dwords);
+    if (!reservation)
+      return std::nullopt;
+    semantic_spill_persistent_end = reservation->second;
+    require_private_segment_bytes(reservation->second);
+    return reservation->first;
   }
 
   /// @brief Reserve @p dwords reusable 32-bit per-lane spill slots.
@@ -169,12 +179,33 @@ struct KernelResourceRequirements {
   /// persistent virtual registers, so every lowering site in the kernel can
   /// reuse the same slot range. Descriptor recomputation later raises
   /// private_segment_fixed_size to cover the largest reservation.
-  [[nodiscard]] uint32_t reserve_semantic_spill_dwords(uint32_t dwords) {
-    constexpr uint32_t kSpillAlignment = 16;
-    const uint32_t base =
-        (semantic_spill_persistent_end + kSpillAlignment - 1u) & ~(kSpillAlignment - 1u);
-    require_private_segment_bytes(base + dwords * 4u);
-    return base;
+  ///
+  /// @returns The per-lane byte offset of the reserved slots, or std::nullopt on
+  /// 32-bit overflow (see reserve_persistent_semantic_spill_dwords). Unlike the
+  /// persistent variant this does not advance semantic_spill_persistent_end.
+  [[nodiscard]] std::optional<uint32_t> reserve_semantic_spill_dwords(uint32_t dwords) {
+    const auto reservation = semantic_spill_reservation(dwords);
+    if (!reservation)
+      return std::nullopt;
+    require_private_segment_bytes(reservation->second);
+    return reservation->first;
+  }
+
+private:
+  /// @brief Compute the aligned base and one-past-end for a spill reservation.
+  ///
+  /// @returns {base_byte_offset, end_byte_offset} using checked 64-bit math, or
+  /// std::nullopt if either would exceed the 32-bit private-size field.
+  [[nodiscard]] std::optional<std::pair<uint32_t, uint32_t>>
+  semantic_spill_reservation(uint32_t dwords) const {
+    constexpr uint64_t kSpillAlignment = 16;
+    constexpr uint64_t kMax = std::numeric_limits<uint32_t>::max();
+    const uint64_t base =
+        util::align_up(static_cast<uint64_t>(semantic_spill_persistent_end), kSpillAlignment);
+    const uint64_t end = base + static_cast<uint64_t>(dwords) * 4u;
+    if (base > kMax || end > kMax)
+      return std::nullopt;
+    return std::pair<uint32_t, uint32_t>{static_cast<uint32_t>(base), static_cast<uint32_t>(end)};
   }
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
@@ -53,6 +53,7 @@
 #include <mutex>
 #include <new>
 #include <optional>
+#include <set>
 #include <shared_mutex>
 #include <signal.h>
 #include <span>
@@ -2308,17 +2309,36 @@ public:
       return;
 
     const uint64_t packet_id = static_cast<uint64_t>(value);
-    if (state.queue->type == HSA_QUEUE_TYPE_SINGLE && packet_id >= state.next_packet_id &&
-        packet_id - state.next_packet_id < state.queue->size) {
+    // A producer (single- OR multi-producer) can reserve and publish several
+    // consecutive packets and then ring once with the final packet ID. Rewriting
+    // only the doorbell-named packet would let an earlier still-unrewritten
+    // predecessor (e.g. a virtual-LDS dispatch at next_packet_id) reach the CP
+    // unrevised, and advancing next_packet_id past it would make the scanner skip
+    // it too. So rewrite the whole newly-published range [next_packet_id,
+    // packet_id]. note_packet_ready advances the contiguous frontier and remembers
+    // ready-but-non-contiguous successors, so an out-of-order producer that leaves
+    // an unready hole does not advance the cursor past it -- but once the hole
+    // closes the cursor catches up across every already-ready successor instead of
+    // stranding below the ready suffix. The range must fit the ring to bound the
+    // scan.
+    if (packet_id >= state.next_packet_id && packet_id - state.next_packet_id < state.queue->size) {
       rewrite_packet_range(state, state.next_packet_id, packet_id + 1, true);
       return;
     }
 
-    // Multi queues may ring arbitrary packet IDs. Also handle unusual single
-    // queue jumps by at least rewriting the packet named by the doorbell value.
+    // Doorbell ID below the frontier (a lagging out-of-order ring) or a jump
+    // larger than the ring: rewrite at least the named packet. The background
+    // scanner covers any packets between the frontier and this one.
     const bool ready = rewrite_packet(state, packet_id);
-    if (ready && packet_id >= state.next_packet_id)
+    if (ready && packet_id >= state.next_packet_id) {
+      // A jump larger than the ring means the intervening packets have wrapped
+      // (their slots reused), so step the cursor past this packet directly and
+      // discard any now-stale ready_ahead entries below the new frontier rather
+      // than trying to make the cursor contiguous across the wrapped gap.
       state.next_packet_id = packet_id + 1;
+      state.ready_ahead.erase(state.ready_ahead.begin(),
+                              state.ready_ahead.lower_bound(state.next_packet_id));
+    }
   }
 
   /// @brief Release all tracked queues during HSA tool unload.
@@ -2422,6 +2442,13 @@ private:
     hsa_agent_t host_agent{};
     uint64_t doorbell_signal = 0;
     uint64_t next_packet_id = 0;
+    // Packet IDs observed ready at or beyond next_packet_id but not yet contiguous
+    // with the cursor (an out-of-order producer rang a later packet while an
+    // earlier hole was still INVALID). When the hole closes, note_packet_ready
+    // drains the contiguous run from here so the cursor catches up across every
+    // already-ready successor instead of stranding below the ready suffix. Bounded
+    // by the ring size: an id leaves the set as soon as the cursor passes it.
+    std::set<uint64_t> ready_ahead;
     uint32_t host_lds_bytes = 0;
     bool uses_packet_interceptor = false;
     // True only for the queue running guest work on the guest's execution host
@@ -2563,8 +2590,29 @@ private:
   }
 
   static void note_packet_ready(QueueState &state, uint64_t packet_id, bool ready) {
-    if (ready && packet_id == state.next_packet_id)
+    // Only packets at or beyond the contiguous cursor can advance it; a ready
+    // packet below it was already accounted for.
+    if (!ready || packet_id < state.next_packet_id)
+      return;
+
+    // Remember this packet as ready even if it is not the one the cursor is
+    // waiting for. An out-of-order producer can ring a later packet while an
+    // earlier hole is still INVALID, so the cursor must be able to catch up across
+    // this successor once the hole closes -- otherwise it strands below the
+    // already-ready suffix and a later doorbell range can skip a packet.
+    if (packet_id != state.next_packet_id) {
+      state.ready_ahead.insert(packet_id);
+      return;
+    }
+
+    // The cursor's packet is ready: advance across it and every contiguous
+    // successor already observed ready in a prior doorbell.
+    ++state.next_packet_id;
+    auto it = state.ready_ahead.begin();
+    while (it != state.ready_ahead.end() && *it == state.next_packet_id) {
       ++state.next_packet_id;
+      it = state.ready_ahead.erase(it);
+    }
   }
 
   [[nodiscard]] static VirtualLdsDispatchState
@@ -3854,7 +3902,7 @@ hsa_status_t HSA_API rj_executable_load_agent_code_object(
         original_load(executable, load_agent, code_object_reader, options, loaded_code_object);
     log_message(kLogVerbose, "load_agent_code_object already-target status=%d",
                 static_cast<int>(status));
-    if (status == HSA_STATUS_SUCCESS && guest_load)
+    if (status == HSA_STATUS_SUCCESS)
       ExecutableAgentRegistry::instance().record(executable, agent, load_agent);
     if (status == HSA_STATUS_SUCCESS) {
       const hsa_loaded_code_object_t loaded =
@@ -3949,7 +3997,7 @@ hsa_status_t HSA_API rj_executable_load_agent_code_object(
   if (status != HSA_STATUS_SUCCESS) {
     std::fprintf(stderr, "[rocjitsu-hooks] translated code-object load failed: %d\n",
                  static_cast<int>(status));
-  } else if (guest_load) {
+  } else {
     ExecutableAgentRegistry::instance().record(executable, agent, load_agent);
   }
   if (status == HSA_STATUS_SUCCESS) {

--- a/emulation/rocjitsu/tests/dbt/hsa_hooks_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hooks_unit_test.cpp
@@ -1725,6 +1725,167 @@ TEST(HsaHooksUnitTest, QueueDoorbellRaisesPacketPrivateSizeFromDescriptor) {
   EXPECT_EQ(api.core.hsa_queue_destroy_fn(queue), HSA_STATUS_SUCCESS);
 }
 
+TEST(HsaHooksUnitTest, MultiProducerDoorbellRewritesEarlierPublishedPacket) {
+  using rocr::llvm::amdhsa::kernel_descriptor_t;
+
+  // Fallback (non-intercept) multi-producer path: a producer publishes two ready
+  // packets and rings once with the FINAL packet id. Packet 0 needs virtual-LDS
+  // rewriting, packet 1 does not. The doorbell must rewrite the whole published
+  // range [next_packet_id, id], not just the named packet -- otherwise packet 0
+  // reaches the command processor as an oversized (host-faulting) launch and the
+  // frontier advances past it so the scanner skips it too.
+  reset_pool_blocker(false);
+  reset_queue_fakes();
+  FakeApiTable api;
+  InstalledHook hook(api);
+  ASSERT_TRUE(hook.installed());
+
+  hsa_queue_t *queue = nullptr;
+  ASSERT_EQ(api.core.hsa_queue_create_fn(kGuestAgent, 4, HSA_QUEUE_TYPE_MULTI, nullptr, nullptr, 0,
+                                         0, &queue),
+            HSA_STATUS_SUCCESS);
+  ASSERT_NE(queue, nullptr);
+
+  kernel_descriptor_t normal_descriptor{};
+  kernel_descriptor_t virtual_descriptor{};
+  normal_descriptor.group_segment_fixed_size = 70000; // exceeds host LDS -> sidecar
+  virtual_descriptor.private_segment_fixed_size = 96;
+  auto registration = register_virtual_lds_kernel_for_test(
+      api, normal_descriptor, virtual_descriptor, normal_descriptor.group_segment_fixed_size);
+  (void)registration;
+
+  // Packet 0: the oversized virtual-LDS dispatch that must be rewritten.
+  auto &oversized = g_fake_queue_packets[0];
+  oversized.header = HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE;
+  oversized.kernel_object = reinterpret_cast<uintptr_t>(&normal_descriptor);
+  oversized.group_segment_size = normal_descriptor.group_segment_fixed_size;
+  oversized.workgroup_size_x = 64;
+  oversized.workgroup_size_y = 1;
+  oversized.workgroup_size_z = 1;
+  oversized.grid_size_x = 64;
+  oversized.grid_size_y = 1;
+  oversized.grid_size_z = 1;
+
+  // Packet 1: an ordinary below-threshold dispatch (no rewrite needed).
+  auto &ordinary = g_fake_queue_packets[1];
+  ordinary.header = HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE;
+  ordinary.kernel_object = 0; // no registered virtual-LDS metadata
+  ordinary.group_segment_size = 0;
+  ordinary.workgroup_size_x = 64;
+  ordinary.grid_size_x = 64;
+
+  // Ring once with the FINAL packet id (1).
+  api.core.hsa_signal_store_relaxed_fn(queue->doorbell_signal, 1);
+
+  // Packet 0 was rewritten to the virtual descriptor (range covered), not left
+  // on its oversized normal descriptor.
+  EXPECT_EQ(oversized.kernel_object, reinterpret_cast<uintptr_t>(&virtual_descriptor));
+  EXPECT_EQ(oversized.group_segment_size, 0u);
+  EXPECT_FALSE(g_fake_allocation_sizes.empty());
+
+  EXPECT_EQ(api.core.hsa_queue_destroy_fn(queue), HSA_STATUS_SUCCESS);
+}
+
+TEST(HsaHooksUnitTest, MultiProducerHoleCloseAdvancesFrontierAcrossReadySuffix) {
+  using rocr::llvm::amdhsa::kernel_descriptor_t;
+
+  // Regression for the stranded-frontier bug: on a size-4 multi-producer queue an
+  // out-of-order ring publishes a ready suffix ABOVE an unready hole, the hole
+  // later closes, and a subsequent batch must not skip a packet.
+  //
+  //   1. next_packet_id = 0. Slot 0 (packet 0) is INVALID (hole); packets 1..3 are
+  //      ready. A producer rings with id 3. The range [0,4) rewrites 1..3, but the
+  //      cursor cannot pass the hole at 0 -- it must REMEMBER 1..3 as ready.
+  //   2. Packet 0 closes (becomes ready) and rings with id 0. The cursor must now
+  //      catch up across the remembered 1..3 -> next_packet_id = 4, NOT 1.
+  //   3. Packets 4 and 5 are published and a producer rings once with id 5. Only
+  //      when the cursor is at 4 does 5 - 4 = 1 < size take the range path and
+  //      rewrite packet 4. If the cursor were stranded at 1, 5 - 1 = 4 == size
+  //      would fall to the single-packet path and packet 4 (needing a virtual-LDS
+  //      rewrite) would reach the command processor as an oversized launch.
+  reset_pool_blocker(false);
+  reset_queue_fakes();
+  FakeApiTable api;
+  InstalledHook hook(api);
+  ASSERT_TRUE(hook.installed());
+
+  hsa_queue_t *queue = nullptr;
+  ASSERT_EQ(api.core.hsa_queue_create_fn(kGuestAgent, 4, HSA_QUEUE_TYPE_MULTI, nullptr, nullptr, 0,
+                                         0, &queue),
+            HSA_STATUS_SUCCESS);
+  ASSERT_NE(queue, nullptr);
+
+  kernel_descriptor_t normal_descriptor{};
+  kernel_descriptor_t virtual_descriptor{};
+  normal_descriptor.group_segment_fixed_size = 70000; // exceeds host LDS -> sidecar
+  virtual_descriptor.private_segment_fixed_size = 96;
+  auto registration = register_virtual_lds_kernel_for_test(
+      api, normal_descriptor, virtual_descriptor, normal_descriptor.group_segment_fixed_size);
+  (void)registration;
+
+  const auto make_oversized = [&](uint32_t slot) {
+    auto &packet = g_fake_queue_packets[slot];
+    packet = {};
+    packet.header = HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE;
+    packet.kernel_object = reinterpret_cast<uintptr_t>(&normal_descriptor);
+    packet.group_segment_size = normal_descriptor.group_segment_fixed_size;
+    packet.workgroup_size_x = 64;
+    packet.workgroup_size_y = 1;
+    packet.workgroup_size_z = 1;
+    packet.grid_size_x = 64;
+    packet.grid_size_y = 1;
+    packet.grid_size_z = 1;
+  };
+  const auto make_ordinary = [&](uint32_t slot) {
+    auto &packet = g_fake_queue_packets[slot];
+    packet = {};
+    packet.header = HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE;
+    packet.kernel_object = 0; // no registered virtual-LDS metadata
+    packet.workgroup_size_x = 64;
+    packet.workgroup_size_y = 1;
+    packet.workgroup_size_z = 1;
+    packet.grid_size_x = 64;
+    packet.grid_size_y = 1;
+    packet.grid_size_z = 1;
+  };
+  const auto make_invalid = [&](uint32_t slot) {
+    auto &packet = g_fake_queue_packets[slot];
+    packet = {};
+    packet.header = HSA_PACKET_TYPE_INVALID << HSA_PACKET_HEADER_TYPE;
+  };
+
+  // Phase 1: slot 0 (packet 0) is an unready hole; packets 1..3 are ready ordinary
+  // dispatches. Ring with the final published id (3).
+  make_invalid(0);
+  make_ordinary(1);
+  make_ordinary(2);
+  make_ordinary(3);
+  api.core.hsa_signal_store_relaxed_fn(queue->doorbell_signal, 3);
+  // The hole blocks the cursor, so no virtual-LDS rewrite happened yet.
+  EXPECT_TRUE(g_fake_allocation_sizes.empty());
+
+  // Phase 2: the hole closes (packet 0 becomes a ready ordinary dispatch) and its
+  // producer rings with id 0. The cursor must catch up across the remembered ready
+  // suffix 1..3 and land at 4.
+  make_ordinary(0);
+  api.core.hsa_signal_store_relaxed_fn(queue->doorbell_signal, 0);
+  EXPECT_TRUE(g_fake_allocation_sizes.empty());
+
+  // Phase 3: packets 4 (slot 0) and 5 (slot 1) are published; packet 4 is the
+  // oversized virtual-LDS dispatch. Ring once with the final id (5).
+  make_oversized(0); // packet 4 -> slot 4 % 4 == 0
+  make_ordinary(1);  // packet 5 -> slot 5 % 4 == 1
+  api.core.hsa_signal_store_relaxed_fn(queue->doorbell_signal, 5);
+
+  // Packet 4 was rewritten to the virtual descriptor -- it was NOT skipped.
+  EXPECT_EQ(g_fake_queue_packets[0].kernel_object,
+            reinterpret_cast<uintptr_t>(&virtual_descriptor));
+  EXPECT_EQ(g_fake_queue_packets[0].group_segment_size, 0u);
+  EXPECT_FALSE(g_fake_allocation_sizes.empty());
+
+  EXPECT_EQ(api.core.hsa_queue_destroy_fn(queue), HSA_STATUS_SUCCESS);
+}
+
 TEST(HsaHooksUnitTest, VirtualLdsRewriteWorksWithoutLoadedCodeObjectOutput) {
   using rocr::llvm::amdhsa::kernel_descriptor_t;
 

--- a/emulation/rocjitsu/tests/dbt/semantic_scratch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/semantic_scratch_test.cpp
@@ -20,8 +20,9 @@ namespace {
 TEST(SemanticSpillFrame, SeparatesPersistentAndTransientRanges) {
   TranslationContext context(/*vgprs=*/8, /*agprs=*/0, /*accum_base=*/0,
                              /*sgprs=*/8, /*private_bytes=*/20);
-  const uint32_t persistent = context.reserve_persistent_semantic_spill_dwords(2);
-  ASSERT_EQ(persistent, 32u);
+  const auto persistent = context.reserve_persistent_semantic_spill_dwords(2);
+  ASSERT_TRUE(persistent);
+  ASSERT_EQ(*persistent, 32u);
 
   SemanticSpillFrame frame(context);
   const auto first = frame.allocate_dwords(3, /*byte_alignment=*/4);
@@ -34,6 +35,23 @@ TEST(SemanticSpillFrame, SeparatesPersistentAndTransientRanges) {
   EXPECT_EQ(first->byte_offset, 48u);
   EXPECT_EQ(second->byte_offset, 64u);
   EXPECT_EQ(context.required_private_segment_fixed_size, 72u);
+}
+
+TEST(SemanticSpillFrame, PersistentReservationRejects32BitOverflow) {
+  // A guest kernel can advertise a private size near UINT32_MAX. Aligning that up
+  // and extending it for a spill must fail closed rather than wrap to a low
+  // offset that would corrupt guest scratch.
+  TranslationContext context(/*vgprs=*/8, /*agprs=*/0, /*accum_base=*/0,
+                             /*sgprs=*/8, /*private_bytes=*/0xfffffff8u);
+  const auto persistent = context.reserve_persistent_semantic_spill_dwords(2);
+  EXPECT_FALSE(persistent);
+}
+
+TEST(SemanticSpillFrame, TransientReservationRejects32BitOverflow) {
+  TranslationContext context(/*vgprs=*/8, /*agprs=*/0, /*accum_base=*/0,
+                             /*sgprs=*/8, /*private_bytes=*/0xfffffff8u);
+  const auto transient = context.reserve_semantic_spill_dwords(2);
+  EXPECT_FALSE(transient);
 }
 
 TEST(SemanticSpillFrame, NewInstructionsReuseTransientFrameBase) {


### PR DESCRIPTION
## Motivation

Two fail-open correctness bugs surfaced in re-review of the DBT/virtual-LDS path.

First, the per-lane private segment is initialized from the guest descriptor's private size, which can be near UINT32_MAX. The semantic spill reservations and the descriptor private/group addends extended it with unchecked uint32_t math, so a kernel with private_segment_fixed_size = 0xfffffff8 aligned up to 16 wraps to 0. The virtual-LDS backing-pointer spill then lands at offset 0 and the generated save/restore instructions overwrite the guest's low private-memory region while translation still reports success -- silent scratch corruption.

Second, the non-intercept doorbell fallback rewrote the full published packet range only for HSA_QUEUE_TYPE_SINGLE. A multi-producer queue can reserve and publish several consecutive packets and ring once with the final packet id. If an earlier packet needs virtual-LDS rewriting and the doorbell names a later one, only the named packet was rewritten and next_packet_id was advanced past the earlier one -- so the oversized packet reached the command processor unrevised and the background scanner (clamped to next_packet_id) skipped it too. This path is used whenever intercept queue creation/registration is unavailable.

## Technical Details

Private-spill / descriptor-addend overflow (translation_rule.h, kernel_descriptor_translator.cpp, cdna4_to_cdna3_virtual_lds.cpp, binary_translator.cpp):

- reserve_persistent_semantic_spill_dwords / reserve_semantic_spill_dwords now return std::optional<uint32_t>, computing the aligned base and one-past-end with checked 64-bit math via a shared semantic_spill_reservation() helper; anything exceeding the 32-bit private-size field yields nullopt.
- The failure propagates: assign_virtual_lds_spill_offsets returns optional and its three lowering call sites return ExpandResult::failed; the persistent-spill site in binary_translator.cpp raises a ResourceLimit kernel failure (skip or leave-unchanged). The descriptor private/group addends use util::checked_add and append_descriptor_error on overflow.

Multi-producer doorbell rewriting (rj_hsa_dbt_hooks.cpp):

- Rewrite the whole newly-published range [next_packet_id, doorbell_id] for every queue type when the span fits the ring, instead of only for single-producer queues. note_packet_ready advances the contiguous frontier only across in-order ready packets, so an out-of-order producer's unready hole is never skipped; a doorbell jump larger than the ring still falls back to rewriting the named packet and lets the scanner cover the gap.

## Issue Tracking

#8939

## Test Plan

Run CI tests.
Boundary-overflow unit tests for the spill reservations. Multi-producer fallback doorbell unit test (verified to fail pre-fix).

## Test Result

- Semantic-scratch overflow tests (persistent + transient reservations at 0xfffffff8 fail closed) and descriptor/DBT suites: 112/112.
- HSA hook suite, including the new HSA_QUEUE_TYPE_MULTI two-packet doorbell test (packet 0 rewritten to the virtual descriptor): 46/46.
- Full suite: 1804/1804.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
