### PR TITLE
fix(clr): load KPACK code objects per device

### DIFF
--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -758,60 +758,68 @@ hipError_t FatBinaryInfo::ExtractKpackBinary(const std::vector<hip::Device*>& de
     return hipErrorInvalidValue;
   }
 
-  // Build architecture priority list from devices
-  // For each device, add native ISA first, then generic fallback.
-  // Reservation in the list is pessimistically assuming there is a generic fallback for each
-  // device.
-  std::vector<std::string> arch_list;
-  arch_list.reserve(devices.size() * 2);
+  // Add KPACK load objects for each device.
+  // For each device type, the KPACK load returns one code object
+  // selected from the architecture priority list by using devices
+  // isa-name or generic name.
+  // Code object needs to be loaded for each device in system separately because
+  // there can be different types of GPUs on the same system and code-object
+  // is GPU type specific. (gfx1201, gfx90a)
   for (auto device : devices) {
+    std::vector<std::string> arch_list;
+    // Architecture names
+    // 1) exact devices ISA name, examples:
+    //  - amdgcn-amd-amdhsa--gfx1100
+    //  - amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack-
+    // 2) generic fallback name, examples:
+    //  - amdgcn-amd-amdhsa--gfx11-generic
+    //  - can also be empty string for some arch like gfx90a
+    arch_list.reserve(2);
     std::string device_name = device->devices()[0]->isa().isaName();
     arch_list.push_back(device_name);
 
-    // Add generic fallback
+    // Add generic fallback arch-name
     auto generic_name = TargetToGeneric(device_name);
     if (!generic_name.empty()) {
       arch_list.push_back(generic_name);
     }
-  }
 
-  // Convert to C-style array for kpack API
-  std::vector<const char*> arch_ptrs;
-  arch_ptrs.reserve(arch_list.size());
-  for (const auto& arch : arch_list) {
-    arch_ptrs.push_back(arch.c_str());
-  }
+    // Convert arch-list to C-style array for kpack API
+    std::vector<const char*> arch_ptrs;
+    arch_ptrs.reserve(arch_list.size());
+    for (const auto& arch : arch_list) {
+      arch_ptrs.push_back(arch.c_str());
+    }
 
-  // Load code object from kpack archive
-  void* code_object = nullptr;
-  size_t code_object_size = 0;
+    // Load device type specific code object from kpack archive
+    void* code_object = nullptr;
+    size_t code_object_size = 0;
 
-  // binary_path is used to resolve relative paths to kpack archives.
-  // bundle_index identifies which code object to load for multi-TU binaries.
-  // The kernel_name (used for TOC lookup) is embedded in the HIPK metadata.
-  kpack_error_t err =
-      kpack_load_code_object(getHipKpackCache(), params.metadata, fname_.c_str(),
-                             static_cast<uint32_t>(params.bundle_index),
-                             arch_ptrs.data(), arch_ptrs.size(), &code_object, &code_object_size);
+    // Binary_path is used to resolve relative paths to kpack archives.
+    // Bundle_index identifies which code object to load for multi-TU binaries.
+    // The kernel_name (used for TOC lookup) is embedded in the HIPK metadata.
+    kpack_error_t err =
+        kpack_load_code_object(getHipKpackCache(), params.metadata, fname_.c_str(),
+                               static_cast<uint32_t>(params.bundle_index), arch_ptrs.data(),
+                               arch_ptrs.size(), &code_object, &code_object_size);
 
-  if (err != KPACK_SUCCESS) {
-    LogPrintfError("kpack_load_code_object failed with error: %d", err);
-    return hipErrorInvalidImage;
-  }
+    if (err != KPACK_SUCCESS) {
+      LogPrintfError("kpack_load_code_object failed with error: %d; isa name: %s", err,
+                     device_name.c_str());
+      return hipErrorInvalidImage;
+    }
 
-  // Add code object to all devices. The kpack buffer isn't backed by a file
-  // on disk, so no fd is passed.
-  for (auto device : devices) {
+    // The kpack buffer isn't backed by a file on disk, so no fd is passed.
     hipError_t hip_err =
         AddDevProgram(device, code_object, code_object_size, amd::Os::FDescInit());
     if (hip_err != hipSuccess) {
       kpack_free_code_object(code_object);
       return hip_err;
     }
-  }
 
