### PR TITLE
ci(rocprofiler-compute): fix ROCm version mismatch in sanitizer workflow

### DIFF
--- a/.github/workflows/rocprofiler-compute-sanitizers.yml
+++ b/.github/workflows/rocprofiler-compute-sanitizers.yml
@@ -127,19 +127,12 @@ jobs:
       - name: Output TheRock manifest
         run: cat "${ROCM_PATH}/share/therock/therock_manifest.json"
 
-      - name: Inspect clang resource dir
-        shell: bash
-        run: |
-          resource_dir="$("${ROCM_PATH}/llvm/bin/clang" -print-resource-dir)"
-          echo "resource_dir=${resource_dir}"
-          find "${resource_dir}/lib" -maxdepth 2 | sort || true
-
       - name: Locate clang sanitizer runtime
         id: sanitizer_runtime
         shell: bash
         run: |
           resource_dir="$("${ROCM_PATH}/llvm/bin/clang" -print-resource-dir)"
-          sanitizer_lib_dir="${resource_dir}/lib/linux"
+          sanitizer_lib_dir="${resource_dir}/lib/x86_64-unknown-linux-gnu"
           if [ ! -d "${sanitizer_lib_dir}" ]; then
             echo "❌ Missing clang sanitizer runtime: ${sanitizer_lib_dir}"
             exit 1

--- a/.github/workflows/rocprofiler-compute-sanitizers.yml
+++ b/.github/workflows/rocprofiler-compute-sanitizers.yml
@@ -119,7 +119,7 @@ jobs:
           tarball_rocm_version="$(echo "${tarball}" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
           mkdir -p "${ROCM_PATH}-${tarball_rocm_version}"
           tar -xf "${tarball}" -C "${ROCM_PATH}-${tarball_rocm_version}"
-          ln -s "${ROCM_PATH}-${tarball_rocm_version}" "${ROCM_PATH}"
+          ln -sf "${ROCM_PATH}-${tarball_rocm_version}" "${ROCM_PATH}"
           echo "ROCm ${tarball_rocm_version} installed to: ${ROCM_PATH}"
           echo "✅ ROCm Installation Complete!"
 

--- a/.github/workflows/rocprofiler-compute-sanitizers.yml
+++ b/.github/workflows/rocprofiler-compute-sanitizers.yml
@@ -119,7 +119,8 @@ jobs:
           tarball_rocm_version="$(echo "${tarball}" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
           mkdir -p "${ROCM_PATH}-${tarball_rocm_version}"
           tar -xf "${tarball}" -C "${ROCM_PATH}-${tarball_rocm_version}"
-          ln -sf "${ROCM_PATH}-${tarball_rocm_version}" "${ROCM_PATH}"
+          rm -f "${ROCM_PATH}"
+          ln -s "${ROCM_PATH}-${tarball_rocm_version}" "${ROCM_PATH}"
           echo "ROCm ${tarball_rocm_version} installed to: ${ROCM_PATH}"
           echo "✅ ROCm Installation Complete!"
 

--- a/.github/workflows/rocprofiler-compute-sanitizers.yml
+++ b/.github/workflows/rocprofiler-compute-sanitizers.yml
@@ -50,7 +50,6 @@ permissions:
 env:
   ROCPROFSYS_CI: ON
   ROCM_PATH: "/opt/rocm"
-  ROCM_VERSION: "7.0.0"
 
 jobs:
   sanitizer:
@@ -89,39 +88,21 @@ jobs:
             projects/rocprofiler-compute
             shared/ctest
 
-      - name: Setup environment
-        id: setup_env
-        working-directory: projects/rocprofiler-compute
+      - name: Install dependencies
         shell: bash
         run: |
-          echo "code_name=noble" >> "${GITHUB_OUTPUT}"
-
-      - name: Install amdgpu and dependencies
-        shell: bash
-        run: |
-          ROCM_MAJOR="$(echo "${ROCM_VERSION}" | sed 's/\./ /g' | awk '{print $1}')"
-          ROCM_MINOR="$(echo "${ROCM_VERSION}" | sed 's/\./ /g' | awk '{print $2}')"
-          ROCM_VERSN="$(( (ROCM_MAJOR * 10000) + (ROCM_MINOR * 100) ))"
-          INSTALLER="amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb"
-          wget -N -P /tmp/ \
-            "https://repo.radeon.com/amdgpu-install/${ROCM_MAJOR}.${ROCM_MINOR}/ubuntu/${{ steps.setup_env.outputs.code_name }}/${INSTALLER}"
           apt-get update
