### PR TITLE
fix(amdsmi): read fan speed from hwmon pwm1, not gpu_od fan_minimum_pwm

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -71,6 +71,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - `amdsmi_get_nic_rdma_dev_info()` returns `AMDSMI_STATUS_SUCCESS` with `num_rdma_dev` set to 0.
   - `amd-smi static` reports `RDMA_DEVICES: N/A` instead of omitting the device. All other NIC information is reported as usual.
 
+- **Fixed `amd-smi metric --fan` reporting `0.0 %` on Navi3x/4x GPUs**.  
+  - `amdsmi_get_gpu_fan_speed()` read the gpu_od `fan_minimum_pwm` node, which is a user-set fan curve floor (`0` by default) and not a live reading. Both it and `amdsmi_get_gpu_fan_speed_max()` now read the hwmon `pwm1`/`pwm1_max` duty cycle again.
+  - The range accepted by `amdsmi_set_gpu_fan_speed()` on gpu_od GPUs is the gpu_od `OD_RANGE` and is not derivable from `amdsmi_get_gpu_fan_speed_max()`; `amd-smi set --fan --help` now advertises that range instead of deriving it from the reported maximum.
+
 ### Upcoming Changes
 
 - **UUIDs will be replaced by CUIDs in an upcoming version**.  

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -21,6 +21,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - For `mclk` and `fclk` ONLY, which expose a discrete DPM table, the requested `max` is now rounded down to the nearest selectable clock level, so the enforced limit never exceeds the requested value.
   - `sclk` supports a continuous frequency range, so its requested `max` is honored exactly (e.g. `600` enforces a limit of 600MHz) and is not snapped.
 
