### PR TITLE
docs(rojitsu): add agent review workflows

### DIFF
--- a/emulation/.agents/skills/README.md
+++ b/emulation/.agents/skills/README.md
@@ -33,3 +33,12 @@ material of uncertain publication status as confidential.
 The skills do not require a particular agent runner or model. Clients that do
 not automatically discover nested `.agents/skills` directories can be pointed
 at this directory as a project skill source.
+
+## GitHub write approval
+
+Every skill must obtain explicit user approval immediately before each GitHub
+write, including pushes and creating or changing pull requests, issues,
+comments, reviews, labels, tags, releases, or other remote state. Earlier task
+approval and approval for a different write do not count. Read-only GitHub
+inspection is allowed; publishing is not implicit in review, rebase, commit, or
+pull-request preparation requests.

--- a/emulation/.agents/skills/README.md
+++ b/emulation/.agents/skills/README.md
@@ -16,11 +16,19 @@ for rocjitsu style.
 
 ## Optional local references
 
-Reviewers may use a Linux source checkout at `~/linux`. Confidential reference
-PDFs may be available at `~/referance` (intentional spelling). Confidential
-material must remain local: do not quote, name, link, commit, summarize, or
-expose it. Reports must be supportable using repository code, public sources,
-or reproducible tests.
+Reviewers may use a Linux source checkout at `~/linux`. Users should put public
+shader programming guides, ISA manuals, and architecture documents in
+`~/reference/public/shader-programming-guides`. Public copies can be obtained
+from
+[AMD GPU architecture programming documentation](https://gpuopen.com/amd-gpu-architecture-programming-documentation/).
+Keep confidential PDFs separately in `~/reference/confidential`.
+
+Confidential material and its contents must remain local. Skills and reviewers
+must not quote, name, link, copy, commit, summarize, upload, or expose it through
+paths, metadata, screenshots, logs, prompts, generated artifacts, internal
+terminology, issues, pull requests, reviews, tests, or chat. Reports must be
+supportable using repository code, public sources, or reproducible tests. Treat
+material of uncertain publication status as confidential.
 
 The skills do not require a particular agent runner or model. Clients that do
 not automatically discover nested `.agents/skills` directories can be pointed

--- a/emulation/.agents/skills/README.md
+++ b/emulation/.agents/skills/README.md
@@ -1,0 +1,27 @@
+# Emulation Agent Skills
+
+This directory uses the open [Agent Skills](https://agentskills.io/)
+`SKILL.md` format so compatible Claude, OpenAI, GitHub Copilot, and other agent
+clients can share the same workflows.
+
+| Skill | Use it for |
+| --- | --- |
+| [`emulation-review`](emulation-review/SKILL.md) | Evidence-driven review of an emulation PR, branch, working tree, or file set |
+| [`rocjitsu-kernel-parity`](rocjitsu-kernel-parity/SKILL.md) | Focused comparison of rocjitsu KFD/AMDGPU behavior with Linux |
+| [`emulation-rebase`](emulation-rebase/SKILL.md) | Rebase or rebuild a branch when some commits or equivalent patches already landed |
+
+The nearest [`AGENTS.md`](../../AGENTS.md) contains shared style, testing, and
+confidentiality rules. In particular, `rocjitsu/docs/style.md` is authoritative
+for rocjitsu style.
+
+## Optional local references
+
+Reviewers may use a Linux source checkout at `~/linux`. Confidential reference
+PDFs may be available at `~/referance` (intentional spelling). Confidential
+material must remain local: do not quote, name, link, commit, summarize, or
+expose it. Reports must be supportable using repository code, public sources,
+or reproducible tests.
+
+The skills do not require a particular agent runner or model. Clients that do
+not automatically discover nested `.agents/skills` directories can be pointed
+at this directory as a project skill source.

--- a/emulation/.agents/skills/emulation-rebase/SKILL.md
+++ b/emulation/.agents/skills/emulation-rebase/SKILL.md
@@ -21,7 +21,12 @@ Mirage behavior afterward.
    history rewrite. Do not stash implicitly.
 3. Create and report a durable local recovery ref for the original tip before
    rebasing. Do not delete it in this workflow.
-4. Do not force-push unless the user explicitly asks. Use
+4. Never push any commit, branch, tag, rebased history, or other content—and
+   never modify a pull request or other GitHub state—without explicit user
+   approval immediately before that specific write. A request to rebase,
+   commit, update a branch, or prepare a pull request is not publication
+   approval. Approval for one write does not authorize another. For an approved
+   rewritten-branch push, use
    `--force-with-lease=<branch>:<expected-remote-oid>`, never plain `--force`.
 5. Never continue a conflicted rebase without inspecting the full file and the
    intent of both sides. Never resolve generated files by choosing one side or
@@ -142,6 +147,8 @@ Report:
 - tests and formatting run, failures, and residual risk;
 - whether the branch was pushed.
 
-If explicitly asked to update the remote, first record the current remote topic
-OID and push with an OID-qualified force-with-lease. Stop if the lease fails;
-fetch and reassess instead of overriding another contributor's work.
+If a remote update is desired, first record the current remote topic OID and
+show the user the local tip, destination, commits/diff to publish, and exact
+push mode. Obtain explicit approval immediately before the push. For rewritten
+history, use an OID-qualified force-with-lease. Stop if the lease fails; fetch
+and reassess instead of overriding another contributor's work.

--- a/emulation/.agents/skills/emulation-rebase/SKILL.md
+++ b/emulation/.agents/skills/emulation-rebase/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: emulation-rebase
+description: Safely analyze and rebase or rebuild an emulation branch when some commits, squash merges, cherry-picks, or equivalent changes have already landed upstream. Use for partial-merge rebases, dropping already-merged commits, resolving replay conflicts, updating a PR branch, or proving that the rebased rocjitsu and Mirage diff preserves the intended changes.
+compatibility: Requires git and a clean worktree; network access is needed only when upstream refs must be fetched.
+metadata:
+  author: ROCm
+  version: "1.0"
+---
+
+# Emulation partial-merge rebase
+
+Rewrite history only after proving which changes are already upstream. Preserve
+the intended patch, provide a recovery point, and validate affected rocjitsu and
+Mirage behavior afterward.
+
+## Hard rules
+
+1. Never infer equivalence from commit subject alone. Use ancestry, patch IDs,
+   diffs, and final tree behavior.
+2. Require a clean worktree, including relevant untracked files, before a
+   history rewrite. Do not stash implicitly.
+3. Create and report a durable local recovery ref for the original tip before
+   rebasing. Do not delete it in this workflow.
+4. Do not force-push unless the user explicitly asks. Use
+   `--force-with-lease=<branch>:<expected-remote-oid>`, never plain `--force`.
+5. Never continue a conflicted rebase without inspecting the full file and the
+   intent of both sides. Never resolve generated files by choosing one side or
+   hand-editing output; resolve generator inputs and regenerate.
+6. Follow `emulation/AGENTS.md`, enforce rocjitsu style, and validate Mirage
+   integration when affected.
+
+## 1. Capture immutable state
+
+Record:
+
+- current branch and tip OID;
+- upstream/default branch name, local OID, and remote OID;
+- configured tracking branch and expected remote topic OID;
+- merge base, worktree status, submodules if any, and recent graph;
+- open PR base/head OIDs when the task concerns a PR.
+
+Fetch only the required refs. If fetching would overwrite no local state but
+network access is unavailable, continue against recorded local refs and label
+them potentially stale.
+
+Create a clearly named recovery branch or tag at the original tip, such as
+`backup/<topic>-pre-rebase-YYYYMMDD`. Confirm it resolves to the recorded OID.
+
+## 2. Classify every topic commit
+
+Use [the equivalence checklist](references/commit-equivalence.md). Start from the
+old merge base and list topic commits in topological order. For each commit,
+classify one of:
+
+- **ancestor:** exact commit is already reachable from new upstream;
+- **patch-equivalent:** stable patch identity is upstream, including a
+  cherry-pick;
+- **squashed/absorbed:** behavior is upstream as part of a different patch;
+- **partially absorbed:** only some hunks or behavior landed;
+- **topic-only:** still needs replay;
+- **uncertain:** evidence is insufficient.
+
+`git cherry` and stable patch IDs are useful signals, not final truth: conflict
+resolution, file movement, generated output, or refactoring can alter patch
+identity while preserving behavior. For absorbed and partially absorbed
+commits, compare the relevant old-parent-to-commit diff against new upstream and
+inspect tests/callers.
+
+Present the classification table before rewriting when any commit is partially
+absorbed or uncertain. Ask the user only for intent that history and code cannot
+answer.
+
+## 3. Choose the least risky transformation
+
+- Use a normal rebase when Git reliably skips exact/equivalent commits and the
+  remaining commits are independent.
+- Use an interactive rebase when specific commits are proven absorbed and can
+  be dropped, reordered, or edited cleanly.
+- Use `rebase --onto <new-upstream> <old-base> <topic>` when the old base is
+  known and the complete remaining series should replay.
+- Preserve intentional merge structure with `--rebase-merges`.
+- For deeply interdependent, partially absorbed, or repeatedly conflicted
+  history, rebuild the branch from new upstream by replaying selected commits
+  or reconstructing the final patch. Keep authorship and meaningful commit
+  boundaries where practical.
+
+Before execution, state the proposed command/sequence, commits to drop or edit,
+and why each is safe.
+
+## 4. Resolve replay conflicts by intent
+
+For each conflict:
+
+1. inspect the original commit and its parent, current upstream implementation,
+   full conflicted files, callers, tests, and later topic commits;
+2. decide whether the topic change is already present, still required, or must
+   be adapted to an upstream refactor;
+3. make the smallest resolution that preserves both upstream fixes and remaining
+   topic intent;
+4. run a focused check when feasible before continuing;
+5. verify no conflict markers or unintended generated/manual edits remain.
+
+Abort rather than guess when behavior or confidential domain intent cannot be
+established. The recovery ref must remain available whether the rebase succeeds
+or aborts.
+
+## 5. Prove the result
+
+After the rewrite, compare old and new history with `range-diff` and compare
+trees against their respective bases. Account for every old topic commit and
+every material hunk as upstream-provided, replayed, intentionally removed, or
+reworked.
+
+Check specifically for:
+
+- accidentally lost tests, docs, build files, generated outputs, or fixups;
+- duplicated changes that Git failed to skip;
+- reverted upstream fixes caused by conflict resolution;
+- generated output not matching the current generator;
+- commits outside `emulation/` that were part of the topic;
+- changed public behavior through Mirage.
+
+Run formatting and focused tests first, then the affected component suites from
+`emulation/AGENTS.md`. For rocjitsu-Mirage boundaries, run an integration path
+through Mirage. Record unavailable tests rather than hiding them.
+
+## 6. Report and optionally publish
+
+Report:
+
+- old tip, new upstream, old merge base, new tip, and recovery ref;
+- commit-classification table and transformation used;
+- conflict resolutions and any intent assumptions;
+- `range-diff`/tree-diff conclusion;
+- tests and formatting run, failures, and residual risk;
+- whether the branch was pushed.
+
+If explicitly asked to update the remote, first record the current remote topic
+OID and push with an OID-qualified force-with-lease. Stop if the lease fails;
+fetch and reassess instead of overriding another contributor's work.

--- a/emulation/.agents/skills/emulation-rebase/SKILL.md
+++ b/emulation/.agents/skills/emulation-rebase/SKILL.md
@@ -28,6 +28,13 @@ Mirage behavior afterward.
    hand-editing output; resolve generator inputs and regenerate.
 6. Follow `emulation/AGENTS.md`, enforce rocjitsu style, and validate Mirage
    integration when affected.
+7. Never leak confidential references or their contents while inspecting
+   history or resolving conflicts. Do not quote, name, link, copy, summarize,
+   upload, or expose them through paths, metadata, screenshots, logs, prompts,
+   generated artifacts, internal terminology, issues, pull requests, reviews,
+   tests, commits, or chat. Base recorded rationale on repository history,
+   public sources, and reproducible tests; treat uncertain publication status
+   as confidential.
 
 ## 1. Capture immutable state
 

--- a/emulation/.agents/skills/emulation-rebase/references/commit-equivalence.md
+++ b/emulation/.agents/skills/emulation-rebase/references/commit-equivalence.md
@@ -1,0 +1,49 @@
+# Commit equivalence checklist
+
+Use multiple signals. No single command proves semantic equivalence in all
+cases.
+
+## Evidence hierarchy
+
+1. **Reachability:** the exact topic commit is an ancestor of new upstream.
+2. **Stable patch identity:** normalized patch IDs match across histories.
+3. **Range comparison:** `git cherry` and `git range-diff` associate a topic
+   patch with an upstream patch.
+4. **Tree evidence:** every material topic hunk or behavior exists upstream,
+   possibly after file movement or refactoring.
+5. **Behavior evidence:** focused tests demonstrate the same contract and edge
+   cases.
+6. **Message/PR metadata:** useful for locating candidates, never sufficient by
+   itself.
+
+## Per-commit questions
+
+- Is the exact OID reachable from upstream?
+- Does a stable patch ID match an upstream commit?
+- Was the change squash-merged with sibling commits?
+- Was it cherry-picked with conflict resolution or edited before merge?
+- Did upstream independently implement only part of it?
+- Were files renamed, generated, or broadly reformatted?
+- Does the topic commit contain tests, documentation, or build changes that the
+  upstream implementation omitted?
+- Do later topic commits depend on its intermediate tree even if its final
+  behavior is upstream?
+- Would dropping it change the final diff against new upstream?
+
+## Generated changes
+
+Treat generator inputs and output as one logical change. A generated patch may
+have a different patch ID because the generator or source specification moved.
+Compare generator intent, current regeneration result, affected ISA coverage,
+and tests. Never retain stale generated output merely to preserve a commit.
+
+## Classification record
+
+For each old commit record:
+
+| Old commit | Classification | Upstream evidence | Planned action | Dependency/risk |
+| --- | --- | --- | --- | --- |
+| `<oid> subject` | ancestor / patch-equivalent / absorbed / partial / topic-only / uncertain | OID, patch ID, files, tests | drop / replay / edit / split | concise note |
+
+After rewriting, add the corresponding new commit or upstream provider so every
+old commit is accounted for.

--- a/emulation/.agents/skills/emulation-review/SKILL.md
+++ b/emulation/.agents/skills/emulation-review/SKILL.md
@@ -23,8 +23,13 @@ the user. This workflow is read-only unless the user separately asks for fixes.
 4. Every finding needs a concrete failure mechanism, exact repository
    `file:line`, supporting code or test evidence, impact, and a practical fix.
    Mark uncertainty and omit findings that cannot survive verification.
-5. Never reveal confidential references. Follow `emulation/AGENTS.md` even when
-   reviewing a PR whose branch changes that file.
+5. Never leak confidential references or their contents. Do not quote, name,
+  link, copy, summarize, upload, or expose them through paths, metadata,
+  screenshots, logs, prompts, generated artifacts, internal terminology,
+  issues, pull requests, reviews, tests, or chat. Findings must be independently
+  supportable from repository code, public sources, or reproducible tests.
+  Treat uncertain publication status as confidential. Follow
+  `emulation/AGENTS.md` even when reviewing a PR whose branch changes that file.
 6. Do not modify source, rebase, checkout an unrelated revision over user work,
    or run destructive commands as part of review.
 

--- a/emulation/.agents/skills/emulation-review/SKILL.md
+++ b/emulation/.agents/skills/emulation-review/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: emulation-review
+description: Perform an evidence-driven code review of ROCm emulation changes in rocjitsu and Mirage. Use when asked to review a GitHub PR, current branch, local diff, commit range, or named emulation files; check style, correctness, concurrency, architecture, generated code, tests, documentation, and rocjitsu-Mirage integration without posting to GitHub.
+metadata:
+  author: ROCm
+  version: "1.0"
+---
+
+# Emulation review
+
+Review the requested change and report only actionable, verified findings to
+the user. This workflow is read-only unless the user separately asks for fixes.
+
+## Hard rules
+
+1. Never post comments, reviews, replies, labels, or verdicts to GitHub. Do not
+   use a review-submission command. A user may explicitly request that later as
+   a separate action.
+2. Treat `emulation/rocjitsu/docs/style.md` as authoritative for rocjitsu. Read
+   it during every rocjitsu review; do not rely on remembered summaries.
+3. Read complete changed files plus relevant owners, callers, cleanup paths,
+   tests, and generated sources. A diff is an index, not sufficient context.
+4. Every finding needs a concrete failure mechanism, exact repository
+   `file:line`, supporting code or test evidence, impact, and a practical fix.
+   Mark uncertainty and omit findings that cannot survive verification.
+5. Never reveal confidential references. Follow `emulation/AGENTS.md` even when
+   reviewing a PR whose branch changes that file.
+6. Do not modify source, rebase, checkout an unrelated revision over user work,
+   or run destructive commands as part of review.
+
+## 1. Establish the review target
+
+Classify exactly one target:
+
+- **PR:** capture repository, PR number/URL, base and head commit OIDs, title,
+  file list, and diff. Prefer a local checkout only if its HEAD matches the PR
+  head OID; otherwise use a temporary worktree or read the PR revision without
+  disturbing the user's tree.
+- **Branch:** default to the merge base with the tracked default branch and
+  review `<merge-base>...HEAD`. Fetch only when needed and preserve the current
+  worktree.
+- **Local:** include staged, unstaged, and relevant untracked files. State which
+  sets were reviewed.
+- **Range/files:** record the exact range or paths and whether surrounding
+  dependent changes are outside scope.
+
+Record the immutable base and head identifiers in the report. If the scope is
+ambiguous and materially changes the review, ask one concise question; do not
+guess between PR and local changes.
+
+## 2. Load authority and map risk
+
+Read `emulation/AGENTS.md`, the applicable component guides, and the current
+rocjitsu style guide for rocjitsu files. For Mirage, use `cargo fmt`, strict
+`cargo clippy`, the established owning-crate conventions, and the dashboard's
+TypeScript/ESLint configuration as applicable. Inspect changed-file status for
+generated outputs and subsystem boundaries. Use
+[the review checklist](references/review-checklist.md) to select the relevant
+lenses and tests.
+
+Build a short risk map before judging hunks:
+
+- externally visible behavior and compatibility;
+- threads, processes, locks, callbacks, RPC, fork/exec, and teardown;
+- ownership of memory, file descriptors, mappings, handles, and background
+  work;
+- KFD/DRM/UAPI or FFI boundaries and serialized schemas;
+- ISA semantics, ordering, memory/coherence, and cross-ISA translation;
+- generated artifacts and the generator inputs that own them;
+- Mirage profile/session/container/environment integration;
+- tests and documentation that define the changed contract.
+
+For KFD/AMDGPU behavior that requires source-level comparison, activate the
+`rocjitsu-kernel-parity` skill rather than improvising a shallow comparison.
+
+## 3. Review in passes
+
+Perform at least these passes, combining them only for very small changes:
+
+1. **Intent and architecture:** infer the intended behavior from the PR
+   description, commit history, docs, tests, and callers. Check that the change
+   is in the correct layer and reuses existing facilities.
+2. **Correctness and lifecycle:** trace success, error, cancellation, shutdown,
+   crash, and partial-initialization paths. Check concurrency and process
+   boundaries before style.
+3. **Domain behavior:** validate ISA, ABI, driver, translation, simulation,
+   container, API, and persistence semantics relevant to the patch.
+4. **Generated code:** reject manual generated-file fixes. Verify generator
+   changes are comprehensive across affected ISAs and regenerated output is
+   complete and contains no unrelated drift.
+5. **Tests, docs, and style:** require focused regression coverage and relevant
+   Mirage integration coverage. Enforce the rocjitsu style guide exactly. Ask
+   for documentation only when a public contract or non-obvious invariant
+   changed.
+
+If the client supports parallel subagents, use independent read-only reviewers
+for cleanly separable lenses or subsystems. Give each the same immutable scope,
+hard rules, and confidentiality policy. Do not split overlapping files merely
+to increase reviewer count. The primary reviewer must verify, deduplicate, and
+curate all returned findings; subagent output is not evidence by itself.
+
+## 4. Validate likely findings
+
+Spend execution time on issues likely to survive. Start with the smallest
+existing test or a non-mutating repro that distinguishes expected from actual
+behavior. Expand based on risk:
+
+- rocjitsu: build, focused CTest, amdisa tests, then broader CTest or an
+  appropriate sanitizer/static-analysis build;
+- Mirage: focused crate/test target, then workspace tests and the owning E2E
+  suite under `emulation/mirage/tests/`;
+- dashboard: lint/type-check/build, unit tests, then Playwright when behavior is
+  user-facing;
+- cross-component changes: test rocjitsu through Mirage, not only each unit in
+  isolation.
+
+Do not silently treat unavailable hardware, tools, references, or credentials
+as a pass. Report what ran, what did not, and why. A failing pre-existing test is
+not a review finding unless the change caused or exposed it.
+
+## 5. Curate and report
+
+Delete speculative, duplicate, stale, praise-only, and low-value findings.
+Style-only findings are normally `NIT`; style violations that create ambiguity,
+wrong ownership, or invalid architecture may be higher.
+
+Report in this order:
+
+1. **Verdict:** `REQUEST CHANGES`, `COMMENT`, or `APPROVE`, with one-sentence
+   rationale. Approval means no verified blocking findings, not that every
+   possible test ran.
+2. **Findings:** group by `BLOCKER`, `MAJOR`, `MINOR`, then `NIT`. For each use:
+   - `file:line` and a short title;
+   - impact and concrete trigger;
+   - evidence from the changed code and cross-check;
+   - minimal suggested fix and regression test;
+   - confidence (`high`, `medium`, or `low`) when not high.
+3. **Validation:** commands/tests run and results; list unavailable checks.
+4. **Scope notes:** immutable base/head, reviewed files, and residual risk.
+
+If there are no findings, say so directly and still report validation and
+residual risk. Never manufacture a comment to make the review appear useful.

--- a/emulation/.agents/skills/emulation-review/SKILL.md
+++ b/emulation/.agents/skills/emulation-review/SKILL.md
@@ -13,9 +13,12 @@ the user. This workflow is read-only unless the user separately asks for fixes.
 
 ## Hard rules
 
-1. Never post comments, reviews, replies, labels, or verdicts to GitHub. Do not
-   use a review-submission command. A user may explicitly request that later as
-   a separate action.
+1. Never push commits, branches, tags, or other content to GitHub, and never
+  create or modify comments, reviews, replies, labels, pull requests, or other
+  GitHub state, without explicit user approval immediately before that specific
+  write. Do not use a review-submission command during this workflow. Review,
+  edit, commit, or pull-request preparation requests are not publication
+  approval, and approval for one write does not authorize another.
 2. Treat `emulation/rocjitsu/docs/style.md` as authoritative for rocjitsu. Read
    it during every rocjitsu review; do not rely on remembered summaries.
 3. Read complete changed files plus relevant owners, callers, cleanup paths,

--- a/emulation/.agents/skills/emulation-review/references/review-checklist.md
+++ b/emulation/.agents/skills/emulation-review/references/review-checklist.md
@@ -1,0 +1,89 @@
+# Emulation review checklist
+
+Select only sections relevant to the change. This is a risk checklist, not a
+requirement to produce one comment per item.
+
+## Correctness and lifecycle
+
+- Bounds, overflow, alignment, signedness, truncation, wraparound, and units.
+- Null/empty/partial inputs and malformed external data.
+- Error propagation, stable error codes, rollback, retries, and idempotence.
+- Ownership and cleanup for allocations, mappings, file descriptors, handles,
+  processes, threads, sockets, temporary files, and persistent state.
+- Initialization and teardown ordering, including failure halfway through.
+- Compatibility of public C APIs, CLI output/exit status, JSON/schema state,
+  environment variables, and on-disk formats.
+
+## Concurrency and process behavior
+
+- Shared fields have one documented synchronization discipline.
+- Lock order is consistent; no lock is held across blocking I/O, callbacks,
+  RPC, process waits, or potentially re-entrant code without justification.
+- Atomics use an ordering that establishes the required happens-before edge.
+- Worker/poll/RPC/simulation threads cannot outlive referenced state.
+- Shutdown, cancellation, timeout, signal, fork, exec, and crash recovery paths
+  wake all waiters and leave recoverable state.
+- Multi-process identifiers, runtime directories, ports, FIFOs, and sockets are
+  isolated; tests remain reliable under parallel execution.
+
+## rocjitsu architecture and domain
+
+- KFD ioctls and process behavior stay in the simulated driver; interposition
+  remains a translation boundary rather than a second implementation.
+- Vendored or kernel UAPI types define kernel ABI; convenience library types do
+  not accidentally become wire formats.
+- Queue/doorbell/event lifecycle, dispatch ordering, VM mappings, cache
+  coherence, and signal semantics match the intended contract.
+- Simulation work does not block engine progress or violate deterministic event
+  ordering.
+- Hot paths avoid exceptions, unnecessary allocation, logging, and contention.
+- DBT preserves control flow, registers, wait/order semantics, code-object
+  metadata, and behavior across every supported source/target ISA pair.
+
+## Generated code
+
+- Generated ISA and DBT files were not manually edited.
+- Generator or semantic source changed in the same patch.
+- Multi-ISA regeneration covers every affected family and pair.
+- Shared semantics remain shared instead of copied into one ISA.
+- Generated diff is deterministic, comprehensive, formatted, and free of
+  unrelated version/tool drift.
+- amdisa tests and representative decode/execute/translation tests cover the
+  source change.
+
+## Mirage
+
+- Crate ownership and feature gating remain coherent; optional features compile
+  independently where supported.
+- FFI loading validates symbols and lifetimes and does not let Rust references
+  outlive loaded libraries or C-owned storage.
+- Profile/session/execution transitions remain atomic and crash recoverable.
+- XDG paths, permissions, cleanup, process groups, PTYs, FIFOs, and signals work
+  for concurrent sessions.
+- Container command construction preserves argument boundaries, mount and
+  environment behavior, rank/topology wiring, and useful errors.
+- HTTP/WebSocket changes preserve authentication assumptions, input validation,
+  cancellation, backpressure, and client-visible compatibility.
+- UI state remains synchronized with server state; asynchronous work handles
+  stale responses, unmount, reconnect, and errors.
+- Integration coverage uses the owning suite in `emulation/mirage/tests/`, such
+  as lifecycle, daemon, container, or matrix E2E tests.
+
+## Style and documentation
+
+- Re-read `emulation/rocjitsu/docs/style.md` for every rocjitsu review.
+- Check type choice and section order, naming, namespaces, C++20/STL usage,
+  header form, `auto`, logging, exceptions, formatting, and comments.
+- Public behavior and non-obvious invariants are documented where maintainers
+  and users will look. Avoid duplicated or narrational documentation.
+
+## Test selection
+
+- Add a regression test that fails before the fix and exercises the public or
+  owning layer, plus focused unit tests for boundary-heavy logic.
+- Include negative, boundary, cleanup, and concurrency cases when those paths
+  changed.
+- Run rocjitsu unit tests for engine changes and Mirage lifecycle/integration
+  tests when users reach the behavior through Mirage.
+- For dashboard changes, run lint, production build/type-check, unit tests, and
+  user-flow E2E tests as warranted.

--- a/emulation/.agents/skills/rocjitsu-kernel-parity/SKILL.md
+++ b/emulation/.agents/skills/rocjitsu-kernel-parity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rocjitsu-kernel-parity
 description: Compare rocjitsu's simulated Linux KFD/AMDGPU behavior with a Linux source checkout and derive focused tests. Use when reviewing or implementing KFD ioctls, DRM/AMDGPU interposition, queue, doorbell, event, memory mapping, process, topology, or error semantics, or when asked whether rocjitsu matches kernel behavior.
-compatibility: Requires read access to a Linux source checkout, normally ~/linux; confidential supplemental PDFs may exist in ~/referance.
+compatibility: Requires read access to a Linux source checkout, normally ~/linux; supplemental documents may exist under ~/reference.
 metadata:
   author: ROCm
   version: "1.0"
@@ -25,11 +25,19 @@ the observable contract remains correct and the project layering is preserved.
 4. Trace behavior from public entry point through validation, state mutation,
    synchronization, and cleanup. Matching a struct declaration is not proof of
    matching behavior.
-5. Confidential PDFs in `~/referance` are supplemental only. Never quote,
-   name, link, cite, summarize, expose their path in a report, or repeat
-   non-public terminology. Findings must be justified by repository code,
-   publicly identifiable Linux source, or reproducible tests.
-6. Separate verified mismatch, intentional emulation difference, version skew,
+5. Public shader programming guides, ISA manuals, and architecture documents
+   may be stored in `~/reference/public/shader-programming-guides`; users can
+   obtain public copies from
+   [AMD GPU architecture programming documentation](https://gpuopen.com/amd-gpu-architecture-programming-documentation/).
+   Keep confidential PDFs separately in `~/reference/confidential`.
+6. Confidential references are supplemental only. Never quote, name, link,
+   copy, cite, summarize, upload, or expose their contents through paths,
+   metadata, screenshots, logs, prompts, generated artifacts, internal
+   terminology, issues, pull requests, reviews, tests, or chat. Findings must be
+   independently justified by repository code, publicly identifiable Linux
+   source, public programming documentation, or reproducible tests. Treat
+   uncertain publication status as confidential.
+7. Separate verified mismatch, intentional emulation difference, version skew,
    and unknown. Do not label an uncertainty as a kernel-parity bug.
 
 ## 1. Pin scope and sources

--- a/emulation/.agents/skills/rocjitsu-kernel-parity/SKILL.md
+++ b/emulation/.agents/skills/rocjitsu-kernel-parity/SKILL.md
@@ -39,6 +39,10 @@ the observable contract remains correct and the project layering is preserved.
    uncertain publication status as confidential.
 7. Separate verified mismatch, intentional emulation difference, version skew,
    and unknown. Do not label an uncertainty as a kernel-parity bug.
+8. Never push or otherwise write to GitHub without explicit user approval
+  immediately before that specific write. Analysis, implementation, commit,
+  review, and pull-request preparation requests do not imply publication
+  approval; approval for one write does not authorize another.
 
 ## 1. Pin scope and sources
 

--- a/emulation/.agents/skills/rocjitsu-kernel-parity/SKILL.md
+++ b/emulation/.agents/skills/rocjitsu-kernel-parity/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: rocjitsu-kernel-parity
+description: Compare rocjitsu's simulated Linux KFD/AMDGPU behavior with a Linux source checkout and derive focused tests. Use when reviewing or implementing KFD ioctls, DRM/AMDGPU interposition, queue, doorbell, event, memory mapping, process, topology, or error semantics, or when asked whether rocjitsu matches kernel behavior.
+compatibility: Requires read access to a Linux source checkout, normally ~/linux; confidential supplemental PDFs may exist in ~/referance.
+metadata:
+  author: ROCm
+  version: "1.0"
+---
+
+# Rocjitsu kernel parity
+
+Establish whether rocjitsu reproduces the externally observable Linux
+AMDGPU/KFD behavior relevant to a change. The kernel is a behavioral oracle,
+not an architecture template: rocjitsu may implement behavior differently if
+the observable contract remains correct and the project layering is preserved.
+
+## Hard rules
+
+1. Follow `emulation/AGENTS.md` and the current
+   `emulation/rocjitsu/docs/style.md`.
+2. Default to read-only analysis. Never modify the Linux checkout. Modify
+   rocjitsu or tests only when the user explicitly asks for implementation.
+3. Record the exact rocjitsu commit and Linux commit or describe why either is
+   unavailable. Do not compare against an assumed kernel version.
+4. Trace behavior from public entry point through validation, state mutation,
+   synchronization, and cleanup. Matching a struct declaration is not proof of
+   matching behavior.
+5. Confidential PDFs in `~/referance` are supplemental only. Never quote,
+   name, link, cite, summarize, expose their path in a report, or repeat
+   non-public terminology. Findings must be justified by repository code,
+   publicly identifiable Linux source, or reproducible tests.
+6. Separate verified mismatch, intentional emulation difference, version skew,
+   and unknown. Do not label an uncertainty as a kernel-parity bug.
+
+## 1. Pin scope and sources
+
+Identify the exact operation and observable behavior under question: ioctl,
+`mmap`, event wait, queue lifecycle, process teardown, topology, memory policy,
+doorbell, exception, or error code. Record relevant inputs, process/thread
+state, expected outputs, and the hardware-independent behavior being modeled.
+
+Locate the Linux tree, normally `~/linux`, and record:
+
+- `git rev-parse HEAD`, nearest release/tag if useful, and whether the tree is
+  clean;
+- AMDGPU/KFD UAPI declarations and implementation files reached by the
+  operation;
+- configuration or version conditions that select alternate behavior.
+
+If the requested kernel revision is not present, ask for it or clearly bound
+the conclusion to the available commit. Do not fetch or checkout over local
+Linux work without permission.
+
+## 2. Build a behavior trace
+
+Use [the parity checklist](references/kernel-parity-checklist.md). Trace both
+sides independently before comparing them:
+
+1. entry point and ABI layout;
+2. validation order and first returned error;
+3. lookup, ownership, permissions, and process/device context;
+4. locks, references, lifetime, and concurrency;
+5. state changes and side effects;
+6. copy-to/from-user behavior and partial failure;
+7. cleanup, rollback, close, process exit, and device loss;
+8. version, capability, and architecture gates.
+
+In rocjitsu, inspect the interposer, simulated driver, VM/model ownership, RPC
+or daemon path, and tests. Verify the behavior is implemented in the correct
+layer rather than duplicated between interposer and simulation.
+
+## 3. Compare observable behavior
+
+Create a compact matrix with rows for meaningful cases and columns for Linux,
+rocjitsu, evidence, and status. Include success plus relevant invalid, missing,
+duplicate, boundary, racing, and teardown cases. Compare:
+
+- accepted inputs and validation precedence;
+- return values, `errno`, output fields, and side effects;
+- object identity, reference ownership, and cross-process visibility;
+- ordering, wakeup, blocking, timeout, and cancellation behavior;
+- memory alignment, offset, size, mapping, coherence, and lifetime rules;
+- behavior after partial setup, close, process exit, reset, or failure.
+
+Do not require internal algorithm or lock-for-lock parity. Require observable
+parity and sufficient synchronization for rocjitsu's own threading model.
+
+## 4. Prove or bound each mismatch
+
+For each candidate mismatch:
+
+- verify the complete Linux and rocjitsu paths, including error and cleanup;
+- check existing tests, comments, history, UAPI version gates, and deliberate
+  emulator limitations;
+- construct the smallest practical rocjitsu regression test or non-mutating
+  repro that distinguishes the behaviors;
+- run focused tests when possible, then the relevant broader CTest; exercise
+  the behavior through Mirage when Mirage owns setup or environment wiring.
+
+If hardware is needed, describe the missing experiment and expected observable
+result; do not imply it ran. Private material may increase confidence but may
+not appear as evidence.
+
+## 5. Report
+
+Start with one of: `MATCH`, `MISMATCH`, `INTENTIONAL DIFFERENCE`,
+`VERSION-DEPENDENT`, or `INCONCLUSIVE`.
+
+For every mismatch provide:
+
+- rocjitsu `file:line` and public Linux `file:line`, with both commits;
+- triggering inputs and state;
+- Linux behavior, rocjitsu behavior, and user-visible impact;
+- why the difference is not merely an implementation detail;
+- a minimal fix in the correct rocjitsu layer;
+- a regression test, including Mirage integration when relevant;
+- confidence and any unverified condition.
+
+End with the behavior matrix, tests run, unavailable checks, and remaining
+version/hardware risk. If confidential references were consulted, do not
+mention that fact in the report.

--- a/emulation/.agents/skills/rocjitsu-kernel-parity/references/kernel-parity-checklist.md
+++ b/emulation/.agents/skills/rocjitsu-kernel-parity/references/kernel-parity-checklist.md
@@ -1,0 +1,67 @@
+# Linux AMDGPU/KFD parity checklist
+
+Use the applicable sections to construct a behavior trace. Search by public
+UAPI operation and symbol rather than assuming a fixed Linux directory layout.
+
+## ABI and dispatch
+
+- UAPI struct size, field width, signedness, padding, alignment, reserved bits,
+  compat behavior, and in/out direction.
+- Ioctl command number, flags, version/capability gates, and device node.
+- Input copy timing, output initialization, partial output, and copy failure.
+- Return convention and the first error selected when multiple inputs are
+  invalid.
+
+## Object and process model
+
+- Which process, PASID, file, device, VM, or session owns the object.
+- Lookup keys, duplicate creation, stale handles, cross-device use, and
+  cross-process visibility.
+- Reference acquisition/release and behavior during close, process exit, exec,
+  fork, reset, or device removal.
+- Locking scope and ordering around lookup, mutation, wait, and destruction.
+
+## Queues and doorbells
+
+- Queue type and property validation, ring size/alignment, priority, percentage,
+  CU masks, EOP/context-save areas, and architecture-specific requirements.
+- Queue ID allocation/reuse and update/destroy behavior.
+- Doorbell allocation, mapping offset, width, page sharing, permissions, and
+  lifetime.
+- Ordering between user writes, packet visibility, queue activation, preemption,
+  eviction, and teardown.
+
+## Events and synchronization
+
+- Event type, auto/manual reset, signal state, event-page slots, and limits.
+- Wait-any/wait-all, zero events, duplicate IDs, timeout conversion/rounding,
+  interruption, spurious wakeups, and destruction while waiting.
+- Memory ordering between state publication and wakeup.
+- Exception/event payload population and reset semantics.
+
+## Memory and mappings
+
+- Allocation flags, permitted combinations, size/alignment/overflow, device and
+  NUMA policy, and accounting.
+- VA reservation, map/unmap granularity, overlap, partial ranges, peer devices,
+  and rollback after partial success.
+- `mmap` offset encoding, page protection, caching, permissions, and mapping
+  lifetime after handle/file close.
+- Userptr pinning, invalidation, process memory, coherence, and fault behavior.
+- Scratch, LDS, GWS, VRAM, system memory, and aperture distinctions relevant to
+  the operation.
+
+## Topology and properties
+
+- Node/device enumeration stability, IDs, capability flags, cache/link
+  properties, and public sysfs formatting.
+- Behavior when data is absent, zero, unknown, hot-added, or removed.
+- Units and conversions for clocks, memory, cache, links, and firmware fields.
+
+## Error, rollback, and observability
+
+- Exact `errno` and validation precedence.
+- State remaining after allocation, mapping, registration, or copyout fails.
+- Idempotence of cleanup and behavior for duplicate destroy/unmap.
+- Logs and diagnostics do not substitute for return behavior.
+- Tests observe public outcomes, not private implementation coincidences.

--- a/emulation/AGENTS.md
+++ b/emulation/AGENTS.md
@@ -38,13 +38,21 @@ GitHub on its own.
 On Linux development systems, agents may assume these optional sources exist:
 
 - `~/linux` contains a Linux source checkout for public AMDGPU/KFD behavior.
-- `~/referance` contains confidential reference PDFs. The spelling of this
-  directory is intentional.
+- `~/reference/public/shader-programming-guides` contains public AMD shader
+  programming guides, ISA manuals, and architecture documentation. Download
+  public documents from the
+  [AMD GPU architecture programming documentation](https://gpuopen.com/amd-gpu-architecture-programming-documentation/)
+  page when local copies are useful.
+- `~/reference/confidential` contains confidential reference PDFs.
 
-Confidential references may be consulted but must never be quoted, named,
-linked, committed, summarized, or exposed through paths or internal
-terminology. Findings must stand on code in this repository, public source, or
-reproducible tests. Treat uncertain publication status as confidential.
+Keep public and confidential documents in their respective subdirectories.
+Confidential references and their contents may be consulted but must never be
+quoted, named, linked, copied, committed, summarized, or exposed through paths,
+metadata, screenshots, logs, prompts, generated artifacts, or internal
+terminology. Do not upload them to external services or include their contents
+in issues, pull requests, reviews, commits, tests, or chat. Findings must stand
+on code in this repository, public sources, or reproducible tests. Treat
+uncertain publication status as confidential.
 
 ## Validation baseline
 

--- a/emulation/AGENTS.md
+++ b/emulation/AGENTS.md
@@ -1,0 +1,117 @@
+# Emulation agent guide
+
+These instructions apply to changes under `emulation/`. Read the nearest
+component documentation before editing code.
+
+## Authoritative guidance
+
+- For rocjitsu C++, Python, and CMake, `rocjitsu/docs/style.md` is the final
+  authority. If another document or nearby code disagrees with it, follow the
+  style guide and call out the discrepancy.
+- Read `rocjitsu/CONTRIBUTING.md` before changing rocjitsu architecture,
+  generated ISA code, or tests.
+- Read `mirage/docs/architecture.md` and `mirage/docs/building.md` before
+  changing Mirage. Preserve crate boundaries and established Rust patterns.
+- For dashboard work, also follow `mirage/dashboard/web/AGENTS.md`.
+
+Prefer extending existing libraries over adding dependencies or duplicate
+helpers. Subject to the rocjitsu style guide, keep documentation proportional
+to the user-visible contract and non-obvious design decisions; do not add
+comments that merely narrate code.
+
+## Review and maintenance skills
+
+Portable Agent Skills are cataloged in `.agents/skills/README.md`:
+
+- `emulation-review` reviews a GitHub pull request, a branch, local changes, or
+  named files.
+- `rocjitsu-kernel-parity` compares rocjitsu behavior with Linux AMDGPU/KFD.
+- `emulation-rebase` safely rebases a branch when some of its commits or
+  equivalent changes have already landed.
+
+Use these workflows when the request matches. They are read-only unless the
+user explicitly asks for fixes or history changes. A review never posts to
+GitHub on its own.
+
+## Local reference material
+
+On Linux development systems, agents may assume these optional sources exist:
+
+- `~/linux` contains a Linux source checkout for public AMDGPU/KFD behavior.
+- `~/referance` contains confidential reference PDFs. The spelling of this
+  directory is intentional.
+
+Confidential references may be consulted but must never be quoted, named,
+linked, committed, summarized, or exposed through paths or internal
+terminology. Findings must stand on code in this repository, public source, or
+reproducible tests. Treat uncertain publication status as confidential.
+
+## Validation baseline
+
+Choose the smallest tests that exercise the changed behavior, then expand when
+risk warrants it. Record every command run and distinguish failures from tests
+that were unavailable.
+
+Emulation builds and runs on Linux. The commands below use a POSIX shell; a
+non-Linux host should run them in the project's Linux development environment
+rather than inventing an unsupported native workflow.
+
+### rocjitsu
+
+From `emulation/rocjitsu`:
+
+```sh
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+ctest --test-dir build --output-on-failure
+cd lib/python && python -m pytest amdisa/tests/ -x
+```
+
+Run relevant sanitizer or clang-tidy configurations for concurrency, memory,
+ABI, or lifetime-sensitive changes. ISA changes must update the amdisa
+generator, regenerate every affected ISA with multi-ISA mode, and include all
+resulting generated files; never hand-edit generated output.
+
+### Mirage
+
+From `emulation/mirage`:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace
+```
+
+For dashboard changes, from `emulation/mirage/dashboard/web`:
+
+```sh
+npm run lint
+npm run build
+npm test
+npm run test:e2e
+```
+
+Rust formatting and lint behavior are defined by `cargo fmt`, `cargo clippy`,
+and established code in the owning crate. Dashboard formatting and lint
+behavior are defined by its TypeScript and ESLint configuration; Rete.js work
+also follows `mirage/dashboard/web/AGENTS.md`.
+
+Mirage changes that affect emulator discovery, profiles, session lifecycle,
+environment wiring, FFI, or rocjitsu integration need an integration test in
+addition to unit tests. Integration tests live in `mirage/tests/`; use the
+existing lifecycle, daemon, container, or matrix E2E suite that owns the
+behavior. Do not omit Mirage validation merely because most of a change is in
+rocjitsu.
+
+## Review quality bar
+
+- Read complete changed files and the owning, calling, cleanup, and test paths.
+- Prioritize correctness, races, deadlocks, ownership, ABI compatibility,
+  generated-code integrity, and cross-component behavior over cosmetic issues.
+- Require a concrete mechanism and evidence for every finding. State
+  uncertainty instead of converting suspicion into a defect.
+- Report findings by severity with exact file and line, impact, evidence, and a
+  minimal suggested fix or test. Deduplicate overlapping findings.
+- Robust code includes focused negative, boundary, failure, cleanup, and
+  concurrency tests where applicable. More tests are not automatically better;
+  each test should protect a meaningful behavior.

--- a/emulation/AGENTS.md
+++ b/emulation/AGENTS.md
@@ -33,6 +33,16 @@ Use these workflows when the request matches. They are read-only unless the
 user explicitly asks for fixes or history changes. A review never posts to
 GitHub on its own.
 
+## GitHub write approval
+
+Never push commits, branches, tags, rebased history, or other content to
+GitHub—and never create or modify pull requests, issues, comments, reviews,
+labels, releases, or other remote state—without the user's explicit approval
+for that specific write. A request to review, edit, commit, rebase, prepare a
+pull request, or follow a skill is not approval to publish. Prepare and validate
+changes locally, show what would be written, and ask immediately before the
+GitHub write. Approval for one write does not authorize later writes.
+
 ## Local reference material
 
 On Linux development systems, agents may assume these optional sources exist:

--- a/emulation/README.md
+++ b/emulation/README.md
@@ -10,11 +10,16 @@ should also follow [AGENTS.md](AGENTS.md); the rocjitsu
 [style guide](rocjitsu/docs/style.md) is authoritative for rocjitsu changes.
 
 Linux development systems may provide a public kernel source checkout at
-`~/linux` and confidential reference PDFs at `~/referance` (intentional
-spelling). Confidential material must stay local and must not be quoted, named,
-linked, committed, summarized, or exposed through internal terminology. Review
-conclusions must be supportable from repository code, public sources, or
-reproducible tests.
+`~/linux`. Put public shader programming guides, ISA manuals, and architecture
+documents in `~/reference/public/shader-programming-guides`; public documents
+are available from
+[AMD GPU architecture programming documentation](https://gpuopen.com/amd-gpu-architecture-programming-documentation/).
+Keep confidential reference PDFs separately in `~/reference/confidential`.
+Confidential material and its contents must stay local and must not be quoted,
+named, linked, copied, committed, summarized, uploaded, or exposed through
+paths, metadata, logs, prompts, generated artifacts, or internal terminology.
+Review conclusions must be supportable from repository code, public sources,
+or reproducible tests.
 
 ## Components
 

--- a/emulation/README.md
+++ b/emulation/README.md
@@ -2,6 +2,20 @@
 
 [work board](https://github.com/orgs/ROCm/projects/164)
 
+## Contributing and agent workflows
+
+Shared code-review, Linux kernel-parity, and partial-merge rebase workflows are
+available as portable [Agent Skills](.agents/skills/README.md). Coding agents
+should also follow [AGENTS.md](AGENTS.md); the rocjitsu
+[style guide](rocjitsu/docs/style.md) is authoritative for rocjitsu changes.
+
+Linux development systems may provide a public kernel source checkout at
+`~/linux` and confidential reference PDFs at `~/referance` (intentional
+spelling). Confidential material must stay local and must not be quoted, named,
+linked, committed, summarized, or exposed through internal terminology. Review
+conclusions must be supportable from repository code, public sources, or
+reproducible tests.
+
 ## Components
 
 - [Rocjitsu](emulation/rocjitsu/) — JIT-based AMD GPU emulator. The core engine that interprets/translates AMDGPU ISA and models GPU blocks so unmodified ROCm apps can run without a physical GPU.

--- a/emulation/rocjitsu/CONTRIBUTING.md
+++ b/emulation/rocjitsu/CONTRIBUTING.md
@@ -59,33 +59,9 @@ Before writing new infrastructure, check these existing libraries:
 
 ## Code style
 
-- **C++20.** Use standard library features (concepts, ranges, `std::format`).
-- **Formatting.** The repo uses pre-commit hooks (clang-format for C++,
-  black for Python, gersemi for CMake). Install once and run before
-  every commit:
-  ```bash
-  pip install pre-commit
-  pre-commit install
-  pre-commit run --all-files
-  ```
-  The config lives at the repo root (`rocm-systems/.pre-commit-config.yaml`).
-- **Naming.** Use clear, descriptive names. No single-letter variables.
-  Non-trivial types with methods must be `class` (not `struct`).
-  Maintain `public:` / `protected:` / `private:` ordering.
-- **Comments.** Use `@brief` / `@details` doxygen style when documenting
-  public APIs. Avoid decorative comment lines (`---`, `===`). Default
-  to writing no comments; only comment when the *why* is non-obvious.
-- **No `fprintf`.** Always use `Logger` from `util/log.h`.
-- **Exceptions.** Exceptions are used only for unrecoverable errors
-  during initialization and configuration (`ConfigError`) or when
-  encountering invalid/unimplemented instructions during code object
-  parsing (`InvalidInst`, `UnimplementedInst`). All exception types
-  live in `util/except.h`. Do not throw exceptions in simulation hot
-  paths (event handlers, instruction execution, cache lookups). Do not
-  add `try`/`catch` blocks unless you are at a boundary that must
-  translate an error (e.g., the C API layer). There is no general
-  exception safety guarantee — assume code is not exception-safe
-  unless explicitly documented.
+Follow [docs/style.md](docs/style.md), the authoritative style guide for
+rocjitsu C++, Python, CMake, formatting, naming, documentation, logging, and
+error handling.
 
 ## ISA codegen workflow
 


### PR DESCRIPTION
## Motivation

Provide reusable, cross-agent workflows for reviewing and maintaining ROCm emulation changes. The workflows aim to improve review consistency, enforce the rocjitsu style guide, validate Mirage integration, and make domain-specific analysis safer and more evidence-driven.

## Technical Details

- Added portable Agent Skills under skills for:
  - Reviewing GitHub PRs, branches, local changes, commit ranges, and selected files.
  - Comparing rocjitsu KFD/AMDGPU behavior against Linux kernel source.
  - Rebasing branches when commits or equivalent changes have already landed upstream.
- Added focused review, kernel-parity, and commit-equivalence checklists using progressive disclosure.
- Added AGENTS.md with shared architecture, style, testing, generated-code, and documentation guidance.
- Made style.md authoritative for rocjitsu reviews.
- Added explicit Mirage Rust, dashboard, lifecycle, and integration-test requirements.
- Documented optional local reference locations:
  - Linux source at `~/linux`.
  - Public shader programming guides under `~/reference/public/shader-programming-guides`.
  - Confidential references under `~/reference/confidential`.
- Linked the public AMD GPU architecture and ISA documentation:
  https://gpuopen.com/amd-gpu-architecture-programming-documentation/
- Added strict safeguards against exposing confidential reference material.
- Added an explicit requirement to obtain user approval immediately before every GitHub write, including pushes and PR updates.
- Used the open Agent Skills and AGENTS.md formats for compatibility with GitHub Copilot, Claude, OpenAI/Codex, and other supporting agents.

## Issue Tracking

#9116

## Test Plan

- Validate every new skill with the Agent Skills reference validator.
- Run repository pre-commit hooks against all changed files.
- Check the complete patch for whitespace errors.
- Verify that no obsolete `~/referance` paths remain.
- Verify the branch diff contains only documentation and agent-workflow files.

## Test Result

- All three Agent Skills passed the Agent Skills reference validator.
- All applicable pre-commit hooks passed.
- `git diff --check` passed.
- No obsolete `~/referance` paths remain.
- The PR contains nine documentation and agent-workflow files with no product-code changes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.