### PR TITLE
ci(rocjitsu): enable msan coverage

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -62,8 +62,10 @@ jobs:
             enable_asan: 0
             enable_ubsan: 0
             enable_tsan: 0
+            enable_msan: 0
             enable_expensive_checks: 0
             sanitizer_runtime: STATIC
+            run_tests: 1
           - name: asan-ubsan
             allow_failure: true
             test_regex: ''
@@ -71,8 +73,10 @@ jobs:
             enable_asan: 1
             enable_ubsan: 1
             enable_tsan: 0
+            enable_msan: 0
             enable_expensive_checks: 1
             sanitizer_runtime: SHARED
+            run_tests: 1
           - name: tsan
             allow_failure: true
             test_regex: ''
@@ -80,8 +84,10 @@ jobs:
             enable_asan: 0
             enable_ubsan: 0
             enable_tsan: 1
+            enable_msan: 0
             enable_expensive_checks: 1
             sanitizer_runtime: SHARED
+            run_tests: 1
           - name: asan-ubsan-gcc
             allow_failure: true
             test_regex: ''
@@ -89,10 +95,28 @@ jobs:
             enable_asan: 1
             enable_ubsan: 1
             enable_tsan: 0
+            enable_msan: 0
             enable_expensive_checks: 1
             sanitizer_runtime: SHARED
+            run_tests: 1
             c_compiler: gcc
             cxx_compiler: g++
+          - name: msan-auto
+            allow_failure: false
+            # MSan requires instrumented runtime dependencies. Keep this gate
+            # to configuration and final linkage without running the binary.
+            test_regex: ''
+            build_type: RelWithDebInfo
+            enable_asan: 0
+            enable_ubsan: 0
+            enable_tsan: 0
+            enable_msan: 1
+            enable_expensive_checks: 0
+            sanitizer_runtime: AUTO
+            run_tests: 0
+            build_target: early_mmap_driver
+            c_compiler: clang
+            cxx_compiler: clang++
           - name: tsan-sparse-memory
             allow_failure: false
             run_static_asan_launch: true
@@ -104,7 +128,9 @@ jobs:
             enable_asan: 0
             enable_ubsan: 0
             enable_tsan: 1
+            enable_msan: 0
             sanitizer_runtime: STATIC
+            run_tests: 1
 
     steps:
       - name: Install base dependencies
@@ -221,22 +247,47 @@ jobs:
             -DRJ_ENABLE_ASAN=${{ matrix.enable_asan }} \
             -DRJ_ENABLE_UBSAN=${{ matrix.enable_ubsan }} \
             -DRJ_ENABLE_TSAN=${{ matrix.enable_tsan }} \
+            -DRJ_ENABLE_MSAN=${{ matrix.enable_msan }} \
             -DRJ_ENABLE_EXPENSIVE_CHECKS=${{ matrix.enable_expensive_checks }} \
             -DRJ_SANITIZER_RUNTIME=${{ matrix.sanitizer_runtime }}
 
           # Set a conservative number of workers to avoid OOM and excessive system load.
           WORKERS="$(( ($(nproc) + 1) / 2 ))"
-          cmake --build "${ROCJITSU_BUILD_DIR}" -j "${WORKERS}"
-
-          CTEST_SELECTION=()
-          if [[ -n "${{ matrix.test_regex }}" ]]; then
-            CTEST_SELECTION=(-R "${{ matrix.test_regex }}")
+          BUILD_TARGET=()
+          if [[ -n "${{ matrix.build_target }}" ]]; then
+            BUILD_TARGET=(--target "${{ matrix.build_target }}")
           fi
-          ctest --test-dir "${ROCJITSU_BUILD_DIR}" \
-            "${CTEST_SELECTION[@]}" \
-            -E "${EXCLUDED_TESTS}" \
-            --output-on-failure \
-            -j "${WORKERS}"
+          cmake --build "${ROCJITSU_BUILD_DIR}" "${BUILD_TARGET[@]}" -j "${WORKERS}"
+
+          if [[ "${{ matrix.name }}" == "msan-auto" ]]; then
+            set +e
+            MSAN_SHARED_OUTPUT="$(
+              ROCM_PATH=`rocm-sdk path --root` \
+                cmake -S . -B "${ROCJITSU_BUILD_DIR}" \
+                  -DRJ_SANITIZER_RUNTIME=SHARED 2>&1
+            )"
+            MSAN_SHARED_STATUS=$?
+            set -e
+            if [[ "${MSAN_SHARED_STATUS}" -eq 0 ]] || \
+              ! grep -Fq "MemorySanitizer has no supported shared runtime" \
+                <<< "${MSAN_SHARED_OUTPUT}"; then
+              echo "Expected shared MSan configuration to be rejected"
+              echo "${MSAN_SHARED_OUTPUT}"
+              exit 1
+            fi
+          fi
+
+          if [[ "${{ matrix.run_tests }}" == "1" ]]; then
+            CTEST_SELECTION=()
+            if [[ -n "${{ matrix.test_regex }}" ]]; then
+              CTEST_SELECTION=(-R "${{ matrix.test_regex }}")
+            fi
+            ctest --test-dir "${ROCJITSU_BUILD_DIR}" \
+              "${CTEST_SELECTION[@]}" \
+              -E "${EXCLUDED_TESTS}" \
+              --output-on-failure \
+              -j "${WORKERS}"
+          fi
 
           echo "${ROCJITSU_BUILD_DIR}/tools/rocjitsu" >> "${GITHUB_PATH}"
           echo "CXXFLAGS=" >> "${GITHUB_ENV}"

