### PR TITLE
fix(rocSHMEM): Fix fabric pod detection and admit pod-spanning IPC jobs on MI450x

### DIFF
--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -36,6 +36,7 @@
 #include "log.hpp"
 #include "memory/default_allocator.hpp"
 #include "memory/hip_allocator_vmm_common.hpp"
+#include "memfabric/pod_detection.hpp"
 
 namespace rocshmem {
 
@@ -166,22 +167,65 @@ IPCBackend::~IPCBackend() {
 int IPCBackend::backend_can_run(MPI_Comm comm, TcpBootstrap* bootstrap) {
   int ret = ROCSHMEM_ERROR;
 
+  /*
+   * A heap exported with hipMemHandleTypeFabric is addressable by every device
+   * in the fabric pod, which on a pod-per-rack system is larger than one node.
+   * Admission must therefore be sized by pod membership rather than by node
+   * membership, otherwise a pod-spanning job is rejected before ipcHostInit()
+   * -- which already makes this same distinction -- ever runs.
+   */
+  bool use_pod_detection{false};
+#ifdef HAVE_AMDSMI_GPU_FABRIC_INFO
+  use_pod_detection =
+      (get_default_allocator()->get_type() == AllocatorTypeVMMFabric);
+#endif
+
   if (comm != MPI_COMM_NULL) {
     int comm_size;
     mpilib_ftable_.Comm_size(comm, &comm_size);
-    MPI_Comm shmcomm;
-    mpilib_ftable_.Comm_split_type(comm, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL,
-                                  &shmcomm);
-    int shm_comm_size;
-    mpilib_ftable_.Comm_size(shmcomm, &shm_comm_size);
-    mpilib_ftable_.Comm_free(&shmcomm);
-    if (shm_comm_size == comm_size) {
+    int group_size{0};
+
+    if (use_pod_detection) {
+      int my_rank;
+      mpilib_ftable_.Comm_rank(comm, &my_rank);
+
+      PodIds localPodIds = detectLocalPodIds();
+      if (!IS_PODIDS_ZERO(localPodIds)) {
+        std::vector<PodIds> allPodIds(comm_size);
+        mpilib_ftable_.Allgather(&localPodIds, sizeof(PodIds), MPI_CHAR,
+                                 allPodIds.data(), sizeof(PodIds), MPI_CHAR,
+                                 comm);
+        group_size =
+            static_cast<int>(matchIpcCapableRanks(my_rank, allPodIds).size());
+      }
+    } else {
+      MPI_Comm shmcomm;
+      mpilib_ftable_.Comm_split_type(comm, MPI_COMM_TYPE_SHARED, 0,
+                                     MPI_INFO_NULL, &shmcomm);
+      mpilib_ftable_.Comm_size(shmcomm, &group_size);
+      mpilib_ftable_.Comm_free(&shmcomm);
+    }
+
+    LOG_INFO("IPC admission (MPI): %s group of %d, world %d",
+             use_pod_detection ? "pod" : "node", group_size, comm_size);
+
+    if (group_size == comm_size) {
       ret = ROCSHMEM_SUCCESS;
     }
   } else if (bootstrap != nullptr) {
       int world_size = bootstrap->getNranks();
-      int shm_size = bootstrap->getNranksPerNode();
-      if (shm_size == world_size) {
+      /*
+       * getIpcCapableRanks() memoises its result, so the pod-id allGather it
+       * performs here is not repeated by ipcHostInit() later.
+       */
+      int group_size = use_pod_detection
+                           ? static_cast<int>(bootstrap->getIpcCapableRanks().size())
+                           : bootstrap->getNranksPerNode();
+
+      LOG_INFO("IPC admission (bootstrap): %s group of %d, world %d",
+               use_pod_detection ? "pod" : "node", group_size, world_size);
+
+      if (group_size == world_size) {
         ret = ROCSHMEM_SUCCESS;
       }
   }

--- a/projects/rocshmem/src/memfabric/amdsmi_loader.hpp
+++ b/projects/rocshmem/src/memfabric/amdsmi_loader.hpp
@@ -97,7 +97,8 @@ typedef void* amdsmi_processor_handle;
  */
 typedef enum {
     AMDSMI_FABRIC_TYPE_UALOE,
-    AMDSMI_FABRIC_TYPE_UALLINK
+    AMDSMI_FABRIC_TYPE_UALLINK,
+    AMDSMI_FABRIC_TYPE_UNKNOWN
 } amdsmi_fabric_type_t;
 
 /**
@@ -105,7 +106,8 @@ typedef enum {
  */
 typedef enum {
     AMDSMI_FABRIC_NHT_ADDRESS_MODE_SOURCE_ALIASING,
-    AMDSMI_FABRIC_NHT_ADDRESS_MODE_SOURCE_IDENTIFICATION
+    AMDSMI_FABRIC_NHT_ADDRESS_MODE_SOURCE_IDENTIFICATION,
+    AMDSMI_FABRIC_NHT_ADDRESS_MODE_UNKNOWN
 } amdsmi_fabric_nht_address_mode_t;
 
 /**
@@ -116,7 +118,8 @@ typedef enum {
     AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_CONFIGURED,
     AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_READY,
     AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE,
-    AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ERROR
+    AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ERROR,
+    AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN
 } amdsmi_fabric_accelerator_vpod_state_t;
 
 typedef union {
@@ -135,9 +138,9 @@ typedef union {
     uint64_t as_uint;
 } amdsmi_bdf_t;
 
-// Constants for fabric info arrays
+// Constants for fabric info arrays (amdsmi_fabric_size_constants_t in amd_smi/amdsmi.h)
 #define AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE 32
-#define AMDSMI_FABRIC_MAX_LOCAL_GPUS 8
+#define AMDSMI_FABRIC_MAX_LOCAL_GPUS 16
 
 /**
  * @brief Fabric device configuration information (version 1)
@@ -170,8 +173,17 @@ typedef struct {
 typedef struct {
     amdsmi_bdf_t bdf;      //!< BDF of the Fabric device
     amdsmi_fabric_info_ver_t info;
-    uint32_t reserved[14];
+    uint32_t reserved[15];
 } amdsmi_fabric_info_t;
+
+// amdsmi_get_gpu_fabric_info() writes sizeof(amdsmi_fabric_info_t) bytes into the
+// buffer it is handed, so these local declarations must match the libamd_smi ABI
+// exactly or the caller's stack is overwritten. Sizes are those of the
+// corresponding structs in amd_smi/amdsmi.h.
+static_assert(sizeof(amdsmi_fabric_info_v1_t) == 244,
+              "amdsmi_fabric_info_v1_t does not match the libamd_smi ABI");
+static_assert(sizeof(amdsmi_fabric_info_t) == 320,
+              "amdsmi_fabric_info_t does not match the libamd_smi ABI");
 
 // AMD SMI initialization flags
 typedef enum {
@@ -193,7 +205,7 @@ struct AmdsmiLoader {
   // Function pointers
   amdsmi_status_t (*init)(uint64_t init_flags);
   amdsmi_status_t (*shut_down)();
-  amdsmi_status_t (*get_processor_handle_from_bdf)(const char* bdf, amdsmi_processor_handle* processor_handle);
+  amdsmi_status_t (*get_processor_handle_from_bdf)(amdsmi_bdf_t bdf, amdsmi_processor_handle* processor_handle);
   amdsmi_status_t (*get_gpu_fabric_info)(amdsmi_processor_handle processor_handle, amdsmi_fabric_info_t* fabric_info);
 
   AmdsmiLoader();

--- a/projects/rocshmem/src/memfabric/pod_detection.cpp
+++ b/projects/rocshmem/src/memfabric/pod_detection.cpp
@@ -26,7 +26,10 @@
 
 #include <hip/hip_runtime.h>
 
+#include <cstdio>
+
 #include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "log.hpp"
 
 #ifdef HAVE_AMDSMI_GPU_FABRIC_INFO
 #include "amdsmi_loader.hpp"
@@ -42,6 +45,7 @@ PodIds detectLocalPodIds() {
   int device;
   hipError_t err = hipGetDevice(&device);
   if (err != hipSuccess) {
+    LOG_WARN("Pod detection: hipGetDevice failed (%s)", hipGetErrorString(err));
     return podIds;
   }
 
@@ -49,33 +53,59 @@ PodIds detectLocalPodIds() {
   char bdfId[64];
   err = hipDeviceGetPCIBusId(bdfId, sizeof(bdfId), device);
   if (err != hipSuccess) {
+    LOG_WARN("Pod detection: hipDeviceGetPCIBusId failed for device %d (%s)", device,
+             hipGetErrorString(err));
     return podIds;
   }
 
   // Load AMD SMI library dynamically
   AmdsmiLoader amdsmi;
   if (!amdsmi.isLoaded()) {
+    LOG_WARN("Pod detection: libamd_smi.so could not be loaded, or it does not export "
+             "amdsmi_get_gpu_fabric_info (requires amd-smi 26.4 or newer)");
     return podIds;
   }
 
   // Initialize AMD SMI library
   amdsmi_status_t status = amdsmi.init(AMDSMI_INIT_AMD_GPUS);
   if (status != AMDSMI_STATUS_SUCCESS) {
+    LOG_WARN("Pod detection: amdsmi_init failed with status %d", static_cast<int>(status));
     return podIds;
   }
 
-  // Get processor handle from BDF ID
+  /*
+   * Resolve the processor handle from the BDF. amdsmi_get_processor_handle_from_bdf()
+   * takes a packed amdsmi_bdf_t by value, so the "domain:bus:device.function" string
+   * that HIP hands back has to be parsed into the bitfields first.
+   */
+  unsigned int domain{0}, bus{0}, dev{0}, func{0};
+  if (sscanf(bdfId, "%x:%x:%x.%x", &domain, &bus, &dev, &func) != 4) {
+    LOG_WARN("Pod detection: could not parse PCI bus id '%s'", bdfId);
+    amdsmi.shut_down();
+    return podIds;
+  }
+
+  amdsmi_bdf_t bdf{};
+  bdf.domain_number = domain;
+  bdf.bus_number = bus;
+  bdf.device_number = dev;
+  bdf.function_number = func;
+
   amdsmi_processor_handle gpuHandle;
-  status = amdsmi.get_processor_handle_from_bdf(bdfId, &gpuHandle);
+  status = amdsmi.get_processor_handle_from_bdf(bdf, &gpuHandle);
   if (status != AMDSMI_STATUS_SUCCESS) {
+    LOG_WARN("Pod detection: amdsmi_get_processor_handle_from_bdf(%s) failed with status %d",
+             bdfId, static_cast<int>(status));
     amdsmi.shut_down();
     return podIds;
   }
 
   // Get fabric information for the GPU
-  amdsmi_fabric_info_t fabricInfo;
+  amdsmi_fabric_info_t fabricInfo{};
   status = amdsmi.get_gpu_fabric_info(gpuHandle, &fabricInfo);
   if (status != AMDSMI_STATUS_SUCCESS) {
+    LOG_WARN("Pod detection: amdsmi_get_gpu_fabric_info(%s) failed with status %d", bdfId,
+             static_cast<int>(status));
     amdsmi.shut_down();
     return podIds;
   }
@@ -83,6 +113,13 @@ PodIds detectLocalPodIds() {
   // Extract pod IDs from fabric info
   memcpy(podIds.physicalPodId, fabricInfo.info.v1.ppod_id, 16);
   podIds.virtualPodId = fabricInfo.info.v1.vpod_id;
+
+  if (IS_PODIDS_ZERO(podIds)) {
+    LOG_WARN("Pod detection: %s reports an all-zero pod id (vpod_id=%u, accel_state=%u); "
+             "the driver is not exposing fabric pod membership on this device",
+             bdfId, fabricInfo.info.v1.vpod_id,
+             static_cast<unsigned>(fabricInfo.info.v1.accel_state));
+  }
 
   // Cleanup AMD SMI
   amdsmi.shut_down();

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -116,7 +116,11 @@ static BackendType select_backend_type(MPI_Comm comm, TcpBootstrap *bootstrap) {
     if (envstr.find("ipc") != std::string::npos) {
       if (IPCBackend::backend_can_run(comm, bootstrap) != ROCSHMEM_SUCCESS) {
         LOG_ERROR_EXIT("ROCSHMEM_BACKEND=ipc requested but IPC backend cannot run.\n"
-                       "  Most likely cause is that PEs are distributed across more than one node.\n"
+                       "  The IPC peer group does not cover every PE.\n"
+                       "  Without the fabric heap allocator, that means the PEs span more than one node.\n"
+                       "  With USE_HEAP_DEVICE_VMM_FABRIC, it means they span more than one fabric pod,\n"
+                       "  or pod detection failed on at least one PE.\n"
+                       "  The preceding 'IPC admission' log line reports the detected group size.\n"
                        "  ");
       }
       return BackendType::IPC_BACKEND;


### PR DESCRIPTION
## Motivation

Makes the `USE_HEAP_DEVICE_VMM_FABRIC` heap usable across the nodes of a
fabric pod on MI450X (gfx1250). 

## Technical Details
- Fix 1 - **AMD SMI fabric ABI and BDF lookup** - 
  `amdsmi_loader.hpp` described an 8-GPU fabric struct, but libamd_smi
  writes the 16-GPU layout, so `amdsmi_get_gpu_fabric_info()` overwrote
  the caller's stack. `get_processor_handle_from_bdf()` was also passed a
  pointer where the ABI takes the packed bitfield by value, so the lookup
  never resolved a handle. Pod detection therefore failed silently.
- Fix 2 **IPC backend admission.** `backend_can_run()` required the
  shared-memory group to cover every PE, i.e. all PEs on one node. A
  fabric heap is addressable by every device in the pod, which spans
  nodes, so pod-spanning jobs were rejected during backend selection
  before `ipcHostInit()` could run. Admission is now sized by pod
  membership when the default allocator is `AllocatorTypeVMMFabric`.

## Issue Tracking

JIRA ID: AIROCSHMEM-472

## Test Plan

## Test Result
AMD SMI fabric ABI declarations compile-checked against the installed
      `amd_smi/amdsmi.h` (26.5.0, ROCm 7.14): struct sizes 244/320, all
      field offsets, and all enum sentinels match.

2x MI450X (gfx1250), 8 PEs under torchrun with
      `USE_HEAP_DEVICE_VMM_FABRIC`: admission reports a pod group of 8 in
      a world of 8. 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
