### PR TITLE
refactor(rocjitsu) Share kernel-descriptor discovery between DBT and DBI

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
@@ -6,6 +6,7 @@ rj_add_object_library(rocjitsu_code
     basic_block.cpp
     executable.cpp
     file_io.cpp
+    kernel_descriptor_scan.cpp
     kernel_symbol.cpp
     relocation_function_table.cpp
     rj_code.cpp

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
@@ -353,41 +353,4 @@ std::optional<uint32_t> AmdGpuCodeObject::min_kernel_sgpr_count(rj_code_arch_t a
   return min_count;
 }
 
-std::vector<KernelDescriptorInfo> AmdGpuCodeObject::kernel_descriptors() const {
-  std::vector<KernelDescriptorInfo> out;
-  if (text_sections().empty())
-    return out;
-  const Section *text = text_sections().front();
-  const uint64_t text_vaddr = text->vaddr();
-  const uint64_t text_end = text_vaddr + text->size();
-
-  for (const auto &[name, kd_vaddr] : kd_offsets_) {
-    const auto located = locate_kernel_descriptor(all_sections(), kd_vaddr);
-    if (!located)
-      continue;
-
-    // kernel_code_entry_byte_offset is signed and relative to the descriptor's
-    // own address. Map it back to a .text-relative offset and drop entries that
-    // do not land inside .text.
-    const int64_t entry_vaddr_signed =
-        static_cast<int64_t>(kd_vaddr) + located->desc.kernel_code_entry_byte_offset;
-    if (entry_vaddr_signed < 0)
-      continue;
-    const uint64_t entry_vaddr = static_cast<uint64_t>(entry_vaddr_signed);
-    if (entry_vaddr < text_vaddr || entry_vaddr >= text_end)
-      continue;
-
-    out.push_back(KernelDescriptorInfo{
-        .name = name,
-        .descriptor_file_offset = located->file_offset,
-        .entry_text_offset = entry_vaddr - text_vaddr,
-        .private_segment_fixed_size = located->desc.private_segment_fixed_size,
-        .granulated_workitem_vgpr_count =
-            AMDHSA_BITS_GET(located->desc.compute_pgm_rsrc1,
-                            rocr::llvm::amdhsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT),
-    });
-  }
-  return out;
-}
-
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.h
@@ -19,16 +19,6 @@
 
 namespace rocjitsu {
 
-/// @brief One kernel descriptor discovered in a code object, with the coordinates
-///        DBI needs to read and (later) rewrite its scratch reservation.
-struct KernelDescriptorInfo {
-  std::string name;                            ///< Kernel name (the .kd symbol minus the suffix).
-  uint64_t descriptor_file_offset = 0;         ///< File offset of the descriptor bytes.
-  uint64_t entry_text_offset = 0;              ///< .text-relative offset of the kernel entry.
-  uint32_t private_segment_fixed_size = 0;     ///< Per-lane scratch bytes from the descriptor.
-  uint32_t granulated_workitem_vgpr_count = 0; ///< Raw compute_pgm_rsrc1 VGPR granule field.
-};
-
 /// @brief Represents a single AMD GPU HSA ELF code object.
 ///
 /// A code object is a device ELF containing GPU machine code (.text sections),
@@ -83,13 +73,6 @@ public:
   /// otherwise the granulated field is an RDNA-style sentinel and the wave owns
   /// the fixed per-wave SGPR pool. @p arch selects that interpretation.
   [[nodiscard]] std::optional<uint32_t> min_kernel_sgpr_count(rj_code_arch_t arch) const;
-
-  /// @brief Enumerate every kernel descriptor with the coordinates a
-  ///        scratch-growing pass needs: descriptor file offset (for writeback),
-  ///        `.text`-relative entry offset (to map an anchor to its kernel), and
-  ///        the current `private_segment_fixed_size`. Skips descriptors that
-  ///        cannot be located or whose entry falls outside `.text`.
-  [[nodiscard]] std::vector<KernelDescriptorInfo> kernel_descriptors() const;
 
 private:
   void load_sections();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
@@ -845,10 +845,10 @@ std::vector<KdTranslation> KernelDescriptorTranslator::translate_image(
     const KernelDescriptorTranslationOptions &options) const {
   std::vector<KdTranslation> translations;
 
-  for (ScannedKernelDescriptor &scanned : scan_kernel_descriptors(image, text_offset, text_size)) {
+  for (KernelDescriptorInfo &kd : scan_kernel_descriptors(image, text_offset, text_size)) {
     translations.push_back(translate_one_descriptor(
-        guest_arch_, host_arch_, scanned.descriptor_file_offset, std::move(scanned.kernel_name),
-        scanned.entry_text_offset, scanned.descriptor, options));
+        guest_arch_, host_arch_, kd.descriptor_file_offset, std::move(kd.kernel_name),
+        kd.entry_text_offset, kd.descriptor, options));
   }
 
   return translations;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
@@ -4,7 +4,7 @@
 #include "rocjitsu/code/dbt/kernel_descriptor_translator.h"
 #include "rocjitsu/code/dbt/virtual_lds.h"
 
-#include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/kernel_descriptor_scan.h"
 #include "rocjitsu/code/patch/instruction_builder.h"
 #include "rocjitsu/code/patch/kernarg_extension.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna1/isa.h"
@@ -29,12 +29,10 @@ RJ_DIAGNOSTIC_POP
 #include <algorithm>
 #include <cstddef>
 #include <cstring>
-#include <functional>
 #include <limits>
 #include <optional>
 #include <sstream>
 #include <string>
-#include <unordered_set>
 #include <utility>
 
 namespace rocjitsu {
@@ -177,125 +175,6 @@ constexpr uint16_t kTtmpRdna4GridX = 9;
   if (arch_supports_wave_size(host_arch, 64))
     return 64;
   return static_cast<uint8_t>(arch_default_wave_size(host_arch));
-}
-
-// -----------------------------------------------------------------------------
-// ELF kernel-descriptor discovery.
-// -----------------------------------------------------------------------------
-
-[[nodiscard]] std::optional<std::string>
-kernel_descriptor_symbol_name(const Elf64_Sym &sym, const char *strtab, size_t strtab_size) {
-  if (sym.st_size != sizeof(KD))
-    return std::nullopt;
-
-  // AMDHSA kernel descriptors are global object symbols. Size alone is not a
-  // durable signal because unrelated data objects can also be 64 bytes.
-  if (elf_symbol_type(sym.st_info) != kElfSymbolTypeObject ||
-      elf_symbol_bind(sym.st_info) != kElfSymbolBindGlobal)
-    return std::nullopt;
-
-  // AMDHSA descriptors are named "<kernel>.kd". An unnamed 64-byte global
-  // object is ambiguous, so require the ABI suffix instead of treating stripped
-  // or minimized symbol records as descriptors.
-  if (strtab == nullptr || strtab_size == 0 || sym.st_name == 0)
-    return std::nullopt;
-  if (sym.st_name >= strtab_size)
-    return std::nullopt;
-
-  const char *name = strtab + sym.st_name;
-  const size_t len = strnlen(name, strtab_size - sym.st_name);
-  if (len <= 3 || std::strcmp(name + len - 3, ".kd") != 0)
-    return std::nullopt;
-  return std::string(name, len - 3);
-}
-
-[[nodiscard]] std::optional<uint64_t> text_vaddr_for_section(uint64_t text_offset,
-                                                             uint64_t text_size,
-                                                             const Elf64_Ehdr &ehdr,
-                                                             const Elf64_Shdr *shdr) {
-  for (int i = 0; i < ehdr.e_shnum; ++i) {
-    if (shdr[i].sh_offset == text_offset && shdr[i].sh_size == text_size)
-      return shdr[i].sh_addr;
-  }
-  return std::nullopt;
-}
-
-using KernelDescriptorVisitor =
-    std::function<void(uint64_t descriptor_file_offset, std::string kernel_name,
-                       uint64_t entry_text_offset, const KD &desc)>;
-
-void visit_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offset,
-                              uint64_t text_size, const KernelDescriptorVisitor &callback) {
-  if (image.size() < sizeof(Elf64_Ehdr))
-    return;
-
-  const auto *ehdr = reinterpret_cast<const Elf64_Ehdr *>(image.data());
-  if (ehdr->e_shoff + static_cast<uint64_t>(ehdr->e_shnum) * sizeof(Elf64_Shdr) > image.size())
-    return;
-
-  const auto *shdr = reinterpret_cast<const Elf64_Shdr *>(image.data() + ehdr->e_shoff);
-  auto text_vaddr = text_vaddr_for_section(text_offset, text_size, *ehdr, shdr);
-  if (!text_vaddr)
-    return;
-  constexpr uint64_t max_u64 = std::numeric_limits<uint64_t>::max();
-  if (*text_vaddr > max_u64 - text_size)
-    return;
-  const uint64_t text_end = *text_vaddr + text_size;
-
-  // .symtab and .dynsym may both describe the same descriptor. Translation is
-  // keyed by descriptor bytes, so visit each file offset once.
-  std::unordered_set<uint64_t> seen_descriptor_offsets;
-  for (int i = 0; i < ehdr->e_shnum; ++i) {
-    if (shdr[i].sh_type != SHT_SYMTAB && shdr[i].sh_type != SHT_DYNSYM)
-      continue;
-    if (shdr[i].sh_offset + shdr[i].sh_size > image.size() || shdr[i].sh_entsize == 0)
-      continue;
-    if (shdr[i].sh_entsize != sizeof(Elf64_Sym))
-      continue;
-
-    const char *strtab = nullptr;
-    size_t strtab_size = 0;
-    if (shdr[i].sh_link < ehdr->e_shnum) {
-      const auto &strtab_shdr = shdr[shdr[i].sh_link];
-      if (strtab_shdr.sh_offset + strtab_shdr.sh_size <= image.size()) {
-        strtab = reinterpret_cast<const char *>(image.data() + strtab_shdr.sh_offset);
-        strtab_size = strtab_shdr.sh_size;
-      }
-    }
-
-    const auto *symtab = reinterpret_cast<const Elf64_Sym *>(image.data() + shdr[i].sh_offset);
-    const size_t nsyms = shdr[i].sh_size / shdr[i].sh_entsize;
-    for (size_t j = 0; j < nsyms; ++j) {
-      auto kernel_name = kernel_descriptor_symbol_name(symtab[j], strtab, strtab_size);
-      if (!kernel_name)
-        continue;
-
-      const uint16_t sec_idx = symtab[j].st_shndx;
-      if (sec_idx >= ehdr->e_shnum || symtab[j].st_value < shdr[sec_idx].sh_addr)
-        continue;
-
-      const uint64_t file_off =
-          shdr[sec_idx].sh_offset + (symtab[j].st_value - shdr[sec_idx].sh_addr);
-      if (file_off + sizeof(KD) > image.size())
-        continue;
-      if (!seen_descriptor_offsets.insert(file_off).second)
-        continue;
-
-      KD desc;
-      std::memcpy(&desc, image.data() + file_off, sizeof(desc));
-      const int64_t entry_vaddr_signed =
-          static_cast<int64_t>(symtab[j].st_value) + desc.kernel_code_entry_byte_offset;
-
-      if (entry_vaddr_signed < 0)
-        continue;
-      const uint64_t entry_vaddr = static_cast<uint64_t>(entry_vaddr_signed);
-      if (entry_vaddr < *text_vaddr || entry_vaddr >= text_end)
-        continue;
-
-      const uint64_t entry_text_offset = entry_vaddr - *text_vaddr;
-      callback(file_off, std::move(*kernel_name), entry_text_offset, desc);
-    }
-  }
 }
 
 // -----------------------------------------------------------------------------
@@ -966,15 +845,11 @@ std::vector<KdTranslation> KernelDescriptorTranslator::translate_image(
     const KernelDescriptorTranslationOptions &options) const {
   std::vector<KdTranslation> translations;
 
-  visit_kernel_descriptors(image, text_offset, text_size,
-                           [&](uint64_t descriptor_file_offset, std::string kernel_name,
-                               uint64_t entry_text_offset, const KD &src) {
-                             KD desc{};
-                             std::memcpy(&desc, &src, sizeof(desc));
-                             translations.push_back(translate_one_descriptor(
-                                 guest_arch_, host_arch_, descriptor_file_offset,
-                                 std::move(kernel_name), entry_text_offset, desc, options));
-                           });
+  for (ScannedKernelDescriptor &scanned : scan_kernel_descriptors(image, text_offset, text_size)) {
+    translations.push_back(translate_one_descriptor(
+        guest_arch_, host_arch_, scanned.descriptor_file_offset, std::move(scanned.kernel_name),
+        scanned.entry_text_offset, scanned.descriptor, options));
+  }
 
   return translations;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_descriptor_scan.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_descriptor_scan.cpp
@@ -58,9 +58,9 @@ kernel_descriptor_symbol_name(const Elf64_Sym &sym, const char *strtab, size_t s
 
 } // namespace
 
-std::vector<ScannedKernelDescriptor>
+std::vector<KernelDescriptorInfo>
 scan_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offset, uint64_t text_size) {
-  std::vector<ScannedKernelDescriptor> out;
+  std::vector<KernelDescriptorInfo> out;
   if (image.size() < sizeof(Elf64_Ehdr))
     return out;
 
@@ -127,7 +127,7 @@ scan_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offset, ui
       if (entry_vaddr < *text_vaddr || entry_vaddr >= text_end)
         continue;
 
-      out.push_back(ScannedKernelDescriptor{
+      out.push_back(KernelDescriptorInfo{
           .descriptor_file_offset = file_off,
           .kernel_name = std::move(*kernel_name),
           .entry_text_offset = entry_vaddr - *text_vaddr,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_descriptor_scan.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_descriptor_scan.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/kernel_descriptor_scan.h"
+
+#include "rocjitsu/code/amdgpu_elf.h"
+
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <unordered_set>
+#include <utility>
+
+namespace rocjitsu {
+
+namespace {
+
+using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
+
+static_assert(sizeof(KD) == 64, "AMDHSA kernel descriptor size changed");
+
+[[nodiscard]] std::optional<std::string>
+kernel_descriptor_symbol_name(const Elf64_Sym &sym, const char *strtab, size_t strtab_size) {
+  if (sym.st_size != sizeof(KD))
+    return std::nullopt;
+
+  // AMDHSA kernel descriptors are global object symbols. Size alone is not a
+  // durable signal because unrelated data objects can also be 64 bytes.
+  if (elf_symbol_type(sym.st_info) != kElfSymbolTypeObject ||
+      elf_symbol_bind(sym.st_info) != kElfSymbolBindGlobal)
+    return std::nullopt;
+
+  // AMDHSA descriptors are named "<kernel>.kd". An unnamed 64-byte global object
+  // is ambiguous, so require the ABI suffix instead of treating stripped or
+  // minimized symbol records as descriptors.
+  if (strtab == nullptr || strtab_size == 0 || sym.st_name == 0)
+    return std::nullopt;
+  if (sym.st_name >= strtab_size)
+    return std::nullopt;
+
+  const char *name = strtab + sym.st_name;
+  const size_t len = strnlen(name, strtab_size - sym.st_name);
+  if (len <= 3 || std::strcmp(name + len - 3, ".kd") != 0)
+    return std::nullopt;
+  return std::string(name, len - 3);
+}
+
+[[nodiscard]] std::optional<uint64_t> text_vaddr_for_section(uint64_t text_offset,
+                                                             uint64_t text_size,
+                                                             const Elf64_Ehdr &ehdr,
+                                                             const Elf64_Shdr *shdr) {
+  for (int i = 0; i < ehdr.e_shnum; ++i) {
+    if (shdr[i].sh_offset == text_offset && shdr[i].sh_size == text_size)
+      return shdr[i].sh_addr;
+  }
+  return std::nullopt;
+}
+
+} // namespace
+
+std::vector<ScannedKernelDescriptor>
+scan_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offset, uint64_t text_size) {
+  std::vector<ScannedKernelDescriptor> out;
+  if (image.size() < sizeof(Elf64_Ehdr))
+    return out;
+
+  const auto *ehdr = reinterpret_cast<const Elf64_Ehdr *>(image.data());
+  if (ehdr->e_shoff + static_cast<uint64_t>(ehdr->e_shnum) * sizeof(Elf64_Shdr) > image.size())
+    return out;
+
+  const auto *shdr = reinterpret_cast<const Elf64_Shdr *>(image.data() + ehdr->e_shoff);
+  auto text_vaddr = text_vaddr_for_section(text_offset, text_size, *ehdr, shdr);
+  if (!text_vaddr)
+    return out;
+  constexpr uint64_t max_u64 = std::numeric_limits<uint64_t>::max();
+  if (*text_vaddr > max_u64 - text_size)
+    return out;
+  const uint64_t text_end = *text_vaddr + text_size;
+
+  // .symtab and .dynsym may both describe the same descriptor. Discovery is keyed
+  // by descriptor bytes, so visit each file offset once.
+  std::unordered_set<uint64_t> seen_descriptor_offsets;
+  for (int i = 0; i < ehdr->e_shnum; ++i) {
+    if (shdr[i].sh_type != SHT_SYMTAB && shdr[i].sh_type != SHT_DYNSYM)
+      continue;
+    if (shdr[i].sh_offset + shdr[i].sh_size > image.size() || shdr[i].sh_entsize == 0)
+      continue;
+    if (shdr[i].sh_entsize != sizeof(Elf64_Sym))
+      continue;
+
+    const char *strtab = nullptr;
+    size_t strtab_size = 0;
+    if (shdr[i].sh_link < ehdr->e_shnum) {
+      const auto &strtab_shdr = shdr[shdr[i].sh_link];
+      if (strtab_shdr.sh_offset + strtab_shdr.sh_size <= image.size()) {
+        strtab = reinterpret_cast<const char *>(image.data() + strtab_shdr.sh_offset);
+        strtab_size = strtab_shdr.sh_size;
+      }
+    }
+
+    const auto *symtab = reinterpret_cast<const Elf64_Sym *>(image.data() + shdr[i].sh_offset);
+    const size_t nsyms = shdr[i].sh_size / shdr[i].sh_entsize;
+    for (size_t j = 0; j < nsyms; ++j) {
+      auto kernel_name = kernel_descriptor_symbol_name(symtab[j], strtab, strtab_size);
+      if (!kernel_name)
+        continue;
+
+      const uint16_t sec_idx = symtab[j].st_shndx;
+      if (sec_idx >= ehdr->e_shnum || symtab[j].st_value < shdr[sec_idx].sh_addr)
+        continue;
+
+      const uint64_t file_off =
+          shdr[sec_idx].sh_offset + (symtab[j].st_value - shdr[sec_idx].sh_addr);
+      if (file_off + sizeof(KD) > image.size())
+        continue;
+      if (!seen_descriptor_offsets.insert(file_off).second)
+        continue;
+
+      KD desc;
+      std::memcpy(&desc, image.data() + file_off, sizeof(desc));
+      const int64_t entry_vaddr_signed =
+          static_cast<int64_t>(symtab[j].st_value) + desc.kernel_code_entry_byte_offset;
+
+      if (entry_vaddr_signed < 0)
+        continue;
+      const uint64_t entry_vaddr = static_cast<uint64_t>(entry_vaddr_signed);
+      if (entry_vaddr < *text_vaddr || entry_vaddr >= text_end)
+        continue;
+
+      out.push_back(ScannedKernelDescriptor{
+          .descriptor_file_offset = file_off,
+          .kernel_name = std::move(*kernel_name),
+          .entry_text_offset = entry_vaddr - *text_vaddr,
+          .descriptor = desc,
+      });
+    }
+  }
+  return out;
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_descriptor_scan.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_descriptor_scan.h
@@ -21,7 +21,7 @@ RJ_DIAGNOSTIC_POP
 namespace rocjitsu {
 
 /// @brief One AMDHSA kernel descriptor located in an ELF image.
-struct ScannedKernelDescriptor {
+struct KernelDescriptorInfo {
   uint64_t descriptor_file_offset = 0; ///< File offset of the 64-byte descriptor (pre-growth).
   std::string kernel_name;             ///< Symbol name minus the ".kd" suffix.
   uint64_t entry_text_offset = 0;      ///< .text-relative kernel entry.
@@ -34,7 +34,7 @@ struct ScannedKernelDescriptor {
 /// .text-relative entry, drops entries outside .text, and dedups by file offset.
 /// The single discovery routine shared by DBT translation and DBI; operates on the
 /// raw, pre-growth image.
-[[nodiscard]] std::vector<ScannedKernelDescriptor>
+[[nodiscard]] std::vector<KernelDescriptorInfo>
 scan_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offset, uint64_t text_size);
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_descriptor_scan.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_descriptor_scan.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file kernel_descriptor_scan.h
+/// @brief Shared AMDHSA kernel-descriptor discovery used by DBT and DBI.
+
+#ifndef ROCJITSU_CODE_KERNEL_DESCRIPTOR_SCAN_H_
+#define ROCJITSU_CODE_KERNEL_DESCRIPTOR_SCAN_H_
+
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "hsa/AMDHSAKernelDescriptor.h"
+RJ_DIAGNOSTIC_POP
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace rocjitsu {
+
+/// @brief One AMDHSA kernel descriptor located in an ELF image.
+struct ScannedKernelDescriptor {
+  uint64_t descriptor_file_offset = 0; ///< File offset of the 64-byte descriptor (pre-growth).
+  std::string kernel_name;             ///< Symbol name minus the ".kd" suffix.
+  uint64_t entry_text_offset = 0;      ///< .text-relative kernel entry.
+  rocr::llvm::amdhsa::kernel_descriptor_t descriptor{}; ///< Raw descriptor bytes.
+};
+
+/// @brief Locate every ".kd" descriptor whose entry lands in .text.
+///
+/// @details Walks .symtab/.dynsym, decodes each descriptor's file offset and
+/// .text-relative entry, drops entries outside .text, and dedups by file offset.
+/// The single discovery routine shared by DBT translation and DBI; operates on the
+/// raw, pre-growth image.
+[[nodiscard]] std::vector<ScannedKernelDescriptor>
+scan_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offset, uint64_t text_size);
+
+} // namespace rocjitsu
+
+#endif // ROCJITSU_CODE_KERNEL_DESCRIPTOR_SCAN_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
@@ -94,6 +94,10 @@ public:
   /// cover the appended spill zone. Reads the descriptor at @p
   /// descriptor_file_offset, sets the scratch-size field to @p bytes, and writes
   /// it back. Returns false if the descriptor does not fit in the image.
+  ///
+  /// Deliberately narrower than DBT's apply_kernel_descriptor_translation: a
+  /// same-arch instrument-only pass must re-encode no other descriptor field
+  /// (VGPR/SGPR granules, mode bits, USER_SGPR_COUNT, kernarg size).
   [[nodiscard]] bool set_private_segment_fixed_size(uint64_t descriptor_file_offset,
                                                     uint32_t bytes);
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -679,7 +679,7 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
   // must spill grows that one kernel's per-lane scratch. The SpillManager is
   // created lazily on the first spilling site and shared by the rest; its final
   // size is written back to the descriptor after all sites succeed.
-  const std::vector<ScannedKernelDescriptor> kernels =
+  const std::vector<KernelDescriptorInfo> kernels =
       scan_kernel_descriptors(patcher.image_bytes(), patcher.text_offset(), patcher.text_size());
   std::optional<SpillManager> spills;
   uint64_t spill_descriptor_file_offset = 0;
@@ -774,7 +774,7 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
               "fixed scratch to spill into");
           continue;
         }
-        const ScannedKernelDescriptor &kernel = kernels.front();
+        const KernelDescriptorInfo &kernel = kernels.front();
         if (!spills) {
           // Cap total per-lane scratch at the widest slot the scratch offset field
           // can encode, so the SpillManager limit and the per-instruction offset

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/basic_block.h"
 #include "rocjitsu/code/code_object.h"
+#include "rocjitsu/code/kernel_descriptor_scan.h"
 #include "rocjitsu/code/patch/code_object_patcher.h"
 #include "rocjitsu/code/patch/error_report.h"
 #include "rocjitsu/code/patch/instruction_builder.h"
@@ -678,7 +679,8 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
   // must spill grows that one kernel's per-lane scratch. The SpillManager is
   // created lazily on the first spilling site and shared by the rest; its final
   // size is written back to the descriptor after all sites succeed.
-  const std::vector<KernelDescriptorInfo> kernels = obj_.kernel_descriptors();
+  const std::vector<ScannedKernelDescriptor> kernels =
+      scan_kernel_descriptors(patcher.image_bytes(), patcher.text_offset(), patcher.text_size());
   std::optional<SpillManager> spills;
   uint64_t spill_descriptor_file_offset = 0;
 
@@ -765,20 +767,20 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
       if (!spill.none()) {
         // Single-kernel assumption: spilling needs exactly one kernel descriptor
         // with non-zero fixed scratch to grow.
-        if (kernels.size() != 1 || kernels.front().private_segment_fixed_size == 0) {
+        if (kernels.size() != 1 || kernels.front().descriptor.private_segment_fixed_size == 0) {
           result.errors.push_back(
               "probe call at anchor_offset " + std::to_string(site.anchor_offset) +
               " must spill live registers, but the code object does not have a single kernel with "
               "fixed scratch to spill into");
           continue;
         }
-        const KernelDescriptorInfo &kernel = kernels.front();
+        const ScannedKernelDescriptor &kernel = kernels.front();
         if (!spills) {
           // Cap total per-lane scratch at the widest slot the scratch offset field
           // can encode, so the SpillManager limit and the per-instruction offset
           // guards in the planners agree.
           const uint32_t scratch_limit = max_scratch_offset_bytes(arch_) + SpillManager::kSlotBytes;
-          spills.emplace(kernel.private_segment_fixed_size, scratch_limit);
+          spills.emplace(kernel.descriptor.private_segment_fixed_size, scratch_limit);
           spill_descriptor_file_offset = kernel.descriptor_file_offset;
         }
         // Split by class: VGPRs go straight to scratch; SGPRs need a bridge VGPR.
@@ -792,8 +794,11 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
           result.errors.push_back(std::move(err));
           continue;
         }
+        const uint32_t granulated_vgpr_count =
+            AMDHSA_BITS_GET(kernel.descriptor.compute_pgm_rsrc1,
+                            rocr::llvm::amdhsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT);
         const uint32_t kernel_vgpr_count =
-            (kernel.granulated_workitem_vgpr_count + 1) * vgpr_encoding_granule(arch_);
+            (granulated_vgpr_count + 1) * vgpr_encoding_granule(arch_);
         if (!sgpr_spill.none() &&
             !plan_sgpr_spills(sgpr_spill, live, plan.vgpr_spills, kernel_vgpr_count, *spills, arch_,
                               plan.sgpr_spills, plan.spill_bridge_vgpr, &err)) {
@@ -837,9 +842,8 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
     return result;
 
   // Grow the spilled kernel's per-lane scratch to cover its DBI spill zone. Done
-  // before replace_text so the edit lands at the descriptor's original file
-  // offset; replace_text then relocates the descriptor bytes with the rest of the
-  // ELF.
+  // before replace_text so the edit lands at the descriptor's original file offset;
+  // replace_text then relocates the descriptor with the rest of the ELF.
   if (spills) {
     if (!patcher.set_private_segment_fixed_size(spill_descriptor_file_offset,
                                                 spills->total_private_bytes())) {

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -362,6 +362,7 @@ add_executable(
     code/code_object_target_id_test.cpp
     code/amdgpu_code_object_test.cpp
     code/relocation_function_table_test.cpp
+    code/kernel_descriptor_scan_test.cpp
     dbt/semantic_scratch_test.cpp
     dbt/waitcnt_translator_test.cpp
     dbt/virtual_lds_dispatch_rewrite_test.cpp

--- a/emulation/rocjitsu/tests/code/kernel_descriptor_scan_test.cpp
+++ b/emulation/rocjitsu/tests/code/kernel_descriptor_scan_test.cpp
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file kernel_descriptor_scan_test.cpp
+/// @brief Unit tests for scan_kernel_descriptors -- the ELF walk shared by DBT
+///        (translate_image) and DBI (instrumentor). Pins the discovery contract
+///        directly, using the shared gfx950 fixture builder. Multi-kernel and
+///        stripped/.dynsym discovery are exercised by tests/dbt/translate_test.cpp.
+
+#include "rocjitsu/code/kernel_descriptor_scan.h"
+
+#include "rocjitsu/code/amdgpu_code_object.h"
+#include "rocjitsu/code/code_object.h"
+
+#include "../patch/gfx950_test_fixtures.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace rocjitsu {
+namespace {
+
+using namespace rocjitsu::test;
+using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
+
+// scan the fixture image using its own .text section coordinates.
+std::vector<ScannedKernelDescriptor> scan_via_text_section(const std::vector<uint8_t> &image) {
+  AmdGpuCodeObject obj(image.data(), image.size());
+  EXPECT_TRUE(obj.is_valid());
+  EXPECT_FALSE(obj.text_sections().empty());
+  const Section *text = obj.text_sections().front();
+  return scan_kernel_descriptors({image.data(), image.size()}, text->sectionOffset(), text->size());
+}
+
+// The single fixture kernel is located with name, file offset, .text-relative
+// entry, and raw descriptor bytes all decoded correctly.
+TEST(KernelDescriptorScan, SingleKernelDecodesAllFields) {
+  const auto image = make_gfx950_kernel_elf({kMovV3V2, 0xbf810000u}, /*private_bytes=*/256);
+  const auto found = scan_via_text_section(image);
+  ASSERT_EQ(found.size(), 1u);
+  EXPECT_EQ(found[0].kernel_name, "test_kernel");
+  EXPECT_EQ(found[0].entry_text_offset, 0u); // fixture entry is at .text offset 0
+  EXPECT_EQ(found[0].descriptor.private_segment_fixed_size, 256u);
+  // The reported file offset points at the actual descriptor bytes.
+  ASSERT_LE(found[0].descriptor_file_offset + sizeof(KD), image.size());
+  KD at_offset{};
+  std::memcpy(&at_offset, image.data() + found[0].descriptor_file_offset, sizeof(KD));
+  EXPECT_EQ(at_offset.private_segment_fixed_size, 256u);
+}
+
+// A descriptor whose decoded entry lands outside .text is dropped. Rewrite the
+// fixture descriptor's entry so it points at the descriptor's own (.rodata)
+// address instead of .text, then confirm the walk excludes it.
+TEST(KernelDescriptorScan, EntryOutsideTextIsDropped) {
+  auto image = make_gfx950_kernel_elf({kMovV3V2, 0xbf810000u}, /*private_bytes=*/64);
+  const auto located = scan_via_text_section(image);
+  ASSERT_EQ(located.size(), 1u);
+
+  KD desc{};
+  std::memcpy(&desc, image.data() + located[0].descriptor_file_offset, sizeof(KD));
+  desc.kernel_code_entry_byte_offset = 0; // entry now resolves to the .rodata KD vaddr
+  std::memcpy(image.data() + located[0].descriptor_file_offset, &desc, sizeof(KD));
+
+  EXPECT_TRUE(scan_via_text_section(image).empty());
+}
+
+// A too-small buffer is not a valid ELF: no descriptors, no crash.
+TEST(KernelDescriptorScan, TooSmallImageReturnsEmpty) {
+  std::vector<uint8_t> tiny(8, 0);
+  EXPECT_TRUE(scan_kernel_descriptors({tiny.data(), tiny.size()}, 0x100, 0x8).empty());
+}
+
+// When no section matches the requested (text_offset, text_size), the walk cannot
+// resolve .text's base address and returns nothing.
+TEST(KernelDescriptorScan, NoMatchingTextSectionReturnsEmpty) {
+  const auto image = make_gfx950_kernel_elf({kMovV3V2, 0xbf810000u}, /*private_bytes=*/64);
+  const auto found = scan_kernel_descriptors({image.data(), image.size()},
+                                             /*text_offset=*/0xDEAD, /*text_size=*/0x4);
+  EXPECT_TRUE(found.empty());
+}
+
+} // namespace
+} // namespace rocjitsu

--- a/emulation/rocjitsu/tests/code/kernel_descriptor_scan_test.cpp
+++ b/emulation/rocjitsu/tests/code/kernel_descriptor_scan_test.cpp
@@ -27,7 +27,7 @@ using namespace rocjitsu::test;
 using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
 
 // scan the fixture image using its own .text section coordinates.
-std::vector<ScannedKernelDescriptor> scan_via_text_section(const std::vector<uint8_t> &image) {
+std::vector<KernelDescriptorInfo> scan_via_text_section(const std::vector<uint8_t> &image) {
   AmdGpuCodeObject obj(image.data(), image.size());
   EXPECT_TRUE(obj.is_valid());
   EXPECT_FALSE(obj.text_sections().empty());

--- a/emulation/rocjitsu/tests/patch/gfx950_test_fixtures.h
+++ b/emulation/rocjitsu/tests/patch/gfx950_test_fixtures.h
@@ -18,6 +18,7 @@
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/code_object.h"
+#include "rocjitsu/code/kernel_descriptor_scan.h"
 
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
@@ -105,9 +106,9 @@ inline uint64_t align_up_for_test(uint64_t value, uint64_t alignment) {
 // gfx950 ET_DYN ELF with one kernel: a .kd descriptor (scratch = private_bytes,
 // SGPR granulation big enough for the s[30:31] link pair) plus a .text holding
 // `text_words`, entry at .text offset 0. The `.kd` symbol is a global
-// STT_OBJECT of descriptor size so AmdGpuCodeObject::kernel_descriptors() (and
-// replace_text) can find and keep it coherent. Modeled on the in-file
-// make_gfx950_kernel_elf in instrumentor_test.cpp.
+// STT_OBJECT of descriptor size so scan_kernel_descriptors() (and replace_text)
+// can find and keep it coherent. Modeled on the in-file make_gfx950_kernel_elf
+// in instrumentor_test.cpp.
 inline std::vector<uint8_t> make_gfx950_kernel_elf(const std::vector<uint32_t> &text_words,
                                                    uint32_t private_bytes,
                                                    uint32_t granulated_sgpr_count = 3) {
@@ -500,8 +501,13 @@ inline std::vector<uint32_t> section_words(const AmdGpuCodeObject &obj, std::str
 
 // Read back the (single) kernel's scratch size from a patched ELF.
 inline uint32_t patched_private_segment_size(const AmdGpuCodeObject &obj) {
-  const auto kernels = obj.kernel_descriptors();
-  return kernels.size() == 1 ? kernels.front().private_segment_fixed_size : 0xFFFFFFFFu;
+  if (obj.text_sections().empty())
+    return 0xFFFFFFFFu;
+  const Section *text = obj.text_sections().front();
+  const auto kernels = scan_kernel_descriptors(
+      {reinterpret_cast<const uint8_t *>(obj.image_data()), obj.image_size()},
+      text->sectionOffset(), text->size());
+  return kernels.size() == 1 ? kernels.front().descriptor.private_segment_fixed_size : 0xFFFFFFFFu;
 }
 
 } // namespace rocjitsu::test

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -6,6 +6,7 @@
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/basic_block.h"
+#include "rocjitsu/code/kernel_descriptor_scan.h"
 #include "rocjitsu/code/patch/instruction_builder.h"
 #include "rocjitsu/code/patch/probe_clobber.h"
 #include "rocjitsu/code/patch/trampoline_builder.h"

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -2258,7 +2258,12 @@ TEST(InstrumentorProbeSpill, Cdna4MultiKernelSpillFailsClosed) {
   AmdGpuCodeObject probe_obj(probe.data(), probe.size());
   ASSERT_TRUE(obj.is_valid());
   ASSERT_TRUE(probe_obj.is_valid());
-  ASSERT_EQ(obj.kernel_descriptors().size(), 2u);
+  const Section *text = obj.text_sections().front();
+  ASSERT_EQ(scan_kernel_descriptors(
+                {reinterpret_cast<const uint8_t *>(obj.image_data()), obj.image_size()},
+                text->sectionOffset(), text->size())
+                .size(),
+            2u);
 
   Instrumentor instr(obj, ROCJITSU_CODE_ARCH_CDNA4);
   InstrumentationPoint pt;


### PR DESCRIPTION
Follow-up to PR #8888 to route DBI descriptor discovery through DBT's existing walk instead of a second copy.

## Motivation
DBI and DBT have overlap for searching kernel descriptors in ELF code objects. This is used to modify their contents. This PR separates out DBT's kernel descriptor walk from the rest of DBT's kernel descriptor functions/structs so that it can be shared with DBI without additional overhead.

## Test Plan
- Added a shared test to pin contract
- Adjusted existing DBI tests that used now refactored code

## Test Result
All tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
