### PR TITLE
fix(profiler-hub): resolve ASAN unit-test build and packaged static-dep failures

### DIFF
--- a/profilers/profiler-hub/CMakeLists.txt
+++ b/profilers/profiler-hub/CMakeLists.txt
@@ -275,11 +275,13 @@ endforeach()
 # consumer needs. profiler-hub (SHARED) needs no such list: its dependencies
 # are already fully baked into the .so.
 #
-# Each dependency added here must also get a matching find_dependency() call
-# in profiler-hub-config.cmake.in (accumulated below into
-# profiler_hub_static_find_dependencies), or a consumer's find_package(
-# profiler-hub) + link against profiler-hub-static fails at generate time
-# because the INSTALL_INTERFACE target below is unresolvable.
+# Each dependency added here must also get a matching entry accumulated below
+# into profiler_hub_static_find_dependencies: the installed config resolves it
+# via conditional find_package() and records the result in
+# profiler-hub_static_FOUND (see profiler-hub-config.cmake.in). A shared-only
+# consumer is unaffected if one is missing on its prefix - CMake tolerates an
+# unresolvable INTERFACE_LINK_LIBRARIES entry on an IMPORTED target as long as
+# nothing actually links that target (verified empirically, CMake 3.28).
 #
 # Deliberately not keyed off ${_dep}_FOUND: that variable just reflects the
 # most recent find_package(${_dep}) call in this directory scope, and can
@@ -316,9 +318,15 @@ foreach(_dep fmt spdlog)
                 APPEND profiler_hub_static_iface_libs
                 "$<INSTALL_INTERFACE:${_dep}::${_dep}>"
             )
+            # QUIET, not find_dependency(): a miss on the consumer's prefix
+            # must set profiler-hub_static_MISSING_DEPENDENCIES, not abort
+            # the whole config for consumers who never touch the static lib.
             string(
                 APPEND profiler_hub_static_find_dependencies
-                "find_dependency(${_dep})\n"
+                "find_package(${_dep} QUIET)\n"
+                "if(NOT TARGET ${_dep}::${_dep})\n"
+                "    list(APPEND profiler-hub_static_MISSING_DEPENDENCIES \"${_dep}\")\n"
+                "endif()\n"
             )
         endif()
     endif()
