### PR TITLE
ci(rocjitsu): Use absolute corpus artifact paths

### DIFF
--- a/emulation/rocjitsu/tests/corpus/run-corpus-tests.sh
+++ b/emulation/rocjitsu/tests/corpus/run-corpus-tests.sh
@@ -67,14 +67,16 @@ while (( $# )); do
 done
 
 corpus_test_status=0
+corpus_work_dir="$(pwd -P)"
+
 for target in "${targets[@]}"; do
   read -r name rocjitsu_config skip_tests_config <<< "${target}"
   echo "::group::(${name}) pytest"
 
   rocjitsu_config_path="${ROCJITSU_SOURCE_DIR}/configs/${rocjitsu_config}"
   skip_tests_config_path="${ROCJITSU_SOURCE_DIR}/tests/corpus/${skip_tests_config}"
-  artifact_dir=".pytest-artifacts/${name}"
-  cache_dir=".pytest-cache/${name}"
+  artifact_dir="${corpus_work_dir}/.pytest-artifacts/${name}"
+  cache_dir="${corpus_work_dir}/.pytest-cache/${name}"
 
   pytest_cmd=(
     rocjitsu --config "${rocjitsu_config_path}" -- pytest tests/test_corpus.py


### PR DESCRIPTION
## Summary
- Fix a small CI result bug from PR: https://github.com/ROCm/rocm-systems/pull/8654
- The last-failed summary section didn't capture failed tests properly:
```
> (gfx942) pytest
  ============================= test session starts ==============================
  platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0 -- /__w/_tool/Python/3.12.13/x64/bin/python
  cachedir: .pytest-cache/gfx942
  rootdir: /__w/rocm-systems/rocm-systems
  
Error: Some (gfx942) tests failed.
> (gfx942) pytest last-failed summary
  ============================= test session starts ==============================
  platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
  cachedir: .pytest-cache/gfx942
  rootdir: /__w/rocm-systems/rocm-systems/rocjitsu-test-corpus
  plugins: timeout-2.4.0, xdist-3.8.0
  cachedir: /__w/rocm-systems/rocm-systems/rocjitsu-test-corpus/.pytest-cache/gfx942
  cache is empty
  
  ============================ no tests ran in 0.00s =============================
  ```
- Set absolute path for pytest artifacts and cache to avoid relative path handling issue.

Issue ID: https://github.com/ROCm/rocm-systems/issues/7891