### PR TITLE
feat(rocjitsu): Introduce SpecialRegisterSet and special uses/defs

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -9445,6 +9445,31 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
             f'}}'
         )
 
+        # to_special_reg_class(): maps a special operand (VCC/EXEC/SDST_EXEC/
+        # SSRC_SPECIAL_SCC/M0/PC) to its special RegClass so InstDefUse can
+        # record it in special_defs/special_uses. Driven by shared fieldless
+        # operand policy table's effect column.
+        special_ref_cases = []
+        for opnd_type in self.isa_spec.operand_types:
+            effect = fieldless_policy(opnd_type).effect
+            if effect is not None and effect.special_reg is not None:
+                special_ref_cases.append(
+                    f'case OperandType::{opnd_type}: '
+                    f'return RegClass::{effect.special_reg.name};'
+                )
+        special_ref_cases.sort()
+        special_ref_body = '\n'.join(special_ref_cases)
+        special_ref_impl = (
+            f'std::optional<RegClass> Operand::to_special_reg_class() const {{\n'
+            f'switch (opr_type_) {{\n'
+            f'{special_ref_body}\n'
+            f'default:\n'
+            f'  break;\n'
+            f'}}\n'
+            f'return std::nullopt;\n'
+            f'}}'
+        )
+
         operand_ctor_decl = (
             '  Operand(int size_bits, OperandType opr_type, int encoding_value,\n'
             '          bool packed_16bit_source = false, bool packed_16bit_dst = false);\n'
@@ -9569,6 +9594,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                 '  std::string name() const override;\n'
                 f'{literal64_decl}'
                 '  std::optional<RegisterRef> to_register_ref() const override;\n'
+                '  std::optional<RegClass> to_special_reg_class() const override;\n'
                 f'{execution_backend_public_decl}'
                 f'{execution_decls}'
                 'private:\n'
@@ -9644,6 +9670,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                 cgen.Line(literal64_impl),
                 cgen.Line(name_impl),
                 cgen.Line(ref_impl),
+                cgen.Line(special_ref_impl),
             ]
         )
 

--- a/emulation/rocjitsu/lib/python/amdisa/fieldless_policy.py
+++ b/emulation/rocjitsu/lib/python/amdisa/fieldless_policy.py
@@ -14,10 +14,13 @@ columns are
   * ``caps``    -- runtime capability for the normal read/write/SIMD accessors
                    (:class:`FieldlessCaps`),
   * ``display`` -- disassembly display policy (:class:`FieldlessDisplay`),
-  * ``effect``  -- architectural-effect metadata.
+  * ``effect``  -- architectural-effect metadata (:class:`FieldlessEffect`): the
+                   special register a fieldless operand corresponds to, or
+                   ``None`` for types with no effect modeled yet.
 
-``role`` and ``caps`` are live today: the generator consumes them to classify
-and lower each operand. ``display`` and ``effect`` are staged extension points.
+``role``, ``caps`` and ``effect`` are live today: the generator consumes them to
+classify and lower each operand and to emit ``to_special_reg_class()``.
+``display`` is a staged extension point.
 """
 
 from __future__ import annotations
@@ -63,6 +66,41 @@ class FieldlessDisplay(enum.Enum):
     """
 
     HIDDEN = 'hidden'
+
+
+class SpecialRegClass(enum.Enum):
+    """An architectural special register a fieldless operand corresponds to.
+
+    Mirrors the special (non-indexed) members of the C++ ``RegClass`` enum
+    (``register_set.h``): each value's name is the C++ enumerator (so generator
+    lowers ``SpecialRegClass.VCC`` to ``RegClass::VCC``). Only the
+    classes a fieldless operand can currently denote are listed; FLAT_SCRATCH
+    and TTMP are C++ RegClass values but are not produced here yet (FLAT_SCRATCH
+    is bucketed as a memory pseudo-operand; see the policy table).
+    """
+
+    EXEC = 'EXEC'
+    VCC = 'VCC'
+    SCC = 'SCC'
+    M0 = 'M0'
+    PC = 'PC'
+
+
+@dataclass(frozen=True)
+class FieldlessEffect:
+    """Architectural-effect metadata for a fieldless operand (one effect object).
+
+    Lives on the :class:`FieldlessPolicy` row so effect data cannot drift into a
+    separate type-keyed map. For now it carries only the special register the
+    operand denotes; memory-effect fields (for the ``MEMORY_PSEUDO`` types) are
+    deferred.
+
+    Attributes:
+        special_reg: The special register this operand reads/writes as an
+            architectural effect, or ``None`` if it denotes no special register.
+    """
+
+    special_reg: SpecialRegClass | None = None
 
 
 @dataclass(frozen=True)
@@ -128,16 +166,16 @@ class FieldlessPolicy:
         role: Semantic category.
         caps: Runtime capability for the normal accessors.
         display: Disassembly display policy.
