### PR TITLE
fix(rdc): require amd_smi 27.0.0

### DIFF
--- a/projects/rdc/CMakeLists.txt
+++ b/projects/rdc/CMakeLists.txt
@@ -209,7 +209,7 @@ if(BUILD_STANDALONE AND GRPC_ROOT STREQUAL GRPC_ROOT_DEFAULT)
     )
 endif()
 
-find_package(amd_smi 26.0.0 NAMES amd_smi HINTS ${ROCM_DIR}/lib/cmake CONFIG REQUIRED)
+find_package(amd_smi 27.0.0 NAMES amd_smi HINTS ${ROCM_DIR}/lib/cmake CONFIG REQUIRED)
 
 if(NOT EXISTS "${AMD_SMI_INCLUDE_DIR}" OR NOT EXISTS "${AMD_SMI_LIB_DIR}")
     message(


### PR DESCRIPTION
amd_smi ships its config-version file with `SameMajorVersion` compatibility, so the 27.0.0 bump (#9217) no longer satisfies `find_package(amd_smi 26.0.0 REQUIRED)` and RDC fails to configure. Bump the pin to match.