### PR TITLE
fix(rocjitsu): harden VOP modifier diagnostics and coverage

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -9649,22 +9649,20 @@ class CodeGenerator:
                                     # operand-local fallback only for marker
                                     # combinations it did not already reject.
                                     if not _rejected_dpp_markers:
-                                        unsupported_dpp_label = (
-                                            unsupported_dpp_markers[0][1]
-                                            if len(unsupported_dpp_markers) == 1
-                                            else 'DPP'
-                                        )
-                                        qualified_dpp_markers = [
-                                            marker.replace(
-                                                'OpEncoding', factory_op_encoding
+                                        for (
+                                            unsupported_marker,
+                                            unsupported_label,
+                                        ) in unsupported_dpp_markers:
+                                            qualified_dpp_marker = (
+                                                unsupported_marker.replace(
+                                                    'OpEncoding', factory_op_encoding
+                                                )
                                             )
-                                            for marker, _ in unsupported_dpp_markers
-                                        ]
-                                        factory_validation_parts.append(
-                                            f'if ({" || ".join(qualified_dpp_markers)}) '
-                                            f'[[unlikely]] return emit_error.emit() << "{inst.name} does not support '
-                                            f'{unsupported_dpp_label}";'
-                                        )
+                                            factory_validation_parts.append(
+                                                f'if ({qualified_dpp_marker}) '
+                                                f'[[unlikely]] return emit_error.emit() << "{inst.name} does not support '
+                                                f'{unsupported_label}";'
+                                            )
                                 elif (
                                     _dpp_struct
                                     and _supports_dpp_encoding

--- a/emulation/rocjitsu/lib/python/amdisa/parser.py
+++ b/emulation/rocjitsu/lib/python/amdisa/parser.py
@@ -1123,6 +1123,10 @@ class Parser:
             inst_name_node = xs.get_node(inst_node, xs.INST_NAME)
             inst_encs_node = xs.get_node(inst_node, xs.INST_ENCODINGS)
             inst_name = inst_name_node.text
+            # Preserve condition-gated alternate encodings as instruction-level
+            # legality provenance. In particular, CDNA4 DPP and SDWA entries may
+            # be skipped below for class emission while still proving that the
+            # instruction supports that modifier form.
             available_encodings = frozenset(
                 xs.get_node_text(xs.get_node(inst_enc_node, xs.ENCODING_NAME))
                 for inst_enc_node in inst_encs_node

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -3816,6 +3816,21 @@ def test_split_execution_ids_name_and_match_callbacks(
         assert sorted(selected_ids) == sorted(callbacks)
 
 
+def test_rdna4_generated_vopc_dpp_availability_is_instruction_specific(
+    rdna4_generated_root: Path,
+):
+    vopc = (rdna4_generated_root / 'vopc.cpp').read_text()
+
+    supported = _generated_constructor_body(vopc, 'VCmpEqU32Vopc')
+    unsupported = _generated_decode_body(vopc, 'VCmpEqF64Vopc')
+
+    assert 'reinterpret_cast<const VopcVopDpp16MachineInst *>' in supported
+    assert 'reinterpret_cast<const VopcVopDpp8MachineInst *>' in supported
+    assert 'V_CMP_EQ_U32 does not support DPP' not in supported
+    assert 'emit_error.emit() << "V_CMP_EQ_F64 does not support DPP"' in unsupported
+    assert 'emit_error.emit() << "V_CMP_EQ_F64 does not support DPP8"' in unsupported
+
+
 def test_generated_vop_execution_has_no_instruction_storage_bypass(
     amdgpu_generated_root: Path,
 ):

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sop1_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sop1_exec.cpp
@@ -5,7 +5,6 @@
 // See lib/python/amdisa/README.md for regeneration instructions.
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/sop1.h"
-#include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/register_access.h"
@@ -22,24 +21,45 @@
 namespace rocjitsu {
 namespace cdna5 {
 
-void SMovB32Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_mov_b32_sop1(*this, wf); }
+void SMovB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, amdgpu::RegisterAccess(wf).read_scalar(ssrc0));
+}
 
-void SMovB64Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_mov_b64_sop1(*this, wf); }
+void SMovB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+}
 
 void SCmovB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmov_b32_sop1(*this, wf);
+  if (wf.read_scc())
+    amdgpu::RegisterAccess(wf).write_scalar(sdst, amdgpu::RegisterAccess(wf).read_scalar(ssrc0));
 }
 
 void SCmovB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmov_b64_sop1(*this, wf);
+  if (wf.read_scc())
+    amdgpu::RegisterAccess(wf).write_scalar64(sdst,
+                                              amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
 }
 
 void SBrevB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_brev_b32_sop1(*this, wf);
+  uint32_t result = [&]() {
+    uint32_t s = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+    uint32_t r = 0;
+    for (int i = 0; i < 32; ++i)
+      r |= ((s >> i) & 1) << (31 - i);
+    return r;
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SBrevB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_brev_b64_sop1(*this, wf);
+  uint64_t result = [&]() {
+    uint64_t s = amdgpu::RegisterAccess(wf).read_scalar64(ssrc0);
+    uint64_t r = 0;
+    for (int i = 0; i < 64; ++i)
+      r |= ((s >> i) & 1ULL) << (63 - i);
+    return r;
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
 }
 
 void SGetShaderCyclesU64Sop1::execute_impl(amdgpu::Wavefront &wf) {
@@ -49,183 +69,408 @@ void SGetShaderCyclesU64Sop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void SCtzI32B32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_ctz_i32_b32_sop1(*this, wf);
+  uint32_t result = [&]() {
+    auto s = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0));
+    return s == 0 ? static_cast<uint32_t>(-1) : static_cast<uint32_t>(std::countr_zero(s));
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SCtzI32B64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_ctz_i32_b64_sop1(*this, wf);
+  uint64_t result = [&]() {
+    auto s = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+    return s == 0 ? static_cast<uint32_t>(-1) : static_cast<uint32_t>(std::countr_zero(s));
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SClzI32U32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_clz_i32_u32_sop1(*this, wf);
+  uint32_t result = [&]() {
+    auto s = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0));
+    return s == 0 ? static_cast<uint32_t>(-1) : static_cast<uint32_t>(std::countl_zero(s));
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SClzI32U64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_clz_i32_u64_sop1(*this, wf);
+  uint64_t result = [&]() {
+    auto s = static_cast<uint64_t>(
+        static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)));
+    return s == 0 ? static_cast<uint32_t>(-1) : static_cast<uint32_t>(std::countl_zero(s));
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
-void SClsI32Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_cls_i32_sop1(*this, wf); }
+void SClsI32Sop1::execute_impl(amdgpu::Wavefront &wf) {
+  int32_t result = [&]() {
+    int32_t sv =
+        static_cast<int32_t>(static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+    uint32_t abs_val = sv < 0 ? ~static_cast<uint32_t>(sv) : static_cast<uint32_t>(sv);
+    return abs_val == 0 ? static_cast<uint32_t>(-1)
+                        : static_cast<uint32_t>(std::countl_zero(abs_val));
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+}
 
 void SClsI32I64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cls_i32_i64_sop1(*this, wf);
+  int64_t result = [&]() {
+    int64_t sv =
+        static_cast<int64_t>(static_cast<int64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)));
+    uint64_t abs_val = sv < 0 ? ~static_cast<uint64_t>(sv) : static_cast<uint64_t>(sv);
+    return abs_val == 0 ? static_cast<uint32_t>(-1)
+                        : static_cast<uint32_t>(std::countl_zero(abs_val));
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SSextI32I8Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_sext_i32_i8_sop1(*this, wf);
+  int32_t result = static_cast<int32_t>(
+      static_cast<int32_t>(static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))
+                           << 24) >>
+      24);
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SSextI32I16Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_sext_i32_i16_sop1(*this, wf);
+  int32_t result = static_cast<int32_t>(
+      static_cast<int32_t>(static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))
+                           << 16) >>
+      16);
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SBitset0B32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_bitset0_b32_sop1(*this, wf);
+  amdgpu::RegisterAccess(wf).write_scalar(
+      sdst, (amdgpu::RegisterAccess(wf).read_scalar(sdst) &
+             (~(1u << (amdgpu::RegisterAccess(wf).read_scalar(ssrc0) & 31u)))));
 }
 
 void SBitset0B64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_bitset0_b64_sop1(*this, wf);
+  amdgpu::RegisterAccess(wf).write_scalar64(
+      sdst, (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(sdst)) &
+             (~(1ULL << (amdgpu::RegisterAccess(wf).read_scalar(ssrc0) & 63u)))));
 }
 
 void SBitset1B32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_bitset1_b32_sop1(*this, wf);
+  amdgpu::RegisterAccess(wf).write_scalar(
+      sdst, (amdgpu::RegisterAccess(wf).read_scalar(sdst) |
+             (1u << (amdgpu::RegisterAccess(wf).read_scalar(ssrc0) & 31u))));
 }
 
 void SBitset1B64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_bitset1_b64_sop1(*this, wf);
+  amdgpu::RegisterAccess(wf).write_scalar64(
+      sdst, (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(sdst)) |
+             (1ULL << (amdgpu::RegisterAccess(wf).read_scalar(ssrc0) & 63u))));
 }
 
 void SBitreplicateB64B32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_bitreplicate_b64_b32_sop1(*this, wf);
+  uint32_t val = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint64_t result = 0;
+  for (uint32_t i = 0; i < 32; ++i) {
+    uint64_t bit = (static_cast<uint64_t>(val) >> i) & 1ULL;
+    result |= bit << (2 * i);
+    result |= bit << (2 * i + 1);
+  }
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
 }
 
-void SAbsI32Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_abs_i32_sop1(*this, wf); }
+void SAbsI32Sop1::execute_impl(amdgpu::Wavefront &wf) {
+  int32_t result = [&]() {
+    int32_t v =
+        static_cast<int32_t>(static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+    return static_cast<uint32_t>(v < 0 ? (0u - static_cast<uint32_t>(v))
+                                       : static_cast<uint32_t>(v));
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
+}
 
 void SBcnt0I32B32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_bcnt0_i32_b32_sop1(*this, wf);
+  uint32_t result =
+      static_cast<uint32_t>(std::popcount(~amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
 }
 
 void SBcnt0I32B64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_bcnt0_i32_b64_sop1(*this, wf);
+  uint64_t result = static_cast<uint32_t>(
+      std::popcount(~static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0))));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0ULL));
 }
 
 void SBcnt1I32B32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_bcnt1_i32_b32_sop1(*this, wf);
+  uint32_t result =
+      static_cast<uint32_t>(std::popcount(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
 }
 
 void SBcnt1I32B64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_bcnt1_i32_b64_sop1(*this, wf);
+  uint64_t result = static_cast<uint32_t>(
+      std::popcount(static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0))));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0ULL));
 }
 
 void SQuadmaskB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_quadmask_b32_sop1(*this, wf);
+  uint32_t result = [&]() {
+    uint32_t s = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+    uint32_t r = 0;
+    for (int i = 0; i < 8; ++i)
+      if (s & (0xFu << (i * 4)))
+        r |= (1u << i);
+    return r;
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
 }
 
 void SQuadmaskB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_quadmask_b64_sop1(*this, wf);
+  uint64_t result = [&]() {
+    uint64_t s = amdgpu::RegisterAccess(wf).read_scalar64(ssrc0);
+    uint64_t r = 0;
+    for (int i = 0; i < 16; ++i)
+      if (s & (0xFULL << (i * 4)))
+        r |= (1ULL << i);
+    return r;
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+  wf.write_scc((result != 0ULL));
 }
 
-void SWqmB32Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_wqm_b32_sop1(*this, wf); }
+void SWqmB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
+  uint32_t result = [&]() {
+    uint32_t s = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+    uint32_t r = 0;
+    for (int i = 0; i < 8; ++i)
+      if (s & (0xFu << (i * 4)))
+        r |= (0xFu << (i * 4));
+    return r;
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
+}
 
-void SWqmB64Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_wqm_b64_sop1(*this, wf); }
+void SWqmB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t result = [&]() {
+    uint64_t s = amdgpu::RegisterAccess(wf).read_scalar64(ssrc0);
+    uint64_t r = 0;
+    for (int i = 0; i < 16; ++i)
+      if (s & (0xFULL << (i * 4)))
+        r |= (0xFULL << (i * 4));
+    return r;
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+  wf.write_scc((result != 0ULL));
+}
 
-void SNotB32Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_not_b32_sop1(*this, wf); }
+void SNotB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
+  uint32_t result = (~amdgpu::RegisterAccess(wf).read_scalar(ssrc0));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
+}
 
-void SNotB64Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_not_b64_sop1(*this, wf); }
+void SNotB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t result = (~static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)));
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+  wf.write_scc((result != 0ULL));
+}
 
 void SAndSaveexecB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_and_saveexec_b32_sop1(*this, wf);
+  uint64_t src = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint64_t old_exec = wf.exec();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, static_cast<uint32_t>(old_exec));
+  wf.set_exec(((old_exec & src) & 0xffffffffULL));
+  wf.write_scc((wf.exec() != 0ULL));
 }
 
 void SAndSaveexecB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_and_saveexec_b64_sop1(*this, wf);
+  uint64_t src = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+  uint64_t old_exec = wf.exec_raw();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, old_exec);
+  wf.set_exec_raw((old_exec & src));
+  wf.write_scc((wf.exec_raw() != 0ULL));
 }
 
 void SOrSaveexecB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_or_saveexec_b32_sop1(*this, wf);
+  uint64_t src = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint64_t old_exec = wf.exec();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, static_cast<uint32_t>(old_exec));
+  wf.set_exec(((old_exec | src) & 0xffffffffULL));
+  wf.write_scc((wf.exec() != 0ULL));
 }
 
 void SOrSaveexecB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_or_saveexec_b64_sop1(*this, wf);
+  uint64_t src = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+  uint64_t old_exec = wf.exec_raw();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, old_exec);
+  wf.set_exec_raw((old_exec | src));
+  wf.write_scc((wf.exec_raw() != 0ULL));
 }
 
 void SXorSaveexecB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_xor_saveexec_b32_sop1(*this, wf);
+  uint64_t src = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint64_t old_exec = wf.exec();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, static_cast<uint32_t>(old_exec));
+  wf.set_exec(((old_exec ^ src) & 0xffffffffULL));
+  wf.write_scc((wf.exec() != 0ULL));
 }
 
 void SXorSaveexecB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_xor_saveexec_b64_sop1(*this, wf);
+  uint64_t src = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+  uint64_t old_exec = wf.exec_raw();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, old_exec);
+  wf.set_exec_raw((old_exec ^ src));
+  wf.write_scc((wf.exec_raw() != 0ULL));
 }
 
 void SNandSaveexecB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_nand_saveexec_b32_sop1(*this, wf);
+  uint64_t src = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint64_t old_exec = wf.exec();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, static_cast<uint32_t>(old_exec));
+  wf.set_exec(((~(old_exec & src)) & 0xffffffffULL));
+  wf.write_scc((wf.exec() != 0ULL));
 }
 
 void SNandSaveexecB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_nand_saveexec_b64_sop1(*this, wf);
+  uint64_t src = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+  uint64_t old_exec = wf.exec_raw();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, old_exec);
+  wf.set_exec_raw((~(old_exec & src)));
+  wf.write_scc((wf.exec_raw() != 0ULL));
 }
 
 void SNorSaveexecB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_nor_saveexec_b32_sop1(*this, wf);
+  uint64_t src = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint64_t old_exec = wf.exec();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, static_cast<uint32_t>(old_exec));
+  wf.set_exec(((~(old_exec | src)) & 0xffffffffULL));
+  wf.write_scc((wf.exec() != 0ULL));
 }
 
 void SNorSaveexecB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_nor_saveexec_b64_sop1(*this, wf);
+  uint64_t src = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+  uint64_t old_exec = wf.exec_raw();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, old_exec);
+  wf.set_exec_raw((~(old_exec | src)));
+  wf.write_scc((wf.exec_raw() != 0ULL));
 }
 
 void SXnorSaveexecB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_xnor_saveexec_b32_sop1(*this, wf);
+  uint64_t src = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint64_t old_exec = wf.exec();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, static_cast<uint32_t>(old_exec));
+  wf.set_exec(((~(old_exec ^ src)) & 0xffffffffULL));
+  wf.write_scc((wf.exec() != 0ULL));
 }
 
 void SXnorSaveexecB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_xnor_saveexec_b64_sop1(*this, wf);
+  uint64_t src = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+  uint64_t old_exec = wf.exec_raw();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, old_exec);
+  wf.set_exec_raw((~(old_exec ^ src)));
+  wf.write_scc((wf.exec_raw() != 0ULL));
 }
 
 void SAndNot0SaveexecB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_and_not0_saveexec_b32_sop1(*this, wf);
