### PR TITLE
fix(rccl): adjust single-node reduceScatter threshold for gfx950

### DIFF
--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -93,9 +93,14 @@ void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, s
     // Change LL protocol threshold
     info->protocol = NCCL_PROTO_LL;
   } else if (!userProtocolInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") &&
-             comm->nNodes == 1 && (info->func == ncclFuncReduceScatter) && sizePerRank <= 131072) {
+             comm->nNodes == 1 && (info->func == ncclFuncReduceScatter) && sizePerRank <= 1048576) {
+#ifdef ENABLE_WARP_SPEED
+    if (sizePerRank <=  131072)
+#endif
+    {
     // Change LL protocol threshold
     info->protocol = NCCL_PROTO_LL;
+    }
   } else if (!userProtocolInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") &&
              comm->nNodes == 1 && (info->func == ncclFuncReduceScatter) && sizePerRank <= 352128) {
     // Change LL protocol threshold


### PR DESCRIPTION
## Motivation

Single-node ReduceScatter threshold for LL protocol had been adjusted to accommodate default warpSpeed enablement on gfx950. Without this adjustment, there was performance regression that resulted from utilizing fewer CUs. 
However, if rccl was built without warpSpeed enablement, the warpSpeed based LL threshold caused regressions.

## Technical Details

Threshold value for LL protocol is now different when warpSpeed is enabled vs disabled.

## Issue Tracking

JIRA ID : AICOMRCCL-1644

## Test Plan

gfx950

## Test Result

Correct protocol selection with and without warpSpeed. 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
