### PR TITLE
ci(rocjitsu): Enable TSan on remaining tests

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -175,12 +175,6 @@ jobs:
             # load-sensitive at the TSan job's CI-level parallelism.
             "DaemonApi\.FullListenerQueueDoesNotBlockOrRemoveSocket"
           )
-          TSAN_SHARED_EXCLUDED_TESTS=(
-            # With the shared TSan runtime, the nested HIP process repeatedly
-            # returns EPERM from process_vm_readv and the test times out. A
-            # local static TSan configuration runs this test successfully.
-            "RocjitsuCliDaemon\.LaunchesApplicationAfterDaemonIsReady"
-          )
 
           TEST_REGEX="${{ matrix.test_regex }}"
           CMAKE_CONFIG_FLAGS=()
@@ -193,9 +187,6 @@ jobs:
           fi
           if [[ "${{ matrix.enable_tsan }}" == "1" ]]; then
             EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${TSAN_EXCLUDED_TESTS[*]}")"
-            if [[ "${{ matrix.sanitizer_runtime }}" == "SHARED" ]]; then
-              EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${TSAN_SHARED_EXCLUDED_TESTS[*]}")"
-            fi
           fi
           if [[ -n "${{ matrix.c_compiler }}" ]]; then
             CMAKE_CONFIG_FLAGS+=(-DCMAKE_C_COMPILER="${{ matrix.c_compiler }}")

--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -74,7 +74,8 @@ jobs:
             enable_expensive_checks: 1
             sanitizer_runtime: SHARED
           - name: tsan
-            allow_failure: true
+            allow_failure: false
+            run_static_asan_launch: true
             test_regex: ''
             build_type: RelWithDebInfo
             enable_asan: 0
@@ -93,16 +94,6 @@ jobs:
             sanitizer_runtime: SHARED
             c_compiler: gcc
             cxx_compiler: g++
-          - name: tsan-validated
-            allow_failure: false
-            run_static_asan_launch: true
-            test_regex: ''
-            build_type: RelWithDebInfo
-            enable_asan: 0
-            enable_ubsan: 0
-            enable_tsan: 1
-            enable_expensive_checks: 0
-            sanitizer_runtime: STATIC
 
     steps:
       - name: Install base dependencies
@@ -186,8 +177,8 @@ jobs:
           )
           TSAN_SHARED_EXCLUDED_TESTS=(
             # With the shared TSan runtime, the nested HIP process repeatedly
-            # returns EPERM from process_vm_readv and the test times out. The
-            # static TSan configuration runs this test successfully.
+            # returns EPERM from process_vm_readv and the test times out. A
+            # local static TSan configuration runs this test successfully.
             "RocjitsuCliDaemon\.LaunchesApplicationAfterDaemonIsReady"
           )
 

--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -80,7 +80,7 @@ jobs:
             enable_asan: 0
             enable_ubsan: 0
             enable_tsan: 1
-            enable_expensive_checks: 1
+            enable_expensive_checks: 0
             sanitizer_runtime: SHARED
           - name: asan-ubsan-gcc
             allow_failure: true
@@ -96,14 +96,12 @@ jobs:
           - name: tsan-validated
             allow_failure: false
             run_static_asan_launch: true
-            # Run only tests that have passed repeated local TSan probes. Some
-            # simulator stress shapes still exceed TSan's fixed 128-lock
-            # deadlock-tracker capacity without producing a race report.
             test_regex: ''
             build_type: RelWithDebInfo
             enable_asan: 0
             enable_ubsan: 0
             enable_tsan: 1
+            enable_expensive_checks: 0
             sanitizer_runtime: STATIC
 
     steps:
@@ -183,23 +181,20 @@ jobs:
           # https://github.com/ROCm/rocm-systems/issues/8922
           TSAN_EXCLUDED_TESTS=(
             "${ASAN_UBSAN_EXCLUDED_TESTS[@]}"
+            # These simulator stress shapes exceed TSan's fixed 128-lock
+            # deadlock-tracker capacity without producing a race report.
             "MatmulStressTest\.TiledAllCU"
             "MatmulStressTest\.MfmaAllCUs"
             "VectorAddStressTest\.AllCUsGoldenReference"
+            # This test has a five-second wall-clock assertion that becomes
+            # load-sensitive at the TSan job's CI-level parallelism.
+            "DaemonApi\.FullListenerQueueDoesNotBlockOrRemoveSocket"
           )
