### PR TITLE
[RCCL][test] Fix illegal MPI_Cancel on Ibarrier in MPIEnvironment tea…

### DIFF
--- a/projects/rccl/test/common/MPIEnvironment.cpp
+++ b/projects/rccl/test/common/MPIEnvironment.cpp
@@ -15,6 +15,7 @@
 #ifdef MPI_TESTS_ENABLED
 
 #include <chrono>
+#include <cstdlib>
 #include <thread>
 
 /**
@@ -237,12 +238,22 @@ void MPIEnvironment::TearDown()
     if(barrier_result == MPI_SUCCESS)
     {
         // Wait for barrier with a timeout.
-        // 3 s: ncclCommDestroy is now explicitly called (and MPI-barrier'd) inside
-        // cleanupTestCommunicator before TearDown runs, so the only remaining rank
-        // skew here is log-file I/O (RCCL_MPI_LOG_ALL_RANKS) which is fast.
-        int        flag             = 0;
-        auto       timeout_start    = std::chrono::steady_clock::now();
-        const auto timeout_duration = std::chrono::seconds(3);
+        // ncclCommDestroy is now explicitly called (and MPI-barrier'd) inside
+        // cleanupTestCommunicator before TearDown runs, so the common remaining rank
+        // skew here is log-file I/O (RCCL_MPI_LOG_ALL_RANKS). However, heavy
+        // multi-phase tests (e.g. GrowMPITest, NetIbMPITest CtsDepthStress) can have
+        // ranks reach TearDown more than a few seconds apart even on success, so a
+        // 3 s timeout produced false "out of sync" aborts. Use a more tolerant default
+        // and allow override via RCCL_TEST_TEARDOWN_TIMEOUT_SEC.
+        int        flag          = 0;
+        auto       timeout_start = std::chrono::steady_clock::now();
+        int        timeout_sec   = 60;
+        if(const char* env = std::getenv("RCCL_TEST_TEARDOWN_TIMEOUT_SEC"))
+        {
+            int v = std::atoi(env);
+            if(v > 0) timeout_sec = v;
+        }
+        const auto timeout_duration = std::chrono::seconds(timeout_sec);
 
         while(!flag)
         {
@@ -254,18 +265,21 @@ void MPIEnvironment::TearDown()
                 auto elapsed = std::chrono::steady_clock::now() - timeout_start;
                 if(elapsed > timeout_duration)
                 {
-                    // Timeout - ranks are out of sync!
+                    // Timeout - ranks are genuinely out of sync (e.g. a rank died or
+                    // deadlocked in the test body). Force abort.
                     std::fprintf(
                         stderr,
-                        "Rank %d: TIMEOUT in TearDown barrier - ranks out of sync, forcing abort\n",
-                        world_rank);
+                        "Rank %d: TIMEOUT (%ds) in TearDown barrier - ranks out of sync, forcing abort\n",
+                        world_rank,
+                        timeout_sec);
                     std::fflush(stderr);
 
-                    // Cancel the barrier request
-                    MPI_Cancel(&barrier_req);
-                    MPI_Request_free(&barrier_req);
-
-                    // Force abort - can't safely continue
+                    // NOTE: Do NOT MPI_Cancel(&barrier_req) here. Cancelling a
+                    // nonblocking *collective* request (MPI_Ibarrier) is forbidden by
+                    // the MPI standard; OpenMPI returns MPI_ERR_REQUEST, and because
+                    // MPI_COMM_WORLD uses MPI_ERRORS_ARE_FATAL that call aborts the job
+                    // itself with a misleading error before we reach MPI_Abort. Since
+                    // MPI_Abort tears the whole job down anyway, just call it directly.
                     MPI_Abort(MPI_COMM_WORLD, 1);
                     return;
                 }


### PR DESCRIPTION
The TearDown safety-net cancelled a nonblocking collective (MPI_Ibarrier) request on timeout, which the MPI standard forbids. OpenMPI raises MPI_ERR_REQUEST and, because MPI_COMM_WORLD uses MPI_ERRORS_ARE_FATAL, that MPI_Cancel call itself aborts the job with a misleading error before the intended MPI_Abort runs. Remove the MPI_Cancel/MPI_Request_free and call MPI_Abort directly (it tears the job down anyway).

Also raise the teardown-barrier timeout 3s -> 60s (overridable via RCCL_TEST_TEARDOWN_TIMEOUT_SEC) so benign rank skew in heavy multi-phase MPI tests (GrowMPITest, NetIbMPITest CtsDepthStress) no longer trips a false 'out of sync' abort.

Test-harness only; no librccl behavior change. Recovers Grow_MultiRankJump and NetIB_CtsDepthStress (ib-cast) from false failures.

## Motivation

Fix an illegal MPI_Cancel on a nonblocking-barrier request that crashed MPI test teardown, causing passing tests to be reported as failures.

## Technical Details
MPIEnvironment::TearDown() uses an MPI_Ibarrier + poll-with-timeout as a safety net. On timeout it called MPI_Cancel(&barrier_req) — but cancelling a nonblocking collective request is forbidden by the MPI standard. OpenMPI returns MPI_ERR_REQUEST, and since MPI_COMM_WORLD uses the default MPI_ERRORS_ARE_FATAL handler, that MPI_Cancel call itself aborts the job (before the intended MPI_Abort). Fix: drop the MPI_Cancel/MPI_Request_free and call MPI_Abort directly. Also raised the barrier timeout 3s→60s (env-overridable via RCCL_TEST_TEARDOWN_TIMEOUT_SEC) so benign rank skew in heavy multi-phase tests doesn't trigger a false abort. Test-harness only; no librccl change.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