+  uint64_t src = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint64_t old_exec = wf.exec();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, static_cast<uint32_t>(old_exec));
+  wf.set_exec(((old_exec & (~src)) & 0xffffffffULL));
+  wf.write_scc((wf.exec() != 0ULL));
 }
 
 void SAndNot0SaveexecB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_and_not0_saveexec_b64_sop1(*this, wf);
+  uint64_t src = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+  uint64_t old_exec = wf.exec_raw();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, old_exec);
+  wf.set_exec_raw((old_exec & (~src)));
+  wf.write_scc((wf.exec_raw() != 0ULL));
 }
 
 void SOrNot0SaveexecB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_or_not0_saveexec_b32_sop1(*this, wf);
+  uint64_t src = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint64_t old_exec = wf.exec();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, static_cast<uint32_t>(old_exec));
+  wf.set_exec(((old_exec | (~src)) & 0xffffffffULL));
+  wf.write_scc((wf.exec() != 0ULL));
 }
 
 void SOrNot0SaveexecB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_or_not0_saveexec_b64_sop1(*this, wf);
+  uint64_t src = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+  uint64_t old_exec = wf.exec_raw();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, old_exec);
+  wf.set_exec_raw((old_exec | (~src)));
+  wf.write_scc((wf.exec_raw() != 0ULL));
 }
 
 void SAndNot1SaveexecB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_and_not1_saveexec_b32_sop1(*this, wf);
+  uint64_t src = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint64_t old_exec = wf.exec();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, static_cast<uint32_t>(old_exec));
+  wf.set_exec(((src & (~old_exec)) & 0xffffffffULL));
+  wf.write_scc((wf.exec() != 0ULL));
 }
 
 void SAndNot1SaveexecB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_and_not1_saveexec_b64_sop1(*this, wf);
+  uint64_t src = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+  uint64_t old_exec = wf.exec_raw();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, old_exec);
+  wf.set_exec_raw((src & (~old_exec)));
+  wf.write_scc((wf.exec_raw() != 0ULL));
 }
 
 void SOrNot1SaveexecB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_or_not1_saveexec_b32_sop1(*this, wf);
+  uint64_t src = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint64_t old_exec = wf.exec();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, static_cast<uint32_t>(old_exec));
+  wf.set_exec(((src | (~old_exec)) & 0xffffffffULL));
+  wf.write_scc((wf.exec() != 0ULL));
 }
 
 void SOrNot1SaveexecB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_or_not1_saveexec_b64_sop1(*this, wf);
+  uint64_t src = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+  uint64_t old_exec = wf.exec_raw();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, old_exec);
+  wf.set_exec_raw((src | (~old_exec)));
+  wf.write_scc((wf.exec_raw() != 0ULL));
 }
 
 void SAndNot0WrexecB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_and_not0_wrexec_b32_sop1(*this, wf);
+  uint64_t src = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint64_t old_exec = wf.exec();
+  uint64_t result = ((old_exec & (~src)) & 0xffffffffULL);
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, static_cast<uint32_t>(result));
+  wf.set_exec(result);
+  wf.write_scc((result != 0ULL));
 }
 
 void SAndNot0WrexecB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_and_not0_wrexec_b64_sop1(*this, wf);
+  uint64_t src = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+  uint64_t old_exec = wf.exec_raw();
+  uint64_t result = (old_exec & (~src));
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, static_cast<uint64_t>(result));
+  wf.set_exec_raw(result);
+  wf.write_scc((result != 0ULL));
 }
 
 void SAndNot1WrexecB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_and_not1_wrexec_b32_sop1(*this, wf);
+  uint64_t src = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint64_t old_exec = wf.exec();
+  uint64_t result = ((src & (~old_exec)) & 0xffffffffULL);
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, static_cast<uint32_t>(result));
+  wf.set_exec(result);
+  wf.write_scc((result != 0ULL));
 }
 
 void SAndNot1WrexecB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_and_not1_wrexec_b64_sop1(*this, wf);
+  uint64_t src = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+  uint64_t old_exec = wf.exec_raw();
+  uint64_t result = (src & (~old_exec));
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, static_cast<uint64_t>(result));
+  wf.set_exec_raw(result);
+  wf.write_scc((result != 0ULL));
 }
 
 void SMovrelsB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
@@ -361,11 +606,59 @@ void SAddPcI64Sop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void SSendmsgRtnB32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_sendmsg_rtn_b32_sop1(*this, wf);
+  uint32_t msg = static_cast<uint32_t>(ssrc0.encoding_value_);
+  uint64_t value = 0;
+  switch (msg) {
+  case 0x83: {
+    auto *engine = wf.cu().engine();
+    value = engine ? engine->global_time() : 0;
+    break;
+  }
+  case 0x80:
+  case 0x81:
+  case 0x82:
+  case 0x84:
+  case 0x85:
+  case 0x86:
+  case 0x87:
+  case 0x88:
+  case 0x98:
+  default:
+    value = 0;
+    break;
+  }
+  if (sdst.size_bits() == 64)
+    amdgpu::RegisterAccess(wf).write_scalar64(sdst, value);
+  else
+    amdgpu::RegisterAccess(wf).write_scalar(sdst, static_cast<uint32_t>(value));
 }
 
 void SSendmsgRtnB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_sendmsg_rtn_b64_sop1(*this, wf);
+  uint32_t msg = static_cast<uint32_t>(ssrc0.encoding_value_);
+  uint64_t value = 0;
+  switch (msg) {
+  case 0x83: {
+    auto *engine = wf.cu().engine();
+    value = engine ? engine->global_time() : 0;
+    break;
+  }
+  case 0x80:
+  case 0x81:
+  case 0x82:
+  case 0x84:
+  case 0x85:
+  case 0x86:
+  case 0x87:
+  case 0x88:
+  case 0x98:
+  default:
+    value = 0;
+    break;
+  }
+  if (sdst.size_bits() == 64)
+    amdgpu::RegisterAccess(wf).write_scalar64(sdst, value);
+  else
+    amdgpu::RegisterAccess(wf).write_scalar(sdst, static_cast<uint32_t>(value));
 }
 
 void SBarrierSignalSop1::execute_impl(amdgpu::Wavefront &wf) {
@@ -415,74 +708,128 @@ void SBarrierJoinSop1::execute_impl(amdgpu::Wavefront &wf) {
   wf.barrier_join(barrier_id);
 }
 
-void SAllocVgprSop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_alloc_vgpr_sop1(*this, wf);
-}
+void SAllocVgprSop1::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
 void SWakeupBarrierSop1::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
 void SSleepVarSop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_sleep_var_sop1(*this, wf);
+  constexpr uint32_t kSleepClocksPerUnit = 64;
+  wf.set_sleep_cycles(kSleepClocksPerUnit *
+                      (amdgpu::RegisterAccess(wf).read_scalar(ssrc0) & 0x7Fu));
+  wf.cu().request_functional_yield();
 }
 
 void SCeilF32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_ceil_f32_sop1(*this, wf);
+  float result = std::ceil(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, std::bit_cast<uint32_t>(result));
 }
 
 void SFloorF32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_floor_f32_sop1(*this, wf);
+  float result =
+      util::floor_scalar(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, std::bit_cast<uint32_t>(result));
 }
 
 void STruncF32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_trunc_f32_sop1(*this, wf);
+  float result =
+      util::trunc_scalar(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, std::bit_cast<uint32_t>(result));
 }
 
 void SRndneF32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_rndne_f32_sop1(*this, wf);
+  float result =
+      std::nearbyint(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, std::bit_cast<uint32_t>(result));
 }
 
 void SCvtF32I32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cvt_f32_i32_sop1(*this, wf);
+  // SOP1 scalar conversions preserve SCC.
+  uint32_t result = std::bit_cast<uint32_t>(
+      static_cast<float>(static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SCvtF32U32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cvt_f32_u32_sop1(*this, wf);
+  // SOP1 scalar conversions preserve SCC.
+  uint32_t result =
+      std::bit_cast<uint32_t>(static_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SCvtI32F32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cvt_i32_f32_sop1(*this, wf);
+  // SOP1 scalar conversions preserve SCC.
+  uint32_t result = [&]() -> uint32_t {
+    float s =
+        std::bit_cast<float>(static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+    if (std::isnan(s))
+      return 0u;
+    if (s >= 2147483648.0f)
+      return static_cast<uint32_t>(INT32_MAX);
+    if (s < -2147483648.0f)
+      return static_cast<uint32_t>(INT32_MIN);
+    return static_cast<uint32_t>(static_cast<int32_t>(s));
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SCvtU32F32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cvt_u32_f32_sop1(*this, wf);
+  // SOP1 scalar conversions preserve SCC.
+  uint32_t result = [&]() -> uint32_t {
+    float s =
+        std::bit_cast<float>(static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+    if (std::isnan(s) || s < 0.0f)
+      return 0u;
+    if (s >= 4294967296.0f)
+      return UINT32_MAX;
+    return static_cast<uint32_t>(s);
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SCvtF16F32Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cvt_f16_f32_sop1(*this, wf);
+  // SOP1 scalar conversions preserve SCC.
+  uint32_t result = util::f32_to_f16_mode(
+      std::bit_cast<float>(static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))),
+      wf.fp16_ovfl());
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SCvtF32F16Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cvt_f32_f16_sop1(*this, wf);
+  // SOP1 scalar conversions preserve SCC.
+  uint32_t result = std::bit_cast<uint32_t>(
+      util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SCvtHiF32F16Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cvt_hi_f32_f16_sop1(*this, wf);
+  // SOP1 scalar conversions preserve SCC.
+  uint32_t result = std::bit_cast<uint32_t>(util::f16_to_f32(
+      static_cast<uint16_t>((amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) >> 16)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SCeilF16Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_ceil_f16_sop1(*this, wf);
+  float result = std::ceil(
+      util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, util::f32_to_f16(result));
 }
 
 void SFloorF16Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_floor_f16_sop1(*this, wf);
+  float result = util::floor_scalar(
+      util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, util::f32_to_f16(result));
 }
 
 void STruncF16Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_trunc_f16_sop1(*this, wf);
+  float result = util::trunc_scalar(
+      util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, util::f32_to_f16(result));
 }
 
 void SRndneF16Sop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_rndne_f16_sop1(*this, wf);
+  float result = std::nearbyint(
+      util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, util::f32_to_f16(result));
 }
 
 } // namespace cdna5

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sop2_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sop2_exec.cpp
@@ -5,7 +5,6 @@
 // See lib/python/amdisa/README.md for regeneration instructions.
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/sop2.h"
-#include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/register_access.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
@@ -20,188 +19,489 @@ namespace rocjitsu {
 namespace cdna5 {
 
 void SAddCoU32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_add_co_u32_sop2(*this, wf);
+  uint32_t s0 = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint32_t s1 = amdgpu::RegisterAccess(wf).read_scalar(ssrc1);
+  uint32_t result = (s0 + s1);
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc(((static_cast<uint64_t>(s0) + static_cast<uint64_t>(s1)) > 4294967295ULL));
 }
 
 void SSubCoU32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_sub_co_u32_sop2(*this, wf);
+  uint32_t s0 = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint32_t s1 = amdgpu::RegisterAccess(wf).read_scalar(ssrc1);
+  uint32_t result = (s0 - s1);
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((s0 < s1));
 }
 
 void SAddCoI32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_add_co_i32_sop2(*this, wf);
+  uint32_t s0 = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint32_t s1 = amdgpu::RegisterAccess(wf).read_scalar(ssrc1);
+  uint32_t result = (s0 + s1);
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc(::rocjitsu::amdgpu::signed_add_overflows(s0, s1));
 }
 
 void SSubCoI32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_sub_co_i32_sop2(*this, wf);
+  uint32_t s0 = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint32_t s1 = amdgpu::RegisterAccess(wf).read_scalar(ssrc1);
+  uint32_t result = (s0 - s1);
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc(::rocjitsu::amdgpu::signed_sub_overflows(s0, s1));
 }
 
 void SAddCoCiU32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_add_co_ci_u32_sop2(*this, wf);
+  uint32_t result = [&]() {
+    uint64_t w = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) +
+                 static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)) +
+                 static_cast<uint64_t>(wf.read_scc());
+    wf.write_scc(w > 0xFFFFFFFFULL);
+    return static_cast<uint32_t>(w);
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SSubCoCiU32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_sub_co_ci_u32_sop2(*this, wf);
+  uint32_t result = [&]() {
+    uint32_t a = amdgpu::RegisterAccess(wf).read_scalar(ssrc0),
+             b = amdgpu::RegisterAccess(wf).read_scalar(ssrc1);
+    uint32_t cin = wf.read_scc() ? 1u : 0u;
+    wf.write_scc(static_cast<uint64_t>(a) < static_cast<uint64_t>(b) + cin);
+    return a - b - cin;
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SAbsdiffI32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_absdiff_i32_sop2(*this, wf);
+  int32_t result = [&]() {
+    auto a = static_cast<int64_t>(
+        static_cast<int32_t>(static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))));
+    auto b = static_cast<int64_t>(
+        static_cast<int32_t>(static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
+    return static_cast<uint32_t>(a > b ? a - b : b - a);
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
 }
 
 void SLshlB32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_lshl_b32_sop2(*this, wf);
+  uint32_t result = (amdgpu::RegisterAccess(wf).read_scalar(ssrc0)
+                     << (amdgpu::RegisterAccess(wf).read_scalar(ssrc1) & 31u));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
 }
 
 void SLshlB64Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_lshl_b64_sop2(*this, wf);
+  uint64_t result =
+      (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0))
+       << (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)) & 63u));
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+  wf.write_scc((result != 0ULL));
 }
 
 void SLshrB32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_lshr_b32_sop2(*this, wf);
+  uint32_t result = (amdgpu::RegisterAccess(wf).read_scalar(ssrc0) >>
+                     (amdgpu::RegisterAccess(wf).read_scalar(ssrc1) & 31u));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
 }
 
 void SLshrB64Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_lshr_b64_sop2(*this, wf);
+  uint64_t result = (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)) >>
+                     (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)) & 63u));
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+  wf.write_scc((result != 0ULL));
 }
 
 void SAshrI32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_ashr_i32_sop2(*this, wf);
+  int32_t result = [&]() {
+    auto v =
+        static_cast<int32_t>(static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+    return static_cast<uint32_t>(
+        v >> (static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)) & 31u));
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
 }
 
 void SAshrI64Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_ashr_i64_sop2(*this, wf);
+  int64_t result = [&]() {
+    auto v =
+        static_cast<int64_t>(static_cast<int64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)));
+    return static_cast<uint64_t>(
+        v >> (static_cast<int64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)) & 63u));
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+  wf.write_scc((result != 0LL));
 }
 
 void SLshl1AddU32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_lshl1_add_u32_sop2(*this, wf);
+  uint32_t result = [&]() {
+    uint64_t w = (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) << 1u) +
+                 static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+    wf.write_scc(w > 0xFFFFFFFFULL);
+    return static_cast<uint32_t>(w);
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SLshl2AddU32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_lshl2_add_u32_sop2(*this, wf);
+  uint32_t result = [&]() {
+    uint64_t w = (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) << 2u) +
+                 static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+    wf.write_scc(w > 0xFFFFFFFFULL);
+    return static_cast<uint32_t>(w);
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SLshl3AddU32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_lshl3_add_u32_sop2(*this, wf);
+  uint32_t result = [&]() {
+    uint64_t w = (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) << 3u) +
+                 static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+    wf.write_scc(w > 0xFFFFFFFFULL);
+    return static_cast<uint32_t>(w);
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SLshl4AddU32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_lshl4_add_u32_sop2(*this, wf);
+  uint32_t result = [&]() {
+    uint64_t w = (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) << 4u) +
+                 static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+    wf.write_scc(w > 0xFFFFFFFFULL);
+    return static_cast<uint32_t>(w);
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
-void SMinI32Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_min_i32_sop2(*this, wf); }
+void SMinI32Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  int32_t s0 = static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0));
+  int32_t s1 = static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+  int32_t result = std::min(s0, s1);
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((s0 < s1));
+}
 
-void SMinU32Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_min_u32_sop2(*this, wf); }
+void SMinU32Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  uint32_t s0 = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint32_t s1 = amdgpu::RegisterAccess(wf).read_scalar(ssrc1);
+  uint32_t result = std::min(s0, s1);
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((s0 < s1));
+}
 
-void SMaxI32Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_max_i32_sop2(*this, wf); }
+void SMaxI32Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  int32_t s0 = static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0));
+  int32_t s1 = static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+  int32_t result = std::max(s0, s1);
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((s0 > s1));
+}
 
