### PR TITLE
[rocjitsu] Treat empty-text code objects as DBT no-ops

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -848,12 +848,20 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   TranslatedCodeObject result;
   result.host_arch = host_arch_;
 
-  CodeObjectPatcher patcher(obj);
   auto leave_unchanged = [&]() {
     const auto *image = reinterpret_cast<const uint8_t *>(obj.image_data());
-    result.elf_bytes.assign(image, image + obj.image_size());
+    if (obj.image_size() != 0)
+      result.elf_bytes.assign(image, image + obj.image_size());
     return result;
   };
+
+  if (obj.image_size() < sizeof(Elf64_Ehdr)) {
+    append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
+                 "code object is too small to contain an ELF header");
+    return leave_unchanged();
+  }
+
+  CodeObjectPatcher patcher(obj);
 
   // A same-architecture gfx1250 translation is direction-specific: A0 and B0
   // share an ELF machine ID, so both revisions must be given and must select a
@@ -881,6 +889,14 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
 
   auto text = patcher.text_bytes();
   if (text.empty()) {
+    Elf64_Ehdr header{};
+    std::memcpy(&header, obj.image_data(), sizeof(header));
+    const uint32_t source_mach = header.e_flags & EF_AMDGPU_MACH;
+    if (guest_arch_ == host_arch_ && source_mach == (target_mach_ & EF_AMDGPU_MACH)) {
+      append_warning(result.diagnostics, DiagnosticKind::NothingToTranslate,
+                     "code object has no executable text; leaving unchanged");
+      return leave_unchanged();
+    }
     append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
                  "code object does not expose a non-empty .text section for translation");
     return leave_unchanged();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_diagnostic.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_diagnostic.h
@@ -27,6 +27,7 @@ enum class DiagnosticKind {
   Legalization,
   ExpandMissing,
   ExpandFailed,
+  NothingToTranslate,
   ResourceLimit,
   KernelSkipped,
 };
@@ -54,6 +55,13 @@ has_error_diagnostic(const std::vector<TranslationDiagnostic> &diagnostics) {
   });
 }
 
+[[nodiscard]] inline bool has_diagnostic_kind(const std::vector<TranslationDiagnostic> &diagnostics,
+                                              DiagnosticKind kind) {
+  return std::ranges::any_of(diagnostics, [kind](const TranslationDiagnostic &diagnostic) {
+    return diagnostic.kind == kind;
+  });
+}
+
 /// @brief True if any kernel was replaced by a non-dispatchable no-op stub.
 ///
 /// @details skip_failed_kernels reports a KernelSkipped *warning* (not an error),