--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -66,49 +66,25 @@ jobs:
             enable_expensive_checks: 0
             sanitizer_runtime: STATIC
             run_tests: 1
-          - name: asan-ubsan
+          - name: asan
             allow_failure: true
             test_regex: ''
             build_type: RelWithDebInfo
             enable_asan: 1
-            enable_ubsan: 1
-            enable_tsan: 0
-            enable_msan: 0
-            enable_expensive_checks: 1
-            sanitizer_runtime: SHARED
-            run_tests: 1
-          - name: tsan
-            allow_failure: true
-            test_regex: ''
-            build_type: RelWithDebInfo
-            enable_asan: 0
             enable_ubsan: 0
-            enable_tsan: 1
-            enable_msan: 0
-            enable_expensive_checks: 1
-            sanitizer_runtime: SHARED
-            run_tests: 1
-          - name: asan-ubsan-gcc
-            allow_failure: true
-            test_regex: ''
-            build_type: RelWithDebInfo
-            enable_asan: 1
-            enable_ubsan: 1
             enable_tsan: 0
             enable_msan: 0
             enable_expensive_checks: 1
             sanitizer_runtime: SHARED
             run_tests: 1
-            c_compiler: gcc
-            cxx_compiler: g++
-          - name: msan-auto
+          - name: msan-ubsan
             allow_failure: false
             # MSan requires instrumented runtime dependencies. Keep this gate
             # to configuration and final linkage without running the binary.
             test_regex: ''
             build_type: RelWithDebInfo
             enable_asan: 0
-            enable_ubsan: 0
+            enable_ubsan: 1
             enable_tsan: 0
             enable_msan: 1
             enable_expensive_checks: 0
@@ -185,7 +161,7 @@ jobs:
           ROCMINFO=RocminfoTest
           RCCL_DAEMON=RcclDaemonTest
           EXCLUDED_TESTS="${ROCMINFO}|${RCCL_DAEMON}"
