### PR TITLE
[rocjitsu] Compact indirect branch lattice facts

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -12,6 +12,7 @@
 #include <array>
 #include <bit>
 #include <bitset>
+#include <cassert>
 #include <cstdint>
 #include <cstring>
 #include <deque>
@@ -316,6 +317,37 @@ struct LatticeValue {
   bool killed = false;
 
   friend bool operator==(const LatticeValue &, const LatticeValue &) = default;
+};
+
+/// @brief Compact sorted block-entry facts keyed by the low SGPR of a pair.
+///
+/// @details The key domain is bounded by the architectural SGPR count and the
+/// dataflow constructs entries in ascending key order. Keeping the sparse facts
+/// contiguous avoids one allocation per key plus one bucket array per block,
+/// which is especially expensive for generated objects with millions of
+/// analysis blocks.
+class LatticeFacts {
+  using Entry = std::pair<uint16_t, LatticeValue>;
+
+public:
+  void reserve(size_t size) { entries_.reserve(size); }
+
+  void append(uint16_t pair_lo, LatticeValue value) {
+    assert(entries_.empty() || entries_.back().first < pair_lo);
+    entries_.emplace_back(pair_lo, std::move(value));
+  }
+
+  [[nodiscard]] const LatticeValue *find(uint16_t pair_lo) const {
+    const auto it =
+        std::lower_bound(entries_.begin(), entries_.end(), pair_lo,
+                         [](const Entry &entry, uint16_t key) { return entry.first < key; });
+    return it != entries_.end() && it->first == pair_lo ? &it->second : nullptr;
+  }
+
+  friend bool operator==(const LatticeFacts &, const LatticeFacts &) = default;
+
+private:
+  std::vector<Entry> entries_;
 };
 
 /// @brief Mutable symbolic state for one straight-line analysis block.
@@ -1468,7 +1500,7 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
   finalize_block_transfers(block, state);
 }
 
