### PR TITLE
fix(ci): disable MI455 test runner - machine is down

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -205,7 +205,8 @@ jobs:
     with:
       projects_to_test: "hip-tests, rocrtst"
       amdgpu_families: gfx125X-dcgpu
-      test_runs_on: linux-mi455-gpu-rocm
+      # MI455 machine is down - disabled until back online (was: linux-mi455-gpu-rocm)
+      test_runs_on: ""
       platform: linux
       artifact_run_id: ${{ github.run_id }}
 

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -117,6 +117,7 @@ jobs:
       ref: main
       # TEMPORARY: MI455 bringup - pass family_overrides to configure test runner and limited tests
       # TODO(geomin12): Remove family_overrides once MI455 is in therock-ci-config
+      # NOTE: MI455 machine is down - test-runs-on set to "" until back online (was: linux-mi455-gpu-rocm)
       external_repo: >-
         {
           "repository": "${{ github.repository }}",
@@ -124,7 +125,7 @@ jobs:
           "family_overrides": {
             "gfx125x": {
               "linux": {
-                "test-runs-on": "linux-mi455-gpu-rocm",
+                "test-runs-on": "",
                 "test_labels_for_family": ["test:hip-tests", "test:rocrtst"],
                 "fetch-gfx-targets": ["gfx1250"]
               }


### PR DESCRIPTION
Set test_runs_on to empty string to prevent jobs from queuing on the unavailable MI455 runner. Original label preserved in comments for easy restoration.