### PR TITLE
fix (profiler-hub) export profiler-hub_queries and profiler-hub-sqlite3 for static consumers

### DIFF
--- a/profilers/profiler-hub/CMakeLists.txt
+++ b/profilers/profiler-hub/CMakeLists.txt
@@ -267,13 +267,25 @@ endforeach()
 # target_link_libraries() above (that only supplies the $<BUILD_INTERFACE:>
 # object library), so consumers of the *installed* static package would
 # otherwise get no transitive link requirements at all. Explicitly restore
-# the ones that are genuinely resolvable by real consumers; queries,
-# sqlite3, and profiler-hub-objects itself are always in-tree-only and
-# never belong here. nlohmann_json is deliberately excluded too: it is a
-# PRIVATE, header-only dependency of profiler-hub-objects that never appears
-# in the installed public headers, so it carries no link symbols a static
-# consumer needs. profiler-hub (SHARED) needs no such list: its dependencies
-# are already fully baked into the .so.
+# the ones that are genuinely resolvable by real consumers.
+#
+# profiler-hub_queries IS one of them (added below, both BUILD_INTERFACE and
+# INSTALL_INTERFACE): it is a genuinely separate static archive
+# (query_builder_base.cpp, select_query_builders.cpp) that profiler-hub-objects
+# only links PRIVATE. Unlike a SHARED library - which bakes a PRIVATE
+# dependency's object code directly into the .so at its own link time - a
+# plain STATIC library link never absorbs a dependency's object code, so
+# profiler-hub_queries's object files never make it into libprofiler-hub.a.
+# Any consumer that pulls in query-builder symbols, including profiler-hub's
+# own reader_impl.cpp, must be told to link profiler-hub_queries explicitly.
+# sqlite3 and profiler-hub-objects itself stay excluded: sqlite3 is in-tree-only
+# for now (a separately-tracked follow-up, not part of this fix), and
+# profiler-hub-objects is the object library itself, not a separate consumable
+# archive. nlohmann_json is deliberately excluded too: it is a PRIVATE,
+# header-only dependency of profiler-hub-objects that never appears in the
+# installed public headers, so it carries no link symbols a static consumer
+# needs. profiler-hub (SHARED) needs no such list: its dependencies are already
+# fully baked into the .so.
 #
 # Each dependency added here must also get a matching find_dependency() call
 # in profiler-hub-config.cmake.in (accumulated below into
@@ -340,6 +352,20 @@ if(USE_SCHEMA_FROM_ROCPROFILER_SDK_ROCPD)
         "find_dependency(rocprofiler-sdk-rocpd)\n"
     )
 endif()