-        effect: Architectural-effect metadata. Stub (``None``) for now; a later
-            slice populates the special-register / memory effect a fieldless
-            operand corresponds to. Present here so effect data lives on the
-            same policy row rather than in a separate type-keyed map.
+        effect: Architectural-effect metadata (:class:`FieldlessEffect`), or
+            ``None`` for a type with no effect modeled yet (literal, memory
+            pseudo, placeholder). Present here so effect data lives on the same
+            policy row rather than in a separate type-keyed map.
     """
 
     role: FieldlessCategory
     caps: FieldlessCaps
     display: FieldlessDisplay = FieldlessDisplay.HIDDEN
-    effect: object | None = None
+    effect: FieldlessEffect | None = None
 
 
 #: The fieldless operand policy table: every fieldless ``operand_type`` ->
@@ -146,14 +184,40 @@ class FieldlessPolicy:
 _FIELDLESS_POLICY: dict[str, FieldlessPolicy] = {
     # Value-bearing literal: the one fieldless operand read as a real value.
     'OPR_SIMM32': FieldlessPolicy(FieldlessCategory.LITERAL, _VALUE_ONLY),
-    # Architectural special registers: inert through normal accessors; their
-    # architectural effects are exposed through a later special-effect API.
-    'OPR_VCC': FieldlessPolicy(FieldlessCategory.SPECIAL_REGISTER, _INERT),
-    'OPR_EXEC': FieldlessPolicy(FieldlessCategory.SPECIAL_REGISTER, _INERT),
-    'OPR_SDST_EXEC': FieldlessPolicy(FieldlessCategory.SPECIAL_REGISTER, _INERT),
-    'OPR_SSRC_SPECIAL_SCC': FieldlessPolicy(FieldlessCategory.SPECIAL_REGISTER, _INERT),
-    'OPR_PC': FieldlessPolicy(FieldlessCategory.SPECIAL_REGISTER, _INERT),
-    'OPR_SDST_M0': FieldlessPolicy(FieldlessCategory.SPECIAL_REGISTER, _INERT),
+    # Architectural special registers: inert through normal accessors, but their
+    # architectural effect (the special register they denote) is carried in the
+    # effect column and consumed by the generated to_special_reg_class() helper.
+    # SDST_EXEC is the SDST-namespace alias for EXEC, so both map to EXEC.
+    'OPR_VCC': FieldlessPolicy(
+        FieldlessCategory.SPECIAL_REGISTER,
+        _INERT,
+        effect=FieldlessEffect(SpecialRegClass.VCC),
+    ),
+    'OPR_EXEC': FieldlessPolicy(
+        FieldlessCategory.SPECIAL_REGISTER,
+        _INERT,
+        effect=FieldlessEffect(SpecialRegClass.EXEC),
+    ),
+    'OPR_SDST_EXEC': FieldlessPolicy(
+        FieldlessCategory.SPECIAL_REGISTER,
+        _INERT,
+        effect=FieldlessEffect(SpecialRegClass.EXEC),
+    ),
+    'OPR_SSRC_SPECIAL_SCC': FieldlessPolicy(
+        FieldlessCategory.SPECIAL_REGISTER,
+        _INERT,
+        effect=FieldlessEffect(SpecialRegClass.SCC),
+    ),
+    'OPR_PC': FieldlessPolicy(
+        FieldlessCategory.SPECIAL_REGISTER,
+        _INERT,
+        effect=FieldlessEffect(SpecialRegClass.PC),
+    ),
+    'OPR_SDST_M0': FieldlessPolicy(
+        FieldlessCategory.SPECIAL_REGISTER,
+        _INERT,
+        effect=FieldlessEffect(SpecialRegClass.M0),
+    ),
     # Memory pseudo-operands: no register value; drive memory-effect metadata
     # in a later slice.
     'OPR_DSMEM': FieldlessPolicy(FieldlessCategory.MEMORY_PSEUDO, _INERT),

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_fieldless_operands.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_fieldless_operands.py
@@ -26,7 +26,9 @@ from amdisa.fieldless_policy import (
     FieldlessCaps,
     FieldlessCategory,
     FieldlessDisplay,
+    FieldlessEffect,
     FieldlessPolicy,
+    SpecialRegClass,
     fieldless_policy,
     validate_fieldless_taxonomy,
 )
@@ -431,14 +433,26 @@ def test_fieldless_policy_table_is_golden():
     mp = FieldlessCategory.MEMORY_PSEUDO
     hidden = FieldlessDisplay.HIDDEN
     value = FieldlessCaps(reads_value=True, writable=False, is_vgpr=False)
+
+    def sreg(cls):
+        return FieldlessEffect(special_reg=cls)
+
     assert fieldless_policy_mod._FIELDLESS_POLICY == {
         'OPR_SIMM32': FieldlessPolicy(FieldlessCategory.LITERAL, value, hidden, None),
-        'OPR_VCC': FieldlessPolicy(sr, _INERT_CAPS, hidden, None),
-        'OPR_EXEC': FieldlessPolicy(sr, _INERT_CAPS, hidden, None),
-        'OPR_SDST_EXEC': FieldlessPolicy(sr, _INERT_CAPS, hidden, None),
-        'OPR_SSRC_SPECIAL_SCC': FieldlessPolicy(sr, _INERT_CAPS, hidden, None),
-        'OPR_PC': FieldlessPolicy(sr, _INERT_CAPS, hidden, None),
-        'OPR_SDST_M0': FieldlessPolicy(sr, _INERT_CAPS, hidden, None),
+        'OPR_VCC': FieldlessPolicy(sr, _INERT_CAPS, hidden, sreg(SpecialRegClass.VCC)),
+        'OPR_EXEC': FieldlessPolicy(
+            sr, _INERT_CAPS, hidden, sreg(SpecialRegClass.EXEC)
+        ),
+        'OPR_SDST_EXEC': FieldlessPolicy(
+            sr, _INERT_CAPS, hidden, sreg(SpecialRegClass.EXEC)
+        ),
+        'OPR_SSRC_SPECIAL_SCC': FieldlessPolicy(
+            sr, _INERT_CAPS, hidden, sreg(SpecialRegClass.SCC)
+        ),
+        'OPR_PC': FieldlessPolicy(sr, _INERT_CAPS, hidden, sreg(SpecialRegClass.PC)),
+        'OPR_SDST_M0': FieldlessPolicy(
+            sr, _INERT_CAPS, hidden, sreg(SpecialRegClass.M0)
+        ),
         'OPR_DSMEM': FieldlessPolicy(mp, _INERT_CAPS, hidden, None),
         'OPR_GPUMEM': FieldlessPolicy(mp, _INERT_CAPS, hidden, None),
         # FLAT_SCRATCH is the per-wave scratch-base register state (SGPR pair),
@@ -511,14 +525,70 @@ def test_validate_fieldless_taxonomy_is_fatal_on_unknown_type():
 
 
 def test_fieldless_policy_entry_carries_all_columns_on_one_object():
-    # Single-table design: capability, role, display, and (stubbed) effect are
-    # fields of one FieldlessPolicy object, so they cannot drift as independent
-    # type-keyed maps.
+    # Single-table design: capability, role, display, and effect are fields of
+    # one FieldlessPolicy object, so they cannot drift as independent type-keyed
+    # maps.
     policy = fieldless_policy('OPR_VCC')
     assert policy.role == FieldlessCategory.SPECIAL_REGISTER
     assert isinstance(policy.caps, FieldlessCaps)
     assert policy.display == FieldlessDisplay.HIDDEN
-    assert policy.effect is None  # stubbed until the special-effect slice
+    assert policy.effect == FieldlessEffect(special_reg=SpecialRegClass.VCC)
+
+
+# The special register each SPECIAL_REGISTER fieldless type denotes, consumed by
+# the generated to_special_reg_class() helper. SDST_EXEC is the SDST-namespace
+# alias for EXEC, so both map to EXEC.
+_EXPECTED_SPECIAL_REG = {
+    'OPR_VCC': SpecialRegClass.VCC,
+    'OPR_EXEC': SpecialRegClass.EXEC,
+    'OPR_SDST_EXEC': SpecialRegClass.EXEC,
+    'OPR_SSRC_SPECIAL_SCC': SpecialRegClass.SCC,
+    'OPR_PC': SpecialRegClass.PC,
+    'OPR_SDST_M0': SpecialRegClass.M0,
+}
+
+
+def test_special_register_types_carry_expected_effect():
+    # Every SPECIAL_REGISTER fieldless type maps to its architectural special
+    # register through the effect column; the mapping is the sole source the
+    # generator lowers into to_special_reg_class().
+    for opr_type, reg in _EXPECTED_SPECIAL_REG.items():
+        policy = fieldless_policy(opr_type)
+        assert policy.role == FieldlessCategory.SPECIAL_REGISTER, opr_type
+        assert policy.effect == FieldlessEffect(special_reg=reg), opr_type
+
+
+def test_special_register_role_and_effect_agree():
+    # Every type carrying a special-register effect is a SPECIAL_REGISTER, and
+    # the effect set is exactly the mapped types. FLAT_SCRATCH is the one
+    # SPECIAL_REGISTER whose architectural effect is intentionally deferred (no
+    # SpecialRegClass produced yet), so role and effect are not identical sets.
+    # Guards against a mapped special reg gaining/losing its effect, or a
+    # non-special type sprouting one, without a conscious edit.
+    with_effect = {
+        t
+        for t in _OBSERVED_FIELDLESS_TYPES
+        if fieldless_policy(t).effect is not None
+        and fieldless_policy(t).effect.special_reg is not None
+    }
+    is_special = {
+        t
+        for t in _OBSERVED_FIELDLESS_TYPES
+        if fieldless_policy(t).role == FieldlessCategory.SPECIAL_REGISTER
+    }
+    assert with_effect == set(_EXPECTED_SPECIAL_REG)
+    assert with_effect < is_special
+    assert is_special - with_effect == {'OPR_FLAT_SCRATCH'}
+
+
+def test_types_without_special_reg_mapping_have_no_effect():
+    # Everything outside the mapped special-register set models no architectural
+    # effect yet: literal, memory-pseudo, placeholder, and the deferred
+    # FLAT_SCRATCH special register.
+    for opr_type in _OBSERVED_FIELDLESS_TYPES:
+        if opr_type in _EXPECTED_SPECIAL_REG:
+            continue
+        assert fieldless_policy(opr_type).effect is None, opr_type
 
 
 def test_fieldless_caps_stmt_emits_policy_caps():

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.cpp
@@ -81,6 +81,8 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
       continue;
     if (auto ref = op->to_register_ref())
       add_def(*this, inst, *op, *ref, vgpr_msb);
+    else if (auto sc = op->to_special_reg_class())
+      special_defs.insert(*sc);
   }
   inst.implicit_defs(defs);
 
@@ -90,6 +92,8 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
       continue;
     if (auto ref = op->to_register_ref())
       expand_operand_register(uses, inst, *op, *ref, vgpr_msb, OperandExpansionKind::Use);
+    else if (auto sc = op->to_special_reg_class())
+      special_uses.insert(*sc);
   }
   inst.implicit_uses(uses);
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.h
@@ -9,6 +9,15 @@
 /// registers, source operands use registers. Operand::to_register_ref()
 /// determines which register class and index are involved. Instruction
 /// subclasses may also report hidden register effects through implicit hooks.
+///
+/// Ordinary register-file effects (SGPR/VGPR/AccVGPR) live in `defs`/`uses`
+/// and drive scratch-allocation liveness. Architectural special-register
+/// effects (EXEC/VCC/SCC/M0/PC/...) and memory effects are exposed on separate
+/// members (`special_defs`/`special_uses`, `memory`) so consumers can query
+/// them without those effects ever entering ordinary liveness. Those separate
+/// members are currently always empty and will be populated once generated
+/// operands report special/memory effects; the ordinary `defs`/`uses` behavior
+/// is unchanged.
 
 #pragma once
 
@@ -19,6 +28,28 @@ namespace rocjitsu {
 class Instruction;
 class Gfx1250VgprMsbAnalysis;
 
+/// @brief Memory-effect summary for one decoded instruction.
+///
+/// @details A coarse description of what memory an instruction touches. Not
+/// currently used. Present now so `InstDefUse` has a stable shape for DBT/DBI
+/// consumers. All flags default to false (no memory effect).
+///
+/// TODO: Update when OPR_GPUMEM, OPR_DSMEM, and OPR_FLAT_SCRATCH become
+/// avaialable.
+struct MemoryEffects {
+  bool reads = false;   ///< Reads memory.
+  bool writes = false;  ///< Writes memory.
+  bool atomic = false;  ///< Performs an atomic read-modify-write (also sets reads+writes).
+  bool global = false;  ///< Touches global/generic memory (OPR_GPUMEM).
+  bool lds = false;     ///< Touches LDS/GDS (OPR_DSMEM).
+  bool scratch = false; ///< Touches scratch/flat-scratch (OPR_FLAT_SCRATCH).
+
+  /// @brief True if the instruction has any memory effect.
+  [[nodiscard]] bool any() const { return reads || writes || atomic || global || lds || scratch; }
+
+  friend bool operator==(const MemoryEffects &, const MemoryEffects &) = default;
+};
+
 /// @brief Registers read and written by one decoded instruction.
 class InstDefUse {
 public:
@@ -26,8 +57,11 @@ public:
   /// @param inst Decoded instruction whose operands have stable lifetimes.
   InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vgpr_msb = nullptr);
 
-  RegisterSet defs;                        ///< Registers overwritten by the instruction.
-  RegisterSet uses;                        ///< Registers read before the instruction writes defs.
+  RegisterSet defs;                ///< Ordinary registers overwritten by the instruction.
+  RegisterSet uses;                ///< Ordinary registers read before the instruction writes defs.
+  SpecialRegisterSet special_defs; ///< Special registers (EXEC/VCC/SCC/M0/PC/...) written.
+  SpecialRegisterSet special_uses; ///< Special registers read.
+  MemoryEffects memory;            ///< Memory-effect summary.
   bool has_exec_masked_vector_def = false; ///< True if any vector def is predicated by EXEC.
   bool has_predicated_def = false;         ///< True if defs preserve old values on some paths.
 };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/operand.cpp
@@ -1152,6 +1152,24 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 namespace {
 
 uint32_t resolve_src_scalar(const amdgpu::Wavefront &wf, int ev) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/operand.h
@@ -24,6 +24,7 @@ public:
   std::string name() const override;
   std::optional<uint64_t> literal64_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
 
 private:
   uint32_t read_scalar(const amdgpu::Wavefront &wf) const override;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/operand.cpp
@@ -1021,6 +1021,24 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 namespace {
 
 uint32_t resolve_src_scalar(const amdgpu::Wavefront &wf, int ev) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/operand.h
@@ -24,6 +24,7 @@ public:
   std::string name() const override;
   std::optional<uint64_t> literal64_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
 
 private:
   uint32_t read_scalar(const amdgpu::Wavefront &wf) const override;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/operand.cpp
@@ -1021,6 +1021,24 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 namespace {
 
 uint32_t resolve_src_scalar(const amdgpu::Wavefront &wf, int ev) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/operand.h
@@ -24,6 +24,7 @@ public:
   std::string name() const override;
   std::optional<uint64_t> literal64_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
 
 private:
   uint32_t read_scalar(const amdgpu::Wavefront &wf) const override;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/operand.cpp
@@ -1343,6 +1343,24 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 namespace {
 
 uint32_t resolve_src_scalar(const amdgpu::Wavefront &wf, int ev) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/operand.h
@@ -24,6 +24,7 @@ public:
   std::string name() const override;
   std::optional<uint64_t> literal64_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
 
 private:
   uint32_t read_scalar(const amdgpu::Wavefront &wf) const override;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/operand.cpp
@@ -1036,6 +1036,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/operand.h
@@ -28,6 +28,7 @@ public:
   std::string name() const override;
   std::optional<uint64_t> literal64_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
   /// @brief Return the immutable full-simulator operand table.
   static const void *full_execution_backend();
   /// @brief Validate that every full-simulator operand callback is present.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/operand.cpp
@@ -1128,6 +1128,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 namespace {
 
 uint32_t resolve_src_scalar(const amdgpu::Wavefront &wf, int ev) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/operand.h
@@ -24,6 +24,7 @@ public:
   std::string name() const override;
   std::optional<uint64_t> literal64_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
 
 private:
   uint32_t read_scalar(const amdgpu::Wavefront &wf) const override;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/operand.cpp
@@ -972,6 +972,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 namespace {
 
 uint32_t resolve_src_scalar(const amdgpu::Wavefront &wf, int ev) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/operand.h
@@ -24,6 +24,7 @@ public:
   std::string name() const override;
   std::optional<uint64_t> literal64_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
 
 private:
   uint32_t read_scalar(const amdgpu::Wavefront &wf) const override;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/operand.cpp
@@ -712,6 +712,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 namespace {
 
 uint32_t resolve_src_scalar(const amdgpu::Wavefront &wf, int ev) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/operand.h
@@ -27,6 +27,7 @@ public:
   std::string name() const override;
   std::optional<uint64_t> literal64_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
   bool simd_capable() const override;
 
 private:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/operand.cpp
@@ -718,6 +718,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 namespace {
 
 uint32_t resolve_src_scalar(const amdgpu::Wavefront &wf, int ev) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/operand.h
@@ -27,6 +27,7 @@ public:
   std::string name() const override;
   std::optional<uint64_t> literal64_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
   bool simd_capable() const override;
 
 private:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/operand.cpp
@@ -758,6 +758,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 namespace {
 
 uint32_t resolve_src_scalar(const amdgpu::Wavefront &wf, int ev) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/operand.h
@@ -27,6 +27,7 @@ public:
   std::string name() const override;
   std::optional<uint64_t> literal64_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
   bool simd_capable() const override;
 
 private:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.cpp
@@ -9,6 +9,8 @@ namespace rocjitsu {
 
 std::optional<RegisterRef> Operand::to_register_ref() const { return std::nullopt; }
 
+std::optional<RegClass> Operand::to_special_reg_class() const { return std::nullopt; }
+
 uint32_t Operand::read_scalar(const amdgpu::Wavefront & /*wf*/) const {
   throw std::logic_error("read_scalar not implemented for this operand type");
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.h
@@ -92,6 +92,17 @@ public:
   /// parse the display string returned by name().
   [[nodiscard]] virtual std::optional<RegisterRef> to_register_ref() const;
 
+  /// @brief Map this operand to the architectural special register it denotes.
+  ///
+  /// @details Returns the special RegClass (EXEC/VCC/SCC/M0/PC) for a fieldless
+  /// architectural special operand, or nullopt for everything else. This is the
+  /// special-register counterpart of to_register_ref(): special registers are
+  /// singletons tracked by SpecialRegisterSet, deliberately kept out of the
+  /// ordinary SGPR/VGPR/AccVGPR RegisterSet liveness that drives scratch
+  /// allocation. ISA-specific subclasses override this from the generated
+  /// fieldless operand policy effect column; the base returns nullopt.
+  [[nodiscard]] virtual std::optional<RegClass> to_special_reg_class() const;
+
   /// @brief Raw encoding value from the instruction binary.
   int encoding_value() const { return encoding_value_; }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
@@ -16,6 +16,7 @@
 #include "rocjitsu/isa/arch/amdgpu/shared/rdna_isa_base.h"
 
 #include <algorithm>
+#include <bit>
 #include <bitset>
 #include <cstddef>
 #include <cstdint>
@@ -47,18 +48,47 @@ inline constexpr size_t REGISTER_SET_ALLOCATABLE_SGPRS =
 /// enum is deliberately small and hardware-oriented; operands that are literals,
 /// labels, waitcnt immediates, message IDs, and other non-register values should
 /// not produce a RegisterRef.
+/// @details The first three classes (SGPR, VGPR, ACC_VGPR) are ordinary
+/// indexed register files tracked by `RegisterSet`. The remainder are
+/// architectural special registers: they are singletons (there is one EXEC,
+/// one SCC, ...), are not used for scratch allocation, and are represented by
+/// `SpecialRegisterSet` rather than `RegisterSet`. `is_special_reg_class()`
+/// distinguishes the two groups; keep the ordinary classes first so that
+/// predicate stays a simple partition.
 enum class RegClass : uint8_t {
-  SGPR,         ///< Scalar general-purpose register, indexed as sN.
-  VGPR,         ///< Vector general-purpose register, indexed as vN.
-  ACC_VGPR,     ///< CDNA accumulator VGPR, indexed as accN.
-  EXEC,         ///< EXEC mask. Not currently tracked by RegisterSet.
-  VCC,          ///< VCC condition mask. Not currently tracked by RegisterSet.
-  SCC,          ///< Scalar condition code bit. Not currently tracked by RegisterSet.
-  M0,           ///< M0 special scalar register. Not currently tracked by RegisterSet.
-  FLAT_SCRATCH, ///< Flat-scratch base pair. Not currently tracked by RegisterSet.
-  TTMP,         ///< Trap-temporary registers. Not currently tracked by RegisterSet.
-  PC,           ///< Program counter/control-flow dependency. Not currently tracked by RegisterSet.
+  SGPR,         ///< Scalar general-purpose register, indexed as sN. Tracked by RegisterSet.
+  VGPR,         ///< Vector general-purpose register, indexed as vN. Tracked by RegisterSet.
+  ACC_VGPR,     ///< CDNA accumulator VGPR, indexed as accN. Tracked by RegisterSet.
+  EXEC,         ///< EXEC mask. Special register; tracked by SpecialRegisterSet, not RegisterSet.
+  VCC,          ///< VCC condition mask. Special register; tracked by SpecialRegisterSet.
+  SCC,          ///< Scalar condition code bit. Special register; tracked by SpecialRegisterSet.
+  M0,           ///< M0 special scalar register. Special register; tracked by SpecialRegisterSet.
+  FLAT_SCRATCH, ///< Flat-scratch base pair. Special register; tracked by SpecialRegisterSet.
+  TTMP,         ///< Trap-temporary registers. Special register; tracked by SpecialRegisterSet.
+  PC, ///< Program counter/control-flow dep. Special register; tracked by SpecialRegisterSet.
 };
+
+/// @brief True if @p cls is an architectural special register (EXEC, VCC, SCC,
+/// M0, FLAT_SCRATCH, TTMP, PC) rather than an ordinary indexed register file
+/// (SGPR, VGPR, ACC_VGPR). Special registers live in `SpecialRegisterSet`;
+/// ordinary ones live in `RegisterSet`.
+[[nodiscard]] constexpr bool is_special_reg_class(RegClass cls) {
+  switch (cls) {
+  case RegClass::EXEC:
+  case RegClass::VCC:
+  case RegClass::SCC:
+  case RegClass::M0:
+  case RegClass::FLAT_SCRATCH:
+  case RegClass::TTMP:
+  case RegClass::PC:
+    return true;
+  case RegClass::SGPR:
+  case RegClass::VGPR:
+  case RegClass::ACC_VGPR:
+    return false;
+  }
+  return false;
+}
 
 /// @brief A contiguous register reference within one register file.
 ///
@@ -147,6 +177,78 @@ private:
   std::bitset<REGISTER_SET_MAX_SGPRS> sgprs_;
   std::bitset<REGISTER_SET_MAX_VGPRS> vgprs_;
   std::bitset<REGISTER_SET_MAX_ACC_VGPRS> acc_vgprs_;
+};
+
+/// @brief A set of architectural special registers (EXEC, VCC, SCC, M0, PC,
+/// FLAT_SCRATCH, TTMP).
+///
+/// @details Special registers are singletons — there is exactly one EXEC, one
+/// SCC, and so on, with no meaningful index or width — so membership is the
+/// only state, and this set stores just a class-membership bitmask rather than
+/// per-index bitsets. It is deliberately a separate type from `RegisterSet`
+/// so DBT and DBI can handle them accordingly.
+class SpecialRegisterSet {
+public:
+  /// @brief Add a special-register class. Ordinary register classes
+  /// (SGPR/VGPR/ACC_VGPR) are ignored — those belong in `RegisterSet`, and
+  /// silently dropping them mirrors how `RegisterSet` ignores special classes.
+  void insert(RegClass cls) {
+    if (is_special_reg_class(cls))
+      mask_ |= bit(cls);
+  }
+
+  /// @brief True if @p cls is present. Only meaningful for special classes;
+  /// ordinary classes are never members and always return false.
+  [[nodiscard]] bool contains(RegClass cls) const { return (mask_ & bit(cls)) != 0; }
+
+  /// @brief True when no special register is present.
+  [[nodiscard]] bool empty() const { return mask_ == 0; }
+
+  /// @brief Number of distinct special registers present.
+  [[nodiscard]] size_t size() const { return static_cast<size_t>(std::popcount(mask_)); }
+
+  /// @brief True if any special register is present in both sets.
+  [[nodiscard]] bool intersects(const SpecialRegisterSet &rhs) const {
+    return (mask_ & rhs.mask_) != 0;
+  }
+
+  SpecialRegisterSet &operator|=(const SpecialRegisterSet &rhs) {
+    mask_ |= rhs.mask_;
+    return *this;
+  }
+
+  friend SpecialRegisterSet operator|(SpecialRegisterSet lhs, const SpecialRegisterSet &rhs) {
+    lhs |= rhs;
+    return lhs;
+  }
+
+  friend bool operator==(const SpecialRegisterSet &, const SpecialRegisterSet &) = default;
+
+  /// @brief Invoke @p f with each present special register class, in ascending
+  /// `RegClass` value order.
+  template <typename F> void for_each(F &&f) const {
+    uint16_t bits = mask_;
+    while (bits != 0) {
+      const auto i = static_cast<uint8_t>(std::countr_zero(bits));
+      f(static_cast<RegClass>(i));
+      bits &= static_cast<uint16_t>(bits - 1);
+    }
+  }
+
+private:
+  static constexpr uint16_t bit(RegClass cls) {
+    return static_cast<uint16_t>(1u << static_cast<uint8_t>(cls));
+  }
+
+  // The bitmask indexes bits by raw RegClass value, so every class must fit in
+  // `mask_`. If RegClass ever grows past the mask width, widen `mask_` (and the
+  // shift base in `bit`) rather than silently truncating membership.
+  static_assert(static_cast<uint8_t>(RegClass::PC) < 16,
+                "SpecialRegisterSet mask_ must hold a bit for every RegClass value");
+
+  /// @brief Bit `static_cast<uint8_t>(cls)` set iff special class `cls`
+  /// present. Only special-class bits are ever set (see `insert`).
+  uint16_t mask_ = 0;
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -579,6 +579,50 @@ TEST(InstDefUseSpecialEffects, SpecialEffectsDoNotEnterScratchLiveness) {
   EXPECT_TRUE(du.memory.any());
 }
 
+TEST(SpecialEffectAnalysis, SaveexecReportsExecAndSccFromDecodedOperands) {
+  // Real decoded instruction: s_and_saveexec_b64 s[0:1], s[0:1] (CDNA4). Its
+  // fieldless special operands drive the InstDefUse special sets by direction:
+  //   dst EXEC + dst SCC  -> special_defs
+  //   src EXEC (old exec) -> special_uses
+  // while the ordinary sdst/ssrc0 SGPRs stay in the ordinary defs/uses that feed
+  // scratch allocation. Special effects never enter ordinary RegisterSet liveness.
+  const uint32_t words[] = {0xBE802000u, 0x00000000u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_and_saveexec_b64");
+
+  InstDefUse du(*inst);
+
+  EXPECT_TRUE(du.special_defs.contains(RegClass::EXEC));
+  EXPECT_TRUE(du.special_defs.contains(RegClass::SCC));
+  EXPECT_TRUE(du.special_uses.contains(RegClass::EXEC));
+  EXPECT_FALSE(du.special_uses.contains(RegClass::SCC));
+
+  // Ordinary sdst/ssrc0 (s[0:1]) still tracked as ordinary registers.
+  EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 0, 2}));
+  EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 0, 2}));
+
+  // Special registers do not leak into ordinary scratch liveness.
+  EXPECT_FALSE(du.defs.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_FALSE(du.defs.contains({RegClass::SCC, 0, 1}));
+}
+
+TEST(SpecialEffectAnalysis, OrdinaryInstructionReportsNoSpecialEffects) {
+  // A plain vector op with only ordinary register operands exposes no special
+  // effects -- both special sets stay empty.
+  constexpr std::array<uint32_t, 2> kWritelaneV141S4Lane2 = {0xd28a008du, 0x00010404u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(kWritelaneV141S4Lane2.data()));
+  ASSERT_NE(inst, nullptr);
+
+  InstDefUse du(*inst);
+  EXPECT_TRUE(du.special_defs.empty());
+  EXPECT_TRUE(du.special_uses.empty());
+}
+
 TEST(CfgAnalysis, LoopBackEdgeLinksPredecessor) {
   auto blocks = build_test_blocks({TestOpcode::Nop, TestOpcode::BranchBackToStart});
 

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -16,6 +16,8 @@
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/opcodes.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/vbuffer.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna3/mubuf.h"
+#include "rocjitsu/isa/arch/amdgpu/rdna4/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/rdna4/opcodes.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/isa_traits.h"
@@ -579,6 +581,15 @@ TEST(InstDefUseSpecialEffects, SpecialEffectsDoNotEnterScratchLiveness) {
   EXPECT_TRUE(du.memory.any());
 }
 
+// Build a SpecialRegisterSet from a list so a test can assert the *exact* set of
+// special registers an instruction reads or writes, not just membership.
+SpecialRegisterSet special_regs(std::initializer_list<RegClass> classes) {
+  SpecialRegisterSet s;
+  for (RegClass c : classes)
+    s.insert(c);
+  return s;
+}
+
 TEST(SpecialEffectAnalysis, SaveexecReportsExecAndSccFromDecodedOperands) {
   // Real decoded instruction: s_and_saveexec_b64 s[0:1], s[0:1] (CDNA4). Its
   // fieldless special operands drive the InstDefUse special sets by direction:
@@ -595,10 +606,8 @@ TEST(SpecialEffectAnalysis, SaveexecReportsExecAndSccFromDecodedOperands) {
 
   InstDefUse du(*inst);
 
-  EXPECT_TRUE(du.special_defs.contains(RegClass::EXEC));
-  EXPECT_TRUE(du.special_defs.contains(RegClass::SCC));
-  EXPECT_TRUE(du.special_uses.contains(RegClass::EXEC));
-  EXPECT_FALSE(du.special_uses.contains(RegClass::SCC));
+  EXPECT_EQ(du.special_defs, special_regs({RegClass::EXEC, RegClass::SCC}));
+  EXPECT_EQ(du.special_uses, special_regs({RegClass::EXEC}));
 
   // Ordinary sdst/ssrc0 (s[0:1]) still tracked as ordinary registers.
   EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 0, 2}));
@@ -621,6 +630,201 @@ TEST(SpecialEffectAnalysis, OrdinaryInstructionReportsNoSpecialEffects) {
   InstDefUse du(*inst);
   EXPECT_TRUE(du.special_defs.empty());
   EXPECT_TRUE(du.special_uses.empty());
+}
+
+// Decode-time special-effect coverage for the hidden-side-effect instruction
+// families. Encodings are built through the generated per-ISA encoders so they
+// cannot silently drift, and each case locks the operand-driven special
+// defs/uses so a change elsewhere cannot alter them unnoticed.
+
+// V_CMPX writes EXEC on every ISA, and additionally VCC on CDNA/GFX9 (its
+// operand list carries a VCC destination). gfx1250 is EXEC-only, so the same
+// mnemonic has a genuinely different side-effect set across ISAs.
+TEST(SpecialEffectAnalysis, CmpxWritesVccAndExecOnCdna) {
+  const auto built = cdna3::build_vopc(cdna3::kVCmpxEqF32Vopc, {.src0 = 256, .vsrc1 = 1});
+  const std::array<uint32_t, 2> words{built[0], 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(du.special_defs, special_regs({RegClass::EXEC, RegClass::VCC}));
+  EXPECT_TRUE(du.special_uses.empty());
+}
+
+TEST(SpecialEffectAnalysis, CmpxWritesExecOnlyOnGfx1250) {
+  const auto built = gfx1250::build_vopc(gfx1250::kVCmpxEqF32Vopc, {.src0 = 256, .vsrc1 = 1});
+  const std::array<uint32_t, 2> words{built[0], 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(du.special_defs, special_regs({RegClass::EXEC}));
+  EXPECT_TRUE(du.special_uses.empty());
+}
+
+// RDNA CMPX is EXEC-only like gfx1250 (and unlike CDNA), tested directly on an
+// RDNA target rather than inferred from the CDNA-family gfx1250.
+TEST(SpecialEffectAnalysis, CmpxWritesExecOnlyOnRdna) {
+  const auto built = rdna4::build_vopc(rdna4::kVCmpxEqF32Vopc, {.src0 = 256, .vsrc1 = 1});
+  const std::array<uint32_t, 2> words{built[0], 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(du.special_defs, special_regs({RegClass::EXEC}));
+  EXPECT_TRUE(du.special_uses.empty());
+}
+
+// s_cbranch_{scc,vcc,exec}* read a special condition register and branch. The
+// condition operand is a special use; nothing is defined.
+TEST(SpecialEffectAnalysis, CbranchSccIsSpecialSccUse) {
+  const uint32_t word = cdna3::build_sopp(cdna3::kSCbranchScc0Sopp, {.simm16 = 0})[0];
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_cbranch_scc0");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(du.special_uses, special_regs({RegClass::SCC}));
+  EXPECT_TRUE(du.special_defs.empty());
+}
+
+TEST(SpecialEffectAnalysis, CbranchVccIsSpecialVccUse) {
+  const uint32_t word = cdna3::build_sopp(cdna3::kSCbranchVcczSopp, {.simm16 = 0})[0];
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_cbranch_vccz");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(du.special_uses, special_regs({RegClass::VCC}));
+  EXPECT_TRUE(du.special_defs.empty());
+}
+
+TEST(SpecialEffectAnalysis, CbranchExecIsSpecialExecUse) {
+  const uint32_t word = cdna3::build_sopp(cdna3::kSCbranchExeczSopp, {.simm16 = 0})[0];
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_cbranch_execz");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(du.special_uses, special_regs({RegClass::EXEC}));
+  EXPECT_TRUE(du.special_defs.empty());
+}
+
+// VOP2 carry reads and writes VCC implicitly. The mnemonic differs by ISA
+// (CDNA/GFX9 v_addc_co_u32 vs RDNA/gfx1250 v_add_co_ci_u32) but both expose the
+// same VCC carry-in use and carry-out def.
+TEST(SpecialEffectAnalysis, Vop2CarryCdnaAddcUsesAndDefsVcc) {
+  const auto built =
+      cdna3::build_vop2(cdna3::kVAddcCoU32Vop2, {.src0 = 256, .vsrc1 = 1, .vdst = 2});
+  const std::array<uint32_t, 2> words{built[0], 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "v_addc_co_u32_e32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(du.special_defs, special_regs({RegClass::VCC}));
+  EXPECT_EQ(du.special_uses, special_regs({RegClass::VCC}));
+  EXPECT_TRUE(du.defs.contains({RegClass::VGPR, 2, 1})); // ordinary vdst still tracked
+}
+
+TEST(SpecialEffectAnalysis, Vop2CarryGfx1250AddCoCiUsesAndDefsVcc) {
+  const auto built =
+      gfx1250::build_vop2(gfx1250::kVAddCoCiU32Vop2, {.src0 = 256, .vsrc1 = 1, .vdst = 2});
+  const std::array<uint32_t, 2> words{built[0], 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "v_add_co_ci_u32_e32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(du.special_defs, special_regs({RegClass::VCC}));
+  EXPECT_EQ(du.special_uses, special_regs({RegClass::VCC}));
+}
+
+// PC family: getpc reads PC (writes an ordinary SGPR pair), setpc writes PC
+// (reads an ordinary SGPR pair), s_call does both.
+TEST(SpecialEffectAnalysis, GetpcReadsPc) {
+  const uint32_t word = cdna3::build_sop1(0x1c, {.ssrc0 = 0, .sdst = 8})[0]; // s_getpc_b64 s[8:9]
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_getpc_b64");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(du.special_uses, special_regs({RegClass::PC}));
+  EXPECT_TRUE(du.special_defs.empty());
+  EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 8, 2}));
+}
+
+TEST(SpecialEffectAnalysis, SetpcWritesPc) {
+  const uint32_t word = cdna3::build_sop1(0x1d, {.ssrc0 = 8, .sdst = 0})[0]; // s_setpc_b64 s[8:9]
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_setpc_b64");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(du.special_defs, special_regs({RegClass::PC}));
+  EXPECT_TRUE(du.special_uses.empty());
+  EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 8, 2}));
+}
+
+TEST(SpecialEffectAnalysis, ScallReadsAndWritesPc) {
+  const uint32_t word = build_s_call_b64(8, 0); // s_call_b64 s[8:9], <rel>
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_call_b64");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(du.special_defs, special_regs({RegClass::PC}));
+  EXPECT_EQ(du.special_uses, special_regs({RegClass::PC}));
+  EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 8, 2}));
+}
+
+// A buffer load's fieldless GPUMEM operand is inert: it yields neither a special
+// register class nor an ordinary register ref, and InstDefUse::memory carries no
+// effect (memory-effect metadata is not modeled for memory pseudo-operands).
+TEST(SpecialEffectAnalysis, MemoryPseudoOperandProducesNoSpecialEffect) {
+  const auto words =
+      gfx1250::build_vbuffer(gfx1250::kBufferLoadB32Vbuffer, {.vdata = 1, .rsrc = 0});
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "buffer_load_b32");
+
+  InstDefUse du(*inst);
+  EXPECT_TRUE(du.special_defs.empty());
+  EXPECT_TRUE(du.special_uses.empty());
+  EXPECT_FALSE(du.memory.any());
 }
 
 TEST(CfgAnalysis, LoopBackEdgeLinksPredecessor) {

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -402,6 +402,183 @@ TEST(RegisterSetAnalysis, Cdna4WritelaneDestinationIsUseAndDef) {
   EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 4, 1}));
 }
 
+// ---------------------------------------------------------------------------
+// Architectural special-register + memory effect API. These effects are
+// represented separately from RegisterSet so they never enter ordinary
+// scratch-allocation liveness.
+// ---------------------------------------------------------------------------
+
+TEST(SpecialRegisterSetAnalysis, ClassifiesSpecialVersusOrdinaryClasses) {
+  EXPECT_FALSE(is_special_reg_class(RegClass::SGPR));
+  EXPECT_FALSE(is_special_reg_class(RegClass::VGPR));
+  EXPECT_FALSE(is_special_reg_class(RegClass::ACC_VGPR));
+  EXPECT_TRUE(is_special_reg_class(RegClass::EXEC));
+  EXPECT_TRUE(is_special_reg_class(RegClass::VCC));
+  EXPECT_TRUE(is_special_reg_class(RegClass::SCC));
+  EXPECT_TRUE(is_special_reg_class(RegClass::M0));
+  EXPECT_TRUE(is_special_reg_class(RegClass::FLAT_SCRATCH));
+  EXPECT_TRUE(is_special_reg_class(RegClass::TTMP));
+  EXPECT_TRUE(is_special_reg_class(RegClass::PC));
+}
+
+TEST(SpecialRegisterSetAnalysis, InsertContainsSizeEmpty) {
+  SpecialRegisterSet s;
+  EXPECT_TRUE(s.empty());
+  EXPECT_EQ(s.size(), 0u);
+
+  s.insert(RegClass::EXEC);
+  s.insert(RegClass::VCC);
+  s.insert(RegClass::EXEC); // idempotent
+
+  EXPECT_FALSE(s.empty());
+  EXPECT_EQ(s.size(), 2u);
+  EXPECT_TRUE(s.contains(RegClass::EXEC));
+  EXPECT_TRUE(s.contains(RegClass::VCC));
+  EXPECT_FALSE(s.contains(RegClass::SCC));
+}
+
+TEST(SpecialRegisterSetAnalysis, IgnoresOrdinaryRegisterClasses) {
+  SpecialRegisterSet s;
+  s.insert(RegClass::SGPR);
+  s.insert(RegClass::VGPR);
+  s.insert(RegClass::ACC_VGPR);
+
+  EXPECT_TRUE(s.empty());
+  EXPECT_FALSE(s.contains(RegClass::SGPR));
+}
+
+TEST(SpecialRegisterSetAnalysis, UnionIntersectsEquality) {
+  SpecialRegisterSet a;
+  a.insert(RegClass::EXEC);
+  SpecialRegisterSet b;
+  b.insert(RegClass::VCC);
+
+  EXPECT_FALSE(a.intersects(b));
+
+  const SpecialRegisterSet u = a | b;
+  EXPECT_EQ(u.size(), 2u);
+  EXPECT_TRUE(u.intersects(a));
+  EXPECT_TRUE(u.intersects(b));
+
+  a |= b;
+  EXPECT_EQ(a, u);
+}
+
+TEST(SpecialRegisterSetAnalysis, ForEachVisitsAscendingClassOrder) {
+  SpecialRegisterSet s;
+  s.insert(RegClass::PC);
+  s.insert(RegClass::EXEC);
+  s.insert(RegClass::M0);
+
+  std::vector<RegClass> seen;
+  s.for_each([&](RegClass c) { seen.push_back(c); });
+
+  EXPECT_EQ(seen, (std::vector<RegClass>{RegClass::EXEC, RegClass::M0, RegClass::PC}));
+}
+
+TEST(SpecialRegisterSetAnalysis, ForEachOnEmptySetNeverInvokesCallback) {
+  SpecialRegisterSet s;
+  int calls = 0;
+  s.for_each([&](RegClass) { ++calls; });
+  EXPECT_EQ(calls, 0);
+}
+
+TEST(SpecialRegisterSetAnalysis, HighBitClassesRoundTrip) {
+  // TTMP and PC occupy the highest RegClass bit positions, where a uint16_t
+  // truncation bug in bit()/for_each would first surface.
+  SpecialRegisterSet s;
+  s.insert(RegClass::TTMP);
+  s.insert(RegClass::PC);
+
+  EXPECT_EQ(s.size(), 2u);
+  EXPECT_TRUE(s.contains(RegClass::TTMP));
+  EXPECT_TRUE(s.contains(RegClass::PC));
+
+  std::vector<RegClass> seen;
+  s.for_each([&](RegClass c) { seen.push_back(c); });
+  EXPECT_EQ(seen, (std::vector<RegClass>{RegClass::TTMP, RegClass::PC}));
+}
+
+TEST(SpecialRegisterSetAnalysis, OrdinaryClassNeverAliasesSpecialBits) {
+  // SGPR maps to bit 0; inserting EXEC must not make an ordinary class appear
+  // present. Guards the raw-value bit indexing against aliasing.
+  SpecialRegisterSet s;
+  s.insert(RegClass::EXEC);
+  EXPECT_FALSE(s.contains(RegClass::SGPR));
+  EXPECT_FALSE(s.contains(RegClass::VGPR));
+  EXPECT_FALSE(s.contains(RegClass::ACC_VGPR));
+}
+
+TEST(SpecialRegisterSetAnalysis, SelfUnionIsIdentity) {
+  SpecialRegisterSet s;
+  s.insert(RegClass::EXEC);
+  s.insert(RegClass::VCC);
+  const SpecialRegisterSet before = s;
+  s |= s;
+  EXPECT_EQ(s, before);
+}
+
+TEST(SpecialRegisterSetAnalysis, HoldsWhatRegisterSetIgnores) {
+  // The special classes RegisterSet drops (see IgnoresSpecialRegisterClasses)
+  // are exactly what SpecialRegisterSet tracks, and the two are independent:
+  // recording special effects never perturbs ordinary scratch liveness.
+  RegisterSet ordinary;
+  ordinary.expand({RegClass::SGPR, 4, 2});
+  const size_t ordinary_size = ordinary.size();
+
+  SpecialRegisterSet special;
+  special.insert(RegClass::EXEC);
+  special.insert(RegClass::SCC);
+  special.insert(RegClass::FLAT_SCRATCH);
+
+  EXPECT_EQ(special.size(), 3u);
+  EXPECT_EQ(ordinary.size(), ordinary_size); // unchanged by special inserts
+
+  // RegisterSet still refuses to store special classes.
+  ordinary.expand({RegClass::EXEC, 0, 2});
+  EXPECT_EQ(ordinary.size(), ordinary_size);
+}
+
+TEST(MemoryEffectsAnalysis, DefaultsToNoEffect) {
+  MemoryEffects m;
+  EXPECT_FALSE(m.any());
+
+  m.atomic = true;
+  EXPECT_TRUE(m.any());
+}
+
+TEST(InstDefUseSpecialEffects, SpecialAndMemoryDefaultEmpty) {
+  // Constructing InstDefUse from a decoded instruction leaves special/memory
+  // effects empty while ordinary def/use extraction is unchanged.
+  TestInstruction inst("test_sp", {{RegClass::SGPR, 4, 1}}, {{RegClass::VGPR, 0, 1}});
+  InstDefUse du(inst);
+
+  EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 4, 1}));
+  EXPECT_TRUE(du.uses.contains({RegClass::VGPR, 0, 1}));
+  EXPECT_TRUE(du.special_defs.empty());
+  EXPECT_TRUE(du.special_uses.empty());
+  EXPECT_FALSE(du.memory.any());
+}
+
+TEST(InstDefUseSpecialEffects, SpecialEffectsDoNotEnterScratchLiveness) {
+  // A future consumer (DBT/DBI) can record special and memory effects on
+  // InstDefUse but doing so must not change the ordinary defs/uses that
+  // drive scratch allocation.
+  TestInstruction inst("test_sp", {{RegClass::SGPR, 4, 1}}, {});
+  InstDefUse du(inst);
+  const size_t defs_size = du.defs.size();
+
+  du.special_defs.insert(RegClass::EXEC);
+  du.special_uses.insert(RegClass::VCC);
+  du.memory.reads = true;
+  du.memory.global = true;
+
+  EXPECT_EQ(du.defs.size(), defs_size);
+  EXPECT_TRUE(du.special_defs.contains(RegClass::EXEC));
+  EXPECT_TRUE(du.special_uses.contains(RegClass::VCC));
+  EXPECT_TRUE(du.memory.any());
+}
+
 TEST(CfgAnalysis, LoopBackEdgeLinksPredecessor) {
   auto blocks = build_test_blocks({TestOpcode::Nop, TestOpcode::BranchBackToStart});
 

--- a/emulation/rocjitsu/tests/decode_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/decode_smoke_test.cpp
@@ -174,6 +174,15 @@ TEST(FieldlessOperandDecodeTest, SaveexecExposesInertExecAndSccOperands) {
   expect_inert_fieldless_operand(inst->dst_operand(2), 1, 253);  // SCC write.
   expect_inert_fieldless_operand(inst->src_operand(1), 64, 126); // EXEC read.
 
+  // The fieldless special operands are inert for ordinary register/SIMD access
+  // (asserted above), but each still reports its architectural special register
+  // through to_special_reg_class() -- the special-effect counterpart of
+  // to_register_ref(). The ordinary sdst carries no special class.
+  EXPECT_EQ(sdst->to_special_reg_class(), std::nullopt);
+  EXPECT_EQ(inst->dst_operand(1)->to_special_reg_class(), RegClass::EXEC);
+  EXPECT_EQ(inst->dst_operand(2)->to_special_reg_class(), RegClass::SCC);
+  EXPECT_EQ(inst->src_operand(1)->to_special_reg_class(), RegClass::EXEC);
+
   EXPECT_EQ(inst->disassemble(), "s_and_saveexec_b64 s[0:1], s[0:1]");
 }
 


### PR DESCRIPTION
## Motivation

Fieldless special operands (VCC, EXEC, SCC, M0, and PC) were decoded but inert so analysis had no way to see if an instruction used or defined them. This PR changes that by adding "special register" def/use. It does not change any runtime execution. 

## Technical Details

* I made the decision to give the special registers their own `SpecialRegisterSet` and `special_{uses,defs}`, rather than adding them to the current ordinary register ones for backwards compatibility and to give us more control over them (e.g. allocating scratch for liveness)
* Adds a `to_special_reg_class` which is like the `to_register_ref` function but for special registers. Returns a `RegClass` instead of a `RegisterRef` since the special registers do not have an index/width associated with them (internally).
* `FLAT_SCRATCH` is classified as a special register internally but isn't quite like the others since it doesn't really have an special effect. There is still a place to handle it in Issue #8625.

Note: I don't feel like too much was introduced by this PR, but the line count would beg to differ. I could split this into two PRs: the first would introduce the data structures and the second would populate/test them.

## Issue Tracking

This is the next step in Issue #8625.

## Test Plan
 
* Added a tests to verify that representative instructions have the correct special defs/uses

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
