### PR TITLE
[ci] Reapply therock_configure_ci_test.py fixes and run tests continuously

### DIFF
--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -10,6 +10,15 @@ import therock_configure_ci
 
 
 class ConfigureCITest(unittest.TestCase):
+    def setUp(self):
+        # Runner selection imports utilities from a sibling TheRock checkout,
+        # which is not required to run these rocm-systems unit tests.
+        select_build_runner_patcher = patch(
+            "therock_configure_ci.select_build_runner", return_value=""
+        )
+        self.addCleanup(select_build_runner_patcher.stop)
+        select_build_runner_patcher.start()
+
     @patch("subprocess.run")
     def test_pull_request(self, mock_run):
         args = {"is_pull_request": True, "base_ref": "HEAD^"}
@@ -18,7 +27,7 @@ class ConfigureCITest(unittest.TestCase):
         mock_process.stdout = "projects/rocminfo/src/main.cpp"
         mock_run.return_value = mock_process
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertGreaterEqual(len(project_to_run), 1)
 
     @patch("subprocess.run")
@@ -29,7 +38,7 @@ class ConfigureCITest(unittest.TestCase):
         mock_process.stdout = ""
         mock_run.return_value = mock_process
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         # Empty modified_paths should return empty list (no changes = no CI)
         self.assertEqual(len(project_to_run), 0)
 
@@ -45,7 +54,7 @@ class ConfigureCITest(unittest.TestCase):
         mock_process.stdout = "projects/rocminfo/src/main.cpp"
         mock_run.return_value = mock_process
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertGreaterEqual(len(project_to_run), 1)
 
     @patch("subprocess.run")
@@ -60,7 +69,7 @@ class ConfigureCITest(unittest.TestCase):
         mock_process.stdout = "projects/rocminfo/src/main.cpp"
         mock_run.return_value = mock_process
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
 
     @patch("subprocess.run")
@@ -75,7 +84,7 @@ class ConfigureCITest(unittest.TestCase):
         mock_process.stdout = "projects/rocminfo/src/main.cpp"
         mock_run.return_value = mock_process
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertGreaterEqual(len(project_to_run), 1)
 
     @patch("subprocess.run")
@@ -86,14 +95,15 @@ class ConfigureCITest(unittest.TestCase):
         mock_process.stdout = "projects/rocminfo/src/main.cpp"
         mock_run.return_value = mock_process
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
 
     def test_scheduled_run(self):
         args = {"is_nightly": True, "input_projects": "", "base_ref": "HEAD^"}
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, test_type = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 1)
+        self.assertEqual(test_type, "comprehensive")
 
     @patch("subprocess.run")
     def test_is_push(self, mock_run):
@@ -103,7 +113,7 @@ class ConfigureCITest(unittest.TestCase):
         mock_process.stdout = "projects/rocminfo/src/main.cpp"
         mock_run.return_value = mock_process
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertGreaterEqual(len(project_to_run), 1)
 
     def test_is_path_skippable(self):
@@ -181,7 +191,7 @@ class ConfigureCITest(unittest.TestCase):
             "projects/rocprim/docs/api.md",
         ]
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
 
     @patch("therock_configure_ci.get_modified_paths")
@@ -201,7 +211,7 @@ class ConfigureCITest(unittest.TestCase):
             "projects/hipother/hello/test.cpp",
         ]
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
 
     @patch("therock_configure_ci.get_modified_paths")
@@ -223,7 +233,7 @@ class ConfigureCITest(unittest.TestCase):
             ".github/workflows/therock-ci.yml",  # contains windows CI trigger
         ]
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 1)
 
     @patch("therock_configure_ci.get_modified_paths")
@@ -249,7 +259,7 @@ class ConfigureCITest(unittest.TestCase):
             ".github/scripts/therock_matrix.py",
         ]
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
 
         self.assertEqual(len(project_to_run), 1)
         cmake_options = project_to_run[0]["cmake_options"]
@@ -280,7 +290,7 @@ class ConfigureCITest(unittest.TestCase):
             "projects/rocprofiler-compute/src/compute.cpp",
         ]
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
 
         # Windows CI must not be skipped for an explicit workflow_dispatch selection
         self.assertEqual(len(project_to_run), 1)
@@ -303,7 +313,7 @@ class ConfigureCITest(unittest.TestCase):
             ".github/scripts/therock_configure_ci.py",
         ]
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertGreaterEqual(len(project_to_run), 1)
 
     @patch("therock_configure_ci.get_modified_paths")
