### PR TITLE
refactor(rocjitsu): Fold new SpecialRegisterSet into RegisterSet

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.cpp
@@ -82,7 +82,7 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
     if (auto ref = op->to_register_ref())
       add_def(*this, inst, *op, *ref, vgpr_msb);
     else if (auto sc = op->to_special_reg_class())
-      special_defs.insert(*sc);
+      defs.expand(RegisterRef{*sc, 0, 1}); // singleton special def
   }
   inst.implicit_defs(defs);
 
@@ -93,7 +93,7 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
     if (auto ref = op->to_register_ref())
       expand_operand_register(uses, inst, *op, *ref, vgpr_msb, OperandExpansionKind::Use);
     else if (auto sc = op->to_special_reg_class())
-      special_uses.insert(*sc);
+      uses.expand(RegisterRef{*sc, 0, 1}); // singleton special use
   }
   inst.implicit_uses(uses);
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.h
@@ -10,14 +10,12 @@
 /// determines which register class and index are involved. Instruction
 /// subclasses may also report hidden register effects through implicit hooks.
 ///
-/// Ordinary register-file effects (SGPR/VGPR/AccVGPR) live in `defs`/`uses`
-/// and drive scratch-allocation liveness. Architectural special-register
-/// effects (EXEC/VCC/SCC/M0/PC/...) and memory effects are exposed on separate
-/// members (`special_defs`/`special_uses`, `memory`) so consumers can query
-/// them without those effects ever entering ordinary liveness. Those separate
-/// members are currently always empty and will be populated once generated
-/// operands report special/memory effects; the ordinary `defs`/`uses` behavior
-/// is unchanged.
+/// `defs`/`uses` hold both ordinary register-file effects (SGPR/VGPR/AccVGPR)
+/// and architectural special-register effects (EXEC/VCC/SCC/M0/PC/...) in one
+/// RegisterSet each. Special registers are singleton members of that set;
+/// consumers that drive scratch-allocation liveness project them out with
+/// `RegisterSet::ordinary_only()` so special state never looks allocatable.
+/// Memory effects are summarized separately in `memory`.
 
 #pragma once
 
@@ -30,12 +28,12 @@ class Gfx1250VgprMsbAnalysis;
 
 /// @brief Memory-effect summary for one decoded instruction.
 ///
-/// @details A coarse description of what memory an instruction touches. Not
-/// currently used. Present now so `InstDefUse` has a stable shape for DBT/DBI
-/// consumers. All flags default to false (no memory effect).
+/// @details A coarse description of what memory an instruction touches. No
+/// operand currently populates these flags, so every field is false today;
+/// the summary exists so `InstDefUse` has a stable shape for DBT/DBI consumers.
 ///
-/// TODO: Update when OPR_GPUMEM, OPR_DSMEM, and OPR_FLAT_SCRATCH become
-/// avaialable.
+/// TODO: Populate from OPR_GPUMEM, OPR_DSMEM, and OPR_FLAT_SCRATCH operands
+/// once memory pseudo-operands report their effects.
 struct MemoryEffects {
   bool reads = false;   ///< Reads memory.
   bool writes = false;  ///< Writes memory.
@@ -57,11 +55,9 @@ public:
   /// @param inst Decoded instruction whose operands have stable lifetimes.
   InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vgpr_msb = nullptr);
 
-  RegisterSet defs;                ///< Ordinary registers overwritten by the instruction.
-  RegisterSet uses;                ///< Ordinary registers read before the instruction writes defs.
-  SpecialRegisterSet special_defs; ///< Special registers (EXEC/VCC/SCC/M0/PC/...) written.
-  SpecialRegisterSet special_uses; ///< Special registers read.
-  MemoryEffects memory;            ///< Memory-effect summary.
+  RegisterSet defs;     ///< Registers written (ordinary lanes + special singletons).
+  RegisterSet uses;     ///< Registers read before defs (ordinary lanes + special singletons).
+  MemoryEffects memory; ///< Memory-effect summary.
   bool has_exec_masked_vector_def = false; ///< True if any vector def is predicated by EXEC.
   bool has_predicated_def = false;         ///< True if defs preserve old values on some paths.
 };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
