### PR TITLE
build(rocm-smi): add ROCM_SMI_DISABLE gate to skip build

### DIFF
--- a/projects/rocm-smi-lib/CHANGELOG.md
+++ b/projects/rocm-smi-lib/CHANGELOG.md
@@ -6,6 +6,11 @@ Full documentation for rocm_smi_lib is available at [https://rocm.docs.amd.com/]
 
 ## rocm_smi_lib for ROCm 7.2.0
 
+### Changed
+
+- **Added `ROCM_SMI_DISABLE` build gate**.
+  - Setting `ROCM_SMI_DISABLE=True` (environment or CMake cache variable) skips building and installing rocm-smi-lib entirely. Composite builds such as TheRock use this to drop the deprecated library from the ROCm stack. Use [AMD SMI](https://github.com/ROCm/amdsmi) instead.
+
 ### Added
 
 - **Added runtime power management detection and device wake support**.  

--- a/projects/rocm-smi-lib/CHANGELOG.md
+++ b/projects/rocm-smi-lib/CHANGELOG.md
@@ -4,12 +4,14 @@ Full documentation for rocm_smi_lib is available at [https://rocm.docs.amd.com/]
 
 ***All information listed below is for reference and subject to change.***
 
-## rocm_smi_lib for ROCm 7.2.0
+## rocm_smi_lib for ROCm 7.15.0
 
 ### Changed
 
 - **Added `ROCM_SMI_DISABLE` build gate**.
-  - Setting `ROCM_SMI_DISABLE=True` (environment or CMake cache variable) skips building and installing rocm-smi-lib entirely. Composite builds such as TheRock use this to drop the deprecated library from the ROCm stack. Use [AMD SMI](https://github.com/ROCm/amdsmi) instead.
+  - Setting `ROCM_SMI_DISABLE=True` (environment or CMake cache variable) skips building and installing rocm-smi-lib entirely. rocm-smi-lib is no longer included in TheRock builds; it can still be built from source if desired. Use [AMD SMI](https://github.com/ROCm/amdsmi) instead.
+
+## rocm_smi_lib for ROCm 7.2.0
 
 ### Added
 

--- a/projects/rocm-smi-lib/CHANGELOG.md
+++ b/projects/rocm-smi-lib/CHANGELOG.md
@@ -4,7 +4,7 @@ Full documentation for rocm_smi_lib is available at [https://rocm.docs.amd.com/]
 
 ***All information listed below is for reference and subject to change.***
 
-## rocm_smi_lib for ROCm 7.15.0
+## rocm_smi_lib for ROCm 10.0.0
 
 ### Changed
 

--- a/projects/rocm-smi-lib/CMakeLists.txt
+++ b/projects/rocm-smi-lib/CMakeLists.txt
@@ -7,6 +7,28 @@ message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 cmake_minimum_required(VERSION 3.14)
 project(rocm_smi_lib)
 
+# ROCm SMI is deprecated in favor of AMD SMI. Builds (including TheRock) set
+# ROCM_SMI_DISABLE=True to skip building the library entirely. Honor both the
+# cache variable and the environment variable of the same name.
+if(DEFINED ENV{ROCM_SMI_DISABLE} AND NOT DEFINED ROCM_SMI_DISABLE)
+    set(ROCM_SMI_DISABLE
+        "$ENV{ROCM_SMI_DISABLE}"
+        CACHE BOOL
+        "Deprecated: skip building rocm-smi-lib"
+        FORCE
+    )
+endif()
+option(ROCM_SMI_DISABLE "Deprecated: skip building rocm-smi-lib" OFF)
+
+if(ROCM_SMI_DISABLE)
+    message(
+        WARNING
+        "rocm-smi-lib is deprecated and ROCM_SMI_DISABLE is set; skipping build. "
+        "Use AMD SMI instead: https://github.com/ROCm/amdsmi"
+    )
+    return()
+endif()
+
 set(ROCM_SMI_LIBS_TARGET "rocm_smi_libraries")
 
 set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared library (.so) or not.")

--- a/projects/rocm-smi-lib/README.md
+++ b/projects/rocm-smi-lib/README.md
@@ -3,7 +3,7 @@
 Starting with ROCm 7.0, only critical bug fixes will be applied to ROCm-SMI.
 For a seamless experience and continued support, please switch to [AMD-SMI](https://github.com/ROCm/amdsmi).
 
-As of ROCm 7.15, ROCm-SMI is no longer included in TheRock builds. It can still be built from source if desired (see the [installation guide](https://rocm.docs.amd.com/projects/rocm_smi_lib/en/latest/install/install.html)).
+As of ROCm 10.0, ROCm-SMI is no longer included in TheRock builds. It can still be built from source if desired (see the [installation guide](https://rocm.docs.amd.com/projects/rocm_smi_lib/en/latest/install/install.html)).
 
 ## Use C++ in ROCm SMI
 

--- a/projects/rocm-smi-lib/README.md
+++ b/projects/rocm-smi-lib/README.md
@@ -3,6 +3,8 @@
 Starting with ROCm 7.0, only critical bug fixes will be applied to ROCm-SMI.
 For a seamless experience and continued support, please switch to [AMD-SMI](https://github.com/ROCm/amdsmi).
 
+As of ROCm 7.15, ROCm-SMI is no longer included in TheRock builds. It can still be built from source if desired (see the [installation guide](https://rocm.docs.amd.com/projects/rocm_smi_lib/en/latest/install/install.html)).
+
 ## Use C++ in ROCm SMI
 
 ### Device Indices

--- a/projects/rocm-smi-lib/docs/index.rst
+++ b/projects/rocm-smi-lib/docs/index.rst
@@ -18,7 +18,7 @@ For more information, refer to `<https://github.com/ROCm/rocm_smi_lib>`__.
 
    AMD SMI will replace ``rocm_smi_lib`` over time. We recommend that users transition to AMD SMI.
 
-   As of ROCm 7.15, ROCm SMI is no longer included in TheRock builds. It can still be built from source if desired
+   As of ROCm 10.0, ROCm SMI is no longer included in TheRock builds. It can still be built from source if desired
    (see the :doc:`installation guide <./install/install>`), but new deployments should use AMD SMI.
 
    For more information, refer to `<https://github.com/ROCm/amdsmi>`__ and the :doc:`AMD SMI documentation <amdsmi:index>`.

--- a/projects/rocm-smi-lib/docs/index.rst
+++ b/projects/rocm-smi-lib/docs/index.rst
@@ -18,6 +18,9 @@ For more information, refer to `<https://github.com/ROCm/rocm_smi_lib>`__.
 
    AMD SMI will replace ``rocm_smi_lib`` over time. We recommend that users transition to AMD SMI.
 
+   As of ROCm 7.15, ROCm SMI is no longer included in TheRock builds. It can still be built from source if desired
+   (see the :doc:`installation guide <./install/install>`), but new deployments should use AMD SMI.
+
    For more information, refer to `<https://github.com/ROCm/amdsmi>`__ and the :doc:`AMD SMI documentation <amdsmi:index>`.
 
 .. grid:: 2

--- a/projects/rocm-smi-lib/docs/install/install.rst
+++ b/projects/rocm-smi-lib/docs/install/install.rst
@@ -67,7 +67,7 @@ Disabling the build
 Because ROCm SMI is deprecated, its build can be skipped entirely. Set
 ``ROCM_SMI_DISABLE=True`` as either an environment variable or a CMake cache
 variable and the project configures to a no-op, building and installing nothing.
-As of ROCm 7.15, TheRock uses this to exclude ROCm SMI from the ROCm stack; it
+As of ROCm 10.0, TheRock uses this to exclude ROCm SMI from the ROCm stack; it
 can still be built from source if desired.
 
 .. code-block:: shell

--- a/projects/rocm-smi-lib/docs/install/install.rst
+++ b/projects/rocm-smi-lib/docs/install/install.rst
@@ -61,6 +61,22 @@ After the ROCm SMI library git repository is cloned to a local Linux machine, us
 
 The built library will appear in the `build` folder.
 
+Disabling the build
+===================
+
+Because ROCm SMI is deprecated, its build can be skipped entirely. Set
+``ROCM_SMI_DISABLE=True`` as either an environment variable or a CMake cache
+variable and the project configures to a no-op, building and installing nothing.
+Composite builds such as TheRock use this to drop ROCm SMI from the ROCm stack.
+
+.. code-block:: shell
+
+    # As an environment variable
+    ROCM_SMI_DISABLE=True cmake ..
+
+    # Or as a CMake cache variable
+    cmake .. -DROCM_SMI_DISABLE=True
+
 To build the rpm and deb packages follow the above steps with:
 
 .. code-block:: shell

--- a/projects/rocm-smi-lib/docs/install/install.rst
+++ b/projects/rocm-smi-lib/docs/install/install.rst
@@ -67,7 +67,8 @@ Disabling the build
 Because ROCm SMI is deprecated, its build can be skipped entirely. Set
 ``ROCM_SMI_DISABLE=True`` as either an environment variable or a CMake cache
 variable and the project configures to a no-op, building and installing nothing.
-Composite builds such as TheRock use this to drop ROCm SMI from the ROCm stack.
+As of ROCm 7.15, TheRock uses this to exclude ROCm SMI from the ROCm stack; it
+can still be built from source if desired.
 
 .. code-block:: shell
 


### PR DESCRIPTION
## Motivation

ROCm SMI is deprecated in favor of AMD SMI. Composite builds such as TheRock need a supported way to skip building the library entirely without patching its sources.

## Technical Details

**Build gate** (`projects/rocm-smi-lib/CMakeLists.txt`):
- Honor `ROCM_SMI_DISABLE` as either an environment variable or a CMake cache variable
- When set, emit a deprecation warning and `return()` before any target is declared, so nothing is built or installed

**Docs** (`projects/rocm-smi-lib/docs/install/install.rst`):
- Document the `ROCM_SMI_DISABLE=True` opt-out for both env and `-D` usage

**Changelog** (`projects/rocm-smi-lib/CHANGELOG.md`):
- Note the new build gate

## Issue Tracking

JIRA ID: ROCM-996

## Test Plan

- `cmake -DROCM_SMI_DISABLE=True ..` — configures to a no-op, no artifacts
- `ROCM_SMI_DISABLE=True cmake ..` — same via environment variable
- `cmake ..` (unset) — normal configure proceeds

## Test Result

All three cases behave as expected: the flag short-circuits the build; unset builds normally.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