-void SMaxU32Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_max_u32_sop2(*this, wf); }
+void SMaxU32Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  uint32_t s0 = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  uint32_t s1 = amdgpu::RegisterAccess(wf).read_scalar(ssrc1);
+  uint32_t result = std::max(s0, s1);
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((s0 > s1));
+}
 
-void SAndB32Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_and_b32_sop2(*this, wf); }
+void SAndB32Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  uint32_t result = (amdgpu::RegisterAccess(wf).read_scalar(ssrc0) &
+                     amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
+}
 
-void SAndB64Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_and_b64_sop2(*this, wf); }
+void SAndB64Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t result = (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)) &
+                     static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc1)));
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+  wf.write_scc((result != 0ULL));
+}
 
-void SOrB32Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_or_b32_sop2(*this, wf); }
+void SOrB32Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  uint32_t result = (amdgpu::RegisterAccess(wf).read_scalar(ssrc0) |
+                     amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
+}
 
-void SOrB64Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_or_b64_sop2(*this, wf); }
+void SOrB64Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t result = (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)) |
+                     static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc1)));
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+  wf.write_scc((result != 0ULL));
+}
 
-void SXorB32Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_xor_b32_sop2(*this, wf); }
+void SXorB32Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  uint32_t result = (amdgpu::RegisterAccess(wf).read_scalar(ssrc0) ^
+                     amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
+}
 
-void SXorB64Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_xor_b64_sop2(*this, wf); }
+void SXorB64Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t result = (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)) ^
+                     static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc1)));
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+  wf.write_scc((result != 0ULL));
+}
 
 void SNandB32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_nand_b32_sop2(*this, wf);
+  uint32_t result = (~(amdgpu::RegisterAccess(wf).read_scalar(ssrc0) &
+                       amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
 }
 
 void SNandB64Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_nand_b64_sop2(*this, wf);
+  uint64_t result = (~(static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)) &
+                       static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc1))));
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+  wf.write_scc((result != 0ULL));
 }
 
-void SNorB32Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_nor_b32_sop2(*this, wf); }
+void SNorB32Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  uint32_t result = (~(amdgpu::RegisterAccess(wf).read_scalar(ssrc0) |
+                       amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
+}
 
-void SNorB64Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_nor_b64_sop2(*this, wf); }
+void SNorB64Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t result = (~(static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)) |
+                       static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc1))));
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+  wf.write_scc((result != 0ULL));
+}
 
 void SXnorB32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_xnor_b32_sop2(*this, wf);
+  uint32_t result = (~(amdgpu::RegisterAccess(wf).read_scalar(ssrc0) ^
+                       amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
 }
 
 void SXnorB64Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_xnor_b64_sop2(*this, wf);
+  uint64_t result = (~(static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)) ^
+                       static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc1))));
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+  wf.write_scc((result != 0ULL));
 }
 
 void SAndNot1B32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_and_not1_b32_sop2(*this, wf);
+  uint32_t result = (amdgpu::RegisterAccess(wf).read_scalar(ssrc0) &
+                     (~amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
 }
 
 void SAndNot1B64Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_and_not1_b64_sop2(*this, wf);
+  uint64_t result = (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)) &
+                     (~static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc1))));
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+  wf.write_scc((result != 0ULL));
 }
 
 void SOrNot1B32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_or_not1_b32_sop2(*this, wf);
+  uint32_t result = (amdgpu::RegisterAccess(wf).read_scalar(ssrc0) |
+                     (~amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
 }
 
 void SOrNot1B64Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_or_not1_b64_sop2(*this, wf);
+  uint64_t result = (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)) |
+                     (~static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc1))));
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+  wf.write_scc((result != 0ULL));
 }
 
-void SBfeU32Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_bfe_u32_sop2(*this, wf); }
+void SBfeU32Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  uint32_t result = [&]() {
+    uint32_t base = amdgpu::RegisterAccess(wf).read_scalar(ssrc0),
+             field = amdgpu::RegisterAccess(wf).read_scalar(ssrc1);
+    uint32_t offset = field & 31u;
+    uint32_t width = (field >> 16) & 127u;
+    if (width == 0)
+      return 0u;
+    if (offset + width > 32)
+      width = 32 - offset;
+    uint32_t mask = width >= 32 ? ~0u : ((1u << width) - 1u);
+    return (base >> offset) & mask;
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
+}
 
-void SBfeI32Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_bfe_i32_sop2(*this, wf); }
+void SBfeI32Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  int32_t result = [&]() {
+    uint32_t base = static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)),
+             field = static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+    uint32_t offset = field & 31u;
+    uint32_t width = (field >> 16) & 127u;
+    if (width == 0)
+      return 0u;
+    if (offset + width > 32)
+      width = 32 - offset;
+    uint32_t mask = width >= 32 ? ~0u : ((1u << width) - 1u);
+    uint32_t extracted = (base >> offset) & mask;
+    if (width < 32 && (extracted & (1u << (width - 1))))
+      extracted |= ~mask;
+    return extracted;
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+  wf.write_scc((result != 0));
+}
 
-void SBfeU64Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_bfe_u64_sop2(*this, wf); }
+void SBfeU64Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t result = [&]() {
+    uint64_t base = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+    uint32_t field =
+        static_cast<uint32_t>(static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+    uint32_t offset = field & 63u;
+    uint32_t width = (field >> 16) & 127u;
+    if (width == 0)
+      return static_cast<uint64_t>(0);
+    if (offset + width > 64)
+      width = 64 - offset;
+    uint64_t mask = width >= 64 ? ~0ULL : ((1ULL << width) - 1ULL);
+    return (base >> offset) & mask;
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+  wf.write_scc((result != 0ULL));
+}
 
-void SBfeI64Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_bfe_i64_sop2(*this, wf); }
+void SBfeI64Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  int64_t result = [&]() {
+    uint64_t base = static_cast<int64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+    uint32_t field =
+        static_cast<uint32_t>(static_cast<int64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+    uint32_t offset = field & 63u;
+    uint32_t width = (field >> 16) & 127u;
+    if (width == 0)
+      return static_cast<int64_t>(0);
+    if (offset + width > 64)
+      width = 64 - offset;
+    uint64_t mask = width >= 64 ? ~0ULL : ((1ULL << width) - 1ULL);
+    uint64_t extracted = (base >> offset) & mask;
+    if (width < 64 && (extracted & (1ULL << (width - 1))))
+      extracted |= ~mask;
+    return static_cast<int64_t>(extracted);
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+  wf.write_scc((result != 0LL));
+}
 
-void SBfmB32Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_bfm_b32_sop2(*this, wf); }
+void SBfmB32Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  uint32_t result = ::rocjitsu::amdgpu::bfm_b32(amdgpu::RegisterAccess(wf).read_scalar(ssrc0),
+                                                amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+}
 
-void SBfmB64Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_bfm_b64_sop2(*this, wf); }
+void SBfmB64Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t result = [&]() {
+    uint64_t cnt = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) & 63u;
+    uint64_t off = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)) & 63u;
+    return cnt == 0 ? 0ULL : ((1ULL << cnt) - 1ULL) << off;
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+}
 
-void SMulI32Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_mul_i32_sop2(*this, wf); }
+void SMulI32Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  uint32_t result =
+      (static_cast<uint32_t>(static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))) *
+       static_cast<uint32_t>(static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
+}
 
 void SMulHiU32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_mul_hi_u32_sop2(*this, wf);
+  uint32_t result = [&]() {
+    auto a = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0));
+    auto b = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+    return static_cast<uint32_t>((a * b) >> 32);
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SMulHiI32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_mul_hi_i32_sop2(*this, wf);
+  int32_t result = [&]() {
+    auto a =
+        static_cast<uint64_t>(static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+    auto b =
+        static_cast<uint64_t>(static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+    return static_cast<uint32_t>((a * b) >> 32);
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SCselectB32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cselect_b32_sop2(*this, wf);
+  amdgpu::RegisterAccess(wf).write_scalar(
+      sdst, wf.read_scc() ? amdgpu::RegisterAccess(wf).read_scalar(ssrc0)
+                          : amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
 }
 
 void SCselectB64Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cselect_b64_sop2(*this, wf);
+  amdgpu::RegisterAccess(wf).write_scalar64(
+      sdst, wf.read_scc() ? amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)
+                          : amdgpu::RegisterAccess(wf).read_scalar64(ssrc1));
 }
 
 void SPackLlB32B16Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_pack_ll_b32_b16_sop2(*this, wf);
+  uint32_t result = ((amdgpu::RegisterAccess(wf).read_scalar(ssrc0) & 0xFFFFu) |
+                     ((amdgpu::RegisterAccess(wf).read_scalar(ssrc1) & 0xFFFFu) << 16));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SPackLhB32B16Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_pack_lh_b32_b16_sop2(*this, wf);
+  uint32_t result = ((amdgpu::RegisterAccess(wf).read_scalar(ssrc0) & 0xFFFFu) |
+                     (amdgpu::RegisterAccess(wf).read_scalar(ssrc1) & 0xFFFF0000u));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SPackHhB32B16Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_pack_hh_b32_b16_sop2(*this, wf);
+  uint32_t result = (((amdgpu::RegisterAccess(wf).read_scalar(ssrc0) >> 16) & 0xFFFFu) |
+                     (amdgpu::RegisterAccess(wf).read_scalar(ssrc1) & 0xFFFF0000u));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
 void SPackHlB32B16Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_pack_hl_b32_b16_sop2(*this, wf);
+  uint32_t result = (((amdgpu::RegisterAccess(wf).read_scalar(ssrc0) >> 16) & 0xFFFFu) |
+                     ((amdgpu::RegisterAccess(wf).read_scalar(ssrc1) & 0xFFFFu) << 16));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, result);
 }
 
-void SAddF32Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_add_f32_sop2(*this, wf); }
+void SAddF32Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  float result = (std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) +
+                  std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, std::bit_cast<uint32_t>(result));
+}
 
-void SSubF32Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_sub_f32_sop2(*this, wf); }
+void SSubF32Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  float result = (std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) -
+                  std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, std::bit_cast<uint32_t>(result));
+}
 
 void SMinNumF32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_min_num_f32_sop2(*this, wf);
+  float result = std::fmin(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)),
+                           std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, std::bit_cast<uint32_t>(result));
 }
 
 void SMaxNumF32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_max_num_f32_sop2(*this, wf);
+  float result = std::fmax(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)),
+                           std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, std::bit_cast<uint32_t>(result));
 }
 
-void SMulF32Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_mul_f32_sop2(*this, wf); }
+void SMulF32Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  float result = (std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) *
+                  std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, std::bit_cast<uint32_t>(result));
+}
 
 void SFmaakF32Sop2::execute_impl(amdgpu::Wavefront &wf) {
   float result = std::fma(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)),
@@ -233,19 +533,40 @@ void SCvtPkRtzF16F32Sop2::execute_impl(amdgpu::Wavefront &wf) {
               << 16)));
 }
 
-void SAddF16Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_add_f16_sop2(*this, wf); }
+void SAddF16Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  float result =
+      (util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))) +
+       util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, util::f32_to_f16(result));
+}
 
-void SSubF16Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_sub_f16_sop2(*this, wf); }
+void SSubF16Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  float result =
+      (util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))) -
+       util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, util::f32_to_f16(result));
+}
 
 void SMinNumF16Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_min_num_f16_sop2(*this, wf);
+  float result = std::fmin(
+      util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))),
+      util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, util::f32_to_f16(result));
 }
 
 void SMaxNumF16Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_max_num_f16_sop2(*this, wf);
+  float result = std::fmax(
+      util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))),
+      util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, util::f32_to_f16(result));
 }
 
-void SMulF16Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_mul_f16_sop2(*this, wf); }
+void SMulF16Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  float result =
+      (util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))) *
+       util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, util::f32_to_f16(result));
+}
 
 void SFmacF16Sop2::execute_impl(amdgpu::Wavefront &wf) {
   float result = std::fma(
@@ -256,30 +577,74 @@ void SFmacF16Sop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void SMinimumF32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_minimum_f32_sop2(*this, wf);
+  float result = [&]() {
+    auto a = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0));
+    auto b = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+    if (std::isnan(a) || std::isnan(b))
+      return std::numeric_limits<decltype(a)>::quiet_NaN();
+    if (a == b)
+      return std::signbit(a) ? a : b;
+    return a < b ? a : b;
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, std::bit_cast<uint32_t>(result));
 }
 
 void SMaximumF32Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_maximum_f32_sop2(*this, wf);
+  float result = [&]() {
+    auto a = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0));
+    auto b = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+    if (std::isnan(a) || std::isnan(b))
+      return std::numeric_limits<decltype(a)>::quiet_NaN();
+    if (a == b)
+      return std::signbit(a) ? b : a;
+    return a > b ? a : b;
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, std::bit_cast<uint32_t>(result));
 }
 
 void SMinimumF16Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_minimum_f16_sop2(*this, wf);
+  float result = [&]() {
+    auto a = util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+    auto b = util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+    if (std::isnan(a) || std::isnan(b))
+      return std::numeric_limits<decltype(a)>::quiet_NaN();
+    if (a == b)
+      return std::signbit(a) ? a : b;
+    return a < b ? a : b;
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, util::f32_to_f16(result));
 }
 
 void SMaximumF16Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_maximum_f16_sop2(*this, wf);
+  float result = [&]() {
+    auto a = util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+    auto b = util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+    if (std::isnan(a) || std::isnan(b))
+      return std::numeric_limits<decltype(a)>::quiet_NaN();
+    if (a == b)
+      return std::signbit(a) ? b : a;
+    return a > b ? a : b;
+  }();
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, util::f32_to_f16(result));
 }
 
 void SAddNcU64Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_add_nc_u64_sop2(*this, wf);
+  uint64_t result = (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)) +
+                     static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc1)));
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
 }
 
 void SSubNcU64Sop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_sub_nc_u64_sop2(*this, wf);
+  uint64_t result = (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)) -
+                     static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc1)));
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
 }
 
-void SMulU64Sop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_mul_u64_sop2(*this, wf); }
+void SMulU64Sop2::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t result = (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)) *
+                     static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc1)));
+  amdgpu::RegisterAccess(wf).write_scalar64(sdst, result);
+}
 
 } // namespace cdna5
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sopc_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sopc_exec.cpp
@@ -5,8 +5,8 @@
 // See lib/python/amdisa/README.md for regeneration instructions.
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/sopc.h"
-#include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
+#include "rocjitsu/vm/amdgpu/register_access.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/data_types.h"
 #include "util/except.h"
@@ -19,187 +19,272 @@ namespace rocjitsu {
 namespace cdna5 {
 
 void SCmpEqI32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_eq_i32_sopc(*this, wf);
+  wf.write_scc((static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) ==
+                static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
 }
 
 void SCmpLgI32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_lg_i32_sopc(*this, wf);
+  wf.write_scc(([&]() {
+    auto a = static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0));
+    auto b = static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+    return (a < b) || (a > b);
+  }()));
 }
 
 void SCmpGtI32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_gt_i32_sopc(*this, wf);
+  wf.write_scc((static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) >
+                static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
 }
 
 void SCmpGeI32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_ge_i32_sopc(*this, wf);
+  wf.write_scc((static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) >=
+                static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
 }
 
 void SCmpLtI32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_lt_i32_sopc(*this, wf);
+  wf.write_scc((static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) <
+                static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
 }
 
 void SCmpLeI32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_le_i32_sopc(*this, wf);
+  wf.write_scc((static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) <=
+                static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
 }
 
 void SCmpEqU32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_eq_u32_sopc(*this, wf);
+  wf.write_scc((amdgpu::RegisterAccess(wf).read_scalar(ssrc0) ==
+                amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
 }
 
 void SCmpLgU32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_lg_u32_sopc(*this, wf);
+  wf.write_scc(([&]() {
+    auto a = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+    auto b = amdgpu::RegisterAccess(wf).read_scalar(ssrc1);
+    return (a < b) || (a > b);
+  }()));
 }
 
 void SCmpGtU32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_gt_u32_sopc(*this, wf);
