### PR TITLE
[rocjitsu] Fix gfx1250 simulator semantics

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -3368,11 +3368,20 @@ class CodeGenerator:
               const uint32_t matrix_b_scale_fmt = scale_inst_.neg_hi & 0x3u;
               const bool scale16 = scale_inst_.op == 0x3a;
 
+              auto scale_word = [&](const Operand &operand, uint32_t lane) -> uint64_t {
+                // For regular scaled WMMA, the inline integer-zero encoding
+                // selects a neutral E8M0 word rather than the numerical value 0.
+                if (!scale16 &&
+                    operand.encoding_value() == OpSelSrcSimple::OPR_SRC_SIMPLE_POS_INT_MIN)
+                  return 0x7f7f7f7fu;
+                return scale16 ? amdgpu::RegisterAccess(wf).read_lane64(operand, lane)
+                               : amdgpu::RegisterAccess(wf).read_lane(operand, lane);
+              };
               auto scale0 = [&](uint32_t lane) -> uint64_t {
-                return scale16 ? amdgpu::RegisterAccess(wf).read_lane64(scale_src0, lane) : amdgpu::RegisterAccess(wf).read_lane(scale_src0, lane);
+                return scale_word(scale_src0, lane);
               };
               auto scale1 = [&](uint32_t lane) -> uint64_t {
-                return scale16 ? amdgpu::RegisterAccess(wf).read_lane64(scale_src1, lane) : amdgpu::RegisterAccess(wf).read_lane(scale_src1, lane);
+                return scale_word(scale_src1, lane);
               };
 
               bool dispatched = false;
@@ -4511,13 +4520,15 @@ class CodeGenerator:
         if cls == 'buffer_atomic':
             return self._gen_buffer_atomic(dst_ops, src_ops, sem)
 
-        if cls == 'ds_atomic':
+        if cls in ('ds_atomic', 'ds_atomic2'):
             gds_guard = ''
             if self._enc_has_field('gds'):
                 gds_guard = (
                     '  if (inst_.gds)\n'
                     '    throw util::UnimplementedInst(mnemonic());\n'
                 )
+            if cls == 'ds_atomic2':
+                return gds_guard + self._gen_ds_atomic2(dst_ops, src_ops, sem)
             return gds_guard + self._gen_ds_atomic(dst_ops, src_ops, sem)
 
         if cls in ('ds_mskor', 'ds_append_consume', 'ds_barrier_arrive'):
