### PR TITLE
[rocjitsu] Translate indirect calls whose scope has no stale PC values

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -177,6 +177,12 @@ struct PcValue {
   uint64_t source_getpc_offset = 0;
   uint64_t source_recovery_begin_offset = 0;
   uint64_t source_recovery_end_offset = 0;
+  /// @brief False once a non-chain instruction was observed inside the recovery
+  /// range. patch_recovered_builder_fixups NOPs the whole
+  /// [begin, end) interval as one contiguous run, so a gap instruction between
+  /// two builder steps would be erased. A value that stops being contiguous can
+  /// never regain the property, so any later delta step keeps it false.
+  bool contiguous = true;
 
   friend bool operator==(const PcValue &, const PcValue &) = default;
 };
@@ -326,6 +332,7 @@ void note_pc_builder(PcAddressBuilderMap &builders, uint16_t pair_lo, const PcVa
       .source_target_offset = value.offset,
       .source_sreg = pair_lo,
       .resolved = true,
+      .contiguous = value.contiguous,
   };
 
   auto it = builders.find(value.source_getpc_offset);
@@ -1316,10 +1323,16 @@ std::optional<size_t> try_apply_temp_delta_pattern(AnalysisContext &ctx, const A
     const PcValue *value = state.builder(pair_lo);
     if (value == nullptr)
       continue;
+    // The matched idiom's first instruction must start where the recorded range
+    // ends, or an unmodeled instruction sits inside the range that the patcher
+    // would NOP-erase along with the builder. Mark the value non-contiguous so
+    // the whole-scope proof declines to rewrite that range.
+    const bool adjacent = ctx.insts[index]->src_loc() == value->source_recovery_end_offset;
     if (auto pattern = match_temp_add_pattern(ctx, index, block.last_index, pair_lo)) {
       PcValue updated = *value;
       updated.offset += pattern->delta;
       updated.source_recovery_end_offset = pattern->end_offset;
+      updated.contiguous = updated.contiguous && adjacent;
 
       for (size_t i = 0; i < pattern->instruction_count; ++i)
         invalidate_written_sgprs(ctx, index + i, state, pair_lo);
@@ -1330,6 +1343,7 @@ std::optional<size_t> try_apply_temp_delta_pattern(AnalysisContext &ctx, const A
       PcValue updated = *value;
       updated.offset += pattern->delta;
       updated.source_recovery_end_offset = pattern->end_offset;
+      updated.contiguous = updated.contiguous && adjacent;
 
       for (size_t i = 0; i < pattern->instruction_count; ++i)
         invalidate_written_sgprs(ctx, index + i, state, pair_lo);
@@ -1478,10 +1492,17 @@ bool try_apply_pair_update(AnalysisContext &ctx, size_t index, BlockState &state
     PcValue updated = *value;
     const Instruction &inst = *ctx.insts[index];
     const uint32_t word = ctx.facts[index].word;
+    // A builder step must start exactly where the recorded range ends. If the
+    // pair survived an instruction between the previous step and this one, that
+    // instruction sits inside [begin, end) and would be NOP-erased by
+    // patch_recovered_builder_fixups. Mark the value non-contiguous so the
+    // whole-scope proof declines to rewrite the range.
+    const bool adjacent = inst.src_loc() == updated.source_recovery_end_offset;
     if (!apply_gfx1250_add_nc_u64_update(inst, word, ctx.text, ctx.arch, pair_lo, updated) &&
         !apply_low_literal_update(inst, word, ctx.text, ctx.arch, pair_lo, updated) &&
         !apply_high_carry_update(inst, word, ctx.text, ctx.arch, pair_lo, updated))
       continue;
+    updated.contiguous = updated.contiguous && adjacent;
 
     invalidate_written_sgprs(ctx, index, state, pair_lo);
     state.set_builder(pair_lo, updated);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -276,6 +276,73 @@ struct PairTransfer {
   PcValue value;
 };
 
+/// @brief One PC-relative address producer while a discovery round is running.
+///
+/// @details `poisoned` is sticky. Once a producer is observed in a way that no
+/// single delta rewrite can repair, no later observation may resurrect it.
+struct PcAddressBuilderEntry {
+  PcAddressBuilder record;
+  bool poisoned = false;
+};
+
+/// @brief Accumulator for every PC-relative address producer seen in one round.
+///
+/// @details Keyed by the producer's `s_getpc_b64` source offset so a getpc that
+/// is observed several times (at its consumer, at a call that clobbers it, and
+/// again at block exit) collapses to one record. Two observations that disagree
+/// cannot both be satisfied by one delta rewrite, so a disagreement poisons the
+/// record instead of picking one.
+using PcAddressBuilderMap = std::unordered_map<uint64_t, PcAddressBuilderEntry>;
+
+void seed_pc_builder(PcAddressBuilderMap &builders, uint64_t getpc_offset, uint16_t pair_lo) {
+  // Every s_getpc_b64 is recorded even when nothing can be proven about it. A
+  // whole-scope "no stale PC values" claim must account for the producers the
+  // pass failed to follow, not silently omit them.
+  builders.try_emplace(getpc_offset,
+                       PcAddressBuilderEntry{.record = {.source_getpc_offset = getpc_offset,
+                                                        .source_sreg = pair_lo,
+                                                        .resolved = false}});
+}
+
+void poison_pc_builder(PcAddressBuilderMap &builders, uint64_t getpc_offset) {
+  auto it = builders.find(getpc_offset);
+  if (it == builders.end())
+    return;
+  it->second.poisoned = true;
+  it->second.record.resolved = false;
+}
+
+/// @brief Record the value a builder leaves in its pair at a stable program point.
+///
+/// @details A stable point is one where the pair stops being tracked: the block
+/// exit, a call that clobbers it, or the consumer that reads it. The recorded
+/// value is exactly what the original builder range produces there, which is the
+/// precondition for rewriting that range to produce the relocated address.
+void note_pc_builder(PcAddressBuilderMap &builders, uint16_t pair_lo, const PcValue &value) {
+  const PcAddressBuilder record{
+      .source_getpc_offset = value.source_getpc_offset,
+      .source_recovery_begin_offset = value.source_recovery_begin_offset,
+      .source_recovery_end_offset = value.source_recovery_end_offset,
+      .source_target_offset = value.offset,
+      .source_sreg = pair_lo,
+      .resolved = true,
+  };
+
+  auto it = builders.find(value.source_getpc_offset);
+  if (it == builders.end()) {
+    builders.emplace(value.source_getpc_offset, PcAddressBuilderEntry{.record = record});
+    return;
+  }
+  if (it->second.poisoned)
+    return;
+  if (it->second.record.resolved && it->second.record != record) {
+    it->second.poisoned = true;
+    it->second.record.resolved = false;
+    return;
+  }
+  it->second.record = record;
+}
+
 struct AnalysisBlock {
   /// Byte offset of the first instruction in this temporary analysis block.
   uint64_t offset = 0;
@@ -1442,7 +1509,7 @@ void emit_fixups_for_values(const AnalysisContext &ctx, size_t inst_index, uint1
 
 void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBlock> &blocks,
                 std::vector<PendingConsumer> &pending_consumers,
-                std::vector<IndirectCallFixup> &recovered) {
+                std::vector<IndirectCallFixup> &recovered, PcAddressBuilderMap &pc_builders) {
   // Phase 2: run local transfer semantics for one straight-line block.
   //
   // This scan has no incoming lattice facts by design. A pair either becomes
@@ -1453,6 +1520,16 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
   AnalysisBlock &block = blocks[block_index];
   BlockState state;
 
+  // Publish every still-live builder's current value. Called only where the
+  // tracked pairs are about to stop being tracked, so the published value is
+  // the one the original builder range really produces at that point.
+  const auto note_live_pc_builders = [&] {
+    for (uint16_t pair_lo : state.active_pairs()) {
+      if (const PcValue *value = state.builder(pair_lo))
+        note_pc_builder(pc_builders, pair_lo, *value);
+    }
+  };
+
   for (size_t index = block.first_index; index <= block.last_index; ++index) {
     const Instruction &inst = *ctx.insts[index];
     const InstructionFacts &facts = ctx.facts[index];
@@ -1462,16 +1539,32 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
       // s_getpc_b64 writes the address of the following instruction. The
       // low/high add sequence edits this base to the eventual branch target.
       const uint16_t pair_lo = *facts.getpc_sdst;
+      // A second builder overwriting the same pair abandons the first one at an
+      // unknown point in its chain. No single delta rewrite is provably correct
+      // for an abandoned chain, so poison it rather than publish a partial value.
+      if (const PcValue *replaced = state.builder(pair_lo))
+        poison_pc_builder(pc_builders, replaced->source_getpc_offset);
+      seed_pc_builder(pc_builders, inst.src_loc(), pair_lo);
       state.set_builder(pair_lo, PcValue{.offset = static_cast<int64_t>(next_offset),
                                          .source_getpc_offset = inst.src_loc(),
                                          .source_recovery_begin_offset = next_offset,
                                          .source_recovery_end_offset = next_offset});
       continue;
     }
+    // A getpc the pass declines to track still produces a PC-derived value.
+    // Record it as an unresolvable producer so it cannot be silently omitted
+    // from a whole-scope claim.
+    if (facts.getpc_sdst) {
+      seed_pc_builder(pc_builders, inst.src_loc(), *facts.getpc_sdst);
+      poison_pc_builder(pc_builders, inst.src_loc());
+    }
 
     const std::optional<uint16_t> consumer_pair =
         facts.setpc_ssrc ? facts.setpc_ssrc : facts.swappc_ssrc;
     if (consumer_pair) {
+      // The consumer terminates this block, and its destination pair write can
+      // clobber a tracked builder. Publish the pre-consumer values first.
+      note_live_pc_builders();
       // A consumer resolved from local state is the strongest case: the builder
       // and the branch/call through that builder are in the same straight-line
       // block. Emit now so BasicBlock can split at the consumer and target.
@@ -1507,6 +1600,9 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
       // context-sensitive return edge, so allowing existing builders to PASS
       // through this block would incorrectly preserve values that the callee may
       // clobber. Fail closed by killing every carried builder at the call site.
+      // The values are still exactly what the builder ranges produced up to
+      // here, so publish them before dropping them.
+      note_live_pc_builders();
       const std::vector<uint16_t> active_pairs = state.active_pairs();
       for (uint16_t pair_lo : active_pairs)
         state.invalidate_pair(pair_lo);
@@ -1533,6 +1629,7 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
     invalidate_written_sgprs(ctx, index, state);
   }
 
+  note_live_pc_builders();
   finalize_block_transfers(block, state);
 }
 
@@ -2218,11 +2315,13 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
 
 [[nodiscard]] std::vector<IndirectCallFixup> discover_indirect_branch_edges_unfiltered(
     std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,
-    std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy) {
+    std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy,
+    std::vector<PcAddressBuilder> *pc_builders) {
   std::vector<IndirectCallFixup> recovered;
   AnalysisContext ctx = build_context(insts, text, arch);
   std::vector<uint64_t> leaders(extra_leaders.begin(), extra_leaders.end());
 
+  PcAddressBuilderMap round_builders;
   for (size_t iteration = 0; iteration < kMaxIndirectDiscoveryIterations; ++iteration) {
     add_recovered_leaders(leaders, recovered);
 
@@ -2236,8 +2335,12 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
     // recovered targets become reachable through those edges, not by being
     // promoted to external roots.
     recover_vector_lane_stashed_pcs(ctx, blocks, iteration_recovered, extra_leaders, entry_policy);
+    // Recovered leaders can split a block between rounds, which changes where a
+    // builder's block-exit value is observed. Keep only the final round's view
+    // so the published records are internally consistent with one CFG.
+    round_builders.clear();
     for (size_t block_index = 0; block_index < blocks.size(); ++block_index)
-      scan_block(ctx, block_index, blocks, pending_consumers, iteration_recovered);
+      scan_block(ctx, block_index, blocks, pending_consumers, iteration_recovered, round_builders);
     recover_signed_delta_templates(ctx, blocks, iteration_recovered);
 
     if (!pending_consumers.empty()) {
@@ -2254,6 +2357,14 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
       break;
   }
 
+  if (pc_builders != nullptr) {
+    pc_builders->clear();
+    pc_builders->reserve(round_builders.size());
+    for (const auto &[getpc_offset, entry] : round_builders)
+      pc_builders->push_back(entry.record);
+    std::ranges::sort(*pc_builders, {}, &PcAddressBuilder::source_getpc_offset);
+  }
+
   std::ranges::sort(recovered, {}, &IndirectCallFixup::source_call_offset);
   return recovered;
 }
@@ -2262,27 +2373,34 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
 
 std::vector<IndirectCallFixup> discover_indirect_branch_edges(
     std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,
-    std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy) {
+    std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy,
+    std::vector<PcAddressBuilder> *pc_builders) {
+  if (pc_builders != nullptr)
+    pc_builders->clear();
   if (insts.empty())
     return {};
 
   // Every recoverable edge ends at an indirect branch/call consumer. Most
   // generated kernels have none, so avoid building the auxiliary CFG and
-  // running its dataflow passes when no fixup can possibly be produced.
+  // running its dataflow passes when no fixup can possibly be produced. A
+  // section with no dynamic transfer also has no consumer whose target could be
+  // a stale PC, so leaving pc_builders empty here withholds a claim rather than
+  // making a false one.
   const bool has_indirect_consumer = std::ranges::any_of(
       insts, [](const Instruction *inst) { return is_recoverable_indirect_consumer(*inst); });
   if (!has_indirect_consumer) {
 #ifndef NDEBUG
     // Keep the cheap predicate coupled to every fixup producer. A future
     // recovery path for another consumer kind must extend the predicate above.
-    const auto unfiltered =
-        discover_indirect_branch_edges_unfiltered(insts, text, arch, extra_leaders, entry_policy);
+    const auto unfiltered = discover_indirect_branch_edges_unfiltered(
+        insts, text, arch, extra_leaders, entry_policy, nullptr);
     assert(unfiltered.empty() && "indirect-recovery prefilter skipped a fixup-producing consumer");
 #endif
     return {};
   }
 
-  return discover_indirect_branch_edges_unfiltered(insts, text, arch, extra_leaders, entry_policy);
+  return discover_indirect_branch_edges_unfiltered(insts, text, arch, extra_leaders, entry_policy,
+                                                   pc_builders);
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
@@ -57,6 +57,38 @@ struct IndirectCallFixup {
   uint64_t target_recovery_end_offset = 0;   ///< Relocated one-past-end byte of builder code.
 };
 
+/// @brief One statically discovered `s_getpc_b64`-rooted PC-relative address producer.
+///
+/// @details A recovered indirect branch is only one consumer of a getpc builder.
+/// The same construct materializes function pointers that are copied, spilled,
+/// or passed as arguments before they reach a dynamic transfer. DBT relocates
+/// `.text`, so every such builder that is copied verbatim keeps its original
+/// delta and therefore computes `new_pc + old_delta` — a stale address. Reporting
+/// every builder lets the translator prove the complementary property: that no
+/// stale PC-derived value can exist in a kernel scope at all.
+///
+/// One record is produced per `s_getpc_b64` instruction, whether or not the pass
+/// could follow it. @ref resolved distinguishes the two cases.
+struct PcAddressBuilder {
+  uint64_t source_getpc_offset = 0;          ///< Source offset of the s_getpc_b64 producer.
+  uint64_t source_recovery_begin_offset = 0; ///< First source byte of replaceable builder code.
+  uint64_t source_recovery_end_offset = 0;   ///< One-past-end source byte of builder code.
+  /// Text-relative byte offset the builder leaves in its SGPR pair at
+  /// @ref source_recovery_end_offset. Signed because an unrelocatable data
+  /// reference can compute an address below the section.
+  int64_t source_target_offset = 0;
+  uint16_t source_sreg = 0; ///< Low SGPR of the pair the builder writes.
+  /// @brief True when the pass followed this getpc to a single concrete offset.
+  ///
+  /// False means an unmodeled write reached the pair before any stable point,
+  /// or two incompatible values were observed for the same producer. Such a
+  /// producer cannot be made relocation-correct and must clear any whole-scope
+  /// relocation invariant that depends on it.
+  bool resolved = false;
+
+  friend bool operator==(const PcAddressBuilder &, const PcAddressBuilder &) = default;
+};
+
 /// @brief Discover concrete targets for statically-built setpc/swappc consumers.
 ///
 /// @details This pass runs before BasicBlock storage is finalized because any
@@ -83,10 +115,16 @@ struct IndirectCallFixup {
 /// @param arch ISA architecture used for scalar instruction matching.
 /// @param extra_leaders Additional known block starts, usually kernel entries.
 /// @param entry_policy Whether predecessorless blocks are inferred to be external entries.
+/// @param pc_builders Optional sink for every discovered PC-relative address
+///        producer, sorted by `source_getpc_offset`. Populated only when the
+///        section actually contains a recoverable indirect consumer, because a
+///        section with no dynamic transfer has no stale-PC branch hazard to
+///        prove anything about.
 /// @returns Recovered indirect branch/call metadata.
 [[nodiscard]] std::vector<IndirectCallFixup> discover_indirect_branch_edges(
     std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,
     std::span<const uint64_t> extra_leaders = {},
-    ExternalEntryPolicy entry_policy = ExternalEntryPolicy::InferPredecessorless);
+    ExternalEntryPolicy entry_policy = ExternalEntryPolicy::InferPredecessorless,
+    std::vector<PcAddressBuilder> *pc_builders = nullptr);
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
@@ -85,6 +85,13 @@ struct PcAddressBuilder {
   /// producer cannot be made relocation-correct and must clear any whole-scope
   /// relocation invariant that depends on it.
   bool resolved = false;
+  /// @brief True when [source_recovery_begin_offset, source_recovery_end_offset)
+  /// holds only the builder's own arithmetic, with no unrelated instruction
+  /// between steps. The relocation patcher rewrites that interval as one
+  /// contiguous run and NOPs the remainder, so a non-contiguous range would
+  /// erase an intervening instruction. A non-contiguous producer cannot back a
+  /// whole-scope relocation invariant even though its final value is known.
+  bool contiguous = true;
 
   friend bool operator==(const PcAddressBuilder &, const PcAddressBuilder &) = default;
 };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
@@ -230,9 +230,8 @@ std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co,
     const auto decoded_span =
         std::span<const Instruction *const>(decoded_insts.data(), decoded_insts.size());
     std::vector<PcAddressBuilder> pc_address_builders;
-    std::vector<IndirectCallFixup> recovered_indirect_targets =
-        discover_indirect_branch_edges(decoded_span, text, arch, extra_leaders, entry_policy,
-                                       &pc_address_builders);
+    std::vector<IndirectCallFixup> recovered_indirect_targets = discover_indirect_branch_edges(
+        decoded_span, text, arch, extra_leaders, entry_policy, &pc_address_builders);
 
     std::set<uint64_t> leaders;
     leaders.insert(decoded.front()->src_loc());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
@@ -165,6 +165,10 @@ void BasicBlock::add_static_indirect_call_fixup(IndirectCallFixup fixup) {
   static_indirect_call_fixups_.push_back(fixup);
 }
 
+void BasicBlock::add_static_pc_address_builder(PcAddressBuilder builder) {
+  static_pc_address_builders_.push_back(builder);
+}
+
 std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co, Decoder &decoder,
                                                            rj_code_arch_t arch,
                                                            std::span<const uint64_t> extra_leaders,
@@ -225,8 +229,10 @@ std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co,
         std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(sec->data()), sec->size());
     const auto decoded_span =
         std::span<const Instruction *const>(decoded_insts.data(), decoded_insts.size());
+    std::vector<PcAddressBuilder> pc_address_builders;
     std::vector<IndirectCallFixup> recovered_indirect_targets =
-        discover_indirect_branch_edges(decoded_span, text, arch, extra_leaders, entry_policy);
+        discover_indirect_branch_edges(decoded_span, text, arch, extra_leaders, entry_policy,
+                                       &pc_address_builders);
 
     std::set<uint64_t> leaders;
     leaders.insert(decoded.front()->src_loc());
@@ -309,6 +315,24 @@ std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co,
     block_by_offset.reserve(section_blocks.size());
     for (auto &block : section_blocks)
       block_by_offset.emplace(block->start_offset(), block.get());
+
+    // Attach every discovered PC-relative address producer to the block that
+    // contains its s_getpc_b64. Blocks are in ascending source order and cover
+    // the decoded stream without overlap, so the owning block is the last one
+    // starting at or before the producer.
+    const auto starts_after = [](uint64_t offset, const std::unique_ptr<BasicBlock> &block) {
+      return offset < block->start_offset();
+    };
+    for (const PcAddressBuilder &builder : pc_address_builders) {
+      const auto it = std::upper_bound(section_blocks.begin(), section_blocks.end(),
+                                       builder.source_getpc_offset, starts_after);
+      if (it == section_blocks.begin())
+        continue;
+      BasicBlock &owner = **(it - 1);
+      if (builder.source_getpc_offset >= owner.end_offset())
+        continue;
+      owner.add_static_pc_address_builder(builder);
+    }
 
     std::vector<DeferredCallSite> deferred_calls;
     std::unordered_map<const BasicBlock *, size_t> call_site_by_source;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.h
@@ -128,6 +128,16 @@ public:
     return static_indirect_call_fixups_;
   }
 
+  /// @brief Every PC-relative address producer whose `s_getpc_b64` lives in this block.
+  ///
+  /// @details Unlike static_indirect_call_fixups(), this covers producers that
+  /// no recovered consumer references, including ones the pass could not follow.
+  /// DBT needs the complete set to decide whether a kernel scope can be made
+  /// free of stale PC-derived values.
+  [[nodiscard]] const std::vector<PcAddressBuilder> &static_pc_address_builders() const {
+    return static_pc_address_builders_;
+  }
+
   /// @brief Mutable access to the intrusive list of instructions.
   /// @returns Reference to the instruction list.
   InstructionList &instructions() { return instructions_; }
@@ -162,6 +172,7 @@ private:
   /// Remove one proven-dead edge while preserving the inverse predecessor list.
   [[nodiscard]] bool remove_successor(BasicBlock &successor);
   void add_static_indirect_call_fixup(IndirectCallFixup fixup);
+  void add_static_pc_address_builder(PcAddressBuilder builder);
 
   uint64_t start_offset_;
   uint32_t size_ = 0;
@@ -175,6 +186,7 @@ private:
   std::vector<BasicBlock *> predecessors_;
   std::vector<CallEdge> call_edges_;
   std::vector<IndirectCallFixup> static_indirect_call_fixups_;
+  std::vector<PcAddressBuilder> static_pc_address_builders_;
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/basic_block.h"
+#include "rocjitsu/code/dbt/binary_translator_internal.h"
 #include "rocjitsu/code/dbt/generated/encoding_cdna4_to_cdna3.h"
 #include "rocjitsu/code/dbt/generated/encoding_cdna4_to_rdna3.h"
 #include "rocjitsu/code/dbt/generated/encoding_cdna4_to_rdna4.h"
@@ -321,6 +322,32 @@ build_block_position_index(const std::vector<std::unique_ptr<BasicBlock>> &block
   return block;
 }
 
+/// @brief Assemble a scope's hardware-entry offsets and run the external-entry
+///        soundness gate (internal::scope_roots_are_entry_state).
+///
+/// @details Thin wrapper over the pure gate so translate() can pass a
+/// KernelTranslationScope; the full soundness argument lives at the pure
+/// function's definition below.
+[[nodiscard]] bool
+scope_incomplete_roots_are_entry_state(const KernelTranslationScope &scope,
+                                       const std::unordered_set<uint64_t> &table_callee_offsets) {
+  // Only the ordinary kernel scope entry is a safe root: hardware/ABI initializes
+  // its SGPRs (dispatch pointer, kernarg pointer, workgroup ids), never a caller-
+  // chosen code address.
+  //
+  // The kernarg-preload firmware entry (+256) is deliberately NOT a safe root.
+  // Before control reaches it the command processor copies caller-controlled
+  // kernarg words straight into user SGPRs (see command_processor.cpp,
+  // KERNARG_PRELOAD_SPEC_LENGTH handling), so a preloaded user SGPR can hold an
+  // original, unrelocated .text pointer that no in-scope builder or relocation
+  // rewrites. An incomplete consumer rooted at that entry could therefore read a
+  // stale code pointer, so it must fail closed.
+  const std::unordered_set<uint64_t> hardware_entry_offsets{scope.entry->start_offset()};
+
+  return internal::scope_roots_are_entry_state(scope.blocks, hardware_entry_offsets,
+                                               table_callee_offsets);
+}
+
 /// @brief Prove that no stale PC-derived value can exist in one kernel scope.
 ///
 /// @details The translator's usual model is "prove the target of every dynamic
@@ -362,21 +389,45 @@ build_block_position_index(const std::vector<std::unique_ptr<BasicBlock>> &block
 [[nodiscard]] std::optional<std::vector<IndirectCallFixup>>
 scope_relocatable_pc_builders(std::span<BasicBlock *const> blocks) {
   std::unordered_set<uint64_t> block_starts;
-  std::unordered_set<uint64_t> instruction_starts;
   block_starts.reserve(blocks.size());
   for (BasicBlock *block : blocks) {
     if (block == nullptr)
       return std::nullopt;
     block_starts.insert(block->start_offset());
-    instruction_starts.insert(block->end_offset());
-    for (const Instruction &inst : block->instructions())
-      instruction_starts.insert(inst.src_loc());
   }
 
   std::vector<IndirectCallFixup> builder_fixups;
-  for (const BasicBlock *block : blocks) {
+  // The instruction-start set is rebuilt per owning block rather than pooled
+  // across the whole scope. patch_recovered_builder_fixups NOPs the entire
+  // [begin, end) interval of a builder as one contiguous run, so that interval
+  // must lie inside a single block. Discovery may add a recovered leader in a
+  // later round that splits the analysis block a builder was recorded on; a
+  // scope-wide instruction-start pool would still accept a range that now
+  // straddles that split, and the patcher would overwrite the bytes inserted
+  // between the final blocks. Bounding each builder to its owning block's
+  // [start_offset, end_offset) and validating its range against only that
+  // block's instruction starts fails the proof closed for any cross-block range.
+  for (BasicBlock *block : blocks) {
+    if (block->static_pc_address_builders().empty())
+      continue;
+
+    std::unordered_set<uint64_t> block_instruction_starts;
+    block_instruction_starts.insert(block->end_offset());
+    for (const Instruction &inst : block->instructions())
+      block_instruction_starts.insert(inst.src_loc());
+
+    const auto in_owning_block = [&](uint64_t offset) {
+      return offset >= block->start_offset() && offset <= block->end_offset() &&
+             block_instruction_starts.contains(offset);
+    };
+
     for (const PcAddressBuilder &builder : block->static_pc_address_builders()) {
       if (!builder.resolved)
+        return std::nullopt;
+      // A non-contiguous range holds an unrelated instruction between builder
+      // steps. patch_recovered_builder_fixups NOPs the whole range, so rewriting
+      // it would erase that instruction. Fail the proof closed instead.
+      if (!builder.contiguous)
         return std::nullopt;
       if (builder.source_target_offset < 0)
         return std::nullopt;
@@ -385,9 +436,11 @@ scope_relocatable_pc_builders(std::span<BasicBlock *const> blocks) {
       // block placements, so only a block start has a defined new address.
       if (!block_starts.contains(target))
         return std::nullopt;
-      if (!instruction_starts.contains(builder.source_getpc_offset) ||
-          !instruction_starts.contains(builder.source_recovery_begin_offset) ||
-          !instruction_starts.contains(builder.source_recovery_end_offset)) {
+      // The getpc and its whole recovery range must be instruction starts inside
+      // the block that owns the getpc, so the NOP-and-rewrite stays contiguous.
+      if (!in_owning_block(builder.source_getpc_offset) ||
+          !in_owning_block(builder.source_recovery_begin_offset) ||
+          !in_owning_block(builder.source_recovery_end_offset)) {
         return std::nullopt;
       }
       if (builder.source_recovery_begin_offset == builder.source_recovery_end_offset) {
@@ -935,6 +988,86 @@ scoped_call_liveness_edges(std::span<BasicBlock *const> blocks, std::span<const 
 
 } // namespace
 
+namespace internal {
+
+/// @brief Prove that every external entry into an incomplete-consumer scope is
+///        an entry-state root that cannot carry an original `.text` pointer.
+///
+/// @details scope_relocatable_pc_builders proves every getpc-derived value in a
+/// scope is relocated, but that proof only covers values this scope PRODUCES. An
+/// incomplete consumer is also reachable along a path that enters the scope
+/// carrying an SGPR value from OUTSIDE it. The whole-scope proof is sound only
+/// when every such external entry is a root whose incoming SGPRs are
+/// architecturally defined, never a raw original code address:
+///   * a hardware kernel entry passed in @p hardware_entry_offsets — the caller
+///     supplies only entries whose live-in SGPRs are ABI-initialized (dispatch
+///     pointer, kernarg pointer, workgroup ids). The kernarg-preload firmware
+///     entry is deliberately excluded there, because caller-controlled kernarg
+///     words are copied into user SGPRs before it runs;
+///   * a getpc-recovered in-scope call target (callee of a proven direct or
+///     swappc call edge) — it is entered only through that call, so its live-in
+///     PC pair is the architected return PC hardware wrote from the already-
+///     relocated program counter, or a value the caller built in-scope from a
+///     getpc (now relocated).
+///
+/// A relocation-table-dispatched callee is NOT such a safe root, even though it
+/// has an in-scope CallEdge: the dispatch selects a callee dynamically and its
+/// live-in scalar registers are arbitrary caller-supplied arguments, which can
+/// include an original, unrelocated `.text` pointer. A call edge constrains
+/// control flow, not the SGPR arguments delivered along it, so a table-dispatched
+/// callee that itself holds an incomplete consumer could still receive a stale
+/// code pointer on one path. Those callees are treated as unconstrained roots.
+///
+/// A block reachable within the scope has an in-scope predecessor (an ordinary
+/// CFG edge) or is a non-table call-edge callee; any other block — one with no
+/// in-scope predecessor and no proven getpc-recovered call edge — is entered from
+/// outside the scope. Such an external-entry block is an unconstrained root:
+/// control can arrive there holding a caller-supplied function pointer that is an
+/// original, unrelocated `.text` address. The producer scan cannot rewrite that
+/// value, so the incomplete consumer downstream could jump to stale bytes. This
+/// gate fails closed for such a scope, which keeps the caller's original refusal.
+/// Empirically every incomplete-consumer scope in the gfx1250 hotswap corpus
+/// roots only at the kernel entry and at getpc-recovered call targets.
+bool scope_roots_are_entry_state(std::span<BasicBlock *const> blocks,
+                                 const std::unordered_set<uint64_t> &hardware_entry_offsets,
+                                 const std::unordered_set<uint64_t> &table_callee_offsets) {
+  std::unordered_set<const BasicBlock *> in_scope(blocks.begin(), blocks.end());
+  std::unordered_set<const BasicBlock *> call_targets;
+  for (const BasicBlock *block : blocks) {
+    if (block == nullptr)
+      return false;
+    for (const BasicBlock::CallEdge &edge : block->call_edges()) {
+      if (in_scope.contains(edge.callee))
+        call_targets.insert(edge.callee);
+    }
+  }
+
+  for (const BasicBlock *block : blocks) {
+    const bool has_in_scope_predecessor = std::ranges::any_of(
+        block->predecessors(), [&](const BasicBlock *pred) { return in_scope.contains(pred); });
+    if (has_in_scope_predecessor)
+      continue;
+    // A block with no in-scope predecessor is an external entry (it has no
+    // ordinary CFG edge from within the scope, even if it is reached by a call
+    // edge or has predecessors outside the scope).
+    //
+    // A relocation-table-dispatched callee delivers unconstrained caller-supplied
+    // SGPR arguments, so it is never a safe root regardless of its CallEdge; fail
+    // closed for it even if it is also a getpc-recovered call target.
+    if (table_callee_offsets.contains(block->start_offset()))
+      return false;
+    // Otherwise accept a hardware kernel entry or a getpc-recovered in-scope call
+    // target; any other root is an unconstrained external entry that may deliver a
+    // stale code pointer.
+    if (hardware_entry_offsets.contains(block->start_offset()) || call_targets.contains(block))
+      continue;
+    return false;
+  }
+  return true;
+}
+
+} // namespace internal
+
 BinaryTranslator::~BinaryTranslator() = default;
 
 BinaryTranslator::BinaryTranslator(rj_code_arch_t guest_arch, rj_code_arch_t host_arch,
@@ -1094,6 +1227,24 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       discover_relocation_table_dispatches(blocks, relocation_function_tables, text_vaddr);
   const auto relocation_table_calls = attach_relocation_table_call_edges(
       block_index, relocation_function_tables, relocation_table_dispatches);
+
+  // Callees reached through a relocation-table dispatch are explicit analysis
+  // roots whose live-in SGPRs are caller-supplied, not architected: a dispatched
+  // callee can be entered with an original .text pointer in a scalar argument.
+  // The whole-scope stale-PC proof must therefore treat such a callee as an
+  // unconstrained external entry rather than a safe entry-state root, even though
+  // it has an in-scope CallEdge. Collect their block-start offsets so the gate
+  // can fail closed for them (see scope_incomplete_roots_are_entry_state).
+  std::unordered_set<uint64_t> relocation_table_callee_offsets;
+  for (const RelocationTableDispatch &dispatch : relocation_table_dispatches) {
+    if (dispatch.table_index >= relocation_function_tables.size())
+      continue;
+    if (!relocation_table_calls.contains(dispatch.source_call_offset))
+      continue;
+    for (const RelocationFunctionPointer &entry :
+         relocation_function_tables[dispatch.table_index].entries)
+      relocation_table_callee_offsets.insert(entry.target_text_offset);
+  }
   auto scopes = kernel_translation_scopes(blocks, block_index, descriptor_translations);
 
   if (can_emit_sidecar_descriptors) {
@@ -1565,7 +1716,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           });
         });
     std::optional<std::vector<IndirectCallFixup>> whole_scope_builder_fixups;
-    if (has_incomplete_consumer)
+    if (has_incomplete_consumer &&
+        scope_incomplete_roots_are_entry_state(scope, relocation_table_callee_offsets))
       whole_scope_builder_fixups = scope_relocatable_pc_builders(scope.blocks);
     const bool no_stale_pc_values_in_scope = whole_scope_builder_fixups.has_value();
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -321,6 +321,101 @@ build_block_position_index(const std::vector<std::unique_ptr<BasicBlock>> &block
   return block;
 }
 
+/// @brief Prove that no stale PC-derived value can exist in one kernel scope.
+///
+/// @details The translator's usual model is "prove the target of every dynamic
+/// transfer, or refuse". This helper establishes the complementary — and
+/// strictly stronger — property: every value in this scope that was derived from
+/// an `s_getpc_b64` is rewritten to hold its RELOCATED address. A consumer whose
+/// dataflow fact is incomplete is then still safe, because whatever the
+/// unconstrained path delivers can only be one of:
+///   * a value this scope built from a getpc, which is now relocation-correct;
+///   * an architectural return PC from s_call/s_swap_pc, which hardware writes
+///     from the already-relocated program counter;
+///   * a code address loaded from data, whose ELF relocation the code-object
+///     patcher rewrites through the same final offset map (and refuses to
+///     translate when it cannot).
+/// No path can therefore carry an original, unrelocated `.text` address.
+///
+/// The proof obligation is discharged per producer and fails closed:
+///   * a producer the analysis could not follow leaves an unknown value;
+///   * a producer whose value is not a block start emitted by this scope cannot
+///     be rewritten to a relocated address (it points at data, into the middle
+///     of an instruction, or outside the emitted scope);
+///   * a bare producer that is the last instruction of its block is the shape
+///     whose delta add lives in a successor, so its chain is not proven closed.
+/// Any of those returns nullopt, which keeps the caller's existing refusal.
+///
+/// The recorded value is the one the pair holds at its block's exit, so a later
+/// unmodeled write inside the SAME block already leaves the producer unresolved.
+/// The residual modeling assumption is that a closed chain is not extended by
+/// unmodeled PC arithmetic in a SUCCESSOR block. Within one function that case
+/// is refused elsewhere: the extension is a KILL transfer, a killed lattice fact
+/// yields no fixup at all, and an indirect consumer with no fixup fails closed
+/// as unrecovered. Escaping it would need an interprocedural chain (partial
+/// build in a caller, completion after a call boundary) whose intermediate value
+/// also lands exactly on an emitted block start. AMDGPU materializes a function
+/// address with one indivisible getpc+add expansion, so no such chain exists.
+///
+/// @returns Builder rewrites that must all be applied, or nullopt when the
+///          scope cannot be made free of stale PC-derived values.
+[[nodiscard]] std::optional<std::vector<IndirectCallFixup>>
+scope_relocatable_pc_builders(std::span<BasicBlock *const> blocks) {
+  std::unordered_set<uint64_t> block_starts;
+  std::unordered_set<uint64_t> instruction_starts;
+  block_starts.reserve(blocks.size());
+  for (BasicBlock *block : blocks) {
+    if (block == nullptr)
+      return std::nullopt;
+    block_starts.insert(block->start_offset());
+    instruction_starts.insert(block->end_offset());
+    for (const Instruction &inst : block->instructions())
+      instruction_starts.insert(inst.src_loc());
+  }
+
+  std::vector<IndirectCallFixup> builder_fixups;
+  for (const BasicBlock *block : blocks) {
+    for (const PcAddressBuilder &builder : block->static_pc_address_builders()) {
+      if (!builder.resolved)
+        return std::nullopt;
+      if (builder.source_target_offset < 0)
+        return std::nullopt;
+      const auto target = static_cast<uint64_t>(builder.source_target_offset);
+      // patch_recovered_builder_fixups resolves the relocated target through
+      // block placements, so only a block start has a defined new address.
+      if (!block_starts.contains(target))
+        return std::nullopt;
+      if (!instruction_starts.contains(builder.source_getpc_offset) ||
+          !instruction_starts.contains(builder.source_recovery_begin_offset) ||
+          !instruction_starts.contains(builder.source_recovery_end_offset)) {
+        return std::nullopt;
+      }
+      if (builder.source_recovery_begin_offset == builder.source_recovery_end_offset) {
+        // A bare getpc has no delta to rewrite: hardware already supplies the
+        // relocated PC. Accept it only when its recorded value really is "the
+        // instruction after the getpc" and at least one more instruction of the
+        // same block follows without consuming it into a delta. A getpc that is
+        // the last instruction of its block is the shape whose add lives in a
+        // successor, where an unmodeled write would leave the original delta.
+        if (target != builder.source_recovery_begin_offset)
+          return std::nullopt;
+        if (builder.source_recovery_end_offset >= block->end_offset())
+          return std::nullopt;
+        continue;
+      }
+
+      builder_fixups.push_back(
+          IndirectCallFixup{.source_getpc_offset = builder.source_getpc_offset,
+                            .source_recovery_begin_offset = builder.source_recovery_begin_offset,
+                            .source_recovery_end_offset = builder.source_recovery_end_offset,
+                            .source_call_offset = builder.source_getpc_offset,
+                            .source_target_offset = target,
+                            .source_call_sreg = builder.source_sreg});
+    }
+  }
+  return builder_fixups;
+}
+
 [[nodiscard]] std::unordered_set<uint64_t>
 attach_relocation_table_call_edges(const BlockOffsetIndex &block_index,
                                    std::span<const RelocationFunctionTable> tables,
@@ -1459,6 +1554,21 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       }
     }
 
+    // An incomplete consumer is only translatable when this scope can be proven
+    // free of stale PC-derived values (see scope_relocatable_pc_builders). That
+    // proof is expensive and only ever needed when such a consumer exists, so
+    // establish it lazily; scopes without one keep byte-identical output.
+    const bool has_incomplete_consumer =
+        std::ranges::any_of(recovered_indirect_by_call, [](const auto &entry) {
+          return std::ranges::any_of(entry.second.fixups, [](const IndirectCallFixup &fixup) {
+            return fixup.source_incomplete;
+          });
+        });
+    std::optional<std::vector<IndirectCallFixup>> whole_scope_builder_fixups;
+    if (has_incomplete_consumer)
+      whole_scope_builder_fixups = scope_relocatable_pc_builders(scope.blocks);
+    const bool no_stale_pc_values_in_scope = whole_scope_builder_fixups.has_value();
+
     std::vector<IndirectCallFixup> pending_builder_fixups;
     for (auto &[source_call_offset, consumer] : recovered_indirect_by_call) {
       if (consumer.fixups.empty())
@@ -1492,12 +1602,12 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       // yet its runtime SGPR pair may hold an original .text address; after DBT
       // relocates .text, the retained dynamic transfer would jump to stale or moved
       // bytes, and the unknown target block may be absent from the emitted scope.
-      // We cannot prove the unconstrained path is free of a relocatable text
-      // address, so fail closed for the whole consumer rather than relocate only
-      // the known builders.
+      // Unless this scope was proven to contain no stale PC-derived value at all,
+      // we cannot rule that out, so fail closed for the whole consumer rather
+      // than relocate only the known builders.
       const bool any_incomplete = std::ranges::any_of(
           consumer.fixups, [](const IndirectCallFixup &fixup) { return fixup.source_incomplete; });
-      if (any_incomplete) {
+      if (any_incomplete && !no_stale_pc_values_in_scope) {
         auto failure = make_kernel_failure(
             DiagnosticKind::Legalization,
             "recovered indirect branch has an unconstrained predecessor path that cannot be "
@@ -1509,6 +1619,14 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           break;
         }
         return leave_unchanged();
+      }
+
+      if (any_incomplete) {
+        // The unconstrained path can still deliver a value this consumer never
+        // reaches through a recovered builder, so a direct transfer window would
+        // redirect it. Keep the dynamic transfer; every PC value it can observe
+        // is relocation-correct under the whole-scope proof.
+        continue;
       }
 
       // A complete consumer with one effective target can become a direct window.
@@ -1524,6 +1642,16 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     }
     if (skip_scope)
       continue;
+
+    // Discharging the proof requires actually performing every rewrite it
+    // assumes. Append it after the consumer-driven fixups so a builder that both
+    // paths cover keeps the bytes the consumer path already produced today;
+    // patch_recovered_builder_fixups collapses the duplicate range.
+    if (no_stale_pc_values_in_scope) {
+      pending_builder_fixups.insert(pending_builder_fixups.end(),
+                                    whole_scope_builder_fixups->begin(),
+                                    whole_scope_builder_fixups->end());
+    }
 
     std::vector<uint8_t> kernel_text;
     std::vector<PendingTrace> pending_traces;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator_internal.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator_internal.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file binary_translator_internal.h
+/// @brief Internal BinaryTranslator helpers exposed only for unit testing.
+///
+/// @details These declarations are implementation details of
+/// binary_translator.cpp. They are surfaced in a header solely so focused unit
+/// tests can exercise soundness gates that are otherwise unreachable through the
+/// public translate() entry point without a large end-to-end fixture. Do not use
+/// them from production code.
+
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <unordered_set>
+
+namespace rocjitsu {
+
+class BasicBlock;
+
+namespace internal {
+
+/// @brief Decide whether every external entry into an incomplete-consumer scope
+///        is an entry-state root that cannot carry an original `.text` pointer.
+///
+/// @details See the definition in binary_translator.cpp for the full soundness
+/// argument. A block with an in-scope ordinary predecessor is reachable within
+/// the scope and needs no check. A predecessor-less block is an external entry;
+/// it is safe only as a hardware kernel entry or a getpc-recovered in-scope call
+/// target. A relocation-table-dispatched callee is never safe: the dispatch
+/// delivers unconstrained caller-supplied SGPR arguments, so it is rejected even
+/// when it also carries an in-scope CallEdge.
+///
+/// @param blocks Every block in the kernel-local scope, in any order.
+/// @param hardware_entry_offsets Start offsets of ABI-initialized hardware
+///        entries (the scope entry and any kernarg-preload firmware entry).
+/// @param table_callee_offsets Start offsets of blocks that are reachable as a
+///        relocation-table dispatch callee anywhere in the object.
+/// @returns true when the scope may keep an incomplete dynamic transfer; false
+///          (fail closed) when any external root is unconstrained.
+[[nodiscard]] bool
+scope_roots_are_entry_state(std::span<BasicBlock *const> blocks,
+                            const std::unordered_set<uint64_t> &hardware_entry_offsets,
+                            const std::unordered_set<uint64_t> &table_callee_offsets);
+
+} // namespace internal
+} // namespace rocjitsu

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -6,6 +6,7 @@
 #include "rocjitsu/analysis/liveness.h"
 #include "rocjitsu/code/basic_block.h"
 #include "rocjitsu/code/code_object.h"
+#include "rocjitsu/code/dbt/binary_translator_internal.h"
 #include "rocjitsu/code/patch/instruction_builder.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna3/builders.h"
@@ -844,11 +845,49 @@ TEST(CfgAnalysis, ReportsResolvedPcAddressBuilderForEveryProducer) {
   ASSERT_EQ(builder_block->static_pc_address_builders().size(), 1u);
   const auto &builder = builder_block->static_pc_address_builders()[0];
   EXPECT_TRUE(builder.resolved);
+  EXPECT_TRUE(builder.contiguous);
   EXPECT_EQ(builder.source_getpc_offset, 0u);
   EXPECT_EQ(builder.source_recovery_begin_offset, 4u);
   EXPECT_EQ(builder.source_recovery_end_offset, 16u);
   EXPECT_EQ(builder.source_target_offset, 20);
   EXPECT_EQ(builder.source_sreg, kPcSreg);
+}
+
+TEST(CfgAnalysis, PcAddressBuilderWithGapInstructionIsReportedNonContiguous) {
+  constexpr uint16_t kPcSreg = 8;
+  constexpr uint16_t kUnrelatedSreg = 20;
+  constexpr uint32_t kLiteralOperand = 255;
+  constexpr uint32_t kInlineInt0 = 128;
+
+  // An unrelated s_mov_b32 sits between the low add and the high carry. The pass
+  // still tracks the pair across it (the move writes s20, not the pair), so the
+  // builder's recorded value is known and its recovery range spans the move. The
+  // relocation patcher NOPs that whole range, so rewriting it would erase the
+  // move. The producer must therefore be reported non-contiguous even though its
+  // final value resolved, so the whole-scope proof declines to rewrite it.
+  std::vector<uint32_t> words = {
+      pack_sop1(0x1c, kPcSreg, 0),                     // 0x00: s_getpc_b64.
+      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand), // 0x04: s_add_u32.
+      20,                                              // 0x08: 0x04 + 20 = 0x18.
+      build_s_mov_b32(kUnrelatedSreg, 0,
+                      ROCJITSU_CODE_ARCH_CDNA4),           // 0x0c: unrelated write, in range.
+      pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0), // 0x10: s_addc_u32.
+      pack_sop1(0x1d, 0, kPcSreg),                         // 0x14: consumer setpc.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),            // 0x18: target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *builder_block = block_starting_at(blocks, 0);
+  ASSERT_NE(builder_block, nullptr);
+  ASSERT_EQ(builder_block->static_pc_address_builders().size(), 1u);
+  const auto &builder = builder_block->static_pc_address_builders()[0];
+  EXPECT_TRUE(builder.resolved);
+  EXPECT_FALSE(builder.contiguous)
+      << "a builder range spanning an unrelated instruction must be non-contiguous";
 }
 
 TEST(CfgAnalysis, UnfollowedPcAddressBuilderIsReportedUnresolved) {
@@ -861,10 +900,10 @@ TEST(CfgAnalysis, UnfollowedPcAddressBuilderIsReportedUnresolved) {
   // than omitted: omitting it would let a caller conclude the scope has no
   // unrelocatable PC producer.
   std::vector<uint32_t> words = {
-      pack_sop1(0x1c, kPcSreg, 0),              // 0x00: s_getpc_b64.
+      pack_sop1(0x1c, kPcSreg, 0),                 // 0x00: s_getpc_b64.
       pack_sop2(0, kPcSreg, kPcSreg, kAddendSreg), // 0x04: s_add_u32 with register addend.
-      pack_sop1(0x1d, 0, kPcSreg),              // 0x08: consumer setpc.
-      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), // 0x0c.
+      pack_sop1(0x1d, 0, kPcSreg),                 // 0x08: consumer setpc.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),    // 0x0c.
   };
 
   TestCodeObject co(std::move(words));
@@ -1133,6 +1172,48 @@ TEST(CfgAnalysis, DirectCallEdgeUsesTerminatorOffset) {
   EXPECT_EQ(edge.source_call_offset, 4u);
   EXPECT_TRUE(has_successor_start(*caller, continuation->start_offset()));
   EXPECT_TRUE(has_predecessor(*continuation, caller));
+}
+
+TEST(BinaryTranslatorInternal, ScopeRootsRejectRelocationTableCallee) {
+  // A returning direct call makes the callee at 0x0c a call-edge target with no
+  // ordinary in-scope predecessor, i.e. an external root that the whole-scope
+  // stale-PC proof must classify. The caller (0x00) is the kernel entry.
+  constexpr uint16_t kReturnSreg = 30;
+  std::vector<uint32_t> words = {
+      build_s_call_b64(kReturnSreg, 1),         // 0x00 -> callee at 0x08.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), // 0x04 continuation.
+      pack_sop1(0x1d, 0, kReturnSreg),          // 0x08 callee return.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *caller = block_starting_at(blocks, 0);
+  auto *callee = block_starting_at(blocks, 8);
+  ASSERT_NE(caller, nullptr);
+  ASSERT_NE(callee, nullptr);
+  ASSERT_EQ(caller->call_edges().size(), 1u);
+  ASSERT_EQ(caller->call_edges()[0].callee, callee);
+
+  const auto scope = block_scope(blocks);
+  const std::unordered_set<uint64_t> hardware_entries{caller->start_offset()};
+
+  // With no relocation-table roots, the callee is a getpc-recovered call target
+  // and the entry is a hardware root, so the scope is accepted.
+  EXPECT_TRUE(rocjitsu::internal::scope_roots_are_entry_state(scope, hardware_entries, {}));
+
+  // Marking the callee a relocation-table dispatch target makes it an
+  // unconstrained root: a dispatched callee receives arbitrary caller-supplied
+  // SGPR arguments, so the gate must fail closed even though it has a CallEdge.
+  const std::unordered_set<uint64_t> table_callees{callee->start_offset()};
+  EXPECT_FALSE(
+      rocjitsu::internal::scope_roots_are_entry_state(scope, hardware_entries, table_callees));
+
+  // A non-hardware, non-call, non-table external root is also rejected: drop the
+  // entry from the hardware set and the caller itself becomes unconstrained.
+  EXPECT_FALSE(rocjitsu::internal::scope_roots_are_entry_state(scope, {}, {}));
 }
 
 TEST(CfgAnalysis, DirectCallToNonreturningTargetDropsFallthrough) {

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -816,6 +816,71 @@ TEST(CfgAnalysis, IncompleteRecoveredSetpcInCalleeKeepsOuterContinuation) {
   EXPECT_TRUE(has_predecessor(*continuation, caller));
 }
 
+TEST(CfgAnalysis, ReportsResolvedPcAddressBuilderForEveryProducer) {
+  constexpr uint16_t kPcSreg = 8;
+  constexpr uint32_t kLiteralOperand = 255;
+  constexpr uint32_t kInlineInt0 = 128;
+
+  // Recovered consumers are only one use of a getpc builder. DBT also needs the
+  // producer itself so it can prove a whole kernel scope holds no unrelocated
+  // PC-derived value, so every builder is reported with the exact byte range
+  // whose delta relocation may rewrite.
+  std::vector<uint32_t> words = {
+      pack_sop1(0x1c, kPcSreg, 0),                         // 0x00: s_getpc_b64.
+      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand),     // 0x04: s_add_u32.
+      16,                                                  // 0x08: 0x04 + 16 = 0x14.
+      pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0), // 0x0c: s_addc_u32.
+      pack_sop1(0x1d, 0, kPcSreg),                         // 0x10: consumer setpc.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),            // 0x14: target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *builder_block = block_starting_at(blocks, 0);
+  ASSERT_NE(builder_block, nullptr);
+  ASSERT_EQ(builder_block->static_pc_address_builders().size(), 1u);
+  const auto &builder = builder_block->static_pc_address_builders()[0];
+  EXPECT_TRUE(builder.resolved);
+  EXPECT_EQ(builder.source_getpc_offset, 0u);
+  EXPECT_EQ(builder.source_recovery_begin_offset, 4u);
+  EXPECT_EQ(builder.source_recovery_end_offset, 16u);
+  EXPECT_EQ(builder.source_target_offset, 20);
+  EXPECT_EQ(builder.source_sreg, kPcSreg);
+}
+
+TEST(CfgAnalysis, UnfollowedPcAddressBuilderIsReportedUnresolved) {
+  constexpr uint16_t kPcSreg = 8;
+  constexpr uint16_t kAddendSreg = 12;
+
+  // The low-half add takes a register addend the pass does not model, so the
+  // pair's final value is unknown. The producer still exists and still yields a
+  // PC-derived value at run time, so it must be reported as unresolved rather
+  // than omitted: omitting it would let a caller conclude the scope has no
+  // unrelocatable PC producer.
+  std::vector<uint32_t> words = {
+      pack_sop1(0x1c, kPcSreg, 0),              // 0x00: s_getpc_b64.
+      pack_sop2(0, kPcSreg, kPcSreg, kAddendSreg), // 0x04: s_add_u32 with register addend.
+      pack_sop1(0x1d, 0, kPcSreg),              // 0x08: consumer setpc.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), // 0x0c.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *builder_block = block_starting_at(blocks, 0);
+  ASSERT_NE(builder_block, nullptr);
+  ASSERT_EQ(builder_block->static_pc_address_builders().size(), 1u);
+  EXPECT_EQ(builder_block->static_pc_address_builders()[0].source_getpc_offset, 0u);
+  EXPECT_FALSE(builder_block->static_pc_address_builders()[0].resolved)
+      << "a producer the pass cannot follow must not be reported as relocatable";
+  EXPECT_TRUE(builder_block->static_indirect_call_fixups().empty());
+}
+
 TEST(CfgAnalysis, DominatedPcBuilderRemainsCompleteAcrossCallLoopBackedge) {
   constexpr uint16_t kPcSreg = 8;
   constexpr uint16_t kReturnSreg = 30;

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -2338,37 +2338,149 @@ TEST(InstructionBuilder, PatchPcrelBranchOffsetRejectsMisalignedDelta) {
   EXPECT_EQ(words[0], build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3));
 }
 
-TEST(BinaryTranslatorE2E, IncompleteIndirectConsumerFailsClosed) {
+/// @brief One incomplete-consumer body with a second, independent PC builder.
+///
+/// @details The consumer's own fact is incomplete: one path builds a concrete PC
+/// in s[8:9], the other reaches the setpc with the pair unconstrained. Whether
+/// the translation may keep that dynamic transfer depends entirely on the second
+/// builder in s[10:11]: @p bypass_builder_delta decides whether its value lands
+/// on a relocatable block start or on an address DBT cannot move.
+std::vector<uint32_t> make_incomplete_indirect_consumer_body(uint32_t bypass_builder_delta) {
   constexpr uint16_t kPcSreg = 8;
+  constexpr uint16_t kBypassSreg = 10;
   constexpr uint32_t kLiteralOperand = 255;
   constexpr uint32_t kInlineInt0 = 128;
 
-  // Same incomplete-fact shape as CfgAnalysis.IncompleteFactConsumerIsFlaggedIncomplete:
-  // one path builds a concrete PC, the other reaches the setpc consumer with the
-  // pair unconstrained. The unconstrained path may hold an original .text address
-  // that DBT cannot relocate, so the whole translation must fail closed rather than
-  // relocate only the known builder and leave the dynamic transfer pointing at
-  // stale bytes.
-  std::vector<uint32_t> words = {
-      pack_sopp(5, 5),                                     // 0x00: cbranch scc0 -> bypass at 0x18.
-      pack_sop1(0x1c, kPcSreg, 0),                         // 0x04: s_getpc_b64.
-      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand),     // 0x08: s_add_u32.
-      28,                                                  // 0x0c: target delta -> 0x24.
+  return {
+      pack_sopp(5, 5),                                 // 0x00: cbranch scc0 -> bypass at 0x18.
+      pack_sop1(0x1c, kPcSreg, 0),                     // 0x04: s_getpc_b64.
+      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand), // 0x08: s_add_u32.
+      40,                                              // 0x0c: target delta -> 0x30.
       pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0), // 0x10: s_addc_u32.
-      build_s_branch(1, ROCJITSU_CODE_ARCH_CDNA4),         // 0x14 -> consumer at 0x1c.
-      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),            // 0x18: bypass (unconstrained).
-      pack_sop1(0x1d, 0, kPcSreg),                         // 0x1c: joined consumer setpc.
-      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),            // 0x20: not a target.
-      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),            // 0x24: builder target.
+      build_s_branch(5, ROCJITSU_CODE_ARCH_CDNA4),         // 0x14 -> consumer at 0x2c.
+      pack_sop1(0x1c, kBypassSreg, 0),                     // 0x18: bypass-path s_getpc_b64.
+      pack_sop2(0, kBypassSreg, kBypassSreg, kLiteralOperand),     // 0x1c: s_add_u32.
+      bypass_builder_delta,                                        // 0x20.
+      pack_sop2(4, kBypassSreg + 1, kBypassSreg + 1, kInlineInt0), // 0x24: s_addc_u32.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),                    // 0x28: closes the chain.
+      pack_sop1(0x1d, 0, kPcSreg),                                 // 0x2c: joined consumer setpc.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),                    // 0x30: builder target.
+  };
+}
+
+TEST(BinaryTranslatorE2E, IncompleteIndirectConsumerFailsClosed) {
+  // The bypass builder computes 0x1c + 0x100000, far outside .text. That value
+  // is a PC-derived address DBT cannot rewrite to a relocated one, so the scope
+  // still contains a potential stale PC. The unconstrained path into the setpc
+  // may hold exactly such a value, so the whole translation must fail closed
+  // rather than relocate only the known builder and leave the dynamic transfer
+  // pointing at stale bytes.
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      make_incomplete_indirect_consumer_body(0x100000));
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  auto result = translator.translate(source);
+  EXPECT_FALSE(result.ok());
+  ASSERT_FALSE(result.diagnostics.empty());
+  EXPECT_NE(result.diagnostics.front().message.find("unconstrained predecessor path"),
+            std::string::npos)
+      << result.diagnostics.front().message;
+  EXPECT_EQ(result.elf_bytes, image) << "fail-closed must leave the object unchanged";
+}
+
+TEST(BinaryTranslatorE2E, IncompleteIndirectConsumerFailsClosedOnOpenPcBuilderChain) {
+  constexpr uint16_t kPcSreg = 8;
+  constexpr uint16_t kOpenSreg = 10;
+  constexpr uint32_t kLiteralOperand = 255;
+  constexpr uint32_t kInlineInt0 = 128;
+
+  // The s[10:11] getpc at 0x14 is the last instruction of its block, so nothing
+  // in this block proves what its value becomes: this is exactly the shape whose
+  // delta add lives in a successor, where an unmodeled write would leave the
+  // original delta in place. The scope therefore cannot be proven free of stale
+  // PC values and the incomplete consumer must keep failing closed.
+  std::vector<uint32_t> words = {
+      pack_sopp(5, 5),                                 // 0x00: cbranch scc0 -> bypass at 0x18.
+      pack_sop1(0x1c, kPcSreg, 0),                     // 0x04: s_getpc_b64.
+      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand), // 0x08: s_add_u32.
+      36,                                              // 0x0c: target delta -> 0x2c.
+      pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0), // 0x10: s_addc_u32 (chain closed).
+      pack_sop1(0x1c, kOpenSreg, 0),                       // 0x14: bare s_getpc_b64 at block end.
+      pack_sop2(0, kOpenSreg, kOpenSreg, kLiteralOperand), // 0x18: its s_add_u32, next block.
+      12,                                                  // 0x1c.
+      pack_sop2(4, kOpenSreg + 1, kOpenSreg + 1, kInlineInt0), // 0x20: s_addc_u32.
+      pack_sop1(0x1d, 0, kPcSreg),                             // 0x24: joined consumer setpc.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),                // 0x28: not a target.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),                // 0x2c: builder target.
   };
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
   ASSERT_TRUE(source.is_valid());
 
-  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_RDNA4);
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
   auto result = translator.translate(source);
   EXPECT_FALSE(result.ok());
+  ASSERT_FALSE(result.diagnostics.empty());
+  EXPECT_NE(result.diagnostics.front().message.find("unconstrained predecessor path"),
+            std::string::npos)
+      << result.diagnostics.front().message;
   EXPECT_EQ(result.elf_bytes, image) << "fail-closed must leave the object unchanged";
+}
+
+TEST(BinaryTranslatorE2E, IncompleteIndirectConsumerTranslatesWhenScopeHasNoStalePcValues) {
+  constexpr uint16_t kPcSreg = 8;
+  constexpr uint16_t kBypassSreg = 10;
+
+  // Same body, except the bypass builder now targets 0x1c + 0x14 = 0x30, the
+  // same relocatable block start as the consumed builder. Every PC-derived value
+  // in the scope can therefore be rewritten to its relocated address, so no path
+  // into the setpc can deliver a stale one and the dynamic transfer is safe to
+  // keep even though the consumer's own fact stays incomplete.
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      make_incomplete_indirect_consumer_body(0x14));
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << result.diagnostics.front().message;
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  const size_t word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+
+  // Assert the relocated deltas structurally instead of by absolute index: for a
+  // rewritten builder, getpc_next + delta must land on the relocated s_endpgm.
+  const auto expect_builder_targets_endpgm = [&](uint16_t pc_sreg) {
+    const uint32_t getpc = pack_sop1(0x1c, pc_sreg, 0);
+    size_t found = 0;
+    for (size_t i = 0; i + 2 < word_count; ++i) {
+      if (target_words[i] != getpc)
+        continue;
+      ++found;
+      const uint64_t target = (i + 1) * sizeof(uint32_t) + target_words[i + 2];
+      ASSERT_EQ(target % sizeof(uint32_t), 0u);
+      ASSERT_LT(target / sizeof(uint32_t), word_count);
+      EXPECT_EQ(target_words[target / sizeof(uint32_t)],
+                build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3))
+          << "builder for s[" << pc_sreg << ":" << pc_sreg + 1
+          << "] was not rewritten to its relocated target";
+    }
+    EXPECT_EQ(found, 1u);
+  };
+  expect_builder_targets_endpgm(kPcSreg);
+  // The unconsumed builder must be relocated too: it is the producer whose
+  // stale value the fail-closed path exists to prevent.
+  expect_builder_targets_endpgm(kBypassSreg);
+
+  EXPECT_NE(std::find(target_words, target_words + word_count, pack_sop1(0x1d, 0, kPcSreg)),
+            target_words + word_count)
+      << "an incomplete consumer must keep its dynamic transfer, not become a direct window";
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -2352,10 +2352,10 @@ std::vector<uint32_t> make_incomplete_indirect_consumer_body(uint32_t bypass_bui
   constexpr uint32_t kInlineInt0 = 128;
 
   return {
-      pack_sopp(5, 5),                                 // 0x00: cbranch scc0 -> bypass at 0x18.
-      pack_sop1(0x1c, kPcSreg, 0),                     // 0x04: s_getpc_b64.
-      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand), // 0x08: s_add_u32.
-      40,                                              // 0x0c: target delta -> 0x30.
+      pack_sopp(5, 5),                                     // 0x00: cbranch scc0 -> bypass at 0x18.
+      pack_sop1(0x1c, kPcSreg, 0),                         // 0x04: s_getpc_b64.
+      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand),     // 0x08: s_add_u32.
+      40,                                                  // 0x0c: target delta -> 0x30.
       pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0), // 0x10: s_addc_u32.
       build_s_branch(5, ROCJITSU_CODE_ARCH_CDNA4),         // 0x14 -> consumer at 0x2c.
       pack_sop1(0x1c, kBypassSreg, 0),                     // 0x18: bypass-path s_getpc_b64.
@@ -2402,10 +2402,10 @@ TEST(BinaryTranslatorE2E, IncompleteIndirectConsumerFailsClosedOnOpenPcBuilderCh
   // original delta in place. The scope therefore cannot be proven free of stale
   // PC values and the incomplete consumer must keep failing closed.
   std::vector<uint32_t> words = {
-      pack_sopp(5, 5),                                 // 0x00: cbranch scc0 -> bypass at 0x18.
-      pack_sop1(0x1c, kPcSreg, 0),                     // 0x04: s_getpc_b64.
-      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand), // 0x08: s_add_u32.
-      36,                                              // 0x0c: target delta -> 0x2c.
+      pack_sopp(5, 5),                                     // 0x00: cbranch scc0 -> bypass at 0x18.
+      pack_sop1(0x1c, kPcSreg, 0),                         // 0x04: s_getpc_b64.
+      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand),     // 0x08: s_add_u32.
+      36,                                                  // 0x0c: target delta -> 0x2c.
       pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0), // 0x10: s_addc_u32 (chain closed).
       pack_sop1(0x1c, kOpenSreg, 0),                       // 0x14: bare s_getpc_b64 at block end.
       pack_sop2(0, kOpenSreg, kOpenSreg, kLiteralOperand), // 0x18: its s_add_u32, next block.
@@ -2466,8 +2466,7 @@ TEST(BinaryTranslatorE2E, IncompleteIndirectConsumerTranslatesWhenScopeHasNoStal
       const uint64_t target = (i + 1) * sizeof(uint32_t) + target_words[i + 2];
       ASSERT_EQ(target % sizeof(uint32_t), 0u);
       ASSERT_LT(target / sizeof(uint32_t), word_count);
-      EXPECT_EQ(target_words[target / sizeof(uint32_t)],
-                build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3))
+      EXPECT_EQ(target_words[target / sizeof(uint32_t)], build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3))
           << "builder for s[" << pc_sreg << ":" << pc_sreg + 1
           << "] was not rewritten to its relocated target";
     }
