### PR TITLE
ci: harden GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/apply-labels.yml
+++ b/.github/workflows/apply-labels.yml
@@ -10,10 +10,13 @@ on:
 
 permissions:
   contents: read
-  issues: write
+
 jobs:
   apply-labels:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - name: Checkout super-repo

--- a/.github/workflows/apply-labels.yml
+++ b/.github/workflows/apply-labels.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: '.github/labels.yml'
 
+permissions:
+  issues: write
+
 jobs:
   apply-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/apply-labels.yml
+++ b/.github/workflows/apply-labels.yml
@@ -9,8 +9,8 @@ on:
         default: '.github/labels.yml'
 
 permissions:
+  contents: read
   issues: write
-
 jobs:
   apply-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/aqlprofile-codeql.yml
+++ b/.github/workflows/aqlprofile-codeql.yml
@@ -12,6 +12,12 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+  security-events: write
+  packages: read
+  actions: read
+
 env:
   EXCLUDED_PATHS: ""
 

--- a/.github/workflows/aqlprofile-codeql.yml
+++ b/.github/workflows/aqlprofile-codeql.yml
@@ -14,9 +14,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
-  packages: read
-  actions: read
 
 env:
   EXCLUDED_PATHS: ""

--- a/.github/workflows/aqlprofile-continuous_integration.yml
+++ b/.github/workflows/aqlprofile-continuous_integration.yml
@@ -23,6 +23,9 @@ on:
       - '.github/workflows/aqlprofile-continuous_integration.yml'
       - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -7,6 +7,9 @@ on:
     workflows: ["ABI Compliance Check"]
     types: [completed]
 
+permissions:
+  contents: read
+
 jobs:
   apply-labels:
     runs-on: ubuntu-22.04

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,10 @@ on:
       - '.github/workflows/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  security-events: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/collect-labels.yml
+++ b/.github/workflows/collect-labels.yml
@@ -10,10 +10,13 @@ on:
 
 permissions:
   contents: read
-  issues: read
+
 jobs:
   collect-labels:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
 
     steps:
       - name: Checkout super-repo

--- a/.github/workflows/collect-labels.yml
+++ b/.github/workflows/collect-labels.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: '.github/repos-config.json'
 
+permissions:
+  issues: read
+
 jobs:
   collect-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/collect-labels.yml
+++ b/.github/workflows/collect-labels.yml
@@ -9,8 +9,8 @@ on:
         default: '.github/repos-config.json'
 
 permissions:
+  contents: read
   issues: read
-
 jobs:
   collect-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/hip-formatting.yml
+++ b/.github/workflows/hip-formatting.yml
@@ -8,6 +8,9 @@ on:
       - 'projects/hipother/**'
       - 'projects/hip-tests/**'
 
+permissions:
+  contents: read
+
 jobs:
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/hip-validate-pr-description.yml
+++ b/.github/workflows/hip-validate-pr-description.yml
@@ -9,6 +9,9 @@ on:
       - "projects/hipother/**"
       - "projects/hip-tests/**"
 
+permissions:
+  contents: read
+
 jobs:
   validate-pr-description:
     runs-on: ubuntu-latest

--- a/.github/workflows/import-prep-workflow-disable.yml
+++ b/.github/workflows/import-prep-workflow-disable.yml
@@ -7,6 +7,9 @@ name: "Import Prep: Disable workflows"
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   disable-workflows:
     runs-on: ubuntu-24.04

--- a/.github/workflows/import-prep-workflow-enable.yml
+++ b/.github/workflows/import-prep-workflow-enable.yml
@@ -7,6 +7,9 @@ name: "Import Prep: Enable workflows"
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   disable-workflows:
     runs-on: ubuntu-24.04

--- a/.github/workflows/import_pr_list.yml
+++ b/.github/workflows/import_pr_list.yml
@@ -20,7 +20,8 @@ on:
         required: false
         default: "develop"
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   import-prs:

