### PR TITLE
[libhsakmt] Remove erroneous reduction in transfer size in hsaKmtAisReadWriteFile.

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/ais.c
+++ b/projects/rocr-runtime/libhsakmt/src/ais.c
@@ -63,8 +63,6 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtAisReadWriteFile(void *MemoryAddress,
 		return HSAKMT_STATUS_INVALID_PARAMETER;
 	}
 
-	transfer_size = MIN(transfer_size, size_offset);
-
 	args.in.handle = handle;
 	args.in.fd = fd;
 	args.in.file_offset = file_offset;


### PR DESCRIPTION
hsakmt_fmm_get_handle verifies the size passed into the function fits in the object.  It returns the offset from the beginning of the object of the address passed in.  It doesn't make sense to compare the transfer size to this offset.

This is resulting in IO sizes being improperly being reduced in the ioctl call.

This behaviour was introduced in https://github.com/ROCm/rocm-systems/pull/7793

## Issue Tracking

JIRA ID: ROCM-1356

Should fix hash mismatch error described in:
JIRA ID: ROCM-27889

Also fixes ROCM-28565

## Test Plan

Test hipFile against a local TheRock build.

## Test Result

Local build with this change fixed reduced IO sizes we see monitoring AIS in KFD.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
