### PR TITLE
Reland: fix(rocr/thunk): Revoke SVM-API GPU access on deregister, with register re-grant

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -1147,15 +1147,16 @@ static svm_api_range_t *svm_api_range_find(struct hsa_kfd_fmm_context *fmm_ctx,
 }
 
 /*
- * Add a new SVM-API range, or bump the refcount of an existing identical one.
+ * Add a new SVM-API range, or refcount an existing one sharing the page-aligned
+ * base.
  *
- * A registration can only be identified at deregister time by its base address
- * (the deregister path, hsaKmtDeregisterMemory, is keyed only by the base
- * pointer and gets no size). We therefore
- * require that a given base address is always (re-)registered with the same
- * size, and reject a re-registration of the same base with a different size -
- * otherwise deregister could not tell which extent to revoke. Repeated
- * registrations of the same (base, size) are refcounted.
+ * Several distinct registrations can share a page-aligned base - small buffers
+ * packed into one page, one of which may straddle into the next page and so
+ * round to a larger span. They are refcounted together on that base and the
+ * tracked extent grows to the largest span seen, so deregister revokes the full
+ * extent once the last owner is dropped. The exact sub-range to revoke is then
+ * computed by interval subtraction in svm_api_range_put (which subtracts the
+ * coverage of any surviving registration, at this base or a neighbouring one).
  */
 static HSAKMT_STATUS svm_api_range_get(struct hsa_kfd_fmm_context *fmm_ctx,
 				       void *aligned_addr, uint64_t aligned_size)
