### PR TITLE
fix(rocprofiler-compute): cap vcopy mismatch reporting and fail on verification error

### DIFF
--- a/projects/rocprofiler-compute/sample/vcopy.cpp
+++ b/projects/rocprofiler-compute/sample/vcopy.cpp
@@ -85,8 +85,6 @@ int main(int argc, char* argv[]) {
   int devId = 0;
   int numIter = 1;
 
-  hipError_t hip_status;
-
   for (int i = 0; i < argc; i++){
     std::string arg = argv[i];
     if ((arg == "--blockSize" || arg == "-b") && i+1 < argc)
@@ -225,5 +223,5 @@ int main(int argc, char* argv[]) {
   free(h_b);
   free(h_c);
 
-  return 0;
+  return numErrors > 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/projects/rocprofiler-compute/sample/vcopy.cpp
+++ b/projects/rocprofiler-compute/sample/vcopy.cpp
@@ -12,6 +12,24 @@ using namespace std;
 
 #define HIP_ASSERT(x) (assert((x)==hipSuccess))
 
+// Unlike HIP_ASSERT, this reports the failing call and error string, and stays
+// active when NDEBUG is defined.
+#define HIP_CHECK(x)                                                           \
+  do {                                                                         \
+    hipError_t _hip_check_err = (x);                                           \
+    if (_hip_check_err != hipSuccess) {                                        \
+      fflush(stdout); /* keep the error in sequence when stdout is a pipe */   \
+      fprintf(stderr, "HIP error at %s:%d in '%s': %s (%d)\n", __FILE__,       \
+              __LINE__, #x, hipGetErrorString(_hip_check_err),                 \
+              (int)_hip_check_err);                                            \
+      exit(EXIT_FAILURE);                                                      \
+    }                                                                          \
+  } while (0)
+
+// Cap on how many individual mismatches are printed. A failed launch leaves
+// every element mismatched, which is millions of lines for a typical -n.
+#define MAX_REPORTED_ERRORS 10
+
 // HIP kernel. Each thread takes care of one element of c
 __global__ void vecCopy(double *a, double *b, double *c, int n, int stride) {
     // Get our global thread ID
@@ -151,12 +169,16 @@ int main(int argc, char* argv[]) {
   // Execute the kernel
   for(int i = 0; i < numIter; i++){
     hipLaunchKernelGGL(vecCopy, dim3(gridSize), dim3(blockSize), 0, 0, d_a, d_b, d_c, n, stride);
-    hip_status = hipDeviceSynchronize();
+    // Catches launch-time failures (e.g. no kernel image for this device);
+    // hipDeviceSynchronize() catches failures during execution.
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
     printf("Finished executing kernel\n");
     // Optionally, launch a second kernel. Only here for testing purposes
     if (multiKernel){
       hipLaunchKernelGGL(vecCopy_2, dim3(gridSize), dim3(blockSize), 0, 0, d_a, d_b, d_c, n, stride);
-      hip_status = hipDeviceSynchronize();
+      HIP_CHECK(hipGetLastError());
+      HIP_CHECK(hipDeviceSynchronize());
       printf("Finished executing kernel\n");
     }
   }
@@ -172,10 +194,19 @@ int main(int argc, char* argv[]) {
   }
 
   // Verfiy results
+  int numErrors = 0;
   for(int i = 0; i < n; i++) {
-    if (abs(h_verify_c[i*stride] - h_c[i*stride]) > 1e-5)
-      printf("Error at position i %d, Expected: %f, Found: %f \n", i, h_c[i], d_c[i]);
+    if (abs(h_verify_c[i*stride] - h_c[i*stride]) > 1e-5) {
+      if (numErrors < MAX_REPORTED_ERRORS)
+        printf("Error at position i %d, Expected: %f, Found: %f \n", i,
+               h_verify_c[i*stride], h_c[i*stride]);
+      numErrors++;
+    }
   }
+  if (numErrors > MAX_REPORTED_ERRORS)
+    printf("... %d further mismatches not shown\n", numErrors - MAX_REPORTED_ERRORS);
+  if (numErrors > 0)
+    printf("Verification FAILED: %d of %d elements mismatched\n", numErrors, n);
   //printf("Printing few elements from the output vector\n");
   for(int i = 0; i < 20; i++) {
     //printf("Output[%d]:%f\n",i, h_c[i]);


### PR DESCRIPTION
JIRA ID: N/A

## Problem

`vcopy` prints one line per mismatched element and ignores the result of the
kernel launch and `hipDeviceSynchronize()`. When a run produces an all-zero
output buffer, every element mismatches, so each invocation emits 1,048,575
error lines and still exits 0.

`config["app_1"]` is `vcopy` and is the default `app_name` in the profiling
fixture (`tests/conftest.py:275`), so roughly 65 tests run it, each replaying
the app once per counter pass. Run 30114683973 produced a log still streaming
past 4.4 GB, with 2,898,277 error lines inside the first 400 MB from only three
invocations, while CTest was still on test 2 of 50. That is the 2+ hour timeout.

The printed values were also wrong: the message reported `h_c[i]` as "Expected"
(the found array) and `d_c[i]`, a host dereference of a device pointer.

## Fix

- Cap individual mismatch reporting at 10, followed by a count of the remainder
  and a `Verification FAILED` summary line.
- Print the real expected/found values.
- Return `EXIT_FAILURE` when any element mismatched. `run_prof()` already checks
  the workload's return code and calls `console_error()`, which exits 1, so
  profiling now stops on the first counter pass rather than replaying a broken
  app ~65 times.
- Check `hipGetLastError()` and `hipDeviceSynchronize()` after each launch via a
  new `HIP_CHECK` macro that reports the failing call and error string. This does
  not fire on the failure seen in run 30114683973, where the kernel reported
  success and returned zeros anyway; it covers launch-time failures such as an
  architecture mismatch, where it names the HIP error instead of leaving a
  million mismatch lines as the only symptom.
- Drop the unused `hip_status` declaration.

A passing run is unchanged.

## Test Plan

Build `sample/vcopy.cpp` with the flags the project actually uses (`-O2`,
`--offload-arch=gfx942`; note `CMakeLists.txt:159` overrides the default Release
flags so `NDEBUG` is not set) and run both the working path and a stubbed kernel
that writes nothing, reproducing the all-zero condition from the CI log.

## Test Result

Works locally on gfx942.

Normal run: unchanged, exit 0, no mismatches.

Stubbed kernel, reproducing the CI condition:

```
Error at position i 1, Expected: 1.000000, Found: 0.000000
... (10 total)
... 1048565 further mismatches not shown
Verification FAILED: 1048575 of 1048576 elements mismatched
EXIT: 1
```

1,048,575 mismatches beginning at index 1, matching the CI log signature, now
reported in 12 lines instead of 1,048,575, with a non-zero exit.