+  wf.write_scc((amdgpu::RegisterAccess(wf).read_scalar(ssrc0) >
+                amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
 }
 
 void SCmpGeU32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_ge_u32_sopc(*this, wf);
+  wf.write_scc((amdgpu::RegisterAccess(wf).read_scalar(ssrc0) >=
+                amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
 }
 
 void SCmpLtU32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_lt_u32_sopc(*this, wf);
+  wf.write_scc((amdgpu::RegisterAccess(wf).read_scalar(ssrc0) <
+                amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
 }
 
 void SCmpLeU32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_le_u32_sopc(*this, wf);
+  wf.write_scc((amdgpu::RegisterAccess(wf).read_scalar(ssrc0) <=
+                amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
 }
 
 void SBitcmp0B32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_bitcmp0_b32_sopc(*this, wf);
+  wf.write_scc((((amdgpu::RegisterAccess(wf).read_scalar(ssrc0) >>
+                  (amdgpu::RegisterAccess(wf).read_scalar(ssrc1) & 31)) &
+                 1) == 0));
 }
 
 void SBitcmp1B32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_bitcmp1_b32_sopc(*this, wf);
+  wf.write_scc((((amdgpu::RegisterAccess(wf).read_scalar(ssrc0) >>
+                  (amdgpu::RegisterAccess(wf).read_scalar(ssrc1) & 31)) &
+                 1) != 0));
 }
 
 void SBitcmp0B64Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_bitcmp0_b64_sopc(*this, wf);
+  wf.write_scc((((static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)) >>
+                  (amdgpu::RegisterAccess(wf).read_scalar(ssrc1) & 63)) &
+                 1ULL) == 0));
 }
 
 void SBitcmp1B64Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_bitcmp1_b64_sopc(*this, wf);
+  wf.write_scc((((static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)) >>
+                  (amdgpu::RegisterAccess(wf).read_scalar(ssrc1) & 63)) &
+                 1ULL) != 0));
 }
 
 void SCmpEqU64Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_eq_u64_sopc(*this, wf);
+  wf.write_scc((static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0)) ==
+                static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc1))));
 }
 
 void SCmpLgU64Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_lg_u64_sopc(*this, wf);
+  wf.write_scc(([&]() {
+    auto a = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc0));
+    auto b = static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_scalar64(ssrc1));
+    return (a < b) || (a > b);
+  }()));
 }
 
 void SCmpLtF32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_lt_f32_sopc(*this, wf);
+  wf.write_scc((std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) <
+                std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
 }
 
 void SCmpLtF16Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_lt_f16_sopc(*this, wf);
+  wf.write_scc(
+      (util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))) <
+       util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)))));
 }
 
 void SCmpEqF32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_eq_f32_sopc(*this, wf);
+  wf.write_scc((std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) ==
+                std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
 }
 
 void SCmpEqF16Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_eq_f16_sopc(*this, wf);
+  wf.write_scc(
+      (util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))) ==
+       util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)))));
 }
 
 void SCmpLeF32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_le_f32_sopc(*this, wf);
+  wf.write_scc((std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) <=
+                std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
 }
 
 void SCmpLeF16Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_le_f16_sopc(*this, wf);
+  wf.write_scc(
+      (util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))) <=
+       util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)))));
 }
 
 void SCmpGtF32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_gt_f32_sopc(*this, wf);
+  wf.write_scc((std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) >
+                std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
 }
 
 void SCmpGtF16Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_gt_f16_sopc(*this, wf);
+  wf.write_scc(
+      (util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))) >
+       util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)))));
 }
 
 void SCmpLgF32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_lg_f32_sopc(*this, wf);
+  wf.write_scc(([&]() {
+    auto a = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0));
+    auto b = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+    return (a < b) || (a > b);
+  }()));
 }
 
 void SCmpLgF16Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_lg_f16_sopc(*this, wf);
+  wf.write_scc(([&]() {
+    auto a = util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+    auto b = util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+    return (a < b) || (a > b);
+  }()));
 }
 
 void SCmpGeF32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_ge_f32_sopc(*this, wf);
+  wf.write_scc((std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) >=
+                std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
 }
 
 void SCmpGeF16Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_ge_f16_sopc(*this, wf);
+  wf.write_scc(
+      (util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))) >=
+       util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)))));
 }
 
 void SCmpOF32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_o_f32_sopc(*this, wf);
+  wf.write_scc((!std::isnan(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))) &&
+                !std::isnan(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)))));
 }
 
 void SCmpOF16Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_o_f16_sopc(*this, wf);
+  wf.write_scc((!std::isnan(util::f16_to_f32(
+                    static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)))) &&
+                !std::isnan(util::f16_to_f32(
+                    static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))))));
 }
 
 void SCmpUF32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_u_f32_sopc(*this, wf);
+  wf.write_scc((std::isnan(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))) ||
+                std::isnan(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)))));
 }
 
 void SCmpUF16Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_u_f16_sopc(*this, wf);
+  wf.write_scc((std::isnan(util::f16_to_f32(
+                    static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)))) ||
+                std::isnan(util::f16_to_f32(
+                    static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))))));
 }
 
 void SCmpNgeF32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_nge_f32_sopc(*this, wf);
+  wf.write_scc((!(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) >=
+                  std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)))));
 }
 
 void SCmpNgeF16Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_nge_f16_sopc(*this, wf);
+  wf.write_scc(
+      (!(util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))) >=
+         util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))))));
 }
 
 void SCmpNlgF32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_nlg_f32_sopc(*this, wf);
+  wf.write_scc((!([&]() {
+    auto a = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0));
+    auto b = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1));
+    return (a < b) || (a > b);
+  }())));
 }
 
 void SCmpNlgF16Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_nlg_f16_sopc(*this, wf);
+  wf.write_scc((!([&]() {
+    auto a = util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)));
+    auto b = util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)));
+    return (a < b) || (a > b);
+  }())));
 }
 
 void SCmpNgtF32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_ngt_f32_sopc(*this, wf);
+  wf.write_scc((!(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) >
+                  std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)))));
 }
 
 void SCmpNgtF16Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_ngt_f16_sopc(*this, wf);
+  wf.write_scc(
+      (!(util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))) >
+         util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))))));
 }
 
 void SCmpNleF32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_nle_f32_sopc(*this, wf);
+  wf.write_scc((!(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) <=
+                  std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)))));
 }
 
 void SCmpNleF16Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_nle_f16_sopc(*this, wf);
+  wf.write_scc(
+      (!(util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))) <=
+         util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))))));
 }
 
 void SCmpNeqF32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_neq_f32_sopc(*this, wf);
+  wf.write_scc((std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) !=
+                std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))));
 }
 
 void SCmpNeqF16Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_neq_f16_sopc(*this, wf);
+  wf.write_scc(
+      (util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))) !=
+       util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)))));
 }
 
 void SCmpNltF32Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_nlt_f32_sopc(*this, wf);
+  wf.write_scc((!(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0)) <
+                  std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1)))));
 }
 
 void SCmpNltF16Sopc::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmp_nlt_f16_sopc(*this, wf);
+  wf.write_scc(
+      (!(util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc0))) <
+         util::f16_to_f32(static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_scalar(ssrc1))))));
 }
 
 } // namespace cdna5

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sopk_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sopk_exec.cpp
@@ -5,7 +5,6 @@
 // See lib/python/amdisa/README.md for regeneration instructions.
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/sopk.h"
-#include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/hwreg.h"
 #include "rocjitsu/vm/amdgpu/register_access.h"
@@ -22,15 +21,17 @@ namespace rocjitsu {
 namespace cdna5 {
 
 void SMovkI32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_movk_i32_sopk(*this, wf);
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, static_cast<uint32_t>(static_cast<int32_t>(
+                                                    static_cast<int16_t>(simm16.encoding_value_))));
 }
 
-void SVersionSopk::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_version_sopk(*this, wf);
-}
+void SVersionSopk::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
 void SCmovkI32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_cmovk_i32_sopk(*this, wf);
+  if (wf.read_scc())
+    amdgpu::RegisterAccess(wf).write_scalar(
+        sdst,
+        static_cast<uint32_t>(static_cast<int32_t>(static_cast<int16_t>(simm16.encoding_value_))));
 }
 
 void SAddkCoI32Sopk::execute_impl(amdgpu::Wavefront &wf) {
@@ -46,7 +47,10 @@ void SAddkCoI32Sopk::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void SMulkI32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_mulk_i32_sopk(*this, wf);
+  uint32_t s0 = amdgpu::RegisterAccess(wf).read_scalar(sdst);
+  uint32_t imm =
+      static_cast<uint32_t>(static_cast<int32_t>(static_cast<int16_t>(simm16.encoding_value_)));
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, s0 * imm);
 }
 
 void SGetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sopp_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sopp_exec.cpp
@@ -5,7 +5,6 @@
 // See lib/python/amdisa/README.md for regeneration instructions.
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/sopp.h"
-#include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/data_types.h"
@@ -18,43 +17,36 @@
 namespace rocjitsu {
 namespace cdna5 {
 
-void SNopSopp::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_nop_sopp(*this, wf); }
+void SNopSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
-void SSethaltSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_sethalt_sopp(*this, wf);
+void SSethaltSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
+
+void SSleepSopp::execute_impl(amdgpu::Wavefront &wf) {
+  constexpr uint32_t kSleepClocksPerUnit = 64;
+  wf.set_sleep_cycles(kSleepClocksPerUnit *
+                      (static_cast<uint32_t>(simm16.encoding_value_) & 0x7Fu));
+  wf.cu().request_functional_yield();
 }
-
-void SSleepSopp::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_sleep_sopp(*this, wf); }
 
 void SMonitorSleepSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
-void SClauseSopp::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_clause_sopp(*this, wf); }
+void SClauseSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
 void SSetVgprMsbSopp::execute_impl(amdgpu::Wavefront &wf) {
   wf.set_vgpr_msb_mode(static_cast<uint8_t>(simm16.encoding_value_ & 0xffu));
 }
 
-void SDelayAluSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_delay_alu_sopp(*this, wf);
-}
+void SDelayAluSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
-void SWaitAluSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_wait_alu_sopp(*this, wf);
-}
+void SWaitAluSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
-void SWaitIdleSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_wait_idle_sopp(*this, wf);
-}
+void SWaitIdleSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
-void STrapSopp::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_trap_sopp(*this, wf); }
+void STrapSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
-void SRoundModeSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_round_mode_sopp(*this, wf);
-}
+void SRoundModeSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
-void SDenormModeSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_denorm_mode_sopp(*this, wf);
-}
+void SDenormModeSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
 void SBarrierWaitSopp::execute_impl(amdgpu::Wavefront &wf) {
   int32_t barrier_id = static_cast<int16_t>(simm16.encoding_value_);
@@ -63,9 +55,7 @@ void SBarrierWaitSopp::execute_impl(amdgpu::Wavefront &wf) {
 
 void SBarrierLeaveSopp::execute_impl(amdgpu::Wavefront &wf) { wf.write_scc(wf.barrier_leave()); }
 
-void SCodeEndSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_code_end_sopp(*this, wf);
-}
+void SCodeEndSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
 void SBranchSopp::execute_impl(amdgpu::Wavefront &wf) {
   int16_t offset = static_cast<int16_t>(simm16.encoding_value_);
@@ -122,39 +112,45 @@ void SEndpgmSopp::execute_impl(amdgpu::Wavefront &wf) { wf.end(); }
 
 void SEndpgmSavedSopp::execute_impl(amdgpu::Wavefront &wf) { wf.end(); }
 
-void SWakeupSopp::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_wakeup_sopp(*this, wf); }
+void SWakeupSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
-void SSetprioSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_setprio_sopp(*this, wf);
-}
+void SSetprioSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
 void SSendmsgSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_sendmsg_sopp(*this, wf);
+  const uint32_t message = static_cast<uint32_t>(simm16.encoding_value_);
+  if (wf.in_trap_handler() && (message & 0xFu) == 1u)
+    wf.set_trap_interrupt_sent(true);
+  wf.cu().handle_sendmsg(wf, message);
 }
 
 void SSendmsghaltSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_sendmsghalt_sopp(*this, wf);
+  const uint32_t message = static_cast<uint32_t>(simm16.encoding_value_);
+  if (wf.in_trap_handler() && (message & 0xFu) == 1u)
+    wf.set_trap_interrupt_sent(true);
+  wf.cu().handle_sendmsg(wf, message);
+
+  // S_SENDMSGHALT halts the wave. Keep the architectural bit and the
+  // scheduler flag in step -- s_rfe consults STATUS.HALT on the way out.
+  constexpr uint32_t kStatusHalt = 1u << 13;
+  wf.set_status_raw(wf.status_raw() | kStatusHalt);
+  wf.set_debug_halted(true);
+  // Remember who raised the bit. The trap handler also raises HALT, via
+  // s_setreg just before it returns, and there it means "keep the wave
+  // stopped" -- the opposite of what it means here, where the wave has
+  // already reported and is waiting to be resumed. The CWSR record cannot
+  // distinguish the two, so the resume path reads this instead.
+  wf.set_self_halted(true);
 }
 
-void SIncperflevelSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_incperflevel_sopp(*this, wf);
-}
+void SIncperflevelSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
-void SDecperflevelSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_decperflevel_sopp(*this, wf);
-}
+void SDecperflevelSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
-void STtracedataSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_ttracedata_sopp(*this, wf);
-}
+void STtracedataSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
-void STtracedataImmSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_ttracedata_imm_sopp(*this, wf);
-}
+void STtracedataImmSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
-void SIcacheInvSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_icache_inv_sopp(*this, wf);
-}
+void SIcacheInvSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
 void SSetprioIncWgSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vds_exec.cpp
@@ -6,7 +6,6 @@
 
 #include "rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vds.h"
-#include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
@@ -542,7 +541,7 @@ void DsMaxNumF32Vds::execute_impl(amdgpu::Wavefront &wf) {
   set_data(std::move(d));
 }
 
-void DsNopVds::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_ds_nop_vds(*this, wf); }
+void DsNopVds::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
 void DsAddF32Vds::execute_impl(amdgpu::Wavefront &wf) {
   auto d = std::make_unique<amdgpu::VectorMemState>(amdgpu::LOCAL_MEM);
@@ -1157,7 +1156,31 @@ void DsMaxNumRtnF32Vds::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void DsSwizzleB32Vds::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_ds_swizzle_b32_vds(*this, wf);
+  uint64_t exec = wf.exec();
+  ::rocjitsu::amdgpu::RegisterAccess regs(wf);
+  uint32_t src_data[64];
+  for (uint32_t i = 0; i < wf.wf_size(); ++i)
+    src_data[i] = regs.read_lane(addr, i);
+  uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t src_lane;
+    if (offset & 0x8000) {
+      // QDMode: four packed 2-bit selectors within each quad.
+      src_lane = (lane & ~0x3u) | ((offset >> (2u * (lane & 0x3u))) & 0x3u);
+    } else {
+      // BitMode: swizzle within 32-lane rows.
+      uint32_t and_mask = offset & 0x1F;
+      uint32_t or_mask = (offset >> 5) & 0x1F;
+      uint32_t xor_mask = (offset >> 10) & 0x1F;
+      uint32_t row_base = lane & ~0x1Fu;
+      uint32_t row_lane = lane & 0x1Fu;
+      src_lane = row_base + (((row_lane & and_mask) | or_mask) ^ xor_mask);
+    }
+    if (src_lane < wf.wf_size())
+      regs.write_lane(vdst, lane, src_data[src_lane]);
+  }
 }
 
 void DsLoadB32Vds::execute_impl(amdgpu::Wavefront &wf) {
@@ -3127,15 +3150,84 @@ void DsLoadAddtidB32Vds::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void DsPermuteB32Vds::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_ds_permute_b32_vds(*this, wf);
+  auto &cu = wf.cu();
+  uint64_t exec = wf.exec();
+  uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
+  uint32_t lane_group_width = wf.wf_size();
+  ::rocjitsu::amdgpu::RegisterAccess regs(wf);
+  if (wf.wf_size() == 64 &&
+      (cu.arch() == ROCJITSU_CODE_ARCH_RDNA3 || cu.arch() == ROCJITSU_CODE_ARCH_RDNA3_5))
+    lane_group_width = 32;
+  // Pre-read all data0 values from every lane.
+  uint32_t src_data[64];
+  for (uint32_t i = 0; i < wf.wf_size(); ++i)
+    src_data[i] = regs.read_lane(data0, i);
+  uint32_t tmp[64] = {};
+  for (uint32_t i = 0; i < wf.wf_size(); ++i) {
+    if (!(exec & (1ULL << i)))
+      continue;
+    uint32_t addr_val = regs.read_lane(addr, i);
+    uint32_t group_base = (i / lane_group_width) * lane_group_width;
+    uint32_t dst_lane = group_base + (((addr_val + offset) / 4) % lane_group_width);
+    tmp[dst_lane] = src_data[i];
+  }
+  for (uint32_t i = 0; i < wf.wf_size(); ++i) {
+    if (exec & (1ULL << i))
+      regs.write_lane(vdst, i, tmp[i]);
+  }
 }
 
 void DsBpermuteB32Vds::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_ds_bpermute_b32_vds(*this, wf);
