### PR TITLE
feat(rocprofiler-sdk): add firmware feature-support query layer

### DIFF
--- a/projects/rocprofiler-sdk/source/docs/api-reference/counter_collection_services.rst
+++ b/projects/rocprofiler-sdk/source/docs/api-reference/counter_collection_services.rst
@@ -333,7 +333,7 @@ Firmware restrictions are defined alongside counter definitions in the ``config.
               expression: 400*reduce(SQ_WAIT_INST_LDS,sum)/reduce(SQ_WAVES,sum)/reduce(GRBM_GUI_ACTIVE,max)
 
       # Required: Firmware restrictions schema version
-      fw_restriction_schema_version: 1
+      fw-restriction-schema-version: 2
 
       # List of firmware restrictions
       firmware_restrictions:
@@ -355,9 +355,18 @@ Firmware restrictions are defined alongside counter definitions in the ``config.
             - "gfx1100"
             - "gfx1101"
 
+        # Example: per-feature capability floor (queried at runtime, not a hard
+        # startup requirement)
+        - firmware_type: CP
+          feature: pc_sampling_host_trap
+          min_version: 210
+          reason: "PC sampling host-trap mode requires CP firmware version 210 or newer on MI300 devices"
+          affected_architectures:
+            - "gfx942"
+
 **Schema elements:**
 
-- ``fw_restriction_schema_version`` (required): Integer specifying the schema version (currently 1).
+- ``fw-restriction-schema-version`` (required): Integer specifying the schema version (currently 2; the ``feature`` field was added in version 2).
 - ``firmware_restrictions``: Array of restriction objects consisting of the following fields:
 
   - ``firmware_type`` (required): Type of firmware being restricted. Supported types include:
@@ -368,6 +377,7 @@ Firmware restrictions are defined alongside counter definitions in the ``config.
   - ``min_version`` (required): Integer specifying the minimum firmware version.
   - ``reason`` (optional): Human-readable explanation for the restriction.
   - ``affected_architectures`` (optional): Array of GPU architecture names, such as "gfx940" and "gfx942" liable to meet this restriction. If empty, the restriction applies to all the architectures.
+  - ``feature`` (optional): String naming a firmware-gated feature. When present, the entry is treated as a *per-feature capability floor* rather than a hard startup requirement: it is **not** enforced during the startup firmware validation and does not prevent ROCprofiler-SDK from initializing. Instead, services query it at runtime (via the internal feature-support API) to decide whether functionality requiring that firmware feature can be enabled on a given agent. When ``feature`` is absent (or empty), the entry is a hard floor as before and is enforced at startup.
 
 Counter definitions file location
 ++++++++++++++++++++++++++++++++++

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/firmware_restrictions.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/firmware_restrictions.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -31,8 +31,8 @@
 
 #include <dlfcn.h>
 #include <fmt/format.h>
+#include <algorithm>
 #include <fstream>
-#include <mutex>
 
 #include "yaml-cpp/exceptions.h"
 #include "yaml-cpp/node/convert.h"
@@ -75,6 +75,117 @@ findViaEnvironment(const std::string& filename)
     return findViaInstallPath(filename);
 }
 