@@ -4925,6 +4936,11 @@ class CodeGenerator:
                 else 'amdgpu::WaitCounterType::LGKMCNT'
             ),
             'ds_atomic': (
+                'amdgpu::WaitCounterType::DSCNT'
+                if is_gfx11_plus
+                else 'amdgpu::WaitCounterType::LGKMCNT'
+            ),
+            'ds_atomic2': (
                 'amdgpu::WaitCounterType::DSCNT'
                 if is_gfx11_plus
                 else 'amdgpu::WaitCounterType::LGKMCNT'
@@ -5429,6 +5445,80 @@ class CodeGenerator:
         L.append('  set_data(std::move(d));')
         return '\n'.join(L)
 
+    def _gen_ds_atomic2(
+        self, dst: list[str], src: list[str], sem: InstructionSemantics
+    ) -> str:
+        """Generate a returning two-address LDS exchange."""
+        esz = sem.elem_size or 4
+        dwords_per_access = esz // 4
+        is_stride64 = 'stride64' in sem.name.lower()
+        stride_scale = f'{esz * 64}U' if is_stride64 else f'{esz}U'
+
+        L = []
+        L.append('  auto &cu = wf.cu();')
+        L.append('  uint64_t exec = wf.exec();')
+        L.append(
+            '  auto d = std::make_unique<amdgpu::VectorMemState>(amdgpu::LOCAL_MEM);'
+        )
+        L.append(f"  d->dst_reg_base = {self._vgpr_base_expr('vdst', role='Dst')};")
+        L.append(f'  d->elem_size = {esz};')
+        L.append('  d->num_elems = 1;')
+        L.append('  d->is_load = true;')
+        L.append('  d->atomic_op = amdgpu::AtomicOp::SWAP;')
+        self._append_wait_counter_type(L, 'ds_atomic2')
+        L.append('  d->exec_mask = exec;')
+        L.append('  d->lane_mask = exec;')
+        L.append('  d->wf_size = wf.wf_size();')
+        L.append('  d->ds2_active = true;')
+        L.append(
+            f"  d->ds2_dst_reg_base = {self._vgpr_base_expr('vdst', role='Dst')} + "
+            f'{dwords_per_access};'
+        )
+        L.append(f'  d->store_data.resize(wf.wf_size() * {esz});')
+        L.append(f'  d->ds2_store_data.resize(wf.wf_size() * {esz});')
+        L.append(
+            f"  uint32_t addr_base = {self._vgpr_base_expr('addr', use_acc=False)};"
+        )
+        L.append(
+            f"  uint32_t data0_base = {self._vgpr_base_expr('data0', role='Src1')};"
+        )
+        L.append(
+            f"  uint32_t data1_base = {self._vgpr_base_expr('data1', role='Src2')};"
+        )
+        L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
+        L.append('    if (!(exec & (1ULL << lane))) continue;')
+        L.append(
+            '    uint32_t base = amdgpu::RegisterAccess(cu).read_vgpr(addr_base, lane);'
+        )
+        L.append(
+            f'    d->per_lane_addr[lane] = base + '
+            f'static_cast<uint32_t>(inst_.offset0) * {stride_scale} + wf.lds_base();'
+        )
+        L.append(
+            f'    d->ds2_per_lane_addr[lane] = base + '
+            f'static_cast<uint32_t>(inst_.offset1) * {stride_scale} + wf.lds_base();'
+        )
+        for i in range(dwords_per_access):
+            L.append(
+                f'    uint32_t val0_{i} = '
+                f'amdgpu::RegisterAccess(cu).read_vgpr(data0_base + {i}, lane);'
+            )
+            L.append(
+                f'    std::memcpy(&d->store_data[lane * {esz} + {i * 4}], '
+                f'&val0_{i}, 4);'
+            )
+            L.append(
+                f'    uint32_t val1_{i} = '
+                f'amdgpu::RegisterAccess(cu).read_vgpr(data1_base + {i}, lane);'
+            )
+            L.append(
+                f'    std::memcpy(&d->ds2_store_data[lane * {esz} + {i * 4}], '
+                f'&val1_{i}, 4);'
+            )
+        L.append('  }')
+        L.append('  set_data(std::move(d));')
+        return '\n'.join(L)
+
     def _gen_ds_mskor(
         self, dst: list[str], src: list[str], sem: InstructionSemantics
     ) -> str:
@@ -5704,10 +5794,38 @@ class CodeGenerator:
         L.append('  set_data(std::move(d));')
         return '\n'.join(L)
 
+    def _append_ds_addtid_addresses(self, lines: list[str]) -> None:
+        """Emit the profile-specific DS ADDTID per-lane address calculation."""
+        lines.append('  {')
+        lines.append('    uint64_t exec = wf.exec();')
+        lines.append('    d->lane_mask = exec; d->exec_mask = exec;')
+        lines.append('    d->wg_id = wf.wg_id(); d->wf_id = wf.wf_id();')
+        lines.append('    d->cu_path = wf.cu().full_path();')
+        lines.append(
+            '    uint32_t offset = (static_cast<uint32_t>(inst_.offset1) << 8) | inst_.offset0;'
+        )
+        lines.append('    uint32_t m0 = wf.m0();')
+        if self.isa_spec.profile.ds_addtid_uses_m0_byte_base:
+            lines.append('    for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
+            lines.append('      if (!(exec & (1ULL << lane))) continue;')
+            lines.append('      uint32_t lane_offset = (m0 + lane * 4U) & 0xFFFFFU;')
+            lines.append(
+                '      d->per_lane_addr[lane] = lane_offset + offset + wf.lds_base();'
+            )
+        else:
+            lines.append('    uint32_t ds_stride_bytes = ((m0 >> 16) & 0x1FF) * 4;')
+            lines.append('    for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
+            lines.append('      if (!(exec & (1ULL << lane))) continue;')
+            lines.append(
+                '      d->per_lane_addr[lane] = lane * ds_stride_bytes + offset + wf.lds_base();'
+            )
+        lines.append('    }')
+        lines.append('  }')
+
     def _gen_ds_read_addtid(
         self, dst: list[str], src: list[str], sem: InstructionSemantics
     ) -> str:
-        """ds_read_addtid_b32: addr = thread_id * M0[24:16] * 4 + offset."""
+        """Generate profile-specific DS ADDTID load addressing."""
         L = []
         L.append(
             '  auto d = std::make_unique<amdgpu::VectorMemState>(amdgpu::LOCAL_MEM);'
@@ -5717,30 +5835,14 @@ class CodeGenerator:
         L.append(f'  d->num_elems = {sem.num_elems};')
         L.append('  d->is_load = true;')
         self._append_wait_counter_type(L, 'ds_read_addtid')
-        L.append('  {')
-        L.append('    uint64_t exec = wf.exec();')
-        L.append('    d->lane_mask = exec; d->exec_mask = exec;')
-        L.append('    d->wg_id = wf.wg_id(); d->wf_id = wf.wf_id();')
-        L.append('    d->cu_path = wf.cu().full_path();')
-        L.append(
-            '    uint32_t offset = (static_cast<uint32_t>(inst_.offset1) << 8) | inst_.offset0;'
-        )
-        L.append('    uint32_t m0 = wf.m0();')
-        L.append('    uint32_t ds_stride_bytes = ((m0 >> 16) & 0x1FF) * 4;')
-        L.append('    for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
-        L.append('      if (!(exec & (1ULL << lane))) continue;')
-        L.append(
-            '      d->per_lane_addr[lane] = lane * ds_stride_bytes + offset + wf.lds_base();'
-        )
-        L.append('    }')
-        L.append('  }')
+        self._append_ds_addtid_addresses(L)
         L.append('  set_data(std::move(d));')
         return '\n'.join(L)
 
     def _gen_ds_write_addtid(
         self, dst: list[str], src: list[str], sem: InstructionSemantics
     ) -> str:
-        """ds_write_addtid_b32: addr = thread_id * M0[24:16] * 4 + offset."""
+        """Generate profile-specific DS ADDTID store addressing."""
         L = []
         L.append(
             '  auto d = std::make_unique<amdgpu::VectorMemState>(amdgpu::LOCAL_MEM);'
@@ -5749,23 +5851,7 @@ class CodeGenerator:
         L.append(f'  d->num_elems = {sem.num_elems};')
         L.append('  d->is_load = false;')
         self._append_wait_counter_type(L, 'ds_write_addtid')
-        L.append('  {')
-        L.append('    uint64_t exec = wf.exec();')
-        L.append('    d->lane_mask = exec; d->exec_mask = exec;')
-        L.append('    d->wg_id = wf.wg_id(); d->wf_id = wf.wf_id();')
-        L.append('    d->cu_path = wf.cu().full_path();')
-        L.append(
-            '    uint32_t offset = (static_cast<uint32_t>(inst_.offset1) << 8) | inst_.offset0;'
-        )
-        L.append('    uint32_t m0 = wf.m0();')
-        L.append('    uint32_t ds_stride_bytes = ((m0 >> 16) & 0x1FF) * 4;')
-        L.append('    for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
-        L.append('      if (!(exec & (1ULL << lane))) continue;')
-        L.append(
-            '      d->per_lane_addr[lane] = lane * ds_stride_bytes + offset + wf.lds_base();'
-        )
-        L.append('    }')
-        L.append('  }')
+        self._append_ds_addtid_addresses(L)
         L.append('  auto &cu = wf.cu();')
         L.append('  uint64_t exec = wf.exec();')
         L.append(f"  uint32_t data_base = {self._vgpr_base_expr('data0')};")
@@ -6055,6 +6141,7 @@ class CodeGenerator:
             'ds_write',
             'ds_write2',
             'ds_atomic',
+            'ds_atomic2',
             'ds_mskor',
             'ds_append_consume',
             'ds_barrier_arrive',
@@ -6831,6 +6918,7 @@ class CodeGenerator:
                             'ds_write',
                             'ds_write2',
                             'ds_atomic',
+                            'ds_atomic2',
                             'ds_mskor',
                             'ds_append_consume',
                             'ds_barrier_arrive',

--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -336,6 +336,22 @@ class IsaProfile(ABC):
         return {}
 
     @property
+    def semantic_class_overrides(self) -> dict[str, str]:
+        """Per-instruction semantic-class refinements for this ISA.
+
+        Unlike :attr:`semantic_overrides`, these preserve the generic
+        derivation's operation, element size, and other metadata. Use this
+        when an ISA-specific instruction shape needs a different codegen
+        template but the remaining mnemonic-derived metadata is still valid.
+        """
+        return {}
+
+    @property
+    def ds_addtid_uses_m0_byte_base(self) -> bool:
+        """True when DS ADDTID addresses use M0 as a byte-address base."""
+        return False
+
+    @property
     def cmpx_writes_vcc(self) -> bool:
         """True if V_CMPX instructions write both EXEC and VCC.
 
@@ -1588,6 +1604,20 @@ class Gfx1250Profile(Rdna4Profile):
     @property
     def generated_arch_name(self) -> str | None:
         return 'gfx1250'
+
+    @property
+    def semantic_class_overrides(self) -> dict[str, str]:
+        return {
+            'DS_STORE_ADDTID_B32': 'ds_write_addtid',
+            'DS_STOREXCHG_2ADDR_RTN_B32': 'ds_atomic2',
+            'DS_STOREXCHG_2ADDR_RTN_B64': 'ds_atomic2',
+            'DS_STOREXCHG_2ADDR_STRIDE64_RTN_B32': 'ds_atomic2',
+            'DS_STOREXCHG_2ADDR_STRIDE64_RTN_B64': 'ds_atomic2',
+        }
+
+    @property
+    def ds_addtid_uses_m0_byte_base(self) -> bool:
+        return True
 
     _SKIP = frozenset(
         {

--- a/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
@@ -1912,6 +1912,41 @@ class _DsAtomic(_ScalarDeriver):
         return SemaBlock(sem.name, ExecModel.VECTOR, body)
 
 
+@_register('ds_atomic2')
+class _DsAtomic2(_ScalarDeriver):
+    @staticmethod
+    def derive(sem: InstructionSemantics) -> SemaBlock:
+        elem_ty = _elem_type(sem.elem_size)
+        op = sem.operation or 'swap'
+        addr0 = _addr_call(
+            'CalcDsAddr', _cast(_src(0), SemaType.U32), _id('OFFSET0', SemaType.U32)
+        )
+        addr1 = _addr_call(
+            'CalcDsAddr', _cast(_src(0), SemaType.U32), _id('OFFSET1', SemaType.U32)
+        )
+
+        def atomic_swap(addr_name: str, source_index: int) -> SemaNode:
+            return SemaNode(
+                SemaNodeKind.CALL,
+                ty=elem_ty,
+                call_name=f'atomic_{op}',
+                children=(
+                    _id(f'atomic_{op}'),
+                    _id(addr_name, SemaType.U32),
+                    _cast(_src(source_index), elem_ty),
+                ),
+            )
+
+        stmts = [
+            _assign(_id('addr0', SemaType.U32), addr0),
+            _assign(_id('addr1', SemaType.U32), addr1),
+            _assign(_cast(_dst(0), elem_ty), atomic_swap('addr0', 1)),
+            _assign(_cast(_dst(1), elem_ty), atomic_swap('addr1', 2)),
+        ]
+        body = SemaNode(SemaNodeKind.SEQ, children=tuple(stmts))
+        return SemaBlock(sem.name, ExecModel.VECTOR, body)
+
+
 @_register('ds_read_addtid')
 class _DsReadAddtid(_ScalarDeriver):
     @staticmethod

--- a/emulation/rocjitsu/lib/python/amdisa/semantics.py
+++ b/emulation/rocjitsu/lib/python/amdisa/semantics.py
@@ -10,7 +10,7 @@ from each instruction's mnemonic name and its encoding format name.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
 import re
@@ -2569,6 +2569,9 @@ def derive_all_semantics(isa_spec: IsaSpec) -> SemanticsSpec:
         SemanticsSpec containing all derivable instructions.
     """
     overrides = isa_spec.profile.semantic_overrides if isa_spec.profile else {}
+    class_overrides = (
+        isa_spec.profile.semantic_class_overrides if isa_spec.profile else {}
+    )
     instructions: dict[str, InstructionSemantics] = {}
     for enc in isa_spec.inst_encodings:
         for inst in enc.insts:
@@ -2586,5 +2589,8 @@ def derive_all_semantics(isa_spec: IsaSpec) -> SemanticsSpec:
                 continue
             sem = derive_semantics(inst.name, enc.enc_name)
             if sem is not None:
+                semantic_class = class_overrides.get(inst.name)
+                if semantic_class is not None:
+                    sem = replace(sem, semantic_class=semantic_class)
                 instructions[inst.name] = sem
     return SemanticsSpec(instructions)

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -116,6 +116,99 @@ def _generated_method_body(cpp: str, class_name: str, next_class_name: str) -> s
     return cpp[start:end]
 
 
+def test_gfx1250_addtid_uses_m0_byte_base_addresses(
+    gfx1250_generated_root: Path,
+) -> None:
+    vds = (gfx1250_generated_root / 'vds_exec.cpp').read_text()
+    store_body = _generated_method_body(
+        vds, 'DsStoreAddtidB32Vds', 'DsLoadAddtidB32Vds'
+    )
+    load_body = _generated_method_body(vds, 'DsLoadAddtidB32Vds', 'DsPermuteB32Vds')
+    for body in (store_body, load_body):
+        assert 'uint32_t lane_offset = (m0 + lane * 4U) & 0xFFFFFU;' in body
+        assert 'lane_offset + offset + wf.lds_base()' in body
+        assert 'ds_stride_bytes' not in body
+
+
+def test_gfx1250_returning_two_address_exchange_b32_uses_dual_atomic_state(
+    gfx1250_generated_root: Path,
+) -> None:
+    vds = (gfx1250_generated_root / 'vds_exec.cpp').read_text()
+    body = _generated_method_body(
+        vds,
+        'DsStorexchg2addrRtnB32Vds',
+        'DsStorexchg2addrStride64RtnB32Vds',
+    )
+    assert 'd->wf_size = wf.wf_size();' in body
+    assert 'd->ds2_active = true;' in body
+    assert 'd->ds2_per_lane_addr[lane]' in body
+    assert 'd->ds2_store_data' in body
+    assert 'd->ds2_dst_reg_base' in body
+
+
+def test_gfx1250_profile_scopes_special_ds_semantics() -> None:
+    names = (
+        'DS_STORE_ADDTID_B32',
+        'DS_STOREXCHG_2ADDR_RTN_B32',
+        'DS_STOREXCHG_2ADDR_RTN_B64',
+        'DS_STOREXCHG_2ADDR_STRIDE64_RTN_B32',
+        'DS_STOREXCHG_2ADDR_STRIDE64_RTN_B64',
+    )
+
+    def semantics_for(profile):
+        spec = SimpleNamespace(
+            profile=profile,
+            inst_encodings=[
+                SimpleNamespace(
+                    enc_name='ENC_VDS',
+                    insts=[SimpleNamespace(name=name) for name in names],
+                )
+            ],
+        )
+        return derive_all_semantics(spec)
+
+    gfx1250 = semantics_for(Gfx1250Profile())
+    assert Gfx1250Profile().ds_addtid_uses_m0_byte_base
+    assert gfx1250['DS_STORE_ADDTID_B32'].semantic_class == 'ds_write_addtid'
+    for name in names[1:]:
+        assert gfx1250[name].semantic_class == 'ds_atomic2'
+        assert gfx1250[name].operation == 'swap'
+
+    rdna4 = semantics_for(Rdna4Profile())
+    assert not Rdna4Profile().ds_addtid_uses_m0_byte_base
+    assert rdna4['DS_STORE_ADDTID_B32'].semantic_class == 'ds_write'
+    for name in names[1:]:
+        assert rdna4[name].semantic_class == 'ds_atomic'
+
+
+@pytest.mark.parametrize(
+    ('name', 'elem_size', 'scale', 'dst_dwords'),
+    [
+        ('DS_STOREXCHG_2ADDR_RTN_B32', 4, '4U', 1),
+        ('DS_STOREXCHG_2ADDR_STRIDE64_RTN_B32', 4, '256U', 1),
+        ('DS_STOREXCHG_2ADDR_RTN_B64', 8, '8U', 2),
+        ('DS_STOREXCHG_2ADDR_STRIDE64_RTN_B64', 8, '512U', 2),
+    ],
+)
+def test_gfx1250_dual_atomic_generator_covers_each_variant(
+    name: str, elem_size: int, scale: str, dst_dwords: int
+) -> None:
+    codegen = object.__new__(CodeGenerator)
+    codegen._vgpr_base_expr = lambda operand, **_kwargs: operand
+    codegen._append_wait_counter_type = lambda lines, _semantic_class: lines.append(
+        '  d->wait_counter_type = amdgpu::WaitCounterType::DSCNT;'
+    )
+    sem = InstructionSemantics(
+        name, 'ds_atomic2', operation='swap', elem_size=elem_size, num_elems=1
+    )
+    body = codegen._gen_ds_atomic2([], [], sem)
+    assert f'inst_.offset0) * {scale}' in body
+    assert f'inst_.offset1) * {scale}' in body
+    assert f'd->ds2_dst_reg_base = vdst + {dst_dwords};' in body
+    assert 'd->ds2_active = true;' in body
+    assert 'd->ds2_store_data' in body
+
+
 def _generated_constructor_body(cpp: str, class_name: str) -> str:
     start = cpp.index(f'{class_name}::{class_name}(')
     end = cpp.index('\n\n', start)

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -2320,6 +2320,7 @@ class TestDeriveMemoryLowerAll:
             ('DS_READ2_B32', 'ds_read2', ExecModel.VECTOR),
             ('DS_WRITE2_B32', 'ds_write2', ExecModel.VECTOR),
             ('DS_ADD_U32', 'ds_atomic', ExecModel.VECTOR),
+            ('DS_STOREXCHG_2ADDR_RTN_B32', 'ds_atomic2', ExecModel.VECTOR),
             ('DS_BPERMUTE_B32', 'ds_permute', ExecModel.VECTOR),
             ('DS_SWIZZLE_B32', 'ds_swizzle', ExecModel.VECTOR),
             ('DS_LOAD_ADDTID_B32', 'ds_read_addtid', ExecModel.VECTOR),
@@ -2858,3 +2859,16 @@ class TestDeriveFingerprinting:
         block_add = derive_sema_block(sem_add)
         block_sub = derive_sema_block(sem_sub)
         assert fingerprint(block_add) != fingerprint(block_sub)
+
+    def test_two_address_exchange_differs_from_single_address_exchange(self):
+        single = _FakeSem('DS_STOREXCHG_RTN_B32', 'ds_atomic', 'swap')
+        dual = _FakeSem('DS_STOREXCHG_2ADDR_RTN_B32', 'ds_atomic2', 'swap')
+        for sem in (single, dual):
+            sem.elem_size = 4
+            sem.num_elems = 1
+            sem.sign_extend = False
+
+        single_block = derive_sema_block(single)
+        dual_block = derive_sema_block(dual)
+
+        assert fingerprint(single_block) != fingerprint(dual_block)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vds_exec.cpp
@@ -983,6 +983,8 @@ void DsStorexchgRtnB32Vds::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void DsStorexchg2addrRtnB32Vds::execute_impl(amdgpu::Wavefront &wf) {
+  auto &cu = wf.cu();
+  uint64_t exec = wf.exec();
   auto d = std::make_unique<amdgpu::VectorMemState>(amdgpu::LOCAL_MEM);
   d->dst_reg_base =
       wf.vgpr_alloc().base +
@@ -992,23 +994,42 @@ void DsStorexchg2addrRtnB32Vds::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->atomic_op = amdgpu::AtomicOp::SWAP;
   d->wait_counter_type = amdgpu::WaitCounterType::DSCNT;
-  ds_calculate_addresses(inst_, wf, *d);
-  auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
-  uint32_t data_base =
+  d->exec_mask = exec;
+  d->lane_mask = exec;
+  d->wf_size = wf.wf_size();
+  d->ds2_active = true;
+  d->ds2_dst_reg_base =
+      wf.vgpr_alloc().base +
+      *Isa::resolved_vgpr_offset(wf, OperandType::OPR_VGPR, inst_.vdst, amdgpu::VgprMsbRole::Dst) +
+      1;
+  d->store_data.resize(wf.wf_size() * 4);
+  d->ds2_store_data.resize(wf.wf_size() * 4);
+  uint32_t addr_base =
+      wf.vgpr_alloc().base +
+      *Isa::resolved_vgpr_offset(wf, addr.opr_type_, addr.encoding_value_, addr.vgpr_msb_role());
+  uint32_t data0_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, OperandType::OPR_VGPR, inst_.data0, amdgpu::VgprMsbRole::Src1);
-  d->store_data.resize(wf.wf_size() * 4);
+  uint32_t data1_base =
+      wf.vgpr_alloc().base +
+      *Isa::resolved_vgpr_offset(wf, OperandType::OPR_VGPR, inst_.data1, amdgpu::VgprMsbRole::Src2);
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t val0 = amdgpu::RegisterAccess(cu).read_vgpr(data_base + 0, lane);
-    std::memcpy(&d->store_data[lane * 4 + 0], &val0, 4);
+    uint32_t base = amdgpu::RegisterAccess(cu).read_vgpr(addr_base, lane);
+    d->per_lane_addr[lane] = base + static_cast<uint32_t>(inst_.offset0) * 4U + wf.lds_base();
+    d->ds2_per_lane_addr[lane] = base + static_cast<uint32_t>(inst_.offset1) * 4U + wf.lds_base();
+    uint32_t val0_0 = amdgpu::RegisterAccess(cu).read_vgpr(data0_base + 0, lane);
+    std::memcpy(&d->store_data[lane * 4 + 0], &val0_0, 4);
+    uint32_t val1_0 = amdgpu::RegisterAccess(cu).read_vgpr(data1_base + 0, lane);
+    std::memcpy(&d->ds2_store_data[lane * 4 + 0], &val1_0, 4);
   }
   set_data(std::move(d));
 }
 
 void DsStorexchg2addrStride64RtnB32Vds::execute_impl(amdgpu::Wavefront &wf) {
+  auto &cu = wf.cu();
+  uint64_t exec = wf.exec();
   auto d = std::make_unique<amdgpu::VectorMemState>(amdgpu::LOCAL_MEM);
   d->dst_reg_base =
       wf.vgpr_alloc().base +
@@ -1018,18 +1039,35 @@ void DsStorexchg2addrStride64RtnB32Vds::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->atomic_op = amdgpu::AtomicOp::SWAP;
   d->wait_counter_type = amdgpu::WaitCounterType::DSCNT;
-  ds_calculate_addresses(inst_, wf, *d);
-  auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
-  uint32_t data_base =
+  d->exec_mask = exec;
+  d->lane_mask = exec;
+  d->wf_size = wf.wf_size();
+  d->ds2_active = true;
+  d->ds2_dst_reg_base =
+      wf.vgpr_alloc().base +
+      *Isa::resolved_vgpr_offset(wf, OperandType::OPR_VGPR, inst_.vdst, amdgpu::VgprMsbRole::Dst) +
+      1;
+  d->store_data.resize(wf.wf_size() * 4);
+  d->ds2_store_data.resize(wf.wf_size() * 4);
+  uint32_t addr_base =
+      wf.vgpr_alloc().base +
+      *Isa::resolved_vgpr_offset(wf, addr.opr_type_, addr.encoding_value_, addr.vgpr_msb_role());
+  uint32_t data0_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, OperandType::OPR_VGPR, inst_.data0, amdgpu::VgprMsbRole::Src1);
-  d->store_data.resize(wf.wf_size() * 4);
+  uint32_t data1_base =
+      wf.vgpr_alloc().base +
+      *Isa::resolved_vgpr_offset(wf, OperandType::OPR_VGPR, inst_.data1, amdgpu::VgprMsbRole::Src2);
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t val0 = amdgpu::RegisterAccess(cu).read_vgpr(data_base + 0, lane);
-    std::memcpy(&d->store_data[lane * 4 + 0], &val0, 4);
+    uint32_t base = amdgpu::RegisterAccess(cu).read_vgpr(addr_base, lane);
+    d->per_lane_addr[lane] = base + static_cast<uint32_t>(inst_.offset0) * 256U + wf.lds_base();
+    d->ds2_per_lane_addr[lane] = base + static_cast<uint32_t>(inst_.offset1) * 256U + wf.lds_base();
+    uint32_t val0_0 = amdgpu::RegisterAccess(cu).read_vgpr(data0_base + 0, lane);
+    std::memcpy(&d->store_data[lane * 4 + 0], &val0_0, 4);
+    uint32_t val1_0 = amdgpu::RegisterAccess(cu).read_vgpr(data1_base + 0, lane);
+    std::memcpy(&d->ds2_store_data[lane * 4 + 0], &val1_0, 4);
   }
   set_data(std::move(d));
 }
@@ -2302,6 +2340,8 @@ void DsStorexchgRtnB64Vds::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void DsStorexchg2addrRtnB64Vds::execute_impl(amdgpu::Wavefront &wf) {
+  auto &cu = wf.cu();
+  uint64_t exec = wf.exec();
   auto d = std::make_unique<amdgpu::VectorMemState>(amdgpu::LOCAL_MEM);
   d->dst_reg_base =
       wf.vgpr_alloc().base +
@@ -2311,25 +2351,46 @@ void DsStorexchg2addrRtnB64Vds::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->atomic_op = amdgpu::AtomicOp::SWAP;
   d->wait_counter_type = amdgpu::WaitCounterType::DSCNT;
-  ds_calculate_addresses(inst_, wf, *d);
-  auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
-  uint32_t data_base =
+  d->exec_mask = exec;
+  d->lane_mask = exec;
+  d->wf_size = wf.wf_size();
+  d->ds2_active = true;
+  d->ds2_dst_reg_base =
+      wf.vgpr_alloc().base +
+      *Isa::resolved_vgpr_offset(wf, OperandType::OPR_VGPR, inst_.vdst, amdgpu::VgprMsbRole::Dst) +
+      2;
+  d->store_data.resize(wf.wf_size() * 8);
+  d->ds2_store_data.resize(wf.wf_size() * 8);
+  uint32_t addr_base =
+      wf.vgpr_alloc().base +
+      *Isa::resolved_vgpr_offset(wf, addr.opr_type_, addr.encoding_value_, addr.vgpr_msb_role());
+  uint32_t data0_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, OperandType::OPR_VGPR, inst_.data0, amdgpu::VgprMsbRole::Src1);
-  d->store_data.resize(wf.wf_size() * 8);
+  uint32_t data1_base =
+      wf.vgpr_alloc().base +
+      *Isa::resolved_vgpr_offset(wf, OperandType::OPR_VGPR, inst_.data1, amdgpu::VgprMsbRole::Src2);
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t val0 = amdgpu::RegisterAccess(cu).read_vgpr(data_base + 0, lane);
-    std::memcpy(&d->store_data[lane * 8 + 0], &val0, 4);
-    uint32_t val1 = amdgpu::RegisterAccess(cu).read_vgpr(data_base + 1, lane);
-    std::memcpy(&d->store_data[lane * 8 + 4], &val1, 4);
+    uint32_t base = amdgpu::RegisterAccess(cu).read_vgpr(addr_base, lane);
+    d->per_lane_addr[lane] = base + static_cast<uint32_t>(inst_.offset0) * 8U + wf.lds_base();
+    d->ds2_per_lane_addr[lane] = base + static_cast<uint32_t>(inst_.offset1) * 8U + wf.lds_base();
+    uint32_t val0_0 = amdgpu::RegisterAccess(cu).read_vgpr(data0_base + 0, lane);
+    std::memcpy(&d->store_data[lane * 8 + 0], &val0_0, 4);
+    uint32_t val1_0 = amdgpu::RegisterAccess(cu).read_vgpr(data1_base + 0, lane);
+    std::memcpy(&d->ds2_store_data[lane * 8 + 0], &val1_0, 4);
+    uint32_t val0_1 = amdgpu::RegisterAccess(cu).read_vgpr(data0_base + 1, lane);
+    std::memcpy(&d->store_data[lane * 8 + 4], &val0_1, 4);
+    uint32_t val1_1 = amdgpu::RegisterAccess(cu).read_vgpr(data1_base + 1, lane);
+    std::memcpy(&d->ds2_store_data[lane * 8 + 4], &val1_1, 4);
   }
   set_data(std::move(d));
 }
 
 void DsStorexchg2addrStride64RtnB64Vds::execute_impl(amdgpu::Wavefront &wf) {
+  auto &cu = wf.cu();
+  uint64_t exec = wf.exec();
   auto d = std::make_unique<amdgpu::VectorMemState>(amdgpu::LOCAL_MEM);
   d->dst_reg_base =
       wf.vgpr_alloc().base +
@@ -2339,20 +2400,39 @@ void DsStorexchg2addrStride64RtnB64Vds::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->atomic_op = amdgpu::AtomicOp::SWAP;
   d->wait_counter_type = amdgpu::WaitCounterType::DSCNT;
-  ds_calculate_addresses(inst_, wf, *d);
-  auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
-  uint32_t data_base =
+  d->exec_mask = exec;
+  d->lane_mask = exec;
+  d->wf_size = wf.wf_size();
+  d->ds2_active = true;
+  d->ds2_dst_reg_base =
+      wf.vgpr_alloc().base +
+      *Isa::resolved_vgpr_offset(wf, OperandType::OPR_VGPR, inst_.vdst, amdgpu::VgprMsbRole::Dst) +
+      2;
+  d->store_data.resize(wf.wf_size() * 8);
+  d->ds2_store_data.resize(wf.wf_size() * 8);
+  uint32_t addr_base =
+      wf.vgpr_alloc().base +
+      *Isa::resolved_vgpr_offset(wf, addr.opr_type_, addr.encoding_value_, addr.vgpr_msb_role());
+  uint32_t data0_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, OperandType::OPR_VGPR, inst_.data0, amdgpu::VgprMsbRole::Src1);
-  d->store_data.resize(wf.wf_size() * 8);
+  uint32_t data1_base =
+      wf.vgpr_alloc().base +
+      *Isa::resolved_vgpr_offset(wf, OperandType::OPR_VGPR, inst_.data1, amdgpu::VgprMsbRole::Src2);
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t val0 = amdgpu::RegisterAccess(cu).read_vgpr(data_base + 0, lane);
-    std::memcpy(&d->store_data[lane * 8 + 0], &val0, 4);
-    uint32_t val1 = amdgpu::RegisterAccess(cu).read_vgpr(data_base + 1, lane);
-    std::memcpy(&d->store_data[lane * 8 + 4], &val1, 4);
+    uint32_t base = amdgpu::RegisterAccess(cu).read_vgpr(addr_base, lane);
+    d->per_lane_addr[lane] = base + static_cast<uint32_t>(inst_.offset0) * 512U + wf.lds_base();
+    d->ds2_per_lane_addr[lane] = base + static_cast<uint32_t>(inst_.offset1) * 512U + wf.lds_base();
+    uint32_t val0_0 = amdgpu::RegisterAccess(cu).read_vgpr(data0_base + 0, lane);
+    std::memcpy(&d->store_data[lane * 8 + 0], &val0_0, 4);
+    uint32_t val1_0 = amdgpu::RegisterAccess(cu).read_vgpr(data1_base + 0, lane);
+    std::memcpy(&d->ds2_store_data[lane * 8 + 0], &val1_0, 4);
+    uint32_t val0_1 = amdgpu::RegisterAccess(cu).read_vgpr(data0_base + 1, lane);
+    std::memcpy(&d->store_data[lane * 8 + 4], &val0_1, 4);
+    uint32_t val1_1 = amdgpu::RegisterAccess(cu).read_vgpr(data1_base + 1, lane);
+    std::memcpy(&d->ds2_store_data[lane * 8 + 4], &val1_1, 4);
   }
   set_data(std::move(d));
 }
