### PR TITLE
[rocjitsu] Keep post-trap blocks unreachable in PC recovery

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -1187,10 +1187,9 @@ explicit_external_entries(const std::vector<AnalysisBlock> &blocks,
   return entries;
 }
 
-[[nodiscard]] bool
-is_analysis_root(size_t block_index, std::span<const uint8_t> external_entries,
-                 const std::vector<std::vector<size_t>> &predecessors,
-                 ExternalEntryPolicy entry_policy) {
+[[nodiscard]] bool is_analysis_root(size_t block_index, std::span<const uint8_t> external_entries,
+                                    const std::vector<std::vector<size_t>> &predecessors,
+                                    ExternalEntryPolicy entry_policy) {
   if (external_entries[block_index] != 0)
     return true;
   return entry_policy == ExternalEntryPolicy::InferPredecessorless &&
@@ -1540,8 +1539,7 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
 [[nodiscard]] std::vector<LatticeFacts>
 run_block_dataflow(const std::vector<AnalysisBlock> &blocks,
                    std::span<const PendingConsumer> pending_consumers,
-                   std::span<const uint64_t> extra_leaders,
-                   ExternalEntryPolicy entry_policy) {
+                   std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy) {
   // Phase 3: compute block-entry facts to a fixed point.
   //
   // entry[B] = JOIN(exit[P]) for every predecessor P of B.
@@ -2219,11 +2217,9 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
   return static_cast<uint16_t>((word >> 16) & 0x7fu);
 }
 
-[[nodiscard]] std::vector<IndirectCallFixup>
-discover_indirect_branch_edges_unfiltered(std::span<const Instruction *const> insts,
-                                          std::span<const uint8_t> text, rj_code_arch_t arch,
-                                          std::span<const uint64_t> extra_leaders,
-                                          ExternalEntryPolicy entry_policy) {
+[[nodiscard]] std::vector<IndirectCallFixup> discover_indirect_branch_edges_unfiltered(
+    std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,
+    std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy) {
   std::vector<IndirectCallFixup> recovered;
   AnalysisContext ctx = build_context(insts, text, arch);
   recover_vector_lane_stashed_pcs(ctx, recovered, extra_leaders, entry_policy);
@@ -2262,11 +2258,9 @@ discover_indirect_branch_edges_unfiltered(std::span<const Instruction *const> in
 
 } // namespace
 
-std::vector<IndirectCallFixup>
-discover_indirect_branch_edges(std::span<const Instruction *const> insts,
-                               std::span<const uint8_t> text, rj_code_arch_t arch,
-                               std::span<const uint64_t> extra_leaders,
-                               ExternalEntryPolicy entry_policy) {
+std::vector<IndirectCallFixup> discover_indirect_branch_edges(
+    std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,
+    std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy) {
   if (insts.empty())
     return {};
 
@@ -2279,8 +2273,8 @@ discover_indirect_branch_edges(std::span<const Instruction *const> insts,
 #ifndef NDEBUG
     // Keep the cheap predicate coupled to every fixup producer. A future
     // recovery path for another consumer kind must extend the predicate above.
-    const auto unfiltered = discover_indirect_branch_edges_unfiltered(
-        insts, text, arch, extra_leaders, entry_policy);
+    const auto unfiltered =
+        discover_indirect_branch_edges_unfiltered(insts, text, arch, extra_leaders, entry_policy);
     assert(unfiltered.empty() && "indirect-recovery prefilter skipped a fixup-producing consumer");
 #endif
     return {};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -1829,7 +1829,7 @@ struct VectorLaneFlowState {
   return phys_vgpr >= 40 && phys_vgpr <= 255 && ((phys_vgpr - 40) % 16) < 8;
 }
 
-void recover_vector_lane_stashed_pcs(AnalysisContext &ctx,
+void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<AnalysisBlock> &blocks,
                                      std::vector<IndirectCallFixup> &recovered,
                                      std::span<const uint64_t> extra_leaders,
                                      ExternalEntryPolicy entry_policy) {
@@ -1858,7 +1858,6 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx,
   if (ctx.arch != ROCJITSU_CODE_ARCH_GFX1250)
     return;
 
-  const std::vector<AnalysisBlock> blocks = build_analysis_blocks(ctx, extra_leaders);
   if (blocks.empty())
     return;
   const std::vector<uint8_t> external_entries = explicit_external_entries(blocks, extra_leaders);
@@ -2222,7 +2221,6 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
     std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy) {
   std::vector<IndirectCallFixup> recovered;
   AnalysisContext ctx = build_context(insts, text, arch);
-  recover_vector_lane_stashed_pcs(ctx, recovered, extra_leaders, entry_policy);
   std::vector<uint64_t> leaders(extra_leaders.begin(), extra_leaders.end());
 
   for (size_t iteration = 0; iteration < kMaxIndirectDiscoveryIterations; ++iteration) {
@@ -2233,22 +2231,26 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
 
     std::vector<PendingConsumer> pending_consumers;
     std::vector<IndirectCallFixup> iteration_recovered;
+    // Lane-stash recovery consumes the same graph as scalar recovery, including
+    // edges proven in earlier rounds. Keep extra_leaders separate from leaders:
+    // recovered targets become reachable through those edges, not by being
+    // promoted to external roots.
+    recover_vector_lane_stashed_pcs(ctx, blocks, iteration_recovered, extra_leaders, entry_policy);
     for (size_t block_index = 0; block_index < blocks.size(); ++block_index)
       scan_block(ctx, block_index, blocks, pending_consumers, iteration_recovered);
     recover_signed_delta_templates(ctx, blocks, iteration_recovered);
 
-    size_t unresolved_consumers = 0;
     if (!pending_consumers.empty()) {
       const auto entry_facts =
           run_block_dataflow(blocks, pending_consumers, extra_leaders, entry_policy);
-      unresolved_consumers = classify_pending_consumers(ctx, blocks, entry_facts, pending_consumers,
-                                                        iteration_recovered);
+      (void)classify_pending_consumers(ctx, blocks, entry_facts, pending_consumers,
+                                       iteration_recovered);
     }
 
     bool changed = false;
     for (const IndirectCallFixup &fixup : iteration_recovered)
       changed |= append_unique(recovered, fixup);
-    if (!changed || unresolved_consumers == 0)
+    if (!changed)
       break;
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -1535,10 +1535,11 @@ run_block_dataflow(const std::vector<AnalysisBlock> &blocks,
   //
   // entry[B] = JOIN(exit[P]) for every predecessor P of B.
   //
-  // Blocks with no predecessors keep an empty entry map. Empty does not mean
-  // "known empty set"; it means every pair is at unconstrained kernel-entry
-  // state unless a predecessor later mentions that pair. Consumers interpret a
-  // missing fact as unresolved.
+  // Explicit external entries begin with an empty map. Empty does not mean
+  // "known empty set"; at those entries every pair has an unconstrained
+  // hardware-supplied value unless a predecessor later mentions it. A
+  // predecessorless non-entry is instead unreachable (BOTTOM), so its empty
+  // map must not participate in a successor join.
   std::vector<std::vector<size_t>> predecessors(blocks.size());
   for (size_t block_index = 0; block_index < blocks.size(); ++block_index) {
     for (size_t successor : blocks[block_index].successors)
@@ -1566,8 +1567,16 @@ run_block_dataflow(const std::vector<AnalysisBlock> &blocks,
   // Treating that backedge as unconstrained permanently poisons an otherwise
   // dominated PC builder (the RCCL call-loop shape). Section entry and every
   // caller-provided kernel entry are nevertheless external roots even when
-  // they have structural predecessors. Blocks with no predecessors remain
-  // conservative analysis roots because they may also be externally entered.
+  // they have structural predecessors.
+  //
+  // Do not infer an external entry merely because a block has no predecessor.
+  // In the DBT pipeline every descriptor- or firmware-visible kernel entry is
+  // supplied in extra_leaders. Translation then walks each entry's reachable
+  // CFG and emits shared blocks separately in every kernel-local scope. A
+  // callable helper is either an explicit leader itself or has a direct or
+  // recovered predecessor edge; a predecessorless block after a non-returning
+  // instruction such as s_trap 2 cannot acquire a hidden incoming edge from
+  // another kernel scope.
   std::vector<bool> reachable(blocks.size(), false);
   // Keep key presence separate from the sparse fact vectors. The dataflow
   // join needs the union of predecessor keys on every worklist visit; caching
@@ -1589,7 +1598,7 @@ run_block_dataflow(const std::vector<AnalysisBlock> &blocks,
     LatticeFacts new_entry;
     std::bitset<REGISTER_SET_MAX_SGPRS> mentioned_pairs;
     const bool new_reachable =
-        external_entries[block_index] != 0 || predecessors[block_index].empty() ||
+        external_entries[block_index] != 0 ||
         std::ranges::any_of(predecessors[block_index],
                             [&](size_t predecessor) { return reachable[predecessor]; });
     if (new_reachable && !predecessors[block_index].empty()) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -1187,6 +1187,16 @@ explicit_external_entries(const std::vector<AnalysisBlock> &blocks,
   return entries;
 }
 
+[[nodiscard]] bool
+is_analysis_root(size_t block_index, std::span<const uint8_t> external_entries,
+                 const std::vector<std::vector<size_t>> &predecessors,
+                 ExternalEntryPolicy entry_policy) {
+  if (external_entries[block_index] != 0)
+    return true;
+  return entry_policy == ExternalEntryPolicy::InferPredecessorless &&
+         predecessors[block_index].empty();
+}
+
 void set_kill_transfer(AnalysisBlock &block, uint16_t pair_lo) {
   // KILL is weaker than SET for the same block: if the final state proves a
   // concrete builder, earlier dirty writes in the block should not downgrade it.
@@ -1530,16 +1540,17 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
 [[nodiscard]] std::vector<LatticeFacts>
 run_block_dataflow(const std::vector<AnalysisBlock> &blocks,
                    std::span<const PendingConsumer> pending_consumers,
-                   std::span<const uint64_t> extra_leaders) {
+                   std::span<const uint64_t> extra_leaders,
+                   ExternalEntryPolicy entry_policy) {
   // Phase 3: compute block-entry facts to a fixed point.
   //
   // entry[B] = JOIN(exit[P]) for every predecessor P of B.
   //
   // Explicit external entries begin with an empty map. Empty does not mean
   // "known empty set"; at those entries every pair has an unconstrained
-  // hardware-supplied value unless a predecessor later mentions it. A
-  // predecessorless non-entry is instead unreachable (BOTTOM), so its empty
-  // map must not participate in a successor join.
+  // hardware-supplied value unless a predecessor later mentions it. Under the
+  // ExplicitOnly policy, a predecessorless non-entry is instead unreachable
+  // (BOTTOM), so its empty map must not participate in a successor join.
   std::vector<std::vector<size_t>> predecessors(blocks.size());
   for (size_t block_index = 0; block_index < blocks.size(); ++block_index) {
     for (size_t successor : blocks[block_index].successors)
@@ -1569,14 +1580,15 @@ run_block_dataflow(const std::vector<AnalysisBlock> &blocks,
   // caller-provided kernel entry are nevertheless external roots even when
   // they have structural predecessors.
   //
-  // Do not infer an external entry merely because a block has no predecessor.
-  // In the DBT pipeline every descriptor- or firmware-visible kernel entry is
-  // supplied in extra_leaders. Translation then walks each entry's reachable
-  // CFG and emits shared blocks separately in every kernel-local scope. A
-  // callable helper is either an explicit leader itself or has a direct or
-  // recovered predecessor edge; a predecessorless block after a non-returning
-  // instruction such as s_trap 2 cannot acquire a hidden incoming edge from
-  // another kernel scope.
+  // With ExplicitOnly, do not infer an external entry merely because a block
+  // has no predecessor. BinaryTranslator supplies every descriptor- or
+  // firmware-visible kernel entry, then walks each entry's reachable CFG and
+  // emits shared blocks separately in every kernel-local scope. A callable
+  // helper is either an explicit leader itself or has a direct or recovered
+  // predecessor edge; a predecessorless block after a non-returning instruction
+  // such as s_trap 2 cannot acquire a hidden incoming edge from another kernel
+  // scope. Generic callers without a complete entry list use
+  // InferPredecessorless to preserve conservative multi-function recovery.
   std::vector<bool> reachable(blocks.size(), false);
   // Keep key presence separate from the sparse fact vectors. The dataflow
   // join needs the union of predecessor keys on every worklist visit; caching
@@ -1598,7 +1610,7 @@ run_block_dataflow(const std::vector<AnalysisBlock> &blocks,
     LatticeFacts new_entry;
     std::bitset<REGISTER_SET_MAX_SGPRS> mentioned_pairs;
     const bool new_reachable =
-        external_entries[block_index] != 0 ||
+        is_analysis_root(block_index, external_entries, predecessors, entry_policy) ||
         std::ranges::any_of(predecessors[block_index],
                             [&](size_t predecessor) { return reachable[predecessor]; });
     if (new_reachable && !predecessors[block_index].empty()) {
@@ -1821,7 +1833,8 @@ struct VectorLaneFlowState {
 
 void recover_vector_lane_stashed_pcs(AnalysisContext &ctx,
                                      std::vector<IndirectCallFixup> &recovered,
-                                     std::span<const uint64_t> extra_leaders) {
+                                     std::span<const uint64_t> extra_leaders,
+                                     ExternalEntryPolicy entry_policy) {
   // gfx1250 device functions sometimes keep a small static call set in one
   // VGPR: getpc-built low/high halves are written to fixed lanes, then read
   // back into an SGPR pair before swappc. Track only fixed-lane
@@ -2056,13 +2069,13 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx,
         new_entry.vgpr_msb_imm = std::nullopt;
     }
 
-    // A block with no direct predecessors is a possible device-function entry.
-    // Section entry and every caller-provided kernel entry are explicit
-    // external entries even when they have structural predecessors. Meet the
-    // corresponding external state with any reachable predecessor: it
-    // contributes no lane stash, and explicit kernel entries begin in bank
-    // zero according to the entry contract.
-    if (predecessors[block_index].empty() || external_entries[block_index] != 0) {
+    // Generic callers conservatively infer predecessorless device-function
+    // entries; callers with a complete entry list leave unlisted blocks at
+    // BOTTOM. Explicit entries remain roots even with structural predecessors.
+    // Meet a root's external state with any reachable predecessor: it
+    // contributes no lane stash, and explicit entries begin in bank zero
+    // according to the entry contract.
+    if (is_analysis_root(block_index, external_entries, predecessors, entry_policy)) {
       new_reachable = true;
       VectorLaneFlowState external_entry;
       if (external_entries[block_index] != 0)
@@ -2209,10 +2222,11 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
 [[nodiscard]] std::vector<IndirectCallFixup>
 discover_indirect_branch_edges_unfiltered(std::span<const Instruction *const> insts,
                                           std::span<const uint8_t> text, rj_code_arch_t arch,
-                                          std::span<const uint64_t> extra_leaders) {
+                                          std::span<const uint64_t> extra_leaders,
+                                          ExternalEntryPolicy entry_policy) {
   std::vector<IndirectCallFixup> recovered;
   AnalysisContext ctx = build_context(insts, text, arch);
-  recover_vector_lane_stashed_pcs(ctx, recovered, extra_leaders);
+  recover_vector_lane_stashed_pcs(ctx, recovered, extra_leaders, entry_policy);
   std::vector<uint64_t> leaders(extra_leaders.begin(), extra_leaders.end());
 
   for (size_t iteration = 0; iteration < kMaxIndirectDiscoveryIterations; ++iteration) {
@@ -2229,7 +2243,8 @@ discover_indirect_branch_edges_unfiltered(std::span<const Instruction *const> in
 
     size_t unresolved_consumers = 0;
     if (!pending_consumers.empty()) {
-      const auto entry_facts = run_block_dataflow(blocks, pending_consumers, extra_leaders);
+      const auto entry_facts =
+          run_block_dataflow(blocks, pending_consumers, extra_leaders, entry_policy);
       unresolved_consumers = classify_pending_consumers(ctx, blocks, entry_facts, pending_consumers,
                                                         iteration_recovered);
     }
@@ -2250,7 +2265,8 @@ discover_indirect_branch_edges_unfiltered(std::span<const Instruction *const> in
 std::vector<IndirectCallFixup>
 discover_indirect_branch_edges(std::span<const Instruction *const> insts,
                                std::span<const uint8_t> text, rj_code_arch_t arch,
-                               std::span<const uint64_t> extra_leaders) {
+                               std::span<const uint64_t> extra_leaders,
+                               ExternalEntryPolicy entry_policy) {
   if (insts.empty())
     return {};
 
@@ -2263,14 +2279,14 @@ discover_indirect_branch_edges(std::span<const Instruction *const> insts,
 #ifndef NDEBUG
     // Keep the cheap predicate coupled to every fixup producer. A future
     // recovery path for another consumer kind must extend the predicate above.
-    const auto unfiltered =
-        discover_indirect_branch_edges_unfiltered(insts, text, arch, extra_leaders);
+    const auto unfiltered = discover_indirect_branch_edges_unfiltered(
+        insts, text, arch, extra_leaders, entry_policy);
     assert(unfiltered.empty() && "indirect-recovery prefilter skipped a fixup-producing consumer");
 #endif
     return {};
   }
 
-  return discover_indirect_branch_edges_unfiltered(insts, text, arch, extra_leaders);
+  return discover_indirect_branch_edges_unfiltered(insts, text, arch, extra_leaders, entry_policy);
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
@@ -16,6 +16,18 @@ namespace rocjitsu {
 
 class Instruction;
 
+/// @brief How indirect-target discovery identifies externally reachable blocks.
+enum class ExternalEntryPolicy : uint8_t {
+  /// Treat every predecessorless block as a possible external function entry.
+  /// This preserves conservative recovery when callers do not have a complete
+  /// list of entries for all functions sharing one .text section.
+  InferPredecessorless,
+  /// Treat only section entry and caller-supplied leaders as external entries.
+  /// Callers may use this when their supplied leader list contains every
+  /// externally reachable entry; other predecessorless blocks remain unreachable.
+  ExplicitOnly,
+};
+
 /// @brief Recovered indirect PC-relative branch through a statically-built PC register.
 ///
 /// @details BasicBlock construction uses this metadata in two ways. A recovered
@@ -70,10 +82,13 @@ struct IndirectCallFixup {
 /// @param text Raw .text bytes matching @p insts.
 /// @param arch ISA architecture used for scalar instruction matching.
 /// @param extra_leaders Additional known block starts, usually kernel entries.
+/// @param entry_policy Whether predecessorless blocks are inferred to be external entries.
 /// @returns Recovered indirect branch/call metadata.
 [[nodiscard]] std::vector<IndirectCallFixup>
 discover_indirect_branch_edges(std::span<const Instruction *const> insts,
                                std::span<const uint8_t> text, rj_code_arch_t arch,
-                               std::span<const uint64_t> extra_leaders = {});
+                               std::span<const uint64_t> extra_leaders = {},
+                               ExternalEntryPolicy entry_policy =
+                                   ExternalEntryPolicy::InferPredecessorless);
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
@@ -84,11 +84,9 @@ struct IndirectCallFixup {
 /// @param extra_leaders Additional known block starts, usually kernel entries.
 /// @param entry_policy Whether predecessorless blocks are inferred to be external entries.
 /// @returns Recovered indirect branch/call metadata.
-[[nodiscard]] std::vector<IndirectCallFixup>
-discover_indirect_branch_edges(std::span<const Instruction *const> insts,
-                               std::span<const uint8_t> text, rj_code_arch_t arch,
-                               std::span<const uint64_t> extra_leaders = {},
-                               ExternalEntryPolicy entry_policy =
-                                   ExternalEntryPolicy::InferPredecessorless);
+[[nodiscard]] std::vector<IndirectCallFixup> discover_indirect_branch_edges(
+    std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,
+    std::span<const uint64_t> extra_leaders = {},
+    ExternalEntryPolicy entry_policy = ExternalEntryPolicy::InferPredecessorless);
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
@@ -148,9 +148,10 @@ void BasicBlock::add_static_indirect_call_fixup(IndirectCallFixup fixup) {
   static_indirect_call_fixups_.push_back(fixup);
 }
 
-std::vector<std::unique_ptr<BasicBlock>>
-BasicBlock::build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
-                  std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy) {
+std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co, Decoder &decoder,
+                                                           rj_code_arch_t arch,
+                                                           std::span<const uint64_t> extra_leaders,
+                                                           ExternalEntryPolicy entry_policy) {
   std::vector<std::unique_ptr<BasicBlock>> blocks;
 
   for (const auto *sec : co.text_sections()) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
@@ -150,7 +150,7 @@ void BasicBlock::add_static_indirect_call_fixup(IndirectCallFixup fixup) {
 
 std::vector<std::unique_ptr<BasicBlock>>
 BasicBlock::build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
-                  std::span<const uint64_t> extra_leaders) {
+                  std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy) {
   std::vector<std::unique_ptr<BasicBlock>> blocks;
 
   for (const auto *sec : co.text_sections()) {
@@ -208,7 +208,7 @@ BasicBlock::build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
     const auto decoded_span =
         std::span<const Instruction *const>(decoded_insts.data(), decoded_insts.size());
     std::vector<IndirectCallFixup> recovered_indirect_targets =
-        discover_indirect_branch_edges(decoded_span, text, arch, extra_leaders);
+        discover_indirect_branch_edges(decoded_span, text, arch, extra_leaders, entry_policy);
 
     std::set<uint64_t> leaders;
     leaders.insert(decoded.front()->src_loc());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.h
@@ -138,10 +138,14 @@ public:
   /// @param[in] decoder Decoder for the target ISA.
   /// @param[in] arch ISA architecture used to match static PC builders.
   /// @param[in] extra_leaders Byte offsets that must start a basic block.
+  /// @param[in] entry_policy Whether predecessorless blocks are inferred to be
+  /// external function entries. Use ExplicitOnly only when extra_leaders
+  /// enumerates every externally reachable entry.
   /// @returns Ordered list of basic blocks with their decoded instructions.
   static std::vector<std::unique_ptr<BasicBlock>>
   build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
-        std::span<const uint64_t> extra_leaders = {});
+        std::span<const uint64_t> extra_leaders = {},
+        ExternalEntryPolicy entry_policy = ExternalEntryPolicy::InferPredecessorless);
 
 private:
   void add_instruction(std::unique_ptr<Instruction> inst);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -966,7 +966,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // helper block, Phase 3 emits that helper into both relocated bodies so every
   // branch or call target can be resolved through the current kernel's placement
   // map without borrowing another kernel's return continuation.
-  auto blocks = BasicBlock::build(obj, *decoder, guest_arch_, block_leaders);
+  auto blocks = BasicBlock::build(obj, *decoder, guest_arch_, block_leaders,
+                                  ExternalEntryPolicy::ExplicitOnly);
   const BlockOffsetIndex block_index = build_block_offset_index(blocks);
   const uint64_t text_vaddr = obj.text_sections().front()->vaddr();
   const auto relocation_table_dispatches =

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -1400,6 +1400,54 @@ TEST(CfgAnalysis, Gfx1250UnreachablePostRocrAbortBlockDoesNotPoisonLaneStash) {
   EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 72u);
 }
 
+TEST(CfgAnalysis, Gfx1250ExplicitOnlyRecoversLaneStashInRecoveredCallee) {
+  // The kernel root first makes a scalar-recoverable call to the helper at
+  // 0x18. The helper is not an explicit entry and has no direct predecessor;
+  // it becomes reachable only after the outer call edge is recovered. Once
+  // reachable, its lane-stashed call to 0x58 must participate in the next
+  // discovery iteration.
+  std::vector<uint32_t> words = {
+      0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+      0xA980FE00u,
+      20u,
+      0u,          // 0x04: s_add_nc_u64 ..., lit64(20) -> helper 0x18.
+      0xBE9E4900u, // 0x10: outer s_swap_pc_i64 -> 0x18.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x14: outer continuation.
+      0xBE804700u,                                // 0x18: helper s_get_pc_i64.
+      0xA980FE00u,
+      60u,
+      0u, // 0x1c: s_add_nc_u64 ..., lit64(60) -> target 0x58.
+      0xD761002Cu,
+      0x02010000u, // 0x28: v_writelane_b32 v44, s0, 0.
+      0xD761002Cu,
+      0x02010201u, // 0x30: v_writelane_b32 v44, s1, 1.
+      0xD7600000u,
+      0x0201012Cu, // 0x38: v_readlane_b32 s0, v44, 0.
+      0xD7600001u,
+      0x0201032Cu,                                // 0x40: lane 1 -> s1.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250), // 0x48: padding.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250), // 0x4c: padding.
+      0xBE9E4900u,                                // 0x50: inner call -> 0x58.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x54: inner continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x58: inner target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250, {},
+                                  ExternalEntryPolicy::ExplicitOnly);
+
+  auto *outer_consumer = block_starting_at(blocks, 16);
+  auto *inner_consumer = block_starting_at(blocks, 80);
+  ASSERT_NE(outer_consumer, nullptr);
+  ASSERT_NE(inner_consumer, nullptr);
+  ASSERT_EQ(outer_consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_EQ(outer_consumer->static_indirect_call_fixups()[0].source_target_offset, 24u);
+  ASSERT_EQ(inner_consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_EQ(inner_consumer->static_indirect_call_fixups()[0].source_target_offset, 88u);
+}
+
 TEST(CfgAnalysis, Gfx1250DirectCallKillsCarriedLaneStash) {
   // The stash lives in v48, a CALLER-saved VGPR under CSR_AMDGPU_VGPRs, so a
   // call is not proven to preserve it and the continuation must not recover a

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -803,6 +803,53 @@ TEST(CfgAnalysis, RocrAbortTrapStopsTemporaryPcBuilderCfg) {
   EXPECT_TRUE(consumer->static_indirect_call_fixups().empty());
 }
 
+TEST(CfgAnalysis, UnreachablePostRocrAbortBlockDoesNotPoisonPcBuilder) {
+  constexpr uint16_t kPcSreg = 8;
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr uint32_t kLiteralOperand = 255;
+  constexpr uint32_t kInlineInt0 = 128;
+
+  // Model the generated complex-math kernels from the offline corpus:
+  //
+  //   builder --conditional--------------------------> call
+  //                 |
+  //                 +--> s_trap 2 -X-> dead branch --^
+  //
+  // ROCr's trap 2 aborts instead of returning, so the block after it has no
+  // predecessor. It is not an implicit external entry: DBT supplies every
+  // hardware-visible kernel entry explicitly, builds a reachable scope from
+  // each one, and duplicates shared reachable blocks per kernel scope. Treating
+  // the dead block as an external root would invent an unconstrained s[8:9]
+  // path into the call and make this otherwise dominated builder incomplete.
+  std::vector<uint32_t> words = {
+      pack_sop1(0x1c, kPcSreg, 0),                         // 0x00: s_getpc_b64.
+      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand),     // 0x04: s_add_u32.
+      40,                                                  // 0x08: 0x04 + 40 = helper at 0x2c.
+      pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0), // 0x0c: s_addc_u32.
+      pack_sopp(5, 3),                                     // 0x10: s_cbranch_scc0 -> 0x20.
+      build_s_trap(ROCJITSU_CODE_ARCH_CDNA4, 2),           // 0x14: abort terminator.
+      build_s_branch(1, ROCJITSU_CODE_ARCH_CDNA4),         // 0x18: dead edge -> 0x20.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),            // 0x1c: dead padding.
+      pack_sop1(0x1e, kReturnSreg, kPcSreg),               // 0x20: s_swappc_b64.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),            // 0x24: call continuation.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),            // 0x28: padding.
+      pack_sop1(0x1d, 0, kReturnSreg),                     // 0x2c: helper return.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *consumer = block_starting_at(blocks, 32);
+  ASSERT_NE(consumer, nullptr);
+  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
+  const auto &fixup = consumer->static_indirect_call_fixups()[0];
+  EXPECT_EQ(fixup.source_target_offset, 44u);
+  EXPECT_FALSE(fixup.source_incomplete)
+      << "unreachable code after a non-returning trap must remain dataflow BOTTOM";
+}
+
 TEST(CfgAnalysis, DirectCallEdgeUsesTerminatorOffset) {
   constexpr uint16_t kReturnSreg = 30;
 

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -1353,11 +1353,9 @@ TEST(CfgAnalysis, Gfx1250CarriesLaneStashAcrossProvenBlockBoundary) {
 }
 
 TEST(CfgAnalysis, Gfx1250UnreachablePostRocrAbortBlockDoesNotPoisonLaneStash) {
-  constexpr auto live_branch =
-      gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp, {.simm16 = 3});
+  constexpr auto live_branch = gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp, {.simm16 = 3});
   constexpr auto dead_branch = gfx1250::build_sopp(gfx1250::kSBranchSopp, {.simm16 = 1});
-  constexpr auto call =
-      gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = 0, .sdst = 30});
+  constexpr auto call = gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = 0, .sdst = 30});
 
   // Mirror the scalar post-trap regression with a gfx1250 PC stashed in v44:
   //
@@ -1376,18 +1374,18 @@ TEST(CfgAnalysis, Gfx1250UnreachablePostRocrAbortBlockDoesNotPoisonLaneStash) {
       0xD761002Cu,
       0x02010000u, // 0x10: v_writelane_b32 v44, s0, 0.
       0xD761002Cu,
-      0x02010201u,                                        // 0x18: lane 1 <- s1.
-      live_branch[0],                                     // 0x20: -> join at 0x30.
-      build_s_trap(ROCJITSU_CODE_ARCH_GFX1250, 2),        // 0x24: abort terminator.
-      dead_branch[0],                                     // 0x28: dead edge -> 0x30.
-      build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250),         // 0x2c: dead padding.
+      0x02010201u,                                 // 0x18: lane 1 <- s1.
+      live_branch[0],                              // 0x20: -> join at 0x30.
+      build_s_trap(ROCJITSU_CODE_ARCH_GFX1250, 2), // 0x24: abort terminator.
+      dead_branch[0],                              // 0x28: dead edge -> 0x30.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250),  // 0x2c: dead padding.
       0xD7600000u,
       0x0201012Cu, // 0x30: v_readlane_b32 s0, v44, 0.
       0xD7600001u,
-      0x0201032Cu,                                        // 0x38: lane 1 -> s1.
-      call[0],                                            // 0x40: s_swap_pc_i64.
-      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),         // 0x44: continuation.
-      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),         // 0x48: target.
+      0x0201032Cu,                                // 0x38: lane 1 -> s1.
+      call[0],                                    // 0x40: s_swap_pc_i64.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x44: continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x48: target.
   };
 
   TestCodeObject co(std::move(words));

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -839,7 +839,8 @@ TEST(CfgAnalysis, UnreachablePostRocrAbortBlockDoesNotPoisonPcBuilder) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, {},
+                                  ExternalEntryPolicy::ExplicitOnly);
 
   auto *consumer = block_starting_at(blocks, 32);
   ASSERT_NE(consumer, nullptr);
@@ -848,6 +849,39 @@ TEST(CfgAnalysis, UnreachablePostRocrAbortBlockDoesNotPoisonPcBuilder) {
   EXPECT_EQ(fixup.source_target_offset, 44u);
   EXPECT_FALSE(fixup.source_incomplete)
       << "unreachable code after a non-returning trap must remain dataflow BOTTOM";
+}
+
+TEST(CfgAnalysis, DefaultEntryPolicyRecoversPredecessorlessFunction) {
+  constexpr uint16_t kPcSreg = 8;
+  constexpr uint32_t kLiteralOperand = 255;
+  constexpr uint32_t kInlineInt0 = 128;
+
+  // Generic BasicBlock::build callers may not know every function entry in a
+  // shared .text section. Preserve the conservative default that treats the
+  // second function as an inferred external entry, allowing its cross-block
+  // PC builder to reach the setpc consumer.
+  std::vector<uint32_t> words = {
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),            // 0x00: first function.
+      pack_sop1(0x1c, kPcSreg, 0),                         // 0x04: second entry, s_getpc_b64.
+      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand),     // 0x08: s_add_u32.
+      24,                                                  // 0x0c: 0x08 + 24 = target 0x20.
+      pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0), // 0x10: s_addc_u32.
+      build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA4),         // 0x14: -> consumer at 0x18.
+      pack_sop1(0x1d, 0, kPcSreg),                         // 0x18: s_setpc_b64.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),            // 0x1c: padding.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),            // 0x20: target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *consumer = block_starting_at(blocks, 24);
+  ASSERT_NE(consumer, nullptr);
+  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 32u);
+  EXPECT_FALSE(consumer->static_indirect_call_fixups()[0].source_incomplete);
 }
 
 TEST(CfgAnalysis, DirectCallEdgeUsesTerminatorOffset) {
@@ -1316,6 +1350,56 @@ TEST(CfgAnalysis, Gfx1250CarriesLaneStashAcrossProvenBlockBoundary) {
   ASSERT_NE(consumer, nullptr);
   ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
   EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 60u);
+}
+
+TEST(CfgAnalysis, Gfx1250UnreachablePostRocrAbortBlockDoesNotPoisonLaneStash) {
+  constexpr auto live_branch =
+      gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp, {.simm16 = 3});
+  constexpr auto dead_branch = gfx1250::build_sopp(gfx1250::kSBranchSopp, {.simm16 = 1});
+  constexpr auto call =
+      gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = 0, .sdst = 30});
+
+  // Mirror the scalar post-trap regression with a gfx1250 PC stashed in v44:
+  //
+  //   writelanes --conditional-----------------------> readlanes/call
+  //                    |
+  //                    +--> s_trap 2 -X-> dead edge --^
+  //
+  // In ExplicitOnly mode the dead post-trap block remains BOTTOM. Letting it
+  // contribute an empty lane-stash state would erase the valid v44 definitions
+  // at the join and lose this otherwise proven call target.
+  std::vector<uint32_t> words = {
+      0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+      0xA980FE00u,
+      68u,
+      0u, // 0x04: s_add_nc_u64 ..., lit64(68) -> target 0x48.
+      0xD761002Cu,
+      0x02010000u, // 0x10: v_writelane_b32 v44, s0, 0.
+      0xD761002Cu,
+      0x02010201u,                                        // 0x18: lane 1 <- s1.
+      live_branch[0],                                     // 0x20: -> join at 0x30.
+      build_s_trap(ROCJITSU_CODE_ARCH_GFX1250, 2),        // 0x24: abort terminator.
+      dead_branch[0],                                     // 0x28: dead edge -> 0x30.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250),         // 0x2c: dead padding.
+      0xD7600000u,
+      0x0201012Cu, // 0x30: v_readlane_b32 s0, v44, 0.
+      0xD7600001u,
+      0x0201032Cu,                                        // 0x38: lane 1 -> s1.
+      call[0],                                            // 0x40: s_swap_pc_i64.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),         // 0x44: continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),         // 0x48: target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250, {},
+                                  ExternalEntryPolicy::ExplicitOnly);
+
+  auto *consumer = block_starting_at(blocks, 64);
+  ASSERT_NE(consumer, nullptr);
+  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 72u);
 }
 
 TEST(CfgAnalysis, Gfx1250DirectCallKillsCarriedLaneStash) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -7692,6 +7692,52 @@ TEST(BinaryTranslatorE2E, RocrAbortTrapTerminatesCfgBeforeFollowingCode) {
                            [](const auto &inst) { return inst->mnemonic() == "s_setpc_b64"; }));
 }
 
+TEST(BinaryTranslatorE2E, RocrAbortDeadEdgeDoesNotPoisonRecoveredCall) {
+  constexpr uint16_t kPcSreg = 8;
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr uint32_t kLiteralOperand = 255;
+  constexpr uint32_t kInlineInt0 = 128;
+
+  // Exercise BinaryTranslator's ExplicitOnly entry policy rather than calling
+  // BasicBlock::build with the policy directly:
+  //
+  //   builder --conditional--------------------------> call
+  //                 |
+  //                 +--> s_trap 2 -X-> dead branch --^
+  //
+  // Treating the dead post-trap block as an inferred entry would add an
+  // unconstrained path to s[8:9] and make translation fail closed.
+  const std::vector<uint32_t> words = {
+      build_s_getpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_CDNA4),    // 0x00.
+      build_s_add_u32(kPcSreg, kPcSreg, kLiteralOperand),      // 0x04.
+      40,                                                      // 0x08: 0x04 + 40 = helper 0x2c.
+      build_s_addc_u32(kPcSreg + 1, kPcSreg + 1, kInlineInt0), // 0x0c.
+      cdna4::build_sopp(cdna4::kSCbranchScc0Sopp, {.simm16 = 3})[0],      // 0x10 -> 0x20.
+      build_s_trap(2),                                                    // 0x14.
+      rocjitsu::build_s_branch(1, ROCJITSU_CODE_ARCH_CDNA4),              // 0x18 -> 0x20.
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),                 // 0x1c.
+      build_s_swappc_b64(kReturnSreg, kPcSreg, ROCJITSU_CODE_ARCH_CDNA4), // 0x20.
+      rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),                 // 0x24.
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),                 // 0x28.
+      build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_CDNA4),           // 0x2c.
+  };
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << result.diagnostics.front().message;
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_CDNA3);
+  EXPECT_TRUE(std::ranges::any_of(
+      decoded, [](const auto &inst) { return inst->mnemonic() == "s_call_b64"; }));
+}
+
 TEST(BinaryTranslatorE2E, RejectsUnrecoveredIndirectBranchInstructions) {
   struct Case {
     const char *name;


### PR DESCRIPTION
Generated complex-math kernels in the offline corpus contain control flow of this form:

    builder --conditional--------------------------> call
                  |
                  +--> s_trap 2 -X-> dead branch --^

For example, one kernel branches from 0x22a18 to 0x234e4 on its live path. The other arm executes the non-returning ROCr abort at 0x22a20, so the s_cbranch_execz at 0x22a24 has no executable predecessor. The static PC built in s[10:11] is therefore preserved on every real path to the s_swap_pc_i64 at 0x23a28.

The temporary dataflow CFG correctly omitted fallthrough from s_trap 2, but then treated every predecessorless block as an external root. That invented an unconstrained s[10:11] path from 0x22a24 into the live join, making the otherwise dominated builder source_incomplete.

Restrict dataflow roots to the text entry and caller-supplied entries. DBT supplies every descriptor- and firmware-visible kernel entry explicitly, then forms a reachable scope from each entry and emits shared reachable blocks separately for each kernel. A helper is either an explicit leader or has a direct/recovered incoming edge, so a predecessorless post-trap block cannot gain a hidden entry through another kernel scope.

Add a regression with a PC builder, live conditional edge, non-returning trap, dead post-trap edge, and s_swappc join. It verifies that the dead edge remains BOTTOM while the existing explicit-kernel-entry test continues to model genuinely external SGPR state.