### PR TITLE
ci(ainic): move concurrency to job level to avoid cancelling pending runs

### DIFF
--- a/.github/workflows/ainic_test_runner.yml
+++ b/.github/workflows/ainic_test_runner.yml
@@ -78,12 +78,6 @@ on:
     # job `if`); the subset that runs is defined by SMOKE_SUITES below.
     types: [labeled, synchronize]
 
-# Serialise on the shared AINIC nodes: only one run at a time, and never cancel
-# an in-progress allocation (it must finish cleanly to release the nodes).
-concurrency:
-  group: ainic-test-runner-pinned-nodes
-  cancel-in-progress: false
-
 permissions:
   contents: read
 
@@ -120,6 +114,14 @@ jobs:
       github.event_name != 'pull_request' ||
       (github.event.pull_request.head.repo.full_name == github.repository &&
        contains(github.event.pull_request.labels.*.name, 'ainic-test'))
+    # Serialise on the shared AINIC nodes: only one run at a time, and never
+    # cancel an in-progress allocation (it must finish cleanly to release the
+    # nodes). Job-level (not workflow-level) so skipped PR runs -- every PR
+    # synchronize in the monorepo triggers this workflow -- don't join the queue
+    # and cancel a pending labeled run that is still waiting for the runner.
+    concurrency:
+      group: ainic-test-runner-pinned-nodes
+      cancel-in-progress: false
     runs-on: [self-hosted, tw-gfx950-ainic-ROCm-scale-runner]
     timeout-minutes: 540
 


### PR DESCRIPTION
## What
Move the `concurrency` block from the workflow level to the `ainic-test-runner` **job** level (same group `ainic-test-runner-pinned-nodes`, `cancel-in-progress: false`).

## Why
The workflow triggers on every `pull_request` `synchronize` across the whole monorepo, so with a single **workflow-level** concurrency group every one of those runs (almost all of which are immediately skipped by the job `if`) joins one shared queue. With `cancel-in-progress: false` GitHub keeps only the newest *pending* run and **cancels older pending ones**.

Consequences observed on the Actions page:
- Runs from unrelated PRs show up as `cancelled` (not `skipped`) ~1 min after creation, e.g. [30017680919](https://github.com/ROCm/rocm-systems/actions/runs/30017680919) — empty jobs, runner never used.
- More importantly, an unrelated PR push can **cancel a legitimately labeled AINIC run while it is still pending** (waiting for the self-hosted runner).

ISSUE ID : AICOMRCCL-1393

## Fix
At the job level, only jobs that pass the `if` gate (labeled same-repo PRs, `schedule`, `workflow_dispatch`) enter the concurrency group; skipped PR runs no longer churn the queue or cancel pending real runs, and they show as `skipped` again. Serialisation on the shared AINIC nodes (one run at a time, in-progress never cancelled) is unchanged.

## Notes
Non-gate workflow; no functional change to how tests run.
