### PR TITLE
(fix) (rocDecode) Perf Script - Create directory for sample mode = 1

### DIFF
--- a/projects/rocdecode/test/testScripts/run_rocDecodeSamples.py
+++ b/projects/rocdecode/test/testScripts/run_rocDecodeSamples.py
@@ -137,7 +137,10 @@ if resultsDir == '':
     elif sampleMode == 1:
         resultsPath = scriptPath+'/rocDecode_videoDecodePerf_results'
 else:
-    resultsPath = resultsDir+'/rocDecode_videoDecode_results'
+    if sampleMode == 0:
+        resultsPath = resultsDir+'/rocDecode_videoDecode_results'
+    elif sampleMode == 1:
+        resultsPath = resultsDir+'/rocDecode_videoDecodePerf_results'
 
 run_rocDecode_app = os.path.abspath(rocDecode_exe)
 os.system('(mkdir -p ' +  resultsPath + ')')

--- a/projects/rocdecode/test/testScripts/run_rocDecodeSamples.py
+++ b/projects/rocdecode/test/testScripts/run_rocDecodeSamples.py
@@ -200,7 +200,7 @@ if sampleMode == 0:
                             /^$/{next}
                             /info: Total pictures decoded: / {totalFrames=$5; next}
                             /info: avg decoding time per picture: /{timePerFrame=$7; next}
-                            /info: avg decode FPS: / { printf("%s, %s, %s, %d, %s, %s, %d, %f, %f\n", filename, codec, videoSize, bitDepth, frameRate, bitRate, totalFrames, timePerFrame, $5) }' rocDecode_videoDecode_results/rocDecode_output.log >> rocDecode_videoDecode_results/rocDecode_test_results.csv'''
+                            /info: avg decode FPS: / { printf("%s, %s, %s, %d, %s, %s, %d, %f, %f\n", filename, codec, videoSize, bitDepth, frameRate, bitRate, totalFrames, timePerFrame, $5) }' ''' + resultsPath + '''/rocDecode_output.log >> ''' + resultsPath + '''/rocDecode_test_results.csv'''
         os.system(runAwk_csv)
 elif sampleMode == 1:
     for current_file in iter_files(filesDirPath):
@@ -236,8 +236,7 @@ elif sampleMode == 1:
                             /^$/{next}
                             /info: Total pictures decoded: / {totalFrames=$5; next}
                             /info: avg decoding time per picture: /{timePerFrame=$7; next}
-                            /info: avg decode FPS: / { printf("%s, %d, %s, %s, %d, %s, %s, %d, %f, %f\n", filename, numThreads, codec, videoSize, bitDepth, frameRate, bitRate, totalFrames, timePerFrame, $5) }' rocDecode_videoDecodePerf_results/rocDecode_output.log >> rocDecode_videoDecodePerf_results/rocDecode_test_results.csv'''
-        sys.stdout = orig_stdout
+                            /info: avg decode FPS: / { printf("%s, %d, %s, %s, %d, %s, %s, %d, %f, %f\n", filename, numThreads, codec, videoSize, bitDepth, frameRate, bitRate, totalFrames, timePerFrame, $5) }' ''' + resultsPath + '''/rocDecode_output.log >> ''' + resultsPath + '''/rocDecode_test_results.csv'''
         os.system(runAwk_csv)
 
 # get data


### PR DESCRIPTION
## Motivation

Currently if the `results_directory` path is provided by user and `sample_mode 1` , the directory created to store results is incorrect and fails to write csv.

## Technical Details

Add an `if-elif` case for creation of results directory in script as per sample mode.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

Run perf script with `--sample_mode 1 --resutls_directory <PATH>`

## Test Result

Should produce `csv`

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
