### PR TITLE
fix(rocshmem) rename back atomic_fetch/nofetch to atomic_fetch_add, atomic_add

### DIFF
--- a/projects/rocshmem/src/gda/context_gda_device_coll.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device_coll.cpp
@@ -446,7 +446,7 @@ __device__ void GDAContext::alltoallmem_linear_thread_puts_wg(rocshmem_team_t te
             ? 0 : qps[dest_pe].get_lkey(reinterpret_cast<uintptr_t>(src_local));
     qps[dest_pe].put_nbi_single(reinterpret_cast<void *>(dst_raddr), dst_rkey,
                                 src_local, src_lkey, nelems, false);
-    qps[dest_pe].atomic_nofetch_single(
+    qps[dest_pe].atomic_add_single(
       reinterpret_cast<char *>(&pSync[alltoall_pSync_offset + my_pe_in_team]) +
       base_heap_offset, 1);
   }
@@ -545,7 +545,7 @@ __device__ void GDAContext::alltoallmem_linear_thread_puts_wave(rocshmem_team_t 
             ? 0 : qps[dest_pe].get_lkey(reinterpret_cast<uintptr_t>(src_local));
     qps[dest_pe].put_nbi_single(reinterpret_cast<void *>(dst_raddr), dst_rkey,
                                 src_local, src_lkey, nelems, false);
-    qps[dest_pe].atomic_nofetch_single(
+    qps[dest_pe].atomic_add_single(
       reinterpret_cast<char *>(&pSync[alltoall_pSync_offset + my_pe_in_team]) +
       base_heap_offset, 1);
   }

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -104,7 +104,7 @@ __device__ void GDAContext::amo_add(void *dst, T value, int pe) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      qps[qp_index].atomic_nofetch(reinterpret_cast<void *>(raddr), rkey, value, 0, wf_info);
+      qps[qp_index].atomic_add(reinterpret_cast<void *>(raddr), rkey, value, wf_info);
       need_turn = false;
     }
     turns = __ballot(need_turn);
@@ -274,7 +274,7 @@ __device__ T GDAContext::amo_fetch_add(void *dst, T value, int pe) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      ret_val =  qps[qp_index].atomic_fetch(reinterpret_cast<void *>(raddr), rkey, value, 0, wf_info);
+      ret_val =  qps[qp_index].atomic_fetch_add(reinterpret_cast<void *>(raddr), rkey, value, wf_info);
       need_turn = false;
     }
     turns = __ballot(need_turn);
@@ -981,7 +981,7 @@ __device__ void GDAContext::alltoallv_copy(rocshmem_team_t team, T *dest,
       qps[dest_pe].put_nbi_single(dst, src, nelems, false);
     }
 
-    qps[dest_pe].atomic_nofetch_single(amo_dst, 1);
+    qps[dest_pe].atomic_add_single(amo_dst, 1);
   }
 
   // wait until everyone has obtained their designated data
@@ -1075,7 +1075,7 @@ __device__ void GDAContext::alltoallv_get(rocshmem_team_t team, T *dest,
 
     /* Put Completion */
     char* amo_dst = ((char*)&pSync[alltoall_pSync_offset + my_pe_in_team] + base_heap_offset);
-    qps[dest_pe].atomic_nofetch_single(amo_dst, 1);
+    qps[dest_pe].atomic_add_single(amo_dst, 1);
 
     long *sync_flags = &pSync[alltoall_pSync_offset + dest_pe];
     while (uncached_load(sync_flags) != 1) { }
@@ -1223,7 +1223,7 @@ __device__ void GDAContext::internal_amo_add(void *dst, T value, int pe,
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      qps[qp_index].atomic_nofetch(base_heap[pe] + L_offset, value, 0, wf_info);
+      qps[qp_index].atomic_add(base_heap[pe] + L_offset, value, wf_info);
       need_turn = false;
     }
     turns = __ballot(need_turn);
@@ -1242,7 +1242,7 @@ __device__ T GDAContext::internal_amo_fetch_add(void *dst, T value, int pe,
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      ret_val =  qps[qp_index].atomic_fetch(base_heap[pe] + L_offset, value, 0, wf_info);
+      ret_val =  qps[qp_index].atomic_fetch_add(base_heap[pe] + L_offset, value, wf_info);
       need_turn = false;
     }
     turns = __ballot(need_turn);

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -361,30 +361,34 @@ __device__ int64_t QueuePair::atomic_cas_nofetch(void *dest,
                       atomic_cmp, wf_info);
 }
 
