### PR TITLE
fix(rocr/thunk): Retry interrupted open of /dev/kfd

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/hsakmtmodel.c
+++ b/projects/rocr-runtime/libhsakmt/src/hsakmtmodel.c
@@ -420,7 +420,7 @@ int hsakmt_drm_open_render(int minor)
 	}
 	char path[128];
 	snprintf(path, sizeof(path), "/dev/dri/renderD%d", minor);
-	return open(path, O_RDWR | O_CLOEXEC);
+	return hsakmt_open(path, O_RDWR | O_CLOEXEC);
 }
 
 void hsakmt_drm_close(int fd)

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.c
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.c
@@ -5,6 +5,7 @@
  */
  
 #include <errno.h>
+#include <fcntl.h>
 #include <sys/ioctl.h>
 
 #include "libhsakmt.h"
@@ -24,6 +25,21 @@ int hsakmt_safe_env_to_int(const char* envvar, int default_val) {
   if (*endptr != '\0') return default_val;
   if (val < INT_MIN || val > INT_MAX) return default_val;
   return (int)val;
+}
+
+/* Call open, restarting if it is interrupted by a signal (EINTR).
+ * Used for device nodes such as /dev/kfd and /dev/dri/renderD* whose open()
+ * can be interrupted by signal-based sampling (e.g. rocprofiler-systems).
+ */
+int hsakmt_open(const char *path, int flags)
+{
+	int ret;
+
+	do {
+		ret = open(path, flags);
+	} while (ret == -1 && errno == EINTR);
+
+	return ret;
 }
 
 /* Call ioctl, restarting if it is interrupted */

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
@@ -254,6 +254,7 @@ void hsakmt_destroy_counter_props(HsaKFDContext *ctx);
 uint32_t *hsakmt_convert_queue_ids(HSAuint32 NumQueues, HSA_QUEUEID *Queues);
 
 extern int hsakmt_ioctl(int fd, unsigned long request, void *arg);
+extern int hsakmt_open(const char *path, int flags);
 
 /* Void pointer arithmetic (or remove -Wpointer-arith to allow void pointers arithmetic) */
 #define VOID_PTR_ADD32(ptr,n) (void*)((uint32_t*)(ptr) + n)/*ptr + offset*/

