### PR TITLE
fix(rocprofiler-systems): use cached Perfetto for UCX merged traces

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/test_ucx.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_ucx.py
@@ -78,7 +78,6 @@ def ucx_env(ucx_base_env) -> dict[str, str]:
     env = ucx_base_env.copy()
     env.update(
         {
-            "ROCPROFSYS_TRACE_LEGACY": "OFF",
             "ROCPROFSYS_PERFETTO_COMBINE_TRACES": "ON",
         }
     )

--- a/projects/rocprofiler-systems/tests/pytest/test_ucx.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_ucx.py
@@ -78,7 +78,7 @@ def ucx_env(ucx_base_env) -> dict[str, str]:
     env = ucx_base_env.copy()
     env.update(
         {
-            "ROCPROFSYS_TRACE_LEGACY": "ON",
+            "ROCPROFSYS_TRACE_LEGACY": "OFF",
             "ROCPROFSYS_PERFETTO_COMBINE_TRACES": "ON",
         }
     )


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
UCX sys-run tests were failing Perfetto validation because `merged.proto` was not produced while the tests were still forcing legacy Perfetto.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Updated the UCX pytest environment to use cached Perfetto by setting `ROCPROFSYS_TRACE_LEGACY=OFF` while keeping `ROCPROFSYS_PERFETTO_COMBINE_TRACES=ON`.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
JIRA ID - AIPROFSYST-428

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ran representative UCX sys-run validation and the full UCX CTest bucket.

## Test Result

<!-- Briefly summarize test outcomes. -->
`ucx-mpi-allreduce-sys-run` passed, and the full UCX CTest bucket passed: 100% tests passed, 0 failed out of 24.
<img width="393" height="263" alt="image" src="https://github.com/user-attachments/assets/6d3d7327-bc4f-43be-8122-53add3e9eb8d" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
