### PR TITLE
fix(rocprofiler-systems): Restore main thread identification in cached Perfetto

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -513,17 +513,35 @@ perfetto_processor_t::get_thread_track(std::uint64_t thread_id)
     auto _track = ::perfetto::ThreadTrack::ForThread(
         static_cast<::perfetto::base::PlatformThreadId>(thread_id));
 
-    // - Worker threads (sequent_value > 0) get a "Thread N" descriptor.
-    // - The main thread (sequent_value == 0) is intentionally left with its
-    //   default descriptor.
+    auto _desc = _track.Serialize();
+
+    // ThreadTrack::ForThread anchors the descriptor's pid to the post-processor's
+    // own OS pid (ProcessTrack::Current().pid). Re-anchor it to the cached process
+    // so the thread is grouped under the correct (synthetic) ProcessTrack that the
+    // parallel cached-Perfetto path emits, rather than the post-processor process.
+    _desc.mutable_thread()->set_pid(static_cast<std::int32_t>(m_process_id));
+
     const auto& _info = thread_info::get(static_cast<std::int64_t>(thread_id), SystemTID);
-    if(_info && _info->index_data && _info->index_data->sequent_value > 0)
+    if(_info && _info->index_data)
     {
-        auto _desc = _track.Serialize();
-        _desc.mutable_thread()->set_thread_name(
-            fmt::format("Thread {}", _info->index_data->sequent_value));
-        ::perfetto::TrackEvent::SetTrackDescriptor(_track, _desc);
+        if(_info->index_data->sequent_value > 0)
+        {
+            // Worker threads (sequent_value > 0) get a "Thread N" descriptor.
+            _desc.mutable_thread()->set_thread_name(
+                fmt::format("Thread {}", _info->index_data->sequent_value));
+        }
+        else
+        {
+            // Main thread (sequent_value == 0): Perfetto labels a thread as the
+            // process "main thread" (and sorts it to the top) when its descriptor
+            // has thread.tid == thread.pid. Force that relationship so the
+            // application's main thread is identified correctly under the cached
+            // process.
+            _desc.mutable_thread()->set_tid(static_cast<std::int32_t>(m_process_id));
+        }
     }
+
+    ::perfetto::TrackEvent::SetTrackDescriptor(_track, _desc);
 
     m_thread_track_cache.emplace(thread_id, _track);
     return _track;


### PR DESCRIPTION
## Motivation

In the cached (post-processed) Perfetto output, the application's main thread is
no longer labeled as the process "main thread" and is no longer sorted to the top
of the trace in the Perfetto UI. This is a regression: worker thread tracks still
render, but the track that identifies the main thread is missing, making captured
traces harder to read and inconsistent with the live Perfetto capture.

## Technical Details

- Re-anchor every thread track's descriptor `thread.pid` to `m_process_id`, so
  threads group under the correct synthetic `ProcessTrack` (consistent with how
  GPU/kernel tracks are already parented via `get_active_process_track()`).
- For the main thread (`sequent_value == 0`), set `thread.tid == thread.pid ==
  m_process_id` so Perfetto identifies it as the process main thread and sorts it
  to the top.
- Worker threads (`sequent_value > 0`) keep their existing `"Thread N"` descriptor.
- If thread info is unavailable, the track keeps its real tid and only gets the
  corrected pid, so an unknown thread is never misidentified as the main thread.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

Jira ID: AIPROFSYST-648

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Before Fix:
<img width="439" height="293" alt="image" src="https://github.com/user-attachments/assets/74cfff86-7b38-4149-bc32-a8b2aeee9a73" />

After Fix
<img width="647" height="92" alt="image" src="https://github.com/user-attachments/assets/d2592ff3-f1ca-4727-84fb-12297ae2a9dd" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
