### PR TITLE
[rocjitsu] Recover lane-stashed PC calls across callee-saved VGPRs

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -1789,6 +1789,25 @@ struct VectorLaneFlowState {
   return ref;
 }
 
+// Whether a physical VGPR is callee-saved under the AMDGPU device calling
+// convention (CSR_AMDGPU_VGPRs). The callee-saved VGPRs are interleaved with
+// scratch registers in stripes of eight at a stride of sixteen starting at
+// v40: v40-47, v56-63, v72-79, ... A conforming callee must preserve these
+// across a call, so a PC stashed in one survives an intervening call even
+// though the analysis does not descend into the callee body. Non-conforming
+// callee code (which clobbers a callee-saved VGPR without saving it) would
+// violate this assumption; that risk is accepted until deployment shows a
+// violation, at which point this predicate is the single seam to replace with
+// a verified-conformance analysis. See llvm AMDGPUCallingConv.td.
+//
+// @p phys_vgpr is the resolved physical index, which for gfx1250 VGPR_MSB
+// banking may exceed 255 (bank*256 + selector). The ABI table only defines the
+// convention for v0-255, so a banked register above that range is NOT proven
+// callee-saved and must fail closed rather than be masked down to its selector.
+[[nodiscard]] bool is_callee_saved_vgpr(uint16_t phys_vgpr) {
+  return phys_vgpr >= 40 && phys_vgpr <= 255 && ((phys_vgpr - 40) % 16) < 8;
+}
+
 void recover_vector_lane_stashed_pcs(AnalysisContext &ctx,
                                      std::vector<IndirectCallFixup> &recovered,
                                      std::span<const uint64_t> extra_leaders) {
@@ -1869,10 +1888,13 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx,
 
       if (facts.call_sdst) {
         // A direct call can clobber any caller-saved VGPR before its
-        // fallthrough continuation executes. The temporary CFG has no
-        // context-sensitive return edge, so no pre-call lane stash is proven
-        // to survive into either successor.
-        state.slots.clear();
+        // fallthrough continuation executes, and the temporary CFG has no
+        // context-sensitive return edge. Drop every stash in a caller-saved
+        // VGPR; a conforming callee must preserve a callee-saved VGPR, so a
+        // stash there survives (see is_callee_saved_vgpr).
+        std::erase_if(state.slots, [](const auto &item) {
+          return !is_callee_saved_vgpr(item.first.vgpr);
+        });
       }
 
       if (mnemonic == "v_writelane_b32") {
@@ -1935,9 +1957,13 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx,
       if (facts.swappc_sdst) {
         // A returning indirect call may execute arbitrary callee code before
         // the fallthrough continuation. Resolve this call from the pre-call
-        // state above, then discard every lane stash before publishing the
-        // block exit so a callee-clobbered value cannot reach the continuation.
-        state.slots.clear();
+        // state above, then drop every stash in a caller-saved VGPR before
+        // publishing the block exit so a callee-clobbered value cannot reach
+        // the continuation. A callee-saved VGPR is preserved by a conforming
+        // callee, so a stash there survives (see is_callee_saved_vgpr).
+        std::erase_if(state.slots, [](const auto &item) {
+          return !is_callee_saved_vgpr(item.first.vgpr);
+        });
       }
 
       RegisterSet vgpr_defs;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -1794,11 +1794,13 @@ struct VectorLaneFlowState {
 // scratch registers in stripes of eight at a stride of sixteen starting at
 // v40: v40-47, v56-63, v72-79, ... A conforming callee must preserve these
 // across a call, so a PC stashed in one survives an intervening call even
-// though the analysis does not descend into the callee body. Non-conforming
-// callee code (which clobbers a callee-saved VGPR without saving it) would
-// violate this assumption; that risk is accepted until deployment shows a
-// violation, at which point this predicate is the single seam to replace with
-// a verified-conformance analysis. See llvm AMDGPUCallingConv.td.
+// though the analysis does not descend into the callee body.
+//
+// TODO: Replace this calling-convention assumption with analysis that proves
+// every reachable callee preserves the stashed physical VGPR before allowing
+// the stash to survive a call. A compiler-generated callee violating the ABI is
+// highly unlikely, but hand-written or otherwise non-conforming code may still
+// do so. See the LLVM AMDGPU User Guide and AMDGPUCallingConv.td.
 //
 // @p phys_vgpr is the resolved physical index, which for gfx1250 VGPR_MSB
 // banking may exceed 255 (bank*256 + selector). The ABI table only defines the

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -1892,9 +1892,8 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx,
         // context-sensitive return edge. Drop every stash in a caller-saved
         // VGPR; a conforming callee must preserve a callee-saved VGPR, so a
         // stash there survives (see is_callee_saved_vgpr).
-        std::erase_if(state.slots, [](const auto &item) {
-          return !is_callee_saved_vgpr(item.first.vgpr);
-        });
+        std::erase_if(state.slots,
+                      [](const auto &item) { return !is_callee_saved_vgpr(item.first.vgpr); });
       }
 
       if (mnemonic == "v_writelane_b32") {
@@ -1961,9 +1960,8 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx,
         // publishing the block exit so a callee-clobbered value cannot reach
         // the continuation. A callee-saved VGPR is preserved by a conforming
         // callee, so a stash there survives (see is_callee_saved_vgpr).
-        std::erase_if(state.slots, [](const auto &item) {
-          return !is_callee_saved_vgpr(item.first.vgpr);
-        });
+        std::erase_if(state.slots,
+                      [](const auto &item) { return !is_callee_saved_vgpr(item.first.vgpr); });
       }
 
       RegisterSet vgpr_defs;

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -1272,26 +1272,30 @@ TEST(CfgAnalysis, Gfx1250CarriesLaneStashAcrossProvenBlockBoundary) {
 }
 
 TEST(CfgAnalysis, Gfx1250DirectCallKillsCarriedLaneStash) {
+  // The stash lives in v48, a CALLER-saved VGPR under CSR_AMDGPU_VGPRs, so a
+  // call is not proven to preserve it and the continuation must not recover a
+  // second call from the stale stash. (A callee-saved VGPR would survive; see
+  // Gfx1250CalleeSavedLaneStashSurvivesDirectCall.)
   constexpr uint16_t kReturnSreg = 30;
-  constexpr auto clobber = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 44});
+  constexpr auto clobber = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 48});
   std::vector<uint32_t> words = {
       0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
       0xA980FE00u, 56u,
       0u, // 0x04: s_add_nc_u64 ..., lit64(56) -> stale target 0x3c.
-      0xD761002Cu,
-      0x02010000u, // 0x10: v_writelane_b32 v44, s0, 0.
-      0xD761002Cu,
-      0x02010201u, // 0x18: v_writelane_b32 v44, s1, 1.
+      0xD7610030u,
+      0x02010000u, // 0x10: v_writelane_b32 v48, s0, 0.
+      0xD7610030u,
+      0x02010201u, // 0x18: v_writelane_b32 v48, s1, 1.
       rocjitsu::build_s_call_b64(kReturnSreg, 7, ROCJITSU_CODE_ARCH_GFX1250),
       // 0x20: direct call -> callee at 0x40.
       0xD7600000u,
-      0x0201012Cu, // 0x24: continuation reads the pre-call low half.
+      0x02010130u, // 0x24: continuation reads the pre-call low half.
       0xD7600001u,
-      0x0201032Cu,                                // 0x2c: continuation reads the high half.
+      0x02010330u,                                // 0x2c: continuation reads the high half.
       0xBE9E4900u,                                // 0x34: stale s_swap_pc_i64.
       build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x38: continuation.
       build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x3c: stale target.
-      clobber[0],                                 // 0x40: callee clobbers v44.
+      clobber[0],                                 // 0x40: callee clobbers v48.
       rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
       // 0x44: callee return.
   };