@@ -56,7 +56,9 @@ void dfs_reverse_post_order(const BasicBlock &start,
 }
 
 [[nodiscard]] RegisterSet kill_defs(const InstDefUse &du) {
-  RegisterSet kills = du.defs;
+  // Ordinary registers only: special singletons (EXEC/VCC/...) live in du.defs
+  // but are not part of scratch-allocation liveness and must not become kills.
+  RegisterSet kills = du.defs.ordinary_only();
   // Predicated defs and EXEC-masked vector defs preserve old values on at least
   // one path or lane. Until EXEC state is tracked at each program point, those
   // writes cannot be treated as unconditional liveness kills.
@@ -184,7 +186,7 @@ void LivenessAnalysis::analyze(KernelBlockScope blocks, const LivenessAnalysisOp
         ++requested_live_before_by_block[i];
       InstDefUse du(inst, gfx1250_vgpr_msb_.get());
       RegisterSet kills = kill_defs(du);
-      RegisterSet upward_uses = du.uses;
+      RegisterSet upward_uses = du.uses.ordinary_only();
       upward_uses -= state.kill;
       state.gen |= upward_uses;
       state.kill |= kills;
@@ -254,7 +256,7 @@ void LivenessAnalysis::analyze(KernelBlockScope blocks, const LivenessAnalysisOp
       InstDefUse du(*inst, gfx1250_vgpr_msb_.get());
       RegisterSet kills = kill_defs(du);
       live -= kills;
-      live |= du.uses;
+      live |= du.uses.ordinary_only();
       if (!filter_live_before || requested_live_before.contains(inst)) {
         live_before_.emplace(inst, live);
         if (filter_live_before && --remaining_requested == 0)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
@@ -52,6 +52,9 @@ struct ScopedCfgEdge {
 /// block. The standard backward equations are:
 ///   live_out(B) = union(live_in(S) for S in successors(B))
 ///   live_in(B)  = gen(B) union (live_out(B) - kill(B))
+///
+/// All four sets are ordinary-register-only; special singletons are projected
+/// out of each instruction's def/use before the transfer function runs.
 struct BlockLiveness {
   RegisterSet live_in;
   RegisterSet live_out;
@@ -153,9 +156,15 @@ public:
   [[nodiscard]] const BlockLiveness &block_liveness(const BasicBlock &block) const;
 
   /// @brief Registers live immediately before @p inst executes.
+  ///
+  /// @details Ordinary registers only. Special singletons (EXEC/M0/PC/...) are
+  /// deliberately excluded: implicit special uses are not yet fully modeled, so
+  /// this analysis does not answer special-register liveness.
   [[nodiscard]] const RegisterSet &live_before(const Instruction &inst) const;
 
-  /// @brief Convenience predicate for one register reference.
+  /// @brief Convenience predicate for one register reference. Only meaningful
+  /// for ordinary classes; special-register liveness is not tracked (see
+  /// live_before()).
   [[nodiscard]] bool is_live_before(const Instruction &inst, RegisterRef ref) const;
 
   /// @brief gfx1250 VGPR bank selected for @p role before @p inst.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -88,23 +88,32 @@ struct AppliedSite {
   uint16_t target_pair_base = 0;
 };
 
-// Human-readable single-lane register name for spill diagnostics.
+// Human-readable register name for spill diagnostics. Ordinary registers are
+// named by prefix and index (s5, v3, acc2); special singletons carry no index.
 std::string reg_name(RegisterRef ref) {
-  const char *prefix = "?";
   switch (ref.cls) {
   case RegClass::SGPR:
-    prefix = "s";
-    break;
+    return "s" + std::to_string(ref.index);
   case RegClass::VGPR:
-    prefix = "v";
-    break;
+    return "v" + std::to_string(ref.index);
   case RegClass::ACC_VGPR:
-    prefix = "acc";
-    break;
-  default:
-    break;
+    return "acc" + std::to_string(ref.index);
+  case RegClass::EXEC:
+    return "exec";
+  case RegClass::VCC:
+    return "vcc";
+  case RegClass::SCC:
+    return "scc";
+  case RegClass::M0:
+    return "m0";
+  case RegClass::FLAT_SCRATCH:
+    return "flat_scratch";
+  case RegClass::TTMP:
+    return "ttmp";
+  case RegClass::PC:
+    return "pc";
   }
-  return std::string(prefix) + std::to_string(ref.index);
+  return "?" + std::to_string(ref.index);
 }
 
 // Special machine state has no save/restore path across a probe call yet.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_clobber.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_clobber.cpp
@@ -146,9 +146,11 @@ std::optional<ProbeClobberSummary> build_probe_clobber_summary(const ProbeCallab
       return std::nullopt;
     }
 
-    // Ordinary clobbers (SGPR/VGPR/AccVGPR), including implicit defs.
+    // Ordinary clobbers (SGPR/VGPR/AccVGPR), including implicit defs. Special
+    // singletons in du.defs are projected out — they are summarized separately
+    // via scan_special_state below and must not enter ordinary_clobbers.
     const InstDefUse du(*inst);
-    summary.ordinary_clobbers |= du.defs;
+    summary.ordinary_clobbers |= du.defs.ordinary_only();
 
     scan_special_state(*inst, summary);
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.cpp
@@ -15,8 +15,9 @@ namespace rocjitsu {
 namespace {
 
 /// Per-class hardware bound. Indices >= this are not representable in
-/// RegisterSet's bitsets and indicate either a programming error or a class
-/// that RegisterSet doesn't track (EXEC, VCC, etc.).
+/// RegisterSet's per-index bitsets and indicate either a programming error or a
+/// special singleton class (EXEC, VCC, ...) that has no scratch slot; those
+/// return 0 so every index is rejected.
 [[nodiscard]] size_t per_class_max(RegClass cls) {
   switch (cls) {
   case RegClass::SGPR:
@@ -85,9 +86,16 @@ std::optional<uint32_t> SpillManager::allocate_slots(RegisterRef reg, unsigned w
 }
 
 bool SpillManager::reserve(const RegisterSet &set) {
+  // Special singletons (EXEC/VCC/...) have no scratch slot. Reject the whole
+  // request up front rather than letting one reach allocate_slot's bounds
+  // rejection and trip the post-capacity-check assert below. Special-register
+  // preservation is out of scope for this allocator.
+  if (set.has_specials())
+    return false;
+
   // Count NEW registers (cache misses) so we can size-check upfront.
   unsigned num_new = 0;
-  set.for_each([&](RegisterRef reg) {
+  set.for_each_ordinary([&](RegisterRef reg) {
     const std::pair<RegClass, uint16_t> key{reg.cls, reg.index};
     if (!reg_to_offset_.contains(key))
       ++num_new;
@@ -97,9 +105,9 @@ bool SpillManager::reserve(const RegisterSet &set) {
   }
 
   // Capacity check passed — no failure possible from here. Every reg from
-  // for_each is within per-class bounds (the bitset itself enforces that),
-  // and we just verified there's enough room.
-  set.for_each([this](RegisterRef reg) {
+  // for_each_ordinary is within per-class bounds (the bitset itself enforces
+  // that), and we just verified there's enough room.
+  set.for_each_ordinary([this](RegisterRef reg) {
     [[maybe_unused]] auto off = allocate_slot(reg);
     assert(off.has_value() && "allocate_slot failed after capacity check");
   });

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.h
@@ -114,10 +114,12 @@ public:
   ///       partially-completed allocation never becomes visible.
   [[nodiscard]] std::optional<uint32_t> allocate_slots(RegisterRef reg, unsigned width);
 
-  /// @brief Allocate slots for every register in @p set.
+  /// @brief Allocate slots for every ordinary register in @p set.
   /// @returns true on success. On failure the manager is unchanged — the
   ///          capacity check runs upfront across all new registers, so no
   ///          partial commit is possible.
+  /// @note A set containing any special singleton (EXEC/VCC/...) fails cleanly
+  ///       and reserves nothing: special registers have no scratch slot.
   /// @note An empty set or a set whose registers are all already cached
   ///       returns true even on an over-limit manager — no new bytes are
   ///       requested, so no capacity check fires.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.h
@@ -97,10 +97,10 @@ public:
   /// @details Returns the special RegClass (EXEC/VCC/SCC/M0/PC) for a fieldless
   /// architectural special operand, or nullopt for everything else. This is the
   /// special-register counterpart of to_register_ref(): special registers are
-  /// singletons tracked by SpecialRegisterSet, deliberately kept out of the
-  /// ordinary SGPR/VGPR/AccVGPR RegisterSet liveness that drives scratch
-  /// allocation. ISA-specific subclasses override this from the generated
-  /// fieldless operand policy effect column; the base returns nullopt.
+  /// recorded as singleton members of a RegisterSet, which scratch-allocation
+  /// liveness projects out with ordinary_only() so they never look allocatable.
+  /// ISA-specific subclasses override this from the generated fieldless operand
+  /// policy effect column; the base returns nullopt.
   [[nodiscard]] virtual std::optional<RegClass> to_special_reg_class() const;
 
   /// @brief Raw encoding value from the instruction binary.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
@@ -4,6 +4,7 @@
 #include "rocjitsu/isa/register_set.h"
 
 #include <algorithm>
+#include <bit>
 
 namespace rocjitsu {
 
@@ -47,6 +48,8 @@ void RegisterSet::expand(RegisterRef ref) {
     set_range(acc_vgprs_, ref.index, width);
     break;
   default:
+    // Special singleton: index/width are meaningless, so just set its bit.
+    special_regs_ |= special_bit(ref.cls);
     break;
   }
 }
@@ -64,6 +67,7 @@ void RegisterSet::erase(RegisterRef ref) {
     reset_range(acc_vgprs_, ref.index, width);
     break;
   default:
+    special_regs_ &= static_cast<uint16_t>(~special_bit(ref.cls));
     break;
   }
 }
@@ -80,6 +84,7 @@ void RegisterSet::clear_class(RegClass cls) {
     acc_vgprs_.reset();
     break;
   default:
+    special_regs_ &= static_cast<uint16_t>(~special_bit(cls));
     break;
   }
 }
@@ -94,23 +99,32 @@ bool RegisterSet::contains(RegisterRef ref) const {
   case RegClass::ACC_VGPR:
     return contains_range(acc_vgprs_, ref.index, width);
   default:
-    return false;
+    return (special_regs_ & special_bit(ref.cls)) != 0;
   }
 }
 
-bool RegisterSet::none() const { return sgprs_.none() && vgprs_.none() && acc_vgprs_.none(); }
+bool RegisterSet::none() const {
+  return sgprs_.none() && vgprs_.none() && acc_vgprs_.none() && special_regs_ == 0;
+}
 
-size_t RegisterSet::size() const { return sgprs_.count() + vgprs_.count() + acc_vgprs_.count(); }
+size_t RegisterSet::size() const {
+  return ordinary_size() + static_cast<size_t>(std::popcount(special_regs_));
+}
+
+size_t RegisterSet::ordinary_size() const {
+  return sgprs_.count() + vgprs_.count() + acc_vgprs_.count();
+}
 
 bool RegisterSet::intersects(const RegisterSet &rhs) const {
   return (sgprs_ & rhs.sgprs_).any() || (vgprs_ & rhs.vgprs_).any() ||
-         (acc_vgprs_ & rhs.acc_vgprs_).any();
+         (acc_vgprs_ & rhs.acc_vgprs_).any() || (special_regs_ & rhs.special_regs_) != 0;
 }
 
 RegisterSet &RegisterSet::operator|=(const RegisterSet &rhs) {
   sgprs_ |= rhs.sgprs_;
   vgprs_ |= rhs.vgprs_;
   acc_vgprs_ |= rhs.acc_vgprs_;
+  special_regs_ |= rhs.special_regs_;
   return *this;
 }
 
@@ -118,6 +132,7 @@ RegisterSet &RegisterSet::operator&=(const RegisterSet &rhs) {
   sgprs_ &= rhs.sgprs_;
   vgprs_ &= rhs.vgprs_;
   acc_vgprs_ &= rhs.acc_vgprs_;
+  special_regs_ &= rhs.special_regs_;
   return *this;
 }
 
@@ -125,6 +140,7 @@ RegisterSet &RegisterSet::operator-=(const RegisterSet &rhs) {
   subtract(sgprs_, rhs.sgprs_);
   subtract(vgprs_, rhs.vgprs_);
   subtract(acc_vgprs_, rhs.acc_vgprs_);
+  special_regs_ &= static_cast<uint16_t>(~rhs.special_regs_);
   return *this;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
@@ -4,10 +4,11 @@
 /// @file register_set.h
 /// @brief Register references and register sets for ISA-level register files.
 ///
-/// @details Tracks scalar registers, vector registers, and AccVGPRs. Other
-/// architectural register classes may appear in decoded metadata, but they are
-/// ignored by RegisterSet until there is a concrete consumer for
-/// special-register liveness.
+/// @details Tracks the ordinary indexed register files (SGPR, VGPR, AccVGPR) as
+/// per-index bitsets and the architectural special registers (EXEC, VCC, SCC,
+/// M0, FLAT_SCRATCH, TTMP, PC) as a compact singleton mask in the same set.
+/// Consumers that only reason about allocatable/indexed registers (scratch
+/// liveness, spilling) project the special members out with `ordinary_only()`.
 
 #pragma once
 
@@ -49,29 +50,29 @@ inline constexpr size_t REGISTER_SET_ALLOCATABLE_SGPRS =
 /// labels, waitcnt immediates, message IDs, and other non-register values should
 /// not produce a RegisterRef.
 /// @details The first three classes (SGPR, VGPR, ACC_VGPR) are ordinary
-/// indexed register files tracked by `RegisterSet`. The remainder are
+/// indexed register files with a per-index bitset. The remainder are
 /// architectural special registers: they are singletons (there is one EXEC,
-/// one SCC, ...), are not used for scratch allocation, and are represented by
-/// `SpecialRegisterSet` rather than `RegisterSet`. `is_special_reg_class()`
-/// distinguishes the two groups; keep the ordinary classes first so that
-/// predicate stays a simple partition.
+/// one SCC, ...), are not used for scratch allocation, and are stored in a
+/// compact membership mask. `is_special_reg_class()` distinguishes the two
+/// groups; keep the ordinary classes first so that predicate stays a simple
+/// partition.
 enum class RegClass : uint8_t {
-  SGPR,         ///< Scalar general-purpose register, indexed as sN. Tracked by RegisterSet.
-  VGPR,         ///< Vector general-purpose register, indexed as vN. Tracked by RegisterSet.
-  ACC_VGPR,     ///< CDNA accumulator VGPR, indexed as accN. Tracked by RegisterSet.
-  EXEC,         ///< EXEC mask. Special register; tracked by SpecialRegisterSet, not RegisterSet.
-  VCC,          ///< VCC condition mask. Special register; tracked by SpecialRegisterSet.
-  SCC,          ///< Scalar condition code bit. Special register; tracked by SpecialRegisterSet.
-  M0,           ///< M0 special scalar register. Special register; tracked by SpecialRegisterSet.
-  FLAT_SCRATCH, ///< Flat-scratch base pair. Special register; tracked by SpecialRegisterSet.
-  TTMP,         ///< Trap-temporary registers. Special register; tracked by SpecialRegisterSet.
-  PC, ///< Program counter/control-flow dep. Special register; tracked by SpecialRegisterSet.
+  SGPR,         ///< Scalar general-purpose register, indexed as sN. Ordinary, per-index.
+  VGPR,         ///< Vector general-purpose register, indexed as vN. Ordinary, per-index.
+  ACC_VGPR,     ///< CDNA accumulator VGPR, indexed as accN. Ordinary, per-index.
+  EXEC,         ///< EXEC mask. Special singleton register.
+  VCC,          ///< VCC condition mask. Special singleton register.
+  SCC,          ///< Scalar condition code bit. Special singleton register.
+  M0,           ///< M0 special scalar register. Special singleton register.
+  FLAT_SCRATCH, ///< Flat-scratch base pair. Special singleton register.
+  TTMP,         ///< Trap-temporary registers. Special singleton register.
+  PC,           ///< Program counter/control-flow dep. Special singleton register.
 };
 
 /// @brief True if @p cls is an architectural special register (EXEC, VCC, SCC,
 /// M0, FLAT_SCRATCH, TTMP, PC) rather than an ordinary indexed register file
-/// (SGPR, VGPR, ACC_VGPR). Special registers live in `SpecialRegisterSet`;
-/// ordinary ones live in `RegisterSet`.
+/// (SGPR, VGPR, ACC_VGPR). Special registers are singletons held in the set's
+/// special mask; ordinary ones occupy per-index bitsets.
 [[nodiscard]] constexpr bool is_special_reg_class(RegClass cls) {
   switch (cls) {
   case RegClass::EXEC:
@@ -107,31 +108,52 @@ struct RegisterRef {
 /// @brief Per-class register set used for def/use and liveness dataflow.
 ///
 /// @details A RegisterSet can represent an instruction's use set, def set,
-/// basic-block live-in/live-out set, or live-before/live-after set. Set
-/// operations are member-wise across tracked register classes, so SGPR, VGPR,
-/// and AccVGPR lanes stay disjoint.
+/// basic-block live-in/live-out set, or live-before/live-after set. It stores
+/// the ordinary indexed classes (SGPR, VGPR, AccVGPR) as per-index bitsets and
+/// the architectural special registers (EXEC, VCC, ...) as a singleton
+/// membership mask. Set operations are member-wise, so the ordinary classes
+/// and the special mask all stay disjoint.
+///
+/// @details Special classes are singleton resources: `expand`, `erase`, and
+/// `contains` ignore a special `RegisterRef`'s index/width and act on the
+/// class as a whole, and full iteration emits a canonical `{cls, 0, 1}` ref
+/// per present special class. The general APIs (`size`, `none`, `for_each`)
+/// describe the full set; consumers that reason only about allocatable/indexed
+/// registers use the ordinary views (`ordinary_size`, `for_each_ordinary`,
+/// `ordinary_only`) so singleton special state never looks spillable or indexed.
 class RegisterSet {
 public:
-  /// @brief Add every 32-bit register lane covered by `ref`.
+  /// @brief Add `ref`. For ordinary classes this marks every 32-bit lane it
+  /// covers; for special classes it marks the singleton (index/width ignored).
   void expand(RegisterRef ref);
 
-  /// @brief Remove every 32-bit register lane covered by `ref`.
+  /// @brief Remove `ref`. For ordinary classes this clears every lane it
+  /// covers; for special classes it clears the singleton (index/width ignored).
   void erase(RegisterRef ref);
 
-  /// @brief Remove all tracked registers in one register class.
+  /// @brief Remove every register in one class (ordinary bitset or special bit).
   void clear_class(RegClass cls);
 
-  /// @brief Return true if every lane covered by `ref` is present.
+  /// @brief Return true if `ref` is present. For ordinary classes every covered
+  /// lane must be present; for special classes only membership is checked.
   [[nodiscard]] bool contains(RegisterRef ref) const;
 
-  /// @brief Return true when no register class contains any live bits.
+  /// @brief Return true when neither the ordinary bitsets nor the special mask
+  /// hold any member.
   [[nodiscard]] bool none() const;
 
-  /// @brief Return the total number of single-lane registers tracked across
-  ///        all classes (SGPR + VGPR + AccVGPR).
+  /// @brief Total number of members: ordinary single-lane registers plus
+  /// distinct special singletons.
   [[nodiscard]] size_t size() const;
 
-  /// @brief Return true if any register lane is present in both sets.
+  /// @brief Number of ordinary single-lane registers only (SGPR + VGPR +
+  /// AccVGPR), excluding special singletons. Use this for scratch/slot sizing.
+  [[nodiscard]] size_t ordinary_size() const;
+
+  /// @brief True if any special singleton is present.
+  [[nodiscard]] bool has_specials() const { return special_regs_ != 0; }
+
+  /// @brief Return true if any member is present in both sets (ordinary or special).
   [[nodiscard]] bool intersects(const RegisterSet &rhs) const;
 
   RegisterSet &operator|=(const RegisterSet &rhs);
@@ -153,12 +175,27 @@ public:
 
   friend bool operator==(const RegisterSet &, const RegisterSet &) = default;
 
-  /// @brief Invoke @p f with each tracked single-lane register in the set.
+  /// @brief Return a copy holding only the ordinary members; special singletons
+  /// are dropped. This is the projection scratch/liveness/spill consumers use.
+  [[nodiscard]] RegisterSet ordinary_only() const {
+    RegisterSet copy = *this;
+    copy.special_regs_ = 0;
+    return copy;
+  }
+
+  /// @brief Invoke @p f with each member of the full set.
   ///
-  /// @details Visits SGPRs, then VGPRs, then AccVGPRs in ascending index
-  /// order. Each yielded RegisterRef has @c width=1 — multi-lane refs that
-  /// were inserted via @c expand are visited as their constituent lanes.
+  /// @details Visits ordinary SGPRs, VGPRs, then AccVGPRs in ascending index
+  /// order (each as a @c width=1 RegisterRef), then each present special class
+  /// in ascending `RegClass` order as a canonical `{cls, 0, 1}` ref.
   template <typename F> void for_each(F &&f) const {
+    for_each_ordinary(f);
+    for_each_special([&](RegClass cls) { f(RegisterRef{cls, 0, 1}); });
+  }
+
+  /// @brief Invoke @p f with each ordinary single-lane register (SGPR, VGPR,
+  /// AccVGPR) in ascending index order. Special singletons are not visited.
+  template <typename F> void for_each_ordinary(F &&f) const {
     for (size_t i = 0; i < sgprs_.size(); ++i) {
       if (sgprs_.test(i))
         f(RegisterRef{RegClass::SGPR, static_cast<uint16_t>(i), 1});
@@ -173,61 +210,10 @@ public:
     }
   }
 
-private:
-  std::bitset<REGISTER_SET_MAX_SGPRS> sgprs_;
-  std::bitset<REGISTER_SET_MAX_VGPRS> vgprs_;
-  std::bitset<REGISTER_SET_MAX_ACC_VGPRS> acc_vgprs_;
-};
-
-/// @brief A set of architectural special registers (EXEC, VCC, SCC, M0, PC,
-/// FLAT_SCRATCH, TTMP).
-///
-/// @details Special registers are singletons — there is exactly one EXEC, one
-/// SCC, and so on, with no meaningful index or width — so membership is the
-/// only state, and this set stores just a class-membership bitmask rather than
-/// per-index bitsets. It is deliberately a separate type from `RegisterSet`
-/// so DBT and DBI can handle them accordingly.
-class SpecialRegisterSet {
-public:
-  /// @brief Add a special-register class. Ordinary register classes
-  /// (SGPR/VGPR/ACC_VGPR) are ignored — those belong in `RegisterSet`, and
-  /// silently dropping them mirrors how `RegisterSet` ignores special classes.
-  void insert(RegClass cls) {
-    if (is_special_reg_class(cls))
-      mask_ |= bit(cls);
-  }
-
-  /// @brief True if @p cls is present. Only meaningful for special classes;
-  /// ordinary classes are never members and always return false.
-  [[nodiscard]] bool contains(RegClass cls) const { return (mask_ & bit(cls)) != 0; }
-
-  /// @brief True when no special register is present.
-  [[nodiscard]] bool empty() const { return mask_ == 0; }
-
-  /// @brief Number of distinct special registers present.
-  [[nodiscard]] size_t size() const { return static_cast<size_t>(std::popcount(mask_)); }
-
-  /// @brief True if any special register is present in both sets.
-  [[nodiscard]] bool intersects(const SpecialRegisterSet &rhs) const {
-    return (mask_ & rhs.mask_) != 0;
-  }
-
-  SpecialRegisterSet &operator|=(const SpecialRegisterSet &rhs) {
-    mask_ |= rhs.mask_;
-    return *this;
-  }
-
-  friend SpecialRegisterSet operator|(SpecialRegisterSet lhs, const SpecialRegisterSet &rhs) {
-    lhs |= rhs;
-    return lhs;
-  }
-
-  friend bool operator==(const SpecialRegisterSet &, const SpecialRegisterSet &) = default;
-
-  /// @brief Invoke @p f with each present special register class, in ascending
+  /// @brief Invoke @p f with each present special class, in ascending
   /// `RegClass` value order.
-  template <typename F> void for_each(F &&f) const {
-    uint16_t bits = mask_;
+  template <typename F> void for_each_special(F &&f) const {
+    uint16_t bits = special_regs_;
     while (bits != 0) {
       const auto i = static_cast<uint8_t>(std::countr_zero(bits));
       f(static_cast<RegClass>(i));
@@ -236,19 +222,24 @@ public:
   }
 
 private:
-  static constexpr uint16_t bit(RegClass cls) {
+  /// @brief Mask bit for a special class. Only valid for special classes.
+  static constexpr uint16_t special_bit(RegClass cls) {
     return static_cast<uint16_t>(1u << static_cast<uint8_t>(cls));
   }
 
-  // The bitmask indexes bits by raw RegClass value, so every class must fit in
-  // `mask_`. If RegClass ever grows past the mask width, widen `mask_` (and the
-  // shift base in `bit`) rather than silently truncating membership.
+  // The special mask indexes bits by raw RegClass value, so every class must
+  // fit in `special_regs_`. If RegClass ever grows past the mask width, widen
+  // it (and the shift base in `special_bit`) rather than truncating membership.
   static_assert(static_cast<uint8_t>(RegClass::PC) < 16,
-                "SpecialRegisterSet mask_ must hold a bit for every RegClass value");
+                "special_regs_ must hold a bit for every RegClass value");
 
-  /// @brief Bit `static_cast<uint8_t>(cls)` set iff special class `cls`
-  /// present. Only special-class bits are ever set (see `insert`).
-  uint16_t mask_ = 0;
+  std::bitset<REGISTER_SET_MAX_SGPRS> sgprs_;
+  std::bitset<REGISTER_SET_MAX_VGPRS> vgprs_;
+  std::bitset<REGISTER_SET_MAX_ACC_VGPRS> acc_vgprs_;
+
+  /// @brief Bit `static_cast<uint8_t>(cls)` set iff special class `cls` is
+  /// present. Only special-class bits are ever set (see `expand`).
+  uint16_t special_regs_ = 0;
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -362,16 +362,22 @@ TEST(GeneratedInstDefUse, MubufCmpswapReturnUsesElementWidthAndTargetGate) {
   }
 }
 
-TEST(RegisterSetAnalysis, IgnoresSpecialRegisterClasses) {
+TEST(RegisterSetAnalysis, SpecialClassesAreHeldButCarryNoOrdinaryLanes) {
   RegisterSet set;
   set.expand({RegClass::EXEC, 0, 2});
   set.expand({RegClass::SCC, 0, 1});
   set.expand({RegClass::FLAT_SCRATCH, 0, 2});
 
-  EXPECT_TRUE(set.none());
-  EXPECT_FALSE(set.contains({RegClass::EXEC, 0, 1}));
-  EXPECT_FALSE(set.contains({RegClass::SCC, 0, 1}));
-  EXPECT_FALSE(set.contains({RegClass::FLAT_SCRATCH, 0, 2}));
+  // Special classes are singleton members, not dropped.
+  EXPECT_FALSE(set.none());
+  EXPECT_TRUE(set.has_specials());
+  EXPECT_TRUE(set.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_TRUE(set.contains({RegClass::SCC, 0, 1}));
+  EXPECT_TRUE(set.contains({RegClass::FLAT_SCRATCH, 0, 2}));
+
+  // But they contribute no ordinary lanes and vanish under ordinary_only().
+  EXPECT_EQ(set.ordinary_size(), 0u);
+  EXPECT_TRUE(set.ordinary_only().none());
 }
 
 TEST(RegisterSetAnalysis, GeneratedCdna4OperandsMapTrackedRegisterRefs) {
@@ -405,12 +411,29 @@ TEST(RegisterSetAnalysis, Cdna4WritelaneDestinationIsUseAndDef) {
 }
 
 // ---------------------------------------------------------------------------
-// Architectural special-register + memory effect API. These effects are
-// represented separately from RegisterSet so they never enter ordinary
-// scratch-allocation liveness.
+// Architectural special-register + memory effect API. Special registers are
+// singleton members of the same RegisterSet as ordinary registers; consumers
+// that drive scratch-allocation liveness project them out with ordinary_only().
 // ---------------------------------------------------------------------------
 
-TEST(SpecialRegisterSetAnalysis, ClassifiesSpecialVersusOrdinaryClasses) {
+// Collect a set's special members in ascending RegClass order, so a test can
+// assert the *exact* set of special registers an instruction reads or writes,
+// not just membership.
+std::vector<RegClass> specials_in(const RegisterSet &set) {
+  std::vector<RegClass> classes;
+  set.for_each_special([&](RegClass c) { classes.push_back(c); });
+  return classes;
+}
+
+// Expected special-register list, sorted to match specials_in()'s ascending
+// iteration order.
+std::vector<RegClass> special_regs(std::initializer_list<RegClass> classes) {
+  std::vector<RegClass> sorted(classes);
+  std::ranges::sort(sorted);
+  return sorted;
+}
+
+TEST(RegisterSetSpecial, ClassifiesSpecialVersusOrdinaryClasses) {
   EXPECT_FALSE(is_special_reg_class(RegClass::SGPR));
   EXPECT_FALSE(is_special_reg_class(RegClass::VGPR));
   EXPECT_FALSE(is_special_reg_class(RegClass::ACC_VGPR));
@@ -423,122 +446,112 @@ TEST(SpecialRegisterSetAnalysis, ClassifiesSpecialVersusOrdinaryClasses) {
   EXPECT_TRUE(is_special_reg_class(RegClass::PC));
 }
 
-TEST(SpecialRegisterSetAnalysis, InsertContainsSizeEmpty) {
-  SpecialRegisterSet s;
-  EXPECT_TRUE(s.empty());
-  EXPECT_EQ(s.size(), 0u);
+TEST(RegisterSetSpecial, OrdinaryAndSpecialInsertionCoexist) {
+  RegisterSet s;
+  s.expand({RegClass::SGPR, 4, 2});
+  s.expand({RegClass::EXEC, 0, 1});
+  s.expand({RegClass::VCC, 0, 1});
 
-  s.insert(RegClass::EXEC);
-  s.insert(RegClass::VCC);
-  s.insert(RegClass::EXEC); // idempotent
-
-  EXPECT_FALSE(s.empty());
-  EXPECT_EQ(s.size(), 2u);
-  EXPECT_TRUE(s.contains(RegClass::EXEC));
-  EXPECT_TRUE(s.contains(RegClass::VCC));
-  EXPECT_FALSE(s.contains(RegClass::SCC));
+  // size() counts ordinary lanes plus special singletons; ordinary_size() sees
+  // only the two SGPR lanes.
+  EXPECT_EQ(s.ordinary_size(), 2u);
+  EXPECT_EQ(s.size(), 4u);
+  EXPECT_TRUE(s.has_specials());
+  EXPECT_TRUE(s.contains({RegClass::SGPR, 4, 1}));
+  EXPECT_TRUE(s.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_EQ(specials_in(s), special_regs({RegClass::EXEC, RegClass::VCC}));
 }
 
-TEST(SpecialRegisterSetAnalysis, IgnoresOrdinaryRegisterClasses) {
-  SpecialRegisterSet s;
-  s.insert(RegClass::SGPR);
-  s.insert(RegClass::VGPR);
-  s.insert(RegClass::ACC_VGPR);
+TEST(RegisterSetSpecial, SpecialMembershipIgnoresIndexAndWidth) {
+  // Special classes are singletons: any index/width refers to the same member.
+  RegisterSet s;
+  s.expand({RegClass::EXEC, 42, 8});
+  EXPECT_TRUE(s.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_TRUE(s.contains({RegClass::EXEC, 99, 2}));
+  EXPECT_EQ(s.size(), 1u);
 
-  EXPECT_TRUE(s.empty());
-  EXPECT_FALSE(s.contains(RegClass::SGPR));
+  s.erase({RegClass::EXEC, 7, 4});
+  EXPECT_FALSE(s.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_TRUE(s.none());
 }
 
-TEST(SpecialRegisterSetAnalysis, UnionIntersectsEquality) {
-  SpecialRegisterSet a;
-  a.insert(RegClass::EXEC);
-  SpecialRegisterSet b;
-  b.insert(RegClass::VCC);
+TEST(RegisterSetSpecial, FullIterationEmitsCanonicalSpecialRefs) {
+  RegisterSet s;
+  s.expand({RegClass::VGPR, 1, 1});
+  s.expand({RegClass::PC, 5, 2});
 
-  EXPECT_FALSE(a.intersects(b));
+  // for_each visits the ordinary lane first, then the special as a canonical
+  // {cls, 0, 1} ref regardless of the index/width it was inserted with.
+  std::vector<RegisterRef> seen;
+  s.for_each([&](RegisterRef r) { seen.push_back(r); });
+  ASSERT_EQ(seen.size(), 2u);
+  EXPECT_EQ(seen[0], (RegisterRef{RegClass::VGPR, 1, 1}));
+  EXPECT_EQ(seen[1], (RegisterRef{RegClass::PC, 0, 1}));
 
-  const SpecialRegisterSet u = a | b;
-  EXPECT_EQ(u.size(), 2u);
-  EXPECT_TRUE(u.intersects(a));
-  EXPECT_TRUE(u.intersects(b));
-
-  a |= b;
-  EXPECT_EQ(a, u);
+  // for_each_ordinary skips the special member entirely.
+  std::vector<RegisterRef> ordinary;
+  s.for_each_ordinary([&](RegisterRef r) { ordinary.push_back(r); });
+  EXPECT_EQ(ordinary, (std::vector<RegisterRef>{{RegClass::VGPR, 1, 1}}));
 }
 
-TEST(SpecialRegisterSetAnalysis, ForEachVisitsAscendingClassOrder) {
-  SpecialRegisterSet s;
-  s.insert(RegClass::PC);
-  s.insert(RegClass::EXEC);
-  s.insert(RegClass::M0);
+TEST(RegisterSetSpecial, OrdinaryOnlyDropsSpecialMembers) {
+  RegisterSet s;
+  s.expand({RegClass::SGPR, 3, 1});
+  s.expand({RegClass::SCC, 0, 1});
 
-  std::vector<RegClass> seen;
-  s.for_each([&](RegClass c) { seen.push_back(c); });
-
-  EXPECT_EQ(seen, (std::vector<RegClass>{RegClass::EXEC, RegClass::M0, RegClass::PC}));
+  const RegisterSet ordinary = s.ordinary_only();
+  EXPECT_FALSE(ordinary.has_specials());
+  EXPECT_EQ(ordinary.size(), 1u);
+  EXPECT_TRUE(ordinary.contains({RegClass::SGPR, 3, 1}));
+  EXPECT_TRUE(s.has_specials()); // source unchanged
 }
 
-TEST(SpecialRegisterSetAnalysis, ForEachOnEmptySetNeverInvokesCallback) {
-  SpecialRegisterSet s;
-  int calls = 0;
-  s.for_each([&](RegClass) { ++calls; });
-  EXPECT_EQ(calls, 0);
+TEST(RegisterSetSpecial, SetAlgebraSpansOrdinaryAndSpecial) {
+  RegisterSet a;
+  a.expand({RegClass::SGPR, 0, 1});
+  a.expand({RegClass::EXEC, 0, 1});
+  RegisterSet b;
+  b.expand({RegClass::SGPR, 1, 1});
+  b.expand({RegClass::EXEC, 0, 1});
+  b.expand({RegClass::VCC, 0, 1});
+
+  EXPECT_TRUE(a.intersects(b)); // shared EXEC
+
+  const RegisterSet u = a | b;
+  EXPECT_EQ(u.size(), 4u); // s0, s1, EXEC, VCC
+  EXPECT_EQ(specials_in(u), special_regs({RegClass::EXEC, RegClass::VCC}));
+
+  const RegisterSet i = a & b;
+  EXPECT_EQ(specials_in(i), special_regs({RegClass::EXEC}));
+  EXPECT_FALSE(i.contains({RegClass::SGPR, 0, 1})); // s0 only in a
+
+  const RegisterSet d = b - a; // removes shared EXEC; keeps VCC and s1
+  EXPECT_EQ(specials_in(d), special_regs({RegClass::VCC}));
+  EXPECT_TRUE(d.contains({RegClass::SGPR, 1, 1}));
+
+  RegisterSet cleared = u;
+  cleared.clear_class(RegClass::EXEC);
+  EXPECT_EQ(specials_in(cleared), special_regs({RegClass::VCC}));
+  EXPECT_EQ(cleared.ordinary_size(), 2u); // clear_class(special) leaves ordinary intact
 }
 
-TEST(SpecialRegisterSetAnalysis, HighBitClassesRoundTrip) {
-  // TTMP and PC occupy the highest RegClass bit positions, where a uint16_t
-  // truncation bug in bit()/for_each would first surface.
-  SpecialRegisterSet s;
-  s.insert(RegClass::TTMP);
-  s.insert(RegClass::PC);
-
-  EXPECT_EQ(s.size(), 2u);
-  EXPECT_TRUE(s.contains(RegClass::TTMP));
-  EXPECT_TRUE(s.contains(RegClass::PC));
-
-  std::vector<RegClass> seen;
-  s.for_each([&](RegClass c) { seen.push_back(c); });
-  EXPECT_EQ(seen, (std::vector<RegClass>{RegClass::TTMP, RegClass::PC}));
+TEST(RegisterSetSpecial, EqualityDistinguishesSpecialMembership) {
+  RegisterSet a;
+  a.expand({RegClass::SGPR, 0, 1});
+  RegisterSet b = a;
+  EXPECT_EQ(a, b);
+  b.expand({RegClass::EXEC, 0, 1});
+  EXPECT_NE(a, b); // the special mask participates in equality
 }
 
-TEST(SpecialRegisterSetAnalysis, OrdinaryClassNeverAliasesSpecialBits) {
-  // SGPR maps to bit 0; inserting EXEC must not make an ordinary class appear
-  // present. Guards the raw-value bit indexing against aliasing.
-  SpecialRegisterSet s;
-  s.insert(RegClass::EXEC);
-  EXPECT_FALSE(s.contains(RegClass::SGPR));
-  EXPECT_FALSE(s.contains(RegClass::VGPR));
-  EXPECT_FALSE(s.contains(RegClass::ACC_VGPR));
-}
-
-TEST(SpecialRegisterSetAnalysis, SelfUnionIsIdentity) {
-  SpecialRegisterSet s;
-  s.insert(RegClass::EXEC);
-  s.insert(RegClass::VCC);
-  const SpecialRegisterSet before = s;
-  s |= s;
-  EXPECT_EQ(s, before);
-}
-
-TEST(SpecialRegisterSetAnalysis, HoldsWhatRegisterSetIgnores) {
-  // The special classes RegisterSet drops (see IgnoresSpecialRegisterClasses)
-  // are exactly what SpecialRegisterSet tracks, and the two are independent:
-  // recording special effects never perturbs ordinary scratch liveness.
-  RegisterSet ordinary;
-  ordinary.expand({RegClass::SGPR, 4, 2});
-  const size_t ordinary_size = ordinary.size();
-
-  SpecialRegisterSet special;
-  special.insert(RegClass::EXEC);
-  special.insert(RegClass::SCC);
-  special.insert(RegClass::FLAT_SCRATCH);
-
-  EXPECT_EQ(special.size(), 3u);
-  EXPECT_EQ(ordinary.size(), ordinary_size); // unchanged by special inserts
-
-  // RegisterSet still refuses to store special classes.
-  ordinary.expand({RegClass::EXEC, 0, 2});
-  EXPECT_EQ(ordinary.size(), ordinary_size);
+TEST(RegisterSetSpecial, HighValuedTtmpAndPcMaskBitsRoundTrip) {
+  // TTMP and PC are the highest RegClass values, where a mask-width bug would
+  // first surface.
+  RegisterSet s;
+  s.expand({RegClass::TTMP, 0, 1});
+  s.expand({RegClass::PC, 0, 1});
+  EXPECT_EQ(specials_in(s), special_regs({RegClass::TTMP, RegClass::PC}));
+  EXPECT_FALSE(s.contains({RegClass::SGPR, 0, 1})); // no aliasing onto bit 0
 }
 
 TEST(MemoryEffectsAnalysis, DefaultsToNoEffect) {
@@ -550,53 +563,45 @@ TEST(MemoryEffectsAnalysis, DefaultsToNoEffect) {
 }
 
 TEST(InstDefUseSpecialEffects, SpecialAndMemoryDefaultEmpty) {
-  // Constructing InstDefUse from a decoded instruction leaves special/memory
-  // effects empty while ordinary def/use extraction is unchanged.
+  // A decoded instruction with only ordinary operands reports no special
+  // members and no memory effect; ordinary def/use extraction is unchanged.
   TestInstruction inst("test_sp", {{RegClass::SGPR, 4, 1}}, {{RegClass::VGPR, 0, 1}});
   InstDefUse du(inst);
 
   EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 4, 1}));
   EXPECT_TRUE(du.uses.contains({RegClass::VGPR, 0, 1}));
-  EXPECT_TRUE(du.special_defs.empty());
-  EXPECT_TRUE(du.special_uses.empty());
+  EXPECT_FALSE(du.defs.has_specials());
+  EXPECT_FALSE(du.uses.has_specials());
   EXPECT_FALSE(du.memory.any());
 }
 
-TEST(InstDefUseSpecialEffects, SpecialEffectsDoNotEnterScratchLiveness) {
-  // A future consumer (DBT/DBI) can record special and memory effects on
-  // InstDefUse but doing so must not change the ordinary defs/uses that
-  // drive scratch allocation.
+TEST(InstDefUseSpecialEffects, SpecialMembersStayOutOfOrdinaryProjection) {
+  // Special singletons live in defs/uses alongside ordinary registers, but the
+  // ordinary projection that drives scratch allocation is unaffected.
   TestInstruction inst("test_sp", {{RegClass::SGPR, 4, 1}}, {});
   InstDefUse du(inst);
-  const size_t defs_size = du.defs.size();
 
-  du.special_defs.insert(RegClass::EXEC);
-  du.special_uses.insert(RegClass::VCC);
+  du.defs.expand({RegClass::EXEC, 0, 1});
+  du.uses.expand({RegClass::VCC, 0, 1});
   du.memory.reads = true;
   du.memory.global = true;
 
-  EXPECT_EQ(du.defs.size(), defs_size);
-  EXPECT_TRUE(du.special_defs.contains(RegClass::EXEC));
-  EXPECT_TRUE(du.special_uses.contains(RegClass::VCC));
+  EXPECT_EQ(du.defs.ordinary_size(), 1u);
+  EXPECT_TRUE(du.defs.ordinary_only().contains({RegClass::SGPR, 4, 1}));
+  EXPECT_FALSE(du.defs.ordinary_only().has_specials());
+  EXPECT_TRUE(du.defs.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_TRUE(du.uses.contains({RegClass::VCC, 0, 1}));
   EXPECT_TRUE(du.memory.any());
-}
-
-// Build a SpecialRegisterSet from a list so a test can assert the *exact* set of
-// special registers an instruction reads or writes, not just membership.
-SpecialRegisterSet special_regs(std::initializer_list<RegClass> classes) {
-  SpecialRegisterSet s;
-  for (RegClass c : classes)
-    s.insert(c);
-  return s;
 }
 
 TEST(SpecialEffectAnalysis, SaveexecReportsExecAndSccFromDecodedOperands) {
   // Real decoded instruction: s_and_saveexec_b64 s[0:1], s[0:1] (CDNA4). Its
-  // fieldless special operands drive the InstDefUse special sets by direction:
-  //   dst EXEC + dst SCC  -> special_defs
-  //   src EXEC (old exec) -> special_uses
-  // while the ordinary sdst/ssrc0 SGPRs stay in the ordinary defs/uses that feed
-  // scratch allocation. Special effects never enter ordinary RegisterSet liveness.
+  // fieldless special operands become singleton members of defs/uses by
+  // direction:
+  //   dst EXEC + dst SCC  -> special members of defs
+  //   src EXEC (old exec) -> special member of uses
+  // while the ordinary sdst/ssrc0 SGPRs stay in the same sets as ordinary
+  // members. The ordinary projection (ordinary_only) sees only the SGPRs.
   const uint32_t words[] = {0xBE802000u, 0x00000000u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
@@ -606,16 +611,17 @@ TEST(SpecialEffectAnalysis, SaveexecReportsExecAndSccFromDecodedOperands) {
 
   InstDefUse du(*inst);
 
-  EXPECT_EQ(du.special_defs, special_regs({RegClass::EXEC, RegClass::SCC}));
-  EXPECT_EQ(du.special_uses, special_regs({RegClass::EXEC}));
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::EXEC, RegClass::SCC}));
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::EXEC}));
 
   // Ordinary sdst/ssrc0 (s[0:1]) still tracked as ordinary registers.
   EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 0, 2}));
   EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 0, 2}));
 
-  // Special registers do not leak into ordinary scratch liveness.
-  EXPECT_FALSE(du.defs.contains({RegClass::EXEC, 0, 1}));
-  EXPECT_FALSE(du.defs.contains({RegClass::SCC, 0, 1}));
+  // EXEC/SCC are members of du.defs but stay out of the ordinary projection
+  // that feeds scratch allocation.
+  EXPECT_TRUE(du.defs.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_FALSE(du.defs.ordinary_only().has_specials());
 }
 
 TEST(SpecialEffectAnalysis, OrdinaryInstructionReportsNoSpecialEffects) {
@@ -628,8 +634,8 @@ TEST(SpecialEffectAnalysis, OrdinaryInstructionReportsNoSpecialEffects) {
   ASSERT_NE(inst, nullptr);
 
   InstDefUse du(*inst);
-  EXPECT_TRUE(du.special_defs.empty());
-  EXPECT_TRUE(du.special_uses.empty());
+  EXPECT_FALSE(du.defs.has_specials());
+  EXPECT_FALSE(du.uses.has_specials());
 }
 
 // Decode-time special-effect coverage for the hidden-side-effect instruction
@@ -650,8 +656,8 @@ TEST(SpecialEffectAnalysis, CmpxWritesVccAndExecOnCdna) {
   ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
 
   InstDefUse du(*inst);
-  EXPECT_EQ(du.special_defs, special_regs({RegClass::EXEC, RegClass::VCC}));
-  EXPECT_TRUE(du.special_uses.empty());
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::EXEC, RegClass::VCC}));
+  EXPECT_FALSE(du.uses.has_specials());
 }
 
 TEST(SpecialEffectAnalysis, CmpxWritesExecOnlyOnGfx1250) {
@@ -664,8 +670,8 @@ TEST(SpecialEffectAnalysis, CmpxWritesExecOnlyOnGfx1250) {
   ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
 
   InstDefUse du(*inst);
-  EXPECT_EQ(du.special_defs, special_regs({RegClass::EXEC}));
-  EXPECT_TRUE(du.special_uses.empty());
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::EXEC}));
+  EXPECT_FALSE(du.uses.has_specials());
 }
 
 // RDNA CMPX is EXEC-only like gfx1250 (and unlike CDNA), tested directly on an
@@ -680,8 +686,8 @@ TEST(SpecialEffectAnalysis, CmpxWritesExecOnlyOnRdna) {
   ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
 
   InstDefUse du(*inst);
-  EXPECT_EQ(du.special_defs, special_regs({RegClass::EXEC}));
-  EXPECT_TRUE(du.special_uses.empty());
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::EXEC}));
+  EXPECT_FALSE(du.uses.has_specials());
 }
 
 // s_cbranch_{scc,vcc,exec}* read a special condition register and branch. The
@@ -696,8 +702,8 @@ TEST(SpecialEffectAnalysis, CbranchSccIsSpecialSccUse) {
   ASSERT_EQ(inst->mnemonic(), "s_cbranch_scc0");
 
   InstDefUse du(*inst);
-  EXPECT_EQ(du.special_uses, special_regs({RegClass::SCC}));
-  EXPECT_TRUE(du.special_defs.empty());
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::SCC}));
+  EXPECT_FALSE(du.defs.has_specials());
 }
 
 TEST(SpecialEffectAnalysis, CbranchVccIsSpecialVccUse) {
@@ -710,8 +716,8 @@ TEST(SpecialEffectAnalysis, CbranchVccIsSpecialVccUse) {
   ASSERT_EQ(inst->mnemonic(), "s_cbranch_vccz");
 
   InstDefUse du(*inst);
-  EXPECT_EQ(du.special_uses, special_regs({RegClass::VCC}));
-  EXPECT_TRUE(du.special_defs.empty());
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::VCC}));
+  EXPECT_FALSE(du.defs.has_specials());
 }
 
 TEST(SpecialEffectAnalysis, CbranchExecIsSpecialExecUse) {
@@ -724,8 +730,8 @@ TEST(SpecialEffectAnalysis, CbranchExecIsSpecialExecUse) {
   ASSERT_EQ(inst->mnemonic(), "s_cbranch_execz");
 
   InstDefUse du(*inst);
-  EXPECT_EQ(du.special_uses, special_regs({RegClass::EXEC}));
-  EXPECT_TRUE(du.special_defs.empty());
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::EXEC}));
+  EXPECT_FALSE(du.defs.has_specials());
 }
 
 // VOP2 carry reads and writes VCC implicitly. The mnemonic differs by ISA
@@ -742,8 +748,8 @@ TEST(SpecialEffectAnalysis, Vop2CarryCdnaAddcUsesAndDefsVcc) {
   ASSERT_EQ(inst->mnemonic(), "v_addc_co_u32_e32");
 
   InstDefUse du(*inst);
-  EXPECT_EQ(du.special_defs, special_regs({RegClass::VCC}));
-  EXPECT_EQ(du.special_uses, special_regs({RegClass::VCC}));
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::VCC}));
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::VCC}));
   EXPECT_TRUE(du.defs.contains({RegClass::VGPR, 2, 1})); // ordinary vdst still tracked
 }
 
@@ -758,8 +764,8 @@ TEST(SpecialEffectAnalysis, Vop2CarryGfx1250AddCoCiUsesAndDefsVcc) {
   ASSERT_EQ(inst->mnemonic(), "v_add_co_ci_u32_e32");
 
   InstDefUse du(*inst);
-  EXPECT_EQ(du.special_defs, special_regs({RegClass::VCC}));
-  EXPECT_EQ(du.special_uses, special_regs({RegClass::VCC}));
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::VCC}));
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::VCC}));
 }
 
 // PC family: getpc reads PC (writes an ordinary SGPR pair), setpc writes PC