+std::optional<std::vector<FirmwareRestriction>>
+load_installed_firmware_restrictions()
+{
+    auto fw_restrictions_path = findViaEnvironment("config.yaml");
+
+    if(!common::filesystem::exists(fw_restrictions_path))
+    {
+        ROCP_WARNING << "Counter definitions file '" << fw_restrictions_path
+                     << "' does not exist, skipping firmware validation";
+        return std::nullopt;
+    }
+
+    std::ifstream file(fw_restrictions_path);
+    if(!file.is_open())
+    {
+        ROCP_WARNING << "Failed to open counter definitions file '" << fw_restrictions_path << "'";
+        return std::nullopt;
+    }
+
+    std::string yaml_content((std::istreambuf_iterator<char>(file)),
+                             std::istreambuf_iterator<char>());
+
+    if(yaml_content.empty())
+    {
+        ROCP_INFO << "Counter definitions file '" << fw_restrictions_path << "' is empty";
+        return std::nullopt;
+    }
+
+    ROCP_INFO << "Checking firmware restrictions from '" << fw_restrictions_path << "'";
+
+    auto restrictions = parse_firmware_restrictions(yaml_content);
+    if(!restrictions)
+        ROCP_WARNING << "Failed to parse firmware restrictions from '" << fw_restrictions_path
+                     << "'";
+    return restrictions;
+}
+
+// Parsed once; shared by the startup gate and feature queries.
+const std::optional<std::vector<FirmwareRestriction>>&
+installed_firmware_restrictions()
+{
+    static const auto restrictions = load_installed_firmware_restrictions();
+    return restrictions;
+}
+
+// A restriction applies to an architecture when its affected list is empty
+// (applies to all) or contains that architecture.
+bool
+affects(const FirmwareRestriction& restriction, std::string_view arch)
+{
+    return restriction.affected_architectures.empty() ||
+           std::any_of(restriction.affected_architectures.begin(),
+                       restriction.affected_architectures.end(),
+                       [&](const auto& a) { return arch == a; });
+}
+
+// Select the agent firmware version relevant to a restriction's firmware_type,
+// or nullopt for an unrecognized type.
+std::optional<uint32_t>
+firmware_version(std::string_view type, uint32_t cp, uint32_t sdma)
+{
+    if(type == "CP" || type == "MEC") return cp;
+    if(type == "SDMA") return sdma;
+    return std::nullopt;
+}
+
+bool
+check_agents_against_restrictions(const std::vector<FirmwareRestriction>& restrictions)
+{
+    bool result = true;
+
+    for(const auto* agent : rocprofiler::agent::get_agents())
+    {
+        if(!agent || agent->type != ROCPROFILER_AGENT_TYPE_GPU) continue;
+
+        const std::string agent_arch = agent->name ? agent->name : "";
+        if(agent_arch.empty())
+        {
+            ROCP_WARNING << "Agent " << agent->node_id << " has no architecture name";
+            continue;
+        }
+
+        for(const auto& restriction : restrictions)
+        {
+            // Feature-scoped floors are queried via agent_supports_feature().
+            if(!restriction.feature.empty()) continue;
+            if(!affects(restriction, agent_arch)) continue;
+
+            auto agent_fw_version = firmware_version(
+                restriction.firmware_type, agent->fw_version.Value, agent->sdma_fw_version.Value);
+            if(!agent_fw_version)
+            {
+                ROCP_WARNING << "Unknown firmware type '" << restriction.firmware_type
+                             << "' in restriction for agent " << agent->node_id;
+                continue;
+            }
+
+            if(*agent_fw_version < restriction.min_version)
+            {
+                ROCP_WARNING << "Agent " << agent->node_id << " (" << agent_arch << ") has "
+                             << restriction.firmware_type << " firmware version "
+                             << *agent_fw_version << " which is below minimum required version "
+                             << restriction.min_version << ". Reason: " << restriction.reason;
+                result = false;
+            }
+        }
+    }
+
+    return result;
+}
+
 }  // namespace
 
 std::optional<std::vector<FirmwareRestriction>>
