### PR TITLE
docs(rocprofiler-systems): use inline env vars instead of invalid -e flag

### DIFF
--- a/projects/rocprofiler-systems/docs/how-to/configuring-runtime-options.rst
+++ b/projects/rocprofiler-systems/docs/how-to/configuring-runtime-options.rst
@@ -430,10 +430,9 @@ Example: trace only activity inside a region named ``Compute``:
 
 .. code-block:: shell
 
-   rocprof-sys-run \
-       -e ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch \
-       -e ROCPROFSYS_SELECTED_REGIONS=Compute \
-       -- ./my_app
+   ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch \
+   ROCPROFSYS_SELECTED_REGIONS=Compute \
+   rocprof-sys-run -- ./my_app
 
 rocprof-sys-avail examples
 -----------------------------------

--- a/projects/rocprofiler-systems/examples/code-coverage/README.md
+++ b/projects/rocprofiler-systems/examples/code-coverage/README.md
@@ -64,7 +64,8 @@ CODE_COVERAGE_USE_FAKE=1 ./code-coverage
 rocprof-sys-run -- ./code-coverage 10 4 2000
 
 # Profile the alternate path
-rocprof-sys-run -e CODE_COVERAGE_USE_FAKE=1 -- ./code-coverage 10 4 2000
+CODE_COVERAGE_USE_FAKE=1 \
+rocprof-sys-run -- ./code-coverage 10 4 2000
 ```
 
 ### Recommended Configuration

--- a/projects/rocprofiler-systems/examples/hipfile/README.md
+++ b/projects/rocprofiler-systems/examples/hipfile/README.md
@@ -49,7 +49,8 @@ hipFILE version: X.Y.Z
 Add `hipfile_api` to `ROCPROFSYS_ROCM_DOMAINS` (shorthand: `hipfile`) to capture the hipFILE API:
 
 ```bash
-rocprof-sys-run -e ROCPROFSYS_ROCM_DOMAINS=hipfile_api -- ./hipfile-trace
+ROCPROFSYS_ROCM_DOMAINS=hipfile_api \
+rocprof-sys-run -- ./hipfile-trace
 ```
 
 The captured hipFILE API calls appear in the Perfetto trace and the RocPD database under the `rocm_hipfile_api` category.
@@ -63,10 +64,9 @@ The captured hipFILE API calls appear in the Perfetto trace and the RocPD databa
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |
 
 ```bash
-rocprof-sys-run \
-    -e ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch,memory_copy,hipfile_api \
-    -e ROCPROFSYS_TRACE=true \
-    -- ./hipfile-trace
+ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch,memory_copy,hipfile_api \
+ROCPROFSYS_TRACE=true \
+rocprof-sys-run -- ./hipfile-trace
 ```
 
 > **Note:** Requesting the `hipfile_api` domain against a ROCProfiler-SDK older than 1.3.5 (which does not expose the hipFILE tracing domain) results in an `unsupported ROCPROFSYS_ROCM_DOMAINS value: hipfile_api` error, the same as any other unavailable domain.

--- a/projects/rocprofiler-systems/examples/hpc/README.md
+++ b/projects/rocprofiler-systems/examples/hpc/README.md
@@ -101,8 +101,7 @@ rocprof-sys-run -- ./matrix-exponential-streams-sync-hip
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |
 
 ```bash
-rocprof-sys-run \
-    -e ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch,memory_copy \
-    -e ROCPROFSYS_TRACE=true \
-    -- ./jacobi-hip
+ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch,memory_copy \
+ROCPROFSYS_TRACE=true \
+rocprof-sys-run -- ./jacobi-hip
 ```

--- a/projects/rocprofiler-systems/examples/jpegdecode/README.md
+++ b/projects/rocprofiler-systems/examples/jpegdecode/README.md
@@ -77,8 +77,7 @@ rocprof-sys-run -- ./jpegdecode -i /path/to/images/ -b 4
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |
 
 ```bash
-rocprof-sys-run \
-    -e ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch,memory_copy \
-    -e ROCPROFSYS_TRACE=true \
-    -- ./jpegdecode -i /path/to/images/ -b 4
+ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch,memory_copy \
+ROCPROFSYS_TRACE=true \
+rocprof-sys-run -- ./jpegdecode -i /path/to/images/ -b 4
 ```

--- a/projects/rocprofiler-systems/examples/lulesh/README.md
+++ b/projects/rocprofiler-systems/examples/lulesh/README.md
@@ -98,8 +98,7 @@ rocprof-sys-causal -- ./lulesh-rocprofsys -i 35 -s 50 -p
 For MPI runs:
 
 ```bash
