### PR TITLE
[rocjitsu] Skip indirect recovery without consumers

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -687,6 +687,12 @@ void invalidate_written_sgprs(AnalysisContext &ctx, size_t index, BlockState &st
   return (inst.flags() & INDIRECT_CALL) != 0 && inst.branch_offset_bytes().has_value();
 }
 
+[[nodiscard]] bool is_recoverable_indirect_consumer(const Instruction &inst) {
+  // Every fixup producer in this pass targets one of these consumer kinds.
+  // Extend this predicate when adding recovery for another terminator.
+  return is_indirect_branch(inst) || ((inst.flags() & INDIRECT_CALL) != 0 && !is_direct_call(inst));
+}
+
 [[nodiscard]] bool has_no_direct_successor(const Instruction &inst) {
   // Indirect branches have no known target until this analysis recovers one.
   // Indirect calls still expose their ordinary fallthrough/return continuation
@@ -2165,16 +2171,11 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
   return static_cast<uint16_t>((word >> 16) & 0x7fu);
 }
 
-} // namespace
-
-std::vector<IndirectCallFixup>
-discover_indirect_branch_edges(std::span<const Instruction *const> insts,
-                               std::span<const uint8_t> text, rj_code_arch_t arch,
-                               std::span<const uint64_t> extra_leaders) {
+[[nodiscard]] std::vector<IndirectCallFixup>
+discover_indirect_branch_edges_unfiltered(std::span<const Instruction *const> insts,
+                                          std::span<const uint8_t> text, rj_code_arch_t arch,
+                                          std::span<const uint64_t> extra_leaders) {
   std::vector<IndirectCallFixup> recovered;
-  if (insts.empty())
-    return recovered;
-
   AnalysisContext ctx = build_context(insts, text, arch);
   recover_vector_lane_stashed_pcs(ctx, recovered, extra_leaders);
   std::vector<uint64_t> leaders(extra_leaders.begin(), extra_leaders.end());
@@ -2207,6 +2208,34 @@ discover_indirect_branch_edges(std::span<const Instruction *const> insts,
 
   std::ranges::sort(recovered, {}, &IndirectCallFixup::source_call_offset);
   return recovered;
+}
+
+} // namespace
+
+std::vector<IndirectCallFixup>
+discover_indirect_branch_edges(std::span<const Instruction *const> insts,
+                               std::span<const uint8_t> text, rj_code_arch_t arch,
+                               std::span<const uint64_t> extra_leaders) {
+  if (insts.empty())
+    return {};
+
+  // Every recoverable edge ends at an indirect branch/call consumer. Most
+  // generated kernels have none, so avoid building the auxiliary CFG and
+  // running its dataflow passes when no fixup can possibly be produced.
+  const bool has_indirect_consumer = std::ranges::any_of(
+      insts, [](const Instruction *inst) { return is_recoverable_indirect_consumer(*inst); });
+  if (!has_indirect_consumer) {
+#ifndef NDEBUG
+    // Keep the cheap predicate coupled to every fixup producer. A future
+    // recovery path for another consumer kind must extend the predicate above.
+    const auto unfiltered =
+        discover_indirect_branch_edges_unfiltered(insts, text, arch, extra_leaders);
+    assert(unfiltered.empty() && "indirect-recovery prefilter skipped a fixup-producing consumer");
+#endif
+    return {};
+  }
+
+  return discover_indirect_branch_edges_unfiltered(insts, text, arch, extra_leaders);
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -467,7 +467,7 @@ TEST(CfgAnalysis, IndirectBranchHasNoStaticSuccessor) {
   EXPECT_TRUE(blocks[1]->predecessors().empty());
 }
 
-TEST(CfgAnalysis, RecoveredIndirectBranchEdgeStartsAtConsumerBlock) {
+TEST(CfgAnalysis, IndirectRecoveryPrefilterAdmitsSetPcConsumer) {
   constexpr uint16_t kPcSreg = 8;
   constexpr uint32_t kLiteralOperand = 255;
   constexpr uint32_t kInlineInt0 = 128;
@@ -504,11 +504,34 @@ TEST(CfgAnalysis, RecoveredIndirectBranchEdgeStartsAtConsumerBlock) {
   ASSERT_EQ(builder->successors().size(), 1u);
   EXPECT_EQ(builder->successors()[0], consumer);
 
-  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
+  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u)
+      << "setpc consumer must pass the indirect-recovery prefilter";
   EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_call_offset, 16u);
   ASSERT_EQ(consumer->successors().size(), 1u);
   EXPECT_EQ(consumer->successors()[0], target);
   EXPECT_FALSE(has_predecessor(*fallthrough, consumer));
+}
+
+TEST(CfgAnalysis, PcBuilderWithoutConsumerProducesNoRecoveredEdge) {
+  constexpr uint16_t kPcSreg = 8;
+  constexpr uint32_t kLiteralOperand = 255;
+  constexpr uint32_t kInlineInt0 = 128;
+
+  std::vector<uint32_t> words = {
+      pack_sop1(0x1c, kPcSreg, 0),                         // s_getpc_b64.
+      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand),     // s_add_u32.
+      4,                                                   // Target delta.
+      pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0), // s_addc_u32.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_EQ(blocks.size(), 1u);
+  EXPECT_TRUE(blocks[0]->static_indirect_call_fixups().empty());
 }
 
 TEST(CfgAnalysis, RecoversMultipleSgprPairsFromOneBlockEntry) {
@@ -1135,7 +1158,7 @@ TEST(CfgAnalysis, Gfx1250SignedDeltaRejectsMoveClobberingTemporary) {
   EXPECT_EQ(resolved_to_target, 0u);
 }
 
-TEST(CfgAnalysis, Gfx1250RecoversPcStashedInVgprLanes) {
+TEST(CfgAnalysis, IndirectRecoveryPrefilterAdmitsGfx1250LaneStashSwapPc) {
   // s[0:1] builds target 0x38, is stashed in v44 lanes 0:1, then restored
   // through v_readlane immediately before swappc. This is the finite static
   // call idiom emitted in RCCL device functions.
@@ -1166,17 +1189,19 @@ TEST(CfgAnalysis, Gfx1250RecoversPcStashedInVgprLanes) {
   auto *target = block_starting_at(blocks, 56);
   ASSERT_NE(consumer, nullptr);
   ASSERT_NE(target, nullptr);
-  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
+  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u)
+      << "lane-stash swappc consumer must pass the indirect-recovery prefilter";
   EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 56u);
   EXPECT_TRUE(has_successor_start(*consumer, target->start_offset()));
 }
 
 TEST(CfgAnalysis, Gfx1250WideVgprWriteInvalidatesStashedLane) {
-  // Same stash idiom as Gfx1250RecoversPcStashedInVgprLanes, but a width-2
-  // v_mov_b64 writes v[44:45] between the writelanes and the readlanes. That wide
-  // write overwrites the stashed VGPR, so the readlane no longer reconstructs the
-  // original PC and recovery must fail closed. A width-one-only invalidation would
-  // miss the b64 write and falsely recover a target.
+  // Same stash idiom as IndirectRecoveryPrefilterAdmitsGfx1250LaneStashSwapPc,
+  // but a width-2 v_mov_b64 writes v[44:45] between the writelanes and the
+  // readlanes. That wide write overwrites the stashed VGPR, so the readlane no
+  // longer reconstructs the original PC and recovery must fail closed. A
+  // width-one-only invalidation would miss the b64 write and falsely recover a
+  // target.
   constexpr auto clobber =
       gfx1250::build_vop3(gfx1250::kVMovB64Vop3, {.vdst = 44, .src0 = 256 + 46});
   std::vector<uint32_t> words = {
@@ -1465,12 +1490,14 @@ TEST(CfgAnalysis, Gfx1250A0UsesLowByteOfWorkaroundAnnotatedVgprMsb) {
 }
 
 TEST(CfgAnalysis, Gfx1250DoesNotRecoverLaneStashWithDifferingRoleBanks) {
-  // Same straight-line stash idiom as Gfx1250RecoversPcStashedInVgprLanes, but an
+  // Same straight-line stash idiom as
+  // IndirectRecoveryPrefilterAdmitsGfx1250LaneStashSwapPc, but an
   // s_set_vgpr_msb sets the DST bank to 1 while leaving the SRC0 bank at 0. The
-  // v_writelane writes physical v[44+256] (DST bank 1) while the v_readlane reads
-  // physical v44 (SRC0 bank 0). Because the roles resolve the same low selector to
-  // different physical VGPRs, no value actually flows, and recovery must fail
-  // closed rather than key both by the low selector and falsely reconstruct a PC.
+  // v_writelane writes physical v[44+256] (DST bank 1) while the v_readlane
+  // reads physical v44 (SRC0 bank 0). Because the roles resolve the same low
+  // selector to different physical VGPRs, no value actually flows, and
+  // recovery must fail closed rather than key both by the low selector and
+  // falsely reconstruct a PC.
   //
   // s_set_vgpr_msb immediate byte is {DST[7:6], SRC2[5:4], SRC1[3:2], SRC0[1:0]};
   // 0x40 selects DST bank 1, all other roles bank 0.


### PR DESCRIPTION
## Motivation

Avoid indirect-target recovery work when a kernel cannot consume a recovered edge.

## Technical Details

Return before auxiliary CFG and dataflow construction when there is no indirect branch or dynamic indirect call.

## Issue Tracking

N/A

## Test Plan

Run ctest and A/B translate the gfx1250 corpus against develop.

## Test Result

Passed. Across 2,659 translatable inputs, CPU time fell from 691 s to 580 s (1.19x speedup); peak RSS changed from 1,812 MiB to 1,819 MiB (+0.4%). Outputs were bit-identical and all 2,685 statuses matched.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.