### PR TITLE
fix(rccl): Fix CE collective hang under graph capture

### DIFF
--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -409,6 +409,66 @@ fail:
   goto exit;
 }
 
+// Capture: issue peer writes as a separate stream batch so the captured graph
+// orders write → wait → reset (reset is a second batch in ncclMemOpSync). Fusing
+// write+wait+reset in one HIP batch can hang on replay.
+static ncclResult_t ncclPrepUCSyncCapture(struct ncclComm* comm, bool isComplete, uint32_t* readyPtrs,
+                                         uint32_t* completePtrs, uint32_t waitValue, cudaStream_t stream) {
+  ncclResult_t ret = ncclSuccess;
+  hipStreamBatchMemOpParams* writeParams = nullptr;
+  size_t writeIdx = 0;
+  void* dstPtr = isComplete ? (void*)&completePtrs[comm->rank] : (void*)&readyPtrs[comm->rank];
+  size_t offset = (uint8_t*)dstPtr - (uint8_t*)comm->ceColl.ceSyncWin->userPtr;
+
+  NCCLCHECKGOTO(ncclCalloc(&writeParams, comm->nRanks), ret, fail);
+  for (int r = 0; r < comm->nRanks; ++r) {
+    if (r == comm->rank) continue;
+    void* peerDstPtr;
+    NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, comm->ceColl.ceSyncWin, offset, r, &peerDstPtr), ret, fail);
+    writeParams[writeIdx] = {};
+    writeParams[writeIdx].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
+    writeParams[writeIdx].writeValue.address = (CUdeviceptr)peerDstPtr;
+    writeParams[writeIdx].writeValue.value = waitValue;
+    writeParams[writeIdx].writeValue.flags = 0;
+    writeIdx++;
+  }
+  if (writeIdx) {
+    CUCHECKGOTO(hipStreamBatchMemOp(stream, writeIdx, writeParams, 0), ret, fail);
+  }
+
+exit:
+  free(writeParams);
+  return ret;
+fail:
+  goto exit;
+}
+
+// Non-capture: fuse peer writes into batchParams with waits (one submit, lower latency).
+static ncclResult_t ncclPrepUCSyncNonCapture(struct ncclComm* comm, bool isComplete, uint32_t* readyPtrs,
+                                            uint32_t* completePtrs, uint32_t waitValue,
+                                            hipStreamBatchMemOpParams* batchParams, size_t* opIdx) {
+  ncclResult_t ret = ncclSuccess;
+  void* dstPtr = isComplete ? (void*)&completePtrs[comm->rank] : (void*)&readyPtrs[comm->rank];
+  size_t offset = (uint8_t*)dstPtr - (uint8_t*)comm->ceColl.ceSyncWin->userPtr;
+
+  for (int r = 0; r < comm->nRanks; ++r) {
+    if (r == comm->rank) continue;
+    void* peerDstPtr;
+    NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, comm->ceColl.ceSyncWin, offset, r, &peerDstPtr), ret, fail);
+    batchParams[*opIdx] = {};
+    batchParams[*opIdx].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
+    batchParams[*opIdx].writeValue.address = (CUdeviceptr)peerDstPtr;
+    batchParams[*opIdx].writeValue.value = waitValue;
+    batchParams[*opIdx].writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
+    (*opIdx)++;
+  }
+
+exit:
+  return ret;
+fail:
+  goto exit;
+}
+
 ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete, hipStreamBatchMemOpParams* batchParams,
                             size_t* opIdx, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
@@ -416,52 +476,19 @@ ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete, hipStreamBat
   #ifdef ENABLE_FAULT_INJECTION
     NCCLCHECK(ceFaultCheck(comm, CE_FAULT_SYNC_PREP, "ncclPrepUCSync"));
   #endif
-  
+
   uint32_t* readyPtrs = (uint32_t*)comm->ceColl.baseUCSymReadyPtr;
   uint32_t* completePtrs = (uint32_t*)comm->ceColl.baseUCSymComplPtr;
-  
+
   bool capturing = ncclCudaGraphValid(comm->planner.capturingGraph);
   uint32_t currentSeq = ++comm->ceColl.ceSeqNum;
   uint32_t waitValue = capturing ? GRAPH_SYNC_VALUE : currentSeq;
-  hipStreamBatchMemOpParams* writeParams = nullptr;
-                              
-  // Non-capture: fuse peer writes into batchParams with waits (one submit, lower latency).
-  // Capture: issue peer writes as a separate stream batch first so the captured graph
-  // orders write → wait → reset (reset is a second batch in ncclMemOpSync). Fusing
-  // write+wait+reset in one HIP batch can hang on replay.
+
   if (capturing) {
-    size_t writeIdx = 0;
-    NCCLCHECKGOTO(ncclCalloc(&writeParams, comm->nRanks), ret, fail);
-    for (int r = 0; r < comm->nRanks; ++r) {
-      if (r == comm->rank) continue;
-      void* peerDstPtr;
-      void* dstPtr = isComplete ? (void*)&completePtrs[comm->rank] : (void*)&readyPtrs[comm->rank];
-      size_t offset = (uint8_t*)dstPtr - (uint8_t*)comm->ceColl.ceSyncWin->userPtr;
-      NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, comm->ceColl.ceSyncWin, offset, r, &peerDstPtr), ret, fail);
-      writeParams[writeIdx] = {};
-      writeParams[writeIdx].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
-      writeParams[writeIdx].writeValue.address = (CUdeviceptr)peerDstPtr;
-      writeParams[writeIdx].writeValue.value = waitValue;
-      writeParams[writeIdx].writeValue.flags = 0;
-      writeIdx++;
-    }
-    if (writeIdx) {
-      CUCHECKGOTO(hipStreamBatchMemOp(stream, writeIdx, writeParams, 0), ret, fail);
-    }
+    NCCLCHECKGOTO(ncclPrepUCSyncCapture(comm, isComplete, readyPtrs, completePtrs, waitValue, stream), ret, fail);
   } else {
-    for (int r = 0; r < comm->nRanks; ++r) {
-      if (r == comm->rank) continue;
-      void* peerDstPtr;
-      void* dstPtr = isComplete ? (void*)&completePtrs[comm->rank] : (void*)&readyPtrs[comm->rank];
-      size_t offset = (uint8_t*)dstPtr - (uint8_t*)comm->ceColl.ceSyncWin->userPtr;
-      NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, comm->ceColl.ceSyncWin, offset, r, &peerDstPtr), ret, fail);
-      batchParams[*opIdx] = {};
-      batchParams[*opIdx].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
-      batchParams[*opIdx].writeValue.address = (CUdeviceptr)peerDstPtr;
-      batchParams[*opIdx].writeValue.value = waitValue;
-      batchParams[*opIdx].writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
-      (*opIdx)++;
-    }
+    NCCLCHECKGOTO(ncclPrepUCSyncNonCapture(comm, isComplete, readyPtrs, completePtrs, waitValue, batchParams, opIdx),
+                  ret, fail);
   }
 
   // Waits always go in batchParams (submitted by ncclMemOpSync; reset follows if capturing).
