### PR TITLE
[rocjitsu] Limit indirect dataflow to pending pairs

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -1447,10 +1447,11 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
         // source pair unless the instruction also defines it. Real kernels can
         // build one callee address once and issue multiple swappc calls through
         // that same pair on the fallthrough path.
-      } else if (!state.pair_dirty(*consumer_pair)) {
+      } else if (*consumer_pair < kMaxTrackedSgprPair && !state.pair_dirty(*consumer_pair)) {
         // The block did not touch the pair, so any useful fact must come from
         // predecessor blocks. Defer classification until the block-entry
-        // lattice is available.
+        // lattice is available. Out-of-range selectors cannot name a tracked
+        // SGPR pair and deliberately remain unresolved.
         pending_consumers.push_back(PendingConsumer{
             .block_index = block_index,
             .inst_index = index,
@@ -1501,7 +1502,8 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
 }
 
 [[nodiscard]] std::vector<LatticeFacts>
-run_block_dataflow(const std::vector<AnalysisBlock> &blocks) {
+run_block_dataflow(const std::vector<AnalysisBlock> &blocks,
+                   std::span<const PendingConsumer> pending_consumers) {
   // Phase 3: compute block-entry facts to a fixed point.
   //
   // entry[B] = JOIN(exit[P]) for every predecessor P of B.
@@ -1516,11 +1518,23 @@ run_block_dataflow(const std::vector<AnalysisBlock> &blocks) {
       predecessors[successor].push_back(block_index);
   }
 
+  // Dataflow results are consumed only by pending cross-block branches. A pair
+  // that is built or killed somewhere but never reaches such a consumer cannot
+  // affect any emitted fixup, so exclude it from the lattice entirely. Local
+  // consumers were already resolved during scan_block(). This set must contain
+  // every tracked pair used by a cross-block consumer; omitted consumers remain
+  // unresolved.
+  std::bitset<REGISTER_SET_MAX_SGPRS> relevant_pairs;
+  for (const PendingConsumer &consumer : pending_consumers) {
+    if (consumer.pair_lo < kMaxTrackedSgprPair)
+      relevant_pairs.set(consumer.pair_lo);
+  }
+
   std::vector<LatticeFacts> entry_facts(blocks.size());
-  // Keep key presence separate from the sparse value maps. The dataflow
+  // Keep key presence separate from the sparse fact vectors. The dataflow
   // join needs the union of predecessor keys on every worklist visit; caching
   // that bounded set avoids repeatedly scanning every fact
-  // to recover information that changes only when the corresponding map does.
+  // to recover information that changes only when the corresponding vector does.
   std::vector<std::bitset<REGISTER_SET_MAX_SGPRS>> entry_pairs(blocks.size());
   std::deque<size_t> worklist;
   std::vector<bool> on_worklist(blocks.size(), false);
@@ -1546,8 +1560,10 @@ run_block_dataflow(const std::vector<AnalysisBlock> &blocks) {
       // predecessor's exit value only for the pair currently being joined.
       for (size_t predecessor : predecessors[block_index]) {
         mentioned_pairs |= entry_pairs[predecessor];
-        for (const auto &[pair_lo, _] : blocks[predecessor].transfers)
-          mentioned_pairs.set(pair_lo);
+        for (const auto &[pair_lo, _] : blocks[predecessor].transfers) {
+          if (relevant_pairs[pair_lo])
+            mentioned_pairs.set(pair_lo);
+        }
       }
 
       new_entry.reserve(mentioned_pairs.count());
@@ -2055,7 +2071,7 @@ discover_indirect_branch_edges(std::span<const Instruction *const> insts,
 
     size_t unresolved_consumers = 0;
     if (!pending_consumers.empty()) {
-      const auto entry_facts = run_block_dataflow(blocks);
+      const auto entry_facts = run_block_dataflow(blocks, pending_consumers);
       unresolved_consumers = classify_pending_consumers(ctx, blocks, entry_facts, pending_consumers,
                                                         iteration_recovered);
     }

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -551,6 +551,56 @@ TEST(CfgAnalysis, RecoversMultipleSgprPairsFromOneBlockEntry) {
   EXPECT_EQ(second_consumer->static_indirect_call_fixups()[0].source_target_offset, 52u);
 }
 
+TEST(CfgAnalysis, OutOfRangeIndirectConsumersRemainUnresolved) {
+  constexpr uint16_t kOutOfRangeSelector = 106;
+  const std::array<uint32_t, 2> consumers = {
+      pack_sop1(0x1d, 0, kOutOfRangeSelector),  // s_setpc_b64 vcc.
+      pack_sop1(0x1e, 30, kOutOfRangeSelector), // s_swappc_b64 s[30:31], vcc.
+  };
+
+  for (uint32_t consumer : consumers) {
+    TestCodeObject co(std::vector<uint32_t>{consumer});
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    ASSERT_NE(decoder, nullptr);
+    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+    ASSERT_EQ(blocks.size(), 1u);
+    EXPECT_TRUE(blocks[0]->static_indirect_call_fixups().empty());
+  }
+}
+
+TEST(CfgAnalysis, IgnoresUnconsumedPairWhileRecoveringPendingConsumer) {
+  constexpr uint16_t kUnusedPcSreg = 8;
+  constexpr uint16_t kUsedPcSreg = 20;
+  constexpr uint32_t kLiteralOperand = 255;
+  constexpr uint32_t kInlineInt0 = 128;
+
+  // Both builders reach the consumer block, but only s[20:21] is consumed.
+  // The relevance filter must drop the s[8:9] transfer without disturbing the
+  // pending consumer's fact.
+  std::vector<uint32_t> words = {
+      pack_sop1(0x1c, kUnusedPcSreg, 0),                           // 0x00: unused getpc.
+      pack_sop1(0x1c, kUsedPcSreg, 0),                             // 0x04: used getpc.
+      pack_sop2(0, kUsedPcSreg, kUsedPcSreg, kLiteralOperand),     // 0x08: used add.
+      20,                                                          // 0x0c: -> 0x1c.
+      pack_sop2(4, kUsedPcSreg + 1, kUsedPcSreg + 1, kInlineInt0), // 0x10.
+      pack_sop1(0x1d, 0, kUsedPcSreg),                             // 0x14: consumer.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),                    // 0x18.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),                    // 0x1c: target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  constexpr std::array<uint64_t, 1> extra_leaders{20};
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
+
+  auto *consumer = block_starting_at(blocks, 20);
+  ASSERT_NE(consumer, nullptr);
+  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 28u);
+}
+
 TEST(CfgAnalysis, IncompleteFactConsumerIsFlaggedIncomplete) {
   constexpr uint16_t kPcSreg = 8;
   constexpr uint32_t kLiteralOperand = 255;


### PR DESCRIPTION
## Motivation

Reduce translation time and memory for DeepSeek V4 Flash gfx1250 B0 kernels.

## Technical Details

Propagate SGPR-pair facts only for unresolved cross-block consumers and reject out-of-range selectors.

## Issue Tracking

N/A

## Test Plan

A/B translate and byte-compare all 128 unique DeepSeek V4 Flash code objects with and without pending-pair slicing.

## Test Result

DeepSeek V4 Flash: 326 s to 211 s (1.55x speedup); peak RSS 31 GiB to 20 GiB (36% lower). Outputs were byte-identical.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.