### PR TITLE
Add CPU unit tests for ArchInfo and Utils.

### DIFF
--- a/projects/rccl/test/ArchInfoTests.cpp
+++ b/projects/rccl/test/ArchInfoTests.cpp
@@ -6,7 +6,6 @@
 
 #include "archinfo.h"
 #include <gtest/gtest.h>
-#include <cstring>
 
 namespace RcclUnitTesting {
 

--- a/projects/rccl/test/ArchInfoTests.cpp
+++ b/projects/rccl/test/ArchInfoTests.cpp
@@ -1,0 +1,106 @@
+/*************************************************************************
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include "archinfo.h"
+#include <gtest/gtest.h>
+#include <cstring>
+
+namespace RcclUnitTesting {
+
+// ---------------------------------------------------------------------------
+// IsArchMatch
+// ---------------------------------------------------------------------------
+
+TEST(IsArchMatch, ExactMatchReturnsTrue) {
+    EXPECT_TRUE(IsArchMatch("gfx942", "gfx942"));
+}
+
+TEST(IsArchMatch, PrefixMatchReturnsTrue) {
+    // strlen("gfx94") == 5, strncmp("gfx942", "gfx94", 5) == 0
+    EXPECT_TRUE(IsArchMatch("gfx942", "gfx94"));
+}
+
+TEST(IsArchMatch, ShortPrefixMatchReturnsTrue) {
+    EXPECT_TRUE(IsArchMatch("gfx906", "gfx"));
+}
+
+TEST(IsArchMatch, DifferentArchReturnsFalse) {
+    EXPECT_FALSE(IsArchMatch("gfx942", "gfx906"));
+}
+
+TEST(IsArchMatch, DifferentFamilyReturnsFalse) {
+    EXPECT_FALSE(IsArchMatch("gfx1100", "gfx9"));
+}
+
+TEST(IsArchMatch, TargetLongerThanArchReturnsFalse) {
+    // "gfx942" vs "gfx9421" — target is longer, so strncmp of 7 chars will differ
+    EXPECT_FALSE(IsArchMatch("gfx942", "gfx9421"));
+}
+
+TEST(IsArchMatch, GfxFamilies) {
+    // RDNA3 gfx1100 should not match MI300 gfx942
+    EXPECT_FALSE(IsArchMatch("gfx1100", "gfx942"));
+    // gfx90a should match prefix gfx90
+    EXPECT_TRUE(IsArchMatch("gfx90a", "gfx90"));
+    // gfx90a should not match gfx906
+    EXPECT_FALSE(IsArchMatch("gfx90a", "gfx906"));
+}
+
+TEST(IsArchMatch, GfxWithSuffix) {
+    // arch strings from device properties may have xnack/sramecc stripped by
+    // GcnArchNameFormat, but IsArchMatch itself does a plain strncmp
+    EXPECT_TRUE(IsArchMatch("gfx942", "gfx942"));
+    EXPECT_FALSE(IsArchMatch("gfx942xnack+", "gfx950"));
+}
+
+// ---------------------------------------------------------------------------
+// convertGcnArchToGcnArchName
+// ---------------------------------------------------------------------------
+
+TEST(ConvertGcnArch, Gfx906From906) {
+    const char* name = nullptr;
+    convertGcnArchToGcnArchName("906", &name);
+    EXPECT_STREQ(name, "gfx906");
+}
+
+TEST(ConvertGcnArch, Gfx908From908) {
+    const char* name = nullptr;
+    convertGcnArchToGcnArchName("908", &name);
+    EXPECT_STREQ(name, "gfx908");
+}
+
+TEST(ConvertGcnArch, Gfx90aFrom910) {
+    const char* name = nullptr;
+    convertGcnArchToGcnArchName("910", &name);
+    EXPECT_STREQ(name, "gfx90a");
+}
+
+TEST(ConvertGcnArch, Gfx942From942) {
+    const char* name = nullptr;
+    convertGcnArchToGcnArchName("942", &name);
+    EXPECT_STREQ(name, "gfx942");
+}
+
+TEST(ConvertGcnArch, Gfx950From950) {
+    const char* name = nullptr;
+    convertGcnArchToGcnArchName("950", &name);
+    EXPECT_STREQ(name, "gfx950");
+}
+
+TEST(ConvertGcnArch, UnknownArchPassthrough) {
+    // An unrecognized gcnArch should be returned as-is
+    const char* name = nullptr;
+    convertGcnArchToGcnArchName("gfx1100", &name);
+    EXPECT_STREQ(name, "gfx1100");
+}
+
+TEST(ConvertGcnArch, EmptyStringPassthrough) {
+    const char* name = nullptr;
+    convertGcnArchToGcnArchName("", &name);
+    EXPECT_STREQ(name, "");
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -339,6 +339,7 @@ if(BUILD_TESTS)
       ParamTests.cpp
       ParameterApiTests.cpp
       ArgCheckTests.cpp
+      ArchInfoTests.cpp
       BootstrapBidirTests.cpp
       DdaAlltoAllThresholdTests.cpp
       DdaIpcEligibilityTests.cpp
@@ -351,6 +352,7 @@ if(BUILD_TESTS)
       RcclWrapTests.cpp
       TransportTests.cpp
       TimeoutTests.cpp
+      UtilsTests.cpp
       mem_manager/MemManagerTests.cpp
       graph/SearchTests.cpp
       graph/XmlTests.cpp

--- a/projects/rccl/test/UtilsTests.cpp
+++ b/projects/rccl/test/UtilsTests.cpp
@@ -6,13 +6,22 @@
 
 #include "utils.h"
 #include <gtest/gtest.h>
-#include <cstring>
-#include <cstdlib>
 
 namespace RcclUnitTesting {
 
 // ---------------------------------------------------------------------------
 // busIdToInt64 / int64ToBusId
+//
+// Expected values below follow the encoding implemented by busIdToInt64 in
+// src/misc/utils.cc (the source of truth): the ':' and '.' separators are
+// stripped from the PCI address DDDD:BB:DD.F, and the remaining hex digits are
+// concatenated and parsed as a single integer via strtol(..., 16).
+//
+//   "0000:03:00.0" -> "000003000" -> 0x3000
+//   "0001:0a:1f.3" -> "00010a1f3" -> 0x10a1f3
+//
+// int64ToBusId is the inverse, laying the integer back out as
+// domain[35:20] bus[19:12] device[11:4] function[3:0].
 // ---------------------------------------------------------------------------
 
 TEST(BusIdConversion, BusIdToInt64ZeroAddress) {
@@ -22,14 +31,12 @@ TEST(BusIdConversion, BusIdToInt64ZeroAddress) {
 }
 
 TEST(BusIdConversion, BusIdToInt64NonZeroBus) {
-    // "0000:03:00.0" => strip separators => "000003000" hex = 0x3000
     int64_t id = -1;
     EXPECT_EQ(busIdToInt64("0000:03:00.0", &id), ncclSuccess);
     EXPECT_EQ(id, 0x3000);
 }
 
 TEST(BusIdConversion, BusIdToInt64NonZeroDomain) {
-    // "0001:0a:1f.3" => "00010a1f3" hex = 0x10a1f3
     int64_t id = -1;
     EXPECT_EQ(busIdToInt64("0001:0a:1f.3", &id), ncclSuccess);
     EXPECT_EQ(id, 0x10a1f3);
@@ -61,6 +68,43 @@ TEST(BusIdConversion, RoundTripBusId) {
         EXPECT_EQ(int64ToBusId(id, output), ncclSuccess) << "input=" << input;
         EXPECT_STREQ(output, input) << "round-trip failed for " << input;
     }
+}
+
+// busIdToInt64 does not validate its input: it performs strtol-style parsing
+// that stops at the first character which is neither a hex digit nor a ':'/'.'
+// separator, then parses whatever digits it collected. It therefore always
+// returns ncclSuccess, even for input that is not a PCI bus ID at all. The
+// tests below pin that *observed* behavior (traced through src/misc/utils.cc)
+// rather than asserting a rejection that the implementation never performs.
+
+TEST(BusIdConversion, BusIdToInt64NonBusIdStringYieldsZero) {
+    // 'n' is not a hex digit, so parsing stops immediately and the collected
+    // (empty) digit string parses as 0.
+    int64_t id = -1;
+    EXPECT_EQ(busIdToInt64("not-a-bus-id", &id), ncclSuccess);
+    EXPECT_EQ(id, 0);
+}
+
+TEST(BusIdConversion, BusIdToInt64EmptyStringYieldsZero) {
+    int64_t id = -1;
+    EXPECT_EQ(busIdToInt64("", &id), ncclSuccess);
+    EXPECT_EQ(id, 0);
+}
+
+TEST(BusIdConversion, BusIdToInt64MissingSeparatorsParsesSameAsSeparated) {
+    // Separators are only skipped, never required, so the unseparated form of
+    // "0000:03:00.0" collects the identical digit string and yields 0x3000.
+    int64_t id = -1;
+    EXPECT_EQ(busIdToInt64("000003000", &id), ncclSuccess);
+    EXPECT_EQ(id, 0x3000);
+}
+
+TEST(BusIdConversion, BusIdToInt64StopsAtGarbageTail) {
+    // Parsing halts at 'z'; the valid prefix still yields 0x3000 and the
+    // trailing garbage is silently ignored.
+    int64_t id = -1;
+    EXPECT_EQ(busIdToInt64("0000:03:00.0zzz", &id), ncclSuccess);
+    EXPECT_EQ(id, 0x3000);
 }
 
 // ---------------------------------------------------------------------------
@@ -113,6 +157,36 @@ TEST(ParseStringList, MixedPortAndNoPort) {
     EXPECT_EQ(ifList[0].port, 1);
     EXPECT_STREQ(ifList[1].prefix, "eth1");
     EXPECT_EQ(ifList[1].port, -1);
+}
+
+// parseStringList only commits an entry when it has accumulated at least one
+// prefix character, so runs of commas simply produce no entry rather than an
+// empty one. It does no whitespace trimming: a space after a comma becomes part
+// of the next prefix. Both behaviors are confirmed from src/misc/utils.cc.
+
+TEST(ParseStringList, LeadingAndTrailingCommasProduceNoEmptyEntries) {
+    struct netIf ifList[8];
+    int n = parseStringList(",eth0,", ifList, 8);
+    EXPECT_EQ(n, 1);
+    EXPECT_STREQ(ifList[0].prefix, "eth0");
+    EXPECT_EQ(ifList[0].port, -1);
+}
+
+TEST(ParseStringList, DoubleCommasProduceNoEmptyEntries) {
+    struct netIf ifList[8];
+    int n = parseStringList("eth0,,eth1", ifList, 8);
+    EXPECT_EQ(n, 2);
+    EXPECT_STREQ(ifList[0].prefix, "eth0");
+    EXPECT_STREQ(ifList[1].prefix, "eth1");
+}
+
+TEST(ParseStringList, WhitespaceAfterCommaIsNotTrimmed) {
+    struct netIf ifList[8];
+    int n = parseStringList("eth0, eth1", ifList, 8);
+    EXPECT_EQ(n, 2);
+    EXPECT_STREQ(ifList[0].prefix, "eth0");
+    // The space is treated as an ordinary prefix character, so it is retained.
+    EXPECT_STREQ(ifList[1].prefix, " eth1");
 }
 
 TEST(ParseStringList, MaxListClamps) {

--- a/projects/rccl/test/UtilsTests.cpp
+++ b/projects/rccl/test/UtilsTests.cpp
@@ -1,0 +1,127 @@
+/*************************************************************************
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include "utils.h"
+#include <gtest/gtest.h>
+#include <cstring>
+#include <cstdlib>
+
+namespace RcclUnitTesting {
+
+// ---------------------------------------------------------------------------
+// busIdToInt64 / int64ToBusId
+// ---------------------------------------------------------------------------
+
+TEST(BusIdConversion, BusIdToInt64ZeroAddress) {
+    int64_t id = -1;
+    EXPECT_EQ(busIdToInt64("0000:00:00.0", &id), ncclSuccess);
+    EXPECT_EQ(id, 0);
+}
+
+TEST(BusIdConversion, BusIdToInt64NonZeroBus) {
+    // "0000:03:00.0" => strip separators => "000003000" hex = 0x3000
+    int64_t id = -1;
+    EXPECT_EQ(busIdToInt64("0000:03:00.0", &id), ncclSuccess);
+    EXPECT_EQ(id, 0x3000);
+}
+
+TEST(BusIdConversion, BusIdToInt64NonZeroDomain) {
+    // "0001:0a:1f.3" => "00010a1f3" hex = 0x10a1f3
+    int64_t id = -1;
+    EXPECT_EQ(busIdToInt64("0001:0a:1f.3", &id), ncclSuccess);
+    EXPECT_EQ(id, 0x10a1f3);
+}
+
+TEST(BusIdConversion, Int64ToBusIdZero) {
+    char busId[32] = {};
+    EXPECT_EQ(int64ToBusId(0, busId), ncclSuccess);
+    EXPECT_STREQ(busId, "0000:00:00.0");
+}
+
+TEST(BusIdConversion, Int64ToBusIdNonZeroBus) {
+    char busId[32] = {};
+    EXPECT_EQ(int64ToBusId(0x3000, busId), ncclSuccess);
+    EXPECT_STREQ(busId, "0000:03:00.0");
+}
+
+TEST(BusIdConversion, RoundTripBusId) {
+    const char* inputs[] = {
+        "0000:00:00.0",
+        "0000:03:00.0",
+        "0001:0a:1f.3",
+        "ffff:ff:1f.7",
+    };
+    for (const char* input : inputs) {
+        int64_t id = -1;
+        char output[32] = {};
+        EXPECT_EQ(busIdToInt64(input, &id), ncclSuccess) << "input=" << input;
+        EXPECT_EQ(int64ToBusId(id, output), ncclSuccess) << "input=" << input;
+        EXPECT_STREQ(output, input) << "round-trip failed for " << input;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// parseStringList
+// ---------------------------------------------------------------------------
+
+TEST(ParseStringList, NullInputReturnsZero) {
+    struct netIf ifList[8];
+    EXPECT_EQ(parseStringList(nullptr, ifList, 8), 0);
+}
+
+TEST(ParseStringList, EmptyStringReturnsZero) {
+    struct netIf ifList[8];
+    EXPECT_EQ(parseStringList("", ifList, 8), 0);
+}
+
+TEST(ParseStringList, SingleInterface) {
+    struct netIf ifList[8];
+    int n = parseStringList("eth0", ifList, 8);
+    EXPECT_EQ(n, 1);
+    EXPECT_STREQ(ifList[0].prefix, "eth0");
+    EXPECT_EQ(ifList[0].port, -1);
+}
+
+TEST(ParseStringList, InterfaceWithPort) {
+    struct netIf ifList[8];
+    int n = parseStringList("eth0:1", ifList, 8);
+    EXPECT_EQ(n, 1);
+    EXPECT_STREQ(ifList[0].prefix, "eth0");
+    EXPECT_EQ(ifList[0].port, 1);
+}
+
+TEST(ParseStringList, MultipleInterfaces) {
+    struct netIf ifList[8];
+    int n = parseStringList("eth0,eth1,ib0", ifList, 8);
+    EXPECT_EQ(n, 3);
+    EXPECT_STREQ(ifList[0].prefix, "eth0");
+    EXPECT_EQ(ifList[0].port, -1);
+    EXPECT_STREQ(ifList[1].prefix, "eth1");
+    EXPECT_EQ(ifList[1].port, -1);
+    EXPECT_STREQ(ifList[2].prefix, "ib0");
+    EXPECT_EQ(ifList[2].port, -1);
+}
+
+TEST(ParseStringList, MixedPortAndNoPort) {
+    struct netIf ifList[8];
+    int n = parseStringList("eth0:1,eth1", ifList, 8);
+    EXPECT_EQ(n, 2);
+    EXPECT_STREQ(ifList[0].prefix, "eth0");
+    EXPECT_EQ(ifList[0].port, 1);
+    EXPECT_STREQ(ifList[1].prefix, "eth1");
+    EXPECT_EQ(ifList[1].port, -1);
+}
+
+TEST(ParseStringList, MaxListClamps) {
+    struct netIf ifList[2];
+    // Give 3 interfaces but max is 2
+    int n = parseStringList("eth0,eth1,eth2", ifList, 2);
+    EXPECT_EQ(n, 2);
+    EXPECT_STREQ(ifList[0].prefix, "eth0");
+    EXPECT_STREQ(ifList[1].prefix, "eth1");
+}
+
+} // namespace RcclUnitTesting


### PR DESCRIPTION
## Summary
- Add host-side unit tests covering architecture info helpers (`IsArchMatch`, `convertGcnArchToGcnArchName`) and utility functions (`busIdToInt64`/`int64ToBusId`, `parseStringList`).
- Tests run on CPU without requiring a GPU, improving CI coverage for pure-logic code paths.
- They build as part of `rccl-UnitTestsFixturesDebug` (Debug build, `ROCM_VERSION >= 60400`).

## History
This supersedes #4321, which was closed. That branch was rebased onto the current `develop` (its head is no longer a descendant of the closed PR's tip, so GitHub cannot reopen it), and the review comments from #4321 have been addressed.

## Changes since #4321
- Rebased onto latest `develop`; resolved the additive conflict in `test/CMakeLists.txt`.
- Removed unused includes.
- Documented the busId hex encoding against its source of truth in `src/misc/utils.cc` rather than leaving bare magic values.
- Added malformed-input tests for `busIdToInt64` pinning its observed `strtol`-style behavior (never rejects; stops at the first invalid character).
- Added `parseStringList` edge cases: leading/trailing commas and double commas (no empty entries), and whitespace after a comma (not trimmed).

## Test plan
- [ ] Verify tests compile and pass via `cmake -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug` + `ctest`
- [ ] Confirm no GPU required for these tests
