### PR TITLE
feat(rocprofiler-systems): add --env flag for rocprof-sys-run and rocprof-sys-sample

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -4,12 +4,20 @@
 
 Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/](https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/).
 
-## ROCm Systems Profiler 1.8.0 for ROCm 7.15.0 (unreleased)
+## ROCm Systems Profiler 1.9.0 for ROCm 7.16.0 (unreleased)
+
+### Added
+
+- `--env` flag for `rocprof-sys-run` and `rocprof-sys-sample` to set environment
+  variables in `VARIABLE=VALUE` form (repeatable).
+
+## ROCm Systems Profiler 1.8.0 for ROCm 7.15.0
 
 ### Added
 
 - hipFILE (GPU-direct storage) API tracing. Add `hipfile_api` to
-  `ROCPROFSYS_ROCM_DOMAINS` (shorthand: `hipfile`) to capture hipFILE API traces. Requires ROCProfiler-SDK version 1.3.5 or later.
+  `ROCPROFSYS_ROCM_DOMAINS` (shorthand: `hipfile`) to capture hipFILE API traces.
+  Requires ROCProfiler-SDK version 1.3.5 or later.
 
 - `--exe-only` flag for `rocprof-sys-instrument`: shorthand for excluding every shared
   library from instrumentation, leaving only the main executable.

--- a/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
@@ -746,7 +746,8 @@ print_compact_help(std::string_view tool_name, std::ostream& out)
         << "COMMON OPTIONS\n"
         << "  -o, --output PATH      Output directory\n"
         << "  -T, --trace            Enable/disable Perfetto tracing\n"
-        << "  -P, --profile          Enable/disable call-stack profiling\n";
+        << "  -P, --profile          Enable/disable call-stack profiling\n"
+        << "  --env VAR=VALUE        Set environment variable (repeatable)\n";
     if(tool_name == "run") out << "  -S, --sample           Enable/disable sampling\n";
     out << "  --export-config[=FILE] Export resolved config as JSON\n"
         << "  -v, --verbose          Increase verbosity\n"

--- a/projects/rocprofiler-systems/source/bin/common/tests/test_help_system.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tests/test_help_system.cpp
@@ -144,6 +144,7 @@ TEST_F(help_system_test, compact_help_contains_essential_info)
     EXPECT_NE(output.find("--help="), std::string::npos);
     EXPECT_NE(output.find("QUICK START"), std::string::npos);
     EXPECT_NE(output.find("HELP TOPICS"), std::string::npos);
