### PR TITLE
ci(rocprofiler-sdk): fix Advanced Analysis build against TheRock rocm_sysdeps layout

### DIFF
--- a/.github/workflows/rocprofiler-sdk-codeql.yml
+++ b/.github/workflows/rocprofiler-sdk-codeql.yml
@@ -143,7 +143,7 @@ jobs:
       run: |
         cd projects/rocprofiler-sdk
         python3 -m pip install -U --user -r requirements.txt
-        cmake -B /tmp/build -DCMAKE_PREFIX_PATH=/opt/rocm ${{ env.GLOBAL_CMAKE_OPTIONS }} -DPython3_EXECUTABLE=$(which python3) .
+        cmake -B /tmp/build -DCMAKE_PREFIX_PATH="/opt/rocm;/opt/rocm/lib/rocm_sysdeps" ${{ env.GLOBAL_CMAKE_OPTIONS }} -DPython3_EXECUTABLE=$(which python3) .
         cmake --build /tmp/build --target all --parallel 16
         rm -rf ${EXCLUDED_PATHS}
 

--- a/projects/rocprofiler-sdk/docker/Dockerfile.ci
+++ b/projects/rocprofiler-sdk/docker/Dockerfile.ci
@@ -93,7 +93,17 @@ RUN set -euo pipefail; \
 # Nightly Tarball
 # The TheRock tarball ships the OpenMP runtime (libomp.so), LLVM, and bundled system deps under
 # lib/llvm/lib and lib/rocm_sysdeps/lib. These directories are not on the default dynamic-linker
-# search path. Register them via ldconfig
+# search path, so register them via ldconfig.
+#
+# TheRock nightly tarballs also ship some bundled rocm_sysdeps pkg-config (.pc) files with
+# non-relocatable, absolute build-stage prefixes (e.g. zlib.pc has
+# prefix=/__w/.../stage/lib/rocm_sysdeps). elfutils' libdw.pc/libelf.pc pull zlib in via
+# "Requires.private: zlib", so that dead path leaks through pkg_check_modules into the imported
+# rocprofiler-sdk target and breaks configure with "includes non-existent path
+# .../rocm_sysdeps/include in its INTERFACE_INCLUDE_DIRECTORIES". Rewrite those build-stage paths
+# to the relocatable ${pcfiledir} form so they resolve relative to the installed location.
+# Idempotent: only lines containing a build-stage rocm_sysdeps path are touched, so this is a
+# no-op once ROCm/TheRock#6906 is fixed.
 RUN set -euo pipefail; \
     if [ $(grep -i "sles" /etc/os-release | wc -l) -gt 0 ]; then \
         source rocprofiler-sdk/bin/activate; \
@@ -105,6 +115,8 @@ RUN set -euo pipefail; \
     mkdir -p /opt/rocm && \
     tar -xf /tmp/rocm-${GPU_TYPE}.tar.gz -C /opt/rocm && \
     rm -f /tmp/rocm-${GPU_TYPE}.tar.gz && \
+    find /opt/rocm -name '*.pc' -path '*rocm_sysdeps*' -print0 \
+        | xargs -0 --no-run-if-empty sed -i -E 's#/[^ =]*/stage/lib/rocm_sysdeps#${pcfiledir}/../..#g' && \
     printf '/opt/rocm/lib\n/opt/rocm/lib/llvm/lib\n/opt/rocm/lib/llvm/lib/%s\n/opt/rocm/lib/rocm_sysdeps/lib\n' \
        "$(/opt/rocm/lib/llvm/bin/amdclang --print-target-triple)" > /etc/ld.so.conf.d/rocm.conf && \
     ldconfig


### PR DESCRIPTION
## Technical Details
- **`.github/workflows/rocprofiler-sdk-codeql.yml`** — add `/opt/rocm/lib/rocm_sysdeps` to `CMAKE_PREFIX_PATH` so `find_package` can locate the sysdep-provided CMake configs (NUMA, etc.).
- **`projects/rocprofiler-sdk/docker/Dockerfile.ci`** — after extracting the nightly tarball, rewrite the non-relocatable build-stage prefixes in bundled `rocm_sysdeps/*.pc` files to the relocatable `${pcfiledir}` form so they resolve relative to the install location. The `sed` only touches lines containing a build-stage `rocm_sysdeps` path, so it is idempotent and becomes a no-op once the upstream packaging bug is fixed.


## Issue Tracking

Workaround for the `.pc` packaging bug: ROCm/TheRock#6906
(https://github.com/ROCm/TheRock/issues/6906). The `Dockerfile.ci`
rewrite can be dropped once that is fixed.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
