### PR TITLE
[rocprofiler-systems] Fix thread-limit tests and fix silent CTest generation failure

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -234,6 +234,17 @@ main(int argc, char** argv)
                       "Write the available hardware counters")
         .max_count(1);
 
+    parser
+        .add_argument({ "--max-threads" },
+                      "Print the compile-time limit on the total number of threads that "
+                      "can be profiled in a single process over its lifetime and exit. "
+                      "Thread slots are counted cumulatively and are not reused when a "
+                      "thread exits")
+        .count(0)
+        .action([](parser_t&) {
+            std::cout << "ROCPROFSYS_MAX_THREADS=" << ROCPROFSYS_MAX_THREADS << "\n";
+        });
+
     parser.add_argument({ "-a", "--all" }, "Print all available info")
         .max_count(1)
         .action([&](parser_t& p) {
@@ -676,7 +687,8 @@ main(int argc, char** argv)
     }
 
     if(parser.exists("list-categories") || parser.exists("list-keys") ||
-       parser.exists("list-operations") || parser.exists("list-domains"))
+       parser.exists("list-operations") || parser.exists("list-domains") ||
+       parser.exists("max-threads"))
         return EXIT_SUCCESS;
 
     std::string _pos_regex{};

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -242,7 +242,10 @@ main(int argc, char** argv)
                       "thread exits")
         .count(0)
         .action([](parser_t&) {
-            std::cout << "ROCPROFSYS_MAX_THREADS=" << ROCPROFSYS_MAX_THREADS << "\n";
+            // NOTE: test_thread_limit.py depends on the wording here to capture
+            // the compile-time value. Any wording change must be reflected in that file.
+            std::cout << "Compile-time limit on the total number of threads: "
+                      << ROCPROFSYS_MAX_THREADS << "\n";
         });
 
     parser.add_argument({ "-a", "--all" }, "Print all available info")

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -242,9 +242,11 @@ main(int argc, char** argv)
                       "thread exits")
         .count(0)
         .action([](parser_t&) {
-            // NOTE: test_thread_limit.py depends on the wording here to capture
-            // the compile-time value. Any wording change must be reflected in that file.
-            std::cout << "Compile-time limit on the total number of threads: "
+            // NOTE: capabilities.py max_threads method depends on the wording here to
+            // capture the compile-time value. Any wording change must be reflected in
+            // that file.
+            std::cout << "Compile-time limit on the total number of threads "
+                         "(ROCPROFSYS_MAX_THREADS): "
                       << ROCPROFSYS_MAX_THREADS << "\n";
         });
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -1120,7 +1120,7 @@ rocprofsys_finalize_hidden(void)
     // if they are still running (e.g. thread-pool still alive), the
     // thread-specific data will be wrong if try to stop them from
     // the main thread.