+    EXPECT_NE(output.find("--env"), std::string::npos);
     EXPECT_NE(output.find("rocprof-sys-run"), std::string::npos);
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -306,7 +306,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                     const auto eq_pos = entry.find('=');
                     if(eq_pos == std::string::npos || eq_pos == 0)
                     {
-                        throw std::runtime_error(fmt::format(
+                        throw exception<std::runtime_error>(fmt::format(
                             "Error! --env value '{}' is not in form VARIABLE=VALUE",
                             entry));
                     }

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -292,6 +292,31 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
         _data.reg.processed_environs.emplace("config_file");
     }
 
+    if(_data.reg.environ_filter("env", _data))
+    {
+        _parser
+            .add_argument({ "--env" },
+                          "Environment variables to set for the target process in form "
+                          "VARIABLE=VALUE. May be repeated.")
+            .min_count(1)
+            .dtype("string")
+            .action([&](parser_t& p) {
+                for(const auto& entry : p.get<strvec_t>("env"))
+                {
+                    const auto eq_pos = entry.find('=');
+                    if(eq_pos == std::string::npos || eq_pos == 0)
+                    {
+                        throw std::runtime_error(fmt::format(
+                            "Error! --env value '{}' is not in form VARIABLE=VALUE",
+                            entry));
+                    }
+                    update_env(_data, entry.substr(0, eq_pos), entry.substr(eq_pos + 1));
+                }
+            });
+
+        _data.reg.processed_environs.emplace("env");
+    }
+
     if(_data.reg.environ_filter("output", _data))
     {
         _parser

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -336,6 +336,7 @@ def pytest_configure(config: pytest.Config) -> None:
         "minimal",
         "rank_filter",
         "pytest_impl",
+        "env_flag",
     ]
     for label in non_functional_markers + generic_functional_markers:
         config.addinivalue_line("markers", f"{label}: label test as {label}")

--- a/projects/rocprofiler-systems/tests/pytest/test_cli_env.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_cli_env.py
@@ -1,0 +1,93 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Tests for the --env flag of rocprof-sys-run and rocprof-sys-sample.
+
+--env sets environment variables for the target process in VARIABLE=VALUE form
+and is repeatable. The launcher echoes every variable it updated as
+"ROCPROFSYS: KEY=value" on stderr before exec, so a non-instrumentable target
+like ``ls`` is sufficient to observe the effect.
+"""
+
+from __future__ import annotations
+import pytest
+from conftest import RocprofsysTest
+
+pytestmark = [pytest.mark.env_flag]
+
+TARGETS = [
+    pytest.param("rocprof-sys-run", marks=pytest.mark.sys_run, id="run"),
+    pytest.param("rocprof-sys-sample", marks=pytest.mark.sampling, id="sample"),
+]
+
+
+# ============================================================================
+# --env sets variables for the target process
+# ----------------------------------------------------------------------------
+# Each --env VARIABLE=VALUE flows through argparse update_env into the launched
+# environment and is echoed as an updated variable. Repeating --env sets each
+# variable independently.
+# ============================================================================
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.class_name("cli-env-sets-vars")
+class TestEnvFlagSetsVars(RocprofsysTest):
+    @pytest.mark.parametrize("target", TARGETS)
+    def test_repeated_env_are_set(self, target):
+        result = self.run_test(
+            "baseline",
+            target=target,
+            run_args=[
+                "--env",
+                "ROCPROFSYS_CPU_FREQ_ENABLED=YES",
+                "--env",
+                "ROCPROFSYS_SAMPLING_CPUS=0",
+                "--",
+                "ls",
+            ],
+            fail_on_not_found=True,
+        )
+        self.assert_regex(
+            result,
+            pass_regex=[
+                r"ROCPROFSYS_CPU_FREQ_ENABLED=YES",
+                r"ROCPROFSYS_SAMPLING_CPUS=0",
+            ],
+        )
+
+
+# ============================================================================
+# --env rejects values not in VARIABLE=VALUE form
+# ----------------------------------------------------------------------------
+# A missing '=' or an empty variable name (leading '=') is an argument error;
+# the launcher exits non-zero before exec with a message naming the offending
+# value.
+# ============================================================================
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.class_name("cli-env-malformed")
+class TestEnvFlagRejectsMalformed(RocprofsysTest):
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            pytest.param("NOEQUALS", id="missing-equals"),
+            pytest.param("=VALUE", id="empty-name"),
+        ],
+    )
+    @pytest.mark.parametrize("target", TARGETS)
+    def test_malformed_env_rejected(self, target, bad_value):
+        result = self.run_test(
+            "baseline",
+            target=target,
+            run_args=["--env", bad_value, "--", "ls"],
+            fail_on_not_found=True,
+            fail_on_pass=True,
+        )
+        self.assert_regex(
+            result,
+            pass_regex=[r"not in form VARIABLE=VALUE"],
+            use_abort_fail_regex=False,  # negative test intentionally exits non-zero
+        )


### PR DESCRIPTION
## Summary

- Add a repeatable `--env VARIABLE=VALUE` flag to `rocprof-sys-run` and `rocprof-sys-sample` that sets environment variables for the target process.
- Values not in `VARIABLE=VALUE` form (missing `=`, or an empty variable name via a leading `=`) are rejected with a clear error before exec.
- Surfaced in the compact help output for both launchers.

## Implementation

- `source/lib/core/argparse.cpp` — new `--env` argument in `add_core_arguments`, following the existing `environ_filter` / `processed_environs` pattern; each entry is split on the first `=` and applied via `update_env`.
- `source/bin/common/common_utils.cpp` — `--env VAR=VALUE` line added to compact help.

## Test plan

- [ ] `test_cli_env.py` (new): positive path asserts both repeated `--env` values appear in the `ROCPROFSYS:` env echo; negative path asserts malformed values are rejected. Parametrized over `rocprof-sys-run` and `rocprof-sys-sample`.
- [ ] `test_help_system.cpp`: asserts `--env` appears in compact help.
- [ ] Run `pytest test_cli_env.py` against a real build (not exercised in the authoring checkout — no binary available).

## Notes

- CHANGELOG entry added under a new **1.9.0 for ROCm 7.16.0 (unreleased)** section. The VERSION file bump will land in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)