### PR TITLE
ci(rocprofiler-sdk): pin CI base image to standard (non-ASan) TheRock nightly tarball

### DIFF
--- a/.github/workflows/rocprofiler-sdk-build-ci-docker-images.yml
+++ b/.github/workflows/rocprofiler-sdk-build-ci-docker-images.yml
@@ -50,11 +50,19 @@ jobs:
           sudo apt-get install -y python3-pip python3-venv
           python3 -m venv /tmp/awscli-venv
           /tmp/awscli-venv/bin/python -m pip install -U pip awscli
+          # Restrict to the standard release tarball under v4/tarball/:
+          #  - the --prefix excludes the v4/tarball-asan/ (AddressSanitizer) builds,
+          #    which are ~10x larger and ship ASan-instrumented ROCm libraries that
+          #    break non-ASan CI test binaries (e.g. rocdecode/rocjpeg tracing).
+          #  - !contains(Key, '-tests-') drops the larger test-bundle variant.
+          # Without these filters, sort_by(... LastModified)[-1] can pick the ASan
+          # tarball for gfx94X/gfx950 (published later in the day than the standard one).
           KEY=$(/tmp/awscli-venv/bin/aws s3api list-objects-v2 \
                 --bucket therock-nightly-tarball \
                 --no-sign-request \
+                --prefix "v4/tarball/" \
                 --output json \
-                --query "sort_by(Contents[?contains(Key, 'linux-${{ matrix.gpu }}')], &LastModified)[-1].Key")
+                --query "sort_by(Contents[?contains(Key, 'linux-${{ matrix.gpu }}') && !contains(Key, 'asan') && !contains(Key, '-tests-')], &LastModified)[-1].Key")
           KEY=${KEY//\"/}
           test -n "$KEY" || { echo "No ${{ matrix.gpu }} tarball found"; exit 1; }
           echo "tarball=${KEY}" >> $GITHUB_OUTPUT

--- a/.github/workflows/rocprofiler-sdk-build-ci-docker-images.yml
+++ b/.github/workflows/rocprofiler-sdk-build-ci-docker-images.yml
@@ -64,7 +64,11 @@ jobs:
                 --output json \
                 --query "sort_by(Contents[?contains(Key, 'linux-${{ matrix.gpu }}') && !contains(Key, 'asan') && !contains(Key, '-tests-')], &LastModified)[-1].Key")
           KEY=${KEY//\"/}
-          test -n "$KEY" || { echo "No ${{ matrix.gpu }} tarball found"; exit 1; }
+          # A no-match filter returns the JSON literal "null" (or "None" for text
+          # output), which is a non-empty string, so guard against it explicitly.
+          if [[ -z "$KEY" || "$KEY" == "null" || "$KEY" == "None" ]]; then
+            echo "No ${{ matrix.gpu }} tarball found"; exit 1
+          fi
           echo "tarball=${KEY}" >> $GITHUB_OUTPUT
 
       - name: Login to Docker Hub


### PR DESCRIPTION
## Motivation

The rocprofiler-sdk-build-ci-docker-images workflow builds the base images all CI runs in. Recently, gfx94X/gfx950 images ballooned from ~3 GB to ~40 GB, and rocdecode-tracing / rocjpeg-tracing tests started failing intermittently at startup with:

`ASan runtime does not come first in initial library list...`
## Technical Details

Restrict selection to the standard release stream:

- `--prefix "v4/tarball/"` -> excludes the v4/tarball-asan/ directory
- `&& !contains(Key, 'asan')` -> defense in depth
- `&& !contains(Key, '-tests-')` -> drop the unneeded test bundle


## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