@@ -320,7 +330,7 @@ class ConfigureCITest(unittest.TestCase):
 
         mock_get_modified.return_value = []
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
 
     @patch("therock_configure_ci.get_modified_paths")
@@ -446,7 +456,6 @@ class ConfigureCITest(unittest.TestCase):
         self.assertGreaterEqual(len(projects), 1)
         self.assertEqual(outputs["run_linux_rccl_ci"], "false")
 
-
     @patch("therock_configure_ci.get_modified_paths")
     def test_hipfile_pr_triggers_storage_libs_linux_ci(self, mock_get_modified):
         """PR with hipfile changes should trigger storage_libs build with THEROCK_ENABLE_STORAGE_LIBS=ON."""
@@ -461,7 +470,7 @@ class ConfigureCITest(unittest.TestCase):
             "projects/hipfile/include/hipfile.h",
         ]
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 1)
         cmake_options = project_to_run[0]["cmake_options"]
         self.assertIn("DTHEROCK_ENABLE_STORAGE_LIBS=ON", cmake_options)
@@ -481,7 +490,7 @@ class ConfigureCITest(unittest.TestCase):
             "projects/hipfile/include/hipfile.h",
         ]
 
-        project_to_run = therock_configure_ci.retrieve_projects(args)
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
 
 

--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import os
 import sys
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 import therock_configure_ci
@@ -11,89 +11,81 @@ import therock_configure_ci
 
 class ConfigureCITest(unittest.TestCase):
     def setUp(self):
-        # Runner selection imports utilities from a sibling TheRock checkout,
-        # which is not required to run these rocm-systems unit tests.
+        # Keep run() tests independent of a sibling TheRock checkout and the
+        # GitHub Actions step output file.
         select_build_runner_patcher = patch(
             "therock_configure_ci.select_build_runner", return_value=""
         )
         self.addCleanup(select_build_runner_patcher.stop)
         select_build_runner_patcher.start()
 
-    @patch("subprocess.run")
-    def test_pull_request(self, mock_run):
+        set_github_output_patcher = patch("therock_configure_ci.set_github_output")
+        self.addCleanup(set_github_output_patcher.stop)
+        set_github_output_patcher.start()
+
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_pull_request(self, mock_get_modified):
         args = {"is_pull_request": True, "base_ref": "HEAD^"}
 
-        mock_process = MagicMock()
-        mock_process.stdout = "projects/rocminfo/src/main.cpp"
-        mock_run.return_value = mock_process
+        mock_get_modified.return_value = ["projects/rocminfo/src/main.cpp"]
 
         project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertGreaterEqual(len(project_to_run), 1)
 
-    @patch("subprocess.run")
-    def test_pull_request_empty(self, mock_run):
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_pull_request_empty(self, mock_get_modified):
         args = {"is_pull_request": True, "base_ref": "HEAD^"}
 
-        mock_process = MagicMock()
-        mock_process.stdout = ""
-        mock_run.return_value = mock_process
+        mock_get_modified.return_value = []
 
         project_to_run, _ = therock_configure_ci.retrieve_projects(args)
-        # Empty modified_paths should return empty list (no changes = no CI)
+        # An empty diff should skip CI.
         self.assertEqual(len(project_to_run), 0)
 
-    @patch("subprocess.run")
-    def test_workflow_dispatch(self, mock_run):
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_workflow_dispatch(self, mock_get_modified):
         args = {
             "is_workflow_dispatch": True,
             "input_projects": "projects/rocminfo projects/clr",
             "base_ref": "HEAD^",
         }
 
-        mock_process = MagicMock()
-        mock_process.stdout = "projects/rocminfo/src/main.cpp"
-        mock_run.return_value = mock_process
+        mock_get_modified.return_value = ["projects/rocminfo/src/main.cpp"]
 
         project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertGreaterEqual(len(project_to_run), 1)
 
-    @patch("subprocess.run")
-    def test_workflow_dispatch_bad_input(self, mock_run):
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_workflow_dispatch_bad_input(self, mock_get_modified):
         args = {
             "is_workflow_dispatch": True,
             "input_projects": "projects/invalid$$projects/fake",
             "base_ref": "HEAD^",
         }
 
-        mock_process = MagicMock()
-        mock_process.stdout = "projects/rocminfo/src/main.cpp"
-        mock_run.return_value = mock_process
+        mock_get_modified.return_value = ["projects/rocminfo/src/main.cpp"]
 
         project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
 
-    @patch("subprocess.run")
-    def test_workflow_dispatch_all(self, mock_run):
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_workflow_dispatch_all(self, mock_get_modified):
         args = {
             "is_workflow_dispatch": True,
             "input_projects": "all",
             "base_ref": "HEAD^",
         }
 
