### PR TITLE
fix(rocjitsu): restore checkpoints through C API

### DIFF
--- a/docs/superpowers/specs/2026-08-03-rocjitsu-checkpoint-restore-review-fixes-design.md
+++ b/docs/superpowers/specs/2026-08-03-rocjitsu-checkpoint-restore-review-fixes-design.md
@@ -1,0 +1,69 @@
+# Rocjitsu Checkpoint Restore Review Fixes
+
+## Scope
+
+Address the four actionable review findings on PR 9370 without changing the
+checkpoint's public C API:
+
+1. Reject malformed FlatBuffers before dereferencing them.
+2. Preserve JSON-loader-derived architecture behavior and execution mode.
+3. Restore resident wavefronts to their recorded hardware slots.
+4. Resume restored resident work after the simulation engine is attached.
+
+## Design
+
+### Checkpoint validation
+
+Construct a FlatBuffers verifier over the complete file buffer and call
+`VerifySimulationCheckpointBuffer` before `GetSimulationCheckpoint`. Invalid
+buffers throw from the internal restore function; `rj_vm_restore_checkpoint`
+continues mapping those failures to `ROCJITSU_STATUS_INVALID_FILE`.
+
+### Configuration parity
+
+Move command-processor architecture policy (VGPR encoding granularity, packed
+TIDs, and SDMA packet dialect) behind one shared initialization function. Both
+the declarative JSON factory and the legacy XCD constructor call it, preventing
+checkpoint restore from carrying a stale duplicate of that policy.
+
+Serialize the source execution mode into the embedded `SimulationConfig` and
+apply it to both the reconstructed `SoC::Config` and returned `LoadedConfig`.
+This ensures restored compute units and links use the original FUNCTIONAL or
+CLOCKED mode.
+
+### Wavefront identity
+
+Refactor compute-unit dispatch so the existing first-free-slot API and a new
+explicit-slot API share the same allocation and initialization implementation.
+Checkpoint restore uses the serialized `wf_id` as the requested slot. It
+rejects out-of-range, already-occupied, or otherwise unallocatable slots rather
+than silently changing wave identity.
+
+### Startup lifecycle
+
+After `SimulationEngine::create()` attaches components to their partitions,
+`create_from_loaded` asks each non-idle CU on every reconstructed SoC to
+schedule work. The existing `schedule_work` guards keep idle or already-running
+CUs unchanged. This is safe for ordinary JSON-created VMs and makes restored
+resident waves runnable.
+
+## Tests and CI
+
+Add focused regressions that prove:
+
+- junk and truncated checkpoint files return `ROCJITSU_STATUS_INVALID_FILE`;
+- gfx942 packed-TID behavior, an architecture-specific SDMA dialect, and
+  CLOCKED execution mode survive a round trip;
+- a resident wave above a halted lower slot retains its `wf_id` and PC;
+- a C API-restored resident wave executes an instruction and terminates.
+
+Run formatting/pre-commit plus the full Release test suite. Mirror the current
+rocjitsu workflow with Clang ASan+UBSan, TSan, and GCC ASan+UBSan builds/tests,
+then push and verify the resulting GitHub checks.
+
+## Compatibility
+
+The FlatBuffer schema shape and public C API remain unchanged. Existing valid
+checkpoints continue to load; malformed files now fail cleanly. The execution
+mode field was already part of `SimulationConfig`, so older checkpoints with no
+value retain the existing FUNCTIONAL default.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/checkpoint.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/checkpoint.cpp
@@ -23,6 +23,8 @@ flatbuffers::Offset<fb::SimulationConfig>
 serialize_config(flatbuffers::FlatBufferBuilder &builder, const SoC &soc,
                  const simdojo::SimulationEngine::Config &engine_config) {
   auto arch_str = builder.CreateString(arch_to_string(soc.arch()));
+  auto exec_mode_str = builder.CreateString(
+      soc.exec_mode() == simdojo::ExecMode::CLOCKED ? "clocked" : "functional");
 
   // Extract configuration from the live component tree.
   uint32_t num_xcds = soc.num_xcds();
@@ -50,8 +52,8 @@ serialize_config(flatbuffers::FlatBufferBuilder &builder, const SoC &soc,
   auto fb_gpu = fb::CreateAmdgpuConfig(builder, num_xcds, num_iods, fb_xcd);
   auto fb_vm = fb::CreateVirtualMachineConfig(builder, arch_str, fb_gpu);
 
-  return fb::CreateSimulationConfig(builder, engine_config.max_ticks, engine_config.num_threads, 0,
-                                    fb_vm);
+  return fb::CreateSimulationConfig(builder, engine_config.max_ticks, engine_config.num_threads,
+                                    exec_mode_str, fb_vm);
 }
 
 /// @brief Reconstruct a VirtualMachine::Config from a stored FlatBuffer config.
@@ -66,6 +68,8 @@ VirtualMachine::Config config_from_checkpoint(const fb::SimulationConfig *fb_con
     vm_config.soc.arch = parse_arch(vm->arch()->str());
   if (vm_config.soc.arch == ROCJITSU_CODE_ARCH_INVALID)
     throw std::runtime_error("Checkpoint has missing or invalid architecture");
+  vm_config.soc.exec_mode =
+      parse_exec_mode(fb_config->exec_mode() ? fb_config->exec_mode()->str() : "");
 
   if (auto *gpu = vm->gpu()) {
     vm_config.soc.num_xcds = gpu->num_xcds();
@@ -183,9 +187,10 @@ LoadedConfig restore_checkpoint(const std::string &path) {
   if (!f.read(reinterpret_cast<char *>(buf.data()), static_cast<std::streamsize>(size)))
     throw std::runtime_error("Failed to read checkpoint file: " + path);
 
-  auto *checkpoint = fb::GetSimulationCheckpoint(buf.data());
-  if (!checkpoint)
+  flatbuffers::Verifier verifier(buf.data(), buf.size());
+  if (!fb::VerifySimulationCheckpointBuffer(verifier))
     throw std::runtime_error("Invalid checkpoint format: " + path);
+  auto *checkpoint = fb::GetSimulationCheckpoint(buf.data());
 
   // Rebuild SoC and engine config from the stored configuration.
   if (!checkpoint->config())
@@ -234,9 +239,10 @@ LoadedConfig restore_checkpoint(const std::string &path) {
               wf_state->sgprs() ? wf_state->sgprs()->size() : cu->config().sgprs_per_wf;
           uint32_t num_vgprs = cu->config().vgprs_per_wf;
 
-          auto *wf = cu->dispatch_wf(wf_state->wg_id(), wf_state->pc(), num_sgprs, num_vgprs);
+          auto *wf = cu->dispatch_wf_at(wf_state->wf_id(), wf_state->wg_id(), wf_state->pc(),
+                                        num_sgprs, num_vgprs);
           if (!wf)
-            throw std::runtime_error("Failed to dispatch wavefront during checkpoint restoration");
+            throw std::runtime_error("Failed to restore wavefront into its recorded slot");
 
           wf->set_exec_raw(wf_state->exec());
           wf->set_vcc(wf_state->vcc());
@@ -269,6 +275,7 @@ LoadedConfig restore_checkpoint(const std::string &path) {
   // Return the same root shape as the JSON configuration loader.
   LoadedConfig result;
   result.engine_config = engine_config;
+  result.exec_mode = vm_config.soc.exec_mode;
   result.build_result.root = std::move(soc);
   result.build_result.memory = mem_ptr;
   return result;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/checkpoint.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/checkpoint.cpp
@@ -196,10 +196,10 @@ LoadedConfig restore_checkpoint(const std::string &path) {
   engine_config.max_ticks = fb_config->max_ticks();
   engine_config.num_threads = fb_config->num_threads();
 
-  // Build a VirtualMachine from the old-format config, then extract SoC as root.
-  auto vm = std::make_unique<VirtualMachine>(vm_config);
-  auto *soc_ptr = vm->soc();
-  auto *mem_ptr = vm->memory();
+  // Rebuild the SoC root expected by LoadedConfig and create_from_loaded().
+  auto soc = std::make_unique<SoC>("gpu_soc", vm_config.soc);
+  auto *soc_ptr = soc.get();
+  auto *mem_ptr = soc->memory();
 
   // Restore GPU memory pages.
   if (auto *mem_state = checkpoint->memory()) {
@@ -266,10 +266,10 @@ LoadedConfig restore_checkpoint(const std::string &path) {
     }
   }
 
-  // Return as LoadedConfig with the VirtualMachine as root (legacy checkpoint path).
+  // Return the same root shape as the JSON configuration loader.
   LoadedConfig result;
   result.engine_config = engine_config;
-  result.build_result.root = std::move(vm);
+  result.build_result.root = std::move(soc);
   result.build_result.memory = mem_ptr;
   return result;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
@@ -46,13 +46,8 @@ engine_config_from_fb(const rocjitsu::fb::SimulationConfig *fb_config) {
   return cfg;
 }
 
-simdojo::ExecMode parse_exec_mode(const rocjitsu::fb::SimulationConfig *fb_config) {
-  if (fb_config->exec_mode()) {
-    std::string mode_str = fb_config->exec_mode()->str();
-    if (mode_str == "clocked")
-      return simdojo::ExecMode::CLOCKED;
-  }
-  return simdojo::ExecMode::FUNCTIONAL;
+simdojo::ExecMode exec_mode_from_fb(const rocjitsu::fb::SimulationConfig *fb_config) {
+  return parse_exec_mode(fb_config->exec_mode() ? fb_config->exec_mode()->str() : "");
 }
 
 uint32_t config_u32(const std::unordered_map<std::string, std::string> &cfg, const std::string &key,
@@ -377,10 +372,11 @@ std::unordered_map<std::string, FactoryFn> &factories() {
       c->set_weight(0);
       return c;
     };
-    f["soc"] = [](const std::string &n, const CfgMap &, simdojo::ExecMode, rj_code_arch_t arch,
+    f["soc"] = [](const std::string &n, const CfgMap &, simdojo::ExecMode mode, rj_code_arch_t arch,
                   amdgpu::GpuMemory *mem) -> std::unique_ptr<simdojo::Component> {
       auto soc = std::make_unique<SoC>(n, mem);
       soc->set_arch(arch);
+      soc->set_exec_mode(mode);
       return soc;
     };
     f["xcd"] = [](const std::string &n, const CfgMap &, simdojo::ExecMode, rj_code_arch_t,
@@ -423,35 +419,7 @@ std::unordered_map<std::string, FactoryFn> &factories() {
                                 rj_code_arch_t arch,
                                 amdgpu::GpuMemory *) -> std::unique_ptr<simdojo::Component> {
       auto cp = std::make_unique<amdgpu::CommandProcessor>(n);
-      // Matches llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
-      // AMDGPUBaseInfo::getVGPREncodingGranule():
-      // gfx1250 has Feature1024AddressableVGPRs, so Wave32 descriptors encode
-      // VGPR counts in 16-register blocks; other RDNA Wave32 targets use 8.
-      // LLVM's AMDGPULowerVGPREncoding.cpp handles the separate gfx1250
-      // s_set_vgpr_msb high-bank indexing needed to access VGPRs above v255.
-      uint32_t gran = 4;
-      if (arch == ROCJITSU_CODE_ARCH_GFX1250)
-        gran = 16;
-      else if (arch == ROCJITSU_CODE_ARCH_CDNA3 || arch == ROCJITSU_CODE_ARCH_CDNA4 ||
-               arch == ROCJITSU_CODE_ARCH_RDNA1 || arch == ROCJITSU_CODE_ARCH_RDNA2 ||
-               arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5 ||
-               arch == ROCJITSU_CODE_ARCH_RDNA4)
-        gran = 8;
-      cp->set_vgpr_granularity(gran);
-      // Matches LLVM's FeaturePackedTID: gfx90a and later CDNA targets, plus
-      // GFX11 and later RDNA targets, receive work-item IDs packed in v0.
-      bool packed = (arch == ROCJITSU_CODE_ARCH_CDNA2 || arch == ROCJITSU_CODE_ARCH_CDNA3 ||
-                     arch == ROCJITSU_CODE_ARCH_CDNA4 || arch == ROCJITSU_CODE_ARCH_RDNA3 ||
-                     arch == ROCJITSU_CODE_ARCH_RDNA3_5 || arch == ROCJITSU_CODE_ARCH_RDNA4 ||
-                     arch == ROCJITSU_CODE_ARCH_GFX1250);
-      cp->set_packed_tid(packed);
-      amdgpu::SdmaPacketDialect sdma_dialect = amdgpu::SdmaPacketDialect::Legacy;
-      if (arch == ROCJITSU_CODE_ARCH_GFX1250)
-        sdma_dialect = amdgpu::SdmaPacketDialect::Gfx1250;
-      else if (arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5 ||
-               arch == ROCJITSU_CODE_ARCH_RDNA4)
-        sdma_dialect = amdgpu::SdmaPacketDialect::Gfx11Plus;
-      cp->set_sdma_packet_dialect(sdma_dialect);
+      cp->configure_for_arch(arch);
       return cp;
     };
 
@@ -680,7 +648,7 @@ TopologyBuildResult build_topology(const fb::TopologyDef *topology_def, simdojo:
 LoadedConfig build_from_fb(const rocjitsu::fb::SimulationConfig *fb_config) {
   LoadedConfig result;
   result.engine_config = engine_config_from_fb(fb_config);
-  result.exec_mode = parse_exec_mode(fb_config);
+  result.exec_mode = exec_mode_from_fb(fb_config);
 
   rj_code_arch_t arch = ROCJITSU_CODE_ARCH_INVALID;
   if (fb_config->vm() && fb_config->vm()->arch())
@@ -721,6 +689,10 @@ LoadedConfig build_from_fb(const rocjitsu::fb::SimulationConfig *fb_config) {
 }
 
 } // namespace
+
+simdojo::ExecMode parse_exec_mode(const std::string &mode_str) {
+  return mode_str == "clocked" ? simdojo::ExecMode::CLOCKED : simdojo::ExecMode::FUNCTIONAL;
+}
 
 rj_code_arch_t parse_arch(const std::string &arch_str) {
   // \NPI new ISA family: add its "arch" string here and in arch_to_string().

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.h
@@ -86,6 +86,9 @@ rj_code_arch_t parse_arch(const std::string &arch_str);
 /// @brief Convert an rj_code_arch_t enum to its string name.
 const char *arch_to_string(rj_code_arch_t arch);
 
+/// @brief Parse an execution mode name, defaulting to FUNCTIONAL.
+simdojo::ExecMode parse_exec_mode(const std::string &mode_str);
+
 /// @brief Load simulation config from a JSON file.
 /// @param json_path Path to the JSON config file.
 /// @param schema_text FlatBuffers schema text (the .fbs content).

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -37,6 +37,37 @@ RJ_DIAGNOSTIC_POP
 namespace rocjitsu {
 namespace amdgpu {
 
+void CommandProcessor::configure_for_arch(rj_code_arch_t arch) {
+  // Matches llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+  // AMDGPUBaseInfo::getVGPREncodingGranule(): gfx1250 has
+  // Feature1024AddressableVGPRs, so Wave32 descriptors encode VGPR counts in
+  // 16-register blocks; other RDNA Wave32 targets use 8. LLVM's
+  // AMDGPULowerVGPREncoding.cpp handles the separate gfx1250 s_set_vgpr_msb
+  // high-bank indexing needed to access VGPRs above v255.
+  vgpr_granularity_ = 4;
+  if (arch == ROCJITSU_CODE_ARCH_GFX1250)
+    vgpr_granularity_ = 16;
+  else if (arch == ROCJITSU_CODE_ARCH_CDNA3 || arch == ROCJITSU_CODE_ARCH_CDNA4 ||
+           arch == ROCJITSU_CODE_ARCH_RDNA1 || arch == ROCJITSU_CODE_ARCH_RDNA2 ||
+           arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5 ||
+           arch == ROCJITSU_CODE_ARCH_RDNA4)
+    vgpr_granularity_ = 8;
+
+  // Matches LLVM's FeaturePackedTID: gfx90a and later CDNA targets, plus
+  // GFX11 and later RDNA targets, receive work-item IDs packed in v0.
+  packed_tid_ = arch == ROCJITSU_CODE_ARCH_CDNA2 || arch == ROCJITSU_CODE_ARCH_CDNA3 ||
+                arch == ROCJITSU_CODE_ARCH_CDNA4 || arch == ROCJITSU_CODE_ARCH_RDNA3 ||
+                arch == ROCJITSU_CODE_ARCH_RDNA3_5 || arch == ROCJITSU_CODE_ARCH_RDNA4 ||
+                arch == ROCJITSU_CODE_ARCH_GFX1250;
+
+  sdma_packet_dialect_ = SdmaPacketDialect::Legacy;
+  if (arch == ROCJITSU_CODE_ARCH_GFX1250)
+    sdma_packet_dialect_ = SdmaPacketDialect::Gfx1250;
+  else if (arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5 ||
+           arch == ROCJITSU_CODE_ARCH_RDNA4)
+    sdma_packet_dialect_ = SdmaPacketDialect::Gfx11Plus;
+}
+
 namespace {
 
 // The supported cluster size must fit the M0 multicast mask captured at issue time.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -117,6 +117,8 @@ public:
   bool packed_tid() const { return packed_tid_; }
   void set_sdma_packet_dialect(SdmaPacketDialect dialect) { sdma_packet_dialect_ = dialect; }
   SdmaPacketDialect sdma_packet_dialect() const { return sdma_packet_dialect_; }
+  /// @brief Configure launch and packet behavior derived from the GPU architecture.
+  void configure_for_arch(rj_code_arch_t arch);
   /// @brief Update doorbell_base for all queues belonging to a process.
   /// @details Called when the doorbell page is mmap'd after queue creation.
   void set_doorbell_base(uint32_t process_id, void *base);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -112,6 +112,15 @@ Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t nu
   if (slot >= config_.num_wf_slots)
     return nullptr;
 
+  return dispatch_wf_at(static_cast<uint32_t>(slot), wg_id, pc, num_sgprs, num_vgprs);
+}
+
+Wavefront *ComputeUnitCore::dispatch_wf_at(uint32_t wf_id, uint32_t wg_id, uint64_t pc,
+                                           uint32_t num_sgprs, uint32_t num_vgprs) {
+  assert(wfs_.size() == config_.num_wf_slots && "wavefront slots not properly initialized");
+  if (wf_id >= config_.num_wf_slots || !wfs_[wf_id]->is_halted())
+    return nullptr;
+
   int32_t sgpr_base = sgpr_file_.allocate(num_sgprs);
   if (sgpr_base < 0)
     return nullptr;
@@ -133,7 +142,7 @@ Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t nu
   // On real hardware, the driver issues s_dcache_inv at kernel launch.
   l1_scalar_.invalidate_all();
 
-  auto *wf = wfs_[slot].get();
+  auto *wf = wfs_[wf_id].get();
   wf->wg_id_ = wg_id;
   wf->pc = pc;
   wf->sgpr_alloc_ = {static_cast<uint32_t>(sgpr_base), num_sgprs};
@@ -152,7 +161,7 @@ Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t nu
   std::fill(sgpr_to_wave_.begin() + sgpr_base, sgpr_to_wave_.begin() + sgpr_base + num_sgprs, wf);
   fill_vgpr_to_wave(static_cast<uint32_t>(vgpr_base), vgpr_allocation_block_size(), wf);
 
-  util::Logger::cp("DISPATCH_WF cu=", this->full_path(), " wf=", wf->wf_id(), " slot=", slot,
+  util::Logger::cp("DISPATCH_WF cu=", this->full_path(), " wf=", wf->wf_id(), " slot=", wf_id,
                    " pc=0x", std::hex, pc, std::dec, " wg=", wg_id, " pid=", wf->process_id());
 
   schedule_work();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -107,6 +107,12 @@ public:
   ///          or insufficient register space.
   Wavefront *dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t num_sgprs, uint32_t num_vgprs);
 
+  /// @brief Activate a specific idle wavefront slot.
+  /// @details Used by checkpoint restoration when hardware slot identity is
+  /// execution state. Returns nullptr when the requested slot is invalid or busy.
+  Wavefront *dispatch_wf_at(uint32_t wf_id, uint32_t wg_id, uint64_t pc, uint32_t num_sgprs,
+                            uint32_t num_vgprs);
+
   /// @brief Advance every RUNNING wavefront by one instruction, then report
   /// residency.
   /// @details Issues one instruction to each wavefront currently in the RUNNING
@@ -149,7 +155,8 @@ public:
   void request_functional_yield() { functional_yield_requested_ = true; }
 
   /// @brief Schedule the tick event if the CU is not already executing.
-  /// Called from dispatch_wf() and the cpl_ port handler.
+  /// Called from dispatch_wf(), the cpl_ port handler, and single-threaded VM
+  /// initialization after engine creation but before simulation workers start.
   virtual void schedule_work() = 0;
 
   /// @brief Check whether this CU has no active wavefronts.
@@ -713,12 +720,12 @@ public:
     // Waking the CU then would run an empty tick with no wave to issue — pure waste.
     // Work is scheduled only when there is work to do.
     //
-    // ENGINE-THREAD ONLY: executing_ and tick_event_ are touched without
-    // synchronization, and schedule_event() pushes to the partition's event queue
-    // non-thread-safely. All callers (dispatch_wf(), the cpl_ port handler, and the
-    // CP on the same partition) run on this CU's owning partition engine thread. A
-    // cross-partition schedule_work() would be an executing_ data race plus an
-    // unsynchronized event-queue push.
+    // When simulation is running, executing_ and tick_event_ are engine-thread
+    // only: dispatch_wf(), the cpl_ handler, and the CP all run on this CU's owning
+    // partition. VM creation may also call this after engine attachment but before
+    // any simulation worker starts, when it has exclusive access to the queues. A
+    // cross-partition call during execution would be an executing_ data race plus
+    // an unsynchronized event-queue push.
     if (executing_ || !this->engine() || !this->has_active_wfs())
       return;
     executing_ = true;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/xcd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/xcd.cpp
@@ -28,6 +28,7 @@ Xcd::Xcd(std::string name, const Config &config, rj_code_arch_t arch, GpuMemory 
   // Create command processor for this XCD.
   auto cp = std::make_unique<CommandProcessor>(xcd_name + ".cp");
   cp_ = cp.get();
+  cp_->configure_for_arch(arch);
 
   // Create shader engines, each with its own CU array sharing the XCD's L2.
   for (uint32_t i = 0; i < config.num_shader_engines; ++i) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
@@ -101,6 +101,17 @@ rj_status_t create_from_loaded(config::LoadedConfig &loaded, rj_vm_mode_t mode, 
   }
   s->engine->create();
 
+  // dispatch_wf() cannot enqueue work while a restored component tree is
+  // detached from an engine. Once create() has assigned partitions and event
+  // queues, resume any resident waves reconstructed from a checkpoint. The
+  // schedule_work() guards make this a no-op for ordinary idle configurations.
+  for (uint32_t i = 0; i < s->vm->num_socs(); ++i) {
+    for (auto *cu : s->vm->soc(i)->all_cus()) {
+      if (!cu->is_idle())
+        cu->schedule_work();
+    }
+  }
+
   if (serve) {
     s->engine->register_as_primary();
     if (loaded.num_gpus > 1 && !loaded.devices.empty())

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.h
@@ -72,6 +72,8 @@ public:
   void wire_backing(simdojo::Topology &topo);
   void set_arch(rj_code_arch_t a) { arch_ = a; }
   rj_code_arch_t arch() const { return arch_; }
+  void set_exec_mode(simdojo::ExecMode mode) { exec_mode_ = mode; }
+  simdojo::ExecMode exec_mode() const { return exec_mode_; }
 
   /// @brief Wire topology links between XCDs, IODs, and memory.
   void initialize() override;

--- a/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
+++ b/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
@@ -298,8 +298,15 @@ void SimulationEngine::worker_loop(PartitionID partition_id) {
       // Phase 4: Barrier (completion function computes new global_lbts).
       barrier_->arrive_and_wait();
       if (done_.load(std::memory_order_acquire)) {
-        // After arrive_and_wait, if done_ was set by the completion function,
-        // ALL threads see it simultaneously and ALL exit.
+        // When the completion function sets done_, every thread observes it
+        // here and they all exit together. request_exit() can also set it from
+        // an unrelated thread at any instant, in which case threads released
+        // from this same phase may disagree: one still reads false, loops, and
+        // commits to the next arrive_and_wait(). Drop rather than plain return,
+        // so a thread leaving now cannot strand that one at a phase whose
+        // expected count still counts us.
+        ctx.local_next.store(TICK_MAX, std::memory_order_relaxed);
+        barrier_->arrive_and_drop();
         return;
       }
     }

--- a/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
+++ b/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
@@ -298,15 +298,8 @@ void SimulationEngine::worker_loop(PartitionID partition_id) {
       // Phase 4: Barrier (completion function computes new global_lbts).
       barrier_->arrive_and_wait();
       if (done_.load(std::memory_order_acquire)) {
-        // When the completion function sets done_, every thread observes it
-        // here and they all exit together. request_exit() can also set it from
-        // an unrelated thread at any instant, in which case threads released
-        // from this same phase may disagree: one still reads false, loops, and
-        // commits to the next arrive_and_wait(). Drop rather than plain return,
-        // so a thread leaving now cannot strand that one at a phase whose
-        // expected count still counts us.
-        ctx.local_next.store(TICK_MAX, std::memory_order_relaxed);
-        barrier_->arrive_and_drop();
+        // After arrive_and_wait, if done_ was set by the completion function,
+        // ALL threads see it simultaneously and ALL exit.
         return;
       }
     }

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -13,6 +13,7 @@
 #include "rocjitsu/isa/arch/amdgpu/shared/accvgpr_layout.h"
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
 #include "rocjitsu/vm/rj_vm.h"
+#include "rocjitsu/vm/rj_vm_impl.h"
 #include "rocjitsu/vm/soc.h"
 
 #include "simdojo/sim/simulation.h"
@@ -739,7 +740,7 @@ TEST(ConfigLoaderTest, DispatchDistributesAcrossCUs) {
 }
 
 TEST(CheckpointTest, SaveAndRestoreMemory) {
-  const char *json = R"({"max_ticks":10000,"num_threads":1,
+  const char *json = R"({"max_ticks":10000,"num_threads":1,"exec_mode":"clocked",
     "vm":{"arch":"cdna3"},
     "topology":{
       "root":{
@@ -769,6 +770,10 @@ TEST(CheckpointTest, SaveAndRestoreMemory) {
 
   auto loaded = config::load_config_from_string(json, rocjitsu::kEmbeddedSchema);
   auto *soc = loaded.soc();
+  auto *source_cp = soc->xcd(0)->command_processor();
+  ASSERT_NE(source_cp, nullptr);
+  EXPECT_TRUE(source_cp->packed_tid());
+  EXPECT_EQ(soc->exec_mode(), simdojo::ExecMode::CLOCKED);
 
   soc->memory()->write32(0x1000, 0xDEADBEEF);
   soc->memory()->write64(0x2000, 0x0123456789ABCDEFULL);
@@ -780,6 +785,9 @@ TEST(CheckpointTest, SaveAndRestoreMemory) {
   auto restored = config::restore_checkpoint(checkpoint.path());
   EXPECT_EQ(restored.memory()->read32(0x1000), 0xDEADBEEFu);
   EXPECT_EQ(restored.memory()->read64(0x2000), 0x0123456789ABCDEFULL);
+  EXPECT_EQ(restored.exec_mode, simdojo::ExecMode::CLOCKED);
+  EXPECT_EQ(restored.soc()->exec_mode(), simdojo::ExecMode::CLOCKED);
+  EXPECT_TRUE(restored.soc()->xcd(0)->command_processor()->packed_tid());
 }
 
 TEST(CheckpointTest, SaveAndRestoreAccVgprs) {
@@ -795,7 +803,7 @@ TEST(CheckpointTest, SaveAndRestoreAccVgprs) {
             {"name":"cp","type":"command_processor"},
             {"name":"se0","type":"shader_engine","children":[
               {"name":"cu[0:1]","type":"compute_unit","config":[
-                {"key":"num_wf_slots","value":"1"},
+                {"key":"num_wf_slots","value":"4"},
                 {"key":"sgprs_per_wf","value":"104"},
                 {"key":"vgprs_per_wf","value":"256"},
                 {"key":"lds_size_kb","value":"64"}
@@ -815,8 +823,12 @@ TEST(CheckpointTest, SaveAndRestoreAccVgprs) {
   auto *cu = loaded.soc()->xcd(0)->shader_engine(0)->compute_unit(0);
   ASSERT_NE(cu, nullptr);
 
-  auto *wf = cu->dispatch_wf(0, 0, cu->config().sgprs_per_wf, cu->config().vgprs_per_wf);
+  auto *lower_wf = cu->dispatch_wf(0, 0x1000, cu->config().sgprs_per_wf, cu->config().vgprs_per_wf);
+  ASSERT_NE(lower_wf, nullptr);
+  auto *wf = cu->dispatch_wf(1, 0x2000, cu->config().sgprs_per_wf, cu->config().vgprs_per_wf);
   ASSERT_NE(wf, nullptr);
+  ASSERT_EQ(wf->wf_id(), 1u);
+  lower_wf->halt();
   const uint32_t acc0 = wf->vgpr_alloc().base + amdgpu::ACC_VGPR_OFFSET;
   const uint32_t acc_last = acc0 + cdna3::Isa::MAX_ACC_VGPRS_PER_WF - 1;
   cu->write_vgpr(acc0, 0, 0xA55A0001u);
@@ -831,8 +843,13 @@ TEST(CheckpointTest, SaveAndRestoreAccVgprs) {
   ASSERT_NE(restored_soc, nullptr);
   auto *restored_cu = restored_soc->xcd(0)->shader_engine(0)->compute_unit(0);
   ASSERT_NE(restored_cu, nullptr);
-  auto *restored_wf = restored_cu->wf(0);
+  EXPECT_TRUE(restored_cu->wf(0)->is_halted());
+  auto *restored_wf = restored_cu->wf(1);
   ASSERT_NE(restored_wf, nullptr);
+  EXPECT_FALSE(restored_wf->is_halted());
+  EXPECT_EQ(restored_wf->wf_id(), 1u);
+  EXPECT_EQ(restored_wf->wg_id(), 1u);
+  EXPECT_EQ(restored_wf->pc, 0x2000u);
   EXPECT_EQ(restored_cu->read_vgpr(restored_wf->vgpr_alloc().base + amdgpu::ACC_VGPR_OFFSET, 0),
             0xA55A0001u);
   EXPECT_EQ(restored_cu->read_vgpr(restored_wf->vgpr_alloc().base + amdgpu::ACC_VGPR_OFFSET +
@@ -886,6 +903,9 @@ TEST(CheckpointTest, SaveAndRestoreWave32ExecScratch) {
   auto restored = config::restore_checkpoint(checkpoint.path());
   auto *restored_soc = restored.soc();
   ASSERT_NE(restored_soc, nullptr);
+  auto *restored_cp = restored_soc->xcd(0)->command_processor();
+  ASSERT_NE(restored_cp, nullptr);
+  EXPECT_EQ(restored_cp->sdma_packet_dialect(), amdgpu::SdmaPacketDialect::Gfx11Plus);
   auto *restored_wf = restored_soc->xcd(0)->shader_engine(0)->compute_unit(0)->wf(0);
   ASSERT_NE(restored_wf, nullptr);
   EXPECT_EQ(restored_wf->exec(), 0xFULL);
@@ -991,6 +1011,15 @@ TEST(CApiTest, CheckpointRoundTrip) {
   ASSERT_NE(raw_source, nullptr);
   std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> source(raw_source, &rj_vm_destroy);
 
+  constexpr uint64_t kCodeAddress = 0x1000;
+  constexpr uint32_t kSEndpgm = 0xBF810000u;
+  source->soc->memory()->write32(kCodeAddress, kSEndpgm);
+  auto *source_cu = source->soc->xcd(0)->shader_engine(0)->compute_unit(0);
+  ASSERT_NE(source_cu, nullptr);
+  auto *source_wf = source_cu->dispatch_wf(0, kCodeAddress, source_cu->config().sgprs_per_wf,
+                                           source_cu->config().vgprs_per_wf);
+  ASSERT_NE(source_wf, nullptr);
+
   test::ScopedTempFile checkpoint("rocjitsu-c-api-checkpoint-");
   ASSERT_EQ(rj_vm_save_checkpoint(source.get(), checkpoint.path().c_str(), 42),
             ROCJITSU_STATUS_SUCCESS);
@@ -1001,7 +1030,42 @@ TEST(CApiTest, CheckpointRoundTrip) {
   ASSERT_NE(raw_restored, nullptr);
   std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> restored(raw_restored, &rj_vm_destroy);
 
-  EXPECT_EQ(rj_vm_step(restored.get(), nullptr), ROCJITSU_STATUS_SUCCESS);
+  auto *restored_cu = restored->soc->xcd(0)->shader_engine(0)->compute_unit(0);
+  ASSERT_NE(restored_cu, nullptr);
+  ASSERT_EQ(restored_cu->num_wfs(), 1u);
+
+  int active = 1;
+  EXPECT_EQ(rj_vm_step(restored.get(), &active), ROCJITSU_STATUS_SUCCESS);
+  EXPECT_EQ(restored_cu->num_wfs(), 0u);
+}
+
+TEST(CApiTest, RejectsMalformedCheckpoints) {
+  test::ScopedTempFile junk("rocjitsu-junk-checkpoint-");
+  junk.write(std::string(512, static_cast<char>(0xA5)));
+
+  rj_vm_t *restored = nullptr;
+  EXPECT_EQ(rj_vm_restore_checkpoint(junk.path().c_str(), &restored), ROCJITSU_STATUS_INVALID_FILE);
+  EXPECT_EQ(restored, nullptr);
+
+  rj_vm_t *raw_source = nullptr;
+  ASSERT_EQ(rj_vm_create((CONFIG_DIR_PATH + "/gfx942_cdna3.json").c_str(), RJ_VM_MODE_DEFAULT,
+                         &raw_source),
+            ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(raw_source, nullptr);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> source(raw_source, &rj_vm_destroy);
+
+  test::ScopedTempFile valid("rocjitsu-valid-checkpoint-");
+  ASSERT_EQ(rj_vm_save_checkpoint(source.get(), valid.path().c_str(), 42), ROCJITSU_STATUS_SUCCESS);
+  std::ifstream input(valid.path(), std::ios::binary);
+  std::string bytes{std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+  ASSERT_GT(bytes.size(), 8u);
+  bytes.resize(bytes.size() / 2);
+
+  test::ScopedTempFile truncated("rocjitsu-truncated-checkpoint-");
+  truncated.write(bytes);
+  EXPECT_EQ(rj_vm_restore_checkpoint(truncated.path().c_str(), &restored),
+            ROCJITSU_STATUS_INVALID_FILE);
+  EXPECT_EQ(restored, nullptr);
 }
 
 TEST(CApiTest, PluginLifecycleDispatchesProfiledShutdownThroughBaseGroup) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -14,7 +14,6 @@
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
 #include "rocjitsu/vm/rj_vm.h"
 #include "rocjitsu/vm/soc.h"
-#include "rocjitsu/vm/virtual_machine.h"
 
 #include "simdojo/sim/simulation.h"
 
@@ -31,6 +30,7 @@ RJ_DIAGNOSTIC_POP
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -827,9 +827,9 @@ TEST(CheckpointTest, SaveAndRestoreAccVgprs) {
   ASSERT_TRUE(std::filesystem::exists(checkpoint.path()));
 
   auto restored = config::restore_checkpoint(checkpoint.path());
-  auto *restored_vm = dynamic_cast<VirtualMachine *>(restored.build_result.root.get());
-  ASSERT_NE(restored_vm, nullptr);
-  auto *restored_cu = restored_vm->soc()->xcd(0)->shader_engine(0)->compute_unit(0);
+  auto *restored_soc = restored.soc();
+  ASSERT_NE(restored_soc, nullptr);
+  auto *restored_cu = restored_soc->xcd(0)->shader_engine(0)->compute_unit(0);
   ASSERT_NE(restored_cu, nullptr);
   auto *restored_wf = restored_cu->wf(0);
   ASSERT_NE(restored_wf, nullptr);
@@ -884,9 +884,9 @@ TEST(CheckpointTest, SaveAndRestoreWave32ExecScratch) {
   ASSERT_TRUE(std::filesystem::exists(checkpoint.path()));
 
   auto restored = config::restore_checkpoint(checkpoint.path());
-  auto *restored_vm = dynamic_cast<VirtualMachine *>(restored.build_result.root.get());
-  ASSERT_NE(restored_vm, nullptr);
-  auto *restored_wf = restored_vm->soc()->xcd(0)->shader_engine(0)->compute_unit(0)->wf(0);
+  auto *restored_soc = restored.soc();
+  ASSERT_NE(restored_soc, nullptr);
+  auto *restored_wf = restored_soc->xcd(0)->shader_engine(0)->compute_unit(0)->wf(0);
   ASSERT_NE(restored_wf, nullptr);
   EXPECT_EQ(restored_wf->exec(), 0xFULL);
   EXPECT_EQ(restored_wf->exec_raw(), 0xDEADBEEF0000000FULL);
@@ -939,9 +939,9 @@ TEST(CheckpointTest, SaveAndRestoreHwregState) {
   ASSERT_TRUE(std::filesystem::exists(checkpoint.path()));
 
   auto restored = config::restore_checkpoint(checkpoint.path());
-  auto *restored_vm = dynamic_cast<VirtualMachine *>(restored.build_result.root.get());
-  ASSERT_NE(restored_vm, nullptr);
-  auto *restored_wf = restored_vm->soc()->xcd(0)->shader_engine(0)->compute_unit(0)->wf(0);
+  auto *restored_soc = restored.soc();
+  ASSERT_NE(restored_soc, nullptr);
+  auto *restored_wf = restored_soc->xcd(0)->shader_engine(0)->compute_unit(0)->wf(0);
   ASSERT_NE(restored_wf, nullptr);
   EXPECT_EQ(restored_wf->status_raw(), kStatus);
   EXPECT_EQ(restored_wf->mode_raw(), amdgpu::Wavefront::FP16_OVFL_BIT);
@@ -981,6 +981,27 @@ TEST(CApiTest, CreateAndDestroyFromString) {
   EXPECT_EQ(rj_vm_create_from_string(json, RJ_VM_MODE_DEFAULT, &handle), ROCJITSU_STATUS_SUCCESS);
   ASSERT_NE(handle, nullptr);
   rj_vm_destroy(handle);
+}
+
+TEST(CApiTest, CheckpointRoundTrip) {
+  rj_vm_t *raw_source = nullptr;
+  ASSERT_EQ(rj_vm_create((CONFIG_DIR_PATH + "/gfx942_cdna3.json").c_str(), RJ_VM_MODE_DEFAULT,
+                         &raw_source),
+            ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(raw_source, nullptr);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> source(raw_source, &rj_vm_destroy);
+
+  test::ScopedTempFile checkpoint("rocjitsu-c-api-checkpoint-");
+  ASSERT_EQ(rj_vm_save_checkpoint(source.get(), checkpoint.path().c_str(), 42),
+            ROCJITSU_STATUS_SUCCESS);
+
+  rj_vm_t *raw_restored = nullptr;
+  ASSERT_EQ(rj_vm_restore_checkpoint(checkpoint.path().c_str(), &raw_restored),
+            ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(raw_restored, nullptr);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> restored(raw_restored, &rj_vm_destroy);
+
+  EXPECT_EQ(rj_vm_step(restored.get(), nullptr), ROCJITSU_STATUS_SUCCESS);
 }
 
 TEST(CApiTest, PluginLifecycleDispatchesProfiledShutdownThroughBaseGroup) {


### PR DESCRIPTION
## Motivation

`rj_vm_restore_checkpoint()` could not restore checkpoints because the checkpoint loader returned a `VirtualMachine` root while the public VM creation path expects a `SoC` root.

## Technical Details

- Restore checkpoints into the same `SoC` root shape used by the JSON configuration loader.
- Update checkpoint state tests to access the restored `SoC` directly.
- Add a public C API save/restore/step round-trip regression.

## Issue Tracking

Review follow-up from #8705.

## Test Plan

- Build `rocjitsu_tests` in Release mode.
- Run `CheckpointTest.*` and `CApiTest.CheckpointRoundTrip`.
- Run pre-commit hooks for the affected files.

## Test Result

All 5 focused tests passed. All affected-file pre-commit hooks passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
