### PR TITLE
fix(hrr): [ROCM-27985] order replay zero-init before later replayed events

### DIFF
--- a/projects/clr/hipamd/src/hrr/playback/hip_playback.cpp
+++ b/projects/clr/hipamd/src/hrr/playback/hip_playback.cpp
@@ -1160,6 +1160,7 @@ static bool hrr_replay_zero_init() {
 // this: it waits for both operations to finish but does not order them. The
 // ordering edge has to be established here, at the allocation.
 static void hrr_zero_init_alloc(PlaybackContext& ctx, void* live, size_t sz) {
+    if (!live || sz == 0) return;  // nothing written, so nothing to order
     if (!hrr_zero_init_needs_drain(hrr_replay_zero_init(), ctx.in_graph_capture))
         return;
     if (hipMemsetAsync(live, 0, sz, nullptr) != hipSuccess) return;

--- a/projects/clr/hipamd/src/hrr/playback/hip_playback.cpp
+++ b/projects/clr/hipamd/src/hrr/playback/hip_playback.cpp
@@ -1138,6 +1138,34 @@ static bool hrr_replay_zero_init() {
     return g_enabled;
 }
 
+// Zero-initialise a host-synchronous replay allocation, ordered.
+//
+// ROCM-27985. hipMalloc is host-synchronous by contract, so the recorded
+// program is free to use the returned pointer immediately from any stream
+// without establishing an ordering edge. The zero-init injected here must
+// therefore be complete before the allocation handler returns.
+//
+// A bare hipMemset does not give that. ihipMemset() promotes a memset on a
+// fresh, non-offset device allocation to asynchronous ("spec says hipMemset
+// will be asynchronous when destination memory is device memory and pointer is
+// non-offseted"), so it is only enqueued on the null stream and the host
+// returns immediately. Streams the capture created with hipStreamNonBlocking do
+// not synchronize with the null stream, so a later replayed H2D restore or
+// kernel launch on such a stream races the zero-init. When the zero-init lands
+// last it overwrites the restored input with zeros and the consuming kernel
+// computes from zeros, which surfaces downstream as a replay D2H validation
+// mismatch against the captured output.
+//
+// Draining after the H2D restore (hrr_sync_after_replayed_h2d) does not fix
+// this: it waits for both operations to finish but does not order them. The
+// ordering edge has to be established here, at the allocation.
+static void hrr_zero_init_alloc(PlaybackContext& ctx, void* live, size_t sz) {
+    if (!hrr_zero_init_needs_drain(hrr_replay_zero_init(), ctx.in_graph_capture))
+        return;
+    if (hipMemsetAsync(live, 0, sz, nullptr) != hipSuccess) return;
+    (void)hipStreamSynchronize(nullptr);
+}
+
 // ---- Divergence-abort guard -------------------------------------------------
 // Replaying a numerically-unstable workload (e.g. a model emitting degenerate
 // output) cannot reproduce bit-identical results from nondeterministic GPU
@@ -1225,13 +1253,10 @@ static hipError_t replay_malloc(PlaybackContext& ctx, const uint8_t* pl,
         // hipMalloc does NOT guarantee zeroed memory (only first-touch pages are
         // scrubbed; reused allocations carry stale bytes). Zero so replay is
         // deterministic and matches first-touch-zeroed assumptions. See
-        // hrr_replay_zero_init().
-        // Skip the zero-init memset while a graph capture is active: the original
-        // run never issued it, and an injected synchronous device memset during
-        // capture is illegal and invalidates the capture (HIP 901) for every
-        // subsequent op in the graph.
-        if (hrr_replay_zero_init() && !ctx.in_graph_capture)
-            (void)hipMemset(live, 0, pad_sz);
+        // hrr_replay_zero_init(). The zero-init is skipped during graph capture,
+        // where the original run never issued it and an injected memset would
+        // invalidate the capture (HIP 901) for every subsequent op in the graph.
+        hrr_zero_init_alloc(ctx, live, pad_sz);
         ctx.record_alloc(a->ptr, live, pad_sz);
         if (ctx.verbose && pad_sz > orig_sz)
             fprintf(stderr, "[HRR] hipMalloc 0x%llx: orig=%zu padded=%zu\n",
@@ -1261,8 +1286,7 @@ hipError_t playback_hipExtMallocWithFlags(PlaybackContext& ctx, const uint8_t* p
     void* live = nullptr;
     hipError_t r = hipExtMallocWithFlags(&live, pad_sz, a->flags);
     if (r == hipSuccess) {
-        if (hrr_replay_zero_init() && !ctx.in_graph_capture)
-            (void)hipMemset(live, 0, pad_sz);
+        hrr_zero_init_alloc(ctx, live, pad_sz);
         ctx.record_alloc(a->ptr, live, pad_sz);
         if (ctx.verbose && pad_sz > orig_sz)
             fprintf(stderr, "[HRR] hipExtMallocWithFlags 0x%llx: orig=%zu padded=%zu\n",
@@ -1277,6 +1301,12 @@ hipError_t playback_hipExtMallocWithFlags(PlaybackContext& ctx, const uint8_t* p
 // ---------------------------------------------------------------------------
 // hipMallocAsync:  ret(4) dev_ptr(8) size(8) stream(8)
 // hipMallocFromPoolAsync: ret(4) dev_ptr(8) size(8) mem_pool(8) stream(8)
+//
+// These do not need hrr_zero_init_alloc()'s drain (ROCM-27985): the zero-init is
+// enqueued on the allocating stream, and stream-ordered allocations are only
+// usable on that stream until the recorded program itself establishes an
+// ordering edge to another stream. Replaying that edge carries the zero-init
+// with it, so it is already ordered ahead of every recorded use.
 
 hipError_t playback_hipMallocAsync(PlaybackContext& ctx,
                                    const uint8_t* pl) {

--- a/projects/clr/hipamd/src/hrr/playback/hip_playback.h
+++ b/projects/clr/hipamd/src/hrr/playback/hip_playback.h
@@ -28,6 +28,21 @@ inline bool hrr_replayed_h2d_needs_drain(bool in_graph_capture) {
     return !in_graph_capture;
 }
 
+// Whether the zero-init injected after a host-synchronous replay allocation
+// (hipMalloc / hipMallocManaged / hipExtMallocWithFlags) must be drained before
+// the allocation handler returns. hipMemset on a fresh, non-offset device
+// allocation is promoted to asynchronous by ihipMemset(), so it is only
+// enqueued on the null stream; a recorded hipStreamNonBlocking stream never
+// synchronizes with the null stream, leaving the zero-init unordered against
+// every later replayed event. Skipped while a stream graph capture is active,
+// where the zero-init is not issued at all. Kept as a small pure predicate so
+// the guard is unit-testable without a GPU. See hrr_zero_init_alloc() in
+// hip_playback.cpp.
+inline bool hrr_zero_init_needs_drain(bool zero_init_enabled,
+                                      bool in_graph_capture) {
+    return zero_init_enabled && !in_graph_capture;
+}
+
 // ---------------------------------------------------------------------------
 // PlaybackContext — central replay state
 // ---------------------------------------------------------------------------

--- a/projects/hip-tests/catch/config/configs/unit/hrr.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/hrr.yaml
@@ -42,6 +42,9 @@ hrr:
   Unit_HRR_Playback_ReplayedH2DDrainGraphGuard:
     <<: *level_2
     tags: [playback, cpu]
+  Unit_HRR_Playback_ZeroInitDrainGuard:
+    <<: *level_2
+    tags: [playback, cpu]
   Unit_HRR_Recovery_CompleteArchive:
     <<: *level_2
     tags: [format, recovery, cpu]
@@ -66,10 +69,11 @@ hrr:
   Unit_HRR_CaptureReplayRoundtrip:
     <<: *level_2
     tags: [capture, playback, roundtrip]
-    # ROCM-27985: intermittent replay D2H failure on gfx1250/MI450, a runtime
-    # H2D->kernel input-coherency gap not addressed by the playback drain fix.
-    # Quarantined on gfx1250 only (other archs still run it) until the runtime
-    # fix lands; tracked in ROCM-27985.
+    # ROCM-27985: intermittent replay D2H failure on gfx1250/MI450. The replay
+    # zero-init ordering fix in this change removes a defect with exactly this
+    # signature, but that has not yet been confirmed against the MI450 stack
+    # that reproduces the original failure. Stays quarantined on gfx1250 only
+    # (other archs still run it) until it is; tracked in ROCM-27985.
     disabled: [gfx1250]
   Unit_HRR_GraphRoundtrip:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/hrr.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/hrr.yaml
@@ -69,12 +69,6 @@ hrr:
   Unit_HRR_CaptureReplayRoundtrip:
     <<: *level_2
     tags: [capture, playback, roundtrip]
-    # ROCM-27985: intermittent replay D2H failure on gfx1250/MI450. The replay
-    # zero-init ordering fix in this change removes a defect with exactly this
-    # signature, but that has not yet been confirmed against the MI450 stack
-    # that reproduces the original failure. Stays quarantined on gfx1250 only
-    # (other archs still run it) until it is; tracked in ROCM-27985.
-    disabled: [gfx1250]
   Unit_HRR_GraphRoundtrip:
     <<: *level_2
     tags: [capture, graph, playback, roundtrip]

--- a/projects/hip-tests/catch/unit/hrr/hrr_playback_test.cc
+++ b/projects/hip-tests/catch/unit/hrr/hrr_playback_test.cc
@@ -25,6 +25,22 @@ HIP_TEST_CASE(Unit_HRR_Playback_ReplayedH2DDrainGraphGuard) {
   REQUIRE_FALSE(hrr_replayed_h2d_needs_drain(true));
 }
 
+// ROCM-27985: hipMalloc is host-synchronous, so the zero-init injected after a
+// host-synchronous replay allocation must be drained before the handler
+// returns. Without that edge the null-stream zero-init races every later
+// replayed event on a hipStreamNonBlocking stream and can overwrite a restored
+// kernel input with zeros. Draining is skipped when zero-init is turned off and
+// during graph capture, where the zero-init is never issued.
+HIP_TEST_CASE(Unit_HRR_Playback_ZeroInitDrainGuard) {
+  // Normal replay: the zero-init must be ordered ahead of later events.
+  REQUIRE(hrr_zero_init_needs_drain(true, false));
+  // HIP_HRR_REPLAY_ZERO_INIT=0: nothing was issued, so nothing to drain.
+  REQUIRE_FALSE(hrr_zero_init_needs_drain(false, false));
+  // During graph capture: zero-init is skipped and a sync would be illegal.
+  REQUIRE_FALSE(hrr_zero_init_needs_drain(true, true));
+  REQUIRE_FALSE(hrr_zero_init_needs_drain(false, true));
+}
+
 /**
  * End doxygen group HRR.
  * @}


### PR DESCRIPTION
## Motivation

HRR replay zero-initialises every fresh allocation so a replayed kernel cannot read stale bytes from a reused page. For the host-synchronous allocators it does that with a bare `hipMemset`.

`ihipMemset()` promotes a memset on a fresh, non-offset device allocation to asynchronous, so it is only enqueued on the null stream and the host returns immediately. `hipMalloc` is host-synchronous by contract, so the recorded program may use the pointer straight away from any stream, and streams the capture created with `hipStreamNonBlocking` never synchronize with the null stream. The zero-init is therefore unordered against every later replayed event. When it lands after a replayed H2D restore it overwrites the restored kernel input with zeros, the consuming kernel computes from zeros, and D2H validation mismatches against the captured output.

This is the remaining half of ROCM-27985. The drain added in #8547 waits for the H2D restore and the zero-init to both finish but does not order them, which is why `Unit_HRR_CaptureReplayRoundtrip` still failed and had to be quarantined.

## Technical Details

`hrr_zero_init_alloc()` issues the zero-init and drains it before the allocation handler returns. Used by `hipMalloc`, `hipMallocManaged` and `hipExtMallocWithFlags`. The existing graph-capture guard is kept, and empty allocations skip it entirely.

`hipMallocAsync` and `hipMallocFromPoolAsync` are unchanged: their zero-init is enqueued on the allocating stream, so the recorded program's own ordering carries it.

The guard is a pure predicate, `hrr_zero_init_needs_drain()`, covered by a CPU-only test.

Removes the gfx1250 quarantine on `Unit_HRR_CaptureReplayRoundtrip` added by #8547.

## Issue Tracking

JIRA ID: ROCM-27985

This PR fixes following issue as well: 
JIRA ID: ROCM-28712

## Test Plan

Interleaved A/B on a gfx1250 system, arms alternated round by round so drift hits both equally. The failure only appears under concurrent replay, so runs are 12 replays in flight; sequential suite runs never fail on this hardware.

## Test Result

Genuine D2H validation mismatches. No setup failures in any arm.

| configuration | scale | without fix | with fix |
|---|---|---|---|
| `Unit_HRR_CaptureReplayRoundtrip` alone | 1200 executions/arm | 10 | 0 |
| all four affected tests | 1200 runs/arm | 180 | 0 |
| all four affected tests, final code | 600 runs/arm | 95 | 0 |

Full suite with the quarantine removed: 66/66 pass, 10 consecutive runs. Sequential baseline without the fix: 20 full suites, 0 failures, confirming the failure needs concurrency to surface.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.