### PR TITLE
initialize clusterSizeX/Y/Z on windows pal

### DIFF
--- a/projects/clr/rocclr/device/pal/palvirtual.cpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.cpp
@@ -2850,6 +2850,10 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
   dispatchParam.useAtc = dev().settings().svmFineGrainSystem_ ? true : false;
   dispatchParam.kernargSegmentSize = hsaKernel.argsBufferSize();
   dispatchParam.aqlPacketIndex = aql_index;
+  // Copy cluster sizes from kernel metadata to dispatch params
+  dispatchParam.clusterSizeX = static_cast<uint8>(hsaKernel.getClusterSize(0));
+  dispatchParam.clusterSizeY = static_cast<uint8>(hsaKernel.getClusterSize(1));
+  dispatchParam.clusterSizeZ = static_cast<uint8>(hsaKernel.getClusterSize(2));
 
   // Update the mqd's information about scratch memory.
   amd_queue.scratch_backing_memory_location = static_cast<uint64_t>(dispatchParam.scratchAddr);


### PR DESCRIPTION
## Motivation
cluster sizes are not initialized correctly causing pal to crash with div by 0


## Technical Details
cluster sizes are not initialized correctly causing pal to crash with div by 0

## Issue Tracking
AIRUNTIME-2571

## Test Plan
PAL tests on windows should build and execute fine without issues

## Test Result
PAL tests on windows should build and execute fine without issues

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