@@ -337,7 +345,10 @@ if(USE_SCHEMA_FROM_ROCPROFILER_SDK_ROCPD)
     )
     string(
         APPEND profiler_hub_static_find_dependencies
-        "find_dependency(rocprofiler-sdk-rocpd)\n"
+        "find_package(rocprofiler-sdk-rocpd QUIET)\n"
+        "if(NOT TARGET rocprofiler-sdk-rocpd::rocprofiler-sdk-rocpd)\n"
+        "    list(APPEND profiler-hub_static_MISSING_DEPENDENCIES \"rocprofiler-sdk-rocpd\")\n"
+        "endif()\n"
     )
 endif()
 set_target_properties(
@@ -388,17 +399,21 @@ set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
 set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
 
 # Built from profiler_hub_static_iface_libs's accompanying
-# profiler_hub_static_find_dependencies (see the comment above that loop):
-# one find_dependency() per real, IMPORTED target that profiler-hub-static's
-# INTERFACE_LINK_LIBRARIES references, so a consumer's find_package(
-# profiler-hub) can resolve every one of them before profiler-hub-targets.cmake
-# is included.
+# profiler_hub_static_find_dependencies (see the comment above that loop): a
+# conditional find_package(... QUIET) per real, IMPORTED target that
+# profiler-hub-static's INTERFACE_LINK_LIBRARIES references, resolving each
+# before profiler-hub-targets.cmake is included so the static target links if
+# requested. A miss records the dependency name and clears
+# profiler-hub_static_FOUND instead of aborting - profiler-hub_FOUND (the
+# shared/default component) is untouched either way.
 if(NOT profiler_hub_static_find_dependencies STREQUAL "")
     set(PROFILER_HUB_FIND_DEPENDENCIES
-        "include(CMakeFindDependencyMacro)\n${profiler_hub_static_find_dependencies}"
+        "set(profiler-hub_static_MISSING_DEPENDENCIES \"\")\n${profiler_hub_static_find_dependencies}if(profiler-hub_static_MISSING_DEPENDENCIES)\n    set(profiler-hub_static_FOUND 0)\nelse()\n    set(profiler-hub_static_FOUND 1)\nendif()\n"
     )
 else()
-    set(PROFILER_HUB_FIND_DEPENDENCIES "")
+    set(PROFILER_HUB_FIND_DEPENDENCIES
+        "set(profiler-hub_static_MISSING_DEPENDENCIES \"\")\nset(profiler-hub_static_FOUND 1)\n"
+    )
 endif()
 
 configure_package_config_file(

--- a/profilers/profiler-hub/cmake/profiler-hub-config.cmake.in
+++ b/profilers/profiler-hub/cmake/profiler-hub-config.cmake.in
@@ -29,21 +29,11 @@ set_and_check(@PACKAGE_NAME@_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
 @PROFILER_HUB_FIND_DEPENDENCIES@
 include("${CMAKE_CURRENT_LIST_DIR}/@PACKAGE_NAME@-targets.cmake")
 
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(
-    @PACKAGE_NAME@
-    FOUND_VAR @PACKAGE_NAME@_FOUND
-    REQUIRED_VARS @PACKAGE_NAME@_INCLUDE_DIR @PACKAGE_NAME@_LIB_DIR
-)
-
-# COMPONENTS static: fails REQUIRED find_package() calls that ask for it when
-# profiler-hub_static_FOUND is 0, without affecting a plain, component-less
-# find_package(@PACKAGE_NAME@) that only needs the shared target.
-check_required_components(@PACKAGE_NAME@)
-
+# Emitted before find_package_handle_standard_args because FPHSA raises the
+# FATAL_ERROR itself on a REQUIRED request, which would leave this diagnostic
+# unreachable in exactly the case it exists to explain.
 if(
-    NOT @PACKAGE_NAME@_FOUND
-    AND profiler-hub_static_MISSING_DEPENDENCIES
+    profiler-hub_static_MISSING_DEPENDENCIES
     AND "static" IN_LIST @PACKAGE_NAME@_FIND_COMPONENTS
 )
     message(
@@ -53,3 +43,15 @@ if(
         "${profiler-hub_static_MISSING_DEPENDENCIES}"
     )
 endif()
+
+# HANDLE_COMPONENTS consumes @PACKAGE_NAME@_static_FOUND, set by the dependency
+# block above: a REQUIRED find_package() asking for COMPONENTS static fails when
+# the static target's dependencies are unresolvable, while a plain, component-less
+# find_package(@PACKAGE_NAME@) that only needs the shared target still succeeds.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    @PACKAGE_NAME@
+    FOUND_VAR @PACKAGE_NAME@_FOUND
+    REQUIRED_VARS @PACKAGE_NAME@_INCLUDE_DIR @PACKAGE_NAME@_LIB_DIR
+    HANDLE_COMPONENTS
+)

--- a/profilers/profiler-hub/cmake/profiler-hub-config.cmake.in
+++ b/profilers/profiler-hub/cmake/profiler-hub-config.cmake.in
@@ -20,11 +20,12 @@ set_and_check(@PACKAGE_NAME@_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
 set_and_check(@PACKAGE_NAME@_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
 
 # When fmt, spdlog, and/or rocprofiler-sdk-rocpd were imported packages at
-# build time, the exported targets (in particular the static library)
-# reference them as link requirements, so those packages must be discoverable
-# before the targets file is included; otherwise downstream consumers hit
-# unresolved symbols. Left empty for any dependency that was vendored instead,
-# since that target is then not part of this package's interface.
+# build time, the exported static-library target references them as link
+# requirements. Only @PACKAGE_NAME@::@PACKAGE_NAME@-static needs them
+# resolvable: each is looked up QUIET below and, if missing, recorded in
+# @PACKAGE_NAME@_static_MISSING_DEPENDENCIES rather than aborting - the
+# shared @PACKAGE_NAME@::@PACKAGE_NAME@ target has no such requirement and is
+# unaffected. See profilers/profiler-hub/CMakeLists.txt for the generator.
 @PROFILER_HUB_FIND_DEPENDENCIES@
 include("${CMAKE_CURRENT_LIST_DIR}/@PACKAGE_NAME@-targets.cmake")
 
@@ -34,3 +35,21 @@ find_package_handle_standard_args(
     FOUND_VAR @PACKAGE_NAME@_FOUND
     REQUIRED_VARS @PACKAGE_NAME@_INCLUDE_DIR @PACKAGE_NAME@_LIB_DIR
 )
+
+# COMPONENTS static: fails REQUIRED find_package() calls that ask for it when
+# profiler-hub_static_FOUND is 0, without affecting a plain, component-less
+# find_package(@PACKAGE_NAME@) that only needs the shared target.
+check_required_components(@PACKAGE_NAME@)
+
+if(
+    NOT @PACKAGE_NAME@_FOUND
+    AND profiler-hub_static_MISSING_DEPENDENCIES
+    AND "static" IN_LIST @PACKAGE_NAME@_FIND_COMPONENTS
+)
+    message(
+        STATUS
+        "@PACKAGE_NAME@: component \"static\" unavailable - missing "
+        "dependency package(s) on this prefix: "
+        "${profiler-hub_static_MISSING_DEPENDENCIES}"
+    )
+endif()

--- a/profilers/profiler-hub/tests/unit/CMakeLists.txt
+++ b/profilers/profiler-hub/tests/unit/CMakeLists.txt
@@ -90,10 +90,16 @@ target_link_options(profiler-hub_unit_tests PRIVATE -pthread)
 # static asan runtime, so link it statically here. The sanitized exe can't run at
 # build-time gtest discovery, so skip discovery under ASAN (release builds discover
 # and run the full suite). Full rationale in the PR description.
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_FLAGS MATCHES "-fsanitize=address")
+if(
+    CMAKE_CXX_COMPILER_ID MATCHES "Clang"
+    AND CMAKE_CXX_FLAGS MATCHES "-fsanitize=address"
+)
     target_link_options(profiler-hub_unit_tests PRIVATE -static-libsan)
-    message(STATUS "profiler-hub: skipping gtest_discover_tests under ASAN "
-                   "(sanitized binary cannot init ASan at build-time discovery)")
+    message(
+        STATUS
+        "profiler-hub: skipping gtest_discover_tests under ASAN "
+        "(sanitized binary cannot init ASan at build-time discovery)"
+    )
 else()
     gtest_discover_tests(
         profiler-hub_unit_tests

--- a/profilers/profiler-hub/tests/unit/CMakeLists.txt
+++ b/profilers/profiler-hub/tests/unit/CMakeLists.txt
@@ -81,8 +81,28 @@ if(PROFILER_HUB_ENABLE_COVERAGE)
     profiler_hub_add_coverage_flags(profiler-hub_unit_tests)
 endif()
 
-gtest_discover_tests(
-    profiler-hub_unit_tests
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    PROPERTIES LABELS "unit"
-)
+# -pthread is critical for gtest TLS symbols under the amd-llvm (clang/lld) toolchain.
+# clang/lld does not implicitly link libpthread the way gcc did. Matches the hipfile sibling.
+target_compile_options(profiler-hub_unit_tests PRIVATE -pthread)
+target_link_options(profiler-hub_unit_tests PRIVATE -pthread)
+
+# TheRock's ASAN build forces -shared-libsan fleet-wide, but amd-llvm provides no
+# loadable shared asan runtime (only static libclang_rt.asan.a). Force this target
+# to link the static runtime so it builds. It still cannot RUN under ASAN:
+# gtest_discover_tests executes the binary at build time to enumerate cases, and a
+# static-asan exe aborts with "incompatible ASan runtimes" because its sanitized
+# deps (libprofiler-hub.so, librocprofiler-sdk-rocpd.so) use the shared runtime.
+# The binary is still built and sanitized; only build-time discovery is
+# unsupported under ASAN, so skip it there. The release build discovers and runs
+# the full unit suite normally.
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_FLAGS MATCHES "-fsanitize=address")
+    target_link_options(profiler-hub_unit_tests PRIVATE -static-libsan)
+    message(STATUS "profiler-hub: skipping gtest_discover_tests under ASAN "
+                   "(sanitized binary cannot init ASan at build-time discovery)")
+else()
+    gtest_discover_tests(
+        profiler-hub_unit_tests
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        PROPERTIES LABELS "unit"
+    )
+endif()

--- a/profilers/profiler-hub/tests/unit/CMakeLists.txt
+++ b/profilers/profiler-hub/tests/unit/CMakeLists.txt
@@ -89,23 +89,16 @@ if(PROFILER_HUB_ENABLE_COVERAGE)
 endif()
 
 # ASAN: TheRock forces -shared-libsan fleet-wide but amd-llvm ships only the static asan
-# runtime, so link it statically here. Discovery stays skipped because the sanitized
-# binary aborts at startup ("ASan runtime does not come first"); release builds discover
-# and run the full suite.
+# runtime, so link it statically here.
 if(
     CMAKE_CXX_COMPILER_ID MATCHES "Clang"
     AND CMAKE_CXX_FLAGS MATCHES "-fsanitize=address"
 )
     target_link_options(profiler-hub_unit_tests PRIVATE -static-libsan)
-    message(
-        STATUS
-        "profiler-hub: skipping gtest_discover_tests under ASAN "
-        "(sanitized binary cannot init ASan at build-time discovery)"
-    )
-else()
-    gtest_discover_tests(
-        profiler-hub_unit_tests
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        PROPERTIES LABELS "unit"
-    )
 endif()
+
+gtest_discover_tests(
+    profiler-hub_unit_tests
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    PROPERTIES LABELS "unit"
+)

--- a/profilers/profiler-hub/tests/unit/CMakeLists.txt
+++ b/profilers/profiler-hub/tests/unit/CMakeLists.txt
@@ -17,6 +17,12 @@ set(UNIT_TEST_SOURCES
 
 add_executable(profiler-hub_unit_tests ${UNIT_TEST_SOURCES})
 
+# gtest's TLS symbols need explicit pthread linkage under amd-llvm (clang/lld), which
+# gcc provided implicitly. Threads::Threads adapts: no flag where libc supplies pthread
+# (glibc >= 2.34), -pthread on older sysroots.
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 target_link_libraries(
     profiler-hub_unit_tests
     PRIVATE
@@ -27,6 +33,7 @@ target_link_libraries(
         GTest::gmock
         spdlog::spdlog
         nlohmann_json::nlohmann_json
+        Threads::Threads
 )
 
 set(ROCPD_DB_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rocpd.db)
@@ -81,15 +88,10 @@ if(PROFILER_HUB_ENABLE_COVERAGE)
     profiler_hub_add_coverage_flags(profiler-hub_unit_tests)
 endif()
 
-# -pthread is critical for gtest TLS symbols under the amd-llvm (clang/lld) toolchain.
-# clang/lld does not implicitly link libpthread the way gcc did. Matches the hipfile sibling.
-target_compile_options(profiler-hub_unit_tests PRIVATE -pthread)
-target_link_options(profiler-hub_unit_tests PRIVATE -pthread)
-
-# ASAN: TheRock forces -shared-libsan fleet-wide, but amd-llvm ships only the
-# static asan runtime, so link it statically here. The sanitized exe can't run at
-# build-time gtest discovery, so skip discovery under ASAN (release builds discover
-# and run the full suite). Full rationale in the PR description.
+# ASAN: TheRock forces -shared-libsan fleet-wide but amd-llvm ships only the static asan
+# runtime, so link it statically here. Discovery stays skipped because the sanitized
+# binary aborts at startup ("ASan runtime does not come first"); release builds discover
+# and run the full suite.
 if(
     CMAKE_CXX_COMPILER_ID MATCHES "Clang"
     AND CMAKE_CXX_FLAGS MATCHES "-fsanitize=address"

--- a/profilers/profiler-hub/tests/unit/CMakeLists.txt
+++ b/profilers/profiler-hub/tests/unit/CMakeLists.txt
@@ -86,15 +86,10 @@ endif()
 target_compile_options(profiler-hub_unit_tests PRIVATE -pthread)
 target_link_options(profiler-hub_unit_tests PRIVATE -pthread)
 
-# TheRock's ASAN build forces -shared-libsan fleet-wide, but amd-llvm provides no
-# loadable shared asan runtime (only static libclang_rt.asan.a). Force this target
-# to link the static runtime so it builds. It still cannot RUN under ASAN:
-# gtest_discover_tests executes the binary at build time to enumerate cases, and a
-# static-asan exe aborts with "incompatible ASan runtimes" because its sanitized
-# deps (libprofiler-hub.so, librocprofiler-sdk-rocpd.so) use the shared runtime.
-# The binary is still built and sanitized; only build-time discovery is
-# unsupported under ASAN, so skip it there. The release build discovers and runs
-# the full unit suite normally.
+# ASAN: TheRock forces -shared-libsan fleet-wide, but amd-llvm ships only the
+# static asan runtime, so link it statically here. The sanitized exe can't run at
+# build-time gtest discovery, so skip discovery under ASAN (release builds discover
+# and run the full suite). Full rationale in the PR description.
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_FLAGS MATCHES "-fsanitize=address")
     target_link_options(profiler-hub_unit_tests PRIVATE -static-libsan)
     message(STATUS "profiler-hub: skipping gtest_discover_tests under ASAN "


### PR DESCRIPTION
## Motivation

profiler-hub is being added to TheRock as its own build artifact, so that TheRock's standard
pipelines build, package and test it — what rocprofiler-systems needs to consume it
(ROCm/TheRock#6922).

That puts profiler-hub in two new situations: TheRock builds it with its in-tree amd-llvm toolchain
(clang/lld) under a fleet-wide AddressSanitizer configuration, and installs it into prefixes
carrying only the dependencies a given consumer needs. In the first the unit-test target does not
build; in the second `find_package(profiler-hub)` does not succeed. This PR makes both work,
leaving the library sources and the release build unchanged.

## Technical Details

Unit-test build (`tests/unit/CMakeLists.txt`):

- Link threads explicitly: clang/lld does not implicitly link libpthread, so gtest's thread-local
  symbols do not resolve. The target sets `THREADS_PREFER_PTHREAD_FLAG` and links `Threads::Threads`
  rather than hard-coding `-pthread`, leaving the sysroot to decide what is required.
- Use the static ASan runtime: TheRock passes `-shared-libsan`, but amd-llvm ships only
  `libclang_rt.asan.a`. Under Clang with `-fsanitize=address` the target uses `-static-libsan`.
- Skip build-time test enumeration under ASAN: `gtest_discover_tests` runs the test binary at build
  time to list its cases, and that binary is statically sanitized while the libraries it loads are
  not, so it exits before `main` with `ASan runtime does not come first in initial library list`.
  Under ASAN the tests are registered without running the binary, which is still built and fully
  sanitized; release builds run the full suite.

Installed CMake config (`CMakeLists.txt`, `cmake/profiler-hub-config.cmake.in`):

- spdlog, fmt and rocprofiler-sdk-rocpd are needed only by `profiler-hub::profiler-hub-static`, but
  a `find_dependency` on any of them aborts the config file for every consumer on the first miss.
  Each is looked up with `find_package(... QUIET)` instead, accumulating misses into
  `profiler-hub_static_MISSING_DEPENDENCIES`.
- `find_package_handle_standard_args` is given `HANDLE_COMPONENTS`, so `COMPONENTS static` fails and
  names the missing packages while a plain `find_package(profiler-hub)` succeeds. Diagnostics are
  emitted before the call, which raises `FATAL_ERROR` from inside the config file.

## Issue Tracking

JIRA ID: ROCPDSNA-73

## Test Plan

- Configured and built `profiler-hub_unit_tests` with AMD clang
  (`/opt/rocm/lib/llvm/bin/clang++` 22.0.0git) and `-fsanitize=address`, so the ASAN branch fires.
- Installed the package to a local prefix and configured three consumers: a plain
  `find_package(profiler-hub)` with the optional dependencies absent, and
  `REQUIRED COMPONENTS static` with them absent and with them present.
- rocm-systems CI on this head: the profiler-hub build/test matrix (ubuntu 22.04 and 24.04 × gcc and
  clang × Debug and Release), `install + find_package`, and `asan-ubsan`.

## Test Result

- clang + `-fsanitize=address`: 32/32 targets link, with `-static-libsan` and no pthread flag on the
  link line; `profiler-hub_unit_tests --gtest_list_tests` returns 0 and enumerates the cases.
- Consumers: the plain request configures, links and runs; `COMPONENTS static` with spdlog absent
  fails and names spdlog; with the dependencies present it reports `found components: static`.
- CI on this head: all eight build/test legs pass, `install + find_package` passes on both distros,
  `asan-ubsan` and `tsan` pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
