### PR TITLE
perf(rocjitsu): avoid repeated race trace disassembly

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.h
@@ -72,11 +72,6 @@ struct DisasmCache {
     entries_.emplace(pc, inst.disassemble());
   }
 
-  void record(uint64_t pc, std::string disasm) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    entries_.try_emplace(pc, std::move(disasm));
-  }
-
   std::unordered_map<uint64_t, std::string> to_map() const {
     std::lock_guard<std::mutex> lock(mutex_);
     return entries_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.h
@@ -65,7 +65,12 @@ std::string formatTrace(const RingBuffer<uint64_t, 256> &trace,
 /// compact, monotonic text range; helper/trampoline code can be far away from
 /// the first PC observed for the dispatch.
 struct DisasmCache {
-  void record(uint64_t pc, const Instruction &inst) { record(pc, inst.disassemble()); }
+  void record(uint64_t pc, const Instruction &inst) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (entries_.contains(pc))
+      return;
+    entries_.emplace(pc, inst.disassemble());
+  }
 
   void record(uint64_t pc, std::string disasm) {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -1601,6 +1601,29 @@ TEST(DisasmCacheTest, HandlesNonMonotonicPcOrder) {
   EXPECT_EQ(disasm.at(0x100002a100), "s_endpgm");
 }
 
+TEST(DisasmCacheTest, DisassemblesOnlyFirstInstructionAtPc) {
+  class ObservableInstruction final : public Instruction {
+  public:
+    ObservableInstruction() : Instruction("s_count", nullptr) {}
+    bool was_disassembled() const { return !disassembly_.empty(); }
+  };
+
+  plugins::race_detector::DisasmCache cache;
+  ObservableInstruction first;
+  ObservableInstruction duplicate;
+
+  // DisasmCache is keyed by the absolute instruction PC. The value itself is
+  // arbitrary here; using the same synthetic PC proves that a newly decoded
+  // instruction at an already-cached address is not disassembled again.
+  constexpr uint64_t synthetic_pc = 0x100;
+  cache.record(synthetic_pc, first);
+  cache.record(synthetic_pc, duplicate);
+
+  EXPECT_TRUE(first.was_disassembled());
+  EXPECT_FALSE(duplicate.was_disassembled());
+  EXPECT_EQ(cache.to_map().at(synthetic_pc), "s_count");
+}
+
 TEST(RaceDetectorPluginOutputTest, DispatchLineUsesQuestionMarksForUnresolvedKernel) {
   StringSink sink;
   ExecutionPluginGroup plugin_group;

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -1593,8 +1593,10 @@ TEST(FormatTraceTest, ConflictBeforeTraceWindow) {
 
 TEST(DisasmCacheTest, HandlesNonMonotonicPcOrder) {
   plugins::race_detector::DisasmCache cache;
-  cache.record(0x540024b100, "s_nop 0");
-  cache.record(0x100002a100, "s_endpgm");
+  Instruction high_instruction("s_nop 0", nullptr);
+  Instruction low_instruction("s_endpgm", nullptr);
+  cache.record(0x540024b100, high_instruction);
+  cache.record(0x100002a100, low_instruction);
 
   auto disasm = cache.to_map();
   EXPECT_EQ(disasm.at(0x540024b100), "s_nop 0");


### PR DESCRIPTION
## Motivation

The race detector caches disassembly by instruction PC for use in race reports. It does this repeatedly, even when revisiting the same program count (PC). This overhead was visible in a emulated hipBLASLt workloads from ROCm/rocm-libraries#9363,. 

## Technical Details

Check the cache under an already existing mutex before formatting the instruction. The first disassembly for a PC is still retained and later observations do not replace it. A regression test verifies that a second instruction object at the same PC is not disassembled.

## Issue Tracking

JIRA ID: AIHPBLAS-3605
^ hipblast uses rocjitsu for race detection in CI

## Test Plan

- One unit test, and verify a speed-up locally on the workload in question 

## Test Result

- Race-detector overhead fell from approximately 19–27% to approximately 9–10%.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
