### PR TITLE
fix(hip): clamp hipEventElapsedTime to non-negative values

### DIFF
--- a/projects/clr/hipamd/src/hip_event.cpp
+++ b/projects/clr/hipamd/src/hip_event.cpp
@@ -123,6 +123,12 @@ hipError_t Event::elapsedTime(Event& eStop, float& ms) {
     eStop.awaitEventCompletion();
     ms = static_cast<float>(eStop.time(false) - time(false)) * kNsToMs;
   }
+  // Guarantee CUDA-compatible semantics: elapsed time is never negative. For very
+  // short intervals the two markers' HW end timestamps can be read with a small
+  // reverse skew, which would otherwise surface as a tiny negative result.
+  if (ms < 0.0f) {
+    ms = 0.0f;
+  }
   return hipSuccess;
 }
 


### PR DESCRIPTION
Event::elapsedTime computed the elapsed time as a raw subtraction of the two events' HW end timestamps. For very short intervals the timestamps can be read back with a small reverse skew, producing a tiny negative result. CUDA guarantees hipEventElapsedTime is never negative, so clamp the result to 0.

This fixes Unit_hipExecutionCtxStreamDetached_EventRecordedBeforeDetach_StillUsable which asserts the returned elapsed time is >= 0.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
