### PR TITLE
fix(rocprofiler-compute): validate pc sampling config from device

### DIFF
--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -544,6 +544,15 @@ add_test(
         ${WORKING_DIR_OPTION}
 )
 
+# rocprofv3 avail library interface — no GPU required
+add_test(
+    NAME test_rocprofv3_avail_interface
+    COMMAND
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION}
+        --junitxml=tests/test_rocprofv3_avail_interface.xml ${COV_OPTION}
+        tests/test_rocprofv3_avail_interface.py ${WORKING_DIR_OPTION}
+)
+
 # Memory chart CLI renderers (gfx9 plotille + gfx11 Rich) — no GPU required
 add_test(
     NAME test_mem_chart
@@ -880,6 +889,7 @@ if(${ENABLE_COVERAGE})
         test_metric_validation
         test_native_tool_finder
         test_profiler_base
+        test_rocprofv3_avail_interface
         test_soc_base
         test_tty
         test_utils_profile_csv

--- a/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
+++ b/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
@@ -28,7 +28,7 @@ Profiling options
 For using profiling options for PC sampling the configuration needed are:
 
 * ``--pc-sampling-method``: Should be either ``stochastic`` or ``host_trap``, (DEFAULT: stochastic)
-* ``--pc-sampling-interval``: For ``stochastic`` sampling, the interval is in cycles; it must be a power of 2 and at least 65536 (DEFAULT: 1048576). These are hardware limits reported by the driver. For ``host_trap`` sampling, the interval is in microseconds and may be any positive integer (DEFAULT: 512). When omitted, the method-appropriate default is used.
+* ``--pc-sampling-interval``: The accepted range is read from the device; see ``rocprofv3-avail info --pc-sampling``. When the device cannot be queried, 1 to 1048576 is accepted. For ``stochastic`` sampling, the interval is in cycles and must be a power of 2 (DEFAULT: 1048576). For ``host_trap`` sampling, the interval is in microseconds (DEFAULT: 512). When omitted, the method-appropriate default is used.
 
 **Sample command:**
 

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -634,9 +634,11 @@ Examples:
         experimental_enabled=experimental_enabled,
         feature_label="PC Sampling",
         help=(
-            "\t\t\tSet the interval of pc sampling.\n"
-            "\t\t\t  For stochastic sampling, the interval is in cycles; it "
-            "must be a power of 2 and at least 65536 (DEFAULT: 1048576).\n"
+            "\t\t\tSet the interval of pc sampling. The accepted range is "
+            "read from the device; see 'rocprofv3-avail info --pc-sampling'. "
+            "When the device cannot be queried, 1 to 1048576 is accepted.\n"
+            "\t\t\t  For stochastic sampling, the interval is in cycles and "
+            "must be a power of 2 (DEFAULT: 1048576).\n"
             "\t\t\t  For host_trap sampling, the interval is in microseconds "
             "(DEFAULT: 512)."
         ),

--- a/projects/rocprofiler-compute/src/pc_sampling/pc_sampling_profile.py
+++ b/projects/rocprofiler-compute/src/pc_sampling/pc_sampling_profile.py
@@ -2,20 +2,19 @@
 # SPDX-License-Identifier:  MIT
 
 import argparse
-import ctypes
 import os
 import shlex
 import time
-from pathlib import Path
-from typing import Optional, TypedDict, Union, cast
+from dataclasses import dataclass
+from typing import Optional, Union, cast
 
+from utils import rocprofv3_avail_interface
 from utils.logger import console_debug, console_error, console_log
 from utils.utils_common import (
     PC_SAMPLING_BLOCK_IDS,
     capture_subprocess_output,
     get_rocprof_cmd,
     perform_attach_detach,
-    resolve_rocm_library_path,
 )
 from utils.utils_profile import ProfilerOptions, is_live_attach
 
@@ -23,12 +22,13 @@ from utils.utils_profile import ProfilerOptions, is_live_attach
 PC_SAMPLING_DEFAULT_INTERVALS = {"stochastic": 1048576, "host_trap": 512}
 
 
-class PCSamplingLimits(TypedDict):
+@dataclass
+class PCSamplingLimits:
     """Interval bounds a sampling method accepts, and whether it needs pow2."""
 
     min_interval: int
     max_interval: int
-    interval_pow2: bool
+    interval_pow2: bool = False
 
 
 def pc_sampling_interval_limits(
@@ -46,112 +46,47 @@ def pc_sampling_interval_limits(
     """
     # Limits rocprofiler-sdk falls back to, see its
     # source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.cpp
-    fallback: PCSamplingLimits = {
-        "min_interval": 1,
-        "max_interval": 1048576,
-        "interval_pow2": method == "stochastic",
-    }
-
-    library = _load_avail_library(sdk_tool_path)
-    if library is None:
-        return fallback
+    fallback = PCSamplingLimits(
+        min_interval=1,
+        max_interval=1048576,
+        interval_pow2=method == "stochastic",
+    )
 
     try:
-        return _query_agent_interval_limits(library).get(method)
+        configs = rocprofv3_avail_interface.get_pc_sample_configs(sdk_tool_path)
     except (AttributeError, OSError, ValueError) as err:
         console_debug(f"PC sampling interval limit query failed: {err}")
         return fallback
 
+    if configs is None:
+        return fallback
 
-def _load_avail_library(sdk_tool_path: Optional[str]) -> Optional[ctypes.CDLL]:
-    """Load the avail library sitting beside the rocprofiler-sdk tool.
-
-    The library reports no PC sampling configuration unless the beta gate is
-    set before it initializes, so it is warmed up while the gate is in place.
-    """
-    if not sdk_tool_path:
-        return None
-
-    library_path = resolve_rocm_library_path(
-        str(Path(sdk_tool_path).parent / "librocprofv3-list-avail.so")
-    )
-    if not library_path or not Path(library_path).exists():
-        console_debug("PC sampling: librocprofv3-list-avail.so not found")
-        return None
-
-    beta_gate = "ROCPROFILER_PC_SAMPLING_BETA_ENABLED"
-    previous_gate = os.environ.get(beta_gate)
-    os.environ[beta_gate] = "on"
-    try:
-        library = ctypes.CDLL(library_path)
-        library.get_number_of_agents.restype = ctypes.c_ulong
-        library.get_number_of_pc_sample_configs.restype = ctypes.c_ulong
-        library.pc_sample_config.argtypes = [ctypes.c_ulong, ctypes.c_ulong] + [
-            ctypes.POINTER(ctypes.c_ulong)
-        ] * 5
-        library.get_number_of_agents()
-        return library
-    except OSError as err:
-        console_debug(f"PC sampling: unable to load {library_path}: {err}")
-        return None
-    finally:
-        if previous_gate is None:
-            os.environ.pop(beta_gate, None)
-        else:
-            os.environ[beta_gate] = previous_gate
+    return _merge_interval_limits(configs).get(method)
 
 
-def _query_agent_configs(
-    library: ctypes.CDLL,
-    agent_handle: int,
-) -> list[tuple[int, ...]]:
-    """Return (method, unit, min, max, flags) for each config of one agent."""
-    configs = []
-    for config_index in range(library.get_number_of_pc_sample_configs(agent_handle)):
-        fields = [ctypes.c_ulong() for _ in range(5)]
-        library.pc_sample_config(
-            agent_handle, config_index, *(ctypes.byref(field) for field in fields)
-        )
-        configs.append(tuple(field.value for field in fields))
-    return configs
-
-
-def _query_agent_interval_limits(
-    library: ctypes.CDLL,
+def _merge_interval_limits(
+    configs: list[tuple[int, ...]],
 ) -> dict[str, PCSamplingLimits]:
     """Merge every agent's configurations into per-method interval limits.
 
     The SDK configures PC sampling when any single agent supports the request,
     so the accepted range is the union across agents.
     """
-    agent_count = library.get_number_of_agents()
-    library.agent_handles.argtypes = [ctypes.c_ulong * agent_count, ctypes.c_ulong]
-    agent_handles = (ctypes.c_ulong * agent_count)()
-    library.agent_handles(agent_handles, agent_count)
-
     # Keyed on (method id, unit id) from rocprofiler-sdk/fwd.h, since the SDK
     # matches a requested configuration on both fields.
     supported = {(1, 2): "stochastic", (2, 3): "host_trap"}
     limits: dict[str, PCSamplingLimits] = {}
-    for agent_handle in agent_handles:
-        for method_id, unit, minimum, maximum, flags in _query_agent_configs(
-            library, agent_handle
-        ):
-            method = supported.get((method_id, unit))
-            if method is None:
-                continue
-            known = limits.setdefault(
-                method,
-                {
-                    "min_interval": minimum,
-                    "max_interval": maximum,
-                    "interval_pow2": False,
-                },
-            )
-            known["min_interval"] = min(known["min_interval"], minimum)
-            known["max_interval"] = max(known["max_interval"], maximum)
-            # INTERVAL_POW2 is bit 0 of the configuration flags.
-            known["interval_pow2"] = known["interval_pow2"] or bool(flags & 1)
+    for method_id, unit, minimum, maximum, flags in configs:
+        method = supported.get((method_id, unit))
+        if method is None:
+            continue
+        known = limits.setdefault(
+            method, PCSamplingLimits(min_interval=minimum, max_interval=maximum)
+        )
+        known.min_interval = min(known.min_interval, minimum)
+        known.max_interval = max(known.max_interval, maximum)
+        # INTERVAL_POW2 is bit 0 of the configuration flags.
+        known.interval_pow2 = known.interval_pow2 or bool(flags & 1)
     return limits
 
 

--- a/projects/rocprofiler-compute/src/pc_sampling/pc_sampling_profile.py
+++ b/projects/rocprofiler-compute/src/pc_sampling/pc_sampling_profile.py
@@ -19,186 +19,123 @@ from utils.utils_common import (
 )
 from utils.utils_profile import ProfilerOptions, is_live_attach
 
-AVAIL_LIBRARY_NAME = "librocprofv3-list-avail.so"
-
-# The avail library reports no PC sampling configurations unless the beta gate
-# is set before it initializes, the same way rocprofv3-avail sets it.
-PC_SAMPLING_BETA_ENV = "ROCPROFILER_PC_SAMPLING_BETA_ENABLED"
-
-# Enum values from rocprofiler_pc_sampling_method_t and
-# rocprofiler_pc_sampling_unit_t in rocprofiler-sdk/pc_sampling.h.
-PC_SAMPLING_METHOD_IDS = {1: "stochastic", 2: "host_trap"}
-PC_SAMPLING_METHOD_UNIT_IDS = {"stochastic": 2, "host_trap": 3}
-PC_SAMPLING_FLAG_INTERVAL_POW2 = 1
-
+# Interval defaults: cycles for stochastic, microseconds for host_trap.
 PC_SAMPLING_DEFAULT_INTERVALS = {"stochastic": 1048576, "host_trap": 512}
-
-# Used when the GPU cannot be queried. The ceiling mirrors the 1 MB clamp the
-# SDK applies to the driver-reported maximum.
-PC_SAMPLING_STATIC_INTERVAL_LIMITS = {
-    "stochastic": {
-        "min_interval": 65536,
-        "max_interval": 1048576,
-        "interval_pow2": True,
-    },
-    "host_trap": {
-        "min_interval": 1,
-        "max_interval": 1048576,
-        "interval_pow2": False,
-    },
-}
-
-
-def query_pc_sampling_configs(
-    sdk_tool_path: Optional[str] = None,
-) -> dict[str, dict[str, int]]:
-    """Return the PC sampling interval limits reported by the local GPUs,
-    keyed by sampling method.
-
-    Mirrors `rocprofv3-avail info --pc-sampling` by loading
-    librocprofv3-list-avail.so and walking each agent's configurations.
-    Returns an empty dict when no GPU agent can be queried.
-    """
-    previous_beta_gate = os.environ.get(PC_SAMPLING_BETA_ENV)
-    os.environ[PC_SAMPLING_BETA_ENV] = "on"
-    try:
-        library = _load_avail_library(sdk_tool_path)
-        if library is None:
-            return {}
-        return _merge_agent_interval_limits(library)
-    except (AttributeError, OSError, ValueError) as err:
-        console_debug(f"PC sampling configuration query failed: {err}")
-        return {}
-    finally:
-        if previous_beta_gate is None:
-            os.environ.pop(PC_SAMPLING_BETA_ENV, None)
-        else:
-            os.environ[PC_SAMPLING_BETA_ENV] = previous_beta_gate
 
 
 def pc_sampling_interval_limits(
     method: str,
     sdk_tool_path: Optional[str] = None,
 ) -> dict[str, int]:
-    """Return the interval limits for one sampling method, falling back to
-    static limits when the GPU cannot be queried."""
-    queried = query_pc_sampling_configs(sdk_tool_path).get(method)
-    if queried is not None:
-        return queried
+    """Return the interval limits the GPUs report for one sampling method.
 
-    console_debug(f"PC sampling: using static interval limits for {method}")
-    return PC_SAMPLING_STATIC_INTERVAL_LIMITS[method]
+    Mirrors `rocprofv3-avail info --pc-sampling`.
+    """
+    # Limits rocprofiler-sdk falls back to, see its
+    # source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.cpp
+    fallback = {
+        "min_interval": 1,
+        "max_interval": 1048576,
+        "interval_pow2": method == "stochastic",
+    }
 
+    library = _load_avail_library(sdk_tool_path)
+    if library is None:
+        return fallback
 
-def _resolve_avail_library_path(sdk_tool_path: Optional[str]) -> Optional[str]:
-    """Locate the avail library next to the SDK tool, or under ROCM_PATH."""
-    if sdk_tool_path:
-        candidate = Path(sdk_tool_path).parent / AVAIL_LIBRARY_NAME
-    else:
-        candidate = (
-            Path(os.getenv("ROCM_PATH", "/opt/rocm"))
-            / "lib/rocprofiler-sdk"
-            / AVAIL_LIBRARY_NAME
-        )
-    return resolve_rocm_library_path(str(candidate))
+    try:
+        return _query_agent_interval_limits(library).get(method, fallback)
+    except (AttributeError, OSError, ValueError) as err:
+        console_debug(f"PC sampling interval limit query failed: {err}")
+        return fallback
 
 
 def _load_avail_library(sdk_tool_path: Optional[str]) -> Optional[ctypes.CDLL]:
-    """Load the avail library, returning None when it is unusable."""
-    library_path = _resolve_avail_library_path(sdk_tool_path)
-    if not library_path or not Path(library_path).exists():
-        console_debug(f"PC sampling: {AVAIL_LIBRARY_NAME} not found")
+    """Load the avail library sitting beside the rocprofiler-sdk tool.
+
+    The library reports no PC sampling configuration unless the beta gate is
+    set before it initializes, so it is warmed up while the gate is in place.
+    """
+    if not sdk_tool_path:
         return None
 
+    library_path = resolve_rocm_library_path(
+        str(Path(sdk_tool_path).parent / "librocprofv3-list-avail.so")
+    )
+    if not library_path or not Path(library_path).exists():
+        console_debug("PC sampling: librocprofv3-list-avail.so not found")
+        return None
+
+    beta_gate = "ROCPROFILER_PC_SAMPLING_BETA_ENABLED"
+    previous_gate = os.environ.get(beta_gate)
+    os.environ[beta_gate] = "on"
     try:
-        return ctypes.CDLL(library_path)
+        library = ctypes.CDLL(library_path)
+        library.get_number_of_agents.restype = ctypes.c_ulong
+        library.get_number_of_pc_sample_configs.restype = ctypes.c_ulong
+        library.pc_sample_config.argtypes = [ctypes.c_ulong, ctypes.c_ulong] + [
+            ctypes.POINTER(ctypes.c_ulong)
+        ] * 5
+        library.get_number_of_agents()
+        return library
     except OSError as err:
         console_debug(f"PC sampling: unable to load {library_path}: {err}")
         return None
+    finally:
+        if previous_gate is None:
+            os.environ.pop(beta_gate, None)
+        else:
+            os.environ[beta_gate] = previous_gate
 
 
-def _query_agent_handles(library: ctypes.CDLL) -> list[int]:
-    """Return the handles of every agent the avail library reports."""
-    library.get_number_of_agents.restype = ctypes.c_ulong
-    agent_count = library.get_number_of_agents()
-    if agent_count == 0:
-        return []
-
-    library.agent_handles.argtypes = [ctypes.c_ulong * agent_count, ctypes.c_ulong]
-    agent_handles = (ctypes.c_ulong * agent_count)()
-    library.agent_handles(agent_handles, agent_count)
-    return list(agent_handles)
-
-
-def _query_agent_pc_sampling_configs(
+def _query_agent_configs(
     library: ctypes.CDLL,
     agent_handle: int,
-) -> list[dict[str, int]]:
-    """Return every PC sampling configuration supported by one agent."""
-    library.get_number_of_pc_sample_configs.argtypes = [ctypes.c_ulong]
-    library.get_number_of_pc_sample_configs.restype = ctypes.c_ulong
-    config_count = library.get_number_of_pc_sample_configs(agent_handle)
-    if config_count == 0:
-        return []
-
-    library.pc_sample_config.argtypes = [ctypes.c_ulong, ctypes.c_ulong] + [
-        ctypes.POINTER(ctypes.c_ulong)
-    ] * 5
-
+) -> list[tuple[int, ...]]:
+    """Return (method, unit, min, max, flags) for each config of one agent."""
     configs = []
-    for config_index in range(config_count):
-        method = ctypes.c_ulong()
-        unit = ctypes.c_ulong()
-        min_interval = ctypes.c_ulong()
-        max_interval = ctypes.c_ulong()
-        flags = ctypes.c_ulong()
+    for config_index in range(library.get_number_of_pc_sample_configs(agent_handle)):
+        fields = [ctypes.c_ulong() for _ in range(5)]
         library.pc_sample_config(
-            agent_handle,
-            config_index,
-            ctypes.byref(method),
-            ctypes.byref(unit),
-            ctypes.byref(min_interval),
-            ctypes.byref(max_interval),
-            ctypes.byref(flags),
+            agent_handle, config_index, *(ctypes.byref(field) for field in fields)
         )
-        configs.append({
-            "method": method.value,
-            "unit": unit.value,
-            "min_interval": min_interval.value,
-            "max_interval": max_interval.value,
-            "flags": flags.value,
-        })
+        configs.append(tuple(field.value for field in fields))
     return configs
 
 
-def _merge_agent_interval_limits(library: ctypes.CDLL) -> dict[str, dict[str, int]]:
-    """Widen the interval range across agents and keep the strictest flags.
+def _query_agent_interval_limits(library: ctypes.CDLL) -> dict[str, dict[str, int]]:
+    """Merge every agent's configurations into per-method interval limits.
 
-    The SDK configures PC sampling when any single agent supports the
-    requested configuration, so the accepted range is the union across agents.
+    The SDK configures PC sampling when any single agent supports the request,
+    so the accepted range is the union across agents.
     """
+    agent_count = library.get_number_of_agents()
+    library.agent_handles.argtypes = [ctypes.c_ulong * agent_count, ctypes.c_ulong]
+    agent_handles = (ctypes.c_ulong * agent_count)()
+    library.agent_handles(agent_handles, agent_count)
+
+    # (method, unit) ids from rocprofiler-sdk/pc_sampling.h
+    supported = {(1, 2): "stochastic", (2, 3): "host_trap"}
     limits: dict[str, dict[str, int]] = {}
-    for agent_handle in _query_agent_handles(library):
-        for config in _query_agent_pc_sampling_configs(library, agent_handle):
-            method = PC_SAMPLING_METHOD_IDS.get(config["method"])
+    for agent_handle in agent_handles:
+        for method_id, unit, minimum, maximum, flags in _query_agent_configs(
+            library, agent_handle
+        ):
+            method = supported.get((method_id, unit))
             if method is None:
                 continue
-            if config["unit"] != PC_SAMPLING_METHOD_UNIT_IDS[method]:
-                continue
-
-            requires_pow2 = bool(config["flags"] & PC_SAMPLING_FLAG_INTERVAL_POW2)
-            known = limits.get(method)
-            if known is None:
-                limits[method] = {
-                    "min_interval": config["min_interval"],
-                    "max_interval": config["max_interval"],
-                    "interval_pow2": requires_pow2,
-                }
-                continue
-
-            known["min_interval"] = min(known["min_interval"], config["min_interval"])
-            known["max_interval"] = max(known["max_interval"], config["max_interval"])
-            known["interval_pow2"] = known["interval_pow2"] or requires_pow2
+            known = limits.setdefault(
+                method,
+                {
+                    "min_interval": minimum,
+                    "max_interval": maximum,
+                    "interval_pow2": False,
+                },
+            )
+            known["min_interval"] = min(known["min_interval"], minimum)
+            known["max_interval"] = max(known["max_interval"], maximum)
+            # INTERVAL_POW2 is bit 0 of the configuration flags.
+            known["interval_pow2"] = known["interval_pow2"] or bool(flags & 1)
     return limits
 
 

--- a/projects/rocprofiler-compute/src/pc_sampling/pc_sampling_profile.py
+++ b/projects/rocprofiler-compute/src/pc_sampling/pc_sampling_profile.py
@@ -26,10 +26,15 @@ PC_SAMPLING_DEFAULT_INTERVALS = {"stochastic": 1048576, "host_trap": 512}
 def pc_sampling_interval_limits(
     method: str,
     sdk_tool_path: Optional[str] = None,
-) -> dict[str, int]:
+) -> Optional[dict[str, int]]:
     """Return the interval limits the GPUs report for one sampling method.
 
     Mirrors `rocprofv3-avail info --pc-sampling`.
+
+    None means the agents were queried and none of them offers a configuration
+    for `method`. That is distinct from being unable to query at all, which
+    yields the SDK fallback limits: rocprofiler-sdk rejects a configuration no
+    agent accepts, so the caller has to stop rather than guess a range.
     """
     # Limits rocprofiler-sdk falls back to, see its
     # source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.cpp
@@ -44,7 +49,7 @@ def pc_sampling_interval_limits(
         return fallback
 
     try:
-        return _query_agent_interval_limits(library).get(method, fallback)
+        return _query_agent_interval_limits(library).get(method)
     except (AttributeError, OSError, ValueError) as err:
         console_debug(f"PC sampling interval limit query failed: {err}")
         return fallback
@@ -114,7 +119,8 @@ def _query_agent_interval_limits(library: ctypes.CDLL) -> dict[str, dict[str, in
     agent_handles = (ctypes.c_ulong * agent_count)()
     library.agent_handles(agent_handles, agent_count)
 
-    # (method, unit) ids from rocprofiler-sdk/pc_sampling.h
+    # Keyed on (method id, unit id) from rocprofiler-sdk/fwd.h, since the SDK
+    # matches a requested configuration on both fields.
     supported = {(1, 2): "stochastic", (2, 3): "host_trap"}
     limits: dict[str, dict[str, int]] = {}
     for agent_handle in agent_handles:

--- a/projects/rocprofiler-compute/src/pc_sampling/pc_sampling_profile.py
+++ b/projects/rocprofiler-compute/src/pc_sampling/pc_sampling_profile.py
@@ -7,7 +7,7 @@ import os
 import shlex
 import time
 from pathlib import Path
-from typing import Optional, Union, cast
+from typing import Optional, TypedDict, Union, cast
 
 from utils.logger import console_debug, console_error, console_log
 from utils.utils_common import (
@@ -23,10 +23,18 @@ from utils.utils_profile import ProfilerOptions, is_live_attach
 PC_SAMPLING_DEFAULT_INTERVALS = {"stochastic": 1048576, "host_trap": 512}
 
 
+class PCSamplingLimits(TypedDict):
+    """Interval bounds a sampling method accepts, and whether it needs pow2."""
+
+    min_interval: int
+    max_interval: int
+    interval_pow2: bool
+
+
 def pc_sampling_interval_limits(
     method: str,
     sdk_tool_path: Optional[str] = None,
-) -> Optional[dict[str, int]]:
+) -> Optional[PCSamplingLimits]:
     """Return the interval limits the GPUs report for one sampling method.
 
     Mirrors `rocprofv3-avail info --pc-sampling`.
@@ -38,7 +46,7 @@ def pc_sampling_interval_limits(
     """
     # Limits rocprofiler-sdk falls back to, see its
     # source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.cpp
-    fallback = {
+    fallback: PCSamplingLimits = {
         "min_interval": 1,
         "max_interval": 1048576,
         "interval_pow2": method == "stochastic",
@@ -108,7 +116,9 @@ def _query_agent_configs(
     return configs
 
 
-def _query_agent_interval_limits(library: ctypes.CDLL) -> dict[str, dict[str, int]]:
+def _query_agent_interval_limits(
+    library: ctypes.CDLL,
+) -> dict[str, PCSamplingLimits]:
     """Merge every agent's configurations into per-method interval limits.
 
     The SDK configures PC sampling when any single agent supports the request,
@@ -122,7 +132,7 @@ def _query_agent_interval_limits(library: ctypes.CDLL) -> dict[str, dict[str, in
     # Keyed on (method id, unit id) from rocprofiler-sdk/fwd.h, since the SDK
     # matches a requested configuration on both fields.
     supported = {(1, 2): "stochastic", (2, 3): "host_trap"}
-    limits: dict[str, dict[str, int]] = {}
+    limits: dict[str, PCSamplingLimits] = {}
     for agent_handle in agent_handles:
         for method_id, unit, minimum, maximum, flags in _query_agent_configs(
             library, agent_handle

--- a/projects/rocprofiler-compute/src/pc_sampling/pc_sampling_profile.py
+++ b/projects/rocprofiler-compute/src/pc_sampling/pc_sampling_profile.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier:  MIT
 
 import argparse
+import ctypes
 import os
 import shlex
 import time
+from pathlib import Path
 from typing import Optional, Union, cast
 
 from utils.logger import console_debug, console_error, console_log
@@ -13,8 +15,191 @@ from utils.utils_common import (
     capture_subprocess_output,
     get_rocprof_cmd,
     perform_attach_detach,
+    resolve_rocm_library_path,
 )
 from utils.utils_profile import ProfilerOptions, is_live_attach
+
+AVAIL_LIBRARY_NAME = "librocprofv3-list-avail.so"
+
+# The avail library reports no PC sampling configurations unless the beta gate
+# is set before it initializes, the same way rocprofv3-avail sets it.
+PC_SAMPLING_BETA_ENV = "ROCPROFILER_PC_SAMPLING_BETA_ENABLED"
+
+# Enum values from rocprofiler_pc_sampling_method_t and
+# rocprofiler_pc_sampling_unit_t in rocprofiler-sdk/pc_sampling.h.
+PC_SAMPLING_METHOD_IDS = {1: "stochastic", 2: "host_trap"}
+PC_SAMPLING_METHOD_UNIT_IDS = {"stochastic": 2, "host_trap": 3}
+PC_SAMPLING_FLAG_INTERVAL_POW2 = 1
+
+PC_SAMPLING_DEFAULT_INTERVALS = {"stochastic": 1048576, "host_trap": 512}
+
+# Used when the GPU cannot be queried. The ceiling mirrors the 1 MB clamp the
+# SDK applies to the driver-reported maximum.
+PC_SAMPLING_STATIC_INTERVAL_LIMITS = {
+    "stochastic": {
+        "min_interval": 65536,
+        "max_interval": 1048576,
+        "interval_pow2": True,
+    },
+    "host_trap": {
+        "min_interval": 1,
+        "max_interval": 1048576,
+        "interval_pow2": False,
+    },
+}
+
+
+def query_pc_sampling_configs(
+    sdk_tool_path: Optional[str] = None,
+) -> dict[str, dict[str, int]]:
+    """Return the PC sampling interval limits reported by the local GPUs,
+    keyed by sampling method.
+
+    Mirrors `rocprofv3-avail info --pc-sampling` by loading
+    librocprofv3-list-avail.so and walking each agent's configurations.
+    Returns an empty dict when no GPU agent can be queried.
+    """
+    previous_beta_gate = os.environ.get(PC_SAMPLING_BETA_ENV)
+    os.environ[PC_SAMPLING_BETA_ENV] = "on"
+    try:
+        library = _load_avail_library(sdk_tool_path)
+        if library is None:
+            return {}
+        return _merge_agent_interval_limits(library)
+    except (AttributeError, OSError, ValueError) as err:
+        console_debug(f"PC sampling configuration query failed: {err}")
+        return {}
+    finally:
+        if previous_beta_gate is None:
+            os.environ.pop(PC_SAMPLING_BETA_ENV, None)
+        else:
+            os.environ[PC_SAMPLING_BETA_ENV] = previous_beta_gate
+
+
+def pc_sampling_interval_limits(
+    method: str,
+    sdk_tool_path: Optional[str] = None,
+) -> dict[str, int]:
+    """Return the interval limits for one sampling method, falling back to
+    static limits when the GPU cannot be queried."""
+    queried = query_pc_sampling_configs(sdk_tool_path).get(method)
+    if queried is not None:
+        return queried
+
+    console_debug(f"PC sampling: using static interval limits for {method}")
+    return PC_SAMPLING_STATIC_INTERVAL_LIMITS[method]
+
+
+def _resolve_avail_library_path(sdk_tool_path: Optional[str]) -> Optional[str]:
+    """Locate the avail library next to the SDK tool, or under ROCM_PATH."""
+    if sdk_tool_path:
+        candidate = Path(sdk_tool_path).parent / AVAIL_LIBRARY_NAME
+    else:
+        candidate = (
+            Path(os.getenv("ROCM_PATH", "/opt/rocm"))
+            / "lib/rocprofiler-sdk"
+            / AVAIL_LIBRARY_NAME
+        )
+    return resolve_rocm_library_path(str(candidate))
+
+
+def _load_avail_library(sdk_tool_path: Optional[str]) -> Optional[ctypes.CDLL]:
+    """Load the avail library, returning None when it is unusable."""
+    library_path = _resolve_avail_library_path(sdk_tool_path)
+    if not library_path or not Path(library_path).exists():
+        console_debug(f"PC sampling: {AVAIL_LIBRARY_NAME} not found")
+        return None
+
+    try:
+        return ctypes.CDLL(library_path)
+    except OSError as err:
+        console_debug(f"PC sampling: unable to load {library_path}: {err}")
+        return None
+
+
+def _query_agent_handles(library: ctypes.CDLL) -> list[int]:
+    """Return the handles of every agent the avail library reports."""
+    library.get_number_of_agents.restype = ctypes.c_ulong
+    agent_count = library.get_number_of_agents()
+    if agent_count == 0:
+        return []
+
+    library.agent_handles.argtypes = [ctypes.c_ulong * agent_count, ctypes.c_ulong]
+    agent_handles = (ctypes.c_ulong * agent_count)()
+    library.agent_handles(agent_handles, agent_count)
+    return list(agent_handles)
+
+
+def _query_agent_pc_sampling_configs(
+    library: ctypes.CDLL,
+    agent_handle: int,
+) -> list[dict[str, int]]:
+    """Return every PC sampling configuration supported by one agent."""
+    library.get_number_of_pc_sample_configs.argtypes = [ctypes.c_ulong]
+    library.get_number_of_pc_sample_configs.restype = ctypes.c_ulong
+    config_count = library.get_number_of_pc_sample_configs(agent_handle)
+    if config_count == 0:
+        return []
+
+    library.pc_sample_config.argtypes = [ctypes.c_ulong, ctypes.c_ulong] + [
+        ctypes.POINTER(ctypes.c_ulong)
+    ] * 5
+
+    configs = []
+    for config_index in range(config_count):
+        method = ctypes.c_ulong()
+        unit = ctypes.c_ulong()
+        min_interval = ctypes.c_ulong()
+        max_interval = ctypes.c_ulong()
+        flags = ctypes.c_ulong()
+        library.pc_sample_config(
+            agent_handle,
+            config_index,
+            ctypes.byref(method),
+            ctypes.byref(unit),
+            ctypes.byref(min_interval),
+            ctypes.byref(max_interval),
+            ctypes.byref(flags),
+        )
+        configs.append({
+            "method": method.value,
+            "unit": unit.value,
+            "min_interval": min_interval.value,
+            "max_interval": max_interval.value,
+            "flags": flags.value,
+        })
+    return configs
+
+
+def _merge_agent_interval_limits(library: ctypes.CDLL) -> dict[str, dict[str, int]]:
+    """Widen the interval range across agents and keep the strictest flags.
+
+    The SDK configures PC sampling when any single agent supports the
+    requested configuration, so the accepted range is the union across agents.
+    """
+    limits: dict[str, dict[str, int]] = {}
+    for agent_handle in _query_agent_handles(library):
+        for config in _query_agent_pc_sampling_configs(library, agent_handle):
+            method = PC_SAMPLING_METHOD_IDS.get(config["method"])
+            if method is None:
+                continue
+            if config["unit"] != PC_SAMPLING_METHOD_UNIT_IDS[method]:
+                continue
+
+            requires_pow2 = bool(config["flags"] & PC_SAMPLING_FLAG_INTERVAL_POW2)
+            known = limits.get(method)
+            if known is None:
+                limits[method] = {
+                    "min_interval": config["min_interval"],
+                    "max_interval": config["max_interval"],
+                    "interval_pow2": requires_pow2,
+                }
+                continue
+
+            known["min_interval"] = min(known["min_interval"], config["min_interval"])
+            known["max_interval"] = max(known["max_interval"], config["max_interval"])
+            known["interval_pow2"] = known["interval_pow2"] or requires_pow2
+    return limits
 
 
 class PCSamplingProfile:

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -630,29 +630,36 @@ class RocProfCompute:
             return
 
         method = args.pc_sampling_method
-        if args.pc_sampling_interval is None:
-            args.pc_sampling_interval = PC_SAMPLING_DEFAULT_INTERVALS[method]
-            return
-
         limits = pc_sampling_interval_limits(
             method, getattr(args, "rocprofiler_sdk_tool_path", None)
         )
+        if limits is None:
+            console_error(
+                f"PC sampling method '{method}' is not supported on any of the "
+                "agents on this system. See supported configurations with "
+                "'rocprofv3-avail info --pc-sampling'."
+            )
+            return
+
+        if args.pc_sampling_interval is None:
+            args.pc_sampling_interval = PC_SAMPLING_DEFAULT_INTERVALS[method]
+
+        interval = args.pc_sampling_interval
         min_interval = limits["min_interval"]
         max_interval = limits["max_interval"]
 
-        interval = args.pc_sampling_interval
         if interval < min_interval or interval > max_interval:
             console_error(
-                f"--pc-sampling-interval for {method} sampling must be between "
-                f"{min_interval} and {max_interval} (got {interval}). "
+                f"PC sampling interval {interval} is outside the range "
+                f"{min_interval} to {max_interval} reported for {method} sampling. "
                 "See supported configurations with "
                 "'rocprofv3-avail info --pc-sampling'."
             )
 
         if limits["interval_pow2"] and interval & (interval - 1) != 0:
             console_error(
-                f"--pc-sampling-interval for {method} sampling must be a "
-                f"power of 2 (got {interval})."
+                f"PC sampling interval {interval} must be a power of 2 for "
+                f"{method} sampling."
             )
 
     def _validate_list_option_exclusions(self) -> None:

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -624,28 +624,21 @@ class RocProfCompute:
 
     def _resolve_pc_sampling_interval(self) -> None:
         """Apply the method-aware default for --pc-sampling-interval and
-        validate a user-supplied value against the limits the GPU reports.
-
-        An out-of-range interval deadlocks the SDK, which calls exit() from
-        inside its own initialization critical section, so it has to be
-        rejected here.
-        """
+        validate a user-supplied value against the limits the GPU reports."""
         args = self.__args
         if not getattr(args, "pc_sampling", False):
             return
 
         method = args.pc_sampling_method
+        if args.pc_sampling_interval is None:
+            args.pc_sampling_interval = PC_SAMPLING_DEFAULT_INTERVALS[method]
+            return
+
         limits = pc_sampling_interval_limits(
             method, getattr(args, "rocprofiler_sdk_tool_path", None)
         )
         min_interval = limits["min_interval"]
         max_interval = limits["max_interval"]
-
-        if args.pc_sampling_interval is None:
-            args.pc_sampling_interval = min(
-                PC_SAMPLING_DEFAULT_INTERVALS[method], max_interval
-            )
-            return
 
         interval = args.pc_sampling_interval
         if interval < min_interval or interval > max_interval:

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -645,10 +645,10 @@ class RocProfCompute:
             args.pc_sampling_interval = PC_SAMPLING_DEFAULT_INTERVALS[method]
 
         interval = args.pc_sampling_interval
-        min_interval = limits["min_interval"]
-        max_interval = limits["max_interval"]
+        min_interval = limits.min_interval
+        max_interval = limits.max_interval
 
-        if interval < min_interval or interval > max_interval:
+        if not (min_interval <= interval <= max_interval):
             console_error(
                 f"PC sampling interval {interval} is outside the range "
                 f"{min_interval} to {max_interval} reported for {method} sampling. "
@@ -656,7 +656,7 @@ class RocProfCompute:
                 "'rocprofv3-avail info --pc-sampling'."
             )
 
-        if limits["interval_pow2"] and interval & (interval - 1) != 0:
+        if limits.interval_pow2 and interval & (interval - 1) != 0:
             console_error(
                 f"PC sampling interval {interval} must be a power of 2 for "
                 f"{method} sampling."

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -13,6 +13,10 @@ from typing import Any, Optional
 
 import config
 from argparser import omniarg_parser
+from pc_sampling.pc_sampling_profile import (
+    PC_SAMPLING_DEFAULT_INTERVALS,
+    pc_sampling_interval_limits,
+)
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from roofline.run_benchmark import BENCHMARKING_SUPPORTED, run_roofline_benchmark
 from utils.logger import (
@@ -620,36 +624,42 @@ class RocProfCompute:
 
     def _resolve_pc_sampling_interval(self) -> None:
         """Apply the method-aware default for --pc-sampling-interval and
-        validate a user-supplied value."""
+        validate a user-supplied value against the limits the GPU reports.
+
+        An out-of-range interval deadlocks the SDK, which calls exit() from
+        inside its own initialization critical section, so it has to be
+        rejected here.
+        """
         args = self.__args
         if not getattr(args, "pc_sampling", False):
             return
 
-        stochastic_default_interval_in_cycles = 1048576
-        stochastic_min_interval_in_cycles = 65536
-        host_trap_default_interval_in_microseconds = 512
-
         method = args.pc_sampling_method
+        limits = pc_sampling_interval_limits(
+            method, getattr(args, "rocprofiler_sdk_tool_path", None)
+        )
+        min_interval = limits["min_interval"]
+        max_interval = limits["max_interval"]
+
         if args.pc_sampling_interval is None:
-            if method == "stochastic":
-                args.pc_sampling_interval = stochastic_default_interval_in_cycles
-            else:
-                args.pc_sampling_interval = host_trap_default_interval_in_microseconds
+            args.pc_sampling_interval = min(
+                PC_SAMPLING_DEFAULT_INTERVALS[method], max_interval
+            )
             return
 
         interval = args.pc_sampling_interval
-        if method == "stochastic":
-            is_power_of_two = interval > 0 and interval & (interval - 1) == 0
-            if not is_power_of_two or interval < stochastic_min_interval_in_cycles:
-                console_error(
-                    "--pc-sampling-interval for stochastic sampling must be a "
-                    f"power of 2 and at least {stochastic_min_interval_in_cycles} "
-                    f"(got {interval})."
-                )
-        elif interval <= 0:
+        if interval < min_interval or interval > max_interval:
             console_error(
-                "--pc-sampling-interval for host_trap sampling must be a "
-                f"positive integer (got {interval})."
+                f"--pc-sampling-interval for {method} sampling must be between "
+                f"{min_interval} and {max_interval} (got {interval}). "
+                "See supported configurations with "
+                "'rocprofv3-avail info --pc-sampling'."
+            )
+
+        if limits["interval_pow2"] and interval & (interval - 1) != 0:
+            console_error(
+                f"--pc-sampling-interval for {method} sampling must be a "
+                f"power of 2 (got {interval})."
             )
 
     def _validate_list_option_exclusions(self) -> None:

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -7,7 +7,6 @@ import argparse
 import functools
 import os
 import shutil
-import sys
 from abc import abstractmethod
 from collections.abc import Iterator
 from pathlib import Path
@@ -15,7 +14,7 @@ from typing import Any, Optional
 
 import config
 from roofline.run_benchmark import BENCHMARKING_SUPPORTED, run_roofline_benchmark
-from utils import amdsmi_interface
+from utils import amdsmi_interface, rocprofv3_avail_interface
 from utils.logger import (
     console_debug,
     console_error,
@@ -36,7 +35,6 @@ from utils.utils_common import (
     is_only_pc_sampling,
     is_tcc_channel_counter,
     parse_sets_yaml,
-    resolve_rocm_library_path,
     validate_roofline_csv,
 )
 from utils.utils_counter_defs import (
@@ -675,46 +673,9 @@ class OmniSoC_Base:
             sdk_config
         )
 
-        # Backward compatibility support for sdk avail module moved from
-        # <rocm_path>/bin/rocprofv3_avail_module/avail.py to
-        # <rocm_path>/lib/python3/site-packages/rocprofv3/avail.py
-        new_path = str(
-            Path(args.rocprofiler_sdk_tool_path).parents[1] / "python3/site-packages"
+        counters = rocprofv3_avail_interface.get_counters(
+            args.rocprofiler_sdk_tool_path
         )
-        old_path = str(Path(args.rocprofiler_sdk_tool_path).parents[2] / "bin")
-        try:
-            sys.path.append(new_path)
-            from rocprofv3 import avail
-        except ImportError:
-            console_debug(
-                f"Could not import rocprofiler-sdk avail module from {new_path}, "
-                f"trying {old_path}"
-            )
-            try:
-                sys.path.remove(new_path)
-                sys.path.append(old_path)
-                from rocprofv3_avail_module import avail
-            except ImportError:
-                console_error("Failed to import rocprofiler-sdk avail module.")
-
-        # librocprofv3-list-avail.so location varies by ROCm version:
-        #   ROCm >= 7.1: <rocm_path>/lib/rocprofiler-sdk/
-        #   ROCm 7.0.x:  <rocm_path>/libexec/rocprofiler-sdk/
-        avail_lib_name = "librocprofv3-list-avail.so"
-        avail_lib_path = resolve_rocm_library_path(
-            str(Path(args.rocprofiler_sdk_tool_path).parent / avail_lib_name)
-        )
-        if not Path(avail_lib_path).exists():
-            avail_lib_path = resolve_rocm_library_path(
-                str(
-                    Path(args.rocprofiler_sdk_tool_path).parents[2]
-                    / "libexec"
-                    / "rocprofiler-sdk"
-                    / avail_lib_name
-                )
-            )
-        avail.loadLibrary.libname = avail_lib_path
-        counters = avail.get_counters()
         rocprof_counters = {
             counter.name
             for counter in counters[list(counters.keys())[0]]

--- a/projects/rocprofiler-compute/src/utils/rocprofv3_avail_interface.py
+++ b/projects/rocprofiler-compute/src/utils/rocprofv3_avail_interface.py
@@ -1,0 +1,181 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""Access to rocprofiler-sdk's avail library and its Python module.
+
+Owns everything about reaching `librocprofv3-list-avail.so`: where it lives on
+a given ROCm install, how it is loaded, and how its C entry points are called.
+Callers get plain Python values and never see ctypes or a library path.
+"""
+
+import ctypes
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Optional
+
+from utils.logger import console_debug, console_error
+from utils.utils_common import resolve_rocm_library_path
+
+LIBRARY_NAME = "librocprofv3-list-avail.so"
+
+# Set on every load: the library caches its PC sampling enumeration on first
+# use and dlopen will not re-init it, so an ungated first load is unrecoverable.
+_BETA_GATE = "ROCPROFILER_PC_SAMPLING_BETA_ENABLED"
+
+# Number of out-parameters pc_sample_config() fills in.
+_CONFIG_FIELD_COUNT = 5
+
+_library: Optional[ctypes.CDLL] = None
+_library_path: Optional[str] = None
+
+
+def get_pc_sample_configs(
+    sdk_tool_path: Optional[str],
+) -> Optional[list[tuple[int, ...]]]:
+    """Return (method, unit, min, max, flags) for every agent configuration.
+
+    None means the library could not be reached at all, which is distinct from
+    an empty list: agents were queried and reported no configuration.
+    """
+    library = _load_library(sdk_tool_path)
+    if library is None:
+        return None
+
+    configs = []
+    for agent_handle in _agent_handles(library):
+        configs.extend(_agent_configs(library, agent_handle))
+    return configs
+
+
+def get_counters(sdk_tool_path: Optional[str]) -> dict[str, Any]:
+    """Return the avail module's per-agent counter listing."""
+    # Load through ctypes first so the beta gate is applied before the avail
+    # module dlopens the same file and settles what the library reports.
+    _load_library(sdk_tool_path)
+    if _library_path is None:
+        console_error(f"Failed to locate {LIBRARY_NAME}.")
+
+    avail = _import_avail_module(sdk_tool_path)
+    avail.loadLibrary.libname = _library_path
+    return avail.get_counters()
+
+
+def resolve_library_path(sdk_tool_path: Optional[str]) -> Optional[str]:
+    """Locate the avail library for the ROCm install the tool belongs to.
+
+    The library moved between ROCm versions:
+      ROCm >= 7.1: <rocm_path>/lib/rocprofiler-sdk/
+      ROCm 7.0.x:  <rocm_path>/libexec/rocprofiler-sdk/
+    """
+    if not sdk_tool_path:
+        return None
+
+    candidates = (
+        Path(sdk_tool_path).parent / LIBRARY_NAME,
+        Path(sdk_tool_path).parents[2] / "libexec" / "rocprofiler-sdk" / LIBRARY_NAME,
+    )
+    for candidate in candidates:
+        resolved = resolve_rocm_library_path(str(candidate))
+        if resolved and Path(resolved).exists():
+            return resolved
+
+    console_debug(f"{LIBRARY_NAME} not found for {sdk_tool_path}")
+    return None
+
+
+def _load_library(sdk_tool_path: Optional[str]) -> Optional[ctypes.CDLL]:
+    """Load the avail library once per process, with PC sampling enabled."""
+    global _library, _library_path
+    if _library is not None:
+        return _library
+
+    library_path = resolve_library_path(sdk_tool_path)
+    if library_path is None:
+        return None
+
+    previous_gate = os.environ.get(_BETA_GATE)
+    os.environ[_BETA_GATE] = "ON"
+    try:
+        library = ctypes.CDLL(library_path)
+        _bind_signatures(library)
+        # Forces the enumeration while the gate is in place. Without this call
+        # the gate has no effect, since the library reads it on first use.
+        library.get_number_of_agents()
+    except OSError as err:
+        console_debug(f"Unable to load {library_path}: {err}")
+        return None
+    finally:
+        _restore_gate(previous_gate)
+
+    _library, _library_path = library, library_path
+    return library
+
+
+def _restore_gate(previous_gate: Optional[str]) -> None:
+    """Put the beta gate back so it never reaches the profiled application."""
+    if previous_gate is None:
+        os.environ.pop(_BETA_GATE, None)
+    else:
+        os.environ[_BETA_GATE] = previous_gate
+
+
+def _bind_signatures(library: ctypes.CDLL) -> None:
+    """Declare return and argument types for the entry points used here."""
+    library.get_number_of_agents.restype = ctypes.c_ulong
+    library.get_number_of_pc_sample_configs.restype = ctypes.c_ulong
+    library.pc_sample_config.argtypes = [ctypes.c_ulong, ctypes.c_ulong] + [
+        ctypes.POINTER(ctypes.c_ulong)
+    ] * _CONFIG_FIELD_COUNT
+
+
+def _agent_handles(library: ctypes.CDLL) -> list[int]:
+    """Return a handle for every agent the library knows about."""
+    agent_count = library.get_number_of_agents()
+    library.agent_handles.argtypes = [ctypes.c_ulong * agent_count, ctypes.c_ulong]
+    handles = (ctypes.c_ulong * agent_count)()
+    library.agent_handles(handles, agent_count)
+    return list(handles)
+
+
+def _agent_configs(library: ctypes.CDLL, agent_handle: int) -> list[tuple[int, ...]]:
+    """Marshal one agent's PC sampling configurations out of the library."""
+    configs = []
+    for config_index in range(library.get_number_of_pc_sample_configs(agent_handle)):
+        fields = [ctypes.c_ulong() for _ in range(_CONFIG_FIELD_COUNT)]
+        library.pc_sample_config(
+            agent_handle, config_index, *(ctypes.byref(field) for field in fields)
+        )
+        configs.append(tuple(field.value for field in fields))
+    return configs
+
+
+def _import_avail_module(sdk_tool_path: Optional[str]) -> ModuleType:
+    """Import the avail Python module shipped alongside the tool.
+
+    The module moved from <rocm_path>/bin/rocprofv3_avail_module/avail.py to
+    <rocm_path>/lib/python3/site-packages/rocprofv3/avail.py.
+    """
+    new_path = str(Path(sdk_tool_path).parents[1] / "python3/site-packages")
+    old_path = str(Path(sdk_tool_path).parents[2] / "bin")
+    try:
+        sys.path.append(new_path)
+        from rocprofv3 import avail
+
+        return avail
+    except ImportError:
+        console_debug(
+            f"Could not import rocprofiler-sdk avail module from {new_path}, "
+            f"trying {old_path}"
+        )
+
+    try:
+        sys.path.remove(new_path)
+        sys.path.append(old_path)
+        from rocprofv3_avail_module import avail
+
+        return avail
+    except ImportError:
+        # console_error exits, so this branch never returns.
+        console_error("Failed to import rocprofiler-sdk avail module.")

--- a/projects/rocprofiler-compute/tests/test_categories.yaml
+++ b/projects/rocprofiler-compute/tests/test_categories.yaml
@@ -27,6 +27,7 @@ test_categories:
       - test_num_xcds_spec_class
       - test_profiler_base
       - test_pc_sampling_profile
+      - test_rocprofv3_avail_interface
       - test_num_xcds_cli_output
       - test_mi_gpu_spec
       - test_utils_profile_csv
@@ -95,6 +96,7 @@ test_categories:
       - test_torch_cpp_loader
       - test_profiler_base
       - test_pc_sampling_profile
+      - test_rocprofv3_avail_interface
       - test_mem_chart
       - test_native_tool_finder
       - test_metrics_common
@@ -160,6 +162,7 @@ test_categories:
       - test_torch_cpp_loader
       - test_profiler_base
       - test_pc_sampling_profile
+      - test_rocprofv3_avail_interface
       - test_mem_chart
       - test_native_tool_finder
       - test_metrics_common
@@ -225,6 +228,7 @@ test_categories:
       - test_torch_cpp_loader
       - test_profiler_base
       - test_pc_sampling_profile
+      - test_rocprofv3_avail_interface
       - test_mem_chart
       - test_native_tool_finder
       - test_metrics_common

--- a/projects/rocprofiler-compute/tests/test_pc_sampling.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling.py
@@ -50,7 +50,15 @@ def is_pc_sampling_not_supported(output):
     To be called with the stdout + stderr after profiling.
     Check whether profiling output said PC sampling is not supported on the machine
     """
-    return "Given PC sampling configuration is not supported" in output
+    return any(
+        marker in output
+        for marker in (
+            # rocprof-compute's own pre-flight check against the agent configs
+            "is not supported on any of the agents on this system",
+            # rocprofiler-sdk, when it accepts the run and then rejects the config
+            "Given PC sampling configuration is not supported",
+        )
+    )
 
 
 def _skip_if_pc_sampling_unsupported(stdout, stderr, workload_dir):

--- a/projects/rocprofiler-compute/tests/test_pc_sampling_profile.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling_profile.py
@@ -7,18 +7,18 @@ import pytest
 from common import patch_console
 
 from pc_sampling.pc_sampling_profile import (
+    PCSamplingLimits,
     PCSamplingProfile,
     pc_sampling_interval_limits,
 )
 
 MODULE = "pc_sampling.pc_sampling_profile"
+AVAIL_MODULE = "utils.rocprofv3_avail_interface"
 
 # Limits pc_sampling_interval_limits() reports when no agent can be queried.
-STOCHASTIC_FALLBACK = {
-    "min_interval": 1,
-    "max_interval": 1048576,
-    "interval_pow2": True,
-}
+STOCHASTIC_FALLBACK = PCSamplingLimits(
+    min_interval=1, max_interval=1048576, interval_pow2=True
+)
 
 
 class MockArgs:
@@ -35,25 +35,14 @@ def _make_pc_sampling_profile(profiler="rocprofiler-sdk", filter_blocks=("21",))
     )
 
 
-def _patch_avail_library(monkeypatch, configs_by_agent):
-    """Stub the avail library with canned per-agent configurations.
+def _patch_avail_configs(monkeypatch, configs_by_agent):
+    """Stub the avail interface with canned per-agent configurations.
 
     Each config is (method, unit, min_interval, max_interval, flags) as
-    pc_sample_config() reports it.
+    pc_sample_config() reports it. The interface flattens them across agents.
     """
-    library = Mock()
-    library.get_number_of_agents.return_value = len(configs_by_agent)
-
-    def fill_handles(handles, _count):
-        for index, handle in enumerate(configs_by_agent):
-            handles[index] = handle
-
-    library.agent_handles.side_effect = fill_handles
-    monkeypatch.setattr(f"{MODULE}._load_avail_library", lambda _path: library)
-    monkeypatch.setattr(
-        f"{MODULE}._query_agent_configs",
-        lambda _library, handle: configs_by_agent[handle],
-    )
+    configs = [config for agent in configs_by_agent.values() for config in agent]
+    monkeypatch.setattr(f"{AVAIL_MODULE}.get_pc_sample_configs", lambda _path: configs)
 
 
 # ---------------------------------------------------------------------------
@@ -224,19 +213,19 @@ def test_run_launches_and_logs(monkeypatch):
         pytest.param(
             {0: [(1, 2, 256, 1048576, 1)]},
             "stochastic",
-            {"min_interval": 256, "max_interval": 1048576, "interval_pow2": True},
+            PCSamplingLimits(256, 1048576, True),
             id="stochastic_cycles_decoded",
         ),
         pytest.param(
             {0: [(2, 3, 1, 1048576, 0)]},
             "host_trap",
-            {"min_interval": 1, "max_interval": 1048576, "interval_pow2": False},
+            PCSamplingLimits(1, 1048576, False),
             id="host_trap_time_decoded",
         ),
         pytest.param(
             {0: [(1, 2, 512, 65536, 1)], 1: [(1, 2, 256, 1048576, 0)]},
             "stochastic",
-            {"min_interval": 256, "max_interval": 1048576, "interval_pow2": True},
+            PCSamplingLimits(256, 1048576, True),
             id="range_unioned_across_agents",
         ),
         pytest.param(
@@ -262,26 +251,25 @@ def test_run_launches_and_logs(monkeypatch):
 def test_interval_limits_from_agent_configs(
     monkeypatch, configs_by_agent, method, expected
 ):
-    """Agent configurations are decoded and merged into per-method limits."""
-    _patch_avail_library(monkeypatch, configs_by_agent)
+    """Agent configurations are merged into per-method limits."""
+    _patch_avail_configs(monkeypatch, configs_by_agent)
 
     assert pc_sampling_interval_limits(method) == expected
 
 
 def test_interval_limits_fall_back_without_avail_library(monkeypatch):
-    """An unloadable avail library yields the SDK fallback limits."""
-    monkeypatch.setattr(f"{MODULE}._load_avail_library", lambda _path: None)
+    """An unreachable avail library yields the SDK fallback limits."""
+    monkeypatch.setattr(f"{AVAIL_MODULE}.get_pc_sample_configs", lambda _path: None)
 
     assert pc_sampling_interval_limits("stochastic") == STOCHASTIC_FALLBACK
 
 
 def test_interval_limits_fall_back_when_query_raises(monkeypatch):
     """A failed query is unknown support, not unsupported."""
-    monkeypatch.setattr(f"{MODULE}._load_avail_library", lambda _path: Mock())
 
-    def raise_os_error(_library):
+    def raise_os_error(_path):
         raise OSError("agent enumeration failed")
 
-    monkeypatch.setattr(f"{MODULE}._query_agent_interval_limits", raise_os_error)
+    monkeypatch.setattr(f"{AVAIL_MODULE}.get_pc_sample_configs", raise_os_error)
 
     assert pc_sampling_interval_limits("stochastic") == STOCHASTIC_FALLBACK

--- a/projects/rocprofiler-compute/tests/test_pc_sampling_profile.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling_profile.py
@@ -242,8 +242,20 @@ def test_run_launches_and_logs(monkeypatch):
         pytest.param(
             {0: [(1, 3, 256, 4096, 0)]},
             "stochastic",
-            STOCHASTIC_FALLBACK,
-            id="mismatched_unit_ignored",
+            None,
+            id="mismatched_unit_unsupported",
+        ),
+        pytest.param(
+            {0: [(2, 3, 1, 1048576, 0)]},
+            "stochastic",
+            None,
+            id="method_absent_from_every_agent",
+        ),
+        pytest.param(
+            {0: []},
+            "host_trap",
+            None,
+            id="agent_reports_no_configs",
         ),
     ],
 )
@@ -259,5 +271,17 @@ def test_interval_limits_from_agent_configs(
 def test_interval_limits_fall_back_without_avail_library(monkeypatch):
     """An unloadable avail library yields the SDK fallback limits."""
     monkeypatch.setattr(f"{MODULE}._load_avail_library", lambda _path: None)
+
+    assert pc_sampling_interval_limits("stochastic") == STOCHASTIC_FALLBACK
+
+
+def test_interval_limits_fall_back_when_query_raises(monkeypatch):
+    """A failed query is unknown support, not unsupported."""
+    monkeypatch.setattr(f"{MODULE}._load_avail_library", lambda _path: Mock())
+
+    def raise_os_error(_library):
+        raise OSError("agent enumeration failed")
+
+    monkeypatch.setattr(f"{MODULE}._query_agent_interval_limits", raise_os_error)
 
     assert pc_sampling_interval_limits("stochastic") == STOCHASTIC_FALLBACK

--- a/projects/rocprofiler-compute/tests/test_pc_sampling_profile.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling_profile.py
@@ -3,18 +3,22 @@
 
 from unittest.mock import Mock
 
+import pytest
 from common import patch_console
 
 from pc_sampling.pc_sampling_profile import (
-    PC_SAMPLING_STATIC_INTERVAL_LIMITS,
     PCSamplingProfile,
-    _merge_agent_interval_limits,
-    _resolve_avail_library_path,
     pc_sampling_interval_limits,
-    query_pc_sampling_configs,
 )
 
 MODULE = "pc_sampling.pc_sampling_profile"
+
+# Limits pc_sampling_interval_limits() reports when no agent can be queried.
+STOCHASTIC_FALLBACK = {
+    "min_interval": 1,
+    "max_interval": 1048576,
+    "interval_pow2": True,
+}
 
 
 class MockArgs:
@@ -28,6 +32,27 @@ def _make_pc_sampling_profile(profiler="rocprofiler-sdk", filter_blocks=("21",))
     return PCSamplingProfile(
         args=MockArgs(filter_blocks=list(filter_blocks)),
         profiler=profiler,
+    )
+
+
+def _patch_avail_library(monkeypatch, configs_by_agent):
+    """Stub the avail library with canned per-agent configurations.
+
+    Each config is (method, unit, min_interval, max_interval, flags) as
+    pc_sample_config() reports it.
+    """
+    library = Mock()
+    library.get_number_of_agents.return_value = len(configs_by_agent)
+
+    def fill_handles(handles, _count):
+        for index, handle in enumerate(configs_by_agent):
+            handles[index] = handle
+
+    library.agent_handles.side_effect = fill_handles
+    monkeypatch.setattr(f"{MODULE}._load_avail_library", lambda _path: library)
+    monkeypatch.setattr(
+        f"{MODULE}._query_agent_configs",
+        lambda _library, handle: configs_by_agent[handle],
     )
 
 
@@ -191,125 +216,48 @@ def test_run_launches_and_logs(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# device interval limit query
+# device interval limits
 # ---------------------------------------------------------------------------
-def make_config(method, unit, min_interval, max_interval, flags=0):
-    """Build one agent config as _query_agent_pc_sampling_configs returns it."""
-    return {
-        "method": method,
-        "unit": unit,
-        "min_interval": min_interval,
-        "max_interval": max_interval,
-        "flags": flags,
-    }
+@pytest.mark.parametrize(
+    "configs_by_agent, method, expected",
+    [
+        pytest.param(
+            {0: [(1, 2, 256, 1048576, 1)]},
+            "stochastic",
+            {"min_interval": 256, "max_interval": 1048576, "interval_pow2": True},
+            id="stochastic_cycles_decoded",
+        ),
+        pytest.param(
+            {0: [(2, 3, 1, 1048576, 0)]},
+            "host_trap",
+            {"min_interval": 1, "max_interval": 1048576, "interval_pow2": False},
+            id="host_trap_time_decoded",
+        ),
+        pytest.param(
+            {0: [(1, 2, 512, 65536, 1)], 1: [(1, 2, 256, 1048576, 0)]},
+            "stochastic",
+            {"min_interval": 256, "max_interval": 1048576, "interval_pow2": True},
+            id="range_unioned_across_agents",
+        ),
+        pytest.param(
+            {0: [(1, 3, 256, 4096, 0)]},
+            "stochastic",
+            STOCHASTIC_FALLBACK,
+            id="mismatched_unit_ignored",
+        ),
+    ],
+)
+def test_interval_limits_from_agent_configs(
+    monkeypatch, configs_by_agent, method, expected
+):
+    """Agent configurations are decoded and merged into per-method limits."""
+    _patch_avail_library(monkeypatch, configs_by_agent)
+
+    assert pc_sampling_interval_limits(method) == expected
 
 
-def patch_agent_configs(monkeypatch, configs_by_agent):
-    """Stub the per-agent ctypes queries with canned configurations."""
-    monkeypatch.setattr(
-        f"{MODULE}._query_agent_handles",
-        lambda _library: list(configs_by_agent),
-    )
-    monkeypatch.setattr(
-        f"{MODULE}._query_agent_pc_sampling_configs",
-        lambda _library, agent_handle: configs_by_agent[agent_handle],
-    )
-
-
-def test_merge_agent_interval_limits_decodes_both_methods(monkeypatch):
-    """Stochastic and host_trap configs are decoded with their pow2 flag."""
-    patch_agent_configs(
-        monkeypatch,
-        {
-            0: [
-                make_config(1, 2, 256, 1048576, flags=1),
-                make_config(2, 3, 1, 1048576),
-            ]
-        },
-    )
-
-    limits = _merge_agent_interval_limits(Mock())
-
-    assert limits["stochastic"] == {
-        "min_interval": 256,
-        "max_interval": 1048576,
-        "interval_pow2": True,
-    }
-    assert limits["host_trap"] == {
-        "min_interval": 1,
-        "max_interval": 1048576,
-        "interval_pow2": False,
-    }
-
-
-def test_merge_agent_interval_limits_widens_range_across_agents(monkeypatch):
-    """The range is the union across agents; pow2 sticks if any agent needs it."""
-    patch_agent_configs(
-        monkeypatch,
-        {
-            0: [make_config(1, 2, 512, 65536, flags=1)],
-            1: [make_config(1, 2, 256, 1048576)],
-        },
-    )
-
-    limits = _merge_agent_interval_limits(Mock())
-
-    assert limits["stochastic"] == {
-        "min_interval": 256,
-        "max_interval": 1048576,
-        "interval_pow2": True,
-    }
-
-
-def test_merge_agent_interval_limits_skips_mismatched_unit(monkeypatch):
-    """A stochastic config reported in time units is not a cycles config."""
-    patch_agent_configs(monkeypatch, {0: [make_config(1, 3, 256, 1048576)]})
-
-    assert _merge_agent_interval_limits(Mock()) == {}
-
-
-def test_query_returns_empty_when_library_missing(monkeypatch):
-    """A missing avail library yields no limits rather than an error."""
+def test_interval_limits_fall_back_without_avail_library(monkeypatch):
+    """An unloadable avail library yields the SDK fallback limits."""
     monkeypatch.setattr(f"{MODULE}._load_avail_library", lambda _path: None)
 
-    assert query_pc_sampling_configs("/nonexistent/tool.so") == {}
-
-
-def test_interval_limits_falls_back_to_static_limits(monkeypatch):
-    """An unqueryable device falls back to the static limits."""
-    monkeypatch.setattr(f"{MODULE}.query_pc_sampling_configs", lambda _path: {})
-
-    limits = pc_sampling_interval_limits("stochastic")
-
-    assert limits == PC_SAMPLING_STATIC_INTERVAL_LIMITS["stochastic"]
-    assert limits["max_interval"] == 1048576
-
-
-def test_interval_limits_prefers_queried_limits(monkeypatch):
-    """A queried device wins over the static limits."""
-    queried = {"min_interval": 256, "max_interval": 4096, "interval_pow2": True}
-    monkeypatch.setattr(
-        f"{MODULE}.query_pc_sampling_configs",
-        lambda _path: {"stochastic": queried},
-    )
-
-    assert pc_sampling_interval_limits("stochastic") == queried
-
-
-def test_avail_library_resolved_next_to_sdk_tool(monkeypatch):
-    """The avail library is looked up beside the configured SDK tool."""
-    monkeypatch.setattr(f"{MODULE}.resolve_rocm_library_path", lambda path: path)
-
-    resolved = _resolve_avail_library_path("/opt/rocm/lib/rocprofiler-sdk/tool.so")
-
-    assert resolved == ("/opt/rocm/lib/rocprofiler-sdk/librocprofv3-list-avail.so")
-
-
-def test_avail_library_falls_back_to_rocm_path(monkeypatch):
-    """Without an SDK tool path, ROCM_PATH locates the avail library."""
-    monkeypatch.setattr(f"{MODULE}.resolve_rocm_library_path", lambda path: path)
-    monkeypatch.setenv("ROCM_PATH", "/custom/rocm")
-
-    resolved = _resolve_avail_library_path(None)
-
-    assert resolved == "/custom/rocm/lib/rocprofiler-sdk/librocprofv3-list-avail.so"
+    assert pc_sampling_interval_limits("stochastic") == STOCHASTIC_FALLBACK

--- a/projects/rocprofiler-compute/tests/test_pc_sampling_profile.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling_profile.py
@@ -5,7 +5,14 @@ from unittest.mock import Mock
 
 from common import patch_console
 
-from pc_sampling.pc_sampling_profile import PCSamplingProfile
+from pc_sampling.pc_sampling_profile import (
+    PC_SAMPLING_STATIC_INTERVAL_LIMITS,
+    PCSamplingProfile,
+    _merge_agent_interval_limits,
+    _resolve_avail_library_path,
+    pc_sampling_interval_limits,
+    query_pc_sampling_configs,
+)
 
 MODULE = "pc_sampling.pc_sampling_profile"
 
@@ -181,3 +188,128 @@ def test_run_launches_and_logs(monkeypatch):
     assert any(
         call.args and call.args[0] == "profiling" for call in mock_debug.call_args_list
     )
+
+
+# ---------------------------------------------------------------------------
+# device interval limit query
+# ---------------------------------------------------------------------------
+def make_config(method, unit, min_interval, max_interval, flags=0):
+    """Build one agent config as _query_agent_pc_sampling_configs returns it."""
+    return {
+        "method": method,
+        "unit": unit,
+        "min_interval": min_interval,
+        "max_interval": max_interval,
+        "flags": flags,
+    }
+
+
+def patch_agent_configs(monkeypatch, configs_by_agent):
+    """Stub the per-agent ctypes queries with canned configurations."""
+    monkeypatch.setattr(
+        f"{MODULE}._query_agent_handles",
+        lambda _library: list(configs_by_agent),
+    )
+    monkeypatch.setattr(
+        f"{MODULE}._query_agent_pc_sampling_configs",
+        lambda _library, agent_handle: configs_by_agent[agent_handle],
+    )
+
+
+def test_merge_agent_interval_limits_decodes_both_methods(monkeypatch):
+    """Stochastic and host_trap configs are decoded with their pow2 flag."""
+    patch_agent_configs(
+        monkeypatch,
+        {
+            0: [
+                make_config(1, 2, 256, 1048576, flags=1),
+                make_config(2, 3, 1, 1048576),
+            ]
+        },
+    )
+
+    limits = _merge_agent_interval_limits(Mock())
+
+    assert limits["stochastic"] == {
+        "min_interval": 256,
+        "max_interval": 1048576,
+        "interval_pow2": True,
+    }
+    assert limits["host_trap"] == {
+        "min_interval": 1,
+        "max_interval": 1048576,
+        "interval_pow2": False,
+    }
+
+
+def test_merge_agent_interval_limits_widens_range_across_agents(monkeypatch):
+    """The range is the union across agents; pow2 sticks if any agent needs it."""
+    patch_agent_configs(
+        monkeypatch,
+        {
+            0: [make_config(1, 2, 512, 65536, flags=1)],
+            1: [make_config(1, 2, 256, 1048576)],
+        },
+    )
+
+    limits = _merge_agent_interval_limits(Mock())
+
+    assert limits["stochastic"] == {
+        "min_interval": 256,
+        "max_interval": 1048576,
+        "interval_pow2": True,
+    }
+
+
+def test_merge_agent_interval_limits_skips_mismatched_unit(monkeypatch):
+    """A stochastic config reported in time units is not a cycles config."""
+    patch_agent_configs(monkeypatch, {0: [make_config(1, 3, 256, 1048576)]})
+
+    assert _merge_agent_interval_limits(Mock()) == {}
+
+
+def test_query_returns_empty_when_library_missing(monkeypatch):
+    """A missing avail library yields no limits rather than an error."""
+    monkeypatch.setattr(f"{MODULE}._load_avail_library", lambda _path: None)
+
+    assert query_pc_sampling_configs("/nonexistent/tool.so") == {}
+
+
+def test_interval_limits_falls_back_to_static_limits(monkeypatch):
+    """An unqueryable device falls back to the static limits."""
+    monkeypatch.setattr(f"{MODULE}.query_pc_sampling_configs", lambda _path: {})
+
+    limits = pc_sampling_interval_limits("stochastic")
+
+    assert limits == PC_SAMPLING_STATIC_INTERVAL_LIMITS["stochastic"]
+    assert limits["max_interval"] == 1048576
+
+
+def test_interval_limits_prefers_queried_limits(monkeypatch):
+    """A queried device wins over the static limits."""
+    queried = {"min_interval": 256, "max_interval": 4096, "interval_pow2": True}
+    monkeypatch.setattr(
+        f"{MODULE}.query_pc_sampling_configs",
+        lambda _path: {"stochastic": queried},
+    )
+
+    assert pc_sampling_interval_limits("stochastic") == queried
+
+
+def test_avail_library_resolved_next_to_sdk_tool(monkeypatch):
+    """The avail library is looked up beside the configured SDK tool."""
+    monkeypatch.setattr(f"{MODULE}.resolve_rocm_library_path", lambda path: path)
+
+    resolved = _resolve_avail_library_path("/opt/rocm/lib/rocprofiler-sdk/tool.so")
+
+    assert resolved == ("/opt/rocm/lib/rocprofiler-sdk/librocprofv3-list-avail.so")
+
+
+def test_avail_library_falls_back_to_rocm_path(monkeypatch):
+    """Without an SDK tool path, ROCM_PATH locates the avail library."""
+    monkeypatch.setattr(f"{MODULE}.resolve_rocm_library_path", lambda path: path)
+    monkeypatch.setenv("ROCM_PATH", "/custom/rocm")
+
+    resolved = _resolve_avail_library_path(None)
+
+    assert resolved == "/custom/rocm/lib/rocprofiler-sdk/librocprofv3-list-avail.so"

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -813,6 +813,49 @@ def test_sanitize_pc_sampling_interval(
         assert args.pc_sampling_interval == expected_interval
 
 
+def test_sanitize_pc_sampling_default_interval_out_of_range(monkeypatch):
+    """The method default is validated too, not just a user-supplied value."""
+    monkeypatch.setattr(
+        "rocprof_compute_base.pc_sampling_interval_limits",
+        lambda _method, _sdk_tool_path=None: {
+            "min_interval": 256,
+            "max_interval": 65536,
+            "interval_pow2": True,
+        },
+    )
+    args = _make_rpc_args(
+        pc_sampling=True,
+        experimental=True,
+        filter_blocks=[],
+        pc_sampling_method="stochastic",
+        pc_sampling_interval=None,
+    )
+    instance = _make_rpc_with_args(args)
+
+    with pytest.raises(SystemExit):
+        instance.sanitize()
+
+
+@pytest.mark.parametrize("interval", [None, 262144], ids=["default", "explicit"])
+def test_sanitize_pc_sampling_method_unsupported(interval, monkeypatch):
+    """A method no agent reports is rejected before the workload launches."""
+    monkeypatch.setattr(
+        "rocprof_compute_base.pc_sampling_interval_limits",
+        lambda _method, _sdk_tool_path=None: None,
+    )
+    args = _make_rpc_args(
+        pc_sampling=True,
+        experimental=True,
+        filter_blocks=[],
+        pc_sampling_method="stochastic",
+        pc_sampling_interval=interval,
+    )
+    instance = _make_rpc_with_args(args)
+
+    with pytest.raises(SystemExit):
+        instance.sanitize()
+
+
 # ---------------------------------------------------------------------------
 # run_profiling(): native_tool_path reaches get_pc_sampling_profiler_options
 # ---------------------------------------------------------------------------

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 import common
 import pytest
 
+from pc_sampling.pc_sampling_profile import PCSamplingLimits
 from rocprof_compute_base import RocProfCompute
 from rocprof_compute_profile.profiler_base import RocProfCompute_Base
 from rocprof_compute_profile.profiler_rocprof_v3 import rocprof_v3_profiler
@@ -555,13 +556,13 @@ def _make_rpc_with_args(args: argparse.Namespace) -> RocProfCompute:
     return instance
 
 
-def _fake_pc_sampling_limits(method: str, _sdk_tool_path=None) -> dict:
+def _fake_pc_sampling_limits(method: str, _sdk_tool_path=None) -> PCSamplingLimits:
     """Stub of the device query, using the limits a gfx950 reports."""
-    return {
-        "min_interval": 256 if method == "stochastic" else 1,
-        "max_interval": 1048576,
-        "interval_pow2": method == "stochastic",
-    }
+    return PCSamplingLimits(
+        min_interval=256 if method == "stochastic" else 1,
+        max_interval=1048576,
+        interval_pow2=method == "stochastic",
+    )
 
 
 @pytest.mark.parametrize(
@@ -817,11 +818,9 @@ def test_sanitize_pc_sampling_default_interval_out_of_range(monkeypatch):
     """The method default is validated too, not just a user-supplied value."""
     monkeypatch.setattr(
         "rocprof_compute_base.pc_sampling_interval_limits",
-        lambda _method, _sdk_tool_path=None: {
-            "min_interval": 256,
-            "max_interval": 65536,
-            "interval_pow2": True,
-        },
+        lambda _method, _sdk_tool_path=None: PCSamplingLimits(
+            min_interval=256, max_interval=65536, interval_pow2=True
+        ),
     )
     args = _make_rpc_args(
         pc_sampling=True,

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -759,23 +759,50 @@ def test_run_profiling_pc_sampling_gating(
     assert multirank_warned is expect_multirank_warning
 
 
+# Limits a gfx950 reports via 'rocprofv3-avail info --pc-sampling'.
+_FAKE_PC_SAMPLING_LIMITS = {
+    "stochastic": {
+        "min_interval": 256,
+        "max_interval": 1048576,
+        "interval_pow2": True,
+    },
+    "host_trap": {
+        "min_interval": 1,
+        "max_interval": 1048576,
+        "interval_pow2": False,
+    },
+}
+
+
 @pytest.mark.parametrize(
     "method, interval, expect_error, expected_interval",
     [
         pytest.param("host_trap", None, False, 512, id="host_trap_unset_default"),
         pytest.param("stochastic", None, False, 1048576, id="stochastic_unset_default"),
-        pytest.param("stochastic", 65536, False, 65536, id="stochastic_min_accepted"),
+        pytest.param("stochastic", 256, False, 256, id="stochastic_min_accepted"),
+        pytest.param(
+            "stochastic", 1048576, False, 1048576, id="stochastic_max_accepted"
+        ),
         pytest.param("stochastic", 12345, True, None, id="stochastic_not_pow2"),
-        pytest.param("stochastic", 32768, True, None, id="stochastic_below_min"),
+        pytest.param("stochastic", 128, True, None, id="stochastic_below_min"),
+        pytest.param("stochastic", 67108864, True, None, id="stochastic_above_max"),
         pytest.param("host_trap", 100, False, 100, id="host_trap_positive_accepted"),
+        pytest.param("host_trap", 2097152, True, None, id="host_trap_above_max"),
         pytest.param("host_trap", 0, True, None, id="host_trap_zero_rejected"),
         pytest.param("host_trap", -1, True, None, id="host_trap_negative_rejected"),
     ],
 )
 def test_sanitize_pc_sampling_interval(
-    method, interval, expect_error, expected_interval
+    method, interval, expect_error, expected_interval, monkeypatch
 ):
-    """Unit test: --pc-sampling-interval default and stochastic validation."""
+    """Unit test: --pc-sampling-interval default and range validation.
+
+    The device query is stubbed so the bounds do not depend on the host GPU.
+    """
+    monkeypatch.setattr(
+        "rocprof_compute_base.pc_sampling_interval_limits",
+        lambda method, _sdk_tool_path=None: _FAKE_PC_SAMPLING_LIMITS[method],
+    )
     args = _make_rpc_args(
         pc_sampling=True,
         experimental=True,
@@ -790,6 +817,28 @@ def test_sanitize_pc_sampling_interval(
     else:
         instance.sanitize()
         assert args.pc_sampling_interval == expected_interval
+
+
+def test_sanitize_pc_sampling_interval_default_clamped_to_device_max(monkeypatch):
+    """The default is lowered when the device reports a smaller maximum."""
+    monkeypatch.setattr(
+        "rocprof_compute_base.pc_sampling_interval_limits",
+        lambda _method, _sdk_tool_path=None: {
+            "min_interval": 256,
+            "max_interval": 65536,
+            "interval_pow2": True,
+        },
+    )
+    args = _make_rpc_args(
+        pc_sampling=True,
+        experimental=True,
+        filter_blocks=[],
+        pc_sampling_method="stochastic",
+        pc_sampling_interval=None,
+    )
+    _make_rpc_with_args(args).sanitize()
+
+    assert args.pc_sampling_interval == 65536
 
 
 # ---------------------------------------------------------------------------

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -555,6 +555,15 @@ def _make_rpc_with_args(args: argparse.Namespace) -> RocProfCompute:
     return instance
 
 
+def _fake_pc_sampling_limits(method: str, _sdk_tool_path=None) -> dict:
+    """Stub of the device query, using the limits a gfx950 reports."""
+    return {
+        "min_interval": 256 if method == "stochastic" else 1,
+        "max_interval": 1048576,
+        "interval_pow2": method == "stochastic",
+    }
+
+
 @pytest.mark.parametrize(
     "args, expect_error, expected_filter_blocks",
     [
@@ -759,21 +768,6 @@ def test_run_profiling_pc_sampling_gating(
     assert multirank_warned is expect_multirank_warning
 
 
-# Limits a gfx950 reports via 'rocprofv3-avail info --pc-sampling'.
-_FAKE_PC_SAMPLING_LIMITS = {
-    "stochastic": {
-        "min_interval": 256,
-        "max_interval": 1048576,
-        "interval_pow2": True,
-    },
-    "host_trap": {
-        "min_interval": 1,
-        "max_interval": 1048576,
-        "interval_pow2": False,
-    },
-}
-
-
 @pytest.mark.parametrize(
     "method, interval, expect_error, expected_interval",
     [
@@ -801,7 +795,7 @@ def test_sanitize_pc_sampling_interval(
     """
     monkeypatch.setattr(
         "rocprof_compute_base.pc_sampling_interval_limits",
-        lambda method, _sdk_tool_path=None: _FAKE_PC_SAMPLING_LIMITS[method],
+        _fake_pc_sampling_limits,
     )
     args = _make_rpc_args(
         pc_sampling=True,
@@ -817,28 +811,6 @@ def test_sanitize_pc_sampling_interval(
     else:
         instance.sanitize()
         assert args.pc_sampling_interval == expected_interval
-
-
-def test_sanitize_pc_sampling_interval_default_clamped_to_device_max(monkeypatch):
-    """The default is lowered when the device reports a smaller maximum."""
-    monkeypatch.setattr(
-        "rocprof_compute_base.pc_sampling_interval_limits",
-        lambda _method, _sdk_tool_path=None: {
-            "min_interval": 256,
-            "max_interval": 65536,
-            "interval_pow2": True,
-        },
-    )
-    args = _make_rpc_args(
-        pc_sampling=True,
-        experimental=True,
-        filter_blocks=[],
-        pc_sampling_method="stochastic",
-        pc_sampling_interval=None,
-    )
-    _make_rpc_with_args(args).sanitize()
-
-    assert args.pc_sampling_interval == 65536
 
 
 # ---------------------------------------------------------------------------

--- a/projects/rocprofiler-compute/tests/test_rocprofv3_avail_interface.py
+++ b/projects/rocprofiler-compute/tests/test_rocprofv3_avail_interface.py
@@ -1,0 +1,249 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+import ctypes
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from utils import rocprofv3_avail_interface as avail_interface
+
+LIBRARY_NAME = avail_interface.LIBRARY_NAME
+BETA_GATE = "ROCPROFILER_PC_SAMPLING_BETA_ENABLED"
+
+
+@pytest.fixture(autouse=True)
+def reset_library_cache(monkeypatch):
+    """Give each test an unloaded interface, since the handle is cached."""
+    monkeypatch.setattr(avail_interface, "_library", None)
+    monkeypatch.setattr(avail_interface, "_library_path", None)
+
+
+@pytest.fixture
+def rocm_tree(tmp_path):
+    """A ROCm install holding the rocprofv3 tool but neither library yet.
+
+    Both directories the interface probes exist, so tests opt into a layout by
+    creating the library file in one of them.
+    """
+    tool_path = tmp_path / "lib" / "rocprofiler-sdk" / "rocprofv3"
+    tool_path.parent.mkdir(parents=True)
+    tool_path.touch()
+    libexec_dir = tmp_path / "libexec" / "rocprofiler-sdk"
+    libexec_dir.mkdir(parents=True)
+    return SimpleNamespace(
+        tool_path=str(tool_path),
+        lib_layout=tool_path.parent / LIBRARY_NAME,
+        libexec_layout=libexec_dir / LIBRARY_NAME,
+    )
+
+
+def fake_avail_library(configs_by_agent, gate_per_call=None):
+    """Stand-in for the CDLL, serving canned per-agent configurations.
+
+    Only the entry points the interface calls are defined, so a wrong C symbol
+    name raises here instead of quietly succeeding. Plain functions are used
+    because the interface assigns restype/argtypes onto them.
+    """
+    handles = sorted(configs_by_agent)
+
+    def get_number_of_agents():
+        if gate_per_call is not None:
+            gate_per_call.append(os.environ.get(BETA_GATE))
+        return len(handles)
+
+    def agent_handles(buffer, count):
+        buffer[0:count] = handles
+
+    def get_number_of_pc_sample_configs(agent_handle):
+        return len(configs_by_agent[agent_handle])
+
+    def pc_sample_config(agent_handle, config_index, *fields):
+        values = configs_by_agent[agent_handle][config_index]
+        for field, value in zip(fields, values):
+            field._obj.value = value
+
+    return SimpleNamespace(
+        get_number_of_agents=get_number_of_agents,
+        agent_handles=agent_handles,
+        get_number_of_pc_sample_configs=get_number_of_pc_sample_configs,
+        pc_sample_config=pc_sample_config,
+    )
+
+
+def patch_library_load(monkeypatch, library):
+    """Serve `library` from every dlopen and record the paths asked for."""
+    loaded_paths = []
+
+    def load(library_path):
+        loaded_paths.append(library_path)
+        return library
+
+    monkeypatch.setattr(ctypes, "CDLL", load)
+    return loaded_paths
+
+
+# ---------------------------------------------------------------------------
+# library path resolution
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "layouts, expected_layout",
+    [
+        pytest.param(["lib_layout"], "lib_layout", id="rocm_7_1_lib_layout"),
+        pytest.param(
+            ["libexec_layout"], "libexec_layout", id="rocm_7_0_libexec_layout"
+        ),
+        pytest.param(
+            ["lib_layout", "libexec_layout"],
+            "lib_layout",
+            id="lib_layout_wins_when_both_exist",
+        ),
+        pytest.param([], None, id="neither_layout_present"),
+    ],
+)
+def test_resolve_library_path_across_rocm_layouts(rocm_tree, layouts, expected_layout):
+    """The library moved to libexec on ROCm 7.0.x, so both are probed."""
+    for layout in layouts:
+        getattr(rocm_tree, layout).touch()
+
+    resolved = avail_interface.resolve_library_path(rocm_tree.tool_path)
+
+    expected = expected_layout and str(getattr(rocm_tree, expected_layout))
+    assert resolved == expected
+
+
+def test_resolve_library_path_without_tool_path():
+    """No sdk tool path means there is nothing to resolve against."""
+    assert avail_interface.resolve_library_path(None) is None
+
+
+# ---------------------------------------------------------------------------
+# beta gate handling
+# ---------------------------------------------------------------------------
+def test_beta_gate_is_set_for_warmup_call_and_restored(monkeypatch, rocm_tree):
+    """The gate covers the warm-up call and is gone once loading finishes.
+
+    The library enumerates PC sampling configurations on the first call into
+    it, so a gate that only covers the dlopen has no effect.
+    """
+    monkeypatch.delenv(BETA_GATE, raising=False)
+    rocm_tree.lib_layout.touch()
+    gate_per_call = []
+    patch_library_load(monkeypatch, fake_avail_library({}, gate_per_call))
+
+    avail_interface.get_pc_sample_configs(rocm_tree.tool_path)
+
+    # Warm-up call sees the gate, the later query call no longer needs it.
+    assert gate_per_call == ["ON", None]
+    assert BETA_GATE not in os.environ
+
+
+def test_beta_gate_restores_preexisting_value(monkeypatch, rocm_tree):
+    """A gate the user already set is put back, not clobbered."""
+    monkeypatch.setenv(BETA_GATE, "off")
+    rocm_tree.lib_layout.touch()
+    patch_library_load(monkeypatch, fake_avail_library({}))
+
+    avail_interface.get_pc_sample_configs(rocm_tree.tool_path)
+
+    assert os.environ[BETA_GATE] == "off"
+
+
+def test_beta_gate_restored_when_load_fails(monkeypatch, rocm_tree):
+    """A library that will not load still leaves the environment clean."""
+    monkeypatch.delenv(BETA_GATE, raising=False)
+    rocm_tree.lib_layout.touch()
+
+    def fail_to_load(_library_path):
+        raise OSError("file too short")
+
+    monkeypatch.setattr(ctypes, "CDLL", fail_to_load)
+
+    assert avail_interface.get_pc_sample_configs(rocm_tree.tool_path) is None
+    assert BETA_GATE not in os.environ
+
+
+# ---------------------------------------------------------------------------
+# configuration marshalling
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "configs_by_agent, expected",
+    [
+        pytest.param(
+            {0: [(1, 2, 256, 1048576, 1)]},
+            [(1, 2, 256, 1048576, 1)],
+            id="single_agent_single_config",
+        ),
+        pytest.param(
+            {0: [(1, 2, 256, 1048576, 1), (2, 3, 1, 1048576, 0)]},
+            [(1, 2, 256, 1048576, 1), (2, 3, 1, 1048576, 0)],
+            id="single_agent_both_methods",
+        ),
+        pytest.param(
+            {0: [(1, 2, 512, 65536, 1)], 1: [(1, 2, 256, 1048576, 0)]},
+            [(1, 2, 512, 65536, 1), (1, 2, 256, 1048576, 0)],
+            id="configs_flattened_across_agents",
+        ),
+        pytest.param({0: []}, [], id="agent_reports_no_configs"),
+    ],
+)
+def test_get_pc_sample_configs(monkeypatch, rocm_tree, configs_by_agent, expected):
+    """Out-parameters are marshalled into plain tuples for every agent."""
+    rocm_tree.lib_layout.touch()
+    patch_library_load(monkeypatch, fake_avail_library(configs_by_agent))
+
+    configs = avail_interface.get_pc_sample_configs(rocm_tree.tool_path)
+
+    assert configs == expected
+
+
+def test_get_pc_sample_configs_without_library(rocm_tree):
+    """None distinguishes an unreachable library from a silent agent."""
+    assert avail_interface.get_pc_sample_configs(rocm_tree.tool_path) is None
+
+
+# ---------------------------------------------------------------------------
+# caching
+# ---------------------------------------------------------------------------
+def test_library_is_loaded_once(monkeypatch, rocm_tree):
+    """Repeated queries reuse the handle instead of dlopening again.
+
+    Reloading cannot undo an ungated first load, so the gate and the handle
+    are settled once per process.
+    """
+    rocm_tree.lib_layout.touch()
+    library = fake_avail_library({0: [(1, 2, 256, 1048576, 1)]})
+    loaded_paths = patch_library_load(monkeypatch, library)
+
+    avail_interface.get_pc_sample_configs(rocm_tree.tool_path)
+    avail_interface.get_pc_sample_configs(rocm_tree.tool_path)
+
+    assert loaded_paths == [str(rocm_tree.lib_layout)]
+
+
+# ---------------------------------------------------------------------------
+# counter listing
+# ---------------------------------------------------------------------------
+def test_get_counters_points_avail_module_at_resolved_library(monkeypatch, rocm_tree):
+    """The avail module is aimed at the same file the gated load used."""
+    rocm_tree.lib_layout.touch()
+    patch_library_load(monkeypatch, fake_avail_library({}))
+    avail_module = SimpleNamespace(
+        loadLibrary=SimpleNamespace(libname=None),
+        get_counters=lambda: {"agent-0": ["SQ_WAVES"]},
+    )
+    monkeypatch.setattr(
+        avail_interface, "_import_avail_module", lambda _path: avail_module
+    )
+
+    counters = avail_interface.get_counters(rocm_tree.tool_path)
+
+    assert avail_module.loadLibrary.libname == str(rocm_tree.lib_layout)
+    assert counters == {"agent-0": ["SQ_WAVES"]}
+
+
+def test_get_counters_errors_without_library(rocm_tree):
+    """A missing library is fatal here, unlike the PC sampling query."""
+    with pytest.raises(SystemExit):
+        avail_interface.get_counters(rocm_tree.tool_path)


### PR DESCRIPTION
## Motivation

Validate the requested PC sampling configuration against the limits the device
reports, so an unsupported method or interval is rejected before the workload
launches.

rocprofiler-sdk has updated the interval limits it accepts, so the bounds
hardcoded here no longer match what the SDK allows. Reading the limits from the
device keeps the two in sync instead of tracking the SDK's values by hand.

Bugfix: a sampling method no agent reports now exits during argument
validation, so the run ends with a clear error rather than waiting on a session
the SDK will not start.

## Technical Details

- Add `pc_sampling_interval_limits()`, which reads the supported range and the
  power-of-2 requirement per sampling method, mirroring
  `rocprofv3-avail info --pc-sampling` via ctypes on `librocprofv3-list-avail.so`
- Union the range across agents, matching how the SDK accepts a configuration
  supported by any single agent
- Return `None` when the agents report no configuration for the method, distinct
  from being unable to query at all, which keeps the SDK fallback limits
- Validate the method's default interval, not only a user-supplied value
- Skip the PC sampling tests on rocprof-compute's own unsupported-method error
  as well as the SDK's

## JIRA ID

JIRA ID: N/A
Issued ID: https://github.com/ROCm/rocm-libraries/issues/10056

Fixes https://github.com/ROCm/rocm-libraries/issues/10056

## Test Plan

- [x] Run pytest tests/test_pc_sampling_profile.py
- [x] Run pytest tests/test_profiler_base.py
- [x] Profile locally on MI350 with an out-of-range interval
- [x] Profile locally on MI350 with `--pc-sampling-interval 262144`
- [ ] Profile locally with a sampling method the device does not report

## Test Result

- [x] pytest tests/test_pc_sampling_profile.py passes
- [x] pytest tests/test_profiler_base.py passes
- [x] `--pc-sampling-interval 67108864` exits 1, reporting the supported range
- [x] `--pc-sampling-interval 262144` completes with exit 0 on MI350
- [ ] Pending: an unsupported sampling method exits 1 before the workload launches

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
