### PR TITLE
fix(clr): Disable device-memory AQL ring buffer by default

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -272,19 +272,17 @@ void Settings::setKernelArgImpl(const amd::Isa& isa, bool isXgmi) {
     kernelArgImpl = KernelArgImpl::DeviceKernelArgsReadback;
   }
 
-  // Enable device kernel args and device-memory AQL queue ring buffers by
-  // default on gfx94x/gfx125x.
+  // Enable device kernel args by default on gfx94x/gfx125x. Device-memory AQL
+  // ring buffers are controlled separately via DEBUG_CLR_AQL_DEV_QUEUE below.
   if (isGfx94x || isGfx125x) {
     kernel_arg_impl_ = kernelArgImpl;
     kernel_arg_opt_ = true;
-    aql_device_ring_buf_ = true;
   }
 
   if (!flagIsDefault(HIP_FORCE_DEV_KERNARG)) {
     kernel_arg_impl_ = kernelArgImpl & (HIP_FORCE_DEV_KERNARG ? 0xF : 0x0);
   }
-  if (!flagIsDefault(DEBUG_CLR_AQL_DEV_QUEUE)) {
-    aql_device_ring_buf_ = (DEBUG_CLR_AQL_DEV_QUEUE > 0);
-  }
+
+  aql_device_ring_buf_ = (DEBUG_CLR_AQL_DEV_QUEUE > 0);
 }
 }  // namespace amd::roc


### PR DESCRIPTION
On gfx94x/gfx125x the device-memory AQL ring buffer was force-enabled by default. On large-BAR configurations where ROCr rejects the device-resident ring buffer (e.g. inside some containers), hsa_amd_queue_create fails, the HIP default stream's backing queue cannot be created, and Device::NullStream() returns null. The first default-stream kernel launch then dereferenced that null hip::Stream* in UpdateNumClustersFromKernel, crashing with SIGSEGV.

- rocsettings: make DEBUG_CLR_AQL_DEV_QUEUE the single source of truth for aql_device_ring_buf_ (default 0 = off, 1 = on) instead of force-enabling the device-memory ring buffer on gfx94x/gfx125x. Restores the pre-regression system-memory ring buffer behavior by default; opt-in for device memory.
- hip_module/hip_graph: enforce the invariant that a resolved hip::Stream* is non-null at the getStream() launch boundaries. ihipModuleLaunchKernel and ihipGraphLaunch now return hipErrorInvalidResourceHandle instead of passing a null stream downstream, so a failed default stream fails loudly rather than crashing.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
JIRA ID: AIRUNTIME-2569

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
