### PR TITLE
Remove 'branch name' checks from PR policy bot

### DIFF
--- a/docs/SYSTEMS_PR_BOT_FAQ.md
+++ b/docs/SYSTEMS_PR_BOT_FAQ.md
@@ -1,8 +1,8 @@
 # Systems PR Bot — Policy FAQ Doc
 
 **Systems PR Bot** is an automated Pull Request (PR) gatekeeper.
-On every Pull Request, it runs a set of policy checks — branch naming,
-title/description, forbidden files, unit tests, and required CI checks —
+On every Pull Request, it runs a set of policy checks — title/description,
+forbidden files, unit tests, and required CI checks —
 then posts a single results table comment summarising what passed or failed.
 PRs that fail key checks are flagged with a **`Not ready to Review`** label
 until the issues are resolved.
@@ -17,40 +17,6 @@ This document explains what each policy check means, why it exists, and how to f
 
 > **Note:** This is **NOT an AI Bot and does not use any LLMs**. It is a
 > deterministic, rule-based checker driven entirely by `policy.yml`.
-
-______________________________________________________________________
-
-## 🌿 Branch Name
-
-**What does it check?**
-Your branch name must follow the agreed naming convention so PRs are easy to trace back to a contributor and topic.
-
-**Allowed formats**
-
-| Pattern                         | Example                                             |
-| ------------------------------- | --------------------------------------------------- |
-| `users/<username>/<anything>`   | users/dgaliffi/fix/remove-build-boost-option        |
-| `users/<username>/<anything>`   | users/frepaul/ROCm-end-user-project-workflow        |
-| `shared/<anything>`             | shared/add-runner-health                            |
-| `<single-segment-name>`         | bump-rocm-libraries-936a6c7                         |
-| `<single-segment-name>`         | ZIP-packaging-RFC                                   |
-| `dependabot/<anything>`         | dependabot/github_actions/github-actions-3dfd2199fc |
-| `revert-<pr-number>-<anything>` | revert-5217-users/derobins/add_hipfile_support      |
-
-Rules:
-
-- A recognised **prefix** must be present (`users/`, `shared/`, `dependabot/`, `revert-…`) — or the branch must be a single segment.
-- **Uppercase letters are allowed** (acronyms and module names are common, e.g. `ROCm`, `SMP`, `RFC`).
-- For `users/`, the `<username>` segment may contain letters (upper or lower), digits, and hyphens.
-- **Anything after the prefix is allowed**, including nested `namespace/feature` paths (e.g. `users/dgaliffi/fix/remove-build-boost-option`).
-
-**How to fix**
-Rename your branch before opening the PR:
-
-```bash
-git branch -m old-name users/<your-username>/<topic>
-git push origin -u users/<your-username>/<topic>
-```
 
 ______________________________________________________________________
 
