### PR TITLE
ROCM-27070: honor NCCL_GIN_ENABLE=0 and select ib-cast GIN backend on AINIC

### DIFF
--- a/projects/rccl/src/plugin/gin.cc
+++ b/projects/rccl/src/plugin/gin.cc
@@ -27,6 +27,8 @@ extern getNcclGin_t getNcclGin_v11;
 extern getNcclGin_t getNcclGin_v12;
 extern getNcclGin_t getNcclGin_v13;
 extern getNcclGin_t getNcclRma_v13;
+extern int64_t ncclParamGinEnable();
+extern bool rcclUseAinic();
 NCCL_PARAM(GinPluginRefCount, "GIN_PLUGIN_REF_COUNT", 0);
 #define NCCL_GIN_VERSION_COUNT 3
 int ncclGinVersion[NCCL_GIN_VERSION_COUNT] = {13, 12, 11};
@@ -249,9 +251,12 @@ static void initPluginLibsOnceFunc() {
     pluginCounter++;
   }
 
-  // Add internal ib plugin
   const char* envNet = ncclGetEnv("NCCL_NET");
-  if (envNet && strcasecmp(envNet, "IB-CAST") == 0) {
+  if (envNet && (strcasecmp(envNet, "ROCM-IB") == 0)) {
+    envNet = "IB-CAST";
+  }
+  if ((envNet && strcasecmp(envNet, "IB-CAST") == 0 && !(envGinPlugin)) ||
+      (!envNet && rcclUseAinic() && !(envGinPlugin))) {
     ginPluginLibs[pluginCounter].ncclGin = &IbCastGinIb;
     ginPluginLibs[pluginCounter].ncclGinPluginState = ncclGinPluginStateInitReady;
     ginPluginLibs[pluginCounter].ncclGinVersion = ncclGinVersion[0];
@@ -259,18 +264,15 @@ static void initPluginLibsOnceFunc() {
     ginPluginLibs[pluginCounter].ncclRmaPluginState = ncclGinPluginStateInitReady;
     ginPluginLibs[pluginCounter].ncclGinVersion = ncclGinVersion[0];
     pluginCounter++;
+  } else {
+    ginPluginLibs[pluginCounter].ncclGin = &ncclGinIbProxy;
+    ginPluginLibs[pluginCounter].ncclGinPluginState = ncclGinPluginStateInitReady;
+    ginPluginLibs[pluginCounter].ncclGinVersion = ncclGinVersion[0];
+    ginPluginLibs[pluginCounter].ncclRma = ginPluginLibs[pluginCounter].ncclGin;
+    ginPluginLibs[pluginCounter].ncclRmaPluginState = ncclGinPluginStateInitReady;
+    ginPluginLibs[pluginCounter].ncclGinVersion = ncclGinVersion[0];
+    pluginCounter++;
   }
-
-  // ncclGinIbProxy is an ncclGin_t (v13) instance, so register it directly
-  // instead of adapting through getNcclGin_v12_internal.
-  ginPluginLibs[pluginCounter].ncclGin = &ncclGinIbProxy;
-  ginPluginLibs[pluginCounter].ncclGinPluginState = ncclGinPluginStateInitReady;
-  ginPluginLibs[pluginCounter].ncclGinVersion = ncclGinVersion[0];
-  ginPluginLibs[pluginCounter].ncclRma = ginPluginLibs[pluginCounter].ncclGin;
-  ginPluginLibs[pluginCounter].ncclRmaPluginState = ncclGinPluginStateInitReady;
-  ginPluginLibs[pluginCounter].ncclGinVersion = ncclGinVersion[0];
-
-  pluginCounter++;
 
 #ifdef ENABLE_ROCSHMEM_GIN
   // Add internal rocshmem GDA plugin (device-initiated, GIN_TYPE=4)
@@ -306,6 +308,10 @@ static ncclResult_t ncclGinPluginFinalize(struct ncclComm* comm, int pluginIndex
 
 ncclResult_t ncclGinInit(struct ncclComm* comm) {
   bool ncclGinPluginInitialized = false;
+  if (ncclParamGinEnable() == 0) {
+    INFO(NCCL_INIT|NCCL_NET, "GIN disabled by NCCL_GIN_ENABLE=0; skipping GIN plugin init");
+    return ncclSuccess;
+  }
   std::call_once(initPluginLibsOnceFlag, initPluginLibsOnceFunc);
   std::lock_guard<std::mutex> lock(ginPluginMutex);
   for (int pluginIndex = 0; pluginIndex < pluginCount; pluginIndex++) {

--- a/projects/rccl/test/transport/GinMPI/GinMPITests.cpp
+++ b/projects/rccl/test/transport/GinMPI/GinMPITests.cpp
@@ -10,9 +10,15 @@
 
 #include "GinMPITestBase.hpp"
 
+#include "comm.h"
+#include "gin.h"
+
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <vector>
+
+extern bool rcclUseAinic();
 
 namespace RCCLGinTests
 {
@@ -771,6 +777,67 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Values(1, 2),
         ::testing::Bool()),
     CtxOnlyName);
+
+// ---------------------------------------------------------------------------
+// Communicator-init fixture — validates GIN backend gating and selection at
+// ncclCommInitRank() time. Unlike the fixtures above it does not stand up any
+// GIN data-path context; it only inspects the backend the communicator bound.
+// ---------------------------------------------------------------------------
+class GinInitMPITest : public MPITestBase
+{
+protected:
+    ncclGin_t* AssignedGin()
+    {
+        auto* comm = reinterpret_cast<struct ncclComm*>(getActiveCommunicator());
+        return comm->sharedRes->ginState.ncclGin;
+    }
+};
+
+TEST_F(GinInitMPITest, GinEnableZeroSkipsInit)
+{
+    const char* e = std::getenv("NCCL_GIN_ENABLE");
+    if (e == nullptr || std::strcmp(e, "0") != 0)
+        GTEST_SKIP() << "Requires NCCL_GIN_ENABLE=0";
+
+    ASSERT_TRUE(validateTestPrerequisites(kMinProcessesForMPI, kNoProcessLimit,
+                                          kNoPowerOfTwoRequired, 1, kNoNodeLimit))
+        << "Test requirements not met";
+
+    ASSERT_EQ(ncclSuccess, createTestCommunicator());
+    EXPECT_EQ(AssignedGin(), nullptr) << "GIN must be skipped when NCCL_GIN_ENABLE=0";
+}
+
+TEST_F(GinInitMPITest, AinicSelectsCastBackend)
+{
+    if (!rcclUseAinic())
+        GTEST_SKIP() << "Requires AINIC hardware";
+
+    const char* e = std::getenv("NCCL_GIN_ENABLE");
+    if (e != nullptr && std::strcmp(e, "0") == 0)
+        GTEST_SKIP() << "GIN disabled by NCCL_GIN_ENABLE=0";
+
+    ASSERT_TRUE(validateTestPrerequisites(kMinProcessesForMPI, kNoProcessLimit,
+                                          kNoPowerOfTwoRequired, 1, kNoNodeLimit))
+        << "Test requirements not met";
+
+    ASSERT_EQ(ncclSuccess, createTestCommunicator());
+
+    ncclGin_t* gin = AssignedGin();
+    if (gin == nullptr)
+        GTEST_SKIP() << "No GIN-capable devices enabled on this host";
+
+    // The generic net_ib proxy (ncclGinIbProxy) and the ionic net_ib_cast
+    // backends all report the name "GIN_IB_PROXY", so the backend identity must
+    // be checked through its function table rather than its name. The ionic
+    // cast entry point (IbCastGinIb) morphs into IbCastGinIbProxy or
+    // IbCastGinIbGdaki during init(); both cast variants share
+    // IbCastGinIbFinalize, which differs from the generic backend's finalize.
+    TEST_INFO("Assigned GIN backend: %s (finalize=%p)", gin->name, (void*)gin->finalize);
+    EXPECT_NE(gin->finalize, ncclGinIbProxy.finalize)
+        << "AINIC must not use the generic IB GIN backend";
+    EXPECT_EQ(gin->finalize, IbCastGinIbProxy.finalize)
+        << "AINIC must use the ionic ib-cast GIN backend";
+}
 
 } // namespace RCCLGinTests
 

--- a/projects/rccl/tools/scripts/test_runner/configs/ainic.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/ainic.json
@@ -191,6 +191,35 @@
       ]
     },
 
+    "a_gin_enable_gate": {
+      "extends": "a_base",
+      "timeout": 600,
+      "description": "A14: ROCM-27070 regression. On AINIC autodetect, NCCL_GIN_ENABLE=0 must gate GIN init early (comm init succeeds, no GIN assigned, no enumeration segfault).",
+      "env_variables": {
+        "NCCL_GIN_ENABLE": "0"
+      },
+      "tests": [
+        {
+          "name": "A14_Gin_EnableZeroSkipsInit",
+          "description": "NCCL_GIN_ENABLE=0 skips GIN plugin init; comm init succeeds with no GIN backend assigned.",
+          "test_filter": "GinInitMPITest.GinEnableZeroSkipsInit"
+        }
+      ]
+    },
+
+    "a_gin_ainic_backend": {
+      "extends": "a_base",
+      "timeout": 600,
+      "description": "A15: ROCM-27070 regression. On AINIC autodetect (NCCL_NET unset), GIN must select the ib-cast backend, never the generic IB proxy that triggers a second device enumeration.",
+      "tests": [
+        {
+          "name": "A15_Gin_AinicSelectsCastBackend",
+          "description": "GIN on AINIC uses IbCastGinIb, not the generic ncclGinIbProxy (no dual enumeration).",
+          "test_filter": "GinInitMPITest.AinicSelectsCastBackend"
+        }
+      ]
+    },
+
     "b_base": {
       "description": "Sweep base: derived suites run the full 1024-16G range for both allreduce and alltoall. Sets NO shared env_variables so each sweep runs against stock defaults plus its own per-suite knobs, and NO group-level command_args by design - every test sets its own explicit, complete command_args so nothing is silently concatenated/duplicated.",
       "is_gtest": false,
@@ -398,6 +427,8 @@
     { "name": "A6-A7. Component - CAST WRR",          "config": "a_cast_wrr",        "enabled": true },
     { "name": "A8. Component - Fault injection",      "config": "a_fault_inject",    "enabled": true },
     { "name": "A9-A13. Component - GIN proxy",        "config": "a_gin",             "enabled": true },
+    { "name": "A14. GIN enable gate (ROCM-27070)",    "config": "a_gin_enable_gate", "enabled": true },
+    { "name": "A15. GIN AINIC backend (ROCM-27070)",  "config": "a_gin_ainic_backend", "enabled": true },
 
     { "name": "B1. IB baseline",                     "config": "b1_ib",             "enabled": true },
     { "name": "B2. CAST alltoall full (1K-16G)",     "config": "b_alltoall_cast_full", "enabled": true },


### PR DESCRIPTION
## Motivation

ROCM-27070: RCCL segfaults during `ncclCommInitRank` on AINIC (Pensando ionic RoCE) hosts. Two root causes:

1. The GIN plugin did not honor `NCCL_GIN_ENABLE=0`, so GIN device enumeration still ran (and crashed) even when GIN was explicitly disabled.
2. On AINIC the data path uses `net_ib_cast` (`rcclUseAinic()`), but GIN registered the generic IB proxy backend (`ncclGinIbProxy`, name `"GIN_IB_PROXY"`) instead of the ionic-aware cast backend. This produced a second, independent RDMA device enumeration (separate `ibv_get_device_list` / `netRefCount`) that crashed inside `libibverbs`/ionic during `commAlloc`.

## Technical Details

`projects/rccl/src/plugin/gin.cc`:

- **Early enable gate:** `ncclGinInit` now returns early (`ncclSuccess`) when `ncclParamGinEnable() == 0`, before `initPluginLibsOnceFunc()` and any device enumeration, so `NCCL_GIN_ENABLE=0` fully skips GIN.
- **Mutually-exclusive internal IB backend registration:** the internal IB GIN backend is now registered exclusively. When `NCCL_NET=IB-CAST`/`ROCM-IB`, or on AINIC autodetect (`NCCL_NET` unset and `rcclUseAinic()`), only the ionic-aware `IbCastGinIb` entry point is registered. Otherwise the generic `ncclGinIbProxy` backend is registered. This mirrors the selection logic in `plugin/net.cc` and prevents dual RDMA device enumeration.

> Note: `IbCastGinIb` is a *morphing* entry point — at `init()` it `memcpy`s the concrete ionic sub-backend (`IbCastGinIbGdaki` or `IbCastGinIbProxy`) over itself. Consequently the ionic proxy sub-backend and the generic `ncclGinIbProxy` both report the name `"GIN_IB_PROXY"` at runtime; they are distinct backends from different transports (`net_ib_cast` vs `net_ib`) and are only distinguishable by their function tables.

Tests / runner:

- `projects/rccl/test/transport/GinMPI/GinInitMPITests.cpp` (new) — `GinInitMPITest` MPI gtests:
  - `GinEnableZeroSkipsInit`: with `NCCL_GIN_ENABLE=0`, `ncclCommInitRank` succeeds and `comm->sharedRes->ginState.ncclGin` is null (GIN skipped, no crash).
  - `AinicSelectsCastBackend`: with GIN enabled on AINIC, the assigned GIN backend is an ionic `net_ib_cast` backend and not the generic `net_ib` proxy. Because the cast entry point morphs at `init()` and both the ionic proxy sub-backend and the generic backend report the name `"GIN_IB_PROXY"`, identity is verified through the backend's function table — `gin->finalize == IbCastGinIbProxy.finalize` (shared `IbCastGinIbFinalize` across both ionic sub-backends) and `gin->finalize != ncclGinIbProxy.finalize` — rather than by name or by a raw pointer to the struct (which is unreliable across the `librccl.so` boundary due to copy relocations).
- `projects/rccl/test/CMakeLists.txt` — builds `GinInitMPITests.cpp` into `rccl-UnitTestsMPI`.
- `projects/rccl/tools/scripts/test_runner/configs/ainic.json` — adds runner configs A14 (`a_gin_enable_gate`) and A15 (`a_gin_ainic_backend`) invoking the two new tests with appropriate env, and registers them in `test_suites`.

## Issue Tracking

JIRA ID : ROCM-27070

## Test Plan

- Build RCCL in Debug with MPI tests enabled: `./install.sh --enable-mpi-tests` on gfx950 AINIC nodes.
- Run cross-node (2 nodes x 1 GPU) to avoid single-node IB loopback issues:
  - `GinInitMPITest.GinEnableZeroSkipsInit` (with `NCCL_GIN_ENABLE=0`)
  - `GinInitMPITest.AinicSelectsCastBackend` (GIN enabled, AINIC autodetect)
  - `NetIbMPITest.InitializePlugin` as a cross-node control.
- Equivalent test-runner entries: `ainic.json` suites A14 (`a_gin_enable_gate`) and A15 (`a_gin_ainic_backend`).

## Test Result

Debug build (`./install.sh --debug -t --enable-mpi-tests --amdgpu_targets gfx950`), run cross-node on 2 nodes × 1 GPU (mia1-p01-g27 + g25, MI355 / gfx950, ROCm 7.0.2, `RCCL_AINIC_ROCE=1`):

- **`NetIbMPITest.InitializePlugin` control — PASSED** cross-node (ionic devices `rdma0..7` enumerated, `libionic.so` loaded).
- **P1 `GinInitMPITest.GinEnableZeroSkipsInit` — PASSED**: with `NCCL_GIN_ENABLE=0`, `ncclCommInitRank` succeeds with `ginState.ncclGin == nullptr` and no crash.
- **P2 `GinInitMPITest.AinicSelectsCastBackend` — PASSED**: assigned GIN backend is the ionic `net_ib_cast` backend (`gin->finalize == IbCastGinIbProxy.finalize`, `!= ncclGinIbProxy.finalize`); data path uses `NET/IB-CAST` — the generic IB proxy is not selected, so there is no dual enumeration.

```
[ RUN      ] GinInitMPITest.GinEnableZeroSkipsInit
[       OK ] GinInitMPITest.GinEnableZeroSkipsInit
[ RUN      ] GinInitMPITest.AinicSelectsCastBackend
[       OK ] GinInitMPITest.AinicSelectsCastBackend
[  PASSED  ] 2 tests.
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