-          TSAN_INCLUDED_TESTS=(
-            "SparseMemory(Threading)?Test\..*"
-            "Gfx1250ExecutionTest\..*"
-            "Gfx1250SimulationTest\..*"
-            "PacingControllerTest\.SeqlockConcurrentReads"
-            "SpinlockTest\.(ConcurrentIncrement|CrossPartitionQueueHighContention)"
-            "SidecarRegistryTest\.ConcurrentMutationAndLookupIsRaceFree"
-            "HsaHooksUnitTest\.(PoolAllocateWaitsForAgentDiscoveryPublication|UninstallDoesNotWaitForPoolMapperDiscoveryLock)"
-            "UtilSimd\.ForceScalar_ImmutableProcessWide"
-            "SimulatedKfdTest\.ConcurrentIoctlAndCloseIsRaceFree"
-            "KfdIoctlTest\.DbgTrapConcurrentEnableDisableIsRaceFree"
-            "DaemonTest\.InterposerDupSerializedReopenUnderContentionRemote"
-            "InterposerDupTest\.SerializedReopenUnderContentionStaysRoutable"
+          TSAN_SHARED_EXCLUDED_TESTS=(
+            # With the shared TSan runtime, the nested HIP process repeatedly
+            # returns EPERM from process_vm_readv and the test times out. The
+            # static TSan configuration runs this test successfully.
+            "RocjitsuCliDaemon\.LaunchesApplicationAfterDaemonIsReady"
           )
 
           TEST_REGEX="${{ matrix.test_regex }}"
@@ -213,7 +208,9 @@ jobs:
           fi
           if [[ "${{ matrix.enable_tsan }}" == "1" ]]; then
             EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${TSAN_EXCLUDED_TESTS[*]}")"
-            TEST_REGEX="^($(IFS='|'; echo "${TSAN_INCLUDED_TESTS[*]}"))$"
+            if [[ "${{ matrix.sanitizer_runtime }}" == "SHARED" ]]; then
+              EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${TSAN_SHARED_EXCLUDED_TESTS[*]}")"
+            fi
           fi
           if [[ -n "${{ matrix.c_compiler }}" ]]; then
             CMAKE_CONFIG_FLAGS+=(-DCMAKE_C_COMPILER="${{ matrix.c_compiler }}")

--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -178,14 +178,8 @@ jobs:
             "CvtNarrow\.AllTests"
             "RaceTest\..*"
           )
-          # https://github.com/ROCm/rocm-systems/issues/8922
           TSAN_EXCLUDED_TESTS=(
             "${ASAN_UBSAN_EXCLUDED_TESTS[@]}"
-            # These simulator stress shapes exceed TSan's fixed 128-lock
-            # deadlock-tracker capacity without producing a race report.
-            "MatmulStressTest\.TiledAllCU"
-            "MatmulStressTest\.MfmaAllCUs"
-            "VectorAddStressTest\.AllCUsGoldenReference"
             # This test has a five-second wall-clock assertion that becomes
             # load-sensitive at the TSan job's CI-level parallelism.
             "DaemonApi\.FullListenerQueueDoesNotBlockOrRemoveSocket"

--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -93,13 +93,13 @@ jobs:
             sanitizer_runtime: SHARED
             c_compiler: gcc
             cxx_compiler: g++
-          - name: tsan-sparse-memory
+          - name: tsan-validated
             allow_failure: false
             run_static_asan_launch: true
-            # The simulator-wide stress tests exceed TSan's fixed 128-lock
-            # deadlock-tracker capacity; keep the race gate focused on the
-            # concurrent memory surfaces hardened by this change.
-            test_regex: '^(SparseMemory(Threading)?Test|GpuMemoryThreadingTest|L2CacheThreadingTest)\.'
+            # Run only tests that have passed repeated local TSan probes. Some
+            # simulator stress shapes still exceed TSan's fixed 128-lock
+            # deadlock-tracker capacity without producing a race report.
+            test_regex: ''
             build_type: RelWithDebInfo
             enable_asan: 0
             enable_ubsan: 0
@@ -186,11 +186,25 @@ jobs:
             "MatmulStressTest\.TiledAllCU"
             "MatmulStressTest\.MfmaAllCUs"
             "VectorAddStressTest\.AllCUsGoldenReference"
-            "Gfx1250SimulationTest\.*"
-            "Gfx1250ExecutionTest\.*"
-            "InterposerDupTest.SerializedReopenUnderContentionStaysRoutable"
+            "Gfx1250SimulationTest\.GlobalStoreWritesVisibleMemory"
+            "Gfx1250SimulationTest\.BufferStoreUsesM0Soffset"
+          )
+          TSAN_INCLUDED_TESTS=(
+            "SparseMemory(Threading)?Test\..*"
+            "Gfx1250ExecutionTest\..*"
+            "Gfx1250SimulationTest\..*"
+            "PacingControllerTest\.SeqlockConcurrentReads"
+            "SpinlockTest\.(ConcurrentIncrement|CrossPartitionQueueHighContention)"
+            "SidecarRegistryTest\.ConcurrentMutationAndLookupIsRaceFree"
+            "HsaHooksUnitTest\.(PoolAllocateWaitsForAgentDiscoveryPublication|UninstallDoesNotWaitForPoolMapperDiscoveryLock)"
+            "UtilSimd\.ForceScalar_ImmutableProcessWide"
+            "SimulatedKfdTest\.ConcurrentIoctlAndCloseIsRaceFree"
+            "KfdIoctlTest\.DbgTrapConcurrentEnableDisableIsRaceFree"
+            "DaemonTest\.InterposerDupSerializedReopenUnderContentionRemote"
+            "InterposerDupTest\.SerializedReopenUnderContentionStaysRoutable"
           )
 
