### PR TITLE
[rocjitsu] Add offline translation idempotence verification

### DIFF
--- a/emulation/rocjitsu/docs/rj_dbt_translate.md
+++ b/emulation/rocjitsu/docs/rj_dbt_translate.md
@@ -39,11 +39,15 @@ Options:
 - `--debug-continue-after-failure`: keep scanning instructions after recoverable
   translation failures so one run can report multiple diagnostics. The output
   code object is still left unchanged when any error diagnostic is emitted.
-- `--verify-idempotence`: when the input and output use the same architecture
-  family, translate the first output again with the same policy and require the
-  complete ELF bytes to stay unchanged. A second-pass failure or byte difference
-  makes the command fail. This option cannot be combined with
-  `--skip-failed-kernels`.
+- `--skip-failed-kernels`: replace kernels that fail translation with
+  non-dispatchable `s_endpgm` stubs so diagnostic modes can continue inspecting
+  other kernels. Executable code-object output is rejected when any kernel was
+  skipped.
+- `--verify-idempotence`: translate the first output again with the same policy
+  and require the complete ELF bytes to stay unchanged. The command rejects
+  requests whose input and output architecture families differ. A second-pass
+  failure or byte difference makes the command fail. This option cannot be
+  combined with `--skip-failed-kernels` or `--list-code-objects`.
 - `--list-code-objects`: list extractable code objects and exit.
 - `--help`: print command-line help.
 
@@ -80,6 +84,10 @@ translation request, and compares the first and second outputs byte-for-byte
 before writing stdout. On a mismatch, stderr identifies the first differing
 executable code-section location when possible, falling back to the complete
 ELF image.
+
+Verification roughly doubles translation work. While comparing the result it
+also retains both translated byte buffers and their parsed code-object copies,
+so peak memory can approach four copies of a large code object.
 
 This is deliberately stricter than checking whether the second pass applies
 another instruction legalization. Relocation, branch layout, symbol sizes, and

--- a/emulation/rocjitsu/docs/rj_dbt_translate.md
+++ b/emulation/rocjitsu/docs/rj_dbt_translate.md
@@ -23,6 +23,9 @@ Required arguments:
 
 Options:
 
+- `--input-revision REVISION` and `--output-revision REVISION`: silicon
+  revisions (`a0` or `b0`). Both are required for `gfx1250`; other targets do
+  not accept them.
 - `--code-object-index N`: code-object index for executable inputs. Defaults to
   `0`.
 - `--output-mode MODE`: output format. `disasm` prints translated
@@ -36,10 +39,16 @@ Options:
 - `--debug-continue-after-failure`: keep scanning instructions after recoverable
   translation failures so one run can report multiple diagnostics. The output
   code object is still left unchanged when any error diagnostic is emitted.
+- `--verify-idempotence`: when the input and output use the same architecture
+  family, translate the first output again with the same policy and require the
+  complete ELF bytes to stay unchanged. A second-pass failure or byte difference
+  makes the command fail. This option cannot be combined with
+  `--skip-failed-kernels`.
 - `--list-code-objects`: list extractable code objects and exit.
 - `--help`: print command-line help.
 
-Supported target names are `gfx942`, `gfx950`, `gfx1200`, and `gfx1201`.
+Supported target names are `gfx942`, `gfx950`, `gfx1200`, `gfx1201`, and
+`gfx1250`.
 
 ## Output
 
@@ -53,6 +62,31 @@ rj_dbt_translate vector_add.o --input-target gfx950 --output-target gfx1200 \
 
 Structured translation diagnostics and validation errors are written to stderr.
 Error diagnostics make the command fail.
+
+## Idempotence Verification
+
+Use `--verify-idempotence` to test whether an offline translation is a strict
+byte-level fixed point. For example, to test the gfx1250 B0-to-A0 path:
+
+```sh
+rj_dbt_translate input.gfx1250.co \
+  --input-target gfx1250 --input-revision b0 \
+  --output-target gfx1250 --output-revision a0 \
+  --verify-idempotence --output-mode code-object > output.gfx1250-a0.co
+```
+
+The verifier keeps the first translated ELF in memory, submits it to the same
+translation request, and compares the first and second outputs byte-for-byte
+before writing stdout. On a mismatch, stderr identifies the first differing
+executable code-section location when possible, falling back to the complete
+ELF image.
+
+This is deliberately stricter than checking whether the second pass applies
+another instruction legalization. Relocation, branch layout, symbol sizes, and
+other ELF materialization are part of the result, so changes in any of them make
+verification fail. A failure does not by itself mean that the first output is
+invalid; it means the translation is not a byte-level fixed point. This mode is
+intended to expose such instability while developing or auditing the translator.
 
 ## Diff Mode
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -757,7 +757,10 @@ target_include_directories(
         ${CMAKE_SOURCE_DIR}/lib/rocjitsu/include
         ${CMAKE_SOURCE_DIR}/lib/rocjitsu/src
 )
-target_link_libraries(rj_dbt_translate_smoke_test PRIVATE GTest::gtest)
+target_link_libraries(
+    rj_dbt_translate_smoke_test
+    PRIVATE rocjitsu_tooling GTest::gtest
+)
 rj_configure_target(rj_dbt_translate_smoke_test TEST)
 add_dependencies(rj_dbt_translate_smoke_test rj_dbt_translate)
 if(RJ_INSTALL_TESTS)

--- a/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
@@ -4,6 +4,7 @@
 /// @file rj_dbt_translate_smoke_test.cpp
 /// @brief End-to-end smoke test for the rj_dbt_translate command-line tool.
 
+#include "dbt_translate.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/rj_code.h"
 #include "scoped_temp.h"
@@ -226,6 +227,96 @@ bool command_exited_with(int status, int exit_code) {
 
 } // namespace
 
