### PR TITLE
fix(rocr/aie): improve memory allocation handling for device heap addresses

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -749,12 +749,13 @@ hsa_status_t XdnaDriver::AllocateMemory(const core::MemoryRegion& mem_region,
 
   bo_guard.Dismiss();
 
-  // The handle word is the driver-native BO id. vaddr is set only when the driver
-  // owns the mapping (share BOs), so FreeMemory unmaps exactly those; dev-SVM
-  // allocations share the device-heap mapping and leave vaddr null. Export-only
-  // fields stay at defaults.
+  // The handle word is the driver-native BO id. vaddr is always the allocation's
+  // real VA (the dev-heap VA for dev-SVM BOs, the mmap'd VA for share BOs), so it
+  // resolves at submit time and can be written at load time. FreeMemory decides
+  // whether to unmap by the VA itself (dev-heap range vs. an owned mmap), so no
+  // ownership flag is carried. Export-only fields stay at defaults.
   handle->handle = bo_handle.handle;
-  handle->vaddr = bo_handle.unmap_vaddr ? bo_handle.vaddr : nullptr;
+  handle->vaddr = bo_handle.vaddr;
   handle->size = size;
 
   return HSA_STATUS_SUCCESS;
@@ -768,10 +769,12 @@ hsa_status_t XdnaDriver::FreeMemory(const core::DriverMemoryHandle& handle) {
   BOHandle bo_handle;
   bo_handle.handle = static_cast<uint32_t>(handle.handle);
   bo_handle.size = handle.size;
-  // vaddr is set only when the driver owns the mapping; DestroyBOHandle unmaps
-  // exactly those.
+  // Unmap only share BOs, which own an independent mmap. Dev-SVM allocations carve
+  // their VA out of the shared device heap and must leave that mapping intact; they
+  // are recognized by the VA falling inside the device-heap range. A null vaddr
+  // (AllocateMemoryOnly share BOs) has nothing to unmap.
   bo_handle.vaddr = handle.vaddr;
-  bo_handle.unmap_vaddr = handle.vaddr != nullptr;
+  bo_handle.unmap_vaddr = (handle.vaddr != nullptr) && !IsDevHeapVA(handle.vaddr);
 
   return DestroyBOHandle(bo_handle);
 }
@@ -1098,6 +1101,12 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) con
   cmd_bo_handle = tmp_cmd_bo_handle;
 
   return HSA_STATUS_SUCCESS;
+}
+
+bool XdnaDriver::IsDevHeapVA(const void* vaddr) const {
+  const auto addr = reinterpret_cast<uintptr_t>(vaddr);
+  const auto base = reinterpret_cast<uintptr_t>(dev_heap_aligned);
+  return (addr >= base) && (addr < base + dev_heap_size);
 }
 
 hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* queue_metadata,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -769,10 +769,10 @@ hsa_status_t XdnaDriver::FreeMemory(const core::DriverMemoryHandle& handle) {
   BOHandle bo_handle;
   bo_handle.handle = static_cast<uint32_t>(handle.handle);
   bo_handle.size = handle.size;
-  // Unmap only share BOs, which own an independent mmap. Dev-SVM allocations carve
+  // Unmap only BO_SHAREs, which own an independent mmap. BO_DEV_HEAP allocations carve
   // their VA out of the shared device heap and must leave that mapping intact; they
   // are recognized by the VA falling inside the device-heap range. A null vaddr
-  // (AllocateMemoryOnly share BOs) has nothing to unmap.
+  // (AllocateMemoryOnly BO_SHAREs) has nothing to unmap.
   bo_handle.vaddr = handle.vaddr;
   bo_handle.unmap_vaddr = (handle.vaddr != nullptr) && !IsDevHeapVA(handle.vaddr);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -1104,9 +1104,10 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) con
 }
 
 bool XdnaDriver::IsDevHeapVA(const void* vaddr) const {
+  if (dev_heap_aligned == nullptr) return false;
   const auto addr = reinterpret_cast<uintptr_t>(vaddr);
   const auto base = reinterpret_cast<uintptr_t>(dev_heap_aligned);
-  return (addr >= base) && (addr < base + dev_heap_size);
+  return (addr >= base) && ((addr - base) < dev_heap_size);
 }
 
 hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* queue_metadata,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -63,6 +63,7 @@
 #include "core/inc/runtime.h"
 #include "core/inc/signal.h"
 #include "core/util/memory.h"