+          TEST_REGEX="${{ matrix.test_regex }}"
           CMAKE_CONFIG_FLAGS=()
           if [[ "${{ matrix.enable_asan }}" == "1" && "${{ matrix.enable_ubsan }}" == "1" ]]; then
             EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${ASAN_UBSAN_EXCLUDED_TESTS[*]}")"
@@ -201,6 +215,7 @@ jobs:
           fi
           if [[ "${{ matrix.enable_tsan }}" == "1" ]]; then
             EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${TSAN_EXCLUDED_TESTS[*]}")"
+            TEST_REGEX="^($(IFS='|'; echo "${TSAN_INCLUDED_TESTS[*]}"))$"
           fi
           if [[ -n "${{ matrix.c_compiler }}" ]]; then
             CMAKE_CONFIG_FLAGS+=(-DCMAKE_C_COMPILER="${{ matrix.c_compiler }}")
@@ -230,8 +245,8 @@ jobs:
           cmake --build "${ROCJITSU_BUILD_DIR}" -j "${WORKERS}"
 
           CTEST_SELECTION=()
-          if [[ -n "${{ matrix.test_regex }}" ]]; then
-            CTEST_SELECTION=(-R "${{ matrix.test_regex }}")
+          if [[ -n "${TEST_REGEX}" ]]; then
+            CTEST_SELECTION=(-R "${TEST_REGEX}")
           fi
           ctest --test-dir "${ROCJITSU_BUILD_DIR}" \
             "${CTEST_SELECTION[@]}" \

--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -186,8 +186,6 @@ jobs:
             "MatmulStressTest\.TiledAllCU"
             "MatmulStressTest\.MfmaAllCUs"
             "VectorAddStressTest\.AllCUsGoldenReference"
