### PR TITLE
test(rccl): 2.30.3/4 device api gin validation

### DIFF
--- a/projects/rccl/docs/how-to/device-api-gin.rst
+++ b/projects/rccl/docs/how-to/device-api-gin.rst
@@ -1,0 +1,184 @@
+.. meta::
+   :description: Configure and use the RCCL device API with GPU-initiated networking
+   :keywords: RCCL, ROCm, device API, GIN, GPU-initiated networking
+
+.. _device-api-gin:
+
+Use the RCCL device API and GIN
+********************************
+
+The experimental RCCL device API lets GPU kernels communicate through a
+device communicator (``ncclDevComm``). GPU-initiated networking (GIN) extends
+that API with one-sided puts, signals, counters, and barriers across nodes.
+RCCL 2.30.4 incorporates Device API and GIN enhancements from upstream
+NCCL 2.30.3. This page describes those APIs and the limits of the AMD
+host-proxy backend.
+
+Requirements
+============
+
+GIN requires a supported network backend, symmetric memory, and collective
+communicator and window setup. The validated AMD path is ``GIN_IB_PROXY``:
+
+.. code-block:: shell
+
+   export NCCL_GIN_TYPE=2
+   export NCCL_CUMEM_ENABLE=1
+   export NCCL_DMABUF_ENABLE=1
+   export NCCL_IB_MERGE_NICS=0
+
+The ROCm runtime and NIC driver must support exporting and registering VMM
+allocations. ``NCCL_DMABUF_ENABLE=1`` is the validated registration path;
+peer-memory registration can also be available on supported systems. Full GIN
+connections require cross-rail reachability, so do not force
+``NCCL_CROSS_NIC=0`` for world-team operations. Leave ``ginQueueDepth`` at its
+default value of zero; the AMD host-proxy backend does not support a custom QP
+depth.
+
+The following snippets abbreviate error handling with ``NCCLCHECK``. Replace it
+with the application's normal ``ncclResult_t`` error handling.
+
+Before using GIN, query communicator properties and confirm that the selected
+backend and Device API are available:
+
+.. code-block:: cpp
+
+   ncclCommProperties properties = NCCL_COMM_PROPERTIES_INITIALIZER;
+   NCCLCHECK(ncclCommQueryProperties(comm, &properties));
+   if (!properties.deviceApiSupport ||
+       properties.ginType != NCCL_GIN_TYPE_PROXY) {
+     // Select a non-GIN path or report that this configuration is unsupported.
+   }
+
+Allocate and register every communication buffer collectively:
+
+.. code-block:: cpp
+
+   void* buffer = nullptr;
+   ncclWindow_t window = nullptr;
+   NCCLCHECK(ncclMemAlloc(&buffer, bytes));
+   NCCLCHECK(ncclCommWindowRegister(
+       comm, buffer, bytes, &window, NCCL_WIN_COLL_SYMMETRIC));
+
+Create a device communicator
+============================
+
+Always initialize requirements with
+``NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER``. The initializer records the header
+version used to compile the application.
+
+.. code-block:: cpp
+
+   ncclDevCommRequirements reqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
+   reqs.ginConnectionType = NCCL_GIN_CONNECTION_FULL;
+   reqs.ginContextCount = 4;       // Hint; inspect devComm.ginContextCount.
+   reqs.ginSignalCount = 1;
+   reqs.ginCounterCount = 1;
+   reqs.barrierCount = 1;          // Generic ncclBarrierSession.
+   reqs.worldGinBarrierCount = 1;
+
+   ncclDevComm devComm{};
+   NCCLCHECK(ncclDevCommCreate(comm, &reqs, &devComm));
+
+GIN contexts and their signal, counter, and queue resources are allocated per
+device communicator. Two device communicators backed by the same host
+communicator therefore don't alias those resources. ``ginContextCount`` is a
+request; use the value returned in ``devComm.ginContextCount`` when assigning
+work to contexts.
+
+``ginTrafficClass`` overrides the host communicator traffic class for this
+device communicator. ``NCCL_IB_SL`` independently overrides the InfiniBand
+service level, and ``NCCL_IB_TC`` independently overrides the RoCE traffic
+class. Set ``reqs.ginTrafficClass`` only when the fabric administrator provides
+an appropriate value.
+
+Device code creates an ``ncclGin`` object for one returned context:
+
+.. code-block:: cpp
+
+   ncclGin gin{devComm, contextIndex, NCCL_GIN_RESOURCE_SHARING_GPU};
+
+For example, a CTA can issue a put and wait for local queue completion:
+
+.. code-block:: cpp
+
+   __global__ void putKernel(
+       ncclDevComm devComm, ncclWindow_t source, ncclWindow_t destination,
+       size_t bytes, int peer) {
+     ncclGin gin{devComm, /*contextIndex=*/0};
+     if (threadIdx.x == 0) {
+       gin.put(ncclTeamWorld(devComm), peer,
+               destination, /*destinationOffset=*/0,
+               source, /*sourceOffset=*/0, bytes,
+               ncclGin_SignalInc{/*signal=*/0});
+     }
+     gin.flush(ncclCoopCta());
+   }
+
+``flush`` makes the local source buffer reusable. It does not by itself prove
+remote visibility; the peer must wait for the associated signal before using
+the destination bytes.
+
+``NCCL_GIN_RESOURCE_SHARING_GPU`` permits sharing across the GPU;
+``NCCL_GIN_RESOURCE_SHARING_CTA`` limits sharing to a CTA. These modes select
+resource-sharing behavior on direct device backends. The AMD GIN host-proxy
+backend uses the same proxy queue behavior for both modes.
+
+Use world-team barriers and timeouts
+====================================
+
+Reserve ``worldGinBarrierCount`` slots to construct a world-team GIN barrier
+without manually allocating a barrier handle:
+
+.. code-block:: cpp
+
+   ncclGinBarrierSession<ncclCoopCta> barrier{
+       ncclCoopCta(), gin, ncclTeamTagWorld{}, barrierIndex};
+
+   ncclResult_t result = barrier.sync(
+       ncclCoopCta(), cuda::memory_order_acq_rel,
+       ncclGinFenceLevel::Relaxed, timeoutCycles);
+
+The timeout overload returns ``ncclTimeout`` if all team members don't arrive
+within ``timeoutCycles``. Barrier resources for ``ncclGinBarrierSession``,
+``ncclLsaBarrierSession``, and ``ncclBarrierSession`` are separate. Reserve
+``barrierCount`` for generic ``ncclBarrierSession`` objects; use
+``lsaBarrierCount``, ``railGinBarrierCount``, or ``worldGinBarrierCount`` for
+the corresponding specialized session. ``barrierIndex`` must be smaller than
+the selected count. Concurrent CTAs must use distinct indices, typically
+``blockIdx.x``.
+
+Destroy resources
+=================
+
+Destroy the device communicator before deregistering its application windows,
+then free the backing allocations. These calls are collective where their
+corresponding create or registration operation is collective.
+
+.. code-block:: cpp
+
+   NCCLCHECK(ncclDevCommDestroy(comm, &devComm));
+   NCCLCHECK(ncclCommWindowDeregister(comm, window));
+   NCCLCHECK(ncclMemFree(buffer));
+
+Version and backend notes
+=========================
+
+``ncclDevComm`` is versioned. The upstream NCCL 2.30.3 and 2.30.4 release notes
+require applications using GIN APIs to be rebuilt with the matching release.
+RCCL accepts compatible layouts within the 2.30 family, but applications using
+pre-2.30 GIN device code must be rebuilt with compatible RCCL headers. The
+runtime rejects pre-2.30 requirements that request indexed GIN resources.
+
+The 128-byte, versioned GIN proxy descriptor and per-context proxy progress are
+internal implementation details and require no application configuration.
+The ``max_rd_atomic`` and ``max_dest_rd_atomic`` changes and the
+``doca-gpunetio`` update in the NCCL 2.30 release apply to NVIDIA's GDAKI
+backend, not the AMD GIN host-proxy backend.
+
+The source includes experimental proxy ``get`` and nonblocking-flush paths, but
+they are not yet validated for production use on the AMD host-proxy backend.
+GIN access to elastic and multi-segment windows is also unavailable on that
+backend until a complete multi-segment VMM range can be exported for DMA-BUF
+registration. Use the validated put/signal path with single-segment symmetric
+windows.