@@ -1165,13 +1166,18 @@ static HSAKMT_STATUS svm_api_range_get(struct hsa_kfd_fmm_context *fmm_ctx,
 	pthread_mutex_lock(&fmm_ctx->svm_api_mutex);
 	r = svm_api_range_find(fmm_ctx, aligned_addr);
 	if (r) {
-		if (r->size != aligned_size) {
-			pthread_mutex_unlock(&fmm_ctx->svm_api_mutex);
-			pr_debug("SVM-API re-register of %p size 0x%" PRIx64 " != tracked 0x%" PRIx64 "; rejected\n",
-				 aligned_addr, aligned_size, r->size);
-			return HSAKMT_STATUS_INVALID_PARAMETER;
-		}
+		/* Distinct sub-page buffers can share a page-aligned base with
+		 * different page-aligned spans (e.g. small calloc'd buffers
+		 * packed into one page, one of which straddles into the next
+		 * page). They are independent registrations, so refcount them
+		 * together and grow the tracked extent to the largest span seen
+		 * at this base; deregister then revokes the full extent once the
+		 * last owner is gone, and overlap with other bases is resolved by
+		 * the interval subtraction in svm_api_range_put.
+		 */
 		++r->refcount;
+		if (aligned_size > r->size)
+			r->size = aligned_size;
 		pthread_mutex_unlock(&fmm_ctx->svm_api_mutex);
 		return HSAKMT_STATUS_SUCCESS;
 	}
@@ -4298,13 +4304,7 @@ HSAKMT_STATUS hsakmt_fmm_register_memory(HsaKFDContext *ctx,
 		/* Register a new user ptr */
 		if (ctx->hsakmt_is_svm_api_supported) {
 			ret = fmm_register_mem_svm_api(ctx, address, size_in_bytes, flags);
-			/* INVALID_PARAMETER is a deliberate rejection (e.g. a same
-			 * base re-registered with a different size); surface it
-			 * rather than silently falling back to a legacy userptr
-			 * registration.
-			 */
-			if (ret == HSAKMT_STATUS_SUCCESS ||
-			    ret == HSAKMT_STATUS_INVALID_PARAMETER)
+			if (ret == HSAKMT_STATUS_SUCCESS)
 				return ret;
 			pr_debug("SVM failed, falling back to old registration\n");
 		}

--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -1369,13 +1369,21 @@ static HSAKMT_STATUS fmm_register_mem_svm_api(HsaKFDContext *ctx,
 	HSAuint64 aligned_addr = (HSAuint64)address - page_offset;
 	HSAuint64 aligned_size = PAGE_ALIGN_UP(page_offset + size);
 	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
+	uint32_t num_gpus = fmm_ctx->all_gpu_id_array_size / sizeof(uint32_t);
+	uint32_t i;
 	HSAKMT_STATUS ret;
 
 	if (!fmm_ctx->first_gpu_mem)
 		return HSAKMT_STATUS_ERROR;
 
-	/* s_attr is a compile-time constant (16 bytes); no overflow possible */
-	s_attr = 2 * sizeof(struct kfd_ioctl_svm_attribute);
+	/* Re-grant ACCESS_IN_PLACE on all GPUs along with the coherency flags.
+	 * A prior deregister leaves NO_ACCESS on the range, and allocators like
+	 * jemalloc reuse the VA without munmap so that attribute sticks in the
+	 * kernel. If we don't clear it here the GPU faults on the re-registered
+	 * buffer. Must be ACCESS_IN_PLACE, not ACCESS: userptr memory can't
+	 * migrate, so ACCESS would fail the restore path and still fault.
+	 */
+	s_attr = (num_gpus + 2) * sizeof(struct kfd_ioctl_svm_attribute);
 	args = malloc(sizeof(*args) + s_attr);
 	if (!args)
 		return HSAKMT_STATUS_NO_MEMORY;
@@ -1383,13 +1391,17 @@ static HSAKMT_STATUS fmm_register_mem_svm_api(HsaKFDContext *ctx,
 	args->start_addr = aligned_addr;
 	args->size = aligned_size;
 	args->op = KFD_IOCTL_SVM_OP_SET_ATTR;
-	args->nattr = 2;
-	args->attrs[0].type = flags.ui32.CoarseGrain ?
+	args->nattr = num_gpus + 2;
+	for (i = 0; i < num_gpus; i++) {
+		args->attrs[i].type = HSA_SVM_ATTR_ACCESS_IN_PLACE;
+		args->attrs[i].value = fmm_ctx->all_gpu_id_array[i];
+	}
+	args->attrs[num_gpus].type = flags.ui32.CoarseGrain ?
 			      HSA_SVM_ATTR_CLR_FLAGS : HSA_SVM_ATTR_SET_FLAGS;
-	args->attrs[0].value = HSA_SVM_FLAG_COHERENT;
-	args->attrs[1].type = flags.ui32.ExtendedCoherent ?
+	args->attrs[num_gpus].value = HSA_SVM_FLAG_COHERENT;
+	args->attrs[num_gpus + 1].type = flags.ui32.ExtendedCoherent ?
 							HSA_SVM_ATTR_SET_FLAGS : HSA_SVM_ATTR_CLR_FLAGS;
-	args->attrs[1].value = HSA_SVM_FLAG_EXT_COHERENT;
+	args->attrs[num_gpus + 1].value = HSA_SVM_FLAG_EXT_COHERENT;
 	/* Validate and reserve the tracking entry before touching kernel state,
 	 * so a same-base re-registration with a mismatched size is rejected
 	 * (INVALID_PARAMETER) without issuing a stray SET_ATTR - deregister is

--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -250,6 +250,23 @@ typedef struct {
 	uint32_t alignment_order;
 } svm_t;
 
+/*
+ * Tracks host memory ranges registered with KFD through the SVM API
+ * (fmm_register_mem_svm_api/fmm_map_mem_svm_api). These registrations only set
+ * SVM attributes on the VA range and do not create a vm_object, so there is no
+ * way to discover the range size at deregistration time. We keep the aligned
+ * base and size here, refcounted to mirror the registration_count handling of
+ * regular userptr vm_objects, so that deregistration can issue the inverse SVM
+ * SET_ATTR (NO_ACCESS + clear coherency flags) instead of being a silent no-op.
+ */
+struct svm_api_range {
+	void *start;			/* page-aligned base address */
+	uint64_t size;			/* page-aligned size */
+	uint32_t refcount;		/* number of outstanding registrations */
+	rbtree_node_t node;		/* svm_api_range_tree, key addr only (size field 0) */
+};
+typedef struct svm_api_range svm_api_range_t;
+
 struct hsa_kfd_fmm_context
 {
 	/* The other apertures are specific to each GPU. gpu_mem_t manages GPU
@@ -267,6 +284,12 @@ struct hsa_kfd_fmm_context
 	void *dgpu_shared_aperture_limit;
 
 	svm_t svm;
+
+	/* RB tree of host ranges registered via the SVM API (see svm_api_range).
+	 * Protected by svm_api_mutex. Keys use aligned VA only (LKP_ADDR).
+	 */
+	rbtree_t svm_api_range_tree;
+	pthread_mutex_t svm_api_mutex;
 
 	/* On APU, for memory allocated on the system memory that GPU doesn't
 	 * access via GPU driver, they are not managed by GPUVM. cpuvm_aperture
@@ -323,6 +346,10 @@ int hsakmt_kfdcontext_init_fmm_context(HsaKFDContext *ctx)
 	ctx->fmm_context->svm.reserve_svm = false;
 	ctx->fmm_context->svm.disable_cache = false;
 	ctx->fmm_context->svm.alignment_order = 0;
+
+	/* Initialize SVM-API range tracking */
+	rbtree_init(&ctx->fmm_context->svm_api_range_tree);
+	pthread_mutex_init(&ctx->fmm_context->svm_api_mutex, NULL);
 
 	/* Initialize cpuvm_aperture */
 	ctx->fmm_context->cpuvm_aperture = init_aperture;
@@ -1102,6 +1129,230 @@ static HsaMemFlags fmm_translate_ioc_to_hsa_flags(uint32_t ioc_flags)
 	return mflags;
 }
 
+/*
+ * SVM-API range tracking helpers. These mirror the registration_count handling
+ * of regular userptr vm_objects so that SVM-API registrations can be torn down
+ * symmetrically on deregistration. `svm_api_range_get/put` manage svm_api_mutex
+ * internally; callers must hold the mutex only when calling svm_api_range_find.
+ */
+static svm_api_range_t *svm_api_range_find(struct hsa_kfd_fmm_context *fmm_ctx,
+					   void *aligned_addr)
+{
+	rbtree_key_t key = rbtree_key((unsigned long)aligned_addr, 0);
+	rbtree_node_t *n = rbtree_lookup(&fmm_ctx->svm_api_range_tree, &key, LKP_ADDR);
+
+	if (!n)
+		return NULL;
+	return rb_entry(n, svm_api_range_t, node);
+}
+
+/*
+ * Add a new SVM-API range, or bump the refcount of an existing identical one.
+ *
+ * A registration can only be identified at deregister time by its base address
+ * (the deregister path, hsaKmtDeregisterMemory, is keyed only by the base
+ * pointer and gets no size). We therefore
+ * require that a given base address is always (re-)registered with the same
+ * size, and reject a re-registration of the same base with a different size -
+ * otherwise deregister could not tell which extent to revoke. Repeated
+ * registrations of the same (base, size) are refcounted.
+ */
+static HSAKMT_STATUS svm_api_range_get(struct hsa_kfd_fmm_context *fmm_ctx,
+				       void *aligned_addr, uint64_t aligned_size)
+{
+	svm_api_range_t *r;
+
+	pthread_mutex_lock(&fmm_ctx->svm_api_mutex);
+	r = svm_api_range_find(fmm_ctx, aligned_addr);
+	if (r) {
+		if (r->size != aligned_size) {
+			pthread_mutex_unlock(&fmm_ctx->svm_api_mutex);
+			pr_debug("SVM-API re-register of %p size 0x%" PRIx64 " != tracked 0x%" PRIx64 "; rejected\n",
+				 aligned_addr, aligned_size, r->size);
+			return HSAKMT_STATUS_INVALID_PARAMETER;
+		}
+		++r->refcount;
+		pthread_mutex_unlock(&fmm_ctx->svm_api_mutex);
+		return HSAKMT_STATUS_SUCCESS;
+	}
+
+	r = calloc(1, sizeof(*r));
+	if (!r) {
+		/* Tracking is best-effort; failure only means deregistration
+		 * falls back to the previous no-op behavior for this range.
+		 */
+		pr_warn("Failed to track SVM-API range %p, deregister will be a no-op\n",
+			aligned_addr);
+		pthread_mutex_unlock(&fmm_ctx->svm_api_mutex);
+		return HSAKMT_STATUS_SUCCESS;
+	}
+	r->start = aligned_addr;
+	r->size = aligned_size;
+	r->refcount = 1;
+	r->node.key = rbtree_key((unsigned long)aligned_addr, 0);
+	hsakmt_rbtree_insert(&fmm_ctx->svm_api_range_tree, &r->node);
+	pthread_mutex_unlock(&fmm_ctx->svm_api_mutex);
+	return HSAKMT_STATUS_SUCCESS;
+}
+
+/* A page range whose GPU access must be revoked on deregister. */
+struct svm_revoke_range {
+	void *addr;
+	uint64_t size;
+};
+
+/* Append [a, b) to a growable array. Best-effort: on OOM returns false and the
+ * caller stops collecting (the unrevoked tail just keeps its GPU mapping). */
+static bool svm_revoke_add(struct svm_revoke_range **arr, int *n, int *cap,
+			   HSAuint64 a, HSAuint64 b)
+{
+	if (a >= b)
+		return true;
+	if (*n == *cap) {
+		int nc = *cap ? *cap * 2 : 4;
+		struct svm_revoke_range *t = realloc(*arr, nc * sizeof(**arr));
+
+		if (!t)
+			return false;
+		*arr = t;
+		*cap = nc;
+	}
+	(*arr)[*n].addr = (void *)a;
+	(*arr)[*n].size = b - a;
+	(*n)++;
+	return true;
+}
+
+/*
+ * Drop a reference on the SVM-API registration based at @addr. If this was the
+ * last reference, remove it and compute which sub-ranges of [base, base+size)
+ * no *other* surviving registration still covers - those are the only ranges
+ * whose GPU access must be revoked. Overlapping or page-rounded-neighbor
+ * registrations keep coverage of the parts they still own, so a shared region
+ * survives until its last owner is dropped.
+ *
+ * On return *out points to a malloc'd array of ranges (caller frees) and the
+ * function returns the count (0 if nothing to revoke). NO_ACCESS is issued by
+ * the caller outside the lock, per range.
+ */
+static int svm_api_range_put(struct hsa_kfd_fmm_context *fmm_ctx, void *addr,
+			     struct svm_revoke_range **out)
+{
+	HSAuint64 page_offset = (HSAuint64)addr & (PAGE_SIZE - 1);
+	void *aligned_addr = (void *)((HSAuint64)addr - page_offset);
+	struct svm_revoke_range *ranges = NULL;
+	int n = 0, cap = 0;
+	HSAuint64 base, end, cur;
+	rbtree_key_t key;
+	rbtree_node_t *node;
+	svm_api_range_t *r;
+
+	*out = NULL;
+
+	pthread_mutex_lock(&fmm_ctx->svm_api_mutex);
+	r = svm_api_range_find(fmm_ctx, aligned_addr);
+	if (!r || --r->refcount > 0) {
+		pthread_mutex_unlock(&fmm_ctx->svm_api_mutex);
+		return 0;
+	}
+
+	base = (HSAuint64)r->start;
+	end = base + r->size;
+	hsakmt_rbtree_delete(&fmm_ctx->svm_api_range_tree, &r->node);
+	free(r);
+
+	/* Emit the gaps in [base, end) not covered by any surviving registration.
+	 * Walk the tree in address order starting from the nearest range at or
+	 * before base (it may extend into us), else from the smallest.
+	 */
+	cur = base;
+	key = rbtree_key(base, 0);
+	node = rbtree_lookup_nearest(&fmm_ctx->svm_api_range_tree, &key, LKP_ADDR, LEFT);
+	if (!node)
+		node = rbtree_min_max(&fmm_ctx->svm_api_range_tree, LEFT);
+
+	while (node && cur < end) {
+		svm_api_range_t *o = rb_entry(node, svm_api_range_t, node);
+		HSAuint64 ostart = (HSAuint64)o->start;
+		HSAuint64 oend = ostart + o->size;
+
+		if (oend <= cur) {		/* entirely before cur */
+			node = hsakmt_rbtree_next(&fmm_ctx->svm_api_range_tree, node);
+			continue;
+		}
+		if (ostart >= end)		/* past our range */
+			break;
+		if (ostart > cur) {		/* uncovered gap [cur, ostart) */
+			if (!svm_revoke_add(&ranges, &n, &cap, cur,
+					    ostart < end ? ostart : end))
+				break;
+			cur = ostart < end ? ostart : end;
+		}
+		if (oend > cur)			/* covered up to oend */
+			cur = oend < end ? oend : end;
+		node = hsakmt_rbtree_next(&fmm_ctx->svm_api_range_tree, node);
+	}
+	if (cur < end)				/* uncovered tail */
+		svm_revoke_add(&ranges, &n, &cap, cur, end);
+
+	pthread_mutex_unlock(&fmm_ctx->svm_api_mutex);
+	*out = ranges;
+	return n;
+}
+
+/*
+ * Inverse of fmm_register_mem_svm_api()/fmm_map_mem_svm_api(): revoke GPU access
+ * to the range (NO_ACCESS for every GPU) and clear the coherency flags that were
+ * set at registration time. Called when the last SVM-API registration of a range
+ * is removed.
+ */
+static HSAKMT_STATUS fmm_unregister_mem_svm_api(HsaKFDContext *ctx,
+						void *aligned_addr,
+						uint64_t aligned_size)
+{
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
+	uint32_t num_gpus = fmm_ctx->all_gpu_id_array_size / sizeof(uint32_t);
+	struct kfd_ioctl_svm_args *args;
+	size_t s_attr;
+	uint32_t nattr, i;
+
+	if (!fmm_ctx->first_gpu_mem)
+		return HSAKMT_STATUS_ERROR;
+
+	/* One NO_ACCESS attribute per GPU plus two CLR_FLAGS attributes.
+	 * NO_ACCESS on a GPU that never had access is harmless.
+	 */
+	nattr = num_gpus + 2;
+	s_attr = nattr * sizeof(struct kfd_ioctl_svm_attribute);
+	args = alloca(sizeof(*args) + s_attr);
+	args->start_addr = (HSAuint64)aligned_addr;
+	args->size = aligned_size;
+	args->op = KFD_IOCTL_SVM_OP_SET_ATTR;
+	args->nattr = nattr;
+	for (i = 0; i < num_gpus; i++) {
+		args->attrs[i].type = HSA_SVM_ATTR_NO_ACCESS;
+		args->attrs[i].value = fmm_ctx->all_gpu_id_array[i];
+	}
+	args->attrs[num_gpus].type = HSA_SVM_ATTR_CLR_FLAGS;
+	args->attrs[num_gpus].value = HSA_SVM_FLAG_COHERENT;
+	args->attrs[num_gpus + 1].type = HSA_SVM_ATTR_CLR_FLAGS;
+	args->attrs[num_gpus + 1].value = HSA_SVM_FLAG_EXT_COHERENT;
+
+	pr_debug("Deregistering from SVM %p size: %" PRIu64 "\n", aligned_addr,
+		 aligned_size);
+	/* Driver does one copy_from_user, with extra attrs size */
+	if (hsakmt_ioctl(ctx->fd, AMDKFD_IOC_SVM + (s_attr << _IOC_SIZESHIFT), args)) {
+		/* The VA may already be gone (e.g. the application unmapped it
+		 * before deregistering); the kernel reclaims the SVM range via
+		 * its MMU notifier in that case, so this is not fatal.
+		 */
+		pr_debug("op clear range attrs failed %s\n", strerror(errno));
+		return HSAKMT_STATUS_ERROR;
+	}
+
+	return HSAKMT_STATUS_SUCCESS;
+}
+
 static HSAKMT_STATUS fmm_register_mem_svm_api(HsaKFDContext *ctx,
 						  void *address,
 					      uint64_t size, HsaMemFlags flags)
@@ -1133,11 +1384,29 @@ static HSAKMT_STATUS fmm_register_mem_svm_api(HsaKFDContext *ctx,
 	args->attrs[1].type = flags.ui32.ExtendedCoherent ?
 							HSA_SVM_ATTR_SET_FLAGS : HSA_SVM_ATTR_CLR_FLAGS;
 	args->attrs[1].value = HSA_SVM_FLAG_EXT_COHERENT;
-	pr_debug("Registering to SVM %p size: %ld\n", (void*)aligned_addr,
+	/* Validate and reserve the tracking entry before touching kernel state,
+	 * so a same-base re-registration with a mismatched size is rejected
+	 * (INVALID_PARAMETER) without issuing a stray SET_ATTR - deregister is
+	 * keyed only by base address and could not disambiguate the two extents.
+	 * Identical (base, size) registrations are refcounted.
+	 */
+	ret = svm_api_range_get(fmm_ctx, (void *)aligned_addr, aligned_size);
+	if (ret != HSAKMT_STATUS_SUCCESS)
+		return ret;
+
+	pr_debug("Registering to SVM %p size: %" PRIu64 "\n", (void*)aligned_addr,
 		 aligned_size);
 	/* Driver does one copy_from_user, with extra attrs size */
 	if (hsakmt_ioctl(ctx->fd, AMDKFD_IOC_SVM + (s_attr << _IOC_SIZESHIFT), args)) {
+		struct svm_revoke_range *rr = NULL;
+
 		pr_debug("op set range attrs failed %s\n", strerror(errno));
+		/* The kernel never got the attributes; drop the reference we
+		 * reserved above. No GPU access was granted, so any revoke
+		 * ranges it computes are moot - just free them.
+		 */
+		svm_api_range_put(fmm_ctx, address, &rr);
+		free(rr);
 		ret = HSAKMT_STATUS_ERROR;
 		goto out;
 	}
@@ -3219,8 +3488,24 @@ gpu_mem_init_failed:
 void hsakmt_fmm_destroy_process_apertures(HsaKFDContext *ctx)
 {
 	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
+	svm_api_range_t *r;
+	rbtree_node_t *n;
 
 	release_mmio(ctx);
+
+	/* Free any SVM-API ranges that were never explicitly deregistered.
+	 * The kernel reclaims the underlying SVM ranges on process teardown,
+	 * so we only release our bookkeeping here.
+	 */
+	pthread_mutex_lock(&fmm_ctx->svm_api_mutex);
+	while (fmm_ctx->svm_api_range_tree.root != &fmm_ctx->svm_api_range_tree.sentinel) {
+		n = rbtree_min(fmm_ctx->svm_api_range_tree.root,
+			       &fmm_ctx->svm_api_range_tree.sentinel);
+		r = rb_entry(n, svm_api_range_t, node);
+		hsakmt_rbtree_delete(&fmm_ctx->svm_api_range_tree, n);
+		free(r);
+	}
+	pthread_mutex_unlock(&fmm_ctx->svm_api_mutex);
 
 	if (fmm_ctx->all_gpu_id_array) {
 		free(fmm_ctx->all_gpu_id_array);
@@ -3259,7 +3544,7 @@ HSAKMT_STATUS hsakmt_fmm_advance_vm_timeline(HsaKFDContext *ctx,
 		*drm_render_fd = fmm_ctx->gpu_mem[index].drm_render_fd;
 	if (vm_timeline_syncobj)
 		*vm_timeline_syncobj = fmm_ctx->gpu_mem[index].drm_vm_timeline_syncobj;
-	
+
 	if (vm_timeline_point)
 		*vm_timeline_point = __atomic_add_fetch(
 			&fmm_ctx->gpu_mem[index].drm_vm_timeline_seqnum, 1,
@@ -4013,7 +4298,13 @@ HSAKMT_STATUS hsakmt_fmm_register_memory(HsaKFDContext *ctx,
 		/* Register a new user ptr */
 		if (ctx->hsakmt_is_svm_api_supported) {
 			ret = fmm_register_mem_svm_api(ctx, address, size_in_bytes, flags);
-			if (ret == HSAKMT_STATUS_SUCCESS)
+			/* INVALID_PARAMETER is a deliberate rejection (e.g. a same
+			 * base re-registered with a different size); surface it
+			 * rather than silently falling back to a legacy userptr
+			 * registration.
+			 */
+			if (ret == HSAKMT_STATUS_SUCCESS ||
+			    ret == HSAKMT_STATUS_INVALID_PARAMETER)
 				return ret;
 			pr_debug("SVM failed, falling back to old registration\n");
 		}
@@ -4421,13 +4712,35 @@ HSAKMT_STATUS hsakmt_fmm_deregister_memory(HsaKFDContext *ctx, void *address)
 	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	object = vm_find_object(fmm_ctx, address, 0, &aperture);
-	if (!object)
+	if (!object) {
+		/* No vm_object: either a random system memory address (APU
+		 * no-op) or a host range registered via the SVM API, which
+		 * does not create a vm_object. For the latter, drop a
+		 * reference and, when the last one is gone, issue the inverse
+		 * SET_ATTR to revoke GPU access and clear coherency flags.
+		 */
+		if (ctx->hsakmt_is_svm_api_supported) {
+			struct svm_revoke_range *rr = NULL;
+			int nr, i;
+
+			/* Revoke only the sub-ranges no surviving registration
+			 * still covers, so overlapping/boundary-sharing
+			 * neighbors keep their GPU access.
+			 */
+			nr = svm_api_range_put(fmm_ctx, address, &rr);
+			for (i = 0; i < nr; i++)
+				fmm_unregister_mem_svm_api(ctx, rr[i].addr,
+							   rr[i].size);
+			free(rr);
+			return HSAKMT_STATUS_SUCCESS;
+		}
 		/* On APUs we assume it's a random system memory address
 		 * where registration and dergistration is a no-op
 		 */
-		return (!hsakmt_is_dgpu || ctx->hsakmt_is_svm_api_supported) ?
+		return (!hsakmt_is_dgpu) ?
 			HSAKMT_STATUS_SUCCESS :
 			HSAKMT_STATUS_MEMORY_NOT_REGISTERED;
+	}
 	/* Successful vm_find_object returns with aperture locked */
 
 	if (aperture == &fmm_ctx->cpuvm_aperture) {
@@ -4777,7 +5090,7 @@ static void fmm_clear_aperture(manageable_aperture_t *app)
 void hsakmt_fmm_clear_all_mem(HsaKFDContext *ctx)
 {
 	uint32_t i;
-	
+
 	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 	/* Close render node FDs. The child process needs to open new ones */
 	for (i = 0; i <= DRM_LAST_RENDER_NODE - DRM_FIRST_RENDER_NODE; i++) {
@@ -4798,7 +5111,7 @@ void hsakmt_fmm_clear_all_aperture(HsaKFDContext *ctx)
 {
 	uint32_t i;
 	void *map_addr;
-	
+
 	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	fmm_clear_aperture(&fmm_ctx->mem_handle_aperture);

--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -1402,34 +1402,21 @@ static HSAKMT_STATUS fmm_register_mem_svm_api(HsaKFDContext *ctx,
 	args->attrs[num_gpus + 1].type = flags.ui32.ExtendedCoherent ?
 							HSA_SVM_ATTR_SET_FLAGS : HSA_SVM_ATTR_CLR_FLAGS;
 	args->attrs[num_gpus + 1].value = HSA_SVM_FLAG_EXT_COHERENT;
-	/* Validate and reserve the tracking entry before touching kernel state,
-	 * so a same-base re-registration with a mismatched size is rejected
-	 * (INVALID_PARAMETER) without issuing a stray SET_ATTR - deregister is
-	 * keyed only by base address and could not disambiguate the two extents.
-	 * Identical (base, size) registrations are refcounted.
-	 */
-	ret = svm_api_range_get(fmm_ctx, (void *)aligned_addr, aligned_size);
-	if (ret != HSAKMT_STATUS_SUCCESS)
-		return ret;
 
 	pr_debug("Registering to SVM %p size: %" PRIu64 "\n", (void*)aligned_addr,
 		 aligned_size);
 	/* Driver does one copy_from_user, with extra attrs size */
 	if (hsakmt_ioctl(ctx->fd, AMDKFD_IOC_SVM + (s_attr << _IOC_SIZESHIFT), args)) {
-		struct svm_revoke_range *rr = NULL;
-
 		pr_debug("op set range attrs failed %s\n", strerror(errno));
-		/* The kernel never got the attributes; drop the reference we
-		 * reserved above. No GPU access was granted, so any revoke
-		 * ranges it computes are moot - just free them.
-		 */
-		svm_api_range_put(fmm_ctx, address, &rr);
-		free(rr);
 		ret = HSAKMT_STATUS_ERROR;
 		goto out;
 	}
 
-	ret = HSAKMT_STATUS_SUCCESS;
+	/* Track only once the kernel has the attributes, so a failed register
+	 * leaves nothing behind and cannot grow a same-base entry's extent to a
+	 * span that never got GPU access.
+	 */
+	ret = svm_api_range_get(fmm_ctx, (void *)aligned_addr, aligned_size);
 
 out:
 	free(args);

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/CMakeLists.txt
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/CMakeLists.txt
@@ -273,6 +273,7 @@ set (SRC_FILES gtest-1.6.0/gtest-all.cpp
   src/KFDPerformanceTest.cpp
   src/KFDPMTest.cpp
   src/KFDSVMRangeTest.cpp
+  src/KFDSVMRangeReGrant_test.cpp
   src/KFDSVMEvictTest.cpp
   src/KFDRASTest.cpp
   src/KFDPCSamplingTest.cpp

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeReGrant_test.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeReGrant_test.cpp
@@ -1,0 +1,69 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+#include "KFDSVMRangeTest.hpp"
+#include <sys/mman.h>
+#include <string.h>
+
+/*
+ * Deregister leaves a range NO_ACCESS, and allocators like jemalloc reuse the
+ * VA without munmap so that sticks. Registering the same VA again has to
+ * restore access or the GPU faults on it. Read access back with hsaKmtSVMGetAttr
+ * instead of relying on a fault.
+ */
+TEST_P(KFDSVMRangeTest, SVMApiRegisterReGrant) {
+    TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
+    TEST_START(TESTPROFILE_RUNALL);
+
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
+        if (!SVMAPISupported_GPU(gpuNode)) {
+            LOG() << "Skipping test: SVM API not supported on gpuNode " << gpuNode << std::endl;
+            return;
+        }
+        if (GetFamilyIdFromNodeId(gpuNode) < FAMILY_AI) {
+            LOG() << "Skipping test: no svm range support on gpuNode " << gpuNode << std::endl;
+            return;
+        }
+        const HsaNodeProperties *pNodeProperties =
+            Get_NodeInfo()->GetNodeProperties(gpuNode);
+        if (pNodeProperties->Integrated || Get_NodeInfo()->IsAppAPU(gpuNode)) {
+            LOG() << "Skipping test on (App)APU gpuNode " << gpuNode << std::endl;
+            return;
+        }
+
+        const HSAuint64 PG = PAGE_SIZE;
+
+        auto access = [&](void *addr) -> HSAuint32 {
+            HSA_SVM_ATTRIBUTE attr = { HSA_SVM_ATTR_ACCESS, (HSAuint32)gpuNode };
+            EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtSVMGetAttr, m_hsakmt_current_ctx,
+                                           addr, PG, 1, &attr), gpuNode);
+            return attr.type;
+        };
+
+        void *buf = mmap(0, PG, PROT_READ | PROT_WRITE,
+                         MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+        ASSERT_NE_GPU(MAP_FAILED, buf, gpuNode);
+        memset(buf, 0, PG);
+
+        /* Register then deregister: the range is left NO_ACCESS. */
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
+                                       buf, PG), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx,
+                                       buf), gpuNode);
+        EXPECT_EQ_GPU(HSA_SVM_ATTR_NO_ACCESS, access(buf), gpuNode);
+
+        /* Re-register the same VA (allocator reuse without munmap): access must
+         * be restored, not left at NO_ACCESS.
+         */
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
+                                       buf, PG), gpuNode);
+        EXPECT_NE_GPU(HSA_SVM_ATTR_NO_ACCESS, access(buf), gpuNode);
+
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx,
+                                       buf), gpuNode);
+        munmap(buf, PG);
+    }));
+
+    TEST_END
+}

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
@@ -1704,6 +1704,163 @@ TEST_P(KFDSVMRangeTest, HMMProfilingEvent) {
 }
 
 /*
+ * Read back the per-GPU access state of [addr, size) via
+ * hsaKmtSVMGetAttr(HSA_SVM_ATTR_ACCESS). On return the attribute type holds the
+ * effective access: HSA_SVM_ATTR_ACCESS, HSA_SVM_ATTR_ACCESS_IN_PLACE or
+ * HSA_SVM_ATTR_NO_ACCESS. Query one page at a time so the result is unambiguous.
+ */
+static HSAuint32 GetSvmGpuAccess(void *addr, HSAuint64 size, int gpuNode) {
+    HSA_SVM_ATTRIBUTE attr = { HSA_SVM_ATTR_ACCESS, (HSAuint32)gpuNode };
+
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtSVMGetAttr, g_baseTest->m_hsakmt_current_ctx,
+                                   addr, size, 1, &attr), gpuNode);
+    return attr.type;
+}
+
+/* Establish a known ACCESS baseline for the GPU over [addr, size), so a later
+ * NO_ACCESS revoke is observable regardless of the XNACK default. */
+static void SetSvmGpuAccess(void *addr, HSAuint64 size, int gpuNode) {
+    HSA_SVM_ATTRIBUTE attr = { HSA_SVM_ATTR_ACCESS, (HSAuint32)gpuNode };
+
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtSVMSetAttr, g_baseTest->m_hsakmt_current_ctx,
+                                   addr, size, 1, &attr), gpuNode);
+}
+
+/*
+ * Guard the thunk SVM-API registration tracking (libhsakmt fmm.c
+ * svm_api_range_get/put). On a dGPU with SVM API support, hsaKmtRegisterMemory
+ * on system memory tracks the page-rounded range so hsaKmtDeregisterMemory can
+ * revoke GPU access (NO_ACCESS) for exactly the sub-ranges that no surviving
+ * registration still covers. Three edge cases are exercised:
+ *
+ *   1. Reject - a base re-registered with a different page-rounded size is
+ *      rejected (HSAKMT_STATUS_INVALID_PARAMETER): deregister is keyed only by
+ *      base address and could not tell the two extents apart.
+ *   2. Refcount - identical (base, size) registrations are refcounted; access
+ *      is revoked only on the last deregister.
+ *   3. Overlap - two registrations whose page-rounded ranges share a page keep
+ *      that page accessible until the last owner is deregistered, instead of
+ *      over-revoking a neighbor's page.
+ *
+ * Access state is read back per page with hsaKmtSVMGetAttr, making the
+ * assertions deterministic without relying on a GPU fault.
+ */
+void KFDSVMRangeTest::SVMApiDeregisterTest(int gpuNode) {
+    if (!SVMAPISupported_GPU(gpuNode)) {
+        LOG() << "Skipping test: SVM API not supported on gpuNode " << gpuNode << std::endl;
+        return;
+    }
+    if (GetFamilyIdFromNodeId(gpuNode) < FAMILY_AI) {
+        LOG() << "Skipping test: no svm range support on gpuNode " << gpuNode << std::endl;
+        return;
+    }
+    const HsaNodeProperties *pNodeProperties =
+        Get_NodeInfo()->GetNodeProperties(gpuNode);
+    if (pNodeProperties->Integrated || Get_NodeInfo()->IsAppAPU(gpuNode)) {
+        LOG() << "Skipping test on (App)APU gpuNode " << gpuNode << std::endl;
+        return;
+    }
+
+    const HSAuint64 PG = PAGE_SIZE;
+
+    /* ---- 1. Reject same-base re-register with a different size ---- */
+    LOG() << "Phase 1: reject same-base / different-size re-register" << std::endl;
+    {
+        void *buf = mmap(0, 2 * PG, PROT_READ | PROT_WRITE,
+                         MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+        ASSERT_NE_GPU(MAP_FAILED, buf, gpuNode);
+        memset(buf, 0, 2 * PG);
+
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
+                                       buf, PG), gpuNode);
+        /* PG rounds to 1 page, 2*PG to 2 pages: a different extent at the same
+         * base must be rejected.
+         */
+        EXPECT_EQ_GPU(HSAKMT_STATUS_INVALID_PARAMETER,
+                      HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
+                                  buf, 2 * PG), gpuNode);
+        /* Same (base, size) is accepted and refcounted. */
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
+                                       buf, PG), gpuNode);
+
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx,
+                                       buf), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx,
+                                       buf), gpuNode);
+        munmap(buf, 2 * PG);
+    }
+
+    /* ---- 2. Refcount: access revoked only on the last deregister ---- */
+    LOG() << "Phase 2: refcounted identical registrations" << std::endl;
+    {
+        void *buf = mmap(0, PG, PROT_READ | PROT_WRITE,
+                         MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+        ASSERT_NE_GPU(MAP_FAILED, buf, gpuNode);
+        memset(buf, 0, PG);
+        SetSvmGpuAccess(buf, PG, gpuNode);
+
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
+                                       buf, PG), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
+                                       buf, PG), gpuNode);
+
+        /* One of two references dropped: still accessible. */
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx,
+                                       buf), gpuNode);
+        EXPECT_EQ_GPU(HSA_SVM_ATTR_ACCESS, GetSvmGpuAccess(buf, PG, gpuNode), gpuNode);
+
+        /* Last reference dropped: now revoked. */
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx,
+                                       buf), gpuNode);
+        EXPECT_EQ_GPU(HSA_SVM_ATTR_NO_ACCESS, GetSvmGpuAccess(buf, PG, gpuNode), gpuNode);
+        munmap(buf, PG);
+    }
+
+    /* ---- 3. Overlap: shared page survives until its last owner ---- */
+    LOG() << "Phase 3: overlapping registrations keep the shared page" << std::endl;
+    {
+        char *buf = (char *)mmap(0, 3 * PG, PROT_READ | PROT_WRITE,
+                                 MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+        ASSERT_NE_GPU(MAP_FAILED, buf, gpuNode);
+        memset(buf, 0, 3 * PG);
+        SetSvmGpuAccess(buf, 3 * PG, gpuNode);
+
+        /* A covers pages [0,1], B covers pages [1,2]; page 1 is shared. */
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
+                                       buf, PG + 1), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
+                                       buf + PG, PG + 1), gpuNode);
+
+        /* Drop A: only its exclusive page 0 is revoked; the shared page 1
+         * (still owned by B) and B's page 2 keep access.
+         */
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx,
+                                       buf), gpuNode);
+        EXPECT_EQ_GPU(HSA_SVM_ATTR_NO_ACCESS, GetSvmGpuAccess(buf,          PG, gpuNode), gpuNode);
+        EXPECT_EQ_GPU(HSA_SVM_ATTR_ACCESS,    GetSvmGpuAccess(buf + PG,     PG, gpuNode), gpuNode);
+        EXPECT_EQ_GPU(HSA_SVM_ATTR_ACCESS,    GetSvmGpuAccess(buf + 2 * PG, PG, gpuNode), gpuNode);
+
+        /* Drop B: pages 1 and 2 are now revoked. */
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx,
+                                       buf + PG), gpuNode);
+        EXPECT_EQ_GPU(HSA_SVM_ATTR_NO_ACCESS, GetSvmGpuAccess(buf + PG,     PG, gpuNode), gpuNode);
+        EXPECT_EQ_GPU(HSA_SVM_ATTR_NO_ACCESS, GetSvmGpuAccess(buf + 2 * PG, PG, gpuNode), gpuNode);
+        munmap(buf, 3 * PG);
+    }
+}
+
+TEST_P(KFDSVMRangeTest, SVMApiDeregisterTest) {
+    TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
+    TEST_START(TESTPROFILE_RUNALL);
+
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
+        this->SVMApiDeregisterTest(gpuNode);
+    }));
+
+    TEST_END
+}
+
+/*
  * Test SVM support VRAM overcommitment
  *
  * Prefetch total VRAM size plus overCommitSize SVM range to VRAM. after VRAM is full,

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
@@ -1763,30 +1763,35 @@ void KFDSVMRangeTest::SVMApiDeregisterTest(int gpuNode) {
 
     const HSAuint64 PG = PAGE_SIZE;
 
-    /* ---- 1. Reject same-base re-register with a different size ---- */
-    LOG() << "Phase 1: reject same-base / different-size re-register" << std::endl;
+    /* ---- 1. Same base, different span: accepted, refcounted, extent grows -- */
+    LOG() << "Phase 1: same-base / different-size registrations coexist" << std::endl;
     {
         void *buf = mmap(0, 2 * PG, PROT_READ | PROT_WRITE,
                          MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
         ASSERT_NE_GPU(MAP_FAILED, buf, gpuNode);
         memset(buf, 0, 2 * PG);
+        SetSvmGpuAccess(buf, 2 * PG, gpuNode);
 
-        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
-                                       buf, PG), gpuNode);
-        /* PG rounds to 1 page, 2*PG to 2 pages: a different extent at the same
-         * base must be rejected.
+        /* Same page-aligned base, different page-aligned span (1 page vs 2):
+         * both are accepted (no reject) and refcounted, and the tracked extent
+         * grows to cover the larger span.
          */
