### PR TITLE
[rocjitsu] Add fixed-profile gfx1250 B0-to-A0 DBT library

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -349,6 +349,10 @@ install(
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    install(
+        TARGETS rocjitsu_gfx1250_b0_to_a0
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
     install(TARGETS rocjitsu_bin RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 

--- a/emulation/rocjitsu/lib/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/CMakeLists.txt
@@ -5,6 +5,7 @@ set(ROCJITSU_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(ROCJITSU_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 include(rj_add_object_library)
+include(rj_configure_target)
 
 add_subdirectory(src/rocjitsu/analysis)
 add_subdirectory(src/rocjitsu/code)
@@ -26,6 +27,50 @@ set_target_properties(
     rocjitsu_dbt_internal
     PROPERTIES POSITION_INDEPENDENT_CODE ON
 )
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    # Fixed-profile shared library for the load-time gfx1250 B0-to-A0
+    # consumer. The frontend supplies a gfx1250-only Decoder::create() and
+    # intentionally uses the model object target rather than the full
+    # simulator aggregate. Keep this Linux-only until equivalent export
+    # control is provided for other shared-library formats.
+    add_library(
+        rocjitsu_gfx1250_b0_to_a0
+        SHARED
+        src/rocjitsu/code/dbt/gfx1250_b0_to_a0_library.cpp
+    )
+    set_target_properties(
+        rocjitsu_gfx1250_b0_to_a0
+        PROPERTIES
+            OUTPUT_NAME rocjitsu_gfx1250_b0_to_a0
+            VERSION ${PROJECT_VERSION}
+            SOVERSION ${PROJECT_VERSION_MAJOR}
+    )
+    target_link_libraries(
+        rocjitsu_gfx1250_b0_to_a0
+        PRIVATE rocjitsu_dbt_internal rocjitsu_isa_gfx1250_model simdojo_headers
+    )
+    rj_configure_target(
+        rocjitsu_gfx1250_b0_to_a0
+        PRIVATE_INCLUDES
+        WARNINGS
+        HIDDEN
+    )
+    set(_gfx1250_b0_to_a0_exports
+        ${ROCJITSU_SRC_DIR}/rocjitsu/code/dbt/gfx1250_b0_to_a0.exports
+    )
+    set_property(
+        TARGET rocjitsu_gfx1250_b0_to_a0
+        APPEND
+        PROPERTY LINK_DEPENDS ${_gfx1250_b0_to_a0_exports}
+    )
+    target_link_options(
+        rocjitsu_gfx1250_b0_to_a0
+        PRIVATE
+            "LINKER:--exclude-libs,ALL"
+            "LINKER:--version-script=${_gfx1250_b0_to_a0_exports}"
+    )
+endif()
 
 add_subdirectory(src/rocjitsu/vm)
 add_subdirectory(src/rocjitsu/kmd)

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_gfx1250_b0_to_a0.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_gfx1250_b0_to_a0.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file rj_gfx1250_b0_to_a0.h
+/// @brief Fixed-profile gfx1250 B0-to-A0 code-object translation API.
+
+#ifndef ROCJITSU_CODE_RJ_GFX1250_B0_TO_A0_H_
+#define ROCJITSU_CODE_RJ_GFX1250_B0_TO_A0_H_
+
+#include "rocjitsu/base/rj_compiler.h"
+#include "rocjitsu/base/rj_status.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Translate one gfx1250 B0 AMDGPU code-object ELF for execution on gfx1250 A0.
+///
+/// The input must be a standalone gfx1250 AMDGPU code object. On success, the
+/// library allocates @p translated_elf with malloc-compatible storage and writes
+/// its size to @p translated_size. Release the allocation with
+/// rj_gfx1250_b0_to_a0_free(). Output arguments are cleared on failure.
+///
+/// @param[in] source_elf Source code-object bytes.
+/// @param[in] source_size Number of bytes in @p source_elf.
+/// @param[out] translated_elf Newly allocated translated code-object bytes.
+/// @param[out] translated_size Number of bytes in @p translated_elf.
+/// @retval ROCJITSU_STATUS_SUCCESS Translation succeeded.
+/// @retval ROCJITSU_STATUS_INVALID_ARGUMENT An input or output argument is invalid.
+/// @retval ROCJITSU_STATUS_INVALID_CODE_OBJECT The input is not a gfx1250 code object.
+/// @retval ROCJITSU_STATUS_OUT_OF_RESOURCES Output allocation failed.
+/// @retval ROCJITSU_STATUS_ERROR Translation failed or produced a non-dispatchable object.
+#ifdef __cplusplus
+[[nodiscard]]
+#endif
+RJ_API_EXPORT rj_status_t rj_gfx1250_b0_to_a0_translate(const void *source_elf, size_t source_size,
+                                                        uint8_t **translated_elf,
+                                                        size_t *translated_size);
+
+/// Release storage returned by rj_gfx1250_b0_to_a0_translate().
+/// @param[in] translated_elf Allocation to release; NULL is accepted.
+RJ_API_EXPORT void rj_gfx1250_b0_to_a0_free(void *translated_elf);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // ROCJITSU_CODE_RJ_GFX1250_B0_TO_A0_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0.exports
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0.exports
@@ -1,0 +1,11 @@
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
+ * SPDX-License-Identifier: MIT
+ */
+
+{
+    global:
+        rj_gfx1250_b0_to_a0_translate;
+        rj_gfx1250_b0_to_a0_free;
+    local:
+        *;
+};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_library.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_library.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/rj_gfx1250_b0_to_a0.h"
+
+#include "rocjitsu/code/amdgpu_code_object.h"
+#include "rocjitsu/code/dbt/binary_translator.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/isa.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <new>
+
+namespace rocjitsu {
+
+// This fixed-profile frontend deliberately supplies its own decoder factory.
+// Keeping the all-ISA registry out of this shared object lets the static linker
+// select only the gfx1250 model objects required by the B0-to-A0 translator.
+std::unique_ptr<Decoder> Decoder::create(rj_code_arch_t arch) {
+  if (arch != ROCJITSU_CODE_ARCH_GFX1250)
+    return nullptr;
+  return std::make_unique<IsaDecoder<gfx1250::Isa>>();
+}
+
+} // namespace rocjitsu
+
+rj_status_t rj_gfx1250_b0_to_a0_translate(const void *source_elf, size_t source_size,
+                                          uint8_t **translated_elf, size_t *translated_size) {
+  if (translated_elf)
+    *translated_elf = nullptr;
+  if (translated_size)
+    *translated_size = 0;
+
+  if (!source_elf || source_size == 0 || !translated_elf || !translated_size)
+    return ROCJITSU_STATUS_INVALID_ARGUMENT;
+
+  try {
+    const auto *source_bytes = static_cast<const uint8_t *>(source_elf);
+    rocjitsu::AmdGpuCodeObject source(source_bytes, source_size);
+    if (!source.is_valid() || source.target_id() != ROCJITSU_CODE_TARGET_GFX1250)
+      return ROCJITSU_STATUS_INVALID_CODE_OBJECT;
+
+    rocjitsu::BinaryTranslatorOptions options;
+    options.input_revision = rocjitsu::ProcessorRevision::Gfx1250B0;
+    options.output_revision = rocjitsu::ProcessorRevision::Gfx1250A0;
+    rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+                                          options);
+    auto result = translator.translate(source);
+    if (result.elf_bytes.empty() || !result.dispatchable())
+      return ROCJITSU_STATUS_ERROR;
+
+    auto *output = static_cast<uint8_t *>(std::malloc(result.elf_bytes.size()));
+    if (!output)
+      return ROCJITSU_STATUS_OUT_OF_RESOURCES;
+
+    std::memcpy(output, result.elf_bytes.data(), result.elf_bytes.size());
+    *translated_elf = output;
+    *translated_size = result.elf_bytes.size();
+    return ROCJITSU_STATUS_SUCCESS;
+  } catch (const std::bad_alloc &) {
+    return ROCJITSU_STATUS_OUT_OF_RESOURCES;
+  } catch (...) {
+    return ROCJITSU_STATUS_ERROR;
+  }
+}
+
+void rj_gfx1250_b0_to_a0_free(void *translated_elf) { std::free(translated_elf); }

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -494,6 +494,32 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
             -DMODEL_BINARY=$<TARGET_FILE:rocjitsu_model_only_test> -P
             ${CMAKE_CURRENT_SOURCE_DIR}/check_model_only_symbols.cmake
     )
+
+    add_executable(
+        gfx1250_b0_to_a0_library_test
+        dbt/gfx1250_b0_to_a0_library_test.cpp
+    )
+    target_link_libraries(
+        gfx1250_b0_to_a0_library_test
+        PRIVATE rocjitsu_gfx1250_b0_to_a0 GTest::gtest_main
+    )
+    if(HAS_GFX1250_DBT_FIXTURE)
+        target_compile_definitions(
+            gfx1250_b0_to_a0_library_test
+            PRIVATE
+                GFX1250_B0_TO_A0_FIXTURE="${KERNEL_OUTPUT_DIR}/relocation_function_table_dispatch_gfx1250.hsaco"
+        )
+        add_dependencies(
+            gfx1250_b0_to_a0_library_test
+            probe_relocation_function_table_dispatch_gfx1250
+        )
+    endif()
+    rj_configure_target(
+        gfx1250_b0_to_a0_library_test
+        PRIVATE_INCLUDES
+        WARNINGS
+    )
+    rj_add_gtest_tests(gfx1250_b0_to_a0_library_test)
 endif()
 
 # --- DBI probe fixture test ---

--- a/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file gfx1250_b0_to_a0_library_test.cpp
+/// @brief Tests the fixed-profile gfx1250 B0-to-A0 shared-library API.
+
+#include "rocjitsu/code/rj_gfx1250_b0_to_a0.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+namespace {
+
+TEST(Gfx1250B0ToA0Library, RejectsInvalidArgumentsAndClearsOutputs) {
+  auto *output = reinterpret_cast<uint8_t *>(0x1);
+  size_t output_size = 1;
+  EXPECT_EQ(rj_gfx1250_b0_to_a0_translate(nullptr, 0, &output, &output_size),
+            ROCJITSU_STATUS_INVALID_ARGUMENT);
+  EXPECT_EQ(output, nullptr);
+  EXPECT_EQ(output_size, 0u);
+
+  constexpr std::array<uint8_t, 64> kNotElf = {'N', 'O', 'T', 'E', 'L', 'F'};
+  EXPECT_EQ(rj_gfx1250_b0_to_a0_translate(kNotElf.data(), kNotElf.size(), &output, &output_size),
+            ROCJITSU_STATUS_INVALID_CODE_OBJECT);
+  EXPECT_EQ(output, nullptr);
+  EXPECT_EQ(output_size, 0u);
+
+  rj_gfx1250_b0_to_a0_free(nullptr);
+}
+
+#ifdef GFX1250_B0_TO_A0_FIXTURE
+TEST(Gfx1250B0ToA0Library, TranslatesRealGfx1250CodeObject) {
+  std::ifstream input(GFX1250_B0_TO_A0_FIXTURE, std::ios::binary);
+  ASSERT_TRUE(input) << GFX1250_B0_TO_A0_FIXTURE;
+  const std::vector<uint8_t> source((std::istreambuf_iterator<char>(input)),
+                                    std::istreambuf_iterator<char>());
+  ASSERT_GE(source.size(), 4u);
+
+  uint8_t *output = nullptr;
+  size_t output_size = 0;
+  ASSERT_EQ(rj_gfx1250_b0_to_a0_translate(source.data(), source.size(), &output, &output_size),
+            ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(output, nullptr);
+  constexpr std::array<uint8_t, 4> kElfMagic = {0x7f, 'E', 'L', 'F'};
+  ASSERT_GE(output_size, kElfMagic.size());
+  EXPECT_TRUE(std::equal(kElfMagic.begin(), kElfMagic.end(), output));
+
+  rj_gfx1250_b0_to_a0_free(output);
+}
+#endif
+
+} // namespace

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -177,9 +177,26 @@ find_program(
     DOC "Path to clang-offload-bundler for device-only probe objects"
 )
 set(HAS_PROBE_FIXTURES FALSE)
+set(HAS_GFX1250_DBT_FIXTURE FALSE)
+set(RJ_GFX1250_DBT_FIXTURE_TARGET)
 if(CLANG_OFFLOAD_BUNDLER)
     rj_add_probe_object(rj_nop_probe gfx90a OUTPUT_NAME rj_nop_probe_gfx90a)
     set(HAS_PROBE_FIXTURES TRUE)
+
+    # The narrow gfx1250 DBT library accepts a raw AMDGPU code object rather
+    # than the host ELF / .hip_fatbin produced by rj_add_device_kernel().
+    if(HAS_GFX1250_DEVICE_KERNELS)
+        rj_add_probe_object(
+            relocation_function_table_dispatch
+            gfx1250
+            OUTPUT_NAME relocation_function_table_dispatch_gfx1250
+        )
+        set(HAS_GFX1250_DBT_FIXTURE TRUE)
+        set(RJ_GFX1250_DBT_FIXTURE_TARGET
+            probe_relocation_function_table_dispatch_gfx1250
+        )
+    endif()
+
     # Install the probe object alongside the other kernel fixtures so installed
     # runs of probe_fixture_test / hsa_dbi_nop_probe_test can find it via
     # ROCJITSU_KERNEL_DIR. Gated here (not in the list above) because it exists
@@ -189,6 +206,13 @@ if(CLANG_OFFLOAD_BUNDLER)
             FILES ${KERNEL_OUTPUT_DIR}/rj_nop_probe_gfx90a.hsaco
             DESTINATION ${CMAKE_INSTALL_DATADIR}/rocjitsu/tests/kernels
         )
+        if(HAS_GFX1250_DBT_FIXTURE)
+            install(
+                FILES
+                    ${KERNEL_OUTPUT_DIR}/relocation_function_table_dispatch_gfx1250.hsaco
+                DESTINATION ${CMAKE_INSTALL_DATADIR}/rocjitsu/tests/kernels
+            )
+        endif()
     endif()
 else()
     message(
@@ -215,6 +239,7 @@ add_custom_target(
         kernel_multikernel_indirect_branch_part0
         kernel_multikernel_indirect_branch_part1
         ${RJ_GFX1250_DEVICE_KERNEL_TARGET}
+        ${RJ_GFX1250_DBT_FIXTURE_TARGET}
         kernel_triton_cdna4_matmul_dynamic_32x32x64
         kernel_triton_cdna4_matmul_buffer_async_1024
         kernel_triton_cdna4_flash_attention_no_async_1024
@@ -234,5 +259,6 @@ endif()
 # Export variables to the parent scope so the test executable can use them.
 set(HAS_DEVICE_KERNELS TRUE PARENT_SCOPE)
 set(HAS_GFX1250_DEVICE_KERNELS ${HAS_GFX1250_DEVICE_KERNELS} PARENT_SCOPE)
+set(HAS_GFX1250_DBT_FIXTURE ${HAS_GFX1250_DBT_FIXTURE} PARENT_SCOPE)
 set(HAS_PROBE_FIXTURES ${HAS_PROBE_FIXTURES} PARENT_SCOPE)
 set(KERNEL_OUTPUT_DIR ${KERNEL_OUTPUT_DIR} PARENT_SCOPE)


### PR DESCRIPTION
## Motivation

This PR adds a dedicated shared library for that fixed translation profile for gfx1250. It uses the model-only ISA layering from #8933, links only the generic DBT base and the gfx1250 model.

This reduces the .so size from >50MB to <5MB.

## Technical Details

- Add `librocjitsu_gfx1250_b0_to_a0.so`, composed from `rocjitsu_dbt_internal`, `rocjitsu_isa_gfx1250_model`, and the header-only SimDojo interface. It does not link the simulator implementation, VM, ISA registry, or non-gfx1250 decoders.
- Add a revision-fixed C API that accepts a standalone AMDGPU ELF, always translates gfx1250 B0 to gfx1250 A0, and returns caller-owned output storage.
- Export only `rj_gfx1250_b0_to_a0_translate` and `rj_gfx1250_b0_to_a0_free`; hide archive internals with the existing hidden visibility policy plus a Linux version script.
- Install the library and public header with the normal RocJITsu artifacts.
- Add a real raw gfx1250 code-object fixture and end-to-end translation test.
- Add a binary-boundary test that checks the required gfx1250 DBT symbols, rejects execution semantics and non-gfx1250 ISA decoders, rejects broad runtime dependencies, pins the public export set, and enforces the 5 MB stripped-size ceiling.

## Issue Tracking

N/A

## Test Plan

ctest + check symbols with `nm`

## Test Result

OK

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.