### PR TITLE
fix(amdsmi): [ROCM-28173] allow SOCKET_SCOPE affinity without NUMA assignment

### DIFF
--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -6332,13 +6332,12 @@ amdsmi_status_t amdsmi_get_cpu_affinity_with_scope(amdsmi_processor_handle proce
     return status;
   }
 
-  if (node_id < 0) {
-    return AMDSMI_STATUS_NOT_FOUND;
-  }
-
   std::memset(cpu_set, 0, cpu_set_size * sizeof(uint64_t));
   switch (scope) {
     case AMDSMI_AFFINITY_SCOPE_NODE: {
+      if (node_id < 0) {
+        return AMDSMI_STATUS_NOT_FOUND;
+      }
       std::vector<uint64_t> bitmask = gpu_device->get_bitmask_from_numa_node(node_id, cpu_set_size);
       if (bitmask[0] == std::numeric_limits<int32_t>::max()) {
         return AMDSMI_STATUS_REFCOUNT_OVERFLOW;


### PR DESCRIPTION
## Motivation

Both NUMA_SCOPE and SOCKET_SCOPE were blocked when node_id < 0.

## Technical Details

SOCKET_SCOPE should work independently of NUMA topology. The earlier check caused SOCKET_AFFINITY to show N/A even when local_cpulist was available. So moved node_id < 0 check from global scope into AMDSMI_AFFINITY_SCOPE_NODE case.

## Issue Tracking

JIRA ID : ROCM-28173

## Test Plan

`amd-smi static --numa`

## Test Result
```
/opt/rocm/bin/amd-smi static --numa
GPU: 0
    NUMA:
        NODE: 0
        AFFINITY: NONE
        CPU_AFFINITY: N/A
        SOCKET_AFFINITY:
            CPU_LIST_0:
                BITMASK: FFFFFFFFFFFFFFFF
                CPU_CORES_AFFINITY: 0-63
            CPU_LIST_1:
                BITMASK: FFFFFFFFFFFFFFFF
                CPU_CORES_AFFINITY: 64-127
            CPU_LIST_2:
                BITMASK: FFFFFFFFFFFFFFFF
                CPU_CORES_AFFINITY: 128-191
            CPU_LIST_3:
                BITMASK: 7FFFFFFFFFFFFFFF
                CPU_CORES_AFFINITY: 192-254
```


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
