### PR TITLE
DNM: validate #9195 + #9197 together

### DIFF
--- a/projects/rocprofiler-systems/cmake/ProfilerHub.cmake
+++ b/projects/rocprofiler-systems/cmake/ProfilerHub.cmake
@@ -14,9 +14,9 @@ set(ROCPROFSYS_PROFILER_HUB_GIT_REPOSITORY
 )
 
 set(ROCPROFSYS_PROFILER_HUB_GIT_TAG
-    "0e57a383b016cfd75b02e83dfb2adcd55f395b42"
+    "8c3804013766488e2b7eba210e1b01f970245ca3"
     CACHE STRING
-    "Git commit for profiler-hub fallback sparse checkout (pinned to the #8610 merge commit that fixes profiler-hub's export-set and schema-API build failures)"
+    "Git commit for profiler-hub fallback sparse checkout (TEMPORARY: unmerged users/adjordje-amd/profiler-hub-queries-export branch tip, PR #9197, for DNM CI validation only - not for merge)"
 )
 
 set(ROCPROFSYS_PROFILER_HUB_GIT_SUBDIR

--- a/projects/rocprofiler-systems/cmake/ProfilerHub.cmake
+++ b/projects/rocprofiler-systems/cmake/ProfilerHub.cmake
@@ -26,7 +26,7 @@ set(ROCPROFSYS_PROFILER_HUB_GIT_SUBDIR
 )
 
 option(ROCPROFSYS_PROFILER_HUB_ENABLE_LOGGING "Enable profiler-hub logging" OFF)
-option(ROCPROFSYS_PROFILER_HUB_LINK_STATIC "Link profiler-hub statically" OFF)
+option(ROCPROFSYS_PROFILER_HUB_LINK_STATIC "Link profiler-hub statically" ON)
 
 # ------------------------------------------------------------------------------
 # Resolution order:


### PR DESCRIPTION
Draft, do not merge. Combines #9195 (static-link default flip) with a temporary pin bump to #9197's unmerged branch tip, to validate CI passes end to end before #9197 actually merges. Will close once confirmed; the real fix lands via #9195 + #9197 through the normal sequence (see #9195's task tracking).

Depends on: #9195, #9197