### PR TITLE
test(rccl): known-defect tests for 17 bugs (transport, channel, allocator)

### DIFF
--- a/projects/rccl/test/BufferBoundsTests.cpp
+++ b/projects/rccl/test/BufferBoundsTests.cpp
@@ -1,0 +1,89 @@
+// Known-defect tests for buffer/array bounds bugs in RCCL infrastructure.
+//
+// These tests reproduce buggy code patterns in isolation using local types.
+// They document and assert the presence of known defects — a FAILING test
+// confirms the bug pattern still exists in the codebase. They do NOT compile
+// production RCCL source, so they will not automatically pass when a fix
+// lands in production code. When a fix is applied, update or remove the
+// corresponding test.
+//
+// Compile with g++; no GPU or network hardware needed.
+
+#include "gtest/gtest.h"
+#include <cstddef>
+#include <cstdint>
+
+namespace RcclUnitTesting {
+
+// =========================================================================
+// CollTrace latency buffer: RANKS_PER_HOST=8 overflows on >8 GPUs/node
+// src/misc/latency_profiler/CollTrace.cc:17, 150-155
+//
+//   constexpr int RANKS_PER_HOST = 8;
+//   latencyAllGather.resize(RANKS_PER_HOST * RECORD_MAX, 0);
+//   int start = localRank * RECORD_MAX;
+//   for (int i = start; ...) latencyAllGather[i] = ...;
+//
+// MI300X nodes commonly have 16 GPUs. localRank >= 8 writes past the end.
+// =========================================================================
+
+TEST(CollTraceBufferTest, AllLocalRanksWithinBounds) {
+  constexpr int RANKS_PER_HOST = 8;
+  constexpr int RECORD_MAX = 100;
+  size_t bufferSize = RANKS_PER_HOST * RECORD_MAX;
+
+  int localRanks = 16;  // MI300X dual-socket
+
+  for (int localRank = 0; localRank < localRanks; localRank++) {
+    size_t start = static_cast<size_t>(localRank) * RECORD_MAX;
+    size_t end   = start + RECORD_MAX;
+    EXPECT_LE(end, bufferSize)
+      << "localRank=" << localRank << " writes past buffer end "
+      << "(index " << end - 1 << " >= size " << bufferSize << ")";
+  }
+}
+
+// =========================================================================
+// GDR support matrix: fixed-size [32] array accessed by cudaDev unbounded
+// src/plugin/net.cc:443
+//
+//   static int gdrSupportMatrix[32] = {};
+//   ... gdrSupportMatrix[comm->cudaDev] ...
+// =========================================================================
+
+TEST(GdrSupportMatrixTest, DeviceIndexWithinBounds) {
+  constexpr int GDR_MATRIX_SIZE = 32;
+
+  // Partitioned/virtualized environments can produce device indices >= 32
+  int testDevices[] = {0, 7, 31, 32, 64, 128};
+  for (int cudaDev : testDevices) {
+    EXPECT_LT(cudaDev, GDR_MATRIX_SIZE)
+      << "cudaDev=" << cudaDev << " exceeds gdrSupportMatrix[" << GDR_MATRIX_SIZE << "]";
+  }
+}
+
+// =========================================================================
+// Allocator insertSegment: malloc result not checked before dereference
+// src/allocator.cc:175-177
+//
+//   int64_t* cuts1 = (int64_t*)malloc(a->capacity * sizeof(int64_t));
+//   for (int i = 0; i < index; i++) cuts1[i] = a->cuts[i];  // NULL deref
+//
+// Also: int capacity doubles until signed overflow -> negative -> huge
+// malloc request -> NULL return -> crash.
+// =========================================================================
+
+TEST(AllocatorResizeTest, CapacityDoublingStaysPositive) {
+  int capacity = 16;  // initial size after first allocation
+
+  while (capacity > 0) {
+    int next = capacity * 2;
+    EXPECT_GT(next, 0)
+      << "capacity=" << capacity << " * 2 overflows signed int to " << next
+      << "; malloc((negative) * sizeof(int64_t)) will return NULL and crash";
+    if (next <= 0) break;
+    capacity = next;
+  }
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/ChannelGroupTests.cpp
+++ b/projects/rccl/test/ChannelGroupTests.cpp
@@ -1,0 +1,86 @@
+// Known-defect tests for bugs in RCCL channel/group runtime.
+//
+// These tests reproduce buggy code patterns in isolation using local types.
+// They document and assert the presence of known defects — a FAILING test
+// confirms the bug pattern still exists in the codebase. They do NOT compile
+// production RCCL source, so they will not automatically pass when a fix
+// lands in production code. When a fix is applied, update or remove the
+// corresponding test.
+//
+// Compile with g++; no GPU or network hardware needed.
+
+#include "gtest/gtest.h"
+#include <vector>
+
+namespace RcclUnitTesting {
+
+// =========================================================================
+// P2P channel base: division by zero when maxLocalRanks=0
+// src/include/channel.h:30-35
+//
+//   int nodeDelta = p2pRound / comm->maxLocalRanks;       // div-by-zero
+//   int fallbackBatch = pxnEnabled ? maxLocalRanks : 1;   // 0 if pxn + mlr=0
+//   base = nodeDelta * divUp(maxLocalRanks, batchSize);   // divUp(0,0) = UB
+// =========================================================================
+
+TEST(ChannelBatchSizeTest, BatchSizeNonZeroWhenMaxLocalRanksZero) {
+  int maxLocalRanks = 0;
+  int nNodes = 2;  // >1 enters the multi-node branch
+
+  bool pxnEnabled = true;
+  int fallbackBatch = pxnEnabled ? maxLocalRanks : 1;
+
+  int p2pBatchEnable = 0;
+  constexpr int MAX_BATCH = 8;
+  int batchSize = (nNodes > 2 && p2pBatchEnable) ? MAX_BATCH : fallbackBatch;
+
+  EXPECT_NE(batchSize, 0)
+    << "batchSize=0 causes division by zero in divUp(maxLocalRanks, batchSize) "
+       "and localDelta/batchSize";
+  EXPECT_NE(maxLocalRanks, 0)
+    << "maxLocalRanks=0 causes division by zero at p2pRound/maxLocalRanks "
+       "and p2pRound%maxLocalRanks";
+}
+
+// =========================================================================
+// Group end: suspend/resume queues drained twice (copy-paste)
+// src/group.cc:320-325 (first drain), then 340-345 (duplicate drain)
+//
+// If rmaCeInitTaskQueue processing (lines 334-338) enqueues a new
+// suspend task between the two drains, it gets processed twice —
+// a double-suspend hazard.
+// =========================================================================
+
+TEST(GroupTaskQueueTest, SuspendTaskProcessedExactlyOnce) {
+  // Model the group.cc drain structure:
+  //   drain suspendQueue      (lines 320-325)
+  //   drain resumeQueue       (lines 327-332)
+  //   drain rmaCeInitQueue    (lines 334-338) -- may enqueue into suspendQueue
+  //   drain suspendQueue AGAIN (lines 340-345) -- BUG: duplicate drain
+  //   drain resumeQueue AGAIN  (lines 347-352) -- BUG: duplicate drain
+
+  std::vector<int> suspended;
+  std::vector<int> suspendQueue = {1};
+
+  // First drain
+  while (!suspendQueue.empty()) {
+    suspended.push_back(suspendQueue.back());
+    suspendQueue.pop_back();
+  }
+
+  // rmaCeInitTaskQueue processing triggers a new suspend
+  suspendQueue.push_back(2);
+
+  // Duplicate drain (the copy-paste bug)
+  while (!suspendQueue.empty()) {
+    suspended.push_back(suspendQueue.back());
+    suspendQueue.pop_back();
+  }
+
+  // Task 2 was meant for the next ncclGroupEnd, not this one
+  EXPECT_EQ(suspended.size(), 1u)
+    << "Each group end should drain suspend queue exactly once; "
+       "task 2 was processed prematurely by the duplicate drain";
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/NetIbCastTests.cpp
+++ b/projects/rccl/test/NetIbCastTests.cpp
@@ -1,0 +1,194 @@
+// Known-defect tests for bugs in src/transport/net_ib_cast/p2p.cc.
+//
+// These tests reproduce buggy code patterns in isolation using local types.
+// They document and assert the presence of known defects — a FAILING test
+// confirms the bug pattern still exists in the codebase. They do NOT compile
+// production RCCL source, so they will not automatically pass when a fix
+// lands in production code. When a fix is applied, update or remove the
+// corresponding test.
+//
+// Compile with g++; no GPU or network hardware needed.
+
+#include "gtest/gtest.h"
+#include <cstdint>
+
+namespace RcclUnitTesting {
+
+// =========================================================================
+// CTS offload FIFO: double-indexing writes to wrong element
+// src/transport/net_ib_cast/p2p.cc:657-662
+//
+// The pointer is set to &localElem[i], then indexed AGAIN by [i]:
+//   ptr = (CtsInline*)&localElem[i];
+//   ptr[i].addr = data[i];          // actually writes to localElem[2*i]
+//
+// The non-CTS path (lines 664-671) correctly uses localElem[i] directly.
+// =========================================================================
+
+struct FifoEntry {
+  uint64_t addr;
+  uint32_t rkeys[4];
+  int nreqs;
+  int size;
+  uint64_t tag;
+};
+
+TEST(IbCastFifoTest, CtsInlineWritesCorrectElement) {
+  constexpr int N = 4;
+  FifoEntry elems[N] = {};
+
+  // Reproduce the buggy CTS offload loop from p2p.cc:654-662
+  for (int i = 0; i < N; i++) {
+    FifoEntry* localElemCtsInline = &elems[i];
+    localElemCtsInline[i].addr = 0xBEEF + i;  // buggy: double-offset
+  }
+
+  // Assert: each elems[i].addr should hold 0xBEEF+i
+  for (int i = 0; i < N; i++) {
+    EXPECT_EQ(elems[i].addr, static_cast<uint64_t>(0xBEEF + i))
+      << "elems[" << i << "].addr: CTS offload loop wrote to wrong element";
+  }
+}
+
+TEST(IbCastFifoTest, NonCtsPathWritesCorrectElement) {
+  constexpr int N = 4;
+  FifoEntry elems[N] = {};
+
+  // Non-CTS path (p2p.cc:664-671) — no double-indexing
+  for (int i = 0; i < N; i++) {
+    elems[i].addr = 0xBEEF + i;
+  }
+
+  for (int i = 0; i < N; i++) {
+    EXPECT_EQ(elems[i].addr, static_cast<uint64_t>(0xBEEF + i));
+  }
+}
+
+// =========================================================================
+// Completion: NCCLCHECK in bool function swallows errors
+// src/transport/net_ib_cast/p2p.cc:794-801
+//
+//   static inline bool IbCastRequestIsComplete(...) {
+//     NCCLCHECK(IbCastResiliencyRequestIsComplete(request, &complete));
+//     return complete;
+//   }
+//
+// NCCLCHECK returns ncclResult_t (int) from a bool function.
+// Any non-zero error code truncates to true (= "request complete").
+// =========================================================================
+
+#define TEST_NCCLCHECK(cmd) do { \
+  int __ret = (cmd);             \
+  if (__ret != 0) return __ret;  \
+} while(0)
+
+static inline bool simulateRequestIsComplete(bool baseComplete, int resiliencyResult) {
+  bool complete = baseComplete;
+  if (!complete) {
+    TEST_NCCLCHECK(resiliencyResult);
+  }
+  return complete;
+}
+
+TEST(IbCastCompletionTest, ResiliencyErrorMustNotIndicateComplete) {
+  // Resiliency subsystem returns ncclSystemError (2)
+  // The function should propagate the error, NOT say "complete"
+  bool result = simulateRequestIsComplete(false, /*ncclSystemError=*/2);
+  EXPECT_FALSE(result)
+    << "Resiliency error (ncclSystemError=2) was truncated to bool true, "
+       "making a failed request appear complete";
+}
+
+TEST(IbCastCompletionTest, ResiliencySuccessWithIncompleteRequest) {
+  bool result = simulateRequestIsComplete(false, /*ncclSuccess=*/0);
+  EXPECT_FALSE(result)
+    << "Request is not complete when base events are still pending";
+}
+
+TEST(IbCastCompletionTest, AlreadyCompleteSkipsResiliency) {
+  bool result = simulateRequestIsComplete(true, /*ncclSystemError=*/2);
+  EXPECT_TRUE(result)
+    << "Already-complete request should stay complete";
+}
+
+#undef TEST_NCCLCHECK
+
+// =========================================================================
+// wr_id packing: bit shift exceeds type width for nreqs > 8
+// src/transport/net_ib_cast/p2p.cc:115
+//
+//   wr_id += (uint64_t)(slot & 0xff) << (r * 8);
+//
+// For r >= 8, shift r*8 >= 64 is undefined behavior on uint64_t.
+// =========================================================================
+
+TEST(IbWrIdPackingTest, AllShiftsWithinBitWidth) {
+  int maxNreqs = 12;  // NCCL_NET_IB_MAX_RECVS may allow this
+
+  for (int r = 0; r < maxNreqs; r++) {
+    int shift = r * 8;
+    EXPECT_LT(shift, 64)
+      << "r=" << r << ": shift of " << shift << " bits on uint64_t is undefined behavior";
+  }
+}
+
+TEST(IbWrIdPackingTest, PackedValuesDoNotOverlap) {
+  // With nreqs <= 8, each request gets a unique byte lane in wr_id
+  uint64_t wr_id = 0;
+  int nreqs = 8;
+  uint8_t slot = 0xAB;
+
+  for (int r = 0; r < nreqs; r++) {
+    wr_id += (uint64_t)(slot & 0xff) << (r * 8);
+  }
+
+  // Verify each byte lane is independently readable
+  for (int r = 0; r < nreqs; r++) {
+    uint8_t extracted = (wr_id >> (r * 8)) & 0xff;
+    EXPECT_EQ(extracted, slot) << "r=" << r;
+  }
+}
+
+// =========================================================================
+// remDevIdx used as array index before initialization
+// src/transport/net_ib_cast/common.cc:49 initializes remDevIdx to -1:
+//   baseComm->qps[i].remDevIdx = -1;
+//
+// It is only set to a valid value during RTR in connect.cc:724:
+//   localQp->remDevIdx = remQpInfo->devIndex;
+//
+// But IbCastPostFifo (p2p.cc:501) uses it as an array index:
+//   wr.wr.rdma.rkey = comm->base.remDevs[ctsQp->remDevIdx].rkey;
+//
+// If called before RTR completes, remDevIdx is still -1, producing
+// an array underflow that reads from memory before remDevs[].
+// =========================================================================
+
+TEST(IbCastRemDevIdxTest, InitialValueIsValidIndex) {
+  constexpr int NCCL_IB_MAX_DEVS_PER_NIC = 4;
+  int remDevIdx = -1;  // as initialized in IbCastBaseCommInit
+
+  EXPECT_GE(remDevIdx, 0)
+    << "remDevIdx initialized to " << remDevIdx
+    << "; used as array index in remDevs[remDevIdx] at p2p.cc:501 "
+       "before RTR sets it, causing buffer underflow";
+}
+
+TEST(IbCastRemDevIdxTest, NegativeIndexCaughtBeforeArrayAccess) {
+  constexpr int NCCL_IB_MAX_DEVS_PER_NIC = 4;
+
+  struct RemDev { uint32_t rkey; int ibv_dev_index; int lid; };
+  RemDev remDevs[NCCL_IB_MAX_DEVS_PER_NIC] = {};
+
+  int remDevIdx = -1;  // uninitialized state from common.cc:49
+
+  // The code at p2p.cc:501 does: remDevs[ctsQp->remDevIdx].rkey
+  // This should be guarded — assert the index is in bounds
+  bool inBounds = (remDevIdx >= 0 && remDevIdx < NCCL_IB_MAX_DEVS_PER_NIC);
+  EXPECT_TRUE(inBounds)
+    << "remDevIdx=" << remDevIdx << " is out of bounds for remDevs["
+    << NCCL_IB_MAX_DEVS_PER_NIC << "]; "
+       "array underflow causes SIGSEGV during CAST transport connect";
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/PipeReadTests.cpp
+++ b/projects/rccl/test/PipeReadTests.cpp
@@ -1,0 +1,52 @@
+// Known-defect tests for PIPE_READ macro in test infrastructure.
+//
+// These tests reproduce buggy code patterns in isolation using local types.
+// They document and assert the presence of known defects — a FAILING test
+// confirms the bug pattern still exists in the codebase. They do NOT compile
+// production RCCL source, so they will not automatically pass when a fix
+// lands in production code. When a fix is applied, update or remove the
+// corresponding test.
+
+#include "gtest/gtest.h"
+#include <cstddef>
+#include <sys/types.h>
+
+namespace RcclUnitTesting {
+
+// =========================================================================
+// PIPE_READ macro: partial read check uses sizeof(int) not sizeof(val)
+// test/common/TestBed.cpp:29
+//
+//   ssize_t retval = read(fd, &val, sizeof(val));
+//   if (retval < sizeof(int)) { FAIL; }     // should be sizeof(val)
+//
+// For types > int (ncclUniqueId = 128 bytes), partial reads are undetected.
+// =========================================================================
+
+TEST(PipeReadTest, PartialReadDetectedForLargeTypes) {
+  struct LargePayload { char data[128]; };
+  ssize_t bytesRead = 64;  // partial: got 64 of 128 bytes
+
+  // Buggy check: sizeof(int) = 4
+  bool buggyCheck = (bytesRead < static_cast<ssize_t>(sizeof(int)));
+  // Correct check: sizeof(LargePayload) = 128
+  bool correctCheck = (bytesRead < static_cast<ssize_t>(sizeof(LargePayload)));
+
+  EXPECT_EQ(buggyCheck, correctCheck)
+    << "PIPE_READ partial-read check uses sizeof(int)=" << sizeof(int)
+    << " instead of sizeof(val)=" << sizeof(LargePayload)
+    << "; 64-byte partial read goes undetected";
+}
+
+TEST(PipeReadTest, IntSizedTypeIsMasked) {
+  int val;
+  ssize_t bytesRead = 2;  // partial read of int
+
+  bool buggyCheck = (bytesRead < static_cast<ssize_t>(sizeof(int)));
+  bool correctCheck = (bytesRead < static_cast<ssize_t>(sizeof(val)));
+
+  EXPECT_EQ(buggyCheck, correctCheck)
+    << "For int-sized values, both checks should agree";
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/SyncRegressionTests.cpp
+++ b/projects/rccl/test/SyncRegressionTests.cpp
@@ -1,0 +1,172 @@
+// Known-defect tests for bugs introduced or exposed by the NCCL 2.30.7 sync.
+//
+// These tests reproduce buggy code patterns in isolation using local types.
+// They document and assert the presence of known defects — a FAILING test
+// confirms the bug pattern still exists in the codebase. They do NOT compile
+// production RCCL source, so they will not automatically pass when a fix
+// lands in production code. When a fix is applied, update or remove the
+// corresponding test.
+//
+// Compile with g++; no GPU or network hardware needed.
+
+#include "gtest/gtest.h"
+#include <cstdint>
+#include <vector>
+
+namespace RcclUnitTesting {
+
+// =========================================================================
+// Switch fallthrough in printIbWcStatusHint
+// src/transport/net_ib/common.h:628-646 (sync branch)
+//
+//   switch (status) {
+//   case IBV_WC_LOC_PROT_ERR:
+//     INFO("ACS hint...");
+//   case IBV_WC_WR_FLUSH_ERR:      // falls through — no break
+//     INFO("NIC hint...");
+//   case IBV_WC_RETRY_EXC_ERR:     // falls through — no break
+//     INFO("TIMEOUT hint...");
+//   default: break;
+//   }
+//
+// Each case prints its own hints PLUS all subsequent cases' hints.
+// IBV_WC_LOC_PROT_ERR prints ACS + NIC + TIMEOUT hints (wrong).
+// =========================================================================
+
+enum TestIbWcStatus {
+  TEST_IBV_WC_SUCCESS = 0,
+  TEST_IBV_WC_LOC_PROT_ERR = 5,
+  TEST_IBV_WC_WR_FLUSH_ERR = 6,
+  TEST_IBV_WC_RETRY_EXC_ERR = 7,
+};
+
+static std::vector<int> simulatePrintIbWcStatusHint(int status) {
+  std::vector<int> hintsEmitted;
+
+  // Exact reproduction of the buggy switch from common.h
+  switch (status) {
+  case TEST_IBV_WC_LOC_PROT_ERR:
+    hintsEmitted.push_back(TEST_IBV_WC_LOC_PROT_ERR);  // ACS hint
+    // MISSING: break;
+  case TEST_IBV_WC_WR_FLUSH_ERR:
+    hintsEmitted.push_back(TEST_IBV_WC_WR_FLUSH_ERR);  // NIC hint
+    // MISSING: break;
+  case TEST_IBV_WC_RETRY_EXC_ERR:
+    hintsEmitted.push_back(TEST_IBV_WC_RETRY_EXC_ERR); // TIMEOUT hint
+    // MISSING: break;
+  default:
+    break;
+  }
+  return hintsEmitted;
+}
+
+TEST(IbWcStatusHintTest, LocProtErrShowsOnlyAcsHint) {
+  auto hints = simulatePrintIbWcStatusHint(TEST_IBV_WC_LOC_PROT_ERR);
+  EXPECT_EQ(hints.size(), 1u)
+    << "IBV_WC_LOC_PROT_ERR should emit 1 hint (ACS), but emitted "
+    << hints.size() << " due to switch fallthrough";
+}
+
+TEST(IbWcStatusHintTest, FlushErrShowsOnlyNicHint) {
+  auto hints = simulatePrintIbWcStatusHint(TEST_IBV_WC_WR_FLUSH_ERR);
+  EXPECT_EQ(hints.size(), 1u)
+    << "IBV_WC_WR_FLUSH_ERR should emit 1 hint (NIC), but emitted "
+    << hints.size() << " due to switch fallthrough";
+}
+
+TEST(IbWcStatusHintTest, RetryErrShowsOnlyTimeoutHint) {
+  auto hints = simulatePrintIbWcStatusHint(TEST_IBV_WC_RETRY_EXC_ERR);
+  // This case is the last before default, so it doesn't fall through
+  EXPECT_EQ(hints.size(), 1u)
+    << "IBV_WC_RETRY_EXC_ERR should emit 1 hint (TIMEOUT)";
+}
+
+// =========================================================================
+// PAT preconnect guard reverted by NCCL 2.30 sync
+// src/group.cc:232 and :656
+//
+// develop branch (correct for ROCm):
+//   if ((comm->cuMemSupport || algoNeedConnect[NCCL_ALGO_PAT]) && needConnect)
+//
+// sync branch (reverted to upstream NCCL):
+//   if (comm->cuMemSupport && needConnect)
+//
+// On ROCm, cuMemSupport is typically false. The develop branch added the
+// algoNeedConnect[NCCL_ALGO_PAT] clause so PAT QPs can be preconnected
+// without cuMem. Removing it means PAT collectives silently skip
+// preconnect and fail at runtime.
+// =========================================================================
+
+TEST(PatPreconnectTest, PatPreconnectEnteredWithoutCuMemSupport) {
+  bool cuMemSupport = false;  // ROCm default
+  bool needConnect = true;
+  bool algoNeedConnect_PAT = true;  // PAT algorithm selected
+
+  // sync branch logic (reverted):
+  bool syncBranchEntersPreconnect = (cuMemSupport && needConnect);
+
+  // develop branch logic (ROCm fix):
+  bool developBranchEntersPreconnect =
+    ((cuMemSupport || algoNeedConnect_PAT) && needConnect);
+
+  EXPECT_EQ(syncBranchEntersPreconnect, developBranchEntersPreconnect)
+    << "PAT preconnect skipped on ROCm: cuMemSupport=false causes "
+       "sync branch to skip preconnect even when PAT algorithm needs it; "
+       "develop branch correctly enters via algoNeedConnect[NCCL_ALGO_PAT]";
+}
+
+TEST(PatPreconnectTest, NonPatAlgoWithoutCuMemSkipsPreconnect) {
+  bool cuMemSupport = false;
+  bool needConnect = true;
+  bool algoNeedConnect_PAT = false;  // non-PAT algorithm
+
+  // Both branches should skip preconnect when neither cuMem nor PAT is needed
+  bool syncResult = (cuMemSupport && needConnect);
+  bool developResult = ((cuMemSupport || algoNeedConnect_PAT) && needConnect);
+
+  EXPECT_EQ(syncResult, developResult)
+    << "Non-PAT algorithm without cuMem: both branches should agree";
+}
+
+// =========================================================================
+// Socket magic mismatch: ncclSocketDefaultMagic() vs NCCL_SOCKET_MAGIC
+// src/transport/net_ib/connect.cc:616 vs :1858
+//
+//   handle->magic = ncclSocketDefaultMagic();  // line 616 — may be overridden by env
+//   ...
+//   if (ibHandle->magic != NCCL_SOCKET_MAGIC)  // line 1858 — hardcoded constant
+//     return ncclInvalidArgument;
+//
+// ncclSocketDefaultMagic() returns NCCL_SOCKET_MAGIC by default, but can
+// be overridden via the NCCL_SOCKET_MAGIC env var. If overridden,
+// rcclNetP2pPolicy rejects valid handles.
+// =========================================================================
+
+TEST(SocketMagicTest, OverriddenMagicPassesValidation) {
+  constexpr uint64_t NCCL_SOCKET_MAGIC = 0x564ab9f2fc4b9d05;
+  uint64_t customMagic = 0xDEADBEEF12345678;  // simulates env override
+
+  // Simulate ncclSocketDefaultMagic() returning custom value
+  uint64_t handleMagic = customMagic;
+
+  // Validation in rcclNetP2pPolicy compares against hardcoded constant
+  bool validationPasses = (handleMagic == NCCL_SOCKET_MAGIC);
+
+  EXPECT_TRUE(validationPasses)
+    << "Handle magic 0x" << std::hex << handleMagic
+    << " rejected by hardcoded check against 0x" << NCCL_SOCKET_MAGIC
+    << "; rcclNetP2pPolicy should use ncclSocketDefaultMagic() for comparison";
+}
+
+TEST(SocketMagicTest, DefaultMagicPassesValidation) {
+  constexpr uint64_t NCCL_SOCKET_MAGIC = 0x564ab9f2fc4b9d05;
+
+  // Default case: ncclSocketDefaultMagic() returns the constant
+  uint64_t handleMagic = NCCL_SOCKET_MAGIC;
+
+  bool validationPasses = (handleMagic == NCCL_SOCKET_MAGIC);
+  EXPECT_TRUE(validationPasses)
+    << "Default magic should always pass validation";
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/TransportBoundsTests.cpp
+++ b/projects/rccl/test/TransportBoundsTests.cpp
@@ -1,0 +1,97 @@
+// Known-defect tests for bounds/overflow bugs in RCCL transport layer.
+//
+// These tests reproduce buggy code patterns in isolation using local types.
+// They document and assert the presence of known defects — a FAILING test
+// confirms the bug pattern still exists in the codebase. They do NOT compile
+// production RCCL source, so they will not automatically pass when a fix
+// lands in production code. When a fix is applied, update or remove the
+// corresponding test.
+//
+// Compile with g++; no GPU or network hardware needed.
+
+#include "gtest/gtest.h"
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+
+namespace RcclUnitTesting {
+
+// =========================================================================
+// CollNet size guard: unsigned comparison fails to catch underflow
+// src/transport/coll_net.cc:340
+//
+//   if ((resources->maxCollBytes <= 0) || (... > MAX))
+//
+// maxCollBytes is size_t. Unsigned underflow wraps to SIZE_MAX which
+// bypasses the <= 0 guard entirely.
+// =========================================================================
+
+TEST(CollNetSizeGuardTest, UnderflowDetectedByGuard) {
+  // Simulate: a subtraction underflows size_t
+  size_t maxCollBytes = static_cast<size_t>(5) - static_cast<size_t>(10);
+  // Wraps to SIZE_MAX - 4
+
+  bool guardTriggered = (maxCollBytes <= 0);
+  EXPECT_TRUE(guardTriggered)
+    << "size_t underflow produced " << maxCollBytes
+    << " which bypassed the <= 0 guard (unsigned can never be < 0)";
+}
+
+TEST(CollNetSizeGuardTest, ExplicitNegativeOneDetected) {
+  size_t maxCollBytes = static_cast<size_t>(-1);
+
+  bool guardTriggered = (maxCollBytes <= 0);
+  EXPECT_TRUE(guardTriggered)
+    << "(size_t)-1 = " << maxCollBytes << " should trigger the size guard";
+}
+
+// =========================================================================
+// PAT connect: signed int mask overflows on large rank counts
+// src/transport/generic.cc:72
+//
+//   for (int mask = 1; mask < comm->nRanks; mask <<= 1)
+//
+// Signed left-shift overflow is undefined behavior in C/C++.
+// mask = 2^30 << 1 = 2^31 overflows signed 32-bit int.
+// =========================================================================
+
+TEST(PatConnectMaskTest, MaskStaysPositiveThroughLoop) {
+  int nRanks = INT_MAX;
+  int mask = 1;
+
+  while (mask < nRanks) {
+    int prev = mask;
+    mask <<= 1;
+    EXPECT_GT(mask, 0)
+      << "mask overflowed to " << mask << " (was " << prev << " before shift); "
+         "signed int left-shift overflow is undefined behavior";
+    if (mask <= 0) break;
+  }
+}
+
+// =========================================================================
+// Transport constants: TRANSPORT_PROFILER index vs NTRANSPORTS array size
+// src/include/transport.h:16-22
+//
+//   #define NTRANSPORTS 4
+//   #define TRANSPORT_PROFILER 4   // not a valid index into [NTRANSPORTS]
+// =========================================================================
+
+TEST(TransportConstantsTest, AllTransportIndicesWithinArrayBounds) {
+  constexpr int NTRANSPORTS = 4;
+  constexpr int TRANSPORT_P2P = 0;
+  constexpr int TRANSPORT_SHM = 1;
+  constexpr int TRANSPORT_NET = 2;
+  constexpr int TRANSPORT_COLLNET = 3;
+  constexpr int TRANSPORT_PROFILER = 4;
+
+  int indices[] = {TRANSPORT_P2P, TRANSPORT_SHM, TRANSPORT_NET,
+                   TRANSPORT_COLLNET, TRANSPORT_PROFILER};
+
+  for (int idx : indices) {
+    EXPECT_LT(idx, NTRANSPORTS)
+      << "Transport index " << idx << " overflows array of size " << NTRANSPORTS;
+  }
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/pure/CMakeLists.txt
+++ b/projects/rccl/test/pure/CMakeLists.txt
@@ -135,6 +135,12 @@ add_executable(rccl-PureUnitTests
   ${RCCL_TEST_DIR}/EnqueueCountTests.cpp
   ${RCCL_TEST_DIR}/BootstrapBidirTests.cpp
   ${RCCL_TEST_DIR}/AltRsmiTests.cpp
+  ${RCCL_TEST_DIR}/NetIbCastTests.cpp
+  ${RCCL_TEST_DIR}/TransportBoundsTests.cpp
+  ${RCCL_TEST_DIR}/ChannelGroupTests.cpp
+  ${RCCL_TEST_DIR}/BufferBoundsTests.cpp
+  ${RCCL_TEST_DIR}/PipeReadTests.cpp
+  ${RCCL_TEST_DIR}/SyncRegressionTests.cpp
   ${RCCL_TEST_DIR}/common/ProcessIsolatedTestRunner.cpp
   bootstrap_bidir_stub.cpp
   ${RCCL_SRC_DIR}/misc/kernel_config.cc


### PR DESCRIPTION
## Summary

Adds 27 known-defect tests covering 17 distinct bugs found during code review of 94 commits from the Intel Nizhny Novgorod team and the NCCL 2.30.7 sync.

Each test reproduces a buggy code pattern in isolation using local types. A **FAILING** test confirms the bug still exists. They do **not** compile production RCCL source, so they will **not** auto-pass when a fix lands — the corresponding test should be updated or removed when a fix is applied.

## Test files

| File | Tests | Bug area |
|------|-------|----------|
| NetIbCastTests.cpp | 9 | CTS FIFO double-indexing, NCCLCHECK in bool, wr_id shift overflow, remDevIdx=-1 |
| TransportBoundsTests.cpp | 4 | collNet unsigned underflow, PAT mask overflow, TRANSPORT_PROFILER array bounds |
| ChannelGroupTests.cpp | 2 | divUp division by zero, suspend queue double-drain |
| BufferBoundsTests.cpp | 3 | CollTrace RANKS_PER_HOST=8 overflow, GDR matrix unbounded, capacity signed overflow |
| PipeReadTests.cpp | 2 | PIPE_READ sizeof(int) vs sizeof(val) |
| SyncRegressionTests.cpp | 7 | Switch fallthrough, PAT preconnect reverted, socket magic mismatch |

## Expected results

- 19 tests FAIL (confirming bugs exist)
- 8 tests PASS (edge cases that happen to work, or validating correct behavior on one branch)

Compile with g++; no GPU or network hardware needed.

## Test plan

- [x] Builds clean on top of rccl-pure-ut branch
- [x] All 27 tests run; 19 expected failures confirm documented bugs
- [x] No regressions in existing 285 functional tests