-        mock_process = MagicMock()
-        mock_process.stdout = "projects/rocminfo/src/main.cpp"
-        mock_run.return_value = mock_process
+        mock_get_modified.return_value = ["projects/rocminfo/src/main.cpp"]
 
         project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertGreaterEqual(len(project_to_run), 1)
 
-    @patch("subprocess.run")
-    def test_workflow_dispatch_empty(self, mock_run):
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_workflow_dispatch_empty(self, mock_get_modified):
         args = {"is_workflow_dispatch": True, "input_projects": "", "base_ref": "HEAD^"}
 
-        mock_process = MagicMock()
-        mock_process.stdout = "projects/rocminfo/src/main.cpp"
-        mock_run.return_value = mock_process
+        mock_get_modified.return_value = ["projects/rocminfo/src/main.cpp"]
 
         project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
@@ -105,13 +97,11 @@ class ConfigureCITest(unittest.TestCase):
         self.assertEqual(len(project_to_run), 1)
         self.assertEqual(test_type, "comprehensive")
 
-    @patch("subprocess.run")
-    def test_is_push(self, mock_run):
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_is_push(self, mock_get_modified):
         args = {"is_push": True, "base_ref": "HEAD^"}
 
-        mock_process = MagicMock()
-        mock_process.stdout = "projects/rocminfo/src/main.cpp"
-        mock_run.return_value = mock_process
+        mock_get_modified.return_value = ["projects/rocminfo/src/main.cpp"]
 
         project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertGreaterEqual(len(project_to_run), 1)
@@ -135,7 +125,8 @@ class ConfigureCITest(unittest.TestCase):
             "tools/systems_pr_bot/policy_check.py",
             "experimental/perf-dkms/CMakeLists.txt",
             "projects/rocr-runtime/libhsakmt/src/dxg/dxgmodule.c",
-            # Workflow and action files unrelated to TheRock CI are skippable.
+            # GitHub metadata, workflow, and action files unrelated to TheRock
+            # CI are skippable.
             ".github/labeler.yml",
             ".github/labels.yml",
             ".github/actions/rocprofiler-sdk-util/action.yml",
@@ -308,10 +299,8 @@ class ConfigureCITest(unittest.TestCase):
             "platform": "windows",
         }
 
-        # Branch only touched CI scripts — no Windows-path files in the diff
-        mock_get_modified.return_value = [
-            ".github/scripts/therock_configure_ci.py",
-        ]
+        # Explicit workflow_dispatch selections do not depend on modified paths.
+        mock_get_modified.return_value = []
 
         project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertGreaterEqual(len(project_to_run), 1)
@@ -335,7 +324,7 @@ class ConfigureCITest(unittest.TestCase):
 
     @patch("therock_configure_ci.get_modified_paths")
     def test_rccl_ci_triggered_by_rccl_paths_pull_request(self, mock_get_modified):
