### PR TITLE
fix(rccl/net_ib_cast): guard ib-cast GIN init against uninitialized devices

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/gin.cc
+++ b/projects/rccl/src/transport/net_ib_cast/gin.cc
@@ -88,7 +88,7 @@ extern ncclGin_t IbCastGinIbProxy;
 ncclResult_t IbCastGinIbInitType(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction, int ginType,
                                  ncclGin_t* ginIb) {
   NCCLCHECK(IbCastInitDevices(logFunction, nullptr));
-  if (IbCastNDevs == 0) return ncclInternalError; // Caught in plugin init code, not propagated to user.
+  if (IbCastNDevs <= 0) return ncclInternalError; // Caught in plugin init code, not propagated to user.
 
 #ifdef RCCL_NET_IB_CAST_ENABLE_GDAKI
   if (ginType == NCCL_GIN_TYPE_GDAKI) goto try_gdaki;


### PR DESCRIPTION
## Motivation

Follow-up hardening to ROCM-27070 (#9085). On an AINIC (Pensando ionic) host whose userspace `libionic` is mismatched, enabling GPU-Initiated Networking (`NCCL_GIN_ENABLE=1 RCCL_AINIC_ROCE=1`) crashes with a SIGSEGV inside `ncclCommInitRank`. This PR makes the internal ib-cast GIN init bail out gracefully and fall back to Socket instead of dereferencing a NULL `ibv_context`.

## Technical Details

Root cause is a sentinel mismatch between the IB-CAST device refcount and the device count:

- `IbCastNDevs` starts at `-1`, meaning "device enumeration never ran", which is distinct from `0` ("enumeration ran, found no devices"): [common.cc#L15](https://github.com/ROCm/rocm-systems/blob/b548e3da476262fc643e69468d8305d517fa163d/projects/rccl/src/transport/net_ib_cast/common.cc#L15)
- `IbCastInitDevices()` increments `netRefCount` first, then returns early when `wrap_ionicdv_symbols()` fails (mismatched libionic is missing `ionic_dv_qp_set_gda@IONIC_1.0`), before reaching enumeration. So `netRefCount == 1` but `IbCastNDevs` stays `-1` and no device is opened (all `ibv_context` pointers remain NULL): [init.cc#L315](https://github.com/ROCm/rocm-systems/blob/b548e3da476262fc643e69468d8305d517fa163d/projects/rccl/src/transport/net_ib_cast/init.cc#L315) and [init.cc#L321-L323](https://github.com/ROCm/rocm-systems/blob/b548e3da476262fc643e69468d8305d517fa163d/projects/rccl/src/transport/net_ib_cast/init.cc#L321-L323)
- The subsequent call from GIN short-circuits on `netRefCount` and returns success, leaving `IbCastNDevs == -1`. The old guard only checked `== 0`, so it missed `-1` and proceeded: [gin.cc#L92](https://github.com/ROCm/rocm-systems/blob/b548e3da476262fc643e69468d8305d517fa163d/projects/rccl/src/transport/net_ib_cast/gin.cc#L92)
- The DMA-BUF probe then reads `ibDev->context` (NULL) and calls `ibv_alloc_pd(NULL)`, which segfaults inside libibverbs: [gdr.cc#L123-L126](https://github.com/ROCm/rocm-systems/blob/b548e3da476262fc643e69468d8305d517fa163d/projects/rccl/src/transport/net_ib_cast/gdr.cc#L123-L126)

Fix: widen the guard to `IbCastNDevs <= 0` so both `-1` (never enumerated / aborted early) and `0` (no devices) are caught. GIN then returns an error and RCCL falls back to Socket instead of crashing.

Note: this is RCCL-side robustness only. The primary (environmental) fix is installing the AMD/Pensando ionic userspace that exports `ionic_dv_qp_set_gda@IONIC_1.0`; the affected host was running stock Ubuntu `rdma-core 61.0` which lacks that GDA symbol.

## JIRA ID

JIRA ID : ROCM-27070

## Test Plan

Reproduced the exact production backtrace on a healthy gfx950 node (ROCm 7.0.2) by simulating the mismatched host with an `LD_PRELOAD` shim that (a) makes `dlvsym("ionic_dv_qp_set_gda", "IONIC_1.0")` return NULL and (b) forces peermem detection off, then running a single-rank NCCL init + allreduce with `NCCL_GIN_ENABLE=1 RCCL_AINIC_ROCE=1`.

## Test Result

- Without the fix (`== 0`): SIGSEGV in `ibv_alloc_pd()` (`rdi=0x0`), backtrace `ibDmaBufSupportInitOnce -> IbCastDmaBufSupport -> IbCastGinIbGdrSupport -> IbCastGinIbInitType -> ncclGinInit -> commAlloc -> ncclCommInitRank`, identical to the field report.
- With the fix (`<= 0`): GIN logs `Failed to initialize any GIN plugin`, falls back to `Using network Socket`, the allreduce completes, exit code 0. No SIGSEGV.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