+- **Fixed `amd-smi metric --fan` reporting `0.0 %` on Navi3x/4x GPUs**.  
+  - `amdsmi_get_gpu_fan_speed()` read the gpu_od `fan_minimum_pwm` node, which is a user-set fan curve floor (`0` by default) and not a live reading. Both it and `amdsmi_get_gpu_fan_speed_max()` now read the hwmon `pwm1`/`pwm1_max` duty cycle again.
+  - The range accepted by `amdsmi_set_gpu_fan_speed()` on gpu_od GPUs is the gpu_od `OD_RANGE` and is not derivable from `amdsmi_get_gpu_fan_speed_max()`; `amd-smi set --fan --help` now advertises that range instead of deriving it from the reported maximum.
+
 ### Upcoming Changes
 
 - **UUIDs will be replaced by CUIDs in an upcoming version**.  

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -1582,8 +1582,8 @@ class AMDSMIHelpers:
     def get_fan_support(self):
         """Check if fan control is supported and return dynamic range info for all devices.
 
-        This method reads actual OD_RANGE values from sysfs for gpu_od GPUs and detects
-        legacy hwmon GPUs. Results are cached to improve CLI performance.
+        This method reads actual OD_RANGE values from sysfs for gpu_od GPUs and falls
+        back to the legacy hwmon range. Results are cached to improve CLI performance.
 
         Returns:
             str: Range description for all GPUs, "N/A" if not supported.
@@ -1604,29 +1604,19 @@ class AMDSMIHelpers:
             try:
                 # Check if fan control is supported
                 _ = amdsmi_interface.amdsmi_get_gpu_fan_speed(dev, 0)
-                max_speed = amdsmi_interface.amdsmi_get_gpu_fan_speed_max(dev, 0)
 
-                # Determine the range based on interface type
-                if max_speed <= 100:
-                    # This is likely a gpu_od GPU - try to get actual min from sysfs
-                    gpu_bdf = amdsmi_interface.amdsmi_get_gpu_device_bdf(dev)
-                    has_gpu_od, gpu_od_path = self.detect_gpu_od(gpu_bdf)
+                # Advertise the range the set path validates against: the gpu_od
+                # OD_RANGE where present, otherwise the legacy hwmon 0-255
+                gpu_bdf = amdsmi_interface.amdsmi_get_gpu_device_bdf(dev)
+                has_gpu_od, gpu_od_path = self.detect_gpu_od(gpu_bdf)
 
-                    if has_gpu_od:
-                        # Use shared helper function to parse OD_RANGE
-                        min_speed, parsed_max = self.parse_gpu_od_fan_range(gpu_od_path)
-                        if min_speed is not None:
-                            # Successfully parsed - use the actual range from sysfs
-                            gpu_ranges.append((idx, f"{min_speed}-{parsed_max} or 0-100%%"))
-                        else:
-                            # Parsing failed - fallback to 0-max_speed
-                            gpu_ranges.append((idx, f"0-{max_speed} or 0-100%%"))
-                    else:
-                        # gpu_od directory doesn't exist but max_speed <= 100
-                        # Could be an edge case - use 0-max_speed
-                        gpu_ranges.append((idx, f"0-{max_speed} or 0-100%%"))
+                min_speed = None
+                if has_gpu_od:
+                    min_speed, max_speed = self.parse_gpu_od_fan_range(gpu_od_path)
+
+                if min_speed is not None:
+                    gpu_ranges.append((idx, f"{min_speed}-{max_speed} or 0-100%%"))
                 else:
-                    # Legacy hwmon GPU (0-255)
                     gpu_ranges.append((idx, "0-255 or 0-100%%"))
 
             except amdsmi_interface.AmdSmiLibraryException as e:

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -2912,8 +2912,8 @@ Description: Get the fan speed for the specified device as a value relative to
 the maximum fan speed. The value is the hwmon pwm1 duty cycle, whose maximum is
 AMDSMI_MAX_FAN_SPEED (255). On GPUs exposing the gpu_od sysfs interface, the range
 accepted by `amdsmi_set_gpu_fan_speed()` is the gpu_od OD_RANGE and is NOT derivable
-from this value or from `amdsmi_get_gpu_fan_speed_max()`.
-It is not supported on virtual machine guest
+from this value or from `amdsmi_get_gpu_fan_speed_max()`. It is not supported on
+virtual machine guest
 
 Input parameters:
 

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -2909,9 +2909,11 @@ finally:
 ### amdsmi_get_gpu_fan_speed
 
 Description: Get the fan speed for the specified device as a value relative to
-the maximum fan speed. For legacy hwmon GPUs the maximum is AMDSMI_MAX_FAN_SPEED (255).
-For GPUs with the gpu_od sysfs interface, use `amdsmi_get_gpu_fan_speed_max()` to
-query the actual maximum. It is not supported on virtual machine guest
+the maximum fan speed. The value is the hwmon pwm1 duty cycle, whose maximum is
+AMDSMI_MAX_FAN_SPEED (255). On GPUs exposing the gpu_od sysfs interface, the range
+accepted by `amdsmi_set_gpu_fan_speed()` is the gpu_od OD_RANGE and is NOT derivable
+from this value or from `amdsmi_get_gpu_fan_speed_max()`.
+It is not supported on virtual machine guest
 
 Input parameters:
 
@@ -2956,8 +2958,9 @@ finally:
 ### amdsmi_get_gpu_fan_speed_max
 
 Description: Get the max fan speed of the device with provided device handle.
-For legacy hwmon GPUs this returns 255. For GPUs with the gpu_od sysfs interface,
-the maximum is read from the OD_RANGE (e.g. 100).
+This is the hwmon pwm1_max ceiling (255) and pairs with `amdsmi_get_gpu_fan_speed()`.
+On GPUs exposing the gpu_od sysfs interface, the range accepted by
+`amdsmi_set_gpu_fan_speed()` is the gpu_od OD_RANGE and is NOT derivable from this value.
 It is not supported on virtual machine guest
 
 Input parameters:

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -2908,9 +2908,11 @@ finally:
 ### amdsmi_get_gpu_fan_speed
 
 Description: Get the fan speed for the specified device as a value relative to
-the maximum fan speed. For legacy hwmon GPUs the maximum is AMDSMI_MAX_FAN_SPEED (255).
-For GPUs with the gpu_od sysfs interface, use `amdsmi_get_gpu_fan_speed_max()` to
-query the actual maximum. It is not supported on virtual machine guest
+the maximum fan speed. The value is the hwmon pwm1 duty cycle, whose maximum is
+AMDSMI_MAX_FAN_SPEED (255). On GPUs exposing the gpu_od sysfs interface, the range
+accepted by `amdsmi_set_gpu_fan_speed()` is the gpu_od OD_RANGE and is NOT derivable
+from this value or from `amdsmi_get_gpu_fan_speed_max()`.
+It is not supported on virtual machine guest
 
 Input parameters:
 
@@ -2955,8 +2957,9 @@ finally:
 ### amdsmi_get_gpu_fan_speed_max
 
 Description: Get the max fan speed of the device with provided device handle.
-For legacy hwmon GPUs this returns 255. For GPUs with the gpu_od sysfs interface,
-the maximum is read from the OD_RANGE (e.g. 100).
+This is the hwmon pwm1_max ceiling (255) and pairs with `amdsmi_get_gpu_fan_speed()`.
+On GPUs exposing the gpu_od sysfs interface, the range accepted by
+`amdsmi_set_gpu_fan_speed()` is the gpu_od OD_RANGE and is NOT derivable from this value.
 It is not supported on virtual machine guest
 
 Input parameters:

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -4583,9 +4583,12 @@ amdsmi_status_t amdsmi_get_gpu_fan_rpms(amdsmi_processor_handle processor_handle
  *  @details Given a processor handle @p processor_handle and a pointer to a uint32_t
  *  @p speed, this function will write the current fan speed (a value
  *  between 0 and the maximum fan speed) to the uint32_t pointed to by @p speed.
- *  For legacy hwmon GPUs the maximum is ::AMDSMI_MAX_FAN_SPEED (255).
- *  For GPUs with the gpu_od sysfs interface, use amdsmi_get_gpu_fan_speed_max()
- *  to query the actual maximum
+ *  The value is the hwmon pwm1 duty cycle, whose maximum is
+ *  ::AMDSMI_MAX_FAN_SPEED (255).
+ *
+ *  @note On GPUs exposing the gpu_od sysfs interface, the range accepted by
+ *  amdsmi_set_gpu_fan_speed() is the gpu_od OD_RANGE and is NOT derivable from
+ *  this value or from amdsmi_get_gpu_fan_speed_max()
  *
  *  @param[in] processor_handle a processor handle
  *
@@ -4615,9 +4618,12 @@ amdsmi_status_t amdsmi_get_gpu_fan_speed(amdsmi_processor_handle processor_handl
  *  @details Given a processor handle @p processor_handle and a pointer to a uint32_t
  *  @p max_speed, this function will write the maximum fan speed possible to
  *  the uint32_t pointed to by @p max_speed.
- *  For legacy hwmon GPUs this is ::AMDSMI_MAX_FAN_SPEED (255).
- *  For GPUs with the gpu_od sysfs interface, the maximum is read from the
- *  OD_RANGE section of the fan_minimum_pwm sysfs file (e.g. 100)
+ *  This is the hwmon pwm1_max ceiling, ::AMDSMI_MAX_FAN_SPEED (255), and pairs
+ *  with amdsmi_get_gpu_fan_speed().
+ *
+ *  @note On GPUs exposing the gpu_od sysfs interface, the range accepted by
+ *  amdsmi_set_gpu_fan_speed() is the gpu_od OD_RANGE and is NOT derivable from
+ *  this value
  *
  *  @param[in] processor_handle a processor handle
  *

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -4538,9 +4538,12 @@ amdsmi_status_t amdsmi_get_gpu_fan_rpms(amdsmi_processor_handle processor_handle
  *  @details Given a processor handle @p processor_handle and a pointer to a uint32_t
  *  @p speed, this function will write the current fan speed (a value
  *  between 0 and the maximum fan speed) to the uint32_t pointed to by @p speed.
- *  For legacy hwmon GPUs the maximum is ::AMDSMI_MAX_FAN_SPEED (255).
- *  For GPUs with the gpu_od sysfs interface, use amdsmi_get_gpu_fan_speed_max()
- *  to query the actual maximum
+ *  The value is the hwmon pwm1 duty cycle, whose maximum is
+ *  ::AMDSMI_MAX_FAN_SPEED (255).
+ *
+ *  @note On GPUs exposing the gpu_od sysfs interface, the range accepted by
+ *  amdsmi_set_gpu_fan_speed() is the gpu_od OD_RANGE and is NOT derivable from
+ *  this value or from amdsmi_get_gpu_fan_speed_max()
  *
  *  @param[in] processor_handle a processor handle
  *
@@ -4570,9 +4573,12 @@ amdsmi_status_t amdsmi_get_gpu_fan_speed(amdsmi_processor_handle processor_handl
  *  @details Given a processor handle @p processor_handle and a pointer to a uint32_t
  *  @p max_speed, this function will write the maximum fan speed possible to
  *  the uint32_t pointed to by @p max_speed.
- *  For legacy hwmon GPUs this is ::AMDSMI_MAX_FAN_SPEED (255).
- *  For GPUs with the gpu_od sysfs interface, the maximum is read from the
- *  OD_RANGE section of the fan_minimum_pwm sysfs file (e.g. 100)
+ *  This is the hwmon pwm1_max ceiling, ::AMDSMI_MAX_FAN_SPEED (255), and pairs
+ *  with amdsmi_get_gpu_fan_speed().
+ *
+ *  @note On GPUs exposing the gpu_od sysfs interface, the range accepted by
+ *  amdsmi_set_gpu_fan_speed() is the gpu_od OD_RANGE and is NOT derivable from
+ *  this value
  *
  *  @param[in] processor_handle a processor handle
  *

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -54,7 +54,7 @@ AMDSMI_MAX_NUM_PM_POLICIES = 32
 # Max supported frequencies
 AMDSMI_MAX_NUM_FREQUENCIES = 33
 
-# Max Fan speed (legacy hwmon). For gpu_od GPUs, use amdsmi_get_gpu_fan_speed_max().
+# Max Fan speed (hwmon pwm1_max), as reported by amdsmi_get_gpu_fan_speed_max()
 AMDSMI_MAX_FAN_SPEED = 255
 
 # Max Votlage Curve Points

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
@@ -64,7 +64,6 @@ rsmi_status_t GetDevBinaryBlob(amd::smi::DevInfoTypes type, uint32_t dv_ind, std
                                void* p_binary_data);
 rsmi_status_t ErrnoToRsmiStatus(int err);
 int ParseGpuOdFanRange(const std::string& path, uint64_t* min_pwm, uint64_t* max_pwm);
-int ParseGpuOdFanCurrentPwm(const std::string& path, uint64_t* current_pwm);
 rsmi_status_t WriteGpuOdFanPwm(const std::string& path, const std::string& value);
 [[nodiscard]] rsmi_status_t KFDIoctlErrnoToRsmiStatus(int err);
 std::string getRSMIStatusString(rsmi_status_t ret, bool fullStatus = true);

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -3574,19 +3574,8 @@ rsmi_status_t rsmi_dev_fan_speed_get(uint32_t dv_ind, uint32_t sensor_ind, int64
 
   DEVICE_MUTEX
 
-  // On gpu_od GPUs (Navi3x+), hwmon pwm1 does not reflect the actual fan speed.
-  // Read the FAN_MINIMUM_PWM value from the gpu_od sysfs instead.
-  std::string fan_ctrl_path = dev->get_gpu_od_fan_min_pwm_path();
-  if (amd::smi::FileExists(fan_ctrl_path.c_str())) {
-    uint64_t current_pwm = 0;
-    int parse_ret = amd::smi::ParseGpuOdFanCurrentPwm(fan_ctrl_path, &current_pwm);
-    if (parse_ret == 0) {
-      *speed = static_cast<int64_t>(current_pwm);
-      return RSMI_STATUS_SUCCESS;
-    }
-  }
-
-  // Legacy hwmon path
+  // hwmon pwm1 is the running fan duty cycle. The gpu_od fan_minimum_pwm node is
+  // only a user-set curve floor (0 by default), so it must not be read here.
   ret = get_dev_mon_value(amd::smi::kMonFanSpeed, dv_ind, sensor_ind, speed);
 
   return ret;
@@ -3731,20 +3720,8 @@ rsmi_status_t rsmi_dev_fan_speed_max_get(uint32_t dv_ind, uint32_t sensor_ind,
   CHK_SUPPORT_SUBVAR_ONLY(max_speed, sensor_ind)
   DEVICE_MUTEX
 
-  // On gpu_od GPUs (Navi3x+), the effective max fan speed is the OD_RANGE
-  // maximum from fan_minimum_pwm, not the hwmon pwm1_max (which is always 255).
-  std::string fan_ctrl_path = dev->get_gpu_od_fan_min_pwm_path();
-  if (amd::smi::FileExists(fan_ctrl_path.c_str())) {
-    uint64_t od_min_pwm = 0;
-    uint64_t od_max_pwm = 0;
-    int parse_ret = amd::smi::ParseGpuOdFanRange(fan_ctrl_path, &od_min_pwm, &od_max_pwm);
-    if (parse_ret == 0) {
-      *max_speed = od_max_pwm;
-      return RSMI_STATUS_SUCCESS;
-    }
-  }
-
-  // Legacy hwmon path
+  // Pair with rsmi_dev_fan_speed_get: the running duty cycle comes from hwmon
+  // pwm1, so its max must be hwmon pwm1_max, not the gpu_od OD_RANGE limit.
   ret = get_dev_mon_value(amd::smi::kMonMaxFanSpeed, dv_ind, sensor_ind,
                           reinterpret_cast<int64_t*>(max_speed));
 

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -3573,19 +3573,8 @@ rsmi_status_t rsmi_dev_fan_speed_get(uint32_t dv_ind, uint32_t sensor_ind, int64
 
   DEVICE_MUTEX
 
-  // On gpu_od GPUs (Navi3x+), hwmon pwm1 does not reflect the actual fan speed.
-  // Read the FAN_MINIMUM_PWM value from the gpu_od sysfs instead.
-  std::string fan_ctrl_path = dev->get_gpu_od_fan_min_pwm_path();
-  if (amd::smi::FileExists(fan_ctrl_path.c_str())) {
-    uint64_t current_pwm = 0;
-    int parse_ret = amd::smi::ParseGpuOdFanCurrentPwm(fan_ctrl_path, &current_pwm);
-    if (parse_ret == 0) {
-      *speed = static_cast<int64_t>(current_pwm);
-      return RSMI_STATUS_SUCCESS;
-    }
-  }
-
-  // Legacy hwmon path
+  // hwmon pwm1 is the running fan duty cycle. The gpu_od fan_minimum_pwm node is
+  // only a user-set curve floor (0 by default), so it must not be read here.
   ret = get_dev_mon_value(amd::smi::kMonFanSpeed, dv_ind, sensor_ind, speed);
 
   return ret;
@@ -3730,20 +3719,8 @@ rsmi_status_t rsmi_dev_fan_speed_max_get(uint32_t dv_ind, uint32_t sensor_ind,
   CHK_SUPPORT_SUBVAR_ONLY(max_speed, sensor_ind)
   DEVICE_MUTEX
 
-  // On gpu_od GPUs (Navi3x+), the effective max fan speed is the OD_RANGE
-  // maximum from fan_minimum_pwm, not the hwmon pwm1_max (which is always 255).
-  std::string fan_ctrl_path = dev->get_gpu_od_fan_min_pwm_path();
-  if (amd::smi::FileExists(fan_ctrl_path.c_str())) {
-    uint64_t od_min_pwm = 0;
-    uint64_t od_max_pwm = 0;
-    int parse_ret = amd::smi::ParseGpuOdFanRange(fan_ctrl_path, &od_min_pwm, &od_max_pwm);
-    if (parse_ret == 0) {
-      *max_speed = od_max_pwm;
-      return RSMI_STATUS_SUCCESS;
-    }
-  }
-
-  // Legacy hwmon path
+  // Pair with rsmi_dev_fan_speed_get: the running duty cycle comes from hwmon
+  // pwm1, so its max must be hwmon pwm1_max, not the gpu_od OD_RANGE limit.
   ret = get_dev_mon_value(amd::smi::kMonMaxFanSpeed, dv_ind, sensor_ind,
                           reinterpret_cast<int64_t*>(max_speed));
 

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
@@ -408,48 +408,6 @@ int ParseGpuOdFanRange(const std::string& path, uint64_t* min_pwm, uint64_t* max
   return 0;
 }
 
-int ParseGpuOdFanCurrentPwm(const std::string& path, uint64_t* current_pwm) {
-  // Read fan_minimum_pwm sysfs file and parse the current FAN_MINIMUM_PWM value.
-  // File format (multi-line):
-  //   FAN_MINIMUM_PWM:
-  //   <value>
-  //   OD_RANGE:
-  //   MINIMUM_PWM: <min> <max>
-  std::vector<std::string> lines;
-  int ret = ReadSysfsLines(path, &lines);
-  if (ret != 0) {
-    return ret;
-  }
-
-  if (lines.empty()) {
-    return EINVAL;
-  }
-
-  // Use TextFileTagContents_t for structured parsing
-  amd::smi::TextFileTagContents_t parser(lines);
-  parser.set_title_terminator(":", amd::smi::TagSplitterPositional_t::kLAST)
-      .set_key_data_splitter(":", amd::smi::TagSplitterPositional_t::kBETWEEN)
-      .structure_content();
-
-  // Check if FAN_MINIMUM_PWM section exists
-  if (!parser.contains_title_key("FAN_MINIMUM_PWM:")) {
-    return EINVAL;
-  }
-
-  // Get the first value under FAN_MINIMUM_PWM section
-  auto current_str = parser.get_structured_data_subkey_first("FAN_MINIMUM_PWM:");
-
-  // Parse the value
-  uint64_t val;
-  std::istringstream iss(current_str);
-  if (!(iss >> val)) {
-    return EINVAL;
-  }
-
-  if (current_pwm) *current_pwm = val;
-  return 0;
-}
-
 rsmi_status_t WriteGpuOdFanPwm(const std::string& path, const std::string& value) {
   int write_ret = WriteSysfsStr(path, value);
   if (write_ret != 0) {

--- a/projects/amdsmi/tests/amd_smi_test/functional/gpu/thermal/fan_read_write_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/gpu/thermal/fan_read_write_test.cc
@@ -7,18 +7,16 @@
 #include <unistd.h>
 
 #include <cstdint>
-#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
 
 #include "amd_smi/amdsmi.h"
+#include "rocm_smi/rocm_smi_utils.h"
 #include "test_common.h"
 
 namespace {
-
-constexpr uint32_t kMaxDrmCards = 64;
 
 // amdsmi_set_gpu_fan_speed validates against the gpu_od OD_RANGE on GPUs that
 // expose it. That range is a different unit space than pwm1/pwm1_max, so it
@@ -29,51 +27,14 @@ bool GetGpuOdFanSetRange(amdsmi_processor_handle handle, uint64_t* od_min, uint6
     return false;
   }
 
-  std::ostringstream bdf_ss;
-  bdf_ss << std::hex << std::setfill('0') << std::setw(4)
-         << static_cast<uint64_t>(bdf.bdf.domain_number) << ":" << std::setw(2)
-         << static_cast<uint64_t>(bdf.bdf.bus_number) << ":" << std::setw(2)
-         << static_cast<uint64_t>(bdf.bdf.device_number) << "."
-         << static_cast<uint64_t>(bdf.bdf.function_number);
-  const std::string bdf_str = bdf_ss.str();
+  std::ostringstream path;
+  path << "/sys/bus/pci/devices/" << std::hex << std::setfill('0') << std::setw(4)
+       << static_cast<uint64_t>(bdf.bdf.domain_number) << ":" << std::setw(2)
+       << static_cast<uint64_t>(bdf.bdf.bus_number) << ":" << std::setw(2)
+       << static_cast<uint64_t>(bdf.bdf.device_number) << "."
+       << static_cast<uint64_t>(bdf.bdf.function_number) << "/gpu_od/fan_ctrl/fan_minimum_pwm";
 
-  std::string pwm_path;
-  for (uint32_t card = 0; card < kMaxDrmCards; ++card) {
-    const std::string dev_link = "/sys/class/drm/card" + std::to_string(card) + "/device";
-    char target[4096] = {};
-    ssize_t len = readlink(dev_link.c_str(), target, sizeof(target) - 1);
-    if (len <= 0) {
-      continue;
-    }
-    if (std::string(target, static_cast<size_t>(len)).find(bdf_str) == std::string::npos) {
-      continue;
-    }
-    pwm_path = dev_link + "/gpu_od/fan_ctrl/fan_minimum_pwm";
-    break;
-  }
-  if (pwm_path.empty()) {
-    return false;
-  }
-
-  std::ifstream pwm_file(pwm_path);
-  if (!pwm_file.is_open()) {
-    return false;
-  }
-
-  // Parse "OD_RANGE:\nMINIMUM_PWM: <min> <max>"
-  std::string line;
-  while (std::getline(pwm_file, line)) {
-    std::istringstream iss(line);
-    std::string tag;
-    uint64_t lo = 0;
-    uint64_t hi = 0;
-    if ((iss >> tag >> lo >> hi) && tag == "MINIMUM_PWM:") {
-      *od_min = lo;
-      *od_max = hi;
-      return true;
-    }
-  }
-  return false;
+  return amd::smi::ParseGpuOdFanRange(path.str(), od_min, od_max) == 0;
 }
 
 }  // namespace

--- a/projects/amdsmi/tests/amd_smi_test/functional/gpu/thermal/fan_read_write_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/gpu/thermal/fan_read_write_test.cc
@@ -4,12 +4,79 @@
 #include "fan_read_write.h"
 
 #include <gtest/gtest.h>
+#include <unistd.h>
 
 #include <cstdint>
+#include <fstream>
+#include <iomanip>
 #include <iostream>
+#include <sstream>
+#include <string>
 
 #include "amd_smi/amdsmi.h"
 #include "test_common.h"
+
+namespace {
+
+constexpr uint32_t kMaxDrmCards = 64;
+
+// amdsmi_set_gpu_fan_speed validates against the gpu_od OD_RANGE on GPUs that
+// expose it. That range is a different unit space than pwm1/pwm1_max, so it
+// cannot be derived from amdsmi_get_gpu_fan_speed_max().
+bool GetGpuOdFanSetRange(amdsmi_processor_handle handle, uint64_t* od_min, uint64_t* od_max) {
+  amdsmi_bdf_t bdf;
+  if (amdsmi_get_gpu_device_bdf(handle, &bdf) != AMDSMI_STATUS_SUCCESS) {
+    return false;
+  }
+
+  std::ostringstream bdf_ss;
+  bdf_ss << std::hex << std::setfill('0') << std::setw(4)
+         << static_cast<uint64_t>(bdf.bdf.domain_number) << ":" << std::setw(2)
+         << static_cast<uint64_t>(bdf.bdf.bus_number) << ":" << std::setw(2)
+         << static_cast<uint64_t>(bdf.bdf.device_number) << "."
+         << static_cast<uint64_t>(bdf.bdf.function_number);
+  const std::string bdf_str = bdf_ss.str();
+
+  std::string pwm_path;
+  for (uint32_t card = 0; card < kMaxDrmCards; ++card) {
+    const std::string dev_link = "/sys/class/drm/card" + std::to_string(card) + "/device";
+    char target[4096] = {};
+    ssize_t len = readlink(dev_link.c_str(), target, sizeof(target) - 1);
+    if (len <= 0) {
+      continue;
+    }
+    if (std::string(target, static_cast<size_t>(len)).find(bdf_str) == std::string::npos) {
+      continue;
+    }
+    pwm_path = dev_link + "/gpu_od/fan_ctrl/fan_minimum_pwm";
+    break;
+  }
+  if (pwm_path.empty()) {
+    return false;
+  }
+
+  std::ifstream pwm_file(pwm_path);
+  if (!pwm_file.is_open()) {
+    return false;
+  }
+
+  // Parse "OD_RANGE:\nMINIMUM_PWM: <min> <max>"
+  std::string line;
+  while (std::getline(pwm_file, line)) {
+    std::istringstream iss(line);
+    std::string tag;
+    uint64_t lo = 0;
+    uint64_t hi = 0;
+    if ((iss >> tag >> lo >> hi) && tag == "MINIMUM_PWM:") {
+      *od_min = lo;
+      *od_max = hi;
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
 
 TestFanReadWrite::TestFanReadWrite() : TestBase() {
   set_title("AMDSMI Fan Read/Write Test");
@@ -84,23 +151,41 @@ void TestFanReadWrite::Run(void) {
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
     CHK_ERR_ASRT(ret)
     IF_VERB(STANDARD) { std::cout << "Max fan speed: " << max_speed << std::endl; }
-    // Max speed must be > 0 and either 255 (legacy hwmon) or <= 100 (gpu_od OD_RANGE)
+    // max_speed always reports the hwmon pwm1_max ceiling, in the same unit
+    // space as amdsmi_get_gpu_fan_speed()
     ASSERT_GT(max_speed, static_cast<uint64_t>(0));
     ASSERT_LE(max_speed, static_cast<uint64_t>(AMDSMI_MAX_FAN_SPEED));
 
-    if (can_read_speed && orig_speed > 0) {
+    // The set path validates against the gpu_od OD_RANGE where available, which
+    // max_speed does not describe.
+    uint64_t od_min = 0;
+    uint64_t od_max = 0;
+    const bool has_gpu_od = GetGpuOdFanSetRange(processor_handles_[dv_ind], &od_min, &od_max);
+    const int64_t set_min = has_gpu_od ? static_cast<int64_t>(od_min) : 0;
+    const int64_t set_max =
+        has_gpu_od ? static_cast<int64_t>(od_max) : static_cast<int64_t>(max_speed);
+    IF_VERB(STANDARD) {
+      std::cout << "Settable fan speed range: " << set_min << "-" << set_max << " ("
+                << (has_gpu_od ? "gpu_od OD_RANGE" : "legacy hwmon") << ")" << std::endl;
+    }
+    if (set_max <= set_min) {
+      std::cout << "***No usable fan speed range on this GPU. Skipping." << std::endl;
+      continue;
+    }
+
+    if (!has_gpu_od && can_read_speed && orig_speed > 0) {
       // Fans are spinning — use a speed slightly above current for the test
       new_speed = static_cast<int64_t>(1.1F * static_cast<float>(orig_speed));
 
-      if (new_speed > static_cast<int64_t>(max_speed)) {
+      if (new_speed > set_max) {
         std::cout << "***System fan speed value is close to max. Will not adjust upward."
                   << std::endl;
         continue;
       }
     } else {
-      // Fans are idle or read is unavailable — use a safe mid-range value
-      // that works for both legacy hwmon (0-255) and gpu_od (typically 20-100)
-      new_speed = max_speed / 2;
+      // orig_speed is not comparable to the settable range on gpu_od GPUs, so
+      // drive the midpoint of the range the set path actually accepts
+      new_speed = set_min + (set_max - set_min) / 2;
     }
 
     IF_VERB(STANDARD) { std::cout << "Setting fan speed to " << new_speed << std::endl; }
@@ -126,8 +211,8 @@ void TestFanReadWrite::Run(void) {
     if (ret == AMDSMI_STATUS_SUCCESS) {
       IF_VERB(STANDARD) { std::cout << "New fan speed: " << cur_speed << std::endl; }
 
-      // Only verify readback range when fans were originally spinning
-      if (can_read_speed && orig_speed > 0) {
+      // Readback is only comparable to new_speed in the hwmon unit space
+      if (!has_gpu_od && can_read_speed && orig_speed > 0) {
         IF_VERB(STANDARD) {
           if (!((cur_speed > static_cast<int64_t>(0.80 * static_cast<double>(new_speed)) &&
                  cur_speed < static_cast<int64_t>(1.25 * static_cast<double>(new_speed))) ||

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/fan_speed_source_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/fan_speed_source_test.cc
@@ -9,9 +9,9 @@
 // spinning. The live duty cycle is hwmon pwm1 / pwm1_max.
 //
 // The fixture below is a fake sysfs tree, so this runs on any host: no
-// OverDrive hardware, no gpu_od node and no GPU at all are required. That
-// matters because every CI runner is gfx94X, which has no gpu_od node and
-// therefore never exercised the broken branch.
+// OverDrive hardware, no gpu_od node and no GPU at all are required. A
+// hardware test cannot cover this, since the broken branch is only reachable
+// on a GPU that exposes gpu_od.
 
 #include <gtest/gtest.h>
 #include <unistd.h>
@@ -103,26 +103,12 @@ TEST(GpuUnit, FanSpeedComesFromHwmonNotOverDriveFloor) {
 }
 
 // The reported maximum is pwm1_max, not the OD_RANGE maximum (100). Pairing a
-// pwm1 speed with an OD_RANGE max would misscale the usage percentage.
+// pwm1 speed with an OD_RANGE max would misscale the usage percentage
+// amd-smi prints.
 TEST(GpuUnit, FanSpeedMaxComesFromHwmonNotOverDriveRange) {
   FakeOverDriveDevice fake;
 
   uint64_t max_speed = 0;
   ASSERT_EQ(rsmi_dev_fan_speed_max_get(fake.index(), 0, &max_speed), RSMI_STATUS_SUCCESS);
   EXPECT_EQ(max_speed, kLivePwmMax);
-}
-
-// End to end: the usage percentage amd-smi prints must track the fan.
-TEST(GpuUnit, FanUsagePercentIsNonZeroWhileFanSpins) {
-  FakeOverDriveDevice fake;
-
-  int64_t speed = -1;
-  uint64_t max_speed = 0;
-  ASSERT_EQ(rsmi_dev_fan_speed_get(fake.index(), 0, &speed), RSMI_STATUS_SUCCESS);
-  ASSERT_EQ(rsmi_dev_fan_speed_max_get(fake.index(), 0, &max_speed), RSMI_STATUS_SUCCESS);
-  ASSERT_NE(max_speed, 0u);
-
-  const double usage = 100.0 * static_cast<double>(speed) / static_cast<double>(max_speed);
-  EXPECT_GT(usage, 0.0) << "amd-smi metric --fan would print USAGE: 0.0 %";
-  EXPECT_NEAR(usage, 20.0, 0.1);
 }

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/fan_speed_source_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/fan_speed_source_test.cc
@@ -1,0 +1,128 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Regression tests for which sysfs node backs the fan-speed getters.
+// ROCm/rocm-systems#8684: on an OverDrive-enabled RDNA3/RDNA4 GPU
+// (amdgpu.ppfeaturemask=0xffffffff) the getters read
+// gpu_od/fan_ctrl/fan_minimum_pwm -- the user-set fan-curve floor and its
+// OD_RANGE -- so amd-smi reported "SPEED: 0 / USAGE: 0.0 %" while the fan was
+// spinning. The live duty cycle is hwmon pwm1 / pwm1_max.
+//
+// The fixture below is a fake sysfs tree, so this runs on any host: no
+// OverDrive hardware, no gpu_od node and no GPU at all are required. That
+// matters because every CI runner is gfx94X, which has no gpu_od node and
+// therefore never exercised the broken branch.
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+
+#include "rocm_smi/rocm_smi.h"
+#include "rocm_smi/rocm_smi_device.h"
+#include "rocm_smi/rocm_smi_main.h"
+#include "rocm_smi/rocm_smi_monitor.h"
+
+namespace {
+
+// Values read from a live Navi21 board: pwm1=51 of pwm1_max=255 (20%) with the
+// fan turning at ~1157 RPM.
+constexpr int64_t kLivePwm = 51;
+constexpr uint64_t kLivePwmMax = 255;
+
+// A stock OverDrive fan curve: floor 0, OD_RANGE 15-100. Reading this node as
+// the live duty cycle is what produced 0 / 0.0 %.
+constexpr char kFanMinimumPwm[] =
+    "FAN_MINIMUM_PWM:\n"
+    "0\n"
+    "OD_RANGE:\n"
+    "MINIMUM_PWM: 15 100\n";
+
+void WriteFile(const std::filesystem::path& path, const std::string& contents) {
+  std::filesystem::create_directories(path.parent_path());
+  std::ofstream out(path);
+  ASSERT_TRUE(out.is_open()) << "cannot write " << path;
+  out << contents;
+}
+
+// Builds a fake OverDrive-enabled GPU under a temp dir, registers it with the
+// RocmSMI device list and removes it again on destruction.
+class FakeOverDriveDevice {
+ public:
+  FakeOverDriveDevice() {
+    root_ = std::filesystem::temp_directory_path() / ("amdsmi_fan_od_" + std::to_string(getpid()));
+    std::filesystem::remove_all(root_);
+
+    const std::filesystem::path card = root_ / "card0";
+    const std::filesystem::path hwmon = card / "device" / "hwmon" / "hwmon0";
+
+    WriteFile(card / "device" / "gpu_od" / "fan_ctrl" / "fan_minimum_pwm", kFanMinimumPwm);
+    WriteFile(hwmon / "pwm1", std::to_string(kLivePwm) + "\n");
+    WriteFile(hwmon / "pwm1_max", std::to_string(kLivePwmMax) + "\n");
+
+    auto dev = std::make_shared<amd::smi::Device>(card.string(), nullptr);
+    dev->set_monitor(std::make_shared<amd::smi::Monitor>(hwmon.string(), nullptr));
+
+    auto& devices = amd::smi::RocmSMI::getInstance().devices();
+    index_ = static_cast<uint32_t>(devices.size());
+    devices.push_back(dev);
+  }
+
+  ~FakeOverDriveDevice() {
+    auto& devices = amd::smi::RocmSMI::getInstance().devices();
+    if (index_ < devices.size()) {
+      devices.erase(devices.begin() + index_);
+    }
+    std::filesystem::remove_all(root_);
+  }
+
+  FakeOverDriveDevice(const FakeOverDriveDevice&) = delete;
+  FakeOverDriveDevice& operator=(const FakeOverDriveDevice&) = delete;
+
+  uint32_t index() const { return index_; }
+
+ private:
+  std::filesystem::path root_;
+  uint32_t index_ = 0;
+};
+
+}  // namespace
+
+// The reported speed is the running pwm1, not the fan-curve floor (0).
+TEST(GpuUnit, FanSpeedComesFromHwmonNotOverDriveFloor) {
+  FakeOverDriveDevice fake;
+
+  int64_t speed = -1;
+  ASSERT_EQ(rsmi_dev_fan_speed_get(fake.index(), 0, &speed), RSMI_STATUS_SUCCESS);
+  EXPECT_NE(speed, 0) << "fan_minimum_pwm floor reported as live speed (issue #8684)";
+  EXPECT_EQ(speed, kLivePwm);
+}
+
+// The reported maximum is pwm1_max, not the OD_RANGE maximum (100). Pairing a
+// pwm1 speed with an OD_RANGE max would misscale the usage percentage.
+TEST(GpuUnit, FanSpeedMaxComesFromHwmonNotOverDriveRange) {
+  FakeOverDriveDevice fake;
+
+  uint64_t max_speed = 0;
+  ASSERT_EQ(rsmi_dev_fan_speed_max_get(fake.index(), 0, &max_speed), RSMI_STATUS_SUCCESS);
+  EXPECT_EQ(max_speed, kLivePwmMax);
+}
+
+// End to end: the usage percentage amd-smi prints must track the fan.
+TEST(GpuUnit, FanUsagePercentIsNonZeroWhileFanSpins) {
+  FakeOverDriveDevice fake;
+
+  int64_t speed = -1;
+  uint64_t max_speed = 0;
+  ASSERT_EQ(rsmi_dev_fan_speed_get(fake.index(), 0, &speed), RSMI_STATUS_SUCCESS);
+  ASSERT_EQ(rsmi_dev_fan_speed_max_get(fake.index(), 0, &max_speed), RSMI_STATUS_SUCCESS);
+  ASSERT_NE(max_speed, 0u);
+
+  const double usage = 100.0 * static_cast<double>(speed) / static_cast<double>(max_speed);
+  EXPECT_GT(usage, 0.0) << "amd-smi metric --fan would print USAGE: 0.0 %";
+  EXPECT_NEAR(usage, 20.0, 0.1);
+}

--- a/projects/amdsmi/tests/python/cli/test_set.py
+++ b/projects/amdsmi/tests/python/cli/test_set.py
@@ -4,7 +4,6 @@
 
 """CLI leaf test: set command."""
 
-import common.common as common
 from common.common import amdsmi
 
 from cli.base import TestCliBase
@@ -41,19 +40,11 @@ class TestSet(TestCliBase):
         # Restore starting values
         cmds = []
         for index, gpu in enumerate(self.common.processors):
-            # Validate max fan speed is sensible; gpu_od GPUs must report <= 100
+            # max fan speed is the hwmon pwm1_max ceiling on every interface
             fan_max = self.metric_data["gpu_data"][index]["fan"]["max"]
             if fan_max != "N/A":
                 self.assertGreater(fan_max, 0, f"GPU {index}: max fan speed must be > 0")
-                # Detect gpu_od interface via sysfs for this GPU
-                gpu_bdf = self.list_data[index]["bdf"]
-                has_gpu_od = common.has_gpu_od_interface(gpu_bdf)
-                if has_gpu_od:
-                    self.assertLessEqual(
-                        fan_max, 100, f"GPU {index}: gpu_od max fan speed must be <= 100"
-                    )
-                else:
-                    self.assertLessEqual(fan_max, 255, f"GPU {index}: max fan speed must be <= 255")
+                self.assertLessEqual(fan_max, 255, f"GPU {index}: max fan speed must be <= 255")
 
             # reset --fans (works for both legacy hwmon and gpu_od interfaces)
             fan_speed = self.metric_data["gpu_data"][index]["fan"]["speed"]

--- a/projects/amdsmi/tests/python/common/common.py
+++ b/projects/amdsmi/tests/python/common/common.py
@@ -757,8 +757,20 @@ class GTestSummaryRunner(unittest.TextTestRunner):
         stream.writeln()
 
 
-def _import_amdsmi_helpers():
-    """Import amdsmi_helpers from the installed AMD-SMI CLI."""
+def get_fan_speed_set_range(bdf):
+    """Get the range that amdsmi_set_gpu_fan_speed() validates against.
+
+    On gpu_od GPUs this is the gpu_od OD_RANGE, which is a different unit space
+    than pwm1/pwm1_max and therefore not derivable from
+    amdsmi_get_gpu_fan_speed_max(). Requires the AMD-SMI CLI to be installed
+    (amdsmi_helpers is imported on first call).
+
+    Args:
+        bdf: PCI Bus/Device/Function string (e.g. '0000:26:00.0')
+
+    Returns:
+        tuple: (min_speed, max_speed) accepted by amdsmi_set_gpu_fan_speed()
+    """
     # TODO(amdsmi_team): Refactor to create an amdsmi_get_gpu_fan_speed_range() API
     #                    amdsmi_get_gpu_fan_speed_range(
     #                                           amdsmi_processor_handle processor_handle,
@@ -784,40 +796,7 @@ def _import_amdsmi_helpers():
         raise ImportError(
             f'Could not import the "amdsmi_helpers" module from "{amdsmi_cli_path}"'
         ) from e
-    return amdsmi_helpers
 
-
-def has_gpu_od_interface(bdf):
-    """Check if a GPU has the gpu_od sysfs interface.
-
-    Delegates to amdsmi_helpers.AMDSMIHelpers.detect_gpu_od(). Requires the
-    AMD-SMI CLI to be installed (amdsmi_helpers is imported on first call).
-
-    Args:
-        bdf: PCI Bus/Device/Function string (e.g. '0000:26:00.0')
-
-    Returns:
-        bool: True if gpu_od directory exists for this GPU
-    """
-    amdsmi_helpers = _import_amdsmi_helpers()
-    has_gpu_od, _ = amdsmi_helpers.AMDSMIHelpers.detect_gpu_od(bdf)
-    return has_gpu_od
-
-
-def get_fan_speed_set_range(bdf):
-    """Get the range that amdsmi_set_gpu_fan_speed() validates against.
-
-    On gpu_od GPUs this is the gpu_od OD_RANGE, which is a different unit space
-    than pwm1/pwm1_max and therefore not derivable from
-    amdsmi_get_gpu_fan_speed_max().
-
-    Args:
-        bdf: PCI Bus/Device/Function string (e.g. '0000:26:00.0')
-
-    Returns:
-        tuple: (min_speed, max_speed) accepted by amdsmi_set_gpu_fan_speed()
-    """
-    amdsmi_helpers = _import_amdsmi_helpers()
     has_gpu_od, gpu_od_path = amdsmi_helpers.AMDSMIHelpers.detect_gpu_od(bdf)
     if has_gpu_od:
         od_min, od_max = amdsmi_helpers.AMDSMIHelpers.parse_gpu_od_fan_range(gpu_od_path)

--- a/projects/amdsmi/tests/python/common/common.py
+++ b/projects/amdsmi/tests/python/common/common.py
@@ -757,27 +757,17 @@ class GTestSummaryRunner(unittest.TextTestRunner):
         stream.writeln()
 
 
-def has_gpu_od_interface(bdf):
-    """Check if a GPU has the gpu_od sysfs interface.
-
-    Delegates to amdsmi_helpers.AMDSMIHelpers.detect_gpu_od(). Requires the
-    AMD-SMI CLI to be installed (amdsmi_helpers is imported on first call).
-
-    Args:
-        bdf: PCI Bus/Device/Function string (e.g. '0000:26:00.0')
-
-    Returns:
-        bool: True if gpu_od directory exists for this GPU
-    """
+def _import_amdsmi_helpers():
+    """Import amdsmi_helpers from the installed AMD-SMI CLI."""
     # TODO(amdsmi_team): Refactor to create an amdsmi_get_gpu_fan_speed_range() API
     #                    amdsmi_get_gpu_fan_speed_range(
     #                                           amdsmi_processor_handle processor_handle,
     #                                           uint32_t sensor_ind,
     #                                           amdsmi_range_t* fan_speed_range)
-    # and begin deprecation of amdsmi_get_gpu_fan_speed_max(). This will allow us
-    # to remove the dependency on amdsmi_helpers from this common module.
-    # Exposing non-public SYSFS API interfaces in the CLI (and in general)
-    # is a bad design pattern and needs to be addressed in the future.
+    # so the range accepted by amdsmi_set_gpu_fan_speed() is queryable through the
+    # public API. This will allow us to remove the dependency on amdsmi_helpers from
+    # this common module. Exposing non-public SYSFS API interfaces in the CLI (and in
+    # general) is a bad design pattern and needs to be addressed in the future.
     amdsmi_cli_path = os.path.normpath(
         os.path.join(amdsmi_path, "..", "..", "libexec", "amdsmi_cli")
     )
@@ -794,8 +784,46 @@ def has_gpu_od_interface(bdf):
         raise ImportError(
             f'Could not import the "amdsmi_helpers" module from "{amdsmi_cli_path}"'
         ) from e
+    return amdsmi_helpers
+
+
+def has_gpu_od_interface(bdf):
+    """Check if a GPU has the gpu_od sysfs interface.
+
+    Delegates to amdsmi_helpers.AMDSMIHelpers.detect_gpu_od(). Requires the
+    AMD-SMI CLI to be installed (amdsmi_helpers is imported on first call).
+
+    Args:
+        bdf: PCI Bus/Device/Function string (e.g. '0000:26:00.0')
+
+    Returns:
+        bool: True if gpu_od directory exists for this GPU
+    """
+    amdsmi_helpers = _import_amdsmi_helpers()
     has_gpu_od, _ = amdsmi_helpers.AMDSMIHelpers.detect_gpu_od(bdf)
     return has_gpu_od
+
+
+def get_fan_speed_set_range(bdf):
+    """Get the range that amdsmi_set_gpu_fan_speed() validates against.
+
+    On gpu_od GPUs this is the gpu_od OD_RANGE, which is a different unit space
+    than pwm1/pwm1_max and therefore not derivable from
+    amdsmi_get_gpu_fan_speed_max().
+
+    Args:
+        bdf: PCI Bus/Device/Function string (e.g. '0000:26:00.0')
+
+    Returns:
+        tuple: (min_speed, max_speed) accepted by amdsmi_set_gpu_fan_speed()
+    """
+    amdsmi_helpers = _import_amdsmi_helpers()
+    has_gpu_od, gpu_od_path = amdsmi_helpers.AMDSMIHelpers.detect_gpu_od(bdf)
+    if has_gpu_od:
+        od_min, od_max = amdsmi_helpers.AMDSMIHelpers.parse_gpu_od_fan_range(gpu_od_path)
+        if od_min is not None:
+            return od_min, od_max
+    return 0, 255
 
 
 class Common:

--- a/projects/amdsmi/tests/python/functional/gpu/test_thermal.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_thermal.py
@@ -73,19 +73,10 @@ class TestGpuThermal(unittest.TestCase):
                 self.assertGreater(
                     fan_speed_max, 0, f"Max fan speed must be > 0, got {fan_speed_max}"
                 )
-                # Detect gpu_od interface to set appropriate max threshold
-                gpu_bdf = amdsmi.amdsmi_get_gpu_device_bdf(gpu)
-                has_gpu_od = common.has_gpu_od_interface(gpu_bdf)
-                if has_gpu_od:
-                    self.assertLessEqual(
-                        fan_speed_max,
-                        100,
-                        f"gpu_od max fan speed must be <= 100, got {fan_speed_max}",
-                    )
-                else:
-                    self.assertLessEqual(
-                        fan_speed_max, 255, f"Max fan speed must be <= 255, got {fan_speed_max}"
-                    )
+                # max fan speed is the hwmon pwm1_max ceiling on every interface
+                self.assertLessEqual(
+                    fan_speed_max, 255, f"Max fan speed must be <= 255, got {fan_speed_max}"
+                )
             except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
                 if self.common.check_ret(msg, e, self.common.PASS):
                     self.raise_exception = e
@@ -94,12 +85,10 @@ class TestGpuThermal(unittest.TestCase):
             if found_error:
                 continue
 
-            # Calculate a safe mid-range value based on actual hardware limits.
-            # This avoids hardcoding and works with any OD_RANGE configuration.
-            # For legacy hwmon: min=0, max=255 -> mid=127
-            # For gpu_od: min=0 (conservative), max from API -> mid dynamically calculated
-            min_value = 0  # Conservative minimum (works for both legacy and gpu_od)
-            max_value = fan_speed_max
+            # amdsmi_set_gpu_fan_speed() validates against the gpu_od OD_RANGE where
+            # present, which fan_speed_max does not describe
+            gpu_bdf = amdsmi.amdsmi_get_gpu_device_bdf(gpu)
+            min_value, max_value = common.get_fan_speed_set_range(gpu_bdf)
             fan_speed = min_value + ((max_value - min_value) // 2)
 
             # Set fan speed


### PR DESCRIPTION
## Motivation

On OverDrive-enabled RDNA3/RDNA4 GPUs:
```
$ echo "ppfeaturemask: $(cat /sys/module/amdgpu/parameters/ppfeaturemask)"
ppfeaturemask: 0xffffffff
```
 `amd-smi metric --fan` reports `USAGE: 0.0 %` (and `SPEED: 0`) while the fan is physically spinning. `sensors`/hwmon read the correct tachometer.

Fixes https://github.com/ROCm/rocm-systems/issues/8684

## Technical Details

The fan-speed getters were rerouted to read `gpu_od/fan_ctrl/fan_minimum_pwm` whenever that sysfs node exists. That node is created only when OverDrive is enabled (the OD bit in `amdgpu.ppfeaturemask`) and holds the user-set OverDrive fan-curve floor plus its OD_RANGE, not the running duty cycle. So `usage = floor / od_max`, pinned to the floor regardless of actual fan speed (0% when the floor defaults to 0; a fixed non-zero % when a floor is set). The running duty cycle lives in hwmon `pwm1` / `pwm1_max`, where these getters read before the regression.

This change:
- Reverts `rsmi_dev_fan_speed_get` and `rsmi_dev_fan_speed_max_get` to the hwmon `pwm1` / `pwm1_max` path.
- Removes the now-unused `ParseGpuOdFanCurrentPwm` helper (declaration and definition).
- Leaves the fan set/reset gpu_od logic intact, which was the legitimate part of the original change.

Scope: the bug only triggers with OverDrive enabled (the `gpu_od` fan node must exist). On a stock `ppfeaturemask` the node is absent and the getters already fall back to hwmon correctly, so default-configured systems are unaffected.

## Test Plan

Verified on hardware with OverDrive enabled and the GPU under sustained load, comparing hwmon/tachometer against `amd-smi metric --fan`, before and after the fix. Covered both affected architectures.

## Test Result

- **RDNA4 (gfx1201):** buggy build reported `USAGE: 0.0 %` while the fan was spinning; patched build tracked the real duty cycle and matched hwmon. A genuinely stopped fan still correctly reported 0.0%.
- **RDNA3 (gfx1100, RX 7900 XTX):** buggy build stayed pinned at `SPEED: 0  USAGE: 0.0 %` while the fan ramped under load; patched build tracked the fan and `SPEED` matched hwmon `pwm1`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