@@ -477,7 +504,6 @@ ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete, hipStreamBat
   }
 
 exit:
-  free(writeParams);
   return ret;
 fail:
   goto exit;

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -110,7 +110,7 @@ ncclResult_t ncclCeInit(struct ncclComm* comm) {
   size_t ceARTmpBufSize = alignUp(NUM_SLOTS * comm->nRanks * maxChunkBytes, 16);
   int i = 0;
   int targetStreams = 0;
-
+  uint32_t graphSyncValue = GRAPH_SYNC_VALUE;
   // Symmetric memory runtime must be initialized before any window registration.
   NCCLCHECKGOTO(ncclDevrInitOnce(comm), ret, fail);
 
@@ -145,7 +145,7 @@ ncclResult_t ncclCeInit(struct ncclComm* comm) {
   // Allocate the UC barrier flag-value buffer: slot [0] tracks the running seq,
   // slot [1] holds the constant GRAPH_SYNC_VALUE for graph capture.
   NCCLCHECKGOTO(ncclCudaCalloc(&comm->ceColl.ceSeqNumDev, 2, comm->memManager), ret, fail);
-  NCCLCHECKGOTO(ncclCudaMemcpy(comm->ceColl.ceSeqNumDev + 1, (uint32_t*)&GRAPH_SYNC_VALUE, 1), ret, fail);
+  NCCLCHECKGOTO(ncclCudaMemcpy(comm->ceColl.ceSeqNumDev + 1, &graphSyncValue, 1), ret, fail);
   comm->ceColl.useCompletePtr = false;
   comm->ceColl.intraBatchSyncFreq = CE_COLL_INTRA_BATCH_SYNC_FREQ;
   comm->ceColl.intraBatchSyncMsgThreshold = CE_COLL_INTRA_BATCH_SYNC_MSG_THRESHOLD;
@@ -221,6 +221,10 @@ fail:
   if (comm->ceColl.synceEvent != nullptr) {
     cudaEventDestroy(comm->ceColl.synceEvent);
     comm->ceColl.synceEvent = nullptr;
+  }
+  if (comm->ceColl.ceSeqNumDev != nullptr) {
+    ncclCudaFree(comm->ceColl.ceSeqNumDev, comm->memManager);
+    comm->ceColl.ceSeqNumDev = nullptr;
   }
   goto exit;
 }

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -249,12 +249,6 @@ ncclResult_t ncclCeFinalize(struct ncclComm* comm) {
     comm->ceColl.ceSyncWin = NULL;
   }
 
-  // Free the UC barrier flag-value device buffer
-  if (comm->ceColl.ceSeqNumDev != NULL) {
-    NCCLCHECKGOTO(ncclCudaFree(comm->ceColl.ceSeqNumDev, comm->memManager), ret, fail);
-    comm->ceColl.ceSeqNumDev = NULL;
-  }
-
   // Clean up CE AllReduce staging buffer
   if (comm->ceColl.ceARTmpBuf != NULL) {
     if (comm->ceColl.ceARTmpWin && comm->ceColl.ceARTmpWin->vidmem) {
@@ -272,7 +266,6 @@ ncclResult_t ncclCeFinalize(struct ncclComm* comm) {
     comm->ceColl.signalBuffer = NULL;
     comm->ceColl.signalWin = NULL;
   }
-
 
   // Free the UC barrier flag-value device buffer
   if (comm->ceColl.ceSeqNumDev != NULL) {
@@ -372,29 +365,38 @@ ncclResult_t ncclPrepMCSync(struct ncclComm* comm, bool isComplete, hipStreamBat
                             size_t* opIdx, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
 
+  int myLsaRank = comm->devrState.lsaSelf;
+  int lsaSize = comm->devrState.lsaSize;
   uint32_t* readyPtrs = (uint32_t*)comm->ceColl.baseUCSymReadyPtr;
   uint32_t* completePtrs = (uint32_t*)comm->ceColl.baseUCSymComplPtr;
 
   bool capturing = ncclCudaGraphValid(comm->planner.capturingGraph);
   uint32_t currentSeq = ++comm->ceColl.ceSeqNum;
 
-  // Source pointer is either the constant graph sync value or the sequence number
-  void* srcPtr = capturing ? (void*)&GRAPH_SYNC_VALUE : (void*)&currentSeq;
   // Wait value is either the constant graph sync value or the sequence number
   uint32_t waitValue = capturing ? GRAPH_SYNC_VALUE : currentSeq;
 
   // Use multi-cast address as destination pointer
   void* mcDstPtr;
-  void* dstPtr = isComplete ? (void*)&completePtrs[comm->rank] : (void*)&readyPtrs[comm->rank];
+  void* dstPtr = isComplete ? (void*)&completePtrs[myLsaRank] : (void*)&readyPtrs[myLsaRank];
   size_t offset = (uint8_t*)dstPtr - (uint8_t*)comm->ceColl.ceSyncWin->userPtr;
   NCCLCHECKGOTO(ncclDevrGetLsaTeamPtrMC(comm, comm->ceColl.ceSyncWin, offset, ncclTeamLsa(comm), &mcDstPtr), ret, fail);
 
+  // Store the updated sequence number in the device buffer.
+  if (!capturing) {
+    CUCHECKGOTO(cuStreamWriteValue32(stream, (CUdeviceptr)comm->ceColl.ceSeqNumDev, currentSeq,
+                                    CU_STREAM_WRITE_VALUE_DEFAULT),
+              ret, fail);
+  }
+
   // Write our own ready/complete flag to the multi-cast address
-  CUDACHECKGOTO(cudaMemcpyAsync(mcDstPtr, srcPtr, sizeof(uint32_t), cudaMemcpyHostToDevice, stream), ret, fail);
+  CUDACHECKGOTO(cudaMemcpyAsync(mcDstPtr, comm->ceColl.ceSeqNumDev + capturing, sizeof(uint32_t),
+                              cudaMemcpyDeviceToDevice, stream),
+              ret, fail);
 
   // Add local wait operations for every other rank
-  for (int r = 0; r < comm->nRanks; ++r) {
-    if (r == comm->rank) continue;
+  for (int r = 0; r < lsaSize; ++r) {
+    if (r == myLsaRank) continue;
     batchParams[*opIdx] = {};
     batchParams[*opIdx].waitValue.operation = CU_STREAM_MEM_OP_WAIT_VALUE_32;
     batchParams[*opIdx].waitValue.address = (CUdeviceptr)(isComplete ? (void*)&completePtrs[r] : (void*)&readyPtrs[r]);
@@ -403,12 +405,11 @@ ncclResult_t ncclPrepMCSync(struct ncclComm* comm, bool isComplete, hipStreamBat
     (*opIdx)++;
   }
 
-exit:
+  exit:
   return ret;
-fail:
+  fail:
   goto exit;
 }
-
 // Capture: issue peer writes as a separate stream batch so the captured graph
 // orders write → wait → reset (reset is a second batch in ncclMemOpSync). Fusing
 // write+wait+reset in one HIP batch can hang on replay.

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -413,61 +413,71 @@ ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete, hipStreamBat
                             size_t* opIdx, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
 
-#ifdef ENABLE_FAULT_INJECTION
-  NCCLCHECK(ceFaultCheck(comm, CE_FAULT_SYNC_PREP, "ncclPrepUCSync"));
-#endif
-
+  #ifdef ENABLE_FAULT_INJECTION
+    NCCLCHECK(ceFaultCheck(comm, CE_FAULT_SYNC_PREP, "ncclPrepUCSync"));
+  #endif
+  
   uint32_t* readyPtrs = (uint32_t*)comm->ceColl.baseUCSymReadyPtr;
   uint32_t* completePtrs = (uint32_t*)comm->ceColl.baseUCSymComplPtr;
-
+  
   bool capturing = ncclCudaGraphValid(comm->planner.capturingGraph);
   uint32_t currentSeq = ++comm->ceColl.ceSeqNum;
-
-  // The peer flag write must be a SEPARATE stream op issued *before* the
-  // wait/reset batch (matching NCCL). Fusing the write into the same
-  // hipStreamBatchMemOp as the wait (and capture reset) deadlocks on graph
-  // replay. Source the value from a device buffer so the write is a plain D2D
-  // memcpy: slot [1] (GRAPH_SYNC_VALUE) during capture, slot [0] (running seq)
-  // otherwise.
-  if (!capturing) {
-    // Store this call's seq into device slot [0], stream-ordered ahead of the
-    // peer copies that read it.
-    hipStreamBatchMemOpParams seqOp = {};
-    seqOp.writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
-    seqOp.writeValue.address   = (CUdeviceptr)(comm->ceColl.ceSeqNumDev + 0);
-    seqOp.writeValue.value     = currentSeq;
-    seqOp.writeValue.flags     = 0;
-    CUCHECKGOTO(hipStreamBatchMemOp(stream, 1, &seqOp, 0), ret, fail);
+  uint32_t waitValue = capturing ? GRAPH_SYNC_VALUE : currentSeq;
+  hipStreamBatchMemOpParams* writeParams = nullptr;
+                              
+  // Non-capture: fuse peer writes into batchParams with waits (one submit, lower latency).
+  // Capture: issue peer writes as a separate stream batch first so the captured graph
+  // orders write → wait → reset (reset is a second batch in ncclMemOpSync). Fusing
+  // write+wait+reset in one HIP batch can hang on replay.
+  if (capturing) {
+    size_t writeIdx = 0;
+    NCCLCHECKGOTO(ncclCalloc(&writeParams, comm->nRanks), ret, fail);
+    for (int r = 0; r < comm->nRanks; ++r) {
+      if (r == comm->rank) continue;
+      void* peerDstPtr;
+      void* dstPtr = isComplete ? (void*)&completePtrs[comm->rank] : (void*)&readyPtrs[comm->rank];
+      size_t offset = (uint8_t*)dstPtr - (uint8_t*)comm->ceColl.ceSyncWin->userPtr;
+      NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, comm->ceColl.ceSyncWin, offset, r, &peerDstPtr), ret, fail);
+      writeParams[writeIdx] = {};
+      writeParams[writeIdx].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
+      writeParams[writeIdx].writeValue.address = (CUdeviceptr)peerDstPtr;
+      writeParams[writeIdx].writeValue.value = waitValue;
+      writeParams[writeIdx].writeValue.flags = 0;
+      writeIdx++;
+    }
+    if (writeIdx) {
+      CUCHECKGOTO(hipStreamBatchMemOp(stream, writeIdx, writeParams, 0), ret, fail);
+    }
+  } else {
+    for (int r = 0; r < comm->nRanks; ++r) {
+      if (r == comm->rank) continue;
+      void* peerDstPtr;
+      void* dstPtr = isComplete ? (void*)&completePtrs[comm->rank] : (void*)&readyPtrs[comm->rank];
+      size_t offset = (uint8_t*)dstPtr - (uint8_t*)comm->ceColl.ceSyncWin->userPtr;
+      NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, comm->ceColl.ceSyncWin, offset, r, &peerDstPtr), ret, fail);
+      batchParams[*opIdx] = {};
+      batchParams[*opIdx].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
+      batchParams[*opIdx].writeValue.address = (CUdeviceptr)peerDstPtr;
+      batchParams[*opIdx].writeValue.value = waitValue;
+      batchParams[*opIdx].writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
+      (*opIdx)++;
+    }
   }
 
-  // Write our own ready/complete flag to remote ranks as separate D2D copies.
-  for (int r = 0; r < comm->nRanks; ++r) {
-    if (r == comm->rank) continue;
-    void* peerDstPtr;
-    void* dstPtr = isComplete ? (void*)&completePtrs[comm->rank] : (void*)&readyPtrs[comm->rank];
-    size_t offset = (uint8_t*)dstPtr - (uint8_t*)comm->ceColl.ceSyncWin->userPtr;
-    NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, comm->ceColl.ceSyncWin, offset, r, &peerDstPtr), ret, fail);
-    CUDACHECKGOTO(cudaMemcpyAsync(
-      peerDstPtr,
-      comm->ceColl.ceSeqNumDev + (capturing ? 1 : 0),
-      sizeof(uint32_t),
-      cudaMemcpyDeviceToDevice,
-      stream), ret, fail);
-  }
-
-  // Add local wait operations for every other rank. Only waits (and the
-  // capture reset ops appended by the caller) go in the batch now.
+  // Waits always go in batchParams (submitted by ncclMemOpSync; reset follows if capturing).
   for (int r = 0; r < comm->nRanks; ++r) {
     if (r == comm->rank) continue;
     batchParams[*opIdx] = {};
     batchParams[*opIdx].waitValue.operation = CU_STREAM_MEM_OP_WAIT_VALUE_32;
-    batchParams[*opIdx].waitValue.address = (CUdeviceptr)(isComplete ? (void*)&completePtrs[r] : (void*)&readyPtrs[r]);
-    batchParams[*opIdx].waitValue.value = capturing ? GRAPH_SYNC_VALUE : currentSeq;
+    batchParams[*opIdx].waitValue.address =
+      (CUdeviceptr)(isComplete ? (void*)&completePtrs[r] : (void*)&readyPtrs[r]);
+    batchParams[*opIdx].waitValue.value = waitValue;
     batchParams[*opIdx].waitValue.flags = CU_STREAM_WAIT_VALUE_EQ;
     (*opIdx)++;
   }
 
 exit:
+  free(writeParams);
   return ret;
 fail:
   goto exit;

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -211,15 +211,15 @@ fail:
   comm->ceColl.signalBuffer = nullptr;
   comm->ceColl.signalWin = nullptr;
   if (comm->ceColl.d_barrierSync != nullptr) {
-    hipFree(comm->ceColl.d_barrierSync);
+    CUDACHECKIGNORE(hipFree(comm->ceColl.d_barrierSync));
     comm->ceColl.d_barrierSync = nullptr;
   }
   if (comm->ceColl.scatterStream != nullptr) {
-    cudaStreamDestroy(comm->ceColl.scatterStream);
+    CUDACHECKIGNORE(cudaStreamDestroy(comm->ceColl.scatterStream));
     comm->ceColl.scatterStream = nullptr;
   }
   if (comm->ceColl.synceEvent != nullptr) {
-    cudaEventDestroy(comm->ceColl.synceEvent);
+    CUDACHECKIGNORE(cudaEventDestroy(comm->ceColl.synceEvent));
     comm->ceColl.synceEvent = nullptr;
   }
   if (comm->ceColl.ceSeqNumDev != nullptr) {
@@ -612,7 +612,7 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeBatchOpsPa
     // ready/complete barrier on graph replay. (ported from NCCL)
     if (params->intraBatchSync &&
         ((params->numOps + comm->ceColl.intraBatchSyncFreq - 1) / comm->ceColl.intraBatchSyncFreq) % 2 == 0) {
-      NCCLCHECKGOTO(ncclMemOpSync(comm, args, stream), ret, fail);
+      NCCLCHECKGOTO(ncclMemOpSync(comm, stream, args), ret, fail);
     }
   }
   //--------------No graph capture--------------

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -597,6 +597,13 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeBatchOpsPa
         NCCLCHECKGOTO(ncclMemOpSync(comm, stream, args), ret, fail);
       }
     }
