### PR TITLE
[rocjitsu] Translate descriptorless gfx1250 callables

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -24,8 +24,8 @@ on:
         required: true
       corpus_ref:
         description: "Branch, tag, or SHA containing the packaged-HSACO DBT suite"
-        # Last updated on 2026/07/27.
-        default: "e1a9a1f7ac9b1d38c7eddf486b529bc3cfcb0c95"
+        # Last updated on 2026/07/28.
+        default: "4c232fc5da6e42bb8fb16e2d8797b3415afeca47"
         required: true
       legacy_corpus_ref:
         description: "Branch, tag, or SHA for the existing corpus tests"
@@ -143,8 +143,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ github.event.inputs.corpus_repository || 'ROCm/rocjitsu-test-corpus' }}
-          # Last updated on 2026/07/27.
-          ref: ${{ github.event.inputs.corpus_ref || 'e1a9a1f7ac9b1d38c7eddf486b529bc3cfcb0c95' }}
+          # Last updated on 2026/07/28.
+          ref: ${{ github.event.inputs.corpus_ref || '4c232fc5da6e42bb8fb16e2d8797b3415afeca47' }}
           path: rocjitsu-dbt-test-corpus
 
       - name: Set up Python

--- a/emulation/rocjitsu/docs/dbt-design.md
+++ b/emulation/rocjitsu/docs/dbt-design.md
@@ -421,6 +421,37 @@ If one dynamic consumer has multiple recovered targets, one direct window cannot
 preserve it. DBT keeps the indirect consumer and rewrites each recovered
 source-side PC-builder range to compute the relocated target instead.
 
+### Descriptorless LLVM Callables
+
+gfx1250 B0-to-A0 translation also accepts complete, non-overlapping, sized
+`STT_FUNC` ranges that are not owned by a kernel descriptor. This path supports
+only linked AMDHSA code objects V4-V6 and the LLVM C/Fast/Cold device-function
+ABI. A symbol type alone does not encode a calling convention, so other
+producers or LLVM graphics/chain conventions are outside this contract.
+
+LLVM's per-function `.amdgpu.info` records cannot carry the contract into this
+path. LLVM emits that `SHF_EXCLUDE` section only in relocatable objects for the
+linker to consume. Legacy `.AMDGPU.gpr_maximums` likewise contains no bytes,
+and its assembler resource symbols are not retained in linked corpus HSACOs.
+RocJITsu runs on the final `ET_DYN` HSACO, where neither form provides mutable
+per-function resource records.
+
+The final-object fallback is deliberately bounded:
+
+- every callable range must decode completely;
+- ABI argument, result, return-address, stack, and callee-saved registers are
+  unavailable to scratch allocation;
+- each function's highest referenced low-bank VGPR is rounded to the hardware
+  allocation granule, and scratch must remain within that same per-function
+  envelope;
+- MODE changes that can select another physical VGPR bank are rejected; and
+- descriptorless translation cannot grow registers or manufacture private
+  spill storage because no descriptor can advertise those resources.
+
+These constraints allow rewrites that reuse a dead caller-clobbered register
+already covered by the source allocation. A rewrite that needs a larger
+resource envelope fails without committing any ELF changes.
+
 ### 6. Feed Resources Back into the Descriptor
 
 Semantic expansion can discover requirements that were unknown during the

--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -845,6 +845,21 @@ class _AmdgpuProfileBase(IsaProfile):
         return 256
 
     @property
+    def vector_lane_encoding_mask(self) -> int:
+        """Word-zero mask for vector readlane/writelane instruction matching."""
+        return 0
+
+    @property
+    def vector_readlane_b32_encoding(self) -> int:
+        """Masked word-zero encoding for V_READLANE_B32."""
+        return 0
+
+    @property
+    def vector_writelane_b32_encoding(self) -> int:
+        """Masked word-zero encoding for V_WRITELANE_B32."""
+        return 0
+
+    @property
     def descriptor_sgpr_count_encoded(self) -> bool:
         """Whether zero SGPR granule fields still use descriptor encoding."""
         return True
@@ -1679,6 +1694,18 @@ class Gfx1250Profile(Rdna4Profile):
     @property
     def max_addressable_vgprs_per_wf(self) -> int:
         return 1024
+
+    @property
+    def vector_lane_encoding_mask(self) -> int:
+        return 0xFFFF0000
+
+    @property
+    def vector_readlane_b32_encoding(self) -> int:
+        return 0xD7600000
+
+    @property
+    def vector_writelane_b32_encoding(self) -> int:
+        return 0xD7610000
 
     @property
     def has_vopd3(self) -> bool:

--- a/emulation/rocjitsu/lib/python/amdisa/isa_properties_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_properties_codegen.py
@@ -42,6 +42,20 @@ def emit_isa_properties(output_dir: str, specs) -> Path:
             'true' if profile.uses_cluster_ttmp_workgroup_ids else 'false'
         )
         addressable_vgprs = profile.max_addressable_vgprs_per_wf
+        vector_lane_encoding_mask = profile.vector_lane_encoding_mask
+        vector_readlane_b32_encoding = profile.vector_readlane_b32_encoding
+        vector_writelane_b32_encoding = profile.vector_writelane_b32_encoding
+        vector_lane_encoding_lines = []
+        if vector_lane_encoding_mask:
+            if not vector_readlane_b32_encoding or not vector_writelane_b32_encoding:
+                raise ValueError(
+                    f'{name} vector lane encodings require both readlane and writelane'
+                )
+            vector_lane_encoding_lines = [
+                f'        .vector_lane_encoding_mask = 0x{vector_lane_encoding_mask:08X},',
+                f'        .vector_readlane_b32_encoding = 0x{vector_readlane_b32_encoding:08X},',
+                f'        .vector_writelane_b32_encoding = 0x{vector_writelane_b32_encoding:08X},',
+            ]
         max_addressable_vgprs_per_wf = max(
             max_addressable_vgprs_per_wf, addressable_vgprs
         )
@@ -53,6 +67,7 @@ def emit_isa_properties(output_dir: str, specs) -> Path:
             f'        .uses_ttmp_workgroup_ids = {uses_ttmp_workgroup_ids},',
             f'        .uses_cluster_ttmp_workgroup_ids = {uses_cluster_ttmp_workgroup_ids},',
             f'        .max_addressable_vgprs_per_wf = {addressable_vgprs},',
+            *vector_lane_encoding_lines,
             '    };',
         ]
 
@@ -78,6 +93,9 @@ def emit_isa_properties(output_dir: str, specs) -> Path:
         '  bool uses_ttmp_workgroup_ids = false;',
         '  bool uses_cluster_ttmp_workgroup_ids = false;',
         '  uint32_t max_addressable_vgprs_per_wf = 0;',
+        '  uint32_t vector_lane_encoding_mask = 0;',
+        '  uint32_t vector_readlane_b32_encoding = 0;',
+        '  uint32_t vector_writelane_b32_encoding = 0;',
         '};',
         '',
         'inline constexpr uint32_t MAX_SUPPORTED_ADDRESSABLE_VGPRS_PER_WF = '

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
@@ -80,6 +80,22 @@ def test_max_addressable_vgprs_per_wf(profile, expected):
     assert profile.max_addressable_vgprs_per_wf == expected
 
 
+@pytest.mark.parametrize(
+    ('profile', 'expected'),
+    [
+        (CdnaProfile(), (0, 0, 0)),
+        (Rdna4Profile(), (0, 0, 0)),
+        (Gfx1250Profile(), (0xFFFF0000, 0xD7600000, 0xD7610000)),
+    ],
+)
+def test_vector_lane_encodings(profile, expected):
+    assert (
+        profile.vector_lane_encoding_mask,
+        profile.vector_readlane_b32_encoding,
+        profile.vector_writelane_b32_encoding,
+    ) == expected
+
+
 def test_only_gfx1250_splits_execution_sources():
     assert Gfx1250Profile().split_execution_sources
     assert not Rdna4Profile().split_execution_sources
@@ -134,6 +150,7 @@ def test_isa_properties_codegen_uses_profile_values(tmp_path):
     output = emit_isa_properties(str(tmp_path), specs).read_text()
 
     assert 'uint32_t max_addressable_vgprs_per_wf = 0;' in output
+    assert 'uint32_t vector_lane_encoding_mask = 0;' in output
     assert 'MAX_SUPPORTED_ADDRESSABLE_VGPRS_PER_WF = 1024;' in output
     assert (
         'case ROCJITSU_CODE_ARCH_CDNA3:\n'
@@ -163,6 +180,9 @@ def test_isa_properties_codegen_uses_profile_values(tmp_path):
         '        .uses_ttmp_workgroup_ids = true,\n'
         '        .uses_cluster_ttmp_workgroup_ids = true,\n'
         '        .max_addressable_vgprs_per_wf = 1024,\n'
+        '        .vector_lane_encoding_mask = 0xFFFF0000,\n'
+        '        .vector_readlane_b32_encoding = 0xD7600000,\n'
+        '        .vector_writelane_b32_encoding = 0xD7610000,\n'
         '    };'
     ) in output
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_vgpr_msb.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_vgpr_msb.cpp
@@ -221,12 +221,34 @@ void transfer_instruction(VgprMsbState &state, const Instruction &inst,
 
 } // namespace
 
+bool changes_gfx1250_vgpr_msb_state(const Instruction &inst) {
+  const std::string_view mnemonic = inst.mnemonic();
+  if (mnemonic == "s_set_vgpr_msb")
+    return true;
+  if (mnemonic != "s_setreg_b32" && mnemonic != "s_setreg_imm32_b32")
+    return false;
+
+  const Operand *hwreg_operand = inst.dst_operand(0);
+  if (hwreg_operand == nullptr)
+    return true;
+  const HwregSlice slice = decode_hwreg(static_cast<uint16_t>(hwreg_operand->encoding_value()));
+  if (slice.id != kModeHwreg)
+    return false;
+  if (mnemonic == "s_setreg_imm32_b32")
+    return true;
+
+  constexpr uint16_t kVgprMsbBegin = 12;
+  constexpr uint16_t kVgprMsbEnd = 20;
+  const uint16_t width = std::min<uint16_t>(slice.width, static_cast<uint16_t>(32u - slice.begin));
+  return slice.begin < kVgprMsbEnd && kVgprMsbBegin < slice.begin + width;
+}
+
 class Gfx1250VgprMsbAnalysis::Impl {
 public:
-  Impl(KernelBlockScope blocks, BasicBlock *entry, std::span<const ScopedCfgEdge> extra_edges,
-       std::span<const uint8_t> text)
+  Impl(KernelBlockScope blocks, std::span<BasicBlock *const> entries,
+       std::span<const ScopedCfgEdge> extra_edges, std::span<const uint8_t> text)
       : text_(text) {
-    analyze(blocks, entry, extra_edges);
+    analyze(blocks, entries, extra_edges);
   }
 
   [[nodiscard]] std::optional<uint8_t> bank_before(const Instruction &inst,
@@ -243,7 +265,7 @@ public:
   }
 
 private:
-  void analyze(KernelBlockScope blocks, BasicBlock *entry,
+  void analyze(KernelBlockScope blocks, std::span<BasicBlock *const> entries,
                std::span<const ScopedCfgEdge> extra_edges) {
     std::unordered_map<const BasicBlock *, size_t> block_index;
     block_index.reserve(blocks.size());
@@ -251,10 +273,6 @@ private:
       if (blocks[i] != nullptr)
         block_index.emplace(blocks[i], i);
     }
-    const auto entry_it = block_index.find(entry);
-    if (entry_it == block_index.end())
-      return;
-
     std::vector<std::vector<size_t>> successors(blocks.size());
     auto add_edge = [&](const BasicBlock *from, const BasicBlock *to) {
       const auto from_it = block_index.find(from);
@@ -276,7 +294,6 @@ private:
 
     std::vector<VgprMsbState> in(blocks.size());
     std::vector<VgprMsbState> out(blocks.size());
-    in[entry_it->second] = entry_state();
 
     std::deque<size_t> worklist;
     std::vector<bool> queued(blocks.size(), false);
@@ -286,7 +303,13 @@ private:
       queued[index] = true;
       worklist.push_back(index);
     };
-    enqueue(entry_it->second);
+    for (BasicBlock *entry : entries) {
+      const auto entry_it = block_index.find(entry);
+      if (entry_it == block_index.end())
+        return;
+      (void)merge_state(in[entry_it->second], entry_state());
+      enqueue(entry_it->second);
+    }
 
     while (!worklist.empty()) {
       const size_t index = worklist.front();
@@ -326,10 +349,11 @@ private:
   std::unordered_map<const Instruction *, VgprMsbState> before_;
 };
 
-Gfx1250VgprMsbAnalysis::Gfx1250VgprMsbAnalysis(KernelBlockScope blocks, BasicBlock *entry,
+Gfx1250VgprMsbAnalysis::Gfx1250VgprMsbAnalysis(KernelBlockScope blocks,
+                                               std::span<BasicBlock *const> entries,
                                                std::span<const ScopedCfgEdge> extra_edges,
                                                std::span<const uint8_t> text)
-    : impl_(std::make_unique<Impl>(blocks, entry, extra_edges, text)) {}
+    : impl_(std::make_unique<Impl>(blocks, entries, extra_edges, text)) {}
 
 Gfx1250VgprMsbAnalysis::~Gfx1250VgprMsbAnalysis() = default;
 Gfx1250VgprMsbAnalysis::Gfx1250VgprMsbAnalysis(Gfx1250VgprMsbAnalysis &&) noexcept = default;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_vgpr_msb.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_vgpr_msb.h
@@ -18,20 +18,24 @@ namespace rocjitsu {
 
 class Instruction;
 
+/// @brief Whether @p inst can modify gfx1250 WAVE_MODE.VGPR_MSB state.
+[[nodiscard]] bool changes_gfx1250_vgpr_msb_state(const Instruction &inst);
+
 /// @brief Resolve gfx1250 encoded VGPR operands to their 256-register bank.
 ///
 /// @details gfx1250 stores only the low eight bits of a VGPR index in vector
 /// instructions. S_SET_VGPR_MSB and MODE register writes provide two high bits
 /// independently for DST, SRC0, SRC1, and SRC2. This analysis propagates those
-/// four fields through a kernel-local CFG. A field is known at a join only when
-/// every reachable predecessor agrees; otherwise bank_before() returns
-/// std::nullopt so clients can behave conservatively.
+/// four fields through a kernel-local CFG from every independently callable ABI
+/// entry. A field is known at a join only when every reachable predecessor
+/// agrees; otherwise bank_before() returns std::nullopt so clients can behave
+/// conservatively.
 class Gfx1250VgprMsbAnalysis {
 public:
   /// @param text Raw .text image, used to read S_SETREG_IMM32_B32 literals safely
   ///        at src_loc()+4. Empty is tolerated: such writes then mark the affected
   ///        banks ambiguous rather than reading a literal.
-  Gfx1250VgprMsbAnalysis(KernelBlockScope blocks, BasicBlock *entry,
+  Gfx1250VgprMsbAnalysis(KernelBlockScope blocks, std::span<BasicBlock *const> entries,
                          std::span<const ScopedCfgEdge> extra_edges = {},
                          std::span<const uint8_t> text = {});
   ~Gfx1250VgprMsbAnalysis();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -5,6 +5,7 @@
 
 #include "rocjitsu/analysis/control_flow.h"
 #include "rocjitsu/code/patch/instruction_builder.h"
+#include "rocjitsu/isa/arch/amdgpu/isa_properties.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/operand.h"
 #include "rocjitsu/isa/register_set.h"
@@ -22,6 +23,7 @@
 #include <set>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace rocjitsu {
@@ -261,6 +263,8 @@ struct AnalysisContext {
   std::span<const uint8_t> text;
   rj_code_arch_t arch;
   std::vector<InstructionFacts> facts;
+  bool has_vector_lane_write = false;
+  std::vector<uint64_t> vector_lane_read_offsets;
 };
 
 /// @brief Per-pair summary for one analysis block.
@@ -1165,6 +1169,7 @@ void join_lattice_value(LatticeValue &dst, const LatticeValue &src) {
   ctx.insts = insts;
   ctx.text = text;
   ctx.arch = arch;
+  const IsaProperties properties = isa_properties(arch);
 
   ctx.facts.resize(insts.size());
   for (size_t i = 0; i < insts.size(); ++i) {
@@ -1177,6 +1182,14 @@ void join_lattice_value(LatticeValue &dst, const LatticeValue &src) {
     if (facts.swappc_ssrc)
       facts.swappc_sdst = static_cast<uint16_t>((facts.word >> 16) & 0x7fu);
     facts.call_sdst = s_call_sdst(inst, facts.word);
+    if (properties.vector_lane_encoding_mask != 0) {
+      // Compare the already-cached word against target-owned encoding
+      // properties instead of decoding every mnemonic on large code objects.
+      const uint32_t encoding = facts.word & properties.vector_lane_encoding_mask;
+      ctx.has_vector_lane_write |= encoding == properties.vector_writelane_b32_encoding;
+      if (encoding == properties.vector_readlane_b32_encoding)
+        ctx.vector_lane_read_offsets.push_back(inst.src_loc());
+    }
   }
 
   return ctx;
@@ -1250,12 +1263,20 @@ build_analysis_blocks(const AnalysisContext &ctx, std::span<const uint64_t> extr
 
 [[nodiscard]] std::vector<uint8_t>
 explicit_external_entries(const std::vector<AnalysisBlock> &blocks,
-                          std::span<const uint64_t> extra_leaders) {
+                          std::span<const uint64_t> external_entry_offsets) {
   std::vector<uint8_t> entries(blocks.size(), 0);
   if (!entries.empty())
     entries[0] = 1;
+
+  // Callers may supply thousands of sized STT_FUNC roots. A linear search for
+  // every block made entry classification O(blocks * functions), dominating
+  // translation of large linked libraries. Hash the comparatively compact
+  // entry set once so this pass remains linear in the block count.
+  std::unordered_set<uint64_t> external_entries;
+  external_entries.reserve(external_entry_offsets.size());
+  external_entries.insert(external_entry_offsets.begin(), external_entry_offsets.end());
   for (size_t block_index = 1; block_index < blocks.size(); ++block_index) {
-    if (std::ranges::find(extra_leaders, blocks[block_index].offset) != extra_leaders.end())
+    if (external_entries.contains(blocks[block_index].offset))
       entries[block_index] = 1;
   }
   return entries;
@@ -1654,10 +1675,9 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
   finalize_block_transfers(block, state);
 }
 
-[[nodiscard]] std::vector<LatticeFacts>
-run_block_dataflow(const std::vector<AnalysisBlock> &blocks,
-                   std::span<const PendingConsumer> pending_consumers,
-                   std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy) {
+[[nodiscard]] std::vector<LatticeFacts> run_block_dataflow(
+    const std::vector<AnalysisBlock> &blocks, std::span<const PendingConsumer> pending_consumers,
+    std::span<const uint64_t> external_entry_offsets, ExternalEntryPolicy entry_policy) {
   // Phase 3: compute block-entry facts to a fixed point.
   //
   // entry[B] = JOIN(exit[P]) for every predecessor P of B.
@@ -1672,7 +1692,8 @@ run_block_dataflow(const std::vector<AnalysisBlock> &blocks,
     for (size_t successor : blocks[block_index].successors)
       predecessors[successor].push_back(block_index);
   }
-  const std::vector<uint8_t> external_entries = explicit_external_entries(blocks, extra_leaders);
+  const std::vector<uint8_t> external_entries =
+      explicit_external_entries(blocks, external_entry_offsets);
 
   // Dataflow results are consumed only by pending cross-block branches. A pair
   // that is built or killed somewhere but never reaches such a consumer cannot
@@ -1860,7 +1881,7 @@ void add_recovered_leaders(std::vector<uint64_t> &leaders,
   leaders.erase(std::ranges::unique(leaders).begin(), leaders.end());
 }
 
-void add_recovered_successors(const std::vector<IndirectCallFixup> &recovered,
+void add_recovered_successors(std::span<const IndirectCallFixup> recovered,
                               std::vector<AnalysisBlock> &blocks) {
   // Recovered indirect edges are not part of the first direct-CFG graph, but
   // they are real control flow once proven. Feeding them into the next
@@ -1949,8 +1970,9 @@ struct VectorLaneFlowState {
 
 void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<AnalysisBlock> &blocks,
                                      std::vector<IndirectCallFixup> &recovered,
-                                     std::span<const uint64_t> extra_leaders,
-                                     ExternalEntryPolicy entry_policy) {
+                                     std::span<const uint64_t> external_entry_offsets,
+                                     ExternalEntryPolicy entry_policy,
+                                     std::span<const IndirectCallFixup> focus_fixups) {
   // gfx1250 device functions sometimes keep a small static call set in one
   // VGPR: getpc-built low/high halves are written to fixed lanes, then read
   // back into an SGPR pair before swappc. Track only fixed-lane
@@ -1973,12 +1995,15 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
   // This pass only observes MODE; it never inserts or reorders
   // S_SETREG/S_SET_VGPR_MSB and therefore cannot violate the required co-issue
   // spacing.
-  if (ctx.arch != ROCJITSU_CODE_ARCH_GFX1250)
+  if (ctx.arch != ROCJITSU_CODE_ARCH_GFX1250 || !ctx.has_vector_lane_write ||
+      ctx.vector_lane_read_offsets.empty()) {
     return;
+  }
 
   if (blocks.empty())
     return;
-  const std::vector<uint8_t> external_entries = explicit_external_entries(blocks, extra_leaders);
+  const std::vector<uint8_t> external_entries =
+      explicit_external_entries(blocks, external_entry_offsets);
 
   const auto changes_vgpr_msb_bank = [](std::string_view mnemonic) {
     return mnemonic == "s_set_vgpr_msb" || mnemonic == "s_setreg_b32" ||
@@ -2147,13 +2172,76 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
       predecessors[successor].push_back(block_index);
   }
 
+  std::vector<uint8_t> active_blocks(blocks.size(), 1);
+  if (!focus_fixups.empty()) {
+    std::ranges::fill(active_blocks, uint8_t{0});
+    std::unordered_map<uint64_t, size_t> block_by_offset;
+    block_by_offset.reserve(blocks.size());
+    for (size_t block_index = 0; block_index < blocks.size(); ++block_index)
+      block_by_offset.emplace(blocks[block_index].offset, block_index);
+
+    std::vector<uint8_t> forward(blocks.size(), 0);
+    std::deque<size_t> worklist;
+    for (const IndirectCallFixup &fixup : focus_fixups) {
+      const auto target = block_by_offset.find(fixup.source_target_offset);
+      if (target == block_by_offset.end() || forward[target->second] != 0)
+        continue;
+      forward[target->second] = 1;
+      worklist.push_back(target->second);
+    }
+    while (!worklist.empty()) {
+      const size_t block_index = worklist.front();
+      worklist.pop_front();
+      for (const size_t successor : blocks[block_index].successors) {
+        if (forward[successor] != 0)
+          continue;
+        forward[successor] = 1;
+        worklist.push_back(successor);
+      }
+    }
+
+    const auto block_containing = [&](uint64_t offset) -> std::optional<size_t> {
+      auto it = std::upper_bound(
+          blocks.begin(), blocks.end(), offset,
+          [](uint64_t value, const AnalysisBlock &block) { return value < block.offset; });
+      if (it == blocks.begin())
+        return std::nullopt;
+      return static_cast<size_t>(std::distance(blocks.begin(), std::prev(it)));
+    };
+    for (const uint64_t read_offset : ctx.vector_lane_read_offsets) {
+      const auto block_index = block_containing(read_offset);
+      if (!block_index || forward[*block_index] == 0 || active_blocks[*block_index] != 0)
+        continue;
+      active_blocks[*block_index] = 1;
+      worklist.push_back(*block_index);
+    }
+    while (!worklist.empty()) {
+      const size_t block_index = worklist.front();
+      worklist.pop_front();
+      if (is_analysis_root(block_index, external_entries, predecessors, entry_policy))
+        continue;
+      for (const size_t predecessor : predecessors[block_index]) {
+        if (active_blocks[predecessor] != 0)
+          continue;
+        active_blocks[predecessor] = 1;
+        worklist.push_back(predecessor);
+      }
+    }
+    if (std::ranges::none_of(active_blocks, [](uint8_t active) { return active != 0; }))
+      return;
+  }
+
   std::vector<VectorLaneFlowState> entry_states(blocks.size());
   std::vector<VectorLaneFlowState> exit_states(blocks.size());
   std::vector<uint8_t> reachable(blocks.size(), 0);
-  std::vector<uint8_t> on_worklist(blocks.size(), 1);
+  std::vector<uint8_t> on_worklist(blocks.size(), 0);
   std::deque<size_t> worklist;
-  for (size_t block_index = 0; block_index < blocks.size(); ++block_index)
+  for (size_t block_index = 0; block_index < blocks.size(); ++block_index) {
+    if (active_blocks[block_index] == 0)
+      continue;
     worklist.push_back(block_index);
+    on_worklist[block_index] = 1;
+  }
 
   while (!worklist.empty()) {
     const size_t block_index = worklist.front();
@@ -2202,6 +2290,16 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
         if (new_entry.vgpr_msb_imm != external_entry.vgpr_msb_imm)
           new_entry.vgpr_msb_imm = std::nullopt;
       }
+      if (!focus_fixups.empty() && external_entries[block_index] != 0 &&
+          std::ranges::any_of(predecessors[block_index], [&](size_t predecessor) {
+            return active_blocks[predecessor] == 0;
+          })) {
+        // Focused re-analysis stops at explicit callable entries because the
+        // external path clears every incoming lane stash. An inactive
+        // structural predecessor can still carry a different MODE bank, so
+        // keep bank selection unknown rather than assuming the entry default.
+        new_entry.vgpr_msb_imm = std::nullopt;
+      }
     }
     if (!new_reachable)
       continue;
@@ -2215,7 +2313,7 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
     entry_states[block_index] = std::move(new_entry);
     exit_states[block_index] = std::move(new_exit);
     for (size_t successor : blocks[block_index].successors) {
-      if (on_worklist[successor])
+      if (active_blocks[successor] == 0 || on_worklist[successor])
         continue;
       worklist.push_back(successor);
       on_worklist[successor] = 1;
@@ -2223,9 +2321,90 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
   }
 
   for (size_t block_index = 0; block_index < blocks.size(); ++block_index) {
-    if (reachable[block_index])
+    if (active_blocks[block_index] != 0 && reachable[block_index])
       (void)scan_block(blocks[block_index], entry_states[block_index], true);
   }
+}
+
+[[nodiscard]] std::vector<IndirectCallFixup>
+recovered_edges_enabling_vector_lane_flow(const AnalysisContext &ctx,
+                                          const std::vector<AnalysisBlock> &blocks,
+                                          std::span<const uint64_t> external_entry_offsets,
+                                          std::span<const IndirectCallFixup> newly_recovered) {
+  if (newly_recovered.empty() || !ctx.has_vector_lane_write ||
+      ctx.vector_lane_read_offsets.empty() || blocks.empty()) {
+    return {};
+  }
+
+  const auto block_containing = [&](uint64_t offset) -> std::optional<size_t> {
+    auto it = std::upper_bound(
+        blocks.begin(), blocks.end(), offset,
+        [](uint64_t value, const AnalysisBlock &block) { return value < block.offset; });
+    if (it == blocks.begin())
+      return std::nullopt;
+    return static_cast<size_t>(std::distance(blocks.begin(), std::prev(it)));
+  };
+
+  std::unordered_set<uint64_t> external_entries(external_entry_offsets.begin(),
+                                                external_entry_offsets.end());
+  external_entries.insert(blocks.front().offset);
+  std::vector<std::pair<const IndirectCallFixup *, size_t>> candidates;
+  candidates.reserve(newly_recovered.size());
+  for (const IndirectCallFixup &fixup : newly_recovered) {
+    if (external_entries.contains(fixup.source_target_offset))
+      continue;
+    if (const auto target = block_containing(fixup.source_target_offset))
+      candidates.emplace_back(&fixup, *target);
+  }
+  if (candidates.empty())
+    return {};
+
+  std::vector<std::vector<size_t>> predecessors(blocks.size());
+  for (size_t block_index = 0; block_index < blocks.size(); ++block_index) {
+    for (const size_t successor : blocks[block_index].successors)
+      predecessors[successor].push_back(block_index);
+  }
+
+  std::vector<uint8_t> can_reach_readlane(blocks.size(), 0);
+  std::deque<size_t> worklist;
+  size_t read_block = 0;
+  for (const uint64_t read_offset : ctx.vector_lane_read_offsets) {
+    while (read_block + 1 < blocks.size() && blocks[read_block + 1].offset <= read_offset)
+      ++read_block;
+    if (can_reach_readlane[read_block] != 0)
+      continue;
+    can_reach_readlane[read_block] = 1;
+    worklist.push_back(read_block);
+  }
+  while (!worklist.empty()) {
+    const size_t block_index = worklist.front();
+    worklist.pop_front();
+    if (external_entries.contains(blocks[block_index].offset))
+      continue;
+    for (const size_t predecessor : predecessors[block_index]) {
+      if (can_reach_readlane[predecessor] != 0)
+        continue;
+      can_reach_readlane[predecessor] = 1;
+      worklist.push_back(predecessor);
+    }
+  }
+
+  std::vector<IndirectCallFixup> relevant;
+  for (const auto &[fixup, target] : candidates) {
+    if (can_reach_readlane[target] == 0)
+      continue;
+
+    const AnalysisBlock &block = blocks[target];
+    const auto read =
+        std::ranges::lower_bound(ctx.vector_lane_read_offsets, fixup->source_target_offset);
+    const bool read_in_target_suffix = read != ctx.vector_lane_read_offsets.end() &&
+                                       *read <= ctx.insts[block.last_index]->src_loc();
+    const bool successor_reaches_read = std::ranges::any_of(
+        block.successors, [&](size_t successor) { return can_reach_readlane[successor] != 0; });
+    if (read_in_target_suffix || successor_reaches_read)
+      relevant.push_back(*fixup);
+  }
+  return relevant;
 }
 
 void recover_signed_delta_templates(const AnalysisContext &ctx,
@@ -2336,11 +2515,12 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
 
 [[nodiscard]] std::vector<IndirectCallFixup> discover_indirect_branch_edges_unfiltered(
     std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,
-    std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy,
-    std::vector<PcAddressBuilder> *pc_builders) {
+    std::span<const uint64_t> block_leaders, std::span<const uint64_t> external_entries,
+    ExternalEntryPolicy entry_policy, std::vector<PcAddressBuilder> *pc_builders) {
   std::vector<IndirectCallFixup> recovered;
   AnalysisContext ctx = build_context(insts, text, arch);
-  std::vector<uint64_t> leaders(extra_leaders.begin(), extra_leaders.end());
+  std::vector<uint64_t> leaders(block_leaders.begin(), block_leaders.end());
+  std::vector<IndirectCallFixup> vector_lane_focus;
 
   PcAddressBuilderMap round_builders;
   for (size_t iteration = 0; iteration < kMaxIndirectDiscoveryIterations; ++iteration) {
@@ -2352,10 +2532,13 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
     std::vector<PendingConsumer> pending_consumers;
     std::vector<IndirectCallFixup> iteration_recovered;
     // Lane-stash recovery consumes the same graph as scalar recovery, including
-    // edges proven in earlier rounds. Keep extra_leaders separate from leaders:
-    // recovered targets become reachable through those edges, not by being
-    // promoted to external roots.
-    recover_vector_lane_stashed_pcs(ctx, blocks, iteration_recovered, extra_leaders, entry_policy);
+    // edges proven in earlier rounds. The first pass covers the complete direct
+    // CFG. Later passes are restricted to newly reachable paths that can carry
+    // a stashed PC to a readlane consumer.
+    if (iteration == 0 || !vector_lane_focus.empty()) {
+      recover_vector_lane_stashed_pcs(ctx, blocks, iteration_recovered, external_entries,
+                                      entry_policy, vector_lane_focus);
+    }
     // Recovered leaders can split a block between rounds, which changes where a
     // builder's block-exit value is observed. Keep only the final round's view
     // so the published records are internally consistent with one CFG.
@@ -2364,17 +2547,25 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
       scan_block(ctx, block_index, blocks, pending_consumers, iteration_recovered, round_builders);
     recover_signed_delta_templates(ctx, blocks, iteration_recovered);
 
+    size_t unresolved_consumers = 0;
     if (!pending_consumers.empty()) {
       const auto entry_facts =
-          run_block_dataflow(blocks, pending_consumers, extra_leaders, entry_policy);
-      (void)classify_pending_consumers(ctx, blocks, entry_facts, pending_consumers,
-                                       iteration_recovered);
+          run_block_dataflow(blocks, pending_consumers, external_entries, entry_policy);
+      unresolved_consumers = classify_pending_consumers(ctx, blocks, entry_facts, pending_consumers,
+                                                        iteration_recovered);
     }
 
     bool changed = false;
-    for (const IndirectCallFixup &fixup : iteration_recovered)
-      changed |= append_unique(recovered, fixup);
-    if (!changed)
+    std::vector<IndirectCallFixup> newly_recovered;
+    for (const IndirectCallFixup &fixup : iteration_recovered) {
+      if (!append_unique(recovered, fixup))
+        continue;
+      changed = true;
+      newly_recovered.push_back(fixup);
+    }
+    vector_lane_focus =
+        recovered_edges_enabling_vector_lane_flow(ctx, blocks, external_entries, newly_recovered);
+    if (!changed || (unresolved_consumers == 0 && vector_lane_focus.empty()))
       break;
   }
 
@@ -2396,6 +2587,14 @@ std::vector<IndirectCallFixup> discover_indirect_branch_edges(
     std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,
     std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy,
     std::vector<PcAddressBuilder> *pc_builders) {
+  return discover_indirect_branch_edges(insts, text, arch, extra_leaders, extra_leaders,
+                                        entry_policy, pc_builders);
+}
+
+std::vector<IndirectCallFixup> discover_indirect_branch_edges(
+    std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,
+    std::span<const uint64_t> block_leaders, std::span<const uint64_t> external_entries,
+    ExternalEntryPolicy entry_policy, std::vector<PcAddressBuilder> *pc_builders) {
   if (pc_builders != nullptr)
     pc_builders->clear();
   if (insts.empty())
@@ -2414,14 +2613,14 @@ std::vector<IndirectCallFixup> discover_indirect_branch_edges(
     // Keep the cheap predicate coupled to every fixup producer. A future
     // recovery path for another consumer kind must extend the predicate above.
     const auto unfiltered = discover_indirect_branch_edges_unfiltered(
-        insts, text, arch, extra_leaders, entry_policy, nullptr);
+        insts, text, arch, block_leaders, external_entries, entry_policy, nullptr);
     assert(unfiltered.empty() && "indirect-recovery prefilter skipped a fixup-producing consumer");
 #endif
     return {};
   }
 
-  return discover_indirect_branch_edges_unfiltered(insts, text, arch, extra_leaders, entry_policy,
-                                                   pc_builders);
+  return discover_indirect_branch_edges_unfiltered(insts, text, arch, block_leaders,
+                                                   external_entries, entry_policy, pc_builders);
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
@@ -134,4 +134,17 @@ struct PcAddressBuilder {
     ExternalEntryPolicy entry_policy = ExternalEntryPolicy::InferPredecessorless,
     std::vector<PcAddressBuilder> *pc_builders = nullptr);
 
+/// @brief Recover indirect branch and call targets with distinct CFG split points and roots.
+///
+/// @param block_leaders Additional offsets that must start analysis blocks.
+/// @param external_entries Offsets whose incoming register state is unconstrained.
+/// @param entry_policy Whether other predecessorless blocks are inferred to be external entries.
+/// @param pc_builders Optional sink for every discovered PC-relative address producer.
+/// @returns Recovered indirect branch/call metadata.
+[[nodiscard]] std::vector<IndirectCallFixup> discover_indirect_branch_edges(
+    std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,
+    std::span<const uint64_t> block_leaders, std::span<const uint64_t> external_entries,
+    ExternalEntryPolicy entry_policy = ExternalEntryPolicy::ExplicitOnly,
+    std::vector<PcAddressBuilder> *pc_builders = nullptr);
+
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
@@ -107,6 +107,17 @@ LivenessAnalysis::LivenessAnalysis(KernelBlockScope blocks, LivenessAnalysisOpti
   min_free_vgpr_ = options.min_free_vgpr;
   max_free_vgpr_ =
       static_cast<uint16_t>(std::min<size_t>(options.max_free_vgpr, REGISTER_SET_MAX_VGPRS));
+  scratch_reserved_ = options.scratch_reserved;
+  has_scratch_vgpr_range_limits_ = !options.scratch_vgpr_range_limits.empty();
+  scratch_vgpr_range_limits_.assign(options.scratch_vgpr_range_limits.begin(),
+                                    options.scratch_vgpr_range_limits.end());
+  for (size_t i = 0; i < scratch_vgpr_range_limits_.size(); ++i) {
+    assert(scratch_vgpr_range_limits_[i].begin_offset < scratch_vgpr_range_limits_[i].end_offset &&
+           "scratch ranges must be non-empty");
+    assert((i == 0 || scratch_vgpr_range_limits_[i - 1].end_offset <=
+                          scratch_vgpr_range_limits_[i].begin_offset) &&
+           "scratch ranges must be sorted and disjoint");
+  }
   analyze(blocks, options, extra_edges);
 }
 
@@ -121,8 +132,8 @@ void LivenessAnalysis::require_available() const {
 
 void LivenessAnalysis::analyze(KernelBlockScope blocks, const LivenessAnalysisOptions &options,
                                std::span<const ScopedCfgEdge> extra_edges) {
-  if (options.arch == ROCJITSU_CODE_ARCH_GFX1250 && options.entry_block != nullptr) {
-    gfx1250_vgpr_msb_ = std::make_unique<Gfx1250VgprMsbAnalysis>(blocks, options.entry_block,
+  if (options.arch == ROCJITSU_CODE_ARCH_GFX1250 && !options.entry_blocks.empty()) {
+    gfx1250_vgpr_msb_ = std::make_unique<Gfx1250VgprMsbAnalysis>(blocks, options.entry_blocks,
                                                                  extra_edges, options.text);
   }
   liveness_.resize(blocks.size());
@@ -302,9 +313,24 @@ std::optional<uint16_t> LivenessAnalysis::find_free_run(const Instruction *inst,
 
   const RegisterSet &live = live_it->second;
   const size_t first_candidate = std::max<size_t>(search_start, min_free_vgpr_);
+  size_t effective_max = max_free_vgpr_;
+  if (has_scratch_vgpr_range_limits_) {
+    auto range = std::ranges::upper_bound(scratch_vgpr_range_limits_, inst->src_loc(), {},
+                                          &ScratchVgprRangeLimit::begin_offset);
+    if (range == scratch_vgpr_range_limits_.begin()) {
+      effective_max = 0;
+    } else {
+      --range;
+      if (inst->src_loc() < range->end_offset)
+        effective_max = std::min<size_t>(effective_max, range->max_free_vgpr);
+      else
+        effective_max = 0;
+    }
+  }
   for (size_t base = util::align_up(first_candidate, static_cast<size_t>(base_alignment));
-       base + count <= max_free_vgpr_; base += base_alignment) {
-    if (!any_live_in_range(live, RegClass::VGPR, static_cast<uint16_t>(base), count))
+       base + count <= effective_max; base += base_alignment) {
+    if (!any_live_in_range(live, RegClass::VGPR, static_cast<uint16_t>(base), count) &&
+        !any_live_in_range(scratch_reserved_, RegClass::VGPR, static_cast<uint16_t>(base), count))
       return static_cast<uint16_t>(base);
   }
   return std::nullopt;
@@ -317,12 +343,16 @@ std::optional<uint16_t> LivenessAnalysis::find_free_sgpr_pair(const Instruction 
   if (live_it == live_before_.end())
     return std::nullopt;
 
+  // scratch_vgpr_range_limits is deliberately VGPR-only. Supported gfx1250
+  // callables share the fixed 106-SGPR ABI envelope, while scratch_reserved_
+  // carries the SGPRs that an unknown external caller may require preserved.
   const RegisterSet &live = live_it->second;
   size_t base = search_start;
   if (base % 2 != 0)
     ++base; // even-align for s_mov_b64-style pair moves.
   for (; base + 1 < REGISTER_SET_ALLOCATABLE_SGPRS; base += 2) {
-    if (!any_live_in_range(live, RegClass::SGPR, static_cast<uint16_t>(base), 2))
+    if (!any_live_in_range(live, RegClass::SGPR, static_cast<uint16_t>(base), 2) &&
+        !any_live_in_range(scratch_reserved_, RegClass::SGPR, static_cast<uint16_t>(base), 2))
       return static_cast<uint16_t>(base);
   }
   return std::nullopt;
@@ -339,7 +369,8 @@ std::optional<uint16_t> LivenessAnalysis::find_free_sgpr(const Instruction *inst
   // Keep this in sync with find_free_sgpr_pair(): only normal SGPRs that are
   // valid across supported families are candidates for temporary allocation.
   for (size_t base = search_start; base < REGISTER_SET_ALLOCATABLE_SGPRS; ++base) {
-    if (!live.contains({RegClass::SGPR, static_cast<uint16_t>(base), 1}))
+    const RegisterRef candidate{RegClass::SGPR, static_cast<uint16_t>(base), 1};
+    if (!live.contains(candidate) && !scratch_reserved_.contains(candidate))
       return static_cast<uint16_t>(base);
   }
   return std::nullopt;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
@@ -45,6 +45,18 @@ struct ScopedCfgEdge {
   BasicBlock *to = nullptr;
 };
 
+/// @brief Source instruction range with its own scratch-VGPR ceiling.
+///
+/// @details A descriptorless ELF can contain several independently callable
+/// STT_FUNC ranges with different source allocation envelopes. A register used
+/// by one function does not prove that an unrelated caller allocated it for
+/// another function, so scratch allocation must honor the containing range.
+struct ScratchVgprRangeLimit {
+  uint64_t begin_offset = 0;
+  uint64_t end_offset = 0;
+  uint16_t max_free_vgpr = 0;
+};
+
 /// @brief Block-level dataflow state for one kernel scope.
 ///
 /// @details `gen` is the upward-exposed use set: registers read in the block
@@ -64,12 +76,17 @@ struct LivenessAnalysisOptions {
   /// @brief Architecture whose register semantics should be analyzed.
   ///
   /// @details INVALID preserves the legacy ISA-independent behavior. DBT sets
-  /// this to gfx1250 together with entry_block so VGPR_MSB state can resolve
+  /// this to gfx1250 together with entry_blocks so VGPR_MSB state can resolve
   /// encoded vector operands to physical VGPRs.
   rj_code_arch_t arch = ROCJITSU_CODE_ARCH_INVALID;
 
-  /// @brief Kernel entry block where architectural VGPR_MSB state is zero.
-  BasicBlock *entry_block = nullptr;
+  /// @brief All ABI entry blocks where architectural VGPR_MSB state is zero.
+  ///
+  /// @details Linked descriptorless libraries can expose several independent
+  /// STT_FUNC entries in one analysis scope. Each entry starts with the ABI
+  /// default bank state; seeding only the first would leave later callables
+  /// unreachable to forward VGPR_MSB analysis.
+  std::span<BasicBlock *const> entry_blocks = {};
 
   /// @brief Lowest VGPR index that find_free_run() may return.
   ///
@@ -86,6 +103,21 @@ struct LivenessAnalysisOptions {
   /// prevents 8-bit destination fields from truncating v256 and above.
   uint16_t max_free_vgpr = static_cast<uint16_t>(
       std::min(amdgpu::CdnaIsaBase::MAX_VGPRS_PER_WF, amdgpu::RdnaIsaBase::MAX_VGPRS_PER_WF));
+
+  /// @brief Registers that scratch allocation must never borrow.
+  ///
+  /// @details This is independent of program liveness. Callers use it for ABI
+  /// registers whose values are not represented by an in-object CFG edge, such
+  /// as unknown descriptorless-function return values and callee-saved
+  /// registers that the original function did not touch.
+  RegisterSet scratch_reserved;
+
+  /// @brief Optional per-source-range exclusive VGPR allocation ceilings.
+  ///
+  /// @details When non-empty, an instruction outside every listed range has no
+  /// scratch VGPRs available. Ranges must be non-empty, source ordered, and
+  /// disjoint.
+  std::span<const ScratchVgprRangeLimit> scratch_vgpr_range_limits = {};
 
   /// @brief Restrict instruction-level live-before materialization to selected instructions.
   ///
@@ -204,6 +236,9 @@ private:
   bool available_ = true;
   uint16_t min_free_vgpr_ = 0;
   uint16_t max_free_vgpr_ = 0;
+  RegisterSet scratch_reserved_;
+  bool has_scratch_vgpr_range_limits_ = false;
+  std::vector<ScratchVgprRangeLimit> scratch_vgpr_range_limits_;
   std::unique_ptr<Gfx1250VgprMsbAnalysis> gfx1250_vgpr_msb_;
   std::vector<BlockLiveness> liveness_;
   std::unordered_map<const BasicBlock *, size_t> block_index_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
@@ -181,14 +181,20 @@ inline constexpr uint32_t SHT_DYNSYM = 11;
 inline constexpr uint32_t R_AMDGPU_ABS64 = 3;
 inline constexpr uint32_t R_AMDGPU_RELATIVE64 = 13;
 
+inline constexpr uint8_t kElfSymbolBindLocal = 0;
 inline constexpr uint8_t kElfSymbolBindGlobal = 1;
-inline constexpr uint8_t kElfSymbolTypeNone = 0;    // STT_NOTYPE
-inline constexpr uint8_t kElfSymbolTypeObject = 1;  // STT_OBJECT
-inline constexpr uint8_t kElfSymbolTypeFunc = 2;    // STT_FUNC
-inline constexpr uint8_t kElfSymbolTypeSection = 3; // STT_SECTION
+inline constexpr uint8_t kElfSymbolBindWeak = 2;
+inline constexpr uint8_t kElfSymbolVisibilityDefault = 0;
+inline constexpr uint8_t kElfSymbolVisibilityProtected = 3;
+inline constexpr uint8_t kElfSymbolTypeNone = 0;             // STT_NOTYPE
+inline constexpr uint8_t kElfSymbolTypeObject = 1;           // STT_OBJECT
+inline constexpr uint8_t kElfSymbolTypeFunc = 2;             // STT_FUNC
+inline constexpr uint8_t kElfSymbolTypeSection = 3;          // STT_SECTION
+inline constexpr uint8_t kElfSymbolTypeAmdGpuHsaKernel = 10; // STT_AMDGPU_HSA_KERNEL
 
 inline constexpr uint8_t elf_symbol_bind(uint8_t info) { return info >> 4; }
 inline constexpr uint8_t elf_symbol_type(uint8_t info) { return info & 0xf; }
+inline constexpr uint8_t elf_symbol_visibility(uint8_t other) { return other & 0x3; }
 inline constexpr uint8_t elf_symbol_info(uint8_t bind, uint8_t type) {
   return static_cast<uint8_t>((bind << 4) | (type & 0xf));
 }
@@ -215,6 +221,11 @@ inline constexpr uint32_t NT_AMDGPU_METADATA = 32;
 inline constexpr uint32_t PT_LOAD = 1;
 inline constexpr uint32_t PT_DYNAMIC = 2;
 inline constexpr uint32_t PT_NOTE = 4;
+
+// Program-header permission bits.
+inline constexpr uint32_t PF_X = 1u << 0;
+inline constexpr uint32_t PF_W = 1u << 1;
+inline constexpr uint32_t PF_R = 1u << 2;
 
 // Dynamic section tags.
 inline constexpr int64_t DT_NULL = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
@@ -47,16 +47,6 @@ uint32_t first_word(const Instruction &inst) {
   return raw == nullptr ? 0 : raw[0];
 }
 
-bool s_setpc_from_sreg(const Instruction &inst, uint32_t word, uint16_t ssrc0) {
-  // gfx1250 renamed the scalar PC transfer without changing its role in the
-  // call/return CFG. Accept both spellings; the raw source operand remains in
-  // the low byte for the canonical one-word form.
-  const std::string_view mnemonic = inst.mnemonic();
-  if (inst.size() != sizeof(uint32_t) || (mnemonic != "s_setpc_b64" && mnemonic != "s_set_pc_i64"))
-    return false;
-  return static_cast<uint16_t>(word & 0xffu) == ssrc0;
-}
-
 bool has_exact_words(const Instruction &inst, std::span<const uint32_t> words) {
   if (inst.size() != static_cast<int>(words.size_bytes()) || inst.raw_encoding() == nullptr)
     return false;
@@ -92,6 +82,16 @@ struct DeferredCallSite {
 };
 
 } // namespace
+
+bool s_setpc_from_sreg(const Instruction &inst, uint32_t word, uint16_t ssrc0) {
+  // gfx1250 renamed the scalar PC transfer without changing its role in the
+  // call/return CFG. Accept both spellings; the raw source operand remains in
+  // the low byte for the canonical one-word form.
+  const std::string_view mnemonic = inst.mnemonic();
+  if (inst.size() != sizeof(uint32_t) || (mnemonic != "s_setpc_b64" && mnemonic != "s_set_pc_i64"))
+    return false;
+  return static_cast<uint16_t>(word & 0xffu) == ssrc0;
+}
 
 BasicBlock::BasicBlock(uint64_t start_offset) : start_offset_(start_offset) {}
 
@@ -173,6 +173,13 @@ std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co,
                                                            rj_code_arch_t arch,
                                                            std::span<const uint64_t> extra_leaders,
                                                            ExternalEntryPolicy entry_policy) {
+  return build(co, decoder, arch, extra_leaders, extra_leaders, entry_policy);
+}
+
+std::vector<std::unique_ptr<BasicBlock>>
+BasicBlock::build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
+                  std::span<const uint64_t> block_leaders,
+                  std::span<const uint64_t> external_entries, ExternalEntryPolicy entry_policy) {
   std::vector<std::unique_ptr<BasicBlock>> blocks;
 
   for (const auto *sec : co.text_sections()) {
@@ -230,12 +237,13 @@ std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co,
     const auto decoded_span =
         std::span<const Instruction *const>(decoded_insts.data(), decoded_insts.size());
     std::vector<PcAddressBuilder> pc_address_builders;
-    std::vector<IndirectCallFixup> recovered_indirect_targets = discover_indirect_branch_edges(
-        decoded_span, text, arch, extra_leaders, entry_policy, &pc_address_builders);
+    std::vector<IndirectCallFixup> recovered_indirect_targets =
+        discover_indirect_branch_edges(decoded_span, text, arch, block_leaders, external_entries,
+                                       entry_policy, &pc_address_builders);
 
     std::set<uint64_t> leaders;
     leaders.insert(decoded.front()->src_loc());
-    for (uint64_t leader : extra_leaders) {
+    for (uint64_t leader : block_leaders) {
       if (leader < section_end)
         leaders.insert(leader);
     }
@@ -438,7 +446,8 @@ std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co,
         block.add_successor(*fallthrough_it->second);
     }
 
-    std::unordered_set<uint64_t> kernel_entry_offsets(extra_leaders.begin(), extra_leaders.end());
+    std::unordered_set<uint64_t> kernel_entry_offsets(external_entries.begin(),
+                                                      external_entries.end());
     std::vector<std::vector<CallReturnClassification>> classifications;
     classifications.reserve(deferred_calls.size());
     for (const DeferredCallSite &site : deferred_calls)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.h
@@ -21,6 +21,10 @@ namespace rocjitsu {
 
 class CodeObject;
 class Decoder;
+class Instruction;
+
+/// @brief Whether @p inst is an exact scalar set-PC through @p ssrc0.
+[[nodiscard]] bool s_setpc_from_sreg(const Instruction &inst, uint32_t word, uint16_t ssrc0);
 
 /// @brief A maximal sequence of instructions with single entry, single exit.
 ///
@@ -164,6 +168,17 @@ public:
   build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
         std::span<const uint64_t> extra_leaders = {},
         ExternalEntryPolicy entry_policy = ExternalEntryPolicy::InferPredecessorless);
+
+  /// @brief Build blocks with distinct split points and external analysis roots.
+  ///
+  /// @param[in] block_leaders Byte offsets that must start a basic block.
+  /// @param[in] external_entries Block offsets that may be entered from outside
+  /// the recovered direct CFG. Unlike block boundaries, these seed conservative
+  /// register state in indirect-control-flow analysis.
+  static std::vector<std::unique_ptr<BasicBlock>>
+  build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
+        std::span<const uint64_t> block_leaders, std::span<const uint64_t> external_entries,
+        ExternalEntryPolicy entry_policy = ExternalEntryPolicy::ExplicitOnly);
 
 private:
   void add_instruction(std::unique_ptr<Instruction> inst);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -4,6 +4,7 @@
 #include "rocjitsu/code/dbt/binary_translator.h"
 
 #include "rocjitsu/analysis/def_use_chain.h"
+#include "rocjitsu/analysis/gfx1250_vgpr_msb.h"
 #include "rocjitsu/analysis/liveness.h"
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
@@ -32,6 +33,7 @@
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/isa_traits.h"
+#include "util/except.h"
 
 #include <algorithm>
 #include <array>
@@ -136,6 +138,394 @@ void append_diagnostics(std::vector<TranslationDiagnostic> &dst,
   dst.insert(dst.end(), src.begin(), src.end());
 }
 
+[[nodiscard]] bool image_contains_range(size_t image_size, uint64_t offset, uint64_t size) {
+  return offset <= image_size && size <= image_size - offset;
+}
+
+[[nodiscard]] bool interval_contains(uint64_t outer_begin, uint64_t outer_size,
+                                     uint64_t inner_begin, uint64_t inner_size) {
+  return inner_begin >= outer_begin && inner_begin - outer_begin <= outer_size &&
+         inner_size <= outer_size - (inner_begin - outer_begin);
+}
+
+/// @brief One decoded, non-empty ELF function-symbol extent in `.text`.
+struct CallableFunctionRange {
+  uint64_t begin = 0;
+  uint64_t end = 0;
+  std::string name;
+  uint8_t binding = kElfSymbolBindLocal;
+  uint8_t visibility = kElfSymbolVisibilityDefault;
+
+  [[nodiscard]] bool externally_visible() const {
+    return (binding == kElfSymbolBindGlobal || binding == kElfSymbolBindWeak) &&
+           (visibility == kElfSymbolVisibilityDefault ||
+            visibility == kElfSymbolVisibilityProtected);
+  }
+};
+
+/// @brief Exhaustive ELF facts used to distinguish data-only objects from code.
+///
+/// The translator itself currently rewrites one canonical `.text` section, but
+/// deciding that an object has no executable work cannot use that implementation
+/// detail. This analysis independently inspects every executable section,
+/// executable PT_LOAD, executable symbol, descriptor-shaped symbol, and
+/// relocation target. Unsupported executable layouts fail closed instead of
+/// being mistaken for a successful no-op.
+struct ExecutableElfAnalysis {
+  bool valid = false;
+  bool data_only = false;
+  bool canonical_text_supported = false;
+  bool assume_llvm_amdhsa_callable_abi = false;
+  bool has_kernel_or_descriptor_symbol = false;
+  size_t canonical_text_index = 0;
+  uint64_t canonical_text_offset = 0;
+  uint64_t canonical_text_size = 0;
+  uint64_t canonical_text_vaddr = 0;
+  std::vector<CallableFunctionRange> callable_functions;
+  std::vector<uint64_t> zero_sized_function_entries;
+  std::string error;
+};
+
+[[nodiscard]] ExecutableElfAnalysis analyze_executable_elf(std::span<const uint8_t> image,
+                                                           uint64_t selected_text_offset,
+                                                           uint64_t selected_text_size) {
+  ExecutableElfAnalysis result;
+  auto fail = [&](std::string message) {
+    result.error = std::move(message);
+    return std::move(result);
+  };
+
+  if (image.size() < sizeof(Elf64_Ehdr))
+    return fail("code object is too small to contain an ELF header");
+
+  Elf64_Ehdr header{};
+  std::memcpy(&header, image.data(), sizeof(header));
+  if (std::memcmp(header.e_ident, EI_MAGIC, EI_MAGIC_SIZE) != 0 ||
+      header.e_ident[EI_CLASS] != ELFCLASS64 || header.e_machine != EM_AMDGPU) {
+    return fail("code object does not contain a supported AMDGPU ELF64 image");
+  }
+  // Inferring a callable ABI from these ELF fields alone is not generally
+  // safe: they establish the linked AMDHSA shape, but not the producer or
+  // calling convention. All descriptorless STT_FUNC inputs known to us are
+  // LLVM-produced, so assume its C/Fast/Cold callable ABI for this shape.
+  // TODO: Generalize this policy when another descriptorless producer is
+  // identified or a reliable producer/convention marker becomes available.
+  result.assume_llvm_amdhsa_callable_abi =
+      header.e_ident[EI_OSABI] == ELFOSABI_AMDGPU_HSA && header.e_type == ET_DYN &&
+      header.e_ident[EI_ABIVERSION] >= ELFABIVERSION_AMDGPU_HSA_V4 &&
+      header.e_ident[EI_ABIVERSION] <= ELFABIVERSION_AMDGPU_HSA_V6;
+  if (header.e_shnum == 0 || header.e_shentsize != sizeof(Elf64_Shdr) ||
+      !image_contains_range(image.size(), header.e_shoff,
+                            static_cast<uint64_t>(header.e_shnum) * sizeof(Elf64_Shdr))) {
+    return fail("code object has an invalid section-header table");
+  }
+
+  std::vector<Elf64_Shdr> sections(header.e_shnum);
+  std::memcpy(sections.data(), image.data() + header.e_shoff, sections.size() * sizeof(Elf64_Shdr));
+  if (header.e_shstrndx >= sections.size()) {
+    return fail("code object has an invalid section-name string table index");
+  }
+  const Elf64_Shdr &shstrtab = sections[header.e_shstrndx];
+  if (shstrtab.sh_type != SHT_STRTAB ||
+      !image_contains_range(image.size(), shstrtab.sh_offset, shstrtab.sh_size)) {
+    return fail("code object has an invalid section-name string table");
+  }
+  const char *section_names = reinterpret_cast<const char *>(image.data() + shstrtab.sh_offset);
+  auto section_name = [&](size_t index) -> std::optional<std::string_view> {
+    if (index >= sections.size() || sections[index].sh_name >= shstrtab.sh_size)
+      return std::nullopt;
+    const uint64_t offset = sections[index].sh_name;
+    const size_t available = static_cast<size_t>(shstrtab.sh_size - offset);
+    const char *name = section_names + offset;
+    const size_t length = strnlen(name, available);
+    if (length == available)
+      return std::nullopt;
+    return std::string_view(name, length);
+  };
+
+  std::vector<size_t> nonempty_executable_sections;
+  std::vector<std::pair<uint64_t, uint64_t>> executable_vaddr_ranges;
+  for (size_t i = 0; i < sections.size(); ++i) {
+    const Elf64_Shdr &section = sections[i];
+    if (section.sh_type != SHT_NOBITS &&
+        !image_contains_range(image.size(), section.sh_offset, section.sh_size)) {
+      return fail("code object has a section payload outside the ELF image");
+    }
+    const auto name = section_name(i);
+    if (!name)
+      return fail("code object has an unterminated or invalid section name");
+    if ((section.sh_flags & SHF_EXECINSTR) == 0 || section.sh_size == 0)
+      continue;
+    nonempty_executable_sections.push_back(i);
+    if (section.sh_addr > std::numeric_limits<uint64_t>::max() - section.sh_size)
+      return fail("code object has an overflowing executable section address range");
+    executable_vaddr_ranges.emplace_back(section.sh_addr, section.sh_size);
+  }
+
+  std::vector<Elf64_Phdr> program_headers;
+  bool has_nonempty_executable_segment = false;
+  if (header.e_phnum != 0) {
+    if (header.e_phentsize != sizeof(Elf64_Phdr) ||
+        !image_contains_range(image.size(), header.e_phoff,
+                              static_cast<uint64_t>(header.e_phnum) * sizeof(Elf64_Phdr))) {
+      return fail("code object has an invalid program-header table");
+    }
+    program_headers.resize(header.e_phnum);
+    std::memcpy(program_headers.data(), image.data() + header.e_phoff,
+                program_headers.size() * sizeof(Elf64_Phdr));
+    for (const Elf64_Phdr &program : program_headers) {
+      if (program.p_type != PT_LOAD)
+        continue;
+      if (!image_contains_range(image.size(), program.p_offset, program.p_filesz))
+        return fail("code object has a PT_LOAD payload outside the ELF image");
+      if ((program.p_flags & PF_X) == 0 || (program.p_filesz == 0 && program.p_memsz == 0))
+        continue;
+      has_nonempty_executable_segment = true;
+      if (program.p_vaddr > std::numeric_limits<uint64_t>::max() - program.p_memsz)
+        return fail("code object has an overflowing executable PT_LOAD address range");
+      executable_vaddr_ranges.emplace_back(program.p_vaddr, program.p_memsz);
+    }
+  }
+
+  if (nonempty_executable_sections.size() == 1) {
+    const size_t index = nonempty_executable_sections.front();
+    const Elf64_Shdr &text = sections[index];
+    const auto name = section_name(index);
+    if (name && *name == ".text" && text.sh_type == SHT_PROGBITS &&
+        text.sh_offset == selected_text_offset && text.sh_size == selected_text_size) {
+      result.canonical_text_supported = true;
+      result.canonical_text_index = index;
+      result.canonical_text_offset = text.sh_offset;
+      result.canonical_text_size = text.sh_size;
+      result.canonical_text_vaddr = text.sh_addr;
+    }
+  }
+
+  // A linked executable object must not hide non-zero instructions in an
+  // executable segment outside the one section DBT rewrites. Zero file padding
+  // is harmless (zero is not a gfx1250 instruction), but any other byte is an
+  // executable payload that would otherwise bypass translation.
+  if (result.canonical_text_supported) {
+    const uint64_t text_file_begin = result.canonical_text_offset;
+    const uint64_t text_file_size = result.canonical_text_size;
+    const uint64_t text_vaddr_begin = result.canonical_text_vaddr;
+    bool text_is_loaded_executable = header.e_type == ET_REL;
+    for (const Elf64_Phdr &program : program_headers) {
+      if (program.p_type != PT_LOAD || (program.p_flags & PF_X) == 0 ||
+          (program.p_filesz == 0 && program.p_memsz == 0)) {
+        continue;
+      }
+      const bool file_contains_text =
+          interval_contains(program.p_offset, program.p_filesz, text_file_begin, text_file_size);
+      const bool text_contains_file =
+          interval_contains(text_file_begin, text_file_size, program.p_offset, program.p_filesz);
+      const bool memory_contains_text =
+          interval_contains(program.p_vaddr, program.p_memsz, text_vaddr_begin, text_file_size);
+      const bool text_contains_memory =
+          interval_contains(text_vaddr_begin, text_file_size, program.p_vaddr, program.p_memsz);
+      if (file_contains_text && memory_contains_text)
+        text_is_loaded_executable = true;
+
+      const uint64_t segment_begin = program.p_offset;
+      const uint64_t segment_end = program.p_offset + program.p_filesz;
+      const uint64_t text_file_end = text_file_begin + text_file_size;
+      const auto contains_nonzero_bytes = [&](uint64_t begin, uint64_t end) {
+        if (begin >= end)
+          return false;
+        return std::ranges::any_of(
+            image.subspan(static_cast<size_t>(begin), static_cast<size_t>(end - begin)),
+            [](uint8_t byte) { return byte != 0; });
+      };
+      // Inspect only the segment gaps around .text. Scanning through the text
+      // body itself made this structural guard needlessly O(code size).
+      const uint64_t prefix_end = std::min(segment_end, text_file_begin);
+      const uint64_t suffix_begin = std::max(segment_begin, text_file_end);
+      if (contains_nonzero_bytes(segment_begin, prefix_end) ||
+          contains_nonzero_bytes(suffix_begin, segment_end)) {
+        result.canonical_text_supported = false;
+      }
+      if (!result.canonical_text_supported)
+        break;
+      // Every executable mapping must describe this .text allocation. A
+      // disjoint or only-partially-overlapping segment is another executable
+      // payload even when its current file bytes happen to be zero.
+      if ((!file_contains_text && !text_contains_file) ||
+          (!memory_contains_text && !text_contains_memory)) {
+        result.canonical_text_supported = false;
+        break;
+      }
+    }
+    if (!text_is_loaded_executable)
+      result.canonical_text_supported = false;
+  }
+
+  bool has_executable_symbol = false;
+  bool has_executable_relocation_target = false;
+  std::unordered_map<uint64_t, CallableFunctionRange> functions_by_start;
+  std::vector<std::vector<Elf64_Sym>> symbol_tables(sections.size());
+  for (size_t i = 0; i < sections.size(); ++i) {
+    const Elf64_Shdr &symtab = sections[i];
+    if (symtab.sh_type != SHT_SYMTAB && symtab.sh_type != SHT_DYNSYM)
+      continue;
+    if (symtab.sh_entsize != sizeof(Elf64_Sym) || symtab.sh_size % sizeof(Elf64_Sym) != 0 ||
+        !image_contains_range(image.size(), symtab.sh_offset, symtab.sh_size) ||
+        symtab.sh_link >= sections.size()) {
+      return fail("code object has an invalid symbol table");
+    }
+    const Elf64_Shdr &strtab = sections[symtab.sh_link];
+    if (strtab.sh_type != SHT_STRTAB ||
+        !image_contains_range(image.size(), strtab.sh_offset, strtab.sh_size)) {
+      return fail("code object has an invalid symbol string table");
+    }
+    const char *strings = reinterpret_cast<const char *>(image.data() + strtab.sh_offset);
+    const size_t count = static_cast<size_t>(symtab.sh_size / sizeof(Elf64_Sym));
+    auto &symbols = symbol_tables[i];
+    symbols.resize(count);
+    std::memcpy(symbols.data(), image.data() + symtab.sh_offset, symtab.sh_size);
+    for (const Elf64_Sym &symbol : symbols) {
+      if (symbol.st_name >= strtab.sh_size)
+        return fail("code object has a symbol name outside its string table");
+      const size_t available = static_cast<size_t>(strtab.sh_size - symbol.st_name);
+      const char *raw_name = strings + symbol.st_name;
+      const size_t name_size = strnlen(raw_name, available);
+      if (name_size == available)
+        return fail("code object has an unterminated symbol name");
+      const std::string_view name(raw_name, name_size);
+      const uint8_t type = elf_symbol_type(symbol.st_info);
+      const bool descriptor_symbol = name.size() > 3 && name.ends_with(".kd");
+      if (descriptor_symbol || type == kElfSymbolTypeAmdGpuHsaKernel)
+        result.has_kernel_or_descriptor_symbol = true;
+
+      const bool defined_in_section = symbol.st_shndx != SHN_UNDEF && symbol.st_shndx != SHN_ABS &&
+                                      symbol.st_shndx < sections.size();
+      const bool defined_in_executable_section =
+          defined_in_section && (sections[symbol.st_shndx].sh_flags & SHF_EXECINSTR) != 0;
+      if ((type == kElfSymbolTypeFunc && defined_in_executable_section) ||
+          type == kElfSymbolTypeAmdGpuHsaKernel) {
+        has_executable_symbol = true;
+      }
+      if (type != kElfSymbolTypeFunc || !defined_in_executable_section)
+        continue;
+      if (!result.canonical_text_supported || symbol.st_shndx != result.canonical_text_index) {
+        continue;
+      }
+      const Elf64_Shdr &text = sections[result.canonical_text_index];
+      uint64_t begin = symbol.st_value;
+      if (header.e_type != ET_REL) {
+        if (begin < text.sh_addr)
+          return fail("code object has an STT_FUNC value before .text");
+        begin -= text.sh_addr;
+      }
+      if (symbol.st_size == 0) {
+        if (begin % sizeof(uint32_t) != 0 || begin > text.sh_size)
+          return fail("code object has an invalid zero-sized STT_FUNC entry");
+        // Linked AMDGPU kernel symbols commonly remain zero-sized STT_FUNCs.
+        // Retain the entry for later descriptor corroboration; without a .kd at
+        // the same address, its callable extent and ownership are unknowable.
+        result.zero_sized_function_entries.push_back(begin);
+        continue;
+      }
+      if (begin % sizeof(uint32_t) != 0 || symbol.st_size % sizeof(uint32_t) != 0 ||
+          begin > text.sh_size || symbol.st_size > text.sh_size - begin) {
+        return fail("code object has an STT_FUNC range that cannot be translated safely");
+      }
+      CallableFunctionRange function{.begin = begin,
+                                     .end = begin + symbol.st_size,
+                                     .name = std::string(name),
+                                     .binding = elf_symbol_bind(symbol.st_info),
+                                     .visibility = elf_symbol_visibility(symbol.st_other)};
+      auto [it, inserted] = functions_by_start.try_emplace(begin, function);
+      if (!inserted && it->second.end != function.end)
+        return fail("code object has conflicting STT_FUNC ranges for one entry");
+      if (!inserted && (it->second.binding != function.binding ||
+                        it->second.visibility != function.visibility)) {
+        return fail("code object has conflicting STT_FUNC linkage for one entry");
+      }
+      if (!inserted && it->second.name.empty() && !function.name.empty())
+        it->second.name = std::move(function.name);
+    }
+  }
+
+  for (size_t i = 0; i < sections.size(); ++i) {
+    const Elf64_Shdr &relocs = sections[i];
+    if (relocs.sh_type != SHT_RELA && relocs.sh_type != SHT_REL)
+      continue;
+    const bool is_rela = relocs.sh_type == SHT_RELA;
+    const size_t entry_size = is_rela ? sizeof(Elf64_Rela) : sizeof(Elf64_Rel);
+    if (relocs.sh_entsize != entry_size || relocs.sh_size % entry_size != 0 ||
+        !image_contains_range(image.size(), relocs.sh_offset, relocs.sh_size)) {
+      return fail("code object has an invalid relocation section");
+    }
+    const std::vector<Elf64_Sym> *symbols = nullptr;
+    if (relocs.sh_link < symbol_tables.size() && (sections[relocs.sh_link].sh_type == SHT_SYMTAB ||
+                                                  sections[relocs.sh_link].sh_type == SHT_DYNSYM)) {
+      symbols = &symbol_tables[relocs.sh_link];
+    } else if (relocs.sh_link != SHN_UNDEF) {
+      return fail("code object has a relocation section with an invalid symbol table link");
+    }
+    const size_t count = static_cast<size_t>(relocs.sh_size / entry_size);
+    for (size_t j = 0; j < count; ++j) {
+      uint64_t info = 0;
+      int64_t addend = 0;
+      if (is_rela) {
+        Elf64_Rela rela{};
+        std::memcpy(&rela, image.data() + relocs.sh_offset + j * entry_size, sizeof(rela));
+        info = rela.r_info;
+        addend = rela.r_addend;
+      } else {
+        Elf64_Rel rel{};
+        std::memcpy(&rel, image.data() + relocs.sh_offset + j * entry_size, sizeof(rel));
+        info = rel.r_info;
+      }
+      const uint32_t symbol_index = elf_reloc_sym(info);
+      if (symbol_index != 0) {
+        if (symbols == nullptr)
+          return fail("code object has a symbolic relocation without a symbol table");
+        if (symbol_index >= symbols->size())
+          return fail("code object has a relocation with an invalid symbol index");
+        const Elf64_Sym &symbol = (*symbols)[symbol_index];
+        if (symbol.st_shndx < sections.size() &&
+            (sections[symbol.st_shndx].sh_flags & SHF_EXECINSTR) != 0) {
+          has_executable_relocation_target = true;
+        }
+        continue;
+      }
+      if (!is_rela || elf_reloc_type(info) != R_AMDGPU_RELATIVE64 || addend < 0)
+        continue;
+      const uint64_t target = static_cast<uint64_t>(addend);
+      if (std::ranges::any_of(executable_vaddr_ranges, [&](const auto &range) {
+            return target >= range.first && target - range.first < range.second;
+          })) {
+        has_executable_relocation_target = true;
+      }
+    }
+  }
+
+  result.callable_functions.reserve(functions_by_start.size());
+  for (auto &[_, function] : functions_by_start)
+    result.callable_functions.push_back(std::move(function));
+  std::ranges::sort(result.callable_functions, {}, &CallableFunctionRange::begin);
+  std::ranges::sort(result.zero_sized_function_entries);
+  result.zero_sized_function_entries.erase(
+      std::ranges::unique(result.zero_sized_function_entries).begin(),
+      result.zero_sized_function_entries.end());
+  for (size_t i = 1; i < result.callable_functions.size(); ++i) {
+    if (result.callable_functions[i].begin < result.callable_functions[i - 1].end)
+      return fail("code object has overlapping STT_FUNC ranges");
+  }
+
+  const bool has_executable_section = !nonempty_executable_sections.empty();
+  result.data_only = !has_executable_section && !has_nonempty_executable_segment &&
+                     !has_executable_symbol && !result.has_kernel_or_descriptor_symbol &&
+                     !has_executable_relocation_target;
+  if (!result.data_only && !result.canonical_text_supported && result.error.empty()) {
+    result.error =
+        "code object executable content is not confined to one supported non-empty .text section";
+  }
+  result.valid = true;
+  return result;
+}
+
 /// @brief Return a human-readable kernel label for diagnostics.
 ///
 /// @details Some code objects carry empty kernel symbol names. Falling back to
@@ -173,9 +563,11 @@ void append_diagnostics(std::vector<TranslationDiagnostic> &dst,
 
 [[nodiscard]] std::vector<uint64_t> kernel_entry_offsets(std::span<const KdTranslation> kernels) {
   std::vector<uint64_t> offsets;
-  offsets.reserve(kernels.size());
-  for (const KdTranslation &kernel : kernels)
+  for (const KdTranslation &kernel : kernels) {
     offsets.push_back(kernel.entry_text_offset);
+    for (const CallableRange &range : kernel.callable_ranges)
+      offsets.push_back(range.begin);
+  }
 
   std::ranges::sort(offsets);
   offsets.erase(std::ranges::unique(offsets).begin(), offsets.end());
@@ -187,6 +579,8 @@ kernel_hardware_entry_offsets(std::span<const KdTranslation> kernels) {
   std::vector<uint64_t> offsets;
   offsets.reserve(kernels.size() * 2);
   for (const KdTranslation &kernel : kernels) {
+    if (kernel.descriptorless_callable)
+      continue;
     offsets.push_back(kernel.entry_text_offset);
     if (kernel.has_kernarg_preload_firmware_skip)
       offsets.push_back(kernel.kernarg_preload_firmware_entry_text_offset);
@@ -203,6 +597,10 @@ kernel_hardware_entry_offsets(std::span<const KdTranslation> kernels) {
   offsets.reserve(kernels.size() * 2);
   for (const KdTranslation &kernel : kernels) {
     offsets.push_back(kernel.entry_text_offset);
+    for (const CallableRange &range : kernel.callable_ranges) {
+      offsets.push_back(range.begin);
+      offsets.push_back(range.end);
+    }
     // AMDHSA kernarg preloading is descriptor-controlled. When
     // kernarg_preload_spec_length is non-zero, compatible CP firmware starts at
     // KERNEL_CODE_ENTRY_BYTE_OFFSET + 256. That address is a real hardware entry,
@@ -210,6 +608,32 @@ kernel_hardware_entry_offsets(std::span<const KdTranslation> kernels) {
     if (kernel.has_kernarg_preload_firmware_skip &&
         kernel.kernarg_preload_firmware_entry_text_offset < text.size())
       offsets.push_back(kernel.kernarg_preload_firmware_entry_text_offset);
+  }
+
+  std::ranges::sort(offsets);
+  offsets.erase(std::ranges::unique(offsets).begin(), offsets.end());
+  return offsets;
+}
+
+/// @brief Return real external entries, excluding boundary-only block leaders.
+///
+/// Function ends split blocks so sized ELF symbols stay exact, but treating
+/// those ends as callable roots poisons indirect-control-flow dataflow and makes
+/// its cost scale with every symbol boundary. Keep only descriptor, callable,
+/// and firmware entry points in the conservative external-entry set.
+[[nodiscard]] std::vector<uint64_t>
+kernel_analysis_entry_offsets(std::span<const KdTranslation> kernels,
+                              std::span<const uint8_t> text) {
+  std::vector<uint64_t> offsets;
+  offsets.reserve(kernels.size() * 2);
+  for (const KdTranslation &kernel : kernels) {
+    offsets.push_back(kernel.entry_text_offset);
+    for (const CallableRange &range : kernel.callable_ranges)
+      offsets.push_back(range.begin);
+    if (kernel.has_kernarg_preload_firmware_skip &&
+        kernel.kernarg_preload_firmware_entry_text_offset < text.size()) {
+      offsets.push_back(kernel.kernarg_preload_firmware_entry_text_offset);
+    }
   }
 
   std::ranges::sort(offsets);
@@ -230,13 +654,15 @@ struct DescriptorVariantCheckpoint {
 };
 
 [[nodiscard]] uint64_t kernel_scope_key(const KdTranslation &kernel) {
-  assert(kernel.entry_text_offset <= (std::numeric_limits<uint64_t>::max() >> 1) &&
-         "kernel entry offset is too large to pack with variant bit");
-  return (kernel.entry_text_offset << 1) | (kernel.needs_lds_overflow_buf ? 1u : 0u);
+  assert(kernel.entry_text_offset <= (std::numeric_limits<uint64_t>::max() >> 2) &&
+         "kernel entry offset is too large to pack with scope bits");
+  return (kernel.entry_text_offset << 2) | (kernel.descriptorless_callable ? 2u : 0u) |
+         (kernel.needs_lds_overflow_buf ? 1u : 0u);
 }
 
 [[nodiscard]] bool same_kernel_scope_variant(const KdTranslation &lhs, const KdTranslation &rhs) {
   return lhs.entry_text_offset == rhs.entry_text_offset &&
+         lhs.descriptorless_callable == rhs.descriptorless_callable &&
          lhs.needs_lds_overflow_buf == rhs.needs_lds_overflow_buf;
 }
 
@@ -580,6 +1006,18 @@ reachable_kernel_blocks(const std::vector<std::unique_ptr<BasicBlock>> &blocks,
   return ordered;
 }
 
+[[nodiscard]] bool valid_callable_ranges(std::span<const CallableRange> ranges) {
+  if (ranges.empty())
+    return false;
+  for (size_t i = 0; i < ranges.size(); ++i) {
+    if (ranges[i].end <= ranges[i].begin)
+      return false;
+    if (i != 0 && ranges[i].begin < ranges[i - 1].end)
+      return false;
+  }
+  return true;
+}
+
 [[nodiscard]] std::vector<KernelTranslationScope>
 kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks,
                           const BlockOffsetIndex &block_index, std::span<KdTranslation> kernels) {
@@ -590,7 +1028,8 @@ kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks
 
   const BlockPositionIndex block_positions = build_block_position_index(blocks);
   const auto hardware_entries = kernel_hardware_entry_offsets(kernels);
-  std::unordered_set<uint64_t> entry_set(hardware_entries.begin(), hardware_entries.end());
+  std::unordered_set<uint64_t> descriptor_entry_set(hardware_entries.begin(),
+                                                    hardware_entries.end());
   std::vector<KdTranslation *> ordered_kernels;
   ordered_kernels.reserve(kernels.size());
   std::unordered_set<uint64_t> seen_scopes;
@@ -608,8 +1047,33 @@ kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks
   scopes.reserve(ordered_kernels.size());
   for (KdTranslation *kernel : ordered_kernels) {
     BasicBlock *entry = block_for_offset(block_index, kernel->entry_text_offset);
-    if (entry == nullptr)
+    if (entry == nullptr || entry->start_offset() != kernel->entry_text_offset)
       continue;
+    if (kernel->descriptorless_callable) {
+      if (!valid_callable_ranges(kernel->callable_ranges) ||
+          kernel->callable_ranges.front().begin != kernel->entry_text_offset) {
+        continue;
+      }
+
+      std::vector<BasicBlock *> callable_blocks;
+      size_t range_index = 0;
+      for (const auto &block : blocks) {
+        if (block == nullptr)
+          continue;
+        while (range_index < kernel->callable_ranges.size() &&
+               kernel->callable_ranges[range_index].end <= block->start_offset()) {
+          ++range_index;
+        }
+        if (range_index == kernel->callable_ranges.size())
+          break;
+        const CallableRange &range = kernel->callable_ranges[range_index];
+        if (block->start_offset() >= range.begin && block->end_offset() <= range.end)
+          callable_blocks.push_back(block.get());
+      }
+      scopes.push_back({kernel, entry, std::move(callable_blocks)});
+      continue;
+    }
+
     std::unordered_set<uint64_t> own_entries{kernel->entry_text_offset};
     if (kernel->has_kernarg_preload_firmware_skip) {
       if (block_for_offset(block_index, kernel->kernarg_preload_firmware_entry_text_offset) ==
@@ -620,23 +1084,218 @@ kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks
 
     scopes.push_back({kernel, entry,
                       reachable_kernel_blocks(blocks, block_index, block_positions, *entry,
-                                              entry_set, own_entries)});
+                                              descriptor_entry_set, own_entries)});
   }
   return scopes;
 }
 
-/// @brief Return whether an instruction is a scalar set-PC through one SGPR pair.
+struct DecodedCallableFunction {
+  CallableFunctionRange function;
+  std::vector<BasicBlock *> blocks;
+};
+
+struct DecodedCallableFunctions {
+  bool valid = false;
+  std::vector<DecodedCallableFunction> functions;
+  std::string error;
+};
+
+/// @brief Prove that every STT_FUNC range is a complete sequence of decoded blocks.
 ///
-/// @details Return-like scalar control flow is left as an indirect branch in the
-/// translated instruction stream, so DBT must validate that the block terminator
-/// reads the call edge's saved return SGPR. This helper intentionally checks the
-/// raw SOP1 source field instead of broader instruction semantics: only the exact
-/// `s_setpc_b64`/`s_set_pc_i64 s[return:return+1]` form is a scoped call return.
-[[nodiscard]] bool s_setpc_from_sreg(const Instruction &inst, uint32_t word, uint16_t ssrc0) {
-  const std::string_view mnemonic = inst.mnemonic();
-  if (inst.size() != sizeof(uint32_t) || (mnemonic != "s_setpc_b64" && mnemonic != "s_set_pc_i64"))
-    return false;
-  return static_cast<uint16_t>(word & 0xffu) == ssrc0;
+/// Function begin/end offsets are forced into the BasicBlock leader set before
+/// this check. A gap or block crossing a symbol boundary therefore means that
+/// final-HSACO metadata is not precise enough to relocate the callable safely.
+[[nodiscard]] DecodedCallableFunctions
+decode_callable_function_ranges(const std::vector<std::unique_ptr<BasicBlock>> &blocks,
+                                std::span<const CallableFunctionRange> functions) {
+  DecodedCallableFunctions result;
+  result.functions.reserve(functions.size());
+  size_t block_index = 0;
+  for (const CallableFunctionRange &function : functions) {
+    while (block_index < blocks.size() && (blocks[block_index] == nullptr ||
+                                           blocks[block_index]->end_offset() <= function.begin)) {
+      ++block_index;
+    }
+
+    uint64_t cursor = function.begin;
+    std::vector<BasicBlock *> function_blocks;
+    size_t scan_index = block_index;
+    for (; scan_index < blocks.size(); ++scan_index) {
+      const auto &block = blocks[scan_index];
+      if (block == nullptr)
+        continue;
+      if (block->start_offset() >= function.end)
+        break;
+      if (block->start_offset() != cursor || block->end_offset() > function.end) {
+        result.error = "STT_FUNC range does not describe a complete decoded instruction sequence";
+        return result;
+      }
+      function_blocks.push_back(block.get());
+      cursor = block->end_offset();
+    }
+    if (function_blocks.empty() || cursor != function.end) {
+      result.error = "STT_FUNC range contains undecodable or unaccounted executable bytes";
+      return result;
+    }
+    result.functions.push_back({function, std::move(function_blocks)});
+    block_index = scan_index;
+  }
+  result.valid = true;
+  return result;
+}
+
+[[nodiscard]] bool scope_intersects_function(const KernelTranslationScope &scope,
+                                             const DecodedCallableFunction &function) {
+  const auto first = std::ranges::lower_bound(scope.blocks, function.function.begin, {},
+                                              &BasicBlock::start_offset);
+  return first != scope.blocks.end() && *first != nullptr &&
+         (*first)->start_offset() < function.function.end;
+}
+
+[[nodiscard]] bool scopes_intersect(const KernelTranslationScope &lhs,
+                                    const KernelTranslationScope &rhs) {
+  size_t lhs_index = 0;
+  size_t rhs_index = 0;
+  while (lhs_index < lhs.blocks.size() && rhs_index < rhs.blocks.size()) {
+    const BasicBlock *lhs_block = lhs.blocks[lhs_index];
+    const BasicBlock *rhs_block = rhs.blocks[rhs_index];
+    if (lhs_block == nullptr) {
+      ++lhs_index;
+      continue;
+    }
+    if (rhs_block == nullptr) {
+      ++rhs_index;
+      continue;
+    }
+    if (lhs_block == rhs_block)
+      return true;
+    if (lhs_block->end_offset() <= rhs_block->start_offset())
+      ++lhs_index;
+    else if (rhs_block->end_offset() <= lhs_block->start_offset())
+      ++rhs_index;
+    else
+      return true;
+  }
+  return false;
+}
+
+/// @brief Keep complete STT_FUNC bodies in every descriptor scope that reaches them.
+///
+/// Static CFG recovery can miss an address-taken internal block even though the
+/// linker retained it inside a sized function symbol. Once any part of that
+/// function is owned by a descriptor, its whole declared body inherits that
+/// descriptor's resource contract and must move with the same kernel-local clone.
+void expand_descriptor_scopes_to_complete_functions(
+    std::span<KernelTranslationScope> scopes, std::span<const DecodedCallableFunction> functions) {
+  for (KernelTranslationScope &scope : scopes) {
+    if (scope.translation == nullptr || scope.translation->descriptorless_callable)
+      continue;
+
+    std::vector<BasicBlock *> additions;
+    for (const DecodedCallableFunction &function : functions) {
+      if (!scope_intersects_function(scope, function))
+        continue;
+      additions.insert(additions.end(), function.blocks.begin(), function.blocks.end());
+    }
+    if (additions.empty())
+      continue;
+
+    // Both inputs are source ordered. Merge them instead of re-sorting a
+    // potentially multi-million-block kernel after every function expansion.
+    std::vector<BasicBlock *> expanded;
+    expanded.reserve(scope.blocks.size() + additions.size());
+    std::ranges::set_union(scope.blocks, additions, std::back_inserter(expanded), {},
+                           &BasicBlock::start_offset, &BasicBlock::start_offset);
+    scope.blocks = std::move(expanded);
+  }
+}
+
+/// @brief Conservative source VGPR allocation envelope for callable-only code.
+///
+/// Final linked HSACO does not retain per-function resource records. For gfx1250
+/// low-bank code, however, any caller capable of executing the source function
+/// must allocate the descriptor granule containing its highest referenced VGPR.
+/// Restricting new dead-register scratch to that same granule preserves the
+/// caller-visible resource contract. Explicit VGPR-MSB changes are rejected by
+/// the caller because their physical-bank dataflow needs a retained linker
+/// resource contract rather than this low-bank inference.
+[[nodiscard]] std::vector<ScratchVgprRangeLimit>
+descriptorless_vgpr_envelopes(const KernelTranslationScope &scope) {
+  const auto &ranges = scope.translation->callable_ranges;
+  if (!valid_callable_ranges(ranges))
+    return {};
+
+  const uint32_t descriptor_granule =
+      descriptor_vgpr_granularity_for_wavefront(ROCJITSU_CODE_ARCH_GFX1250, 32);
+  std::vector<ScratchVgprRangeLimit> envelopes;
+  envelopes.reserve(ranges.size());
+  size_t block_index = 0;
+  for (const CallableRange &range : ranges) {
+    const uint64_t begin = range.begin;
+    const uint64_t end = range.end;
+
+    while (block_index < scope.blocks.size() &&
+           (scope.blocks[block_index] == nullptr ||
+            scope.blocks[block_index]->end_offset() <= begin)) {
+      ++block_index;
+    }
+
+    uint32_t referenced = 0;
+    size_t scan_index = block_index;
+    for (; scan_index < scope.blocks.size(); ++scan_index) {
+      BasicBlock *block = scope.blocks[scan_index];
+      if (block == nullptr)
+        continue;
+      if (block->start_offset() >= end)
+        break;
+      for (const Instruction &inst : block->instructions()) {
+        if (inst.src_loc() < begin || inst.src_loc() >= end)
+          continue;
+        const InstDefUse def_use(inst);
+        const auto account = [&](const RegisterSet &set) {
+          set.for_each([&](RegisterRef ref) {
+            if (ref.cls == RegClass::VGPR)
+              referenced = std::max(referenced, static_cast<uint32_t>(ref.index) + 1u);
+          });
+        };
+        account(def_use.defs);
+        account(def_use.uses);
+      }
+    }
+    block_index = scan_index;
+    referenced = std::max(referenced, descriptor_granule);
+    const uint32_t envelope =
+        ((referenced + descriptor_granule - 1u) / descriptor_granule) * descriptor_granule;
+    envelopes.push_back({.begin_offset = begin,
+                         .end_offset = end,
+                         .max_free_vgpr = static_cast<uint16_t>(envelope)});
+  }
+  return envelopes;
+}
+
+/// @brief Registers unavailable to scratch code in an LLVM AMDHSA C callable.
+///
+/// Final linked HSACO does not retain a function signature. The LLVM
+/// C/Fast/Cold convention can return values in v0-v31 and s4-s29, so all of
+/// those registers are possible external live-outs. LLVM's striped
+/// callee-saved registers must also be preserved even when the original
+/// function never references them and local liveness cannot see their
+/// caller-owned values. Other LLVM calling conventions are outside the
+/// descriptorless translation contract.
+[[nodiscard]] const RegisterSet &llvm_amdhsa_callable_scratch_reserved_registers() {
+  static const RegisterSet reserved = [] {
+    RegisterSet value;
+    value.expand({RegClass::VGPR, 0, 32});
+    for (uint16_t base = 40; base <= 248; base = static_cast<uint16_t>(base + 16))
+      value.expand({RegClass::VGPR, base, 8});
+
+    value.expand({RegClass::SGPR, 0, 40});
+    for (uint16_t base : {48, 64, 80})
+      value.expand({RegClass::SGPR, base, 8});
+    value.expand({RegClass::SGPR, 96, 10});
+    return value;
+  }();
+  return reserved;
 }
 
 /// @brief Find return blocks inside one context-sensitive call target.
@@ -742,6 +1401,54 @@ scoped_call_return_offsets(std::span<BasicBlock *const> blocks, std::span<const 
   return returns;
 }
 
+/// @brief Recognize ABI returns at externally entered descriptorless functions.
+///
+/// A callable object has no in-object call edge for a function invoked through
+/// a relocated pointer. Accepting every s_setpc would be unsafe, so require an
+/// exact block terminator that reads the AMDGPU ABI return-address pair
+/// SGPR30:31 and is wholly contained in a complete, rooted STT_FUNC range.
+/// Multiple such terminators are valid: optimized functions need not merge all
+/// returns into one final epilogue.
+[[nodiscard]] std::unordered_set<uint64_t>
+descriptorless_callable_return_offsets(const KdTranslation &translation, KernelBlockScope blocks,
+                                       std::span<const uint8_t> text) {
+  std::unordered_set<uint64_t> returns;
+  if (!translation.descriptorless_callable)
+    return returns;
+
+  if (!valid_callable_ranges(translation.callable_ranges))
+    return returns;
+
+  constexpr uint16_t kCallableReturnSgpr = 30;
+  size_t block_index = 0;
+  for (const CallableRange &range : translation.callable_ranges) {
+    const uint64_t begin = range.begin;
+    const uint64_t end = range.end;
+
+    while (block_index < blocks.size() &&
+           (blocks[block_index] == nullptr || blocks[block_index]->end_offset() <= begin)) {
+      ++block_index;
+    }
+    size_t scan_index = block_index;
+    for (; scan_index < blocks.size(); ++scan_index) {
+      BasicBlock *block = blocks[scan_index];
+      if (block == nullptr)
+        continue;
+      if (block->start_offset() >= end)
+        break;
+      if (block->start_offset() < begin || block->end_offset() > end)
+        continue;
+      const Instruction *term = block->terminator();
+      if (term != nullptr &&
+          s_setpc_from_sreg(*term, text_word_at(text, term->src_loc()), kCallableReturnSgpr)) {
+        returns.insert(term->src_loc());
+      }
+    }
+    block_index = scan_index;
+  }
+  return returns;
+}
+
 /// @brief Materialize context-sensitive call edges for liveness.
 ///
 /// @details `BasicBlock` deliberately separates call edges from ordinary CFG
@@ -793,13 +1500,13 @@ scoped_call_liveness_edges(std::span<BasicBlock *const> blocks, std::span<const 
     std::span<const TextOffsetRelocation> text_relocations,
     std::span<const PcRelativeDataRelocation> data_relocations,
     std::span<const KdTranslation> translations, rj_code_arch_t host_arch, uint32_t target_mach,
-    std::vector<TranslationDiagnostic> &diagnostics) {
+    bool require_exact_function_ranges, std::vector<TranslationDiagnostic> &diagnostics) {
   if (translated_text.size() < original_text_size)
     append_nop_padding(translated_text, original_text_size - translated_text.size(), host_arch);
 
   std::unordered_set<uint64_t> applied_descriptors;
   for (const KdTranslation &translation : translations) {
-    if (translation.sidecar_descriptor)
+    if (translation.descriptorless_callable || translation.sidecar_descriptor)
       continue;
     if (!applied_descriptors.insert(translation.descriptor_file_offset).second)
       continue;
@@ -815,11 +1522,19 @@ scoped_call_liveness_edges(std::span<BasicBlock *const> blocks, std::span<const 
     }
   }
 
-  if (!patcher.replace_text(translated_text, text_relocations, data_relocations)) {
-    append_error(diagnostics, DiagnosticKind::ResourceLimit,
-                 "relocated .text could not be materialized safely; leaving code object unchanged");
+  std::string replace_text_error;
+  std::vector<std::string> patch_warnings;
+  if (!patcher.replace_text(translated_text, text_relocations, data_relocations,
+                            &replace_text_error, &patch_warnings, require_exact_function_ranges)) {
+    std::string message = "relocated .text could not be materialized safely";
+    if (!replace_text_error.empty())
+      message += ": " + replace_text_error;
+    message += "; leaving code object unchanged";
+    append_error(diagnostics, DiagnosticKind::ResourceLimit, std::move(message));
     return std::nullopt;
   }
+  for (std::string &warning : patch_warnings)
+    append_warning(diagnostics, DiagnosticKind::Legalization, std::move(warning));
 
   std::vector<uint64_t> sidecar_descriptor_vaddrs(translations.size(), 0);
   std::vector<KdTranslation> sidecar_descriptors;
@@ -833,12 +1548,15 @@ scoped_call_liveness_edges(std::span<BasicBlock *const> blocks, std::span<const 
     sidecar_indices.push_back(i);
   }
   if (!sidecar_descriptors.empty()) {
-    auto appended =
-        patcher.append_sidecar_descriptor_translations(sidecar_descriptors, host_arch, 64);
+    std::string sidecar_error;
+    auto appended = patcher.append_sidecar_descriptor_translations(sidecar_descriptors, host_arch,
+                                                                   64, &sidecar_error);
     if (!appended || appended->size() != sidecar_descriptors.size()) {
-      append_error(diagnostics, DiagnosticKind::ResourceLimit,
-                   "virtual LDS sidecar descriptors could not be materialized safely; leaving code "
-                   "object unchanged");
+      std::string message = "virtual LDS sidecar descriptors could not be materialized safely";
+      if (!sidecar_error.empty())
+        message += ": " + sidecar_error;
+      message += "; leaving code object unchanged";
+      append_error(diagnostics, DiagnosticKind::ResourceLimit, std::move(message));
       return std::nullopt;
     }
     for (size_t i = 0; i < appended->size(); ++i)
@@ -1101,12 +1819,20 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   TranslatedCodeObject result;
   result.host_arch = host_arch_;
 
-  CodeObjectPatcher patcher(obj);
   auto leave_unchanged = [&]() {
     const auto *image = reinterpret_cast<const uint8_t *>(obj.image_data());
-    result.elf_bytes.assign(image, image + obj.image_size());
+    if (obj.image_size() != 0)
+      result.elf_bytes.assign(image, image + obj.image_size());
     return result;
   };
+
+  if (obj.image_size() < sizeof(Elf64_Ehdr)) {
+    append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
+                 "code object is too small to contain an ELF header");
+    return leave_unchanged();
+  }
+
+  CodeObjectPatcher patcher(obj);
 
   // A same-architecture gfx1250 translation is direction-specific: A0 and B0
   // share an ELF machine ID, so both revisions must be given. Enforce this here
@@ -1128,12 +1854,42 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     }
   }
 
-  auto text = patcher.text_bytes();
-  if (text.empty()) {
+  const auto image = std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(obj.image_data()),
+                                              obj.image_size());
+  const ExecutableElfAnalysis executable =
+      analyze_executable_elf(image, patcher.text_offset(), patcher.text_size());
+  if (!executable.valid) {
     append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
-                 "code object does not expose a non-empty .text section for translation");
+                 executable.error.empty() ? "code object executable layout is malformed"
+                                          : executable.error);
     return leave_unchanged();
   }
+
+  Elf64_Ehdr header{};
+  std::memcpy(&header, obj.image_data(), sizeof(header));
+  const uint32_t source_mach = header.e_flags & EF_AMDGPU_MACH;
+  if (executable.data_only) {
+    if (guest_arch_ == host_arch_ && source_mach == (target_mach_ & EF_AMDGPU_MACH)) {
+      append_warning(result.diagnostics, DiagnosticKind::DataOnly,
+                     "code object has no executable sections, segments, or callable symbols; "
+                     "leaving unchanged");
+      return leave_unchanged();
+    }
+    append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
+                 "data-only code object cannot be translated when input and output targets differ");
+    return leave_unchanged();
+  }
+  if (!executable.canonical_text_supported) {
+    append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
+                 executable.error.empty()
+                     ? "code object executable content is not confined to one supported non-empty "
+                       ".text section"
+                     : executable.error);
+    return leave_unchanged();
+  }
+
+  auto text = patcher.text_bytes();
+  assert(!text.empty() && "supported executable layout must have non-empty .text");
 
   // DBT relocates instructions within .text (compaction, expansion, per-kernel
   // block placement) but does not rewrite relocation places that land inside
@@ -1198,20 +1954,59 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     return leave_unchanged();
   }
 
-  if (descriptor_translations.empty()) {
-    append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
-                 "kernel descriptors are required for kernel-level translation");
-    return leave_unchanged();
+  const bool is_gfx1250_b0_to_a0 = guest_arch_ == ROCJITSU_CODE_ARCH_GFX1250 &&
+                                   host_arch_ == ROCJITSU_CODE_ARCH_GFX1250 &&
+                                   options_.input_revision == ProcessorRevision::Gfx1250B0 &&
+                                   options_.output_revision == ProcessorRevision::Gfx1250A0;
+  const bool has_kernel_descriptors = !descriptor_translations.empty();
+  std::unordered_set<uint64_t> descriptor_entries;
+  for (const KdTranslation &translation : descriptor_translations)
+    descriptor_entries.insert(translation.entry_text_offset);
+  if (is_gfx1250_b0_to_a0) {
+    const auto uncorroborated_zero_sized_function =
+        std::ranges::find_if(executable.zero_sized_function_entries,
+                             [&](uint64_t entry) { return !descriptor_entries.contains(entry); });
+    if (uncorroborated_zero_sized_function != executable.zero_sized_function_entries.end()) {
+      append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                   "zero-sized STT_FUNC entry is not corroborated by a kernel descriptor",
+                   *uncorroborated_zero_sized_function);
+      return leave_unchanged();
+    }
+  }
+
+  if (!has_kernel_descriptors) {
+    if (executable.callable_functions.empty()) {
+      append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                   "executable .text has neither kernel descriptors nor complete STT_FUNC ranges");
+      return leave_unchanged();
+    }
+    if (!is_gfx1250_b0_to_a0) {
+      append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                   "descriptorless callable translation is only supported for gfx1250 B0-to-A0");
+      return leave_unchanged();
+    }
   }
 
   const auto relocation_function_tables = discover_relocation_function_tables(obj);
   auto block_leaders = kernel_block_leaders(descriptor_translations, text);
+  auto analysis_entries = kernel_analysis_entry_offsets(descriptor_translations, text);
+  if (is_gfx1250_b0_to_a0) {
+    for (const CallableFunctionRange &function : executable.callable_functions) {
+      block_leaders.push_back(function.begin);
+      block_leaders.push_back(function.end);
+      analysis_entries.push_back(function.begin);
+    }
+  }
   for (const RelocationFunctionTable &table : relocation_function_tables) {
-    for (const RelocationFunctionPointer &entry : table.entries)
+    for (const RelocationFunctionPointer &entry : table.entries) {
       block_leaders.push_back(entry.target_text_offset);
+      analysis_entries.push_back(entry.target_text_offset);
+    }
   }
   std::ranges::sort(block_leaders);
   block_leaders.erase(std::ranges::unique(block_leaders).begin(), block_leaders.end());
+  std::ranges::sort(analysis_entries);
+  analysis_entries.erase(std::ranges::unique(analysis_entries).begin(), analysis_entries.end());
 
   // Phase 2: build a CFG over .text, including recovered indirect targets as
   // block leaders, then compute one source-reachable block set per descriptor
@@ -1219,8 +2014,15 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // helper block, Phase 3 emits that helper into both relocated bodies so every
   // branch or call target can be resolved through the current kernel's placement
   // map without borrowing another kernel's return continuation.
-  auto blocks = BasicBlock::build(obj, *decoder, guest_arch_, block_leaders,
-                                  ExternalEntryPolicy::ExplicitOnly);
+  std::vector<std::unique_ptr<BasicBlock>> blocks;
+  try {
+    blocks = BasicBlock::build(obj, *decoder, guest_arch_, block_leaders, analysis_entries,
+                               ExternalEntryPolicy::ExplicitOnly);
+  } catch (const util::InvalidInst &error) {
+    append_error(result.diagnostics, DiagnosticKind::Legalization,
+                 std::string("failed to decode executable .text: ") + error.what());
+    return leave_unchanged();
+  }
   const BlockOffsetIndex block_index = build_block_offset_index(blocks);
   const uint64_t text_vaddr = obj.text_sections().front()->vaddr();
   const auto relocation_table_dispatches =
@@ -1245,12 +2047,48 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
          relocation_function_tables[dispatch.table_index].entries)
       relocation_table_callee_offsets.insert(entry.target_text_offset);
   }
+
+  if (!has_kernel_descriptors) {
+    const bool needs_instruction_rewrite = std::ranges::any_of(blocks, [&](const auto &block) {
+      if (block == nullptr)
+        return false;
+      return std::ranges::any_of(block->instructions(), [&](const Instruction &inst) {
+        return lookup_legalization(inst) != nullptr ||
+               (semantic_translator_ != nullptr && semantic_translator_->has_expand_rule(inst));
+      });
+    });
+
+    // A descriptorless callable library whose decoded instructions have no B0
+    // rewrite candidates needs no address, symbol, unwind, or resource rewrite.
+    // Scan the entire decoded .text before taking this path; the CLI still
+    // performs normal host-decode validation for this executable no-op.
+    if (!needs_instruction_rewrite) {
+      append_warning(result.diagnostics, DiagnosticKind::NothingToTranslate,
+                     "descriptorless executable functions contain no instructions that require "
+                     "rewriting; leaving unchanged");
+      return leave_unchanged();
+    }
+  }
+
+  DecodedCallableFunctions decoded_callables;
+  decoded_callables.valid = true;
+  if (is_gfx1250_b0_to_a0) {
+    decoded_callables = decode_callable_function_ranges(blocks, executable.callable_functions);
+    if (!decoded_callables.valid) {
+      append_error(result.diagnostics, DiagnosticKind::Legalization,
+                   decoded_callables.error + "; leaving code object unchanged");
+      return leave_unchanged();
+    }
+  }
+
   auto scopes = kernel_translation_scopes(blocks, block_index, descriptor_translations);
+  if (is_gfx1250_b0_to_a0)
+    expand_descriptor_scopes_to_complete_functions(scopes, decoded_callables.functions);
 
   if (can_emit_sidecar_descriptors) {
     std::vector<KdTranslation> sidecar_variants;
     for (const KernelTranslationScope &scope : scopes) {
-      if (scope.translation == nullptr)
+      if (scope.translation == nullptr || scope.translation->descriptorless_callable)
         continue;
       const uint32_t host_lds_bytes = arch_lds_bytes(host_arch_);
       const bool static_lds_exceeds_host =
@@ -1285,7 +2123,78 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                                      std::make_move_iterator(sidecar_variants.begin()),
                                      std::make_move_iterator(sidecar_variants.end()));
       scopes = kernel_translation_scopes(blocks, block_index, descriptor_translations);
+      if (is_gfx1250_b0_to_a0)
+        expand_descriptor_scopes_to_complete_functions(scopes, decoded_callables.functions);
     }
+  }
+
+  // Any complete STT_FUNC body not owned by a descriptor scope remains
+  // independently callable in the linked image. Translate all such functions
+  // together under the conservative descriptorless ABI/resource contract,
+  // including in mixed kernel-plus-library code objects.
+  std::vector<CallableFunctionRange> independent_callables;
+  if (is_gfx1250_b0_to_a0) {
+    for (const DecodedCallableFunction &function : decoded_callables.functions) {
+      const bool descriptor_owned = std::ranges::any_of(scopes, [&](const auto &scope) {
+        return scope.translation != nullptr && !scope.translation->descriptorless_callable &&
+               scope_intersects_function(scope, function);
+      });
+      if (descriptor_owned && function.function.externally_visible() &&
+          !descriptor_entries.contains(function.function.begin)) {
+        append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                     "externally visible STT_FUNC is reachable from a kernel descriptor and "
+                     "cannot safely inherit that kernel's private resource contract",
+                     function.function.begin);
+        return leave_unchanged();
+      }
+      if (!descriptor_owned && !descriptor_entries.contains(function.function.begin))
+        independent_callables.push_back(function.function);
+    }
+  }
+
+  if (!independent_callables.empty()) {
+    if (!is_gfx1250_b0_to_a0) {
+      append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                   "independent STT_FUNC callable translation is only supported for gfx1250 "
+                   "B0-to-A0");
+      return leave_unchanged();
+    }
+    if (!executable.assume_llvm_amdhsa_callable_abi) {
+      append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                   "descriptorless STT_FUNC translation supports only linked LLVM AMDHSA code "
+                   "objects V4-V6");
+      return leave_unchanged();
+    }
+
+    KdTranslation callable;
+    callable.descriptorless_callable = true;
+    callable.kernel_name = "descriptorless callable functions";
+    callable.entry_text_offset = independent_callables.front().begin;
+    callable.callable_ranges.reserve(independent_callables.size());
+    for (const CallableFunctionRange &function : independent_callables)
+      callable.callable_ranges.push_back({function.begin, function.end});
+    assert(valid_callable_ranges(callable.callable_ranges) &&
+           callable.callable_ranges.front().begin == callable.entry_text_offset);
+    // gfx1250 allocates ordinary VGPRs in 16-register descriptor granules. The
+    // exact source envelope is tightened after decode; starting at the minimum
+    // granule prevents an empty/argument-free callable from manufacturing a
+    // zero-register resource contract.
+    callable.target_vgpr_count = 16;
+    callable.target_vgpr_allocation_count = 16;
+    callable.target_sgpr_count = 106;
+    callable.target_wave_size = 32;
+    callable.guest_wavefront_size = 32;
+    callable.host_wavefront_size = 32;
+    descriptor_translations.push_back(std::move(callable));
+
+    scopes = kernel_translation_scopes(blocks, block_index, descriptor_translations);
+    expand_descriptor_scopes_to_complete_functions(scopes, decoded_callables.functions);
+  }
+
+  if (descriptor_translations.empty()) {
+    append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                 "executable .text has no translatable descriptor or STT_FUNC scope");
+    return leave_unchanged();
   }
 
   const size_t expected_scope_count = kernel_translation_scope_count(descriptor_translations);
@@ -1293,6 +2202,59 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
                  "kernel descriptor entry offsets are required to map to decoded text blocks");
     return leave_unchanged();
+  }
+
+  // A callable-only object has no descriptor roots that define which code may
+  // be discarded, so every decoded block must belong to a complete STT_FUNC
+  // range. Descriptor-backed objects may still compact genuinely unreachable,
+  // unreferenced blocks: replace_text() removes those bytes rather than leaving
+  // stale B0 instructions executable, while every retained STT_FUNC range is
+  // proven and owned above.
+  if (!has_kernel_descriptors) {
+    std::unordered_set<const BasicBlock *> covered_blocks;
+    for (const KernelTranslationScope &scope : scopes) {
+      for (const BasicBlock *block : scope.blocks) {
+        if (block != nullptr)
+          covered_blocks.insert(block);
+      }
+    }
+    const auto uncovered = std::ranges::find_if(blocks, [&](const auto &block) {
+      return block != nullptr && !covered_blocks.contains(block.get());
+    });
+    if (uncovered != blocks.end()) {
+      append_error(result.diagnostics, DiagnosticKind::Legalization,
+                   "descriptorless executable .text contains decoded instructions outside "
+                   "complete STT_FUNC ranges",
+                   (*uncovered)->start_offset());
+      return leave_unchanged();
+    }
+  }
+
+  // No descriptor scope may silently absorb an independently callable range.
+  // Such overlap would give one source address two target placements while ELF
+  // symbols, RELATIVE64 addends, and unwind FDEs can name only one. Cross-scope
+  // callable transfers need a dedicated global fixup before that layout is safe.
+  const auto descriptorless_scope =
+      std::ranges::find_if(scopes, [](const KernelTranslationScope &scope) {
+        return scope.translation != nullptr && scope.translation->descriptorless_callable;
+      });
+  if (descriptorless_scope != scopes.end()) {
+    for (const KernelTranslationScope &scope : scopes) {
+      if (scope.translation == nullptr || scope.translation->descriptorless_callable)
+        continue;
+      const bool overlaps = scopes_intersect(scope, *descriptorless_scope);
+      // Independent-callable discovery excludes every function intersecting a
+      // descriptor scope using the same block identity, so overlap is an
+      // internal construction invariant today. Keep the release-mode check
+      // below as a fail-closed backstop for future scope-building changes.
+      assert(!overlaps && "independent callable scope must be disjoint from descriptor scopes");
+      if (overlaps) {
+        append_error(result.diagnostics, DiagnosticKind::Legalization,
+                     "independently callable STT_FUNC code overlaps a kernel-local translation "
+                     "scope");
+        return leave_unchanged();
+      }
+    }
   }
 
   std::vector<uint8_t> translated_text;
@@ -1420,7 +2382,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     }
 
     for (KdTranslation &translation : descriptor_translations) {
-      if (translation.entry_text_offset != source_entry)
+      if (translation.descriptorless_callable || translation.entry_text_offset != source_entry)
         continue;
       // Normal hardware-LDS and virtual-LDS sidecar descriptors share the same
       // source entry, but a sidecar translation failure must not turn a normal
@@ -1463,12 +2425,13 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // then applies to the replacement stub or a later kernel.
   std::vector<TextOffsetRelocation> text_relocations;
   std::vector<PcRelativeDataRelocation> data_relocations;
+  uint64_t next_text_relocation_placement = 0;
 
   auto fail_or_skip_kernel =
       [&](const KernelTranslationScope &scope, KernelFailure failure, size_t output_begin,
           const std::vector<DescriptorVariantCheckpoint> &descriptor_snapshot,
           size_t text_relocations_begin, size_t data_relocations_begin) -> bool {
-    if (!skip_failed_kernels) {
+    if (!skip_failed_kernels || scope.translation->descriptorless_callable) {
       append_error(result.diagnostics, failure.kind, std::move(failure.message),
                    failure.guest_offset, std::move(failure.mnemonic),
                    std::move(failure.required_work));
@@ -1570,11 +2533,58 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     // without precomputing speculative side-region offsets.
     KernelTextLayout layout;
     layout.source_entry = scope.translation->entry_text_offset;
+    std::vector<ScratchVgprRangeLimit> descriptorless_vgpr_limits;
+
+    if (scope.translation->descriptorless_callable) {
+      const auto mode_write = std::ranges::find_if(scope.blocks, [](BasicBlock *block) {
+        if (block == nullptr)
+          return false;
+        return std::ranges::any_of(block->instructions(), changes_gfx1250_vgpr_msb_state);
+      });
+      if (mode_write != scope.blocks.end()) {
+        auto failure = make_kernel_failure(
+            DiagnosticKind::ResourceLimit,
+            "descriptorless callable code changes VGPR-MSB/MODE state, so its physical register "
+            "envelope cannot be proven from final-HSACO metadata");
+        if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
+                                text_relocations_begin, data_relocations_begin))
+          continue;
+        return leave_unchanged();
+      }
+
+      descriptorless_vgpr_limits = descriptorless_vgpr_envelopes(scope);
+      if (descriptorless_vgpr_limits.empty()) {
+        auto failure = make_kernel_failure(
+            DiagnosticKind::ResourceLimit,
+            "descriptorless callable function ranges do not provide complete VGPR resource "
+            "envelopes");
+        if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
+                                text_relocations_begin, data_relocations_begin))
+          continue;
+        return leave_unchanged();
+      }
+      const uint32_t source_vgpr_envelope =
+          std::ranges::max(descriptorless_vgpr_limits, {}, &ScratchVgprRangeLimit::max_free_vgpr)
+              .max_free_vgpr;
+      if (source_vgpr_envelope > 256) {
+        auto failure = make_kernel_failure(
+            DiagnosticKind::ResourceLimit,
+            "descriptorless callable low-bank VGPR envelope exceeds the supported resource "
+            "contract");
+        if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
+                                text_relocations_begin, data_relocations_begin))
+          continue;
+        return leave_unchanged();
+      }
+      scope.translation->target_vgpr_count = source_vgpr_envelope;
+      scope.translation->target_vgpr_allocation_count = source_vgpr_envelope;
+    }
 
     TranslationContext kernel_context(
         scope.translation->target_vgpr_count, scope.translation->target_agpr_count,
         scope.translation->target_accvgpr_base, scope.translation->target_sgpr_count,
         scope.translation->target_private_size);
+    kernel_context.private_spills_allowed = !scope.translation->descriptorless_callable;
     if (scope.translation->needs_lds_overflow_buf) {
       auto virtual_lds_base =
           reserve_virtual_lds_base_sgpr_pair(kernel_context, KernelBlockScope(scope.blocks),
@@ -1646,12 +2656,34 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       return leave_unchanged();
     }
     const bool can_use_long_direct_branches =
+        !scope.translation->descriptorless_callable &&
         next_long_branch_sgpr_pair(kernel_context, host_arch_).has_value();
     LivenessAnalysisOptions liveness_options;
     liveness_options.max_free_vgpr =
-        static_cast<uint16_t>(isa_properties(host_arch_).max_addressable_vgprs_per_wf);
+        static_cast<uint16_t>(scope.translation->descriptorless_callable
+                                  ? scope.translation->target_vgpr_count
+                                  : isa_properties(host_arch_).max_addressable_vgprs_per_wf);
     liveness_options.arch = guest_arch_;
-    liveness_options.entry_block = scope.entry;
+    if (scope.translation->descriptorless_callable) {
+      liveness_options.scratch_reserved = llvm_amdhsa_callable_scratch_reserved_registers();
+      liveness_options.scratch_vgpr_range_limits = descriptorless_vgpr_limits;
+    }
+    std::vector<BasicBlock *> scope_analysis_entries{scope.entry};
+    const auto add_analysis_entry = [&](uint64_t offset) {
+      BasicBlock *entry = block_for_offset(block_index, offset);
+      if (entry != nullptr && entry->start_offset() == offset)
+        scope_analysis_entries.push_back(entry);
+    };
+    if (scope.translation->descriptorless_callable) {
+      for (const CallableRange &range : scope.translation->callable_ranges)
+        add_analysis_entry(range.begin);
+    } else if (scope.translation->has_kernarg_preload_firmware_skip) {
+      add_analysis_entry(scope.translation->kernarg_preload_firmware_entry_text_offset);
+    }
+    std::ranges::sort(scope_analysis_entries);
+    scope_analysis_entries.erase(std::ranges::unique(scope_analysis_entries).begin(),
+                                 scope_analysis_entries.end());
+    liveness_options.entry_blocks = scope_analysis_entries;
     liveness_options.text = text;
     if (options_.debug_min_free_vgpr)
       liveness_options.min_free_vgpr = *options_.debug_min_free_vgpr;
@@ -1691,8 +2723,11 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     // one dynamic consumer has multiple recovered targets, no single direct
     // window can preserve semantics; DBT keeps the original indirect consumer
     // and asks the patch layer to rewrite each source-side PC builder once.
-    const std::unordered_set<uint64_t> valid_call_return_offsets =
+    std::unordered_set<uint64_t> valid_call_return_offsets =
         scoped_call_return_offsets(KernelBlockScope(scope.blocks), text);
+    const auto callable_returns = descriptorless_callable_return_offsets(
+        *scope.translation, KernelBlockScope(scope.blocks), text);
+    valid_call_return_offsets.insert(callable_returns.begin(), callable_returns.end());
     struct RecoveredConsumer {
       std::vector<IndirectCallFixup> fixups;
       bool use_transfer_window = false;
@@ -1810,6 +2845,32 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     uint64_t source_body_size = 0;
     for (BasicBlock *block : scope.blocks)
       source_body_size += block->size();
+    uint64_t source_allocation_size = source_body_size;
+    if (scope.translation->descriptorless_callable) {
+      source_allocation_size = 0;
+      for (size_t range_index = 0; range_index < scope.translation->callable_ranges.size();
+           ++range_index) {
+        const CallableRange &range = scope.translation->callable_ranges[range_index];
+        uint64_t allocation_end = range_index + 1 < scope.translation->callable_ranges.size()
+                                      ? scope.translation->callable_ranges[range_index + 1].begin
+                                      : text.size();
+        for (const KernelTranslationScope &other : scopes) {
+          if (other.translation == nullptr || other.translation->descriptorless_callable)
+            continue;
+          for (const BasicBlock *block : other.blocks) {
+            if (block != nullptr && block->start_offset() >= range.end)
+              allocation_end = std::min(allocation_end, block->start_offset());
+          }
+        }
+        if (allocation_end < range.end ||
+            allocation_end - range.begin >
+                std::numeric_limits<uint64_t>::max() - source_allocation_size) {
+          source_allocation_size = 0;
+          break;
+        }
+        source_allocation_size += allocation_end - range.begin;
+      }
+    }
     const uint64_t recovered_window_growth =
         recovered_indirect_by_call.size() * kMaxRecoveredIndirectTransferWords * sizeof(uint32_t);
     kernel_text.reserve(static_cast<size_t>(std::min<uint64_t>(
@@ -1818,6 +2879,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     std::unordered_map<uint64_t, uint64_t> target_offset_by_source_offset;
     target_offset_by_source_offset.reserve(
         static_cast<size_t>(source_body_size / sizeof(uint32_t)) + scope.blocks.size());
+    std::unordered_set<uint64_t> instruction_start_offsets;
+    instruction_start_offsets.reserve(static_cast<size_t>(source_body_size / sizeof(uint32_t)));
     layout.body_begin = 0;
     layout.blocks.reserve(scope.blocks.size());
     uint64_t next_branch_island_pool_offset = first_direct_branch_island_pool_offset();
@@ -1844,7 +2907,11 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         // Record every instruction start, not just recovered-PC builder
         // boundaries. The same final map keeps ELF labels attached to the
         // relocated instruction stream after semantic expansions change sizes.
-        target_offset_by_source_offset.emplace(offset, target_offset);
+        // A block start can equal the previous block's end. If an island pool
+        // was inserted at that boundary, replace the pre-pool end mapping so
+        // branches and symbols land on the instruction.
+        target_offset_by_source_offset.insert_or_assign(offset, target_offset);
+        instruction_start_offsets.insert(offset);
 
         const auto recovered_it = recovered_indirect_by_call.find(offset);
         const bool has_recovered_indirect_call = recovered_it != recovered_indirect_by_call.end();
@@ -2129,8 +3196,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       placement.target_end = kernel_text.size();
       layout.blocks.push_back(placement);
       target_offset_by_source_offset.emplace(block->end_offset(), kernel_text.size());
-      if (!can_use_long_direct_branches && block != scope.blocks.back() &&
-          kernel_text.size() >= next_branch_island_pool_offset) {
+      if (!scope.translation->descriptorless_callable && !can_use_long_direct_branches &&
+          block != scope.blocks.back() && kernel_text.size() >= next_branch_island_pool_offset) {
         append_direct_branch_island_pool(kernel_text, layout, host_arch_);
         next_branch_island_pool_offset = next_direct_branch_island_pool_offset(kernel_text.size());
       }
@@ -2179,10 +3246,25 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         continue;
       return leave_unchanged();
     }
+    if (scope.translation->descriptorless_callable &&
+        translated_text.size() - output_begin > source_allocation_size) {
+      auto failure = make_kernel_failure(
+          DiagnosticKind::ResourceLimit,
+          "descriptorless callable translation exceeds its original executable allocation");
+      if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
+                              text_relocations_begin, data_relocations_begin))
+        continue;
+      return leave_unchanged();
+    }
     const uint64_t target_delta = materialized.target_delta;
+    const uint64_t placement_id = next_text_relocation_placement++;
     for (const auto &[source_offset, target_offset] : target_offset_by_source_offset) {
-      text_relocations.push_back(
-          {.source_offset = source_offset, .target_offset = target_offset + target_delta});
+      text_relocations.push_back({
+          .source_offset = source_offset,
+          .target_offset = target_offset + target_delta,
+          .placement_id = placement_id,
+          .source_is_instruction_start = instruction_start_offsets.contains(source_offset),
+      });
     }
     for (const RelocationTableDispatch &dispatch : relocation_table_dispatches) {
       if (!target_offset_by_source_offset.contains(dispatch.source_call_offset))
@@ -2244,17 +3326,39 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       return leave_unchanged();
     }
 
-    if (kernel_context.required_vgpr_count > kernel_context.num_vgprs)
-      scope.translation->target_vgpr_count = kernel_context.required_vgpr_count;
-    if (kernel_context.required_sgpr_count > kernel_context.num_sgprs)
-      scope.translation->target_sgpr_count = kernel_context.required_sgpr_count;
-    if (kernel_context.required_private_segment_fixed_size >
-        kernel_context.private_segment_fixed_size)
-      scope.translation->target_private_size = kernel_context.required_private_segment_fixed_size;
+    if (scope.translation->descriptorless_callable) {
+      // There is no descriptor to advertise a larger resource request to the
+      // caller. The source callable's decoded low-bank VGPR envelope and the
+      // architecture's fixed callable SGPR set are therefore hard limits, and
+      // descriptorless lowering may not manufacture private spill storage.
+      if (kernel_context.required_vgpr_count > kernel_context.num_vgprs ||
+          kernel_context.required_sgpr_count > kernel_context.num_sgprs ||
+          kernel_context.required_private_segment_fixed_size >
+              kernel_context.private_segment_fixed_size) {
+        auto failure = make_kernel_failure(
+            DiagnosticKind::ResourceLimit,
+            "descriptorless callable lowering requires resources that cannot be advertised "
+            "without a kernel descriptor");
+        if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
+                                text_relocations_begin, data_relocations_begin))
+          continue;
+        return leave_unchanged();
+      }
+    } else {
+      if (kernel_context.required_vgpr_count > kernel_context.num_vgprs)
+        scope.translation->target_vgpr_count = kernel_context.required_vgpr_count;
+      if (kernel_context.required_sgpr_count > kernel_context.num_sgprs)
+        scope.translation->target_sgpr_count = kernel_context.required_sgpr_count;
+      if (kernel_context.required_private_segment_fixed_size >
+          kernel_context.private_segment_fixed_size) {
+        scope.translation->target_private_size = kernel_context.required_private_segment_fixed_size;
+      }
+    }
 
-    if (scope.translation->target_vgpr_count != kernel_context.num_vgprs ||
-        scope.translation->target_sgpr_count != kernel_context.num_sgprs ||
-        scope.translation->target_private_size != kernel_context.private_segment_fixed_size) {
+    if (!scope.translation->descriptorless_callable &&
+        (scope.translation->target_vgpr_count != kernel_context.num_vgprs ||
+         scope.translation->target_sgpr_count != kernel_context.num_sgprs ||
+         scope.translation->target_private_size != kernel_context.private_segment_fixed_size)) {
       // Semantic rules may allocate descriptor-backed scratch registers or
       // per-lane private spill slots beyond the kernel's original resources.
       // Recompute the descriptor with those larger minimums before patching it
@@ -2384,11 +3488,19 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   if (continue_after_failure && has_error_diagnostic(result.diagnostics))
     return leave_unchanged();
 
+  if (!has_kernel_descriptors && translated_text.size() > text.size()) {
+    append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
+                 "descriptorless callable translation exceeds the original executable .text "
+                 "allocation");
+    return leave_unchanged();
+  }
+
   // Phase 6 commits the completed translation plan without mixing ELF mutation
   // and sidecar metadata construction into the per-kernel lowering transaction.
   auto materialized = materialize_translated_code_object(
       std::move(patcher), std::move(translated_text), text.size(), text_relocations,
-      data_relocations, descriptor_translations, host_arch_, target_mach_, result.diagnostics);
+      data_relocations, descriptor_translations, host_arch_, target_mach_, is_gfx1250_b0_to_a0,
+      result.diagnostics);
   if (!materialized)
     return leave_unchanged();
   result.elf_bytes = std::move(*materialized);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
@@ -36,6 +36,7 @@ RJ_DIAGNOSTIC_POP
 #include <string>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 namespace rocjitsu {
 
@@ -52,6 +53,10 @@ constexpr uint64_t kKernargPreloadSkipBytes = 256;
 constexpr uint16_t kScalarOperandTtmpBase = 108;
 constexpr uint16_t kTtmpRdna4GridYz = 7;
 constexpr uint16_t kTtmpRdna4GridX = 9;
+
+[[nodiscard]] bool image_contains_range(size_t image_size, uint64_t offset, uint64_t size) {
+  return offset <= image_size && size <= image_size - offset;
+}
 
 // -----------------------------------------------------------------------------
 // ISA-family helpers.
@@ -211,11 +216,10 @@ kernel_descriptor_symbol_name(const Elf64_Sym &sym, const char *strtab, size_t s
 
 [[nodiscard]] std::optional<uint64_t> text_vaddr_for_section(uint64_t text_offset,
                                                              uint64_t text_size,
-                                                             const Elf64_Ehdr &ehdr,
-                                                             const Elf64_Shdr *shdr) {
-  for (int i = 0; i < ehdr.e_shnum; ++i) {
-    if (shdr[i].sh_offset == text_offset && shdr[i].sh_size == text_size)
-      return shdr[i].sh_addr;
+                                                             std::span<const Elf64_Shdr> sections) {
+  for (const Elf64_Shdr &section : sections) {
+    if (section.sh_offset == text_offset && section.sh_size == text_size)
+      return section.sh_addr;
   }
   return std::nullopt;
 }
@@ -229,12 +233,16 @@ void visit_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offs
   if (image.size() < sizeof(Elf64_Ehdr))
     return;
 
-  const auto *ehdr = reinterpret_cast<const Elf64_Ehdr *>(image.data());
-  if (ehdr->e_shoff + static_cast<uint64_t>(ehdr->e_shnum) * sizeof(Elf64_Shdr) > image.size())
+  Elf64_Ehdr ehdr{};
+  std::memcpy(&ehdr, image.data(), sizeof(ehdr));
+  const uint64_t section_table_size = static_cast<uint64_t>(ehdr.e_shnum) * sizeof(Elf64_Shdr);
+  if (ehdr.e_shnum == 0 || ehdr.e_shentsize != sizeof(Elf64_Shdr) ||
+      !image_contains_range(image.size(), ehdr.e_shoff, section_table_size))
     return;
 
-  const auto *shdr = reinterpret_cast<const Elf64_Shdr *>(image.data() + ehdr->e_shoff);
-  auto text_vaddr = text_vaddr_for_section(text_offset, text_size, *ehdr, shdr);
+  std::vector<Elf64_Shdr> sections(ehdr.e_shnum);
+  std::memcpy(sections.data(), image.data() + ehdr.e_shoff, section_table_size);
+  auto text_vaddr = text_vaddr_for_section(text_offset, text_size, sections);
   if (!text_vaddr)
     return;
   constexpr uint64_t max_u64 = std::numeric_limits<uint64_t>::max();
@@ -245,38 +253,43 @@ void visit_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offs
   // .symtab and .dynsym may both describe the same descriptor. Translation is
   // keyed by descriptor bytes, so visit each file offset once.
   std::unordered_set<uint64_t> seen_descriptor_offsets;
-  for (int i = 0; i < ehdr->e_shnum; ++i) {
-    if (shdr[i].sh_type != SHT_SYMTAB && shdr[i].sh_type != SHT_DYNSYM)
+  for (const Elf64_Shdr &symbol_section : sections) {
+    if (symbol_section.sh_type != SHT_SYMTAB && symbol_section.sh_type != SHT_DYNSYM)
       continue;
-    if (shdr[i].sh_offset + shdr[i].sh_size > image.size() || shdr[i].sh_entsize == 0)
+    if (!image_contains_range(image.size(), symbol_section.sh_offset, symbol_section.sh_size) ||
+        symbol_section.sh_entsize == 0)
       continue;
-    if (shdr[i].sh_entsize != sizeof(Elf64_Sym))
+    if (symbol_section.sh_entsize != sizeof(Elf64_Sym))
       continue;
 
     const char *strtab = nullptr;
     size_t strtab_size = 0;
-    if (shdr[i].sh_link < ehdr->e_shnum) {
-      const auto &strtab_shdr = shdr[shdr[i].sh_link];
-      if (strtab_shdr.sh_offset + strtab_shdr.sh_size <= image.size()) {
+    if (symbol_section.sh_link < sections.size()) {
+      const auto &strtab_shdr = sections[symbol_section.sh_link];
+      if (image_contains_range(image.size(), strtab_shdr.sh_offset, strtab_shdr.sh_size)) {
         strtab = reinterpret_cast<const char *>(image.data() + strtab_shdr.sh_offset);
-        strtab_size = strtab_shdr.sh_size;
+        strtab_size = static_cast<size_t>(strtab_shdr.sh_size);
       }
     }
 
-    const auto *symtab = reinterpret_cast<const Elf64_Sym *>(image.data() + shdr[i].sh_offset);
-    const size_t nsyms = shdr[i].sh_size / shdr[i].sh_entsize;
+    const size_t nsyms = symbol_section.sh_size / symbol_section.sh_entsize;
     for (size_t j = 0; j < nsyms; ++j) {
-      auto kernel_name = kernel_descriptor_symbol_name(symtab[j], strtab, strtab_size);
+      Elf64_Sym symbol{};
+      std::memcpy(&symbol, image.data() + symbol_section.sh_offset + j * symbol_section.sh_entsize,
+                  sizeof(symbol));
+      auto kernel_name = kernel_descriptor_symbol_name(symbol, strtab, strtab_size);
       if (!kernel_name)
         continue;
 
-      const uint16_t sec_idx = symtab[j].st_shndx;
-      if (sec_idx >= ehdr->e_shnum || symtab[j].st_value < shdr[sec_idx].sh_addr)
+      const uint16_t sec_idx = symbol.st_shndx;
+      if (sec_idx >= sections.size() || symbol.st_value < sections[sec_idx].sh_addr)
         continue;
 
-      const uint64_t file_off =
-          shdr[sec_idx].sh_offset + (symtab[j].st_value - shdr[sec_idx].sh_addr);
-      if (file_off + sizeof(KD) > image.size())
+      const uint64_t section_offset = symbol.st_value - sections[sec_idx].sh_addr;
+      if (sections[sec_idx].sh_offset > max_u64 - section_offset)
+        continue;
+      const uint64_t file_off = sections[sec_idx].sh_offset + section_offset;
+      if (!image_contains_range(image.size(), file_off, sizeof(KD)))
         continue;
       if (!seen_descriptor_offsets.insert(file_off).second)
         continue;
@@ -284,7 +297,7 @@ void visit_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offs
       KD desc;
       std::memcpy(&desc, image.data() + file_off, sizeof(desc));
       const int64_t entry_vaddr_signed =
-          static_cast<int64_t>(symtab[j].st_value) + desc.kernel_code_entry_byte_offset;
+          static_cast<int64_t>(symbol.st_value) + desc.kernel_code_entry_byte_offset;
 
       if (entry_vaddr_signed < 0)
         continue;
@@ -454,32 +467,6 @@ void visit_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offs
 
 [[nodiscard]] bool uses_gfx10_plus_rsrc3(rj_code_arch_t arch) {
   return arch_is_rdna(arch) || arch == ROCJITSU_CODE_ARCH_GFX1250;
-}
-
-[[nodiscard]] uint32_t descriptor_vgpr_granularity_for_wavefront(rj_code_arch_t arch,
-                                                                 uint32_t wavefront_size) {
-  // This is the AMDHSA kernel-descriptor encoding granularity for
-  // COMPUTE_PGM_RSRC1.GRANULATED_WORKITEM_VGPR_COUNT, not the physical VGPR
-  // allocation block from the ISA manuals. For example, RDNA3/RDNA4 manuals
-  // describe Wave64 physical allocation in blocks of 8 VGPRs (or 12 on
-  // 1536-VGPR/SIMD parts), while the AMDHSA descriptor table encodes
-  // GFX10-GFX12 Wave64 as max(0, ceil(vgprs_used / 4) - 1).
-  //
-  // If/when occupancy modeling needs the physical allocation block size, add a
-  // separate helper for that policy. Reusing this descriptor helper for
-  // occupancy would mix two different hardware contracts.
-  if (arch == ROCJITSU_CODE_ARCH_CDNA1)
-    return 4;
-  if (arch_is_cdna(arch))
-    return 8;
-  // gfx1250 exposes four 256-VGPR banks selected by WAVE_MODE.VGPR_MSB. Its
-  // AMDHSA descriptor allocates that combined Wave32 namespace in blocks of
-  // 16 VGPRs, unlike the 8-VGPR Wave32 granule used by generic RDNA targets.
-  if (arch == ROCJITSU_CODE_ARCH_GFX1250)
-    return 16;
-  if (arch_is_rdna(arch))
-    return wavefront_size == 32 ? 8 : 4;
-  return 1;
 }
 
 [[nodiscard]] uint32_t granulated_count_to_registers(uint32_t granulated, uint32_t granularity) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.h
@@ -332,20 +332,44 @@ struct VirtualLdsPlan {
   int16_t lds_overflow_workgroup_id_sgpr_z = -1;
 };
 
-/// @brief Composed per-kernel descriptor/resource/ABI translation plan.
+/// @brief Composed descriptor-backed kernel or descriptorless callable translation plan.
 ///
 /// @details The component plans are independently reusable by descriptor
 /// translation, semantic DBT, patching, and future DBI entry instrumentation.
-/// Inheritance retains the established field syntax while call sites migrate to
-/// narrower component types.
+/// Descriptorless STT_FUNC scopes reuse the entry/resource fields as
+/// conservative translation constraints even though they have no descriptor to
+/// patch. Inheritance retains the established field syntax while call sites
+/// migrate to narrower component types.
+struct CallableRange {
+  uint64_t begin = 0;
+  uint64_t end = 0;
+};
+
 struct KdTranslation : KernelDescriptorFacts, KernelResourcePlan, KernelEntryPlan, VirtualLdsPlan {
-  /// @brief False when resource or ABI translation cannot be represented safely.
+  /// @brief True when this plan represents ELF STT_FUNC roots rather than a
+  /// hardware-dispatchable AMDHSA kernel descriptor.
+  ///
+  /// Descriptorless callable functions still contain executable ISA and must
+  /// participate in stepping translation. They have no descriptor whose entry
+  /// or resource fields can be rewritten, so BinaryTranslator uses this marker
+  /// to keep their text/relocation transaction separate from descriptor policy.
+  bool descriptorless_callable = false;
+
+  /// @brief Complete, source-ordered STT_FUNC ranges in one callable scope.
+  ///
+  /// All descriptorless functions in an object are translated as one scope so
+  /// direct calls between them can be relocated without cloning a runtime
+  /// function-pointer target. Keeping both bounds in one value makes the
+  /// sorted/disjoint range invariant explicit.
+  std::vector<CallableRange> callable_ranges;
+
+  /// @brief False when this scope's resource or ABI translation cannot be represented safely.
   bool supported = true;
 
-  /// @brief True when DBT emitted a target `s_endpgm` stub instead of translating this kernel.
+  /// @brief True when DBT emitted a target `s_endpgm` stub for a descriptor-backed kernel scope.
   bool skipped = false;
 
-  /// @brief Structured warnings and errors produced while planning this descriptor.
+  /// @brief Structured warnings and errors produced while planning this translation scope.
   std::vector<TranslationDiagnostic> diagnostics;
 
   /// @brief Replace target resource/ABI state with a minimal skipped-kernel stub plan.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_scratch.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_scratch.cpp
@@ -20,7 +20,7 @@ SemanticSpillFrame::SemanticSpillFrame(TranslationContext &context)
 std::optional<SemanticSpillRange> SemanticSpillFrame::allocate_dwords(uint16_t dword_count,
                                                                       uint32_t byte_alignment,
                                                                       uint32_t max_dword_offset) {
-  if (dword_count == 0 || byte_alignment == 0)
+  if (!context_.private_spills_allowed || dword_count == 0 || byte_alignment == 0)
     return std::nullopt;
 
   const uint32_t bytes = static_cast<uint32_t>(dword_count) * sizeof(uint32_t);
@@ -75,7 +75,7 @@ SemanticScratchAllocator::acquire_vgprs(const SemanticScratchRequest &request) {
     search_start = static_cast<uint16_t>(*free + request.alignment);
   }
 
-  if (!request.allow_spill)
+  if (!request.allow_spill || !context_.private_spills_allowed)
     return {.lease = std::nullopt, .failure = SemanticScratchFailure::NoRegisterWindow};
 
   const uint16_t allocated_vgprs =

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_diagnostic.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_diagnostic.h
@@ -27,9 +27,45 @@ enum class DiagnosticKind {
   Legalization,
   ExpandMissing,
   ExpandFailed,
+  DataOnly,
+  NothingToTranslate,
   ResourceLimit,
   KernelSkipped,
 };
+
+[[nodiscard]] inline constexpr const char *diagnostic_severity_name(DiagnosticSeverity severity) {
+  switch (severity) {
+  case DiagnosticSeverity::Warning:
+    return "warning";
+  case DiagnosticSeverity::Error:
+    return "error";
+  }
+  return "diagnostic";
+}
+
+[[nodiscard]] inline constexpr const char *diagnostic_kind_name(DiagnosticKind kind) {
+  switch (kind) {
+  case DiagnosticKind::UnsupportedGuestArch:
+    return "unsupported-guest-arch";
+  case DiagnosticKind::KernelDescriptor:
+    return "kernel-descriptor";
+  case DiagnosticKind::Legalization:
+    return "legalization";
+  case DiagnosticKind::ExpandMissing:
+    return "expand-missing";
+  case DiagnosticKind::ExpandFailed:
+    return "expand-failed";
+  case DiagnosticKind::DataOnly:
+    return "data-only";
+  case DiagnosticKind::NothingToTranslate:
+    return "nothing-to-translate";
+  case DiagnosticKind::ResourceLimit:
+    return "resource-limit";
+  case DiagnosticKind::KernelSkipped:
+    return "kernel-skipped";
+  }
+  return "unknown";
+}
 
 /// @brief One user/developer-facing DBT diagnostic.
 ///
@@ -54,6 +90,13 @@ has_error_diagnostic(const std::vector<TranslationDiagnostic> &diagnostics) {
   });
 }
 
+[[nodiscard]] inline bool has_diagnostic_kind(const std::vector<TranslationDiagnostic> &diagnostics,
+                                              DiagnosticKind kind) {
+  return std::ranges::any_of(diagnostics, [kind](const TranslationDiagnostic &diagnostic) {
+    return diagnostic.kind == kind;
+  });
+}
+
 /// @brief True if any kernel was replaced by a non-dispatchable no-op stub.
 ///
 /// @details skip_failed_kernels reports a KernelSkipped *warning* (not an error),
@@ -64,9 +107,7 @@ has_error_diagnostic(const std::vector<TranslationDiagnostic> &diagnostics) {
 /// non-dispatchable, matching the HSA hook which refuses such a load.
 [[nodiscard]] inline bool
 has_skipped_kernel(const std::vector<TranslationDiagnostic> &diagnostics) {
-  return std::ranges::any_of(diagnostics, [](const TranslationDiagnostic &diagnostic) {
-    return diagnostic.kind == DiagnosticKind::KernelSkipped;
-  });
+  return has_diagnostic_kind(diagnostics, DiagnosticKind::KernelSkipped);
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_rule.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_rule.h
@@ -98,6 +98,12 @@ struct KernelResourceRequirements {
   /// guest body is allowed to clobber the dispatch/kernarg pointer SGPRs.
   uint32_t semantic_spill_persistent_end = 0;
 
+  /// @brief Whether semantic lowerings may grow and use per-lane private memory.
+  ///
+  /// Descriptorless callables have no dispatch descriptor whose private
+  /// segment size can be raised, so their translation must remain spill-free.
+  bool private_spills_allowed = true;
+
   /// @brief Construct an empty context component for tests or call sites without
   /// descriptor feedback.
   KernelResourceRequirements() = default;
@@ -198,6 +204,8 @@ private:
   /// std::nullopt if either would exceed the 32-bit private-size field.
   [[nodiscard]] std::optional<std::pair<uint32_t, uint32_t>>
   semantic_spill_reservation(uint32_t dwords) const {
+    if (!private_spills_allowed)
+      return std::nullopt;
     constexpr uint64_t kSpillAlignment = 16;
     constexpr uint64_t kMax = std::numeric_limits<uint32_t>::max();
     const uint64_t base =

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -6,6 +6,7 @@
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/dbt/kernel_descriptor_translator.h"
+#include "rocjitsu/code/patch/error_report.h"
 #include "rocjitsu/isa/arch/amdgpu/isa_properties.h"
 
 #include "rocjitsu/base/rj_compiler.h"
@@ -160,6 +161,979 @@ void insert_file_bytes(std::vector<uint8_t> &image, Elf64_Ehdr &ehdr,
       return i;
   }
   return std::nullopt;
+}
+
+[[nodiscard]] bool image_contains_range(size_t image_size, uint64_t file_offset, uint64_t size);
+
+[[nodiscard]] std::optional<std::string_view> section_name(const std::vector<uint8_t> &image,
+                                                           const Elf64_Ehdr &ehdr,
+                                                           std::span<const Elf64_Shdr> shdrs,
+                                                           size_t index) {
+  if (ehdr.e_shstrndx >= shdrs.size() || index >= shdrs.size())
+    return std::nullopt;
+  const Elf64_Shdr &strings = shdrs[ehdr.e_shstrndx];
+  if (strings.sh_type != SHT_STRTAB ||
+      !image_contains_range(image.size(), strings.sh_offset, strings.sh_size) ||
+      shdrs[index].sh_name >= strings.sh_size) {
+    return std::nullopt;
+  }
+
+  const uint64_t name_offset = strings.sh_offset + shdrs[index].sh_name;
+  const size_t available = static_cast<size_t>(strings.sh_size - shdrs[index].sh_name);
+  const char *name = reinterpret_cast<const char *>(image.data() + name_offset);
+  const size_t length = strnlen(name, available);
+  if (length == available)
+    return std::nullopt;
+  return std::string_view(name, length);
+}
+
+[[nodiscard]] std::optional<uint64_t> read_uleb128(std::span<const uint8_t> bytes, size_t &cursor,
+                                                   size_t end) {
+  uint64_t value = 0;
+  unsigned shift = 0;
+  while (cursor < end) {
+    const uint8_t byte = bytes[cursor++];
+    const uint64_t payload = byte & 0x7fu;
+    if (shift >= 64 || (payload << shift) >> shift != payload)
+      return std::nullopt;
+    value |= payload << shift;
+    if ((byte & 0x80u) == 0)
+      return value;
+    shift += 7;
+  }
+  return std::nullopt;
+}
+
+[[nodiscard]] std::optional<int64_t> read_sleb128(std::span<const uint8_t> bytes, size_t &cursor,
+                                                  size_t end) {
+  uint64_t value = 0;
+  unsigned shift = 0;
+  uint8_t byte = 0;
+  do {
+    if (cursor >= end || shift >= 64)
+      return std::nullopt;
+    byte = bytes[cursor++];
+    const uint64_t payload = byte & 0x7fu;
+    if ((payload << shift) >> shift != payload)
+      return std::nullopt;
+    value |= payload << shift;
+    shift += 7;
+  } while ((byte & 0x80u) != 0);
+
+  if ((byte & 0x40u) != 0 && shift < 64)
+    value |= std::numeric_limits<uint64_t>::max() << shift;
+  return static_cast<int64_t>(value);
+}
+
+[[nodiscard]] bool skip_uleb128(std::span<const uint8_t> bytes, size_t &cursor, size_t end) {
+  return read_uleb128(bytes, cursor, end).has_value();
+}
+
+[[nodiscard]] bool skip_sleb128(std::span<const uint8_t> bytes, size_t &cursor, size_t end) {
+  return read_sleb128(bytes, cursor, end).has_value();
+}
+
+[[nodiscard]] bool skip_cfi_expression(std::span<const uint8_t> bytes, size_t &cursor, size_t end) {
+  const auto length = read_uleb128(bytes, cursor, end);
+  if (!length || *length > end - cursor)
+    return false;
+  cursor += static_cast<size_t>(*length);
+  return true;
+}
+
+/// @brief Return whether a CFI program describes one state for the whole FDE.
+///
+/// Descriptorless DBT may change instruction offsets inside a callable. CFI
+/// state that advances at particular PCs would need its own instruction-level
+/// relocation map; range-wide AMDGPU rules can be preserved by relocating only
+/// the FDE start and end. Parse operands rather than byte-scanning so opcodes
+/// embedded in DWARF expressions do not cause false decisions.
+[[nodiscard]] bool cfi_program_is_location_invariant(std::span<const uint8_t> bytes) {
+  size_t cursor = 0;
+  while (cursor < bytes.size()) {
+    const uint8_t opcode = bytes[cursor++];
+    const uint8_t primary = opcode & 0xc0u;
+    if (primary == 0x40u)
+      return false; // DW_CFA_advance_loc
+    if (primary == 0x80u) {
+      if (!skip_uleb128(bytes, cursor, bytes.size()))
+        return false; // DW_CFA_offset
+      continue;
+    }
+    if (primary == 0xc0u)
+      continue; // DW_CFA_restore
+
+    switch (opcode) {
+    case 0x00: // DW_CFA_nop
+    case 0x0a: // DW_CFA_remember_state
+    case 0x0b: // DW_CFA_restore_state
+    case 0x2d: // DW_CFA_GNU_window_save / AArch64 negate_ra_state
+      break;
+    case 0x01: // DW_CFA_set_loc
+    case 0x02: // DW_CFA_advance_loc1
+    case 0x03: // DW_CFA_advance_loc2
+    case 0x04: // DW_CFA_advance_loc4
+      return false;
+    case 0x05: // DW_CFA_offset_extended
+    case 0x09: // DW_CFA_register
+    case 0x0c: // DW_CFA_def_cfa
+    case 0x14: // DW_CFA_val_offset
+    case 0x2f: // DW_CFA_GNU_negative_offset_extended
+      if (!skip_uleb128(bytes, cursor, bytes.size()) ||
+          !skip_uleb128(bytes, cursor, bytes.size())) {
+        return false;
+      }
+      break;
+    case 0x06: // DW_CFA_restore_extended
+    case 0x07: // DW_CFA_undefined
+    case 0x08: // DW_CFA_same_value
+    case 0x0d: // DW_CFA_def_cfa_register
+    case 0x0e: // DW_CFA_def_cfa_offset
+    case 0x2e: // DW_CFA_GNU_args_size
+      if (!skip_uleb128(bytes, cursor, bytes.size()))
+        return false;
+      break;
+    case 0x0f: // DW_CFA_def_cfa_expression
+      if (!skip_cfi_expression(bytes, cursor, bytes.size()))
+        return false;
+      break;
+    case 0x10: // DW_CFA_expression
+    case 0x16: // DW_CFA_val_expression
+      if (!skip_uleb128(bytes, cursor, bytes.size()) ||
+          !skip_cfi_expression(bytes, cursor, bytes.size())) {
+        return false;
+      }
+      break;
+    case 0x11: // DW_CFA_offset_extended_sf
+    case 0x12: // DW_CFA_def_cfa_sf
+    case 0x15: // DW_CFA_val_offset_sf
+      if (!skip_uleb128(bytes, cursor, bytes.size()) ||
+          !skip_sleb128(bytes, cursor, bytes.size())) {
+        return false;
+      }
+      break;
+    case 0x13: // DW_CFA_def_cfa_offset_sf
+      if (!skip_sleb128(bytes, cursor, bytes.size()))
+        return false;
+      break;
+    default:
+      return false;
+    }
+  }
+  return true;
+}
+
+struct PlacedTextOffset {
+  uint64_t target_offset = 0;
+  bool is_instruction_start = false;
+};
+using PlacedTextOffsets = std::unordered_map<uint64_t, PlacedTextOffset>;
+
+/// @brief Relocate the PC transitions in one FDE CFI program in place.
+///
+/// The linked AMDGPU form uses a four-byte code-alignment factor and compact
+/// advance_loc opcodes. Re-encode each transition through DBT's exact text
+/// offset map, preserving the original operand width so the `.eh_frame`
+/// section itself does not change size.
+[[nodiscard]] bool
+relocate_fde_cfi_program(std::span<const uint8_t> bytes, uint64_t source_start, uint64_t source_end,
+                         uint64_t target_start, uint64_t target_end, uint64_t text_vaddr,
+                         uint64_t code_alignment_factor, const PlacedTextOffsets &targets_by_source,
+                         std::vector<uint8_t> &relocated_out, std::string *error_out) {
+  const auto fail = [error_out](const char *message) {
+    report(error_out, message);
+    return false;
+  };
+  if (code_alignment_factor == 0)
+    return fail(".eh_frame CIE has a zero code-alignment factor");
+
+  uint64_t source_location = source_start;
+  uint64_t target_location = target_start;
+  std::vector<uint8_t> relocated;
+  relocated.reserve(bytes.size());
+  const auto emit_advance = [&](uint64_t units) -> bool {
+    if (units <= 0x3fu) {
+      relocated.push_back(static_cast<uint8_t>(0x40u | units));
+      return true;
+    }
+    if (units <= std::numeric_limits<uint8_t>::max()) {
+      relocated.push_back(0x02);
+      relocated.push_back(static_cast<uint8_t>(units));
+      return true;
+    }
+    if (units <= std::numeric_limits<uint16_t>::max()) {
+      relocated.push_back(0x03);
+      const uint16_t encoded = static_cast<uint16_t>(units);
+      const auto *data = reinterpret_cast<const uint8_t *>(&encoded);
+      relocated.insert(relocated.end(), data, data + sizeof(encoded));
+      return true;
+    }
+    if (units <= std::numeric_limits<uint32_t>::max()) {
+      relocated.push_back(0x04);
+      const uint32_t encoded = static_cast<uint32_t>(units);
+      const auto *data = reinterpret_cast<const uint8_t *>(&encoded);
+      relocated.insert(relocated.end(), data, data + sizeof(encoded));
+      return true;
+    }
+    return fail("relocated .eh_frame CFI advance_loc4 no longer fits");
+  };
+  const auto relocate_advance = [&](uint64_t source_units, uint64_t &target_units) -> bool {
+    if (source_units >
+        (std::numeric_limits<uint64_t>::max() - source_location) / code_alignment_factor) {
+      return fail(".eh_frame CFI source location overflows");
+    }
+    const uint64_t next_source = source_location + source_units * code_alignment_factor;
+    if (next_source > source_end)
+      return fail(".eh_frame CFI location has no exact text relocation");
+    const auto targets_it = targets_by_source.find(next_source);
+    if (targets_it == targets_by_source.end())
+      return fail(".eh_frame CFI location has no monotonic text relocation");
+    const uint64_t target = targets_it->second.target_offset;
+    if (target < target_location || target > target_end)
+      return fail(".eh_frame CFI location has no monotonic text relocation");
+    const uint64_t target_delta = target - target_location;
+    if (target_delta % code_alignment_factor != 0)
+      return fail(".eh_frame CFI advance is not code-aligned after relocation");
+    target_units = target_delta / code_alignment_factor;
+    source_location = next_source;
+    target_location = target;
+    return true;
+  };
+  const auto relocate_set_location = [&](uint64_t source_vaddr, uint64_t &target_vaddr) -> bool {
+    if (source_vaddr < text_vaddr)
+      return fail(".eh_frame CFI set_loc points before .text");
+    const uint64_t source_offset = source_vaddr - text_vaddr;
+    if (source_offset < source_location || source_offset > source_end) {
+      return fail(".eh_frame CFI set_loc has no exact text relocation");
+    }
+    const auto targets_it = targets_by_source.find(source_offset);
+    if (targets_it == targets_by_source.end())
+      return fail(".eh_frame CFI set_loc has no representable monotonic relocation");
+    const uint64_t target = targets_it->second.target_offset;
+    if (target < target_location || target > target_end ||
+        text_vaddr > std::numeric_limits<uint64_t>::max() - target)
+      return fail(".eh_frame CFI set_loc has no representable monotonic relocation");
+    source_location = source_offset;
+    target_location = target;
+    target_vaddr = text_vaddr + target_location;
+    return true;
+  };
+
+  size_t cursor = 0;
+  while (cursor < bytes.size()) {
+    const size_t opcode_offset = cursor;
+    const uint8_t opcode = bytes[cursor++];
+    const uint8_t primary = opcode & 0xc0u;
+    if (primary == 0x40u) {
+      uint64_t target_units = 0;
+      if (!relocate_advance(opcode & 0x3fu, target_units))
+        return false;
+      if (!emit_advance(target_units))
+        return false;
+      continue;
+    }
+    if (primary == 0x80u) {
+      if (!skip_uleb128(bytes, cursor, bytes.size()))
+        return fail("allocated .eh_frame has malformed CFI");
+      relocated.insert(relocated.end(), bytes.begin() + opcode_offset, bytes.begin() + cursor);
+      continue;
+    }
+    if (primary == 0xc0u) {
+      relocated.push_back(opcode);
+      continue;
+    }
+
+    switch (opcode) {
+    case 0x00: // DW_CFA_nop
+      continue;
+    case 0x0a: // DW_CFA_remember_state
+    case 0x0b: // DW_CFA_restore_state
+    case 0x2d: // DW_CFA_GNU_window_save / AArch64 negate_ra_state
+      break;
+    case 0x01: { // DW_CFA_set_loc
+      if (bytes.size() - cursor < sizeof(uint64_t))
+        return fail("allocated .eh_frame has a truncated CFI set_loc");
+      uint64_t source_vaddr = 0;
+      std::memcpy(&source_vaddr, bytes.data() + cursor, sizeof(source_vaddr));
+      uint64_t target_vaddr = 0;
+      if (!relocate_set_location(source_vaddr, target_vaddr))
+        return false;
+      relocated.push_back(opcode);
+      const auto *data = reinterpret_cast<const uint8_t *>(&target_vaddr);
+      relocated.insert(relocated.end(), data, data + sizeof(target_vaddr));
+      cursor += sizeof(target_vaddr);
+      continue;
+    }
+    case 0x02: { // DW_CFA_advance_loc1
+      if (cursor == bytes.size())
+        return fail("allocated .eh_frame has a truncated CFI advance_loc1");
+      uint64_t target_units = 0;
+      if (!relocate_advance(bytes[cursor], target_units))
+        return false;
+      ++cursor;
+      if (!emit_advance(target_units))
+        return false;
+      continue;
+    }
+    case 0x03: { // DW_CFA_advance_loc2
+      if (bytes.size() - cursor < sizeof(uint16_t))
+        return fail("allocated .eh_frame has a truncated CFI advance_loc2");
+      uint16_t source_units = 0;
+      std::memcpy(&source_units, bytes.data() + cursor, sizeof(source_units));
+      uint64_t target_units = 0;
+      if (!relocate_advance(source_units, target_units))
+        return false;
+      cursor += sizeof(source_units);
+      if (!emit_advance(target_units))
+        return false;
+      continue;
+    }
+    case 0x04: { // DW_CFA_advance_loc4
+      if (bytes.size() - cursor < sizeof(uint32_t))
+        return fail("allocated .eh_frame has a truncated CFI advance_loc4");
+      uint32_t source_units = 0;
+      std::memcpy(&source_units, bytes.data() + cursor, sizeof(source_units));
+      uint64_t target_units = 0;
+      if (!relocate_advance(source_units, target_units))
+        return false;
+      cursor += sizeof(source_units);
+      if (!emit_advance(target_units))
+        return false;
+      continue;
+    }
+    case 0x05: // DW_CFA_offset_extended
+    case 0x09: // DW_CFA_register
+    case 0x0c: // DW_CFA_def_cfa
+    case 0x14: // DW_CFA_val_offset
+    case 0x2f: // DW_CFA_GNU_negative_offset_extended
+      if (!skip_uleb128(bytes, cursor, bytes.size()) ||
+          !skip_uleb128(bytes, cursor, bytes.size())) {
+        return fail("allocated .eh_frame has malformed CFI");
+      }
+      break;
+    case 0x06: // DW_CFA_restore_extended
+    case 0x07: // DW_CFA_undefined
+    case 0x08: // DW_CFA_same_value
+    case 0x0d: // DW_CFA_def_cfa_register
+    case 0x0e: // DW_CFA_def_cfa_offset
+    case 0x2e: // DW_CFA_GNU_args_size
+      if (!skip_uleb128(bytes, cursor, bytes.size()))
+        return fail("allocated .eh_frame has malformed CFI");
+      break;
+    case 0x0f: // DW_CFA_def_cfa_expression
+      if (!skip_cfi_expression(bytes, cursor, bytes.size()))
+        return fail("allocated .eh_frame has malformed CFI");
+      break;
+    case 0x10: // DW_CFA_expression
+    case 0x16: // DW_CFA_val_expression
+      if (!skip_uleb128(bytes, cursor, bytes.size()) ||
+          !skip_cfi_expression(bytes, cursor, bytes.size())) {
+        return fail("allocated .eh_frame has malformed CFI");
+      }
+      break;
+    case 0x11: // DW_CFA_offset_extended_sf
+    case 0x12: // DW_CFA_def_cfa_sf
+    case 0x15: // DW_CFA_val_offset_sf
+      if (!skip_uleb128(bytes, cursor, bytes.size()) ||
+          !skip_sleb128(bytes, cursor, bytes.size())) {
+        return fail("allocated .eh_frame has malformed CFI");
+      }
+      break;
+    case 0x13: // DW_CFA_def_cfa_offset_sf
+      if (!skip_sleb128(bytes, cursor, bytes.size()))
+        return fail("allocated .eh_frame has malformed CFI");
+      break;
+    default:
+      return fail("allocated .eh_frame uses an unsupported CFI opcode");
+    }
+    relocated.insert(relocated.end(), bytes.begin() + opcode_offset, bytes.begin() + cursor);
+  }
+  relocated_out = std::move(relocated);
+  return true;
+}
+
+/// @brief Decoded CIE properties required to relocate one `.eh_frame` FDE.
+struct EhFrameCie {
+  uint8_t fde_encoding = 0;
+  bool has_augmentation_length = false;
+  bool initial_program_location_invariant = true;
+  uint64_t code_alignment_factor = 0;
+  size_t relocated_offset = 0;
+};
+
+void shift_symbols_in_moved_sections(std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr,
+                                     std::span<const Elf64_Shdr> shdrs,
+                                     const std::vector<bool> &shift_section_vaddr, uint64_t delta);
+void shift_relocation_offsets_in_moved_sections(std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr,
+                                                std::span<const Elf64_Shdr> shdrs,
+                                                const std::vector<bool> &shift_section_vaddr,
+                                                uint64_t delta);
+
+/// @brief Relocate allocated `.eh_frame` FDEs through DBT's text offset map.
+///
+/// The supported AMDGPU form is the linked-HSACO `zR` CIE with
+/// pcrel+sdata4 FDE starts. Function ranges and FDE CFI location advances are
+/// relocated through the exact instruction offset map. Unsupported forms fail
+/// closed instead of leaving unwind PCs pointing at stale B0 code.
+[[nodiscard]] bool relocate_eh_frame_fdes(std::vector<uint8_t> &image, Elf64_Ehdr &ehdr,
+                                          std::vector<Elf64_Shdr> &shdrs,
+                                          std::vector<Elf64_Phdr> &phdrs, size_t text_index,
+                                          uint64_t old_text_size, uint64_t new_text_size,
+                                          std::span<const TextOffsetRelocation> relocations,
+                                          std::vector<bool> &shift_section_vaddr,
+                                          uint64_t future_text_delta, std::string *error_out) {
+  const auto fail = [error_out](const char *message) {
+    report(error_out, message);
+    return false;
+  };
+  for (const TextOffsetRelocation &relocation : relocations) {
+    if (relocation.source_offset > old_text_size || relocation.target_offset > new_text_size)
+      return fail(".eh_frame relocation map contains an out-of-range text offset");
+  }
+
+  const bool layout_changed = old_text_size != new_text_size ||
+                              std::ranges::any_of(relocations, [](const auto &relocation) {
+                                return relocation.source_offset != relocation.target_offset;
+                              });
+  if (!layout_changed)
+    return true;
+  if (shift_section_vaddr.size() != shdrs.size())
+    return fail(".eh_frame relocation has incomplete final section placement");
+
+  std::vector<size_t> eh_frame_sections;
+  for (size_t section_index = 0; section_index < shdrs.size(); ++section_index) {
+    const auto name = section_name(image, ehdr, shdrs, section_index);
+    if (!name)
+      return fail("ELF section names are malformed while locating .eh_frame");
+    if (*name == ".eh_frame_hdr" && (shdrs[section_index].sh_flags & SHF_ALLOC) != 0)
+      return fail("allocated .eh_frame_hdr relocation is unsupported");
+    if (*name == ".eh_frame" && (shdrs[section_index].sh_flags & SHF_ALLOC) != 0)
+      eh_frame_sections.push_back(section_index);
+  }
+  if (eh_frame_sections.empty())
+    return true;
+
+  struct RelocationPlacement {
+    PlacedTextOffsets offsets;
+  };
+  std::vector<RelocationPlacement> placements;
+  std::unordered_map<uint64_t, size_t> placement_index_by_id;
+  for (const TextOffsetRelocation &relocation : relocations) {
+    auto [placement_it, inserted] =
+        placement_index_by_id.try_emplace(relocation.placement_id, placements.size());
+    if (inserted)
+      placements.emplace_back();
+    PlacedTextOffsets &offsets = placements[placement_it->second].offsets;
+    auto [offset_it, offset_inserted] = offsets.try_emplace(
+        relocation.source_offset,
+        PlacedTextOffset{.target_offset = relocation.target_offset,
+                         .is_instruction_start = relocation.source_is_instruction_start});
+    if (!offset_inserted) {
+      if (offset_it->second.target_offset != relocation.target_offset)
+        return fail(".eh_frame relocation placement maps one source offset to multiple targets");
+      offset_it->second.is_instruction_start |= relocation.source_is_instruction_start;
+    }
+  }
+
+  const Elf64_Shdr &text = shdrs[text_index];
+  if (text.sh_addr > std::numeric_limits<uint64_t>::max() - old_text_size)
+    return fail(".text address range overflows while relocating .eh_frame");
+  const uint64_t old_text_end = text.sh_addr + old_text_size;
+
+  for (const size_t section_index : eh_frame_sections) {
+    const Elf64_Shdr section = shdrs[section_index];
+    if (section.sh_type != SHT_PROGBITS ||
+        !image_contains_range(image.size(), section.sh_offset, section.sh_size)) {
+      return fail("allocated .eh_frame section is malformed");
+    }
+    const uint64_t section_future_delta =
+        shift_section_vaddr[section_index] ? future_text_delta : 0;
+    if (section.sh_addr > std::numeric_limits<uint64_t>::max() - section_future_delta) {
+      return fail("relocated .eh_frame section address overflows");
+    }
+    // Parse pcrel fields at their source address, then encode them relative to
+    // the section's final address after text growth shifts later LOADs.
+    const uint64_t target_section_vaddr = section.sh_addr + section_future_delta;
+    const auto bytes =
+        std::span<uint8_t>(image.data() + section.sh_offset, static_cast<size_t>(section.sh_size));
+    const auto const_bytes = std::span<const uint8_t>(bytes.data(), bytes.size());
+    std::vector<uint8_t> relocated_section;
+    relocated_section.reserve(bytes.size());
+    std::vector<size_t> relocated_initial_location_fields;
+    bool had_terminator = false;
+    std::unordered_map<uint64_t, EhFrameCie> cies;
+    size_t cursor = 0;
+    while (cursor < bytes.size()) {
+      const size_t entry_start = cursor;
+      if (bytes.size() - cursor < sizeof(uint32_t))
+        return fail("allocated .eh_frame has a truncated entry length");
+      uint32_t length = 0;
+      std::memcpy(&length, bytes.data() + cursor, sizeof(length));
+      cursor += sizeof(length);
+      if (length == 0) {
+        if (!std::ranges::all_of(bytes.subspan(cursor), [](uint8_t byte) { return byte == 0; }))
+          return fail("allocated .eh_frame has nonzero data after its terminator");
+        had_terminator = true;
+        break;
+      }
+      if (length == std::numeric_limits<uint32_t>::max() || length < sizeof(uint32_t) ||
+          length > bytes.size() - cursor) {
+        return fail("allocated .eh_frame has an unsupported or invalid entry length");
+      }
+      const size_t entry_end = cursor + length;
+      const size_t id_field = cursor;
+      uint32_t cie_pointer = 0;
+      std::memcpy(&cie_pointer, bytes.data() + cursor, sizeof(cie_pointer));
+      cursor += sizeof(cie_pointer);
+
+      if (cie_pointer == 0) {
+        if (cursor >= entry_end)
+          return fail("allocated .eh_frame has a truncated CIE");
+        const uint8_t version = bytes[cursor++];
+        if (version != 1)
+          return fail("unsupported .eh_frame CIE version");
+        const size_t augmentation_start = cursor;
+        while (cursor < entry_end && bytes[cursor] != 0)
+          ++cursor;
+        if (cursor == entry_end)
+          return fail("allocated .eh_frame CIE has an unterminated augmentation string");
+        const std::string_view augmentation(
+            reinterpret_cast<const char *>(bytes.data() + augmentation_start),
+            cursor - augmentation_start);
+        ++cursor;
+        const auto code_alignment_factor = read_uleb128(const_bytes, cursor, entry_end);
+        if (!code_alignment_factor || *code_alignment_factor == 0 ||
+            !read_sleb128(const_bytes, cursor, entry_end)) {
+          return fail("allocated .eh_frame CIE has malformed alignment fields");
+        }
+        if (cursor >= entry_end)
+          return fail("allocated .eh_frame CIE is missing its return-address register");
+        ++cursor;
+
+        EhFrameCie cie;
+        if (!augmentation.empty()) {
+          if (augmentation.front() != 'z')
+            return fail("allocated .eh_frame CIE uses an unsupported augmentation format");
+          cie.has_augmentation_length = true;
+          const auto augmentation_size = read_uleb128(const_bytes, cursor, entry_end);
+          if (!augmentation_size || *augmentation_size > entry_end - cursor)
+            return fail("allocated .eh_frame CIE has malformed augmentation data");
+          const size_t augmentation_end = cursor + static_cast<size_t>(*augmentation_size);
+          for (const char kind : augmentation.substr(1)) {
+            switch (kind) {
+            case 'R':
+              if (cursor >= augmentation_end)
+                return fail("allocated .eh_frame CIE is missing its FDE encoding");
+              cie.fde_encoding = bytes[cursor++];
+              break;
+            case 'L':
+              return fail("allocated .eh_frame CIE uses unsupported LSDA augmentation");
+            case 'S':
+              break;
+            default:
+              // Personality encodings and vendor augmentation data need a
+              // complete encoded-pointer parser before their FDE layout can be
+              // trusted.
+              return fail("allocated .eh_frame CIE uses an unsupported augmentation");
+            }
+          }
+          if (cursor > augmentation_end)
+            return fail("allocated .eh_frame CIE augmentation exceeds its declared size");
+          cursor = augmentation_end;
+        }
+        cie.code_alignment_factor = *code_alignment_factor;
+        cie.initial_program_location_invariant =
+            cfi_program_is_location_invariant(const_bytes.subspan(cursor, entry_end - cursor));
+        cie.relocated_offset = relocated_section.size();
+        cies.emplace(entry_start, cie);
+        relocated_section.insert(relocated_section.end(), bytes.begin() + entry_start,
+                                 bytes.begin() + entry_end);
+        cursor = entry_end;
+        continue;
+      }
+
+      if (cie_pointer > id_field)
+        return fail("allocated .eh_frame FDE has an invalid CIE pointer");
+      const uint64_t cie_start = id_field - cie_pointer;
+      const auto cie_it = cies.find(cie_start);
+      if (cie_it == cies.end())
+        return fail("allocated .eh_frame FDE references an unknown CIE");
+      const EhFrameCie &cie = cie_it->second;
+      constexpr uint8_t kDwEhPePcrelSdata4 = 0x1b;
+      if (cie.fde_encoding != kDwEhPePcrelSdata4 || entry_end - cursor < 2 * sizeof(uint32_t)) {
+        return fail("allocated .eh_frame FDE uses an unsupported encoding or is truncated");
+      }
+
+      const size_t initial_location_field = cursor;
+      int32_t initial_location_delta = 0;
+      std::memcpy(&initial_location_delta, bytes.data() + cursor, sizeof(initial_location_delta));
+      cursor += sizeof(initial_location_delta);
+      int32_t address_range = 0;
+      const size_t address_range_field = cursor;
+      std::memcpy(&address_range, bytes.data() + cursor, sizeof(address_range));
+      cursor += sizeof(address_range);
+      if (address_range < 0 ||
+          section.sh_addr >
+              static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) - initial_location_field) {
+        return fail("allocated .eh_frame FDE has an invalid address range");
+      }
+      const int64_t field_vaddr = static_cast<int64_t>(section.sh_addr + initial_location_field);
+      if ((initial_location_delta > 0 &&
+           field_vaddr > std::numeric_limits<int64_t>::max() - initial_location_delta) ||
+          (initial_location_delta < 0 &&
+           field_vaddr < std::numeric_limits<int64_t>::min() - initial_location_delta)) {
+        return fail("allocated .eh_frame FDE initial location overflows");
+      }
+      const int64_t initial_location = field_vaddr + initial_location_delta;
+      if (initial_location < 0)
+        return fail("allocated .eh_frame FDE has a negative initial location");
+      const uint64_t source_vaddr = static_cast<uint64_t>(initial_location);
+      const uint64_t source_range = static_cast<uint32_t>(address_range);
+      if (source_vaddr > std::numeric_limits<uint64_t>::max() - source_range)
+        return fail("allocated .eh_frame FDE source range overflows");
+      const uint64_t source_vaddr_end = source_vaddr + source_range;
+
+      if (cie.has_augmentation_length) {
+        const auto augmentation_size = read_uleb128(const_bytes, cursor, entry_end);
+        if (!augmentation_size || *augmentation_size > entry_end - cursor)
+          return fail("allocated .eh_frame FDE has malformed augmentation data");
+        cursor += static_cast<size_t>(*augmentation_size);
+      }
+
+      const bool starts_in_text = source_vaddr >= text.sh_addr && source_vaddr < old_text_end;
+      const bool overlaps_text = source_vaddr < old_text_end && source_vaddr_end > text.sh_addr;
+      struct RelocatedFde {
+        uint64_t target_vaddr = 0;
+        uint64_t target_range_size = 0;
+        std::vector<uint8_t> cfi;
+      };
+      std::vector<RelocatedFde> relocated_fdes;
+      if (!starts_in_text) {
+        if (overlaps_text)
+          return fail("allocated .eh_frame FDE partially overlaps .text");
+        relocated_fdes.push_back(
+            {.target_vaddr = source_vaddr,
+             .target_range_size = source_range,
+             .cfi = std::vector<uint8_t>(bytes.begin() + cursor, bytes.begin() + entry_end)});
+      } else {
+        if (source_vaddr_end > old_text_end)
+          return fail("allocated .eh_frame FDE extends beyond .text");
+        const uint64_t source_start = source_vaddr - text.sh_addr;
+        const uint64_t source_end = source_vaddr_end - text.sh_addr;
+        // A helper may be copied into several kernel-local translated bodies.
+        // Preserve an FDE for every copy: ELF can retain only one symbol value,
+        // but unwind consumers must be able to cover traps and samples in all
+        // emitted clones. Pair start/end mappings only within the same emitted
+        // placement, and require a real instruction at the source start. This
+        // excludes the block-end mapping from the preceding kernel when two
+        // source functions meet at the same offset.
+        for (const RelocationPlacement &placement : placements) {
+          const auto target_start_it = placement.offsets.find(source_start);
+          const auto target_end_it = placement.offsets.find(source_end);
+          if (target_start_it == placement.offsets.end() ||
+              !target_start_it->second.is_instruction_start ||
+              target_end_it == placement.offsets.end()) {
+            continue;
+          }
+
+          const uint64_t target_start = target_start_it->second.target_offset;
+          const uint64_t target_end = target_end_it->second.target_offset;
+          if (target_end < target_start ||
+              (source_end != source_start && target_end == target_start) ||
+              target_end > new_text_size) {
+            continue;
+          }
+
+          bool affine = true;
+          for (const auto &[source, target] : placement.offsets) {
+            if (source < source_start || source > source_end)
+              continue;
+            if (source - source_start > target_end - target_start ||
+                target.target_offset != target_start + (source - source_start)) {
+              affine = false;
+              break;
+            }
+          }
+          if (!affine && !cie.initial_program_location_invariant)
+            return fail("non-affine .eh_frame CIE has location-sensitive CFI");
+
+          std::vector<uint8_t> relocated_cfi;
+          if (!relocate_fde_cfi_program(const_bytes.subspan(cursor, entry_end - cursor),
+                                        source_start, source_end, target_start, target_end,
+                                        text.sh_addr, cie.code_alignment_factor, placement.offsets,
+                                        relocated_cfi, error_out)) {
+            return false;
+          }
+          if (text.sh_addr > std::numeric_limits<uint64_t>::max() - target_start)
+            return fail("relocated .eh_frame FDE target address overflows");
+          relocated_fdes.push_back({.target_vaddr = text.sh_addr + target_start,
+                                    .target_range_size = target_end - target_start,
+                                    .cfi = std::move(relocated_cfi)});
+        }
+        if (relocated_fdes.empty())
+          return fail("allocated .eh_frame FDE lacks an exact instruction relocation range");
+      }
+
+      const size_t initial_location_in_entry = initial_location_field - entry_start;
+      const size_t address_range_in_entry = address_range_field - entry_start;
+      const size_t id_field_in_entry = id_field - entry_start;
+      for (const RelocatedFde &relocated_fde : relocated_fdes) {
+        const size_t relocated_entry_start = relocated_section.size();
+        if (relocated_entry_start >
+                std::numeric_limits<uint64_t>::max() - initial_location_in_entry ||
+            target_section_vaddr > std::numeric_limits<uint64_t>::max() -
+                                       (relocated_entry_start + initial_location_in_entry)) {
+          return fail("relocated .eh_frame FDE field address overflows");
+        }
+        const uint64_t relocated_initial_location_field =
+            relocated_entry_start + initial_location_in_entry;
+        const uint64_t target_field_vaddr = target_section_vaddr + relocated_initial_location_field;
+        if (relocated_fde.target_vaddr >
+                static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) ||
+            target_field_vaddr > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+          return fail("relocated .eh_frame FDE target is not representable");
+        }
+        const int64_t target_delta = static_cast<int64_t>(relocated_fde.target_vaddr) -
+                                     static_cast<int64_t>(target_field_vaddr);
+        if (target_delta < std::numeric_limits<int32_t>::min() ||
+            target_delta > std::numeric_limits<int32_t>::max() ||
+            relocated_fde.target_range_size >
+                static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+          return fail("relocated .eh_frame FDE does not fit its pcrel+sdata4 encoding");
+        }
+
+        std::vector<uint8_t> relocated_entry(bytes.begin() + entry_start, bytes.begin() + cursor);
+        relocated_entry.insert(relocated_entry.end(), relocated_fde.cfi.begin(),
+                               relocated_fde.cfi.end());
+        while (relocated_entry.size() % sizeof(uint32_t) != 0)
+          relocated_entry.push_back(0);
+        if (relocated_entry.size() < 2 * sizeof(uint32_t) ||
+            relocated_entry.size() - sizeof(uint32_t) > std::numeric_limits<uint32_t>::max()) {
+          return fail("relocated .eh_frame FDE length is not representable");
+        }
+        if (relocated_entry_start > std::numeric_limits<uint64_t>::max() - id_field_in_entry ||
+            relocated_entry_start + id_field_in_entry < cie.relocated_offset ||
+            relocated_entry_start + id_field_in_entry - cie.relocated_offset >
+                std::numeric_limits<uint32_t>::max()) {
+          return fail("relocated .eh_frame FDE CIE pointer is not representable");
+        }
+        const uint32_t encoded_length =
+            static_cast<uint32_t>(relocated_entry.size() - sizeof(uint32_t));
+        const uint32_t encoded_cie_pointer =
+            static_cast<uint32_t>(relocated_entry_start + id_field_in_entry - cie.relocated_offset);
+        const int32_t encoded_target_delta = static_cast<int32_t>(target_delta);
+        const int32_t encoded_target_range = static_cast<int32_t>(relocated_fde.target_range_size);
+        std::memcpy(relocated_entry.data(), &encoded_length, sizeof(encoded_length));
+        std::memcpy(relocated_entry.data() + id_field_in_entry, &encoded_cie_pointer,
+                    sizeof(encoded_cie_pointer));
+        std::memcpy(relocated_entry.data() + initial_location_in_entry, &encoded_target_delta,
+                    sizeof(encoded_target_delta));
+        std::memcpy(relocated_entry.data() + address_range_in_entry, &encoded_target_range,
+                    sizeof(encoded_target_range));
+        relocated_initial_location_fields.push_back(relocated_initial_location_field);
+        relocated_section.insert(relocated_section.end(), relocated_entry.begin(),
+                                 relocated_entry.end());
+      }
+      cursor = entry_end;
+    }
+    if (had_terminator)
+      relocated_section.resize(relocated_section.size() + sizeof(uint32_t), 0);
+    if (relocated_section.size() > bytes.size()) {
+      const uint64_t insertion_file_offset = section.sh_offset + section.sh_size;
+      const uint64_t required_growth = relocated_section.size() - bytes.size();
+      const uint64_t file_alignment = shifted_load_delta_alignment(phdrs, insertion_file_offset);
+      const uint64_t padded_growth = align_up(required_growth, file_alignment);
+      if (padded_growth < required_growth || padded_growth > std::numeric_limits<size_t>::max() ||
+          section.sh_size > std::numeric_limits<uint64_t>::max() - padded_growth) {
+        return fail("relocated .eh_frame section growth overflows");
+      }
+
+      std::optional<size_t> owner_index;
+      for (size_t phdr_index = 0; phdr_index < phdrs.size(); ++phdr_index) {
+        const Elf64_Phdr &phdr = phdrs[phdr_index];
+        if (phdr.p_type != PT_LOAD ||
+            phdr.p_offset > std::numeric_limits<uint64_t>::max() - phdr.p_filesz)
+          continue;
+        if (section.sh_offset >= phdr.p_offset &&
+            phdr.p_offset + phdr.p_filesz == insertion_file_offset) {
+          owner_index = phdr_index;
+          break;
+        }
+      }
+
+      bool can_grow_in_place = false;
+      if (owner_index &&
+          section.sh_addr <= std::numeric_limits<uint64_t>::max() - section.sh_size) {
+        const Elf64_Phdr &owner = phdrs[*owner_index];
+        if (owner.p_vaddr <= std::numeric_limits<uint64_t>::max() - owner.p_memsz &&
+            section.sh_addr + section.sh_size <= owner.p_vaddr + owner.p_memsz) {
+          const uint64_t owner_vaddr_end = owner.p_vaddr + owner.p_memsz;
+          if (owner_vaddr_end <= std::numeric_limits<uint64_t>::max() - padded_growth) {
+            can_grow_in_place = std::ranges::none_of(phdrs, [&](const Elf64_Phdr &phdr) {
+              return phdr.p_type == PT_LOAD && phdr.p_vaddr >= owner_vaddr_end &&
+                     phdr.p_vaddr < owner_vaddr_end + padded_growth;
+            });
+          }
+        }
+      }
+
+      if (can_grow_in_place) {
+        std::vector<uint8_t> inserted(static_cast<size_t>(padded_growth), 0);
+        insert_file_bytes(image, ehdr, shdrs, phdrs, insertion_file_offset, inserted, section_index,
+                          true);
+        shdrs[section_index].sh_size += padded_growth;
+      } else {
+        // Linked GPU objects commonly place .eh_frame immediately before the
+        // executable LOAD. When cloning a shared helper requires more unwind
+        // entries than that virtual gap can hold, move the rebuilt section to
+        // the tail LOAD instead of shifting the executable image or dropping
+        // coverage for a clone.
+        std::optional<size_t> tail_load_index;
+        uint64_t greatest_file_end = 0;
+        uint64_t greatest_memory_end = 0;
+        for (size_t phdr_index = 0; phdr_index < phdrs.size(); ++phdr_index) {
+          const Elf64_Phdr &phdr = phdrs[phdr_index];
+          if (phdr.p_type != PT_LOAD ||
+              phdr.p_offset > std::numeric_limits<uint64_t>::max() - phdr.p_filesz ||
+              phdr.p_vaddr > std::numeric_limits<uint64_t>::max() - phdr.p_memsz) {
+            continue;
+          }
+          const uint64_t file_end = phdr.p_offset + phdr.p_filesz;
+          const uint64_t memory_end = phdr.p_vaddr + phdr.p_memsz;
+          greatest_file_end = std::max(greatest_file_end, file_end);
+          if (!tail_load_index || memory_end > greatest_memory_end ||
+              (memory_end == greatest_memory_end &&
+               file_end > phdrs[*tail_load_index].p_offset + phdrs[*tail_load_index].p_filesz)) {
+            tail_load_index = phdr_index;
+            greatest_memory_end = memory_end;
+          }
+        }
+        if (!tail_load_index)
+          return fail("allocated .eh_frame has no LOAD available for expanded unwind data");
+
+        const Elf64_Phdr tail_source = phdrs[*tail_load_index];
+        if (tail_source.p_offset > std::numeric_limits<uint64_t>::max() - tail_source.p_filesz ||
+            tail_source.p_vaddr > std::numeric_limits<uint64_t>::max() - tail_source.p_memsz ||
+            tail_source.p_offset + tail_source.p_filesz != greatest_file_end ||
+            tail_source.p_vaddr + tail_source.p_memsz != greatest_memory_end ||
+            tail_source.p_memsz < tail_source.p_filesz) {
+          return fail("allocated .eh_frame cannot identify a non-overlapping tail LOAD");
+        }
+
+        const uint64_t section_alignment = std::max<uint64_t>(section.sh_addralign, 1);
+        const uint64_t tail_memory_end = tail_source.p_vaddr + tail_source.p_memsz;
+        if (tail_memory_end > std::numeric_limits<uint64_t>::max() - (section_alignment - 1)) {
+          return fail("allocated .eh_frame tail alignment overflows");
+        }
+        const uint64_t destination_vaddr = align_up(tail_memory_end, section_alignment);
+        const uint64_t section_load_offset = destination_vaddr - tail_source.p_vaddr;
+        if (section_load_offset < tail_source.p_filesz ||
+            section_load_offset > std::numeric_limits<uint64_t>::max() - relocated_section.size()) {
+          return fail("allocated .eh_frame tail placement overflows");
+        }
+        const uint64_t inserted_size =
+            section_load_offset - tail_source.p_filesz + relocated_section.size();
+        if (inserted_size > std::numeric_limits<size_t>::max() ||
+            tail_source.p_offset > std::numeric_limits<uint64_t>::max() - tail_source.p_filesz ||
+            tail_source.p_offset > std::numeric_limits<uint64_t>::max() - section_load_offset ||
+            tail_source.p_offset + tail_source.p_filesz > image.size() ||
+            tail_source.p_vaddr > std::numeric_limits<uint64_t>::max() - section_load_offset) {
+          return fail("allocated .eh_frame tail insertion is not representable");
+        }
+
+        const uint64_t tail_insertion_file_offset = tail_source.p_offset + tail_source.p_filesz;
+        std::vector<std::pair<size_t, uint64_t>> preserved_nobits_offsets;
+        for (size_t other_index = 0; other_index < shdrs.size(); ++other_index) {
+          const Elf64_Shdr &other = shdrs[other_index];
+          if (other.sh_type != SHT_NOBITS || (other.sh_flags & SHF_ALLOC) == 0 ||
+              other.sh_offset < tail_insertion_file_offset) {
+            continue;
+          }
+          const bool remains_in_place = std::ranges::any_of(phdrs, [&](const Elf64_Phdr &phdr) {
+            return phdr.p_type == PT_LOAD &&
+                   phdr.p_vaddr <= std::numeric_limits<uint64_t>::max() - phdr.p_memsz &&
+                   other.sh_addr >= phdr.p_vaddr && other.sh_addr - phdr.p_vaddr < phdr.p_memsz;
+          });
+          if (remains_in_place)
+            preserved_nobits_offsets.emplace_back(other_index, other.sh_offset);
+        }
+
+        std::vector<uint8_t> inserted(static_cast<size_t>(inserted_size), 0);
+        insert_file_bytes(image, ehdr, shdrs, phdrs, tail_insertion_file_offset, inserted,
+                          std::nullopt, false);
+        Elf64_Phdr &tail = phdrs[*tail_load_index];
+        tail.p_offset = tail_source.p_offset;
+        tail.p_filesz = section_load_offset + relocated_section.size();
+        tail.p_memsz = tail.p_filesz;
+        for (const auto &[other_index, old_offset] : preserved_nobits_offsets)
+          shdrs[other_index].sh_offset = old_offset;
+
+        const uint64_t destination_file_offset = tail_source.p_offset + section_load_offset;
+        if (destination_file_offset % section_alignment != 0)
+          return fail("allocated .eh_frame tail LOAD cannot preserve section alignment");
+        if (destination_vaddr < section.sh_addr)
+          return fail("allocated .eh_frame tail LOAD precedes its source address");
+        tail.p_flags |= PF_R;
+        const uint64_t move_delta = destination_vaddr - section.sh_addr;
+        shdrs[section_index].sh_addr = destination_vaddr;
+        shdrs[section_index].sh_offset = destination_file_offset;
+        shdrs[section_index].sh_size = relocated_section.size();
+
+        std::vector<bool> moved_section(shdrs.size(), false);
+        moved_section[section_index] = true;
+        shift_symbols_in_moved_sections(image, ehdr, shdrs, moved_section, move_delta);
+        shift_relocation_offsets_in_moved_sections(image, ehdr, shdrs, moved_section, move_delta);
+
+        if (text.sh_offset > std::numeric_limits<uint64_t>::max() - old_text_size)
+          return fail("source .text file range overflows while moving .eh_frame");
+        const uint64_t old_text_end_file = text.sh_offset + old_text_size;
+        const bool destination_shifts_with_text = future_text_delta != 0 &&
+                                                  destination_vaddr >= old_text_end &&
+                                                  destination_file_offset >= old_text_end_file;
+        shift_section_vaddr[section_index] = destination_shifts_with_text;
+        const uint64_t destination_future_delta =
+            destination_shifts_with_text ? future_text_delta : 0;
+        if (destination_vaddr > std::numeric_limits<uint64_t>::max() - destination_future_delta) {
+          return fail("relocated .eh_frame tail address overflows");
+        }
+        const uint64_t final_destination_vaddr = destination_vaddr + destination_future_delta;
+        if (target_section_vaddr > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) ||
+            final_destination_vaddr > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+          return fail("relocated .eh_frame tail address is not representable");
+        }
+        const int64_t base_adjustment = static_cast<int64_t>(target_section_vaddr) -
+                                        static_cast<int64_t>(final_destination_vaddr);
+        for (const size_t field_offset : relocated_initial_location_fields) {
+          if (field_offset > relocated_section.size() ||
+              sizeof(int32_t) > relocated_section.size() - field_offset) {
+            return fail("relocated .eh_frame FDE field lies outside the rebuilt section");
+          }
+          int32_t encoded_delta = 0;
+          std::memcpy(&encoded_delta, relocated_section.data() + field_offset,
+                      sizeof(encoded_delta));
+          if ((encoded_delta > 0 &&
+               base_adjustment > std::numeric_limits<int64_t>::max() - encoded_delta) ||
+              (encoded_delta < 0 &&
+               base_adjustment < std::numeric_limits<int64_t>::min() - encoded_delta)) {
+            return fail("relocated .eh_frame tail PC adjustment overflows");
+          }
+          const int64_t adjusted_delta = base_adjustment + encoded_delta;
+          if (adjusted_delta < std::numeric_limits<int32_t>::min() ||
+              adjusted_delta > std::numeric_limits<int32_t>::max()) {
+            return fail("relocated .eh_frame tail PC does not fit pcrel+sdata4");
+          }
+          const int32_t adjusted = static_cast<int32_t>(adjusted_delta);
+          std::memcpy(relocated_section.data() + field_offset, &adjusted, sizeof(adjusted));
+        }
+      }
+    }
+    const auto relocated_bytes =
+        std::span<uint8_t>(image.data() + shdrs[section_index].sh_offset,
+                           static_cast<size_t>(shdrs[section_index].sh_size));
+    std::ranges::fill(relocated_bytes, 0);
+    std::ranges::copy(relocated_section, relocated_bytes.begin());
+  }
+  return true;
 }
 
 [[nodiscard]] bool target_supports_wave32(rj_code_arch_t arch) {
@@ -429,7 +1403,8 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
 [[nodiscard]] bool relocate_text_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr,
                                          std::span<const Elf64_Shdr> shdrs, size_t text_index,
                                          uint64_t old_text_size, uint64_t new_text_size,
-                                         std::span<const TextOffsetRelocation> relocations) {
+                                         std::span<const TextOffsetRelocation> relocations,
+                                         bool require_exact_function_ranges) {
   if (relocations.empty())
     return true;
 
@@ -525,10 +1500,19 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
       }
 
       const uint64_t old_size = symbol.st_size;
-      if (old_size <= old_text_size - source_text_offset) {
+      const uint8_t symbol_type = elf_symbol_type(symbol.st_info);
+      const bool sized_function = old_size != 0 && (symbol_type == kElfSymbolTypeFunc ||
+                                                    symbol_type == kElfSymbolTypeAmdGpuHsaKernel);
+      if (old_size > old_text_size - source_text_offset) {
+        if (must_relocate || (require_exact_function_ranges && sized_function))
+          return false;
+      } else {
         const auto relocated_end = target_by_source.find(source_text_offset + old_size);
-        if (relocated_end != target_by_source.end() &&
-            relocated_end->second >= relocated_start->second) {
+        if (relocated_end == target_by_source.end() ||
+            relocated_end->second < relocated_start->second) {
+          if (must_relocate || (require_exact_function_ranges && sized_function))
+            return false;
+        } else {
           symbol.st_size = relocated_end->second - relocated_start->second;
         }
       }
@@ -953,21 +1937,47 @@ bool CodeObjectPatcher::has_unsupported_relocation_to_text() const {
 
 bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
                                      std::span<const TextOffsetRelocation> text_relocations,
-                                     std::span<const PcRelativeDataRelocation> data_relocations) {
+                                     std::span<const PcRelativeDataRelocation> data_relocations,
+                                     std::string *error_out, std::vector<std::string> *warnings_out,
+                                     bool require_exact_function_ranges) {
+  const auto fail = [error_out](const char *message) {
+    report(error_out, message);
+    return false;
+  };
   // Keep fail-closed behavior for callers that assume word-aligned executable
   // sections; accepting a non-word-aligned replacement can break downstream
   // PC-relative patching and branch-distance checks.
   if ((new_text.size() % sizeof(uint32_t)) != 0)
-    return false;
+    return fail("replacement .text is not word-aligned");
 
   if (text_size_ == 0)
-    return false;
+    return fail("code object has no replaceable .text payload");
   if (new_text.size() < text_size_)
-    return false;
+    return fail("replacement .text is smaller than the source allocation");
   if (!image_contains_range(image_.size(), text_offset_, text_size_))
-    return false;
+    return fail("source .text extends beyond the ELF image");
   if (!text_relocations.empty() && has_unsupported_relocation_to_text())
-    return false;
+    return fail("ELF contains an unsupported relocation referencing .text");
+
+  // replace_text() is a public patch transaction. Several late validation
+  // paths run after unwind relocation or file insertion, so retain the exact
+  // original state until every ELF table update succeeds.
+  struct Rollback {
+    CodeObjectPatcher &patcher;
+    std::vector<uint8_t> image;
+    uint64_t text_offset;
+    uint64_t text_size;
+    uint64_t text_tail_size;
+    bool committed = false;
+    ~Rollback() {
+      if (committed)
+        return;
+      patcher.image_ = std::move(image);
+      patcher.text_offset_ = text_offset;
+      patcher.text_size_ = text_size;
+      patcher.text_tail_size_ = text_tail_size;
+    }
+  } rollback{*this, image_, text_offset_, text_size_, text_tail_size_};
 
   auto *ehdr = reinterpret_cast<Elf64_Ehdr *>(image_.data());
   auto header = *ehdr;
@@ -977,10 +1987,70 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
   const auto text_index = find_text_section(shdrs, text_offset_, text_size_);
   if (!text_index) {
     assert(false && "text section header not found");
-    return false;
+    return fail("source .text section header could not be found");
+  }
+  const auto text_header = shdrs[*text_index];
+  uint64_t old_text_end_file = text_offset_ + text_size_;
+  const uint64_t old_text_end_vaddr = text_header.sh_addr + text_size_;
+  const uint64_t growth = new_text.size() - text_size_;
+  uint64_t padded_file_delta = 0;
+  std::vector<bool> shift_section_vaddr(shdrs.size(), false);
+  std::vector<bool> shift_segment_vaddr(phdrs.size(), false);
+  if (growth != 0) {
+    // Growing .text can shift later LOAD segments. Pad the inserted file range
+    // so every shifted LOAD keeps p_offset % p_align congruent with p_vaddr %
+    // p_align. The padding is executable segment filler, not part of .text.
+    const uint64_t file_delta_alignment = shifted_load_delta_alignment(phdrs, old_text_end_file);
+    padded_file_delta = align_up(growth, file_delta_alignment);
+    assert(padded_file_delta >= growth && "aligned text growth underflowed");
+    assert(padded_file_delta % sizeof(uint32_t) == 0 && "text growth must stay word-aligned");
+
+    for (size_t i = 0; i < shdrs.size(); ++i) {
+      if (i == *text_index || shdrs[i].sh_type == SHT_NULL)
+        continue;
+      if ((shdrs[i].sh_flags & SHF_ALLOC) != 0 && shdrs[i].sh_addr >= old_text_end_vaddr) {
+        shift_section_vaddr[i] = true;
+      }
+    }
+    for (size_t i = 0; i < phdrs.size(); ++i) {
+      if (phdrs[i].p_vaddr >= old_text_end_vaddr && phdrs[i].p_offset >= old_text_end_file)
+        shift_segment_vaddr[i] = true;
+    }
   }
 
-  const auto text_header = shdrs[*text_index];
+  std::vector<std::string> warnings;
+  const bool layout_changed =
+      new_text.size() != text_size_ ||
+      std::ranges::any_of(text_relocations, [](const TextOffsetRelocation &relocation) {
+        return relocation.source_offset != relocation.target_offset;
+      });
+  if (layout_changed) {
+    bool dropped_debug = false;
+    for (size_t section_index = 0; section_index < shdrs.size(); ++section_index) {
+      const auto name = section_name(image_, header, shdrs, section_index);
+      if (!name)
+        return fail("ELF section names are malformed while locating debug metadata");
+      if ((shdrs[section_index].sh_flags & SHF_ALLOC) == 0 &&
+          (name->starts_with(".debug_") || name->starts_with(".zdebug_")) &&
+          shdrs[section_index].sh_size != 0) {
+        shdrs[section_index].sh_size = 0;
+        dropped_debug = true;
+      }
+    }
+    if (dropped_debug) {
+      warnings.emplace_back(
+          "dropped non-allocated DWARF sections whose PC ranges became stale after .text "
+          "relocation");
+    }
+  }
+  if (!relocate_eh_frame_fdes(image_, header, shdrs, phdrs, *text_index, text_size_,
+                              new_text.size(), text_relocations, shift_section_vaddr,
+                              padded_file_delta, error_out)) {
+    return false;
+  }
+  text_offset_ = shdrs[*text_index].sh_offset;
+  old_text_end_file = text_offset_ + text_size_;
+
   struct ResolvedDataRelocation {
     PcRelativeDataRelocation relocation;
     size_t target_section = 0;
@@ -993,7 +2063,7 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
         sizeof(uint32_t) > new_text.size() - relocation.target_getpc_offset ||
         relocation.target_literal_offset > new_text.size() ||
         sizeof(uint64_t) > new_text.size() - relocation.target_literal_offset) {
-      return false;
+      return fail("PC-relative data relocation lies outside replacement .text");
     }
     const auto section = std::ranges::find_if(shdrs, [&](const Elf64_Shdr &candidate) {
       return (candidate.sh_flags & SHF_ALLOC) != 0 && (candidate.sh_flags & SHF_EXECINSTR) == 0 &&
@@ -1001,40 +2071,14 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
              relocation.source_target_vaddr - candidate.sh_addr < candidate.sh_size;
     });
     if (section == shdrs.end())
-      return false;
+      return fail("PC-relative data relocation target is not in allocated non-executable data");
     resolved_data_relocations.push_back(
         {.relocation = relocation,
          .target_section = static_cast<size_t>(section - shdrs.begin()),
          .target_section_offset = relocation.source_target_vaddr - section->sh_addr});
   }
-  const uint64_t old_text_end_file = text_offset_ + text_size_;
-  const uint64_t old_text_end_vaddr = text_header.sh_addr + text_size_;
-  const uint64_t growth = new_text.size() - text_size_;
-
   if (growth != 0) {
-    // Growing .text can shift later LOAD segments. Pad the inserted file range
-    // so every shifted LOAD keeps p_offset % p_align congruent with p_vaddr %
-    // p_align. The padding is executable segment filler, not part of .text.
-    const uint64_t file_delta_alignment = shifted_load_delta_alignment(phdrs, old_text_end_file);
-    const uint64_t padded_file_delta = align_up(growth, file_delta_alignment);
-    assert(padded_file_delta >= growth && "aligned text growth underflowed");
-    assert(padded_file_delta % sizeof(uint32_t) == 0 && "text growth must stay word-aligned");
-
     std::vector<uint8_t> inserted(padded_file_delta, 0);
-    std::vector<bool> shift_section_vaddr(shdrs.size(), false);
-    for (size_t i = 0; i < shdrs.size(); ++i) {
-      if (i == *text_index || shdrs[i].sh_type == SHT_NULL)
-        continue;
-      if ((shdrs[i].sh_flags & SHF_ALLOC) != 0 && shdrs[i].sh_addr >= old_text_end_vaddr)
-        shift_section_vaddr[i] = true;
-    }
-
-    std::vector<bool> shift_segment_vaddr(phdrs.size(), false);
-    for (size_t i = 0; i < phdrs.size(); ++i) {
-      if (phdrs[i].p_vaddr >= old_text_end_vaddr && phdrs[i].p_offset >= old_text_end_file)
-        shift_segment_vaddr[i] = true;
-    }
-
     insert_file_bytes(image_, header, shdrs, phdrs, old_text_end_file, inserted, *text_index, true);
 
     for (size_t i = 0; i < shdrs.size(); ++i) {
@@ -1070,7 +2114,7 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
   for (const ResolvedDataRelocation &resolved : resolved_data_relocations) {
     if (resolved.target_section >= shdrs.size() ||
         resolved.target_section_offset >= shdrs[resolved.target_section].sh_size) {
-      return false;
+      return fail("PC-relative data relocation target moved outside its section");
     }
     const uint64_t target_vaddr =
         shdrs[resolved.target_section].sh_addr + resolved.target_section_offset;
@@ -1078,7 +2122,7 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
             std::numeric_limits<uint64_t>::max() - resolved.relocation.target_getpc_offset ||
         text_header.sh_addr + resolved.relocation.target_getpc_offset >
             std::numeric_limits<uint64_t>::max() - sizeof(uint32_t)) {
-      return false;
+      return fail("PC-relative data relocation address overflows");
     }
     const uint64_t getpc_result =
         text_header.sh_addr + resolved.relocation.target_getpc_offset + sizeof(uint32_t);
@@ -1088,12 +2132,12 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
   }
   shdrs[*text_index].sh_size = new_text.size();
   if (!relocate_text_symbols(image_, header, shdrs, *text_index, text_size_, new_text.size(),
-                             text_relocations)) {
-    return false;
+                             text_relocations, require_exact_function_ranges)) {
+    return fail("text symbols cannot be mapped exactly into replacement .text");
   }
   if (!relocate_relative_text_addends(image_, header, shdrs, *text_index, text_size_,
                                       new_text.size(), text_relocations)) {
-    return false;
+    return fail("R_AMDGPU_RELATIVE64 addends cannot be mapped exactly into replacement .text");
   }
   // Instrumentation appends a cave without relocating the original body and
   // therefore supplies no offset map. Preserve its historical function-range
@@ -1109,6 +2153,9 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
            "patched LOAD lost file/virtual address congruence");
   }
   write_elf_tables(image_, header, shdrs, phdrs);
+  rollback.committed = true;
+  if (warnings_out != nullptr)
+    warnings_out->insert(warnings_out->end(), warnings.begin(), warnings.end());
   return true;
 }
 
@@ -1145,7 +2192,8 @@ bool CodeObjectPatcher::apply_kernel_descriptor_translation(const KdTranslation 
 
 std::optional<std::vector<AppendedSidecarDescriptor>>
 CodeObjectPatcher::append_sidecar_descriptor_translations(
-    std::span<const KdTranslation> translations, rj_code_arch_t target_arch, uint64_t alignment) {
+    std::span<const KdTranslation> translations, rj_code_arch_t target_arch, uint64_t alignment,
+    std::string *error_out) {
   if (translations.empty())
     return std::vector<AppendedSidecarDescriptor>{};
   if (alignment == 0 || (alignment & (alignment - 1)) != 0)
@@ -1176,6 +2224,21 @@ CodeObjectPatcher::append_sidecar_descriptor_translations(
   });
   if (!insertion_is_loaded)
     return std::nullopt;
+
+  for (size_t section_index = 0; section_index < shdrs.size(); ++section_index) {
+    const auto name = section_name(image_, header, shdrs, section_index);
+    if (!name) {
+      report(error_out, "ELF section names are malformed while locating unwind metadata");
+      return std::nullopt;
+    }
+    if ((shdrs[section_index].sh_flags & SHF_ALLOC) != 0 &&
+        (*name == ".eh_frame" || *name == ".eh_frame_hdr") &&
+        shdrs[section_index].sh_addr >= insertion_vaddr) {
+      report(error_out,
+             "sidecar insertion would move allocated unwind metadata without relocating it");
+      return std::nullopt;
+    }
+  }
 
   std::vector<uint8_t> inserted;
   std::vector<AppendedSidecarDescriptor> appended;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <optional>
 #include <span>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -19,11 +20,16 @@ struct KdTranslation;
 /// @brief One exact source-to-target offset mapping inside `.text`.
 ///
 /// @details DBT supplies instruction starts and block ends after final kernel
-/// placement. The ELF patcher uses these mappings to keep local labels and
-/// function symbols attached to relocated code without interpreting the ISA.
+/// placement. The ELF patcher uses these mappings to keep local labels,
+/// function symbols, and unwind ranges attached to relocated code without
+/// interpreting the ISA. A source range copied into multiple kernel-local
+/// placements receives one placement ID per copy. Block-end-only mappings do
+/// not begin unwind ranges at an adjacent function boundary.
 struct TextOffsetRelocation {
   uint64_t source_offset = 0;
   uint64_t target_offset = 0;
+  uint64_t placement_id = 0;
+  bool source_is_instruction_start = true;
 };
 
 /// @brief One relocated literal64 PC builder whose target is outside `.text`.
@@ -55,10 +61,18 @@ public:
   /// @details Updates the .text section size, shifts later file contents, grows
   /// the executable LOAD segment that contains .text, preserves LOAD alignment,
   /// updates moved symbols and relocation places, and keeps descriptor-relative
-  /// entries coherent with explicit descriptor patches applied by DBT.
+  /// entries coherent with explicit descriptor patches applied by DBT. When
+  /// provided, @p error_out receives a specific reason for failure.
+  /// @param require_exact_function_ranges Require every sized text function's
+  /// end to appear in the relocation map. Descriptorless gfx1250 translation
+  /// needs this fail-closed guarantee; established architecture pairs retain
+  /// their prior best-effort symbol-size behavior.
   [[nodiscard]] bool replace_text(std::span<const uint8_t> new_text,
                                   std::span<const TextOffsetRelocation> text_relocations = {},
-                                  std::span<const PcRelativeDataRelocation> data_relocations = {});
+                                  std::span<const PcRelativeDataRelocation> data_relocations = {},
+                                  std::string *error_out = nullptr,
+                                  std::vector<std::string> *warnings_out = nullptr,
+                                  bool require_exact_function_ranges = true);
 
   /// @brief True if any relocation's place (r_offset) falls inside .text.
   ///
@@ -106,7 +120,8 @@ public:
   /// itself. Runtime metadata records the returned virtual addresses.
   [[nodiscard]] std::optional<std::vector<AppendedSidecarDescriptor>>
   append_sidecar_descriptor_translations(std::span<const KdTranslation> translations,
-                                         rj_code_arch_t target_arch, uint64_t alignment = 64);
+                                         rj_code_arch_t target_arch, uint64_t alignment = 64,
+                                         std::string *error_out = nullptr);
 
   /// @brief Append a named, non-allocated ELF section without moving loadable bytes.
   ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
@@ -519,38 +519,6 @@ void trace_virtual_lds_kernarg(uint64_t packet_id, const void *kernarg, size_t s
   }
 }
 
-/// @brief Return a stable diagnostic severity name.
-[[nodiscard]] const char *diagnostic_severity_name(DiagnosticSeverity severity) {
-  switch (severity) {
-  case DiagnosticSeverity::Warning:
-    return "warning";
-  case DiagnosticSeverity::Error:
-    return "error";
-  }
-  return "diagnostic";
-}
-
-/// @brief Return a stable diagnostic kind name.
-[[nodiscard]] const char *diagnostic_kind_name(DiagnosticKind kind) {
-  switch (kind) {
-  case DiagnosticKind::UnsupportedGuestArch:
-    return "unsupported-guest-arch";
-  case DiagnosticKind::KernelDescriptor:
-    return "kernel-descriptor";
-  case DiagnosticKind::Legalization:
-    return "legalization";
-  case DiagnosticKind::ExpandMissing:
-    return "expand-missing";
-  case DiagnosticKind::ExpandFailed:
-    return "expand-failed";
-  case DiagnosticKind::ResourceLimit:
-    return "resource-limit";
-  case DiagnosticKind::KernelSkipped:
-    return "kernel-skipped";
-  }
-  return "unknown";
-}
-
 /// @brief Print one structured DBT diagnostic in the same compact style as the CLI.
 void print_diagnostic(FILE *stream, const TranslationDiagnostic &diagnostic) {
   std::fprintf(stream, "[rocjitsu-dbt] %s: %s", diagnostic_severity_name(diagnostic.severity),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/isa_properties.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/isa_properties.h
@@ -19,6 +19,9 @@ struct IsaProperties {
   bool uses_ttmp_workgroup_ids = false;
   bool uses_cluster_ttmp_workgroup_ids = false;
   uint32_t max_addressable_vgprs_per_wf = 0;
+  uint32_t vector_lane_encoding_mask = 0;
+  uint32_t vector_readlane_b32_encoding = 0;
+  uint32_t vector_writelane_b32_encoding = 0;
 };
 
 inline constexpr uint32_t MAX_SUPPORTED_ADDRESSABLE_VGPRS_PER_WF = 1024;
@@ -104,6 +107,9 @@ inline constexpr uint32_t MAX_SUPPORTED_ADDRESSABLE_VGPRS_PER_WF = 1024;
         .uses_ttmp_workgroup_ids = true,
         .uses_cluster_ttmp_workgroup_ids = true,
         .max_addressable_vgprs_per_wf = 1024,
+        .vector_lane_encoding_mask = 0xFFFF0000,
+        .vector_readlane_b32_encoding = 0xD7600000,
+        .vector_writelane_b32_encoding = 0xD7610000,
     };
   default:
     return {};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_traits.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_traits.h
@@ -117,6 +117,23 @@ template <GpuIsa Isa> inline constexpr bool supports_wave_size(uint32_t wf) {
   return 0;
 }
 
+/// @brief AMDHSA descriptor VGPR encoding granularity for one wave size.
+///
+/// This is the COMPUTE_PGM_RSRC1 descriptor granule, not the physical VGPR
+/// allocation block used by occupancy modeling.
+[[nodiscard]] inline constexpr uint32_t
+descriptor_vgpr_granularity_for_wavefront(rj_code_arch_t arch, uint32_t wavefront_size) {
+  if (arch == ROCJITSU_CODE_ARCH_CDNA1)
+    return 4;
+  if (arch_is_cdna(arch))
+    return 8;
+  if (arch == ROCJITSU_CODE_ARCH_GFX1250)
+    return 16;
+  if (arch_is_rdna(arch))
+    return wavefront_size == 32 ? 8 : 4;
+  return 1;
+}
+
 /// @brief Maximum hardware LDS bytes available to one workgroup on @p arch.
 ///
 /// @details Zero means the limit is not modeled yet. Callers use that

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -211,7 +211,7 @@ build_test_blocks(std::vector<TestOpcode> ops, std::span<const uint64_t> extra_l
 
   TestCodeObject co(std::move(words));
   TestDecoder decoder;
-  return BasicBlock::build(co, decoder, ROCJITSU_CODE_ARCH_CDNA3, extra_leaders);
+  return BasicBlock::build(co, decoder, ROCJITSU_CODE_ARCH_CDNA3, extra_leaders, extra_leaders);
 }
 
 bool has_predecessor(const BasicBlock &block, const BasicBlock *pred) {
@@ -520,6 +520,36 @@ TEST(CfgAnalysis, ExtraLeaderSplitsBlockAtKernelEntry) {
   EXPECT_TRUE(has_predecessor(*blocks[1], blocks[0].get()));
 }
 
+TEST(CfgAnalysis, BoundaryOnlyLeaderDoesNotBecomeExternalEntry) {
+  constexpr uint16_t kPcSreg = 8;
+  constexpr uint32_t kLiteralOperand = 255;
+  constexpr uint32_t kInlineInt0 = 128;
+  std::vector<uint32_t> words = {
+      pack_sop1(0x1c, kPcSreg, 0),                         // 0x00: s_getpc_b64.
+      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand),     // 0x04: s_add_u32.
+      20,                                                  // 0x08: -> 0x18.
+      pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0), // 0x0c: s_addc_u32.
+      pack_sop1(0x1d, 0, kPcSreg),                         // 0x10: s_setpc_b64.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),            // 0x14.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),            // 0x18: target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  constexpr std::array<uint64_t, 1> block_leaders{16};
+  constexpr std::array<uint64_t, 1> external_entries{0};
+  auto blocks =
+      BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, block_leaders, external_entries);
+
+  BasicBlock *consumer = block_starting_at(blocks, 16);
+  ASSERT_NE(consumer, nullptr);
+  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 24u);
+  EXPECT_FALSE(consumer->static_indirect_call_fixups()[0].source_incomplete)
+      << "a symbol end may split a block without manufacturing an external CFG entry";
+}
+
 TEST(CfgAnalysis, IndirectCallFallsThroughToReturnSuccessor) {
   auto blocks =
       build_test_blocks({TestOpcode::IndirectCall, TestOpcode::UseSgpr4, TestOpcode::End});
@@ -561,7 +591,8 @@ TEST(CfgAnalysis, IndirectRecoveryPrefilterAdmitsSetPcConsumer) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
   constexpr std::array<uint64_t, 1> extra_leaders{16};
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
+  auto blocks =
+      BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders, extra_leaders);
 
   auto *builder = block_starting_at(blocks, 0);
   auto *consumer = block_starting_at(blocks, 16);
@@ -688,7 +719,8 @@ TEST(CfgAnalysis, IgnoresUnconsumedPairWhileRecoveringPendingConsumer) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
   constexpr std::array<uint64_t, 1> extra_leaders{20};
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
+  auto blocks =
+      BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders, extra_leaders);
 
   auto *consumer = block_starting_at(blocks, 20);
   ASSERT_NE(consumer, nullptr);
@@ -1018,7 +1050,8 @@ TEST(CfgAnalysis, ExplicitKernelEntryMakesIncomingPcBuilderIncomplete) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
   constexpr std::array<uint64_t, 1> extra_leaders{24};
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
+  auto blocks =
+      BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders, extra_leaders);
 
   auto *consumer = block_starting_at(blocks, 24);
   ASSERT_NE(consumer, nullptr);
@@ -1051,7 +1084,8 @@ TEST(CfgAnalysis, RocrAbortTrapStopsTemporaryPcBuilderCfg) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
   constexpr std::array<uint64_t, 1> extra_leaders{20};
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
+  auto blocks =
+      BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders, extra_leaders);
 
   auto *consumer = block_starting_at(blocks, 20);
   ASSERT_NE(consumer, nullptr);
@@ -1541,7 +1575,8 @@ TEST(CfgAnalysis, KillPredecessorPreventsRecoveredConsumer) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
   constexpr std::array<uint64_t, 1> extra_leaders{40};
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
+  auto blocks =
+      BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders, extra_leaders);
 
   auto *consumer = block_starting_at(blocks, 32);
   auto *target = block_starting_at(blocks, 40);
@@ -2035,6 +2070,58 @@ TEST(CfgAnalysis, Gfx1250UnreachablePostRocrAbortBlockDoesNotPoisonLaneStash) {
   EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 72u);
 }
 
+TEST(CfgAnalysis, Gfx1250VectorLaneRecoveryUsesRecoveredScalarEdge) {
+  constexpr auto scalar_getpc = gfx1250::build_sop1(gfx1250::kSGetPcI64Sop1, {.sdst = 8});
+  constexpr auto scalar_add =
+      gfx1250::build_sop2(gfx1250::kSAddNcU64Sop2, {.ssrc0 = 8, .ssrc1 = 254, .sdst = 8});
+  constexpr auto scalar_setpc =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 8, .sdst = 0});
+  std::vector<uint32_t> words = {
+      0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+      0xA980FE00u, 84u,
+      0u, // 0x04: s_add_nc_u64 ..., lit64(84) -> lane-stashed target 0x58.
+      0xD761002Cu,
+      0x02010000u, // 0x10: v_writelane_b32 v44, s0, 0.
+      0xD761002Cu,
+      0x02010201u,     // 0x18: v_writelane_b32 v44, s1, 1.
+      scalar_getpc[0], // 0x20: s_get_pc_i64 s[8:9].
+      scalar_add[0], 20u,
+      0u,              // 0x24: s_add_nc_u64 ..., lit64(20) -> bridge 0x38.
+      scalar_setpc[0], // 0x30: recovered scalar edge to 0x38.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x34: no lexical path to consumer.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250), // 0x38: recovered bridge.
+      gfx1250::build_sopp(gfx1250::kSBranchSopp, {.simm16 = 0})[0],
+      // 0x3c: direct edge from the recovered bridge to the consumer.
+      0xD7600000u,
+      0x0201012Cu, // 0x40: v_readlane_b32 s0, v44, 0.
+      0xD7600001u,
+      0x0201032Cu,                                // 0x48: v_readlane_b32 s1, v44, 1.
+      0xBE9E4900u,                                // 0x50: s_swap_pc_i64 s[30:31], s[0:1].
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x54: continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x58: lane-stashed target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  const IndirectCallFixup *scalar_fixup = nullptr;
+  const IndirectCallFixup *vector_fixup = nullptr;
+  for (const auto &block : blocks) {
+    for (const IndirectCallFixup &fixup : block->static_indirect_call_fixups()) {
+      if (fixup.source_call_offset == 48u)
+        scalar_fixup = &fixup;
+      if (fixup.source_call_offset == 80u)
+        vector_fixup = &fixup;
+    }
+  }
+  ASSERT_NE(scalar_fixup, nullptr);
+  EXPECT_EQ(scalar_fixup->source_target_offset, 56u);
+  ASSERT_NE(vector_fixup, nullptr);
+  EXPECT_EQ(vector_fixup->source_target_offset, 88u);
+}
+
 TEST(CfgAnalysis, Gfx1250ExplicitOnlyRecoversLaneStashInRecoveredCallee) {
   // The kernel root first makes a scalar-recoverable call to the helper at
   // 0x18. The helper is not an explicit entry and has no direct predecessor;
@@ -2415,7 +2502,8 @@ TEST(CfgAnalysis, Gfx1250ExplicitKernelEntryClearsIncomingLaneStash) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   constexpr std::array<uint64_t, 1> extra_leaders{40};
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250, extra_leaders);
+  auto blocks =
+      BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250, extra_leaders, extra_leaders);
 
   size_t total_fixups = 0;
   for (const auto &block : blocks)
@@ -2617,7 +2705,7 @@ TEST(CfgAnalysis, Gfx1250DoesNotReuseStashFromSkippedFallthroughPredecessor) {
 
   const auto fixups = discover_indirect_branch_edges(
       std::span<const Instruction *const>(decoded_insts.data(), decoded_insts.size()), text,
-      ROCJITSU_CODE_ARCH_GFX1250);
+      ROCJITSU_CODE_ARCH_GFX1250, {}, {});
   EXPECT_TRUE(fixups.empty()) << "must-dataflow must not reuse a skipped-path stash";
 }
 
@@ -2699,7 +2787,7 @@ TEST(LivenessAnalysis, Gfx1250VgprMsbResolvesPhysicalRegisterBank) {
 
   LivenessAnalysisOptions options;
   options.arch = ROCJITSU_CODE_ARCH_GFX1250;
-  options.entry_block = scope.front();
+  options.entry_blocks = std::span<BasicBlock *const>(scope.data(), 1);
   options.text = text_span(co);
   LivenessAnalysis liveness(KernelBlockScope(scope), options);
 
@@ -2710,6 +2798,35 @@ TEST(LivenessAnalysis, Gfx1250VgprMsbResolvesPhysicalRegisterBank) {
   EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Dst), 2);
   EXPECT_TRUE(liveness.is_live_before(*instruction, {RegClass::VGPR, 513, 1}));
   EXPECT_FALSE(liveness.is_live_before(*instruction, {RegClass::VGPR, 1, 1}));
+}
+
+TEST(LivenessAnalysis, Gfx1250VgprMsbExternalEntryMergesWithInternalPredecessor) {
+  constexpr auto set_bank_two = gfx1250::build_sopp(gfx1250::kSSetVgprMsbSopp, {.simm16 = 2});
+  constexpr auto move = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 257, .vdst = 0});
+  constexpr auto end = gfx1250::build_sopp(gfx1250::kSEndpgmSopp);
+  TestCodeObject co({set_bank_two[0], move[0], end[0]});
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+
+  constexpr std::array<uint64_t, 1> block_leaders{4};
+  constexpr std::array<uint64_t, 2> external_entries{0, 4};
+  auto blocks =
+      BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250, block_leaders, external_entries);
+  ASSERT_EQ(blocks.size(), 2u);
+  auto scope = block_scope(blocks);
+  std::array entry_blocks{blocks[0].get(), blocks[1].get()};
+
+  LivenessAnalysisOptions options;
+  options.arch = ROCJITSU_CODE_ARCH_GFX1250;
+  options.entry_blocks = entry_blocks;
+  options.text = text_span(co);
+  LivenessAnalysis liveness(KernelBlockScope(scope), options);
+
+  const Instruction &joined_move = *blocks[1]->instructions().begin();
+  EXPECT_EQ(liveness.vgpr_msb_bank_before(joined_move, amdgpu::VgprMsbRole::Src0), std::nullopt);
+  for (uint16_t bank = 0; bank < 4; ++bank)
+    EXPECT_TRUE(liveness.is_live_before(
+        joined_move, {RegClass::VGPR, static_cast<uint16_t>(1 + bank * 256), 1}));
 }
 
 TEST(LivenessAnalysis, Gfx1250DynamicModeWriteConservativelyUsesEveryBank) {
@@ -2727,7 +2844,7 @@ TEST(LivenessAnalysis, Gfx1250DynamicModeWriteConservativelyUsesEveryBank) {
 
   LivenessAnalysisOptions options;
   options.arch = ROCJITSU_CODE_ARCH_GFX1250;
-  options.entry_block = scope.front();
+  options.entry_blocks = std::span<BasicBlock *const>(scope.data(), 1);
   options.text = text_span(co);
   LivenessAnalysis liveness(KernelBlockScope(scope), options);
 
@@ -2760,7 +2877,7 @@ TEST(LivenessAnalysis, Gfx1250FullLiteralModeWriteRecoversKnownBank) {
 
   LivenessAnalysisOptions options;
   options.arch = ROCJITSU_CODE_ARCH_GFX1250;
-  options.entry_block = scope.front();
+  options.entry_blocks = std::span<BasicBlock *const>(scope.data(), 1);
   options.text = text_span(co);
   LivenessAnalysis liveness(KernelBlockScope(scope), options);
 
@@ -2798,7 +2915,7 @@ TEST(LivenessAnalysis, Gfx1250TruncatedLiteralModeWriteMarksBanksAmbiguous) {
 
   LivenessAnalysisOptions options;
   options.arch = ROCJITSU_CODE_ARCH_GFX1250;
-  options.entry_block = scope.front();
+  options.entry_blocks = std::span<BasicBlock *const>(scope.data(), 1);
   // Truncate the text span to 8 bytes: the setreg (at offset 4) has no readable
   // literal at offset 8.
   const auto full = text_span(co);
@@ -2830,7 +2947,7 @@ TEST(LivenessAnalysis, Gfx1250PartialLiteralModeWriteUsesUnmaskedVgprFields) {
 
   LivenessAnalysisOptions options;
   options.arch = ROCJITSU_CODE_ARCH_GFX1250;
-  options.entry_block = scope.front();
+  options.entry_blocks = std::span<BasicBlock *const>(scope.data(), 1);
   options.text = text_span(co);
   LivenessAnalysis liveness(KernelBlockScope(scope), options);
 
@@ -2862,7 +2979,7 @@ TEST(LivenessAnalysis, Gfx1250ImmediateModeWriteRecoversBanksOutsideRequestedSli
 
   LivenessAnalysisOptions options;
   options.arch = ROCJITSU_CODE_ARCH_GFX1250;
-  options.entry_block = scope.front();
+  options.entry_blocks = std::span<BasicBlock *const>(scope.data(), 1);
   options.text = text_span(co);
   LivenessAnalysis liveness(KernelBlockScope(scope), options);
 
@@ -2889,7 +3006,7 @@ TEST(LivenessAnalysis, Gfx1250LiteralModeWriteTracksEveryRole) {
 
   LivenessAnalysisOptions options;
   options.arch = ROCJITSU_CODE_ARCH_GFX1250;
-  options.entry_block = scope.front();
+  options.entry_blocks = std::span<BasicBlock *const>(scope.data(), 1);
   options.text = text_span(co);
   LivenessAnalysis liveness(KernelBlockScope(scope), options);
 
@@ -2917,7 +3034,7 @@ TEST(LivenessAnalysis, Gfx1250ImmediateNonModeWriteDoesNotChangeBanks) {
 
   LivenessAnalysisOptions options;
   options.arch = ROCJITSU_CODE_ARCH_GFX1250;
-  options.entry_block = scope.front();
+  options.entry_blocks = std::span<BasicBlock *const>(scope.data(), 1);
   options.text = text_span(co);
   LivenessAnalysis liveness(KernelBlockScope(scope), options);
 
@@ -2948,7 +3065,7 @@ TEST(LivenessAnalysis, Gfx1250VgprMsbCfgJoinRequiresPredecessorsToAgree) {
 
   LivenessAnalysisOptions options;
   options.arch = ROCJITSU_CODE_ARCH_GFX1250;
-  options.entry_block = scope.front();
+  options.entry_blocks = std::span<BasicBlock *const>(scope.data(), 1);
   options.text = text_span(co);
   LivenessAnalysis liveness(KernelBlockScope(scope), options);
 
@@ -2976,7 +3093,7 @@ TEST(LivenessAnalysis, Gfx1250VgprMsbCfgJoinPreservesAgreeingBank) {
 
   LivenessAnalysisOptions options;
   options.arch = ROCJITSU_CODE_ARCH_GFX1250;
-  options.entry_block = scope.front();
+  options.entry_blocks = std::span<BasicBlock *const>(scope.data(), 1);
   options.text = text_span(co);
   LivenessAnalysis liveness(KernelBlockScope(scope), options);
 
@@ -3013,7 +3130,7 @@ TEST(LivenessAnalysis, Gfx1250VgprMsbJoinExcludesUnreachablePredecessor) {
 
   LivenessAnalysisOptions options;
   options.arch = ROCJITSU_CODE_ARCH_GFX1250;
-  options.entry_block = scope.front();
+  options.entry_blocks = std::span<BasicBlock *const>(scope.data(), 1);
   options.text = text_span(co);
   LivenessAnalysis liveness(KernelBlockScope(scope), options);
 
@@ -3108,6 +3225,89 @@ TEST(LivenessAnalysis, FindFreeRunHonorsBaseAlignment) {
   const Instruction &use = *blocks[0]->instructions().begin();
   EXPECT_EQ(liveness.find_free_run(&use, 4, 0, 2), 94);
   EXPECT_EQ(liveness.find_free_run(&use, 4, 94, 4), 96);
+}
+
+TEST(LivenessAnalysis, ScratchAllocationSkipsAbiReservedRegisters) {
+  auto blocks = build_test_blocks({TestOpcode::UseSgpr4, TestOpcode::End});
+  auto scope = block_scope(blocks);
+
+  LivenessAnalysisOptions options;
+  options.scratch_reserved.expand({RegClass::VGPR, 0, 32});
+  options.scratch_reserved.expand({RegClass::VGPR, 40, 8});
+  options.scratch_reserved.expand({RegClass::SGPR, 0, 6});
+  options.scratch_reserved.expand({RegClass::SGPR, 8, 1});
+
+  LivenessAnalysis liveness(KernelBlockScope(scope), options);
+
+  const Instruction &use = *blocks[0]->instructions().begin();
+  EXPECT_EQ(liveness.find_free_run(&use, 1), 32);
+  EXPECT_EQ(liveness.find_free_run(&use, 8, 33), 48);
+  EXPECT_EQ(liveness.find_free_sgpr(&use), 6);
+  EXPECT_EQ(liveness.find_free_sgpr_pair(&use), 6);
+}
+
+TEST(LivenessAnalysis, ScratchAllocationHonorsPerFunctionVgprEnvelope) {
+  auto blocks = build_test_blocks({TestOpcode::UseSgpr4, TestOpcode::End});
+  auto scope = block_scope(blocks);
+  constexpr std::array limits = {
+      ScratchVgprRangeLimit{.begin_offset = 0, .end_offset = 4, .max_free_vgpr = 34}};
+
+  LivenessAnalysisOptions options;
+  options.max_free_vgpr = 64;
+  options.scratch_reserved.expand({RegClass::VGPR, 0, 32});
+  options.scratch_vgpr_range_limits = limits;
+
+  LivenessAnalysis liveness(KernelBlockScope(scope), options);
+
+  const Instruction &use = *blocks[0]->instructions().begin();
+  const Instruction &outside = *std::next(blocks[0]->instructions().begin());
+  EXPECT_EQ(liveness.find_free_run(&use, 2), 32);
+  EXPECT_EQ(liveness.find_free_run(&use, 3), std::nullopt);
+  EXPECT_EQ(liveness.find_free_run(&outside, 1), std::nullopt);
+}
+
+TEST(LivenessAnalysis, PerFunctionVgprEnvelopeCannotRaiseDestinationLimit) {
+  auto blocks = build_test_blocks({TestOpcode::UseSgpr4, TestOpcode::End});
+  auto scope = block_scope(blocks);
+  constexpr std::array limits = {
+      ScratchVgprRangeLimit{.begin_offset = 0, .end_offset = 4, .max_free_vgpr = 64}};
+
+  LivenessAnalysisOptions options;
+  options.max_free_vgpr = 32;
+  options.scratch_reserved.expand({RegClass::VGPR, 0, 32});
+  options.scratch_vgpr_range_limits = limits;
+
+  LivenessAnalysis liveness(KernelBlockScope(scope), options);
+
+  const Instruction &use = *blocks[0]->instructions().begin();
+  EXPECT_EQ(liveness.find_free_run(&use, 1), std::nullopt);
+}
+
+TEST(LivenessAnalysis, GapBetweenPerFunctionVgprEnvelopesDisablesScratch) {
+  constexpr std::array<uint64_t, 2> extra_leaders{4, 8};
+  auto blocks = build_test_blocks(
+      {TestOpcode::UseSgpr4, TestOpcode::UseSgpr4, TestOpcode::UseSgpr4, TestOpcode::End},
+      extra_leaders);
+  auto scope = block_scope(blocks);
+  constexpr std::array limits = {
+      ScratchVgprRangeLimit{.begin_offset = 0, .end_offset = 4, .max_free_vgpr = 34},
+      ScratchVgprRangeLimit{.begin_offset = 8, .end_offset = 12, .max_free_vgpr = 36},
+  };
+
+  LivenessAnalysisOptions options;
+  options.max_free_vgpr = 64;
+  options.scratch_reserved.expand({RegClass::VGPR, 0, 32});
+  options.scratch_vgpr_range_limits = limits;
+  LivenessAnalysis liveness(KernelBlockScope(scope), options);
+
+  const Instruction &first = *blocks[0]->instructions().begin();
+  const Instruction &gap = *blocks[1]->instructions().begin();
+  const Instruction &second = *blocks[2]->instructions().begin();
+  EXPECT_EQ(liveness.find_free_run(&first, 2), 32);
+  EXPECT_EQ(liveness.find_free_run(&first, 3), std::nullopt);
+  EXPECT_EQ(liveness.find_free_run(&gap, 1), std::nullopt);
+  EXPECT_EQ(liveness.find_free_run(&second, 4), 32);
+  EXPECT_EQ(liveness.find_free_run(&second, 5), std::nullopt);
 }
 
 TEST(LivenessAnalysis, ReadWriteSameRegisterIsLiveBeforeInstruction) {

--- a/emulation/rocjitsu/tests/code/relocation_function_table_test.cpp
+++ b/emulation/rocjitsu/tests/code/relocation_function_table_test.cpp
@@ -488,7 +488,8 @@ TEST(RelocationFunctionTable, ResolvesDynamicDispatchThroughGotAndTableLoads) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   std::array<uint64_t, 1> leaders{40};
-  const auto blocks = BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
+  const auto blocks =
+      BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders, leaders);
   const auto dispatches = discover_relocation_table_dispatches(blocks, tables, 0x1000);
   ASSERT_EQ(dispatches.size(), 1u);
   EXPECT_EQ(dispatches[0].table_index, 0u);
@@ -513,7 +514,8 @@ TEST(RelocationFunctionTable, ResolvesRcclDirectIndexedTableDispatch) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   std::array<uint64_t, 1> leaders{32};
-  const auto blocks = BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
+  const auto blocks =
+      BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders, leaders);
   const auto dispatches = discover_relocation_table_dispatches(blocks, tables, 0x1000);
   ASSERT_EQ(dispatches.size(), 1u);
   EXPECT_EQ(dispatches[0].table_index, 0u);
@@ -537,7 +539,8 @@ TEST(RelocationFunctionTable, RejectsChainedAddressAddDispatch) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   std::array<uint64_t, 1> leaders{44};
-  const auto blocks = BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
+  const auto blocks =
+      BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders, leaders);
   const auto dispatches = discover_relocation_table_dispatches(blocks, tables, 0x1000);
   // The base is built with two literal adds; only one add offset can be relocated,
   // so the dispatch must fail closed rather than resolve to a value whose first
@@ -566,7 +569,8 @@ TEST(RelocationFunctionTable, ResolvesBackwardTableAddress) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   std::array<uint64_t, 1> leaders{32};
-  const auto blocks = BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
+  const auto blocks =
+      BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders, leaders);
   const auto dispatches = discover_relocation_table_dispatches(blocks, tables, kAssumedTextVaddr);
   ASSERT_EQ(dispatches.size(), 1u);
   EXPECT_EQ(dispatches[0].table_index, 0u);

--- a/emulation/rocjitsu/tests/corpus/dbt/gfx1250_b0_a0_expected_failures.json
+++ b/emulation/rocjitsu/tests/corpus/dbt/gfx1250_b0_a0_expected_failures.json
@@ -4,17 +4,23 @@
       "kind": "memory-limit",
       "reason": "RCCL code object exceeds the per-object DBT memory limit in indirect-branch discovery"
     },
-    "5d2a4110c0d8274651992689ae47abfb014cd36584338a725d77cecdec9718aa": {
+    "2ec18e4129beae79f7112d789ef4e84450c71fd9745ac27d09f1b1bbbedd998d": {
       "kind": "translation-error",
-      "reason": "PyTorch object currently exposes no non-empty text section",
+      "reason": "descriptor-backed kernel contains an unrecovered indirect control-flow target",
       "returncode": 3,
-      "stderr_regex": "resource-limit: code object does not expose a non-empty \\.text section for translation"
+      "stderr_regex": "indirect branch or call target recovery is not implemented for relocated kernel text"
     },
-    "af9e659f75ad449b591d855208fb122fd27d7e66422b687ee643054a5df4a2f7": {
+    "ce78502403711aea3192b7a9256817cca008874cf5ab16a83bc4a96bceb7ef30": {
       "kind": "translation-error",
-      "reason": "rocFFT object currently has no kernel descriptors",
+      "reason": "descriptorless callable changes mode state without a provable final-HSACO register envelope",
       "returncode": 3,
-      "stderr_regex": "kernel-descriptor: kernel descriptors are required for kernel-level translation"
+      "stderr_regex": "descriptorless callable code changes VGPR-MSB/MODE state"
+    },
+    "e78a60937e78d5026df75de19d604f3a7e90284f231074fab87a2ae5bb34a0ef": {
+      "kind": "translation-error",
+      "reason": "descriptor-backed kernel contains an unrecovered indirect control-flow target",
+      "returncode": 3,
+      "stderr_regex": "indirect branch or call target recovery is not implemented for relocated kernel text"
     }
   },
   "input_revision": "b0",

--- a/emulation/rocjitsu/tests/dbt/multikernel_indirect_branch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/multikernel_indirect_branch_test.cpp
@@ -176,8 +176,8 @@ cfg_block_counts_by_kernel(const rocjitsu::AmdGpuCodeObject &co,
   if (!decoder)
     return counts;
 
-  auto blocks =
-      rocjitsu::BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, kernel_entry_leaders);
+  auto blocks = rocjitsu::BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4,
+                                            kernel_entry_leaders, kernel_entry_leaders);
 
   for (const char *name : kernel_names) {
     const auto *kernel = kernel_translation_by_name(source_kernels, co, name);
@@ -282,8 +282,8 @@ TEST(BinaryTranslatorE2E, BuildsCfgForRealMultiKernelIndirectBranches) {
 
   auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks =
-      rocjitsu::BasicBlock::build(*co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, kernel_entries);
+  auto blocks = rocjitsu::BasicBlock::build(*co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, kernel_entries,
+                                            kernel_entries);
   ASSERT_FALSE(blocks.empty());
 
   size_t recovered_swappc_blocks = 0;
@@ -359,8 +359,8 @@ TEST(BinaryTranslatorE2E, CountsRealMultiKernelIndirectBranchCfgBlocksPerKernel)
 
   auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks =
-      rocjitsu::BasicBlock::build(*co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, kernel_entry_leaders);
+  auto blocks = rocjitsu::BasicBlock::build(*co, *decoder, ROCJITSU_CODE_ARCH_CDNA4,
+                                            kernel_entry_leaders, kernel_entry_leaders);
   ASSERT_FALSE(blocks.empty());
 
   struct ExpectedKernelCfg {

--- a/emulation/rocjitsu/tests/dbt/relocation_function_table_hip_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/relocation_function_table_hip_test.cpp
@@ -60,8 +60,8 @@ TEST(RelocationFunctionTableHip, TranslatesEightWayDeviceDispatch) {
 
   auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
-  const auto blocks =
-      rocjitsu::BasicBlock::build(*source, *decoder, ROCJITSU_CODE_ARCH_GFX1250, source_targets);
+  const auto blocks = rocjitsu::BasicBlock::build(*source, *decoder, ROCJITSU_CODE_ARCH_GFX1250,
+                                                  source_targets, source_targets);
   const auto dispatches = rocjitsu::discover_relocation_table_dispatches(
       blocks, source_tables, source->text_sections()[0]->vaddr());
   ASSERT_EQ(dispatches.size(), 1u);

--- a/emulation/rocjitsu/tests/dbt/semantic_scratch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/semantic_scratch_test.cpp
@@ -54,6 +54,19 @@ TEST(SemanticSpillFrame, TransientReservationRejects32BitOverflow) {
   EXPECT_FALSE(transient);
 }
 
+TEST(SemanticSpillFrame, DisabledPrivateSpillsRejectAllReservations) {
+  TranslationContext context(/*vgprs=*/8, /*agprs=*/0, /*accum_base=*/0,
+                             /*sgprs=*/8, /*private_bytes=*/20);
+  context.private_spills_allowed = false;
+
+  EXPECT_FALSE(context.reserve_persistent_semantic_spill_dwords(1));
+  EXPECT_FALSE(context.reserve_semantic_spill_dwords(1));
+
+  SemanticSpillFrame frame(context);
+  EXPECT_FALSE(frame.allocate_dwords(1, /*byte_alignment=*/4));
+  EXPECT_EQ(context.required_private_segment_fixed_size, 20u);
+}
+
 TEST(SemanticSpillFrame, NewInstructionsReuseTransientFrameBase) {
   TranslationContext context(/*vgprs=*/8, /*agprs=*/0, /*accum_base=*/0,
                              /*sgprs=*/8, /*private_bytes=*/12);
@@ -112,6 +125,25 @@ TEST(SemanticScratchAllocator, ReportsTargetSpillOffsetLimit) {
   EXPECT_FALSE(result);
   EXPECT_EQ(result.failure, SemanticScratchFailure::SpillOffsetUnencodable);
   EXPECT_EQ(context.required_private_segment_fixed_size, 32u);
+}
+
+TEST(SemanticScratchAllocator, DisabledPrivateSpillsFailWithoutGrowingPrivateMemory) {
+  Instruction inst("scratch_test", nullptr);
+  std::vector<BasicBlock *> blocks;
+  LivenessAnalysis liveness(blocks);
+  TranslationContext context(/*vgprs=*/8, /*agprs=*/0, /*accum_base=*/0,
+                             /*sgprs=*/8, /*private_bytes=*/20);
+  context.private_spills_allowed = false;
+  SemanticScratchAllocator allocator(inst, liveness, context,
+                                     Cdna3ScratchEmitter::allocation_policy());
+
+  SemanticScratchRequest request;
+  request.count = 2;
+  const SemanticScratchResult result = allocator.acquire_vgprs(request);
+
+  EXPECT_FALSE(result);
+  EXPECT_EQ(result.failure, SemanticScratchFailure::NoRegisterWindow);
+  EXPECT_EQ(context.required_private_segment_fixed_size, 20u);
 }
 
 TEST(Cdna3ScratchEmitter, MaterializesSaveAndRestoreSequences) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -100,12 +100,17 @@ RJ_DIAGNOSTIC_POP
 #include <cstring>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <optional>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
+
+std::vector<std::unique_ptr<rocjitsu::Instruction>>
+decode_text_instructions(const rocjitsu::Section &text, rj_code_arch_t arch);
 
 namespace rocjitsu {
 namespace {
@@ -299,33 +304,79 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_text_and_rodata() {
   return image;
 }
 
-std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
+std::vector<uint8_t> make_minimal_gfx1250_elf_with_empty_text_and_rodata() {
+  auto image = make_minimal_amdgpu_elf_with_text_and_rodata();
+  auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  assert(shdrs.size() >= 2);
+
+  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX1250;
+  shdrs[1].sh_size = 0;
+  write_elf_struct_for_test(image, 0, ehdr);
+  write_bytes_for_test(image, ehdr.e_shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  return image;
+}
+
+struct TestFunctionRange {
+  uint64_t offset = 0;
+  uint64_t size = 0;
+};
+
+std::vector<uint8_t>
+make_minimal_amdgpu_elf_with_load_segments(std::span<const uint32_t> text_words,
+                                           uint64_t function_size = 0,
+                                           std::span<const TestFunctionRange> extra_functions = {},
+                                           std::span<const uint8_t> allocated_data = {},
+                                           std::string_view allocated_section_name = ".rodata",
+                                           std::span<const uint8_t> trailing_allocated_data = {},
+                                           std::string_view trailing_allocated_section_name = {}) {
   constexpr uint64_t text_offset = 0x100;
   constexpr uint64_t text_vaddr = 0x1100;
-  constexpr uint64_t text_size = 8;
-  constexpr uint64_t rodata_size = 4;
+  const uint64_t text_size = text_words.size_bytes();
+  const uint64_t rodata_size = allocated_data.empty() ? sizeof(uint32_t) : allocated_data.size();
   constexpr uint64_t load_align = 0x1000;
+  assert(text_size != 0);
+  if (function_size == 0)
+    function_size = text_size;
+  assert(function_size != 0 && function_size <= text_size);
+  assert(function_size % sizeof(uint32_t) == 0);
 
   std::vector<uint8_t> shstrtab{'\0'};
   const uint32_t text_name = add_elf_name(shstrtab, ".text");
-  const uint32_t rodata_name = add_elf_name(shstrtab, ".rodata");
+  const uint32_t rodata_name = add_elf_name(shstrtab, allocated_section_name);
   const uint32_t symtab_name = add_elf_name(shstrtab, ".symtab");
   const uint32_t strtab_name = add_elf_name(shstrtab, ".strtab");
+  const uint32_t trailing_allocated_name =
+      trailing_allocated_data.empty() ? 0 : add_elf_name(shstrtab, trailing_allocated_section_name);
   const uint32_t shstrtab_name = add_elf_name(shstrtab, ".shstrtab");
+  assert(trailing_allocated_data.empty() == trailing_allocated_section_name.empty());
 
   std::vector<uint8_t> strtab{'\0'};
   const uint32_t rodata_symbol_name = add_elf_name(strtab, "rodata_object");
   const uint32_t text_symbol_name = add_elf_name(strtab, "text_start");
+  std::vector<uint32_t> extra_function_names;
+  extra_function_names.reserve(extra_functions.size());
+  for (size_t i = 0; i < extra_functions.size(); ++i) {
+    const TestFunctionRange &function = extra_functions[i];
+    (void)function;
+    assert(function.size != 0 && function.offset < text_size);
+    assert(function.size <= text_size - function.offset);
+    assert(function.offset % sizeof(uint32_t) == 0);
+    assert(function.size % sizeof(uint32_t) == 0);
+    extra_function_names.push_back(add_elf_name(strtab, "text_extra"));
+  }
 
   const uint64_t rodata_offset = text_offset + text_size;
   const uint64_t rodata_vaddr = text_vaddr + text_size + load_align;
-  const uint64_t strtab_offset = rodata_offset + rodata_size;
+  const uint64_t trailing_allocated_offset = rodata_offset + rodata_size;
+  const uint64_t trailing_allocated_vaddr = rodata_vaddr + rodata_size + load_align;
+  const uint64_t strtab_offset = trailing_allocated_offset + trailing_allocated_data.size();
   const uint64_t symtab_offset = align_up_for_test(strtab_offset + strtab.size(), 8);
-  constexpr size_t sym_count = 3;
+  const size_t sym_count = 3 + extra_functions.size();
   const uint64_t shstrtab_offset = symtab_offset + sym_count * sizeof(Elf64_Sym);
   const uint64_t shoff = align_up_for_test(shstrtab_offset + shstrtab.size(), 8);
-  constexpr uint16_t section_count = 6;
-  constexpr uint16_t phdr_count = 2;
+  const uint16_t section_count = trailing_allocated_data.empty() ? 6 : 7;
+  const uint16_t phdr_count = trailing_allocated_data.empty() ? 2 : 3;
 
   std::vector<uint8_t> image(shoff + section_count * sizeof(Elf64_Shdr), 0);
 
@@ -333,6 +384,7 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
   std::memcpy(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
   ehdr.e_ident[EI_CLASS] = ELFCLASS64;
   ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  ehdr.e_ident[EI_ABIVERSION] = ELFABIVERSION_AMDGPU_HSA_V6;
   ehdr.e_type = ET_DYN;
   ehdr.e_machine = EM_AMDGPU;
   ehdr.e_version = 1;
@@ -344,10 +396,10 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
   ehdr.e_phnum = phdr_count;
   ehdr.e_shentsize = sizeof(Elf64_Shdr);
   ehdr.e_shnum = section_count;
-  ehdr.e_shstrndx = 5;
+  ehdr.e_shstrndx = trailing_allocated_data.empty() ? 5 : 6;
   std::memcpy(image.data(), &ehdr, sizeof(ehdr));
 
-  std::array<Elf64_Phdr, phdr_count> phdrs{};
+  std::vector<Elf64_Phdr> phdrs(phdr_count);
   phdrs[0].p_type = PT_LOAD;
   phdrs[0].p_flags = 0x5; // PF_R | PF_X
   phdrs[0].p_offset = text_offset;
@@ -365,16 +417,33 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
   phdrs[1].p_filesz = rodata_size;
   phdrs[1].p_memsz = rodata_size;
   phdrs[1].p_align = load_align;
+  if (!trailing_allocated_data.empty()) {
+    phdrs[2].p_type = PT_LOAD;
+    phdrs[2].p_flags = PF_R;
+    phdrs[2].p_offset = trailing_allocated_offset;
+    phdrs[2].p_vaddr = trailing_allocated_vaddr;
+    phdrs[2].p_paddr = trailing_allocated_vaddr;
+    phdrs[2].p_filesz = trailing_allocated_data.size();
+    phdrs[2].p_memsz = trailing_allocated_data.size();
+    phdrs[2].p_align = load_align;
+  }
   std::memcpy(image.data() + ehdr.e_phoff, phdrs.data(), phdrs.size() * sizeof(Elf64_Phdr));
 
-  const std::array<uint32_t, 2> text_words = {0xBF800000u, 0xBF800000u};
   std::memcpy(image.data() + text_offset, text_words.data(), text_size);
 
-  const uint32_t rodata_word = 0xA5A55A5Au;
-  std::memcpy(image.data() + rodata_offset, &rodata_word, sizeof(rodata_word));
+  if (allocated_data.empty()) {
+    const uint32_t rodata_word = 0xA5A55A5Au;
+    std::memcpy(image.data() + rodata_offset, &rodata_word, sizeof(rodata_word));
+  } else {
+    std::memcpy(image.data() + rodata_offset, allocated_data.data(), allocated_data.size());
+  }
+  if (!trailing_allocated_data.empty()) {
+    std::memcpy(image.data() + trailing_allocated_offset, trailing_allocated_data.data(),
+                trailing_allocated_data.size());
+  }
   std::memcpy(image.data() + strtab_offset, strtab.data(), strtab.size());
 
-  std::array<Elf64_Sym, sym_count> syms{};
+  std::vector<Elf64_Sym> syms(sym_count);
   syms[1].st_name = rodata_symbol_name;
   syms[1].st_shndx = 2;
   syms[1].st_value = rodata_vaddr;
@@ -383,12 +452,19 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
   syms[2].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeFunc);
   syms[2].st_shndx = 1;
   syms[2].st_value = text_vaddr;
-  syms[2].st_size = text_size;
+  syms[2].st_size = function_size;
+  for (size_t i = 0; i < extra_functions.size(); ++i) {
+    syms[3 + i].st_name = extra_function_names[i];
+    syms[3 + i].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeFunc);
+    syms[3 + i].st_shndx = 1;
+    syms[3 + i].st_value = text_vaddr + extra_functions[i].offset;
+    syms[3 + i].st_size = extra_functions[i].size;
+  }
   std::memcpy(image.data() + symtab_offset, syms.data(), syms.size() * sizeof(Elf64_Sym));
 
   std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
 
-  std::array<Elf64_Shdr, section_count> shdrs{};
+  std::vector<Elf64_Shdr> shdrs(section_count);
   shdrs[1].sh_name = text_name;
   shdrs[1].sh_type = SHT_PROGBITS;
   shdrs[1].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
@@ -420,14 +496,97 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
   shdrs[4].sh_size = strtab.size();
   shdrs[4].sh_addralign = 1;
 
-  shdrs[5].sh_name = shstrtab_name;
-  shdrs[5].sh_type = SHT_STRTAB;
-  shdrs[5].sh_offset = shstrtab_offset;
-  shdrs[5].sh_size = shstrtab.size();
-  shdrs[5].sh_addralign = 1;
+  if (!trailing_allocated_data.empty()) {
+    shdrs[5].sh_name = trailing_allocated_name;
+    shdrs[5].sh_type = SHT_PROGBITS;
+    shdrs[5].sh_flags = SHF_ALLOC;
+    shdrs[5].sh_addr = trailing_allocated_vaddr;
+    shdrs[5].sh_offset = trailing_allocated_offset;
+    shdrs[5].sh_size = trailing_allocated_data.size();
+    shdrs[5].sh_addralign = sizeof(uint32_t);
+  }
+
+  Elf64_Shdr &shstrtab_header = shdrs[ehdr.e_shstrndx];
+  shstrtab_header.sh_name = shstrtab_name;
+  shstrtab_header.sh_type = SHT_STRTAB;
+  shstrtab_header.sh_offset = shstrtab_offset;
+  shstrtab_header.sh_size = shstrtab.size();
+  shstrtab_header.sh_addralign = 1;
 
   std::memcpy(image.data() + shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
   return image;
+}
+
+std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
+  constexpr std::array<uint32_t, 2> text_words = {0xBF800000u, 0xBF800000u};
+  return make_minimal_amdgpu_elf_with_load_segments(text_words);
+}
+
+void add_kernel_descriptor_to_load_segment_fixture(std::vector<uint8_t> &image,
+                                                   uint64_t kernel_entry_text_offset) {
+  const auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  assert(shdrs.size() >= 5);
+  assert(shdrs[2].sh_size >= kKernelDescriptorSize);
+  assert(kernel_entry_text_offset < shdrs[1].sh_size);
+
+  auto symbols = read_elf_array_for_test<Elf64_Sym>(image, shdrs[3].sh_offset,
+                                                    shdrs[3].sh_size / sizeof(Elf64_Sym));
+  assert(symbols.size() >= 2);
+  constexpr std::string_view descriptor_name = "kernel.kd";
+  assert(symbols[1].st_name + descriptor_name.size() + 1 <= shdrs[4].sh_size);
+  write_bytes_for_test(image, shdrs[4].sh_offset + symbols[1].st_name, descriptor_name.data(),
+                       descriptor_name.size());
+  write_value_for_test<uint8_t>(
+      image, shdrs[4].sh_offset + symbols[1].st_name + descriptor_name.size(), 0);
+
+  symbols[1].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
+  symbols[1].st_shndx = 2;
+  symbols[1].st_value = shdrs[2].sh_addr;
+  symbols[1].st_size = kKernelDescriptorSize;
+  write_bytes_for_test(image, shdrs[3].sh_offset, symbols.data(),
+                       symbols.size() * sizeof(Elf64_Sym));
+
+  std::fill_n(image.data() + shdrs[2].sh_offset, kKernelDescriptorSize, uint8_t{0});
+  const int64_t entry_delta = static_cast<int64_t>(shdrs[1].sh_addr + kernel_entry_text_offset) -
+                              static_cast<int64_t>(shdrs[2].sh_addr);
+  write_value_for_test<int64_t>(image, shdrs[2].sh_offset + kKernelDescriptorEntryOffset,
+                                entry_delta);
+  shdrs[2].sh_addralign = 64;
+  write_bytes_for_test(image, ehdr.e_shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+}
+
+std::vector<uint8_t> make_eh_frame_for_test(uint64_t section_vaddr, uint64_t text_vaddr,
+                                            std::span<const TestFunctionRange> functions) {
+  // One DWARF32 CIE followed by fixed-size FDEs and a zero terminator. This is
+  // the linked AMDGPU zR / pcrel+sdata4 form emitted by clang.
+  constexpr size_t cie_size = 20;
+  constexpr size_t fde_size = 20;
+  std::vector<uint8_t> bytes(cie_size + functions.size() * fde_size + sizeof(uint32_t), 0);
+  write_value_for_test<uint32_t>(bytes, 0, 16);
+  write_value_for_test<uint32_t>(bytes, 4, 0);
+  constexpr std::array<uint8_t, 12> cie_body = {1, 'z', 'R', 0, 4, 4, 16, 1, 0x1b, 0, 0, 0};
+  write_bytes_for_test(bytes, 8, cie_body.data(), cie_body.size());
+
+  for (size_t i = 0; i < functions.size(); ++i) {
+    const size_t entry_start = cie_size + i * fde_size;
+    const size_t id_field = entry_start + sizeof(uint32_t);
+    const size_t initial_location_field = id_field + sizeof(uint32_t);
+    write_value_for_test<uint32_t>(bytes, entry_start, 16);
+    write_value_for_test<uint32_t>(bytes, id_field, static_cast<uint32_t>(id_field));
+    const int64_t field_vaddr = static_cast<int64_t>(section_vaddr + initial_location_field);
+    const int64_t function_vaddr = static_cast<int64_t>(text_vaddr + functions[i].offset);
+    const int64_t delta = function_vaddr - field_vaddr;
+    assert(delta >= std::numeric_limits<int32_t>::min() &&
+           delta <= std::numeric_limits<int32_t>::max());
+    assert(functions[i].size <= std::numeric_limits<uint32_t>::max());
+    write_value_for_test<int32_t>(bytes, initial_location_field, static_cast<int32_t>(delta));
+    write_value_for_test<uint32_t>(bytes, initial_location_field + sizeof(uint32_t),
+                                   static_cast<uint32_t>(functions[i].size));
+    // z augmentation length is zero; the remaining bytes are DW_CFA_nop.
+    bytes[initial_location_field + 2 * sizeof(uint32_t)] = 0;
+  }
+  return bytes;
 }
 
 std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
@@ -613,24 +772,46 @@ bool has_error_containing(const TranslatedCodeObject &result, DiagnosticKind kin
                      });
 }
 
+bool has_warning_containing(const TranslatedCodeObject &result, DiagnosticKind kind,
+                            std::string_view message) {
+  return std::any_of(result.diagnostics.begin(), result.diagnostics.end(),
+                     [&](const TranslationDiagnostic &diagnostic) {
+                       return diagnostic.severity == DiagnosticSeverity::Warning &&
+                              diagnostic.kind == kind &&
+                              diagnostic.message.find(message) != std::string::npos;
+                     });
+}
+
 std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernel_descriptors(
-    const std::vector<uint32_t> &text_words = {0xBF810000u, 0xBF810000u}) {
+    const std::vector<uint32_t> &text_words = {0xBF810000u, 0xBF810000u},
+    std::span<const uint8_t> allocated_eh_frame = {},
+    std::optional<TestFunctionRange> shared_helper = std::nullopt,
+    bool constrain_eh_frame_growth = false) {
   constexpr uint64_t text_offset = 0x100;
-  constexpr uint64_t text_vaddr = 0x1100;
+  const uint64_t text_vaddr = constrain_eh_frame_growth ? 0x1170 : 0x1100;
   const uint64_t text_size = text_words.size() * sizeof(uint32_t);
-  constexpr uint64_t load_align = 0x1000;
+  const uint64_t load_align = constrain_eh_frame_growth ? sizeof(uint32_t) : 0x1000;
   constexpr uint64_t rodata_size = 2 * kKernelDescriptorSize;
+  assert(!constrain_eh_frame_growth || !allocated_eh_frame.empty());
+  assert(!constrain_eh_frame_growth || rodata_size + allocated_eh_frame.size() < text_vaddr);
 
   std::vector<uint8_t> shstrtab{'\0'};
   const uint32_t text_name = add_elf_name(shstrtab, ".text");
   const uint32_t rodata_name = add_elf_name(shstrtab, ".rodata");
   const uint32_t symtab_name = add_elf_name(shstrtab, ".symtab");
   const uint32_t strtab_name = add_elf_name(shstrtab, ".strtab");
+  const uint32_t eh_frame_name =
+      allocated_eh_frame.empty() ? 0 : add_elf_name(shstrtab, ".eh_frame");
   const uint32_t shstrtab_name = add_elf_name(shstrtab, ".shstrtab");
 
   std::vector<uint8_t> strtab{'\0'};
   const uint32_t kernel0_name = add_elf_name(strtab, "kernel0.kd");
   const uint32_t kernel1_name = add_elf_name(strtab, "kernel1.kd");
+  const uint32_t helper_name = shared_helper ? add_elf_name(strtab, "shared_helper") : 0;
+  if (shared_helper) {
+    assert(shared_helper->size != 0 && shared_helper->offset < text_size);
+    assert(shared_helper->size <= text_size - shared_helper->offset);
+  }
 
   // The kernel descriptors require 8-byte alignment (tests reinterpret_cast the
   // .rodata bytes to TestKernelDescriptor). An odd text_words count leaves
@@ -638,14 +819,21 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernel_descriptors(
   // text_vaddr are both 8-aligned and differ by a multiple of load_align, so
   // padding both keeps the PT_LOAD p_offset == p_vaddr (mod p_align) congruence.
   const uint64_t rodata_offset = align_up_for_test(text_offset + text_size, 8);
-  const uint64_t rodata_vaddr = align_up_for_test(text_vaddr + text_size, 8) + load_align;
-  const uint64_t strtab_offset = rodata_offset + rodata_size;
+  const uint64_t eh_frame_offset = rodata_offset + rodata_size;
+  const uint64_t rodata_vaddr =
+      constrain_eh_frame_growth
+          ? (text_vaddr - rodata_size - allocated_eh_frame.size()) & ~(kKernelDescriptorSize - 1)
+          : align_up_for_test(text_vaddr + text_size, 8) + load_align;
+  const uint64_t eh_frame_vaddr =
+      rodata_vaddr + rodata_size + (constrain_eh_frame_growth ? 0 : load_align);
+  const uint64_t strtab_offset =
+      allocated_eh_frame.empty() ? eh_frame_offset : eh_frame_offset + allocated_eh_frame.size();
   const uint64_t symtab_offset = align_up_for_test(strtab_offset + strtab.size(), 8);
-  constexpr size_t sym_count = 3;
+  const size_t sym_count = shared_helper ? 4 : 3;
   const uint64_t shstrtab_offset = symtab_offset + sym_count * sizeof(Elf64_Sym);
   const uint64_t shoff = align_up_for_test(shstrtab_offset + shstrtab.size(), 8);
-  constexpr uint16_t section_count = 6;
-  constexpr uint16_t phdr_count = 2;
+  const uint16_t section_count = allocated_eh_frame.empty() ? 6 : 7;
+  const uint16_t phdr_count = allocated_eh_frame.empty() ? 2 : 3;
 
   std::vector<uint8_t> image(shoff + section_count * sizeof(Elf64_Shdr), 0);
 
@@ -664,10 +852,10 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernel_descriptors(
   ehdr.e_phnum = phdr_count;
   ehdr.e_shentsize = sizeof(Elf64_Shdr);
   ehdr.e_shnum = section_count;
-  ehdr.e_shstrndx = 5;
+  ehdr.e_shstrndx = allocated_eh_frame.empty() ? 5 : 6;
   std::memcpy(image.data(), &ehdr, sizeof(ehdr));
 
-  std::array<Elf64_Phdr, phdr_count> phdrs{};
+  std::vector<Elf64_Phdr> phdrs(phdr_count);
   phdrs[0].p_type = PT_LOAD;
   phdrs[0].p_flags = 0x5; // PF_R | PF_X
   phdrs[0].p_offset = text_offset;
@@ -682,9 +870,20 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernel_descriptors(
   phdrs[1].p_offset = rodata_offset;
   phdrs[1].p_vaddr = rodata_vaddr;
   phdrs[1].p_paddr = rodata_vaddr;
-  phdrs[1].p_filesz = rodata_size;
-  phdrs[1].p_memsz = rodata_size;
+  phdrs[1].p_filesz = rodata_size + (constrain_eh_frame_growth ? allocated_eh_frame.size() : 0);
+  phdrs[1].p_memsz = phdrs[1].p_filesz;
   phdrs[1].p_align = load_align;
+  if (!allocated_eh_frame.empty()) {
+    phdrs[2].p_type = PT_LOAD;
+    phdrs[2].p_flags = constrain_eh_frame_growth ? (PF_R | PF_W) : PF_R;
+    phdrs[2].p_offset =
+        eh_frame_offset + (constrain_eh_frame_growth ? allocated_eh_frame.size() : 0);
+    phdrs[2].p_vaddr = constrain_eh_frame_growth ? text_vaddr + text_size + 0x1000 : eh_frame_vaddr;
+    phdrs[2].p_paddr = phdrs[2].p_vaddr;
+    phdrs[2].p_filesz = constrain_eh_frame_growth ? 0 : allocated_eh_frame.size();
+    phdrs[2].p_memsz = constrain_eh_frame_growth ? 1 : allocated_eh_frame.size();
+    phdrs[2].p_align = load_align;
+  }
   std::memcpy(image.data() + ehdr.e_phoff, phdrs.data(), phdrs.size() * sizeof(Elf64_Phdr));
 
   std::memcpy(image.data() + text_offset, text_words.data(), text_size);
@@ -697,9 +896,13 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernel_descriptors(
       static_cast<int64_t>(text_vaddr + sizeof(uint32_t)) -
           static_cast<int64_t>(rodata_vaddr + kKernelDescriptorSize));
   std::memcpy(image.data() + rodata_offset, descriptors.data(), descriptors.size());
+  if (!allocated_eh_frame.empty()) {
+    std::memcpy(image.data() + eh_frame_offset, allocated_eh_frame.data(),
+                allocated_eh_frame.size());
+  }
   std::memcpy(image.data() + strtab_offset, strtab.data(), strtab.size());
 
-  std::array<Elf64_Sym, sym_count> syms{};
+  std::vector<Elf64_Sym> syms(sym_count);
   syms[1].st_name = kernel0_name;
   syms[1].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
   syms[1].st_shndx = 2;
@@ -710,11 +913,18 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernel_descriptors(
   syms[2].st_shndx = 2;
   syms[2].st_value = rodata_vaddr + kKernelDescriptorSize;
   syms[2].st_size = kKernelDescriptorSize;
+  if (shared_helper) {
+    syms[3].st_name = helper_name;
+    syms[3].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeFunc);
+    syms[3].st_shndx = 1;
+    syms[3].st_value = text_vaddr + shared_helper->offset;
+    syms[3].st_size = shared_helper->size;
+  }
   std::memcpy(image.data() + symtab_offset, syms.data(), syms.size() * sizeof(Elf64_Sym));
 
   std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
 
-  std::array<Elf64_Shdr, section_count> shdrs{};
+  std::vector<Elf64_Shdr> shdrs(section_count);
   shdrs[1].sh_name = text_name;
   shdrs[1].sh_type = SHT_PROGBITS;
   shdrs[1].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
@@ -746,11 +956,22 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernel_descriptors(
   shdrs[4].sh_size = strtab.size();
   shdrs[4].sh_addralign = 1;
 
-  shdrs[5].sh_name = shstrtab_name;
-  shdrs[5].sh_type = SHT_STRTAB;
-  shdrs[5].sh_offset = shstrtab_offset;
-  shdrs[5].sh_size = shstrtab.size();
-  shdrs[5].sh_addralign = 1;
+  if (!allocated_eh_frame.empty()) {
+    shdrs[5].sh_name = eh_frame_name;
+    shdrs[5].sh_type = SHT_PROGBITS;
+    shdrs[5].sh_flags = SHF_ALLOC;
+    shdrs[5].sh_addr = eh_frame_vaddr;
+    shdrs[5].sh_offset = eh_frame_offset;
+    shdrs[5].sh_size = allocated_eh_frame.size();
+    shdrs[5].sh_addralign = sizeof(uint32_t);
+  }
+
+  Elf64_Shdr &shstrtab_header = shdrs[ehdr.e_shstrndx];
+  shstrtab_header.sh_name = shstrtab_name;
+  shstrtab_header.sh_type = SHT_STRTAB;
+  shstrtab_header.sh_offset = shstrtab_offset;
+  shstrtab_header.sh_size = shstrtab.size();
+  shstrtab_header.sh_addralign = 1;
 
   std::memcpy(image.data() + shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
   return image;
@@ -1574,6 +1795,1500 @@ TEST(LegalizationFmaK, Rdna1ToRdna3FmaakF16IsIdentity) {
   ASSERT_NE(e, nullptr);
   EXPECT_EQ(e->action, Action::Identity);
   EXPECT_EQ(e->target_opcode, 56);
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextSameArchIsSuccessfulNoOp) {
+  const auto image = make_minimal_gfx1250_elf_with_empty_text_and_rodata();
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_EQ(source.target_id(), ROCJITSU_CODE_TARGET_GFX1250);
+  ASSERT_FALSE(source.text_sections().empty());
+  ASSERT_EQ(source.text_sections()[0]->size(), 0u);
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_TRUE(result.ok());
+  EXPECT_TRUE(result.dispatchable());
+  EXPECT_EQ(result.elf_bytes, image);
+  const auto warning = std::ranges::find_if(result.diagnostics, [](const auto &diagnostic) {
+    return diagnostic.kind == DiagnosticKind::DataOnly;
+  });
+  ASSERT_NE(warning, result.diagnostics.end());
+  EXPECT_EQ(warning->severity, DiagnosticSeverity::Warning);
+  EXPECT_EQ(warning->message,
+            "code object has no executable sections, segments, or callable symbols; leaving "
+            "unchanged");
+}
+
+TEST(BinaryTranslatorE2E, TruncatedImageFailsBeforeReadingElfHeader) {
+  const std::array<uint8_t, sizeof(Elf64_Ehdr) - 1> image{};
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_FALSE(source.is_valid());
+  ASSERT_LT(source.image_size(), sizeof(Elf64_Ehdr));
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_RDNA4, ROCJITSU_CODE_ARCH_RDNA4);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_TRUE(result.elf_bytes.empty());
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ResourceLimit,
+                                   "too small to contain an ELF header"));
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextCrossArchStillFails) {
+  const auto image = make_minimal_gfx1250_elf_with_empty_text_and_rodata();
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_RDNA4);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ResourceLimit,
+                                   "data-only code object cannot be translated when input and "
+                                   "output targets differ"));
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextSameArchDifferentMachineStillFails) {
+  auto image = make_minimal_gfx1250_elf_with_empty_text_and_rodata();
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1200);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_EQ(source.target_id(), ROCJITSU_CODE_TARGET_GFX1200);
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_RDNA4, ROCJITSU_CODE_ARCH_RDNA4,
+                              EF_AMDGPU_MACH_AMDGCN_GFX1201);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ResourceLimit,
+                                   "data-only code object cannot be translated when input and "
+                                   "output targets differ"));
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextGfx1250StillRequiresRevisions) {
+  const auto image = make_minimal_gfx1250_elf_with_empty_text_and_rodata();
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::Legalization,
+                                   "requires both input and output silicon revisions"));
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextGfx1250StillRejectsA0ToB0) {
+  const auto image = make_minimal_gfx1250_elf_with_empty_text_and_rodata();
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250A0;
+  options.output_revision = ProcessorRevision::Gfx1250B0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::Legalization,
+                                   "A0-to-B0 translation is not supported"));
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextWithRetainedKernelDescriptorFailsClosed) {
+  auto image = make_minimal_amdgpu_elf_with_descriptor_after_text();
+  auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  auto phdrs = read_elf_array_for_test<Elf64_Phdr>(image, ehdr.e_phoff, ehdr.e_phnum);
+  ASSERT_GE(shdrs.size(), 2u);
+  ASSERT_FALSE(phdrs.empty());
+  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX1250;
+  shdrs[1].sh_size = 0;
+  phdrs[0].p_filesz = 0;
+  phdrs[0].p_memsz = 0;
+  write_elf_struct_for_test(image, 0, ehdr);
+  write_bytes_for_test(image, ehdr.e_shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  write_bytes_for_test(image, ehdr.e_phoff, phdrs.data(), phdrs.size() * sizeof(Elf64_Phdr));
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_NE(source.kernel_descriptor_offset("kernel"), 0u);
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ResourceLimit,
+                                   "not confined to one supported non-empty .text section"));
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextWithExecutableLoadPayloadFailsClosed) {
+  auto image = make_minimal_amdgpu_elf_with_load_segments();
+  auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  ASSERT_GE(shdrs.size(), 4u);
+  auto symbols = read_elf_array_for_test<Elf64_Sym>(image, shdrs[3].sh_offset,
+                                                    shdrs[3].sh_size / sizeof(Elf64_Sym));
+  ASSERT_GE(symbols.size(), 3u);
+  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX1250;
+  shdrs[1].sh_size = 0;
+  symbols[2] = {};
+  write_elf_struct_for_test(image, 0, ehdr);
+  write_bytes_for_test(image, ehdr.e_shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  write_bytes_for_test(image, shdrs[3].sh_offset, symbols.data(),
+                       symbols.size() * sizeof(Elf64_Sym));
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ResourceLimit,
+                                   "not confined to one supported non-empty .text section"));
+}
+
+TEST(BinaryTranslatorE2E, EmptyFirstTextWithNonemptySecondTextFailsClosed) {
+  auto image = make_minimal_amdgpu_elf_with_text_and_rodata();
+  auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  ASSERT_GE(shdrs.size(), 3u);
+  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX1250;
+  shdrs[1].sh_size = 0;
+  shdrs[2].sh_name = shdrs[1].sh_name;
+  shdrs[2].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  write_elf_struct_for_test(image, 0, ehdr);
+  write_bytes_for_test(image, ehdr.e_shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_EQ(source.text_sections().size(), 2u);
+  ASSERT_EQ(source.text_sections()[0]->size(), 0u);
+  ASSERT_GT(source.text_sections()[1]->size(), 0u);
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ResourceLimit,
+                                   "not confined to one supported non-empty .text section"));
+}
+
+TEST(BinaryTranslatorE2E, DifferentlyNamedExecutableSectionFailsClosed) {
+  auto image = make_minimal_amdgpu_elf_with_load_segments();
+  auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  ASSERT_GE(shdrs.size(), 3u);
+  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX1250;
+  shdrs[1].sh_name = shdrs[2].sh_name;
+  write_elf_struct_for_test(image, 0, ehdr);
+  write_bytes_for_test(image, ehdr.e_shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_TRUE(source.text_sections().empty());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ResourceLimit,
+                                   "not confined to one supported non-empty .text section"));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorTargetingAlternateExecutableSectionFailsClosed) {
+  auto image = make_minimal_amdgpu_elf_with_descriptor_after_text();
+  auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  auto phdrs = read_elf_array_for_test<Elf64_Phdr>(image, ehdr.e_phoff, ehdr.e_phnum);
+  ASSERT_GE(shdrs.size(), 3u);
+  ASSERT_GE(phdrs.size(), 2u);
+  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX1250;
+  shdrs[1].sh_size = 0;
+  shdrs[2].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  phdrs[0].p_filesz = 0;
+  phdrs[0].p_memsz = 0;
+  phdrs[1].p_flags = PF_R | PF_X;
+  write_value_for_test<int64_t>(image, shdrs[2].sh_offset + kKernelDescriptorEntryOffset, 0);
+  write_elf_struct_for_test(image, 0, ehdr);
+  write_bytes_for_test(image, ehdr.e_shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  write_bytes_for_test(image, ehdr.e_phoff, phdrs.data(), phdrs.size() * sizeof(Elf64_Phdr));
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_NE(source.kernel_descriptor_offset("kernel"), 0u);
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ResourceLimit,
+                                   "not confined to one supported non-empty .text section"));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableWithoutRewriteIsSuccessfulNoOp) {
+  auto image = make_minimal_amdgpu_elf_with_load_segments();
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_FALSE(source.text_sections().empty());
+  ASSERT_GT(source.text_sections()[0]->size(), 0u);
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_warning_containing(result, DiagnosticKind::NothingToTranslate,
+                                     "descriptorless executable functions"));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableRejectsPreV4AmdhsaAbi) {
+  constexpr auto source_clause = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 0});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  constexpr std::array source_words = {source_clause[0], source_return[0]};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words);
+  image[EI_ABIVERSION] = ELFABIVERSION_AMDGPU_HSA_V3;
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::KernelDescriptor,
+                                   "linked LLVM AMDHSA code objects V4-V6"));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableRejectsRelocatableElf) {
+  constexpr auto source_clause = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 0});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  constexpr std::array source_words = {source_clause[0], source_return[0]};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words);
+
+  auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  ASSERT_GE(shdrs.size(), 4u);
+  auto symbols = read_elf_array_for_test<Elf64_Sym>(image, shdrs[3].sh_offset,
+                                                    shdrs[3].sh_size / sizeof(Elf64_Sym));
+  ASSERT_GE(symbols.size(), 3u);
+  ehdr.e_type = ET_REL;
+  ehdr.e_phoff = 0;
+  ehdr.e_phnum = 0;
+  shdrs[1].sh_addr = 0;
+  symbols[2].st_value = 0;
+  write_bytes_for_test(image, 0, &ehdr, sizeof(ehdr));
+  write_bytes_for_test(image, ehdr.e_shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  write_bytes_for_test(image, shdrs[3].sh_offset, symbols.data(),
+                       symbols.size() * sizeof(Elf64_Sym));
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::KernelDescriptor,
+                                   "linked LLVM AMDHSA code objects V4-V6"));
+}
+
+TEST(BinaryTranslatorE2E, ZeroSizedFunctionSymbolDoesNotOverrideKernelDescriptor) {
+  constexpr auto source_clause = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 0});
+  constexpr auto source_end = gfx1250::build_sopp(gfx1250::kSEndpgmSopp);
+  constexpr std::array source_words = {source_clause[0], source_end[0]};
+  constexpr std::array<uint8_t, kKernelDescriptorSize> descriptor{};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(
+      source_words, source_words.size() * sizeof(uint32_t), {}, descriptor);
+  add_kernel_descriptor_to_load_segment_fixture(image, 0);
+
+  const auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  const auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  auto symbols = read_elf_array_for_test<Elf64_Sym>(image, shdrs[3].sh_offset,
+                                                    shdrs[3].sh_size / sizeof(Elf64_Sym));
+  ASSERT_GE(symbols.size(), 3u);
+  symbols[2].st_size = 0;
+  write_bytes_for_test(image, shdrs[3].sh_offset, symbols.data(),
+                       symbols.size() * sizeof(Elf64_Sym));
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_NE(source.kernel_descriptor_offset("kernel"), 0u);
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_EQ(translated.text_sections().size(), 1u);
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  EXPECT_EQ(target_words[0], gfx1250::build_sopp(gfx1250::kSNopSopp)[0]);
+  EXPECT_EQ(target_words[1], source_end[0]);
+}
+
+TEST(BinaryTranslatorE2E, NonGfxKernelFunctionRangeDoesNotExpandScope) {
+  constexpr std::array source_words = {
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),
+      build_s_setpc_b64(/*ssrc0=*/4, ROCJITSU_CODE_ARCH_CDNA4),
+  };
+  constexpr std::array<uint8_t, kKernelDescriptorSize> descriptor{};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(
+      source_words, sizeof(source_words), std::span<const TestFunctionRange>{}, descriptor);
+  add_kernel_descriptor_to_load_segment_fixture(image, 0);
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_NE(source.kernel_descriptor_offset("kernel"), 0u);
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_RDNA4);
+  const auto result = translator.translate(source);
+
+  EXPECT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+}
+
+TEST(BinaryTranslatorE2E, ExportedCallableReachableFromKernelDoesNotInheritDescriptor) {
+  constexpr uint16_t kReturnSgpr = 30;
+  std::array<uint32_t, 16> source_words{};
+  source_words[0] = build_s_call_b64(kReturnSgpr, 3, ROCJITSU_CODE_ARCH_GFX1250);
+  source_words[1] = build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250);
+  source_words[4] = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 0})[0];
+  source_words[5] = build_s_setpc_b64(kReturnSgpr, ROCJITSU_CODE_ARCH_GFX1250);
+  constexpr std::array extra_functions = {
+      TestFunctionRange{.offset = 4 * sizeof(uint32_t), .size = 2 * sizeof(uint32_t)}};
+  constexpr std::array<uint8_t, kKernelDescriptorSize> descriptor{};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words, 2 * sizeof(uint32_t),
+                                                          extra_functions, descriptor);
+  add_kernel_descriptor_to_load_segment_fixture(image, 0);
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_NE(source.kernel_descriptor_offset("kernel"), 0u);
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::KernelDescriptor,
+                                   "externally visible STT_FUNC is reachable"));
+}
+
+TEST(BinaryTranslatorE2E, ZeroSizedFunctionSymbolIsNotADescriptorlessCallableRoot) {
+  constexpr auto source_clause = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 0});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  constexpr std::array source_words = {source_clause[0], source_return[0]};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words);
+
+  const auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  const auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  auto symbols = read_elf_array_for_test<Elf64_Sym>(image, shdrs[3].sh_offset,
+                                                    shdrs[3].sh_size / sizeof(Elf64_Sym));
+  ASSERT_GE(symbols.size(), 3u);
+  symbols[2].st_size = 0;
+  write_bytes_for_test(image, shdrs[3].sh_offset, symbols.data(),
+                       symbols.size() * sizeof(Elf64_Sym));
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::KernelDescriptor,
+                                   "not corroborated by a kernel descriptor"));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableRejectsTrailingUndecodedSymbolBytes) {
+  constexpr auto source_clause = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 0});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  constexpr std::array source_words = {source_clause[0], source_return[0], uint32_t{0}};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words);
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::Legalization,
+                                   "undecodable or unaccounted executable bytes"));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableRejectsSymbolEndingInsideInstruction) {
+  constexpr auto source_addtid = gfx1250::build_vds(gfx1250::kDsStoreAddtidB32Vds, {.data0 = 8});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  constexpr std::array source_words = {source_addtid[0], source_addtid[1], source_return[0]};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words, sizeof(uint32_t));
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::Legalization,
+                                   "does not describe a complete decoded instruction sequence"));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessInvalidInstructionFailsClosedWithoutThrowing) {
+  constexpr std::array<uint32_t, 1> source_words = {0xffffffffu};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words);
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::Legalization,
+                                   "failed to decode executable .text: Invalid instruction "
+                                   "opcode: FFFFFFFF at .text byte offset 0"));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableReplacesSClauseForA0) {
+  constexpr auto source_clause = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 4});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  constexpr std::array source_words = {source_clause[0], source_return[0]};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words);
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_EQ(translated.text_sections().size(), 1u);
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  EXPECT_EQ(target_words[0], gfx1250::build_sopp(gfx1250::kSNopSopp, {.simm16 = 0})[0]);
+  EXPECT_EQ(target_words[1], source_return[0]);
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableHandlesThousandsOfFunctionRanges) {
+  // Cross the 64 KiB direct-branch-island threshold. Descriptorless scopes
+  // cannot grow an ABI-visible text allocation merely to seed unused islands.
+  constexpr size_t kFunctionCount = 8193;
+  constexpr auto source_clause = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 0});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  constexpr auto target_nop = gfx1250::build_sopp(gfx1250::kSNopSopp, {.simm16 = 0});
+
+  std::vector<uint32_t> source_words(kFunctionCount * 2);
+  std::vector<TestFunctionRange> extra_functions;
+  extra_functions.reserve(kFunctionCount - 1);
+  for (size_t i = 0; i < kFunctionCount; ++i) {
+    source_words[i * 2] = source_clause[0];
+    source_words[i * 2 + 1] = source_return[0];
+    if (i != 0) {
+      extra_functions.push_back({.offset = i * 2 * sizeof(uint32_t), .size = 2 * sizeof(uint32_t)});
+    }
+  }
+
+  // This fixture is intentionally large enough that nested
+  // functions-by-blocks scans make the focused test time out or become
+  // conspicuously slow, while the indexed/monotonic implementation remains
+  // linear. Avoid a wall-clock assertion: loaded CI machines still get the
+  // same structural regression coverage from the fixed-size workload.
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words, 2 * sizeof(uint32_t),
+                                                          extra_functions);
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_EQ(translated.text_sections().size(), 1u);
+  ASSERT_GE(translated.text_sections()[0]->size(), source_words.size() * sizeof(uint32_t));
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  for (size_t i = 0; i < kFunctionCount; ++i) {
+    EXPECT_EQ(target_words[i * 2], target_nop[0]);
+    EXPECT_EQ(target_words[i * 2 + 1], source_return[0]);
+  }
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableAcceptsMultipleAbiReturnBlocks) {
+  constexpr auto source_clause = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 0});
+  constexpr auto source_branch = gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp, {.simm16 = 1});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  std::array<uint32_t, 16> source_words{};
+  source_words[0] = source_clause[0];
+  source_words[1] = source_branch[0]; // SCC == 0 branches over the first return.
+  source_words[2] = source_return[0];
+  source_words[3] = gfx1250::build_sopp(gfx1250::kSNopSopp, {.simm16 = 0})[0];
+  source_words[4] = source_return[0];
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words, 5 * sizeof(uint32_t));
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  const auto decoded =
+      ::decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "s_set_pc_i64"; }),
+            2);
+  EXPECT_EQ(std::ranges::count_if(decoded,
+                                  [](const auto &inst) { return inst->mnemonic() == "s_clause"; }),
+            0);
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableAllowsSetregSliceEndingAtVgprBankState) {
+  // WAVE_MODE bits [11:4] end exactly where VGPR-MSB state starts at bit 12.
+  constexpr uint16_t kAdjacentModeSliceHwreg = 0x3901u;
+  constexpr auto source_setreg =
+      gfx1250::build_sopk(gfx1250::kSSetregB32Sopk, {.simm16 = kAdjacentModeSliceHwreg, .sdst = 0});
+  constexpr auto source_clause = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 0});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  constexpr std::array source_words = {source_setreg[0], source_clause[0], source_return[0]};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words);
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  EXPECT_EQ(target_words[0], source_setreg[0]);
+  EXPECT_EQ(target_words[1], gfx1250::build_sopp(gfx1250::kSNopSopp, {.simm16 = 0})[0]);
+  EXPECT_EQ(target_words[2], source_return[0]);
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableRejectsSetregOverlappingVgprBankState) {
+  // WAVE_MODE bits [19:12] are precisely the four gfx1250 VGPR-MSB fields.
+  constexpr uint16_t kVgprBankModeSliceHwreg = 0x3B01u;
+  constexpr auto source_setreg =
+      gfx1250::build_sopk(gfx1250::kSSetregB32Sopk, {.simm16 = kVgprBankModeSliceHwreg, .sdst = 0});
+  constexpr auto source_clause = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 0});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  constexpr std::array source_words = {source_setreg[0], source_clause[0], source_return[0]};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words);
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(
+      has_error_containing(result, DiagnosticKind::ResourceLimit, "changes VGPR-MSB/MODE state"));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableRejectsSetVgprMsb) {
+  constexpr auto source_set_vgpr_msb =
+      gfx1250::build_sopp(gfx1250::kSSetVgprMsbSopp, {.simm16 = 1});
+  constexpr auto source_clause = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 0});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  constexpr std::array source_words = {source_set_vgpr_msb[0], source_clause[0], source_return[0]};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words);
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(
+      has_error_containing(result, DiagnosticKind::ResourceLimit, "changes VGPR-MSB/MODE state"));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableRejectsImmediateModeBankSideEffect) {
+  constexpr uint16_t kModeBitZeroHwreg = 1u;
+  constexpr auto source_setreg =
+      gfx1250::build_sopk(gfx1250::kSSetregImm32B32Sopk, {.simm16 = kModeBitZeroHwreg});
+  constexpr auto source_clause = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 0});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  constexpr std::array source_words = {source_setreg[0], 0u, source_clause[0], source_return[0]};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words);
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(
+      has_error_containing(result, DiagnosticKind::ResourceLimit, "changes VGPR-MSB/MODE state"));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableSeedsModeAtEveryFunctionEntry) {
+  constexpr auto source_addtid = gfx1250::build_vds(gfx1250::kDsStoreAddtidB32Vds, {.data0 = 8});
+  constexpr auto source_high_vgpr =
+      gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 32});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  std::array<uint32_t, 128> source_words{};
+  source_words[0] = gfx1250::build_sopp(gfx1250::kSNopSopp, {.simm16 = 0})[0];
+  source_words[1] = source_return[0];
+  constexpr size_t second_word = 32;
+  source_words[second_word] = source_high_vgpr[0];
+  source_words[second_word + 1] = source_addtid[0];
+  source_words[second_word + 2] = source_addtid[1];
+  source_words[second_word + 3] = source_return[0];
+  constexpr std::array extra_functions = {
+      TestFunctionRange{.offset = second_word * sizeof(uint32_t), .size = 4 * sizeof(uint32_t)}};
+
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words, 2 * sizeof(uint32_t),
+                                                          extra_functions);
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  const auto decoded =
+      ::decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(
+      std::ranges::count_if(
+          decoded, [](const auto &inst) { return inst->mnemonic() == "ds_store_addtid_b32"; }),
+      0);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "ds_store_b32"; }),
+            1);
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableDoesNotBorrowAnotherFunctionsVgprEnvelope) {
+  constexpr auto source_high_vgpr =
+      gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 32});
+  constexpr auto source_addtid = gfx1250::build_vds(gfx1250::kDsStoreAddtidB32Vds, {.data0 = 8});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  std::array<uint32_t, 128> source_words{};
+  source_words[0] = source_high_vgpr[0];
+  source_words[1] = source_return[0];
+  constexpr size_t second_word = 32;
+  source_words[second_word] = source_addtid[0];
+  source_words[second_word + 1] = source_addtid[1];
+  source_words[second_word + 2] = source_return[0];
+  constexpr std::array extra_functions = {
+      TestFunctionRange{.offset = second_word * sizeof(uint32_t), .size = 3 * sizeof(uint32_t)}};
+
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words, 2 * sizeof(uint32_t),
+                                                          extra_functions);
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ExpandFailed,
+                                   "could not allocate a dead low-bank scratch VGPR"));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableExpandsDs2WithinExistingTextAllocation) {
+  constexpr gfx1250::VdsBuilderFields fields{.offset0 = 1, .offset1 = 3, .addr = 7, .vdst = 9};
+  constexpr auto source_ds2 = gfx1250::build_vds(gfx1250::kDsLoad2addrB32Vds, fields);
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  std::array<uint32_t, 16> source_words{};
+  source_words[0] = source_ds2[0];
+  source_words[1] = source_ds2[1];
+  source_words[2] = source_return[0];
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words, 3 * sizeof(uint32_t));
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_EQ(translated.text_sections().size(), 1u);
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  constexpr auto first =
+      gfx1250::build_vds(gfx1250::kDsLoadB32Vds, {.offset0 = 4, .addr = 7, .vdst = 9});
+  constexpr auto second =
+      gfx1250::build_vds(gfx1250::kDsLoadB32Vds, {.offset0 = 12, .addr = 7, .vdst = 10});
+  EXPECT_EQ(target_words[0], first[0]);
+  EXPECT_EQ(target_words[1], first[1]);
+  EXPECT_EQ(target_words[2], second[0]);
+  EXPECT_EQ(target_words[3], second[1]);
+  EXPECT_EQ(target_words[4], gfx1250::build_sopp(gfx1250::kSWaitDscntSopp, {.simm16 = 0})[0]);
+  EXPECT_EQ(target_words[5], source_return[0]);
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableReservesLlvmAmdhsaAbiSgprs) {
+  constexpr auto source_tensor = gfx1250::build_vimage(
+      gfx1250::kTensorLoadToLdsVimage,
+      {.vaddr4 = 124, .vaddr0 = 8, .vaddr1 = 8, .vaddr2 = 124, .vaddr3 = 124});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  std::array<uint32_t, 32> source_words{};
+  std::ranges::copy(source_tensor, source_words.begin());
+  source_words[3] = source_return[0];
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words, 4 * sizeof(uint32_t));
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_EQ(translated.text_sections().size(), 1u);
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  constexpr auto save_descriptor =
+      gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 8, .sdst = 40});
+  EXPECT_EQ(target_words[0], save_descriptor[0]);
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableRelocatesEhFrameFunctionRanges) {
+  constexpr auto source_clause = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 0});
+  constexpr auto source_ds2 = gfx1250::build_vds(
+      gfx1250::kDsLoad2addrB32Vds, {.offset0 = 1, .offset1 = 3, .addr = 7, .vdst = 9});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  std::array<uint32_t, 128> source_words{};
+  source_words[0] = source_clause[0];
+  source_words[1] = source_return[0];
+  constexpr size_t second_word = 32;
+  source_words[second_word] = source_ds2[0];
+  source_words[second_word + 1] = source_ds2[1];
+  source_words[second_word + 2] = source_return[0];
+
+  constexpr uint64_t text_vaddr = 0x1100;
+  constexpr uint64_t allocated_vaddr = text_vaddr + sizeof(source_words) + 0x1000;
+  constexpr std::array functions = {
+      TestFunctionRange{.offset = 0, .size = 2 * sizeof(uint32_t)},
+      TestFunctionRange{.offset = second_word * sizeof(uint32_t), .size = 3 * sizeof(uint32_t)}};
+  constexpr std::array extra_functions = {functions[1]};
+  const auto eh_frame = make_eh_frame_for_test(allocated_vaddr, text_vaddr, functions);
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words, functions[0].size,
+                                                          extra_functions, eh_frame, ".eh_frame");
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  const Section *translated_eh_frame = find_section(translated, ".eh_frame");
+  ASSERT_NE(translated_eh_frame, nullptr);
+  ASSERT_GE(translated_eh_frame->size(), 60u);
+
+  const auto fde_range = [&](size_t entry_start) {
+    const size_t initial_location_field = entry_start + 2 * sizeof(uint32_t);
+    int32_t delta = 0;
+    uint32_t range = 0;
+    std::memcpy(&delta, translated_eh_frame->data() + initial_location_field, sizeof(delta));
+    std::memcpy(&range, translated_eh_frame->data() + initial_location_field + sizeof(uint32_t),
+                sizeof(range));
+    const int64_t field_vaddr =
+        static_cast<int64_t>(translated_eh_frame->vaddr() + initial_location_field);
+    return std::pair<uint64_t, uint32_t>{static_cast<uint64_t>(field_vaddr + delta), range};
+  };
+
+  const auto first = fde_range(20);
+  const auto second = fde_range(40);
+  EXPECT_EQ(first.first, text_vaddr);
+  EXPECT_EQ(first.second, 2 * sizeof(uint32_t));
+  EXPECT_EQ(second.first, text_vaddr + 2 * sizeof(uint32_t));
+  EXPECT_EQ(second.second, 6 * sizeof(uint32_t));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorBackedTextGrowthRelocatesAllocatedEhFrame) {
+  constexpr auto source_ds2 = gfx1250::build_vds(
+      gfx1250::kDsLoad2addrB32Vds, {.offset0 = 1, .offset1 = 3, .addr = 7, .vdst = 9});
+  constexpr auto source_end = gfx1250::build_sopp(gfx1250::kSEndpgmSopp);
+  constexpr std::array source_words = {source_ds2[0], source_ds2[1], source_end[0]};
+  constexpr uint64_t text_vaddr = 0x1100;
+  constexpr uint64_t descriptor_vaddr = text_vaddr + sizeof(source_words) + 0x1000;
+  constexpr uint64_t eh_frame_vaddr = descriptor_vaddr + kKernelDescriptorSize + 0x1000;
+  constexpr std::array functions = {TestFunctionRange{.offset = 0, .size = sizeof(source_words)}};
+  auto eh_frame = make_eh_frame_for_test(eh_frame_vaddr, text_vaddr, functions);
+  constexpr size_t fde_cfi_program = 20 + 4 + 4 + 4 + 4 + 1;
+  ASSERT_LT(fde_cfi_program, eh_frame.size());
+  eh_frame[fde_cfi_program] = 0x42; // DW_CFA_advance_loc by two four-byte instructions.
+  constexpr std::array<uint8_t, kKernelDescriptorSize> descriptor{};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(
+      source_words, sizeof(source_words), std::span<const TestFunctionRange>{}, descriptor,
+      ".rodata", eh_frame, ".eh_frame");
+  add_kernel_descriptor_to_load_segment_fixture(image, 0);
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_NE(source.kernel_descriptor_offset("kernel"), 0u);
+  const Section *source_eh_frame = find_section(source, ".eh_frame");
+  ASSERT_NE(source_eh_frame, nullptr);
+  ASSERT_EQ(source_eh_frame->vaddr(), eh_frame_vaddr);
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_EQ(translated.text_sections().size(), 1u);
+  const Section *translated_text = translated.text_sections()[0];
+  ASSERT_GT(translated_text->size(), sizeof(source_words));
+
+  const Section *translated_eh_frame = find_section(translated, ".eh_frame");
+  ASSERT_NE(translated_eh_frame, nullptr);
+  EXPECT_GT(translated_eh_frame->vaddr(), source_eh_frame->vaddr());
+  constexpr size_t initial_location_field = 20 + 2 * sizeof(uint32_t);
+  int32_t delta = 0;
+  uint32_t range = 0;
+  std::memcpy(&delta, translated_eh_frame->data() + initial_location_field, sizeof(delta));
+  std::memcpy(&range, translated_eh_frame->data() + initial_location_field + sizeof(uint32_t),
+              sizeof(range));
+  const int64_t field_vaddr =
+      static_cast<int64_t>(translated_eh_frame->vaddr() + initial_location_field);
+  EXPECT_EQ(static_cast<uint64_t>(field_vaddr + delta), translated_text->vaddr());
+  EXPECT_EQ(range, translated_text->size());
+  const uint8_t relocated_advance = translated_eh_frame->data()[fde_cfi_program];
+  EXPECT_EQ(relocated_advance & 0xc0u, 0x40u);
+  EXPECT_EQ(relocated_advance & 0x3fu,
+            (translated_text->size() - sizeof(source_end)) / sizeof(uint32_t));
+
+  const Section *translated_rodata = find_section(translated, ".rodata");
+  ASSERT_NE(translated_rodata, nullptr);
+  const int64_t entry_delta = read_kernel_descriptor_entry_offset(translated_rodata->data());
+  EXPECT_EQ(static_cast<int64_t>(translated_rodata->vaddr()) + entry_delta,
+            static_cast<int64_t>(translated_text->vaddr()));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorBackedGrowthExpandsAllocatedEhFrameCfi) {
+  constexpr auto source_ds2 = gfx1250::build_vds(
+      gfx1250::kDsLoad2addrB32Vds, {.offset0 = 1, .offset1 = 3, .addr = 7, .vdst = 9});
+  constexpr auto source_end = gfx1250::build_sopp(gfx1250::kSEndpgmSopp);
+  constexpr uint64_t cfi_transition_offset = 65532;
+  std::vector<uint32_t> source_words(cfi_transition_offset / sizeof(uint32_t) + 2, 0xbf800000u);
+  source_words[0] = source_ds2[0];
+  source_words[1] = source_ds2[1];
+  source_words.back() = source_end[0];
+
+  constexpr uint64_t text_vaddr = 0x1100;
+  const uint64_t descriptor_vaddr = text_vaddr + source_words.size() * sizeof(uint32_t) + 0x1000;
+  const uint64_t eh_frame_vaddr = descriptor_vaddr + kKernelDescriptorSize + 0x1000;
+  const std::array functions = {
+      TestFunctionRange{.offset = 0, .size = source_words.size() * sizeof(uint32_t)}};
+  auto eh_frame = make_eh_frame_for_test(eh_frame_vaddr, text_vaddr, functions);
+  constexpr size_t fde_cfi_program = 20 + 4 + 4 + 4 + 4 + 1;
+  ASSERT_EQ(eh_frame.size(), 44u);
+  eh_frame[12] = 1;                 // CIE code-alignment factor.
+  eh_frame[fde_cfi_program] = 0x03; // DW_CFA_advance_loc2.
+  write_value_for_test<uint16_t>(eh_frame, fde_cfi_program + 1,
+                                 static_cast<uint16_t>(cfi_transition_offset));
+
+  constexpr std::array<uint8_t, kKernelDescriptorSize> descriptor{};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(
+      source_words, source_words.size() * sizeof(uint32_t), std::span<const TestFunctionRange>{},
+      descriptor, ".rodata", eh_frame, ".eh_frame");
+  add_kernel_descriptor_to_load_segment_fixture(image, 0);
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  const Section *translated_eh_frame = find_section(translated, ".eh_frame");
+  ASSERT_NE(translated_eh_frame, nullptr);
+  ASSERT_GT(translated_eh_frame->size(), eh_frame.size());
+  ASSERT_GT(translated_eh_frame->size(), fde_cfi_program + sizeof(uint32_t));
+  EXPECT_EQ(translated_eh_frame->data()[fde_cfi_program], 0x04);
+  uint32_t relocated_units = 0;
+  std::memcpy(&relocated_units, translated_eh_frame->data() + fde_cfi_program + 1,
+              sizeof(relocated_units));
+  EXPECT_EQ(relocated_units, cfi_transition_offset + 3 * sizeof(uint32_t));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableReportsEhFrameRelocationFailure) {
+  constexpr auto source_ds2 = gfx1250::build_vds(
+      gfx1250::kDsLoad2addrB32Vds, {.offset0 = 1, .offset1 = 3, .addr = 7, .vdst = 9});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  std::array<uint32_t, 64> source_words{};
+  source_words[0] = source_ds2[0];
+  source_words[1] = source_ds2[1];
+  source_words[2] = source_return[0];
+
+  constexpr uint64_t text_vaddr = 0x1100;
+  constexpr uint64_t allocated_vaddr = text_vaddr + sizeof(source_words) + 0x1000;
+  constexpr std::array functions = {TestFunctionRange{.offset = 0, .size = 3 * sizeof(uint32_t)}};
+  auto eh_frame = make_eh_frame_for_test(allocated_vaddr, text_vaddr, functions);
+  ASSERT_GT(eh_frame.size(), 8u);
+  eh_frame[8] = 2; // The patcher supports only the linked AMDGPU version-1 CIE.
+  auto image = make_minimal_amdgpu_elf_with_load_segments(
+      source_words, functions[0].size, std::span<const TestFunctionRange>{}, eh_frame, ".eh_frame");
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ResourceLimit,
+                                   "unsupported .eh_frame CIE version"));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableRejectsLocationSensitiveCieForNonAffineMapping) {
+  constexpr auto source_ds2 = gfx1250::build_vds(
+      gfx1250::kDsLoad2addrB32Vds, {.offset0 = 1, .offset1 = 3, .addr = 7, .vdst = 9});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  std::array<uint32_t, 16> source_words{};
+  source_words[0] = source_ds2[0];
+  source_words[1] = source_ds2[1];
+  source_words[2] = source_return[0];
+  constexpr uint64_t text_vaddr = 0x1100;
+  constexpr uint64_t allocated_vaddr = text_vaddr + sizeof(source_words) + 0x1000;
+  constexpr std::array functions = {TestFunctionRange{.offset = 0, .size = 3 * sizeof(uint32_t)}};
+  auto eh_frame = make_eh_frame_for_test(allocated_vaddr, text_vaddr, functions);
+  ASSERT_GE(eh_frame.size(), 19u);
+  eh_frame[17] = 0x02; // DW_CFA_advance_loc1.
+  eh_frame[18] = 1;
+  auto image = make_minimal_amdgpu_elf_with_load_segments(
+      source_words, functions[0].size, std::span<const TestFunctionRange>{}, eh_frame, ".eh_frame");
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ResourceLimit,
+                                   "non-affine .eh_frame CIE has location-sensitive CFI"));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableDropsStaleNonallocDebugFrames) {
+  constexpr auto source_ds2 = gfx1250::build_vds(
+      gfx1250::kDsLoad2addrB32Vds, {.offset0 = 1, .offset1 = 3, .addr = 7, .vdst = 9});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  std::array<uint32_t, 16> source_words{};
+  source_words[0] = source_ds2[0];
+  source_words[1] = source_ds2[1];
+  source_words[2] = source_return[0];
+  constexpr std::array<uint8_t, 16> debug_frame{};
+  for (const std::string_view section_name : {".debug_frame", ".zdebug_frame"}) {
+    SCOPED_TRACE(std::string(section_name));
+    auto image = make_minimal_amdgpu_elf_with_load_segments(source_words, 3 * sizeof(uint32_t),
+                                                            std::span<const TestFunctionRange>{},
+                                                            debug_frame, section_name);
+    auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+    auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+    ASSERT_GE(shdrs.size(), 3u);
+    shdrs[2].sh_flags = 0;
+    write_bytes_for_test(image, ehdr.e_shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+    write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                   EF_AMDGPU_MACH_AMDGCN_GFX1250);
+
+    AmdGpuCodeObject source(image.data(), image.size());
+    ASSERT_TRUE(source.is_valid());
+    BinaryTranslatorOptions options;
+    options.input_revision = ProcessorRevision::Gfx1250B0;
+    options.output_revision = ProcessorRevision::Gfx1250A0;
+    BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+    const auto result = translator.translate(source);
+
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+    EXPECT_TRUE(has_warning_containing(result, DiagnosticKind::Legalization,
+                                       "dropped non-allocated DWARF sections"));
+    AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    ASSERT_TRUE(translated.is_valid());
+    const Section *translated_debug_frame = find_section(translated, section_name);
+    ASSERT_NE(translated_debug_frame, nullptr);
+    EXPECT_EQ(translated_debug_frame->size(), 0u);
+  }
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableRejectsEhFrameLsdaAugmentation) {
+  constexpr auto source_ds2 = gfx1250::build_vds(
+      gfx1250::kDsLoad2addrB32Vds, {.offset0 = 1, .offset1 = 3, .addr = 7, .vdst = 9});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  std::array<uint32_t, 16> source_words{};
+  source_words[0] = source_ds2[0];
+  source_words[1] = source_ds2[1];
+  source_words[2] = source_return[0];
+  constexpr uint64_t text_vaddr = 0x1100;
+  constexpr uint64_t allocated_vaddr = text_vaddr + sizeof(source_words) + 0x1000;
+  constexpr std::array functions = {TestFunctionRange{.offset = 0, .size = 3 * sizeof(uint32_t)}};
+  auto eh_frame = make_eh_frame_for_test(allocated_vaddr, text_vaddr, functions);
+  ASSERT_GT(eh_frame.size(), 10u);
+  eh_frame[10] = 'L';
+  auto image = make_minimal_amdgpu_elf_with_load_segments(
+      source_words, functions[0].size, std::span<const TestFunctionRange>{}, eh_frame, ".eh_frame");
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(
+      has_error_containing(result, DiagnosticKind::ResourceLimit, "unsupported LSDA augmentation"));
+}
+
+TEST(CodeObjectPatcher, ReplaceTextRollsBackAfterLateRelocationFailure) {
+  constexpr auto source_clause = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 0});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  constexpr std::array source_words = {source_clause[0], source_return[0], source_clause[0],
+                                       source_return[0]};
+  constexpr std::array<uint8_t, sizeof(Elf64_Rela)> relocation_bytes{};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(
+      source_words, source_words.size() * sizeof(uint32_t), std::span<const TestFunctionRange>{},
+      relocation_bytes, ".rela.test");
+  const auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  ASSERT_GE(shdrs.size(), 3u);
+  Elf64_Rela relocation{};
+  relocation.r_offset = shdrs[2].sh_addr;
+  relocation.r_info = R_AMDGPU_RELATIVE64;
+  relocation.r_addend = static_cast<int64_t>(shdrs[1].sh_addr + 2 * sizeof(uint32_t));
+  write_elf_struct_for_test(image, shdrs[2].sh_offset, relocation);
+  shdrs[2].sh_type = SHT_RELA;
+  shdrs[2].sh_flags = 0;
+  shdrs[2].sh_entsize = sizeof(Elf64_Rela);
+  shdrs[2].sh_link = SHN_UNDEF;
+  write_bytes_for_test(image, ehdr.e_shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  CodeObjectPatcher patcher(source);
+  const std::array relocations = {TextOffsetRelocation{.source_offset = 0, .target_offset = 0},
+                                  TextOffsetRelocation{.source_offset = sizeof(source_words),
+                                                       .target_offset = sizeof(source_words)}};
+  std::vector<uint8_t> replacement(patcher.text_bytes().begin(), patcher.text_bytes().end());
+  replacement[0] ^= 0xffu;
+  std::string error;
+
+  EXPECT_FALSE(patcher.replace_text(replacement, relocations, {}, &error));
+  EXPECT_NE(error.find("R_AMDGPU_RELATIVE64 addends"), std::string::npos);
+  EXPECT_EQ(patcher.emit(), image);
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableUsesScratchInsideSourceVgprGranule) {
+  constexpr auto source_addtid =
+      gfx1250::build_vds(gfx1250::kDsStoreAddtidB32Vds, {.offset0 = 4, .data0 = 8});
+  constexpr auto source_return_value =
+      gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 256 + 8, .vdst = 0});
+  constexpr auto source_high_vgpr =
+      gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 32});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+
+  // v0 contains a possible externally observed return value before the ADDTID
+  // store, while a dead source write to caller-clobbered v32 proves that the
+  // original callable already requires a 48-VGPR hardware allocation envelope.
+  // The lowering may borrow v32, but never any unknown v0-v31 return register.
+  std::array<uint32_t, 64> source_words{};
+  size_t cursor = 0;
+  source_words[cursor++] = source_return_value[0];
+  source_words[cursor++] = source_high_vgpr[0];
+  source_words[cursor++] = source_addtid[0];
+  source_words[cursor++] = source_addtid[1];
+  source_words[cursor++] = source_return[0];
+
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words, cursor * sizeof(uint32_t));
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  const auto decoded =
+      ::decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(
+      std::ranges::count_if(
+          decoded, [](const auto &inst) { return inst->mnemonic() == "ds_store_addtid_b32"; }),
+      0);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "ds_store_b32"; }),
+            1);
+  const auto mbcnt_lo = std::ranges::find_if(
+      decoded, [](const auto &inst) { return inst->mnemonic() == "v_mbcnt_lo_u32_b32"; });
+  ASSERT_NE(mbcnt_lo, decoded.end());
+  ASSERT_NE((*mbcnt_lo)->raw_encoding(), nullptr);
+  EXPECT_EQ((*mbcnt_lo)->raw_encoding()[0] & 0xffu, 32u)
+      << "scratch must use a caller-clobbered register above the unknown return set";
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessCallableFailsClosedWhenScratchWouldGrowVgprs) {
+  constexpr auto source_addtid =
+      gfx1250::build_vds(gfx1250::kDsStoreAddtidB32Vds, {.offset0 = 4, .data0 = 8});
+  constexpr auto source_return_value =
+      gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 256 + 8, .vdst = 0});
+  constexpr auto source_v31 = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 31});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+
+  // The source allocation ends at v31, and all v0-v31 registers are possible
+  // return values because final HSACO has no function signature. There is no
+  // descriptor through which DBT could advertise v32, so translation must fail
+  // closed and preserve the input bytes.
+  std::array<uint32_t, 64> source_words{};
+  size_t cursor = 0;
+  source_words[cursor++] = source_return_value[0];
+  source_words[cursor++] = source_v31[0];
+  source_words[cursor++] = source_addtid[0];
+  source_words[cursor++] = source_addtid[1];
+  source_words[cursor++] = source_return[0];
+
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words, cursor * sizeof(uint32_t));
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ExpandFailed,
+                                   "could not allocate a dead low-bank scratch VGPR"));
+}
+
+TEST(BinaryTranslatorE2E, MixedKernelAndIndependentCallableTranslateWithoutAliasing) {
+  constexpr auto source_clause = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 0});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  constexpr auto source_end = gfx1250::build_sopp(gfx1250::kSEndpgmSopp);
+  constexpr size_t kernel_word = 32;
+  std::array<uint32_t, 64> source_words{};
+  source_words[0] = source_clause[0];
+  source_words[1] = source_return[0];
+  source_words[kernel_word] = source_clause[0];
+  source_words[kernel_word + 1] = source_end[0];
+  constexpr std::array kernel_function = {
+      TestFunctionRange{.offset = kernel_word * sizeof(uint32_t), .size = 2 * sizeof(uint32_t)}};
+  constexpr std::array<uint8_t, kKernelDescriptorSize> descriptor{};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words, 2 * sizeof(uint32_t),
+                                                          kernel_function, descriptor);
+  add_kernel_descriptor_to_load_segment_fixture(image, kernel_function[0].offset);
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_NE(source.kernel_descriptor_offset("kernel"), 0u);
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_EQ(translated.text_sections().size(), 1u);
+
+  const auto target_ehdr = read_elf_struct_for_test<Elf64_Ehdr>(result.elf_bytes, 0);
+  const auto target_shdrs = read_elf_array_for_test<Elf64_Shdr>(
+      result.elf_bytes, target_ehdr.e_shoff, target_ehdr.e_shnum);
+  ASSERT_GE(target_shdrs.size(), 4u);
+  const auto target_symbols = read_elf_array_for_test<Elf64_Sym>(
+      result.elf_bytes, target_shdrs[3].sh_offset, target_shdrs[3].sh_size / sizeof(Elf64_Sym));
+  ASSERT_GE(target_symbols.size(), 4u);
+  const uint64_t text_vaddr = translated.text_sections()[0]->vaddr();
+  ASSERT_GE(target_symbols[2].st_value, text_vaddr);
+  ASSERT_GE(target_symbols[3].st_value, text_vaddr);
+  const uint64_t callable_offset = target_symbols[2].st_value - text_vaddr;
+  const uint64_t kernel_offset = target_symbols[3].st_value - text_vaddr;
+  ASSERT_NE(callable_offset, kernel_offset);
+  ASSERT_LE(callable_offset + 2 * sizeof(uint32_t), translated.text_sections()[0]->size());
+  ASSERT_LE(kernel_offset + 2 * sizeof(uint32_t), translated.text_sections()[0]->size());
+
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  EXPECT_EQ(target_words[callable_offset / sizeof(uint32_t)],
+            gfx1250::build_sopp(gfx1250::kSNopSopp)[0]);
+  EXPECT_EQ(target_words[callable_offset / sizeof(uint32_t) + 1], source_return[0]);
+  EXPECT_EQ(target_words[kernel_offset / sizeof(uint32_t)],
+            gfx1250::build_sopp(gfx1250::kSNopSopp)[0]);
+  EXPECT_EQ(target_words[kernel_offset / sizeof(uint32_t) + 1], source_end[0]);
+
+  const Section *target_rodata = find_section(translated, ".rodata");
+  ASSERT_NE(target_rodata, nullptr);
+  const int64_t target_entry_delta = read_kernel_descriptor_entry_offset(target_rodata->data());
+  EXPECT_EQ(static_cast<int64_t>(target_rodata->vaddr()) + target_entry_delta,
+            static_cast<int64_t>(text_vaddr + kernel_offset));
+}
+
+TEST(BinaryTranslatorE2E, MixedKernelRejectsUncorroboratedZeroSizedCallable) {
+  constexpr auto source_clause = gfx1250::build_sopp(gfx1250::kSClauseSopp, {.simm16 = 0});
+  constexpr auto source_return =
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30, .sdst = 0});
+  constexpr auto source_end = gfx1250::build_sopp(gfx1250::kSEndpgmSopp);
+  constexpr size_t kernel_word = 32;
+  std::array<uint32_t, 64> source_words{};
+  source_words[0] = source_clause[0];
+  source_words[1] = source_return[0];
+  source_words[kernel_word] = source_clause[0];
+  source_words[kernel_word + 1] = source_end[0];
+  constexpr std::array kernel_function = {
+      TestFunctionRange{.offset = kernel_word * sizeof(uint32_t), .size = 2 * sizeof(uint32_t)}};
+  constexpr std::array<uint8_t, kKernelDescriptorSize> descriptor{};
+  auto image = make_minimal_amdgpu_elf_with_load_segments(source_words, 2 * sizeof(uint32_t),
+                                                          kernel_function, descriptor);
+  add_kernel_descriptor_to_load_segment_fixture(image, kernel_function[0].offset);
+
+  const auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  const auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  auto symbols = read_elf_array_for_test<Elf64_Sym>(image, shdrs[3].sh_offset,
+                                                    shdrs[3].sh_size / sizeof(Elf64_Sym));
+  ASSERT_GE(symbols.size(), 4u);
+  symbols[2].st_size = 0;
+  write_bytes_for_test(image, shdrs[3].sh_offset, symbols.data(),
+                       symbols.size() * sizeof(Elf64_Sym));
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_NE(source.kernel_descriptor_offset("kernel"), 0u);
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::KernelDescriptor,
+                                   "not corroborated by a kernel descriptor"));
 }
 
 TEST(CodeObjectPatcher, ReplaceTextGrowsTextAndShiftsFollowingSections) {
@@ -4949,6 +6664,94 @@ TEST(BinaryTranslatorE2E, DuplicatesSharedReachableBlocksPerKernel) {
   EXPECT_EQ(target_words[1], kCdna4SEndpgm);
   EXPECT_EQ(target_words[second_entry_word], rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3));
   EXPECT_EQ(target_words[second_entry_word + 1], kCdna4SEndpgm);
+}
+
+TEST(BinaryTranslatorE2E, DuplicatesSharedHelperEhFrameFdePerKernel) {
+  constexpr uint32_t kCdna4SEndpgm = cdna4::build_sopp(cdna4::kSEndpgmSopp)[0];
+  const std::vector<uint32_t> words = {
+      rocjitsu::build_s_branch(1, ROCJITSU_CODE_ARCH_CDNA4), // kernel0 -> shared helper.
+      rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA4), // kernel1 -> shared helper.
+      kCdna4SEndpgm,
+  };
+  constexpr uint64_t text_vaddr = 0x1170;
+  constexpr uint64_t helper_offset = 2 * sizeof(uint32_t);
+  constexpr uint64_t helper_size = sizeof(uint32_t);
+  constexpr rocjitsu::TestFunctionRange helper{.offset = helper_offset, .size = helper_size};
+  constexpr std::array functions = {helper};
+  auto eh_frame = rocjitsu::make_eh_frame_for_test(0, text_vaddr, functions);
+  const uint64_t rodata_vaddr =
+      (text_vaddr - 2 * rocjitsu::kKernelDescriptorSize - eh_frame.size()) &
+      ~(rocjitsu::kKernelDescriptorSize - 1);
+  const uint64_t eh_frame_vaddr = rodata_vaddr + 2 * rocjitsu::kKernelDescriptorSize;
+  eh_frame = rocjitsu::make_eh_frame_for_test(eh_frame_vaddr, text_vaddr, functions);
+  auto image =
+      rocjitsu::make_minimal_amdgpu_elf_with_two_kernel_descriptors(words, eh_frame, helper, true);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  const rocjitsu::Section *source_eh_frame = rocjitsu::find_section(source, ".eh_frame");
+  ASSERT_NE(source_eh_frame, nullptr);
+  EXPECT_EQ(text_vaddr - (source_eh_frame->vaddr() + source_eh_frame->size()), 4u);
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_EQ(translated.text_sections().size(), 1u);
+  const rocjitsu::Section *text = translated.text_sections().front();
+  const rocjitsu::Section *translated_eh_frame = rocjitsu::find_section(translated, ".eh_frame");
+  ASSERT_NE(translated_eh_frame, nullptr);
+  EXPECT_GT(translated_eh_frame->vaddr(), source_eh_frame->vaddr());
+
+  rocjitsu::KernelDescriptorTranslator parser(ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA3);
+  const auto infos = parser.translate_image(result.elf_bytes, text->sectionOffset(), text->size(),
+                                            rocjitsu::KernelDescriptorTranslationOptions{});
+  ASSERT_EQ(infos.size(), 2u);
+  std::vector<uint64_t> expected_helper_vaddrs;
+  for (const auto &info : infos)
+    expected_helper_vaddrs.push_back(text->vaddr() + info.entry_text_offset + sizeof(uint32_t));
+  std::ranges::sort(expected_helper_vaddrs);
+
+  std::vector<uint64_t> fde_starts;
+  size_t cursor = 0;
+  while (cursor + sizeof(uint32_t) <= translated_eh_frame->size()) {
+    uint32_t length = 0;
+    std::memcpy(&length, translated_eh_frame->data() + cursor, sizeof(length));
+    if (length == 0)
+      break;
+    ASSERT_GE(length, sizeof(uint32_t));
+    ASSERT_LE(cursor + sizeof(uint32_t) + length, translated_eh_frame->size());
+    uint32_t cie_pointer = 0;
+    std::memcpy(&cie_pointer, translated_eh_frame->data() + cursor + sizeof(uint32_t),
+                sizeof(cie_pointer));
+    if (cie_pointer != 0) {
+      const size_t initial_location_field = cursor + 2 * sizeof(uint32_t);
+      int32_t delta = 0;
+      uint32_t range = 0;
+      std::memcpy(&delta, translated_eh_frame->data() + initial_location_field, sizeof(delta));
+      std::memcpy(&range, translated_eh_frame->data() + initial_location_field + sizeof(uint32_t),
+                  sizeof(range));
+      const int64_t field_vaddr =
+          static_cast<int64_t>(translated_eh_frame->vaddr() + initial_location_field);
+      fde_starts.push_back(static_cast<uint64_t>(field_vaddr + delta));
+      EXPECT_EQ(range, helper_size);
+    }
+    cursor += sizeof(uint32_t) + length;
+  }
+  std::ranges::sort(fde_starts);
+  EXPECT_EQ(fde_starts, expected_helper_vaddrs);
+
+  const auto ehdr = rocjitsu::read_elf_struct_for_test<rocjitsu::Elf64_Ehdr>(result.elf_bytes, 0);
+  const auto shdrs = rocjitsu::read_elf_array_for_test<rocjitsu::Elf64_Shdr>(
+      result.elf_bytes, ehdr.e_shoff, ehdr.e_shnum);
+  ASSERT_GT(shdrs.size(), 3u);
+  const auto symbols = rocjitsu::read_elf_array_for_test<rocjitsu::Elf64_Sym>(
+      result.elf_bytes, shdrs[3].sh_offset, shdrs[3].sh_size / sizeof(rocjitsu::Elf64_Sym));
+  ASSERT_GT(symbols.size(), 3u);
+  EXPECT_EQ(symbols[3].st_size, helper_size);
+  EXPECT_TRUE(std::ranges::binary_search(fde_starts, symbols[3].st_value));
 }
 
 TEST(BinaryTranslatorE2E, Cdna4ToCdna3SemanticExpandRulesHaveTranslationFixtures) {

--- a/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
@@ -196,6 +196,89 @@ std::vector<uint8_t> make_gfx1250_smoke_code_object() {
   return make_gfx1250_smoke_code_object(text_words);
 }
 
+std::vector<uint8_t> make_empty_text_code_object() {
+  auto image = make_smoke_code_object();
+
+  rocjitsu::Elf64_Ehdr header{};
+  std::memcpy(&header, image.data(), sizeof(header));
+  header.e_flags = rocjitsu::EF_AMDGPU_MACH_AMDGCN_GFX1250;
+  std::memcpy(image.data(), &header, sizeof(header));
+
+  rocjitsu::Elf64_Phdr executable_load{};
+  std::memcpy(&executable_load, image.data() + header.e_phoff, sizeof(executable_load));
+  executable_load.p_filesz = 0;
+  executable_load.p_memsz = 0;
+  std::memcpy(image.data() + header.e_phoff, &executable_load, sizeof(executable_load));
+
+  auto section_offset = [&](size_t index) {
+    return header.e_shoff + index * sizeof(rocjitsu::Elf64_Shdr);
+  };
+  rocjitsu::Elf64_Shdr text{};
+  std::memcpy(&text, image.data() + section_offset(1), sizeof(text));
+  text.sh_size = 0;
+  std::memcpy(image.data() + section_offset(1), &text, sizeof(text));
+
+  // The source smoke fixture has one synthetic kernel descriptor. Clear it so
+  // this variant represents the descriptor-free, data-only corpus object that
+  // motivated the successful empty-text no-op.
+  rocjitsu::Elf64_Shdr symtab{};
+  std::memcpy(&symtab, image.data() + section_offset(3), sizeof(symtab));
+  rocjitsu::Elf64_Sym descriptor{};
+  std::memcpy(&descriptor, image.data() + symtab.sh_offset + sizeof(rocjitsu::Elf64_Sym),
+              sizeof(descriptor));
+  descriptor.st_name = 0;
+  descriptor.st_info = 0;
+  descriptor.st_shndx = rocjitsu::SHN_UNDEF;
+  descriptor.st_value = 0;
+  descriptor.st_size = 0;
+  std::memcpy(image.data() + symtab.sh_offset + sizeof(rocjitsu::Elf64_Sym), &descriptor,
+              sizeof(descriptor));
+
+  return image;
+}
+
+std::vector<uint8_t> make_padded_descriptorless_code_object() {
+  auto image = make_smoke_code_object();
+
+  rocjitsu::Elf64_Ehdr header{};
+  std::memcpy(&header, image.data(), sizeof(header));
+  header.e_flags = rocjitsu::EF_AMDGPU_MACH_AMDGCN_GFX1250;
+  std::memcpy(image.data(), &header, sizeof(header));
+
+  const auto section_offset = [&](size_t index) {
+    return header.e_shoff + index * sizeof(rocjitsu::Elf64_Shdr);
+  };
+  rocjitsu::Elf64_Shdr text{};
+  rocjitsu::Elf64_Shdr symtab{};
+  rocjitsu::Elf64_Shdr strtab{};
+  std::memcpy(&text, image.data() + section_offset(1), sizeof(text));
+  std::memcpy(&symtab, image.data() + section_offset(3), sizeof(symtab));
+  std::memcpy(&strtab, image.data() + section_offset(4), sizeof(strtab));
+
+  // One valid callable followed by a zero-filled linker padding word is enough
+  // to exercise the tool's post-translation host-decode padding path. The
+  // translator returns this object unchanged with NothingToTranslate.
+  constexpr std::array<uint32_t, 2> text_words = {0xbf800000u, 0};
+  write_bytes(image, text.sh_offset, text_words.data(), sizeof(text_words));
+
+  rocjitsu::Elf64_Sym callable{};
+  std::memcpy(&callable, image.data() + symtab.sh_offset + sizeof(rocjitsu::Elf64_Sym),
+              sizeof(callable));
+  constexpr std::string_view callable_name = "callable";
+  assert(callable.st_name + callable_name.size() + 1 <= strtab.sh_size);
+  write_bytes(image, strtab.sh_offset + callable.st_name, callable_name.data(),
+              callable_name.size());
+  image[strtab.sh_offset + callable.st_name + callable_name.size()] = '\0';
+  callable.st_info =
+      rocjitsu::elf_symbol_info(rocjitsu::kElfSymbolBindGlobal, rocjitsu::kElfSymbolTypeFunc);
+  callable.st_shndx = 1;
+  callable.st_value = text.sh_addr;
+  callable.st_size = sizeof(uint32_t);
+  write_bytes(image, symtab.sh_offset + sizeof(rocjitsu::Elf64_Sym), &callable, sizeof(callable));
+
+  return image;
+}
+
 std::string shell_quote(std::string_view text) {
   std::string quoted = "'";
   for (const char ch : text) {
@@ -355,6 +438,71 @@ TEST(RjDbtTranslate, Smoke) {
         << "missing expected output fragment: " << needle << "\noutput:\n"
         << stdout_text;
   }
+}
+
+TEST(RjDbtTranslate, EmptyTextSameArchWarnsAndCopiesInput) {
+  const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_empty_text_");
+  const std::filesystem::path temp_path(temp_dir.path());
+
+  const auto input = temp_path / "data_only_gfx1250.co";
+  const auto output = temp_path / "translated.co";
+  const auto error = temp_path / "stderr.txt";
+  const auto image = make_empty_text_code_object();
+
+  {
+    std::ofstream out(input, std::ios::binary);
+    out.write(reinterpret_cast<const char *>(image.data()),
+              static_cast<std::streamsize>(image.size()));
+  }
+
+  const std::string command = shell_quote(g_translate_tool.string()) + " " +
+                              shell_quote(input.string()) +
+                              " --input-target gfx1250 --input-revision b0 --output-target gfx1250 "
+                              "--output-revision a0 --output-mode code-object > " +
+                              shell_quote(output.string()) + " 2> " + shell_quote(error.string());
+
+  const int status = std::system(command.c_str());
+  const std::string output_bytes = read_text_file(output);
+  const std::string stderr_text = read_text_file(error);
+
+  ASSERT_TRUE(command_succeeded(status)) << stderr_text;
+  EXPECT_EQ(output_bytes, std::string(reinterpret_cast<const char *>(image.data()), image.size()));
+  EXPECT_TRUE(contains(stderr_text, "warning: data-only: code object has no executable sections, "
+                                    "segments, or callable symbols; leaving unchanged"))
+      << stderr_text;
+}
+
+TEST(RjDbtTranslate, DescriptorlessPaddingPassesHostDecode) {
+  const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_padding_");
+  const std::filesystem::path temp_path(temp_dir.path());
+
+  const auto input = temp_path / "descriptorless_padding_gfx1250.co";
+  const auto output = temp_path / "translated.co";
+  const auto error = temp_path / "stderr.txt";
+  const auto image = make_padded_descriptorless_code_object();
+
+  {
+    std::ofstream out(input, std::ios::binary);
+    out.write(reinterpret_cast<const char *>(image.data()),
+              static_cast<std::streamsize>(image.size()));
+  }
+
+  const std::string command = shell_quote(g_translate_tool.string()) + " " +
+                              shell_quote(input.string()) +
+                              " --input-target gfx1250 --input-revision b0 --output-target gfx1250 "
+                              "--output-revision a0 --output-mode code-object > " +
+                              shell_quote(output.string()) + " 2> " + shell_quote(error.string());
+
+  const int status = std::system(command.c_str());
+  const std::string output_bytes = read_text_file(output);
+  const std::string stderr_text = read_text_file(error);
+
+  ASSERT_TRUE(command_succeeded(status)) << stderr_text;
+  EXPECT_EQ(output_bytes, std::string(reinterpret_cast<const char *>(image.data()), image.size()));
+  EXPECT_TRUE(contains(stderr_text, "warning: nothing-to-translate: descriptorless executable "
+                                    "functions contain no instructions that require rewriting; "
+                                    "leaving unchanged"))
+      << stderr_text;
 }
 
 TEST(RjDbtTranslate, RequiresRevisionsOnlyForGfx1250) {

--- a/emulation/rocjitsu/tools/dbt_translate.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate.cpp
@@ -86,6 +86,13 @@ void record_decode_failure(CodeSectionReport &section_report, size_t byte_offset
     size_t pc = 0;
 
     while (pc < word_count) {
+      // gfx1250 linked code objects use zero-filled holes between independently
+      // aligned function bodies. Match BasicBlock::build(): zero is padding,
+      // not a decodable instruction and therefore not a host-decode failure.
+      if (arch == ROCJITSU_CODE_ARCH_GFX1250 && words[pc] == 0) {
+        ++pc;
+        continue;
+      }
       try {
         std::unique_ptr<Instruction> inst(decoder->decode(&words[pc]));
         if (!inst) {
@@ -526,7 +533,13 @@ ToolResult<TranslateOutput> translate_code_object(const TranslateOptions &option
     output.value.disassembly += translated_inspection.disassembly;
   }
 
-  if (!validate_host_decode(output.value.translated_report, error)) {
+  const bool data_only_noop =
+      has_diagnostic_kind(output.value.diagnostics, DiagnosticKind::DataOnly);
+  // A data-only object intentionally has no instructions to validate. An
+  // executable descriptorless no-op still goes through normal host decoding:
+  // NothingToTranslate means no rewrite matched, not that its bytes are exempt
+  // from structural validation.
+  if (!data_only_noop && !validate_host_decode(output.value.translated_report, error)) {
     add_error(output, kValidationError, error);
     return output;
   }

--- a/emulation/rocjitsu/tools/dbt_translate_main.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate_main.cpp
@@ -314,36 +314,6 @@ struct ReportTotals {
   return os.str();
 }
 
-[[nodiscard]] const char *diagnostic_severity_name(DiagnosticSeverity severity) {
-  switch (severity) {
-  case DiagnosticSeverity::Warning:
-    return "warning";
-  case DiagnosticSeverity::Error:
-    return "error";
-  }
-  return "diagnostic";
-}
-
-[[nodiscard]] const char *diagnostic_kind_name(DiagnosticKind kind) {
-  switch (kind) {
-  case DiagnosticKind::UnsupportedGuestArch:
-    return "unsupported-guest-arch";
-  case DiagnosticKind::KernelDescriptor:
-    return "kernel-descriptor";
-  case DiagnosticKind::Legalization:
-    return "legalization";
-  case DiagnosticKind::ExpandMissing:
-    return "expand-missing";
-  case DiagnosticKind::ExpandFailed:
-    return "expand-failed";
-  case DiagnosticKind::ResourceLimit:
-    return "resource-limit";
-  case DiagnosticKind::KernelSkipped:
-    return "kernel-skipped";
-  }
-  return "unknown";
-}
-
 void print_diagnostic(std::ostream &os, const TranslationDiagnostic &diagnostic,
                       std::string_view prefix = {}) {
   if (!prefix.empty())


### PR DESCRIPTION
## Motivation

Safely handle data-only and descriptorless executable code objects during gfx1250 B0-to-A0 translation without regressing translation time.

## Technical Details

Inspect all executable ELF content before allowing a byte-identical data-only no-op. Translate complete sized STT_FUNC ranges, including independent callables in mixed kernel objects, and relocate their symbols, RELATIVE64 addends, and unwind ranges.

Infer conservative per-function register envelopes, preserve the callable ABI without resource growth or spills, and fail closed when layout, decoding, control flow, symbols, or resources are ambiguous. Keep callable discovery and CFG dataflow scalable by separating block boundaries from external entries and using canonical ordered range lookups.

## Issue Tracking

N/A

## Test Plan

Run ctest and descriptorless HIP errata fixtures, the gfx1250 nightly corpus, and an A/B translation of the 224 MB corpus object against the pre-change parent.

## Test Result

OK. Descriptorless HIP inputs rewrote all affected instructions, nightly-corpus structural validation passed, and the large-object translation took 122.00 s versus 126.12 s at the parent with the same result.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.