### PR TITLE
fix (rocprofiler-systems) default to static-linking profiler-hub

### DIFF
--- a/projects/rocprofiler-systems/cmake/ProfilerHub.cmake
+++ b/projects/rocprofiler-systems/cmake/ProfilerHub.cmake
@@ -26,7 +26,7 @@ set(ROCPROFSYS_PROFILER_HUB_GIT_SUBDIR
 )
 
 option(ROCPROFSYS_PROFILER_HUB_ENABLE_LOGGING "Enable profiler-hub logging" OFF)
-option(ROCPROFSYS_PROFILER_HUB_LINK_STATIC "Link profiler-hub statically" OFF)
+option(ROCPROFSYS_PROFILER_HUB_LINK_STATIC "Link profiler-hub statically" ON)
 
 # ------------------------------------------------------------------------------
 # Resolution order:


### PR DESCRIPTION
## Motivation

librocprof-sys.so dynamically links libprofiler-hub.so.0, but no downstream packaging pipeline reliably bundles that extra runtime dependency. AIPROFSYST-669: the rocm-profiler nightly wheel ships rocprof-sys binaries hard-linked against libprofiler-hub.so.0 while the library itself is absent from the wheel, breaking every rocprof-sys tool at load time.

## Technical Details

ROCPROFSYS_PROFILER_HUB_LINK_STATIC already existed and was fully wired through both the find_package and in-tree fallback resolution paths in ProfilerHub.cmake, just defaulted to OFF. This flips the default to ON so profiler-hub links statically into librocprof-sys.so instead of dynamically, removing the runtime .so dependency entirely.

## Issue Tracking

JIRA ID: AIPROFSYST-669

## Test Plan

Local build of rocprofiler-systems (debug preset) with the flag flipped. Checked readelf -d NEEDED entries on librocprof-sys.so and all rocprof-sys-* binaries, nm -D for leaked sqlite3 symbols, and ran the RocPD/sqlite3 write path end to end (rocprof-sys-sample --output-format rocpd).

## Test Result

No libprofiler-hub* NEEDED entry on any binary (previously present on all of them). No sqlite3 symbols exported from librocprof-sys.so's dynamic symbol table - profiler-hub's vendored sqlite3 is compiled -fvisibility=hidden and that protection holds once statically folded in. rocprof-sys-sample --output-format rocpd produced a valid database with no crash.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.