### PR TITLE
fix(cuid): support GIM driver GPU discovery via ioctl

### DIFF
--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -279,11 +279,14 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
   info.bdf = bdf;
   info.render_node = full_device_node;
 
-  // Fallback for GIM SR-IOV hosts, where PCI device files are not exposed to
-  // userspace: fill the core identifiers from the GIM SMI ioctl interface.
-  const bool needs_gim_fallback = !info.bdf.empty() && gim_client != nullptr &&
-                                  (info.header.fields.gpu.vendor_id == 0 ||
-                                   info.header.fields.gpu.device_id == 0);
+  // For GIM SR-IOV hosts, query the GIM SMI ioctl interface for every GIM
+  // device. When PCI device files are not exposed to userspace this fills the
+  // core identifiers (vendor/device/revision). Crucially, it always captures
+  // the per-GPU ASIC serial as the hardware fingerprint: on hosts where PCI
+  // sysfs vendor/device *are* present, no sysfs unique_id or usable PCI config
+  // space exists for the SR-IOV PF, so without the GIM ASIC serial every GPU
+  // would collapse to an identical fallback CUID.
+  const bool needs_gim_fallback = !info.bdf.empty() && gim_client != nullptr;
   if (needs_gim_fallback) {
     cuid::gim::GimAsicInfo asic;
     if (gim_client->get_asic_info_for_bdf(info.bdf, asic) ==

--- a/projects/cuid/lib/src/gim_util.cc
+++ b/projects/cuid/lib/src/gim_util.cc
@@ -106,33 +106,51 @@ struct SmiHandshakeWire {
 };
 static_assert(sizeof(SmiHandshakeWire) == 4, "SmiHandshakeWire size mismatch");
 
-// struct smi_server_static_info (Linux, natural alignment).
+// struct smi_device_handle_t (smi_device_handle.h). The GIM SMI ABI identifies
+// a device by a 16-byte handle: an opaque 64-bit handle plus the 64-bit PCI
+// device id. Modeling this as a bare uint64_t (as an earlier revision did)
+// under-sizes every consumer of the handle and corrupts the device array.
+struct SmiDeviceHandleWire {
+  uint64_t handle;
+  uint64_t device_id;
+};
+static_assert(sizeof(SmiDeviceHandleWire) == 16,
+              "SmiDeviceHandleWire size mismatch");
+
+// One entry of struct smi_server_static_info::devices[] (Linux, natural
+// alignment). dev_id is a 16-byte smi_device_handle_t, so each entry is 40
+// bytes.
 struct SmiServerDeviceWire {
-  uint64_t dev_id;
+  SmiDeviceHandleWire dev_id;
   uint64_t bdf;     // union smi_bdf packed 64-bit value
   uint8_t failed;
   uint8_t padding[3];
   uint32_t reserved[3];
 };
-static_assert(sizeof(SmiServerDeviceWire) == 32,
+static_assert(sizeof(SmiServerDeviceWire) == 40,
               "SmiServerDeviceWire size mismatch");
 
+// struct smi_server_static_info (Linux, natural alignment). The trailing
+// reserved area expands the struct to the full 4096-byte SMI payload; the GIM
+// driver validates out_len against this exact size, so it must be 4096.
 struct SmiServerStaticInfoWire {
   uint32_t debug_level;
   uint32_t num_devices;
   SmiServerDeviceWire devices[kSmiMaxDevices];
   uint64_t reserved[351];
 };
-static_assert(sizeof(SmiServerStaticInfoWire) == 3840,
+static_assert(sizeof(SmiServerStaticInfoWire) == 4096,
               "SmiServerStaticInfoWire size mismatch");
 static_assert(sizeof(SmiServerStaticInfoWire) <= kSmiMaxPayloadBytes,
               "SmiServerStaticInfoWire larger than SMI payload");
 
-// struct smi_device_info (input for GET_ASIC_INFO).
+// struct smi_device_info (input for GET_ASIC_INFO). Holds a full 16-byte
+// smi_device_handle_t.
 struct SmiDeviceInfoWire {
-  uint64_t dev_id;
+  SmiDeviceHandleWire dev_id;
 };
-static_assert(sizeof(SmiDeviceInfoWire) == 8, "SmiDeviceInfoWire size mismatch");
+static_assert(sizeof(SmiDeviceInfoWire) == 16,
+              "SmiDeviceInfoWire size mismatch");
 
 // struct smi_asic_info (Linux, natural alignment).
 struct SmiAsicInfoWire {
@@ -305,7 +323,7 @@ amdcuid_status_t GimClient::get_devices(std::vector<GimDeviceEntry> &out) {
   out.reserve(n);
   for (uint32_t i = 0; i < n; ++i) {
     GimDeviceEntry e;
-    e.dev_id = info.devices[i].dev_id;
+    e.dev_id = info.devices[i].dev_id.handle;
     e.bdf = format_bdf(info.devices[i].bdf);
     e.failed = info.devices[i].failed != 0;
     out.push_back(std::move(e));
@@ -338,7 +356,7 @@ amdcuid_status_t GimClient::get_asic_info(uint64_t dev_id, GimAsicInfo &info) {
     return st;
   }
 
-  SmiDeviceInfoWire req{dev_id};
+  SmiDeviceInfoWire req{{dev_id, 0}};
   SmiAsicInfoWire raw;
   std::memset(&raw, 0, sizeof(raw));
   st = do_ioctl(kSmiCmdCodeGetAsicInfo, &req, sizeof(req), &raw, sizeof(raw));

--- a/projects/cuid/tests/main.cc
+++ b/projects/cuid/tests/main.cc
@@ -40,6 +40,7 @@
 #include "functional/device_refresh_test.h"
 #include "functional/hmac_test.h"
 #include "functional/reverse_lookup_test.h"
+#include "src/gim_util.h"
 
 // =============================================================================
 // cuidtstUnprivileged — tests that run without root
@@ -202,6 +203,17 @@ TEST(cuidtstPrivileged, ReverseDeviceType) {
     GTEST_SKIP() << "Requires root; run with sudo to enable.";
   }
   TestReverseDeviceType tst;
+  RunGenericTest(&tst);
+}
+
+TEST(cuidtstPrivileged, GimDeviceEnumeration) {
+  if (geteuid() != 0) {
+    GTEST_SKIP() << "Requires root; run with sudo to enable.";
+  }
+  if (!cuid::gim::GimClient::is_available()) {
+    GTEST_SKIP() << "GIM device node not present; skipping.";
+  }
+  TestGimDeviceEnumeration tst;
   RunGenericTest(&tst);
 }
 

--- a/projects/cuid/tests/unit/gim_util_test.cc
+++ b/projects/cuid/tests/unit/gim_util_test.cc
@@ -27,6 +27,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -162,4 +163,56 @@ void TestGimFormatBdf::Run() {
   const uint64_t packed2 =
       (uint64_t{0x1234} << 16) | (uint64_t{0xab} << 8) | (uint64_t{0x1f} << 3) | uint64_t{7};
   EXPECT_EQ(GimClient::format_bdf(packed2), "1234:ab:1f.7");
+}
+
+// ---------------------------------------------------------------------------
+// TestGimDeviceEnumeration
+// ---------------------------------------------------------------------------
+TestGimDeviceEnumeration::TestGimDeviceEnumeration() {
+  SetTitle("GIM Device Enumeration");
+  SetDescription(
+      "Enumerate GPUs from a live GIM driver and verify each has a unique, "
+      "canonical BDF and a unique, parseable ASIC serial. Detects wire-ABI "
+      "regressions that yield zero/garbage devices or collapsed identities.");
+}
+
+void TestGimDeviceEnumeration::SetUp() {}
+
+void TestGimDeviceEnumeration::Run() {
+  GimClient client;
+  ASSERT_EQ(client.init(), AMDCUID_STATUS_SUCCESS)
+      << "GIM handshake must succeed when the device node is present and "
+         "running as root";
+  EXPECT_TRUE(client.is_connected());
+
+  std::vector<GimDeviceEntry> devices;
+  // A wrong smi_server_static_info size makes the driver reject the request
+  // (status != SUCCESS); a wrong device-entry stride yields garbage entries.
+  ASSERT_EQ(client.get_devices(devices), AMDCUID_STATUS_SUCCESS);
+  ASSERT_FALSE(devices.empty()) << "GIM reported zero devices";
+
+  std::set<std::string> seen_bdfs;
+  std::set<uint64_t> seen_serials;
+  for (const auto &dev : devices) {
+    // Canonical "dddd:bb:dd.f" is exactly 12 characters and must be unique.
+    EXPECT_EQ(dev.bdf.size(), 12u) << "malformed BDF: '" << dev.bdf << "'";
+    EXPECT_NE(dev.bdf.find(':'), std::string::npos)
+        << "malformed BDF: '" << dev.bdf << "'";
+    EXPECT_TRUE(seen_bdfs.insert(dev.bdf).second)
+        << "duplicate BDF indicates a wrong ABI stride: " << dev.bdf;
+
+    GimAsicInfo info;
+    ASSERT_EQ(client.get_asic_info(dev.dev_id, info), AMDCUID_STATUS_SUCCESS)
+        << "GET_ASIC_INFO failed for " << dev.bdf;
+    EXPECT_NE(info.vendor_id, 0u) << "zero vendor id for " << dev.bdf;
+    EXPECT_FALSE(info.asic_serial.empty()) << "empty serial for " << dev.bdf;
+
+    uint64_t serial = 0;
+    EXPECT_TRUE(GimClient::parse_asic_serial(info.asic_serial, serial))
+        << "unparseable serial '" << info.asic_serial << "' for " << dev.bdf;
+    // The per-GPU ASIC serial is the CUID hardware fingerprint; duplicates
+    // would collapse multiple GPUs into a single CUID.
+    EXPECT_TRUE(seen_serials.insert(serial).second)
+        << "duplicate ASIC serial across devices: " << info.asic_serial;
+  }
 }

--- a/projects/cuid/tests/unit/gim_util_test.h
+++ b/projects/cuid/tests/unit/gim_util_test.h
@@ -52,4 +52,16 @@ class TestGimFormatBdf : public TestBase {
   void Run() override;
 };
 
+// End-to-end enumeration against a live GIM driver. Requires root and the GIM
+// device node; asserts every device has a unique, canonical BDF and a unique,
+// parseable ASIC serial. Guards against wire-ABI regressions (a wrong struct
+// size or handle width yields zero/garbage devices, duplicate BDFs, or
+// duplicate serials that would collapse GPUs into one CUID).
+class TestGimDeviceEnumeration : public TestBase {
+ public:
+  TestGimDeviceEnumeration();
+  void SetUp() override;
+  void Run() override;
+};
+
 #endif  // CUID_TEST_UNIT_GIM_UTIL_TEST_H_


### PR DESCRIPTION
### Summary
Fixes CUID failing to discover GPUs on GIM SR-IOV hosts (AILITOOLS-238). Two independent root causes, both validated end-to-end on an MI300X x8 GIM host against a live `gim` driver.

### Root causes & fixes
1. **Wrong GIM SMI wire ABI** in `gim_util.cc`. `smi_device_handle_t` was mirrored as a `uint64_t` (8 bytes) but the driver ABI is 16 bytes (`handle` + `device_id`). This made the device-entry stride, `smi_server_static_info` (must be 4096B, was 3840B) and the asic-info input length (must be 16B, was 8B) all wrong, so `GET_SERVER_STATIC_INFO` was rejected with status 1 -> zero GPUs (or garbage BDFs). Corrected the wire structs and added `static_assert`s (16/40/4096/16) so size drift fails at compile time.
2. **ASIC-serial fingerprint never fetched** in `cuid_gpu.cc`. The GIM fallback was gated on `vendor_id==0 || device_id==0`; on hosts where PCI sysfs vendor/device exist, the unique per-GPU ASIC serial (the only fingerprint source for an SR-IOV PF) was never read, collapsing all GPUs to one identical CUID. Now always query GIM for GIM devices (field overrides remain individually guarded).

### Issue Tracking
JIRA ID : ROCM-28628

### Testing
- New driver-gated integration test `cuidtstPrivileged.GimDeviceEnumeration` asserts every GIM device has a unique, canonical BDF and a unique, parseable ASIC serial — catches both regressions. Skips cleanly without root or without the GIM device node.
- Full suite on the GIM host: root 28 ran / 27 passed / 0 failed; non-root 19 passed with privileged tests skipped.
- Example/library discovery now reports all 8 GPUs with unique CUIDs matching `amd-smi list`.