-[[nodiscard]] std::vector<std::unordered_map<uint16_t, LatticeValue>>
+[[nodiscard]] std::vector<LatticeFacts>
 run_block_dataflow(const std::vector<AnalysisBlock> &blocks) {
   // Phase 3: compute block-entry facts to a fixed point.
   //
@@ -1484,10 +1516,10 @@ run_block_dataflow(const std::vector<AnalysisBlock> &blocks) {
       predecessors[successor].push_back(block_index);
   }
 
-  std::vector<std::unordered_map<uint16_t, LatticeValue>> entry_facts(blocks.size());
-  // Keep key presence separate from the node-based value maps. The dataflow
+  std::vector<LatticeFacts> entry_facts(blocks.size());
+  // Keep key presence separate from the sparse value maps. The dataflow
   // join needs the union of predecessor keys on every worklist visit; caching
-  // that bounded set avoids repeatedly chasing every unordered_map node just
+  // that bounded set avoids repeatedly scanning every fact
   // to recover information that changes only when the corresponding map does.
   std::vector<std::bitset<REGISTER_SET_MAX_SGPRS>> entry_pairs(blocks.size());
   std::deque<size_t> worklist;
@@ -1502,7 +1534,7 @@ run_block_dataflow(const std::vector<AnalysisBlock> &blocks) {
     worklist.pop_front();
     on_worklist[block_index] = false;
 
-    std::unordered_map<uint16_t, LatticeValue> new_entry;
+    LatticeFacts new_entry;
     std::bitset<REGISTER_SET_MAX_SGPRS> mentioned_pairs;
     if (!predecessors[block_index].empty()) {
       // A predecessor exit is its sparse entry map with this block's SET/KILL
@@ -1518,6 +1550,7 @@ run_block_dataflow(const std::vector<AnalysisBlock> &blocks) {
           mentioned_pairs.set(pair_lo);
       }
 
+      new_entry.reserve(mentioned_pairs.count());
       for (uint16_t pair_lo = 0; pair_lo < mentioned_pairs.size(); ++pair_lo) {
         if (!mentioned_pairs[pair_lo])
           continue;
@@ -1536,27 +1569,27 @@ run_block_dataflow(const std::vector<AnalysisBlock> &blocks) {
               // Pass is normally represented by absence from the sparse
               // transfer map, but handle it explicitly to keep this lookup
               // equivalent if a caller ever stores a Pass summary.
-              const auto entry = entry_facts[predecessor].find(pair_lo);
-              if (entry == entry_facts[predecessor].end())
+              const LatticeValue *entry = entry_facts[predecessor].find(pair_lo);
+              if (entry == nullptr)
                 joined.incomplete = true;
               else
-                join_lattice_value(joined, entry->second);
+                join_lattice_value(joined, *entry);
             }
             continue;
           }
 
-          const auto entry = entry_facts[predecessor].find(pair_lo);
-          if (entry == entry_facts[predecessor].end()) {
+          const LatticeValue *entry = entry_facts[predecessor].find(pair_lo);
+          if (entry == nullptr) {
             // A missing predecessor fact means the pair is still at its
             // unconstrained kernel-entry value on that path. Joining a concrete
             // PC with an unconstrained value must not create a speculative CFG
             // edge, so the result becomes incomplete.
             joined.incomplete = true;
           } else {
-            join_lattice_value(joined, entry->second);
+            join_lattice_value(joined, *entry);
           }
         }
-        new_entry.emplace(pair_lo, std::move(joined));
+        new_entry.append(pair_lo, std::move(joined));
       }
     }
 
@@ -1576,11 +1609,11 @@ run_block_dataflow(const std::vector<AnalysisBlock> &blocks) {
   return entry_facts;
 }
 
-[[nodiscard]] size_t classify_pending_consumers(
-    const AnalysisContext &ctx, const std::vector<AnalysisBlock> &blocks,
-    const std::vector<std::unordered_map<uint16_t, LatticeValue>> &entry_facts,
-    const std::vector<PendingConsumer> &pending_consumers,
-    std::vector<IndirectCallFixup> &recovered) {
+[[nodiscard]] size_t
+classify_pending_consumers(const AnalysisContext &ctx, const std::vector<AnalysisBlock> &blocks,
+                           const std::vector<LatticeFacts> &entry_facts,
+                           const std::vector<PendingConsumer> &pending_consumers,
+                           std::vector<IndirectCallFixup> &recovered) {
   // Phase 4: resolve consumers that were pristine in their own block. A complete
   // entry fact provides concrete getpc-built targets. Missing, empty, or killed
   // facts are unresolved. Incomplete facts are still allowed when the concrete
@@ -1596,18 +1629,18 @@ run_block_dataflow(const std::vector<AnalysisBlock> &blocks) {
       continue;
     }
     const auto &facts = entry_facts[consumer.block_index];
-    auto it = facts.find(consumer.pair_lo);
-    if (it == facts.end() || it->second.values.empty() || it->second.killed) {
+    const LatticeValue *value = facts.find(consumer.pair_lo);
+    if (value == nullptr || value->values.empty() || value->killed) {
       ++unresolved;
       continue;
     }
-    if (it->second.incomplete && it->second.values.size() >= kMaxIndirectTargetsPerConsumer) {
+    if (value->incomplete && value->values.size() >= kMaxIndirectTargetsPerConsumer) {
       ++unresolved;
       continue;
     }
 
-    emit_fixups_for_values(ctx, consumer.inst_index, consumer.pair_lo, it->second.values, recovered,
-                           it->second.incomplete);
+    emit_fixups_for_values(ctx, consumer.inst_index, consumer.pair_lo, value->values, recovered,
+                           value->incomplete);
   }
   return unresolved;
 }

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -511,6 +511,46 @@ TEST(CfgAnalysis, RecoveredIndirectBranchEdgeStartsAtConsumerBlock) {
   EXPECT_FALSE(has_predecessor(*fallthrough, consumer));
 }
 
+TEST(CfgAnalysis, RecoversMultipleSgprPairsFromOneBlockEntry) {
+  constexpr uint16_t kFirstPcSreg = 8;
+  constexpr uint16_t kSecondPcSreg = 20;
+  constexpr uint32_t kLiteralOperand = 255;
+  constexpr uint32_t kInlineInt0 = 128;
+
+  // Both PC builders reach both successor blocks. The two pending consumers
+  // exercise lookup of distinct keys in the same sorted block-entry fact set.
+  std::vector<uint32_t> words = {
+      pack_sop1(0x1c, kFirstPcSreg, 0),                                // 0x00: first getpc.
+      pack_sop2(0, kFirstPcSreg, kFirstPcSreg, kLiteralOperand),       // 0x04: first add.
+      44,                                                              // 0x08: -> 0x30.
+      pack_sop2(4, kFirstPcSreg + 1, kFirstPcSreg + 1, kInlineInt0),   // 0x0c.
+      pack_sop1(0x1c, kSecondPcSreg, 0),                               // 0x10: second getpc.
+      pack_sop2(0, kSecondPcSreg, kSecondPcSreg, kLiteralOperand),     // 0x14: second add.
+      32,                                                              // 0x18: -> 0x34.
+      pack_sop2(4, kSecondPcSreg + 1, kSecondPcSreg + 1, kInlineInt0), // 0x1c.
+      pack_sopp(5, 1),                                                 // 0x20: -> 0x28.
+      pack_sop1(0x1d, 0, kFirstPcSreg),                                // 0x24: first consumer.
+      pack_sop1(0x1d, 0, kSecondPcSreg),                               // 0x28: second consumer.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),                        // 0x2c.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),                        // 0x30: first target.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),                        // 0x34: second target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *first_consumer = block_starting_at(blocks, 36);
+  auto *second_consumer = block_starting_at(blocks, 40);
+  ASSERT_NE(first_consumer, nullptr);
+  ASSERT_NE(second_consumer, nullptr);
+  ASSERT_EQ(first_consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_EQ(first_consumer->static_indirect_call_fixups()[0].source_target_offset, 48u);
+  ASSERT_EQ(second_consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_EQ(second_consumer->static_indirect_call_fixups()[0].source_target_offset, 52u);
+}
+
 TEST(CfgAnalysis, IncompleteFactConsumerIsFlaggedIncomplete) {
   constexpr uint16_t kPcSreg = 8;
   constexpr uint32_t kLiteralOperand = 255;


### PR DESCRIPTION
## Motivation

Reduce translation time and memory for large gfx1250 B0 code objects.

## Technical Details

Store sparse block-entry lattice facts in sorted contiguous storage, enforce ordered insertion, and cover multiple SGPR pairs.

## Issue Tracking

N/A

## Test Plan

ctest + benchmark the DeepSeek kernel translation

## Test Result

OK. RCCL elapsed time fell 22.8% (1.29x speedup) and peak RSS fell 24.5%, with byte-identical output.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