+# Unconditional (not tied to the fmt/spdlog loop or the rocpd block above):
+# profiler-hub_queries is always built in-tree as part of this project, so both
+# the BUILD_INTERFACE (in-tree add_subdirectory consumption, e.g. ProfilerHub.cmake's
+# fallback tier) and INSTALL_INTERFACE (exported/installed package) entries are
+# needed - only one evaluates non-empty depending on how profiler-hub-static ends
+# up consumed.
+list(
+    APPEND profiler_hub_static_iface_libs
+    "$<BUILD_INTERFACE:profiler-hub_queries>"
+)
+list(
+    APPEND profiler_hub_static_iface_libs
+    "$<INSTALL_INTERFACE:profiler-hub::profiler-hub_queries>"
+)
 set_target_properties(
     profiler-hub-static
     PROPERTIES INTERFACE_LINK_LIBRARIES "${profiler_hub_static_iface_libs}"
@@ -372,6 +398,19 @@ install(
 
 install(
     TARGETS ${PACKAGE_NAME}-static
+    EXPORT ${PACKAGE_NAME}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT profiler-hub
+)
+
+# profiler-hub_queries is a real, separate static archive (query_builder_base.cpp,
+# select_query_builders.cpp), not something baked into libprofiler-hub.a - a static
+# archive never absorbs its own PRIVATE target_link_libraries dependencies' object
+# code, unlike a SHARED library. Any consumer of profiler-hub-static (installed or
+# in-tree) that uses public headers under source/queries/ (e.g. table_select_query.hpp,
+# used by profiler-hub's own reader_impl.cpp) needs this archive on its own link line.
+# Export it so tier-1 (installed package) consumers can resolve it too.
+install(
+    TARGETS profiler-hub_queries
     EXPORT ${PACKAGE_NAME}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT profiler-hub
 )

--- a/profilers/profiler-hub/CMakeLists.txt
+++ b/profilers/profiler-hub/CMakeLists.txt
@@ -269,11 +269,10 @@ endforeach()
 # otherwise get no transitive link requirements at all. Explicitly restore
 # the ones that are genuinely resolvable by real consumers.
 #
-# profiler-hub_queries is added below (BUILD_INTERFACE + INSTALL_INTERFACE):
-# unlike a SHARED library, a STATIC archive doesn't absorb its PRIVATE deps'
-# object code, so consumers need it linked explicitly. sqlite3 stays excluded
-# (separately-tracked follow-up); nlohmann_json is header-only, no link
-# symbols needed.
+# profiler-hub_queries and profiler-hub-sqlite3 are added below (BUILD_INTERFACE
+# + INSTALL_INTERFACE): unlike a SHARED library, a STATIC archive doesn't absorb
+# its PRIVATE deps' object code, so consumers need them linked explicitly.
+# nlohmann_json stays excluded: header-only, no link symbols needed.
 #
 # Each dependency added here must also get a matching find_dependency() call
 # in profiler-hub-config.cmake.in (accumulated below into
@@ -341,14 +340,20 @@ if(USE_SCHEMA_FROM_ROCPROFILER_SDK_ROCPD)
     )
 endif()
 # Always in-tree; needs both interfaces since only one evaluates non-empty
-# depending on how profiler-hub-static ends up consumed.
+# depending on how profiler-hub-static ends up consumed. Same reasoning
+# applies to profiler-hub-sqlite3 (interface wrapper around the vendored,
+# -fvisibility=hidden sqlite3 archive + CMAKE_DL_LIBS): never propagated
+# either, previously masked only by accident when a consumer happens to link
+# its own separate sqlite3 for unrelated reasons.
 list(
     APPEND profiler_hub_static_iface_libs
     "$<BUILD_INTERFACE:profiler-hub_queries>"
+    "$<BUILD_INTERFACE:profiler-hub-sqlite3>"
 )
 list(
     APPEND profiler_hub_static_iface_libs
     "$<INSTALL_INTERFACE:profiler-hub::profiler-hub_queries>"
+    "$<INSTALL_INTERFACE:profiler-hub::profiler-hub-sqlite3>"
 )
 set_target_properties(
     profiler-hub-static
@@ -390,6 +395,15 @@ install(
 # installed-package consumers can resolve it.
 install(
     TARGETS profiler-hub_queries
+    EXPORT ${PACKAGE_NAME}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT profiler-hub
+)
+
+# Same reasoning as profiler-hub_queries. profiler-hub-sqlite3 (INTERFACE,
+# no files of its own) is exported alongside the real archive it wraps so
+# profiler-hub::profiler-hub-sqlite3 resolves for installed-package consumers.
+install(
+    TARGETS profiler-hub-sqlite3-static profiler-hub-sqlite3
     EXPORT ${PACKAGE_NAME}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT profiler-hub
 )

--- a/profilers/profiler-hub/CMakeLists.txt
+++ b/profilers/profiler-hub/CMakeLists.txt
@@ -269,23 +269,11 @@ endforeach()
 # otherwise get no transitive link requirements at all. Explicitly restore
 # the ones that are genuinely resolvable by real consumers.
 #
-# profiler-hub_queries IS one of them (added below, both BUILD_INTERFACE and
-# INSTALL_INTERFACE): it is a genuinely separate static archive
-# (query_builder_base.cpp, select_query_builders.cpp) that profiler-hub-objects
-# only links PRIVATE. Unlike a SHARED library - which bakes a PRIVATE
-# dependency's object code directly into the .so at its own link time - a
-# plain STATIC library link never absorbs a dependency's object code, so
-# profiler-hub_queries's object files never make it into libprofiler-hub.a.
-# Any consumer that pulls in query-builder symbols, including profiler-hub's
-# own reader_impl.cpp, must be told to link profiler-hub_queries explicitly.
-# sqlite3 and profiler-hub-objects itself stay excluded: sqlite3 is in-tree-only
-# for now (a separately-tracked follow-up, not part of this fix), and
-# profiler-hub-objects is the object library itself, not a separate consumable
-# archive. nlohmann_json is deliberately excluded too: it is a PRIVATE,
-# header-only dependency of profiler-hub-objects that never appears in the
-# installed public headers, so it carries no link symbols a static consumer
-# needs. profiler-hub (SHARED) needs no such list: its dependencies are already
-# fully baked into the .so.
+# profiler-hub_queries is added below (BUILD_INTERFACE + INSTALL_INTERFACE):
+# unlike a SHARED library, a STATIC archive doesn't absorb its PRIVATE deps'
+# object code, so consumers need it linked explicitly. sqlite3 stays excluded
+# (separately-tracked follow-up); nlohmann_json is header-only, no link
+# symbols needed.
 #
 # Each dependency added here must also get a matching find_dependency() call
 # in profiler-hub-config.cmake.in (accumulated below into
@@ -352,12 +340,8 @@ if(USE_SCHEMA_FROM_ROCPROFILER_SDK_ROCPD)
         "find_dependency(rocprofiler-sdk-rocpd)\n"
     )
 endif()
-# Unconditional (not tied to the fmt/spdlog loop or the rocpd block above):
-# profiler-hub_queries is always built in-tree as part of this project, so both
-# the BUILD_INTERFACE (in-tree add_subdirectory consumption, e.g. ProfilerHub.cmake's
-# fallback tier) and INSTALL_INTERFACE (exported/installed package) entries are
-# needed - only one evaluates non-empty depending on how profiler-hub-static ends
-# up consumed.
+# Always in-tree; needs both interfaces since only one evaluates non-empty
+# depending on how profiler-hub-static ends up consumed.
 list(
     APPEND profiler_hub_static_iface_libs
     "$<BUILD_INTERFACE:profiler-hub_queries>"
@@ -402,13 +386,8 @@ install(
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT profiler-hub
 )
 
-# profiler-hub_queries is a real, separate static archive (query_builder_base.cpp,
-# select_query_builders.cpp), not something baked into libprofiler-hub.a - a static
-# archive never absorbs its own PRIVATE target_link_libraries dependencies' object
-# code, unlike a SHARED library. Any consumer of profiler-hub-static (installed or
-# in-tree) that uses public headers under source/queries/ (e.g. table_select_query.hpp,
-# used by profiler-hub's own reader_impl.cpp) needs this archive on its own link line.
-# Export it so tier-1 (installed package) consumers can resolve it too.
+# Not baked into libprofiler-hub.a (see comment above); export it too so
+# installed-package consumers can resolve it.
 install(
     TARGETS profiler-hub_queries
     EXPORT ${PACKAGE_NAME}


### PR DESCRIPTION
## Motivation

profiler-hub_queries and profiler-hub-sqlite3 (both separate static archives) were never linked into consumers of profiler-hub-static - masked until now by the default dynamic link. Blocks ROCm/rocm-systems#9195.

## Technical Details

Added both to profiler_hub_static_iface_libs (build + install interface) and to the exported install(TARGETS) set.

## Issue Tracking

JIRA ID: AIPROFSYST-669

## Test Plan

Rebuilt rocprofiler-systems with testing and static-link enabled, both with and without its own separate sqlite3 build (ROCPROFSYS_BUILD_SQLITE3 ON/OFF).

## Test Result

rocprof-sys-unit-tests now links cleanly (previously 59 undefined references). sqlite3 resolves unambiguously via profiler-hub's own archive when no competing sqlite3 exists (production config); no regression when one does (dev-build config). Full rebuilds clean, no regressions.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
