### PR TITLE
ci: bump TheRock ref to 2e7c190b99c (2026-07-22)

### DIFF
--- a/.github/workflows/therock-build-linux.yml
+++ b/.github/workflows/therock-build-linux.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 22004a6bc8a28393f8b772b7f6e2a3040f11cd8d # 2026-07-20
+          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 22004a6bc8a28393f8b772b7f6e2a3040f11cd8d # 2026-07-20
+          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 22004a6bc8a28393f8b772b7f6e2a3040f11cd8d # 2026-07-20
+          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 22004a6bc8a28393f8b772b7f6e2a3040f11cd8d # 2026-07-20
+          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 22004a6bc8a28393f8b772b7f6e2a3040f11cd8d # 2026-07-20
+          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 22004a6bc8a28393f8b772b7f6e2a3040f11cd8d # 2026-07-20
+          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 22004a6bc8a28393f8b772b7f6e2a3040f11cd8d # 2026-07-20
+          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
 
       # Centralized arch-specific configuration
       - name: Set arch-specific paths

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 22004a6bc8a28393f8b772b7f6e2a3040f11cd8d # 2026-07-20
+          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 22004a6bc8a28393f8b772b7f6e2a3040f11cd8d # 2026-07-20
+          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
 
       - name: Checkout rocm-systems scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 22004a6bc8a28393f8b772b7f6e2a3040f11cd8d # 2026-07-20
+          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 22004a6bc8a28393f8b772b7f6e2a3040f11cd8d # 2026-07-20
+          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Description:
  Bumps the pinned TheRock ref from `22004a6bc8a` (2026-07-20) to `2e7c190b99c` (2026-07-22).

  ## What's in this bump

  Includes the fix from ROCm/TheRock#6776 which adds `openmpi` to rocprofiler-sdk's
  `RUNTIME_DEPS` in the TheRock profiler CMakeLists. This resolves the rocprofiler-sdk
  configure failure caused by `find_package(MPI)` being intercepted by TheRock's dep
  provider after openmpi was added as a super-project component.

  ## Why

  Unblocks RCCL CI which has been failing since the previous TheRock bump to `22004a6`
  introduced openmpi as a super-project component without a corresponding dep declaration
  in rocprofiler-sdk.

  ## Follow-up

  A separate PR in rocprofiler-sdk will guard the `find_package(MPI)` call at the source
  level as the longer-term fix, keeping MPI out of standard builds entirely.