-            "Gfx1250SimulationTest\.GlobalStoreWritesVisibleMemory"
-            "Gfx1250SimulationTest\.BufferStoreUsesM0Soffset"
           )
           TSAN_INCLUDED_TESTS=(
             "SparseMemory(Threading)?Test\..*"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.cpp
@@ -14,13 +14,21 @@
 namespace rocjitsu {
 namespace amdgpu {
 
-void MemorySideCache::WriterPreferredAccessGate::lock_shared() {
+void WriterPreferredAccessGate::lock_shared() {
   std::unique_lock lock(mutex_);
   cv_.wait(lock, [this] { return !writer_active_ && waiting_writers_ == 0; });
   ++active_readers_;
 }
 
-void MemorySideCache::WriterPreferredAccessGate::unlock_shared() {
+bool WriterPreferredAccessGate::try_lock_shared() {
+  std::lock_guard lock(mutex_);
+  if (writer_active_ || waiting_writers_ != 0)
+    return false;
+  ++active_readers_;
+  return true;
+}
+
+void WriterPreferredAccessGate::unlock_shared() {
   bool notify_writer = false;
   {
     std::lock_guard lock(mutex_);
@@ -32,7 +40,7 @@ void MemorySideCache::WriterPreferredAccessGate::unlock_shared() {
     cv_.notify_all();
 }
 
-void MemorySideCache::WriterPreferredAccessGate::lock() {
+void WriterPreferredAccessGate::lock() {
   std::unique_lock lock(mutex_);
   ++waiting_writers_;
   cv_.wait(lock, [this] { return !writer_active_ && active_readers_ == 0; });
@@ -40,7 +48,7 @@ void MemorySideCache::WriterPreferredAccessGate::lock() {
   writer_active_ = true;
 }
 
-void MemorySideCache::WriterPreferredAccessGate::unlock() {
+void WriterPreferredAccessGate::unlock() {
   {
     std::lock_guard lock(mutex_);
     assert(writer_active_ && "unlock without an active writer");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.cpp
@@ -9,9 +9,45 @@
 #include <bit>
 #include <cassert>
 #include <cstring>
+#include <shared_mutex>
 
 namespace rocjitsu {
 namespace amdgpu {
+
+void MemorySideCache::WriterPreferredAccessGate::lock_shared() {
+  std::unique_lock lock(mutex_);
+  cv_.wait(lock, [this] { return !writer_active_ && waiting_writers_ == 0; });
+  ++active_readers_;
+}
+
+void MemorySideCache::WriterPreferredAccessGate::unlock_shared() {
+  bool notify_writer = false;
+  {
+    std::lock_guard lock(mutex_);
+    assert(active_readers_ != 0 && "unlock_shared without an active reader");
+    --active_readers_;
+    notify_writer = active_readers_ == 0 && waiting_writers_ != 0;
+  }
+  if (notify_writer)
+    cv_.notify_all();
+}
+
+void MemorySideCache::WriterPreferredAccessGate::lock() {
+  std::unique_lock lock(mutex_);
+  ++waiting_writers_;
+  cv_.wait(lock, [this] { return !writer_active_ && active_readers_ == 0; });
+  --waiting_writers_;
+  writer_active_ = true;
+}
+
+void MemorySideCache::WriterPreferredAccessGate::unlock() {
+  {
+    std::lock_guard lock(mutex_);
+    assert(writer_active_ && "unlock without an active writer");
+    writer_active_ = false;
+  }
+  cv_.notify_all();
+}
 
 void MemorySideCache::send_backing(uint64_t addr, uint8_t *data, uint32_t size,
                                    simdojo::MessageOp op, uint32_t vmid) {
@@ -55,7 +91,7 @@ void MemorySideCache::ensure_line(uint64_t addr, uint32_t vmid) {
 }
 
 void MemorySideCache::read(uint64_t addr, uint8_t *dst, uint32_t size, uint32_t vmid) {
-  std::shared_lock access_lock(access_mutex_);
+  std::shared_lock access_lock(access_gate_);
   uint32_t copied = 0;
   while (copied < size) {
     const uint64_t ea = addr + copied;
@@ -70,7 +106,7 @@ void MemorySideCache::read(uint64_t addr, uint8_t *dst, uint32_t size, uint32_t 
 }
 
 void MemorySideCache::write(uint64_t addr, const uint8_t *src, uint32_t size, uint32_t vmid) {
-  std::shared_lock access_lock(access_mutex_);
+  std::shared_lock access_lock(access_gate_);
   uint32_t copied = 0;
   while (copied < size) {
     const uint64_t ea = addr + copied;
@@ -93,8 +129,9 @@ void MemorySideCache::write(uint64_t addr, const uint8_t *src, uint32_t size, ui
 
 void MemorySideCache::flush_all() {
   // Exclude reads and writes while iterating every set. Ordinary accesses hold
-  // this gate in shared mode and retain their per-stripe concurrency.
-  std::unique_lock access_lock(access_mutex_);
+  // this gate in shared mode and retain their per-stripe concurrency. Once a
+  // flush waits, the gate blocks new shared entrants so the flush makes progress.
+  std::unique_lock access_lock(access_gate_);
   cache_.for_each_dirty([this](simdojo::CacheTag &tag, uint64_t line_addr, uint8_t *data) {
     send_backing(line_addr, data, LINE_SIZE, simdojo::MessageOp::WRITE, tag.vmid);
     tag.dirty = false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.cpp
@@ -55,6 +55,7 @@ void MemorySideCache::ensure_line(uint64_t addr, uint32_t vmid) {
 }
 
 void MemorySideCache::read(uint64_t addr, uint8_t *dst, uint32_t size, uint32_t vmid) {
+  std::shared_lock access_lock(access_mutex_);
   uint32_t copied = 0;
   while (copied < size) {
     const uint64_t ea = addr + copied;
@@ -69,6 +70,7 @@ void MemorySideCache::read(uint64_t addr, uint8_t *dst, uint32_t size, uint32_t 
 }
 
 void MemorySideCache::write(uint64_t addr, const uint8_t *src, uint32_t size, uint32_t vmid) {
+  std::shared_lock access_lock(access_mutex_);
   uint32_t copied = 0;
   while (copied < size) {
     const uint64_t ea = addr + copied;
@@ -90,18 +92,14 @@ void MemorySideCache::write(uint64_t addr, const uint8_t *src, uint32_t size, ui
 }
 
 void MemorySideCache::flush_all() {
-  // flush_all iterates all sets, so acquire all stripes to prevent concurrent access.
-  // This is only called after engine->run() completes (single-threaded), so no contention.
-  std::lock_guard<std::mutex> flush_lock(flush_mutex_);
-  for (auto &s : stripes_)
-    s.lock();
+  // Exclude reads and writes while iterating every set. Ordinary accesses hold
+  // this gate in shared mode and retain their per-stripe concurrency.
+  std::unique_lock access_lock(access_mutex_);
   cache_.for_each_dirty([this](simdojo::CacheTag &tag, uint64_t line_addr, uint8_t *data) {
     send_backing(line_addr, data, LINE_SIZE, simdojo::MessageOp::WRITE, tag.vmid);
     tag.dirty = false;
   });
   cache_.invalidate_all();
-  for (auto &s : stripes_)
-    s.unlock();
 }
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.h
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <utility>
 
@@ -109,7 +110,7 @@ private:
   }
 
   mutable std::array<std::mutex, STRIPE_COUNT> stripes_;
-  mutable std::mutex flush_mutex_; ///< Exclusive lock for flush_all (must not race with stripes).
+  mutable std::shared_mutex access_mutex_;
   CacheStore cache_;
   simdojo::Port *req_ = nullptr;
   std::vector<simdojo::Port *> cpl_ports_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.h
@@ -19,6 +19,30 @@
 namespace rocjitsu {
 namespace amdgpu {
 
+class WriterPreferredAccessGateTestAccess;
+
+/// @brief Shared access gate that gives queued exclusive owners priority.
+///
+/// @details This type is internal to the memory-side cache implementation but
+/// is kept separate so its writer-preference invariant can be tested directly.
+class WriterPreferredAccessGate {
+public:
+  void lock_shared();
+  bool try_lock_shared();
+  void unlock_shared();
+  void lock();
+  void unlock();
+
+private:
+  friend class WriterPreferredAccessGateTestAccess;
+
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  uint32_t active_readers_ = 0;
+  uint32_t waiting_writers_ = 0;
+  bool writer_active_ = false;
+};
+
 /// @brief Memory-side cache component sitting between L2 and HBM on each IOD.
 ///
 /// @details Write-through, write-allocate cache, and no mtype awareness. All traffic from
@@ -101,21 +125,6 @@ public:
   }
 
 private:
-  class WriterPreferredAccessGate {
-  public:
-    void lock_shared();
-    void unlock_shared();
-    void lock();
-    void unlock();
-
-  private:
-    std::mutex mutex_;
-    std::condition_variable cv_;
-    uint32_t active_readers_ = 0;
-    uint32_t waiting_writers_ = 0;
-    bool writer_active_ = false;
-  };
-
   void ensure_line(uint64_t addr, uint32_t vmid);
 
   /// @brief Send a read or write request to the backing store via the req port.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.h
@@ -9,10 +9,10 @@
 #include "simdojo/sim/message.h"
 
 #include <array>
+#include <condition_variable>
 #include <cstdint>
 #include <memory>
 #include <mutex>
-#include <shared_mutex>
 #include <string>
 #include <utility>
 
@@ -32,10 +32,13 @@ namespace amdgpu {
 /// through the requester port (req), which is connected to the HBM controller via a link.
 ///
 /// @par Thread safety
-/// All public methods are thread-safe. Striped locking (by cache set index)
-/// serializes access because multiple XCDs assigned to the same IOD may share
-/// this MSC from different partition threads. Stripes allow concurrent access
-/// to different cache sets, eliminating contention for non-overlapping addresses.
+/// @c read(), @c write(), and @c flush_all() are thread-safe. Reads and writes
+/// acquire the writer-preference access gate in shared mode before acquiring a
+/// stripe mutex by cache set index. A waiting flush blocks new shared entrants,
+/// then acquires the gate exclusively after active accesses finish. This
+/// guarantees flush progress while preserving concurrent access to different
+/// cache sets. The required lock order is access gate before stripe; no path
+/// may acquire them in the opposite order.
 class MemorySideCache : public simdojo::Component {
 public:
   static constexpr uint32_t LINE_SIZE_BITS = 7; // 128 bytes
@@ -98,6 +101,21 @@ public:
   }
 
 private:
+  class WriterPreferredAccessGate {
+  public:
+    void lock_shared();
+    void unlock_shared();
+    void lock();
+    void unlock();
+
+  private:
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    uint32_t active_readers_ = 0;
+    uint32_t waiting_writers_ = 0;
+    bool writer_active_ = false;
+  };
+
   void ensure_line(uint64_t addr, uint32_t vmid);
 
   /// @brief Send a read or write request to the backing store via the req port.
@@ -110,7 +128,7 @@ private:
   }
 
   mutable std::array<std::mutex, STRIPE_COUNT> stripes_;
-  mutable std::shared_mutex access_mutex_;
+  WriterPreferredAccessGate access_gate_;
   CacheStore cache_;
   simdojo::Port *req_ = nullptr;
   std::vector<simdojo::Port *> cpl_ports_;

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -27,6 +27,7 @@
 #include "rocjitsu/vm/amdgpu/lds_barrier_cell.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
 #include "rocjitsu/vm/amdgpu/memory_pipeline.h"
+#include "rocjitsu/vm/amdgpu/memory_side_cache.h"
 #include "rocjitsu/vm/amdgpu/vgpr_msb.h"
 #include "rocjitsu/vm/soc.h"
 #include "util/except.h"
@@ -54,12 +55,25 @@ RJ_DIAGNOSTIC_POP
 #include <memory>
 #include <optional>
 #include <set>
+#include <shared_mutex>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 #include <thread>
 #include <utility>
 #include <vector>
+
+namespace rocjitsu::amdgpu {
+
+class WriterPreferredAccessGateTestAccess {
+public:
+  static bool has_waiting_writer(WriterPreferredAccessGate &gate) {
+    std::lock_guard lock(gate.mutex_);
+    return gate.waiting_writers_ != 0;
+  }
+};
+
+} // namespace rocjitsu::amdgpu
 
 namespace {
 
@@ -5163,6 +5177,34 @@ TEST(Gfx1250SimulationTest, MemorySideCacheFlushSerializesConcurrentAccess) {
   EXPECT_EQ(sim.memory->read32(output_addr), iterations);
 }
 
+TEST(WriterPreferredAccessGateTest, WaitingWriterBlocksLateSharedEntrant) {
+  amdgpu::WriterPreferredAccessGate gate;
+  std::shared_lock active_reader(gate);
+  bool writer_acquired = false;
+  std::thread writer([&] {
+    std::unique_lock waiting_writer(gate);
+    writer_acquired = true;
+  });
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(60);
+  while (!amdgpu::WriterPreferredAccessGateTestAccess::has_waiting_writer(gate) &&
+         std::chrono::steady_clock::now() < deadline)
+    std::this_thread::yield();
+
+  const bool writer_waiting = amdgpu::WriterPreferredAccessGateTestAccess::has_waiting_writer(gate);
+  EXPECT_TRUE(writer_waiting);
+  if (writer_waiting) {
+    const bool late_reader_acquired = gate.try_lock_shared();
+    EXPECT_FALSE(late_reader_acquired);
+    if (late_reader_acquired)
+      gate.unlock_shared();
+  }
+
+  active_reader.unlock();
+  writer.join();
+  EXPECT_TRUE(writer_acquired);
+}
+
 TEST(Gfx1250SimulationTest, MemorySideCacheFlushMakesProgressUnderContinuousReads) {
   constexpr uint64_t output_addr = 0x2000;
   constexpr uint32_t reader_count = 4;
@@ -5171,22 +5213,26 @@ TEST(Gfx1250SimulationTest, MemorySideCacheFlushMakesProgressUnderContinuousRead
   auto *msc = sim.soc->iod(0)->msc();
   std::barrier start(reader_count + 1);
   std::atomic<bool> stop_readers = false;
-  std::atomic<uint32_t> completed_reads = 0;
+  std::atomic<uint32_t> readers_started = 0;
   std::vector<std::thread> readers;
   readers.reserve(reader_count);
   for (uint32_t i = 0; i < reader_count; ++i) {
     readers.emplace_back([&] {
       start.arrive_and_wait();
+      bool first_read = true;
       while (!stop_readers.load(std::memory_order_acquire)) {
         uint32_t value = 0;
         msc->read(output_addr, reinterpret_cast<uint8_t *>(&value), sizeof(value));
-        completed_reads.fetch_add(1, std::memory_order_relaxed);
+        if (first_read) {
+          readers_started.fetch_add(1, std::memory_order_release);
+          first_read = false;
+        }
       }
     });
   }
 
   start.arrive_and_wait();
-  while (completed_reads.load(std::memory_order_relaxed) < reader_count)
+  while (readers_started.load(std::memory_order_acquire) < reader_count)
     std::this_thread::yield();
 
   std::atomic<bool> flush_completed = false;
@@ -5195,7 +5241,7 @@ TEST(Gfx1250SimulationTest, MemorySideCacheFlushMakesProgressUnderContinuousRead
     flush_completed.store(true, std::memory_order_release);
   });
 
-  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(60);
   while (!flush_completed.load(std::memory_order_acquire) &&
          std::chrono::steady_clock::now() < deadline)
     std::this_thread::yield();

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -23,6 +23,7 @@
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/dispatch_entry.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/iod.h"
 #include "rocjitsu/vm/amdgpu/lds_barrier_cell.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
 #include "rocjitsu/vm/amdgpu/memory_pipeline.h"
@@ -44,6 +45,7 @@ RJ_DIAGNOSTIC_POP
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <barrier>
 #include <bit>
 #include <cmath>
 #include <cstdint>
@@ -54,6 +56,7 @@ RJ_DIAGNOSTIC_POP
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -5117,6 +5120,36 @@ TEST(Gfx1250SimulationTest, BufferStoreUsesM0Soffset) {
     EXPECT_EQ(sim.memory->read32(output_addr + lane * 32), 0u) << "lane " << lane;
     EXPECT_EQ(sim.memory->read32(output_addr + 16 + lane * 32), 7u) << "lane " << lane;
   }
+}
+
+TEST(Gfx1250SimulationTest, MemorySideCacheFlushSerializesConcurrentAccess) {
+  constexpr uint64_t output_addr = 0x2000;
+  constexpr uint32_t iterations = 32;
+
+  Gfx1250Sim sim;
+  auto *msc = sim.soc->iod(0)->msc();
+  std::barrier start(2);
+
+  std::thread writer([&] {
+    start.arrive_and_wait();
+    for (uint32_t value = 1; value <= iterations; ++value) {
+      msc->write(output_addr, reinterpret_cast<const uint8_t *>(&value), sizeof(value));
+      std::this_thread::yield();
+    }
+  });
+  std::thread flusher([&] {
+    start.arrive_and_wait();
+    for (uint32_t i = 0; i < iterations; ++i) {
+      msc->flush_all();
+      std::this_thread::yield();
+    }
+  });
+
+  writer.join();
+  flusher.join();
+  msc->flush_all();
+
+  EXPECT_EQ(sim.memory->read32(output_addr), iterations);
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -47,6 +47,7 @@ RJ_DIAGNOSTIC_POP
 #include <atomic>
 #include <barrier>
 #include <bit>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
@@ -5128,12 +5129,21 @@ TEST(Gfx1250SimulationTest, MemorySideCacheFlushSerializesConcurrentAccess) {
 
   Gfx1250Sim sim;
   auto *msc = sim.soc->iod(0)->msc();
-  std::barrier start(2);
+  std::barrier start(3);
 
   std::thread writer([&] {
     start.arrive_and_wait();
     for (uint32_t value = 1; value <= iterations; ++value) {
       msc->write(output_addr, reinterpret_cast<const uint8_t *>(&value), sizeof(value));
+      std::this_thread::yield();
+    }
+  });
+  std::thread reader([&] {
+    start.arrive_and_wait();
+    for (uint32_t i = 0; i < iterations; ++i) {
+      uint32_t value = 0;
+      msc->read(output_addr, reinterpret_cast<uint8_t *>(&value), sizeof(value));
+      EXPECT_LE(value, iterations);
       std::this_thread::yield();
     }
   });
@@ -5146,10 +5156,57 @@ TEST(Gfx1250SimulationTest, MemorySideCacheFlushSerializesConcurrentAccess) {
   });
 
   writer.join();
+  reader.join();
   flusher.join();
   msc->flush_all();
 
   EXPECT_EQ(sim.memory->read32(output_addr), iterations);
+}
+
+TEST(Gfx1250SimulationTest, MemorySideCacheFlushMakesProgressUnderContinuousReads) {
+  constexpr uint64_t output_addr = 0x2000;
+  constexpr uint32_t reader_count = 4;
+
+  Gfx1250Sim sim;
+  auto *msc = sim.soc->iod(0)->msc();
+  std::barrier start(reader_count + 1);
+  std::atomic<bool> stop_readers = false;
+  std::atomic<uint32_t> completed_reads = 0;
+  std::vector<std::thread> readers;
+  readers.reserve(reader_count);
+  for (uint32_t i = 0; i < reader_count; ++i) {
+    readers.emplace_back([&] {
+      start.arrive_and_wait();
+      while (!stop_readers.load(std::memory_order_acquire)) {
+        uint32_t value = 0;
+        msc->read(output_addr, reinterpret_cast<uint8_t *>(&value), sizeof(value));
+        completed_reads.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+  }
+
+  start.arrive_and_wait();
+  while (completed_reads.load(std::memory_order_relaxed) < reader_count)
+    std::this_thread::yield();
+
+  std::atomic<bool> flush_completed = false;
+  std::thread flusher([&] {
+    msc->flush_all();
+    flush_completed.store(true, std::memory_order_release);
+  });
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (!flush_completed.load(std::memory_order_acquire) &&
+         std::chrono::steady_clock::now() < deadline)
+    std::this_thread::yield();
+  const bool completed_while_readers_active = flush_completed.load(std::memory_order_acquire);
+
+  stop_readers.store(true, std::memory_order_release);
+  for (auto &reader : readers)
+    reader.join();
+  flusher.join();
+
+  EXPECT_TRUE(completed_while_readers_active);
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/hip_vector_add_test.cpp
+++ b/emulation/rocjitsu/tests/hip_vector_add_test.cpp
@@ -19,6 +19,15 @@
 // retaining LeakSanitizer coverage for rocjitsu and this test executable.
 extern "C" const char *__lsan_default_suppressions() { return "leak:libhsa-runtime64.so\n"; }
 
+// ROCR serializes its async-event pool with rocr::HybridMutex, an atomic CAS
+// spinlock. The external HSA runtime is not instrumented, so ThreadSanitizer
+// cannot observe that happens-before edge and reports the pool's heap reuse as
+// a race. Ignore only interceptors called from the HSA runtime while retaining
+// ThreadSanitizer coverage for rocjitsu and this test executable.
+extern "C" const char *__tsan_default_suppressions() {
+  return "called_from_lib:libhsa-runtime64.so\n";
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   int rc = RUN_ALL_TESTS();


### PR DESCRIPTION
Closes #8922

## Summary

- Consolidate rocjitsu TSan CI into one blocking shared-runtime `tsan` job.
- Expand shared TSan coverage from the broad exclusions on the `develop` branch to the main rocjitsu test suite.
- Keep the 24 expensive MFMA/WMMA exact checks disabled under TSan to control runtime.
- Retain only two reproduced TSan-specific exclusions: one load-sensitive daemon timing test and one shared-runtime nested-process test.
- Replace the fairness-unspecified `std::shared_mutex` used for cache access serialization with a writer-preference access gate.
- Once `MemorySideCache::flush_all()` is waiting, block new cache accesses so active accesses drain and the flush makes progress while retaining per-stripe concurrency for ordinary reads and writes.
- Cover concurrent cache reads, writes, and flushes, including a deterministic writer-preference test and flush progress under continuous reader traffic.

## Coverage

Compared with the `develop` TSan policy on this head, the shared TSan job newly covers 111 previously excluded tests:

- 60 `Gfx1250SimulationTest` cases.
- 44 `Gfx1250ExecutionTest` cases.
- Four matmul stress cases.
- Two vector-add stress cases.
- One interposer contention case.

The PR also adds `WriterPreferredAccessGateTest.WaitingWriterBlocksLateSharedEntrant`, bringing the consolidated shared TSan selection to 1,859 tests. Removing the static sparse-memory job does not reduce unique test-case coverage because its SparseMemory cases are already included in the shared suite.

The remaining differences from the Clang ASan/UBSan selection are:

- 24 expensive MFMA/WMMA exact checks, which passed separately.
- `DaemonApi.FullListenerQueueDoesNotBlockOrRemoveSocket`, whose five-second assertion is load-sensitive at TSan CI parallelism.
- `RocjitsuCliDaemon.LaunchesApplicationAfterDaemonIsReady`, whose nested HIP process receives `EPERM` from `process_vm_readv` under the shared TSan runtime and times out.

## Validation

- The shared TSan configuration passed 1,858 tests with zero failures before the deterministic gate test was added.
- Focused release and shared-TSan runs passed all three cache/gate regressions.
- The shared-TSan continuous-reader progress and deterministic gate tests each passed 5/5 repeated runs.
- The continuous-reader test took 6.37-6.48 seconds under shared TSan, validating the 60-second starvation watchdog margin.
- The previous head also passed release, Clang ASan/UBSan, GCC ASan/UBSan, pre-commit, and TheRock CI.
- The 24 expensive MFMA/WMMA exact tests passed separately.
- Pre-commit, formatting, and diff checks passed.