### PR TITLE
rocr: Fix coredump generation for multi-XCC targets

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
@@ -770,6 +770,7 @@ typedef struct
 	HSAuint64 ControlStackUsedInBytes; // Must be 4-Byte aligned
 	HsaUserContextSaveAreaHeader *SaveAreaHeader;
 	HSAuint64 Reserved2;		// runtime/system CU assignment
+	HSAuint64 SaveAreaAllocSize;	// Size of the full save area, per XCC
 } HsaQueueInfo;
 
 typedef struct _HsaQueueResource

--- a/projects/rocr-runtime/libhsakmt/src/debug.c
+++ b/projects/rocr-runtime/libhsakmt/src/debug.c
@@ -708,7 +708,7 @@ static HSAKMT_STATUS hsaKmtGetCoreDeviceInfoCtx(HsaKFDContext *ctx,
 	/* SIMD/compute topology */
 	device_info->simd_count = props.NumFComputeCores;
 	device_info->max_waves_per_simd = props.MaxWavesPerSIMD;
-	device_info->array_count = props.NumArrays * props.NumShaderBanks;
+	device_info->array_count = (props.NumArrays * props.NumShaderBanks) / props.NumXcc;
 	device_info->simd_arrays_per_engine = props.NumArrays;
 	device_info->num_xcc = props.NumXcc;
 

--- a/projects/rocr-runtime/libhsakmt/src/queues.c
+++ b/projects/rocr-runtime/libhsakmt/src/queues.c
@@ -1002,6 +1002,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtGetQueueInfoCtx(HsaKFDContext *ctx,
 	QueueInfo->QueueDetailError = 0;
 	QueueInfo->QueueTypeExtended = 0;
 	QueueInfo->SaveAreaHeader = q->ctx_save_restore;
+	QueueInfo->SaveAreaAllocSize = q->ctx_save_restore_size;
 
 	return HSAKMT_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
@@ -345,10 +345,11 @@ static hsa_status_t build_lightweight_coredump_ranges(MemoryRegionFilter& filter
 
       debug_print("Added CWSR area range: %#" PRIx64 " - %#" PRIx64 " (size: %zu)\n",
                   reinterpret_cast<uint64_t>(queue_info.SaveAreaHeader),
-                  reinterpret_cast<uint64_t>(queue_info.SaveAreaHeader) + queue_info.SaveAreaSizeInBytes,
-                  queue_info.SaveAreaSizeInBytes);
+                  reinterpret_cast<uint64_t>(queue_info.SaveAreaHeader)
+                    + (queue_info.SaveAreaAllocSize * gpu_agent->properties().NumXcc),
+                  queue_info.SaveAreaAllocSize * gpu_agent->properties().NumXcc);
       filter.add_range(reinterpret_cast<uint64_t>(queue_info.SaveAreaHeader),
-                       queue_info.SaveAreaSizeInBytes);
+                       queue_info.SaveAreaAllocSize * gpu_agent->properties().NumXcc);
     }
   }
 
@@ -425,7 +426,7 @@ static bool GetCoreQueueInfo(AMD::AqlQueue* queue, kfd_queue_snapshot_entry& ent
     return false;
   }
   entry.ctx_save_restore_address = (uint64_t)queue_info.SaveAreaHeader;
-  entry.ctx_save_restore_area_size = (uint32_t)queue_info.SaveAreaSizeInBytes;
+  entry.ctx_save_restore_area_size = (uint32_t)queue_info.SaveAreaAllocSize;
 
   return true;
 }


### PR DESCRIPTION
## Motivation

ROCgdb testsuite revealed that core dumps produced by ROCr were invalid for multi XCC targets.

## Technical Details

Testing revealed 2 issues:
- The CWSR area size reported in the kfd_queue_snapshot_entry reported the number of bytes used by the wave region of the CWSR buffer, just for XCC0.  The debugger however needs to know the full size of reserved per XCC so it can deduce the base of each XCC save region.
- The filter for lightweight core dump was only marking save area region for XCC0 as required.  This was unlikely to be an issue in practice as the allocation covers all the XCCs so the filter should keep it completely, but this still needs fixing.
- The "array_count" field of kfd_dbg_device_info_entry contained the total number of arrays instead of the number of arrays per XCC.

This patch fixes both of those issues.

This patch raises questions regarding the fields contained in HsaQueueInfo.  All the CWSR related fields in this struct only contain XCC0 status, which is probably not sufficient for milti-XCC systems. This patch does not aim at addressing all of the uses of this structure, instead it adds the necessary information required to make CWSR work correctly.

Tested on gfx1031 and gfx942 with ROCgdb's testsuite.

## Issue Tracking

JIRA ID: AIROCGDB-637

## Test Plan

Validate using ROCgdb's testsuite locally, as CI is not able to validate coredump creation.  Need validation on all major GPU families.

## Test Result

Test pass on gfx1031 and gfx942 so far.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
