### PR TITLE
fix(rocr): reference count userptr mapping in wddm thunk

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/gpu_memory.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/gpu_memory.h
@@ -202,6 +202,8 @@ public:
   inline void IncSharedReference() { desc_.flags.is_imported_from_same_process++; }
   inline uint32_t DecSharedReference() { return (desc_.flags.is_imported_from_same_process == 0) ? 0 : --desc_.flags.is_imported_from_same_process; }
   inline bool IsSharedFromSameProcess() const { return desc_.flags.is_imported_from_same_process > 0; }
+  inline uint32_t IncMappingCount() { return ++mapping_count_; }
+  inline uint32_t DecMappingCount() { return (mapping_count_ == 0) ? 0 : --mapping_count_; }
   inline bool IsPhysicalCreated() const { return is_phymem_created; }
 
   WinAllocationHandle GetAllocationHandle(size_t index) const { return alloc_handles_ptr_[index]; }
@@ -264,6 +266,9 @@ private:
 
   bool is_phymem_created = false; // status of physical memory allocation
   bool is_sysmem_locked_ = false; // kSystem allocation pinned via D3DKMTLock2
+
+  // Number of outstanding GPU mappings of a user pointer.
+  uint32_t mapping_count_ = 1;
 
   DISALLOW_COPY_AND_ASSIGN(GpuMemory);
 };

--- a/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
@@ -871,13 +871,12 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMapMemoryToGPUNodes(
       }
     }
 
-    // Reuse only an exact user-pointer mapping.
+    // Reuse the user-pointer mapping already registered for this address.
     auto map_it = allocation_map_->find(MemoryAddress);
     if (map_it != allocation_map_->end() && map_it->second.userptr &&
-        map_it->second.size_requested == MemorySizeInBytes) {
+        map_it->second.size >= aligned_size) {
       wsl::thunk::GpuMemory::Convert(map_it->second.handle)->IncMappingCount();
-      *AlternateVAGPU =
-          (uintptr_t)map_it->second.gpu_addr +
+      *AlternateVAGPU = (uintptr_t)map_it->second.gpu_addr +
           ((uintptr_t)MemoryAddress - (uintptr_t)map_it->second.cpu_addr);
       return HSAKMT_STATUS_SUCCESS;
     }

--- a/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
@@ -872,12 +872,11 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMapMemoryToGPUNodes(
     }
 
     // Reuse the user-pointer mapping already registered for this address.
-    auto map_it = allocation_map_->find(MemoryAddress);
-    if (map_it != allocation_map_->end() && map_it->second.userptr &&
-        map_it->second.size >= aligned_size) {
-      wsl::thunk::GpuMemory::Convert(map_it->second.handle)->IncMappingCount();
-      *AlternateVAGPU = (uintptr_t)map_it->second.gpu_addr +
-          ((uintptr_t)MemoryAddress - (uintptr_t)map_it->second.cpu_addr);
+    auto *allocation = FindAllocation(MemoryAddress, aligned_size);
+    if (allocation != nullptr && allocation->userptr) {
+      wsl::thunk::GpuMemory::Convert(allocation->handle)->IncMappingCount();
+      *AlternateVAGPU = (uintptr_t)allocation->gpu_addr +
+          ((uintptr_t)MemoryAddress - (uintptr_t)allocation->cpu_addr);
       return HSAKMT_STATUS_SUCCESS;
     }
   }

--- a/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
@@ -793,12 +793,6 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtDeregisterMemory(void *MemoryAddress) {
       delete gpu_mem;
       return HSAKMT_STATUS_SUCCESS;
     }
-    if (it->second.userptr) {
-      allocation_map_->erase((void*)it->second.gpu_addr);
-      allocation_map_->erase(it);
-      delete gpu_mem;
-      return HSAKMT_STATUS_SUCCESS;
-    }
   }
   return HSAKMT_STATUS_SUCCESS;
 }
@@ -877,15 +871,15 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMapMemoryToGPUNodes(
       }
     }
 
-    // userptr mem
-    it = FindAllocation(MemoryAddress, aligned_size);
-    if (it != nullptr) {
-      if (it->userptr && it->size >= MemorySizeInBytes) {
-        *AlternateVAGPU =
-            (uintptr_t)it->gpu_addr +
-            ((uintptr_t)MemoryAddress - (uintptr_t)it->cpu_addr);
-        return HSAKMT_STATUS_SUCCESS;
-      }
+    // Reuse only an exact user-pointer mapping.
+    auto map_it = allocation_map_->find(MemoryAddress);
+    if (map_it != allocation_map_->end() && map_it->second.userptr &&
+        map_it->second.size_requested == MemorySizeInBytes) {
+      wsl::thunk::GpuMemory::Convert(map_it->second.handle)->IncMappingCount();
+      *AlternateVAGPU =
+          (uintptr_t)map_it->second.gpu_addr +
+          ((uintptr_t)MemoryAddress - (uintptr_t)map_it->second.cpu_addr);
+      return HSAKMT_STATUS_SUCCESS;
     }
   }
 
@@ -967,6 +961,15 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtUnmapMemoryToGPU(void *MemoryAddress) {
         return HSAKMT_STATUS_ERROR;
       gpu_mem->Evict();
 
+      return HSAKMT_STATUS_SUCCESS;
+    }
+
+    if (it->second.userptr) {
+      if (gpu_mem->DecMappingCount() == 0) {
+        allocation_map_->erase((void*)it->second.gpu_addr);
+        allocation_map_->erase(it);
+        delete gpu_mem;
+      }
       return HSAKMT_STATUS_SUCCESS;
     }
   }
@@ -1292,7 +1295,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMemoryGetCpuAddr(HsaAMDGPUDeviceHandle DeviceHandl
   return HSAKMT_STATUS_SUCCESS;
 }
 
-HSAKMT_STATUS HSAKMTAPI hsaKmtGetAmdGPUDeviceFd(HsaAMDGPUDeviceHandle DeviceHandle, HSAint32* fd) 
+HSAKMT_STATUS HSAKMTAPI hsaKmtGetAmdGPUDeviceFd(HsaAMDGPUDeviceHandle DeviceHandle, HSAint32* fd)
 {
   return HSAKMT_STATUS_NOT_SUPPORTED;
 }


### PR DESCRIPTION
## Motivation

OpenCL conformance test buffer_copy is failing. Test sequence that fails is:
 - Two consecutive clCreateBuffer calls on the same host_ptr following one clReleaseMemObj
 - This results in clReleaseMemObj removing the mapping object, making both cl_mem objects invalid, not just the released one.

## Technical Details

 - Reuse the user-pointer mapping, count the outstanding mappings in GpuMemory, and release the allocation from hsaKmtUnmapMemoryToGPU when it reaches zero.

## Issue Tracking

ISSUE ID
AIRUNTIME-2423

## Test Plan

 - Failing test is OpenCL Conformance test
 - Run the buffer_copy test on windows platform with GPU_ENABLE_PAL=0

## Test Result

 - Test passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
