### PR TITLE
fix(ci): Migrate RCCL workflows from decommissioned azure-linux-scale-rocm to aws-linux-scale-rocm-prod

### DIFF
--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -38,7 +38,7 @@ jobs:
     # Skipped when artifact_run_id is provided (reuse mode). Downstream jobs
     # use `!cancelled()` in their `if:` so they still run when this is skipped.
     if: ${{ inputs.artifact_run_id == '' }}
-    runs-on: azure-linux-scale-rocm
+    runs-on: aws-linux-scale-rocm-prod
     permissions:
       id-token: write
     container:


### PR DESCRIPTION
  ## Summary
  The `azure-linux-scale-rocm` runner label has been decommissioned. This updates
  the RCCL CI build jobs to use `aws-linux-scale-rocm-prod` instead.

  ## Changes
  - `.github/workflows/therock-rccl-ci-linux.yml`: `therock-build-linux` job
    `runs-on` updated from `azure-linux-scale-rocm` to `aws-linux-scale-rocm-prod`

  ## Scope
  Scoped to the RCCL workflows only. Note: `azure-linux-scale-rocm` is still
  referenced in several other workflows in this repo (therock-build-linux.yml,
  therock-ci-linux.yml, therock-test-packages.yml, hip-nvidia-ci.yml,
  rocprofiler-sdk-codeql.yml, rocprofiler-sdk-build-ci-docker-images.yml,
  rocjitsu-corpus-tests.yml) and will need the same migration since the runner
  is fully decommissioned