### PR TITLE
fix(rccl) Fix two DDA IPC unit-test bugs

### DIFF
--- a/projects/rccl/test/DdaIpcEligibilityTests.cpp
+++ b/projects/rccl/test/DdaIpcEligibilityTests.cpp
@@ -151,7 +151,7 @@ TEST_F(DdaIpcEligibilityTest, AllToAll_StagingBytesAtThresholdFitsScratch)
 TEST_F(DdaIpcEligibilityTest, AllToAll_StagingBytesOneCountOverThresholdStillEligible)
 {
     // Eligibility is independent of the 4 MiB dispatch cap enforced in collectives.cc.
-    const size_t count = kAlltoAllFloat32CountAt4MbThreshold + 1;
+    const size_t count = kAlltoAllFloat32CountAt4MbThreshold + 4;
     const size_t stagingBytes = testAlltoAllDdaIpcStagingBytes(
         count, mockComm_.comm.nRanks, sizeof(float));
     EXPECT_GT(stagingBytes, kDdaAlltoAllGfx950ThresholdBytes);

--- a/projects/rccl/test/common/DdaAlltoAllTestHelpers.hpp
+++ b/projects/rccl/test/common/DdaAlltoAllTestHelpers.hpp
@@ -65,14 +65,16 @@ inline size_t testAlltoAllDdaIpcStagingBytes(size_t count, int nRanks, size_t ty
 struct DdaAlltoAllMockComm
 {
     ncclComm comm{};
+    char archNameBuf[64]{};
 
     DdaAlltoAllMockComm() { reset("gfx950:sramecc+:xnack-"); }
 
     void reset(const char* archName)
     {
         std::memset(&comm, 0, sizeof(comm));
-        std::strncpy(comm.archName, archName, sizeof(comm.archName) - 1);
-        comm.archName[sizeof(comm.archName) - 1] = '\0';
+        std::strncpy(archNameBuf, archName, sizeof(archNameBuf) - 1);
+        archNameBuf[sizeof(archNameBuf) - 1] = '\0';
+        comm.archName = archNameBuf;
         comm.nNodes = 1;
         comm.nRanks = nccl_dda_detail::kDdaNranks;
         comm.symmetricSupport = 0;


### PR DESCRIPTION
## Motivation

Fix failing unit tests

```
# rccl-UnitTestsFixturesDebug --gtest_filter="DdaIpcEligibilityTest.*"
[  FAILED  ] DdaIpcEligibilityTest.AllToAll_StagingBytesOneCountOverThresholdStillEligible

# rccl-UnitTestsFixturesDebug --gtest_filter="DdaAlltoAllThresholdTest.*"
[ RUN      ] DdaAlltoAllThresholdTest.Gfx942_ExactlyAt4MbThreshold_Enabled
Segmentation fault
```
## Technical Details

- DdaAlltoAllMockComm::reset treated ncclComm::archName (a char*) as an inline buffer: memset() nulled the pointer and strncpy() then wrote through null, segfaulting every DdaAlltoAllThresholdTest at fixture construction. Add an owned archNameBuf and point comm.archName at it.

- AllToAll_StagingBytesOneCountOverThresholdStillEligible used count+1 to exceed the 4 MiB dispatch cap, but that broke the 16-byte per-rank alignment the eligibility check requires, so it returned false. Step over the cap with +16/sizeof(float) to keep the count aligned.

## Issue Tracking

JIRA ID: AICOMRCCL-1607

## Test Plan

Run unit tests and check the failing test passes

```
# rccl-UnitTestsFixturesDebug --gtest_filter="DdaIpcEligibilityTest.*"
# rccl-UnitTestsFixturesDebug --gtest_filter="DdaAlltoAllThresholdTest.*"
```

## Test Result

```
# rccl-UnitTestsFixturesDebug --gtest_filter="DdaIpcEligibilityTest.*"
[----------] 26 tests from DdaIpcEligibilityTest (0 ms total)

[----------] Global test environment tear-down
[==========] 26 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 26 tests.

# rccl-UnitTestsFixturesDebug --gtest_filter="DdaAlltoAllThresholdTest.*"
[----------] 8 tests from DdaAlltoAllThresholdTest (1 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 8 tests.
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
