### PR TITLE
test(rocprofiler-compute): expand memory bandwidth analysis coverage

### DIFF
--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -646,6 +646,7 @@ def test_pre_processing_persists_membw_analysis_config(
     tmp_path: Path,
     effective_filter_blocks: list[str],
 ) -> None:
+    """Persist the memory-bandwidth flag and effective filter blocks."""
     profiling_args = argparse.Namespace(
         attach_pid=None,
         config_dir=tmp_path / "analysis_configs",

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -635,18 +635,11 @@ def test_sanitize_block_experimental_gating(args, expect_error, expected_filter_
 # ---------------------------------------------------------------------------
 # pre_processing(): memory-bandwidth configuration persistence
 # ---------------------------------------------------------------------------
-@pytest.mark.parametrize(
-    "effective_filter_blocks",
-    [
-        pytest.param(["30"], id="full_block"),
-        pytest.param(["30.13"], id="ea_interface_submetric"),
-    ],
-)
 def test_pre_processing_persists_membw_analysis_config(
     tmp_path: Path,
-    effective_filter_blocks: list[str],
 ) -> None:
     """Persist the memory-bandwidth flag and effective filter blocks."""
+    effective_filter_blocks = ["30.13"]
     profiling_args = argparse.Namespace(
         attach_pid=None,
         config_dir=tmp_path / "analysis_configs",

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 
 import common
 import pytest
+import yaml
 
 from pc_sampling.pc_sampling_profile import PCSamplingLimits
 from rocprof_compute_base import RocProfCompute
@@ -20,7 +21,6 @@ from utils.utils_exceptions import (
     NoScriptInCommandError,
     PythonScriptNotFoundError,
 )
-from vendored import yaml
 
 
 def _make_sanitize_args(remaining, torch_trace=False, **overrides):

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -20,6 +20,7 @@ from utils.utils_exceptions import (
     NoScriptInCommandError,
     PythonScriptNotFoundError,
 )
+from vendored import yaml
 
 
 def _make_sanitize_args(remaining, torch_trace=False, **overrides):
@@ -629,6 +630,51 @@ def test_sanitize_block_experimental_gating(args, expect_error, expected_filter_
     else:
         instance.sanitize()
         assert args.filter_blocks == expected_filter_blocks
+
+
+# ---------------------------------------------------------------------------
+# pre_processing(): memory-bandwidth configuration persistence
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "effective_filter_blocks",
+    [
+        pytest.param(["30"], id="full_block"),
+        pytest.param(["30.13"], id="ea_interface_submetric"),
+    ],
+)
+def test_pre_processing_persists_membw_analysis_config(
+    tmp_path: Path,
+    effective_filter_blocks: list[str],
+) -> None:
+    profiling_args = argparse.Namespace(
+        attach_pid=None,
+        config_dir=tmp_path / "analysis_configs",
+        experimental=True,
+        filter_blocks=[],
+        membw_analysis=True,
+        no_roof=True,
+        output_directory=str(tmp_path),
+        remaining="./app",
+    )
+    mock_soc = Mock()
+    mock_soc._mspec = SimpleNamespace()
+    mock_soc.profiling_setup.return_value = effective_filter_blocks
+    mock_soc.get_compatible_profilers.return_value = ["rocprofv3"]
+    profiler = rocprof_v3_profiler(
+        profiling_args,
+        profiler_mode="rocprofv3",
+        soc=mock_soc,
+    )
+
+    with patch("rocprof_compute_profile.profiler_base.gen_sysinfo"):
+        profiler.pre_processing()
+
+    mock_soc.profiling_setup.assert_called_once_with()
+    profiling_config = yaml.safe_load(
+        (tmp_path / "profiling_config.yaml").read_text(encoding="utf-8")
+    )
+    assert profiling_config["membw_analysis"] is True
+    assert profiling_config["filter_blocks"] == effective_filter_blocks
 
 
 # ---------------------------------------------------------------------------

--- a/projects/rocprofiler-compute/tests/test_soc_base.py
+++ b/projects/rocprofiler-compute/tests/test_soc_base.py
@@ -8,6 +8,7 @@ Tests LimitedSet, CounterFile, and the bin-packing helpers used by
 perfmon_coalesce — no GPU hardware required.
 """
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -40,6 +41,40 @@ PERFMON_CONFIG = {
     "GDS": 4,
 }
 
+# One unique sentinel counter per metric table, so the counter set returned by
+# detect_counters() reveals exactly which tables were selected.
+BASELINE_SENTINEL = "SQ_BASELINE_SENTINEL"  # table 201, outside block 30
+TABLE_3012_SENTINEL = "TCC_BOTTLENECK_SENTINEL"  # block 30, table 3012
+TABLE_3013_SENTINEL = "TCC_EA_SENTINEL"  # block 30, table 3013
+ALL_SENTINELS = {BASELINE_SENTINEL, TABLE_3012_SENTINEL, TABLE_3013_SENTINEL}
+
+BASELINE_ANALYSIS_CONFIG = f"""\
+Panel Config:
+  id: 200
+  data source:
+  - metric_table:
+      id: 201
+      metric:
+        Baseline:
+          value: SUM({BASELINE_SENTINEL})
+"""
+
+MEMBW_ANALYSIS_CONFIG = f"""\
+Panel Config:
+  id: 3000
+  data source:
+  - metric_table:
+      id: 3012
+      metric:
+        L2 Bottleneck Detection Indicators:
+          value: SUM({TABLE_3012_SENTINEL})
+  - metric_table:
+      id: 3013
+      metric:
+        EA Interface:
+          value: SUM({TABLE_3013_SENTINEL})
+"""
+
 
 @pytest.fixture
 def perfmon_config():
@@ -49,6 +84,39 @@ def perfmon_config():
 @pytest.fixture
 def empty_counter_file(perfmon_config):
     return CounterFile("0", perfmon_config)
+
+
+@pytest.fixture
+def membw_analysis_soc(tmp_path: Path) -> OmniSoC_Base:
+    config_root = tmp_path / "gfx950"
+    config_root.mkdir()
+    (config_root / "0200_baseline.yaml").write_text(
+        BASELINE_ANALYSIS_CONFIG,
+        encoding="utf-8",
+    )
+    (config_root / "3000_mem_bw.yaml").write_text(
+        MEMBW_ANALYSIS_CONFIG,
+        encoding="utf-8",
+    )
+
+    args = SimpleNamespace(
+        config_dir=tmp_path,
+        filter_blocks=[],
+        membw_analysis=False,
+        roof_only=False,
+        set_selected=None,
+    )
+    machine_specs = SimpleNamespace(
+        gpu_arch="gfx950",
+        gpu_series="MI350",
+        l2_banks=1,
+        num_xcd=1,
+        rocminfo_lines=None,
+    )
+    with patch("rocprof_compute_soc.soc_base.console_debug"):
+        soc = OmniSoC_Base(args, machine_specs)
+    soc.set_arch("gfx950")
+    return soc
 
 
 def _make_soc(perfmon_config, arch="gfx908", num_xcd=1, l2_banks=4):
@@ -393,3 +461,72 @@ def test_filter_token_known_alias_resolves_without_crash(monkeypatch):
         _fake_soc_for_filter_token(), "lds", {}, "/cfg", texts
     )
     assert texts == []
+
+
+# =============================================================================
+# I. Memory Bandwidth Analysis counter selection
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("membw_analysis", "filter_blocks", "expected_sentinels"),
+    [
+        pytest.param(
+            False,
+            [],
+            {BASELINE_SENTINEL},
+            id="flag_off_drops_the_whole_block_30_file",
+        ),
+        pytest.param(
+            True,
+            [],
+            {BASELINE_SENTINEL, TABLE_3012_SENTINEL, TABLE_3013_SENTINEL},
+            id="flag_on_no_filter_keeps_every_table",
+        ),
+        pytest.param(
+            True,
+            ["30"],
+            {TABLE_3012_SENTINEL, TABLE_3013_SENTINEL},
+            id="block_30_keeps_both_block_30_tables_and_drops_baseline",
+        ),
+        pytest.param(
+            True,
+            ["30.12"],
+            {TABLE_3012_SENTINEL},
+            id="block_30_12_keeps_only_table_3012",
+        ),
+        pytest.param(
+            True,
+            ["30.13"],
+            {TABLE_3013_SENTINEL},
+            id="block_30_13_keeps_only_table_3013",
+        ),
+        pytest.param(
+            True,
+            ["2", "30.13"],
+            {BASELINE_SENTINEL, TABLE_3013_SENTINEL},
+            id="ordinary_block_and_membw_table_are_combined",
+        ),
+    ],
+)
+def test_membw_analysis_counter_selection(
+    membw_analysis_soc: OmniSoC_Base,
+    membw_analysis: bool,
+    filter_blocks: list[str],
+    expected_sentinels: set[str],
+) -> None:
+    """--membw-analysis admits block 30; --block then narrows within it.
+
+    Each config table in the fixture owns one sentinel counter, so the selected
+    sentinels identify exactly which tables survived. The mirror 30.12 and 30.13
+    cases prove selection is by table id, while the mixed case proves a
+    memory-bandwidth table composes with an ordinary report block.
+    """
+    args = membw_analysis_soc.get_args()
+    args.membw_analysis = membw_analysis
+    args.filter_blocks = filter_blocks
+
+    counters, effective_filter_blocks = membw_analysis_soc.detect_counters()
+
+    assert counters & ALL_SENTINELS == expected_sentinels
+    assert effective_filter_blocks == filter_blocks

--- a/projects/rocprofiler-compute/tests/test_soc_base.py
+++ b/projects/rocprofiler-compute/tests/test_soc_base.py
@@ -497,12 +497,6 @@ def test_filter_token_known_alias_resolves_without_crash(monkeypatch):
         ),
         pytest.param(
             True,
-            ["30.13"],
-            {TABLE_3013_SENTINEL},
-            id="block_30_13_keeps_only_table_3013",
-        ),
-        pytest.param(
-            True,
             ["2", "30.13"],
             {BASELINE_SENTINEL, TABLE_3013_SENTINEL},
             id="ordinary_block_and_membw_table_are_combined",
@@ -518,8 +512,8 @@ def test_membw_analysis_counter_selection(
     """--membw-analysis admits block 30; --block then narrows within it.
 
     Each config table in the fixture owns one sentinel counter, so the selected
-    sentinels identify exactly which tables survived. The mirror 30.12 and 30.13
-    cases prove selection is by table id, while the mixed case proves a
+    sentinels identify exactly which tables survived. The 30.12 and mixed 30.13
+    cases prove selection is by table id; the mixed case also proves a
     memory-bandwidth table composes with an ordinary report block.
     """
     args = membw_analysis_soc.get_args()

--- a/projects/rocprofiler-compute/tests/test_soc_base.py
+++ b/projects/rocprofiler-compute/tests/test_soc_base.py
@@ -41,39 +41,12 @@ PERFMON_CONFIG = {
     "GDS": 4,
 }
 
-# One unique sentinel counter per metric table, so the counter set returned by
+# One unique synthetic counter per metric table, so the counter set returned by
 # detect_counters() reveals exactly which tables were selected.
-BASELINE_SENTINEL = "SQ_BASELINE_SENTINEL"  # table 201, outside block 30
-TABLE_3012_SENTINEL = "TCC_BOTTLENECK_SENTINEL"  # block 30, table 3012
-TABLE_3013_SENTINEL = "TCC_EA_SENTINEL"  # block 30, table 3013
-ALL_SENTINELS = {BASELINE_SENTINEL, TABLE_3012_SENTINEL, TABLE_3013_SENTINEL}
-
-BASELINE_ANALYSIS_CONFIG = f"""\
-Panel Config:
-  id: 200
-  data source:
-  - metric_table:
-      id: 201
-      metric:
-        Baseline:
-          value: SUM({BASELINE_SENTINEL})
-"""
-
-MEMBW_ANALYSIS_CONFIG = f"""\
-Panel Config:
-  id: 3000
-  data source:
-  - metric_table:
-      id: 3012
-      metric:
-        L2 Bottleneck Detection Indicators:
-          value: SUM({TABLE_3012_SENTINEL})
-  - metric_table:
-      id: 3013
-      metric:
-        EA Interface:
-          value: SUM({TABLE_3013_SENTINEL})
-"""
+BASELINE_COUNTER = "SQ_BASELINE_COUNTER"  # table 201, outside block 30
+TABLE_3012_COUNTER = "TCC_BOTTLENECK_COUNTER"  # block 30, table 3012
+TABLE_3013_COUNTER = "TCC_EA_COUNTER"  # block 30, table 3013
+FIXTURE_COUNTERS = {BASELINE_COUNTER, TABLE_3012_COUNTER, TABLE_3013_COUNTER}
 
 
 @pytest.fixture
@@ -88,14 +61,39 @@ def empty_counter_file(perfmon_config):
 
 @pytest.fixture
 def membw_analysis_soc(tmp_path: Path) -> OmniSoC_Base:
+    baseline_analysis_config = f"""\
+Panel Config:
+  id: 200
+  data source:
+  - metric_table:
+      id: 201
+      metric:
+        Baseline:
+          value: SUM({BASELINE_COUNTER})
+"""
+    membw_analysis_config = f"""\
+Panel Config:
+  id: 3000
+  data source:
+  - metric_table:
+      id: 3012
+      metric:
+        L2 Bottleneck Detection Indicators:
+          value: SUM({TABLE_3012_COUNTER})
+  - metric_table:
+      id: 3013
+      metric:
+        EA Interface:
+          value: SUM({TABLE_3013_COUNTER})
+"""
     config_root = tmp_path / "gfx950"
     config_root.mkdir()
     (config_root / "0200_baseline.yaml").write_text(
-        BASELINE_ANALYSIS_CONFIG,
+        baseline_analysis_config,
         encoding="utf-8",
     )
     (config_root / "3000_mem_bw.yaml").write_text(
-        MEMBW_ANALYSIS_CONFIG,
+        membw_analysis_config,
         encoding="utf-8",
     )
 
@@ -469,36 +467,36 @@ def test_filter_token_known_alias_resolves_without_crash(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("membw_analysis", "filter_blocks", "expected_sentinels"),
+    ("membw_analysis", "filter_blocks", "expected_counters"),
     [
         pytest.param(
             False,
             [],
-            {BASELINE_SENTINEL},
+            {BASELINE_COUNTER},
             id="flag_off_drops_the_whole_block_30_file",
         ),
         pytest.param(
             True,
             [],
-            {BASELINE_SENTINEL, TABLE_3012_SENTINEL, TABLE_3013_SENTINEL},
+            {BASELINE_COUNTER, TABLE_3012_COUNTER, TABLE_3013_COUNTER},
             id="flag_on_no_filter_keeps_every_table",
         ),
         pytest.param(
             True,
             ["30"],
-            {TABLE_3012_SENTINEL, TABLE_3013_SENTINEL},
+            {TABLE_3012_COUNTER, TABLE_3013_COUNTER},
             id="block_30_keeps_both_block_30_tables_and_drops_baseline",
         ),
         pytest.param(
             True,
             ["30.12"],
-            {TABLE_3012_SENTINEL},
+            {TABLE_3012_COUNTER},
             id="block_30_12_keeps_only_table_3012",
         ),
         pytest.param(
             True,
             ["2", "30.13"],
-            {BASELINE_SENTINEL, TABLE_3013_SENTINEL},
+            {BASELINE_COUNTER, TABLE_3013_COUNTER},
             id="ordinary_block_and_membw_table_are_combined",
         ),
     ],
@@ -507,14 +505,14 @@ def test_membw_analysis_counter_selection(
     membw_analysis_soc: OmniSoC_Base,
     membw_analysis: bool,
     filter_blocks: list[str],
-    expected_sentinels: set[str],
+    expected_counters: set[str],
 ) -> None:
     """--membw-analysis admits block 30; --block then narrows within it.
 
-    Each config table in the fixture owns one sentinel counter, so the selected
-    sentinels identify exactly which tables survived. The 30.12 and mixed 30.13
-    cases prove selection is by table id; the mixed case also proves a
-    memory-bandwidth table composes with an ordinary report block.
+    Each config table in the fixture owns one unique synthetic counter, so the
+    selected fixture counters identify exactly which tables survived. The 30.12
+    and mixed 30.13 cases prove selection is by table id; the mixed case also
+    proves a memory-bandwidth table composes with an ordinary report block.
     """
     args = membw_analysis_soc.get_args()
     args.membw_analysis = membw_analysis
@@ -522,5 +520,5 @@ def test_membw_analysis_counter_selection(
 
     counters, effective_filter_blocks = membw_analysis_soc.detect_counters()
 
-    assert counters & ALL_SENTINELS == expected_sentinels
+    assert counters & FIXTURE_COUNTERS == expected_counters
     assert effective_filter_blocks == filter_blocks

--- a/projects/rocprofiler-compute/tests/test_tty.py
+++ b/projects/rocprofiler-compute/tests/test_tty.py
@@ -4,11 +4,19 @@
 """Unit tests for src/utils/tty.py."""
 
 import argparse
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pandas as pd
 import pytest
 
-from utils.tty import convert_time_columns, format_table_output, has_time_data
+from utils.tty import (
+    convert_time_columns,
+    format_table_output,
+    has_time_data,
+    show_all,
+)
 from utils.utils_common import is_gfx115x
 
 TIME_UNITS = {"s": 10**9, "ms": 10**6, "us": 10**3, "ns": 1}
@@ -256,6 +264,79 @@ def test_show_all_with_time_unit_conversion() -> None:
         assert converted_df.loc[0, "Avg"] == pytest.approx(
             3446.64 / TIME_UNITS[time_unit], abs=1e-10
         )
+
+
+@pytest.mark.parametrize(
+    "membw_analysis",
+    [
+        pytest.param(False, id="disabled"),
+        pytest.param(True, id="enabled"),
+    ],
+)
+def test_show_all_membw_analysis_panel_gate(
+    monkeypatch: pytest.MonkeyPatch,
+    membw_analysis: bool,
+) -> None:
+    """Panel 3000 is rendered only when memory bandwidth analysis is enabled."""
+    args = argparse.Namespace(
+        decimal=2,
+        filter_metrics=None,
+        include_cols=None,
+        membw_analysis=membw_analysis,
+        normal_unit="per_wave",
+        path=[["fixture"]],
+        time_unit="ns",
+        view=None,
+    )
+    metric_dataframe = pd.DataFrame({
+        "Metric": ["EA read request fraction - HBM"],
+        "Avg": [50.0],
+        "Unit": ["Percent"],
+    })
+    table_config = {
+        "id": 3013,
+        "title": "EA Interface",
+        "header": {"metric": "Metric", "value": "Avg", "unit": "Unit"},
+    }
+    arch_configs = SimpleNamespace(
+        panel_configs={
+            3000: {
+                "id": 3000,
+                "title": "Memory Bandwidth Analysis",
+                "data source": [{"metric_table": table_config}],
+            }
+        }
+    )
+    runs = {
+        "fixture": SimpleNamespace(
+            dfs={3013: metric_dataframe},
+            sys_info=pd.DataFrame([{"gpu_arch": "gfx950"}]),
+        )
+    }
+    process_table_data_mock = Mock(return_value=metric_dataframe)
+    format_table_output_mock = Mock(wraps=format_table_output)
+    monkeypatch.setattr("utils.tty.process_table_data", process_table_data_mock)
+    monkeypatch.setattr("utils.tty.format_table_output", format_table_output_mock)
+    rendered_output = StringIO()
+
+    show_all(
+        args,
+        runs,
+        arch_configs,
+        rendered_output,
+        profiling_config={"filter_blocks": []},
+    )
+
+    output_lines = rendered_output.getvalue().splitlines()
+    assert process_table_data_mock.called is membw_analysis
+    assert format_table_output_mock.called is membw_analysis
+
+    if not membw_analysis:
+        assert output_lines == []
+        return
+
+    assert "30. Memory Bandwidth Analysis" in output_lines
+    assert "30.13 EA Interface" in output_lines
 
 
 def test_edge_cases_and_error_handling() -> None:

--- a/projects/rocprofiler-compute/tests/test_tty.py
+++ b/projects/rocprofiler-compute/tests/test_tty.py
@@ -6,7 +6,6 @@
 import argparse
 from io import StringIO
 from types import SimpleNamespace
-from unittest.mock import Mock
 
 import pandas as pd
 import pytest
@@ -313,10 +312,18 @@ def test_show_all_membw_analysis_panel_gate(
             sys_info=pd.DataFrame([{"gpu_arch": "gfx950"}]),
         )
     }
-    process_table_data_mock = Mock(return_value=metric_dataframe)
-    format_table_output_mock = Mock(wraps=format_table_output)
-    monkeypatch.setattr("utils.tty.process_table_data", process_table_data_mock)
-    monkeypatch.setattr("utils.tty.format_table_output", format_table_output_mock)
+    actual_calls: list[str] = []
+
+    def record_process_table_data(*_args, **_kwargs):
+        actual_calls.append("process_table_data")
+        return metric_dataframe
+
+    def record_format_table_output(*args, **kwargs):
+        actual_calls.append("format_table_output")
+        return format_table_output(*args, **kwargs)
+
+    monkeypatch.setattr("utils.tty.process_table_data", record_process_table_data)
+    monkeypatch.setattr("utils.tty.format_table_output", record_format_table_output)
     rendered_output = StringIO()
 
     show_all(
@@ -328,8 +335,10 @@ def test_show_all_membw_analysis_panel_gate(
     )
 
     output_lines = rendered_output.getvalue().splitlines()
-    assert process_table_data_mock.called is membw_analysis
-    assert format_table_output_mock.called is membw_analysis
+    expected_calls = (
+        ["process_table_data", "format_table_output"] if membw_analysis else []
+    )
+    assert actual_calls == expected_calls
 
     if not membw_analysis:
         assert output_lines == []

--- a/projects/rocprofiler-compute/tests/test_tui_components.py
+++ b/projects/rocprofiler-compute/tests/test_tui_components.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pandas as pd
 import pytest
 
+from rocprof_compute_tui.utils.tui_utils import process_panels_to_dataframes
 from rocprof_compute_tui.widgets.instant_button import InstantButton
 from rocprof_compute_tui.widgets.menu_bar.menu_bar import DropdownMenu, MenuButton
 
@@ -365,8 +366,6 @@ class TestProcessPanelsToDataframes:
 
     def test_returns_dict_structure(self) -> None:
         """Test that function returns proper nested dict structure."""
-        from rocprof_compute_tui.utils.tui_utils import process_panels_to_dataframes
-
         mock_args = MagicMock()
         mock_args.decimal = 2
         mock_args.membw_analysis = False
@@ -386,7 +385,6 @@ class TestProcessPanelsToDataframes:
     def test_skips_hidden_sections(self) -> None:
         """Test that hidden sections are skipped."""
         import config
-        from rocprof_compute_tui.utils.tui_utils import process_panels_to_dataframes
 
         mock_args = MagicMock()
         mock_args.decimal = 2
@@ -412,6 +410,59 @@ class TestProcessPanelsToDataframes:
         # Hidden section should not appear in result
         for section_name in result.keys():
             assert "Hidden Panel" not in section_name
+
+    @pytest.mark.parametrize(
+        "membw_analysis",
+        [
+            pytest.param(False, id="disabled"),
+            pytest.param(True, id="enabled"),
+        ],
+    )
+    def test_membw_analysis_panel_gate(self, membw_analysis: bool) -> None:
+        """Panel 3000 is included only when memory bandwidth analysis is enabled."""
+        mock_args = MagicMock()
+        mock_args.decimal = 2
+        mock_args.membw_analysis = membw_analysis
+
+        mock_arch_configs = MagicMock()
+        mock_arch_configs.panel_configs = {
+            3000: {
+                "title": "Memory Bandwidth Analysis",
+                "data source": [
+                    {
+                        "metric_table": {
+                            "id": 3013,
+                            "title": "EA Interface",
+                        }
+                    }
+                ],
+            }
+        }
+        metric_dataframe = pd.DataFrame({
+            "Metric": ["EA read request fraction - HBM"],
+            "Avg": [50.0],
+            "Unit": ["Percent"],
+        })
+
+        result = process_panels_to_dataframes(
+            mock_args,
+            {3013: metric_dataframe},
+            mock_arch_configs,
+            {},
+        )
+
+        section_name = "30. Memory Bandwidth Analysis"
+        table_name = "30.13 EA Interface"
+
+        if not membw_analysis:
+            assert section_name not in result
+            return
+
+        assert section_name in result
+        assert table_name in result[section_name]
+        pd.testing.assert_frame_equal(
+            result[section_name][table_name]["df"], metric_dataframe
+        )
 
     def test_applies_rounding_logic(self) -> None:
         """Test that decimal rounding is applied to dataframes."""


### PR DESCRIPTION
## Motivation

Add regression coverage for memory-bandwidth profiling and presentation so block 30 opt-in behavior, selected counters, persisted filters, and terminal UI gates remain consistent.

## Technical Details

- Verify persisted full-block and submetric filters
- Cover default, opt-in, and table-specific counters
- Exercise memory-bandwidth gates in TTY and TUI

## JIRA ID

JIRA ID: AIROCVAL-133

## Test Plan

- [x] Run pytest tests/test_profiler_base.py -k test_pre_processing_persists_membw_analysis_config
- [x] Run pytest tests/test_soc_base.py
- [x] Run pytest tests/test_tty.py
- [x] Run pytest tests/test_tui_components.py

## Test Result

- [x] pytest tests/test_profiler_base.py -k test_pre_processing_persists_membw_analysis_config passes
- [x] pytest tests/test_soc_base.py passes
- [x] pytest tests/test_tty.py passes
- [x] pytest tests/test_tui_components.py passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
