### PR TITLE
fix(rccl): rename ncclDevrGetRmaDevWin to ncclDevrGetRmaWin

### DIFF
--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -2262,8 +2262,8 @@ ncclResult_t ncclDevrGetLsaRankPtr(struct ncclComm* comm, struct ncclDevrWindow*
   return ncclSuccess;
 }
 
-// Get the RMA device window handle for a specific context
-ncclGinWindow_t ncclDevrGetRmaDevWin(struct ncclDevrWindow* winHost, int ctx) {
+// Get the RMA window handle for a specific context
+void* ncclDevrGetRmaWin(struct ncclDevrWindow* winHost, int ctx) {
   if (winHost == nullptr) {
     return nullptr;
   }


### PR DESCRIPTION
## Summary

- Renames `ncclDevrGetRmaDevWin` to `ncclDevrGetRmaWin` to match the declaration in `dev_runtime.h` and the call site in `rma_proxy_launch.cc` from NCCL 2.30
- Also fixes the return type from `ncclGinWindow_t` to `void*` to match the header
- Without this fix, `--allow-shlib-undefined` hides the linker error at build time, but PyTorch's `ctypes.CDLL` (`dlopen RTLD_NOW`) fails on the unresolved symbol at runtime

## Test plan

- [ ] Verify librccl.so builds without undefined symbol warnings for `ncclDevrGetRmaWin`
- [ ] Verify `nm -D librccl.so | grep ncclDevrGetRmaWin` shows the symbol as defined (T)
- [ ] Verify PyTorch can load librccl.so without dlopen errors