@@ -260,7 +226,6 @@ A **Bump PR** is an automated pull request that updates dependencies (e.g. from 
 
 When a PR is detected as a bump update from a configured bot account (e.g. `@assistant-librarian[bot]`), **all policy checks are auto-approved**. This includes:
 
-- Branch name validation
 - PR title (length) check
 - JIRA/ISSUE ID reference requirement
 - Unit test requirement
@@ -288,13 +253,13 @@ The label is added when:
 1. **Unit Test check fails** — your PR changes source code but has no accompanying test file.
 1. **JIRA/ISSUE ID reference is missing** — your PR description does not include a tracking reference.
 
-All other policy failures (branch name, title format, description length, forbidden files, etc.) do not add the label; they are still reported in the table but do not block the PR.
+All other policy failures (title format, description length, forbidden files, etc.) do not add the label; they are still reported in the table but do not block the PR.
 
 **What is the "Not ready to Review" label?**
 
 When **PR Title/Description**, **Unit Test**, or **Forbidden Files** fails, the bot adds a **`Not ready to Review`** label to the PR so it is clearly gated.
 The label is removed automatically once all policy checks pass.
-Other failures (Branch Name, PR Size, Draft PR, pre-commit, CodeQL) do **not** add the label.
+Other failures (PR Size, Draft PR, pre-commit, CodeQL) do **not** add the label.
 
 **How are pre-commit and CodeQL shown?**
 

--- a/tools/systems_pr_bot/policy.yml
+++ b/tools/systems_pr_bot/policy.yml
@@ -1,32 +1,6 @@
 version: 2
 
 pr:
-  # Branch naming rules:
-  #   A recognised PREFIX must be present; anything AFTER the prefix is allowed
-  #   (including nested namespace/feature segments). We mostly care that a
-  #   known prefix is there. Uppercase letters ARE allowed (acronyms / module
-  #   names are common, e.g. ROCm, SMP, RFC).
-  # Examples:
-  #   users/chi/ucicd_setup_visible_devices
-  #   users/frepaul/ROCm-end-user-project-workflow   (uppercase in branch)
-  #   users/dgaliffi/fix/remove-build-boost-option    (nested namespace/feature)
-  #   shared/add-runner-health
-  #   compiler-ww-24-SMP-2                             (single-segment, uppercase)
-  #   ZIP-packaging-RFC                                (single-segment, uppercase)
-  #   dependabot/github_actions/github-actions-3dfd2199fc
-  #   revert-5217-users/derobins/add_hipfile_support  (auto-revert)
-  branch_name_patterns:
-    # users/<username>/<anything> — username may use upper/lower/digits/hyphens.
-    - '^users\/[A-Za-z0-9][A-Za-z0-9\-]*\/.+'
-    # shared/<anything>
-    - '^shared\/.+'
-    # Single-segment branches, e.g. ZIP-packaging-RFC, bump-rocm-libraries-936a6c7
-    - '^[A-Za-z0-9][A-Za-z0-9\-_]*$'
-    # dependabot/<anything>
-    - '^dependabot\/.+'
-    # GitHub auto-revert branches, e.g. revert-5217-users/derobins/add_hipfile_support
-    - '^revert-[0-9]+-.+'
-
   # Special case: automated dependency "bump" PRs.
   #
   # WHY: These bots open routine, high-volume dependency-bump PRs (e.g.

--- a/tools/systems_pr_bot/policy_check.py
+++ b/tools/systems_pr_bot/policy_check.py
@@ -1,7 +1,7 @@
 """
 Main script to policy-check PRs and report results in a comment. This is the
 core of the bot's logic: it loads policy.yml, validates the pull request
-(branch name, title, description, forbidden files, unit tests), waits for the
+(title, description, forbidden files, unit tests), waits for the
 required CI checks, posts a single results-table comment, and manages the
 "Not ready to Review" label.
 """
@@ -57,7 +57,7 @@ CAN_MUTATE_PR = _env_flag("MUTATE_PR")
 #   • Unit Test failures, and
 #   • the JIRA/ISSUE ID reference part of the description (detected separately
 #     in main() via `jira_issue_failed`).
-# All other failures (Branch Name, title format, description length/checklist,
+# All other failures (title format, description length/checklist,
 # Forbidden Files, PR Size, pre-commit, …) do NOT add the label.
 LABEL_TRIGGER_CHECKS = {
     "Unit Test",
@@ -66,7 +66,6 @@ LABEL_TRIGGER_CHECKS = {
 # Fixed display order for rows in the results table (by check name). Any row
 # whose name is not listed here is appended after these, in its original order.
 TABLE_ORDER = [
-    "Branch Name",
     "PR Title/Description",
     "Forbidden Files",
     "Unit Test",
@@ -98,7 +97,6 @@ class CheckResult:
 
 @dataclass(frozen=True)
 class Policy:
-    branch_patterns: List[re.Pattern[str]]
     title_min_length: int
     title_max_length: int
     description_min_length: int
@@ -129,9 +127,6 @@ def load_policy(policy_path: Path) -> Policy:
     pr = raw.get("pr", {}) or {}
     diff = raw.get("diff", {}) or {}
     checks = raw.get("checks", {}) or {}
-
-    patterns_raw = pr.get("branch_name_patterns", []) or []
-    branch_patterns = [re.compile(str(p)) for p in patterns_raw]
 
     # PR title rules now live under the nested `title:` mapping.
     title_cfg = pr.get("title", {}) or {}
@@ -181,7 +176,6 @@ def load_policy(policy_path: Path) -> Policy:
         )
 
     return Policy(
-        branch_patterns=branch_patterns,
         title_min_length=title_min_length,
         title_max_length=title_max_length,
         description_min_length=description_min_length,
@@ -286,34 +280,6 @@ def get_check_runs(owner: str, repo: str, sha: str, token: str) -> List[Dict[str
         raise RuntimeError("Unexpected check-runs payload")
     runs = data.get("check_runs", [])
     return runs if isinstance(runs, list) else []
-
-
-def ensure_branch_name(policy: Policy, branch_name: str, errors: List[str]) -> None:
-    """Validate the branch name against the allowed patterns.
-
-    Appends a descriptive message to `errors` if the name matches none of
-    `policy.branch_patterns`.
-    """
-    if not policy.branch_patterns:
-        return
-    if any(p.match(branch_name) for p in policy.branch_patterns):
-        return
-
-    allowed = "\n".join([f"- `{p.pattern}`" for p in policy.branch_patterns])
-    errors.append(
-        "Branch name does not match allowed patterns.\n"
-        f"Branch: `{branch_name}`\n"
-        "Allowed patterns:\n"
-        f"{allowed}"
-    )
-
-
-def _short(value: str, limit: int = 80) -> str:
-    """Truncate a value for display so one long field can't bloat the table."""
-    value = (value or "").strip()
-    if len(value) <= limit:
-        return value
-    return value[:limit] + "…"
 
 
 def ensure_pr_title(policy: Policy, title: str, errors: List[str]) -> None:
@@ -915,7 +881,6 @@ def build_bump_pr_results(policy: Policy) -> List[CheckResult]:
     """All-pass table rows for an automated dependency bump PR."""
     bump_note = "Bump PR — check auto-approved (automated dependency update)"
     rows: List[CheckResult] = [
-        CheckResult("Branch Name", "🌿", True, [], note=bump_note),
         CheckResult("PR Title/Description", "📝", True, [], note=bump_note),
         CheckResult("Draft PR", "🚫", True, [], note=bump_note),
         CheckResult("Forbidden Files", "⛔", True, [], note=bump_note),
@@ -996,7 +961,6 @@ def main(argv: Optional[List[str]] = None) -> int:
     policy = load_policy(policy_path)
 
     pr = get_pr(owner=owner, repo=repo, pr_number=pr_number, token=token)  # type: ignore[arg-type]
-    branch_name = str((pr.get("head") or {}).get("ref") or "")
     title = str(pr.get("title") or "")
     body = str(pr.get("body") or "")
 
@@ -1036,12 +1000,10 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     # Each check appends its failure messages to `check_errors`; an empty list
     # means the check passed. We reset it before every check.
-    # NOTE: all policies — including branch name — are enforced for BOTH
-    # same-repo PRs and fork PRs. `pull_request_target` gives us write access
-    # for forks, so there is no reason to skip any check.
+    # NOTE: all policies are enforced for BOTH same-repo PRs and fork PRs.
+    # `pull_request_target` gives us secret access (required for posting PR
+    # comments) for forks, so there is no reason to skip the policy checks.
     check_errors: List[str] = []
-    ensure_branch_name(policy, branch_name, check_errors)
-    results.append(CheckResult("Branch Name", "🌿", not check_errors, check_errors))
 
     check_errors = []
     ensure_pr_title(policy, title, check_errors)
@@ -1098,8 +1060,8 @@ def main(argv: Optional[List[str]] = None) -> int:
 
         # Add "Not ready to Review" ONLY when Unit Test fails OR the JIRA/ISSUE
         # ID reference is missing from the description. All other failures
-        # (title format, description length/checklist, branch name, forbidden
-        # files, PR size, pre-commit) do NOT add the label.
+        # (title format, description length/checklist, forbidden files,
+        # PR size, pre-commit) do NOT add the label.
         should_label = jira_issue_failed or any(
             not r.passed and r.name in LABEL_TRIGGER_CHECKS for r in results
         )

--- a/tools/systems_pr_bot/test_policy_check_ut.py
+++ b/tools/systems_pr_bot/test_policy_check_ut.py
@@ -3,7 +3,7 @@ Unit + integration tests for policy_check.py.
 
 These let us iterate on policies WITHOUT pushing branches or running workflows:
   • Unit tests   — exercise individual validators / regex patterns.
-  • Integration  — feed blobs of [branch, title, description, files] through
+  • Integration  — feed blobs of [title, description, files] through
                    the higher-level ensure_* functions.
 """
 
@@ -48,13 +48,6 @@ def make_policy(**overrides: Any) -> pc.Policy:
     if the shipped config changes.
     """
     defaults: Dict[str, Any] = dict(
-        branch_patterns=[
-            re.compile(r"^users\/[A-Za-z0-9][A-Za-z0-9\-]*\/.+"),
-            re.compile(r"^shared\/.+"),
-            re.compile(r"^[A-Za-z0-9][A-Za-z0-9\-_]*$"),
-            re.compile(r"^dependabot\/.+"),
-            re.compile(r"^revert-[0-9]+-.+"),
-        ],
         title_min_length=10,
         title_max_length=80,
         description_min_length=30,
@@ -94,58 +87,6 @@ def make_file(
         "deletions": deletions,
         "changes": changes if changes is not None else additions + deletions,
     }
-
-
-# ----------------------------- branch name -----------------------------------
-
-
-class BranchNameTests(unittest.TestCase):
-    def setUp(self) -> None:
-        self.policy = make_policy()
-
-    def _errs(self, branch: str) -> List[str]:
-        e: List[str] = []
-        pc.ensure_branch_name(self.policy, branch, e)
-        return e
-
-    def test_valid_branches(self) -> None:
-        for branch in [
-            "users/chi/ucicd_setup_visible_devices",
-            # Nested namespace/feature after the username is allowed.
-            "users/dgaliffi/fix/remove-build-boost-option",
-            # Uppercase letters are allowed (acronyms / module names).
-            "users/frepaul/ROCm-end-user-project-workflow",
-            "users/agunashe/hipModuleGetLoadingMode_test",
-            "compiler-ww-24-SMP-2",
-            "ZIP-packaging-RFC",
-            "shared/add-runner-health",
-            "shared/team/feature",
-            "bump-rocm-libraries-936a6c7",
-            "dependabot/github_actions/github-actions-3dfd2199fc",
-            "revert-5217-users/derobins/add_hipfile_support",
-        ]:
-            with self.subTest(branch=branch):
-                self.assertEqual(self._errs(branch), [])
-
-    def test_invalid_branches(self) -> None:
-        # "Feature/Bad" -> unknown prefix; "users//missing"/"users/" -> empty
-        # segments; "bad branch name" -> spaces are not allowed.
-        for branch in ["Feature/Bad", "users//missing", "bad branch name", "users/"]:
-            with self.subTest(branch=branch):
-                self.assertTrue(self._errs(branch))
-
-    def test_fork_pr_branch_name_is_enforced(self) -> None:
-        # All policies — including branch name — are enforced for fork PRs too.
-        # The validator always runs; there is no fork-based skip.
-        policy = make_policy()
-        e: List[str] = []
-        pc.ensure_branch_name(policy, "BadBranch", e)
-        self.assertTrue(e, "Branch name must be validated for fork PRs too")
-
-        # A valid branch name passes for both same-repo and fork PRs.
-        e = []
-        pc.ensure_branch_name(policy, "users/sam/my-feature", e)
-        self.assertEqual(e, [])
 
 
 # ----------------------------- PR title --------------------------------------
@@ -408,21 +349,17 @@ class DraftAndBumpTests(unittest.TestCase):
 
 
 class IntegrationBlobTests(unittest.TestCase):
-    """Feed full [branch, title, description, files] blobs through validators."""
+    """Feed full [title, description, files] blobs through validators."""
 
     def setUp(self) -> None:
         self.policy = make_policy()
 
     def _evaluate(
-        self, *, branch: str, title: str, body: str, files: List[Dict[str, Any]]
+        self, *, title: str, body: str, files: List[Dict[str, Any]]
     ) -> Dict[str, List[str]]:
         out: Dict[str, List[str]] = {}
 
         e: List[str] = []
-        pc.ensure_branch_name(self.policy, branch, e)
-        out["branch"] = e
-
-        e = []
         pc.ensure_pr_title(self.policy, title, e)
         pc.ensure_pr_description(self.policy, body, e)
         out["title_desc"] = e
@@ -438,7 +375,6 @@ class IntegrationBlobTests(unittest.TestCase):
 
     def test_fully_compliant_pr(self) -> None:
         result = self._evaluate(
-            branch="users/sam/add-feature",
             title="feat(ci): add policy unit tests",
             body=(
                 "Adds unit tests for the policy checker.\n"
@@ -453,19 +389,16 @@ class IntegrationBlobTests(unittest.TestCase):
 
     def test_fully_noncompliant_pr(self) -> None:
         result = self._evaluate(
-            branch="BadBranch",
             title="wip",
             body="too short",
             files=[make_file("secret.pem"), make_file("src/module.py")],
         )
-        self.assertTrue(result["branch"])
         self.assertTrue(result["title_desc"])
         self.assertTrue(result["forbidden"])
         self.assertTrue(result["unit"])
 
     def test_docs_only_pr_is_compliant(self) -> None:
         result = self._evaluate(
-            branch="shared/update-docs",
             title="docs: clarify contributing guide",
             body=(
                 "Improves the contributing docs.\n"
@@ -490,7 +423,6 @@ class LoadPolicyTests(unittest.TestCase):
         if not policy_path.exists():
             self.skipTest("policy.yml not present next to tests")
         policy = pc.load_policy(policy_path)
-        self.assertGreater(len(policy.branch_patterns), 0)
         self.assertIn("pre-commit", policy.required_checks)
         self.assertGreaterEqual(policy.title_max_length, policy.title_min_length)
 


### PR DESCRIPTION
## Motivation

* Progress on https://github.com/ROCm/rocm-systems/issues/9004
* See also https://github.com/ROCm/TheRock/pull/6751 and https://github.com/ROCm/rocm-libraries/pull/10031

Branch naming patterns will be enforced via a branch protection ruleset that prevents creating branches that don't match allowed patterns, so we will no longer need the bot to check them.

## Test Plan

* Ran `python .\tools\systems_pr_bot\test_policy_check_ut.py` locally (not yet running on CI)
* Watch PR policy bot logs on PRs _after this is merged_ (due to `pull_request_target` sequencing)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