@@ -2482,6 +2481,104 @@ TEST(BinaryTranslatorE2E, IncompleteIndirectConsumerTranslatesWhenScopeHasNoStal
             target_words + word_count)
       << "an incomplete consumer must keep its dynamic transfer, not become a direct window";
 }
+
+TEST(BinaryTranslatorE2E, IncompleteIndirectConsumerFailsClosedOnNonContiguousBuilderRange) {
+  constexpr uint16_t kPcSreg = 8;
+  constexpr uint16_t kBypassSreg = 10;
+  constexpr uint16_t kUnrelatedSreg = 20;
+  constexpr uint32_t kLiteralOperand = 255;
+  constexpr uint32_t kInlineInt0 = 128;
+
+  // The bypass builder in s[10:11] targets the relocatable block start at 0x34,
+  // so on its own it would satisfy the whole-scope proof. But an unrelated
+  // s_mov_b32 sits between its s_add_u32 and s_addc_u32: the pair survives that
+  // move (it writes s20, not the pair), so the recovered builder range spans it.
+  // patch_recovered_builder_fixups NOPs the whole range, which would erase the
+  // move. The proof must fail closed on the non-contiguous range, keeping the
+  // incomplete consumer's original refusal and leaving the object unchanged.
+  std::vector<uint32_t> words = {
+      pack_sopp(5, 6),                                     // 0x00: cbranch scc0 -> bypass at 0x1c.
+      pack_sop1(0x1c, kPcSreg, 0),                         // 0x04: s_getpc_b64.
+      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand),     // 0x08: s_add_u32.
+      44,                                                  // 0x0c: target delta -> 0x34.
+      pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0), // 0x10: s_addc_u32.
+      build_s_branch(6, ROCJITSU_CODE_ARCH_CDNA4),         // 0x14 -> consumer at 0x30.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),            // 0x18: padding before bypass.
+      pack_sop1(0x1c, kBypassSreg, 0),                     // 0x1c: bypass s_getpc_b64.
+      pack_sop2(0, kBypassSreg, kBypassSreg, kLiteralOperand), // 0x20: s_add_u32.
+      20,                                                      // 0x24: -> 0x20 + 20 = 0x34.
+      build_s_mov_b32(kUnrelatedSreg, 0,
+                      ROCJITSU_CODE_ARCH_CDNA4), // 0x28: unrelated write, in range.
+      pack_sop2(4, kBypassSreg + 1, kBypassSreg + 1, kInlineInt0), // 0x2c: s_addc_u32.
+      pack_sop1(0x1d, 0, kPcSreg),                                 // 0x30: joined consumer setpc.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),                    // 0x34: builder target.
+  };
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  auto result = translator.translate(source);
+  EXPECT_FALSE(result.ok());
+  ASSERT_FALSE(result.diagnostics.empty());
+  EXPECT_NE(result.diagnostics.front().message.find("unconstrained predecessor path"),
+            std::string::npos)
+      << result.diagnostics.front().message;
+  EXPECT_EQ(result.elf_bytes, image)
+      << "a non-contiguous builder range must fail closed, preserving the unrelated instruction";
+}
+
+TEST(BinaryTranslatorE2E, IncompleteConsumerFailsClosedAtKernargPreloadFirmwareEntry) {
+  // The same incomplete-consumer body that translates when rooted at the ordinary
+  // kernel entry (IncompleteIndirectConsumerTranslatesWhenScopeHasNoStalePcValues)
+  // must instead fail closed when its scope root is the kernarg-preload firmware
+  // entry (descriptor entry + 256). Before that entry runs, the command processor
+  // copies caller-controlled kernarg words into user SGPRs, so the pair the
+  // consumer reads on its unconstrained path can hold an original .text pointer
+  // that no in-scope builder or relocation rewrites. The entry-state gate must not
+  // treat the +256 entry as a safe root.
+  constexpr size_t kPreloadEntryWord = kKernargPreloadSkipBytes / sizeof(uint32_t);
+
+  // Descriptor entry (word 0) is a trivial ordinary path. The incomplete-consumer
+  // body is placed at the +256 preload firmware entry, so it is reachable only
+  // from that root.
+  std::vector<uint32_t> words(kPreloadEntryWord, build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4));
+  words[0] = build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4);
+  const auto body = make_incomplete_indirect_consumer_body(0x14);
+  words.insert(words.end(), body.begin(), body.end());
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  enable_workgroup_id_x_sgpr(image);
+
+  rocjitsu::AmdGpuCodeObject source_layout(image.data(), image.size());
+  ASSERT_TRUE(source_layout.is_valid());
+  const auto *source_rodata = find_section(source_layout, ".rodata");
+  ASSERT_NE(source_rodata, nullptr);
+  auto source_kd = read_kernel_descriptor_for_test(image.data() + source_rodata->sectionOffset());
+  AMDHSA_BITS_SET(source_kd.kernarg_preload, rocr::llvm::amdhsa::KERNARG_PRELOAD_SPEC_LENGTH, 1);
+  write_kernel_descriptor_for_test(image.data() + source_rodata->sectionOffset(), source_kd);
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  auto result = translator.translate(source);
+  EXPECT_FALSE(result.ok());
+  ASSERT_FALSE(result.diagnostics.empty());
+  EXPECT_NE(result.diagnostics.front().message.find("unconstrained predecessor path"),
+            std::string::npos)
+      << result.diagnostics.front().message;
+  EXPECT_EQ(result.elf_bytes, image) << "fail-closed must leave the object unchanged";
+}
+
+// The external-entry soundness gate (rejecting relocation-table-dispatched
+// callees as unconstrained roots) is unit-tested directly in
+// analysis/liveness_test.cpp (BinaryTranslatorInternal.ScopeRootsReject
+// RelocationTableCallee): reaching its rejecting branch end-to-end would require
+// a descriptor-bearing relocation-table dispatch fixture, whereas the pure gate
+// exercises both the accept and reject paths precisely. The entry-state ACCEPT
+// path is already covered end-to-end by
+// IncompleteIndirectConsumerTranslatesWhenScopeHasNoStalePcValues above.
 
 } // namespace
 } // namespace rocjitsu