+  auto &cu = wf.cu();
+  uint64_t exec = wf.exec();
+  uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
+  uint32_t lane_group_width = wf.wf_size();
+  ::rocjitsu::amdgpu::RegisterAccess regs(wf);
+  if (wf.wf_size() == 64 &&
+      (cu.arch() == ROCJITSU_CODE_ARCH_RDNA3 || cu.arch() == ROCJITSU_CODE_ARCH_RDNA3_5))
+    lane_group_width = 32;
+  // Pre-read all data0 values from every lane.
+  uint32_t src_data[64];
+  for (uint32_t i = 0; i < wf.wf_size(); ++i)
+    src_data[i] = regs.read_lane(data0, i);
+  uint32_t tmp[64] = {};
+  for (uint32_t i = 0; i < wf.wf_size(); ++i) {
+    uint32_t addr_val = regs.read_lane(addr, i);
+    uint32_t group_base = (i / lane_group_width) * lane_group_width;
+    uint32_t src_lane = group_base + (((addr_val + offset) / 4) % lane_group_width);
+    if (exec & (1ULL << src_lane))
+      tmp[i] = src_data[src_lane];
+  }
+  for (uint32_t i = 0; i < wf.wf_size(); ++i) {
+    if (exec & (1ULL << i))
+      regs.write_lane(vdst, i, tmp[i]);
+  }
 }
 
 void DsBpermuteFiB32Vds::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_ds_bpermute_fi_b32_vds(*this, wf);
+  auto &cu = wf.cu();
+  uint64_t exec = wf.exec();
+  uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
+  uint32_t lane_group_width = wf.wf_size();
+  ::rocjitsu::amdgpu::RegisterAccess regs(wf);
+  if (wf.wf_size() == 64 &&
+      (cu.arch() == ROCJITSU_CODE_ARCH_RDNA3 || cu.arch() == ROCJITSU_CODE_ARCH_RDNA3_5))
+    lane_group_width = 32;
+  // Pre-read all data0 values from every lane.
+  uint32_t src_data[64];
+  for (uint32_t i = 0; i < wf.wf_size(); ++i)
+    src_data[i] = regs.read_lane(data0, i);
+  uint32_t tmp[64] = {};
+  for (uint32_t i = 0; i < wf.wf_size(); ++i) {
+    uint32_t addr_val = regs.read_lane(addr, i);
+    uint32_t group_base = (i / lane_group_width) * lane_group_width;
+    uint32_t src_lane = group_base + (((addr_val + offset) / 4) % lane_group_width);
+    tmp[i] = src_data[src_lane];
+  }
+  for (uint32_t i = 0; i < wf.wf_size(); ++i) {
+    if (exec & (1ULL << i))
+      regs.write_lane(vdst, i, tmp[i]);
+  }
 }
 
 void DsStoreB96Vds::execute_impl(amdgpu::Wavefront &wf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop1_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop1_exec.cpp
@@ -23,7 +23,7 @@
 namespace rocjitsu {
 namespace cdna5 {
 
-void VNopVop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_nop_vop1(*this, wf); }
+void VNopVop1::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
 void VMovB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
   if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) {
@@ -364,7 +364,18 @@ void VCvtOffF32I4Vop1::execute_impl(amdgpu::Wavefront &wf) {
     execute_modifier_impl(wf);
     return;
   }
-  amdgpu::execute_v_cvt_off_f32_i4_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<true>(*this, wf, vdst, lane, std::bit_cast<uint32_t>([&]() -> float {
+      int32_t nibble =
+          static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src0, lane) & 0xfu);
+      if (nibble & 0x8)
+        nibble -= 16;
+      return static_cast<float>(nibble) * 0.0625f;
+    }()));
+  }
 }
 
 RJ_NOINLINE void VCvtOffF32I4Vop1::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -383,7 +394,18 @@ RJ_NOINLINE void VCvtOffF32I4Vop1::execute_modifier_impl(amdgpu::Wavefront &wf) 
   if (inst_.src0 == amdgpu::SRC_DPP)
     dpp_write_mask_scope_.bind(wf,
                                wf.exec() & dpp_plan_.row_bank_mask & dpp_plan_.source_write_mask);
-  amdgpu::execute_v_cvt_off_f32_i4_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<true>(*this, wf, vdst, lane, std::bit_cast<uint32_t>([&]() -> float {
+      int32_t nibble =
+          static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src0, lane) & 0xfu);
+      if (nibble & 0x8)
+        nibble -= 16;
+      return static_cast<float>(nibble) * 0.0625f;
+    }()));
+  }
   dpp_write_mask_scope_.restore();
 }
 
@@ -707,9 +729,7 @@ RJ_NOINLINE void VFloorF64Vop1::execute_modifier_impl(amdgpu::Wavefront &wf) {
   dpp_write_mask_scope_.restore();
 }
 
-void VPipeflushVop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_pipeflush_vop1(*this, wf);
-}
+void VPipeflushVop1::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
 void VMovB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) {
@@ -1194,7 +1214,15 @@ void VSinF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
     execute_modifier_impl(wf);
     return;
   }
-  amdgpu::execute_v_sin_f32_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<true>(
+        *this, wf, vdst, lane,
+        std::bit_cast<uint32_t>(amdgpu::transcendental::sin_f32(
+            std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src0, lane)))));
+  }
 }
 
 RJ_NOINLINE void VSinF32Vop1::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -1213,7 +1241,15 @@ RJ_NOINLINE void VSinF32Vop1::execute_modifier_impl(amdgpu::Wavefront &wf) {
   if (inst_.src0 == amdgpu::SRC_DPP)
     dpp_write_mask_scope_.bind(wf,
                                wf.exec() & dpp_plan_.row_bank_mask & dpp_plan_.source_write_mask);
-  amdgpu::execute_v_sin_f32_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<true>(
+        *this, wf, vdst, lane,
+        std::bit_cast<uint32_t>(amdgpu::transcendental::sin_f32(
+            std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src0, lane)))));
+  }
   dpp_write_mask_scope_.restore();
 }
 
@@ -1222,7 +1258,15 @@ void VCosF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
     execute_modifier_impl(wf);
     return;
   }
-  amdgpu::execute_v_cos_f32_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<true>(
+        *this, wf, vdst, lane,
+        std::bit_cast<uint32_t>(amdgpu::transcendental::cos_f32(
+            std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src0, lane)))));
+  }
 }
 
 RJ_NOINLINE void VCosF32Vop1::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -1241,7 +1285,15 @@ RJ_NOINLINE void VCosF32Vop1::execute_modifier_impl(amdgpu::Wavefront &wf) {
   if (inst_.src0 == amdgpu::SRC_DPP)
     dpp_write_mask_scope_.bind(wf,
                                wf.exec() & dpp_plan_.row_bank_mask & dpp_plan_.source_write_mask);
-  amdgpu::execute_v_cos_f32_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<true>(
+        *this, wf, vdst, lane,
+        std::bit_cast<uint32_t>(amdgpu::transcendental::cos_f32(
+            std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src0, lane)))));
+  }
   dpp_write_mask_scope_.restore();
 }
 
@@ -3001,7 +3053,17 @@ void VSwapB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void VPermlane64B32Vop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_permlane64_b32_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  uint32_t snap[64];
+  for (uint32_t i = 0; i < wf.wf_size(); ++i)
+    snap[i] = amdgpu::RegisterAccess(wf).read_lane(src0, i);
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t partner = lane ^ 32;
+    if (partner < wf.wf_size())
+      amdgpu::sdwa::write_lane<false>(*this, wf, vdst, lane, snap[partner]);
+  }
 }
 
 void VSwaprelB32Vop1::execute_impl(amdgpu::Wavefront &wf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop2_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop2_exec.cpp
@@ -803,7 +803,15 @@ void VLshlrevB64Vop2::execute_impl(amdgpu::Wavefront &wf) {
     execute_modifier_impl(wf);
     return;
   }
-  amdgpu::execute_v_lshlrev_b64_vop2(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane64<false>(
+        *this, wf, vdst, lane,
+        (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_lane64(vsrc1, lane))
+         << (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_lane(src0, lane)) & 63u)));
+  }
 }
 
 RJ_NOINLINE void VLshlrevB64Vop2::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -820,7 +828,15 @@ RJ_NOINLINE void VLshlrevB64Vop2::execute_modifier_impl(amdgpu::Wavefront &wf) {
   if (inst_.src0 == amdgpu::SRC_DPP)
     dpp_write_mask_scope_.bind(wf,
                                wf.exec() & dpp_plan_.row_bank_mask & dpp_plan_.source_write_mask);
-  amdgpu::execute_v_lshlrev_b64_vop2(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane64<false>(
+        *this, wf, vdst, lane,
+        (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_lane64(vsrc1, lane))
+         << (static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_lane(src0, lane)) & 63u)));
+  }
   dpp_write_mask_scope_.restore();
 }
 
@@ -1672,7 +1688,25 @@ RJ_NOINLINE void VLdexpF16Vop2::execute_modifier_impl(amdgpu::Wavefront &wf) {
 }
 
 void VPkFmacF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_pk_fmac_f16_vop2(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
+    uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(vsrc1, lane);
+    uint32_t rawd = amdgpu::RegisterAccess(wf).read_lane(vdst, lane);
+    uint32_t r0 =
+        amdgpu::fp_mode::fma_f16(static_cast<uint16_t>(raw0), static_cast<uint16_t>(raw1),
+                                 static_cast<uint16_t>(rawd), false, false, false, false, false,
+                                 false, wf.fp_round_mode_f16_f64(), wf.fp_denorm_mode_f16_f64(), 0,
+                                 false, wf.fp16_ovfl(), amdgpu::floating_clamp_nan_to_zero(wf));
+    uint32_t r1 = amdgpu::fp_mode::fma_f16(
+        static_cast<uint16_t>(raw0 >> 16), static_cast<uint16_t>(raw1 >> 16),
+        static_cast<uint16_t>(rawd >> 16), false, false, false, false, false, false,
+        wf.fp_round_mode_f16_f64(), wf.fp_denorm_mode_f16_f64(), 0, false, wf.fp16_ovfl(),
+        amdgpu::floating_clamp_nan_to_zero(wf));
+    amdgpu::sdwa::write_lane<true>(*this, wf, vdst, lane, r0 | (r1 << 16));
+  }
 }
 
 } // namespace cdna5

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_exec_alu.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_exec_alu.cpp
@@ -648,7 +648,36 @@ void VSinF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     execute_modifier_impl(wf);
     return;
   }
-  amdgpu::execute_v_sin_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<true>(*this, wf, vdst, lane, std::bit_cast<uint32_t>([&]() {
+      float v = [&]() {
+        float v = amdgpu::transcendental::sin_f32([&]() {
+          float sv = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src0, lane));
+          if (inst_.abs & (1u << 0))
+            sv = std::fabs(sv);
+          if (inst_.neg & (1u << 0))
+            sv = -sv;
+          return sv;
+        }());
+        const uint32_t effective_omod = amdgpu::fp_mode::effective_omod(
+            wf.cu().arch(), wf.fp_denorm_mode_f32(), wf.ieee_mode(), inst_.omod);
+        if (effective_omod == 1)
+          v *= 2.0f;
+        else if (effective_omod == 2)
+          v *= 4.0f;
+        else if (effective_omod == 3)
+          v *= 0.5f;
+        v = amdgpu::fp_mode::finalize_omod_f32(v, effective_omod);
+        return v;
+      }();
+      if (inst_.clamp)
+        v = amdgpu::clamp_floating_result(v, wf);
+      return v;
+    }()));
+  }
 }
 
 RJ_NOINLINE void VSinF32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -667,7 +696,36 @@ RJ_NOINLINE void VSinF32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
   if (inst_.src0 == amdgpu::SRC_DPP)
     dpp_write_mask_scope_.bind(wf,
                                wf.exec() & dpp_plan_.row_bank_mask & dpp_plan_.source_write_mask);
-  amdgpu::execute_v_sin_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<true>(*this, wf, vdst, lane, std::bit_cast<uint32_t>([&]() {
+      float v = [&]() {
+        float v = amdgpu::transcendental::sin_f32([&]() {
+          float sv = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src0, lane));
+          if (inst_.abs & (1u << 0))
+            sv = std::fabs(sv);
+          if (inst_.neg & (1u << 0))
+            sv = -sv;
+          return sv;
+        }());
+        const uint32_t effective_omod = amdgpu::fp_mode::effective_omod(
+            wf.cu().arch(), wf.fp_denorm_mode_f32(), wf.ieee_mode(), inst_.omod);
+        if (effective_omod == 1)
+          v *= 2.0f;
+        else if (effective_omod == 2)
+          v *= 4.0f;
+        else if (effective_omod == 3)
+          v *= 0.5f;
+        v = amdgpu::fp_mode::finalize_omod_f32(v, effective_omod);
+        return v;
+      }();
+      if (inst_.clamp)
+        v = amdgpu::clamp_floating_result(v, wf);
+      return v;
+    }()));
+  }
   dpp_write_mask_scope_.restore();
 }
 
@@ -676,7 +734,36 @@ void VCosF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     execute_modifier_impl(wf);
     return;
   }
-  amdgpu::execute_v_cos_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<true>(*this, wf, vdst, lane, std::bit_cast<uint32_t>([&]() {
+      float v = [&]() {
+        float v = amdgpu::transcendental::cos_f32([&]() {
+          float sv = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src0, lane));
+          if (inst_.abs & (1u << 0))
+            sv = std::fabs(sv);
+          if (inst_.neg & (1u << 0))
+            sv = -sv;
+          return sv;
+        }());
+        const uint32_t effective_omod = amdgpu::fp_mode::effective_omod(
+            wf.cu().arch(), wf.fp_denorm_mode_f32(), wf.ieee_mode(), inst_.omod);
+        if (effective_omod == 1)
+          v *= 2.0f;
+        else if (effective_omod == 2)
+          v *= 4.0f;
+        else if (effective_omod == 3)
+          v *= 0.5f;
+        v = amdgpu::fp_mode::finalize_omod_f32(v, effective_omod);
+        return v;
+      }();
+      if (inst_.clamp)
+        v = amdgpu::clamp_floating_result(v, wf);
+      return v;
+    }()));
+  }
 }
 
 RJ_NOINLINE void VCosF32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -695,7 +782,36 @@ RJ_NOINLINE void VCosF32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
   if (inst_.src0 == amdgpu::SRC_DPP)
     dpp_write_mask_scope_.bind(wf,
                                wf.exec() & dpp_plan_.row_bank_mask & dpp_plan_.source_write_mask);
-  amdgpu::execute_v_cos_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<true>(*this, wf, vdst, lane, std::bit_cast<uint32_t>([&]() {
+      float v = [&]() {
+        float v = amdgpu::transcendental::cos_f32([&]() {
+          float sv = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src0, lane));
+          if (inst_.abs & (1u << 0))
+            sv = std::fabs(sv);
+          if (inst_.neg & (1u << 0))
+            sv = -sv;
+          return sv;
+        }());
+        const uint32_t effective_omod = amdgpu::fp_mode::effective_omod(
+            wf.cu().arch(), wf.fp_denorm_mode_f32(), wf.ieee_mode(), inst_.omod);
+        if (effective_omod == 1)
+          v *= 2.0f;
+        else if (effective_omod == 2)
+          v *= 4.0f;
+        else if (effective_omod == 3)
+          v *= 0.5f;
+        v = amdgpu::fp_mode::finalize_omod_f32(v, effective_omod);
+        return v;
+      }();
+      if (inst_.clamp)
+        v = amdgpu::clamp_floating_result(v, wf);
+      return v;
+    }()));
+  }
   dpp_write_mask_scope_.restore();
 }
 
@@ -5637,7 +5753,12 @@ RJ_NOINLINE void VDivFixupF16Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) 
 }
 
 void VSExpF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_s_exp_f32_vop3(*this, wf);
+  amdgpu::RegisterAccess(wf).write_scalar(
+      vdst, amdgpu::pseudo_scalar::execute_f32(
+                amdgpu::pseudo_scalar::Operation::EXP2,
+                std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(src0)),
+                (inst_.abs & 1u) != 0, (inst_.neg & 1u) != 0, wf.fp_round_mode_f32(),
+                wf.fp_denorm_mode_f32(), inst_.omod, inst_.clamp));
 }
 
 void VSExpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
@@ -5651,7 +5772,12 @@ void VSExpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void VSLogF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_s_log_f32_vop3(*this, wf);
+  amdgpu::RegisterAccess(wf).write_scalar(
+      vdst, amdgpu::pseudo_scalar::execute_f32(
+                amdgpu::pseudo_scalar::Operation::LOG2,
+                std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(src0)),
+                (inst_.abs & 1u) != 0, (inst_.neg & 1u) != 0, wf.fp_round_mode_f32(),
+                wf.fp_denorm_mode_f32(), inst_.omod, inst_.clamp));
 }
 
 void VSLogF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
