### PR TITLE
refactor(rocprofiler-systems): Remove Timemory basename()

### DIFF
--- a/projects/rocprofiler-systems/source/bin/common/tool_runner.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tool_runner.cpp
@@ -79,13 +79,6 @@ reset_color()
                                                              : ANSI_RESET;
 }
 
-std::string_view
-basename_of(std::string_view path)
-{
-    const auto slash = path.rfind('/');
-    return (slash == std::string_view::npos) ? path : path.substr(slash + 1);
-}
-
 int
 terminal_columns()
 {
@@ -361,8 +354,7 @@ tool_runner::prepare_command(const char* exe)
     new_argv.reserve(data.out.command.size() + LAUNCHER_INJECT_SLOTS);
     for(const auto& arg : data.out.command)
     {
-        if(!injected &&
-           basename_of(arg).find(data.out.launcher) != std::string_view::npos)
+        if(!injected && path::filename(arg).find(data.out.launcher) != std::string::npos)
         {
             new_argv.emplace_back(exe);
             new_argv.emplace_back("--");
@@ -492,7 +484,7 @@ tool_runner::do_full_parse()
     rocprofsys::argparse::init_parser(data);
     signals::disable_signal_detection(signals::signal_settings::get_enabled());
 
-    auto parser = parser_t{ std::string{ basename_of(argv[0]) }, build_description() };
+    auto parser = parser_t{ path::filename(argv[0]), build_description() };
 
     configure_parser(parser);
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
@@ -24,7 +24,6 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
 #include <gnu/lib-names.h>
 #include <iostream>
 #include <regex>
@@ -299,7 +298,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         - Note: source scope requires debug info
     )desc";
 
-    auto parser = parser_t{ basename(argv[0]), _desc };
+    auto parser = parser_t{ path::filename(argv[0]), _desc };
 
     parser.on_error([](parser_t&, const parser_err_t& _err) {
         stream(std::cerr, color::fatal()) << _err << "\n";

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <gnu/lib-names.h>
 #include <iostream>
 #include <regex>

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
@@ -1037,7 +1037,7 @@ filter_modules(std::vector<module_t*>* app_modules)
         if(!mod) continue;
 
         auto _module_name = std::string{ get_name(mod) };
-        auto _module_base = std::string{ tim::filepath::basename(_module_name) };
+        auto _module_base = rocprofsys::path::filename(_module_name);
         auto _module_real = rocprofsys::path::realpath(_module_name);
 
         bool _is_excluded = false;
@@ -1053,7 +1053,7 @@ filter_modules(std::vector<module_t*>* app_modules)
         {
             for(const auto& [lib_path, sub_map] : _internal_libs)
             {
-                auto _lib_base = std::string{ tim::filepath::basename(lib_path) };
+                auto _lib_base = rocprofsys::path::filename(lib_path);
                 if(_module_base == _lib_base || _module_real == lib_path ||
                    sub_map.find(_module_base) != sub_map.end() ||
                    sub_map.find(_module_real) != sub_map.end() ||
@@ -1255,10 +1255,8 @@ process_modules(const std::vector<module_t*>& _app_modules)
 
     for(auto* itr : symtab_data.modules)
     {
-        const auto* _base_name = tim::filepath::basename(itr->fullName());
-        auto        _real_name = rocprofsys::path::realpath(itr->fullName());
-
-        if(!_base_name) continue;
+        auto _base_name = rocprofsys::path::filename(itr->fullName());
+        auto _real_name = rocprofsys::path::realpath(itr->fullName());
 
         if(_names.count(_base_name) == 0 && _names.count(_real_name) == 0)
         {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
@@ -890,7 +890,6 @@ error_func_fake(error_level_t level, int num, const char* const* params)
 #include "internal_libs.hpp"
 
 #include <timemory/components/timing/wall_clock.hpp>
-#include <timemory/utility/filepath.hpp>
 
 //======================================================================================//
 //

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/function_signature.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/function_signature.cpp
@@ -4,6 +4,7 @@
 #include "function_signature.hpp"
 #include <cstdint>
 
+#include "common/path.hpp"
 #include "core/demangler.hpp"
 
 function_signature::function_signature(std::string_view _ret, std::string_view _name,
@@ -17,11 +18,8 @@ function_signature::function_signature(std::string_view _ret, std::string_view _
 , m_col(std::move(_col))
 , m_return(_ret)
 , m_name(rocprofsys::utility::demangle(_name.data()))
-, m_file(_file)
-{
-    if(m_file.find('/') != std::string_view::npos)
-        m_file = m_file.substr(m_file.find_last_of('/') + 1);
-}
+, m_file(rocprofsys::path::filename(_file))
+{}
 
 function_signature::function_signature(std::string_view _ret, std::string_view _name,
                                        std::string_view                _file,

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
@@ -462,7 +462,7 @@ get_internal_libs_data_impl()
                 continue;
 
             verbprintf(3, "[internal]     parsing module: '%s' (via '%s')...\n",
-                       _mname.c_str(), filepath::basename(itr.first));
+                       _mname.c_str(), rocprofsys::path::filename(itr.first).c_str());
 
             _data[itr.first].emplace(_mpath, func_set_t{});
             _data[itr.first].emplace(_mname, func_set_t{});

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.cpp
@@ -414,10 +414,6 @@ module_function::get_visibility() const
 bool
 module_function::is_internal_constrained() const
 {
-    auto _basename = [](std::string_view _v) {
-        return std::string{ tim::filepath::basename(_v) };
-    };
-
     auto _report = [&](const string_t& _action, const std::string& _type,
                        const string_t& _reason, int _lvl) {
         messages.emplace_back(_lvl, _action, _type, _reason, module_name);
@@ -426,7 +422,7 @@ module_function::is_internal_constrained() const
 
     const auto& _gnu_libs = get_internal_libs_data();
 
-    auto _module_base = _basename(module_name);
+    auto _module_base = rocprofsys::path::filename(module_name);
     auto _module_real = rocprofsys::path::realpath(module_name);
 
     if(std::regex_search(module_name,
@@ -454,7 +450,7 @@ module_function::is_internal_constrained() const
 
     for(const auto& litr : _gnu_libs)
     {
-        if(_module_base == _basename(litr.first) ||
+        if(_module_base == rocprofsys::path::filename(litr.first) ||
            litr.second.find(_module_base) != litr.second.end() ||
            _module_real == litr.first ||
            litr.second.find(_module_real) != litr.second.end() ||

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -1195,7 +1195,7 @@ main(int argc, char** argv)
     if(_cmdv && _cmdv[0] && strlen(_cmdv[0]) > 0)
     {
         auto _is_executable    = rocprofsys_get_is_executable(_cmdv[0], binary_rewrite);
-        std::string _cmdv_base = ::basename(_cmdv[0]);
+        std::string _cmdv_base = path::filename(_cmdv[0]);
         auto        _has_lib_suffix = _cmdv_base.length() > 3 &&
                                (_cmdv_base.find(".so.") != std::string::npos ||
                                 _cmdv_base.find(".so") == (_cmdv_base.length() - 3) ||
@@ -1246,8 +1246,8 @@ main(int argc, char** argv)
     if(binary_rewrite && outfile.empty())
     {
         auto _is_local = (path::realpath(cmdv0) ==
-                          fmt::format("{}/{}", get_cwd(), ::basename(cmdv0.c_str())));
-        auto _cmd      = std::string{ ::basename(cmdv0.c_str()) };
+                          fmt::format("{}/{}", get_cwd(), path::filename(cmdv0)));
+        auto _cmd      = path::filename(cmdv0);
         if(_cmd.find('.') == std::string::npos)
         {
             // there is no extension, assume it is an exe
@@ -1851,10 +1851,8 @@ main(int argc, char** argv)
 
     for(const auto& itr : extra_libs)
     {
-        string_t _name = itr;
-        size_t   _pos  = _name.find_last_of('/');
-        if(_pos != npos_v) _name = _name.substr(_pos + 1);
-        _pos = _name.find('.');
+        string_t _name = path::filename(itr);
+        size_t   _pos  = _name.find('.');
         if(_pos != npos_v) _name = _name.substr(0, _pos);
         _pos = _name.find("librocprof-sys-");
         if(_pos != npos_v)
@@ -2778,7 +2776,7 @@ get_absolute_filepath(std::string _name, const strvec_t& _search_paths)
             ROCPROFSYS_ADD_LOG_ENTRY("searching", itr, "for", _name);
             for(const auto& pitr :
                 { absolute(fmt::format("{}/{}", itr, _name)),
-                  absolute(fmt::format("{}/{}", itr, filepath::basename(_name))) })
+                  absolute(fmt::format("{}/{}", itr, path::filename(_name))) })
             {
                 _exists = exists(pitr) && is_file(pitr);
                 if(_exists)
@@ -2817,7 +2815,7 @@ get_absolute_filepath(std::string _name)
 {
     auto _search_paths  = strvec_t{};
     auto _combine_paths = std::vector<strvec_t>{ bin_search_paths, lib_search_paths };
-    auto _base_name     = std::string_view{ filepath::basename(_name) };
+    auto _base_name     = path::filename(_name);
     // if the name looks like a library, put the lib_search_paths first
     if(_base_name.find("lib") == 0 || _base_name.find(".so") != std::string::npos ||
        _base_name.find(".a") != std::string::npos)

--- a/projects/rocprofiler-systems/source/lib/binary/analysis.cpp
+++ b/projects/rocprofiler-systems/source/lib/binary/analysis.cpp
@@ -206,12 +206,11 @@ lookup_ipaddr_entry(uintptr_t _addr, unw_context_t* _context_p,
             auto _exclude_range_v      = std::set<address_range>{};
             auto _insert_exclude_range = [&_maps,
                                           &_exclude_range_v](const std::string& _v) {
-                auto _base_v = std::string_view{ filepath::basename(_v) };
+                auto _base_v = path::filename(_v);
                 auto _real_v = path::realpath(_v);
                 for(const auto& mitr : _maps)
                 {
-                    if(std::string_view{ filepath::basename(mitr.pathname) } == _base_v ||
-                       _real_v == _v)
+                    if(path::filename(mitr.pathname) == _base_v || _real_v == _v)
                     {
                         _exclude_range_v.emplace(
                             address_range{ mitr.load_address, mitr.last_address });

--- a/projects/rocprofiler-systems/source/lib/binary/link_map.cpp
+++ b/projects/rocprofiler-systems/source/lib/binary/link_map.cpp
@@ -3,15 +3,10 @@
 
 #include "link_map.hpp"
 #include "common/path.hpp"
-#include "core/common.hpp"
 #include "core/config.hpp"
-#include "core/timemory.hpp"
-
-#include <timemory/utility/filepath.hpp>
 
 #include "logger/debug.hpp"
 
-#include <cstdint>
 #include <dlfcn.h>
 #include <link.h>
 #include <set>

--- a/projects/rocprofiler-systems/source/lib/binary/link_map.cpp
+++ b/projects/rocprofiler-systems/source/lib/binary/link_map.cpp
@@ -121,7 +121,7 @@ get_link_map(const char* _lib, const std::string& _exclude_linked_by,
     auto _name = (!_lib) ? config::get_exe_realpath() : std::string{ _lib };
     for(const auto& itr : _fini_chain)
     {
-        LOG_DEBUG("[linkmap][{}]: {}", filepath::basename(_name), itr.real());
+        LOG_DEBUG("[linkmap][{}]: {}", path::filename(_name), itr.real());
     }
 
     for(const auto& itr : _excl_chain)
@@ -147,10 +147,10 @@ link_file::operator<(const link_file& _rhs) const
     return (_lhs_real < _rhs_real);
 }
 
-std::string_view
+std::string
 link_file::base() const
 {
-    return std::string_view{ filepath::basename(name) };
+    return path::filename(name);
 }
 
 std::string

--- a/projects/rocprofiler-systems/source/lib/binary/link_map.hpp
+++ b/projects/rocprofiler-systems/source/lib/binary/link_map.hpp
@@ -23,9 +23,9 @@ struct link_file
     : name{ _v }
     {}
 
-    std::string_view base() const;
-    std::string      real() const;
-    bool             operator<(const link_file&) const;
+    std::string base() const;
+    std::string real() const;
+    bool        operator<(const link_file&) const;
 
     std::string name = {};
 };

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -507,10 +507,7 @@ is_python_interpreter(std::string_view executable)
 {
     if(executable.empty()) return false;
 
-    const auto slash_pos = executable.rfind('/');
-    const auto basename  = (slash_pos != std::string_view::npos)
-                               ? executable.substr(slash_pos + 1)
-                               : executable;
+    const auto basename = path::filename(executable);
 
     if(basename == "python" || basename == "python3") return true;
 

--- a/projects/rocprofiler-systems/source/lib/common/path.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/path.hpp
@@ -90,6 +90,9 @@ find_path(const std::string& _path, int _verbose,
 parent_path(std::string_view fpath, std::uint16_t levels = 1) ROCPROFSYS_INTERNAL_API;
 
 [[nodiscard]] inline std::string
+filename(std::string_view path) ROCPROFSYS_INTERNAL_API;
+
+[[nodiscard]] inline std::string
 realpath(const std::string& path) ROCPROFSYS_INTERNAL_API;
 
 inline bool
@@ -235,6 +238,21 @@ parent_path(std::string_view fpath, std::uint16_t levels)
         result = std::move(parent);
     }
     return result.string();
+}
+
+/**
+ * Get the component of @p path after the last '/'.
+ * Pure lexical operation: no filesystem access, no normalization.
+ * @code filename("/a/b.so") @endcode returns "b.so".
+ * @code filename("/a/b/") @endcode returns "".
+ * @param path the path to take the filename of
+ * @return the filename component, or "" if @p path ends in '/'
+ */
+[[nodiscard]] std::string
+filename(std::string_view path)
+{
+    const auto pos = path.rfind('/');
+    return std::string{ (pos == std::string_view::npos) ? path : path.substr(pos + 1) };
 }
 
 /** @brief Read the symbolic link target.

--- a/projects/rocprofiler-systems/source/lib/common/path.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/path.hpp
@@ -194,8 +194,7 @@ find_path(const std::string& _path, int _verbose, const std::string& _search_pat
 
     for(const auto& itr : _paths)
     {
-        if(std::string_view{ ::basename(itr.c_str()) }.find("lib") ==
-               std::string_view::npos &&
+        if(path::filename(itr).find("lib") == std::string::npos &&
            !parent_path(itr).empty())
         {
             for(const auto* sitr : { "lib", "lib64", "../lib", "../lib64" })

--- a/projects/rocprofiler-systems/source/lib/common/setup.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/setup.hpp
@@ -8,7 +8,6 @@
 #include <spdlog/fmt/fmt.h>
 
 #include <cstdlib>
-#include <cstring>
 #include <dlfcn.h>
 #include <link.h>
 #include <linux/limits.h>
@@ -71,14 +70,13 @@ get_environ(int _verbose, std::string _search_paths = {},
 
     if(!_omnilib_path.empty())
     {
-        _omnilib      = fmt::format("{}/{}", _omnilib_path, ::basename(_omnilib.c_str()));
+        _omnilib      = fmt::format("{}/{}", _omnilib_path, path::filename(_omnilib));
         _search_paths = fmt::format("{}:{}", _omnilib_path, _search_paths);
     }
 
     if(!_omnilib_dl_path.empty())
     {
-        _omnilib_dl =
-            fmt::format("{}/{}", _omnilib_dl_path, ::basename(_omnilib_dl.c_str()));
+        _omnilib_dl = fmt::format("{}/{}", _omnilib_dl_path, path::filename(_omnilib_dl));
         _search_paths = fmt::format("{}:{}", _omnilib_dl_path, _search_paths);
     }
 

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
@@ -436,3 +436,37 @@ TEST_F(PathTest, ParentPath_RealExe_TwoLevels)
     EXPECT_FALSE(result.empty());
     EXPECT_EQ(result.front(), '/');
 }
+
+TEST_F(PathTest, Filename_StandardPath) { EXPECT_EQ(filename("/a/b.so"), "b.so"); }
+
+TEST_F(PathTest, Filename_NoSlash) { EXPECT_EQ(filename("filename"), "filename"); }
+
+TEST_F(PathTest, Filename_TrailingSlash) { EXPECT_EQ(filename("/a/b/"), ""); }
+
+TEST_F(PathTest, Filename_TrailingDoubleSlash) { EXPECT_EQ(filename("/a/b//"), ""); }
+
+TEST_F(PathTest, Filename_Root) { EXPECT_EQ(filename("/"), ""); }
+
+TEST_F(PathTest, Filename_EmptyString) { EXPECT_EQ(filename(""), ""); }
+
+TEST_F(PathTest, Filename_Dot) { EXPECT_EQ(filename("."), "."); }
+
+TEST_F(PathTest, Filename_DotDot) { EXPECT_EQ(filename(".."), ".."); }
+
+TEST_F(PathTest, Filename_DoubleSlash) { EXPECT_EQ(filename("/a//b"), "b"); }
+
+TEST_F(PathTest, Filename_RedundantInteriorSlash) { EXPECT_EQ(filename("/a///b"), "b"); }
+
+TEST_F(PathTest, Filename_MultipleExtensions)
+{
+    EXPECT_EQ(filename("/a/b.tar.gz"), "b.tar.gz");
+}
+
+TEST_F(PathTest, Filename_Dotfile) { EXPECT_EQ(filename("/a/.bashrc"), ".bashrc"); }
+
+TEST_F(PathTest, Filename_RelativePath) { EXPECT_EQ(filename("a/b/c"), "c"); }
+
+TEST_F(PathTest, Filename_AcceptsTemporary)
+{
+    EXPECT_EQ(filename(std::string("/a/b/c.so")), "c.so");
+}

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -3509,9 +3509,7 @@ get_tmp_file(std::string _basename, std::string _ext)
     // subdirectory="rocprofsys-output/%ppid%" (not
     // "/home/user/rocprofsys-output/%ppid%"), so files go under
     // get_tmpdir()/rocprofsys-output/.
-    auto _output_path = settings::output_path();
-    auto _pos         = _output_path.rfind('/');
-    if(_pos != std::string::npos) _output_path = _output_path.substr(_pos + 1);
+    auto _output_path = path::filename(settings::output_path());
     if(_output_path.empty()) _output_path = "rocprofsys";
     _cfg.subdirectory = fmt::format("{}/{}/", _output_path, "%ppid%");
     auto _fname =

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
@@ -18,6 +18,7 @@
 #include "common/delimit.hpp"
 #include "common/environment.hpp"
 #include "common/invoke.hpp"
+#include "common/path.hpp"
 #include "common/setup.hpp"
 #include "dl/dl.hpp"
 #include "rocprofiler-systems/categories.h"
@@ -224,11 +225,11 @@ struct ROCPROFSYS_INTERNAL_API indirect
         {
             ROCPROFSYS_COMMON_LIBRARY_LOG_START
             fprintf(stderr, "[rocprof-sys][dl][pid=%i] %s resolved to '%s'\n", getpid(),
-                    ::basename(_omnilib.c_str()), m_omnilib.c_str());
+                    path::filename(_omnilib).c_str(), m_omnilib.c_str());
             fprintf(stderr, "[rocprof-sys][dl][pid=%i] %s resolved to '%s'\n", getpid(),
-                    ::basename(_dllib.c_str()), m_dllib.c_str());
+                    path::filename(_dllib).c_str(), m_dllib.c_str());
             fprintf(stderr, "[rocprof-sys][dl][pid=%i] %s resolved to '%s'\n", getpid(),
-                    ::basename(_userlib.c_str()), m_userlib.c_str());
+                    path::filename(_userlib).c_str(), m_userlib.c_str());
             ROCPROFSYS_COMMON_LIBRARY_LOG_END
         }
 
@@ -1263,7 +1264,7 @@ rocprofsys_postinit(std::string _exe)
             if(_exe.empty())
                 rocprofsys_push_trace("main");
             else
-                rocprofsys_push_trace(basename(_exe.c_str()));
+                rocprofsys_push_trace(path::filename(_exe).c_str());
             break;
         }
         case InstrumentMode::PythonProfile:
@@ -1573,7 +1574,7 @@ extern "C"
 
         int ret = (*::rocprofsys::dl::main_real)(argc, argv, envp);
 
-        rocprofsys_pop_trace(basename(argv[0]));
+        rocprofsys_pop_trace(rocprofsys::path::filename(argv[0]).c_str());
         rocprofsys_finalize();
 
         return ret;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/experiment.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/experiment.cpp
@@ -7,6 +7,7 @@
 #include "binary/symbol.hpp"
 #include "common/defines.h"
 #include "common/env_vars.hpp"
+#include "common/path.hpp"
 #include "common/units.hpp"
 #include "core/config.hpp"
 #include "core/demangler.hpp"
@@ -354,7 +355,7 @@ experiment::as_string() const
     if(selection.symbol_address > 0 && selection.address != selection.symbol_address)
         _ss << "(symbol@" << fmt::format("0x{:X}", selection.symbol_address) << ") ";
     if(!selection.symbol.file.empty() && selection.symbol.line > 0)
-        _ss << "[" << filepath::basename(selection.symbol.file) << ":"
+        _ss << "[" << path::filename(selection.symbol.file) << ":"
             << selection.symbol.line << "]";
 
     auto _patch = [](std::string _v) {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -6,6 +6,7 @@
 #include "binary/analysis.hpp"
 #include "common/delimit.hpp"
 #include "common/env_vars.hpp"
+#include "common/path.hpp"
 #include "common/synchronized.hpp"
 #include "core/common.hpp"
 #include "core/common_types.hpp"
@@ -438,7 +439,7 @@ get_backtrace(std::optional<std::vector<tim::unwind::processed_entry>>& _bt_data
                                      : ((itr.lineno == 0) ? std::string{ "?" }
                                                           : fmt::format("{}", itr.lineno));
             auto _entry = fmt::format("{} @ {}:{}", rocprofsys::utility::demangle(*_func),
-                                      ::basename(_loc->c_str()), _line);
+                                      path::filename(*_loc), _line);
             backtrace[fmt::format("frame#{}", _bt_cnt++)] = _entry;
         }
     }
@@ -760,7 +761,7 @@ tool_tracing_callback_stop(
                                                          : fmt::format("{}", itr.lineno));
                             auto _entry = fmt::format(
                                 "{} @ {}:{}", rocprofsys::utility::demangle(*_func),
-                                ::basename(_loc->c_str()), _line);
+                                path::filename(*_loc), _line);
                             if(_bt_cnt < 10)
                             {
                                 // Prepend zero for better ordering in UI. Only one
@@ -1264,7 +1265,7 @@ ompt_tracing_callback_stop(
                                                      : fmt::format("{}", itr.lineno));
                         auto _entry = fmt::format("{} @ {}:{}",
                                                   rocprofsys::utility::demangle(*_func),
-                                                  ::basename(_loc->c_str()), _line);
+                                                  path::filename(*_loc), _line);
                         if(_bt_cnt < 10)
                         {
                             // Prepend zero for better ordering in UI. Only one zero

--- a/projects/rocprofiler-systems/source/python/libpyrocprofsys.cpp
+++ b/projects/rocprofiler-systems/source/python/libpyrocprofsys.cpp
@@ -3,6 +3,7 @@
 
 #include "libpyrocprofsys.hpp"
 #include "common/env_vars.hpp"
+#include "common/path.hpp"
 #include "dl/dl.hpp"
 #include "library/coverage.hpp"
 #include "library/coverage/impl.hpp"
@@ -454,9 +455,7 @@ profiler_function(py::object pframe, const char* swhat, py::object arg)
     auto& _incl_files = _config.include_filenames;
     auto& _skip_files = _config.exclude_filenames;
     auto  _full       = py::cast<std::string>(get_frame_code(frame)->co_filename);
-    auto  _file       = (_full.find('/') != std::string::npos)
-                            ? _full.substr(_full.find_last_of('/') + 1)
-                            : _full;
+    auto  _file       = rocprofsys::path::filename(_full);
 
     if(!_config.include_internal &&
        strncmp(_full.c_str(), _rocprofsys_path.c_str(), _rocprofsys_path.length()) == 0)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This PR is part of a PR series to remove the dependency on Timemory filepath utilities. This particular PR replaces Timemory basename() function with equivalent in-tree function filename().

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- Replaced tim::filepath::basename() and several hand-rolled rfind('/')/substr() basename snippets with a new path::filename() function implemented in path.hpp. Matches std::filesystem::path::filename() semantics.
  - link_file::base() (lib/binary/link_map.hpp) return type changed from std::string_view to std::string, since filename() returns an owning string rather than a view into a caller-owned buffer. The only caller (operator<) uses auto, so ordering of std::set<link_file> is unaffected.
  - Three dead-code removals, each replaced directly by path::filename(): a null check in details.cpp (tim::filepath::basename() could return a null pointer; path::filename() never does), a redundant _basename lambda in module_function.cpp, and a redundant basename_of() helper in tool_runner.cpp.
  - Unit tests created for filename(): 14 PathTest.Filename_* cases in test_path.cpp covering standard paths, no-slash, trailing/double/redundant slashes, root, empty string, ./.., multiple extensions, dotfiles, relative paths, and temporary-argument lifetime.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

JIRA ID : AIPROFSYST-528

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- Existing CTest suite and new unit tests should pass
- Manual / end-to-end verification should pass (see below)

## Test Result

<!-- Briefly summarize test outcomes. -->

- Existing and new unit tests pass

- Manual / end-to-end verification passes:

  Performed differential runs against examples/minimal (minimal-recursion) to confirm zero behavior change, comparing byte-for-byte against pre-change baselines (only pid/timestamp/RSS values differ, as expected):

  - rocprof-sys-instrument --print-available/--print-excluded modules|functions — module and function lists identical before/after.
  - ROCPROFSYS_DEBUG=1 — resolved librocprof-sys.so/librocprof-sys-dl.so paths identical.
  - ROCPROFSYS_VERBOSE=3 — [linkmap] lines and their ordering identical (confirms the link_file::base() return-type change didn't affect std::set<link_file> ordering).
  - ROCPROFSYS_DL_VERBOSE=1 under a real LD_PRELOAD run — "resolved to" lines identical; root trace region confirmed to still be the exe basename (minimal-recursion), not a full path or empty, with no unclosed root region.
  - rocprof-sys-instrument -v 1 / -v 3 — "Resolved 'x' to 'y'" and "[internal] parsing module ... (via 'lib...')" diagnostic lines correct.
  - --help on all four CLI tools (rocprof-sys-instrument, rocprof-sys-sample, rocprof-sys-run, rocprof-sys-causal) — program-name header shows the correct basename.
  - ROCPROFSYS_OUTPUT_PATH=/tmp/xyz/out tracing run — output correctly written under the given path with no errors.
  - Failure path — pointed ROCPROFSYS_PATH at a nonexistent directory so find_path exhausts its search and filename sees non-existent input; process completed normally with no crash and unchanged diagnostics shape.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