@@ -774,8 +780,8 @@ TEST(SpecialEffectAnalysis, GetpcReadsPc) {
   ASSERT_EQ(inst->mnemonic(), "s_getpc_b64");
 
   InstDefUse du(*inst);
-  EXPECT_EQ(du.special_uses, special_regs({RegClass::PC}));
-  EXPECT_TRUE(du.special_defs.empty());
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::PC}));
+  EXPECT_FALSE(du.defs.has_specials());
   EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 8, 2}));
 }
 
@@ -789,8 +795,8 @@ TEST(SpecialEffectAnalysis, SetpcWritesPc) {
   ASSERT_EQ(inst->mnemonic(), "s_setpc_b64");
 
   InstDefUse du(*inst);
-  EXPECT_EQ(du.special_defs, special_regs({RegClass::PC}));
-  EXPECT_TRUE(du.special_uses.empty());
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::PC}));
+  EXPECT_FALSE(du.uses.has_specials());
   EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 8, 2}));
 }
 
@@ -804,8 +810,8 @@ TEST(SpecialEffectAnalysis, ScallReadsAndWritesPc) {
   ASSERT_EQ(inst->mnemonic(), "s_call_b64");
 
   InstDefUse du(*inst);
-  EXPECT_EQ(du.special_defs, special_regs({RegClass::PC}));
-  EXPECT_EQ(du.special_uses, special_regs({RegClass::PC}));
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::PC}));
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::PC}));
   EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 8, 2}));
 }
 