-  // Track allocation for cleanup in destructor
-  code_obj_allocations_.insert(code_object);
+    // Track allocation for cleanup in destructor
+    code_obj_allocations_.insert(code_object);
+  }
 
   return hipSuccess;
 #endif

--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -758,22 +758,24 @@ hipError_t FatBinaryInfo::ExtractKpackBinary(const std::vector<hip::Device*>& de
     return hipErrorInvalidValue;
   }
 
-  // Load KPACK code objects per device.
-  // For each device, kpack selects a code object from an architecture
-  // priority list (device ISA name first, then a generic fallback).
-  // This must be done per device because heterogeneous systems can have
-  // different GPU ISAs (e.g., gfx1201 vs gfx90a).
+  // Load one KPACK code object per unique device ISA. Devices with the
+  // same ISA can share the extracted buffer, while heterogeneous devices
+  // require separate architecture selection.
+  std::unordered_map<std::string, std::vector<hip::Device*>> devices_by_isa;
   for (auto device : devices) {
+    devices_by_isa[device->devices()[0]->isa().isaName()].push_back(device);
+  }
+
+  for (const auto& [device_name, matching_devices] : devices_by_isa) {
     std::vector<std::string> arch_list;
     // Architecture names
-    // 1) exact devices ISA name, examples:
+    // 1) exact device ISA name, examples:
     //  - amdgcn-amd-amdhsa--gfx1100
     //  - amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack-
     // 2) generic fallback name, examples:
     //  - amdgcn-amd-amdhsa--gfx11-generic
     //  - can also be empty string for some arch like gfx90a
     arch_list.reserve(2);
-    std::string device_name = device->devices()[0]->isa().isaName();
     arch_list.push_back(device_name);
 
     // Add generic fallback arch-name
@@ -807,12 +809,19 @@ hipError_t FatBinaryInfo::ExtractKpackBinary(const std::vector<hip::Device*>& de
       return hipErrorInvalidImage;
     }
 
-    // The kpack buffer isn't backed by a file on disk, so no fd is passed.
-    hipError_t hip_err =
-        AddDevProgram(device, code_object, code_object_size, amd::Os::FDescInit());
-    if (hip_err != hipSuccess) {
-      kpack_free_code_object(code_object);
-      return hip_err;
+    // Add device type specific kpack code object buffer for each similar type of device.
+    // The kpack buffer is shared by devices with the same ISA and is not
+    // backed by a file on disk, so no fd is passed.
+    for (auto device : matching_devices) {
+      hipError_t hip_err =
+          AddDevProgram(device, code_object, code_object_size, amd::Os::FDescInit());
+      if (hip_err != hipSuccess) {
+        LogPrintfError(
+            "AddDevProgram failed with error: %d; isa name: %s; device id: %d", hip_err,
+            device_name.c_str(), device->deviceId());
+        kpack_free_code_object(code_object);
+        return hip_err;
+      }
     }
 
     // Track allocation for cleanup in destructor

--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -758,13 +758,11 @@ hipError_t FatBinaryInfo::ExtractKpackBinary(const std::vector<hip::Device*>& de
     return hipErrorInvalidValue;
   }
 
-  // Add KPACK load objects for each device.
-  // For each device type, the KPACK load returns one code object
-  // selected from the architecture priority list by using devices
-  // isa-name or generic name.
-  // Code object needs to be loaded for each device in system separately because
-  // there can be different types of GPUs on the same system and code-object
-  // is GPU type specific. (gfx1201, gfx90a)
+  // Load KPACK code objects per device.
+  // For each device, kpack selects a code object from an architecture
+  // priority list (device ISA name first, then a generic fallback).
+  // This must be done per device because heterogeneous systems can have
+  // different GPU ISAs (e.g., gfx1201 vs gfx90a).
   for (auto device : devices) {
     std::vector<std::string> arch_list;
     // Architecture names

--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -804,9 +804,9 @@ hipError_t FatBinaryInfo::ExtractKpackBinary(const std::vector<hip::Device*>& de
                                arch_ptrs.size(), &code_object, &code_object_size);
 
     if (err != KPACK_SUCCESS) {
-      LogPrintfError("kpack_load_code_object failed with error: %d; isa name: %s", err,
-                     device_name.c_str());
-      return hipErrorInvalidImage;
+      LogPrintfWarning("Could not load kpack object for %s, err: %d",
+                     device_name.c_str(), err);
+      continue;
     }
 
     // Add device type specific kpack code object buffer for each similar type of device.
@@ -817,8 +817,8 @@ hipError_t FatBinaryInfo::ExtractKpackBinary(const std::vector<hip::Device*>& de
           AddDevProgram(device, code_object, code_object_size, amd::Os::FDescInit());
       if (hip_err != hipSuccess) {
         LogPrintfError(
-            "AddDevProgram failed with error: %d; isa name: %s; device id: %d", hip_err,
-            device_name.c_str(), device->deviceId());
+            "Could not add kpack object for %s, device id: %d, err: %d",
+            device_name.c_str(), device->deviceId(), hip_err);
         kpack_free_code_object(code_object);
         return hip_err;
       }

--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -766,6 +766,25 @@ hipError_t FatBinaryInfo::ExtractKpackBinary(const std::vector<hip::Device*>& de
     devices_by_isa[device->devices()[0]->isa().isaName()].push_back(device);
   }
 
+  std::vector<int> registered_device_ids;
+  registered_device_ids.reserve(devices.size());
+  std::vector<void*> loaded_code_objects;
+  loaded_code_objects.reserve(devices_by_isa.size());
+
+  // Device and kpack code object cleanup method for error cases
+  auto rollback_kpack_state = [&]() {
+    for (int device_id : registered_device_ids) {
+      if (dev_programs_[device_id] != nullptr) {
+        dev_programs_[device_id]->release();
+        dev_programs_[device_id] = nullptr;
+      }
+    }
+    for (void* code_object : loaded_code_objects) {
+      code_obj_allocations_.erase(code_object);
+      kpack_free_code_object(code_object);
+    }
+  };
+
   for (const auto& [device_name, matching_devices] : devices_by_isa) {
     std::vector<std::string> arch_list;
     // Architecture names
@@ -803,29 +822,48 @@ hipError_t FatBinaryInfo::ExtractKpackBinary(const std::vector<hip::Device*>& de
                                static_cast<uint32_t>(params.bundle_index), arch_ptrs.data(),
                                arch_ptrs.size(), &code_object, &code_object_size);
 
-    if (err != KPACK_SUCCESS) {
-      LogPrintfWarning("Could not load kpack object for %s, err: %d",
-                     device_name.c_str(), err);
+    if (err == KPACK_ERROR_ARCHIVE_NOT_FOUND || err == KPACK_ERROR_ARCH_NOT_FOUND) {
+      LogPrintfWarning(
+          "Could not load device type specific kpack object for ISA %s, err: %d, host binary: %s",
+          device_name.c_str(), err, params.binary_path.c_str());
       continue;
     }
+    if (err != KPACK_SUCCESS) {
+      LogPrintfError(
+          "Failed to load device type specific kpack object for ISA %s, err: %d, "
+          "host binary: %s",
+          device_name.c_str(), err, params.binary_path.c_str());
+      rollback_kpack_state();
+      return hipErrorInvalidImage;
+    }
+
+    loaded_code_objects.push_back(code_object);
+    code_obj_allocations_.insert(code_object);
 
     // Add device type specific kpack code object buffer for each similar type of device.
     // The kpack buffer is shared by devices with the same ISA and is not
     // backed by a file on disk, so no fd is passed.
     for (auto device : matching_devices) {
+      registered_device_ids.push_back(device->deviceId());
       hipError_t hip_err =
           AddDevProgram(device, code_object, code_object_size, amd::Os::FDescInit());
       if (hip_err != hipSuccess) {
         LogPrintfError(
-            "Could not add kpack object for %s, device id: %d, err: %d",
+            "Could not add device type specific kpack object for %s, device id: %d, err: %d",
             device_name.c_str(), device->deviceId(), hip_err);
-        kpack_free_code_object(code_object);
+        rollback_kpack_state();
         return hip_err;
       }
     }
+  }
 
-    // Track allocation for cleanup in destructor
-    code_obj_allocations_.insert(code_object);
+  if (loaded_code_objects.empty()) {
+    // Return an error if no device-specific kpack code object was found for any device.
+    LogPrintfError(
+        "Could not find device type specific kpack code objects for any available device from "
+        "binary: %s",
+        params.binary_path.c_str());
+    return hipErrorInvalidKernelFile;
   }
 
   return hipSuccess;


### PR DESCRIPTION
KPACK previously selected one kpack code object belonging for the first device in a
combined architecture priority list and registered it for every visible device. 
On heterogeneous GPU systems, this assigns a code object belonging to first ISA device type
also to all other incompatible devices types on the system, causing a segmentation fault during kernel launch.

Pytorch application segfaulted if user tried to use cuda:1 device instead of default cuda:0 in systems which
have two or more different types of GPUs installed and visible. (Not hidden with HIP_VISIBLE_DEVICES)

Fix is to get a list of all ISA-device types on the system and try to load the device type specific kpack
object for each of device type and then register them for all GPUs that are same type.

There is however also a possibility that user has installed the rocm support only for some of the
supported device types which will cause that code object is found only for some of the device types.
User could for example have gfx90a and gfx1100 and has installed rocm device support only for gfx1100 by using
command: 

$ pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch torch[device-gfx1100] numpy
instead of using
$ pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch torch[device-gfx90a,device-gfx1100] numpy
or
$ pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch torch[device-all] numpy

Therefore the updated code will not return error if device type specific code is not found but instead will skip that
device type and try to load the device object for next device type.  Reason for this is that it is possible that user wants to use only a certain type of devices in it's applications and has by purpose uninstalled the kpack files for other types of GPUs. 

Instead of segfaulting, Pytorch application will after this patch "throw torch.AcceleratorError: CUDA error: invalid kernel file" if the device type specific kpack files are not installed/available/loaded for the GPU associated to cuda:x index that application try to use. 

Tools used:
        GPT-5.6 Sol Medium

Fixes: https://github.com/ROCm/TheRock/issues/6696

## Motivation

This fixes pytorch crash on systems which have more than 1 different GPUs
and pytorch application try to use other than default cuda/cuda:0 gpu instead
of making that GPU to be a first one with HIP_VISIBLE_DEVICES env variable.

## Technical Details

The problem was that old code assumed that all GPU devices in system
where same type and only loaded the GPU arch-type specific kpack code object
for the first GPU in system. If some of the GPUs on system where different type than
the first visible GPU, then the code object load/execution on that GPU failed causing
a segfault.

If all of the GPUs on system where similar (2 x gfx1201 for example) then there were not problem.
But if there were different types of GPUs like gfx90a and gfx1100 on same system
and application wanted to execute the code by using the CUDA:1 device,
then that caused segfault because there were only the device type code object loaded for CUDA:0 gpu.

Problem required that the ROCM and Pytorch binaries were converted to KPACK format. 

## Issue Tracking

https://github.com/ROCm/TheRock/issues/6696

## Test Plan

I have tested this issue manually 3 systems.
- system with 2 x gfx1251 (Worked also without fix because both GPUs were on same type)
- system with 1 x gfx90a + 1 x gfx1100 (Segfaults without the fix, works with the fix)
- system with 1 x gfx1100 + 1 x gfx1030 (Segfaults without the fix, works with the fix)
- system with only 1 GPU

To be able to land CI test code, we need to have dedicated machine with two different types of GPUs to run a following at least a following code:

```
import torch

print("PyTorch version:", torch.__version__, flush=True)
print("ROCm HIP version:", torch.version.hip, flush=True)
print(f"cuda:1: {torch.cuda.get_device_name(1)}", flush=True)
print(torch.zeros(1, device=f"cuda:1"), flush=True)

```

## Test Result

Tests described in https://github.com/ROCm/TheRock/issues/6696 now works without segfault.
More extensive test sequence which involves installing and uninstalling the device type specific kpack files for some GPU architectures is documented in comment section of this PR.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