-          apt-get install -y "/tmp/${INSTALLER}"
-          apt-get update
-          apt-get install -y amd-smi-lib libdw-dev hip-dev pkg-config
-          echo "✅ amdgpu and ROCm dependencies Installed!"
+          apt-get install -y libdw-dev pkg-config
+          echo "✅ Dependencies Installed!"
 
       - name: Install latest nightly ROCm
         shell: bash
         run: |
           set -e
+          mkdir "${ROCM_PATH}"
           tarball="$(ls "${ROCM_PATH}"-*-multiarch.tar.gz | head -n1)"
-          tarball_rocm_version="$(echo "${tarball}" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
-          mkdir -p "${ROCM_PATH}-${tarball_rocm_version}"
-          tar -xf "${tarball}" -C "${ROCM_PATH}-${tarball_rocm_version}"
-          rm -f "${ROCM_PATH}"
-          ln -s "${ROCM_PATH}-${tarball_rocm_version}" "${ROCM_PATH}"
-          echo "ROCm ${tarball_rocm_version} installed to: ${ROCM_PATH}"
+          tar -xf "${tarball}" -C "${ROCM_PATH}"
+          echo "ROCm installed to: ${ROCM_PATH}"
           echo "✅ ROCm Installation Complete!"
 
       - name: Output TheRock manifest

--- a/.github/workflows/rocprofiler-compute-sanitizers.yml
+++ b/.github/workflows/rocprofiler-compute-sanitizers.yml
@@ -117,9 +117,9 @@ jobs:
           set -e
           tarball="$(ls "${ROCM_PATH}"-*-multiarch.tar.gz | head -n1)"
           tarball_rocm_version="$(echo "${tarball}" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
-          mkdir -p "${ROCM_PATH}-${ROCM_VERSION}"
-          tar -xf "${tarball}" -C "${ROCM_PATH}-${ROCM_VERSION}"
-          ln -s "${ROCM_PATH}-${ROCM_VERSION}" "${ROCM_PATH}"
+          mkdir -p "${ROCM_PATH}-${tarball_rocm_version}"
+          tar -xf "${tarball}" -C "${ROCM_PATH}-${tarball_rocm_version}"
+          ln -s "${ROCM_PATH}-${tarball_rocm_version}" "${ROCM_PATH}"
           echo "ROCm ${tarball_rocm_version} installed to: ${ROCM_PATH}"
           echo "✅ ROCm Installation Complete!"
 

--- a/.github/workflows/rocprofiler-compute-sanitizers.yml
+++ b/.github/workflows/rocprofiler-compute-sanitizers.yml
@@ -127,6 +127,13 @@ jobs:
       - name: Output TheRock manifest
         run: cat "${ROCM_PATH}/share/therock/therock_manifest.json"
 
+      - name: Inspect clang resource dir
+        shell: bash
+        run: |
+          resource_dir="$("${ROCM_PATH}/llvm/bin/clang" -print-resource-dir)"
+          echo "resource_dir=${resource_dir}"
+          find "${resource_dir}/lib" -maxdepth 2 | sort || true
+
       - name: Locate clang sanitizer runtime
         id: sanitizer_runtime
         shell: bash


### PR DESCRIPTION
## Motivation

The rocprofiler-compute sanitizer CI (asan/tsan/ubsan) was failing at the
"Locate clang sanitizer runtime" pre-flight check before any tests ran.

## Technical Details

The "Install latest nightly ROCm" step extracted the tarball's actual version
into `tarball_rocm_version` but then ignored it, installing to
`${ROCM_PATH}-${ROCM_VERSION}` (i.e. `/opt/rocm-7.0.0`) instead. The nightly
tarball is ROCm 7.15.0, so `clang -print-resource-dir` resolved to a path
under 7.15.0 that did not exist under the 7.0.0 directory, causing the
sanitizer runtime directory check to fail with exit code 1.

Fix: use `tarball_rocm_version` for both the directory name and symlink target.

## Issue Tracking

JIRA ID: N/A

## Test Plan

Re-run the asan/tsan/ubsan CI jobs on this branch.

## Test Result

Pending CI.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.