### PR TITLE
fix(simdojo): drop from the barrier when exiting after a phase

### DIFF
--- a/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
+++ b/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
@@ -298,8 +298,15 @@ void SimulationEngine::worker_loop(PartitionID partition_id) {
       // Phase 4: Barrier (completion function computes new global_lbts).
       barrier_->arrive_and_wait();
       if (done_.load(std::memory_order_acquire)) {
-        // After arrive_and_wait, if done_ was set by the completion function,
-        // ALL threads see it simultaneously and ALL exit.
+        // When the completion function sets done_, every thread observes it
+        // here and they all exit together. request_exit() can also set it from
+        // an unrelated thread at any instant, in which case threads released
+        // from this same phase may disagree: one still reads false, loops, and
+        // commits to the next arrive_and_wait(). Drop rather than plain return,
+        // so a thread leaving now cannot strand that one at a phase whose
+        // expected count still counts us.
+        ctx.local_next.store(TICK_MAX, std::memory_order_relaxed);
+        barrier_->arrive_and_drop();
         return;
       }
     }


### PR DESCRIPTION
## Motivation

`TerminationTest.RequestExitWakesAllPartitions` intermittently times out in the sanitizer CI jobs, hanging with no test output and burning ctest's full 1500 s timeout. It is a deadlock in the simdojo simulation engine, not a test problem.

Observed on PR #9370, which touches only `config/checkpoint.cpp` and `tests/config_test.cpp` — nothing under `simdojo`. Both `test (asan-ubsan)` and `test (asan-ubsan-gcc)` failed there on this single test:

```
The following tests FAILED:
	320 - TerminationTest.RequestExitWakesAllPartitions (Timeout)
```

## Technical Details

The multi-threaded LBTS worker loop in `lib/simdojo/src/simulation.cpp` can leave in three places. Two of them observe `done_` *before* arriving at the barrier and correctly call `arrive_and_drop()`, permanently lowering the expected count:

- the check at the top of the loop iteration
- the check inside the event-processing loop

The third, immediately after `barrier_->arrive_and_wait()`, returned without arriving or dropping. Its comment justified that:

> After arrive_and_wait, if done_ was set by the completion function, ALL threads see it simultaneously and ALL exit.

That reasoning is sound for `barrier_completion()`, which runs while every thread is parked inside the barrier — all threads are released after the store and all observe it.

It does not hold for `SimulationEngine::request_exit()`, which stores `done_` from an unrelated thread at an arbitrary instant. Threads released from the *same* barrier phase can then disagree about what they read:

- thread A reads `done_ == false`, loops around, and commits to `arrive_and_wait()` for phase N+1
- threads B, C, D read `done_ == true` and return, never arriving and never dropping

Phase N+1 still requires every thread to arrive, so A blocks forever, `run()` never returns, and the test's `runner.join()` hangs.

This change drops instead of returning, matching the other two exit paths. Publishing `TICK_MAX` for `local_next` first keeps a final completion function from computing a global LBTS out of a stale value. `set_exit()` is first-writer-wins, so the `EXIT_REQUEST` recorded by `request_exit()` still survives a subsequent `COMPLETED`.

### Why only the sanitizer jobs see it

The bug is a genuine lost-drop deadlock, not sanitizer-specific — the sanitizers only supply the timing that opens the window.

`TerminationTest.RequestExitWakesAllPartitions` runs the engine with `max_ticks = 500` and calls `request_exit()` after 50 ms. On an unloaded machine those 500 ticks complete in well under 50 ms, so the exit request arrives *after* `run()` has already returned via the `max_ticks` path in `check_termination()`, and the racing code is never reached. Under ASan/UBSan instrumentation, with the rest of the suite running in parallel, the run is still in progress at the 50 ms mark, `request_exit()` lands mid-phase, and the divergent-observation window opens.

## Issue Tracking

N/A

## Test Plan

The stock test cannot reproduce this on demand for the reason above, so the engine was driven directly: a four-partition `InfiniteComponent` harness built against `lib/simdojo/src/*.cpp` with `-fsanitize=address,undefined`, using `max_ticks = 50000` so the run outlasts the 50 ms exit request. 20 runs of each build, 25 s timeout per run.

Then the full CI suite on the branch this fix was validated on.

## Test Result

Harness, against the real engine:

| build | deadlocked |
| --- | --- |
| before | 11 / 20 |
| after | 0 / 20 |

CI (run 30386461067), both previously-failing jobs green with the test running by name:

```
Test #320: TerminationTest.RequestExitWakesAllPartitions ... Passed
100% tests passed, 0 tests failed out of 2113   (asan-ubsan)
100% tests passed, 0 tests failed out of 2107   (asan-ubsan-gcc)
```

Test totals are unchanged from the failing run, so nothing was filtered out to reach green. `test (release)` and `test (tsan)` also stayed green. `test (asan-ubsan)` additionally dropped from 30m12s to 11m26s, which is the 1500 s timeout no longer being spent on the hung test.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