+#include "core/util/os.h"
 #include "core/util/utils.h"
 #include "uapi/amdxdna_accel.h"
 
@@ -732,27 +733,25 @@ hsa_status_t XdnaDriver::AllocateMemory(const core::MemoryRegion& mem_region,
   if (use_bo_share) {
     if (alloc_flags & core::MemoryRegion::AllocateMemoryOnly) {
       bo_handle.vaddr = nullptr;
-      bo_handle.unmap_vaddr = false;
     } else {
       bo_handle.vaddr =
           mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, get_bo_info_args.map_offset);
       if (bo_handle.vaddr == MAP_FAILED) {
+        // bo_guard must not try to unmap MAP_FAILED.
+        bo_handle.vaddr = nullptr;
         return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
       }
-      bo_handle.unmap_vaddr = true;
     }
   } else {
     /// This is dev heap and is already mapped. See InitDeviceHeap().
     bo_handle.vaddr = reinterpret_cast<void*>(get_bo_info_args.vaddr);
-    bo_handle.unmap_vaddr = false;
   }
 
   bo_guard.Dismiss();
 
-  // The handle word is the driver-native BO id. vaddr is always the allocation's
-  // real VA (the dev-heap VA for dev-SVM BOs, the mmap'd VA for share BOs), so it
-  // resolves at submit time and can be written at load time. FreeMemory decides
-  // whether to unmap by the VA itself (dev-heap range vs. an owned mmap), so no
+  // The handle word is the driver-native BO id. vaddr is the allocation's real VA (the VA for dev
+  // heap BOs, the mmap'd VA for share BOs). It is nullptr only for AllocateMemoryOnly SHARE BOs.
+  // FreeMemory decides whether to unmap by the VA itself (dev heap range vs. an owned mmap), so no
   // ownership flag is carried. Export-only fields stay at defaults.
   handle->handle = bo_handle.handle;
   handle->vaddr = bo_handle.vaddr;
@@ -769,12 +768,7 @@ hsa_status_t XdnaDriver::FreeMemory(const core::DriverMemoryHandle& handle) {
   BOHandle bo_handle;
   bo_handle.handle = static_cast<uint32_t>(handle.handle);
   bo_handle.size = handle.size;
-  // Unmap only BO_SHAREs, which own an independent mmap. BO_DEV_HEAP allocations carve
-  // their VA out of the shared device heap and must leave that mapping intact; they
-  // are recognized by the VA falling inside the device-heap range. A null vaddr
-  // (AllocateMemoryOnly BO_SHAREs) has nothing to unmap.
   bo_handle.vaddr = handle.vaddr;
-  bo_handle.unmap_vaddr = (handle.vaddr != nullptr) && !IsDevHeapVA(handle.vaddr);
 
   return DestroyBOHandle(bo_handle);
 }