-mpirun -np 8 rocprof-sys-run \
-    -e ROCPROFSYS_USE_MPIP=ON \
-    -e ROCPROFSYS_TRACE=true \
-    -- ./lulesh -i 35 -s 30 -p
+ROCPROFSYS_USE_MPIP=ON \
+ROCPROFSYS_TRACE=true \
+mpirun -np 8 rocprof-sys-run -- ./lulesh -i 35 -s 30 -p
 ```

--- a/projects/rocprofiler-systems/examples/mpi/README.md
+++ b/projects/rocprofiler-systems/examples/mpi/README.md
@@ -84,19 +84,17 @@ mpirun -np 2 rocprof-sys-run -- ./mpi-example
 | `ROCPROFSYS_USE_SAMPLING` | `ON` | Enable sampling |
 
 ```bash
-mpirun -np 2 rocprof-sys-run \
-    -e ROCPROFSYS_USE_MPIP=ON \
-    -e ROCPROFSYS_TRACE=true \
-    -- ./mpi-example
+ROCPROFSYS_USE_MPIP=ON \
+ROCPROFSYS_TRACE=true \
+mpirun -np 2 rocprof-sys-run -- ./mpi-example
 ```
 
 For flat profiling with collapsed processes/threads:
 
 ```bash
-mpirun -np 2 rocprof-sys-run \
-    -e ROCPROFSYS_USE_MPIP=ON \
-    -e ROCPROFSYS_FLAT_PROFILE=ON \
-    -e ROCPROFSYS_COLLAPSE_PROCESSES=ON \
-    -e ROCPROFSYS_COLLAPSE_THREADS=ON \
-    -- ./mpi-example
+ROCPROFSYS_USE_MPIP=ON \
+ROCPROFSYS_FLAT_PROFILE=ON \
+ROCPROFSYS_COLLAPSE_PROCESSES=ON \
+ROCPROFSYS_COLLAPSE_THREADS=ON \
+mpirun -np 2 rocprof-sys-run -- ./mpi-example
 ```

--- a/projects/rocprofiler-systems/examples/openmp/README.md
+++ b/projects/rocprofiler-systems/examples/openmp/README.md
@@ -93,8 +93,7 @@ OMP_NUM_THREADS=4 rocprof-sys-run -- ./openmp-cg
 
 ```bash
 OMP_NUM_THREADS=4 OMP_PROC_BIND=spread OMP_PLACES=threads \
-    rocprof-sys-run \
-    -e ROCPROFSYS_TRACE=true \
-    -e ROCPROFSYS_USE_SAMPLING=ON \
-    -- ./openmp-cg
+ROCPROFSYS_TRACE=true \
+ROCPROFSYS_USE_SAMPLING=ON \
+rocprof-sys-run -- ./openmp-cg
 ```

--- a/projects/rocprofiler-systems/examples/rccl/README.md
+++ b/projects/rocprofiler-systems/examples/rccl/README.md
@@ -71,8 +71,7 @@ rocprof-sys-run -- ./all_reduce_perf -b 8 -e 128M -f 2 -g 2
 > **Note:** RCCL collective calls (`ncclAllReduce`, `ncclBroadcast`, ...) are only captured when the `rccl_api` domain is enabled. Add `rccl_api` to `ROCPROFSYS_ROCM_DOMAINS`, or set `ROCPROFSYS_USE_RCCLP=true` (which enables the `rccl_api` domain for you).
 
 ```bash
-rocprof-sys-run \
-    -e ROCPROFSYS_ROCM_DOMAINS=rccl_api,hip_runtime_api,kernel_dispatch,memory_copy \
-    -e ROCPROFSYS_TRACE=true \
-    -- ./all_reduce_perf -b 8 -e 128M -f 2 -g 2
+ROCPROFSYS_ROCM_DOMAINS=rccl_api,hip_runtime_api,kernel_dispatch,memory_copy \
+ROCPROFSYS_TRACE=true \
+rocprof-sys-run -- ./all_reduce_perf -b 8 -e 128M -f 2 -g 2
 ```

--- a/projects/rocprofiler-systems/examples/roctx/README.md
+++ b/projects/rocprofiler-systems/examples/roctx/README.md
@@ -62,16 +62,15 @@ rocprof-sys-run -- ./roctx
 | `ROCPROFSYS_SELECTED_REGIONS` | `Region1` | Filter tracing to only the named region(s) |
 
 ```bash
