### PR TITLE
feat(rocr): Changes to allow FreeBSD compilation

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
@@ -52,7 +52,7 @@ extern "C" {
     typedef signed __int64     HSAint64;
     typedef unsigned __int64   HSAuint64;
 
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__FreeBSD__)
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -42,11 +42,13 @@
 
 #include "core/inc/amd_kfd_driver.h"
 
+#if defined(__linux__) || defined(__FreeBSD__)
+    #include <sys/ioctl.h>
+    #include <link.h>
+#endif
+
 #if defined(__linux__)
-#include <amdgpu_drm.h>
-#include <link.h>
-#include <sys/ioctl.h>
-#include <fcntl.h>
+    #include <amdgpu_drm.h>
 #endif
 
 #include "hsakmt/hsakmt.h"

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/uapi/amdxdna_accel.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/uapi/amdxdna_accel.h
@@ -11,8 +11,13 @@
 #else
 #include <libdrm/drm.h>
 #endif
+#ifdef __linux__
 #include <linux/const.h>
 #include <linux/stddef.h>
+#elif defined(__FreeBSD__)
+#include <sys/cdefs.h>
+#include <sys/stddef.h>
+#endif
 
 #if defined(__cplusplus)
 extern "C" {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -682,18 +682,19 @@ void AqlQueue::CloseRingBufferFD(const char* ring_buf_shm_path, int fd) const {
 
 int AqlQueue::CreateRingBufferFD(const char* ring_buf_shm_path,
                                  uint32_t ring_buf_phys_size_bytes) const {
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
   int fd;
-#ifdef HAVE_MEMFD_CREATE
-  fd = syscall(__NR_memfd_create, ring_buf_shm_path, 0);
 
-  if (fd == -1) return -1;
+  fd = memfd_create(ring_buf_shm_path, 0);
 
-  if (ftruncate(fd, ring_buf_phys_size_bytes) == -1) {
-    CloseRingBufferFD(ring_buf_shm_path, fd);
+  if (fd != -1) {
+    if (ftruncate(fd, ring_buf_phys_size_bytes) == 0) {
+      return fd;
+    }
+    close(fd);
     return -1;
   }
-#else
+
   fd = shm_open(ring_buf_shm_path, O_CREAT | O_RDWR | O_EXCL, S_IRUSR | S_IWUSR);
 
   if (fd == -1) return -1;
@@ -702,10 +703,10 @@ int AqlQueue::CreateRingBufferFD(const char* ring_buf_shm_path,
     CloseRingBufferFD(ring_buf_shm_path, fd);
     return -1;
   }
-#endif
+
   return fd;
 #else
-  assert(false && "Function only needed on Linux.");
+  assert(false && "Function only needed on Linux and FreeBSD.");
   return -1;
 #endif
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
@@ -46,6 +46,7 @@
 #include <cstring>
 #include <sstream>
 #include <string>
+#include <atomic>
 
 #include "core/inc/amd_gpu_agent.h"
 #include "core/inc/hsa_internal.h"

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_topology.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_topology.cpp
@@ -85,7 +85,7 @@ namespace {
 const std::array<std::function<hsa_status_t(std::unique_ptr<core::Driver>&)>,
 #if _WIN32
                  1
-#elif __linux__
+#elif defined(__linux__) || defined(__FreeBSD__)
                  static_cast<size_t>(core::DriverType::NUM_DRIVER_TYPES)
 #endif
                  >

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/memory.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/memory.h
@@ -53,7 +53,7 @@
 #include "os.h"
 namespace rocr {
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
 /// @brief Converts @ref hsa_access_permission_t to mmap memory protection
 ///        flags.
 __forceinline int PermissionsToMmapFlags(hsa_access_permission_t perms) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
@@ -65,6 +65,14 @@
 #include "core/inc/amd_gpu_agent.h"
 #include "core/inc/amd_aql_queue.h"
 
+#ifdef __FreeBSD__
+#include <pthread_np.h>
+#define GET_THREAD_ID() pthread_getthreadid_np()
+#elif defined(__linux__)
+#include <sys/syscall.h>
+#define GET_THREAD_ID() syscall(SYS_gettid)
+#endif
+
 constexpr char SNAPSHOT_INFO_ALIGNMENT = 0x8;
 constexpr uint32_t LOAD_ALIGNMENT_SHIFT = 4;
 constexpr uint32_t NOTE_ALIGNMENT_SHIFT = 2;
@@ -107,7 +115,7 @@ std::string substitute_core_pattern(const std::string& pattern) {
        (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 30))
     pid_t tid = gettid();
 #else
-  pid_t tid = static_cast<pid_t>(syscall(SYS_gettid));
+  pid_t tid = static_cast<pid_t>(GET_THREAD_ID());
 #endif
   time_t now = time(nullptr);
   // Get hostname


### PR DESCRIPTION
## Summary

This PR cherry-picks the FreeBSD-portability header/source changes from #8430 and
fixes the Linux build breakage that was failing that PR's CI.

The last commit on #8430 (`Update hsakmttypes.h to also include freebsd include`)
misspelled `defined` as `defind` in the `#elif` guard:

```c
#elif defined(__linux__) || defind(__FreeBSD__)
```

The preprocessor treated `defind(__FreeBSD__)` as a function-like use of an
undefined macro, emitting `missing binary operator before token "("` and skipping
the entire Linux/FreeBSD typedef block. That left `HSAKMTAPI` and the
`HSAuintXX`/`HSAintXX` types undefined, cascading into hundreds of errors across
`libhsakmt` and breaking the Linux packages build on gfx94X, gfx950 and gfx125X.

This branch restores the correct spelling so both `__linux__` and `__FreeBSD__`
select the typedef block, unblocking the Linux build while preserving the FreeBSD
support work.

## JIRA ID

ISSUE ID: #9999999

Cherry-picked from #8430 (Sponsored By: The FreeBSD Foundation).

## Test plan

- [ ] `hsakmttypes.h` now preprocesses cleanly on Linux (verified `-fsyntax-only`)
- [ ] Linux Packages build passes CI (gfx94X / gfx950 / gfx125X)
