### PR TITLE
AIRUNTIME-2552 - Fix overflow issue when merging multiple packets

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/device.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/device.h
@@ -214,6 +214,7 @@ public:
   uint32_t LdsBlocks(const hsa_kernel_dispatch_packet_t *pkt);
   uint32_t GetCmdbufSize(void) const { return cmdbuf_size_; }
   uint32_t GetAqlFrameSize(void) const { return cmdbuf_aql_frame_size_; }
+  uint32_t GetAqlPacketMaxSize(void) const { return cmdbuf_aql_packet_max_size_; }
   static uint32_t GetAqlFrameNum(void) { return cmdbuf_aql_frame_num_; }
 
   bool AllocUserQueueMemFromUMD(void) const {
@@ -278,6 +279,10 @@ private:
 
   uint32_t cmdbuf_size_;
   uint32_t cmdbuf_aql_frame_size_;
+  // Worst-case PM4 size of a single translated AQL packet; a frame holds up to
+  // kAqlFrameMergeCapacity of these to allow packet merging without overflowing.
+  uint32_t cmdbuf_aql_packet_max_size_;
+  static constexpr uint32_t kAqlFrameMergeCapacity = 16;
   static const uint32_t cmdbuf_aql_frame_num_;
   uint32_t node_id_;
   // device info

--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/queue.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/queue.h
@@ -216,6 +216,9 @@ public:
 
   uint64_t cmdbuf_aql_frame_write_index;
   uint32_t cmdbuf_aql_frame_size;
+  // Worst-case PM4 size of a single translated AQL packet; used to flush a partially filled
+  // frame before merging a packet that would not fit, preventing command-buffer overflow.
+  uint32_t cmdbuf_aql_packet_max_size;
 
   uint64_t  *signal_addr_;
   bool platform_atomic_support_;

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -604,7 +604,14 @@ void WDDMDevice::InitCmdbufInfo(void) {
   // Add safety margin to account for alignment and future additions
   cmdbuf_aql_frame_size_ += 128;
 
-  cmdbuf_aql_frame_size_ = rocr::AlignUp(cmdbuf_aql_frame_size_, 0x10);
+  // Worst-case PM4 size of a single translated AQL packet (kernel dispatch / barrier /
+  // vendor-specific). The AQL->PM4 translator merges multiple signal-less packets into one frame
+  // (see ComputeQueue::SwitchAql2PM4), so the frame must be large enough to hold several packets;
+  // sizing it for a single packet caused a command-buffer overflow when back-to-back dispatches
+  // (e.g. per-layer copies of a layered array) merged into one frame.
+  cmdbuf_aql_packet_max_size_ = rocr::AlignUp(cmdbuf_aql_frame_size_, 0x10);
+
+  cmdbuf_aql_frame_size_ = cmdbuf_aql_packet_max_size_ * kAqlFrameMergeCapacity;
 
   cmdbuf_size_ = rocr::AlignUp(cmdbuf_aql_frame_num_ * cmdbuf_aql_frame_size_, 0x1000);
 }

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
@@ -609,6 +609,7 @@ hsa_status_t ComputeQueue::Init(void) {
 
   ib_start_addr = cmdbuf_addr;
   cmdbuf_aql_frame_size = device->GetAqlFrameSize();
+  cmdbuf_aql_packet_max_size = device->GetAqlPacketMaxSize();
   platform_atomic_support_ = device->SupportPlatformAtomic();
 
   return ret;
@@ -975,6 +976,19 @@ hsa_status_t ComputeQueue::SwitchAql2PM4(void) {
   header &= (1 << HSA_PACKET_HEADER_WIDTH_TYPE) - 1;
   hsa_kernel_dispatch_packet_t* aql_packet = (hsa_kernel_dispatch_packet_t*)packet;
   hsa_status_t ret;
+
+  // If the current frame already holds translated packets and merging one more could overflow it,
+  // submit the accumulated frame now and translate this packet into a fresh frame. The frame is
+  // sized to hold several worst-case packets (see WDDMDevice::InitCmdbufInfo), but bursts of
+  // signal-less dispatches (e.g. per-layer copies of a layered array) can accumulate beyond that;
+  // without this flush the post-build overflow check would fail the whole queue. Returning here
+  // leaves cmdbuf_aql_frame_write_index unchanged (it advances only inside the *AqlToPm4 builders),
+  // so the same packet is re-translated after EndSubmit() resets ib_size and advances the frame.
+  if (ib_size != 0 && header != HSA_PACKET_TYPE_INVALID &&
+      (ib_size + cmdbuf_aql_packet_max_size) > cmdbuf_aql_frame_size) {
+    ready_to_submit = true;
+    return HSA_STATUS_SUCCESS;
+  }
 
   switch (header) {
     case HSA_PACKET_TYPE_KERNEL_DISPATCH:


### PR DESCRIPTION
…to one frame

This is to fix issue of Commit 7449be6:
  libhsakmt WDDM: Fix heap buffer overflow in VendorSpecificAqlToPm4

The issue fails many layered image tests in hip-test.

If the current frame already holds translated packets and merging one more could overflow it, submit the accumulated frame now and translate this packet into a fresh frame. The frame is sized to hold several worst-case packets (see WDDMDevice::InitCmdbufInfo), but bursts of signal-less dispatches (e.g. per-layer copies of a layered array) can accumulate beyond that, thus the post-build overflow check would fail the whole queue.

## Motivation

fix issue of Commit 7449be6:
  libhsakmt WDDM: Fix heap buffer overflow in VendorSpecificAqlToPm4
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

AIRUNTIME-2552 

## Test Plan

All hip-tests

## Test Result

should pass
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
