### PR TITLE
fix(amdsmi): emit valid JSON for ras --afid --folder --json with no readable files

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -14,6 +14,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Resolved Issues
 
+- **Fixed `amd-smi ras --afid --folder --json` emitting nothing when no CPER files are readable**.  
+  - When every `.cper` file in the folder was skipped (e.g. rejected as a symlink), the JSON path printed empty output, so consumers feeding stdout to `json.loads` failed with `Expecting value: line 1 column 1 (char 0)`. It now emits `[]` for that case, matching the `--cper --json` contract.
+
 - **Fixed `amd-smi static --vram` reporting `GDDR7` for LPDDR5 unified memory on APUs (e.g. gfx117x)**.  
   - `AMDSMI_VRAM_TYPE__MAX` aliases the highest real memory type (`LPDDR5`), so a genuine LPDDR5 reading was matched by the `__MAX` special case and mislabeled `GDDR7`. It is now correctly reported as `LPDDR5`.
 

--- a/projects/amdsmi/amdsmi_cli/subcommands/ras.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/ras.py
@@ -117,7 +117,7 @@ class RasCommands:
 
         if self.logger.is_json_format():
             self.logger.multiple_device_output = results
-            self.logger.print_output(multiple_device_enabled=True)
+            self.logger.print_output(multiple_device_enabled=True, emit_empty=True)
         else:
             print(f"{'file_name':<32} list of afids")
             for entry in results:

--- a/projects/amdsmi/tests/python/unit/gpu/test_cli_ras_cper_json.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_cli_ras_cper_json.py
@@ -25,6 +25,7 @@ import io
 import json
 import os
 import sys
+import tempfile
 import types
 import unittest
 
@@ -298,6 +299,24 @@ class TestCliRasCperJson(unittest.TestCase):
             self.assertEqual(buffer.getvalue(), "")
         finally:
             self.ras_module.time.sleep = original_sleep
+
+    def test_afid_folder_all_files_skipped_emits_empty_json(self):
+        # --afid --folder --json where every *.cper is a symlink: O_NOFOLLOW
+        # skips them all, so results is empty. It must still print exactly `[]`
+        # so json.loads consumers don't choke on empty output.
+        with tempfile.TemporaryDirectory() as folder:
+            link = os.path.join(folder, "planted.cper")
+            os.symlink(os.devnull, link)
+
+            commands = self._make_commands()
+            args = argparse.Namespace(folder=folder)
+            buffer = io.StringIO()
+            with contextlib.redirect_stdout(buffer):
+                commands._decode_afid_folder(args)
+            captured = buffer.getvalue()
+
+        self.assertEqual(captured.strip(), "[]")
+        self.assertEqual(json.loads(captured), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`amd-smi ras --cper --json` was recently fixed (#8819) to always emit one valid JSON document so consumers can pipe stdout to `json.loads`. The sibling `--afid --folder --json` path has the same latent bug: when every `.cper` file in the folder is skipped (e.g. rejected as a symlink by `O_NOFOLLOW`), the JSON path printed nothing and `json.loads` failed with `Expecting value: line 1 column 1 (char 0)`.

## Technical Details

- `amdsmi_cli/subcommands/ras.py`: `_decode_afid_folder` now passes `emit_empty=True` on its JSON `print_output` call, so an empty result renders as `[]` instead of nothing. This reuses the opt-in logger flag added in #8819; no logger changes are needed.
- The empty-folder case (no `.cper` files at all) still raises `AmdSmiInvalidFilePathException` as before. This fix only affects the case where files exist but are all skipped as unreadable.

Python-CLI-only; the C library, C API, ctypes wrapper, and Rust/Go bindings are untouched.

## Issue Tracking

JIRA ID: DCGPUSDV-4010

## Test Plan

New unit test `tests/python/unit/gpu/test_cli_ras_cper_json.py::test_afid_folder_all_files_skipped_emits_empty_json` (real `AMDSMILogger` in JSON mode, driver boundary faked; no GPU/root/library). It plants a symlinked `.cper` in a temp folder (skipped by `O_NOFOLLOW`) and asserts stdout is exactly `[]` and `json.loads` succeeds.

```
python3 -m pytest tests/python/unit/gpu/test_cli_ras_cper_json.py -q
```

## Test Result

`5 passed` (proven RED against the pre-fix path: the new assertion fails with `'' != '[]'`).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