-        """workflow_dispatch with a windows_only subtree must not trigger Linux CI."""
+        """A RCCL-only pull request should run RCCL CI but not regular CI."""
         args = {"is_pull_request": True, "base_ref": "HEAD^", "platform": "linux"}
 
         mock_get_modified.return_value = [
@@ -352,7 +341,7 @@ class ConfigureCITest(unittest.TestCase):
     def test_rccl_ci_not_triggered_by_non_rccl_paths_pull_request(
         self, mock_get_modified
     ):
-        """workflow_dispatch with a windows_only subtree must not trigger Linux CI."""
+        """A non-RCCL pull request should run regular CI but not RCCL CI."""
         args = {"is_pull_request": True, "base_ref": "HEAD^", "platform": "linux"}
 
         mock_get_modified.return_value = ["projects/rocprim/rocprim.cpp"]
@@ -363,7 +352,7 @@ class ConfigureCITest(unittest.TestCase):
         self.assertEqual(outputs["run_linux_rccl_ci"], "false")
 
     def test_rccl_ci_triggered_nightly(self):
-        """workflow_dispatch with a windows_only subtree must not trigger Linux CI."""
+        """A nightly event should run both regular and RCCL CI."""
         args = {"is_nightly": True, "base_ref": "HEAD^", "platform": "linux"}
 
         outputs = therock_configure_ci.run(args)
@@ -371,8 +360,9 @@ class ConfigureCITest(unittest.TestCase):
         self.assertGreaterEqual(len(projects), 1)
         self.assertEqual(outputs["run_linux_rccl_ci"], "true")
 
-    def test_rccl_ci_triggered_workflow_dispatch(self):
-        """workflow_dispatch with a windows_only subtree must not trigger Linux CI."""
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_rccl_ci_triggered_workflow_dispatch(self, mock_get_modified):
+        """Selecting only RCCL manually should run RCCL CI but not regular CI."""
         args = {
             "is_workflow_dispatch": True,
             "input_projects": "projects/rccl",
@@ -380,21 +370,26 @@ class ConfigureCITest(unittest.TestCase):
             "platform": "linux",
         }
 
+        mock_get_modified.return_value = []
+
         outputs = therock_configure_ci.run(args)
         projects = json.loads(outputs["projects"])
         self.assertEqual(len(projects), 0)
         self.assertEqual(outputs["run_linux_rccl_ci"], "true")
 
-    def test_rccl_ci_not_triggered_push(self):
-        """workflow_dispatch with a windows_only subtree must not trigger Linux CI."""
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_non_rccl_push_runs_regular_ci_only(self, mock_get_modified):
+        """A non-RCCL push should run regular CI but not RCCL CI."""
         args = {"is_push": True, "base_ref": "HEAD^", "platform": "linux"}
+
+        mock_get_modified.return_value = ["projects/rocprim/rocprim.cpp"]
 
         outputs = therock_configure_ci.run(args)
         projects = json.loads(outputs["projects"])
         self.assertGreaterEqual(len(projects), 1)
         self.assertEqual(outputs["run_linux_rccl_ci"], "false")
 
-    # Tests for push event with RCCL changes
+    # Push event combinations.
     @patch("therock_configure_ci.get_modified_paths")
     def test_push_only_rccl_skips_regular_ci(self, mock_get_modified):
         """Push with only RCCL changes should skip regular CI but run RCCL CI."""

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -23,11 +23,6 @@ import time
 from typing import List, Mapping, Optional, Iterable
 import os
 
-# Add TheRock's github_actions to path for shared utilities
-THEROCK_ACTIONS_PATH = Path("TheRock") / "build_tools" / "github_actions"
-sys.path.insert(0, str(THEROCK_ACTIONS_PATH))
-from amdgpu_family_matrix import get_build_runner_labels, select_weighted_label
-
 # Valid test types in order of comprehensiveness (least to most)
 VALID_TEST_TYPES = ["quick", "standard", "comprehensive", "full"]
 
@@ -232,8 +227,7 @@ def check_hip_rocr_changes(modified_paths: Optional[Iterable[str]]) -> bool:
 
     # Check for HIP/ROCR code changes (excluding ignored files)
     return any(
-        is_hip_rocr_code(path) and not is_ignored(path)
-        for path in modified_paths
+        is_hip_rocr_code(path) and not is_ignored(path) for path in modified_paths
     )
 
 
@@ -307,7 +301,9 @@ def retrieve_projects(args):
 
         # Change in CI workflow triggers full subtree evaluation with quick tests
         if check_for_workflow_file_related_to_ci(modified_paths):
-            logging.info("CI workflow files changed, evaluating all subtrees with quick tests")
+            logging.info(
+                "CI workflow files changed, evaluating all subtrees with quick tests"
+            )
             subtrees = list(subtree_to_project_map.keys())
             test_type = "quick"
         elif matched_subtrees:
@@ -343,7 +339,9 @@ def retrieve_projects(args):
 
         # Change in CI workflow triggers full subtree evaluation with quick tests
         if check_for_workflow_file_related_to_ci(modified_paths):
-            logging.info("CI workflow files changed, evaluating all subtrees with quick tests")
+            logging.info(
+                "CI workflow files changed, evaluating all subtrees with quick tests"
+            )
             subtrees = list(subtree_to_project_map.keys())
             test_type = "quick"
 
@@ -445,6 +443,14 @@ def retrieve_projects(args):
 
 def select_build_runner(platform: str) -> str:
     """Select a build runner label based on platform and build variant."""
+    # TheRock is checked out alongside this repository in therock-ci.yml, but it
+    # is not available in a standalone rocm-systems checkout. Keep this import
+    # local so the rest of this module, including its unit tests, can run without
+    # TheRock.
+    therock_actions_path = Path("TheRock") / "build_tools" / "github_actions"
+    sys.path.insert(0, str(therock_actions_path))
+    from amdgpu_family_matrix import get_build_runner_labels, select_weighted_label
+
     build_runner_labels = get_build_runner_labels()
     if platform not in build_runner_labels:
         # Platform not configured for weighted selection, return default
@@ -495,7 +501,9 @@ def run(args):
         if args.get("is_pull_request"):
             base_ref = args.get("base_ref")
             modified_paths = get_modified_paths(base_ref)
-            if check_for_workflow_file_related_to_ci(modified_paths) or check_hip_rocr_changes(modified_paths):
+            if check_for_workflow_file_related_to_ci(
+                modified_paths
+            ) or check_hip_rocr_changes(modified_paths):
                 outputs["run_mi455_test"] = "true"
             else:
                 outputs["run_mi455_test"] = "false"

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -63,6 +63,19 @@ jobs:
           sparse-checkout-cone-mode: true
           fetch-depth: 2
 
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pydantic pytest requests
+
+      - name: Run TheRock CI unit tests
+        run: python -m pytest .github/scripts/tests/therock_configure_ci_test.py
+
       - name: Checkout TheRock repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -77,16 +90,6 @@ jobs:
           ref: main
           path: ci-config
         continue-on-error: true
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: "3.12"
-
-      - name: Install python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pydantic requests
 
       - name: Detect changed subtrees
         id: detect


### PR DESCRIPTION
## Motivation

This reverts https://github.com/ROCm/rocm-systems/pull/9038 to re-apply https://github.com/ROCm/rocm-systems/pull/8882.

Getting these unit tests passing will make it easier to apply adjustments to the filters that run CI and to roll out review policy changes / enforcement as part of https://github.com/ROCm/rocm-systems/issues/7842.

## Technical Details

The second commit contains test fixes to make `.github/scripts/tests/therock_configure_ci_test.py` run correctly even if local git state includes changes in `HEAD^`, which should avoid errors like

```
Run python -m pytest .github/scripts/tests/therock_configure_ci_test.py
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/runner/work/rocm-systems/rocm-systems
collected 28 items

.github/scripts/tests/therock_configure_ci_test.py ...............F..... [ 75%]
.......                                                                  [100%]

=================================== FAILURES ===================================
_______________ ConfigureCITest.test_rccl_ci_not_triggered_push ________________

self = <therock_configure_ci_test.ConfigureCITest testMethod=test_rccl_ci_not_triggered_push>

    def test_rccl_ci_not_triggered_push(self):
        """workflow_dispatch with a windows_only subtree must not trigger Linux CI."""
        args = {"is_push": True, "base_ref": "HEAD^", "platform": "linux"}
    
        outputs = therock_configure_ci.run(args)
        projects = json.loads(outputs["projects"])
>       self.assertGreaterEqual(len(projects), 1)
E       AssertionError: 0 not greater than or equal to 1

.github/scripts/tests/therock_configure_ci_test.py:394: AssertionError
----------------------------- Captured stdout call -----------------------------
modified_paths (max 200): ['projects/rocshmem/docs/sphinx/requirements.txt']
=========================== short test summary info ============================
FAILED .github/scripts/tests/therock_configure_ci_test.py::ConfigureCITest::test_rccl_ci_not_triggered_push - AssertionError: 0 not greater than or equal to 1
========================= 1 failed, 27 passed in 0.25s =========================
Error: Process completed with exit code 1.
```

See also https://github.com/ROCm/rocm-systems/pull/5370 which introduced some of these buggy tests with inaccurate comments.

The test fixes were generated by Codex with this prompt, FYI:

```
I'm working on a roll forward for https://github.com/ROCm/rocm-systems/pull/8882, which I reverted in
https://github.com/ROCm/rocm-systems/pull/9038 due to test failures that only appeared after merge. See also
https://github.com/ROCm/rocm-systems/pull/5370 which originally added some of the failing tests. My local branch
already has the revert reverted so we're ready to update the unit tests with fixes. They pass for me locally with
`python .github\scripts\tests\therock_configure_ci_test.py` in the rocm-systems submodule though, so something from
the environment may be leaking into the tests (e.g. the `"base_ref": "HEAD^"` may be checking git state). See also
build_tools/github_actions/configure_ci_path_filters.py and its tests in TheRock, along with
build_tools/github_actions/tests/configure_multi_arch_ci_test.py - those tests are known working and have already
solved this.

I want to do two things here, with your help:
1. Fix the comments in the rocm-systems/.github/scripts/tests/therock_configure_ci_test.py file in rocm-systems so
they actually reflect the test code (and check that the behavior is what we actually want... hard to tell with
comments that are inaccurate)
2. Make the tests robust to the environment so they pass on both CI and locally
```

## Test Plan

* Ran the unit tests locally (they passed on the PR and locally before though).
* Watch for unit test behavior on postsubmit.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