@@ -822,9 +828,48 @@ TEST(SpecialEffectAnalysis, MemoryPseudoOperandProducesNoSpecialEffect) {
   ASSERT_EQ(inst->mnemonic(), "buffer_load_b32");
 
   InstDefUse du(*inst);
-  EXPECT_TRUE(du.special_defs.empty());
-  EXPECT_TRUE(du.special_uses.empty());
+  EXPECT_FALSE(du.defs.has_specials());
+  EXPECT_FALSE(du.uses.has_specials());
   EXPECT_FALSE(du.memory.any());
+}
+
+// Liveness models ordinary scratch registers only: an instruction's special
+// def/use appears in InstDefUse but must never reach BlockLiveness or
+// live_before(), which drive scratch allocation.
+TEST(SpecialEffectLiveness, SpecialEffectsAreAbsentFromOrdinaryLiveness) {
+  // s_and_saveexec_b64 s[0:1], s[0:1] defs {s[0:1], EXEC, SCC} and uses
+  // {s[0:1], EXEC}; s_endpgm terminates the single block.
+  std::vector<uint32_t> words = {
+      0xBE802000u, // s_and_saveexec_b64 s[0:1], s[0:1]
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),
+  };
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_FALSE(blocks.empty());
+
+  BasicBlock *entry = block_starting_at(blocks, 0);
+  ASSERT_NE(entry, nullptr);
+  auto &insts = entry->instructions();
+  ASSERT_NE(insts.begin(), insts.end());
+  const Instruction &saveexec = *insts.begin();
+  ASSERT_EQ(saveexec.mnemonic(), "s_and_saveexec_b64");
+
+  // InstDefUse records the special effects.
+  const InstDefUse du(saveexec);
+  EXPECT_TRUE(du.defs.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_TRUE(du.defs.contains({RegClass::SCC, 0, 1}));
+  EXPECT_TRUE(du.uses.contains({RegClass::EXEC, 0, 1}));
+
+  // Liveness projects them out of every ordinary set.
+  const LivenessAnalysis liveness = analyze_scope(blocks);
+  const BlockLiveness &bl = liveness.block_liveness(*entry);
+  EXPECT_FALSE(bl.live_in.has_specials());
+  EXPECT_FALSE(bl.live_out.has_specials());
+  EXPECT_FALSE(bl.gen.has_specials());
+  EXPECT_FALSE(bl.kill.has_specials());
+  EXPECT_FALSE(liveness.live_before(saveexec).has_specials());
 }
 
 TEST(CfgAnalysis, LoopBackEdgeLinksPredecessor) {

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -296,6 +296,27 @@ TEST(Validator, RejectsNegativeInstructionSize) {
   EXPECT_NE(err.find("size must be 4 or 8"), std::string::npos) << "error was: " << err;
 }
 
+TEST(SpillPolicy, EmptySpillSetPasses) {
+  RegisterSet spill_set;
+  std::string err;
+  EXPECT_TRUE(check_spill_policy(spill_set, SpillPolicy::NoSpillsSupported, &err));
+  EXPECT_TRUE(err.empty()) << err;
+}
+
+TEST(SpillPolicy, NamesSpecialRegistersInDiagnostic) {
+  // Spill sets are normally projected to ordinary registers before they reach
+  // check_spill_policy, but the diagnostic must still name any special member
+  // by its architectural name rather than emitting "?0".
+  RegisterSet spill_set;
+  spill_set.expand(RegisterRef{RegClass::EXEC, 0, 1});
+  spill_set.expand(RegisterRef{RegClass::SCC, 0, 1});
+  std::string err;
+  EXPECT_FALSE(check_spill_policy(spill_set, SpillPolicy::NoSpillsSupported, &err));
+  EXPECT_NE(err.find("exec"), std::string::npos) << err;
+  EXPECT_NE(err.find("scc"), std::string::npos) << err;
+  EXPECT_EQ(err.find('?'), std::string::npos) << err;
+}
+
 //==============================================================================
 // Section 1b: validate_inline_nop_plan
 //

--- a/emulation/rocjitsu/tests/patch/probe_clobber_test.cpp
+++ b/emulation/rocjitsu/tests/patch/probe_clobber_test.cpp
@@ -142,5 +142,19 @@ TEST(ProbeClobber, DetectsExplicitFlatScratchWrite) {
   EXPECT_FALSE(summary->touches_m0);
 }
 
+// A body that writes both an ordinary SGPR (s5) and EXEC. InstDefUse now carries
+// EXEC as a singleton member of its def set, but ordinary_clobbers is built from
+// the ordinary projection, so s5 must appear there while no special member does.
+// The EXEC write is still surfaced separately via touches_exec.
+TEST(ProbeClobber, SpecialWritesDoNotLeakIntoOrdinaryClobbers) {
+  const auto callable = make_callable({kSMovS5_0, kSMovExecLo_0, kSSetpcS30S31});
+  std::string err;
+  const auto summary = build_probe_clobber_summary(callable, &err);
+  ASSERT_TRUE(summary.has_value()) << err;
+  EXPECT_TRUE(has_sgpr(summary->ordinary_clobbers, 5));
+  EXPECT_FALSE(summary->ordinary_clobbers.has_specials());
+  EXPECT_TRUE(summary->touches_exec);
+}
+
 } // namespace
 } // namespace rocjitsu

