### PR TITLE
[rocprofiler-systems] Block sampling during hsa_init()

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -41,6 +41,7 @@
 #include "library/components/mpi_gotcha.hpp"
 #include "library/components/numa_gotcha.hpp"
 #include "library/components/pthread_gotcha.hpp"
+#include "library/components/sampling_gotcha_policy.hpp"
 #include "library/components/shmem_gotcha_policy.hpp"
 #include "library/components/ucx_gotcha_policy.hpp"
 #include "library/components/vaapi_gotcha.hpp"
@@ -733,6 +734,15 @@ rocprofsys_init_tooling_hidden(void)
         component::vaapi_gotcha::start();
     }
 
+    if(get_use_sampling())
+    {
+        // certain functions can fail if a sampling signal is delivered during their
+        // execution
+        LOG_DEBUG(
+            "Setting up sampling signal protection for certain runtime functions...");
+        component::sampling_gotcha<rocprofsys::DefaultSamplingPolicy>::start();
+    }
+
     if(get_use_sampling()) sampling::block_signals();
 
     // perfetto initialization
@@ -1100,6 +1110,7 @@ rocprofsys_finalize_hidden(void)
     {
         LOG_DEBUG("Shutting down sampling...");
         sampling::shutdown();
+        component::sampling_gotcha<rocprofsys::DefaultSamplingPolicy>::shutdown();
     }
 
     LOG_TRACE("Reporting the process- and thread-level metrics...");

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/CMakeLists.txt
@@ -13,6 +13,7 @@ set(component_sources
     ${CMAKE_CURRENT_LIST_DIR}/kill_gotcha.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mpi_gotcha.cpp
     ${CMAKE_CURRENT_LIST_DIR}/numa_gotcha.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/sampling_gotcha.cpp
     ${CMAKE_CURRENT_LIST_DIR}/shmem_gotcha.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ucx_gotcha.cpp
     ${CMAKE_CURRENT_LIST_DIR}/vaapi_gotcha.cpp
@@ -35,6 +36,7 @@ set(component_headers
     ${CMAKE_CURRENT_LIST_DIR}/mpip.hpp
     ${CMAKE_CURRENT_LIST_DIR}/mpi_gotcha.hpp
     ${CMAKE_CURRENT_LIST_DIR}/numa_gotcha.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/sampling_gotcha.hpp
     ${CMAKE_CURRENT_LIST_DIR}/shmem_gotcha.hpp
     ${CMAKE_CURRENT_LIST_DIR}/ucx_gotcha.hpp
     ${CMAKE_CURRENT_LIST_DIR}/vaapi_gotcha.hpp

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/sampling_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/sampling_gotcha.cpp
@@ -1,0 +1,10 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "library/components/sampling_gotcha.hpp"
+#include "library/components/sampling_gotcha_policy.hpp"
+
+#include <timemory/components/macros.hpp>
+
+TIMEMORY_STORAGE_INITIALIZER(
+    rocprofsys::component::sampling_gotcha<rocprofsys::DefaultSamplingPolicy>)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/sampling_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/sampling_gotcha.hpp
@@ -1,0 +1,210 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <timemory/components/base/declaration.hpp>
+
+#include <csignal>
+#include <cstddef>
+#include <set>
+#include <string>
+#include <type_traits>
+
+namespace rocprofsys::component::sampling_concepts
+{
+template <typename Policy>
+concept HasGotchaData = requires { typename Policy::gotcha_data_t; };
+
+template <typename Policy>
+concept HasGotcha = requires { typename Policy::gotcha_t; };
+
+template <typename Policy>
+concept HasGotchaBundle = requires { typename Policy::gotcha_bundle_t; };
+}  // namespace rocprofsys::component::sampling_concepts
+
+namespace rocprofsys
+{
+namespace component
+{
+// Blocks the sampling signals for the scope. Restores the caller's mask verbatim
+// instead of unblocking, since callers such as sampler setup, thread creation and MPI
+// finalize hold these signals blocked across regions that reach a wrapped function.
+template <typename Policy>
+struct scoped_sampling_block
+{
+    scoped_sampling_block()
+    {
+        if(s_depth++ != 0) return;
+
+        const auto* _signals = Policy::get_sampling_signals();
+        if(!_signals || _signals->empty()) return;
+
+        auto _blocked = sigset_t{};
+        sigemptyset(&_blocked);
+        for(auto itr : *_signals)
+            sigaddset(&_blocked, itr);
+
+        m_restore = (Policy::block_signals(&_blocked, &m_prev_mask) == 0);
+    }
+
+    ~scoped_sampling_block()
+    {
+        if(--s_depth == 0 && m_restore) Policy::restore_signals(&m_prev_mask);
+    }
+
+    scoped_sampling_block(const scoped_sampling_block&)            = delete;
+    scoped_sampling_block(scoped_sampling_block&&)                 = delete;
+    scoped_sampling_block& operator=(const scoped_sampling_block&) = delete;
+    scoped_sampling_block& operator=(scoped_sampling_block&&)      = delete;
+
+private:
+    static thread_local int s_depth;
+
+    sigset_t m_prev_mask{};
+    bool     m_restore = false;
+};
+
+template <typename Policy>
+thread_local int scoped_sampling_block<Policy>::s_depth = 0;
+
+// Wraps function calls that can fail if a sampling signal is delivered during their
+// execution. Only hsa_init is covered for now; see configure() for why that is the
+// entry point and how to widen the set.
+template <typename Policy>
+struct sampling_gotcha : tim::component::base<sampling_gotcha<Policy>, void>
+{
+    // gotcha_t and gotcha_bundle_t are checked in the member functions rather than
+    // here: the policy names this component to size its own gotcha_t, so those types
+    // do not exist yet while this class body is being instantiated
+    static_assert(sampling_concepts::HasGotchaData<Policy>,
+                  "Policy must have a gotcha_data_t type");
+
+    // Binding slots, one per wrapped function. To cover another entry point, add a
+    // slot here and a matching configure() call in the initializer; the capacity below
+    // follows along on its own, so the two cannot drift apart.
+    enum wrapped_call : size_t
+    {
+        hsa_init_slot = 0,
+        wrapped_call_count
+    };
+
+    static constexpr size_t gotcha_capacity = wrapped_call_count;
+
+    using gotcha_data_t = typename Policy::gotcha_data_t;
+
+    // string id for component
+    static std::string label() { return "sampling_gotcha"; }
+
+    // generate the gotcha wrappers
+    static void configure();
+    static void shutdown();
+
+    // activate / deactivate the gotcha bindings
+    static void start();
+    static void stop();
+
+    // mask sampling signals -> call the real function -> restore signals
+    template <typename Ret, typename... Args>
+    Ret operator()(const gotcha_data_t&, Ret (*)(Args...), Args...) const;
+};
+
+namespace detail
+{
+template <typename Policy>
+auto&
+get_sampling_gotcha()
+{
+    static auto _v = typename Policy::gotcha_bundle_t{};
+    return _v;
+}
+}  // namespace detail
+
+template <typename Policy>
+void
+sampling_gotcha<Policy>::configure()
+{
+    static_assert(sampling_concepts::HasGotcha<Policy>,
+                  "Policy must have a gotcha_t type");
+
+    using gotcha_t = typename Policy::gotcha_t;
+
+    // A process that never loads the GPU runtime has no such symbol to bind, which is
+    // not a fault, so stay quiet about a failed binding unless asked for detail
+    if(Policy::suppress_binding_warnings())
+    {
+        for(size_t i = 0; i < gotcha_t::capacity(); ++i)
+        {
+            auto* itr = static_cast<gotcha_data_t*>(gotcha_t::at(i));
+            if(itr) itr->verbose = -1;
+        }
+    }
+
+    gotcha_t::get_initializer() = []() {
+        // hsa_init is the choke point behind HIP entry points, and it is where the
+        // device discovery that talks to the driver happens.
+        gotcha_t::template configure<hsa_init_slot, int>("hsa_init");
+    };
+}
+
+template <typename Policy>
+void
+sampling_gotcha<Policy>::shutdown()
+{
+    static_assert(sampling_concepts::HasGotcha<Policy>,
+                  "Policy must have a gotcha_t type");
+
+    Policy::gotcha_t::disable();
+}
+
+template <typename Policy>
+void
+sampling_gotcha<Policy>::start()
+{
+    static_assert(sampling_concepts::HasGotcha<Policy>,
+                  "Policy must have a gotcha_t type");
+    static_assert(sampling_concepts::HasGotchaBundle<Policy>,
+                  "Policy must have a gotcha_bundle_t type");
+
+    using gotcha_t = typename Policy::gotcha_t;
+
+    if(!detail::get_sampling_gotcha<Policy>().template get<gotcha_t>()->get_is_running())
+    {
+        configure();
+        detail::get_sampling_gotcha<Policy>().template get<gotcha_t>()->start();
+    }
+}
+
+template <typename Policy>
+void
+sampling_gotcha<Policy>::stop()
+{
+    static_assert(sampling_concepts::HasGotcha<Policy>,
+                  "Policy must have a gotcha_t type");
+    static_assert(sampling_concepts::HasGotchaBundle<Policy>,
+                  "Policy must have a gotcha_bundle_t type");
+
+    using gotcha_t = typename Policy::gotcha_t;
+
+    detail::get_sampling_gotcha<Policy>().template get<gotcha_t>()->stop();
+}
+
+template <typename Policy>
+template <typename Ret, typename... Args>
+Ret
+sampling_gotcha<Policy>::operator()(const gotcha_data_t&, Ret (*_func)(Args...),
+                                    Args... _args) const
+{
+    if constexpr(std::is_void_v<Ret>)
+    {
+        scoped_sampling_block<Policy> _block{};
+        (*_func)(_args...);
+    }
+    else
+    {
+        scoped_sampling_block<Policy> _block{};
+        return (*_func)(_args...);
+    }
+}
+}  // namespace component
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/sampling_gotcha_policy.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/sampling_gotcha_policy.hpp
@@ -1,0 +1,58 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "core/common.hpp"
+#include "core/config.hpp"
+#include "core/timemory.hpp"
+#include "library/components/sampling_gotcha.hpp"
+#include "library/sampling.hpp"
+
+#include <timemory/components/gotcha/backends.hpp>
+#include <timemory/components/gotcha/components.hpp>
+#include <timemory/process/threading.hpp>
+#include <timemory/variadic/lightweight_tuple.hpp>
+
+#include <csignal>
+#include <pthread.h>
+#include <set>
+#include <tuple>
+
+namespace rocprofsys
+{
+struct DefaultSamplingPolicy
+{
+    using gotcha_data_t = tim::component::gotcha_data;
+    using component_t   = component::sampling_gotcha<DefaultSamplingPolicy>;
+    using gotcha_t =
+        comp::gotcha<component_t::gotcha_capacity, std::tuple<>, component_t>;
+    using gotcha_bundle_t = tim::lightweight_tuple<gotcha_t>;
+
+    // Binding failures are expected in processes that never load the GPU runtime, so
+    // they are only worth reporting to someone who asked for the detail.
+    static bool suppress_binding_warnings()
+    {
+        return get_verbose_env() < 3 && !get_debug_env();
+    }
+
+    // Returns null when this thread has no sampling signals registered, which is the
+    // case before the sampler is set up and after it is torn down. Returned by
+    // pointer so that the wrapper does not allocate on every wrapped call.
+    static const std::set<int>* get_sampling_signals()
+    {
+        const auto& _signals = sampling::get_signal_types(threading::get_id());
+        return (_signals) ? _signals.get() : nullptr;
+    }
+
+    static int block_signals(const sigset_t* _blocked, sigset_t* _prev)
+    {
+        return pthread_sigmask(SIG_BLOCK, _blocked, _prev);
+    }
+
+    static int restore_signals(const sigset_t* _prev)
+    {
+        return pthread_sigmask(SIG_SETMASK, _prev, nullptr);
+    }
+};
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(
     test_shmem_gotcha.cpp
     test_ucx_gotcha.cpp
     test_pthread_mutex_gotcha.cpp
+    test_sampling_gotcha.cpp
     test_category_region.cpp
 )
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/tests/test_sampling_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/tests/test_sampling_gotcha.cpp
@@ -1,0 +1,588 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocprof-sys/library/components/sampling_gotcha.hpp"
+
+#include <cerrno>
+#include <csignal>
+#include <cstddef>
+#include <functional>
+#include <gtest/gtest.h>
+#include <pthread.h>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+// Everything below has internal linkage on purpose: the component tests are compiled
+// into a single rocprof-sys-unit-tests binary and the sibling suites declare their own
+// test_globals with names such as g_callee_calls, so anything with external linkage
+// here collides at link time.
+namespace
+{
+// Real-time signals well clear of the ones glibc reserves for itself, so that
+// blocking them in a test cannot perturb anything else in the process.
+int
+signal_a()
+{
+    return SIGRTMIN + 4;
+}
+
+int
+signal_b()
+{
+    return SIGRTMIN + 5;
+}
+
+std::set<int>
+to_set(const sigset_t* _mask)
+{
+    auto _signals = std::set<int>{};
+    if(!_mask) return _signals;
+    for(int i = 1; i <= SIGRTMAX; ++i)
+        if(sigismember(_mask, i) == 1) _signals.emplace(i);
+    return _signals;
+}
+
+sigset_t
+make_mask(const std::set<int>& _signals)
+{
+    auto _mask = sigset_t{};
+    sigemptyset(&_mask);
+    for(auto itr : _signals)
+        sigaddset(&_mask, itr);
+    return _mask;
+}
+
+bool
+is_blocked(int _signal)
+{
+    auto _current = sigset_t{};
+    sigemptyset(&_current);
+    pthread_sigmask(SIG_BLOCK, nullptr, &_current);
+    return sigismember(&_current, _signal) == 1;
+}
+
+struct MockGotchaData
+{
+    int verbose = 0;
+};
+
+namespace test_globals
+{
+// signal set the policy reports for the current thread
+std::set<int> g_signals;
+bool          g_signals_available = true;
+
+// recorded sigmask traffic
+struct sigmask_call
+{
+    std::string   op;
+    std::set<int> signals;
+};
+std::vector<sigmask_call> g_calls;
+
+// what the recording policy hands back as the caller's previous mask
+std::set<int> g_previous_mask;
+int           g_block_result = 0;
+
+// mocked gotcha state
+bool                        g_suppress_warnings = true;
+bool                        g_is_running        = false;
+int                         g_start_calls       = 0;
+int                         g_stop_calls        = 0;
+int                         g_disable_calls     = 0;
+std::function<void()>       g_initializer;
+std::vector<std::string>    g_configured;
+std::vector<MockGotchaData> g_data;
+
+// observations made from inside a wrapped call
+bool g_blocked_during_call = false;
+int  g_callee_calls        = 0;
+
+void
+reset()
+{
+    g_signals           = { signal_a() };
+    g_signals_available = true;
+    g_calls.clear();
+    g_previous_mask     = { signal_b() };
+    g_block_result      = 0;
+    g_suppress_warnings = true;
+    g_is_running        = false;
+    g_start_calls       = 0;
+    g_stop_calls        = 0;
+    g_disable_calls     = 0;
+    g_initializer       = nullptr;
+    g_configured.clear();
+    g_blocked_during_call = false;
+    g_callee_calls        = 0;
+}
+}  // namespace test_globals
+
+// Stands in for the timemory gotcha type: the static half is the binding interface
+// used by configure()/shutdown(), the instance half is what the bundle hands out.
+struct MockGotcha
+{
+    template <size_t N, typename Ret, typename... Args>
+    static void configure(std::string _name)
+    {
+        test_globals::g_configured.emplace_back(std::move(_name));
+    }
+
+    static size_t capacity() { return test_globals::g_data.size(); }
+
+    static MockGotchaData* at(size_t _idx)
+    {
+        return (_idx < test_globals::g_data.size()) ? &test_globals::g_data.at(_idx)
+                                                    : nullptr;
+    }
+
+    static std::function<void()>& get_initializer()
+    {
+        return test_globals::g_initializer;
+    }
+
+    static void disable() { ++test_globals::g_disable_calls; }
+
+    bool get_is_running() const { return test_globals::g_is_running; }
+
+    void start()
+    {
+        test_globals::g_is_running = true;
+        ++test_globals::g_start_calls;
+    }
+
+    void stop()
+    {
+        test_globals::g_is_running = false;
+        ++test_globals::g_stop_calls;
+    }
+};
+
+struct MockGotchaBundle
+{
+    MockGotcha instance;
+
+    template <typename>
+    MockGotcha* get()
+    {
+        return &instance;
+    }
+};
+
+// Records the sigmask traffic instead of performing it, so the exact sequence of
+// operations and the contents of each mask can be asserted.
+struct RecordingPolicy
+{
+    using gotcha_data_t   = MockGotchaData;
+    using gotcha_t        = MockGotcha;
+    using gotcha_bundle_t = MockGotchaBundle;
+
+    static bool suppress_binding_warnings() { return test_globals::g_suppress_warnings; }
+
+    static const std::set<int>* get_sampling_signals()
+    {
+        return (test_globals::g_signals_available) ? &test_globals::g_signals : nullptr;
+    }
+
+    static int block_signals(const sigset_t* _blocked, sigset_t* _prev)
+    {
+        test_globals::g_calls.push_back({ "block", to_set(_blocked) });
+        if(_prev) *_prev = make_mask(test_globals::g_previous_mask);
+        return test_globals::g_block_result;
+    }
+
+    static int restore_signals(const sigset_t* _prev)
+    {
+        test_globals::g_calls.push_back({ "restore", to_set(_prev) });
+        return 0;
+    }
+};
+
+// Drives the real pthread_sigmask so that the mask the thread actually ends up with
+// can be observed.
+struct RealSigmaskPolicy
+{
+    using gotcha_data_t   = MockGotchaData;
+    using gotcha_t        = MockGotcha;
+    using gotcha_bundle_t = MockGotchaBundle;
+
+    static bool suppress_binding_warnings() { return true; }
+
+    static const std::set<int>* get_sampling_signals()
+    {
+        return (test_globals::g_signals_available) ? &test_globals::g_signals : nullptr;
+    }
+
+    static int block_signals(const sigset_t* _blocked, sigset_t* _prev)
+    {
+        return pthread_sigmask(SIG_BLOCK, _blocked, _prev);
+    }
+
+    static int restore_signals(const sigset_t* _prev)
+    {
+        return pthread_sigmask(SIG_SETMASK, _prev, nullptr);
+    }
+};
+
+using recording_block_t = rocprofsys::component::scoped_sampling_block<RecordingPolicy>;
+using real_block_t      = rocprofsys::component::scoped_sampling_block<RealSigmaskPolicy>;
+using recording_gotcha_t = rocprofsys::component::sampling_gotcha<RecordingPolicy>;
+using real_gotcha_t      = rocprofsys::component::sampling_gotcha<RealSigmaskPolicy>;
+
+int
+probe_callee(int _value)
+{
+    ++test_globals::g_callee_calls;
+    test_globals::g_blocked_during_call = is_blocked(signal_a());
+    return _value * 2;
+}
+
+void
+void_callee()
+{
+    ++test_globals::g_callee_calls;
+    test_globals::g_blocked_during_call = is_blocked(signal_a());
+}
+
+int
+throwing_callee(int)
+{
+    throw std::runtime_error{ "wrapped call failed" };
+}
+}  // namespace
+
+class sampling_gotcha_test : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        test_globals::reset();
+        // the mock stands in for the real gotcha's slot array, so it has to be sized
+        // from the component rather than a literal that can drift from it
+        test_globals::g_data.assign(recording_gotcha_t::gotcha_capacity,
+                                    MockGotchaData{});
+
+        // start every test from a known, empty mask
+        auto _empty = sigset_t{};
+        sigemptyset(&_empty);
+        pthread_sigmask(SIG_SETMASK, &_empty, &m_entry_mask);
+    }
+
+    void TearDown() override { pthread_sigmask(SIG_SETMASK, &m_entry_mask, nullptr); }
+
+private:
+    sigset_t m_entry_mask{};
+};
+
+// --- mask neutrality -------------------------------------------------------------
+
+// A caller that deliberately holds the sampling signals blocked must still have them
+// blocked once the wrapper returns. Unblocking here would resume sampling on a thread
+// that had switched it off.
+TEST_F(sampling_gotcha_test, LeavesSignalsBlockedWhenCallerHadThemBlocked)
+{
+    auto _blocked = make_mask({ signal_a() });
+    pthread_sigmask(SIG_BLOCK, &_blocked, nullptr);
+    ASSERT_TRUE(is_blocked(signal_a()));
+
+    {
+        real_block_t _scope{};
+        EXPECT_TRUE(is_blocked(signal_a()));
+    }
+
+    EXPECT_TRUE(is_blocked(signal_a()));
+}
+
+TEST_F(sampling_gotcha_test, BlocksDuringScopeAndUnblocksWhenCallerHadThemUnblocked)
+{
+    ASSERT_FALSE(is_blocked(signal_a()));
+
+    {
+        real_block_t _scope{};
+        EXPECT_TRUE(is_blocked(signal_a()));
+    }
+
+    EXPECT_FALSE(is_blocked(signal_a()));
+}
+
+TEST_F(sampling_gotcha_test, LeavesUnrelatedSignalsInTheMaskUntouched)
+{
+    auto _blocked = make_mask({ signal_b() });
+    pthread_sigmask(SIG_BLOCK, &_blocked, nullptr);
+
+    {
+        real_block_t _scope{};
+        EXPECT_TRUE(is_blocked(signal_b()));
+    }
+
+    EXPECT_TRUE(is_blocked(signal_b()));
+    EXPECT_FALSE(is_blocked(signal_a()));
+}
+
+TEST_F(sampling_gotcha_test, RestoresTheMaskThatBlockSaved)
+{
+    {
+        recording_block_t _scope{};
+    }
+
+    ASSERT_EQ(test_globals::g_calls.size(), 2U);
+    EXPECT_EQ(test_globals::g_calls[0].op, "block");
+    EXPECT_EQ(test_globals::g_calls[0].signals, std::set<int>({ signal_a() }));
+    EXPECT_EQ(test_globals::g_calls[1].op, "restore");
+    EXPECT_EQ(test_globals::g_calls[1].signals, std::set<int>({ signal_b() }));
+}
+
+TEST_F(sampling_gotcha_test, BlocksExactlyTheRegisteredSamplingSignals)
+{
+    test_globals::g_signals = { signal_a(), signal_b() };
+
+    {
+        recording_block_t _scope{};
+    }
+
+    ASSERT_FALSE(test_globals::g_calls.empty());
+    EXPECT_EQ(test_globals::g_calls[0].signals,
+              std::set<int>({ signal_a(), signal_b() }));
+}
+
+// --- nesting ---------------------------------------------------------------------
+
+TEST_F(sampling_gotcha_test, NestedScopesTouchTheMaskOnlyOnTheOuterBoundary)
+{
+    {
+        recording_block_t _outer{};
+        {
+            recording_block_t _inner{};
+            EXPECT_EQ(test_globals::g_calls.size(), 1U);
+        }
+        EXPECT_EQ(test_globals::g_calls.size(), 1U);
+    }
+
+    ASSERT_EQ(test_globals::g_calls.size(), 2U);
+    EXPECT_EQ(test_globals::g_calls[0].op, "block");
+    EXPECT_EQ(test_globals::g_calls[1].op, "restore");
+}
+
+TEST_F(sampling_gotcha_test, NestingDepthUnwindsSoALaterScopeBlocksAgain)
+{
+    {
+        recording_block_t _outer{};
+        recording_block_t _inner{};
+    }
+    test_globals::g_calls.clear();
+
+    {
+        recording_block_t _scope{};
+    }
+
+    ASSERT_EQ(test_globals::g_calls.size(), 2U);
+    EXPECT_EQ(test_globals::g_calls[0].op, "block");
+}
+
+TEST_F(sampling_gotcha_test, NestedRealScopesRestoreTheOutermostCallersMask)
+{
+    auto _blocked = make_mask({ signal_a() });
+    pthread_sigmask(SIG_BLOCK, &_blocked, nullptr);
+
+    {
+        real_block_t _outer{};
+        {
+            real_block_t _inner{};
+            EXPECT_TRUE(is_blocked(signal_a()));
+        }
+        EXPECT_TRUE(is_blocked(signal_a()));
+    }
+
+    EXPECT_TRUE(is_blocked(signal_a()));
+}
+
+// --- degenerate signal sets ------------------------------------------------------
+
+TEST_F(sampling_gotcha_test, DoesNotTouchTheMaskWhenNoSignalsAreRegistered)
+{
+    test_globals::g_signals.clear();
+
+    {
+        recording_block_t _scope{};
+    }
+
+    EXPECT_TRUE(test_globals::g_calls.empty());
+}
+
+TEST_F(sampling_gotcha_test, DoesNotTouchTheMaskWhenTheSignalSetIsUnavailable)
+{
+    test_globals::g_signals_available = false;
+
+    {
+        recording_block_t _scope{};
+    }
+
+    EXPECT_TRUE(test_globals::g_calls.empty());
+}
+
+TEST_F(sampling_gotcha_test, DoesNotRestoreWhenBlockingFails)
+{
+    test_globals::g_block_result = EINVAL;
+
+    {
+        recording_block_t _scope{};
+    }
+
+    ASSERT_EQ(test_globals::g_calls.size(), 1U);
+    EXPECT_EQ(test_globals::g_calls[0].op, "block");
+}
+
+// --- exception safety ------------------------------------------------------------
+
+TEST_F(sampling_gotcha_test, RestoresTheMaskWhenTheWrappedCallThrows)
+{
+    ASSERT_FALSE(is_blocked(signal_a()));
+
+    EXPECT_THROW(
+        {
+            real_gotcha_t _gotcha{};
+            _gotcha(MockGotchaData{}, &throwing_callee, 1);
+        },
+        std::runtime_error);
+
+    EXPECT_FALSE(is_blocked(signal_a()));
+}
+
+// --- per-thread independence -----------------------------------------------------
+
+TEST_F(sampling_gotcha_test, NestingDepthIsTrackedPerThread)
+{
+    recording_block_t _outer_on_main{};
+    ASSERT_EQ(test_globals::g_calls.size(), 1U);
+    test_globals::g_calls.clear();
+
+    // a fresh thread starts at depth zero, so it masks the signals itself instead of
+    // assuming the depth held by the thread that created it
+    std::thread{ []() { recording_block_t _scope{}; } }.join();
+
+    ASSERT_EQ(test_globals::g_calls.size(), 2U);
+    EXPECT_EQ(test_globals::g_calls[0].op, "block");
+    EXPECT_EQ(test_globals::g_calls[1].op, "restore");
+}
+
+// A new thread inherits its creator's mask, so a thread spawned while the signals are
+// blocked has to leave them blocked -- the same reason the wrapper restores rather
+// than unblocks.
+TEST_F(sampling_gotcha_test, PreservesAnInheritedBlockedMaskInANewThread)
+{
+    real_block_t _outer_on_main{};
+    ASSERT_TRUE(is_blocked(signal_a()));
+
+    auto _blocked_inside_thread = false;
+    auto _blocked_after_thread  = false;
+
+    std::thread{ [&]() {
+        {
+            real_block_t _scope{};
+            _blocked_inside_thread = is_blocked(signal_a());
+        }
+        _blocked_after_thread = is_blocked(signal_a());
+    } }.join();
+
+    EXPECT_TRUE(_blocked_inside_thread);
+    EXPECT_TRUE(_blocked_after_thread);
+    EXPECT_TRUE(is_blocked(signal_a()));
+}
+
+// --- the wrapper itself ----------------------------------------------------------
+
+TEST_F(sampling_gotcha_test, ForwardsArgumentsAndReturnValueAndBlocksDuringTheCall)
+{
+    real_gotcha_t _gotcha{};
+
+    EXPECT_EQ(_gotcha(MockGotchaData{}, &probe_callee, 21), 42);
+    EXPECT_EQ(test_globals::g_callee_calls, 1);
+    EXPECT_TRUE(test_globals::g_blocked_during_call);
+    EXPECT_FALSE(is_blocked(signal_a()));
+}
+
+TEST_F(sampling_gotcha_test, WrapsCallsThatReturnVoid)
+{
+    real_gotcha_t _gotcha{};
+
+    _gotcha(MockGotchaData{}, &void_callee);
+
+    EXPECT_EQ(test_globals::g_callee_calls, 1);
+    EXPECT_TRUE(test_globals::g_blocked_during_call);
+    EXPECT_FALSE(is_blocked(signal_a()));
+}
+
+// --- bindings --------------------------------------------------------------------
+
+TEST_F(sampling_gotcha_test, ConfigureRegistersEveryWrappedSymbol)
+{
+    recording_gotcha_t::configure();
+    ASSERT_TRUE(static_cast<bool>(test_globals::g_initializer));
+    test_globals::g_initializer();
+
+    EXPECT_EQ(test_globals::g_configured, std::vector<std::string>({ "hsa_init" }));
+}
+
+// the number of bindings must not outgrow the capacity reserved for them
+TEST_F(sampling_gotcha_test, ConfigureFillsTheDeclaredCapacityExactly)
+{
+    recording_gotcha_t::configure();
+    ASSERT_TRUE(static_cast<bool>(test_globals::g_initializer));
+    test_globals::g_initializer();
+
+    EXPECT_EQ(test_globals::g_configured.size(), recording_gotcha_t::gotcha_capacity);
+}
+
+TEST_F(sampling_gotcha_test, ConfigureSilencesBindingWarningsWhenRequested)
+{
+    test_globals::g_suppress_warnings = true;
+
+    recording_gotcha_t::configure();
+
+    for(const auto& itr : test_globals::g_data)
+        EXPECT_EQ(itr.verbose, -1);
+}
+
+TEST_F(sampling_gotcha_test, ConfigureKeepsBindingWarningsWhenVerbose)
+{
+    test_globals::g_suppress_warnings = false;
+
+    recording_gotcha_t::configure();
+
+    for(const auto& itr : test_globals::g_data)
+        EXPECT_EQ(itr.verbose, 0);
+}
+
+TEST_F(sampling_gotcha_test, ShutdownDisablesTheBindings)
+{
+    recording_gotcha_t::shutdown();
+
+    EXPECT_EQ(test_globals::g_disable_calls, 1);
+}
+
+TEST_F(sampling_gotcha_test, StartIsIdempotentWhileTheGotchaIsRunning)
+{
+    recording_gotcha_t::start();
+    EXPECT_EQ(test_globals::g_start_calls, 1);
+
+    recording_gotcha_t::start();
+    EXPECT_EQ(test_globals::g_start_calls, 1);
+}
+
+// stop() runs on the finalization path, so a subsequent start() has to be able to
+// bring the bindings back up rather than find them still marked as running
+TEST_F(sampling_gotcha_test, StopDeactivatesTheBindingsSoStartCanRunAgain)
+{
+    recording_gotcha_t::start();
+    ASSERT_TRUE(test_globals::g_is_running);
+
+    recording_gotcha_t::stop();
+    EXPECT_EQ(test_globals::g_stop_calls, 1);
+    EXPECT_FALSE(test_globals::g_is_running);
+
+    recording_gotcha_t::start();
+    EXPECT_EQ(test_globals::g_start_calls, 2);
+}

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/tests/test_sampling_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/tests/test_sampling_gotcha.cpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 // Everything below has internal linkage on purpose: the component tests are compiled


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

`transpose-sampling` would sometimes fail with:
```
/<some-path>/projects/rocprofiler-systems/examples/transpose/transpose.cpp:242 :: HIP error : no ROCm-capable device is detected
terminate called after throwing an instance of 'std::runtime_error'
  what():  hip_api_call
```

After investigation, it appears that when the sampler dispatched a signal during the first HIP call, which internally would call `hsa_init`, it would interrupt the process of discovering the GPU and this `transpose` would run without a GPU.

The fix is to wrap `hsa_init` with a gotcha wrapper and block sampling during that period. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- New `sampling_gotcha` component that gotcha-wraps `hsa_init` and blocks the calling thread's sampling signals for the duration of the call, restoring the caller's previous mask afterwards rather than unblocking.
- Structured after the existing `ucx_gotcha` and `shmem_gotcha` implementations, including their policy-based dependency injection so the signal-mask backend and gotcha type can be mocked.
- Files added:
  - `library/components/sampling_gotcha.hpp` — component and RAII signal-mask guard
  - `library/components/sampling_gotcha_policy.hpp` — default policy (`pthread_sigmask` backend, gotcha types)
  - `library/components/sampling_gotcha.cpp` — storage initializer
  - `library/components/tests/test_sampling_gotcha.cpp` — unit tests
- Files modified: `library.cpp` (start/shutdown hooks), the two `CMakeLists.txt` files, and `tests/pytest/test_transpose.py`.
- Unit tests follow the same pattern as the UCX and SHMEM gotcha tests, covering mask handling, nesting, exception safety, per-thread behaviour, and the bindings.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

TBD

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Locally. I run the following command:
```
i=0; while ctest --test-dir rocprof-sys-build -R transpose-sampling --output-on-failure; do i=$((i+1)); echo "===== PASS #$i($(date +%T)) ====="; done; echo "clearclear! FAILED on run #$((i+1)) after $i consecutive passes clearclear!"
```
With `ROCPROFSYS_SAMPLING_DELAY=0.01` to recreate the case where the sampler would run at the same time as the first `hip` call in transpose that wants to get information from the GPU.

## Test Result

<!-- Briefly summarize test outcomes. -->

The same error is no longer observed in my repeated runs.

Note: I have discovered that if sampling frequency is set very high, then it is possible that a deadlock between `glibc` and `libunwind` takes place. Since this is completely different from what the current PR addresses, I will tackle this problem in a different PR, or not at all since sampling freq was set to 5000-10000 whereas in our tests, it is set to 300. (With sampling freq=1000, I have yet to see the deadlock...)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