+TEST(RjDbtTranslateIdempotence, DescribesChangedByteAndSize) {
+  constexpr std::array<uint8_t, 2> first = {0x10, 0x20};
+  constexpr std::array<uint8_t, 3> second = {0x10, 0x21, 0x22};
+
+  EXPECT_EQ(rocjitsu::tools::detail::describe_byte_difference(first, second, "section '.text'"),
+            "section '.text' first differs at 0x1 (first=0x20, second=0x21); size 2 -> 3 bytes");
+}
+
+TEST(RjDbtTranslateIdempotence, DescribesPureSizeChange) {
+  constexpr std::array<uint8_t, 2> first = {0x10, 0x20};
+  constexpr std::array<uint8_t, 3> second = {0x10, 0x20, 0x30};
+
+  EXPECT_EQ(rocjitsu::tools::detail::describe_byte_difference(first, second, "ELF image"),
+            "ELF image size changed from 2 to 3 bytes");
+}
+
+TEST(RjDbtTranslateIdempotence, LocalizesExecutableSectionDifference) {
+  using rocjitsu::tools::detail::ExecutableSectionBytes;
+
+  constexpr std::array<uint8_t, 2> first_text = {0x10, 0x20};
+  constexpr std::array<uint8_t, 2> second_text = {0x10, 0x21};
+  constexpr std::array<uint8_t, 2> first_elf = {0x01, 0x02};
+  constexpr std::array<uint8_t, 2> second_elf = {0x01, 0x03};
+  const std::array first_sections = {ExecutableSectionBytes{".text", first_text}};
+  const std::array second_sections = {ExecutableSectionBytes{".text", second_text}};
+
+  EXPECT_EQ(rocjitsu::tools::detail::find_idempotence_difference(first_sections, second_sections,
+                                                                 first_elf, second_elf),
+            "section '.text' first differs at 0x1 (first=0x20, second=0x21)");
+}
+
+TEST(RjDbtTranslateIdempotence, FallsBackToWholeElfDifference) {
+  using rocjitsu::tools::detail::ExecutableSectionBytes;
+
+  constexpr std::array<uint8_t, 2> text = {0x10, 0x20};
+  constexpr std::array<uint8_t, 2> first_elf = {0x01, 0x02};
+  constexpr std::array<uint8_t, 2> second_elf = {0x01, 0x03};
+  const std::array first_sections = {ExecutableSectionBytes{".text", text}};
+  const std::array second_sections = {ExecutableSectionBytes{".text", text}};
+
+  EXPECT_EQ(rocjitsu::tools::detail::find_idempotence_difference(first_sections, second_sections,
+                                                                 first_elf, second_elf),
+            "ELF image first differs at 0x1 (first=0x02, second=0x03)");
+}
+
+TEST(RjDbtTranslateIdempotence, ReportsExecutableSectionSetAndOrderChanges) {
+  using rocjitsu::tools::detail::ExecutableSectionBytes;
+
+  constexpr std::array<uint8_t, 1> bytes = {0x10};
+  constexpr std::array<uint8_t, 1> first_elf = {0x01};
+  constexpr std::array<uint8_t, 1> second_elf = {0x02};
+  const std::array first_sections = {
+      ExecutableSectionBytes{".text", bytes},
+      ExecutableSectionBytes{".init", bytes},
+  };
+  const std::array renamed_sections = {
+      ExecutableSectionBytes{".text", bytes},
+      ExecutableSectionBytes{".fini", bytes},
+  };
+  const std::array reordered_sections = {
+      ExecutableSectionBytes{".init", bytes},
+      ExecutableSectionBytes{".text", bytes},
+  };
+  const std::array added_sections = {
+      ExecutableSectionBytes{".text", bytes},
+      ExecutableSectionBytes{".init", bytes},
+      ExecutableSectionBytes{".fini", bytes},
+  };
+
+  EXPECT_EQ(rocjitsu::tools::detail::find_idempotence_difference(first_sections, renamed_sections,
+                                                                 first_elf, second_elf),
+            "executable sections changed: removed '.init', added '.fini'");
+  EXPECT_EQ(rocjitsu::tools::detail::find_idempotence_difference(first_sections, reordered_sections,
+                                                                 first_elf, second_elf),
+            "executable sections were reordered at index 0: first='.text', second='.init'");
+  EXPECT_EQ(rocjitsu::tools::detail::find_idempotence_difference(first_sections, added_sections,
+                                                                 first_elf, second_elf),
+            "executable section '.fini' was added");
+}
+
+TEST(RjDbtTranslateIdempotence, VerificationDiagnosticsDoNotInvalidateFirstPassOutput) {
+  rocjitsu::tools::TranslateOutput output;
+  rocjitsu::TranslationDiagnostic diagnostic;
+  diagnostic.severity = rocjitsu::DiagnosticSeverity::Error;
+  output.idempotence_diagnostics.push_back(std::move(diagnostic));
+
+  EXPECT_TRUE(output.ok());
+  EXPECT_TRUE(output.dispatchable());
+}
+
 TEST(RjDbtTranslate, Smoke) {
   const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_smoke_");
   const std::filesystem::path temp_path(temp_dir.path());
@@ -355,18 +446,95 @@ TEST(RjDbtTranslate, VerifiesGfx1250B0ToA0Idempotence) {
                                          << stdout_text;
   EXPECT_TRUE(stderr_text.empty()) << stderr_text;
   EXPECT_TRUE(contains(stdout_text, "idempotence: verified")) << stdout_text;
+  EXPECT_TRUE(contains(stdout_text, "idempotence_diagnostics: 0")) << stdout_text;
   EXPECT_TRUE(contains(stdout_text, "changed=1")) << stdout_text;
   EXPECT_TRUE(contains(stdout_text, "source: s_clause 4")) << stdout_text;
   EXPECT_TRUE(contains(stdout_text, "target: s_nop 0")) << stdout_text;
 }
 
-TEST(RjDbtTranslate, ReportsGfx1250ClusterLoadRewrapAsNonIdempotent) {
+TEST(RjDbtTranslate, VerifiesNonGfx1250SameArchitectureTranslation) {
+  const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_non_gfx_idempotence_");
+  const std::filesystem::path temp_path(temp_dir.path());
+  const std::filesystem::path input = temp_path / "smoke_gfx950.co";
+  const std::filesystem::path output = temp_path / "stdout.txt";
+  const std::filesystem::path error = temp_path / "stderr.txt";
+
+  {
+    const std::vector<uint8_t> image = make_smoke_code_object();
+    std::ofstream out(input, std::ios::binary);
+    out.write(reinterpret_cast<const char *>(image.data()),
+              static_cast<std::streamsize>(image.size()));
+  }
+
+  const std::string command =
+      shell_quote(g_translate_tool.string()) + " " + shell_quote(input.string()) +
+      " --input-target gfx950 --output-target gfx950 --verify-idempotence --output-mode diff > " +
+      shell_quote(output.string()) + " 2> " + shell_quote(error.string());
+
+  const int status = std::system(command.c_str());
+  const std::string stdout_text = read_text_file(output);
+  const std::string stderr_text = read_text_file(error);
+
+  ASSERT_TRUE(command_succeeded(status)) << "stderr:\n"
+                                         << stderr_text << "\nstdout:\n"
+                                         << stdout_text;
+  EXPECT_TRUE(stderr_text.empty()) << stderr_text;
+  EXPECT_TRUE(contains(stdout_text, "idempotence: verified")) << stdout_text;
+}
+
+TEST(RjDbtTranslate, RejectsInvalidIdempotenceOptionCombinations) {
+  const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_idempotence_options_");
+  const std::filesystem::path temp_path(temp_dir.path());
+  const std::filesystem::path input = temp_path / "smoke_gfx950.co";
+  const std::filesystem::path output = temp_path / "stdout.txt";
+  const std::filesystem::path error = temp_path / "stderr.txt";
+
+  {
+    const std::vector<uint8_t> image = make_smoke_code_object();
+    std::ofstream out(input, std::ios::binary);
+    out.write(reinterpret_cast<const char *>(image.data()),
+              static_cast<std::streamsize>(image.size()));
+  }
+
+  const std::string different_arch_command =
+      shell_quote(g_translate_tool.string()) + " " + shell_quote(input.string()) +
+      " --input-target gfx950 --output-target gfx1200 --verify-idempotence > " +
+      shell_quote(output.string()) + " 2> " + shell_quote(error.string());
+  int status = std::system(different_arch_command.c_str());
+  EXPECT_TRUE(command_exited_with(status, 1));
+  EXPECT_TRUE(contains(read_text_file(error),
+                       "--verify-idempotence requires matching input and output architectures"));
+
+  const std::string skip_failed_command =
+      shell_quote(g_translate_tool.string()) + " " + shell_quote(input.string()) +
+      " --input-target gfx950 --output-target gfx950 --verify-idempotence "
+      "--skip-failed-kernels > " +
+      shell_quote(output.string()) + " 2> " + shell_quote(error.string());
+  status = std::system(skip_failed_command.c_str());
+  EXPECT_TRUE(command_exited_with(status, 1));
+  EXPECT_TRUE(contains(read_text_file(error),
+                       "--verify-idempotence cannot be combined with --skip-failed-kernels"));
+
+  const std::string list_command =
+      shell_quote(g_translate_tool.string()) + " " + shell_quote(input.string()) +
+      " --list-code-objects --verify-idempotence > " + shell_quote(output.string()) + " 2> " +
+      shell_quote(error.string());
+  status = std::system(list_command.c_str());
+  EXPECT_TRUE(command_exited_with(status, 1));
+  EXPECT_TRUE(contains(read_text_file(error),
+                       "--verify-idempotence cannot be combined with --list-code-objects"));
+}
+
+TEST(RjDbtTranslate, CharacterizesGfx1250ClusterLoadRewrapAsNonIdempotent) {
   const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_non_idempotent_");
   const std::filesystem::path temp_path(temp_dir.path());
   const std::filesystem::path input = temp_path / "cluster_load_gfx1250.co";
   const std::filesystem::path output = temp_path / "stdout.txt";
   const std::filesystem::path error = temp_path / "stderr.txt";
 
+  // TODO(PR #9272 follow-up): Remove this characterization once cluster-load
+  // expansion recognizes its own M0 save/restore wrapper. The permanent
+  // mismatch-reporting coverage lives in the RjDbtTranslateIdempotence tests.
   // The cluster load is followed by s_endpgm. Its expansion preserves the load
   // inside an M0 save/restore wrapper, so each pass wraps it again.
   constexpr std::array<uint32_t, 4> text_words = {0xee19c07cu, 0x00000001u, 0x00000002u,
@@ -392,6 +560,7 @@ TEST(RjDbtTranslate, ReportsGfx1250ClusterLoadRewrapAsNonIdempotent) {
                                               << stderr_text << "\nstdout:\n"
                                               << stdout_text;
   EXPECT_TRUE(contains(stdout_text, "idempotence: not-verified")) << stdout_text;
+  EXPECT_TRUE(contains(stdout_text, "idempotence_diagnostics: 0")) << stdout_text;
   EXPECT_TRUE(contains(stderr_text, "translation output is not byte-idempotent")) << stderr_text;
   EXPECT_TRUE(contains(stderr_text, "section '.text'")) << stderr_text;
 }

--- a/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <span>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -55,12 +56,13 @@ template <typename T> void write_value(std::vector<uint8_t> &image, uint64_t off
   write_bytes(image, offset, &value, sizeof(value));
 }
 
-std::vector<uint8_t> make_smoke_code_object() {
+std::vector<uint8_t> make_smoke_code_object(uint32_t elf_mach,
+                                            std::span<const uint32_t> text_words) {
   using namespace rocjitsu;
 
   constexpr uint64_t text_offset = 0x100;
   constexpr uint64_t text_vaddr = 0x1100;
-  constexpr uint64_t text_size = 8;
+  const uint64_t text_size = text_words.size_bytes();
   constexpr uint64_t load_align = 0x1000;
   constexpr uint64_t kernel_descriptor_size = 64;
 
@@ -97,7 +99,7 @@ std::vector<uint8_t> make_smoke_code_object() {
   write_value<uint32_t>(image, offsetof(Elf64_Ehdr, e_version), 1);
   write_value<uint64_t>(image, offsetof(Elf64_Ehdr, e_phoff), sizeof(Elf64_Ehdr));
   write_value<uint64_t>(image, offsetof(Elf64_Ehdr, e_shoff), shoff);
-  write_value<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags), EF_AMDGPU_MACH_AMDGCN_GFX950);
+  write_value<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags), elf_mach);
   write_value<uint16_t>(image, offsetof(Elf64_Ehdr, e_ehsize), sizeof(Elf64_Ehdr));
   write_value<uint16_t>(image, offsetof(Elf64_Ehdr, e_phentsize), sizeof(Elf64_Phdr));
   write_value<uint16_t>(image, offsetof(Elf64_Ehdr, e_phnum), phdr_count);
@@ -125,9 +127,6 @@ std::vector<uint8_t> make_smoke_code_object() {
   write_value<uint64_t>(image, phdr1 + offsetof(Elf64_Phdr, p_memsz), kernel_descriptor_size);
   write_value<uint64_t>(image, phdr1 + offsetof(Elf64_Phdr, p_align), load_align);
 
-  // Use a CDNA4 waitcnt that lowers to split RDNA4 wait instructions so the
-  // diff report is guaranteed to contain a shown source/target pair.
-  const std::array<uint32_t, 2> text_words = {0xbf8cc07fu, 0xbf810000u};
   std::memcpy(image.data() + text_offset, text_words.data(), text_size);
 
   // The DBT pipeline translates kernel entry offsets through AMDHSA kernel
@@ -176,6 +175,24 @@ std::vector<uint8_t> make_smoke_code_object() {
   write_shdr(4, strtab_name, SHT_STRTAB, 0, 0, strtab_offset, strtab.size(), 0, 0, 1, 0);
   write_shdr(5, shstrtab_name, SHT_STRTAB, 0, 0, shstrtab_offset, shstrtab.size(), 0, 0, 1, 0);
   return image;
+}
+
+std::vector<uint8_t> make_smoke_code_object() {
+  // Use a CDNA4 waitcnt that lowers to split RDNA4 wait instructions so the
+  // diff report is guaranteed to contain a shown source/target pair.
+  constexpr std::array<uint32_t, 2> text_words = {0xbf8cc07fu, 0xbf810000u};
+  return make_smoke_code_object(rocjitsu::EF_AMDGPU_MACH_AMDGCN_GFX950, text_words);
+}
+
+std::vector<uint8_t> make_gfx1250_smoke_code_object(std::span<const uint32_t> text_words) {
+  return make_smoke_code_object(rocjitsu::EF_AMDGPU_MACH_AMDGCN_GFX1250, text_words);
+}
+
+std::vector<uint8_t> make_gfx1250_smoke_code_object() {
+  // B0-to-A0 replaces s_clause with s_nop, giving the first pass real work while
+  // leaving the translated instruction stable on the verification pass.
+  constexpr std::array<uint32_t, 2> text_words = {0xbf850004u, 0xbfb00000u};
+  return make_gfx1250_smoke_code_object(text_words);
 }
 
 std::string shell_quote(std::string_view text) {
@@ -307,6 +324,76 @@ TEST(RjDbtTranslate, RequiresRevisionsOnlyForGfx1250) {
   status = std::system(reverse_revision_command.c_str());
   EXPECT_TRUE(command_exited_with(status, 1));
   EXPECT_TRUE(contains(read_text_file(error), "gfx1250 A0-to-B0 translation is not supported"));
+}
+
+TEST(RjDbtTranslate, VerifiesGfx1250B0ToA0Idempotence) {
+  const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_idempotence_");
+  const std::filesystem::path temp_path(temp_dir.path());
+  const std::filesystem::path input = temp_path / "smoke_gfx1250.co";
+  const std::filesystem::path output = temp_path / "stdout.txt";
+  const std::filesystem::path error = temp_path / "stderr.txt";
+
+  {
+    const std::vector<uint8_t> image = make_gfx1250_smoke_code_object();
+    std::ofstream out(input, std::ios::binary);
+    out.write(reinterpret_cast<const char *>(image.data()),
+              static_cast<std::streamsize>(image.size()));
+  }
+
+  const std::string command = shell_quote(g_translate_tool.string()) + " " +
+                              shell_quote(input.string()) +
+                              " --input-target gfx1250 --input-revision b0 --output-target gfx1250 "
+                              "--output-revision a0 --verify-idempotence --output-mode diff > " +
+                              shell_quote(output.string()) + " 2> " + shell_quote(error.string());
+
+  const int status = std::system(command.c_str());
+  const std::string stdout_text = read_text_file(output);
+  const std::string stderr_text = read_text_file(error);
+
+  ASSERT_TRUE(command_succeeded(status)) << "stderr:\n"
+                                         << stderr_text << "\nstdout:\n"
+                                         << stdout_text;
+  EXPECT_TRUE(stderr_text.empty()) << stderr_text;
+  EXPECT_TRUE(contains(stdout_text, "idempotence: verified")) << stdout_text;
+  EXPECT_TRUE(contains(stdout_text, "changed=1")) << stdout_text;
+  EXPECT_TRUE(contains(stdout_text, "source: s_clause 4")) << stdout_text;
+  EXPECT_TRUE(contains(stdout_text, "target: s_nop 0")) << stdout_text;
+}
+
+TEST(RjDbtTranslate, ReportsGfx1250ClusterLoadRewrapAsNonIdempotent) {
+  const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_non_idempotent_");
+  const std::filesystem::path temp_path(temp_dir.path());
+  const std::filesystem::path input = temp_path / "cluster_load_gfx1250.co";
+  const std::filesystem::path output = temp_path / "stdout.txt";
+  const std::filesystem::path error = temp_path / "stderr.txt";
+
+  // The cluster load is followed by s_endpgm. Its expansion preserves the load
+  // inside an M0 save/restore wrapper, so each pass wraps it again.
+  constexpr std::array<uint32_t, 4> text_words = {0xee19c07cu, 0x00000001u, 0x00000002u,
+                                                  0xbfb00000u};
+  {
+    const std::vector<uint8_t> image = make_gfx1250_smoke_code_object(text_words);
+    std::ofstream out(input, std::ios::binary);
+    out.write(reinterpret_cast<const char *>(image.data()),
+              static_cast<std::streamsize>(image.size()));
+  }
+
+  const std::string command = shell_quote(g_translate_tool.string()) + " " +
+                              shell_quote(input.string()) +
+                              " --input-target gfx1250 --input-revision b0 --output-target gfx1250 "
+                              "--output-revision a0 --verify-idempotence --output-mode diff > " +
+                              shell_quote(output.string()) + " 2> " + shell_quote(error.string());
+
+  const int status = std::system(command.c_str());
+  const std::string stdout_text = read_text_file(output);
+  const std::string stderr_text = read_text_file(error);
+
+  EXPECT_TRUE(command_exited_with(status, 5)) << "stderr:\n"
+                                              << stderr_text << "\nstdout:\n"
+                                              << stdout_text;
+  EXPECT_TRUE(contains(stdout_text, "idempotence: not-verified")) << stdout_text;
+  EXPECT_TRUE(contains(stderr_text, "translation output is not byte-idempotent")) << stderr_text;
+  EXPECT_TRUE(contains(stderr_text, "section '.text'")) << stderr_text;
 }
 
 int main(int argc, char **argv) {

--- a/emulation/rocjitsu/tools/dbt_translate.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate.cpp
@@ -11,7 +11,9 @@
 #include "rocjitsu/isa/instruction.h"
 
 #include <algorithm>
+#include <cassert>
 #include <exception>
+#include <format>
 #include <iomanip>
 #include <memory>
 #include <span>
@@ -182,34 +184,97 @@ make_binary_translator_options(const TranslateOptions &options) {
   return translator_options;
 }
 
-[[nodiscard]] std::string describe_byte_difference(std::span<const uint8_t> first,
-                                                   std::span<const uint8_t> second,
-                                                   std::string_view location) {
+} // namespace
+
+namespace detail {
+
+std::string describe_byte_difference(std::span<const uint8_t> first,
+                                     std::span<const uint8_t> second, std::string_view location) {
+  assert(!std::ranges::equal(first, second));
+
   const size_t common_size = std::min(first.size(), second.size());
   size_t offset = 0;
   while (offset < common_size && first[offset] == second[offset])
     ++offset;
 
   if (offset < common_size) {
-    std::ostringstream os;
-    os << location << " first differs at " << format_offset(offset) << " (first=0x" << std::hex
-       << std::setw(2) << std::setfill('0') << static_cast<unsigned>(first[offset]) << ", second=0x"
-       << std::setw(2) << static_cast<unsigned>(second[offset]) << ")" << std::dec;
-    if (first.size() != second.size())
-      os << "; size " << first.size() << " -> " << second.size() << " bytes";
-    return os.str();
+    const std::string size_change =
+        first.size() == second.size()
+            ? ""
+            : std::format("; size {} -> {} bytes", first.size(), second.size());
+    return std::format("{} first differs at 0x{:x} (first=0x{:02x}, second=0x{:02x}){}", location,
+                       offset, static_cast<unsigned>(first[offset]),
+                       static_cast<unsigned>(second[offset]), size_change);
   }
 
-  return std::string(location) + " size changed from " + std::to_string(first.size()) + " to " +
-         std::to_string(second.size()) + " bytes";
+  return std::format("{} size changed from {} to {} bytes", location, first.size(), second.size());
 }
 
-[[nodiscard]] std::vector<const Section *>
+std::string find_idempotence_difference(std::span<const ExecutableSectionBytes> first_sections,
+                                        std::span<const ExecutableSectionBytes> second_sections,
+                                        std::span<const uint8_t> first_elf,
+                                        std::span<const uint8_t> second_elf) {
+  const auto count_named = [](std::span<const ExecutableSectionBytes> sections,
+                              std::string_view name) {
+    return std::ranges::count_if(
+        sections, [name](const ExecutableSectionBytes &section) { return section.name == name; });
+  };
+
+  std::optional<std::string_view> removed;
+  for (const ExecutableSectionBytes &section : first_sections) {
+    if (count_named(first_sections, section.name) > count_named(second_sections, section.name)) {
+      removed = section.name;
+      break;
+    }
+  }
+
+  std::optional<std::string_view> added;
+  for (const ExecutableSectionBytes &section : second_sections) {
+    if (count_named(second_sections, section.name) > count_named(first_sections, section.name)) {
+      added = section.name;
+      break;
+    }
+  }
+
+  if (removed && added) {
+    return std::format("executable sections changed: removed '{}', added '{}'", *removed, *added);
+  }
+  if (removed)
+    return std::format("executable section '{}' was removed", *removed);
+  if (added)
+    return std::format("executable section '{}' was added", *added);
+
+  for (size_t index = 0; index < first_sections.size(); ++index) {
+    if (first_sections[index].name != second_sections[index].name) {
+      return std::format("executable sections were reordered at index {}: first='{}', second='{}'",
+                         index, first_sections[index].name, second_sections[index].name);
+    }
+  }
+
+  for (size_t index = 0; index < first_sections.size(); ++index) {
+    const ExecutableSectionBytes &first_section = first_sections[index];
+    const ExecutableSectionBytes &second_section = second_sections[index];
+    if (!std::ranges::equal(first_section.bytes, second_section.bytes)) {
+      return describe_byte_difference(first_section.bytes, second_section.bytes,
+                                      std::format("section '{}'", first_section.name));
+    }
+  }
+
+  return describe_byte_difference(first_elf, second_elf, "ELF image");
+}
+
+} // namespace detail
+
+namespace {
+
+[[nodiscard]] std::vector<detail::ExecutableSectionBytes>
 collect_executable_sections(const AmdGpuCodeObject &object) {
-  std::vector<const Section *> sections;
+  std::vector<detail::ExecutableSectionBytes> sections;
   for (const std::unique_ptr<Section> &section : object.all_sections()) {
-    if ((section->flags() & SHF_EXECINSTR) != 0)
-      sections.push_back(section.get());
+    if ((section->flags() & SHF_EXECINSTR) == 0)
+      continue;
+    sections.push_back(
+        {section->name(), {reinterpret_cast<const uint8_t *>(section->data()), section->size()}});
   }
   return sections;
 }
@@ -218,27 +283,9 @@ collect_executable_sections(const AmdGpuCodeObject &object) {
                                                       const AmdGpuCodeObject &second_obj,
                                                       std::span<const uint8_t> first_elf,
                                                       std::span<const uint8_t> second_elf) {
-  const std::vector<const Section *> first_code = collect_executable_sections(first_obj);
-  const std::vector<const Section *> second_code = collect_executable_sections(second_obj);
-  if (first_code.size() == second_code.size()) {
-    for (size_t index = 0; index < first_code.size(); ++index) {
-      const Section &first_section = *first_code[index];
-      const Section &second_section = *second_code[index];
-      if (first_section.name() != second_section.name())
-        break;
-
-      const std::span<const uint8_t> first_bytes(
-          reinterpret_cast<const uint8_t *>(first_section.data()), first_section.size());
-      const std::span<const uint8_t> second_bytes(
-          reinterpret_cast<const uint8_t *>(second_section.data()), second_section.size());
-      if (!std::ranges::equal(first_bytes, second_bytes)) {
-        return describe_byte_difference(first_bytes, second_bytes,
-                                        "section '" + first_section.name() + "'");
-      }
-    }
-  }
-
-  return describe_byte_difference(first_elf, second_elf, "ELF image");
+  return detail::find_idempotence_difference(collect_executable_sections(first_obj),
+                                             collect_executable_sections(second_obj), first_elf,
+                                             second_elf);
 }
 
 [[nodiscard]] std::string disassemble_source_instruction(const AmdGpuCodeObject &obj,
@@ -367,12 +414,32 @@ struct SelectedInput {
 
 } // namespace
 
-std::optional<std::string_view> idempotence_request_error(const TranslateOptions &options) {
-  if (!options.verify_idempotence)
-    return std::nullopt;
-  if (options.guest_arch != options.host_arch)
+std::optional<std::string_view> translation_request_error(const TranslateOptions &options) {
+  if (options.guest_arch == ROCJITSU_CODE_ARCH_GFX1250 &&
+      options.input_revision == ProcessorRevision::Unspecified) {
+    return "--input-revision is required when --input-target is gfx1250";
+  }
+  if (options.guest_arch != ROCJITSU_CODE_ARCH_GFX1250 &&
+      options.input_revision != ProcessorRevision::Unspecified) {
+    return "--input-revision is only valid when --input-target is gfx1250";
+  }
+  if (options.host_arch == ROCJITSU_CODE_ARCH_GFX1250 &&
+      options.output_revision == ProcessorRevision::Unspecified) {
+    return "--output-revision is required when --output-target is gfx1250";
+  }
+  if (options.host_arch != ROCJITSU_CODE_ARCH_GFX1250 &&
+      options.output_revision != ProcessorRevision::Unspecified) {
+    return "--output-revision is only valid when --output-target is gfx1250";
+  }
+  if (options.guest_arch == ROCJITSU_CODE_ARCH_GFX1250 &&
+      options.host_arch == ROCJITSU_CODE_ARCH_GFX1250 &&
+      options.input_revision == ProcessorRevision::Gfx1250A0 &&
+      options.output_revision == ProcessorRevision::Gfx1250B0) {
+    return "gfx1250 A0-to-B0 translation is not supported";
+  }
+  if (options.verify_idempotence && options.guest_arch != options.host_arch)
     return "--verify-idempotence requires matching input and output architectures";
-  if (options.skip_failed_kernels)
+  if (options.verify_idempotence && options.skip_failed_kernels)
     return "--verify-idempotence cannot be combined with --skip-failed-kernels";
   return std::nullopt;
 }
@@ -385,36 +452,7 @@ ToolResult<TranslateOutput> translate_code_object(const TranslateOptions &option
   output.value.input_revision = options.input_revision;
   output.value.output_revision = options.output_revision;
 
-  // A0 and B0 share gfx1250's ELF machine ID, so the tool API requires the
-  // separate input and output revisions before it can choose a direction.
-  if (options.guest_arch == ROCJITSU_CODE_ARCH_GFX1250 &&
-      options.input_revision == ProcessorRevision::Unspecified) {
-    add_error(output, kInputError, "input revision is required for gfx1250");
-    return output;
-  }
-  if (options.guest_arch != ROCJITSU_CODE_ARCH_GFX1250 &&
-      options.input_revision != ProcessorRevision::Unspecified) {
-    add_error(output, kInputError, "input revision is only supported for gfx1250");
-    return output;
-  }
-  if (options.host_arch == ROCJITSU_CODE_ARCH_GFX1250 &&
-      options.output_revision == ProcessorRevision::Unspecified) {
-    add_error(output, kInputError, "output revision is required for gfx1250");
-    return output;
-  }
-  if (options.host_arch != ROCJITSU_CODE_ARCH_GFX1250 &&
-      options.output_revision != ProcessorRevision::Unspecified) {
-    add_error(output, kInputError, "output revision is only supported for gfx1250");
-    return output;
-  }
-  if (options.guest_arch == ROCJITSU_CODE_ARCH_GFX1250 &&
-      options.host_arch == ROCJITSU_CODE_ARCH_GFX1250 &&
-      options.input_revision == ProcessorRevision::Gfx1250A0 &&
-      options.output_revision == ProcessorRevision::Gfx1250B0) {
-    add_error(output, kInputError, "gfx1250 A0-to-B0 translation is not supported");
-    return output;
-  }
-  if (const std::optional<std::string_view> request_error = idempotence_request_error(options)) {
+  if (const std::optional<std::string_view> request_error = translation_request_error(options)) {
     add_error(output, kInputError, std::string(*request_error));
     return output;
   }
@@ -499,11 +537,9 @@ ToolResult<TranslateOutput> translate_code_object(const TranslateOptions &option
       BinaryTranslator verifier(options.guest_arch, options.host_arch, options.target_mach,
                                 make_binary_translator_options(options));
       TranslatedCodeObject second = verifier.translate(translated_obj);
-      if (!second.ok()) {
-        for (TranslationDiagnostic &diagnostic : second.diagnostics) {
-          diagnostic.message = "idempotence verification: " + diagnostic.message;
-          output.value.diagnostics.push_back(std::move(diagnostic));
-        }
+      const bool second_ok = second.ok();
+      output.value.idempotence_diagnostics = std::move(second.diagnostics);
+      if (!second_ok) {
         add_error(output, kValidationError, "idempotence verification second translation failed");
         return output;
       }
@@ -522,7 +558,7 @@ ToolResult<TranslateOutput> translate_code_object(const TranslateOptions &option
       }
       output.value.idempotence_verified = true;
     } catch (const std::exception &e) {
-      add_error(output, kValidationError,
+      add_error(output, kTranslationError,
                 std::string("idempotence verification second translation threw exception: ") +
                     e.what());
       return output;

--- a/emulation/rocjitsu/tools/dbt_translate.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate.cpp
@@ -10,6 +10,7 @@
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
 
+#include <algorithm>
 #include <exception>
 #include <iomanip>
 #include <memory>
@@ -170,6 +171,76 @@ void record_decode_failure(CodeSectionReport &section_report, size_t byte_offset
   return true;
 }
 
+[[nodiscard]] BinaryTranslatorOptions
+make_binary_translator_options(const TranslateOptions &options) {
+  BinaryTranslatorOptions translator_options;
+  translator_options.debug_min_free_vgpr = options.debug_min_free_vgpr;
+  translator_options.debug_continue_after_failure = options.debug_continue_after_failure;
+  translator_options.skip_failed_kernels = options.skip_failed_kernels;
+  translator_options.input_revision = options.input_revision;
+  translator_options.output_revision = options.output_revision;
+  return translator_options;
+}
+
+[[nodiscard]] std::string describe_byte_difference(std::span<const uint8_t> first,
+                                                   std::span<const uint8_t> second,
+                                                   std::string_view location) {
+  const size_t common_size = std::min(first.size(), second.size());
+  size_t offset = 0;
+  while (offset < common_size && first[offset] == second[offset])
+    ++offset;
+
+  if (offset < common_size) {
+    std::ostringstream os;
+    os << location << " first differs at " << format_offset(offset) << " (first=0x" << std::hex
+       << std::setw(2) << std::setfill('0') << static_cast<unsigned>(first[offset]) << ", second=0x"
+       << std::setw(2) << static_cast<unsigned>(second[offset]) << ")" << std::dec;
+    if (first.size() != second.size())
+      os << "; size " << first.size() << " -> " << second.size() << " bytes";
+    return os.str();
+  }
+
+  return std::string(location) + " size changed from " + std::to_string(first.size()) + " to " +
+         std::to_string(second.size()) + " bytes";
+}
+
+[[nodiscard]] std::vector<const Section *>
+collect_executable_sections(const AmdGpuCodeObject &object) {
+  std::vector<const Section *> sections;
+  for (const std::unique_ptr<Section> &section : object.all_sections()) {
+    if ((section->flags() & SHF_EXECINSTR) != 0)
+      sections.push_back(section.get());
+  }
+  return sections;
+}
+
+[[nodiscard]] std::string find_idempotence_difference(const AmdGpuCodeObject &first_obj,
+                                                      const AmdGpuCodeObject &second_obj,
+                                                      std::span<const uint8_t> first_elf,
+                                                      std::span<const uint8_t> second_elf) {
+  const std::vector<const Section *> first_code = collect_executable_sections(first_obj);
+  const std::vector<const Section *> second_code = collect_executable_sections(second_obj);
+  if (first_code.size() == second_code.size()) {
+    for (size_t index = 0; index < first_code.size(); ++index) {
+      const Section &first_section = *first_code[index];
+      const Section &second_section = *second_code[index];
+      if (first_section.name() != second_section.name())
+        break;
+
+      const std::span<const uint8_t> first_bytes(
+          reinterpret_cast<const uint8_t *>(first_section.data()), first_section.size());
+      const std::span<const uint8_t> second_bytes(
+          reinterpret_cast<const uint8_t *>(second_section.data()), second_section.size());
+      if (!std::ranges::equal(first_bytes, second_bytes)) {
+        return describe_byte_difference(first_bytes, second_bytes,
+                                        "section '" + first_section.name() + "'");
+      }
+    }
+  }
+
+  return describe_byte_difference(first_elf, second_elf, "ELF image");
+}
+
 [[nodiscard]] std::string disassemble_source_instruction(const AmdGpuCodeObject &obj,
                                                          uint64_t offset, rj_code_arch_t arch) {
   auto decoder = Decoder::create(arch);
@@ -296,6 +367,16 @@ struct SelectedInput {
 
 } // namespace
 
+std::optional<std::string_view> idempotence_request_error(const TranslateOptions &options) {
+  if (!options.verify_idempotence)
+    return std::nullopt;
+  if (options.guest_arch != options.host_arch)
+    return "--verify-idempotence requires matching input and output architectures";
+  if (options.skip_failed_kernels)
+    return "--verify-idempotence cannot be combined with --skip-failed-kernels";
+  return std::nullopt;
+}
+
 ToolResult<TranslateOutput> translate_code_object(const TranslateOptions &options) {
   ToolResult<TranslateOutput> output;
   output.value.host_arch = options.host_arch;
@@ -333,6 +414,10 @@ ToolResult<TranslateOutput> translate_code_object(const TranslateOptions &option
     add_error(output, kInputError, "gfx1250 A0-to-B0 translation is not supported");
     return output;
   }
+  if (const std::optional<std::string_view> request_error = idempotence_request_error(options)) {
+    add_error(output, kInputError, std::string(*request_error));
+    return output;
+  }
 
   if (options.input_path.empty()) {
     add_error(output, kInputError, "input path is required");
@@ -360,14 +445,8 @@ ToolResult<TranslateOutput> translate_code_object(const TranslateOptions &option
   }
 
   try {
-    BinaryTranslatorOptions translator_options;
-    translator_options.debug_min_free_vgpr = options.debug_min_free_vgpr;
-    translator_options.debug_continue_after_failure = options.debug_continue_after_failure;
-    translator_options.skip_failed_kernels = options.skip_failed_kernels;
-    translator_options.input_revision = options.input_revision;
-    translator_options.output_revision = options.output_revision;
     BinaryTranslator translator(options.guest_arch, options.host_arch, options.target_mach,
-                                translator_options);
+                                make_binary_translator_options(options));
     if (need_report) {
       output.value.instruction_translations.clear();
       translator.set_trace_callback([&](const TranslationTraceEvent &trace) {
@@ -412,6 +491,42 @@ ToolResult<TranslateOutput> translate_code_object(const TranslateOptions &option
   if (!validate_host_decode(output.value.translated_report, error)) {
     add_error(output, kValidationError, error);
     return output;
+  }
+
+  if (options.verify_idempotence) {
+    output.value.idempotence_checked = true;
+    try {
+      BinaryTranslator verifier(options.guest_arch, options.host_arch, options.target_mach,
+                                make_binary_translator_options(options));
+      TranslatedCodeObject second = verifier.translate(translated_obj);
+      if (!second.ok()) {
+        for (TranslationDiagnostic &diagnostic : second.diagnostics) {
+          diagnostic.message = "idempotence verification: " + diagnostic.message;
+          output.value.diagnostics.push_back(std::move(diagnostic));
+        }
+        add_error(output, kValidationError, "idempotence verification second translation failed");
+        return output;
+      }
+      if (second.elf_bytes != output.value.elf_bytes) {
+        AmdGpuCodeObject second_obj(second.elf_bytes.data(), second.elf_bytes.size());
+        if (!second_obj.is_valid()) {
+          add_error(output, kValidationError,
+                    "idempotence verification produced an invalid AMDGPU code object");
+          return output;
+        }
+        add_error(output, kValidationError,
+                  "translation output is not byte-idempotent: " +
+                      find_idempotence_difference(translated_obj, second_obj,
+                                                  output.value.elf_bytes, second.elf_bytes));
+        return output;
+      }
+      output.value.idempotence_verified = true;
+    } catch (const std::exception &e) {
+      add_error(output, kValidationError,
+                std::string("idempotence verification second translation threw exception: ") +
+                    e.what());
+      return output;
+    }
   }
 
   return output;

--- a/emulation/rocjitsu/tools/dbt_translate.h
+++ b/emulation/rocjitsu/tools/dbt_translate.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace rocjitsu::tools {
@@ -79,6 +80,8 @@ struct TranslateOptions {
   std::optional<uint16_t> debug_min_free_vgpr;
   bool debug_continue_after_failure = false;
   bool skip_failed_kernels = false;
+  /// @brief Rerun a same-architecture translation and require identical ELF bytes.
+  bool verify_idempotence = false;
   DisassemblyMode disassembly = DisassemblyMode::None;
 };
 
@@ -93,6 +96,10 @@ struct TranslateOutput {
   std::vector<InstructionTranslationReport> instruction_translations;
   std::vector<TranslationDiagnostic> diagnostics;
   std::string disassembly;
+  /// @brief True when the requested second translation was attempted.
+  bool idempotence_checked = false;
+  /// @brief True when the requested second translation matched the first output.
+  bool idempotence_verified = false;
 
   /// @brief True if translation produced no error diagnostics.
   [[nodiscard]] bool ok() const { return !has_error_diagnostic(diagnostics); }
@@ -105,6 +112,11 @@ struct TranslateOutput {
   /// gate on this, not just ok() -- a KernelSkipped diagnostic is only a warning.
   [[nodiscard]] bool dispatchable() const { return ok() && !has_skipped_kernel(diagnostics); }
 };
+
+/// @brief Validate option combinations required by idempotence verification.
+/// @returns An error message when the request is invalid, or nullopt otherwise.
+[[nodiscard]] std::optional<std::string_view>
+idempotence_request_error(const TranslateOptions &options);
 
 /// @brief Translate one AMDGPU code object using the DBT pipeline.
 ///

--- a/emulation/rocjitsu/tools/dbt_translate.h
+++ b/emulation/rocjitsu/tools/dbt_translate.h
@@ -16,6 +16,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -95,6 +96,11 @@ struct TranslateOutput {
   CodeObjectReport translated_report;
   std::vector<InstructionTranslationReport> instruction_translations;
   std::vector<TranslationDiagnostic> diagnostics;
+  /// @brief Diagnostics produced by the verification translation only.
+  ///
+  /// @details These do not affect ok() or dispatchable(): elf_bytes is the
+  /// already-validated first-pass output.
+  std::vector<TranslationDiagnostic> idempotence_diagnostics;
   std::string disassembly;
   /// @brief True when the requested second translation was attempted.
   bool idempotence_checked = false;
@@ -113,10 +119,30 @@ struct TranslateOutput {
   [[nodiscard]] bool dispatchable() const { return ok() && !has_skipped_kernel(diagnostics); }
 };
 
-/// @brief Validate option combinations required by idempotence verification.
+/// @brief Validate translation option combinations.
 /// @returns An error message when the request is invalid, or nullopt otherwise.
 [[nodiscard]] std::optional<std::string_view>
-idempotence_request_error(const TranslateOptions &options);
+translation_request_error(const TranslateOptions &options);
+
+namespace detail {
+
+/// @brief Non-owning executable-section data used by idempotence comparison.
+struct ExecutableSectionBytes {
+  std::string_view name;
+  std::span<const uint8_t> bytes;
+};
+
+[[nodiscard]] std::string describe_byte_difference(std::span<const uint8_t> first,
+                                                   std::span<const uint8_t> second,
+                                                   std::string_view location);
+
+[[nodiscard]] std::string
+find_idempotence_difference(std::span<const ExecutableSectionBytes> first_sections,
+                            std::span<const ExecutableSectionBytes> second_sections,
+                            std::span<const uint8_t> first_elf,
+                            std::span<const uint8_t> second_elf);
+
+} // namespace detail
 
 /// @brief Translate one AMDGPU code object using the DBT pipeline.
 ///

--- a/emulation/rocjitsu/tools/dbt_translate_main.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate_main.cpp
@@ -93,6 +93,8 @@ void print_help() {
       << "  --debug-conservative-liveness N Only allocate free VGPR scratch at or above N\n"
       << "  --debug-continue-after-failure Continue collecting diagnostics after failures\n"
       << "  --skip-failed-kernels          Preserve failed kernels and continue other kernels\n"
+      << "  --verify-idempotence           Require a same-architecture second pass to be "
+         "unchanged\n"
       << "  --show-all-translations         Include unchanged identity mappings in diff output\n"
       << "  --list-code-objects             List extractable code objects and exit\n"
       << "  --help                          Show this help\n\n"
@@ -193,6 +195,10 @@ void print_help() {
     }
     if (arg == "--skip-failed-kernels") {
       options.translate.skip_failed_kernels = true;
+      continue;
+    }
+    if (arg == "--verify-idempotence") {
+      options.translate.verify_idempotence = true;
       continue;
     }
 
@@ -511,6 +517,8 @@ void print_text_report(std::ostream &os, const CliOptions &options,
   if (options.saw_output_revision)
     os << "output_revision: " << revision_name(output.output_revision) << "\n";
   os << "output_elf_bytes: " << output.elf_bytes.size() << "\n";
+  if (options.translate.verify_idempotence && output.idempotence_checked)
+    os << "idempotence: " << (output.idempotence_verified ? "verified" : "not-verified") << "\n";
 
   print_code_object_report(os, "source", output.source_report);
   print_code_object_report(os, "translated", output.translated_report);
@@ -601,6 +609,11 @@ int main(int argc, char **argv) {
       options.translate.input_revision == ProcessorRevision::Gfx1250A0 &&
       options.translate.output_revision == ProcessorRevision::Gfx1250B0) {
     std::cerr << "gfx1250 A0-to-B0 translation is not supported\n";
+    return kUsageError;
+  }
+  if (const std::optional<std::string_view> request_error =
+          idempotence_request_error(options.translate)) {
+    std::cerr << *request_error << "\n";
     return kUsageError;
   }
 

--- a/emulation/rocjitsu/tools/dbt_translate_main.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate_main.cpp
@@ -344,7 +344,10 @@ struct ReportTotals {
   return "unknown";
 }
 
-void print_diagnostic(std::ostream &os, const TranslationDiagnostic &diagnostic) {
+void print_diagnostic(std::ostream &os, const TranslationDiagnostic &diagnostic,
+                      std::string_view prefix = {}) {
+  if (!prefix.empty())
+    os << prefix << ' ';
   os << diagnostic_severity_name(diagnostic.severity) << ": "
      << diagnostic_kind_name(diagnostic.kind);
   if (diagnostic.guest_offset)
@@ -352,8 +355,12 @@ void print_diagnostic(std::ostream &os, const TranslationDiagnostic &diagnostic)
   if (!diagnostic.mnemonic.empty())
     os << " " << diagnostic.mnemonic;
   os << ": " << diagnostic.message << "\n";
-  for (const auto &item : diagnostic.required_work)
-    os << "  required: " << item << "\n";
+  for (const auto &item : diagnostic.required_work) {
+    os << "  ";
+    if (!prefix.empty())
+      os << prefix << ' ';
+    os << "required: " << item << "\n";
+  }
 }
 
 [[nodiscard]] const char *legalization_action_name(Action action) {
@@ -517,14 +524,19 @@ void print_text_report(std::ostream &os, const CliOptions &options,
   if (options.saw_output_revision)
     os << "output_revision: " << revision_name(output.output_revision) << "\n";
   os << "output_elf_bytes: " << output.elf_bytes.size() << "\n";
-  if (options.translate.verify_idempotence && output.idempotence_checked)
-    os << "idempotence: " << (output.idempotence_verified ? "verified" : "not-verified") << "\n";
+  if (options.translate.verify_idempotence) {
+    const std::string_view status = !output.idempotence_checked   ? "not-checked"
+                                    : output.idempotence_verified ? "verified"
+                                                                  : "not-verified";
+    os << "idempotence: " << status << "\n";
+  }
 
   print_code_object_report(os, "source", output.source_report);
   print_code_object_report(os, "translated", output.translated_report);
   print_instruction_translation_report(os, output, options.show_all_translations);
 
   os << "\ndiagnostics: " << output.diagnostics.size() << "\n";
+  os << "idempotence_diagnostics: " << output.idempotence_diagnostics.size() << "\n";
   os << "errors: " << result.errors.size() << "\n";
 }
 
@@ -579,6 +591,11 @@ int main(int argc, char **argv) {
     return 0;
   }
 
+  if (options.list_code_objects && options.translate.verify_idempotence) {
+    std::cerr << "--verify-idempotence cannot be combined with --list-code-objects\n";
+    return kUsageError;
+  }
+
   if (options.list_code_objects)
     return list_code_objects(options);
 
@@ -588,31 +605,8 @@ int main(int argc, char **argv) {
     return kUsageError;
   }
 
-  if (options.translate.guest_arch == ROCJITSU_CODE_ARCH_GFX1250 && !options.saw_input_revision) {
-    std::cerr << "--input-revision is required when --input-target is gfx1250\n";
-    return kUsageError;
-  }
-  if (options.translate.guest_arch != ROCJITSU_CODE_ARCH_GFX1250 && options.saw_input_revision) {
-    std::cerr << "--input-revision is only valid when --input-target is gfx1250\n";
-    return kUsageError;
-  }
-  if (options.translate.host_arch == ROCJITSU_CODE_ARCH_GFX1250 && !options.saw_output_revision) {
-    std::cerr << "--output-revision is required when --output-target is gfx1250\n";
-    return kUsageError;
-  }
-  if (options.translate.host_arch != ROCJITSU_CODE_ARCH_GFX1250 && options.saw_output_revision) {
-    std::cerr << "--output-revision is only valid when --output-target is gfx1250\n";
-    return kUsageError;
-  }
-  if (options.translate.guest_arch == ROCJITSU_CODE_ARCH_GFX1250 &&
-      options.translate.host_arch == ROCJITSU_CODE_ARCH_GFX1250 &&
-      options.translate.input_revision == ProcessorRevision::Gfx1250A0 &&
-      options.translate.output_revision == ProcessorRevision::Gfx1250B0) {
-    std::cerr << "gfx1250 A0-to-B0 translation is not supported\n";
-    return kUsageError;
-  }
   if (const std::optional<std::string_view> request_error =
-          idempotence_request_error(options.translate)) {
+          translation_request_error(options.translate)) {
     std::cerr << *request_error << "\n";
     return kUsageError;
   }
@@ -626,6 +620,8 @@ int main(int argc, char **argv) {
 
   for (const auto &diagnostic : result.value.diagnostics)
     print_diagnostic(std::cerr, diagnostic);
+  for (const auto &diagnostic : result.value.idempotence_diagnostics)
+    print_diagnostic(std::cerr, diagnostic, "idempotence");
 
   if (options.output_mode == OutputMode::Diff)
     print_text_report(std::cout, options, result);


### PR DESCRIPTION
## Motivation

Detect offline translations whose output changes when translated again -- usually it's an indication of a bug in the translator. This is meant for future offline translation tests in CI.

## Technical Details

- Add `--verify-idempotence` for same-architecture translations and fail before emitting output if the second pass fails or changes the ELF bytes.
- Preserve second-pass diagnostics and localize mismatches to the first differing executable-section byte when possible.
- Document the strict whole-ELF contract and cover stable replacement and unstable wrapping rules.

## Issue Tracking

N/A

## Test Plan

Build the offline translator, run focused tests, and sweep the gfx1250 HotSwap corpus.

## Test Result

Passed. All focused tests passed. The HotSwap corpus is not clean yet; stabilizing the remaining translator output is separate follow-up work.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.