### PR TITLE
hipFile: Update Python changelog for hipFile 0.4.0

### DIFF
--- a/projects/hipfile/python/CHANGELOG.md
+++ b/projects/hipfile/python/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to the hipFile Python bindings will be documented in this fi
 
 ## [0.4.0.dev0]
 
+### Added
+
+- Cython and Python API support for the hipFile async stream I/O APIs.
+- High-level `FileHandle.read_async` / `FileHandle.write_async` methods for
+  submitting asynchronous I/O on a stream.
+- `Stream` context manager for registering and deregistering a HIP stream.
+- `AsyncIOHandle` holding the async operation's I/O parameters and receiving
+  the transferred byte count once the stream completes.
+- `supports_async()` to report whether the loaded library implements the async
+  API.
+
 ## [0.3.0.dev0]
 
 ### Added


### PR DESCRIPTION
## Motivation

Updates the hipFile Python CHANGELOG. Sits on top of #9114 

## Technical Details

Describes the Async API support that was added.

## Issue Tracking

JIRA ID: AIHIPFILE-242

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
