### PR TITLE
AIRUNTIME-2512 : make SpawnProc stderr capture opt-in

### DIFF
--- a/projects/hip-tests/catch/include/hip_test_process.hh
+++ b/projects/hip-tests/catch/include/hip_test_process.hh
@@ -108,6 +108,7 @@ class SpawnProc {
   std::string resultStr_;
   std::string tmpFileName_;
   bool captureOutput_;
+  bool captureStderr_;
   Process process_{};
   bool spawned_ = false;
   std::future<int> asyncFuture_;
@@ -163,7 +164,8 @@ class SpawnProc {
       if (hFile != INVALID_HANDLE_VALUE) {
         si.dwFlags |= STARTF_USESTDHANDLES;
         si.hStdOutput = hFile;
-        si.hStdError = hFile;  // Redirect stderr to the same file as stdout
+        // Only merge stderr into the captured file when explicitly requested.
+        si.hStdError = captureStderr_ ? hFile : GetStdHandle(STD_ERROR_HANDLE);
         si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
         inheritHandles = TRUE;
       }
@@ -230,7 +232,8 @@ class SpawnProc {
         int fd = open(tmpFileName_.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
         if (fd >= 0) {
           dup2(fd, STDOUT_FILENO);
-          dup2(fd, STDERR_FILENO);  // Redirect stderr to the same file as stdout
+          // Only merge stderr into the captured file when explicitly requested.
+          if (captureStderr_) dup2(fd, STDERR_FILENO);
           close(fd);
         }
       }
@@ -290,8 +293,14 @@ class SpawnProc {
   }
 
  public:
-  SpawnProc(std::string exeName, bool captureOutput = false)
-      : exeName_(std::move(exeName)), captureOutput_(captureOutput) {
+  // captureStderr only takes effect when captureOutput is also true. It merges
+  // the child's stderr into the captured output; leave it false for tests that
+  // compare stdout exactly, so unrelated stderr (diagnostics or banners) does
+  // not corrupt the comparison. Opt in for tests that assert on stderr content
+  // (e.g. AMD_LOG output).
+  SpawnProc(std::string exeName, bool captureOutput = false, bool captureStderr = false)
+      : exeName_(std::move(exeName)), captureOutput_(captureOutput),
+        captureStderr_(captureStderr) {
     if (!fs::path(exeName_).is_absolute()) {
       auto dir = fs::path(TestContext::get().currentPath());
       dir /= exeName_;

--- a/projects/hip-tests/catch/unit/env/hipEnvGpuEnablePal.cc
+++ b/projects/hip-tests/catch/unit/env/hipEnvGpuEnablePal.cc
@@ -43,7 +43,7 @@
  *  - HIP_VERSION >= 6.0
  */
 HIP_TEST_CASE(Unit_hipEnvGpuEnablePal_Default_UsesPlatformDefault) {
-  hip::SpawnProc proc("hipSetEnv_helper", true);
+  hip::SpawnProc proc("hipSetEnv_helper", true, /*captureStderr=*/true);
 
   int result = proc.run("GPU_ENABLE_PAL UNSET");
   std::string output = proc.getOutput();
@@ -83,7 +83,7 @@ HIP_TEST_CASE(Unit_hipEnvGpuEnablePal_Default_UsesPlatformDefault) {
  *  - HIP_VERSION >= 6.0
  */
 HIP_TEST_CASE(Unit_hipEnvGpuEnablePal_EmptyString_UsesPlatformDefault) {
-  hip::SpawnProc proc("hipSetEnv_helper", true);
+  hip::SpawnProc proc("hipSetEnv_helper", true, /*captureStderr=*/true);
 
   int result = proc.run("GPU_ENABLE_PAL \"\"");
   std::string output = proc.getOutput();
@@ -127,7 +127,7 @@ HIP_TEST_CASE(Unit_hipEnvGpuEnablePal_ExplicitValues_WorkCorrectly) {
   // AIRUNTIME-2370. fails rocr init and conitinues to init PAL
   // Once the issue is fixed this can be enabled
   {
-    hip::SpawnProc proc0("hipSetEnv_helper", true);
+    hip::SpawnProc proc0("hipSetEnv_helper", true, /*captureStderr=*/true);
     int result0 = proc0.run("GPU_ENABLE_PAL 0");
     std::string output0 = proc0.getOutput();
     // Debug: print what we received
@@ -143,7 +143,7 @@ HIP_TEST_CASE(Unit_hipEnvGpuEnablePal_ExplicitValues_WorkCorrectly) {
 
   // Test GPU_ENABLE_PAL="1" -> PAL
   {
-    hip::SpawnProc proc1("hipSetEnv_helper", true);
+    hip::SpawnProc proc1("hipSetEnv_helper", true, /*captureStderr=*/true);
     int result1 = proc1.run("GPU_ENABLE_PAL 1");
     std::string output1 = proc1.getOutput();
     // Debug: print what we received
@@ -165,7 +165,7 @@ HIP_TEST_CASE(Unit_hipEnvGpuEnablePal_ExplicitValues_WorkCorrectly) {
 
   // Test GPU_ENABLE_PAL="2" -> Auto-select
   {
-    hip::SpawnProc proc2("hipSetEnv_helper", true);
+    hip::SpawnProc proc2("hipSetEnv_helper", true, /*captureStderr=*/true);
     int result2 = proc2.run("GPU_ENABLE_PAL 2");
     std::string output2 = proc2.getOutput();
     // Debug: print what we received


### PR DESCRIPTION
## Motivation
  `SpawnProc` unconditionally redirected the child process's stderr into the same
  file it used to capture stdout. Tests that compare stdout exactly are fragile
  under this behavior: any unrelated stderr from the child (driver diagnostics,
  banners, log lines) gets interleaved into the captured buffer and corrupts the
  comparison. This makes stdout-only tests flaky depending on the environment.


## Technical Details

 Make stderr capture opt-in via a new `captureStderr` constructor parameter on
  `SpawnProc` (default `false`). It only takes effect when `captureOutput` is
  also `true`.

  - When `captureStderr` is false, the child's stderr is left attached to the
    parent's stderr instead of being merged into the capture file
    (`GetStdHandle(STD_ERROR_HANDLE)` on Windows; skip the `dup2` on POSIX).
  - When `captureStderr` is true, behavior is unchanged — stderr is merged into
    the captured stdout file, which is what tests asserting on stderr content
    (e.g. `AMD_LOG` output) rely on.
  - Updated `hipEnvGpuEnablePal.cc`, which does assert on stderr content, to pass
    `captureStderr=true` explicitly so it keeps its existing behavior.


## Issue Tracking

AIRUNTIME-2512

## Test Plan

  - Build hip-tests catch suite.
  - Run the `Unit_hipEnvGpuEnablePal_*` cases that assert on stderr content to
    confirm they still pass with the explicit `captureStderr=true`.
  - Run a stdout-only comparison test to confirm unrelated stderr no longer
    leaks into the captured output.


## Test Result

Tests pass

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
