### PR TITLE
[rocjitsu] Make gfx1250 B0-to-A0 translation idempotent

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -67,7 +67,12 @@ jobs:
       matrix:
         include:
           - name: release
-            allow_failure: true
+            allow_failure: false
+            # 20,000 verified objects completed in 148.97s locally; 20 minutes
+            # leaves substantial runner headroom while this release-only gate lands.
+            verify_dbt_idempotence: 1
+            dbt_timeout: 60
+            dbt_job_timeout: 20
             test_regex: ''
             build_type: Release
             enable_asan: 0
@@ -77,6 +82,11 @@ jobs:
             sanitizer_runtime: STATIC
           - name: asan-ubsan
             allow_failure: true
+            # Keep the first corpus gate on the fastest lane. Focused second-pass
+            # paths remain covered by the sanitizer test suite.
+            verify_dbt_idempotence: 0
+            dbt_timeout: 90
+            dbt_job_timeout: 30
             test_regex: ''
             build_type: RelWithDebInfo
             enable_asan: 1
@@ -86,6 +96,9 @@ jobs:
             sanitizer_runtime: SHARED
           - name: tsan
             allow_failure: false
+            verify_dbt_idempotence: 0
+            dbt_timeout: 30
+            dbt_job_timeout: 20
             run_static_asan_launch: true
             test_regex: ''
             build_type: RelWithDebInfo
@@ -96,6 +109,9 @@ jobs:
             sanitizer_runtime: SHARED
           - name: asan-ubsan-gcc
             allow_failure: true
+            verify_dbt_idempotence: 0
+            dbt_timeout: 90
+            dbt_job_timeout: 30
             test_regex: ''
             build_type: RelWithDebInfo
             enable_asan: 1
@@ -348,11 +364,20 @@ jobs:
 
       - name: Run gfx1250 DBT corpus tests
         if: ${{ !cancelled() && matrix.enable_tsan == 0 && steps.extract_dbt.outcome == 'success' }}
-        timeout-minutes: ${{ matrix.enable_asan == 1 && 30 || 20 }}
+        timeout-minutes: ${{ matrix.dbt_job_timeout }}
         working-directory: ${{ env.ROCJITSU_DBT_CORPUS_DIR }}
         shell: bash
         run: |
           DBT_ROCM_PATH="$("${ROCJITSU_DBT_VENV}/bin/rocm-sdk" path --root)"
+          DBT_TRANSLATOR_BINARY="${ROCJITSU_BUILD_DIR}/tools/rj_dbt_translate"
+          DBT_TRANSLATOR="${DBT_TRANSLATOR_BINARY}"
+          if [[ "${{ matrix.verify_dbt_idempotence }}" == "1" ]]; then
+            DBT_TRANSLATOR="${RUNNER_TEMP}/rj_dbt_translate-verify-idempotence"
+            printf '#!/usr/bin/env bash\nexec %q --verify-idempotence "$@"\n' \
+              "${DBT_TRANSLATOR_BINARY}" \
+              > "${DBT_TRANSLATOR}"
+            chmod +x "${DBT_TRANSLATOR}"
+          fi
           DBT_WORKERS="$(nproc)"
           if (( DBT_WORKERS > 16 )); then
             DBT_WORKERS=16
@@ -361,13 +386,13 @@ jobs:
             --target gfx1250 \
             --suite dbt \
             --dbt-corpus "${ROCJITSU_HSACO_CORPUS}" \
-            --dbt-translator "${ROCJITSU_BUILD_DIR}/tools/rj_dbt_translate" \
+            --dbt-translator "${DBT_TRANSLATOR}" \
             --dbt-llvm-objdump "${DBT_ROCM_PATH}/lib/llvm/bin/llvm-objdump" \
             --dbt-package-lock "${ROCJITSU_SOURCE_DIR}/tests/corpus/dbt/gfx1250_20260726_package_lock.json" \
             --dbt-expected-failures "${ROCJITSU_SOURCE_DIR}/tests/corpus/dbt/gfx1250_b0_a0_expected_failures.json" \
             --dbt-expected-rewrites "${ROCJITSU_SOURCE_DIR}/tests/corpus/dbt/gfx1250_b0_a0_expected_rewrites.json" \
             --dbt-allow-incomplete-corpus \
-            --dbt-timeout "${{ matrix.enable_asan == 1 && 90 || 30 }}" \
+            --dbt-timeout "${{ matrix.dbt_timeout }}" \
             --artifact-directory .pytest-artifacts/gfx1250-dbt \
             -n "${DBT_WORKERS}" \
             -q \

--- a/emulation/rocjitsu/docs/rj_dbt_translate.md
+++ b/emulation/rocjitsu/docs/rj_dbt_translate.md
@@ -96,6 +96,19 @@ verification fail. A failure does not by itself mean that the first output is
 invalid; it means the translation is not a byte-level fixed point. This mode is
 intended to expose such instability while developing or auditing the translator.
 
+### Generated Artifact Markers
+
+Translated control-flow artifacts use `s_nop` immediates `0x1250` and `0x1251`
+to mark canonical long transfers and branch-island pools. These values belong
+to DBT's reserved marker range. A marker word alone is never authoritative:
+recognition also validates the complete instruction sequence, decoded CFG
+adjacency, and artifact-specific bounds before preserving generated code.
+
+Add any future marker through the shared range constants in
+`kernel_text_layout.h`, give it a canonical structural recognizer, and add
+near-miss tests proving that marker-shaped guest instructions are not accepted
+on their own.
+
 ## Diff Mode
 
 `diff` mode is the primary debugging mode. It prints a compact translation

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -98,6 +98,45 @@ LegalizationLookupFn select_legalization(rj_code_arch_t guest, rj_code_arch_t ho
   return word;
 }
 
+[[nodiscard]] std::unordered_set<uint64_t>
+generated_branch_island_pool_offsets(std::span<const uint8_t> text, rj_code_arch_t arch) {
+  std::unordered_set<uint64_t> offsets;
+  auto decoder = Decoder::create(arch);
+  if (!decoder)
+    return offsets;
+
+  const uint32_t marker = build_s_nop(kBranchIslandPoolMarkerNopImmediate, arch);
+  const uint32_t skip_pool =
+      build_s_branch(static_cast<int16_t>(kDirectBranchIslandPoolSlots), arch);
+  constexpr uint64_t kPoolBytes = (kGeneratedIslandPoolHeaderWords + kDirectBranchIslandPoolSlots) *
+                                  static_cast<uint64_t>(sizeof(uint32_t));
+  for (uint64_t offset = 0;
+       offset + kGeneratedIslandPoolHeaderWords * sizeof(uint32_t) <= text.size();
+       offset += sizeof(uint32_t)) {
+    if (text_word_at(text, offset) != marker ||
+        text_word_at(text, offset + sizeof(uint32_t)) != skip_pool || text.size() < kPoolBytes ||
+        offset > text.size() - kPoolBytes) {
+      continue;
+    }
+
+    bool has_canonical_slots = true;
+    for (uint16_t slot = 0; slot < kDirectBranchIslandPoolSlots; ++slot) {
+      const uint64_t slot_offset =
+          offset + (kGeneratedIslandPoolHeaderWords + slot) * sizeof(uint32_t);
+      uint32_t slot_word = text_word_at(text, slot_offset);
+      std::unique_ptr<Instruction> slot_inst(decoder->decode(&slot_word));
+      if (!slot_inst || slot_inst->size() != static_cast<int>(sizeof(uint32_t)) ||
+          slot_inst->mnemonic() != "s_branch" || !slot_inst->branch_offset_bytes()) {
+        has_canonical_slots = false;
+        break;
+      }
+    }
+    if (has_canonical_slots)
+      offsets.insert(offset);
+  }
+  return offsets;
+}
+
 [[nodiscard]] bool words_changed(std::span<const uint32_t> before,
                                  std::span<const uint32_t> after) {
   if (before.size() != after.size())
@@ -1151,6 +1190,9 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                  "code object does not expose a non-empty .text section for translation");
     return leave_unchanged();
   }
+  std::unordered_set<uint64_t> generated_island_pool_candidates;
+  if (guest_arch_ == host_arch_)
+    generated_island_pool_candidates = generated_branch_island_pool_offsets(text, guest_arch_);
 
   // DBT relocates instructions within .text (compaction, expansion, per-kernel
   // block placement) but does not rewrite relocation places that land inside
@@ -1709,19 +1751,119 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       liveness = LivenessAnalysis(KernelBlockScope(scope.blocks), liveness_options, liveness_edges);
     }
 
+    std::unordered_map<uint64_t, const Instruction *> source_instruction_by_offset;
+    std::unordered_map<uint64_t, const BasicBlock *> source_block_by_end_offset;
+    for (BasicBlock *block : scope.blocks) {
+      for (const Instruction &inst : block->instructions())
+        source_instruction_by_offset.emplace(inst.src_loc(), &inst);
+      source_block_by_end_offset.emplace(block->end_offset(), block);
+    }
+
+    // Raw marker bytes are only candidates. Preserve a pool for this kernel
+    // when either its marker and skip are adjacent decoded instructions in this
+    // CFG scope, a reachable private slot proves that the kernel uses it, or a
+    // reachable direct branch immediately before the pool skips exactly to the
+    // first instruction after it. The latter two forms cover used and unused
+    // pools whose headers became unreachable after relocation. Candidate
+    // discovery already proved that every private slot is a one-word direct
+    // branch; requiring reachable code here rejects marker-shaped literal data
+    // and keeps preservation local to the kernel that owns the generated pool.
+    constexpr uint64_t kGeneratedIslandPoolWords =
+        kGeneratedIslandPoolHeaderWords + kDirectBranchIslandPoolSlots;
+    constexpr uint64_t kGeneratedIslandPoolBytes =
+        kGeneratedIslandPoolWords * static_cast<uint64_t>(sizeof(uint32_t));
+    std::unordered_set<uint64_t> generated_island_pool_offsets;
+    std::unordered_map<uint64_t, uint64_t> generated_island_pool_by_source_offset;
+    if (guest_arch_ == host_arch_) {
+      for (const uint64_t pool_offset : generated_island_pool_candidates) {
+        const auto marker_it = source_instruction_by_offset.find(pool_offset);
+        const auto skip_it = source_instruction_by_offset.find(pool_offset + sizeof(uint32_t));
+        bool reachable_header = false;
+        if (marker_it != source_instruction_by_offset.end() &&
+            skip_it != source_instruction_by_offset.end()) {
+          const Instruction *marker = marker_it->second;
+          const Instruction *skip = skip_it->second;
+          const auto skip_delta = skip->branch_offset_bytes();
+          reachable_header =
+              marker->size() == static_cast<int>(sizeof(uint32_t)) &&
+              marker->raw_encoding() != nullptr &&
+              marker->raw_encoding()[0] ==
+                  build_s_nop(kBranchIslandPoolMarkerNopImmediate, guest_arch_) &&
+              marker->next_instruction() == skip &&
+              skip->size() == static_cast<int>(sizeof(uint32_t)) &&
+              skip->raw_encoding() != nullptr &&
+              skip->raw_encoding()[0] ==
+                  build_s_branch(static_cast<int16_t>(kDirectBranchIslandPoolSlots), guest_arch_) &&
+              skip_delta &&
+              pool_offset + kGeneratedIslandPoolHeaderWords * sizeof(uint32_t) +
+                      static_cast<uint64_t>(*skip_delta) ==
+                  pool_offset + kGeneratedIslandPoolBytes;
+        }
+
+        bool reachable_slot = false;
+        for (uint64_t word_index = kGeneratedIslandPoolHeaderWords;
+             word_index < kGeneratedIslandPoolWords; ++word_index) {
+          const uint64_t source_offset = pool_offset + word_index * sizeof(uint32_t);
+          if (source_instruction_by_offset.contains(source_offset)) {
+            reachable_slot = true;
+            break;
+          }
+        }
+        const uint64_t pool_end = pool_offset + kGeneratedIslandPoolBytes;
+        const auto preceding_block_it = source_block_by_end_offset.find(pool_offset);
+        const BasicBlock *preceding_block = preceding_block_it == source_block_by_end_offset.end()
+                                                ? nullptr
+                                                : preceding_block_it->second;
+        const Instruction *preceding_terminator =
+            preceding_block == nullptr ? nullptr : preceding_block->terminator();
+        int64_t preceding_branch_target = -1;
+        if (preceding_terminator != nullptr) {
+          if (const auto delta = preceding_terminator->branch_offset_bytes()) {
+            preceding_branch_target = static_cast<int64_t>(preceding_terminator->src_loc() +
+                                                           preceding_terminator->size()) +
+                                      static_cast<int64_t>(*delta);
+          }
+        }
+        const bool reachable_skip_over_pool =
+            preceding_terminator != nullptr && preceding_terminator->mnemonic() == "s_branch" &&
+            source_instruction_by_offset.contains(pool_end) && preceding_branch_target >= 0 &&
+            static_cast<uint64_t>(preceding_branch_target) == pool_end;
+        if (!reachable_header && !reachable_slot && !reachable_skip_over_pool)
+          continue;
+
+        generated_island_pool_offsets.insert(pool_offset);
+        for (uint64_t word_index = 0; word_index < kGeneratedIslandPoolWords; ++word_index) {
+          generated_island_pool_by_source_offset.emplace(
+              pool_offset + word_index * sizeof(uint32_t), pool_offset);
+        }
+        if (!reachable_header && !reachable_slot)
+          generated_island_pool_by_source_offset.emplace(pool_end, pool_offset);
+      }
+    }
+    // A recognized pool comes from an already translated body. Reuse that
+    // deterministic grid instead of appending another set on the verification
+    // pass. If preserved capacity is insufficient after an unexpected body
+    // change, relocation fails closed; fixed-size pool slots are not widened.
+    const bool preserve_generated_branch_island_pools = !generated_island_pool_offsets.empty();
+
     // Phase 4: translate each relocated body instruction at the current cursor.
     // Return-like s_setpc_b64 instructions are accepted only when they are the
     // terminator of a block reached from a validated call edge in this
     // kernel-local scope. Recovered indirect setpc/swappc consumers reserve a
-    // fixed maximum-size window when recovery proves one effective target. When
-    // one dynamic consumer has multiple recovered targets, no single direct
-    // window can preserve semantics; DBT keeps the original indirect consumer
-    // and asks the patch layer to rewrite each source-side PC builder once.
+    // compact window when recovery proves one effective target. A
+    // marked long direct transfer generated by an earlier pass is instead
+    // preserved as one exact getpc-through-consumer window. When one dynamic
+    // consumer has multiple recovered targets, no single direct window can
+    // preserve semantics; DBT keeps the original indirect consumer and asks the
+    // patch layer to rewrite each source-side PC builder once.
     const std::unordered_set<uint64_t> valid_call_return_offsets =
         scoped_call_return_offsets(KernelBlockScope(scope.blocks), text);
     struct RecoveredConsumer {
       std::vector<IndirectCallFixup> fixups;
       bool use_transfer_window = false;
+      bool preserve_marked_long_transfer = false;
+      uint64_t marked_window_begin = 0;
+      uint64_t marked_window_end = 0;
       IndirectCallFixup window_fixup;
     };
     std::unordered_map<uint64_t, RecoveredConsumer> recovered_indirect_by_call;
@@ -1807,12 +1949,65 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         continue;
       }
 
-      // A complete consumer with one effective target can become a direct window.
-      // A complete multi-target consumer keeps the dynamic consumer and rewrites
-      // each source-side builder (relocation/liveness).
+      // A complete consumer with one effective target can become a direct
+      // window. Preserve a translator-generated long direct transfer as one
+      // marked source window so a repeated pass cannot wrap its setpc/swappc
+      // consumer a second time. A complete multi-target consumer keeps the
+      // dynamic consumer and rewrites each source-side builder
+      // (relocation/liveness).
       if (single_effective_target) {
-        consumer.use_transfer_window = true;
         consumer.window_fixup = first;
+        const bool contiguous_builder =
+            consumer.fixups.size() == 1 && first.source_getpc_offset >= sizeof(uint32_t) &&
+            first.source_recovery_begin_offset == first.source_getpc_offset + sizeof(uint32_t) &&
+            first.source_recovery_end_offset == first.source_call_offset &&
+            first.source_call_offset <= text.size() &&
+            sizeof(uint32_t) <= text.size() - first.source_call_offset;
+        const auto getpc_it = source_instruction_by_offset.find(first.source_getpc_offset);
+        const Instruction *getpc =
+            getpc_it == source_instruction_by_offset.end() ? nullptr : getpc_it->second;
+        const Instruction *marker = getpc == nullptr ? nullptr : getpc->previous_instruction();
+        const auto call_it = source_instruction_by_offset.find(first.source_call_offset);
+        const Instruction *call =
+            call_it == source_instruction_by_offset.end() ? nullptr : call_it->second;
+        const bool has_interior_block_entry =
+            std::ranges::any_of(scope.blocks, [&](const BasicBlock *candidate) {
+              return candidate->start_offset() > first.source_getpc_offset &&
+                     candidate->start_offset() < first.source_call_offset;
+            });
+        const auto builder_block_it =
+            std::ranges::find_if(scope.blocks, [&](const BasicBlock *candidate) {
+              return candidate->start_offset() <= first.source_getpc_offset &&
+                     candidate->end_offset() == first.source_call_offset;
+            });
+        const auto call_block_it =
+            std::ranges::find_if(scope.blocks, [&](const BasicBlock *candidate) {
+              return candidate->start_offset() == first.source_call_offset;
+            });
+        // Recovered consumers are block leaders by construction, so their
+        // canonical fallthrough block is expected. Reject only an additional
+        // CFG predecessor that can enter at the consumer and bypass the builder.
+        const bool has_external_call_entry =
+            builder_block_it == scope.blocks.end() || call_block_it == scope.blocks.end() ||
+            std::ranges::any_of(
+                (*call_block_it)->predecessors(),
+                [&](const BasicBlock *predecessor) { return predecessor != *builder_block_it; });
+        const bool canonical_marked_window =
+            contiguous_builder && marker != nullptr &&
+            marker->size() == static_cast<int>(sizeof(uint32_t)) &&
+            marker->src_loc() + sizeof(uint32_t) == first.source_getpc_offset &&
+            marker->raw_encoding() != nullptr &&
+            marker->raw_encoding()[0] ==
+                build_s_nop(kLongDirectBranchMarkerNopImmediate, guest_arch_) &&
+            call != nullptr && call->size() == static_cast<int>(sizeof(uint32_t)) &&
+            !has_interior_block_entry && !has_external_call_entry;
+        if (canonical_marked_window) {
+          consumer.preserve_marked_long_transfer = true;
+          consumer.marked_window_begin = marker->src_loc();
+          consumer.marked_window_end = first.source_call_offset + sizeof(uint32_t);
+        } else {
+          consumer.use_transfer_window = true;
+        }
       } else {
         pending_builder_fixups.insert(pending_builder_fixups.end(), consumer.fixups.begin(),
                                       consumer.fixups.end());
@@ -1831,6 +2026,13 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                                     whole_scope_builder_fixups->end());
     }
 
+    std::unordered_map<uint64_t, const RecoveredConsumer *> marked_long_transfer_by_start;
+    for (const auto &[source_call_offset, consumer] : recovered_indirect_by_call) {
+      (void)source_call_offset;
+      if (consumer.preserve_marked_long_transfer)
+        marked_long_transfer_by_start.emplace(consumer.marked_window_begin, &consumer);
+    }
+
     std::vector<uint8_t> kernel_text;
     std::vector<PendingTrace> pending_traces;
     uint64_t source_body_size = 0;
@@ -1847,18 +2049,164 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     layout.body_begin = 0;
     layout.blocks.reserve(scope.blocks.size());
     uint64_t next_branch_island_pool_offset = first_direct_branch_island_pool_offset();
