### PR TITLE
[rocjitsu][CI] Drop resolved gfx1250 DBT xfails

### DIFF
--- a/emulation/rocjitsu/tests/corpus/dbt/gfx1250_b0_a0_expected_failures.json
+++ b/emulation/rocjitsu/tests/corpus/dbt/gfx1250_b0_a0_expected_failures.json
@@ -4,71 +4,17 @@
       "kind": "memory-limit",
       "reason": "RCCL code object exceeds the per-object DBT memory limit in indirect-branch discovery"
     },
-    "522bdabb8ec787b512c8c0535a5adf2e72985f33d931461accde47216b8c7cf0": {
-      "kind": "translation-error",
-      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
-      "returncode": 3,
-      "stderr_regex": "legalization \\.text\\+0x17c28 indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
-    },
-    "5b24ad46e20c38dd3acb6a8b67cf9b27d90aca146186d773bc009514c355492f": {
-      "kind": "translation-error",
-      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
-      "returncode": 3,
-      "stderr_regex": "legalization \\.text\\+0x2b760 indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
-    },
-    "5bbd0cf23d3b5bc1b62a3f56151a1beba8781d833c35575f2d47979693241018": {
-      "kind": "translation-error",
-      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
-      "returncode": 3,
-      "stderr_regex": "legalization \\.text\\+0xee28 indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
-    },
     "5d2a4110c0d8274651992689ae47abfb014cd36584338a725d77cecdec9718aa": {
       "kind": "translation-error",
       "reason": "PyTorch object currently exposes no non-empty text section",
       "returncode": 3,
       "stderr_regex": "resource-limit: code object does not expose a non-empty \\.text section for translation"
     },
-    "88a3928b98afde04c3bb92d0134aa1b04b1342ce83eacd389857bcb9023e3f97": {
-      "kind": "translation-error",
-      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
-      "returncode": 3,
-      "stderr_regex": "legalization \\.text\\+0x85828 indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
-    },
     "af9e659f75ad449b591d855208fb122fd27d7e66422b687ee643054a5df4a2f7": {
       "kind": "translation-error",
       "reason": "rocFFT object currently has no kernel descriptors",
       "returncode": 3,
       "stderr_regex": "kernel-descriptor: kernel descriptors are required for kernel-level translation"
-    },
-    "c1896e26ef64eb5998bdff6cfbe54c39f672f7f189eb54801d8f37a96210892b": {
-      "kind": "translation-error",
-      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
-      "returncode": 3,
-      "stderr_regex": "legalization \\.text\\+0x21260 indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
-    },
-    "dacb8abe8349d5a5448113d60173bb9d651caa1a81b64db015fe915909c41c8a": {
-      "kind": "translation-error",
-      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
-      "returncode": 3,
-      "stderr_regex": "legalization \\.text\\+0x3f460 indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
-    },
-    "e6efa69e5ae03f61c907ed0e9175711a3e65d6294c2d04f0b83cc1f607ef6258": {
-      "kind": "translation-error",
-      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
-      "returncode": 3,
-      "stderr_regex": "legalization \\.text\\+0x34860 indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
-    },
-    "e78a60937e78d5026df75de19d604f3a7e90284f231074fab87a2ae5bb34a0ef": {
-      "kind": "translation-error",
-      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
-      "returncode": 3,
-      "stderr_regex": "legalization \\.text\\+0x35473c indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
-    },
-    "f15ec0007d25e530da9f3e3c517bb0c1a603df74013b944d68953216e1beae0e": {
-      "kind": "translation-error",
-      "reason": "PyTorch indirect branch currently has an unconstrained predecessor path",
-      "returncode": 3,
-      "stderr_regex": "legalization \\.text\\+0x28b4ac indirect branch: recovered indirect branch has an unconstrained predecessor path that cannot be relocated"
     }
   },
   "input_revision": "b0",


### PR DESCRIPTION
## Motivation

Keep the packaged gfx1250 DBT expectations aligned with the landed translator.

## Technical Details

Remove nine indirect-branch translation failures that now pass B0-to-A0 translation and output validation.

## Issue Tracking

N/A

## Test Plan

Rebuild rj_dbt_translate, extract the pinned 20,000-object corpus, and run the full offline DBT suite.

## Test Result

Passed. 19,997 objects passed and three remain expected failures in 1m37s.