-__device__ int64_t QueuePair::atomic_fetch(void *dest, int64_t atomic_data,
-    int64_t atomic_cmp, ActiveWFInfo &wf_info) {
+__device__ int64_t QueuePair::atomic_fetch_add(void *dest, int64_t value,
+    ActiveWFInfo &wf_info) {
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  return post_wqe_amo(dst, rkey, gda_op_atomic_fa, atomic_data,
-                      atomic_cmp, wf_info, true);
+  return post_wqe_amo(dst, rkey, gda_op_atomic_fa, value, 0, wf_info, true);
 }
 
-__device__ void QueuePair::atomic_nofetch(void *dest, int64_t atomic_data,
-    int64_t atomic_cmp, ActiveWFInfo &wf_info) {
+__device__ void QueuePair::atomic_add(void *dest, int64_t value,
+    ActiveWFInfo &wf_info) {
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  post_wqe_amo(dst, rkey, gda_op_atomic_fa, atomic_data,
-               atomic_cmp, wf_info);
+  post_wqe_amo(dst, rkey, gda_op_atomic_fa, value, 0, wf_info);
 }
 
-__device__ int64_t QueuePair::atomic_fetch(void *dest, uint32_t rkey,
-    int64_t value, int64_t cond, ActiveWFInfo &wf_info) {
+__device__ int64_t QueuePair::atomic_fetch_add(void *dest, uint32_t rkey,
+    int64_t value, ActiveWFInfo &wf_info) {
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  return post_wqe_amo(dst, rkey, gda_op_atomic_fa, value, cond, wf_info, true);
+  return post_wqe_amo(dst, rkey, gda_op_atomic_fa, value, 0, wf_info, true);
 }
 
-__device__ void QueuePair::atomic_nofetch(void *dest, uint32_t rkey,
-    int64_t value, int64_t cond, ActiveWFInfo &wf_info) {
-  uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  post_wqe_amo(dst, rkey, gda_op_atomic_fa, value, cond, wf_info);
+__device__ void QueuePair::atomic_add(void *raddr, uint32_t rkey,
+    int64_t value, ActiveWFInfo &wf_info, bool fence) {
+  uintptr_t r = reinterpret_cast<uintptr_t>(raddr);
+  post_wqe_amo(r, rkey, gda_op_atomic_fa, value, 0, wf_info, false, fence);
+}
+
+__device__ void QueuePair::atomic_add_single(void *raddr, uint32_t rkey,
+    int64_t value, bool fence) {
+  uintptr_t r = reinterpret_cast<uintptr_t>(raddr);
+  post_wqe_amo_single(r, rkey, gda_op_atomic_fa, value, 0, false, fence);
 }
 
 __device__ int64_t QueuePair::atomic_cas(void *dest, uint32_t rkey,
@@ -409,7 +413,7 @@ __device__ void QueuePair::get_nbi(void *dest, uint32_t lkey,
                gda_op_rdma_read, wf_info, true);
 }
 
-__device__ void QueuePair::atomic_nofetch_single(void *dest, int64_t value) {
+__device__ void QueuePair::atomic_add_single(void *dest, int64_t value) {
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
   post_wqe_amo_single(dst, rkey, gda_op_atomic_fa, value, 0);
 }

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -236,30 +236,28 @@ class QueuePair {
   __device__ void quiet_scope(ActiveWFInfo &wf_info);
 
   /**
-   * @brief Create and enqueue an atomic fetch work queue entry (wqe).
+   * @brief Create and enqueue an atomic fetch-and-add work queue entry (wqe).
    *
    * @param[in] dest Destination address for data transmission.
    * @param[in] value Data value for the atomic operation.
-   * @param[in] cond Used in atomic comparisons.
    * @param[in] wf_info Wavefront information.
    *
-   * @return An atomic value
+   * @return The previous value at dest.
    */
-  __device__ int64_t atomic_fetch(void *dest, int64_t value, int64_t cond,
+  __device__ int64_t atomic_fetch_add(void *dest, int64_t value,
       ActiveWFInfo &wf_info);
 
   /**
-   * @brief Create and enqueue an atomic fetch work queue entry (wqe).
+   * @brief Create and enqueue a non-fetching atomic add work queue entry (wqe).
    *
    * @param[in] dest Destination address for data transmission.
    * @param[in] value Data value for the atomic operation.
-   * @param[in] cond Used in atomic comparisons.
    * @param[in] wf_info Wavefront information.
    */
-  __device__ void atomic_nofetch(void *dest, int64_t value, int64_t cond,
+  __device__ void atomic_add(void *dest, int64_t value,
       ActiveWFInfo &wf_info);
 
-  __device__ void atomic_nofetch_single(void *dest, int64_t value);
+  __device__ void atomic_add_single(void *dest, int64_t value);
 
   /**
    * @brief Create and enqueue an atomic cas work queue entry (wqe).
@@ -292,11 +290,14 @@ class QueuePair {
    * remote key differs from the QP's default heap key. Mirror the default-key
    * versions above but forward the caller-supplied @p rkey.
    */
-  __device__ int64_t atomic_fetch(void *dest, uint32_t rkey, int64_t value,
-      int64_t cond, ActiveWFInfo &wf_info);
+  __device__ int64_t atomic_fetch_add(void *dest, uint32_t rkey, int64_t value,
+      ActiveWFInfo &wf_info);
 
-  __device__ void atomic_nofetch(void *dest, uint32_t rkey, int64_t value,
-      int64_t cond, ActiveWFInfo &wf_info);
+  __device__ void atomic_add(void *raddr, uint32_t rkey, int64_t value,
+      ActiveWFInfo &wf_info, bool fence = false);
+
+  __device__ void atomic_add_single(void *raddr, uint32_t rkey,
+      int64_t value, bool fence = false);
 
   __device__ int64_t atomic_cas(void *dest, uint32_t rkey, int64_t atomic_data,
       int64_t atomic_cmp, ActiveWFInfo &wf_info);


### PR DESCRIPTION
name change got mistakenly reverted during a merge conflict resolution in bda93247

## Motivation

The internal qp API is consumed by rccl-gin, and needs to remain stable. 

## Technical Details

The function names got reverted to their prior naming during a merge conflict with the symm-buffer api (that also introduced explicit rkey variants of the atomic apis) 

## Issue Tracking

JIRA ID: AICOMMRCCL-1466

## Test Plan

* Ran on banff mlx5 [x]
* ci run

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
