### PR TITLE
ci(ainic): set NCCL_IB_HCA=rdma,roce for AINIC runs

### DIFF
--- a/projects/rccl/tools/scripts/test_runner/configs/ainic.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/ainic.json
@@ -21,7 +21,8 @@
     "ainic": {
       "NCCL_SOCKET_IFNAME": "eno0",
       "RCCL_AINIC_ROCE": "1",
-      "IONIC_LOCKFREE": "all"
+      "IONIC_LOCKFREE": "all",
+      "NCCL_IB_HCA": "rdma,roce"
     }
   },
   "build_configuration": {


### PR DESCRIPTION
## What
Add `NCCL_IB_HCA="rdma,roce"` to the AINIC test-runner config (`configs/ainic.json`, `system_env_variables.ainic`), so it applies to all Group A/B/C runs.

## Why
The first automated nightly ([run 29976033317](https://github.com/ROCm/rocm-systems/actions/runs/29976033317)) failed: all 16-rank (2×8 GPU) Group B/C collective tests aborted at `ncclCommInitRank` with:

```
RCCL FATAL: mismatched Rome preset topology model index across ranks
  rank 8 host mia1-p01-g27 romeTopoModelIdx=40   (g24 ranks voted refIdx -1)
```

Per Tensorwave: their shared RCCL config keys off IB HCA names like `rdma*`, but some AINIC nodes expose their NICs under different names (e.g. `roce*`). When device names don't match, per-node topology detection diverges → the Rome preset consensus fails. Setting `NCCL_IB_HCA="rdma,roce"` makes every rank pick up the NICs regardless of naming; TW confirmed it is safe to set for any node pair.

Group A (1 GPU/node, 2 ranks) already passed — the mismatch only surfaced on the full 8-GPU-per-node topology.

## Notes
- Non-gate workflow; this only affects the AINIC nightly / label-gated smoke runs.
- Longer term the NIC naming should be made consistent across nodes; this is the agreed interim workaround.