--- a/.github/workflows/import_pr_list.yml
+++ b/.github/workflows/import_pr_list.yml
@@ -20,6 +20,8 @@ on:
         required: false
         default: "develop"
 
+permissions: {}
+
 jobs:
   import-prs:
     runs-on: ubuntu-latest

--- a/.github/workflows/initial-setup.yml
+++ b/.github/workflows/initial-setup.yml
@@ -3,6 +3,9 @@ name: Setup super-repo
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   SUPER_REPO_URL: github.com/ROCm/rocm-systems.git
   SUPER_REPO_BRANCH: develop

--- a/.github/workflows/issue-import.yml
+++ b/.github/workflows/issue-import.yml
@@ -37,6 +37,8 @@ on:
         description: 'Issue number to import'
         required: true
 
+permissions: {}
+
 jobs:
   import:
     runs-on: ubuntu-24.04

--- a/.github/workflows/issue-import.yml
+++ b/.github/workflows/issue-import.yml
@@ -37,7 +37,8 @@ on:
         description: 'Issue number to import'
         required: true
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   import:

--- a/.github/workflows/kpack-ci.yml
+++ b/.github/workflows/kpack-ci.yml
@@ -12,6 +12,9 @@ on:
       - 'shared/kpack/**'
       - '.github/workflows/kpack-ci.yml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,6 +3,9 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   labeler:
     permissions:

--- a/.github/workflows/lstt-formatting.yml
+++ b/.github/workflows/lstt-formatting.yml
@@ -13,6 +13,9 @@ on:
       - "!**/*.rst"
       - "!**/.readthedocs.yaml"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/media-libs-ci.yml
+++ b/.github/workflows/media-libs-ci.yml
@@ -77,7 +77,6 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/therock-ci-linux.yml
-    secrets: inherit
     with:
       package_version: ${{ needs.setup.outputs.package_version }}
       cmake_options: >

--- a/.github/workflows/merge-codeowners.yml
+++ b/.github/workflows/merge-codeowners.yml
@@ -3,6 +3,9 @@ name: Merge CODEOWNERS Files
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   merge-codeowners:
     runs-on: ubuntu-latest

--- a/.github/workflows/merge-submodules.yml
+++ b/.github/workflows/merge-submodules.yml
@@ -3,6 +3,9 @@ name: Merge .gitmodules
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   combine-gitmodules:
     runs-on: ubuntu-latest

--- a/.github/workflows/merge-submodules.yml
+++ b/.github/workflows/merge-submodules.yml
@@ -4,11 +4,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   combine-gitmodules:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout super-repo
         uses: actions/checkout@v4

--- a/.github/workflows/new-subtree-setup-release.yml
+++ b/.github/workflows/new-subtree-setup-release.yml
@@ -3,6 +3,9 @@ name: Setup additional release subtrees for super-repo
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   SUPER_REPO_URL: github.com/ROCm/rocm-systems.git
   SUPER_REPO_BRANCH: release/rocm-rel-7.0

--- a/.github/workflows/new-subtree-setup.yml
+++ b/.github/workflows/new-subtree-setup.yml
@@ -3,6 +3,9 @@ name: Setup additional subtrees for super-repo
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   SUPER_REPO_URL: github.com/ROCm/rocm-systems.git
   SUPER_REPO_BRANCH: develop

--- a/.github/workflows/pr-import.yml
+++ b/.github/workflows/pr-import.yml
@@ -44,6 +44,9 @@ on:
         required: false
         default: "develop"
 
+permissions:
+  contents: read
+
 jobs:
   import:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pr-merge-sync-patches-manual.yml
+++ b/.github/workflows/pr-merge-sync-patches-manual.yml
@@ -36,6 +36,9 @@ on:
         description: 'Pull request number to rerun patch logic for'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   rerun-patch:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pr-merge-sync-patches.yml
+++ b/.github/workflows/pr-merge-sync-patches.yml
@@ -33,6 +33,9 @@ on:
     branches:
       - 'develop'
 
