### PR TITLE
[rocjitsu][CI] Add gfx1250 b0 a0 dbt rewrite corpus workflow

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -23,7 +23,14 @@ on:
         default: "ROCm/rocjitsu-test-corpus"
         required: true
       corpus_ref:
-        description: "Branch, tag, or SHA to check out from the corpus repository"
+        description: "Branch, tag, or SHA containing the packaged-HSACO DBT suite"
+        # Last updated on 2026/07/27.
+        default: "e1a9a1f7ac9b1d38c7eddf486b529bc3cfcb0c95"
+        required: true
+      legacy_corpus_ref:
+        description: "Branch, tag, or SHA for the existing corpus tests"
+        # TODO: Drop this pin once the workflow's ROCm SDK includes the gfx1250
+        # rocBLAS and hipBLASLt libraries required by the latest corpus.
         # Last updated on 2026/07/17.
         default: "aa54cc86c9ebff3eb840743b36ff8d9b3b2d43c4"
         required: true
@@ -39,7 +46,11 @@ env:
   ROCJITSU_SOURCE_DIR: ${{ github.workspace }}/rocm-systems/emulation/rocjitsu
   ROCJITSU_BUILD_DIR: ${{ github.workspace }}/build
   ROCJITSU_CORPUS_DIR: ${{ github.workspace }}/rocjitsu-test-corpus
+  ROCJITSU_DBT_CORPUS_DIR: ${{ github.workspace }}/rocjitsu-dbt-test-corpus
+  ROCJITSU_DBT_VENV: ${{ github.workspace }}/gfx1250-dbt-venv-${{ github.run_id }}-${{ github.run_attempt }}
+  ROCJITSU_HSACO_CORPUS: ${{ github.workspace }}/gfx1250-packaged-hsacos-${{ github.run_id }}-${{ github.run_attempt }}
   ROCM_SDK_VERSION: 7.14.0a20260624
+  UV_VERSION: 0.9.26
 
 jobs:
   test:
@@ -135,24 +146,38 @@ jobs:
         with:
           repository: ${{ github.event.inputs.corpus_repository || 'ROCm/rocjitsu-test-corpus' }}
           # Last updated on 2026/07/17.
-          ref: ${{ github.event.inputs.corpus_ref || 'aa54cc86c9ebff3eb840743b36ff8d9b3b2d43c4' }}
+          ref: ${{ github.event.inputs.legacy_corpus_ref || 'aa54cc86c9ebff3eb840743b36ff8d9b3b2d43c4' }}
           path: rocjitsu-test-corpus
+
+      - name: Checkout rocjitsu DBT corpus
+        if: matrix.enable_tsan == 0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ github.event.inputs.corpus_repository || 'ROCm/rocjitsu-test-corpus' }}
+          # Last updated on 2026/07/27.
+          ref: ${{ github.event.inputs.corpus_ref || 'e1a9a1f7ac9b1d38c7eddf486b529bc3cfcb0c95' }}
+          path: rocjitsu-dbt-test-corpus
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: ${{ env.UV_VERSION }}
+
       - name: Install ROCm SDK
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install --pre \
+          uv pip install --system --prerelease allow \
             --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
             "rocm[devel,libraries]==${ROCM_SDK_VERSION}"
           ROCM_LIB="$(rocm-sdk path --root)"/lib
           echo "LD_LIBRARY_PATH=${ROCM_LIB}:${LD_LIBRARY_PATH:-}" >> "${GITHUB_ENV}"
 
       - name: Build rocjitsu
+        id: build_rocjitsu
         working-directory: ${{ env.ROCJITSU_SOURCE_DIR }}
         shell: bash
         run: |
@@ -269,9 +294,8 @@ jobs:
         if: matrix.name == 'release'
         working-directory: ${{ env.ROCJITSU_CORPUS_DIR }}
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-          python -m pip install --pre \
+          uv pip install --system -r requirements.txt
+          uv pip install --system --prerelease allow \
             --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
             "rocm-sdk-device-gfx942==${ROCM_SDK_VERSION}" \
             "rocm-sdk-device-gfx950==${ROCM_SDK_VERSION}"
