### PR TITLE
fix(topo_expl): avoid fabric type redefinition on newer ROCm headers

### DIFF
--- a/projects/rccl/src/include/mem_manager.h
+++ b/projects/rccl/src/include/mem_manager.h
@@ -25,7 +25,9 @@ extern "C" {
 #ifndef HIP_IPC_HANDLE_SIZE
 #define HIP_IPC_HANDLE_SIZE 64
 #endif
-typedef struct hipMemFabricHandle_st {
+// AICOMRCCL-1629: anonymous tag; newer HIP defines struct hipMemFabricHandle_st,
+// which this compat type redefined when HIP_FABRIC_API is unset.
+typedef struct {
   unsigned char data[HIP_IPC_HANDLE_SIZE];
 } hipMemFabricHandle_compat_t;
 #else

--- a/projects/rccl/tools/topo_expl/Makefile
+++ b/projects/rccl/tools/topo_expl/Makefile
@@ -33,10 +33,19 @@ CXXFLAGS = -g -ffunction-sections -fdata-sections -DROCM_VERSION=$(ROCM_VERSION)
            -Wl,--gc-sections -fgpu-rdc \
            -Iinclude -Itest -Ihipify_rccl/include -Ihipify_rccl/include/plugin \
 		   -Ihipify_rccl/include/nccl_device \
-           -Ihipify_rccl/src/device/include -Ihipify_rccl/graph -I/opt/rocm/include/ \
+           -Ihipify_rccl/src/device/include -Ihipify_rccl/graph -I$(ROCM_PATH)/include/ \
            -DTOPO_EXPL -DENABLE_TRACE -DENABLE_LL128 -DNVTX_NO_IMPL -DRCCL_EXPOSE_STATIC \
            $(NCCL_OS_DEFINE) \
            -lpthread
+
+# AICOMRCCL-1629: set AMDSMI_FABRIC_DIRECT when amd_smi provides the fabric API,
+# else amdsmi_wrap.h's compat types redefine the real ones. CMake does this for
+# the main build; the standalone build must probe.
+HAVE_AMDSMI_FABRIC := $(shell printf '#include <amd_smi/amdsmi.h>\namdsmi_fabric_info_t topo_expl_amdsmi_probe_;\n' | \
+                        $(HIPCC) -xc++ -std=c++17 -I$(ROCM_PATH)/include -fsyntax-only - >/dev/null 2>&1 && echo yes || echo no)
+ifeq ($(HAVE_AMDSMI_FABRIC),yes)
+  CXXFLAGS += -DAMDSMI_FABRIC_DIRECT
+endif
 
 TOPO_EXPL_FILES = src/$(EXE).cpp src/topo_expl_api.cpp src/model.cpp src/topo_expl_impl.cpp src/utils.cpp src/stubs.cc test/topo_expl_tests.cpp
 


### PR DESCRIPTION
Skip the HIP/amd_smi fabric compat definitions when the installed headers already provide them, so the standalone topo_expl build stops colliding.

## Motivation

RCCL CI builds are failing (at tools/topo_expl) due to ROCM version change (7.13 -> 7.14)

## Technical Details

Skip the HIP/amd_smi fabric compat definitions when the installed headers  already provide them, so the standalone topo_expl build stops colliding.

## Issue Tracking

JIRA ID: AICOMRCCL-1629

## Test Plan

CI runs, no new plan is required

## Test Result
CI runs should pass

## Submission Checklist