### PR TITLE
[AICOMRCCL-1577] test: bound NetIB connection handshake and cap net_ib_transfer timeouts

### DIFF
--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -355,7 +355,10 @@ protected:
             int attempts = 0;
             while (!done) {
                 ncclResult_t result = ConnectToRemote(dev, &pair.handle, &pair.sendComm);
-                if (result == ncclSuccess && pair.sendComm != nullptr) {
+                if (result != ncclSuccess) {
+                    return result;
+                }
+                if (pair.sendComm != nullptr) {
                     done = 1;
                     break;
                 }

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -168,6 +168,7 @@ protected:
     // Timing constants
     static constexpr int kDefaultTimeoutMs = 5000;
     static constexpr int kLargeTransferTimeoutMs = 30000;
+    static constexpr int kConnectTimeoutMs = 30000;  // Handshake watchdog (see SetupConnection)
     static constexpr int kPollIntervalUs = 10000;  // 10ms
     static constexpr int kPollIntervalMs = 10;
     static constexpr int kMaxRetryAttempts = 1000;  // For NULL request handling
@@ -318,6 +319,9 @@ protected:
     };
 
     ncclResult_t SetupConnection(int dev, ConnectionPair& pair, int rank, int peerRank) {
+        // Cap the accept/connect handshake so a dead fabric fails fast instead
+        // of spinning forever (AICOMRCCL-1577).
+        const int maxAttempts = kConnectTimeoutMs / kPollIntervalMs;
         if (rank == 0) {
             // Rank 0: Listen
             RCCL_TEST_CHECK(CreateListenComm(dev, &pair.handle, &pair.listenComm));
@@ -327,11 +331,17 @@ protected:
 
             // Accept connection
             int done = 0;
+            int attempts = 0;
             while (!done) {
                 ncclResult_t result = AcceptConnection(pair.listenComm, &pair.recvComm);
                 if (result == ncclSuccess && pair.recvComm != nullptr) {
                     done = 1;
+                    break;
                 }
+                if (++attempts >= maxAttempts) {
+                    return ncclInternalError;
+                }
+                usleep(kPollIntervalUs);
             }
         } else {
             // Rank 1: Connect
@@ -339,11 +349,17 @@ protected:
 
             // Connect to peer
             int done = 0;
+            int attempts = 0;
             while (!done) {
                 ncclResult_t result = ConnectToRemote(dev, &pair.handle, &pair.sendComm);
                 if (result == ncclSuccess && pair.sendComm != nullptr) {
                     done = 1;
+                    break;
                 }
+                if (++attempts >= maxAttempts) {
+                    return ncclInternalError;
+                }
+                usleep(kPollIntervalUs);
             }
         }
 

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -334,7 +334,10 @@ protected:
             int attempts = 0;
             while (!done) {
                 ncclResult_t result = AcceptConnection(pair.listenComm, &pair.recvComm);
-                if (result == ncclSuccess && pair.recvComm != nullptr) {
+                if (result != ncclSuccess) {
+                    return result;
+                }
+                if (pair.recvComm != nullptr) {
                     done = 1;
                     break;
                 }

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -255,6 +255,7 @@
     },
     "net_ib_transfer": {
       "extends": "net_ib_base",
+      "timeout": 300,
       "env_variables": {
         "NCCL_DEBUG": "TRACE",
         "NCCL_DEBUG_SUBSYS": "NET,INIT"
@@ -284,17 +285,20 @@
         {
           "name": "NetIB_Xfer_DifferentMemoryTypes",
           "description": "Send/recv with mixed host and GPU memory buffers",
-          "test_filter": "NetIbMPITest.SendRecvDifferentMemoryTypes"
+          "test_filter": "NetIbMPITest.SendRecvDifferentMemoryTypes",
+          "timeout": 300
         },
         {
           "name": "NetIB_Xfer_MultipleSizesFusion",
           "description": "Send/recv multiple buffer sizes through fused vNIC",
-          "test_filter": "NetIbMPITest.SendRecvMultipleSizesFusion"
+          "test_filter": "NetIbMPITest.SendRecvMultipleSizesFusion",
+          "timeout": 300
         },
         {
           "name": "NetIB_Xfer_MultipleOutstanding",
           "description": "Multiple outstanding send/recv requests in flight simultaneously",
-          "test_filter": "NetIbMPITest.MultipleOutstandingSendRecv"
+          "test_filter": "NetIbMPITest.MultipleOutstandingSendRecv",
+          "timeout": 300
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -2834,11 +2834,11 @@
       "tests": [
         {
           "name": "Bootstrap_Combined",
-          "description": "Combined NCCL_OOB_NET_ENABLE + NCCL_OOB_NET_IFNAME + NCCL_UID_STAGGER_RATE + NCCL_UID_STAGGER_THRESHOLD",
+          "description": "Combined NCCL_OOB_NET_ENABLE + NCCL_OOB_NET_IFNAME + NCCL_UID_STAGGER_RATE + NCCL_UID_STAGGER_THRESHOLD. With OOB net enabled the OOB device is selected from the NET plugin (IB) device list, so NCCL_OOB_NET_IFNAME must name an HCA (mlx5_*), not an ethernet interface.",
           "command_args": "-o all",
           "env_variables": {
             "NCCL_OOB_NET_ENABLE": "1",
-            "NCCL_OOB_NET_IFNAME": "eth0",
+            "NCCL_OOB_NET_IFNAME": "mlx5_0",
             "NCCL_UID_STAGGER_RATE": "5000",
             "NCCL_UID_STAGGER_THRESHOLD": "128"
           }


### PR DESCRIPTION
## Motivation

Two RCCL test-harness issues on the MI300X + Mellanox IB setup caused hangs and spurious failures. NetIB MPI transport tests could hang indefinitely when a peer's IB fabric was unhealthy; this was hit in practice when one node's IB interfaces were stuck in the INIT port state (no Subnet Manager had moved them to ACTIVE), so the handshake never completed. The ports were later restored to ACTIVE, but the harness must fail fast regardless of fabric health. Separately, Bootstrap_Combined failed comm-init on every rank because its OOB-net interface was misconfigured.

## Technical Details

- `NetIbMPITestBase.hpp`: added a `kConnectTimeoutMs` (30s) watchdog to the `SetupConnection()` handshake loops with throttled polling, so a non-completing handshake fails deterministically instead of spinning forever.
- `mi300x_mellanox_ib.json` (net_ib_transfer): added a 300s suite-level default plus per-test 300s timeouts to the transfer tests that lacked one.
- `mi300x_mellanox_ib.json` (Bootstrap_Combined): set `NCCL_OOB_NET_IFNAME` to the IB HCA `mlx5_0`. With `NCCL_OOB_NET_ENABLE=1` the OOB device is selected from the NET plugin (IB) device list via `matchIfList(props.name, ...)`, so the value must name an HCA, not an ethernet interface (`eth0`/`eth1` matched no device).

## Issue Tracking

JIRA ID: AICOMRCCL-1577

## Test Plan

Ran the NET IB suites (Initialization, Device Properties, Connection Setup, Memory Registration, Data Transfer) and the Bootstrap/OOB Net rccl-tests suite via test_runner with `rccl-UnitTestsMPI` on an MI300X node (8 GPUs, 6 active Mellanox HCAs), after the affected node's IB ports were restored from INIT to ACTIVE.

## Test Result

NET IB core suites: 8 passed, 0 failed, 0 timeouts, 4 topology-gated skips; previously hanging Connection Setup / Data Transfer tests now complete in 9-15s each. Bootstrap_Combined: PASSED (146s, 0 out-of-bounds values).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
