### PR TITLE
tests(rocjitsu): RAII to fix temp file races

### DIFF
--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -680,6 +680,7 @@ add_executable(
 target_include_directories(
     rj_dbt_translate_smoke_test
     PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_SOURCE_DIR}/lib/rocjitsu/include
         ${CMAKE_SOURCE_DIR}/lib/rocjitsu/src
 )
@@ -966,6 +967,7 @@ target_compile_definitions(
 target_include_directories(
     hsa_hooks_unit_test
     PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_SOURCE_DIR}/lib/rocjitsu/include
         ${CMAKE_SOURCE_DIR}/lib/rocjitsu/src
         ${CMAKE_SOURCE_DIR}/lib/util/include

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -419,6 +419,7 @@ add_executable(
     instruction_execution_harness_test.cpp
     scalar_scc_test.cpp
     cdna3_predicate_mask_test.cpp
+    scoped_temp_test.cpp
     decode_execute_benchmark.cpp
     util_unique_handle_test.cpp
     util_simd_test.cpp
@@ -513,6 +514,7 @@ target_link_libraries(
         Threads::Threads
         GTest::gtest_main
 )
+target_include_directories(rocjitsu_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 rj_configure_target(rocjitsu_tests TEST)
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_compile_definitions(

--- a/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
+++ b/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
@@ -19,16 +19,13 @@
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/kernel_symbol.h"
 #include "rocjitsu/code/rj_code.h"
+#include "scoped_temp.h"
 
 #include <gtest/gtest.h>
-
-#include <unistd.h>
 
 #include <array>
 #include <cstdint>
 #include <cstring>
-#include <filesystem>
-#include <fstream>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -134,20 +131,11 @@ void expect_machine_flag_maps_to_target(uint32_t mach_flag, rj_code_target_id_t 
 void expect_c_api_accepts_target(uint32_t mach_flag, rj_code_target_id_t target) {
   auto image = make_minimal_amdgpu_elf(mach_flag);
 
-  // PID-suffix the tmp filename so concurrent ctest runs and stale leftovers
-  // from prior crashed runs don't collide.
-  const std::filesystem::path tmp =
-      std::filesystem::temp_directory_path() /
-      ("rj_code_object_target_id_test_" + std::to_string(getpid()) + ".co");
-  {
-    std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
-    ASSERT_TRUE(out.is_open()) << "could not open " << tmp;
-    out.write(reinterpret_cast<const char *>(image.data()),
-              static_cast<std::streamsize>(image.size()));
-  }
+  test::ScopedTempFile file("rj-code-object-target-id-");
+  file.write(std::string_view(reinterpret_cast<const char *>(image.data()), image.size()));
 
   rj_code_executable_t *exec = nullptr;
-  ASSERT_EQ(rj_code_executable_create(tmp.c_str(), &exec), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_EQ(rj_code_executable_create(file.path().c_str(), &exec), ROCJITSU_STATUS_SUCCESS);
   ASSERT_NE(exec, nullptr);
 
   ASSERT_GT(rj_code_executable_num_code_objects(exec, target), 0u)
@@ -182,9 +170,6 @@ void expect_c_api_accepts_target(uint32_t mach_flag, rj_code_target_id_t target)
   rj_code_basic_block_release(block);
   rj_code_object_destroy(obj);
   rj_code_object_release(obj);
-
-  std::error_code ec;
-  std::filesystem::remove(tmp, ec); // best-effort
 }
 
 //==============================================================================

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -3,6 +3,7 @@
 
 #include "aql_queue.h"
 #include "halt_snapshot_plugin.h"
+#include "scoped_temp.h"
 
 #include "embedded_schema.h"
 #include "rocjitsu/config/checkpoint.h"
@@ -33,8 +34,6 @@ RJ_DIAGNOSTIC_POP
 #include <stdexcept>
 #include <string>
 #include <string_view>
-#include <unistd.h>
-
 namespace {
 
 const std::string CONFIG_DIR_PATH = CONFIG_DIR;
@@ -42,11 +41,10 @@ const std::string CONFIG_DIR_PATH = CONFIG_DIR;
 // \NPI new GPU: add a config-load test for its configs/<gpu>.json here.
 using namespace rocjitsu;
 
-std::filesystem::path write_temp_config(std::string_view name, std::string_view json) {
-  std::filesystem::path path = std::filesystem::temp_directory_path() / std::string(name);
-  std::ofstream out(path);
-  out << json;
-  return path;
+test::ScopedTempFile write_temp_config(std::string_view json) {
+  test::ScopedTempFile file("rocjitsu-config-");
+  file.write(json);
+  return file;
 }
 
 TEST(ConfigLoaderTest, LoadCdna4Config) {
@@ -325,7 +323,7 @@ TEST(ConfigLoaderTest, DeviceCapabilityFieldsRoundTripFromJson) {
 }
 
 TEST(ConfigLoaderTest, LoadsDbtOnlyConfigWithoutVmOrTopology) {
-  const std::filesystem::path path = write_temp_config("rocjitsu_dbt_only_config_test.json", R"({
+  const auto file = write_temp_config(R"({
       "dbt_guest": {
         "enabled": true,
         "guest_isa": "gfx950",
@@ -351,8 +349,7 @@ TEST(ConfigLoaderTest, LoadsDbtOnlyConfigWithoutVmOrTopology) {
       }
     })");
 
-  auto dbt = config::load_dbt_guest_config_from_file(path.string());
-  std::filesystem::remove(path);
+  auto dbt = config::load_dbt_guest_config_from_file(file.path());
 
   EXPECT_TRUE(dbt.enabled);
   EXPECT_EQ(dbt.guest_isa, "gfx950");
@@ -380,8 +377,7 @@ TEST(ConfigLoaderTest, LoadsDbtGuestSiliconRevisions) {
   // gfx1250 A0/B0 share an ELF machine ID, so the silicon revision is carried in
   // the DBT guest config out of band. A same-target B0->A0 load selects the A0
   // workarounds from these fields.
-  const std::filesystem::path path =
-      write_temp_config("rocjitsu_dbt_guest_revision_config_test.json", R"({
+  const auto file = write_temp_config(R"({
       "dbt_guest": {
         "enabled": true,
         "guest_isa": "gfx1250",
@@ -391,16 +387,14 @@ TEST(ConfigLoaderTest, LoadsDbtGuestSiliconRevisions) {
       }
     })");
 
-  auto dbt = config::load_dbt_guest_config_from_file(path.string());
-  std::filesystem::remove(path);
+  auto dbt = config::load_dbt_guest_config_from_file(file.path());
 
   EXPECT_EQ(dbt.guest_revision, config::DbtSiliconRevision::Gfx1250B0);
   EXPECT_EQ(dbt.host_revision, config::DbtSiliconRevision::Gfx1250A0);
 }
 
 TEST(ConfigLoaderTest, RejectsDbtGuestDeviceWithInconsistentSimdCount) {
-  const std::filesystem::path path =
-      write_temp_config("rocjitsu_bad_dbt_guest_geometry_config_test.json", R"({
+  const auto file = write_temp_config(R"({
       "dbt_guest": {
         "enabled": true,
         "guest_isa": "gfx950",
@@ -416,8 +410,7 @@ TEST(ConfigLoaderTest, RejectsDbtGuestDeviceWithInconsistentSimdCount) {
       }
     })");
 
-  EXPECT_THROW(config::load_dbt_guest_config_from_file(path.string()), std::runtime_error);
-  std::filesystem::remove(path);
+  EXPECT_THROW(config::load_dbt_guest_config_from_file(file.path()), std::runtime_error);
 }
 
 TEST(ConfigLoaderTest, LoadsDbtGuestThroughFullConfigLoader) {
@@ -452,10 +445,8 @@ TEST(ConfigLoaderTest, LoadsDbtGuestThroughFullConfigLoader) {
     },
   )");
 
-  const std::filesystem::path path =
-      write_temp_config("rocjitsu_full_dbt_guest_config_test.json", json);
-  auto loaded = config::load_config(path.string(), rocjitsu::kEmbeddedSchema);
-  std::filesystem::remove(path);
+  const auto file = write_temp_config(json);
+  auto loaded = config::load_config(file.path(), rocjitsu::kEmbeddedSchema);
 
   EXPECT_TRUE(loaded.dbt_guest.enabled);
   EXPECT_EQ(loaded.dbt_guest.guest_isa, "gfx950");
@@ -471,11 +462,9 @@ TEST(ConfigLoaderTest, LoadsDbtGuestThroughFullConfigLoader) {
 }
 
 TEST(ConfigLoaderTest, MissingDbtGuestConfigReturnsDefaults) {
-  const std::filesystem::path path =
-      write_temp_config("rocjitsu_missing_dbt_guest_config_test.json", "{}");
+  const auto file = write_temp_config("{}");
 
-  auto dbt = config::load_dbt_guest_config_from_file(path.string());
-  std::filesystem::remove(path);
+  auto dbt = config::load_dbt_guest_config_from_file(file.path());
 
   EXPECT_FALSE(dbt.enabled);
   EXPECT_TRUE(dbt.guest_isa.empty());
@@ -488,8 +477,7 @@ TEST(ConfigLoaderTest, MissingDbtGuestConfigReturnsDefaults) {
 }
 
 TEST(ConfigLoaderTest, MissingDbtGuestDeviceLeavesDeviceAbsent) {
-  const std::filesystem::path path =
-      write_temp_config("rocjitsu_missing_dbt_guest_device_config_test.json", R"({
+  const auto file = write_temp_config(R"({
         "dbt_guest": {
           "enabled": true,
           "guest_isa": "gfx950",
@@ -497,8 +485,7 @@ TEST(ConfigLoaderTest, MissingDbtGuestDeviceLeavesDeviceAbsent) {
         }
       })");
 
-  auto dbt = config::load_dbt_guest_config_from_file(path.string());
-  std::filesystem::remove(path);
+  auto dbt = config::load_dbt_guest_config_from_file(file.path());
 
   EXPECT_TRUE(dbt.enabled);
   EXPECT_EQ(dbt.guest_isa, "gfx950");
@@ -507,16 +494,13 @@ TEST(ConfigLoaderTest, MissingDbtGuestDeviceLeavesDeviceAbsent) {
 }
 
 TEST(ConfigLoaderTest, MalformedDbtGuestConfigThrows) {
-  const std::filesystem::path path =
-      write_temp_config("rocjitsu_malformed_dbt_guest_config_test.json", R"({ "dbt_guest": )");
+  const auto file = write_temp_config(R"({ "dbt_guest": )");
 
-  EXPECT_THROW(config::load_dbt_guest_config_from_file(path.string()), std::runtime_error);
-  std::filesystem::remove(path);
+  EXPECT_THROW(config::load_dbt_guest_config_from_file(file.path()), std::runtime_error);
 }
 
 TEST(ConfigLoaderTest, LoadsSimulatorDbtBackendConfig) {
-  const std::filesystem::path external_path =
-      write_temp_config("rocjitsu_simulator_dbt_guest_config_test.json", R"({
+  const auto external_file = write_temp_config(R"({
         "dbt_guest": {
           "enabled": true,
           "guest_isa": "gfx950",
@@ -525,8 +509,7 @@ TEST(ConfigLoaderTest, LoadsSimulatorDbtBackendConfig) {
           "simulator_config": "gfx942_cdna3_kmd.json"
         }
       })");
-  const std::filesystem::path self_contained_path =
-      write_temp_config("rocjitsu_self_contained_dbt_guest_config_test.json", R"({
+  const auto self_contained_file = write_temp_config(R"({
         "dbt_guest": {
           "enabled": true,
           "guest_isa": "gfx950",
@@ -535,10 +518,8 @@ TEST(ConfigLoaderTest, LoadsSimulatorDbtBackendConfig) {
         }
       })");
 
-  auto external = config::load_dbt_guest_config_from_file(external_path.string());
-  auto self_contained = config::load_dbt_guest_config_from_file(self_contained_path.string());
-  std::filesystem::remove(external_path);
-  std::filesystem::remove(self_contained_path);
+  auto external = config::load_dbt_guest_config_from_file(external_file.path());
+  auto self_contained = config::load_dbt_guest_config_from_file(self_contained_file.path());
 
   EXPECT_EQ(external.host.isa, "gfx942");
   EXPECT_EQ(external.host.backend, config::DbtExecutionBackend::Simulator);
@@ -548,44 +529,38 @@ TEST(ConfigLoaderTest, LoadsSimulatorDbtBackendConfig) {
 }
 
 TEST(ConfigLoaderTest, LoadsExplicitHardwareDbtBackendConfig) {
-  const std::filesystem::path path =
-      write_temp_config("rocjitsu_hardware_dbt_guest_config_test.json", R"({
+  const auto file = write_temp_config(R"({
         "dbt_guest": {
           "enabled": true,
           "execution_backend": "hardware"
         }
       })");
 
-  auto dbt = config::load_dbt_guest_config_from_file(path.string());
-  std::filesystem::remove(path);
+  auto dbt = config::load_dbt_guest_config_from_file(file.path());
 
   EXPECT_EQ(dbt.host.backend, config::DbtExecutionBackend::Hardware);
 }
 
 TEST(ConfigLoaderTest, RejectsEmptyDbtExecutionBackend) {
-  const std::filesystem::path path =
-      write_temp_config("rocjitsu_empty_dbt_backend_config_test.json", R"({
+  const auto file = write_temp_config(R"({
         "dbt_guest": {
           "enabled": true,
           "execution_backend": ""
         }
       })");
 
-  EXPECT_THROW(config::load_dbt_guest_config_from_file(path.string()), std::runtime_error);
-  std::filesystem::remove(path);
+  EXPECT_THROW(config::load_dbt_guest_config_from_file(file.path()), std::runtime_error);
 }
 
 TEST(ConfigLoaderTest, RejectsMisspelledDbtExecutionBackend) {
-  const std::filesystem::path path =
-      write_temp_config("rocjitsu_misspelled_dbt_backend_config_test.json", R"({
+  const auto file = write_temp_config(R"({
         "dbt_guest": {
           "enabled": true,
           "execution_backed": "simulator"
         }
       })");
 
-  EXPECT_THROW(config::load_dbt_guest_config_from_file(path.string()), std::runtime_error);
-  std::filesystem::remove(path);
+  EXPECT_THROW(config::load_dbt_guest_config_from_file(file.path()), std::runtime_error);
 }
 
 TEST(ConfigLoaderTest, ValidatesSimulatorDbtGuestDeviceLimits) {
@@ -614,15 +589,13 @@ TEST(ConfigLoaderTest, ValidatesSimulatorDbtGuestDeviceLimits) {
 }
 
 TEST(ConfigLoaderTest, DisabledDbtBackendSkipsBackendSpecificValidation) {
-  const std::filesystem::path simulator_path =
-      write_temp_config("rocjitsu_disabled_simulator_dbt_config_test.json", R"({
+  const auto simulator_file = write_temp_config(R"({
         "dbt_guest": {
           "enabled": false,
           "execution_backend": "simulator"
         }
       })");
-  const std::filesystem::path hardware_path =
-      write_temp_config("rocjitsu_disabled_hardware_dbt_config_test.json", R"({
+  const auto hardware_file = write_temp_config(R"({
         "dbt_guest": {
           "enabled": false,
           "execution_backend": "hardware",
@@ -630,10 +603,8 @@ TEST(ConfigLoaderTest, DisabledDbtBackendSkipsBackendSpecificValidation) {
         }
       })");
 
-  EXPECT_NO_THROW(config::load_dbt_guest_config_from_file(simulator_path.string()));
-  EXPECT_NO_THROW(config::load_dbt_guest_config_from_file(hardware_path.string()));
-  std::filesystem::remove(simulator_path);
-  std::filesystem::remove(hardware_path);
+  EXPECT_NO_THROW(config::load_dbt_guest_config_from_file(simulator_file.path()));
+  EXPECT_NO_THROW(config::load_dbt_guest_config_from_file(hardware_file.path()));
 }
 
 TEST(ConfigLoaderTest, ResolvesDbtHostConfigPath) {
@@ -646,21 +617,18 @@ TEST(ConfigLoaderTest, ResolvesDbtHostConfigPath) {
 }
 
 TEST(ConfigLoaderTest, RejectsUnknownDbtExecutionBackend) {
-  const std::filesystem::path path =
-      write_temp_config("rocjitsu_unknown_dbt_backend_config_test.json", R"({
+  const auto file = write_temp_config(R"({
         "dbt_guest": {
           "enabled": true,
           "execution_backend": "magic"
         }
       })");
 
-  EXPECT_THROW(config::load_dbt_guest_config_from_file(path.string()), std::runtime_error);
-  std::filesystem::remove(path);
+  EXPECT_THROW(config::load_dbt_guest_config_from_file(file.path()), std::runtime_error);
 }
 
 TEST(ConfigLoaderTest, RejectsSimulatorConfigForHardwareDbtBackend) {
-  const std::filesystem::path path =
-      write_temp_config("rocjitsu_hardware_with_simulator_config_test.json", R"({
+  const auto file = write_temp_config(R"({
         "dbt_guest": {
           "enabled": true,
           "execution_backend": "hardware",
@@ -668,8 +636,7 @@ TEST(ConfigLoaderTest, RejectsSimulatorConfigForHardwareDbtBackend) {
         }
       })");
 
-  EXPECT_THROW(config::load_dbt_guest_config_from_file(path.string()), std::runtime_error);
-  std::filesystem::remove(path);
+  EXPECT_THROW(config::load_dbt_guest_config_from_file(file.path()), std::runtime_error);
 }
 
 TEST(ConfigLoaderTest, Gfx1250ComputeUnitDefaultsCoverTtmpAndHighVgprs) {
@@ -807,15 +774,13 @@ TEST(CheckpointTest, SaveAndRestoreMemory) {
   soc->memory()->write32(0x1000, 0xDEADBEEF);
   soc->memory()->write64(0x2000, 0x0123456789ABCDEFULL);
 
-  const char *path = "/tmp/rocjitsu_test_checkpoint.bin";
-  config::save_checkpoint(path, *soc, 42, loaded.engine_config);
-  ASSERT_TRUE(std::filesystem::exists(path));
+  test::ScopedTempFile checkpoint("rocjitsu-checkpoint-");
+  config::save_checkpoint(checkpoint.path(), *soc, 42, loaded.engine_config);
+  ASSERT_TRUE(std::filesystem::exists(checkpoint.path()));
 
-  auto restored = config::restore_checkpoint(path);
+  auto restored = config::restore_checkpoint(checkpoint.path());
   EXPECT_EQ(restored.memory()->read32(0x1000), 0xDEADBEEFu);
   EXPECT_EQ(restored.memory()->read64(0x2000), 0x0123456789ABCDEFULL);
-
-  std::filesystem::remove(path);
 }
 
 TEST(CheckpointTest, SaveAndRestoreAccVgprs) {
@@ -858,11 +823,11 @@ TEST(CheckpointTest, SaveAndRestoreAccVgprs) {
   cu->write_vgpr(acc0, 0, 0xA55A0001u);
   cu->write_vgpr(acc_last, 0, 0xDEADBEEFu);
 
-  const char *path = "/tmp/rocjitsu_test_checkpoint_accvgpr.bin";
-  config::save_checkpoint(path, *loaded.soc(), 42, loaded.engine_config);
-  ASSERT_TRUE(std::filesystem::exists(path));
+  test::ScopedTempFile checkpoint("rocjitsu-checkpoint-");
+  config::save_checkpoint(checkpoint.path(), *loaded.soc(), 42, loaded.engine_config);
+  ASSERT_TRUE(std::filesystem::exists(checkpoint.path()));
 
-  auto restored = config::restore_checkpoint(path);
+  auto restored = config::restore_checkpoint(checkpoint.path());
   auto *restored_vm = dynamic_cast<VirtualMachine *>(restored.build_result.root.get());
   ASSERT_NE(restored_vm, nullptr);
   auto *restored_cu = restored_vm->soc()->xcd(0)->shader_engine(0)->compute_unit(0);
@@ -875,8 +840,6 @@ TEST(CheckpointTest, SaveAndRestoreAccVgprs) {
                                        cdna3::Isa::MAX_ACC_VGPRS_PER_WF - 1,
                                    0),
             0xDEADBEEFu);
-
-  std::filesystem::remove(path);
 }
 
 TEST(CheckpointTest, SaveAndRestoreWave32ExecScratch) {
@@ -917,19 +880,17 @@ TEST(CheckpointTest, SaveAndRestoreWave32ExecScratch) {
   ASSERT_EQ(wf->wf_size(), 32u);
   wf->set_exec_raw(0xDEADBEEF0000000FULL);
 
-  const char *path = "/tmp/rocjitsu_test_checkpoint_wave32_exec.bin";
-  config::save_checkpoint(path, *loaded.soc(), 42, loaded.engine_config);
-  ASSERT_TRUE(std::filesystem::exists(path));
+  test::ScopedTempFile checkpoint("rocjitsu-checkpoint-");
+  config::save_checkpoint(checkpoint.path(), *loaded.soc(), 42, loaded.engine_config);
+  ASSERT_TRUE(std::filesystem::exists(checkpoint.path()));
 
-  auto restored = config::restore_checkpoint(path);
+  auto restored = config::restore_checkpoint(checkpoint.path());
   auto *restored_vm = dynamic_cast<VirtualMachine *>(restored.build_result.root.get());
   ASSERT_NE(restored_vm, nullptr);
   auto *restored_wf = restored_vm->soc()->xcd(0)->shader_engine(0)->compute_unit(0)->wf(0);
   ASSERT_NE(restored_wf, nullptr);
   EXPECT_EQ(restored_wf->exec(), 0xFULL);
   EXPECT_EQ(restored_wf->exec_raw(), 0xDEADBEEF0000000FULL);
-
-  std::filesystem::remove(path);
 }
 
 TEST(CApiTest, CreateAndDestroyFromString) {
@@ -967,10 +928,8 @@ TEST(CApiTest, CreateAndDestroyFromString) {
 }
 
 TEST(CApiTest, PluginLifecycleDispatchesProfiledShutdownThroughBaseGroup) {
-  const auto sink_dir = std::filesystem::temp_directory_path() /
-                        ("rocjitsu_plugin_lifecycle_" + std::to_string(getpid()));
-  std::filesystem::remove_all(sink_dir);
-  std::filesystem::create_directories(sink_dir);
+  test::ScopedTempDirectory sink_dir("rocjitsu-plugin-lifecycle-");
+  const std::filesystem::path sink_path(sink_dir.path());
 
   rj_vm_t *handle = nullptr;
   ASSERT_EQ(
@@ -979,15 +938,14 @@ TEST(CApiTest, PluginLifecycleDispatchesProfiledShutdownThroughBaseGroup) {
   ASSERT_NE(handle, nullptr);
 
   const std::string plugin_config = std::format(
-      R"({{"profiled":true,"sinks":{{"types":["file"],"dir":"{}"}}}})", sink_dir.string());
+      R"({{"profiled":true,"sinks":{{"types":["file"],"dir":"{}"}}}})", sink_path.string());
   ASSERT_EQ(rj_vm_load_plugins(handle, plugin_config.c_str(), nullptr), ROCJITSU_STATUS_SUCCESS);
   rj_vm_destroy(handle);
 
-  std::ifstream profile(sink_dir / "profile.log");
+  std::ifstream profile(sink_path / "profile.log");
   const std::string output{std::istreambuf_iterator<char>(profile),
                            std::istreambuf_iterator<char>()};
   EXPECT_NE(output.find("total emulation time"), std::string::npos) << output;
-  std::filesystem::remove_all(sink_dir);
 }
 
 TEST(CApiTest, InvalidArguments) {

--- a/emulation/rocjitsu/tests/dbt/hsa_hooks_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hooks_unit_test.cpp
@@ -26,6 +26,7 @@
 #include "rocjitsu/code/patch/kernarg_extension.h"
 #include "rocjitsu/code/patch/sidecar_metadata.h"
 #include "rocjitsu/kmd/linux/rpc.h"
+#include "scoped_temp.h"
 
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
@@ -622,11 +623,7 @@ struct FakeApiTable {
   }
 };
 
-void write_runtime_config_path() {
-  std::filesystem::path runtime_dir =
-      std::filesystem::temp_directory_path() /
-      ("rocjitsu-hsa-hooks-unit-" + std::to_string(static_cast<long long>(::getpid())));
-  std::filesystem::create_directories(runtime_dir);
+void write_runtime_config_path(const std::string &runtime_dir) {
   setenv("ROCJITSU_RUNTIME_DIR", runtime_dir.c_str(), 1);
 
   std::ofstream config_path(rocjitsu::rpc_default_config_file_path());
@@ -635,9 +632,9 @@ void write_runtime_config_path() {
 
 class InstalledHook {
 public:
-  explicit InstalledHook(FakeApiTable &api) {
+  explicit InstalledHook(FakeApiTable &api) : runtime_dir_("rocjitsu-hsa-hooks-unit-") {
     OnUnload();
-    write_runtime_config_path();
+    write_runtime_config_path(runtime_dir_.path());
     installed_ = OnLoad(&api.table, 0, 0, nullptr);
   }
   ~InstalledHook() { OnUnload(); }
@@ -645,6 +642,7 @@ public:
   [[nodiscard]] bool installed() const { return installed_; }
 
 private:
+  rocjitsu::test::ScopedTempDirectory runtime_dir_;
   bool installed_ = false;
 };
 

--- a/emulation/rocjitsu/tests/launch_preload_test.cpp
+++ b/emulation/rocjitsu/tests/launch_preload_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "launch_preload.h"
+#include "scoped_temp.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -149,19 +150,13 @@ TEST(LaunchPreloadTest, SanitizerNamedExecutableAliasDoesNotPreloadExecutable) {
   const std::filesystem::path exe = std::filesystem::read_symlink("/proc/self/exe", ec);
   ASSERT_FALSE(ec) << ec.message();
 
-  const std::filesystem::path temp_dir =
-      std::filesystem::temp_directory_path() /
-      ("rocjitsu_launch_preload_test_" + std::to_string(getpid()));
-  ASSERT_TRUE(std::filesystem::create_directories(temp_dir, ec) ||
-              std::filesystem::exists(temp_dir))
-      << ec.message();
+  const rocjitsu::test::ScopedTempDirectory temp_dir_owner("rocjitsu-launch-preload-");
+  const std::filesystem::path temp_dir(temp_dir_owner.path());
 
   static constexpr const char *alias_names[] = {"launch-asan-preload-test",
                                                 "launch-tsan-preload-test"};
   for (const char *alias_name : alias_names) {
     const std::filesystem::path alias = temp_dir / alias_name;
-    std::filesystem::remove(alias, ec);
-    ec.clear();
     std::filesystem::create_symlink(exe, alias, ec);
     ASSERT_FALSE(ec) << ec.message();
 
@@ -182,7 +177,6 @@ TEST(LaunchPreloadTest, SanitizerNamedExecutableAliasDoesNotPreloadExecutable) {
     ASSERT_TRUE(WIFEXITED(status));
     EXPECT_EQ(0, WEXITSTATUS(status));
   }
-  std::filesystem::remove_all(temp_dir, ec);
 #endif
 }
 

--- a/emulation/rocjitsu/tests/plugin_loader_test.cpp
+++ b/emulation/rocjitsu/tests/plugin_loader_test.cpp
@@ -3,16 +3,15 @@
 
 #include "rocjitsu/vm/plugins/plugin_loader.h"
 #include "rocjitsu/vm/plugins/plugin_sink.h"
+#include "scoped_temp.h"
 
 #include <gtest/gtest.h>
 
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 #include <iterator>
 #include <stdexcept>
 #include <string>
-#include <unistd.h>
 
 #ifndef PLUGIN_LOADER_FIXTURE_DIR
 #error "PLUGIN_LOADER_FIXTURE_DIR must be defined"
@@ -23,19 +22,13 @@ namespace {
 class PluginLoaderTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    trace_ = std::filesystem::temp_directory_path() /
-             ("rocjitsu_plugin_loader_" + std::to_string(getpid()) + ".trace");
-    std::filesystem::remove(trace_);
-    ASSERT_EQ(setenv("ROCJITSU_PLUGIN_TEST_TRACE", trace_.c_str(), 1), 0);
+    ASSERT_EQ(setenv("ROCJITSU_PLUGIN_TEST_TRACE", trace_.path().c_str(), 1), 0);
   }
 
-  void TearDown() override {
-    unsetenv("ROCJITSU_PLUGIN_TEST_TRACE");
-    std::filesystem::remove(trace_);
-  }
+  void TearDown() override { unsetenv("ROCJITSU_PLUGIN_TEST_TRACE"); }
 
   std::string trace() const {
-    std::ifstream input(trace_);
+    std::ifstream input(trace_.path());
     return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
   }
 
@@ -44,7 +37,7 @@ protected:
     return rocjitsu::PluginLoader::load_from_config(config, group, PLUGIN_LOADER_FIXTURE_DIR);
   }
 
-  std::filesystem::path trace_;
+  rocjitsu::test::ScopedTempFile trace_{"rocjitsu-plugin-loader-"};
 };
 
 TEST_F(PluginLoaderTest, LoadsMatchingAbi) {

--- a/emulation/rocjitsu/tests/scoped_temp.h
+++ b/emulation/rocjitsu/tests/scoped_temp.h
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+
+#include <unistd.h>
+
+namespace rocjitsu::test {
+
+class ScopedTempFile {
+public:
+  explicit ScopedTempFile(std::string_view prefix) : path_(make_pattern(prefix)) {
+    const int fd = ::mkstemp(path_.data());
+    if (fd == -1)
+      throw std::runtime_error("Failed to create temporary file");
+    (void)::close(fd);
+  }
+
+  ~ScopedTempFile() { cleanup(); }
+
+  ScopedTempFile(const ScopedTempFile &) = delete;
+  ScopedTempFile &operator=(const ScopedTempFile &) = delete;
+
+  ScopedTempFile(ScopedTempFile &&other) noexcept : path_(std::move(other.path_)) {
+    other.path_.clear();
+  }
+
+  ScopedTempFile &operator=(ScopedTempFile &&other) noexcept {
+    if (this != &other) {
+      cleanup();
+      path_ = std::move(other.path_);
+      other.path_.clear();
+    }
+    return *this;
+  }
+
+  [[nodiscard]] const std::string &path() const { return path_; }
+
+  void write(std::string_view contents) const {
+    std::ofstream output(path_, std::ios::binary | std::ios::trunc);
+    output.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+    if (!output)
+      throw std::runtime_error("Failed to write temporary file");
+  }
+
+private:
+  static std::string make_pattern(std::string_view prefix) {
+    return (std::filesystem::temp_directory_path() / (std::string(prefix) + "XXXXXX")).string();
+  }
+
+  void cleanup() noexcept {
+    if (path_.empty())
+      return;
+    std::error_code error;
+    std::filesystem::remove(path_, error);
+  }
+
+  std::string path_;
+};
+
+class ScopedTempDirectory {
+public:
+  explicit ScopedTempDirectory(std::string_view prefix) : path_(make_pattern(prefix)) {
+    if (::mkdtemp(path_.data()) == nullptr)
+      throw std::runtime_error("Failed to create temporary directory");
+  }
+
+  ~ScopedTempDirectory() { cleanup(); }
+
+  ScopedTempDirectory(const ScopedTempDirectory &) = delete;
+  ScopedTempDirectory &operator=(const ScopedTempDirectory &) = delete;
+
+  ScopedTempDirectory(ScopedTempDirectory &&other) noexcept : path_(std::move(other.path_)) {
+    other.path_.clear();
+  }
+
+  ScopedTempDirectory &operator=(ScopedTempDirectory &&other) noexcept {
+    if (this != &other) {
+      cleanup();
+      path_ = std::move(other.path_);
+      other.path_.clear();
+    }
+    return *this;
+  }
+
+  [[nodiscard]] const std::string &path() const { return path_; }
+
+private:
+  static std::string make_pattern(std::string_view prefix) {
+    return (std::filesystem::temp_directory_path() / (std::string(prefix) + "XXXXXX")).string();
+  }
+
+  void cleanup() noexcept {
+    if (path_.empty())
+      return;
+    std::error_code error;
+    std::filesystem::remove_all(path_, error);
+  }
+
+  std::string path_;
+};
+
+} // namespace rocjitsu::test

--- a/emulation/rocjitsu/tests/scoped_temp_test.cpp
+++ b/emulation/rocjitsu/tests/scoped_temp_test.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "scoped_temp.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <utility>
+
+namespace {
+
+TEST(ScopedTempFileTest, MoveTransferCleansReplacedAndFinalFiles) {
+  std::filesystem::path transferred_path;
+  std::filesystem::path replaced_path;
+
+  {
+    rocjitsu::test::ScopedTempFile source("rocjitsu-temp-file-source-");
+    transferred_path = source.path();
+    source.write("transferred contents");
+
+    rocjitsu::test::ScopedTempFile moved(std::move(source));
+    EXPECT_TRUE(source.path().empty());
+    EXPECT_EQ(std::filesystem::path(moved.path()), transferred_path);
+
+    rocjitsu::test::ScopedTempFile destination("rocjitsu-temp-file-destination-");
+    replaced_path = destination.path();
+    destination.write("replaced contents");
+
+    destination = std::move(moved);
+    EXPECT_TRUE(moved.path().empty());
+    EXPECT_EQ(std::filesystem::path(destination.path()), transferred_path);
+    EXPECT_FALSE(std::filesystem::exists(replaced_path));
+
+    std::ifstream input(destination.path(), std::ios::binary);
+    ASSERT_TRUE(input);
+    const std::string contents((std::istreambuf_iterator<char>(input)),
+                               std::istreambuf_iterator<char>());
+    EXPECT_EQ(contents, "transferred contents");
+  }
+
+  EXPECT_FALSE(std::filesystem::exists(transferred_path));
+  EXPECT_FALSE(std::filesystem::exists(replaced_path));
+}
+
+TEST(ScopedTempDirectoryTest, MoveTransferRecursivelyCleansReplacedAndFinalDirectories) {
+  std::filesystem::path transferred_path;
+  std::filesystem::path replaced_path;
+
+  {
+    rocjitsu::test::ScopedTempDirectory source("rocjitsu-temp-dir-source-");
+    transferred_path = source.path();
+    const auto transferred_child = transferred_path / "transferred.txt";
+    {
+      std::ofstream output(transferred_child);
+      ASSERT_TRUE(output);
+      output << "transferred contents";
+    }
+    ASSERT_TRUE(std::filesystem::exists(transferred_child));
+
+    rocjitsu::test::ScopedTempDirectory moved(std::move(source));
+    EXPECT_TRUE(source.path().empty());
+    EXPECT_EQ(std::filesystem::path(moved.path()), transferred_path);
+
+    rocjitsu::test::ScopedTempDirectory destination("rocjitsu-temp-dir-destination-");
+    replaced_path = destination.path();
+    const auto replaced_child = replaced_path / "replaced.txt";
+    {
+      std::ofstream output(replaced_child);
+      ASSERT_TRUE(output);
+      output << "replaced contents";
+    }
+    ASSERT_TRUE(std::filesystem::exists(replaced_child));
+
+    destination = std::move(moved);
+    EXPECT_TRUE(moved.path().empty());
+    EXPECT_EQ(std::filesystem::path(destination.path()), transferred_path);
+    EXPECT_FALSE(std::filesystem::exists(replaced_path));
+    EXPECT_TRUE(std::filesystem::exists(transferred_child));
+  }
+
+  EXPECT_FALSE(std::filesystem::exists(transferred_path));
+  EXPECT_FALSE(std::filesystem::exists(replaced_path));
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
@@ -6,6 +6,7 @@
 
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/rj_code.h"
+#include "scoped_temp.h"
 
 #include <gtest/gtest.h>
 
@@ -31,16 +32,6 @@
 namespace {
 
 std::filesystem::path g_translate_tool;
-
-struct TempDir {
-  std::filesystem::path path;
-
-  explicit TempDir(std::filesystem::path temp_path) : path(std::move(temp_path)) {
-    std::filesystem::create_directories(path);
-  }
-
-  ~TempDir() { std::filesystem::remove_all(path); }
-};
 
 uint32_t add_elf_name(std::vector<uint8_t> &names, std::string_view name) {
   const uint32_t offset = static_cast<uint32_t>(names.size());
@@ -219,13 +210,11 @@ bool command_exited_with(int status, int exit_code) {
 } // namespace
 
 TEST(RjDbtTranslate, Smoke) {
-  const TempDir temp_dir(
-      std::filesystem::temp_directory_path() /
-      ("rj_dbt_translate_smoke_" + std::to_string(static_cast<long long>(getpid()))));
+  const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_smoke_");
 
-  const auto input = temp_dir.path / "smoke_gfx950.co";
-  const auto output = temp_dir.path / "stdout.txt";
-  const auto error = temp_dir.path / "stderr.txt";
+  const auto input = std::filesystem::path(temp_dir.path()) / "smoke_gfx950.co";
+  const auto output = std::filesystem::path(temp_dir.path()) / "stdout.txt";
+  const auto error = std::filesystem::path(temp_dir.path()) / "stderr.txt";
 
   {
     const auto image = make_smoke_code_object();
@@ -260,12 +249,10 @@ TEST(RjDbtTranslate, Smoke) {
 }
 
 TEST(RjDbtTranslate, RequiresRevisionsOnlyForGfx1250) {
-  const TempDir temp_dir(
-      std::filesystem::temp_directory_path() /
-      ("rj_dbt_translate_revision_" + std::to_string(static_cast<long long>(getpid()))));
-  const auto input = temp_dir.path / "smoke.co";
-  const auto output = temp_dir.path / "stdout.txt";
-  const auto error = temp_dir.path / "stderr.txt";
+  const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_revision_");
+  const auto input = std::filesystem::path(temp_dir.path()) / "smoke.co";
+  const auto output = std::filesystem::path(temp_dir.path()) / "stdout.txt";
+  const auto error = std::filesystem::path(temp_dir.path()) / "stderr.txt";
 
   {
     const auto image = make_smoke_code_object();

--- a/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
@@ -211,10 +211,11 @@ bool command_exited_with(int status, int exit_code) {
 
 TEST(RjDbtTranslate, Smoke) {
   const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_smoke_");
+  const std::filesystem::path temp_path(temp_dir.path());
 
-  const auto input = std::filesystem::path(temp_dir.path()) / "smoke_gfx950.co";
-  const auto output = std::filesystem::path(temp_dir.path()) / "stdout.txt";
-  const auto error = std::filesystem::path(temp_dir.path()) / "stderr.txt";
+  const auto input = temp_path / "smoke_gfx950.co";
+  const auto output = temp_path / "stdout.txt";
+  const auto error = temp_path / "stderr.txt";
 
   {
     const auto image = make_smoke_code_object();
@@ -250,9 +251,10 @@ TEST(RjDbtTranslate, Smoke) {
 
 TEST(RjDbtTranslate, RequiresRevisionsOnlyForGfx1250) {
   const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_revision_");
-  const auto input = std::filesystem::path(temp_dir.path()) / "smoke.co";
-  const auto output = std::filesystem::path(temp_dir.path()) / "stdout.txt";
-  const auto error = std::filesystem::path(temp_dir.path()) / "stderr.txt";
+  const std::filesystem::path temp_path(temp_dir.path());
+  const auto input = temp_path / "smoke.co";
+  const auto output = temp_path / "stdout.txt";
+  const auto error = temp_path / "stderr.txt";
 
   {
     const auto image = make_smoke_code_object();


### PR DESCRIPTION
## Motivation

Hardcoded temp-file/dir names can cause races across builds

## Technical Details

Add RAII helper for temporary file/directory creation and destruction. 

## Issue Tracking

N/A

## Test Plan

Run existing tests across multiple builds

## Test Result

Tests no longer race

## Submission Checklist

- [X ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