### PR DESCRIPTION
## Motivation

rocjitsu relocates each kernel's .text into a fresh layout during gfx1250 B0→A0 hotswap translation. An s_swap_pc_i64 s_setpc_b64 whose recovered dataflow fact is incomplete (one predecessor reaches the consumer with the PC pair unconstrained) previously failed the whole kernel with:

error: legalization .text+0xADDR indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated

Ten PyTorch/ATen complex-math kernels (asin/tan/pow on c10::complex) hit this in the gfx1250 B0→A0 hotswap corpus. Origin tracing shows the unconstrained path is a def-free path from a predecessor-less CFG root to the consumer — i.e. a caller-supplied function pointer that no intraprocedural analysis can recover because this function never produces it.

This PR proves the complementary, strictly stronger property and translates those kernels safely instead of refusing them.

## Technical Details

The core idea. The refusal existed because an unrecovered s_getpc_b64 builder is copied verbatim and, after relocation, computes new_pc + old_delta — a stale address. patch_recovered_builder_fixups already rewrites a builder's delta to its relocated target, but only for builders tied to a recovered consumer. Instead of trying to recover the unconstrainable value, this PR proves that every getpc-derived value in the kernel scope is rewritten to its relocated address (scope_relocatable_pc_builders). An incomplete consumer is then safe, because whatever the unconstrained path delivers can only be:

