### PR TITLE
fix(rocr): Resolve NUMA dependency in exported hsakmt config (ROCM-21395)

### DIFF
--- a/projects/rocr-runtime/libhsakmt/hsakmt-config.cmake.in
+++ b/projects/rocr-runtime/libhsakmt/hsakmt-config.cmake.in
@@ -7,7 +7,12 @@ include( CMakeFindDependencyMacro )
 # the build. If libnuma was represented by an imported target when hsakmt was
 # built, recreate that target before loading hsakmt's exported target.
 if(@HSAKMT_FIND_NUMA_DEPENDENCY@)
+  # A ROCm distribution that bundles libnuma installs its package config under
+  # lib/rocm_sysdeps, which is not on a consumer's default search path. Scope
+  # the hint to this lookup so it does not leak into the consuming project.
+  list(APPEND CMAKE_PREFIX_PATH "${PACKAGE_PREFIX_DIR}/lib/rocm_sysdeps")
   find_dependency(NUMA)
+  list(REMOVE_AT CMAKE_PREFIX_PATH -1)
 endif()
 
 # If the option is ON link other dependent libraries dynamically

--- a/projects/rocr-runtime/libhsakmt/hsakmt-config.cmake.in
+++ b/projects/rocr-runtime/libhsakmt/hsakmt-config.cmake.in
@@ -8,11 +8,8 @@ include( CMakeFindDependencyMacro )
 # built, recreate that target before loading hsakmt's exported target.
 if(@HSAKMT_FIND_NUMA_DEPENDENCY@)
   # A ROCm distribution that bundles libnuma installs its package config under
-  # lib/rocm_sysdeps, which is not on a consumer's default search path. Scope
-  # the hint to this lookup so it does not leak into the consuming project.
-  list(APPEND CMAKE_PREFIX_PATH "${PACKAGE_PREFIX_DIR}/lib/rocm_sysdeps")
-  find_dependency(NUMA)
-  list(REMOVE_AT CMAKE_PREFIX_PATH -1)
+  # lib/rocm_sysdeps, which is not on a consumer's default search path.
+  find_dependency(NUMA PATHS "${PACKAGE_PREFIX_DIR}/lib/rocm_sysdeps")
 endif()
 
 # If the option is ON link other dependent libraries dynamically


### PR DESCRIPTION
## Motivation

Follow-up to #8559. It added `find_dependency(NUMA)` to the installed `hsakmt-config.cmake`, but nothing made `NUMA` resolvable downstream, so `find_package(hsakmt)` now fails. The bundled libnuma's package config lives under `lib/rocm_sysdeps`, which isn't on a consumer's default search path.

## Technical Details

Pass the prefix to the lookup: `find_dependency(NUMA PATHS "${PACKAGE_PREFIX_DIR}/lib/rocm_sysdeps")`. Scoped to this call, nothing global mutated. Uses `PACKAGE_PREFIX_DIR` so the config stays relocatable.

## Issue Tracking

JIRA ID: ROCM-21395

## Test Plan

Reconstructed the installed tree and ran `find_package(hsakmt)` with bundled libnuma present and absent.

## Test Result

Reproduced the reported error pre-fix; post-fix `hsakmt_FOUND=1` with `numa::numa` created. System-libnuma builds unaffected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.