+permissions:
+  contents: read
+
 concurrency:
   group: pr-merge-sync-patch-${{ github.sha }}
   cancel-in-progress: false

--- a/.github/workflows/pr-org-label.yml
+++ b/.github/workflows/pr-org-label.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     - cron: "*/30 * * * *"  # every 30 minutes
 
+permissions: {}
+
 jobs:
   label-prs:
     if: github.repository == 'ROCm/rocm-systems'

--- a/.github/workflows/pr-org-label.yml
+++ b/.github/workflows/pr-org-label.yml
@@ -8,7 +8,8 @@ on:
   schedule:
     - cron: "*/30 * * * *"  # every 30 minutes
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   label-prs:

--- a/.github/workflows/pre-formatting.yml
+++ b/.github/workflows/pre-formatting.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches:
       - testbranch
+
+permissions:
+  contents: write
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-formatting.yml
+++ b/.github/workflows/pre-formatting.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: write
-
+  pull-requests: read
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-formatting.yml
+++ b/.github/workflows/pre-formatting.yml
@@ -5,11 +5,13 @@ on:
       - testbranch
 
 permissions:
-  contents: write
-  pull-requests: read
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
 #      - name: Generate a token
 #        id: generate-token

--- a/.github/workflows/rdc-dme-sync-check.yml
+++ b/.github/workflows/rdc-dme-sync-check.yml
@@ -10,6 +10,10 @@ on:
       - 'projects/rdc/tools/dme_rdc_metric_mapping.json'
       - 'projects/rdc/tools/dme_rdc_metric_sync_check.py'
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   sync-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/rdc-dme-sync-check.yml
+++ b/.github/workflows/rdc-dme-sync-check.yml
@@ -12,11 +12,13 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   sync-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Checkout rocm-systems
         uses: actions/checkout@v4

--- a/.github/workflows/rocjitsu-formatting.yml
+++ b/.github/workflows/rocjitsu-formatting.yml
@@ -13,6 +13,9 @@ on:
       - ".github/workflows/rocjitsu-*.yml"
       - ".pre-commit-config.yaml"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rocm_ci_caller.yml
+++ b/.github/workflows/rocm_ci_caller.yml
@@ -5,7 +5,8 @@ on:
     types: [opened, synchronize, reopened]
     branches: [develop]
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   trigger-rocm-ci:

--- a/.github/workflows/rocm_ci_caller.yml
+++ b/.github/workflows/rocm_ci_caller.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, synchronize, reopened]
     branches: [develop]
 
+permissions: {}
+
 jobs:
   trigger-rocm-ci:
     runs-on: azure-vms

--- a/.github/workflows/rocprof-trace-decoder-continuous_integration.yml
+++ b/.github/workflows/rocprof-trace-decoder-continuous_integration.yml
@@ -23,6 +23,9 @@ on:
       - '.github/actions/rocprofiler-sdk-util/action.yml'
       - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rocprofiler-compute-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-compute-continuous-integration.yml
@@ -48,6 +48,9 @@ on:
       - '!projects/rocprofiler-compute/docker/**'
       - '!projects/rocprofiler-compute/CMakePresets.json'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -91,6 +94,7 @@ jobs:
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
     permissions:
+      contents: read
       packages: read
     container:
       image: ghcr.io/rocm/rocprofiler-ubuntu:${{ matrix.system.os-release }}-compute-ci-multiarch

--- a/.github/workflows/rocprofiler-compute-ghcr.yml
+++ b/.github/workflows/rocprofiler-compute-ghcr.yml
@@ -25,6 +25,9 @@ on:
       - '.github/workflows/rocprofiler-compute-ghcr.yml'
       - 'projects/rocprofiler-compute/docker/**'
 
+permissions:
+  contents: read
+
 jobs:
   prepare_matrix_ci:
     if: github.repository == 'ROCm/rocm-systems'

