### PR TITLE
net_ib_cast: clamp CQ size to device max_cqe

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -116,6 +116,7 @@ struct alignas(64) ncclIbDev {
   char* pciPath;
   int realPort;
   int maxQp;
+  int maxCqe;
   float latency;
   struct ncclIbMrCache mrCache;
   int ar; // ADAPTIVE_ROUTING

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -892,6 +892,9 @@ ib_recv_dev_list:
     if (comm->base.resiliency) {
       IbCastResiliencyDataCqSizeGet(comm->base.resiliency, i, &cqSize);
     }
+    if (IbCastDevs[ibDevN].maxCqe > 0) {
+      cqSize = std::min(IbCastDevs[ibDevN].maxCqe, cqSize);
+    }
     NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, cqSize), ret, fail);
     comm->ar = comm->ar && IbCastDevs[ibDevN].ar; // ADAPTIVE_ROUTING - if all merged devs have it enabled
     if (comm->base.resiliency) {
@@ -1491,6 +1494,9 @@ ib_recv:
     ibDevN = rComm->base.vProps.devs[i];
     if (rComm->base.resiliency) {
       IbCastResiliencyDataCqSizeGet(rComm->base.resiliency, i, &cqSize);
+    }
+    if (IbCastDevs[ibDevN].maxCqe > 0) {
+      cqSize = std::min(IbCastDevs[ibDevN].maxCqe, cqSize);
     }
     NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, cqSize), ret, fail);
     if (rComm->base.resiliency) {

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -460,6 +460,7 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
             }
 
             IbCastDevs[IbCastNDevs].maxQp = devAttr.max_qp;
+            IbCastDevs[IbCastNDevs].maxCqe = devAttr.max_cqe;
             IbCastDevs[IbCastNDevs].oooRqSize = oooRqSize;
             IbCastDevs[IbCastNDevs].mrCache.capacity = 0;
             IbCastDevs[IbCastNDevs].mrCache.population = 0;


### PR DESCRIPTION
## Motivation

The CAST connect path sizes each CQ as 3 * NET_IB_MAX_REQUESTS * QpsPerConn (= 768 * nqps). On AMD AI NIC (ionic) max_cqe is 65435,

```
hca_id:	rdma0
	max_qp:				4096
	max_qp_wr:			65535
	max_cq:				4096
	max_cqe:			65435
	max_qp_rd_atom:			16
``` 
so for nqps >= ~86 ibv_create_cq fails, tearing down the connection handshake and leaving NULL send/recv comms that later segfault (e.g. Cast_MaxQPCount128). Store max_cqe per device and clamp the requested CQ size to it before ibv_create_cq.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

```
NCCL_IB_QPS_PER_CONNECTION=128
```
```
[ RUN      ] NetIbMPITest.CastMaxQPCount128
[  PASSED  ] 1 test.
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