-          ASAN_UBSAN_EXCLUDED_TESTS=(
+          ASAN_EXCLUDED_TESTS=(
             "HsaTest\.InitSucceeded"
             "HsaTest\.GpuAgentFound"
             "Cdna4ToCdna3SimulatedDispatchTest\..*"
@@ -207,7 +183,7 @@ jobs:
           )
           # https://github.com/ROCm/rocm-systems/issues/8922
           TSAN_EXCLUDED_TESTS=(
-            "${ASAN_UBSAN_EXCLUDED_TESTS[@]}"
+            "${ASAN_EXCLUDED_TESTS[@]}"
             "MatmulStressTest\.TiledAllCU"
             "MatmulStressTest\.MfmaAllCUs"
             "VectorAddStressTest\.AllCUsGoldenReference"
@@ -217,8 +193,8 @@ jobs:
           )
 
           CMAKE_CONFIG_FLAGS=()
-          if [[ "${{ matrix.enable_asan }}" == "1" && "${{ matrix.enable_ubsan }}" == "1" ]]; then
-            EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${ASAN_UBSAN_EXCLUDED_TESTS[*]}")"
+          if [[ "${{ matrix.enable_asan }}" == "1" ]]; then
+            EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${ASAN_EXCLUDED_TESTS[*]}")"
             CMAKE_CONFIG_FLAGS+=(
               -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -g"
               -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -g"
@@ -259,7 +235,7 @@ jobs:
           fi
           cmake --build "${ROCJITSU_BUILD_DIR}" "${BUILD_TARGET[@]}" -j "${WORKERS}"
 
-          if [[ "${{ matrix.name }}" == "msan-auto" ]]; then
+          if [[ "${{ matrix.name }}" == "msan-ubsan" ]]; then
             set +e
             MSAN_SHARED_OUTPUT="$(
               ROCM_PATH=`rocm-sdk path --root` \

--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -338,6 +338,13 @@ set(FLATBUFFERS_BUILD_FLATLIB ON CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(googletest flatbuffers)
 
+# flatc executes during the build and uses uninstrumented host libraries. Keep
+# that host tool runnable while the rocjitsu targets remain MSan-instrumented.
+if(RJ_ENABLE_MSAN)
+    target_compile_options(flatc PRIVATE -fno-sanitize=memory)
+    target_link_options(flatc PRIVATE -fno-sanitize=memory)
+endif()
+
 include(rj_flatbuffers)
 
 # Set include paths before adding subdirectories so all targets can find them.

--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -341,8 +341,12 @@ set(FLATBUFFERS_BUILD_FLATLIB ON CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(googletest flatbuffers)
 
-# flatc executes during the build and uses uninstrumented host libraries. Keep
-# that host tool runnable while the rocjitsu targets remain MSan-instrumented.
+# flatc is a build-time host tool that is executed to generate schema headers.
+# It uses uninstrumented host libraries, so instrumenting flatc itself would make
+# the generator unreliable under MSan. Deliberately exempt only this target from
+# MSan compile and link instrumentation; RJ_ENABLE_MSAN remains enabled for the
+# rocjitsu targets. This is not a fallback for incompatible sanitizer options:
+# those combinations are rejected with FATAL_ERROR above.
 if(RJ_ENABLE_MSAN)
     target_compile_options(flatc PRIVATE -fno-sanitize=memory)
     target_link_options(flatc PRIVATE -fno-sanitize=memory)

--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -180,10 +180,13 @@ if(_rj_sanitizer_count GREATER 0)
             "ThreadSanitizer can not be combined with address or memory sanitizers"
         )
     endif()
-    if(memory IN_LIST _rj_sanitizer_kinds AND _rj_sanitizer_count GREATER 1)
+    if(
+        memory IN_LIST _rj_sanitizer_kinds
+        AND address IN_LIST _rj_sanitizer_kinds
+    )
         message(
             FATAL_ERROR
-            "MemorySanitizer cannot be combined with other sanitizers"
+            "MemorySanitizer cannot be combined with AddressSanitizer"
         )
     endif()
     list(JOIN _rj_sanitizer_kinds "," _rj_sanitizer_arg)

--- a/emulation/rocjitsu/docs/building.md
+++ b/emulation/rocjitsu/docs/building.md
@@ -44,13 +44,17 @@ cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DRJ_ENABLE_TSAN=1
 # MemorySanitizer
 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DRJ_ENABLE_MSAN=1
 
+# MemorySanitizer + UndefinedBehaviorSanitizer
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DRJ_ENABLE_MSAN=1 -DRJ_ENABLE_UBSAN=1
+
 # UndefinedBehaviorSanitizer
 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DRJ_ENABLE_UBSAN=1
 ```
 
 `AUTO` uses shared runtimes for ASan, UBSan, and TSan, and the only
 supported static runtime for MSan. `SHARED` rejects MSan explicitly because
-Clang does not provide a shared MSan runtime.
+Clang does not provide a shared MSan runtime. MSan can be combined with UBSan,
+but not with ASan or TSan.
 
 ### Static analysis
 


### PR DESCRIPTION
## Motivation

  RocJitsu supports MemorySanitizer through `RJ_ENABLE_MSAN`, but the configuration
  is not currently exercised by CI.

  Add blocking compile-and-link coverage while keeping runtime tests disabled until
  the required dependencies can be fully MSan-instrumented.

  ## Technical Details

  - Add a blocking Clang `msan-auto` CI configuration.
  - Build and link `early_mmap_driver` with MSan using the supported static
  runtime.
  - Verify that `RJ_SANITIZER_RUNTIME=SHARED` is rejected for MSan.
  - Keep existing sanitizer configurations and runtime tests unchanged.
  - Build the host `flatc` tool without MSan instrumentation because it executes
  against uninstrumented host libraries during schema generation.

  This is a follow-up to #8589.

  ## Issue Tracking

  GitHub issue: https://github.com/ROCm/rocm-systems/issues/7891

  ## Test Plan

  - Configure RocJitsu with Clang and `RJ_ENABLE_MSAN=1`.
  - Build and run `early_mmap_driver`.
  - Generate the FlatBuffers schemas using the uninstrumented host `flatc`.
  - Confirm that shared MSan configuration fails with the expected diagnostic.
  - Run pre-commit over the complete branch diff.

  ## Test Result

  - Clang 14 MSan configure, compile, link, and execution passed.
  - FlatBuffers schema generation passed.
  - Shared MSan rejection check passed.
  - Full `origin/develop..HEAD` pre-commit sweep passed.

  Runtime CTests remain disabled for this configuration because MSan requires fully
  instrumented dependencies.

  ## Submission Checklist

  - [x] Look over the contributing guidelines at
  https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.