--- a/projects/rocr-runtime/libhsakmt/src/openclose.c
+++ b/projects/rocr-runtime/libhsakmt/src/openclose.c
@@ -209,9 +209,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtOpenKFDCtx(HsaKFDContext **pCtx)
 		model_init_env_vars();
 
 		if (hsakmt_primary_kfd_ctx.fd < 0 && !hsakmt_use_model) {
-			do {
-				fd = open(kfd_device_name, O_RDWR | O_CLOEXEC);
-			} while (fd == -1 && errno == EINTR);
+			fd = hsakmt_open(kfd_device_name, O_RDWR | O_CLOEXEC);
 
 			if (fd == -1) {
 				result = HSAKMT_STATUS_KERNEL_IO_CHANNEL_NOT_OPENED;
@@ -341,10 +339,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtOpenSecondaryKFDCtx(HsaKFDContext **pCtx)
 	CHECK_KFD_OPEN();
 	pthread_mutex_lock(&hsakmt_mutex);
 
-	do {
-		kfd_fd = open(kfd_device_name, O_RDWR | O_CLOEXEC);
-	} while (kfd_fd == -1 && errno == EINTR);
-
+	kfd_fd = hsakmt_open(kfd_device_name, O_RDWR | O_CLOEXEC);
 	if (kfd_fd < 0) {
 		result = HSAKMT_STATUS_KERNEL_IO_CHANNEL_NOT_OPENED;
 	} else {

--- a/projects/rocr-runtime/libhsakmt/src/openclose.c
+++ b/projects/rocr-runtime/libhsakmt/src/openclose.c
@@ -209,7 +209,9 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtOpenKFDCtx(HsaKFDContext **pCtx)
 		model_init_env_vars();
 
 		if (hsakmt_primary_kfd_ctx.fd < 0 && !hsakmt_use_model) {
-			fd = open(kfd_device_name, O_RDWR | O_CLOEXEC);
+			do {
+				fd = open(kfd_device_name, O_RDWR | O_CLOEXEC);
+			} while (fd == -1 && errno == EINTR);
 
 			if (fd == -1) {
 				result = HSAKMT_STATUS_KERNEL_IO_CHANNEL_NOT_OPENED;

--- a/projects/rocr-runtime/libhsakmt/src/openclose.c
+++ b/projects/rocr-runtime/libhsakmt/src/openclose.c
@@ -341,7 +341,10 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtOpenSecondaryKFDCtx(HsaKFDContext **pCtx)
 	CHECK_KFD_OPEN();
 	pthread_mutex_lock(&hsakmt_mutex);
 
-	kfd_fd = open(kfd_device_name, O_RDWR | O_CLOEXEC);
+	do {
+		kfd_fd = open(kfd_device_name, O_RDWR | O_CLOEXEC);
+	} while (kfd_fd == -1 && errno == EINTR);
+
 	if (kfd_fd < 0) {
 		result = HSAKMT_STATUS_KERNEL_IO_CHANNEL_NOT_OPENED;
 	} else {

--- a/projects/rocr-runtime/libhsakmt/src/virtio/virtio_gpu.c
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/virtio_gpu.c
@@ -29,6 +29,7 @@
 #include <fcntl.h>
 
 #include "virtio_gpu.h"
+#include "libhsakmt.h"
 
 #define SHMEM_SZ (80 * 0x1000)
 
@@ -304,7 +305,7 @@ int virtio_gpu_kfd_open(void) {
   if (num_devices <= 0) return -1;
 
   for (i = 0; i < num_devices; i++) {
-    fd = open(devices[i]->nodes[DRM_NODE_RENDER], O_RDWR | O_CLOEXEC);
+    fd = hsakmt_open(devices[i]->nodes[DRM_NODE_RENDER], O_RDWR | O_CLOEXEC);
     if (fd < 0) continue;
 
     struct virgl_renderer_capset_hsakmt caps;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

`rocprofiler-systems`'s `transpose-sampling` CTest would sporadically fail both locally and on CI with the following error:
```
/<some-path>/projects/rocprofiler-systems/examples/transpose/transpose.cpp:242 :: HIP error : no ROCm-capable device is detected
terminate called after throwing an instance of 'std::runtime_error'
  what():  hip_api_call
```

However the test ONLY runs on a device WITH a GPU. For example, consider https://github.com/ROCm/rocm-systems/actions/runs/30052351970/job/89368330419?pr=8137#step:11:1001, we see the test fail here but then other `transpose` tests pass.

The error comes from the first `hip` function being called that attempts to access GPU. Since `hsa` at this point is not initialized, it will initialize it. The backtrace reveals that the `open` of `/dev/kfd` is causing the problem (https://github.com/ROCm/rocm-systems/blob/develop/projects/rocr-runtime/libhsakmt/src/openclose.c#L212C4-L212C51).

To see this, rebuild `rocr-runtime` with symbols and then, with the `transpose` binary and `rocprof-sys-sample` binary (you can obtain this through TheRock if you don't want to build), run the following loop:

```
# This is assumed to be run from rocprofiler-systems build folder
for i in $(seq 1 60); do
  ROCPROFSYS_SAMPLING_REALTIME=ON \
  ROCPROFSYS_SAMPLING_CPUTIME=OFF \
  ROCPROFSYS_SAMPLING_FREQ=2100 \
  ROCPROFSYS_SAMPLING_DELAY=0.001 \
    strace --seccomp-bpf -f -k \
           -e trace=openat -e signal=none -e status=failed \
           -P /dev/kfd -o kfd-bt.txt \
           ./bin/rocprof-sys-sample -- ./transpose 1 2 2 > /dev/null 2>&1
  if grep -q EINTR kfd-bt.txt; then
    echo "reproduced on run $i -- backtrace in $PWD/kfd-bt.txt"
    grep -v "exited with" kfd-bt.txt
    break
  fi
  echo "run $i ok"
done
```

On failure, opening the `kfd-bt.txt` reveals:
```
477670 openat(AT_FDCWD, "/dev/kfd", O_RDWR|O_CLOEXEC) = -1 EINTR (Interrupted system call)
 > /usr/lib/x86_64-linux-gnu/libc.so.6(__open64+0xc5) [0x11b215]
 > /opt/rocm-7.1.1/lib/libhsa-runtime64.so.1.18.70101(hsa_amd_ais_file_read+0x7d5c3) [0x145353]
 > /opt/rocm-7.1.1/lib/libhsa-runtime64.so.1.18.70101() [0x34a1f]
 > /opt/rocm-7.1.1/lib/libhsa-runtime64.so.1.18.70101() [0x6b740]
 > /opt/rocm-7.1.1/lib/libhsa-runtime64.so.1.18.70101(hsa_amd_image_get_info_max_dim+0x2823b) [0xa532b]
 > /opt/rocm-7.1.1/lib/libhsa-runtime64.so.1.18.70101(hsa_amd_image_get_info_max_dim+0x284d4) [0xa55c4]
 > /opt/rocm-7.1.1/lib/libhsa-runtime64.so.1.18.70101() [0x6e25e]
 > /opt/rocm-7.1.1/lib/libamdhip64.so.7.1.70101(hipHccModuleLaunchKernel+0x6b05d) [0x43d08d]
 > /opt/rocm-7.1.1/lib/libamdhip64.so.7.1.70101(hipHccModuleLaunchKernel+0x1bec2) [0x3edef2]
 > /opt/rocm-7.1.1/lib/libamdhip64.so.7.1.70101(hipHccModuleLaunchKernel+0x5a2fe) [0x42c32e]
 > /opt/rocm-7.1.1/lib/libamdhip64.so.7.1.70101(hipGetCmdName+0x6976) [0x614c6]
 > /usr/lib/x86_64-linux-gnu/libc.so.6(pthread_mutexattr_settype+0x123) [0xa1ed3]
 > /opt/rocm-7.1.1/lib/libamdhip64.so.7.1.70101(hipGetCmdName+0x213c2) [0x7bf12]
 > /opt/rocm-7.1.1/lib/librocprofiler-sdk.so.1.3.1(hipError_t rocprofiler::hip::hip_api_impl<1ul, 103ul>::functor<hipError_t, int*>(int*)+0x42a) [0x49d4ba]
 > <some-path>/rocprofiler-systems/rocprof-sys-build/transpose(main+0x215) [0x7965]
```

Yes, I realize this is using `rocm-7.1.1`, but I can still reproduce with `rocm-7.14`:
```
481627 openat(AT_FDCWD, "/dev/kfd", O_RDWR|O_CLOEXEC) = -1 EINTR (Interrupted system call)
 > /usr/lib/x86_64-linux-gnu/libc.so.6(__open64+0xc5) [0x11b215]
 > /opt/rocm-7.14/lib/libhsa-runtime64.so.1.21.0(hsaKmtOpenKFDCtx+0x224) [0x1cb054]
481628 +++ exited with 0 +++
```

**The problem** lies with https://github.com/ROCm/rocm-systems/blob/develop/projects/rocr-runtime/libhsakmt/src/openclose.c#L212C4-L212C51, it does not retry on `EINTR`.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

In `hsaKmtOpenKFDCtx`, have `open(kfd_device_name, O_RDWR | O_CLOEXEC)` repeat if `EINTR` detected.

Copilot and cfreeamd's AI both raised the fact that the similar `open` around line 344 should also be guarded, which I have done in https://github.com/ROCm/rocm-systems/pull/9369/commits/e7201312e862b70be4529a2312df2fb84bb5ccf7

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

Jira ID: AIPROFSYST-691

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Build `rocr` and run a new loop:
```
fails=0; recovered=0
for i in $(seq 1 60); do
  ROCPROFSYS_SAMPLING_REALTIME=ON \
  ROCPROFSYS_SAMPLING_CPUTIME=OFF \
  ROCPROFSYS_SAMPLING_FREQ=2100 \
  ROCPROFSYS_SAMPLING_DELAY=0.001 \
    strace --seccomp-bpf -f \
           -e trace=openat -e signal=none \
           -P /dev/kfd -o kfd-bt.txt \
           ./bin/rocprof-sys-sample -- ./transpose 1 2 2 > run.log 2>&1
  rc=$?
  if grep -q EINTR kfd-bt.txt; then
    recovered=$((recovered+1))
    echo "run $i: open interrupted and retried (exit=$rc)"
    grep -E "/dev/kfd" kfd-bt.txt
    cp kfd-bt.txt kfd-eintr-recovered.txt
  fi
  if [ $rc -ne 0 ]; then
    fails=$((fails+1))
    echo "run $i: FAILED exit=$rc"
    grep -i "no ROCm-capable device" run.log
  fi
done
echo "failures=$fails  interrupted-and-recovered=$recovered  of 60"
```

Which detects runs where `EINTR` was detected and `open` was rerun.

## Test Result

<!-- Briefly summarize test outcomes. -->

All 60 iterations of the loop pass:
```
failures=0  interrupted-and-recovered=12  of 60
```
We note some runs where it was interrupted but recovered:
```
run 55: open interrupted and retried (exit=0)
493942 openat(AT_FDCWD, "/dev/kfd", O_RDWR|O_CLOEXEC) = -1 EINTR (Interrupted system call)
493942 openat(AT_FDCWD, "/dev/kfd", O_RDWR|O_CLOEXEC) = 97
run 59: open interrupted and retried (exit=0)
494069 openat(AT_FDCWD, "/dev/kfd", O_RDWR|O_CLOEXEC) = -1 EINTR (Interrupted system call)
494069 openat(AT_FDCWD, "/dev/kfd", O_RDWR|O_CLOEXEC) = 97
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
