### PR TITLE
clr: strip obsolete -fbin-amdil/-fno-bin-amdil options to prevent build failure

### DIFF
--- a/projects/clr/rocclr/platform/program.cpp
+++ b/projects/clr/rocclr/platform/program.cpp
@@ -19,21 +19,26 @@
 
 namespace amd {
 
-static void remove_g_option(std::string& option) {
-  // Remove " -g " option from application.
-  // People can still add -g in AMD_OCL_BUILD_OPTIONS_APPEND, if it is so desired.
-  std::string g_str("-g");
-  std::size_t g_pos = 0;
-  while ((g_pos = option.find(g_str, g_pos)) != std::string::npos) {
-    if ((g_pos == 0 || option[g_pos - 1] == ' ') &&
-        (g_pos + 2 == option.size() || option[g_pos + 2] == ' ')) {
-      option.erase(g_pos, g_str.size());
+static void remove_token(std::string& option, const std::string& token) {
+  std::size_t pos = 0;
+  while ((pos = option.find(token, pos)) != std::string::npos) {
+    if ((pos == 0 || option[pos - 1] == ' ') &&
+        (pos + token.size() == option.size() || option[pos + token.size()] == ' ')) {
+      option.erase(pos, token.size());
     } else {
-      g_pos += g_str.size();
+      pos += token.size();
     }
   }
+}
 
-  return;
+static void sanitize_options(std::string& option) {
+  // Remove " -g " option from application.
+  // People can still add -g in AMD_OCL_BUILD_OPTIONS_APPEND, if it is so desired.
+  remove_token(option, "-g");
+
+  // Remove obsolete AMDIL binary options no longer recognized by the parser.
+  remove_token(option, "-fbin-amdil");
+  remove_token(option, "-fno-bin-amdil");
 }
 
 Program::~Program() {
@@ -166,7 +171,7 @@ static bool adjustOptionsOnIgnoreEnv(std::string& cppstr) {
       cppstr = cppstr.substr(pos + sizeof(ignore_env));
       optionChangable = false;
     }
-    remove_g_option(cppstr);
+    sanitize_options(cppstr);
   }
   return optionChangable;
 }


### PR DESCRIPTION
## Motivation
-fbin-amdil/-fno-bin-amdil are no longer recognized build options.
Strip the obsolete flag before parsing.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Leveraged the existing remove_g_option mechanism (now renamed to sanitize_options) to strip -fbin-amdil and -fno-bin-amdil before the options string reaches the parser.
<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking
ROCM-27806
<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan
3dcarvectorblur.nk test for Nuke 15
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Passed.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
