### PR TITLE
test(amdsmi): packaging install-path and multi-Python-version coverage

### DIFF
--- a/.github/workflows/amdsmi-python-versions.yml
+++ b/.github/workflows/amdsmi-python-versions.yml
@@ -1,0 +1,86 @@
+# ---------------------------------------------------------------------------
+# AMD SMI Python-version loader tests.
+#
+# The amdsmi loader and wrapper must behave identically across every CPython
+# version AMD SMI supports (3.6.8 through the latest release). This job runs the
+# version-independent loader contract tests under a matrix of interpreters so a
+# change that only breaks on a specific version is caught. No GPU required.
+# ---------------------------------------------------------------------------
+
+name: AMDSMI Python Version Tests
+
+on:
+  pull_request:
+    branches: [develop]
+    paths:
+      - 'projects/amdsmi/py-interface/**'
+      - 'projects/amdsmi/tools/generator.py'
+      - 'projects/amdsmi/tools/disable_system_fallback.py'
+      - 'projects/amdsmi/tests/python/**'
+      - 'projects/amdsmi/tests/run_amdsmi_python_versions_test.py'
+      - '.github/workflows/amdsmi-python-versions.yml'
+  push:
+    branches: [develop]
+    paths:
+      - 'projects/amdsmi/py-interface/**'
+      - 'projects/amdsmi/tools/generator.py'
+      - 'projects/amdsmi/tools/disable_system_fallback.py'
+      - 'projects/amdsmi/tests/python/**'
+      - 'projects/amdsmi/tests/run_amdsmi_python_versions_test.py'
+      - '.github/workflows/amdsmi-python-versions.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  python-version-tests:
+    name: Python ${{matrix.python-version}}
+    runs-on: ubuntu-22.04
+    # 3.6/3.7 run inside official python images because actions/setup-python no
+    # longer provides those EOL interpreters on a supported hosted runner (they
+    # were only on ubuntu-20.04, itself being retired). The images are archived,
+    # not deleted, so this stays green after the runner EOL. Newer minors run
+    # natively via setup-python. Empty matrix.container = no container.
+    container: ${{matrix.container}}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { python-version: '3.6',  container: 'python:3.6-slim-bullseye' }
+          - { python-version: '3.7',  container: 'python:3.7-slim-bullseye' }
+          - { python-version: '3.8',  container: '' }
+          - { python-version: '3.9',  container: '' }
+          - { python-version: '3.10', container: '' }
+          - { python-version: '3.11', container: '' }
+          - { python-version: '3.12', container: '' }
+          - { python-version: '3.13', container: '' }
+          - { python-version: '3.14', container: '' }
+
+    steps:
+      # The slim python images ship without git; actions/checkout needs it.
+      - name: Install git (container legs only)
+        if: matrix.container != ''
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends git ca-certificates
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          # rocm-systems is a large monorepo; only the amdsmi tests are needed.
+          sparse-checkout: |
+            projects/amdsmi
+            .github/workflows
+
+      - name: Set up Python ${{matrix.python-version}}
+        # Container legs already ship the exact interpreter; only host runners
+        # need setup-python.
+        if: matrix.container == ''
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{matrix.python-version}}
+
+      - name: Run loader tests under this interpreter
+        run: |
+          python3 projects/amdsmi/tests/run_amdsmi_python_versions_test.py \
+            --interpreters "$(command -v python3)"