+    struct ActiveMarkedLongTransfer {
+      uint64_t source_end = 0;
+    };
+    std::optional<ActiveMarkedLongTransfer> active_marked_long_transfer;
+    struct ActiveGeneratedIslandPool {
+      uint64_t source_begin = 0;
+      uint64_t source_end = 0;
+      uint64_t target_begin = 0;
+    };
+    std::optional<ActiveGeneratedIslandPool> active_generated_island_pool;
+    // reachable_kernel_blocks() materializes reached indices in source order.
+    // Pool preservation relies on that ordering while one copied pool spans
+    // several reachable slot blocks.
+    assert(std::ranges::is_sorted(scope.blocks, [](const BasicBlock *lhs, const BasicBlock *rhs) {
+      return lhs->start_offset() < rhs->start_offset();
+    }));
     for (BasicBlock *block : scope.blocks) {
+      std::optional<ActiveGeneratedIslandPool> block_generated_island_pool;
+      if (active_generated_island_pool &&
+          block->start_offset() < active_generated_island_pool->source_end) {
+        block_generated_island_pool = active_generated_island_pool;
+      }
+      const uint64_t block_target_start =
+          block_generated_island_pool
+              ? block_generated_island_pool->target_begin +
+                    (block->start_offset() - block_generated_island_pool->source_begin)
+              : kernel_text.size();
       BlockPlacement placement{.block = block,
                                .source_start = block->start_offset(),
                                .source_end = block->end_offset(),
-                               .target_start = kernel_text.size(),
-                               .target_end = kernel_text.size()};
+                               .target_start = block_target_start,
+                               .target_end = block_target_start};
 
       for (auto it = block->instructions().begin(); it != block->instructions().end(); ++it) {
         const auto &inst = *it;
         const uint64_t offset = inst.src_loc();
-        const uint64_t target_offset = kernel_text.size();
+        uint64_t target_offset = kernel_text.size();
         const uint32_t inst_size = inst.size();
+
+        if (active_generated_island_pool && offset < active_generated_island_pool->source_end)
+          continue;
+        active_generated_island_pool.reset();
+
+        if (const auto pool_it = generated_island_pool_by_source_offset.find(offset);
+            pool_it != generated_island_pool_by_source_offset.end()) {
+          const uint64_t pool_offset = pool_it->second;
+          const uint64_t source_end = pool_offset + kGeneratedIslandPoolBytes;
+          const bool source_instruction_in_pool = offset < source_end;
+          // Candidate qualification already bounds the complete pool.
+          assert(source_end <= text.size());
+          for (uint64_t word_index = kGeneratedIslandPoolHeaderWords;
+               word_index < kGeneratedIslandPoolWords; ++word_index) {
+            const uint64_t source_branch_offset = pool_offset + word_index * sizeof(uint32_t);
+            const auto source_branch_it = source_instruction_by_offset.find(source_branch_offset);
+            // Unused placeholder slots are unreachable and absent from this
+            // scope. Make those slots available to repair any new layout drift;
+            // an unused slot remains s_branch 0 when no fixup allocates it.
+            if (source_branch_it == source_instruction_by_offset.end()) {
+              layout.branch_island_slots.push_back(target_offset + word_index * sizeof(uint32_t));
+              continue;
+            }
+            const Instruction *source_branch = source_branch_it->second;
+            const auto source_branch_delta = source_branch->branch_offset_bytes();
+            assert(source_branch->raw_encoding() != nullptr && source_branch_delta &&
+                   "candidate qualification proved every generated pool slot");
+            if (source_branch->raw_encoding() == nullptr || !source_branch_delta) {
+              auto failure = make_kernel_failure(
+                  DiagnosticKind::Legalization,
+                  "generated direct branch island pool contains malformed live slot",
+                  source_branch_offset);
+              if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
+                                      text_relocations_begin, data_relocations_begin)) {
+                skip_scope = true;
+                break;
+              }
+              return leave_unchanged();
+            }
+            const int64_t source_target =
+                static_cast<int64_t>(source_branch_offset + sizeof(uint32_t)) +
+                static_cast<int64_t>(*source_branch_delta);
+            if (source_target < 0 || static_cast<uint64_t>(source_target) > text.size()) {
+              auto failure = make_kernel_failure(
+                  DiagnosticKind::Legalization,
+                  "generated direct branch island pool targets outside source .text",
+                  source_branch_offset);
+              if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
+                                      text_relocations_begin, data_relocations_begin)) {
+                skip_scope = true;
+                break;
+              }
+              return leave_unchanged();
+            }
+            layout.branch_fixups.push_back(
+                {.inst = source_branch,
+                 .source_inst_offset = source_branch_offset,
+                 .source_target_offset = static_cast<uint64_t>(source_target),
+                 .target_inst_offset = target_offset + word_index * sizeof(uint32_t),
+                 .target_window_bytes = sizeof(uint32_t),
+                 .allow_window_growth = false,
+                 .translated_words = {source_branch->raw_encoding()[0]}});
+          }
+          if (skip_scope)
+            break;
+          for (uint64_t source_word = pool_offset; source_word < source_end;
+               source_word += sizeof(uint32_t)) {
+            target_offset_by_source_offset.emplace(source_word,
+                                                   target_offset + (source_word - pool_offset));
+          }
+          kernel_text.insert(kernel_text.end(),
+                             text.begin() + static_cast<std::ptrdiff_t>(pool_offset),
+                             text.begin() + static_cast<std::ptrdiff_t>(source_end));
+          if (source_instruction_in_pool) {
+            active_generated_island_pool = {
+                .source_begin = pool_offset,
+                .source_end = source_end,
+                .target_begin = target_offset,
+            };
+            block_generated_island_pool = active_generated_island_pool;
+            if (block->start_offset() >= pool_offset) {
+              placement.target_start = target_offset + (block->start_offset() - pool_offset);
+            }
+            continue;
+          }
+          placement.target_start = kernel_text.size();
+          target_offset = kernel_text.size();
+        }
+
+        if (active_marked_long_transfer && offset < active_marked_long_transfer->source_end) {
+          // The patch layer regenerates the marked window, so its interior
+          // source instructions have no stable one-to-one target offsets.
+          if (offset + inst_size >= active_marked_long_transfer->source_end)
+            active_marked_long_transfer.reset();
+          continue;
+        }
+        active_marked_long_transfer.reset();
+
+        if (const auto marked = marked_long_transfer_by_start.find(offset);
+            marked != marked_long_transfer_by_start.end()) {
+          const RecoveredConsumer &consumer = *marked->second;
+          const IndirectCallFixup &source_fixup = consumer.window_fixup;
+          const uint64_t window_bytes = consumer.marked_window_end - consumer.marked_window_begin;
+          target_offset_by_source_offset.emplace(offset, target_offset);
+          layout.recovered_indirect_fixups.push_back(
+              {.source_call_offset = source_fixup.source_call_offset,
+               .source_target_offset = source_fixup.source_target_offset,
+               .target_window_offset = target_offset,
+               .target_window_bytes = window_bytes,
+               .target_sreg = source_fixup.source_call_sreg,
+               .return_sreg = source_fixup.source_return_sreg,
+               .is_call = source_fixup.source_is_call,
+               .preserve_marked_long_transfer = true});
+          append_nop_padding(kernel_text, window_bytes, host_arch_);
+          active_marked_long_transfer = {
+              .source_end = consumer.marked_window_end,
+          };
+          continue;
+        }
+
         // Ask the semantic translator directly whether this instruction has an
         // expand rule. The previous positional cursor into live_before_instructions
         // silently depended on that vector being built in the exact same block/
@@ -1904,10 +2252,11 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           // Record direct branches while emitting the body, but patch only after
           // every block has a final target placement. This keeps fallthrough
           // implicit and limits fixups to explicit PC-relative edges. Emit the
-          // branch into a fixed-size patch window. Kernels with a legal
-          // descriptor-backed SGPR pair reserve the long form up front; kernels
-          // already at the SGPR allocation limit keep compact branch slots so
-          // DBT does not create artificial range pressure it cannot repair.
+          // branch into an initially compact patch window. Kernels with a legal
+          // descriptor-backed SGPR pair can grow that window later if the final
+          // target moves out of range; kernels already at the SGPR allocation
+          // limit grow only an out-of-range conditional into the two-word
+          // SGPR-free island form.
           const int64_t source_target =
               static_cast<int64_t>(offset + inst_size) + static_cast<int64_t>(*direct_branch_delta);
           if (source_target < 0) {
@@ -1929,14 +2278,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
             }
             return leave_unchanged();
           }
-          const uint64_t branch_window_bytes = direct_branch_patch_window_bytes(
-              inst, offset, static_cast<uint64_t>(source_target), can_use_long_direct_branches);
-          layout.branch_fixups.push_back(
-              {.inst = &inst,
-               .source_inst_offset = offset,
-               .source_target_offset = static_cast<uint64_t>(source_target),
-               .target_inst_offset = target_offset,
-               .target_window_bytes = branch_window_bytes});
+          const uint64_t branch_window_bytes = initial_direct_branch_patch_window_bytes(inst);
 
           if (!inst.raw_encoding()) {
             auto failure = make_kernel_failure(DiagnosticKind::Legalization,
@@ -1956,13 +2298,19 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           bool copied_original = false;
           bool changed = false;
           std::vector<uint32_t> target_words;
-          if (!handle_encoding(inst, offset, kernel_text, branch_dst_opcode, text,
-                               trace_callback_ != nullptr, copied_original, changed,
-                               target_words)) {
+          if (!handle_encoding(inst, offset, kernel_text, branch_dst_opcode, text, true,
+                               copied_original, changed, target_words)) {
             if (continue_after_instruction_error(inst, offset, kernel_text, pending_traces))
               continue;
             return leave_unchanged();
           }
+          layout.branch_fixups.push_back(
+              {.inst = &inst,
+               .source_inst_offset = offset,
+               .source_target_offset = static_cast<uint64_t>(source_target),
+               .target_inst_offset = target_offset,
+               .target_window_bytes = branch_window_bytes,
+               .translated_words = target_words});
           append_nop_padding(kernel_text, branch_window_bytes - inst.size(), host_arch_);
           queue_trace(pending_traces, inst, offset, branch_leg, copied_original, false, changed,
                       target_offset, std::move(target_words));
@@ -1978,8 +2326,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                .target_sreg = source_fixup.source_call_sreg,
                .return_sreg = source_fixup.source_return_sreg,
                .is_call = source_fixup.source_is_call});
-          append_nop_padding(kernel_text, kMaxRecoveredIndirectTransferWords * sizeof(uint32_t),
-                             host_arch_);
+          append_nop_padding(kernel_text, sizeof(uint32_t), host_arch_);
           continue;
         }
 
@@ -2152,11 +2499,16 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         const uint32_t endpgm = build_s_endpgm(host_arch_);
         append_words(kernel_text, std::span<const uint32_t>(&endpgm, 1));
       }
-      placement.target_end = kernel_text.size();
+      placement.target_end =
+          block_generated_island_pool &&
+                  block->end_offset() <= block_generated_island_pool->source_end
+              ? block_generated_island_pool->target_begin +
+                    (block->end_offset() - block_generated_island_pool->source_begin)
+              : kernel_text.size();
       layout.blocks.push_back(placement);
-      target_offset_by_source_offset.emplace(block->end_offset(), kernel_text.size());
-      if (!can_use_long_direct_branches && block != scope.blocks.back() &&
-          kernel_text.size() >= next_branch_island_pool_offset) {
+      target_offset_by_source_offset.emplace(block->end_offset(), placement.target_end);
+      if (!can_use_long_direct_branches && !preserve_generated_branch_island_pools &&
+          block != scope.blocks.back() && kernel_text.size() >= next_branch_island_pool_offset) {
         append_direct_branch_island_pool(kernel_text, layout, host_arch_);
         next_branch_island_pool_offset = next_direct_branch_island_pool_offset(kernel_text.size());
       }
@@ -2195,6 +2547,143 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     if (skip_scope)
       continue;
 
+    // Resolve control flow against the kernel-local body before materializing
+    // it in the output section. Direct and recovered-indirect transfers both
+    // start compact. If final placement proves a long transfer is required,
+    // grow all requested windows in one rebuild and retry. Insertions can move a
+    // later transfer across the range boundary, so repeat until the monotonic
+    // layout is fixed.
+    const auto patch_control_flow = [&]() {
+      TextRelocationResult patched = patch_direct_branch_fixups(kernel_text, layout, host_arch_);
+      if (!patched.ok)
+        return patched;
+      return patch_recovered_indirect_fixups(kernel_text, layout, host_arch_);
+    };
+    TextRelocationResult patched_control_flow = patch_control_flow();
+    constexpr uint64_t kDirectGrowthWords = kMaxDirectBranchTransferWords - 1;
+    constexpr uint64_t kRecoveredGrowthWords = kMaxRecoveredIndirectTransferWords - 1;
+    // Each fixup grows monotonically and is capped at its format-specific
+    // maximum. Its cumulative growth is therefore bounded by the maximum minus
+    // the one-word initial window, no matter how many rounds request it. The sum
+    // below is a proof-sized convergence budget. Exhaustion or an invalid
+    // request is not constructible from a valid code object; keep the runtime
+    // checks fail-closed against future patcher changes.
+    uint64_t remaining_growth_words = 0;
+    if (layout.branch_fixups.size() > std::numeric_limits<uint64_t>::max() / kDirectGrowthWords ||
+        layout.recovered_indirect_fixups.size() >
+            std::numeric_limits<uint64_t>::max() / kRecoveredGrowthWords) {
+      remaining_growth_words = std::numeric_limits<uint64_t>::max();
+    } else {
+      const uint64_t direct_words = layout.branch_fixups.size() * kDirectGrowthWords;
+      const uint64_t recovered_words =
+          layout.recovered_indirect_fixups.size() * kRecoveredGrowthWords;
+      remaining_growth_words = direct_words > std::numeric_limits<uint64_t>::max() - recovered_words
+                                   ? std::numeric_limits<uint64_t>::max()
+                                   : direct_words + recovered_words;
+    }
+    while (!patched_control_flow.ok) {
+      if (patched_control_flow.reason != TextLayoutFailureReason::BranchOutOfRange)
+        break;
+
+      if (!patched_control_flow.required_windows.empty()) {
+        uint64_t requested_growth_words = 0;
+        bool valid_growth_budget = true;
+        for (const ControlFlowWindowRequirement &requirement :
+             patched_control_flow.required_windows) {
+          uint64_t current_window_bytes = 0;
+          uint64_t maximum_window_bytes = 0;
+          if (requirement.kind == ControlFlowWindowKind::DirectBranch) {
+            const auto fixup =
+                std::ranges::find_if(layout.branch_fixups, [&](const BranchFixup &candidate) {
+                  return candidate.source_inst_offset == requirement.source_inst_offset;
+                });
+            if (fixup == layout.branch_fixups.end()) {
+              valid_growth_budget = false;
+              break;
+            }
+            current_window_bytes = fixup->target_window_bytes;
+            maximum_window_bytes = kMaxDirectBranchTransferWords * sizeof(uint32_t);
+          } else {
+            const auto fixup = std::ranges::find_if(
+                layout.recovered_indirect_fixups, [&](const RecoveredIndirectFixup &candidate) {
+                  return candidate.source_call_offset == requirement.source_inst_offset;
+                });
+            if (fixup == layout.recovered_indirect_fixups.end()) {
+              valid_growth_budget = false;
+              break;
+            }
+            current_window_bytes = fixup->target_window_bytes;
+            maximum_window_bytes = kMaxRecoveredIndirectTransferWords * sizeof(uint32_t);
+          }
+          if (requirement.required_window_bytes <= current_window_bytes ||
+              requirement.required_window_bytes > maximum_window_bytes) {
+            valid_growth_budget = false;
+            break;
+          }
+          requested_growth_words +=
+              (requirement.required_window_bytes - current_window_bytes) / sizeof(uint32_t);
+        }
+        if (!valid_growth_budget || requested_growth_words > remaining_growth_words) {
+          patched_control_flow = {
+              .ok = false,
+              .failure = TextLayoutFailureCategory::InvalidLayout,
+              .source_offset = patched_control_flow.source_offset,
+              .required_windows = {},
+              .message = "control-flow layout growth did not converge",
+          };
+          break;
+        }
+
+        const auto insertions = grow_control_flow_windows(
+            kernel_text, layout, patched_control_flow.required_windows, host_arch_);
+        if (!insertions) {
+          patched_control_flow = {
+              .ok = false,
+              .failure = TextLayoutFailureCategory::InvalidLayout,
+              .source_offset = patched_control_flow.source_offset,
+              .required_windows = {},
+              .message = "control-flow layout returned an invalid growth request",
+          };
+          break;
+        }
+        for (auto &[source_offset, target_offset] : target_offset_by_source_offset) {
+          (void)source_offset;
+          rebase_text_offset(target_offset, *insertions);
+        }
+        for (PendingTrace &trace : pending_traces)
+          rebase_text_offset(trace.target_offset, *insertions);
+        remaining_growth_words -= requested_growth_words;
+      } else if (!layout.long_branch_sgpr) {
+        auto sgpr = reserve_long_branch_sgpr_pair(kernel_context);
+        if (!sgpr)
+          break;
+        layout.long_branch_sgpr = *sgpr;
+      } else {
+        break;
+      }
+
+      patched_control_flow = patch_control_flow();
+    }
+    if (!patched_control_flow.ok) {
+      auto failure =
+          make_kernel_failure(relocation_diagnostic_kind(patched_control_flow),
+                              patched_control_flow.message, patched_control_flow.source_offset);
+      if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
+                              text_relocations_begin, data_relocations_begin))
+        continue;
+      return leave_unchanged();
+    }
+
+    if (auto patched = patch_recovered_builder_fixups(kernel_text, layout, host_arch_);
+        !patched.ok) {
+      auto failure = make_kernel_failure(relocation_diagnostic_kind(patched), patched.message,
+                                         patched.source_offset, "indirect branch");
+      if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
+                              text_relocations_begin, data_relocations_begin))
+        continue;
+      return leave_unchanged();
+    }
+
     auto materialized =
         append_relocated_kernel_text(translated_text, layout, kernel_text, host_arch_);
     if (!materialized.ok) {
@@ -2227,47 +2716,6 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           {.target_getpc_offset = getpc->second + target_delta,
            .target_literal_offset = add->second + target_delta + sizeof(uint32_t),
            .source_target_vaddr = dispatch.source_table_address_vaddr});
-    }
-
-    // Phase 5: now that every emitted source block has a final target offset,
-    // patch explicit direct branches, recovered source-side builders, and
-    // recovered indirect transfer windows.
-    auto patched_direct_branches = patch_direct_branch_fixups(translated_text, layout, host_arch_);
-    if (!patched_direct_branches.ok &&
-        patched_direct_branches.reason == TextLayoutFailureReason::BranchOutOfRange) {
-      if (auto sgpr = reserve_long_branch_sgpr_pair(kernel_context)) {
-        layout.long_branch_sgpr = *sgpr;
-        patched_direct_branches = patch_direct_branch_fixups(translated_text, layout, host_arch_);
-      }
-    }
-    if (!patched_direct_branches.ok) {
-      auto failure = make_kernel_failure(relocation_diagnostic_kind(patched_direct_branches),
-                                         patched_direct_branches.message,
-                                         patched_direct_branches.source_offset);
-      if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                              text_relocations_begin, data_relocations_begin))
-        continue;
-      return leave_unchanged();
-    }
-
-    if (auto patched = patch_recovered_builder_fixups(translated_text, layout, host_arch_);
-        !patched.ok) {
-      auto failure = make_kernel_failure(relocation_diagnostic_kind(patched), patched.message,
-                                         patched.source_offset, "indirect branch");
-      if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                              text_relocations_begin, data_relocations_begin))
-        continue;
-      return leave_unchanged();
-    }
-
-    if (auto patched = patch_recovered_indirect_fixups(translated_text, layout, host_arch_);
-        !patched.ok) {
-      auto failure = make_kernel_failure(relocation_diagnostic_kind(patched), patched.message,
-                                         patched.source_offset, "indirect branch");
-      if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                              text_relocations_begin, data_relocations_begin))
-        continue;
-      return leave_unchanged();
     }
 
     if (kernel_context.required_vgpr_count > kernel_context.num_vgprs)
