### PR TITLE
test(rocprofiler-sdk): label GPU-isolated CTests

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
@@ -100,6 +100,19 @@ rocprofiler_add_unit_test(
         "Running non-intercept test(.*)could not be locked for profiling due to lack of permissions.*"
     )
 
+set_tests_properties(
+    unit.core.check_packet_generation
+    unit.core.test_profile_incremental
+    unit.dimension.block_dim_test
+    unit.device_counting_service_test.sync_counters
+    unit.device_counting_service_test.async_counters
+    unit.device_counting_service_test.sync_grbm_verify
+    unit.device_counting_service_test.sync_gpu_util_verify
+    unit.device_counting_service_test.sync_sq_waves_verify
+    unit.device_counting_service_test.sync_sq_waves_verify_non_intercept
+    unit.device_counting_service_test.raw_sq_waves_verify
+    PROPERTIES LABELS "unittests;exclusive-gpu")
+
 set(ROCPROFILER_LIB_CONSUMER_TEST_SOURCES consumer_test.cpp)
 
 add_executable(consumer-test)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/tests/CMakeLists.txt
@@ -31,3 +31,15 @@ rocprofiler_add_unit_test(
     ENVIRONMENT
         "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
+set_tests_properties(
+    unit.pc_sampling.rocprofiler_configure_pc_sampling_service
+    unit.pc_sampling.pc_sampling_vs_dispatch_counter_collection
+    unit.pc_sampling.pc_sampling_vs_device_counter_collection
+    unit.pc_sampling.dispatch_counter_collection_vs_pc_sampling
+    unit.pc_sampling.device_counter_collection_vs_pc_sampling
+    unit.pc_sampling.query_configs_after_service_setup
+    PROPERTIES LABELS "unittests;pc-sampling;exclusive-gpu")
+
+set_tests_properties(unit.pc_sampling.multiple_contexts_one_per_agent
+                     PROPERTIES LABELS "unittests;pc-sampling;exclusive-gpu;multi-gpu")

--- a/projects/rocprofiler-sdk/tests/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/common/CMakeLists.txt
@@ -1,6 +1,15 @@
 #
 # common utilities for tests
 #
+# Common CTest labels used by these helpers:
+#   integration-tests - added to all integration tests
+#   execution         - added to rocprofiler_add_integration_execute_test
+#   validation        - added to rocprofiler_add_integration_validate_test
+#   exclusive-gpu     - requires exclusive access to each visible GPU
+#   multi-gpu         - requires more than one visible GPU
+#
+# GPU access labels can be combined when a test has both requirements. Filter them with
+# ctest -L <label> or ctest -LE <label>.
 
 include(FetchContent)
 include(CMakeParseArguments)
@@ -196,11 +205,12 @@ function(rocprofiler_add_integration_execute_test NAME)
         "UNSTABLE" # disable when ROCPROFILER_DISABLE_UNSTABLE_CTESTS=ON
         "DISABLED_CODECOV" # disable when ROCPROFILER_BUILD_CODECOV=ON
         )