+    // Force an even sync count so useCompletePtr returns to its pre-launch
+    // state; an odd count leaves the toggle flipped and desyncs the next
+    // ready/complete barrier on graph replay. (ported from NCCL)
+    if (params->intraBatchSync &&
+        ((params->numOps + comm->ceColl.intraBatchSyncFreq - 1) / comm->ceColl.intraBatchSyncFreq) % 2 == 0) {
+      NCCLCHECKGOTO(ncclMemOpSync(comm, args, stream), ret, fail);
+    }
   }
   //--------------No graph capture--------------
   else {

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -245,6 +245,12 @@ ncclResult_t ncclCeFinalize(struct ncclComm* comm) {
     comm->ceColl.ceSyncWin = NULL;
   }
 
+  // Free the UC barrier flag-value device buffer
+  if (comm->ceColl.ceSeqNumDev != NULL) {
+    NCCLCHECKGOTO(ncclCudaFree(comm->ceColl.ceSeqNumDev, comm->memManager), ret, fail);
+    comm->ceColl.ceSeqNumDev = NULL;
+  }
+
   // Clean up CE AllReduce staging buffer
   if (comm->ceColl.ceARTmpBuf != NULL) {
     if (comm->ceColl.ceARTmpWin && comm->ceColl.ceARTmpWin->vidmem) {

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -142,6 +142,10 @@ ncclResult_t ncclCeInit(struct ncclComm* comm) {
   comm->ceColl.baseUCSymReadyPtr = (uint8_t*)comm->ceColl.ceSyncWin->userPtr + comm->ceColl.baseUCSymReadyOffset;
   comm->ceColl.baseUCSymComplPtr = (uint8_t*)comm->ceColl.ceSyncWin->userPtr + comm->ceColl.baseUCSymComplOffset;
   comm->ceColl.ceSeqNum = 0;
+  // Allocate the UC barrier flag-value buffer: slot [0] tracks the running seq,
+  // slot [1] holds the constant GRAPH_SYNC_VALUE for graph capture.
+  NCCLCHECKGOTO(ncclCudaCalloc(&comm->ceColl.ceSeqNumDev, 2, comm->memManager), ret, fail);
+  NCCLCHECKGOTO(ncclCudaMemcpy(comm->ceColl.ceSeqNumDev + 1, (uint32_t*)&GRAPH_SYNC_VALUE, 1), ret, fail);
   comm->ceColl.useCompletePtr = false;
   comm->ceColl.intraBatchSyncFreq = CE_COLL_INTRA_BATCH_SYNC_FREQ;
   comm->ceColl.intraBatchSyncMsgThreshold = CE_COLL_INTRA_BATCH_SYNC_MSG_THRESHOLD;
@@ -257,6 +261,13 @@ ncclResult_t ncclCeFinalize(struct ncclComm* comm) {
     }
     comm->ceColl.signalBuffer = NULL;
     comm->ceColl.signalWin = NULL;
+  }
+
+
+  // Free the UC barrier flag-value device buffer
+  if (comm->ceColl.ceSeqNumDev != NULL) {
+    NCCLCHECKGOTO(ncclCudaFree(comm->ceColl.ceSeqNumDev, comm->memManager), ret, fail);
+    comm->ceColl.ceSeqNumDev = NULL;
   }
 
   // Clean up copy streams and events
@@ -389,7 +400,7 @@ fail:
 }
 
 ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete, hipStreamBatchMemOpParams* batchParams,
-                            size_t* opIdx) {
+                            size_t* opIdx, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
 
 #ifdef ENABLE_FAULT_INJECTION
@@ -402,23 +413,40 @@ ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete, hipStreamBat
   bool capturing = ncclCudaGraphValid(comm->planner.capturingGraph);
   uint32_t currentSeq = ++comm->ceColl.ceSeqNum;
 
-  // Write our own ready/complete flag to remote ranks
-  uint32_t waitValue = capturing ? GRAPH_SYNC_VALUE : currentSeq;
+  // The peer flag write must be a SEPARATE stream op issued *before* the
+  // wait/reset batch (matching NCCL). Fusing the write into the same
+  // hipStreamBatchMemOp as the wait (and capture reset) deadlocks on graph
+  // replay. Source the value from a device buffer so the write is a plain D2D
+  // memcpy: slot [1] (GRAPH_SYNC_VALUE) during capture, slot [0] (running seq)
+  // otherwise.
+  if (!capturing) {
+    // Store this call's seq into device slot [0], stream-ordered ahead of the
+    // peer copies that read it.
+    hipStreamBatchMemOpParams seqOp = {};
+    seqOp.writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
+    seqOp.writeValue.address   = (CUdeviceptr)(comm->ceColl.ceSeqNumDev + 0);
+    seqOp.writeValue.value     = currentSeq;
+    seqOp.writeValue.flags     = 0;
+    CUCHECKGOTO(hipStreamBatchMemOp(stream, 1, &seqOp, 0), ret, fail);
+  }
+
+  // Write our own ready/complete flag to remote ranks as separate D2D copies.
   for (int r = 0; r < comm->nRanks; ++r) {
     if (r == comm->rank) continue;
     void* peerDstPtr;
     void* dstPtr = isComplete ? (void*)&completePtrs[comm->rank] : (void*)&readyPtrs[comm->rank];
     size_t offset = (uint8_t*)dstPtr - (uint8_t*)comm->ceColl.ceSyncWin->userPtr;
     NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, comm->ceColl.ceSyncWin, offset, r, &peerDstPtr), ret, fail);
-    batchParams[*opIdx] = {};
-    batchParams[*opIdx].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
-    batchParams[*opIdx].writeValue.address = (CUdeviceptr)peerDstPtr;
-    batchParams[*opIdx].writeValue.value = waitValue;
-    batchParams[*opIdx].writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
-    (*opIdx)++;
+    CUDACHECKGOTO(cudaMemcpyAsync(
+      peerDstPtr,
+      comm->ceColl.ceSeqNumDev + (capturing ? 1 : 0),
+      sizeof(uint32_t),
+      cudaMemcpyDeviceToDevice,
+      stream), ret, fail);
   }
 