@@ -990,7 +984,6 @@ hsa_status_t XdnaDriver::DestroyMemoryHandle(core::DriverMemoryHandle* handle) {
   if (err != HSA_STATUS_SUCCESS) {
     return err;
   }
-
   *handle = {};
 
   return HSA_STATUS_SUCCESS;
@@ -1020,49 +1013,65 @@ hsa_status_t XdnaDriver::InitDeviceHeap() {
   if (err != HSA_STATUS_SUCCESS) {
     return err;
   }
+  dev_heap_bo = create_bo_args.handle;
 
-  dev_heap_handle.handle = create_bo_args.handle;
-
-  // Unmap memory and close the BO in case of error.
-  MAKE_NAMED_SCOPE_GUARD(dev_heap_handle_guard, [&] { DestroyBOHandle(dev_heap_handle); });
+  // Unmap memory and close the dev heap BO in case of error.
+  MAKE_NAMED_SCOPE_GUARD(dev_heap_guard, [&] { FreeDeviceHeap(); });
 
   amdxdna_drm_get_bo_info get_bo_info_args = {};
-  get_bo_info_args.handle = dev_heap_handle.handle;
+  get_bo_info_args.handle = dev_heap_bo;
   err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args);
   if (err != HSA_STATUS_SUCCESS) {
     return err;
   }
 
-  const size_t size = dev_heap_align * 2 - 1;
-  dev_heap_handle.vaddr =
-      mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-  if (dev_heap_handle.vaddr == MAP_FAILED) {
-    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-  }
-  dev_heap_handle.unmap_vaddr = true;
-  dev_heap_handle.size = size;
-
-  void* addr_aligned = reinterpret_cast<void*>(
-      AlignUp(reinterpret_cast<uintptr_t>(dev_heap_handle.vaddr), dev_heap_align));
-
-  dev_heap_aligned =
-      mmap(addr_aligned, dev_heap_size, PROT_READ | PROT_WRITE,
-           MAP_SHARED | MAP_FIXED, fd_, get_bo_info_args.map_offset);
-  if (dev_heap_aligned == MAP_FAILED) {
-    dev_heap_aligned = nullptr;
+  // ReserveMemory over-allocates, aligns, and trims the slack, leaving exactly one
+  // dev_heap_size mapping to own.
+  void* heap = os::ReserveMemory(nullptr, dev_heap_size, dev_heap_alignment, os::MEM_PROT_NONE);
+  if (heap == nullptr) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
-  dev_heap_handle_guard.Dismiss();
+  if (!os::MapMemory(heap, dev_heap_size, os::MEM_PROT_RW, fd_, get_bo_info_args.map_offset)) {
+    os::ReleaseMemory(heap, dev_heap_size);
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+  dev_heap_vaddr = heap;
+
+  dev_heap_guard.Dismiss();
 
   return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t XdnaDriver::FreeDeviceHeap() {
-  hsa_status_t err = DestroyBOHandle(dev_heap_handle);
-  assert(err == HSA_STATUS_SUCCESS && "Failed to destroy device heap BO handle.");
-  dev_heap_aligned = nullptr;
-  return err;
+  if (dev_heap_bo == AMDXDNA_INVALID_BO_HANDLE) {
+    return HSA_STATUS_SUCCESS;
+  }
+
+  // Unmap dev heap.
+  hsa_status_t munmap_err = HSA_STATUS_SUCCESS;
+  if (dev_heap_vaddr != nullptr && !os::ReleaseMemory(dev_heap_vaddr, dev_heap_size)) {
+    munmap_err = HSA_STATUS_ERROR;
+    assert(false && "Failed to unmap device heap BO.");
+  }
+
+  // dev_heap_vaddr is deliberately left set: DestroyBOHandle uses IsDevHeapVA() to
+  // recognize dev heap allocations that carve their VA out of the heap and must not be
+  // unmapped. Clearing it here would make a dev heap freed after teardown munmap a VA
+  // range that has since been recycled. InitDeviceHeap() overwrites it on re-init.
+
+  // Close the BO.
+  drm_gem_close close_bo_args = {};
+  close_bo_args.handle = dev_heap_bo;
+  hsa_status_t ioctl_err = xdna_ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
+  assert(ioctl_err == HSA_STATUS_SUCCESS && "Failed to destroy device heap BO handle.");
+  if (ioctl_err != HSA_STATUS_SUCCESS) {
+    return ioctl_err;
+  }
+
+  dev_heap_bo = AMDXDNA_INVALID_BO_HANDLE;
+
+  return munmap_err;
 }
 
 hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) const {
@@ -1094,7 +1103,6 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) con
     return HSA_STATUS_ERROR;
   }
   tmp_cmd_bo_handle.vaddr = mem;
-  tmp_cmd_bo_handle.unmap_vaddr = true;
 
   tmp_cmd_bo_handle_guard.Dismiss();
 
@@ -1104,9 +1112,9 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) con
 }
 
 bool XdnaDriver::IsDevHeapVA(const void* vaddr) const {
-  if (dev_heap_aligned == nullptr) return false;
+  if (dev_heap_vaddr == nullptr) return false;
   const auto addr = reinterpret_cast<uintptr_t>(vaddr);
-  const auto base = reinterpret_cast<uintptr_t>(dev_heap_aligned);
+  const auto base = reinterpret_cast<uintptr_t>(dev_heap_vaddr);
   return (addr >= base) && ((addr - base) < dev_heap_size);
 }
 