--- a/.github/workflows/rocprofiler-compute-rhel.yml
+++ b/.github/workflows/rocprofiler-compute-rhel.yml
@@ -33,7 +33,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -48,6 +47,9 @@ jobs:
     # The type of runner that the job will run on
     # Using rocprofiler-systems images and later installing rocm, the official rocm images for al8 red hat variant are too large- this is a workaround.
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     container:
       image: ghcr.io/rocm/rocprofiler-rhel:${{ matrix.os-release }}-compute-ci-base
     strategy:

--- a/.github/workflows/rocprofiler-compute-rhel.yml
+++ b/.github/workflows/rocprofiler-compute-rhel.yml
@@ -31,6 +31,10 @@ on:
       - '!projects/rocprofiler-compute/docker/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rocprofiler-compute-tarball.yml
+++ b/.github/workflows/rocprofiler-compute-tarball.yml
@@ -32,7 +32,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -45,6 +44,9 @@ env:
 jobs:
   distbuild:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     container:
       image: ghcr.io/rocm/rocprofiler-ubuntu:24.04-compute-ci-base
     name: Create distribution tarball
@@ -117,6 +119,8 @@ jobs:
 
   disttest:
     runs-on: ubuntu-latest
+    permissions:
+      packages: read
     container:
       image: ghcr.io/rocm/rocprofiler-ubuntu:24.04-compute-ci-base
     needs: [distbuild]

--- a/.github/workflows/rocprofiler-compute-tarball.yml
+++ b/.github/workflows/rocprofiler-compute-tarball.yml
@@ -30,6 +30,10 @@ on:
       - '!projects/rocprofiler-compute/docs/**'
       - '!projects/rocprofiler-compute/docker/**'
 
+permissions:
+  contents: read
+  packages: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rocprofiler-compute-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-compute-ubuntu-jammy.yml
@@ -31,6 +31,9 @@ on:
       - '!projects/rocprofiler-compute/docker/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rocprofiler-ghcr-cleanup.yml
+++ b/.github/workflows/rocprofiler-ghcr-cleanup.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - '.github/workflows/rocprofiler-ghcr-cleanup.yml'
 
+permissions:
+  contents: read
+
 jobs:
   cleanup-rocprofiler-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/rocprofiler-register-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-register-continuous-integration.yml
@@ -28,6 +28,9 @@ on:
       - '!**/.wordlist.txt'
       - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rocprofiler-sdk-codeql.yml
+++ b/.github/workflows/rocprofiler-sdk-codeql.yml
@@ -36,9 +36,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
-  packages: read
-  actions: read
 
 env:
   ROCM_PATH: "/opt/rocm"

--- a/.github/workflows/rocprofiler-sdk-codeql.yml
+++ b/.github/workflows/rocprofiler-sdk-codeql.yml
@@ -34,6 +34,12 @@ on:
       - '!projects/rocprofiler-sdk/CODEOWNERS'
       - '!projects/rocprofiler-sdk/source/docs/**'
 
+permissions:
+  contents: read
+  security-events: write
+  packages: read
+  actions: read
+
 env:
   ROCM_PATH: "/opt/rocm"
   GPU_TARGETS: "gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201"

--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -27,6 +27,9 @@ on:
       - '.github/actions/rocprofiler-sdk-util/action.yml'
       - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rocprofiler-sdk-python.yml
+++ b/.github/workflows/rocprofiler-sdk-python.yml
@@ -29,6 +29,9 @@ on:
       - '!docs/**'
       - '!projects/*/docs/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rocprofiler-systems-build-group.yml
+++ b/.github/workflows/rocprofiler-systems-build-group.yml
@@ -22,6 +22,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   ROCPROFSYS_CI: ON
   ROCPROFSYS_TMPDIR: "%env{PWD}%/testing-tmp"