- a value this scope built from a getpc (now relocation-correct),
- an architectural return PC that hardware writes from the already-relocated program counter, or
- a code address loaded from data, whose ELF relocation the code-object patcher rewrites through the same offset map (and refuses when it cannot).

No path can therefore carry an original, unrelocated .text address. The consumer keeps its dynamic transfer and never becomes a direct window (which would redirect a value it never dynamically reaches). The proof runs only for scopes that actually contain an incomplete consumer, so every other scope emits byte-identical output.

Discovery changes. Indirect-branch discovery now reports every PC-address builder it finds — not just the ones a consumer resolves, including producers it could not follow — and BasicBlock carries them (static_pc_address_builders()).

Fail-closed guards (soundness). The proof discharges its obligation per producer and refuses (keeping the original behavior) on each of:
- a producer the analysis could not follow (unresolved / unknown value);
- a non-contiguous builder range — scan_block can keep a builder alive across an unrelated instruction, but the patcher NOPs the whole [begin, end) interval as one run, so a getpc; add; <side effect>; addc shape would erase the intervening instruction. A contiguous flag tracked from each step's offset-adjacency fails the proof closed;
- a cross-block builder range — each builder's getpc and recovery range is bounded to its owning block's [start, end) and that block's own instruction starts, so a range split across a final CFG boundary by a later discovery round cannot be treated as contiguous and overwrite bytes inserted between blocks;
- a target that is not a block start emitted by this scope, or a bare getpc at a block end whose delta add would live in a successor.