-  // Add local wait operations for every other rank
+  // Add local wait operations for every other rank. Only waits (and the
+  // capture reset ops appended by the caller) go in the batch now.
   for (int r = 0; r < comm->nRanks; ++r) {
     if (r == comm->rank) continue;
     batchParams[*opIdx] = {};
@@ -455,27 +483,35 @@ ncclResult_t ncclMemOpSync(struct ncclComm* comm, cudaStream_t stream, struct nc
   if (comm->nvlsSupport) {
     NCCLCHECKGOTO(ncclPrepMCSync(comm, comm->ceColl.useCompletePtr, batchParams, &opIdx, stream), ret, fail);
   } else {
-    NCCLCHECKGOTO(ncclPrepUCSync(comm, comm->ceColl.useCompletePtr, batchParams, &opIdx), ret, fail);
+    NCCLCHECKGOTO(ncclPrepUCSync(comm, comm->ceColl.useCompletePtr, batchParams, &opIdx, stream), ret, fail);
   }
 
-  // For CUDA graph capture, add reset operation
+  // Execute the wait batch first and let it fully drain. The reset-to-0 ops
+  // MUST run strictly after every wait is satisfied: if they share one batch
+  // with the waits, ROCm's hipStreamBatchMemOp does not guarantee the resets
+  // wait for the wait ops, so a reset can clobber a peer's flag mid-barrier
+  // and hang graph replay. Issuing them as a separate, stream-ordered batch
+  // forces reset-after-wait.
+  CUCHECKGOTO(hipStreamBatchMemOp(stream, opIdx, batchParams, 0), ret, fail);
+
+  // For graph capture, reset our flag array to 0 in a separate batch so the
+  // fixed-value barrier can be replayed.
   if (ncclCudaGraphValid(comm->planner.capturingGraph)) {
-    for (int i = 0; i < lsaSize; i++) {
-      batchParams[opIdx] = {};
-      batchParams[opIdx].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
-      batchParams[opIdx].writeValue.address =
+    size_t resetIdx = 0;
+    for (int i = 0; i < comm->nRanks; i++) {
+      batchParams[resetIdx] = {};
+      batchParams[resetIdx].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
+      batchParams[resetIdx].writeValue.address =
         (CUdeviceptr)(comm->ceColl.useCompletePtr ? (void*)&completePtrs[i] : (void*)&readyPtrs[i]);
-      batchParams[opIdx].writeValue.value = 0;
+      batchParams[resetIdx].writeValue.value = 0;
       // CU_STREAM_WRITE_VALUE_DEFAULT is a CUDA-specific constant with no HIP equivalent.
       // This field must be initialized to satisfy the CUDA-compatible struct definition,
       // but the HIP runtime does not use this flag and treats it as 0.
-      batchParams[opIdx].writeValue.flags = 0;
-      opIdx++;
+      batchParams[resetIdx].writeValue.flags = 0;
+      resetIdx++;
     }
+    CUCHECKGOTO(hipStreamBatchMemOp(stream, resetIdx, batchParams, 0), ret, fail);
   }
-
-  // Execute all memory operations in a single batch
-  CUCHECKGOTO(hipStreamBatchMemOp(stream, opIdx, batchParams, 0), ret, fail);
 
   // Toggle the flag for next call
   comm->ceColl.useCompletePtr = !comm->ceColl.useCompletePtr;

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -210,6 +210,7 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
   struct ncclDevrState* devr = &comm->devrState;
   cudaStream_t stream;
   ncclResult_t ret = ncclSuccess;
+  ncclResult_t fatalRet = ncclSuccess;
   cudaStreamCaptureMode captureMode = cudaStreamCaptureModeRelaxed;
   if (devr->bigSize == 0) return ncclSuccess;
 
@@ -240,31 +241,25 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
   } else
 #endif
   {
-    CUDACHECKIGNORE(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
     while (devr->winSortedCount > 0) {
       struct ncclDevrWindow* win = devr->winSorted[0].win;
       NCCLCHECKIGNORE(symWindowDestroy(comm, win->vidmem, stream), ret);
     }
     CUDACHECKIGNORE(cudaStreamSynchronize(stream));
-    CUDACHECKIGNORE(cudaStreamDestroy(stream));
   }
 
   if (comm->symmetricSupport) {
     symTeamDestroyAll(comm);
     { // delete windowTable
-      cudaStream_t stream;
-      if (CUDASUCCESS(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking))) {
-        struct ncclDevCommWindowTable* tableDev = devr->windowTable;
-        while (tableDev != nullptr) {
-          struct ncclDevCommWindowTable* tableHost;
-          if (ncclSuccess != ncclShadowPoolToHost(&devr->shadows, tableDev, &tableHost)) break;
-          struct ncclDevCommWindowTable* next = tableHost->next;
-          ncclShadowPoolFree(&devr->shadows, tableDev, stream);
-          tableDev = next;
-        }
-        CUDACHECKIGNORE(cudaStreamSynchronize(stream));
-        CUDACHECKIGNORE(cudaStreamDestroy(stream));
+      struct ncclDevCommWindowTable* tableDev = devr->windowTable;
+      while (tableDev != nullptr) {
+        struct ncclDevCommWindowTable* tableHost;
+        if (ncclSuccess != ncclShadowPoolToHost(&devr->shadows, tableDev, &tableHost)) break;
+        struct ncclDevCommWindowTable* next = tableHost->next;
+        ncclShadowPoolFree(&devr->shadows, tableDev, stream);
+        tableDev = next;
       }
+      CUDACHECKIGNORE(cudaStreamSynchronize(stream));
     }
     // Drain memories whose owning windows were never explicitly destroyed
     // (e.g. resource windows created by ncclDevCommCreate when the caller
@@ -285,11 +280,12 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
       // masking with CUCHECKIGNORE — a regression in the drain path should
       // not be silently swallowed (AICOMRCCL-835).
       CUdeviceptr flatAddr = reinterpret_cast<CUdeviceptr>(devr->lsaFlatBase);
-      CUCHECK(cuMemAddressFree(flatAddr, devr->lsaSize * devr->bigSize));
+      CUCHECKGOTO(cuMemAddressFree(flatAddr, devr->lsaSize * devr->bigSize), fatalRet, cleanup);
     }
     ncclSpaceDestruct(&devr->bigSpace);
   }
 
+cleanup:
   // RCCL: shadows is constructed unconditionally in ncclDevrInitOnce; destruct
   // is safe whether or not it ever held pages (hbits==0 shortcuts the cleanup).
   // ncclShadowPoolDestruct frees device objects via cudaFreeAsync and
@@ -302,9 +298,11 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
     }
   }
 
