### PR TITLE
[rocjitsu] Pass through descriptorless gfx1250 code objects

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -24,8 +24,8 @@ on:
         required: true
       corpus_ref:
         description: "Branch, tag, or SHA containing the packaged-HSACO DBT suite"
-        # Last updated on 2026/07/27.
-        default: "e1a9a1f7ac9b1d38c7eddf486b529bc3cfcb0c95"
+        # Last updated on 2026/07/28.
+        default: "4c232fc5da6e42bb8fb16e2d8797b3415afeca47"
         required: true
       legacy_corpus_ref:
         description: "Branch, tag, or SHA for the existing corpus tests"
@@ -143,8 +143,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ github.event.inputs.corpus_repository || 'ROCm/rocjitsu-test-corpus' }}
-          # Last updated on 2026/07/27.
-          ref: ${{ github.event.inputs.corpus_ref || 'e1a9a1f7ac9b1d38c7eddf486b529bc3cfcb0c95' }}
+          # Last updated on 2026/07/28.
+          ref: ${{ github.event.inputs.corpus_ref || '4c232fc5da6e42bb8fb16e2d8797b3415afeca47' }}
           path: rocjitsu-dbt-test-corpus
 
       - name: Set up Python

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1101,12 +1101,20 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   TranslatedCodeObject result;
   result.host_arch = host_arch_;
 
-  CodeObjectPatcher patcher(obj);
   auto leave_unchanged = [&]() {
     const auto *image = reinterpret_cast<const uint8_t *>(obj.image_data());
-    result.elf_bytes.assign(image, image + obj.image_size());
+    if (obj.image_size() != 0)
+      result.elf_bytes.assign(image, image + obj.image_size());
     return result;
   };
+
+  if (obj.image_size() < sizeof(Elf64_Ehdr)) {
+    append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
+                 "code object is too small to contain an ELF header");
+    return leave_unchanged();
+  }
+
+  CodeObjectPatcher patcher(obj);
 
   // A same-architecture gfx1250 translation is direction-specific: A0 and B0
   // share an ELF machine ID, so both revisions must be given. Enforce this here
@@ -1130,6 +1138,15 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
 
   auto text = patcher.text_bytes();
   if (text.empty()) {
+    Elf64_Ehdr header{};
+    std::memcpy(&header, obj.image_data(), sizeof(header));
+    const uint32_t source_mach = header.e_flags & EF_AMDGPU_MACH;
+    if (guest_arch_ == host_arch_ && source_mach == (target_mach_ & EF_AMDGPU_MACH)) {
+      append_warning(result.diagnostics, DiagnosticKind::DataOnly,
+                     "code object has no executable sections, segments, or callable symbols; "
+                     "leaving unchanged");
+      return leave_unchanged();
+    }
     append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
                  "code object does not expose a non-empty .text section for translation");
     return leave_unchanged();
@@ -1199,8 +1216,17 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   }
 
   if (descriptor_translations.empty()) {
-    append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
-                 "kernel descriptors are required for kernel-level translation");
+    const bool descriptorless_gfx1250_b0_to_a0 =
+        guest_arch_ == ROCJITSU_CODE_ARCH_GFX1250 && host_arch_ == ROCJITSU_CODE_ARCH_GFX1250 &&
+        options_.input_revision == ProcessorRevision::Gfx1250B0 &&
+        options_.output_revision == ProcessorRevision::Gfx1250A0;
+    if (!descriptorless_gfx1250_b0_to_a0) {
+      append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                   "kernel descriptors are required for kernel-level translation");
+      return leave_unchanged();
+    }
+    append_warning(result.diagnostics, DiagnosticKind::NothingToTranslate,
+                   "code object has no kernel descriptors; leaving executable text unchanged");
     return leave_unchanged();
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_diagnostic.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_diagnostic.h
@@ -27,6 +27,8 @@ enum class DiagnosticKind {
   Legalization,
   ExpandMissing,
   ExpandFailed,
+  DataOnly,
+  NothingToTranslate,
   ResourceLimit,
   KernelSkipped,
 };
@@ -54,6 +56,13 @@ has_error_diagnostic(const std::vector<TranslationDiagnostic> &diagnostics) {
   });
 }
 
