### PR TITLE
docs(rocprofiler-systems): Update README for rocshmem-test example

### DIFF
--- a/projects/rocprofiler-systems/examples/rocshmem/README.md
+++ b/projects/rocprofiler-systems/examples/rocshmem/README.md
@@ -44,13 +44,13 @@ cmake --build <build_dir>
 
 ```bash
 cmake -B <build_dir> -S <project_root>/examples/
-cmake --build <build_dir> --target rocshmem
+cmake --build <build_dir> --target rocshmem-test
 ```
 
 ## Running
 
 ```bash
-mpirun -np 2 ./rocshmem
+mpirun -np 2 ./rocshmem-test
 ```
 
 Expected output:
@@ -63,22 +63,21 @@ Expected output:
 ## Profiling with rocprofiler-systems
 
 ```bash
-mpirun -np 2 rocprof-sys-run -- ./rocshmem
+mpirun -np 2 rocprof-sys-run -- ./rocshmem-test
 ```
 
 ### Recommended Configuration
 
-| Variable | Value | Purpose |
+| Argument | Value | Purpose |
 | --- | --- | --- |
-| `ROCPROFSYS_ROCM_DOMAINS` | `rocshmem_api` | Enable rocSHMEM host-stream API tracing |
-| `ROCPROFSYS_USE_ROCPD` | `ON` | Generate rocpd database |
-| `ROCPROFSYS_USE_SAMPLING` | `OFF` | Disable statistical sampling (use instrumentation only) |
+| `--rocm-domains` | `hip_runtime_api kernel_dispatch rocshmem_api` | Enable HIP runtime API, kernel dispatch, and rocSHMEM API tracing |
+| `--output-format` | `rocpd proto` | Output a `rocpd` database and perfetto (protobuf) file |
 
 ```bash
 mpirun -np 2 rocprof-sys-run \
-    -e ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch,rocshmem_api \
-    -e ROCPROFSYS_USE_ROCPD=ON \
-    -- ./rocshmem
+    --rocm-domains hip_runtime_api kernel_dispatch rocshmem_api \
+    --output-format rocpd proto \
+    -- ./rocshmem-test
 ```
 
 The resulting rocpd database will contain `rocm_rocshmem_api` spans for each of

--- a/projects/rocprofiler-systems/examples/rocshmem/README.md
+++ b/projects/rocprofiler-systems/examples/rocshmem/README.md
@@ -68,15 +68,17 @@ mpirun -np 2 rocprof-sys-run -- ./rocshmem-test
 
 ### Recommended Configuration
 
-| Argument | Value | Purpose |
+| Variable | Value | Purpose |
 | --- | --- | --- |
-| `--rocm-domains` | `hip_runtime_api kernel_dispatch rocshmem_api` | Enable HIP runtime API, kernel dispatch, and rocSHMEM API tracing |
-| `--output-format` | `rocpd proto` | Output a `rocpd` database and perfetto (protobuf) file |
+| `ROCPROFSYS_ROCM_DOMAINS` | `hip_runtime_api,kernel_dispatch,rocshmem_api` | Enable HIP runtime API, kernel dispatch, and rocSHMEM API tracing |
+| `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace as output |
+| `ROCPROFSYS_ROCPD` | `true` | Generate rocpd database as output |
 
 ```bash
+ROCPROFSYS_ROCM_DOMAINS="hip_runtime_api,kernel_dispatch,rocshmem_api" \
+ROCPROFSYS_TRACE=true \
+ROCPROFSYS_ROCPD=true \
 mpirun -np 2 rocprof-sys-run \
-    --rocm-domains hip_runtime_api kernel_dispatch rocshmem_api \
-    --output-format rocpd proto \
     -- ./rocshmem-test
 ```
 


### PR DESCRIPTION
## Motivation

Updated the README.md to reflect changes in the build and run commands for the `rocshmem-test` example. The target has been changed from `rocshmem` to `rocshmem-test`, and the corresponding profiling commands have been updated to match this change. Additionally, the configuration section was modified to clarify the arguments used for profiling.

## Issue Tracking

JIRA ID - AIPROFSYST-479
JIRA ID - AIPROFSYST-480

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
