### PR TITLE
fix(clr/rocr): Fix BatchmemcpyAsync DtoH on APUs

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2933,6 +2933,29 @@ bool KernelBlitManager::ShaderCopyBufferBatchRaw(
 }
 
 // ================================================================================================
+bool KernelBlitManager::ShaderCopyPinnedBatch(
+    const std::vector<amd::BatchCopyOp>& pinned_ops, bool needs_system_scope,
+    bool attach_signal) const {
+  std::vector<BatchRawCopyOp> raw_copy_ops;
+  raw_copy_ops.reserve(pinned_ops.size());
+
+  for (const amd::BatchCopyOp& op : pinned_ops) {
+    Memory* src_memory = dev().getRocMemory(op.srcMemory);
+    Memory* dst_memory = dev().getRocMemory(op.dstMemory);
+    if (src_memory == nullptr || dst_memory == nullptr) {
+      LogError("KernelBlitManager::ShaderCopyPinnedBatch: Invalid memory objects!");
+      return false;
+    }
+
+    raw_copy_ops.push_back({src_memory->getDeviceMemory() + op.srcOffset,
+                            dst_memory->getDeviceMemory() + op.dstOffset, op.size, op.metadata,
+                            needs_system_scope, attach_signal});
+  }
+
+  return ShaderCopyBufferBatchRaw(raw_copy_ops);
+}
+
+// ================================================================================================
 bool KernelBlitManager::WriteBufferBatch(
     const std::vector<amd::BatchWriteMemoryOp>& write_ops) const {
   for (const amd::BatchWriteMemoryOp& op : write_ops) {
@@ -3006,9 +3029,18 @@ bool KernelBlitManager::WriteBufferBatch(
     constexpr bool kSkipCpuWait = true;
     gpu().releaseGpuMemoryFence(kSkipCpuWait);
     if (!hsaCopyBatch(pinned_copy_ops)) {
-      gpu().releaseGpuMemoryFence();
-      gpu().command()->ReleasePinnedMemory();
-      return false;
+      LogWarning(
+          "KernelBlitManager::WriteBufferBatch: SDMA batch copy failed, falling back to shader "
+          "copy");
+      // System scope so the dispatch observes the application's writes
+      // to the pinned source.
+      constexpr bool kNeedsSystemScope = true;
+      constexpr bool kAttachSignal = false;
+      if (!ShaderCopyPinnedBatch(pinned_copy_ops, kNeedsSystemScope, kAttachSignal)) {
+        gpu().releaseGpuMemoryFence();
+        gpu().command()->ReleasePinnedMemory();
+        return false;
+      }
     }
     pinned_copy_ops.clear();
   }
@@ -3103,9 +3135,18 @@ bool KernelBlitManager::ReadBufferBatch(const std::vector<amd::BatchReadMemoryOp
     constexpr bool kSkipCpuWait = true;
     gpu().releaseGpuMemoryFence(kSkipCpuWait);
     if (!hsaCopyBatch(pinned_copy_ops)) {
-      gpu().releaseGpuMemoryFence();
-      gpu().command()->ReleasePinnedMemory();
-      return false;
+      LogWarning(
+          "KernelBlitManager::ReadBufferBatch: SDMA batch copy failed, falling back to shader "
+          "copy");
+      // The shader writes to pinned application memory that the host
+      // reads once this command completes, so it needs a system scope release.
+      constexpr bool kNeedsSystemScope = true;
+      constexpr bool kAttachSignal = true;
+      if (!ShaderCopyPinnedBatch(pinned_copy_ops, kNeedsSystemScope, kAttachSignal)) {
+        gpu().releaseGpuMemoryFence();
+        gpu().command()->ReleasePinnedMemory();
+        return false;
+      }
     }
     pinned_copy_ops.clear();
   }

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2933,29 +2933,6 @@ bool KernelBlitManager::ShaderCopyBufferBatchRaw(
 }
 
 // ================================================================================================
-bool KernelBlitManager::ShaderCopyPinnedBatch(
-    const std::vector<amd::BatchCopyOp>& pinned_ops, bool needs_system_scope,
-    bool attach_signal) const {
-  std::vector<BatchRawCopyOp> raw_copy_ops;
-  raw_copy_ops.reserve(pinned_ops.size());
-
-  for (const amd::BatchCopyOp& op : pinned_ops) {
-    Memory* src_memory = dev().getRocMemory(op.srcMemory);
-    Memory* dst_memory = dev().getRocMemory(op.dstMemory);
-    if (src_memory == nullptr || dst_memory == nullptr) {
-      LogError("KernelBlitManager::ShaderCopyPinnedBatch: Invalid memory objects!");
-      return false;
-    }
-
-    raw_copy_ops.push_back({src_memory->getDeviceMemory() + op.srcOffset,
-                            dst_memory->getDeviceMemory() + op.dstOffset, op.size, op.metadata,
-                            needs_system_scope, attach_signal});
-  }
-
-  return ShaderCopyBufferBatchRaw(raw_copy_ops);
-}
-
-// ================================================================================================
 bool KernelBlitManager::WriteBufferBatch(
     const std::vector<amd::BatchWriteMemoryOp>& write_ops) const {
   for (const amd::BatchWriteMemoryOp& op : write_ops) {
@@ -2971,6 +2948,12 @@ bool KernelBlitManager::WriteBufferBatch(
 
   for (const amd::BatchWriteMemoryOp& op : write_ops) {
     Memory* dst_memory = dev().getRocMemory(op.dst_memory);
+    if (dst_memory == nullptr) {
+      LogError("KernelBlitManager::WriteBufferBatch: Invalid destination memory!");
+      gpu().releaseGpuMemoryFence();
+      gpu().command()->ReleasePinnedMemory();
+      return false;
+    }
 
     const_address src_addr = reinterpret_cast<const_address>(op.src_host);
     size_t copy_offset = 0;
@@ -3036,10 +3019,12 @@ bool KernelBlitManager::WriteBufferBatch(
       // to the pinned source.
       constexpr bool kNeedsSystemScope = true;
       constexpr bool kAttachSignal = false;
-      if (!ShaderCopyPinnedBatch(pinned_copy_ops, kNeedsSystemScope, kAttachSignal)) {
-        gpu().releaseGpuMemoryFence();
-        gpu().command()->ReleasePinnedMemory();
-        return false;
+      for (const amd::BatchCopyOp& op : pinned_copy_ops) {
+        Memory* src_memory = dev().getRocMemory(op.srcMemory);
+        Memory* dst_memory = dev().getRocMemory(op.dstMemory);
+        staging_copy_ops.push_back({src_memory->getDeviceMemory() + op.srcOffset,
+                                    dst_memory->getDeviceMemory() + op.dstOffset, op.size,
+                                    op.metadata, kNeedsSystemScope, kAttachSignal});
       }
     }
     pinned_copy_ops.clear();
@@ -3142,10 +3127,12 @@ bool KernelBlitManager::ReadBufferBatch(const std::vector<amd::BatchReadMemoryOp
       // reads once this command completes, so it needs a system scope release.
       constexpr bool kNeedsSystemScope = true;
       constexpr bool kAttachSignal = true;
-      if (!ShaderCopyPinnedBatch(pinned_copy_ops, kNeedsSystemScope, kAttachSignal)) {
-        gpu().releaseGpuMemoryFence();
-        gpu().command()->ReleasePinnedMemory();
-        return false;
+      for (const amd::BatchCopyOp& op : pinned_copy_ops) {
+        Memory* src_memory = dev().getRocMemory(op.srcMemory);
+        Memory* dst_memory = dev().getRocMemory(op.dstMemory);
+        staging_copy_ops.push_back({src_memory->getDeviceMemory() + op.srcOffset,
+                                    dst_memory->getDeviceMemory() + op.dstOffset, op.size,
+                                    op.metadata, kNeedsSystemScope, kAttachSignal});
       }
     }
     pinned_copy_ops.clear();
@@ -3157,9 +3144,14 @@ bool KernelBlitManager::ReadBufferBatch(const std::vector<amd::BatchReadMemoryOp
       gpu().command()->ReleasePinnedMemory();
       return false;
     }
-    gpu().Barriers().WaitCurrent();
-    for (const StagingReadBack& read_back : staging_read_backs) {
-      memcpy(read_back.dst, read_back.staging, read_back.size);
+    // Only staged ops need the host read-back; a pinned op writes straight into
+    // the caller's buffer, so keep the copy asynchronous when the batch is all
+    // pinned fallback ops.
+    if (!staging_read_backs.empty()) {
+      gpu().Barriers().WaitCurrent();
+      for (const StagingReadBack& read_back : staging_read_backs) {
+        memcpy(read_back.dst, read_back.staging, read_back.size);
+      }
     }
   }
 

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -634,10 +634,6 @@ class KernelBlitManager : public DmaBlitManager {
   //! Copies a batch of raw virtual-address ranges using the shader path
   bool ShaderCopyBufferBatchRaw(const std::vector<BatchRawCopyOp>& copy_ops) const;
 
-  //! Re-issues the pinned-host ops of a failed SDMA batch using the shader path.
-  bool ShaderCopyPinnedBatch(const std::vector<amd::BatchCopyOp>& pinned_ops,
-                             bool needs_system_scope, bool attach_signal) const;
-
   //! Atomically updates a memory location (i.e. writes, increments or decrements the memory).
   bool streamOpsUpdate(uint blitType, device::Memory& memory, uint64_t value, size_t offset,
                        size_t sizeBytes) const;

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -634,6 +634,10 @@ class KernelBlitManager : public DmaBlitManager {
   //! Copies a batch of raw virtual-address ranges using the shader path
   bool ShaderCopyBufferBatchRaw(const std::vector<BatchRawCopyOp>& copy_ops) const;
 
+  //! Re-issues the pinned-host ops of a failed SDMA batch using the shader path.
+  bool ShaderCopyPinnedBatch(const std::vector<amd::BatchCopyOp>& pinned_ops,
+                             bool needs_system_scope, bool attach_signal) const;
+
   //! Atomically updates a memory location (i.e. writes, increments or decrements the memory).
   bool streamOpsUpdate(uint blitType, device::Memory& memory, uint64_t value, size_t offset,
                        size_t sizeBytes) const;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1284,7 +1284,12 @@ hsa_status_t GpuAgent::DmaCopyOnEngine(void* dst, core::Agent& dst_agent,
           (dst_agent.device_type() == core::Agent::kAmdGpuDevice)) &&
          ("Both devices are CPU agents which is not expected"));
 
-  if (engine_offset > num_h2d_d2h_engines_ + num_p2p_engines_) {
+  // engine_offset is an index into blits_, not an SDMA engine count. blits_ is
+  // always sized DefaultBlitCount + num_p2p_engines_, so BlitHostToDev(1) and
+  // BlitDevToHost(2) are valid everywhere regardless of how many SDMA engines
+  // engines it has. Limiting against the engine count instead rejected BlitDevToHost
+  // whenever NumSdmaEngines == 1 (e.g. gfx1151).
+  if (engine_offset < 0 || engine_offset >= static_cast<int>(blits_.size())) {
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1286,8 +1286,8 @@ hsa_status_t GpuAgent::DmaCopyOnEngine(void* dst, core::Agent& dst_agent,
 
   // engine_offset is an index into blits_, not an SDMA engine count. blits_ is
   // always sized DefaultBlitCount + num_p2p_engines_, so BlitHostToDev(1) and
-  // BlitDevToHost(2) are valid everywhere regardless of how many SDMA engines
-  // engines it has. Limiting against the engine count instead rejected BlitDevToHost
+  // BlitDevToHost(2) are valid everywhere, regardless of how many SDMA engines
+  // it has. Bounding by the engine count instead rejected BlitDevToHost
   // whenever NumSdmaEngines == 1 (e.g. gfx1151).
   if (engine_offset < 0 || engine_offset >= static_cast<int>(blits_.size())) {
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;


### PR DESCRIPTION
## Motivation

Fix Unit_hipMemcpyBatchAsync_D2H_Functional test failures on Strixhalo.

## Technical Details

Correct the engine_offset checks for APUs like Strixhalo which has only 1 SDMA engine.  Also, adds the fallback shader copy path for ReadBufferBatch and WriteBufferBatch (in CLR) similar to CopyBufferBatch so that copy goes through when there is an issue reported in ROCr.

## Issue Tracking

 GitHub issue: https://github.com/ROCm/TheRock/issues/5514


## Test Plan

Run Unit_hipMemcpyBatchAsync_D2H_Functional (along with other batch memcpy tests) on Strixhalo.

## Test Result

PASS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
