### PR TITLE
[rocjitsu] Preserve nonreturning control-flow boundaries

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -348,7 +348,7 @@ jobs:
 
       - name: Run gfx1250 DBT corpus tests
         if: ${{ !cancelled() && matrix.enable_tsan == 0 && steps.extract_dbt.outcome == 'success' }}
-        timeout-minutes: ${{ matrix.enable_asan == 1 && 20 || 15 }}
+        timeout-minutes: ${{ matrix.enable_asan == 1 && 30 || 20 }}
         working-directory: ${{ env.ROCJITSU_DBT_CORPUS_DIR }}
         shell: bash
         run: |

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
@@ -71,20 +71,24 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
   return static_cast<uint16_t>((word >> 16) & 0x7fu);
 }
 
-struct DeferredIndirectCall {
-  BasicBlock *source = nullptr;
-  BasicBlock *target = nullptr;
-  BasicBlock *continuation = nullptr;
-  uint64_t source_call_offset = 0;
-  uint16_t return_sreg = 0;
+enum class CallReturnClassification {
+  Unknown,
+  Returning,
+  NonReturning,
 };
 
-struct DeferredDirectCall {
-  BasicBlock *source = nullptr;
+struct DeferredCallTarget {
+  BasicBlock::CallEdgeKind kind = BasicBlock::CallEdgeKind::IndirectSwapPc;
   BasicBlock *target = nullptr;
-  BasicBlock *continuation = nullptr;
   uint64_t source_call_offset = 0;
+};
+
+struct DeferredCallSite {
+  BasicBlock *source = nullptr;
+  BasicBlock *continuation = nullptr;
   uint16_t return_sreg = 0;
+  bool target_set_incomplete = false;
+  std::vector<DeferredCallTarget> targets;
 };
 
 } // namespace
@@ -128,6 +132,19 @@ void BasicBlock::add_successor(BasicBlock &successor) {
     return;
   successors_.push_back(&successor);
   successor.predecessors_.push_back(this);
+}
+
+bool BasicBlock::remove_successor(BasicBlock &successor) {
+  const auto successor_it = std::ranges::find(successors_, &successor);
+  if (successor_it == successors_.end())
+    return false;
+  successors_.erase(successor_it);
+
+  const auto predecessor_it = std::ranges::find(successor.predecessors_, this);
+  assert(predecessor_it != successor.predecessors_.end() &&
+         "successor/predecessor edges must remain inverse");
+  successor.predecessors_.erase(predecessor_it);
+  return true;
 }
 
 void BasicBlock::add_call_edge(CallEdge edge) {
@@ -264,16 +281,22 @@ std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co,
         current->add_instruction(std::move(decoded[i]));
         ++i;
 
+        const bool decoded_section_end = i >= decoded.size() && next_offset == section_end;
         const bool decode_gap =
             i >= decoded.size() ? next_offset < section_end : decoded[i]->src_loc() != next_offset;
-        if (decode_gap && !terminates) {
-          const bool reaches_gfx1250_zero = arch == ROCJITSU_CODE_ARCH_GFX1250 &&
+        if (!terminates) {
+          const bool reaches_gfx1250_zero = decode_gap && arch == ROCJITSU_CODE_ARCH_GFX1250 &&
                                             next_offset < section_end &&
                                             inst_data[next_offset / sizeof(uint32_t)] == 0;
-          if (reaches_gfx1250_zero && current->is_gfx1250_clang_unreachable_stub())
+          const bool is_gfx1250_section_end_stub =
+              decoded_section_end && arch == ROCJITSU_CODE_ARCH_GFX1250;
+          if ((reaches_gfx1250_zero || is_gfx1250_section_end_stub) &&
+              current->is_gfx1250_clang_unreachable_stub()) {
             current->has_terminator_ = true;
-          else
+            current->has_implicit_terminator_ = true;
+          } else if (decode_gap) {
             current->falls_through_to_undecodable_text_ = true;
+          }
         }
 
         if (terminates || decode_gap || (i < decoded.size() && leaders.contains(next_offset)))
@@ -287,44 +310,38 @@ std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co,
     for (auto &block : section_blocks)
       block_by_offset.emplace(block->start_offset(), block.get());
 
-    std::unordered_set<uint64_t> kernel_entry_offsets(extra_leaders.begin(), extra_leaders.end());
-    auto function_returns_to_sreg = [&](BasicBlock &callee, uint16_t return_sreg) {
-      std::vector<BasicBlock *> stack{&callee};
-      std::unordered_set<BasicBlock *> visited;
-
-      while (!stack.empty()) {
-        BasicBlock *block = stack.back();
-        stack.pop_back();
-        if (block == nullptr || !visited.insert(block).second)
-          continue;
-
-        const Instruction *term = block->terminator();
-        if (term == nullptr)
-          continue;
-
-        if (s_setpc_from_sreg(*term, first_word(*term), return_sreg))
-          return true;
-
-        // Call validation runs after ordinary direct CFG edges and recovered
-        // non-call setpc edges have been installed in successors(). Follow that
-        // graph instead of re-deriving direct edges here; shared helpers often
-        // branch through a recovered setpc before reaching the setpc return.
-        // Kernel entries remain scope boundaries, except when the callee itself
-        // is a kernel entry. That keeps a helper walk from proving a return by
-        // wandering into an unrelated kernel body.
-        for (BasicBlock *succ : block->successors()) {
-          if (succ == nullptr)
-            continue;
-          if (kernel_entry_offsets.contains(succ->start_offset()) && succ != &callee)
-            continue;
-          stack.push_back(succ);
-        }
+    std::vector<DeferredCallSite> deferred_calls;
+    std::unordered_map<const BasicBlock *, size_t> call_site_by_source;
+    auto defer_call = [&](BasicBlock &source, BasicBlock &target, BasicBlock &continuation,
+                          CallEdgeKind kind, uint64_t source_call_offset, uint16_t return_sreg,
+                          bool target_set_incomplete) {
+      const auto [map_it, inserted] =
+          call_site_by_source.try_emplace(&source, deferred_calls.size());
+      if (inserted) {
+        deferred_calls.push_back({.source = &source,
+                                  .continuation = &continuation,
+                                  .return_sreg = return_sreg,
+                                  .target_set_incomplete = target_set_incomplete,
+                                  .targets = {}});
+      } else {
+        DeferredCallSite &site = deferred_calls[map_it->second];
+        if (site.continuation != &continuation || site.return_sreg != return_sreg)
+          throw util::Exception(
+              std::string_view("inconsistent deferred call metadata for one terminator"));
+        site.target_set_incomplete |= target_set_incomplete;
       }
 
-      return false;
+      DeferredCallSite &site = deferred_calls[map_it->second];
+      const auto duplicate =
+          std::ranges::find_if(site.targets, [&](const DeferredCallTarget &existing) {
+            return existing.kind == kind && existing.target == &target &&
+                   existing.source_call_offset == source_call_offset;
+          });
+      if (duplicate == site.targets.end())
+        site.targets.push_back(
+            {.kind = kind, .target = &target, .source_call_offset = source_call_offset});
     };
 
-    std::vector<DeferredIndirectCall> deferred_indirect_calls;
     for (const IndirectCallFixup &fixup : recovered_indirect_targets) {
       auto source_it = block_by_offset.find(fixup.source_call_offset);
       if (source_it == block_by_offset.end())
@@ -347,11 +364,8 @@ std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co,
           // ordinary direct CFG edges have been added for every block; otherwise
           // helpers that branch or fall through internally to their return block
           // look falsely non-returning.
-          deferred_indirect_calls.push_back({.source = source,
-                                             .target = target,
-                                             .continuation = continuation,
-                                             .source_call_offset = fixup.source_call_offset,
-                                             .return_sreg = fixup.source_return_sreg});
+          defer_call(*source, *target, *continuation, CallEdgeKind::IndirectSwapPc,
+                     fixup.source_call_offset, fixup.source_return_sreg, fixup.source_incomplete);
         } else {
           // Non-call recovered setpc targets are ordinary local CFG edges. If a
           // swappc has no statically-known continuation, keep the old
@@ -362,7 +376,6 @@ std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co,
       }
     }
 
-    std::vector<DeferredDirectCall> deferred_direct_calls;
     for (size_t i = 0; i < section_blocks.size(); ++i) {
       auto &block = *section_blocks[i];
       const Instruction *term = block.terminator();
@@ -387,11 +400,8 @@ std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co,
             // Like recovered swappc, direct s_call validation needs the callee's
             // internal CFG to be complete before we decide whether the target is
             // a returning helper or an ordinary reachable branch target.
-            deferred_direct_calls.push_back({.source = &block,
-                                             .target = target_it->second,
-                                             .continuation = fallthrough_it->second,
-                                             .source_call_offset = term->src_loc(),
-                                             .return_sreg = *call_sdst});
+            defer_call(block, *target_it->second, *fallthrough_it->second, CallEdgeKind::DirectCall,
+                       term->src_loc(), *call_sdst, false);
           } else if (target_it != block_by_offset.end()) {
             block.add_successor(*target_it->second);
           }
@@ -405,34 +415,182 @@ std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co,
         block.add_successor(*fallthrough_it->second);
     }
 
-    for (const DeferredIndirectCall &call : deferred_indirect_calls) {
-      if (call.source == nullptr || call.target == nullptr || call.continuation == nullptr)
-        continue;
-      if (function_returns_to_sreg(*call.target, call.return_sreg)) {
-        call.source->add_call_edge(CallEdge{.kind = CallEdgeKind::IndirectSwapPc,
-                                            .callee = call.target,
-                                            .continuation = call.continuation,
-                                            .source_call_offset = call.source_call_offset,
-                                            .return_sreg = call.return_sreg});
-      } else {
-        // A statically recovered swappc target that does not return through the
-        // swappc destination is just indirect control flow with a concrete
-        // target. Model that conservatively as an ordinary CFG edge.
-        call.source->add_successor(*call.target);
+    std::unordered_set<uint64_t> kernel_entry_offsets(extra_leaders.begin(), extra_leaders.end());
+    std::vector<std::vector<CallReturnClassification>> classifications;
+    classifications.reserve(deferred_calls.size());
+    for (const DeferredCallSite &site : deferred_calls)
+      classifications.emplace_back(site.targets.size(), CallReturnClassification::Unknown);
+
+    auto classify_function = [&](BasicBlock &callee, uint16_t return_sreg,
+                                 const std::vector<std::vector<CallReturnClassification>> &known) {
+      struct WalkPoint {
+        BasicBlock *block = nullptr;
+        std::optional<uint16_t> terminal_return_sreg;
+      };
+      std::vector<WalkPoint> stack{{.block = &callee, .terminal_return_sreg = std::nullopt}};
+      std::set<std::pair<BasicBlock *, std::optional<uint16_t>>> visited;
+      bool has_unknown_exit = false;
+
+      auto push_within_function = [&](BasicBlock *successor,
+                                      std::optional<uint16_t> terminal_return_sreg) {
+        if (successor == nullptr)
+          return;
+        if (kernel_entry_offsets.contains(successor->start_offset()) && successor != &callee) {
+          has_unknown_exit = true;
+          return;
+        }
+        stack.push_back({.block = successor, .terminal_return_sreg = terminal_return_sreg});
+      };
+
+      while (!stack.empty()) {
+        const WalkPoint point = stack.back();
+        stack.pop_back();
+        BasicBlock *block = point.block;
+        if (block == nullptr || !visited.insert({block, point.terminal_return_sreg}).second)
+          continue;
+
+        const Instruction *term = block->terminator();
+        if (term == nullptr) {
+          has_unknown_exit = true;
+          continue;
+        }
+        if (point.terminal_return_sreg &&
+            s_setpc_from_sreg(*term, first_word(*term), *point.terminal_return_sreg)) {
+          // This path is the normal return from a nested callee whose body is
+          // also being scanned for a direct return through the enclosing pair.
+          continue;
+        }
+        if (s_setpc_from_sreg(*term, first_word(*term), return_sreg))
+          return CallReturnClassification::Returning;
+
+        if (auto site_it = call_site_by_source.find(block); site_it != call_site_by_source.end()) {
+          const size_t site_index = site_it->second;
+          const DeferredCallSite &site = deferred_calls[site_index];
+          has_unknown_exit |= site.target_set_incomplete;
+          bool reaches_continuation = false;
+          for (size_t target_index = 0; target_index < site.targets.size(); ++target_index) {
+            switch (known[site_index][target_index]) {
+            case CallReturnClassification::Returning:
+              reaches_continuation = true;
+              push_within_function(site.targets[target_index].target, site.return_sreg);
+              break;
+            case CallReturnClassification::NonReturning:
+              push_within_function(site.targets[target_index].target, point.terminal_return_sreg);
+              break;
+            case CallReturnClassification::Unknown:
+              has_unknown_exit = true;
+              break;
+            }
+          }
+          if (reaches_continuation)
+            push_within_function(site.continuation, point.terminal_return_sreg);
+          for (BasicBlock *successor : block->successors()) {
+            if (successor != site.continuation)
+              push_within_function(successor, point.terminal_return_sreg);
+          }
+          continue;
+        }
+
+        if (block->falls_through_to_undecodable_text())
+          has_unknown_exit = true;
+
+        const bool is_program_exit =
+            block->has_implicit_terminator() || is_program_path_terminator(*term);
+        const uint64_t flags = term->flags();
+        if ((flags & (INDIRECT_BRANCH | INDIRECT_CALL)) != 0) {
+          const auto &fixups = block->static_indirect_call_fixups();
+          if (fixups.empty() || std::ranges::any_of(fixups, &IndirectCallFixup::source_incomplete))
+            has_unknown_exit = true;
+        } else if (!is_program_exit) {
+          if (auto branch_delta = term->branch_offset_bytes()) {
+            const int64_t target = static_cast<int64_t>(block->end_offset()) + *branch_delta;
+            if (target < 0 ||
+                block_by_offset.find(static_cast<uint64_t>(target)) == block_by_offset.end())
+              has_unknown_exit = true;
+          }
+          if (!is_unconditional_branch(*term) && (flags & INDIRECT_BRANCH) == 0 &&
+              block_by_offset.find(block->end_offset()) == block_by_offset.end())
+            has_unknown_exit = true;
+        }
+
+        if (block->successors().empty() && !is_program_exit)
+          has_unknown_exit = true;
+        for (BasicBlock *successor : block->successors())
+          push_within_function(successor, point.terminal_return_sreg);
+      }
+
+      return has_unknown_exit ? CallReturnClassification::Unknown
+                              : CallReturnClassification::NonReturning;
+    };
+
+    // Call sites form a small interprocedural graph. Resolve leaf callees first,
+    // then repeat against a stable snapshot so nested tail transfers cannot make
+    // classification depend on source or fixup order. Cycles without a positive
+    // return or non-return proof remain conservative Unknown sites.
+    size_t num_targets = 0;
+    for (const DeferredCallSite &site : deferred_calls)
+      num_targets += site.targets.size();
+    const size_t max_rounds = num_targets + 2;
+    bool converged = false;
+    for (size_t round = 0; round < max_rounds; ++round) {
+      std::vector<std::vector<CallReturnClassification>> next = classifications;
+      bool changed = false;
+      for (size_t site_index = 0; site_index < deferred_calls.size(); ++site_index) {
+        const DeferredCallSite &site = deferred_calls[site_index];
+        for (size_t target_index = 0; target_index < site.targets.size(); ++target_index) {
+          BasicBlock *target = site.targets[target_index].target;
+          if (target == nullptr)
+            continue;
+          const CallReturnClassification classification =
+              classify_function(*target, site.return_sreg, classifications);
+          if (classification != next[site_index][target_index]) {
+            next[site_index][target_index] = classification;
+            changed = true;
+          }
+        }
+      }
+      classifications = std::move(next);
+      if (!changed) {
+        converged = true;
+        break;
       }
     }
+    if (!converged) {
+      // A pathological non-monotone call graph must lose precision, not hang
+      // or retain a potentially stale NonReturning classification.
+      for (auto &site_classifications : classifications)
+        std::ranges::fill(site_classifications, CallReturnClassification::Unknown);
+    }
 
-    for (const DeferredDirectCall &call : deferred_direct_calls) {
-      if (call.source == nullptr || call.target == nullptr || call.continuation == nullptr)
-        continue;
-      if (function_returns_to_sreg(*call.target, call.return_sreg)) {
-        call.source->add_call_edge(CallEdge{.kind = CallEdgeKind::DirectCall,
-                                            .callee = call.target,
-                                            .continuation = call.continuation,
-                                            .source_call_offset = call.source_call_offset,
-                                            .return_sreg = call.return_sreg});
-      } else {
-        call.source->add_successor(*call.target);
+    for (size_t site_index = 0; site_index < deferred_calls.size(); ++site_index) {
+      const DeferredCallSite &site = deferred_calls[site_index];
+
+      bool all_targets_nonreturning = !site.target_set_incomplete;
+      bool continuation_is_target = false;
+      for (size_t target_index = 0; target_index < site.targets.size(); ++target_index) {
+        const DeferredCallTarget &target = site.targets[target_index];
+        const CallReturnClassification classification = classifications[site_index][target_index];
+        all_targets_nonreturning &= classification == CallReturnClassification::NonReturning;
+        continuation_is_target |= target.target == site.continuation;
+
+        if (classification == CallReturnClassification::Returning) {
+          site.source->add_call_edge(CallEdge{.kind = target.kind,
+                                              .callee = target.target,
+                                              .continuation = site.continuation,
+                                              .source_call_offset = target.source_call_offset,
+                                              .return_sreg = site.return_sreg});
+        } else {
+          // Proven tail targets and unknown callees both remain reachable.
+          // Unknown callees also conservatively keep the syntactic continuation.
+          site.source->add_successor(*target.target);
+        }
+      }
+
+      if (all_targets_nonreturning && !continuation_is_target) {
+        // Every finite target is proven to end without returning through this
+        // call site's destination pair. Drop only this dead fallthrough; mixed
+        // and unknown target sets retain the continuation conservatively.
+        (void)site.source->remove_successor(*site.continuation);
       }
     }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.h
@@ -83,6 +83,13 @@ public:
   /// recognized gfx1250 clang unreachable-stub body followed by zero padding.
   bool falls_through_to_undecodable_text() const { return falls_through_to_undecodable_text_; }
 
+  /// @brief Whether zero padding supplies this block's implicit terminator.
+  ///
+  /// @details The recognized gfx1250 clang unreachable stub has no architectural
+  /// terminator. Its following zero-filled alignment hole establishes a CFG
+  /// boundary that relocation must materialize as an s_endpgm in target text.
+  bool has_implicit_terminator() const { return has_implicit_terminator_; }
+
   /// @brief Last instruction in the block, or nullptr for an empty block.
   [[nodiscard]] const Instruction *terminator() const;
 
@@ -133,7 +140,8 @@ public:
   ///
   /// @details Recovered indirect branch targets are added as block leaders before
   /// the block objects are finalized, so users never see a recovered edge whose
-  /// destination points into the middle of a larger block.
+  /// destination points into the middle of a larger block. Syntactic call
+  /// fallthroughs remain provisional until call-return classification finishes.
   /// @param[in] co Code object to analyze.
   /// @param[in] decoder Decoder for the target ISA.
   /// @param[in] arch ISA architecture used to match static PC builders.
@@ -151,6 +159,8 @@ private:
   void add_instruction(std::unique_ptr<Instruction> inst);
   [[nodiscard]] bool is_gfx1250_clang_unreachable_stub() const;
   void add_successor(BasicBlock &successor);
+  /// Remove one proven-dead edge while preserving the inverse predecessor list.
+  [[nodiscard]] bool remove_successor(BasicBlock &successor);
   void add_static_indirect_call_fixup(IndirectCallFixup fixup);
 
   uint64_t start_offset_;
@@ -158,6 +168,7 @@ private:
   uint32_t num_instructions_ = 0;
   bool has_terminator_ = false;
   bool falls_through_to_undecodable_text_ = false;
+  bool has_implicit_terminator_ = false;
   InstructionList instructions_;
   std::vector<std::unique_ptr<Instruction>> storage_;
   std::vector<BasicBlock *> successors_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -40,6 +40,7 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <set>
 #include <span>
 #include <sstream>
 #include <string>
@@ -496,34 +497,58 @@ kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks
 /// edge from the callee back to every possible continuation. The same helper
 /// block can be entered by multiple kernels or multiple call sites, and the
 /// correct continuation is the one selected by the return SGPR written at that
-/// call site. This walk therefore stays inside @p allowed_blocks, follows only
-/// ordinary successors within the callee body, and reports terminators that
-/// return through @p return_sreg. The caller then pairs each return with the
-/// specific continuation from the call edge being analyzed.
+/// call site. This walk therefore stays inside @p allowed_blocks and mirrors
+/// call-return classification: nested callees are visited with their own return
+/// SGPR as a stopping condition, while their continuations retain the enclosing
+/// condition. This exposes paths that return directly through an enclosing pair
+/// without mistaking a nested callee's normal return for the enclosing return.
+/// The caller then pairs each reported return with the specific continuation
+/// from the call edge being analyzed.
 [[nodiscard]] std::vector<BasicBlock *>
 function_return_blocks(BasicBlock &callee, uint16_t return_sreg, std::span<const uint8_t> text,
                        const std::unordered_set<BasicBlock *> &allowed_blocks) {
+  struct WalkPoint {
+    BasicBlock *block = nullptr;
+    std::optional<uint16_t> terminal_return_sreg;
+  };
+
   std::vector<BasicBlock *> returns;
-  std::vector<BasicBlock *> stack{&callee};
-  std::unordered_set<BasicBlock *> visited;
+  std::unordered_set<BasicBlock *> return_set;
+  std::vector<WalkPoint> stack{{.block = &callee, .terminal_return_sreg = std::nullopt}};
+  std::set<std::pair<BasicBlock *, std::optional<uint16_t>>> visited;
 
   while (!stack.empty()) {
-    BasicBlock *block = stack.back();
+    const WalkPoint point = stack.back();
     stack.pop_back();
+    BasicBlock *block = point.block;
     assert(block != nullptr && "return-block walk stack should contain only decoded blocks");
-    if (!allowed_blocks.contains(block) || !visited.insert(block).second)
+    if (!allowed_blocks.contains(block) ||
+        !visited.insert({block, point.terminal_return_sreg}).second)
       continue;
 
     const Instruction *term = block->terminator();
     assert(term != nullptr && "decoded BasicBlock should contain at least one instruction");
+    if (point.terminal_return_sreg && s_setpc_from_sreg(*term, text_word_at(text, term->src_loc()),
+                                                        *point.terminal_return_sreg)) {
+      continue;
+    }
     if (s_setpc_from_sreg(*term, text_word_at(text, term->src_loc()), return_sreg)) {
-      returns.push_back(block);
+      if (return_set.insert(block).second)
+        returns.push_back(block);
       continue;
     }
 
     for (BasicBlock *succ : block->successors()) {
       assert(succ != nullptr && "BasicBlock successors should never be null");
-      stack.push_back(succ);
+      stack.push_back({.block = succ, .terminal_return_sreg = point.terminal_return_sreg});
+    }
+    for (const BasicBlock::CallEdge &call : block->call_edges()) {
+      assert(call.callee != nullptr && "BasicBlock call edges should always have a callee");
+      assert(call.continuation != nullptr &&
+             "BasicBlock call edges should always have a continuation");
+      stack.push_back({.block = call.callee, .terminal_return_sreg = call.return_sreg});
+      stack.push_back(
+          {.block = call.continuation, .terminal_return_sreg = point.terminal_return_sreg});
     }
   }
 
@@ -1813,6 +1838,14 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       }
       if (skip_scope)
         break;
+      if (block->has_implicit_terminator()) {
+        // Materialize the CFG boundary as part of the translated block. Like
+        // any other target-side expansion, the terminator belongs in relocated
+        // function extents. Without an architectural terminator, ordinary text
+        // materialization can turn this unreachable stub into a fallthrough.
+        const uint32_t endpgm = build_s_endpgm(host_arch_);
+        append_words(kernel_text, std::span<const uint32_t>(&endpgm, 1));
+      }
       placement.target_end = kernel_text.size();
       layout.blocks.push_back(placement);
       target_offset_by_source_offset.emplace(block->end_offset(), kernel_text.size());

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -411,6 +411,76 @@ TEST(CfgAnalysis, LoopBackEdgeLinksPredecessor) {
   EXPECT_TRUE(has_predecessor(*blocks[0], blocks[0].get()));
 }
 
+TEST(CfgAnalysis, Gfx1250ClassifiesImplicitUnreachableStubTerminator) {
+  struct Case {
+    const char *name;
+    std::vector<uint32_t> words;
+    bool has_terminator;
+    bool has_implicit_terminator;
+    bool falls_through_to_undecodable_text;
+  };
+  const std::array cases = {
+      Case{"clang unreachable stub", {0xb9800641u, 1u, 0}, true, true, false},
+      Case{"clang unreachable stub with prefetch",
+           {0xee174000u, 0x00040000u, 0, 0x7e000000u, 0xb9800641u, 1u, 0},
+           true,
+           true,
+           false},
+      Case{"section-final clang unreachable stub", {0xb9800641u, 1u}, true, true, false},
+      Case{"ordinary fallthrough",
+           {build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250), 0},
+           false,
+           false,
+           true},
+      Case{"architectural terminator",
+           {build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), 0},
+           true,
+           false,
+           false},
+  };
+
+  for (const auto &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    TestCodeObject co(test_case.words);
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+    ASSERT_NE(decoder, nullptr);
+    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+    ASSERT_EQ(blocks.size(), 1u);
+    EXPECT_EQ(blocks[0]->has_terminator(), test_case.has_terminator);
+    EXPECT_EQ(blocks[0]->has_implicit_terminator(), test_case.has_implicit_terminator);
+    EXPECT_EQ(blocks[0]->falls_through_to_undecodable_text(),
+              test_case.falls_through_to_undecodable_text);
+  }
+}
+
+TEST(CfgAnalysis, DirectCallToImplicitNonreturningTargetDropsFallthrough) {
+  constexpr uint16_t kReturnSreg = 30;
+  std::vector<uint32_t> words = {
+      rocjitsu::build_s_call_b64(kReturnSreg, 1, ROCJITSU_CODE_ARCH_GFX1250),
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x04 continuation.
+      0xb9800641u,
+      1u,
+      0, // 0x08 clang unreachable-stub target followed by padding.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  auto *caller = block_starting_at(blocks, 0);
+  auto *continuation = block_starting_at(blocks, 4);
+  auto *target = block_starting_at(blocks, 8);
+  ASSERT_NE(caller, nullptr);
+  ASSERT_NE(continuation, nullptr);
+  ASSERT_NE(target, nullptr);
+
+  EXPECT_TRUE(caller->call_edges().empty());
+  EXPECT_TRUE(has_successor_start(*caller, target->start_offset()));
+  EXPECT_FALSE(has_successor_start(*caller, continuation->start_offset()));
+  EXPECT_FALSE(has_predecessor(*continuation, caller));
+}
 TEST(CfgAnalysis, IfElseSuccessorsAndPredecessorsAreInverse) {
   auto blocks = build_test_blocks(
       {TestOpcode::CBranchToElse, TestOpcode::BranchToJoin, TestOpcode::Nop, TestOpcode::End});
@@ -665,6 +735,87 @@ TEST(CfgAnalysis, IncompleteFactConsumerIsFlaggedIncomplete) {
       << "a consumer joined from an unconstrained path must be flagged incomplete";
 }
 
+TEST(CfgAnalysis, IncompleteSwappcTargetSetKeepsContinuation) {
+  constexpr uint16_t kPcSreg = 8;
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr uint32_t kLiteralOperand = 255;
+  constexpr uint32_t kInlineInt0 = 128;
+
+  std::vector<uint32_t> words = {
+      pack_sopp(5, 5),                                     // 0x00 -> bypass at 0x18.
+      pack_sop1(0x1c, kPcSreg, 0),                         // 0x04: s_getpc_b64.
+      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand),     // 0x08: s_add_u32.
+      28,                                                  // 0x0c: target at 0x24.
+      pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0), // 0x10: s_addc_u32.
+      build_s_branch(1, ROCJITSU_CODE_ARCH_CDNA4),         // 0x14 -> consumer at 0x1c.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),            // 0x18: unconstrained bypass.
+      pack_sop1(0x1e, kReturnSreg, kPcSreg),               // 0x1c: joined swappc consumer.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),            // 0x20: continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),            // 0x24: known non-returning target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *consumer = block_starting_at(blocks, 28);
+  auto *continuation = block_starting_at(blocks, 32);
+  auto *target = block_starting_at(blocks, 36);
+  ASSERT_NE(consumer, nullptr);
+  ASSERT_NE(continuation, nullptr);
+  ASSERT_NE(target, nullptr);
+  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_TRUE(consumer->static_indirect_call_fixups()[0].source_incomplete);
+  EXPECT_TRUE(consumer->call_edges().empty());
+  EXPECT_TRUE(has_successor_start(*consumer, continuation->start_offset()));
+  EXPECT_TRUE(has_successor_start(*consumer, target->start_offset()));
+  EXPECT_TRUE(has_predecessor(*continuation, consumer));
+}
+
+TEST(CfgAnalysis, IncompleteRecoveredSetpcInCalleeKeepsOuterContinuation) {
+  constexpr uint16_t kPcSreg = 8;
+  constexpr uint16_t kOuterReturnSreg = 30;
+  constexpr uint32_t kLiteralOperand = 255;
+  constexpr uint32_t kInlineInt0 = 128;
+
+  std::vector<uint32_t> words = {
+      build_s_call_b64(kOuterReturnSreg, 1),               // 0x00 -> callee at 0x08.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),            // 0x04 live continuation.
+      pack_sopp(5, 5),                                     // 0x08 -> bypass at 0x20.
+      pack_sop1(0x1c, kPcSreg, 0),                         // 0x0c: s_getpc_b64.
+      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand),     // 0x10: s_add_u32.
+      28,                                                  // 0x14: target at 0x2c.
+      pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0), // 0x18: s_addc_u32.
+      build_s_branch(1, ROCJITSU_CODE_ARCH_CDNA4),         // 0x1c -> consumer at 0x24.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),            // 0x20: unconstrained bypass.
+      pack_sop1(0x1d, 0, kPcSreg),                         // 0x24: joined setpc.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),            // 0x28: not a target.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),            // 0x2c: known target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *caller = block_starting_at(blocks, 0);
+  auto *continuation = block_starting_at(blocks, 4);
+  auto *callee = block_starting_at(blocks, 8);
+  auto *consumer = block_starting_at(blocks, 36);
+  ASSERT_NE(caller, nullptr);
+  ASSERT_NE(continuation, nullptr);
+  ASSERT_NE(callee, nullptr);
+  ASSERT_NE(consumer, nullptr);
+  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_TRUE(consumer->static_indirect_call_fixups()[0].source_incomplete);
+
+  EXPECT_TRUE(caller->call_edges().empty());
+  EXPECT_TRUE(has_successor_start(*caller, callee->start_offset()));
+  EXPECT_TRUE(has_successor_start(*caller, continuation->start_offset()));
+  EXPECT_TRUE(has_predecessor(*continuation, caller));
+}
+
 TEST(CfgAnalysis, DominatedPcBuilderRemainsCompleteAcrossCallLoopBackedge) {
   constexpr uint16_t kPcSreg = 8;
   constexpr uint16_t kReturnSreg = 30;
@@ -915,6 +1066,263 @@ TEST(CfgAnalysis, DirectCallEdgeUsesTerminatorOffset) {
   EXPECT_EQ(edge.callee, callee);
   EXPECT_EQ(edge.continuation, continuation);
   EXPECT_EQ(edge.source_call_offset, 4u);
+  EXPECT_TRUE(has_successor_start(*caller, continuation->start_offset()));
+  EXPECT_TRUE(has_predecessor(*continuation, caller));
+}
+
+TEST(CfgAnalysis, DirectCallToNonreturningTargetDropsFallthrough) {
+  constexpr uint16_t kReturnSreg = 30;
+
+  std::vector<uint32_t> words = {
+      build_s_call_b64(kReturnSreg, 1),         // 0x00 -> target at 0x08.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4), // 0x04 unreachable padding.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), // 0x08 non-returning target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *caller = block_starting_at(blocks, 0);
+  auto *continuation = block_starting_at(blocks, 4);
+  auto *target = block_starting_at(blocks, 8);
+  ASSERT_NE(caller, nullptr);
+  ASSERT_NE(continuation, nullptr);
+  ASSERT_NE(target, nullptr);
+
+  EXPECT_TRUE(caller->call_edges().empty());
+  EXPECT_TRUE(has_successor_start(*caller, target->start_offset()));
+  EXPECT_FALSE(has_successor_start(*caller, continuation->start_offset()));
+  EXPECT_FALSE(has_predecessor(*continuation, caller));
+}
+
+TEST(CfgAnalysis, DirectCallWithCopiedReturnPairKeepsFallthrough) {
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr uint16_t kCopiedReturnSreg = 34;
+
+  std::vector<uint32_t> words = {
+      build_s_call_b64(kReturnSreg, 1),             // 0x00 -> callee at 0x08.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),     // 0x04 live continuation.
+      pack_sop1(1, kCopiedReturnSreg, kReturnSreg), // 0x08: s_mov_b64.
+      pack_sop1(0x1d, 0, kCopiedReturnSreg),        // 0x0c: copied-pair return.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *caller = block_starting_at(blocks, 0);
+  auto *continuation = block_starting_at(blocks, 4);
+  auto *callee = block_starting_at(blocks, 8);
+  ASSERT_NE(caller, nullptr);
+  ASSERT_NE(continuation, nullptr);
+  ASSERT_NE(callee, nullptr);
+
+  EXPECT_TRUE(caller->call_edges().empty());
+  EXPECT_TRUE(has_successor_start(*caller, continuation->start_offset()));
+  EXPECT_TRUE(has_successor_start(*caller, callee->start_offset()));
+  EXPECT_TRUE(has_predecessor(*continuation, caller));
+}
+
+TEST(CfgAnalysis, DirectCallWithUnrecoveredTailExitKeepsFallthrough) {
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr uint16_t kUnknownTargetSreg = 0;
+
+  std::vector<uint32_t> words = {
+      build_s_call_b64(kReturnSreg, 1),         // 0x00 -> callee at 0x08.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), // 0x04 live continuation.
+      pack_sop1(0x1d, 0, kUnknownTargetSreg),   // 0x08: unrecovered tail exit.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *caller = block_starting_at(blocks, 0);
+  auto *continuation = block_starting_at(blocks, 4);
+  auto *callee = block_starting_at(blocks, 8);
+  ASSERT_NE(caller, nullptr);
+  ASSERT_NE(continuation, nullptr);
+  ASSERT_NE(callee, nullptr);
+
+  EXPECT_TRUE(caller->call_edges().empty());
+  EXPECT_TRUE(has_successor_start(*caller, continuation->start_offset()));
+  EXPECT_TRUE(has_successor_start(*caller, callee->start_offset()));
+  EXPECT_TRUE(has_predecessor(*continuation, caller));
+}
+
+TEST(CfgAnalysis, DirectCallCrossingScopeBoundaryKeepsFallthrough) {
+  constexpr uint16_t kReturnSreg = 30;
+
+  std::vector<uint32_t> words = {
+      build_s_call_b64(kReturnSreg, 1),            // 0x00 -> callee at 0x08.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),    // 0x04 live continuation.
+      build_s_branch(1, ROCJITSU_CODE_ARCH_CDNA4), // 0x08 -> leader at 0x10.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),    // 0x0c skipped.
+      pack_sop1(0x1d, 0, kReturnSreg),             // 0x10: return across boundary.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  constexpr std::array<uint64_t, 1> extra_leaders{16};
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
+
+  auto *caller = block_starting_at(blocks, 0);
+  auto *continuation = block_starting_at(blocks, 4);
+  auto *callee = block_starting_at(blocks, 8);
+  ASSERT_NE(caller, nullptr);
+  ASSERT_NE(continuation, nullptr);
+  ASSERT_NE(callee, nullptr);
+
+  EXPECT_TRUE(caller->call_edges().empty());
+  EXPECT_TRUE(has_successor_start(*caller, continuation->start_offset()));
+  EXPECT_TRUE(has_successor_start(*caller, callee->start_offset()));
+  EXPECT_TRUE(has_predecessor(*continuation, caller));
+}
+
+TEST(CfgAnalysis, NestedReturningCallMayReturnThroughOuterPair) {
+  constexpr uint16_t kOuterReturnSreg = 30;
+  constexpr uint16_t kInnerReturnSreg = 28;
+
+  std::vector<uint32_t> words = {
+      build_s_call_b64(kOuterReturnSreg, 1),    // 0x00 -> outer callee at 0x08.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), // 0x04 outer continuation.
+      build_s_call_b64(kInnerReturnSreg, 1),    // 0x08 -> inner callee at 0x10.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), // 0x0c inner continuation.
+      pack_sopp(5, 1),                          // 0x10 -> outer return at 0x18.
+      pack_sop1(0x1d, 0, kInnerReturnSreg),     // 0x14: normal inner return.
+      pack_sop1(0x1d, 0, kOuterReturnSreg),     // 0x18: direct outer return.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *outer = block_starting_at(blocks, 0);
+  auto *outer_continuation = block_starting_at(blocks, 4);
+  ASSERT_NE(outer, nullptr);
+  ASSERT_NE(outer_continuation, nullptr);
+
+  ASSERT_EQ(outer->call_edges().size(), 1u);
+  EXPECT_EQ(outer->call_edges()[0].continuation, outer_continuation);
+  EXPECT_TRUE(has_successor_start(*outer, outer_continuation->start_offset()));
+  EXPECT_TRUE(has_predecessor(*outer_continuation, outer));
+}
+
+TEST(CfgAnalysis, NestedNonreturningCallsDropBothFallthroughs) {
+  constexpr uint16_t kOuterReturnSreg = 30;
+  constexpr uint16_t kInnerReturnSreg = 28;
+
+  std::vector<uint32_t> words = {
+      build_s_call_b64(kOuterReturnSreg, 1),    // 0x00 -> outer callee at 0x08.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), // 0x04 outer continuation.
+      build_s_call_b64(kInnerReturnSreg, 1),    // 0x08 -> inner target at 0x10.
+      pack_sop1(0x1d, 0, kOuterReturnSreg),     // 0x0c dead inner continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), // 0x10 non-returning target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *outer = block_starting_at(blocks, 0);
+  auto *outer_continuation = block_starting_at(blocks, 4);
+  auto *inner = block_starting_at(blocks, 8);
+  auto *inner_continuation = block_starting_at(blocks, 12);
+  auto *target = block_starting_at(blocks, 16);
+  ASSERT_NE(outer, nullptr);
+  ASSERT_NE(outer_continuation, nullptr);
+  ASSERT_NE(inner, nullptr);
+  ASSERT_NE(inner_continuation, nullptr);
+  ASSERT_NE(target, nullptr);
+
+  EXPECT_TRUE(outer->call_edges().empty());
+  EXPECT_TRUE(inner->call_edges().empty());
+  EXPECT_TRUE(has_successor_start(*outer, inner->start_offset()));
+  EXPECT_FALSE(has_successor_start(*outer, outer_continuation->start_offset()));
+  EXPECT_TRUE(has_successor_start(*inner, target->start_offset()));
+  EXPECT_FALSE(has_successor_start(*inner, inner_continuation->start_offset()));
+}
+
+TEST(CfgAnalysis, CyclicCallGraphKeepsConservativeFallthrough) {
+  constexpr uint16_t kOuterReturnSreg = 30;
+  constexpr uint16_t kRecursiveReturnSreg = 28;
+
+  std::vector<uint32_t> words = {
+      build_s_call_b64(kOuterReturnSreg, 1),      // 0x00 -> callee at 0x08.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),   // 0x04 outer continuation.
+      build_s_call_b64(kRecursiveReturnSreg, -1), // 0x08 -> itself.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),   // 0x0c recursive continuation.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *caller = block_starting_at(blocks, 0);
+  auto *continuation = block_starting_at(blocks, 4);
+  ASSERT_NE(caller, nullptr);
+  ASSERT_NE(continuation, nullptr);
+
+  EXPECT_TRUE(has_successor_start(*caller, continuation->start_offset()));
+  EXPECT_TRUE(has_predecessor(*continuation, caller));
+}
+
+TEST(CfgAnalysis, CallToInfiniteLoopDropsFallthrough) {
+  constexpr uint16_t kReturnSreg = 30;
+
+  std::vector<uint32_t> words = {
+      build_s_call_b64(kReturnSreg, 1),             // 0x00 -> callee at 0x08.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),     // 0x04 dead continuation.
+      build_s_branch(-1, ROCJITSU_CODE_ARCH_CDNA4), // 0x08 -> itself.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *caller = block_starting_at(blocks, 0);
+  auto *continuation = block_starting_at(blocks, 4);
+  auto *callee = block_starting_at(blocks, 8);
+  ASSERT_NE(caller, nullptr);
+  ASSERT_NE(continuation, nullptr);
+  ASSERT_NE(callee, nullptr);
+
+  EXPECT_TRUE(has_successor_start(*caller, callee->start_offset()));
+  EXPECT_FALSE(has_successor_start(*caller, continuation->start_offset()));
+  EXPECT_FALSE(has_predecessor(*continuation, caller));
+}
+
+TEST(CfgAnalysis, ZeroDeltaCallToNonreturningTargetKeepsSingleEdge) {
+  constexpr uint16_t kReturnSreg = 30;
+
+  std::vector<uint32_t> words = {
+      build_s_call_b64(kReturnSreg, 0),         // 0x00 -> target/continuation at 0x04.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), // 0x04 non-returning target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *caller = block_starting_at(blocks, 0);
+  auto *target = block_starting_at(blocks, 4);
+  ASSERT_NE(caller, nullptr);
+  ASSERT_NE(target, nullptr);
+
+  ASSERT_EQ(caller->successors().size(), 1u);
+  EXPECT_EQ(caller->successors()[0], target);
+  ASSERT_EQ(target->predecessors().size(), 1u);
+  EXPECT_EQ(target->predecessors()[0], caller);
 }
 
 TEST(CfgAnalysis, DirectCallKillsCarriedPcBuilderFacts) {
@@ -1090,6 +1498,87 @@ TEST(CfgAnalysis, KeepsDistinctBuildersReachingSameTarget) {
   std::vector<uint64_t> getpc_offsets{fixups[0].source_getpc_offset, fixups[1].source_getpc_offset};
   std::ranges::sort(getpc_offsets);
   EXPECT_EQ(getpc_offsets, (std::vector<uint64_t>{4u, 20u}));
+}
+
+TEST(CfgAnalysis, RecoveredSwappcToNonreturningTargetDropsFallthrough) {
+  constexpr uint16_t kPcSreg = 8;
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr uint32_t kLiteralOperand = 255;
+  constexpr uint32_t kInlineInt0 = 128;
+
+  std::vector<uint32_t> words = {
+      pack_sop1(0x1c, kPcSreg, 0),                         // 0x00: s_getpc_b64.
+      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand),     // 0x04: s_add_u32.
+      20,                                                  // 0x08: target at 0x18.
+      pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0), // 0x0c: s_addc_u32.
+      pack_sop1(0x1e, kReturnSreg, kPcSreg),               // 0x10: s_swappc_b64.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),            // 0x14: dead continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),            // 0x18: terminal target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *consumer = block_starting_at(blocks, 16);
+  auto *continuation = block_starting_at(blocks, 20);
+  auto *target = block_starting_at(blocks, 24);
+  ASSERT_NE(consumer, nullptr);
+  ASSERT_NE(continuation, nullptr);
+  ASSERT_NE(target, nullptr);
+
+  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_TRUE(consumer->call_edges().empty());
+  EXPECT_TRUE(has_successor_start(*consumer, target->start_offset()));
+  EXPECT_FALSE(has_successor_start(*consumer, continuation->start_offset()));
+  EXPECT_FALSE(has_predecessor(*continuation, consumer));
+}
+
+TEST(CfgAnalysis, MixedSwappcTargetsKeepSharedContinuation) {
+  constexpr uint16_t kPcSreg = 8;
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr uint32_t kLiteralOperand = 255;
+
+  // Two paths build different finite targets for one swappc consumer. The
+  // first target returns through the saved pair; the second terminates.
+  std::vector<uint32_t> words = {
+      pack_sopp(5, 4),                                 // 0x00 -> builder B at 0x14.
+      pack_sop1(0x1c, kPcSreg, 0),                     // 0x04: builder A getpc.
+      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand), // 0x08: s_add_u32.
+      0x20u,                                           // 0x0c: target A at 0x28.
+      build_s_branch(3, ROCJITSU_CODE_ARCH_CDNA4),     // 0x10 -> consumer at 0x20.
+      pack_sop1(0x1c, kPcSreg, 0),                     // 0x14: builder B getpc.
+      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand), // 0x18: s_add_u32.
+      0x14u,                                           // 0x1c: target B at 0x2c.
+      pack_sop1(0x1e, kReturnSreg, kPcSreg),           // 0x20: s_swappc_b64.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),        // 0x24: continuation.
+      pack_sop1(0x1d, 0, kReturnSreg),                 // 0x28: returning target A.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),        // 0x2c: non-returning target B.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto *consumer = block_starting_at(blocks, 32);
+  auto *continuation = block_starting_at(blocks, 36);
+  auto *returning_target = block_starting_at(blocks, 40);
+  auto *nonreturning_target = block_starting_at(blocks, 44);
+  ASSERT_NE(consumer, nullptr);
+  ASSERT_NE(continuation, nullptr);
+  ASSERT_NE(returning_target, nullptr);
+  ASSERT_NE(nonreturning_target, nullptr);
+
+  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 2u);
+  ASSERT_EQ(consumer->call_edges().size(), 1u);
+  EXPECT_EQ(consumer->call_edges()[0].callee, returning_target);
+  EXPECT_EQ(consumer->call_edges()[0].continuation, continuation);
+  EXPECT_TRUE(has_successor_start(*consumer, continuation->start_offset()));
+  EXPECT_TRUE(has_successor_start(*consumer, nonreturning_target->start_offset()));
+  EXPECT_FALSE(has_successor_start(*consumer, returning_target->start_offset()));
+  EXPECT_TRUE(has_predecessor(*continuation, consumer));
 }
 
 TEST(CfgAnalysis, Gfx1250RecoversSignedDeltaTemplateWithPrefetch) {

--- a/emulation/rocjitsu/tests/dbt/multikernel_indirect_branch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/multikernel_indirect_branch_test.cpp
@@ -288,7 +288,7 @@ TEST(BinaryTranslatorE2E, BuildsCfgForRealMultiKernelIndirectBranches) {
 
   size_t recovered_swappc_blocks = 0;
   size_t recovered_setpc_blocks = 0;
-  size_t direct_scall_blocks = 0;
+  std::vector<uint64_t> direct_scall_offsets;
   for (const auto &block : blocks) {
     const auto *term = block->terminator();
     if (term == nullptr)
@@ -309,21 +309,27 @@ TEST(BinaryTranslatorE2E, BuildsCfgForRealMultiKernelIndirectBranches) {
       EXPECT_FALSE(has_successor_start(*block, block->end_offset()))
           << "indirect branches must not keep a fallthrough edge";
     } else if (mnemonic == "s_call_b64") {
-      ++direct_scall_blocks;
+      direct_scall_offsets.push_back(term->src_loc());
       const auto branch_delta = term->branch_offset_bytes();
       ASSERT_TRUE(branch_delta.has_value());
       const int64_t target =
           static_cast<int64_t>(block->end_offset()) + static_cast<int64_t>(*branch_delta);
       ASSERT_GE(target, 0);
       EXPECT_TRUE(has_successor_start(*block, static_cast<uint64_t>(target)));
-      EXPECT_TRUE(has_successor_start(*block, block->end_offset()))
-          << "direct calls must retain the return/fallthrough edge";
+      EXPECT_TRUE(block->call_edges().empty()) << "fixture s_call sites are tail transfers";
+      EXPECT_FALSE(has_successor_start(*block, block->end_offset()))
+          << "tail transfers must drop their unreachable fallthrough edge";
     }
   }
 
+  std::ranges::sort(direct_scall_offsets);
+  // These are the three RJ_STATIC_SCALL_ISLAND sites in the checked-in
+  // fixture. Each target jumps to the join instead of returning, so its
+  // syntactic s_branch continuation is dead.
+  const std::vector<uint64_t> expected_direct_scall_offsets{0xbacu, 0xbdcu, 0xc10u};
   EXPECT_GE(recovered_swappc_blocks, 6u);
   EXPECT_GE(recovered_setpc_blocks, 3u);
-  EXPECT_GE(direct_scall_blocks, 3u);
+  EXPECT_EQ(direct_scall_offsets, expected_direct_scall_offsets);
 }
 
 TEST(BinaryTranslatorE2E, CountsRealMultiKernelIndirectBranchCfgBlocksPerKernel) {
@@ -380,11 +386,11 @@ TEST(BinaryTranslatorE2E, CountsRealMultiKernelIndirectBranchCfgBlocksPerKernel)
       // recovered target block, with the surrounding range-check and final
       // store/end blocks making the exact reachable count below.
       {"multikernel_indirect_branch_setpc", 20},
-      // The s_call kernel has three independent direct-call islands. Each call
-      // block has both the direct call-target edge and the return/fallthrough
-      // edge; the exact count catches accidental extra CFG edges between those
-      // islands or into another kernel entry.
-      {"multikernel_indirect_branch_scall", 23},
+      // The s_call kernel has three independent tail-transfer islands. Each
+      // non-returning call reaches its target but not the dead continuation;
+      // the exact count catches accidental CFG edges between those islands or
+      // into another kernel entry.
+      {"multikernel_indirect_branch_scall", 20},
   };
 
   for (const auto &test_case : expected) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -102,6 +102,7 @@ RJ_DIAGNOSTIC_POP
 #include <iterator>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -139,6 +140,46 @@ std::vector<T> read_elf_array_for_test(const std::vector<uint8_t> &image, uint64
   assert(count <= (image.size() - offset) / sizeof(T));
   std::memcpy(values.data(), image.data() + offset, count * sizeof(T));
   return values;
+}
+
+std::optional<Elf64_Sym> find_elf_symbol_for_test(const std::vector<uint8_t> &image,
+                                                  std::string_view name) {
+  const auto range_is_in_image = [&](uint64_t offset, uint64_t size) {
+    const uint64_t image_size = image.size();
+    return offset <= image_size && size <= image_size - offset;
+  };
+  if (!range_is_in_image(0, sizeof(Elf64_Ehdr)))
+    return std::nullopt;
+
+  const auto header = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  const uint64_t section_table_size = static_cast<uint64_t>(header.e_shnum) * sizeof(Elf64_Shdr);
+  if (!range_is_in_image(header.e_shoff, section_table_size))
+    return std::nullopt;
+
+  const auto sections = read_elf_array_for_test<Elf64_Shdr>(image, header.e_shoff, header.e_shnum);
+  for (const Elf64_Shdr &symtab : sections) {
+    if ((symtab.sh_type != SHT_SYMTAB && symtab.sh_type != SHT_DYNSYM) ||
+        symtab.sh_entsize != sizeof(Elf64_Sym) || symtab.sh_size % sizeof(Elf64_Sym) != 0 ||
+        symtab.sh_link >= sections.size() || !range_is_in_image(symtab.sh_offset, symtab.sh_size)) {
+      continue;
+    }
+    const Elf64_Shdr &strtab = sections[symtab.sh_link];
+    if (strtab.sh_type != SHT_STRTAB || !range_is_in_image(strtab.sh_offset, strtab.sh_size))
+      continue;
+    const auto symbols = read_elf_array_for_test<Elf64_Sym>(image, symtab.sh_offset,
+                                                            symtab.sh_size / sizeof(Elf64_Sym));
+    for (const Elf64_Sym &symbol : symbols) {
+      if (symbol.st_name >= strtab.sh_size)
+        continue;
+      const char *begin =
+          reinterpret_cast<const char *>(image.data() + strtab.sh_offset + symbol.st_name);
+      const size_t remaining = strtab.sh_size - symbol.st_name;
+      const auto *end = static_cast<const char *>(std::memchr(begin, '\0', remaining));
+      if (end != nullptr && std::string_view(begin, static_cast<size_t>(end - begin)) == name)
+        return symbol;
+    }
+  }
+  return std::nullopt;
 }
 
 template <typename T>
@@ -389,8 +430,11 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
   return image;
 }
 
-std::vector<uint8_t>
-make_minimal_amdgpu_elf_with_descriptor_after_text(const std::vector<uint32_t> &text_words) {
+std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
+    const std::vector<uint32_t> &text_words,
+    std::optional<size_t> text_function_words = std::nullopt) {
+  if (text_function_words && *text_function_words > text_words.size())
+    throw std::invalid_argument("text function extent exceeds .text fixture");
   constexpr uint64_t text_offset = 0x100;
   constexpr uint64_t text_vaddr = 0x1100;
   const uint64_t text_size = text_words.size() * sizeof(uint32_t);
@@ -406,6 +450,7 @@ make_minimal_amdgpu_elf_with_descriptor_after_text(const std::vector<uint32_t> &
 
   std::vector<uint8_t> strtab{'\0'};
   const uint32_t kd_symbol_name = add_elf_name(strtab, "kernel.kd");
+  const uint32_t text_symbol_name = text_function_words ? add_elf_name(strtab, "kernel") : 0;
 
   // The kernel descriptor requires 8-byte alignment (tests reinterpret_cast the
   // .rodata bytes to TestKernelDescriptor). An odd text_words count leaves
@@ -416,7 +461,7 @@ make_minimal_amdgpu_elf_with_descriptor_after_text(const std::vector<uint32_t> &
   const uint64_t rodata_vaddr = align_up_for_test(text_vaddr + text_size, 8) + load_align;
   const uint64_t strtab_offset = rodata_offset + rodata_size;
   const uint64_t symtab_offset = align_up_for_test(strtab_offset + strtab.size(), 8);
-  constexpr size_t sym_count = 2;
+  const size_t sym_count = text_function_words ? 3 : 2;
   const uint64_t shstrtab_offset = symtab_offset + sym_count * sizeof(Elf64_Sym);
   const uint64_t shoff = align_up_for_test(shstrtab_offset + shstrtab.size(), 8);
   constexpr uint16_t section_count = 6;
@@ -469,12 +514,19 @@ make_minimal_amdgpu_elf_with_descriptor_after_text(const std::vector<uint32_t> &
   std::memcpy(image.data() + rodata_offset, descriptor.data(), descriptor.size());
   std::memcpy(image.data() + strtab_offset, strtab.data(), strtab.size());
 
-  std::array<Elf64_Sym, sym_count> syms{};
+  std::vector<Elf64_Sym> syms(sym_count);
   syms[1].st_name = kd_symbol_name;
   syms[1].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
   syms[1].st_shndx = 2;
   syms[1].st_value = rodata_vaddr;
   syms[1].st_size = kKernelDescriptorSize;
+  if (text_function_words) {
+    syms[2].st_name = text_symbol_name;
+    syms[2].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeFunc);
+    syms[2].st_shndx = 1;
+    syms[2].st_value = text_vaddr;
+    syms[2].st_size = *text_function_words * sizeof(uint32_t);
+  }
   std::memcpy(image.data() + symtab_offset, syms.data(), syms.size() * sizeof(Elf64_Sym));
 
   std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
@@ -7305,9 +7357,9 @@ TEST(BinaryTranslatorE2E, PatchesRecoveredSwappcTargetAfterRelocation) {
       kOriginalGetpcDelta,                                                // 0x08.
       build_s_addc_u32(kPcSreg + 1, kPcSreg + 1, kInlineInt0),            // 0x0c.
       build_s_swappc_b64(kReturnSreg, kPcSreg, ROCJITSU_CODE_ARCH_CDNA4), // 0x10.
-      rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),                 // 0x14 fallthrough.
-      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),                 // 0x18 unreachable.
-      rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),                 // 0x1c target.
+      rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), // 0x14 unreachable continuation.
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4), // 0x18 unreachable.
+      rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), // 0x1c target.
   };
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
@@ -7323,15 +7375,16 @@ TEST(BinaryTranslatorE2E, PatchesRecoveredSwappcTargetAfterRelocation) {
 
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
-  ASSERT_GE(translated.text_sections()[0]->size(), 12 * sizeof(uint32_t));
+  ASSERT_GE(translated.text_sections()[0]->size(), 11 * sizeof(uint32_t));
   EXPECT_EQ(target_words[0], build_s_getpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_CDNA3));
   EXPECT_EQ(target_words[1], build_s_add_u32(kPcSreg, kPcSreg, kLiteralOperand));
   EXPECT_EQ(target_words[2], kOriginalGetpcDelta);
   EXPECT_EQ(target_words[3], build_s_addc_u32(kPcSreg + 1, kPcSreg + 1, kInlineInt0));
-  EXPECT_EQ(target_words[4], build_s_call_b64(kReturnSreg, 6));
+  // The target is non-returning, so relocation drops the dead continuation.
+  // The pre-existing recovered-transfer window remains in place on this branch.
+  EXPECT_EQ(target_words[4], build_s_call_b64(kReturnSreg, 5));
   expect_nop_words(target_words, 5, 10, ROCJITSU_CODE_ARCH_CDNA3);
   EXPECT_EQ(target_words[10], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3));
-  EXPECT_EQ(target_words[11], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3));
 }
 
 TEST(BinaryTranslatorE2E, TranslatesDirectSCallWithSetpcReturn) {
@@ -7406,6 +7459,40 @@ TEST(BinaryTranslatorE2E, TranslatesDirectSCallWhenCalleeBranchesToSetpcReturn) 
   EXPECT_EQ(target_words[2], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3));
   EXPECT_EQ(target_words[3], rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3));
   EXPECT_EQ(target_words[4], build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_CDNA3));
+}
+
+TEST(BinaryTranslatorE2E, TranslatesNestedCallReturningThroughOuterPair) {
+  constexpr uint16_t kOuterReturnSreg = 30;
+  constexpr uint16_t kInnerReturnSreg = 28;
+  const std::vector<uint32_t> words = {
+      build_s_call_b64(kOuterReturnSreg, 1),              // 0x00 -> outer callee at 0x08.
+      rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), // 0x04 outer continuation.
+      build_s_call_b64(kInnerReturnSreg, 1),              // 0x08 -> inner callee at 0x10.
+      rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), // 0x0c inner continuation.
+      rocjitsu::pack_sopp(5, 1),                          // 0x10 -> outer return at 0x18.
+      build_s_setpc_b64(kInnerReturnSreg, ROCJITSU_CODE_ARCH_CDNA4), // 0x14 inner return.
+      build_s_setpc_b64(kOuterReturnSreg, ROCJITSU_CODE_ARCH_CDNA4), // 0x18 outer return.
+  };
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << result.diagnostics.front().message;
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_GE(decoded.size(), words.size());
+  const auto count_mnemonic = [&](std::string_view mnemonic) {
+    return std::ranges::count_if(
+        decoded, [&](const auto &inst) { return inst != nullptr && inst->mnemonic() == mnemonic; });
+  };
+  EXPECT_EQ(count_mnemonic("s_call_b64"), 2);
+  EXPECT_EQ(count_mnemonic("s_setpc_b64"), 2);
 }
 
 TEST(BinaryTranslatorE2E, TranslatesSwappcCallWhenCalleeSetpcBranchesToReturn) {
@@ -7996,6 +8083,44 @@ TEST(BinaryTranslatorE2E, Gfx1250RelocatesDirectCallForB0ToA0) {
   EXPECT_EQ(decoded[1]->mnemonic(), "s_call_i64");
   ASSERT_TRUE(decoded[1]->branch_offset_bytes().has_value());
   EXPECT_EQ(*decoded[1]->branch_offset_bytes(), 4);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250DirectTailTransferCompactionIsIdempotent) {
+  constexpr uint16_t kReturnSreg = 30;
+  const std::vector<uint32_t> words = {
+      rocjitsu::build_s_call_b64(kReturnSreg, 1, ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),
+  };
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  EXPECT_EQ(target_words[0],
+            rocjitsu::build_s_call_b64(kReturnSreg, 0, ROCJITSU_CODE_ARCH_GFX1250));
+  EXPECT_EQ(target_words[1], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250));
+
+  rocjitsu::BinaryTranslator verifier(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto second = verifier.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250KernargPreloadUsesSingleDescriptorEntry) {
@@ -10015,7 +10140,7 @@ TEST(BinaryTranslatorE2E, Gfx1250AcceptsClangUnreachableKernelStub) {
   constexpr uint32_t kSetReplayMode = 0xb9800641u;
   constexpr uint32_t kLiteralOne = 1u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
-      {kSetReplayMode, kLiteralOne, 0});
+      {kSetReplayMode, kLiteralOne, 0}, 2);
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
   ASSERT_TRUE(source.is_valid());
 
@@ -10031,13 +10156,18 @@ TEST(BinaryTranslatorE2E, Gfx1250AcceptsClangUnreachableKernelStub) {
   ASSERT_FALSE(translated.text_sections().empty());
   const auto decoded =
       decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
-  ASSERT_EQ(decoded.size(), 2u);
+  ASSERT_EQ(decoded.size(), 2u)
+      << "the synthesized endpgm must be the only instruction after the stub body";
   ASSERT_NE(decoded[0]->raw_encoding(), nullptr);
   EXPECT_EQ(decoded[0]->mnemonic(), "s_setreg_imm32_b32");
   EXPECT_EQ(decoded[0]->raw_encoding()[0], kSetReplayMode);
   EXPECT_EQ(decoded[0]->raw_encoding()[1], kLiteralOne);
-  EXPECT_EQ(decoded[1]->mnemonic(), "s_nop")
-      << "the translated body may contain only the normal text-alignment nop";
+  EXPECT_EQ(decoded[1]->mnemonic(), "s_endpgm");
+
+  const auto kernel_symbol = rocjitsu::find_elf_symbol_for_test(result.elf_bytes, "kernel");
+  ASSERT_TRUE(kernel_symbol.has_value());
+  EXPECT_EQ(kernel_symbol->st_size, 3 * sizeof(uint32_t))
+      << "the translated function extent must include its synthesized terminator";
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250AcceptsClangUnreachableKernelStubWithPrefetchPrologue) {
@@ -10064,15 +10194,42 @@ TEST(BinaryTranslatorE2E, Gfx1250AcceptsClangUnreachableKernelStubWithPrefetchPr
   ASSERT_FALSE(translated.text_sections().empty());
   const auto decoded =
       decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
-  ASSERT_EQ(decoded.size(), 4u);
+  ASSERT_EQ(decoded.size(), 4u)
+      << "the synthesized endpgm must be the only instruction after the stub body";
   EXPECT_EQ(decoded[0]->mnemonic(), "global_prefetch_b8");
   EXPECT_EQ(decoded[1]->mnemonic(), "v_nop_e32");
   EXPECT_EQ(decoded[2]->mnemonic(), "s_setreg_imm32_b32");
   ASSERT_NE(decoded[2]->raw_encoding(), nullptr);
   EXPECT_EQ(decoded[2]->raw_encoding()[0], kSetReplayMode[0]);
   EXPECT_EQ(decoded[2]->raw_encoding()[1], kSetReplayMode[1]);
-  EXPECT_EQ(decoded[3]->mnemonic(), "s_nop")
-      << "the translated body may contain only the normal text-alignment nop";
+  EXPECT_EQ(decoded[3]->mnemonic(), "s_endpgm");
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250MaterializesSectionFinalClangUnreachableKernelStub) {
+  constexpr uint32_t kSetReplayMode = 0xb9800641u;
+  constexpr uint32_t kLiteralOne = 1u;
+  auto image =
+      rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text({kSetReplayMode, kLiteralOne});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto first = translator.translate(source);
+  ASSERT_TRUE(first.ok()) << (first.diagnostics.empty() ? "" : first.diagnostics.front().message);
+  rocjitsu::AmdGpuCodeObject first_output(first.elf_bytes.data(), first.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*first_output.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_EQ(decoded.size(), 2u);
+  EXPECT_EQ(decoded[0]->mnemonic(), "s_setreg_imm32_b32");
+  EXPECT_EQ(decoded[1]->mnemonic(), "s_endpgm");
+
+  auto second = translator.translate(first_output);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, first.elf_bytes);
 }
 
 TEST(BinaryTranslatorE2E, MatchedSemanticExpandRuleFailureIsDiagnostic) {


### PR DESCRIPTION
## Motivation

Calls proven nonreturning retained synthetic fallthrough edges, which could pull unrelated code into a kernel scope. Recognized gfx1250 clang unreachable stubs also lost their implicit padding boundary during text materialization.

## Technical Details

- Resolve call returns with a conservative fixed point and drop continuations only when every target is complete and proven nonreturning.
- Materialize `s_endpgm` for recognized implicit stubs and include it in relocated `STT_FUNC` extents.
- Cover direct, recovered, nested, and partial calls plus both stub forms and section-final stubs.

## Issue Tracking

N/A

## Test Plan

Build RocJITsu and run focused CFG and translator regressions, offline idempotence smoke tests, and repository hooks.

## Test Result

Passed. All 214 focused CFG and translator tests and all 12 offline translator smoke tests passed; repository hooks passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.