-rocprof-sys-run \
-    -e ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch \
-    -e ROCPROFSYS_TRACE=true \
-    -- ./roctx
+ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch \
+ROCPROFSYS_TRACE=true \
+rocprof-sys-run -- ./roctx
 ```
 
 ### Selective Region Example
 
 ```bash
-ROCPROFSYS_SELECTED_REGIONS="Region1" rocprof-sys-run \
-    -e ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch \
-    -- ./selective-region
+ROCPROFSYS_SELECTED_REGIONS=Region1 \
+ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch \
+rocprof-sys-run -- ./selective-region
 ```

--- a/projects/rocprofiler-systems/examples/scratch-memory/README.md
+++ b/projects/rocprofiler-systems/examples/scratch-memory/README.md
@@ -53,8 +53,7 @@ rocprof-sys-run -- ./scratch-memory
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace |
 
 ```bash
-rocprof-sys-run \
-    -e ROCPROFSYS_ROCM_DOMAINS=hip_api,hsa_api,kernel_dispatch,scratch_memory \
-    -e ROCPROFSYS_TRACE=true \
-    -- ./scratch-memory
+ROCPROFSYS_ROCM_DOMAINS=hip_api,hsa_api,kernel_dispatch,scratch_memory \
+ROCPROFSYS_TRACE=true \
+rocprof-sys-run -- ./scratch-memory
 ```

--- a/projects/rocprofiler-systems/examples/sdma-test/README.md
+++ b/projects/rocprofiler-systems/examples/sdma-test/README.md
@@ -69,9 +69,8 @@ rocprof-sys-run -- ./sdma-test -s 256 -n 5
 To capture SDMA-specific metrics:
 
 ```bash
-rocprof-sys-run \
-    -e ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,memory_copy \
-    -e ROCPROFSYS_AMD_SMI_METRICS=sdma_usage \
-    -e ROCPROFSYS_TRACE=true \
-    -- ./sdma-test -s 512 -n 5
+ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,memory_copy \
+ROCPROFSYS_AMD_SMI_METRICS=sdma_usage \
+ROCPROFSYS_TRACE=true \
+rocprof-sys-run -- ./sdma-test -s 512 -n 5
 ```

--- a/projects/rocprofiler-systems/examples/sdma-test/sdma-test.cpp
+++ b/projects/rocprofiler-systems/examples/sdma-test/sdma-test.cpp
@@ -15,7 +15,7 @@
  *   -h, --help             Show this help message
  *
  * Run with profiler:
- *   rocprof-sys-run -e ROCPROFSYS_AMD_SMI_METRICS=sdma_usage -- ./sdma_test
+ *   ROCPROFSYS_AMD_SMI_METRICS=sdma_usage rocprof-sys-run -- ./sdma_test
  */
 
 #include <chrono>
@@ -73,8 +73,7 @@ print_usage(const char* prog_name)
     printf("  %s -s 1024 -n 5        # 1GB transfers, 5 iterations\n", prog_name);
     printf("  %s -s 256 -n 0         # 256MB transfers, run until Ctrl+C\n", prog_name);
     printf("\nRun with profiler:\n");
-    printf("  rocprof-sys-run -e ROCPROFSYS_AMD_SMI_METRICS=sdma_usage -- %s\n",
-           prog_name);
+    printf("  ROCPROFSYS_AMD_SMI_METRICS=sdma_usage rocprof-sys-run -- %s\n", prog_name);
 }
 
 size_t

--- a/projects/rocprofiler-systems/examples/sdma-test/sdma-test.cpp
+++ b/projects/rocprofiler-systems/examples/sdma-test/sdma-test.cpp
@@ -15,7 +15,7 @@
  *   -h, --help             Show this help message
  *
  * Run with profiler:
- *   ROCPROFSYS_AMD_SMI_METRICS=sdma_usage rocprof-sys-run -- ./sdma_test
+ *   rocprof-sys-run -e ROCPROFSYS_AMD_SMI_METRICS=sdma_usage -- ./sdma_test
  */
 
 #include <chrono>
@@ -73,7 +73,8 @@ print_usage(const char* prog_name)
     printf("  %s -s 1024 -n 5        # 1GB transfers, 5 iterations\n", prog_name);
     printf("  %s -s 256 -n 0         # 256MB transfers, run until Ctrl+C\n", prog_name);
     printf("\nRun with profiler:\n");
-    printf("  ROCPROFSYS_AMD_SMI_METRICS=sdma_usage rocprof-sys-run -- %s\n", prog_name);
+    printf("  rocprof-sys-run -e ROCPROFSYS_AMD_SMI_METRICS=sdma_usage -- %s\n",
+           prog_name);
 }
 
 size_t

--- a/projects/rocprofiler-systems/examples/trace-time-window/README.md
+++ b/projects/rocprofiler-systems/examples/trace-time-window/README.md
@@ -63,8 +63,7 @@ rocprof-sys-run -- ./trace-time-window 2
 | `ROCPROFSYS_LOG_LEVEL` | `trace` | Detailed log output |
 
 ```bash