@@ -84,10 +195,8 @@ parse_firmware_restrictions(const std::string& yaml_content)
 
     try
     {
-        // Parse the YAML content
         YAML::Node root = YAML::Load(yaml_content);
 
-        // Check for required top-level key
         if(!root["rocprofiler-sdk"])
         {
             return std::nullopt;
@@ -95,25 +204,22 @@ parse_firmware_restrictions(const std::string& yaml_content)
 
         YAML::Node sdk_node = root["rocprofiler-sdk"];
 
-        // Check for schema version
         if(!sdk_node["fw-restriction-schema-version"])
         {
             return std::nullopt;
         }
 
-        // For future reference on how to read schema versions:
-        // int schema_version = sdk_node["fw-restriction-schema-version"].as<int>();
-        // if(schema_version != 1)
-        // {
-        //     return std::nullopt;
-        // }
+        // Schema 2 added the optional per-feature `feature` field.
+        const auto schema_version = sdk_node["fw-restriction-schema-version"].as<int>();
+        if(schema_version < 1 || schema_version > 2)
+        {
+            return std::nullopt;
+        }
 
-        // Parse firmware restrictions if present
         if(sdk_node["firmware_restrictions"])
         {
             YAML::Node restrictions = sdk_node["firmware_restrictions"];
 
-            // Iterate through each firmware restriction entry
             for(const auto& fw_entry : restrictions)
             {
                 auto& restriction = result.emplace_back(FirmwareRestriction{});
@@ -127,8 +233,9 @@ parse_firmware_restrictions(const std::string& yaml_content)
                 restriction.min_version   = fw_entry["min_version"].as<uint32_t>();
                 restriction.reason =
                     (fw_entry["reason"] ? fw_entry["reason"].as<std::string>() : std::string{});
+                restriction.feature =
+                    (fw_entry["feature"] ? fw_entry["feature"].as<std::string>() : std::string{});
 
-                // Parse affected architectures
                 if(fw_entry["affected_architectures"])
                 {
                     for(const auto& arch : fw_entry["affected_architectures"])
@@ -149,133 +256,67 @@ parse_firmware_restrictions(const std::string& yaml_content)
 bool
 check_agent_firmware_restrictions(const std::string& yaml_content)
 {
-    bool result = true;  // Assume valid until proven otherwise
-
-    // Parse firmware restrictions from YAML
     auto restrictions_opt = parse_firmware_restrictions(yaml_content);
     if(!restrictions_opt)
     {
         ROCP_WARNING << "Failed to parse firmware restrictions from YAML content";
-        return true;  // If parsing fails, assume no restrictions
+        return true;
     }
 
-    const auto& restrictions = *restrictions_opt;
-    // Get all agents
-    auto agents = rocprofiler::agent::get_agents();
-    // Check each agent against applicable firmware restrictions
-    for(const auto* agent : agents)
-    {
-        if(!agent || agent->type != ROCPROFILER_AGENT_TYPE_GPU)
-        {
-            continue;  // Skip non-GPU agents
-        }
-
-        // Get agent architecture (name field contains gfx architecture)
-        const std::string agent_arch = agent->name ? agent->name : "";
-        if(agent_arch.empty())
-        {
-            ROCP_WARNING << "Agent " << agent->node_id << " has no architecture name";
-            continue;
-        }
-
-        // Check each firmware restriction
-        for(const auto& restriction : restrictions)
-        {
-            // Check if this architecture is affected by this restriction
-            bool is_affected = restriction.affected_architectures.empty();
-            for(const auto& affected_arch : restriction.affected_architectures)
-            {
-                if(agent_arch == affected_arch)
-                {
-                    is_affected = true;
-                    break;
-                }
-            }
-
-            if(!is_affected)
-            {
-                continue;  // This restriction doesn't apply to this architecture
-            }
-
-            // Get firmware version based on type
-            uint32_t agent_fw_version = 0;
-            if(restriction.firmware_type == "CP" || restriction.firmware_type == "MEC")
-            {
-                agent_fw_version = agent->fw_version.Value;
-            }
-            else if(restriction.firmware_type == "SDMA")
-            {
-                agent_fw_version = agent->sdma_fw_version.Value;
-            }
-            else
-            {
-                ROCP_WARNING << "Unknown firmware type '" << restriction.firmware_type
-                             << "' in restriction for agent " << agent->node_id;
-                continue;
-            }
-
-            // Check if firmware version meets minimum requirement
-            if(agent_fw_version < restriction.min_version)
-            {
-                ROCP_WARNING << "Agent " << agent->node_id << " (" << agent_arch << ") has "
-                             << restriction.firmware_type << " firmware version "
-                             << agent_fw_version << " which is below minimum required version "
-                             << restriction.min_version << ". Reason: " << restriction.reason;
-                result = false;
-            }
-        }
-    }
-
-    return result;
+    return check_agents_against_restrictions(*restrictions_opt);
 }
 
 bool
 check_installed_firmware_restrictions()
 {
-    static std::once_flag check_flag;
-    static bool           result = true;
-
-    std::call_once(check_flag, []() {
-        result = true;  // Assume valid until proven otherwise
-
-        // Find the counter definitions YAML file that contains firmware restrictions
-        auto fw_restrictions_path = findViaEnvironment("config.yaml");
-
-        // Check if file exists
-        if(!common::filesystem::exists(fw_restrictions_path))
-        {
-            ROCP_WARNING << "Counter definitions file '" << fw_restrictions_path
-                         << "' does not exist, skipping firmware validation";
-            return;  // No restrictions file means no restrictions
-        }
-
-        // Read the file content
-        std::ifstream file(fw_restrictions_path);
-        if(!file.is_open())
-        {
-            ROCP_WARNING << "Failed to open counter definitions file '" << fw_restrictions_path
-                         << "'";
-            return;  // If we can't read the file, assume no restrictions
-        }
-
-        std::string yaml_content((std::istreambuf_iterator<char>(file)),
-                                 std::istreambuf_iterator<char>());
-        file.close();
-
-        if(yaml_content.empty())
-        {
-            ROCP_INFO << "Counter definitions file '" << fw_restrictions_path
-                      << "' is empty, no restrictions to apply";
-            return;
-        }
-
-        ROCP_INFO << "Checking firmware restrictions from '" << fw_restrictions_path << "'";
-
-        // Use the existing function to perform the actual check
-        result = check_agent_firmware_restrictions(yaml_content);
-    });
+    static const bool result = []() {
+        const auto& restrictions = installed_firmware_restrictions();
+        return restrictions ? check_agents_against_restrictions(*restrictions) : true;
+    }();
 
     return result;
+}
+
+std::optional<bool>
+evaluate_feature_support(const std::vector<FirmwareRestriction>& restrictions,
+                         std::string_view                        agent_arch,
+                         uint32_t                                cp_fw_version,
+                         uint32_t                                sdma_fw_version,
+                         std::string_view                        feature)
+{
+    if(feature.empty()) return std::nullopt;
+
+    bool any_matched = false;
+    bool all_met     = true;
+
+    for(const auto& restriction : restrictions)
+    {
+        if(restriction.feature != feature || !affects(restriction, agent_arch)) continue;
+
+        auto agent_fw_version =
+            firmware_version(restriction.firmware_type, cp_fw_version, sdma_fw_version);
+        if(!agent_fw_version) return std::nullopt;  // malformed applicable entry
+
+        any_matched = true;
+        if(*agent_fw_version < restriction.min_version) all_met = false;
+    }
+
+    if(!any_matched) return std::nullopt;
+    return all_met;
+}
+
+std::optional<bool>
+agent_supports_feature(const rocprofiler_agent_t* agent, std::string_view feature)
+{
+    if(agent == nullptr || agent->type != ROCPROFILER_AGENT_TYPE_GPU || agent->name == nullptr ||
+       agent->name[0] == '\0')
+        return std::nullopt;
+
+    const auto& restrictions = installed_firmware_restrictions();
+    if(!restrictions) return std::nullopt;
+
+    return evaluate_feature_support(
+        *restrictions, agent->name, agent->fw_version.Value, agent->sdma_fw_version.Value, feature);
 }
 
 }  // namespace counters

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/firmware_restrictions.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/firmware_restrictions.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,9 +22,12 @@
 
 #pragma once
 
+#include <rocprofiler-sdk/agent.h>
+
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace rocprofiler
@@ -38,6 +41,8 @@ struct FirmwareRestriction
     uint32_t                 current_version        = 0;   // Current firmware version on agent
     std::string              reason                 = {};  // Reason for the restriction
     std::vector<std::string> affected_architectures = {};  // Architectures requiring this minimum
+    std::string              feature                = {};  // Optional feature name; empty = hard
+                                                           // global floor
 };
 
 // Parse YAML string and return a vector of FirmwareRestriction structs
@@ -52,10 +57,27 @@ check_agent_firmware_restrictions(const std::string& yaml_content);
 
 // Check all agents against firmware restrictions from installed YAML file
 // Returns false if any agent has firmware below minimum requirements
-// Uses std::call_once to ensure this check is only performed once
-// Looks for config.yaml in the same way as metrics.cpp
+// The result is computed once and cached; feature-scoped entries are excluded.
 bool
 check_installed_firmware_restrictions();
+
+// Query whether an agent meets the firmware floor(s) for a named feature.
+// Feature entries are capability metadata, excluded from the startup gate.
+//   std::nullopt -> no matching entry (undeclared, arch mismatch, invalid agent)
+//   false        -> a matching feature floor exists and the agent is below it
+//   true         -> matching feature floor(s) exist and all are met
+// Callers must not treat std::nullopt as "feature unsupported": it means the
+// query could not be evaluated. Only false means an evaluated floor was not met.
+std::optional<bool>
+agent_supports_feature(const rocprofiler_agent_t* agent, std::string_view feature);
+
+// Pure evaluator behind agent_supports_feature(), exposed for testing.
+std::optional<bool>
+evaluate_feature_support(const std::vector<FirmwareRestriction>& restrictions,
+                         std::string_view                        agent_arch,
+                         uint32_t                                cp_fw_version,
+                         uint32_t                                sdma_fw_version,
+                         std::string_view                        feature);
 
 }  // namespace counters
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
@@ -61,7 +61,7 @@ target_link_libraries(
 
 set(ROCPROFILER_LIB_COUNTER_TEST_SOURCES
     metrics_test.cpp evaluate_ast_test.cpp dimension.cpp core.cpp code_object_loader.cpp
-    device_counting.cpp firmware_restrictions.cpp)
+    device_counting.cpp firmware_restrictions_test.cpp)
 set(ROCPROFILER_LIB_COUNTER_TEST_HEADERS code_object_loader.hpp device_counting.hpp)
 
 add_executable(counter-tests)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/firmware_restrictions_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/firmware_restrictions_test.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -80,6 +80,103 @@ rocprofiler-sdk:
     EXPECT_EQ((*result)[1].reason, "SDMA firmware below 150 causes instability");
     ASSERT_EQ((*result)[1].affected_architectures.size(), 1);
     EXPECT_EQ((*result)[1].affected_architectures[0], "gfx1030");
+}
+
+TEST(FirmwareRestrictions, FeatureFieldParsing)
+{
+    std::string yaml_content = R"(
+rocprofiler-sdk:
+  counters-schema-version: 1
+  counters: []
+  fw-restriction-schema-version: 2
+  firmware_restrictions:
+    - firmware_type: CP
+      feature: pc_sampling_host_trap
+      min_version: 210
+      affected_architectures:
+        - "gfx942"
+    - firmware_type: SDMA
+      min_version: 150
+)";
+
+    auto result = parse_firmware_restrictions(yaml_content);
+
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->size(), 2);
+
+    EXPECT_EQ((*result)[0].feature, "pc_sampling_host_trap");
+    EXPECT_EQ((*result)[0].min_version, 210);
+    EXPECT_EQ((*result)[1].feature, "");  // absent feature -> empty (hard floor)
+}
+
+TEST(FirmwareRestrictions, FeatureEntryExcludedFromStartupGate)
+{
+    // A feature entry with an impossibly high min_version and empty arch list
+    // (which would otherwise match every agent) must not fail the startup gate.
+    std::string yaml_content = R"(
+rocprofiler-sdk:
+  counters-schema-version: 1
+  counters: []
+  fw-restriction-schema-version: 2
+  firmware_restrictions:
+    - firmware_type: MEC
+      feature: some_optional_feature
+      min_version: 99999
+      affected_architectures: []
+)";
+
+    EXPECT_TRUE(check_agent_firmware_restrictions(yaml_content));
+}
+
+TEST(FirmwareRestrictions, SchemaVersionRange)
+{
+    auto with_version = [](int v) {
+        return "rocprofiler-sdk:\n  fw-restriction-schema-version: " + std::to_string(v) +
+               "\n  firmware_restrictions: []\n";
+    };
+    EXPECT_TRUE(parse_firmware_restrictions(with_version(1)).has_value());
+    EXPECT_TRUE(parse_firmware_restrictions(with_version(2)).has_value());
+    EXPECT_FALSE(parse_firmware_restrictions(with_version(0)).has_value());
+    EXPECT_FALSE(parse_firmware_restrictions(with_version(3)).has_value());
+}
+
+TEST(FirmwareRestrictions, AgentSupportsFeatureInvalidAgent)
+{
+    EXPECT_EQ(agent_supports_feature(nullptr, "pc_sampling_host_trap"), std::nullopt);
+}
+
+// Deterministic coverage of the evaluate_feature_support() tri-state logic.
+TEST(FirmwareRestrictions, EvaluateFeatureSupport)
+{
+    const std::vector<FirmwareRestriction> restrictions = {
+        FirmwareRestriction{"CP", 210, 0, "", {"gfx942"}, "pc_sampling_host_trap"},
+        FirmwareRestriction{"SDMA", 95, 0, "", {"gfx942"}, "pc_sampling_host_trap"},
+        FirmwareRestriction{"CP", 100, 0, "", {}, "global_feature"},
+        FirmwareRestriction{"BOGUS", 100, 0, "", {"gfx942"}, "weird_feature"},
+    };
+
+    struct
+    {
+        std::string_view    arch;
+        uint32_t            cp;
+        uint32_t            sdma;
+        std::string_view    feature;
+        std::optional<bool> expected;
+    } cases[] = {
+        {"gfx942", 999, 999, "nonexistent", std::nullopt},            // undeclared feature
+        {"gfx908", 999, 999, "pc_sampling_host_trap", std::nullopt},  // arch not affected
+        {"gfx942", 210, 95, "pc_sampling_host_trap", true},           // all floors met
+        {"gfx942", 200, 95, "pc_sampling_host_trap", false},          // CP below floor
+        {"gfx1200", 100, 0, "global_feature", true},                  // empty arch = all
+        {"gfx1200", 99, 0, "global_feature", false},                  // empty arch, below
+        {"gfx942", 999, 999, "weird_feature", std::nullopt},          // unknown firmware type
+        {"gfx942", 999, 999, "", std::nullopt},                       // empty feature query
+    };
+
+    for(const auto& c : cases)
+        EXPECT_EQ(evaluate_feature_support(restrictions, c.arch, c.cp, c.sdma, c.feature),
+                  c.expected)
+            << "feature=" << c.feature << " arch=" << c.arch;
 }
 
 TEST(FirmwareRestrictions, EmptyRestrictionsList)

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
@@ -15194,7 +15194,7 @@ rocprofiler-sdk:
             - gfx1151
             - gfx1152
           expression: reduce(TCP_TCP_TA_REQ_STALL,sum)
