### PR TITLE
Add tuning to address 128MB AR regression in two node.

### DIFF
--- a/projects/rccl/src/graph/tuning.cc
+++ b/projects/rccl/src/graph/tuning.cc
@@ -680,7 +680,10 @@ static struct tuningModel tuning_model_6{
      {1, 1, 48},
      {1048576, 4194304, 56},
      {4194304, 268435457, 64}},
-    /*AllReduce*/ {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},
+    // gfx950 multi-node: cap AllReduce to 48 channels for per-rank sizes in
+    // (4 MiB, 8 MiB]; 64 (post-#7848 default) regresses this window on RING.
+    /*AllReduce*/
+    {{4194304, 8388608, 48}},
   },
 };
 


### PR DESCRIPTION
## Motivation

Fix small regression

## Technical Details

Raising channels to 64 seems to cause a regression for the 128 MiB data size on 2 nodes.  This fix appears to fix it.

## Issue Tracking

JIRA ID: AICOMRCCL-1553

## Test Plan

Performance sweep with this

## Test Result

In process

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