External-entry gate. The producer scan only covers values a scope produces, not a value entering the scope in an SGPR.

scope_incomplete_roots_are_entry_state admits an incomplete consumer only when every predecessor-less scope root has architecturally-defined live-[0/1870] SGPRs:
- a hardware kernel entry (ABI-initialized dispatch/kernarg pointers, workgroup ids), or
- a getpc-recovered in-scope call target (entered only through a proven call edge, so its live-in PC pair is the architected return PC).

A relocation-table-dispatched callee (e.g. RCCL ncclDevFuncTable) is explicitly not a safe root even though it has an in-scope CallEdge: the dispatch delivers arbitrary caller-supplied SGPR arguments, so it can carry an original .text pointer on one path. Such callees fail the gate closed. The gate is factored into a pure, unit-testable helper (internal::scope_roots_are_entry_state in binary_translator_internal.h).

## Test Plan / Test Result

- Unit suite: full rocjitsu_tests passes (0 failed, 1 pre-existing skip), including new fail-closed regressions:
- IncompleteIndirectConsumerTranslatesWhenScopeHasNoStalePcValues — the accept path (entry-rooted incomplete consumer keeps its dynamic transfer, both builders relocated).
- IncompleteIndirectConsumerFailsClosed / ...OnOpenPcBuilderChain / ...OnNonContiguousBuilderRange — the refusal paths (stale bypass builder, open chain across a block end, unrelated instruction inside a builder range) all leave the object unchanged.
- BinaryTranslatorInternal.ScopeRootsRejectRelocationTableCallee — drives the pure gate and asserts accept (getpc call target + hardware entry) vs. reject (relocation-table callee root; non-hardware root).
- CfgAnalysis.ReportsResolvedPcAddressBuilderForEveryProducer / UnfollowedPcAddressBuilderIsReportedUnresolved discovery reports every producer with its exact rewrite range and resolved/unresolved status.
- Pre-existing guards unchanged: IncompleteFactConsumerIsFlaggedIncomplete, both KillsCarriedLaneStash.
- Corpus (gfx1250 B0→A0, 20,442 .hsaco): failures drop from 12 → 2. The remaining two are non-kernel inputs (one empty .text section, one object with no kernel descriptors) — not translation bugs. All ten complex-math kernels translate; exit codes are otherwise identical to the pre-change baseline.