-    auto _thr_verbose = (config::get_use_causal() || config::get_verbose() > 0) ? 1 : 0;
+    const bool _thr_verbose = config::get_use_causal() || config::get_verbose() > 0;
     if(thread_data<thread_bundle_t>::get())
     {
         for(auto& itr : *thread_data<thread_bundle_t>::get())
@@ -1131,7 +1131,7 @@ rocprofsys_finalize_hidden(void)
                 std::string _msg = itr->as_string();
                 auto        _pos = _msg.find(">>>  ");
                 if(_pos != std::string::npos) _msg = _msg.substr(_pos + 5);
-                if(_thr_verbose > 0)
+                if(_thr_verbose)
                 {
                     LOG_INFO("{}", _msg);
                 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -1120,7 +1120,7 @@ rocprofsys_finalize_hidden(void)
     // if they are still running (e.g. thread-pool still alive), the
     // thread-specific data will be wrong if try to stop them from
     // the main thread.
-    auto _thr_verbose = (config::get_use_causal()) ? 1 : 0;
+    auto _thr_verbose = (config::get_use_causal() || config::get_verbose() > 0) ? 1 : 0;
     if(thread_data<thread_bundle_t>::get())
     {
         for(auto& itr : *thread_data<thread_bundle_t>::get())
@@ -1131,7 +1131,7 @@ rocprofsys_finalize_hidden(void)
                 std::string _msg = itr->as_string();
                 auto        _pos = _msg.find(">>>  ");
                 if(_pos != std::string::npos) _msg = _msg.substr(_pos + 5);
-                if(_thr_verbose >= 0)
+                if(_thr_verbose > 0)
                 {
                     LOG_INFO("{}", _msg);
                 }

--- a/projects/rocprofiler-systems/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/tests/CMakeLists.txt
@@ -48,11 +48,6 @@ set_target_properties(
 # test_categories.yaml drives tier (quick/standard/comprehensive/full) label
 # injection at CTest-generate time (see conftest.py:_load_test_categories).
 set(ROCPROFSYS_TEST_CATEGORIES_YAML ${CMAKE_CURRENT_LIST_DIR}/test_categories.yaml)
-configure_file(
-    ${ROCPROFSYS_TEST_CATEGORIES_YAML}
-    ${CMAKE_BINARY_DIR}/share/rocprofiler-systems/tests/test_categories.yaml
-    COPYONLY
-)
 
 add_custom_target(
     copy-test-files
@@ -78,6 +73,7 @@ add_custom_target(
         ${CMAKE_BINARY_DIR}/share/rocprofiler-systems/tests
 )
 add_dependencies(copy-test-files rocprof-sys-capchk)
+add_dependencies(generate-pytest-ctests copy-test-files)
 
 # ------------------------------------------------------------------------------#
 #

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -612,10 +612,8 @@ def pytest_collection_modifyitems(config, items) -> None:
                 )
 
 
-# Modules that fail to collect (import errors, parametrize-time crashes, ...)
-# are recorded here so CTest generate mode can fail the build loudly instead of
-# silently omitting their tests from the generated suite.
-_collection_errors: list = []
+# Modules that fail to collect are recorded here so CTest generate mode can fail
+_collection_errors: list[pytest.CollectReport] = []
 
 
 def pytest_collectreport(report) -> None:
@@ -624,7 +622,7 @@ def pytest_collectreport(report) -> None:
         _collection_errors.append(report)
 
 
-def pytest_collection_finish(session):
+def pytest_collection_finish(session) -> None:
     if session.config.getoption("--ctest-mode", default="off") == "generate":
         if _collection_errors:
             failures = "\n".join(f"  - {r.nodeid}" for r in _collection_errors)

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -612,8 +612,26 @@ def pytest_collection_modifyitems(config, items) -> None:
                 )
 
 
+# Modules that fail to collect (import errors, parametrize-time crashes, ...)
+# are recorded here so CTest generate mode can fail the build loudly instead of
+# silently omitting their tests from the generated suite.
+_collection_errors: list = []
+
+
+def pytest_collectreport(report) -> None:
+    """Record collection failures for CTest generate mode's abort check."""
+    if report.failed:
+        _collection_errors.append(report)
+
+
 def pytest_collection_finish(session):
     if session.config.getoption("--ctest-mode", default="off") == "generate":
+        if _collection_errors:
+            failures = "\n".join(f"  - {r.nodeid}" for r in _collection_errors)
+            pytest.exit(
+                f"CTestTestfile.cmake generation failed due to:\n{failures}",
+                returncode=1,
+            )
         raw_path = session.config.getoption("--ctest-output-path", default=None)
         output_path = Path(raw_path) if raw_path else None
         _ctest_generate_tests(session.items, output_path)

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -1574,6 +1574,9 @@ def _build_rocprofsys_config_header() -> list[str]:
         else "Not found"
     )
 
+    # capabilities.max_threads reports 0 when rocprof-sys-avail could not be queried
+    max_threads_str = cap.max_threads if cap.max_threads else "Not found"
+
     W = 22  # label width for alignment
 
     def _row(label: str, value) -> str:
@@ -1617,7 +1620,7 @@ def _build_rocprofsys_config_header() -> list[str]:
         "-" * 70,
         "System Capabilities:",
         _row("Detected num procs:", cap.num_procs),
-        _row("Max threads:", cap.max_threads),
+        _row("Max threads:", max_threads_str),
         _row("UCX available:", cap.ucx_availability),
         _row("Perf event paranoid:", cap.perf_event_paranoid),
         _row("CAP_SYS_ADMIN:", cap.cap_sys_admin),

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -1601,6 +1601,7 @@ def _build_rocprofsys_config_header() -> list[str]:
         "-" * 70,
         "System Capabilities:",
         _row("Detected num procs:", cap.num_procs),
+        _row("Max threads:", cap.max_threads),
         _row("UCX available:", cap.ucx_availability),
         _row("Perf event paranoid:", cap.perf_event_paranoid),
         _row("CAP_SYS_ADMIN:", cap.cap_sys_admin),

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -407,11 +407,12 @@ class SystemCapabilities:
             timeout=10,
             check=True,
         )
-        # This should never fail
-        match = re.search(r"ROCPROFSYS_MAX_THREADS\s*=\s*(\d+)", result.stdout)
+        # Must stay in sync with the exact line printed by rocprof-sys-avail's
+        # `--max-threads` action (source/bin/rocprof-sys-avail/avail.cpp).
+        match = re.search(r"total number of threads:\s*(\d+)", result.stdout)
         if not match:
             raise RuntimeError(
-                "Could not parse ROCPROFSYS_MAX_THREADS from "
+                "Could not parse the thread limit from "
                 f"'{self.rocprofsys_avail} --max-threads' output: "
                 f"{result.stdout!r}"
             )

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -390,6 +390,33 @@ class SystemCapabilities:
         except (subprocess.SubprocessError, OSError, subprocess.TimeoutExpired):
             return False
 
+    @persistent_cached_property
+    def max_threads(self) -> int:
+        """Compile-time maximum number of threads that can be profiled at once.
+
+        This is the ``ROCPROFSYS_MAX_THREADS`` CMake constant baked into the
+        binaries at build time. It is queried from
+        ``rocprof-sys-avail --max-threads``
+
+        Throws an error if the value cannot be parsed from the output.
+        """
+        result = subprocess.run(
+            [str(self.rocprofsys_avail), "--max-threads"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+        # This should never fail
+        match = re.search(r"ROCPROFSYS_MAX_THREADS\s*=\s*(\d+)", result.stdout)
+        if not match:
+            raise RuntimeError(
+                "Could not parse ROCPROFSYS_MAX_THREADS from "
+                f"'{self.rocprofsys_avail} --max-threads' output: "
+                f"{result.stdout!r}"
+            )
+        return int(match.group(1))
+
     # ---------------------------------------------------------------------------
     # Do NOT make this a persistent_cached_property: the result depends on the
     # per-process --python-versions / --python-root-dirs hints, so it must not be

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -392,7 +392,11 @@ class SystemCapabilities:
 
     @persistent_cached_property
     def max_threads(self) -> int:
-        """Compile-time maximum number of threads that can be profiled at once.
+        """Compile-time limit on the total number of threads profiled per process.
+
+        The limit is cumulative over the lifetime of the process rather than a
+        cap on concurrency: every thread that is created consumes a slot, and
+        that slot is not reused when the thread exits.
 
         This is the ``ROCPROFSYS_MAX_THREADS`` CMake constant baked into the
         binaries at build time. It is queried from
@@ -409,7 +413,9 @@ class SystemCapabilities:
         )
         # Must stay in sync with the exact line printed by rocprof-sys-avail's
         # `--max-threads` action (source/bin/rocprof-sys-avail/avail.cpp).
-        match = re.search(r"total number of threads:\s*(\d+)", result.stdout)
+        match = re.search(
+            r"total number of threads \(ROCPROFSYS_MAX_THREADS\):\s*(\d+)", result.stdout
+        )
         if not match:
             raise RuntimeError(
                 "Could not parse the thread limit from "

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -402,27 +402,26 @@ class SystemCapabilities:
         binaries at build time. It is queried from
         ``rocprof-sys-avail --max-threads``
 
-        Throws an error if the value cannot be parsed from the output.
+        Returns 0 when the value cannot be determined, so callers degrade
+        gracefully instead of aborting the whole configuration step.
         """
-        result = subprocess.run(
-            [str(self.rocprofsys_avail), "--max-threads"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-            check=True,
-        )
+        try:
+            result = subprocess.run(
+                [str(self.rocprofsys_avail), "--max-threads"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                return 0
+        except (subprocess.SubprocessError, OSError):
+            return 0
         # Must stay in sync with the exact line printed by rocprof-sys-avail's
         # `--max-threads` action (source/bin/rocprof-sys-avail/avail.cpp).
         match = re.search(
             r"total number of threads \(ROCPROFSYS_MAX_THREADS\):\s*(\d+)", result.stdout
         )
-        if not match:
-            raise RuntimeError(
-                "Could not parse the thread limit from "
-                f"'{self.rocprofsys_avail} --max-threads' output: "
-                f"{result.stdout!r}"
-            )
-        return int(match.group(1))
+        return int(match.group(1)) if match else 0
 
     # ---------------------------------------------------------------------------
     # Do NOT make this a persistent_cached_property: the result depends on the

--- a/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
@@ -41,29 +41,8 @@ def thread_limit_env() -> dict[str, str]:
 
 
 def get_thread_limit() -> int:
-    """Get the thread limit values for the test."""
-    # ROCPROFSYS_MAX_THREADS may have been explicitly set, so use that if it exists
-    import os
-
-    max_threads = os.getenv("ROCPROFSYS_MAX_THREADS")
-    if max_threads:
-        return int(max_threads)
-
-    rocprof_config = get_rocprof_config()
-    num_procs = rocprof_config.capabilities.num_procs
-    if num_procs < 128:
-        thread_count = 2048
-    else:
-        # Round up to nearest power of 2
-        n = 16 * num_procs - 1
-        n |= n >> 1
-        n |= n >> 2
-        n |= n >> 4
-        n |= n >> 8
-        n |= n >> 16
-        n |= n >> 32
-        thread_count = n + 1
-    return thread_count
+    """Get the thread limit for the test"""
+    return get_rocprof_config().capabilities.max_threads
 
 
 def get_overflow_thread_load_count() -> int:

--- a/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
@@ -83,22 +83,20 @@ def get_thread_limit_warning_regex(thread_limit: int) -> str:
 @pytest.mark.parametrize(
     "mode", ["sampling", "binary_rewrite", "runtime_instrument", "sys_run"]
 )
-@pytest.mark.parametrize(
-    "thread_count",
-    [
-        get_thread_limit() // 2,
-        get_thread_limit(),
-        get_thread_limit() * 2,
-    ],
-    ids=["half", "at", "double"],
-)
-@pytest.mark.timeout(480)
+@pytest.mark.parametrize("thread_ratio", ["half", "at", "double"])
 @pytest.mark.class_name("thread-limit")
 class TestThreadLimit(RocprofsysTest):
     BINARY_REWRITE_ARGS = ["-e", "-v", "2", "-i", "1024", "--label", "return", "args"]
     RUNTIME_INSTRUMENT_ARGS = ["-e", "-v", "1", "-i", "1024", "--label", "return", "args"]
 
-    def test(self, mode, thread_count, thread_limit_env):
+    def test(self, mode, thread_ratio, thread_limit_env):
+        thread_limit = get_thread_limit()
+        if thread_ratio == "half":
+            thread_count = thread_limit // 2
+        elif thread_ratio == "at":
+            thread_count = thread_limit
+        else:  # "double"
+            thread_count = thread_limit * 2
         result = self.run_test(
             mode,
             "thread-limit",
@@ -107,7 +105,6 @@ class TestThreadLimit(RocprofsysTest):
             binary_rewrite_args=self.BINARY_REWRITE_ARGS,
             runtime_instrument_args=self.RUNTIME_INSTRUMENT_ARGS,
         )
-        thread_limit = get_thread_limit()
         pass_value = get_expected_pass_value(thread_count, thread_limit)
         fail_value = get_expected_fail_value(thread_count, thread_limit)
 

--- a/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
@@ -87,8 +87,14 @@ THREAD_LIMIT_CASES: dict[str, ThreadLimitCase] = {
 
 
 def get_thread_limit() -> int:
-    """Get the thread limit for the test"""
-    return get_rocprof_config().capabilities.max_threads
+    """Thread limit for the test, or skip when rocprof-sys-avail could not report it."""
+    thread_limit = get_rocprof_config().capabilities.max_threads
+    if not thread_limit:
+        pytest.skip(
+            "Could not determine ROCPROFSYS_MAX_THREADS from "
+            "'rocprof-sys-avail --max-threads'"
+        )
+    return thread_limit
 
 
 def get_thread_limit_warning_regex(thread_limit: int) -> str:

--- a/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
@@ -73,7 +73,7 @@ THREAD_LIMIT_CASES: dict[str, ThreadLimitCase] = {
         expect_exhausted_warning=False,
     ),
     "exhausted": ThreadLimitCase(
-        thread_count=lambda limit: limit * 2,
+        thread_count=lambda limit: limit * 4,
         pass_value=lambda thread_count, limit: (limit - 1) - INTERNAL_THREAD_OFFSET,
         fail_value=lambda thread_count, limit: limit + 1,
         expect_exhausted_warning=True,

--- a/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
@@ -6,17 +6,21 @@ Thread limit tests.
 """
 
 from __future__ import annotations
+from dataclasses import dataclass
+from typing import Callable
 import pytest
 from conftest import RocprofsysTest, get_rocprof_config
 
 pytestmark = [pytest.mark.thread_limit]
 
-# rocprof-sys may initialize internal/offset threads (sampling, ROCm, etc.)
-# that consume thread slots without appearing as workload thread rows. Expect the
-# highest profiled thread index to be at most thread_limit - INTERNAL_THREAD_OFFSET.
-# The half-thread case is far below the limit, so use the exact highest launched index.
+# rocprof-sys' own threads (sampling, ROCm) consume slots without producing
+# workload rows, so back off by this much when at or over the limit.
 INTERNAL_THREAD_OFFSET = 20
-OVERFLOW_THREAD_LOAD_MULTIPLIER = 8
+
+# Workload args shared by every case. Threads are created in batches of
+# WORKLOAD_CONCURRENCY, so slots are consumed cumulatively without many being live.
+WORKLOAD_FIB = 35
+WORKLOAD_CONCURRENCY = 2
 
 # ============================================================================
 # Thread Limit Fixtures
@@ -36,33 +40,55 @@ def thread_limit_env() -> dict[str, str]:
 
 
 # ============================================================================
-# Helper Function
+# Thread Limit Case Matrix
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class ThreadLimitCase:
+    """A thread-limit scenario expressed as functions of the runtime thread limit."""
+
+    thread_count: Callable[[int], int]
+    pass_value: Callable[[int, int], int]
+    fail_value: Callable[[int, int], int]
+    expect_exhausted_warning: bool
+
+
+# Below the limit ("half") every launched thread is profiled, so the highest index
+# is the exact top launched index and the absent index is one past it. At or over
+# the limit, internal/offset threads consume slots, so back off by
+# INTERNAL_THREAD_OFFSET and expect one past the limit to be absent. Only the
+# over-limit row is required to emit the thread-limit warning.
+THREAD_LIMIT_CASES: dict[str, ThreadLimitCase] = {
+    "half": ThreadLimitCase(
+        thread_count=lambda limit: limit // 2,
+        pass_value=lambda thread_count, limit: thread_count - 1,
+        fail_value=lambda thread_count, limit: thread_count + 1,
+        expect_exhausted_warning=False,
+    ),
+    "at_limit": ThreadLimitCase(
+        thread_count=lambda limit: limit,
+        pass_value=lambda thread_count, limit: (limit - 1) - INTERNAL_THREAD_OFFSET,
+        fail_value=lambda thread_count, limit: limit + 1,
+        expect_exhausted_warning=False,
+    ),
+    "exhausted": ThreadLimitCase(
+        thread_count=lambda limit: limit * 2,
+        pass_value=lambda thread_count, limit: (limit - 1) - INTERNAL_THREAD_OFFSET,
+        fail_value=lambda thread_count, limit: limit + 1,
+        expect_exhausted_warning=True,
+    ),
+}
+
+
+# ============================================================================
+# Helper Functions
 # ============================================================================
 
 
 def get_thread_limit() -> int:
     """Get the thread limit for the test"""
     return get_rocprof_config().capabilities.max_threads
-
-
-def get_overflow_thread_load_count() -> int:
-    """Thread count for load test — scales with the configured thread limit."""
-    return get_thread_limit() * OVERFLOW_THREAD_LOAD_MULTIPLIER
-
-
-def get_expected_pass_value(thread_count: int, thread_limit: int) -> int:
-    """Highest profiled thread index expected after internal/offset overhead."""
-    max_profiled = min(thread_count - 1, thread_limit - 1)
-    if thread_count == thread_limit // 2:
-        return max_profiled
-    return max_profiled - INTERNAL_THREAD_OFFSET
-
-
-def get_expected_fail_value(thread_count: int, thread_limit: int) -> int:
-    """Thread index that must not appear in profile output."""
-    if thread_count >= thread_limit:
-        return thread_limit + 1
-    return thread_count + 1
 
 
 def get_thread_limit_warning_regex(thread_limit: int) -> str:
@@ -83,59 +109,35 @@ def get_thread_limit_warning_regex(thread_limit: int) -> str:
 @pytest.mark.parametrize(
     "mode", ["sampling", "binary_rewrite", "runtime_instrument", "sys_run"]
 )
-@pytest.mark.parametrize("thread_ratio", ["half", "at", "double"])
+@pytest.mark.parametrize("thread_ratio", list(THREAD_LIMIT_CASES))
 @pytest.mark.class_name("thread-limit")
 class TestThreadLimit(RocprofsysTest):
     BINARY_REWRITE_ARGS = ["-e", "-v", "2", "-i", "1024", "--label", "return", "args"]
-    RUNTIME_INSTRUMENT_ARGS = ["-e", "-v", "1", "-i", "1024", "--label", "return", "args"]
+    RUNTIME_INSTRUMENT_ARGS = ["-e", "-v", "2", "-i", "1024", "--label", "return", "args"]
 
     def test(self, mode, thread_ratio, thread_limit_env):
         thread_limit = get_thread_limit()
-        if thread_ratio == "half":
-            thread_count = thread_limit // 2
-        elif thread_ratio == "at":
-            thread_count = thread_limit
-        else:  # "double"
-            thread_count = thread_limit * 2
+        case = THREAD_LIMIT_CASES[thread_ratio]
+        thread_count = case.thread_count(thread_limit)
         result = self.run_test(
             mode,
             "thread-limit",
             env=thread_limit_env,
-            run_args=["35", "2", str(thread_count)],
+            run_args=[
+                str(WORKLOAD_FIB),
+                str(WORKLOAD_CONCURRENCY),
+                str(thread_count),
+            ],
             binary_rewrite_args=self.BINARY_REWRITE_ARGS,
             runtime_instrument_args=self.RUNTIME_INSTRUMENT_ARGS,
         )
-        pass_value = get_expected_pass_value(thread_count, thread_limit)
-        fail_value = get_expected_fail_value(thread_count, thread_limit)
+        pass_regex = [f"\\|{case.pass_value(thread_count, thread_limit)}>>>"]
+        if case.expect_exhausted_warning:
+            pass_regex.append(get_thread_limit_warning_regex(thread_limit))
 
         self.assert_regex(
             result,
             mode,
-            pass_regex=[f"\\|{pass_value}>>>"],
-            fail_regex=[f"\\|{fail_value}>>>"],
-        )
-
-
-@pytest.mark.parametrize("mode", ["sampling", "sys_run"])
-@pytest.mark.timeout(600)
-@pytest.mark.class_name("thread-limit-load-test")
-class TestThreadLimitLoadTest(RocprofsysTest):
-    def test(self, mode, thread_limit_env, rocprof_config):
-        concurrency = min(rocprof_config.capabilities.num_procs, 16)
-        thread_count = get_overflow_thread_load_count()
-        result = self.run_test(
-            mode,
-            "thread-limit",
-            env=thread_limit_env,
-            run_args=["30", str(concurrency), str(thread_count)],
-        )
-        thread_limit = get_thread_limit()
-        pass_value = get_expected_pass_value(thread_count, thread_limit)
-        fail_value = get_expected_fail_value(thread_count, thread_limit)
-        warning_re = get_thread_limit_warning_regex(thread_limit)
-        self.assert_regex(
-            result,
-            mode,
-            pass_regex=[f"\\|{pass_value}>>>", warning_re],
-            fail_regex=[f"\\|{fail_value}>>>"],
+            pass_regex=pass_regex,
+            fail_regex=[f"\\|{case.fail_value(thread_count, thread_limit)}>>>"],
         )

--- a/projects/rocprofiler-systems/tests/rocprof-sys-pytest.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-pytest.cmake
@@ -134,6 +134,10 @@ set(PYTEST_GENERATE_DEPENDENCIES
     ${ROCPROFSYS_PYTEST_FILES}
 )
 
+# Changes done in this file are used during the CTest generate step to append the
+# appropriate labels to the tests.
+list(APPEND PYTEST_GENERATE_DEPENDENCIES "${CMAKE_CURRENT_LIST_DIR}/test_categories.yaml")
+
 # The pytest CTest generation must wait for the base executables to exist,
 # but relinking them should not invalidate the generated CTest file.
 set(PYTEST_TARGET_DEPENDENCIES

--- a/projects/rocprofiler-systems/tests/test_categories.yaml
+++ b/projects/rocprofiler-systems/tests/test_categories.yaml
@@ -50,7 +50,6 @@ _common_therock_labels_exclude: &_common_therock_labels_exclude
   - "lulesh"
   - "network"
   - "overflow"
-  - "thread_limit"
 
 test_categories:
   quick:


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

`ROCPROFSYS_MAX_THREADS` is a compile time constant that is the core of the `thread-limit` tests. For this test to work on TheRock, we need a way to get the compile time value at runtime and run the test with it. The idea here is to store it within `rocprof-sys-avail`, then read it and run the test against that value.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

**Regarding thread-limit**
 - Store `ROCPROFSYS_MAX_THREADS` in `rocprof-sys-avail`. Accessed using `rocprof-sys-avail --max-threads`.
 - Make` test_categories.yaml` copied to build folder during build time, not configure time.
 - Gate per thread finalization logs on `ROCPROFSYS_VERBOSE>0` or in causal mode.
   - This gets rid of some of the many logs that would be seen during this test. I will be leaving the messages that say:
   `[SIG27] Sampler for thread <N> will be triggered 250.0x per second of CPU-time (every 4.000e+00 milliseconds)... `

**Regarding silent failure**:
 - CTest generation step has been silently failing on TheRock regarding thread-limit test as the `pytest.exit(0)` would mask any error during generation. To fix this, we detect any collection errors and report them, failing the build. 
 - Moved `get_thread_limit()` into the `test` definition itself. Evaluating it during build (during CTesttestfile.cmake generation step) would cause a failure in TheRock CI.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

Jira ID: AIPROFSYST-523
Jira ID: AIPROFSYST-656
Jira ID: ROCM-29285

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Examining TheRock CI workflow to see that the test ran and passed.

## Test Result

<!-- Briefly summarize test outcomes. -->

Ongoing.

Test passes in TheRock CI: https://github.com/ROCm/rocm-systems/actions/runs/30031596021/job/89312443869?pr=9044
```
        Start 546: thread-limit-half-sampling
420/498 Test #546: thread-limit-half-sampling ......................................................................................................................................................   Passed    4.60 sec
        Start 547: thread-limit-half-binary-rewrite
421/498 Test #547: thread-limit-half-binary-rewrite ................................................................................................................................................   Passed    5.49 sec
        Start 548: thread-limit-half-runtime-instrument
422/498 Test #548: thread-limit-half-runtime-instrument ............................................................................................................................................   Passed    7.47 sec
        Start 549: thread-limit-half-sys-run
423/498 Test #549: thread-limit-half-sys-run .......................................................................................................................................................   Passed    4.63 sec
        Start 550: thread-limit-at-limit-sampling
424/498 Test #550: thread-limit-at-limit-sampling ..................................................................................................................................................   Passed    7.57 sec
        Start 551: thread-limit-at-limit-binary-rewrite
425/498 Test #551: thread-limit-at-limit-binary-rewrite ............................................................................................................................................   Passed    8.40 sec
        Start 552: thread-limit-at-limit-runtime-instrument
426/498 Test #552: thread-limit-at-limit-runtime-instrument ........................................................................................................................................   Passed   11.47 sec
        Start 553: thread-limit-at-limit-sys-run
427/498 Test #553: thread-limit-at-limit-sys-run ...................................................................................................................................................   Passed    7.76 sec
        Start 554: thread-limit-exhausted-sampling
428/498 Test #554: thread-limit-exhausted-sampling .................................................................................................................................................   Passed    8.72 sec
        Start 555: thread-limit-exhausted-binary-rewrite
429/498 Test #555: thread-limit-exhausted-binary-rewrite ...........................................................................................................................................   Passed    9.85 sec
        Start 556: thread-limit-exhausted-runtime-instrument
430/498 Test #556: thread-limit-exhausted-runtime-instrument .......................................................................................................................................   Passed   12.59 sec
        Start 557: thread-limit-exhausted-sys-run
431/498 Test #557: thread-limit-exhausted-sys-run ..................................................................................................................................................   Passed    8.47 sec
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
