### PR TITLE
feat(rocr): add engine-type and SDMA engine-id queue info attributes

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocrctx.cpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.cpp
@@ -31,6 +31,7 @@ bool Hsa::LoadLib() {
   GET_ROCR_SYMBOL(hsa_agent_get_info)
   GET_ROCR_SYMBOL(hsa_queue_create)
   GET_ROCR_SYMBOL(hsa_queue_destroy)
+  GET_ROCR_SYMBOL(hsa_amd_queue_get_info)
   GET_ROCR_SYMBOL(hsa_queue_load_read_index_scacquire)
   GET_ROCR_SYMBOL(hsa_queue_load_read_index_relaxed)
   GET_ROCR_SYMBOL(hsa_queue_load_write_index_scacquire)

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -42,6 +42,7 @@ struct RocrEntryPoints {
   decltype(hsa_agent_get_info)* hsa_agent_get_info_;
   decltype(hsa_queue_create)* hsa_queue_create_;
   decltype(hsa_queue_destroy)* hsa_queue_destroy_;
+  decltype(hsa_amd_queue_get_info)* hsa_amd_queue_get_info_;
   decltype(hsa_queue_load_read_index_scacquire)* hsa_queue_load_read_index_scacquire_;
   decltype(hsa_queue_load_read_index_relaxed)* hsa_queue_load_read_index_relaxed_;
   decltype(hsa_queue_load_write_index_scacquire)* hsa_queue_load_write_index_scacquire_;
@@ -194,6 +195,10 @@ class Hsa : public amd::AllStatic {
   }
   static hsa_status_t queue_destroy(hsa_queue_t* queue) {
     return ROCR_DYN(hsa_queue_destroy)(queue);
+  }
+  static hsa_status_t amd_queue_get_info(hsa_queue_t* queue,
+                                         hsa_queue_info_attribute_t attribute, void* value) {
+    return ROCR_DYN(hsa_amd_queue_get_info)(queue, attribute, value);
   }
   static uint64_t queue_load_read_index_scacquire(const hsa_queue_t* queue) {
     return ROCR_DYN(hsa_queue_load_read_index_scacquire)(queue);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_sdma_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_sdma_queue.h
@@ -114,9 +114,7 @@ class SdmaQueue : public core::Queue, private core::LocalSignal, public core::Do
     assert(false && "SdmaQueue::ExecutePM4 is unimplemented");
   }
 
-  hsa_status_t GetInfo(hsa_queue_info_attribute_t attribute, void* value) override {
-    return HSA_STATUS_ERROR_INVALID_QUEUE;
-  }
+  hsa_status_t GetInfo(hsa_queue_info_attribute_t attribute, void* value) override;
 
   /// @brief Update write pointer and ring the SDMA queue doorbell.
   hsa_status_t RingDoorbell(uint64_t write_index);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -251,6 +251,11 @@ hsa_status_t AieAqlQueue::GetInfo(hsa_queue_info_attribute_t attribute, void* va
     case HSA_QUEUE_INFO_HW_ID:
       *static_cast<uint32_t*>(value) = public_handle()->id;
       break;
+    case HSA_AMD_QUEUE_INFO_ENGINE_TYPE:
+      *static_cast<hsa_amd_queue_engine_t*>(value) = HSA_AMD_QUEUE_ENGINE_AIE;
+      break;
+    case HSA_AMD_QUEUE_INFO_SDMA_ENGINE_ID:
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
     default:
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -562,6 +562,11 @@ hsa_status_t AqlQueue::GetInfo(hsa_queue_info_attribute_t attribute, void* value
     case HSA_AMD_QUEUE_INFO_VM_FAULT_REASON:
       *reinterpret_cast<uint32_t*>(value) = vm_fault_reason_;
       break;
+    case HSA_AMD_QUEUE_INFO_ENGINE_TYPE:
+      *static_cast<hsa_amd_queue_engine_t*>(value) = HSA_AMD_QUEUE_ENGINE_COMPUTE;
+      break;
+    case HSA_AMD_QUEUE_INFO_SDMA_ENGINE_ID:
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
     default:
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_sdma_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_sdma_queue.cpp
@@ -206,6 +206,19 @@ hsa_status_t SdmaQueue::Inactivate() {
   return status;
 }
 
+hsa_status_t SdmaQueue::GetInfo(hsa_queue_info_attribute_t attribute, void* value) {
+  switch (attribute) {
+    case HSA_AMD_QUEUE_INFO_ENGINE_TYPE:
+      *static_cast<hsa_amd_queue_engine_t*>(value) = HSA_AMD_QUEUE_ENGINE_SDMA;
+      return HSA_STATUS_SUCCESS;
+    case HSA_AMD_QUEUE_INFO_SDMA_ENGINE_ID:
+      *static_cast<uint32_t*>(value) = static_cast<uint32_t>(sdma_engine_id_);
+      return HSA_STATUS_SUCCESS;
+    default:
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+}
+
 hsa_status_t SdmaQueue::RingDoorbell(uint64_t write_index) {
   if (queue_wptr_ == nullptr || queue_doorbell_ == nullptr) {
     return HSA_STATUS_ERROR_INVALID_QUEUE;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
@@ -436,7 +436,9 @@ hsa_status_t InterceptQueue::GetInfo(hsa_queue_info_attribute_t attribute, void*
     case HSA_AMD_QUEUE_INFO_AGENT:
     case HSA_AMD_QUEUE_INFO_DOORBELL_ID: 
     case HSA_QUEUE_INFO_USE_COUNT:
-    case HSA_QUEUE_INFO_HW_ID: {
+    case HSA_QUEUE_INFO_HW_ID:
+    case HSA_AMD_QUEUE_INFO_ENGINE_TYPE:
+    case HSA_AMD_QUEUE_INFO_SDMA_ENGINE_ID: {
       if (!AMD::AqlQueue::IsType(wrapped.get())) return HSA_STATUS_ERROR_INVALID_QUEUE;
 
       AMD::AqlQueue* aqlQueue = static_cast<AMD::AqlQueue*>(wrapped.get());

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -81,9 +81,10 @@
  * - 1.27 - hsa_amd_queue_signal_external_semaphore, hsa_amd_queue_wait_external_semaphore
  * - 1.28 - hsa_amd_agent_info_t: HSA_AMD_AGENT_INFO_HOST_ALLOC_DMABUF_SUPPORTED
  * - 1.29 - hsa_amd_image_create_v2, hsa_amd_interop_map_buffer_with_size
+ * - 1.30 - hsa_amd_queue_get_info: engine type and SDMA engine ID
  */
 #define HSA_AMD_INTERFACE_VERSION_MAJOR 1
-#define HSA_AMD_INTERFACE_VERSION_MINOR 29
+#define HSA_AMD_INTERFACE_VERSION_MINOR 30
 
 #ifdef __cplusplus
 extern "C" {
@@ -3986,7 +3987,7 @@ typedef struct hsa_amd_queue_create_desc_s {
  * @retval ::HSA_STATUS_ERROR_INVALID_QUEUE_CREATION @p agent does not support
  * queues of the requested type, or a descriptor requested an @c engine_type
  * that is recognised by the API but not yet implemented by the runtime (for
- * example ::HSA_AMD_QUEUE_ENGINE_SDMA or ::HSA_AMD_QUEUE_ENGINE_AIE).
+ * example ::HSA_AMD_QUEUE_ENGINE_AIE).
  */
 hsa_status_t HSA_API hsa_amd_queue_create(
     hsa_agent_t agent,
@@ -4925,6 +4926,18 @@ typedef enum {
    * is true.  The type of this attribute is uint32_t.
    */
   HSA_AMD_QUEUE_INFO_VM_FAULT_REASON,
+  /*
+   * Hardware engine type targeted by this queue.
+   * The type of this attribute is hsa_amd_queue_engine_t.
+   */
+  HSA_AMD_QUEUE_INFO_ENGINE_TYPE,
+  /*
+   * Resolved hardware SDMA engine ID. Automatic SDMA queue creation returns
+   * the selected engine ID, never HSA_AMD_SDMA_ENGINE_ID_ANY. This attribute
+   * is valid only for queues whose engine type is HSA_AMD_QUEUE_ENGINE_SDMA.
+   * The type of this attribute is uint32_t.
+   */
+  HSA_AMD_QUEUE_INFO_SDMA_ENGINE_ID,
 } hsa_queue_info_attribute_t;
 
 hsa_status_t hsa_amd_queue_get_info(hsa_queue_t* queue, hsa_queue_info_attribute_t attribute,


### PR DESCRIPTION
Extend hsa_amd_queue_get_info with HSA_AMD_QUEUE_INFO_ENGINE_TYPE and HSA_AMD_QUEUE_INFO_SDMA_ENGINE_ID so callers can query a queue's engine class and its resolved hardware SDMA engine id. Implement the queries for SDMA/AQL/AIE queues, forward them through intercept queues, and expose the entry point via CLR's dynamic ROCr interface.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking
JIRA ID: AIRUNTIME-2549

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