@@ -281,7 +305,8 @@ jobs:
         if: matrix.name == 'release'
         working-directory: ${{ env.ROCJITSU_SOURCE_DIR }}
         run: |
-          cd lib/python && pip install -e . && pytest amdisa/tests
+          uv pip install --system -e lib/python
+          python -m pytest lib/python/amdisa/tests
 
       - name: Run corpus tests
         if: matrix.name == 'release'
@@ -298,7 +323,10 @@ jobs:
 
           corpus_test_status=0
 
-          WORKERS="$(( ($(nproc) + 1) / 2 ))"
+          WORKERS="$(nproc)"
+          if (( WORKERS > 16 )); then
+            WORKERS=16
+          fi
           corpus_test_flags=(
             --workers "${WORKERS}" \
             --soft-timeout 15 \
@@ -307,3 +335,66 @@ jobs:
           )
           bash "${ROCJITSU_SOURCE_DIR}/tests/corpus/run-corpus-tests.sh" "${corpus_test_flags[@]}" || corpus_test_status=$?
           exit "${corpus_test_status}"
+
+      - name: Extract pinned gfx1250 packaged HSACOs
+        id: extract_dbt
+        if: ${{ !cancelled() && matrix.enable_tsan == 0 && steps.build_rocjitsu.outcome == 'success' }}
+        timeout-minutes: 10
+        working-directory: ${{ env.ROCJITSU_DBT_CORPUS_DIR }}
+        shell: bash
+        run: |
+          uv venv --python 3.12 "${ROCJITSU_DBT_VENV}"
+          uv pip install \
+            --python "${ROCJITSU_DBT_VENV}/bin/python" \
+            "pytest>=5.4.1" \
+            "pytest-xdist>=1.32.0"
+          uv pip install \
+            --python "${ROCJITSU_DBT_VENV}/bin/python" \
+            -r "${ROCJITSU_SOURCE_DIR}/tests/corpus/dbt/requirements-gfx1250-dbt.txt"
+          "${ROCJITSU_DBT_VENV}/bin/rocm-sdk" init
+
+          DBT_ROCM_PATH="$("${ROCJITSU_DBT_VENV}/bin/rocm-sdk" path --root)"
+          LD_LIBRARY_PATH="${DBT_ROCM_PATH}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" \
+            "${ROCJITSU_DBT_VENV}/bin/python" \
+            scripts/extract_gfx1250_hsacos.py \
+            --environment "${ROCJITSU_DBT_VENV}" \
+            --destination "${ROCJITSU_HSACO_CORPUS}"
+
+      - name: Run gfx1250 DBT corpus tests
+        if: ${{ !cancelled() && matrix.enable_tsan == 0 && steps.extract_dbt.outcome == 'success' }}
+        timeout-minutes: ${{ matrix.enable_asan == 1 && 20 || 15 }}
+        working-directory: ${{ env.ROCJITSU_DBT_CORPUS_DIR }}
+        shell: bash
+        run: |
+          DBT_ROCM_PATH="$("${ROCJITSU_DBT_VENV}/bin/rocm-sdk" path --root)"
+          DBT_WORKERS="$(nproc)"
+          if (( DBT_WORKERS > 16 )); then
+            DBT_WORKERS=16
+          fi
+          "${ROCJITSU_DBT_VENV}/bin/python" -m pytest tests/test_corpus.py \
+            --target gfx1250 \
+            --suite dbt \
+            --dbt-corpus "${ROCJITSU_HSACO_CORPUS}" \
+            --dbt-translator "${ROCJITSU_BUILD_DIR}/tools/rj_dbt_translate" \
+            --dbt-llvm-objdump "${DBT_ROCM_PATH}/lib/llvm/bin/llvm-objdump" \
+            --dbt-package-lock "${ROCJITSU_SOURCE_DIR}/tests/corpus/dbt/gfx1250_20260726_package_lock.json" \
+            --dbt-expected-failures "${ROCJITSU_SOURCE_DIR}/tests/corpus/dbt/gfx1250_b0_a0_expected_failures.json" \
+            --dbt-expected-rewrites "${ROCJITSU_SOURCE_DIR}/tests/corpus/dbt/gfx1250_b0_a0_expected_rewrites.json" \
+            --dbt-allow-incomplete-corpus \
+            --dbt-timeout "${{ matrix.enable_asan == 1 && 90 || 30 }}" \
+            --artifact-directory .pytest-artifacts/gfx1250-dbt \
+            -n "${DBT_WORKERS}" \
+            -q \
+            -rxX \
+            --tb=short
+
+      # Debugging aid only. The pinned extraction is reproducible, so retain
+      # translator logs but never upload the extracted HSACOs.
+      - name: Upload gfx1250 DBT diagnostic logs
+        if: always() && matrix.enable_tsan == 0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gfx1250-dbt-logs-${{ matrix.name }}
+          path: ${{ env.ROCJITSU_DBT_CORPUS_DIR }}/.pytest-artifacts/gfx1250-dbt
+          if-no-files-found: ignore
+          retention-days: 7

