### PR TITLE
fix(rocprofiler-sdk): split sanitizer flags from no-undefined policy

### DIFF
--- a/projects/rocprofiler-sdk/cmake/rocprofiler_interfaces.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_interfaces.cmake
@@ -43,6 +43,9 @@ rocprofiler_add_interface_library(rocprofiler-sdk-release-flags
                                   "Compiler flags for more debug info" INTERNAL)
 rocprofiler_add_interface_library(rocprofiler-sdk-stack-protector
                                   "Adds stack-protector compiler flags" INTERNAL)
+rocprofiler_add_interface_library(
+    rocprofiler-sdk-sanitizer
+    "Sanitizer instrumentation flags (no --no-undefined link policy)" INTERNAL)
 rocprofiler_add_interface_library(rocprofiler-sdk-memcheck INTERFACE INTERNAL)
 rocprofiler_add_interface_library(
     rocprofiler-sdk-experimental-flags

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_memcheck.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_memcheck.cmake
@@ -13,14 +13,21 @@ endif()
 
 set_property(CACHE ROCPROFILER_MEMCHECK PROPERTY STRINGS "${ROCPROFILER_MEMCHECK_TYPES}")
 
+# Keep sanitizer instrumentation (rocprofiler-sdk-sanitizer) separate from the strict link
+# policy (rocprofiler-sdk-memcheck) so targets such as Python MODULE libraries can opt into
+# instrumentation without --no-undefined.
 function(rocprofiler_add_memcheck_flags _TYPE _LIB_BASE _FLAG)
     target_compile_options(
-        rocprofiler-sdk-memcheck
+        rocprofiler-sdk-sanitizer
         INTERFACE $<BUILD_INTERFACE:-g3 -Og -fno-omit-frame-pointer
                   -fno-optimize-sibling-calls -fno-inline-functions -fsanitize=${_FLAG}
                   ${ARGN}>)
-    target_link_options(rocprofiler-sdk-memcheck INTERFACE
-                        $<BUILD_INTERFACE:-fsanitize=${_FLAG} -Wl,--no-undefined>)
+    target_link_options(rocprofiler-sdk-sanitizer
+                        INTERFACE $<BUILD_INTERFACE:-fsanitize=${_FLAG}>)
+    target_link_libraries(rocprofiler-sdk-memcheck
+                          INTERFACE rocprofiler-sdk::rocprofiler-sdk-sanitizer)
+    target_link_options(rocprofiler-sdk-memcheck
+                        INTERFACE $<BUILD_INTERFACE:-Wl,--no-undefined>)
 
     if(NOT EXISTS ${PROJECT_BINARY_DIR}/CMakeFiles/CMakeTmp)
         file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/CMakeFiles/CMakeTmp")
@@ -61,7 +68,7 @@ function(rocprofiler_set_memcheck_env _TYPE _LIB_BASE)
         endforeach()
     endif()
 
-    target_link_libraries(rocprofiler-sdk-memcheck INTERFACE ${_LIB_BASE})
+    target_link_libraries(rocprofiler-sdk-sanitizer INTERFACE ${_LIB_BASE})
 
     if(${_TYPE}_LIBRARY)
         set(ROCPROFILER_MEMCHECK_PRELOAD_ENV

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_memcheck.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_memcheck.cmake
@@ -14,20 +14,20 @@ endif()
 set_property(CACHE ROCPROFILER_MEMCHECK PROPERTY STRINGS "${ROCPROFILER_MEMCHECK_TYPES}")
 
 # Keep sanitizer instrumentation (rocprofiler-sdk-sanitizer) separate from the strict link
-# policy (rocprofiler-sdk-memcheck) so targets such as Python MODULE libraries can opt into
-# instrumentation without --no-undefined.
+# policy (rocprofiler-sdk-memcheck) so targets such as Python MODULE libraries can opt
+# into instrumentation without --no-undefined.
 function(rocprofiler_add_memcheck_flags _TYPE _LIB_BASE _FLAG)
     target_compile_options(
         rocprofiler-sdk-sanitizer
         INTERFACE $<BUILD_INTERFACE:-g3 -Og -fno-omit-frame-pointer
                   -fno-optimize-sibling-calls -fno-inline-functions -fsanitize=${_FLAG}
                   ${ARGN}>)
-    target_link_options(rocprofiler-sdk-sanitizer
-                        INTERFACE $<BUILD_INTERFACE:-fsanitize=${_FLAG}>)
+    target_link_options(rocprofiler-sdk-sanitizer INTERFACE
+                        $<BUILD_INTERFACE:-fsanitize=${_FLAG}>)
     target_link_libraries(rocprofiler-sdk-memcheck
                           INTERFACE rocprofiler-sdk::rocprofiler-sdk-sanitizer)
-    target_link_options(rocprofiler-sdk-memcheck
-                        INTERFACE $<BUILD_INTERFACE:-Wl,--no-undefined>)
+    target_link_options(rocprofiler-sdk-memcheck INTERFACE
+                        $<BUILD_INTERFACE:-Wl,--no-undefined>)
 
     if(NOT EXISTS ${PROJECT_BINARY_DIR}/CMakeFiles/CMakeTmp)
         file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/CMakeFiles/CMakeTmp")

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(
     PRIVATE $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-headers>
             # $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-build-flags>
             $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-threading>
-            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-memcheck>
+            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-sanitizer>
             $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-cxx-filesystem>
             $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-abseil>
             $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-fmt>

--- a/projects/rocprofiler-sdk/source/lib/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/common/CMakeLists.txt
@@ -59,7 +59,7 @@ target_link_libraries(
     PUBLIC $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-headers>
            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-build-flags>
            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-threading>
-           $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-memcheck>
+           $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-sanitizer>
            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-cxx-filesystem>
            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-abseil>
            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-fmt>

--- a/projects/rocprofiler-sdk/source/lib/output/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/output/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_libraries(
            rocprofiler-sdk::rocprofiler-sdk-aqlprofile
     PRIVATE rocprofiler-sdk::rocprofiler-sdk-headers
             rocprofiler-sdk::rocprofiler-sdk-build-flags
-            rocprofiler-sdk::rocprofiler-sdk-memcheck
+            rocprofiler-sdk::rocprofiler-sdk-sanitizer
             rocprofiler-sdk::rocprofiler-sdk-common-library
             rocprofiler-sdk::rocprofiler-sdk-cereal
             rocprofiler-sdk::rocprofiler-sdk-perfetto

--- a/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
+++ b/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
@@ -199,9 +199,9 @@ function(rocprofiler_rocpd_python_bindings _VERSION)
 
     # do not link to sqlite3 library here. Python will import the _sqlite3 extension
     # module which links to sqlite3, and we want to avoid mixed-lib symbol collisions by
-    # ensuring Python and librocpd use the same sqlite3 library.
-    # Use the sanitizer-only target because this Python MODULE intentionally leaves
-    # SQLite symbols unresolved until Python loads _sqlite3.
+    # ensuring Python and librocpd use the same sqlite3 library. Use the sanitizer-only
+    # target because this Python MODULE intentionally leaves SQLite symbols unresolved
+    # until Python loads _sqlite3.
     target_link_libraries(
         rocprofiler-sdk-rocpd-python-bindings-${_VERSION}
         PRIVATE rocprofiler-sdk::rocprofiler-sdk-headers

--- a/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
+++ b/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
@@ -200,11 +200,13 @@ function(rocprofiler_rocpd_python_bindings _VERSION)
     # do not link to sqlite3 library here. Python will import the _sqlite3 extension
     # module which links to sqlite3, and we want to avoid mixed-lib symbol collisions by
     # ensuring Python and librocpd use the same sqlite3 library.
+    # Use the sanitizer-only target because this Python MODULE intentionally leaves
+    # SQLite symbols unresolved until Python loads _sqlite3.
     target_link_libraries(
         rocprofiler-sdk-rocpd-python-bindings-${_VERSION}
         PRIVATE rocprofiler-sdk::rocprofiler-sdk-headers
                 rocprofiler-sdk::rocprofiler-sdk-build-flags
-                rocprofiler-sdk::rocprofiler-sdk-memcheck
+                rocprofiler-sdk::rocprofiler-sdk-sanitizer
                 rocprofiler-sdk::rocprofiler-sdk-common-library
                 rocprofiler-sdk::rocprofiler-sdk-output-library
                 rocprofiler-sdk::rocprofiler-sdk-cereal

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries(
     PRIVATE rocprofiler-sdk::rocprofiler-sdk-shared-library
             rocprofiler-sdk::rocprofiler-sdk-headers
             rocprofiler-sdk::rocprofiler-sdk-build-flags
+            rocprofiler-sdk::rocprofiler-sdk-memcheck
             rocprofiler-sdk::rocprofiler-sdk-common-library
             rocprofiler-sdk::rocprofiler-sdk-cereal)
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/kokkosp/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/kokkosp/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(
     rocprofiler-sdk-tool-kokkosp
     PRIVATE rocprofiler-sdk-roctx::rocprofiler-sdk-roctx-shared-library
             rocprofiler-sdk::rocprofiler-sdk-headers
+            rocprofiler-sdk::rocprofiler-sdk-memcheck
             rocprofiler-sdk::rocprofiler-sdk-common-library
             rocprofiler-sdk::rocprofiler-sdk-abseil)
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/CMakeLists.txt
@@ -66,7 +66,7 @@ target_link_libraries(
     rocprofiler-sdk-object-library
     PUBLIC rocprofiler-sdk::rocprofiler-sdk-headers
     PRIVATE rocprofiler-sdk::rocprofiler-sdk-build-flags
-            rocprofiler-sdk::rocprofiler-sdk-memcheck
+            rocprofiler-sdk::rocprofiler-sdk-sanitizer
             rocprofiler-sdk::rocprofiler-sdk-common-library
             rocprofiler-sdk::rocprofiler-sdk-amd-comgr
             rocprofiler-sdk::rocprofiler-sdk-aqlprofile


### PR DESCRIPTION
## Motivation

When `rocprofiler-sdk` is configured with any sanitizer enabled via `ROCPROFILER_MEMCHECK` (`AddressSanitizer`, `ThreadSanitizer`, `LeakSanitizer`, or `UndefinedBehaviorSanitizer`), the build fails during linking of the Python bindings module `rocprofiler-sdk-rocpd-python-bindings-<pyver>` (`libpyrocpd.cpython-*.so`). 

## Technical Details

Introduce a sanitizer-only memcheck interface target so sanitizer builds can apply compile and runtime link instrumentation without also inheriting -Wl,--no-undefined.

Keep `rocprofiler-sdk::rocprofiler-sdk-memcheck` strict by layering the no-undefined link option on top of the sanitizer-only target. Use the sanitizer-only target for rocpd Python bindings because the Python MODULE intentionally leaves SQLite symbols unresolved until Python loads _sqlite3.

Move intermediate libraries to sanitizer-only propagation and keep strict memcheck on final shared libraries that should continue enforcing undefined symbol checks.

## Issue Tracking

https://github.com/ROCm/rocm-systems/issues/9305

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
