### PR TITLE
fix(rocprofiler-compute): strip conflicting GPU_DEVICE_ORDINAL in test runner

### DIFF
--- a/projects/rocprofiler-compute/therock_test_runner.py
+++ b/projects/rocprofiler-compute/therock_test_runner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# Copyright Advanced Micro Devices, Inc.
-# SPDX-License-Identifier: MIT
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
 """Run the rocprofiler-compute project's installed CTest suite.
 
 This runner is installed with the rocprofiler-compute test payload and executes
@@ -144,6 +144,14 @@ def rocm_lib_dirs(rocm_path: Path) -> List[Path]:
 def setup_env(rocm_path: Path) -> Dict[str, str]:
     env = os.environ.copy()
     env["ROCM_PATH"] = str(rocm_path)
+
+    # Multi-GPU CI runners inject a GPU_DEVICE_ORDINAL alongside
+    # HIP_VISIBLE_DEVICES via their GPU-isolation env-file. Newer HIP treats the
+    # mismatch as a fatal agent-visibility conflict and exposes zero GPU agents,
+    # so profiling collects no kernel data. HIP_VISIBLE_DEVICES supersedes it, so
+    # drop the ordinal. Mirrors the fix in TheRock's test_rocprofiler_sdk.py.
+    if env.get("HIP_VISIBLE_DEVICES"):
+        env.pop("GPU_DEVICE_ORDINAL", None)
 
     prepend_env_path(env, "PATH", [rocm_path / "bin"])
     prepend_env_path(


### PR DESCRIPTION
## Problem

`test_kernel` fails on multi-GPU CI runners with `No GPU kernel data collected`. The runner injects `GPU_DEVICE_ORDINAL` alongside `HIP_VISIBLE_DEVICES` via its GPU-isolation env-file. Newer HIP treats the mismatch as a fatal agent-visibility conflict (`agent-N ... not visible to HSA`) and exposes zero GPU agents, so profiling produces no `pmc_perf_*.csv` and the CSV assertion trips.

## Fix

Drop `GPU_DEVICE_ORDINAL` in `therock_test_runner.py::setup_env()` when `HIP_VISIBLE_DEVICES` is set, since the latter supersedes it. Mirrors the existing fix in TheRock's `test_rocprofiler_sdk.py` and `pytorch_utils.py`.