@@ -1361,27 +1369,28 @@ hsa_status_t XdnaDriver::DestroyBOHandle(BOHandle& bo_handle) const {
 
   hsa_status_t unmap_err = HSA_STATUS_SUCCESS;
 
-  // Unmap the memory.
-  if (bo_handle.unmap_vaddr) {
+  // Unmap only non-null BO_SHAREs, which own an independent mmap. Dev heap allocations carve
+  // their VA out of the shared device heap and must leave that mapping intact; they
+  // are recognized by the VA falling inside the device-heap range.
+  if ((bo_handle.vaddr != nullptr) && !IsDevHeapVA(bo_handle.vaddr)) {
     if (munmap(bo_handle.vaddr, bo_handle.size) != 0) {
       unmap_err = HSA_STATUS_ERROR;
       assert(false && "Failed to unmap BO memory.");
     } else {
-      bo_handle.unmap_vaddr = false;
       bo_handle.vaddr = nullptr;
       bo_handle.size = 0;
     }
   }
 
-  // Close the BO handle.
+  // Close the BO.
   drm_gem_close close_bo_args = {};
   close_bo_args.handle = bo_handle.handle;
   hsa_status_t ioctl_err = xdna_ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
-  bo_handle.handle = AMDXDNA_INVALID_BO_HANDLE;
-
   if (ioctl_err != HSA_STATUS_SUCCESS) {
     return ioctl_err;
   }
+  bo_handle.handle = AMDXDNA_INVALID_BO_HANDLE;
+
   return unmap_err;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -69,8 +69,6 @@ class XdnaDriver final : public core::Driver {
     uint32_t handle = 0;
     /// Size in bytes.
     size_t size = 0;
-    /// True if @ref vaddr needs to be unmapped.
-    bool unmap_vaddr = false;
 
     constexpr BOHandle() = default;
     constexpr BOHandle(void* vaddr, uint32_t handle, size_t size)
@@ -199,10 +197,10 @@ public:
   /// @brief Queries the driver version and updates internal state.
   hsa_status_t QueryDriverVersion();
 
-  /// @brief Allocate device accessible heap space.
+  /// @brief Allocate device accessible heap (dev heap) space.
   hsa_status_t InitDeviceHeap();
 
-  /// @brief Free device accessible heap space.
+  /// @brief Free device accessible heap (dev heap) space.
   hsa_status_t FreeDeviceHeap();
 
   /// @brief Creates a command BO and returns it to @p bo_info.
@@ -211,26 +209,28 @@ public:
   /// @param[out] bo_info allocated BO
   hsa_status_t CreateCmdBO(uint32_t size, BOHandle& bo_info) const;
 
-  /// @brief Returns true if @p vaddr lies within the shared device-heap mapping.
+  /// @brief Returns true if @p vaddr lies within the dev heap mapping.
   ///
-  /// Dev-SVM BOs carve their VA out of the device heap and borrow its mapping, so
+  /// Dev heap BOs carve their VA out of the device heap and borrow its mapping, so
   /// FreeMemory must not unmap them. This lets FreeMemory distinguish those from
-  /// share BOs (which own an independent mmap) by the VA alone, without the caller
+  /// BO_SHAREs (which own an independent mmap) by the VA alone, without the caller
   /// tracking mapping ownership.
   bool IsDevHeapVA(const void* vaddr) const;
 
-  /// @brief Virtual address range allocated for the device heap.
+  /// @brief Device heap BO.
   ///
-  /// Allocate a large enough space so we can carve out the device heap in
-  /// this range and ensure it is aligned to 64MB. Currently, npu1 supports
-  /// 64MB device heap and it must be aligned to 64MB.
-  BOHandle dev_heap_handle;
+  /// Its mapping is @ref dev_heap_vaddr, which BO_DEV allocations carve their VA out of.
+  uint32_t dev_heap_bo = 0;
 
-  /// @brief The aligned device heap.
-  void *dev_heap_aligned = nullptr;
+  /// @brief The aligned device heap mapping, of size @ref dev_heap_size and alignment
+  /// @ref dev_heap_alignment.
+  void* dev_heap_vaddr = nullptr;
 
+  /// @brief Device heap size in bytes.
   static constexpr size_t dev_heap_size = 64 * 1024 * 1024;
-  static constexpr size_t dev_heap_align = 64 * 1024 * 1024;
+
+  /// @brief Device heap alignment in bytes.
+  static constexpr size_t dev_heap_alignment = 64 * 1024 * 1024;
 };
 
 } // namespace AMD

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -211,6 +211,14 @@ public:
   /// @param[out] bo_info allocated BO
   hsa_status_t CreateCmdBO(uint32_t size, BOHandle& bo_info) const;
 
+  /// @brief Returns true if @p vaddr lies within the shared device-heap mapping.
+  ///
+  /// Dev-SVM BOs carve their VA out of the device heap and borrow its mapping, so
+  /// FreeMemory must not unmap them. This lets FreeMemory distinguish those from
+  /// share BOs (which own an independent mmap) by the VA alone, without the caller
+  /// tracking mapping ownership.
+  bool IsDevHeapVA(const void* vaddr) const;
+
   /// @brief Virtual address range allocated for the device heap.
   ///
   /// Allocate a large enough space so we can carve out the device heap in

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -74,8 +74,9 @@ struct DriverMemoryHandle {
   /// - allocation address / thunk buffer handle for @ref KfdDriver
   /// - XDNA BO handle for @ref XdnaDriver
   uint64_t handle{};
-  /// Virtual address mmap'd by the driver for this allocation, or nullptr if the
-  /// driver does not own a mapping. When set, FreeMemory unmaps it.
+  /// Virtual address of this allocation, or nullptr if the driver exposes none.
+  /// Whether FreeMemory unmaps it is driver-defined: an allocation may borrow a
+  /// mapping owned by something else, in which case FreeMemory leaves it intact.
   void* vaddr{};
   int dmabuf_fd{-1};
   uint64_t mmap_offset{0};


### PR DESCRIPTION
## Motivation

The `XdnaDriver` is responsible for unmapping memory; the previous solution was breaking the contract on if memory is mapped or not.

## Technical Details

The contract from the driver API states that vaddr is set if a mapping exists. The previous solution was breaking that contract. The current change satisfies the contract and makes `XdnaDriver` the responsible party on when to unmap and when not.

## Issue Tracking

Follow-up on https://github.com/ROCm/rocm-systems/issues/8448

## Test Plan

- rocrtst
- Provisional NPU unit tests from https://github.com/ROCm/rocm-systems/tree/users/ypapadop-amd/aie-tests/projects/rocr-runtime/rocrtst/suites/aie
  - Single packet dispatch
  - Multi packet dispatch
  - Sliding window dispatch
  - Memory allocation 
  - Memory sharing via vmem API

## Test Result

Success.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