-    set(_SINGLE_OPTS "TARGET" "WORKING_DIRECTORY" "DEPENDS" "TIMEOUT" "LABELS" "DISABLED"
+    set(_SINGLE_OPTS "TARGET" "WORKING_DIRECTORY" "DEPENDS" "TIMEOUT" "DISABLED"
                      "DISABLED_MEMCHECKS")
     set(_MULTI_OPTS
         "ARGS"
         "COMMAND"
+        "LABELS"
         "ATTACHED_FILES"
         "ATTACHED_FILES_ON_FAIL"
         "ENVIRONMENT"
@@ -282,6 +292,8 @@ function(rocprofiler_add_integration_execute_test NAME)
         list(APPEND arg_LABELS "execution")
     endif()
 
+    list(JOIN arg_LABELS ";" _labels)
+
     # Helper to set a property only if the arg is set
     function(_rocprofiler_set_test_property_if_arg TEST_NAME PROPERTY_NAME)
         if(arg_${PROPERTY_NAME})
@@ -308,9 +320,8 @@ function(rocprofiler_add_integration_execute_test NAME)
 
         add_test(NAME "${arg_NAME}" COMMAND ${arg_COMMAND})
 
-        set_tests_properties(${arg_NAME} PROPERTIES RUN_SERIAL ON)
+        set_tests_properties(${arg_NAME} PROPERTIES RUN_SERIAL ON LABELS "${_labels}")
         _rocprofiler_set_test_property_if_arg(${arg_NAME} TIMEOUT)
-        _rocprofiler_set_test_property_if_arg(${arg_NAME} LABELS)
         _rocprofiler_set_test_property_if_arg(${arg_NAME} WORKING_DIRECTORY)
         _rocprofiler_set_test_property_if_arg(${arg_NAME} ENVIRONMENT)
         _rocprofiler_set_test_property_if_arg(${arg_NAME} PASS_REGULAR_EXPRESSION)
@@ -329,9 +340,8 @@ function(rocprofiler_add_integration_execute_test NAME)
 
         add_test(NAME "${arg_NAME}" COMMAND $<TARGET_FILE:${arg_TARGET}> ${arg_ARGS})
 
-        set_tests_properties(${arg_NAME} PROPERTIES RUN_SERIAL ON)
+        set_tests_properties(${arg_NAME} PROPERTIES RUN_SERIAL ON LABELS "${_labels}")
         _rocprofiler_set_test_property_if_arg(${arg_NAME} TIMEOUT)
-        _rocprofiler_set_test_property_if_arg(${arg_NAME} LABELS)
         _rocprofiler_set_test_property_if_arg(${arg_NAME} WORKING_DIRECTORY)
         _rocprofiler_set_test_property_if_arg(${arg_NAME} ENVIRONMENT)
         _rocprofiler_set_test_property_if_arg(${arg_NAME} PASS_REGULAR_EXPRESSION)
@@ -371,9 +381,10 @@ function(rocprofiler_add_integration_validate_test NAME)
         "STRIP_PARAM_BRACKETS"
         "INCLUDE_FILE_PATH"
         "BUNDLE_TESTS")
-    set(_SINGLE_OPTS "TARGET_DEPENDS" "WORKING_DIRECTORY" "DEPENDS" "TIMEOUT" "LABELS"
-                     "DISABLED" "DISABLED_MEMCHECKS" "PYTHON_EXECUTABLE")
+    set(_SINGLE_OPTS "TARGET_DEPENDS" "WORKING_DIRECTORY" "DEPENDS" "TIMEOUT" "DISABLED"
+                     "DISABLED_MEMCHECKS" "PYTHON_EXECUTABLE")
     set(_MULTI_OPTS
+        "LABELS"
         "TEST_PATHS"
         "CONFIG"
         "COPY"

--- a/projects/rocprofiler-sdk/tests/counter-collection/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/counter-collection/CMakeLists.txt
@@ -15,7 +15,7 @@ rocprofiler_add_integration_execute_test(
     counter-collection
     TARGET multistream
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "$<TARGET_FILE:rocprofiler-sdk-json-tool>"
     ENVIRONMENT
         "ROCPROFILER_TOOL_OUTPUT_FILE=counter-collection-test.json"
@@ -29,7 +29,7 @@ rocprofiler_add_integration_validate_test(
     TEST_PATHS validate.py
     COPY conftest.py
     CONFIG pytest.ini
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     TIMEOUT 45
     FIXTURES_REQUIRED counter-collection
     ARGS --input ${CMAKE_CURRENT_BINARY_DIR}/counter-collection-test.json

--- a/projects/rocprofiler-sdk/tests/pc_sampling/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/pc_sampling/CMakeLists.txt
@@ -79,7 +79,7 @@ rocprofiler_add_integration_execute_test(
     COMMAND $<TARGET_FILE:pc-sampling-integration-test>
     DEPENDS pc-sampling-integration-test-client
     TIMEOUT 45
-    LABELS "integration-tests;pc-sampling"
+    LABELS "integration-tests;pc-sampling;exclusive-gpu"
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     SKIP_REGULAR_EXPRESSION "PC sampling unavailable"
     DISABLED "${IS_PC_SAMPLING_DISABLED}")

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -141,7 +141,7 @@ rocprofiler_add_integration_execute_test(
             $<TARGET_FILE:rocprofiler-sdk-c-tool>
     DEPENDS rocattach-parallel-attach-test
     TIMEOUT 45
-    LABELS "attachment"
+    LABELS "attachment;exclusive-gpu"
     ENVIRONMENT "${rocattach-test-env}"
     DISABLED ${IS_DISABLED}
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
@@ -194,7 +194,7 @@ rocprofiler_add_integration_execute_test(
             $<TARGET_FILE:rocprofiler-sdk-c-tool> --send-signal
     DEPENDS rocattach-parallel-attach-test
     TIMEOUT 45
-    LABELS "attachment"
+    LABELS "attachment;exclusive-gpu"
     ENVIRONMENT "${rocattach-test-env}"
     DISABLED ${IS_DISABLED}
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
@@ -214,7 +214,7 @@ rocprofiler_add_integration_execute_test(
     TARGET rocattach-attach-tree-test
     ARGS $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk-c-tool>
     TIMEOUT 45
-    LABELS "attachment"
+    LABELS "attachment;exclusive-gpu"
     ENVIRONMENT "${rocattach-test-env}"
     DISABLED ${IS_DISABLED}
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"

--- a/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/CMakeLists.txt
@@ -74,7 +74,7 @@ rocprofiler_add_integration_execute_test(
         --att-buffer-size 0x6000000 --att-simd-select 0x3 --att-serialize-all 1 -o out --
         $<TARGET_FILE:hsa_code_object_testapp>
     DEPENDS hsa_code_object_testapp
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     TIMEOUT 45
     DISABLED ${IS_DISABLED}
     FIXTURES_SETUP rocprofv3-test-att-hsa-multiqueue-cmd-env-att-lib-path)
@@ -87,7 +87,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/att_input.json --
         $<TARGET_FILE:hsa_code_object_testapp>
     DEPENDS hsa_code_object_testapp
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     TIMEOUT 45
     DISABLED ${IS_DISABLED}
     FIXTURES_SETUP rocprofv3-test-att-hsa-multiqueue-json)
@@ -99,7 +99,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     FIXTURES_REQUIRED rocprofv3-test-att-hsa-multiqueue-cmd-env-att-lib-path
     ARGS --input
@@ -116,7 +116,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-att-hsa-multiqueue-json
     DISABLED ${IS_DISABLED}
     ARGS --input
@@ -145,7 +145,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:hsa_code_object_testapp>
     DEPENDS hsa_code_object_testapp
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     DISABLED ${IS_DISABLED})
 
 # Invalid lib path has to fail
@@ -157,7 +157,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:hsa_code_object_testapp>
     DEPENDS hsa_code_object_testapp
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     WILL_FAIL
     DISABLED ${IS_DISABLED})
 
@@ -167,7 +167,7 @@ rocprofiler_add_integration_execute_test(
             --log-level env --echo -- $<TARGET_FILE:hsa_code_object_testapp>
     DEPENDS hsa_code_object_testapp
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     WILL_FAIL
     DISABLED ${IS_DISABLED})
 
@@ -177,7 +177,7 @@ rocprofiler_add_integration_execute_test(
             --att-library-path . --echo -- $<TARGET_FILE:hsa_code_object_testapp>
     DEPENDS hsa_code_object_testapp
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     WILL_FAIL
     DISABLED ${IS_DISABLED}
     ENVIRONMENT "ROCPROF_ATT_LIBRARY_PATH=${attdecoder_LIB_DIR}")
@@ -188,7 +188,7 @@ rocprofiler_add_integration_execute_test(
             $<TARGET_FILE:hsa_code_object_testapp>
     DEPENDS hsa_code_object_testapp
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     ENVIRONMENT "ROCPROF_ATT_LIBRARY_PATH=${attdecoder_LIB_DIR}")
 #
@@ -200,7 +200,7 @@ rocprofiler_add_integration_execute_test(
             SQ_WAVES -o out -- $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     DISABLED ${IS_DISABLED})
 
 # Check for conflict PMC + activity
@@ -210,7 +210,7 @@ rocprofiler_add_integration_execute_test(
             SQ_WAVES -o out --att-activity 8 -- $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     WILL_FAIL
     DISABLED ${IS_DISABLED})
 
@@ -221,7 +221,7 @@ rocprofiler_add_integration_execute_test(
             --att-perfcounter-ctrl 8 -o out --att-activity 8 -- $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     WILL_FAIL
     DISABLED ${IS_DISABLED})
 
@@ -245,7 +245,7 @@ rocprofiler_add_integration_execute_test(
             ${PCS_ARGS} -o out -- $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 90
-    LABELS "integration-tests;thread-trace;pc-sampling"
+    LABELS "integration-tests;thread-trace;pc-sampling;exclusive-gpu"
     DISABLED ${ATT_PLUS_PCS_DISABLE})
 
 rocprofiler_add_integration_execute_test(
@@ -256,7 +256,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu;multi-gpu"
     DISABLED ${ROCPROFILER_DISABLE_UNSTABLE_CTESTS}
     ENVIRONMENT "ROCPROF_ATT_LIBRARY_PATH=${attdecoder_LIB_DIR}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
@@ -269,7 +269,7 @@ rocprofiler_add_integration_validate_test(
     CONFIG pytest.ini
     DISCOVERY_ARGS -k test_multi_gpu_separate_agents
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu;multi-gpu"
     DISABLED ${ROCPROFILER_DISABLE_UNSTABLE_CTESTS}
     FIXTURES_REQUIRED rocprofv3-test-att-gpu-index-two-gpus
     ARGS --att-multi-gpu-out-dir ${CMAKE_CURRENT_BINARY_DIR}/att-multi-gpu
@@ -283,7 +283,7 @@ rocprofiler_add_integration_execute_test(
             --att-gpu-index 0,9999 -- $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     WILL_FAIL
     DISABLED ${IS_DISABLED}
     FAIL_REGULAR_EXPRESSION "Invalid GPU Device Index")
@@ -301,7 +301,7 @@ rocprofiler_add_integration_execute_test(
         -o out --kernel-include-regex matrixTranspose -- $<TARGET_FILE:simple-transpose>
     DEPENDS simple-transpose
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     FIXTURES_SETUP rocprofv3-test-att-perfcounter-target-cu)
 
@@ -311,7 +311,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     FIXTURES_REQUIRED rocprofv3-test-att-perfcounter-target-cu
     ARGS --input
@@ -333,7 +333,7 @@ if(attdecoder_FOUND
             out --kernel-include-regex matrixTranspose -- $<TARGET_FILE:simple-transpose>
         DEPENDS simple-transpose
         TIMEOUT 45
-        LABELS "integration-tests"
+        LABELS "integration-tests;exclusive-gpu"
         FIXTURES_SETUP rocprofv3-test-att-event-tracing)
 
     rocprofiler_add_integration_validate_test(
@@ -343,7 +343,7 @@ if(attdecoder_FOUND
         CONFIG pytest.ini
         DISCOVERY_ARGS -k test_occupancy_event_tracing_fields
         TIMEOUT 45
-        LABELS "integration-tests"
+        LABELS "integration-tests;exclusive-gpu"
         FIXTURES_REQUIRED rocprofv3-test-att-event-tracing
         ARGS --att-occupancy-event-trace-out-dir
              ${CMAKE_CURRENT_BINARY_DIR}/simple-transpose-trace/event_tracing
@@ -365,7 +365,7 @@ rocprofiler_add_integration_execute_test(
             $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     DISABLED ${IS_DISABLED_OTHER_SIMD}
     ENVIRONMENT "ROCPROF_ATT_LIBRARY_PATH=${attdecoder_LIB_DIR}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
@@ -377,7 +377,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     DISABLED ${IS_DISABLED_OTHER_SIMD}
     FIXTURES_REQUIRED rocprofv3-test-att-other-simd
     DISCOVERY_ARGS -k test_other_simd_data
@@ -394,7 +394,7 @@ rocprofiler_add_integration_execute_test(
         --selected-regions --att-shader-engine-mask 0xF --output-format json --log-level
         env -o out -- $<TARGET_FILE:att-marker-trace>
     DEPENDS att-marker-trace
-    LABELS "integration-tests;thread-trace"
+    LABELS "integration-tests;thread-trace;exclusive-gpu"
     TIMEOUT 45
     DISABLED ${IS_DISABLED}
     ENVIRONMENT "ROCPROF_ATT_LIBRARY_PATH=${attdecoder_LIB_DIR}"
@@ -407,7 +407,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 45
-    LABELS "integration-tests;thread-trace"
+    LABELS "integration-tests;thread-trace;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     FIXTURES_REQUIRED rocprofv3-test-att-marker-trace
     DISCOVERY_ARGS -k test_att_marker_trace
@@ -422,7 +422,7 @@ rocprofiler_add_integration_execute_test(
             --att-consecutive-kernels 5 -- $<TARGET_FILE:att-marker-trace>
     DEPENDS att-marker-trace
     TIMEOUT 45
-    LABELS "integration-tests;thread-trace"
+    LABELS "integration-tests;thread-trace;exclusive-gpu"
     WILL_FAIL
     DISABLED ${IS_DISABLED}
     FAIL_REGULAR_EXPRESSION
@@ -437,7 +437,7 @@ rocprofiler_add_integration_execute_test(
         --att-no-intercept --kernel-include-regex looping_lds_kernel --output-format json
         --log-level env -o out -- $<TARGET_FILE:thread-trace-test-app>
     DEPENDS thread-trace-test-app
-    LABELS "integration-tests;thread-trace"
+    LABELS "integration-tests;thread-trace;exclusive-gpu"
     TIMEOUT 45
     DISABLED ${IS_DISABLED}
     ENVIRONMENT "ROCPROF_ATT_LIBRARY_PATH=${attdecoder_LIB_DIR}"
@@ -451,7 +451,7 @@ rocprofiler_add_integration_validate_test(
     CONFIG pytest.ini
     DISCOVERY_ARGS -k test_att_no_intercept_target_kernel
     TIMEOUT 45
-    LABELS "integration-tests;thread-trace"
+    LABELS "integration-tests;thread-trace;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     FIXTURES_REQUIRED rocprofv3-test-att-no-intercept
     ARGS --att-no-intercept-out-dir ${ATT_NO_INTERCEPT_OUT_DIR}
@@ -465,7 +465,7 @@ rocprofiler_add_integration_execute_test(
             $<TARGET_FILE:thread-trace-test-app>
     DEPENDS thread-trace-test-app
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     ENVIRONMENT "ROCPROF_ATT_LIBRARY_PATH=${attdecoder_LIB_DIR}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
@@ -478,7 +478,7 @@ rocprofiler_add_integration_validate_test(
     CONFIG pytest.ini
     DISCOVERY_ARGS -k test_shaderdata
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     FIXTURES_REQUIRED rocprofv3-test-att-shaderdata
     ARGS --att-shaderdata-out-dir ${SHADERDATA_OUT_DIR}

--- a/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/CMakeLists.txt
@@ -74,7 +74,7 @@ rocprofiler_add_integration_execute_test(
         --log-level env -- $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-att-consecutive-kernels)
@@ -85,7 +85,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 60
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-att-consecutive-kernels
     DISABLED ${IS_DISABLED}
     ARGS --csv-directory-input ${CMAKE_CURRENT_BINARY_DIR}/vector-ops-trace/

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once-att/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once-att/CMakeLists.txt
@@ -49,7 +49,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR} ${LOG_LEVEL} out "${attdecoder_LIB_DIR}"
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 90
-    LABELS "attachment" "att"
+    LABELS "attachment;att;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${attachment-env}"
@@ -66,7 +66,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 30
-    LABELS "attachment" "att"
+    LABELS "attachment;att;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     DISABLED_CODECOV
     SKIP_REGULAR_EXPRESSION "SKIPPED"

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
@@ -38,7 +38,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR} ${LOG_LEVEL} out
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 60
-    LABELS "attachment"
+    LABELS "attachment;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${attachment-env}"
@@ -54,7 +54,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 30
-    LABELS "attachment"
+    LABELS "attachment;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     SKIP_REGULAR_EXPRESSION "SKIPPED"
     FIXTURES_REQUIRED rocprofv3-test-attachment-attach-once

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/CMakeLists.txt
@@ -38,7 +38,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR} ${LOG_LEVEL} out
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 60
-    LABELS "attachment"
+    LABELS "attachment;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${attachment-env}"
@@ -54,7 +54,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 30
-    LABELS "attachment"
+    LABELS "attachment;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     SKIP_REGULAR_EXPRESSION "SKIPPED"
     FIXTURES_REQUIRED rocprofv3-test-attachment-attach-tree

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/CMakeLists.txt
@@ -38,7 +38,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR} ${LOG_LEVEL} out
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 90
-    LABELS "attachment"
+    LABELS "attachment;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${attachment-env}"
@@ -54,7 +54,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 30
-    LABELS "attachment"
+    LABELS "attachment;exclusive-gpu"
     DISABLED ${IS_DISABLED}
     SKIP_REGULAR_EXPRESSION "SKIPPED"
     FIXTURES_REQUIRED rocprofv3-test-attachment-attach-twice

--- a/projects/rocprofiler-sdk/tests/rocprofv3/conversion-script/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/conversion-script/CMakeLists.txt
@@ -44,7 +44,7 @@ rocprofiler_add_integration_execute_test(
         -T -d ${CMAKE_CURRENT_BINARY_DIR}/out_conversion_script -o pmc1 --output-format
         csv -- $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     TIMEOUT 45
     PRELOAD "${PRELOAD_ENV}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
@@ -94,7 +94,7 @@ foreach(i RANGE 0 ${convert_test_length})
         COMMAND ${conversion_cmd}
         DEPENDS rocprofiler-sdk::convert-counters-collection-format
         TIMEOUT 45
-        LABELS "integration-tests"
+        LABELS "integration-tests;exclusive-gpu"
         PRELOAD "${PRELOAD_ENV}"
         FIXTURES_REQUIRED rocprofv3-test-conversion-script
         FIXTURES_SETUP ${test_name})
@@ -106,7 +106,7 @@ foreach(i RANGE 0 ${convert_test_length})
         CONFIG pytest.ini
         ARGS --input ${output} ${validate_args}
         TIMEOUT 45
-        LABELS "integration-tests"
+        LABELS "integration-tests;exclusive-gpu"
         FIXTURES_REQUIRED ${test_name}
         UNSTABLE)
 endforeach()

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/cli-multipass/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/cli-multipass/CMakeLists.txt
@@ -44,7 +44,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:simple-transpose>
     DEPENDS simple-transpose
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-counter-collection-cli-multipass)
 
@@ -55,5 +55,5 @@ rocprofiler_add_integration_validate_test(
     CONFIG pytest.ini
     ARGS --output-dir ${CMAKE_CURRENT_BINARY_DIR}/simple-transpose-cc
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-cli-multipass)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/CMakeLists.txt
@@ -22,7 +22,7 @@ rocprofiler_add_integration_execute_test(
         csv -- $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-counter-collection-txt-pmc1-extra-counters)
 
@@ -34,5 +34,5 @@ rocprofiler_add_integration_validate_test(
     ARGS --input
          ${CMAKE_CURRENT_BINARY_DIR}/out_counter_collection_1_extra/pmc_1/pmc1_counter_collection.csv
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-txt-pmc1-extra-counters)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/input1/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/input1/CMakeLists.txt
@@ -25,7 +25,7 @@ rocprofiler_add_integration_execute_test(
         csv json -- $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-counter-collection-txt-pmc1)
 
@@ -39,5 +39,5 @@ rocprofiler_add_integration_validate_test(
          --json-input
          ${CMAKE_CURRENT_BINARY_DIR}/out_counter_collection_1/pmc_1/pmc1_results.json
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-txt-pmc1)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/input2/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/input2/CMakeLists.txt
@@ -22,7 +22,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:simple-transpose>
     DEPENDS vector-ops
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-counter-collection-txt-pmc2)
 
@@ -40,5 +40,5 @@ rocprofiler_add_integration_validate_test(
          --counter-input
          ${CMAKE_CURRENT_BINARY_DIR}/simple-transpose-cc/pmc_2/out_counter_collection.csv
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-txt-pmc2)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/input3/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/input3/CMakeLists.txt
@@ -24,7 +24,7 @@ rocprofiler_add_integration_execute_test(
         out_json -f csv -- $<TARGET_FILE:simple-transpose>
     DEPENDS simple-transpose
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     ENVIRONMENT "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-counter-collection-json-pmc1)
 
@@ -42,7 +42,7 @@ rocprofiler_add_integration_validate_test(
          --counter-input
          ${CMAKE_CURRENT_BINARY_DIR}/simple-transpose-cc/pass_2/out_json_counter_collection.csv
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-json-pmc1)
 
 # YAML input test
@@ -54,7 +54,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:simple-transpose>
     DEPENDS simple-transpose
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-counter-collection-yaml-pmc1)
 
@@ -72,5 +72,5 @@ rocprofiler_add_integration_validate_test(
          --counter-input
          ${CMAKE_CURRENT_BINARY_DIR}/simple-transpose-cc/pass_2/out_yaml_counter_collection.csv
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-yaml-pmc1)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/kernel_filtering/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/kernel_filtering/CMakeLists.txt
@@ -21,7 +21,7 @@ rocprofiler_add_integration_execute_test(
         -- $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 120
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-counter-collection-kernel-filtering-input-json)
 
@@ -48,7 +48,7 @@ rocprofiler_add_integration_validate_test(
          --input-json-pass4
          ${CMAKE_CURRENT_BINARY_DIR}/json_input/pass_4/out_results.json
     TIMEOUT 120
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-kernel-filtering-input-json)
 
 rocprofiler_add_integration_execute_test(
@@ -60,7 +60,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 120
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-counter-collection-kernel-filtering-input-cmd)
 
@@ -73,7 +73,7 @@ rocprofiler_add_integration_validate_test(
     ARGS --input-csv-pmc1
          ${CMAKE_CURRENT_BINARY_DIR}/cmd_input/pmc_1/out_counter_collection.csv
     TIMEOUT 120
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-kernel-filtering-input-cmd)
 
 rocprofiler_add_integration_execute_test(
@@ -84,7 +84,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 120
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-counter-collection-kernel-filtering-input-yaml)
 
@@ -111,5 +111,5 @@ rocprofiler_add_integration_validate_test(
          --input-json-pass4
          ${CMAKE_CURRENT_BINARY_DIR}/yaml_input/pass_4/out_results.json
     TIMEOUT 120
-    LABELS "integration-tests" FIXTURES
-           rocprofv3-test-counter-collection-kernel-filtering-input-yaml)
+    LABELS "integration-tests;exclusive-gpu"
+    FIXTURES_REQUIRED rocprofv3-test-counter-collection-kernel-filtering-input-yaml)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/multiplex/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/multiplex/CMakeLists.txt
@@ -44,7 +44,7 @@ rocprofiler_add_integration_execute_test(
         out_json -f csv -- $<TARGET_FILE:simple-transpose>
     DEPENDS simple-transpose
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-counter-collection-multiplex
     UNSTABLE)
@@ -59,7 +59,7 @@ rocprofiler_add_integration_validate_test(
          --counter-input
          ${CMAKE_CURRENT_BINARY_DIR}/simple-transpose-cc/out_json_counter_collection.csv
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-multiplex
     UNSTABLE)
 
@@ -72,7 +72,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:simple-transpose>
     DEPENDS simple-transpose
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-counter-collection-multiple-yaml
     UNSTABLE)
@@ -87,6 +87,6 @@ rocprofiler_add_integration_validate_test(
          --counter-input
          ${CMAKE_CURRENT_BINARY_DIR}/simple-transpose-cc/out_yaml_counter_collection.csv
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-multiple-yaml
     UNSTABLE)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/pmc-selected-regions/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/pmc-selected-regions/CMakeLists.txt
@@ -45,7 +45,8 @@ rocprofiler_add_integration_execute_test(
         --log-level info -- $<TARGET_FILE:roctx-pause-resume>
     DEPENDS roctx-pause-resume
     TIMEOUT 120
-    LABELS "integration-tests;pause-resume;counter-collection;selected-regions"
+    LABELS
+        "integration-tests;pause-resume;counter-collection;selected-regions;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-counter-collection-pmc-selected-regions)
 
@@ -56,6 +57,7 @@ rocprofiler_add_integration_validate_test(
     CONFIG pytest.ini
     ARGS --json-input ${CMAKE_CURRENT_BINARY_DIR}/pmc-sel-reg-out/out_results.json
     TIMEOUT 120
-    LABELS "integration-tests;pause-resume;counter-collection;selected-regions"
+    LABELS
+        "integration-tests;pause-resume;counter-collection;selected-regions;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-pmc-selected-regions
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/queue-overflow/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/queue-overflow/CMakeLists.txt
@@ -33,7 +33,7 @@ rocprofiler_add_integration_execute_test(
         queue_overflow --output-format csv json -- $<TARGET_FILE:multistream>
     DEPENDS multistream
     TIMEOUT 300
-    LABELS "integration-tests;counter-collection"
+    LABELS "integration-tests;counter-collection;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-counter-collection-queue-overflow)
 
@@ -47,5 +47,5 @@ rocprofiler_add_integration_validate_test(
          --json-input
          ${CMAKE_CURRENT_BINARY_DIR}/out_counter_collection_queue_overflow/queue_overflow_results.json
     TIMEOUT 120
-    LABELS "integration-tests;counter-collection"
+    LABELS "integration-tests;counter-collection;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-queue-overflow)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/range_filtering/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/range_filtering/CMakeLists.txt
@@ -22,7 +22,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/range_filter -- $<TARGET_FILE:transpose> 1 15
     DEPENDS transpose
     TIMEOUT 120
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-counter-collection-kernel-filtering-range-filter)
 
@@ -40,5 +40,5 @@ rocprofiler_add_integration_validate_test(
          --input-json-pass3
          ${CMAKE_CURRENT_BINARY_DIR}/range_filter/pass_3/out_results.json
     TIMEOUT 120
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-kernel-filtering-range-filter)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/kfd/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/kfd/CMakeLists.txt
@@ -32,7 +32,7 @@ foreach(_XNACK on off)
         DEPENDS transpose
         TIMEOUT 45
         DISABLED ON
-        LABELS "integration-tests;multi-gpu"
+        LABELS "integration-tests;exclusive-gpu"
         ENVIRONMENT "${kfd-xnack-${_XNACK}-env}"
         FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
         FIXTURES_SETUP rocprofv3-test-kfd-xnack-${_XNACK})
@@ -46,7 +46,7 @@ foreach(_XNACK on off)
              ${CMAKE_CURRENT_BINARY_DIR}/kfd-xnack-${_XNACK}-trace/out_results.json
         TIMEOUT 45
         DISABLED ON
-        LABELS "integration-tests;multi-gpu"
+        LABELS "integration-tests;exclusive-gpu"
         FAIL_REGULAR_EXPRESSION "AssertionError"
         FIXTURES_REQUIRED rocprofv3-test-kfd-xnack-${_XNACK})
 endforeach()

--- a/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/host-trap/exec-mask-manipulation/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/host-trap/exec-mask-manipulation/CMakeLists.txt
@@ -25,7 +25,7 @@ rocprofiler_add_integration_execute_test(
         -- $<TARGET_FILE:exec-mask-manipulation>
     DEPENDS exec-mask-manipulation
     TIMEOUT 90
-    LABELS "integration-tests;pc-sampling"
+    LABELS "integration-tests;pc-sampling;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-input-cmd
@@ -44,7 +44,7 @@ rocprofiler_add_integration_validate_test(
          --all-sampled
          False
     TIMEOUT 60
-    LABELS "integration-tests;pc-sampling"
+    LABELS "integration-tests;pc-sampling;exclusive-gpu"
     FIXTURES_REQUIRED
         rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-input-cmd
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
@@ -59,7 +59,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:exec-mask-manipulation>
     DEPENDS exec-mask-manipulation
     TIMEOUT 90
-    LABELS "integration-tests;pc-sampling"
+    LABELS "integration-tests;pc-sampling;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-input-json
@@ -78,7 +78,7 @@ rocprofiler_add_integration_validate_test(
          --all-sampled
          False
     TIMEOUT 60
-    LABELS "integration-tests;pc-sampling"
+    LABELS "integration-tests;pc-sampling;exclusive-gpu"
     FIXTURES_REQUIRED
         rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-input-json
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
@@ -92,7 +92,7 @@ rocprofiler_add_integration_execute_test(
         json -- $<TARGET_FILE:exec-mask-manipulation>
     DEPENDS exec-mask-manipulation
     TIMEOUT 90
-    LABELS "integration-tests;pc-sampling"
+    LABELS "integration-tests;pc-sampling;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-input-yaml
@@ -111,7 +111,7 @@ rocprofiler_add_integration_validate_test(
          --all-sampled
          False
     TIMEOUT 60
-    LABELS "integration-tests;pc-sampling"
+    LABELS "integration-tests;pc-sampling;exclusive-gpu"
     FIXTURES_REQUIRED
         rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-input-yaml
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"

--- a/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/host-trap/transpose-multiple-agents/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/host-trap/transpose-multiple-agents/CMakeLists.txt
@@ -31,7 +31,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:transpose> ${TRANSPOSE_NUM_THREADS} ${TRANSPOSE_NUM_ITERATIONS}
     DEPENDS transpose
     TIMEOUT 90
-    LABELS "integration-tests;pc-sampling"
+    LABELS "integration-tests;pc-sampling;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP
@@ -52,7 +52,7 @@ rocprofiler_add_integration_validate_test(
          --input-agent-info-csv
          ${CMAKE_CURRENT_BINARY_DIR}/pc_sampling_cmd_input/out_agent_info.csv
     TIMEOUT 60
-    LABELS "integration-tests;pc-sampling"
+    LABELS "integration-tests;pc-sampling;exclusive-gpu"
     FIXTURES_REQUIRED
         rocprofv3-test-pc-sampling-host-trap-transpose-multiple-agents-input-cmd
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
@@ -67,7 +67,7 @@ rocprofiler_add_integration_execute_test(
         ${TRANSPOSE_NUM_THREADS} ${TRANSPOSE_NUM_ITERATIONS}
     DEPENDS transpose
     TIMEOUT 90
-    LABELS "integration-tests;pc-sampling"
+    LABELS "integration-tests;pc-sampling;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP
@@ -88,7 +88,7 @@ rocprofiler_add_integration_validate_test(
          --input-agent-info-csv
          ${CMAKE_CURRENT_BINARY_DIR}/pc_sampling_json_input/out_agent_info.csv
     TIMEOUT 60
-    LABELS "integration-tests;pc-sampling"
+    LABELS "integration-tests;pc-sampling;exclusive-gpu"
     FIXTURES_REQUIRED
         rocprofv3-test-pc-sampling-host-trap-transpose-multiple-agents-input-json
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
@@ -102,7 +102,7 @@ rocprofiler_add_integration_execute_test(
         -- $<TARGET_FILE:transpose> ${TRANSPOSE_NUM_THREADS} ${TRANSPOSE_NUM_ITERATIONS}
     DEPENDS transpose
     TIMEOUT 90
-    LABELS "integration-tests;pc-sampling"
+    LABELS "integration-tests;pc-sampling;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP
@@ -123,7 +123,7 @@ rocprofiler_add_integration_validate_test(
          --input-agent-info-csv
          ${CMAKE_CURRENT_BINARY_DIR}/pc_sampling_yaml_input/out_agent_info.csv
     TIMEOUT 60
-    LABELS "integration-tests;pc-sampling"
+    LABELS "integration-tests;pc-sampling;exclusive-gpu"
     FIXTURES_REQUIRED
         rocprofv3-test-pc-sampling-host-trap-transpose-multiple-agents-input-yaml
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"

--- a/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/stochastic/exec-mask-manipulation/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/stochastic/exec-mask-manipulation/CMakeLists.txt
@@ -47,7 +47,7 @@ rocprofiler_add_integration_execute_test(
         -- $<TARGET_FILE:exec-mask-manipulation>
     DEPENDS exec-mask-manipulation
     TIMEOUT 90
-    LABELS "integration-tests;pc-sampling;stochastic"
+    LABELS "integration-tests;pc-sampling;stochastic;exclusive-gpu"
     ENVIRONMENT "${PRELOAD_ENV}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-input-cmd
@@ -69,7 +69,7 @@ rocprofiler_add_integration_validate_test(
          --all-sampled
          False
     TIMEOUT 60
-    LABELS "integration-tests;pc-sampling;stochastic"
+    LABELS "integration-tests;pc-sampling;stochastic;exclusive-gpu"
     FIXTURES_REQUIRED
         rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-input-cmd
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
@@ -84,7 +84,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:exec-mask-manipulation>
     DEPENDS exec-mask-manipulation
     TIMEOUT 90
-    LABELS "integration-tests;pc-sampling;stochastic"
+    LABELS "integration-tests;pc-sampling;stochastic;exclusive-gpu"
     ENVIRONMENT "${PRELOAD_ENV}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-input-json
@@ -106,7 +106,7 @@ rocprofiler_add_integration_validate_test(
          --all-sampled
          False
     TIMEOUT 60
-    LABELS "integration-tests;pc-sampling;stochastic"
+    LABELS "integration-tests;pc-sampling;stochastic;exclusive-gpu"
     FIXTURES_REQUIRED
         rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-input-json
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
@@ -120,7 +120,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:exec-mask-manipulation>
     DEPENDS exec-mask-manipulation
     TIMEOUT 90
-    LABELS "integration-tests;pc-sampling;stochastic"
+    LABELS "integration-tests;pc-sampling;stochastic;exclusive-gpu"
     ENVIRONMENT "${PRELOAD_ENV}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-input-yaml
@@ -142,7 +142,7 @@ rocprofiler_add_integration_validate_test(
          --all-sampled
          False
     TIMEOUT 60
-    LABELS "integration-tests;pc-sampling;stochastic"
+    LABELS "integration-tests;pc-sampling;stochastic;exclusive-gpu"
     FIXTURES_REQUIRED
         rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-input-yaml
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"

--- a/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/stochastic/transpose-multiple-agents/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/stochastic/transpose-multiple-agents/CMakeLists.txt
@@ -53,7 +53,7 @@ rocprofiler_add_integration_execute_test(
         -- $<TARGET_FILE:transpose> ${TRANSPOSE_NUM_THREADS} ${TRANSPOSE_NUM_ITERATIONS}
     DEPENDS transpose
     TIMEOUT 90
-    LABELS "integration-tests;pc-sampling;stochastic"
+    LABELS "integration-tests;pc-sampling;stochastic;exclusive-gpu"
     ENVIRONMENT "${PRELOAD_ENV}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP
@@ -76,7 +76,7 @@ rocprofiler_add_integration_validate_test(
          --input-agent-info-csv
          ${CMAKE_CURRENT_BINARY_DIR}/pc_sampling_cmd_input/out_agent_info.csv
     TIMEOUT 60
-    LABELS "integration-tests;pc-sampling;stochastic"
+    LABELS "integration-tests;pc-sampling;stochastic;exclusive-gpu"
     FIXTURES_REQUIRED
         rocprofv3-test-pc-sampling-stochastic-transpose-multiple-agents-input-cmd
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
@@ -91,7 +91,7 @@ rocprofiler_add_integration_execute_test(
         ${TRANSPOSE_NUM_THREADS} ${TRANSPOSE_NUM_ITERATIONS}
     DEPENDS transpose
     TIMEOUT 90
-    LABELS "integration-tests;pc-sampling;stochastic"
+    LABELS "integration-tests;pc-sampling;stochastic;exclusive-gpu"
     ENVIRONMENT "${PRELOAD_ENV}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP
@@ -114,7 +114,7 @@ rocprofiler_add_integration_validate_test(
          --input-agent-info-csv
          ${CMAKE_CURRENT_BINARY_DIR}/pc_sampling_json_input/out_agent_info.csv
     TIMEOUT 60
-    LABELS "integration-tests;pc-sampling;stochastic"
+    LABELS "integration-tests;pc-sampling;stochastic;exclusive-gpu"
     FIXTURES_REQUIRED
         rocprofv3-test-pc-sampling-stochastic-transpose-multiple-agents-input-json
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
@@ -128,7 +128,7 @@ rocprofiler_add_integration_execute_test(
         ${TRANSPOSE_NUM_THREADS} ${TRANSPOSE_NUM_ITERATIONS}
     DEPENDS transpose
     TIMEOUT 90
-    LABELS "integration-tests;pc-sampling;stochastic"
+    LABELS "integration-tests;pc-sampling;stochastic;exclusive-gpu"
     ENVIRONMENT "${PRELOAD_ENV}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP
@@ -151,7 +151,7 @@ rocprofiler_add_integration_validate_test(
          --input-agent-info-csv
          ${CMAKE_CURRENT_BINARY_DIR}/pc_sampling_yaml_input/out_agent_info.csv
     TIMEOUT 60
-    LABELS "integration-tests;pc-sampling;stochastic"
+    LABELS "integration-tests;pc-sampling;stochastic;exclusive-gpu"
     FIXTURES_REQUIRED
         rocprofv3-test-pc-sampling-stochastic-transpose-multiple-agents-input-yaml
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/CMakeLists.txt
@@ -46,7 +46,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:reproducible-dispatch-count> 500 2
     DEPENDS reproducible-dispatch-count
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-rocpd)
 
@@ -60,7 +60,7 @@ rocprofiler_add_integration_execute_test(
         SQ_WAVES -- $<TARGET_FILE:reproducible-dispatch-count> 200 1
     DEPENDS reproducible-dispatch-count
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-rocpd-multiproc
     DISABLED "${MULTIPROC_IS_DISABLED}")
@@ -76,7 +76,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:reproducible-dispatch-count> 500 2
     DEPENDS reproducible-dispatch-count
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     FIXTURES_SETUP rocprofv3-test-rocpd)
@@ -95,7 +95,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/out_results.db
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-generation
@@ -110,7 +110,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data-multiproc/out_mp_1_results.db
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-generation
@@ -131,7 +131,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/out_results.db
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-generation
@@ -147,7 +147,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data-multiproc/out_mp_1_results.db
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-generation
@@ -168,7 +168,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/out_results.db
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-generation
@@ -188,7 +188,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/out_results.db
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 45
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-generation
@@ -203,7 +203,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data-multiproc/out_mp_1_results.db
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-generation
@@ -218,7 +218,7 @@ rocprofiler_add_integration_execute_test(
         -o out_trunc -i ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/out_results.db
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 45
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-generation
@@ -232,7 +232,7 @@ rocprofiler_add_integration_execute_test(
         -o out_mangled -i ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/out_results.db
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 45
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-generation
@@ -253,7 +253,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/out_results.db
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 45
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-region-category
@@ -268,7 +268,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/out_results.db
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 45
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-region-category
@@ -283,7 +283,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/out_results.db
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 45
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-region-category
@@ -298,7 +298,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/out_results.db
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 45
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-region-category
@@ -337,7 +337,7 @@ rocprofiler_add_integration_validate_test(
          ${CMAKE_CURRENT_BINARY_DIR}/rocpd-output-data/out_memory_allocation_trace.csv
          ${CMAKE_CURRENT_BINARY_DIR}/rocpd-output-data/out_regions_trace.csv
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-rocpd-generation)
 
 # Validate kernel name format tests (truncated, mangled)
@@ -358,7 +358,7 @@ rocprofiler_add_integration_validate_test(
          --csv-input-mangled
          ${CMAKE_CURRENT_BINARY_DIR}/rocpd-output-data/summary/out_mangled_kernels_summary.csv
     TIMEOUT 60
-    LABELS "integration-tests;rocpd;kernel-name"
+    LABELS "integration-tests;rocpd;kernel-name;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-rocpd-generation)
 
 # Validate region category filtering
@@ -383,7 +383,7 @@ rocprofiler_add_integration_validate_test(
          ${CMAKE_CURRENT_BINARY_DIR}/rocpd-output-data/summary-none/out_kernels_summary.csv
          ${CMAKE_CURRENT_BINARY_DIR}/rocpd-output-data/summary-none/out_memory_allocations_summary.csv
     TIMEOUT 60
-    LABELS "integration-tests;rocpd;region-category"
+    LABELS "integration-tests;rocpd;region-category;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-rocpd-region-category)
 
 #########################################################################################
@@ -408,7 +408,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/out*.db
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     FIXTURES_SETUP rocprofv3-test-rocpd-package-generation
@@ -422,7 +422,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data-multiproc/out*.db
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     DISABLED "${MULTIPROC_IS_DISABLED}"
@@ -443,7 +443,7 @@ rocprofiler_add_integration_execute_test(
         "SELECT id, type FROM rocpd_info_agent LIMIT 10;"
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     FIXTURES_REQUIRED rocprofv3-test-rocpd-package-generation)
@@ -456,7 +456,7 @@ rocprofiler_add_integration_execute_test(
         --query "SELECT id, type FROM rocpd_info_agent LIMIT 10;"
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     DISABLED "${MULTIPROC_IS_DISABLED}"
@@ -476,7 +476,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/test_package.rpdb
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     FIXTURES_SETUP rocprofv3-test-rocpd-merge-generation-using-package
@@ -490,7 +490,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data-multiproc/test_package_multi.rpdb
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     DISABLED "${MULTIPROC_IS_DISABLED}"
@@ -511,7 +511,7 @@ rocprofiler_add_integration_execute_test(
         "SELECT id, type FROM rocpd_info_agent LIMIT 10;"
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     FIXTURES_REQUIRED rocprofv3-test-rocpd-merge-generation-using-package)
@@ -524,7 +524,7 @@ rocprofiler_add_integration_execute_test(
         "SELECT id, type FROM rocpd_info_agent LIMIT 10;"
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 120
-    LABELS "integration-tests;rocpd"
+    LABELS "integration-tests;rocpd;exclusive-gpu"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     DISABLED "${MULTIPROC_IS_DISABLED}"

--- a/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/pc-sampling/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/pc-sampling/CMakeLists.txt
@@ -49,7 +49,7 @@ rocprofiler_add_integration_execute_test(
         --log-level env -- $<TARGET_FILE:roctx-pause-resume>
     DEPENDS roctx-pause-resume
     TIMEOUT 45
-    LABELS "integration-tests;pc-sampling;pause-resume"
+    LABELS "integration-tests;pc-sampling;pause-resume;exclusive-gpu"
     ENVIRONMENT "${roctx-pause-resume-env}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     DISABLED "${IS_PC_SAMPLING_DISABLED}"
@@ -63,7 +63,7 @@ rocprofiler_add_integration_validate_test(
     ARGS --json-input
          ${CMAKE_CURRENT_BINARY_DIR}/roctx-pause-resume-pc-sampling/out_results.json
     TIMEOUT 45
-    LABELS "integration-tests;pc-sampling;pause-resume"
+    LABELS "integration-tests;pc-sampling;pause-resume;exclusive-gpu"
     FIXTURES_REQUIRED rocprofv3-test-roctx-pause-resume-pc-sampling
     FAIL_REGULAR_EXPRESSION "AssertionError"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"

--- a/projects/rocprofiler-sdk/tests/rocprofv3/spm/json/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/spm/json/CMakeLists.txt
@@ -12,7 +12,7 @@ rocprofiler_add_integration_execute_test(
         json -o spm -- $<TARGET_FILE:simple-transpose>
     DEPENDS simple-transpose
     TIMEOUT 60
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     ENVIRONMENT "${PRELOAD_ENV}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     DISABLED ${IS_DISABLED})
@@ -26,7 +26,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:simple-transpose>
     DEPENDS simple-transpose
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     ENVIRONMENT "${PRELOAD_ENV}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     DISABLED ${IS_DISABLED})
@@ -40,7 +40,7 @@ rocprofiler_add_integration_validate_test(
          ${CMAKE_CURRENT_BINARY_DIR}/out_spm/spm_results.json
     CONFIG pytest.ini
     COPY spm_input.json conftest.py
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FIXTURES_REQUIRED
         "rocprofv3-test-spm-json-execute;rocprofv3-test-spm-json-compare-to-pmc"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
@@ -55,7 +55,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 60
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu;multi-gpu"
     ENVIRONMENT "${PRELOAD_ENV}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     DISABLED ${IS_DISABLED})
@@ -68,7 +68,7 @@ rocprofiler_add_integration_validate_test(
     ARGS --spm-json ${CMAKE_CURRENT_BINARY_DIR}/out_multi/multi_results.json
     CONFIG pytest.ini
     COPY conftest.py
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu;multi-gpu"
     FIXTURES_REQUIRED "rocprofv3-test-spm-multigpu-json-execute"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     DISABLED ${IS_DISABLED})

--- a/projects/rocprofiler-sdk/tests/rocprofv3/spm/rocpd/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/spm/rocpd/CMakeLists.txt
@@ -16,7 +16,7 @@ rocprofiler_add_integration_execute_test(
         rocpd json -o spm -- $<TARGET_FILE:simple-transpose>
     DEPENDS simple-transpose
     TIMEOUT 60
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     ENVIRONMENT "${PRELOAD_ENV}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     DISABLED ${IS_DISABLED})
@@ -30,7 +30,7 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR}/out_spm/spm_results.db
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 60
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     ENVIRONMENT "${rocprofv3-spm-rocpd-env}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     FIXTURES_SETUP rocprofv3-test-spm-rocpd-csv-generation
@@ -50,7 +50,7 @@ rocprofiler_add_integration_validate_test(
          ${CMAKE_CURRENT_BINARY_DIR}/out_spm/rocpd_csv/out_spm_counter_collection_trace.csv
     CONFIG pytest.ini
     COPY conftest.py
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FIXTURES_REQUIRED
         "rocprofv3-test-spm-rocpd-execute;rocprofv3-test-spm-rocpd-csv-generation"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
@@ -65,7 +65,7 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 60
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu;multi-gpu"
     ENVIRONMENT "${PRELOAD_ENV}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     DISABLED ${IS_DISABLED})
@@ -77,7 +77,7 @@ rocprofiler_add_integration_validate_test(
     ARGS --rocpd-input ${CMAKE_CURRENT_BINARY_DIR}/out_multi/multi_results.db
     COPY spm_input.json conftest.py
     CONFIG pytest.ini
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu;multi-gpu"
     FIXTURES_REQUIRED "rocprofv3-test-spm-multigpu-rocpd-execute"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     DISABLED ${IS_DISABLED})

--- a/projects/rocprofiler-sdk/tests/rocprofv3/tracing-plus-counter-collection/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/tracing-plus-counter-collection/CMakeLists.txt
@@ -23,7 +23,7 @@ rocprofiler_add_integration_execute_test(
         JSON PFTRACE CSV -- $<TARGET_FILE:simple-transpose>
     DEPENDS simple-transpose
     TIMEOUT 90
-    LABELS "integration-tests;application-replay"
+    LABELS "integration-tests;application-replay;exclusive-gpu"
     PRELOAD "${PRELOAD_ENV}"
     FIXTURES_SETUP rocprofv3-test-tracing-plus-counter-collection)
 
@@ -44,7 +44,7 @@ foreach(_DIR "pmc_1" "pmc_2" "pmc_3" "pmc_4")
              --counter-input
              ${CMAKE_CURRENT_BINARY_DIR}/out_counter_collection_trace/${_DIR}/pmc_counter_collection.csv
         TIMEOUT 45
-        LABELS "integration-tests;application-replay"
+        LABELS "integration-tests;application-replay;exclusive-gpu"
         FIXTURES_REQUIRED rocprofv3-test-tracing-plus-counter-collection)
 endforeach()
 
@@ -62,6 +62,7 @@ foreach(_GROUP "single" "multiple")
             2 50 5
         DEPENDS transpose
         TIMEOUT 45
+        LABELS "integration-tests;exclusive-gpu"
         PRELOAD "${PRELOAD_ENV}"
         FIXTURES_SETUP rocprofv3-test-tracing-plus-counter-collection-cmdl-${_GROUP})
 
@@ -84,6 +85,6 @@ foreach(_GROUP "single" "multiple")
              --counter-input
              ${_TEST_OUTPUT_PREFIX}_counter_collection.csv
         TIMEOUT 45
-        LABELS "integration-tests"
+        LABELS "integration-tests;exclusive-gpu"
         FIXTURES_REQUIRED rocprofv3-test-tracing-plus-counter-collection-cmdl-${_GROUP})
 endforeach()

--- a/projects/rocprofiler-sdk/tests/spm/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/spm/CMakeLists.txt
@@ -33,7 +33,7 @@ rocprofiler_add_integration_execute_test(
     test-spm-dispatch-collection-execute
     TARGET simple-transpose
     TIMEOUT 60
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "$<TARGET_FILE:rocprofiler-sdk-json-tool>"
     ENVIRONMENT
         "ROCPROFILER_TOOL_OUTPUT_FILE=spm-dispatch-collection-test.json"
@@ -47,7 +47,7 @@ rocprofiler_add_integration_execute_test(
     test-spm-dispatch-buffer-collection-execute
     TARGET simple-transpose
     TIMEOUT 45
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "$<TARGET_FILE:rocprofiler-sdk-json-tool>"
     ENVIRONMENT
         "ROCPROFILER_TOOL_OUTPUT_FILE=spm-buffer-dispatch-collection-test.json"
@@ -64,7 +64,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 160
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     FIXTURES_REQUIRED spm-dispatch
     DISABLED ${IS_DISABLED})
@@ -76,7 +76,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 160
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     FIXTURES_REQUIRED spm-buffer
     DISABLED ${IS_DISABLED})

--- a/projects/rocprofiler-sdk/tests/thread-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/thread-trace/CMakeLists.txt
@@ -15,7 +15,7 @@ rocprofiler_add_integration_execute_test(
     thread-trace-api-single-test
     TARGET thread-trace-test-app
     TIMEOUT 10
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "$<TARGET_FILE:thread-trace-single-tool>")
 
 # Multi dispatch test
@@ -23,7 +23,7 @@ rocprofiler_add_integration_execute_test(
     thread-trace-api-multi-test
     TARGET thread-trace-test-app
     TIMEOUT 10
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "$<TARGET_FILE:thread-trace-multi-tool>")
 
 # Agent profiling test
@@ -31,7 +31,7 @@ rocprofiler_add_integration_execute_test(
     thread-trace-api-agent-test
     TARGET thread-trace-test-app
     TIMEOUT 10
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "$<TARGET_FILE:thread-trace-agent-tool>")
 
 # Start before hsa_init(): verifies the request is cached and replayed once HSA registers.
@@ -39,7 +39,7 @@ rocprofiler_add_integration_execute_test(
     thread-trace-api-agent-before-hsa-init-test
     TARGET thread-trace-test-app
     TIMEOUT 10
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "$<TARGET_FILE:thread-trace-agent-tool>"
     ENVIRONMENT "ATT_START_BEFORE_HSA_INIT=1")
 
@@ -48,7 +48,7 @@ rocprofiler_add_integration_execute_test(
     thread-trace-api-agent-start-stop-before-hsa-init-test
     TARGET thread-trace-test-app
     TIMEOUT 10
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "$<TARGET_FILE:thread-trace-agent-tool>"
     ENVIRONMENT "ATT_START_BEFORE_HSA_INIT=1;ATT_STOP_BEFORE_HSA_INIT=1")
 
@@ -69,7 +69,7 @@ rocprofiler_add_integration_execute_test(
     thread-trace-api-large-buffer-test
     TARGET thread-trace-test-app
     TIMEOUT 30
-    LABELS "integration-tests"
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "$<TARGET_FILE:thread-trace-agent-tool>"
     ENVIRONMENT "ATT_LARGE_BUFFER_TEST=1"
     DISABLED ${IS_DISABLED})
@@ -79,6 +79,7 @@ rocprofiler_add_integration_execute_test(
     thread-trace-api-extra-args
     TARGET thread-trace-test-app
     TIMEOUT 10
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "$<TARGET_FILE:thread-trace-agent-tool>"
     ENVIRONMENT "ATT_NODETAIL=1"
     DISABLED ${ROCPROFILER_DISABLE_UNSTABLE_CTESTS})
@@ -91,6 +92,7 @@ rocprofiler_add_integration_execute_test(
     thread-trace-api-triple-buffer-consistency-test
     TARGET thread-trace-test-app
     TIMEOUT 120
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "$<TARGET_FILE:thread-trace-triple-buffer-tool>"
     ENVIRONMENT "TRIPLEBUFFER=1;ATT_NODETAIL=1;ATT_SLOW_CALLBACK=0"
     DISABLED ${TRIPLE_BUFFER_DISABLED})
@@ -100,6 +102,7 @@ rocprofiler_add_integration_execute_test(
     thread-trace-api-triple-buffer-hammer-test
     TARGET thread-trace-test-app
     TIMEOUT 240
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "$<TARGET_FILE:thread-trace-triple-buffer-tool>"
     ENVIRONMENT "TRIPLEBUFFER=1;ATT_NODETAIL=0;ATT_SLOW_CALLBACK=0"
     DISABLED ${TRIPLE_BUFFER_DISABLED})
@@ -109,6 +112,7 @@ rocprofiler_add_integration_execute_test(
     thread-trace-api-triple-buffer-slow-test
     TARGET thread-trace-test-app
     TIMEOUT 120
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "$<TARGET_FILE:thread-trace-triple-buffer-tool>"
     ENVIRONMENT "TRIPLEBUFFER=1;ATT_NODETAIL=1;ATT_SLOW_CALLBACK=1"
     DISABLED ${TRIPLE_BUFFER_DISABLED})
@@ -119,6 +123,7 @@ rocprofiler_add_integration_execute_test(
     thread-trace-api-triple-buffer-no-pause-test
     TARGET thread-trace-test-app
     TIMEOUT 120
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "$<TARGET_FILE:thread-trace-triple-buffer-tool>"
     ENVIRONMENT "TRIPLEBUFFER=1;EXECUTE_PAUSE=0"
     DISABLED ${ROCPROFILER_DISABLE_UNSTABLE_CTESTS} OR ${TRIPLE_BUFFER_DISABLED})
@@ -128,6 +133,7 @@ rocprofiler_add_integration_execute_test(
     thread-trace-api-triple-buffer-multiple-cmds-test
     TARGET thread-trace-test-app
     TIMEOUT 120
+    LABELS "integration-tests;exclusive-gpu"
     PRELOAD "$<TARGET_FILE:thread-trace-triple-buffer-tool>"
     ENVIRONMENT "TRIPLEBUFFER=1;STARTSTOP=1;ATT_NODETAIL=1"
     DISABLED ${TRIPLE_BUFFER_DISABLED})


### PR DESCRIPTION
## Motivation

Distinguish exclusive GPU tests and multi-GPU tests with CMake label so a multi-node CI machine can run these tests in isolation with exclusive gpu access.

## Technical Details

Multi-gpu tests:

tests.integration.execute.rocprofv3-test-att-gpu-index-two-gpus
tests.integration.validate.rocprofv3-test-att-gpu-index-two-gpus.test_multi_gpu_separate_agents
tests.integration.execute.rocprofv3-test-spm-multigpu-json-execute
tests.integration.validate.rocprofv3-test-spm-multigpu-json-validate.test_validate_spm_multigpu_stream_id
tests.integration.execute.rocprofv3-test-spm-multigpu-rocpd-execute
tests.integration.validate.rocprofv3-test-spm-multigpu-rocpd-validate.test_validate_spm_multigpu_rocpd_stream_id
unit.pc_sampling.multiple_contexts_one_per_agent

Exlclusive GPU Tests

- Counter collection tests (tests/rocprofv3/counter-collection/) - hardware counter access may conflict with other containers sharing the GPU node

- Attachment tests (tests/rocprofv3/attachment/) - rocattach may interact with processes in other containers

- PC sampling tests (tests/rocprofv3/pc-sampling/) - particularly host-trap/transpose-multiple-agents/ and stochastic/transpose-multiple-agents/ which explicitly test multi-agent scenarios

- Agent index tests (tests/rocprofv3/agent-index/) - enumerate and test across multiple agents/devices

- Any unit tests in source/lib/rocprofiler-sdk/counters/tests/ or source/lib/rocprofiler-sdk/pc_sampling/tests/ that require hardware access

- ATT/thread trace: ATT/SQTT uses exclusive per-GPU trace hardware. Several tests also combine ATT with PMC or PC sampling.

- SPM: Continuously programs GPU performance-monitoring counters, which conflict with other profilers.

- ROCpd: Its fixture-generating tests run rocprofv3 --pmc SQ_WAVES. CPU-only conversion/validation descendants were also labeled so CTest cannot reintroduce the GPU fixture when using -LE exclusive-gpu.

- KFD: Exercises KFD tracing under HSA_XNACK=0/1. It is not multi-GPU; exclusive-gpu was chosen to isolate shared-node 
KFD activity. This is the most conservative classification.

- tests/rocattach/: Same rationale as the attachment group—successful attach/injection workflows manipulate live target processes. Pure argument/path-validation tests were left unlabeled.

## Issue Tracking

JIRA ID: AIPROFSDK-753

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
