### PR TITLE
feat(ci): enable postsubmit ASAN on push to develop

### DIFF
--- a/.github/workflows/therock-multi-arch-ci-asan.yml
+++ b/.github/workflows/therock-multi-arch-ci-asan.yml
@@ -3,12 +3,18 @@
 
 # Multi-Arch CI ASAN for rocm-systems
 #
-# On-demand ASAN builds with full device-side instrumentation.
+# Postsubmit and on-demand ASAN builds. TheRock's configure_multi_arch_ci.py
+# automatically selects host-asan for push events (faster, host-only) and
+# full asan for workflow_dispatch (comprehensive device-side instrumentation).
+#
 # For scheduled nightly runs, see therock-multi-arch-ci-asan-nightly.yml.
 
 name: TheRock Multi-Arch CI ASAN
 
 on:
+  push:
+    branches:
+      - develop
   workflow_dispatch:
     inputs:
       linux_amdgpu_families:


### PR DESCRIPTION
TheRock's configure_multi_arch_ci.py automatically selects host-asan (faster, host-only sanitization) for push events, while workflow_dispatch continues to use full asan with device-side instrumentation.

TheRock's configure_multi_arch_ci.py already handles this automatically (lines 1218-1220):
```
  if build_variant == "asan" and ci_inputs.is_push:
      build_variant = "host-asan"
```

ISSUE ID: https://github.com/ROCm/TheRock/issues/6627