### PR TITLE
fix(rocjitsu): Fix local memory fallback for VMID misses

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.cpp
@@ -49,13 +49,25 @@ void EventState::adopt_page(void *ptr, size_t size) {
   }
 }
 
-bool EventState::release_page(void *ptr) {
+EventState::PageReleaseResult EventState::release_page(void *ptr, size_t size) {
   std::lock_guard<std::mutex> lock(mutex_);
-  if (page != ptr)
-    return false;
+  if (!page)
+    return PageReleaseResult::kNotMapped;
+
+  const uintptr_t request_begin = reinterpret_cast<uintptr_t>(ptr);
+  const uintptr_t page_begin = reinterpret_cast<uintptr_t>(page);
+  if (size > UINTPTR_MAX - request_begin || page_size > UINTPTR_MAX - page_begin)
+    return PageReleaseResult::kOverlap;
+  const uintptr_t request_end = request_begin + size;
+  const uintptr_t page_end = page_begin + page_size;
+  if (request_begin >= page_end || request_end <= page_begin)
+    return PageReleaseResult::kNotMapped;
+  if (request_begin != page_begin || size != page_size)
+    return PageReleaseResult::kOverlap;
+
   page = nullptr;
   page_size = 0;
-  return true;
+  return PageReleaseResult::kReleased;
 }
 
 /// @brief Signal event(s) from the CP's interrupt callback.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.h
@@ -34,6 +34,8 @@ namespace rocjitsu {
 /// for mmap/munmap operations.
 class EventState {
 public:
+  enum class PageReleaseResult { kNotMapped, kReleased, kOverlap };
+
   ~EventState();
 
   /// @brief Handle KFD CREATE_EVENT ioctl.
@@ -74,11 +76,11 @@ public:
   /// @details Idempotent, subsequent calls after the first are no-ops.
   void adopt_page(void *ptr, size_t size);
 
-  /// @brief If @p ptr is the adopted event page, clear page/page_size and return true.
-  /// @details Clears the fields under mutex_ so the CP interrupt thread (which
-  /// reads page/page_size under the same lock in signal_interrupt) can never race
-  /// a concurrent munmap tearing the mapping down.
-  [[nodiscard]] bool release_page(void *ptr);
+  /// @brief Release an exact event-page mapping or report a protected overlap.
+  /// @details Clears page/page_size only when the requested range exactly matches
+  /// the adopted page. Classification and release happen under mutex_, so the CP
+  /// interrupt thread cannot retain a pointer to an unmapped event page.
+  [[nodiscard]] PageReleaseResult release_page(void *ptr, size_t size);
 
   /// @brief Signal event(s) from the CP's interrupt callback.
   /// @details When event_id is non-zero, signals that specific event. When

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -2267,20 +2267,13 @@ RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, 
       if (lookup == RemoteDriver::MemfdLookup::kFound) {
         // memfd_out is a caller-owned dup; close it once we are done. Its
         // validity is independent of a concurrent RemoteDriver teardown/close.
-        auto total = static_cast<off_t>(length) + memfd_offset;
-        [[maybe_unused]] auto ft_rc = ftruncate(memfd_out, total);
-        fallocate(memfd_out, 0, memfd_offset, static_cast<off_t>(length));
         auto *raw = InterposerContext::real().mmap(
             addr, length, prot, (flags & ~MAP_ANONYMOUS) | MAP_SHARED, memfd_out, memfd_offset);
         // Preserve the mmap errno across close() (which may set its own).
         int mmap_errno = errno;
         InterposerContext::real().close(memfd_out);
-        if (raw != MAP_FAILED) {
-#ifdef MADV_POPULATE_WRITE
-          InterposerContext::real().madvise(raw, length, MADV_POPULATE_WRITE);
-#endif
+        if (raw != MAP_FAILED)
           return raw;
-        }
         // A daemon-shared range matched but the shared mapping failed. Fail
         // closed with the real errno rather than falling through to an anonymous
         // MAP_FIXED mapping, which would silently detach this GPUVM address from

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -26,6 +26,7 @@
 #include <shared_mutex>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <sys/types.h> // pid_t

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -16,10 +16,13 @@
 #include "rocjitsu/vm/amdgpu/mtype.h"
 #include "util/unique_handle.h"
 
+#include <algorithm>
 #include <atomic>
 #include <cassert>
 #include <cstdint>
+#include <map>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <unordered_map>
 #include <unordered_set>
@@ -79,20 +82,64 @@ public:
   struct GpuAllocation {
     uint64_t gpu_va = 0;
     uint64_t size = 0;
+    uint64_t backing_size = 0;
     void *host_ptr = nullptr;
     uint32_t flags = 0;
+    amdgpu::Mtype backing_mtype = amdgpu::Mtype::RW;
     uint64_t handle = 0;
     int memfd = -1;
     uint32_t gpu_id = 0;
     bool user_va = false;
     bool imported = false;
     int dmabuf_fd = -1;
+    bool permanent_backing = false;
+    bool mapped_to_gpu = false;
+    bool backing_authoritative = false;
+    // Page-aligned allocation-relative intervals already consumed from an
+    // existing MAP_FIXED client reservation. Keys are inclusive starts and
+    // values are exclusive ends.
+    std::map<uint64_t, uint64_t> imported_client_extents;
     // True when the driver created host_ptr (mmap it itself) and must munmap it
     // on teardown. False for caller-owned pages (e.g. reused MAP_FIXED pages
     // from the thunk) that the driver must never unmap, since unmapping them
     // races with the owning process still accessing the memory.
     bool host_ptr_owned = false;
   };
+
+  /// @brief A stable lookup result for allocation-owned GPU backing.
+  /// @details An inaccessible result identifies a managed address that must not
+  /// fall through to identity-pointer translation. The guard keeps accessible
+  /// backing alive until the caller finishes the memory operation.
+  struct ResolvedBacking {
+    uint8_t *address = nullptr;
+    uint8_t *page_base = nullptr;
+    uint8_t *range_base = nullptr;
+    uint64_t range_size = 0;
+    amdgpu::Mtype mtype = amdgpu::Mtype::RW;
+    bool gpu_accessible = false;
+    std::shared_lock<std::shared_mutex> guard;
+  };
+
+  [[nodiscard]] static bool is_valid_gpu_range(uint64_t gpu_va, uint64_t size) {
+    return size != 0 && gpu_va <= UINT64_MAX - (size - 1);
+  }
+
+  /// @brief Whether an allocation already covers any page in a proposed range.
+  /// @details The caller must hold alloc_mutex_. GPU mappings are page-granular,
+  /// so byte-disjoint ranges sharing a page are treated as overlapping.
+  [[nodiscard]] bool overlaps_allocation_locked(uint64_t gpu_va, uint64_t size) const {
+    assert(is_valid_gpu_range(gpu_va, size));
+    const uint64_t first_page = gpu_va >> kPageShift;
+    const uint64_t end_page = ((gpu_va + size - 1) >> kPageShift) + 1;
+    for (const auto &[handle, alloc] : allocations_) {
+      (void)handle;
+      const uint64_t alloc_first_page = alloc.gpu_va >> kPageShift;
+      const uint64_t alloc_end_page = ((alloc.gpu_va + alloc.size - 1) >> kPageShift) + 1;
+      if (first_page < alloc_end_page && alloc_first_page < end_page)
+        return true;
+    }
+    return false;
+  }
 
   /// @brief Memory policy descriptor.
   struct MemoryPolicy {
@@ -254,6 +301,41 @@ public:
   /// @brief Return the mutation counter used by GpuMemory translation caches.
   const uint64_t *page_table_generation() const { return &page_table_generation_; }
 
+  /// @brief Resolve a managed GPU range to allocation-owned host backing.
+  /// @details Unmapped allocations still return a result with
+  /// gpu_accessible=false, preventing unsafe identity-pointer fallback. The
+  /// returned guard prevents teardown while accessible backing is in use.
+  [[nodiscard]] std::optional<ResolvedBacking> resolve_backing(uint64_t gpu_va, size_t size) const {
+    if (size == 0 || gpu_va > UINT64_MAX - (static_cast<uint64_t>(size) - 1))
+      return std::nullopt;
+
+    std::shared_lock lock(backing_ranges_mutex_);
+    auto it = std::upper_bound(
+        backing_ranges_.begin(), backing_ranges_.end(), gpu_va,
+        [](uint64_t addr, const BackingRange &range) { return addr < range.first; });
+    if (it == backing_ranges_.begin())
+      return std::nullopt;
+    --it;
+
+    const uint64_t offset = gpu_va - it->first;
+    if (offset >= it->size || static_cast<uint64_t>(size) > it->size - offset)
+      return std::nullopt;
+
+    const uintptr_t address_value = reinterpret_cast<uintptr_t>(it->host_base) + offset;
+    return ResolvedBacking{reinterpret_cast<uint8_t *>(address_value),
+                           reinterpret_cast<uint8_t *>(address_value - (gpu_va & (kPageSize - 1))),
+                           it->host_base,
+                           it->size,
+                           it->mtype,
+                           it->gpu_accessible,
+                           std::move(lock)};
+  }
+
+  /// @brief Republish allocation-backed address ranges after a state change.
+  /// @details The caller must hold alloc_mutex_. Acquiring the unique range lock
+  /// waits for in-flight GPU accesses before backing can be unmapped.
+  void refresh_backing_ranges_locked() { publish_backing_ranges_locked(); }
+
   mutable std::shared_mutex page_table_mutex_;
   PageTable page_table_;
 
@@ -271,6 +353,9 @@ public:
   std::mutex op_mutex_;
   mutable std::mutex alloc_mutex_;
   std::unordered_map<uint64_t, GpuAllocation> allocations_;
+  // Page-aligned CPU alias intervals. Keys are inclusive host addresses and
+  // values are exclusive ends.
+  std::map<uintptr_t, uintptr_t> cpu_mappings_;
   uint64_t next_handle_ = 1;
   uint64_t next_gpu_va_;
 
@@ -309,6 +394,42 @@ private:
   ///          this generation; all reads and writes occur while holding
   ///          page_table_mutex_, so the counter itself does not need atomics.
   uint64_t page_table_generation_{1};
+
+  struct BackingRange {
+    uint64_t first = 0;
+    uint64_t size = 0;
+    uint8_t *host_base = nullptr;
+    amdgpu::Mtype mtype = amdgpu::Mtype::RW;
+    bool gpu_accessible = false;
+  };
+
+  void publish_backing_ranges_locked() {
+    std::vector<BackingRange> ranges;
+    ranges.reserve(allocations_.size());
+    for (const auto &[handle, alloc] : allocations_) {
+      (void)handle;
+      if (!alloc.permanent_backing || !alloc.host_ptr)
+        continue;
+      assert(is_valid_gpu_range(alloc.gpu_va, alloc.size));
+      ranges.push_back({alloc.gpu_va, alloc.size, static_cast<uint8_t *>(alloc.host_ptr),
+                        alloc.backing_mtype, alloc.mapped_to_gpu});
+    }
+
+    std::sort(ranges.begin(), ranges.end(), [](const BackingRange &lhs, const BackingRange &rhs) {
+      return lhs.first < rhs.first;
+    });
+    for (size_t i = 1; i < ranges.size(); ++i) {
+      assert(ranges[i - 1].first <= ranges[i].first);
+      assert(ranges[i - 1].size <= ranges[i].first - ranges[i - 1].first &&
+             "overlapping GPU allocation backings");
+    }
+
+    std::unique_lock lock(backing_ranges_mutex_);
+    backing_ranges_ = std::move(ranges);
+  }
+
+  mutable std::shared_mutex backing_ranges_mutex_;
+  std::vector<BackingRange> backing_ranges_;
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
@@ -8,13 +8,16 @@
 #include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
 #include "rocjitsu/kmd/linux/rpc.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cerrno>
 #include <chrono>
 #include <cstring>
 #include <fcntl.h>
+#include <iterator>
 #include <limits>
 #include <linux/mman.h>
+#include <map>
 #ifndef MADV_POPULATE_WRITE
 #define MADV_POPULATE_WRITE 23
 #endif
@@ -29,10 +32,59 @@
 #include <sys/un.h>
 #include <thread>
 #include <unistd.h>
+#include <utility>
 #include <vector>
 
 namespace rocjitsu {
 namespace {
+
+template <typename Address>
+void merge_interval(std::map<Address, Address> &intervals, Address begin, Address end) {
+  assert(begin < end);
+
+  typename std::map<Address, Address>::iterator it = intervals.lower_bound(begin);
+  if (it != intervals.begin()) {
+    typename std::map<Address, Address>::iterator previous = std::prev(it);
+    if (previous->second >= begin) {
+      begin = previous->first;
+      end = std::max(end, previous->second);
+      it = intervals.erase(previous);
+    }
+  }
+
+  while (it != intervals.end() && it->first <= end) {
+    end = std::max(end, it->second);
+    it = intervals.erase(it);
+  }
+  intervals.emplace(begin, end);
+}
+
+std::vector<std::pair<uint64_t, uint64_t>>
+find_uncovered_extents(const std::map<uint64_t, uint64_t> &covered, uint64_t begin, uint64_t end) {
+  std::vector<std::pair<uint64_t, uint64_t>> uncovered;
+  uint64_t cursor = begin;
+  std::map<uint64_t, uint64_t>::const_iterator it = covered.upper_bound(begin);
+  if (it != covered.begin()) {
+    --it;
+  }
+
+  for (; it != covered.end() && cursor < end; ++it) {
+    if (it->second <= cursor) {
+      continue;
+    }
+    if (it->first >= end) {
+      break;
+    }
+    if (it->first > cursor) {
+      uncovered.emplace_back(cursor, std::min(it->first, end));
+    }
+    cursor = std::max(cursor, it->second);
+  }
+  if (cursor < end) {
+    uncovered.emplace_back(cursor, end);
+  }
+  return uncovered;
+}
 
 constexpr bool has_embedded_pointers(unsigned long request) {
   switch (canonical_ioctl_request(request)) {
@@ -128,7 +180,7 @@ RemoteDriver::MemfdLookup RemoteDriver::find_memfd_for_addr(void *addr, size_t l
       // Return a DUP of the memfd, not the stored fd, so the caller owns a
       // descriptor whose lifetime is independent of this RemoteDriver. Without
       // this, a concurrent last-close -> RemoteDriver::close() (which closes the
-      // stored handle_memfds_ fds) could close the fd between this return and the
+      // stored allocation fds) could close the fd between this return and the
       // caller's ftruncate/fallocate/mmap, operating on a closed/reused fd. The
       // dup is taken under rpc_mutex_, the same lock close() holds, so the stored
       // fd is guaranteed still open here. The caller MUST close the returned fd.
@@ -156,9 +208,11 @@ RemoteDriver::RemoteDriver(int sock_fd) : sock_(sock_fd) {
 }
 
 RemoteDriver::~RemoteDriver() {
-  for (auto &[handle, fd] : handle_memfds_) {
-    if (fd >= 0)
-      syscall(SYS_close, fd);
+  for (const auto &[handle, allocation] : remote_allocations_) {
+    (void)handle;
+    if (allocation.memfd >= 0) {
+      syscall(SYS_close, allocation.memfd);
+    }
   }
   if (sock_ >= 0)
     syscall(SYS_close, sock_);
@@ -267,11 +321,13 @@ int RemoteDriver::close() {
       sock_ = -1;
     }
 
-    for (auto &[handle, fd] : handle_memfds_) {
-      if (fd >= 0)
-        syscall(SYS_close, fd);
+    for (const auto &[handle, allocation] : remote_allocations_) {
+      (void)handle;
+      if (allocation.memfd >= 0) {
+        syscall(SYS_close, allocation.memfd);
+      }
     }
-    handle_memfds_.clear();
+    remote_allocations_.clear();
     alloc_ranges_.clear();
     // Deliberately do NOT clear the handshake metadata (topology_path_,
     // drm_path_, gpu_info_, has_gpu_info_). It is written once during open() and
@@ -613,10 +669,15 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
     }
   }
 
-  auto register_allocation = [&](uint64_t handle, uint64_t va_addr, uint64_t size, int memfd) {
-    handle_memfds_[handle] = memfd;
-    if (va_addr != 0 && size > 0)
+  auto register_allocation = [&](uint64_t handle, uint64_t va_addr, uint64_t size, int memfd,
+                                 bool backing_authoritative) {
+    RemoteAllocation allocation;
+    allocation.memfd = memfd;
+    allocation.backing_authoritative = backing_authoritative;
+    remote_allocations_[handle] = std::move(allocation);
+    if (va_addr != 0 && size > 0) {
       alloc_ranges_.push_back({va_addr, size, memfd});
+    }
   };
 
   auto promote_userptr = [&](uint64_t va_addr, uint64_t size, int memfd) {
@@ -658,7 +719,7 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
     auto *alloc_args = static_cast<kfd_ioctl_alloc_memory_of_gpu_args *>(arg);
     if (num_fds > 0 && received_fds[0] >= 0) {
       register_allocation(alloc_args->handle, alloc_args->va_addr, alloc_args->size,
-                          received_fds[0]);
+                          received_fds[0], false);
 
       if (alloc_args->flags & KFD_IOC_ALLOC_MEM_FLAGS_USERPTR)
         promote_userptr(alloc_args->va_addr, alloc_args->size, received_fds[0]);
@@ -672,7 +733,16 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
       struct stat st {};
       if (fstat(received_fds[0], &st) == 0)
         size = static_cast<uint64_t>(st.st_size);
-      register_allocation(import_args->handle, import_args->va_addr, size, received_fds[0]);
+      register_allocation(import_args->handle, import_args->va_addr, size, received_fds[0], true);
+    }
+  }
+
+  if (request == AMDKFD_IOC_MAP_MEMORY_TO_GPU && resp->result == 0) {
+    const auto *map_args = static_cast<const kfd_ioctl_map_memory_to_gpu_args *>(arg);
+    std::unordered_map<uint64_t, RemoteAllocation>::iterator allocation =
+        remote_allocations_.find(map_args->handle);
+    if (allocation != remote_allocations_.end()) {
+      allocation->second.backing_authoritative = true;
     }
   }
 
@@ -684,12 +754,14 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
 
   if (request == AMDKFD_IOC_FREE_MEMORY_OF_GPU && resp->result == 0) {
     auto *free_args = static_cast<kfd_ioctl_free_memory_of_gpu_args *>(arg);
-    if (auto it = handle_memfds_.find(free_args->handle); it != handle_memfds_.end()) {
-      int freed_memfd = it->second;
+    std::unordered_map<uint64_t, RemoteAllocation>::iterator allocation =
+        remote_allocations_.find(free_args->handle);
+    if (allocation != remote_allocations_.end()) {
+      const int freed_memfd = allocation->second.memfd;
       std::erase_if(alloc_ranges_,
                     [freed_memfd](const AllocRange &r) { return r.memfd == freed_memfd; });
       syscall(SYS_close, freed_memfd);
-      handle_memfds_.erase(it);
+      remote_allocations_.erase(allocation);
     }
   }
 
@@ -719,11 +791,23 @@ void *RemoteDriver::mmap(void *addr, size_t length, int prot, int flags, off_t o
   // Resolve the memfd for this allocation: prefer the mmap response fd, fall
   // back to the stored ALLOC_MEMORY fd (same underlying file, different fd).
   int mapping_memfd = memfd;
-  uint64_t type = static_cast<uint64_t>(offset) & (0x3ULL << 62);
+  const uint64_t type = static_cast<uint64_t>(offset) & (0x3ULL << 62);
+  RemoteAllocation *allocation = nullptr;
   if (mapping_memfd < 0 && type == 0) {
-    uint64_t handle = static_cast<uint64_t>(offset) >> 12;
-    if (auto it = handle_memfds_.find(handle); it != handle_memfds_.end())
-      mapping_memfd = it->second;
+    const uint64_t handle = static_cast<uint64_t>(offset) >> 12;
+    std::unordered_map<uint64_t, RemoteAllocation>::iterator allocation_it =
+        remote_allocations_.find(handle);
+    if (allocation_it != remote_allocations_.end()) {
+      allocation = &allocation_it->second;
+      mapping_memfd = allocation->memfd;
+    }
+  } else if (type == 0) {
+    const uint64_t handle = static_cast<uint64_t>(offset) >> 12;
+    std::unordered_map<uint64_t, RemoteAllocation>::iterator allocation_it =
+        remote_allocations_.find(handle);
+    if (allocation_it != remote_allocations_.end()) {
+      allocation = &allocation_it->second;
+    }
   }
   if (mapping_memfd >= 0) {
     struct stat backing_stat {};
@@ -741,24 +825,32 @@ void *RemoteDriver::mmap(void *addr, size_t length, int prot, int flags, off_t o
       return MAP_FAILED;
     }
 
-    // Pre-copy committed pages (code objects) from the existing anonymous
-    // reservation into the memfd before MAP_FIXED replaces them. Uses a temp
-    // mapping outside the GPUVM range for the copy target.
-    if ((flags & MAP_FIXED) && addr != nullptr) {
+    const bool replaces_client_reservation = (flags & MAP_FIXED) && addr != nullptr;
+    const bool can_import_client_pages = !allocation || !allocation->backing_authoritative;
+    if (replaces_client_reservation && can_import_client_pages) {
       auto prot_rc = syscall(SYS_mprotect, addr, rounded_length, PROT_READ | PROT_WRITE);
       if (prot_rc == 0) {
-        size_t num_pages = rounded_length / page_size;
-        std::vector<uint8_t> page_resident(num_pages);
-        auto mc_rc = syscall(SYS_mincore, addr, rounded_length, page_resident.data());
         auto *temp = static_cast<uint8_t *>(
             safe_mmap(nullptr, rounded_length, PROT_WRITE, MAP_SHARED, mapping_memfd, 0));
         if (temp != MAP_FAILED) {
-          if (mc_rc == 0) {
-            auto *src = static_cast<uint8_t *>(addr);
+          const std::vector<std::pair<uint64_t, uint64_t>> extents =
+              allocation
+                  ? find_uncovered_extents(allocation->imported_client_extents, 0, rounded_length)
+                  : std::vector<std::pair<uint64_t, uint64_t>>{{0, rounded_length}};
+          auto *source = static_cast<uint8_t *>(addr);
+          for (const auto &[extent_begin, extent_end] : extents) {
+            const size_t import_size = static_cast<size_t>(extent_end - extent_begin);
+            const size_t num_pages = import_size / page_size;
+            std::vector<uint8_t> page_resident(num_pages);
+            if (syscall(SYS_mincore, source + extent_begin, import_size, page_resident.data()) !=
+                0) {
+              continue;
+            }
             for (size_t i = 0; i < num_pages; ++i) {
               if (page_resident[i] & 1) {
-                size_t off = i * page_size;
-                std::memcpy(temp + off, src + off, page_size);
+                const size_t page_offset = i * page_size;
+                std::memcpy(temp + extent_begin + page_offset, source + extent_begin + page_offset,
+                            page_size);
               }
             }
           }
@@ -774,6 +866,11 @@ void *RemoteDriver::mmap(void *addr, size_t length, int prot, int flags, off_t o
     if (flags & MAP_FIXED)
       mflags |= MAP_FIXED;
     auto *mapped = safe_mmap(addr, length, PROT_READ | PROT_WRITE, mflags, mapping_memfd, 0);
+    if (mapped != MAP_FAILED && allocation && replaces_client_reservation &&
+        !allocation->backing_authoritative) {
+      merge_interval(allocation->imported_client_extents, uint64_t{0},
+                     static_cast<uint64_t>(rounded_length));
+    }
     if (memfd >= 0)
       syscall(SYS_close, memfd);
     return mapped;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
@@ -717,7 +717,20 @@ void *RemoteDriver::mmap(void *addr, size_t length, int prot, int flags, off_t o
       mapping_memfd = it->second;
   }
   if (mapping_memfd >= 0) {
-    [[maybe_unused]] auto ft_rc2 = ftruncate(mapping_memfd, static_cast<off_t>(length));
+    struct stat backing_stat {};
+    if (syscall(SYS_fstat, mapping_memfd, &backing_stat) != 0) {
+      const int saved_errno = errno;
+      if (memfd >= 0)
+        syscall(SYS_close, memfd);
+      errno = saved_errno;
+      return MAP_FAILED;
+    }
+    if (backing_stat.st_size < 0 || length > static_cast<uint64_t>(backing_stat.st_size)) {
+      if (memfd >= 0)
+        syscall(SYS_close, memfd);
+      errno = EINVAL;
+      return MAP_FAILED;
+    }
 
     // Pre-copy committed pages (code objects) from the existing anonymous
     // reservation into the memfd before MAP_FIXED replaces them. Uses a temp
@@ -747,18 +760,14 @@ void *RemoteDriver::mmap(void *addr, size_t length, int prot, int flags, off_t o
       }
     }
 
-    // QEMU vhost-user pattern: per-allocation memfd with F_SEAL_SHRINK (set at
-    // creation in alloc_memory_ioctl), MAP_SHARED|MAP_FIXED, then
-    // MADV_POPULATE_WRITE to pre-fault pages. This surfaces any shmem ENOSPC
-    // as errno rather than deferred SIGBUS on page fault.
+    // The allocation owns an already-sized memfd. Keep pages lazy: VRAM
+    // reservations can be tens of GiB and must not be physically populated by
+    // a CPU mapping alone.
     int mflags = MAP_SHARED;
     if (flags & MAP_FIXED)
       mflags |= MAP_FIXED;
     auto *mapped = safe_mmap(addr, length, PROT_READ | PROT_WRITE, mflags, mapping_memfd, 0);
-    if (mapped != MAP_FAILED)
-      syscall(SYS_madvise, mapped, length, MADV_POPULATE_WRITE);
-
-    if (memfd >= 0 && memfd != mapping_memfd)
+    if (memfd >= 0)
       syscall(SYS_close, memfd);
     return mapped;
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <cstring>
 #include <fcntl.h>
+#include <limits>
 #include <linux/mman.h>
 #ifndef MADV_POPULATE_WRITE
 #define MADV_POPULATE_WRITE 23
@@ -698,6 +699,14 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
 void *RemoteDriver::mmap(void *addr, size_t length, int prot, int flags, off_t offset) {
   std::lock_guard<std::mutex> lock(rpc_mutex_);
 
+  constexpr size_t page_size = 4096;
+  constexpr size_t page_mask = page_size - 1;
+  if (length == 0 || length > std::numeric_limits<size_t>::max() - page_mask) {
+    errno = EINVAL;
+    return MAP_FAILED;
+  }
+  const size_t rounded_length = (length + page_mask) & ~page_mask;
+
   // Send the mmap RPC so the daemon creates its own mapping for GPU simulation.
   int memfd = -1;
   int rc = send_mmap(addr, length, prot, flags, offset, &memfd);
@@ -725,7 +734,7 @@ void *RemoteDriver::mmap(void *addr, size_t length, int prot, int flags, off_t o
       errno = saved_errno;
       return MAP_FAILED;
     }
-    if (backing_stat.st_size < 0 || length > static_cast<uint64_t>(backing_stat.st_size)) {
+    if (backing_stat.st_size < 0 || rounded_length > static_cast<uint64_t>(backing_stat.st_size)) {
       if (memfd >= 0)
         syscall(SYS_close, memfd);
       errno = EINVAL;
@@ -736,26 +745,24 @@ void *RemoteDriver::mmap(void *addr, size_t length, int prot, int flags, off_t o
     // reservation into the memfd before MAP_FIXED replaces them. Uses a temp
     // mapping outside the GPUVM range for the copy target.
     if ((flags & MAP_FIXED) && addr != nullptr) {
-      auto prot_rc = syscall(SYS_mprotect, addr, length, PROT_READ | PROT_WRITE);
+      auto prot_rc = syscall(SYS_mprotect, addr, rounded_length, PROT_READ | PROT_WRITE);
       if (prot_rc == 0) {
-        constexpr size_t page_size = 4096;
-        size_t num_pages = (length + page_size - 1) / page_size;
+        size_t num_pages = rounded_length / page_size;
         std::vector<uint8_t> page_resident(num_pages);
-        auto mc_rc = syscall(SYS_mincore, addr, length, page_resident.data());
+        auto mc_rc = syscall(SYS_mincore, addr, rounded_length, page_resident.data());
         auto *temp = static_cast<uint8_t *>(
-            safe_mmap(nullptr, length, PROT_WRITE, MAP_SHARED, mapping_memfd, 0));
+            safe_mmap(nullptr, rounded_length, PROT_WRITE, MAP_SHARED, mapping_memfd, 0));
         if (temp != MAP_FAILED) {
           if (mc_rc == 0) {
             auto *src = static_cast<uint8_t *>(addr);
             for (size_t i = 0; i < num_pages; ++i) {
               if (page_resident[i] & 1) {
                 size_t off = i * page_size;
-                size_t n = std::min(page_size, length - off);
-                std::memcpy(temp + off, src + off, n);
+                std::memcpy(temp + off, src + off, page_size);
               }
             }
           }
-          syscall(SYS_munmap, temp, length);
+          syscall(SYS_munmap, temp, rounded_length);
         }
       }
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.h
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <map>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -135,8 +136,14 @@ private:
   /// socket writes without this lock, corrupting the RPC stream.
   std::mutex rpc_mutex_;
 
-  /// @brief Memfds received from the daemon during ALLOC_MEMORY, keyed by handle.
-  std::unordered_map<uint64_t, int> handle_memfds_;
+  struct RemoteAllocation {
+    int memfd = -1;
+    bool backing_authoritative = false;
+    std::map<uint64_t, uint64_t> imported_client_extents;
+  };
+
+  /// @brief Client-side state for allocations shared by the daemon.
+  std::unordered_map<uint64_t, RemoteAllocation> remote_allocations_;
 
   /// @brief Maps GPUVM addresses to allocation memfds for anonymous MAP_FIXED
   /// interception. When ROCR's FMM does anonymous MAP_FIXED at a GPUVM address

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -25,7 +25,11 @@ RJ_DIAGNOSTIC_POP
 #include <cstring>
 #include <fcntl.h>
 #include <format>
+#include <iterator>
+#include <limits>
 #include <linux/types.h>
+#include <map>
+#include <optional>
 #include <sstream>
 #include <sys/mman.h>
 #include <sys/random.h>
@@ -36,6 +40,7 @@ RJ_DIAGNOSTIC_POP
 #endif
 #include <thread>
 #include <unistd.h>
+#include <utility>
 #include <vector>
 
 namespace rocjitsu {
@@ -105,6 +110,147 @@ int safe_fstat(int fd, struct stat *st) { return libc_passthrough().fstat_fn(fd,
 /// (F_DUPFD_CLOEXEC, F_ADD_SEALS, F_GETFL/no-arg) used here forward cleanly.
 template <typename... Args> int safe_fcntl(int fd, int cmd, Args... args) {
   return libc_passthrough().fcntl(fd, cmd, args...);
+}
+
+std::optional<uint64_t> checked_page_aligned_size(uint64_t size) {
+  constexpr uint64_t page_mask = KfdProcess::kPageSize - 1;
+  if (size == 0 || size > UINT64_MAX - page_mask)
+    return std::nullopt;
+  return (size + page_mask) & ~page_mask;
+}
+
+template <typename Address>
+void merge_interval(std::map<Address, Address> &intervals, Address begin, Address end) {
+  assert(begin < end);
+
+  typename std::map<Address, Address>::iterator it = intervals.lower_bound(begin);
+  if (it != intervals.begin()) {
+    typename std::map<Address, Address>::iterator previous = std::prev(it);
+    if (previous->second >= begin) {
+      begin = previous->first;
+      end = std::max(end, previous->second);
+      it = intervals.erase(previous);
+    }
+  }
+
+  while (it != intervals.end() && it->first <= end) {
+    end = std::max(end, it->second);
+    it = intervals.erase(it);
+  }
+  intervals.emplace(begin, end);
+}
+
+std::vector<std::pair<uint64_t, uint64_t>>
+find_uncovered_extents(const std::map<uint64_t, uint64_t> &covered, uint64_t begin, uint64_t end) {
+  std::vector<std::pair<uint64_t, uint64_t>> uncovered;
+  uint64_t cursor = begin;
+  std::map<uint64_t, uint64_t>::const_iterator it = covered.upper_bound(begin);
+  if (it != covered.begin())
+    --it;
+
+  for (; it != covered.end() && cursor < end; ++it) {
+    if (it->second <= cursor)
+      continue;
+    if (it->first >= end)
+      break;
+    if (it->first > cursor)
+      uncovered.emplace_back(cursor, std::min(it->first, end));
+    cursor = std::max(cursor, it->second);
+  }
+  if (cursor < end)
+    uncovered.emplace_back(cursor, end);
+  return uncovered;
+}
+
+std::optional<uint64_t> assign_gpu_va_locked(KfdProcess &proc, uint64_t requested_va,
+                                             uint64_t size) {
+  if (requested_va != 0) {
+    if (!KfdProcess::is_valid_gpu_range(requested_va, size) ||
+        proc.overlaps_allocation_locked(requested_va, size))
+      return std::nullopt;
+    return requested_va;
+  }
+
+  std::optional<uint64_t> aligned_size = checked_page_aligned_size(size);
+  if (!aligned_size)
+    return std::nullopt;
+
+  uint64_t gpu_va = proc.next_gpu_va_;
+  while (gpu_va <= UINT64_MAX - *aligned_size) {
+    const uint64_t first_page = gpu_va >> KfdProcess::kPageShift;
+    const uint64_t end_page = ((gpu_va + *aligned_size - 1) >> KfdProcess::kPageShift) + 1;
+    uint64_t next_page = first_page;
+    for (const auto &[handle, alloc] : proc.allocations_) {
+      (void)handle;
+      assert(KfdProcess::is_valid_gpu_range(alloc.gpu_va, alloc.size));
+      const uint64_t alloc_first_page = alloc.gpu_va >> KfdProcess::kPageShift;
+      const uint64_t alloc_end_page =
+          ((alloc.gpu_va + alloc.size - 1) >> KfdProcess::kPageShift) + 1;
+      if (first_page < alloc_end_page && alloc_first_page < end_page)
+        next_page = std::max(next_page, alloc_end_page);
+    }
+    if (next_page == first_page) {
+      proc.next_gpu_va_ = gpu_va + *aligned_size;
+      return gpu_va;
+    }
+    constexpr uint64_t address_space_pages = (UINT64_MAX >> KfdProcess::kPageShift) + 1;
+    if (next_page >= address_space_pages)
+      return std::nullopt;
+    gpu_va = next_page << KfdProcess::kPageShift;
+  }
+  return std::nullopt;
+}
+
+struct LazyVramBacking {
+  int fd = -1;
+  void *mapping = MAP_FAILED;
+  uint64_t size = 0;
+};
+
+std::optional<LazyVramBacking> create_lazy_vram_backing(uint64_t requested_size) {
+  std::optional<uint64_t> aligned_size = checked_page_aligned_size(requested_size);
+  if (!aligned_size || *aligned_size > static_cast<uint64_t>(std::numeric_limits<size_t>::max()) ||
+      *aligned_size > static_cast<uint64_t>(std::numeric_limits<off_t>::max())) {
+    errno = EOVERFLOW;
+    return std::nullopt;
+  }
+
+  int raw_fd = memfd_create("rocjitsu_vram", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+  if (raw_fd < 0)
+    return std::nullopt;
+
+  int fd = safe_fcntl(raw_fd, F_DUPFD_CLOEXEC, 4096);
+  if (fd < 0) {
+    fd = raw_fd;
+  } else {
+    libc_passthrough().close(raw_fd);
+  }
+
+  if (ftruncate(fd, static_cast<off_t>(*aligned_size)) != 0) {
+    const int saved_errno = errno;
+    libc_passthrough().close(fd);
+    errno = saved_errno;
+    return std::nullopt;
+  }
+
+  void *mapping = safe_mmap(nullptr, static_cast<size_t>(*aligned_size), PROT_READ | PROT_WRITE,
+                            MAP_SHARED, fd, 0);
+  if (mapping == MAP_FAILED) {
+    const int saved_errno = errno;
+    libc_passthrough().close(fd);
+    errno = saved_errno;
+    return std::nullopt;
+  }
+
+  if (safe_fcntl(fd, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW) != 0) {
+    const int saved_errno = errno;
+    libc_passthrough().munmap(mapping, static_cast<size_t>(*aligned_size));
+    libc_passthrough().close(fd);
+    errno = saved_errno;
+    return std::nullopt;
+  }
+
+  return LazyVramBacking{fd, mapping, *aligned_size};
 }
 
 } // namespace
@@ -368,10 +514,17 @@ int SimulatedKfd::open() {
   // DBG_TRAP self-resolution therefore requires a post-fork re-open.
   proc->set_client_pid(static_cast<pid_t>(getpid()));
   proc->event_state_.reset();
+  std::weak_ptr<KfdProcess> weak_proc = proc;
   for (auto &g : gpus_) {
     if (auto *mem = g.soc ? g.soc->memory() : nullptr) {
       mem->register_process(pid, &proc->page_table_, &proc->page_table_mutex_,
                             proc->page_table_generation());
+      mem->set_process_backing_resolver(
+          pid,
+          [weak_proc](uint64_t gpu_va, size_t size) -> std::optional<KfdProcess::ResolvedBacking> {
+            auto process = weak_proc.lock();
+            return process ? process->resolve_backing(gpu_va, size) : std::nullopt;
+          });
       if (!daemon_mode_)
         mem->set_passthrough(true);
     }
@@ -430,10 +583,18 @@ uint32_t SimulatedKfd::open_process(pid_t client_pid) {
     if (client_pid > 0)
       proc->set_client_pid(client_pid);
     proc->event_state_.reset();
+    std::weak_ptr<KfdProcess> weak_proc = proc;
     for (auto &g : gpus_) {
       if (auto *mem = g.soc ? g.soc->memory() : nullptr) {
         mem->register_process(pid, &proc->page_table_, &proc->page_table_mutex_,
                               proc->page_table_generation());
+        mem->set_process_backing_resolver(
+            pid,
+            [weak_proc](uint64_t gpu_va,
+                        size_t size) -> std::optional<KfdProcess::ResolvedBacking> {
+              auto process = weak_proc.lock();
+              return process ? process->resolve_backing(gpu_va, size) : std::nullopt;
+            });
         if (client_pid > 0)
           mem->set_process_client_pid(pid, client_pid);
       }
@@ -587,13 +748,21 @@ int SimulatedKfd::close(uint32_t process_id) {
     if (trace_enabled)
       leaked_handles.reserve(proc.allocations_.size());
     for (auto &[handle, alloc] : proc.allocations_) {
+      (void)handle;
+      if (alloc.permanent_backing)
+        alloc.mapped_to_gpu = false;
+    }
+    proc.refresh_backing_ranges_locked();
+    for (auto &[handle, alloc] : proc.allocations_) {
       ++leaked_allocations;
       leaked_bytes += alloc.size;
       if (trace_enabled)
         leaked_handles.push_back(handle);
       if (alloc.host_ptr && alloc.host_ptr_owned) {
-        unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
-        libc_passthrough().munmap(alloc.host_ptr, alloc.size);
+        if (!alloc.permanent_backing)
+          unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
+        libc_passthrough().munmap(alloc.host_ptr,
+                                  alloc.permanent_backing ? alloc.backing_size : alloc.size);
         alloc.host_ptr = nullptr;
         alloc.host_ptr_owned = false;
       }
@@ -607,6 +776,10 @@ int SimulatedKfd::close(uint32_t process_id) {
       }
     }
     proc.allocations_.clear();
+    proc.refresh_backing_ranges_locked();
+    for (const auto &[begin, end] : proc.cpu_mappings_)
+      libc_passthrough().munmap(reinterpret_cast<void *>(begin), end - begin);
+    proc.cpu_mappings_.clear();
   }
 
   for (uint32_t qid : queue_ids) {
@@ -994,6 +1167,76 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
 
   auto &alloc = it->second;
 
+  if (alloc.permanent_backing) {
+    if (length == 0 || length > alloc.backing_size) {
+      errno = EINVAL;
+      return MAP_FAILED;
+    }
+
+    std::optional<uint64_t> rounded_length = checked_page_aligned_size(length);
+    if (!rounded_length || *rounded_length > alloc.backing_size) {
+      errno = EINVAL;
+      return MAP_FAILED;
+    }
+
+    if (daemon_mode_ && alloc.memfd >= 0 && alloc.host_ptr != nullptr)
+      return alloc.host_ptr;
+
+    const bool replaces_client_reservation =
+        alloc.user_va && (flags & MAP_FIXED) && addr != nullptr;
+
+    // Import each committed source extent at most once and only before GPU use
+    // makes the allocation-owned memfd authoritative.
+    if (!alloc.backing_authoritative && replaces_client_reservation) {
+      int prot_rc = libc_passthrough().mprotect(addr, length, PROT_READ | PROT_WRITE);
+      if (prot_rc == 0) {
+        constexpr size_t page_size = KfdProcess::kPageSize;
+        std::vector<std::pair<uint64_t, uint64_t>> uncovered =
+            find_uncovered_extents(alloc.imported_client_extents, 0, *rounded_length);
+        uint8_t *source = static_cast<uint8_t *>(addr);
+        uint8_t *destination = static_cast<uint8_t *>(alloc.host_ptr);
+        for (const auto &[extent_begin, extent_end] : uncovered) {
+          const uint64_t import_end = std::min<uint64_t>(extent_end, length);
+          if (extent_begin >= import_end)
+            continue;
+          const size_t import_size = static_cast<size_t>(import_end - extent_begin);
+          const size_t num_pages = (import_size + page_size - 1) / page_size;
+          std::vector<uint8_t> page_resident(num_pages);
+          if (mincore(source + extent_begin, import_size, page_resident.data()) != 0)
+            continue;
+          for (size_t i = 0; i < num_pages; ++i) {
+            if ((page_resident[i] & 1) == 0)
+              continue;
+            const size_t page_offset = i * page_size;
+            const size_t copy_size = std::min(page_size, import_size - page_offset);
+            std::memcpy(destination + extent_begin + page_offset,
+                        source + extent_begin + page_offset, copy_size);
+          }
+        }
+      }
+    }
+
+    int map_flags = MAP_SHARED;
+    if (flags & MAP_FIXED)
+      map_flags |= MAP_FIXED;
+    void *client_ptr = safe_mmap(addr, length, prot, map_flags, alloc.memfd, 0);
+    if (client_ptr == MAP_FAILED)
+      return MAP_FAILED;
+
+    if (replaces_client_reservation)
+      merge_interval(alloc.imported_client_extents, uint64_t{0}, *rounded_length);
+
+    const uintptr_t mapping_begin = reinterpret_cast<uintptr_t>(client_ptr);
+    if (*rounded_length > UINTPTR_MAX - mapping_begin) {
+      libc_passthrough().munmap(client_ptr, static_cast<size_t>(*rounded_length));
+      errno = EOVERFLOW;
+      return MAP_FAILED;
+    }
+    merge_interval(proc.cpu_mappings_, mapping_begin,
+                   mapping_begin + static_cast<uintptr_t>(*rounded_length));
+    return client_ptr;
+  }
+
   if (daemon_mode_ && alloc.memfd >= 0 && alloc.host_ptr != nullptr)
     return alloc.host_ptr;
 
@@ -1142,6 +1385,36 @@ int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
     return 0;
   }
   std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
+  const uintptr_t unmap_begin = reinterpret_cast<uintptr_t>(addr);
+  std::optional<uint64_t> rounded_length = checked_page_aligned_size(length);
+  std::map<uintptr_t, uintptr_t>::iterator mapping = proc.cpu_mappings_.upper_bound(unmap_begin);
+  if (mapping != proc.cpu_mappings_.begin()) {
+    --mapping;
+    if (mapping->first <= unmap_begin && unmap_begin < mapping->second) {
+      if (!rounded_length || (unmap_begin & (KfdProcess::kPageSize - 1)) != 0 ||
+          *rounded_length > UINTPTR_MAX - unmap_begin) {
+        errno = EINVAL;
+        return -1;
+      }
+      const uintptr_t unmap_end = unmap_begin + static_cast<uintptr_t>(*rounded_length);
+      if (unmap_end > mapping->second) {
+        errno = EINVAL;
+        return -1;
+      }
+
+      const uintptr_t mapping_begin = mapping->first;
+      const uintptr_t mapping_end = mapping->second;
+      int rc = libc_passthrough().munmap(addr, static_cast<size_t>(*rounded_length));
+      if (rc != 0)
+        return rc;
+      proc.cpu_mappings_.erase(mapping);
+      if (mapping_begin < unmap_begin)
+        proc.cpu_mappings_.emplace(mapping_begin, unmap_begin);
+      if (unmap_end < mapping_end)
+        proc.cpu_mappings_.emplace(unmap_end, mapping_end);
+      return 0;
+    }
+  }
   for (auto &[handle, alloc] : proc.allocations_) {
     if (alloc.host_ptr == addr) {
       unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
@@ -1270,17 +1543,19 @@ int SimulatedKfd::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
   std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
 
   bool user_provided_va = (args->va_addr != 0);
-  uint64_t va = args->va_addr;
-  if (va == 0) {
-    va = proc.next_gpu_va_;
-    proc.next_gpu_va_ += (args->size + 0xFFF) & ~0xFFFULL;
-  }
+  std::optional<uint64_t> aligned_size = checked_page_aligned_size(args->size);
+  if (!aligned_size)
+    return -EINVAL;
+
+  std::optional<uint64_t> assigned_va = assign_gpu_va_locked(proc, args->va_addr, *aligned_size);
+  if (!assigned_va)
+    return -EINVAL;
+  uint64_t va = *assigned_va;
 
   KfdProcess::GpuAllocation alloc{};
   alloc.gpu_va = va;
   alloc.size = args->size;
   alloc.flags = args->flags;
-  alloc.handle = proc.next_handle_++;
   alloc.host_ptr = nullptr;
   alloc.gpu_id = args->gpu_id;
   alloc.user_va = user_provided_va;
@@ -1288,10 +1563,29 @@ int SimulatedKfd::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
   auto alloc_mtype = pte_mtype_for_flags(args->flags);
   bool is_userptr = (args->flags & KFD_IOC_ALLOC_MEM_FLAGS_USERPTR) != 0;
   bool is_doorbell = (args->flags & KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL) != 0;
+  bool is_vram = (args->flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM) != 0;
+  bool needs_permanent_backing = is_vram && !is_userptr && !is_doorbell;
+  alloc.backing_mtype = alloc_mtype;
+
+  if (needs_permanent_backing) {
+    if ((va & (KfdProcess::kPageSize - 1)) != 0)
+      return -EINVAL;
+    std::optional<LazyVramBacking> backing = create_lazy_vram_backing(alloc.size);
+    if (!backing)
+      return errno == EOVERFLOW ? -EOVERFLOW : -ENOMEM;
+    alloc.memfd = backing->fd;
+    alloc.host_ptr = backing->mapping;
+    alloc.host_ptr_owned = true;
+    alloc.backing_size = backing->size;
+    alloc.permanent_backing = true;
+    std::lock_guard<std::mutex> lk(owned_fds_mutex_);
+    owned_fds_.insert(alloc.memfd);
+  }
+
   if (is_userptr && !daemon_mode_) {
     alloc.host_ptr = reinterpret_cast<void *>(va);
     map_to_gpu(proc, va, reinterpret_cast<void *>(va), args->size, alloc_mtype);
-  } else if (daemon_mode_ || !user_provided_va) {
+  } else if (!needs_permanent_backing && (daemon_mode_ || !user_provided_va)) {
     auto raw_fd = memfd_create("rocjitsu_alloc", MFD_CLOEXEC | MFD_ALLOW_SEALING);
     if (raw_fd >= 0) {
       alloc.memfd = safe_fcntl(raw_fd, F_DUPFD_CLOEXEC, 4096);
@@ -1321,7 +1615,9 @@ int SimulatedKfd::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
     }
   }
 
+  alloc.handle = proc.next_handle_++;
   proc.allocations_[alloc.handle] = alloc;
+  proc.refresh_backing_ranges_locked();
 
   args->handle = alloc.handle;
   args->va_addr = va;
@@ -1437,8 +1733,17 @@ int SimulatedKfd::free_memory_ioctl(KfdProcess &proc, void *arg) {
         proc.imported_dmabufs_.erase(dmabuf_it);
       }
     }
-    if (alloc.host_ptr && !alloc.user_va)
+    if (alloc.permanent_backing) {
+      alloc.mapped_to_gpu = false;
+      proc.refresh_backing_ranges_locked();
+      if (alloc.host_ptr) {
+        libc_passthrough().munmap(alloc.host_ptr, alloc.backing_size);
+        alloc.host_ptr = nullptr;
+        alloc.host_ptr_owned = false;
+      }
+    } else if (alloc.host_ptr && !alloc.user_va) {
       unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
+    }
     if (alloc.memfd >= 0) {
       {
         std::lock_guard<std::mutex> lk(owned_fds_mutex_);
@@ -1450,6 +1755,7 @@ int SimulatedKfd::free_memory_ioctl(KfdProcess &proc, void *arg) {
     uint32_t freed_process_id = proc.process_id();
     uint64_t freed_handle = args->handle;
     proc.allocations_.erase(it);
+    proc.refresh_backing_ranges_locked();
 
     {
       std::lock_guard<std::mutex> ilk(ipc_mutex_);
@@ -1484,8 +1790,13 @@ int SimulatedKfd::map_memory_ioctl(KfdProcess &proc, void *arg) {
                       alloc.handle, alloc.gpu_va, alloc.size, args->n_devices,
                       alloc.host_ptr != nullptr);
   });
-  if (alloc.host_ptr)
+  if (alloc.permanent_backing) {
+    alloc.backing_authoritative = true;
+    alloc.mapped_to_gpu = true;
+    proc.refresh_backing_ranges_locked();
+  } else if (alloc.host_ptr) {
     map_to_gpu(proc, alloc.gpu_va, alloc.host_ptr, alloc.size, pte_mtype_for_flags(alloc.flags));
+  }
   args->n_success = args->n_devices;
   return 0;
 }
@@ -1500,8 +1811,12 @@ int SimulatedKfd::unmap_memory_ioctl(KfdProcess &proc, void *arg) {
     // releases it. Erasing here would leak those fds and make a later FREE a
     // no-op for this handle.
     auto &alloc = it->second;
-    if (alloc.host_ptr)
+    if (alloc.permanent_backing) {
+      alloc.mapped_to_gpu = false;
+      proc.refresh_backing_ranges_locked();
+    } else if (alloc.host_ptr) {
       unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
+    }
   }
   args->n_success = args->n_devices;
   return 0;
@@ -1800,7 +2115,12 @@ int SimulatedKfd::ipc_export_handle_ioctl(KfdProcess &proc, void *arg) {
     // the local GPU sees writes from the importing GPU.  On real hardware
     // xGMI snoops handle this; in the simulator CC forces L2 invalidate
     // before every refetch, emulating the cross-GPU coherence protocol.
-    proc.set_page_mtype(alloc.gpu_va, alloc.size, amdgpu::Mtype::CC);
+    if (alloc.permanent_backing) {
+      alloc.backing_mtype = amdgpu::Mtype::CC;
+      proc.refresh_backing_ranges_locked();
+    } else {
+      proc.set_page_mtype(alloc.gpu_va, alloc.size, amdgpu::Mtype::CC);
+    }
 
     alloc_size = alloc.size;
     alloc_flags = alloc.flags;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -1387,33 +1387,42 @@ int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
   std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
   const uintptr_t unmap_begin = reinterpret_cast<uintptr_t>(addr);
   std::optional<uint64_t> rounded_length = checked_page_aligned_size(length);
-  std::map<uintptr_t, uintptr_t>::iterator mapping = proc.cpu_mappings_.upper_bound(unmap_begin);
-  if (mapping != proc.cpu_mappings_.begin()) {
-    --mapping;
-    if (mapping->first <= unmap_begin && unmap_begin < mapping->second) {
-      if (!rounded_length || (unmap_begin & (KfdProcess::kPageSize - 1)) != 0 ||
-          *rounded_length > UINTPTR_MAX - unmap_begin) {
-        errno = EINVAL;
-        return -1;
-      }
-      const uintptr_t unmap_end = unmap_begin + static_cast<uintptr_t>(*rounded_length);
-      if (unmap_end > mapping->second) {
-        errno = EINVAL;
-        return -1;
-      }
+  if (length == 0 || !rounded_length || (unmap_begin & (KfdProcess::kPageSize - 1)) != 0 ||
+      *rounded_length > UINTPTR_MAX - unmap_begin) {
+    errno = EINVAL;
+    return -1;
+  }
+  const uintptr_t unmap_end = unmap_begin + static_cast<uintptr_t>(*rounded_length);
 
+  std::map<uintptr_t, uintptr_t>::iterator mapping = proc.cpu_mappings_.lower_bound(unmap_begin);
+  if (mapping != proc.cpu_mappings_.begin()) {
+    std::map<uintptr_t, uintptr_t>::iterator previous = std::prev(mapping);
+    if (previous->second > unmap_begin)
+      mapping = previous;
+  }
+  const bool overlaps_cpu_mapping = mapping != proc.cpu_mappings_.end() &&
+                                    mapping->first < unmap_end && mapping->second > unmap_begin;
+  if (overlaps_cpu_mapping) {
+    int rc = libc_passthrough().munmap(addr, length);
+    if (rc != 0)
+      return rc;
+
+    while (mapping != proc.cpu_mappings_.end() && mapping->first < unmap_end) {
+      if (mapping->second <= unmap_begin) {
+        ++mapping;
+        continue;
+      }
       const uintptr_t mapping_begin = mapping->first;
       const uintptr_t mapping_end = mapping->second;
-      int rc = libc_passthrough().munmap(addr, static_cast<size_t>(*rounded_length));
-      if (rc != 0)
-        return rc;
-      proc.cpu_mappings_.erase(mapping);
+      mapping = proc.cpu_mappings_.erase(mapping);
       if (mapping_begin < unmap_begin)
         proc.cpu_mappings_.emplace(mapping_begin, unmap_begin);
-      if (unmap_end < mapping_end)
+      if (unmap_end < mapping_end) {
         proc.cpu_mappings_.emplace(unmap_end, mapping_end);
-      return 0;
+        break;
+      }
     }
+    return 0;
   }
   for (auto &[handle, alloc] : proc.allocations_) {
     if (alloc.host_ptr == addr) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -1188,7 +1188,8 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
     // Import each committed source extent at most once and only before GPU use
     // makes the allocation-owned memfd authoritative.
     if (!alloc.backing_authoritative && replaces_client_reservation) {
-      int prot_rc = libc_passthrough().mprotect(addr, length, PROT_READ | PROT_WRITE);
+      int prot_rc = libc_passthrough().mprotect(addr, static_cast<size_t>(*rounded_length),
+                                                PROT_READ | PROT_WRITE);
       if (prot_rc == 0) {
         constexpr size_t page_size = KfdProcess::kPageSize;
         std::vector<std::pair<uint64_t, uint64_t>> uncovered =
@@ -1196,10 +1197,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
         uint8_t *source = static_cast<uint8_t *>(addr);
         uint8_t *destination = static_cast<uint8_t *>(alloc.host_ptr);
         for (const auto &[extent_begin, extent_end] : uncovered) {
-          const uint64_t import_end = std::min<uint64_t>(extent_end, length);
-          if (extent_begin >= import_end)
-            continue;
-          const size_t import_size = static_cast<size_t>(import_end - extent_begin);
+          const size_t import_size = static_cast<size_t>(extent_end - extent_begin);
           const size_t num_pages = (import_size + page_size - 1) / page_size;
           std::vector<uint8_t> page_resident(num_pages);
           if (mincore(source + extent_begin, import_size, page_resident.data()) != 0)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -1327,6 +1327,15 @@ int SimulatedKfd::munmap(uint32_t process_id, void *addr, size_t length) {
 }
 
 int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
+  const uintptr_t unmap_begin = reinterpret_cast<uintptr_t>(addr);
+  std::optional<uint64_t> rounded_length = checked_page_aligned_size(length);
+  if (length == 0 || !rounded_length || (unmap_begin & (KfdProcess::kPageSize - 1)) != 0 ||
+      *rounded_length > UINTPTR_MAX - unmap_begin) {
+    errno = EINVAL;
+    return -1;
+  }
+  const uintptr_t unmap_end = unmap_begin + static_cast<uintptr_t>(*rounded_length);
+
   {
     uint32_t doorbell_ord = 0;
     size_t doorbell_page_size = 0;
@@ -1335,7 +1344,7 @@ int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
       std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
       for (size_t ord = 0; ord < proc.gpu_state_.size(); ++ord) {
         auto &gs = proc.gpu(ord);
-        if (gs.doorbell_page == addr) {
+        if (gs.doorbell_page == addr && gs.doorbell_page_size == length) {
           if (!proc.event_state_.is_closing()) {
             errno = EPERM;
             return -1;
@@ -1375,22 +1384,30 @@ int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
       return 0;
     }
   }
-  // release_page() clears page/page_size under EventState::mutex_, the same lock
-  // the CP interrupt thread holds when reading them in signal_interrupt, so the
-  // munmap below cannot race a concurrent signal writing into the mapping.
-  if (proc.event_state_.release_page(addr)) {
+  // release_page() classifies and clears page/page_size under EventState::mutex_,
+  // the same lock the CP interrupt thread holds when reading them.
+  const EventState::PageReleaseResult event_page = proc.event_state_.release_page(addr, length);
+  if (event_page == EventState::PageReleaseResult::kOverlap) {
+    errno = EPERM;
+    return -1;
+  }
+  if (event_page == EventState::PageReleaseResult::kReleased) {
     libc_passthrough().munmap(addr, length);
     return 0;
   }
   std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
-  const uintptr_t unmap_begin = reinterpret_cast<uintptr_t>(addr);
-  std::optional<uint64_t> rounded_length = checked_page_aligned_size(length);
-  if (length == 0 || !rounded_length || (unmap_begin & (KfdProcess::kPageSize - 1)) != 0 ||
-      *rounded_length > UINTPTR_MAX - unmap_begin) {
-    errno = EINVAL;
-    return -1;
+  for (const KfdProcess::PerGpuState &gpu_state : proc.gpu_state_) {
+    if (!gpu_state.doorbell_page || gpu_state.doorbell_page_size == 0)
+      continue;
+    const uintptr_t doorbell_begin = reinterpret_cast<uintptr_t>(gpu_state.doorbell_page);
+    std::optional<uint64_t> doorbell_length =
+        checked_page_aligned_size(gpu_state.doorbell_page_size);
+    if (!doorbell_length || *doorbell_length > UINTPTR_MAX - doorbell_begin ||
+        (unmap_begin < doorbell_begin + *doorbell_length && unmap_end > doorbell_begin)) {
+      errno = EPERM;
+      return -1;
+    }
   }
-  const uintptr_t unmap_end = unmap_begin + static_cast<uintptr_t>(*rounded_length);
 
   std::map<uintptr_t, uintptr_t>::iterator mapping = proc.cpu_mappings_.lower_bound(unmap_begin);
   if (mapping != proc.cpu_mappings_.begin()) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -160,9 +160,11 @@ public:
   void read_block(uint64_t addr, std::span<uint8_t> dst, uint32_t vmid = 0) const {
     for_each_page_chunk(addr, dst.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
       auto out = dst.subspan(offset, chunk);
-      if (read_mapped(ea, out.data(), chunk, vmid))
+      const HostAccessResult result = read_mapped(ea, out.data(), chunk, vmid);
+      if (result == HostAccessResult::ACCESSED)
         return;
-      if (vmid > 0 && read_client_memory(ea, out.data(), chunk, vmid))
+      if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
+          read_client_memory(ea, out.data(), chunk, vmid))
         return;
       for (size_t i = 0; i < chunk; ++i)
         out[i] = simdojo::SparseMemory::read8(ea + i);
@@ -175,9 +177,11 @@ public:
   void write_block(uint64_t addr, std::span<const uint8_t> src, uint32_t vmid = 0) {
     for_each_page_chunk(addr, src.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
       auto in = src.subspan(offset, chunk);
-      if (write_mapped(ea, in.data(), chunk, vmid))
+      const HostAccessResult result = write_mapped(ea, in.data(), chunk, vmid);
+      if (result == HostAccessResult::ACCESSED)
         return;
-      if (vmid > 0 && write_client_memory(ea, in.data(), chunk, vmid))
+      if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
+          write_client_memory(ea, in.data(), chunk, vmid))
         return;
       for (size_t i = 0; i < chunk; ++i)
         simdojo::SparseMemory::write8(ea + i, in[i]);
@@ -225,7 +229,7 @@ public:
         if (backing->gpu_accessible)
           atomic_rmw_mapped(addr, backing->page_base, fn);
         else
-          atomic_rmw_fallback(addr, size, entry.client_pid, fn);
+          atomic_rmw_fallback(addr, size, 0, fn);
         return;
       }
     }
@@ -315,73 +319,125 @@ public:
 
   uint8_t read8(uint64_t addr, uint32_t vmid = 0) const {
     uint8_t val = 0;
-    if (read_mapped(addr, &val, sizeof(val), vmid))
+    const HostAccessResult result = read_mapped(addr, &val, sizeof(val), vmid);
+    if (result == HostAccessResult::ACCESSED)
       return val;
-    if (vmid > 0 && read_client_memory(addr, &val, 1, vmid))
+    if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
+        read_client_memory(addr, &val, 1, vmid))
       return val;
     return SparseMemory::read8(addr);
   }
 
   uint16_t read16(uint64_t addr, uint32_t vmid = 0) const {
     uint16_t val = 0;
-    if (read_mapped(addr, &val, sizeof(val), vmid))
+    if (read_cross_page(addr, val, vmid))
       return val;
-    if (vmid > 0 && read_client_memory(addr, &val, 2, vmid))
+    const HostAccessResult result = read_mapped(addr, &val, sizeof(val), vmid);
+    if (result == HostAccessResult::ACCESSED)
+      return val;
+    if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
+        read_client_memory(addr, &val, 2, vmid))
       return val;
     return SparseMemory::read16(addr);
   }
 
   uint32_t read32(uint64_t addr, uint32_t vmid = 0) const {
     uint32_t val = 0;
-    if (read_mapped(addr, &val, sizeof(val), vmid))
+    if (read_cross_page(addr, val, vmid))
       return val;
-    if (vmid > 0 && read_client_memory(addr, &val, 4, vmid))
+    const HostAccessResult result = read_mapped(addr, &val, sizeof(val), vmid);
+    if (result == HostAccessResult::ACCESSED)
+      return val;
+    if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
+        read_client_memory(addr, &val, 4, vmid))
       return val;
     return SparseMemory::read32(addr);
   }
 
   uint64_t read64(uint64_t addr, uint32_t vmid = 0) const {
     uint64_t val = 0;
-    if (read_mapped(addr, &val, sizeof(val), vmid))
+    if (read_cross_page(addr, val, vmid))
       return val;
-    if (vmid > 0 && read_client_memory(addr, &val, 8, vmid))
+    const HostAccessResult result = read_mapped(addr, &val, sizeof(val), vmid);
+    if (result == HostAccessResult::ACCESSED)
+      return val;
+    if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
+        read_client_memory(addr, &val, 8, vmid))
       return val;
     return SparseMemory::read64(addr);
   }
 
   void write8(uint64_t addr, uint8_t val, uint32_t vmid = 0) {
-    if (write_mapped(addr, &val, sizeof(val), vmid))
+    const HostAccessResult result = write_mapped(addr, &val, sizeof(val), vmid);
+    if (result == HostAccessResult::ACCESSED)
       return;
-    if (vmid > 0 && write_client_memory(addr, &val, 1, vmid))
+    if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
+        write_client_memory(addr, &val, 1, vmid))
       return;
     SparseMemory::write8(addr, val);
   }
 
   void write16(uint64_t addr, uint16_t val, uint32_t vmid = 0) {
-    if (write_mapped(addr, &val, sizeof(val), vmid))
+    if (write_cross_page(addr, val, vmid))
       return;
-    if (vmid > 0 && write_client_memory(addr, &val, 2, vmid))
+    const HostAccessResult result = write_mapped(addr, &val, sizeof(val), vmid);
+    if (result == HostAccessResult::ACCESSED)
+      return;
+    if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
+        write_client_memory(addr, &val, 2, vmid))
       return;
     SparseMemory::write16(addr, val);
   }
 
   void write32(uint64_t addr, uint32_t val, uint32_t vmid = 0) {
-    if (write_mapped(addr, &val, sizeof(val), vmid))
+    if (write_cross_page(addr, val, vmid))
       return;
-    if (vmid > 0 && write_client_memory(addr, &val, 4, vmid))
+    const HostAccessResult result = write_mapped(addr, &val, sizeof(val), vmid);
+    if (result == HostAccessResult::ACCESSED)
+      return;
+    if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
+        write_client_memory(addr, &val, 4, vmid))
       return;
     SparseMemory::write32(addr, val);
   }
 
   void write64(uint64_t addr, uint64_t val, uint32_t vmid = 0) {
-    if (write_mapped(addr, &val, sizeof(val), vmid))
+    if (write_cross_page(addr, val, vmid))
       return;
-    if (vmid > 0 && write_client_memory(addr, &val, 8, vmid))
+    const HostAccessResult result = write_mapped(addr, &val, sizeof(val), vmid);
+    if (result == HostAccessResult::ACCESSED)
+      return;
+    if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
+        write_client_memory(addr, &val, 8, vmid))
       return;
     SparseMemory::write64(addr, val);
   }
 
 private:
+  /// @brief Result of attempting to resolve and access VMID-scoped host storage.
+  /// @details Only UNRESOLVED permits client-memory fallback. INACCESSIBLE
+  /// identifies a managed allocation that is not mapped to the GPU.
+  enum class HostAccessResult {
+    ACCESSED,
+    UNRESOLVED,
+    INACCESSIBLE,
+  };
+
+  template <typename T> bool read_cross_page(uint64_t addr, T &value, uint32_t vmid) const {
+    if ((addr & PAGE_MASK) + sizeof(T) <= PAGE_SIZE)
+      return false;
+    read_block(addr, std::span<uint8_t>(reinterpret_cast<uint8_t *>(&value), sizeof(T)), vmid);
+    return true;
+  }
+
+  template <typename T> bool write_cross_page(uint64_t addr, const T &value, uint32_t vmid) {
+    if ((addr & PAGE_MASK) + sizeof(T) <= PAGE_SIZE)
+      return false;
+    write_block(
+        addr, std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(&value), sizeof(T)), vmid);
+    return true;
+  }
+
   // The largest supported atomic is eight bytes, so discard the three byte
   // offset bits before choosing a lock stripe.
   static constexpr unsigned kBackingAtomicGranuleShift = 3;
@@ -539,13 +595,13 @@ private:
   }
 
   template <typename F>
-  bool with_host_ptr(uint64_t addr, size_t size, uint32_t vmid, F &&fn) const {
+  HostAccessResult with_host_ptr(uint64_t addr, size_t size, uint32_t vmid, F &&fn) const {
     if (vmid == 0) {
       auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
       if (!passthrough_ || addr >= kUserSpaceLimit || page == nullptr)
-        return false;
+        return HostAccessResult::UNRESOLVED;
       fn(page);
-      return true;
+      return HostAccessResult::ACCESSED;
     }
 
     static thread_local PteCache cache;
@@ -559,36 +615,34 @@ private:
           return 1;
         });
     if (page_table_status != 0)
-      return page_table_status > 0;
+      return page_table_status > 0 ? HostAccessResult::ACCESSED : HostAccessResult::UNRESOLVED;
 
     std::optional<KfdProcess::ResolvedBacking> backing = resolve_process_backing(addr, size, vmid);
     if (backing) {
       if (!backing->gpu_accessible)
-        return false;
+        return HostAccessResult::INACCESSIBLE;
       fn(backing->page_base);
-      return true;
+      return HostAccessResult::ACCESSED;
     }
 
     if (!passthrough_ || addr >= kUserSpaceLimit)
-      return false;
+      return HostAccessResult::UNRESOLVED;
     auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
     if (page == nullptr)
-      return false;
+      return HostAccessResult::UNRESOLVED;
     fn(page);
-    return true;
+    return HostAccessResult::ACCESSED;
   }
 
-  bool read_mapped(uint64_t addr, void *dst, size_t len, uint32_t vmid) const {
-    if ((addr & PAGE_MASK) + len > PAGE_SIZE)
-      return false;
+  HostAccessResult read_mapped(uint64_t addr, void *dst, size_t len, uint32_t vmid) const {
+    assert((addr & PAGE_MASK) + len <= PAGE_SIZE);
     return with_host_ptr(addr, len, vmid, [&](const uint8_t *page) {
       std::memcpy(dst, page + (addr & PAGE_MASK), len);
     });
   }
 
-  bool write_mapped(uint64_t addr, const void *src, size_t len, uint32_t vmid) {
-    if ((addr & PAGE_MASK) + len > PAGE_SIZE)
-      return false;
+  HostAccessResult write_mapped(uint64_t addr, const void *src, size_t len, uint32_t vmid) {
+    assert((addr & PAGE_MASK) + len <= PAGE_SIZE);
     return with_host_ptr(addr, len, vmid,
                          [&](uint8_t *page) { std::memcpy(page + (addr & PAGE_MASK), src, len); });
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -140,16 +140,15 @@ public:
     if (vmid == 0)
       return Mtype::RW;
     static thread_local PteCache cache;
-    std::optional<Mtype> pte =
-        cached_walk(addr, vmid, cache, [](const KfdProcess::PageTableEntry *entry) {
-          return entry ? std::optional(entry->mtype) : std::nullopt;
-        });
-    if (pte)
-      return *pte;
-    std::optional<KfdProcess::ResolvedBacking> backing = resolve_process_backing(addr, 1, vmid);
-    if (backing && backing->gpu_accessible)
-      return backing->mtype;
-    return Mtype::RW;
+    return with_vmid_resolution(addr, 1, vmid, cache,
+                                [](const VmidEntry *, const KfdProcess::PageTableEntry *pte,
+                                   const KfdProcess::ResolvedBacking *backing) {
+                                  if (pte)
+                                    return pte->mtype;
+                                  if (backing && backing->gpu_accessible)
+                                    return backing->mtype;
+                                  return Mtype::RW;
+                                });
   }
 
   uint32_t fetch32(uint64_t addr, uint32_t vmid = 0) const { return read32(addr, vmid); }
@@ -160,11 +159,11 @@ public:
   void read_block(uint64_t addr, std::span<uint8_t> dst, uint32_t vmid = 0) const {
     for_each_page_chunk(addr, dst.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
       auto out = dst.subspan(offset, chunk);
-      const HostAccessResult result = read_mapped(ea, out.data(), chunk, vmid);
-      if (result == HostAccessResult::ACCESSED)
+      const HostAccessOutcome access = read_mapped(ea, out.data(), chunk, vmid);
+      if (access.result == HostAccessResult::ACCESSED)
         return;
-      if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
-          read_client_memory(ea, out.data(), chunk, vmid))
+      if (access.result == HostAccessResult::UNRESOLVED &&
+          read_client_memory_for_pid(ea, out.data(), chunk, access.client_pid))
         return;
       for (size_t i = 0; i < chunk; ++i)
         out[i] = simdojo::SparseMemory::read8(ea + i);
@@ -177,11 +176,11 @@ public:
   void write_block(uint64_t addr, std::span<const uint8_t> src, uint32_t vmid = 0) {
     for_each_page_chunk(addr, src.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
       auto in = src.subspan(offset, chunk);
-      const HostAccessResult result = write_mapped(ea, in.data(), chunk, vmid);
-      if (result == HostAccessResult::ACCESSED)
+      const HostAccessOutcome access = write_mapped(ea, in.data(), chunk, vmid);
+      if (access.result == HostAccessResult::ACCESSED)
         return;
-      if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
-          write_client_memory(ea, in.data(), chunk, vmid))
+      if (access.result == HostAccessResult::UNRESOLVED &&
+          write_client_memory_for_pid(ea, in.data(), chunk, access.client_pid))
         return;
       for (size_t i = 0; i < chunk; ++i)
         simdojo::SparseMemory::write8(ea + i, in[i]);
@@ -205,36 +204,26 @@ public:
       return;
     }
 
-    std::shared_lock vmid_lock(vmid_mutex_);
-    auto vmid_entry = vmid_table_.find(vmid);
-    if (vmid_entry == vmid_table_.end()) {
-      atomic_rmw_unmapped(addr, size, 0, fn);
-      return;
-    }
-
-    auto &entry = vmid_entry->second;
-    std::shared_lock page_table_lock(*entry.mutex);
-    auto pte = entry.page_table->find(addr >> PAGE_SHIFT);
-    if (pte != entry.page_table->end()) {
-      if (pte->second.host_ptr != nullptr)
-        atomic_rmw_mapped(addr, pte->second.host_ptr, fn);
-      else
-        atomic_rmw_fallback(addr, size, entry.client_pid, fn);
-      return;
-    }
-
-    if (entry.backing_resolver) {
-      std::optional<KfdProcess::ResolvedBacking> backing = entry.backing_resolver(addr, size);
-      if (backing) {
-        if (backing->gpu_accessible)
-          atomic_rmw_mapped(addr, backing->page_base, fn);
-        else
-          atomic_rmw_fallback(addr, size, 0, fn);
-        return;
-      }
-    }
-
-    atomic_rmw_unmapped(addr, size, entry.client_pid, fn);
+    static thread_local PteCache cache;
+    with_vmid_resolution(addr, size, vmid, cache,
+                         [&](const VmidEntry *entry, const KfdProcess::PageTableEntry *pte,
+                             const KfdProcess::ResolvedBacking *backing) {
+                           if (pte) {
+                             if (pte->host_ptr != nullptr)
+                               atomic_rmw_mapped(addr, pte->host_ptr, fn);
+                             else
+                               atomic_rmw_fallback(addr, size, entry->client_pid, fn);
+                             return;
+                           }
+                           if (backing) {
+                             if (backing->gpu_accessible)
+                               atomic_rmw_mapped(addr, backing->page_base, fn);
+                             else
+                               atomic_rmw_fallback(addr, size, 0, fn);
+                             return;
+                           }
+                           atomic_rmw_unmapped(addr, size, entry ? entry->client_pid : 0, fn);
+                         });
   }
 
   uint8_t *translate_debug(uint64_t addr, uint32_t vmid) const { return translate(addr, vmid); }
@@ -251,48 +240,47 @@ public:
       return {reinterpret_cast<uint64_t>(host), PAGE_SIZE};
     }
 
-    std::shared_lock vmid_lock(vmid_mutex_);
-    auto vmid_entry = vmid_table_.find(vmid);
-    if (vmid_entry == vmid_table_.end())
-      return {0, 0};
+    static thread_local PteCache cache;
+    return with_vmid_resolution(
+        addr, 1, vmid, cache,
+        [&](const VmidEntry *entry, const KfdProcess::PageTableEntry *pte,
+            const KfdProcess::ResolvedBacking *backing) -> std::pair<uint64_t, uint64_t> {
+          if (!pte) {
+            if (backing && backing->gpu_accessible)
+              return {reinterpret_cast<uint64_t>(backing->range_base), backing->range_size};
+            return {0, 0};
+          }
+          if (pte->host_ptr == nullptr)
+            return {0, 0};
 
-    auto &entry = vmid_entry->second;
-    std::shared_lock page_table_lock(*entry.mutex);
-    const uint64_t page = addr >> PAGE_SHIFT;
-    auto page_entry = entry.page_table->find(page);
-    if (page_entry == entry.page_table->end()) {
-      page_table_lock.unlock();
-      vmid_lock.unlock();
-      std::optional<KfdProcess::ResolvedBacking> backing = resolve_process_backing(addr, 1, vmid);
-      if (backing && backing->gpu_accessible)
-        return {reinterpret_cast<uint64_t>(backing->range_base), backing->range_size};
-      return {0, 0};
-    }
+          const uint64_t page = addr >> PAGE_SHIFT;
+          uint64_t first_page = page;
+          uint8_t *first_host_page = pte->host_ptr;
+          while (first_page > 0) {
+            KfdProcess::PageTable::const_iterator previous_page_entry =
+                entry->page_table->find(first_page - 1);
+            if (previous_page_entry == entry->page_table->end() ||
+                previous_page_entry->second.host_ptr + PAGE_SIZE != first_host_page)
+              break;
+            --first_page;
+            first_host_page = previous_page_entry->second.host_ptr;
+          }
 
-    uint64_t first_page = page;
-    uint8_t *first_host_page = page_entry->second.host_ptr;
-    while (first_page > 0) {
-      auto previous_page_entry = entry.page_table->find(first_page - 1);
-      if (previous_page_entry == entry.page_table->end() ||
-          previous_page_entry->second.host_ptr + PAGE_SIZE != first_host_page)
-        break;
-      --first_page;
-      first_host_page = previous_page_entry->second.host_ptr;
-    }
+          uint64_t last_page = page;
+          uint8_t *last_host_page = pte->host_ptr;
+          while (true) {
+            KfdProcess::PageTable::const_iterator next_page_entry =
+                entry->page_table->find(last_page + 1);
+            if (next_page_entry == entry->page_table->end() ||
+                next_page_entry->second.host_ptr != last_host_page + PAGE_SIZE)
+              break;
+            ++last_page;
+            last_host_page = next_page_entry->second.host_ptr;
+          }
 
-    uint64_t last_page = page;
-    uint8_t *last_host_page = page_entry->second.host_ptr;
-    while (true) {
-      auto next_page_entry = entry.page_table->find(last_page + 1);
-      if (next_page_entry == entry.page_table->end() ||
-          next_page_entry->second.host_ptr != last_host_page + PAGE_SIZE)
-        break;
-      ++last_page;
-      last_host_page = next_page_entry->second.host_ptr;
-    }
-
-    const uint64_t range_size = ((last_page - first_page) + 1) << PAGE_SHIFT;
-    return {reinterpret_cast<uint64_t>(first_host_page), range_size};
+          const uint64_t range_size = ((last_page - first_page) + 1) << PAGE_SHIFT;
+          return {reinterpret_cast<uint64_t>(first_host_page), range_size};
+        });
   }
 
   std::string debug_page_table_info(uint32_t vmid, uint64_t page_key) const {
@@ -319,11 +307,11 @@ public:
 
   uint8_t read8(uint64_t addr, uint32_t vmid = 0) const {
     uint8_t val = 0;
-    const HostAccessResult result = read_mapped(addr, &val, sizeof(val), vmid);
-    if (result == HostAccessResult::ACCESSED)
+    const HostAccessOutcome access = read_mapped(addr, &val, sizeof(val), vmid);
+    if (access.result == HostAccessResult::ACCESSED)
       return val;
-    if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
-        read_client_memory(addr, &val, 1, vmid))
+    if (access.result == HostAccessResult::UNRESOLVED &&
+        read_client_memory_for_pid(addr, &val, 1, access.client_pid))
       return val;
     return SparseMemory::read8(addr);
   }
@@ -332,11 +320,11 @@ public:
     uint16_t val = 0;
     if (read_cross_page(addr, val, vmid))
       return val;
-    const HostAccessResult result = read_mapped(addr, &val, sizeof(val), vmid);
-    if (result == HostAccessResult::ACCESSED)
+    const HostAccessOutcome access = read_mapped(addr, &val, sizeof(val), vmid);
+    if (access.result == HostAccessResult::ACCESSED)
       return val;
-    if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
-        read_client_memory(addr, &val, 2, vmid))
+    if (access.result == HostAccessResult::UNRESOLVED &&
+        read_client_memory_for_pid(addr, &val, 2, access.client_pid))
       return val;
     return SparseMemory::read16(addr);
   }
@@ -345,11 +333,11 @@ public:
     uint32_t val = 0;
     if (read_cross_page(addr, val, vmid))
       return val;
-    const HostAccessResult result = read_mapped(addr, &val, sizeof(val), vmid);
-    if (result == HostAccessResult::ACCESSED)
+    const HostAccessOutcome access = read_mapped(addr, &val, sizeof(val), vmid);
+    if (access.result == HostAccessResult::ACCESSED)
       return val;
-    if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
-        read_client_memory(addr, &val, 4, vmid))
+    if (access.result == HostAccessResult::UNRESOLVED &&
+        read_client_memory_for_pid(addr, &val, 4, access.client_pid))
       return val;
     return SparseMemory::read32(addr);
   }
@@ -358,21 +346,21 @@ public:
     uint64_t val = 0;
     if (read_cross_page(addr, val, vmid))
       return val;
-    const HostAccessResult result = read_mapped(addr, &val, sizeof(val), vmid);
-    if (result == HostAccessResult::ACCESSED)
+    const HostAccessOutcome access = read_mapped(addr, &val, sizeof(val), vmid);
+    if (access.result == HostAccessResult::ACCESSED)
       return val;
-    if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
-        read_client_memory(addr, &val, 8, vmid))
+    if (access.result == HostAccessResult::UNRESOLVED &&
+        read_client_memory_for_pid(addr, &val, 8, access.client_pid))
       return val;
     return SparseMemory::read64(addr);
   }
 
   void write8(uint64_t addr, uint8_t val, uint32_t vmid = 0) {
-    const HostAccessResult result = write_mapped(addr, &val, sizeof(val), vmid);
-    if (result == HostAccessResult::ACCESSED)
+    const HostAccessOutcome access = write_mapped(addr, &val, sizeof(val), vmid);
+    if (access.result == HostAccessResult::ACCESSED)
       return;
-    if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
-        write_client_memory(addr, &val, 1, vmid))
+    if (access.result == HostAccessResult::UNRESOLVED &&
+        write_client_memory_for_pid(addr, &val, 1, access.client_pid))
       return;
     SparseMemory::write8(addr, val);
   }
@@ -380,11 +368,11 @@ public:
   void write16(uint64_t addr, uint16_t val, uint32_t vmid = 0) {
     if (write_cross_page(addr, val, vmid))
       return;
-    const HostAccessResult result = write_mapped(addr, &val, sizeof(val), vmid);
-    if (result == HostAccessResult::ACCESSED)
+    const HostAccessOutcome access = write_mapped(addr, &val, sizeof(val), vmid);
+    if (access.result == HostAccessResult::ACCESSED)
       return;
-    if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
-        write_client_memory(addr, &val, 2, vmid))
+    if (access.result == HostAccessResult::UNRESOLVED &&
+        write_client_memory_for_pid(addr, &val, 2, access.client_pid))
       return;
     SparseMemory::write16(addr, val);
   }
@@ -392,11 +380,11 @@ public:
   void write32(uint64_t addr, uint32_t val, uint32_t vmid = 0) {
     if (write_cross_page(addr, val, vmid))
       return;
-    const HostAccessResult result = write_mapped(addr, &val, sizeof(val), vmid);
-    if (result == HostAccessResult::ACCESSED)
+    const HostAccessOutcome access = write_mapped(addr, &val, sizeof(val), vmid);
+    if (access.result == HostAccessResult::ACCESSED)
       return;
-    if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
-        write_client_memory(addr, &val, 4, vmid))
+    if (access.result == HostAccessResult::UNRESOLVED &&
+        write_client_memory_for_pid(addr, &val, 4, access.client_pid))
       return;
     SparseMemory::write32(addr, val);
   }
@@ -404,11 +392,11 @@ public:
   void write64(uint64_t addr, uint64_t val, uint32_t vmid = 0) {
     if (write_cross_page(addr, val, vmid))
       return;
-    const HostAccessResult result = write_mapped(addr, &val, sizeof(val), vmid);
-    if (result == HostAccessResult::ACCESSED)
+    const HostAccessOutcome access = write_mapped(addr, &val, sizeof(val), vmid);
+    if (access.result == HostAccessResult::ACCESSED)
       return;
-    if (result == HostAccessResult::UNRESOLVED && vmid > 0 &&
-        write_client_memory(addr, &val, 8, vmid))
+    if (access.result == HostAccessResult::UNRESOLVED &&
+        write_client_memory_for_pid(addr, &val, 8, access.client_pid))
       return;
     SparseMemory::write64(addr, val);
   }
@@ -421,6 +409,11 @@ private:
     ACCESSED,
     UNRESOLVED,
     INACCESSIBLE,
+  };
+
+  struct HostAccessOutcome {
+    HostAccessResult result = HostAccessResult::UNRESOLVED;
+    pid_t client_pid = 0;
   };
 
   template <typename T> bool read_cross_page(uint64_t addr, T &value, uint32_t vmid) const {
@@ -535,34 +528,36 @@ private:
     const uint64_t *generation_ptr = nullptr;
   };
 
-  /// @brief Walk a VMID page table with a generation-keyed thread-local cache.
-  /// @details The callback runs while both VMID registration and the selected
-  /// page table are shared-locked. This keeps a cached host pointer alive for
-  /// the whole copy and makes translate() and pte_mtype() share one invalidation
-  /// protocol.
+  /// @brief Resolve one VMID access through its page table or allocation backing.
+  /// @details One VMID shared lock covers registration lookup, the cached page
+  /// walk, backing resolution, and the callback. The selected page table is also
+  /// shared-locked throughout, so neither registration nor storage
+  /// classification can change during the operation.
   template <typename F>
-  auto cached_walk(uint64_t addr, uint32_t vmid, PteCache &cache,
-                   F &&fn) const -> std::invoke_result_t<F, const KfdProcess::PageTableEntry *> {
+  auto with_vmid_resolution(uint64_t addr, size_t size, uint32_t vmid, PteCache &cache, F &&fn)
+      const -> std::invoke_result_t<F, const VmidEntry *, const KfdProcess::PageTableEntry *,
+                                    const KfdProcess::ResolvedBacking *> {
     const uint64_t page_key = addr >> PAGE_SHIFT;
     std::shared_lock vmid_lock(vmid_mutex_);
     const uint64_t registry_generation = vmid_registry_generation_;
+    std::unordered_map<uint32_t, VmidEntry>::const_iterator vmid_entry = vmid_table_.find(vmid);
+    if (vmid_entry == vmid_table_.end()) {
+      cache = {};
+      return fn(nullptr, nullptr, nullptr);
+    }
+    const VmidEntry &entry = vmid_entry->second;
 
     const bool cached_table =
         cache.memory == this && cache.memory_instance == instance_id_ && cache.vmid == vmid &&
         cache.registry_generation == registry_generation && cache.page_table && cache.mutex;
     if (!cached_table) {
-      auto it = vmid_table_.find(vmid);
-      if (it == vmid_table_.end()) {
-        cache = {};
-        return fn(nullptr);
-      }
       cache.memory = this;
       cache.memory_instance = instance_id_;
       cache.vmid = vmid;
       cache.registry_generation = registry_generation;
-      cache.page_table = it->second.page_table;
-      cache.mutex = it->second.mutex;
-      cache.generation_ptr = it->second.generation;
+      cache.page_table = entry.page_table;
+      cache.mutex = entry.mutex;
+      cache.generation_ptr = entry.generation;
       cache.found = false;
     }
 
@@ -579,69 +574,58 @@ private:
         cache.pte = it->second;
     }
 
-    return fn(cache.found ? &cache.pte : nullptr);
-  }
-
-  std::optional<KfdProcess::ResolvedBacking> resolve_process_backing(uint64_t addr, size_t size,
-                                                                     uint32_t vmid) const {
-    if (vmid == 0)
-      return std::nullopt;
-
-    std::shared_lock lock(vmid_mutex_);
-    std::unordered_map<uint32_t, VmidEntry>::const_iterator it = vmid_table_.find(vmid);
-    if (it == vmid_table_.end() || !it->second.backing_resolver)
-      return std::nullopt;
-    return it->second.backing_resolver(addr, size);
+    std::optional<KfdProcess::ResolvedBacking> backing;
+    if (!cache.found && entry.backing_resolver)
+      backing = entry.backing_resolver(addr, size);
+    return fn(&entry, cache.found ? &cache.pte : nullptr, backing ? &*backing : nullptr);
   }
 
   template <typename F>
-  HostAccessResult with_host_ptr(uint64_t addr, size_t size, uint32_t vmid, F &&fn) const {
+  HostAccessOutcome with_host_ptr(uint64_t addr, size_t size, uint32_t vmid, F &&fn) const {
     if (vmid == 0) {
       auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
       if (!passthrough_ || addr >= kUserSpaceLimit || page == nullptr)
-        return HostAccessResult::UNRESOLVED;
+        return {HostAccessResult::UNRESOLVED, 0};
       fn(page);
-      return HostAccessResult::ACCESSED;
+      return {HostAccessResult::ACCESSED, 0};
     }
 
     static thread_local PteCache cache;
-    const int page_table_status =
-        cached_walk(addr, vmid, cache, [&](const KfdProcess::PageTableEntry *pte) {
-          if (!pte)
-            return 0;
-          if (pte->host_ptr == nullptr)
-            return -1;
-          fn(pte->host_ptr);
-          return 1;
+    return with_vmid_resolution(
+        addr, size, vmid, cache,
+        [&](const VmidEntry *entry, const KfdProcess::PageTableEntry *pte,
+            const KfdProcess::ResolvedBacking *backing) -> HostAccessOutcome {
+          const pid_t client_pid = entry ? entry->client_pid : 0;
+          if (pte) {
+            if (pte->host_ptr == nullptr)
+              return {HostAccessResult::UNRESOLVED, client_pid};
+            fn(pte->host_ptr);
+            return {HostAccessResult::ACCESSED, client_pid};
+          }
+          if (backing) {
+            if (!backing->gpu_accessible)
+              return {HostAccessResult::INACCESSIBLE, client_pid};
+            fn(backing->page_base);
+            return {HostAccessResult::ACCESSED, client_pid};
+          }
+          if (!passthrough_ || addr >= kUserSpaceLimit)
+            return {HostAccessResult::UNRESOLVED, client_pid};
+          auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
+          if (page == nullptr)
+            return {HostAccessResult::UNRESOLVED, client_pid};
+          fn(page);
+          return {HostAccessResult::ACCESSED, client_pid};
         });
-    if (page_table_status != 0)
-      return page_table_status > 0 ? HostAccessResult::ACCESSED : HostAccessResult::UNRESOLVED;
-
-    std::optional<KfdProcess::ResolvedBacking> backing = resolve_process_backing(addr, size, vmid);
-    if (backing) {
-      if (!backing->gpu_accessible)
-        return HostAccessResult::INACCESSIBLE;
-      fn(backing->page_base);
-      return HostAccessResult::ACCESSED;
-    }
-
-    if (!passthrough_ || addr >= kUserSpaceLimit)
-      return HostAccessResult::UNRESOLVED;
-    auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
-    if (page == nullptr)
-      return HostAccessResult::UNRESOLVED;
-    fn(page);
-    return HostAccessResult::ACCESSED;
   }
 
-  HostAccessResult read_mapped(uint64_t addr, void *dst, size_t len, uint32_t vmid) const {
+  HostAccessOutcome read_mapped(uint64_t addr, void *dst, size_t len, uint32_t vmid) const {
     assert((addr & PAGE_MASK) + len <= PAGE_SIZE);
     return with_host_ptr(addr, len, vmid, [&](const uint8_t *page) {
       std::memcpy(dst, page + (addr & PAGE_MASK), len);
     });
   }
 
-  HostAccessResult write_mapped(uint64_t addr, const void *src, size_t len, uint32_t vmid) {
+  HostAccessOutcome write_mapped(uint64_t addr, const void *src, size_t len, uint32_t vmid) {
     assert((addr & PAGE_MASK) + len <= PAGE_SIZE);
     return with_host_ptr(addr, len, vmid,
                          [&](uint8_t *page) { std::memcpy(page + (addr & PAGE_MASK), src, len); });
@@ -651,16 +635,6 @@ private:
     uint8_t *host_ptr = nullptr;
     with_host_ptr(addr, 1, vmid, [&](uint8_t *page) { host_ptr = page; });
     return host_ptr;
-  }
-
-  pid_t client_pid_for_vmid(uint32_t vmid) const {
-    std::shared_lock lk(vmid_mutex_);
-    auto it = vmid_table_.find(vmid);
-    return (it != vmid_table_.end()) ? it->second.client_pid : 0;
-  }
-
-  bool read_client_memory(uint64_t addr, void *dst, size_t len, uint32_t vmid) const {
-    return read_client_memory_for_pid(addr, dst, len, client_pid_for_vmid(vmid));
   }
 
   static bool read_client_memory_for_pid(uint64_t addr, void *dst, size_t len, pid_t pid) {
@@ -675,10 +649,6 @@ private:
       return false;
     }
     return true;
-  }
-
-  bool write_client_memory(uint64_t addr, const void *src, size_t len, uint32_t vmid) {
-    return write_client_memory_for_pid(addr, src, len, client_pid_for_vmid(vmid));
   }
 
   static bool write_client_memory_for_pid(uint64_t addr, const void *src, size_t len, pid_t pid) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -18,9 +18,11 @@
 #include <cassert>
 #include <cstring>
 #include <format>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <span>
 #include <string>
@@ -41,6 +43,13 @@ namespace amdgpu {
 /// issuing wave through the memory hierarchy.
 class GpuMemory : public simdojo::SparseMemory {
 public:
+  /// @brief Resolve a VMID-managed GPU range to allocation-owned backing.
+  /// @details A missing value means the range is unmanaged. A present but
+  /// inaccessible value prevents identity-pointer fallback. The returned guard
+  /// keeps accessible backing alive after VMID lookup completes.
+  using BackingResolver =
+      std::function<std::optional<KfdProcess::ResolvedBacking>(uint64_t, size_t)>;
+
   explicit GpuMemory(std::string name)
       : simdojo::SparseMemory(std::move(name)),
         // Function-static TLS translation caches may outlive a GpuMemory on a
@@ -76,6 +85,7 @@ public:
         .mutex = mu,
         .client_pid = 0,
         .generation = generation,
+        .backing_resolver = {},
     };
     // The VMID may now select a different page table even though neither page
     // table changed. Invalidate TLS entries that cached the old registration.
@@ -101,6 +111,16 @@ public:
       it->second.client_pid = client_pid;
   }
 
+  /// @brief Install the allocation-backing resolver for a registered VMID.
+  /// @details Resolver invocation is protected by vmid_mutex_ so unregistering
+  /// or replacing the VMID cannot race selection of its process backing.
+  void set_process_backing_resolver(uint32_t pid, BackingResolver resolver) {
+    std::unique_lock lk(vmid_mutex_);
+    auto it = vmid_table_.find(pid);
+    if (it != vmid_table_.end())
+      it->second.backing_resolver = std::move(resolver);
+  }
+
   /// @brief Enable passthrough for unmapped addresses (local/user-mode only).
   /// @details When true, addresses not found in the page table are treated as
   /// host pointers (GPU VA == host VA). This mirrors QEMU user-mode's identity
@@ -120,9 +140,16 @@ public:
     if (vmid == 0)
       return Mtype::RW;
     static thread_local PteCache cache;
-    return cached_walk(addr, vmid, cache, [](const KfdProcess::PageTableEntry *pte) {
-      return pte ? pte->mtype : Mtype::RW;
-    });
+    std::optional<Mtype> pte =
+        cached_walk(addr, vmid, cache, [](const KfdProcess::PageTableEntry *entry) {
+          return entry ? std::optional(entry->mtype) : std::nullopt;
+        });
+    if (pte)
+      return *pte;
+    std::optional<KfdProcess::ResolvedBacking> backing = resolve_process_backing(addr, 1, vmid);
+    if (backing && backing->gpu_accessible)
+      return backing->mtype;
+    return Mtype::RW;
   }
 
   uint32_t fetch32(uint64_t addr, uint32_t vmid = 0) const { return read32(addr, vmid); }
@@ -192,6 +219,17 @@ public:
       return;
     }
 
+    if (entry.backing_resolver) {
+      std::optional<KfdProcess::ResolvedBacking> backing = entry.backing_resolver(addr, size);
+      if (backing) {
+        if (backing->gpu_accessible)
+          atomic_rmw_mapped(addr, backing->page_base, fn);
+        else
+          atomic_rmw_fallback(addr, size, entry.client_pid, fn);
+        return;
+      }
+    }
+
     atomic_rmw_unmapped(addr, size, entry.client_pid, fn);
   }
 
@@ -218,8 +256,14 @@ public:
     std::shared_lock page_table_lock(*entry.mutex);
     const uint64_t page = addr >> PAGE_SHIFT;
     auto page_entry = entry.page_table->find(page);
-    if (page_entry == entry.page_table->end())
+    if (page_entry == entry.page_table->end()) {
+      page_table_lock.unlock();
+      vmid_lock.unlock();
+      std::optional<KfdProcess::ResolvedBacking> backing = resolve_process_backing(addr, 1, vmid);
+      if (backing && backing->gpu_accessible)
+        return {reinterpret_cast<uint64_t>(backing->range_base), backing->range_size};
       return {0, 0};
+    }
 
     uint64_t first_page = page;
     uint8_t *first_host_page = page_entry->second.host_ptr;
@@ -418,6 +462,7 @@ private:
     std::shared_mutex *mutex = nullptr;
     pid_t client_pid = 0;
     const uint64_t *generation = nullptr;
+    BackingResolver backing_resolver;
   };
 
   struct PteCache {
@@ -481,7 +526,20 @@ private:
     return fn(cache.found ? &cache.pte : nullptr);
   }
 
-  template <typename F> bool with_host_ptr(uint64_t addr, uint32_t vmid, F &&fn) const {
+  std::optional<KfdProcess::ResolvedBacking> resolve_process_backing(uint64_t addr, size_t size,
+                                                                     uint32_t vmid) const {
+    if (vmid == 0)
+      return std::nullopt;
+
+    std::shared_lock lock(vmid_mutex_);
+    std::unordered_map<uint32_t, VmidEntry>::const_iterator it = vmid_table_.find(vmid);
+    if (it == vmid_table_.end() || !it->second.backing_resolver)
+      return std::nullopt;
+    return it->second.backing_resolver(addr, size);
+  }
+
+  template <typename F>
+  bool with_host_ptr(uint64_t addr, size_t size, uint32_t vmid, F &&fn) const {
     if (vmid == 0) {
       auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
       if (!passthrough_ || addr >= kUserSpaceLimit || page == nullptr)
@@ -491,41 +549,53 @@ private:
     }
 
     static thread_local PteCache cache;
-    return cached_walk(addr, vmid, cache, [&](const KfdProcess::PageTableEntry *pte) {
-      if (pte) {
-        if (pte->host_ptr == nullptr)
-          return false;
-        fn(pte->host_ptr);
-        return true;
-      }
-      if (passthrough_ && addr < kUserSpaceLimit) {
-        auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
-        if (page == nullptr)
-          return false;
-        fn(page);
-        return true;
-      }
+    const int page_table_status =
+        cached_walk(addr, vmid, cache, [&](const KfdProcess::PageTableEntry *pte) {
+          if (!pte)
+            return 0;
+          if (pte->host_ptr == nullptr)
+            return -1;
+          fn(pte->host_ptr);
+          return 1;
+        });
+    if (page_table_status != 0)
+      return page_table_status > 0;
+
+    std::optional<KfdProcess::ResolvedBacking> backing = resolve_process_backing(addr, size, vmid);
+    if (backing) {
+      if (!backing->gpu_accessible)
+        return false;
+      fn(backing->page_base);
+      return true;
+    }
+
+    if (!passthrough_ || addr >= kUserSpaceLimit)
       return false;
-    });
+    auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
+    if (page == nullptr)
+      return false;
+    fn(page);
+    return true;
   }
 
   bool read_mapped(uint64_t addr, void *dst, size_t len, uint32_t vmid) const {
     if ((addr & PAGE_MASK) + len > PAGE_SIZE)
       return false;
-    return with_host_ptr(
-        addr, vmid, [&](const uint8_t *page) { std::memcpy(dst, page + (addr & PAGE_MASK), len); });
+    return with_host_ptr(addr, len, vmid, [&](const uint8_t *page) {
+      std::memcpy(dst, page + (addr & PAGE_MASK), len);
+    });
   }
 
   bool write_mapped(uint64_t addr, const void *src, size_t len, uint32_t vmid) {
     if ((addr & PAGE_MASK) + len > PAGE_SIZE)
       return false;
-    return with_host_ptr(addr, vmid,
+    return with_host_ptr(addr, len, vmid,
                          [&](uint8_t *page) { std::memcpy(page + (addr & PAGE_MASK), src, len); });
   }
 
   uint8_t *translate(uint64_t addr, uint32_t vmid) const {
     uint8_t *host_ptr = nullptr;
-    with_host_ptr(addr, vmid, [&](uint8_t *page) { host_ptr = page; });
+    with_host_ptr(addr, 1, vmid, [&](uint8_t *page) { host_ptr = page; });
     return host_ptr;
   }
 

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -562,7 +562,7 @@ TEST(GpuMemoryTest, ReregisterProcessInvalidatesThreadLocalTranslationCaches) {
   EXPECT_EQ(memory.pte_mtype(kAddr, kPid), amdgpu::Mtype::CC);
 }
 
-TEST(GpuMemoryThreadingTest, UnregisterWaitsForBackingResolution) {
+TEST(GpuMemoryThreadingTest, BackingResolutionKeepsVmidAndPageTableLocked) {
   amdgpu::GpuMemory memory("memory");
   constexpr uint32_t kPid = 7;
   constexpr uint64_t kAddr = 0x40000000;
@@ -581,6 +581,11 @@ TEST(GpuMemoryThreadingTest, UnregisterWaitsForBackingResolution) {
 
   std::thread reader([&] { EXPECT_EQ(memory.resolve_host_ptr(kAddr, kPid), nullptr); });
   resolver_entered.arrive_and_wait();
+
+  const bool acquired_page_table_lock = process.page_table_mutex_.try_lock();
+  if (acquired_page_table_lock)
+    process.page_table_mutex_.unlock();
+  EXPECT_FALSE(acquired_page_table_lock);
 
   std::promise<void> unregister_complete;
   std::future<void> unregister_result = unregister_complete.get_future();

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -38,6 +38,7 @@ RJ_DIAGNOSTIC_POP
 #include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <future>
 #include <limits>
 #include <memory>
 #include <new>
@@ -559,6 +560,40 @@ TEST(GpuMemoryTest, ReregisterProcessInvalidatesThreadLocalTranslationCaches) {
   EXPECT_EQ(memory.resolve_host_ptr(kAddr, kPid), second_page.data());
   EXPECT_EQ(memory.read8(kAddr, kPid), second_page[kOffset]);
   EXPECT_EQ(memory.pte_mtype(kAddr, kPid), amdgpu::Mtype::CC);
+}
+
+TEST(GpuMemoryThreadingTest, UnregisterWaitsForBackingResolution) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kAddr = 0x40000000;
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  std::barrier resolver_entered(2);
+  std::barrier release_resolver(2);
+  memory.set_process_backing_resolver(
+      kPid, [&](uint64_t, size_t) -> std::optional<KfdProcess::ResolvedBacking> {
+        resolver_entered.arrive_and_wait();
+        release_resolver.arrive_and_wait();
+        return std::nullopt;
+      });
+
+  std::thread reader([&] { EXPECT_EQ(memory.resolve_host_ptr(kAddr, kPid), nullptr); });
+  resolver_entered.arrive_and_wait();
+
+  std::promise<void> unregister_complete;
+  std::future<void> unregister_result = unregister_complete.get_future();
+  std::thread unregister([&] {
+    memory.unregister_process(kPid);
+    unregister_complete.set_value();
+  });
+
+  EXPECT_EQ(unregister_result.wait_for(std::chrono::milliseconds(50)), std::future_status::timeout);
+  release_resolver.arrive_and_wait();
+  reader.join();
+  unregister.join();
+  EXPECT_EQ(unregister_result.wait_for(std::chrono::seconds(0)), std::future_status::ready);
 }
 
 TEST(GpuMemoryTest, PageTableEntryMutationsInvalidateCachedPtes) {

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -872,6 +872,159 @@ TEST(GpuMemoryTest, RegisteredVmidBlockMissUsesClientMemory) {
   EXPECT_TRUE(std::equal(replacement.begin(), replacement.end(), mapping.data + kAccessOffset));
 }
 
+TEST(GpuMemoryTest, VmidReadsDistinguishAllBackingStates) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr size_t kPageSize = KfdProcess::kPageSize;
+  constexpr size_t kMappingSize = 3 * kPageSize;
+  constexpr uint32_t kAccessibleBackingValue = 0x11111111;
+  constexpr uint32_t kAccessibleClientValue = 0xaaaaaaaa;
+  constexpr uint32_t kUnmanagedClientValue = 0x22222222;
+  constexpr uint32_t kInaccessibleClientValue = 0xbbbbbbbb;
+  constexpr uint32_t kInaccessibleSparseValue = 0x33333333;
+
+  void *raw_mapping =
+      mmap(nullptr, kMappingSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw_mapping, MAP_FAILED);
+  struct Mapping {
+    uint8_t *data = nullptr;
+    size_t size = 0;
+    ~Mapping() { munmap(data, size); }
+  } mapping{static_cast<uint8_t *>(raw_mapping), kMappingSize};
+
+  const uint64_t accessible_va = reinterpret_cast<uint64_t>(mapping.data);
+  const uint64_t inaccessible_va = accessible_va + kPageSize;
+  const uint64_t unmanaged_va = inaccessible_va + kPageSize;
+  std::memcpy(mapping.data, &kAccessibleClientValue, sizeof(kAccessibleClientValue));
+  std::memcpy(mapping.data + kPageSize, &kInaccessibleClientValue,
+              sizeof(kInaccessibleClientValue));
+  std::memcpy(mapping.data + 2 * kPageSize, &kUnmanagedClientValue, sizeof(kUnmanagedClientValue));
+
+  std::array<uint8_t, kPageSize> accessible_backing{};
+  std::array<uint8_t, kPageSize> inaccessible_backing{};
+  std::memcpy(accessible_backing.data(), &kAccessibleBackingValue, sizeof(kAccessibleBackingValue));
+
+  KfdProcess process(kPid);
+  {
+    std::lock_guard<std::mutex> lock(process.alloc_mutex_);
+    KfdProcess::GpuAllocation accessible{};
+    accessible.handle = 1;
+    accessible.gpu_va = accessible_va;
+    accessible.size = kPageSize;
+    accessible.host_ptr = accessible_backing.data();
+    accessible.permanent_backing = true;
+    accessible.mapped_to_gpu = true;
+    process.allocations_.emplace(accessible.handle, std::move(accessible));
+
+    KfdProcess::GpuAllocation inaccessible{};
+    inaccessible.handle = 2;
+    inaccessible.gpu_va = inaccessible_va;
+    inaccessible.size = kPageSize;
+    inaccessible.host_ptr = inaccessible_backing.data();
+    inaccessible.permanent_backing = true;
+    process.allocations_.emplace(inaccessible.handle, std::move(inaccessible));
+    process.refresh_backing_ranges_locked();
+  }
+
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+  memory.set_process_client_pid(kPid, getpid());
+  memory.set_process_backing_resolver(
+      kPid, [&process](uint64_t gpu_va, size_t size) -> std::optional<KfdProcess::ResolvedBacking> {
+        return process.resolve_backing(gpu_va, size);
+      });
+  memory.write32(inaccessible_va, kInaccessibleSparseValue);
+
+  auto expect_scalar_and_block_read = [&](uint64_t gpu_va, uint32_t expected) {
+    EXPECT_EQ(memory.read32(gpu_va, kPid), expected);
+    uint32_t block_value = 0;
+    memory.read_block(
+        gpu_va, std::span<uint8_t>(reinterpret_cast<uint8_t *>(&block_value), sizeof(block_value)),
+        kPid);
+    EXPECT_EQ(block_value, expected);
+  };
+  expect_scalar_and_block_read(accessible_va, kAccessibleBackingValue);
+  expect_scalar_and_block_read(unmanaged_va, kUnmanagedClientValue);
+  expect_scalar_and_block_read(inaccessible_va, kInaccessibleSparseValue);
+}
+
+TEST(GpuMemoryTest, InaccessibleManagedRangeNeverWritesClientMemory) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr size_t kPageSize = KfdProcess::kPageSize;
+  constexpr size_t kMappingSize = 2 * kPageSize;
+  constexpr uint32_t kClientValue = 0x11111111;
+  constexpr uint32_t kInitialSparseValue = 0x22222222;
+  constexpr uint32_t kScalarWriteValue = 0x33333333;
+  constexpr uint32_t kBlockWriteValue = 0x44444444;
+
+  void *raw_mapping =
+      mmap(nullptr, kMappingSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw_mapping, MAP_FAILED);
+  struct Mapping {
+    uint8_t *data = nullptr;
+    size_t size = 0;
+    ~Mapping() { munmap(data, size); }
+  } mapping{static_cast<uint8_t *>(raw_mapping), kMappingSize};
+  const uint64_t allocation_va = reinterpret_cast<uint64_t>(mapping.data);
+  const uint64_t cross_page_va = allocation_va + kPageSize - 2;
+  std::memcpy(reinterpret_cast<void *>(cross_page_va), &kClientValue, sizeof(kClientValue));
+
+  std::array<uint8_t, kMappingSize> backing{};
+  KfdProcess process(kPid);
+  {
+    std::lock_guard<std::mutex> lock(process.alloc_mutex_);
+    KfdProcess::GpuAllocation allocation{};
+    allocation.handle = 1;
+    allocation.gpu_va = allocation_va;
+    allocation.size = kMappingSize;
+    allocation.host_ptr = backing.data();
+    allocation.permanent_backing = true;
+    process.allocations_.emplace(allocation.handle, std::move(allocation));
+    process.refresh_backing_ranges_locked();
+  }
+
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+  memory.set_process_client_pid(kPid, getpid());
+  memory.set_process_backing_resolver(
+      kPid,
+      [&process](uint64_t address, size_t size) -> std::optional<KfdProcess::ResolvedBacking> {
+        return process.resolve_backing(address, size);
+      });
+  memory.write32(cross_page_va, kInitialSparseValue);
+  EXPECT_EQ(memory.read32(cross_page_va, kPid), kInitialSparseValue);
+
+  memory.write32(cross_page_va, kScalarWriteValue, kPid);
+  uint32_t client_value = 0;
+  std::memcpy(&client_value, reinterpret_cast<void *>(cross_page_va), sizeof(client_value));
+  EXPECT_EQ(client_value, kClientValue);
+  EXPECT_EQ(memory.read32(cross_page_va), kScalarWriteValue);
+
+  memory.write_block(cross_page_va,
+                     std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(&kBlockWriteValue),
+                                              sizeof(kBlockWriteValue)),
+                     kPid);
+  std::memcpy(&client_value, reinterpret_cast<void *>(cross_page_va), sizeof(client_value));
+  EXPECT_EQ(client_value, kClientValue);
+  EXPECT_EQ(memory.read32(cross_page_va), kBlockWriteValue);
+
+  std::memcpy(mapping.data, &kClientValue, sizeof(kClientValue));
+  memory.write32(allocation_va, kBlockWriteValue);
+  memory.atomic_rmw(
+      allocation_va, sizeof(uint32_t),
+      [](uint8_t *storage) {
+        uint32_t value = 0;
+        std::memcpy(&value, storage, sizeof(value));
+        ++value;
+        std::memcpy(storage, &value, sizeof(value));
+      },
+      kPid);
+  std::memcpy(&client_value, mapping.data, sizeof(client_value));
+  EXPECT_EQ(client_value, kClientValue);
+  EXPECT_EQ(memory.read32(allocation_va), kBlockWriteValue + 1);
+}
+
 TEST(VmLifecycleTest, CreateAndDestroy) {
   std::string json = R"({"max_ticks":10000,"num_threads":1,
     "vm":{"arch":"cdna3"},

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -803,6 +803,66 @@ TEST(RemoteDriverMmapTest, RejectsMappingLargerThanReceivedBacking) {
   EXPECT_EQ(errno, EINVAL);
 }
 
+TEST(RemoteDriverMmapTest, PartialFixedMappingPreservesWholeReplacedPage) {
+  int sv[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << strerror(errno);
+
+  constexpr size_t kPageSize = 4096;
+  int backing_fd = memfd_create("remote_partial_mmap_test", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+  ASSERT_GE(backing_fd, 0);
+  ASSERT_EQ(ftruncate(backing_fd, kPageSize), 0);
+  ASSERT_EQ(fcntl(backing_fd, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW), 0);
+
+  uint8_t *reservation = static_cast<uint8_t *>(
+      ::mmap(nullptr, kPageSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  ASSERT_NE(reservation, MAP_FAILED);
+  std::memset(reservation, 0xA5, kPageSize);
+  reservation[0] = 0x11;
+
+  std::jthread server([server_fd = sv[1], backing_fd] {
+    constexpr std::array<size_t, 2> expected_lengths = {1, 4096};
+    for (size_t expected_length : expected_lengths) {
+      rocjitsu::RpcHeader request_header{};
+      ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, &request_header, sizeof(request_header)));
+      ASSERT_EQ(request_header.opcode, rocjitsu::RPC_MMAP);
+      ASSERT_EQ(request_header.payload_bytes, sizeof(rocjitsu::RpcMmapRequest));
+      rocjitsu::RpcMmapRequest request{};
+      ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, &request, sizeof(request)));
+      EXPECT_EQ(request.length, expected_length);
+
+      rocjitsu::RpcHeader response_header{};
+      response_header.opcode = rocjitsu::RPC_MMAP;
+      response_header.request_id = request_header.request_id;
+      response_header.payload_bytes = sizeof(rocjitsu::RpcMmapResponse);
+      rocjitsu::RpcMmapResponse response{};
+      std::array<uint8_t, sizeof(response_header) + sizeof(response)> response_buffer{};
+      std::memcpy(response_buffer.data(), &response_header, sizeof(response_header));
+      std::memcpy(response_buffer.data() + sizeof(response_header), &response, sizeof(response));
+      ASSERT_GT(rocjitsu::rpc_send_msg(server_fd, response_buffer.data(), response_buffer.size(),
+                                       &backing_fd, 1),
+                0);
+    }
+    ::close(backing_fd);
+    ::close(server_fd);
+  });
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+  ASSERT_EQ(driver.mmap(reservation, 1, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
+                        /*offset=*/0),
+            reservation);
+  EXPECT_EQ(reservation[0], 0x11);
+  EXPECT_EQ(reservation[1], 0xA5);
+  EXPECT_EQ(reservation[kPageSize - 1], 0xA5);
+
+  ASSERT_EQ(driver.mmap(reservation, kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
+                        /*offset=*/0),
+            reservation);
+  EXPECT_EQ(reservation[0], 0x11);
+  EXPECT_EQ(reservation[1], 0xA5);
+  EXPECT_EQ(reservation[kPageSize - 1], 0xA5);
+  EXPECT_EQ(syscall(SYS_munmap, reservation, kPageSize), 0);
+}
+
 TEST(RemoteDriverEmbeddedArrayTest, WaitEventsSerializesEventsAcrossBufferGrowth) {
   int sv[2];
   ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << strerror(errno);

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -808,6 +808,7 @@ TEST(RemoteDriverMmapTest, PartialFixedMappingPreservesWholeReplacedPage) {
   ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << strerror(errno);
 
   constexpr size_t kPageSize = 4096;
+  constexpr uint64_t kHandle = 7;
   int backing_fd = memfd_create("remote_partial_mmap_test", MFD_CLOEXEC | MFD_ALLOW_SEALING);
   ASSERT_GE(backing_fd, 0);
   ASSERT_EQ(ftruncate(backing_fd, kPageSize), 0);
@@ -820,6 +821,30 @@ TEST(RemoteDriverMmapTest, PartialFixedMappingPreservesWholeReplacedPage) {
   reservation[0] = 0x11;
 
   std::jthread server([server_fd = sv[1], backing_fd] {
+    rocjitsu::RpcHeader alloc_header{};
+    ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, &alloc_header, sizeof(alloc_header)));
+    ASSERT_EQ(alloc_header.opcode, rocjitsu::RPC_IOCTL);
+    std::vector<uint8_t> alloc_payload(alloc_header.payload_bytes);
+    ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, alloc_payload.data(), alloc_payload.size()));
+    auto *alloc_request = reinterpret_cast<rocjitsu::RpcIoctlRequest *>(alloc_payload.data());
+    ASSERT_EQ(alloc_request->ioctl_cmd, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU);
+    auto *alloc_args = reinterpret_cast<kfd_ioctl_alloc_memory_of_gpu_args *>(
+        alloc_payload.data() + sizeof(*alloc_request));
+    alloc_args->handle = kHandle;
+    alloc_args->mmap_offset = kHandle << 12;
+
+    rocjitsu::RpcHeader alloc_response{};
+    alloc_response.opcode = rocjitsu::RPC_IOCTL;
+    alloc_response.request_id = alloc_header.request_id;
+    alloc_response.payload_bytes = sizeof(*alloc_args);
+    std::array<uint8_t, sizeof(alloc_response) + sizeof(*alloc_args)> alloc_response_buffer{};
+    std::memcpy(alloc_response_buffer.data(), &alloc_response, sizeof(alloc_response));
+    std::memcpy(alloc_response_buffer.data() + sizeof(alloc_response), alloc_args,
+                sizeof(*alloc_args));
+    ASSERT_GT(rocjitsu::rpc_send_msg(server_fd, alloc_response_buffer.data(),
+                                     alloc_response_buffer.size(), &backing_fd, 1),
+              0);
+
     constexpr std::array<size_t, 2> expected_lengths = {1, 4096};
     for (size_t expected_length : expected_lengths) {
       rocjitsu::RpcHeader request_header{};
@@ -847,19 +872,144 @@ TEST(RemoteDriverMmapTest, PartialFixedMappingPreservesWholeReplacedPage) {
   });
 
   rocjitsu::RemoteDriver driver(sv[0]);
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = reinterpret_cast<uint64_t>(reservation);
+  alloc.size = kPageSize;
+  alloc.gpu_id = kGpuId;
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(driver.ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+
   ASSERT_EQ(driver.mmap(reservation, 1, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
-                        /*offset=*/0),
+                        static_cast<off_t>(alloc.mmap_offset)),
             reservation);
   EXPECT_EQ(reservation[0], 0x11);
   EXPECT_EQ(reservation[1], 0xA5);
   EXPECT_EQ(reservation[kPageSize - 1], 0xA5);
 
+  ASSERT_EQ(syscall(SYS_munmap, reservation, kPageSize), 0);
+  ASSERT_EQ(::mmap(reservation, kPageSize, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0),
+            reservation);
+  std::memset(reservation, 0xCC, kPageSize);
+
   ASSERT_EQ(driver.mmap(reservation, kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
-                        /*offset=*/0),
+                        static_cast<off_t>(alloc.mmap_offset)),
             reservation);
   EXPECT_EQ(reservation[0], 0x11);
   EXPECT_EQ(reservation[1], 0xA5);
   EXPECT_EQ(reservation[kPageSize - 1], 0xA5);
+  EXPECT_EQ(syscall(SYS_munmap, reservation, kPageSize), 0);
+}
+
+TEST(RemoteDriverMmapTest, GpuAuthoritativeBackingSurvivesClientMmap) {
+  int sv[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << strerror(errno);
+
+  constexpr size_t kPageSize = 4096;
+  constexpr uint64_t kHandle = 7;
+  constexpr uint32_t kStaleClientValue = 0x11111111;
+  constexpr uint32_t kGpuBackingValue = 0x22222222;
+  int backing_fd = memfd_create("remote_authoritative_mmap_test", MFD_CLOEXEC);
+  ASSERT_GE(backing_fd, 0);
+  ASSERT_EQ(ftruncate(backing_fd, kPageSize), 0);
+
+  uint32_t *reservation = static_cast<uint32_t *>(
+      ::mmap(nullptr, kPageSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  ASSERT_NE(reservation, MAP_FAILED);
+  *reservation = kStaleClientValue;
+
+  std::jthread server([server_fd = sv[1], backing_fd, reservation, kHandle, kGpuBackingValue] {
+    rocjitsu::RpcHeader alloc_header{};
+    ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, &alloc_header, sizeof(alloc_header)));
+    ASSERT_EQ(alloc_header.opcode, rocjitsu::RPC_IOCTL);
+    std::vector<uint8_t> alloc_payload(alloc_header.payload_bytes);
+    ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, alloc_payload.data(), alloc_payload.size()));
+    auto *alloc_request = reinterpret_cast<rocjitsu::RpcIoctlRequest *>(alloc_payload.data());
+    ASSERT_EQ(alloc_request->ioctl_cmd, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU);
+    auto *alloc_args = reinterpret_cast<kfd_ioctl_alloc_memory_of_gpu_args *>(
+        alloc_payload.data() + sizeof(*alloc_request));
+    alloc_args->handle = kHandle;
+    alloc_args->mmap_offset = kHandle << 12;
+
+    rocjitsu::RpcHeader alloc_response{};
+    alloc_response.opcode = rocjitsu::RPC_IOCTL;
+    alloc_response.request_id = alloc_header.request_id;
+    alloc_response.payload_bytes = sizeof(*alloc_args);
+    std::array<uint8_t, sizeof(alloc_response) + sizeof(*alloc_args)> alloc_response_buffer{};
+    std::memcpy(alloc_response_buffer.data(), &alloc_response, sizeof(alloc_response));
+    std::memcpy(alloc_response_buffer.data() + sizeof(alloc_response), alloc_args,
+                sizeof(*alloc_args));
+    ASSERT_GT(rocjitsu::rpc_send_msg(server_fd, alloc_response_buffer.data(),
+                                     alloc_response_buffer.size(), &backing_fd, 1),
+              0);
+
+    rocjitsu::RpcHeader map_header{};
+    ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, &map_header, sizeof(map_header)));
+    ASSERT_EQ(map_header.opcode, rocjitsu::RPC_IOCTL);
+    std::vector<uint8_t> map_payload(map_header.payload_bytes);
+    ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, map_payload.data(), map_payload.size()));
+    auto *map_request = reinterpret_cast<rocjitsu::RpcIoctlRequest *>(map_payload.data());
+    ASSERT_EQ(map_request->ioctl_cmd, AMDKFD_IOC_MAP_MEMORY_TO_GPU);
+    auto *map_args = reinterpret_cast<kfd_ioctl_map_memory_to_gpu_args *>(map_payload.data() +
+                                                                          sizeof(*map_request));
+    ASSERT_EQ(map_args->handle, kHandle);
+    map_args->n_success = map_args->n_devices;
+    ASSERT_EQ(pwrite(backing_fd, &kGpuBackingValue, sizeof(kGpuBackingValue), 0),
+              static_cast<ssize_t>(sizeof(kGpuBackingValue)));
+
+    rocjitsu::RpcHeader map_response{};
+    map_response.opcode = rocjitsu::RPC_IOCTL;
+    map_response.request_id = map_header.request_id;
+    map_response.payload_bytes = sizeof(*map_args);
+    ASSERT_TRUE(rocjitsu::rpc_send_exact(server_fd, &map_response, sizeof(map_response)));
+    ASSERT_TRUE(rocjitsu::rpc_send_exact(server_fd, map_args, sizeof(*map_args)));
+
+    rocjitsu::RpcHeader mmap_header{};
+    ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, &mmap_header, sizeof(mmap_header)));
+    ASSERT_EQ(mmap_header.opcode, rocjitsu::RPC_MMAP);
+    ASSERT_EQ(mmap_header.payload_bytes, sizeof(rocjitsu::RpcMmapRequest));
+    rocjitsu::RpcMmapRequest mmap_request{};
+    ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, &mmap_request, sizeof(mmap_request)));
+    EXPECT_EQ(mmap_request.addr, reinterpret_cast<uint64_t>(reservation));
+    EXPECT_EQ(mmap_request.offset, static_cast<int64_t>(kHandle << 12));
+
+    rocjitsu::RpcHeader mmap_response_header{};
+    mmap_response_header.opcode = rocjitsu::RPC_MMAP;
+    mmap_response_header.request_id = mmap_header.request_id;
+    mmap_response_header.payload_bytes = sizeof(rocjitsu::RpcMmapResponse);
+    rocjitsu::RpcMmapResponse mmap_response{.mapped_addr = mmap_request.addr};
+    std::array<uint8_t, sizeof(mmap_response_header) + sizeof(mmap_response)>
+        mmap_response_buffer{};
+    std::memcpy(mmap_response_buffer.data(), &mmap_response_header, sizeof(mmap_response_header));
+    std::memcpy(mmap_response_buffer.data() + sizeof(mmap_response_header), &mmap_response,
+                sizeof(mmap_response));
+    ASSERT_GT(rocjitsu::rpc_send_msg(server_fd, mmap_response_buffer.data(),
+                                     mmap_response_buffer.size(), &backing_fd, 1),
+              0);
+    EXPECT_EQ(::close(backing_fd), 0);
+    EXPECT_EQ(::close(server_fd), 0);
+  });
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = reinterpret_cast<uint64_t>(reservation);
+  alloc.size = kPageSize;
+  alloc.gpu_id = kGpuId;
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(driver.ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+  ASSERT_EQ(alloc.handle, kHandle);
+
+  uint32_t gpu_id = kGpuId;
+  kfd_ioctl_map_memory_to_gpu_args map{};
+  map.handle = alloc.handle;
+  map.device_ids_array_ptr = reinterpret_cast<uint64_t>(&gpu_id);
+  map.n_devices = 1;
+  ASSERT_EQ(driver.ioctl(AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), 0);
+
+  ASSERT_EQ(driver.mmap(reservation, kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
+                        static_cast<off_t>(alloc.mmap_offset)),
+            reservation);
+  EXPECT_EQ(*reservation, kGpuBackingValue);
   EXPECT_EQ(syscall(SYS_munmap, reservation, kPageSize), 0);
 }
 

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -762,6 +762,47 @@ TEST(RemoteDriverEmbeddedArrayTest, MapMemorySerializesDeviceIdsAcrossBufferGrow
   EXPECT_EQ(driver.ioctl(AMDKFD_IOC_MAP_MEMORY_TO_GPU, &args), -EINVAL);
 }
 
+TEST(RemoteDriverMmapTest, RejectsMappingLargerThanReceivedBacking) {
+  int sv[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << strerror(errno);
+
+  constexpr size_t kPageSize = 4096;
+  int backing_fd = memfd_create("remote_mmap_test", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+  ASSERT_GE(backing_fd, 0);
+  ASSERT_EQ(ftruncate(backing_fd, kPageSize), 0);
+  ASSERT_EQ(fcntl(backing_fd, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW), 0);
+
+  std::jthread server([server_fd = sv[1], backing_fd] {
+    rocjitsu::RpcHeader request_header{};
+    ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, &request_header, sizeof(request_header)));
+    ASSERT_EQ(request_header.opcode, rocjitsu::RPC_MMAP);
+    ASSERT_EQ(request_header.payload_bytes, sizeof(rocjitsu::RpcMmapRequest));
+    rocjitsu::RpcMmapRequest request{};
+    ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, &request, sizeof(request)));
+
+    rocjitsu::RpcHeader response_header{};
+    response_header.opcode = rocjitsu::RPC_MMAP;
+    response_header.request_id = request_header.request_id;
+    response_header.payload_bytes = sizeof(rocjitsu::RpcMmapResponse);
+    rocjitsu::RpcMmapResponse response{};
+    std::array<uint8_t, sizeof(response_header) + sizeof(response)> response_buffer{};
+    std::memcpy(response_buffer.data(), &response_header, sizeof(response_header));
+    std::memcpy(response_buffer.data() + sizeof(response_header), &response, sizeof(response));
+    ASSERT_GT(rocjitsu::rpc_send_msg(server_fd, response_buffer.data(), response_buffer.size(),
+                                     &backing_fd, 1),
+              0);
+    ::close(backing_fd);
+    ::close(server_fd);
+  });
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+  errno = 0;
+  void *mapping =
+      driver.mmap(nullptr, 2 * kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED, /*offset=*/0);
+  EXPECT_EQ(mapping, MAP_FAILED);
+  EXPECT_EQ(errno, EINVAL);
+}
+
 TEST(RemoteDriverEmbeddedArrayTest, WaitEventsSerializesEventsAcrossBufferGrowth) {
   int sv[2];
   ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << strerror(errno);

--- a/emulation/rocjitsu/tests/simulated_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/simulated_kfd_test.cpp
@@ -30,6 +30,7 @@ RJ_DIAGNOSTIC_POP
 
 #include <atomic>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <iterator>
 #include <map>
@@ -266,6 +267,7 @@ TEST_F(SimulatedKfdTest, PermanentVramBackingImportsAcrossPartialMappings) {
   uint8_t *reservation = static_cast<uint8_t *>(
       ::mmap(nullptr, kAllocationSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
   ASSERT_NE(reservation, MAP_FAILED);
+  std::memset(reservation, 0xA5, kPageSize);
   *reinterpret_cast<uint32_t *>(reservation) = 0x11111111u;
   *reinterpret_cast<uint32_t *>(reservation + kPageSize) = 0x22222222u;
   *reinterpret_cast<uint32_t *>(reservation + 2 * kPageSize) = 0x33333333u;
@@ -277,12 +279,16 @@ TEST_F(SimulatedKfdTest, PermanentVramBackingImportsAcrossPartialMappings) {
   alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
   ASSERT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
 
-  ASSERT_EQ(t.driver()->mmap(reservation, kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
+  ASSERT_EQ(t.driver()->mmap(reservation, 1, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
                              static_cast<off_t>(alloc.mmap_offset)),
             reservation);
+  EXPECT_EQ(reservation[1], 0x11);
+  EXPECT_EQ(reservation[kPageSize - 1], 0xA5);
   ASSERT_EQ(t.driver()->mmap(reservation, kAllocationSize, PROT_READ | PROT_WRITE,
                              MAP_SHARED | MAP_FIXED, static_cast<off_t>(alloc.mmap_offset)),
             reservation);
+  EXPECT_EQ(reservation[1], 0x11);
+  EXPECT_EQ(reservation[kPageSize - 1], 0xA5);
 
   uint32_t gpu_id = alloc.gpu_id;
   kfd_ioctl_map_memory_to_gpu_args map{};
@@ -291,6 +297,7 @@ TEST_F(SimulatedKfdTest, PermanentVramBackingImportsAcrossPartialMappings) {
   map.n_devices = 1;
   ASSERT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), 0);
   EXPECT_EQ(memory->read32(alloc.va_addr, process_id), 0x11111111u);
+  EXPECT_EQ(memory->read8(alloc.va_addr + kPageSize - 1, process_id), 0xA5);
   EXPECT_EQ(memory->read32(alloc.va_addr + kPageSize, process_id), 0x22222222u);
   EXPECT_EQ(memory->read32(alloc.va_addr + 2 * kPageSize, process_id), 0x33333333u);
 

--- a/emulation/rocjitsu/tests/simulated_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/simulated_kfd_test.cpp
@@ -288,8 +288,9 @@ TEST_F(SimulatedKfdTest, SpanningMunmapCannotConsumeDoorbellPage) {
   process->event_state_.notify_closing();
   EXPECT_EQ(t.driver()->munmap(doorbell_page, kPageSize), 0);
   process->event_state_.reset();
-  if (spanning_result != 0)
+  if (spanning_result != 0) {
     EXPECT_EQ(t.driver()->munmap(reservation, kPageSize), 0);
+  }
   EXPECT_EQ(t.driver()->close(), 0);
 }
 
@@ -326,8 +327,9 @@ TEST_F(SimulatedKfdTest, SpanningMunmapCannotConsumeEventPage) {
   EXPECT_EQ(process->event_state_.page, event_page);
 
   EXPECT_EQ(t.driver()->munmap(event_page, kPageSize), 0);
-  if (spanning_result != 0)
+  if (spanning_result != 0) {
     EXPECT_EQ(t.driver()->munmap(reservation, kPageSize), 0);
+  }
   EXPECT_EQ(t.driver()->close(), 0);
 }
 

--- a/emulation/rocjitsu/tests/simulated_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/simulated_kfd_test.cpp
@@ -584,42 +584,6 @@ TEST_F(SimulatedKfdTest, PermanentVramBackingDoesNotPrefaultLargeAllocations) {
   EXPECT_EQ(t.driver()->close(), 0);
 }
 
-TEST_F(SimulatedKfdTest, LargePermanentBackingUsesOneRangeInsteadOfPerPageEntries) {
-  rocjitsu::KfdProcess process(/*process_id=*/9);
-  constexpr uint64_t kBaseVa = 0x8000000000ULL;
-  constexpr uint64_t kLargeAllocationSize = 1ULL << 40;
-  constexpr uint64_t kPage = rocjitsu::KfdProcess::kPageSize;
-  constexpr uintptr_t kHostBase = 0x1000000000ULL;
-
-  {
-    std::lock_guard<std::mutex> lock(process.alloc_mutex_);
-    rocjitsu::KfdProcess::GpuAllocation allocation{};
-    allocation.handle = 1;
-    allocation.gpu_va = kBaseVa;
-    allocation.size = kLargeAllocationSize;
-    allocation.backing_size = kLargeAllocationSize;
-    allocation.host_ptr = reinterpret_cast<void *>(kHostBase);
-    allocation.permanent_backing = true;
-    allocation.mapped_to_gpu = true;
-    process.allocations_[allocation.handle] = allocation;
-    process.refresh_backing_ranges_locked();
-  }
-
-  auto expect_resolved = [&](uint64_t gpu_va) {
-    auto backing = process.resolve_backing(gpu_va, kPage);
-    ASSERT_TRUE(backing.has_value());
-    ASSERT_TRUE(backing->gpu_accessible);
-    EXPECT_EQ(reinterpret_cast<uintptr_t>(backing->address), kHostBase + (gpu_va - kBaseVa));
-    EXPECT_EQ(backing->range_size, kLargeAllocationSize);
-  };
-  expect_resolved(kBaseVa);
-  expect_resolved(kBaseVa + (kLargeAllocationSize / 2));
-  expect_resolved(kBaseVa + kLargeAllocationSize - kPage);
-  EXPECT_FALSE(process.resolve_backing(kBaseVa - kPage, kPage).has_value());
-  EXPECT_FALSE(process.resolve_backing(kBaseVa + kLargeAllocationSize, kPage).has_value());
-  EXPECT_TRUE(process.page_table_.empty());
-}
-
 TEST_F(SimulatedKfdTest, GuestDiscoveryOpenIsReleasedOnLastClose) {
   rj_vm_t *raw_vm = nullptr;
   ASSERT_EQ(rj_vm_create(CONFIG_PATH.c_str(), RJ_VM_MODE_LOCAL, &raw_vm), ROCJITSU_STATUS_SUCCESS);

--- a/emulation/rocjitsu/tests/simulated_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/simulated_kfd_test.cpp
@@ -174,7 +174,7 @@ TEST_F(SimulatedKfdTest, PermanentVramBackingSurvivesCpuMapLifecycle) {
   EXPECT_EQ(t.driver()->close(), 0);
 }
 
-TEST_F(SimulatedKfdTest, PermanentVramBackingTracksPartialCpuUnmapsByPage) {
+TEST_F(SimulatedKfdTest, PermanentVramBackingTracksPartialAndCrossRangeCpuUnmaps) {
   TestVM t = create_test_vm();
   ASSERT_NE(t.driver(), nullptr);
   ASSERT_GE(t.driver()->open(), 0);
@@ -220,8 +220,25 @@ TEST_F(SimulatedKfdTest, PermanentVramBackingTracksPartialCpuUnmapsByPage) {
     EXPECT_EQ(second->second, begin + kAllocationSize);
   }
 
+  ASSERT_EQ(t.driver()->munmap(mapping, kAllocationSize), 0);
+  {
+    std::lock_guard<std::mutex> lock(process->alloc_mutex_);
+    EXPECT_TRUE(process->cpu_mappings_.empty());
+  }
+
+  mapping = t.driver()->mmap(reservation, kMappingLength, PROT_READ | PROT_WRITE,
+                             MAP_SHARED | MAP_FIXED, static_cast<off_t>(alloc.mmap_offset));
+  ASSERT_EQ(mapping, reservation);
+  ASSERT_EQ(t.driver()->munmap(middle_page, kPageSize), 0);
+  ASSERT_EQ(t.driver()->munmap(middle_page, 2 * kPageSize), 0);
+  {
+    std::lock_guard<std::mutex> lock(process->alloc_mutex_);
+    ASSERT_EQ(process->cpu_mappings_.size(), 1u);
+    EXPECT_EQ(process->cpu_mappings_.begin()->first, begin);
+    EXPECT_EQ(process->cpu_mappings_.begin()->second, begin + kPageSize);
+  }
+
   ASSERT_EQ(t.driver()->munmap(mapping, 1), 0);
-  ASSERT_EQ(t.driver()->munmap(static_cast<uint8_t *>(mapping) + 2 * kPageSize, kPageSize), 0);
   {
     std::lock_guard<std::mutex> lock(process->alloc_mutex_);
     EXPECT_TRUE(process->cpu_mappings_.empty());

--- a/emulation/rocjitsu/tests/simulated_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/simulated_kfd_test.cpp
@@ -31,9 +31,14 @@ RJ_DIAGNOSTIC_POP
 #include <atomic>
 #include <cstdlib>
 #include <filesystem>
+#include <iterator>
+#include <map>
+#include <memory>
 #include <thread>
+#include <utility>
 #include <vector>
 
+#include <sys/mman.h>
 #include <unistd.h>
 
 namespace {
@@ -92,6 +97,423 @@ TEST_F(SimulatedKfdTest, OpenAndClose) {
 
   int ret = t.driver()->close();
   EXPECT_EQ(ret, 0);
+}
+
+TEST_F(SimulatedKfdTest, PermanentVramBackingSurvivesCpuMapLifecycle) {
+  auto t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  auto *vm = dynamic_cast<rocjitsu::VirtualMachine *>(t.engine->topology().root());
+  ASSERT_NE(vm, nullptr);
+  auto *memory = vm->memory();
+  ASSERT_NE(memory, nullptr);
+
+  ASSERT_GE(t.driver()->open(), 0);
+  uint32_t process_id = t.driver()->local_process_id();
+  auto process = t.driver()->find_process(process_id);
+  ASSERT_NE(process, nullptr);
+
+  constexpr size_t kPageSize = rocjitsu::KfdProcess::kPageSize;
+  void *reservation = ::mmap(nullptr, kPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(reservation, MAP_FAILED);
+
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = reinterpret_cast<uint64_t>(reservation);
+  alloc.size = kPageSize;
+  alloc.gpu_id = t.driver()->gpu_id();
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+
+  {
+    auto backing = process->resolve_backing(alloc.va_addr, alloc.size);
+    ASSERT_TRUE(backing.has_value());
+    EXPECT_FALSE(backing->gpu_accessible);
+  }
+  EXPECT_EQ(memory->resolve_host_ptr(alloc.va_addr, process_id), nullptr);
+
+  uint32_t gpu_id = alloc.gpu_id;
+  kfd_ioctl_map_memory_to_gpu_args map{};
+  map.handle = alloc.handle;
+  map.device_ids_array_ptr = reinterpret_cast<uint64_t>(&gpu_id);
+  map.n_devices = 1;
+  ASSERT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), 0);
+  ASSERT_EQ(map.n_success, 1u);
+  EXPECT_NE(memory->resolve_host_ptr(alloc.va_addr, process_id), nullptr);
+  EXPECT_TRUE(process->page_table_.empty());
+
+  constexpr uint32_t kGpuValue = 0xABCDEF01u;
+  constexpr uint32_t kCpuValue = 0x10203040u;
+  memory->write32(alloc.va_addr, kGpuValue, process_id);
+
+  void *cpu_mapping =
+      t.driver()->mmap(reservation, kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
+                       static_cast<off_t>(alloc.mmap_offset));
+  ASSERT_EQ(cpu_mapping, reservation);
+  EXPECT_EQ(*static_cast<uint32_t *>(cpu_mapping), kGpuValue);
+  *static_cast<uint32_t *>(cpu_mapping) = kCpuValue;
+  EXPECT_EQ(memory->read32(alloc.va_addr, process_id), kCpuValue);
+
+  ASSERT_EQ(t.driver()->munmap(cpu_mapping, kPageSize), 0);
+  EXPECT_EQ(memory->read32(alloc.va_addr, process_id), kCpuValue);
+
+  cpu_mapping = t.driver()->mmap(reservation, kPageSize, PROT_READ | PROT_WRITE,
+                                 MAP_SHARED | MAP_FIXED, static_cast<off_t>(alloc.mmap_offset));
+  ASSERT_EQ(cpu_mapping, reservation);
+  EXPECT_EQ(*static_cast<uint32_t *>(cpu_mapping), kCpuValue);
+  ASSERT_EQ(t.driver()->munmap(cpu_mapping, kPageSize), 0);
+
+  kfd_ioctl_unmap_memory_from_gpu_args unmap{};
+  unmap.handle = alloc.handle;
+  unmap.device_ids_array_ptr = reinterpret_cast<uint64_t>(&gpu_id);
+  unmap.n_devices = 1;
+  ASSERT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU, &unmap), 0);
+  EXPECT_EQ(memory->resolve_host_ptr(alloc.va_addr, process_id), nullptr);
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = alloc.handle;
+  EXPECT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+  EXPECT_EQ(t.driver()->close(), 0);
+}
+
+TEST_F(SimulatedKfdTest, PermanentVramBackingTracksPartialCpuUnmapsByPage) {
+  TestVM t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  ASSERT_GE(t.driver()->open(), 0);
+  const uint32_t process_id = t.driver()->local_process_id();
+  std::shared_ptr<rocjitsu::KfdProcess> process = t.driver()->find_process(process_id);
+  ASSERT_NE(process, nullptr);
+
+  constexpr size_t kPageSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr size_t kAllocationSize = 3 * kPageSize;
+  constexpr size_t kMappingLength = 2 * kPageSize + 1;
+  void *reservation =
+      ::mmap(nullptr, kAllocationSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(reservation, MAP_FAILED);
+
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = reinterpret_cast<uint64_t>(reservation);
+  alloc.size = kAllocationSize;
+  alloc.gpu_id = t.driver()->gpu_id();
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+
+  void *mapping = t.driver()->mmap(reservation, kMappingLength, PROT_READ | PROT_WRITE,
+                                   MAP_SHARED | MAP_FIXED, static_cast<off_t>(alloc.mmap_offset));
+  ASSERT_EQ(mapping, reservation);
+  const uintptr_t begin = reinterpret_cast<uintptr_t>(mapping);
+  {
+    std::lock_guard<std::mutex> lock(process->alloc_mutex_);
+    ASSERT_EQ(process->cpu_mappings_.size(), 1u);
+    EXPECT_EQ(process->cpu_mappings_.begin()->first, begin);
+    EXPECT_EQ(process->cpu_mappings_.begin()->second, begin + kAllocationSize);
+  }
+
+  void *middle_page = static_cast<uint8_t *>(mapping) + kPageSize;
+  ASSERT_EQ(t.driver()->munmap(middle_page, kPageSize), 0);
+  {
+    std::lock_guard<std::mutex> lock(process->alloc_mutex_);
+    ASSERT_EQ(process->cpu_mappings_.size(), 2u);
+    std::map<uintptr_t, uintptr_t>::const_iterator first = process->cpu_mappings_.begin();
+    EXPECT_EQ(first->first, begin);
+    EXPECT_EQ(first->second, begin + kPageSize);
+    std::map<uintptr_t, uintptr_t>::const_iterator second = std::next(first);
+    EXPECT_EQ(second->first, begin + 2 * kPageSize);
+    EXPECT_EQ(second->second, begin + kAllocationSize);
+  }
+
+  ASSERT_EQ(t.driver()->munmap(mapping, 1), 0);
+  ASSERT_EQ(t.driver()->munmap(static_cast<uint8_t *>(mapping) + 2 * kPageSize, kPageSize), 0);
+  {
+    std::lock_guard<std::mutex> lock(process->alloc_mutex_);
+    EXPECT_TRUE(process->cpu_mappings_.empty());
+  }
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = alloc.handle;
+  EXPECT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+  EXPECT_EQ(t.driver()->close(), 0);
+}
+
+TEST_F(SimulatedKfdTest, PermanentVramBackingImportsAcrossPartialMappings) {
+  TestVM t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  rocjitsu::VirtualMachine *vm =
+      dynamic_cast<rocjitsu::VirtualMachine *>(t.engine->topology().root());
+  ASSERT_NE(vm, nullptr);
+  rocjitsu::amdgpu::GpuMemory *memory = vm->memory();
+  ASSERT_NE(memory, nullptr);
+  ASSERT_GE(t.driver()->open(), 0);
+  const uint32_t process_id = t.driver()->local_process_id();
+
+  constexpr size_t kPageSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr size_t kAllocationSize = 3 * kPageSize;
+  uint8_t *reservation = static_cast<uint8_t *>(
+      ::mmap(nullptr, kAllocationSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  ASSERT_NE(reservation, MAP_FAILED);
+  *reinterpret_cast<uint32_t *>(reservation) = 0x11111111u;
+  *reinterpret_cast<uint32_t *>(reservation + kPageSize) = 0x22222222u;
+  *reinterpret_cast<uint32_t *>(reservation + 2 * kPageSize) = 0x33333333u;
+
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = reinterpret_cast<uint64_t>(reservation);
+  alloc.size = kAllocationSize;
+  alloc.gpu_id = t.driver()->gpu_id();
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+
+  ASSERT_EQ(t.driver()->mmap(reservation, kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
+                             static_cast<off_t>(alloc.mmap_offset)),
+            reservation);
+  ASSERT_EQ(t.driver()->mmap(reservation, kAllocationSize, PROT_READ | PROT_WRITE,
+                             MAP_SHARED | MAP_FIXED, static_cast<off_t>(alloc.mmap_offset)),
+            reservation);
+
+  uint32_t gpu_id = alloc.gpu_id;
+  kfd_ioctl_map_memory_to_gpu_args map{};
+  map.handle = alloc.handle;
+  map.device_ids_array_ptr = reinterpret_cast<uint64_t>(&gpu_id);
+  map.n_devices = 1;
+  ASSERT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), 0);
+  EXPECT_EQ(memory->read32(alloc.va_addr, process_id), 0x11111111u);
+  EXPECT_EQ(memory->read32(alloc.va_addr + kPageSize, process_id), 0x22222222u);
+  EXPECT_EQ(memory->read32(alloc.va_addr + 2 * kPageSize, process_id), 0x33333333u);
+
+  ASSERT_EQ(t.driver()->munmap(reservation, kAllocationSize), 0);
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = alloc.handle;
+  EXPECT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+  EXPECT_EQ(t.driver()->close(), 0);
+}
+
+TEST_F(SimulatedKfdTest, GpuUsePermanentlyMakesVramBackingAuthoritative) {
+  TestVM t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  rocjitsu::VirtualMachine *vm =
+      dynamic_cast<rocjitsu::VirtualMachine *>(t.engine->topology().root());
+  ASSERT_NE(vm, nullptr);
+  rocjitsu::amdgpu::GpuMemory *memory = vm->memory();
+  ASSERT_NE(memory, nullptr);
+  ASSERT_GE(t.driver()->open(), 0);
+  const uint32_t process_id = t.driver()->local_process_id();
+
+  constexpr size_t kPageSize = rocjitsu::KfdProcess::kPageSize;
+  uint32_t *reservation = static_cast<uint32_t *>(
+      ::mmap(nullptr, kPageSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  ASSERT_NE(reservation, MAP_FAILED);
+  *reservation = 0x11111111u;
+
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = reinterpret_cast<uint64_t>(reservation);
+  alloc.size = kPageSize;
+  alloc.gpu_id = t.driver()->gpu_id();
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+
+  uint32_t gpu_id = alloc.gpu_id;
+  kfd_ioctl_map_memory_to_gpu_args map{};
+  map.handle = alloc.handle;
+  map.device_ids_array_ptr = reinterpret_cast<uint64_t>(&gpu_id);
+  map.n_devices = 1;
+  ASSERT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), 0);
+  memory->write32(alloc.va_addr, 0x22222222u, process_id);
+
+  kfd_ioctl_unmap_memory_from_gpu_args unmap{};
+  unmap.handle = alloc.handle;
+  unmap.device_ids_array_ptr = reinterpret_cast<uint64_t>(&gpu_id);
+  unmap.n_devices = 1;
+  ASSERT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU, &unmap), 0);
+
+  void *mapping = t.driver()->mmap(reservation, kPageSize, PROT_READ | PROT_WRITE,
+                                   MAP_SHARED | MAP_FIXED, static_cast<off_t>(alloc.mmap_offset));
+  ASSERT_EQ(mapping, reservation);
+  EXPECT_EQ(*static_cast<uint32_t *>(mapping), 0x22222222u);
+
+  ASSERT_EQ(t.driver()->munmap(mapping, kPageSize), 0);
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = alloc.handle;
+  EXPECT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+  EXPECT_EQ(t.driver()->close(), 0);
+}
+
+TEST_F(SimulatedKfdTest, IpcExportUpdatesPermanentBackingMtype) {
+  TestVM t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  rocjitsu::VirtualMachine *vm =
+      dynamic_cast<rocjitsu::VirtualMachine *>(t.engine->topology().root());
+  ASSERT_NE(vm, nullptr);
+  rocjitsu::amdgpu::GpuMemory *memory = vm->memory();
+  ASSERT_NE(memory, nullptr);
+  ASSERT_GE(t.driver()->open(), 0);
+  const uint32_t process_id = t.driver()->local_process_id();
+
+  constexpr uint64_t kGpuVa = 0x7100000000ULL;
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = kGpuVa;
+  alloc.size = rocjitsu::KfdProcess::kPageSize;
+  alloc.gpu_id = t.driver()->gpu_id();
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+
+  uint32_t gpu_id = alloc.gpu_id;
+  kfd_ioctl_map_memory_to_gpu_args map{};
+  map.handle = alloc.handle;
+  map.device_ids_array_ptr = reinterpret_cast<uint64_t>(&gpu_id);
+  map.n_devices = 1;
+  ASSERT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), 0);
+  ASSERT_EQ(memory->pte_mtype(kGpuVa, process_id), rocjitsu::amdgpu::Mtype::RW);
+
+  kfd_ioctl_ipc_export_handle_args export_args{};
+  export_args.handle = alloc.handle;
+  ASSERT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_IPC_EXPORT_HANDLE, &export_args), 0);
+  EXPECT_EQ(memory->pte_mtype(kGpuVa, process_id), rocjitsu::amdgpu::Mtype::CC);
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = alloc.handle;
+  EXPECT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+  EXPECT_EQ(t.driver()->close(), 0);
+}
+
+TEST_F(SimulatedKfdTest, PermanentVramBackingIsIsolatedAndReclaimedByProcess) {
+  auto t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  auto *vm = dynamic_cast<rocjitsu::VirtualMachine *>(t.engine->topology().root());
+  ASSERT_NE(vm, nullptr);
+  auto *memory = vm->memory();
+  ASSERT_NE(memory, nullptr);
+
+  uint32_t first_process = t.driver()->open_process(/*client_pid=*/0);
+  uint32_t second_process = t.driver()->open_process(/*client_pid=*/0);
+  ASSERT_NE(first_process, second_process);
+
+  constexpr uint64_t kGpuVa = 0x7000000000ULL;
+  constexpr uint64_t kSize = rocjitsu::KfdProcess::kPageSize;
+  auto allocate_vram = [&](uint32_t process_id) {
+    kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+    alloc.va_addr = kGpuVa;
+    alloc.size = kSize;
+    alloc.gpu_id = t.driver()->gpu_id();
+    alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+    EXPECT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+
+    uint32_t gpu_id = alloc.gpu_id;
+    kfd_ioctl_map_memory_to_gpu_args map{};
+    map.handle = alloc.handle;
+    map.device_ids_array_ptr = reinterpret_cast<uint64_t>(&gpu_id);
+    map.n_devices = 1;
+    EXPECT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), 0);
+    EXPECT_EQ(map.n_success, 1u);
+    return alloc.handle;
+  };
+  auto free_vram = [&](uint32_t process_id, uint64_t handle) {
+    uint32_t gpu_id = t.driver()->gpu_id();
+    kfd_ioctl_unmap_memory_from_gpu_args unmap{};
+    unmap.handle = handle;
+    unmap.device_ids_array_ptr = reinterpret_cast<uint64_t>(&gpu_id);
+    unmap.n_devices = 1;
+    EXPECT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU, &unmap), 0);
+
+    kfd_ioctl_free_memory_of_gpu_args free_args{};
+    free_args.handle = handle;
+    EXPECT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+  };
+
+  uint64_t first_handle = allocate_vram(first_process);
+  uint64_t second_handle = allocate_vram(second_process);
+  ASSERT_NE(first_handle, 0u);
+  ASSERT_NE(second_handle, 0u);
+
+  memory->write32(kGpuVa, 0x11111111u, first_process);
+  memory->write32(kGpuVa, 0x22222222u, second_process);
+  EXPECT_EQ(memory->read32(kGpuVa, first_process), 0x11111111u);
+  EXPECT_EQ(memory->read32(kGpuVa, second_process), 0x22222222u);
+
+  free_vram(first_process, first_handle);
+  EXPECT_EQ(memory->read32(kGpuVa, second_process), 0x22222222u);
+
+  first_handle = allocate_vram(first_process);
+  ASSERT_NE(first_handle, 0u);
+  EXPECT_EQ(memory->read32(kGpuVa, first_process), 0u);
+
+  free_vram(first_process, first_handle);
+  free_vram(second_process, second_handle);
+  EXPECT_EQ(t.driver()->close(first_process), 0);
+  EXPECT_EQ(t.driver()->close(second_process), 0);
+}
+
+TEST_F(SimulatedKfdTest, PermanentVramBackingDoesNotPrefaultLargeAllocations) {
+  auto t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  ASSERT_GE(t.driver()->open(), 0);
+  uint32_t process_id = t.driver()->local_process_id();
+  auto process = t.driver()->find_process(process_id);
+  ASSERT_NE(process, nullptr);
+
+  constexpr uint64_t kGpuVa = 0x6000000000ULL;
+  constexpr uint64_t kAllocationSize = 1ULL << 30;
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = kGpuVa;
+  alloc.size = kAllocationSize;
+  alloc.gpu_id = t.driver()->gpu_id();
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+
+  {
+    std::lock_guard<std::mutex> lock(process->alloc_mutex_);
+    auto allocation = process->allocations_.find(alloc.handle);
+    ASSERT_NE(allocation, process->allocations_.end());
+    ASSERT_TRUE(allocation->second.permanent_backing);
+    ASSERT_EQ(allocation->second.backing_size, kAllocationSize);
+
+    const size_t page_count = kAllocationSize / rocjitsu::KfdProcess::kPageSize;
+    std::vector<uint8_t> residency(page_count);
+    ASSERT_EQ(
+        ::mincore(allocation->second.host_ptr, allocation->second.backing_size, residency.data()),
+        0);
+    size_t resident_pages = 0;
+    for (uint8_t state : residency)
+      resident_pages += state & 1;
+    EXPECT_EQ(resident_pages, 0u);
+  }
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = alloc.handle;
+  EXPECT_EQ(t.driver()->ioctl(process_id, AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+  EXPECT_EQ(t.driver()->close(), 0);
+}
+
+TEST_F(SimulatedKfdTest, LargePermanentBackingUsesOneRangeInsteadOfPerPageEntries) {
+  rocjitsu::KfdProcess process(/*process_id=*/9);
+  constexpr uint64_t kBaseVa = 0x8000000000ULL;
+  constexpr uint64_t kLargeAllocationSize = 1ULL << 40;
+  constexpr uint64_t kPage = rocjitsu::KfdProcess::kPageSize;
+  constexpr uintptr_t kHostBase = 0x1000000000ULL;
+
+  {
+    std::lock_guard<std::mutex> lock(process.alloc_mutex_);
+    rocjitsu::KfdProcess::GpuAllocation allocation{};
+    allocation.handle = 1;
+    allocation.gpu_va = kBaseVa;
+    allocation.size = kLargeAllocationSize;
+    allocation.backing_size = kLargeAllocationSize;
+    allocation.host_ptr = reinterpret_cast<void *>(kHostBase);
+    allocation.permanent_backing = true;
+    allocation.mapped_to_gpu = true;
+    process.allocations_[allocation.handle] = allocation;
+    process.refresh_backing_ranges_locked();
+  }
+
+  auto expect_resolved = [&](uint64_t gpu_va) {
+    auto backing = process.resolve_backing(gpu_va, kPage);
+    ASSERT_TRUE(backing.has_value());
+    ASSERT_TRUE(backing->gpu_accessible);
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(backing->address), kHostBase + (gpu_va - kBaseVa));
+    EXPECT_EQ(backing->range_size, kLargeAllocationSize);
+  };
+  expect_resolved(kBaseVa);
+  expect_resolved(kBaseVa + (kLargeAllocationSize / 2));
+  expect_resolved(kBaseVa + kLargeAllocationSize - kPage);
+  EXPECT_FALSE(process.resolve_backing(kBaseVa - kPage, kPage).has_value());
+  EXPECT_FALSE(process.resolve_backing(kBaseVa + kLargeAllocationSize, kPage).has_value());
+  EXPECT_TRUE(process.page_table_.empty());
 }
 
 TEST_F(SimulatedKfdTest, GuestDiscoveryOpenIsReleasedOnLastClose) {

--- a/emulation/rocjitsu/tests/simulated_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/simulated_kfd_test.cpp
@@ -251,6 +251,86 @@ TEST_F(SimulatedKfdTest, PermanentVramBackingTracksPartialAndCrossRangeCpuUnmaps
   EXPECT_EQ(t.driver()->close(), 0);
 }
 
+TEST_F(SimulatedKfdTest, SpanningMunmapCannotConsumeDoorbellPage) {
+  TestVM t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  ASSERT_GE(t.driver()->open(), 0);
+  const uint32_t process_id = t.driver()->local_process_id();
+  std::shared_ptr<rocjitsu::KfdProcess> process = t.driver()->find_process(process_id);
+  ASSERT_NE(process, nullptr);
+
+  constexpr size_t kPageSize = rocjitsu::KfdProcess::kPageSize;
+  uint8_t *reservation = static_cast<uint8_t *>(
+      ::mmap(nullptr, 2 * kPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  ASSERT_NE(reservation, MAP_FAILED);
+  uint8_t *doorbell_page = reservation + kPageSize;
+  const off_t doorbell_offset = static_cast<off_t>(rocjitsu::KFD_MMAP_TYPE_DOORBELL |
+                                                   rocjitsu::kfd_mmap_gpu_id(t.driver()->gpu_id()));
+  ASSERT_EQ(t.driver()->mmap(doorbell_page, kPageSize, PROT_READ | PROT_WRITE,
+                             MAP_SHARED | MAP_FIXED, doorbell_offset),
+            doorbell_page);
+  {
+    std::lock_guard<std::mutex> lock(process->alloc_mutex_);
+    process->cpu_mappings_.emplace(reinterpret_cast<uintptr_t>(reservation),
+                                   reinterpret_cast<uintptr_t>(doorbell_page));
+  }
+
+  errno = 0;
+  const int spanning_result = t.driver()->munmap(reservation, 2 * kPageSize);
+  EXPECT_EQ(spanning_result, -1);
+  EXPECT_EQ(errno, EPERM);
+  {
+    std::lock_guard<std::mutex> lock(process->alloc_mutex_);
+    EXPECT_EQ(process->cpu_mappings_.size(), 1u);
+    EXPECT_EQ(process->gpu(0).doorbell_page, doorbell_page);
+  }
+
+  process->event_state_.notify_closing();
+  EXPECT_EQ(t.driver()->munmap(doorbell_page, kPageSize), 0);
+  process->event_state_.reset();
+  if (spanning_result != 0)
+    EXPECT_EQ(t.driver()->munmap(reservation, kPageSize), 0);
+  EXPECT_EQ(t.driver()->close(), 0);
+}
+
+TEST_F(SimulatedKfdTest, SpanningMunmapCannotConsumeEventPage) {
+  TestVM t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  ASSERT_GE(t.driver()->open(), 0);
+  const uint32_t process_id = t.driver()->local_process_id();
+  std::shared_ptr<rocjitsu::KfdProcess> process = t.driver()->find_process(process_id);
+  ASSERT_NE(process, nullptr);
+
+  constexpr size_t kPageSize = rocjitsu::KfdProcess::kPageSize;
+  uint8_t *reservation = static_cast<uint8_t *>(
+      ::mmap(nullptr, 2 * kPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  ASSERT_NE(reservation, MAP_FAILED);
+  uint8_t *event_page = reservation + kPageSize;
+  ASSERT_EQ(t.driver()->mmap(event_page, kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
+                             static_cast<off_t>(rocjitsu::KFD_MMAP_TYPE_EVENTS)),
+            event_page);
+  {
+    std::lock_guard<std::mutex> lock(process->alloc_mutex_);
+    process->cpu_mappings_.emplace(reinterpret_cast<uintptr_t>(reservation),
+                                   reinterpret_cast<uintptr_t>(event_page));
+  }
+
+  errno = 0;
+  const int spanning_result = t.driver()->munmap(reservation, 2 * kPageSize);
+  EXPECT_EQ(spanning_result, -1);
+  EXPECT_EQ(errno, EPERM);
+  {
+    std::lock_guard<std::mutex> lock(process->alloc_mutex_);
+    EXPECT_EQ(process->cpu_mappings_.size(), 1u);
+  }
+  EXPECT_EQ(process->event_state_.page, event_page);
+
+  EXPECT_EQ(t.driver()->munmap(event_page, kPageSize), 0);
+  if (spanning_result != 0)
+    EXPECT_EQ(t.driver()->munmap(reservation, kPageSize), 0);
+  EXPECT_EQ(t.driver()->close(), 0);
+}
+
 TEST_F(SimulatedKfdTest, PermanentVramBackingImportsAcrossPartialMappings) {
   TestVM t = create_test_vm();
   ASSERT_NE(t.driver(), nullptr);


### PR DESCRIPTION
## Motivation

Rocjitsu may reserve the virtual-address range for a simulated VRAM allocation using a `PROT_NONE` CPU mapping.
In local mode, if a VMID page-table lookup misses, rocjitsu may incorrectly cast the GPU virtual address to a CPU pointer, and causing a seg fault.

## Technical Details

- Create permanent host backing for each VRAM allocation.
- Resolve GPU VA to their owned backing in the local model.
- Prevent inaccessible VRAM allocations from falling back to CPU pointers.
- Preserve backing data across CPU and GPU map/unmap operations.
- Share the permanent backing during IPC export and import.
- Reject spanning `munmap()` ranges that overlap event or doorbell pages.

## Issue Tracking

GitHub issue: https://github.com/ROCm/rocm-systems/issues/9933

## Test Plan

Run CI and RocBLAS SGEMM test from the test corpus.

## Test Result

Passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.