-  fw-restriction-schema-version: 1
+  fw-restriction-schema-version: 2
   firmware_restrictions:
     - affected_architectures:
         - gfx940


### PR DESCRIPTION
## Summary

Extend the rocprofiler-sdk firmware restrictions mechanism so a minimum-firmware-version floor can be scoped to a named capability instead of only being a global hard requirement. This adds the query layer that lets services ask, at runtime, whether the installed firmware supports a specific feature on a given agent.

## Changes

- Add an optional per-entry `feature` field to the `firmware_restrictions` schema (bumped `fw-restriction-schema-version` to `2`). Entries with a `feature` are capability metadata and are **excluded** from the startup hard gate; entries without one remain hard floors enforced at startup (unchanged behavior).
- Add `agent_supports_feature(const rocprofiler_agent_t*, std::string_view)` returning `std::optional<bool>`: `nullopt` = no matching entry (undeclared / arch mismatch / invalid agent), `false` = a matching floor exists and the agent is below it, `true` = all matching floors met. Services decide for themselves whether a `nullopt`/`false` result is fatal.
- Factor the core matching into a pure `evaluate_feature_support()` so the tri-state logic is unit-testable without on-disk config or a live agent; share the arch-match and firmware-type-select helpers with the existing startup gate; cache the parsed installed restrictions.
- Add an illustrative `feature` entry and schema-version docs; strip a pre-existing trailing-whitespace line in the edited config block.
- Add deterministic unit tests: `feature` parsing, startup-gate exclusion, schema-version range, invalid-agent handling, and a table-driven evaluator test covering undeclared / arch-mismatch / below-floor / all-met / empty-arch / unknown-firmware-type / empty-feature cases.

This is a foundational query layer; wiring specific consumers (e.g. PC sampling host-trap) is tracked separately in the linked issue.

## Testing

Built and ran on a gfx942 (MI300) host inside the `therock-lttng-gfx942` ROCm 7.14 container (amdclang++ 23.0.0git, cmake 3.28):

- `cmake -B build -S . -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=/opt/rocm -DROCPROFILER_BUILD_TESTS=ON`
- `cmake --build build --target counter-tests -j 32` — compiles and links cleanly, no warnings/errors on the changed files.
- `./bin/counter-tests --gtest_filter='FirmwareRestrictions.*'` — **21/21 tests pass**, including the 5 new cases (`FeatureFieldParsing`, `FeatureEntryExcludedFromStartupGate`, `SchemaVersionRange`, `AgentSupportsFeatureInvalidAgent`, `EvaluateFeatureSupport`).

`clang-format` and `check-yaml` pre-commit hooks pass on the changed files.

## Tracking

Issue #9130