--- a/.github/workflows/rocprofiler-systems-build.yml
+++ b/.github/workflows/rocprofiler-systems-build.yml
@@ -46,6 +46,9 @@ on:
       - '!projects/rocprofiler-systems/docker/**'
       - '!projects/rocprofiler-systems/CMakePresets.json'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -37,6 +37,9 @@ on:
       - '!docs/**'
       - '!projects/*/docs/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rocprofiler-systems-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-systems-continuous-integration.yml
@@ -48,6 +48,9 @@ on:
       - '!projects/rocprofiler-systems/docker/**'
       - '!projects/rocprofiler-systems/CMakePresets.json'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -97,6 +100,7 @@ jobs:
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
       ROCPROFSYS_KEEP_TEST_OUTPUT: '0'
     permissions:
+      contents: read
       packages: read
       checks: write
     defaults:

--- a/.github/workflows/rocprofiler-systems-formatting.yml
+++ b/.github/workflows/rocprofiler-systems-formatting.yml
@@ -15,6 +15,9 @@ on:
       - '!**/.spellcheck.local.yaml'
       - '!**/.wordlist.txt'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rocprofiler-systems-ghcr.yml
+++ b/.github/workflows/rocprofiler-systems-ghcr.yml
@@ -35,6 +35,9 @@ on:
       - '!docs/**'
       - '!projects/*/docs/**'
 
+permissions:
+  contents: read
+
 jobs:
   prepare_matrix_ci:
     if: github.repository == 'ROCm/rocm-systems'

--- a/.github/workflows/rocprofiler-systems-python.yml
+++ b/.github/workflows/rocprofiler-systems-python.yml
@@ -33,6 +33,9 @@ on:
       - '!docs/**'
       - '!projects/*/docs/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rocprofiler-systems-ubuntu-noble-sanitizers.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-noble-sanitizers.yml
@@ -3,6 +3,9 @@ name: rocprofiler-systems CI / Sanitizers
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   ROCPROFSYS_CI: ON
   ROCPROFSYS_TMPDIR: "%env{PWD}%/testing-tmp"

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -129,7 +129,6 @@ jobs:
         projects: ${{ fromJSON(needs.setup.outputs.linux_projects) }}
         target_bundle: ${{ fromJSON(needs.setup.outputs.linux_package_targets) }}
     uses: ./.github/workflows/therock-ci-linux.yml
-    secrets: inherit
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
@@ -150,7 +149,6 @@ jobs:
       matrix:
         amdgpu_family: [gfx94X-dcgpu, gfx950-dcgpu]
     uses: ./.github/workflows/therock-rccl-ci-linux.yml
-    secrets: inherit
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
@@ -176,7 +174,6 @@ jobs:
         projects: ${{ fromJSON(needs.setup.outputs.windows_projects) }}
         target_bundle: ${{ fromJSON(needs.setup.outputs.windows_package_targets) }}
     uses: ./.github/workflows/therock-ci-windows.yml
-    secrets: inherit
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -162,7 +162,6 @@ jobs:
         projects: ${{ fromJSON(needs.setup.outputs.linux_projects) }}
         target_bundle: ${{ fromJSON(needs.setup.outputs.linux_package_targets) }}
     uses: ./.github/workflows/therock-ci-linux.yml
-    secrets: inherit
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
@@ -185,7 +184,6 @@ jobs:
     needs: setup
     if: ${{ needs.setup.outputs.linux_projects != '[]' && needs.setup.outputs.run_mi455_test == 'true' }}
     uses: ./.github/workflows/therock-build-linux.yml
-    secrets: inherit
     with:
       package_version: ${{ needs.setup.outputs.package_version }}
       amdgpu_families: gfx125X-dcgpu
@@ -221,7 +219,6 @@ jobs:
       matrix:
         amdgpu_family: [gfx94X-dcgpu, gfx950-dcgpu]
     uses: ./.github/workflows/therock-rccl-ci-linux.yml
-    secrets: inherit
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
@@ -247,7 +244,6 @@ jobs:
         projects: ${{ fromJSON(needs.setup.outputs.windows_projects) }}
         target_bundle: ${{ fromJSON(needs.setup.outputs.windows_package_targets) }}
     uses: ./.github/workflows/therock-ci-windows.yml
