### PR TITLE
fix(rocprofiler-compute): co-locate HBM traffic % counters in same pass

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -32,6 +32,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Optimized
 
+* HBM and remote traffic percentages are now more accurate, with all their counters collected in a single profiling pass.
+
 * Improved the profiling failure message when the workload and the profiler load different ROCm installations. The error now points to the PyTorch and `rocm[profiler]` install instructions instead of only showing the LLVM abort.
 
 ### Resolved issues

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/profiling_counter_grouping_policy.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/profiling_counter_grouping_policy.yaml
@@ -15,21 +15,43 @@
 # =============================================================================
 
 architectures:
-  # CDNA / MI-class (no default same-bucket priority set here).
+  # CDNA / MI-class: co-locate RDREQ_DRAM_sum with RDREQ_sum (and WRREQ
+  # equivalents) so HBM/Remote traffic % never exceeds 100% due to
+  # multi-pass replay variance.
   gfx908:
-    same_bucket_priority_metric_ids: {}
+    same_bucket_priority_metric_ids:
+      "3.1.63":
+        name: "HBM Read Traffic"
+      "3.1.64":
+        name: "HBM Write and Atomic Traffic"
 
   gfx90a:
-    same_bucket_priority_metric_ids: {}
+    same_bucket_priority_metric_ids:
+      "3.1.63":
+        name: "HBM Read Traffic"
+      "3.1.64":
+        name: "HBM Write and Atomic Traffic"
 
   gfx940:
-    same_bucket_priority_metric_ids: {}
+    same_bucket_priority_metric_ids:
+      "3.1.60":
+        name: "HBM Read Traffic"
+      "3.1.61":
+        name: "HBM Write and Atomic Traffic"
 
   gfx941:
-    same_bucket_priority_metric_ids: {}
+    same_bucket_priority_metric_ids:
+      "3.1.60":
+        name: "HBM Read Traffic"
+      "3.1.61":
+        name: "HBM Write and Atomic Traffic"
 
   gfx942:
-    same_bucket_priority_metric_ids: {}
+    same_bucket_priority_metric_ids:
+      "3.1.60":
+        name: "HBM Read Traffic"
+      "3.1.61":
+        name: "HBM Write and Atomic Traffic"
 
   gfx950:
     same_bucket_priority_metric_ids: {}

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/profiling_counter_grouping_policy.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/profiling_counter_grouping_policy.yaml
@@ -15,21 +15,63 @@
 # =============================================================================
 
 architectures:
-  # CDNA / MI-class (no default same-bucket priority set here).
+  # CDNA / MI-class: co-locate RDREQ_DRAM_sum with RDREQ_sum (and WRREQ
+  # equivalents) so HBM/Remote traffic % never exceeds 100% due to
+  # multi-pass replay variance.
   gfx908:
-    same_bucket_priority_metric_ids: {}
+    same_bucket_priority_metric_ids:
+      "3.1.66":
+        name: "HBM Read Traffic"
+      "3.1.67":
+        name: "HBM Write and Atomic Traffic"
+      "17.2.1":
+        name: "HBM Read Traffic"
+      "17.2.5":
+        name: "HBM Write and Atomic Traffic"
 
   gfx90a:
-    same_bucket_priority_metric_ids: {}
+    same_bucket_priority_metric_ids:
+      "3.1.66":
+        name: "HBM Read Traffic"
+      "3.1.67":
+        name: "HBM Write and Atomic Traffic"
+      "17.2.1":
+        name: "HBM Read Traffic"
+      "17.2.5":
+        name: "HBM Write and Atomic Traffic"
 
   gfx940:
-    same_bucket_priority_metric_ids: {}
+    same_bucket_priority_metric_ids:
+      "3.1.63":
+        name: "HBM Read Traffic"
+      "3.1.64":
+        name: "HBM Write and Atomic Traffic"
+      "17.2.1":
+        name: "HBM Read Traffic"
+      "17.2.5":
+        name: "HBM Write and Atomic Traffic"
 
   gfx941:
-    same_bucket_priority_metric_ids: {}
+    same_bucket_priority_metric_ids:
+      "3.1.63":
+        name: "HBM Read Traffic"
+      "3.1.64":
+        name: "HBM Write and Atomic Traffic"
+      "17.2.1":
+        name: "HBM Read Traffic"
+      "17.2.5":
+        name: "HBM Write and Atomic Traffic"
 
   gfx942:
-    same_bucket_priority_metric_ids: {}
+    same_bucket_priority_metric_ids:
+      "3.1.63":
+        name: "HBM Read Traffic"
+      "3.1.64":
+        name: "HBM Write and Atomic Traffic"
+      "17.2.1":
+        name: "HBM Read Traffic"
+      "17.2.5":
+        name: "HBM Write and Atomic Traffic"
 
   gfx950:
     same_bucket_priority_metric_ids: {}

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
@@ -15,7 +15,9 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
+import config
 from rocprof_compute_soc.soc_base import (
     CounterFile,
     LimitedSet,
@@ -24,6 +26,7 @@ from rocprof_compute_soc.soc_base import (
     _trial_counter_file_with_extra,
     flat_counters_in_perfmon_file,
 )
+from utils.utils_common import canonical_config_arch, convert_metric_id_to_panel_info
 
 # =============================================================================
 # Fixtures
@@ -62,6 +65,8 @@ BASELINE_COUNTER = "SQ_BASELINE_COUNTER"  # table 201, outside block 30
 TABLE_3012_COUNTER = "TCC_BOTTLENECK_COUNTER"  # block 30, table 3012
 TABLE_3013_COUNTER = "TCC_EA_COUNTER"  # block 30, table 3013
 FIXTURE_COUNTERS = {BASELINE_COUNTER, TABLE_3012_COUNTER, TABLE_3013_COUNTER}
+
+HBM_TRAFFIC_METRIC_NAMES = {"HBM Read Traffic", "HBM Write and Atomic Traffic"}
 
 
 @pytest.fixture
@@ -177,6 +182,28 @@ def apply_cp_util_priority_patches(soc: OmniSoC_Base, patch_stack: ExitStack) ->
             ]),
         )
     )
+
+
+def _resolve_metric_name(config_dir: Path, arch: str, metric_id: str) -> str | None:
+    """Look up the metric name for *metric_id* in the analysis YAML tree."""
+    file_id, panel_id, metric_idx = convert_metric_id_to_panel_info(metric_id)
+    arch_dir = config_dir / (canonical_config_arch(arch) or arch)
+    for ypath in sorted(arch_dir.glob("*.yaml")):
+        if not ypath.name.startswith(file_id):
+            continue
+        doc = yaml.safe_load(ypath.read_text(encoding="utf-8"))
+        if not isinstance(doc, dict):
+            continue
+        sources = doc.get("Panel Config", {}).get("data source", [])
+        for src in sources:
+            mt = src.get("metric_table", {})
+            if mt.get("id") != panel_id:
+                continue
+            metrics = mt.get("metric", {})
+            for idx, name in enumerate(metrics):
+                if idx == metric_idx:
+                    return name
+    return None
 
 
 # =============================================================================
@@ -554,8 +581,29 @@ def test_same_bucket_priority_resolves_gfx115x_policy(gpu_arch):
     assert "17.1.0" in ids
 
 
-def test_same_bucket_priority_empty_for_gfx942():
-    soc = _make_soc(PERFMON_CONFIG, arch="gfx942")
+@pytest.mark.parametrize("gpu_arch", ["gfx908", "gfx90a", "gfx940", "gfx941", "gfx942"])
+def test_same_bucket_priority_hbm_traffic_ids_match_yaml(gpu_arch):
+    """Policy metric IDs must resolve to 'HBM Read Traffic' and
+    'HBM Write and Atomic Traffic' in the analysis YAMLs.  Guards against
+    metric index drift after YAML re-org."""
+    config_dir = (
+        Path(config.rocprof_compute_home) / "rocprof_compute_soc" / "analysis_configs"
+    )
+    soc = _make_soc(PERFMON_CONFIG, arch=gpu_arch)
+    ids = soc._same_bucket_priority_metric_ids()
+    resolved = [_resolve_metric_name(config_dir, gpu_arch, mid) for mid in ids]
+    assert None not in resolved, (
+        f"{gpu_arch}: some policy IDs did not resolve: "
+        f"{[mid for mid, name in zip(ids, resolved) if name is None]}"
+    )
+    unexpected = set(resolved) - HBM_TRAFFIC_METRIC_NAMES
+    assert not unexpected, (
+        f"{gpu_arch}: policy IDs resolve to unexpected metrics: {unexpected}"
+    )
+
+
+def test_same_bucket_priority_empty_for_gfx950():
+    soc = _make_soc(PERFMON_CONFIG, arch="gfx950")
     assert soc._same_bucket_priority_metric_ids() == ()
 
 


### PR DESCRIPTION
## Motivation

The memory chart rich layout (#8648 ) displays HBM and Remote traffic percentages in the Data Fabric panel. These metrics can report values exceeding 100% (for example, `fma_throughput<int>` shows 207% HBM Read and 140% HBM Write) because the numerator (`RDREQ_DRAM_sum`) and denominator (`RDREQ_sum`) are collected in separate profiling passes. Each pass replays the kernel, and non-deterministic kernels produce different counter values across replays.

## Technical Details

Add same-bucket priority entries for gfx908-gfx942 so the metric-aware coalesce pass places each ratio's counters together. The hardware guarantees DRAM ≤ total within a single pass, eliminating the >100% artifact.

### Impact on other metrics

Grouping these 4 counters together uses all 4 TCC slots in one pass (the hardware limit per pass), which displaces `RDREQ_sum` and `WRREQ_sum` from their current passes. This affects three metrics that previously shared a pass with those counters:
| Metric | Where displayed |
|--------|-----------------|
| Fabric Rd Latency | SOL table, Dash web UI (not in memory chart rich layout) |
| Uncached Read Traffic | L2 Cache table only |
| Uncached Write Traffic | L2 Cache table only |

However, these metrics are only defined in their respective analysis YAML files; none are consumed in any dedicated rendering code (memory chart of roofline) beyond their YAML definitions.

## Issue Tracking

JIRA ID: AIPROFCOMP-776

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