--- a/.github/workflows/amdsmi-upgrade-downgrade.yml
+++ b/.github/workflows/amdsmi-upgrade-downgrade.yml
@@ -1,0 +1,136 @@
+# ---------------------------------------------------------------------------
+# AMD SMI package upgrade / downgrade test.
+#
+# The packaging rework changed how the module is delivered (direct
+# site-packages install instead of a postinst pip install), which changes the
+# postinst/prerm/postun semantics. This job builds the package twice with
+# different versions in the SAME distro container, then installs old -> upgrades
+# to new -> downgrades back, asserting the module, CLI, and the ld.so.conf.d
+# linker registration stay consistent at each step (a self-upgrade round trip;
+# a true cross-release test additionally needs a prior published artifact).
+#
+# The package must be built and tested in the same distro image: the RPM/DEB
+# bakes in the distro's site-packages path, so a package built on one distro
+# will not import on another. No GPU required.
+# ---------------------------------------------------------------------------
+
+name: AMDSMI Upgrade Downgrade
+
+on:
+  pull_request:
+    branches: [develop]
+    paths:
+      - 'projects/amdsmi/DEBIAN/**'
+      - 'projects/amdsmi/RPM/**'
+      - 'projects/amdsmi/py-interface/**'
+      - 'projects/amdsmi/CMakeLists.txt'
+      - 'projects/amdsmi/tests/run_amdsmi_upgrade_downgrade_test.py'
+      - '.github/workflows/amdsmi-upgrade-downgrade.yml'
+  push:
+    branches: [develop]
+    paths:
+      - 'projects/amdsmi/DEBIAN/**'
+      - 'projects/amdsmi/RPM/**'
+      - 'projects/amdsmi/py-interface/**'
+      - 'projects/amdsmi/CMakeLists.txt'
+      - 'projects/amdsmi/tests/run_amdsmi_upgrade_downgrade_test.py'
+      - '.github/workflows/amdsmi-upgrade-downgrade.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  upgrade-downgrade:
+    name: ${{matrix.name}}
+    runs-on: ubuntu-22.04
+    container: ${{matrix.container}}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Debian (Ubuntu 22.04)
+            container: ubuntu:22.04
+            generator: DEB
+            manager: apt
+            ext: deb
+          - name: RPM (AlmaLinux 9)
+            container: almalinux:9
+            generator: RPM
+            manager: dnf
+            ext: rpm
+
+    env:
+      BUILD_DIR: /tmp/amdsmi-build
+
+    steps:
+      - name: Install Debian build prerequisites
+        if: matrix.generator == 'DEB'
+        run: |
+          set -e
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            git ca-certificates gcc g++ cmake make file pkg-config \
+            libdrm-dev libnl-3-dev libnl-genl-3-dev libmnl-dev python3 sudo
+
+      - name: Install RPM build prerequisites
+        if: matrix.generator == 'RPM'
+        run: |
+          set -e
+          # libnl3-devel/libmnl-devel live in CRB + EPEL on AlmaLinux 9.
+          dnf install -y 'dnf-command(config-manager)'
+          dnf config-manager --set-enabled crb
+          dnf install -y epel-release
+          dnf install -y \
+            git gcc gcc-c++ cmake make rpm-build file \
+            libdrm-devel libnl3-devel libmnl-devel python3 sudo
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          # rocm-systems is a large monorepo; only the amdsmi project is needed.
+          sparse-checkout: |
+            projects/amdsmi
+            .github/workflows
+
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Configure and build once
+        working-directory: projects/amdsmi
+        run: |
+          set -e
+          cmake -S . -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Release -DENABLE_ESMI_LIB=ON
+          cmake --build "$BUILD_DIR" -j"$(nproc)"
+
+      - name: Package two versions (old, new)
+        working-directory: projects/amdsmi
+        run: |
+          set -e
+          # Re-package the same build tree at two versions via
+          # ROCM_LIBPATCH_VERSION (the 4th version component); no rebuild.
+          # Select the MAIN package only (exclude the -tests package). Match by
+          # build order rather than a hardcoded version so a version bump does
+          # not silently break the selection: after the first cpack only v1
+          # exists, and after the second the newest by version sort is v2.
+          mkdir -p /tmp/pkgs
+          main_pkgs() {
+            find "$BUILD_DIR" -maxdepth 1 -name "amd-smi-lib[-_]*.${{matrix.ext}}" \
+              | grep -v -- '-tests' | sort -V
+          }
+          ROCM_LIBPATCH_VERSION=1 cmake "$BUILD_DIR" >/dev/null
+          ( cd "$BUILD_DIR" && cpack -G ${{matrix.generator}} )
+          cp "$(main_pkgs | head -1)" /tmp/pkgs/old.${{matrix.ext}}
+          ROCM_LIBPATCH_VERSION=2 cmake "$BUILD_DIR" >/dev/null
+          ( cd "$BUILD_DIR" && cpack -G ${{matrix.generator}} )
+          cp "$(main_pkgs | tail -1)" /tmp/pkgs/new.${{matrix.ext}}
+          ls -l /tmp/pkgs
+
+      - name: Install old, upgrade to new, downgrade to old
+        working-directory: projects/amdsmi
+        run: |
+          set -e
+          python3 tests/run_amdsmi_upgrade_downgrade_test.py \
+            --old-package /tmp/pkgs/old.${{matrix.ext}} \
+            --new-package /tmp/pkgs/new.${{matrix.ext}} \
+            --package-manager ${{matrix.manager}}