@@ -2986,7 +3066,22 @@ void DsStoreAddtidB32Vds::execute_impl(amdgpu::Wavefront &wf) {
   d->num_elems = 1;
   d->is_load = false;
   d->wait_counter_type = amdgpu::WaitCounterType::DSCNT;
-  ds_calculate_addresses(inst_, wf, *d);
+  {
+    uint64_t exec = wf.exec();
+    d->lane_mask = exec;
+    d->exec_mask = exec;
+    d->wg_id = wf.wg_id();
+    d->wf_id = wf.wf_id();
+    d->cu_path = wf.cu().full_path();
+    uint32_t offset = (static_cast<uint32_t>(inst_.offset1) << 8) | inst_.offset0;
+    uint32_t m0 = wf.m0();
+    for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+      if (!(exec & (1ULL << lane)))
+        continue;
+      uint32_t lane_offset = (m0 + lane * 4U) & 0xFFFFFU;
+      d->per_lane_addr[lane] = lane_offset + offset + wf.lds_base();
+    }
+  }
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
   uint32_t data_base =
@@ -2996,8 +3091,8 @@ void DsStoreAddtidB32Vds::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t val0 = amdgpu::RegisterAccess(cu).read_vgpr(data_base + 0, lane);
-    std::memcpy(&d->store_data[lane * 4 + 0], &val0, 4);
+    uint32_t val0 = amdgpu::RegisterAccess(cu).read_vgpr(data_base, lane);
+    std::memcpy(&d->store_data[lane * 4], &val0, 4);
   }
   set_data(std::move(d));
 }