-        EXPECT_EQ_GPU(HSAKMT_STATUS_INVALID_PARAMETER,
-                      HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
-                                  buf, 2 * PG), gpuNode);
-        /* Same (base, size) is accepted and refcounted. */
         EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
                                        buf, PG), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
+                                       buf, 2 * PG), gpuNode);
 
+        /* One of two dropped: still accessible (refcount > 0). */
         EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx,
                                        buf), gpuNode);
+        EXPECT_EQ_GPU(HSA_SVM_ATTR_ACCESS, GetSvmGpuAccess(buf, PG, gpuNode), gpuNode);
+
+        /* Last dropped: revoked across the full grown extent (both pages). */
         EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx,
                                        buf), gpuNode);
+        EXPECT_EQ_GPU(HSA_SVM_ATTR_NO_ACCESS, GetSvmGpuAccess(buf, PG, gpuNode), gpuNode);
+        EXPECT_EQ_GPU(HSA_SVM_ATTR_NO_ACCESS,
+                      GetSvmGpuAccess((char *)buf + PG, PG, gpuNode), gpuNode);
         munmap(buf, 2 * PG);
     }
 
@@ -1855,6 +1860,193 @@ TEST_P(KFDSVMRangeTest, SVMApiDeregisterTest) {
 
     ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SVMApiDeregisterTest(gpuNode);
+    }));
+
+    TEST_END
+}
+
+/*
+ * Thunk-only reproduction of the HIP reproducer-1 overlap sequence, with no
+ * CLR/ROCr in the path. Mirrors:
+ *     ptr = malloc(10000);
+ *     hipHostRegister(ptr + 5000, 1000);   // high sub-range first
+ *     hipHostRegister(ptr,        5000);   // low sub-range
+ *     hipHostUnregister(ptr);              // must NOT revoke the shared page
+ *     hipHostUnregister(ptr + 5000);
+ *
+ * malloc is not page-aligned, so whether the two page-rounded registrations
+ * actually share a page depends on ptr's in-page offset. We place ptr at a
+ * small fixed offset so the two ranges DETERMINISTICALLY share a page - that is
+ * exactly the case where deregister(ptr) must revoke only its exclusive pages
+ * and leave the shared page (still owned by the ptr+5000 registration) mapped.
+ *
+ * Because this drives hsaKmtRegisterMemory/hsaKmtDeregisterMemory directly, it
+ * isolates the thunk: if the shared page is preserved here, the thunk is not
+ * over-revoking and any over-revoke seen through HIP is upstream (CLR/ROCr).
+ */
+void KFDSVMRangeTest::SVMApiOverlapReproTest(int gpuNode) {
+    if (!SVMAPISupported_GPU(gpuNode)) {
+        LOG() << "Skipping test: SVM API not supported on gpuNode " << gpuNode << std::endl;
+        return;
+    }
+    if (GetFamilyIdFromNodeId(gpuNode) < FAMILY_AI) {
+        LOG() << "Skipping test: no svm range support on gpuNode " << gpuNode << std::endl;
+        return;
+    }
+    const HsaNodeProperties *pNodeProperties =
+        Get_NodeInfo()->GetNodeProperties(gpuNode);
+    if (pNodeProperties->Integrated || Get_NodeInfo()->IsAppAPU(gpuNode)) {
+        LOG() << "Skipping test on (App)APU gpuNode " << gpuNode << std::endl;
+        return;
+    }
+
+    const HSAuint64 PG = PAGE_SIZE;
+    const HSAuint64 pageMask = ~(PG - 1);
+    const size_t allocSize = 10000;
+
+    /* Page-aligned backing so we control ptr's in-page offset deterministically.
+     * Offset 100 -> low=[page0,page2), high=[page1,page2): they share page1.
+     */
+    uint8_t *base = (uint8_t *)mmap(0, allocSize + 2 * PG, PROT_READ | PROT_WRITE,
+                                    MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    ASSERT_NE_GPU(MAP_FAILED, (void *)base, gpuNode);
+    uint8_t *ptr = base + 100;
+    memset(ptr, 0, allocSize);
+
+    HSAuint64 lowBase  = (HSAuint64)ptr & pageMask;
+    HSAuint64 lowEnd   = ((HSAuint64)ptr + 5000 + PG - 1) & pageMask;
+    HSAuint64 highBase = (HSAuint64)(ptr + 5000) & pageMask;
+    HSAuint64 highEnd  = ((HSAuint64)(ptr + 5000) + 1000 + PG - 1) & pageMask;
+    LOG() << std::hex
+          << "ptr=0x" << (HSAuint64)ptr
+          << " offset=0x" << ((HSAuint64)ptr & (PG - 1))
+          << "  low=[0x" << lowBase << ",0x" << lowEnd << ")"
+          << "  high=[0x" << highBase << ",0x" << highEnd << ")"
+          << std::dec << std::endl;
+
+    HSAuint64 spanBase = lowBase < highBase ? lowBase : highBase;
+    HSAuint64 spanEnd  = lowEnd  > highEnd  ? lowEnd  : highEnd;
+    SetSvmGpuAccess((void *)spanBase, spanEnd - spanBase, gpuNode);
+
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
+                                   ptr + 5000, 1000), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
+                                   ptr, 5000), gpuNode);
+
+    /* Drop the low range. Each page of [lowBase,lowEnd) that the surviving high
+     * range still covers must stay ACCESS; the rest must be revoked.
+     */
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx,
+                                   ptr), gpuNode);
+    for (HSAuint64 p = lowBase; p < lowEnd; p += PG) {
+        bool sharedWithSurvivor = (p >= highBase && p < highEnd);
+        HSAuint32 acc = GetSvmGpuAccess((void *)p, PG, gpuNode);
+        LOG() << std::hex << "  after unreg(ptr): page 0x" << p
+              << (sharedWithSurvivor ? "  [shared -> expect ACCESS]"
+                                     : "  [exclusive -> expect NO_ACCESS]")
+              << "  got "
+              << (acc == HSA_SVM_ATTR_ACCESS ? "ACCESS"
+                  : acc == HSA_SVM_ATTR_NO_ACCESS ? "NO_ACCESS" : "OTHER")
+              << std::dec << std::endl;
+        EXPECT_EQ_GPU(sharedWithSurvivor ? HSA_SVM_ATTR_ACCESS
+                                         : HSA_SVM_ATTR_NO_ACCESS,
+                      acc, gpuNode);
+    }
+
+    /* Drop the high range. Now its pages are revoked too. */
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx,
+                                   ptr + 5000), gpuNode);
+    for (HSAuint64 p = highBase; p < highEnd; p += PG)
+        EXPECT_EQ_GPU(HSA_SVM_ATTR_NO_ACCESS,
+                      GetSvmGpuAccess((void *)p, PG, gpuNode), gpuNode);
+
+    munmap(base, allocSize + 2 * PG);
+}
+
+TEST_P(KFDSVMRangeTest, SVMApiOverlapReproTest) {
+    TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
+    TEST_START(TESTPROFILE_RUNALL);
+
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
+        this->SVMApiOverlapReproTest(gpuNode);
+    }));
+
+    TEST_END
+}
+
+/*
+ * Two DISTINCT sub-page buffers that land in the SAME page but whose
+ * page-aligned spans DIFFER - the calloc-packed pattern that regressed
+ * Unit_hipHostRegister_Nbuf_MultiFlag_RegisterUnregister. b1 near the page
+ * start rounds to one page; b2 near the page end straddles into the next page,
+ * so it rounds to two. Both share the page-aligned base, so a scheme that keys
+ * tracking by base must NOT reject the second as a "size mismatch" - they are
+ * two independent registrations, distinguished at deregister time by their user
+ * pointer. This guards that both are accepted and that access is revoked only
+ * once the last owner of a page is gone.
+ */
+void KFDSVMRangeTest::SVMApiSharedPageTest(int gpuNode) {
+    if (!SVMAPISupported_GPU(gpuNode)) {
+        LOG() << "Skipping test: SVM API not supported on gpuNode " << gpuNode << std::endl;
+        return;
+    }
+    if (GetFamilyIdFromNodeId(gpuNode) < FAMILY_AI) {
+        LOG() << "Skipping test: no svm range support on gpuNode " << gpuNode << std::endl;
+        return;
+    }
+    const HsaNodeProperties *pNodeProperties =
+        Get_NodeInfo()->GetNodeProperties(gpuNode);
+    if (pNodeProperties->Integrated || Get_NodeInfo()->IsAppAPU(gpuNode)) {
+        LOG() << "Skipping test on (App)APU gpuNode " << gpuNode << std::endl;
+        return;
+    }
+
+    const HSAuint64 PG = PAGE_SIZE;
+
+    uint8_t *base = (uint8_t *)mmap(0, 3 * PG, PROT_READ | PROT_WRITE,
+                                    MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    ASSERT_NE_GPU(MAP_FAILED, (void *)base, gpuNode);
+    memset(base, 0, 3 * PG);
+
+    /* b1 @ +0xbb0 size 1024 -> aligned [base, base+PG)      (1 page)
+     * b2 @ +0xfc0 size 1024 -> aligned [base, base+2*PG)    (straddles -> 2 pages)
+     * Both round down to the same base page; b2's span differs.
+     */
+    uint8_t *b1 = base + 0xbb0;
+    uint8_t *b2 = base + 0xfc0;
+    void *page0 = base;
+    void *page1 = base + PG;
+
+    SetSvmGpuAccess(base, 2 * PG, gpuNode);
+
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
+                                   b1, 1024), gpuNode);
+    /* The regression: this second, distinct buffer shares the page base but has
+     * a different page-aligned span and was wrongly rejected.
+     */
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx,
+                                   b2, 1024), gpuNode);
+
+    /* Drop b1: page0 is still owned by b2, so it must stay accessible. */
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx,
+                                   b1), gpuNode);
+    EXPECT_EQ_GPU(HSA_SVM_ATTR_ACCESS, GetSvmGpuAccess(page0, PG, gpuNode), gpuNode);
+
+    /* Drop b2: now both pages are revoked. */
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx,
+                                   b2), gpuNode);
+    EXPECT_EQ_GPU(HSA_SVM_ATTR_NO_ACCESS, GetSvmGpuAccess(page0, PG, gpuNode), gpuNode);
+    EXPECT_EQ_GPU(HSA_SVM_ATTR_NO_ACCESS, GetSvmGpuAccess(page1, PG, gpuNode), gpuNode);
+
+    munmap(base, 3 * PG);
+}
+
+TEST_P(KFDSVMRangeTest, SVMApiSharedPageTest) {
+    TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
+    TEST_START(TESTPROFILE_RUNALL);
+
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
+        this->SVMApiSharedPageTest(gpuNode);
     }));
 
     TEST_END

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.hpp
@@ -53,6 +53,7 @@ class KFDSVMRangeTest : public KFDBaseComponentTest,
     void HMMProfilingEvent(int gpuNode);
     void VramOvercommitTest(int gpuNode);
     void PrefaultPartialRangeTest(int gpuNode);
