### PR TITLE
fix(rocprofiler-compute): Update the torch-compiled-triton ctest

### DIFF
--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -3142,12 +3142,12 @@ def test_ml_api_trace_torch_compile_triton(
     capsys,
 ):
     """
-    ML API trace flow for a torch.compile workload that generates Triton kernels.
+    Validate the ML API trace flow for a torch.compile Triton workload.
 
-    Profiles sample/torch_compile_triton.py with --ml-api-trace, verifies Triton
-    markers reach the marker and counter CSVs, then analyzes the consolidated
-    ml_api_trace with --triton-operator and --torch-operator.
-    Requires PyTorch, Triton, and a GPU.
+    Profiles the workload with --ml-api-trace and runs analyze with
+    --list-triton-operators, --triton-operator, and --torch-operator. Verifies
+    that a Triton kernel is attributed to an operator in the consolidated
+    trace. Requires PyTorch, Triton, and a GPU.
     """
     require_triton(gpu=True)
     workload_dir = common.get_output_dir(param_id="ml_api_trace")
@@ -3179,23 +3179,7 @@ def test_ml_api_trace_torch_compile_triton(
         "marker_api_trace.csv and counter_collection.csv counts differ"
     )
 
-    found_triton_marker = False
-    for marker_file in marker_api_trace_files:
-        with open(marker_file, newline="", encoding="utf-8") as f:
-            reader = csv.DictReader(f)
-            assert reader.fieldnames is not None, f"No columns in {marker_file}"
-            assert "Function" in reader.fieldnames, (
-                f"'Function' column missing in {marker_file}"
-            )
-            for row in reader:
-                if "triton" in str(row["Function"]).lower():
-                    found_triton_marker = True
-                    break
-        if found_triton_marker:
-            break
-    assert found_triton_marker, "No Triton markers in marker_api_trace output"
-
-    # Flush profiling output so capsys captures only the analyze output.
+    # Discard captured profiling output.
     capsys.readouterr()
 
     # ---- Consolidated ml_api_trace ----
@@ -3208,16 +3192,25 @@ def test_ml_api_trace_torch_compile_triton(
         "--list-triton-operators",
     ])
     assert returncode_list == 0, "Analyze with --list-triton-operators failed"
-    list_output = capsys.readouterr().out
-    assert "Triton Operator Call Tree:" in list_output, "Missing call-tree banner"
+    capsys.readouterr()
 
     consolidated_csv = Path(workload_dir) / "ml_api_trace" / "consolidated.csv"
     assert consolidated_csv.exists(), "consolidated.csv not found in ml_api_trace"
     df = pd.read_csv(consolidated_csv)
     assert not df.empty, "consolidated.csv is empty"
-    assert "Operator_Name" in df.columns, "Operator_Name column missing"
-    assert df["Operator_Name"].astype(str).str.contains("triton").any(), (
-        "No Triton operators in consolidated.csv"
+    for column in ("Operator_Name", "Backend", "Kernel_Name"):
+        assert column in df.columns, f"{column} column missing in consolidated.csv"
+
+    # A Triton kernel is attributed to an operator marker from the torch or
+    # triton backend.
+    attributed_triton = df[
+        df["Kernel_Name"].astype(str).str.contains("triton_", case=False, na=False)
+        & df["Operator_Name"].notna()
+        & df["Backend"].isin(["torch", "triton"])
+    ]
+    assert not attributed_triton.empty, (
+        "No torch.compile Triton kernel (triton_*) was attributed to an "
+        "operator marker in consolidated.csv"
     )
 
     # ---- analyze --triton-operator ----
@@ -3232,11 +3225,7 @@ def test_ml_api_trace_torch_compile_triton(
         "all",
     ])
     assert returncode_triton == 0, "Analyze with --triton-operator all failed"
-    out_triton = capsys.readouterr().out
-    assert "Matched Triton Operators" in out_triton, "Missing matched-operators header"
 
-    # Torch operators may be absent under torch.compile; the analyze run only
-    # needs to complete successfully.
     capsys.readouterr()
     returncode_torch = binary_handler_analyze_rocprof_compute([
         "--experimental",


### PR DESCRIPTION
## Motivation

ctest test_profile_triton_trace was failing in the latest torch container due to an update in pytorch source code.  Previously, Triton kernels from Torch.Compile reached Triton package. They appeared in --list-triton-operators. Newer version of Torch is failing the Triton ctest. Torch is now using static launcher to launch Triton kernels. That means the flow doesn't enter Triton at all. The kernel is attributed to Torch. 

## Technical Details

The ctest test_profile_triton_trace is updated to look only for triton kernel launch, not triton backend markers.

## Issue Tracking

JIRA ID : ROCM-28200

## Test Plan

`ctest -R test_profile_triton_trace`

## Test Result

Test Passes.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