-rocprof-sys-run \
-    -e ROCPROFSYS_TRACE=true \
-    -e ROCPROFSYS_VERBOSE=2 \
-    -- ./trace-time-window 2
+ROCPROFSYS_TRACE=true \
+ROCPROFSYS_VERBOSE=2 \
+rocprof-sys-run -- ./trace-time-window 2
 ```

--- a/projects/rocprofiler-systems/examples/transferBench/README.md
+++ b/projects/rocprofiler-systems/examples/transferBench/README.md
@@ -63,8 +63,7 @@ rocprof-sys-run -- ./transferBench
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace |
 
 ```bash
-rocprof-sys-run \
-    -e ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch,memory_copy \
-    -e ROCPROFSYS_TRACE=true \
-    -- ./transferBench
+ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch,memory_copy \
+ROCPROFSYS_TRACE=true \
+rocprof-sys-run -- ./transferBench
 ```

--- a/projects/rocprofiler-systems/examples/transpose/README.md
+++ b/projects/rocprofiler-systems/examples/transpose/README.md
@@ -71,8 +71,7 @@ rocprof-sys-run -- ./transpose 4 200 10
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |
 
 ```bash
-rocprof-sys-run \
-    -e ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch,memory_copy \
-    -e ROCPROFSYS_TRACE=true \
-    -- ./transpose 4 200 10
+ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch,memory_copy \
+ROCPROFSYS_TRACE=true \
+rocprof-sys-run -- ./transpose 4 200 10
 ```

--- a/projects/rocprofiler-systems/examples/videodecode/README.md
+++ b/projects/rocprofiler-systems/examples/videodecode/README.md
@@ -70,8 +70,7 @@ rocprof-sys-run -- ./videodecode -i /path/to/video.mp4
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |
 
 ```bash
-rocprof-sys-run \
-    -e ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch,memory_copy \
-    -e ROCPROFSYS_TRACE=true \
-    -- ./videodecode -i /path/to/video.mp4
+ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch,memory_copy \
+ROCPROFSYS_TRACE=true \
+rocprof-sys-run -- ./videodecode -i /path/to/video.mp4
 ```


### PR DESCRIPTION
## Summary

- Replace documented `-e VAR=VALUE` usage on `rocprof-sys-run` and `rocprof-sys-sample` with inline shell environment assignments, since `-e` is not implemented for those tools.
- Update `docs/how-to/configuring-runtime-options.rst` and 15 example READMEs to use the preferred style:

```bash
ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch \
ROCPROFSYS_SELECTED_REGIONS=Compute \
rocprof-sys-run -- ./my_app
```

## Motivation

Fixes the documentation portion of AIPROFSYST-685 / AIPROFSYST-688. Users following current docs hit:

```
[rocprof-sys] error: Unrecognized command line option 'e'
```

Code support for `--env` is tracked separately in AIPROFSYST-689.

## Issue Tracking

JIRA ID - AIPROFSYST-685
JIRA ID - AIPROFSYST-688

## Test plan

- [x] Verified no remaining `-e ROCPROFSYS` / `rocprof-sys-run -e` patterns under `docs/` and `examples/`
- [x] Documentation review only (no runtime/code behavior changes)