+    void SVMApiDeregisterTest(int gpuNode);
 
  protected:
     virtual void SetUp();

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.hpp
@@ -54,6 +54,8 @@ class KFDSVMRangeTest : public KFDBaseComponentTest,
     void VramOvercommitTest(int gpuNode);
     void PrefaultPartialRangeTest(int gpuNode);
     void SVMApiDeregisterTest(int gpuNode);
+    void SVMApiOverlapReproTest(int gpuNode);
+    void SVMApiSharedPageTest(int gpuNode);
 
  protected:
     virtual void SetUp();


### PR DESCRIPTION
## Motivation

Relands #6699 (reverted in 51c421c0 / #9187) with the fix for what broke it.

#6699 made deregister revoke GPU access with NO_ACCESS, but register never re-granted it. jemalloc reuses a VA without munmap, so that NO_ACCESS stays on the kernel SVM range and the GPU faults on the next register of the same address. Under ASan + XNACK the hip-tests hung on that fault and CI killed them on timeout, which is what turned ASan red.

## Technical Details

- Revoke SVM-API GPU access on deregister (original #6699, reapplied past the revert).
- Accept same-base registrations with differing spans (follow-on lost in the revert).
- kfdtest coverage for the same-page divergent-span case.
- Re-grant GPU access on SVM-API register (new). Register now sets ACCESS_IN_PLACE per GPU so a reused VA regains access. Has to be ACCESS_IN_PLACE, not ACCESS: userptr memory can't migrate, so ACCESS makes the fault handler try a migration that fails and still faults. Matches what fmm_map_mem_svm_api() already uses.
- kfdtest for the register re-grant path.

Complementary to Philip Yang's kernel patch (unmap svm range when all GPUs set to no-access); kernel unmaps on no-access, thunk revokes on deregister and re-grants on register. Both are needed.

## Issue Tracking

JIRA ID: ROCM-28520

## Test Plan

Built the full-ASan gfx942 stack on top of Philip's kernel patch and ran the failing hip-tests (MemoryTest1/2, GraphsTest2) with HSA_XNACK=1, comparing baseline, #6699, #6699 + this fix, and the ACCESS-instead-of-ACCESS_IN_PLACE variant.

## Test Result

- #6699 without this fix: MemoryTest1 hangs mid-suite on VM_L2_PROTECTION_FAULT.
- #6699 with this fix: completes all 376 cases, same as baseline (261 pass, 10 pre-existing fails).
- ACCESS variant: still hangs, so ACCESS_IN_PLACE is required.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.