@@ -5665,7 +5791,12 @@ void VSLogF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void VSRcpF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_s_rcp_f32_vop3(*this, wf);
+  amdgpu::RegisterAccess(wf).write_scalar(
+      vdst, amdgpu::pseudo_scalar::execute_f32(
+                amdgpu::pseudo_scalar::Operation::RCP,
+                std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(src0)),
+                (inst_.abs & 1u) != 0, (inst_.neg & 1u) != 0, wf.fp_round_mode_f32(),
+                wf.fp_denorm_mode_f32(), inst_.omod, inst_.clamp));
 }
 
 void VSRcpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
@@ -5679,7 +5810,12 @@ void VSRcpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void VSRsqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_s_rsq_f32_vop3(*this, wf);
+  amdgpu::RegisterAccess(wf).write_scalar(
+      vdst, amdgpu::pseudo_scalar::execute_f32(
+                amdgpu::pseudo_scalar::Operation::RSQ,
+                std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(src0)),
+                (inst_.abs & 1u) != 0, (inst_.neg & 1u) != 0, wf.fp_round_mode_f32(),
+                wf.fp_denorm_mode_f32(), inst_.omod, inst_.clamp));
 }
 
 void VSRsqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
@@ -5693,7 +5829,12 @@ void VSRsqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void VSSqrtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_s_sqrt_f32_vop3(*this, wf);
+  amdgpu::RegisterAccess(wf).write_scalar(
+      vdst, amdgpu::pseudo_scalar::execute_f32(
+                amdgpu::pseudo_scalar::Operation::SQRT,
+                std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_scalar(src0)),
+                (inst_.abs & 1u) != 0, (inst_.neg & 1u) != 0, wf.fp_round_mode_f32(),
+                wf.fp_denorm_mode_f32(), inst_.omod, inst_.clamp));
 }
 
 void VSSqrtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
@@ -6445,7 +6586,16 @@ void VMbcntLoU32B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     execute_modifier_impl(wf);
     return;
   }
-  amdgpu::execute_v_mbcnt_lo_u32_b32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t mask = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
+    uint32_t base = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    uint32_t thread_mask = lane < 32 ? (1u << lane) - 1 : 0xFFFFFFFFu;
+    uint32_t count = std::popcount(mask & thread_mask);
+    amdgpu::sdwa::write_lane<false>(*this, wf, vdst, lane, base + count);
+  }
 }
 
 RJ_NOINLINE void VMbcntLoU32B32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -6464,7 +6614,16 @@ RJ_NOINLINE void VMbcntLoU32B32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf
   if (inst_.src0 == amdgpu::SRC_DPP)
     dpp_write_mask_scope_.bind(wf,
                                wf.exec() & dpp_plan_.row_bank_mask & dpp_plan_.source_write_mask);
-  amdgpu::execute_v_mbcnt_lo_u32_b32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t mask = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
+    uint32_t base = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    uint32_t thread_mask = lane < 32 ? (1u << lane) - 1 : 0xFFFFFFFFu;
+    uint32_t count = std::popcount(mask & thread_mask);
+    amdgpu::sdwa::write_lane<false>(*this, wf, vdst, lane, base + count);
+  }
   dpp_write_mask_scope_.restore();
 }
 
@@ -6473,7 +6632,17 @@ void VMbcntHiU32B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     execute_modifier_impl(wf);
     return;
   }
-  amdgpu::execute_v_mbcnt_hi_u32_b32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t mask = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
+    uint32_t base = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    uint32_t shift = lane >= 32 ? lane - 32 : 0;
+    uint32_t thread_mask = lane >= 32 ? (1u << shift) - 1 : 0;
+    uint32_t count = std::popcount(mask & thread_mask);
+    amdgpu::sdwa::write_lane<false>(*this, wf, vdst, lane, base + count);
+  }
 }
 
 RJ_NOINLINE void VMbcntHiU32B32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -6492,7 +6661,17 @@ RJ_NOINLINE void VMbcntHiU32B32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf
   if (inst_.src0 == amdgpu::SRC_DPP)
     dpp_write_mask_scope_.bind(wf,
                                wf.exec() & dpp_plan_.row_bank_mask & dpp_plan_.source_write_mask);
-  amdgpu::execute_v_mbcnt_hi_u32_b32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t mask = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
+    uint32_t base = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    uint32_t shift = lane >= 32 ? lane - 32 : 0;
+    uint32_t thread_mask = lane >= 32 ? (1u << shift) - 1 : 0;
+    uint32_t count = std::popcount(mask & thread_mask);
+    amdgpu::sdwa::write_lane<false>(*this, wf, vdst, lane, base + count);
+  }
   dpp_write_mask_scope_.restore();
 }
 
@@ -7563,7 +7742,57 @@ void VDivScaleF32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t final_result = raw_result;
     amdgpu::write_wave_mask_scalar(sdst, wf, final_result);
   };
-  amdgpu::execute_v_div_scale_f32_vop3(*this, wf, commit_result);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = wf.vcc();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src0, lane));
+    float s1 = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    float s2 = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (inst_.neg & (1u << 2))
+      s2 = -s2;
+    float result = s0;
+    bool set_vcc = false;
+    if (s2 == 0.0f || s1 == 0.0f) {
+      // Zero numerator or denominator: pass through s0 unscaled.
+      // Special-case handling (0/0, 0/x, x/0) is done by v_div_fixup.
+    } else {
+      int exp1 = 0, exp2 = 0;
+      std::frexp(s1, &exp1);
+      std::frexp(s2, &exp2);
+      if (exp2 - exp1 >= 96) {
+        set_vcc = true;
+        if (s0 == s1)
+          result = std::ldexp(s0, 64);
+      } else if (std::fpclassify(s1) == FP_SUBNORMAL) {
+        result = std::ldexp(s0, 64);
+      } else if (std::fpclassify(1.0 / static_cast<double>(s1)) == FP_SUBNORMAL &&
+                 std::fpclassify(s2 / s1) == FP_SUBNORMAL) {
+        set_vcc = true;
+        if (s0 == s1)
+          result = std::ldexp(s0, 64);
+      } else if (std::fpclassify(1.0 / static_cast<double>(s1)) == FP_SUBNORMAL) {
+        result = std::ldexp(s0, -64);
+      } else if (std::fpclassify(s2 / s1) == FP_SUBNORMAL) {
+        set_vcc = true;
+        if (s0 == s2)
+          result = std::ldexp(s0, 64);
+      } else if (exp2 <= -23) {
+        result = std::ldexp(s0, 64);
+      }
+    }
+    if (set_vcc)
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+    amdgpu::sdwa::write_lane<true>(*this, wf, vdst, lane, std::bit_cast<uint32_t>(result));
+  }
+  commit_result(vcc);
 }
 
 void VDivScaleF64Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
@@ -7574,7 +7803,57 @@ void VDivScaleF64Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
   auto commit_result = [&](uint64_t raw_result) {
     amdgpu::write_wave_mask_scalar(sdst, wf, raw_result);
   };
-  amdgpu::execute_v_div_scale_f64_vop3(*this, wf, commit_result);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = wf.vcc();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    double s0 = std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(src0, lane));
+    double s1 = std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(src1, lane));
+    double s2 = std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(src2, lane));
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (inst_.neg & (1u << 2))
+      s2 = -s2;
+    double result = s0;
+    bool set_vcc = false;
+    if (s2 == 0.0 || s1 == 0.0) {
+      // Zero numerator or denominator: pass through s0 unscaled.
+      // Special-case handling (0/0, 0/x, x/0) is done by v_div_fixup.
+    } else {
+      int exp1 = 0, exp2 = 0;
+      std::frexp(s1, &exp1);
+      std::frexp(s2, &exp2);
+      if (exp2 - exp1 >= 768) {
+        set_vcc = true;
+        if (s0 == s1)
+          result = std::ldexp(s0, 128);
+      } else if (std::fpclassify(s1) == FP_SUBNORMAL) {
+        result = std::ldexp(s0, 128);
+      } else if (std::fpclassify(1.0 / s1) == FP_SUBNORMAL &&
+                 std::fpclassify(s2 / s1) == FP_SUBNORMAL) {
+        set_vcc = true;
+        if (s0 == s1)
+          result = std::ldexp(s0, 128);
+      } else if (std::fpclassify(1.0 / s1) == FP_SUBNORMAL) {
+        result = std::ldexp(s0, -128);
+      } else if (std::fpclassify(s2 / s1) == FP_SUBNORMAL) {
+        set_vcc = true;
+        if (s0 == s2)
+          result = std::ldexp(s0, 128);
+      } else if (exp2 <= -53) {
+        result = std::ldexp(s0, 128);
+      }
+    }
+    if (set_vcc)
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+    amdgpu::sdwa::write_lane64<true>(*this, wf, vdst, lane, std::bit_cast<uint64_t>(result));
+  }
+  commit_result(vcc);
 }
 
 RJ_NOINLINE void VDivScaleF64Vop3SdstEnc::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -7605,7 +7884,57 @@ RJ_NOINLINE void VDivScaleF64Vop3SdstEnc::execute_modifier_impl(amdgpu::Wavefron
           raw_result, dpp_old_secondary_dst_, dpp_old_exec_, dpp_source_write_mask_);
     amdgpu::write_wave_mask_scalar(sdst, wf, final_result);
   };
-  amdgpu::execute_v_div_scale_f64_vop3(*this, wf, commit_result);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = wf.vcc();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    double s0 = std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(src0, lane));
+    double s1 = std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(src1, lane));
+    double s2 = std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(src2, lane));
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (inst_.neg & (1u << 2))
+      s2 = -s2;
+    double result = s0;
+    bool set_vcc = false;
+    if (s2 == 0.0 || s1 == 0.0) {
+      // Zero numerator or denominator: pass through s0 unscaled.
+      // Special-case handling (0/0, 0/x, x/0) is done by v_div_fixup.
+    } else {
+      int exp1 = 0, exp2 = 0;
+      std::frexp(s1, &exp1);
+      std::frexp(s2, &exp2);
+      if (exp2 - exp1 >= 768) {
+        set_vcc = true;
+        if (s0 == s1)
+          result = std::ldexp(s0, 128);
+      } else if (std::fpclassify(s1) == FP_SUBNORMAL) {
+        result = std::ldexp(s0, 128);
+      } else if (std::fpclassify(1.0 / s1) == FP_SUBNORMAL &&
+                 std::fpclassify(s2 / s1) == FP_SUBNORMAL) {
+        set_vcc = true;
+        if (s0 == s1)
+          result = std::ldexp(s0, 128);
+      } else if (std::fpclassify(1.0 / s1) == FP_SUBNORMAL) {
+        result = std::ldexp(s0, -128);
+      } else if (std::fpclassify(s2 / s1) == FP_SUBNORMAL) {
+        set_vcc = true;
+        if (s0 == s2)
+          result = std::ldexp(s0, 128);
+      } else if (exp2 <= -53) {
+        result = std::ldexp(s0, 128);
+      }
+    }
+    if (set_vcc)
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+    amdgpu::sdwa::write_lane64<true>(*this, wf, vdst, lane, std::bit_cast<uint64_t>(result));
+  }
+  commit_result(vcc);
   dpp_write_mask_scope_.restore();
 }
 
@@ -7617,7 +7946,21 @@ void VMadCoU64U32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
   auto commit_result = [&](uint64_t raw_result) {
     amdgpu::write_wave_mask_scalar(sdst, wf, raw_result);
   };
-  amdgpu::execute_v_mad_co_u64_u32_vop3(*this, wf, commit_result);
+  uint64_t exec = wf.exec();
+  uint64_t carry = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint64_t s0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
+    uint64_t s1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    uint64_t s2 = amdgpu::RegisterAccess(wf).read_lane64(src2, lane);
+    uint64_t product = s0 * s1;
+    uint64_t result = product + s2;
+    if (result < product)
+      carry |= 1ULL << lane;
+    amdgpu::sdwa::write_lane64<false>(*this, wf, vdst, lane, result);
+  }
+  commit_result(carry);
 }
 
 RJ_NOINLINE void VMadCoU64U32Vop3SdstEnc::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -7648,7 +7991,21 @@ RJ_NOINLINE void VMadCoU64U32Vop3SdstEnc::execute_modifier_impl(amdgpu::Wavefron
           raw_result, dpp_old_secondary_dst_, dpp_old_exec_, dpp_source_write_mask_);
     amdgpu::write_wave_mask_scalar(sdst, wf, final_result);
   };
-  amdgpu::execute_v_mad_co_u64_u32_vop3(*this, wf, commit_result);
+  uint64_t exec = wf.exec();
+  uint64_t carry = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint64_t s0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
+    uint64_t s1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    uint64_t s2 = amdgpu::RegisterAccess(wf).read_lane64(src2, lane);
+    uint64_t product = s0 * s1;
+    uint64_t result = product + s2;
+    if (result < product)
+      carry |= 1ULL << lane;
+    amdgpu::sdwa::write_lane64<false>(*this, wf, vdst, lane, result);
+  }
+  commit_result(carry);
   dpp_write_mask_scope_.restore();
 }
 
@@ -7660,7 +8017,22 @@ void VMadCoI64I32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
   auto commit_result = [&](uint64_t raw_result) {
     amdgpu::write_wave_mask_scalar(sdst, wf, raw_result);
   };
-  amdgpu::execute_v_mad_co_i64_i32_vop3(*this, wf, commit_result);
+  uint64_t exec = wf.exec();
+  uint64_t carry = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    int64_t s0 = static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src0, lane));
+    int64_t s1 = static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    uint64_t s2 = amdgpu::RegisterAccess(wf).read_lane64(src2, lane);
+    uint64_t product = static_cast<uint64_t>(s0) * static_cast<uint64_t>(s1);
+    uint64_t result = product + s2;
+    constexpr uint64_t sign_bit = 1ULL << 63;
+    if (((~(product ^ s2) & (product ^ result)) & sign_bit) != 0)
+      carry |= 1ULL << lane;
+    amdgpu::sdwa::write_lane64<false>(*this, wf, vdst, lane, result);
+  }
+  commit_result(carry);
 }
 
 RJ_NOINLINE void VMadCoI64I32Vop3SdstEnc::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -7691,7 +8063,22 @@ RJ_NOINLINE void VMadCoI64I32Vop3SdstEnc::execute_modifier_impl(amdgpu::Wavefron
           raw_result, dpp_old_secondary_dst_, dpp_old_exec_, dpp_source_write_mask_);
     amdgpu::write_wave_mask_scalar(sdst, wf, final_result);
   };
-  amdgpu::execute_v_mad_co_i64_i32_vop3(*this, wf, commit_result);
+  uint64_t exec = wf.exec();
+  uint64_t carry = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    int64_t s0 = static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src0, lane));
+    int64_t s1 = static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    uint64_t s2 = amdgpu::RegisterAccess(wf).read_lane64(src2, lane);
+    uint64_t product = static_cast<uint64_t>(s0) * static_cast<uint64_t>(s1);
+    uint64_t result = product + s2;
+    constexpr uint64_t sign_bit = 1ULL << 63;
+    if (((~(product ^ s2) & (product ^ result)) & sign_bit) != 0)
+      carry |= 1ULL << lane;
+    amdgpu::sdwa::write_lane64<false>(*this, wf, vdst, lane, result);
+  }
+  commit_result(carry);
   dpp_write_mask_scope_.restore();
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_exec_cvt.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_exec_cvt.cpp
@@ -361,7 +361,35 @@ void VCvtOffF32I4Vop3::execute_impl(amdgpu::Wavefront &wf) {
     execute_modifier_impl(wf);
     return;
   }
-  amdgpu::execute_v_cvt_off_f32_i4_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<true>(*this, wf, vdst, lane, std::bit_cast<uint32_t>([&]() {
+      float v = [&]() {
+        float v = [&]() -> float {
+          int32_t nibble =
+              static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src0, lane) & 0xfu);
+          if (nibble & 0x8)
+            nibble -= 16;
+          return static_cast<float>(nibble) * 0.0625f;
+        }();
+        const uint32_t effective_omod = amdgpu::fp_mode::effective_omod(
+            wf.cu().arch(), wf.fp_denorm_mode_f32(), wf.ieee_mode(), inst_.omod);
+        if (effective_omod == 1)
+          v *= 2.0f;
+        else if (effective_omod == 2)
+          v *= 4.0f;
+        else if (effective_omod == 3)
+          v *= 0.5f;
+        v = amdgpu::fp_mode::finalize_omod_f32(v, effective_omod);
+        return v;
+      }();
+      if (inst_.clamp)
+        v = amdgpu::clamp_floating_result(v, wf);
+      return v;
+    }()));
+  }
 }
 
 RJ_NOINLINE void VCvtOffF32I4Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -380,7 +408,35 @@ RJ_NOINLINE void VCvtOffF32I4Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) 
   if (inst_.src0 == amdgpu::SRC_DPP)
     dpp_write_mask_scope_.bind(wf,
                                wf.exec() & dpp_plan_.row_bank_mask & dpp_plan_.source_write_mask);
