### PR TITLE
feat(amdsmi): Add Ppod/Vpod/Station config APIs

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -142,6 +142,27 @@ GPU: 0
   - Both are UALoE-backed and report `AMDSMI_STATUS_NOT_SUPPORTED` (or the `UINT32_MAX` sentinel for `physical_acc_id`) on systems without an active UALoE session.
   - CLI: `amd-smi static --asic` now includes `PHYSICAL_ACC_ID`; new `amd-smi node --tray`/`-T` flag prints tray type and accelerator count.
 
+- **Added the fabric PPoD/vPoD/DF-station configuration write APIs**.  
+  - New APIs: `amdsmi_set_gpu_fabric_ppod_config()`, `amdsmi_set_gpu_fabric_vpod_config()`, `amdsmi_set_gpu_fabric_station_config()`.
+  - New structures: `amdsmi_fabric_ppod_config_t`, `amdsmi_fabric_vpod_config_t`, `amdsmi_fabric_station_config_t`, and the `amdsmi_fabric_ppod_data_t`, `amdsmi_fabric_vpod_data_t`, `amdsmi_fabric_station_data_t` payloads they share with `amdsmi_get_gpu_fabric_info()`.
+  - New enums: `amdsmi_fabric_config_version_t`, `amdsmi_fabric_ppod_field_t`, `amdsmi_fabric_vpod_field_t`, `amdsmi_fabric_df_field_t`. Each config carries a `mask` selecting the fields to write and a `commit` flag.
+  - `commit == false` validates the request and writes nothing. The driver ignores the staging files unless a commit follows, so values left there would only be picked up by the next commit.
+  - `mask` must select at least one field. A request with `mask == 0` returns `AMDSMI_STATUS_INVAL` even when `commit` is set, so a bare commit cannot flush whatever a prior partial write left staged.
+  - A committing request compares the write subtree against the flat surface before it writes anything and logs any field already pending, since the driver applies everything staged rather than only the fields the request named. The check is observational and never changes the result; enable debug logging to see the report.
+
+- **Added `amdsmi_fabric_info_v2_t`, a second layout for `amdsmi_get_gpu_fabric_info()`**.  
+  - Groups the version 1 fields into the `ppod`/`vpod`/`station` payloads shared with the write APIs above, and exposes the DF/station data (`station_flags`, `num_stations`, `lane_en_bitmap`) and `local_accelerator_count`, none of which have a version 1 equivalent.
+  - New enum `amdsmi_fabric_info_version_t` selects the layout. Set `fabric_version` to `AMDSMI_FABRIC_INFO_VERSION_2` before the call to receive the new layout:
+
+    ```c
+    amdsmi_fabric_info_t info = {0};   /* C++: amdsmi_fabric_info_t info = {}; */
+    info.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
+    amdsmi_get_gpu_fabric_info(handle, &info);
+    ```
+
+  - Adds `ppod_mask`, `vpod_mask`, and `station_mask`, reporting which fields the call actually read. A clear bit means the corresponding field holds its sentinel, which distinguishes "not published by the driver" from a real value that happens to equal the sentinel. The three words are carved from the existing `reserved` array, so `sizeof(amdsmi_fabric_info_v2_t)` is unchanged.
+  - The Python `amdsmi_get_gpu_fabric_info()` requests the new layout automatically; its dictionary gains the three mask keys and is otherwise unchanged.
+
 ### Changed
 
 - **Bumped the library major version to 27.0.0** (breaking).  
@@ -158,7 +179,15 @@ GPU: 0
 - **Flattened the `amdsmi_fabric_info_t` structure and removed `amdsmi_fabric_info_ver_t`**.  
   - The intermediate `amdsmi_fabric_info_ver_t` type was removed from the public header. Its payload union is now the `fabric_info` member of `amdsmi_fabric_info_t`, and its version field is exposed directly as the top-level `fabric_version` field.
   - Field access simplifies from `fabric_info.fabric_version.v1.<field>` to `fabric_info.v1.<field>`, and `fabric_info.version` becomes `fabric_version`.
-  - The change is ABI-preserving: field offsets and the overall structure size are unchanged. The Python `amdsmi_get_gpu_fabric_info()` dictionary keys are also unchanged.
+  - The change is ABI-preserving: field offsets are unchanged. The Python `amdsmi_get_gpu_fabric_info()` dictionary keys are also unchanged. The structure size does change elsewhere in this release; see the `fabric_version` entry below.
+
+- **`amdsmi_fabric_info_t::fabric_version` is now an in/out layout selector**.  
+  - On input it names the union member `amdsmi_get_gpu_fabric_info()` fills; on output it reports the member that was filled. Any value other than `AMDSMI_FABRIC_INFO_VERSION_2` selects `amdsmi_fabric_info_v1_t`, so a zero-initialized structure and one left uninitialized both yield the version 1 layout. An unrecognized value is not an error.
+  - `amdsmi_fabric_info_v1_t` and its field offsets are unchanged and now frozen; on the version 1 path no byte past that union member is written, including the trailing `reserved` words. Existing binaries need no recompile.
+  - `sizeof(amdsmi_fabric_info_t)` grows from 320 to 552 bytes to accommodate `amdsmi_fabric_info_v2_t`. Code that allocates the structure by name is unaffected after a recompile; code that hardcodes the size or serializes the structure whole must be updated.
+
+- **`amdsmi_get_gpu_fabric_info()` reports an over-length accelerator list as absent instead of truncating it**.  
+  - `vpod_active_accelerators` and `local_accelerators` previously kept as many IDs as the array holds and dropped the rest. Neither field carries a count that covers the drop, so a truncated list was indistinguishable from a complete one. A list longer than the array now leaves the field at its sentinel with the corresponding `vpod_mask` / `ppod_mask` bit clear.
 
 - **Prefixed public preprocessor macros with `AMDSMI_` in `amdsmi.h`** (breaking).  
   - `MAX_SVI3_RAIL_INDEX`, `MAX_SVI3_RAIL_SELECTION`, `POWER_EFFICIENCY_MODE_4`, `POWER_EFFICIENCY_MODE_5`, and `MAX_NUMBER_OF_AFIDS_PER_RECORD` are now `AMDSMI_MAX_SVI3_RAIL_INDEX`, `AMDSMI_MAX_SVI3_RAIL_SELECTION`, `AMDSMI_POWER_EFFICIENCY_MODE_4`, `AMDSMI_POWER_EFFICIENCY_MODE_5`, and `AMDSMI_MAX_NUMBER_OF_AFIDS_PER_RECORD`. The unused `CENTRIGRADE_TO_MILLI_CENTIGRADE` macro was removed. Update references to the new names.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -72,6 +72,27 @@ GPU: 0
   - New enum: `amdsmi_accelerator_partition_mem_alloc_mode_t` (`AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING`, `AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL`).
   - Supersedes the equivalent `compute_partition` memory allocation mode APIs, which are now deprecated.
 
+- **Added the fabric PPoD/vPoD/DF-station configuration write APIs**.  
+  - New APIs: `amdsmi_set_gpu_fabric_ppod_config()`, `amdsmi_set_gpu_fabric_vpod_config()`, `amdsmi_set_gpu_fabric_station_config()`.
+  - New structures: `amdsmi_fabric_ppod_config_t`, `amdsmi_fabric_vpod_config_t`, `amdsmi_fabric_station_config_t`, and the `amdsmi_fabric_ppod_data_t`, `amdsmi_fabric_vpod_data_t`, `amdsmi_fabric_station_data_t` payloads they share with `amdsmi_get_gpu_fabric_info()`.
+  - New enums: `amdsmi_fabric_config_version_t`, `amdsmi_fabric_ppod_field_t`, `amdsmi_fabric_vpod_field_t`, `amdsmi_fabric_df_field_t`. Each config carries a `mask` selecting the fields to write and a `commit` flag.
+  - `commit == false` validates the request and writes nothing. The driver ignores the staging files unless a commit follows, so values left there would only be picked up by the next commit.
+  - `mask` must select at least one field. A request with `mask == 0` returns `AMDSMI_STATUS_INVAL` even when `commit` is set, so a bare commit cannot flush whatever a prior partial write left staged.
+  - A committing request compares the write subtree against the flat surface before it writes anything and logs any field already pending, since the driver applies everything staged rather than only the fields the request named. The check is observational and never changes the result; enable debug logging to see the report.
+
+- **Added `amdsmi_fabric_info_v2_t`, a second layout for `amdsmi_get_gpu_fabric_info()`**.  
+  - Groups the version 1 fields into the `ppod`/`vpod`/`station` payloads shared with the write APIs above, and exposes the DF/station data (`station_flags`, `num_stations`, `lane_en_bitmap`) and `local_accelerator_count`, none of which have a version 1 equivalent.
+  - New enum `amdsmi_fabric_info_version_t` selects the layout. Set `fabric_version` to `AMDSMI_FABRIC_INFO_VERSION_2` before the call to receive the new layout:
+
+    ```c
+    amdsmi_fabric_info_t info = {0};   /* C++: amdsmi_fabric_info_t info = {}; */
+    info.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
+    amdsmi_get_gpu_fabric_info(handle, &info);
+    ```
+
+  - Adds `ppod_mask`, `vpod_mask`, and `station_mask`, reporting which fields the call actually read. A clear bit means the corresponding field holds its sentinel, which distinguishes "not published by the driver" from a real value that happens to equal the sentinel. The three words are carved from the existing `reserved` array, so `sizeof(amdsmi_fabric_info_v2_t)` is unchanged.
+  - The Python `amdsmi_get_gpu_fabric_info()` requests the new layout automatically; its dictionary gains the three mask keys and is otherwise unchanged.
+
 ### Changed
 
 - **Bumped the library major version to 27.0.0** (breaking).  
@@ -88,7 +109,15 @@ GPU: 0
 - **Flattened the `amdsmi_fabric_info_t` structure and removed `amdsmi_fabric_info_ver_t`**.  
   - The intermediate `amdsmi_fabric_info_ver_t` type was removed from the public header. Its payload union is now the `fabric_info` member of `amdsmi_fabric_info_t`, and its version field is exposed directly as the top-level `fabric_version` field.
   - Field access simplifies from `fabric_info.fabric_version.v1.<field>` to `fabric_info.v1.<field>`, and `fabric_info.version` becomes `fabric_version`.
-  - The change is ABI-preserving: field offsets and the overall structure size are unchanged. The Python `amdsmi_get_gpu_fabric_info()` dictionary keys are also unchanged.
+  - The change is ABI-preserving: field offsets are unchanged. The Python `amdsmi_get_gpu_fabric_info()` dictionary keys are also unchanged. The structure size does change elsewhere in this release; see the `fabric_version` entry below.
+
+- **`amdsmi_fabric_info_t::fabric_version` is now an in/out layout selector**.  
+  - On input it names the union member `amdsmi_get_gpu_fabric_info()` fills; on output it reports the member that was filled. Any value other than `AMDSMI_FABRIC_INFO_VERSION_2` selects `amdsmi_fabric_info_v1_t`, so a zero-initialized structure and one left uninitialized both yield the version 1 layout. An unrecognized value is not an error.
+  - `amdsmi_fabric_info_v1_t` and its field offsets are unchanged and now frozen; on the version 1 path no byte past that union member is written, including the trailing `reserved` words. Existing binaries need no recompile.
+  - `sizeof(amdsmi_fabric_info_t)` grows from 320 to 552 bytes to accommodate `amdsmi_fabric_info_v2_t`. Code that allocates the structure by name is unaffected after a recompile; code that hardcodes the size or serializes the structure whole must be updated.
+
+- **`amdsmi_get_gpu_fabric_info()` reports an over-length accelerator list as absent instead of truncating it**.  
+  - `vpod_active_accelerators` and `local_accelerators` previously kept as many IDs as the array holds and dropped the rest. Neither field carries a count that covers the drop, so a truncated list was indistinguishable from a complete one. A list longer than the array now leaves the field at its sentinel with the corresponding `vpod_mask` / `ppod_mask` bit clear.
 
 - **Prefixed public preprocessor macros with `AMDSMI_` in `amdsmi.h`** (breaking).  
   - `MAX_SVI3_RAIL_INDEX`, `MAX_SVI3_RAIL_SELECTION`, `POWER_EFFICIENCY_MODE_4`, `POWER_EFFICIENCY_MODE_5`, and `MAX_NUMBER_OF_AFIDS_PER_RECORD` are now `AMDSMI_MAX_SVI3_RAIL_INDEX`, `AMDSMI_MAX_SVI3_RAIL_SELECTION`, `AMDSMI_POWER_EFFICIENCY_MODE_4`, `AMDSMI_POWER_EFFICIENCY_MODE_5`, and `AMDSMI_MAX_NUMBER_OF_AFIDS_PER_RECORD`. The unused `CENTRIGRADE_TO_MILLI_CENTIGRADE` macro was removed. Update references to the new names.

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -6613,9 +6613,13 @@ Field | Description
 `vpod_id` | Virtual PoD identifier
 `vpod_size` | Virtual PoD size
 `local_accelerators` | List of local accelerator IDs
-`vpod_active_accelerators` | Active-accelerator bitmap as a list of 32-bit words (bit N set = accelerator ID N is active)
+`local_accelerator_count` | Count of valid entries in `local_accelerators`
+`vpod_active_accelerators` | List of active accelerator IDs; unused slots read `UINT32_MAX` (UNSET), as with `local_accelerators`
 `addr_mode` | NPA address mode: `SOURCE_ALIASING`, `SOURCE_IDENTIFICATION`, or `UNKNOWN`
 `accel_state` | Accelerator vPoD state: `UNCONFIGURED`, `CONFIGURED`, `READY`, `ACTIVE`, `ERROR`, or `UNKNOWN`
+`station_flags` | DF/station flags
+`num_stations` | Number of stations
+`lane_en_bitmap` | Per-lane enable bitmap as a list of bytes
 
 Exceptions that can be thrown by `amdsmi_get_gpu_fabric_info` function:
 

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -6603,7 +6603,7 @@ Output: Dictionary with the corresponding fields
 Field | Description
 ---|---
 `bdf` | BDF of the fabric device
-`version` | Fabric info structure version
+`version` | Fabric info layout version; always `2`, the nested layout the bindings request
 `accelerator_id` | Accelerator identifier (range 0 to 1023)
 `fabric_type` | Fabric type: `UALOE`, `UALLINK`, or `UNKNOWN`
 `bandwidth` | Station bandwidth share in Mb/s
@@ -6620,6 +6620,9 @@ Field | Description
 `station_flags` | DF/station flags
 `num_stations` | Number of stations
 `lane_en_bitmap` | Per-lane enable bitmap as a list of bytes
+`ppod_mask` | `amdsmi_fabric_ppod_field_t` bits actually read into the PPoD fields; a clear bit means that field holds its sentinel
+`vpod_mask` | `amdsmi_fabric_vpod_field_t` bits actually read into the vPoD fields
+`station_mask` | `amdsmi_fabric_df_field_t` bits actually read into the DF/station fields
 
 Exceptions that can be thrown by `amdsmi_get_gpu_fabric_info` function:
 

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -6566,9 +6566,13 @@ Field | Description
 `vpod_id` | Virtual PoD identifier
 `vpod_size` | Virtual PoD size
 `local_accelerators` | List of local accelerator IDs
-`vpod_active_accelerators` | Active-accelerator bitmap as a list of 32-bit words (bit N set = accelerator ID N is active)
+`local_accelerator_count` | Count of valid entries in `local_accelerators`
+`vpod_active_accelerators` | List of active accelerator IDs; unused slots read `UINT32_MAX` (UNSET), as with `local_accelerators`
 `addr_mode` | NPA address mode: `SOURCE_ALIASING`, `SOURCE_IDENTIFICATION`, or `UNKNOWN`
 `accel_state` | Accelerator vPoD state: `UNCONFIGURED`, `CONFIGURED`, `READY`, `ACTIVE`, `ERROR`, or `UNKNOWN`
+`station_flags` | DF/station flags
+`num_stations` | Number of stations
+`lane_en_bitmap` | Per-lane enable bitmap as a list of bytes
 
 Exceptions that can be thrown by `amdsmi_get_gpu_fabric_info` function:
 

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -6556,7 +6556,7 @@ Output: Dictionary with the corresponding fields
 Field | Description
 ---|---
 `bdf` | BDF of the fabric device
-`version` | Fabric info structure version
+`version` | Fabric info layout version; always `2`, the nested layout the bindings request
 `accelerator_id` | Accelerator identifier (range 0 to 1023)
 `fabric_type` | Fabric type: `UALOE`, `UALLINK`, or `UNKNOWN`
 `bandwidth` | Station bandwidth share in Mb/s
@@ -6573,6 +6573,9 @@ Field | Description
 `station_flags` | DF/station flags
 `num_stations` | Number of stations
 `lane_en_bitmap` | Per-lane enable bitmap as a list of bytes
+`ppod_mask` | `amdsmi_fabric_ppod_field_t` bits actually read into the PPoD fields; a clear bit means that field holds its sentinel
+`vpod_mask` | `amdsmi_fabric_vpod_field_t` bits actually read into the vPoD fields
+`station_mask` | `amdsmi_fabric_df_field_t` bits actually read into the DF/station fields
 
 Exceptions that can be thrown by `amdsmi_get_gpu_fabric_info` function:
 

--- a/projects/amdsmi/example/amd_smi_fabric_example.cc
+++ b/projects/amdsmi/example/amd_smi_fabric_example.cc
@@ -68,6 +68,17 @@ std::string ppod_id_to_str(const std::uint8_t (&id)[MAX_UUID_ELEMENTS]) {
   return outstream.str();
 }
 
+std::string lane_bitmap_to_str(const std::uint8_t (&bitmap)[AMDSMI_FABRIC_MAX_BITMAP_SIZE]) {
+  std::ostringstream outstream{};
+  outstream << std::hex << std::setfill('0');
+  for (auto idx = std::size_t(0); idx < AMDSMI_FABRIC_MAX_BITMAP_SIZE; ++idx) {
+    outstream << std::setw(2) << static_cast<unsigned>(bitmap[idx]);
+  }
+  outstream << std::dec;
+
+  return outstream.str();
+}
+
 constexpr auto MAX_COLUMNS_PER_GRID = std::uint16_t(8);
 void print_array_grid(std::ostream& outstrm, std::string_view line_prefix,
                       std::string_view line_title, const uint32_t* array_data,
@@ -216,6 +227,7 @@ int main() {
 
       // Get the fabric info (partial sysfs reads; NO_DATA if no UALoE files had content)
       amdsmi_fabric_info_t fabric_info{};
+      fabric_info.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
       ret = amdsmi_get_gpu_fabric_info(processor_handles[device_index], &fabric_info);
       if (ret != AMDSMI_STATUS_SUCCESS && ret != AMDSMI_STATUS_NO_DATA &&
           ret != AMDSMI_STATUS_NOT_SUPPORTED) {
@@ -230,31 +242,49 @@ int main() {
                     << "\n";
           continue;
         }
+        if (fabric_info.fabric_version != AMDSMI_FABRIC_INFO_VERSION_2) {
+          // A library predating the nested layout filled the flat v1 member instead, so every
+          // field below would be read at the wrong offset
+          std::cout << "\t\t\tNote: library filled fabric info version "
+                    << fabric_info.fabric_version << ", not version 2." << "\n";
+          continue;
+        }
         std::cout << "\t\t\tFabric info data: " << "\n";
         std::cout << "\t\t\t\t** BDF: " << bdf_to_str(fabric_info.bdf) << "\n";
         std::cout << "\t\t\t\t** Fabric Version: " << fabric_info.fabric_version << "\n";
-        std::cout << "\t\t\t\t** Fabric Type: " << fabric_info.fabric_info.v1.fabric_type << "\n";
-        std::cout << "\t\t\t\t** Accelerator ID: " << fabric_info.fabric_info.v1.ppod.accelerator_id
+        std::cout << "\t\t\t\t** Fabric Type: " << fabric_info.fabric_info.v2.fabric_type << "\n";
+        std::cout << "\t\t\t\t** Accelerator ID: " << fabric_info.fabric_info.v2.ppod.accelerator_id
                   << "\n";
-        std::cout << "\t\t\t\t** Bandwidth: " << fabric_info.fabric_info.v1.ppod.bandwidth << "\n";
-        std::cout << "\t\t\t\t** Latency: " << fabric_info.fabric_info.v1.ppod.latency << "\n";
+        std::cout << "\t\t\t\t** Bandwidth: " << fabric_info.fabric_info.v2.ppod.bandwidth << "\n";
+        std::cout << "\t\t\t\t** Latency: " << fabric_info.fabric_info.v2.ppod.latency << "\n";
         std::cout << "\t\t\t\t** PPOD ID: "
-                  << ppod_id_to_str(fabric_info.fabric_info.v1.ppod.ppod_id) << "\n";
-        std::cout << "\t\t\t\t** PPOD Size: " << fabric_info.fabric_info.v1.ppod.ppod_size << "\n";
+                  << ppod_id_to_str(fabric_info.fabric_info.v2.ppod.ppod_id) << "\n";
+        std::cout << "\t\t\t\t** PPOD Size: " << fabric_info.fabric_info.v2.ppod.ppod_size << "\n";
         std::cout << "\t\t\t\t** Local Accelerator Count: "
-                  << fabric_info.fabric_info.v1.ppod.local_accelerator_count << "\n";
-        std::cout << "\t\t\t\t** VPOD ID: " << fabric_info.fabric_info.v1.vpod.vpod_id << "\n";
-        std::cout << "\t\t\t\t** VPOD Size: " << fabric_info.fabric_info.v1.vpod.vpod_size << "\n";
+                  << fabric_info.fabric_info.v2.ppod.local_accelerator_count << "\n";
+        std::cout << "\t\t\t\t** VPOD ID: " << fabric_info.fabric_info.v2.vpod.vpod_id << "\n";
+        std::cout << "\t\t\t\t** VPOD Size: " << fabric_info.fabric_info.v2.vpod.vpod_size << "\n";
         print_array_grid(std::cout, "\t\t\t\t", "VPOD Active Accelerators",
-                         fabric_info.fabric_info.v1.vpod.vpod_active_accelerators,
+                         fabric_info.fabric_info.v2.vpod.vpod_active_accelerators,
                          AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE, MAX_COLUMNS_PER_GRID);
         print_array_grid(std::cout, "\t\t\t\t", "Local Accelerators",
-                         fabric_info.fabric_info.v1.ppod.local_accelerators,
+                         fabric_info.fabric_info.v2.ppod.local_accelerators,
                          AMDSMI_FABRIC_MAX_LOCAL_GPUS, MAX_COLUMNS_PER_GRID);
-        std::cout << "\t\t\t\t** Address Mode: " << fabric_info.fabric_info.v1.vpod.addr_mode
+        std::cout << "\t\t\t\t** Address Mode: " << fabric_info.fabric_info.v2.vpod.addr_mode
                   << "\n";
-        std::cout << "\t\t\t\t** Accelerator State: " << fabric_info.fabric_info.v1.accel_state
+        std::cout << "\t\t\t\t** Accelerator State: " << fabric_info.fabric_info.v2.accel_state
                   << "\n";
+        std::cout << "\t\t\t\t** Station Flags: "
+                  << fabric_info.fabric_info.v2.station.station_flags << "\n";
+        std::cout << "\t\t\t\t** Number of Stations: "
+                  << static_cast<unsigned>(fabric_info.fabric_info.v2.station.num_stations) << "\n";
+        std::cout << "\t\t\t\t** Lane Enable Bitmap: "
+                  << lane_bitmap_to_str(fabric_info.fabric_info.v2.station.lane_en_bitmap) << "\n";
+        // A clear mask bit means the matching field was not read and holds its default value
+        std::cout << "\t\t\t\t** Read Masks (ppod/vpod/station): " << std::hex << "0x"
+                  << fabric_info.fabric_info.v2.ppod_mask << " 0x"
+                  << fabric_info.fabric_info.v2.vpod_mask << " 0x"
+                  << fabric_info.fabric_info.v2.station_mask << std::dec << "\n";
         std::cout << "\n";
       }
     }

--- a/projects/amdsmi/example/amd_smi_fabric_example.cc
+++ b/projects/amdsmi/example/amd_smi_fabric_example.cc
@@ -234,22 +234,25 @@ int main() {
         std::cout << "\t\t\t\t** BDF: " << bdf_to_str(fabric_info.bdf) << "\n";
         std::cout << "\t\t\t\t** Fabric Version: " << fabric_info.fabric_version << "\n";
         std::cout << "\t\t\t\t** Fabric Type: " << fabric_info.fabric_info.v1.fabric_type << "\n";
-        std::cout << "\t\t\t\t** Accelerator ID: " << fabric_info.fabric_info.v1.accelerator_id
+        std::cout << "\t\t\t\t** Accelerator ID: " << fabric_info.fabric_info.v1.ppod.accelerator_id
                   << "\n";
-        std::cout << "\t\t\t\t** Bandwidth: " << fabric_info.fabric_info.v1.bandwidth << "\n";
-        std::cout << "\t\t\t\t** Latency: " << fabric_info.fabric_info.v1.latency << "\n";
-        std::cout << "\t\t\t\t** PPOD ID: " << ppod_id_to_str(fabric_info.fabric_info.v1.ppod_id)
-                  << "\n";
-        std::cout << "\t\t\t\t** PPOD Size: " << fabric_info.fabric_info.v1.ppod_size << "\n";
-        std::cout << "\t\t\t\t** VPOD ID: " << fabric_info.fabric_info.v1.vpod_id << "\n";
-        std::cout << "\t\t\t\t** VPOD Size: " << fabric_info.fabric_info.v1.vpod_size << "\n";
+        std::cout << "\t\t\t\t** Bandwidth: " << fabric_info.fabric_info.v1.ppod.bandwidth << "\n";
+        std::cout << "\t\t\t\t** Latency: " << fabric_info.fabric_info.v1.ppod.latency << "\n";
+        std::cout << "\t\t\t\t** PPOD ID: "
+                  << ppod_id_to_str(fabric_info.fabric_info.v1.ppod.ppod_id) << "\n";
+        std::cout << "\t\t\t\t** PPOD Size: " << fabric_info.fabric_info.v1.ppod.ppod_size << "\n";
+        std::cout << "\t\t\t\t** Local Accelerator Count: "
+                  << fabric_info.fabric_info.v1.ppod.local_accelerator_count << "\n";
+        std::cout << "\t\t\t\t** VPOD ID: " << fabric_info.fabric_info.v1.vpod.vpod_id << "\n";
+        std::cout << "\t\t\t\t** VPOD Size: " << fabric_info.fabric_info.v1.vpod.vpod_size << "\n";
         print_array_grid(std::cout, "\t\t\t\t", "VPOD Active Accelerators",
-                         fabric_info.fabric_info.v1.vpod_active_accelerators,
+                         fabric_info.fabric_info.v1.vpod.vpod_active_accelerators,
                          AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE, MAX_COLUMNS_PER_GRID);
         print_array_grid(std::cout, "\t\t\t\t", "Local Accelerators",
-                         fabric_info.fabric_info.v1.local_accelerators,
+                         fabric_info.fabric_info.v1.ppod.local_accelerators,
                          AMDSMI_FABRIC_MAX_LOCAL_GPUS, MAX_COLUMNS_PER_GRID);
-        std::cout << "\t\t\t\t** Address Mode: " << fabric_info.fabric_info.v1.addr_mode << "\n";
+        std::cout << "\t\t\t\t** Address Mode: " << fabric_info.fabric_info.v1.vpod.addr_mode
+                  << "\n";
         std::cout << "\t\t\t\t** Accelerator State: " << fabric_info.fabric_info.v1.accel_state
                   << "\n";
         std::cout << "\n";

--- a/projects/amdsmi/example/amd_smi_fabric_example.cc
+++ b/projects/amdsmi/example/amd_smi_fabric_example.cc
@@ -87,6 +87,17 @@ std::string ppod_id_to_str(const std::uint8_t (&id)[MAX_UUID_ELEMENTS]) {
   return outstream.str();
 }
 
+std::string lane_bitmap_to_str(const std::uint8_t (&bitmap)[AMDSMI_FABRIC_MAX_BITMAP_SIZE]) {
+  std::ostringstream outstream{};
+  outstream << std::hex << std::setfill('0');
+  for (auto idx = std::size_t(0); idx < AMDSMI_FABRIC_MAX_BITMAP_SIZE; ++idx) {
+    outstream << std::setw(2) << static_cast<unsigned>(bitmap[idx]);
+  }
+  outstream << std::dec;
+
+  return outstream.str();
+}
+
 constexpr auto MAX_COLUMNS_PER_GRID = std::uint16_t(8);
 void print_array_grid(std::ostream& outstrm, std::string_view line_prefix,
                       std::string_view line_title, const uint32_t* array_data,
@@ -235,6 +246,7 @@ int main() {
 
       // Get the fabric info (partial sysfs reads; NO_DATA if no UALoE files had content)
       amdsmi_fabric_info_t fabric_info{};
+      fabric_info.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
       ret = amdsmi_get_gpu_fabric_info(processor_handles[device_index], &fabric_info);
       if (ret != AMDSMI_STATUS_SUCCESS && ret != AMDSMI_STATUS_NO_DATA &&
           ret != AMDSMI_STATUS_NOT_SUPPORTED) {
@@ -249,31 +261,49 @@ int main() {
                     << "\n";
           continue;
         }
+        if (fabric_info.fabric_version != AMDSMI_FABRIC_INFO_VERSION_2) {
+          // A library predating the nested layout filled the flat v1 member instead, so every
+          // field below would be read at the wrong offset
+          std::cout << "\t\t\tNote: library filled fabric info version "
+                    << fabric_info.fabric_version << ", not version 2." << "\n";
+          continue;
+        }
         std::cout << "\t\t\tFabric info data: " << "\n";
         std::cout << "\t\t\t\t** BDF: " << bdf_to_str(fabric_info.bdf) << "\n";
         std::cout << "\t\t\t\t** Fabric Version: " << fabric_info.fabric_version << "\n";
-        std::cout << "\t\t\t\t** Fabric Type: " << fabric_info.fabric_info.v1.fabric_type << "\n";
-        std::cout << "\t\t\t\t** Accelerator ID: " << fabric_info.fabric_info.v1.ppod.accelerator_id
+        std::cout << "\t\t\t\t** Fabric Type: " << fabric_info.fabric_info.v2.fabric_type << "\n";
+        std::cout << "\t\t\t\t** Accelerator ID: " << fabric_info.fabric_info.v2.ppod.accelerator_id
                   << "\n";
-        std::cout << "\t\t\t\t** Bandwidth: " << fabric_info.fabric_info.v1.ppod.bandwidth << "\n";
-        std::cout << "\t\t\t\t** Latency: " << fabric_info.fabric_info.v1.ppod.latency << "\n";
+        std::cout << "\t\t\t\t** Bandwidth: " << fabric_info.fabric_info.v2.ppod.bandwidth << "\n";
+        std::cout << "\t\t\t\t** Latency: " << fabric_info.fabric_info.v2.ppod.latency << "\n";
         std::cout << "\t\t\t\t** PPOD ID: "
-                  << ppod_id_to_str(fabric_info.fabric_info.v1.ppod.ppod_id) << "\n";
-        std::cout << "\t\t\t\t** PPOD Size: " << fabric_info.fabric_info.v1.ppod.ppod_size << "\n";
+                  << ppod_id_to_str(fabric_info.fabric_info.v2.ppod.ppod_id) << "\n";
+        std::cout << "\t\t\t\t** PPOD Size: " << fabric_info.fabric_info.v2.ppod.ppod_size << "\n";
         std::cout << "\t\t\t\t** Local Accelerator Count: "
-                  << fabric_info.fabric_info.v1.ppod.local_accelerator_count << "\n";
-        std::cout << "\t\t\t\t** VPOD ID: " << fabric_info.fabric_info.v1.vpod.vpod_id << "\n";
-        std::cout << "\t\t\t\t** VPOD Size: " << fabric_info.fabric_info.v1.vpod.vpod_size << "\n";
+                  << fabric_info.fabric_info.v2.ppod.local_accelerator_count << "\n";
+        std::cout << "\t\t\t\t** VPOD ID: " << fabric_info.fabric_info.v2.vpod.vpod_id << "\n";
+        std::cout << "\t\t\t\t** VPOD Size: " << fabric_info.fabric_info.v2.vpod.vpod_size << "\n";
         print_array_grid(std::cout, "\t\t\t\t", "VPOD Active Accelerators",
-                         fabric_info.fabric_info.v1.vpod.vpod_active_accelerators,
+                         fabric_info.fabric_info.v2.vpod.vpod_active_accelerators,
                          AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE, MAX_COLUMNS_PER_GRID);
         print_array_grid(std::cout, "\t\t\t\t", "Local Accelerators",
-                         fabric_info.fabric_info.v1.ppod.local_accelerators,
+                         fabric_info.fabric_info.v2.ppod.local_accelerators,
                          AMDSMI_FABRIC_MAX_LOCAL_GPUS, MAX_COLUMNS_PER_GRID);
-        std::cout << "\t\t\t\t** Address Mode: " << fabric_info.fabric_info.v1.vpod.addr_mode
+        std::cout << "\t\t\t\t** Address Mode: " << fabric_info.fabric_info.v2.vpod.addr_mode
                   << "\n";
-        std::cout << "\t\t\t\t** Accelerator State: " << fabric_info.fabric_info.v1.accel_state
+        std::cout << "\t\t\t\t** Accelerator State: " << fabric_info.fabric_info.v2.accel_state
                   << "\n";
+        std::cout << "\t\t\t\t** Station Flags: "
+                  << fabric_info.fabric_info.v2.station.station_flags << "\n";
+        std::cout << "\t\t\t\t** Number of Stations: "
+                  << static_cast<unsigned>(fabric_info.fabric_info.v2.station.num_stations) << "\n";
+        std::cout << "\t\t\t\t** Lane Enable Bitmap: "
+                  << lane_bitmap_to_str(fabric_info.fabric_info.v2.station.lane_en_bitmap) << "\n";
+        // A clear mask bit means the matching field was not read and holds its default value
+        std::cout << "\t\t\t\t** Read Masks (ppod/vpod/station): " << std::hex << "0x"
+                  << fabric_info.fabric_info.v2.ppod_mask << " 0x"
+                  << fabric_info.fabric_info.v2.vpod_mask << " 0x"
+                  << fabric_info.fabric_info.v2.station_mask << std::dec << "\n";
         std::cout << "\n";
       }
     }

--- a/projects/amdsmi/example/amd_smi_fabric_example.cc
+++ b/projects/amdsmi/example/amd_smi_fabric_example.cc
@@ -253,22 +253,25 @@ int main() {
         std::cout << "\t\t\t\t** BDF: " << bdf_to_str(fabric_info.bdf) << "\n";
         std::cout << "\t\t\t\t** Fabric Version: " << fabric_info.fabric_version << "\n";
         std::cout << "\t\t\t\t** Fabric Type: " << fabric_info.fabric_info.v1.fabric_type << "\n";
-        std::cout << "\t\t\t\t** Accelerator ID: " << fabric_info.fabric_info.v1.accelerator_id
+        std::cout << "\t\t\t\t** Accelerator ID: " << fabric_info.fabric_info.v1.ppod.accelerator_id
                   << "\n";
-        std::cout << "\t\t\t\t** Bandwidth: " << fabric_info.fabric_info.v1.bandwidth << "\n";
-        std::cout << "\t\t\t\t** Latency: " << fabric_info.fabric_info.v1.latency << "\n";
-        std::cout << "\t\t\t\t** PPOD ID: " << ppod_id_to_str(fabric_info.fabric_info.v1.ppod_id)
-                  << "\n";
-        std::cout << "\t\t\t\t** PPOD Size: " << fabric_info.fabric_info.v1.ppod_size << "\n";
-        std::cout << "\t\t\t\t** VPOD ID: " << fabric_info.fabric_info.v1.vpod_id << "\n";
-        std::cout << "\t\t\t\t** VPOD Size: " << fabric_info.fabric_info.v1.vpod_size << "\n";
+        std::cout << "\t\t\t\t** Bandwidth: " << fabric_info.fabric_info.v1.ppod.bandwidth << "\n";
+        std::cout << "\t\t\t\t** Latency: " << fabric_info.fabric_info.v1.ppod.latency << "\n";
+        std::cout << "\t\t\t\t** PPOD ID: "
+                  << ppod_id_to_str(fabric_info.fabric_info.v1.ppod.ppod_id) << "\n";
+        std::cout << "\t\t\t\t** PPOD Size: " << fabric_info.fabric_info.v1.ppod.ppod_size << "\n";
+        std::cout << "\t\t\t\t** Local Accelerator Count: "
+                  << fabric_info.fabric_info.v1.ppod.local_accelerator_count << "\n";
+        std::cout << "\t\t\t\t** VPOD ID: " << fabric_info.fabric_info.v1.vpod.vpod_id << "\n";
+        std::cout << "\t\t\t\t** VPOD Size: " << fabric_info.fabric_info.v1.vpod.vpod_size << "\n";
         print_array_grid(std::cout, "\t\t\t\t", "VPOD Active Accelerators",
-                         fabric_info.fabric_info.v1.vpod_active_accelerators,
+                         fabric_info.fabric_info.v1.vpod.vpod_active_accelerators,
                          AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE, MAX_COLUMNS_PER_GRID);
         print_array_grid(std::cout, "\t\t\t\t", "Local Accelerators",
-                         fabric_info.fabric_info.v1.local_accelerators,
+                         fabric_info.fabric_info.v1.ppod.local_accelerators,
                          AMDSMI_FABRIC_MAX_LOCAL_GPUS, MAX_COLUMNS_PER_GRID);
-        std::cout << "\t\t\t\t** Address Mode: " << fabric_info.fabric_info.v1.addr_mode << "\n";
+        std::cout << "\t\t\t\t** Address Mode: " << fabric_info.fabric_info.v1.vpod.addr_mode
+                  << "\n";
         std::cout << "\t\t\t\t** Accelerator State: " << fabric_info.fabric_info.v1.accel_state
                   << "\n";
         std::cout << "\n";

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -5820,7 +5820,8 @@ amdsmi_status_t amdsmi_free_fabric_telemetry(amdsmi_processor_handle processor_h
 typedef enum {
   AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE =
       32,  //!< Active accelerators bitmap size (32 x 32-bit words = 1024 bits)
-  AMDSMI_FABRIC_MAX_LOCAL_GPUS = 16  //!< Maximum local GPUs in fabric
+  AMDSMI_FABRIC_MAX_LOCAL_GPUS = 16,  //!< Maximum local GPUs in fabric
+  AMDSMI_FABRIC_MAX_BITMAP_SIZE = 64  //!< Maximum bitmap size (64 bytes = 512 bits)
 } amdsmi_fabric_size_constants_t;
 
 /**
@@ -5862,26 +5863,80 @@ typedef enum {
 } amdsmi_fabric_accelerator_vpod_state_t;
 
 /**
- * @brief Fabric device configuration information (version 1)
+ * @brief Physical PoD (PPOD) data payload
+ *
+ * @details Shared data members embedded in both ::amdsmi_fabric_ppod_config_t and
+ * ::amdsmi_fabric_info_v1_t
+ *
+ * Fields with no data present read back at a sentinel: numeric fields at their maximum
+ * representable value (ie: accelerator_id at 0xFFFFFFFF), and the ppod_id byte array at the
+ * guard byte 0x99
  *
  * @cond @tag{gpu_bm_linux} @tag{host} @endcond
  */
 typedef struct {
-  uint32_t accelerator_id;           //!< Accelerator identifier (range 0 to 1023)
-  amdsmi_fabric_type_t fabric_type;  //!< UALOE or UALINK
-  uint32_t bandwidth;                //!< Station bandwidth share in Mb/s
+  uint32_t accelerator_id;                    //!< Accelerator identifier (range 0 to 1023)
+  uint8_t ppod_id[AMDSMI_MAX_UUID_ELEMENTS];  //!< Physical PoD Identifier (16 bytes; not all-zero
+                                              //!< nor all-0x99)
+  uint32_t ppod_size;                         //!< Physical PoD size
+  uint32_t local_accelerators[AMDSMI_FABRIC_MAX_LOCAL_GPUS];  //!< Local Accelerator IDs
+  uint32_t local_accelerator_count;                           //!< Count of valid local accelerators
+  uint32_t bandwidth;                                         //!< Station bandwidth share in Mb/s
   uint32_t latency;  //!< Latency in nanoseconds (depends on switch presence and type)
-  uint8_t ppod_id[AMDSMI_MAX_UUID_ELEMENTS];  //!< Physical PoD Identifier (16 bytes)
+} amdsmi_fabric_ppod_data_t;
 
-  uint32_t ppod_size;  //!< Physical PoD size
-  uint32_t vpod_id;    //!< Virtual PoD Identifier
+/**
+ * @brief Virtual PoD (VPOD) data payload
+ *
+ * @details Shared data members embedded in both ::amdsmi_fabric_vpod_config_t and
+ * ::amdsmi_fabric_info_v1_t
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef struct {
+  uint32_t vpod_id;    //!< Virtual PoD Identifier (nonzero; 0 is not a valid pod ID)
   uint32_t vpod_size;  //!< Virtual PoD size
   uint32_t vpod_active_accelerators
-      [AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE];  //!< 1024-bit list (32 x 32-bit words): bit
-                                                        //!< N set = accelerator ID N is active
-  uint32_t local_accelerators[AMDSMI_FABRIC_MAX_LOCAL_GPUS];  //!< Local Accelerator IDs
-  amdsmi_fabric_npa_address_mode_t addr_mode;          //!< Source aliasing or identification mode
+      [AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE];  //!< Active accelerator IDs; unused slots
+                                                        //!< read UINT32_MAX (UNSET), as with
+                                                        //!< local_accelerators
+  amdsmi_fabric_npa_address_mode_t addr_mode;           //!< Source aliasing or identification mode
+} amdsmi_fabric_vpod_data_t;
+
+/**
+ * @brief DF/station data payload
+ *
+ * @details Shared data members embedded in both ::amdsmi_fabric_station_config_t and
+ * ::amdsmi_fabric_info_v1_t
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef struct {
+  uint32_t station_flags;                                 //!< DF/station flags
+  uint8_t num_stations;                                   //!< Number of stations
+  uint8_t lane_en_bitmap[AMDSMI_FABRIC_MAX_BITMAP_SIZE];  //!< Per-lane enable bitmap (64 bytes =
+                                                          //!< 512 bits); reads 0 (lanes disabled)
+                                                          //!< when absent
+} amdsmi_fabric_station_data_t;
+
+/**
+ * @brief Fabric device configuration information (version 1)
+ *
+ * @details Presence/configured-ness is conveyed by the top-level return of
+ * ::amdsmi_get_gpu_fabric_info (SUCCESS / NOT_SUPPORTED / NO_DATA / NOT_INIT) and
+ * by the accel_state field
+ *
+ * Fields with no data are left at their sentinel value, except lane_en_bitmap,
+ * which reads 0 (lanes disabled) when absent
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef struct {
+  amdsmi_fabric_type_t fabric_type;                    //!< UALOE or UALINK
   amdsmi_fabric_accelerator_vpod_state_t accel_state;  //!< Accelerator vPoD State
+  amdsmi_fabric_ppod_data_t ppod;                      //!< Physical PoD data (16 bytes)
+  amdsmi_fabric_vpod_data_t vpod;                      //!< Virtual PoD data
+  amdsmi_fabric_station_data_t station;                //!< DF/station data (64 bytes)
 } amdsmi_fabric_info_v1_t;
 
 /**
@@ -5905,31 +5960,181 @@ typedef struct {
  *
  *  @platform{gpu_bm_linux} @platform{host}
  *
- *  @details Reads optional UALoE fabric attributes from sysfs (one file per field).
- *  Missing or unreadable files are skipped so the call can return partial data:
- *    - any field that was not updated from sysfs keeps its sentinel value (ie:
- *      numeric fields at their maximum representable value, and unknown enumeration
- *      values where documented for ::amdsmi_fabric_info_v1_t).
- *    - The device BDF in @p info is always filled when the call completes successfully
- *      or returns ::AMDSMI_STATUS_NO_DATA.
+ *  @details Reads optional UALoE fabric attributes
+ *  Missing/unreadable files are skipped so the call can return partial data:
+ *      - any field that was not updated from sysfs keeps its sentinel value (ie:
+ *      numeric fields at their maximum representable value, the ppod_id byte array at
+ *      the guard byte 0x99, and unknown enumeration values where documented for
+ *      ::amdsmi_fabric_info_v1_t)
+ *      - The device BDF in @p info is always filled when the call completes
+ *      successfully or returns ::AMDSMI_STATUS_NO_DATA
  *
  *  @param[in] processor_handle - Handle for the target processor
  *
- *  @param[out] info - Pointer to Fabric information structure to be populated.
+ *  @param[out] info - Pointer to Fabric information structure to be populated
  *  Must be allocated by the caller. Written on every return except errors such
- *  as ::AMDSMI_STATUS_INVAL.
+ *  as ::AMDSMI_STATUS_INVAL
  *
  *  @return ::amdsmi_status_t
- *  - ::AMDSMI_STATUS_SUCCESS if at least one sysfs file yielded usable content.
- *  - ::AMDSMI_STATUS_NO_DATA if no sysfs file yielded usable lines (output still
- *    contains BDF and default/sentinel fabric fields).
- *  - Other codes (e.g. invalid processor handle) on failure.
+ *  - ::AMDSMI_STATUS_SUCCESS if at least one attribute yielded usable content
+ *  - ::AMDSMI_STATUS_NO_DATA if no attribute yielded usable data (output still
+ *    contains BDF and default/sentinel fabric fields)
+ *  - ::AMDSMI_STATUS_NOT_INIT if the fabric read succeeded but the accelerator
+ *    state is unconfigured or unknown. Despite the name, this is data-bearing and
+ *    not a failure: @p info is populated and its accel_state field reports the
+ *    unconfigured state. Callers reading fabric data should treat this like
+ *    ::AMDSMI_STATUS_SUCCESS
+ *  - Other codes (e.g. ::AMDSMI_STATUS_INVAL for an invalid processor handle) on
+ *    failure
  *
- *  @note This path reads sysfs only. It does not require UALoE netlink
- *  (::ualoe_open) to succeed; that handle is still needed for fabric telemetry APIs.
  */
 amdsmi_status_t amdsmi_get_gpu_fabric_info(amdsmi_processor_handle processor_handle,
                                            amdsmi_fabric_info_t* info);
+
+/**
+ * @brief UALink fabric configuration struct versions
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef enum {
+  AMDSMI_FABRIC_PPOD_CONFIG_V1 = 1,
+  AMDSMI_FABRIC_VPOD_CONFIG_V1 = 1,
+  AMDSMI_FABRIC_STATION_CONFIG_V1 = 1
+} amdsmi_fabric_config_version_t;
+
+/**
+ * @brief PPOD config field mask bits (::amdsmi_fabric_ppod_config_t::mask)
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef enum {
+  AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID = (1u << 0),
+  AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID = (1u << 1),
+  AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE = (1u << 2),
+  AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS = (1u << 3),
+  AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH = (1u << 4),
+  AMDSMI_FABRIC_PPOD_FIELD_LATENCY = (1u << 5)
+} amdsmi_fabric_ppod_field_t;
+
+/**
+ * @brief VPOD config field mask bits (::amdsmi_fabric_vpod_config_t::mask)
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef enum {
+  AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID = (1u << 0),
+  AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE = (1u << 1),
+  AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS = (1u << 2),
+  AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE = (1u << 3)
+} amdsmi_fabric_vpod_field_t;
+
+/**
+ * @brief DF/station config field mask bits (::amdsmi_fabric_station_config_t::mask)
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef enum {
+  AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS = (1u << 0),
+  AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP = (1u << 1),
+  AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS = (1u << 2)
+} amdsmi_fabric_df_field_t;
+
+/**
+ * @brief PPOD setup request
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef struct {
+  uint32_t version;  //!< Must be ::AMDSMI_FABRIC_PPOD_CONFIG_V1
+  uint32_t mask;     //!< ::AMDSMI_FABRIC_PPOD_FIELD_* bits for parameters to write (32 bits)
+  bool commit;       //!< When true, write setup/commit after masked parameters
+  amdsmi_fabric_ppod_data_t data;  //!< PPOD data payload
+} amdsmi_fabric_ppod_config_t;
+
+/**
+ * @brief VPOD configuration request
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef struct {
+  uint32_t version;  //!< Must be ::AMDSMI_FABRIC_VPOD_CONFIG_V1
+  uint32_t mask;
+  bool commit;
+  amdsmi_fabric_vpod_data_t data;  //!< VPOD data payload
+} amdsmi_fabric_vpod_config_t;
+
+/**
+ * @brief DF/Station reconfiguration request
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef struct {
+  uint32_t version;  //!< Must be ::AMDSMI_FABRIC_STATION_CONFIG_V1
+  uint32_t mask;
+  bool commit;
+  amdsmi_fabric_station_data_t data;  //!< DF/station data payload
+} amdsmi_fabric_station_config_t;
+
+/**
+ *  @brief Apply PPOD configuration
+ *
+ *  @ingroup tagFabric
+ *
+ *  @platform{gpu_bm_linux} @platform{host}
+ *
+ *  @details Writes setup/accel_id, setup/ppod_id, setup/ppod_size, setup/local_accels,
+ *  setup/bandwidth, and setup/latency for each bit set in @p config->mask (fixed order),
+ *  then setup/commit when @p config->commit is true
+ *
+ *  @param[in] processor_handle Handle for the target GPU
+ *  @param[in] config Non-NULL request; @p config->mask and @p config->commit must not both be false
+ *
+ *  @return ::amdsmi_status_t
+ */
+amdsmi_status_t amdsmi_set_gpu_fabric_ppod_config(amdsmi_processor_handle processor_handle,
+                                                  const amdsmi_fabric_ppod_config_t* config);
+
+/**
+ *  @brief Apply VPOD configuration
+ *
+ *  @ingroup tagFabric
+ *
+ *  @platform{gpu_bm_linux} @platform{host}
+ *
+ *  @details Writes config/vpod_id, config/vpod_size, config/vpod_active_accels, and
+ *  config/addr_mode for each bit set in @p config->mask, then config/commit when
+ *  @p config->commit is true
+ *
+ *  @note vpod_active_accelerators has no count field: unused slots hold the UNSET
+ *  sentinel (UINT32_MAX). Serialization emits the leading run of IDs and stops at
+ *  the first UINT32_MAX. Fill unused slots with UINT32_MAX; 0 is a valid accelerator ID.
+ *
+ *  @param[in] processor_handle Handle for the target GPU
+ *  @param[in] config Non-NULL request
+ *
+ *  @return ::amdsmi_status_t
+ */
+amdsmi_status_t amdsmi_set_gpu_fabric_vpod_config(amdsmi_processor_handle processor_handle,
+                                                  const amdsmi_fabric_vpod_config_t* config);
+
+/**
+ *  @brief Apply DF/Station configuration
+ *
+ *  @ingroup tagFabric
+ *
+ *  @platform{gpu_bm_linux} @platform{host}
+ *
+ *  @details Writes stations/station_flags, stations/num_stations, and
+ *  stations/lane_en_bitmap for each bit set in @p config->mask, then
+ *  stations/commit when @p config->commit is true
+ *
+ *  @param[in] processor_handle Handle for the target GPU
+ *  @param[in] config Non-NULL request
+ *
+ *  @return ::amdsmi_status_t
+ */
+amdsmi_status_t amdsmi_set_gpu_fabric_station_config(amdsmi_processor_handle processor_handle,
+                                                     const amdsmi_fabric_station_config_t* config);
 
 /** @} End tagFabric */
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -5819,9 +5819,12 @@ amdsmi_status_t amdsmi_free_fabric_telemetry(amdsmi_processor_handle processor_h
  */
 typedef enum {
   AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE =
-      32,  //!< Active accelerators bitmap size (32 x 32-bit words = 1024 bits)
-  AMDSMI_FABRIC_MAX_LOCAL_GPUS = 16,  //!< Maximum local GPUs in fabric
-  AMDSMI_FABRIC_MAX_BITMAP_SIZE = 64  //!< Maximum bitmap size (64 bytes = 512 bits)
+      32,                              //!< Maximum active accelerator IDs reported per vPoD
+  AMDSMI_FABRIC_MAX_LOCAL_GPUS = 16,   //!< Maximum local GPUs in fabric
+  AMDSMI_FABRIC_MAX_BITMAP_SIZE = 64,  //!< Maximum bitmap size (64 bytes = 512 bits)
+  AMDSMI_FABRIC_INFO_V2_RESERVED_WORDS =
+      37  //!< Growth window in ::amdsmi_fabric_info_v2_t (148 bytes). New fields are carved
+          //!< from here so ::amdsmi_fabric_info_t never changes size again
 } amdsmi_fabric_size_constants_t;
 
 /**
@@ -5866,7 +5869,7 @@ typedef enum {
  * @brief Physical PoD (PPOD) data payload
  *
  * @details Shared data members embedded in both ::amdsmi_fabric_ppod_config_t and
- * ::amdsmi_fabric_info_v1_t
+ * ::amdsmi_fabric_info_v2_t
  *
  * Fields with no data present read back at a sentinel: numeric fields at their maximum
  * representable value (ie: accelerator_id at 0xFFFFFFFF), and the ppod_id byte array at the
@@ -5889,7 +5892,7 @@ typedef struct {
  * @brief Virtual PoD (VPOD) data payload
  *
  * @details Shared data members embedded in both ::amdsmi_fabric_vpod_config_t and
- * ::amdsmi_fabric_info_v1_t
+ * ::amdsmi_fabric_info_v2_t
  *
  * @cond @tag{gpu_bm_linux} @tag{host} @endcond
  */
@@ -5899,7 +5902,9 @@ typedef struct {
   uint32_t vpod_active_accelerators
       [AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE];  //!< Active accelerator IDs; unused slots
                                                         //!< read UINT32_MAX (UNSET), as with
-                                                        //!< local_accelerators
+                                                        //!< local_accelerators. A longer list than
+                                                        //!< this array holds is reported as absent
+                                                        //!< rather than truncated
   amdsmi_fabric_npa_address_mode_t addr_mode;           //!< Source aliasing or identification mode
 } amdsmi_fabric_vpod_data_t;
 
@@ -5907,13 +5912,15 @@ typedef struct {
  * @brief DF/station data payload
  *
  * @details Shared data members embedded in both ::amdsmi_fabric_station_config_t and
- * ::amdsmi_fabric_info_v1_t
+ * ::amdsmi_fabric_info_v2_t
  *
  * @cond @tag{gpu_bm_linux} @tag{host} @endcond
  */
 typedef struct {
-  uint32_t station_flags;                                 //!< DF/station flags
-  uint8_t num_stations;                                   //!< Number of stations
+  uint32_t station_flags;  //!< DF/station flags
+  uint8_t num_stations;    //!< Number of stations (0 to 255). The driver reports this count in 32
+                           //!< bits (ualoe_lib.h, up to 1016 stations); a larger value is reported
+                           //!< as absent rather than truncated
   uint8_t lane_en_bitmap[AMDSMI_FABRIC_MAX_BITMAP_SIZE];  //!< Per-lane enable bitmap (64 bytes =
                                                           //!< 512 bits); reads 0 (lanes disabled)
                                                           //!< when absent
@@ -5922,9 +5929,46 @@ typedef struct {
 /**
  * @brief Fabric device configuration information (version 1)
  *
- * @details Presence/configured-ness is conveyed by the top-level return of
- * ::amdsmi_get_gpu_fabric_info (SUCCESS / NOT_SUPPORTED / NO_DATA / NOT_INIT) and
- * by the accel_state field
+ * @details Flat layout. Frozen: the field order and offsets below are relied on by
+ * binaries already linked against this library and must never change
+ *
+ * Presence/configured-ness is conveyed by the top-level return of
+ * ::amdsmi_get_gpu_fabric_info (SUCCESS / NOT_SUPPORTED / NO_DATA) and by the
+ * accel_state field
+ *
+ * Fields with no data are left at their sentinel value
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef struct {
+  uint32_t accelerator_id;           //!< Accelerator identifier (range 0 to 1023)
+  amdsmi_fabric_type_t fabric_type;  //!< UALOE or UALINK
+  uint32_t bandwidth;                //!< Station bandwidth share in Mb/s
+  uint32_t latency;  //!< Latency in nanoseconds (depends on switch presence and type)
+  uint8_t ppod_id[AMDSMI_MAX_UUID_ELEMENTS];  //!< Physical PoD Identifier (16 bytes)
+
+  uint32_t ppod_size;  //!< Physical PoD size
+  uint32_t vpod_id;    //!< Virtual PoD Identifier
+  uint32_t vpod_size;  //!< Virtual PoD size
+  uint32_t vpod_active_accelerators
+      [AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE];  //!< Active accelerator IDs; unused slots
+                                                        //!< read UINT32_MAX (UNSET), as with
+                                                        //!< local_accelerators
+  uint32_t local_accelerators[AMDSMI_FABRIC_MAX_LOCAL_GPUS];  //!< Local Accelerator IDs
+  amdsmi_fabric_npa_address_mode_t addr_mode;          //!< Source aliasing or identification mode
+  amdsmi_fabric_accelerator_vpod_state_t accel_state;  //!< Accelerator vPoD State
+} amdsmi_fabric_info_v1_t;
+
+/**
+ * @brief Fabric device configuration information (version 2)
+ *
+ * @details Groups the version 1 fields into the ppod/vpod/station payloads shared with
+ * ::amdsmi_set_gpu_fabric_ppod_config and friends, and adds the DF/station data that has
+ * no version 1 equivalent
+ *
+ * Presence/configured-ness is conveyed by the top-level return of
+ * ::amdsmi_get_gpu_fabric_info (SUCCESS / NOT_SUPPORTED / NO_DATA) and by the
+ * accel_state field
  *
  * Fields with no data are left at their sentinel value, except lane_en_bitmap,
  * which reads 0 (lanes disabled) when absent
@@ -5934,10 +5978,35 @@ typedef struct {
 typedef struct {
   amdsmi_fabric_type_t fabric_type;                    //!< UALOE or UALINK
   amdsmi_fabric_accelerator_vpod_state_t accel_state;  //!< Accelerator vPoD State
-  amdsmi_fabric_ppod_data_t ppod;                      //!< Physical PoD data (16 bytes)
+  amdsmi_fabric_ppod_data_t ppod;                      //!< Physical PoD data
   amdsmi_fabric_vpod_data_t vpod;                      //!< Virtual PoD data
-  amdsmi_fabric_station_data_t station;                //!< DF/station data (64 bytes)
-} amdsmi_fabric_info_v1_t;
+  amdsmi_fabric_station_data_t station;                //!< DF/station data
+  uint32_t ppod_mask;     //!< ::amdsmi_fabric_ppod_field_t bits actually read into @p ppod; a clear
+                          //!< bit means that field holds its sentinel
+  uint32_t vpod_mask;     //!< ::amdsmi_fabric_vpod_field_t bits actually read into @p vpod
+  uint32_t station_mask;  //!< ::amdsmi_fabric_df_field_t bits actually read into @p station
+  uint32_t reserved[AMDSMI_FABRIC_INFO_V2_RESERVED_WORDS];  //!< Reserved for future use. New
+                                                            //!< fields are carved from here rather
+                                                            //!< than added as a new version
+} amdsmi_fabric_info_v2_t;
+
+/**
+ * @brief Fabric device information layout selector
+ *
+ * @details Written to ::amdsmi_fabric_info_t::fabric_version before calling
+ * ::amdsmi_get_gpu_fabric_info to choose which union member is filled
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef enum {
+  AMDSMI_FABRIC_INFO_VERSION_1 = 0x00000000u,  //!< Flat layout. What zero-initialization yields,
+                                               //!< so it is the default for a caller that does not
+                                               //!< set the field
+  AMDSMI_FABRIC_INFO_VERSION_2 = 0xFAB10002u   //!< Nested layout. Deliberately high-entropy: an
+                                               //!< uninitialized fabric_version must not be able
+                                               //!< to select a member larger than the caller
+                                               //!< allocated
+} amdsmi_fabric_info_version_t;
 
 /**
  * @brief Fabric device information structure
@@ -5945,12 +6014,18 @@ typedef struct {
  * @cond @tag{gpu_bm_linux} @tag{host} @endcond
  */
 typedef struct {
-  amdsmi_bdf_t bdf;  //!< BDF (Bus, Device, Function) of the Fabric device
-  uint32_t fabric_version;
+  amdsmi_bdf_t bdf;         //!< BDF (Bus, Device, Function) of the Fabric device
+  uint32_t fabric_version;  //!< IN: ::amdsmi_fabric_info_version_t selecting the union member to
+                            //!< fill. Any value other than ::AMDSMI_FABRIC_INFO_VERSION_2 selects
+                            //!< v1. OUT: the member actually filled
   union fabric_info_ {
-    amdsmi_fabric_info_v1_t v1;
+    amdsmi_fabric_info_v1_t v1;  //!< Filled when fabric_version is not
+                                 //!< ::AMDSMI_FABRIC_INFO_VERSION_2
+    amdsmi_fabric_info_v2_t v2;  //!< Filled when fabric_version is
+                                 //!< ::AMDSMI_FABRIC_INFO_VERSION_2
   } fabric_info;
-  uint32_t reserved[15];  //!< Reserved for future use
+  uint32_t reserved[15];  //!< Reserved for future use. Not written by
+                          //!< ::amdsmi_get_gpu_fabric_info
 } amdsmi_fabric_info_t;
 
 /**
@@ -5965,27 +6040,40 @@ typedef struct {
  *      - any field that was not updated from sysfs keeps its sentinel value (ie:
  *      numeric fields at their maximum representable value, the ppod_id byte array at
  *      the guard byte 0x99, and unknown enumeration values where documented for
- *      ::amdsmi_fabric_info_v1_t)
+ *      ::amdsmi_fabric_info_v1_t and ::amdsmi_fabric_info_v2_t)
  *      - The device BDF in @p info is always filled when the call completes
  *      successfully or returns ::AMDSMI_STATUS_NO_DATA
  *
+ *  Request the nested layout, which is the only one carrying the DF/station fields:
+ *  @code
+ *    amdsmi_fabric_info_t info = {0};  // C++: amdsmi_fabric_info_t info = {};
+ *    info.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
+ *    amdsmi_get_gpu_fabric_info(handle, &info);
+ *  @endcode
+ *
  *  @param[in] processor_handle - Handle for the target processor
  *
- *  @param[out] info - Pointer to Fabric information structure to be populated
+ *  @param[in,out] info - Pointer to Fabric information structure to be populated
  *  Must be allocated by the caller. Written on every return except errors such
  *  as ::AMDSMI_STATUS_INVAL
+ *
+ *  On input, @p info->fabric_version selects the union member to fill. Any value other
+ *  than ::AMDSMI_FABRIC_INFO_VERSION_2 selects ::amdsmi_fabric_info_v1_t, so a
+ *  zero-initialized structure and one left uninitialized both yield the flat layout and
+ *  no byte past the v1 member is written. An unrecognized value is not an error
+ *
+ *  On output, @p info->fabric_version reports the member filled. The reserved trailing
+ *  words of @p info are never written
  *
  *  @return ::amdsmi_status_t
  *  - ::AMDSMI_STATUS_SUCCESS if at least one attribute yielded usable content
  *  - ::AMDSMI_STATUS_NO_DATA if no attribute yielded usable data (output still
  *    contains BDF and default/sentinel fabric fields)
- *  - ::AMDSMI_STATUS_NOT_INIT if the fabric read succeeded but the accelerator
- *    state is unconfigured or unknown. Despite the name, this is data-bearing and
- *    not a failure: @p info is populated and its accel_state field reports the
- *    unconfigured state. Callers reading fabric data should treat this like
- *    ::AMDSMI_STATUS_SUCCESS
  *  - Other codes (e.g. ::AMDSMI_STATUS_INVAL for an invalid processor handle) on
  *    failure
+ *
+ *  An unconfigured accelerator is not an error: the read returns
+ *  ::AMDSMI_STATUS_SUCCESS and the accel_state field reports the unconfigured state
  *
  */
 amdsmi_status_t amdsmi_get_gpu_fabric_info(amdsmi_processor_handle processor_handle,
@@ -6047,7 +6135,8 @@ typedef enum {
 typedef struct {
   uint32_t version;  //!< Must be ::AMDSMI_FABRIC_PPOD_CONFIG_V1
   uint32_t mask;     //!< ::AMDSMI_FABRIC_PPOD_FIELD_* bits for parameters to write (32 bits)
-  bool commit;       //!< When true, write setup/commit after masked parameters
+  bool commit;       //!< When true, write the masked parameters then setup/commit; when false,
+                     //!< validate the request and write nothing
   amdsmi_fabric_ppod_data_t data;  //!< PPOD data payload
 } amdsmi_fabric_ppod_config_t;
 
@@ -6082,12 +6171,18 @@ typedef struct {
  *
  *  @platform{gpu_bm_linux} @platform{host}
  *
- *  @details Writes setup/accel_id, setup/ppod_id, setup/ppod_size, setup/local_accels,
- *  setup/bandwidth, and setup/latency for each bit set in @p config->mask (fixed order),
- *  then setup/commit when @p config->commit is true
+ *  @details When @p config->commit is true, writes setup/accel_id, setup/ppod_id, setup/ppod_size,
+ *  setup/local_accels, setup/bandwidth, and setup/latency for each bit set in @p config->mask
+ *  (fixed order), then setup/commit. When false, the request is validated and nothing is written:
+ *  the driver ignores the staging files unless a commit follows
+ *
+ *  @note Masked fields are written one sysfs file at a time. A failure part way through leaves the
+ *  earlier fields staged, and a commit applies everything staged rather than only what its own mask
+ *  named, so a later unrelated commit will pick up that residue. There is no discard primitive:
+ *  re-issue the full field set before committing again
  *
  *  @param[in] processor_handle Handle for the target GPU
- *  @param[in] config Non-NULL request; @p config->mask and @p config->commit must not both be false
+ *  @param[in] config Non-NULL request; @p config->mask must select at least one field
  *
  *  @return ::amdsmi_status_t
  */
@@ -6101,16 +6196,22 @@ amdsmi_status_t amdsmi_set_gpu_fabric_ppod_config(amdsmi_processor_handle proces
  *
  *  @platform{gpu_bm_linux} @platform{host}
  *
- *  @details Writes config/vpod_id, config/vpod_size, config/vpod_active_accels, and
- *  config/addr_mode for each bit set in @p config->mask, then config/commit when
- *  @p config->commit is true
+ *  @details When @p config->commit is true, writes config/vpod_id, config/vpod_size,
+ *  config/vpod_active_accels, and config/addr_mode for each bit set in @p config->mask, then
+ *  config/commit. When false, the request is validated and nothing is written: the driver
+ *  ignores the staging files unless a commit follows
  *
  *  @note vpod_active_accelerators has no count field: unused slots hold the UNSET
  *  sentinel (UINT32_MAX). Serialization emits the leading run of IDs and stops at
  *  the first UINT32_MAX. Fill unused slots with UINT32_MAX; 0 is a valid accelerator ID.
  *
+ *  @note Masked fields are written one sysfs file at a time. A failure part way through leaves the
+ *  earlier fields staged, and a commit applies everything staged rather than only what its own mask
+ *  named, so a later unrelated commit will pick up that residue. There is no discard primitive:
+ *  re-issue the full field set before committing again
+ *
  *  @param[in] processor_handle Handle for the target GPU
- *  @param[in] config Non-NULL request
+ *  @param[in] config Non-NULL request; @p config->mask must select at least one field
  *
  *  @return ::amdsmi_status_t
  */
@@ -6124,12 +6225,18 @@ amdsmi_status_t amdsmi_set_gpu_fabric_vpod_config(amdsmi_processor_handle proces
  *
  *  @platform{gpu_bm_linux} @platform{host}
  *
- *  @details Writes stations/station_flags, stations/num_stations, and
- *  stations/lane_en_bitmap for each bit set in @p config->mask, then
- *  stations/commit when @p config->commit is true
+ *  @details When @p config->commit is true, writes stations/station_flags, stations/num_stations,
+ *  and stations/lane_en_bitmap for each bit set in @p config->mask, then stations/commit. When
+ *  false, the request is validated and nothing is written: the driver ignores the staging files
+ *  unless a commit follows
+ *
+ *  @note Masked fields are written one sysfs file at a time. A failure part way through leaves the
+ *  earlier fields staged, and a commit applies everything staged rather than only what its own mask
+ *  named, so a later unrelated commit will pick up that residue. There is no discard primitive:
+ *  re-issue the full field set before committing again
  *
  *  @param[in] processor_handle Handle for the target GPU
- *  @param[in] config Non-NULL request
+ *  @param[in] config Non-NULL request; @p config->mask must select at least one field
  *
  *  @return ::amdsmi_status_t
  */

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -5779,9 +5779,12 @@ amdsmi_status_t amdsmi_free_fabric_telemetry(amdsmi_processor_handle processor_h
  */
 typedef enum {
   AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE =
-      32,  //!< Active accelerators bitmap size (32 x 32-bit words = 1024 bits)
-  AMDSMI_FABRIC_MAX_LOCAL_GPUS = 16,  //!< Maximum local GPUs in fabric
-  AMDSMI_FABRIC_MAX_BITMAP_SIZE = 64  //!< Maximum bitmap size (64 bytes = 512 bits)
+      32,                              //!< Maximum active accelerator IDs reported per vPoD
+  AMDSMI_FABRIC_MAX_LOCAL_GPUS = 16,   //!< Maximum local GPUs in fabric
+  AMDSMI_FABRIC_MAX_BITMAP_SIZE = 64,  //!< Maximum bitmap size (64 bytes = 512 bits)
+  AMDSMI_FABRIC_INFO_V2_RESERVED_WORDS =
+      37  //!< Growth window in ::amdsmi_fabric_info_v2_t (148 bytes). New fields are carved
+          //!< from here so ::amdsmi_fabric_info_t never changes size again
 } amdsmi_fabric_size_constants_t;
 
 /**
@@ -5826,7 +5829,7 @@ typedef enum {
  * @brief Physical PoD (PPOD) data payload
  *
  * @details Shared data members embedded in both ::amdsmi_fabric_ppod_config_t and
- * ::amdsmi_fabric_info_v1_t
+ * ::amdsmi_fabric_info_v2_t
  *
  * Fields with no data present read back at a sentinel: numeric fields at their maximum
  * representable value (ie: accelerator_id at 0xFFFFFFFF), and the ppod_id byte array at the
@@ -5849,7 +5852,7 @@ typedef struct {
  * @brief Virtual PoD (VPOD) data payload
  *
  * @details Shared data members embedded in both ::amdsmi_fabric_vpod_config_t and
- * ::amdsmi_fabric_info_v1_t
+ * ::amdsmi_fabric_info_v2_t
  *
  * @cond @tag{gpu_bm_linux} @tag{host} @endcond
  */
@@ -5859,7 +5862,9 @@ typedef struct {
   uint32_t vpod_active_accelerators
       [AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE];  //!< Active accelerator IDs; unused slots
                                                         //!< read UINT32_MAX (UNSET), as with
-                                                        //!< local_accelerators
+                                                        //!< local_accelerators. A longer list than
+                                                        //!< this array holds is reported as absent
+                                                        //!< rather than truncated
   amdsmi_fabric_npa_address_mode_t addr_mode;           //!< Source aliasing or identification mode
 } amdsmi_fabric_vpod_data_t;
 
@@ -5867,13 +5872,15 @@ typedef struct {
  * @brief DF/station data payload
  *
  * @details Shared data members embedded in both ::amdsmi_fabric_station_config_t and
- * ::amdsmi_fabric_info_v1_t
+ * ::amdsmi_fabric_info_v2_t
  *
  * @cond @tag{gpu_bm_linux} @tag{host} @endcond
  */
 typedef struct {
-  uint32_t station_flags;                                 //!< DF/station flags
-  uint8_t num_stations;                                   //!< Number of stations
+  uint32_t station_flags;  //!< DF/station flags
+  uint8_t num_stations;    //!< Number of stations (0 to 255). The driver reports this count in 32
+                           //!< bits (ualoe_lib.h, up to 1016 stations); a larger value is reported
+                           //!< as absent rather than truncated
   uint8_t lane_en_bitmap[AMDSMI_FABRIC_MAX_BITMAP_SIZE];  //!< Per-lane enable bitmap (64 bytes =
                                                           //!< 512 bits); reads 0 (lanes disabled)
                                                           //!< when absent
@@ -5882,9 +5889,46 @@ typedef struct {
 /**
  * @brief Fabric device configuration information (version 1)
  *
- * @details Presence/configured-ness is conveyed by the top-level return of
- * ::amdsmi_get_gpu_fabric_info (SUCCESS / NOT_SUPPORTED / NO_DATA / NOT_INIT) and
- * by the accel_state field
+ * @details Flat layout. Frozen: the field order and offsets below are relied on by
+ * binaries already linked against this library and must never change
+ *
+ * Presence/configured-ness is conveyed by the top-level return of
+ * ::amdsmi_get_gpu_fabric_info (SUCCESS / NOT_SUPPORTED / NO_DATA) and by the
+ * accel_state field
+ *
+ * Fields with no data are left at their sentinel value
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef struct {
+  uint32_t accelerator_id;           //!< Accelerator identifier (range 0 to 1023)
+  amdsmi_fabric_type_t fabric_type;  //!< UALOE or UALINK
+  uint32_t bandwidth;                //!< Station bandwidth share in Mb/s
+  uint32_t latency;  //!< Latency in nanoseconds (depends on switch presence and type)
+  uint8_t ppod_id[AMDSMI_MAX_UUID_ELEMENTS];  //!< Physical PoD Identifier (16 bytes)
+
+  uint32_t ppod_size;  //!< Physical PoD size
+  uint32_t vpod_id;    //!< Virtual PoD Identifier
+  uint32_t vpod_size;  //!< Virtual PoD size
+  uint32_t vpod_active_accelerators
+      [AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE];  //!< Active accelerator IDs; unused slots
+                                                        //!< read UINT32_MAX (UNSET), as with
+                                                        //!< local_accelerators
+  uint32_t local_accelerators[AMDSMI_FABRIC_MAX_LOCAL_GPUS];  //!< Local Accelerator IDs
+  amdsmi_fabric_npa_address_mode_t addr_mode;          //!< Source aliasing or identification mode
+  amdsmi_fabric_accelerator_vpod_state_t accel_state;  //!< Accelerator vPoD State
+} amdsmi_fabric_info_v1_t;
+
+/**
+ * @brief Fabric device configuration information (version 2)
+ *
+ * @details Groups the version 1 fields into the ppod/vpod/station payloads shared with
+ * ::amdsmi_set_gpu_fabric_ppod_config and friends, and adds the DF/station data that has
+ * no version 1 equivalent
+ *
+ * Presence/configured-ness is conveyed by the top-level return of
+ * ::amdsmi_get_gpu_fabric_info (SUCCESS / NOT_SUPPORTED / NO_DATA) and by the
+ * accel_state field
  *
  * Fields with no data are left at their sentinel value, except lane_en_bitmap,
  * which reads 0 (lanes disabled) when absent
@@ -5894,10 +5938,35 @@ typedef struct {
 typedef struct {
   amdsmi_fabric_type_t fabric_type;                    //!< UALOE or UALINK
   amdsmi_fabric_accelerator_vpod_state_t accel_state;  //!< Accelerator vPoD State
-  amdsmi_fabric_ppod_data_t ppod;                      //!< Physical PoD data (16 bytes)
+  amdsmi_fabric_ppod_data_t ppod;                      //!< Physical PoD data
   amdsmi_fabric_vpod_data_t vpod;                      //!< Virtual PoD data
-  amdsmi_fabric_station_data_t station;                //!< DF/station data (64 bytes)
-} amdsmi_fabric_info_v1_t;
+  amdsmi_fabric_station_data_t station;                //!< DF/station data
+  uint32_t ppod_mask;     //!< ::amdsmi_fabric_ppod_field_t bits actually read into @p ppod; a clear
+                          //!< bit means that field holds its sentinel
+  uint32_t vpod_mask;     //!< ::amdsmi_fabric_vpod_field_t bits actually read into @p vpod
+  uint32_t station_mask;  //!< ::amdsmi_fabric_df_field_t bits actually read into @p station
+  uint32_t reserved[AMDSMI_FABRIC_INFO_V2_RESERVED_WORDS];  //!< Reserved for future use. New
+                                                            //!< fields are carved from here rather
+                                                            //!< than added as a new version
+} amdsmi_fabric_info_v2_t;
+
+/**
+ * @brief Fabric device information layout selector
+ *
+ * @details Written to ::amdsmi_fabric_info_t::fabric_version before calling
+ * ::amdsmi_get_gpu_fabric_info to choose which union member is filled
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef enum {
+  AMDSMI_FABRIC_INFO_VERSION_1 = 0x00000000u,  //!< Flat layout. What zero-initialization yields,
+                                               //!< so it is the default for a caller that does not
+                                               //!< set the field
+  AMDSMI_FABRIC_INFO_VERSION_2 = 0xFAB10002u   //!< Nested layout. Deliberately high-entropy: an
+                                               //!< uninitialized fabric_version must not be able
+                                               //!< to select a member larger than the caller
+                                               //!< allocated
+} amdsmi_fabric_info_version_t;
 
 /**
  * @brief Fabric device information structure
@@ -5905,12 +5974,18 @@ typedef struct {
  * @cond @tag{gpu_bm_linux} @tag{host} @endcond
  */
 typedef struct {
-  amdsmi_bdf_t bdf;  //!< BDF (Bus, Device, Function) of the Fabric device
-  uint32_t fabric_version;
+  amdsmi_bdf_t bdf;         //!< BDF (Bus, Device, Function) of the Fabric device
+  uint32_t fabric_version;  //!< IN: ::amdsmi_fabric_info_version_t selecting the union member to
+                            //!< fill. Any value other than ::AMDSMI_FABRIC_INFO_VERSION_2 selects
+                            //!< v1. OUT: the member actually filled
   union fabric_info_ {
-    amdsmi_fabric_info_v1_t v1;
+    amdsmi_fabric_info_v1_t v1;  //!< Filled when fabric_version is not
+                                 //!< ::AMDSMI_FABRIC_INFO_VERSION_2
+    amdsmi_fabric_info_v2_t v2;  //!< Filled when fabric_version is
+                                 //!< ::AMDSMI_FABRIC_INFO_VERSION_2
   } fabric_info;
-  uint32_t reserved[15];  //!< Reserved for future use
+  uint32_t reserved[15];  //!< Reserved for future use. Not written by
+                          //!< ::amdsmi_get_gpu_fabric_info
 } amdsmi_fabric_info_t;
 
 /**
@@ -5925,27 +6000,40 @@ typedef struct {
  *      - any field that was not updated from sysfs keeps its sentinel value (ie:
  *      numeric fields at their maximum representable value, the ppod_id byte array at
  *      the guard byte 0x99, and unknown enumeration values where documented for
- *      ::amdsmi_fabric_info_v1_t)
+ *      ::amdsmi_fabric_info_v1_t and ::amdsmi_fabric_info_v2_t)
  *      - The device BDF in @p info is always filled when the call completes
  *      successfully or returns ::AMDSMI_STATUS_NO_DATA
  *
+ *  Request the nested layout, which is the only one carrying the DF/station fields:
+ *  @code
+ *    amdsmi_fabric_info_t info = {0};  // C++: amdsmi_fabric_info_t info = {};
+ *    info.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
+ *    amdsmi_get_gpu_fabric_info(handle, &info);
+ *  @endcode
+ *
  *  @param[in] processor_handle - Handle for the target processor
  *
- *  @param[out] info - Pointer to Fabric information structure to be populated
+ *  @param[in,out] info - Pointer to Fabric information structure to be populated
  *  Must be allocated by the caller. Written on every return except errors such
  *  as ::AMDSMI_STATUS_INVAL
+ *
+ *  On input, @p info->fabric_version selects the union member to fill. Any value other
+ *  than ::AMDSMI_FABRIC_INFO_VERSION_2 selects ::amdsmi_fabric_info_v1_t, so a
+ *  zero-initialized structure and one left uninitialized both yield the flat layout and
+ *  no byte past the v1 member is written. An unrecognized value is not an error
+ *
+ *  On output, @p info->fabric_version reports the member filled. The reserved trailing
+ *  words of @p info are never written
  *
  *  @return ::amdsmi_status_t
  *  - ::AMDSMI_STATUS_SUCCESS if at least one attribute yielded usable content
  *  - ::AMDSMI_STATUS_NO_DATA if no attribute yielded usable data (output still
  *    contains BDF and default/sentinel fabric fields)
- *  - ::AMDSMI_STATUS_NOT_INIT if the fabric read succeeded but the accelerator
- *    state is unconfigured or unknown. Despite the name, this is data-bearing and
- *    not a failure: @p info is populated and its accel_state field reports the
- *    unconfigured state. Callers reading fabric data should treat this like
- *    ::AMDSMI_STATUS_SUCCESS
  *  - Other codes (e.g. ::AMDSMI_STATUS_INVAL for an invalid processor handle) on
  *    failure
+ *
+ *  An unconfigured accelerator is not an error: the read returns
+ *  ::AMDSMI_STATUS_SUCCESS and the accel_state field reports the unconfigured state
  *
  */
 amdsmi_status_t amdsmi_get_gpu_fabric_info(amdsmi_processor_handle processor_handle,
@@ -6007,7 +6095,8 @@ typedef enum {
 typedef struct {
   uint32_t version;  //!< Must be ::AMDSMI_FABRIC_PPOD_CONFIG_V1
   uint32_t mask;     //!< ::AMDSMI_FABRIC_PPOD_FIELD_* bits for parameters to write (32 bits)
-  bool commit;       //!< When true, write setup/commit after masked parameters
+  bool commit;       //!< When true, write the masked parameters then setup/commit; when false,
+                     //!< validate the request and write nothing
   amdsmi_fabric_ppod_data_t data;  //!< PPOD data payload
 } amdsmi_fabric_ppod_config_t;
 
@@ -6042,12 +6131,18 @@ typedef struct {
  *
  *  @platform{gpu_bm_linux} @platform{host}
  *
- *  @details Writes setup/accel_id, setup/ppod_id, setup/ppod_size, setup/local_accels,
- *  setup/bandwidth, and setup/latency for each bit set in @p config->mask (fixed order),
- *  then setup/commit when @p config->commit is true
+ *  @details When @p config->commit is true, writes setup/accel_id, setup/ppod_id, setup/ppod_size,
+ *  setup/local_accels, setup/bandwidth, and setup/latency for each bit set in @p config->mask
+ *  (fixed order), then setup/commit. When false, the request is validated and nothing is written:
+ *  the driver ignores the staging files unless a commit follows
+ *
+ *  @note Masked fields are written one sysfs file at a time. A failure part way through leaves the
+ *  earlier fields staged, and a commit applies everything staged rather than only what its own mask
+ *  named, so a later unrelated commit will pick up that residue. There is no discard primitive:
+ *  re-issue the full field set before committing again
  *
  *  @param[in] processor_handle Handle for the target GPU
- *  @param[in] config Non-NULL request; @p config->mask and @p config->commit must not both be false
+ *  @param[in] config Non-NULL request; @p config->mask must select at least one field
  *
  *  @return ::amdsmi_status_t
  */
@@ -6061,16 +6156,22 @@ amdsmi_status_t amdsmi_set_gpu_fabric_ppod_config(amdsmi_processor_handle proces
  *
  *  @platform{gpu_bm_linux} @platform{host}
  *
- *  @details Writes config/vpod_id, config/vpod_size, config/vpod_active_accels, and
- *  config/addr_mode for each bit set in @p config->mask, then config/commit when
- *  @p config->commit is true
+ *  @details When @p config->commit is true, writes config/vpod_id, config/vpod_size,
+ *  config/vpod_active_accels, and config/addr_mode for each bit set in @p config->mask, then
+ *  config/commit. When false, the request is validated and nothing is written: the driver
+ *  ignores the staging files unless a commit follows
  *
  *  @note vpod_active_accelerators has no count field: unused slots hold the UNSET
  *  sentinel (UINT32_MAX). Serialization emits the leading run of IDs and stops at
  *  the first UINT32_MAX. Fill unused slots with UINT32_MAX; 0 is a valid accelerator ID.
  *
+ *  @note Masked fields are written one sysfs file at a time. A failure part way through leaves the
+ *  earlier fields staged, and a commit applies everything staged rather than only what its own mask
+ *  named, so a later unrelated commit will pick up that residue. There is no discard primitive:
+ *  re-issue the full field set before committing again
+ *
  *  @param[in] processor_handle Handle for the target GPU
- *  @param[in] config Non-NULL request
+ *  @param[in] config Non-NULL request; @p config->mask must select at least one field
  *
  *  @return ::amdsmi_status_t
  */
@@ -6084,12 +6185,18 @@ amdsmi_status_t amdsmi_set_gpu_fabric_vpod_config(amdsmi_processor_handle proces
  *
  *  @platform{gpu_bm_linux} @platform{host}
  *
- *  @details Writes stations/station_flags, stations/num_stations, and
- *  stations/lane_en_bitmap for each bit set in @p config->mask, then
- *  stations/commit when @p config->commit is true
+ *  @details When @p config->commit is true, writes stations/station_flags, stations/num_stations,
+ *  and stations/lane_en_bitmap for each bit set in @p config->mask, then stations/commit. When
+ *  false, the request is validated and nothing is written: the driver ignores the staging files
+ *  unless a commit follows
+ *
+ *  @note Masked fields are written one sysfs file at a time. A failure part way through leaves the
+ *  earlier fields staged, and a commit applies everything staged rather than only what its own mask
+ *  named, so a later unrelated commit will pick up that residue. There is no discard primitive:
+ *  re-issue the full field set before committing again
  *
  *  @param[in] processor_handle Handle for the target GPU
- *  @param[in] config Non-NULL request
+ *  @param[in] config Non-NULL request; @p config->mask must select at least one field
  *
  *  @return ::amdsmi_status_t
  */

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -5780,7 +5780,8 @@ amdsmi_status_t amdsmi_free_fabric_telemetry(amdsmi_processor_handle processor_h
 typedef enum {
   AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE =
       32,  //!< Active accelerators bitmap size (32 x 32-bit words = 1024 bits)
-  AMDSMI_FABRIC_MAX_LOCAL_GPUS = 16  //!< Maximum local GPUs in fabric
+  AMDSMI_FABRIC_MAX_LOCAL_GPUS = 16,  //!< Maximum local GPUs in fabric
+  AMDSMI_FABRIC_MAX_BITMAP_SIZE = 64  //!< Maximum bitmap size (64 bytes = 512 bits)
 } amdsmi_fabric_size_constants_t;
 
 /**
@@ -5822,26 +5823,80 @@ typedef enum {
 } amdsmi_fabric_accelerator_vpod_state_t;
 
 /**
- * @brief Fabric device configuration information (version 1)
+ * @brief Physical PoD (PPOD) data payload
+ *
+ * @details Shared data members embedded in both ::amdsmi_fabric_ppod_config_t and
+ * ::amdsmi_fabric_info_v1_t
+ *
+ * Fields with no data present read back at a sentinel: numeric fields at their maximum
+ * representable value (ie: accelerator_id at 0xFFFFFFFF), and the ppod_id byte array at the
+ * guard byte 0x99
  *
  * @cond @tag{gpu_bm_linux} @tag{host} @endcond
  */
 typedef struct {
-  uint32_t accelerator_id;           //!< Accelerator identifier (range 0 to 1023)
-  amdsmi_fabric_type_t fabric_type;  //!< UALOE or UALINK
-  uint32_t bandwidth;                //!< Station bandwidth share in Mb/s
+  uint32_t accelerator_id;                    //!< Accelerator identifier (range 0 to 1023)
+  uint8_t ppod_id[AMDSMI_MAX_UUID_ELEMENTS];  //!< Physical PoD Identifier (16 bytes; not all-zero
+                                              //!< nor all-0x99)
+  uint32_t ppod_size;                         //!< Physical PoD size
+  uint32_t local_accelerators[AMDSMI_FABRIC_MAX_LOCAL_GPUS];  //!< Local Accelerator IDs
+  uint32_t local_accelerator_count;                           //!< Count of valid local accelerators
+  uint32_t bandwidth;                                         //!< Station bandwidth share in Mb/s
   uint32_t latency;  //!< Latency in nanoseconds (depends on switch presence and type)
-  uint8_t ppod_id[AMDSMI_MAX_UUID_ELEMENTS];  //!< Physical PoD Identifier (16 bytes)
+} amdsmi_fabric_ppod_data_t;
 
-  uint32_t ppod_size;  //!< Physical PoD size
-  uint32_t vpod_id;    //!< Virtual PoD Identifier
+/**
+ * @brief Virtual PoD (VPOD) data payload
+ *
+ * @details Shared data members embedded in both ::amdsmi_fabric_vpod_config_t and
+ * ::amdsmi_fabric_info_v1_t
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef struct {
+  uint32_t vpod_id;    //!< Virtual PoD Identifier (nonzero; 0 is not a valid pod ID)
   uint32_t vpod_size;  //!< Virtual PoD size
   uint32_t vpod_active_accelerators
-      [AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE];  //!< 1024-bit list (32 x 32-bit words): bit
-                                                        //!< N set = accelerator ID N is active
-  uint32_t local_accelerators[AMDSMI_FABRIC_MAX_LOCAL_GPUS];  //!< Local Accelerator IDs
-  amdsmi_fabric_npa_address_mode_t addr_mode;          //!< Source aliasing or identification mode
+      [AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE];  //!< Active accelerator IDs; unused slots
+                                                        //!< read UINT32_MAX (UNSET), as with
+                                                        //!< local_accelerators
+  amdsmi_fabric_npa_address_mode_t addr_mode;           //!< Source aliasing or identification mode
+} amdsmi_fabric_vpod_data_t;
+
+/**
+ * @brief DF/station data payload
+ *
+ * @details Shared data members embedded in both ::amdsmi_fabric_station_config_t and
+ * ::amdsmi_fabric_info_v1_t
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef struct {
+  uint32_t station_flags;                                 //!< DF/station flags
+  uint8_t num_stations;                                   //!< Number of stations
+  uint8_t lane_en_bitmap[AMDSMI_FABRIC_MAX_BITMAP_SIZE];  //!< Per-lane enable bitmap (64 bytes =
+                                                          //!< 512 bits); reads 0 (lanes disabled)
+                                                          //!< when absent
+} amdsmi_fabric_station_data_t;
+
+/**
+ * @brief Fabric device configuration information (version 1)
+ *
+ * @details Presence/configured-ness is conveyed by the top-level return of
+ * ::amdsmi_get_gpu_fabric_info (SUCCESS / NOT_SUPPORTED / NO_DATA / NOT_INIT) and
+ * by the accel_state field
+ *
+ * Fields with no data are left at their sentinel value, except lane_en_bitmap,
+ * which reads 0 (lanes disabled) when absent
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef struct {
+  amdsmi_fabric_type_t fabric_type;                    //!< UALOE or UALINK
   amdsmi_fabric_accelerator_vpod_state_t accel_state;  //!< Accelerator vPoD State
+  amdsmi_fabric_ppod_data_t ppod;                      //!< Physical PoD data (16 bytes)
+  amdsmi_fabric_vpod_data_t vpod;                      //!< Virtual PoD data
+  amdsmi_fabric_station_data_t station;                //!< DF/station data (64 bytes)
 } amdsmi_fabric_info_v1_t;
 
 /**
@@ -5865,31 +5920,181 @@ typedef struct {
  *
  *  @platform{gpu_bm_linux} @platform{host}
  *
- *  @details Reads optional UALoE fabric attributes from sysfs (one file per field).
- *  Missing or unreadable files are skipped so the call can return partial data:
- *    - any field that was not updated from sysfs keeps its sentinel value (ie:
- *      numeric fields at their maximum representable value, and unknown enumeration
- *      values where documented for ::amdsmi_fabric_info_v1_t).
- *    - The device BDF in @p info is always filled when the call completes successfully
- *      or returns ::AMDSMI_STATUS_NO_DATA.
+ *  @details Reads optional UALoE fabric attributes
+ *  Missing/unreadable files are skipped so the call can return partial data:
+ *      - any field that was not updated from sysfs keeps its sentinel value (ie:
+ *      numeric fields at their maximum representable value, the ppod_id byte array at
+ *      the guard byte 0x99, and unknown enumeration values where documented for
+ *      ::amdsmi_fabric_info_v1_t)
+ *      - The device BDF in @p info is always filled when the call completes
+ *      successfully or returns ::AMDSMI_STATUS_NO_DATA
  *
  *  @param[in] processor_handle - Handle for the target processor
  *
- *  @param[out] info - Pointer to Fabric information structure to be populated.
+ *  @param[out] info - Pointer to Fabric information structure to be populated
  *  Must be allocated by the caller. Written on every return except errors such
- *  as ::AMDSMI_STATUS_INVAL.
+ *  as ::AMDSMI_STATUS_INVAL
  *
  *  @return ::amdsmi_status_t
- *  - ::AMDSMI_STATUS_SUCCESS if at least one sysfs file yielded usable content.
- *  - ::AMDSMI_STATUS_NO_DATA if no sysfs file yielded usable lines (output still
- *    contains BDF and default/sentinel fabric fields).
- *  - Other codes (e.g. invalid processor handle) on failure.
+ *  - ::AMDSMI_STATUS_SUCCESS if at least one attribute yielded usable content
+ *  - ::AMDSMI_STATUS_NO_DATA if no attribute yielded usable data (output still
+ *    contains BDF and default/sentinel fabric fields)
+ *  - ::AMDSMI_STATUS_NOT_INIT if the fabric read succeeded but the accelerator
+ *    state is unconfigured or unknown. Despite the name, this is data-bearing and
+ *    not a failure: @p info is populated and its accel_state field reports the
+ *    unconfigured state. Callers reading fabric data should treat this like
+ *    ::AMDSMI_STATUS_SUCCESS
+ *  - Other codes (e.g. ::AMDSMI_STATUS_INVAL for an invalid processor handle) on
+ *    failure
  *
- *  @note This path reads sysfs only. It does not require UALoE netlink
- *  (::ualoe_open) to succeed; that handle is still needed for fabric telemetry APIs.
  */
 amdsmi_status_t amdsmi_get_gpu_fabric_info(amdsmi_processor_handle processor_handle,
                                            amdsmi_fabric_info_t* info);
+
+/**
+ * @brief UALink fabric configuration struct versions
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef enum {
+  AMDSMI_FABRIC_PPOD_CONFIG_V1 = 1,
+  AMDSMI_FABRIC_VPOD_CONFIG_V1 = 1,
+  AMDSMI_FABRIC_STATION_CONFIG_V1 = 1
+} amdsmi_fabric_config_version_t;
+
+/**
+ * @brief PPOD config field mask bits (::amdsmi_fabric_ppod_config_t::mask)
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef enum {
+  AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID = (1u << 0),
+  AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID = (1u << 1),
+  AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE = (1u << 2),
+  AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS = (1u << 3),
+  AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH = (1u << 4),
+  AMDSMI_FABRIC_PPOD_FIELD_LATENCY = (1u << 5)
+} amdsmi_fabric_ppod_field_t;
+
+/**
+ * @brief VPOD config field mask bits (::amdsmi_fabric_vpod_config_t::mask)
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef enum {
+  AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID = (1u << 0),
+  AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE = (1u << 1),
+  AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS = (1u << 2),
+  AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE = (1u << 3)
+} amdsmi_fabric_vpod_field_t;
+
+/**
+ * @brief DF/station config field mask bits (::amdsmi_fabric_station_config_t::mask)
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef enum {
+  AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS = (1u << 0),
+  AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP = (1u << 1),
+  AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS = (1u << 2)
+} amdsmi_fabric_df_field_t;
+
+/**
+ * @brief PPOD setup request
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef struct {
+  uint32_t version;  //!< Must be ::AMDSMI_FABRIC_PPOD_CONFIG_V1
+  uint32_t mask;     //!< ::AMDSMI_FABRIC_PPOD_FIELD_* bits for parameters to write (32 bits)
+  bool commit;       //!< When true, write setup/commit after masked parameters
+  amdsmi_fabric_ppod_data_t data;  //!< PPOD data payload
+} amdsmi_fabric_ppod_config_t;
+
+/**
+ * @brief VPOD configuration request
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef struct {
+  uint32_t version;  //!< Must be ::AMDSMI_FABRIC_VPOD_CONFIG_V1
+  uint32_t mask;
+  bool commit;
+  amdsmi_fabric_vpod_data_t data;  //!< VPOD data payload
+} amdsmi_fabric_vpod_config_t;
+
+/**
+ * @brief DF/Station reconfiguration request
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef struct {
+  uint32_t version;  //!< Must be ::AMDSMI_FABRIC_STATION_CONFIG_V1
+  uint32_t mask;
+  bool commit;
+  amdsmi_fabric_station_data_t data;  //!< DF/station data payload
+} amdsmi_fabric_station_config_t;
+
+/**
+ *  @brief Apply PPOD configuration
+ *
+ *  @ingroup tagFabric
+ *
+ *  @platform{gpu_bm_linux} @platform{host}
+ *
+ *  @details Writes setup/accel_id, setup/ppod_id, setup/ppod_size, setup/local_accels,
+ *  setup/bandwidth, and setup/latency for each bit set in @p config->mask (fixed order),
+ *  then setup/commit when @p config->commit is true
+ *
+ *  @param[in] processor_handle Handle for the target GPU
+ *  @param[in] config Non-NULL request; @p config->mask and @p config->commit must not both be false
+ *
+ *  @return ::amdsmi_status_t
+ */
+amdsmi_status_t amdsmi_set_gpu_fabric_ppod_config(amdsmi_processor_handle processor_handle,
+                                                  const amdsmi_fabric_ppod_config_t* config);
+
+/**
+ *  @brief Apply VPOD configuration
+ *
+ *  @ingroup tagFabric
+ *
+ *  @platform{gpu_bm_linux} @platform{host}
+ *
+ *  @details Writes config/vpod_id, config/vpod_size, config/vpod_active_accels, and
+ *  config/addr_mode for each bit set in @p config->mask, then config/commit when
+ *  @p config->commit is true
+ *
+ *  @note vpod_active_accelerators has no count field: unused slots hold the UNSET
+ *  sentinel (UINT32_MAX). Serialization emits the leading run of IDs and stops at
+ *  the first UINT32_MAX. Fill unused slots with UINT32_MAX; 0 is a valid accelerator ID.
+ *
+ *  @param[in] processor_handle Handle for the target GPU
+ *  @param[in] config Non-NULL request
+ *
+ *  @return ::amdsmi_status_t
+ */
+amdsmi_status_t amdsmi_set_gpu_fabric_vpod_config(amdsmi_processor_handle processor_handle,
+                                                  const amdsmi_fabric_vpod_config_t* config);
+
+/**
+ *  @brief Apply DF/Station configuration
+ *
+ *  @ingroup tagFabric
+ *
+ *  @platform{gpu_bm_linux} @platform{host}
+ *
+ *  @details Writes stations/station_flags, stations/num_stations, and
+ *  stations/lane_en_bitmap for each bit set in @p config->mask, then
+ *  stations/commit when @p config->commit is true
+ *
+ *  @param[in] processor_handle Handle for the target GPU
+ *  @param[in] config Non-NULL request
+ *
+ *  @return ::amdsmi_status_t
+ */
+amdsmi_status_t amdsmi_set_gpu_fabric_station_config(amdsmi_processor_handle processor_handle,
+                                                     const amdsmi_fabric_station_config_t* config);
 
 /** @} End tagFabric */
 

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_fabric_ualink.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_fabric_ualink.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef AMD_SMI_INCLUDE_IMPL_AMD_SMI_FABRIC_UALINK_H_
+#define AMD_SMI_INCLUDE_IMPL_AMD_SMI_FABRIC_UALINK_H_
+
+#include <string>
+#include <string_view>
+
+#include "amd_smi/amdsmi.h"
+#include "amd_smi/impl/amd_smi_gpu_device.h"
+
+namespace amd::smi {
+
+namespace fabric_ualink {
+
+/**
+ *  Filesystem-seam cores for the fabric apply/query paths.
+ *
+ *  These take the resolved UALink @p ualink_root and a @p device_supports_ualink
+ *  flag instead of a live AMDSmiGPUDevice, so the sysfs serialize/parse round-trip
+ *  can be exercised against a temp directory without hardware. The device-taking
+ *  free functions in the .cc wrap these; commit-verify diagnostics live in those
+ *  wrappers, not here.
+ */
+auto apply_ppod_config_at(const std::string& ualink_root, bool device_supports_ualink,
+                          const amdsmi_fabric_ppod_config_t& config) -> amdsmi_status_t;
+auto apply_vpod_config_at(const std::string& ualink_root, bool device_supports_ualink,
+                          const amdsmi_fabric_vpod_config_t& config) -> amdsmi_status_t;
+auto apply_station_config_at(const std::string& ualink_root, bool device_supports_ualink,
+                             const amdsmi_fabric_station_config_t& config) -> amdsmi_status_t;
+
+auto query_ppod_config_at(const std::string& ualink_root, bool device_supports_ualink,
+                          amdsmi_fabric_ppod_config_t& config,
+                          std::string_view subdir = kUALOE_UALINK_SETUP_SUBDIR) -> amdsmi_status_t;
+auto query_vpod_config_at(const std::string& ualink_root, bool device_supports_ualink,
+                          amdsmi_fabric_vpod_config_t& config,
+                          std::string_view subdir = kUALOE_UALINK_CONFIG_SUBDIR) -> amdsmi_status_t;
+auto query_station_config_at(const std::string& ualink_root, bool device_supports_ualink,
+                             amdsmi_fabric_station_config_t& config,
+                             std::string_view subdir = kUALOE_UALINK_STATIONS_SUBDIR)
+    -> amdsmi_status_t;
+
+}  // namespace fabric_ualink
+
+}  // namespace amd::smi
+
+#endif  // AMD_SMI_INCLUDE_IMPL_AMD_SMI_FABRIC_UALINK_H_

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_fabric_ualink.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_fabric_ualink.h
@@ -1,24 +1,5 @@
-/*
- * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
 
 #ifndef AMD_SMI_INCLUDE_IMPL_AMD_SMI_FABRIC_UALINK_H_
 #define AMD_SMI_INCLUDE_IMPL_AMD_SMI_FABRIC_UALINK_H_

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_gpu_device.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_gpu_device.h
@@ -4,6 +4,7 @@
 #ifndef AMD_SMI_INCLUDE_IMPL_AMD_SMI_GPU_DEVICE_H_
 #define AMD_SMI_INCLUDE_IMPL_AMD_SMI_GPU_DEVICE_H_
 
+#include <cstdint>
 #include <map>
 #include <mutex>
 #include <set>
@@ -153,6 +154,8 @@ class AMDSmiGPUDevice : public AMDSmiProcessor {
   /**
    *    UALoE fabric sysfs:
    *        - partial reads (see amdsmi_get_gpu_fabric_info() for status info)
+   *        - fabric_info is in/out: its fabric_version on entry selects the layout written back,
+   *          and only the bytes belonging to that layout are touched
    */
   auto get_fabric_info_from_ualoe(
       amdsmi_fabric_info_t& fabric_info,
@@ -213,6 +216,25 @@ class AMDSmiGPUDevice : public AMDSmiProcessor {
    */
   auto get_ualink_directory_path() const -> std::string;
 };
+
+namespace gpu_device::details {
+
+/**
+ *  Project the version 2 payload onto the frozen version 1 layout
+ */
+auto flatten_v2_to_v1(const amdsmi_fabric_info_v2_t& source, amdsmi_fabric_info_v1_t& destination)
+    -> void;
+
+/**
+ *  Bounded write into caller memory: only the union member named by requested_version is
+ *  touched, so a caller that predates version 2 keeps its smaller allocation intact.
+ *  Declared here so the layout tests can exercise the bound without a live device
+ */
+auto publish_fabric_info(const amdsmi_bdf_t& fabric_bdf, const amdsmi_fabric_info_v2_t& source,
+                         std::uint32_t requested_version, amdsmi_fabric_info_t& destination)
+    -> void;
+
+}  // namespace gpu_device::details
 
 }  // namespace amd::smi
 

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_gpu_device.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_gpu_device.h
@@ -55,37 +55,35 @@ constexpr auto kUALOE_VPOD_ACTIVE_ACCELS = std::string_view("vpod_active_accels"
 constexpr auto kUALOE_LOCAL_ACCELS = std::string_view("local_accels");
 constexpr auto kUALOE_ADDR_MODE = std::string_view("addr_mode");
 constexpr auto kUALOE_ACCEL_STATE = std::string_view("accel_state");
-constexpr auto kUALOE_BDF_OFFSET = std::uint16_t(0x01);  // TODO: Example offset - TBD
+constexpr auto kUALOE_STATION_FLAGS = std::string_view("station_flags");
+constexpr auto kUALOE_NUM_STATIONS = std::string_view("num_stations");
+constexpr auto kUALOE_LANE_EN_BITMAP = std::string_view("lane_en_bitmap");
 
-enum class UALoeLinkInfo_t : std::uint16_t {
-  LINK_TYPE = 0,
-  ACCEL_ID,
-  BANDWIDTH,
-  LATENCY,
-  PPOD_ID,
-  PPOD_SIZE,
-  VPOD_ID,
-  VPOD_SIZE,
-  VPOD_ACTIVE_ACCELS,
-  LOCAL_ACCELS,
-  ADDR_MODE,
-  ACCEL_STATE,
-  ALL_LINK_INFO
-};
+constexpr auto kUALOE_UALINK_SETUP_SUBDIR = std::string_view("setup/");
+constexpr auto kUALOE_UALINK_CONFIG_SUBDIR = std::string_view("config/");
+constexpr auto kUALOE_UALINK_STATIONS_SUBDIR = std::string_view("stations/");
+constexpr auto kUALOE_UALINK_COMMIT_FILE = std::string_view("commit");
+
+/**
+ *  Flat surface: the legacy field files that live directly under the ualink root
+ *  (no write-subtree prefix). Reads here use the same field filenames as the
+ *  subtree readers, letting a caller diff flat vs setup/config/df to confirm a
+ *  commit propagated into the flat surface.
+ */
+constexpr auto kUALOE_UALINK_FLAT_SUBDIR = std::string_view("");
+
+enum class UALoeLinkInfo_t : std::uint16_t { LINK_TYPE = 0, ACCEL_STATE, ALL_LINK_INFO };
 
 using UALoeLinkInfoMap_t = std::map<UALoeLinkInfo_t, std::string_view>;
+
+/**
+ *  Flat surface owned by get_fabric_info_from_ualoe()
+ *      - fabric_type and accel_state only
+ *  The Ppod/Vpod/Station payloads are sourced authoritatively from their
+ *  respective subtrees via the 'query_fabric_*_config()' readers
+ */
 inline const auto UALoeLinkInfoMap = UALoeLinkInfoMap_t{
     {UALoeLinkInfo_t::LINK_TYPE, kUALOE_LINK_TYPE},
-    {UALoeLinkInfo_t::ACCEL_ID, kUALOE_ACCEL_ID},
-    {UALoeLinkInfo_t::BANDWIDTH, kUALOE_BANDWIDTH},
-    {UALoeLinkInfo_t::LATENCY, kUALOE_LATENCY},
-    {UALoeLinkInfo_t::PPOD_ID, kUALOE_PPOD_ID},
-    {UALoeLinkInfo_t::PPOD_SIZE, kUALOE_PPOD_SIZE},
-    {UALoeLinkInfo_t::VPOD_ID, kUALOE_VPOD_ID},
-    {UALoeLinkInfo_t::VPOD_SIZE, kUALOE_VPOD_SIZE},
-    {UALoeLinkInfo_t::VPOD_ACTIVE_ACCELS, kUALOE_VPOD_ACTIVE_ACCELS},
-    {UALoeLinkInfo_t::LOCAL_ACCELS, kUALOE_LOCAL_ACCELS},
-    {UALoeLinkInfo_t::ADDR_MODE, kUALOE_ADDR_MODE},
     {UALoeLinkInfo_t::ACCEL_STATE, kUALOE_ACCEL_STATE},
 };
 using UALoeLinkInfoType_t = std::underlying_type_t<UALoeLinkInfo_t>;
@@ -152,12 +150,37 @@ class AMDSmiGPUDevice : public AMDSmiProcessor {
   // initialization in an uninterruptible generic-netlink wait.
   ualoe_handle_t get_ualoe_handle();
 
-  /** UALoE fabric sysfs:
-   *    - partial reads; see amdsmi_get_gpu_fabric_info() for status info
+  /**
+   *    UALoE fabric sysfs:
+   *        - partial reads (see amdsmi_get_gpu_fabric_info() for status info)
    */
   auto get_fabric_info_from_ualoe(
       amdsmi_fabric_info_t& fabric_info,
       UALoeLinkInfo_t link_info_type = UALoeLinkInfo_t::ALL_LINK_INFO) const -> amdsmi_status_t;
+
+  auto apply_fabric_ppod_config(const amdsmi_fabric_ppod_config_t& config) const -> amdsmi_status_t;
+  auto apply_fabric_vpod_config(const amdsmi_fabric_vpod_config_t& config) const -> amdsmi_status_t;
+  auto apply_fabric_station_config(const amdsmi_fabric_station_config_t& config) const
+      -> amdsmi_status_t;
+
+  /**
+   *    UALoE fabric write-subtree readback (live, post-commit state):
+   *        - config.mask selects fields to read. On return it reports fields actually populated
+   *        - absent/empty masked fields keep a sentinel value and clear their readback bit
+   */
+  auto query_fabric_ppod_config(amdsmi_fabric_ppod_config_t& config) const -> amdsmi_status_t;
+  auto query_fabric_vpod_config(amdsmi_fabric_vpod_config_t& config) const -> amdsmi_status_t;
+  auto query_fabric_station_config(amdsmi_fabric_station_config_t& config) const -> amdsmi_status_t;
+
+  /**
+   *    UALoE fabric flat-surface readback (legacy files directly under the ualink
+   *    root). Same fields/semantics as the subtree readers above, but sourced from
+   *    the flat surface so callers can diff the two and confirm commit propagation.
+   */
+  auto query_fabric_ppod_config_flat(amdsmi_fabric_ppod_config_t& config) const -> amdsmi_status_t;
+  auto query_fabric_vpod_config_flat(amdsmi_fabric_vpod_config_t& config) const -> amdsmi_status_t;
+  auto query_fabric_station_config_flat(amdsmi_fabric_station_config_t& config) const
+      -> amdsmi_status_t;
 
   auto has_ifoe_related_bdf() const -> bool;
   auto get_ifoe_bdf_string() const -> std::string;
@@ -179,10 +202,16 @@ class AMDSmiGPUDevice : public AMDSmiProcessor {
   int32_t get_compute_process_list_impl(GPUComputeProcessList_t& compute_process_list,
                                         ComputeProcessListType_t list_type);
   void populate_ifoe_fabric_bdf_list();
+
   // UALoE — session is opened lazily on the first get_ualoe_handle() call
   void open_ualoe_session();
   ualoe_handle_t ualoe_handle_ = (-1);
   std::once_flag ualoe_open_once_;
+
+  /**
+   *  UALoE sysfs ualink root: /sys/class/drm/<gpu_path>/device/ualink
+   */
+  auto get_ualink_directory_path() const -> std::string;
 };
 
 }  // namespace amd::smi

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_gpu_device.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_gpu_device.h
@@ -74,37 +74,35 @@ constexpr auto kUALOE_VPOD_ACTIVE_ACCELS = std::string_view("vpod_active_accels"
 constexpr auto kUALOE_LOCAL_ACCELS = std::string_view("local_accels");
 constexpr auto kUALOE_ADDR_MODE = std::string_view("addr_mode");
 constexpr auto kUALOE_ACCEL_STATE = std::string_view("accel_state");
-constexpr auto kUALOE_BDF_OFFSET = std::uint16_t(0x01);  // TODO: Example offset - TBD
+constexpr auto kUALOE_STATION_FLAGS = std::string_view("station_flags");
+constexpr auto kUALOE_NUM_STATIONS = std::string_view("num_stations");
+constexpr auto kUALOE_LANE_EN_BITMAP = std::string_view("lane_en_bitmap");
 
-enum class UALoeLinkInfo_t : std::uint16_t {
-  LINK_TYPE = 0,
-  ACCEL_ID,
-  BANDWIDTH,
-  LATENCY,
-  PPOD_ID,
-  PPOD_SIZE,
-  VPOD_ID,
-  VPOD_SIZE,
-  VPOD_ACTIVE_ACCELS,
-  LOCAL_ACCELS,
-  ADDR_MODE,
-  ACCEL_STATE,
-  ALL_LINK_INFO
-};
+constexpr auto kUALOE_UALINK_SETUP_SUBDIR = std::string_view("setup/");
+constexpr auto kUALOE_UALINK_CONFIG_SUBDIR = std::string_view("config/");
+constexpr auto kUALOE_UALINK_STATIONS_SUBDIR = std::string_view("stations/");
+constexpr auto kUALOE_UALINK_COMMIT_FILE = std::string_view("commit");
+
+/**
+ *  Flat surface: the legacy field files that live directly under the ualink root
+ *  (no write-subtree prefix). Reads here use the same field filenames as the
+ *  subtree readers, letting a caller diff flat vs setup/config/df to confirm a
+ *  commit propagated into the flat surface.
+ */
+constexpr auto kUALOE_UALINK_FLAT_SUBDIR = std::string_view("");
+
+enum class UALoeLinkInfo_t : std::uint16_t { LINK_TYPE = 0, ACCEL_STATE, ALL_LINK_INFO };
 
 using UALoeLinkInfoMap_t = std::map<UALoeLinkInfo_t, std::string_view>;
+
+/**
+ *  Flat surface owned by get_fabric_info_from_ualoe()
+ *      - fabric_type and accel_state only
+ *  The Ppod/Vpod/Station payloads are sourced authoritatively from their
+ *  respective subtrees via the 'query_fabric_*_config()' readers
+ */
 inline const auto UALoeLinkInfoMap = UALoeLinkInfoMap_t{
     {UALoeLinkInfo_t::LINK_TYPE, kUALOE_LINK_TYPE},
-    {UALoeLinkInfo_t::ACCEL_ID, kUALOE_ACCEL_ID},
-    {UALoeLinkInfo_t::BANDWIDTH, kUALOE_BANDWIDTH},
-    {UALoeLinkInfo_t::LATENCY, kUALOE_LATENCY},
-    {UALoeLinkInfo_t::PPOD_ID, kUALOE_PPOD_ID},
-    {UALoeLinkInfo_t::PPOD_SIZE, kUALOE_PPOD_SIZE},
-    {UALoeLinkInfo_t::VPOD_ID, kUALOE_VPOD_ID},
-    {UALoeLinkInfo_t::VPOD_SIZE, kUALOE_VPOD_SIZE},
-    {UALoeLinkInfo_t::VPOD_ACTIVE_ACCELS, kUALOE_VPOD_ACTIVE_ACCELS},
-    {UALoeLinkInfo_t::LOCAL_ACCELS, kUALOE_LOCAL_ACCELS},
-    {UALoeLinkInfo_t::ADDR_MODE, kUALOE_ADDR_MODE},
     {UALoeLinkInfo_t::ACCEL_STATE, kUALOE_ACCEL_STATE},
 };
 using UALoeLinkInfoType_t = std::underlying_type_t<UALoeLinkInfo_t>;
@@ -168,12 +166,37 @@ class AMDSmiGPUDevice : public AMDSmiProcessor {
   // initialization in an uninterruptible generic-netlink wait.
   ualoe_handle_t get_ualoe_handle();
 
-  /** UALoE fabric sysfs:
-   *    - partial reads; see amdsmi_get_gpu_fabric_info() for status info
+  /**
+   *    UALoE fabric sysfs:
+   *        - partial reads (see amdsmi_get_gpu_fabric_info() for status info)
    */
   auto get_fabric_info_from_ualoe(
       amdsmi_fabric_info_t& fabric_info,
       UALoeLinkInfo_t link_info_type = UALoeLinkInfo_t::ALL_LINK_INFO) const -> amdsmi_status_t;
+
+  auto apply_fabric_ppod_config(const amdsmi_fabric_ppod_config_t& config) const -> amdsmi_status_t;
+  auto apply_fabric_vpod_config(const amdsmi_fabric_vpod_config_t& config) const -> amdsmi_status_t;
+  auto apply_fabric_station_config(const amdsmi_fabric_station_config_t& config) const
+      -> amdsmi_status_t;
+
+  /**
+   *    UALoE fabric write-subtree readback (live, post-commit state):
+   *        - config.mask selects fields to read. On return it reports fields actually populated
+   *        - absent/empty masked fields keep a sentinel value and clear their readback bit
+   */
+  auto query_fabric_ppod_config(amdsmi_fabric_ppod_config_t& config) const -> amdsmi_status_t;
+  auto query_fabric_vpod_config(amdsmi_fabric_vpod_config_t& config) const -> amdsmi_status_t;
+  auto query_fabric_station_config(amdsmi_fabric_station_config_t& config) const -> amdsmi_status_t;
+
+  /**
+   *    UALoE fabric flat-surface readback (legacy files directly under the ualink
+   *    root). Same fields/semantics as the subtree readers above, but sourced from
+   *    the flat surface so callers can diff the two and confirm commit propagation.
+   */
+  auto query_fabric_ppod_config_flat(amdsmi_fabric_ppod_config_t& config) const -> amdsmi_status_t;
+  auto query_fabric_vpod_config_flat(amdsmi_fabric_vpod_config_t& config) const -> amdsmi_status_t;
+  auto query_fabric_station_config_flat(amdsmi_fabric_station_config_t& config) const
+      -> amdsmi_status_t;
 
   auto has_ifoe_related_bdf() const -> bool;
   auto get_ifoe_bdf_string() const -> std::string;
@@ -195,10 +218,16 @@ class AMDSmiGPUDevice : public AMDSmiProcessor {
   int32_t get_compute_process_list_impl(GPUComputeProcessList_t& compute_process_list,
                                         ComputeProcessListType_t list_type);
   void populate_ifoe_fabric_bdf_list();
+
   // UALoE — session is opened lazily on the first get_ualoe_handle() call
   void open_ualoe_session();
   ualoe_handle_t ualoe_handle_ = (-1);
   std::once_flag ualoe_open_once_;
+
+  /**
+   *  UALoE sysfs ualink root: /sys/class/drm/<gpu_path>/device/ualink
+   */
+  auto get_ualink_directory_path() const -> std::string;
 };
 
 }  // namespace amd::smi

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_gpu_device.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_gpu_device.h
@@ -23,6 +23,7 @@
 #ifndef AMD_SMI_INCLUDE_IMPL_AMD_SMI_GPU_DEVICE_H_
 #define AMD_SMI_INCLUDE_IMPL_AMD_SMI_GPU_DEVICE_H_
 
+#include <cstdint>
 #include <map>
 #include <mutex>
 #include <set>
@@ -169,6 +170,8 @@ class AMDSmiGPUDevice : public AMDSmiProcessor {
   /**
    *    UALoE fabric sysfs:
    *        - partial reads (see amdsmi_get_gpu_fabric_info() for status info)
+   *        - fabric_info is in/out: its fabric_version on entry selects the layout written back,
+   *          and only the bytes belonging to that layout are touched
    */
   auto get_fabric_info_from_ualoe(
       amdsmi_fabric_info_t& fabric_info,
@@ -229,6 +232,25 @@ class AMDSmiGPUDevice : public AMDSmiProcessor {
    */
   auto get_ualink_directory_path() const -> std::string;
 };
+
+namespace gpu_device::details {
+
+/**
+ *  Project the version 2 payload onto the frozen version 1 layout
+ */
+auto flatten_v2_to_v1(const amdsmi_fabric_info_v2_t& source, amdsmi_fabric_info_v1_t& destination)
+    -> void;
+
+/**
+ *  Bounded write into caller memory: only the union member named by requested_version is
+ *  touched, so a caller that predates version 2 keeps its smaller allocation intact.
+ *  Declared here so the layout tests can exercise the bound without a live device
+ */
+auto publish_fabric_info(const amdsmi_bdf_t& fabric_bdf, const amdsmi_fabric_info_v2_t& source,
+                         std::uint32_t requested_version, amdsmi_fabric_info_t& destination)
+    -> void;
+
+}  // namespace gpu_device::details
 
 }  // namespace amd::smi
 

--- a/projects/amdsmi/py-interface/__init__.py
+++ b/projects/amdsmi/py-interface/__init__.py
@@ -345,6 +345,9 @@ from .amdsmi_interface import amdsmi_reset_ttm_pages_limit
 # # Fabric (IFoE/UALoE) Information
 from .amdsmi_interface import amdsmi_get_fabric_telemetry_data
 from .amdsmi_interface import amdsmi_get_gpu_fabric_info
+from .amdsmi_interface import amdsmi_set_gpu_fabric_ppod_config
+from .amdsmi_interface import amdsmi_set_gpu_fabric_vpod_config
+from .amdsmi_interface import amdsmi_set_gpu_fabric_station_config
 
 # Exceptions
 from .amdsmi_exception import AmdSmiLibraryException

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -7143,6 +7143,15 @@ def amdsmi_get_gpu_fabric_info(processor_handle: processor_handle_t) -> Dict[str
     lines; the struct is still populated with BDF and sentinel/default fabric fields.
     An unconfigured accelerator returns AMDSMI_STATUS_SUCCESS and reports itself
     through the accelerator_state key.
+
+    A library predating the nested (version 2) layout never echoes back
+    AMDSMI_FABRIC_INFO_VERSION_2 and instead fills the flat version 1 member; this
+    degrades gracefully to that flat layout (mirroring amd_smi_fabric_example.cc)
+    rather than raising. The returned dict always carries the same keys; the
+    station-only fields (station_flags, num_stations, lane_en_bitmap, the
+    ppod/vpod/station masks, and local_accelerator_count) have no version 1
+    equivalent and are None on that path, "version" reports which layout was
+    actually filled.
     """
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
@@ -7159,9 +7168,35 @@ def amdsmi_get_gpu_fabric_info(processor_handle: processor_handle_t) -> Dict[str
         raise AmdSmiLibraryException(ret)
 
     if fabric_info.fabric_version != amdsmi_wrapper.AMDSMI_FABRIC_INFO_VERSION_2:
-        # A library predating the nested layout filled the flat v1 member instead, so every
-        # field below would be read at the wrong offset
-        raise AmdSmiLibraryException(amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED)
+        # A library predating the nested layout filled the flat v1 member instead; read
+        # it directly rather than erroring, so callers linked against an older
+        # libamd_smi.so keep working the way they did before the v2 layout existed
+        v1 = fabric_info.fabric_info.v1
+        return {
+            "bdf": _format_bdf(fabric_info.bdf),
+            "version": 1,
+            "accelerator_id": v1.accelerator_id,
+            "fabric_type": _FABRIC_TYPE_NAMES.get(v1.fabric_type, "UNKNOWN"),
+            "bandwidth": v1.bandwidth,
+            "latency": v1.latency,
+            "ppod_id": list(v1.ppod_id),
+            "ppod_size": v1.ppod_size,
+            "vpod_id": v1.vpod_id,
+            "vpod_size": v1.vpod_size,
+            "local_accelerators": list(v1.local_accelerators),
+            "local_accelerator_count": None,
+            "vpod_active_accelerators": list(v1.vpod_active_accelerators),
+            "addr_mode": _FABRIC_ADDR_MODE_NAMES.get(v1.addr_mode, "UNKNOWN"),
+            "accel_state": _FABRIC_ACCEL_STATE_NAMES.get(v1.accel_state, "UNKNOWN"),
+            # Station data has no version 1 equivalent
+            "station_flags": None,
+            "num_stations": None,
+            "lane_en_bitmap": None,
+            # No per-field read mask exists in version 1
+            "ppod_mask": None,
+            "vpod_mask": None,
+            "station_mask": None,
+        }
 
     v2 = fabric_info.fabric_info.v2
     ppod = v2.ppod

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -7228,6 +7228,200 @@ def amdsmi_get_gpu_fabric_info(processor_handle: processor_handle_t) -> Dict[str
     }
 
 
+# Field name -> AMDSMI_FABRIC_*_FIELD_* mask bit, one map per config struct's `data`
+# member. Keys are exactly the ctypes field names on that struct.
+_FABRIC_PPOD_CONFIG_FIELD_MASKS = {
+    "accelerator_id": amdsmi_wrapper.AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID,
+    "ppod_id": amdsmi_wrapper.AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID,
+    "ppod_size": amdsmi_wrapper.AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE,
+    "local_accelerators": amdsmi_wrapper.AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS,
+    "bandwidth": amdsmi_wrapper.AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH,
+    "latency": amdsmi_wrapper.AMDSMI_FABRIC_PPOD_FIELD_LATENCY,
+}
+
+_FABRIC_VPOD_CONFIG_FIELD_MASKS = {
+    "vpod_id": amdsmi_wrapper.AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID,
+    "vpod_size": amdsmi_wrapper.AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE,
+    "vpod_active_accelerators": amdsmi_wrapper.AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS,
+    "addr_mode": amdsmi_wrapper.AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE,
+}
+
+_FABRIC_STATION_CONFIG_FIELD_MASKS = {
+    "station_flags": amdsmi_wrapper.AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS,
+    "lane_en_bitmap": amdsmi_wrapper.AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP,
+    "num_stations": amdsmi_wrapper.AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS,
+}
+
+
+def _populate_fabric_config_data(config, data: Dict[str, Any], field_masks: Dict[str, int]) -> int:
+    """
+    Write `data` into a fabric ppod/vpod/station config struct's `.data` member and
+    return the OR of the mask bits for the fields written.
+
+    Only the keys present in `data` are written (and included in the mask), matching
+    the C API contract: an unmasked field is not read by the driver, so it is left at
+    whatever the zero-initialized struct already holds.
+
+    Args:
+        config: a freshly constructed amdsmi_fabric_{ppod,vpod,station}_config_t;
+            its `.data` member is written in place
+        data: mapping of `.data` field name to value to write
+        field_masks: the AMDSMI_FABRIC_*_FIELD_* mask bit for each valid field name
+            on this config struct
+
+    Returns:
+        int: OR of the mask bits for every field named in `data`
+
+    Raises:
+        AmdSmiParameterException: `data` names a field that is not in `field_masks`
+    """
+    mask = 0
+    for field_name, value in data.items():
+        if field_name not in field_masks:
+            raise AmdSmiParameterException(field_name, list(field_masks.keys()))
+        mask |= field_masks[field_name]
+        target = getattr(config.data, field_name)
+        if isinstance(target, ctypes.Array):
+            target[:] = value
+        else:
+            setattr(config.data, field_name, value)
+    return mask
+
+
+def amdsmi_set_gpu_fabric_ppod_config(
+    processor_handle: processor_handle_t, ppod_data: Dict[str, Any], commit: bool = True
+) -> None:
+    """
+    Apply physical PoD (PPOD) fabric configuration.
+
+    When `commit` is True, the masked fields (derived from the keys present in
+    `ppod_data`) are written and then committed. When False, the request is
+    validated and nothing is written: the driver ignores the staging files unless
+    a commit follows.
+
+    Args:
+        processor_handle: GPU processor handle
+        ppod_data: mapping of fields to write. Valid keys: "accelerator_id" (int),
+            "ppod_id" (16-byte iterable), "ppod_size" (int),
+            "local_accelerators" (16-entry iterable of accelerator IDs; fill unused
+            slots with UINT32_MAX), "bandwidth" (int), "latency" (int). Only the
+            supplied fields are written; `ppod_data` must select at least one field
+        commit: when True (default), write the masked fields then commit; when
+            False, validate only and write nothing
+
+    Raises:
+        AmdSmiParameterException: processor_handle is not a processor_handle_t,
+            ppod_data is not a dict, commit is not a bool, or ppod_data names an
+            unrecognized field
+        AmdSmiException: the underlying call failed
+    """
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
+    if not isinstance(ppod_data, dict):
+        raise AmdSmiParameterException(ppod_data, dict)
+    if not isinstance(commit, bool):
+        raise AmdSmiParameterException(commit, bool)
+
+    config = amdsmi_wrapper.amdsmi_fabric_ppod_config_t()
+    config.version = amdsmi_wrapper.AMDSMI_FABRIC_PPOD_CONFIG_V1
+    config.commit = commit
+    config.mask = _populate_fabric_config_data(config, ppod_data, _FABRIC_PPOD_CONFIG_FIELD_MASKS)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_gpu_fabric_ppod_config(processor_handle, ctypes.byref(config))
+    )
+
+
+def amdsmi_set_gpu_fabric_vpod_config(
+    processor_handle: processor_handle_t, vpod_data: Dict[str, Any], commit: bool = True
+) -> None:
+    """
+    Apply virtual PoD (VPOD) fabric configuration.
+
+    When `commit` is True, the masked fields (derived from the keys present in
+    `vpod_data`) are written and then committed. When False, the request is
+    validated and nothing is written: the driver ignores the staging files unless
+    a commit follows.
+
+    Args:
+        processor_handle: GPU processor handle
+        vpod_data: mapping of fields to write. Valid keys: "vpod_id" (int,
+            nonzero), "vpod_size" (int), "vpod_active_accelerators" (32-entry
+            iterable; fill unused slots with UINT32_MAX, 0 is a valid accelerator
+            ID), "addr_mode" (int, an amdsmi_fabric_npa_address_mode_t value).
+            Only the supplied fields are written; `vpod_data` must select at
+            least one field
+        commit: when True (default), write the masked fields then commit; when
+            False, validate only and write nothing
+
+    Raises:
+        AmdSmiParameterException: processor_handle is not a processor_handle_t,
+            vpod_data is not a dict, commit is not a bool, or vpod_data names an
+            unrecognized field
+        AmdSmiException: the underlying call failed
+    """
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
+    if not isinstance(vpod_data, dict):
+        raise AmdSmiParameterException(vpod_data, dict)
+    if not isinstance(commit, bool):
+        raise AmdSmiParameterException(commit, bool)
+
+    config = amdsmi_wrapper.amdsmi_fabric_vpod_config_t()
+    config.version = amdsmi_wrapper.AMDSMI_FABRIC_VPOD_CONFIG_V1
+    config.commit = commit
+    config.mask = _populate_fabric_config_data(config, vpod_data, _FABRIC_VPOD_CONFIG_FIELD_MASKS)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_gpu_fabric_vpod_config(processor_handle, ctypes.byref(config))
+    )
+
+
+def amdsmi_set_gpu_fabric_station_config(
+    processor_handle: processor_handle_t, station_data: Dict[str, Any], commit: bool = True
+) -> None:
+    """
+    Apply DF/station fabric configuration.
+
+    When `commit` is True, the masked fields (derived from the keys present in
+    `station_data`) are written and then committed. When False, the request is
+    validated and nothing is written: the driver ignores the staging files unless
+    a commit follows.
+
+    Args:
+        processor_handle: GPU processor handle
+        station_data: mapping of fields to write. Valid keys: "station_flags"
+            (int), "lane_en_bitmap" (64-byte iterable), "num_stations" (int, 0 to
+            255). Only the supplied fields are written; `station_data` must
+            select at least one field
+        commit: when True (default), write the masked fields then commit; when
+            False, validate only and write nothing
+
+    Raises:
+        AmdSmiParameterException: processor_handle is not a processor_handle_t,
+            station_data is not a dict, commit is not a bool, or station_data
+            names an unrecognized field
+        AmdSmiException: the underlying call failed
+    """
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
+    if not isinstance(station_data, dict):
+        raise AmdSmiParameterException(station_data, dict)
+    if not isinstance(commit, bool):
+        raise AmdSmiParameterException(commit, bool)
+
+    config = amdsmi_wrapper.amdsmi_fabric_station_config_t()
+    config.version = amdsmi_wrapper.AMDSMI_FABRIC_STATION_CONFIG_V1
+    config.commit = commit
+    config.mask = _populate_fabric_config_data(
+        config, station_data, _FABRIC_STATION_CONFIG_FIELD_MASKS
+    )
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_gpu_fabric_station_config(processor_handle, ctypes.byref(config))
+    )
+
+
 def amdsmi_get_gpu_busy_percent(processor_handle: processor_handle_t):
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -7139,6 +7139,7 @@ def amdsmi_get_gpu_fabric_info(processor_handle: processor_handle_t) -> Dict[str
     """
     Return fabric info from UALoE sysfs (partial reads).
 
+    The C API may return AMDSMI_STATUS_NOT_INIT when the accelerators are not configured/setup
     The C API may return AMDSMI_STATUS_NO_DATA when no sysfs files produced usable
     lines; the struct is still populated with BDF and sentinel/default fabric fields.
     """
@@ -7151,25 +7152,36 @@ def amdsmi_get_gpu_fabric_info(processor_handle: processor_handle_t) -> Dict[str
         raise AmdSmiRetryException()
     if ret == amdsmi_wrapper.AMDSMI_STATUS_TIMEOUT:
         raise AmdSmiTimeoutException()
-    if ret not in (amdsmi_wrapper.AMDSMI_STATUS_SUCCESS, amdsmi_wrapper.AMDSMI_STATUS_NO_DATA):
+    if ret not in (
+        amdsmi_wrapper.AMDSMI_STATUS_SUCCESS,
+        amdsmi_wrapper.AMDSMI_STATUS_NO_DATA,
+        amdsmi_wrapper.AMDSMI_STATUS_NOT_INIT,
+    ):
         raise AmdSmiLibraryException(ret)
 
     v1 = fabric_info.fabric_info.v1
+    ppod = v1.ppod
+    vpod = v1.vpod
+    station = v1.station
     return {
         "bdf": _format_bdf(fabric_info.bdf),
         "version": fabric_info.fabric_version,
-        "accelerator_id": v1.accelerator_id,
+        "accelerator_id": ppod.accelerator_id,
         "fabric_type": _FABRIC_TYPE_NAMES.get(v1.fabric_type, "UNKNOWN"),
-        "bandwidth": v1.bandwidth,
-        "latency": v1.latency,
-        "ppod_id": list(v1.ppod_id),
-        "ppod_size": v1.ppod_size,
-        "vpod_id": v1.vpod_id,
-        "vpod_size": v1.vpod_size,
-        "local_accelerators": list(v1.local_accelerators),
-        "vpod_active_accelerators": list(v1.vpod_active_accelerators),
-        "addr_mode": _FABRIC_ADDR_MODE_NAMES.get(v1.addr_mode, "UNKNOWN"),
+        "bandwidth": ppod.bandwidth,
+        "latency": ppod.latency,
+        "ppod_id": list(ppod.ppod_id),
+        "ppod_size": ppod.ppod_size,
+        "vpod_id": vpod.vpod_id,
+        "vpod_size": vpod.vpod_size,
+        "local_accelerators": list(ppod.local_accelerators),
+        "local_accelerator_count": ppod.local_accelerator_count,
+        "vpod_active_accelerators": list(vpod.vpod_active_accelerators),
+        "addr_mode": _FABRIC_ADDR_MODE_NAMES.get(vpod.addr_mode, "UNKNOWN"),
         "accel_state": _FABRIC_ACCEL_STATE_NAMES.get(v1.accel_state, "UNKNOWN"),
+        "station_flags": station.station_flags,
+        "num_stations": station.num_stations,
+        "lane_en_bitmap": list(station.lane_en_bitmap),
     }
 
 

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -7139,35 +7139,39 @@ def amdsmi_get_gpu_fabric_info(processor_handle: processor_handle_t) -> Dict[str
     """
     Return fabric info from UALoE sysfs (partial reads).
 
-    The C API may return AMDSMI_STATUS_NOT_INIT when the accelerators are not configured/setup
     The C API may return AMDSMI_STATUS_NO_DATA when no sysfs files produced usable
     lines; the struct is still populated with BDF and sentinel/default fabric fields.
+    An unconfigured accelerator returns AMDSMI_STATUS_SUCCESS and reports itself
+    through the accelerator_state key.
     """
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
     fabric_info = amdsmi_wrapper.amdsmi_fabric_info_t()
+    # Selects the nested layout; the flat v1 layout carries no station data
+    fabric_info.fabric_version = amdsmi_wrapper.AMDSMI_FABRIC_INFO_VERSION_2
     ret = amdsmi_wrapper.amdsmi_get_gpu_fabric_info(processor_handle, ctypes.byref(fabric_info))
     if ret == amdsmi_wrapper.AMDSMI_STATUS_RETRY:
         raise AmdSmiRetryException()
     if ret == amdsmi_wrapper.AMDSMI_STATUS_TIMEOUT:
         raise AmdSmiTimeoutException()
-    if ret not in (
-        amdsmi_wrapper.AMDSMI_STATUS_SUCCESS,
-        amdsmi_wrapper.AMDSMI_STATUS_NO_DATA,
-        amdsmi_wrapper.AMDSMI_STATUS_NOT_INIT,
-    ):
+    if ret not in (amdsmi_wrapper.AMDSMI_STATUS_SUCCESS, amdsmi_wrapper.AMDSMI_STATUS_NO_DATA):
         raise AmdSmiLibraryException(ret)
 
-    v1 = fabric_info.fabric_info.v1
-    ppod = v1.ppod
-    vpod = v1.vpod
-    station = v1.station
+    if fabric_info.fabric_version != amdsmi_wrapper.AMDSMI_FABRIC_INFO_VERSION_2:
+        # A library predating the nested layout filled the flat v1 member instead, so every
+        # field below would be read at the wrong offset
+        raise AmdSmiLibraryException(amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED)
+
+    v2 = fabric_info.fabric_info.v2
+    ppod = v2.ppod
+    vpod = v2.vpod
+    station = v2.station
     return {
         "bdf": _format_bdf(fabric_info.bdf),
-        "version": fabric_info.fabric_version,
+        "version": 2,
         "accelerator_id": ppod.accelerator_id,
-        "fabric_type": _FABRIC_TYPE_NAMES.get(v1.fabric_type, "UNKNOWN"),
+        "fabric_type": _FABRIC_TYPE_NAMES.get(v2.fabric_type, "UNKNOWN"),
         "bandwidth": ppod.bandwidth,
         "latency": ppod.latency,
         "ppod_id": list(ppod.ppod_id),
@@ -7178,10 +7182,14 @@ def amdsmi_get_gpu_fabric_info(processor_handle: processor_handle_t) -> Dict[str
         "local_accelerator_count": ppod.local_accelerator_count,
         "vpod_active_accelerators": list(vpod.vpod_active_accelerators),
         "addr_mode": _FABRIC_ADDR_MODE_NAMES.get(vpod.addr_mode, "UNKNOWN"),
-        "accel_state": _FABRIC_ACCEL_STATE_NAMES.get(v1.accel_state, "UNKNOWN"),
+        "accel_state": _FABRIC_ACCEL_STATE_NAMES.get(v2.accel_state, "UNKNOWN"),
         "station_flags": station.station_flags,
         "num_stations": station.num_stations,
         "lane_en_bitmap": list(station.lane_en_bitmap),
+        # Which fields above were actually read; a clear bit means the field holds its sentinel
+        "ppod_mask": v2.ppod_mask,
+        "vpod_mask": v2.vpod_mask,
+        "station_mask": v2.station_mask,
     }
 
 

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -7087,35 +7087,39 @@ def amdsmi_get_gpu_fabric_info(processor_handle: processor_handle_t) -> Dict[str
     """
     Return fabric info from UALoE sysfs (partial reads).
 
-    The C API may return AMDSMI_STATUS_NOT_INIT when the accelerators are not configured/setup
     The C API may return AMDSMI_STATUS_NO_DATA when no sysfs files produced usable
     lines; the struct is still populated with BDF and sentinel/default fabric fields.
+    An unconfigured accelerator returns AMDSMI_STATUS_SUCCESS and reports itself
+    through the accelerator_state key.
     """
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
     fabric_info = amdsmi_wrapper.amdsmi_fabric_info_t()
+    # Selects the nested layout; the flat v1 layout carries no station data
+    fabric_info.fabric_version = amdsmi_wrapper.AMDSMI_FABRIC_INFO_VERSION_2
     ret = amdsmi_wrapper.amdsmi_get_gpu_fabric_info(processor_handle, ctypes.byref(fabric_info))
     if ret == amdsmi_wrapper.AMDSMI_STATUS_RETRY:
         raise AmdSmiRetryException()
     if ret == amdsmi_wrapper.AMDSMI_STATUS_TIMEOUT:
         raise AmdSmiTimeoutException()
-    if ret not in (
-        amdsmi_wrapper.AMDSMI_STATUS_SUCCESS,
-        amdsmi_wrapper.AMDSMI_STATUS_NO_DATA,
-        amdsmi_wrapper.AMDSMI_STATUS_NOT_INIT,
-    ):
+    if ret not in (amdsmi_wrapper.AMDSMI_STATUS_SUCCESS, amdsmi_wrapper.AMDSMI_STATUS_NO_DATA):
         raise AmdSmiLibraryException(ret)
 
-    v1 = fabric_info.fabric_info.v1
-    ppod = v1.ppod
-    vpod = v1.vpod
-    station = v1.station
+    if fabric_info.fabric_version != amdsmi_wrapper.AMDSMI_FABRIC_INFO_VERSION_2:
+        # A library predating the nested layout filled the flat v1 member instead, so every
+        # field below would be read at the wrong offset
+        raise AmdSmiLibraryException(amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED)
+
+    v2 = fabric_info.fabric_info.v2
+    ppod = v2.ppod
+    vpod = v2.vpod
+    station = v2.station
     return {
         "bdf": _format_bdf(fabric_info.bdf),
-        "version": fabric_info.fabric_version,
+        "version": 2,
         "accelerator_id": ppod.accelerator_id,
-        "fabric_type": _FABRIC_TYPE_NAMES.get(v1.fabric_type, "UNKNOWN"),
+        "fabric_type": _FABRIC_TYPE_NAMES.get(v2.fabric_type, "UNKNOWN"),
         "bandwidth": ppod.bandwidth,
         "latency": ppod.latency,
         "ppod_id": list(ppod.ppod_id),
@@ -7126,10 +7130,14 @@ def amdsmi_get_gpu_fabric_info(processor_handle: processor_handle_t) -> Dict[str
         "local_accelerator_count": ppod.local_accelerator_count,
         "vpod_active_accelerators": list(vpod.vpod_active_accelerators),
         "addr_mode": _FABRIC_ADDR_MODE_NAMES.get(vpod.addr_mode, "UNKNOWN"),
-        "accel_state": _FABRIC_ACCEL_STATE_NAMES.get(v1.accel_state, "UNKNOWN"),
+        "accel_state": _FABRIC_ACCEL_STATE_NAMES.get(v2.accel_state, "UNKNOWN"),
         "station_flags": station.station_flags,
         "num_stations": station.num_stations,
         "lane_en_bitmap": list(station.lane_en_bitmap),
+        # Which fields above were actually read; a clear bit means the field holds its sentinel
+        "ppod_mask": v2.ppod_mask,
+        "vpod_mask": v2.vpod_mask,
+        "station_mask": v2.station_mask,
     }
 
 

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -7087,6 +7087,7 @@ def amdsmi_get_gpu_fabric_info(processor_handle: processor_handle_t) -> Dict[str
     """
     Return fabric info from UALoE sysfs (partial reads).
 
+    The C API may return AMDSMI_STATUS_NOT_INIT when the accelerators are not configured/setup
     The C API may return AMDSMI_STATUS_NO_DATA when no sysfs files produced usable
     lines; the struct is still populated with BDF and sentinel/default fabric fields.
     """
@@ -7099,25 +7100,36 @@ def amdsmi_get_gpu_fabric_info(processor_handle: processor_handle_t) -> Dict[str
         raise AmdSmiRetryException()
     if ret == amdsmi_wrapper.AMDSMI_STATUS_TIMEOUT:
         raise AmdSmiTimeoutException()
-    if ret not in (amdsmi_wrapper.AMDSMI_STATUS_SUCCESS, amdsmi_wrapper.AMDSMI_STATUS_NO_DATA):
+    if ret not in (
+        amdsmi_wrapper.AMDSMI_STATUS_SUCCESS,
+        amdsmi_wrapper.AMDSMI_STATUS_NO_DATA,
+        amdsmi_wrapper.AMDSMI_STATUS_NOT_INIT,
+    ):
         raise AmdSmiLibraryException(ret)
 
     v1 = fabric_info.fabric_info.v1
+    ppod = v1.ppod
+    vpod = v1.vpod
+    station = v1.station
     return {
         "bdf": _format_bdf(fabric_info.bdf),
         "version": fabric_info.fabric_version,
-        "accelerator_id": v1.accelerator_id,
+        "accelerator_id": ppod.accelerator_id,
         "fabric_type": _FABRIC_TYPE_NAMES.get(v1.fabric_type, "UNKNOWN"),
-        "bandwidth": v1.bandwidth,
-        "latency": v1.latency,
-        "ppod_id": list(v1.ppod_id),
-        "ppod_size": v1.ppod_size,
-        "vpod_id": v1.vpod_id,
-        "vpod_size": v1.vpod_size,
-        "local_accelerators": list(v1.local_accelerators),
-        "vpod_active_accelerators": list(v1.vpod_active_accelerators),
-        "addr_mode": _FABRIC_ADDR_MODE_NAMES.get(v1.addr_mode, "UNKNOWN"),
+        "bandwidth": ppod.bandwidth,
+        "latency": ppod.latency,
+        "ppod_id": list(ppod.ppod_id),
+        "ppod_size": ppod.ppod_size,
+        "vpod_id": vpod.vpod_id,
+        "vpod_size": vpod.vpod_size,
+        "local_accelerators": list(ppod.local_accelerators),
+        "local_accelerator_count": ppod.local_accelerator_count,
+        "vpod_active_accelerators": list(vpod.vpod_active_accelerators),
+        "addr_mode": _FABRIC_ADDR_MODE_NAMES.get(vpod.addr_mode, "UNKNOWN"),
         "accel_state": _FABRIC_ACCEL_STATE_NAMES.get(v1.accel_state, "UNKNOWN"),
+        "station_flags": station.station_flags,
+        "num_stations": station.num_stations,
+        "lane_en_bitmap": list(station.lane_en_bitmap),
     }
 
 

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -3836,10 +3836,12 @@ amdsmi_fabric_size_constants_t__enumvalues = {
     32: 'AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE',
     16: 'AMDSMI_FABRIC_MAX_LOCAL_GPUS',
     64: 'AMDSMI_FABRIC_MAX_BITMAP_SIZE',
+    37: 'AMDSMI_FABRIC_INFO_V2_RESERVED_WORDS',
 }
 AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE = 32
 AMDSMI_FABRIC_MAX_LOCAL_GPUS = 16
 AMDSMI_FABRIC_MAX_BITMAP_SIZE = 64
+AMDSMI_FABRIC_INFO_V2_RESERVED_WORDS = 37
 amdsmi_fabric_size_constants_t = ctypes.c_uint32 # enum
 
 # values for enumeration 'amdsmi_fabric_type_t'
@@ -3925,17 +3927,53 @@ struct_amdsmi_fabric_station_data_t._fields_ = [
 
 amdsmi_fabric_station_data_t = struct_amdsmi_fabric_station_data_t
 class struct_amdsmi_fabric_info_v1_t(Structure):
-    _pack_ = 1 # source:False
-    _layout_ = 'ms'
-    _fields_ = [
+    pass
+
+struct_amdsmi_fabric_info_v1_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_info_v1_t._layout_ = 'ms'
+struct_amdsmi_fabric_info_v1_t._fields_ = [
+    ('accelerator_id', ctypes.c_uint32),
+    ('fabric_type', amdsmi_fabric_type_t),
+    ('bandwidth', ctypes.c_uint32),
+    ('latency', ctypes.c_uint32),
+    ('ppod_id', ctypes.c_ubyte * 16),
+    ('ppod_size', ctypes.c_uint32),
+    ('vpod_id', ctypes.c_uint32),
+    ('vpod_size', ctypes.c_uint32),
+    ('vpod_active_accelerators', ctypes.c_uint32 * 32),
+    ('local_accelerators', ctypes.c_uint32 * 16),
+    ('addr_mode', amdsmi_fabric_npa_address_mode_t),
+    ('accel_state', amdsmi_fabric_accelerator_vpod_state_t),
+]
+
+amdsmi_fabric_info_v1_t = struct_amdsmi_fabric_info_v1_t
+class struct_amdsmi_fabric_info_v2_t(Structure):
+    pass
+
+struct_amdsmi_fabric_info_v2_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_info_v2_t._layout_ = 'ms'
+struct_amdsmi_fabric_info_v2_t._fields_ = [
     ('fabric_type', amdsmi_fabric_type_t),
     ('accel_state', amdsmi_fabric_accelerator_vpod_state_t),
     ('ppod', amdsmi_fabric_ppod_data_t),
     ('vpod', amdsmi_fabric_vpod_data_t),
     ('station', amdsmi_fabric_station_data_t),
-     ]
+    ('ppod_mask', ctypes.c_uint32),
+    ('vpod_mask', ctypes.c_uint32),
+    ('station_mask', ctypes.c_uint32),
+    ('reserved', ctypes.c_uint32 * 37),
+]
 
-amdsmi_fabric_info_v1_t = struct_amdsmi_fabric_info_v1_t
+amdsmi_fabric_info_v2_t = struct_amdsmi_fabric_info_v2_t
+
+# values for enumeration 'amdsmi_fabric_info_version_t'
+amdsmi_fabric_info_version_t__enumvalues = {
+    0: 'AMDSMI_FABRIC_INFO_VERSION_1',
+    4205903874: 'AMDSMI_FABRIC_INFO_VERSION_2',
+}
+AMDSMI_FABRIC_INFO_VERSION_1 = 0
+AMDSMI_FABRIC_INFO_VERSION_2 = 4205903874
+amdsmi_fabric_info_version_t = ctypes.c_uint32 # enum
 class struct_amdsmi_fabric_info_t(Structure):
     pass
 
@@ -3944,6 +3982,7 @@ class union_fabric_info_(Union):
     _layout_ = 'ms'
     _fields_ = [
     ('v1', amdsmi_fabric_info_v1_t),
+    ('v2', amdsmi_fabric_info_v2_t),
      ]
 
 struct_amdsmi_fabric_info_t._pack_ = 1 # source:False
@@ -5207,6 +5246,8 @@ __all__ = \
     'AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP',
     'AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS',
     'AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS',
+    'AMDSMI_FABRIC_INFO_V2_RESERVED_WORDS',
+    'AMDSMI_FABRIC_INFO_VERSION_1', 'AMDSMI_FABRIC_INFO_VERSION_2',
     'AMDSMI_FABRIC_MAX_BITMAP_SIZE', 'AMDSMI_FABRIC_MAX_LOCAL_GPUS',
     'AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING',
     'AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_IDENTIFICATION',
@@ -5514,6 +5555,7 @@ __all__ = \
     'amdsmi_fabric_accelerator_vpod_state_t',
     'amdsmi_fabric_config_version_t', 'amdsmi_fabric_df_field_t',
     'amdsmi_fabric_info_t', 'amdsmi_fabric_info_v1_t',
+    'amdsmi_fabric_info_v2_t', 'amdsmi_fabric_info_version_t',
     'amdsmi_fabric_label_t', 'amdsmi_fabric_npa_address_mode_t',
     'amdsmi_fabric_ppod_config_t', 'amdsmi_fabric_ppod_data_t',
     'amdsmi_fabric_ppod_field_t', 'amdsmi_fabric_size_constants_t',
@@ -5754,7 +5796,7 @@ __all__ = \
     'struct_amdsmi_enumeration_info_t', 'struct_amdsmi_error_count_t',
     'struct_amdsmi_evt_notification_data_t',
     'struct_amdsmi_fabric_info_t', 'struct_amdsmi_fabric_info_v1_t',
-    'struct_amdsmi_fabric_label_t',
+    'struct_amdsmi_fabric_info_v2_t', 'struct_amdsmi_fabric_label_t',
     'struct_amdsmi_fabric_ppod_config_t',
     'struct_amdsmi_fabric_ppod_data_t',
     'struct_amdsmi_fabric_station_config_t',

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -3835,9 +3835,11 @@ except AttributeError:
 amdsmi_fabric_size_constants_t__enumvalues = {
     32: 'AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE',
     16: 'AMDSMI_FABRIC_MAX_LOCAL_GPUS',
+    64: 'AMDSMI_FABRIC_MAX_BITMAP_SIZE',
 }
 AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE = 32
 AMDSMI_FABRIC_MAX_LOCAL_GPUS = 16
+AMDSMI_FABRIC_MAX_BITMAP_SIZE = 64
 amdsmi_fabric_size_constants_t = ctypes.c_uint32 # enum
 
 # values for enumeration 'amdsmi_fabric_type_t'
@@ -3880,25 +3882,58 @@ AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE = 3
 AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ERROR = 4
 AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN = 5
 amdsmi_fabric_accelerator_vpod_state_t = ctypes.c_uint32 # enum
-class struct_amdsmi_fabric_info_v1_t(Structure):
+class struct_amdsmi_fabric_ppod_data_t(Structure):
     pass
 
-struct_amdsmi_fabric_info_v1_t._pack_ = 1 # source:False
-struct_amdsmi_fabric_info_v1_t._layout_ = 'ms'
-struct_amdsmi_fabric_info_v1_t._fields_ = [
+struct_amdsmi_fabric_ppod_data_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_ppod_data_t._layout_ = 'ms'
+struct_amdsmi_fabric_ppod_data_t._fields_ = [
     ('accelerator_id', ctypes.c_uint32),
-    ('fabric_type', amdsmi_fabric_type_t),
-    ('bandwidth', ctypes.c_uint32),
-    ('latency', ctypes.c_uint32),
     ('ppod_id', ctypes.c_ubyte * 16),
     ('ppod_size', ctypes.c_uint32),
+    ('local_accelerators', ctypes.c_uint32 * 16),
+    ('local_accelerator_count', ctypes.c_uint32),
+    ('bandwidth', ctypes.c_uint32),
+    ('latency', ctypes.c_uint32),
+]
+
+amdsmi_fabric_ppod_data_t = struct_amdsmi_fabric_ppod_data_t
+class struct_amdsmi_fabric_vpod_data_t(Structure):
+    pass
+
+struct_amdsmi_fabric_vpod_data_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_vpod_data_t._layout_ = 'ms'
+struct_amdsmi_fabric_vpod_data_t._fields_ = [
     ('vpod_id', ctypes.c_uint32),
     ('vpod_size', ctypes.c_uint32),
     ('vpod_active_accelerators', ctypes.c_uint32 * 32),
-    ('local_accelerators', ctypes.c_uint32 * 16),
     ('addr_mode', amdsmi_fabric_npa_address_mode_t),
-    ('accel_state', amdsmi_fabric_accelerator_vpod_state_t),
 ]
+
+amdsmi_fabric_vpod_data_t = struct_amdsmi_fabric_vpod_data_t
+class struct_amdsmi_fabric_station_data_t(Structure):
+    pass
+
+struct_amdsmi_fabric_station_data_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_station_data_t._layout_ = 'ms'
+struct_amdsmi_fabric_station_data_t._fields_ = [
+    ('station_flags', ctypes.c_uint32),
+    ('num_stations', ctypes.c_ubyte),
+    ('lane_en_bitmap', ctypes.c_ubyte * 64),
+    ('PADDING_0', ctypes.c_ubyte * 3),
+]
+
+amdsmi_fabric_station_data_t = struct_amdsmi_fabric_station_data_t
+class struct_amdsmi_fabric_info_v1_t(Structure):
+    _pack_ = 1 # source:False
+    _layout_ = 'ms'
+    _fields_ = [
+    ('fabric_type', amdsmi_fabric_type_t),
+    ('accel_state', amdsmi_fabric_accelerator_vpod_state_t),
+    ('ppod', amdsmi_fabric_ppod_data_t),
+    ('vpod', amdsmi_fabric_vpod_data_t),
+    ('station', amdsmi_fabric_station_data_t),
+     ]
 
 amdsmi_fabric_info_v1_t = struct_amdsmi_fabric_info_v1_t
 class struct_amdsmi_fabric_info_t(Structure):
@@ -3918,7 +3953,6 @@ struct_amdsmi_fabric_info_t._fields_ = [
     ('fabric_version', ctypes.c_uint32),
     ('fabric_info', union_fabric_info_),
     ('reserved', ctypes.c_uint32 * 15),
-    ('PADDING_0', ctypes.c_ubyte * 4),
 ]
 
 amdsmi_fabric_info_t = struct_amdsmi_fabric_info_t
@@ -3926,6 +3960,118 @@ try:
     amdsmi_get_gpu_fabric_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_fabric_info
     amdsmi_get_gpu_fabric_info.restype = amdsmi_status_t
     amdsmi_get_gpu_fabric_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_fabric_info_t)]
+except AttributeError:
+    pass
+
+# values for enumeration 'amdsmi_fabric_config_version_t'
+amdsmi_fabric_config_version_t__enumvalues = {
+    1: 'AMDSMI_FABRIC_PPOD_CONFIG_V1',
+    1: 'AMDSMI_FABRIC_VPOD_CONFIG_V1',
+    1: 'AMDSMI_FABRIC_STATION_CONFIG_V1',
+}
+AMDSMI_FABRIC_PPOD_CONFIG_V1 = 1
+AMDSMI_FABRIC_VPOD_CONFIG_V1 = 1
+AMDSMI_FABRIC_STATION_CONFIG_V1 = 1
+amdsmi_fabric_config_version_t = ctypes.c_uint32 # enum
+
+# values for enumeration 'amdsmi_fabric_ppod_field_t'
+amdsmi_fabric_ppod_field_t__enumvalues = {
+    1: 'AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID',
+    2: 'AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID',
+    4: 'AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE',
+    8: 'AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS',
+    16: 'AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH',
+    32: 'AMDSMI_FABRIC_PPOD_FIELD_LATENCY',
+}
+AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID = 1
+AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID = 2
+AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE = 4
+AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS = 8
+AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH = 16
+AMDSMI_FABRIC_PPOD_FIELD_LATENCY = 32
+amdsmi_fabric_ppod_field_t = ctypes.c_uint32 # enum
+
+# values for enumeration 'amdsmi_fabric_vpod_field_t'
+amdsmi_fabric_vpod_field_t__enumvalues = {
+    1: 'AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID',
+    2: 'AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE',
+    4: 'AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS',
+    8: 'AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE',
+}
+AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID = 1
+AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE = 2
+AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS = 4
+AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE = 8
+amdsmi_fabric_vpod_field_t = ctypes.c_uint32 # enum
+
+# values for enumeration 'amdsmi_fabric_df_field_t'
+amdsmi_fabric_df_field_t__enumvalues = {
+    1: 'AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS',
+    2: 'AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP',
+    4: 'AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS',
+}
+AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS = 1
+AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP = 2
+AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS = 4
+amdsmi_fabric_df_field_t = ctypes.c_uint32 # enum
+class struct_amdsmi_fabric_ppod_config_t(Structure):
+    pass
+
+struct_amdsmi_fabric_ppod_config_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_ppod_config_t._layout_ = 'ms'
+struct_amdsmi_fabric_ppod_config_t._fields_ = [
+    ('version', ctypes.c_uint32),
+    ('mask', ctypes.c_uint32),
+    ('commit', ctypes.c_bool),
+    ('PADDING_0', ctypes.c_ubyte * 3),
+    ('data', amdsmi_fabric_ppod_data_t),
+]
+
+amdsmi_fabric_ppod_config_t = struct_amdsmi_fabric_ppod_config_t
+class struct_amdsmi_fabric_vpod_config_t(Structure):
+    pass
+
+struct_amdsmi_fabric_vpod_config_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_vpod_config_t._layout_ = 'ms'
+struct_amdsmi_fabric_vpod_config_t._fields_ = [
+    ('version', ctypes.c_uint32),
+    ('mask', ctypes.c_uint32),
+    ('commit', ctypes.c_bool),
+    ('PADDING_0', ctypes.c_ubyte * 3),
+    ('data', amdsmi_fabric_vpod_data_t),
+]
+
+amdsmi_fabric_vpod_config_t = struct_amdsmi_fabric_vpod_config_t
+class struct_amdsmi_fabric_station_config_t(Structure):
+    pass
+
+struct_amdsmi_fabric_station_config_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_station_config_t._layout_ = 'ms'
+struct_amdsmi_fabric_station_config_t._fields_ = [
+    ('version', ctypes.c_uint32),
+    ('mask', ctypes.c_uint32),
+    ('commit', ctypes.c_bool),
+    ('PADDING_0', ctypes.c_ubyte * 3),
+    ('data', amdsmi_fabric_station_data_t),
+]
+
+amdsmi_fabric_station_config_t = struct_amdsmi_fabric_station_config_t
+try:
+    amdsmi_set_gpu_fabric_ppod_config = _libraries['libamd_smi.so'].amdsmi_set_gpu_fabric_ppod_config
+    amdsmi_set_gpu_fabric_ppod_config.restype = amdsmi_status_t
+    amdsmi_set_gpu_fabric_ppod_config.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_fabric_ppod_config_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_fabric_vpod_config = _libraries['libamd_smi.so'].amdsmi_set_gpu_fabric_vpod_config
+    amdsmi_set_gpu_fabric_vpod_config.restype = amdsmi_status_t
+    amdsmi_set_gpu_fabric_vpod_config.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_fabric_vpod_config_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_fabric_station_config = _libraries['libamd_smi.so'].amdsmi_set_gpu_fabric_station_config
+    amdsmi_set_gpu_fabric_station_config.restype = amdsmi_status_t
+    amdsmi_set_gpu_fabric_station_config.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_fabric_station_config_t)]
 except AttributeError:
     pass
 try:
@@ -5058,10 +5204,21 @@ __all__ = \
     'AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNCONFIGURED',
     'AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN',
     'AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE',
-    'AMDSMI_FABRIC_MAX_LOCAL_GPUS',
+    'AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP',
+    'AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS',
+    'AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS',
+    'AMDSMI_FABRIC_MAX_BITMAP_SIZE', 'AMDSMI_FABRIC_MAX_LOCAL_GPUS',
     'AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING',
     'AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_IDENTIFICATION',
     'AMDSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN',
+    'AMDSMI_FABRIC_PPOD_CONFIG_V1',
+    'AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID',
+    'AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH',
+    'AMDSMI_FABRIC_PPOD_FIELD_LATENCY',
+    'AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS',
+    'AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID',
+    'AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE',
+    'AMDSMI_FABRIC_STATION_CONFIG_V1',
     'AMDSMI_FABRIC_TELEMETRY_CATEGORY_CRYPTO',
     'AMDSMI_FABRIC_TELEMETRY_CATEGORY_DERIVED_NETPORT',
     'AMDSMI_FABRIC_TELEMETRY_CATEGORY_DERIVED_UALOE',
@@ -5082,6 +5239,11 @@ __all__ = \
     'AMDSMI_FABRIC_TELEMETRY_CATEGORY_UNKNOWN',
     'AMDSMI_FABRIC_TYPE_UALINK', 'AMDSMI_FABRIC_TYPE_UALLINK',
     'AMDSMI_FABRIC_TYPE_UALOE', 'AMDSMI_FABRIC_TYPE_UNKNOWN',
+    'AMDSMI_FABRIC_VPOD_CONFIG_V1',
+    'AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE',
+    'AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS',
+    'AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID',
+    'AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE',
     'AMDSMI_FINE_DECODER_ACTIVITY', 'AMDSMI_FINE_GRAIN_GFX_ACTIVITY',
     'AMDSMI_FINE_GRAIN_MEM_ACTIVITY', 'AMDSMI_FREQ_IND_INVALID',
     'AMDSMI_FREQ_IND_MAX', 'AMDSMI_FREQ_IND_MIN', 'AMDSMI_FW_ID_ASD',
@@ -5349,17 +5511,22 @@ __all__ = \
     'amdsmi_event_group_t', 'amdsmi_event_handle_t',
     'amdsmi_event_type_t', 'amdsmi_evt_notification_data_t',
     'amdsmi_evt_notification_type_t',
-    'amdsmi_fabric_accelerator_vpod_state_t', 'amdsmi_fabric_info_t',
-    'amdsmi_fabric_info_v1_t', 'amdsmi_fabric_label_t',
-    'amdsmi_fabric_npa_address_mode_t',
-    'amdsmi_fabric_size_constants_t',
+    'amdsmi_fabric_accelerator_vpod_state_t',
+    'amdsmi_fabric_config_version_t', 'amdsmi_fabric_df_field_t',
+    'amdsmi_fabric_info_t', 'amdsmi_fabric_info_v1_t',
+    'amdsmi_fabric_label_t', 'amdsmi_fabric_npa_address_mode_t',
+    'amdsmi_fabric_ppod_config_t', 'amdsmi_fabric_ppod_data_t',
+    'amdsmi_fabric_ppod_field_t', 'amdsmi_fabric_size_constants_t',
+    'amdsmi_fabric_station_config_t', 'amdsmi_fabric_station_data_t',
     'amdsmi_fabric_telem_id_to_string',
     'amdsmi_fabric_telemetry_category_mask_t',
     'amdsmi_fabric_telemetry_category_t',
     'amdsmi_fabric_telemetry_dataset_t',
     'amdsmi_fabric_telemetry_instance_t',
     'amdsmi_fabric_telemetry_item_t', 'amdsmi_fabric_telemetry_t',
-    'amdsmi_fabric_type_t', 'amdsmi_first_online_core_on_cpu_socket',
+    'amdsmi_fabric_type_t', 'amdsmi_fabric_vpod_config_t',
+    'amdsmi_fabric_vpod_data_t', 'amdsmi_fabric_vpod_field_t',
+    'amdsmi_first_online_core_on_cpu_socket',
     'amdsmi_free_fabric_telemetry', 'amdsmi_freq_ind_t',
     'amdsmi_freq_volt_region_t', 'amdsmi_frequencies_t',
     'amdsmi_frequency_range_t', 'amdsmi_fw_block_t',
@@ -5538,7 +5705,10 @@ __all__ = \
     'amdsmi_set_gpu_clk_limit', 'amdsmi_set_gpu_compute_partition',
     'amdsmi_set_gpu_compute_partition_mem_alloc_mode',
     'amdsmi_set_gpu_event_notification_mask',
-    'amdsmi_set_gpu_fan_speed', 'amdsmi_set_gpu_memory_partition',
+    'amdsmi_set_gpu_fabric_ppod_config',
+    'amdsmi_set_gpu_fabric_station_config',
+    'amdsmi_set_gpu_fabric_vpod_config', 'amdsmi_set_gpu_fan_speed',
+    'amdsmi_set_gpu_memory_partition',
     'amdsmi_set_gpu_memory_partition_mode',
     'amdsmi_set_gpu_od_clk_info', 'amdsmi_set_gpu_od_volt_info',
     'amdsmi_set_gpu_overdrive_level', 'amdsmi_set_gpu_pci_bandwidth',
@@ -5585,10 +5755,16 @@ __all__ = \
     'struct_amdsmi_evt_notification_data_t',
     'struct_amdsmi_fabric_info_t', 'struct_amdsmi_fabric_info_v1_t',
     'struct_amdsmi_fabric_label_t',
+    'struct_amdsmi_fabric_ppod_config_t',
+    'struct_amdsmi_fabric_ppod_data_t',
+    'struct_amdsmi_fabric_station_config_t',
+    'struct_amdsmi_fabric_station_data_t',
     'struct_amdsmi_fabric_telemetry_dataset_t',
     'struct_amdsmi_fabric_telemetry_instance_t',
     'struct_amdsmi_fabric_telemetry_item_t',
     'struct_amdsmi_fabric_telemetry_t',
+    'struct_amdsmi_fabric_vpod_config_t',
+    'struct_amdsmi_fabric_vpod_data_t',
     'struct_amdsmi_freq_volt_region_t', 'struct_amdsmi_frequencies_t',
     'struct_amdsmi_frequency_range_t', 'struct_amdsmi_fw_info_t',
     'struct_amdsmi_gpu_cache_info_t', 'struct_amdsmi_gpu_metrics_t',

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -3782,9 +3782,11 @@ except AttributeError:
 amdsmi_fabric_size_constants_t__enumvalues = {
     32: 'AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE',
     16: 'AMDSMI_FABRIC_MAX_LOCAL_GPUS',
+    64: 'AMDSMI_FABRIC_MAX_BITMAP_SIZE',
 }
 AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE = 32
 AMDSMI_FABRIC_MAX_LOCAL_GPUS = 16
+AMDSMI_FABRIC_MAX_BITMAP_SIZE = 64
 amdsmi_fabric_size_constants_t = ctypes.c_uint32 # enum
 
 # values for enumeration 'amdsmi_fabric_type_t'
@@ -3827,25 +3829,58 @@ AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE = 3
 AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ERROR = 4
 AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN = 5
 amdsmi_fabric_accelerator_vpod_state_t = ctypes.c_uint32 # enum
-class struct_amdsmi_fabric_info_v1_t(Structure):
+class struct_amdsmi_fabric_ppod_data_t(Structure):
     pass
 
-struct_amdsmi_fabric_info_v1_t._pack_ = 1 # source:False
-struct_amdsmi_fabric_info_v1_t._layout_ = 'ms'
-struct_amdsmi_fabric_info_v1_t._fields_ = [
+struct_amdsmi_fabric_ppod_data_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_ppod_data_t._layout_ = 'ms'
+struct_amdsmi_fabric_ppod_data_t._fields_ = [
     ('accelerator_id', ctypes.c_uint32),
-    ('fabric_type', amdsmi_fabric_type_t),
-    ('bandwidth', ctypes.c_uint32),
-    ('latency', ctypes.c_uint32),
     ('ppod_id', ctypes.c_ubyte * 16),
     ('ppod_size', ctypes.c_uint32),
+    ('local_accelerators', ctypes.c_uint32 * 16),
+    ('local_accelerator_count', ctypes.c_uint32),
+    ('bandwidth', ctypes.c_uint32),
+    ('latency', ctypes.c_uint32),
+]
+
+amdsmi_fabric_ppod_data_t = struct_amdsmi_fabric_ppod_data_t
+class struct_amdsmi_fabric_vpod_data_t(Structure):
+    pass
+
+struct_amdsmi_fabric_vpod_data_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_vpod_data_t._layout_ = 'ms'
+struct_amdsmi_fabric_vpod_data_t._fields_ = [
     ('vpod_id', ctypes.c_uint32),
     ('vpod_size', ctypes.c_uint32),
     ('vpod_active_accelerators', ctypes.c_uint32 * 32),
-    ('local_accelerators', ctypes.c_uint32 * 16),
     ('addr_mode', amdsmi_fabric_npa_address_mode_t),
-    ('accel_state', amdsmi_fabric_accelerator_vpod_state_t),
 ]
+
+amdsmi_fabric_vpod_data_t = struct_amdsmi_fabric_vpod_data_t
+class struct_amdsmi_fabric_station_data_t(Structure):
+    pass
+
+struct_amdsmi_fabric_station_data_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_station_data_t._layout_ = 'ms'
+struct_amdsmi_fabric_station_data_t._fields_ = [
+    ('station_flags', ctypes.c_uint32),
+    ('num_stations', ctypes.c_ubyte),
+    ('lane_en_bitmap', ctypes.c_ubyte * 64),
+    ('PADDING_0', ctypes.c_ubyte * 3),
+]
+
+amdsmi_fabric_station_data_t = struct_amdsmi_fabric_station_data_t
+class struct_amdsmi_fabric_info_v1_t(Structure):
+    _pack_ = 1 # source:False
+    _layout_ = 'ms'
+    _fields_ = [
+    ('fabric_type', amdsmi_fabric_type_t),
+    ('accel_state', amdsmi_fabric_accelerator_vpod_state_t),
+    ('ppod', amdsmi_fabric_ppod_data_t),
+    ('vpod', amdsmi_fabric_vpod_data_t),
+    ('station', amdsmi_fabric_station_data_t),
+     ]
 
 amdsmi_fabric_info_v1_t = struct_amdsmi_fabric_info_v1_t
 class struct_amdsmi_fabric_info_t(Structure):
@@ -3865,7 +3900,6 @@ struct_amdsmi_fabric_info_t._fields_ = [
     ('fabric_version', ctypes.c_uint32),
     ('fabric_info', union_fabric_info_),
     ('reserved', ctypes.c_uint32 * 15),
-    ('PADDING_0', ctypes.c_ubyte * 4),
 ]
 
 amdsmi_fabric_info_t = struct_amdsmi_fabric_info_t
@@ -3873,6 +3907,118 @@ try:
     amdsmi_get_gpu_fabric_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_fabric_info
     amdsmi_get_gpu_fabric_info.restype = amdsmi_status_t
     amdsmi_get_gpu_fabric_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_fabric_info_t)]
+except AttributeError:
+    pass
+
+# values for enumeration 'amdsmi_fabric_config_version_t'
+amdsmi_fabric_config_version_t__enumvalues = {
+    1: 'AMDSMI_FABRIC_PPOD_CONFIG_V1',
+    1: 'AMDSMI_FABRIC_VPOD_CONFIG_V1',
+    1: 'AMDSMI_FABRIC_STATION_CONFIG_V1',
+}
+AMDSMI_FABRIC_PPOD_CONFIG_V1 = 1
+AMDSMI_FABRIC_VPOD_CONFIG_V1 = 1
+AMDSMI_FABRIC_STATION_CONFIG_V1 = 1
+amdsmi_fabric_config_version_t = ctypes.c_uint32 # enum
+
+# values for enumeration 'amdsmi_fabric_ppod_field_t'
+amdsmi_fabric_ppod_field_t__enumvalues = {
+    1: 'AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID',
+    2: 'AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID',
+    4: 'AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE',
+    8: 'AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS',
+    16: 'AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH',
+    32: 'AMDSMI_FABRIC_PPOD_FIELD_LATENCY',
+}
+AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID = 1
+AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID = 2
+AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE = 4
+AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS = 8
+AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH = 16
+AMDSMI_FABRIC_PPOD_FIELD_LATENCY = 32
+amdsmi_fabric_ppod_field_t = ctypes.c_uint32 # enum
+
+# values for enumeration 'amdsmi_fabric_vpod_field_t'
+amdsmi_fabric_vpod_field_t__enumvalues = {
+    1: 'AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID',
+    2: 'AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE',
+    4: 'AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS',
+    8: 'AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE',
+}
+AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID = 1
+AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE = 2
+AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS = 4
+AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE = 8
+amdsmi_fabric_vpod_field_t = ctypes.c_uint32 # enum
+
+# values for enumeration 'amdsmi_fabric_df_field_t'
+amdsmi_fabric_df_field_t__enumvalues = {
+    1: 'AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS',
+    2: 'AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP',
+    4: 'AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS',
+}
+AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS = 1
+AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP = 2
+AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS = 4
+amdsmi_fabric_df_field_t = ctypes.c_uint32 # enum
+class struct_amdsmi_fabric_ppod_config_t(Structure):
+    pass
+
+struct_amdsmi_fabric_ppod_config_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_ppod_config_t._layout_ = 'ms'
+struct_amdsmi_fabric_ppod_config_t._fields_ = [
+    ('version', ctypes.c_uint32),
+    ('mask', ctypes.c_uint32),
+    ('commit', ctypes.c_bool),
+    ('PADDING_0', ctypes.c_ubyte * 3),
+    ('data', amdsmi_fabric_ppod_data_t),
+]
+
+amdsmi_fabric_ppod_config_t = struct_amdsmi_fabric_ppod_config_t
+class struct_amdsmi_fabric_vpod_config_t(Structure):
+    pass
+
+struct_amdsmi_fabric_vpod_config_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_vpod_config_t._layout_ = 'ms'
+struct_amdsmi_fabric_vpod_config_t._fields_ = [
+    ('version', ctypes.c_uint32),
+    ('mask', ctypes.c_uint32),
+    ('commit', ctypes.c_bool),
+    ('PADDING_0', ctypes.c_ubyte * 3),
+    ('data', amdsmi_fabric_vpod_data_t),
+]
+
+amdsmi_fabric_vpod_config_t = struct_amdsmi_fabric_vpod_config_t
+class struct_amdsmi_fabric_station_config_t(Structure):
+    pass
+
+struct_amdsmi_fabric_station_config_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_station_config_t._layout_ = 'ms'
+struct_amdsmi_fabric_station_config_t._fields_ = [
+    ('version', ctypes.c_uint32),
+    ('mask', ctypes.c_uint32),
+    ('commit', ctypes.c_bool),
+    ('PADDING_0', ctypes.c_ubyte * 3),
+    ('data', amdsmi_fabric_station_data_t),
+]
+
+amdsmi_fabric_station_config_t = struct_amdsmi_fabric_station_config_t
+try:
+    amdsmi_set_gpu_fabric_ppod_config = _libraries['libamd_smi.so'].amdsmi_set_gpu_fabric_ppod_config
+    amdsmi_set_gpu_fabric_ppod_config.restype = amdsmi_status_t
+    amdsmi_set_gpu_fabric_ppod_config.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_fabric_ppod_config_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_fabric_vpod_config = _libraries['libamd_smi.so'].amdsmi_set_gpu_fabric_vpod_config
+    amdsmi_set_gpu_fabric_vpod_config.restype = amdsmi_status_t
+    amdsmi_set_gpu_fabric_vpod_config.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_fabric_vpod_config_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_fabric_station_config = _libraries['libamd_smi.so'].amdsmi_set_gpu_fabric_station_config
+    amdsmi_set_gpu_fabric_station_config.restype = amdsmi_status_t
+    amdsmi_set_gpu_fabric_station_config.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_fabric_station_config_t)]
 except AttributeError:
     pass
 try:
@@ -4995,10 +5141,21 @@ __all__ = \
     'AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNCONFIGURED',
     'AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN',
     'AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE',
-    'AMDSMI_FABRIC_MAX_LOCAL_GPUS',
+    'AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP',
+    'AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS',
+    'AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS',
+    'AMDSMI_FABRIC_MAX_BITMAP_SIZE', 'AMDSMI_FABRIC_MAX_LOCAL_GPUS',
     'AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING',
     'AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_IDENTIFICATION',
     'AMDSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN',
+    'AMDSMI_FABRIC_PPOD_CONFIG_V1',
+    'AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID',
+    'AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH',
+    'AMDSMI_FABRIC_PPOD_FIELD_LATENCY',
+    'AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS',
+    'AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID',
+    'AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE',
+    'AMDSMI_FABRIC_STATION_CONFIG_V1',
     'AMDSMI_FABRIC_TELEMETRY_CATEGORY_CRYPTO',
     'AMDSMI_FABRIC_TELEMETRY_CATEGORY_DERIVED_NETPORT',
     'AMDSMI_FABRIC_TELEMETRY_CATEGORY_DERIVED_UALOE',
@@ -5019,6 +5176,11 @@ __all__ = \
     'AMDSMI_FABRIC_TELEMETRY_CATEGORY_UNKNOWN',
     'AMDSMI_FABRIC_TYPE_UALINK', 'AMDSMI_FABRIC_TYPE_UALLINK',
     'AMDSMI_FABRIC_TYPE_UALOE', 'AMDSMI_FABRIC_TYPE_UNKNOWN',
+    'AMDSMI_FABRIC_VPOD_CONFIG_V1',
+    'AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE',
+    'AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS',
+    'AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID',
+    'AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE',
     'AMDSMI_FINE_DECODER_ACTIVITY', 'AMDSMI_FINE_GRAIN_GFX_ACTIVITY',
     'AMDSMI_FINE_GRAIN_MEM_ACTIVITY', 'AMDSMI_FREQ_IND_INVALID',
     'AMDSMI_FREQ_IND_MAX', 'AMDSMI_FREQ_IND_MIN', 'AMDSMI_FW_ID_ASD',
@@ -5276,17 +5438,22 @@ __all__ = \
     'amdsmi_event_group_t', 'amdsmi_event_handle_t',
     'amdsmi_event_type_t', 'amdsmi_evt_notification_data_t',
     'amdsmi_evt_notification_type_t',
-    'amdsmi_fabric_accelerator_vpod_state_t', 'amdsmi_fabric_info_t',
-    'amdsmi_fabric_info_v1_t', 'amdsmi_fabric_label_t',
-    'amdsmi_fabric_npa_address_mode_t',
-    'amdsmi_fabric_size_constants_t',
+    'amdsmi_fabric_accelerator_vpod_state_t',
+    'amdsmi_fabric_config_version_t', 'amdsmi_fabric_df_field_t',
+    'amdsmi_fabric_info_t', 'amdsmi_fabric_info_v1_t',
+    'amdsmi_fabric_label_t', 'amdsmi_fabric_npa_address_mode_t',
+    'amdsmi_fabric_ppod_config_t', 'amdsmi_fabric_ppod_data_t',
+    'amdsmi_fabric_ppod_field_t', 'amdsmi_fabric_size_constants_t',
+    'amdsmi_fabric_station_config_t', 'amdsmi_fabric_station_data_t',
     'amdsmi_fabric_telem_id_to_string',
     'amdsmi_fabric_telemetry_category_mask_t',
     'amdsmi_fabric_telemetry_category_t',
     'amdsmi_fabric_telemetry_dataset_t',
     'amdsmi_fabric_telemetry_instance_t',
     'amdsmi_fabric_telemetry_item_t', 'amdsmi_fabric_telemetry_t',
-    'amdsmi_fabric_type_t', 'amdsmi_first_online_core_on_cpu_socket',
+    'amdsmi_fabric_type_t', 'amdsmi_fabric_vpod_config_t',
+    'amdsmi_fabric_vpod_data_t', 'amdsmi_fabric_vpod_field_t',
+    'amdsmi_first_online_core_on_cpu_socket',
     'amdsmi_free_fabric_telemetry', 'amdsmi_freq_ind_t',
     'amdsmi_freq_volt_region_t', 'amdsmi_frequencies_t',
     'amdsmi_frequency_range_t', 'amdsmi_fw_block_t',
@@ -5465,7 +5632,10 @@ __all__ = \
     'amdsmi_set_gpu_clk_limit', 'amdsmi_set_gpu_compute_partition',
     'amdsmi_set_gpu_compute_partition_mem_alloc_mode',
     'amdsmi_set_gpu_event_notification_mask',
-    'amdsmi_set_gpu_fan_speed', 'amdsmi_set_gpu_memory_partition',
+    'amdsmi_set_gpu_fabric_ppod_config',
+    'amdsmi_set_gpu_fabric_station_config',
+    'amdsmi_set_gpu_fabric_vpod_config', 'amdsmi_set_gpu_fan_speed',
+    'amdsmi_set_gpu_memory_partition',
     'amdsmi_set_gpu_memory_partition_mode',
     'amdsmi_set_gpu_od_clk_info', 'amdsmi_set_gpu_od_volt_info',
     'amdsmi_set_gpu_overdrive_level', 'amdsmi_set_gpu_pci_bandwidth',
@@ -5511,10 +5681,16 @@ __all__ = \
     'struct_amdsmi_evt_notification_data_t',
     'struct_amdsmi_fabric_info_t', 'struct_amdsmi_fabric_info_v1_t',
     'struct_amdsmi_fabric_label_t',
+    'struct_amdsmi_fabric_ppod_config_t',
+    'struct_amdsmi_fabric_ppod_data_t',
+    'struct_amdsmi_fabric_station_config_t',
+    'struct_amdsmi_fabric_station_data_t',
     'struct_amdsmi_fabric_telemetry_dataset_t',
     'struct_amdsmi_fabric_telemetry_instance_t',
     'struct_amdsmi_fabric_telemetry_item_t',
     'struct_amdsmi_fabric_telemetry_t',
+    'struct_amdsmi_fabric_vpod_config_t',
+    'struct_amdsmi_fabric_vpod_data_t',
     'struct_amdsmi_freq_volt_region_t', 'struct_amdsmi_frequencies_t',
     'struct_amdsmi_frequency_range_t', 'struct_amdsmi_fw_info_t',
     'struct_amdsmi_gpu_cache_info_t', 'struct_amdsmi_gpu_metrics_t',

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -3783,10 +3783,12 @@ amdsmi_fabric_size_constants_t__enumvalues = {
     32: 'AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE',
     16: 'AMDSMI_FABRIC_MAX_LOCAL_GPUS',
     64: 'AMDSMI_FABRIC_MAX_BITMAP_SIZE',
+    37: 'AMDSMI_FABRIC_INFO_V2_RESERVED_WORDS',
 }
 AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE = 32
 AMDSMI_FABRIC_MAX_LOCAL_GPUS = 16
 AMDSMI_FABRIC_MAX_BITMAP_SIZE = 64
+AMDSMI_FABRIC_INFO_V2_RESERVED_WORDS = 37
 amdsmi_fabric_size_constants_t = ctypes.c_uint32 # enum
 
 # values for enumeration 'amdsmi_fabric_type_t'
@@ -3872,17 +3874,53 @@ struct_amdsmi_fabric_station_data_t._fields_ = [
 
 amdsmi_fabric_station_data_t = struct_amdsmi_fabric_station_data_t
 class struct_amdsmi_fabric_info_v1_t(Structure):
-    _pack_ = 1 # source:False
-    _layout_ = 'ms'
-    _fields_ = [
+    pass
+
+struct_amdsmi_fabric_info_v1_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_info_v1_t._layout_ = 'ms'
+struct_amdsmi_fabric_info_v1_t._fields_ = [
+    ('accelerator_id', ctypes.c_uint32),
+    ('fabric_type', amdsmi_fabric_type_t),
+    ('bandwidth', ctypes.c_uint32),
+    ('latency', ctypes.c_uint32),
+    ('ppod_id', ctypes.c_ubyte * 16),
+    ('ppod_size', ctypes.c_uint32),
+    ('vpod_id', ctypes.c_uint32),
+    ('vpod_size', ctypes.c_uint32),
+    ('vpod_active_accelerators', ctypes.c_uint32 * 32),
+    ('local_accelerators', ctypes.c_uint32 * 16),
+    ('addr_mode', amdsmi_fabric_npa_address_mode_t),
+    ('accel_state', amdsmi_fabric_accelerator_vpod_state_t),
+]
+
+amdsmi_fabric_info_v1_t = struct_amdsmi_fabric_info_v1_t
+class struct_amdsmi_fabric_info_v2_t(Structure):
+    pass
+
+struct_amdsmi_fabric_info_v2_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_info_v2_t._layout_ = 'ms'
+struct_amdsmi_fabric_info_v2_t._fields_ = [
     ('fabric_type', amdsmi_fabric_type_t),
     ('accel_state', amdsmi_fabric_accelerator_vpod_state_t),
     ('ppod', amdsmi_fabric_ppod_data_t),
     ('vpod', amdsmi_fabric_vpod_data_t),
     ('station', amdsmi_fabric_station_data_t),
-     ]
+    ('ppod_mask', ctypes.c_uint32),
+    ('vpod_mask', ctypes.c_uint32),
+    ('station_mask', ctypes.c_uint32),
+    ('reserved', ctypes.c_uint32 * 37),
+]
 
-amdsmi_fabric_info_v1_t = struct_amdsmi_fabric_info_v1_t
+amdsmi_fabric_info_v2_t = struct_amdsmi_fabric_info_v2_t
+
+# values for enumeration 'amdsmi_fabric_info_version_t'
+amdsmi_fabric_info_version_t__enumvalues = {
+    0: 'AMDSMI_FABRIC_INFO_VERSION_1',
+    4205903874: 'AMDSMI_FABRIC_INFO_VERSION_2',
+}
+AMDSMI_FABRIC_INFO_VERSION_1 = 0
+AMDSMI_FABRIC_INFO_VERSION_2 = 4205903874
+amdsmi_fabric_info_version_t = ctypes.c_uint32 # enum
 class struct_amdsmi_fabric_info_t(Structure):
     pass
 
@@ -3891,6 +3929,7 @@ class union_fabric_info_(Union):
     _layout_ = 'ms'
     _fields_ = [
     ('v1', amdsmi_fabric_info_v1_t),
+    ('v2', amdsmi_fabric_info_v2_t),
      ]
 
 struct_amdsmi_fabric_info_t._pack_ = 1 # source:False
@@ -5144,6 +5183,8 @@ __all__ = \
     'AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP',
     'AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS',
     'AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS',
+    'AMDSMI_FABRIC_INFO_V2_RESERVED_WORDS',
+    'AMDSMI_FABRIC_INFO_VERSION_1', 'AMDSMI_FABRIC_INFO_VERSION_2',
     'AMDSMI_FABRIC_MAX_BITMAP_SIZE', 'AMDSMI_FABRIC_MAX_LOCAL_GPUS',
     'AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING',
     'AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_IDENTIFICATION',
@@ -5441,6 +5482,7 @@ __all__ = \
     'amdsmi_fabric_accelerator_vpod_state_t',
     'amdsmi_fabric_config_version_t', 'amdsmi_fabric_df_field_t',
     'amdsmi_fabric_info_t', 'amdsmi_fabric_info_v1_t',
+    'amdsmi_fabric_info_v2_t', 'amdsmi_fabric_info_version_t',
     'amdsmi_fabric_label_t', 'amdsmi_fabric_npa_address_mode_t',
     'amdsmi_fabric_ppod_config_t', 'amdsmi_fabric_ppod_data_t',
     'amdsmi_fabric_ppod_field_t', 'amdsmi_fabric_size_constants_t',
@@ -5680,7 +5722,7 @@ __all__ = \
     'struct_amdsmi_enumeration_info_t', 'struct_amdsmi_error_count_t',
     'struct_amdsmi_evt_notification_data_t',
     'struct_amdsmi_fabric_info_t', 'struct_amdsmi_fabric_info_v1_t',
-    'struct_amdsmi_fabric_label_t',
+    'struct_amdsmi_fabric_info_v2_t', 'struct_amdsmi_fabric_label_t',
     'struct_amdsmi_fabric_ppod_config_t',
     'struct_amdsmi_fabric_ppod_data_t',
     'struct_amdsmi_fabric_station_config_t',

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -4471,6 +4471,7 @@ extern "C" {
 pub enum AmdsmiFabricSizeConstantsT {
     AmdsmiFabricActiveAcceleratorsBitmapSize = 32,
     AmdsmiFabricMaxLocalGpus = 16,
+    AmdsmiFabricMaxBitmapSize = 64,
 }
 impl AmdsmiFabricTypeT {
     pub const AmdsmiFabricTypeUallink: AmdsmiFabricTypeT =
@@ -4502,48 +4503,100 @@ pub enum AmdsmiFabricAcceleratorVpodStateT {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct AmdsmiFabricInfoV1T {
+pub struct AmdsmiFabricPpodDataT {
     pub accelerator_id: u32,
-    pub fabric_type: AmdsmiFabricTypeT,
-    pub bandwidth: u32,
-    pub latency: u32,
     pub ppod_id: [u8; 16usize],
     pub ppod_size: u32,
-    pub vpod_id: u32,
-    pub vpod_size: u32,
-    pub vpod_active_accelerators: [u32; 32usize],
     pub local_accelerators: [u32; 16usize],
-    pub addr_mode: AmdsmiFabricNpaAddressModeT,
-    pub accel_state: AmdsmiFabricAcceleratorVpodStateT,
+    pub local_accelerator_count: u32,
+    pub bandwidth: u32,
+    pub latency: u32,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiFabricInfoV1T"][::std::mem::size_of::<AmdsmiFabricInfoV1T>() - 244usize];
+    ["Size of AmdsmiFabricPpodDataT"][::std::mem::size_of::<AmdsmiFabricPpodDataT>() - 100usize];
+    ["Alignment of AmdsmiFabricPpodDataT"]
+        [::std::mem::align_of::<AmdsmiFabricPpodDataT>() - 4usize];
+    ["Offset of field: AmdsmiFabricPpodDataT::accelerator_id"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodDataT, accelerator_id) - 0usize];
+    ["Offset of field: AmdsmiFabricPpodDataT::ppod_id"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodDataT, ppod_id) - 4usize];
+    ["Offset of field: AmdsmiFabricPpodDataT::ppod_size"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodDataT, ppod_size) - 20usize];
+    ["Offset of field: AmdsmiFabricPpodDataT::local_accelerators"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodDataT, local_accelerators) - 24usize];
+    ["Offset of field: AmdsmiFabricPpodDataT::local_accelerator_count"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodDataT, local_accelerator_count) - 88usize];
+    ["Offset of field: AmdsmiFabricPpodDataT::bandwidth"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodDataT, bandwidth) - 92usize];
+    ["Offset of field: AmdsmiFabricPpodDataT::latency"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodDataT, latency) - 96usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricVpodDataT {
+    pub vpod_id: u32,
+    pub vpod_size: u32,
+    pub vpod_active_accelerators: [u32; 32usize],
+    pub addr_mode: AmdsmiFabricNpaAddressModeT,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricVpodDataT"][::std::mem::size_of::<AmdsmiFabricVpodDataT>() - 140usize];
+    ["Alignment of AmdsmiFabricVpodDataT"]
+        [::std::mem::align_of::<AmdsmiFabricVpodDataT>() - 4usize];
+    ["Offset of field: AmdsmiFabricVpodDataT::vpod_id"]
+        [::std::mem::offset_of!(AmdsmiFabricVpodDataT, vpod_id) - 0usize];
+    ["Offset of field: AmdsmiFabricVpodDataT::vpod_size"]
+        [::std::mem::offset_of!(AmdsmiFabricVpodDataT, vpod_size) - 4usize];
+    ["Offset of field: AmdsmiFabricVpodDataT::vpod_active_accelerators"]
+        [::std::mem::offset_of!(AmdsmiFabricVpodDataT, vpod_active_accelerators) - 8usize];
+    ["Offset of field: AmdsmiFabricVpodDataT::addr_mode"]
+        [::std::mem::offset_of!(AmdsmiFabricVpodDataT, addr_mode) - 136usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricStationDataT {
+    pub station_flags: u32,
+    pub num_stations: u8,
+    pub lane_en_bitmap: [u8; 64usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricStationDataT"]
+        [::std::mem::size_of::<AmdsmiFabricStationDataT>() - 72usize];
+    ["Alignment of AmdsmiFabricStationDataT"]
+        [::std::mem::align_of::<AmdsmiFabricStationDataT>() - 4usize];
+    ["Offset of field: AmdsmiFabricStationDataT::station_flags"]
+        [::std::mem::offset_of!(AmdsmiFabricStationDataT, station_flags) - 0usize];
+    ["Offset of field: AmdsmiFabricStationDataT::num_stations"]
+        [::std::mem::offset_of!(AmdsmiFabricStationDataT, num_stations) - 4usize];
+    ["Offset of field: AmdsmiFabricStationDataT::lane_en_bitmap"]
+        [::std::mem::offset_of!(AmdsmiFabricStationDataT, lane_en_bitmap) - 5usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricInfoV1T {
+    pub fabric_type: AmdsmiFabricTypeT,
+    pub accel_state: AmdsmiFabricAcceleratorVpodStateT,
+    pub ppod: AmdsmiFabricPpodDataT,
+    pub vpod: AmdsmiFabricVpodDataT,
+    pub station: AmdsmiFabricStationDataT,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricInfoV1T"][::std::mem::size_of::<AmdsmiFabricInfoV1T>() - 320usize];
     ["Alignment of AmdsmiFabricInfoV1T"][::std::mem::align_of::<AmdsmiFabricInfoV1T>() - 4usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::accelerator_id"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, accelerator_id) - 0usize];
     ["Offset of field: AmdsmiFabricInfoV1T::fabric_type"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, fabric_type) - 4usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::bandwidth"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, bandwidth) - 8usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::latency"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, latency) - 12usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::ppod_id"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, ppod_id) - 16usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::ppod_size"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, ppod_size) - 32usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::vpod_id"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod_id) - 36usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::vpod_size"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod_size) - 40usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::vpod_active_accelerators"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod_active_accelerators) - 44usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::local_accelerators"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, local_accelerators) - 172usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::addr_mode"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, addr_mode) - 236usize];
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, fabric_type) - 0usize];
     ["Offset of field: AmdsmiFabricInfoV1T::accel_state"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, accel_state) - 240usize];
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, accel_state) - 4usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::ppod"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, ppod) - 8usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::vpod"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod) - 108usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::station"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, station) - 248usize];
 };
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -4561,7 +4614,7 @@ pub union AmdsmiFabricInfoTFabricInfo {
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AmdsmiFabricInfoTFabricInfo"]
-        [::std::mem::size_of::<AmdsmiFabricInfoTFabricInfo>() - 244usize];
+        [::std::mem::size_of::<AmdsmiFabricInfoTFabricInfo>() - 320usize];
     ["Alignment of AmdsmiFabricInfoTFabricInfo"]
         [::std::mem::align_of::<AmdsmiFabricInfoTFabricInfo>() - 4usize];
     ["Offset of field: AmdsmiFabricInfoTFabricInfo::v1"]
@@ -4569,7 +4622,7 @@ const _: () = {
 };
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiFabricInfoT"][::std::mem::size_of::<AmdsmiFabricInfoT>() - 320usize];
+    ["Size of AmdsmiFabricInfoT"][::std::mem::size_of::<AmdsmiFabricInfoT>() - 392usize];
     ["Alignment of AmdsmiFabricInfoT"][::std::mem::align_of::<AmdsmiFabricInfoT>() - 8usize];
     ["Offset of field: AmdsmiFabricInfoT::bdf"]
         [::std::mem::offset_of!(AmdsmiFabricInfoT, bdf) - 0usize];
@@ -4578,12 +4631,137 @@ const _: () = {
     ["Offset of field: AmdsmiFabricInfoT::fabric_info"]
         [::std::mem::offset_of!(AmdsmiFabricInfoT, fabric_info) - 12usize];
     ["Offset of field: AmdsmiFabricInfoT::reserved"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoT, reserved) - 256usize];
+        [::std::mem::offset_of!(AmdsmiFabricInfoT, reserved) - 332usize];
 };
 extern "C" {
     pub fn amdsmi_get_gpu_fabric_info(
         processor_handle: AmdsmiProcessorHandle,
         info: *mut AmdsmiFabricInfoT,
+    ) -> AmdsmiStatusT;
+}
+impl AmdsmiFabricConfigVersionT {
+    pub const AmdsmiFabricVpodConfigV1: AmdsmiFabricConfigVersionT =
+        AmdsmiFabricConfigVersionT::AmdsmiFabricPpodConfigV1;
+}
+impl AmdsmiFabricConfigVersionT {
+    pub const AmdsmiFabricStationConfigV1: AmdsmiFabricConfigVersionT =
+        AmdsmiFabricConfigVersionT::AmdsmiFabricPpodConfigV1;
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiFabricConfigVersionT {
+    AmdsmiFabricPpodConfigV1 = 1,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiFabricPpodFieldT {
+    AmdsmiFabricPpodFieldAccelId = 1,
+    AmdsmiFabricPpodFieldPpodId = 2,
+    AmdsmiFabricPpodFieldPpodSize = 4,
+    AmdsmiFabricPpodFieldLocalAccels = 8,
+    AmdsmiFabricPpodFieldBandwidth = 16,
+    AmdsmiFabricPpodFieldLatency = 32,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiFabricVpodFieldT {
+    AmdsmiFabricVpodFieldVpodId = 1,
+    AmdsmiFabricVpodFieldVpodSize = 2,
+    AmdsmiFabricVpodFieldVpodActiveAccels = 4,
+    AmdsmiFabricVpodFieldAddrMode = 8,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiFabricDfFieldT {
+    AmdsmiFabricDfFieldStationFlags = 1,
+    AmdsmiFabricDfFieldLaneEnBitmap = 2,
+    AmdsmiFabricDfFieldNumStations = 4,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricPpodConfigT {
+    pub version: u32,
+    pub mask: u32,
+    pub commit: bool,
+    pub data: AmdsmiFabricPpodDataT,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricPpodConfigT"]
+        [::std::mem::size_of::<AmdsmiFabricPpodConfigT>() - 112usize];
+    ["Alignment of AmdsmiFabricPpodConfigT"]
+        [::std::mem::align_of::<AmdsmiFabricPpodConfigT>() - 4usize];
+    ["Offset of field: AmdsmiFabricPpodConfigT::version"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodConfigT, version) - 0usize];
+    ["Offset of field: AmdsmiFabricPpodConfigT::mask"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodConfigT, mask) - 4usize];
+    ["Offset of field: AmdsmiFabricPpodConfigT::commit"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodConfigT, commit) - 8usize];
+    ["Offset of field: AmdsmiFabricPpodConfigT::data"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodConfigT, data) - 12usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricVpodConfigT {
+    pub version: u32,
+    pub mask: u32,
+    pub commit: bool,
+    pub data: AmdsmiFabricVpodDataT,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricVpodConfigT"]
+        [::std::mem::size_of::<AmdsmiFabricVpodConfigT>() - 152usize];
+    ["Alignment of AmdsmiFabricVpodConfigT"]
+        [::std::mem::align_of::<AmdsmiFabricVpodConfigT>() - 4usize];
+    ["Offset of field: AmdsmiFabricVpodConfigT::version"]
+        [::std::mem::offset_of!(AmdsmiFabricVpodConfigT, version) - 0usize];
+    ["Offset of field: AmdsmiFabricVpodConfigT::mask"]
+        [::std::mem::offset_of!(AmdsmiFabricVpodConfigT, mask) - 4usize];
+    ["Offset of field: AmdsmiFabricVpodConfigT::commit"]
+        [::std::mem::offset_of!(AmdsmiFabricVpodConfigT, commit) - 8usize];
+    ["Offset of field: AmdsmiFabricVpodConfigT::data"]
+        [::std::mem::offset_of!(AmdsmiFabricVpodConfigT, data) - 12usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricStationConfigT {
+    pub version: u32,
+    pub mask: u32,
+    pub commit: bool,
+    pub data: AmdsmiFabricStationDataT,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricStationConfigT"]
+        [::std::mem::size_of::<AmdsmiFabricStationConfigT>() - 84usize];
+    ["Alignment of AmdsmiFabricStationConfigT"]
+        [::std::mem::align_of::<AmdsmiFabricStationConfigT>() - 4usize];
+    ["Offset of field: AmdsmiFabricStationConfigT::version"]
+        [::std::mem::offset_of!(AmdsmiFabricStationConfigT, version) - 0usize];
+    ["Offset of field: AmdsmiFabricStationConfigT::mask"]
+        [::std::mem::offset_of!(AmdsmiFabricStationConfigT, mask) - 4usize];
+    ["Offset of field: AmdsmiFabricStationConfigT::commit"]
+        [::std::mem::offset_of!(AmdsmiFabricStationConfigT, commit) - 8usize];
+    ["Offset of field: AmdsmiFabricStationConfigT::data"]
+        [::std::mem::offset_of!(AmdsmiFabricStationConfigT, data) - 12usize];
+};
+extern "C" {
+    pub fn amdsmi_set_gpu_fabric_ppod_config(
+        processor_handle: AmdsmiProcessorHandle,
+        config: *const AmdsmiFabricPpodConfigT,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_set_gpu_fabric_vpod_config(
+        processor_handle: AmdsmiProcessorHandle,
+        config: *const AmdsmiFabricVpodConfigT,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_set_gpu_fabric_station_config(
+        processor_handle: AmdsmiProcessorHandle,
+        config: *const AmdsmiFabricStationConfigT,
     ) -> AmdsmiStatusT;
 }
 extern "C" {

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -4472,6 +4472,7 @@ pub enum AmdsmiFabricSizeConstantsT {
     AmdsmiFabricActiveAcceleratorsBitmapSize = 32,
     AmdsmiFabricMaxLocalGpus = 16,
     AmdsmiFabricMaxBitmapSize = 64,
+    AmdsmiFabricInfoV2ReservedWords = 37,
 }
 impl AmdsmiFabricTypeT {
     pub const AmdsmiFabricTypeUallink: AmdsmiFabricTypeT =
@@ -4577,27 +4578,90 @@ const _: () = {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct AmdsmiFabricInfoV1T {
+    pub accelerator_id: u32,
+    pub fabric_type: AmdsmiFabricTypeT,
+    pub bandwidth: u32,
+    pub latency: u32,
+    pub ppod_id: [u8; 16usize],
+    pub ppod_size: u32,
+    pub vpod_id: u32,
+    pub vpod_size: u32,
+    pub vpod_active_accelerators: [u32; 32usize],
+    pub local_accelerators: [u32; 16usize],
+    pub addr_mode: AmdsmiFabricNpaAddressModeT,
+    pub accel_state: AmdsmiFabricAcceleratorVpodStateT,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricInfoV1T"][::std::mem::size_of::<AmdsmiFabricInfoV1T>() - 244usize];
+    ["Alignment of AmdsmiFabricInfoV1T"][::std::mem::align_of::<AmdsmiFabricInfoV1T>() - 4usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::accelerator_id"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, accelerator_id) - 0usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::fabric_type"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, fabric_type) - 4usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::bandwidth"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, bandwidth) - 8usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::latency"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, latency) - 12usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::ppod_id"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, ppod_id) - 16usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::ppod_size"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, ppod_size) - 32usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::vpod_id"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod_id) - 36usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::vpod_size"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod_size) - 40usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::vpod_active_accelerators"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod_active_accelerators) - 44usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::local_accelerators"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, local_accelerators) - 172usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::addr_mode"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, addr_mode) - 236usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::accel_state"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, accel_state) - 240usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricInfoV2T {
     pub fabric_type: AmdsmiFabricTypeT,
     pub accel_state: AmdsmiFabricAcceleratorVpodStateT,
     pub ppod: AmdsmiFabricPpodDataT,
     pub vpod: AmdsmiFabricVpodDataT,
     pub station: AmdsmiFabricStationDataT,
+    pub ppod_mask: u32,
+    pub vpod_mask: u32,
+    pub station_mask: u32,
+    pub reserved: [u32; 37usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiFabricInfoV1T"][::std::mem::size_of::<AmdsmiFabricInfoV1T>() - 320usize];
-    ["Alignment of AmdsmiFabricInfoV1T"][::std::mem::align_of::<AmdsmiFabricInfoV1T>() - 4usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::fabric_type"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, fabric_type) - 0usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::accel_state"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, accel_state) - 4usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::ppod"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, ppod) - 8usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::vpod"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod) - 108usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::station"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, station) - 248usize];
+    ["Size of AmdsmiFabricInfoV2T"][::std::mem::size_of::<AmdsmiFabricInfoV2T>() - 480usize];
+    ["Alignment of AmdsmiFabricInfoV2T"][::std::mem::align_of::<AmdsmiFabricInfoV2T>() - 4usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::fabric_type"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, fabric_type) - 0usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::accel_state"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, accel_state) - 4usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::ppod"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, ppod) - 8usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::vpod"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, vpod) - 108usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::station"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, station) - 248usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::ppod_mask"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, ppod_mask) - 320usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::vpod_mask"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, vpod_mask) - 324usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::station_mask"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, station_mask) - 328usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::reserved"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, reserved) - 332usize];
 };
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiFabricInfoVersionT {
+    AmdsmiFabricInfoVersion1 = 0,
+    AmdsmiFabricInfoVersion2 = 4205903874,
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct AmdsmiFabricInfoT {
@@ -4610,19 +4674,22 @@ pub struct AmdsmiFabricInfoT {
 #[derive(Copy, Clone)]
 pub union AmdsmiFabricInfoTFabricInfo {
     pub v1: AmdsmiFabricInfoV1T,
+    pub v2: AmdsmiFabricInfoV2T,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AmdsmiFabricInfoTFabricInfo"]
-        [::std::mem::size_of::<AmdsmiFabricInfoTFabricInfo>() - 320usize];
+        [::std::mem::size_of::<AmdsmiFabricInfoTFabricInfo>() - 480usize];
     ["Alignment of AmdsmiFabricInfoTFabricInfo"]
         [::std::mem::align_of::<AmdsmiFabricInfoTFabricInfo>() - 4usize];
     ["Offset of field: AmdsmiFabricInfoTFabricInfo::v1"]
         [::std::mem::offset_of!(AmdsmiFabricInfoTFabricInfo, v1) - 0usize];
+    ["Offset of field: AmdsmiFabricInfoTFabricInfo::v2"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoTFabricInfo, v2) - 0usize];
 };
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiFabricInfoT"][::std::mem::size_of::<AmdsmiFabricInfoT>() - 392usize];
+    ["Size of AmdsmiFabricInfoT"][::std::mem::size_of::<AmdsmiFabricInfoT>() - 552usize];
     ["Alignment of AmdsmiFabricInfoT"][::std::mem::align_of::<AmdsmiFabricInfoT>() - 8usize];
     ["Offset of field: AmdsmiFabricInfoT::bdf"]
         [::std::mem::offset_of!(AmdsmiFabricInfoT, bdf) - 0usize];
@@ -4631,7 +4698,7 @@ const _: () = {
     ["Offset of field: AmdsmiFabricInfoT::fabric_info"]
         [::std::mem::offset_of!(AmdsmiFabricInfoT, fabric_info) - 12usize];
     ["Offset of field: AmdsmiFabricInfoT::reserved"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoT, reserved) - 332usize];
+        [::std::mem::offset_of!(AmdsmiFabricInfoT, reserved) - 492usize];
 };
 extern "C" {
     pub fn amdsmi_get_gpu_fabric_info(

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -137,7 +137,7 @@ pub const AMDSMI_MAX_NUM_CLKS_PER_MID: u32 = 2;
 pub const AMDSMI_TIME_FORMAT: &[u8; 20] = b"%02d:%02d:%02d.%03d\0";
 pub const AMDSMI_DATE_FORMAT: &[u8; 35] = b"%04d-%02d-%02d:%02d:%02d:%02d.%03d\0";
 pub const AMDSMI_LIB_VERSION_MAJOR: u32 = 27;
-pub const AMDSMI_LIB_VERSION_MINOR: u32 = 0;
+pub const AMDSMI_LIB_VERSION_MINOR: u32 = 1;
 pub const AMDSMI_LIB_VERSION_RELEASE: u32 = 0;
 pub const AMDSMI_MAX_DRIVER_INFO_RSVD: u32 = 64;
 pub const AMDSMI_MAX_UUID_ELEMENTS: u32 = 16;
@@ -4430,6 +4430,7 @@ pub enum AmdsmiFabricSizeConstantsT {
     AmdsmiFabricActiveAcceleratorsBitmapSize = 32,
     AmdsmiFabricMaxLocalGpus = 16,
     AmdsmiFabricMaxBitmapSize = 64,
+    AmdsmiFabricInfoV2ReservedWords = 37,
 }
 impl AmdsmiFabricTypeT {
     pub const AmdsmiFabricTypeUallink: AmdsmiFabricTypeT =
@@ -4535,27 +4536,90 @@ const _: () = {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct AmdsmiFabricInfoV1T {
+    pub accelerator_id: u32,
+    pub fabric_type: AmdsmiFabricTypeT,
+    pub bandwidth: u32,
+    pub latency: u32,
+    pub ppod_id: [u8; 16usize],
+    pub ppod_size: u32,
+    pub vpod_id: u32,
+    pub vpod_size: u32,
+    pub vpod_active_accelerators: [u32; 32usize],
+    pub local_accelerators: [u32; 16usize],
+    pub addr_mode: AmdsmiFabricNpaAddressModeT,
+    pub accel_state: AmdsmiFabricAcceleratorVpodStateT,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricInfoV1T"][::std::mem::size_of::<AmdsmiFabricInfoV1T>() - 244usize];
+    ["Alignment of AmdsmiFabricInfoV1T"][::std::mem::align_of::<AmdsmiFabricInfoV1T>() - 4usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::accelerator_id"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, accelerator_id) - 0usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::fabric_type"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, fabric_type) - 4usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::bandwidth"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, bandwidth) - 8usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::latency"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, latency) - 12usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::ppod_id"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, ppod_id) - 16usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::ppod_size"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, ppod_size) - 32usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::vpod_id"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod_id) - 36usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::vpod_size"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod_size) - 40usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::vpod_active_accelerators"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod_active_accelerators) - 44usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::local_accelerators"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, local_accelerators) - 172usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::addr_mode"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, addr_mode) - 236usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::accel_state"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, accel_state) - 240usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricInfoV2T {
     pub fabric_type: AmdsmiFabricTypeT,
     pub accel_state: AmdsmiFabricAcceleratorVpodStateT,
     pub ppod: AmdsmiFabricPpodDataT,
     pub vpod: AmdsmiFabricVpodDataT,
     pub station: AmdsmiFabricStationDataT,
+    pub ppod_mask: u32,
+    pub vpod_mask: u32,
+    pub station_mask: u32,
+    pub reserved: [u32; 37usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiFabricInfoV1T"][::std::mem::size_of::<AmdsmiFabricInfoV1T>() - 320usize];
-    ["Alignment of AmdsmiFabricInfoV1T"][::std::mem::align_of::<AmdsmiFabricInfoV1T>() - 4usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::fabric_type"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, fabric_type) - 0usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::accel_state"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, accel_state) - 4usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::ppod"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, ppod) - 8usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::vpod"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod) - 108usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::station"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, station) - 248usize];
+    ["Size of AmdsmiFabricInfoV2T"][::std::mem::size_of::<AmdsmiFabricInfoV2T>() - 480usize];
+    ["Alignment of AmdsmiFabricInfoV2T"][::std::mem::align_of::<AmdsmiFabricInfoV2T>() - 4usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::fabric_type"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, fabric_type) - 0usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::accel_state"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, accel_state) - 4usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::ppod"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, ppod) - 8usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::vpod"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, vpod) - 108usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::station"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, station) - 248usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::ppod_mask"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, ppod_mask) - 320usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::vpod_mask"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, vpod_mask) - 324usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::station_mask"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, station_mask) - 328usize];
+    ["Offset of field: AmdsmiFabricInfoV2T::reserved"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV2T, reserved) - 332usize];
 };
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiFabricInfoVersionT {
+    AmdsmiFabricInfoVersion1 = 0,
+    AmdsmiFabricInfoVersion2 = 4205903874,
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct AmdsmiFabricInfoT {
@@ -4568,19 +4632,22 @@ pub struct AmdsmiFabricInfoT {
 #[derive(Copy, Clone)]
 pub union AmdsmiFabricInfoTFabricInfo {
     pub v1: AmdsmiFabricInfoV1T,
+    pub v2: AmdsmiFabricInfoV2T,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AmdsmiFabricInfoTFabricInfo"]
-        [::std::mem::size_of::<AmdsmiFabricInfoTFabricInfo>() - 320usize];
+        [::std::mem::size_of::<AmdsmiFabricInfoTFabricInfo>() - 480usize];
     ["Alignment of AmdsmiFabricInfoTFabricInfo"]
         [::std::mem::align_of::<AmdsmiFabricInfoTFabricInfo>() - 4usize];
     ["Offset of field: AmdsmiFabricInfoTFabricInfo::v1"]
         [::std::mem::offset_of!(AmdsmiFabricInfoTFabricInfo, v1) - 0usize];
+    ["Offset of field: AmdsmiFabricInfoTFabricInfo::v2"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoTFabricInfo, v2) - 0usize];
 };
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiFabricInfoT"][::std::mem::size_of::<AmdsmiFabricInfoT>() - 392usize];
+    ["Size of AmdsmiFabricInfoT"][::std::mem::size_of::<AmdsmiFabricInfoT>() - 552usize];
     ["Alignment of AmdsmiFabricInfoT"][::std::mem::align_of::<AmdsmiFabricInfoT>() - 8usize];
     ["Offset of field: AmdsmiFabricInfoT::bdf"]
         [::std::mem::offset_of!(AmdsmiFabricInfoT, bdf) - 0usize];
@@ -4589,7 +4656,7 @@ const _: () = {
     ["Offset of field: AmdsmiFabricInfoT::fabric_info"]
         [::std::mem::offset_of!(AmdsmiFabricInfoT, fabric_info) - 12usize];
     ["Offset of field: AmdsmiFabricInfoT::reserved"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoT, reserved) - 332usize];
+        [::std::mem::offset_of!(AmdsmiFabricInfoT, reserved) - 492usize];
 };
 extern "C" {
     pub fn amdsmi_get_gpu_fabric_info(

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -4429,6 +4429,7 @@ extern "C" {
 pub enum AmdsmiFabricSizeConstantsT {
     AmdsmiFabricActiveAcceleratorsBitmapSize = 32,
     AmdsmiFabricMaxLocalGpus = 16,
+    AmdsmiFabricMaxBitmapSize = 64,
 }
 impl AmdsmiFabricTypeT {
     pub const AmdsmiFabricTypeUallink: AmdsmiFabricTypeT =
@@ -4460,48 +4461,100 @@ pub enum AmdsmiFabricAcceleratorVpodStateT {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct AmdsmiFabricInfoV1T {
+pub struct AmdsmiFabricPpodDataT {
     pub accelerator_id: u32,
-    pub fabric_type: AmdsmiFabricTypeT,
-    pub bandwidth: u32,
-    pub latency: u32,
     pub ppod_id: [u8; 16usize],
     pub ppod_size: u32,
-    pub vpod_id: u32,
-    pub vpod_size: u32,
-    pub vpod_active_accelerators: [u32; 32usize],
     pub local_accelerators: [u32; 16usize],
-    pub addr_mode: AmdsmiFabricNpaAddressModeT,
-    pub accel_state: AmdsmiFabricAcceleratorVpodStateT,
+    pub local_accelerator_count: u32,
+    pub bandwidth: u32,
+    pub latency: u32,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiFabricInfoV1T"][::std::mem::size_of::<AmdsmiFabricInfoV1T>() - 244usize];
+    ["Size of AmdsmiFabricPpodDataT"][::std::mem::size_of::<AmdsmiFabricPpodDataT>() - 100usize];
+    ["Alignment of AmdsmiFabricPpodDataT"]
+        [::std::mem::align_of::<AmdsmiFabricPpodDataT>() - 4usize];
+    ["Offset of field: AmdsmiFabricPpodDataT::accelerator_id"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodDataT, accelerator_id) - 0usize];
+    ["Offset of field: AmdsmiFabricPpodDataT::ppod_id"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodDataT, ppod_id) - 4usize];
+    ["Offset of field: AmdsmiFabricPpodDataT::ppod_size"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodDataT, ppod_size) - 20usize];
+    ["Offset of field: AmdsmiFabricPpodDataT::local_accelerators"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodDataT, local_accelerators) - 24usize];
+    ["Offset of field: AmdsmiFabricPpodDataT::local_accelerator_count"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodDataT, local_accelerator_count) - 88usize];
+    ["Offset of field: AmdsmiFabricPpodDataT::bandwidth"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodDataT, bandwidth) - 92usize];
+    ["Offset of field: AmdsmiFabricPpodDataT::latency"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodDataT, latency) - 96usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricVpodDataT {
+    pub vpod_id: u32,
+    pub vpod_size: u32,
+    pub vpod_active_accelerators: [u32; 32usize],
+    pub addr_mode: AmdsmiFabricNpaAddressModeT,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricVpodDataT"][::std::mem::size_of::<AmdsmiFabricVpodDataT>() - 140usize];
+    ["Alignment of AmdsmiFabricVpodDataT"]
+        [::std::mem::align_of::<AmdsmiFabricVpodDataT>() - 4usize];
+    ["Offset of field: AmdsmiFabricVpodDataT::vpod_id"]
+        [::std::mem::offset_of!(AmdsmiFabricVpodDataT, vpod_id) - 0usize];
+    ["Offset of field: AmdsmiFabricVpodDataT::vpod_size"]
+        [::std::mem::offset_of!(AmdsmiFabricVpodDataT, vpod_size) - 4usize];
+    ["Offset of field: AmdsmiFabricVpodDataT::vpod_active_accelerators"]
+        [::std::mem::offset_of!(AmdsmiFabricVpodDataT, vpod_active_accelerators) - 8usize];
+    ["Offset of field: AmdsmiFabricVpodDataT::addr_mode"]
+        [::std::mem::offset_of!(AmdsmiFabricVpodDataT, addr_mode) - 136usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricStationDataT {
+    pub station_flags: u32,
+    pub num_stations: u8,
+    pub lane_en_bitmap: [u8; 64usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricStationDataT"]
+        [::std::mem::size_of::<AmdsmiFabricStationDataT>() - 72usize];
+    ["Alignment of AmdsmiFabricStationDataT"]
+        [::std::mem::align_of::<AmdsmiFabricStationDataT>() - 4usize];
+    ["Offset of field: AmdsmiFabricStationDataT::station_flags"]
+        [::std::mem::offset_of!(AmdsmiFabricStationDataT, station_flags) - 0usize];
+    ["Offset of field: AmdsmiFabricStationDataT::num_stations"]
+        [::std::mem::offset_of!(AmdsmiFabricStationDataT, num_stations) - 4usize];
+    ["Offset of field: AmdsmiFabricStationDataT::lane_en_bitmap"]
+        [::std::mem::offset_of!(AmdsmiFabricStationDataT, lane_en_bitmap) - 5usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricInfoV1T {
+    pub fabric_type: AmdsmiFabricTypeT,
+    pub accel_state: AmdsmiFabricAcceleratorVpodStateT,
+    pub ppod: AmdsmiFabricPpodDataT,
+    pub vpod: AmdsmiFabricVpodDataT,
+    pub station: AmdsmiFabricStationDataT,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricInfoV1T"][::std::mem::size_of::<AmdsmiFabricInfoV1T>() - 320usize];
     ["Alignment of AmdsmiFabricInfoV1T"][::std::mem::align_of::<AmdsmiFabricInfoV1T>() - 4usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::accelerator_id"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, accelerator_id) - 0usize];
     ["Offset of field: AmdsmiFabricInfoV1T::fabric_type"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, fabric_type) - 4usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::bandwidth"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, bandwidth) - 8usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::latency"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, latency) - 12usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::ppod_id"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, ppod_id) - 16usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::ppod_size"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, ppod_size) - 32usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::vpod_id"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod_id) - 36usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::vpod_size"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod_size) - 40usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::vpod_active_accelerators"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod_active_accelerators) - 44usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::local_accelerators"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, local_accelerators) - 172usize];
-    ["Offset of field: AmdsmiFabricInfoV1T::addr_mode"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, addr_mode) - 236usize];
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, fabric_type) - 0usize];
     ["Offset of field: AmdsmiFabricInfoV1T::accel_state"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, accel_state) - 240usize];
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, accel_state) - 4usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::ppod"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, ppod) - 8usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::vpod"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod) - 108usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::station"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, station) - 248usize];
 };
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -4519,7 +4572,7 @@ pub union AmdsmiFabricInfoTFabricInfo {
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AmdsmiFabricInfoTFabricInfo"]
-        [::std::mem::size_of::<AmdsmiFabricInfoTFabricInfo>() - 244usize];
+        [::std::mem::size_of::<AmdsmiFabricInfoTFabricInfo>() - 320usize];
     ["Alignment of AmdsmiFabricInfoTFabricInfo"]
         [::std::mem::align_of::<AmdsmiFabricInfoTFabricInfo>() - 4usize];
     ["Offset of field: AmdsmiFabricInfoTFabricInfo::v1"]
@@ -4527,7 +4580,7 @@ const _: () = {
 };
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiFabricInfoT"][::std::mem::size_of::<AmdsmiFabricInfoT>() - 320usize];
+    ["Size of AmdsmiFabricInfoT"][::std::mem::size_of::<AmdsmiFabricInfoT>() - 392usize];
     ["Alignment of AmdsmiFabricInfoT"][::std::mem::align_of::<AmdsmiFabricInfoT>() - 8usize];
     ["Offset of field: AmdsmiFabricInfoT::bdf"]
         [::std::mem::offset_of!(AmdsmiFabricInfoT, bdf) - 0usize];
@@ -4536,12 +4589,137 @@ const _: () = {
     ["Offset of field: AmdsmiFabricInfoT::fabric_info"]
         [::std::mem::offset_of!(AmdsmiFabricInfoT, fabric_info) - 12usize];
     ["Offset of field: AmdsmiFabricInfoT::reserved"]
-        [::std::mem::offset_of!(AmdsmiFabricInfoT, reserved) - 256usize];
+        [::std::mem::offset_of!(AmdsmiFabricInfoT, reserved) - 332usize];
 };
 extern "C" {
     pub fn amdsmi_get_gpu_fabric_info(
         processor_handle: AmdsmiProcessorHandle,
         info: *mut AmdsmiFabricInfoT,
+    ) -> AmdsmiStatusT;
+}
+impl AmdsmiFabricConfigVersionT {
+    pub const AmdsmiFabricVpodConfigV1: AmdsmiFabricConfigVersionT =
+        AmdsmiFabricConfigVersionT::AmdsmiFabricPpodConfigV1;
+}
+impl AmdsmiFabricConfigVersionT {
+    pub const AmdsmiFabricStationConfigV1: AmdsmiFabricConfigVersionT =
+        AmdsmiFabricConfigVersionT::AmdsmiFabricPpodConfigV1;
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiFabricConfigVersionT {
+    AmdsmiFabricPpodConfigV1 = 1,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiFabricPpodFieldT {
+    AmdsmiFabricPpodFieldAccelId = 1,
+    AmdsmiFabricPpodFieldPpodId = 2,
+    AmdsmiFabricPpodFieldPpodSize = 4,
+    AmdsmiFabricPpodFieldLocalAccels = 8,
+    AmdsmiFabricPpodFieldBandwidth = 16,
+    AmdsmiFabricPpodFieldLatency = 32,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiFabricVpodFieldT {
+    AmdsmiFabricVpodFieldVpodId = 1,
+    AmdsmiFabricVpodFieldVpodSize = 2,
+    AmdsmiFabricVpodFieldVpodActiveAccels = 4,
+    AmdsmiFabricVpodFieldAddrMode = 8,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiFabricDfFieldT {
+    AmdsmiFabricDfFieldStationFlags = 1,
+    AmdsmiFabricDfFieldLaneEnBitmap = 2,
+    AmdsmiFabricDfFieldNumStations = 4,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricPpodConfigT {
+    pub version: u32,
+    pub mask: u32,
+    pub commit: bool,
+    pub data: AmdsmiFabricPpodDataT,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricPpodConfigT"]
+        [::std::mem::size_of::<AmdsmiFabricPpodConfigT>() - 112usize];
+    ["Alignment of AmdsmiFabricPpodConfigT"]
+        [::std::mem::align_of::<AmdsmiFabricPpodConfigT>() - 4usize];
+    ["Offset of field: AmdsmiFabricPpodConfigT::version"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodConfigT, version) - 0usize];
+    ["Offset of field: AmdsmiFabricPpodConfigT::mask"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodConfigT, mask) - 4usize];
+    ["Offset of field: AmdsmiFabricPpodConfigT::commit"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodConfigT, commit) - 8usize];
+    ["Offset of field: AmdsmiFabricPpodConfigT::data"]
+        [::std::mem::offset_of!(AmdsmiFabricPpodConfigT, data) - 12usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricVpodConfigT {
+    pub version: u32,
+    pub mask: u32,
+    pub commit: bool,
+    pub data: AmdsmiFabricVpodDataT,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricVpodConfigT"]
+        [::std::mem::size_of::<AmdsmiFabricVpodConfigT>() - 152usize];
+    ["Alignment of AmdsmiFabricVpodConfigT"]
+        [::std::mem::align_of::<AmdsmiFabricVpodConfigT>() - 4usize];
+    ["Offset of field: AmdsmiFabricVpodConfigT::version"]
+        [::std::mem::offset_of!(AmdsmiFabricVpodConfigT, version) - 0usize];
+    ["Offset of field: AmdsmiFabricVpodConfigT::mask"]
+        [::std::mem::offset_of!(AmdsmiFabricVpodConfigT, mask) - 4usize];
+    ["Offset of field: AmdsmiFabricVpodConfigT::commit"]
+        [::std::mem::offset_of!(AmdsmiFabricVpodConfigT, commit) - 8usize];
+    ["Offset of field: AmdsmiFabricVpodConfigT::data"]
+        [::std::mem::offset_of!(AmdsmiFabricVpodConfigT, data) - 12usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricStationConfigT {
+    pub version: u32,
+    pub mask: u32,
+    pub commit: bool,
+    pub data: AmdsmiFabricStationDataT,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricStationConfigT"]
+        [::std::mem::size_of::<AmdsmiFabricStationConfigT>() - 84usize];
+    ["Alignment of AmdsmiFabricStationConfigT"]
+        [::std::mem::align_of::<AmdsmiFabricStationConfigT>() - 4usize];
+    ["Offset of field: AmdsmiFabricStationConfigT::version"]
+        [::std::mem::offset_of!(AmdsmiFabricStationConfigT, version) - 0usize];
+    ["Offset of field: AmdsmiFabricStationConfigT::mask"]
+        [::std::mem::offset_of!(AmdsmiFabricStationConfigT, mask) - 4usize];
+    ["Offset of field: AmdsmiFabricStationConfigT::commit"]
+        [::std::mem::offset_of!(AmdsmiFabricStationConfigT, commit) - 8usize];
+    ["Offset of field: AmdsmiFabricStationConfigT::data"]
+        [::std::mem::offset_of!(AmdsmiFabricStationConfigT, data) - 12usize];
+};
+extern "C" {
+    pub fn amdsmi_set_gpu_fabric_ppod_config(
+        processor_handle: AmdsmiProcessorHandle,
+        config: *const AmdsmiFabricPpodConfigT,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_set_gpu_fabric_vpod_config(
+        processor_handle: AmdsmiProcessorHandle,
+        config: *const AmdsmiFabricVpodConfigT,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_set_gpu_fabric_station_config(
+        processor_handle: AmdsmiProcessorHandle,
+        config: *const AmdsmiFabricStationConfigT,
     ) -> AmdsmiStatusT;
 }
 extern "C" {

--- a/projects/amdsmi/src/CMakeLists.txt
+++ b/projects/amdsmi/src/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SRC_LIST
     "${SRC_DIR}/amd_smi_cper.cc"
     "${SRC_DIR}/amd_smi_common.cc"
     "${SRC_DIR}/amd_smi_drm.cc"
+    "${SRC_DIR}/amd_smi_fabric_ualink.cc"
     "${SRC_DIR}/amd_smi_gpu_device.cc"
     "${SRC_DIR}/amd_smi_lib_loader.cc"
     "${SRC_DIR}/amd_smi_socket.cc"

--- a/projects/amdsmi/src/CMakeLists.txt
+++ b/projects/amdsmi/src/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SRC_LIST
     "${SRC_DIR}/amd_smi_cper.cc"
     "${SRC_DIR}/amd_smi_common.cc"
     "${SRC_DIR}/amd_smi_drm.cc"
+    "${SRC_DIR}/amd_smi_fabric_ualink.cc"
     "${SRC_DIR}/amd_smi_gpu_device.cc"
     "${SRC_DIR}/amd_smi_lib_loader.cc"
     "${SRC_DIR}/amd_smi_socket.cc"

--- a/projects/amdsmi/src/amd_smi/amd_smi_fabric_ualink.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_fabric_ualink.cc
@@ -1,0 +1,1146 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "amd_smi/impl/amd_smi_fabric_ualink.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cerrno>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include "amd_smi/impl/amd_smi_common.h"
+#include "amd_smi/impl/amd_smi_gpu_device.h"
+#include "rocm_smi/rocm_smi_logger.h"
+#include "rocm_smi/rocm_smi_utils.h"
+
+namespace amd::smi {
+
+namespace fabric_ualink {
+
+namespace {
+
+constexpr auto kPpodValidMask =
+    (AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID | AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID |
+     AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE | AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS |
+     AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH | AMDSMI_FABRIC_PPOD_FIELD_LATENCY);
+
+constexpr auto kVpodValidMask =
+    (AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID | AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE |
+     AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS | AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE);
+
+constexpr auto kStationValidMask =
+    (AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS | AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP |
+     AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS);
+
+// Driver commit payload (confirm with kernel if this changes).
+constexpr auto kFabricCommitPayload = "1";
+
+auto get_ualink_root(const AMDSmiGPUDevice& device) -> std::string {
+  return (std::string(kUALOE_BASE_PATH) + device.get_gpu_path() +
+          std::string(kUALOE_UALINK_DIRECTORY));
+}
+
+auto subdirectory_exists(const std::string& ualink_root, std::string_view subdir) -> bool {
+  const auto path = (std::filesystem::path(ualink_root) / subdir);
+  auto ec = std::error_code{};
+  return std::filesystem::is_directory(path, ec);
+}
+
+auto write_sysfs_string(const std::string& sysfs_path, const std::string& payload)
+    -> amdsmi_status_t {
+  auto outstream = std::ostringstream();
+  outstream << __func__ << " | path: " << sysfs_path << " | payload: " << payload;
+  LOG_DEBUG(outstream);
+
+  /**
+   *    std::ofstream does not guarantee errno on a failed open, so clear it first
+   *    to avoid mapping a stale value, and fall back to a generic file error when
+   *    the open fails without setting errno.
+   */
+  errno = 0;
+  auto sysfs_file_stream = std::ofstream(sysfs_path);
+  if (!sysfs_file_stream.good()) {
+    const auto saved_errno = errno;
+    errno = 0;
+    auto err = std::ostringstream();
+    err << __func__ << " | open failed | path: " << sysfs_path << " | errno: " << saved_errno;
+    LOG_ERROR(err);
+    return ((saved_errno != 0) ? rsmi_to_amdsmi_status(ErrnoToRsmiStatus(saved_errno))
+                               : amdsmi_status_t::AMDSMI_STATUS_FILE_ERROR);
+  }
+
+  // Buffered writes surface a driver rejection at flush/close, not open. Clear
+  // errno first so the logged value reflects this write and not a stale one.
+  errno = 0;
+  sysfs_file_stream << payload << "\n";
+  sysfs_file_stream.flush();
+  if (!sysfs_file_stream.good()) {
+    auto err = std::ostringstream();
+    err << __func__ << " | flush failed | path: " << sysfs_path << " | errno: " << errno;
+    LOG_ERROR(err);
+    return amdsmi_status_t::AMDSMI_STATUS_FILE_ERROR;
+  }
+
+  errno = 0;
+  sysfs_file_stream.close();
+  if (!sysfs_file_stream.good()) {
+    auto err = std::ostringstream();
+    err << __func__ << " | close failed | path: " << sysfs_path << " | errno: " << errno;
+    LOG_ERROR(err);
+    return amdsmi_status_t::AMDSMI_STATUS_FILE_ERROR;
+  }
+
+  return amdsmi_status_t::AMDSMI_STATUS_SUCCESS;
+}
+
+auto join_subdirectory_file(std::string_view subdir, std::string_view filename) -> std::string {
+  return (std::filesystem::path(subdir) / filename).string();
+}
+
+auto format_u32_decimal(uint32_t value) -> std::string { return (std::to_string(value)); }
+
+auto format_ppod_id(const uint8_t* ppod_id, std::size_t len) -> std::string {
+  auto outstream = std::ostringstream();
+  outstream << "0x";
+  for (auto idx = std::size_t(0); idx < len; ++idx) {
+    outstream << std::hex << std::setfill('0') << std::setw(2)
+              << static_cast<std::uint32_t>(ppod_id[idx]);
+  }
+
+  return outstream.str();
+}
+
+auto format_accel_list_space_separated(const uint32_t* accels, uint32_t count) -> std::string {
+  auto outstream = std::ostringstream();
+  for (auto idx = uint32_t(0); idx < count; ++idx) {
+    if (idx > 0) {
+      outstream << ' ';
+    }
+    outstream << accels[idx];
+  }
+  return outstream.str();
+}
+
+// Accelerator IDs are documented as 0..1023 (see amdsmi_fabric_ppod_data_t).
+constexpr auto kMaxAcceleratorId = uint32_t(1023);
+
+// Length of the leading accelerator-ID run, ending at the first UNSET sentinel.
+// Shared by the serializer and the range validator so both agree on the run.
+auto vpod_active_run_length(const uint32_t* accels, std::size_t capacity) -> std::size_t {
+  auto count = std::size_t(0);
+  while ((count < capacity) && (accels[count] != std::numeric_limits<uint32_t>::max())) {
+    ++count;
+  }
+  return count;
+}
+
+// True when every ID in [accels, accels + count) is within the valid range.
+auto accel_ids_in_range(const uint32_t* accels, std::size_t count) -> bool {
+  for (auto idx = std::size_t(0); idx < count; ++idx) {
+    if (accels[idx] > kMaxAcceleratorId) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Guard byte marking an unset ppod_id; the readback fill uses the same value so
+// a caller echoing back a fully-unset readback can be rejected on write.
+constexpr auto kPpodIdUnsetByte = uint8_t(0x99);
+
+// True when every byte of the physical pod ID equals `value`.
+auto ppod_id_all_bytes(const uint8_t* ppod_id, std::size_t len, uint8_t value) -> bool {
+  for (auto idx = std::size_t(0); idx < len; ++idx) {
+    if (ppod_id[idx] != value) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ *  Serializes vpod_active_accelerators as a space-separated decimal ID list, the
+ *  inverse of the read path. There is no count field: unused slots hold the UNSET
+ *  sentinel (UINT32_MAX), so emit only the leading run up to the first sentinel.
+ *  0 is a valid accelerator ID and must not terminate the run.
+ */
+auto format_vpod_active_accelerators(const uint32_t* accels, std::size_t capacity) -> std::string {
+  const auto count = static_cast<uint32_t>(vpod_active_run_length(accels, capacity));
+  return format_accel_list_space_separated(accels, count);
+}
+
+auto format_addr_mode(amdsmi_fabric_npa_address_mode_t mode) -> std::optional<std::string> {
+  switch (mode) {
+    case AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING:
+      return std::string("aliasing");
+    case AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_IDENTIFICATION:
+      return std::string("identification");
+    default:
+      return std::nullopt;
+  }
+}
+
+auto format_lane_en_bitmap(const uint8_t* bytes, std::size_t count) -> std::string {
+  auto outstream = std::ostringstream();
+  outstream << "0x";
+  for (auto idx = std::size_t(0); idx < count; ++idx) {
+    outstream << std::hex << std::setfill('0') << std::setw(2) << static_cast<uint32_t>(bytes[idx]);
+  }
+  return outstream.str();
+}
+
+auto validate_request_common(uint32_t version, uint32_t expected_version, uint32_t mask,
+                             uint32_t valid_mask, bool commit) -> amdsmi_status_t {
+  if (version != expected_version) {
+    return amdsmi_status_t::AMDSMI_STATUS_INVAL;
+  }
+
+  /**
+   *  A bare commit (mask==0, commit==true) is permitted so pre-staged fields can be
+   *  flushed by a later call. That same path lets a prior partial-write's residue be
+   *  applied, so it is also the lever for closing that window.
+   *
+   *  TODO: confirm with the driver team whether a commit with nothing freshly staged
+   *  is accepted or rejected; if rejected, tighten this to reject all mask==0 and
+   *  drop bare-commit support.
+   */
+  if ((mask == 0) && !commit) {
+    return amdsmi_status_t::AMDSMI_STATUS_INVAL;
+  }
+  if ((mask & ~valid_mask) != 0) {
+    return amdsmi_status_t::AMDSMI_STATUS_INVAL;
+  }
+
+  return amdsmi_status_t::AMDSMI_STATUS_SUCCESS;
+}
+
+auto write_field(const std::string& ualink_root, std::string_view subdir, std::string_view filename,
+                 const std::string& payload) -> amdsmi_status_t {
+  const auto relative_path = join_subdirectory_file(subdir, filename);
+  const auto full_path = (ualink_root + "/" + relative_path);
+
+  return write_sysfs_string(full_path, payload);
+}
+
+auto write_commit(const std::string& ualink_root, std::string_view subdir) -> amdsmi_status_t {
+  return write_field(ualink_root, subdir, kUALOE_UALINK_COMMIT_FILE, kFabricCommitPayload);
+}
+
+/**
+ *  A single deferred sysfs write produced during the build phase
+ *      - Formatting and input validation happen while the plan is assembled
+ *      - Nothing reaches sysfs until ::flush_writes iterates the completed list
+ */
+struct WriteRequest_t {
+  std::string_view m_subdir;
+  std::string_view m_file;
+  std::string m_payload;
+};
+using WriteRequestList_t = std::vector<WriteRequest_t>;
+
+/**
+ *  Accumulates masked sysfs writes into one subtree's request list
+ *      - Binds the list, the request mask, and the target @p subdir once
+ *      - ::add_if appends only when the field's mask bit is set, keeping the
+ *        per-field call sites down to (bit, file, payload)
+ */
+struct WriteRequestBuilder_t {
+  WriteRequestList_t& m_list;
+  uint32_t m_mask;
+  std::string_view m_subdir;
+
+  auto add_if(uint32_t bit, std::string_view file, std::string payload) -> void {
+    if (((m_mask & bit) != 0)) {
+      m_list.push_back(WriteRequest_t{m_subdir, file, std::move(payload)});
+    }
+  }
+};
+
+/**
+ *  Flushes a built write data request, then writes the subtree commit when requested
+ *      - All entries share one subtree, so commit targets that same @p subdir
+ *      - A mid-flush hardware failure could still leave partial state; the
+ *        build/flush split only removes avoidable partial state from bad input
+ */
+auto flush_writes(const std::string& ualink_root, const WriteRequestList_t& request_list,
+                  std::string_view subdir, bool commit) -> amdsmi_status_t {
+  for (const auto& request : request_list) {
+    if (auto status = write_field(ualink_root, request.m_subdir, request.m_file, request.m_payload);
+        status != amdsmi_status_t::AMDSMI_STATUS_SUCCESS) {
+      return status;
+    }
+  }
+
+  if (commit) {
+    return write_commit(ualink_root, subdir);
+  }
+
+  return amdsmi_status_t::AMDSMI_STATUS_SUCCESS;
+}
+
+/**
+ *  Reads a single sysfs attribute, returning its trimmed content
+ *      - Multi-line files (e.g. accelerator lists) are joined with single spaces
+ *      - Returns nullopt when the file is absent, unreadable, or empty after trimming
+ */
+auto read_field(const std::string& ualink_root, std::string_view subdir, std::string_view filename)
+    -> std::optional<std::string> {
+  const auto relative_path = join_subdirectory_file(subdir, filename);
+  const auto full_path = (ualink_root + "/" + relative_path);
+
+  errno = 0;
+  auto sysfs_file_stream = std::ifstream(full_path);
+  if (!sysfs_file_stream.is_open()) {
+    const auto rsmi_status = ErrnoToRsmiStatus(errno);
+    errno = 0;
+    auto outstream = std::ostringstream();
+    outstream << __func__ << " | failed to open: " << full_path << " | status: " << rsmi_status;
+    LOG_DEBUG(outstream);
+    return std::nullopt;
+  }
+
+  auto joined_lines = std::string();
+  auto line = std::string();
+  while (std::getline(sysfs_file_stream, line)) {
+    if (!joined_lines.empty()) {
+      joined_lines += ' ';
+    }
+    joined_lines += line;
+  }
+
+  const auto trimmed = trim(joined_lines);
+  if (trimmed.empty()) {
+    return std::nullopt;
+  }
+
+  return trimmed;
+}
+
+auto parse_u32_decimal(const std::string& text) -> std::optional<uint32_t> {
+  auto value = std::uint64_t(0);
+  auto instream = std::istringstream(text);
+  if (!(instream >> value)) {
+    return std::nullopt;
+  }
+  if ((value > std::numeric_limits<uint32_t>::max())) {
+    return std::nullopt;
+  }
+  // Reject trailing non-whitespace so "12abc" or "1 2" do not parse as 12.
+  auto trailing = char{};
+  if (instream >> trailing) {
+    return std::nullopt;
+  }
+
+  return static_cast<uint32_t>(value);
+}
+
+/**
+ *  Parses "0x"-prefixed hex into bytes (inverse of format_ppod_id / format_lane_en_bitmap)
+ *      - Separators between bytes ('-', ':', whitespace) are skipped so a UUID-style readback
+ *        parses like the packed form the writer emits
+ *      - Each byte is exactly two hex digits; an odd digit count or overflow past @p max fails
+ *      - Returns the number of bytes written, or nullopt on any malformed input
+ */
+auto parse_hex_bytes(const std::string& text, uint8_t* out, std::size_t max)
+    -> std::optional<std::size_t> {
+  auto body = std::string_view(text);
+  if (((body.size() >= 2) && (body[0] == '0') && ((body[1] == 'x') || (body[1] == 'X')))) {
+    body.remove_prefix(2);
+  }
+
+  auto packed = std::string();
+  packed.reserve(body.size());
+  for (const auto ch : body) {
+    if (((ch == '-') || (ch == ':') || (std::isspace(static_cast<unsigned char>(ch)) != 0))) {
+      continue;
+    }
+    packed.push_back(ch);
+  }
+
+  if (((packed.size() % 2) != 0)) {
+    return std::nullopt;
+  }
+
+  const auto byte_count = (packed.size() / 2);
+  if ((byte_count > max)) {
+    return std::nullopt;
+  }
+
+  const auto hex_value = [](char ch) -> std::optional<int> {
+    if (((ch >= '0') && (ch <= '9'))) {
+      return (ch - '0');
+    }
+    if (((ch >= 'a') && (ch <= 'f'))) {
+      return ((ch - 'a') + 10);
+    }
+    if (((ch >= 'A') && (ch <= 'F'))) {
+      return ((ch - 'A') + 10);
+    }
+    return std::nullopt;
+  };
+
+  for (auto idx = std::size_t(0); idx < byte_count; ++idx) {
+    const auto hi = hex_value(packed[(idx * 2)]);
+    const auto lo = hex_value(packed[((idx * 2) + 1)]);
+    if (((!hi.has_value()) || (!lo.has_value()))) {
+      return std::nullopt;
+    }
+    out[idx] = static_cast<uint8_t>(((hi.value() << 4) | lo.value()));
+  }
+
+  return byte_count;
+}
+
+/**
+ *  Parses a space-separated decimal list (inverse of format_accel_list_space_separated)
+ *      - Stops at @p max tokens, a value exceeding uint32_t ends parsing
+ *      - Returns the count of values written
+ */
+auto parse_u32_list(const std::string& text, uint32_t* out, std::size_t max) -> std::size_t {
+  auto instream = std::istringstream(text);
+  auto token = std::uint64_t(0);
+  auto count = std::size_t(0);
+  while (((count < max) && (instream >> token))) {
+    if ((token > std::numeric_limits<uint32_t>::max())) {
+      break;
+    }
+    out[count++] = static_cast<uint32_t>(token);
+  }
+
+  return count;
+}
+
+auto parse_addr_mode(const std::string& text) -> std::optional<amdsmi_fabric_npa_address_mode_t> {
+  auto lowered = text;
+  std::transform(lowered.begin(), lowered.end(), lowered.begin(),
+                 [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+
+  if ((lowered == "aliasing")) {
+    return AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING;
+  }
+  if ((lowered == "identification")) {
+    return AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_IDENTIFICATION;
+  }
+
+  return std::nullopt;
+}
+
+auto validate_read_request(uint32_t version, uint32_t expected_version, uint32_t mask,
+                           uint32_t valid_mask) -> amdsmi_status_t {
+  if (version != expected_version) {
+    return amdsmi_status_t::AMDSMI_STATUS_INVAL;
+  }
+  if (mask == 0) {
+    return amdsmi_status_t::AMDSMI_STATUS_INVAL;
+  }
+  if ((mask & ~valid_mask) != 0) {
+    return amdsmi_status_t::AMDSMI_STATUS_INVAL;
+  }
+
+  return amdsmi_status_t::AMDSMI_STATUS_SUCCESS;
+}
+
+/**
+ *  Reads masked sysfs fields from one subtree, recording which fields landed
+ *      - Binds the root, the requested mask, the @p subdir, and the result
+ *        accumulator once so per-field call sites stay (bit, file, assign)
+ *      - @p assign parses the raw value into @p config and returns whether it
+ *        succeeded; only then is the field's mask bit recorded in m_fields_read
+ */
+struct FieldReader_t {
+  const std::string& m_ualink_root;
+  uint32_t m_requested_mask;
+  std::string_view m_subdir;
+  uint32_t& m_fields_read;
+
+  template <typename AssignTp>
+  auto read(uint32_t bit, std::string_view file, AssignTp&& assign) -> void {
+    if (((m_requested_mask & bit) == 0)) {
+      return;
+    }
+    if (const auto raw = read_field(m_ualink_root, m_subdir, file);
+        raw.has_value() && assign(raw.value())) {
+      m_fields_read |= bit;
+    }
+  }
+};
+
+}  // namespace
+
+/**
+ *  Post-commit diagnostics: Re-read the just-committed fields from both the write
+ *  subtree and the flat surface and LOG_DEBUG any field that disagrees (value or
+ *  presence).
+ *
+ *  Purely observational: It never changes the apply result.
+ *  The double read is skipped entirely when logging is off, so there is no cost on the hot path.
+ */
+auto verify_commit_propagation(const AMDSmiGPUDevice& device,
+                               const amdsmi_fabric_ppod_config_t& committed) -> void;
+auto verify_commit_propagation(const AMDSmiGPUDevice& device,
+                               const amdsmi_fabric_vpod_config_t& committed) -> void;
+auto verify_commit_propagation(const AMDSmiGPUDevice& device,
+                               const amdsmi_fabric_station_config_t& committed) -> void;
+
+auto apply_ppod_config_at(const std::string& ualink_root, bool device_supports_ualink,
+                          const amdsmi_fabric_ppod_config_t& config) -> amdsmi_status_t {
+  if (auto status = validate_request_common(config.version, AMDSMI_FABRIC_PPOD_CONFIG_V1,
+                                            config.mask, kPpodValidMask, config.commit);
+      status != amdsmi_status_t::AMDSMI_STATUS_SUCCESS) {
+    return status;
+  }
+
+  /**
+   *    Pure input validation runs before the hardware-capability gate so a malformed
+   *    request is reported as AMDSMI_STATUS_INVAL regardless of whether this system
+   *    exposes UALink (mirrors validate_request_common above)
+   */
+  if ((config.mask & AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID) != 0) {
+    if (config.data.accelerator_id > kMaxAcceleratorId) {
+      return amdsmi_status_t::AMDSMI_STATUS_INVAL;
+    }
+  }
+
+  if ((config.mask & AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID) != 0) {
+    // All-zero is not a valid pod ID; all-guard-byte is the unset sentinel echoed back.
+    if (ppod_id_all_bytes(config.data.ppod_id, AMDSMI_MAX_UUID_ELEMENTS, 0) ||
+        ppod_id_all_bytes(config.data.ppod_id, AMDSMI_MAX_UUID_ELEMENTS, kPpodIdUnsetByte)) {
+      return amdsmi_status_t::AMDSMI_STATUS_INVAL;
+    }
+  }
+
+  if ((config.mask & AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS) != 0) {
+    if (((config.data.local_accelerator_count == 0)) ||
+        ((config.data.local_accelerator_count > AMDSMI_FABRIC_MAX_LOCAL_GPUS))) {
+      return amdsmi_status_t::AMDSMI_STATUS_INVAL;
+    }
+    if (!accel_ids_in_range(config.data.local_accelerators, config.data.local_accelerator_count)) {
+      return amdsmi_status_t::AMDSMI_STATUS_INVAL;
+    }
+  }
+
+  if (!device_supports_ualink) {
+    return amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  if (!subdirectory_exists(ualink_root, kUALOE_UALINK_SETUP_SUBDIR)) {
+    return amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  auto request_list = WriteRequestList_t{};
+  auto writer = WriteRequestBuilder_t{request_list, config.mask, kUALOE_UALINK_SETUP_SUBDIR};
+
+  writer.add_if(AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID, kUALOE_ACCEL_ID,
+                format_u32_decimal(config.data.accelerator_id));
+  writer.add_if(AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID, kUALOE_PPOD_ID,
+                format_ppod_id(config.data.ppod_id, AMDSMI_MAX_UUID_ELEMENTS));
+  writer.add_if(AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE, kUALOE_PPOD_SIZE,
+                format_u32_decimal(config.data.ppod_size));
+  // add_if evaluates its payload argument eagerly, so the count must be gated
+  // here: on a masked-out LOCAL_ACCELS write the count is uninitialized and
+  // would drive an out-of-bounds read in the formatter.
+  const auto local_accel_count = ((config.mask & AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS) != 0)
+                                     ? config.data.local_accelerator_count
+                                     : 0U;
+  writer.add_if(
+      AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS, kUALOE_LOCAL_ACCELS,
+      format_accel_list_space_separated(config.data.local_accelerators, local_accel_count));
+  writer.add_if(AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH, kUALOE_BANDWIDTH,
+                format_u32_decimal(config.data.bandwidth));
+  writer.add_if(AMDSMI_FABRIC_PPOD_FIELD_LATENCY, kUALOE_LATENCY,
+                format_u32_decimal(config.data.latency));
+
+  return flush_writes(ualink_root, request_list, kUALOE_UALINK_SETUP_SUBDIR, config.commit);
+}
+
+auto apply_ppod_config(const AMDSmiGPUDevice& device, const amdsmi_fabric_ppod_config_t& config)
+    -> amdsmi_status_t {
+  const auto status =
+      apply_ppod_config_at(get_ualink_root(device), device.device_has_ualink(), config);
+  if (((status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS) && config.commit)) {
+    verify_commit_propagation(device, config);
+  }
+  return status;
+}
+
+auto apply_vpod_config_at(const std::string& ualink_root, bool device_supports_ualink,
+                          const amdsmi_fabric_vpod_config_t& config) -> amdsmi_status_t {
+  if (auto status = validate_request_common(config.version, AMDSMI_FABRIC_VPOD_CONFIG_V1,
+                                            config.mask, kVpodValidMask, config.commit);
+      status != amdsmi_status_t::AMDSMI_STATUS_SUCCESS) {
+    return status;
+  }
+
+  /**
+   *    Pure input validation runs before the hardware-capability gate so a malformed
+   *    request is reported as AMDSMI_STATUS_INVAL regardless of whether this system
+   *    exposes UALink
+   *
+   *    The formatted value is reused for the write below
+   */
+  auto addr_mode_str = std::optional<std::string>{};
+  if ((config.mask & AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE) != 0) {
+    addr_mode_str = format_addr_mode(config.data.addr_mode);
+    if (!addr_mode_str.has_value()) {
+      return amdsmi_status_t::AMDSMI_STATUS_INVAL;
+    }
+  }
+
+  if ((config.mask & AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID) != 0) {
+    if (config.data.vpod_id == 0) {  // 0 is not a valid pod ID
+      return amdsmi_status_t::AMDSMI_STATUS_INVAL;
+    }
+  }
+
+  if ((config.mask & AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS) != 0) {
+    const auto run = vpod_active_run_length(config.data.vpod_active_accelerators,
+                                            AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE);
+    if (!accel_ids_in_range(config.data.vpod_active_accelerators, run)) {
+      return amdsmi_status_t::AMDSMI_STATUS_INVAL;
+    }
+    // A value past the first sentinel would be silently dropped by the serializer;
+    // reject the request rather than truncate the caller's list.
+    for (auto idx = run;
+         idx < static_cast<std::size_t>(AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE); ++idx) {
+      if (config.data.vpod_active_accelerators[idx] != std::numeric_limits<uint32_t>::max()) {
+        return amdsmi_status_t::AMDSMI_STATUS_INVAL;
+      }
+    }
+  }
+
+  if (!device_supports_ualink) {
+    return amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  if (!subdirectory_exists(ualink_root, kUALOE_UALINK_CONFIG_SUBDIR)) {
+    return amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  auto request_list = WriteRequestList_t{};
+  auto writer = WriteRequestBuilder_t{request_list, config.mask, kUALOE_UALINK_CONFIG_SUBDIR};
+
+  writer.add_if(AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID, kUALOE_VPOD_ID,
+                format_u32_decimal(config.data.vpod_id));
+  writer.add_if(AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE, kUALOE_VPOD_SIZE,
+                format_u32_decimal(config.data.vpod_size));
+  writer.add_if(AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS, kUALOE_VPOD_ACTIVE_ACCELS,
+                format_vpod_active_accelerators(config.data.vpod_active_accelerators,
+                                                AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE));
+  if (addr_mode_str.has_value()) {
+    writer.add_if(AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE, kUALOE_ADDR_MODE,
+                  std::move(addr_mode_str.value()));
+  }
+
+  return flush_writes(ualink_root, request_list, kUALOE_UALINK_CONFIG_SUBDIR, config.commit);
+}
+
+auto apply_vpod_config(const AMDSmiGPUDevice& device, const amdsmi_fabric_vpod_config_t& config)
+    -> amdsmi_status_t {
+  const auto status =
+      apply_vpod_config_at(get_ualink_root(device), device.device_has_ualink(), config);
+  if (((status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS) && config.commit)) {
+    verify_commit_propagation(device, config);
+  }
+  return status;
+}
+
+auto apply_station_config_at(const std::string& ualink_root, bool device_supports_ualink,
+                             const amdsmi_fabric_station_config_t& config) -> amdsmi_status_t {
+  if (auto status = validate_request_common(config.version, AMDSMI_FABRIC_STATION_CONFIG_V1,
+                                            config.mask, kStationValidMask, config.commit);
+      status != amdsmi_status_t::AMDSMI_STATUS_SUCCESS) {
+    return status;
+  }
+
+  if (!device_supports_ualink) {
+    return amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  if (!subdirectory_exists(ualink_root, kUALOE_UALINK_STATIONS_SUBDIR)) {
+    return amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  /**
+   *    Build phase: format every masked field before any sysfs write
+   *    An invalid input must not leave partial sysfs state that a subsequent commit would apply
+   */
+  auto request_list = WriteRequestList_t{};
+  auto writer = WriteRequestBuilder_t{request_list, config.mask, kUALOE_UALINK_STATIONS_SUBDIR};
+
+  writer.add_if(AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS, kUALOE_STATION_FLAGS,
+                format_u32_decimal(config.data.station_flags));
+  writer.add_if(AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS, kUALOE_NUM_STATIONS,
+                format_u32_decimal(static_cast<uint32_t>(config.data.num_stations)));
+  writer.add_if(AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP, kUALOE_LANE_EN_BITMAP,
+                format_lane_en_bitmap(config.data.lane_en_bitmap, AMDSMI_FABRIC_MAX_BITMAP_SIZE));
+
+  return flush_writes(ualink_root, request_list, kUALOE_UALINK_STATIONS_SUBDIR, config.commit);
+}
+
+auto apply_station_config(const AMDSmiGPUDevice& device,
+                          const amdsmi_fabric_station_config_t& config) -> amdsmi_status_t {
+  const auto status =
+      apply_station_config_at(get_ualink_root(device), device.device_has_ualink(), config);
+  if (((status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS) && config.commit)) {
+    verify_commit_propagation(device, config);
+  }
+  return status;
+}
+
+auto query_ppod_config_at(const std::string& ualink_root, bool device_supports_ualink,
+                          amdsmi_fabric_ppod_config_t& config, std::string_view subdir)
+    -> amdsmi_status_t {
+  const auto requested_mask = config.mask;
+  if (auto status = validate_read_request(config.version, AMDSMI_FABRIC_PPOD_CONFIG_V1,
+                                          requested_mask, kPpodValidMask);
+      status != amdsmi_status_t::AMDSMI_STATUS_SUCCESS) {
+    return status;
+  }
+
+  if (!device_supports_ualink) {
+    return amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  if (!subdirectory_exists(ualink_root, subdir)) {
+    return amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  /**
+   *    Guard values match the flat reader so both surfaces agree on "field absent"
+   */
+  config.data.accelerator_id = std::numeric_limits<uint32_t>::max();
+  std::fill(std::begin(config.data.ppod_id), std::end(config.data.ppod_id), kPpodIdUnsetByte);
+  config.data.ppod_size = std::numeric_limits<uint32_t>::max();
+  std::fill(std::begin(config.data.local_accelerators), std::end(config.data.local_accelerators),
+            std::numeric_limits<uint32_t>::max());
+  config.data.local_accelerator_count = 0;
+  config.data.bandwidth = std::numeric_limits<uint32_t>::max();
+  config.data.latency = std::numeric_limits<uint32_t>::max();
+
+  auto fields_read = uint32_t(0);
+  auto reader = FieldReader_t{ualink_root, requested_mask, subdir, fields_read};
+
+  reader.read(AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID, kUALOE_ACCEL_ID,
+              [&](const std::string& str_value) {
+                const auto parsed_value = parse_u32_decimal(str_value);
+                if (parsed_value.has_value()) {
+                  config.data.accelerator_id = parsed_value.value();
+                }
+                return parsed_value.has_value();
+              });
+  reader.read(AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID, kUALOE_PPOD_ID, [&](const std::string& str_value) {
+    return parse_hex_bytes(str_value, config.data.ppod_id, AMDSMI_MAX_UUID_ELEMENTS).has_value();
+  });
+  reader.read(AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE, kUALOE_PPOD_SIZE,
+              [&](const std::string& str_value) {
+                const auto parsed_value = parse_u32_decimal(str_value);
+                if (parsed_value.has_value()) {
+                  config.data.ppod_size = parsed_value.value();
+                }
+                return parsed_value.has_value();
+              });
+  reader.read(AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS, kUALOE_LOCAL_ACCELS,
+              [&](const std::string& str_value) {
+                const auto count = parse_u32_list(str_value, config.data.local_accelerators,
+                                                  AMDSMI_FABRIC_MAX_LOCAL_GPUS);
+                config.data.local_accelerator_count = static_cast<uint32_t>(count);
+                return (count > 0);
+              });
+  reader.read(AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH, kUALOE_BANDWIDTH,
+              [&](const std::string& str_value) {
+                const auto parsed_value = parse_u32_decimal(str_value);
+                if (parsed_value.has_value()) {
+                  config.data.bandwidth = parsed_value.value();
+                }
+                return parsed_value.has_value();
+              });
+  reader.read(AMDSMI_FABRIC_PPOD_FIELD_LATENCY, kUALOE_LATENCY, [&](const std::string& str_value) {
+    const auto parsed_value = parse_u32_decimal(str_value);
+    if (parsed_value.has_value()) {
+      config.data.latency = parsed_value.value();
+    }
+    return parsed_value.has_value();
+  });
+
+  config.mask = fields_read;
+  return ((fields_read != 0) ? amdsmi_status_t::AMDSMI_STATUS_SUCCESS
+                             : amdsmi_status_t::AMDSMI_STATUS_NO_DATA);
+}
+
+auto query_ppod_config(const AMDSmiGPUDevice& device, amdsmi_fabric_ppod_config_t& config,
+                       std::string_view subdir = kUALOE_UALINK_SETUP_SUBDIR) -> amdsmi_status_t {
+  return query_ppod_config_at(get_ualink_root(device), device.device_has_ualink(), config, subdir);
+}
+
+auto query_vpod_config_at(const std::string& ualink_root, bool device_supports_ualink,
+                          amdsmi_fabric_vpod_config_t& config, std::string_view subdir)
+    -> amdsmi_status_t {
+  const auto requested_mask = config.mask;
+  if (auto status = validate_read_request(config.version, AMDSMI_FABRIC_VPOD_CONFIG_V1,
+                                          requested_mask, kVpodValidMask);
+      status != amdsmi_status_t::AMDSMI_STATUS_SUCCESS) {
+    return status;
+  }
+
+  if (!device_supports_ualink) {
+    return amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  if (!subdirectory_exists(ualink_root, subdir)) {
+    return amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  config.data.vpod_id = std::numeric_limits<uint32_t>::max();
+  config.data.vpod_size = std::numeric_limits<uint32_t>::max();
+  // Accelerator-ID list, as with local_accelerators: unused slots stay at the UNSET sentinel, so a
+  // partial or absent read is not mistaken for accelerator ID 0 being active.
+  std::fill(std::begin(config.data.vpod_active_accelerators),
+            std::end(config.data.vpod_active_accelerators), std::numeric_limits<uint32_t>::max());
+  config.data.addr_mode = AMDSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN;
+
+  auto fields_read = uint32_t(0);
+  auto reader = FieldReader_t{ualink_root, requested_mask, subdir, fields_read};
+
+  reader.read(AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID, kUALOE_VPOD_ID, [&](const std::string& str_value) {
+    const auto parsed_value = parse_u32_decimal(str_value);
+    if (parsed_value.has_value()) {
+      config.data.vpod_id = parsed_value.value();
+    }
+    return parsed_value.has_value();
+  });
+  reader.read(AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE, kUALOE_VPOD_SIZE,
+              [&](const std::string& str_value) {
+                const auto parsed_value = parse_u32_decimal(str_value);
+                if (parsed_value.has_value()) {
+                  config.data.vpod_size = parsed_value.value();
+                }
+                return parsed_value.has_value();
+              });
+  reader.read(AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS, kUALOE_VPOD_ACTIVE_ACCELS,
+              [&](const std::string& str_value) {
+                const auto count = parse_u32_list(str_value, config.data.vpod_active_accelerators,
+                                                  AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE);
+                return (count > 0);
+              });
+  reader.read(AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE, kUALOE_ADDR_MODE,
+              [&](const std::string& str_value) {
+                const auto parsed_value = parse_addr_mode(str_value);
+                if (parsed_value.has_value()) {
+                  config.data.addr_mode = parsed_value.value();
+                }
+                return parsed_value.has_value();
+              });
+
+  config.mask = fields_read;
+  return ((fields_read != 0) ? amdsmi_status_t::AMDSMI_STATUS_SUCCESS
+                             : amdsmi_status_t::AMDSMI_STATUS_NO_DATA);
+}
+
+auto query_vpod_config(const AMDSmiGPUDevice& device, amdsmi_fabric_vpod_config_t& config,
+                       std::string_view subdir = kUALOE_UALINK_CONFIG_SUBDIR) -> amdsmi_status_t {
+  return query_vpod_config_at(get_ualink_root(device), device.device_has_ualink(), config, subdir);
+}
+
+auto query_station_config_at(const std::string& ualink_root, bool device_supports_ualink,
+                             amdsmi_fabric_station_config_t& config, std::string_view subdir)
+    -> amdsmi_status_t {
+  const auto requested_mask = config.mask;
+  if (auto status = validate_read_request(config.version, AMDSMI_FABRIC_STATION_CONFIG_V1,
+                                          requested_mask, kStationValidMask);
+      status != amdsmi_status_t::AMDSMI_STATUS_SUCCESS) {
+    return status;
+  }
+
+  if (!device_supports_ualink) {
+    return amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  if (!subdirectory_exists(ualink_root, subdir)) {
+    return amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  config.data.station_flags = std::numeric_limits<uint32_t>::max();
+  config.data.num_stations = std::numeric_limits<uint8_t>::max();
+  // Bitmap: an unread byte must read as "lane disabled" (0), not all-ones, so a partial or
+  // absent read never reports spurious enabled lanes.
+  std::fill(std::begin(config.data.lane_en_bitmap), std::end(config.data.lane_en_bitmap),
+            static_cast<uint8_t>(0));
+
+  auto fields_read = uint32_t(0);
+  auto reader = FieldReader_t{ualink_root, requested_mask, subdir, fields_read};
+
+  reader.read(AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS, kUALOE_STATION_FLAGS,
+              [&](const std::string& str_value) {
+                const auto parsed_value = parse_u32_decimal(str_value);
+                if (parsed_value.has_value()) {
+                  config.data.station_flags = parsed_value.value();
+                }
+                return parsed_value.has_value();
+              });
+  reader.read(AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS, kUALOE_NUM_STATIONS,
+              [&](const std::string& str_value) {
+                const auto parsed_value = parse_u32_decimal(str_value);
+                if (parsed_value.has_value() &&
+                    (parsed_value.value() <= std::numeric_limits<uint8_t>::max())) {
+                  config.data.num_stations = static_cast<uint8_t>(parsed_value.value());
+                  return true;
+                }
+                return false;
+              });
+  reader.read(AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP, kUALOE_LANE_EN_BITMAP,
+              [&](const std::string& str_value) {
+                return parse_hex_bytes(str_value, config.data.lane_en_bitmap,
+                                       AMDSMI_FABRIC_MAX_BITMAP_SIZE)
+                    .has_value();
+              });
+
+  config.mask = fields_read;
+  return ((fields_read != 0) ? amdsmi_status_t::AMDSMI_STATUS_SUCCESS
+                             : amdsmi_status_t::AMDSMI_STATUS_NO_DATA);
+}
+
+auto query_station_config(const AMDSmiGPUDevice& device, amdsmi_fabric_station_config_t& config,
+                          std::string_view subdir = kUALOE_UALINK_STATIONS_SUBDIR)
+    -> amdsmi_status_t {
+  return query_station_config_at(get_ualink_root(device), device.device_has_ualink(), config,
+                                 subdir);
+}
+
+namespace {
+
+/**
+ *  Accumulates flat-vs-subtree disagreements for one config's committed fields.
+ *  A field is only compared when its bit was in the committed mask.
+ *  Both surfaces reporting the field lets us compare values. Exactly one reporting it is itself
+ *  a divergence (the commit reached one surface but not the other).
+ */
+struct SurfaceComparison_t {
+  std::ostringstream& m_report;
+  uint32_t m_committed_mask;
+  uint32_t m_subtree_mask;
+  uint32_t m_flat_mask;
+  int m_mismatches = 0;
+
+  auto comparable(uint32_t bit, const char* name) -> bool {
+    if (((m_committed_mask & bit) == 0)) {
+      return false;
+    }
+
+    const auto subtree_has = ((m_subtree_mask & bit) != 0);
+    const auto flat_has = ((m_flat_mask & bit) != 0);
+    if ((subtree_has && flat_has)) {
+      return true;
+    }
+
+    if ((subtree_has != flat_has)) {
+      m_report << " | PRESENCE-DIFF " << name << " subtree=" << (subtree_has ? "present" : "absent")
+               << " flat=" << (flat_has ? "present" : "absent");
+      ++m_mismatches;
+    }
+
+    return false;
+  }
+
+  auto scalar(uint32_t bit, const char* name, uint64_t subtree_val, uint64_t flat_val) -> void {
+    if ((comparable(bit, name) && (subtree_val != flat_val))) {
+      m_report << " | MISMATCH " << name << " subtree=" << subtree_val << " flat=" << flat_val;
+      ++m_mismatches;
+    }
+  }
+
+  template <typename ElemTp>
+  auto array(uint32_t bit, const char* name, const ElemTp* subtree_arr, const ElemTp* flat_arr,
+             std::size_t count) -> void {
+    if ((comparable(bit, name) && (!std::equal(subtree_arr, (subtree_arr + count), flat_arr)))) {
+      m_report << " | MISMATCH " << name << " (array differs)";
+      ++m_mismatches;
+    }
+  }
+};
+
+}  // namespace
+
+auto verify_commit_propagation(const AMDSmiGPUDevice& device,
+                               const amdsmi_fabric_ppod_config_t& committed) -> void {
+  if ((!ROCmLogging::Logger::getInstance()->isLoggerEnabled())) {
+    return;
+  }
+
+  auto subtree = amdsmi_fabric_ppod_config_t{};
+  subtree.version = committed.version;
+  subtree.mask = committed.mask;
+  auto flat = subtree;
+
+  const auto subtree_status = query_ppod_config(device, subtree);
+  const auto flat_status = query_ppod_config(device, flat, kUALOE_UALINK_FLAT_SUBDIR);
+
+  auto report = std::ostringstream();
+  report << __func__ << " | ppod | subtree_status: " << subtree_status
+         << " | flat_status: " << flat_status;
+
+  auto diff = SurfaceComparison_t{report, committed.mask, subtree.mask, flat.mask};
+  diff.scalar(AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID, "accelerator_id", subtree.data.accelerator_id,
+              flat.data.accelerator_id);
+  diff.array(AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID, "ppod_id", subtree.data.ppod_id, flat.data.ppod_id,
+             AMDSMI_MAX_UUID_ELEMENTS);
+  diff.scalar(AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE, "ppod_size", subtree.data.ppod_size,
+              flat.data.ppod_size);
+  diff.array(AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS, "local_accelerators",
+             subtree.data.local_accelerators, flat.data.local_accelerators,
+             AMDSMI_FABRIC_MAX_LOCAL_GPUS);
+  diff.scalar(AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS, "local_accelerator_count",
+              subtree.data.local_accelerator_count, flat.data.local_accelerator_count);
+  diff.scalar(AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH, "bandwidth", subtree.data.bandwidth,
+              flat.data.bandwidth);
+  diff.scalar(AMDSMI_FABRIC_PPOD_FIELD_LATENCY, "latency", subtree.data.latency, flat.data.latency);
+
+  if (diff.m_mismatches == 0) {
+    report << " | all committed fields match across surfaces";
+  }
+  LOG_DEBUG(report);
+}
+
+auto verify_commit_propagation(const AMDSmiGPUDevice& device,
+                               const amdsmi_fabric_vpod_config_t& committed) -> void {
+  if ((!ROCmLogging::Logger::getInstance()->isLoggerEnabled())) {
+    return;
+  }
+
+  auto subtree = amdsmi_fabric_vpod_config_t{};
+  subtree.version = committed.version;
+  subtree.mask = committed.mask;
+  auto flat = subtree;
+
+  const auto subtree_status = query_vpod_config(device, subtree);
+  const auto flat_status = query_vpod_config(device, flat, kUALOE_UALINK_FLAT_SUBDIR);
+
+  auto report = std::ostringstream();
+  report << __func__ << " | vpod | subtree_status: " << subtree_status
+         << " | flat_status: " << flat_status;
+
+  auto surface_compare = SurfaceComparison_t{report, committed.mask, subtree.mask, flat.mask};
+  surface_compare.scalar(AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID, "vpod_id", subtree.data.vpod_id,
+                         flat.data.vpod_id);
+  surface_compare.scalar(AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE, "vpod_size", subtree.data.vpod_size,
+                         flat.data.vpod_size);
+  surface_compare.array(AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS, "vpod_active_accelerators",
+                        subtree.data.vpod_active_accelerators, flat.data.vpod_active_accelerators,
+                        AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE);
+  surface_compare.scalar(AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE, "addr_mode",
+                         static_cast<uint64_t>(subtree.data.addr_mode),
+                         static_cast<uint64_t>(flat.data.addr_mode));
+
+  if (surface_compare.m_mismatches == 0) {
+    report << " | all committed fields match across surfaces";
+  }
+  LOG_DEBUG(report);
+}
+
+auto verify_commit_propagation(const AMDSmiGPUDevice& device,
+                               const amdsmi_fabric_station_config_t& committed) -> void {
+  if ((!ROCmLogging::Logger::getInstance()->isLoggerEnabled())) {
+    return;
+  }
+
+  auto subtree = amdsmi_fabric_station_config_t{};
+  subtree.version = committed.version;
+  subtree.mask = committed.mask;
+  auto flat = subtree;
+
+  const auto subtree_status = query_station_config(device, subtree);
+  const auto flat_status = query_station_config(device, flat, kUALOE_UALINK_FLAT_SUBDIR);
+
+  auto report = std::ostringstream();
+  report << __func__ << " | station | subtree_status: " << subtree_status
+         << " | flat_status: " << flat_status;
+
+  auto surface_compare = SurfaceComparison_t{report, committed.mask, subtree.mask, flat.mask};
+  surface_compare.scalar(AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS, "station_flags",
+                         subtree.data.station_flags, flat.data.station_flags);
+  surface_compare.scalar(AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS, "num_stations",
+                         subtree.data.num_stations, flat.data.num_stations);
+  surface_compare.array(AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP, "lane_en_bitmap",
+                        subtree.data.lane_en_bitmap, flat.data.lane_en_bitmap,
+                        AMDSMI_FABRIC_MAX_BITMAP_SIZE);
+
+  if (surface_compare.m_mismatches == 0) {
+    report << " | all committed fields match across surfaces";
+  }
+  LOG_DEBUG(report);
+}
+
+}  // namespace fabric_ualink
+
+auto AMDSmiGPUDevice::apply_fabric_ppod_config(const amdsmi_fabric_ppod_config_t& config) const
+    -> amdsmi_status_t {
+  return fabric_ualink::apply_ppod_config(*this, config);
+}
+
+auto AMDSmiGPUDevice::apply_fabric_vpod_config(const amdsmi_fabric_vpod_config_t& config) const
+    -> amdsmi_status_t {
+  return fabric_ualink::apply_vpod_config(*this, config);
+}
+
+auto AMDSmiGPUDevice::apply_fabric_station_config(
+    const amdsmi_fabric_station_config_t& config) const -> amdsmi_status_t {
+  return fabric_ualink::apply_station_config(*this, config);
+}
+
+auto AMDSmiGPUDevice::query_fabric_ppod_config(amdsmi_fabric_ppod_config_t& config) const
+    -> amdsmi_status_t {
+  return fabric_ualink::query_ppod_config(*this, config);
+}
+
+auto AMDSmiGPUDevice::query_fabric_vpod_config(amdsmi_fabric_vpod_config_t& config) const
+    -> amdsmi_status_t {
+  return fabric_ualink::query_vpod_config(*this, config);
+}
+
+auto AMDSmiGPUDevice::query_fabric_station_config(amdsmi_fabric_station_config_t& config) const
+    -> amdsmi_status_t {
+  return fabric_ualink::query_station_config(*this, config);
+}
+
+auto AMDSmiGPUDevice::query_fabric_ppod_config_flat(amdsmi_fabric_ppod_config_t& config) const
+    -> amdsmi_status_t {
+  return fabric_ualink::query_ppod_config(*this, config, kUALOE_UALINK_FLAT_SUBDIR);
+}
+
+auto AMDSmiGPUDevice::query_fabric_vpod_config_flat(amdsmi_fabric_vpod_config_t& config) const
+    -> amdsmi_status_t {
+  return fabric_ualink::query_vpod_config(*this, config, kUALOE_UALINK_FLAT_SUBDIR);
+}
+
+auto AMDSmiGPUDevice::query_fabric_station_config_flat(amdsmi_fabric_station_config_t& config) const
+    -> amdsmi_status_t {
+  return fabric_ualink::query_station_config(*this, config, kUALOE_UALINK_FLAT_SUBDIR);
+}
+
+}  // namespace amd::smi

--- a/projects/amdsmi/src/amd_smi/amd_smi_fabric_ualink.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_fabric_ualink.cc
@@ -1,24 +1,5 @@
-/*
- * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
 
 #include "amd_smi/impl/amd_smi_fabric_ualink.h"
 

--- a/projects/amdsmi/src/amd_smi/amd_smi_fabric_ualink.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_fabric_ualink.cc
@@ -217,21 +217,16 @@ auto format_lane_en_bitmap(const uint8_t* bytes, std::size_t count) -> std::stri
 }
 
 auto validate_request_common(uint32_t version, uint32_t expected_version, uint32_t mask,
-                             uint32_t valid_mask, bool commit) -> amdsmi_status_t {
+                             uint32_t valid_mask) -> amdsmi_status_t {
   if (version != expected_version) {
     return amdsmi_status_t::AMDSMI_STATUS_INVAL;
   }
 
   /**
-   *  A bare commit (mask==0, commit==true) is permitted so pre-staged fields can be
-   *  flushed by a later call. That same path lets a prior partial-write's residue be
-   *  applied, so it is also the lever for closing that window.
-   *
-   *  TODO: confirm with the driver team whether a commit with nothing freshly staged
-   *  is accepted or rejected; if rejected, tighten this to reject all mask==0 and
-   *  drop bare-commit support.
+   *  A commit with nothing freshly staged would flush whatever a prior partial write left
+   *  behind, so every request must name at least one field
    */
-  if ((mask == 0) && !commit) {
+  if (mask == 0) {
     return amdsmi_status_t::AMDSMI_STATUS_INVAL;
   }
   if ((mask & ~valid_mask) != 0) {
@@ -284,13 +279,19 @@ struct WriteRequestBuilder_t {
 };
 
 /**
- *  Flushes a built write data request, then writes the subtree commit when requested
+ *  Flushes a built write data request, then writes the subtree commit
  *      - All entries share one subtree, so commit targets that same @p subdir
  *      - A mid-flush hardware failure could still leave partial state; the
  *        build/flush split only removes avoidable partial state from bad input
+ *      - The driver ignores the staging files until a commit follows, so a non-committing
+ *        request stops at validation instead of leaving values for the next commit to apply
  */
 auto flush_writes(const std::string& ualink_root, const WriteRequestList_t& request_list,
                   std::string_view subdir, bool commit) -> amdsmi_status_t {
+  if (!commit) {
+    return amdsmi_status_t::AMDSMI_STATUS_SUCCESS;
+  }
+
   for (const auto& request : request_list) {
     if (auto status = write_field(ualink_root, request.m_subdir, request.m_file, request.m_payload);
         status != amdsmi_status_t::AMDSMI_STATUS_SUCCESS) {
@@ -298,11 +299,7 @@ auto flush_writes(const std::string& ualink_root, const WriteRequestList_t& requ
     }
   }
 
-  if (commit) {
-    return write_commit(ualink_root, subdir);
-  }
-
-  return amdsmi_status_t::AMDSMI_STATUS_SUCCESS;
+  return write_commit(ualink_root, subdir);
 }
 
 /**
@@ -393,26 +390,29 @@ auto parse_hex_bytes(const std::string& text, uint8_t* out, std::size_t max)
     return std::nullopt;
   }
 
-  const auto hex_value = [](char ch) -> std::optional<int> {
+  /**
+   *    Reject the whole string before writing a byte: bailing out mid-loop would leave the
+   *    caller's buffer part sentinel, part payload, behind a mask bit reported as unread
+   */
+  for (const auto ch : packed) {
+    if ((std::isxdigit(static_cast<unsigned char>(ch)) == 0)) {
+      return std::nullopt;
+    }
+  }
+
+  const auto hex_value = [](char ch) -> int {
     if (((ch >= '0') && (ch <= '9'))) {
       return (ch - '0');
     }
     if (((ch >= 'a') && (ch <= 'f'))) {
       return ((ch - 'a') + 10);
     }
-    if (((ch >= 'A') && (ch <= 'F'))) {
-      return ((ch - 'A') + 10);
-    }
-    return std::nullopt;
+    return ((ch - 'A') + 10);
   };
 
   for (auto idx = std::size_t(0); idx < byte_count; ++idx) {
-    const auto hi = hex_value(packed[(idx * 2)]);
-    const auto lo = hex_value(packed[((idx * 2) + 1)]);
-    if (((!hi.has_value()) || (!lo.has_value()))) {
-      return std::nullopt;
-    }
-    out[idx] = static_cast<uint8_t>(((hi.value() << 4) | lo.value()));
+    out[idx] = static_cast<uint8_t>(
+        ((hex_value(packed[(idx * 2)]) << 4) | hex_value(packed[((idx * 2) + 1)])));
   }
 
   return byte_count;
@@ -420,21 +420,28 @@ auto parse_hex_bytes(const std::string& text, uint8_t* out, std::size_t max)
 
 /**
  *  Parses a space-separated decimal list (inverse of format_accel_list_space_separated)
- *      - Stops at @p max tokens, a value exceeding uint32_t ends parsing
- *      - Returns the count of values written
+ *      - Returns std::nullopt and leaves @p out untouched on a malformed token, a value
+ *        exceeding uint32_t, or more than @p max values
+ *      - A list too long to hold is reported absent rather than truncated: with no count
+ *        field, a truncated list is indistinguishable from a complete one
  */
-auto parse_u32_list(const std::string& text, uint32_t* out, std::size_t max) -> std::size_t {
+auto parse_u32_list(const std::string& text, uint32_t* out, std::size_t max)
+    -> std::optional<std::size_t> {
   auto instream = std::istringstream(text);
   auto token = std::uint64_t(0);
-  auto count = std::size_t(0);
-  while (((count < max) && (instream >> token))) {
-    if ((token > std::numeric_limits<uint32_t>::max())) {
-      break;
+  auto values = std::vector<uint32_t>();
+  while ((instream >> token)) {
+    if (((token > std::numeric_limits<uint32_t>::max()) || (values.size() >= max))) {
+      return std::nullopt;
     }
-    out[count++] = static_cast<uint32_t>(token);
+    values.push_back(static_cast<uint32_t>(token));
+  }
+  if (!instream.eof()) {
+    return std::nullopt;
   }
 
-  return count;
+  std::copy(values.begin(), values.end(), out);
+  return values.size();
 }
 
 auto parse_addr_mode(const std::string& text) -> std::optional<amdsmi_fabric_npa_address_mode_t> {
@@ -492,27 +499,34 @@ struct FieldReader_t {
   }
 };
 
+enum class SurfacePhase_t { PreStage, PostCommit };
+
 }  // namespace
 
 /**
- *  Post-commit diagnostics: Re-read the just-committed fields from both the write
- *  subtree and the flat surface and LOG_DEBUG any field that disagrees (value or
- *  presence).
+ *  Surface diagnostics: Re-read fields from both the write subtree and the flat surface and
+ *  LOG_DEBUG any that disagree (value or presence).
+ *
+ *  PreStage runs before a committing request writes anything, over the full valid mask, so a
+ *  disagreement means an earlier partial write left fields staged that this commit is about to
+ *  apply. PostCommit runs afterwards over the committed fields only.
  *
  *  Purely observational: It never changes the apply result.
- *  The double read is skipped entirely when logging is off, so there is no cost on the hot path.
+ *  The comparison runs at every log level so the sysfs read path does not vary with logging
+ *  state; only the report itself is gated, inside LOG_DEBUG.
  */
-auto verify_commit_propagation(const AMDSmiGPUDevice& device,
-                               const amdsmi_fabric_ppod_config_t& committed) -> void;
-auto verify_commit_propagation(const AMDSmiGPUDevice& device,
-                               const amdsmi_fabric_vpod_config_t& committed) -> void;
-auto verify_commit_propagation(const AMDSmiGPUDevice& device,
-                               const amdsmi_fabric_station_config_t& committed) -> void;
+auto log_surface_divergence(const AMDSmiGPUDevice& device, const amdsmi_fabric_ppod_config_t& probe,
+                            SurfacePhase_t phase) -> void;
+auto log_surface_divergence(const AMDSmiGPUDevice& device, const amdsmi_fabric_vpod_config_t& probe,
+                            SurfacePhase_t phase) -> void;
+auto log_surface_divergence(const AMDSmiGPUDevice& device,
+                            const amdsmi_fabric_station_config_t& probe, SurfacePhase_t phase)
+    -> void;
 
 auto apply_ppod_config_at(const std::string& ualink_root, bool device_supports_ualink,
                           const amdsmi_fabric_ppod_config_t& config) -> amdsmi_status_t {
   if (auto status = validate_request_common(config.version, AMDSMI_FABRIC_PPOD_CONFIG_V1,
-                                            config.mask, kPpodValidMask, config.commit);
+                                            config.mask, kPpodValidMask);
       status != amdsmi_status_t::AMDSMI_STATUS_SUCCESS) {
     return status;
   }
@@ -582,10 +596,22 @@ auto apply_ppod_config_at(const std::string& ualink_root, bool device_supports_u
 
 auto apply_ppod_config(const AMDSmiGPUDevice& device, const amdsmi_fabric_ppod_config_t& config)
     -> amdsmi_status_t {
+  /**
+   *    A commit applies everything staged, not only this request's fields, so residue from an
+   *    earlier partial write is about to be applied too. Probe before staging, while that residue
+   *    is still distinguishable from this request's own writes
+   */
+  if (config.commit) {
+    auto probe = amdsmi_fabric_ppod_config_t{};
+    probe.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+    probe.mask = kPpodValidMask;
+    log_surface_divergence(device, probe, SurfacePhase_t::PreStage);
+  }
+
   const auto status =
       apply_ppod_config_at(get_ualink_root(device), device.device_has_ualink(), config);
   if (((status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS) && config.commit)) {
-    verify_commit_propagation(device, config);
+    log_surface_divergence(device, config, SurfacePhase_t::PostCommit);
   }
   return status;
 }
@@ -593,7 +619,7 @@ auto apply_ppod_config(const AMDSmiGPUDevice& device, const amdsmi_fabric_ppod_c
 auto apply_vpod_config_at(const std::string& ualink_root, bool device_supports_ualink,
                           const amdsmi_fabric_vpod_config_t& config) -> amdsmi_status_t {
   if (auto status = validate_request_common(config.version, AMDSMI_FABRIC_VPOD_CONFIG_V1,
-                                            config.mask, kVpodValidMask, config.commit);
+                                            config.mask, kVpodValidMask);
       status != amdsmi_status_t::AMDSMI_STATUS_SUCCESS) {
     return status;
   }
@@ -663,10 +689,17 @@ auto apply_vpod_config_at(const std::string& ualink_root, bool device_supports_u
 
 auto apply_vpod_config(const AMDSmiGPUDevice& device, const amdsmi_fabric_vpod_config_t& config)
     -> amdsmi_status_t {
+  if (config.commit) {
+    auto probe = amdsmi_fabric_vpod_config_t{};
+    probe.version = AMDSMI_FABRIC_VPOD_CONFIG_V1;
+    probe.mask = kVpodValidMask;
+    log_surface_divergence(device, probe, SurfacePhase_t::PreStage);
+  }
+
   const auto status =
       apply_vpod_config_at(get_ualink_root(device), device.device_has_ualink(), config);
   if (((status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS) && config.commit)) {
-    verify_commit_propagation(device, config);
+    log_surface_divergence(device, config, SurfacePhase_t::PostCommit);
   }
   return status;
 }
@@ -674,7 +707,7 @@ auto apply_vpod_config(const AMDSmiGPUDevice& device, const amdsmi_fabric_vpod_c
 auto apply_station_config_at(const std::string& ualink_root, bool device_supports_ualink,
                              const amdsmi_fabric_station_config_t& config) -> amdsmi_status_t {
   if (auto status = validate_request_common(config.version, AMDSMI_FABRIC_STATION_CONFIG_V1,
-                                            config.mask, kStationValidMask, config.commit);
+                                            config.mask, kStationValidMask);
       status != amdsmi_status_t::AMDSMI_STATUS_SUCCESS) {
     return status;
   }
@@ -688,8 +721,8 @@ auto apply_station_config_at(const std::string& ualink_root, bool device_support
   }
 
   /**
-   *    Build phase: format every masked field before any sysfs write
-   *    An invalid input must not leave partial sysfs state that a subsequent commit would apply
+   *    Build phase mirrors the ppod/vpod paths, but no station field has a value constraint
+   *    checkable here, so the driver is what rejects a bad value at write time
    */
   auto request_list = WriteRequestList_t{};
   auto writer = WriteRequestBuilder_t{request_list, config.mask, kUALOE_UALINK_STATIONS_SUBDIR};
@@ -706,10 +739,17 @@ auto apply_station_config_at(const std::string& ualink_root, bool device_support
 
 auto apply_station_config(const AMDSmiGPUDevice& device,
                           const amdsmi_fabric_station_config_t& config) -> amdsmi_status_t {
+  if (config.commit) {
+    auto probe = amdsmi_fabric_station_config_t{};
+    probe.version = AMDSMI_FABRIC_STATION_CONFIG_V1;
+    probe.mask = kStationValidMask;
+    log_surface_divergence(device, probe, SurfacePhase_t::PreStage);
+  }
+
   const auto status =
       apply_station_config_at(get_ualink_root(device), device.device_has_ualink(), config);
   if (((status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS) && config.commit)) {
-    verify_commit_propagation(device, config);
+    log_surface_divergence(device, config, SurfacePhase_t::PostCommit);
   }
   return status;
 }
@@ -770,8 +810,11 @@ auto query_ppod_config_at(const std::string& ualink_root, bool device_supports_u
               [&](const std::string& str_value) {
                 const auto count = parse_u32_list(str_value, config.data.local_accelerators,
                                                   AMDSMI_FABRIC_MAX_LOCAL_GPUS);
-                config.data.local_accelerator_count = static_cast<uint32_t>(count);
-                return (count > 0);
+                if (!count.has_value()) {
+                  return false;
+                }
+                config.data.local_accelerator_count = static_cast<uint32_t>(count.value());
+                return (count.value() > 0);
               });
   reader.read(AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH, kUALOE_BANDWIDTH,
               [&](const std::string& str_value) {
@@ -847,7 +890,7 @@ auto query_vpod_config_at(const std::string& ualink_root, bool device_supports_u
               [&](const std::string& str_value) {
                 const auto count = parse_u32_list(str_value, config.data.vpod_active_accelerators,
                                                   AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE);
-                return (count > 0);
+                return (count.has_value() && (count.value() > 0));
               });
   reader.read(AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE, kUALOE_ADDR_MODE,
               [&](const std::string& str_value) {
@@ -936,20 +979,28 @@ auto query_station_config(const AMDSmiGPUDevice& device, amdsmi_fabric_station_c
 namespace {
 
 /**
- *  Accumulates flat-vs-subtree disagreements for one config's committed fields.
- *  A field is only compared when its bit was in the committed mask.
- *  Both surfaces reporting the field lets us compare values. Exactly one reporting it is itself
- *  a divergence (the commit reached one surface but not the other).
+ *  Accumulates flat-vs-subtree disagreements over one config's compared mask.
+ *  Both surfaces reporting a field lets us compare values.
+ *
+ *  Presence handling differs by phase. PostCommit expects both surfaces to hold the committed
+ *  fields, so either direction is a divergence. PreStage treats only subtree-present/flat-absent
+ *  as one: the reverse is a field nobody has staged since boot, which says nothing about residue
+ *  and would otherwise fire on every field the caller has never written.
+ *
+ *  PostCommit assumes the driver leaves applied values in the write subtree. If it starts clearing
+ *  those files instead, every committed field reports a spurious PRESENCE-DIFF and that phase needs
+ *  reworking; PreStage degrades to silence on its own.
  */
 struct SurfaceComparison_t {
   std::ostringstream& m_report;
-  uint32_t m_committed_mask;
+  SurfacePhase_t m_phase;
+  uint32_t m_compared_mask;
   uint32_t m_subtree_mask;
   uint32_t m_flat_mask;
   int m_mismatches = 0;
 
   auto comparable(uint32_t bit, const char* name) -> bool {
-    if (((m_committed_mask & bit) == 0)) {
+    if (((m_compared_mask & bit) == 0)) {
       return false;
     }
 
@@ -959,7 +1010,10 @@ struct SurfaceComparison_t {
       return true;
     }
 
-    if ((subtree_has != flat_has)) {
+    const auto is_presence_diff =
+        ((m_phase == SurfacePhase_t::PostCommit) ? (subtree_has != flat_has)
+                                                 : (subtree_has && (!flat_has)));
+    if (is_presence_diff) {
       m_report << " | PRESENCE-DIFF " << name << " subtree=" << (subtree_has ? "present" : "absent")
                << " flat=" << (flat_has ? "present" : "absent");
       ++m_mismatches;
@@ -985,27 +1039,45 @@ struct SurfaceComparison_t {
   }
 };
 
+auto phase_label(SurfacePhase_t phase) -> const char* {
+  return ((phase == SurfacePhase_t::PreStage) ? "pre-stage" : "post-commit");
+}
+
+/**
+ *  An empty or unreadable write subtree is the clean pre-stage state, not a divergence. It is also
+ *  how a driver that clears the subtree on commit would read, so staying quiet keeps the log usable
+ *  if the retention assumption above turns out to be wrong.
+ *
+ *  The status has to be checked, not just the mask: the query functions leave @p config.mask at the
+ *  caller's request on their early-return paths, so a missing subtree would otherwise look like
+ *  every field is staged
+ */
+auto is_quiet_phase(SurfacePhase_t phase, amdsmi_status_t subtree_status, uint32_t subtree_mask)
+    -> bool {
+  return ((phase == SurfacePhase_t::PreStage) &&
+          ((subtree_status != amdsmi_status_t::AMDSMI_STATUS_SUCCESS) || (subtree_mask == 0)));
+}
+
 }  // namespace
 
-auto verify_commit_propagation(const AMDSmiGPUDevice& device,
-                               const amdsmi_fabric_ppod_config_t& committed) -> void {
-  if ((!ROCmLogging::Logger::getInstance()->isLoggerEnabled())) {
-    return;
-  }
-
+auto log_surface_divergence(const AMDSmiGPUDevice& device, const amdsmi_fabric_ppod_config_t& probe,
+                            SurfacePhase_t phase) -> void {
   auto subtree = amdsmi_fabric_ppod_config_t{};
-  subtree.version = committed.version;
-  subtree.mask = committed.mask;
+  subtree.version = probe.version;
+  subtree.mask = probe.mask;
   auto flat = subtree;
 
   const auto subtree_status = query_ppod_config(device, subtree);
   const auto flat_status = query_ppod_config(device, flat, kUALOE_UALINK_FLAT_SUBDIR);
+  if (is_quiet_phase(phase, subtree_status, subtree.mask)) {
+    return;
+  }
 
   auto report = std::ostringstream();
-  report << __func__ << " | ppod | subtree_status: " << subtree_status
-         << " | flat_status: " << flat_status;
+  report << __func__ << " | ppod | " << phase_label(phase)
+         << " | subtree_status: " << subtree_status << " | flat_status: " << flat_status;
 
-  auto diff = SurfaceComparison_t{report, committed.mask, subtree.mask, flat.mask};
+  auto diff = SurfaceComparison_t{report, phase, probe.mask, subtree.mask, flat.mask};
   diff.scalar(AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID, "accelerator_id", subtree.data.accelerator_id,
               flat.data.accelerator_id);
   diff.array(AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID, "ppod_id", subtree.data.ppod_id, flat.data.ppod_id,
@@ -1027,25 +1099,24 @@ auto verify_commit_propagation(const AMDSmiGPUDevice& device,
   LOG_DEBUG(report);
 }
 
-auto verify_commit_propagation(const AMDSmiGPUDevice& device,
-                               const amdsmi_fabric_vpod_config_t& committed) -> void {
-  if ((!ROCmLogging::Logger::getInstance()->isLoggerEnabled())) {
-    return;
-  }
-
+auto log_surface_divergence(const AMDSmiGPUDevice& device, const amdsmi_fabric_vpod_config_t& probe,
+                            SurfacePhase_t phase) -> void {
   auto subtree = amdsmi_fabric_vpod_config_t{};
-  subtree.version = committed.version;
-  subtree.mask = committed.mask;
+  subtree.version = probe.version;
+  subtree.mask = probe.mask;
   auto flat = subtree;
 
   const auto subtree_status = query_vpod_config(device, subtree);
   const auto flat_status = query_vpod_config(device, flat, kUALOE_UALINK_FLAT_SUBDIR);
+  if (is_quiet_phase(phase, subtree_status, subtree.mask)) {
+    return;
+  }
 
   auto report = std::ostringstream();
-  report << __func__ << " | vpod | subtree_status: " << subtree_status
-         << " | flat_status: " << flat_status;
+  report << __func__ << " | vpod | " << phase_label(phase)
+         << " | subtree_status: " << subtree_status << " | flat_status: " << flat_status;
 
-  auto surface_compare = SurfaceComparison_t{report, committed.mask, subtree.mask, flat.mask};
+  auto surface_compare = SurfaceComparison_t{report, phase, probe.mask, subtree.mask, flat.mask};
   surface_compare.scalar(AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID, "vpod_id", subtree.data.vpod_id,
                          flat.data.vpod_id);
   surface_compare.scalar(AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE, "vpod_size", subtree.data.vpod_size,
@@ -1063,25 +1134,25 @@ auto verify_commit_propagation(const AMDSmiGPUDevice& device,
   LOG_DEBUG(report);
 }
 
-auto verify_commit_propagation(const AMDSmiGPUDevice& device,
-                               const amdsmi_fabric_station_config_t& committed) -> void {
-  if ((!ROCmLogging::Logger::getInstance()->isLoggerEnabled())) {
-    return;
-  }
-
+auto log_surface_divergence(const AMDSmiGPUDevice& device,
+                            const amdsmi_fabric_station_config_t& probe, SurfacePhase_t phase)
+    -> void {
   auto subtree = amdsmi_fabric_station_config_t{};
-  subtree.version = committed.version;
-  subtree.mask = committed.mask;
+  subtree.version = probe.version;
+  subtree.mask = probe.mask;
   auto flat = subtree;
 
   const auto subtree_status = query_station_config(device, subtree);
   const auto flat_status = query_station_config(device, flat, kUALOE_UALINK_FLAT_SUBDIR);
+  if (is_quiet_phase(phase, subtree_status, subtree.mask)) {
+    return;
+  }
 
   auto report = std::ostringstream();
-  report << __func__ << " | station | subtree_status: " << subtree_status
-         << " | flat_status: " << flat_status;
+  report << __func__ << " | station | " << phase_label(phase)
+         << " | subtree_status: " << subtree_status << " | flat_status: " << flat_status;
 
-  auto surface_compare = SurfaceComparison_t{report, committed.mask, subtree.mask, flat.mask};
+  auto surface_compare = SurfaceComparison_t{report, phase, probe.mask, subtree.mask, flat.mask};
   surface_compare.scalar(AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS, "station_flags",
                          subtree.data.station_flags, flat.data.station_flags);
   surface_compare.scalar(AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS, "num_stations",

--- a/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
@@ -11,7 +11,6 @@ extern "C" {
 #include <sys/types.h>
 
 #include <algorithm>
-#include <array>
 #include <atomic>
 #include <cctype>
 #include <cerrno>
@@ -19,6 +18,7 @@ extern "C" {
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <iterator>
 #include <limits>
 #include <map>
 #include <memory>
@@ -540,12 +540,6 @@ inline const auto UALoeLinkTypeMap =
     UALoeLinkTypeMap_t{{"ualoe", amdsmi_fabric_type_t::AMDSMI_FABRIC_TYPE_UALOE},
                        {"ualink", amdsmi_fabric_type_t::AMDSMI_FABRIC_TYPE_UALINK}};
 
-using UALoeAddressModeTypeMap_t = std::map<std::string_view, amdsmi_fabric_npa_address_mode_t>;
-inline const auto UALoeAddressModeTypeMap = UALoeAddressModeTypeMap_t{
-    {"aliasing", amdsmi_fabric_npa_address_mode_t::AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING},
-    {"identification",
-     amdsmi_fabric_npa_address_mode_t::AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_IDENTIFICATION}};
-
 using UALoeAcceleratorStateTypeMap_t =
     std::map<std::string_view, amdsmi_fabric_accelerator_vpod_state_t>;
 inline const auto UALoeAcceleratorStateTypeMap = UALoeAcceleratorStateTypeMap_t{
@@ -556,11 +550,6 @@ inline const auto UALoeAcceleratorStateTypeMap = UALoeAcceleratorStateTypeMap_t{
     {"ready", amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_READY},
     {"active", amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE},
     {"error", amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ERROR}};
-
-// Default populated values for all link info types, with max values for each field
-using EnumDefaultType_t = std::int32_t;
-using AcceleratorArrayType_t = std::uint32_t;
-using PPodIDType_t = std::uint8_t;
 
 auto log_ualoe_file_info(std::ostringstream&& log_stream_info) -> void {
   std::ostringstream outstream;
@@ -577,7 +566,7 @@ auto get_fabric_type(const std::string& link_value, amdsmi_fabric_info_t& local_
   std::transform(fabric_type_str.begin(), fabric_type_str.end(), fabric_type_str.begin(),
                  [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
 
-  const std::string_view fabric_type_sv{fabric_type_str};
+  const auto fabric_type_sv = std::string_view{fabric_type_str};
   if (auto fabric_type_itr = UALoeLinkTypeMap.find(fabric_type_sv);
       fabric_type_itr != UALoeLinkTypeMap.end()) {
     local_fabric_info.fabric_info.v1.fabric_type = fabric_type_itr->second;
@@ -591,286 +580,29 @@ auto get_fabric_type(const std::string& link_value, amdsmi_fabric_info_t& local_
   log_ualoe_file_info(std::move(outstream));
 }
 
-auto get_accelerator_id(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info)
-    -> void {
-  auto result = parse_number_from_string<decltype(local_fabric_info.fabric_info.v1.accelerator_id)>(
-      link_value);
-  if (result.has_value()) {
-    local_fabric_info.fabric_info.v1.accelerator_id =
-        static_cast<decltype(local_fabric_info.fabric_info.v1.accelerator_id)>(result.value());
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value
-            << " | accelerator_id: " << local_fabric_info.fabric_info.v1.accelerator_id << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-auto get_bandwidth(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info) -> void {
-  auto result =
-      parse_number_from_string<decltype(local_fabric_info.fabric_info.v1.bandwidth)>(link_value);
-  if (result.has_value()) {
-    local_fabric_info.fabric_info.v1.bandwidth =
-        static_cast<decltype(local_fabric_info.fabric_info.v1.bandwidth)>(result.value());
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value
-            << " | bandwidth: " << local_fabric_info.fabric_info.v1.bandwidth << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-auto get_latency(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info) -> void {
-  auto result =
-      parse_number_from_string<decltype(local_fabric_info.fabric_info.v1.latency)>(link_value);
-  if (result.has_value()) {
-    local_fabric_info.fabric_info.v1.latency =
-        static_cast<decltype(local_fabric_info.fabric_info.v1.latency)>(result.value());
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value
-            << " | latency: " << local_fabric_info.fabric_info.v1.latency << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-template <std::size_t MaxElems>
-auto get_ppod_id(const std::string& link_value, std::array<PPodIDType_t, MaxElems>& local_ppod_id)
-    -> void {
-  std::fill(std::begin(local_ppod_id), std::end(local_ppod_id), 0);
-  if (link_value.empty()) {
-    return;
-  }
-
-  /*
-   *  -  2 hex characters per byte (0x1234567890abcdef)
-   *  - 16 bytes per 128-bit UUID (MaxElems)
-   */
-  constexpr auto kHEX_CHARS_PER_BYTE = std::size_t(2);
-  auto value_view = std::string_view(link_value);
-  if ((value_view.size() >= kHEX_CHARS_PER_BYTE) && (value_view[0] == '0') &&
-      ((value_view[1] == 'x') || (value_view[1] == 'X'))) {
-    value_view.remove_prefix(kHEX_CHARS_PER_BYTE);
-  }
-
-  auto byte_idx = std::size_t(0);
-  auto char_idx = std::size_t(0);
-  while ((byte_idx < MaxElems) && ((char_idx + kHEX_CHARS_PER_BYTE) <= value_view.size())) {
-    /*
-     *  Convert two hex characters to a single byte
-     */
-    auto higher_nibble = std::uint8_t(0);
-    auto lower_nibble = std::uint8_t(0);
-    if (std::isxdigit(static_cast<unsigned char>(value_view[char_idx])) &&
-        std::isxdigit(static_cast<unsigned char>(value_view[char_idx + 1]))) {
-      auto hex_digit = [](char ch) -> std::uint8_t {
-        /*
-         *  Convert a hex character to its numeric value
-         *  - '0' to '9' -> 0 to 9
-         *  - 'a' to 'f' -> 10 to 15
-         *  - 'A' to 'F' -> 10 to 15
-         */
-        if ((ch >= '0') && (ch <= '9')) {
-          return static_cast<std::uint8_t>(ch - '0');
-        }
-        if ((ch >= 'a') && (ch <= 'f')) {
-          return static_cast<std::uint8_t>(10 + (ch - 'a'));
-        }
-
-        return static_cast<std::uint8_t>(10 + (ch - 'A'));
-      };
-
-      higher_nibble = hex_digit(value_view[char_idx]);
-      lower_nibble = hex_digit(value_view[char_idx + 1]);
-      local_ppod_id[byte_idx++] = static_cast<PPodIDType_t>((higher_nibble << 4) | lower_nibble);
-    }
-
-    char_idx += kHEX_CHARS_PER_BYTE;
-
-    /*
-     *  Skip single separators (e.g. '-' in UUID) between its bytes
-     */
-    while ((char_idx < value_view.size()) &&
-           ((value_view[char_idx] == '-') ||
-            (std::isspace(static_cast<unsigned char>(value_view[char_idx]))))) {
-      ++char_idx;
-    }
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value << " | local_ppod_id (hex): ";
-  for (auto idx = std::size_t(0); idx < byte_idx; ++idx) {
-    outstream << std::hex << std::setfill('0') << std::setw(2)
-              << static_cast<unsigned int>(local_ppod_id[idx]);
-  }
-  outstream << std::dec;
-  outstream << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-auto get_ppod_size(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info) -> void {
-  auto result =
-      parse_number_from_string<decltype(local_fabric_info.fabric_info.v1.ppod_size)>(link_value);
-  if (result.has_value()) {
-    local_fabric_info.fabric_info.v1.ppod_size =
-        static_cast<decltype(local_fabric_info.fabric_info.v1.ppod_size)>(result.value());
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value
-            << " | ppod_size: " << local_fabric_info.fabric_info.v1.ppod_size << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-auto get_vpod_id(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info) -> void {
-  auto result =
-      parse_number_from_string<decltype(local_fabric_info.fabric_info.v1.vpod_id)>(link_value);
-  if (result.has_value()) {
-    local_fabric_info.fabric_info.v1.vpod_id =
-        static_cast<decltype(local_fabric_info.fabric_info.v1.vpod_id)>(result.value());
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value
-            << " | vpod_id: " << local_fabric_info.fabric_info.v1.vpod_id << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-auto get_vpod_size(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info) -> void {
-  auto result =
-      parse_number_from_string<decltype(local_fabric_info.fabric_info.v1.vpod_size)>(link_value);
-  if (result.has_value()) {
-    local_fabric_info.fabric_info.v1.vpod_size =
-        static_cast<decltype(local_fabric_info.fabric_info.v1.vpod_size)>(result.value());
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value
-            << " | vpod_size: " << local_fabric_info.fabric_info.v1.vpod_size << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-/*
- *  Note:   For get_vpod_active_accelerators(), and get_local_accelerators(),
- *          we handle all lines from the file at once, and then fill the array.
- */
-template <std::size_t MaxElems>
-auto get_vpod_active_accelerators(
-    const UALoeLinkInfoLines_t& file_lines,
-    std::array<AcceleratorArrayType_t, MaxElems>& local_active_accelerators) -> void {
-  std::fill(std::begin(local_active_accelerators), std::end(local_active_accelerators),
-            std::numeric_limits<AcceleratorArrayType_t>::max());
-
-  auto idx = std::size_t(0);
-  auto accel_count = std::size_t(0);
-  for (const auto& line : file_lines) {
-    if (idx >= MaxElems) {
-      break;
-    }
-
-    // We are supposed to only have 1 line per file, and separated by spaces
-    auto accel_vector = split_string(line, ' ');
-
-    if (!accel_vector.empty()) {
-      accel_count = accel_vector.size();
-      for (const auto& accel_value_str : accel_vector) {
-        if (idx < MaxElems) {
-          auto result = parse_number_from_string<AcceleratorArrayType_t>(accel_value_str);
-          if (result.has_value()) {
-            local_active_accelerators[idx++] = static_cast<AcceleratorArrayType_t>(result.value());
-          }
-        }
-      }
-    }
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | File lines: " << file_lines.size()
-            << " | local_active_accelerators_count: " << accel_count
-            << "local_active_accelerators: ";
-  std::copy(std::begin(local_active_accelerators), std::end(local_active_accelerators),
-            amd::smi::make_ostream_joiner(&outstream, ", "));
-  outstream << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-template <std::size_t MaxElems>
-auto get_local_accelerators(const UALoeLinkInfoLines_t& file_lines,
-                            std::array<AcceleratorArrayType_t, MaxElems>& local_accelerators)
-    -> void {
-  std::fill(std::begin(local_accelerators), std::end(local_accelerators),
-            std::numeric_limits<AcceleratorArrayType_t>::max());
-
-  auto idx = std::size_t(0);
-  auto accel_count = std::size_t(0);
-  for (const auto& line : file_lines) {
-    if (idx >= MaxElems) {
-      break;
-    }
-
-    // We are supposed to only have 1 line per file, and separated by spaces
-    auto accel_vector = split_string(line, ' ');
-    if (!accel_vector.empty()) {
-      accel_count = accel_vector.size();
-      for (const auto& accel_value_str : accel_vector) {
-        if (idx < MaxElems) {
-          auto result = parse_number_from_string<AcceleratorArrayType_t>(accel_value_str);
-          if (result.has_value()) {
-            local_accelerators[idx++] = static_cast<AcceleratorArrayType_t>(result.value());
-          }
-        }
-      }
-    }
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | File lines: " << file_lines.size()
-            << " | local_accelerators_count: " << accel_count << " | local_accelerators: ";
-  std::copy(std::begin(local_accelerators), std::end(local_accelerators),
-            amd::smi::make_ostream_joiner(&outstream, ", "));
-  outstream << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-auto get_addr_mode(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info) -> void {
-  // Convert the string to lowercase
-  auto addr_mode_str = link_value;
-  std::transform(addr_mode_str.begin(), addr_mode_str.end(), addr_mode_str.begin(),
-                 [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-
-  const std::string_view addr_mode_sv{addr_mode_str};
-  if (auto addr_mode_itr = UALoeAddressModeTypeMap.find(addr_mode_sv);
-      addr_mode_itr != UALoeAddressModeTypeMap.end()) {
-    local_fabric_info.fabric_info.v1.addr_mode = addr_mode_itr->second;
-  } else {
-    local_fabric_info.fabric_info.v1.addr_mode =
-        amdsmi_fabric_npa_address_mode_t::AMDSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN;
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value << " -> " << addr_mode_str
-            << " | addr_mode: " << local_fabric_info.fabric_info.v1.addr_mode << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-auto get_accel_state(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info)
-    -> void {
-  // Convert the string to lowercase
+auto parse_accel_state_from_sysfs_line(const std::string& link_value)
+    -> amdsmi_fabric_accelerator_vpod_state_t {
+  auto accel_state =
+      amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN;
   auto accel_state_str = link_value;
   std::transform(accel_state_str.begin(), accel_state_str.end(), accel_state_str.begin(),
                  [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
 
-  const std::string_view accel_state_sv{accel_state_str};
+  const auto accel_state_sv = std::string_view{accel_state_str};
   if (auto accel_state_itr = UALoeAcceleratorStateTypeMap.find(accel_state_sv);
       accel_state_itr != UALoeAcceleratorStateTypeMap.end()) {
-    local_fabric_info.fabric_info.v1.accel_state = accel_state_itr->second;
-  } else {
-    local_fabric_info.fabric_info.v1.accel_state =
-        amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN;
+    return accel_state_itr->second;
   }
 
+  return accel_state;
+}
+
+auto get_accel_state(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info)
+    -> void {
+  local_fabric_info.fabric_info.v1.accel_state = parse_accel_state_from_sysfs_line(link_value);
+
   std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value << " -> " << accel_state_str
+  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value
             << " | accel_state: " << local_fabric_info.fabric_info.v1.accel_state << " |";
   log_ualoe_file_info(std::move(outstream));
 }
@@ -920,7 +652,7 @@ auto read_fabric_info_file(const std::string& sysfs_file_path,
 /*
  *  Scan "/sys/bus/pci/drivers/ifoe/" for PCI device symlink names (BDF form)
  *  For entries where the domain, bus, and device match gpu_bdf (same physical PCIe device / slot;
- * any function), are inserted into fabric_bdf_list with the full BDF including function from sysfs
+ *  any function), are inserted into fabric_bdf_list with the full BDF including function from sysfs
  */
 auto populate_ifoe_fabric_bdf_list(const amdsmi_bdf_t& gpu_bdf, FabricBDFList_t& fabric_bdf_list)
     -> amdsmi_status_t {
@@ -1006,19 +738,19 @@ auto AMDSmiGPUDevice::get_ifoe_bdf_string() const -> std::string {
   return {};
 }
 
+auto AMDSmiGPUDevice::get_ualink_directory_path() const -> std::string {
+  return std::string(kUALOE_BASE_PATH) + get_gpu_path() + std::string(kUALOE_UALINK_DIRECTORY);
+}
+
 // Check if this GPU device has ualink sysfs directory (required for UALOE)
-// Uses the same path construction as get_fabric_info_from_ualoe()
 bool AMDSmiGPUDevice::device_has_ualink() const {
   if (!has_ifoe_related_bdf()) {
     return false;
   }
 
-  // Use the same ualink path logic as get_fabric_info_from_ualoe()
-  const auto ualink_directory =
-      (std::string(kUALOE_BASE_PATH) + get_gpu_path() + std::string(kUALOE_UALINK_DIRECTORY));
-  const auto ualink_directory_path = std::filesystem::path(ualink_directory);
-
-  return std::filesystem::is_directory(ualink_directory_path);
+  std::error_code err_code;
+  return std::filesystem::is_directory(std::filesystem::path(get_ualink_directory_path()),
+                                       err_code);
 }
 
 auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_info,
@@ -1029,11 +761,6 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
   LOG_TRACE(outstream);
 
   auto local_fabric_info = amdsmi_fabric_info_t{};
-  auto local_ppod_id = std::array<std::uint8_t, AMDSMI_FABRIC_PPOD_ID_SIZE>{};
-  auto local_active_accelerators = std::array<gpu_device::details::AcceleratorArrayType_t,
-                                              AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE>{};
-  auto local_accelerators =
-      std::array<gpu_device::details::AcceleratorArrayType_t, AMDSMI_FABRIC_MAX_LOCAL_GPUS>{};
 
   if (has_ifoe_related_bdf()) {
     local_fabric_info.bdf = *fabric_bdf_list_.begin();
@@ -1041,60 +768,47 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
     local_fabric_info.bdf = bdf_;
   }
 
-  /*
-   *  TODO: We need to define a which offset (kUALOE_BDF_OFFSET) will be used for the function
-   * number (in BDF).
-   *
-   *  - PCIe BDF format:
-   *      - Bits 31-24: Bus number (8 bits)
-   *      - Bits 23-16: Device number (5 bits, but stored in 8 bits)
-   *      - Bits  15-8: Function number (3 bits, but stored in 8 bits)
-   *      - Bits   7-0: Other info
-   *
-   *  - 0x07 is the mask for the function number (extracts only the lower 3 bits)
-   *      - 00000111 (last 3 bits are 1, all others 0)
-   */
-  // local_fabric_info.bdf.function_number = ((bdf_.function_number + kUALOE_BDF_OFFSET) & 0x07);
   local_fabric_info.fabric_version =
       std::numeric_limits<decltype(local_fabric_info.fabric_version)>::max();
 
-  local_fabric_info.fabric_info.v1.fabric_type = static_cast<amdsmi_fabric_type_t>(
-      std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.fabric_type)>::max());
+  auto& v1 = local_fabric_info.fabric_info.v1;
 
-  local_fabric_info.fabric_info.v1.accelerator_id =
-      std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.accelerator_id)>::max();
+  /**
+   *    Flat surface: owned by this reader (fabric_type + accel_state).
+   *    Both start at their sentinel and are overwritten only when the corresponding flat file
+   *    yields usable content
+   */
+  v1.fabric_type = amdsmi_fabric_type_t::AMDSMI_FABRIC_TYPE_UNKNOWN;
+  v1.accel_state =
+      amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN;
 
-  local_fabric_info.fabric_info.v1.bandwidth =
-      std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.bandwidth)>::max();
+  /**
+   *    Ppod/Vpod/Station payloads: sentinel-init here so a subtree that is absent (its
+   *    'query_fabric_*_config()' returns NOT_SUPPORTED) leaves documented sentinels
+   *
+   *    When a subtree is present the reader re-applies these same sentinels for fields it cannot
+   *    read, so the copy below is authoritative.
+   */
+  v1.ppod.accelerator_id = std::numeric_limits<decltype(v1.ppod.accelerator_id)>::max();
+  std::fill(std::begin(v1.ppod.ppod_id), std::end(v1.ppod.ppod_id),
+            static_cast<std::uint8_t>(0x99));
+  v1.ppod.ppod_size = std::numeric_limits<decltype(v1.ppod.ppod_size)>::max();
+  std::fill(std::begin(v1.ppod.local_accelerators), std::end(v1.ppod.local_accelerators),
+            std::numeric_limits<std::uint32_t>::max());
+  v1.ppod.local_accelerator_count = 0;
+  v1.ppod.bandwidth = std::numeric_limits<decltype(v1.ppod.bandwidth)>::max();
+  v1.ppod.latency = std::numeric_limits<decltype(v1.ppod.latency)>::max();
 
-  local_fabric_info.fabric_info.v1.latency =
-      std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.latency)>::max();
+  v1.vpod.vpod_id = std::numeric_limits<decltype(v1.vpod.vpod_id)>::max();
+  v1.vpod.vpod_size = std::numeric_limits<decltype(v1.vpod.vpod_size)>::max();
+  std::fill(std::begin(v1.vpod.vpod_active_accelerators),
+            std::end(v1.vpod.vpod_active_accelerators), std::numeric_limits<std::uint32_t>::max());
+  v1.vpod.addr_mode = amdsmi_fabric_npa_address_mode_t::AMDSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN;
 
-  // Sentinel when sysfs provides no ppod_id: UUID 99999999-9999-9999-9999-999999999999 (16 × 0x99)
-  std::fill(std::begin(local_fabric_info.fabric_info.v1.ppod_id),
-            std::end(local_fabric_info.fabric_info.v1.ppod_id), static_cast<std::uint8_t>(0x99));
-
-  local_fabric_info.fabric_info.v1.ppod_size =
-      std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.ppod_size)>::max();
-
-  local_fabric_info.fabric_info.v1.vpod_id =
-      std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.vpod_id)>::max();
-
-  local_fabric_info.fabric_info.v1.vpod_size =
-      std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.vpod_size)>::max();
-
-  local_fabric_info.fabric_info.v1.addr_mode = static_cast<amdsmi_fabric_npa_address_mode_t>(
-      std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.addr_mode)>::max());
-
-  local_fabric_info.fabric_info.v1.accel_state =
-      static_cast<amdsmi_fabric_accelerator_vpod_state_t>(
-          std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.accel_state)>::max());
-
-  std::fill(std::begin(local_active_accelerators), std::end(local_active_accelerators),
-            std::numeric_limits<gpu_device::details::AcceleratorArrayType_t>::max());
-  std::fill(std::begin(local_accelerators), std::end(local_accelerators),
-            std::numeric_limits<gpu_device::details::AcceleratorArrayType_t>::max());
-  std::fill(std::begin(local_ppod_id), std::end(local_ppod_id), static_cast<std::uint8_t>(0));
+  v1.station.station_flags = std::numeric_limits<decltype(v1.station.station_flags)>::max();
+  v1.station.num_stations = std::numeric_limits<decltype(v1.station.num_stations)>::max();
+  std::fill(std::begin(v1.station.lane_en_bitmap), std::end(v1.station.lane_en_bitmap),
+            static_cast<std::uint8_t>(0));
 
   /**
    * Check if the 'ualink' directory exists in the sysfs path, if not, return
@@ -1103,8 +817,7 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
    * is the AMDSMI processor index and is not guaranteed to equal the DRM card index when devices
    * are gapped or filtered.
    */
-  const auto ualink_directory =
-      (std::string(kUALOE_BASE_PATH) + get_gpu_path() + std::string(kUALOE_UALINK_DIRECTORY));
+  const auto ualink_directory = get_ualink_directory_path();
   const auto ualink_directory_path = std::filesystem::path(ualink_directory);
 
   outstream << __PRETTY_FUNCTION__ << " | gpu_path: " << get_gpu_path()
@@ -1112,7 +825,8 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
             << " | ualink_directory: " << ualink_directory << " |";
   LOG_DEBUG(outstream);
 
-  if (!std::filesystem::is_directory(ualink_directory_path)) {
+  std::error_code err_code;
+  if (!std::filesystem::is_directory(ualink_directory_path, err_code)) {
     outstream << __PRETTY_FUNCTION__
               << " | UALOE sysfs not present: " << ualink_directory_path.string()
               << " | returning AMDSMI_STATUS_NOT_SUPPORTED";
@@ -1121,20 +835,18 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
     return amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED;
   }
 
-  auto link_info_files_in_scope = std::size_t(0);
-  auto link_info_files_with_usable_content = std::size_t(0);
+  /**
+   *    Flat surface: (fabric_type + accel_state only). UALoeLinkInfoMap is trimmed to these two
+   *    The Ppod/Vpod/Station payloads come from the subtree readers below, not from here
+   */
+  auto flat_files_with_usable_content = std::size_t(0);
   for (const auto& [link_info_type_key, link_info_file_value] : UALoeLinkInfoMap) {
-    // If not all, apply filter based on the link info type
     if ((link_info_type != UALoeLinkInfo_t::ALL_LINK_INFO) &&
         (link_info_type_key != link_info_type)) {
       continue;
     }
 
-    ++link_info_files_in_scope;
     const auto sysfs_file_path = (ualink_directory + "/" + std::string(link_info_file_value));
-    outstream << __PRETTY_FUNCTION__ << " | sysfs_file_path: " << sysfs_file_path << " |";
-    LOG_DEBUG(outstream);
-
     auto ualoe_file_lines = UALoeLinkInfoLines_t{};
     const auto read_status =
         gpu_device::details::read_fabric_info_file(sysfs_file_path, ualoe_file_lines);
@@ -1146,71 +858,11 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
       continue;
     }
 
-    ++link_info_files_with_usable_content;
-    outstream << __PRETTY_FUNCTION__ << " | UALOE File: " << sysfs_file_path
-              << " | Lines: " << ualoe_file_lines.size()
-              << " | Link Info Type: " << static_cast<UALoeLinkInfoType_t>(link_info_type_key)
-              << " |";
-    LOG_DEBUG(outstream);
-
-    /*
-     *  List-based fields: one value per line; pass all lines at once
-     *      - VPOD_ACTIVE_ACCELS
-     *      - LOCAL_ACCELS
-     */
-    if (link_info_type_key == UALoeLinkInfo_t::VPOD_ACTIVE_ACCELS) {
-      gpu_device::details::get_vpod_active_accelerators(ualoe_file_lines,
-                                                        local_active_accelerators);
-      std::copy(local_active_accelerators.data(),
-                (local_active_accelerators.data() + local_active_accelerators.size()),
-                local_fabric_info.fabric_info.v1.vpod_active_accelerators);
-      continue;
-    }
-    if (link_info_type_key == UALoeLinkInfo_t::LOCAL_ACCELS) {
-      gpu_device::details::get_local_accelerators(ualoe_file_lines, local_accelerators);
-      std::copy(local_accelerators.data(), (local_accelerators.data() + local_accelerators.size()),
-                local_fabric_info.fabric_info.v1.local_accelerators);
-      continue;
-    }
-
+    ++flat_files_with_usable_content;
     for (const auto& link_value : ualoe_file_lines) {
       switch (link_info_type_key) {
         case UALoeLinkInfo_t::LINK_TYPE:
           gpu_device::details::get_fabric_type(link_value, local_fabric_info);
-          break;
-
-        case UALoeLinkInfo_t::ACCEL_ID:
-          gpu_device::details::get_accelerator_id(link_value, local_fabric_info);
-          break;
-
-        case UALoeLinkInfo_t::BANDWIDTH:
-          gpu_device::details::get_bandwidth(link_value, local_fabric_info);
-          break;
-
-        case UALoeLinkInfo_t::LATENCY:
-          gpu_device::details::get_latency(link_value, local_fabric_info);
-          break;
-
-        case UALoeLinkInfo_t::PPOD_ID:
-          gpu_device::details::get_ppod_id(link_value, local_ppod_id);
-          std::copy(local_ppod_id.data(), (local_ppod_id.data() + local_ppod_id.size()),
-                    local_fabric_info.fabric_info.v1.ppod_id);
-          break;
-
-        case UALoeLinkInfo_t::PPOD_SIZE:
-          gpu_device::details::get_ppod_size(link_value, local_fabric_info);
-          break;
-
-        case UALoeLinkInfo_t::VPOD_ID:
-          gpu_device::details::get_vpod_id(link_value, local_fabric_info);
-          break;
-
-        case UALoeLinkInfo_t::VPOD_SIZE:
-          gpu_device::details::get_vpod_size(link_value, local_fabric_info);
-          break;
-
-        case UALoeLinkInfo_t::ADDR_MODE:
-          gpu_device::details::get_addr_mode(link_value, local_fabric_info);
           break;
 
         case UALoeLinkInfo_t::ACCEL_STATE:
@@ -1224,22 +876,76 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
   }
 
   /**
-   * For cases where the 'ualink' directory exists in the sysfs path, but we can read any usable
-   * content, return AMDSMI_STATUS_NO_DATA.
+   *    Ppod/Vpod/Station: authoritative subtree readers.
+   *    Each returns AMDSMI_STATUS_SUCCESS, AMDSMI_STATUS_NO_DATA, AMDSMI_STATUS_NOT_SUPPORTED
+   *
+   *    On anything but AMDSMI_STATUS_NOT_SUPPORTED its data payload (sentinels plus populated
+   *    fields) is copied into the info struct
+   *
+   *    These device-level queries assume the per-GPU mutex is already held by the API entry point
    */
-  fabric_info = local_fabric_info;
-  if (link_info_files_in_scope == 0) {
-    return amdsmi_status_t::AMDSMI_STATUS_NO_DATA;
+  auto is_any_plane_success = false;
+  auto ppod_cfg = amdsmi_fabric_ppod_config_t{};
+  ppod_cfg.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  ppod_cfg.mask = (AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID | AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID |
+                   AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE | AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS |
+                   AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH | AMDSMI_FABRIC_PPOD_FIELD_LATENCY);
+  const auto ppod_status = query_fabric_ppod_config(ppod_cfg);
+  if (ppod_status != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
+    v1.ppod = ppod_cfg.data;
   }
+  is_any_plane_success =
+      (is_any_plane_success || (ppod_status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS));
+
+  auto vpod_cfg = amdsmi_fabric_vpod_config_t{};
+  vpod_cfg.version = AMDSMI_FABRIC_VPOD_CONFIG_V1;
+  vpod_cfg.mask =
+      (AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID | AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE |
+       AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS | AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE);
+  const auto vpod_status = query_fabric_vpod_config(vpod_cfg);
+  if (vpod_status != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
+    v1.vpod = vpod_cfg.data;
+  }
+  is_any_plane_success =
+      (is_any_plane_success || (vpod_status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS));
+
+  auto station_cfg = amdsmi_fabric_station_config_t{};
+  station_cfg.version = AMDSMI_FABRIC_STATION_CONFIG_V1;
+  station_cfg.mask = (AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS | AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP |
+                      AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS);
+  const auto station_status = query_fabric_station_config(station_cfg);
+  if (station_status != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
+    v1.station = station_cfg.data;
+  }
+  is_any_plane_success =
+      (is_any_plane_success || (station_status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS));
+
+  fabric_info = local_fabric_info;
 
   /**
-   * For cases where the 'ualink' directory exists in the sysfs path, and we can read all files with
-   * usable content, return AMDSMI_STATUS_SUCCESS. Otherwise, return AMDSMI_STATUS_UNEXPECTED_DATA
-   * (some files are missing or empty).
+   *    Driver contract: a present sysfs file means the feature is supported; a
+   *    present-but-empty IFoE file means supported-but-unconfigured.
+   *    File presence alone can't tell the two apart, so accel_state below is what separates a
+   *    configured read (SUCCESS) from an unconfigured one (NOT_INIT).
    */
-  return (link_info_files_with_usable_content == link_info_files_in_scope)
-             ? amdsmi_status_t::AMDSMI_STATUS_SUCCESS
-             : amdsmi_status_t::AMDSMI_STATUS_UNEXPECTED_DATA;
+  auto status_code = (((flat_files_with_usable_content > 0) || is_any_plane_success)
+                          ? amdsmi_status_t::AMDSMI_STATUS_SUCCESS
+                          : amdsmi_status_t::AMDSMI_STATUS_NO_DATA);
+
+  /**
+   *  Reuse the accel_state already parsed into v1 (avoids a second sysfs read) so the status
+   *  matches the value returned in fabric_info. Relies on the flat loop having read accel_state:
+   *  a link_info_type that excludes it leaves the UNKNOWN sentinel and forces NOT_INIT.
+   */
+  if (is_any_plane_success &&
+      ((v1.accel_state == amdsmi_fabric_accelerator_vpod_state_t::
+                              AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNCONFIGURED) ||
+       (v1.accel_state ==
+        amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN))) {
+    status_code = amdsmi_status_t::AMDSMI_STATUS_NOT_INIT;
+  }
+
+  return status_code;
 }
 
 }  // namespace amd::smi

--- a/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
@@ -14,6 +14,7 @@ extern "C" {
 #include <atomic>
 #include <cctype>
 #include <cerrno>
+#include <cstddef>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -30,6 +31,7 @@ extern "C" {
 #include <vector>
 
 #include "amd_smi/impl/amd_smi_common.h"
+#include "amd_smi/impl/amd_smi_fabric_ualink.h"
 #include "amd_smi/impl/amd_smi_utils.h"
 #include "amd_smi/impl/fdinfo.h"
 #include "rocm_smi/rocm_smi_kfd.h"
@@ -559,7 +561,7 @@ auto log_ualoe_file_info(std::ostringstream&& log_stream_info) -> void {
 }
 
 // Set values based on link info type
-auto get_fabric_type(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info)
+auto get_fabric_type(const std::string& link_value, amdsmi_fabric_info_v2_t& local_fabric_info)
     -> void {
   // Convert the string to lowercase
   auto fabric_type_str = link_value;
@@ -569,14 +571,14 @@ auto get_fabric_type(const std::string& link_value, amdsmi_fabric_info_t& local_
   const auto fabric_type_sv = std::string_view{fabric_type_str};
   if (auto fabric_type_itr = UALoeLinkTypeMap.find(fabric_type_sv);
       fabric_type_itr != UALoeLinkTypeMap.end()) {
-    local_fabric_info.fabric_info.v1.fabric_type = fabric_type_itr->second;
+    local_fabric_info.fabric_type = fabric_type_itr->second;
   } else {
-    local_fabric_info.fabric_info.v1.fabric_type = amdsmi_fabric_type_t::AMDSMI_FABRIC_TYPE_UNKNOWN;
+    local_fabric_info.fabric_type = amdsmi_fabric_type_t::AMDSMI_FABRIC_TYPE_UNKNOWN;
   }
 
   std::ostringstream outstream;
   outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value << " -> " << fabric_type_str
-            << " | fabric_type: " << local_fabric_info.fabric_info.v1.fabric_type << " |";
+            << " | fabric_type: " << local_fabric_info.fabric_type << " |";
   log_ualoe_file_info(std::move(outstream));
 }
 
@@ -597,13 +599,13 @@ auto parse_accel_state_from_sysfs_line(const std::string& link_value)
   return accel_state;
 }
 
-auto get_accel_state(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info)
+auto get_accel_state(const std::string& link_value, amdsmi_fabric_info_v2_t& local_fabric_info)
     -> void {
-  local_fabric_info.fabric_info.v1.accel_state = parse_accel_state_from_sysfs_line(link_value);
+  local_fabric_info.accel_state = parse_accel_state_from_sysfs_line(link_value);
 
   std::ostringstream outstream;
   outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value
-            << " | accel_state: " << local_fabric_info.fabric_info.v1.accel_state << " |";
+            << " | accel_state: " << local_fabric_info.accel_state << " |";
   log_ualoe_file_info(std::move(outstream));
 }
 
@@ -692,6 +694,64 @@ auto populate_ifoe_fabric_bdf_list(const amdsmi_bdf_t& gpu_bdf, FabricBDFList_t&
   return status_code;
 }
 
+/*
+ *  Additive fields come out of amdsmi_fabric_info_v2_t::reserved, never off the end, so this size
+ *  must not move again. Asserted here rather than in the public header so consumers pay nothing
+ *  for it, and unconditionally rather than in the tests, which are an opt-in build
+ */
+constexpr auto kFabricInfoV2Size = std::size_t{480};
+static_assert(sizeof(amdsmi_fabric_info_v2_t) == kFabricInfoV2Size,
+              "amdsmi_fabric_info_v2_t size is frozen; grow it by carving from reserved");
+
+/*
+ *  Project the version 2 payload onto the frozen version 1 layout. The station data and
+ *  local_accelerator_count have no version 1 equivalent and are dropped
+ */
+auto flatten_v2_to_v1(const amdsmi_fabric_info_v2_t& source, amdsmi_fabric_info_v1_t& destination)
+    -> void {
+  destination.accelerator_id = source.ppod.accelerator_id;
+  destination.fabric_type = source.fabric_type;
+  destination.bandwidth = source.ppod.bandwidth;
+  destination.latency = source.ppod.latency;
+  std::copy(std::begin(source.ppod.ppod_id), std::end(source.ppod.ppod_id),
+            std::begin(destination.ppod_id));
+  destination.ppod_size = source.ppod.ppod_size;
+  destination.vpod_id = source.vpod.vpod_id;
+  destination.vpod_size = source.vpod.vpod_size;
+  std::copy(std::begin(source.vpod.vpod_active_accelerators),
+            std::end(source.vpod.vpod_active_accelerators),
+            std::begin(destination.vpod_active_accelerators));
+  std::copy(std::begin(source.ppod.local_accelerators), std::end(source.ppod.local_accelerators),
+            std::begin(destination.local_accelerators));
+  destination.addr_mode = source.vpod.addr_mode;
+  destination.accel_state = source.accel_state;
+}
+
+/*
+ *  Bounded write into caller memory: a caller that did not request version 2 only allocated
+ *  through the version 1 union member, so no byte past it may be touched. Any unrecognized
+ *  requested_version takes the narrow path rather than erroring, so a caller predating the
+ *  selector keeps working
+ *
+ *  Match the version exactly; never rank the values and take the highest supported one at or
+ *  below the request. The version 1 path stamps UINT32_MAX below, so a caller reusing the struct
+ *  across calls would request UINT32_MAX and be handed the widest member
+ */
+auto publish_fabric_info(const amdsmi_bdf_t& fabric_bdf, const amdsmi_fabric_info_v2_t& source,
+                         std::uint32_t requested_version, amdsmi_fabric_info_t& destination)
+    -> void {
+  destination.bdf = fabric_bdf;
+
+  if (requested_version == static_cast<std::uint32_t>(AMDSMI_FABRIC_INFO_VERSION_2)) {
+    destination.fabric_version = static_cast<std::uint32_t>(AMDSMI_FABRIC_INFO_VERSION_2);
+    destination.fabric_info.v2 = source;
+    return;
+  }
+
+  destination.fabric_version = std::numeric_limits<decltype(destination.fabric_version)>::max();
+  flatten_v2_to_v1(source, destination.fabric_info.v1);
+}
+
 }  // namespace gpu_device::details
 
 auto AMDSmiGPUDevice::populate_ifoe_fabric_bdf_list() -> void {
@@ -760,26 +820,27 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
   outstream << __PRETTY_FUNCTION__ << " | ======= start =======";
   LOG_TRACE(outstream);
 
-  auto local_fabric_info = amdsmi_fabric_info_t{};
+  /**
+   *    The layout the caller asked for, captured before anything is written back. Reading it
+   *    after the first store would see our own output
+   */
+  const auto requested_version = fabric_info.fabric_version;
 
-  if (has_ifoe_related_bdf()) {
-    local_fabric_info.bdf = *fabric_bdf_list_.begin();
-  } else {
-    local_fabric_info.bdf = bdf_;
-  }
+  const auto fabric_bdf = (has_ifoe_related_bdf() ? *fabric_bdf_list_.begin() : bdf_);
 
-  local_fabric_info.fabric_version =
-      std::numeric_limits<decltype(local_fabric_info.fabric_version)>::max();
-
-  auto& v1 = local_fabric_info.fabric_info.v1;
+  /**
+   *    Always gather into the widest layout; publish_fabric_info() narrows it to whatever the
+   *    caller allocated
+   */
+  auto v2 = amdsmi_fabric_info_v2_t{};
 
   /**
    *    Flat surface: owned by this reader (fabric_type + accel_state).
    *    Both start at their sentinel and are overwritten only when the corresponding flat file
    *    yields usable content
    */
-  v1.fabric_type = amdsmi_fabric_type_t::AMDSMI_FABRIC_TYPE_UNKNOWN;
-  v1.accel_state =
+  v2.fabric_type = amdsmi_fabric_type_t::AMDSMI_FABRIC_TYPE_UNKNOWN;
+  v2.accel_state =
       amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN;
 
   /**
@@ -789,25 +850,25 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
    *    When a subtree is present the reader re-applies these same sentinels for fields it cannot
    *    read, so the copy below is authoritative.
    */
-  v1.ppod.accelerator_id = std::numeric_limits<decltype(v1.ppod.accelerator_id)>::max();
-  std::fill(std::begin(v1.ppod.ppod_id), std::end(v1.ppod.ppod_id),
+  v2.ppod.accelerator_id = std::numeric_limits<decltype(v2.ppod.accelerator_id)>::max();
+  std::fill(std::begin(v2.ppod.ppod_id), std::end(v2.ppod.ppod_id),
             static_cast<std::uint8_t>(0x99));
-  v1.ppod.ppod_size = std::numeric_limits<decltype(v1.ppod.ppod_size)>::max();
-  std::fill(std::begin(v1.ppod.local_accelerators), std::end(v1.ppod.local_accelerators),
+  v2.ppod.ppod_size = std::numeric_limits<decltype(v2.ppod.ppod_size)>::max();
+  std::fill(std::begin(v2.ppod.local_accelerators), std::end(v2.ppod.local_accelerators),
             std::numeric_limits<std::uint32_t>::max());
-  v1.ppod.local_accelerator_count = 0;
-  v1.ppod.bandwidth = std::numeric_limits<decltype(v1.ppod.bandwidth)>::max();
-  v1.ppod.latency = std::numeric_limits<decltype(v1.ppod.latency)>::max();
+  v2.ppod.local_accelerator_count = 0;
+  v2.ppod.bandwidth = std::numeric_limits<decltype(v2.ppod.bandwidth)>::max();
+  v2.ppod.latency = std::numeric_limits<decltype(v2.ppod.latency)>::max();
 
-  v1.vpod.vpod_id = std::numeric_limits<decltype(v1.vpod.vpod_id)>::max();
-  v1.vpod.vpod_size = std::numeric_limits<decltype(v1.vpod.vpod_size)>::max();
-  std::fill(std::begin(v1.vpod.vpod_active_accelerators),
-            std::end(v1.vpod.vpod_active_accelerators), std::numeric_limits<std::uint32_t>::max());
-  v1.vpod.addr_mode = amdsmi_fabric_npa_address_mode_t::AMDSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN;
+  v2.vpod.vpod_id = std::numeric_limits<decltype(v2.vpod.vpod_id)>::max();
+  v2.vpod.vpod_size = std::numeric_limits<decltype(v2.vpod.vpod_size)>::max();
+  std::fill(std::begin(v2.vpod.vpod_active_accelerators),
+            std::end(v2.vpod.vpod_active_accelerators), std::numeric_limits<std::uint32_t>::max());
+  v2.vpod.addr_mode = amdsmi_fabric_npa_address_mode_t::AMDSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN;
 
-  v1.station.station_flags = std::numeric_limits<decltype(v1.station.station_flags)>::max();
-  v1.station.num_stations = std::numeric_limits<decltype(v1.station.num_stations)>::max();
-  std::fill(std::begin(v1.station.lane_en_bitmap), std::end(v1.station.lane_en_bitmap),
+  v2.station.station_flags = std::numeric_limits<decltype(v2.station.station_flags)>::max();
+  v2.station.num_stations = std::numeric_limits<decltype(v2.station.num_stations)>::max();
+  std::fill(std::begin(v2.station.lane_en_bitmap), std::end(v2.station.lane_en_bitmap),
             static_cast<std::uint8_t>(0));
 
   /**
@@ -831,7 +892,7 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
               << " | UALOE sysfs not present: " << ualink_directory_path.string()
               << " | returning AMDSMI_STATUS_NOT_SUPPORTED";
     LOG_DEBUG(outstream);
-    fabric_info = local_fabric_info;
+    gpu_device::details::publish_fabric_info(fabric_bdf, v2, requested_version, fabric_info);
     return amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED;
   }
 
@@ -862,11 +923,11 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
     for (const auto& link_value : ualoe_file_lines) {
       switch (link_info_type_key) {
         case UALoeLinkInfo_t::LINK_TYPE:
-          gpu_device::details::get_fabric_type(link_value, local_fabric_info);
+          gpu_device::details::get_fabric_type(link_value, v2);
           break;
 
         case UALoeLinkInfo_t::ACCEL_STATE:
-          gpu_device::details::get_accel_state(link_value, local_fabric_info);
+          gpu_device::details::get_accel_state(link_value, v2);
           break;
 
         default:
@@ -876,11 +937,18 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
   }
 
   /**
-   *    Ppod/Vpod/Station: authoritative subtree readers.
-   *    Each returns AMDSMI_STATUS_SUCCESS, AMDSMI_STATUS_NO_DATA, AMDSMI_STATUS_NOT_SUPPORTED
+   *    Ppod/Vpod/Station: read from the flat surface, which is what the driver syncs to after a
+   *    successful commit. The setup/config/stations subtrees stage pending setter writes, so
+   *    reporting them here would return values that are not yet in effect.
    *
-   *    On anything but AMDSMI_STATUS_NOT_SUPPORTED its data payload (sentinels plus populated
-   *    fields) is copied into the info struct
+   *    Each read returns AMDSMI_STATUS_SUCCESS, AMDSMI_STATUS_NO_DATA or
+   *    AMDSMI_STATUS_NOT_SUPPORTED. On anything but AMDSMI_STATUS_NOT_SUPPORTED its data payload
+   *    (sentinels plus populated fields) and the mask of fields actually read are copied into the
+   *    info struct.
+   *
+   *    device_supports_ualink is passed as true because the ualink directory check above already
+   *    established it; going through device_has_ualink() would additionally demand an IFoE BDF and
+   *    lock out devices this function otherwise serves.
    *
    *    These device-level queries assume the per-GPU mutex is already held by the API entry point
    */
@@ -890,9 +958,11 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
   ppod_cfg.mask = (AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID | AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID |
                    AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE | AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS |
                    AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH | AMDSMI_FABRIC_PPOD_FIELD_LATENCY);
-  const auto ppod_status = query_fabric_ppod_config(ppod_cfg);
+  const auto ppod_status = fabric_ualink::query_ppod_config_at(ualink_directory, true, ppod_cfg,
+                                                               kUALOE_UALINK_FLAT_SUBDIR);
   if (ppod_status != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
-    v1.ppod = ppod_cfg.data;
+    v2.ppod = ppod_cfg.data;
+    v2.ppod_mask = ppod_cfg.mask;
   }
   is_any_plane_success =
       (is_any_plane_success || (ppod_status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS));
@@ -902,9 +972,11 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
   vpod_cfg.mask =
       (AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID | AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE |
        AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS | AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE);
-  const auto vpod_status = query_fabric_vpod_config(vpod_cfg);
+  const auto vpod_status = fabric_ualink::query_vpod_config_at(ualink_directory, true, vpod_cfg,
+                                                               kUALOE_UALINK_FLAT_SUBDIR);
   if (vpod_status != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
-    v1.vpod = vpod_cfg.data;
+    v2.vpod = vpod_cfg.data;
+    v2.vpod_mask = vpod_cfg.mask;
   }
   is_any_plane_success =
       (is_any_plane_success || (vpod_status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS));
@@ -913,39 +985,26 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
   station_cfg.version = AMDSMI_FABRIC_STATION_CONFIG_V1;
   station_cfg.mask = (AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS | AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP |
                       AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS);
-  const auto station_status = query_fabric_station_config(station_cfg);
+  const auto station_status = fabric_ualink::query_station_config_at(
+      ualink_directory, true, station_cfg, kUALOE_UALINK_FLAT_SUBDIR);
   if (station_status != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
-    v1.station = station_cfg.data;
+    v2.station = station_cfg.data;
+    v2.station_mask = station_cfg.mask;
   }
   is_any_plane_success =
       (is_any_plane_success || (station_status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS));
 
-  fabric_info = local_fabric_info;
+  gpu_device::details::publish_fabric_info(fabric_bdf, v2, requested_version, fabric_info);
 
   /**
    *    Driver contract: a present sysfs file means the feature is supported; a
    *    present-but-empty IFoE file means supported-but-unconfigured.
-   *    File presence alone can't tell the two apart, so accel_state below is what separates a
-   *    configured read (SUCCESS) from an unconfigured one (NOT_INIT).
+   *    File presence alone can't tell the two apart, so an unconfigured device still reads as
+   *    SUCCESS and accel_state in fabric_info is what reports it.
    */
-  auto status_code = (((flat_files_with_usable_content > 0) || is_any_plane_success)
-                          ? amdsmi_status_t::AMDSMI_STATUS_SUCCESS
-                          : amdsmi_status_t::AMDSMI_STATUS_NO_DATA);
-
-  /**
-   *  Reuse the accel_state already parsed into v1 (avoids a second sysfs read) so the status
-   *  matches the value returned in fabric_info. Relies on the flat loop having read accel_state:
-   *  a link_info_type that excludes it leaves the UNKNOWN sentinel and forces NOT_INIT.
-   */
-  if (is_any_plane_success &&
-      ((v1.accel_state == amdsmi_fabric_accelerator_vpod_state_t::
-                              AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNCONFIGURED) ||
-       (v1.accel_state ==
-        amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN))) {
-    status_code = amdsmi_status_t::AMDSMI_STATUS_NOT_INIT;
-  }
-
-  return status_code;
+  return (((flat_files_with_usable_content > 0) || is_any_plane_success)
+              ? amdsmi_status_t::AMDSMI_STATUS_SUCCESS
+              : amdsmi_status_t::AMDSMI_STATUS_NO_DATA);
 }
 
 }  // namespace amd::smi

--- a/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
@@ -734,8 +734,10 @@ auto flatten_v2_to_v1(const amdsmi_fabric_info_v2_t& source, amdsmi_fabric_info_
  *  selector keeps working
  *
  *  Match the version exactly; never rank the values and take the highest supported one at or
- *  below the request. The version 1 path stamps UINT32_MAX below, so a caller reusing the struct
- *  across calls would request UINT32_MAX and be handed the widest member
+ *  below the request. The version 1 path stamps AMDSMI_FABRIC_INFO_VERSION_1 below (per the
+ *  public header doc: "On output, info->fabric_version reports the member filled"), so a
+ *  caller that checks the output against AMDSMI_FABRIC_INFO_VERSION_1 sees a match rather
+ *  than a sentinel that never equals either documented constant
  */
 auto publish_fabric_info(const amdsmi_bdf_t& fabric_bdf, const amdsmi_fabric_info_v2_t& source,
                          std::uint32_t requested_version, amdsmi_fabric_info_t& destination)
@@ -748,7 +750,7 @@ auto publish_fabric_info(const amdsmi_bdf_t& fabric_bdf, const amdsmi_fabric_inf
     return;
   }
 
-  destination.fabric_version = std::numeric_limits<decltype(destination.fabric_version)>::max();
+  destination.fabric_version = static_cast<std::uint32_t>(AMDSMI_FABRIC_INFO_VERSION_1);
   flatten_v2_to_v1(source, destination.fabric_info.v1);
 }
 

--- a/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
@@ -30,7 +30,6 @@ extern "C" {
 #include <sys/types.h>
 
 #include <algorithm>
-#include <array>
 #include <atomic>
 #include <cctype>
 #include <cerrno>
@@ -38,6 +37,7 @@ extern "C" {
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <iterator>
 #include <limits>
 #include <map>
 #include <memory>
@@ -561,12 +561,6 @@ inline const auto UALoeLinkTypeMap =
     UALoeLinkTypeMap_t{{"ualoe", amdsmi_fabric_type_t::AMDSMI_FABRIC_TYPE_UALOE},
                        {"ualink", amdsmi_fabric_type_t::AMDSMI_FABRIC_TYPE_UALINK}};
 
-using UALoeAddressModeTypeMap_t = std::map<std::string_view, amdsmi_fabric_npa_address_mode_t>;
-inline const auto UALoeAddressModeTypeMap = UALoeAddressModeTypeMap_t{
-    {"aliasing", amdsmi_fabric_npa_address_mode_t::AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING},
-    {"identification",
-     amdsmi_fabric_npa_address_mode_t::AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_IDENTIFICATION}};
-
 using UALoeAcceleratorStateTypeMap_t =
     std::map<std::string_view, amdsmi_fabric_accelerator_vpod_state_t>;
 inline const auto UALoeAcceleratorStateTypeMap = UALoeAcceleratorStateTypeMap_t{
@@ -577,11 +571,6 @@ inline const auto UALoeAcceleratorStateTypeMap = UALoeAcceleratorStateTypeMap_t{
     {"ready", amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_READY},
     {"active", amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE},
     {"error", amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ERROR}};
-
-// Default populated values for all link info types, with max values for each field
-using EnumDefaultType_t = std::int32_t;
-using AcceleratorArrayType_t = std::uint32_t;
-using PPodIDType_t = std::uint8_t;
 
 auto log_ualoe_file_info(std::ostringstream&& log_stream_info) -> void {
   std::ostringstream outstream;
@@ -598,7 +587,7 @@ auto get_fabric_type(const std::string& link_value, amdsmi_fabric_info_t& local_
   std::transform(fabric_type_str.begin(), fabric_type_str.end(), fabric_type_str.begin(),
                  [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
 
-  const std::string_view fabric_type_sv{fabric_type_str};
+  const auto fabric_type_sv = std::string_view{fabric_type_str};
   if (auto fabric_type_itr = UALoeLinkTypeMap.find(fabric_type_sv);
       fabric_type_itr != UALoeLinkTypeMap.end()) {
     local_fabric_info.fabric_info.v1.fabric_type = fabric_type_itr->second;
@@ -612,286 +601,29 @@ auto get_fabric_type(const std::string& link_value, amdsmi_fabric_info_t& local_
   log_ualoe_file_info(std::move(outstream));
 }
 
-auto get_accelerator_id(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info)
-    -> void {
-  auto result = parse_number_from_string<decltype(local_fabric_info.fabric_info.v1.accelerator_id)>(
-      link_value);
-  if (result.has_value()) {
-    local_fabric_info.fabric_info.v1.accelerator_id =
-        static_cast<decltype(local_fabric_info.fabric_info.v1.accelerator_id)>(result.value());
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value
-            << " | accelerator_id: " << local_fabric_info.fabric_info.v1.accelerator_id << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-auto get_bandwidth(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info) -> void {
-  auto result =
-      parse_number_from_string<decltype(local_fabric_info.fabric_info.v1.bandwidth)>(link_value);
-  if (result.has_value()) {
-    local_fabric_info.fabric_info.v1.bandwidth =
-        static_cast<decltype(local_fabric_info.fabric_info.v1.bandwidth)>(result.value());
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value
-            << " | bandwidth: " << local_fabric_info.fabric_info.v1.bandwidth << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-auto get_latency(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info) -> void {
-  auto result =
-      parse_number_from_string<decltype(local_fabric_info.fabric_info.v1.latency)>(link_value);
-  if (result.has_value()) {
-    local_fabric_info.fabric_info.v1.latency =
-        static_cast<decltype(local_fabric_info.fabric_info.v1.latency)>(result.value());
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value
-            << " | latency: " << local_fabric_info.fabric_info.v1.latency << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-template <std::size_t MaxElems>
-auto get_ppod_id(const std::string& link_value, std::array<PPodIDType_t, MaxElems>& local_ppod_id)
-    -> void {
-  std::fill(std::begin(local_ppod_id), std::end(local_ppod_id), 0);
-  if (link_value.empty()) {
-    return;
-  }
-
-  /*
-   *  -  2 hex characters per byte (0x1234567890abcdef)
-   *  - 16 bytes per 128-bit UUID (MaxElems)
-   */
-  constexpr auto kHEX_CHARS_PER_BYTE = std::size_t(2);
-  auto value_view = std::string_view(link_value);
-  if ((value_view.size() >= kHEX_CHARS_PER_BYTE) && (value_view[0] == '0') &&
-      ((value_view[1] == 'x') || (value_view[1] == 'X'))) {
-    value_view.remove_prefix(kHEX_CHARS_PER_BYTE);
-  }
-
-  auto byte_idx = std::size_t(0);
-  auto char_idx = std::size_t(0);
-  while ((byte_idx < MaxElems) && ((char_idx + kHEX_CHARS_PER_BYTE) <= value_view.size())) {
-    /*
-     *  Convert two hex characters to a single byte
-     */
-    auto higher_nibble = std::uint8_t(0);
-    auto lower_nibble = std::uint8_t(0);
-    if (std::isxdigit(static_cast<unsigned char>(value_view[char_idx])) &&
-        std::isxdigit(static_cast<unsigned char>(value_view[char_idx + 1]))) {
-      auto hex_digit = [](char ch) -> std::uint8_t {
-        /*
-         *  Convert a hex character to its numeric value
-         *  - '0' to '9' -> 0 to 9
-         *  - 'a' to 'f' -> 10 to 15
-         *  - 'A' to 'F' -> 10 to 15
-         */
-        if ((ch >= '0') && (ch <= '9')) {
-          return static_cast<std::uint8_t>(ch - '0');
-        }
-        if ((ch >= 'a') && (ch <= 'f')) {
-          return static_cast<std::uint8_t>(10 + (ch - 'a'));
-        }
-
-        return static_cast<std::uint8_t>(10 + (ch - 'A'));
-      };
-
-      higher_nibble = hex_digit(value_view[char_idx]);
-      lower_nibble = hex_digit(value_view[char_idx + 1]);
-      local_ppod_id[byte_idx++] = static_cast<PPodIDType_t>((higher_nibble << 4) | lower_nibble);
-    }
-
-    char_idx += kHEX_CHARS_PER_BYTE;
-
-    /*
-     *  Skip single separators (e.g. '-' in UUID) between its bytes
-     */
-    while ((char_idx < value_view.size()) &&
-           ((value_view[char_idx] == '-') ||
-            (std::isspace(static_cast<unsigned char>(value_view[char_idx]))))) {
-      ++char_idx;
-    }
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value << " | local_ppod_id (hex): ";
-  for (auto idx = std::size_t(0); idx < byte_idx; ++idx) {
-    outstream << std::hex << std::setfill('0') << std::setw(2)
-              << static_cast<unsigned int>(local_ppod_id[idx]);
-  }
-  outstream << std::dec;
-  outstream << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-auto get_ppod_size(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info) -> void {
-  auto result =
-      parse_number_from_string<decltype(local_fabric_info.fabric_info.v1.ppod_size)>(link_value);
-  if (result.has_value()) {
-    local_fabric_info.fabric_info.v1.ppod_size =
-        static_cast<decltype(local_fabric_info.fabric_info.v1.ppod_size)>(result.value());
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value
-            << " | ppod_size: " << local_fabric_info.fabric_info.v1.ppod_size << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-auto get_vpod_id(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info) -> void {
-  auto result =
-      parse_number_from_string<decltype(local_fabric_info.fabric_info.v1.vpod_id)>(link_value);
-  if (result.has_value()) {
-    local_fabric_info.fabric_info.v1.vpod_id =
-        static_cast<decltype(local_fabric_info.fabric_info.v1.vpod_id)>(result.value());
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value
-            << " | vpod_id: " << local_fabric_info.fabric_info.v1.vpod_id << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-auto get_vpod_size(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info) -> void {
-  auto result =
-      parse_number_from_string<decltype(local_fabric_info.fabric_info.v1.vpod_size)>(link_value);
-  if (result.has_value()) {
-    local_fabric_info.fabric_info.v1.vpod_size =
-        static_cast<decltype(local_fabric_info.fabric_info.v1.vpod_size)>(result.value());
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value
-            << " | vpod_size: " << local_fabric_info.fabric_info.v1.vpod_size << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-/*
- *  Note:   For get_vpod_active_accelerators(), and get_local_accelerators(),
- *          we handle all lines from the file at once, and then fill the array.
- */
-template <std::size_t MaxElems>
-auto get_vpod_active_accelerators(
-    const UALoeLinkInfoLines_t& file_lines,
-    std::array<AcceleratorArrayType_t, MaxElems>& local_active_accelerators) -> void {
-  std::fill(std::begin(local_active_accelerators), std::end(local_active_accelerators),
-            std::numeric_limits<AcceleratorArrayType_t>::max());
-
-  auto idx = std::size_t(0);
-  auto accel_count = std::size_t(0);
-  for (const auto& line : file_lines) {
-    if (idx >= MaxElems) {
-      break;
-    }
-
-    // We are supposed to only have 1 line per file, and separated by spaces
-    auto accel_vector = split_string(line, ' ');
-
-    if (!accel_vector.empty()) {
-      accel_count = accel_vector.size();
-      for (const auto& accel_value_str : accel_vector) {
-        if (idx < MaxElems) {
-          auto result = parse_number_from_string<AcceleratorArrayType_t>(accel_value_str);
-          if (result.has_value()) {
-            local_active_accelerators[idx++] = static_cast<AcceleratorArrayType_t>(result.value());
-          }
-        }
-      }
-    }
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | File lines: " << file_lines.size()
-            << " | local_active_accelerators_count: " << accel_count
-            << "local_active_accelerators: ";
-  std::copy(std::begin(local_active_accelerators), std::end(local_active_accelerators),
-            amd::smi::make_ostream_joiner(&outstream, ", "));
-  outstream << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-template <std::size_t MaxElems>
-auto get_local_accelerators(const UALoeLinkInfoLines_t& file_lines,
-                            std::array<AcceleratorArrayType_t, MaxElems>& local_accelerators)
-    -> void {
-  std::fill(std::begin(local_accelerators), std::end(local_accelerators),
-            std::numeric_limits<AcceleratorArrayType_t>::max());
-
-  auto idx = std::size_t(0);
-  auto accel_count = std::size_t(0);
-  for (const auto& line : file_lines) {
-    if (idx >= MaxElems) {
-      break;
-    }
-
-    // We are supposed to only have 1 line per file, and separated by spaces
-    auto accel_vector = split_string(line, ' ');
-    if (!accel_vector.empty()) {
-      accel_count = accel_vector.size();
-      for (const auto& accel_value_str : accel_vector) {
-        if (idx < MaxElems) {
-          auto result = parse_number_from_string<AcceleratorArrayType_t>(accel_value_str);
-          if (result.has_value()) {
-            local_accelerators[idx++] = static_cast<AcceleratorArrayType_t>(result.value());
-          }
-        }
-      }
-    }
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | File lines: " << file_lines.size()
-            << " | local_accelerators_count: " << accel_count << " | local_accelerators: ";
-  std::copy(std::begin(local_accelerators), std::end(local_accelerators),
-            amd::smi::make_ostream_joiner(&outstream, ", "));
-  outstream << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-auto get_addr_mode(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info) -> void {
-  // Convert the string to lowercase
-  auto addr_mode_str = link_value;
-  std::transform(addr_mode_str.begin(), addr_mode_str.end(), addr_mode_str.begin(),
-                 [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-
-  const std::string_view addr_mode_sv{addr_mode_str};
-  if (auto addr_mode_itr = UALoeAddressModeTypeMap.find(addr_mode_sv);
-      addr_mode_itr != UALoeAddressModeTypeMap.end()) {
-    local_fabric_info.fabric_info.v1.addr_mode = addr_mode_itr->second;
-  } else {
-    local_fabric_info.fabric_info.v1.addr_mode =
-        amdsmi_fabric_npa_address_mode_t::AMDSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN;
-  }
-
-  std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value << " -> " << addr_mode_str
-            << " | addr_mode: " << local_fabric_info.fabric_info.v1.addr_mode << " |";
-  log_ualoe_file_info(std::move(outstream));
-}
-
-auto get_accel_state(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info)
-    -> void {
-  // Convert the string to lowercase
+auto parse_accel_state_from_sysfs_line(const std::string& link_value)
+    -> amdsmi_fabric_accelerator_vpod_state_t {
+  auto accel_state =
+      amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN;
   auto accel_state_str = link_value;
   std::transform(accel_state_str.begin(), accel_state_str.end(), accel_state_str.begin(),
                  [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
 
-  const std::string_view accel_state_sv{accel_state_str};
+  const auto accel_state_sv = std::string_view{accel_state_str};
   if (auto accel_state_itr = UALoeAcceleratorStateTypeMap.find(accel_state_sv);
       accel_state_itr != UALoeAcceleratorStateTypeMap.end()) {
-    local_fabric_info.fabric_info.v1.accel_state = accel_state_itr->second;
-  } else {
-    local_fabric_info.fabric_info.v1.accel_state =
-        amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN;
+    return accel_state_itr->second;
   }
 
+  return accel_state;
+}
+
+auto get_accel_state(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info)
+    -> void {
+  local_fabric_info.fabric_info.v1.accel_state = parse_accel_state_from_sysfs_line(link_value);
+
   std::ostringstream outstream;
-  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value << " -> " << accel_state_str
+  outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value
             << " | accel_state: " << local_fabric_info.fabric_info.v1.accel_state << " |";
   log_ualoe_file_info(std::move(outstream));
 }
@@ -941,7 +673,7 @@ auto read_fabric_info_file(const std::string& sysfs_file_path,
 /*
  *  Scan "/sys/bus/pci/drivers/ifoe/" for PCI device symlink names (BDF form)
  *  For entries where the domain, bus, and device match gpu_bdf (same physical PCIe device / slot;
- * any function), are inserted into fabric_bdf_list with the full BDF including function from sysfs
+ *  any function), are inserted into fabric_bdf_list with the full BDF including function from sysfs
  */
 auto populate_ifoe_fabric_bdf_list(const amdsmi_bdf_t& gpu_bdf, FabricBDFList_t& fabric_bdf_list)
     -> amdsmi_status_t {
@@ -1027,19 +759,19 @@ auto AMDSmiGPUDevice::get_ifoe_bdf_string() const -> std::string {
   return {};
 }
 
+auto AMDSmiGPUDevice::get_ualink_directory_path() const -> std::string {
+  return std::string(kUALOE_BASE_PATH) + get_gpu_path() + std::string(kUALOE_UALINK_DIRECTORY);
+}
+
 // Check if this GPU device has ualink sysfs directory (required for UALOE)
-// Uses the same path construction as get_fabric_info_from_ualoe()
 bool AMDSmiGPUDevice::device_has_ualink() const {
   if (!has_ifoe_related_bdf()) {
     return false;
   }
 
-  // Use the same ualink path logic as get_fabric_info_from_ualoe()
-  const auto ualink_directory =
-      (std::string(kUALOE_BASE_PATH) + get_gpu_path() + std::string(kUALOE_UALINK_DIRECTORY));
-  const auto ualink_directory_path = std::filesystem::path(ualink_directory);
-
-  return std::filesystem::is_directory(ualink_directory_path);
+  std::error_code err_code;
+  return std::filesystem::is_directory(std::filesystem::path(get_ualink_directory_path()),
+                                       err_code);
 }
 
 auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_info,
@@ -1050,11 +782,6 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
   LOG_TRACE(outstream);
 
   auto local_fabric_info = amdsmi_fabric_info_t{};
-  auto local_ppod_id = std::array<std::uint8_t, AMDSMI_FABRIC_PPOD_ID_SIZE>{};
-  auto local_active_accelerators = std::array<gpu_device::details::AcceleratorArrayType_t,
-                                              AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE>{};
-  auto local_accelerators =
-      std::array<gpu_device::details::AcceleratorArrayType_t, AMDSMI_FABRIC_MAX_LOCAL_GPUS>{};
 
   if (has_ifoe_related_bdf()) {
     local_fabric_info.bdf = *fabric_bdf_list_.begin();
@@ -1062,60 +789,47 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
     local_fabric_info.bdf = bdf_;
   }
 
-  /*
-   *  TODO: We need to define a which offset (kUALOE_BDF_OFFSET) will be used for the function
-   * number (in BDF).
-   *
-   *  - PCIe BDF format:
-   *      - Bits 31-24: Bus number (8 bits)
-   *      - Bits 23-16: Device number (5 bits, but stored in 8 bits)
-   *      - Bits  15-8: Function number (3 bits, but stored in 8 bits)
-   *      - Bits   7-0: Other info
-   *
-   *  - 0x07 is the mask for the function number (extracts only the lower 3 bits)
-   *      - 00000111 (last 3 bits are 1, all others 0)
-   */
-  // local_fabric_info.bdf.function_number = ((bdf_.function_number + kUALOE_BDF_OFFSET) & 0x07);
   local_fabric_info.fabric_version =
       std::numeric_limits<decltype(local_fabric_info.fabric_version)>::max();
 
-  local_fabric_info.fabric_info.v1.fabric_type = static_cast<amdsmi_fabric_type_t>(
-      std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.fabric_type)>::max());
+  auto& v1 = local_fabric_info.fabric_info.v1;
 
-  local_fabric_info.fabric_info.v1.accelerator_id =
-      std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.accelerator_id)>::max();
+  /**
+   *    Flat surface: owned by this reader (fabric_type + accel_state).
+   *    Both start at their sentinel and are overwritten only when the corresponding flat file
+   *    yields usable content
+   */
+  v1.fabric_type = amdsmi_fabric_type_t::AMDSMI_FABRIC_TYPE_UNKNOWN;
+  v1.accel_state =
+      amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN;
 
-  local_fabric_info.fabric_info.v1.bandwidth =
-      std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.bandwidth)>::max();
+  /**
+   *    Ppod/Vpod/Station payloads: sentinel-init here so a subtree that is absent (its
+   *    'query_fabric_*_config()' returns NOT_SUPPORTED) leaves documented sentinels
+   *
+   *    When a subtree is present the reader re-applies these same sentinels for fields it cannot
+   *    read, so the copy below is authoritative.
+   */
+  v1.ppod.accelerator_id = std::numeric_limits<decltype(v1.ppod.accelerator_id)>::max();
+  std::fill(std::begin(v1.ppod.ppod_id), std::end(v1.ppod.ppod_id),
+            static_cast<std::uint8_t>(0x99));
+  v1.ppod.ppod_size = std::numeric_limits<decltype(v1.ppod.ppod_size)>::max();
+  std::fill(std::begin(v1.ppod.local_accelerators), std::end(v1.ppod.local_accelerators),
+            std::numeric_limits<std::uint32_t>::max());
+  v1.ppod.local_accelerator_count = 0;
+  v1.ppod.bandwidth = std::numeric_limits<decltype(v1.ppod.bandwidth)>::max();
+  v1.ppod.latency = std::numeric_limits<decltype(v1.ppod.latency)>::max();
 
-  local_fabric_info.fabric_info.v1.latency =
-      std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.latency)>::max();
+  v1.vpod.vpod_id = std::numeric_limits<decltype(v1.vpod.vpod_id)>::max();
+  v1.vpod.vpod_size = std::numeric_limits<decltype(v1.vpod.vpod_size)>::max();
+  std::fill(std::begin(v1.vpod.vpod_active_accelerators),
+            std::end(v1.vpod.vpod_active_accelerators), std::numeric_limits<std::uint32_t>::max());
+  v1.vpod.addr_mode = amdsmi_fabric_npa_address_mode_t::AMDSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN;
 
-  // Sentinel when sysfs provides no ppod_id: UUID 99999999-9999-9999-9999-999999999999 (16 × 0x99)
-  std::fill(std::begin(local_fabric_info.fabric_info.v1.ppod_id),
-            std::end(local_fabric_info.fabric_info.v1.ppod_id), static_cast<std::uint8_t>(0x99));
-
-  local_fabric_info.fabric_info.v1.ppod_size =
-      std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.ppod_size)>::max();
-
-  local_fabric_info.fabric_info.v1.vpod_id =
-      std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.vpod_id)>::max();
-
-  local_fabric_info.fabric_info.v1.vpod_size =
-      std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.vpod_size)>::max();
-
-  local_fabric_info.fabric_info.v1.addr_mode = static_cast<amdsmi_fabric_npa_address_mode_t>(
-      std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.addr_mode)>::max());
-
-  local_fabric_info.fabric_info.v1.accel_state =
-      static_cast<amdsmi_fabric_accelerator_vpod_state_t>(
-          std::numeric_limits<decltype(local_fabric_info.fabric_info.v1.accel_state)>::max());
-
-  std::fill(std::begin(local_active_accelerators), std::end(local_active_accelerators),
-            std::numeric_limits<gpu_device::details::AcceleratorArrayType_t>::max());
-  std::fill(std::begin(local_accelerators), std::end(local_accelerators),
-            std::numeric_limits<gpu_device::details::AcceleratorArrayType_t>::max());
-  std::fill(std::begin(local_ppod_id), std::end(local_ppod_id), static_cast<std::uint8_t>(0));
+  v1.station.station_flags = std::numeric_limits<decltype(v1.station.station_flags)>::max();
+  v1.station.num_stations = std::numeric_limits<decltype(v1.station.num_stations)>::max();
+  std::fill(std::begin(v1.station.lane_en_bitmap), std::end(v1.station.lane_en_bitmap),
+            static_cast<std::uint8_t>(0));
 
   /**
    * Check if the 'ualink' directory exists in the sysfs path, if not, return
@@ -1124,8 +838,7 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
    * is the AMDSMI processor index and is not guaranteed to equal the DRM card index when devices
    * are gapped or filtered.
    */
-  const auto ualink_directory =
-      (std::string(kUALOE_BASE_PATH) + get_gpu_path() + std::string(kUALOE_UALINK_DIRECTORY));
+  const auto ualink_directory = get_ualink_directory_path();
   const auto ualink_directory_path = std::filesystem::path(ualink_directory);
 
   outstream << __PRETTY_FUNCTION__ << " | gpu_path: " << get_gpu_path()
@@ -1133,7 +846,8 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
             << " | ualink_directory: " << ualink_directory << " |";
   LOG_DEBUG(outstream);
 
-  if (!std::filesystem::is_directory(ualink_directory_path)) {
+  std::error_code err_code;
+  if (!std::filesystem::is_directory(ualink_directory_path, err_code)) {
     outstream << __PRETTY_FUNCTION__
               << " | UALOE sysfs not present: " << ualink_directory_path.string()
               << " | returning AMDSMI_STATUS_NOT_SUPPORTED";
@@ -1142,20 +856,18 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
     return amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED;
   }
 
-  auto link_info_files_in_scope = std::size_t(0);
-  auto link_info_files_with_usable_content = std::size_t(0);
+  /**
+   *    Flat surface: (fabric_type + accel_state only). UALoeLinkInfoMap is trimmed to these two
+   *    The Ppod/Vpod/Station payloads come from the subtree readers below, not from here
+   */
+  auto flat_files_with_usable_content = std::size_t(0);
   for (const auto& [link_info_type_key, link_info_file_value] : UALoeLinkInfoMap) {
-    // If not all, apply filter based on the link info type
     if ((link_info_type != UALoeLinkInfo_t::ALL_LINK_INFO) &&
         (link_info_type_key != link_info_type)) {
       continue;
     }
 
-    ++link_info_files_in_scope;
     const auto sysfs_file_path = (ualink_directory + "/" + std::string(link_info_file_value));
-    outstream << __PRETTY_FUNCTION__ << " | sysfs_file_path: " << sysfs_file_path << " |";
-    LOG_DEBUG(outstream);
-
     auto ualoe_file_lines = UALoeLinkInfoLines_t{};
     const auto read_status =
         gpu_device::details::read_fabric_info_file(sysfs_file_path, ualoe_file_lines);
@@ -1167,71 +879,11 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
       continue;
     }
 
-    ++link_info_files_with_usable_content;
-    outstream << __PRETTY_FUNCTION__ << " | UALOE File: " << sysfs_file_path
-              << " | Lines: " << ualoe_file_lines.size()
-              << " | Link Info Type: " << static_cast<UALoeLinkInfoType_t>(link_info_type_key)
-              << " |";
-    LOG_DEBUG(outstream);
-
-    /*
-     *  List-based fields: one value per line; pass all lines at once
-     *      - VPOD_ACTIVE_ACCELS
-     *      - LOCAL_ACCELS
-     */
-    if (link_info_type_key == UALoeLinkInfo_t::VPOD_ACTIVE_ACCELS) {
-      gpu_device::details::get_vpod_active_accelerators(ualoe_file_lines,
-                                                        local_active_accelerators);
-      std::copy(local_active_accelerators.data(),
-                (local_active_accelerators.data() + local_active_accelerators.size()),
-                local_fabric_info.fabric_info.v1.vpod_active_accelerators);
-      continue;
-    }
-    if (link_info_type_key == UALoeLinkInfo_t::LOCAL_ACCELS) {
-      gpu_device::details::get_local_accelerators(ualoe_file_lines, local_accelerators);
-      std::copy(local_accelerators.data(), (local_accelerators.data() + local_accelerators.size()),
-                local_fabric_info.fabric_info.v1.local_accelerators);
-      continue;
-    }
-
+    ++flat_files_with_usable_content;
     for (const auto& link_value : ualoe_file_lines) {
       switch (link_info_type_key) {
         case UALoeLinkInfo_t::LINK_TYPE:
           gpu_device::details::get_fabric_type(link_value, local_fabric_info);
-          break;
-
-        case UALoeLinkInfo_t::ACCEL_ID:
-          gpu_device::details::get_accelerator_id(link_value, local_fabric_info);
-          break;
-
-        case UALoeLinkInfo_t::BANDWIDTH:
-          gpu_device::details::get_bandwidth(link_value, local_fabric_info);
-          break;
-
-        case UALoeLinkInfo_t::LATENCY:
-          gpu_device::details::get_latency(link_value, local_fabric_info);
-          break;
-
-        case UALoeLinkInfo_t::PPOD_ID:
-          gpu_device::details::get_ppod_id(link_value, local_ppod_id);
-          std::copy(local_ppod_id.data(), (local_ppod_id.data() + local_ppod_id.size()),
-                    local_fabric_info.fabric_info.v1.ppod_id);
-          break;
-
-        case UALoeLinkInfo_t::PPOD_SIZE:
-          gpu_device::details::get_ppod_size(link_value, local_fabric_info);
-          break;
-
-        case UALoeLinkInfo_t::VPOD_ID:
-          gpu_device::details::get_vpod_id(link_value, local_fabric_info);
-          break;
-
-        case UALoeLinkInfo_t::VPOD_SIZE:
-          gpu_device::details::get_vpod_size(link_value, local_fabric_info);
-          break;
-
-        case UALoeLinkInfo_t::ADDR_MODE:
-          gpu_device::details::get_addr_mode(link_value, local_fabric_info);
           break;
 
         case UALoeLinkInfo_t::ACCEL_STATE:
@@ -1245,22 +897,76 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
   }
 
   /**
-   * For cases where the 'ualink' directory exists in the sysfs path, but we can read any usable
-   * content, return AMDSMI_STATUS_NO_DATA.
+   *    Ppod/Vpod/Station: authoritative subtree readers.
+   *    Each returns AMDSMI_STATUS_SUCCESS, AMDSMI_STATUS_NO_DATA, AMDSMI_STATUS_NOT_SUPPORTED
+   *
+   *    On anything but AMDSMI_STATUS_NOT_SUPPORTED its data payload (sentinels plus populated
+   *    fields) is copied into the info struct
+   *
+   *    These device-level queries assume the per-GPU mutex is already held by the API entry point
    */
-  fabric_info = local_fabric_info;
-  if (link_info_files_in_scope == 0) {
-    return amdsmi_status_t::AMDSMI_STATUS_NO_DATA;
+  auto is_any_plane_success = false;
+  auto ppod_cfg = amdsmi_fabric_ppod_config_t{};
+  ppod_cfg.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  ppod_cfg.mask = (AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID | AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID |
+                   AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE | AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS |
+                   AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH | AMDSMI_FABRIC_PPOD_FIELD_LATENCY);
+  const auto ppod_status = query_fabric_ppod_config(ppod_cfg);
+  if (ppod_status != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
+    v1.ppod = ppod_cfg.data;
   }
+  is_any_plane_success =
+      (is_any_plane_success || (ppod_status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS));
+
+  auto vpod_cfg = amdsmi_fabric_vpod_config_t{};
+  vpod_cfg.version = AMDSMI_FABRIC_VPOD_CONFIG_V1;
+  vpod_cfg.mask =
+      (AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID | AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE |
+       AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS | AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE);
+  const auto vpod_status = query_fabric_vpod_config(vpod_cfg);
+  if (vpod_status != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
+    v1.vpod = vpod_cfg.data;
+  }
+  is_any_plane_success =
+      (is_any_plane_success || (vpod_status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS));
+
+  auto station_cfg = amdsmi_fabric_station_config_t{};
+  station_cfg.version = AMDSMI_FABRIC_STATION_CONFIG_V1;
+  station_cfg.mask = (AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS | AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP |
+                      AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS);
+  const auto station_status = query_fabric_station_config(station_cfg);
+  if (station_status != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
+    v1.station = station_cfg.data;
+  }
+  is_any_plane_success =
+      (is_any_plane_success || (station_status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS));
+
+  fabric_info = local_fabric_info;
 
   /**
-   * For cases where the 'ualink' directory exists in the sysfs path, and we can read all files with
-   * usable content, return AMDSMI_STATUS_SUCCESS. Otherwise, return AMDSMI_STATUS_UNEXPECTED_DATA
-   * (some files are missing or empty).
+   *    Driver contract: a present sysfs file means the feature is supported; a
+   *    present-but-empty IFoE file means supported-but-unconfigured.
+   *    File presence alone can't tell the two apart, so accel_state below is what separates a
+   *    configured read (SUCCESS) from an unconfigured one (NOT_INIT).
    */
-  return (link_info_files_with_usable_content == link_info_files_in_scope)
-             ? amdsmi_status_t::AMDSMI_STATUS_SUCCESS
-             : amdsmi_status_t::AMDSMI_STATUS_UNEXPECTED_DATA;
+  auto status_code = (((flat_files_with_usable_content > 0) || is_any_plane_success)
+                          ? amdsmi_status_t::AMDSMI_STATUS_SUCCESS
+                          : amdsmi_status_t::AMDSMI_STATUS_NO_DATA);
+
+  /**
+   *  Reuse the accel_state already parsed into v1 (avoids a second sysfs read) so the status
+   *  matches the value returned in fabric_info. Relies on the flat loop having read accel_state:
+   *  a link_info_type that excludes it leaves the UNKNOWN sentinel and forces NOT_INIT.
+   */
+  if (is_any_plane_success &&
+      ((v1.accel_state == amdsmi_fabric_accelerator_vpod_state_t::
+                              AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNCONFIGURED) ||
+       (v1.accel_state ==
+        amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN))) {
+    status_code = amdsmi_status_t::AMDSMI_STATUS_NOT_INIT;
+  }
+
+  return status_code;
 }
 
 }  // namespace amd::smi

--- a/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
@@ -33,6 +33,7 @@ extern "C" {
 #include <atomic>
 #include <cctype>
 #include <cerrno>
+#include <cstddef>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -49,6 +50,7 @@ extern "C" {
 #include <vector>
 
 #include "amd_smi/impl/amd_smi_common.h"
+#include "amd_smi/impl/amd_smi_fabric_ualink.h"
 #include "amd_smi/impl/amd_smi_utils.h"
 #include "amd_smi/impl/fdinfo.h"
 #include "rocm_smi/rocm_smi_kfd.h"
@@ -580,7 +582,7 @@ auto log_ualoe_file_info(std::ostringstream&& log_stream_info) -> void {
 }
 
 // Set values based on link info type
-auto get_fabric_type(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info)
+auto get_fabric_type(const std::string& link_value, amdsmi_fabric_info_v2_t& local_fabric_info)
     -> void {
   // Convert the string to lowercase
   auto fabric_type_str = link_value;
@@ -590,14 +592,14 @@ auto get_fabric_type(const std::string& link_value, amdsmi_fabric_info_t& local_
   const auto fabric_type_sv = std::string_view{fabric_type_str};
   if (auto fabric_type_itr = UALoeLinkTypeMap.find(fabric_type_sv);
       fabric_type_itr != UALoeLinkTypeMap.end()) {
-    local_fabric_info.fabric_info.v1.fabric_type = fabric_type_itr->second;
+    local_fabric_info.fabric_type = fabric_type_itr->second;
   } else {
-    local_fabric_info.fabric_info.v1.fabric_type = amdsmi_fabric_type_t::AMDSMI_FABRIC_TYPE_UNKNOWN;
+    local_fabric_info.fabric_type = amdsmi_fabric_type_t::AMDSMI_FABRIC_TYPE_UNKNOWN;
   }
 
   std::ostringstream outstream;
   outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value << " -> " << fabric_type_str
-            << " | fabric_type: " << local_fabric_info.fabric_info.v1.fabric_type << " |";
+            << " | fabric_type: " << local_fabric_info.fabric_type << " |";
   log_ualoe_file_info(std::move(outstream));
 }
 
@@ -618,13 +620,13 @@ auto parse_accel_state_from_sysfs_line(const std::string& link_value)
   return accel_state;
 }
 
-auto get_accel_state(const std::string& link_value, amdsmi_fabric_info_t& local_fabric_info)
+auto get_accel_state(const std::string& link_value, amdsmi_fabric_info_v2_t& local_fabric_info)
     -> void {
-  local_fabric_info.fabric_info.v1.accel_state = parse_accel_state_from_sysfs_line(link_value);
+  local_fabric_info.accel_state = parse_accel_state_from_sysfs_line(link_value);
 
   std::ostringstream outstream;
   outstream << __PRETTY_FUNCTION__ << " | Link value: " << link_value
-            << " | accel_state: " << local_fabric_info.fabric_info.v1.accel_state << " |";
+            << " | accel_state: " << local_fabric_info.accel_state << " |";
   log_ualoe_file_info(std::move(outstream));
 }
 
@@ -713,6 +715,64 @@ auto populate_ifoe_fabric_bdf_list(const amdsmi_bdf_t& gpu_bdf, FabricBDFList_t&
   return status_code;
 }
 
+/*
+ *  Additive fields come out of amdsmi_fabric_info_v2_t::reserved, never off the end, so this size
+ *  must not move again. Asserted here rather than in the public header so consumers pay nothing
+ *  for it, and unconditionally rather than in the tests, which are an opt-in build
+ */
+constexpr auto kFabricInfoV2Size = std::size_t{480};
+static_assert(sizeof(amdsmi_fabric_info_v2_t) == kFabricInfoV2Size,
+              "amdsmi_fabric_info_v2_t size is frozen; grow it by carving from reserved");
+
+/*
+ *  Project the version 2 payload onto the frozen version 1 layout. The station data and
+ *  local_accelerator_count have no version 1 equivalent and are dropped
+ */
+auto flatten_v2_to_v1(const amdsmi_fabric_info_v2_t& source, amdsmi_fabric_info_v1_t& destination)
+    -> void {
+  destination.accelerator_id = source.ppod.accelerator_id;
+  destination.fabric_type = source.fabric_type;
+  destination.bandwidth = source.ppod.bandwidth;
+  destination.latency = source.ppod.latency;
+  std::copy(std::begin(source.ppod.ppod_id), std::end(source.ppod.ppod_id),
+            std::begin(destination.ppod_id));
+  destination.ppod_size = source.ppod.ppod_size;
+  destination.vpod_id = source.vpod.vpod_id;
+  destination.vpod_size = source.vpod.vpod_size;
+  std::copy(std::begin(source.vpod.vpod_active_accelerators),
+            std::end(source.vpod.vpod_active_accelerators),
+            std::begin(destination.vpod_active_accelerators));
+  std::copy(std::begin(source.ppod.local_accelerators), std::end(source.ppod.local_accelerators),
+            std::begin(destination.local_accelerators));
+  destination.addr_mode = source.vpod.addr_mode;
+  destination.accel_state = source.accel_state;
+}
+
+/*
+ *  Bounded write into caller memory: a caller that did not request version 2 only allocated
+ *  through the version 1 union member, so no byte past it may be touched. Any unrecognized
+ *  requested_version takes the narrow path rather than erroring, so a caller predating the
+ *  selector keeps working
+ *
+ *  Match the version exactly; never rank the values and take the highest supported one at or
+ *  below the request. The version 1 path stamps UINT32_MAX below, so a caller reusing the struct
+ *  across calls would request UINT32_MAX and be handed the widest member
+ */
+auto publish_fabric_info(const amdsmi_bdf_t& fabric_bdf, const amdsmi_fabric_info_v2_t& source,
+                         std::uint32_t requested_version, amdsmi_fabric_info_t& destination)
+    -> void {
+  destination.bdf = fabric_bdf;
+
+  if (requested_version == static_cast<std::uint32_t>(AMDSMI_FABRIC_INFO_VERSION_2)) {
+    destination.fabric_version = static_cast<std::uint32_t>(AMDSMI_FABRIC_INFO_VERSION_2);
+    destination.fabric_info.v2 = source;
+    return;
+  }
+
+  destination.fabric_version = std::numeric_limits<decltype(destination.fabric_version)>::max();
+  flatten_v2_to_v1(source, destination.fabric_info.v1);
+}
+
 }  // namespace gpu_device::details
 
 auto AMDSmiGPUDevice::populate_ifoe_fabric_bdf_list() -> void {
@@ -781,26 +841,27 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
   outstream << __PRETTY_FUNCTION__ << " | ======= start =======";
   LOG_TRACE(outstream);
 
-  auto local_fabric_info = amdsmi_fabric_info_t{};
+  /**
+   *    The layout the caller asked for, captured before anything is written back. Reading it
+   *    after the first store would see our own output
+   */
+  const auto requested_version = fabric_info.fabric_version;
 
-  if (has_ifoe_related_bdf()) {
-    local_fabric_info.bdf = *fabric_bdf_list_.begin();
-  } else {
-    local_fabric_info.bdf = bdf_;
-  }
+  const auto fabric_bdf = (has_ifoe_related_bdf() ? *fabric_bdf_list_.begin() : bdf_);
 
-  local_fabric_info.fabric_version =
-      std::numeric_limits<decltype(local_fabric_info.fabric_version)>::max();
-
-  auto& v1 = local_fabric_info.fabric_info.v1;
+  /**
+   *    Always gather into the widest layout; publish_fabric_info() narrows it to whatever the
+   *    caller allocated
+   */
+  auto v2 = amdsmi_fabric_info_v2_t{};
 
   /**
    *    Flat surface: owned by this reader (fabric_type + accel_state).
    *    Both start at their sentinel and are overwritten only when the corresponding flat file
    *    yields usable content
    */
-  v1.fabric_type = amdsmi_fabric_type_t::AMDSMI_FABRIC_TYPE_UNKNOWN;
-  v1.accel_state =
+  v2.fabric_type = amdsmi_fabric_type_t::AMDSMI_FABRIC_TYPE_UNKNOWN;
+  v2.accel_state =
       amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN;
 
   /**
@@ -810,25 +871,25 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
    *    When a subtree is present the reader re-applies these same sentinels for fields it cannot
    *    read, so the copy below is authoritative.
    */
-  v1.ppod.accelerator_id = std::numeric_limits<decltype(v1.ppod.accelerator_id)>::max();
-  std::fill(std::begin(v1.ppod.ppod_id), std::end(v1.ppod.ppod_id),
+  v2.ppod.accelerator_id = std::numeric_limits<decltype(v2.ppod.accelerator_id)>::max();
+  std::fill(std::begin(v2.ppod.ppod_id), std::end(v2.ppod.ppod_id),
             static_cast<std::uint8_t>(0x99));
-  v1.ppod.ppod_size = std::numeric_limits<decltype(v1.ppod.ppod_size)>::max();
-  std::fill(std::begin(v1.ppod.local_accelerators), std::end(v1.ppod.local_accelerators),
+  v2.ppod.ppod_size = std::numeric_limits<decltype(v2.ppod.ppod_size)>::max();
+  std::fill(std::begin(v2.ppod.local_accelerators), std::end(v2.ppod.local_accelerators),
             std::numeric_limits<std::uint32_t>::max());
-  v1.ppod.local_accelerator_count = 0;
-  v1.ppod.bandwidth = std::numeric_limits<decltype(v1.ppod.bandwidth)>::max();
-  v1.ppod.latency = std::numeric_limits<decltype(v1.ppod.latency)>::max();
+  v2.ppod.local_accelerator_count = 0;
+  v2.ppod.bandwidth = std::numeric_limits<decltype(v2.ppod.bandwidth)>::max();
+  v2.ppod.latency = std::numeric_limits<decltype(v2.ppod.latency)>::max();
 
-  v1.vpod.vpod_id = std::numeric_limits<decltype(v1.vpod.vpod_id)>::max();
-  v1.vpod.vpod_size = std::numeric_limits<decltype(v1.vpod.vpod_size)>::max();
-  std::fill(std::begin(v1.vpod.vpod_active_accelerators),
-            std::end(v1.vpod.vpod_active_accelerators), std::numeric_limits<std::uint32_t>::max());
-  v1.vpod.addr_mode = amdsmi_fabric_npa_address_mode_t::AMDSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN;
+  v2.vpod.vpod_id = std::numeric_limits<decltype(v2.vpod.vpod_id)>::max();
+  v2.vpod.vpod_size = std::numeric_limits<decltype(v2.vpod.vpod_size)>::max();
+  std::fill(std::begin(v2.vpod.vpod_active_accelerators),
+            std::end(v2.vpod.vpod_active_accelerators), std::numeric_limits<std::uint32_t>::max());
+  v2.vpod.addr_mode = amdsmi_fabric_npa_address_mode_t::AMDSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN;
 
-  v1.station.station_flags = std::numeric_limits<decltype(v1.station.station_flags)>::max();
-  v1.station.num_stations = std::numeric_limits<decltype(v1.station.num_stations)>::max();
-  std::fill(std::begin(v1.station.lane_en_bitmap), std::end(v1.station.lane_en_bitmap),
+  v2.station.station_flags = std::numeric_limits<decltype(v2.station.station_flags)>::max();
+  v2.station.num_stations = std::numeric_limits<decltype(v2.station.num_stations)>::max();
+  std::fill(std::begin(v2.station.lane_en_bitmap), std::end(v2.station.lane_en_bitmap),
             static_cast<std::uint8_t>(0));
 
   /**
@@ -852,7 +913,7 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
               << " | UALOE sysfs not present: " << ualink_directory_path.string()
               << " | returning AMDSMI_STATUS_NOT_SUPPORTED";
     LOG_DEBUG(outstream);
-    fabric_info = local_fabric_info;
+    gpu_device::details::publish_fabric_info(fabric_bdf, v2, requested_version, fabric_info);
     return amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED;
   }
 
@@ -883,11 +944,11 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
     for (const auto& link_value : ualoe_file_lines) {
       switch (link_info_type_key) {
         case UALoeLinkInfo_t::LINK_TYPE:
-          gpu_device::details::get_fabric_type(link_value, local_fabric_info);
+          gpu_device::details::get_fabric_type(link_value, v2);
           break;
 
         case UALoeLinkInfo_t::ACCEL_STATE:
-          gpu_device::details::get_accel_state(link_value, local_fabric_info);
+          gpu_device::details::get_accel_state(link_value, v2);
           break;
 
         default:
@@ -897,11 +958,18 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
   }
 
   /**
-   *    Ppod/Vpod/Station: authoritative subtree readers.
-   *    Each returns AMDSMI_STATUS_SUCCESS, AMDSMI_STATUS_NO_DATA, AMDSMI_STATUS_NOT_SUPPORTED
+   *    Ppod/Vpod/Station: read from the flat surface, which is what the driver syncs to after a
+   *    successful commit. The setup/config/stations subtrees stage pending setter writes, so
+   *    reporting them here would return values that are not yet in effect.
    *
-   *    On anything but AMDSMI_STATUS_NOT_SUPPORTED its data payload (sentinels plus populated
-   *    fields) is copied into the info struct
+   *    Each read returns AMDSMI_STATUS_SUCCESS, AMDSMI_STATUS_NO_DATA or
+   *    AMDSMI_STATUS_NOT_SUPPORTED. On anything but AMDSMI_STATUS_NOT_SUPPORTED its data payload
+   *    (sentinels plus populated fields) and the mask of fields actually read are copied into the
+   *    info struct.
+   *
+   *    device_supports_ualink is passed as true because the ualink directory check above already
+   *    established it; going through device_has_ualink() would additionally demand an IFoE BDF and
+   *    lock out devices this function otherwise serves.
    *
    *    These device-level queries assume the per-GPU mutex is already held by the API entry point
    */
@@ -911,9 +979,11 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
   ppod_cfg.mask = (AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID | AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID |
                    AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE | AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS |
                    AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH | AMDSMI_FABRIC_PPOD_FIELD_LATENCY);
-  const auto ppod_status = query_fabric_ppod_config(ppod_cfg);
+  const auto ppod_status = fabric_ualink::query_ppod_config_at(ualink_directory, true, ppod_cfg,
+                                                               kUALOE_UALINK_FLAT_SUBDIR);
   if (ppod_status != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
-    v1.ppod = ppod_cfg.data;
+    v2.ppod = ppod_cfg.data;
+    v2.ppod_mask = ppod_cfg.mask;
   }
   is_any_plane_success =
       (is_any_plane_success || (ppod_status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS));
@@ -923,9 +993,11 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
   vpod_cfg.mask =
       (AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID | AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE |
        AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS | AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE);
-  const auto vpod_status = query_fabric_vpod_config(vpod_cfg);
+  const auto vpod_status = fabric_ualink::query_vpod_config_at(ualink_directory, true, vpod_cfg,
+                                                               kUALOE_UALINK_FLAT_SUBDIR);
   if (vpod_status != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
-    v1.vpod = vpod_cfg.data;
+    v2.vpod = vpod_cfg.data;
+    v2.vpod_mask = vpod_cfg.mask;
   }
   is_any_plane_success =
       (is_any_plane_success || (vpod_status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS));
@@ -934,39 +1006,26 @@ auto AMDSmiGPUDevice::get_fabric_info_from_ualoe(amdsmi_fabric_info_t& fabric_in
   station_cfg.version = AMDSMI_FABRIC_STATION_CONFIG_V1;
   station_cfg.mask = (AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS | AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP |
                       AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS);
-  const auto station_status = query_fabric_station_config(station_cfg);
+  const auto station_status = fabric_ualink::query_station_config_at(
+      ualink_directory, true, station_cfg, kUALOE_UALINK_FLAT_SUBDIR);
   if (station_status != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
-    v1.station = station_cfg.data;
+    v2.station = station_cfg.data;
+    v2.station_mask = station_cfg.mask;
   }
   is_any_plane_success =
       (is_any_plane_success || (station_status == amdsmi_status_t::AMDSMI_STATUS_SUCCESS));
 
-  fabric_info = local_fabric_info;
+  gpu_device::details::publish_fabric_info(fabric_bdf, v2, requested_version, fabric_info);
 
   /**
    *    Driver contract: a present sysfs file means the feature is supported; a
    *    present-but-empty IFoE file means supported-but-unconfigured.
-   *    File presence alone can't tell the two apart, so accel_state below is what separates a
-   *    configured read (SUCCESS) from an unconfigured one (NOT_INIT).
+   *    File presence alone can't tell the two apart, so an unconfigured device still reads as
+   *    SUCCESS and accel_state in fabric_info is what reports it.
    */
-  auto status_code = (((flat_files_with_usable_content > 0) || is_any_plane_success)
-                          ? amdsmi_status_t::AMDSMI_STATUS_SUCCESS
-                          : amdsmi_status_t::AMDSMI_STATUS_NO_DATA);
-
-  /**
-   *  Reuse the accel_state already parsed into v1 (avoids a second sysfs read) so the status
-   *  matches the value returned in fabric_info. Relies on the flat loop having read accel_state:
-   *  a link_info_type that excludes it leaves the UNKNOWN sentinel and forces NOT_INIT.
-   */
-  if (is_any_plane_success &&
-      ((v1.accel_state == amdsmi_fabric_accelerator_vpod_state_t::
-                              AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNCONFIGURED) ||
-       (v1.accel_state ==
-        amdsmi_fabric_accelerator_vpod_state_t::AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN))) {
-    status_code = amdsmi_status_t::AMDSMI_STATUS_NOT_INIT;
-  }
-
-  return status_code;
+  return (((flat_files_with_usable_content > 0) || is_any_plane_success)
+              ? amdsmi_status_t::AMDSMI_STATUS_SUCCESS
+              : amdsmi_status_t::AMDSMI_STATUS_NO_DATA);
 }
 
 }  // namespace amd::smi

--- a/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
@@ -875,3 +875,57 @@ amdsmi_status_t amdsmi_get_tray_info(amdsmi_node_handle node_handle, amdsmi_tray
 
   return AMDSMI_STATUS_NOT_SUPPORTED;
 }
+
+amdsmi_status_t amdsmi_set_gpu_fabric_ppod_config(amdsmi_processor_handle processor_handle,
+                                                  const amdsmi_fabric_ppod_config_t* config) {
+  AMDSMI_CHECK_INIT();
+
+  if (!processor_handle || !config) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  amd::smi::AMDSmiGPUDevice* device = nullptr;
+  const auto handle_status = get_gpu_device_from_handle(processor_handle, &device);
+  if (handle_status != AMDSMI_STATUS_SUCCESS) {
+    return handle_status;
+  }
+
+  SMIGPUDEVICE_MUTEX(device->get_mutex());
+  return device->apply_fabric_ppod_config(*config);
+}
+
+amdsmi_status_t amdsmi_set_gpu_fabric_vpod_config(amdsmi_processor_handle processor_handle,
+                                                  const amdsmi_fabric_vpod_config_t* config) {
+  AMDSMI_CHECK_INIT();
+
+  if (!processor_handle || !config) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  amd::smi::AMDSmiGPUDevice* device = nullptr;
+  const auto handle_status = get_gpu_device_from_handle(processor_handle, &device);
+  if (handle_status != AMDSMI_STATUS_SUCCESS) {
+    return handle_status;
+  }
+
+  SMIGPUDEVICE_MUTEX(device->get_mutex());
+  return device->apply_fabric_vpod_config(*config);
+}
+
+amdsmi_status_t amdsmi_set_gpu_fabric_station_config(amdsmi_processor_handle processor_handle,
+                                                     const amdsmi_fabric_station_config_t* config) {
+  AMDSMI_CHECK_INIT();
+
+  if (!processor_handle || !config) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  amd::smi::AMDSmiGPUDevice* device = nullptr;
+  const auto handle_status = get_gpu_device_from_handle(processor_handle, &device);
+  if (handle_status != AMDSMI_STATUS_SUCCESS) {
+    return handle_status;
+  }
+
+  SMIGPUDEVICE_MUTEX(device->get_mutex());
+  return device->apply_fabric_station_config(*config);
+}

--- a/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
@@ -20,6 +20,7 @@
  * THE SOFTWARE.
  */
 
+#include "amd_smi/impl/amd_smi_common.h"
 #include "amd_smi/impl/amd_smi_gpu_device.h"
 #include "amd_smi/impl/amd_smi_gpu_mutex.h"
 #include "amd_smi/impl/amd_smi_system.h"
@@ -777,4 +778,58 @@ amdsmi_status_t amdsmi_get_gpu_fabric_info(amdsmi_processor_handle processor_han
   status_code = device->get_fabric_info_from_ualoe(*info);
 
   return status_code;
+}
+
+amdsmi_status_t amdsmi_set_gpu_fabric_ppod_config(amdsmi_processor_handle processor_handle,
+                                                  const amdsmi_fabric_ppod_config_t* config) {
+  AMDSMI_CHECK_INIT();
+
+  if (!processor_handle || !config) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  amd::smi::AMDSmiGPUDevice* device = nullptr;
+  const auto handle_status = get_gpu_device_from_handle(processor_handle, &device);
+  if (handle_status != AMDSMI_STATUS_SUCCESS) {
+    return handle_status;
+  }
+
+  SMIGPUDEVICE_MUTEX(device->get_mutex());
+  return device->apply_fabric_ppod_config(*config);
+}
+
+amdsmi_status_t amdsmi_set_gpu_fabric_vpod_config(amdsmi_processor_handle processor_handle,
+                                                  const amdsmi_fabric_vpod_config_t* config) {
+  AMDSMI_CHECK_INIT();
+
+  if (!processor_handle || !config) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  amd::smi::AMDSmiGPUDevice* device = nullptr;
+  const auto handle_status = get_gpu_device_from_handle(processor_handle, &device);
+  if (handle_status != AMDSMI_STATUS_SUCCESS) {
+    return handle_status;
+  }
+
+  SMIGPUDEVICE_MUTEX(device->get_mutex());
+  return device->apply_fabric_vpod_config(*config);
+}
+
+amdsmi_status_t amdsmi_set_gpu_fabric_station_config(amdsmi_processor_handle processor_handle,
+                                                     const amdsmi_fabric_station_config_t* config) {
+  AMDSMI_CHECK_INIT();
+
+  if (!processor_handle || !config) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  amd::smi::AMDSmiGPUDevice* device = nullptr;
+  const auto handle_status = get_gpu_device_from_handle(processor_handle, &device);
+  if (handle_status != AMDSMI_STATUS_SUCCESS) {
+    return handle_status;
+  }
+
+  SMIGPUDEVICE_MUTEX(device->get_mutex());
+  return device->apply_fabric_station_config(*config);
 }

--- a/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_read_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_read_test.cc
@@ -5,10 +5,18 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
+#include <iomanip>
 #include <iostream>
+#include <limits>
+#include <sstream>
+#include <string>
 
 #include "amd_smi/amdsmi.h"
+#include "amd_smi/impl/amd_smi_gpu_device.h"
+#include "amd_smi/impl/amd_smi_utils.h"
 #include "test_common.h"
 
 // Category mask covering all telemetry categories
@@ -57,6 +65,28 @@ void TestFabricRead::Run(void) {
     return;
   }
 
+  if (num_monitor_devs() == 0) {
+    IF_VERB(STANDARD) { std::cout << "\tNo GPU devices found. Skipping test." << std::endl; }
+    GTEST_SKIP() << "No GPU devices found";
+  }
+
+  /**
+   *    IFoE capability gate: fabric-less systems report NOT_SUPPORTED from
+   *    amdsmi_get_gpu_fabric_info(); skip the whole test rather than exercise the
+   *    hardware paths below (matches the Fabric Write test)
+   *    Probes device 0 only, assuming a homogeneous fabric config across devices;
+   *    a mixed host (some devices fabric-capable, some not) would skip on device 0.
+   */
+  {
+    amdsmi_fabric_info_t probe = {};
+    if (amdsmi_get_gpu_fabric_info(processor_handles_[0], &probe) == AMDSMI_STATUS_NOT_SUPPORTED) {
+      IF_VERB(STANDARD) {
+        std::cout << "\t**Fabric (IFoE) not supported on this system; skipping test" << std::endl;
+      }
+      GTEST_SKIP() << "Fabric (IFoE) not supported on this system";
+    }
+  }
+
   for (uint32_t dv_ind = 0; dv_ind < num_monitor_devs(); ++dv_ind) {
     auto device = processor_handles_[dv_ind];
     PrintDeviceHeader(device);
@@ -102,7 +132,7 @@ void TestFabricRead::Run(void) {
       }
     }
 
-    // ── amdsmi_get_gpu_fabric_info ─────────────────────────────────────────
+    // Test amdsmi_get_gpu_fabric_info
     IF_VERB(STANDARD) { std::cout << "\t** Testing amdsmi_get_gpu_fabric_info()" << std::endl; }
 
     amdsmi_fabric_info_t fabric_info = {};
@@ -119,7 +149,8 @@ void TestFabricRead::Run(void) {
                   << std::endl;
       }
       continue;
-    } else if (err != AMDSMI_STATUS_SUCCESS && err != AMDSMI_STATUS_NO_DATA) {
+    } else if (err != AMDSMI_STATUS_SUCCESS && err != AMDSMI_STATUS_NO_DATA &&
+               err != AMDSMI_STATUS_NOT_INIT) {
       CHK_ERR_ASRT(err)
     } else {
       IF_VERB(STANDARD) {
@@ -128,17 +159,176 @@ void TestFabricRead::Run(void) {
                        "(no UALoE sysfs content); BDF may still be valid"
                     << std::endl;
         }
+        if (err == AMDSMI_STATUS_NOT_INIT) {
+          std::cout << "\t**amdsmi_get_gpu_fabric_info() returned NOT_INIT "
+                       "(no UALoE sysfs content); accelerators may not be configured/setup"
+                    << std::endl;
+        }
         const auto& v1 = fabric_info.fabric_info.v1;
-        std::cout << "\t\tversion:        " << fabric_info.fabric_version << "\n"
-                  << "\t\taccelerator_id: " << v1.accelerator_id << "\n"
-                  << "\t\tfabric_type:    " << v1.fabric_type << "\n"
-                  << "\t\tbandwidth:      " << v1.bandwidth << " Mb/s" << "\n"
-                  << "\t\tlatency:        " << v1.latency << " ns" << "\n"
-                  << "\t\tvpod_id:        " << v1.vpod_id << "\n"
-                  << "\t\tvpod_size:      " << v1.vpod_size << "\n"
-                  << "\t\tppod_size:      " << v1.ppod_size << "\n"
-                  << "\t\taddr_mode:      " << v1.addr_mode << "\n"
-                  << "\t\taccel_state:    " << v1.accel_state << "\n";
+
+        // Render a byte array (ppod_id, lane_en_bitmap) as contiguous "0x.." hex.
+        auto to_hex = [](const uint8_t* data, std::size_t count) {
+          auto os = std::ostringstream();
+          os << "0x";
+          for (auto i = std::size_t{0}; i < count; ++i) {
+            os << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned>(data[i]);
+          }
+          return os.str();
+        };
+
+        // Render the valid entries of a u32 id array; UINT32_MAX marks an unset slot.
+        auto to_id_list = [](const uint32_t* data, std::size_t count) {
+          auto os = std::ostringstream();
+          auto first = true;
+          for (auto i = std::size_t{0}; i < count; ++i) {
+            if ((data[i] == std::numeric_limits<uint32_t>::max())) {
+              continue;
+            }
+            os << (first ? "" : ", ") << data[i];
+            first = false;
+          }
+          return (first ? std::string("(none)") : os.str());
+        };
+
+        std::cout << "\t\tversion:                  " << fabric_info.fabric_version << "\n"
+                  << "\t\tfabric_type:              " << v1.fabric_type << "\n"
+                  << "\t\taccel_state:              " << v1.accel_state << "\n"
+                  << "\t\taccelerator_id:           " << v1.ppod.accelerator_id << "\n"
+                  << "\t\tbandwidth:                " << v1.ppod.bandwidth << " Mb/s\n"
+                  << "\t\tlatency:                  " << v1.ppod.latency << " ns\n"
+                  << "\t\tppod_id:                  "
+                  << to_hex(v1.ppod.ppod_id, AMDSMI_MAX_UUID_ELEMENTS) << "\n"
+                  << "\t\tppod_size:                " << v1.ppod.ppod_size << "\n"
+                  << "\t\tlocal_accelerators:       "
+                  << to_id_list(v1.ppod.local_accelerators, AMDSMI_FABRIC_MAX_LOCAL_GPUS) << "\n"
+                  << "\t\tlocal_accelerator_count:  " << v1.ppod.local_accelerator_count << "\n"
+                  << "\t\tvpod_id:                  " << v1.vpod.vpod_id << "\n"
+                  << "\t\tvpod_size:                " << v1.vpod.vpod_size << "\n"
+                  << "\t\tvpod_active_accelerators: "
+                  << to_id_list(v1.vpod.vpod_active_accelerators,
+                                AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE)
+                  << "\n"
+                  << "\t\taddr_mode:                " << v1.vpod.addr_mode << "\n"
+                  << "\t\tstation_flags:            " << v1.station.station_flags << "\n"
+                  << "\t\tnum_stations:             "
+                  << static_cast<unsigned>(v1.station.num_stations) << "\n"
+                  << "\t\tlane_en_bitmap:           "
+                  << to_hex(v1.station.lane_en_bitmap, AMDSMI_FABRIC_MAX_BITMAP_SIZE) << "\n";
+      }
+    }
+
+    /**
+     * Cross-check commit propagation: read each config domain from the write
+     * subtree (setup/config/df) and from the flat surface, then report per-field
+     * whether the two agree. The subtree-vs-flat agreement is diagnostic only --
+     * a mismatch may simply mean the driver does not mirror committed values into
+     * the flat files. Per-reader invariants (status code and mask) are asserted.
+     * Both readers sentinel-init identically, so a plain value compare is
+     * meaningful even for fields absent on a surface.
+     */
+    IF_VERB(STANDARD) {
+      amd::smi::AMDSmiGPUDevice* dev = nullptr;
+      if (((get_gpu_device_from_handle(device, &dev) == AMDSMI_STATUS_SUCCESS) &&
+           (dev != nullptr))) {
+        std::cout << "\t** Comparing flat vs subtree fabric config (commit propagation)"
+                  << std::endl;
+
+        auto show_scalar = [](const char* name, uint64_t s, uint64_t f) {
+          std::cout << "\t\t" << name << ": " << ((s == f) ? "MATCH" : "MISMATCH")
+                    << " (subtree=" << s << " flat=" << f << ")\n";
+        };
+        auto show_array = [](const char* name, const auto* s, const auto* f, std::size_t n) {
+          std::cout << "\t\t" << name << ": " << (std::equal(s, (s + n), f) ? "MATCH" : "MISMATCH")
+                    << "\n";
+        };
+        // Per-reader contract, independent of whether the driver mirrors subtree into flat:
+        // status is one of the documented codes, and SUCCESS reports a non-empty mask.
+        auto expect_reader_contract = [](amdsmi_status_t st, uint32_t read_mask) {
+          EXPECT_TRUE((st == AMDSMI_STATUS_SUCCESS) || (st == AMDSMI_STATUS_NO_DATA) ||
+                      (st == AMDSMI_STATUS_NOT_SUPPORTED))
+              << "unexpected fabric query status: " << st;
+          if (st == AMDSMI_STATUS_SUCCESS) {
+            EXPECT_NE(read_mask, 0u);
+          } else if (st == AMDSMI_STATUS_NO_DATA) {
+            EXPECT_EQ(read_mask, 0u);
+          }
+        };
+
+        {
+          auto sub = amdsmi_fabric_ppod_config_t{};
+          sub.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+          sub.mask = (AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID | AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID |
+                      AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE | AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS |
+                      AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH | AMDSMI_FABRIC_PPOD_FIELD_LATENCY);
+          auto flat = sub;
+          const auto s_st = dev->query_fabric_ppod_config(sub);
+          const auto f_st = dev->query_fabric_ppod_config_flat(flat);
+          std::cout << "\t\t[ppod] subtree_status=" << s_st << " flat_status=" << f_st << "\n";
+          expect_reader_contract(s_st, sub.mask);
+          expect_reader_contract(f_st, flat.mask);
+          if (s_st == AMDSMI_STATUS_SUCCESS) {
+            EXPECT_LE(sub.data.local_accelerator_count,
+                      static_cast<uint32_t>(AMDSMI_FABRIC_MAX_LOCAL_GPUS));
+          }
+          if (f_st == AMDSMI_STATUS_SUCCESS) {
+            EXPECT_LE(flat.data.local_accelerator_count,
+                      static_cast<uint32_t>(AMDSMI_FABRIC_MAX_LOCAL_GPUS));
+          }
+          if (((s_st == AMDSMI_STATUS_SUCCESS) || (f_st == AMDSMI_STATUS_SUCCESS))) {
+            show_scalar("ppod.accelerator_id", sub.data.accelerator_id, flat.data.accelerator_id);
+            show_array("ppod.ppod_id", sub.data.ppod_id, flat.data.ppod_id,
+                       AMDSMI_MAX_UUID_ELEMENTS);
+            show_scalar("ppod.ppod_size", sub.data.ppod_size, flat.data.ppod_size);
+            show_array("ppod.local_accelerators", sub.data.local_accelerators,
+                       flat.data.local_accelerators, AMDSMI_FABRIC_MAX_LOCAL_GPUS);
+            show_scalar("ppod.local_accelerator_count", sub.data.local_accelerator_count,
+                        flat.data.local_accelerator_count);
+            show_scalar("ppod.bandwidth", sub.data.bandwidth, flat.data.bandwidth);
+            show_scalar("ppod.latency", sub.data.latency, flat.data.latency);
+          }
+        }
+
+        {
+          auto sub = amdsmi_fabric_vpod_config_t{};
+          sub.version = AMDSMI_FABRIC_VPOD_CONFIG_V1;
+          sub.mask =
+              (AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID | AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE |
+               AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS | AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE);
+          auto flat = sub;
+          const auto s_st = dev->query_fabric_vpod_config(sub);
+          const auto f_st = dev->query_fabric_vpod_config_flat(flat);
+          std::cout << "\t\t[vpod] subtree_status=" << s_st << " flat_status=" << f_st << "\n";
+          expect_reader_contract(s_st, sub.mask);
+          expect_reader_contract(f_st, flat.mask);
+          if (((s_st == AMDSMI_STATUS_SUCCESS) || (f_st == AMDSMI_STATUS_SUCCESS))) {
+            show_scalar("vpod.vpod_id", sub.data.vpod_id, flat.data.vpod_id);
+            show_scalar("vpod.vpod_size", sub.data.vpod_size, flat.data.vpod_size);
+            show_array("vpod.vpod_active_accelerators", sub.data.vpod_active_accelerators,
+                       flat.data.vpod_active_accelerators,
+                       AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE);
+            show_scalar("vpod.addr_mode", static_cast<uint64_t>(sub.data.addr_mode),
+                        static_cast<uint64_t>(flat.data.addr_mode));
+          }
+        }
+
+        {
+          auto sub = amdsmi_fabric_station_config_t{};
+          sub.version = AMDSMI_FABRIC_STATION_CONFIG_V1;
+          sub.mask = (AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS | AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP |
+                      AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS);
+          auto flat = sub;
+          const auto s_st = dev->query_fabric_station_config(sub);
+          const auto f_st = dev->query_fabric_station_config_flat(flat);
+          std::cout << "\t\t[station] subtree_status=" << s_st << " flat_status=" << f_st << "\n";
+          expect_reader_contract(s_st, sub.mask);
+          expect_reader_contract(f_st, flat.mask);
+          if (((s_st == AMDSMI_STATUS_SUCCESS) || (f_st == AMDSMI_STATUS_SUCCESS))) {
+            show_scalar("station.station_flags", sub.data.station_flags, flat.data.station_flags);
+            show_scalar("station.num_stations", sub.data.num_stations, flat.data.num_stations);
+            show_array("station.lane_en_bitmap", sub.data.lane_en_bitmap, flat.data.lane_en_bitmap,
+                       AMDSMI_FABRIC_MAX_BITMAP_SIZE);
+          }
+        }
       }
     }
 
@@ -149,7 +339,10 @@ void TestFabricRead::Run(void) {
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_INVAL);
     ASSERT_EQ(err, AMDSMI_STATUS_INVAL);
 
-    // ── amdsmi_alloc_fabric_telemetry / amdsmi_get_fabric_telemetry_data ──
+    /**
+     * Test amdsmi_alloc_fabric_telemetry(), amdsmi_get_fabric_telemetry_data(),
+     * amdsmi_free_fabric_telemetry()
+     */
     IF_VERB(STANDARD) {
       std::cout << "\t** Testing amdsmi_alloc_fabric_telemetry() / "
                    "amdsmi_get_fabric_telemetry_data() / "
@@ -231,9 +424,7 @@ void TestFabricRead::Run(void) {
       }
     }
 
-    // ── amdsmi_free_fabric_telemetry ──────────────────────────────────────
-    DISPLAY_AMDSMI_API("amdsmi_free_fabric_telemetry", "gpu=" + std::to_string(dv_ind),
-                       VERB(STANDARD));
+    // amdsmi_free_fabric_telemetry
     err = amdsmi_free_fabric_telemetry(device, tel);
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_SUCCESS);
     CHK_ERR_ASRT(err)

--- a/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_read_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_read_test.cc
@@ -79,6 +79,7 @@ void TestFabricRead::Run(void) {
    */
   {
     amdsmi_fabric_info_t probe = {};
+    probe.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
     if (amdsmi_get_gpu_fabric_info(processor_handles_[0], &probe) == AMDSMI_STATUS_NOT_SUPPORTED) {
       IF_VERB(STANDARD) {
         std::cout << "\t**Fabric (IFoE) not supported on this system; skipping test" << std::endl;
@@ -136,6 +137,7 @@ void TestFabricRead::Run(void) {
     IF_VERB(STANDARD) { std::cout << "\t** Testing amdsmi_get_gpu_fabric_info()" << std::endl; }
 
     amdsmi_fabric_info_t fabric_info = {};
+    fabric_info.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
     DISPLAY_AMDSMI_API("amdsmi_get_gpu_fabric_info", "gpu=" + std::to_string(dv_ind),
                        VERB(STANDARD));
     err = amdsmi_get_gpu_fabric_info(device, &fabric_info);
@@ -149,8 +151,7 @@ void TestFabricRead::Run(void) {
                   << std::endl;
       }
       continue;
-    } else if (err != AMDSMI_STATUS_SUCCESS && err != AMDSMI_STATUS_NO_DATA &&
-               err != AMDSMI_STATUS_NOT_INIT) {
+    } else if (err != AMDSMI_STATUS_SUCCESS && err != AMDSMI_STATUS_NO_DATA) {
       CHK_ERR_ASRT(err)
     } else {
       IF_VERB(STANDARD) {
@@ -159,12 +160,7 @@ void TestFabricRead::Run(void) {
                        "(no UALoE sysfs content); BDF may still be valid"
                     << std::endl;
         }
-        if (err == AMDSMI_STATUS_NOT_INIT) {
-          std::cout << "\t**amdsmi_get_gpu_fabric_info() returned NOT_INIT "
-                       "(no UALoE sysfs content); accelerators may not be configured/setup"
-                    << std::endl;
-        }
-        const auto& v1 = fabric_info.fabric_info.v1;
+        const auto& v2 = fabric_info.fabric_info.v2;
 
         // Render a byte array (ppod_id, lane_en_bitmap) as contiguous "0x.." hex.
         auto to_hex = [](const uint8_t* data, std::size_t count) {
@@ -191,29 +187,29 @@ void TestFabricRead::Run(void) {
         };
 
         std::cout << "\t\tversion:                  " << fabric_info.fabric_version << "\n"
-                  << "\t\tfabric_type:              " << v1.fabric_type << "\n"
-                  << "\t\taccel_state:              " << v1.accel_state << "\n"
-                  << "\t\taccelerator_id:           " << v1.ppod.accelerator_id << "\n"
-                  << "\t\tbandwidth:                " << v1.ppod.bandwidth << " Mb/s\n"
-                  << "\t\tlatency:                  " << v1.ppod.latency << " ns\n"
+                  << "\t\tfabric_type:              " << v2.fabric_type << "\n"
+                  << "\t\taccel_state:              " << v2.accel_state << "\n"
+                  << "\t\taccelerator_id:           " << v2.ppod.accelerator_id << "\n"
+                  << "\t\tbandwidth:                " << v2.ppod.bandwidth << " Mb/s\n"
+                  << "\t\tlatency:                  " << v2.ppod.latency << " ns\n"
                   << "\t\tppod_id:                  "
-                  << to_hex(v1.ppod.ppod_id, AMDSMI_MAX_UUID_ELEMENTS) << "\n"
-                  << "\t\tppod_size:                " << v1.ppod.ppod_size << "\n"
+                  << to_hex(v2.ppod.ppod_id, AMDSMI_MAX_UUID_ELEMENTS) << "\n"
+                  << "\t\tppod_size:                " << v2.ppod.ppod_size << "\n"
                   << "\t\tlocal_accelerators:       "
-                  << to_id_list(v1.ppod.local_accelerators, AMDSMI_FABRIC_MAX_LOCAL_GPUS) << "\n"
-                  << "\t\tlocal_accelerator_count:  " << v1.ppod.local_accelerator_count << "\n"
-                  << "\t\tvpod_id:                  " << v1.vpod.vpod_id << "\n"
-                  << "\t\tvpod_size:                " << v1.vpod.vpod_size << "\n"
+                  << to_id_list(v2.ppod.local_accelerators, AMDSMI_FABRIC_MAX_LOCAL_GPUS) << "\n"
+                  << "\t\tlocal_accelerator_count:  " << v2.ppod.local_accelerator_count << "\n"
+                  << "\t\tvpod_id:                  " << v2.vpod.vpod_id << "\n"
+                  << "\t\tvpod_size:                " << v2.vpod.vpod_size << "\n"
                   << "\t\tvpod_active_accelerators: "
-                  << to_id_list(v1.vpod.vpod_active_accelerators,
+                  << to_id_list(v2.vpod.vpod_active_accelerators,
                                 AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE)
                   << "\n"
-                  << "\t\taddr_mode:                " << v1.vpod.addr_mode << "\n"
-                  << "\t\tstation_flags:            " << v1.station.station_flags << "\n"
+                  << "\t\taddr_mode:                " << v2.vpod.addr_mode << "\n"
+                  << "\t\tstation_flags:            " << v2.station.station_flags << "\n"
                   << "\t\tnum_stations:             "
-                  << static_cast<unsigned>(v1.station.num_stations) << "\n"
+                  << static_cast<unsigned>(v2.station.num_stations) << "\n"
                   << "\t\tlane_en_bitmap:           "
-                  << to_hex(v1.station.lane_en_bitmap, AMDSMI_FABRIC_MAX_BITMAP_SIZE) << "\n";
+                  << to_hex(v2.station.lane_en_bitmap, AMDSMI_FABRIC_MAX_BITMAP_SIZE) << "\n";
       }
     }
 

--- a/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_read_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_read_test.cc
@@ -98,6 +98,7 @@ void TestFabricRead::Run(void) {
    */
   {
     amdsmi_fabric_info_t probe = {};
+    probe.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
     if (amdsmi_get_gpu_fabric_info(processor_handles_[0], &probe) == AMDSMI_STATUS_NOT_SUPPORTED) {
       IF_VERB(STANDARD) {
         std::cout << "\t**Fabric (IFoE) not supported on this system; skipping test" << std::endl;
@@ -155,6 +156,7 @@ void TestFabricRead::Run(void) {
     IF_VERB(STANDARD) { std::cout << "\t** Testing amdsmi_get_gpu_fabric_info()" << std::endl; }
 
     amdsmi_fabric_info_t fabric_info = {};
+    fabric_info.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
     DISPLAY_AMDSMI_API("amdsmi_get_gpu_fabric_info", "gpu=" + std::to_string(dv_ind),
                        VERB(STANDARD));
     err = amdsmi_get_gpu_fabric_info(device, &fabric_info);
@@ -168,8 +170,7 @@ void TestFabricRead::Run(void) {
                   << std::endl;
       }
       continue;
-    } else if (err != AMDSMI_STATUS_SUCCESS && err != AMDSMI_STATUS_NO_DATA &&
-               err != AMDSMI_STATUS_NOT_INIT) {
+    } else if (err != AMDSMI_STATUS_SUCCESS && err != AMDSMI_STATUS_NO_DATA) {
       CHK_ERR_ASRT(err)
     } else {
       IF_VERB(STANDARD) {
@@ -178,12 +179,7 @@ void TestFabricRead::Run(void) {
                        "(no UALoE sysfs content); BDF may still be valid"
                     << std::endl;
         }
-        if (err == AMDSMI_STATUS_NOT_INIT) {
-          std::cout << "\t**amdsmi_get_gpu_fabric_info() returned NOT_INIT "
-                       "(no UALoE sysfs content); accelerators may not be configured/setup"
-                    << std::endl;
-        }
-        const auto& v1 = fabric_info.fabric_info.v1;
+        const auto& v2 = fabric_info.fabric_info.v2;
 
         // Render a byte array (ppod_id, lane_en_bitmap) as contiguous "0x.." hex.
         auto to_hex = [](const uint8_t* data, std::size_t count) {
@@ -210,29 +206,29 @@ void TestFabricRead::Run(void) {
         };
 
         std::cout << "\t\tversion:                  " << fabric_info.fabric_version << "\n"
-                  << "\t\tfabric_type:              " << v1.fabric_type << "\n"
-                  << "\t\taccel_state:              " << v1.accel_state << "\n"
-                  << "\t\taccelerator_id:           " << v1.ppod.accelerator_id << "\n"
-                  << "\t\tbandwidth:                " << v1.ppod.bandwidth << " Mb/s\n"
-                  << "\t\tlatency:                  " << v1.ppod.latency << " ns\n"
+                  << "\t\tfabric_type:              " << v2.fabric_type << "\n"
+                  << "\t\taccel_state:              " << v2.accel_state << "\n"
+                  << "\t\taccelerator_id:           " << v2.ppod.accelerator_id << "\n"
+                  << "\t\tbandwidth:                " << v2.ppod.bandwidth << " Mb/s\n"
+                  << "\t\tlatency:                  " << v2.ppod.latency << " ns\n"
                   << "\t\tppod_id:                  "
-                  << to_hex(v1.ppod.ppod_id, AMDSMI_MAX_UUID_ELEMENTS) << "\n"
-                  << "\t\tppod_size:                " << v1.ppod.ppod_size << "\n"
+                  << to_hex(v2.ppod.ppod_id, AMDSMI_MAX_UUID_ELEMENTS) << "\n"
+                  << "\t\tppod_size:                " << v2.ppod.ppod_size << "\n"
                   << "\t\tlocal_accelerators:       "
-                  << to_id_list(v1.ppod.local_accelerators, AMDSMI_FABRIC_MAX_LOCAL_GPUS) << "\n"
-                  << "\t\tlocal_accelerator_count:  " << v1.ppod.local_accelerator_count << "\n"
-                  << "\t\tvpod_id:                  " << v1.vpod.vpod_id << "\n"
-                  << "\t\tvpod_size:                " << v1.vpod.vpod_size << "\n"
+                  << to_id_list(v2.ppod.local_accelerators, AMDSMI_FABRIC_MAX_LOCAL_GPUS) << "\n"
+                  << "\t\tlocal_accelerator_count:  " << v2.ppod.local_accelerator_count << "\n"
+                  << "\t\tvpod_id:                  " << v2.vpod.vpod_id << "\n"
+                  << "\t\tvpod_size:                " << v2.vpod.vpod_size << "\n"
                   << "\t\tvpod_active_accelerators: "
-                  << to_id_list(v1.vpod.vpod_active_accelerators,
+                  << to_id_list(v2.vpod.vpod_active_accelerators,
                                 AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE)
                   << "\n"
-                  << "\t\taddr_mode:                " << v1.vpod.addr_mode << "\n"
-                  << "\t\tstation_flags:            " << v1.station.station_flags << "\n"
+                  << "\t\taddr_mode:                " << v2.vpod.addr_mode << "\n"
+                  << "\t\tstation_flags:            " << v2.station.station_flags << "\n"
                   << "\t\tnum_stations:             "
-                  << static_cast<unsigned>(v1.station.num_stations) << "\n"
+                  << static_cast<unsigned>(v2.station.num_stations) << "\n"
                   << "\t\tlane_en_bitmap:           "
-                  << to_hex(v1.station.lane_en_bitmap, AMDSMI_FABRIC_MAX_BITMAP_SIZE) << "\n";
+                  << to_hex(v2.station.lane_en_bitmap, AMDSMI_FABRIC_MAX_BITMAP_SIZE) << "\n";
       }
     }
 

--- a/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_read_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_read_test.cc
@@ -24,10 +24,18 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
+#include <iomanip>
 #include <iostream>
+#include <limits>
+#include <sstream>
+#include <string>
 
 #include "amd_smi/amdsmi.h"
+#include "amd_smi/impl/amd_smi_gpu_device.h"
+#include "amd_smi/impl/amd_smi_utils.h"
 #include "test_common.h"
 
 // Category mask covering all telemetry categories
@@ -76,6 +84,28 @@ void TestFabricRead::Run(void) {
     return;
   }
 
+  if (num_monitor_devs() == 0) {
+    IF_VERB(STANDARD) { std::cout << "\tNo GPU devices found. Skipping test." << std::endl; }
+    GTEST_SKIP() << "No GPU devices found";
+  }
+
+  /**
+   *    IFoE capability gate: fabric-less systems report NOT_SUPPORTED from
+   *    amdsmi_get_gpu_fabric_info(); skip the whole test rather than exercise the
+   *    hardware paths below (matches the Fabric Write test)
+   *    Probes device 0 only, assuming a homogeneous fabric config across devices;
+   *    a mixed host (some devices fabric-capable, some not) would skip on device 0.
+   */
+  {
+    amdsmi_fabric_info_t probe = {};
+    if (amdsmi_get_gpu_fabric_info(processor_handles_[0], &probe) == AMDSMI_STATUS_NOT_SUPPORTED) {
+      IF_VERB(STANDARD) {
+        std::cout << "\t**Fabric (IFoE) not supported on this system; skipping test" << std::endl;
+      }
+      GTEST_SKIP() << "Fabric (IFoE) not supported on this system";
+    }
+  }
+
   for (uint32_t dv_ind = 0; dv_ind < num_monitor_devs(); ++dv_ind) {
     auto device = processor_handles_[dv_ind];
     PrintDeviceHeader(device);
@@ -121,7 +151,7 @@ void TestFabricRead::Run(void) {
       }
     }
 
-    // ── amdsmi_get_gpu_fabric_info ─────────────────────────────────────────
+    // Test amdsmi_get_gpu_fabric_info
     IF_VERB(STANDARD) { std::cout << "\t** Testing amdsmi_get_gpu_fabric_info()" << std::endl; }
 
     amdsmi_fabric_info_t fabric_info = {};
@@ -138,7 +168,8 @@ void TestFabricRead::Run(void) {
                   << std::endl;
       }
       continue;
-    } else if (err != AMDSMI_STATUS_SUCCESS && err != AMDSMI_STATUS_NO_DATA) {
+    } else if (err != AMDSMI_STATUS_SUCCESS && err != AMDSMI_STATUS_NO_DATA &&
+               err != AMDSMI_STATUS_NOT_INIT) {
       CHK_ERR_ASRT(err)
     } else {
       IF_VERB(STANDARD) {
@@ -147,17 +178,176 @@ void TestFabricRead::Run(void) {
                        "(no UALoE sysfs content); BDF may still be valid"
                     << std::endl;
         }
+        if (err == AMDSMI_STATUS_NOT_INIT) {
+          std::cout << "\t**amdsmi_get_gpu_fabric_info() returned NOT_INIT "
+                       "(no UALoE sysfs content); accelerators may not be configured/setup"
+                    << std::endl;
+        }
         const auto& v1 = fabric_info.fabric_info.v1;
-        std::cout << "\t\tversion:        " << fabric_info.fabric_version << "\n"
-                  << "\t\taccelerator_id: " << v1.accelerator_id << "\n"
-                  << "\t\tfabric_type:    " << v1.fabric_type << "\n"
-                  << "\t\tbandwidth:      " << v1.bandwidth << " Mb/s" << "\n"
-                  << "\t\tlatency:        " << v1.latency << " ns" << "\n"
-                  << "\t\tvpod_id:        " << v1.vpod_id << "\n"
-                  << "\t\tvpod_size:      " << v1.vpod_size << "\n"
-                  << "\t\tppod_size:      " << v1.ppod_size << "\n"
-                  << "\t\taddr_mode:      " << v1.addr_mode << "\n"
-                  << "\t\taccel_state:    " << v1.accel_state << "\n";
+
+        // Render a byte array (ppod_id, lane_en_bitmap) as contiguous "0x.." hex.
+        auto to_hex = [](const uint8_t* data, std::size_t count) {
+          auto os = std::ostringstream();
+          os << "0x";
+          for (auto i = std::size_t{0}; i < count; ++i) {
+            os << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned>(data[i]);
+          }
+          return os.str();
+        };
+
+        // Render the valid entries of a u32 id array; UINT32_MAX marks an unset slot.
+        auto to_id_list = [](const uint32_t* data, std::size_t count) {
+          auto os = std::ostringstream();
+          auto first = true;
+          for (auto i = std::size_t{0}; i < count; ++i) {
+            if ((data[i] == std::numeric_limits<uint32_t>::max())) {
+              continue;
+            }
+            os << (first ? "" : ", ") << data[i];
+            first = false;
+          }
+          return (first ? std::string("(none)") : os.str());
+        };
+
+        std::cout << "\t\tversion:                  " << fabric_info.fabric_version << "\n"
+                  << "\t\tfabric_type:              " << v1.fabric_type << "\n"
+                  << "\t\taccel_state:              " << v1.accel_state << "\n"
+                  << "\t\taccelerator_id:           " << v1.ppod.accelerator_id << "\n"
+                  << "\t\tbandwidth:                " << v1.ppod.bandwidth << " Mb/s\n"
+                  << "\t\tlatency:                  " << v1.ppod.latency << " ns\n"
+                  << "\t\tppod_id:                  "
+                  << to_hex(v1.ppod.ppod_id, AMDSMI_MAX_UUID_ELEMENTS) << "\n"
+                  << "\t\tppod_size:                " << v1.ppod.ppod_size << "\n"
+                  << "\t\tlocal_accelerators:       "
+                  << to_id_list(v1.ppod.local_accelerators, AMDSMI_FABRIC_MAX_LOCAL_GPUS) << "\n"
+                  << "\t\tlocal_accelerator_count:  " << v1.ppod.local_accelerator_count << "\n"
+                  << "\t\tvpod_id:                  " << v1.vpod.vpod_id << "\n"
+                  << "\t\tvpod_size:                " << v1.vpod.vpod_size << "\n"
+                  << "\t\tvpod_active_accelerators: "
+                  << to_id_list(v1.vpod.vpod_active_accelerators,
+                                AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE)
+                  << "\n"
+                  << "\t\taddr_mode:                " << v1.vpod.addr_mode << "\n"
+                  << "\t\tstation_flags:            " << v1.station.station_flags << "\n"
+                  << "\t\tnum_stations:             "
+                  << static_cast<unsigned>(v1.station.num_stations) << "\n"
+                  << "\t\tlane_en_bitmap:           "
+                  << to_hex(v1.station.lane_en_bitmap, AMDSMI_FABRIC_MAX_BITMAP_SIZE) << "\n";
+      }
+    }
+
+    /**
+     * Cross-check commit propagation: read each config domain from the write
+     * subtree (setup/config/df) and from the flat surface, then report per-field
+     * whether the two agree. The subtree-vs-flat agreement is diagnostic only --
+     * a mismatch may simply mean the driver does not mirror committed values into
+     * the flat files. Per-reader invariants (status code and mask) are asserted.
+     * Both readers sentinel-init identically, so a plain value compare is
+     * meaningful even for fields absent on a surface.
+     */
+    IF_VERB(STANDARD) {
+      amd::smi::AMDSmiGPUDevice* dev = nullptr;
+      if (((get_gpu_device_from_handle(device, &dev) == AMDSMI_STATUS_SUCCESS) &&
+           (dev != nullptr))) {
+        std::cout << "\t** Comparing flat vs subtree fabric config (commit propagation)"
+                  << std::endl;
+
+        auto show_scalar = [](const char* name, uint64_t s, uint64_t f) {
+          std::cout << "\t\t" << name << ": " << ((s == f) ? "MATCH" : "MISMATCH")
+                    << " (subtree=" << s << " flat=" << f << ")\n";
+        };
+        auto show_array = [](const char* name, const auto* s, const auto* f, std::size_t n) {
+          std::cout << "\t\t" << name << ": " << (std::equal(s, (s + n), f) ? "MATCH" : "MISMATCH")
+                    << "\n";
+        };
+        // Per-reader contract, independent of whether the driver mirrors subtree into flat:
+        // status is one of the documented codes, and SUCCESS reports a non-empty mask.
+        auto expect_reader_contract = [](amdsmi_status_t st, uint32_t read_mask) {
+          EXPECT_TRUE((st == AMDSMI_STATUS_SUCCESS) || (st == AMDSMI_STATUS_NO_DATA) ||
+                      (st == AMDSMI_STATUS_NOT_SUPPORTED))
+              << "unexpected fabric query status: " << st;
+          if (st == AMDSMI_STATUS_SUCCESS) {
+            EXPECT_NE(read_mask, 0u);
+          } else if (st == AMDSMI_STATUS_NO_DATA) {
+            EXPECT_EQ(read_mask, 0u);
+          }
+        };
+
+        {
+          auto sub = amdsmi_fabric_ppod_config_t{};
+          sub.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+          sub.mask = (AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID | AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID |
+                      AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE | AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS |
+                      AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH | AMDSMI_FABRIC_PPOD_FIELD_LATENCY);
+          auto flat = sub;
+          const auto s_st = dev->query_fabric_ppod_config(sub);
+          const auto f_st = dev->query_fabric_ppod_config_flat(flat);
+          std::cout << "\t\t[ppod] subtree_status=" << s_st << " flat_status=" << f_st << "\n";
+          expect_reader_contract(s_st, sub.mask);
+          expect_reader_contract(f_st, flat.mask);
+          if (s_st == AMDSMI_STATUS_SUCCESS) {
+            EXPECT_LE(sub.data.local_accelerator_count,
+                      static_cast<uint32_t>(AMDSMI_FABRIC_MAX_LOCAL_GPUS));
+          }
+          if (f_st == AMDSMI_STATUS_SUCCESS) {
+            EXPECT_LE(flat.data.local_accelerator_count,
+                      static_cast<uint32_t>(AMDSMI_FABRIC_MAX_LOCAL_GPUS));
+          }
+          if (((s_st == AMDSMI_STATUS_SUCCESS) || (f_st == AMDSMI_STATUS_SUCCESS))) {
+            show_scalar("ppod.accelerator_id", sub.data.accelerator_id, flat.data.accelerator_id);
+            show_array("ppod.ppod_id", sub.data.ppod_id, flat.data.ppod_id,
+                       AMDSMI_MAX_UUID_ELEMENTS);
+            show_scalar("ppod.ppod_size", sub.data.ppod_size, flat.data.ppod_size);
+            show_array("ppod.local_accelerators", sub.data.local_accelerators,
+                       flat.data.local_accelerators, AMDSMI_FABRIC_MAX_LOCAL_GPUS);
+            show_scalar("ppod.local_accelerator_count", sub.data.local_accelerator_count,
+                        flat.data.local_accelerator_count);
+            show_scalar("ppod.bandwidth", sub.data.bandwidth, flat.data.bandwidth);
+            show_scalar("ppod.latency", sub.data.latency, flat.data.latency);
+          }
+        }
+
+        {
+          auto sub = amdsmi_fabric_vpod_config_t{};
+          sub.version = AMDSMI_FABRIC_VPOD_CONFIG_V1;
+          sub.mask =
+              (AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID | AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE |
+               AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS | AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE);
+          auto flat = sub;
+          const auto s_st = dev->query_fabric_vpod_config(sub);
+          const auto f_st = dev->query_fabric_vpod_config_flat(flat);
+          std::cout << "\t\t[vpod] subtree_status=" << s_st << " flat_status=" << f_st << "\n";
+          expect_reader_contract(s_st, sub.mask);
+          expect_reader_contract(f_st, flat.mask);
+          if (((s_st == AMDSMI_STATUS_SUCCESS) || (f_st == AMDSMI_STATUS_SUCCESS))) {
+            show_scalar("vpod.vpod_id", sub.data.vpod_id, flat.data.vpod_id);
+            show_scalar("vpod.vpod_size", sub.data.vpod_size, flat.data.vpod_size);
+            show_array("vpod.vpod_active_accelerators", sub.data.vpod_active_accelerators,
+                       flat.data.vpod_active_accelerators,
+                       AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE);
+            show_scalar("vpod.addr_mode", static_cast<uint64_t>(sub.data.addr_mode),
+                        static_cast<uint64_t>(flat.data.addr_mode));
+          }
+        }
+
+        {
+          auto sub = amdsmi_fabric_station_config_t{};
+          sub.version = AMDSMI_FABRIC_STATION_CONFIG_V1;
+          sub.mask = (AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS | AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP |
+                      AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS);
+          auto flat = sub;
+          const auto s_st = dev->query_fabric_station_config(sub);
+          const auto f_st = dev->query_fabric_station_config_flat(flat);
+          std::cout << "\t\t[station] subtree_status=" << s_st << " flat_status=" << f_st << "\n";
+          expect_reader_contract(s_st, sub.mask);
+          expect_reader_contract(f_st, flat.mask);
+          if (((s_st == AMDSMI_STATUS_SUCCESS) || (f_st == AMDSMI_STATUS_SUCCESS))) {
+            show_scalar("station.station_flags", sub.data.station_flags, flat.data.station_flags);
+            show_scalar("station.num_stations", sub.data.num_stations, flat.data.num_stations);
+            show_array("station.lane_en_bitmap", sub.data.lane_en_bitmap, flat.data.lane_en_bitmap,
+                       AMDSMI_FABRIC_MAX_BITMAP_SIZE);
+          }
+        }
       }
     }
 
@@ -168,7 +358,10 @@ void TestFabricRead::Run(void) {
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_INVAL);
     ASSERT_EQ(err, AMDSMI_STATUS_INVAL);
 
-    // ── amdsmi_alloc_fabric_telemetry / amdsmi_get_fabric_telemetry_data ──
+    /**
+     * Test amdsmi_alloc_fabric_telemetry(), amdsmi_get_fabric_telemetry_data(),
+     * amdsmi_free_fabric_telemetry()
+     */
     IF_VERB(STANDARD) {
       std::cout << "\t** Testing amdsmi_alloc_fabric_telemetry() / "
                    "amdsmi_get_fabric_telemetry_data() / "
@@ -250,9 +443,7 @@ void TestFabricRead::Run(void) {
       }
     }
 
-    // ── amdsmi_free_fabric_telemetry ──────────────────────────────────────
-    DISPLAY_AMDSMI_API("amdsmi_free_fabric_telemetry", "gpu=" + std::to_string(dv_ind),
-                       VERB(STANDARD));
+    // amdsmi_free_fabric_telemetry
     err = amdsmi_free_fabric_telemetry(device, tel);
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_SUCCESS);
     CHK_ERR_ASRT(err)

--- a/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_write.h
+++ b/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_write.h
@@ -1,24 +1,5 @@
-/*
- * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
 
 #ifndef TESTS_AMD_SMI_TEST_FUNCTIONAL_FABRIC_WRITE_H_
 #define TESTS_AMD_SMI_TEST_FUNCTIONAL_FABRIC_WRITE_H_

--- a/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_write.h
+++ b/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_write.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TESTS_AMD_SMI_TEST_FUNCTIONAL_FABRIC_WRITE_H_
+#define TESTS_AMD_SMI_TEST_FUNCTIONAL_FABRIC_WRITE_H_
+
+#include "test_base.h"
+
+class TestFabricWrite : public TestBase {
+ public:
+  TestFabricWrite();
+  virtual ~TestFabricWrite();
+
+  virtual void SetUp();
+  virtual void Run();
+  virtual void Close();
+  virtual void DisplayResults() const;
+  virtual void DisplayTestInfo();
+};
+
+#endif  // TESTS_AMD_SMI_TEST_FUNCTIONAL_FABRIC_WRITE_H_

--- a/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_write_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_write_test.cc
@@ -110,6 +110,7 @@ void TestFabricWrite::Run() {
    */
   {
     auto probe = amdsmi_fabric_info_t{};
+    probe.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
     if (amdsmi_get_gpu_fabric_info(device, &probe) == AMDSMI_STATUS_NOT_SUPPORTED) {
       IF_VERB(STANDARD) {
         std::cout << "\t**Fabric (IFoE) not supported on this system; skipping test" << "\n";
@@ -232,6 +233,8 @@ void TestFabricWrite::Run() {
 
   /**
    *    Hw path: accepts valid requests or reports NOT_SUPPORTED
+   *      - commit=false, so this reaches the support gate without writing sysfs;
+   *        the round-trip block below covers the write path
    */
   for (auto dv_ind = uint32_t(0); dv_ind < num_monitor_devs(); ++dv_ind) {
     auto dev = processor_handles_[dv_ind];
@@ -293,6 +296,7 @@ void TestFabricWrite::Run() {
     PrintDeviceHeader(dev);
 
     auto baseline_info = amdsmi_fabric_info_t{};
+    baseline_info.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
     auto baseline_status = amdsmi_get_gpu_fabric_info(dev, &baseline_info);
     if (baseline_status == AMDSMI_STATUS_NOT_SUPPORTED) {
       IF_VERB(STANDARD) {
@@ -301,16 +305,15 @@ void TestFabricWrite::Run() {
       continue;
     }
     ASSERT_TRUE((baseline_status == AMDSMI_STATUS_SUCCESS) ||
-                (baseline_status == AMDSMI_STATUS_NO_DATA) ||
-                (baseline_status == AMDSMI_STATUS_NOT_INIT));
+                (baseline_status == AMDSMI_STATUS_NO_DATA));
 
-    const auto& baseline_v1 = baseline_info.fabric_info.v1;
+    const auto& baseline_v2 = baseline_info.fabric_info.v2;
 
     /**
      *  Ppod: accelerator_id round-trip
      */
     {
-      const auto baseline_accel_id = baseline_v1.ppod.accelerator_id;
+      const auto baseline_accel_id = baseline_v2.ppod.accelerator_id;
       if (baseline_accel_id == std::numeric_limits<uint32_t>::max()) {
         IF_VERB(STANDARD) {
           std::cout << "\t**Ppod accelerator_id unconfigured; skipping round-trip "
@@ -328,9 +331,10 @@ void TestFabricWrite::Run() {
           ++round_trips_verified;
 
           auto post = amdsmi_fabric_info_t{};
+          post.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
           auto rd = amdsmi_get_gpu_fabric_info(dev, &post);
-          ASSERT_TRUE((rd == AMDSMI_STATUS_SUCCESS) || (rd == AMDSMI_STATUS_NOT_INIT));
-          ASSERT_EQ(post.fabric_info.v1.ppod.accelerator_id, 7u);
+          ASSERT_EQ(rd, AMDSMI_STATUS_SUCCESS);
+          ASSERT_EQ(post.fabric_info.v2.ppod.accelerator_id, 7u);
 
           auto restore = make_minimal_ppod_config();
           restore.mask = AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID;
@@ -345,7 +349,7 @@ void TestFabricWrite::Run() {
      *  Vpod: vpod_id round-trip
      */
     {
-      const auto baseline_vpod_id = baseline_v1.vpod.vpod_id;
+      const auto baseline_vpod_id = baseline_v2.vpod.vpod_id;
       if (baseline_vpod_id == std::numeric_limits<uint32_t>::max()) {
         IF_VERB(STANDARD) {
           std::cout << "\t**Vpod vpod_id unconfigured; skipping round-trip "
@@ -363,9 +367,10 @@ void TestFabricWrite::Run() {
           ++round_trips_verified;
 
           auto post = amdsmi_fabric_info_t{};
+          post.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
           auto rd = amdsmi_get_gpu_fabric_info(dev, &post);
-          ASSERT_TRUE((rd == AMDSMI_STATUS_SUCCESS) || (rd == AMDSMI_STATUS_NOT_INIT));
-          ASSERT_EQ(post.fabric_info.v1.vpod.vpod_id, 3u);
+          ASSERT_EQ(rd, AMDSMI_STATUS_SUCCESS);
+          ASSERT_EQ(post.fabric_info.v2.vpod.vpod_id, 3u);
 
           auto restore = make_minimal_vpod_config();
           restore.mask = AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID;
@@ -383,7 +388,7 @@ void TestFabricWrite::Run() {
      *        serialized as accelerator ID 0)
      */
     {
-      const auto baseline_head = baseline_v1.vpod.vpod_active_accelerators[0];
+      const auto baseline_head = baseline_v2.vpod.vpod_active_accelerators[0];
       if (baseline_head == std::numeric_limits<uint32_t>::max()) {
         IF_VERB(STANDARD) {
           std::cout << "\t**Vpod vpod_active_accelerators unconfigured; skipping round-trip "
@@ -404,9 +409,10 @@ void TestFabricWrite::Run() {
           ++round_trips_verified;
 
           auto post = amdsmi_fabric_info_t{};
+          post.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
           auto rd = amdsmi_get_gpu_fabric_info(dev, &post);
-          ASSERT_TRUE((rd == AMDSMI_STATUS_SUCCESS) || (rd == AMDSMI_STATUS_NOT_INIT));
-          const auto& accels = post.fabric_info.v1.vpod.vpod_active_accelerators;
+          ASSERT_EQ(rd, AMDSMI_STATUS_SUCCESS);
+          const auto& accels = post.fabric_info.v2.vpod.vpod_active_accelerators;
           ASSERT_EQ(accels[0], 2u);
           ASSERT_EQ(accels[1], 5u);
           ASSERT_EQ(accels[2], std::numeric_limits<uint32_t>::max());
@@ -414,8 +420,8 @@ void TestFabricWrite::Run() {
           auto restore = make_minimal_vpod_config();
           restore.mask = AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS;
           restore.commit = true;
-          std::copy(std::begin(baseline_v1.vpod.vpod_active_accelerators),
-                    std::end(baseline_v1.vpod.vpod_active_accelerators),
+          std::copy(std::begin(baseline_v2.vpod.vpod_active_accelerators),
+                    std::end(baseline_v2.vpod.vpod_active_accelerators),
                     std::begin(restore.data.vpod_active_accelerators));
           ASSERT_EQ(amdsmi_set_gpu_fabric_vpod_config(dev, &restore), AMDSMI_STATUS_SUCCESS);
         }
@@ -426,7 +432,7 @@ void TestFabricWrite::Run() {
      *  Station: station_flags round-trip
      */
     {
-      const auto baseline_station_flags = baseline_v1.station.station_flags;
+      const auto baseline_station_flags = baseline_v2.station.station_flags;
       if (baseline_station_flags == std::numeric_limits<uint32_t>::max()) {
         IF_VERB(STANDARD) {
           std::cout << "\t**Station station_flags unconfigured; skipping round-trip "
@@ -444,9 +450,10 @@ void TestFabricWrite::Run() {
           ++round_trips_verified;
 
           auto post = amdsmi_fabric_info_t{};
+          post.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
           auto rd = amdsmi_get_gpu_fabric_info(dev, &post);
-          ASSERT_TRUE((rd == AMDSMI_STATUS_SUCCESS) || (rd == AMDSMI_STATUS_NOT_INIT));
-          ASSERT_EQ(post.fabric_info.v1.station.station_flags, 1u);
+          ASSERT_EQ(rd, AMDSMI_STATUS_SUCCESS);
+          ASSERT_EQ(post.fabric_info.v2.station.station_flags, 1u);
 
           auto restore = make_minimal_station_config();
           restore.mask = AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS;

--- a/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_write_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_write_test.cc
@@ -1,24 +1,5 @@
-/*
- * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
 
 #include "fabric_write.h"
 

--- a/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_write_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/ifoe/fabric/fabric_write_test.cc
@@ -1,0 +1,470 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "fabric_write.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <iostream>
+#include <iterator>
+#include <limits>
+
+#include "amd_smi/amdsmi.h"
+
+TestFabricWrite::TestFabricWrite() : TestBase() {
+  set_title("AMDSMI Fabric Write Test");
+  set_description(
+      "Tests amdsmi_set_gpu_fabric_ppod_config(), amdsmi_set_gpu_fabric_vpod_config(), "
+      "and amdsmi_set_gpu_fabric_station_config() for input validation and hw paths, "
+      "along with read->set+commit->read round-trips with matching getters");
+}
+
+TestFabricWrite::~TestFabricWrite() {}
+
+void TestFabricWrite::SetUp() { TestBase::SetUp(); }
+
+void TestFabricWrite::DisplayTestInfo() { TestBase::DisplayTestInfo(); }
+
+void TestFabricWrite::DisplayResults() const { TestBase::DisplayResults(); }
+
+void TestFabricWrite::Close() { TestBase::Close(); }
+
+/**
+ *  Helpers to make minimal fabric config structs
+ *      - Used to test input validation and hardware paths
+ *      - All fields are set to 0 or false, except for the mask and commit bit
+ *      - The mask is set to the minimal required bits for the test
+ *      - The commit bit is set to false
+ *      - The struct is returned
+ */
+static auto make_minimal_ppod_config() -> amdsmi_fabric_ppod_config_t {
+  amdsmi_fabric_ppod_config_t ppod_config = {};
+  ppod_config.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  ppod_config.mask = AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID;
+  ppod_config.commit = false;
+  ppod_config.data.accelerator_id = 0;
+  return ppod_config;
+}
+
+static auto make_minimal_vpod_config() -> amdsmi_fabric_vpod_config_t {
+  amdsmi_fabric_vpod_config_t vpod_config = {};
+  vpod_config.version = AMDSMI_FABRIC_VPOD_CONFIG_V1;
+  vpod_config.mask = AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID;
+  vpod_config.commit = false;
+  vpod_config.data.vpod_id = 1;  // 0 is rejected as an invalid pod ID before the hw-capability gate
+  return vpod_config;
+}
+
+static auto make_minimal_station_config() -> amdsmi_fabric_station_config_t {
+  amdsmi_fabric_station_config_t station_config = {};
+  station_config.version = AMDSMI_FABRIC_STATION_CONFIG_V1;
+  station_config.mask = AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS;
+  station_config.commit = false;
+  station_config.data.station_flags = 0;
+  return station_config;
+}
+
+/**
+ *  Run the test
+ */
+void TestFabricWrite::Run() {
+  TestBase::Run();
+  if (setup_failed_) {
+    IF_VERB(STANDARD) { std::cout << "** SetUp Failed for this test. Skipping.**" << "\n"; }
+    return;
+  }
+
+  if (num_monitor_devs() == 0) {
+    IF_VERB(STANDARD) { std::cout << "\tNo GPU devices found. Skipping test." << "\n"; }
+    GTEST_SKIP() << "No GPU devices found";
+  }
+  auto device = processor_handles_[0];
+
+  /**
+   *    IFoE capability gate: fabric-less systems report NOT_SUPPORTED from
+   *    amdsmi_get_gpu_fabric_info(); skip the whole test rather than exercise the
+   *    hardware paths below (matches the Fabric Read test)
+   *    Probes device 0 only, assuming a homogeneous fabric config across devices;
+   *    a mixed host (some devices fabric-capable, some not) would skip on device 0.
+   */
+  {
+    auto probe = amdsmi_fabric_info_t{};
+    if (amdsmi_get_gpu_fabric_info(device, &probe) == AMDSMI_STATUS_NOT_SUPPORTED) {
+      IF_VERB(STANDARD) {
+        std::cout << "\t**Fabric (IFoE) not supported on this system; skipping test" << "\n";
+      }
+      GTEST_SKIP() << "Fabric (IFoE) not supported on this system";
+    }
+  }
+
+  /**
+   *    Null handle rejection (no device required)
+   */
+  {
+    auto ppod = make_minimal_ppod_config();
+    ASSERT_EQ(amdsmi_set_gpu_fabric_ppod_config(nullptr, &ppod), AMDSMI_STATUS_INVAL);
+
+    auto vpod = make_minimal_vpod_config();
+    ASSERT_EQ(amdsmi_set_gpu_fabric_vpod_config(nullptr, &vpod), AMDSMI_STATUS_INVAL);
+
+    auto station = make_minimal_station_config();
+    ASSERT_EQ(amdsmi_set_gpu_fabric_station_config(nullptr, &station), AMDSMI_STATUS_INVAL);
+
+    amdsmi_fabric_info_t info_rd = {};
+    ASSERT_EQ(amdsmi_get_gpu_fabric_info(nullptr, &info_rd), AMDSMI_STATUS_INVAL);
+  }
+
+  /**
+   *    Null struct pointer rejection
+   */
+  {
+    ASSERT_EQ(amdsmi_set_gpu_fabric_ppod_config(device, nullptr), AMDSMI_STATUS_INVAL);
+    ASSERT_EQ(amdsmi_set_gpu_fabric_vpod_config(device, nullptr), AMDSMI_STATUS_INVAL);
+    ASSERT_EQ(amdsmi_set_gpu_fabric_station_config(device, nullptr), AMDSMI_STATUS_INVAL);
+
+    ASSERT_EQ(amdsmi_get_gpu_fabric_info(device, nullptr), AMDSMI_STATUS_INVAL);
+  }
+
+  /**
+   *    Version mismatch rejection
+   */
+  {
+    auto ppod = make_minimal_ppod_config();
+    ppod.version = 0;
+    ASSERT_EQ(amdsmi_set_gpu_fabric_ppod_config(device, &ppod), AMDSMI_STATUS_INVAL);
+
+    auto vpod = make_minimal_vpod_config();
+    vpod.version = 0;
+    ASSERT_EQ(amdsmi_set_gpu_fabric_vpod_config(device, &vpod), AMDSMI_STATUS_INVAL);
+
+    auto station = make_minimal_station_config();
+    station.version = 0;
+    ASSERT_EQ(amdsmi_set_gpu_fabric_station_config(device, &station), AMDSMI_STATUS_INVAL);
+  }
+
+  /**
+   *    No-op request rejection
+   */
+  {
+    auto ppod = make_minimal_ppod_config();
+    ppod.mask = 0;
+    ppod.commit = false;
+    ASSERT_EQ(amdsmi_set_gpu_fabric_ppod_config(device, &ppod), AMDSMI_STATUS_INVAL);
+
+    auto vpod = make_minimal_vpod_config();
+    vpod.mask = 0;
+    vpod.commit = false;
+    ASSERT_EQ(amdsmi_set_gpu_fabric_vpod_config(device, &vpod), AMDSMI_STATUS_INVAL);
+
+    auto station = make_minimal_station_config();
+    station.mask = 0;
+    station.commit = false;
+    ASSERT_EQ(amdsmi_set_gpu_fabric_station_config(device, &station), AMDSMI_STATUS_INVAL);
+  }
+
+  /**
+   *    Invalid mask bits rejection
+   */
+  {
+    auto ppod = make_minimal_ppod_config();
+    ppod.mask = 0xFFFFFFFF;
+    ASSERT_EQ(amdsmi_set_gpu_fabric_ppod_config(device, &ppod), AMDSMI_STATUS_INVAL);
+
+    auto vpod = make_minimal_vpod_config();
+    vpod.mask = 0xFFFFFFFF;
+    ASSERT_EQ(amdsmi_set_gpu_fabric_vpod_config(device, &vpod), AMDSMI_STATUS_INVAL);
+
+    auto station = make_minimal_station_config();
+    station.mask = 0xFFFFFFFF;
+    ASSERT_EQ(amdsmi_set_gpu_fabric_station_config(device, &station), AMDSMI_STATUS_INVAL);
+  }
+
+  /**
+   *    Ppod: LOCAL_ACCELS with count=0 rejected
+   */
+  {
+    auto ppod = make_minimal_ppod_config();
+    ppod.mask = AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS;
+    ppod.data.local_accelerator_count = 0;
+    ASSERT_EQ(amdsmi_set_gpu_fabric_ppod_config(device, &ppod), AMDSMI_STATUS_INVAL);
+  }
+
+  /**
+   *    Ppod: LOCAL_ACCELS with count > max rejected
+   */
+  {
+    auto ppod = make_minimal_ppod_config();
+    ppod.mask = AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS;
+    ppod.data.local_accelerator_count = (AMDSMI_FABRIC_MAX_LOCAL_GPUS + 1);
+    ASSERT_EQ(amdsmi_set_gpu_fabric_ppod_config(device, &ppod), AMDSMI_STATUS_INVAL);
+  }
+
+  /**
+   *    Vpod: invalid addr_mode rejected before any sysfs write
+   */
+  {
+    auto vpod = make_minimal_vpod_config();
+    vpod.mask = (AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID | AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE);
+    vpod.data.addr_mode = AMDSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN;
+    ASSERT_EQ(amdsmi_set_gpu_fabric_vpod_config(device, &vpod), AMDSMI_STATUS_INVAL);
+  }
+
+  /**
+   *    Hw path: accepts valid requests or reports NOT_SUPPORTED
+   */
+  for (auto dv_ind = uint32_t(0); dv_ind < num_monitor_devs(); ++dv_ind) {
+    auto dev = processor_handles_[dv_ind];
+    PrintDeviceHeader(dev);
+
+    {
+      auto ppod = make_minimal_ppod_config();
+      auto status_code = amdsmi_set_gpu_fabric_ppod_config(dev, &ppod);
+      if (status_code == AMDSMI_STATUS_NOT_SUPPORTED) {
+        IF_VERB(STANDARD) {
+          std::cout << "\t**amdsmi_set_gpu_fabric_ppod_config() not supported on this system"
+                    << "\n";
+        }
+      } else {
+        ASSERT_EQ(status_code, AMDSMI_STATUS_SUCCESS);
+      }
+    }
+
+    {
+      auto vpod = make_minimal_vpod_config();
+      auto status_code = amdsmi_set_gpu_fabric_vpod_config(dev, &vpod);
+      if (status_code == AMDSMI_STATUS_NOT_SUPPORTED) {
+        IF_VERB(STANDARD) {
+          std::cout << "\t**amdsmi_set_gpu_fabric_vpod_config() not supported on this system"
+                    << "\n";
+        }
+      } else {
+        ASSERT_EQ(status_code, AMDSMI_STATUS_SUCCESS);
+      }
+    }
+
+    {
+      auto station = make_minimal_station_config();
+      auto status_code = amdsmi_set_gpu_fabric_station_config(dev, &station);
+      if (status_code == AMDSMI_STATUS_NOT_SUPPORTED) {
+        IF_VERB(STANDARD) {
+          std::cout << "\t**amdsmi_set_gpu_fabric_station_config() not supported on this system"
+                    << "\n";
+        }
+      } else {
+        ASSERT_EQ(status_code, AMDSMI_STATUS_SUCCESS);
+      }
+    }
+  }
+
+  /**
+   *    Round-trip: (set+commit) -> read back via amdsmi_get_gpu_fabric_info()
+   *      - The per-plane getters were removed; amdsmi_get_gpu_fabric_info() is the sole reader
+   *      - A baseline read establishes whether fabric is present (NOT_SUPPORTED skips the plane)
+   *      - Only fields with a non-sentinel baseline are exercised: those can be restored exactly,
+   *        so the device is left as found. Unconfigured fields (baseline == UINT*_MAX) are skipped
+   *        rather than written, since a sentinel cannot be restored and committing would leave the
+   *        device permanently mutated
+   *      - round_trips_verified guards a silent pass when no field could be exercised
+   */
+  auto round_trips_verified = 0;
+  for (auto dv_ind = uint32_t(0); dv_ind < num_monitor_devs(); ++dv_ind) {
+    auto dev = processor_handles_[dv_ind];
+    PrintDeviceHeader(dev);
+
+    auto baseline_info = amdsmi_fabric_info_t{};
+    auto baseline_status = amdsmi_get_gpu_fabric_info(dev, &baseline_info);
+    if (baseline_status == AMDSMI_STATUS_NOT_SUPPORTED) {
+      IF_VERB(STANDARD) {
+        std::cout << "\t**Fabric round-trip not supported on this system" << "\n";
+      }
+      continue;
+    }
+    ASSERT_TRUE((baseline_status == AMDSMI_STATUS_SUCCESS) ||
+                (baseline_status == AMDSMI_STATUS_NO_DATA) ||
+                (baseline_status == AMDSMI_STATUS_NOT_INIT));
+
+    const auto& baseline_v1 = baseline_info.fabric_info.v1;
+
+    /**
+     *  Ppod: accelerator_id round-trip
+     */
+    {
+      const auto baseline_accel_id = baseline_v1.ppod.accelerator_id;
+      if (baseline_accel_id == std::numeric_limits<uint32_t>::max()) {
+        IF_VERB(STANDARD) {
+          std::cout << "\t**Ppod accelerator_id unconfigured; skipping round-trip "
+                       "to avoid mutating hardware"
+                    << "\n";
+        }
+      } else {
+        auto wr = make_minimal_ppod_config();
+        wr.mask = AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID;
+        wr.commit = true;
+        wr.data.accelerator_id = 7;
+        auto set_status = amdsmi_set_gpu_fabric_ppod_config(dev, &wr);
+        if (set_status != AMDSMI_STATUS_NOT_SUPPORTED) {
+          ASSERT_EQ(set_status, AMDSMI_STATUS_SUCCESS);
+          ++round_trips_verified;
+
+          auto post = amdsmi_fabric_info_t{};
+          auto rd = amdsmi_get_gpu_fabric_info(dev, &post);
+          ASSERT_TRUE((rd == AMDSMI_STATUS_SUCCESS) || (rd == AMDSMI_STATUS_NOT_INIT));
+          ASSERT_EQ(post.fabric_info.v1.ppod.accelerator_id, 7u);
+
+          auto restore = make_minimal_ppod_config();
+          restore.mask = AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID;
+          restore.commit = true;
+          restore.data.accelerator_id = baseline_accel_id;
+          ASSERT_EQ(amdsmi_set_gpu_fabric_ppod_config(dev, &restore), AMDSMI_STATUS_SUCCESS);
+        }
+      }
+    }
+
+    /**
+     *  Vpod: vpod_id round-trip
+     */
+    {
+      const auto baseline_vpod_id = baseline_v1.vpod.vpod_id;
+      if (baseline_vpod_id == std::numeric_limits<uint32_t>::max()) {
+        IF_VERB(STANDARD) {
+          std::cout << "\t**Vpod vpod_id unconfigured; skipping round-trip "
+                       "to avoid mutating hardware"
+                    << "\n";
+        }
+      } else {
+        auto wr = make_minimal_vpod_config();
+        wr.mask = AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID;
+        wr.commit = true;
+        wr.data.vpod_id = 3;
+        auto set_status = amdsmi_set_gpu_fabric_vpod_config(dev, &wr);
+        if (set_status != AMDSMI_STATUS_NOT_SUPPORTED) {
+          ASSERT_EQ(set_status, AMDSMI_STATUS_SUCCESS);
+          ++round_trips_verified;
+
+          auto post = amdsmi_fabric_info_t{};
+          auto rd = amdsmi_get_gpu_fabric_info(dev, &post);
+          ASSERT_TRUE((rd == AMDSMI_STATUS_SUCCESS) || (rd == AMDSMI_STATUS_NOT_INIT));
+          ASSERT_EQ(post.fabric_info.v1.vpod.vpod_id, 3u);
+
+          auto restore = make_minimal_vpod_config();
+          restore.mask = AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID;
+          restore.commit = true;
+          restore.data.vpod_id = baseline_vpod_id;
+          ASSERT_EQ(amdsmi_set_gpu_fabric_vpod_config(dev, &restore), AMDSMI_STATUS_SUCCESS);
+        }
+      }
+    }
+
+    /**
+     *  Vpod: vpod_active_accelerators list round-trip
+     *      - Unused slots must hold UINT32_MAX; writing two IDs must read back exactly
+     *        two, with the next slot still at the sentinel (guards trailing slots being
+     *        serialized as accelerator ID 0)
+     */
+    {
+      const auto baseline_head = baseline_v1.vpod.vpod_active_accelerators[0];
+      if (baseline_head == std::numeric_limits<uint32_t>::max()) {
+        IF_VERB(STANDARD) {
+          std::cout << "\t**Vpod vpod_active_accelerators unconfigured; skipping round-trip "
+                       "to avoid mutating hardware"
+                    << "\n";
+        }
+      } else {
+        auto wr = make_minimal_vpod_config();
+        wr.mask = AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS;
+        wr.commit = true;
+        std::fill(std::begin(wr.data.vpod_active_accelerators),
+                  std::end(wr.data.vpod_active_accelerators), std::numeric_limits<uint32_t>::max());
+        wr.data.vpod_active_accelerators[0] = 2;
+        wr.data.vpod_active_accelerators[1] = 5;
+        auto set_status = amdsmi_set_gpu_fabric_vpod_config(dev, &wr);
+        if (set_status != AMDSMI_STATUS_NOT_SUPPORTED) {
+          ASSERT_EQ(set_status, AMDSMI_STATUS_SUCCESS);
+          ++round_trips_verified;
+
+          auto post = amdsmi_fabric_info_t{};
+          auto rd = amdsmi_get_gpu_fabric_info(dev, &post);
+          ASSERT_TRUE((rd == AMDSMI_STATUS_SUCCESS) || (rd == AMDSMI_STATUS_NOT_INIT));
+          const auto& accels = post.fabric_info.v1.vpod.vpod_active_accelerators;
+          ASSERT_EQ(accels[0], 2u);
+          ASSERT_EQ(accels[1], 5u);
+          ASSERT_EQ(accels[2], std::numeric_limits<uint32_t>::max());
+
+          auto restore = make_minimal_vpod_config();
+          restore.mask = AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS;
+          restore.commit = true;
+          std::copy(std::begin(baseline_v1.vpod.vpod_active_accelerators),
+                    std::end(baseline_v1.vpod.vpod_active_accelerators),
+                    std::begin(restore.data.vpod_active_accelerators));
+          ASSERT_EQ(amdsmi_set_gpu_fabric_vpod_config(dev, &restore), AMDSMI_STATUS_SUCCESS);
+        }
+      }
+    }
+
+    /**
+     *  Station: station_flags round-trip
+     */
+    {
+      const auto baseline_station_flags = baseline_v1.station.station_flags;
+      if (baseline_station_flags == std::numeric_limits<uint32_t>::max()) {
+        IF_VERB(STANDARD) {
+          std::cout << "\t**Station station_flags unconfigured; skipping round-trip "
+                       "to avoid mutating hardware"
+                    << "\n";
+        }
+      } else {
+        auto wr = make_minimal_station_config();
+        wr.mask = AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS;
+        wr.commit = true;
+        wr.data.station_flags = 1;
+        auto set_status = amdsmi_set_gpu_fabric_station_config(dev, &wr);
+        if (set_status != AMDSMI_STATUS_NOT_SUPPORTED) {
+          ASSERT_EQ(set_status, AMDSMI_STATUS_SUCCESS);
+          ++round_trips_verified;
+
+          auto post = amdsmi_fabric_info_t{};
+          auto rd = amdsmi_get_gpu_fabric_info(dev, &post);
+          ASSERT_TRUE((rd == AMDSMI_STATUS_SUCCESS) || (rd == AMDSMI_STATUS_NOT_INIT));
+          ASSERT_EQ(post.fabric_info.v1.station.station_flags, 1u);
+
+          auto restore = make_minimal_station_config();
+          restore.mask = AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS;
+          restore.commit = true;
+          restore.data.station_flags = baseline_station_flags;
+          ASSERT_EQ(amdsmi_set_gpu_fabric_station_config(dev, &restore), AMDSMI_STATUS_SUCCESS);
+        }
+      }
+    }
+  }
+
+  if (round_trips_verified == 0) {
+    IF_VERB(STANDARD) {
+      std::cout << "\t**No fabric field had a restorable baseline with a supported setter; "
+                   "round-trip verified nothing"
+                << "\n";
+    }
+    GTEST_SKIP() << "Fabric round-trip exercised no field (setters unsupported or all "
+                    "fields unconfigured)";
+  }
+}

--- a/projects/amdsmi/tests/amd_smi_test/main.cc
+++ b/projects/amdsmi/tests/amd_smi_test/main.cc
@@ -45,6 +45,7 @@
 #include "functional/gpu/thermal/temp_read.h"
 #include "functional/gpu/xgmi/xgmi_read_write.h"
 #include "functional/ifoe/fabric/fabric_read.h"
+#include "functional/ifoe/fabric/fabric_write.h"
 #include "functional/ifoe/identity/ifoe_info_read.h"
 #include "functional/ifoe/tray/tray_info_read.h"
 #include "functional/system/cross_process_serialization.h"
@@ -331,6 +332,13 @@ TEST(IfoeFunctionalReadOnly, TestFabricRead) {
   if (access("/dev/dxg", F_OK) == 0)
     GTEST_SKIP() << "Skipped on WSL: UALoE/fabric sysfs not available on DXG backend";
   TestFabricRead tst;
+  RunGenericTest(&tst);
+}
+
+TEST(IfoeFunctionalReadWrite, TestFabricWrite) {
+  if (std::getenv("AMDSMI_NON_PRIVILEGED")) GTEST_SKIP_("Skipped in non-privileged mode");
+  if (!amd::smi::is_sudo_user()) GTEST_SKIP_("Invalid permission - Must run as super user");
+  TestFabricWrite tst;
   RunGenericTest(&tst);
 }
 

--- a/projects/amdsmi/tests/amd_smi_test/main.cc
+++ b/projects/amdsmi/tests/amd_smi_test/main.cc
@@ -63,6 +63,7 @@
 #include "functional/gpu/thermal/temp_read.h"
 #include "functional/gpu/xgmi/xgmi_read_write.h"
 #include "functional/ifoe/fabric/fabric_read.h"
+#include "functional/ifoe/fabric/fabric_write.h"
 #include "functional/ifoe/identity/ifoe_info_read.h"
 #include "functional/system/cross_process_serialization.h"
 #include "functional/system/hw_topology_read.h"
@@ -348,6 +349,13 @@ TEST(IfoeFunctionalReadOnly, TestFabricRead) {
   if (access("/dev/dxg", F_OK) == 0)
     GTEST_SKIP() << "Skipped on WSL: UALoE/fabric sysfs not available on DXG backend";
   TestFabricRead tst;
+  RunGenericTest(&tst);
+}
+
+TEST(IfoeFunctionalReadWrite, TestFabricWrite) {
+  if (std::getenv("AMDSMI_NON_PRIVILEGED")) GTEST_SKIP_("Skipped in non-privileged mode");
+  if (!amd::smi::is_sudo_user()) GTEST_SKIP_("Invalid permission - Must run as super user");
+  TestFabricWrite tst;
   RunGenericTest(&tst);
 }
 

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/fabric_config_roundtrip_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/fabric_config_roundtrip_test.cc
@@ -23,7 +23,9 @@
 // Hardware-free round-trip of the fabric config serialize/parse paths. The
 // apply_*_at / query_*_at cores take a resolved sysfs root + support flag instead
 // of a live device, so the real WriteRequestBuilder/FieldReader logic is exercised
-// against a temp directory with commit=false: no hardware, no irreversible commit.
+// against a temp directory: no hardware, and the commit file lands in that temp
+// directory rather than on a driver. Round-trip cases set commit=true because a
+// non-committing request writes nothing.
 
 #include <gtest/gtest.h>
 
@@ -92,6 +94,7 @@ TEST(GpuUnit, FabricConfigPpodAllFieldsRoundTrip) {
   auto in = amdsmi_fabric_ppod_config_t{};
   in.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
   in.mask = kPpodAllFields;
+  in.commit = true;
   in.data.accelerator_id = 42;
   for (auto idx = 0; idx < AMDSMI_MAX_UUID_ELEMENTS; ++idx) {
     in.data.ppod_id[idx] = static_cast<uint8_t>(0x10 + idx);
@@ -134,6 +137,7 @@ TEST(GpuUnit, FabricConfigPpodLocalAccelsStopAtCount) {
   auto in = amdsmi_fabric_ppod_config_t{};
   in.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
   in.mask = AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS;
+  in.commit = true;
   for (auto idx = 0; idx < AMDSMI_FABRIC_MAX_LOCAL_GPUS; ++idx) {
     in.data.local_accelerators[idx] = static_cast<uint32_t>(200 + idx);
   }
@@ -162,6 +166,7 @@ TEST(GpuUnit, FabricConfigPpodPartialWriteLeavesUnwrittenAtSentinel) {
   auto in = amdsmi_fabric_ppod_config_t{};
   in.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
   in.mask = AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID;
+  in.commit = true;
   in.data.accelerator_id = 77;
   ASSERT_EQ(fabric_ualink::apply_ppod_config_at(root.path, true, in), AMDSMI_STATUS_SUCCESS);
 
@@ -186,6 +191,7 @@ TEST(GpuUnit, FabricConfigVpodRoundTripAccelIdZeroPreserved) {
   auto in = amdsmi_fabric_vpod_config_t{};
   in.version = AMDSMI_FABRIC_VPOD_CONFIG_V1;
   in.mask = kVpodAllFields;
+  in.commit = true;
   in.data.vpod_id = 7;
   in.data.vpod_size = 4;
   // Contract: unused slots hold the UNSET sentinel; the run ends at the first one.
@@ -221,6 +227,7 @@ TEST(GpuUnit, FabricConfigStationRoundTripFullBitmap) {
   auto in = amdsmi_fabric_station_config_t{};
   in.version = AMDSMI_FABRIC_STATION_CONFIG_V1;
   in.mask = kStationAllFields;
+  in.commit = true;
   in.data.station_flags = 0xABCD;
   in.data.num_stations = 12;
   for (auto idx = 0; idx < AMDSMI_FABRIC_MAX_BITMAP_SIZE; ++idx) {
@@ -262,6 +269,24 @@ TEST(GpuUnit, FabricConfigPpodCommitWritesCommitFile) {
   auto contents = std::string();
   std::getline(stream, contents);
   EXPECT_EQ(contents, "1");
+}
+
+// commit=false validates and writes nothing: the driver ignores the staging files
+// unless a commit follows, so leaving values there would only feed the next commit.
+TEST(GpuUnit, FabricConfigNoCommitWritesNothing) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_ppod_config_t{};
+  in.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  in.mask = AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID;
+  in.commit = false;
+  in.data.accelerator_id = 3;
+  ASSERT_EQ(fabric_ualink::apply_ppod_config_at(root.path, true, in), AMDSMI_STATUS_SUCCESS);
+
+  const auto setup_dir = fs::path(root.path) / std::string(kUALOE_UALINK_SETUP_SUBDIR);
+  EXPECT_FALSE(fs::exists(setup_dir / std::string(kUALOE_ACCEL_ID)));
+  EXPECT_FALSE(fs::exists(setup_dir / std::string(kUALOE_UALINK_COMMIT_FILE)));
 }
 
 // device_supports_ualink=false is rejected even when the sysfs tree exists.
@@ -397,6 +422,48 @@ TEST(GpuUnit, FabricConfigQueryMissingSubdirNotSupported) {
 
   auto ec = std::error_code{};
   fs::remove_all(empty_root, ec);
+}
+
+// A commit with nothing freshly staged would flush a prior partial write's residue.
+TEST(GpuUnit, FabricConfigBareCommitIsRejected) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_ppod_config_t{};
+  in.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  in.mask = 0;
+  in.commit = true;
+  EXPECT_EQ(fabric_ualink::apply_ppod_config_at(root.path, true, in), AMDSMI_STATUS_INVAL);
+}
+
+// The unified getter reads the flat surface, which the driver syncs on commit. Fields must
+// come back even when the setup/config/stations write subtrees are absent.
+TEST(GpuUnit, FabricConfigQueryFlatSurfaceWithoutWriteSubtrees) {
+  auto tmpl = std::string("/tmp/amdsmi_fabric_flat_XXXXXX");
+  ASSERT_NE(::mkdtemp(tmpl.data()), nullptr) << "mkdtemp failed";
+  const auto flat_root = std::string(tmpl);
+
+  {
+    auto accel_id_file = std::ofstream(fs::path(flat_root) / std::string(kUALOE_ACCEL_ID));
+    accel_id_file << "42\n";
+    auto ppod_size_file = std::ofstream(fs::path(flat_root) / std::string(kUALOE_PPOD_SIZE));
+    ppod_size_file << "8\n";
+  }
+
+  auto cfg = amdsmi_fabric_ppod_config_t{};
+  cfg.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  cfg.mask = (AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID | AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE |
+              AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH);
+  EXPECT_EQ(fabric_ualink::query_ppod_config_at(flat_root, true, cfg, kUALOE_UALINK_FLAT_SUBDIR),
+            AMDSMI_STATUS_SUCCESS);
+  EXPECT_EQ(cfg.mask, static_cast<uint32_t>(AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID |
+                                            AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE));
+  EXPECT_EQ(cfg.data.accelerator_id, 42u);
+  EXPECT_EQ(cfg.data.ppod_size, 8u);
+  EXPECT_EQ(cfg.data.bandwidth, kU32Sentinel);
+
+  auto ec = std::error_code{};
+  fs::remove_all(flat_root, ec);
 }
 
 }  // namespace

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/fabric_config_roundtrip_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/fabric_config_roundtrip_test.cc
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Hardware-free round-trip of the fabric config serialize/parse paths. The
+// apply_*_at / query_*_at cores take a resolved sysfs root + support flag instead
+// of a live device, so the real WriteRequestBuilder/FieldReader logic is exercised
+// against a temp directory with commit=false: no hardware, no irreversible commit.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <string>
+
+#include "amd_smi/impl/amd_smi_fabric_ualink.h"
+
+namespace amd::smi {
+
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr auto kPpodAllFields = static_cast<uint32_t>(
+    AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID | AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID |
+    AMDSMI_FABRIC_PPOD_FIELD_PPOD_SIZE | AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS |
+    AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH | AMDSMI_FABRIC_PPOD_FIELD_LATENCY);
+
+constexpr auto kVpodAllFields = static_cast<uint32_t>(
+    AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID | AMDSMI_FABRIC_VPOD_FIELD_VPOD_SIZE |
+    AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS | AMDSMI_FABRIC_VPOD_FIELD_ADDR_MODE);
+
+constexpr auto kStationAllFields = static_cast<uint32_t>(AMDSMI_FABRIC_DF_FIELD_STATION_FLAGS |
+                                                         AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS |
+                                                         AMDSMI_FABRIC_DF_FIELD_LANE_EN_BITMAP);
+
+constexpr auto kU32Sentinel = std::numeric_limits<uint32_t>::max();
+
+// RAII sysfs root: creates the setup/config/stations subtree in a fresh temp dir
+// and removes it on destruction. A plain helper (not a GTest fixture) so these
+// tests can register under the shared GpuUnit suite required by test-design.md.
+struct TempRoot {
+  std::string path;
+
+  TempRoot() {
+    auto tmpl = std::string("/tmp/amdsmi_fabric_rt_XXXXXX");
+    if (::mkdtemp(tmpl.data()) == nullptr) {
+      return;
+    }
+    path = tmpl;
+    for (const auto subdir :
+         {kUALOE_UALINK_SETUP_SUBDIR, kUALOE_UALINK_CONFIG_SUBDIR, kUALOE_UALINK_STATIONS_SUBDIR}) {
+      auto ec = std::error_code{};
+      fs::create_directories(fs::path(path) / std::string(subdir), ec);
+    }
+  }
+
+  ~TempRoot() {
+    if (path.empty()) {
+      return;
+    }
+    auto ec = std::error_code{};
+    fs::remove_all(path, ec);
+  }
+};
+
+TEST(GpuUnit, FabricConfigPpodAllFieldsRoundTrip) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_ppod_config_t{};
+  in.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  in.mask = kPpodAllFields;
+  in.data.accelerator_id = 42;
+  for (auto idx = 0; idx < AMDSMI_MAX_UUID_ELEMENTS; ++idx) {
+    in.data.ppod_id[idx] = static_cast<uint8_t>(0x10 + idx);
+  }
+  in.data.ppod_size = 8;
+  in.data.local_accelerators[0] = 100;
+  in.data.local_accelerators[1] = 101;
+  in.data.local_accelerators[2] = 102;
+  in.data.local_accelerator_count = 3;
+  in.data.bandwidth = 1234;
+  in.data.latency = 56;
+
+  ASSERT_EQ(fabric_ualink::apply_ppod_config_at(root.path, true, in), AMDSMI_STATUS_SUCCESS);
+
+  auto out = amdsmi_fabric_ppod_config_t{};
+  out.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  out.mask = kPpodAllFields;
+  ASSERT_EQ(fabric_ualink::query_ppod_config_at(root.path, true, out), AMDSMI_STATUS_SUCCESS);
+
+  EXPECT_EQ(out.mask, kPpodAllFields);
+  EXPECT_EQ(out.data.accelerator_id, 42u);
+  for (auto idx = 0; idx < AMDSMI_MAX_UUID_ELEMENTS; ++idx) {
+    EXPECT_EQ(out.data.ppod_id[idx], static_cast<uint8_t>(0x10 + idx)) << "ppod_id[" << idx << "]";
+  }
+  EXPECT_EQ(out.data.ppod_size, 8u);
+  EXPECT_EQ(out.data.local_accelerator_count, 3u);
+  EXPECT_EQ(out.data.local_accelerators[0], 100u);
+  EXPECT_EQ(out.data.local_accelerators[1], 101u);
+  EXPECT_EQ(out.data.local_accelerators[2], 102u);
+  EXPECT_EQ(out.data.bandwidth, 1234u);
+  EXPECT_EQ(out.data.latency, 56u);
+}
+
+// local_accelerator_count < list length: the serializer must stop at the count and
+// the reader must not resurrect a phantom tail from the write-side array.
+TEST(GpuUnit, FabricConfigPpodLocalAccelsStopAtCount) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_ppod_config_t{};
+  in.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  in.mask = AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS;
+  for (auto idx = 0; idx < AMDSMI_FABRIC_MAX_LOCAL_GPUS; ++idx) {
+    in.data.local_accelerators[idx] = static_cast<uint32_t>(200 + idx);
+  }
+  in.data.local_accelerator_count = 3;  // only 200, 201, 202 are valid
+
+  ASSERT_EQ(fabric_ualink::apply_ppod_config_at(root.path, true, in), AMDSMI_STATUS_SUCCESS);
+
+  auto out = amdsmi_fabric_ppod_config_t{};
+  out.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  out.mask = AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS;
+  ASSERT_EQ(fabric_ualink::query_ppod_config_at(root.path, true, out), AMDSMI_STATUS_SUCCESS);
+
+  EXPECT_EQ(out.data.local_accelerator_count, 3u);
+  EXPECT_EQ(out.data.local_accelerators[0], 200u);
+  EXPECT_EQ(out.data.local_accelerators[1], 201u);
+  EXPECT_EQ(out.data.local_accelerators[2], 202u);
+  EXPECT_EQ(out.data.local_accelerators[3], kU32Sentinel);
+}
+
+// A field left out of the write mask must read back at its guard sentinel, and the
+// read mask must report only the field that was actually persisted.
+TEST(GpuUnit, FabricConfigPpodPartialWriteLeavesUnwrittenAtSentinel) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_ppod_config_t{};
+  in.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  in.mask = AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID;
+  in.data.accelerator_id = 77;
+  ASSERT_EQ(fabric_ualink::apply_ppod_config_at(root.path, true, in), AMDSMI_STATUS_SUCCESS);
+
+  auto out = amdsmi_fabric_ppod_config_t{};
+  out.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  out.mask = kPpodAllFields;
+  ASSERT_EQ(fabric_ualink::query_ppod_config_at(root.path, true, out), AMDSMI_STATUS_SUCCESS);
+
+  EXPECT_EQ(out.mask, static_cast<uint32_t>(AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID));
+  EXPECT_EQ(out.data.accelerator_id, 77u);
+  EXPECT_EQ(out.data.ppod_size, kU32Sentinel);
+  EXPECT_EQ(out.data.bandwidth, kU32Sentinel);
+  EXPECT_EQ(out.data.latency, kU32Sentinel);
+}
+
+// A 0 in the active-accelerator list is not a real ID and must terminate the
+// serialized run; slots past it stay at the read sentinel.
+TEST(GpuUnit, FabricConfigVpodRoundTripAccelIdZeroPreserved) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_vpod_config_t{};
+  in.version = AMDSMI_FABRIC_VPOD_CONFIG_V1;
+  in.mask = kVpodAllFields;
+  in.data.vpod_id = 7;
+  in.data.vpod_size = 4;
+  // Contract: unused slots hold the UNSET sentinel; the run ends at the first one.
+  for (auto& id : in.data.vpod_active_accelerators) {
+    id = kU32Sentinel;
+  }
+  in.data.vpod_active_accelerators[0] = 3;
+  in.data.vpod_active_accelerators[1] = 0;  // 0 is a valid accelerator ID, not a terminator
+  in.data.vpod_active_accelerators[2] = 5;
+  in.data.addr_mode = AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING;
+
+  ASSERT_EQ(fabric_ualink::apply_vpod_config_at(root.path, true, in), AMDSMI_STATUS_SUCCESS);
+
+  auto out = amdsmi_fabric_vpod_config_t{};
+  out.version = AMDSMI_FABRIC_VPOD_CONFIG_V1;
+  out.mask = kVpodAllFields;
+  ASSERT_EQ(fabric_ualink::query_vpod_config_at(root.path, true, out), AMDSMI_STATUS_SUCCESS);
+
+  EXPECT_EQ(out.mask, kVpodAllFields);
+  EXPECT_EQ(out.data.vpod_id, 7u);
+  EXPECT_EQ(out.data.vpod_size, 4u);
+  EXPECT_EQ(out.data.vpod_active_accelerators[0], 3u);
+  EXPECT_EQ(out.data.vpod_active_accelerators[1], 0u);
+  EXPECT_EQ(out.data.vpod_active_accelerators[2], 5u);
+  EXPECT_EQ(out.data.vpod_active_accelerators[3], kU32Sentinel);
+  EXPECT_EQ(out.data.addr_mode, AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING);
+}
+
+TEST(GpuUnit, FabricConfigStationRoundTripFullBitmap) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_station_config_t{};
+  in.version = AMDSMI_FABRIC_STATION_CONFIG_V1;
+  in.mask = kStationAllFields;
+  in.data.station_flags = 0xABCD;
+  in.data.num_stations = 12;
+  for (auto idx = 0; idx < AMDSMI_FABRIC_MAX_BITMAP_SIZE; ++idx) {
+    in.data.lane_en_bitmap[idx] = static_cast<uint8_t>((idx * 7) & 0xFF);
+  }
+
+  ASSERT_EQ(fabric_ualink::apply_station_config_at(root.path, true, in), AMDSMI_STATUS_SUCCESS);
+
+  auto out = amdsmi_fabric_station_config_t{};
+  out.version = AMDSMI_FABRIC_STATION_CONFIG_V1;
+  out.mask = kStationAllFields;
+  ASSERT_EQ(fabric_ualink::query_station_config_at(root.path, true, out), AMDSMI_STATUS_SUCCESS);
+
+  EXPECT_EQ(out.mask, kStationAllFields);
+  EXPECT_EQ(out.data.station_flags, 0xABCDu);
+  EXPECT_EQ(out.data.num_stations, static_cast<uint8_t>(12));
+  for (auto idx = 0; idx < AMDSMI_FABRIC_MAX_BITMAP_SIZE; ++idx) {
+    EXPECT_EQ(out.data.lane_en_bitmap[idx], static_cast<uint8_t>((idx * 7) & 0xFF))
+        << "lane_en_bitmap[" << idx << "]";
+  }
+}
+
+// commit=true writes the subtree commit file after the masked fields.
+TEST(GpuUnit, FabricConfigPpodCommitWritesCommitFile) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_ppod_config_t{};
+  in.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  in.mask = AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID;
+  in.commit = true;
+  in.data.accelerator_id = 3;
+  ASSERT_EQ(fabric_ualink::apply_ppod_config_at(root.path, true, in), AMDSMI_STATUS_SUCCESS);
+
+  const auto commit_path = fs::path(root.path) / std::string(kUALOE_UALINK_SETUP_SUBDIR) /
+                           std::string(kUALOE_UALINK_COMMIT_FILE);
+  ASSERT_TRUE(fs::exists(commit_path));
+  auto stream = std::ifstream(commit_path);
+  auto contents = std::string();
+  std::getline(stream, contents);
+  EXPECT_EQ(contents, "1");
+}
+
+// device_supports_ualink=false is rejected even when the sysfs tree exists.
+TEST(GpuUnit, FabricConfigApplyUnsupportedDeviceNotSupported) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_ppod_config_t{};
+  in.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  in.mask = AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID;
+  in.data.accelerator_id = 1;
+  EXPECT_EQ(fabric_ualink::apply_ppod_config_at(root.path, false, in), AMDSMI_STATUS_NOT_SUPPORTED);
+}
+
+// Input validation precedes the support gate: a bad version is INVAL regardless of
+// device support, preserving the validation-before-hardware-gate contract.
+TEST(GpuUnit, FabricConfigApplyValidationRunsBeforeSupportGate) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_ppod_config_t{};
+  in.version = 0xBADBADu;  // wrong version
+  in.mask = AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID;
+  EXPECT_EQ(fabric_ualink::apply_ppod_config_at(root.path, false, in), AMDSMI_STATUS_INVAL);
+}
+
+TEST(GpuUnit, FabricConfigApplyLocalAccelCountOutOfRangeInval) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_ppod_config_t{};
+  in.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  in.mask = AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS;
+  in.data.local_accelerator_count = static_cast<uint32_t>(AMDSMI_FABRIC_MAX_LOCAL_GPUS + 1);
+  EXPECT_EQ(fabric_ualink::apply_ppod_config_at(root.path, true, in), AMDSMI_STATUS_INVAL);
+}
+
+TEST(GpuUnit, FabricConfigApplyAccelIdOutOfRangeInval) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_ppod_config_t{};
+  in.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  in.mask = AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID;
+  in.data.accelerator_id = 1024;  // valid range is 0..1023
+  EXPECT_EQ(fabric_ualink::apply_ppod_config_at(root.path, true, in), AMDSMI_STATUS_INVAL);
+}
+
+TEST(GpuUnit, FabricConfigApplyLocalAccelIdOutOfRangeInval) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_ppod_config_t{};
+  in.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  in.mask = AMDSMI_FABRIC_PPOD_FIELD_LOCAL_ACCELS;
+  in.data.local_accelerator_count = 1;
+  in.data.local_accelerators[0] = 1024;  // valid range is 0..1023
+  EXPECT_EQ(fabric_ualink::apply_ppod_config_at(root.path, true, in), AMDSMI_STATUS_INVAL);
+}
+
+TEST(GpuUnit, FabricConfigApplyVpodActiveAccelOutOfRangeInval) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_vpod_config_t{};
+  in.version = AMDSMI_FABRIC_VPOD_CONFIG_V1;
+  in.mask = AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS;
+  in.data.vpod_active_accelerators[0] = 1024;  // valid range is 0..1023
+  in.data.vpod_active_accelerators[1] = kU32Sentinel;
+  EXPECT_EQ(fabric_ualink::apply_vpod_config_at(root.path, true, in), AMDSMI_STATUS_INVAL);
+
+  // A value stranded past the first sentinel would be silently dropped by the
+  // serializer; reject the request instead of truncating the caller's list.
+  auto gap = amdsmi_fabric_vpod_config_t{};
+  gap.version = AMDSMI_FABRIC_VPOD_CONFIG_V1;
+  gap.mask = AMDSMI_FABRIC_VPOD_FIELD_VPOD_ACTIVE_ACCELS;
+  for (auto& id : gap.data.vpod_active_accelerators) {
+    id = kU32Sentinel;
+  }
+  gap.data.vpod_active_accelerators[0] = 3;
+  gap.data.vpod_active_accelerators[1] = kU32Sentinel;  // terminator
+  gap.data.vpod_active_accelerators[2] = 5;             // stranded past the terminator
+  EXPECT_EQ(fabric_ualink::apply_vpod_config_at(root.path, true, gap), AMDSMI_STATUS_INVAL);
+}
+
+TEST(GpuUnit, FabricConfigApplyVpodIdZeroInval) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_vpod_config_t{};
+  in.version = AMDSMI_FABRIC_VPOD_CONFIG_V1;
+  in.mask = AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID;
+  in.data.vpod_id = 0;  // 0 is not a valid pod ID
+  EXPECT_EQ(fabric_ualink::apply_vpod_config_at(root.path, true, in), AMDSMI_STATUS_INVAL);
+}
+
+TEST(GpuUnit, FabricConfigApplyPpodIdZeroInval) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_ppod_config_t{};
+  in.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  in.mask = AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID;
+  // ppod_id is all-zero by value-init; 0 is not a valid pod ID.
+  EXPECT_EQ(fabric_ualink::apply_ppod_config_at(root.path, true, in), AMDSMI_STATUS_INVAL);
+}
+
+TEST(GpuUnit, FabricConfigApplyPpodIdUnsetSentinelInval) {
+  auto root = TempRoot{};
+  ASSERT_FALSE(root.path.empty()) << "mkdtemp failed";
+
+  auto in = amdsmi_fabric_ppod_config_t{};
+  in.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  in.mask = AMDSMI_FABRIC_PPOD_FIELD_PPOD_ID;
+  // All-0x99 is the unset-readback sentinel; echoing it back is rejected on write.
+  for (auto& byte : in.data.ppod_id) {
+    byte = 0x99;
+  }
+  EXPECT_EQ(fabric_ualink::apply_ppod_config_at(root.path, true, in), AMDSMI_STATUS_INVAL);
+}
+
+// Missing write subtree under the root reports NOT_SUPPORTED rather than crashing.
+TEST(GpuUnit, FabricConfigQueryMissingSubdirNotSupported) {
+  auto tmpl = std::string("/tmp/amdsmi_fabric_empty_XXXXXX");
+  ASSERT_NE(::mkdtemp(tmpl.data()), nullptr) << "mkdtemp failed";
+  const auto empty_root = std::string(tmpl);
+
+  auto cfg = amdsmi_fabric_ppod_config_t{};
+  cfg.version = AMDSMI_FABRIC_PPOD_CONFIG_V1;
+  cfg.mask = AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID;
+  EXPECT_EQ(fabric_ualink::query_ppod_config_at(empty_root, true, cfg),
+            AMDSMI_STATUS_NOT_SUPPORTED);
+
+  auto ec = std::error_code{};
+  fs::remove_all(empty_root, ec);
+}
+
+}  // namespace
+
+}  // namespace amd::smi

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/fabric_config_roundtrip_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/fabric_config_roundtrip_test.cc
@@ -1,24 +1,5 @@
-/*
- * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
 
 // Hardware-free round-trip of the fabric config serialize/parse paths. The
 // apply_*_at / query_*_at cores take a resolved sysfs root + support flag instead

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/fabric_info_layout_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/fabric_info_layout_test.cc
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Hardware-free guard on the amdsmi_fabric_info_t versioned-union contract. Binaries
+// already linked against the version 1 layout allocated only through the v1 union member,
+// so both the field offsets and the write bound below are load-bearing: breaking either
+// corrupts caller memory rather than producing a compile error on their side.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+
+#include "amd_smi/amdsmi.h"
+#include "amd_smi/impl/amd_smi_gpu_device.h"
+
+namespace amd::smi {
+
+namespace {
+
+// The shipped version 1 struct, byte for byte
+constexpr auto kV1Size = std::size_t{244};
+
+// Where the union starts: sizeof(amdsmi_bdf_t) + sizeof(fabric_version)
+constexpr auto kUnionOffset = std::size_t{12};
+
+// One past the last byte a version 1 caller allocated for the payload
+constexpr auto kV1WriteBound = (kUnionOffset + kV1Size);
+
+// What a version 1 caller allocated in total: kV1WriteBound plus reserved[15]
+constexpr auto kV1CallerSize = std::size_t{320};
+
+constexpr auto kGuardByte = std::uint8_t{0xCC};
+
+static_assert(sizeof(amdsmi_fabric_info_v1_t) == kV1Size, "version 1 layout is frozen");
+static_assert(offsetof(amdsmi_fabric_info_t, fabric_info) == kUnionOffset,
+              "union offset is frozen");
+
+static_assert(offsetof(amdsmi_fabric_info_v1_t, accelerator_id) == 0);
+static_assert(offsetof(amdsmi_fabric_info_v1_t, fabric_type) == 4);
+static_assert(offsetof(amdsmi_fabric_info_v1_t, bandwidth) == 8);
+static_assert(offsetof(amdsmi_fabric_info_v1_t, latency) == 12);
+static_assert(offsetof(amdsmi_fabric_info_v1_t, ppod_id) == 16);
+static_assert(offsetof(amdsmi_fabric_info_v1_t, ppod_size) == 32);
+static_assert(offsetof(amdsmi_fabric_info_v1_t, vpod_id) == 36);
+static_assert(offsetof(amdsmi_fabric_info_v1_t, vpod_size) == 40);
+static_assert(offsetof(amdsmi_fabric_info_v1_t, vpod_active_accelerators) == 44);
+static_assert(offsetof(amdsmi_fabric_info_v1_t, local_accelerators) == 172);
+static_assert(offsetof(amdsmi_fabric_info_v1_t, addr_mode) == 236);
+static_assert(offsetof(amdsmi_fabric_info_v1_t, accel_state) == 240);
+
+// Populate every field with a distinguishable value so a dropped or mis-mapped
+// member shows up as a mismatch rather than as a coincidental zero
+auto make_populated_v2() -> amdsmi_fabric_info_v2_t {
+  auto source = amdsmi_fabric_info_v2_t{};
+  source.fabric_type = AMDSMI_FABRIC_TYPE_UALINK;
+  source.accel_state = AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE;
+
+  source.ppod.accelerator_id = 11;
+  for (auto i = std::size_t{0}; i < AMDSMI_MAX_UUID_ELEMENTS; ++i) {
+    source.ppod.ppod_id[i] = static_cast<std::uint8_t>(i + 1);
+  }
+  source.ppod.ppod_size = 22;
+  for (auto i = std::size_t{0}; i < AMDSMI_FABRIC_MAX_LOCAL_GPUS; ++i) {
+    source.ppod.local_accelerators[i] = static_cast<std::uint32_t>(100 + i);
+  }
+  source.ppod.local_accelerator_count = AMDSMI_FABRIC_MAX_LOCAL_GPUS;
+  source.ppod.bandwidth = 33;
+  source.ppod.latency = 44;
+
+  source.vpod.vpod_id = 55;
+  source.vpod.vpod_size = 66;
+  for (auto i = std::size_t{0}; i < AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE; ++i) {
+    source.vpod.vpod_active_accelerators[i] = static_cast<std::uint32_t>(200 + i);
+  }
+  source.vpod.addr_mode = AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING;
+
+  source.station.station_flags = 77;
+  source.station.num_stations = 8;
+  for (auto i = std::size_t{0}; i < AMDSMI_FABRIC_MAX_BITMAP_SIZE; ++i) {
+    source.station.lane_en_bitmap[i] = static_cast<std::uint8_t>(0xA0 + (i % 16));
+  }
+
+  source.ppod_mask = 0x0000003Fu;
+  source.vpod_mask = 0x0000000Fu;
+  source.station_mask = 0x00000007u;
+
+  return source;
+}
+
+// Stands in for a caller compiled against the version 1 header: only kV1CallerSize bytes
+// are theirs, and the rest of the buffer catches an out-of-bounds write
+class LegacyCallerBuffer {
+ public:
+  LegacyCallerBuffer() { storage_.fill(kGuardByte); }
+
+  auto info() -> amdsmi_fabric_info_t& {
+    return *reinterpret_cast<amdsmi_fabric_info_t*>(storage_.data());
+  }
+
+  auto is_untouched_from(std::size_t offset) const -> bool {
+    for (auto i = offset; i < storage_.size(); ++i) {
+      if (storage_[i] != kGuardByte) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+ private:
+  alignas(amdsmi_fabric_info_t) std::array<std::uint8_t, sizeof(amdsmi_fabric_info_t)> storage_{};
+};
+
+}  // namespace
+
+TEST(GpuUnit, FabricInfoLayoutVersionOneRequestWritesNothingPastTheVersionOneMember) {
+  auto buffer = LegacyCallerBuffer{};
+  buffer.info().fabric_version = AMDSMI_FABRIC_INFO_VERSION_1;
+
+  gpu_device::details::publish_fabric_info(amdsmi_bdf_t{}, make_populated_v2(),
+                                           AMDSMI_FABRIC_INFO_VERSION_1, buffer.info());
+
+  EXPECT_TRUE(buffer.is_untouched_from(kV1WriteBound));
+  EXPECT_LE(kV1WriteBound, kV1CallerSize);
+}
+
+TEST(GpuUnit, FabricInfoLayoutUnrecognizedVersionDegradesToVersionOne) {
+  const auto unrecognized_versions = std::array<std::uint32_t, 5>{
+      1u, 2u, 3u, std::numeric_limits<std::uint32_t>::max(), 0xFAB10003u};
+
+  for (const auto requested : unrecognized_versions) {
+    auto buffer = LegacyCallerBuffer{};
+    buffer.info().fabric_version = requested;
+
+    gpu_device::details::publish_fabric_info(amdsmi_bdf_t{}, make_populated_v2(), requested,
+                                             buffer.info());
+
+    EXPECT_TRUE(buffer.is_untouched_from(kV1WriteBound)) << "requested version " << requested;
+    EXPECT_NE(buffer.info().fabric_version, AMDSMI_FABRIC_INFO_VERSION_2)
+        << "requested version " << requested;
+  }
+}
+
+TEST(GpuUnit, FabricInfoLayoutVersionTwoRequestFillsTheNestedMember) {
+  const auto source = make_populated_v2();
+
+  auto destination = amdsmi_fabric_info_t{};
+  gpu_device::details::publish_fabric_info(amdsmi_bdf_t{}, source, AMDSMI_FABRIC_INFO_VERSION_2,
+                                           destination);
+
+  EXPECT_EQ(destination.fabric_version, static_cast<std::uint32_t>(AMDSMI_FABRIC_INFO_VERSION_2));
+
+  // Both operands descend from the same value-initialized aggregate, so the padding bytes agree
+  // and a byte compare is exactly what "copied verbatim" means here
+  // NOLINTNEXTLINE(bugprone-suspicious-memory-comparison)
+  EXPECT_EQ(std::memcmp(&destination.fabric_info.v2, &source, sizeof(source)), 0);
+}
+
+TEST(GpuUnit, FabricInfoLayoutFlattenMapsEveryVersionOneField) {
+  const auto source = make_populated_v2();
+
+  auto destination = amdsmi_fabric_info_v1_t{};
+  gpu_device::details::flatten_v2_to_v1(source, destination);
+
+  EXPECT_EQ(destination.accelerator_id, source.ppod.accelerator_id);
+  EXPECT_EQ(destination.fabric_type, source.fabric_type);
+  EXPECT_EQ(destination.bandwidth, source.ppod.bandwidth);
+  EXPECT_EQ(destination.latency, source.ppod.latency);
+  EXPECT_EQ(std::memcmp(destination.ppod_id, source.ppod.ppod_id, sizeof(destination.ppod_id)), 0);
+  EXPECT_EQ(destination.ppod_size, source.ppod.ppod_size);
+  EXPECT_EQ(destination.vpod_id, source.vpod.vpod_id);
+  EXPECT_EQ(destination.vpod_size, source.vpod.vpod_size);
+  EXPECT_EQ(std::memcmp(destination.vpod_active_accelerators, source.vpod.vpod_active_accelerators,
+                        sizeof(destination.vpod_active_accelerators)),
+            0);
+  EXPECT_EQ(std::memcmp(destination.local_accelerators, source.ppod.local_accelerators,
+                        sizeof(destination.local_accelerators)),
+            0);
+  EXPECT_EQ(destination.addr_mode, source.vpod.addr_mode);
+  EXPECT_EQ(destination.accel_state, source.accel_state);
+}
+
+}  // namespace amd::smi

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/fabric_info_layout_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/fabric_info_layout_test.cc
@@ -1,24 +1,5 @@
-/*
- * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
 
 // Hardware-free guard on the amdsmi_fabric_info_t versioned-union contract. Binaries
 // already linked against the version 1 layout allocated only through the v1 union member,

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/fabric_public_api_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/fabric_public_api_test.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Argument rejection on the public fabric surface. The functional fabric suites cover this
+// logic only behind a hardware-and-root gate, so it never runs in CI.
+
+#include <gtest/gtest.h>
+
+#include "amd_smi/amdsmi.h"
+
+TEST(GpuUnit, FabricPublicApiGetRejectsNullArguments) {
+  auto info = amdsmi_fabric_info_t{};
+  info.fabric_version = AMDSMI_FABRIC_INFO_VERSION_2;
+
+  EXPECT_EQ(amdsmi_get_gpu_fabric_info(nullptr, &info), AMDSMI_STATUS_INVAL);
+  EXPECT_EQ(amdsmi_get_gpu_fabric_info(nullptr, nullptr), AMDSMI_STATUS_INVAL);
+}

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/fabric_public_api_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/fabric_public_api_test.cc
@@ -1,24 +1,5 @@
-/*
- * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
 
 // Argument rejection on the public fabric surface. The functional fabric suites cover this
 // logic only behind a hardware-and-root gate, so it never runs in CI.

--- a/projects/amdsmi/tests/python/unit/gpu/test_fabric_config_setters.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_fabric_config_setters.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the ppod/vpod/station fabric config setters (hardware-free).
+
+Covers argument validation for amdsmi_set_gpu_fabric_{ppod,vpod,station}_config
+and the shared _populate_fabric_config_data() packing helper, stubbing the C
+entry point so nothing here touches real hardware or sysfs.
+"""
+
+import unittest
+from unittest import mock
+
+from common.common import amdsmi
+
+_BAD_HANDLE = None
+_GOOD_HANDLE = amdsmi.amdsmi_wrapper.amdsmi_processor_handle()
+
+
+class TestFabricConfigSetterArgumentValidation(unittest.TestCase):
+    """Every setter must reject the same shapes of bad input the same way."""
+
+    def test_ppod_rejects_bad_processor_handle(self):
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_gpu_fabric_ppod_config(_BAD_HANDLE, {"accelerator_id": 1})
+
+    def test_vpod_rejects_bad_processor_handle(self):
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_gpu_fabric_vpod_config(_BAD_HANDLE, {"vpod_id": 1})
+
+    def test_station_rejects_bad_processor_handle(self):
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_gpu_fabric_station_config(_BAD_HANDLE, {"station_flags": 1})
+
+    def test_ppod_rejects_non_dict_data(self):
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_gpu_fabric_ppod_config(_GOOD_HANDLE, "not a dict")
+
+    def test_vpod_rejects_non_dict_data(self):
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_gpu_fabric_vpod_config(_GOOD_HANDLE, ["not", "a", "dict"])
+
+    def test_station_rejects_non_dict_data(self):
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_gpu_fabric_station_config(_GOOD_HANDLE, 5)
+
+    def test_ppod_rejects_non_bool_commit(self):
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_gpu_fabric_ppod_config(_GOOD_HANDLE, {"accelerator_id": 1}, commit=1)
+
+    def test_vpod_rejects_non_bool_commit(self):
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_gpu_fabric_vpod_config(_GOOD_HANDLE, {"vpod_id": 1}, commit="yes")
+
+    def test_station_rejects_non_bool_commit(self):
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_gpu_fabric_station_config(
+                _GOOD_HANDLE, {"station_flags": 1}, commit=None
+            )
+
+    def test_ppod_rejects_unknown_field_name(self):
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_gpu_fabric_ppod_config(_GOOD_HANDLE, {"not_a_real_field": 1})
+
+    def test_vpod_rejects_unknown_field_name(self):
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_gpu_fabric_vpod_config(_GOOD_HANDLE, {"num_stations": 1})
+
+    def test_station_rejects_unknown_field_name(self):
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_gpu_fabric_station_config(_GOOD_HANDLE, {"vpod_id": 1})
+
+
+class TestPopulateFabricConfigData(unittest.TestCase):
+    """The shared packing helper: mask derivation and per-field writes."""
+
+    def test_scalar_fields_written_and_masked(self):
+        config = amdsmi.amdsmi_wrapper.amdsmi_fabric_ppod_config_t()
+        mask = amdsmi.amdsmi_interface._populate_fabric_config_data(
+            config,
+            {"accelerator_id": 42, "bandwidth": 100},
+            amdsmi.amdsmi_interface._FABRIC_PPOD_CONFIG_FIELD_MASKS,
+        )
+        self.assertEqual(config.data.accelerator_id, 42)
+        self.assertEqual(config.data.bandwidth, 100)
+        expected_mask = (
+            amdsmi.amdsmi_wrapper.AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID
+            | amdsmi.amdsmi_wrapper.AMDSMI_FABRIC_PPOD_FIELD_BANDWIDTH
+        )
+        self.assertEqual(mask, expected_mask)
+
+    def test_unsupplied_fields_left_untouched(self):
+        # A zero-initialized struct's other fields are not written just because
+        # one field was requested; only the mask bits for supplied keys are set.
+        config = amdsmi.amdsmi_wrapper.amdsmi_fabric_ppod_config_t()
+        amdsmi.amdsmi_interface._populate_fabric_config_data(
+            config, {"latency": 7}, amdsmi.amdsmi_interface._FABRIC_PPOD_CONFIG_FIELD_MASKS
+        )
+        self.assertEqual(config.data.bandwidth, 0)
+        self.assertEqual(config.data.accelerator_id, 0)
+
+    def test_array_field_written_via_slice_assignment(self):
+        config = amdsmi.amdsmi_wrapper.amdsmi_fabric_ppod_config_t()
+        values = list(range(16))
+        amdsmi.amdsmi_interface._populate_fabric_config_data(
+            config,
+            {"local_accelerators": values},
+            amdsmi.amdsmi_interface._FABRIC_PPOD_CONFIG_FIELD_MASKS,
+        )
+        self.assertEqual(list(config.data.local_accelerators), values)
+
+    def test_unknown_field_raises_before_any_write(self):
+        config = amdsmi.amdsmi_wrapper.amdsmi_fabric_vpod_config_t()
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_interface._populate_fabric_config_data(
+                config,
+                {"vpod_id": 3, "bogus_field": 1},
+                amdsmi.amdsmi_interface._FABRIC_VPOD_CONFIG_FIELD_MASKS,
+            )
+
+
+class TestFabricSetterCallSite(unittest.TestCase):
+    """Drives each setter through the (stubbed) C entry point end to end."""
+
+    def test_ppod_config_reaches_the_c_api_with_version_and_mask(self):
+        captured = {}
+
+        def _stub(_handle, config_ptr):
+            cfg = config_ptr._obj
+            captured["version"] = cfg.version
+            captured["mask"] = cfg.mask
+            captured["commit"] = cfg.commit
+            captured["accelerator_id"] = cfg.data.accelerator_id
+            return 0
+
+        with mock.patch.object(amdsmi.amdsmi_wrapper, "amdsmi_set_gpu_fabric_ppod_config", _stub):
+            amdsmi.amdsmi_set_gpu_fabric_ppod_config(
+                _GOOD_HANDLE, {"accelerator_id": 7}, commit=False
+            )
+
+        self.assertEqual(captured["version"], amdsmi.amdsmi_wrapper.AMDSMI_FABRIC_PPOD_CONFIG_V1)
+        self.assertEqual(captured["mask"], amdsmi.amdsmi_wrapper.AMDSMI_FABRIC_PPOD_FIELD_ACCEL_ID)
+        self.assertFalse(captured["commit"])
+        self.assertEqual(captured["accelerator_id"], 7)
+
+    def test_vpod_config_reaches_the_c_api(self):
+        captured = {}
+
+        def _stub(_handle, config_ptr):
+            cfg = config_ptr._obj
+            captured["vpod_id"] = cfg.data.vpod_id
+            captured["mask"] = cfg.mask
+            return 0
+
+        with mock.patch.object(amdsmi.amdsmi_wrapper, "amdsmi_set_gpu_fabric_vpod_config", _stub):
+            amdsmi.amdsmi_set_gpu_fabric_vpod_config(_GOOD_HANDLE, {"vpod_id": 9})
+
+        self.assertEqual(captured["vpod_id"], 9)
+        self.assertEqual(captured["mask"], amdsmi.amdsmi_wrapper.AMDSMI_FABRIC_VPOD_FIELD_VPOD_ID)
+
+    def test_station_config_reaches_the_c_api(self):
+        captured = {}
+
+        def _stub(_handle, config_ptr):
+            cfg = config_ptr._obj
+            captured["num_stations"] = cfg.data.num_stations
+            captured["mask"] = cfg.mask
+            return 0
+
+        with mock.patch.object(
+            amdsmi.amdsmi_wrapper, "amdsmi_set_gpu_fabric_station_config", _stub
+        ):
+            amdsmi.amdsmi_set_gpu_fabric_station_config(_GOOD_HANDLE, {"num_stations": 3})
+
+        self.assertEqual(captured["num_stations"], 3)
+        self.assertEqual(
+            captured["mask"], amdsmi.amdsmi_wrapper.AMDSMI_FABRIC_DF_FIELD_NUM_STATIONS
+        )
+
+    def test_library_error_raised_as_amdsmi_exception(self):
+        with mock.patch.object(
+            amdsmi.amdsmi_wrapper,
+            "amdsmi_set_gpu_fabric_ppod_config",
+            lambda _h, _c: amdsmi.amdsmi_wrapper.AMDSMI_STATUS_INVAL,
+        ):
+            with self.assertRaises(amdsmi.AmdSmiLibraryException):
+                amdsmi.amdsmi_set_gpu_fabric_ppod_config(_GOOD_HANDLE, {"accelerator_id": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add Ppod/Vpod/station config APIs for AIFM integration

Code changes related to the following:
  * Add amdsmi_set_gpu_fabric_ppod_config(), amdsmi_set_gpu_fabric_vpod_config(), amdsmi_set_gpu_fabric_station_config() public C API entry points
  * Refactor code to use amdsmi_fabric_info_v1_t and amdsmi_get_gpu_fabric_info() as unified getter
  * Add amd_smi_fabric_ualink.cc to CMakeLists.txt source list
  * Add TestFabricWrite functional test covering null-handle, invalid-mask, and per-device hardware paths

## Motivation

AIFM needs to program AMD GPU fabric topology at runtime. Until now, the **fabric API was read-only**. This PR adds three write entry points (`Ppod, Vpod, station`) and unifies the read path behind a single versioned getter so AIFM can configure and read back fabric state through one struct.

## Technical Details

Public header (`include/amd_smi/amdsmi.h`):
  - Add `amdsmi_set_gpu_fabric_ppod_config()`, `amdsmi_set_gpu_fabric_vpod_config()`, `amdsmi_set_gpu_fabric_station_config()`. Each takes a versioned config struct using the `version + field-mask + data` pattern
  - Add config structs and their `*_CONFIG_V1` version enums, plus field-mask enums `AMDSMI_FABRIC_PPOD_FIELD_*`, `AMDSMI_FABRIC_VPOD_FIELD_*`, `AMDSMI_FABRIC_DF_FIELD_*`
  - Refactor the **fabric getter** onto `amdsmi_fabric_info_v1_t` / `amdsmi_get_gpu_fabric_info()` as the unified read path, document sentinel semantics (numeric fields at max, ppod_id guard byte 0x99)
  
Core implementation (`src/amd_smi/amd_smi_fabric_ualink.cc`, `amd_smi_gpu_device.cc`, `amd_smi_ualoe.cc`):
  - Implement the three setters and the UALink serialization/deserialization path; new file `amd_smi_fabric_ualink.cc` added to `src/CMakeLists.txt`
  - Validate handle, mask bits, and version, and reject `null handle/config` and undefined mask bits with `AMDSMI_STATUS_INVAL`
  - `vpod_active_accelerators` serialization emits the leading run of real IDs and stops at `UINT32_MAX` or `0` (neither is a real accelerator ID)  

## Issue Tracking

JIRA ID: ROCM-3759

## Test Plan

- C++ `GTest TestFabricWrite` (`tests/amd_smi_test/functional/fabric_write.cc`): `null-handle`, `null-config`, `invalid-version`, and `undefined/invalid-mask` paths for all three setters, per-device hardware round-trip (`set → read back → restore baseline`) gated on **UALink-capable** hardware
- Extended `fabric_read.cc` for the unified getter
- Python unit tests (`tests/python/unit/gpu/test_fabric_config_validation.py`): **masked-key-absent, local-accels-requires-both-keys, undefined-mask-bit, station num-stations** gate, oversized/non-sequence array rejection, and valid scalar/array landing in the struct
- Build: `cmake -DBUILD_TESTS=ON`; run `build/tests/amd_smi_test/amdsmitst` and python3 unit tests

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
