### PR TITLE
feat(rocr): expose the physical execution ISA

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/agent_props.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/agent_props.cc
@@ -239,4 +239,22 @@ void AgentPropTest::QueryAgentClockCounters() {
   }
 }
 
+void AgentPropTest::QueryAgentExecutionIsa() {
+  std::vector<hsa_agent_t> gpus;
+  hsa_status_t err = hsa_iterate_agents(rocrtst::IterateGPUAgents, &gpus);
+  ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+
+  for (hsa_agent_t gpu : gpus) {
+    hsa_isa_t isa = {};
+    hsa_isa_t execution_isa = {};
+    err = hsa_agent_get_info(gpu, HSA_AGENT_INFO_ISA, &isa);
+    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+    err = hsa_agent_get_info(
+        gpu, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_EXECUTION_ISA),
+        &execution_isa);
+    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+    EXPECT_EQ(execution_isa.handle, isa.handle);
+  }
+}
+
 #undef RET_IF_HSA_ERR

--- a/projects/rocr-runtime/rocrtst/suites/functional/agent_props.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/agent_props.cc
@@ -253,6 +253,13 @@ void AgentPropTest::QueryAgentExecutionIsa() {
         gpu, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_EXECUTION_ISA),
         &execution_isa);
     ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+
+    uint32_t isa_name_length = 0;
+    err = hsa_isa_get_info_alt(execution_isa, HSA_ISA_INFO_NAME_LENGTH,
+                               &isa_name_length);
+    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+    EXPECT_GT(isa_name_length, 0u);
+
     EXPECT_EQ(execution_isa.handle, isa.handle);
   }
 }

--- a/projects/rocr-runtime/rocrtst/suites/functional/agent_props.h
+++ b/projects/rocr-runtime/rocrtst/suites/functional/agent_props.h
@@ -80,6 +80,9 @@ class AgentPropTest : public TestBase {
   // @Brief: Query Clock Counter property of agents of a ROCm platform
   void QueryAgentClockCounters();
 
+  // @Brief: Query physical execution ISA property of GPU agents
+  void QueryAgentExecutionIsa();
+
  private:
   // Capture value for all agents on system
   std::vector<std::string> propList_;

--- a/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
@@ -507,6 +507,7 @@ TEST(rocrtstFunc, AgentPropertiesTests) {
     if (!RunCustomTestProlog(&propTest)) return;
     propTest.QueryAgentUUID();
     propTest.QueryAgentClockCounters();
+    propTest.QueryAgentExecutionIsa();
     RunCustomTestEpilog(&propTest);
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -2344,6 +2344,7 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
       }
     } break;
     case HSA_AGENT_INFO_ISA:
+    case HSA_AMD_AGENT_INFO_EXECUTION_ISA:
       *((hsa_isa_t*)value) = core::Isa::Handle(supported_isas()[0]);
       break;
     case HSA_AGENT_INFO_EXTENSIONS: {

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -82,9 +82,10 @@
  * - 1.28 - hsa_amd_agent_info_t: HSA_AMD_AGENT_INFO_HOST_ALLOC_DMABUF_SUPPORTED
  * - 1.29 - hsa_amd_image_create_v2, hsa_amd_interop_map_buffer_with_size
  * - 1.30 - hsa_amd_queue_get_info: engine type and SDMA engine ID
+ * - 1.31 - hsa_amd_agent_info_t: HSA_AMD_AGENT_INFO_EXECUTION_ISA
  */
 #define HSA_AMD_INTERFACE_VERSION_MAJOR 1
-#define HSA_AMD_INTERFACE_VERSION_MINOR 30
+#define HSA_AMD_INTERFACE_VERSION_MINOR 31
 
 #ifdef __cplusplus
 extern "C" {
@@ -986,6 +987,15 @@ typedef enum hsa_amd_agent_info_s {
    * The type of this attribute is bool.
    */
   HSA_AMD_AGENT_INFO_HOST_ALLOC_DMABUF_SUPPORTED = 0xA124,
+  /**
+   * Concrete physical instruction set used by a GPU agent for hardware
+   * execution. The type of this attribute is ::hsa_isa_t. This attribute is
+   * only for hardware-specific runtime policy. Code-object and compilation
+   * target selection must use the standard agent ISA queries. API tools must
+   * preserve this value when presenting another ISA through
+   * ::HSA_AGENT_INFO_ISA.
+   */
+  HSA_AMD_AGENT_INFO_EXECUTION_ISA = 0xA125,
 } hsa_amd_agent_info_t;
 
 /**


### PR DESCRIPTION
## Motivation

An HSA API tool may present a different ISA through `HSA_AGENT_INFO_ISA`, for
example, so clients select code objects for the presented target. Some runtime
components still require the physical execution ISA for hardware-specific
policy.

A separate execution-ISA query allows the presented and physical views to
coexist without adding ISA-presentation state or tool-specific policy to ROCr.

## Technical Details

Add `HSA_AMD_AGENT_INFO_EXECUTION_ISA` to `hsa_amd_agent_info_t`. For GPU
agents, the query returns the concrete physical ISA represented by the agent's
primary supported ISA.

The new attribute is only for hardware-specific runtime policy. Code-object and
compilation target selection must use the standard agent ISA queries. API tools
must preserve the physical value when presenting another ISA through
`HSA_AGENT_INFO_ISA`.

Advance the AMD extension interface to version 1.31. Extend the existing
agent-properties coverage to query the new attribute for every GPU. Because
ROCr itself models only physical agents, the test verifies that the execution
ISA and ordinary agent ISA return the same handle in the standard ROCr test
configuration.

## Test Plan

- Build the `hsa-runtime64` and `rocrtst64` targets.
- Run `rocrtstFunc.AgentPropertiesTests` to query the execution ISA for every
  available GPU and compare it with the agent's primary ISA.

## Test Result

- `hsa-runtime64` and `rocrtst64` built successfully.
- `rocrtstFunc.AgentPropertiesTests` passed on all eight visible gfx942 GPUs.

JIRA ID: ROCM-28199