### PR TITLE
Add CPU unit tests for graph Rings and Trees

### DIFF
--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -352,6 +352,8 @@ if(BUILD_TESTS)
       TransportTests.cpp
       TimeoutTests.cpp
       mem_manager/MemManagerTests.cpp
+      graph/RingsTests.cpp
+      graph/TreesTests.cpp
       graph/SearchTests.cpp
       graph/XmlTests.cpp
       graph/NetDevsPolicyP2pNetTests.cpp

--- a/projects/rccl/test/graph/RingsTests.cpp
+++ b/projects/rccl/test/graph/RingsTests.cpp
@@ -1,0 +1,244 @@
+/*************************************************************************
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// ncclBuildRings: given prev/next arrays from rank's perspective, produce the
+// ring traversal order starting from `rank`.
+//
+// rings[r*nranks + i] = the i-th rank visited in ring r, starting from `rank`.
+
+#include "nccl.h"
+#include "graph/rings.h"
+#include <gtest/gtest.h>
+#include <vector>
+#include <algorithm>
+
+namespace RcclUnitTesting {
+
+// ---------------------------------------------------------------------------
+// Helper: build identity ring  0→1→2→…→N-1→0
+// ---------------------------------------------------------------------------
+static void makeLinearRing(int nranks, std::vector<int>& next, std::vector<int>& prev) {
+    next.resize(nranks);
+    prev.resize(nranks);
+    for (int i = 0; i < nranks; i++) {
+        next[i] = (i + 1) % nranks;
+        prev[i] = (i - 1 + nranks) % nranks;
+    }
+}
+
+// Verify that the ring is a proper permutation starting from `rank`.
+static void verifyRing(const std::vector<int>& rings, int ring, int rank, int nranks) {
+    ASSERT_GE((int)rings.size(), (ring + 1) * nranks) << "ring vector too small";
+    // First element is `rank`
+    EXPECT_EQ(rings[ring * nranks + 0], rank) << "ring does not start at rank " << rank;
+    // All ranks appear exactly once
+    std::vector<int> seen(nranks, 0);
+    for (int i = 0; i < nranks; i++) {
+        int r = rings[ring * nranks + i];
+        ASSERT_GE(r, 0) << "negative rank at position " << i;
+        ASSERT_LT(r, nranks) << "rank " << r << " out of bounds at position " << i;
+        seen[r]++;
+    }
+    for (int i = 0; i < nranks; i++) {
+        EXPECT_EQ(seen[i], 1) << "rank " << i << " appears " << seen[i] << " times";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2-rank ring
+// ---------------------------------------------------------------------------
+TEST(RingsTest, TwoRanksFromRank0) {
+    const int nranks = 2;
+    const int nrings = 1;
+    std::vector<int> next, prev;
+    makeLinearRing(nranks, next, prev);
+
+    std::vector<int> rings(nrings * nranks, -1);
+    ncclResult_t ret = ncclBuildRings(nrings, rings.data(), 0, nranks, prev.data(), next.data());
+    EXPECT_EQ(ret, ncclSuccess);
+
+    // From rank 0: 0 → 1 → (back to 0)
+    EXPECT_EQ(rings[0], 0);
+    EXPECT_EQ(rings[1], 1);
+    verifyRing(rings, 0, 0, nranks);
+}
+
+TEST(RingsTest, TwoRanksFromRank1) {
+    const int nranks = 2;
+    const int nrings = 1;
+    std::vector<int> next, prev;
+    makeLinearRing(nranks, next, prev);
+
+    std::vector<int> rings(nrings * nranks, -1);
+    ncclResult_t ret = ncclBuildRings(nrings, rings.data(), 1, nranks, prev.data(), next.data());
+    EXPECT_EQ(ret, ncclSuccess);
+
+    // From rank 1: 1 → 0 → (back to 1)
+    EXPECT_EQ(rings[0], 1);
+    EXPECT_EQ(rings[1], 0);
+    verifyRing(rings, 0, 1, nranks);
+}
+
+// ---------------------------------------------------------------------------
+// 4-rank ring
+// ---------------------------------------------------------------------------
+TEST(RingsTest, FourRanksLinearFromRank0) {
+    const int nranks = 4;
+    const int nrings = 1;
+    std::vector<int> next, prev;
+    makeLinearRing(nranks, next, prev);
+
+    std::vector<int> rings(nrings * nranks, -1);
+    ncclResult_t ret = ncclBuildRings(nrings, rings.data(), 0, nranks, prev.data(), next.data());
+    EXPECT_EQ(ret, ncclSuccess);
+
+    EXPECT_EQ(rings[0], 0);
+    EXPECT_EQ(rings[1], 1);
+    EXPECT_EQ(rings[2], 2);
+    EXPECT_EQ(rings[3], 3);
+}
+
+TEST(RingsTest, FourRanksLinearFromRank2) {
+    const int nranks = 4;
+    const int nrings = 1;
+    std::vector<int> next, prev;
+    makeLinearRing(nranks, next, prev);
+
+    std::vector<int> rings(nrings * nranks, -1);
+    ncclResult_t ret = ncclBuildRings(nrings, rings.data(), 2, nranks, prev.data(), next.data());
+    EXPECT_EQ(ret, ncclSuccess);
+
+    // From rank 2: 2 → 3 → 0 → 1
+    EXPECT_EQ(rings[0], 2);
+    EXPECT_EQ(rings[1], 3);
+    EXPECT_EQ(rings[2], 0);
+    EXPECT_EQ(rings[3], 1);
+    verifyRing(rings, 0, 2, nranks);
+}
+
+// ---------------------------------------------------------------------------
+// Reversed ring (N-1 → N-2 → … → 0 → N-1)
+// ---------------------------------------------------------------------------
+TEST(RingsTest, FourRanksReversedFromRank0) {
+    const int nranks = 4;
+    const int nrings = 1;
+
+    // next[i] = (i - 1 + nranks) % nranks  (reverse direction)
+    std::vector<int> next(nranks), prev(nranks);
+    for (int i = 0; i < nranks; i++) {
+        next[i] = (i - 1 + nranks) % nranks;
+        prev[i] = (i + 1) % nranks;
+    }
+
+    std::vector<int> rings(nrings * nranks, -1);
+    ncclResult_t ret = ncclBuildRings(nrings, rings.data(), 0, nranks, prev.data(), next.data());
+    EXPECT_EQ(ret, ncclSuccess);
+
+    // From rank 0: 0 → 3 → 2 → 1
+    EXPECT_EQ(rings[0], 0);
+    EXPECT_EQ(rings[1], 3);
+    EXPECT_EQ(rings[2], 2);
+    EXPECT_EQ(rings[3], 1);
+    verifyRing(rings, 0, 0, nranks);
+}
+
+// ---------------------------------------------------------------------------
+// 8-rank ring
+// ---------------------------------------------------------------------------
+TEST(RingsTest, EightRanksFromRank0) {
+    const int nranks = 8;
+    const int nrings = 1;
+    std::vector<int> next, prev;
+    makeLinearRing(nranks, next, prev);
+
+    std::vector<int> rings(nrings * nranks, -1);
+    ncclResult_t ret = ncclBuildRings(nrings, rings.data(), 0, nranks, prev.data(), next.data());
+    EXPECT_EQ(ret, ncclSuccess);
+
+    for (int i = 0; i < nranks; i++) {
+        EXPECT_EQ(rings[i], i) << "position " << i;
+    }
+    verifyRing(rings, 0, 0, nranks);
+}
+
+TEST(RingsTest, EightRanksFromRank5) {
+    const int nranks = 8;
+    const int nrings = 1;
+    std::vector<int> next, prev;
+    makeLinearRing(nranks, next, prev);
+
+    std::vector<int> rings(nrings * nranks, -1);
+    ncclResult_t ret = ncclBuildRings(nrings, rings.data(), 5, nranks, prev.data(), next.data());
+    EXPECT_EQ(ret, ncclSuccess);
+
+    // From rank 5: 5, 6, 7, 0, 1, 2, 3, 4
+    int expected[] = {5, 6, 7, 0, 1, 2, 3, 4};
+    for (int i = 0; i < nranks; i++) {
+        EXPECT_EQ(rings[i], expected[i]) << "position " << i;
+    }
+    verifyRing(rings, 0, 5, nranks);
+}
+
+// ---------------------------------------------------------------------------
+// Multiple rings
+// ---------------------------------------------------------------------------
+TEST(RingsTest, TwoRingsFromRank0) {
+    const int nranks = 4;
+    const int nrings = 2;
+    // Ring 0: 0→1→2→3→0 (linear)
+    // Ring 1: 0→2→1→3→0 (different order)
+    std::vector<int> next(nrings * nranks), prev(nrings * nranks);
+
+    // Ring 0 (forward)
+    for (int i = 0; i < nranks; i++) {
+        next[0 * nranks + i] = (i + 1) % nranks;
+        prev[0 * nranks + i] = (i - 1 + nranks) % nranks;
+    }
+    // Ring 1 (stride-2, wrapping): 0→2→1→3→0
+    // next[1*4+0]=2, next[1*4+2]=1, next[1*4+1]=3, next[1*4+3]=0
+    next[1 * nranks + 0] = 2;
+    next[1 * nranks + 2] = 1;
+    next[1 * nranks + 1] = 3;
+    next[1 * nranks + 3] = 0;
+    prev[1 * nranks + 2] = 0;
+    prev[1 * nranks + 1] = 2;
+    prev[1 * nranks + 3] = 1;
+    prev[1 * nranks + 0] = 3;
+
+    std::vector<int> rings(nrings * nranks, -1);
+    ncclResult_t ret = ncclBuildRings(nrings, rings.data(), 0, nranks, prev.data(), next.data());
+    EXPECT_EQ(ret, ncclSuccess);
+
+    // Ring 0: 0,1,2,3
+    EXPECT_EQ(rings[0 * nranks + 0], 0);
+    EXPECT_EQ(rings[0 * nranks + 1], 1);
+    EXPECT_EQ(rings[0 * nranks + 2], 2);
+    EXPECT_EQ(rings[0 * nranks + 3], 3);
+
+    // Ring 1: 0,2,1,3
+    EXPECT_EQ(rings[1 * nranks + 0], 0);
+    EXPECT_EQ(rings[1 * nranks + 1], 2);
+    EXPECT_EQ(rings[1 * nranks + 2], 1);
+    EXPECT_EQ(rings[1 * nranks + 3], 3);
+}
+
+// ---------------------------------------------------------------------------
+// Error: broken ring (doesn't loop back to start)
+// ---------------------------------------------------------------------------
+TEST(RingsTest, BrokenRingReturnsError) {
+    const int nranks = 4;
+    const int nrings = 1;
+    // Build a broken next array: 0→1→2→1 (cycle that doesn't include all ranks)
+    std::vector<int> next = {1, 2, 1, 0};  // rank 2 points back to 1, not 3
+    std::vector<int> prev = {3, 0, 1, 2};
+
+    std::vector<int> rings(nrings * nranks, -1);
+    // ncclBuildRings should detect the broken ring and return an error
+    ncclResult_t ret = ncclBuildRings(nrings, rings.data(), 0, nranks, prev.data(), next.data());
+    EXPECT_NE(ret, ncclSuccess);
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/graph/RingsTests.cpp
+++ b/projects/rccl/test/graph/RingsTests.cpp
@@ -190,6 +190,11 @@ TEST(RingsTest, TwoRingsFromRank0) {
     const int nrings = 2;
     // Ring 0: 0→1→2→3→0 (linear)
     // Ring 1: 0→2→1→3→0 (different order)
+    //
+    // Layout convention: next/prev (and the rings output) are ring-major, i.e.
+    // indexed [ring * nranks + rank], so each ring occupies a contiguous block
+    // of nranks entries. This matches how ncclBuildRings indexes its input in
+    // src/graph/rings.cc (next[r * nranks + current]).
     std::vector<int> next(nrings * nranks), prev(nrings * nranks);
 
     // Ring 0 (forward)
@@ -228,6 +233,11 @@ TEST(RingsTest, TwoRingsFromRank0) {
 // ---------------------------------------------------------------------------
 // Error: broken ring (doesn't loop back to start)
 // ---------------------------------------------------------------------------
+// Rejecting a malformed ring is documented, defined behavior rather than
+// undefined: ncclBuildRings in src/graph/rings.cc explicitly validates that the
+// walk loops back to the starting rank and that every rank was visited, and
+// returns ncclInternalError (after a WARN) when either check fails. This test
+// exercises that contract.
 TEST(RingsTest, BrokenRingReturnsError) {
     const int nranks = 4;
     const int nrings = 1;

--- a/projects/rccl/test/graph/TreesTests.cpp
+++ b/projects/rccl/test/graph/TreesTests.cpp
@@ -203,8 +203,13 @@ TEST(BtreeTest, EightRanks_ParentChildConsistency) {
 }
 
 // Applies the same structural checks as the 4/8-rank consistency tests above to
-// an arbitrary rank count, so non-power-of-2 sizes get the same coverage.
+// an arbitrary rank count, so non-power-of-2 and large sizes get the same
+// coverage. Individual mismatches are reported only up to kMaxReported so that a
+// regression at a large rank count produces a readable failure rather than
+// thousands of lines; the final count assertion still reflects every mismatch.
 static void ExpectBtreeConsistent(int nranks) {
+    constexpr int kMaxReported = 10;
+
     struct NodeInfo { int u, d0, d1, pct; };
     std::vector<NodeInfo> info(nranks);
 
@@ -217,22 +222,70 @@ static void ExpectBtreeConsistent(int nranks) {
     // Rank 0 is the root of the btree and therefore has no parent.
     EXPECT_EQ(info[0].u, -1) << "nranks=" << nranks;
 
+    // Every non-root rank is listed as a child by the parent it points at.
+    int linkErrors = 0;
     for (int r = 1; r < nranks; r++) {
         int parent = info[r].u;
         ASSERT_GE(parent, 0) << "nranks=" << nranks << " rank " << r << " has no parent";
         ASSERT_LT(parent, nranks) << "nranks=" << nranks << " rank " << r;
-        bool found = (info[parent].d0 == r || info[parent].d1 == r);
-        EXPECT_TRUE(found) << "nranks=" << nranks << " rank " << r
-                           << " not found as child of rank " << parent;
-    }
-
-    // Children, when present, must be in range.
-    for (int r = 0; r < nranks; r++) {
-        for (int child : {info[r].d0, info[r].d1}) {
-            EXPECT_TRUE(child == -1 || (child >= 0 && child < nranks))
-                << "nranks=" << nranks << " rank " << r << " child=" << child;
+        if (info[parent].d0 != r && info[parent].d1 != r) {
+            if (linkErrors < kMaxReported) {
+                ADD_FAILURE() << "nranks=" << nranks << " rank " << r
+                              << " not found as child of rank " << parent;
+            }
+            linkErrors++;
         }
     }
+    EXPECT_EQ(linkErrors, 0) << "nranks=" << nranks << ": " << linkErrors
+                             << " rank(s) not listed as a child of their parent";
+
+    // Children, when present, must be in range.
+    int rangeErrors = 0;
+    for (int r = 0; r < nranks; r++) {
+        for (int child : {info[r].d0, info[r].d1}) {
+            if (child == -1 || (child >= 0 && child < nranks)) continue;
+            if (rangeErrors < kMaxReported) {
+                ADD_FAILURE() << "nranks=" << nranks << " rank " << r << " child=" << child
+                              << " out of range";
+            }
+            rangeErrors++;
+        }
+    }
+    EXPECT_EQ(rangeErrors, 0) << "nranks=" << nranks << ": " << rangeErrors
+                              << " out-of-range child link(s)";
+
+    // The links must form a single tree spanning every rank: walking down from
+    // the root must reach each rank exactly once (no orphans, no cycles, no rank
+    // claimed by two parents). Descending-only linkage checks cannot catch a
+    // disconnected forest, which is the failure mode that matters at large
+    // rank counts where the tree cannot be inspected by hand.
+    std::vector<int> visits(nranks, 0);
+    std::vector<int> stack;
+    stack.push_back(0);
+    while (!stack.empty()) {
+        int r = stack.back();
+        stack.pop_back();
+        if (r == -1) continue;
+        ASSERT_GE(r, 0) << "nranks=" << nranks;
+        ASSERT_LT(r, nranks) << "nranks=" << nranks;
+        // Guard against cycles so the walk cannot loop forever.
+        if (++visits[r] > 1) continue;
+        stack.push_back(info[r].d0);
+        stack.push_back(info[r].d1);
+    }
+
+    int unreached = 0, repeated = 0;
+    for (int r = 0; r < nranks; r++) {
+        if (visits[r] == 0 && ++unreached <= kMaxReported) {
+            ADD_FAILURE() << "nranks=" << nranks << " rank " << r << " unreachable from root";
+        } else if (visits[r] > 1 && ++repeated <= kMaxReported) {
+            ADD_FAILURE() << "nranks=" << nranks << " rank " << r << " reached "
+                          << visits[r] << " times";
+        }
+    }
+    EXPECT_EQ(unreached, 0) << "nranks=" << nranks << ": " << unreached << " unreachable rank(s)";
+    EXPECT_EQ(repeated, 0) << "nranks=" << nranks << ": " << repeated
+                           << " rank(s) reached more than once";
 }
 
 TEST(BtreeTest, FiveRanks_ParentChildConsistency) {
@@ -241,6 +294,21 @@ TEST(BtreeTest, FiveRanks_ParentChildConsistency) {
 
 TEST(BtreeTest, SixRanks_ParentChildConsistency) {
     ExpectBtreeConsistent(6);
+}
+
+// Large rank counts, around the 1000 mark. ncclGetBtree derives parent/child
+// links from bit manipulation of the rank index, so the interesting cases are
+// clustered around a power-of-2 boundary: 1024 exercises the exact-power-of-2
+// path, 1023/1025 the sizes either side of it where the down1 clamping loop
+// runs, and 1000 an ordinary non-power-of-2 count.
+TEST(BtreeTest, ThousandRanks_ParentChildConsistency) {
+    ExpectBtreeConsistent(1000);
+}
+
+TEST(BtreeTest, PowerOfTwoBoundaryRanks_ParentChildConsistency) {
+    ExpectBtreeConsistent(1023);
+    ExpectBtreeConsistent(1024);
+    ExpectBtreeConsistent(1025);
 }
 
 // ---------------------------------------------------------------------------

--- a/projects/rccl/test/graph/TreesTests.cpp
+++ b/projects/rccl/test/graph/TreesTests.cpp
@@ -32,8 +32,13 @@ namespace RcclUnitTesting {
 // ncclGetBtree
 // ---------------------------------------------------------------------------
 
-// Header signature: ncclGetBtree(nranks, rank, up, down0, down1, parentChildType)
-// Note: "down0" is the left child (rank - lowbit), "down1" is the right child
+// These tests follow the parameter meaning from the ncclGetBtree *definition*
+// in src/graph/trees.cc: after (nranks, rank) the outputs are
+// (up, down0, down1, parentChildType), where down0 is the left child
+// (rank - lowbit) and down1 is the right child (rank + lowbit).
+// Note: the declaration in src/include/trees.h names these two child pointers
+// in the opposite order (u0, d1, d0); the parameters are positional pointers, so
+// behavior is governed by the definition above, which is what we assert against.
 
 TEST(BtreeTest, SingleRank) {
     int u = 0, d0 = 0, d1 = 0, pct = 0;
@@ -274,13 +279,22 @@ static void ExpectBtreeConsistent(int nranks) {
         stack.push_back(info[r].d1);
     }
 
+    // Count every mismatch, but only emit the first kMaxReported messages of
+    // each kind so a large-nranks regression stays readable. The counts below
+    // are unconditional; the message cap does not affect them.
     int unreached = 0, repeated = 0;
     for (int r = 0; r < nranks; r++) {
-        if (visits[r] == 0 && ++unreached <= kMaxReported) {
-            ADD_FAILURE() << "nranks=" << nranks << " rank " << r << " unreachable from root";
-        } else if (visits[r] > 1 && ++repeated <= kMaxReported) {
-            ADD_FAILURE() << "nranks=" << nranks << " rank " << r << " reached "
-                          << visits[r] << " times";
+        if (visits[r] == 0) {
+            unreached++;
+            if (unreached <= kMaxReported) {
+                ADD_FAILURE() << "nranks=" << nranks << " rank " << r << " unreachable from root";
+            }
+        } else if (visits[r] > 1) {
+            repeated++;
+            if (repeated <= kMaxReported) {
+                ADD_FAILURE() << "nranks=" << nranks << " rank " << r << " reached "
+                              << visits[r] << " times";
+            }
         }
     }
     EXPECT_EQ(unreached, 0) << "nranks=" << nranks << ": " << unreached << " unreachable rank(s)";

--- a/projects/rccl/test/graph/TreesTests.cpp
+++ b/projects/rccl/test/graph/TreesTests.cpp
@@ -19,8 +19,12 @@
 //                  1  3 5  7
 
 #include "nccl.h"
+// trees.h lives at src/include/trees.h, which is on the include path directly —
+// there is no src/graph/trees.h. (RingsTests.cpp includes "graph/rings.h"
+// because rings.h genuinely does live at src/graph/rings.h.)
 #include "trees.h"
 #include <gtest/gtest.h>
+#include <vector>
 
 namespace RcclUnitTesting {
 
@@ -159,7 +163,7 @@ TEST(BtreeTest, EightRanks_LeafNodes) {
 TEST(BtreeTest, FourRanks_ParentChildConsistency) {
     const int nranks = 4;
     struct NodeInfo { int u, d0, d1, pct; };
-    NodeInfo info[nranks];
+    std::vector<NodeInfo> info(nranks);
 
     for (int r = 0; r < nranks; r++) {
         ncclResult_t ret = ncclGetBtree(nranks, r, &info[r].u, &info[r].d0, &info[r].d1, &info[r].pct);
@@ -179,7 +183,7 @@ TEST(BtreeTest, FourRanks_ParentChildConsistency) {
 TEST(BtreeTest, EightRanks_ParentChildConsistency) {
     const int nranks = 8;
     struct NodeInfo { int u, d0, d1, pct; };
-    NodeInfo info[nranks];
+    std::vector<NodeInfo> info(nranks);
 
     for (int r = 0; r < nranks; r++) {
         ncclResult_t ret = ncclGetBtree(nranks, r, &info[r].u, &info[r].d0, &info[r].d1, &info[r].pct);
@@ -198,27 +202,69 @@ TEST(BtreeTest, EightRanks_ParentChildConsistency) {
     }
 }
 
+// Applies the same structural checks as the 4/8-rank consistency tests above to
+// an arbitrary rank count, so non-power-of-2 sizes get the same coverage.
+static void ExpectBtreeConsistent(int nranks) {
+    struct NodeInfo { int u, d0, d1, pct; };
+    std::vector<NodeInfo> info(nranks);
+
+    for (int r = 0; r < nranks; r++) {
+        ncclResult_t ret = ncclGetBtree(nranks, r, &info[r].u, &info[r].d0,
+                                        &info[r].d1, &info[r].pct);
+        ASSERT_EQ(ret, ncclSuccess) << "nranks=" << nranks << " rank=" << r;
+    }
+
+    // Rank 0 is the root of the btree and therefore has no parent.
+    EXPECT_EQ(info[0].u, -1) << "nranks=" << nranks;
+
+    for (int r = 1; r < nranks; r++) {
+        int parent = info[r].u;
+        ASSERT_GE(parent, 0) << "nranks=" << nranks << " rank " << r << " has no parent";
+        ASSERT_LT(parent, nranks) << "nranks=" << nranks << " rank " << r;
+        bool found = (info[parent].d0 == r || info[parent].d1 == r);
+        EXPECT_TRUE(found) << "nranks=" << nranks << " rank " << r
+                           << " not found as child of rank " << parent;
+    }
+
+    // Children, when present, must be in range.
+    for (int r = 0; r < nranks; r++) {
+        for (int child : {info[r].d0, info[r].d1}) {
+            EXPECT_TRUE(child == -1 || (child >= 0 && child < nranks))
+                << "nranks=" << nranks << " rank " << r << " child=" << child;
+        }
+    }
+}
+
+TEST(BtreeTest, FiveRanks_ParentChildConsistency) {
+    ExpectBtreeConsistent(5);
+}
+
+TEST(BtreeTest, SixRanks_ParentChildConsistency) {
+    ExpectBtreeConsistent(6);
+}
+
 // ---------------------------------------------------------------------------
 // ncclGetDtree — double binary tree
 // ---------------------------------------------------------------------------
 
-// For an even number of ranks, the second tree is the mirror of the first.
+// For an even number of ranks, ncclGetDtree builds the second tree by mirroring
+// the btree: it queries the btree for rank mirror(rank) and maps every non-(-1)
+// result back through mirror(). See ncclGetDtree in src/graph/trees.cc.
+static int mirror(int r, int n) { return n - 1 - r; }
+
 TEST(DtreeTest, TwoRanks_Rank0) {
     int s0 = 0, d0_0 = 0, d0_1 = 0, pct0 = 0;
     int s1 = 0, d1_0 = 0, d1_1 = 0, pct1 = 0;
     ncclResult_t ret = ncclGetDtree(2, 0, &s0, &d0_0, &d0_1, &pct0,
                                              &s1, &d1_0, &d1_1, &pct1);
     EXPECT_EQ(ret, ncclSuccess);
-    // Tree 0: rank 0 is root (nranks=2, even: mirror)
+    // Tree 0: rank 0 is the btree root.
     EXPECT_EQ(s0, -1);  // no parent
     EXPECT_EQ(d0_1, 1); // right child
-    // Tree 1: mirror → rank nranks-1-0 = 1 is root in mirrored btree
-    // mirrored: s1 = nranks-1-u, d1_0 = nranks-1-d0, d1_1 = nranks-1-d1
-    // btree for nranks=2, rank=1: u=0, d0=-1, d1=-1
-    // mirror of rank 1: s1=nranks-1-0=1 (parent in mirror), d1_0=-1, d1_1=-1
-    // Actually for rank 0 in mirror: btree(2, 1, ...) → u=0, d0=-1, d1=-1
-    // s1=nranks-1-0=1, d1_0=-1, d1_1=-1
-    EXPECT_EQ(s1, 1);   // parent in second tree
+
+    // Tree 1: btree(2, mirror(0,2)=1) yields u=0, d0=-1, d1=-1, so rank 0's
+    // parent in the mirrored tree is mirror(0,2) and it has no children.
+    EXPECT_EQ(s1, mirror(0, 2));  // == 1
     EXPECT_EQ(d1_0, -1);
     EXPECT_EQ(d1_1, -1);
 }
@@ -229,13 +275,13 @@ TEST(DtreeTest, FourRanks_Rank0) {
     ncclResult_t ret = ncclGetDtree(4, 0, &s0, &d0_0, &d0_1, &pct0,
                                              &s1, &d1_0, &d1_1, &pct1);
     EXPECT_EQ(ret, ncclSuccess);
-    // Tree 0: rank 0 is root
+    // Tree 0: rank 0 is the btree root.
     EXPECT_EQ(s0, -1);
-    EXPECT_EQ(d0_1, 2);  // right child is 2 (from btree)
+    EXPECT_EQ(d0_1, 2);  // right child
 
-    // Tree 1 is mirror: btree(4, nranks-1-0=3, ...) gives u=2, d0=-1, d1=-1
-    // mirror: s1=nranks-1-2=1, d1_0=-1, d1_1=-1
-    EXPECT_EQ(s1, 1);    // parent in second tree is nranks-1-2=1
+    // Tree 1: btree(4, mirror(0,4)=3) yields u=2, d0=-1, d1=-1, so rank 0's
+    // parent in the mirrored tree is mirror(2,4) and it has no children.
+    EXPECT_EQ(s1, mirror(2, 4));  // == 1
     EXPECT_EQ(d1_0, -1);
     EXPECT_EQ(d1_1, -1);
 }
@@ -262,6 +308,9 @@ TEST(DtreeTest, ThreeRanks_ShiftTree) {
 
 TEST(DtreeTest, FourRanks_AllRanksValid) {
     const int nranks = 4;
+    struct NodeInfo { int u, d0, d1; };
+    std::vector<NodeInfo> tree0(nranks), tree1(nranks);
+
     for (int rank = 0; rank < nranks; rank++) {
         int s0 = 0, d0_0 = 0, d0_1 = 0, pct0 = 0;
         int s1 = 0, d1_0 = 0, d1_1 = 0, pct1 = 0;
@@ -278,7 +327,34 @@ TEST(DtreeTest, FourRanks_AllRanksValid) {
         EXPECT_TRUE(validRank(s1))   << "rank=" << rank << " s1=" << s1;
         EXPECT_TRUE(validRank(d1_0)) << "rank=" << rank << " d1_0=" << d1_0;
         EXPECT_TRUE(validRank(d1_1)) << "rank=" << rank << " d1_1=" << d1_1;
+
+        tree0[rank] = {s0, d0_0, d0_1};
+        tree1[rank] = {s1, d1_0, d1_1};
     }
+
+    // Beyond bounds-checking, both trees must be structurally sound: exactly one
+    // root (u == -1), and every non-root rank listed as a child of its parent.
+    // This mirrors the btree consistency tests above, applied to each of the two
+    // trees ncclGetDtree returns.
+    auto expectConsistent = [nranks](const std::vector<NodeInfo>& tree, const char* which) {
+        int roots = 0;
+        for (int r = 0; r < nranks; r++) {
+            if (tree[r].u == -1) {
+                roots++;
+                continue;
+            }
+            int parent = tree[r].u;
+            ASSERT_GE(parent, 0) << which << " rank " << r;
+            ASSERT_LT(parent, nranks) << which << " rank " << r;
+            bool found = (tree[parent].d0 == r || tree[parent].d1 == r);
+            EXPECT_TRUE(found) << which << ": rank " << r
+                               << " not found as child of rank " << parent;
+        }
+        EXPECT_EQ(roots, 1) << which << " should have exactly one root";
+    };
+
+    expectConsistent(tree0, "tree0");
+    expectConsistent(tree1, "tree1");
 }
 
 } // namespace RcclUnitTesting

--- a/projects/rccl/test/graph/TreesTests.cpp
+++ b/projects/rccl/test/graph/TreesTests.cpp
@@ -1,0 +1,284 @@
+/*************************************************************************
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Tests for ncclGetBtree and ncclGetDtree from src/graph/trees.cc
+//
+// The binary tree structure for N ranks (root = 0):
+//
+//   For N=4:   0---2
+//                 / \
+//                1   3
+//
+//   For N=8:   0-------4
+//                     / \
+//                    2   6
+//                   / \ / \
+//                  1  3 5  7
+
+#include "nccl.h"
+#include "trees.h"
+#include <gtest/gtest.h>
+
+namespace RcclUnitTesting {
+
+// ---------------------------------------------------------------------------
+// ncclGetBtree
+// ---------------------------------------------------------------------------
+
+// Header signature: ncclGetBtree(nranks, rank, up, down0, down1, parentChildType)
+// Note: "down0" is the left child (rank - lowbit), "down1" is the right child
+
+TEST(BtreeTest, SingleRank) {
+    int u = 0, d0 = 0, d1 = 0, pct = 0;
+    ncclResult_t ret = ncclGetBtree(1, 0, &u, &d0, &d1, &pct);
+    EXPECT_EQ(ret, ncclSuccess);
+    // Single rank: root with no children, no parent
+    EXPECT_EQ(u, -1);
+    EXPECT_EQ(d0, -1);
+    EXPECT_EQ(d1, -1);
+}
+
+TEST(BtreeTest, TwoRanks_Rank0) {
+    int u = 0, d0 = 0, d1 = 0, pct = 0;
+    ncclResult_t ret = ncclGetBtree(2, 0, &u, &d0, &d1, &pct);
+    EXPECT_EQ(ret, ncclSuccess);
+    // Rank 0 is root: no parent, no left child, right child is rank 1
+    EXPECT_EQ(u, -1);
+    EXPECT_EQ(d0, -1);
+    EXPECT_EQ(d1, 1);
+}
+
+TEST(BtreeTest, TwoRanks_Rank1) {
+    int u = 0, d0 = 0, d1 = 0, pct = 0;
+    ncclResult_t ret = ncclGetBtree(2, 1, &u, &d0, &d1, &pct);
+    EXPECT_EQ(ret, ncclSuccess);
+    // Rank 1 is a leaf: parent is 0, no children
+    EXPECT_EQ(u, 0);
+    EXPECT_EQ(d0, -1);
+    EXPECT_EQ(d1, -1);
+}
+
+// 4-rank tree:
+//   0---2
+//      / \
+//     1   3
+TEST(BtreeTest, FourRanks_Root) {
+    int u = 0, d0 = 0, d1 = 0, pct = 0;
+    ncclResult_t ret = ncclGetBtree(4, 0, &u, &d0, &d1, &pct);
+    EXPECT_EQ(ret, ncclSuccess);
+    EXPECT_EQ(u, -1);
+    EXPECT_EQ(d0, -1);
+    EXPECT_EQ(d1, 2);  // right child
+}
+
+TEST(BtreeTest, FourRanks_Rank1) {
+    int u = 0, d0 = 0, d1 = 0, pct = 0;
+    ncclResult_t ret = ncclGetBtree(4, 1, &u, &d0, &d1, &pct);
+    EXPECT_EQ(ret, ncclSuccess);
+    EXPECT_EQ(u, 2);   // parent
+    EXPECT_EQ(d0, -1); // no children (leaf)
+    EXPECT_EQ(d1, -1);
+}
+
+TEST(BtreeTest, FourRanks_Rank2) {
+    int u = 0, d0 = 0, d1 = 0, pct = 0;
+    ncclResult_t ret = ncclGetBtree(4, 2, &u, &d0, &d1, &pct);
+    EXPECT_EQ(ret, ncclSuccess);
+    EXPECT_EQ(u, 0);   // parent is root
+    EXPECT_EQ(d0, 1);  // left child
+    EXPECT_EQ(d1, 3);  // right child
+}
+
+TEST(BtreeTest, FourRanks_Rank3) {
+    int u = 0, d0 = 0, d1 = 0, pct = 0;
+    ncclResult_t ret = ncclGetBtree(4, 3, &u, &d0, &d1, &pct);
+    EXPECT_EQ(ret, ncclSuccess);
+    EXPECT_EQ(u, 2);   // parent
+    EXPECT_EQ(d0, -1); // no children (leaf)
+    EXPECT_EQ(d1, -1);
+}
+
+// 8-rank tree:
+//   0---4
+//      / \
+//     2   6
+//    / \ / \
+//   1  3 5  7
+TEST(BtreeTest, EightRanks_Root) {
+    int u = 0, d0 = 0, d1 = 0, pct = 0;
+    ncclResult_t ret = ncclGetBtree(8, 0, &u, &d0, &d1, &pct);
+    EXPECT_EQ(ret, ncclSuccess);
+    EXPECT_EQ(u, -1);
+    EXPECT_EQ(d0, -1);
+    EXPECT_EQ(d1, 4);
+}
+
+TEST(BtreeTest, EightRanks_Rank4) {
+    int u = 0, d0 = 0, d1 = 0, pct = 0;
+    ncclResult_t ret = ncclGetBtree(8, 4, &u, &d0, &d1, &pct);
+    EXPECT_EQ(ret, ncclSuccess);
+    EXPECT_EQ(u, 0);   // parent
+    EXPECT_EQ(d0, 2);  // left child
+    EXPECT_EQ(d1, 6);  // right child
+}
+
+TEST(BtreeTest, EightRanks_Rank2) {
+    int u = 0, d0 = 0, d1 = 0, pct = 0;
+    ncclResult_t ret = ncclGetBtree(8, 2, &u, &d0, &d1, &pct);
+    EXPECT_EQ(ret, ncclSuccess);
+    EXPECT_EQ(u, 4);   // parent
+    EXPECT_EQ(d0, 1);  // left child
+    EXPECT_EQ(d1, 3);  // right child
+}
+
+TEST(BtreeTest, EightRanks_Rank6) {
+    int u = 0, d0 = 0, d1 = 0, pct = 0;
+    ncclResult_t ret = ncclGetBtree(8, 6, &u, &d0, &d1, &pct);
+    EXPECT_EQ(ret, ncclSuccess);
+    EXPECT_EQ(u, 4);   // parent
+    EXPECT_EQ(d0, 5);  // left child
+    EXPECT_EQ(d1, 7);  // right child
+}
+
+TEST(BtreeTest, EightRanks_LeafNodes) {
+    // Ranks 1, 3, 5, 7 are all leaves
+    for (int rank : {1, 3, 5, 7}) {
+        int u = 0, d0 = 0, d1 = 0, pct = 0;
+        ncclResult_t ret = ncclGetBtree(8, rank, &u, &d0, &d1, &pct);
+        EXPECT_EQ(ret, ncclSuccess) << "rank=" << rank;
+        EXPECT_NE(u, -1) << "leaf rank " << rank << " should have a parent";
+        EXPECT_EQ(d0, -1) << "leaf rank " << rank << " should have no left child";
+        EXPECT_EQ(d1, -1) << "leaf rank " << rank << " should have no right child";
+    }
+}
+
+// Verify tree connectivity: every non-root rank's parent should list it as a child
+TEST(BtreeTest, FourRanks_ParentChildConsistency) {
+    const int nranks = 4;
+    struct NodeInfo { int u, d0, d1, pct; };
+    NodeInfo info[nranks];
+
+    for (int r = 0; r < nranks; r++) {
+        ncclResult_t ret = ncclGetBtree(nranks, r, &info[r].u, &info[r].d0, &info[r].d1, &info[r].pct);
+        EXPECT_EQ(ret, ncclSuccess) << "rank=" << r;
+    }
+
+    // For each non-root rank, verify it appears as a child of its parent
+    for (int r = 1; r < nranks; r++) {
+        int parent = info[r].u;
+        ASSERT_GE(parent, 0) << "rank " << r << " has no parent";
+        ASSERT_LT(parent, nranks);
+        bool found = (info[parent].d0 == r || info[parent].d1 == r);
+        EXPECT_TRUE(found) << "rank " << r << " not found as child of rank " << parent;
+    }
+}
+
+TEST(BtreeTest, EightRanks_ParentChildConsistency) {
+    const int nranks = 8;
+    struct NodeInfo { int u, d0, d1, pct; };
+    NodeInfo info[nranks];
+
+    for (int r = 0; r < nranks; r++) {
+        ncclResult_t ret = ncclGetBtree(nranks, r, &info[r].u, &info[r].d0, &info[r].d1, &info[r].pct);
+        EXPECT_EQ(ret, ncclSuccess) << "rank=" << r;
+    }
+
+    // Root has no parent
+    EXPECT_EQ(info[0].u, -1);
+
+    for (int r = 1; r < nranks; r++) {
+        int parent = info[r].u;
+        ASSERT_GE(parent, 0) << "rank " << r << " has no parent";
+        ASSERT_LT(parent, nranks);
+        bool found = (info[parent].d0 == r || info[parent].d1 == r);
+        EXPECT_TRUE(found) << "rank " << r << " not found as child of rank " << parent;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ncclGetDtree — double binary tree
+// ---------------------------------------------------------------------------
+
+// For an even number of ranks, the second tree is the mirror of the first.
+TEST(DtreeTest, TwoRanks_Rank0) {
+    int s0 = 0, d0_0 = 0, d0_1 = 0, pct0 = 0;
+    int s1 = 0, d1_0 = 0, d1_1 = 0, pct1 = 0;
+    ncclResult_t ret = ncclGetDtree(2, 0, &s0, &d0_0, &d0_1, &pct0,
+                                             &s1, &d1_0, &d1_1, &pct1);
+    EXPECT_EQ(ret, ncclSuccess);
+    // Tree 0: rank 0 is root (nranks=2, even: mirror)
+    EXPECT_EQ(s0, -1);  // no parent
+    EXPECT_EQ(d0_1, 1); // right child
+    // Tree 1: mirror → rank nranks-1-0 = 1 is root in mirrored btree
+    // mirrored: s1 = nranks-1-u, d1_0 = nranks-1-d0, d1_1 = nranks-1-d1
+    // btree for nranks=2, rank=1: u=0, d0=-1, d1=-1
+    // mirror of rank 1: s1=nranks-1-0=1 (parent in mirror), d1_0=-1, d1_1=-1
+    // Actually for rank 0 in mirror: btree(2, 1, ...) → u=0, d0=-1, d1=-1
+    // s1=nranks-1-0=1, d1_0=-1, d1_1=-1
+    EXPECT_EQ(s1, 1);   // parent in second tree
+    EXPECT_EQ(d1_0, -1);
+    EXPECT_EQ(d1_1, -1);
+}
+
+TEST(DtreeTest, FourRanks_Rank0) {
+    int s0 = 0, d0_0 = 0, d0_1 = 0, pct0 = 0;
+    int s1 = 0, d1_0 = 0, d1_1 = 0, pct1 = 0;
+    ncclResult_t ret = ncclGetDtree(4, 0, &s0, &d0_0, &d0_1, &pct0,
+                                             &s1, &d1_0, &d1_1, &pct1);
+    EXPECT_EQ(ret, ncclSuccess);
+    // Tree 0: rank 0 is root
+    EXPECT_EQ(s0, -1);
+    EXPECT_EQ(d0_1, 2);  // right child is 2 (from btree)
+
+    // Tree 1 is mirror: btree(4, nranks-1-0=3, ...) gives u=2, d0=-1, d1=-1
+    // mirror: s1=nranks-1-2=1, d1_0=-1, d1_1=-1
+    EXPECT_EQ(s1, 1);    // parent in second tree is nranks-1-2=1
+    EXPECT_EQ(d1_0, -1);
+    EXPECT_EQ(d1_1, -1);
+}
+
+TEST(DtreeTest, ThreeRanks_ShiftTree) {
+    // Odd nranks: second tree is a shift by 1
+    // nranks=3 is odd
+    int s0 = 0, d0_0 = 0, d0_1 = 0, pct0 = 0;
+    int s1 = 0, d1_0 = 0, d1_1 = 0, pct1 = 0;
+    ncclResult_t ret = ncclGetDtree(3, 0, &s0, &d0_0, &d0_1, &pct0,
+                                             &s1, &d1_0, &d1_1, &pct1);
+    EXPECT_EQ(ret, ncclSuccess);
+    // Just verify it succeeds and produces valid rank indices
+    auto validRank = [](int r, int nranks) {
+        return r == -1 || (r >= 0 && r < nranks);
+    };
+    EXPECT_TRUE(validRank(s0, 3));
+    EXPECT_TRUE(validRank(d0_0, 3));
+    EXPECT_TRUE(validRank(d0_1, 3));
+    EXPECT_TRUE(validRank(s1, 3));
+    EXPECT_TRUE(validRank(d1_0, 3));
+    EXPECT_TRUE(validRank(d1_1, 3));
+}
+
+TEST(DtreeTest, FourRanks_AllRanksValid) {
+    const int nranks = 4;
+    for (int rank = 0; rank < nranks; rank++) {
+        int s0 = 0, d0_0 = 0, d0_1 = 0, pct0 = 0;
+        int s1 = 0, d1_0 = 0, d1_1 = 0, pct1 = 0;
+        ncclResult_t ret = ncclGetDtree(nranks, rank, &s0, &d0_0, &d0_1, &pct0,
+                                                       &s1, &d1_0, &d1_1, &pct1);
+        EXPECT_EQ(ret, ncclSuccess) << "rank=" << rank;
+
+        auto validRank = [nranks](int r) {
+            return r == -1 || (r >= 0 && r < nranks);
+        };
+        EXPECT_TRUE(validRank(s0))   << "rank=" << rank << " s0=" << s0;
+        EXPECT_TRUE(validRank(d0_0)) << "rank=" << rank << " d0_0=" << d0_0;
+        EXPECT_TRUE(validRank(d0_1)) << "rank=" << rank << " d0_1=" << d0_1;
+        EXPECT_TRUE(validRank(s1))   << "rank=" << rank << " s1=" << s1;
+        EXPECT_TRUE(validRank(d1_0)) << "rank=" << rank << " d1_0=" << d1_0;
+        EXPECT_TRUE(validRank(d1_1)) << "rank=" << rank << " d1_1=" << d1_1;
+    }
+}
+
+} // namespace RcclUnitTesting


### PR DESCRIPTION
## Summary
- Add host-side unit tests for ring construction/validation (`ncclBuildRings`) and binary/double-binary tree structure (`ncclGetBtree`, `ncclGetDtree`).
- Tests run on CPU without requiring a GPU, extending CI coverage for graph topology code paths.
- They build as part of `rccl-UnitTestsFixturesDebug` (Debug build, `ROCM_VERSION >= 60400`).

## History
This supersedes #4322, which was closed. That branch was rebased onto the current `develop` (its head is no longer a descendant of the closed PR's tip, so GitHub cannot reopen it), and the review comments from #4322 have been addressed.

## Changes since #4322
- Rebased onto latest `develop`; resolved the additive conflict in `test/CMakeLists.txt`.
- Clarified why `"trees.h"` and `"graph/rings.h"` use different include paths (`src/include/trees.h` vs `src/graph/rings.h`).
- Replaced VLAs in the tree consistency tests with `std::vector`.
- Added a `mirror()` helper and expressed the `ncclGetDtree` expectations directly in terms of it, replacing dense inline derivation comments.
- Extended `FourRanks_AllRanksValid` beyond bounds checks: both trees must have exactly one root and list every non-root rank as a child of its parent.
- Added btree parent/child consistency coverage for non-power-of-2 rank counts (5 and 6).
- Documented the ring-major `[ring * nranks + rank]` layout expected by `ncclBuildRings`, and that rejecting a broken ring is its documented contract (`ncclInternalError`), not undefined behavior.
- Added large-scale btree consistency tests (~1000 ranks: 1000, and 1023/1024/1025 around the power-of-2 boundary), with a spanning check that every rank is reachable from the root exactly once.

## Test plan
- [ ] Verify tests compile and pass via `cmake -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug` + `ctest`
- [ ] Confirm no GPU required for these tests
