### PR TITLE
ci(rocprofiler-sdk): Fix omp lookup

### DIFF
--- a/projects/rocprofiler-sdk/docker/Dockerfile.ci
+++ b/projects/rocprofiler-sdk/docker/Dockerfile.ci
@@ -105,5 +105,6 @@ RUN set -euo pipefail; \
     mkdir -p /opt/rocm && \
     tar -xf /tmp/rocm-${GPU_TYPE}.tar.gz -C /opt/rocm && \
     rm -f /tmp/rocm-${GPU_TYPE}.tar.gz && \
-    printf '/opt/rocm/lib\n/opt/rocm/lib/llvm/lib\n/opt/rocm/lib/rocm_sysdeps/lib\n' > /etc/ld.so.conf.d/rocm.conf && \
-    ldconfig;
+    printf '/opt/rocm/lib\n/opt/rocm/lib/llvm/lib\n/opt/rocm/lib/llvm/lib/%s\n/opt/rocm/lib/rocm_sysdeps/lib\n' \
+       "$(/opt/rocm/lib/llvm/bin/amdclang --print-target-triple)" > /etc/ld.so.conf.d/rocm.conf && \
+    ldconfig

--- a/projects/rocprofiler-sdk/docker/Dockerfile.ci
+++ b/projects/rocprofiler-sdk/docker/Dockerfile.ci
@@ -91,6 +91,9 @@ RUN set -euo pipefail; \
     fi;
 
 # Nightly Tarball
+# The TheRock tarball ships the OpenMP runtime (libomp.so), LLVM, and bundled system deps under
+# lib/llvm/lib and lib/rocm_sysdeps/lib. These directories are not on the default dynamic-linker
+# search path. Register them via ldconfig
 RUN set -euo pipefail; \
     if [ $(grep -i "sles" /etc/os-release | wc -l) -gt 0 ]; then \
         source rocprofiler-sdk/bin/activate; \
@@ -101,4 +104,6 @@ RUN set -euo pipefail; \
     rm -rf /opt/rocm* && \
     mkdir -p /opt/rocm && \
     tar -xf /tmp/rocm-${GPU_TYPE}.tar.gz -C /opt/rocm && \
-    rm -f /tmp/rocm-${GPU_TYPE}.tar.gz;
+    rm -f /tmp/rocm-${GPU_TYPE}.tar.gz && \
+    printf '/opt/rocm/lib\n/opt/rocm/lib/llvm/lib\n/opt/rocm/lib/rocm_sysdeps/lib\n' > /etc/ld.so.conf.d/rocm.conf && \
+    ldconfig;

--- a/projects/rocprofiler-sdk/docker/Dockerfile.ci
+++ b/projects/rocprofiler-sdk/docker/Dockerfile.ci
@@ -18,7 +18,7 @@ ENV PATH=/opt/rh/gcc-toolset-11/root/usr/bin:/usr/lib64/openmpi/bin:/opt/rocm/bi
 ENV LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/llvm/lib:${LD_LIBRARY_PATH:-}
 
 # Debian/Ubuntu
-RUN set-euo pipefail; \
+RUN set -euo pipefail; \
     if [ -f /etc/debian_version ]; then \
         apt-get update && \
         apt-get install -y curl wget gpg python3 python3-pip build-essential coreutils software-properties-common cmake g++-11 g++-12 libdw-dev libsqlite3-dev libdrm-dev file autoconf pkg-config rpm libzstd-dev && \

--- a/projects/rocprofiler-sdk/docker/Dockerfile.ci
+++ b/projects/rocprofiler-sdk/docker/Dockerfile.ci
@@ -13,7 +13,7 @@ ENV HIP_PLATFORM=amd
 ENV HIP_RUNTIME=rocclr
 ENV HIP_COMPILER=amdclang++
 ENV LLVM_PATH=/opt/rocm/llvm
-ENV CMAKE_PREFIX_PATH=/opt/rocm
+ENV CMAKE_PREFIX_PATH=/opt/rocm:/opt/rocm/lib/rocm_sysdeps
 ENV PATH=/opt/rh/gcc-toolset-11/root/usr/bin:/usr/lib64/openmpi/bin:/opt/rocm/bin:/opt/rocm/llvm/bin:/usr/local/bin:~/.local/bin:${PATH}
 ENV LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/llvm/lib:${LD_LIBRARY_PATH:-}
 


### PR DESCRIPTION
## Motivation

~~Since #9059, OpenMP/OMPT tests fail at load: `libomp.so: cannot open shared object file` (\~26 tests red on every PR)~~

Root cause is upstream in TheRock, not https://github.com/ROCm/rocm-systems/pull/9059. [See this](https://github.com/ROCm/rocm-systems/pull/9170#issuecomment-5067040668).

## Fix
`libomp.so` ships under `lib/llvm/lib`, which isn't on the linker path. `Dockerfile.ci`
extracts the tarball but never registers it — so after extract, write
`/etc/ld.so.conf.d/rocm.conf` (`lib`, `lib/llvm/lib`, `lib/rocm_sysdeps/lib`) + `ldconfig`,
mirroring the devcontainer. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
https://github.com/ROCm/rocm-systems/issues/9169

Closes #9169.

## Test plan
- [ ] Rebuild base image (`rocprofiler-sdk-build-ci-docker-images`); effect lands when `*-latest` republishes.
- [ ] `ldconfig -p | grep libomp` resolves; openmp/ompt tests pass.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