@@ -3020,11 +3115,11 @@ void DsLoadAddtidB32Vds::execute_impl(amdgpu::Wavefront &wf) {
     d->cu_path = wf.cu().full_path();
     uint32_t offset = (static_cast<uint32_t>(inst_.offset1) << 8) | inst_.offset0;
     uint32_t m0 = wf.m0();
-    uint32_t ds_stride_bytes = ((m0 >> 16) & 0x1FF) * 4;
     for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
       if (!(exec & (1ULL << lane)))
         continue;
-      d->per_lane_addr[lane] = lane * ds_stride_bytes + offset + wf.lds_base();
+      uint32_t lane_offset = (m0 + lane * 4U) & 0xFFFFFU;
+      d->per_lane_addr[lane] = lane_offset + offset + wf.lds_base();
     }
   }
   set_data(std::move(d));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p_exec.cpp
@@ -4980,14 +4980,16 @@ void VWmmaScaleF32Vop3px2::execute_impl(amdgpu::Wavefront &wf) {
   const uint32_t matrix_b_scale_fmt = scale_inst_.neg_hi & 0x3u;
   const bool scale16 = scale_inst_.op == 0x3a;
 
-  auto scale0 = [&](uint32_t lane) -> uint64_t {
-    return scale16 ? amdgpu::RegisterAccess(wf).read_lane64(scale_src0, lane)
-                   : amdgpu::RegisterAccess(wf).read_lane(scale_src0, lane);
+  auto scale_word = [&](const Operand &operand, uint32_t lane) -> uint64_t {
+    // For regular scaled WMMA, the inline integer-zero encoding
+    // selects a neutral E8M0 word rather than the numerical value 0.
+    if (!scale16 && operand.encoding_value() == OpSelSrcSimple::OPR_SRC_SIMPLE_POS_INT_MIN)
+      return 0x7f7f7f7fu;
+    return scale16 ? amdgpu::RegisterAccess(wf).read_lane64(operand, lane)
+                   : amdgpu::RegisterAccess(wf).read_lane(operand, lane);
   };
-  auto scale1 = [&](uint32_t lane) -> uint64_t {
-    return scale16 ? amdgpu::RegisterAccess(wf).read_lane64(scale_src1, lane)
-                   : amdgpu::RegisterAccess(wf).read_lane(scale_src1, lane);
-  };
+  auto scale0 = [&](uint32_t lane) -> uint64_t { return scale_word(scale_src0, lane); };
+  auto scale1 = [&](uint32_t lane) -> uint64_t { return scale_word(scale_src1, lane); };
 
   bool dispatched = false;
   if (inst_.op == 0x88) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
@@ -128,12 +128,13 @@ struct VectorMemState : DynamicInstState {
   std::vector<uint8_t> store_data;
   uint8_t transpose = 0; ///< Transpose-load kind (0=none, see ds_transpose.h).
 
-  /// @brief DS dual-access support (ds_write2/ds_read2).
+  /// @brief DS dual-access support.
   ///
   /// When ds2_active is true, per_lane_addr holds the first access addresses
-  /// and ds2_per_lane_addr holds the second. For loads, ds2_dst_reg_base is
-  /// the VGPR base for the second access result. For stores, ds2_store_data
-  /// contains the second access data.
+  /// and ds2_per_lane_addr holds the second. For ordinary loads and returning
+  /// atomics, ds2_dst_reg_base is the VGPR base for the second result and the
+  /// two response vectors preserve each access independently. For stores and
+  /// atomics, ds2_store_data contains the second access payload.
   bool ds2_active = false;
   std::array<uint64_t, 64> ds2_per_lane_addr = {};
   uint32_t ds2_dst_reg_base = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -296,14 +296,14 @@ template <typename F> F apply_fp_atomic(AtomicOp op, F old_val, F src_val) {
   }
 }
 
-uint32_t atomic_source_stride(const VectorMemState &d) {
+uint32_t atomic_source_stride(const VectorMemState &d, const std::vector<uint8_t> &store_data) {
   const bool uses_two_sources =
       (d.atomic_op == AtomicOp::CMPSWAP || d.atomic_op == AtomicOp::MSKOR);
   const uint32_t fallback = uses_two_sources ? d.elem_size * 2 : d.elem_size;
-  if (d.wf_size == 0 || d.store_data.empty())
+  if (d.wf_size == 0 || store_data.empty())
     return fallback;
 
-  const size_t per_lane = d.store_data.size() / d.wf_size;
+  const size_t per_lane = store_data.size() / d.wf_size;
   return per_lane == 0 ? fallback : static_cast<uint32_t>(per_lane);
 }
 
@@ -318,7 +318,7 @@ void execute_atomic_rmw(VectorMemState &d, L2Cache *l2, uint32_t vmid) {
   d.response_data.resize(d.wf_size * esz);
   const bool uses_two_sources =
       (d.atomic_op == AtomicOp::CMPSWAP || d.atomic_op == AtomicOp::MSKOR);
-  const uint32_t src_stride = atomic_source_stride(d);
+  const uint32_t src_stride = atomic_source_stride(d, d.store_data);
   const bool is_fp = (d.atomic_op == AtomicOp::FADD || d.atomic_op == AtomicOp::FMIN ||
                       d.atomic_op == AtomicOp::FMAX);
 
@@ -379,12 +379,15 @@ void execute_atomic_rmw(VectorMemState &d, L2Cache *l2, uint32_t vmid) {
 }
 
 /// @brief Perform a per-lane atomic RMW on LDS memory.
-void execute_lds_atomic_rmw(VectorMemState &d, Lds *lds) {
+void execute_lds_atomic_rmw(VectorMemState &d, Lds *lds,
+                            const std::array<uint64_t, 64> &per_lane_addr,
+                            const std::vector<uint8_t> &store_data,
+                            std::vector<uint8_t> &response_data) {
   const uint32_t esz = d.elem_size;
-  d.response_data.resize(d.wf_size * esz);
+  response_data.resize(d.wf_size * esz);
   const bool uses_two_sources =
       (d.atomic_op == AtomicOp::CMPSWAP || d.atomic_op == AtomicOp::MSKOR);
-  const uint32_t src_stride = atomic_source_stride(d);
+  const uint32_t src_stride = atomic_source_stride(d, store_data);
   const bool is_fp = (d.atomic_op == AtomicOp::FADD || d.atomic_op == AtomicOp::FMIN ||
                       d.atomic_op == AtomicOp::FMAX);
 
@@ -393,7 +396,7 @@ void execute_lds_atomic_rmw(VectorMemState &d, Lds *lds) {
     bool any_lane = false;
     for (uint32_t lane = 0; lane < d.wf_size; ++lane) {
       if (d.lane_mask & (1ULL << lane)) {
-        addr = static_cast<uint32_t>(d.per_lane_addr[lane]);
+        addr = static_cast<uint32_t>(per_lane_addr[lane]);
         any_lane = true;
         break;
       }
@@ -409,7 +412,7 @@ void execute_lds_atomic_rmw(VectorMemState &d, Lds *lds) {
         continue;
       const uint32_t result =
           d.atomic_op == AtomicOp::APPEND ? old_val + active_rank : old_val - active_rank - 1;
-      std::memcpy(&d.response_data[lane * 4], &result, 4);
+      std::memcpy(&response_data[lane * 4], &result, 4);
       ++active_rank;
     }
     const uint32_t new_val =
@@ -422,7 +425,7 @@ void execute_lds_atomic_rmw(VectorMemState &d, Lds *lds) {
     if (!(d.lane_mask & (1ULL << lane)))
       continue;
 
-    auto addr = static_cast<uint32_t>(d.per_lane_addr[lane]);
+    auto addr = static_cast<uint32_t>(per_lane_addr[lane]);
 
     if (esz == 4) {
       uint32_t old_val = lds->read32(addr);
@@ -430,40 +433,40 @@ void execute_lds_atomic_rmw(VectorMemState &d, Lds *lds) {
       if (is_fp) {
         float old_f = std::bit_cast<float>(old_val);
         float src_f;
-        std::memcpy(&src_f, &d.store_data[lane * src_stride], 4);
+        std::memcpy(&src_f, &store_data[lane * src_stride], 4);
         new_val = std::bit_cast<uint32_t>(apply_fp_atomic(d.atomic_op, old_f, src_f));
       } else {
         uint32_t src_val = 0, cmp_val = 0;
-        std::memcpy(&src_val, &d.store_data[lane * src_stride], 4);
+        std::memcpy(&src_val, &store_data[lane * src_stride], 4);
         if (uses_two_sources)
-          std::memcpy(&cmp_val, &d.store_data[lane * src_stride + 4], 4);
+          std::memcpy(&cmp_val, &store_data[lane * src_stride + 4], 4);
         new_val = apply_int_atomic(d.atomic_op, old_val, src_val, cmp_val);
       }
       lds->write32(addr, new_val);
-      std::memcpy(&d.response_data[lane * 4], &old_val, 4);
+      std::memcpy(&response_data[lane * 4], &old_val, 4);
     } else if (esz == 8) {
       uint64_t old_val = lds->read64(addr);
       uint64_t new_val;
       if (d.atomic_op == AtomicOp::BARRIER_ARRIVE) {
         uint64_t decrement = 0;
-        const bool has_decrement = d.store_data.size() >= lane * src_stride + 8;
+        const bool has_decrement = store_data.size() >= lane * src_stride + 8;
         if (has_decrement)
-          std::memcpy(&decrement, &d.store_data[lane * src_stride], 8);
+          std::memcpy(&decrement, &store_data[lane * src_stride], 8);
         new_val = lds_barrier_cell_update_arrive(old_val, has_decrement ? decrement : 1);
       } else if (is_fp) {
         double old_f = std::bit_cast<double>(old_val);
         double src_f;
-        std::memcpy(&src_f, &d.store_data[lane * src_stride], 8);
+        std::memcpy(&src_f, &store_data[lane * src_stride], 8);
         new_val = std::bit_cast<uint64_t>(apply_fp_atomic(d.atomic_op, old_f, src_f));
       } else {
         uint64_t src_val = 0, cmp_val = 0;
-        std::memcpy(&src_val, &d.store_data[lane * src_stride], 8);
+        std::memcpy(&src_val, &store_data[lane * src_stride], 8);
         if (uses_two_sources)
-          std::memcpy(&cmp_val, &d.store_data[lane * src_stride + 8], 8);
+          std::memcpy(&cmp_val, &store_data[lane * src_stride + 8], 8);
         new_val = apply_int_atomic(d.atomic_op, old_val, src_val, cmp_val);
       }
       lds->write64(addr, new_val);
-      std::memcpy(&d.response_data[lane * 8], &old_val, 8);
+      std::memcpy(&response_data[lane * 8], &old_val, 8);
     }
   }
 }
@@ -504,6 +507,7 @@ MemoryAccessCompletion GlobalMemPipeline::complete_access(Instruction &inst, Wav
 void LocalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
   auto &d = *inst.data_as<VectorMemState>();
   auto &lds = wf.lds();
+  d.wf_size = wf.wf_size();
   if (d.cu_path.empty()) {
     d.cu_path = wf.cu().full_path();
     d.wg_id = wf.wg_id();
@@ -511,7 +515,10 @@ void LocalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
   }
 
   if (d.atomic_op != AtomicOp::NONE) {
-    execute_lds_atomic_rmw(d, &lds);
+    execute_lds_atomic_rmw(d, &lds, d.per_lane_addr, d.store_data, d.response_data);
+    if (d.ds2_active) {
+      execute_lds_atomic_rmw(d, &lds, d.ds2_per_lane_addr, d.ds2_store_data, d.ds2_response_data);
+    }
     return;
   }
 
@@ -601,7 +608,7 @@ MemoryAccessCompletion LocalMemPipeline::complete_access(Instruction &inst, Wave
     transpose_response(d);
   MemoryAccessCompletion completion = vector_complete(d, wf, wf.raw_cu(), std::move(complete));
 
-  // DS dual-access (ds_read2/ds_write2): write the second access results.
+  // DS dual-access: write the second load or returning-atomic result.
   if (d.ds2_active && d.is_load) {
     auto &cu = wf.raw_cu();
     uint32_t vgpr_count = d.elem_size / 4;
@@ -615,12 +622,12 @@ MemoryAccessCompletion LocalMemPipeline::complete_access(Instruction &inst, Wave
         cu.write_vgpr(d.ds2_dst_reg_base + i, lane, val);
       }
     }
-    // Per-lane DS read2 complete trace: show first 4 lanes with both accesses.
+    // Per-lane dual-access completion trace.
     util::Logger::vm([&](auto &os) {
       static thread_local uint64_t ds2_comp_trace = 0;
       if (++ds2_comp_trace > 80)
         return;
-      os << std::format("DS read2 complete: dst1_v={} dst2_v={}", d.dst_reg_base,
+      os << std::format("DS dual-access complete: dst1_v={} dst2_v={}", d.dst_reg_base,
                         d.ds2_dst_reg_base);
       for (uint32_t ln = 0; ln < d.wf_size; ++ln) {
         if (!(d.lane_mask & (1ULL << ln)))

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -8,7 +8,9 @@
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/config/config_loader.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/builders.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/execution_backend.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/opcodes.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/operand.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/vds.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/vglobal.h"
@@ -3426,6 +3428,55 @@ TEST(Gfx1250DecodeTest, WmmaScaleF4_32x16x128ConsumesVop3px2Pair) {
             "v_wmma_scale_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], 0, v40, v41");
 }
 
+TEST(Gfx1250ExecutionTest, WmmaRegularScaleInlineZeroMatchesNeutralScalarSources) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = sim.dispatch_scratch_wf();
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0xffffffffu);
+
+  constexpr uint16_t kVgprEncoding = 256;
+  constexpr auto scalar_prefix =
+      gfx1250::build_vop3p(0x35, {.src0 = 0, .src1 = 1, .src2 = kVgprEncoding});
+  constexpr auto inline_prefix =
+      gfx1250::build_vop3p(0x35, {.src0 = 128, .src1 = 128, .src2 = kVgprEncoding});
+  constexpr auto scalar_matrix = gfx1250::build_vop3p(
+      gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p,
+      {.vdst = 32, .src0 = kVgprEncoding, .src1 = kVgprEncoding + 16, .src2 = kVgprEncoding + 32});
+  constexpr auto inline_matrix = gfx1250::build_vop3p(
+      gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p,
+      {.vdst = 40, .src0 = kVgprEncoding, .src1 = kVgprEncoding + 16, .src2 = kVgprEncoding + 40});
+  const std::array<uint32_t, 4> scalar_words = {scalar_prefix[0], scalar_prefix[1],
+                                                scalar_matrix[0], scalar_matrix[1]};
+  const std::array<uint32_t, 4> inline_words = {inline_prefix[0], inline_prefix[1],
+                                                inline_matrix[0], inline_matrix[1]};
+
+  write_wave_sgpr(*cu, *wf, 0, 0x7f7f7f7fu);
+  write_wave_sgpr(*cu, *wf, 1, 0x7f7f7f7fu);
+  const uint32_t vgpr_base = wf->vgpr_alloc().base;
+  for (uint32_t reg = 0; reg < 32; ++reg)
+    for (uint32_t lane = 0; lane < wf->wf_size(); ++lane)
+      cu->write_vgpr(vgpr_base + reg, lane, 0x38383838u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> scalar_inst(decoder->decode(scalar_words.data()));
+  std::unique_ptr<Instruction> inline_inst(decoder->decode(inline_words.data()));
+  ASSERT_NE(scalar_inst, nullptr);
+  ASSERT_NE(inline_inst, nullptr);
+  cu->execute_instruction(scalar_inst.get(), *wf);
+  cu->execute_instruction(inline_inst.get(), *wf);
+
+  for (uint32_t reg = 0; reg < 8; ++reg)
+    for (uint32_t lane = 0; lane < wf->wf_size(); ++lane) {
+      const uint32_t scalar_result = cu->read_vgpr(vgpr_base + 32 + reg, lane);
+      EXPECT_EQ(scalar_result, std::bit_cast<uint32_t>(128.0f))
+          << "reg " << reg << ", lane " << lane;
+      EXPECT_EQ(cu->read_vgpr(vgpr_base + 40 + reg, lane), scalar_result)
+          << "reg " << reg << ", lane " << lane;
+    }
+}
+
 TEST(Gfx1250DecodeTest, SwmmacPrintsIndexKeyAndReuseModifiers) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
@@ -4733,6 +4784,181 @@ TEST(Gfx1250SimulationTest, DsStore2addrUsesSrc2HighBank) {
   EXPECT_EQ(actual1, kExpected1);
 }
 
+TEST(Gfx1250SimulationTest, DsStorexchg2addrB64ExchangesBothAddresses) {
+  Gfx1250Sim sim;
+  auto *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1u);
+
+  auto &cu = *sim.cu();
+  wf->set_lds_base(cu.allocate_lds(256));
+  constexpr uint32_t kAddr = 1;
+  constexpr uint32_t kData0 = 2;
+  constexpr uint32_t kData1 = 4;
+  constexpr uint32_t kDst = 6;
+  constexpr uint32_t kAddress = 0x20;
+  constexpr uint64_t kOld0 = 0x1122334455667788ull;
+  constexpr uint64_t kOld1 = 0x99AABBCCDDEEFF00ull;
+  constexpr uint64_t kNew0 = 0x0123456789ABCDEFull;
+  constexpr uint64_t kNew1 = 0xFEDCBA9876543210ull;
+  const uint32_t vb = wf->vgpr_alloc().base;
+
+  cu.write_vgpr(vb + kAddr, 0, kAddress);
+  cu.write_vgpr(vb + kData0, 0, static_cast<uint32_t>(kNew0));
+  cu.write_vgpr(vb + kData0 + 1, 0, static_cast<uint32_t>(kNew0 >> 32));
+  cu.write_vgpr(vb + kData1, 0, static_cast<uint32_t>(kNew1));
+  cu.write_vgpr(vb + kData1 + 1, 0, static_cast<uint32_t>(kNew1 >> 32));
+  cu.lds().write64(wf->lds_base() + kAddress + 8, kOld0);
+  cu.lds().write64(wf->lds_base() + kAddress + 24, kOld1);
+
+  gfx1250::VdsMachineInst raw{};
+  raw.addr = kAddr;
+  raw.data0 = kData0;
+  raw.data1 = kData1;
+  raw.vdst = kDst;
+  raw.offset0 = 1;
+  raw.offset1 = 3;
+  auto *inst =
+      new gfx1250::DsStorexchg2addrRtnB64Vds(reinterpret_cast<const gfx1250::MachineInst *>(&raw));
+  inst->execute_impl(*wf);
+
+  auto *state = inst->data_as<amdgpu::VectorMemState>();
+  ASSERT_NE(state, nullptr);
+  EXPECT_EQ(state->wf_size, wf->wf_size());
+  EXPECT_EQ(state->per_lane_addr[0], wf->lds_base() + kAddress + 8);
+  EXPECT_EQ(state->ds2_per_lane_addr[0], wf->lds_base() + kAddress + 24);
+
+  amdgpu::LocalMemPipeline local_pipeline;
+  local_pipeline.issue(inst, *wf);
+
+  EXPECT_EQ(cu.lds().read64(wf->lds_base() + kAddress + 8), kNew0);
+  EXPECT_EQ(cu.lds().read64(wf->lds_base() + kAddress + 24), kNew1);
+  const uint64_t returned0 =
+      cu.read_vgpr(vb + kDst, 0) | (static_cast<uint64_t>(cu.read_vgpr(vb + kDst + 1, 0)) << 32);
+  const uint64_t returned1 = cu.read_vgpr(vb + kDst + 2, 0) |
+                             (static_cast<uint64_t>(cu.read_vgpr(vb + kDst + 3, 0)) << 32);
+  EXPECT_EQ(returned0, kOld0);
+  EXPECT_EQ(returned1, kOld1);
+}
+
+TEST(Gfx1250SimulationTest, DsStorexchg2addrStride64B32UsesScaledOffsetsForActiveLanes) {
+  Gfx1250Sim sim;
+  auto *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0x5u);
+
+  auto &cu = *sim.cu();
+  wf->set_lds_base(cu.allocate_lds(1024));
+  constexpr uint32_t kAddr = 1;
+  constexpr uint32_t kData0 = 2;
+  constexpr uint32_t kData1 = 3;
+  constexpr uint32_t kDst = 4;
+  constexpr uint32_t kLane0Address = 0x20;
+  constexpr uint32_t kLane2Address = 0x40;
+  constexpr uint32_t kOffset0 = 256;
+  constexpr uint32_t kOffset1 = 768;
+  constexpr uint32_t kLane0New0 = 0x01020304;
+  constexpr uint32_t kLane0New1 = 0x11121314;
+  constexpr uint32_t kLane2New0 = 0x21222324;
+  constexpr uint32_t kLane2New1 = 0x31323334;
+  constexpr uint32_t kLane0Old0 = 0x41424344;
+  constexpr uint32_t kLane0Old1 = 0x51525354;
+  constexpr uint32_t kLane2Old0 = 0x61626364;
+  constexpr uint32_t kLane2Old1 = 0x71727374;
+  constexpr uint32_t kInactiveSentinel = 0xDEADBEEF;
+  const uint32_t vb = wf->vgpr_alloc().base;
+
+  cu.write_vgpr(vb + kAddr, 0, kLane0Address);
+  cu.write_vgpr(vb + kAddr, 2, kLane2Address);
+  cu.write_vgpr(vb + kData0, 0, kLane0New0);
+  cu.write_vgpr(vb + kData1, 0, kLane0New1);
+  cu.write_vgpr(vb + kData0, 2, kLane2New0);
+  cu.write_vgpr(vb + kData1, 2, kLane2New1);
+  cu.write_vgpr(vb + kDst, 1, kInactiveSentinel);
+  cu.write_vgpr(vb + kDst + 1, 1, kInactiveSentinel);
+
+  const uint32_t lane0_addr0 = wf->lds_base() + kLane0Address + kOffset0;
+  const uint32_t lane0_addr1 = wf->lds_base() + kLane0Address + kOffset1;
+  const uint32_t lane2_addr0 = wf->lds_base() + kLane2Address + kOffset0;
+  const uint32_t lane2_addr1 = wf->lds_base() + kLane2Address + kOffset1;
+  cu.lds().write32(lane0_addr0, kLane0Old0);
+  cu.lds().write32(lane0_addr1, kLane0Old1);
+  cu.lds().write32(lane2_addr0, kLane2Old0);
+  cu.lds().write32(lane2_addr1, kLane2Old1);
+
+  gfx1250::VdsMachineInst raw{};
+  raw.addr = kAddr;
+  raw.data0 = kData0;
+  raw.data1 = kData1;
+  raw.vdst = kDst;
+  raw.offset0 = 1;
+  raw.offset1 = 3;
+  auto *inst = new gfx1250::DsStorexchg2addrStride64RtnB32Vds(
+      reinterpret_cast<const gfx1250::MachineInst *>(&raw));
+  inst->execute_impl(*wf);
+
+  auto *state = inst->data_as<amdgpu::VectorMemState>();
+  ASSERT_NE(state, nullptr);
+  EXPECT_EQ(state->per_lane_addr[0], lane0_addr0);
+  EXPECT_EQ(state->ds2_per_lane_addr[0], lane0_addr1);
+  EXPECT_EQ(state->per_lane_addr[2], lane2_addr0);
+  EXPECT_EQ(state->ds2_per_lane_addr[2], lane2_addr1);
+
+  amdgpu::LocalMemPipeline local_pipeline;
+  local_pipeline.issue(inst, *wf);
+
+  EXPECT_EQ(cu.lds().read32(lane0_addr0), kLane0New0);
+  EXPECT_EQ(cu.lds().read32(lane0_addr1), kLane0New1);
+  EXPECT_EQ(cu.lds().read32(lane2_addr0), kLane2New0);
+  EXPECT_EQ(cu.lds().read32(lane2_addr1), kLane2New1);
+  EXPECT_EQ(cu.read_vgpr(vb + kDst, 0), kLane0Old0);
+  EXPECT_EQ(cu.read_vgpr(vb + kDst + 1, 0), kLane0Old1);
+  EXPECT_EQ(cu.read_vgpr(vb + kDst, 2), kLane2Old0);
+  EXPECT_EQ(cu.read_vgpr(vb + kDst + 1, 2), kLane2Old1);
+  EXPECT_EQ(cu.read_vgpr(vb + kDst, 1), kInactiveSentinel);
+  EXPECT_EQ(cu.read_vgpr(vb + kDst + 1, 1), kInactiveSentinel);
+}
+
+TEST(Gfx1250SimulationTest, DsStorexchg2addrSameAddressAppliesBothExchangesInOrder) {
+  Gfx1250Sim sim;
+  auto *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1u);
+
+  auto &cu = *sim.cu();
+  wf->set_lds_base(cu.allocate_lds(64));
+  constexpr uint32_t kAddr = 1;
+  constexpr uint32_t kData0 = 2;
+  constexpr uint32_t kData1 = 3;
+  constexpr uint32_t kDst = 4;
+  constexpr uint32_t kAddress = 0x20;
+  constexpr uint32_t kOld = 0x11223344;
+  constexpr uint32_t kNew0 = 0x55667788;
+  constexpr uint32_t kNew1 = 0x99AABBCC;
+  const uint32_t vb = wf->vgpr_alloc().base;
+
+  cu.write_vgpr(vb + kAddr, 0, kAddress);
+  cu.write_vgpr(vb + kData0, 0, kNew0);
+  cu.write_vgpr(vb + kData1, 0, kNew1);
+  cu.lds().write32(wf->lds_base() + kAddress, kOld);
+
+  gfx1250::VdsMachineInst raw{};
+  raw.addr = kAddr;
+  raw.data0 = kData0;
+  raw.data1 = kData1;
+  raw.vdst = kDst;
+  auto *inst =
+      new gfx1250::DsStorexchg2addrRtnB32Vds(reinterpret_cast<const gfx1250::MachineInst *>(&raw));
+  inst->execute_impl(*wf);
+
+  amdgpu::LocalMemPipeline local_pipeline;
+  local_pipeline.issue(inst, *wf);
+
+  EXPECT_EQ(cu.read_vgpr(vb + kDst, 0), kOld);
+  EXPECT_EQ(cu.read_vgpr(vb + kDst + 1, 0), kNew0);
+  EXPECT_EQ(cu.lds().read32(wf->lds_base() + kAddress), kNew1);
+}
+
 TEST(Gfx1250SimulationTest, DsTransposeLoadUsesHighDestinationBank) {
   Gfx1250Sim sim;
   // Resident wave: these tests inject instructions directly (execute_impl) and read
@@ -4935,6 +5161,71 @@ TEST(Gfx1250SimulationTest, AddtidStoresUseSrc1HighBank) {
   uint32_t global_value = 0;
   std::memcpy(&global_value, global_state->store_data.data(), sizeof(global_value));
   EXPECT_EQ(global_value, kExpected);
+}
+
+TEST(Gfx1250SimulationTest, DsAddtidLoadAndStoreUseM0ByteBaseAddresses) {
+  Gfx1250Sim sim;
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf(kGfx1250Wave32VgprAllocation);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0x3u);
+
+  auto &cu = *sim.cu();
+  wf->set_lds_base(cu.allocate_lds(0x4000));
+  constexpr uint32_t kM0ByteBase = 0x1000;
+  wf->set_m0(kM0ByteBase);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  const uint32_t vb = wf->vgpr_alloc().base;
+  constexpr uint32_t kLane0Data = 0x12345678u;
+  constexpr uint32_t kLane1Data = 0x9ABCDEF0u;
+  cu.write_vgpr(vb + 5, 0, kLane0Data);
+  cu.write_vgpr(vb + 5, 1, kLane1Data);
+  const uint32_t expected0 = wf->lds_base() + kM0ByteBase + 0x1234;
+  const uint32_t expected1 = expected0 + sizeof(uint32_t);
+
+  const uint32_t store_words[] = {0xDAC01234u, 0x00000500u};
+  std::unique_ptr<Instruction> store(decoder->decode(store_words));
+  ASSERT_NE(store, nullptr);
+  ASSERT_EQ(std::string_view(store->mnemonic()), "ds_store_addtid_b32");
+  cu.execute_instruction(store.get(), *wf);
+  auto *store_state = store->data_as<amdgpu::VectorMemState>();
+  ASSERT_NE(store_state, nullptr);
+  EXPECT_EQ(store_state->per_lane_addr[0], expected0);
+  EXPECT_EQ(store_state->per_lane_addr[1], expected1);
+  uint32_t lane0_data = 0;
+  uint32_t lane1_data = 0;
+  std::memcpy(&lane0_data, &store_state->store_data[0], sizeof(lane0_data));
+  std::memcpy(&lane1_data, &store_state->store_data[4], sizeof(lane1_data));
+  EXPECT_EQ(lane0_data, kLane0Data);
+  EXPECT_EQ(lane1_data, kLane1Data);
+  amdgpu::LocalMemPipeline local_pipeline;
+  local_pipeline.issue(store.release(), *wf);
+  EXPECT_EQ(cu.lds().read32(expected0), kLane0Data);
+  EXPECT_EQ(cu.lds().read32(expected1), kLane1Data);
+
+  const uint32_t load_words[] = {0xDAC41234u, 0x08000000u};
+  std::unique_ptr<Instruction> load(decoder->decode(load_words));
+  ASSERT_NE(load, nullptr);
+  ASSERT_EQ(std::string_view(load->mnemonic()), "ds_load_addtid_b32");
+  cu.execute_instruction(load.get(), *wf);
+  auto *load_state = load->data_as<amdgpu::VectorMemState>();
+  ASSERT_NE(load_state, nullptr);
+  EXPECT_EQ(load_state->per_lane_addr[0], expected0);
+  EXPECT_EQ(load_state->per_lane_addr[1], expected1);
+  const uint32_t load_dst_base = load_state->dst_reg_base;
+  local_pipeline.issue(load.release(), *wf);
+  EXPECT_EQ(cu.read_vgpr(load_dst_base, 0), kLane0Data);
+  EXPECT_EQ(cu.read_vgpr(load_dst_base, 1), kLane1Data);
+
+  wf->set_m0(0);
+  std::unique_ptr<Instruction> default_m0_store(decoder->decode(store_words));
+  ASSERT_NE(default_m0_store, nullptr);
+  cu.execute_instruction(default_m0_store.get(), *wf);
+  auto *default_m0_state = default_m0_store->data_as<amdgpu::VectorMemState>();
+  ASSERT_NE(default_m0_state, nullptr);
+  EXPECT_EQ(default_m0_state->per_lane_addr[0], wf->lds_base() + 0x1234);
+  EXPECT_EQ(default_m0_state->per_lane_addr[1], wf->lds_base() + 0x1238);
 }
 
 TEST(Gfx1250SimulationTest, VMovrelsReadsM0RelativeVgpr) {


### PR DESCRIPTION
## Motivation

The functional gfx1250 simulator must execute untranslated code objects so translation qualification has an independent semantic baseline. Several LDS forms used the wrong behavior, dual-address exchanges were not distinct in the generated semantics, and regular scaled WMMA interpreted the inline neutral-scale encoding as numerical zero.

## Technical Details

- Add profile-gated semantics for the affected two-address and ADDTID VDS instructions.
- Model distinct dual-address exchange behavior and route the correct addresses and wait counters through the memory pipeline.
- Fix generated wait-counter labels and keep the gfx1250 execution sources reproducible.
- Interpret inline integer zero as the neutral E8M0 word for regular scaled WMMA while preserving ordinary operand semantics elsewhere.
- Cover the generated profile gates, LDS address behavior, dual-address exchanges, and numeric WMMA equivalence.

## Test Plan

Build RocJITsu in an isolated worktree, run the full gfx1250 simulator test selection, and run the complete AMD ISA generator test suite.

## Test Result

The gfx1250 simulator tests and AMD ISA generator suite pass. The scaled-WMMA regression also produces identical results for inline and explicit neutral scales.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.