+[[nodiscard]] inline bool has_diagnostic_kind(const std::vector<TranslationDiagnostic> &diagnostics,
+                                              DiagnosticKind kind) {
+  return std::ranges::any_of(diagnostics, [kind](const TranslationDiagnostic &diagnostic) {
+    return diagnostic.kind == kind;
+  });
+}
+
 /// @brief True if any kernel was replaced by a non-dispatchable no-op stub.
 ///
 /// @details skip_failed_kernels reports a KernelSkipped *warning* (not an error),
@@ -64,9 +73,7 @@ has_error_diagnostic(const std::vector<TranslationDiagnostic> &diagnostics) {
 /// non-dispatchable, matching the HSA hook which refuses such a load.
 [[nodiscard]] inline bool
 has_skipped_kernel(const std::vector<TranslationDiagnostic> &diagnostics) {
-  return std::ranges::any_of(diagnostics, [](const TranslationDiagnostic &diagnostic) {
-    return diagnostic.kind == DiagnosticKind::KernelSkipped;
-  });
+  return has_diagnostic_kind(diagnostics, DiagnosticKind::KernelSkipped);
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
@@ -543,6 +543,10 @@ void trace_virtual_lds_kernarg(uint64_t packet_id, const void *kernarg, size_t s
     return "expand-missing";
   case DiagnosticKind::ExpandFailed:
     return "expand-failed";
+  case DiagnosticKind::DataOnly:
+    return "data-only";
+  case DiagnosticKind::NothingToTranslate:
+    return "nothing-to-translate";
   case DiagnosticKind::ResourceLimit:
     return "resource-limit";
   case DiagnosticKind::KernelSkipped:

--- a/emulation/rocjitsu/tests/corpus/dbt/gfx1250_b0_a0_expected_failures.json
+++ b/emulation/rocjitsu/tests/corpus/dbt/gfx1250_b0_a0_expected_failures.json
@@ -3,18 +3,6 @@
     "2bff3e6611af6c6de83ff384fd5b659f9c42441c3553cf41c779047d4432b78b": {
       "kind": "memory-limit",
       "reason": "RCCL code object exceeds the per-object DBT memory limit in indirect-branch discovery"
-    },
-    "5d2a4110c0d8274651992689ae47abfb014cd36584338a725d77cecdec9718aa": {
-      "kind": "translation-error",
-      "reason": "PyTorch object currently exposes no non-empty text section",
-      "returncode": 3,
-      "stderr_regex": "resource-limit: code object does not expose a non-empty \\.text section for translation"
-    },
-    "af9e659f75ad449b591d855208fb122fd27d7e66422b687ee643054a5df4a2f7": {
-      "kind": "translation-error",
-      "reason": "rocFFT object currently has no kernel descriptors",
-      "returncode": 3,
-      "stderr_regex": "kernel-descriptor: kernel descriptors are required for kernel-level translation"
     }
   },
   "input_revision": "b0",

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -299,6 +299,19 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_text_and_rodata() {
   return image;
 }
 
+std::vector<uint8_t> make_minimal_gfx1250_elf_with_empty_text_and_rodata() {
+  auto image = make_minimal_amdgpu_elf_with_text_and_rodata();
+  auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  assert(shdrs.size() >= 2);
+
+  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX1250;
+  shdrs[1].sh_size = 0;
+  write_elf_struct_for_test(image, 0, ehdr);
+  write_bytes_for_test(image, ehdr.e_shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  return image;
+}
+
 std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
   constexpr uint64_t text_offset = 0x100;
   constexpr uint64_t text_vaddr = 0x1100;
@@ -1574,6 +1587,138 @@ TEST(LegalizationFmaK, Rdna1ToRdna3FmaakF16IsIdentity) {
   ASSERT_NE(e, nullptr);
   EXPECT_EQ(e->action, Action::Identity);
   EXPECT_EQ(e->target_opcode, 56);
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextSameArchIsSuccessfulNoOp) {
+  const auto image = make_minimal_gfx1250_elf_with_empty_text_and_rodata();
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_EQ(source.target_id(), ROCJITSU_CODE_TARGET_GFX1250);
+  ASSERT_FALSE(source.text_sections().empty());
+  ASSERT_EQ(source.text_sections()[0]->size(), 0u);
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_TRUE(result.ok());
+  EXPECT_TRUE(result.dispatchable());
+  EXPECT_EQ(result.elf_bytes, image);
+  const auto warning = std::ranges::find_if(result.diagnostics, [](const auto &diagnostic) {
+    return diagnostic.kind == DiagnosticKind::DataOnly;
+  });
+  ASSERT_NE(warning, result.diagnostics.end());
+  EXPECT_EQ(warning->severity, DiagnosticSeverity::Warning);
+  EXPECT_EQ(warning->message,
+            "code object has no executable sections, segments, or callable symbols; leaving "
+            "unchanged");
+}
+
+TEST(BinaryTranslatorE2E, TruncatedImageFailsBeforeReadingElfHeader) {
+  const std::array<uint8_t, sizeof(Elf64_Ehdr) - 1> image{};
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_FALSE(source.is_valid());
+  ASSERT_LT(source.image_size(), sizeof(Elf64_Ehdr));
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_RDNA4, ROCJITSU_CODE_ARCH_RDNA4);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_TRUE(result.elf_bytes.empty());
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ResourceLimit,
+                                   "too small to contain an ELF header"));
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextCrossArchStillFails) {
+  const auto image = make_minimal_gfx1250_elf_with_empty_text_and_rodata();
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_RDNA4);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ResourceLimit,
+                                   "does not expose a non-empty .text section"));
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextSameArchDifferentMachineStillFails) {
+  auto image = make_minimal_gfx1250_elf_with_empty_text_and_rodata();
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1200);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_EQ(source.target_id(), ROCJITSU_CODE_TARGET_GFX1200);
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_RDNA4, ROCJITSU_CODE_ARCH_RDNA4,
+                              EF_AMDGPU_MACH_AMDGCN_GFX1201);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::ResourceLimit,
+                                   "does not expose a non-empty .text section"));
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextGfx1250StillRequiresRevisions) {
+  const auto image = make_minimal_gfx1250_elf_with_empty_text_and_rodata();
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::Legalization,
+                                   "requires both input and output silicon revisions"));
+}
+
+TEST(BinaryTranslatorE2E, EmptyTextGfx1250StillRejectsA0ToB0) {
+  const auto image = make_minimal_gfx1250_elf_with_empty_text_and_rodata();
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250A0;
+  options.output_revision = ProcessorRevision::Gfx1250B0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(has_error_containing(result, DiagnosticKind::Legalization,
+                                   "A0-to-B0 translation is not supported"));
+}
+
+TEST(BinaryTranslatorE2E, DescriptorlessExecutableTextIsSuccessfulNoOp) {
+  auto image = make_minimal_amdgpu_elf_with_text_and_rodata();
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  write_value_for_test<uint32_t>(image, 0x100, 0xbf850004u);
+  AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_FALSE(source.text_sections().empty());
+  ASSERT_GT(source.text_sections()[0]->size(), 0u);
+
+  BinaryTranslatorOptions options;
+  options.input_revision = ProcessorRevision::Gfx1250B0;
+  options.output_revision = ProcessorRevision::Gfx1250A0;
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0, options);
+  const auto result = translator.translate(source);
+
+  EXPECT_TRUE(result.ok());
+  EXPECT_TRUE(result.dispatchable());
+  EXPECT_EQ(result.elf_bytes, image);
+  const auto warning = std::ranges::find_if(result.diagnostics, [](const auto &diagnostic) {
+    return diagnostic.kind == DiagnosticKind::NothingToTranslate;
+  });
+  ASSERT_NE(warning, result.diagnostics.end());
+  EXPECT_EQ(warning->severity, DiagnosticSeverity::Warning);
+  EXPECT_NE(warning->message.find("no kernel descriptors"), std::string::npos);
 }
 
 TEST(CodeObjectPatcher, ReplaceTextGrowsTextAndShiftsFollowingSections) {

--- a/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
@@ -196,6 +196,55 @@ std::vector<uint8_t> make_gfx1250_smoke_code_object() {
   return make_gfx1250_smoke_code_object(text_words);
 }
 
+void clear_smoke_kernel_descriptor_symbol(std::vector<uint8_t> &image) {
+  rocjitsu::Elf64_Ehdr header{};
+  std::memcpy(&header, image.data(), sizeof(header));
+
+  auto section_offset = [&](size_t index) {
+    return header.e_shoff + index * sizeof(rocjitsu::Elf64_Shdr);
+  };
+  rocjitsu::Elf64_Shdr symtab{};
+  std::memcpy(&symtab, image.data() + section_offset(3), sizeof(symtab));
+  rocjitsu::Elf64_Sym descriptor{};
+  std::memcpy(&descriptor, image.data() + symtab.sh_offset + sizeof(rocjitsu::Elf64_Sym),
+              sizeof(descriptor));
+  descriptor.st_name = 0;
+  descriptor.st_info = 0;
+  descriptor.st_shndx = rocjitsu::SHN_UNDEF;
+  descriptor.st_value = 0;
+  descriptor.st_size = 0;
+  std::memcpy(image.data() + symtab.sh_offset + sizeof(rocjitsu::Elf64_Sym), &descriptor,
+              sizeof(descriptor));
+}
+
+std::vector<uint8_t> make_descriptorless_code_object() {
+  constexpr std::array<uint32_t, 2> text_words = {0xbf800000u, 0};
+  auto image = make_gfx1250_smoke_code_object(text_words);
+  clear_smoke_kernel_descriptor_symbol(image);
+  return image;
+}
+
+std::vector<uint8_t> make_empty_text_code_object() {
+  auto image = make_descriptorless_code_object();
+
+  rocjitsu::Elf64_Ehdr header{};
+  std::memcpy(&header, image.data(), sizeof(header));
+
+  rocjitsu::Elf64_Phdr executable_load{};
+  std::memcpy(&executable_load, image.data() + header.e_phoff, sizeof(executable_load));
+  executable_load.p_filesz = 0;
+  executable_load.p_memsz = 0;
+  std::memcpy(image.data() + header.e_phoff, &executable_load, sizeof(executable_load));
+
+  const uint64_t text_section = header.e_shoff + sizeof(rocjitsu::Elf64_Shdr);
+  rocjitsu::Elf64_Shdr text{};
+  std::memcpy(&text, image.data() + text_section, sizeof(text));
+  text.sh_size = 0;
+  std::memcpy(image.data() + text_section, &text, sizeof(text));
+
+  return image;
+}
+
 std::string shell_quote(std::string_view text) {
   std::string quoted = "'";
   for (const char ch : text) {
@@ -355,6 +404,71 @@ TEST(RjDbtTranslate, Smoke) {
         << "missing expected output fragment: " << needle << "\noutput:\n"
         << stdout_text;
   }
+}
+
+TEST(RjDbtTranslate, EmptyTextSameArchWarnsAndCopiesInput) {
+  const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_empty_text_");
+  const std::filesystem::path temp_path(temp_dir.path());
+
+  const auto input = temp_path / "data_only_gfx1250.co";
+  const auto output = temp_path / "translated.co";
+  const auto error = temp_path / "stderr.txt";
+  const auto image = make_empty_text_code_object();
+
+  {
+    std::ofstream out(input, std::ios::binary);
+    out.write(reinterpret_cast<const char *>(image.data()),
+              static_cast<std::streamsize>(image.size()));
+  }
+
+  const std::string command = shell_quote(g_translate_tool.string()) + " " +
+                              shell_quote(input.string()) +
+                              " --input-target gfx1250 --input-revision b0 --output-target gfx1250 "
+                              "--output-revision a0 --output-mode code-object > " +
+                              shell_quote(output.string()) + " 2> " + shell_quote(error.string());
+
+  const int status = std::system(command.c_str());
+  const std::string output_bytes = read_text_file(output);
+  const std::string stderr_text = read_text_file(error);
+
+  ASSERT_TRUE(command_succeeded(status)) << stderr_text;
+  EXPECT_EQ(output_bytes, std::string(reinterpret_cast<const char *>(image.data()), image.size()));
+  EXPECT_TRUE(contains(stderr_text, "warning: data-only: code object has no executable sections, "
+                                    "segments, or callable symbols; leaving unchanged"))
+      << stderr_text;
+}
+
+TEST(RjDbtTranslate, DescriptorlessExecutableWarnsAndCopiesInput) {
+  const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_descriptorless_");
+  const std::filesystem::path temp_path(temp_dir.path());
+
+  const auto input = temp_path / "descriptorless_gfx1250.co";
+  const auto output = temp_path / "translated.co";
+  const auto error = temp_path / "stderr.txt";
+  const auto image = make_descriptorless_code_object();
+
+  {
+    std::ofstream out(input, std::ios::binary);
+    out.write(reinterpret_cast<const char *>(image.data()),
+              static_cast<std::streamsize>(image.size()));
+  }
+
+  const std::string command = shell_quote(g_translate_tool.string()) + " " +
+                              shell_quote(input.string()) +
+                              " --input-target gfx1250 --input-revision b0 --output-target gfx1250 "
+                              "--output-revision a0 --output-mode code-object > " +
+                              shell_quote(output.string()) + " 2> " + shell_quote(error.string());
+
+  const int status = std::system(command.c_str());
+  const std::string output_bytes = read_text_file(output);
+  const std::string stderr_text = read_text_file(error);
+
+  ASSERT_TRUE(command_succeeded(status)) << stderr_text;
+  EXPECT_EQ(output_bytes, std::string(reinterpret_cast<const char *>(image.data()), image.size()));
+  EXPECT_TRUE(contains(stderr_text,
+                       "warning: nothing-to-translate: code object has no kernel descriptors; "
+                       "leaving executable text unchanged"))
+      << stderr_text;
 }
 
 TEST(RjDbtTranslate, RequiresRevisionsOnlyForGfx1250) {

--- a/emulation/rocjitsu/tools/dbt_translate.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate.cpp
@@ -86,6 +86,13 @@ void record_decode_failure(CodeSectionReport &section_report, size_t byte_offset
     size_t pc = 0;
 
     while (pc < word_count) {
+      // Linked gfx1250 objects use zero-filled holes between independently
+      // aligned function bodies. BasicBlock::build() treats these words as
+      // padding rather than instructions, so host validation must do the same.
+      if (arch == ROCJITSU_CODE_ARCH_GFX1250 && words[pc] == 0) {
+        ++pc;
+        continue;
+      }
       try {
         std::unique_ptr<Instruction> inst(decoder->decode(&words[pc]));
         if (!inst) {
@@ -526,7 +533,8 @@ ToolResult<TranslateOutput> translate_code_object(const TranslateOptions &option
     output.value.disassembly += translated_inspection.disassembly;
   }
 
-  if (!validate_host_decode(output.value.translated_report, error)) {
+  const bool data_only = has_diagnostic_kind(output.value.diagnostics, DiagnosticKind::DataOnly);
+  if (!data_only && !validate_host_decode(output.value.translated_report, error)) {
     add_error(output, kValidationError, error);
     return output;
   }

--- a/emulation/rocjitsu/tools/dbt_translate_main.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate_main.cpp
@@ -336,6 +336,10 @@ struct ReportTotals {
     return "expand-missing";
   case DiagnosticKind::ExpandFailed:
     return "expand-failed";
+  case DiagnosticKind::DataOnly:
+    return "data-only";
+  case DiagnosticKind::NothingToTranslate:
+    return "nothing-to-translate";
   case DiagnosticKind::ResourceLimit:
     return "resource-limit";
   case DiagnosticKind::KernelSkipped:


### PR DESCRIPTION
## Motivation

Some packaged gfx1250 B0 code objects contain no kernel descriptors, so kernel-level rewriting has no resource contract.

## Technical Details

- Return descriptorless gfx1250 B0-to-A0 objects byte-for-byte with a warning.
- Treat data-only objects as explicit successful no-ops while retaining host decode validation for executable pass-throughs.
- Accept zero-filled gfx1250 linker padding during CLI decode validation.
- Pin the corpus validator for data-only no-ops and remove two obsolete expected failures.

## Issue Tracking

N/A

## Test Plan

Build RocJITsu, run focused no-op tests, run the full CTest suite, and validate the complete 20,000-object gfx1250 corpus.

## Test Result

- `ninja all` passed.
- CTest completed with 2,183 passed, 3 skipped, and 0 failed; RCCL passed 5/5.
- The DBT corpus completed with 19,999 passed and 1 expected resource-limit failure.
- Pre-commit passed on all changed files.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.