--- a/emulation/rocjitsu/tests/corpus/dbt/gfx1250_20260726_package_lock.json
+++ b/emulation/rocjitsu/tests/corpus/dbt/gfx1250_20260726_package_lock.json
@@ -1,0 +1,22 @@
+{
+  "baseline_manifest_sha256": "f7beed8fe664445ba5150d52786e2c7450ef1e0c5367defebd9974d2b52db8d8",
+  "expected_unique_code_objects": {
+    "materialized": {
+      "minimum": 20000
+    },
+    "skipped": {
+      "exact": 20000
+    }
+  },
+  "packages": {
+    "amd-torch-device-gfx1250": "2.12.0+rocm7.15.0a20260726",
+    "rocm": "7.15.0a20260726",
+    "rocm-sdk-core": "7.15.0a20260726",
+    "rocm-sdk-devel": "7.15.0a20260726",
+    "rocm-sdk-device-gfx1250": "7.15.0a20260726",
+    "rocm-sdk-libraries": "7.15.0a20260726",
+    "torch": "2.12.0+rocm7.15.0a20260726",
+    "triton": "3.8.0+git4cff872c.rocm7.15.0a20260726"
+  },
+  "schema_version": 1
+}

--- a/emulation/rocjitsu/tests/corpus/dbt/gfx1250_b0_a0_expected_failures.json
+++ b/emulation/rocjitsu/tests/corpus/dbt/gfx1250_b0_a0_expected_failures.json
@@ -1,0 +1,78 @@
+{
+  "expected_failures": {
+    "2bff3e6611af6c6de83ff384fd5b659f9c42441c3553cf41c779047d4432b78b": {
+      "kind": "memory-limit",
+      "reason": "RCCL code object exceeds the per-object DBT memory limit in indirect-branch discovery"
+    },
+    "522bdabb8ec787b512c8c0535a5adf2e72985f33d931461accde47216b8c7cf0": {
+      "kind": "translation-error",
+      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
+      "returncode": 3,
+      "stderr_regex": "legalization \\.text\\+0x17c28 indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
+    },
+    "5b24ad46e20c38dd3acb6a8b67cf9b27d90aca146186d773bc009514c355492f": {
+      "kind": "translation-error",
+      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
+      "returncode": 3,
+      "stderr_regex": "legalization \\.text\\+0x2b760 indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
+    },
+    "5bbd0cf23d3b5bc1b62a3f56151a1beba8781d833c35575f2d47979693241018": {
+      "kind": "translation-error",
+      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
+      "returncode": 3,
+      "stderr_regex": "legalization \\.text\\+0xee28 indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
+    },
+    "5d2a4110c0d8274651992689ae47abfb014cd36584338a725d77cecdec9718aa": {
+      "kind": "translation-error",
+      "reason": "PyTorch object currently exposes no non-empty text section",
+      "returncode": 3,
+      "stderr_regex": "resource-limit: code object does not expose a non-empty \\.text section for translation"
+    },
+    "88a3928b98afde04c3bb92d0134aa1b04b1342ce83eacd389857bcb9023e3f97": {
+      "kind": "translation-error",
+      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
+      "returncode": 3,
+      "stderr_regex": "legalization \\.text\\+0x85828 indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
+    },
+    "af9e659f75ad449b591d855208fb122fd27d7e66422b687ee643054a5df4a2f7": {
+      "kind": "translation-error",
+      "reason": "rocFFT object currently has no kernel descriptors",
+      "returncode": 3,
+      "stderr_regex": "kernel-descriptor: kernel descriptors are required for kernel-level translation"
+    },
+    "c1896e26ef64eb5998bdff6cfbe54c39f672f7f189eb54801d8f37a96210892b": {
+      "kind": "translation-error",
+      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
+      "returncode": 3,
+      "stderr_regex": "legalization \\.text\\+0x21260 indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
+    },
+    "dacb8abe8349d5a5448113d60173bb9d651caa1a81b64db015fe915909c41c8a": {
+      "kind": "translation-error",
+      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
+      "returncode": 3,
+      "stderr_regex": "legalization \\.text\\+0x3f460 indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
+    },
+    "e6efa69e5ae03f61c907ed0e9175711a3e65d6294c2d04f0b83cc1f607ef6258": {
+      "kind": "translation-error",
+      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
+      "returncode": 3,
+      "stderr_regex": "legalization \\.text\\+0x34860 indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
+    },
+    "e78a60937e78d5026df75de19d604f3a7e90284f231074fab87a2ae5bb34a0ef": {
+      "kind": "translation-error",
+      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
+      "returncode": 3,
+      "stderr_regex": "legalization \\.text\\+0x35473c indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
+    },
+    "f15ec0007d25e530da9f3e3c517bb0c1a603df74013b944d68953216e1beae0e": {
+      "kind": "translation-error",
+      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
+      "returncode": 3,
+      "stderr_regex": "legalization \\.text\\+0x28b4ac indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
+    }
+  },
+  "input_revision": "b0",
+  "output_revision": "a0",
+  "schema_version": 1,
+  "target": "gfx1250"
+}

