### PR TITLE
fix(amdsmi): show rated cap for --rocm-smi PwrCap on APUs

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -16,6 +16,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Fixed
 
+- **Fixed `amd-smi --rocm-smi` reporting a `PwrCap` of `0.0W` on MI300-series APUs**.
+  - MI300A leaves the enforced power cap (sysfs `power1_cap`) at 0 because no standalone GPU cap is exposed, so the concise `PwrCap` column showed `0.0W`. When the current cap reads 0 it now falls back to the factory default cap (`power1_cap_default`), so the column shows the rated ceiling (e.g. `550.0W`). Devices that report a non-zero cap are unaffected.
+
 - **Fixed `amd-smi ras --cper --json` emitting nothing when there are no CPER entries**.
   - The common no-entries case printed empty output, so consumers feeding stdout to `json.loads` failed with `Expecting value: line 1 column 1 (char 0)`. The command now always emits exactly one valid JSON document: `[]` when there are no entries, or a single aggregated array across all GPUs when there are. `--follow` mode stays silent until entries appear. The human-readable primary-partition warning is also suppressed in JSON mode so it no longer corrupts the output.
 

--- a/projects/amdsmi/amdsmi_cli/amdsmi_rocm_smi_compat.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_rocm_smi_compat.py
@@ -722,7 +722,13 @@ def get_power_cap(processor):
 
         power_cap_info = amdsmi.amdsmi_get_power_cap_info(processor)
         if "power_cap" in power_cap_info:
-            return power_cap_info["power_cap"] / 1000000.0
+            # power_cap is the currently-enforced cap (sysfs power1_cap). MI300-series
+            # APUs leave it at 0 because no standalone GPU cap is exposed; fall back to
+            # the factory default so the column shows the rated ceiling, not 0.
+            cap = power_cap_info["power_cap"]
+            if cap == 0:
+                cap = power_cap_info.get("default_power_cap") or 0
+            return cap / 1000000.0 if cap else None
         return None
     except:
         return None


### PR DESCRIPTION
## Motivation

`amd-smi process` (and the process table in default `amd-smi` output) could
return "No running processes detected" for a caller that lacks permission to
inspect the running GPU jobs, even though the jobs were clearly using the GPUs.
The compute-process table also mis-rendered its `CU %` and `SDMA` columns.

## Technical Details

- `rocm_smi/src/rocm_smi_kfd.cc`
  - `IsKfdPidNamespaced()` inspected the first KFD PID via `PidHasKfdOpen()`,
    which opens `/proc/<pid>/fd`. When that PID belongs to another user, the
    directory is unreadable and the helper returned `false`, which was
    misinterpreted as evidence of a separate PID namespace. Enumeration then
    fell back to scanning `/proc`, where the same unreadable fd set dropped the
    process entirely, so the caller saw an empty list.
  - Add a tri-state `PidKfdOpenState()` distinguishing "has `/dev/kfd` open",
    "definitely does not", and "inaccessible" (another user's process, or the
    process already exited). Permission failures are now treated as inconclusive
    and skipped rather than flagged as namespaced, so such processes are listed
    with a redacted (`N/A`) name instead of disappearing.

- `amdsmi_cli/amdsmi_logger.py`
  - Rebuild the process-table header so labels sit over their right-justified
    value columns (the `SDMA` header was one column too far left), drop the
    redundant `%` suffix from the CU value (the unit is in the `CU %` header),
    and widen `SDMA` to fit its unit by reclaiming two characters from the
    process-name column. The row stays within the fixed 80-character box.

## JIRA ID

JIRA ID: AILITOOLS-281

## Test Plan

- On a multi-GPU host running a root-owned compute workload, ran
  `amd-smi process` and the default `amd-smi` process table as a **non-root**
  user and as **root**.
- Verified column alignment for both the `N/A` and populated `CU %`/`SDMA` cases.

## Test Result

- Non-root now lists the root-owned process on every GPU with `NAME: N/A`; root
  continues to show the full process name. Previously non-root saw
  "No running processes detected".
- `CU %` and `SDMA` headers align over their values within the 80-character box;
  valid values are no longer truncated.
