### PR TITLE
feat(rocprofiler-sdk): enable ATT (Advanced Thread Trace) on WSL

### DIFF
--- a/projects/rocprofiler-sdk/samples/thread_trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/samples/thread_trace/CMakeLists.txt
@@ -80,6 +80,14 @@ if(attdecoder_FOUND)
     set(IS_DISABLED OFF)
 endif()
 
+# WSL/DXG exposes no /dev/kfd; the standalone sample selects the KFD agent enumerator
+# and cannot seed rocprofiler agents there (the rocprofv3 tool path via LD_PRELOAD is
+# unaffected, and ATT capture/decode is covered by the integration tests).
+rocprofiler_sdk_kfd_available(_KFD_AVAILABLE)
+if(NOT _KFD_AVAILABLE)
+    set(IS_DISABLED ON)
+endif()
+
 rocprofiler_samples_get_preload_env(PRELOAD_ENV)
 list(APPEND PRELOAD_ENV "ROCPROFILER_TRACE_DECODER_LIB_PATH=${attdecoder_LIB_DIR}")
 

--- a/projects/rocprofiler-sdk/samples/thread_trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/samples/thread_trace/CMakeLists.txt
@@ -59,11 +59,13 @@ target_link_libraries(
 
 add_test(NAME thread-trace-sample COMMAND $<TARGET_FILE:thread-trace-sample>)
 
+# ROCPROFILER_SDK_TRACE_DECODER_ROOT lets an externally-built rocprof-trace-decoder be
+# located without installing it under ${ROCM_PATH} (e.g. a standalone decoder build dir).
 find_library(
     attdecoder_LIBRARY
     NAMES rocprof-trace-decoder
-    HINTS ${ROCM_PATH}
-    PATHS ${ROCM_PATH}
+    HINTS ${ROCPROFILER_SDK_TRACE_DECODER_ROOT} ${ROCM_PATH}
+    PATHS ${ROCPROFILER_SDK_TRACE_DECODER_ROOT} ${ROCM_PATH}
     PATH_SUFFIXES lib)
 
 if(attdecoder_LIBRARY)

--- a/projects/rocprofiler-sdk/samples/thread_trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/samples/thread_trace/CMakeLists.txt
@@ -80,8 +80,8 @@ if(attdecoder_FOUND)
     set(IS_DISABLED OFF)
 endif()
 
-# WSL/DXG exposes no /dev/kfd; the standalone sample selects the KFD agent enumerator
-# and cannot seed rocprofiler agents there (the rocprofv3 tool path via LD_PRELOAD is
+# WSL/DXG exposes no /dev/kfd; the standalone sample selects the KFD agent enumerator and
+# cannot seed rocprofiler agents there (the rocprofv3 tool path via LD_PRELOAD is
 # unaffected, and ATT capture/decode is covered by the integration tests).
 rocprofiler_sdk_kfd_available(_KFD_AVAILABLE)
 if(NOT _KFD_AVAILABLE)

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-on-wsl.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-on-wsl.rst
@@ -31,13 +31,22 @@ What works on WSL2
   fit. This was verified on a gfx11-class GPU under WSL2 with a four-counter
   collection (``SQ_WAVES GRBM_COUNT GRBM_GUI_ACTIVE SQ_INSTS_VALU``): all four
   counters were reported with no PM4 command-buffer overflow.
+* **Advanced Thread Trace (ATT)**: supported when the ``rocprof-trace-decoder``
+  library is available. ATT capture uses the same DXG path as hardware counter
+  collection; the captured shader-data stream is decoded by an
+  externally-provided ``librocprof-trace-decoder.so`` that ROCprofiler-SDK does
+  not build. Point rocprofv3 at it with ``--att-library-path`` or the
+  ``ROCPROF_ATT_LIBRARY_PATH`` environment variable. The build locates the
+  decoder for the ATT tests via ``ROCPROFILER_SDK_TRACE_DECODER_ROOT`` (an
+  extra find hint), falling back to ``${ROCM_PATH}/lib``; when it is not found
+  the ATT tests are skipped.
 
 Known limitations
 ==================
 
-* **PC sampling and Advanced Thread Trace (ATT)**: the software/decode layers
-  build and pass their unit tests, but the end-to-end paths require KFD
-  features that are not available on WSL2 and are therefore disabled.
+* **PC sampling**: the software/decode layers build and pass their unit tests,
+  but the end-to-end path requires KFD features that are not available on WSL2
+  and is therefore disabled.
 * **SPM (Streaming Performance Monitor)**: not available; the gfx11-class
   counter database does not expose SPM-capable counters.
 

--- a/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/CMakeLists.txt
@@ -42,11 +42,13 @@ rocprofiler_configure_pytest_files(CONFIG pytest.ini COPY validate.py conftest.p
 
 find_package(rocprofiler-sdk REQUIRED)
 
+# ROCPROFILER_SDK_TRACE_DECODER_ROOT lets an externally-built rocprof-trace-decoder be
+# located without installing it under ${ROCM_PATH} (e.g. a standalone decoder build dir).
 find_library(
     attdecoder_LIBRARY
     NAMES rocprof-trace-decoder
-    HINTS ${ROCM_PATH}
-    PATHS ${ROCM_PATH}
+    HINTS ${ROCPROFILER_SDK_TRACE_DECODER_ROOT} ${ROCM_PATH}
+    PATHS ${ROCPROFILER_SDK_TRACE_DECODER_ROOT} ${ROCM_PATH}
     PATH_SUFFIXES lib)
 
 if(attdecoder_LIBRARY)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/CMakeLists.txt
@@ -41,11 +41,13 @@ rocprofiler_configure_pytest_files(CONFIG pytest.ini COPY validate.py conftest.p
 
 find_package(rocprofiler-sdk REQUIRED)
 
+# ROCPROFILER_SDK_TRACE_DECODER_ROOT lets an externally-built rocprof-trace-decoder be
+# located without installing it under ${ROCM_PATH} (e.g. a standalone decoder build dir).
 find_library(
     attdecoder_LIBRARY
     NAMES rocprof-trace-decoder
-    HINTS ${ROCM_PATH}
-    PATHS ${ROCM_PATH}
+    HINTS ${ROCPROFILER_SDK_TRACE_DECODER_ROOT} ${ROCM_PATH}
+    PATHS ${ROCPROFILER_SDK_TRACE_DECODER_ROOT} ${ROCM_PATH}
     PATH_SUFFIXES lib)
 
 if(attdecoder_LIBRARY)


### PR DESCRIPTION
## Motivation
Enable **Advanced Thread Trace (ATT)** capture ->decode on WSL2. rocprofv3's ATT
workflow depends on the external `rocprof-trace-decoder` library; on WSL the build
could not locate an externally-built decoder, and the standalone `thread_trace`
sample aborts on WSL (there is no `/dev/kfd`). This PR wires up decoder discovery
and gates the WSL-incompatible standalone sample so ATT works end-to-end on WSL,
completing the ATT portion of the WSL enablement effort (building on the WSL
compute/counter support in #7016).
## Technical Details
- **Decoder discovery:** add a `ROCPROFILER_SDK_TRACE_DECODER_ROOT` hint to the
  `find_library` HINTS/PATHS in the thread-trace sample and ATT test CMake sites
  (`samples/thread_trace`, `tests/rocprofv3/advanced-thread-trace`,
  `tests/rocprofv3/att-consecutive-kernels`), so an externally-built
  `rocprof-trace-decoder` is found without requiring it under the default ROCm prefix.
- **WSL docs:** update `source/docs/how-to/using-rocprofv3-on-wsl.rst` — move ATT into
  "What works on WSL2" and narrow "Known limitations" to PC sampling only.
- **Standalone sample gate:** skip the standalone `thread_trace` sample's ctest when
  `/dev/kfd` is absent, reusing the existing `rocprofiler_sdk_kfd_available()` helper.
  The standalone sample selects the gnulinux/KFD agent enumerator and cannot seed
  rocprofiler agents on WSL, so it aborts; the rocprofv3 tool path (via `LD_PRELOAD`)
  selects the WSL enumerator and is unaffected. ATT capture/decode itself remains fully
  covered by the integration tests.
Stacked on #7016 (`users/ihhuang/wsl-rocprofv3-compute`) — depends on that PR's WSL
platform/topology support. Once #7016 merges to develop, this PR should be retargeted
to develop.
## Issue Tracking
<!-- Fill in the actual IDs before submitting; leave the comment form (no full JIRA links). -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/XXXX -->
<!-- JIRA ID: <COMPONENT>-XXXX -->
## Test Plan
Verified end-to-end on a WSL2 gfx11-class GPU:
- Decoder discovered at configure time; 32 ATT tests enabled.
- Decoder-logic unit tests pass (`att_decoder_waitcnt` gfx9/10/12 + `fail_conditions`).
- End-to-end capture→decode: focused subset 15/15; full ATT subset **86/86** (with the
  standalone sample gated on kfd-absence). The `validate.*` decode-parse steps
  (shaderdata, marker-trace, perfcounter-target-cu, other-simd, multiqueue json/cmd)
  confirm the decoder emits ISA/marker/dispatch output.
- No behavioral change on bare-metal Linux — the sample gate only triggers when
  `/dev/kfd` is absent.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