+  CUDACHECKIGNORE(cudaStreamDestroy(stream));
+  CUDACHECKIGNORE(cudaThreadExchangeStreamCaptureMode(&captureMode));
   free(devr->lsaRankList);
   free(devr->winSorted);
-  return ncclSuccess;
+  return fatalRet;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1288,6 +1286,7 @@ ncclResult_t ncclDevrWindowRegisterInGroup(struct ncclComm* comm, void* userPtr,
   // helper which lays out IPC for intra-node and proxy/GIN MR for inter-node
   if (!comm->symmetricSupport) {
     NCCLCHECKGOTO(windowRegisterNonSym(comm, userPtr, userSize, winFlags, localRegHandle, outWinDev), ret, fail_locReg);
+    cudaThreadExchangeStreamCaptureMode(&captureMode);
     return ncclSuccess;
   }
 #endif
@@ -1967,10 +1966,11 @@ ncclResult_t ncclCommWindowDeregister_impl(struct ncclComm* comm, struct ncclWin
 
   if (winDev == nullptr) goto exit;
 
+  CUDACHECK(cudaThreadExchangeStreamCaptureMode(&captureMode));
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   if (!comm->symmetricSupport) {
     NCCLCHECKGOTO(windowDeregisterNonSym(comm, winDev), ret, fail);
-    goto exit;
+    goto fail; // shared epilogue, restores the capture mode
   }
 #endif
   CUDACHECKGOTO(cudaGetDevice(&saveDev), ret, fail);

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -215,6 +215,7 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
   if (devr->bigSize == 0) return ncclSuccess;
 
   CUDACHECKIGNORE(cudaThreadExchangeStreamCaptureMode(&captureMode));
+  CUDACHECKIGNORE(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   while (!ncclIntruQueueEmpty(&devr->regTaskQueue)) {
     struct ncclDevrRegTask* task = ncclIntruQueueDequeue(&devr->regTaskQueue);
@@ -288,15 +289,7 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
 cleanup:
   // RCCL: shadows is constructed unconditionally in ncclDevrInitOnce; destruct
   // is safe whether or not it ever held pages (hbits==0 shortcuts the cleanup).
-  // ncclShadowPoolDestruct frees device objects via cudaFreeAsync and
-  // synchronizes internally, so it needs a stream that we create and destroy here.
-  {
-    cudaStream_t shadowStream;
-    if (CUDASUCCESS(cudaStreamCreateWithFlags(&shadowStream, cudaStreamNonBlocking))) {
-      ncclShadowPoolDestruct(&devr->shadows, shadowStream);
-      CUDACHECKIGNORE(cudaStreamDestroy(shadowStream));
-    }
-  }
+  ncclShadowPoolDestruct(&devr->shadows, stream);
 
   CUDACHECKIGNORE(cudaStreamDestroy(stream));
   CUDACHECKIGNORE(cudaThreadExchangeStreamCaptureMode(&captureMode));
@@ -1286,7 +1279,7 @@ ncclResult_t ncclDevrWindowRegisterInGroup(struct ncclComm* comm, void* userPtr,
   // helper which lays out IPC for intra-node and proxy/GIN MR for inter-node
   if (!comm->symmetricSupport) {
     NCCLCHECKGOTO(windowRegisterNonSym(comm, userPtr, userSize, winFlags, localRegHandle, outWinDev), ret, fail_locReg);
-    cudaThreadExchangeStreamCaptureMode(&captureMode);
+    CUDACHECKIGNORE(cudaThreadExchangeStreamCaptureMode(&captureMode));
     return ncclSuccess;
   }
 #endif
@@ -1385,7 +1378,7 @@ ncclResult_t ncclDevrWindowRegisterInGroup(struct ncclComm* comm, void* userPtr,
 
   CUDACHECKIGNORE(cudaStreamDestroy(stream));
   free(memHandles);
-  cudaThreadExchangeStreamCaptureMode(&captureMode);
+  CUDACHECKIGNORE(cudaThreadExchangeStreamCaptureMode(&captureMode));
   return ret;
 
 fail_locReg_memHandle_mem_stream_win:
@@ -1405,7 +1398,7 @@ fail_locReg_memHandle:
 fail_locReg:
   ncclCommDeregister(comm, localRegHandle);
 fail:
-  cudaThreadExchangeStreamCaptureMode(&captureMode);
+  CUDACHECKIGNORE(cudaThreadExchangeStreamCaptureMode(&captureMode));
   *outWinDev = nullptr;
   return ret;
 }
@@ -1813,7 +1806,7 @@ ncclResult_t ncclDevrCommCreateInternal(struct ncclComm* comm, struct ncclDevCom
   if (outDevCommPreserve) {
     NCCLCHECKGOTO(devCompat->devCommCopyNewToOld(comm, outDevCommPreserve, outDevComm), ret, fail_stream_mem_win);
   }
-  cudaThreadExchangeStreamCaptureMode(&captureMode);
+  CUDACHECKIGNORE(cudaThreadExchangeStreamCaptureMode(&captureMode));
   return ret;
 
 fail_stream_mem_win:
@@ -1827,7 +1820,7 @@ fail_stream_mem:
 fail_stream:
   CUDACHECKIGNORE(cudaStreamDestroy(stream));
 fail:
-  cudaThreadExchangeStreamCaptureMode(&captureMode);
+  CUDACHECKIGNORE(cudaThreadExchangeStreamCaptureMode(&captureMode));
   return ret;
 }
 
@@ -1983,7 +1976,7 @@ fail_dev_stream:
 fail_dev:
   CUDACHECKIGNORE(cudaSetDevice(saveDev));
 fail:
-  cudaThreadExchangeStreamCaptureMode(&captureMode);
+  CUDACHECKIGNORE(cudaThreadExchangeStreamCaptureMode(&captureMode));
 exit:
   return ret;
 }

--- a/projects/rccl/src/include/ce_coll.h
+++ b/projects/rccl/src/include/ce_coll.h
@@ -65,6 +65,11 @@ struct ncclCeColl {
   size_t baseUCSymReadyOffset;
   size_t baseUCSymComplOffset;
   uint32_t ceSeqNum;
+  // Device buffer sourcing the UC barrier flag value. Slot [0]: running seq
+  // (stored per non-capture barrier); slot [1]: constant GRAPH_SYNC_VALUE used
+  // during graph capture. Peer writes memcpy from here so they can be issued
+  // as a separate stream op ahead of the wait/reset batch (see ncclPrepUCSync).
+  uint32_t* ceSeqNumDev;
   bool useCompletePtr;
   uint32_t intraBatchSyncFreq;
   uint64_t intraBatchSyncMsgThreshold;

--- a/projects/rccl/test/ce/CeInternalMPITests.cpp
+++ b/projects/rccl/test/ce/CeInternalMPITests.cpp
@@ -29,7 +29,7 @@ using namespace MPITestConstants;
 // Internal CE helpers not in ce_coll.h; accessible in Debug builds (-fvisibility=hidden not applied).
 ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete,
                             hipStreamBatchMemOpParams* batchParams,
-                            size_t* opIdx);
+                            size_t* opIdx, hipStream_t stream);
 
 ncclResult_t ncclCeInitBatchOpsParams(struct ncclCeBatchOpsParams* params, int nRanks);
 void         ncclCeFreeBatchOpsParams(struct ncclCeBatchOpsParams* params);
@@ -121,7 +121,8 @@ protected:
     {
         PrepSyncResult res;
         res.batch = makePrepSyncBatch();
-        EXPECT_EQ(ncclPrepUCSync(ceComm, isComplete, res.batch.data(), &res.opIdx),
+        EXPECT_EQ(ncclPrepUCSync(ceComm, isComplete, res.batch.data(), &res.opIdx,
+                                 getActiveStream()),
                   ncclSuccess);
         return res;
     }
@@ -348,7 +349,8 @@ TEST_F(CeInternalMPITest, PrepUCSyncIncrementsCeSeqNum)
     for(int n = 1; n <= kCallCount; ++n)
     {
         size_t opIdx = 0;
-        ASSERT_EQ(ncclPrepUCSync(ceComm, false, batch.data(), &opIdx), ncclSuccess)
+        ASSERT_EQ(ncclPrepUCSync(ceComm, false, batch.data(), &opIdx, getActiveStream()),
+                  ncclSuccess)
             << "call " << n;
         EXPECT_EQ(ceComm->ceColl.ceSeqNum, initialSeq + static_cast<uint32_t>(n))
             << "ceSeqNum should increment by 1 per call, call " << n << "/" << kCallCount;
@@ -650,13 +652,14 @@ TEST_F(CeFaultInjTest, SyncPrepErrorPropagates)
     size_t opIdx = 0;
 
     ASSERT_EQ(ncclCeFaultSet(ceComm, CE_FAULT_SYNC_PREP), ncclSuccess);
-    EXPECT_EQ(ncclPrepUCSync(ceComm, false, batch.data(), &opIdx),
+    EXPECT_EQ(ncclPrepUCSync(ceComm, false, batch.data(), &opIdx, getActiveStream()),
               ncclSystemError)
         << "Expected ncclSystemError when CE_FAULT_SYNC_PREP is armed";
 
     ASSERT_EQ(ncclCeFaultClear(ceComm), ncclSuccess);
     opIdx = 0;
-    EXPECT_EQ(ncclPrepUCSync(ceComm, false, batch.data(), &opIdx), ncclSuccess)
+    EXPECT_EQ(ncclPrepUCSync(ceComm, false, batch.data(), &opIdx, getActiveStream()),
+              ncclSuccess)
         << "Expected ncclSuccess after fault cleared";
 }
 
@@ -737,7 +740,7 @@ TEST_F(CeFaultInjTest, MultipleFaultsArmedAndCleared)
 
     auto   batch = makePrepSyncBatch();
     size_t opIdx = 0;
-    EXPECT_EQ(ncclPrepUCSync(ceComm, false, batch.data(), &opIdx),
+    EXPECT_EQ(ncclPrepUCSync(ceComm, false, batch.data(), &opIdx, getActiveStream()),
               ncclSystemError);
 
     ncclCeBatchOpsParams emptyParams{};
@@ -750,7 +753,8 @@ TEST_F(CeFaultInjTest, MultipleFaultsArmedAndCleared)
     EXPECT_EQ(ncclCeFaultGet(ceComm), 0u) << "All faults should be cleared";
 
     opIdx = 0;
-    EXPECT_EQ(ncclPrepUCSync(ceComm, false, batch.data(), &opIdx), ncclSuccess);
+    EXPECT_EQ(ncclPrepUCSync(ceComm, false, batch.data(), &opIdx, getActiveStream()),
+              ncclSuccess);
 }
 
 #endif // ENABLE_FAULT_INJECTION


### PR DESCRIPTION
## Motivation

RCCL's CE data-movement collectives (AllGather, AlltoAll, Scatter, Gather) already run under HIP graph capture on develop, but the UC cross-rank barrier was not safe to replay: peer flag-writes, waits, and capture resets could share one hipStreamBatchMemOp. On HIP that batch does not guarantee wait-before-reset ordering, so a fused reset can clobber a peer flag mid-barrier and hang on graph replay.

This PR makes the UC CE barrier graph-replay-safe on HIP, while keeping the fast fused write+wait path for non-capture launches (full NCCL-style always-split peer writes regress small-message latency)

## Technical Details

Changes are in ce_coll.cc / ce_coll.h, plus whitebox test updates. No enqueue.cc changes; develop already routes data-movement CE under capture.

1. **Hybrid UC peer writes (ncclPrepUCSync)**

- Non-capture: fuse peer WRITE_VALUE + WAIT_VALUE into one batchParams submit (same latency shape as develop).

- Capture: issue peer writes as a separate hipStreamBatchMemOp first, then put only waits in batchParams, so the captured stream orders write → wait → reset. Peer values use immediate WRITE_VALUE with GRAPH_SYNC_VALUE while capturing (and the running seq otherwise). We do not use NCCL's D2D memcpy/ceSeqNumDev peer-write path for UC, to avoid a permanent non-graph latency tax.

3. **Even CE intra-batch sync count (ncclCeLaunchBatchOps)**
Ported from NCCL: an odd sync count leaves useCompletePtr flipped and desyncs the next ready/complete barrier on replay; append one extra sync when the count would be odd.

4. **Graph-capture window creation**
Port NCCL's fix ([22bf876](https://github.com/NVIDIA/nccl/commit/22bf8764a62b7684479ad0b5bd94fa1ab63e8bb0)) so window creation stays graph-safe during capture.

5. **Tests**
Update CeInternalMPITests.cpp for the new ncclPrepUCSync(..., stream) signature (hipStream_t). Non-capture whitebox expectations remain 2*(nRanks-1) ops in the batch.
The MC path (`ncclPrepMCSync`) already issues its write separately and is unchanged.

## Issue Tracking

JIRA ID: AICOMRCCL-1518 

## Test Plan

Validation was performed with and without `NCCL_GRAPH_MIXING_SUPPORT=1`, and with `-G 20`, `-R 2`, and `-x 2`, successfully exercising graph capture and replay for CE collectives. To validate the CE graph path, the current graph guard that prevents RCCL from taking the CE path when graph capture is enabled was temporarily removed. This change was used for validation purposes only and is not included in this PR.

The existing graph guard remains in `develop` and is not modified by this PR. CE Graph support will be re-enabled in a follow-up PR once the required HIP stream capture fix #8911 is available in an official ROCm release. At that point, the guard will be converted to ROCm version-based gating, with an environment-variable override if needed. Because the graph guard currently prevents this code path from being exercised in `develop`, no automated **test case is added as part of this PR.**

## Test Result

Tested in MI355 with CLR build that include this PR #8911 and in MI450 with latest TheRock nightly build that include this fix. 

<!-- Pending. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