@@ -2423,20 +2871,20 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
 
 bool BinaryTranslator::handle_encoding(const Instruction &inst, uint64_t offset,
                                        std::vector<uint8_t> &text, uint16_t dst_opcode,
-                                       std::span<const uint8_t> orig_text, bool collect_trace_words,
-                                       bool &copied_original, bool &changed,
-                                       std::vector<uint32_t> &target_words) {
+                                       std::span<const uint8_t> orig_text,
+                                       bool collect_target_words, bool &copied_original,
+                                       bool &changed, std::vector<uint32_t> &target_words) {
   const uint32_t *raw = inst.raw_encoding();
   assert(raw && "handle_encoding called without raw encoding");
   copied_original = false;
   changed = false;
-  if (collect_trace_words)
+  if (collect_target_words)
     target_words.clear();
 
   if (!encoding_translate_) {
     copied_original = true;
     const size_t word_count = inst.size() / sizeof(uint32_t);
-    if (collect_trace_words)
+    if (collect_target_words)
       target_words.assign(raw, raw + word_count);
     append_words(text, std::span<const uint32_t>(raw, word_count));
     return true;
@@ -2451,7 +2899,7 @@ bool BinaryTranslator::handle_encoding(const Instruction &inst, uint64_t offset,
   if (tr.word_count == 0) {
     copied_original = true;
     const size_t word_count = inst.size() / sizeof(uint32_t);
-    if (collect_trace_words)
+    if (collect_target_words)
       target_words.assign(raw, raw + word_count);
     append_words(text, std::span<const uint32_t>(raw, word_count));
     return true;
@@ -2473,7 +2921,7 @@ bool BinaryTranslator::handle_encoding(const Instruction &inst, uint64_t offset,
   }
 
   append_words(text, std::span<const uint32_t>(tr.words, tr.word_count));
-  if (collect_trace_words) {
+  if (collect_target_words) {
     target_words.assign(tr.words, tr.words + tr.word_count);
     changed = words_changed(raw_words_for_inst(inst), target_words);
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.h
@@ -209,7 +209,7 @@ private:
   /// @returns true if the instruction was translated or copied safely.
   [[nodiscard]] bool handle_encoding(const Instruction &inst, uint64_t offset,
                                      std::vector<uint8_t> &text, uint16_t dst_opcode,
-                                     std::span<const uint8_t> orig_text, bool collect_trace_words,
+                                     std::span<const uint8_t> orig_text, bool collect_target_words,
                                      bool &copied_original, bool &changed,
                                      std::vector<uint32_t> &target_words);
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -329,15 +329,60 @@ ExpandResult expand_gfx1250_ds2(const Instruction &inst, uint32_t, uint64_t,
   return ExpandResult::success(std::move(words));
 }
 
+/// @brief Canonical save/clear/restore words emitted around one tensor load.
+struct TensorMaskWrapper {
+  uint32_t save = 0;
+  uint32_t clear = 0;
+  uint32_t restore = 0;
+};
+
+/// @brief Build the canonical descriptor-mask clear word.
+[[nodiscard]] uint32_t build_tensor_mask_clear(uint8_t descriptor_base) {
+  return gfx1250::build_sop2(
+      gfx1250::kSPackHhB32B16Sop2,
+      {.ssrc0 = kGfx1250InlineZero, .ssrc1 = descriptor_base, .sdst = descriptor_base})[0];
+}
+
+/// @brief Build the canonical save/clear/restore words around one tensor load.
+[[nodiscard]] TensorMaskWrapper build_tensor_mask_wrapper(uint8_t descriptor_base,
+                                                          uint8_t scratch) {
+  return {
+      .save = gfx1250::build_sop1(gfx1250::kSMovB32Sop1,
+                                  {.ssrc0 = descriptor_base, .sdst = scratch})[0],
+      .clear = build_tensor_mask_clear(descriptor_base),
+      .restore = gfx1250::build_sop1(gfx1250::kSMovB32Sop1,
+                                     {.ssrc0 = scratch, .sdst = descriptor_base})[0],
+  };
+}
+
+/// @brief Check for one exact, contiguous predecessor in the same basic block.
+[[nodiscard]] bool has_canonical_predecessor(const Instruction &inst, uint32_t expected_word) {
+  const Instruction *previous = inst.previous_instruction();
+  return previous != nullptr && previous->size() == static_cast<int>(sizeof(uint32_t)) &&
+         previous->src_loc() + sizeof(uint32_t) == inst.src_loc() &&
+         previous->raw_encoding() != nullptr && previous->raw_encoding()[0] == expected_word;
+}
+
+/// @brief Check whether every path to a tensor load executes the canonical mask clear.
+[[nodiscard]] bool has_tensor_mask_clear(const Instruction &inst, uint8_t descriptor_base) {
+  return has_canonical_predecessor(inst, build_tensor_mask_clear(descriptor_base));
+}
+
 /// @brief Disable Tensor-DMA multicast for one A0 tensor load.
 ///
 /// @details TENSOR_LOAD_TO_LDS does not encode multicast in the instruction.
 /// Descriptor group 1 bits [15:0], held in the first SGPR named by VADDR1,
-/// select the workgroups which receive a multicast load.  On A0 those bits
-/// must therefore be cleared for every tensor load; inspecting only the
-/// instruction cannot prove that the runtime descriptor mask is zero.
-/// Preserve the guest descriptor value around the load because later tensor
-/// instructions commonly reuse and update the same descriptor.
+/// select the workgroups which receive a multicast load. On A0 those bits must
+/// therefore be cleared for every tensor load; inspecting only the instruction
+/// cannot prove that the runtime descriptor mask is zero. Preserve the guest
+/// descriptor value around the load because later tensor instructions commonly
+/// reuse and update the same descriptor.
+///
+/// A second translation preserves the load when its immediately preceding
+/// decoded instruction in the same basic block is the canonical mask clear.
+/// This proves that no control-flow edge can bypass the clear. The clear
+/// instruction currently has no B0-to-A0 semantic rule and is copied unchanged;
+/// this reuse condition must be revisited if such a rule is added.
 ExpandResult expand_gfx1250_tensor_load_to_lds(const Instruction &inst, uint32_t, uint64_t,
                                                std::span<const uint8_t>,
                                                const LivenessAnalysis &liveness,
@@ -360,6 +405,12 @@ ExpandResult expand_gfx1250_tensor_load_to_lds(const Instruction &inst, uint32_t
         {"Provide TENSOR_LOAD_TO_LDS VADDR1 as an ordinary eight-SGPR descriptor."});
   }
 
+  if (has_tensor_mask_clear(inst, descriptor_base)) {
+    return ExpandResult::success(std::vector<uint32_t>(
+        inst.raw_encoding(),
+        inst.raw_encoding() + sizeof(gfx1250::VimageMachineInst) / sizeof(uint32_t)));
+  }
+
   const std::optional<uint16_t> scratch = liveness.find_free_sgpr(&inst);
   if (!scratch || *scratch > kLastOrdinarySgpr) {
     return ExpandResult::failed(
@@ -369,19 +420,15 @@ ExpandResult expand_gfx1250_tensor_load_to_lds(const Instruction &inst, uint32_t
 
   std::vector<uint32_t> words;
   words.reserve(6);
-  append_words(
-      words, gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = descriptor_base,
-                                                         .sdst = static_cast<uint8_t>(*scratch)}));
+  const TensorMaskWrapper wrapper =
+      build_tensor_mask_wrapper(descriptor_base, static_cast<uint8_t>(*scratch));
+  words.push_back(wrapper.save);
   // PACK_HH forms {SRC1[31:16], SRC0[31:16]}. Inline zero as SRC0 clears
   // D1[15:0] while preserving all descriptor fields in D1[31:16].
-  append_words(words, gfx1250::build_sop2(
-                          gfx1250::kSPackHhB32B16Sop2,
-                          {.ssrc0 = 128, .ssrc1 = descriptor_base, .sdst = descriptor_base}));
+  words.push_back(wrapper.clear);
   words.insert(words.end(), inst.raw_encoding(),
                inst.raw_encoding() + sizeof(gfx1250::VimageMachineInst) / sizeof(uint32_t));
-  append_words(words,
-               gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = static_cast<uint8_t>(*scratch),
-                                                           .sdst = descriptor_base}));
+  words.push_back(wrapper.restore);
   return ExpandResult::success(std::move(words));
 }
 
@@ -894,9 +941,11 @@ ExpandResult expand_gfx1250_wmma_scale16(const Instruction &inst, uint32_t, uint
 ///
 /// @details gfx1250 requires nine separating V_NOPs when dense IU8 WMMA feeds a
 /// following XDL matrix input, and five for sparse IU8 SWMMAC. These bounds also
-/// cover their shorter WMMA-to-VALU hazard windows. This temporary local
-/// lowering does not inspect following control-flow successors, so it appends
-/// the full instruction-family bound unconditionally.
+/// cover their shorter WMMA-to-VALU hazard windows. Count exact canonical V_NOPs
+/// already following the instruction in the same basic block and append only
+/// the missing slots. Limiting credit to the block guarantees that every
+/// credited word remains adjacent after layout. Noncanonical NOPs and following
+/// control-flow successors conservatively receive no credit.
 ExpandResult expand_gfx1250_wmma_iu8_spacing(const Instruction &inst, uint32_t, uint64_t,
                                              std::span<const uint8_t>, const LivenessAnalysis &,
                                              TranslationContext &, const LaneLayout *,
@@ -910,10 +959,20 @@ ExpandResult expand_gfx1250_wmma_iu8_spacing(const Instruction &inst, uint32_t, 
   std::vector<uint32_t> words(inst.raw_encoding(),
                               inst.raw_encoding() + inst.size() / sizeof(uint32_t));
   const int required_slots = inst.mnemonic() == "v_wmma_i32_16x16x64_iu8" ? 9 : 5;
-  // TODO: Replace fixed padding with a whole-kernel lookahead that counts
-  // existing V_NOPs/independent VALU and inserts exactly the required slots.
-  for (int slot = 0; slot < required_slots; ++slot)
-    append_words(words, gfx1250::build_vop1(gfx1250::kVNopVop1));
+  const uint32_t v_nop = gfx1250::build_vop1(gfx1250::kVNopVop1)[0];
+  int existing_slots = 0;
+  const Instruction *next = inst.next_instruction();
+  while (existing_slots < required_slots && next != nullptr &&
+         next->size() == static_cast<int>(sizeof(uint32_t)) && next->raw_encoding() != nullptr &&
+         next->raw_encoding()[0] == v_nop) {
+    ++existing_slots;
+    next = next->next_instruction();
+  }
+
+  // TODO: Replace canonical V_NOP counting with whole-kernel scheduling that
+  // can also credit independent VALU in each reachable successor.
+  for (int slot = existing_slots; slot < required_slots; ++slot)
+    words.push_back(v_nop);
   return ExpandResult::success(std::move(words));
 }
 
@@ -934,12 +993,24 @@ ExpandResult expand_gfx1250_wmma_iu8_spacing(const Instruction &inst, uint32_t, 
   }
 }
 
+/// @brief Build the canonical M0 = 0 word emitted before a cluster load.
+[[nodiscard]] constexpr uint32_t build_cluster_m0_clear() {
+  return gfx1250::build_sop1(gfx1250::kSMovB32Sop1,
+                             {.ssrc0 = kGfx1250InlineZero, .sdst = kGfx1250M0})[0];
+}
+
 /// @brief Rewrite a gfx1250 cluster load to run with M0 = 0.
 ///
 /// @details Every cluster-load form (both SADDR and off/NULL-saddr, all widths)
 /// is left as a cluster load and wrapped so it executes with M0 forced to zero:
 /// save M0 to a dead SGPR, set M0 = 0, run the load, then restore M0. The opcode
 /// is not changed.
+///
+/// A second translation preserves the load when its immediately preceding
+/// decoded instruction in the same basic block is the canonical M0 clear. This
+/// proves that no control-flow edge can bypass the clear. The clear instruction
+/// currently has no B0-to-A0 semantic rule and is copied unchanged; this reuse
+/// condition must be revisited if such a rule is added.
 ExpandResult expand_gfx1250_cluster_load(const Instruction &inst, uint32_t, uint64_t,
                                          std::span<const uint8_t>, const LivenessAnalysis &liveness,
                                          TranslationContext &, const LaneLayout *,
@@ -947,6 +1018,11 @@ ExpandResult expand_gfx1250_cluster_load(const Instruction &inst, uint32_t, uint
   if (!is_gfx1250_cluster_load(inst.opcode()) ||
       inst.size() != 3 * static_cast<int>(sizeof(uint32_t)) || inst.raw_encoding() == nullptr) {
     return ExpandResult::failed("gfx1250 cluster-load rule received an unsupported instruction");
+  }
+
+  if (has_canonical_predecessor(inst, build_cluster_m0_clear())) {
+    return ExpandResult::success(
+        std::vector<uint32_t>(inst.raw_encoding(), inst.raw_encoding() + 3));
   }
 
   const std::optional<uint16_t> scratch = liveness.find_free_sgpr(&inst);
@@ -962,14 +1038,12 @@ ExpandResult expand_gfx1250_cluster_load(const Instruction &inst, uint32_t, uint
   // Inline constant 0 encodes as 128 in a scalar source. Every M0 reference here
   // MUST use kGfx1250M0 (125): on gfx1250 M0 encodes as 125 and NULL as 124 (the
   // inverse of CDNA), so a write to 124 would be a discarded NULL write.
-  constexpr uint8_t kInlineZero = 128;
   std::vector<uint32_t> words;
   words.reserve(6);
   append_words(words,
                gfx1250::build_sop1(gfx1250::kSMovB32Sop1,
                                    {.ssrc0 = kGfx1250M0, .sdst = static_cast<uint8_t>(*scratch)}));
-  append_words(words, gfx1250::build_sop1(gfx1250::kSMovB32Sop1,
-                                          {.ssrc0 = kInlineZero, .sdst = kGfx1250M0}));
+  words.push_back(build_cluster_m0_clear());
   words.insert(words.end(), inst.raw_encoding(), inst.raw_encoding() + 3);
   append_words(words,
                gfx1250::build_sop1(gfx1250::kSMovB32Sop1,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.cpp
@@ -21,18 +21,15 @@ namespace rocjitsu {
 namespace {
 
 constexpr uint64_t kKernargPreloadSkipBytes = 256;
-constexpr uint64_t kDirectBranchIslandSpacingBytes = 64 * 1024;
-constexpr uint16_t kDirectBranchIslandPoolSlots = 16;
-/// @brief Source-distance cutoff for reserving a long direct-branch window.
-///
-/// @details The largest current gfx1250 semantic replacement grows a 16-byte
-/// Scale16 WMMA to at most 272 bytes (17x, including VGPR-MSB mode changes).
-/// Four KiB of maximally dense expansion remains comfortably below the 128 KiB
-/// signed SOPP reach after accounting for branch windows and island pools,
-/// while genuinely close branches keep compact slots. The production NVFP4
-/// branch which exposed this limit spans 5,568 bytes and is conservatively
-/// assigned a long window by this threshold.
-constexpr uint64_t kLongDirectBranchSourceDistanceThresholdBytes = 4 * 1024;
+// SOPP reaches almost 128 KiB in either direction, and a branch-island chain
+// keeps each hop within a 64 KiB safety interval. Pools are placed before
+// control-flow windows grow. A dense interval of recovered indirect consumers
+// or direct branches can grow to their respective maximum transfer widths.
+// An 8 KiB grid remains within the 64 KiB interval under either bound.
+constexpr uint64_t kDirectBranchIslandSpacingBytes = 8 * 1024;
+static_assert(kDirectBranchIslandSpacingBytes *
+                  std::max(kMaxRecoveredIndirectTransferWords, kMaxDirectBranchTransferWords) <=
+              64 * 1024);
 } // namespace
 
 [[nodiscard]] TextRelocationResult relocation_ok() { return {}; }
@@ -45,6 +42,7 @@ relocation_error(uint64_t source_offset, std::string message,
           .failure = failure,
           .reason = reason,
           .source_offset = source_offset,
+          .required_windows = {},
           .message = std::move(message)};
 }
 
@@ -331,17 +329,25 @@ KernelTextAppendResult append_relocated_kernel_text(std::vector<uint8_t> &transl
 [[nodiscard]] bool append_recovered_indirect_sequence(std::vector<uint32_t> &words,
                                                       const RecoveredIndirectFixup &fixup,
                                                       uint64_t target_offset, rj_code_arch_t arch) {
-  if (const auto direct_simm =
-          compute_sopp_branch_simm16(fixup.target_window_offset, target_offset)) {
-    if (fixup.is_call)
-      words.push_back(build_s_call_b64(fixup.return_sreg, *direct_simm, arch));
-    else
-      words.push_back(build_s_branch(*direct_simm, arch));
-    return true;
+  if (!fixup.preserve_marked_long_transfer) {
+    if (const auto direct_simm =
+            compute_sopp_branch_simm16(fixup.target_window_offset, target_offset)) {
+      if (fixup.is_call)
+        words.push_back(build_s_call_b64(fixup.return_sreg, *direct_simm, arch));
+      else
+        words.push_back(build_s_branch(*direct_simm, arch));
+      return true;
+    }
   }
 
+  // Every long recovered transfer carries the same non-padding marker. A later
+  // pass can then preserve the exact window even if CFG compaction has brought
+  // its target back within direct SOPP range.
+  words.push_back(build_s_nop(kLongDirectBranchMarkerNopImmediate, arch));
+  const uint64_t sequence_offset = fixup.target_window_offset + sizeof(uint32_t);
+
   constexpr uint64_t kMaxSigned = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
-  if (fixup.target_window_offset > kMaxSigned - sizeof(uint32_t) || target_offset > kMaxSigned)
+  if (sequence_offset > kMaxSigned - sizeof(uint32_t) || target_offset > kMaxSigned)
     return false;
 
   // The long form intentionally rebuilds the final translated target in the same
@@ -349,7 +355,7 @@ KernelTextAppendResult append_relocated_kernel_text(std::vector<uint8_t> &transl
   // address builder may still execute, but this sequence overwrites the pair
   // immediately before the actual control transfer.
   words.push_back(build_s_getpc_b64(fixup.target_sreg, arch));
-  const int64_t base = static_cast<int64_t>(fixup.target_window_offset + sizeof(uint32_t));
+  const int64_t base = static_cast<int64_t>(sequence_offset + sizeof(uint32_t));
   const int64_t delta = static_cast<int64_t>(target_offset) - base;
   if (!append_pc_delta_builder(words, arch, fixup.target_sreg, delta))
     return false;
@@ -357,7 +363,7 @@ KernelTextAppendResult append_relocated_kernel_text(std::vector<uint8_t> &transl
     words.push_back(build_s_swappc_b64(fixup.return_sreg, fixup.target_sreg, arch));
   else
     words.push_back(build_s_setpc_b64(fixup.target_sreg, arch));
-  return words.size() <= kMaxRecoveredIndirectTransferWords;
+  return true;
 }
 
 [[nodiscard]] bool append_long_pc_transfer(std::vector<uint32_t> &words, rj_code_arch_t arch,
@@ -391,35 +397,144 @@ KernelTextAppendResult append_relocated_kernel_text(std::vector<uint8_t> &transl
          mnemonic == "s_cbranch_execz" || mnemonic == "s_cbranch_execnz";
 }
 
-[[nodiscard]] uint64_t absolute_branch_distance(uint64_t source_inst_offset,
-                                                uint64_t source_target_offset) {
-  return source_inst_offset < source_target_offset ? source_target_offset - source_inst_offset
-                                                   : source_inst_offset - source_target_offset;
+uint64_t initial_direct_branch_patch_window_bytes(const Instruction &inst) { return inst.size(); }
+
+void rebase_text_offset(uint64_t &offset, std::span<const TextLayoutInsertion> insertions) {
+  assert(std::ranges::is_sorted(
+      insertions, {}, [](const TextLayoutInsertion &insertion) { return insertion.offset; }));
+  const uint64_t original_offset = offset;
+  for (const TextLayoutInsertion &insertion : insertions) {
+    if (original_offset < insertion.offset)
+      break;
+    offset += insertion.size;
+  }
 }
 
-uint64_t direct_branch_patch_window_bytes(const Instruction &inst, uint64_t source_inst_offset,
-                                          uint64_t source_target_offset,
-                                          bool can_use_long_direct_branches) {
-  const bool speculate_long_branch =
-      absolute_branch_distance(source_inst_offset, source_target_offset) >
-      kLongDirectBranchSourceDistanceThresholdBytes;
-  const bool invertible_conditional =
-      (inst.flags() & COND_BRANCH) != 0 && conditional_branch_can_invert(inst.mnemonic());
-  if (can_use_long_direct_branches && speculate_long_branch)
-    return kMaxDirectBranchTransferWords * sizeof(uint32_t);
+std::optional<std::vector<TextLayoutInsertion>>
+grow_control_flow_windows(std::vector<uint8_t> &text, KernelTextLayout &layout,
+                          std::span<const ControlFlowWindowRequirement> requirements,
+                          rj_code_arch_t arch) {
+  struct ValidatedGrowth {
+    ControlFlowWindowKind kind = ControlFlowWindowKind::DirectBranch;
+    size_t fixup_index = 0;
+    uint64_t required_window_bytes = 0;
+    TextLayoutInsertion insertion;
+  };
 
-  // Conditional branches need a two-word source window for the SGPR-free
-  // branch-island form: invert the condition to skip over an unconditional
-  // branch into the island chain. Keep this policy beside the actual patcher
-  // support check so the translator only reserves windows the patch layer owns.
-  //
-  // A source-near branch can still move out of SOPP range when many instructions
-  // in the intervening region expand. The long-window threshold above leaves
-  // enough headroom for the largest current Scale16 WMMA expansion.
-  if (invertible_conditional)
-    return 2 * sizeof(uint32_t);
+  std::vector<ValidatedGrowth> growths;
+  growths.reserve(requirements.size());
+  uint64_t total_insertion_bytes = 0;
+  for (const ControlFlowWindowRequirement &requirement : requirements) {
+    size_t fixup_index = 0;
+    uint64_t target_window_offset = 0;
+    uint64_t target_window_bytes = 0;
+    if (requirement.kind == ControlFlowWindowKind::DirectBranch) {
+      const auto selected =
+          std::ranges::find_if(layout.branch_fixups, [&](const BranchFixup &fixup) {
+            return fixup.source_inst_offset == requirement.source_inst_offset;
+          });
+      if (selected == layout.branch_fixups.end())
+        return std::nullopt;
+      if (!selected->allow_window_growth)
+        return std::nullopt;
+      fixup_index = static_cast<size_t>(std::distance(layout.branch_fixups.begin(), selected));
+      target_window_offset = selected->target_inst_offset;
+      target_window_bytes = selected->target_window_bytes;
+    } else {
+      const auto selected = std::ranges::find_if(
+          layout.recovered_indirect_fixups, [&](const RecoveredIndirectFixup &fixup) {
+            return fixup.source_call_offset == requirement.source_inst_offset;
+          });
+      if (selected == layout.recovered_indirect_fixups.end())
+        return std::nullopt;
+      fixup_index =
+          static_cast<size_t>(std::distance(layout.recovered_indirect_fixups.begin(), selected));
+      target_window_offset = selected->target_window_offset;
+      target_window_bytes = selected->target_window_bytes;
+    }
 
-  return inst.size();
+    if (target_window_bytes == 0 || target_window_bytes % sizeof(uint32_t) != 0 ||
+        requirement.required_window_bytes <= target_window_bytes ||
+        requirement.required_window_bytes % sizeof(uint32_t) != 0 ||
+        target_window_offset > text.size() ||
+        target_window_bytes > text.size() - target_window_offset)
+      return std::nullopt;
+
+    if (std::ranges::any_of(growths, [&](const ValidatedGrowth &growth) {
+          return growth.kind == requirement.kind && growth.fixup_index == fixup_index;
+        }))
+      return std::nullopt;
+
+    const uint64_t insertion_offset = target_window_offset + target_window_bytes;
+    const uint64_t insertion_size = requirement.required_window_bytes - target_window_bytes;
+    if (insertion_offset > text.size() ||
+        insertion_size > std::numeric_limits<size_t>::max() - text.size() ||
+        total_insertion_bytes >
+            static_cast<uint64_t>(std::numeric_limits<size_t>::max()) - insertion_size)
+      return std::nullopt;
+
+    total_insertion_bytes += insertion_size;
+    growths.push_back({.kind = requirement.kind,
+                       .fixup_index = fixup_index,
+                       .required_window_bytes = requirement.required_window_bytes,
+                       .insertion = {.offset = insertion_offset, .size = insertion_size}});
+  }
+
+  if (total_insertion_bytes >
+      static_cast<uint64_t>(std::numeric_limits<size_t>::max() - text.size()))
+    return std::nullopt;
+
+  std::ranges::sort(growths, {},
+                    [](const ValidatedGrowth &growth) { return growth.insertion.offset; });
+  for (size_t i = 1; i < growths.size(); ++i) {
+    if (growths[i - 1].insertion.offset >= growths[i].insertion.offset)
+      return std::nullopt;
+  }
+
+  std::vector<uint8_t> grown_text;
+  grown_text.reserve(text.size() + static_cast<size_t>(total_insertion_bytes));
+  uint64_t copied_until = 0;
+  std::vector<TextLayoutInsertion> insertions;
+  insertions.reserve(growths.size());
+  for (const ValidatedGrowth &growth : growths) {
+    const TextLayoutInsertion insertion = growth.insertion;
+    grown_text.insert(grown_text.end(), text.begin() + static_cast<std::ptrdiff_t>(copied_until),
+                      text.begin() + static_cast<std::ptrdiff_t>(insertion.offset));
+    append_nop_padding(grown_text, insertion.size, arch);
+    copied_until = insertion.offset;
+    insertions.push_back(insertion);
+  }
+  grown_text.insert(grown_text.end(), text.begin() + static_cast<std::ptrdiff_t>(copied_until),
+                    text.end());
+
+  for (const ValidatedGrowth &growth : growths) {
+    if (growth.kind == ControlFlowWindowKind::DirectBranch) {
+      layout.branch_fixups[growth.fixup_index].target_window_bytes = growth.required_window_bytes;
+    } else {
+      layout.recovered_indirect_fixups[growth.fixup_index].target_window_bytes =
+          growth.required_window_bytes;
+    }
+  }
+
+  for (BlockPlacement &block : layout.blocks) {
+    rebase_text_offset(block.target_start, insertions);
+    rebase_text_offset(block.target_end, insertions);
+  }
+  for (BranchFixup &fixup : layout.branch_fixups)
+    rebase_text_offset(fixup.target_inst_offset, insertions);
+  for (RecoveredIndirectFixup &fixup : layout.recovered_indirect_fixups)
+    rebase_text_offset(fixup.target_window_offset, insertions);
+  for (IndirectCallFixup &fixup : layout.recovered_builder_fixups) {
+    rebase_text_offset(fixup.target_getpc_offset, insertions);
+    rebase_text_offset(fixup.target_recovery_begin_offset, insertions);
+    rebase_text_offset(fixup.target_recovery_end_offset, insertions);
+  }
+  for (uint64_t &slot : layout.branch_island_slots)
+    rebase_text_offset(slot, insertions);
+  rebase_text_offset(layout.body_end, insertions);
+
+  text = std::move(grown_text);
+  return insertions;
 }
 
 uint64_t first_direct_branch_island_pool_offset() { return kDirectBranchIslandSpacingBytes; }
@@ -430,6 +545,9 @@ uint64_t next_direct_branch_island_pool_offset(uint64_t current_body_size) {
 
 void append_direct_branch_island_pool(std::vector<uint8_t> &kernel_text, KernelTextLayout &layout,
                                       rj_code_arch_t arch) {
+  const uint32_t marker = build_s_nop(kBranchIslandPoolMarkerNopImmediate, arch);
+  append_words(kernel_text, std::span<const uint32_t>(&marker, 1));
+
   const uint64_t skip_offset = kernel_text.size();
   const uint32_t skip_pool =
       build_s_branch(static_cast<int16_t>(kDirectBranchIslandPoolSlots), arch);
@@ -539,17 +657,6 @@ allocate_branch_island_chain(uint64_t branch_pc, uint64_t target_offset,
   return chain;
 }
 
-[[nodiscard]] bool patch_branch_word(std::span<uint8_t> text, uint64_t branch_pc,
-                                     uint64_t target_offset, rj_code_arch_t arch) {
-  const auto simm = compute_sopp_branch_simm16(branch_pc, target_offset);
-  if (!simm || !text_contains_range(text, branch_pc, sizeof(uint32_t)))
-    return false;
-
-  const uint32_t word = build_s_branch(*simm, arch);
-  std::memcpy(text.data() + branch_pc, &word, sizeof(word));
-  return true;
-}
-
 [[nodiscard]] bool append_branch_island_direct_sequence(
     std::vector<uint32_t> &words, const Instruction &inst, uint32_t translated_word,
     uint64_t window_offset, uint64_t window_bytes, uint64_t first_target, rj_code_arch_t arch) {
@@ -579,43 +686,23 @@ allocate_branch_island_chain(uint64_t branch_pc, uint64_t target_offset,
   return true;
 }
 
-[[nodiscard]] bool append_branch_island_sequence(
-    std::vector<uint32_t> &words, std::vector<uint8_t> &text, const BranchFixup &fixup,
-    const Instruction &inst, uint32_t translated_word, uint64_t target_offset, rj_code_arch_t arch,
-    std::span<const uint64_t> island_slots, std::vector<uint8_t> &island_used) {
-  const uint64_t first_branch_pc = (inst.flags() & BRANCH) != 0
-                                       ? fixup.target_inst_offset
-                                       : fixup.target_inst_offset + sizeof(uint32_t);
-  auto chain =
-      allocate_branch_island_chain(first_branch_pc, target_offset, island_slots, island_used);
-  if (!chain || chain->empty())
-    return false;
-
-  if (!append_branch_island_direct_sequence(words, inst, translated_word, fixup.target_inst_offset,
-                                            fixup.target_window_bytes, chain->front(), arch))
-    return false;
-
-  for (size_t i = 0; i < chain->size(); ++i) {
-    const uint64_t next = i + 1 < chain->size() ? (*chain)[i + 1] : target_offset;
-    if (!patch_branch_word(text, (*chain)[i], next, arch))
-      return false;
-  }
-  return true;
-}
-
 [[nodiscard]] bool append_long_direct_branch_sequence(std::vector<uint32_t> &words,
                                                       const Instruction &inst,
                                                       uint32_t translated_word,
                                                       uint64_t window_offset, uint64_t window_bytes,
                                                       uint64_t target_offset, rj_code_arch_t arch,
                                                       uint16_t pc_sreg) {
+  const uint32_t marker = build_s_nop(kLongDirectBranchMarkerNopImmediate, arch);
   if ((inst.flags() & BRANCH) != 0) {
-    return append_long_pc_transfer(words, arch, pc_sreg, window_offset, target_offset,
-                                   std::nullopt);
+    words.push_back(marker);
+    return append_long_pc_transfer(words, arch, pc_sreg, window_offset + sizeof(uint32_t),
+                                   target_offset, std::nullopt);
   }
 
   if (auto call_sdst = direct_call_return_sgpr(inst, translated_word)) {
-    return append_long_pc_transfer(words, arch, pc_sreg, window_offset, target_offset, call_sdst);
+    words.push_back(marker);
+    return append_long_pc_transfer(words, arch, pc_sreg, window_offset + sizeof(uint32_t),
+                                   target_offset, call_sdst);
   }
 
   auto inverted =
@@ -623,14 +710,30 @@ allocate_branch_island_chain(uint64_t branch_pc, uint64_t target_offset,
   if (!inverted)
     return false;
   words.push_back(*inverted);
-  return append_long_pc_transfer(words, arch, pc_sreg, window_offset + sizeof(uint32_t),
+  words.push_back(marker);
+  return append_long_pc_transfer(words, arch, pc_sreg, window_offset + 2 * sizeof(uint32_t),
                                  target_offset, std::nullopt);
 }
 
 TextRelocationResult patch_direct_branch_fixups(std::vector<uint8_t> &text,
                                                 const KernelTextLayout &layout,
                                                 rj_code_arch_t arch) {
+  struct PlannedWindowPatch {
+    uint64_t offset = 0;
+    std::vector<uint32_t> words;
+  };
+  struct PlannedIslandPatch {
+    uint64_t offset = 0;
+    uint32_t word = 0;
+  };
+
   std::vector<uint8_t> branch_island_used(layout.branch_island_slots.size(), 0);
+  std::vector<PlannedWindowPatch> window_patches;
+  window_patches.reserve(layout.branch_fixups.size());
+  std::vector<PlannedIslandPatch> island_patches;
+  TextRelocationResult growth_required = relocation_error(
+      0, "direct branches require wider patch windows", TextLayoutFailureCategory::ResourceLimit,
+      TextLayoutFailureReason::BranchOutOfRange);
 
   for (const BranchFixup &fixup : layout.branch_fixups) {
     auto target_target = target_for_source_offset(layout, fixup.source_target_offset);
@@ -648,6 +751,12 @@ TextRelocationResult patch_direct_branch_fixups(std::vector<uint8_t> &text,
       return relocation_error(fixup.source_inst_offset,
                               "direct branch relocation has malformed patch window");
     }
+    if (fixup.translated_words.size() * sizeof(uint32_t) !=
+        static_cast<size_t>(fixup.inst->size())) {
+      return relocation_error(
+          fixup.source_inst_offset,
+          "direct branch relocation is missing its pristine translated encoding");
+    }
     if (!text_contains_range(text, fixup.target_inst_offset, fixup.target_window_bytes)) {
       return relocation_error(fixup.source_inst_offset,
                               "direct branch relocation points outside translated .text");
@@ -658,20 +767,60 @@ TextRelocationResult patch_direct_branch_fixups(std::vector<uint8_t> &text,
     // coordinates and patch only the immediate bits of the translated branch.
     const int64_t new_delta = static_cast<int64_t>(*target_target) -
                               static_cast<int64_t>(fixup.target_inst_offset + fixup.inst->size());
-    std::vector<uint32_t> words(fixup.inst->size() / sizeof(uint32_t));
-    std::memcpy(words.data(), text.data() + fixup.target_inst_offset, fixup.inst->size());
+    std::vector<uint32_t> words = fixup.translated_words;
     if (!patch_pcrel_branch_offset(*fixup.inst, words, new_delta, arch)) {
       if (!layout.long_branch_sgpr) {
-        std::vector<uint32_t> island_words;
-        if (!append_branch_island_sequence(island_words, text, fixup, *fixup.inst, words.front(),
-                                           *target_target, arch, layout.branch_island_slots,
-                                           branch_island_used)) {
+        const uint64_t first_branch_pc = (fixup.inst->flags() & BRANCH) != 0
+                                             ? fixup.target_inst_offset
+                                             : fixup.target_inst_offset + sizeof(uint32_t);
+        auto chain = allocate_branch_island_chain(first_branch_pc, *target_target,
+                                                  layout.branch_island_slots, branch_island_used);
+        if (!chain || chain->empty()) {
           return relocation_error(
               fixup.source_inst_offset,
               direct_branch_range_error(fixup.target_inst_offset, *target_target, new_delta),
               TextLayoutFailureCategory::ResourceLimit, TextLayoutFailureReason::BranchOutOfRange);
         }
+
+        std::vector<uint32_t> island_words;
+        if (!append_branch_island_direct_sequence(
+                island_words, *fixup.inst, words.front(), fixup.target_inst_offset,
+                fixup.target_window_bytes, chain->front(), arch)) {
+          const bool can_grow_conditional_source =
+              (fixup.inst->flags() & COND_BRANCH) != 0 &&
+              conditional_branch_can_invert(fixup.inst->mnemonic()) &&
+              fixup.target_window_bytes < 2 * sizeof(uint32_t);
+          if (!can_grow_conditional_source) {
+            return relocation_error(
+                fixup.source_inst_offset,
+                "direct branch relocation cannot build SGPR-free island sequence");
+          }
+          if (!fixup.allow_window_growth) {
+            return relocation_error(
+                fixup.source_inst_offset,
+                "fixed-size direct branch window cannot grow for an island sequence",
+                TextLayoutFailureCategory::ResourceLimit,
+                TextLayoutFailureReason::BranchOutOfRange);
+          }
+          if (growth_required.required_windows.empty())
+            growth_required.source_offset = fixup.source_inst_offset;
+          growth_required.required_windows.push_back(
+              {.kind = ControlFlowWindowKind::DirectBranch,
+               .source_inst_offset = fixup.source_inst_offset,
+               .required_window_bytes = 2 * sizeof(uint32_t)});
+          continue;
+        }
         words = std::move(island_words);
+        for (size_t i = 0; i < chain->size(); ++i) {
+          const uint64_t next =
+              i + 1 < chain->size() ? (*chain)[i + 1] : static_cast<uint64_t>(*target_target);
+          const auto simm = compute_sopp_branch_simm16((*chain)[i], next);
+          if (!simm || !text_contains_range(text, (*chain)[i], sizeof(uint32_t))) {
+            return relocation_error(fixup.source_inst_offset,
+                                    "direct branch island patch points outside translated .text");
+          }
+          island_patches.push_back({.offset = (*chain)[i], .word = build_s_branch(*simm, arch)});
+        }
       } else {
         std::vector<uint32_t> long_words;
         if (!append_long_direct_branch_sequence(long_words, *fixup.inst, words.front(),
@@ -681,9 +830,19 @@ TextRelocationResult patch_direct_branch_fixups(std::vector<uint8_t> &text,
                                   "direct branch relocation cannot build long branch sequence");
         }
         if (long_words.size() * sizeof(uint32_t) > fixup.target_window_bytes) {
-          return relocation_error(fixup.source_inst_offset,
-                                  "direct branch long sequence exceeds reserved window",
-                                  TextLayoutFailureCategory::ResourceLimit);
+          if (!fixup.allow_window_growth) {
+            return relocation_error(fixup.source_inst_offset,
+                                    "fixed-size direct branch window cannot grow for a long branch",
+                                    TextLayoutFailureCategory::ResourceLimit,
+                                    TextLayoutFailureReason::BranchOutOfRange);
+          }
+          if (growth_required.required_windows.empty())
+            growth_required.source_offset = fixup.source_inst_offset;
+          growth_required.required_windows.push_back(
+              {.kind = ControlFlowWindowKind::DirectBranch,
+               .source_inst_offset = fixup.source_inst_offset,
+               .required_window_bytes = long_words.size() * sizeof(uint32_t)});
+          continue;
         }
         words = std::move(long_words);
       }
@@ -692,9 +851,19 @@ TextRelocationResult patch_direct_branch_fixups(std::vector<uint8_t> &text,
     std::vector<uint32_t> window_words(fixup.target_window_bytes / sizeof(uint32_t),
                                        build_s_nop(0, arch));
     std::copy(words.begin(), words.end(), window_words.begin());
-    std::memcpy(text.data() + fixup.target_inst_offset, window_words.data(),
-                fixup.target_window_bytes);
+    window_patches.push_back(
+        {.offset = fixup.target_inst_offset, .words = std::move(window_words)});
   }
+
+  if (!growth_required.required_windows.empty())
+    return growth_required;
+
+  for (const PlannedWindowPatch &patch : window_patches) {
+    std::memcpy(text.data() + patch.offset, patch.words.data(),
+                patch.words.size() * sizeof(uint32_t));
+  }
+  for (const PlannedIslandPatch &patch : island_patches)
+    std::memcpy(text.data() + patch.offset, &patch.word, sizeof(patch.word));
 
   return relocation_ok();
 }
@@ -702,7 +871,17 @@ TextRelocationResult patch_direct_branch_fixups(std::vector<uint8_t> &text,
 TextRelocationResult patch_recovered_indirect_fixups(std::vector<uint8_t> &text,
                                                      const KernelTextLayout &layout,
                                                      rj_code_arch_t arch) {
+  struct PlannedWindowPatch {
+    uint64_t offset = 0;
+    std::vector<uint32_t> words;
+  };
+
   std::unordered_map<uint64_t, uint64_t> patched_windows;
+  std::vector<PlannedWindowPatch> window_patches;
+  window_patches.reserve(layout.recovered_indirect_fixups.size());
+  TextRelocationResult growth_required = relocation_error(
+      0, "recovered indirect branches require wider patch windows",
+      TextLayoutFailureCategory::ResourceLimit, TextLayoutFailureReason::BranchOutOfRange);
   for (const RecoveredIndirectFixup &fixup : layout.recovered_indirect_fixups) {
     auto target_target = target_for_source_offset(layout, fixup.source_target_offset);
     if (!target_target) {
@@ -721,9 +900,8 @@ TextRelocationResult patch_recovered_indirect_fixups(std::vector<uint8_t> &text,
       continue;
     }
 
-    constexpr uint64_t kWindowBytes =
-        kMaxRecoveredIndirectTransferWords * static_cast<uint64_t>(sizeof(uint32_t));
-    if (!text_contains_range(text, fixup.target_window_offset, kWindowBytes)) {
+    if (fixup.target_window_bytes == 0 || fixup.target_window_bytes % sizeof(uint32_t) != 0 ||
+        !text_contains_range(text, fixup.target_window_offset, fixup.target_window_bytes)) {
       return relocation_error(fixup.source_call_offset,
                               "recovered indirect branch window points outside translated .text");
     }
@@ -735,21 +913,37 @@ TextRelocationResult patch_recovered_indirect_fixups(std::vector<uint8_t> &text,
           "target ISA cannot encode canonical recovered indirect branch sequence",
           TextLayoutFailureCategory::ResourceLimit);
     }
-    if (words.size() > kMaxRecoveredIndirectTransferWords) {
-      return relocation_error(fixup.source_call_offset,
-                              "recovered indirect branch sequence exceeds reserved window",
-                              TextLayoutFailureCategory::ResourceLimit);
+    if (words.size() * sizeof(uint32_t) > fixup.target_window_bytes) {
+      // The current sequence builder is bounded by this constant. Retain the
+      // check as a fail-closed contract if a future encoding adds words.
+      if (words.size() > kMaxRecoveredIndirectTransferWords) {
+        return relocation_error(fixup.source_call_offset,
+                                "recovered indirect branch sequence exceeds maximum window",
+                                TextLayoutFailureCategory::ResourceLimit);
+      }
+      if (growth_required.required_windows.empty())
+        growth_required.source_offset = fixup.source_call_offset;
+      growth_required.required_windows.push_back(
+          {.kind = ControlFlowWindowKind::RecoveredIndirect,
+           .source_inst_offset = fixup.source_call_offset,
+           .required_window_bytes = words.size() * sizeof(uint32_t)});
+      continue;
     }
 
-    std::memcpy(text.data() + fixup.target_window_offset, words.data(),
-                words.size() * sizeof(uint32_t));
-    const uint32_t nop = build_s_nop(0, arch);
-    for (uint64_t off = fixup.target_window_offset + words.size() * sizeof(uint32_t);
-         off < fixup.target_window_offset + kWindowBytes; off += sizeof(uint32_t)) {
-      std::memcpy(text.data() + off, &nop, sizeof(nop));
-    }
+    std::vector<uint32_t> window_words(fixup.target_window_bytes / sizeof(uint32_t),
+                                       build_s_nop(0, arch));
+    std::copy(words.begin(), words.end(), window_words.begin());
+    window_patches.push_back(
+        {.offset = fixup.target_window_offset, .words = std::move(window_words)});
   }
 
+  if (!growth_required.required_windows.empty())
+    return growth_required;
+
+  for (const PlannedWindowPatch &patch : window_patches) {
+    std::memcpy(text.data() + patch.offset, patch.words.data(),
+                patch.words.size() * sizeof(uint32_t));
+  }
   return relocation_ok();
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.h
@@ -15,10 +15,39 @@
 namespace rocjitsu {
 
 /// @brief Reserved dwords for a canonical recovered indirect transfer.
-inline constexpr size_t kMaxRecoveredIndirectTransferWords = 6;
+///
+/// The long form is marker + getpc + up to four delta-builder words + consumer.
+inline constexpr size_t kMaxRecoveredIndirectTransferWords = 7;
 
 /// @brief Reserved dwords for the largest direct long-branch sequence.
-inline constexpr size_t kMaxDirectBranchTransferWords = 7;
+inline constexpr size_t kMaxDirectBranchTransferWords = 8;
+
+/// @brief Private branch slots in one generated SGPR-free island pool.
+inline constexpr uint16_t kDirectBranchIslandPoolSlots = 16;
+
+/// @brief Header words before the private slots in a generated island pool.
+inline constexpr uint16_t kGeneratedIslandPoolHeaderWords = 2;
+
+/// @brief First immediate in the distinctive range reserved for DBT markers.
+///
+/// @details DBT owns s_nop immediates in [base, base + count) for generated
+/// artifact markers. Recognition still requires the marker-specific canonical
+/// instruction sequence.
+inline constexpr uint16_t kDbtMarkerImmediateBase = 0x1250;
+inline constexpr uint16_t kDbtMarkerImmediateCount = 2;
+
+/// @brief Executed no-op that marks a translator-generated long direct transfer.
+///
+/// @details A repeated translation recognizes this marker immediately before
+/// the canonical getpc/add/setpc-or-swappc sequence and preserves that sequence
+/// as one relocation window instead of wrapping its indirect consumer again.
+inline constexpr uint16_t kLongDirectBranchMarkerNopImmediate = kDbtMarkerImmediateBase;
+
+/// @brief Executed no-op that marks a generated branch-island pool header.
+inline constexpr uint16_t kBranchIslandPoolMarkerNopImmediate = kDbtMarkerImmediateBase + 1;
+static_assert(kLongDirectBranchMarkerNopImmediate != kBranchIslandPoolMarkerNopImmediate);
+static_assert(kBranchIslandPoolMarkerNopImmediate <
+              kDbtMarkerImmediateBase + kDbtMarkerImmediateCount);
 
 class BasicBlock;
 class Instruction;
@@ -46,22 +75,42 @@ struct BranchFixup {
   uint64_t source_target_offset = 0; ///< Original .text offset of the branch target.
   uint64_t target_inst_offset = 0;   ///< New .text offset of the branch patch window.
   uint64_t target_window_bytes = 0;  ///< Reserved bytes available for final branch encoding.
+  /// False when widening the window would invalidate a surrounding fixed-size artifact.
+  bool allow_window_growth = true;
+  /// Pristine target-ISA encoding used by every relocation attempt.
+  std::vector<uint32_t> translated_words;
 };
 
 /// @brief Pending recovered indirect branch/call window in one relocated kernel.
 ///
 /// @details Static recovery gives DBT one concrete source target for an indirect
-/// `s_setpc_b64` or `s_swappc_b64` consumer. The translated block reserves a fixed
-/// worst-case window at the consumer site; after all blocks have final target
-/// offsets, the patch layer rewrites that window to either a direct control
-/// transfer or a canonical long getpc/add/setpc-or-swappc sequence.
+/// `s_setpc_b64` or `s_swappc_b64` consumer. The translated block starts with a
+/// compact one-word window at the consumer site. After all blocks have final
+/// target offsets, the patch layer either writes one direct control transfer or
+/// requests monotonic growth for a marked long getpc/add/setpc-or-swappc sequence.
 struct RecoveredIndirectFixup {
   uint64_t source_call_offset = 0;   ///< Original .text offset of setpc/swappc.
   uint64_t source_target_offset = 0; ///< Recovered original .text target offset.
   uint64_t target_window_offset = 0; ///< New .text offset of the reserved window.
-  uint16_t target_sreg = 0;          ///< Low SGPR pair used for the rebuilt target PC.
-  uint16_t return_sreg = 0;          ///< Low SGPR pair receiving return PC for calls.
-  bool is_call = false;              ///< True for swappc-like calls, false for setpc jumps.
+  /// Exact bytes reserved at @ref target_window_offset.
+  uint64_t target_window_bytes = sizeof(uint32_t);
+  uint16_t target_sreg = 0; ///< Low SGPR pair used for the rebuilt target PC.
+  uint16_t return_sreg = 0; ///< Low SGPR pair receiving return PC for calls.
+  bool is_call = false;     ///< True for swappc-like calls, false for setpc jumps.
+  /// Preserve a marked generated long transfer instead of choosing a compact branch.
+  bool preserve_marked_long_transfer = false;
+};
+
+enum class ControlFlowWindowKind : uint8_t {
+  DirectBranch,
+  RecoveredIndirect,
+};
+
+/// @brief One control-flow window that must grow before fixups can be committed.
+struct ControlFlowWindowRequirement {
+  ControlFlowWindowKind kind = ControlFlowWindowKind::DirectBranch;
+  uint64_t source_inst_offset = 0;    ///< Source offset identifying the fixup.
+  uint64_t required_window_bytes = 0; ///< Exact new window size.
 };
 
 /// @brief Stable failure category returned across the text-layout boundary.
@@ -88,7 +137,14 @@ struct TextRelocationResult {
   TextLayoutFailureCategory failure = TextLayoutFailureCategory::None;
   TextLayoutFailureReason reason = TextLayoutFailureReason::None;
   uint64_t source_offset = 0;
+  std::vector<ControlFlowWindowRequirement> required_windows;
   std::string message;
+};
+
+/// @brief One insertion made while growing a direct-branch patch window.
+struct TextLayoutInsertion {
+  uint64_t offset = 0; ///< Original insertion point in the kernel-local body.
+  uint64_t size = 0;   ///< Number of bytes inserted.
 };
 
 /// @brief Descriptor-neutral entry layout requested by DBT or DBI.
@@ -178,15 +234,29 @@ void append_nop_padding(std::vector<uint8_t> &text, uint64_t byte_count, rj_code
 /// @brief Return true if @p plan's preload launch stubs fit the ABI window.
 [[nodiscard]] bool kernarg_preload_launch_window_fits(const KernelEntryLayoutPlan &plan);
 
-/// @brief Choose the fixed patch-window size for a direct branch.
+/// @brief Choose the initial compact patch-window size for a direct branch.
 ///
-/// @details This centralizes patch-layer knowledge of long direct-branch
-/// windows and conditional branch-island windows. DBT records the source branch
-/// and reserves exactly the number of bytes the patch layer may later rewrite.
-[[nodiscard]] uint64_t direct_branch_patch_window_bytes(const Instruction &inst,
-                                                        uint64_t source_inst_offset,
-                                                        uint64_t source_target_offset,
-                                                        bool can_use_long_direct_branches);
+/// @details Every branch starts at its encoded size and grows monotonically only
+/// when final layout proves that a long transfer or two-word conditional island
+/// source is required.
+[[nodiscard]] uint64_t initial_direct_branch_patch_window_bytes(const Instruction &inst);
+
+/// @brief Grow control-flow windows in one kernel-local text rebuild.
+///
+/// @param text Kernel-local emitted body.
+/// @param layout Pre-materialization kernel-local layout matching @p text. Its
+/// descriptor entry fields must not have been rebased into final `.text`.
+/// @param requirements Exact monotonic window-growth requests.
+/// @param arch Target architecture used to initialize inserted words.
+/// @returns Insertions in the original @p text coordinate space, or
+/// std::nullopt without mutation when any request is invalid.
+[[nodiscard]] std::optional<std::vector<TextLayoutInsertion>>
+grow_control_flow_windows(std::vector<uint8_t> &text, KernelTextLayout &layout,
+                          std::span<const ControlFlowWindowRequirement> requirements,
+                          rj_code_arch_t arch);
+
+/// @brief Rebase one offset through a sorted set of text insertions.
+void rebase_text_offset(uint64_t &offset, std::span<const TextLayoutInsertion> insertions);
 
 /// @brief First body offset at which an SGPR-free branch-island pool should appear.
 [[nodiscard]] uint64_t first_direct_branch_island_pool_offset();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/instruction.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/instruction.h
@@ -179,6 +179,22 @@ public:
   /// @returns Encoding size in bytes.
   int size() const { return size_; }
 
+  /// @brief Previous decoded instruction in the same basic block.
+  /// @returns The preceding instruction, or nullptr at the block boundary.
+  [[nodiscard]] const Instruction *previous_instruction() const {
+    if (parent_ == nullptr || prev_ == nullptr || prev_->parent_ != parent_)
+      return nullptr;
+    return static_cast<const Instruction *>(prev_);
+  }
+
+  /// @brief Next decoded instruction in the same basic block.
+  /// @returns The following instruction, or nullptr at the block boundary.
+  [[nodiscard]] const Instruction *next_instruction() const {
+    if (parent_ == nullptr || next_ == nullptr || next_->parent_ != parent_)
+      return nullptr;
+    return static_cast<const Instruction *>(next_);
+  }
+
   /// @brief Source byte offset of this instruction in the decoded text section.
   ///
   /// @details Most decoder users only care about the instruction encoding and

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -759,7 +759,7 @@ target_include_directories(
 )
 target_link_libraries(
     rj_dbt_translate_smoke_test
-    PRIVATE rocjitsu_tooling GTest::gtest
+    PRIVATE rocjitsu_translate_cli GTest::gtest
 )
 rj_configure_target(rj_dbt_translate_smoke_test TEST)
 add_dependencies(rj_dbt_translate_smoke_test rj_dbt_translate)

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -482,6 +482,68 @@ TEST(CfgAnalysis, DirectCallToImplicitNonreturningTargetDropsFallthrough) {
   EXPECT_FALSE(has_successor_start(*caller, continuation->start_offset()));
   EXPECT_FALSE(has_predecessor(*continuation, caller));
 }
+
+TEST(CfgAnalysis, PreviousInstructionReturnsPrecedingInstructionInBlock) {
+  auto blocks = build_test_blocks({TestOpcode::Nop, TestOpcode::UseSgpr4, TestOpcode::End});
+
+  ASSERT_EQ(blocks.size(), 1u);
+  auto instruction = blocks[0]->instructions().begin();
+  ASSERT_NE(instruction, blocks[0]->instructions().end());
+  const Instruction *first = &*instruction;
+  ++instruction;
+  ASSERT_NE(instruction, blocks[0]->instructions().end());
+  const Instruction *second = &*instruction;
+
+  EXPECT_EQ(first->previous_instruction(), nullptr);
+  EXPECT_EQ(second->previous_instruction(), first);
+}
+
+TEST(CfgAnalysis, PreviousInstructionIsNullAtBranchTargetBlockEntry) {
+  auto blocks = build_test_blocks(
+      {TestOpcode::CBranchToElse, TestOpcode::Nop, TestOpcode::UseSgpr4, TestOpcode::End});
+
+  BasicBlock *target = block_starting_at(blocks, 8);
+  ASSERT_NE(target, nullptr);
+  ASSERT_NE(target->instructions().begin(), target->instructions().end());
+  const Instruction &entry = *target->instructions().begin();
+  EXPECT_EQ(entry.previous_instruction(), nullptr);
+}
+
+TEST(CfgAnalysis, NextInstructionReturnsFollowingInstructionInBlock) {
+  auto blocks = build_test_blocks({TestOpcode::Nop, TestOpcode::UseSgpr4, TestOpcode::End});
+
+  ASSERT_EQ(blocks.size(), 1u);
+  auto instruction = blocks[0]->instructions().begin();
+  ASSERT_NE(instruction, blocks[0]->instructions().end());
+  const Instruction *first = &*instruction;
+  ++instruction;
+  ASSERT_NE(instruction, blocks[0]->instructions().end());
+  const Instruction *second = &*instruction;
+
+  EXPECT_EQ(first->next_instruction(), second);
+}
+
+TEST(CfgAnalysis, NextInstructionIsNullAtBlockTerminator) {
+  auto blocks = build_test_blocks(
+      {TestOpcode::CBranchToElse, TestOpcode::Nop, TestOpcode::UseSgpr4, TestOpcode::End});
+
+  ASSERT_FALSE(blocks.empty());
+  const Instruction *terminator = blocks[0]->terminator();
+  ASSERT_NE(terminator, nullptr);
+  EXPECT_EQ(terminator->next_instruction(), nullptr);
+}
+
+TEST(CfgAnalysis, StandaloneInstructionHasNoDecodedNeighbors) {
+  constexpr uint32_t kNop = 0xbf800000u;
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> instruction(decoder->decode(&kNop));
+
+  ASSERT_NE(instruction, nullptr);
+  EXPECT_EQ(instruction->previous_instruction(), nullptr);
+  EXPECT_EQ(instruction->next_instruction(), nullptr);
+}
+
 TEST(CfgAnalysis, IfElseSuccessorsAndPredecessorsAreInverse) {
   auto blocks = build_test_blocks(
       {TestOpcode::CBranchToElse, TestOpcode::BranchToJoin, TestOpcode::Nop, TestOpcode::End});

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -53,6 +53,7 @@
 #include "rocjitsu/code/dbt/generated/legalization_types.h"
 #include "rocjitsu/code/dbt/kernel_descriptor_translator.h"
 #include "rocjitsu/code/dbt/semantic/rules.h"
+#include "rocjitsu/code/dbt/semantic_translator.h"
 #include "rocjitsu/code/dbt/virtual_lds.h"
 #include "rocjitsu/code/dbt/waitcnt_translator.h"
 #include "rocjitsu/code/patch/code_object_patcher.h"
@@ -4452,13 +4453,6 @@ decode_text_instructions(const rocjitsu::Section &text, rj_code_arch_t arch) {
   return decoded;
 }
 
-void expect_nop_words(const uint32_t *words, size_t begin, size_t end, rj_code_arch_t arch) {
-  for (size_t i = begin; i < end; ++i) {
-    SCOPED_TRACE(i);
-    EXPECT_EQ(words[i], rocjitsu::build_s_nop(0, arch));
-  }
-}
-
 // --- Synthetic BinaryTranslator integration tests ---
 TEST(BinaryTranslatorE2E, TranslatesMultiKernelCodeObject) {
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_two_kernel_descriptors();
@@ -4898,49 +4892,70 @@ TEST(BinaryTranslatorE2E, VirtualLdsWrapperIgnoresDirectKernargLoadsInSharedHelp
   EXPECT_EQ(virtual_kd.kernarg_size, kExpectedWrapperBytes);
 }
 
-TEST(BinaryTranslatorE2E, DirectBranchRelocationUsesLongBranchWindowWhenExpandedOutOfRange) {
-  constexpr size_t kTargetWord = 20000;
-  constexpr uint16_t kLongBranchScratchSgpr = 8;
-  constexpr uint32_t kCdna4SEndpgm = 0xBF810000u;
+TEST(BinaryTranslatorE2E, Gfx1250LongDirectBranchGrowthIsIdempotent) {
+  // Each selected DS2 becomes two two-word operations plus a wait. Choose the
+  // count so the first target starts one dword below SOPP's forward limit.
+  // Growing the already-out-of-range second branch then shifts that near target
+  // and forces a second monotonic layout round; both branches must end up long.
+  constexpr size_t kSoppMaxForwardDwords = 0x7fff;
+  constexpr size_t kExpandedDs2Words = 5;
+  constexpr size_t kNearExpansionCount = (kSoppMaxForwardDwords - 2) / kExpandedDs2Words;
+  static_assert(1 + kNearExpansionCount * kExpandedDs2Words == kSoppMaxForwardDwords - 1);
+  constexpr size_t kExpansionCount = kNearExpansionCount + 1;
+  constexpr size_t kNearTargetWord = 2 + kNearExpansionCount * 2;
+  constexpr size_t kFarTargetWord = 2 + kExpansionCount * 2;
+  constexpr auto ds2 =
+      gfx1250::build_vds(gfx1250::kDsStore2addrB32Vds,
+                         {.offset0 = 3, .offset1 = 5, .addr = 20, .data0 = 30, .data1 = 40});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
 
   std::vector<uint32_t> words;
-  words.reserve(kTargetWord + 1);
-  words.push_back(
-      rocjitsu::pack_sopp(cdna3::kSCbranchExecnzSopp, static_cast<uint16_t>(kTargetWord - 1)));
-  for (size_t i = 1; i < kTargetWord; ++i)
-    words.push_back(rocjitsu::pack_sopp(cdna3::kSCbranchScc0Sopp, 0));
-  words.push_back(kCdna4SEndpgm);
+  words.reserve(kFarTargetWord + 1);
+  words.push_back(gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp,
+                                      {.simm16 = static_cast<uint16_t>(kNearTargetWord - 1)})[0]);
+  words.push_back(gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp,
+                                      {.simm16 = static_cast<uint16_t>(kFarTargetWord - 2)})[0]);
+  for (size_t i = 0; i < kExpansionCount; ++i) {
+    words.push_back(ds2[0]);
+    words.push_back(ds2[1]);
+  }
+  words.push_back(kGfx1250SEndpgm);
 
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
   ASSERT_TRUE(source.is_valid());
 
-  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
-  auto result = translator.translate(source);
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
   ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
                                                           : result.diagnostics.front().message);
-  ASSERT_FALSE(result.elf_bytes.empty());
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_TRUE(translated.is_valid());
   ASSERT_FALSE(translated.text_sections().empty());
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  const uint32_t marker = rocjitsu::build_s_nop(rocjitsu::kLongDirectBranchMarkerNopImmediate,
+                                                ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ((target_words[0] >> 16) & 0x7fu, gfx1250::kSCbranchScc1Sopp);
+  EXPECT_EQ(target_words[1], marker);
+  const auto translated_word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+  EXPECT_EQ(std::count(target_words, target_words + translated_word_count, marker), 2);
 
-  // The source branch is in range, but reserving branch windows for the many
-  // intervening branches pushes the relocated target outside the SOPP simm16
-  // range. DBT inverts the condition to skip over the long transfer when EXEC
-  // is zero, then rebuilds the target PC in a descriptor-backed SGPR pair. This
-  // specifically guards the highest adjacent conditional pair: opcode 38 must
-  // invert to 37, not invalid opcode 39.
-  EXPECT_EQ(target_words[0], rocjitsu::pack_sopp(cdna3::kSCbranchExeczSopp,
-                                                 rocjitsu::kMaxDirectBranchTransferWords - 1));
-  EXPECT_EQ(target_words[1], build_s_getpc_b64(kLongBranchScratchSgpr, ROCJITSU_CODE_ARCH_CDNA3));
-  EXPECT_EQ(target_words[5], build_s_setpc_b64(kLongBranchScratchSgpr, ROCJITSU_CODE_ARCH_CDNA3));
-  EXPECT_EQ(target_words[6], rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3));
+  rocjitsu::BinaryTranslator verifier(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto second = verifier.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250LongBranchInvertsExecNzToExecZ) {
+TEST(BinaryTranslatorE2E, Gfx1250CompactConditionalLayoutIsIdempotent) {
   constexpr size_t kTargetWord = 20000;
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
 
@@ -4969,48 +4984,616 @@ TEST(BinaryTranslatorE2E, Gfx1250LongBranchInvertsExecNzToExecZ) {
   ASSERT_FALSE(translated.text_sections().empty());
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
-  EXPECT_EQ(target_words[0], rocjitsu::pack_sopp(gfx1250::kSCbranchExeczSopp,
-                                                 rocjitsu::kMaxDirectBranchTransferWords - 1));
+  EXPECT_EQ(target_words[0], rocjitsu::pack_sopp(gfx1250::kSCbranchExecnzSopp,
+                                                 static_cast<uint16_t>(kTargetWord - 1)));
+
+  rocjitsu::BinaryTranslator verifier(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto second = verifier.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
 }
 
-TEST(BinaryTranslatorE2E, DirectBranchWindowKeepsFourKibibyteBranchesCompact) {
+TEST(BinaryTranslatorE2E, Gfx1250CompilerLongJumpCompactsIdempotentlyAfterPaddingNop) {
+  constexpr uint16_t kPcSreg = 4;
+  constexpr uint16_t kGfx1250SAddNcU64Opcode = 83;
+  constexpr uint16_t kLiteralOperand = 255;
+  constexpr uint32_t kTargetOffset = 140000;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+
+  std::vector<uint32_t> words = {
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_getpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_sop2_encoding(ROCJITSU_CODE_ARCH_GFX1250, kGfx1250SAddNcU64Opcode, kPcSreg,
+                                    kPcSreg, kLiteralOperand),
+      kTargetOffset - 2 * sizeof(uint32_t),
+      rocjitsu::build_s_setpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_GFX1250),
+  };
+  words.resize(kTargetOffset / sizeof(uint32_t),
+               rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250));
+  words.push_back(kGfx1250SEndpgm);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  EXPECT_EQ(target_words[0], rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250));
+  EXPECT_EQ((target_words[4] >> 16) & 0x7fu, gfx1250::kSBranchSopp);
+
+  rocjitsu::BinaryTranslator verifier(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto second = verifier.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250MarkedLongJumpStaysLongWhenTargetIsDirectlyReachable) {
+  constexpr uint16_t kPcSreg = 4;
+  constexpr uint16_t kGfx1250SAddNcU64Opcode = 83;
+  constexpr uint16_t kLiteralOperand = 255;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint32_t kTargetOffset = 5 * sizeof(uint32_t);
+  const uint32_t marker = rocjitsu::build_s_nop(rocjitsu::kLongDirectBranchMarkerNopImmediate,
+                                                ROCJITSU_CODE_ARCH_GFX1250);
+  const std::vector<uint32_t> words = {
+      marker,
+      rocjitsu::build_s_getpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_sop2_encoding(ROCJITSU_CODE_ARCH_GFX1250, kGfx1250SAddNcU64Opcode, kPcSreg,
+                                    kPcSreg, kLiteralOperand),
+      kTargetOffset - 2 * sizeof(uint32_t),
+      rocjitsu::build_s_setpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      kGfx1250SEndpgm,
+  };
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  EXPECT_EQ(target_words[0], marker);
+  EXPECT_EQ(target_words[4], rocjitsu::build_s_setpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_GFX1250));
+
+  rocjitsu::BinaryTranslator verifier(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto second = verifier.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250DoesNotTreatLiteralAsLongJumpMarker) {
+  constexpr uint16_t kPcSreg = 4;
+  constexpr uint16_t kUnrelatedSgpr = 20;
+  constexpr uint16_t kGfx1250SAddNcU64Opcode = 83;
+  constexpr uint16_t kLiteralOperand = 255;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint32_t kTargetOffset = 7 * sizeof(uint32_t);
+  const uint32_t marker = rocjitsu::build_s_nop(rocjitsu::kLongDirectBranchMarkerNopImmediate,
+                                                ROCJITSU_CODE_ARCH_GFX1250);
+  const std::vector<uint32_t> words = {
+      rocjitsu::build_sop2_encoding(ROCJITSU_CODE_ARCH_GFX1250, 0, kUnrelatedSgpr, kUnrelatedSgpr,
+                                    kLiteralOperand),
+      marker,
+      rocjitsu::build_s_getpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_sop2_encoding(ROCJITSU_CODE_ARCH_GFX1250, kGfx1250SAddNcU64Opcode, kPcSreg,
+                                    kPcSreg, kLiteralOperand),
+      kTargetOffset - 3 * sizeof(uint32_t),
+      rocjitsu::build_s_setpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250),
+      kGfx1250SEndpgm,
+  };
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "s_setpc_b64"; }),
+            0);
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250DoesNotPreserveLongJumpMarkerAcrossBlockBoundary) {
+  constexpr uint16_t kPcSreg = 4;
+  constexpr uint16_t kGfx1250SAddNcU64Opcode = 83;
+  constexpr uint16_t kLiteralOperand = 255;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint32_t kTargetOffset = 7 * sizeof(uint32_t);
+  const uint32_t marker = rocjitsu::build_s_nop(rocjitsu::kLongDirectBranchMarkerNopImmediate,
+                                                ROCJITSU_CODE_ARCH_GFX1250);
+  const std::vector<uint32_t> words = {
+      gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp, {.simm16 = 1})[0],
+      marker,
+      rocjitsu::build_s_getpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_sop2_encoding(ROCJITSU_CODE_ARCH_GFX1250, kGfx1250SAddNcU64Opcode, kPcSreg,
+                                    kPcSreg, kLiteralOperand),
+      kTargetOffset - 3 * sizeof(uint32_t),
+      rocjitsu::build_s_setpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250),
+      kGfx1250SEndpgm,
+  };
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "s_setpc_b64"; }),
+            0);
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250DoesNotPreserveLongJumpMarkerAcrossInteriorBlockEntry) {
+  constexpr uint16_t kPcSreg = 4;
+  constexpr uint16_t kGfx1250SAddNcU64Opcode = 83;
+  constexpr uint16_t kLiteralOperand = 255;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint32_t kTargetOffset = 8 * sizeof(uint32_t);
+  const uint32_t marker = rocjitsu::build_s_nop(rocjitsu::kLongDirectBranchMarkerNopImmediate,
+                                                ROCJITSU_CODE_ARCH_GFX1250);
+  const std::vector<uint32_t> words = {
+      marker,
+      rocjitsu::build_s_getpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // The branch retains the getpc result while making the add an interior
+      // block entry in the recovered window.
+      rocjitsu::build_s_branch(1, ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_sop2_encoding(ROCJITSU_CODE_ARCH_GFX1250, kGfx1250SAddNcU64Opcode, kPcSreg,
+                                    kPcSreg, kLiteralOperand),
+      kTargetOffset - 2 * sizeof(uint32_t),
+      rocjitsu::build_s_setpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250),
+      kGfx1250SEndpgm,
+  };
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(
+      rocjitsu::has_error_containing(result, rocjitsu::DiagnosticKind::Legalization,
+                                     "indirect branch or call target recovery is not implemented"));
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250DoesNotPreserveLongJumpMarkerAtConsumerBlockEntry) {
+  constexpr uint16_t kPcSreg = 4;
+  constexpr uint16_t kGfx1250SAddNcU64Opcode = 83;
+  constexpr uint16_t kLiteralOperand = 255;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint32_t kTargetOffset = 5 * sizeof(uint32_t);
+  const uint32_t marker = rocjitsu::build_s_nop(rocjitsu::kLongDirectBranchMarkerNopImmediate,
+                                                ROCJITSU_CODE_ARCH_GFX1250);
+  const std::vector<uint32_t> words = {
+      marker,
+      rocjitsu::build_s_getpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_sop2_encoding(ROCJITSU_CODE_ARCH_GFX1250, kGfx1250SAddNcU64Opcode, kPcSreg,
+                                    kPcSreg, kLiteralOperand),
+      kTargetOffset - 2 * sizeof(uint32_t),
+      rocjitsu::build_s_setpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // The recovered target branches back to the consumer, making the
+      // consumer itself a second block entry into the marked window.
+      rocjitsu::build_s_branch(-2, ROCJITSU_CODE_ARCH_GFX1250),
+      kGfx1250SEndpgm,
+  };
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "s_setpc_b64"; }),
+            0);
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, LongDirectBranchInvertsEveryGfx1250ConditionalPair) {
+  struct TestCase {
+    uint16_t source_opcode;
+    uint16_t inverse_opcode;
+  };
+  constexpr std::array test_cases = {
+      TestCase{gfx1250::kSCbranchScc0Sopp, gfx1250::kSCbranchScc1Sopp},
+      TestCase{gfx1250::kSCbranchScc1Sopp, gfx1250::kSCbranchScc0Sopp},
+      TestCase{gfx1250::kSCbranchVcczSopp, gfx1250::kSCbranchVccnzSopp},
+      TestCase{gfx1250::kSCbranchVccnzSopp, gfx1250::kSCbranchVcczSopp},
+      TestCase{gfx1250::kSCbranchExeczSopp, gfx1250::kSCbranchExecnzSopp},
+      TestCase{gfx1250::kSCbranchExecnzSopp, gfx1250::kSCbranchExeczSopp},
+  };
+  constexpr uint64_t kTargetOffset = 140000;
+
+  for (const TestCase &test_case : test_cases) {
+    const uint32_t branch_word = rocjitsu::pack_sopp(test_case.source_opcode, 0);
+    const auto branch = rocjitsu::decode_one(branch_word, ROCJITSU_CODE_ARCH_GFX1250);
+    ASSERT_NE(branch, nullptr);
+
+    std::vector<uint8_t> text(kTargetOffset + sizeof(uint32_t), 0);
+    rocjitsu::KernelTextLayout layout;
+    layout.body_end = text.size();
+    layout.long_branch_sgpr = 8;
+    layout.blocks.push_back(
+        {.source_start = 0,
+         .source_end = sizeof(uint32_t),
+         .target_start = 0,
+         .target_end = rocjitsu::kMaxDirectBranchTransferWords * sizeof(uint32_t)});
+    layout.blocks.push_back({.source_start = sizeof(uint32_t),
+                             .source_end = 2 * sizeof(uint32_t),
+                             .target_start = kTargetOffset,
+                             .target_end = kTargetOffset + sizeof(uint32_t)});
+    layout.branch_fixups.push_back(
+        {.inst = branch.get(),
+         .source_inst_offset = 0,
+         .source_target_offset = sizeof(uint32_t),
+         .target_inst_offset = 0,
+         .target_window_bytes = rocjitsu::kMaxDirectBranchTransferWords * sizeof(uint32_t),
+         .translated_words = {branch_word}});
+
+    const auto result =
+        rocjitsu::patch_direct_branch_fixups(text, layout, ROCJITSU_CODE_ARCH_GFX1250);
+    ASSERT_TRUE(result.ok) << result.message;
+    uint32_t inverted = 0;
+    std::memcpy(&inverted, text.data(), sizeof(inverted));
+    EXPECT_EQ((inverted >> 16) & 0x7fu, test_case.inverse_opcode);
+  }
+}
+
+TEST(BinaryTranslatorE2E, RebaseTextOffsetShiftsOffsetsAtInsertionBoundaries) {
+  constexpr uint64_t kWord = sizeof(uint32_t);
+  const std::array insertions = {
+      rocjitsu::TextLayoutInsertion{.offset = kWord, .size = kWord},
+      rocjitsu::TextLayoutInsertion{.offset = 2 * kWord, .size = 2 * kWord},
+  };
+
+  uint64_t before = kWord - 1;
+  uint64_t at_first = kWord;
+  uint64_t between = 2 * kWord - 1;
+  uint64_t at_second = 2 * kWord;
+  rocjitsu::rebase_text_offset(before, insertions);
+  rocjitsu::rebase_text_offset(at_first, insertions);
+  rocjitsu::rebase_text_offset(between, insertions);
+  rocjitsu::rebase_text_offset(at_second, insertions);
+
+  EXPECT_EQ(before, kWord - 1);
+  EXPECT_EQ(at_first, 2 * kWord);
+  EXPECT_EQ(between, 3 * kWord - 1);
+  EXPECT_EQ(at_second, 5 * kWord);
+}
+
+TEST(BinaryTranslatorE2E, GrowDirectBranchWindowsRebasesEveryLaterLayoutOffset) {
   const uint32_t branch_word = rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_GFX1250);
   const auto branch = rocjitsu::decode_one(branch_word, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(branch, nullptr);
 
-  constexpr uint64_t kCompactDistance = 4 * 1024;
-  EXPECT_EQ(rocjitsu::direct_branch_patch_window_bytes(*branch, 0, kCompactDistance, true),
-            sizeof(uint32_t));
-  EXPECT_EQ(rocjitsu::direct_branch_patch_window_bytes(*branch, 0,
-                                                       kCompactDistance + sizeof(uint32_t), true),
-            rocjitsu::kMaxDirectBranchTransferWords * sizeof(uint32_t));
+  constexpr uint64_t kWord = sizeof(uint32_t);
+  std::vector<uint8_t> text(8 * kWord, 0);
+  rocjitsu::KernelTextLayout layout;
+  layout.body_end = text.size();
+  layout.blocks.push_back(
+      {.source_start = 0, .source_end = kWord, .target_start = 0, .target_end = kWord});
+  layout.blocks.push_back({.source_start = kWord,
+                           .source_end = 8 * kWord,
+                           .target_start = kWord,
+                           .target_end = 8 * kWord});
+  layout.branch_fixups.push_back({.inst = branch.get(),
+                                  .source_inst_offset = 0,
+                                  .source_target_offset = kWord,
+                                  .target_inst_offset = 0,
+                                  .target_window_bytes = kWord,
+                                  .translated_words = {branch_word}});
+  layout.branch_fixups.push_back({.inst = branch.get(),
+                                  .source_inst_offset = 2 * kWord,
+                                  .source_target_offset = 0,
+                                  .target_inst_offset = 2 * kWord,
+                                  .target_window_bytes = kWord,
+                                  .translated_words = {branch_word}});
+  layout.recovered_indirect_fixups.push_back({.source_call_offset = 3 * kWord,
+                                              .target_window_offset = 3 * kWord,
+                                              .target_window_bytes = 3 * kWord});
+  layout.recovered_builder_fixups.push_back({.target_getpc_offset = 4 * kWord,
+                                             .target_recovery_begin_offset = 5 * kWord,
+                                             .target_recovery_end_offset = 6 * kWord});
+  layout.branch_island_slots.push_back(7 * kWord);
+
+  const std::array requirements = {
+      rocjitsu::ControlFlowWindowRequirement{.source_inst_offset = 0,
+                                             .required_window_bytes = 3 * kWord},
+      rocjitsu::ControlFlowWindowRequirement{.kind =
+                                                 rocjitsu::ControlFlowWindowKind::RecoveredIndirect,
+                                             .source_inst_offset = 3 * kWord,
+                                             .required_window_bytes = 5 * kWord},
+  };
+  const auto insertions =
+      rocjitsu::grow_control_flow_windows(text, layout, requirements, ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_TRUE(insertions.has_value());
+  ASSERT_EQ(insertions->size(), 2u);
+  EXPECT_EQ(insertions->at(0).offset, kWord);
+  EXPECT_EQ(insertions->at(0).size, 2 * kWord);
+  EXPECT_EQ(insertions->at(1).offset, 6 * kWord);
+  EXPECT_EQ(insertions->at(1).size, 2 * kWord);
+  EXPECT_EQ(text.size(), 12 * kWord);
+  EXPECT_EQ(layout.body_end, text.size());
+  EXPECT_EQ(layout.blocks[0].target_end, 3 * kWord);
+  EXPECT_EQ(layout.blocks[1].target_start, 3 * kWord);
+  EXPECT_EQ(layout.blocks[1].target_end, 12 * kWord);
+  EXPECT_EQ(layout.branch_fixups[0].target_inst_offset, 0u);
+  EXPECT_EQ(layout.branch_fixups[0].target_window_bytes, 3 * kWord);
+  EXPECT_EQ(layout.branch_fixups[1].target_inst_offset, 4 * kWord);
+  EXPECT_EQ(layout.recovered_indirect_fixups[0].target_window_offset, 5 * kWord);
+  EXPECT_EQ(layout.recovered_indirect_fixups[0].target_window_bytes, 5 * kWord);
+  EXPECT_EQ(layout.recovered_builder_fixups[0].target_getpc_offset, 6 * kWord);
+  EXPECT_EQ(layout.recovered_builder_fixups[0].target_recovery_begin_offset, 7 * kWord);
+  EXPECT_EQ(layout.recovered_builder_fixups[0].target_recovery_end_offset, 10 * kWord);
+  EXPECT_EQ(layout.branch_island_slots[0], 11 * kWord);
+
+  const uint32_t expected_nop = rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250);
+  uint32_t inserted_word = 0;
+  std::memcpy(&inserted_word, text.data() + kWord, sizeof(inserted_word));
+  EXPECT_EQ(inserted_word, expected_nop);
+  std::memcpy(&inserted_word, text.data() + 2 * kWord, sizeof(inserted_word));
+  EXPECT_EQ(inserted_word, expected_nop);
+  std::memcpy(&inserted_word, text.data() + 8 * kWord, sizeof(inserted_word));
+  EXPECT_EQ(inserted_word, expected_nop);
+  std::memcpy(&inserted_word, text.data() + 9 * kWord, sizeof(inserted_word));
+  EXPECT_EQ(inserted_word, expected_nop);
 }
 
-TEST(BinaryTranslatorE2E, DirectBranchWindowReservesLongFormForExpandedConditional) {
-  const uint32_t branch_word =
-      rocjitsu::pack_sopp(gfx1250::kSCbranchScc0Sopp, static_cast<uint16_t>(1391));
+TEST(BinaryTranslatorE2E, FixedDirectBranchWindowRejectsGrowthWithoutMutation) {
+  constexpr uint64_t kWord = sizeof(uint32_t);
+  constexpr uint64_t kTargetOffset = 140000;
+  const uint32_t branch_word = rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_GFX1250);
   const auto branch = rocjitsu::decode_one(branch_word, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(branch, nullptr);
 
-  constexpr uint64_t kNvfp4BranchDistance = 5568;
-  EXPECT_EQ(rocjitsu::direct_branch_patch_window_bytes(*branch, 0, kNvfp4BranchDistance, true),
-            rocjitsu::kMaxDirectBranchTransferWords * sizeof(uint32_t));
-  EXPECT_EQ(rocjitsu::direct_branch_patch_window_bytes(*branch, 0, kNvfp4BranchDistance, false),
-            2 * sizeof(uint32_t));
+  std::vector<uint8_t> text(kTargetOffset + kWord, 0);
+  rocjitsu::KernelTextLayout layout;
+  layout.body_end = text.size();
+  layout.long_branch_sgpr = 8;
+  layout.blocks.push_back(
+      {.source_start = 0, .source_end = kWord, .target_start = 0, .target_end = kWord});
+  layout.blocks.push_back({.source_start = kWord,
+                           .source_end = 2 * kWord,
+                           .target_start = kTargetOffset,
+                           .target_end = kTargetOffset + kWord});
+  layout.branch_fixups.push_back({.inst = branch.get(),
+                                  .source_inst_offset = 0,
+                                  .source_target_offset = kWord,
+                                  .target_inst_offset = 0,
+                                  .target_window_bytes = kWord,
+                                  .allow_window_growth = false,
+                                  .translated_words = {branch_word}});
+
+  const auto original_text = text;
+  const auto result =
+      rocjitsu::patch_direct_branch_fixups(text, layout, ROCJITSU_CODE_ARCH_GFX1250);
+
+  EXPECT_FALSE(result.ok);
+  EXPECT_EQ(result.reason, rocjitsu::TextLayoutFailureReason::BranchOutOfRange);
+  EXPECT_TRUE(result.required_windows.empty());
+  EXPECT_NE(result.message.find("fixed-size"), std::string::npos);
+  EXPECT_EQ(text, original_text);
 }
 
-TEST(BinaryTranslatorE2E, DirectBranchRelocationUsesIslandsWhenSgprsAreFull) {
+TEST(BinaryTranslatorE2E, DirectBranchWindowsRejectInvalidGrowthWithoutMutation) {
+  const uint32_t branch_word = rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_GFX1250);
+  const auto branch = rocjitsu::decode_one(branch_word, ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(branch, nullptr);
+
+  auto rejects_without_mutation =
+      [&](std::vector<rocjitsu::ControlFlowWindowRequirement> requirements) {
+        std::vector<uint8_t> text(sizeof(uint32_t), 0);
+        rocjitsu::KernelTextLayout layout;
+        layout.body_end = text.size();
+        layout.branch_fixups.push_back({.inst = branch.get(),
+                                        .source_inst_offset = 0,
+                                        .source_target_offset = sizeof(uint32_t),
+                                        .target_inst_offset = 0,
+                                        .target_window_bytes = sizeof(uint32_t),
+                                        .translated_words = {branch_word}});
+
+        const auto original_text = text;
+        const auto result = rocjitsu::grow_control_flow_windows(text, layout, requirements,
+                                                                ROCJITSU_CODE_ARCH_GFX1250);
+        EXPECT_FALSE(result.has_value());
+        EXPECT_EQ(text, original_text);
+        EXPECT_EQ(layout.body_end, sizeof(uint32_t));
+        EXPECT_EQ(layout.branch_fixups.front().target_inst_offset, 0u);
+        EXPECT_EQ(layout.branch_fixups.front().target_window_bytes, sizeof(uint32_t));
+      };
+
+  rejects_without_mutation(
+      {{.source_inst_offset = 0, .required_window_bytes = sizeof(uint32_t) + 1}});
+  rejects_without_mutation(
+      {{.source_inst_offset = 0x1000, .required_window_bytes = 2 * sizeof(uint32_t)}});
+  rejects_without_mutation({{.source_inst_offset = 0, .required_window_bytes = sizeof(uint32_t)}});
+  rejects_without_mutation(
+      {{.source_inst_offset = 0, .required_window_bytes = 2 * sizeof(uint32_t)},
+       {.source_inst_offset = 0, .required_window_bytes = 3 * sizeof(uint32_t)}});
+
+  {
+    std::vector<uint8_t> text(sizeof(uint32_t), 0);
+    rocjitsu::KernelTextLayout layout;
+    layout.body_end = text.size();
+    layout.recovered_indirect_fixups.push_back({.source_call_offset = 0,
+                                                .target_window_offset = 0,
+                                                .target_window_bytes = sizeof(uint32_t)});
+    const std::array requirements = {rocjitsu::ControlFlowWindowRequirement{
+        .kind = rocjitsu::ControlFlowWindowKind::RecoveredIndirect,
+        .source_inst_offset = 0x1000,
+        .required_window_bytes = 2 * sizeof(uint32_t),
+    }};
+
+    const auto original_text = text;
+    const auto result =
+        rocjitsu::grow_control_flow_windows(text, layout, requirements, ROCJITSU_CODE_ARCH_GFX1250);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(text, original_text);
+    EXPECT_EQ(layout.body_end, sizeof(uint32_t));
+    EXPECT_EQ(layout.recovered_indirect_fixups.front().target_window_bytes, sizeof(uint32_t));
+  }
+}
+
+TEST(BinaryTranslatorE2E, PatchesOutOfRangeConditionalThroughIslandSlotWithoutSgpr) {
+  constexpr uint64_t kWord = sizeof(uint32_t);
+  constexpr uint64_t kTargetOffset = 140000;
+  constexpr uint64_t kIslandOffset = 70000;
+  const uint32_t branch_word =
+      rocjitsu::pack_sopp(gfx1250::kSCbranchScc1Sopp, static_cast<uint16_t>(0));
+  const auto branch = rocjitsu::decode_one(branch_word, ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(branch, nullptr);
+
+  std::vector<uint8_t> text(kTargetOffset + kWord, 0);
+  rocjitsu::KernelTextLayout layout;
+  layout.body_end = text.size();
+  layout.blocks.push_back(
+      {.source_start = 0, .source_end = kWord, .target_start = 0, .target_end = kWord});
+  layout.blocks.push_back({.source_start = kWord,
+                           .source_end = 2 * kWord,
+                           .target_start = kTargetOffset,
+                           .target_end = kTargetOffset + kWord});
+  layout.branch_fixups.push_back({.inst = branch.get(),
+                                  .source_inst_offset = 0,
+                                  .source_target_offset = kWord,
+                                  .target_inst_offset = 0,
+                                  .target_window_bytes = kWord,
+                                  .translated_words = {branch_word}});
+  layout.branch_island_slots.push_back(kIslandOffset);
+
+  const auto before_growth =
+      rocjitsu::patch_direct_branch_fixups(text, layout, ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_FALSE(before_growth.ok);
+  ASSERT_EQ(before_growth.required_windows.size(), 1u);
+  EXPECT_EQ(before_growth.required_windows.front().required_window_bytes, 2 * kWord);
+
+  const auto insertions = rocjitsu::grow_control_flow_windows(
+      text, layout, before_growth.required_windows, ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_TRUE(insertions.has_value());
+  ASSERT_TRUE(rocjitsu::patch_direct_branch_fixups(text, layout, ROCJITSU_CODE_ARCH_GFX1250).ok);
+
+  const auto *target_words = reinterpret_cast<const uint32_t *>(text.data());
+  EXPECT_EQ(target_words[0], rocjitsu::pack_sopp(gfx1250::kSCbranchScc0Sopp, 1));
+  const uint64_t rebased_island_offset = kIslandOffset + kWord;
+  const auto source_to_island = rocjitsu::compute_sopp_branch_simm16(kWord, rebased_island_offset);
+  ASSERT_TRUE(source_to_island.has_value());
+  EXPECT_EQ(target_words[1],
+            rocjitsu::build_s_branch(*source_to_island, ROCJITSU_CODE_ARCH_GFX1250));
+
+  uint32_t island_word = 0;
+  std::memcpy(&island_word, text.data() + rebased_island_offset, sizeof(island_word));
+  const auto island_to_target =
+      rocjitsu::compute_sopp_branch_simm16(rebased_island_offset, kTargetOffset + kWord);
+  ASSERT_TRUE(island_to_target.has_value());
+  EXPECT_EQ(island_word, rocjitsu::build_s_branch(*island_to_target, ROCJITSU_CODE_ARCH_GFX1250));
+}
+
+TEST(BinaryTranslatorE2E, FullSgprConditionalPreservesPoolAfterUnconditionalBranch) {
   using namespace rocr::llvm::amdhsa;
 
-  constexpr size_t kTargetWord = 20000;
+  constexpr size_t kExpansionCount = 16000;
+  const auto cvt = make_cdna4_cvt_f32_bf16_words(cdna4::encoding::kVop1);
   constexpr uint32_t kCdna4SEndpgm = 0xBF810000u;
 
   std::vector<uint32_t> words;
-  words.reserve(kTargetWord + 1);
-  words.push_back(
-      rocjitsu::pack_sopp(cdna3::kSCbranchScc1Sopp, static_cast<uint16_t>(kTargetWord - 1)));
-  for (size_t i = 1; i < kTargetWord; ++i)
-    words.push_back(rocjitsu::pack_sopp(cdna3::kSCbranchScc0Sopp, 0));
+  words.reserve(2 * kExpansionCount + 2);
+  for (size_t i = 0; i < kExpansionCount; ++i) {
+    words.push_back(cvt[0]);
+    // The first pass inserts each pool after one of these source blocks. Once
+    // relocated, the direct branch skips that pool's header while the
+    // out-of-range branch below still reaches one of its private slots.
+    words.push_back(rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA4));
+  }
+  const int16_t back_to_entry = static_cast<int16_t>(-static_cast<int64_t>(words.size() + 1));
+  words.push_back(cdna4::build_sopp(cdna4::kSCbranchScc1Sopp,
+                                    {.simm16 = static_cast<uint16_t>(back_to_entry)})[0]);
   words.push_back(kCdna4SEndpgm);
 
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
@@ -5019,39 +5602,169 @@ TEST(BinaryTranslatorE2E, DirectBranchRelocationUsesIslandsWhenSgprsAreFull) {
   const auto *rodata = rocjitsu::find_section(layout, ".rodata");
   ASSERT_NE(rodata, nullptr);
   ASSERT_GE(rodata->size(), sizeof(rocjitsu::TestKernelDescriptor));
-
   auto *source_kd =
       reinterpret_cast<rocjitsu::TestKernelDescriptor *>(image.data() + rodata->sectionOffset());
-  // 112 SGPRs is the largest CDNA descriptor allocation this translator accepts.
-  // There is no legal descriptor-backed pair left for the getpc/add/setpc long
-  // direct-branch sequence. Full-SGPR kernels therefore need SOPP-only branch
-  // islands instead of forcing an unpatchable s112:s113 scratch requirement.
   AMDHSA_BITS_SET(source_kd->compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
                   13);
 
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
   ASSERT_TRUE(source.is_valid());
-
   rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
-  auto result = translator.translate(source);
+  const auto result = translator.translate(source);
   ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
                                                           : result.diagnostics.front().message);
-  ASSERT_FALSE(result.elf_bytes.empty());
-  expect_cdna3_translated_descriptor_sgprs_eq(result.elf_bytes, 112);
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_TRUE(translated.is_valid());
   ASSERT_FALSE(translated.text_sections().empty());
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
-  // The original s_cbranch_scc1 is out of range after every conditional branch
-  // reserves a two-word islandable window. DBT inverts it to skip over a local
-  // s_branch into a private island slot; no scratch SGPR is required.
-  EXPECT_EQ(target_words[0], rocjitsu::pack_sopp(cdna3::kSCbranchScc0Sopp, 1));
-  rocjitsu::cdna3::SoppMachineInst island_branch{};
-  std::memcpy(&island_branch, target_words + 1, sizeof(island_branch));
-  EXPECT_EQ(island_branch.encoding, 0x17Fu);
-  EXPECT_EQ(island_branch.op, 2u);
+  const size_t translated_word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+  const uint32_t marker = rocjitsu::build_s_nop(rocjitsu::kBranchIslandPoolMarkerNopImmediate,
+                                                ROCJITSU_CODE_ARCH_CDNA3);
+  const uint32_t skip_pool = rocjitsu::build_s_branch(16, ROCJITSU_CODE_ARCH_CDNA3);
+  const uint32_t skip_over_pool =
+      rocjitsu::build_s_branch(static_cast<int16_t>(rocjitsu::kGeneratedIslandPoolHeaderWords +
+                                                    rocjitsu::kDirectBranchIslandPoolSlots),
+                               ROCJITSU_CODE_ARCH_CDNA3);
+  const uint32_t unused_slot = rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3);
+  bool found_live_skipped_pool = false;
+  for (size_t i = 1;
+       i + rocjitsu::kGeneratedIslandPoolHeaderWords + rocjitsu::kDirectBranchIslandPoolSlots <=
+       translated_word_count;
+       ++i) {
+    if (target_words[i] != marker || target_words[i - 1] != skip_over_pool ||
+        target_words[i + 1] != skip_pool) {
+      continue;
+    }
+    const size_t first_slot = i + rocjitsu::kGeneratedIslandPoolHeaderWords;
+    const size_t past_slots = first_slot + rocjitsu::kDirectBranchIslandPoolSlots;
+    if (std::any_of(target_words + first_slot, target_words + past_slots,
+                    [&](uint32_t word) { return word != unused_slot; })) {
+      found_live_skipped_pool = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found_live_skipped_pool);
+  bool found_island_source = false;
+  const uint32_t inverted = cdna3::build_sopp(cdna3::kSCbranchScc0Sopp, {.simm16 = 1})[0];
+  for (size_t i = 0; i + 1 < translated_word_count; ++i) {
+    if (target_words[i] == inverted && ((target_words[i + 1] >> 23) & 0x1ffu) == 0x17fu) {
+      found_island_source = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found_island_source);
+  expect_cdna3_translated_descriptor_sgprs_eq(result.elf_bytes, 112);
+
+  rocjitsu::BinaryTranslator verifier(ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA3);
+  const auto second = verifier.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250RelocatesReachableGeneratedIslandPoolSlotsIdempotently) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  std::vector<uint32_t> words = {
+      // The conditional reaches the first private slot while fallthrough
+      // reaches the pool header and skip.
+      gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp, {.simm16 = 2})[0],
+      rocjitsu::build_s_nop(rocjitsu::kBranchIslandPoolMarkerNopImmediate,
+                            ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_branch(static_cast<int16_t>(rocjitsu::kDirectBranchIslandPoolSlots),
+                               ROCJITSU_CODE_ARCH_GFX1250),
+  };
+  words.insert(words.end(), rocjitsu::kDirectBranchIslandPoolSlots,
+               rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_GFX1250));
+  words.push_back(kGfx1250SEndpgm);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto first = translator.translate(source);
+  ASSERT_TRUE(first.ok()) << (first.diagnostics.empty() ? "" : first.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(first.elf_bytes.data(), first.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, first.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250RejectsGeneratedIslandPoolSlotTargetingOutsideText) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  std::vector<uint32_t> words = {
+      // Reach the first private slot so it is live in this kernel scope.
+      gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp, {.simm16 = 2})[0],
+      rocjitsu::build_s_nop(rocjitsu::kBranchIslandPoolMarkerNopImmediate,
+                            ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_branch(static_cast<int16_t>(rocjitsu::kDirectBranchIslandPoolSlots),
+                               ROCJITSU_CODE_ARCH_GFX1250),
+  };
+  words.insert(words.end(), rocjitsu::kDirectBranchIslandPoolSlots,
+               rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_GFX1250));
+  words[rocjitsu::kGeneratedIslandPoolHeaderWords + 1] =
+      rocjitsu::build_s_branch(30000, ROCJITSU_CODE_ARCH_GFX1250);
+  words.push_back(kGfx1250SEndpgm);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_TRUE(rocjitsu::has_error_containing(
+      result, rocjitsu::DiagnosticKind::Legalization,
+      "generated direct branch island pool targets outside source .text"));
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250RejectsNearMissGeneratedIslandPool) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  std::vector<uint32_t> words = {
+      rocjitsu::build_s_nop(rocjitsu::kBranchIslandPoolMarkerNopImmediate,
+                            ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_branch(static_cast<int16_t>(rocjitsu::kDirectBranchIslandPoolSlots),
+                               ROCJITSU_CODE_ARCH_GFX1250),
+  };
+  words.insert(words.end(), rocjitsu::kDirectBranchIslandPoolSlots,
+               rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_GFX1250));
+  words[2 + rocjitsu::kDirectBranchIslandPoolSlots / 2] =
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250);
+  words.push_back(kGfx1250SEndpgm);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto first = translator.translate(source);
+  ASSERT_TRUE(first.ok()) << (first.diagnostics.empty() ? "" : first.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(first.elf_bytes.data(), first.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(std::ranges::count_if(decoded,
+                                  [](const auto &inst) { return inst->mnemonic() == "s_branch"; }),
+            1);
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, first.elf_bytes);
 }
 
 TEST(BinaryTranslatorE2E, DuplicatesSharedReachableBlocksPerKernel) {
@@ -7615,13 +8328,10 @@ TEST(BinaryTranslatorE2E, RelocatedKernelCompactsReachableBodyAndPatchesBranches
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
   // This kernel does not use the kernarg-preload compatibility entry path, so
   // relocation emits only the reachable CFG body. Source gaps disappear and
-  // branch immediates are patched against the compact target layout. Conditional
-  // direct branches still reserve their patch window, so the compact body keeps
-  // one target-ISA NOP slot beside each conditional transfer.
+  // branch immediates are patched against the compact target layout.
   const std::vector<uint32_t> expected = {
       rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3),
-      cdna3::build_sopp(cdna3::kSCbranchScc1Sopp, {.simm16 = 2})[0],
-      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3),
+      cdna3::build_sopp(cdna3::kSCbranchScc1Sopp, {.simm16 = 1})[0],
       rocjitsu::build_s_branch(1, ROCJITSU_CODE_ARCH_CDNA3),
       rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3),
       kCdna4SEndpgm,
@@ -7705,17 +8415,16 @@ TEST(BinaryTranslatorE2E, PatchesRecoveredSetpcTargetAfterRelocation) {
 
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
-  ASSERT_GE(translated.text_sections()[0]->size(), 11 * sizeof(uint32_t));
+  ASSERT_GE(translated.text_sections()[0]->size(), 6 * sizeof(uint32_t));
   // Recovered indirect jumps now patch the consumer site rather than rewriting
-  // the source-side getpc/add builder. The fixed six-word transfer window keeps
-  // block placement deterministic before the final target address is known.
+  // the source-side getpc/add builder. Its consumer starts as one compact word
+  // and grows only if final placement requires the canonical long form.
   EXPECT_EQ(target_words[0], build_s_getpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_CDNA3));
   EXPECT_EQ(target_words[1], build_s_add_u32(kPcSreg, kPcSreg, kLiteralOperand));
   EXPECT_EQ(target_words[2], kOriginalGetpcDelta);
   EXPECT_EQ(target_words[3], build_s_addc_u32(kPcSreg + 1, kPcSreg + 1, kInlineInt0));
-  EXPECT_EQ(target_words[4], rocjitsu::build_s_branch(5, ROCJITSU_CODE_ARCH_CDNA3));
-  expect_nop_words(target_words, 5, 10, ROCJITSU_CODE_ARCH_CDNA3);
-  EXPECT_EQ(target_words[10], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(target_words[4], rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(target_words[5], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3));
 }
 
 TEST(BinaryTranslatorE2E, PatchesRecoveredSwappcTargetAfterRelocation) {
@@ -7748,16 +8457,15 @@ TEST(BinaryTranslatorE2E, PatchesRecoveredSwappcTargetAfterRelocation) {
 
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
-  ASSERT_GE(translated.text_sections()[0]->size(), 11 * sizeof(uint32_t));
+  ASSERT_GE(translated.text_sections()[0]->size(), 6 * sizeof(uint32_t));
   EXPECT_EQ(target_words[0], build_s_getpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_CDNA3));
   EXPECT_EQ(target_words[1], build_s_add_u32(kPcSreg, kPcSreg, kLiteralOperand));
   EXPECT_EQ(target_words[2], kOriginalGetpcDelta);
   EXPECT_EQ(target_words[3], build_s_addc_u32(kPcSreg + 1, kPcSreg + 1, kInlineInt0));
-  // The target is non-returning, so relocation drops the dead continuation.
-  // The pre-existing recovered-transfer window remains in place on this branch.
-  EXPECT_EQ(target_words[4], build_s_call_b64(kReturnSreg, 5));
-  expect_nop_words(target_words, 5, 10, ROCJITSU_CODE_ARCH_CDNA3);
-  EXPECT_EQ(target_words[10], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3));
+  // The target is non-returning, so relocation drops the dead continuation
+  // and compacts the target immediately after the call.
+  EXPECT_EQ(target_words[4], build_s_call_b64(kReturnSreg, 0));
+  EXPECT_EQ(target_words[5], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3));
 }
 
 TEST(BinaryTranslatorE2E, TranslatesDirectSCallWithSetpcReturn) {
@@ -7907,19 +8615,17 @@ TEST(BinaryTranslatorE2E, TranslatesSwappcCallWhenCalleeSetpcBranchesToReturn) {
 
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
-  ASSERT_GE(translated.text_sections()[0]->size(), 22 * sizeof(uint32_t));
+  ASSERT_GE(translated.text_sections()[0]->size(), 12 * sizeof(uint32_t));
   EXPECT_EQ(target_words[0], build_s_getpc_b64(kCallTargetSreg, ROCJITSU_CODE_ARCH_CDNA3));
   EXPECT_EQ(target_words[2], kOriginalCallTargetDelta);
-  EXPECT_EQ(target_words[4], build_s_call_b64(kReturnSreg, 6))
+  EXPECT_EQ(target_words[4], build_s_call_b64(kReturnSreg, 1))
       << "the swappc call window should patch directly to the compact callee body";
-  expect_nop_words(target_words, 5, 10, ROCJITSU_CODE_ARCH_CDNA3);
-  EXPECT_EQ(target_words[10], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3));
-  EXPECT_EQ(target_words[11], build_s_getpc_b64(kReturnTargetSreg, ROCJITSU_CODE_ARCH_CDNA3));
-  EXPECT_EQ(target_words[13], kOriginalReturnTargetDelta);
-  EXPECT_EQ(target_words[15], rocjitsu::build_s_branch(5, ROCJITSU_CODE_ARCH_CDNA3))
+  EXPECT_EQ(target_words[5], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(target_words[6], build_s_getpc_b64(kReturnTargetSreg, ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(target_words[8], kOriginalReturnTargetDelta);
+  EXPECT_EQ(target_words[10], rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3))
       << "the callee's recovered setpc window is what reaches the return block";
-  expect_nop_words(target_words, 16, 21, ROCJITSU_CODE_ARCH_CDNA3);
-  EXPECT_EQ(target_words[21], build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(target_words[11], build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_CDNA3));
 }
 
 TEST(BinaryTranslatorE2E, PatchesOneRecoveredBuilderUsedByTwoSetpcConsumers) {
@@ -7952,18 +8658,15 @@ TEST(BinaryTranslatorE2E, PatchesOneRecoveredBuilderUsedByTwoSetpcConsumers) {
 
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
-  ASSERT_GE(translated.text_sections()[0]->size(), 18 * sizeof(uint32_t));
+  ASSERT_GE(translated.text_sections()[0]->size(), 8 * sizeof(uint32_t));
   EXPECT_EQ(target_words[0], build_s_getpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_CDNA3));
   EXPECT_EQ(target_words[1], build_s_add_u32(kPcSreg, kPcSreg, kLiteralOperand));
   EXPECT_EQ(target_words[2], kOriginalGetpcDelta);
   EXPECT_EQ(target_words[3], build_s_addc_u32(kPcSreg + 1, kPcSreg + 1, kInlineInt0));
-  EXPECT_EQ(target_words[4], cdna3::build_sopp(cdna3::kSCbranchScc1Sopp, {.simm16 = 7})[0]);
-  EXPECT_EQ(target_words[5], rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3));
-  EXPECT_EQ(target_words[6], rocjitsu::build_s_branch(11, ROCJITSU_CODE_ARCH_CDNA3));
-  expect_nop_words(target_words, 7, 12, ROCJITSU_CODE_ARCH_CDNA3);
-  EXPECT_EQ(target_words[12], rocjitsu::build_s_branch(5, ROCJITSU_CODE_ARCH_CDNA3));
-  expect_nop_words(target_words, 13, 18, ROCJITSU_CODE_ARCH_CDNA3);
-  EXPECT_EQ(target_words[18], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(target_words[4], cdna3::build_sopp(cdna3::kSCbranchScc1Sopp, {.simm16 = 1})[0]);
+  EXPECT_EQ(target_words[5], rocjitsu::build_s_branch(1, ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(target_words[6], rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(target_words[7], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3));
 }
 
 TEST(BinaryTranslatorE2E, RewritesDistinctBuildersForOneMultiTargetSetpcConsumer) {
@@ -8006,14 +8709,14 @@ TEST(BinaryTranslatorE2E, RewritesDistinctBuildersForOneMultiTargetSetpcConsumer
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
   ASSERT_GE(translated.text_sections()[0]->size(), 15 * sizeof(uint32_t));
-  EXPECT_EQ(target_words[4], kRelocatedTargetADelta)
+  EXPECT_EQ(target_words[3], kRelocatedTargetADelta)
       << "builder A should be rewritten once for its relocated target";
-  EXPECT_EQ(target_words[9], kRelocatedTargetBDelta)
+  EXPECT_EQ(target_words[8], kRelocatedTargetBDelta)
       << "builder B should be rewritten once for its relocated target";
-  EXPECT_EQ(target_words[12], build_s_setpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_CDNA3))
+  EXPECT_EQ(target_words[11], build_s_setpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_CDNA3))
       << "one consumer with multiple possible targets must stay indirect";
+  EXPECT_EQ(target_words[12], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3));
   EXPECT_EQ(target_words[13], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3));
-  EXPECT_EQ(target_words[14], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3));
 }
 
 TEST(BinaryTranslatorE2E, RelocatesDirectCallReturnAcrossShiftedOffsets) {
@@ -9121,6 +9824,26 @@ TEST(SemanticTranslator, Gfx1250ClassifiesLivenessFreeExpandRules) {
           gfx1250::kVWmmaF3232x16x128F4Vop3p,
   };
   EXPECT_EQ(liveness_free_rules, expected);
+
+  rocjitsu::SemanticTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250,
+                                          rocjitsu::ProcessorRevision::Gfx1250B0,
+                                          rocjitsu::ProcessorRevision::Gfx1250A0);
+  constexpr auto tensor_mask_clear =
+      gfx1250::build_sop2(gfx1250::kSPackHhB32B16Sop2, {.ssrc0 = 128, .ssrc1 = 0, .sdst = 0});
+  constexpr auto cluster_m0_clear =
+      gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 128, .sdst = 125});
+  constexpr auto v_nop = gfx1250::build_vop1(gfx1250::kVNopVop1);
+  const auto tensor_clear_inst =
+      rocjitsu::decode_one(tensor_mask_clear[0], ROCJITSU_CODE_ARCH_GFX1250);
+  const auto cluster_clear_inst =
+      rocjitsu::decode_one(cluster_m0_clear[0], ROCJITSU_CODE_ARCH_GFX1250);
+  const auto v_nop_inst = rocjitsu::decode_one(v_nop[0], ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(tensor_clear_inst, nullptr);
+  ASSERT_NE(cluster_clear_inst, nullptr);
+  ASSERT_NE(v_nop_inst, nullptr);
+  EXPECT_FALSE(translator.has_expand_rule(*tensor_clear_inst));
+  EXPECT_FALSE(translator.has_expand_rule(*cluster_clear_inst));
+  EXPECT_FALSE(translator.has_expand_rule(*v_nop_inst));
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250LowersF32K128Fp8Bf8WmmaToNeutralRegularScale) {
@@ -9307,6 +10030,16 @@ TEST(BinaryTranslatorE2E, Gfx1250MasksM0AroundOffFormClusterLoadForA0) {
       cleared_m0 = true;
   }
   EXPECT_TRUE(cleared_m0) << "off-form cluster load must still set M0 (125) = inline 0 (128)";
+
+  rocjitsu::BinaryTranslator verifier(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto second_result = verifier.translate(translated);
+  ASSERT_TRUE(second_result.ok()) << (second_result.diagnostics.empty()
+                                          ? ""
+                                          : second_result.diagnostics.front().message);
+  EXPECT_EQ(second_result.elf_bytes, result.elf_bytes);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250MasksM0AroundSaddrClusterLoadForA0) {
@@ -9356,6 +10089,189 @@ TEST(BinaryTranslatorE2E, Gfx1250MasksM0AroundSaddrClusterLoadForA0) {
   EXPECT_TRUE(saved_m0) << "no s_mov_b32 reads M0 (125) to save it";
   EXPECT_TRUE(cleared_m0) << "no s_mov_b32 sets M0 (125) = inline 0 (128)";
   EXPECT_TRUE(restored_m0) << "no s_mov_b32 restores M0 (125) from the saved scratch";
+
+  rocjitsu::BinaryTranslator verifier(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto second_result = verifier.translate(translated);
+  ASSERT_TRUE(second_result.ok()) << (second_result.diagnostics.empty()
+                                          ? ""
+                                          : second_result.diagnostics.front().message);
+  EXPECT_EQ(second_result.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadPreservesGuestM0ClearWithoutRestore) {
+  constexpr auto clear_m0 = gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 128, .sdst = 125});
+  constexpr auto cluster = gfx1250::build_vglobal(gfx1250::kClusterLoadB32Vglobal,
+                                                  {.saddr = 124, .vdst = 8, .vaddr = 12});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {clear_m0[0], cluster[0], cluster[1], cluster[2], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  ASSERT_EQ(translated.text_sections()[0]->size(), 5 * sizeof(uint32_t));
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  EXPECT_EQ(target_words[0], clear_m0[0]);
+  EXPECT_EQ(target_words[1], cluster[0]);
+  EXPECT_EQ(target_words[2], cluster[1]);
+  EXPECT_EQ(target_words[3], cluster[2]);
+  EXPECT_EQ(target_words[4], kGfx1250SEndpgm);
+
+  rocjitsu::BinaryTranslator verifier(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto second_result = verifier.translate(translated);
+  ASSERT_TRUE(second_result.ok()) << (second_result.diagnostics.empty()
+                                          ? ""
+                                          : second_result.diagnostics.front().message);
+  EXPECT_EQ(second_result.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseNonzeroM0Write) {
+  constexpr auto nonzero_m0 = gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 1, .sdst = 125});
+  constexpr auto clear_m0 = gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 128, .sdst = 125});
+  constexpr auto cluster = gfx1250::build_vglobal(gfx1250::kClusterLoadB32Vglobal,
+                                                  {.saddr = 124, .vdst = 8, .vaddr = 12});
+  constexpr auto generated_save =
+      gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 125, .sdst = 0});
+  constexpr auto generated_restore =
+      gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 0, .sdst = 125});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {nonzero_m0[0], cluster[0], cluster[1], cluster[2], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  ASSERT_EQ(translated.text_sections()[0]->size(), 8 * sizeof(uint32_t));
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  EXPECT_EQ(target_words[0], nonzero_m0[0]);
+  EXPECT_EQ(target_words[1], generated_save[0]);
+  EXPECT_EQ(target_words[2], clear_m0[0]);
+  EXPECT_EQ(target_words[3], cluster[0]);
+  EXPECT_EQ(target_words[4], cluster[1]);
+  EXPECT_EQ(target_words[5], cluster[2]);
+  EXPECT_EQ(target_words[6], generated_restore[0]);
+  EXPECT_EQ(target_words[7], kGfx1250SEndpgm);
+
+  rocjitsu::BinaryTranslator verifier(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto second_result = verifier.translate(translated);
+  ASSERT_TRUE(second_result.ok()) << (second_result.diagnostics.empty()
+                                          ? ""
+                                          : second_result.diagnostics.front().message);
+  EXPECT_EQ(second_result.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseZeroWriteToOtherSgpr) {
+  constexpr auto clear_s7 = gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 128, .sdst = 7});
+  constexpr auto clear_m0 = gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 128, .sdst = 125});
+  constexpr auto cluster = gfx1250::build_vglobal(gfx1250::kClusterLoadB32Vglobal,
+                                                  {.saddr = 124, .vdst = 8, .vaddr = 12});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {clear_s7[0], cluster[0], cluster[1], cluster[2], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  ASSERT_EQ(translated.text_sections()[0]->size(), 8 * sizeof(uint32_t));
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  EXPECT_EQ(target_words[0], clear_s7[0]);
+  EXPECT_EQ(target_words[2], clear_m0[0]);
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseM0ClearBypassedByBranch) {
+  constexpr auto branch_to_cluster = gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp, {.simm16 = 2});
+  constexpr auto source_save =
+      gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 125, .sdst = 12});
+  constexpr auto clear_m0 = gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 128, .sdst = 125});
+  constexpr auto cluster = gfx1250::build_vglobal(gfx1250::kClusterLoadB32Vglobal,
+                                                  {.saddr = 124, .vdst = 8, .vaddr = 12});
+  constexpr auto source_restore =
+      gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 12, .sdst = 125});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {branch_to_cluster[0], source_save[0], clear_m0[0], cluster[0], cluster[1], cluster[2],
+       source_restore[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  ASSERT_EQ(translated.text_sections()[0]->size(), 11 * sizeof(uint32_t));
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  constexpr auto generated_save =
+      gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 125, .sdst = 0});
+  constexpr auto generated_restore =
+      gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 0, .sdst = 125});
+  EXPECT_EQ(target_words[0], branch_to_cluster[0]);
+  EXPECT_EQ(target_words[1], source_save[0]);
+  EXPECT_EQ(target_words[2], clear_m0[0]);
+  EXPECT_EQ(target_words[3], generated_save[0]);
+  EXPECT_EQ(target_words[4], clear_m0[0]);
+  EXPECT_EQ(target_words[5], cluster[0]);
+  EXPECT_EQ(target_words[6], cluster[1]);
+  EXPECT_EQ(target_words[7], cluster[2]);
+  EXPECT_EQ(target_words[8], generated_restore[0]);
+  EXPECT_EQ(target_words[9], source_restore[0]);
+  EXPECT_EQ(target_words[10], kGfx1250SEndpgm);
+
+  rocjitsu::BinaryTranslator verifier(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto second_result = verifier.translate(translated);
+  ASSERT_TRUE(second_result.ok()) << (second_result.diagnostics.empty()
+                                          ? ""
+                                          : second_result.diagnostics.front().message);
+  EXPECT_EQ(second_result.elf_bytes, result.elf_bytes);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250MaterializesDsAddtidAddressForA0) {
@@ -9784,21 +10700,107 @@ TEST(BinaryTranslatorE2E, Gfx1250AddtidStoreModeUsesSrc1BankNotSrc0) {
          "must record the previous mode in SIMM16[15:8]";
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250ConservativelyPadsIu8WmmaForA0) {
+TEST(BinaryTranslatorE2E, Gfx1250Iu8WmmaSpacingCreditsOnlySameBlockCanonicalVNops) {
+  enum class Consumer {
+    EndProgram,
+    ValuThenVNops,
+    DenseWmma,
+    ScalarNopThenDenseWmma,
+  };
   struct Case {
+    const char *name;
     uint16_t opcode;
     size_t required_slots;
+    size_t existing_slots;
+    Consumer consumer;
+    size_t trailing_slots;
   };
   constexpr std::array cases = {
-      Case{gfx1250::kVWmmaI3216x16x64Iu8Vop3p, 9},
-      Case{gfx1250::kVSwmmacI3216x16x128Iu8Vop3p, 5},
+      Case{.name = "dense_no_existing_padding",
+           .opcode = gfx1250::kVWmmaI3216x16x64Iu8Vop3p,
+           .required_slots = 9,
+           .existing_slots = 0,
+           .consumer = Consumer::EndProgram,
+           .trailing_slots = 0},
+      Case{.name = "sparse_no_existing_padding",
+           .opcode = gfx1250::kVSwmmacI3216x16x128Iu8Vop3p,
+           .required_slots = 5,
+           .existing_slots = 0,
+           .consumer = Consumer::EndProgram,
+           .trailing_slots = 0},
+      Case{.name = "dense_partial_credit",
+           .opcode = gfx1250::kVWmmaI3216x16x64Iu8Vop3p,
+           .required_slots = 9,
+           .existing_slots = 4,
+           .consumer = Consumer::EndProgram,
+           .trailing_slots = 0},
+      Case{.name = "sparse_partial_credit",
+           .opcode = gfx1250::kVSwmmacI3216x16x128Iu8Vop3p,
+           .required_slots = 5,
+           .existing_slots = 3,
+           .consumer = Consumer::EndProgram,
+           .trailing_slots = 0},
+      Case{.name = "sparse_exact_credit",
+           .opcode = gfx1250::kVSwmmacI3216x16x128Iu8Vop3p,
+           .required_slots = 5,
+           .existing_slots = 5,
+           .consumer = Consumer::EndProgram,
+           .trailing_slots = 0},
+      Case{.name = "dense_over_padded",
+           .opcode = gfx1250::kVWmmaI3216x16x64Iu8Vop3p,
+           .required_slots = 9,
+           .existing_slots = 12,
+           .consumer = Consumer::EndProgram,
+           .trailing_slots = 0},
+      Case{.name = "dense_credit_stops_at_valu",
+           .opcode = gfx1250::kVWmmaI3216x16x64Iu8Vop3p,
+           .required_slots = 9,
+           .existing_slots = 0,
+           .consumer = Consumer::ValuThenVNops,
+           .trailing_slots = 8},
+      Case{.name = "back_to_back_dense",
+           .opcode = gfx1250::kVWmmaI3216x16x64Iu8Vop3p,
+           .required_slots = 9,
+           .existing_slots = 0,
+           .consumer = Consumer::DenseWmma,
+           .trailing_slots = 0},
+      Case{.name = "dense_partial_credit_before_matrix_consumer",
+           .opcode = gfx1250::kVWmmaI3216x16x64Iu8Vop3p,
+           .required_slots = 9,
+           .existing_slots = 4,
+           .consumer = Consumer::DenseWmma,
+           .trailing_slots = 0},
+      Case{.name = "scalar_nop_receives_no_credit",
+           .opcode = gfx1250::kVWmmaI3216x16x64Iu8Vop3p,
+           .required_slots = 9,
+           .existing_slots = 0,
+           .consumer = Consumer::ScalarNopThenDenseWmma,
+           .trailing_slots = 0},
   };
+  const uint32_t v_nop = gfx1250::build_vop1(gfx1250::kVNopVop1)[0];
+  const uint32_t v_mov = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 0})[0];
+  const uint32_t s_nop = gfx1250::build_sopp(gfx1250::kSNopSopp, {.simm16 = 8})[0];
+  const auto consumer_wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaI3216x16x64Iu8Vop3p,
+                           {.vdst = 64, .src0 = 256 + 72, .src1 = 256 + 136, .src2 = 256 + 200});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   for (const Case &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
     const auto source_wmma = gfx1250::build_vop3p(
         test_case.opcode, {.vdst = 32, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
-    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
-        {source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
+    std::vector<uint32_t> source_words = {source_wmma[0], source_wmma[1]};
+    source_words.insert(source_words.end(), test_case.existing_slots, v_nop);
+    if (test_case.consumer == Consumer::ValuThenVNops) {
+      source_words.push_back(v_mov);
+      source_words.insert(source_words.end(), test_case.trailing_slots, v_nop);
+    } else if (test_case.consumer == Consumer::DenseWmma) {
+      source_words.insert(source_words.end(), consumer_wmma.begin(), consumer_wmma.end());
+    } else if (test_case.consumer == Consumer::ScalarNopThenDenseWmma) {
+      source_words.push_back(s_nop);
+      source_words.insert(source_words.end(), consumer_wmma.begin(), consumer_wmma.end());
+    }
+    source_words.push_back(kGfx1250SEndpgm);
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(source_words);
     rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
 
     rocjitsu::BinaryTranslator translator(
@@ -9811,15 +10813,80 @@ TEST(BinaryTranslatorE2E, Gfx1250ConservativelyPadsIu8WmmaForA0) {
 
     rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
     ASSERT_FALSE(translated.text_sections().empty());
+    const size_t expected_prefix_slots =
+        std::max(test_case.required_slots, test_case.existing_slots);
+    std::vector<uint32_t> expected_words = {source_wmma[0], source_wmma[1]};
+    expected_words.insert(expected_words.end(), expected_prefix_slots, v_nop);
+    if (test_case.consumer == Consumer::ValuThenVNops) {
+      expected_words.push_back(v_mov);
+      expected_words.insert(expected_words.end(), test_case.trailing_slots, v_nop);
+    } else if (test_case.consumer == Consumer::DenseWmma) {
+      expected_words.insert(expected_words.end(), consumer_wmma.begin(), consumer_wmma.end());
+      expected_words.insert(expected_words.end(), 9, v_nop);
+    } else if (test_case.consumer == Consumer::ScalarNopThenDenseWmma) {
+      expected_words.push_back(s_nop);
+      expected_words.insert(expected_words.end(), consumer_wmma.begin(), consumer_wmma.end());
+      expected_words.insert(expected_words.end(), 9, v_nop);
+    }
+    expected_words.push_back(kGfx1250SEndpgm);
+    ASSERT_EQ(translated.text_sections()[0]->size(), expected_words.size() * sizeof(uint32_t));
     const auto *target_words =
         reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
-    EXPECT_EQ(target_words[0], source_wmma[0]);
-    EXPECT_EQ(target_words[1], source_wmma[1]);
-    const uint32_t v_nop = gfx1250::build_vop1(gfx1250::kVNopVop1)[0];
-    for (size_t slot = 0; slot < test_case.required_slots; ++slot)
-      EXPECT_EQ(target_words[2 + slot], v_nop);
-    EXPECT_EQ(target_words[2 + test_case.required_slots], kGfx1250SEndpgm);
+    EXPECT_EQ(std::vector<uint32_t>(target_words, target_words + expected_words.size()),
+              expected_words);
+
+    rocjitsu::BinaryTranslator verifier(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    auto second_result = verifier.translate(translated);
+    ASSERT_TRUE(second_result.ok())
+        << (second_result.diagnostics.empty() ? "" : second_result.diagnostics.front().message);
+    EXPECT_EQ(second_result.elf_bytes, result.elf_bytes);
   }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250Iu8WmmaDoesNotCreditVNopsAcrossBlockBoundary) {
+  constexpr auto branch_to_padding = gfx1250::build_sopp(gfx1250::kSCbranchScc1Sopp, {.simm16 = 2});
+  constexpr auto source_wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaI3216x16x64Iu8Vop3p,
+                           {.vdst = 32, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
+  const uint32_t v_nop = gfx1250::build_vop1(gfx1250::kVNopVop1)[0];
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  std::vector<uint32_t> source_words = {branch_to_padding[0], source_wmma[0], source_wmma[1]};
+  source_words.insert(source_words.end(), 9, v_nop);
+  source_words.push_back(kGfx1250SEndpgm);
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(source_words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  ASSERT_EQ(translated.text_sections()[0]->size(), 22 * sizeof(uint32_t));
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  EXPECT_EQ(target_words[1], source_wmma[0]);
+  EXPECT_EQ(target_words[2], source_wmma[1]);
+  for (size_t slot = 0; slot < 18; ++slot)
+    EXPECT_EQ(target_words[3 + slot], v_nop);
+  EXPECT_EQ(target_words[21], kGfx1250SEndpgm);
+
+  rocjitsu::BinaryTranslator verifier(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto second_result = verifier.translate(translated);
+  ASSERT_TRUE(second_result.ok()) << (second_result.diagnostics.empty()
+                                          ? ""
+                                          : second_result.diagnostics.front().message);
+  EXPECT_EQ(second_result.elf_bytes, result.elf_bytes);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250TensorLoadAlwaysClearsDynamicMulticastMask) {
@@ -9860,6 +10927,182 @@ TEST(BinaryTranslatorE2E, Gfx1250TensorLoadAlwaysClearsDynamicMulticastMask) {
   EXPECT_EQ(target_words[4], source_tensor[2]);
   EXPECT_EQ(target_words[5], restore_d1[0]);
   EXPECT_EQ(target_words[6], kGfx1250SEndpgm);
+
+  auto second_result = translator.translate(translated);
+  ASSERT_TRUE(second_result.ok()) << (second_result.diagnostics.empty()
+                                          ? ""
+                                          : second_result.diagnostics.front().message);
+  EXPECT_EQ(second_result.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250TensorLoadPreservesGuestMaskClearWithoutRestore) {
+  // An immediately preceding clear in the same block already guarantees the
+  // A0 mask invariant. Preserve the guest's choice not to restore the mask.
+  constexpr auto source_clear =
+      gfx1250::build_sop2(gfx1250::kSPackHhB32B16Sop2, {.ssrc0 = 128, .ssrc1 = 0, .sdst = 0});
+  constexpr auto source_tensor = gfx1250::build_vimage(
+      gfx1250::kTensorLoadToLdsVimage,
+      {.vaddr4 = 124, .vaddr0 = 8, .vaddr1 = 0, .vaddr2 = 124, .vaddr3 = 124});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {source_clear[0], source_tensor[0], source_tensor[1], source_tensor[2], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  ASSERT_EQ(translated.text_sections()[0]->size(), 5 * sizeof(uint32_t));
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  EXPECT_EQ(target_words[0], source_clear[0]);
+  EXPECT_EQ(target_words[1], source_tensor[0]);
+  EXPECT_EQ(target_words[2], source_tensor[1]);
+  EXPECT_EQ(target_words[3], source_tensor[2]);
+  EXPECT_EQ(target_words[4], kGfx1250SEndpgm);
+
+  auto second_result = translator.translate(translated);
+  ASSERT_TRUE(second_result.ok()) << (second_result.diagnostics.empty()
+                                          ? ""
+                                          : second_result.diagnostics.front().message);
+  EXPECT_EQ(second_result.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250TensorLoadDoesNotReuseNonzeroMaskWrite) {
+  constexpr auto source_nonzero =
+      gfx1250::build_sop2(gfx1250::kSPackHhB32B16Sop2, {.ssrc0 = 1, .ssrc1 = 0, .sdst = 0});
+  constexpr auto source_tensor = gfx1250::build_vimage(
+      gfx1250::kTensorLoadToLdsVimage,
+      {.vaddr4 = 124, .vaddr0 = 8, .vaddr1 = 0, .vaddr2 = 124, .vaddr3 = 124});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {source_nonzero[0], source_tensor[0], source_tensor[1], source_tensor[2], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto first = translator.translate(source);
+  ASSERT_TRUE(first.ok()) << (first.diagnostics.empty() ? "" : first.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(first.elf_bytes.data(), first.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  constexpr auto save_d1 = gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 0, .sdst = 12});
+  constexpr auto clear_mask =
+      gfx1250::build_sop2(gfx1250::kSPackHhB32B16Sop2, {.ssrc0 = 128, .ssrc1 = 0, .sdst = 0});
+  constexpr auto restore_d1 = gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 12, .sdst = 0});
+  EXPECT_EQ(target_words[0], source_nonzero[0]);
+  EXPECT_EQ(target_words[1], save_d1[0]);
+  EXPECT_EQ(target_words[2], clear_mask[0]);
+  EXPECT_EQ(target_words[3], source_tensor[0]);
+  EXPECT_EQ(target_words[4], source_tensor[1]);
+  EXPECT_EQ(target_words[5], source_tensor[2]);
+  EXPECT_EQ(target_words[6], restore_d1[0]);
+  EXPECT_EQ(target_words[7], kGfx1250SEndpgm);
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, first.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250TensorLoadDoesNotReuseClearOfDifferentDescriptor) {
+  constexpr auto clear_s4 =
+      gfx1250::build_sop2(gfx1250::kSPackHhB32B16Sop2, {.ssrc0 = 128, .ssrc1 = 4, .sdst = 4});
+  constexpr auto clear_s0 =
+      gfx1250::build_sop2(gfx1250::kSPackHhB32B16Sop2, {.ssrc0 = 128, .ssrc1 = 0, .sdst = 0});
+  constexpr auto source_tensor = gfx1250::build_vimage(
+      gfx1250::kTensorLoadToLdsVimage,
+      {.vaddr4 = 124, .vaddr0 = 8, .vaddr1 = 0, .vaddr2 = 124, .vaddr3 = 124});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {clear_s4[0], source_tensor[0], source_tensor[1], source_tensor[2], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  ASSERT_EQ(translated.text_sections()[0]->size(), 8 * sizeof(uint32_t));
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  EXPECT_EQ(target_words[0], clear_s4[0]);
+  EXPECT_EQ(target_words[2], clear_s0[0]);
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250TensorLoadDoesNotReuseMaskPrefixBypassedByBranch) {
+  // The branch makes the tensor load a block leader, so it can bypass the
+  // guest-authored clear and must receive a new wrapper. The guest save keeps
+  // s12 live across the load, making s13 the first free scratch register.
+  constexpr auto branch_to_tensor = gfx1250::build_sopp(gfx1250::kSBranchSopp, {.simm16 = 2});
+  constexpr auto source_save = gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 0, .sdst = 12});
+  constexpr auto source_clear =
+      gfx1250::build_sop2(gfx1250::kSPackHhB32B16Sop2, {.ssrc0 = 128, .ssrc1 = 0, .sdst = 0});
+  constexpr auto source_tensor = gfx1250::build_vimage(
+      gfx1250::kTensorLoadToLdsVimage,
+      {.vaddr4 = 124, .vaddr0 = 8, .vaddr1 = 0, .vaddr2 = 124, .vaddr3 = 124});
+  constexpr auto source_restore =
+      gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 12, .sdst = 0});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {branch_to_tensor[0], source_save[0], source_clear[0], source_tensor[0], source_tensor[1],
+       source_tensor[2], source_restore[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  ASSERT_GE(translated.text_sections()[0]->size(), 9 * sizeof(uint32_t));
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  constexpr auto relocated_branch = gfx1250::build_sopp(gfx1250::kSBranchSopp, {.simm16 = 0});
+  constexpr auto generated_save =
+      gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 0, .sdst = 13});
+  constexpr auto generated_restore =
+      gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 13, .sdst = 0});
+  EXPECT_EQ(target_words[0], relocated_branch[0]);
+  EXPECT_EQ(target_words[1], generated_save[0]);
+  EXPECT_EQ(target_words[2], source_clear[0]);
+  EXPECT_EQ(target_words[3], source_tensor[0]);
+  EXPECT_EQ(target_words[4], source_tensor[1]);
+  EXPECT_EQ(target_words[5], source_tensor[2]);
+  EXPECT_EQ(target_words[6], generated_restore[0]);
+  EXPECT_EQ(target_words[7], source_restore[0]);
+  EXPECT_EQ(target_words[8], kGfx1250SEndpgm);
+
+  auto second_result = translator.translate(translated);
+  ASSERT_TRUE(second_result.ok()) << (second_result.diagnostics.empty()
+                                          ? ""
+                                          : second_result.diagnostics.front().message);
+  EXPECT_EQ(second_result.elf_bytes, result.elf_bytes);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250RegularWmmaScaleEncodesUnusedSrc2AsVgpr) {

--- a/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
@@ -5,6 +5,7 @@
 /// @brief End-to-end smoke test for the rj_dbt_translate command-line tool.
 
 #include "dbt_translate.h"
+#include "dbt_translate_cli.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/rj_code.h"
 #include "scoped_temp.h"
@@ -34,6 +35,19 @@
 namespace {
 
 std::filesystem::path g_translate_tool;
+
+rocjitsu::tools::ToolResult<rocjitsu::tools::TranslateOutput>
+synthetic_idempotence_mismatch(const rocjitsu::tools::TranslateOptions &options) {
+  EXPECT_TRUE(options.verify_idempotence);
+
+  rocjitsu::tools::ToolResult<rocjitsu::tools::TranslateOutput> result;
+  result.value.idempotence_checked = true;
+  result.errors.push_back(
+      {.exit_code = 5,
+       .message =
+           "translation output is not byte-idempotent: section '.text' first differs at 0x4"});
+  return result;
+}
 
 uint32_t add_elf_name(std::vector<uint8_t> &names, std::string_view name) {
   const uint32_t offset = static_cast<uint32_t>(names.size());
@@ -366,6 +380,40 @@ TEST(RjDbtTranslateIdempotence, VerificationDiagnosticsDoNotInvalidateFirstPassO
   EXPECT_TRUE(output.dispatchable());
 }
 
+TEST(RjDbtTranslateIdempotence, ReportsSyntheticMismatchThroughCli) {
+  std::array arguments = {
+      std::string("rj_dbt_translate"),
+      std::string("synthetic.co"),
+      std::string("--input-target"),
+      std::string("gfx1250"),
+      std::string("--input-revision"),
+      std::string("b0"),
+      std::string("--output-target"),
+      std::string("gfx1250"),
+      std::string("--output-revision"),
+      std::string("a0"),
+      std::string("--verify-idempotence"),
+      std::string("--output-mode"),
+      std::string("diff"),
+  };
+  std::vector<char *> argv;
+  argv.reserve(arguments.size());
+  for (std::string &argument : arguments)
+    argv.push_back(argument.data());
+
+  testing::internal::CaptureStdout();
+  testing::internal::CaptureStderr();
+  const int status = rocjitsu::tools::detail::run_dbt_translate_cli(
+      static_cast<int>(argv.size()), argv.data(), synthetic_idempotence_mismatch);
+  const std::string stderr_text = testing::internal::GetCapturedStderr();
+  const std::string stdout_text = testing::internal::GetCapturedStdout();
+
+  EXPECT_EQ(status, 5);
+  EXPECT_TRUE(contains(stdout_text, "idempotence: not-verified")) << stdout_text;
+  EXPECT_TRUE(contains(stderr_text, "translation output is not byte-idempotent")) << stderr_text;
+  EXPECT_TRUE(contains(stderr_text, "section '.text' first differs at 0x4")) << stderr_text;
+}
+
 TEST(RjDbtTranslate, Smoke) {
   const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_smoke_");
   const std::filesystem::path temp_path(temp_dir.path());
@@ -639,18 +687,15 @@ TEST(RjDbtTranslate, RejectsInvalidIdempotenceOptionCombinations) {
                        "--verify-idempotence cannot be combined with --list-code-objects"));
 }
 
-TEST(RjDbtTranslate, CharacterizesGfx1250ClusterLoadRewrapAsNonIdempotent) {
-  const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_non_idempotent_");
+TEST(RjDbtTranslate, VerifiesGfx1250ClusterLoadIdempotence) {
+  const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_cluster_load_idempotence_");
   const std::filesystem::path temp_path(temp_dir.path());
   const std::filesystem::path input = temp_path / "cluster_load_gfx1250.co";
   const std::filesystem::path output = temp_path / "stdout.txt";
   const std::filesystem::path error = temp_path / "stderr.txt";
 
-  // TODO(PR #9272 follow-up): Remove this characterization once cluster-load
-  // expansion recognizes its own M0 save/restore wrapper. The permanent
-  // mismatch-reporting coverage lives in the RjDbtTranslateIdempotence tests.
-  // The cluster load is followed by s_endpgm. Its expansion preserves the load
-  // inside an M0 save/restore wrapper, so each pass wraps it again.
+  // The first pass wraps the cluster load with an M0 save/clear/restore. The
+  // second pass recognizes the canonical same-block clear and preserves it.
   constexpr std::array<uint32_t, 4> text_words = {0xee19c07cu, 0x00000001u, 0x00000002u,
                                                   0xbfb00000u};
   {
@@ -670,13 +715,12 @@ TEST(RjDbtTranslate, CharacterizesGfx1250ClusterLoadRewrapAsNonIdempotent) {
   const std::string stdout_text = read_text_file(output);
   const std::string stderr_text = read_text_file(error);
 
-  EXPECT_TRUE(command_exited_with(status, 5)) << "stderr:\n"
-                                              << stderr_text << "\nstdout:\n"
-                                              << stdout_text;
-  EXPECT_TRUE(contains(stdout_text, "idempotence: not-verified")) << stdout_text;
+  ASSERT_TRUE(command_succeeded(status)) << "stderr:\n"
+                                         << stderr_text << "\nstdout:\n"
+                                         << stdout_text;
+  EXPECT_TRUE(stderr_text.empty()) << stderr_text;
+  EXPECT_TRUE(contains(stdout_text, "idempotence: verified")) << stdout_text;
   EXPECT_TRUE(contains(stdout_text, "idempotence_diagnostics: 0")) << stdout_text;
-  EXPECT_TRUE(contains(stderr_text, "translation output is not byte-idempotent")) << stderr_text;
-  EXPECT_TRUE(contains(stderr_text, "section '.text'")) << stderr_text;
 }
 
 int main(int argc, char **argv) {

--- a/emulation/rocjitsu/tools/CMakeLists.txt
+++ b/emulation/rocjitsu/tools/CMakeLists.txt
@@ -21,6 +21,14 @@ target_link_libraries(
 )
 rj_configure_target(rocjitsu_tooling TOOL)
 
-add_executable(rj_dbt_translate dbt_translate_main.cpp)
-target_link_libraries(rj_dbt_translate PRIVATE rocjitsu_tooling)
+add_library(rocjitsu_translate_cli STATIC dbt_translate_cli.cpp)
+target_include_directories(
+    rocjitsu_translate_cli
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(rocjitsu_translate_cli PUBLIC rocjitsu_tooling)
+rj_configure_target(rocjitsu_translate_cli TOOL)
+
+add_executable(rj_dbt_translate rj_dbt_translate_main.cpp)
+target_link_libraries(rj_dbt_translate PRIVATE rocjitsu_translate_cli)
 rj_configure_target(rj_dbt_translate TOOL)

--- a/emulation/rocjitsu/tools/dbt_translate_cli.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate_cli.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
-#include "dbt_translate.h"
+#include "dbt_translate_cli.h"
 
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
@@ -583,7 +583,8 @@ int list_code_objects(const CliOptions &options) {
 
 } // namespace
 
-int main(int argc, char **argv) {
+int rocjitsu::tools::detail::run_dbt_translate_cli(int argc, char **argv,
+                                                   TranslateCodeObjectFn translate) {
   CliOptions options;
   if (!parse_args(argc, argv, options)) {
     print_help();
@@ -620,7 +621,7 @@ int main(int argc, char **argv) {
                                       ? DisassemblyMode::Translated
                                       : DisassemblyMode::None;
 
-  auto result = translate_code_object(options.translate);
+  auto result = translate(options.translate);
 
   for (const auto &diagnostic : result.value.diagnostics)
     print_diagnostic(std::cerr, diagnostic);

--- a/emulation/rocjitsu/tools/dbt_translate_cli.h
+++ b/emulation/rocjitsu/tools/dbt_translate_cli.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file dbt_translate_cli.h
+/// @brief Command-line entry point shared by rj_dbt_translate and its tests.
+
+#pragma once
+
+#include "dbt_translate.h"
+
+namespace rocjitsu::tools::detail {
+
+using TranslateCodeObjectFn = ToolResult<TranslateOutput> (*)(const TranslateOptions &);
+
+/// @brief Run the rj_dbt_translate command-line interface.
+///
+/// The translation callback keeps CLI result handling independently testable
+/// without adding test-only command-line behavior to the production binary.
+int run_dbt_translate_cli(int argc, char **argv, TranslateCodeObjectFn translate);
+
+} // namespace rocjitsu::tools::detail

--- a/emulation/rocjitsu/tools/rj_dbt_translate_main.cpp
+++ b/emulation/rocjitsu/tools/rj_dbt_translate_main.cpp
@@ -1,0 +1,9 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "dbt_translate_cli.h"
+
+int main(int argc, char **argv) {
+  return rocjitsu::tools::detail::run_dbt_translate_cli(argc, argv,
+                                                        rocjitsu::tools::translate_code_object);
+}


### PR DESCRIPTION
## Motivation

Repeated B0-to-A0 translation changed control-flow layout and reapplied semantic workarounds, preventing byte-for-byte corpus verification.

## Technical Details

- Grow direct-branch windows on demand and safely preserve canonical generated transfers and island pools across repeated translation.
- Reuse tensor-mask, cluster-load, and IU8-spacing sequences only when their exact local shape proves the required behavior.
- Report deterministic second-pass mismatches and enable verification in the required release corpus lane with bounded timeouts.

## Issue Tracking

N/A

## Test Plan

ctest + corpus.

## Test Result

Passed. The focused suite passed 258/258 and the full suite passed 2206/2206 with three expected skips, including RCCL 5/5. The corpus had 19,997 passes, three stable non-pass outcomes, and zero idempotence failures.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.