### PR TITLE
ci(rocprofiler-compute): Fix library directory in rocprofiler-compute-sanitizers.yml

### DIFF
--- a/.github/workflows/rocprofiler-compute-sanitizers.yml
+++ b/.github/workflows/rocprofiler-compute-sanitizers.yml
@@ -113,7 +113,7 @@ jobs:
         shell: bash
         run: |
           resource_dir="$("${ROCM_PATH}/llvm/bin/clang" -print-resource-dir)"
-          sanitizer_lib_dir="${resource_dir}/lib/x86_64-unknown-linux-gnu"
+          sanitizer_lib_dir="${resource_dir}/lib/linux"
           if [ ! -d "${sanitizer_lib_dir}" ]; then
             echo "❌ Missing clang sanitizer runtime: ${sanitizer_lib_dir}"
             exit 1


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The `rocprofiler-compute-sanitizers.yml` workflow appears to have been failing since July 23rd due to a recent change.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Updated `sanitizer_lib_dir` to use `${resource_dir}/lib/linux` instead of `${resource_dir}/lib/x86_64-unknown-linux-gnu`
  - #9106 changed this value and it was passing at time of merge
  - However, it has been failing since. Likely cause is TheRock changed where the sanitizer libs exist in the structure, and the new tarballs that the Docker images are using picked this change up leading to being unable to find the libs

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
JIRA ID : AIPROFCOMP-711

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Ensure sanitizer workflows pass

## Test Result

<!-- Briefly summarize test outcomes. -->
- Workflows pass

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