@@ -64,9 +72,7 @@ has_error_diagnostic(const std::vector<TranslationDiagnostic> &diagnostics) {
 /// non-dispatchable, matching the HSA hook which refuses such a load.
 [[nodiscard]] inline bool
 has_skipped_kernel(const std::vector<TranslationDiagnostic> &diagnostics) {
-  return std::ranges::any_of(diagnostics, [](const TranslationDiagnostic &diagnostic) {
-    return diagnostic.kind == DiagnosticKind::KernelSkipped;
-  });
+  return has_diagnostic_kind(diagnostics, DiagnosticKind::KernelSkipped);
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
@@ -543,6 +543,8 @@ void trace_virtual_lds_kernarg(uint64_t packet_id, const void *kernarg, size_t s
     return "expand-missing";
   case DiagnosticKind::ExpandFailed:
     return "expand-failed";
+  case DiagnosticKind::NothingToTranslate:
+    return "nothing-to-translate";
   case DiagnosticKind::ResourceLimit:
     return "resource-limit";
   case DiagnosticKind::KernelSkipped:

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -257,6 +257,19 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_text_and_rodata() {
   return image;
 }
 
+std::vector<uint8_t> make_minimal_gfx1250_elf_with_empty_text_and_rodata() {
+  auto image = make_minimal_amdgpu_elf_with_text_and_rodata();
+  auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  assert(shdrs.size() >= 2);
+
+  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX1250;
+  shdrs[1].sh_size = 0;
+  write_elf_struct_for_test(image, 0, ehdr);
+  write_bytes_for_test(image, ehdr.e_shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  return image;
+}
+
 std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
   constexpr uint64_t text_offset = 0x100;
   constexpr uint64_t text_vaddr = 0x1100;
@@ -1502,6 +1515,130 @@ TEST(LegalizationFmaK, Rdna1ToRdna3FmaakF16IsIdentity) {
   ASSERT_NE(e, nullptr);
   EXPECT_EQ(e->action, Action::Identity);
   EXPECT_EQ(e->target_opcode, 56);
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextSameArchIsSuccessfulNoOp) {
+  const auto image = make_minimal_gfx1250_elf_with_empty_text_and_rodata();
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_EQ(source.target_id(), ROCJITSU_CODE_TARGET_GFX1250);
+  ASSERT_FALSE(source.text_sections().empty());
+  ASSERT_EQ(source.text_sections()[0]->size(), 0u);
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_TRUE(result.ok());
+  EXPECT_TRUE(result.dispatchable());
+  EXPECT_EQ(result.elf_bytes, image);
+  const auto warning = std::ranges::find_if(result.diagnostics, [](const auto &diagnostic) {
+    return diagnostic.kind == DiagnosticKind::NothingToTranslate;
+  });
+  ASSERT_NE(warning, result.diagnostics.end());
+  EXPECT_EQ(warning->severity, DiagnosticSeverity::Warning);
+  EXPECT_EQ(warning->message, "code object has no executable text; leaving unchanged");
+}
+
+TEST(BinaryTranslatorE2E, TruncatedImageFailsBeforeReadingElfHeader) {
+  const std::array<uint8_t, sizeof(Elf64_Ehdr) - 1> image{};
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_FALSE(source.is_valid());
+  ASSERT_LT(source.image_size(), sizeof(Elf64_Ehdr));
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_RDNA4, ROCJITSU_CODE_ARCH_RDNA4);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_TRUE(result.elf_bytes.empty());
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ResourceLimit,
+                                   "too small to contain an ELF header"));
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextCrossArchStillFails) {
+  const auto image = make_minimal_gfx1250_elf_with_empty_text_and_rodata();
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_RDNA4);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ResourceLimit,
+                                   "does not expose a non-empty .text section"));
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextSameArchDifferentMachineStillFails) {
+  auto image = make_minimal_gfx1250_elf_with_empty_text_and_rodata();
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1200);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_EQ(source.target_id(), ROCJITSU_CODE_TARGET_GFX1200);
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_RDNA4, ROCJITSU_CODE_ARCH_RDNA4,
+                              EF_AMDGPU_MACH_AMDGCN_GFX1201);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ResourceLimit,
+                                   "does not expose a non-empty .text section"));
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextGfx1250StillRequiresRevisions) {
+  const auto image = make_minimal_gfx1250_elf_with_empty_text_and_rodata();
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::Legalization,
+                                   "requires both input and output silicon revisions"));
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextGfx1250StillRejectsA0ToB0) {
+  const auto image = make_minimal_gfx1250_elf_with_empty_text_and_rodata();
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250A0;
+  options.output_revision = ProcessorRevision::Gfx1250B0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::Legalization,
+                                   "A0-to-B0 translation is not supported"));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessExecutableTextStillFails) {
+  auto image = make_minimal_amdgpu_elf_with_text_and_rodata();
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_FALSE(source.text_sections().empty());
+  ASSERT_GT(source.text_sections()[0]->size(), 0u);
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::KernelDescriptor,
+                                   "kernel descriptors are required"));
 }
 
 TEST(CodeObjectPatcher, ReplaceTextGrowsTextAndShiftsFollowingSections) {

--- a/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
@@ -178,6 +178,47 @@ std::vector<uint8_t> make_smoke_code_object() {
   return image;
 }
 
+std::vector<uint8_t> make_empty_text_code_object() {
+  auto image = make_smoke_code_object();
+
+  rocjitsu::Elf64_Ehdr header{};
+  std::memcpy(&header, image.data(), sizeof(header));
+  header.e_flags = rocjitsu::EF_AMDGPU_MACH_AMDGCN_GFX1250;
+  std::memcpy(image.data(), &header, sizeof(header));
+
+  rocjitsu::Elf64_Phdr executable_load{};
+  std::memcpy(&executable_load, image.data() + header.e_phoff, sizeof(executable_load));
+  executable_load.p_filesz = 0;
+  executable_load.p_memsz = 0;
+  std::memcpy(image.data() + header.e_phoff, &executable_load, sizeof(executable_load));
+
+  auto section_offset = [&](size_t index) {
+    return header.e_shoff + index * sizeof(rocjitsu::Elf64_Shdr);
+  };
+  rocjitsu::Elf64_Shdr text{};
+  std::memcpy(&text, image.data() + section_offset(1), sizeof(text));
+  text.sh_size = 0;
+  std::memcpy(image.data() + section_offset(1), &text, sizeof(text));
+
+  // The source smoke fixture has one synthetic kernel descriptor. Clear it so
+  // this variant represents the descriptor-free, data-only corpus object that
+  // motivated the successful empty-text no-op.
+  rocjitsu::Elf64_Shdr symtab{};
+  std::memcpy(&symtab, image.data() + section_offset(3), sizeof(symtab));
+  rocjitsu::Elf64_Sym descriptor{};
+  std::memcpy(&descriptor, image.data() + symtab.sh_offset + sizeof(rocjitsu::Elf64_Sym),
+              sizeof(descriptor));
+  descriptor.st_name = 0;
+  descriptor.st_info = 0;
+  descriptor.st_shndx = rocjitsu::SHN_UNDEF;
+  descriptor.st_value = 0;
+  descriptor.st_size = 0;
+  std::memcpy(image.data() + symtab.sh_offset + sizeof(rocjitsu::Elf64_Sym), &descriptor,
+              sizeof(descriptor));
+
+  return image;
+}
+
 std::string shell_quote(std::string_view text) {
   std::string quoted = "'";
   for (const char ch : text) {
@@ -247,6 +288,38 @@ TEST(RjDbtTranslate, Smoke) {
         << "missing expected output fragment: " << needle << "\noutput:\n"
         << stdout_text;
   }
+}
+
+TEST(RjDbtTranslate, EmptyTextSameArchWarnsAndCopiesInput) {
+  const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_empty_text_");
+  const std::filesystem::path temp_path(temp_dir.path());
+
+  const auto input = temp_path / "data_only_gfx1250.co";
+  const auto output = temp_path / "translated.co";
+  const auto error = temp_path / "stderr.txt";
+  const auto image = make_empty_text_code_object();
+
+  {
+    std::ofstream out(input, std::ios::binary);
+    out.write(reinterpret_cast<const char *>(image.data()),
+              static_cast<std::streamsize>(image.size()));
+  }
+
+  const std::string command = shell_quote(g_translate_tool.string()) + " " +
+                              shell_quote(input.string()) +
+                              " --input-target gfx1250 --input-revision b0 --output-target gfx1250 "
+                              "--output-revision a0 --output-mode code-object > " +
+                              shell_quote(output.string()) + " 2> " + shell_quote(error.string());
+
+  const int status = std::system(command.c_str());
+  const std::string output_bytes = read_text_file(output);
+  const std::string stderr_text = read_text_file(error);
+
+  ASSERT_TRUE(command_succeeded(status)) << stderr_text;
+  EXPECT_EQ(output_bytes, std::string(reinterpret_cast<const char *>(image.data()), image.size()));
+  EXPECT_TRUE(contains(stderr_text, "warning: nothing-to-translate: code object has no executable "
+                                    "text; leaving unchanged"))
+      << stderr_text;
 }
 
 TEST(RjDbtTranslate, RequiresRevisionsOnlyForGfx1250) {

--- a/emulation/rocjitsu/tools/dbt_translate.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate.cpp
@@ -409,7 +409,9 @@ ToolResult<TranslateOutput> translate_code_object(const TranslateOptions &option
     output.value.disassembly += translated_inspection.disassembly;
   }
 
-  if (!validate_host_decode(output.value.translated_report, error)) {
+  const bool nothing_to_translate =
+      has_diagnostic_kind(output.value.diagnostics, DiagnosticKind::NothingToTranslate);
+  if (!nothing_to_translate && !validate_host_decode(output.value.translated_report, error)) {
     add_error(output, kValidationError, error);
     return output;
   }

--- a/emulation/rocjitsu/tools/dbt_translate_main.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate_main.cpp
@@ -330,6 +330,8 @@ struct ReportTotals {
     return "expand-missing";
   case DiagnosticKind::ExpandFailed:
     return "expand-failed";
+  case DiagnosticKind::NothingToTranslate:
+    return "nothing-to-translate";
   case DiagnosticKind::ResourceLimit:
     return "resource-limit";
   case DiagnosticKind::KernelSkipped:


### PR DESCRIPTION
## Motivation

Allow gfx1250 B0-to-A0 translation to accept data-only code objects with no executable text.

## Technical Details

Emit a `nothing-to-translate` warning and return the original bytes when the source and destination architecture and ELF machine match. Let the CLI accept that explicit no-op while keeping cross-target empty-text and descriptor-less executable objects fail-closed.

## Issue Tracking

N/A

## Test Plan

Run ctest and both HotSwap corpus tests.

## Test Result

ctest OK. The data-only object exited 0 with byte-identical output; the descriptor-less executable object remained an exit-3 error.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.