### PR TITLE
[Rocprofiler-systems]: Skip GPU perf counter validation on specific gfx archs

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/gpu.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/gpu.py
@@ -14,6 +14,12 @@ from .cache import persistent_cache
 
 GFX_XXXX_PATTERN = re.compile(r"(gfx[0-9a-fA-F]+)")
 
+# Architectures where GPU perf counter (device counting service) validation is
+# unreliable and dependent tests should be skipped.
+UNSUPPORTED_PERF_COUNTER_GFX = frozenset(
+    {"gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1152", "gfx1153"}
+)
+
 
 @dataclass
 class GPUInfo:
@@ -86,6 +92,16 @@ class GPUInfo:
         such as ``rocprof-device-0-SQ_WAVES-0.txt``.
         """
         return [f"rocprof-device-[0-9]-{name}*.txt" for name in self.counter_names]
+
+    @property
+    def unsupported_perf_counter_archs(self) -> set[str]:
+        """Detected architectures where GPU perf counter validation is unreliable.
+
+        Returns the intersection of the detected architectures with
+        ``UNSUPPORTED_PERF_COUNTER_GFX``.
+        https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/input1/validate.py#L83C4-L83C82
+        """
+        return set(UNSUPPORTED_PERF_COUNTER_GFX.intersection(self.architectures))
 
 
 def get_rocminfo(rocm_path: Optional[Path] = None) -> Optional[Path]:

--- a/projects/rocprofiler-systems/tests/pytest/test_pytest_impl.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_pytest_impl.py
@@ -135,6 +135,26 @@ class TestGPUInfo(RocprofsysTest):
         assert gpu_info.rocm_events_for_test == "SQ_WAVES"
         assert gpu_info.counter_names == ["SQ_WAVES"]
 
+    def test_unsupported_perf_counter_archs_flags_matches(self):
+        gpu_info = GPUInfo(
+            available=True,
+            architectures=["gfx1102", "gfx942"],
+            device_count=2,
+            categories={"radeon", "instinct"},
+        )
+
+        assert gpu_info.unsupported_perf_counter_archs == {"gfx1102"}
+
+    def test_unsupported_perf_counter_archs_empty_when_supported(self):
+        gpu_info = GPUInfo(
+            available=True,
+            architectures=["gfx942"],
+            device_count=1,
+            categories={"instinct"},
+        )
+
+        assert gpu_info.unsupported_perf_counter_archs == set()
+
 
 @pytest.mark.class_name("test-result")
 class TestTestResult(RocprofsysTest):

--- a/projects/rocprofiler-systems/tests/pytest/test_transpose.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_transpose.py
@@ -355,8 +355,12 @@ class TestTransposeGPUPerfCounters(RocprofsysTest):
         gpu_info,
         validation_rules_dir,
     ):
-        if "gfx1151" in gpu_info.architectures:
-            pytest.skip("transpose GPU perf counter test skipped on gfx1151")
+        unsupported = gpu_info.unsupported_perf_counter_archs
+        if unsupported:
+            pytest.skip(
+                "transpose GPU perf counter test skipped on "
+                f"{', '.join(sorted(unsupported))}"
+            )
 
         result = self.run_test(
             "sampling",


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
- `TestTransposeGPUPerfCounters` only skipped `gfx1151`, but the GPU perf counter (device counting service) validation is unreliable on a broader set of architectures, causing spurious failures on those GPUs.
- The list is taken from the SDK test skip list - https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/input1/validate.py#L83C4-L83C82
- The skip list needs to cover `gfx1101`, `gfx1102`, `gfx1150`, `gfx1151`, `gfx1152`, and `gfx1153`.



## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- Added `UNSUPPORTED_PERF_COUNTER_GFX` module constant in `tests/pytest/rocprofsys/gpu.py` listing the archs where GPU perf counter validation is unsupported: `gfx1101`, `gfx1102`, `gfx1150`, `gfx1151`, `gfx1152`, `gfx1153`.
- Added a `GPUInfo.unsupported_perf_counter_archs` property that returns the intersection of detected architectures with that set (empty set = all detected GPUs supported).
- Updated `TestTransposeGPUPerfCounters.test` in `test_transpose.py` to skip via the new property and report exactly which detected arch(es) triggered the skip, replacing the single hard-coded `gfx1151` check.
- Added unit tests in `test_pytest_impl.py::TestGPUInfo` covering both the "match present" and "all supported" cases.


## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
Jira ID: AIPROFSYST-659

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- Run the new unit tests on a configured build: `pytest tests/pytest/test_pytest_impl.py -k unsupported_perf_counter`.
- On an affected GPU (e.g. gfx1102/gfx115x), confirm `TestTransposeGPUPerfCounters` is skipped with the arch named in the reason; on a supported GPU (e.g. gfx942), confirm it runs.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