@@ -1319,33 +1323,36 @@ TEST(CfgAnalysis, Gfx1250IndirectCallKillsCarriedLaneStash) {
       gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = kCallPcSreg, .sdst = kReturnSreg});
   constexpr auto stale_call =
       gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = 0, .sdst = kStaleReturnSreg});
-  constexpr auto clobber = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 44});
+  constexpr auto clobber = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 48});
 
-  // Stash a target in v44, then issue a separately-proven indirect call whose
-  // callee clobbers v44. The current call is resolved from its pre-call state,
-  // but the continuation must not recover a second call from the stale stash.
+  // Stash a target in v48 (a CALLER-saved VGPR under CSR_AMDGPU_VGPRs), then
+  // issue a separately-proven indirect call whose callee clobbers v48. The
+  // current call is resolved from its pre-call state, but the continuation must
+  // not recover a second call from the stale stash because a caller-saved VGPR
+  // is not proven to survive the call. (A callee-saved VGPR would survive; see
+  // Gfx1250CalleeSavedLaneStashSurvivesIndirectCall.)
   std::vector<uint32_t> words = {
       stale_getpc[0], // 0x00: s_get_pc_i64 s[0:1].
       0xA980FE00u,
       72u,
       0u, // 0x04: stale target 0x04 + 72 = 0x4c.
-      0xD761002Cu,
-      0x02010000u, // 0x10: v_writelane_b32 v44, s0, 0.
-      0xD761002Cu,
-      0x02010201u, // 0x18: v_writelane_b32 v44, s1, 1.
+      0xD7610030u,
+      0x02010000u, // 0x10: v_writelane_b32 v48, s0, 0.
+      0xD7610030u,
+      0x02010201u, // 0x18: v_writelane_b32 v48, s1, 1.
       call_getpc[0],
       call_add[0],
       44u,
       0u,      // 0x24: call target 0x24 + 44 = 0x50.
       call[0], // 0x30: resolved indirect call.
       0xD7600000u,
-      0x0201012Cu, // 0x34: continuation reads the pre-call low half.
+      0x02010130u, // 0x34: continuation reads the pre-call low half.
       0xD7600001u,
-      0x0201032Cu,                                // 0x3c: reads the high half.
+      0x02010330u,                                // 0x3c: reads the high half.
       stale_call[0],                              // 0x44: stale indirect call.
       build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x48: continuation.
       build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x4c: stale target.
-      clobber[0],                                 // 0x50: callee clobbers v44.
+      clobber[0],                                 // 0x50: callee clobbers v48.
       rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
       // 0x54: callee return.
   };