--- a/projects/rccl/docs/index.rst
+++ b/projects/rccl/docs/index.rst
@@ -26,6 +26,7 @@ The RCCL public repository is located within the rocm-systems repo at `<https://
 
   .. grid-item-card:: How to
 
+    * :doc:`Use the device API and GIN <./how-to/device-api-gin>`
     * :doc:`Using the RCCL Tuner plugin <./how-to/using-rccl-tuner-plugin-api>`
     * :doc:`Using the NCCL Net plugin <./how-to/using-nccl>`
     * :doc:`Fault tolerance in RCCL <./how-to/fault-tolerance>`

--- a/projects/rccl/docs/sphinx/_toc.yml.in
+++ b/projects/rccl/docs/sphinx/_toc.yml.in
@@ -16,6 +16,8 @@ subtrees:
 
 - caption: How to
   entries:
+  - file: how-to/device-api-gin
+    title: Use the device API and GIN
   - file: how-to/using-rccl-tuner-plugin-api
     title: Using the RCCL Tuner plugin
   - file: how-to/using-nccl

--- a/projects/rccl/test/CommMPITests.cpp
+++ b/projects/rccl/test/CommMPITests.cpp
@@ -11,10 +11,14 @@
 #include "TestChecks.hpp"
 #include "ResourceGuards.hpp"
 
+#include "nccl_device.h"
 #include "comm.h"
 
+#include <array>
 #include <cstdlib>
+#include <regex>
 #include <string>
+#include <vector>
 
 using namespace MPITestConstants;
 using namespace RCCLTestGuards;
@@ -229,6 +233,317 @@ TEST_F(TrafficClassMPITest, ConfiguredTrafficClass)
     }
 
     ASSERT_MPI_TRUE(found_line);
+}
+
+// Every layer of the traffic-class precedence chain gets a distinct value, so a
+// regression reports which layer won instead of aliasing with the value it was
+// supposed to override.
+constexpr int kHostCommTrafficClass   = 3;   // ncclConfig_t::trafficClass
+constexpr int kDeviceCommTrafficClass = 7;   // ncclDevCommRequirements::ginTrafficClass
+constexpr int kEnvServiceLevel        = 5;   // NCCL_IB_SL
+constexpr int kEnvTrafficClass        = 96;  // NCCL_IB_TC
+
+// ibv_link_layer::IBV_LINK_LAYER_ETHERNET. On native InfiniBand the generic
+// traffic-class value programs SL while the GRH traffic-class field stays zero;
+// on RoCE both fields are observable.
+constexpr int kIbvLinkLayerEthernet      = 2;
+constexpr int kInfiniBandGrhTrafficClass = 0;
+
+// getEnvParam() fallback: no valid service level or traffic class is negative.
+constexpr int kEnvParamUnset = -1;
+
+// One rank on each of exactly two nodes. The QP oracle reads the leading GIN
+// queue pairs of a single cross-node connection, so extra ranks would add
+// connections whose attributes it does not expect.
+constexpr int kTrafficClassRanks = 2;
+constexpr int kTrafficClassNodes = 2;
+
+struct GinQpTrafficClass
+{
+    int link_layer;
+    int service_level;
+    int traffic_class;
+};
+
+struct GinTrafficClassCapture
+{
+    ncclResult_t create_result{ncclSuccess};
+    ncclResult_t destroy_result{ncclSuccess};
+    bool          proxy_handles{true};
+    int           connection_count{0};
+    bool          saw_create_marker{false};
+    std::vector<GinQpTrafficClass> qps;
+};
+
+class GinTrafficClassMPITest : public TrafficClassMPITest
+{
+protected:
+    static bool envParamIsUnset(const char* name)
+    {
+        const char* value = std::getenv(name);
+        return value == nullptr || value[0] == '\0';
+    }
+
+    static bool proxyPrerequisitesMet()
+    {
+        const char* gin_type = std::getenv("NCCL_GIN_TYPE");
+        const char* cumem    = std::getenv("NCCL_CUMEM_ENABLE");
+        return gin_type != nullptr && std::string(gin_type) == "2"
+            && cumem != nullptr && std::string(cumem) == "1";
+    }
+
+    static std::array<int, 2> collectiveBoolSummary(bool value)
+    {
+        int minimum = value ? 1 : 0;
+        int maximum = minimum;
+        MPI_Allreduce(MPI_IN_PLACE, &minimum, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+        MPI_Allreduce(MPI_IN_PLACE, &maximum, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+        return {minimum, maximum};
+    }
+
+    GinTrafficClassCapture captureGinQpTrafficClass(
+        int requested_traffic_class,
+        const MPIHelpers::TestLogAssertionContext& log_ctx)
+    {
+        GinTrafficClassCapture capture;
+        const std::string before = log_ctx.readNcclDebugLog();
+
+        ncclDevCommRequirements reqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
+        reqs.ginConnectionType       = NCCL_GIN_CONNECTION_FULL;
+        reqs.ginContextCount         = 1;
+        reqs.ginSignalCount          = 1;
+        reqs.ginTrafficClass         = requested_traffic_class;
+
+        ncclDevComm dev_comm{};
+        capture.create_result = ncclDevCommCreate(getActiveCommunicator(), &reqs, &dev_comm);
+        if(capture.create_result != ncclSuccess) return capture;
+
+        capture.connection_count = dev_comm.ginConnectionCount;
+        if(capture.connection_count <= 0) capture.proxy_handles = false;
+        for(int connection = 0; connection < dev_comm.ginConnectionCount; ++connection)
+        {
+            capture.proxy_handles =
+                capture.proxy_handles
+                && dev_comm.ginNetDeviceTypes[connection] == NCCL_NET_DEVICE_GIN_PROXY;
+        }
+
+        // The log is sampled immediately before and after ncclDevCommCreate, so
+        // the appended text covers only this device communicator. The existing
+        // devCommCreate marker narrows it further to the last GIN setup.
+        const std::string after = log_ctx.readNcclDebugLog();
+        const std::string appended =
+            after.size() >= before.size() ? after.substr(before.size()) : after;
+        const std::string marker = "devCommCreate: creating";
+        const size_t marker_pos = appended.rfind(marker);
+        capture.saw_create_marker = marker_pos != std::string::npos;
+        const std::string qp_log =
+            capture.saw_create_marker ? appended.substr(marker_pos) : appended;
+
+        const std::regex qp_pattern(
+            R"(ncclIbQpRtr:.*ll=([0-9]+).*sl: ([0-9]+) tc: ([0-9]+))");
+        for(std::sregex_iterator it(qp_log.begin(), qp_log.end(), qp_pattern), end;
+            it != end;
+            ++it)
+        {
+            capture.qps.push_back(
+                {std::stoi((*it)[1].str()),
+                 std::stoi((*it)[2].str()),
+                 std::stoi((*it)[3].str())});
+        }
+
+        capture.destroy_result =
+            ncclDevCommDestroy(getActiveCommunicator(), &dev_comm);
+        return capture;
+    }
+
+    static bool qpsMatch(
+        const std::vector<GinQpTrafficClass>& qps,
+        int expected_service_level,
+        int expected_roce_traffic_class)
+    {
+        for(const auto& qp : qps)
+        {
+            if(qp.service_level != expected_service_level)
+            {
+                fprintf(stderr,
+                        "Unexpected GIN QP traffic class: ll=%d sl=%d tc=%d; "
+                        "expected sl=%d\n",
+                        qp.link_layer,
+                        qp.service_level,
+                        qp.traffic_class,
+                        expected_service_level);
+                return false;
+            }
+            const int expected_tc = qp.link_layer == kIbvLinkLayerEthernet
+                                        ? expected_roce_traffic_class
+                                        : kInfiniBandGrhTrafficClass;
+            if(qp.traffic_class != expected_tc)
+            {
+                fprintf(stderr,
+                        "Unexpected GIN QP traffic class: ll=%d sl=%d tc=%d; "
+                        "expected tc=%d\n",
+                        qp.link_layer,
+                        qp.service_level,
+                        qp.traffic_class,
+                        expected_tc);
+                return false;
+            }
+        }
+        return !qps.empty();
+    }
+
+    static bool containsEthernetQp(const std::vector<GinQpTrafficClass>& qps)
+    {
+        for(const auto& qp : qps)
+            if(qp.link_layer == kIbvLinkLayerEthernet) return true;
+        return false;
+    }
+
+    // The GIN contexts are created first inside ncclDevCommCreate, so their queue
+    // pairs lead the captured window. The ordinary transport connections that
+    // follow in the same call always carry the host communicator value, so
+    // compare only the leading run sharing one SL/TC pair.
+    static std::vector<GinQpTrafficClass> leadingGinQps(
+        const std::vector<GinQpTrafficClass>& qps)
+    {
+        std::vector<GinQpTrafficClass> leading;
+        for(const auto& qp : qps)
+        {
+            if(!leading.empty()
+               && (qp.service_level != leading.front().service_level
+                   || qp.traffic_class != leading.front().traffic_class))
+                break;
+            leading.push_back(qp);
+        }
+        return leading;
+    }
+};
+
+// Run this case in a fresh process with NCCL_IB_SL/NCCL_IB_TC unset. It
+// observes the QP RTR attributes submitted to ibv_modify_qp, proving that a
+// device-communicator traffic class overrides the host communicator value and
+// that an unset device value falls back to it.
+TEST_F(GinTrafficClassMPITest, DeviceHostPrecedence)
+{
+    const auto proxy_prerequisites = collectiveBoolSummary(proxyPrerequisitesMet());
+    if(proxy_prerequisites[0] == 0 && proxy_prerequisites[1] == 0)
+        GTEST_SKIP() << "Requires NCCL_GIN_TYPE=2 and NCCL_CUMEM_ENABLE=1";
+    ASSERT_MPI_TRUE(proxy_prerequisites[0] == 1 && proxy_prerequisites[1] == 1);
+
+    const bool local_ib_env_unset =
+        envParamIsUnset("NCCL_IB_SL") && envParamIsUnset("NCCL_IB_TC");
+    const auto ib_env_unset = collectiveBoolSummary(local_ib_env_unset);
+    if(ib_env_unset[0] == 0 && ib_env_unset[1] == 0)
+        GTEST_SKIP() << "Run with NCCL_IB_SL and NCCL_IB_TC unset";
+    ASSERT_MPI_TRUE(ib_env_unset[0] == 1 && ib_env_unset[1] == 1);
+
+    if(!validateTestPrerequisites(/*min_processes=*/kTrafficClassRanks,
+                                  /*max_processes=*/kTrafficClassRanks,
+                                  /*require_power_of_two=*/false,
+                                  /*min_nodes=*/kTrafficClassNodes,
+                                  /*max_nodes=*/kTrafficClassNodes))
+        GTEST_SKIP() << "Requires exactly " << kTrafficClassRanks << " ranks on "
+                     << kTrafficClassNodes << " nodes";
+
+    auto reset_debug =
+        makeScopeGuard([]() { MPIHelpers::resetNcclDebugState(); });
+    MPIHelpers::MpiEnvGuard debug("NCCL_DEBUG", "TRACE");
+    MPIHelpers::MpiEnvGuard debug_subsys("NCCL_DEBUG_SUBSYS", "INIT,NET");
+    MPIHelpers::resetNcclDebugState();
+    MPIHelpers::TestLogAssertionContext log_ctx(
+        MPIHelpers::makeNcclDebugFileAssertionOptions(getTestMpiRank()));
+
+    configured_traffic_class_ = kHostCommTrafficClass;
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    GinTrafficClassCapture device =
+        captureGinQpTrafficClass(kDeviceCommTrafficClass, log_ctx);
+    ASSERT_MPI_EQ(ncclSuccess, device.create_result);
+    ASSERT_MPI_EQ(ncclSuccess, device.destroy_result);
+    ASSERT_MPI_GT(device.connection_count, 0);
+    ASSERT_MPI_TRUE(device.proxy_handles);
+    const bool local_trace_unavailable =
+        device.saw_create_marker && device.qps.empty();
+    const auto trace_unavailable = collectiveBoolSummary(local_trace_unavailable);
+    if(trace_unavailable[0] == 1 && trace_unavailable[1] == 1)
+        GTEST_SKIP() << "RCCL was built without TRACE=ON; QP RTR attributes are unavailable";
+    const bool local_trace_ready = device.saw_create_marker && !device.qps.empty();
+    const auto trace_ready = collectiveBoolSummary(local_trace_ready);
+    ASSERT_MPI_TRUE(trace_ready[0] == 1 && trace_ready[1] == 1);
+    ASSERT_MPI_TRUE(qpsMatch(leadingGinQps(device.qps),
+                             /*expected_service_level=*/kDeviceCommTrafficClass,
+                             /*expected_roce_traffic_class=*/kDeviceCommTrafficClass));
+
+    // The IB context is mutable and reused, so observing the host value here
+    // also proves the previous device value did not persist.
+    GinTrafficClassCapture host =
+        captureGinQpTrafficClass(NCCL_CONFIG_UNDEF_INT, log_ctx);
+    ASSERT_MPI_EQ(ncclSuccess, host.create_result);
+    ASSERT_MPI_EQ(ncclSuccess, host.destroy_result);
+    ASSERT_MPI_GT(host.connection_count, 0);
+    ASSERT_MPI_TRUE(host.proxy_handles);
+    ASSERT_MPI_TRUE(host.saw_create_marker);
+    ASSERT_MPI_TRUE(qpsMatch(leadingGinQps(host.qps),
+                             /*expected_service_level=*/kHostCommTrafficClass,
+                             /*expected_roce_traffic_class=*/kHostCommTrafficClass));
+}
+
+// Run in a separate process with NCCL_IB_SL=5 and NCCL_IB_TC=96. Distinct
+// values prove the two explicit IB settings independently override both the
+// device-communicator value and the host communicator value.
+TEST_F(GinTrafficClassMPITest, ExplicitIbEnvironmentOverrides)
+{
+    const auto proxy_prerequisites = collectiveBoolSummary(proxyPrerequisitesMet());
+    if(proxy_prerequisites[0] == 0 && proxy_prerequisites[1] == 0)
+        GTEST_SKIP() << "Requires NCCL_GIN_TYPE=2 and NCCL_CUMEM_ENABLE=1";
+    ASSERT_MPI_TRUE(proxy_prerequisites[0] == 1 && proxy_prerequisites[1] == 1);
+
+    const bool local_env_matches =
+        MPIHelpers::getEnvParam<int>("NCCL_IB_SL", kEnvParamUnset) == kEnvServiceLevel
+        && MPIHelpers::getEnvParam<int>("NCCL_IB_TC", kEnvParamUnset) == kEnvTrafficClass;
+    const auto env_matches = collectiveBoolSummary(local_env_matches);
+    if(env_matches[0] == 0 && env_matches[1] == 0)
+        GTEST_SKIP() << "Run in a fresh process with NCCL_IB_SL=" << kEnvServiceLevel
+                     << " and NCCL_IB_TC=" << kEnvTrafficClass;
+    ASSERT_MPI_TRUE(env_matches[0] == 1 && env_matches[1] == 1);
+
+    if(!validateTestPrerequisites(/*min_processes=*/kTrafficClassRanks,
+                                  /*max_processes=*/kTrafficClassRanks,
+                                  /*require_power_of_two=*/false,
+                                  /*min_nodes=*/kTrafficClassNodes,
+                                  /*max_nodes=*/kTrafficClassNodes))
+        GTEST_SKIP() << "Requires exactly " << kTrafficClassRanks << " ranks on "
+                     << kTrafficClassNodes << " nodes";
+
+    auto reset_debug =
+        makeScopeGuard([]() { MPIHelpers::resetNcclDebugState(); });
+    MPIHelpers::MpiEnvGuard debug("NCCL_DEBUG", "TRACE");
+    MPIHelpers::MpiEnvGuard debug_subsys("NCCL_DEBUG_SUBSYS", "INIT,NET");
+    MPIHelpers::resetNcclDebugState();
+    MPIHelpers::TestLogAssertionContext log_ctx(
+        MPIHelpers::makeNcclDebugFileAssertionOptions(getTestMpiRank()));
+
+    configured_traffic_class_ = kHostCommTrafficClass;
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    GinTrafficClassCapture capture =
+        captureGinQpTrafficClass(kDeviceCommTrafficClass, log_ctx);
+    ASSERT_MPI_EQ(ncclSuccess, capture.create_result);
+    ASSERT_MPI_EQ(ncclSuccess, capture.destroy_result);
+    ASSERT_MPI_GT(capture.connection_count, 0);
+    ASSERT_MPI_TRUE(capture.proxy_handles);
+    const bool local_trace_unavailable =
+        capture.saw_create_marker && capture.qps.empty();
+    const auto trace_unavailable = collectiveBoolSummary(local_trace_unavailable);
+    if(trace_unavailable[0] == 1 && trace_unavailable[1] == 1)
+        GTEST_SKIP() << "RCCL was built without TRACE=ON; QP RTR attributes are unavailable";
+    const bool local_trace_ready = capture.saw_create_marker && !capture.qps.empty();
+    const auto trace_ready = collectiveBoolSummary(local_trace_ready);
+    ASSERT_MPI_TRUE(trace_ready[0] == 1 && trace_ready[1] == 1);
+    const std::vector<GinQpTrafficClass> gin_qps = leadingGinQps(capture.qps);
+    ASSERT_MPI_TRUE(containsEthernetQp(gin_qps));
+    ASSERT_MPI_TRUE(qpsMatch(gin_qps,
+                             /*expected_service_level=*/kEnvServiceLevel,
+                             /*expected_roce_traffic_class=*/kEnvTrafficClass));
 }
 
 /**

--- a/projects/rccl/test/GinNcclTimeoutMPITests.cpp
+++ b/projects/rccl/test/GinNcclTimeoutMPITests.cpp
@@ -65,6 +65,22 @@ namespace {
 constexpr uint64_t kHealthyTimeoutCycles = 5000000000ULL;
 constexpr uint64_t kShortTimeoutCycles   = 200000000ULL;
 
+// Every case needs a real inter-node rail, so at least one rank on each of two
+// nodes.
+constexpr int kMinProcessesForGinTimeout = 2;
+constexpr int kMinNodesForGinTimeout     = 2;
+
+// The absent-peer cases withhold the last rail rank, so the rail must hold
+// exactly one other rank for the barrier to have someone to wait on. The
+// healthy cases only need a rail that spans more than one rank.
+constexpr int kAbsentPeerRailRanks    = 2;
+constexpr int kMinNonTrivialRailRanks = 2;
+
+// Named at the call sites so setUpGinDevComm()'s rail requirement does not read
+// as a bare boolean.
+constexpr bool kRequireTwoRankRail = true;
+constexpr bool kAnyUniformRail     = false;
+
 // --- Collective helpers ---
 
 bool allocFill(float** ptr, int n, float val) {
@@ -160,6 +176,9 @@ __global__ void ginBarrierTimeoutKernel(struct ncclDevComm devComm,
         ncclCoopCta(), gin, ncclTeamTagRail{}, /*index=*/0u};
     ncclResult_t r = bar.sync(ncclCoopCta(), cuda::memory_order_relaxed,
                               ncclGinFenceLevel::Relaxed, timeoutCycles);
+    // A timeout can return while signal GFDs are still queued. Drain them
+    // before host-side teardown or a follow-up devComm is created.
+    gin.flush(ncclCoopCta());
     if (threadIdx.x == 0 && blockIdx.x == 0) *outResult = static_cast<int>(r);
 }
 
@@ -174,6 +193,7 @@ __global__ void ginRepeatedBarrierKernel(struct ncclDevComm devComm,
                      ncclGinFenceLevel::Relaxed, timeoutCycles) == ncclSuccess)
             ++successes;
     }
+    gin.flush(ncclCoopCta());
     if (threadIdx.x == 0 && blockIdx.x == 0) *outCount = successes;
 }
 
@@ -474,19 +494,41 @@ class GinBarrierTimeoutMPITest : public MPITestBase {
  protected:
     std::string skipReason_;
 
-    bool setUpGinDevComm(int nBarriers, ncclComm_t* commOut,
-                         hipStream_t* streamOut, ncclDevComm* devCommOut) {
+    bool setUpGinDevComm(int nBarriers, bool requireTwoRankRail,
+                         ncclComm_t* commOut, hipStream_t* streamOut,
+                         ncclDevComm* devCommOut) {
         skipReason_.clear();
         if (auto reason = ginBarrierSkipReason(); !reason.empty()) {
             skipReason_ = reason; return false;
         }
-        if (!validateTestPrerequisites(2, kNoProcessLimit, kNoPowerOfTwoRequired, 1, kNoNodeLimit)) {
-            ADD_FAILURE() << "Test requires at least 2 MPI processes"; return false;
+        if (!validateTestPrerequisites(kMinProcessesForGinTimeout, kNoProcessLimit,
+                                       kNoPowerOfTwoRequired,
+                                       kMinNodesForGinTimeout, kNoNodeLimit)) {
+            skipReason_ = "GIN timeout tests require at least 2 physical nodes";
+            return false;
         }
         if (createTestCommunicator() != ncclSuccess) {
             ADD_FAILURE() << "createTestCommunicator failed"; return false;
         }
         ncclComm_t comm = getActiveCommunicator();
+        ncclTeam_t railTeam = ncclTeamRail(comm);
+        int minRailSize = railTeam.nRanks;
+        int maxRailSize = railTeam.nRanks;
+        MPI_Allreduce(MPI_IN_PLACE, &minRailSize, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+        MPI_Allreduce(MPI_IN_PLACE, &maxRailSize, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+        if (requireTwoRankRail && (minRailSize != kAbsentPeerRailRanks ||
+                                   maxRailSize != kAbsentPeerRailRanks)) {
+            skipReason_ =
+                "GIN absent-peer timeout tests require two-rank rail teams "
+                "(normally exactly two nodes with uniform ranks per node)";
+            return false;
+        }
+        if (!requireTwoRankRail &&
+            (minRailSize < kMinNonTrivialRailRanks || minRailSize != maxRailSize)) {
+            skipReason_ =
+                "Healthy GIN timeout tests require uniform, non-trivial rail teams";
+            return false;
+        }
         ncclResult_t devRc = createGinDevComm(comm, nBarriers, devCommOut);
         if (devRc != ncclSuccess) {
             skipReason_ = std::string("GIN devComm unavailable; ncclDevCommCreate returned ")
@@ -503,7 +545,7 @@ class GinBarrierTimeoutMPITest : public MPITestBase {
 TEST_F(GinBarrierTimeoutMPITest, HealthyBarrierReturnsSuccess)
 {
     ncclComm_t comm{}; hipStream_t stream{}; ncclDevComm devComm{};
-    if (!setUpGinDevComm(1, &comm, &stream, &devComm)) GIN_SETUP_OR_BAIL();
+    if (!setUpGinDevComm(1, kAnyUniformRail, &comm, &stream, &devComm)) GIN_SETUP_OR_BAIL();
     SCOPE_EXIT((void)ncclDevCommDestroy(comm, &devComm));
     MPI_Barrier(MPI_COMM_WORLD);
     ASSERT_MPI_EQ(static_cast<int>(ncclSuccess), runGinBarrier(devComm, stream, kHealthyTimeoutCycles));
@@ -512,7 +554,7 @@ TEST_F(GinBarrierTimeoutMPITest, HealthyBarrierReturnsSuccess)
 TEST_F(GinBarrierTimeoutMPITest, AbsentPeerProducesTimeout)
 {
     ncclComm_t comm{}; hipStream_t stream{}; ncclDevComm devComm{};
-    if (!setUpGinDevComm(1, &comm, &stream, &devComm)) GIN_SETUP_OR_BAIL();
+    if (!setUpGinDevComm(1, kRequireTwoRankRail, &comm, &stream, &devComm)) GIN_SETUP_OR_BAIL();
     SCOPE_EXIT((void)ncclDevCommDestroy(comm, &devComm));
     ncclTeam_t railTeam = ncclTeamRail(comm);
     const bool isAbsent = (railTeam.rank == railTeam.nRanks - 1);
@@ -536,7 +578,7 @@ TEST_F(GinBarrierTimeoutMPITest, AbsentPeerProducesTimeout)
 TEST_F(GinBarrierTimeoutMPITest, ZeroBudgetAbsentPeerTimesOut)
 {
     ncclComm_t comm{}; hipStream_t stream{}; ncclDevComm devComm{};
-    if (!setUpGinDevComm(1, &comm, &stream, &devComm)) GIN_SETUP_OR_BAIL();
+    if (!setUpGinDevComm(1, kRequireTwoRankRail, &comm, &stream, &devComm)) GIN_SETUP_OR_BAIL();
     SCOPE_EXIT((void)ncclDevCommDestroy(comm, &devComm));
     ncclTeam_t railTeam = ncclTeamRail(comm);
     const bool isAbsent = (railTeam.rank == railTeam.nRanks - 1);
@@ -560,7 +602,7 @@ TEST_F(GinBarrierTimeoutMPITest, ZeroBudgetAbsentPeerTimesOut)
 TEST_F(GinBarrierTimeoutMPITest, RepeatedHealthyBarriersSucceed)
 {
     ncclComm_t comm{}; hipStream_t stream{}; ncclDevComm devComm{};
-    if (!setUpGinDevComm(1, &comm, &stream, &devComm)) GIN_SETUP_OR_BAIL();
+    if (!setUpGinDevComm(1, kAnyUniformRail, &comm, &stream, &devComm)) GIN_SETUP_OR_BAIL();
     SCOPE_EXIT((void)ncclDevCommDestroy(comm, &devComm));
     constexpr int kIters = 32;
     int* dCount = nullptr;
@@ -579,7 +621,7 @@ TEST_F(GinBarrierTimeoutMPITest, RepeatedHealthyBarriersSucceed)
 TEST_F(GinBarrierTimeoutMPITest, RecoversAfterTimeout)
 {
     ncclComm_t comm{}; hipStream_t stream{}; ncclDevComm devComm{};
-    if (!setUpGinDevComm(1, &comm, &stream, &devComm)) GIN_SETUP_OR_BAIL();
+    if (!setUpGinDevComm(1, kRequireTwoRankRail, &comm, &stream, &devComm)) GIN_SETUP_OR_BAIL();
     SCOPE_EXIT((void)ncclDevCommDestroy(comm, &devComm));
     ncclTeam_t railTeam = ncclTeamRail(comm);
     const bool isAbsent = (railTeam.rank == railTeam.nRanks - 1);
@@ -605,7 +647,7 @@ TEST_F(GinBarrierTimeoutMPITest, RecoversAfterTimeout)
 TEST_F(GinBarrierTimeoutMPITest, BackToBackTimeouts)
 {
     ncclComm_t comm{}; hipStream_t stream{}; ncclDevComm devComm{};
-    if (!setUpGinDevComm(1, &comm, &stream, &devComm)) GIN_SETUP_OR_BAIL();
+    if (!setUpGinDevComm(1, kRequireTwoRankRail, &comm, &stream, &devComm)) GIN_SETUP_OR_BAIL();
     SCOPE_EXIT((void)ncclDevCommDestroy(comm, &devComm));
     ncclTeam_t railTeam = ncclTeamRail(comm);
     const bool isAbsent = (railTeam.rank == railTeam.nRanks - 1);

--- a/projects/rccl/test/device/GinDeviceTests.cpp
+++ b/projects/rccl/test/device/GinDeviceTests.cpp
@@ -163,6 +163,8 @@ TEST_F(GinDeviceTest, BuildGfd_PutOnly) {
 
   // Header qword: flag, size (op now lives in the headerExt qword).
   EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeader].header.flag), 1ULL);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeader].header.version),
+            static_cast<uint64_t>(NCCL_GIN_PROXY_GFD_VERSION));
   EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeaderExt].headerExt.op),
             static_cast<uint64_t>(ncclGinProxyOpPut));
   EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeader].header.size), kSize);

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -15,6 +15,7 @@
 #include "nccl_device.h"
 
 #include <algorithm>
+#include <array>
 #include <cerrno>
 #include <cstdint>
 #include <cstdlib>
@@ -72,6 +73,18 @@ int nodeLocalRanks() {
   return n;
 }
 
+// Collective topology check: every rank receives the same verdict, so an
+// uneven placement cannot make one node skip while another enters NCCL setup.
+bool uniformNodeLocalRanks(int* ranksPerNode) {
+  int local = nodeLocalRanks();
+  int minimum = local;
+  int maximum = local;
+  MPI_Allreduce(MPI_IN_PLACE, &minimum, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+  MPI_Allreduce(MPI_IN_PLACE, &maximum, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+  if (ranksPerNode) *ranksPerNode = minimum;
+  return minimum == maximum;
+}
+
 // Single-node runs need intranet mode -- otherwise the topology pruner
 // removes the NET node and GIN has no path to bind.
 std::string intranetReason() {
@@ -121,6 +134,15 @@ ncclDevCommRequirements defaultGinReqs() {
 // Standard single-CTA GIN kernel launch (thread 0 issues, whole CTA waits/flushes).
 constexpr int kGinKernelBlocks  = 1;
 constexpr int kGinKernelThreads = 32;
+
+// Single-thread GIN kernel launch, for kernels where one thread both issues and
+// polls so there is no CTA-wide wait or flush to widen.
+constexpr int kGinSingleThreadBlocks  = 1;
+constexpr int kGinSingleThreadThreads = 1;
+
+// An LSA team only becomes non-trivial once a node hosts more than one rank; at
+// one rank per node it has size 1 and any LSA assertion is vacuous.
+constexpr int kMinLsaRanksPerNode = 2;
 
 }  // namespace
 
@@ -1038,16 +1060,27 @@ __global__ void barrier2RanksKernel(int iters, struct ncclDevComm devComm) {
   }
 }
 
-// First test that actually USES the railGinBarrier resource (prior tests
-// only provisioned it). Kernel completion after kIters rounds proves both
-// ranks moved through the barrier in lockstep -- if the epoch math broke,
-// iter 1 would deadlock waiting for an epoch the peer never reaches.
+// Direct rail-team barrier coverage. Exactly one rank per node makes the
+// two-rank rail team non-trivial and avoids conflating it with the world test.
 TEST_F(GinMPIDeviceTests, Barrier_TwoRanks) {
+  constexpr int kNodes = 2;
+  constexpr int kRanksPerNode = 1;
+  constexpr int kWorldRanks = kNodes * kRanksPerNode;
+
   if (auto reason = ginProxyTestSkipReason(); !reason.empty())
     GTEST_SKIP() << reason;
+  if (auto reason = crossNodeReason(); !reason.empty())
+    GTEST_SKIP() << reason;
 
-  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
-    GTEST_SKIP() << "Requires exactly 2 ranks";
+  if (!validateTestPrerequisites(/*min_processes=*/kWorldRanks,
+                                 /*max_processes=*/kWorldRanks,
+                                 /*require_power_of_two=*/false,
+                                 /*min_nodes=*/kNodes, /*max_nodes=*/kNodes))
+    GTEST_SKIP() << "Requires exactly " << kWorldRanks << " ranks on " << kNodes
+                 << " nodes";
+  int ranksPerNode = 0;
+  if (!uniformNodeLocalRanks(&ranksPerNode) || ranksPerNode != kRanksPerNode)
+    GTEST_SKIP() << "Requires exactly " << kRanksPerNode << " rank per node";
 
   ASSERT_EQ(ncclSuccess, createTestCommunicator());
   ncclComm_t  comm   = getActiveCommunicator();
@@ -1056,7 +1089,7 @@ TEST_F(GinMPIDeviceTests, Barrier_TwoRanks) {
   int rank = -1, nRanks = -1;
   ncclCommUserRank(comm, &rank);
   ncclCommCount(comm, &nRanks);
-  ASSERT_EQ(2, nRanks);
+  ASSERT_EQ(kWorldRanks, nRanks);
 
   // Large enough that a stuck-at-zero expected value would deadlock at
   // iter 1 (not silently pass on iter 0); small enough to stay fast. Each
@@ -1174,6 +1207,125 @@ TEST_F(GinMPIDeviceTests, Barrier_FourRanks) {
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
+struct WorldBarrierObservation {
+  int teamNRanks;
+  int teamRank;
+  int teamStride;
+  uint32_t handleSignal0;
+  uint32_t activeSignal;
+  int selectionMatched;
+  int completedIters;
+  int signalMismatches;
+};
+
+// Observe the baked-in team and handle before synchronizing. A wrong world
+// constructor returns cleanly with selectionMatched=0 instead of hanging on an
+// unallocated or differently sized rail pool.
+__global__ void worldBarrierObservationKernel(
+    int iters, WorldBarrierObservation* observation,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  ncclGinBarrierSession<ncclCoopCta> bar{
+      ncclCoopCta(), gin, ncclTeamTagWorld{}, /*barrierIndex=*/0};
+  ncclTeam world = ncclTeamWorld(devComm);
+  bool selectionMatched =
+      bar.team.nRanks == world.nRanks &&
+      bar.team.rank == world.rank &&
+      bar.team.stride == world.stride &&
+      bar.handle.signal0 == devComm.worldGinBarrier.signal0 &&
+      bar.signal == devComm.worldGinBarrier.signal0;
+
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    observation->teamNRanks = bar.team.nRanks;
+    observation->teamRank = bar.team.rank;
+    observation->teamStride = bar.team.stride;
+    observation->handleSignal0 = bar.handle.signal0;
+    observation->activeSignal = bar.signal;
+    observation->selectionMatched = selectionMatched ? 1 : 0;
+  }
+  if (!selectionMatched) return;
+
+  for (int i = 0; i < iters; ++i) {
+    bar.sync(ncclCoopCta(), cuda::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
+  }
+
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    int mismatches = 0;
+    for (int peer = 0; peer < world.nRanks; ++peer) {
+      uint64_t expected = peer == world.rank ? 0 : static_cast<uint64_t>(iters);
+      if (gin.readSignal(bar.signal + peer) != expected) ++mismatches;
+    }
+    observation->completedIters = iters;
+    observation->signalMismatches = mismatches;
+  }
+}
+
+// Two ranks per node make the world team (4 ranks, stride 1) observably
+// different from each non-trivial rail team (2 ranks, stride 2).
+TEST_F(GinMPIDeviceTests, Barrier_WorldTeamUsesWorldPool) {
+  constexpr int kNodes = 2;
+  constexpr int kRanksPerNode = 2;
+  constexpr int kWorldRanks = kNodes * kRanksPerNode;
+  constexpr int kRailRanks = kNodes;
+
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+  if (auto reason = crossNodeReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+  if (!validateTestPrerequisites(/*min_processes=*/kWorldRanks,
+                                 /*max_processes=*/kWorldRanks,
+                                 /*require_power_of_two=*/false,
+                                 /*min_nodes=*/kNodes, /*max_nodes=*/kNodes))
+    GTEST_SKIP() << "Requires exactly " << kWorldRanks << " ranks on " << kNodes
+                 << " nodes";
+  int ranksPerNode = 0;
+  if (!uniformNodeLocalRanks(&ranksPerNode) || ranksPerNode != kRanksPerNode)
+    GTEST_SKIP() << "Requires exactly " << kRanksPerNode << " ranks per node";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t comm = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+  ncclTeam_t world = ncclTeamWorld(comm);
+  ncclTeam_t rail = ncclTeamRail(comm);
+  ASSERT_EQ(kWorldRanks, world.nRanks);
+  ASSERT_EQ(kRailRanks, rail.nRanks);
+  ASSERT_NE(world.stride, rail.stride);
+
+  ncclDevCommRequirements reqs = defaultGinReqs();
+  reqs.worldGinBarrierCount = 1;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  WorldBarrierObservation* dObservation = nullptr;
+  ASSERT_MPI_EQ(hipSuccess, hipMalloc(&dObservation, sizeof(WorldBarrierObservation)));
+  auto observationCleanup = makeScopeGuard([&]() {
+    if (dObservation) (void)hipFree(dObservation);
+  });
+  ASSERT_MPI_EQ(hipSuccess, hipMemset(dObservation, 0, sizeof(WorldBarrierObservation)));
+
+  constexpr int kIters = 16;
+  MPI_Barrier(MPI_COMM_WORLD);
+  worldBarrierObservationKernel<<<kGinKernelBlocks, kGinKernelThreads, 0, stream>>>(
+      kIters, dObservation, devComm);
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  WorldBarrierObservation observation{};
+  ASSERT_MPI_EQ(hipSuccess,
+                hipMemcpy(&observation, dObservation, sizeof(observation), hipMemcpyDeviceToHost));
+  ASSERT_MPI_EQ(world.nRanks, observation.teamNRanks);
+  ASSERT_MPI_EQ(world.rank, observation.teamRank);
+  ASSERT_MPI_EQ(world.stride, observation.teamStride);
+  ASSERT_MPI_EQ(devComm.worldGinBarrier.signal0, observation.handleSignal0);
+  ASSERT_MPI_EQ(devComm.worldGinBarrier.signal0, observation.activeSignal);
+  ASSERT_MPI_EQ(1, observation.selectionMatched);
+  ASSERT_MPI_EQ(kIters, observation.completedIters);
+  ASSERT_MPI_EQ(0, observation.signalMismatches);
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
 // Direct tests for ncclBarrierSession (barrier.h), separate from the alltoall
 // kernels that use it incidentally: BarrierSession_LsaOnly (LSA-only subset,
 // ncclTeamTagLsa, no GIN) and BarrierSession_Hybrid (world-team: inner LSA +
@@ -1222,9 +1374,10 @@ TEST_F(GinMPIDeviceTests, BarrierSession_LsaOnly) {
   if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
     GTEST_SKIP() << "Requires 2-8 ranks";
 
-  // Needs >=2 co-located ranks; otherwise the LSA team is size 1 (vacuous).
-  if (nodeLocalRanks() < 2)
-    GTEST_SKIP() << "Requires >=2 ranks co-located on a node for a non-trivial LSA team";
+  int ranksPerNode = 0;
+  if (!uniformNodeLocalRanks(&ranksPerNode) || ranksPerNode < kMinLsaRanksPerNode)
+    GTEST_SKIP() << "Requires a uniform placement with >=" << kMinLsaRanksPerNode
+                 << " ranks per node";
 
   ASSERT_EQ(ncclSuccess, createTestCommunicator());
   ncclComm_t  comm   = getActiveCommunicator();
@@ -1303,9 +1456,23 @@ __global__ void barrierSessionHybridKernel(int iters, struct ncclDevComm devComm
 TEST_F(GinMPIDeviceTests, BarrierSession_Hybrid) {
   if (auto reason = ginProxyTestSkipReason(); !reason.empty())
     GTEST_SKIP() << reason;
+  if (auto reason = crossNodeReason(); !reason.empty())
+    GTEST_SKIP() << reason;
 
-  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
-    GTEST_SKIP() << "Requires 2-8 ranks";
+  // The hybrid session needs both a non-trivial LSA team and a cross-node rail,
+  // so at least two nodes each hosting a non-trivial LSA team. The upper bound
+  // is the harness limit shared with the other barrier tests.
+  constexpr int kMinNodes = 2;
+  constexpr int kMinRanks = kMinNodes * kMinLsaRanksPerNode;
+  constexpr int kMaxRanks = 8;
+
+  if (!validateTestPrerequisites(/*min_processes=*/kMinRanks,
+                                 /*max_processes=*/kMaxRanks))
+    GTEST_SKIP() << "Requires " << kMinRanks << "-" << kMaxRanks << " ranks";
+  int ranksPerNode = 0;
+  if (!uniformNodeLocalRanks(&ranksPerNode) || ranksPerNode < kMinLsaRanksPerNode)
+    GTEST_SKIP() << "Requires a uniform placement with at least "
+                 << kMinLsaRanksPerNode << " ranks per node";
 
   ASSERT_EQ(ncclSuccess, createTestCommunicator());
   ncclComm_t  comm   = getActiveCommunicator();
@@ -1318,17 +1485,20 @@ TEST_F(GinMPIDeviceTests, BarrierSession_Hybrid) {
 
   constexpr int kIters = 16;
 
-  // The world-team ncclBarrierSession sizes its hybrid LSA+rail-GIN barriers from
-  // reqs.barrierCount (not lsa/railGinBarrierCount); 0 hangs the rail arm.
-  // defaultGinReqs()'s ginConnectionType=FULL activates GIN so the outer
-  // barrier's waitSignal has a valid ctx (see Barrier_TwoRanks).
+  // Only barrierCount provisions the two pools consumed by the generic
+  // world-team session. Keeping every specialized count at zero ensures an
+  // accidental constructor or requirement-routing regression cannot be masked.
   ncclDevCommRequirements reqs = defaultGinReqs();
-  reqs.barrierCount        = 1;
+  reqs.barrierCount = 1;
   ncclDevComm devComm{};
   ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
   auto devCommCleanup = makeScopeGuard([&]() {
     (void)ncclDevCommDestroy(comm, &devComm);
   });
+
+  ASSERT_MPI_EQ(1, devComm.hybridLsaBarrier.nBarriers);
+  ASSERT_MPI_EQ(0, devComm.lsaBarrier.nBarriers);
+  ASSERT_MPI_EQ(ncclTeamRail(comm).nRanks, devComm.ginSignalCount);
 
   MPI_Barrier(MPI_COMM_WORLD);
 
@@ -1339,6 +1509,156 @@ TEST_F(GinMPIDeviceTests, BarrierSession_Hybrid) {
   ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
 
   MPI_Barrier(MPI_COMM_WORLD);
+}
+
+struct BarrierSelectionObservation {
+  uint64_t genericLsaBufHandle;
+  int genericLsaNBarriers;
+  uint32_t genericRailSignal0;
+  uint64_t dedicatedLsaBufHandle;
+  int dedicatedLsaNBarriers;
+  uint32_t directRailSignal0;
+  uint32_t directWorldSignal0;
+  int genericLsaNRanks;
+  int genericRailNRanks;
+  int dedicatedLsaNRanks;
+  int directRailNRanks;
+  int directWorldNRanks;
+};
+
+// Selection-only kernel: constructing every session is enough to observe which
+// pool it selected. Deliberately do not sync; valid specialized allocations
+// must not hide a generic constructor routed to the wrong pool.
+__global__ void barrierSelectionObservationKernel(
+    BarrierSelectionObservation* observation,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  ncclBarrierSession<ncclCoopCta> generic{
+      ncclCoopCta(), ncclTeamTagWorld{}, gin, /*index=*/0};
+  ncclLsaBarrierSession<ncclCoopCta> dedicatedLsa{
+      ncclCoopCta(), devComm, ncclTeamTagLsa{}, /*index=*/0};
+  ncclGinBarrierSession<ncclCoopCta> directRail{
+      ncclCoopCta(), gin, ncclTeamTagRail{}, /*barrierIndex=*/0};
+  ncclGinBarrierSession<ncclCoopCta> directWorld{
+      ncclCoopCta(), gin, ncclTeamTagWorld{}, /*barrierIndex=*/0};
+
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    auto& genericLsa = generic.lsaBarrier();
+    auto& genericRail = generic.ginBarrier();
+    observation->genericLsaBufHandle = genericLsa.handle.bufHandle;
+    observation->genericLsaNBarriers = genericLsa.handle.nBarriers;
+    observation->genericRailSignal0 = genericRail.handle.signal0;
+    observation->dedicatedLsaBufHandle = dedicatedLsa.handle.bufHandle;
+    observation->dedicatedLsaNBarriers = dedicatedLsa.handle.nBarriers;
+    observation->directRailSignal0 = directRail.handle.signal0;
+    observation->directWorldSignal0 = directWorld.handle.signal0;
+    observation->genericLsaNRanks = genericLsa.team.nRanks;
+    observation->genericRailNRanks = genericRail.team.nRanks;
+    observation->dedicatedLsaNRanks = dedicatedLsa.team.nRanks;
+    observation->directRailNRanks = directRail.team.nRanks;
+    observation->directWorldNRanks = directWorld.team.nRanks;
+  }
+}
+
+TEST_F(GinMPIDeviceTests, BarrierPools_AreIsolated) {
+  // Two ranks per node keeps the LSA, rail, and world teams distinct, so each
+  // barrier flavor has its own team to select.
+  constexpr int kNodes = 2;
+  constexpr int kRanksPerNode = 2;
+  constexpr int kWorldRanks = kNodes * kRanksPerNode;
+
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+  if (auto reason = crossNodeReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+  if (!validateTestPrerequisites(/*min_processes=*/kWorldRanks,
+                                 /*max_processes=*/kWorldRanks,
+                                 /*require_power_of_two=*/false,
+                                 /*min_nodes=*/kNodes, /*max_nodes=*/kNodes))
+    GTEST_SKIP() << "Requires exactly " << kWorldRanks << " ranks on " << kNodes
+                 << " nodes";
+  int ranksPerNode = 0;
+  if (!uniformNodeLocalRanks(&ranksPerNode) || ranksPerNode != kRanksPerNode)
+    GTEST_SKIP() << "Requires exactly " << kRanksPerNode << " ranks per node";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t comm = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+  ncclTeam_t lsa = ncclTeamLsa(comm);
+  ncclTeam_t rail = ncclTeamRail(comm);
+  ncclTeam_t world = ncclTeamWorld(comm);
+
+  ncclDevCommRequirements reqs = defaultGinReqs();
+  reqs.ginSignalCount = 1;
+  reqs.barrierCount = 1;
+  reqs.lsaBarrierCount = 1;
+  reqs.railGinBarrierCount = 1;
+  reqs.worldGinBarrierCount = 1;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  using Range = std::array<uint64_t, 2>;
+  std::array<Range, 4> ginRanges{{
+      {0, 1},
+      {devComm.hybridRailGinBarrier.signal0,
+       devComm.hybridRailGinBarrier.signal0 + static_cast<uint64_t>(rail.nRanks)},
+      {devComm.railGinBarrier.signal0,
+       devComm.railGinBarrier.signal0 + static_cast<uint64_t>(rail.nRanks)},
+      {devComm.worldGinBarrier.signal0,
+       devComm.worldGinBarrier.signal0 + static_cast<uint64_t>(world.nRanks)},
+  }};
+  bool ginRangesValid = true;
+  for (size_t i = 0; i < ginRanges.size(); ++i) {
+    ginRangesValid =
+        ginRangesValid && ginRanges[i][0] < ginRanges[i][1] &&
+        ginRanges[i][1] <= static_cast<uint64_t>(devComm.ginSignalCount);
+    for (size_t j = i + 1; j < ginRanges.size(); ++j) {
+      ginRangesValid =
+          ginRangesValid &&
+          (ginRanges[i][1] <= ginRanges[j][0] ||
+           ginRanges[j][1] <= ginRanges[i][0]);
+    }
+  }
+  ASSERT_MPI_TRUE(ginRangesValid);
+
+  uint64_t lsaBytes = static_cast<uint64_t>(3 + lsa.nRanks) * sizeof(uint32_t);
+  Range hybridLsaRange{
+      ncclGetResourceBufferOffset(devComm.hybridLsaBarrier.bufHandle),
+      ncclGetResourceBufferOffset(devComm.hybridLsaBarrier.bufHandle) + lsaBytes};
+  Range dedicatedLsaRange{
+      ncclGetResourceBufferOffset(devComm.lsaBarrier.bufHandle),
+      ncclGetResourceBufferOffset(devComm.lsaBarrier.bufHandle) + lsaBytes};
+  ASSERT_MPI_TRUE(hybridLsaRange[1] <= dedicatedLsaRange[0] ||
+                  dedicatedLsaRange[1] <= hybridLsaRange[0]);
+
+  BarrierSelectionObservation* dObservation = nullptr;
+  ASSERT_MPI_EQ(hipSuccess, hipMalloc(&dObservation, sizeof(BarrierSelectionObservation)));
+  auto observationCleanup = makeScopeGuard([&]() {
+    if (dObservation) (void)hipFree(dObservation);
+  });
+  ASSERT_MPI_EQ(hipSuccess, hipMemset(dObservation, 0, sizeof(BarrierSelectionObservation)));
+  barrierSelectionObservationKernel<<<kGinKernelBlocks, kGinKernelThreads, 0, stream>>>(
+      dObservation, devComm);
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  BarrierSelectionObservation observation{};
+  ASSERT_MPI_EQ(hipSuccess,
+                hipMemcpy(&observation, dObservation, sizeof(observation), hipMemcpyDeviceToHost));
+  ASSERT_MPI_EQ(devComm.hybridLsaBarrier.bufHandle, observation.genericLsaBufHandle);
+  ASSERT_MPI_EQ(devComm.hybridLsaBarrier.nBarriers, observation.genericLsaNBarriers);
+  ASSERT_MPI_EQ(devComm.hybridRailGinBarrier.signal0, observation.genericRailSignal0);
+  ASSERT_MPI_EQ(devComm.lsaBarrier.bufHandle, observation.dedicatedLsaBufHandle);
+  ASSERT_MPI_EQ(devComm.lsaBarrier.nBarriers, observation.dedicatedLsaNBarriers);
+  ASSERT_MPI_EQ(devComm.railGinBarrier.signal0, observation.directRailSignal0);
+  ASSERT_MPI_EQ(devComm.worldGinBarrier.signal0, observation.directWorldSignal0);
+  ASSERT_MPI_EQ(lsa.nRanks, observation.genericLsaNRanks);
+  ASSERT_MPI_EQ(rail.nRanks, observation.genericRailNRanks);
+  ASSERT_MPI_EQ(lsa.nRanks, observation.dedicatedLsaNRanks);
+  ASSERT_MPI_EQ(rail.nRanks, observation.directRailNRanks);
+  ASSERT_MPI_EQ(world.nRanks, observation.directWorldNRanks);
 }
 
 // ---------------------------------------------------------------------------
@@ -2127,6 +2447,346 @@ TEST_F(GinMPIDeviceTests, AlltoallHybrid_Reference) {
       }
     }
   }
+}
+
+// A 2.29.7-versioned request for indexed GIN resources is rejected because
+// those device layouts are not compatible with the 2.30 GIN layout. This is
+// intentionally narrower than claiming every possible legacy pure-put binary
+// is detected by the compatibility filter.
+TEST_F(GinMPIDeviceTests, DevComm_LegacyGinSignalRequestRejected) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t comm = getActiveCommunicator();
+
+  // GIN device code compiled against 2.29.7 is ABI-incompatible with 2.30.
+  ncclDevCommRequirements legacyReqs = defaultGinReqs();
+  legacyReqs.version = NCCL_VERSION(2, 29, 7);
+  legacyReqs.ginSignalCount = 1;
+  ncclDevComm legacyDevComm{};
+  ncclResult_t result = ncclDevCommCreate(comm, &legacyReqs, &legacyDevComm);
+  if (result == ncclSuccess) {
+    (void)ncclDevCommDestroy(comm, &legacyDevComm);
+  }
+  ASSERT_MPI_EQ(ncclInvalidUsage, result);
+}
+
+// A compatible 2.30 request carries its requested ABI version into the returned
+// device communicator; it is not silently stamped with the runtime's version.
+TEST_F(GinMPIDeviceTests, DevComm_ReturnsRequestedVersion) {
+  if (auto reason = cuMemReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t comm = getActiveCommunicator();
+
+  ncclDevCommRequirements reqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
+  reqs.version = NCCL_VERSION(2, 30, 0);
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+  ASSERT_MPI_EQ(reqs.version, devComm.version);
+}
+
+// Backend-independent ownership check retained for both proxy and rocSHMEM-GDA
+// runs. The proxy-only test below adds functional queue/signal/counter coverage.
+TEST_F(GinMPIDeviceTests, DevComm_PerInstanceGinHandlesAreDistinct) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t comm = getActiveCommunicator();
+  ncclDevCommRequirements reqs = defaultGinReqs();
+  reqs.ginContextCount = 1;
+  reqs.ginSignalCount = 1;
+
+  ncclDevComm first{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &first));
+  bool firstLive = true;
+  auto firstCleanup = makeScopeGuard([&]() {
+    if (firstLive) (void)ncclDevCommDestroy(comm, &first);
+  });
+
+  ncclDevComm second{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &second));
+  bool secondLive = true;
+  auto secondCleanup = makeScopeGuard([&]() {
+    if (secondLive) (void)ncclDevCommDestroy(comm, &second);
+  });
+
+  ASSERT_MPI_GT(first.ginConnectionCount, 0);
+  ASSERT_MPI_EQ(first.ginConnectionCount, second.ginConnectionCount);
+  bool locallyDistinct = true;
+  for (int connection = 0; connection < first.ginConnectionCount; ++connection) {
+    locallyDistinct =
+        locallyDistinct &&
+        first.ginHandles[connection] != second.ginHandles[connection];
+  }
+  int allDistinct = locallyDistinct ? 1 : 0;
+  MPI_Allreduce(MPI_IN_PLACE, &allDistinct, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+  if (allDistinct == 0) secondLive = false;
+  ASSERT_MPI_TRUE(allDistinct == 1);
+}
+
+__global__ void perDevCommIsolationProducerKernel(
+    ncclWindow_t srcWin, ncclWindow_t dstWin, size_t offset, size_t bytes,
+    uint64_t expectedEpoch, uint64_t timeoutCycles, int* completed,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    gin.put(ncclTeamWorld(devComm), /*peer=*/1,
+            dstWin, offset, srcWin, offset, bytes,
+            ncclGin_SignalInc{/*signal=*/0},
+            ncclGin_CounterInc{/*counter=*/0});
+    uint64_t start = clock64();
+    while (gin.readCounter(/*counter=*/0) < expectedEpoch &&
+           clock64() - start < timeoutCycles) {
+    }
+    *completed = gin.readCounter(/*counter=*/0) >= expectedEpoch ? 1 : 0;
+  }
+}
+
+__global__ void perDevCommIsolationConsumerKernel(
+    uint64_t expectedEpoch, uint64_t timeoutCycles, int* completed,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    uint64_t start = clock64();
+    while (gin.readSignal(/*signal=*/0) < expectedEpoch &&
+           clock64() - start < timeoutCycles) {
+    }
+    *completed = gin.readSignal(/*signal=*/0) >= expectedEpoch ? 1 : 0;
+  }
+}
+
+__global__ void readPerDevCommStateKernel(
+    uint64_t* state, struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    state[0] = gin.readSignal(/*signal=*/0);
+    state[1] = gin.readCounter(/*counter=*/0);
+  }
+}
+
+hipError_t runPerDevCommIsolationPhase(
+    int rank, ncclWindow_t srcWin, ncclWindow_t dstWin,
+    size_t offset, size_t bytes, uint64_t expectedEpoch,
+    ncclDevComm devComm, hipStream_t stream, int* dCompleted,
+    bool* completed) {
+  constexpr uint64_t kTimeoutCycles = 5000000000ULL;
+  MPI_Barrier(MPI_COMM_WORLD);
+  if (rank == 0) {
+    perDevCommIsolationProducerKernel<<<kGinSingleThreadBlocks,
+                                        kGinSingleThreadThreads, 0, stream>>>(
+        srcWin, dstWin, offset, bytes, expectedEpoch, kTimeoutCycles,
+        dCompleted, devComm);
+  } else {
+    perDevCommIsolationConsumerKernel<<<kGinSingleThreadBlocks,
+                                        kGinSingleThreadThreads, 0, stream>>>(
+        expectedEpoch, kTimeoutCycles, dCompleted, devComm);
+  }
+  hipError_t result = hipStreamSynchronize(stream);
+  int hCompleted = 0;
+  if (result == hipSuccess) {
+    result = hipMemcpy(&hCompleted, dCompleted, sizeof(int), hipMemcpyDeviceToHost);
+  }
+  if (completed) *completed = hCompleted == 1;
+  MPI_Barrier(MPI_COMM_WORLD);
+  return result;
+}
+
+hipError_t readPerDevCommState(
+    ncclDevComm devComm, hipStream_t stream, uint64_t state[2]) {
+  uint64_t* dState = nullptr;
+  hipError_t result = hipMalloc(&dState, 2 * sizeof(uint64_t));
+  if (result != hipSuccess) return result;
+  result = hipMemsetAsync(dState, 0, 2 * sizeof(uint64_t), stream);
+  if (result == hipSuccess) {
+    readPerDevCommStateKernel<<<kGinSingleThreadBlocks, kGinSingleThreadThreads, 0,
+                                stream>>>(dState, devComm);
+    result = hipStreamSynchronize(stream);
+  }
+  if (result == hipSuccess) {
+    result = hipMemcpy(state, dState, 2 * sizeof(uint64_t), hipMemcpyDeviceToHost);
+  }
+  (void)hipFree(dState);
+  return result;
+}
+
+// Exercise two device communicators backed by one host communicator, prove
+// their signal/counter epochs are independent, destroy the first out of LIFO
+// order, and then prove the second context and queue remain usable.
+TEST_F(GinMPIDeviceTests, DevComm_PerInstanceGinResourcesRemainUsable) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+  if (requestedGinType() != 2)
+    GTEST_SKIP() << "Functional resource-isolation oracle requires GIN_IB_PROXY";
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t comm = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+  int rank = -1;
+  ncclCommUserRank(comm, &rank);
+
+  constexpr size_t kSlotBytes = 64;
+  constexpr int kSlots = 3;
+  constexpr size_t kBufferBytes = kSlots * kSlotBytes;
+  void* dSrc = nullptr;
+  void* dDst = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSrc, kBufferBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dSrc) (void)ncclMemFree(dSrc);
+    if (dDst) (void)ncclMemFree(dDst);
+  });
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dDst, kBufferBytes));
+
+  ncclWindow_t srcWin = nullptr, dstWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dSrc, kBufferBytes, &srcWin,
+                                       NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (srcWin) (void)ncclCommWindowDeregister(comm, srcWin);
+    if (dstWin) (void)ncclCommWindowDeregister(comm, dstWin);
+  });
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dDst, kBufferBytes, &dstWin,
+                                       NCCL_WIN_COLL_SYMMETRIC));
+
+  std::vector<uint8_t> hostSrc(kBufferBytes, 0);
+  std::vector<uint8_t> hostDst(kBufferBytes, 0);
+  for (int slot = 0; slot < kSlots; ++slot) {
+    for (size_t i = 0; i < kSlotBytes; ++i) {
+      hostSrc[slot * kSlotBytes + i] =
+          static_cast<uint8_t>(0x20 + slot * 0x20 + (i & 0x1f));
+    }
+  }
+  ASSERT_MPI_EQ(hipSuccess,
+                hipMemcpy(dSrc, hostSrc.data(), kBufferBytes, hipMemcpyHostToDevice));
+  ASSERT_MPI_EQ(hipSuccess,
+                hipMemcpy(dDst, hostDst.data(), kBufferBytes, hipMemcpyHostToDevice));
+
+  ncclDevCommRequirements reqs = defaultGinReqs();
+  reqs.ginContextCount = 1;
+  reqs.ginSignalCount = 1;
+  reqs.ginCounterCount = 1;
+
+  ncclDevComm first{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &first));
+  bool firstLive = true;
+  auto firstCleanup = makeScopeGuard([&]() {
+    if (firstLive) (void)ncclDevCommDestroy(comm, &first);
+  });
+
+  ncclDevComm second{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &second));
+  bool secondLive = true;
+  auto secondCleanup = makeScopeGuard([&]() {
+    if (secondLive) (void)ncclDevCommDestroy(comm, &second);
+  });
+
+  ASSERT_MPI_GT(first.ginConnectionCount, 0);
+  ASSERT_MPI_EQ(first.ginConnectionCount, second.ginConnectionCount);
+  bool handlesDistinct = true;
+  for (int connection = 0; connection < first.ginConnectionCount; ++connection) {
+    handlesDistinct =
+        handlesDistinct &&
+        first.ginHandles[connection] != second.ginHandles[connection];
+  }
+  int minHandlesDistinct = handlesDistinct ? 1 : 0;
+  int maxHandlesDistinct = minHandlesDistinct;
+  MPI_Allreduce(MPI_IN_PLACE, &minHandlesDistinct, 1, MPI_INT, MPI_MIN,
+                MPI_COMM_WORLD);
+  MPI_Allreduce(MPI_IN_PLACE, &maxHandlesDistinct, 1, MPI_INT, MPI_MAX,
+                MPI_COMM_WORLD);
+  // Avoid a second destroy through an intentionally aliased handle in the
+  // fail-before mutation; the process may exit with the leaked test context.
+  if (minHandlesDistinct == 0) secondLive = false;
+  ASSERT_MPI_TRUE(minHandlesDistinct == 1 && maxHandlesDistinct == 1);
+
+  auto stateMatches = [&](ncclDevComm devComm,
+                          uint64_t expectedSignal,
+                          uint64_t expectedCounter) {
+    uint64_t state[2] = {};
+    if (readPerDevCommState(devComm, stream, state) != hipSuccess) return false;
+    return state[0] == expectedSignal && state[1] == expectedCounter;
+  };
+
+  int* dPhaseCompleted = nullptr;
+  ASSERT_MPI_EQ(hipSuccess, hipMalloc(&dPhaseCompleted, sizeof(int)));
+  auto phaseStatusCleanup = makeScopeGuard([&]() {
+    if (dPhaseCompleted) (void)hipFree(dPhaseCompleted);
+  });
+
+  ASSERT_MPI_TRUE(stateMatches(first, 0, 0));
+  ASSERT_MPI_TRUE(stateMatches(second, 0, 0));
+
+  bool phaseCompleted = false;
+  ASSERT_MPI_EQ(hipSuccess, hipMemset(dPhaseCompleted, 0, sizeof(int)));
+  ASSERT_MPI_EQ(hipSuccess,
+                runPerDevCommIsolationPhase(rank, srcWin, dstWin,
+                                            /*offset=*/0, kSlotBytes,
+                                            /*expectedEpoch=*/1, first, stream,
+                                            dPhaseCompleted,
+                                            &phaseCompleted));
+  ASSERT_MPI_TRUE(phaseCompleted);
+  ASSERT_MPI_TRUE(stateMatches(first, rank == 1 ? 1 : 0, rank == 0 ? 1 : 0));
+  ASSERT_MPI_TRUE(stateMatches(second, 0, 0));
+
+  phaseCompleted = false;
+  ASSERT_MPI_EQ(hipSuccess, hipMemset(dPhaseCompleted, 0, sizeof(int)));
+  ASSERT_MPI_EQ(hipSuccess,
+                runPerDevCommIsolationPhase(rank, srcWin, dstWin,
+                                            /*offset=*/kSlotBytes, kSlotBytes,
+                                            /*expectedEpoch=*/1, second, stream,
+                                            dPhaseCompleted,
+                                            &phaseCompleted));
+  ASSERT_MPI_TRUE(phaseCompleted);
+  ASSERT_MPI_TRUE(stateMatches(first, rank == 1 ? 1 : 0, rank == 0 ? 1 : 0));
+  ASSERT_MPI_TRUE(stateMatches(second, rank == 1 ? 1 : 0, rank == 0 ? 1 : 0));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+  ncclResult_t firstDestroyResult = ncclDevCommDestroy(comm, &first);
+  firstLive = false;
+  ASSERT_MPI_EQ(ncclSuccess, firstDestroyResult);
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  phaseCompleted = false;
+  ASSERT_MPI_EQ(hipSuccess, hipMemset(dPhaseCompleted, 0, sizeof(int)));
+  ASSERT_MPI_EQ(hipSuccess,
+                runPerDevCommIsolationPhase(rank, srcWin, dstWin,
+                                            /*offset=*/2 * kSlotBytes, kSlotBytes,
+                                            /*expectedEpoch=*/2, second, stream,
+                                            dPhaseCompleted,
+                                            &phaseCompleted));
+  ASSERT_MPI_TRUE(phaseCompleted);
+  ASSERT_MPI_TRUE(stateMatches(second, rank == 1 ? 2 : 0, rank == 0 ? 2 : 0));
+
+  bool payloadMatches = true;
+  if (rank == 1) {
+    std::vector<uint8_t> hostResult(kBufferBytes, 0);
+    payloadMatches =
+        hipMemcpy(hostResult.data(), dDst, kBufferBytes, hipMemcpyDeviceToHost) ==
+            hipSuccess &&
+        hostSrc == hostResult;
+  }
+  ASSERT_MPI_TRUE(payloadMatches);
+
+  MPI_Barrier(MPI_COMM_WORLD);
+  ncclResult_t secondDestroyResult = ncclDevCommDestroy(comm, &second);
+  secondLive = false;
+  ASSERT_MPI_EQ(ncclSuccess, secondDestroyResult);
+  MPI_Barrier(MPI_COMM_WORLD);
 }
 
 // Producer: one block per GIN context. Block b uses ginContext=b, puts into

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -3498,6 +3498,38 @@
         }
       ]
     },
+    "gin_traffic_class": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 2,
+      "num_gpus": 1,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_GIN_TYPE": "2",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_ENV_PLUGIN": "none",
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_IB_FIFO_TC": "",
+        "NCCL_CROSS_NIC": "1",
+        "NCCL_DEBUG": "TRACE",
+        "NCCL_DEBUG_SUBSYS": "INIT,NET"
+      },
+      "tests": [
+        {
+          "name": "GIN_TrafficClass_DeviceHost",
+          "description": "GIN devComm traffic-class precedence at QP RTR attributes submitted to ibv_modify_qp: device request overrides host config",
+          "test_filter": "GinTrafficClassMPITest.DeviceHostPrecedence",
+          "env_variables": {
+            "NCCL_IB_SL": "",
+            "NCCL_IB_TC": ""
+          }
+        }
+      ]
+    },
     "gin_barrier_session": {
       "extends": "default",
       "is_gtest": true,
@@ -3529,6 +3561,24 @@
           "name": "GIN_Barrier_FourRanks",
           "description": "ncclGinBarrierSession over the 4-rank world team: 16 collective rounds with 3 peers per rank; completion proves the multi-peer arrival accounting keeps all ranks in lockstep",
           "test_filter": "GinMPIDeviceTests.Barrier_FourRanks",
+          "env_variables": {
+            "NCCL_GIN_TYPE": "2",
+            "NCCL_GIN_ENABLE": "1"
+          }
+        },
+        {
+          "name": "GIN_Barrier_WorldTeamUsesWorldPool",
+          "description": "Direct world-team GIN barrier selects the four-rank world team and world-specific signal pool",
+          "test_filter": "GinMPIDeviceTests.Barrier_WorldTeamUsesWorldPool",
+          "env_variables": {
+            "NCCL_GIN_TYPE": "2",
+            "NCCL_GIN_ENABLE": "1"
+          }
+        },
+        {
+          "name": "GIN_BarrierPools_AreIsolated",
+          "description": "Generic, dedicated LSA, rail-GIN, and world-GIN sessions select disjoint resource ranges and their intended handles",
+          "test_filter": "GinMPIDeviceTests.BarrierPools_AreIsolated",
           "env_variables": {
             "NCCL_GIN_TYPE": "2",
             "NCCL_GIN_ENABLE": "1"
@@ -4386,8 +4436,14 @@
       "enabled": true
     },
     {
-      "name": "GIN BarrierSession - LSA + Hybrid",
-      "description": "ncclBarrierSession LSA-only and hybrid LSA+GIN barrier with 2 ranks/node",
+      "name": "GIN Traffic Class - QP Precedence",
+      "description": "GIN devComm, host communicator, transport default, and explicit IB traffic-class precedence observed at QP RTR programming",
+      "config": "gin_traffic_class",
+      "enabled": true
+    },
+    {
+      "name": "GIN Barriers - LSA, Hybrid, World, and Pool Isolation",
+      "description": "LSA-only, hybrid LSA+GIN, direct world-team, and disjoint barrier-pool coverage with 2 ranks/node",
       "config": "gin_barrier_session",
       "enabled": true
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
@@ -1936,6 +1936,47 @@
         }
       ]
     },
+    "gin_traffic_class": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 2,
+      "num_gpus": 1,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_GIN_TYPE": "2",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_ENV_PLUGIN": "none",
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_IB_FIFO_TC": "",
+        "NCCL_CROSS_NIC": "1",
+        "NCCL_DEBUG": "TRACE",
+        "NCCL_DEBUG_SUBSYS": "INIT,NET"
+      },
+      "tests": [
+        {
+          "name": "GIN_TrafficClass_DeviceHost",
+          "description": "GIN devComm traffic-class precedence at RoCE QP RTR attributes submitted to ibv_modify_qp: device request overrides host config",
+          "test_filter": "GinTrafficClassMPITest.DeviceHostPrecedence",
+          "env_variables": {
+            "NCCL_IB_SL": "",
+            "NCCL_IB_TC": ""
+          }
+        },
+        {
+          "name": "GIN_TrafficClass_ExplicitIbOverrides",
+          "description": "Explicit NCCL_IB_SL/NCCL_IB_TC override both GIN devComm and host values at RoCE QP RTR programming",
+          "test_filter": "GinTrafficClassMPITest.ExplicitIbEnvironmentOverrides",
+          "env_variables": {
+            "NCCL_IB_SL": "5",
+            "NCCL_IB_TC": "96"
+          }
+        }
+      ]
+    },
     "ubr_multi_node": {
       "extends": "default",
       "is_gtest": true,
@@ -3068,6 +3109,12 @@
       "name": "Comm MPI Tests",
       "description": "MPI unit tests from CommMPITests.cpp",
       "config": "comm_mpi_tests",
+      "enabled": true
+    },
+    {
+      "name": "GIN Traffic Class - RoCE QP Precedence",
+      "description": "GIN device, host, default, and explicit IB traffic-class precedence observed at RoCE QP RTR programming",
+      "config": "gin_traffic_class",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Motivation

NCCL 2.30.3/2.30.4 introduced Device API and GIN enhancements that RCCL imported in sync commit b40d918f58. This adds focused validation for the AMD-applicable behavior and documents the backend limits.

## Technical Details

- `Barrier_TwoRanks` uses the direct world-team `ncclGinBarrierSession` constructor.
- `BarrierSession_Hybrid` requests the specialized lsa/railGin/worldGin pools alongside `barrierCount` and asserts the hybrid handles never alias them.
- New `DevComm_VersionedPerInstanceContexts` covers versioned `ncclDevComm`, per-device-communicator GIN contexts, rejection of 2.29.7 GIN requirements, and `ginTrafficClass` context creation.
- `BuildGfd_PutOnly` checks the 128-byte GFD version nibble.
- New `how-to/device-api-gin` page documents requirements, barrier counts, and the NVIDIA-GDAKI-only items.

Rebased onto develop; the barrier-pool corrections from #8724 are now inherited rather than duplicated.

## Issue Tracking

JIRA ID : AICOMRCCL-1199

## Test Plan

2 nodes x MI350X on Ruby, GIN PROXY (`NCCL_GIN_TYPE=2`), ROCm 7.14.

## Test Result

All 7 focused tests pass (2x1 rank, 2x2 ranks, and single-GPU GFD). Sphinx HTML builds with no new warnings.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