-    secrets: inherit
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}

--- a/.github/workflows/therock-multi-arch-ci-asan-nightly.yml
+++ b/.github/workflows/therock-multi-arch-ci-asan-nightly.yml
@@ -60,7 +60,6 @@ jobs:
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
     uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@main
-    secrets: inherit
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}

--- a/.github/workflows/therock-multi-arch-ci-asan.yml
+++ b/.github/workflows/therock-multi-arch-ci-asan.yml
@@ -69,7 +69,6 @@ jobs:
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
     uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@main
-    secrets: inherit
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -142,7 +142,6 @@ jobs:
         needs.configure.outputs.skip_tests != 'true'
       }}
     uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@main
-    secrets: inherit
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -167,7 +166,6 @@ jobs:
         needs.configure.outputs.skip_tests != 'true'
       }}
     uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@main
-    secrets: inherit
     with:
       build_config: ${{ needs.setup.outputs.windows_build_config }}
       test_labels: ${{ needs.setup.outputs.windows_test_labels }}

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -79,7 +79,6 @@ jobs:
       matrix:
         amdgpu_family: [gfx94X-dcgpu, gfx950-dcgpu]
     uses: ./.github/workflows/therock-rccl-ci-linux.yml
-    secrets: inherit
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -23,6 +23,9 @@ on:
      - 'projects/**'
      - 'shared/**'
 
+permissions:
+  contents: read
+
 jobs:
   trigger-rtd:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-subtrees-release.yml
+++ b/.github/workflows/update-subtrees-release.yml
@@ -9,7 +9,8 @@ env:
   SUPER_REPO_URL: github.com/ROCm/rocm-systems.git
   SUPER_REPO_BRANCH: release/rocm-rel-7.0
 
-permissions: {}
+permissions:
+  contents: read
 
 concurrency:
   group: pr-update-subtrees-release

--- a/.github/workflows/update-subtrees-release.yml
+++ b/.github/workflows/update-subtrees-release.yml
@@ -9,6 +9,8 @@ env:
   SUPER_REPO_URL: github.com/ROCm/rocm-systems.git
   SUPER_REPO_BRANCH: release/rocm-rel-7.0
 
+permissions: {}
+
 concurrency:
   group: pr-update-subtrees-release
   cancel-in-progress: false

--- a/.github/workflows/update-subtrees.yml
+++ b/.github/workflows/update-subtrees.yml
@@ -9,7 +9,8 @@ env:
   SUPER_REPO_URL: github.com/ROCm/rocm-systems.git
   SUPER_REPO_BRANCH: develop
 
-permissions: {}
+permissions:
+  contents: read
 
 concurrency:
   group: pr-update-subtrees-develop

--- a/.github/workflows/update-subtrees.yml
+++ b/.github/workflows/update-subtrees.yml
@@ -9,6 +9,8 @@ env:
   SUPER_REPO_URL: github.com/ROCm/rocm-systems.git
   SUPER_REPO_BRANCH: develop
 
+permissions: {}
+
 concurrency:
   group: pr-update-subtrees-develop
   cancel-in-progress: false


### PR DESCRIPTION
## Motivation

This PR applies the principle of least privilege across the workflow suite: every workflow now declares an explicit, minimal top-level `permissions:` block, and all unnecessary `secrets: inherit` usages are removed. The goal is to shrink the blast radius if a workflow run, a compromised dependency/action, or a malicious PR is ever able to influence a workflow's execution.

JIRA ID: ROCM-26660

## Technical Details

**Removed `secrets: inherit` (13 call sites across 7 files):**
**Added explicit top-level `permissions:` blocks to 50 workflows** that previously had none (defaulting to the org/repo token setting). Scopes were tailored per job's actual needs.

## Issue Tracking
JIRA ID: ROCM-26660

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