@@ -1367,6 +1374,68 @@ TEST(CfgAnalysis, Gfx1250IndirectCallKillsCarriedLaneStash) {
   ASSERT_EQ(total_fixups, 1u);
   ASSERT_NE(call_fixup, nullptr);
   EXPECT_EQ(call_fixup->source_target_offset, 80u);
+}
+
+TEST(CfgAnalysis, Gfx1250CalleeSavedLaneStashSurvivesIndirectCall) {
+  // Same shape as Gfx1250IndirectCallKillsCarriedLaneStash, but the stash lives
+  // in v44 (CALLEE-saved under CSR_AMDGPU_VGPRs). A conforming callee must
+  // preserve it, so the continuation swappc IS recovered from the stash. This
+  // is the RCCL ncclDevKernel pattern: a getpc code target stashed in a
+  // callee-saved VGPR, carried across an intervening call, then read back and
+  // called.
+  constexpr uint16_t kCallPcSreg = 8;
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr uint16_t kStaleReturnSreg = 28;
+  constexpr auto stale_getpc = gfx1250::build_sop1(gfx1250::kSGetPcI64Sop1, {.sdst = 0});
+  constexpr auto call_getpc = gfx1250::build_sop1(gfx1250::kSGetPcI64Sop1, {.sdst = kCallPcSreg});
+  constexpr auto call_add = gfx1250::build_sop2(
+      gfx1250::kSAddNcU64Sop2, {.ssrc0 = kCallPcSreg, .ssrc1 = 254, .sdst = kCallPcSreg});
+  constexpr auto call =
+      gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = kCallPcSreg, .sdst = kReturnSreg});
+  constexpr auto stale_call =
+      gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = 0, .sdst = kStaleReturnSreg});
+  constexpr auto clobber = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 44});
+
+  std::vector<uint32_t> words = {
+      stale_getpc[0], // 0x00: s_get_pc_i64 s[0:1].
+      0xA980FE00u,
+      72u,
+      0u, // 0x04: stashed target 0x04 + 72 = 0x4c.
+      0xD761002Cu,
+      0x02010000u, // 0x10: v_writelane_b32 v44, s0, 0.
+      0xD761002Cu,
+      0x02010201u, // 0x18: v_writelane_b32 v44, s1, 1.
+      call_getpc[0],
+      call_add[0],
+      44u,
+      0u,      // 0x24: call target 0x24 + 44 = 0x50.
+      call[0], // 0x30: resolved intervening indirect call.
+      0xD7600000u,
+      0x0201012Cu, // 0x34: continuation reads the surviving low half.
+      0xD7600001u,
+      0x0201032Cu,                                // 0x3c: reads the high half.
+      stale_call[0],                              // 0x44: continuation indirect call.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x48: continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x4c: stashed target.
+      clobber[0],                                 // 0x50: callee body (v44 preserved by ABI).
+      rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x54: callee return.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  const IndirectCallFixup *continuation_fixup = nullptr;
+  for (const auto &block : blocks) {
+    for (const auto &fixup : block->static_indirect_call_fixups()) {
+      if (fixup.source_call_offset == 68) // 0x44: the continuation swappc.
+        continuation_fixup = &fixup;
+    }
+  }
+  ASSERT_NE(continuation_fixup, nullptr);
+  EXPECT_EQ(continuation_fixup->source_target_offset, 76u); // 0x4c: the stashed target.
 }
 
 TEST(CfgAnalysis, Gfx1250SeedsTextEntryWithLoopBackedgeForLaneStash) {

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -1311,6 +1311,96 @@ TEST(CfgAnalysis, Gfx1250DirectCallKillsCarriedLaneStash) {
   EXPECT_EQ(total_fixups, 0u);
 }
 
+TEST(CfgAnalysis, Gfx1250CalleeSavedLaneStashSurvivesDirectCall) {
+  // Same shape as Gfx1250DirectCallKillsCarriedLaneStash, but the stash lives
+  // in v44 (CALLEE-saved under CSR_AMDGPU_VGPRs). The synthetic callee writes
+  // only caller-saved v48, so the continuation must recover the call target
+  // from the surviving v44 stash.
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr auto clobber = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 48});
+  std::vector<uint32_t> words = {
+      0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+      0xA980FE00u, 56u,
+      0u, // 0x04: s_add_nc_u64 ..., lit64(56) -> stashed target 0x3c.
+      0xD761002Cu,
+      0x02010000u, // 0x10: v_writelane_b32 v44, s0, 0.
+      0xD761002Cu,
+      0x02010201u, // 0x18: v_writelane_b32 v44, s1, 1.
+      rocjitsu::build_s_call_b64(kReturnSreg, 7, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x20: direct call -> callee at 0x40.
+      0xD7600000u,
+      0x0201012Cu, // 0x24: continuation reads the surviving low half.
+      0xD7600001u,
+      0x0201032Cu,                                // 0x2c: reads the high half.
+      0xBE9E4900u,                                // 0x34: recovered s_swap_pc_i64.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x38: continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x3c: stashed target.
+      clobber[0],                                 // 0x40: callee clobbers caller-saved v48.
+      rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x44: callee return.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  const IndirectCallFixup *continuation_fixup = nullptr;
+  for (const auto &block : blocks) {
+    for (const auto &fixup : block->static_indirect_call_fixups()) {
+      if (fixup.source_call_offset == 52) // 0x34: the continuation swappc.
+        continuation_fixup = &fixup;
+    }
+  }
+  ASSERT_NE(continuation_fixup, nullptr);
+  EXPECT_EQ(continuation_fixup->source_target_offset, 60u); // 0x3c: the stashed target.
+}
+
+TEST(CfgAnalysis, Gfx1250BankedLaneStashDoesNotSurviveDirectCall) {
+  // Select bank 1 for both DST and SRC0, so the v44 operands below consistently
+  // address physical v300. Although low selector v44 is callee-saved, the ABI
+  // table does not prove physical VGPRs above v255 are preserved. The call must
+  // therefore discard the stash rather than mask v300 down to v44.
+  //
+  // s_set_vgpr_msb immediate byte is {DST[7:6], SRC2[5:4], SRC1[3:2], SRC0[1:0]};
+  // 0x41 selects bank 1 for DST and SRC0.
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr auto set_dst_src0_bank_one =
+      gfx1250::build_sopp(gfx1250::kSSetVgprMsbSopp, {.simm16 = 0x41});
+  std::vector<uint32_t> words = {
+      0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+      0xA980FE00u, 60u,
+      0u,                       // 0x04: s_add_nc_u64 ..., lit64(60) -> stale target 0x40.
+      set_dst_src0_bank_one[0], // 0x10: v44 DST/SRC0 operands resolve to physical v300.
+      0xD761002Cu,
+      0x02010000u, // 0x14: v_writelane_b32 physical v300, s0, 0.
+      0xD761002Cu,
+      0x02010201u, // 0x1c: v_writelane_b32 physical v300, s1, 1.
+      rocjitsu::build_s_call_b64(kReturnSreg, 7, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x24: direct call -> callee at 0x44.
+      0xD7600000u,
+      0x0201012Cu, // 0x28: continuation reads physical v300 lane 0.
+      0xD7600001u,
+      0x0201032Cu,                                // 0x30: reads physical v300 lane 1.
+      0xBE9E4900u,                                // 0x38: must remain dynamic.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x3c: continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x40: stale target.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250), // 0x44: conforming callee body.
+      rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x48: callee return.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  size_t total_fixups = 0;
+  for (const auto &block : blocks)
+    total_fixups += block->static_indirect_call_fixups().size();
+  EXPECT_EQ(total_fixups, 0u);
+}
+
 TEST(CfgAnalysis, Gfx1250IndirectCallKillsCarriedLaneStash) {
   constexpr uint16_t kCallPcSreg = 8;
   constexpr uint16_t kReturnSreg = 30;
@@ -1394,7 +1484,7 @@ TEST(CfgAnalysis, Gfx1250CalleeSavedLaneStashSurvivesIndirectCall) {
       gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = kCallPcSreg, .sdst = kReturnSreg});
   constexpr auto stale_call =
       gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = 0, .sdst = kStaleReturnSreg});
-  constexpr auto clobber = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 44});
+  constexpr auto clobber = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 48});
 
   std::vector<uint32_t> words = {
       stale_getpc[0], // 0x00: s_get_pc_i64 s[0:1].
@@ -1417,7 +1507,7 @@ TEST(CfgAnalysis, Gfx1250CalleeSavedLaneStashSurvivesIndirectCall) {
       stale_call[0],                              // 0x44: continuation indirect call.
       build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x48: continuation.
       build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x4c: stashed target.
-      clobber[0],                                 // 0x50: callee body (v44 preserved by ABI).
+      clobber[0],                                 // 0x50: callee clobbers caller-saved v48.
       rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
       // 0x54: callee return.
   };


### PR DESCRIPTION
The vector-lane PC-stash recovery pass cleared every stashed getpc target at an intervening call, so an s_swap_pc_i64 whose target is stashed in a VGPR across a call was never recovered and the kernel failed closed with "indirect branch or call target recovery is not implemented". This is the RCCL ncclDevKernel_Generic pattern: a getpc code address is written to a fixed lane of a callee-saved VGPR, carried across a call, read back into an SGPR pair, and called.

Preserve a lane stash across a call when its physical VGPR is callee-saved under the AMDGPU calling convention (CSR_AMDGPU_VGPRs: v40-47, v56-63, v72-79, ...). A conforming callee must preserve those registers, so the stashed target is valid at the readback even though the analysis does not descend into the callee body. Stashes in caller-saved VGPRs are still cleared. The must-reaching-def CFG meet is unchanged, so a stash that is multi-valued across paths (e.g. a branch diamond) is still dropped and only single-target getpc values are recovered.

The predicate takes the resolved physical VGPR index; a gfx1250 VGPR_MSB banked register above v255 is not covered by the ABI table and fails closed rather than being masked to its selector.

This trusts the calling convention: non-conforming callee code that clobbers a callee-saved VGPR without saving it would violate the assumption. The is_callee_saved_vgpr predicate is the single seam to replace with a verified-conformance analysis if a violation is found in deployment.

The two RCCL kernels in the gfx1250 B0-to-A0 hotswap corpus now translate (corpus failures 14 -> 12; no other kernel affected). Existing lane-stash kill tests move their stash to a caller-saved VGPR to keep asserting the kill behavior, and a new test covers the callee-saved survive case.