-  amdgpu::execute_v_cvt_off_f32_i4_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<true>(*this, wf, vdst, lane, std::bit_cast<uint32_t>([&]() {
+      float v = [&]() {
+        float v = [&]() -> float {
+          int32_t nibble =
+              static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src0, lane) & 0xfu);
+          if (nibble & 0x8)
+            nibble -= 16;
+          return static_cast<float>(nibble) * 0.0625f;
+        }();
+        const uint32_t effective_omod = amdgpu::fp_mode::effective_omod(
+            wf.cu().arch(), wf.fp_denorm_mode_f32(), wf.ieee_mode(), inst_.omod);
+        if (effective_omod == 1)
+          v *= 2.0f;
+        else if (effective_omod == 2)
+          v *= 4.0f;
+        else if (effective_omod == 3)
+          v *= 0.5f;
+        v = amdgpu::fp_mode::finalize_omod_f32(v, effective_omod);
+        return v;
+      }();
+      if (inst_.clamp)
+        v = amdgpu::clamp_floating_result(v, wf);
+      return v;
+    }()));
+  }
   dpp_write_mask_scope_.restore();
 }
 
@@ -1821,7 +1877,17 @@ void VCvtPkU8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     execute_modifier_impl(wf);
     return;
   }
-  amdgpu::execute_v_cvt_pk_u8_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float fval = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src0, lane));
+    uint32_t byte_sel = amdgpu::RegisterAccess(wf).read_lane(src1, lane) & 3;
+    uint32_t old = amdgpu::RegisterAccess(wf).read_lane(src2, lane);
+    uint32_t byte = static_cast<uint32_t>(std::clamp(fval, 0.0f, 255.0f));
+    uint32_t mask = ~(0xFFu << (byte_sel * 8));
+    amdgpu::sdwa::write_lane<false>(*this, wf, vdst, lane, (old & mask) | (byte << (byte_sel * 8)));
+  }
 }
 
 RJ_NOINLINE void VCvtPkU8F32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -1840,7 +1906,17 @@ RJ_NOINLINE void VCvtPkU8F32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
   if (inst_.src0 == amdgpu::SRC_DPP)
     dpp_write_mask_scope_.bind(wf,
                                wf.exec() & dpp_plan_.row_bank_mask & dpp_plan_.source_write_mask);
-  amdgpu::execute_v_cvt_pk_u8_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float fval = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src0, lane));
+    uint32_t byte_sel = amdgpu::RegisterAccess(wf).read_lane(src1, lane) & 3;
+    uint32_t old = amdgpu::RegisterAccess(wf).read_lane(src2, lane);
+    uint32_t byte = static_cast<uint32_t>(std::clamp(fval, 0.0f, 255.0f));
+    uint32_t mask = ~(0xFFu << (byte_sel * 8));
+    amdgpu::sdwa::write_lane<false>(*this, wf, vdst, lane, (old & mask) | (byte << (byte_sel * 8)));
+  }
   dpp_write_mask_scope_.restore();
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_exec_misc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_exec_misc.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/dpp_sdwa_ops.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/fp_mode.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/transcendental.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
@@ -24,11 +25,9 @@
 namespace rocjitsu {
 namespace cdna5 {
 
-void VNopVop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_nop_vop3(*this, wf); }
+void VNopVop3::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
-void VPipeflushVop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_pipeflush_vop3(*this, wf);
-}
+void VPipeflushVop3::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
 void VPrngB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
   if (inst_.src0 == amdgpu::SRC_DPP || amdgpu::dpp::is_src_dpp8(inst_.src0)) {
@@ -207,7 +206,44 @@ void VMullitF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     execute_modifier_impl(wf);
     return;
   }
-  amdgpu::execute_v_mullit_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src0, lane));
+    float s1 = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    float s2 = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    if (inst_.abs & (1u << 0))
+      s0 = std::fabs(s0);
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.abs & (1u << 1))
+      s1 = std::fabs(s1);
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (inst_.abs & (1u << 2))
+      s2 = std::fabs(s2);
+    if (inst_.neg & (1u << 2))
+      s2 = -s2;
+    float result;
+    if (s1 == -std::numeric_limits<float>::max() || s1 == -std::numeric_limits<float>::infinity() ||
+        std::isnan(s1) || s2 <= 0.0f || std::isnan(s2))
+      result = -std::numeric_limits<float>::max();
+    else
+      result = (s0 == 0.0f || s1 == 0.0f) ? 0.0f : s0 * s1;
+    const uint32_t effective_omod = amdgpu::fp_mode::effective_omod(
+        wf.cu().arch(), wf.fp_denorm_mode_f32(), wf.ieee_mode(), inst_.omod);
+    if (effective_omod == 1)
+      result *= 2.0f;
+    else if (effective_omod == 2)
+      result *= 4.0f;
+    else if (effective_omod == 3)
+      result *= 0.5f;
+    if (inst_.clamp)
+      result = amdgpu::clamp_floating_result(result, wf);
+    result = amdgpu::fp_mode::finalize_omod_f32(result, effective_omod);
+    amdgpu::sdwa::write_lane<true>(*this, wf, vdst, lane, std::bit_cast<uint32_t>(result));
+  }
 }
 
 RJ_NOINLINE void VMullitF32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -226,7 +262,44 @@ RJ_NOINLINE void VMullitF32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
   if (inst_.src0 == amdgpu::SRC_DPP)
     dpp_write_mask_scope_.bind(wf,
                                wf.exec() & dpp_plan_.row_bank_mask & dpp_plan_.source_write_mask);
-  amdgpu::execute_v_mullit_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src0, lane));
+    float s1 = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    float s2 = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    if (inst_.abs & (1u << 0))
+      s0 = std::fabs(s0);
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.abs & (1u << 1))
+      s1 = std::fabs(s1);
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (inst_.abs & (1u << 2))
+      s2 = std::fabs(s2);
+    if (inst_.neg & (1u << 2))
+      s2 = -s2;
+    float result;
+    if (s1 == -std::numeric_limits<float>::max() || s1 == -std::numeric_limits<float>::infinity() ||
+        std::isnan(s1) || s2 <= 0.0f || std::isnan(s2))
+      result = -std::numeric_limits<float>::max();
+    else
+      result = (s0 == 0.0f || s1 == 0.0f) ? 0.0f : s0 * s1;
+    const uint32_t effective_omod = amdgpu::fp_mode::effective_omod(
+        wf.cu().arch(), wf.fp_denorm_mode_f32(), wf.ieee_mode(), inst_.omod);
+    if (effective_omod == 1)
+      result *= 2.0f;
+    else if (effective_omod == 2)
+      result *= 4.0f;
+    else if (effective_omod == 3)
+      result *= 0.5f;
+    if (inst_.clamp)
+      result = amdgpu::clamp_floating_result(result, wf);
+    result = amdgpu::fp_mode::finalize_omod_f32(result, effective_omod);
+    amdgpu::sdwa::write_lane<true>(*this, wf, vdst, lane, std::bit_cast<uint32_t>(result));
+  }
   dpp_write_mask_scope_.restore();
 }
 
@@ -343,7 +416,54 @@ RJ_NOINLINE void VBcntU32B32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
 }
 
 void VTrigPreopF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_trig_preop_f64_vop3(*this, wf);
+  // MSB-first 24-bit chunks of the binary expansion of 2/pi used by
+  // the ISA range-reduction lookup (the fdlibm/Payne-Hanek layout).
+  static constexpr uint32_t kTwoOverPiChunks[] = {
+      0xA2F983u, 0x6E4E44u, 0x1529FCu, 0x2757D1u, 0xF534DDu, 0xC0DB62u, 0x95993Cu, 0x439041u,
+      0xFE5163u, 0xABDEBBu, 0xC561B7u, 0x246E3Au, 0x424DD2u, 0xE00649u, 0x2EEA09u, 0xD1921Cu,
+      0xFE1DEBu, 0x1CB129u, 0xA73EE8u, 0x8235F5u, 0x2EBB44u, 0x84E99Cu, 0x7026B4u, 0x5F7E41u,
+      0x3991D6u, 0x398353u, 0x39F49Cu, 0x845F8Bu, 0xBDF928u, 0x3B1FF8u, 0x97FFDEu, 0x05980Fu,
+      0xEF2F11u, 0x8B5A0Au, 0x6D1F6Du, 0x367ECFu, 0x27CB09u, 0xB74F46u, 0x3F669Eu, 0x5FEA2Du,
+      0x7527BAu, 0xC7EBE5u, 0xF17B3Du, 0x0739F7u, 0x8A5292u, 0xEA6BFBu, 0x5FB11Fu, 0x8D5D08u,
+      0x560330u, 0x46FC7Bu, 0x6BABF0u};
+  static constexpr uint32_t kChunkBits = 24u;
+  static constexpr uint32_t kValidBits = 1201u;
+  auto table_bit = [](uint32_t bit) -> uint64_t {
+    if (bit >= kValidBits)
+      return 0;
+    uint32_t chunk = bit / kChunkBits;
+    if (chunk >= std::size(kTwoOverPiChunks))
+      return 0;
+    return (kTwoOverPiChunks[chunk] >> (kChunkBits - 1u - bit % kChunkBits)) & 1u;
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint64_t raw0 = amdgpu::RegisterAccess(wf).read_lane64(src0, lane);
+    double s0 = std::bit_cast<double>(raw0);
+    if (inst_.abs & (1u << 0))
+      s0 = std::fabs(s0);
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    uint32_t selector = amdgpu::RegisterAccess(wf).read_lane(src1, lane) & 31u;
+    uint32_t exponent = static_cast<uint32_t>((std::bit_cast<uint64_t>(s0) >> 52) & 0x7ffu);
+    uint32_t shift = selector * 53u;
+    if (exponent > 1077u)
+      shift += exponent - 1077u;
+    uint64_t segment = 0;
+    for (uint32_t bit = 0; bit < 53; ++bit)
+      segment = (segment << 1) | table_bit(shift + bit);
+    int scale = -53 - static_cast<int>(shift);
+    if (exponent >= 1968u)
+      scale += 128;
+    uint64_t result = amdgpu::fp_mode::scale_u53_f64_rtz(segment, scale);
+    uint32_t effective_omod = amdgpu::fp_mode::effective_omod(
+        wf.cu().arch(), wf.fp_denorm_mode_f16_f64(), wf.ieee_mode(), inst_.omod);
+    result = amdgpu::fp_mode::finish_f64(result, wf.fp_round_mode_f16_f64(), effective_omod,
+                                         inst_.clamp, amdgpu::floating_clamp_nan_to_zero(wf));
+    amdgpu::sdwa::write_lane64<true>(*this, wf, vdst, lane, result);
+  }
 }
 
 } // namespace cdna5

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_exec_ternary.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_exec_ternary.cpp
@@ -1472,7 +1472,55 @@ void VMed3NumF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     execute_modifier_impl(wf);
     return;
   }
-  amdgpu::execute_v_med3_num_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<true>(*this, wf, vdst, lane, std::bit_cast<uint32_t>([&]() {
+      float v = [&]() {
+        float v = [&]() {
+          auto a = [&]() {
+            float sv = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src0, lane));
+            if (inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }();
+          auto b = [&]() {
+            float sv = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+            if (inst_.abs & (1u << 1))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 1))
+              sv = -sv;
+            return sv;
+          }();
+          auto c = [&]() {
+            float sv = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+            if (inst_.abs & (1u << 2))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 2))
+              sv = -sv;
+            return sv;
+          }();
+          return std::fmax(std::fmin(std::fmax(a, b), c), std::fmin(a, b));
+        }();
+        const uint32_t effective_omod = amdgpu::fp_mode::effective_omod(
+            wf.cu().arch(), wf.fp_denorm_mode_f32(), wf.ieee_mode(), inst_.omod);
+        if (effective_omod == 1)
+          v *= 2.0f;
+        else if (effective_omod == 2)
+          v *= 4.0f;
+        else if (effective_omod == 3)
+          v *= 0.5f;
+        v = amdgpu::fp_mode::finalize_omod_f32(v, effective_omod);
+        return v;
+      }();
+      if (inst_.clamp)
+        v = amdgpu::clamp_floating_result(v, wf);
+      return v;
+    }()));
+  }
 }
 
 RJ_NOINLINE void VMed3NumF32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -1491,7 +1539,55 @@ RJ_NOINLINE void VMed3NumF32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
   if (inst_.src0 == amdgpu::SRC_DPP)
     dpp_write_mask_scope_.bind(wf,
                                wf.exec() & dpp_plan_.row_bank_mask & dpp_plan_.source_write_mask);
-  amdgpu::execute_v_med3_num_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<true>(*this, wf, vdst, lane, std::bit_cast<uint32_t>([&]() {
+      float v = [&]() {
+        float v = [&]() {
+          auto a = [&]() {
+            float sv = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src0, lane));
+            if (inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }();
+          auto b = [&]() {
+            float sv = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+            if (inst_.abs & (1u << 1))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 1))
+              sv = -sv;
+            return sv;
+          }();
+          auto c = [&]() {
+            float sv = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+            if (inst_.abs & (1u << 2))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 2))
+              sv = -sv;
+            return sv;
+          }();
+          return std::fmax(std::fmin(std::fmax(a, b), c), std::fmin(a, b));
+        }();
+        const uint32_t effective_omod = amdgpu::fp_mode::effective_omod(
+            wf.cu().arch(), wf.fp_denorm_mode_f32(), wf.ieee_mode(), inst_.omod);
+        if (effective_omod == 1)
+          v *= 2.0f;
+        else if (effective_omod == 2)
+          v *= 4.0f;
+        else if (effective_omod == 3)
+          v *= 0.5f;
+        v = amdgpu::fp_mode::finalize_omod_f32(v, effective_omod);
+        return v;
+      }();
+      if (inst_.clamp)
+        v = amdgpu::clamp_floating_result(v, wf);
+      return v;
+    }()));
+  }
   dpp_write_mask_scope_.restore();
 }
 
@@ -2969,7 +3065,16 @@ void VMaxminU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     execute_modifier_impl(wf);
     return;
   }
-  amdgpu::execute_v_maxmin_u32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<false>(
+        *this, wf, vdst, lane,
+        std::fmin(std::fmax(amdgpu::RegisterAccess(wf).read_lane(src0, lane),
+                            amdgpu::RegisterAccess(wf).read_lane(src1, lane)),
+                  amdgpu::RegisterAccess(wf).read_lane(src2, lane)));
+  }
 }
 
 RJ_NOINLINE void VMaxminU32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -2988,7 +3093,16 @@ RJ_NOINLINE void VMaxminU32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
   if (inst_.src0 == amdgpu::SRC_DPP)
     dpp_write_mask_scope_.bind(wf,
                                wf.exec() & dpp_plan_.row_bank_mask & dpp_plan_.source_write_mask);
-  amdgpu::execute_v_maxmin_u32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<false>(
+        *this, wf, vdst, lane,
+        std::fmin(std::fmax(amdgpu::RegisterAccess(wf).read_lane(src0, lane),
+                            amdgpu::RegisterAccess(wf).read_lane(src1, lane)),
+                  amdgpu::RegisterAccess(wf).read_lane(src2, lane)));
+  }
   dpp_write_mask_scope_.restore();
 }
 
@@ -2997,7 +3111,16 @@ void VMinmaxU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     execute_modifier_impl(wf);
     return;
   }
-  amdgpu::execute_v_minmax_u32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<false>(
+        *this, wf, vdst, lane,
+        std::fmax(std::fmin(amdgpu::RegisterAccess(wf).read_lane(src0, lane),
+                            amdgpu::RegisterAccess(wf).read_lane(src1, lane)),
+                  amdgpu::RegisterAccess(wf).read_lane(src2, lane)));
+  }
 }
 
 RJ_NOINLINE void VMinmaxU32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -3016,7 +3139,16 @@ RJ_NOINLINE void VMinmaxU32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
   if (inst_.src0 == amdgpu::SRC_DPP)
     dpp_write_mask_scope_.bind(wf,
                                wf.exec() & dpp_plan_.row_bank_mask & dpp_plan_.source_write_mask);
-  amdgpu::execute_v_minmax_u32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<false>(
+        *this, wf, vdst, lane,
+        std::fmax(std::fmin(amdgpu::RegisterAccess(wf).read_lane(src0, lane),
+                            amdgpu::RegisterAccess(wf).read_lane(src1, lane)),
+                  amdgpu::RegisterAccess(wf).read_lane(src2, lane)));
+  }
   dpp_write_mask_scope_.restore();
 }
 