--- a/emulation/rocjitsu/tests/patch/spill_manager_test.cpp
+++ b/emulation/rocjitsu/tests/patch/spill_manager_test.cpp
@@ -358,6 +358,36 @@ TEST(SpillManager, ReserveSet_HandlesEmpty) {
   EXPECT_EQ(m.total_private_bytes(), before);
 }
 
+// A set containing a special singleton (EXEC/VCC/...) has no scratch slot, so
+// reserve must fail cleanly and reserve NOTHING — not even its ordinary members,
+// and without tripping the post-capacity-check assert on the special reg.
+TEST(SpillManager, ReserveSet_FailsCleanlyOnSpecialRegisters) {
+  RegisterSet set;
+  set.expand(sgpr(0));
+  set.expand(RegisterRef{RegClass::EXEC, 0, 1});
+
+  SpillManager m(0, kBigLimit);
+  EXPECT_FALSE(m.reserve(set));
+  EXPECT_EQ(m.total_private_bytes(), 0u);
+  EXPECT_EQ(m.offset_for(sgpr(0)), std::nullopt);
+}
+
+// The ordinary_only() projection of a set with specials is reservable — the
+// ordinary members allocate normally once the special is projected out.
+TEST(SpillManager, ReserveSet_OrdinaryProjectionIsReservable) {
+  RegisterSet set;
+  set.expand(sgpr(0));
+  set.expand(vgpr(3));
+  set.expand(RegisterRef{RegClass::VCC, 0, 1});
+
+  SpillManager m(0, kBigLimit);
+  ASSERT_FALSE(m.reserve(set)); // specials present -> clean fail
+  EXPECT_TRUE(m.reserve(set.ordinary_only()));
+  EXPECT_EQ(m.total_private_bytes(), 8u);
+  EXPECT_TRUE(m.offset_for(sgpr(0)).has_value());
+  EXPECT_TRUE(m.offset_for(vgpr(3)).has_value());
+}
+
 TEST(SpillManager, AllocateSlotReturnsNulloptOnOverflow) {
   SpillManager m(0, /*limit=*/8);
   EXPECT_TRUE(m.allocate_slot(sgpr(0)).has_value());

--- a/emulation/rocjitsu/tests/scalar_scc_test.cpp
+++ b/emulation/rocjitsu/tests/scalar_scc_test.cpp
@@ -690,8 +690,9 @@ TEST(ScalarSccTest, AddkAndMulkRegisterDestinationRead) {
       ASSERT_NE(inst, nullptr) << profile.name << " " << mnemonic;
       ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic) << profile.name;
 
-      // s_addk_i32 sets SCC, modeled as an inert fieldless dst operand;
-      // s_mulk_i32 does not touch SCC. SCC carries no def/use either way.
+      // s_addk_i32 sets SCC through a fieldless dst operand (no RegisterRef);
+      // s_mulk_i32 does not. InstDefUse records that SCC write as a singleton
+      // special member of defs, kept out of the ordinary projection below.
       const bool sets_scc = mnemonic != std::string_view{"s_mulk_i32"};
       ASSERT_EQ(inst->num_src_operands(), 2) << profile.name << " " << mnemonic;
       ASSERT_EQ(inst->num_dst_operands(), sets_scc ? 2 : 1) << profile.name << " " << mnemonic;

--- a/emulation/rocjitsu/tests/scalar_scc_test.cpp
+++ b/emulation/rocjitsu/tests/scalar_scc_test.cpp
@@ -284,10 +284,10 @@ void expect_wrexec_def_use(const ScalarSccProfile &profile, const WrexecPair &pa
 
     const RegisterRef source{RegClass::SGPR, kSourceSgpr, width};
     const RegisterRef destination{RegClass::SGPR, kDestSgpr, width};
-    // The implicit EXEC read/write and SCC def are modeled as inert fieldless
-    // operands (to_register_ref() == nullopt): they add to the operand counts
-    // but contribute nothing to def/use at this time. The field-bearing SGPR
-    // source/dest stay at index 0.
+    // The implicit EXEC read/write and SCC def are fieldless special operands
+    // (to_register_ref() == nullopt): they become singleton special members of
+    // the def/use sets, but stay out of the ordinary projection asserted below.
+    // The field-bearing SGPR source/dest stay at index 0.
     ASSERT_EQ(inst->num_src_operands(), 2) << profile.name << " " << mnemonic;
     ASSERT_EQ(inst->num_dst_operands(), 3) << profile.name << " " << mnemonic;
     EXPECT_EQ(inst->src_operand(0)->to_register_ref(), source) << profile.name << " " << mnemonic;
@@ -307,8 +307,10 @@ void expect_wrexec_def_use(const ScalarSccProfile &profile, const WrexecPair &pa
     EXPECT_FALSE(def_use.uses.contains(destination)) << profile.name << " " << mnemonic;
     EXPECT_TRUE(def_use.defs.contains(destination)) << profile.name << " " << mnemonic;
     EXPECT_FALSE(def_use.defs.contains(source)) << profile.name << " " << mnemonic;
-    EXPECT_EQ(def_use.uses.size(), static_cast<size_t>(width)) << profile.name << " " << mnemonic;
-    EXPECT_EQ(def_use.defs.size(), static_cast<size_t>(width)) << profile.name << " " << mnemonic;
+    EXPECT_EQ(def_use.uses.ordinary_size(), static_cast<size_t>(width))
+        << profile.name << " " << mnemonic;
+    EXPECT_EQ(def_use.defs.ordinary_size(), static_cast<size_t>(width))
+        << profile.name << " " << mnemonic;
   }
 }
 
@@ -712,8 +714,10 @@ TEST(ScalarSccTest, AddkAndMulkRegisterDestinationRead) {
           << profile.name << " " << mnemonic;
       EXPECT_TRUE(def_use.defs.contains(RegisterRef{RegClass::SGPR, 4, 1}))
           << profile.name << " " << mnemonic;
-      EXPECT_EQ(def_use.uses.size(), 1u) << profile.name << " " << mnemonic;
-      EXPECT_EQ(def_use.defs.size(), 1u) << profile.name << " " << mnemonic;
+      // The implicit SCC def is a special member of defs; the ordinary
+      // projection is just the s4 read-modify-write.
+      EXPECT_EQ(def_use.uses.ordinary_size(), 1u) << profile.name << " " << mnemonic;
+      EXPECT_EQ(def_use.defs.ordinary_size(), 1u) << profile.name << " " << mnemonic;
     }
   }
 }


### PR DESCRIPTION
## Motivation

TL;DR: One `RegisterSet` or two?

PR #9112 introduced the special register def/use by placing them in a `SpecialRegisterSet`, separate from `RegisterSet`. The idea at the time is that this would be an easier introduction of the special operands. The existing liveness analysis would be unaffected, the spill manager would not have to consider them, they don't have an "index" like the other registers, etc. Ultimately, it assumes that users will query the `SpecialRegisterSet` when they need to.

This PR shows what would be changed if we fold the special registers in the the `RegisterSet` so now users have to be deliberate in their use of the ordinary registers. It required the addition of `ordinary_only()`, `for_each_ordinary()`, and related functions and changing consumers to specifically use the ordinary registers. 

## Test Plan

Tests were updated to reflect the single `RegisterSet`.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