--- a/projects/amdsmi/tests/amdsmi_build/run_amdsmi_build.py
+++ b/projects/amdsmi/tests/amdsmi_build/run_amdsmi_build.py
@@ -148,10 +148,7 @@ def _bootstrap_python():
     if pkg_mgr == "apt":
         try:
             # Keep stdout quiet but let stderr surface install diagnostics.
-            subprocess.check_call(
-                ["apt-get", "update"],
-                stdout=subprocess.DEVNULL,
-            )
+            subprocess.check_call(["apt-get", "update"], stdout=subprocess.DEVNULL)
         except subprocess.CalledProcessError:
             pass
     for pkgs in pkg_candidates:
@@ -172,8 +169,7 @@ def _bootstrap_python():
         sys.exit("ERROR: could not find a Python 3.7+ interpreter after install")
     try:
         subprocess.check_call(
-            ["alternatives", "--set", "python3", new_py],
-            stdout=subprocess.DEVNULL,
+            ["alternatives", "--set", "python3", new_py], stdout=subprocess.DEVNULL
         )
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):
         link = "/usr/bin/python3"
@@ -442,8 +438,10 @@ def install_build_prereqs(cfg: "RunnerConfig") -> None:
     ship cmake on PATH. This step installs cmake/gcc/g++/make on demand so
     the cmake-configure step doesn't die with FileNotFoundError.
     """
-    if shutil.which("cmake") and shutil.which("make") and (
-        shutil.which("gcc") or shutil.which("cc")
+    if (
+        shutil.which("cmake")
+        and shutil.which("make")
+        and (shutil.which("gcc") or shutil.which("cc"))
     ):
         return
 
@@ -490,16 +488,7 @@ def install_build_prereqs(cfg: "RunnerConfig") -> None:
         )
     elif cfg.package_manager == "zypper":
         run_command(
-            [
-                "zypper",
-                "--non-interactive",
-                "install",
-                "cmake",
-                "gcc",
-                "gcc-c++",
-                "make",
-                "git",
-            ],
+            ["zypper", "--non-interactive", "install", "cmake", "gcc", "gcc-c++", "make", "git"],
             name="zypper-install-prereqs",
             retries=cfg.retries,
             log_dir=cfg.log_dir,
@@ -562,20 +551,11 @@ def install_netlink_deps(cfg: "RunnerConfig") -> None:
             cmd += ["--noplugins", "--nogpgcheck"]
         cmd += ["libnl3-devel", "libmnl-devel"]
         run_command(
-            cmd,
-            name=f"{installer}-install-netlink",
-            retries=cfg.retries,
-            log_dir=cfg.log_dir,
+            cmd, name=f"{installer}-install-netlink", retries=cfg.retries, log_dir=cfg.log_dir
         )
     elif cfg.package_manager == "zypper":
         run_command(
-            [
-                "zypper",
-                "--non-interactive",
-                "install",
-                "libnl3-devel",
-                "libmnl-devel",
-            ],
+            ["zypper", "--non-interactive", "install", "libnl3-devel", "libmnl-devel"],
             name="zypper-install-netlink",
             retries=cfg.retries,
             log_dir=cfg.log_dir,
@@ -718,12 +698,7 @@ def build_amdsmi(cfg: "RunnerConfig") -> None:
         env["QA_RPATHS"] = str(0x0010 | 0x0002)
         print(f"QA_RPATHS set to {env['QA_RPATHS']}")
 
-    cmake_args = [
-        "cmake",
-        str(cfg.project_dir),
-        "-DBUILD_TESTS=ON",
-        "-DENABLE_ESMI_LIB=ON",
-    ]
+    cmake_args = ["cmake", str(cfg.project_dir), "-DBUILD_TESTS=ON", "-DENABLE_ESMI_LIB=ON"]
     run_command(
         cmake_args,
         name="cmake-configure",
@@ -909,10 +884,7 @@ def install_package(cfg: "RunnerConfig", package_path: Path) -> None:
         "amdsmi.amdsmi_shut_down(); "
         "print('init/shutdown ok')"
     )
-    verify_commands = [
-        [str(rocm_binary), "version"],
-        [system_python, "-c", import_smoke],
-    ]
+    verify_commands = [[str(rocm_binary), "version"], [system_python, "-c", import_smoke]]
     for idx, verify_cmd in enumerate(verify_commands, start=1):
         try:
             run_command(verify_cmd, name=f"verify-{idx}", retries=1, log_dir=cfg.log_dir)
@@ -1050,8 +1022,48 @@ def verify_dual_copy(cfg: "RunnerConfig") -> None:
 
     test_script = cfg.project_dir / "tests" / "run_amdsmi_dual_copy_test.py"
     run_command(
-        ["python3", str(test_script)],
-        name="dual-copy-guard",
+        ["python3", str(test_script)], name="dual-copy-guard", retries=1, log_dir=cfg.log_dir
+    )
+
+
+def verify_cpack_paths(cfg: "RunnerConfig", artifact: Path) -> None:
+    """Assert the built package ships the amdsmi module on an import path."""
+    test_script = cfg.project_dir / "tests" / "run_amdsmi_cpack_path_test.py"
+    run_command(
+        ["python3", str(test_script), str(artifact)],
+        name="cpack-path-check",
+        retries=1,
+        log_dir=cfg.log_dir,
+    )
+
+
+def verify_python_versions(cfg: "RunnerConfig") -> None:
+    """Run the loader contract tests under multiple Python interpreters."""
+    test_script = cfg.project_dir / "tests" / "run_amdsmi_python_versions_test.py"
+    cmd = ["python3", str(test_script)]
+    if cfg.python_interpreters:
+        cmd += ["--interpreters"] + cfg.python_interpreters.split(",")
+    run_command(cmd, name="python-versions", retries=1, log_dir=cfg.log_dir)
+
+
+def verify_upgrade_downgrade(cfg: "RunnerConfig", new_artifact: Path) -> None:
+    """Exercise the deb/rpm upgrade and downgrade path from a prior package."""
+    if not cfg.upgrade_from:
+        print("Skipping upgrade/downgrade check: no --upgrade-from package given")
+        return
+    test_script = cfg.project_dir / "tests" / "run_amdsmi_upgrade_downgrade_test.py"
+    run_command(
+        [
+            "python3",
+            str(test_script),
+            "--old-package",
+            str(cfg.upgrade_from),
+            "--new-package",
+            str(new_artifact),
+            "--package-manager",
+            cfg.package_manager,
+        ],
+        name="upgrade-downgrade",
         retries=1,
         log_dir=cfg.log_dir,
     )
@@ -1076,6 +1088,8 @@ class RunnerConfig:
     qa_rpaths: bool
     skip_build: bool
     skip_install: bool
+    upgrade_from: "Optional[Path]"
+    python_interpreters: "Optional[str]"
 
 
 def parse_args() -> RunnerConfig:
@@ -1124,6 +1138,18 @@ def parse_args() -> RunnerConfig:
     )
     parser.add_argument("--skip-install", action="store_true", help="Skip package installation")
     parser.add_argument(
+        "--upgrade-from",
+        type=Path,
+        default=None,
+        help="Prior-version .deb/.rpm to test the upgrade/downgrade path against",
+    )
+    parser.add_argument(
+        "--python-interpreters",
+        default=None,
+        help="Comma-separated interpreters for the Python-version loader tests "
+        "(default: discovered python3.6..3.13)",
+    )
+    parser.add_argument(
         "--no-autodetect",
         action="store_true",
         help="Disable auto-detection of OS profile from /etc/os-release",
@@ -1136,9 +1162,7 @@ def parse_args() -> RunnerConfig:
 
     project_dir = find_project_dir(args.project_dir)
     build_dir = args.build_dir or project_dir / "build"
-    package_manager = detect_package_manager(
-        args.package_manager or profile.get("package_manager")
-    )
+    package_manager = detect_package_manager(args.package_manager or profile.get("package_manager"))
     package_format = detect_package_format(
         package_manager, args.package_format or profile.get("package_format")
     )
@@ -1163,11 +1187,15 @@ def parse_args() -> RunnerConfig:
         os_label=os_label,
         refresh_apt=not args.no_apt_update,
         debian10_sources=args.debian10_sources or profile.get("debian10_sources", False),
-        skip_setuptools_upgrade=args.skip_setuptools_upgrade or profile.get("skip_setuptools_upgrade", False),
-        install_more_itertools=args.install_more_itertools or profile.get("install_more_itertools", False),
+        skip_setuptools_upgrade=args.skip_setuptools_upgrade
+        or profile.get("skip_setuptools_upgrade", False),
+        install_more_itertools=args.install_more_itertools
+        or profile.get("install_more_itertools", False),
         qa_rpaths=args.qa_rpaths or profile.get("qa_rpaths", False),
         skip_build=args.skip_build,
         skip_install=args.skip_install,
+        upgrade_from=args.upgrade_from,
+        python_interpreters=args.python_interpreters,
     )
 
 
@@ -1233,9 +1261,7 @@ def summarize_results(results_dir: Path, os_label: str, summary_file: Optional[P
         gtest_fails = text.count("[  FAILED  ]")
         if gtest_fails > 0:
             failures.append(f"AMDSMI Tests ({gtest_fails})")
-            details.append(
-                f"#### AMDSMI Tests \u2014 {gtest_fails} failure(s)\n\n" + _fenced(text)
-            )
+            details.append(f"#### AMDSMI Tests \u2014 {gtest_fails} failure(s)\n\n" + _fenced(text))
 
     # 4. Python test outputs
     fail_re = _re.compile(r"^(FAIL|ERROR):", _re.MULTILINE)
@@ -1253,9 +1279,7 @@ def summarize_results(results_dir: Path, os_label: str, summary_file: Optional[P
         if py_fails > 0:
             name = test_file.replace("_output.txt", "").replace("_", " ")
             failures.append(f"{name} ({py_fails})")
-            details.append(
-                f"#### {name} \u2014 {py_fails} failure(s)\n\n" + _fenced(text)
-            )
+            details.append(f"#### {name} \u2014 {py_fails} failure(s)\n\n" + _fenced(text))
 
     # 5. example test results (segfault detection)
     crash_re = _re.compile(r"segfault|SIGSEGV|abort", _re.IGNORECASE)
@@ -1274,9 +1298,7 @@ def summarize_results(results_dir: Path, os_label: str, summary_file: Optional[P
     # transient amd-smi CLI flakes do not fail the whole job.
     cmd_summary = ""
     if cmd_fails:
-        cmd_summary = (
-            f"\n\n:warning: Command tests (non-fatal): `{' '.join(cmd_fails)}`\n"
-        )
+        cmd_summary = f"\n\n:warning: Command tests (non-fatal): `{' '.join(cmd_fails)}`\n"
 
     if failures:
         header = [
@@ -1389,6 +1411,32 @@ def main() -> None:
     print(f"Build artifact: {artifact}")
     _write_result(cfg.test_results_dir, "build_result.txt", f"BUILD PASSED\nArtifact: {artifact}")
 
+    # 5b. Package ships the module on an import path (no install needed)
+    try:
+        verify_cpack_paths(cfg, artifact)
+    except CommandError as exc:
+        _write_result(
+            cfg.test_results_dir,
+            "cpack_path_result.txt",
+            f"CPACK PATH CHECK FAILED: {exc.name} exited {exc.code}\n\n"
+            f"Log ({exc.log_path}):\n{read_log(exc.log_path)}",
+        )
+        report_and_raise("CPACK PATH CHECK", exc)
+    _write_result(cfg.test_results_dir, "cpack_path_result.txt", "CPACK PATH CHECK PASSED")
+
+    # 5c. Loader behaves identically across supported Python versions
+    try:
+        verify_python_versions(cfg)
+    except CommandError as exc:
+        _write_result(
+            cfg.test_results_dir,
+            "python_versions_result.txt",
+            f"PYTHON VERSIONS FAILED: {exc.name} exited {exc.code}\n\n"
+            f"Log ({exc.log_path}):\n{read_log(exc.log_path)}",
+        )
+        report_and_raise("PYTHON VERSIONS", exc)
+    _write_result(cfg.test_results_dir, "python_versions_result.txt", "PYTHON VERSIONS PASSED")
+
     # 6. Install
     if not cfg.skip_install:
         try:
@@ -1446,6 +1494,22 @@ def main() -> None:
             )
             report_and_raise("DUAL COPY CHECK", exc)
         _write_result(cfg.test_results_dir, "dual_copy_result.txt", "DUAL COPY CHECK PASSED")
+
+    # 10. Upgrade/downgrade from a prior package (only when one is provided)
+    if not cfg.skip_install and cfg.upgrade_from:
+        try:
+            verify_upgrade_downgrade(cfg, artifact)
+        except CommandError as exc:
+            _write_result(
+                cfg.test_results_dir,
+                "upgrade_downgrade_result.txt",
+                f"UPGRADE/DOWNGRADE FAILED: {exc.name} exited {exc.code}\n\n"
+                f"Log ({exc.log_path}):\n{read_log(exc.log_path)}",
+            )
+            report_and_raise("UPGRADE/DOWNGRADE", exc)
+        _write_result(
+            cfg.test_results_dir, "upgrade_downgrade_result.txt", "UPGRADE/DOWNGRADE PASSED"
+        )
 
     print("AMDSMI workflow complete")
 

--- a/projects/amdsmi/tests/run_amdsmi_cpack_path_test.py
+++ b/projects/amdsmi/tests/run_amdsmi_cpack_path_test.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+run_amdsmi_cpack_path_test.py
+=============================
+
+The packaging rework installs the amdsmi Python module to an absolute system
+path (site-packages / dist-packages) outside the /opt/rocm prefix. That path is
+detected at configure time, so a packaging regression can silently ship the
+module where no interpreter looks. This test inspects a BUILT .deb/.rpm and
+asserts the amdsmi module files appear under a site-packages or dist-packages
+directory, before the package is ever installed.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# amdsmi_interface.py is a stable module file the package must ship; matching it
+# under a site/dist-packages path proves the module landed on an import path.
+MODULE_MARKER = re.compile(r"(site-packages|dist-packages)/amdsmi/amdsmi_interface\.py$")
+
+
+def _list_deb(pkg: Path) -> list:
+    out = subprocess.run(
+        ["dpkg", "-c", str(pkg)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        check=True,
+    )
+    # dpkg -c lines end with the path (may be "./usr/lib/..."); take the last field.
+    paths = []
+    for line in out.stdout.splitlines():
+        parts = line.split()
+        if parts:
+            paths.append(parts[-1].lstrip("."))
+    return paths
+
+
+def _list_rpm(pkg: Path) -> list:
+    out = subprocess.run(
+        ["rpm", "-qpl", str(pkg)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        check=True,
+    )
+    return [ln.strip() for ln in out.stdout.splitlines() if ln.strip()]
+
+
+def list_package(pkg: Path) -> list:
+    suffix = pkg.suffix.lower()
+    if suffix == ".deb":
+        return _list_deb(pkg)
+    if suffix == ".rpm":
+        return _list_rpm(pkg)
+    sys.exit(f"unsupported package type: {pkg}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("package", type=Path, help="Built .deb or .rpm to inspect.")
+    args = parser.parse_args()
+    pkg = args.package
+    if not pkg.is_file():
+        sys.exit(f"package not found: {pkg}")
+
+    paths = list_package(pkg)
+    matches = [p for p in paths if MODULE_MARKER.search(p)]
+    if not matches:
+        sample = "\n  ".join(p for p in paths if "amdsmi" in p) or "(no amdsmi paths at all)"
+        sys.exit(
+            "amdsmi module not found under a site-packages/dist-packages path in "
+            f"{pkg.name}.\namdsmi-related entries:\n  {sample}"
+        )
+
+    print(f"PASS: {pkg.name} ships the amdsmi module at:")
+    for m in matches:
+        print(f"  {m}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/projects/amdsmi/tests/run_amdsmi_python_versions_test.py
+++ b/projects/amdsmi/tests/run_amdsmi_python_versions_test.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+run_amdsmi_python_versions_test.py
+==================================
+
+The amdsmi loader and wrapper must behave identically across the range of
+CPython versions AMD SMI supports (3.6.8 through the latest release). This
+harness runs the version-independent loader contract tests under each
+interpreter it is given, so a change that only breaks on, say, 3.6 or a newer
+release is caught.
+
+For each interpreter it:
+  * confirms the wrapper imports and the loader resolves a path (or degrades to
+    the _MissingLibrary sentinel without raising at import), and
+  * runs the ABI-compat and dual-copy guard unit tests under that interpreter.
+
+No GPU is required: the loader tests use a fake ctypes.CDLL.
+"""
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PY_INTERFACE = REPO_ROOT / "py-interface"
+TEST_DIR = REPO_ROOT / "tests" / "python"
+
+
+def _discover_default_interpreters() -> list:
+    found = []
+    for minor in range(6, 14):
+        exe = shutil.which(f"python3.{minor}")
+        if exe:
+            found.append(exe)
+    if not found:
+        found.append(sys.executable)
+    return found
+
+
+def _import_smoke(interp: str) -> None:
+    # Import the wrapper and print the resolved library path. Import must not
+    # raise even when no library is present (the _MissingLibrary sentinel keeps
+    # it tolerant); a raised exception here is a real regression.
+    code = (
+        "import sys; sys.path.insert(0, %r)\n"
+        "import amdsmi_wrapper as w\n"
+        "print('  loaded:', getattr(w, '_loaded_lib_path', None))\n"
+    ) % str(PY_INTERFACE)
+    subprocess.run([interp, "-c", code], check=True)
+
+
+def _run_unit_tests(interp: str) -> None:
+    for test in ("test_abi_compat.py", "test_dual_copy_guard.py"):
+        subprocess.run([interp, str(TEST_DIR / test)], check=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--interpreters",
+        nargs="*",
+        default=None,
+        help="Python interpreters to test (default: discovered python3.6..3.13).",
+    )
+    args = parser.parse_args()
+    interpreters = args.interpreters or _discover_default_interpreters()
+
+    failures = []
+    for interp in interpreters:
+        ver = subprocess.run(
+            [interp, "-c", "import sys; print('%d.%d.%d' % sys.version_info[:3])"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        ).stdout.strip()
+        print(f"=== {interp} (Python {ver}) ===")
+        try:
+            _import_smoke(interp)
+            _run_unit_tests(interp)
+            print(f"PASS: {interp}")
+        except subprocess.CalledProcessError as exc:
+            print(f"FAIL: {interp} exited {exc.returncode}")
+            failures.append(f"{interp} (Python {ver})")
+
+    if failures:
+        sys.exit("python-version tests failed for: " + ", ".join(failures))
+    print("PASS: all interpreters behaved identically.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/projects/amdsmi/tests/run_amdsmi_upgrade_downgrade_test.py
+++ b/projects/amdsmi/tests/run_amdsmi_upgrade_downgrade_test.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+run_amdsmi_upgrade_downgrade_test.py
+====================================
+
+The packaging rework changed how the amdsmi Python module is delivered (direct
+site-packages install instead of a postinst pip install). This test exercises
+the deb/rpm upgrade and downgrade paths to prove the module, the ld.so.conf.d
+entry, and the CLI stay consistent when moving between two package builds.
+
+Given an OLD and a NEW package it:
+  1. installs OLD, verifies import + CLI,
+  2. installs NEW on top (upgrade), verifies again,
+  3. reinstalls OLD (downgrade), verifies again,
+so a broken pre/postinst transition fails here instead of on a user's machine.
+
+Requires root (installs/removes system packages). Skips cleanly if the package
+manager is unavailable. Not run by default in the build harness; wire it into
+CI where a prior-version artifact is available.
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(cmd: list) -> None:
+    print("+ " + " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def _run_cli_version(amd_smi: str) -> None:
+    # The CLI initializes the driver for every subcommand, so on a GPU-less CI
+    # runner `amd-smi version` exits non-zero with "Drivers not loaded" instead
+    # of printing a version. That still proves the CLI is installed and wired
+    # up (the point of this packaging test), so accept it. Fail only when the
+    # binary cannot be executed at all (missing/broken install).
+    cmd = [amd_smi, "version"]
+    print("+ " + " ".join(cmd))
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True)
+    except OSError as e:
+        sys.exit(f"CLI {amd_smi} could not be executed: {e}")
+    print(result.stdout, end="")
+    print(result.stderr, end="", file=sys.stderr)
+    if result.returncode != 0 and "Drivers not loaded" not in result.stderr:
+        sys.exit(f"CLI {amd_smi} version failed with exit {result.returncode}")
+
+
+def _install(pkg: Path, manager: str, downgrade: bool = False) -> None:
+    if manager == "apt":
+        _run(["apt-get", "install", "-y", "--allow-downgrades", "--reinstall", str(pkg)])
+    elif manager == "dnf":
+        # dnf install refuses to downgrade; use dnf downgrade for that direction.
+        # apt and zypper handle both directions with their existing flags.
+        if downgrade:
+            _run(["dnf", "downgrade", "-y", str(pkg)])
+        else:
+            _run(["dnf", "install", "-y", str(pkg)])
+    elif manager == "zypper":
+        _run(["zypper", "--non-interactive", "install", "--allow-downgrade", str(pkg)])
+    else:
+        sys.exit(f"unsupported package manager: {manager}")
+
+
+def _verify() -> None:
+    # Module imports and resolves a library path.
+    _run(["python3", "-c", "import amdsmi; print('import OK from', amdsmi.__file__)"])
+    # CLI runs. The package installs amd-smi to <ROCM_PATH>/bin, which is not
+    # on PATH in the CI container, so resolve it there directly rather than via
+    # `which` (which would silently skip the check and let a broken CLI pass).
+    rocm_path = os.environ.get("ROCM_PATH") or os.environ.get("ROCM_HOME") or "/opt/rocm"
+    amd_smi = Path(rocm_path) / "bin" / "amd-smi"
+    if not amd_smi.is_file():
+        sys.exit(f"CLI {amd_smi} is missing after install/upgrade")
+    _run_cli_version(str(amd_smi))
+    # The ld.so.conf.d entry the postinst writes must survive install AND
+    # upgrade. A prior package's %postun/prerm running after the new %post can
+    # delete it (RPM transaction ordering), leaving the new package without its
+    # linker registration -- so require the file rather than skipping when it is
+    # absent, which is exactly the broken-upgrade state this test must catch.
+    conf = Path("/etc/ld.so.conf.d/x86_64-libamd_smi_lib.conf")
+    if not conf.is_file():
+        sys.exit(f"linker registration {conf} is missing after install/upgrade")
+    libdir = conf.read_text().strip().splitlines()[0].strip()
+    if not list(Path(libdir).glob("libamd_smi.so*")):
+        sys.exit(f"ld.so.conf.d points at {libdir} but no libamd_smi.so is there")
+
+
+def _detect_manager() -> str:
+    for mgr in ("apt-get", "dnf", "zypper"):
+        if shutil.which(mgr):
+            return {"apt-get": "apt", "dnf": "dnf", "zypper": "zypper"}[mgr]
+    sys.exit("no supported package manager found")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--old-package", type=Path, required=True, help="Prior-version .deb/.rpm.")
+    parser.add_argument("--new-package", type=Path, required=True, help="New .deb/.rpm to test.")
+    parser.add_argument(
+        "--package-manager", default=None, help="apt / dnf / zypper (default: auto)."
+    )
+    args = parser.parse_args()
+
+    for p in (args.old_package, args.new_package):
+        if not p.is_file():
+            sys.exit(f"package not found: {p}")
+
+    manager = args.package_manager or _detect_manager()
+
+    print("=== 1. install OLD ===")
+    _install(args.old_package, manager)
+    _verify()
+
+    print("=== 2. upgrade to NEW ===")
+    _install(args.new_package, manager)
+    _verify()
+
+    print("=== 3. downgrade to OLD ===")
+    _install(args.old_package, manager, downgrade=True)
+    _verify()
+
+    print("PASS: upgrade and downgrade keep the module, CLI, and linker config consistent.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Description

Packaging install-path and multi-Python-version test coverage for the AMD SMI Python packaging rework. Stacks on #9033 (packaging correctness follow-ups).

- **Loader across Python versions** — verify loader behavior across supported interpreters; run the 3.6/3.7 loader tests in python container images.
- **Install-path assertion** — assert the system package ships the module on an importable path (`site-packages`/`dist-packages`).
- **Upgrade/downgrade round trip** — exercise the deb/rpm upgrade and downgrade path in CI; select upgrade-test packages by build order (not version string); fail the upgrade test when the `ld.so.conf.d` linker registration is missing; actually run the CLI check in the upgrade test.
- **Python 3.6 compatibility** — make the version and package tests run on Python 3.6.
- **CI hygiene** — wire the packaging tests into the harness and CI, sparse-checkout the python-version and upgrade jobs, pin `actions/setup-python` to a commit SHA.

## JIRA ID

ROCM-3941