@@ -3025,7 +3157,16 @@ void VMaxminI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     execute_modifier_impl(wf);
     return;
   }
-  amdgpu::execute_v_maxmin_i32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<false>(
+        *this, wf, vdst, lane,
+        std::fmin(std::fmax(static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src0, lane)),
+                            static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane))),
+                  static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src2, lane))));
+  }
 }
 
 RJ_NOINLINE void VMaxminI32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -3044,7 +3185,16 @@ RJ_NOINLINE void VMaxminI32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
   if (inst_.src0 == amdgpu::SRC_DPP)
     dpp_write_mask_scope_.bind(wf,
                                wf.exec() & dpp_plan_.row_bank_mask & dpp_plan_.source_write_mask);
-  amdgpu::execute_v_maxmin_i32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<false>(
+        *this, wf, vdst, lane,
+        std::fmin(std::fmax(static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src0, lane)),
+                            static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane))),
+                  static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src2, lane))));
+  }
   dpp_write_mask_scope_.restore();
 }
 
@@ -3053,7 +3203,16 @@ void VMinmaxI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     execute_modifier_impl(wf);
     return;
   }
-  amdgpu::execute_v_minmax_i32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<false>(
+        *this, wf, vdst, lane,
+        std::fmax(std::fmin(static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src0, lane)),
+                            static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane))),
+                  static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src2, lane))));
+  }
 }
 
 RJ_NOINLINE void VMinmaxI32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
@@ -3072,7 +3231,16 @@ RJ_NOINLINE void VMinmaxI32Vop3::execute_modifier_impl(amdgpu::Wavefront &wf) {
   if (inst_.src0 == amdgpu::SRC_DPP)
     dpp_write_mask_scope_.bind(wf,
                                wf.exec() & dpp_plan_.row_bank_mask & dpp_plan_.source_write_mask);
-  amdgpu::execute_v_minmax_i32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    amdgpu::sdwa::write_lane<false>(
+        *this, wf, vdst, lane,
+        std::fmax(std::fmin(static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src0, lane)),
+                            static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane))),
+                  static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(src2, lane))));
+  }
   dpp_write_mask_scope_.restore();
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vds_exec.cpp
@@ -2477,29 +2477,7 @@ void DsStoreAddtidB32Vds::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void DsLoadAddtidB32Vds::execute_impl(amdgpu::Wavefront &wf) {
-  auto d = std::make_unique<amdgpu::VectorMemState>(amdgpu::LOCAL_MEM);
-  d->dst_reg_base = wf.vgpr_alloc().base + 0u + inst_.vdst;
-  d->elem_size = 4;
-  d->num_elems = 1;
-  d->is_load = true;
-  d->wait_counter_type = amdgpu::WaitCounterType::DSCNT;
-  {
-    uint64_t exec = wf.exec();
-    d->lane_mask = exec;
-    d->exec_mask = exec;
-    d->wg_id = wf.wg_id();
-    d->wf_id = wf.wf_id();
-    d->cu_path = wf.cu().full_path();
-    uint32_t offset = (static_cast<uint32_t>(inst_.offset1) << 8) | inst_.offset0;
-    uint32_t m0 = wf.m0();
-    uint32_t ds_stride_bytes = ((m0 >> 16) & 0x1FF) * 4;
-    for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-      if (!(exec & (1ULL << lane)))
-        continue;
-      d->per_lane_addr[lane] = lane * ds_stride_bytes + offset + wf.lds_base();
-    }
-  }
-  set_data(std::move(d));
+  amdgpu::execute_ds_load_addtid_b32_vds(*this, wf);
 }
 
 void DsPermuteB32Vds::execute_impl(amdgpu::Wavefront &wf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h
@@ -176,6 +176,34 @@ inline void execute_ds_load_addtid_b32_ds([[maybe_unused]] Inst &inst,
 }
 
 template <typename Inst>
+inline void execute_ds_load_addtid_b32_vds([[maybe_unused]] Inst &inst,
+                                           [[maybe_unused]] Wavefront &wf) {
+  auto d = std::make_unique<amdgpu::VectorMemState>(amdgpu::LOCAL_MEM);
+  d->dst_reg_base = wf.vgpr_alloc().base + 0u + inst.inst_.vdst;
+  d->elem_size = 4;
+  d->num_elems = 1;
+  d->is_load = true;
+  d->wait_counter_type = amdgpu::WaitCounterType::DSCNT;
+  {
+    uint64_t exec = dpp::execution_lane_mask(inst, wf);
+    d->lane_mask = exec;
+    d->exec_mask = exec;
+    d->wg_id = wf.wg_id();
+    d->wf_id = wf.wf_id();
+    d->cu_path = wf.cu().full_path();
+    uint32_t offset = (static_cast<uint32_t>(inst.inst_.offset1) << 8) | inst.inst_.offset0;
+    uint32_t m0 = wf.m0();
+    uint32_t ds_stride_bytes = ((m0 >> 16) & 0x1FF) * 4;
+    for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+      if (!(exec & (1ULL << lane)))
+        continue;
+      d->per_lane_addr[lane] = lane * ds_stride_bytes + offset + wf.lds_base();
+    }
+  }
+  inst.set_data(std::move(d));
+}
+
+template <typename Inst>
 inline void execute_ds_nop_ds([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {}
 
 template <typename Inst>

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -4671,8 +4671,8 @@ void rdna4_wave64_generated_vcmpx_dpp_write_mask_preserves_exec() {
   for (uint32_t lane = 0; lane < wf->wf_size(); ++lane) {
     uint32_t src = 0x1000u + lane;
     uint32_t cmp = lane < 16 ? 0xDEAD0000u + lane : 0x1000u + ((lane & ~15u) - 1u);
-    if (lane == 20)
-      cmp = 0xDEAD0020u;
+    if (lane == 20 || lane == 33)
+      cmp = 0xDEAD0000u + lane;
     cu->write_vgpr(vbase + kSrc0, lane, src);
     cu->write_vgpr(vbase + kSrc1, lane, cmp);
   }
@@ -4691,7 +4691,7 @@ void rdna4_wave64_generated_vcmpx_dpp_write_mask_preserves_exec() {
   inst.execute_impl(*wf);
 
   EXPECT_EQ(wf->vcc(), kOldVcc);
-  EXPECT_EQ(wf->exec(), 0xA5A55A5AFFEF005AULL);
+  EXPECT_EQ(wf->exec(), 0xA5A55A58FFEF005AULL);
 }
 
 template <typename Traits> void wave32_generated_vcmpx_preserves_exec_hi() {
@@ -5013,7 +5013,8 @@ void rdna4_vop3_dpp_availability_is_instruction_specific() {
   rdna4_vop3p_dpp_marker_is_unsupported<rdna4::Vop3pVopDpp8MachineInst>(amdgpu::SRC_DPP8_FI_0);
 }
 
-template <typename Raw> void rdna4_vopc_dpp_marker_is_instruction_specific(uint32_t marker) {
+template <typename Raw>
+void rdna4_vopc_dpp_marker_is_instruction_specific(uint32_t marker, const char *expected_label) {
   Raw raw{};
   raw.src0 = marker;
   raw.vsrc1 = 8;
@@ -5047,9 +5048,10 @@ template <typename Raw> void rdna4_vopc_dpp_marker_is_instruction_specific(uint3
 }
 
 void rdna4_vopc_dpp_availability_is_instruction_specific() {
-  rdna4_vopc_dpp_marker_is_instruction_specific<rdna4::VopcVopDpp16MachineInst>(amdgpu::SRC_DPP);
+  rdna4_vopc_dpp_marker_is_instruction_specific<rdna4::VopcVopDpp16MachineInst>(amdgpu::SRC_DPP,
+                                                                                "DPP");
   rdna4_vopc_dpp_marker_is_instruction_specific<rdna4::VopcVopDpp8MachineInst>(
-      amdgpu::SRC_DPP8_FI_0);
+      amdgpu::SRC_DPP8_FI_0, "DPP8");
 }
 
 TEST(DppPermuteTest, CdnaGeneratedVop1UsesSharedRowBroadcast) {

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -3093,6 +3093,15 @@ struct Gfx1250DppTraits {
   }
 };
 
+// Test-only RDNA4 trait for exercising 64-bit EXEC handling. The production
+// RDNA factory still constructs the ISA default Wave32 form.
+struct Rdna4Wave64DppTestIsa : rdna4::Isa {
+  static constexpr uint32_t WF_SIZE = 64;
+  static constexpr uint32_t WF_SIZE_MAX = 64;
+};
+
+static_assert(GpuIsa<Rdna4Wave64DppTestIsa>);
+
 template <typename Traits> void generated_dpp_instruction_reuse_reads_current_source() {
   SCOPED_TRACE(Traits::name);
   ScopedIsaExecutionBackend execution_backend_scope{&Traits::backend()};
@@ -4631,6 +4640,60 @@ void wave32_generated_vcmpx_dpp_zeros_invalid_sources_preserves_exec_hi() {
   EXPECT_EQ(wf->exec_raw(), 0xA5A55A5AFFFE005AULL);
 }
 
+void rdna4_wave64_generated_vcmpx_dpp_write_mask_preserves_exec() {
+  ScopedIsaExecutionBackend execution_backend_scope{&rdna4::execution_backend()};
+  amdgpu::GpuMemory mem("rdna4_dpp_vcmpx_wave64_exec_mask_mem");
+  amdgpu::L2Cache l2("rdna4_dpp_vcmpx_wave64_exec_mask_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_RDNA4;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = rdna4::Isa::MAX_SGPRS_PER_WF;
+  cfg.vgprs_per_wf = 32;
+  cfg.lds_size_kb = 64;
+
+  auto cu = std::make_unique<
+      amdgpu::IsaExecComputeUnit<simdojo::ExecMode::FUNCTIONAL, Rdna4Wave64DppTestIsa>>(
+      "rdna4_dpp_vcmpx_wave64_exec_mask_cu", cfg, &mem, &l2);
+
+  auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+  ASSERT_EQ(wf->wf_size(), 64u);
+
+  constexpr uint64_t kOldExec = 0xA5A55A5AFFFF005AULL;
+  constexpr uint64_t kOldVcc = 0x00000000000000A5ULL;
+  wf->set_exec(kOldExec);
+  wf->set_vcc(kOldVcc);
+
+  constexpr uint32_t kSrc0 = 4;
+  constexpr uint32_t kSrc1 = 8;
+  uint32_t vbase = wf->vgpr_alloc().base;
+  for (uint32_t lane = 0; lane < wf->wf_size(); ++lane) {
+    uint32_t src = 0x1000u + lane;
+    uint32_t cmp = lane < 16 ? 0xDEAD0000u + lane : 0x1000u + ((lane & ~15u) - 1u);
+    if (lane == 20)
+      cmp = 0xDEAD0020u;
+    cu->write_vgpr(vbase + kSrc0, lane, src);
+    cu->write_vgpr(vbase + kSrc1, lane, cmp);
+  }
+
+  rdna4::VopcVopDpp16MachineInst raw{};
+  raw.src0 = amdgpu::SRC_DPP;
+  raw.vsrc1 = kSrc1;
+  raw.vsrc0 = kSrc0;
+  raw.dpp_ctrl = amdgpu::dpp::ROW_BCAST15;
+  raw.fi = 1;
+  raw.bound_ctrl = 0;
+  raw.bank_mask = 0xF;
+  raw.row_mask = 0xF;
+
+  rdna4::VCmpxEqU32Vopc inst(reinterpret_cast<const rdna4::MachineInst *>(&raw));
+  inst.execute_impl(*wf);
+
+  EXPECT_EQ(wf->vcc(), kOldVcc);
+  EXPECT_EQ(wf->exec(), 0xA5A55A5AFFEF005AULL);
+}
+
 template <typename Traits> void wave32_generated_vcmpx_preserves_exec_hi() {
   SCOPED_TRACE(Traits::name);
   ScopedIsaExecutionBackend execution_backend_scope{&Traits::backend()};
@@ -5282,6 +5345,10 @@ TEST(DppPermuteTest, RdnaGeneratedVopcDppZerosMaskedCompareBits) {
   wave32_generated_vopc_dpp_zeros_masked_compare_bits<Rdna3DppTraits>();
   wave32_generated_vopc_dpp_zeros_masked_compare_bits<Rdna3_5DppTraits>();
   wave32_generated_vopc_dpp_zeros_masked_compare_bits<Rdna4DppTraits>();
+}
+
+TEST(DppPermuteTest, Rdna4GeneratedVcmpxDppWave64WriteMaskPreservesExec) {
+  rdna4_wave64_generated_vcmpx_dpp_write_mask_preserves_exec();
 }
 
 TEST(DppPermuteTest, Gfx1250GeneratedVopcDppZerosMaskedCompareBits) {

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -4950,6 +4950,45 @@ void rdna4_vop3_dpp_availability_is_instruction_specific() {
   rdna4_vop3p_dpp_marker_is_unsupported<rdna4::Vop3pVopDpp8MachineInst>(amdgpu::SRC_DPP8_FI_0);
 }
 
+template <typename Raw> void rdna4_vopc_dpp_marker_is_instruction_specific(uint32_t marker) {
+  Raw raw{};
+  raw.src0 = marker;
+  raw.vsrc1 = 8;
+  raw.op = rdna4::kVCmpEqU32Vopc;
+  raw.encoding = rdna4::encoding::kVopc >> 2;
+  raw.vsrc0 = 4;
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  {
+    util::StringDiagnostic diagnostic;
+    const DecodeResult decoded =
+        decoder->decode(reinterpret_cast<const uint32_t *>(&raw), diagnostic.emitter());
+    EXPECT_TRUE(decoded.succeeded()) << diagnostic.message();
+    EXPECT_TRUE(diagnostic.message().empty());
+  }
+
+  raw.op = rdna4::kVCmpEqF64Vopc;
+  {
+    util::StringDiagnostic diagnostic;
+    const DecodeResult decoded =
+        decoder->decode(reinterpret_cast<const uint32_t *>(&raw), diagnostic.emitter());
+    const uint32_t encoded_word = std::bit_cast<std::array<uint32_t, 2>>(raw)[0];
+    EXPECT_TRUE(decoded.failed()) << "decoded as " << decoded.value()->mnemonic() << " for "
+                                  << expected_label << ", word=0x" << std::hex << encoded_word
+                                  << ", primary=0x" << (encoded_word >> 24);
+    const std::string expected_message =
+        std::string("V_CMP_EQ_F64 does not support ") + expected_label;
+    EXPECT_EQ(diagnostic.message(), expected_message);
+  }
+}
+
+void rdna4_vopc_dpp_availability_is_instruction_specific() {
+  rdna4_vopc_dpp_marker_is_instruction_specific<rdna4::VopcVopDpp16MachineInst>(amdgpu::SRC_DPP);
+  rdna4_vopc_dpp_marker_is_instruction_specific<rdna4::VopcVopDpp8MachineInst>(
+      amdgpu::SRC_DPP8_FI_0);
+}
+
 TEST(DppPermuteTest, CdnaGeneratedVop1UsesSharedRowBroadcast) {
   cdna_generated_vop1_uses_shared_row_broadcast<Cdna1DppTraits>();
   cdna_generated_vop1_uses_shared_row_broadcast<Cdna2DppTraits>();
@@ -4981,6 +5020,10 @@ TEST(DppPermuteTest, Cdna4UnsupportedSdwaDecodeHaltsWave) {
 
 TEST(DppPermuteTest, Rdna4Vop3DppAvailabilityIsInstructionSpecific) {
   rdna4_vop3_dpp_availability_is_instruction_specific();
+}
+
+TEST(DppPermuteTest, Rdna4VopcDppAvailabilityIsInstructionSpecific) {
+  rdna4_vopc_dpp_availability_is_instruction_specific();
 }
 
 TEST(DppPermuteTest, RdnaGeneratedVop1DppWriteMaskHonorsBoundCtrl) {


### PR DESCRIPTION
ISSUE ID: #8798

## Summary

The MRISA-driven modifier-availability implementation originally developed in this PR landed as part of #9250. This PR now contains the remaining review-driven correctness and coverage improvements.

Generated constructors distinguish unsupported DPP and DPP8 markers in their `InvalidInst` diagnostics instead of reporting both as DPP. This does not change modifier availability or execution semantics.

The change also:

- adds positive and negative RDNA4 VOPC availability coverage;
- adds RDNA4 Wave64 VCMPX coverage for preserving masked-off `EXEC` bits; and
- documents why condition-gated alternate encodings remain part of instruction-level MRISA provenance even when skipped for class emission.

Generated output is isolated in the final commit.

