### PR TITLE
docs(amdsmi): [AILITOOLS-267] correct perf-level and determinism GPU support table

### DIFF
--- a/projects/amdsmi/docs/conceptual/perf-determinism.md
+++ b/projects/amdsmi/docs/conceptual/perf-determinism.md
@@ -120,11 +120,11 @@ returns an error.
 | Feature | MI200 | MI300 | MI350 | RDNA 3 | RDNA 4 |
 | :--- | :---: | :---: | :---: | :---: | :---: |
 | `--perf-level AUTO` | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `--perf-level LOW` | ✅ | ✅ | ✅ | ✅ | ❓ |
-| `--perf-level HIGH` | ✅ | ✅ | ✅ | ✅ | ❓ |
-| `--perf-level MANUAL` | ✅ | ✅ | ✅ | ✅ | ❓ |
-| `--perf-level STABLE_*` | ✅ | ✅ | ❓ | ✅ | ❓ |
-| `--perf-determinism` | ✅ | ⚠️ | ❌ | ✅ | ❓ |
+| `--perf-level LOW` | ✅ | ❌ | ❌ | ✅ | ✅ |
+| `--perf-level HIGH` | ✅ | ❌ | ❌ | ✅ | ✅ |
+| `--perf-level MANUAL` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `--perf-level STABLE_*` | ✅ | ❌ | ❌ | ✅ | ✅ |
+| `--perf-determinism` | ✅ | ⚠️ | ❌ | ❌ | ❌ |
 
 **Legend:** ✅ Supported  ⚠️ Limited / ASIC-dependent  ❌ Not supported  ❓ Unconfirmed
 
@@ -132,13 +132,25 @@ returns an error.
 
 - **MI200 (Aldebaran)** -- Full support for all performance levels and
   determinism.
-- **MI300 (Aqua Vanjaram)** -- Performance determinism support depends on the
-  PMFW version. Verify with `amd-smi metric --perf-level` after setting.
-- **MI350** -- Performance determinism is **defeatured**. CSC (Clock Stretching
-  Compensation) is intended to address the variability use case that determinism
-  previously covered.
-- **RDNA 3 (Navi 3x)** -- Full support for performance levels and determinism.
-- **RDNA 4 (Navi 4x)** -- Depends on PMFW capabilities for the specific ASIC.
+- **MI300 (Aqua Vanjaram)** -- Only `AUTO` and `MANUAL` are accepted; `LOW`,
+  `HIGH`, and the `STABLE_*` profiling levels are rejected by PMFW
+  (`AMDSMI_STATUS_NOT_SUPPORTED`). Performance determinism is ASIC/PMFW-dependent
+  -- observed working on MI300A but returning `NOT_SUPPORTED` on MI308X. Verify
+  with `amd-smi metric --perf-level` after setting.
+- **MI350** -- Only `AUTO` and `MANUAL` are accepted; `LOW`, `HIGH`, and
+  `STABLE_*` are rejected by PMFW. Performance determinism is **defeatured**; CSC
+  (Clock Stretching Compensation) is intended to address the variability use case
+  that determinism previously covered.
+- **RDNA 3 (Navi 3x)** -- All performance levels (`AUTO`, `LOW`, `HIGH`,
+  `MANUAL`, `STABLE_*`) are supported. Performance determinism is **not**
+  supported on the tested consumer parts (Navi 31 / RX 7900 XTX, Navi 32 /
+  RX 7700 XT): `amd-smi set --perf-determinism` returns
+  `AMDSMI_STATUS_NOT_SUPPORTED` and the `perf_determinism` level is rejected at
+  the sysfs interface. Behavior on workstation RDNA SKUs is unverified.
+- **RDNA 4 (Navi 4x)** -- All performance levels (`AUTO`, `LOW`, `HIGH`,
+  `MANUAL`, `STABLE_*`) are supported on Navi 48 (RX 9070 XT). Performance
+  determinism is **not** supported (`AMDSMI_STATUS_NOT_SUPPORTED`;
+  `perf_determinism` rejected at sysfs).
 
 ## From concept to action
 

--- a/projects/amdsmi/docs/conceptual/perf-determinism.md
+++ b/projects/amdsmi/docs/conceptual/perf-determinism.md
@@ -126,7 +126,7 @@ returns an error.
 | `--perf-level STABLE_*` | ✅ | ❌ | ❌ | ✅ | ✅ |
 | `--perf-determinism` | ✅ | ⚠️ | ❌ | ❌ | ❌ |
 
-**Legend:** ✅ Supported  ⚠️ Limited / ASIC-dependent  ❌ Not supported  ❓ Unconfirmed
+**Legend:** ✅ Supported  ⚠️ Limited / ASIC-dependent  ❌ Not supported
 
 **Notes on specific GPU families:**
 
@@ -135,8 +135,8 @@ returns an error.
 - **MI300 (Aqua Vanjaram)** -- Only `AUTO` and `MANUAL` are accepted; `LOW`,
   `HIGH`, and the `STABLE_*` profiling levels are rejected by PMFW
   (`AMDSMI_STATUS_NOT_SUPPORTED`). Performance determinism is ASIC/PMFW-dependent
-  -- observed working on MI300A but returning `NOT_SUPPORTED` on MI308X. Verify
-  with `amd-smi metric --perf-level` after setting.
+  -- observed working on MI300A but returning `AMDSMI_STATUS_NOT_SUPPORTED` on
+  MI308X. Verify with `amd-smi metric --perf-level` after setting.
 - **MI350** -- Only `AUTO` and `MANUAL` are accepted; `LOW`, `HIGH`, and
   `STABLE_*` are rejected by PMFW. Performance determinism is **defeatured**; CSC
   (Clock Stretching Compensation) is intended to address the variability use case
@@ -146,7 +146,7 @@ returns an error.
   supported on the tested consumer parts (Navi 31 / RX 7900 XTX, Navi 32 /
   RX 7700 XT): `amd-smi set --perf-determinism` returns
   `AMDSMI_STATUS_NOT_SUPPORTED` and the `perf_determinism` level is rejected at
-  the sysfs interface. Behavior on workstation RDNA SKUs is unverified.
+  the sysfs interface. Workstation RDNA SKUs have not been tested.
 - **RDNA 4 (Navi 4x)** -- All performance levels (`AUTO`, `LOW`, `HIGH`,
   `MANUAL`, `STABLE_*`) are supported on Navi 48 (RX 9070 XT). Performance
   determinism is **not** supported (`AMDSMI_STATUS_NOT_SUPPORTED`;


### PR DESCRIPTION
## Motivation

Correct the `perf-determinism.md` GPU support table, which incorrectly marked several perf-levels and determinism modes as supported on MI300, MI350, and RDNA hardware that actually reject them.

## Technical Details

**Docs** (`projects/amdsmi/docs/conceptual/perf-determinism.md`): set MI300/MI350 `LOW`/`HIGH`/`STABLE_*` to ❌, filled RDNA 4 perf-levels ✅, marked RDNA 3/4 determinism ❌, and rewrote the per-family notes.

## Issue Tracking

JIRA ID: AILITOOLS-267

## Test Plan

Set each `--perf-level` and `--perf-determinism` via amd-smi CLI and raw sysfs (readback = ground truth) on MI210 (MI200), MI300A, MI308X, MI350X, Navi 31/32, and Navi 48.

## Test Result

MI200 (MI210) supports all perf-levels and determinism; MI300/MI350 accept only `AUTO`/`MANUAL` (rest rejected by PMFW); determinism works only on MI300A; RDNA 3/4 support all perf-levels but not determinism, table now matches.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