--- a/emulation/rocjitsu/tests/corpus/dbt/gfx1250_b0_a0_expected_rewrites.json
+++ b/emulation/rocjitsu/tests/corpus/dbt/gfx1250_b0_a0_expected_rewrites.json
@@ -1,0 +1,23 @@
+{
+  "expected_rewrites": {
+    "00023c9f3fc277f35d928cca3a2e5614bba26b581e71abd3bbcff3fe3a417405": {
+      "instructions_requiring_rewrite": 9
+    },
+    "00045dc998d1757d07529707db095b0ccfe75efbe920276a2415d67d4ec716f3": {
+      "instructions_requiring_rewrite": 891
+    },
+    "072f1bfcde3c4f062c5aaa29b354ddd0f5ed19388d58647eba3c06c2e94a2fca": {
+      "instructions_requiring_rewrite": 304
+    },
+    "1c2a9f4347fddcb05799148110648013771317cb5c0065a8ff29e22b73c3933d": {
+      "instructions_requiring_rewrite": 56
+    },
+    "f7cdacd90fb93aabab5bb5856a6655fed3e9e27688e76c6c76423711305d9127": {
+      "instructions_requiring_rewrite": 316
+    }
+  },
+  "input_revision": "b0",
+  "output_revision": "a0",
+  "schema_version": 1,
+  "target": "gfx1250"
+}

--- a/emulation/rocjitsu/tests/corpus/dbt/requirements-gfx1250-dbt.txt
+++ b/emulation/rocjitsu/tests/corpus/dbt/requirements-gfx1250-dbt.txt
@@ -1,0 +1,4 @@
+--index-url https://rocm.nightlies.amd.com/whl-multi-arch/
+
+amd-torch-device-gfx1250==2.12.0+rocm7.15.0a20260726
+rocm-sdk-devel==7.15.0a20260726


### PR DESCRIPTION
## Motivation

Exercise gfx1250 B0-to-A0 translation against the code objects shipped in pinned TheRock and PyTorch wheels.

## Technical Details

- Extract the corpus inside every RocJITsu matrix job and keep HSACOs local to that job.
- Run the pytest DBT checks with TheRock llvm-objdump and upload diagnostic logs only.

## Issue Tracking

N/A

## Test Plan

Validate the workflow and reproduce extraction plus translation locally with the pinned 20,000-object corpus.

## Test Result

Passed. Workflow hooks passed; the local corpus reported 19,988 passes and 12 expected xfails.

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
