### PR TITLE
[rocjitsu] Translate 64-bit FLAT_SCRATCH_BASE sources for gfx1250 A0

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
@@ -24,6 +24,7 @@ rj_add_object_library(rocjitsu_code
     dbt/semantic/cdna4_to_rdna3.cpp
     dbt/semantic/cdna4_to_rdna4.cpp
     dbt/semantic/gfx1250_b0_to_a0.cpp
+    dbt/semantic/gfx1250_flat_scratch_base.cpp
     dbt/semantic_translator.cpp
     dbt/semantic_scratch.cpp
     dbt/virtual_lds.cpp

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -19,6 +19,7 @@
 #include "rocjitsu/code/dbt/kernel_descriptor_translator.h"
 #include "rocjitsu/code/dbt/lds_virtualization.h"
 #include "rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.h"
+#include "rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.h"
 #include "rocjitsu/code/dbt/semantic_translator.h"
 #include "rocjitsu/code/dbt/virtual_lds.h"
 #include "rocjitsu/code/patch/code_object_patcher.h"
@@ -1118,15 +1119,19 @@ BinaryTranslator::BinaryTranslator(rj_code_arch_t guest_arch, rj_code_arch_t hos
       semantic_translator_(std::make_unique<SemanticTranslator>(
           guest_arch, host_arch, options.input_revision, options.output_revision)) {}
 
+bool BinaryTranslator::is_gfx1250_b0_to_a0() const {
+  return guest_arch_ == ROCJITSU_CODE_ARCH_GFX1250 && host_arch_ == ROCJITSU_CODE_ARCH_GFX1250 &&
+         options_.input_revision == ProcessorRevision::Gfx1250B0 &&
+         options_.output_revision == ProcessorRevision::Gfx1250A0;
+}
+
 const InstructionLegalization *
 BinaryTranslator::lookup_legalization(const Instruction &inst) const {
   // gfx1250 B0 and A0 have the same structural ISA, so the generated cross-ISA
   // tables cannot express their revision-specific behavior. Instructions in
   // the B0-to-A0 profile use handwritten legalization; everything else follows
   // the raw same-ISA copy path.
-  if (guest_arch_ == ROCJITSU_CODE_ARCH_GFX1250 && host_arch_ == ROCJITSU_CODE_ARCH_GFX1250 &&
-      options_.input_revision == ProcessorRevision::Gfx1250B0 &&
-      options_.output_revision == ProcessorRevision::Gfx1250A0)
+  if (is_gfx1250_b0_to_a0())
     return gfx1250_b0_to_a0_legalization(inst);
 
   return legalization_lookup_ ? legalization_lookup_(inst.encoding_id(), inst.opcode()) : nullptr;
@@ -1735,7 +1740,13 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         if (block == nullptr)
           continue;
         for (const Instruction &inst : block->instructions()) {
-          if (semantic_translator_->expand_rule_requires_liveness(inst)) {
+          // The gfx1250 flat-scratch-base rewrite is selected by operand rather
+          // than by (encoding, opcode), so the rule-table query above cannot see
+          // it. It borrows an SGPR pair for vector reads and therefore carries
+          // its own live-before requirement.
+          const bool operand_driven_rewrite =
+              is_gfx1250_b0_to_a0() && gfx1250_reads_flat_scratch_base_64bit(inst);
+          if (semantic_translator_->expand_rule_requires_liveness(inst) || operand_driven_rewrite) {
             scope_requires_liveness = true;
             live_before_instructions.push_back(&inst);
           }
@@ -2405,6 +2416,39 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
 
           if (virtual_lds_expansion.status == ExpandStatus::Success) {
             std::vector<uint32_t> target_words = std::move(virtual_lds_expansion.words);
+            append_words(kernel_text, target_words);
+            queue_trace(pending_traces, inst, offset, leg, false, true, true, target_offset,
+                        std::move(target_words));
+            continue;
+          }
+        }
+
+        // Operand-driven gfx1250 rewrites cannot be keyed by (encoding, opcode)
+        // the way the semantic rule table is, so they run after that lookup
+        // misses and before the missing-rule failure below.
+        if (is_gfx1250_b0_to_a0()) {
+          auto base_expansion =
+              gfx1250_lower_flat_scratch_base_source(inst, offset, text, liveness, kernel_context);
+          if (base_expansion.status == ExpandStatus::Failed) {
+            auto failure = make_kernel_failure(DiagnosticKind::ExpandFailed, base_expansion.message,
+                                               offset, std::string(inst.mnemonic()),
+                                               std::move(base_expansion.required_work));
+            if (continue_after_failure && !skip_failed_kernels) {
+              append_error(result.diagnostics, failure.kind, failure.message, failure.guest_offset,
+                           failure.mnemonic, failure.required_work);
+              if (continue_after_instruction_error(inst, offset, kernel_text, pending_traces)) {
+                continue;
+              }
+            }
+            if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
+                                    text_relocations_begin, data_relocations_begin)) {
+              skip_scope = true;
+              break;
+            }
+            return leave_unchanged();
+          }
+          if (base_expansion.status == ExpandStatus::Success) {
+            std::vector<uint32_t> target_words = std::move(base_expansion.words);
             append_words(kernel_text, target_words);
             queue_trace(pending_traces, inst, offset, leg, false, true, true, target_offset,
                         std::move(target_words));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.h
@@ -192,6 +192,9 @@ public:
   [[nodiscard]] TranslatedCodeObject translate(const AmdGpuCodeObject &obj);
 
 private:
+  /// @brief Whether this translator is running the gfx1250 B0-to-A0 profile.
+  [[nodiscard]] bool is_gfx1250_b0_to_a0() const;
+
   /// @brief Return the generated or revision-specific legalization for an instruction.
   [[nodiscard]] const InstructionLegalization *lookup_legalization(const Instruction &inst) const;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.h"
 
 #include "rocjitsu/code/dbt/generated/legalization_types.h"
+#include "rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/encodings.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/machine_insts.h"
 #include "rocjitsu/isa/instruction.h"
@@ -35,8 +36,8 @@ namespace {
 ///   * v_wmma_scale / v_wmma_scale16 forms without an implemented rule,
 ///   * integer IU4 and IU8 WMMA/SWMMAC forms without an implemented spacing
 ///     rule.
-/// Separately, a 64-bit source using FLAT_SCRATCH_BASE_HI is classified via
-/// operand inspection (see uses_flat_scratch_base_hi_64bit_source), and the
+/// Separately, a 64-bit source reading FLAT_SCRATCH_BASE is classified via
+/// operand inspection (see gfx1250_reads_flat_scratch_base_64bit), and the
 /// barrier-state and sleep/monitor families are DEFERRED with a pass-through
 /// warning rather than fail-closed (see is_deferred_gfx1250_family).
 /// Classifying the fail-closed cases keeps the failure explicit and located; add
@@ -150,25 +151,6 @@ inline constexpr std::array<std::string_view, 18> kExactB0ToA0TranslationMnemoni
   return encoding.clamp != 0;
 }
 
-/// @brief True when any source operand uses the special FLAT_SCRATCH_BASE_HI
-/// value in a 64-bit source position.
-/// @details This special scalar source is not usable in a 64-bit source position
-/// on this target, but the restriction is operand-sensitive rather than tied to a
-/// mnemonic family, so it needs per-operand inspection. A 32-bit use of the same
-/// value is unaffected. Encoding value 231 identifies the special source (see
-/// gfx1250/operand_types.h).
-[[nodiscard]] bool uses_flat_scratch_base_hi_64bit_source(const Instruction &inst) {
-  constexpr int kFlatScratchBaseHiEncoding = 231;
-  constexpr int k64BitOperand = 64;
-  for (int i = 0; i < inst.num_src_operands(); ++i) {
-    const Operand *op = inst.src_operand(i);
-    if (op != nullptr && op->size_bits() == k64BitOperand &&
-        op->encoding_value() == kFlatScratchBaseHiEncoding)
-      return true;
-  }
-  return false;
-}
-
 /// @brief True for instruction families whose A0 handling is deferred pending
 /// confirmation of the exact translated set.
 /// @details The barrier-state query and the sleep/monitor families may need
@@ -194,8 +176,10 @@ const InstructionLegalization *gfx1250_b0_to_a0_legalization(const Instruction &
   if (fp8_clamp_family && !requires_fp8_clamp_emulation(inst))
     return nullptr;
 
+  // Reading FLAT_SCRATCH_BASE through a 64-bit source position is a property of
+  // the operand rather than the mnemonic, so it is classified separately.
   if (!requires_b0_to_a0_expansion(inst.mnemonic()) &&
-      !uses_flat_scratch_base_hi_64bit_source(inst)) {
+      !gfx1250_reads_flat_scratch_base_64bit(inst)) {
     // Deferred families pass through unchanged but warn, so the not-yet-handled
     // case is visible rather than silent. See is_deferred_gfx1250_family.
     if (is_deferred_gfx1250_family(mnemonic))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.cpp
@@ -1,0 +1,278 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file semantic/gfx1250_flat_scratch_base.cpp
+/// @brief gfx1250 B0-to-A0 lowering for FLAT_SCRATCH_BASE source operands.
+
+#include "rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.h"
+
+#include "rocjitsu/analysis/liveness.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/opcodes.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/isa/operand.h"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <optional>
+#include <vector>
+
+namespace rocjitsu {
+namespace {
+
+/// @brief Scalar selectors that name the flat-scratch base.
+/// @details Both deliver the whole 64-bit base in a 64-bit source position; the
+/// low selector is the spelling the A0 profile reads. See gfx1250
+/// operand_types.h (OPR_SSRC_SRC_FLAT_SCRATCH_BASE_LO / _HI).
+constexpr int kFlatScratchBaseLo = 230;
+constexpr int kFlatScratchBaseHi = 231;
+constexpr int k64BitOperand = 64;
+
+/// @brief Highest scalar selector usable as an ordinary SGPR source operand.
+/// @details Selectors above this range name architectural values rather than
+/// the general-purpose file, so a borrowed pair must stay below it.
+constexpr uint16_t kMaxOrdinarySgpr = 105;
+
+/// @brief Width of a vector source field wide enough to name a scalar value.
+/// @details The compact vector formats give their second source an eight-bit
+/// field that indexes the vector file directly, so it can hold the selector's
+/// numeric value without naming it. Only the nine-bit form reaches the scalar
+/// encodings at all.
+constexpr uint8_t kSelectorCapableVectorFieldWidth = 9;
+
+/// @brief One source-operand field within a base instruction encoding.
+struct SourceField {
+  uint8_t word;  ///< Index of the containing 32-bit word.
+  uint8_t shift; ///< Bit position of the field within that word.
+  uint8_t width; ///< Field width in bits.
+};
+
+/// @brief Layout of the source-operand fields for one base encoding.
+struct EncodingSourceFields {
+  std::array<SourceField, 3> fields{};
+  uint8_t count = 0;
+  bool vector = false; ///< True when sources are read by the vector ALU.
+};
+
+/// @brief Identify the base encoding from its self-describing high bits.
+///
+/// @details Encoding IDs carry high opcode bits and are not contiguous per
+/// format, so they cannot be range-tested reliably. The leading bits of the
+/// first word identify the format directly and are the same constants the
+/// gfx1250 builders emit. Source-operand fields are listed in the order the
+/// decoder reports them, so field N corresponds to source operand N.
+///
+/// Formats whose sources cannot be a 64-bit scalar special value are omitted;
+/// the caller treats an unrecognized format as a rewrite it cannot encode
+/// rather than copying the instruction unchanged.
+[[nodiscard]] std::optional<EncodingSourceFields> source_fields(uint32_t word0) {
+  if ((word0 >> 23) == 381) // SOP1
+    return EncodingSourceFields{.fields = {{{0, 0, 8}}}, .count = 1, .vector = false};
+  if ((word0 >> 23) == 382) // SOPC
+    return EncodingSourceFields{.fields = {{{0, 0, 8}, {0, 8, 8}}}, .count = 2, .vector = false};
+  if ((word0 >> 30) == 2) // SOP2
+    return EncodingSourceFields{.fields = {{{0, 0, 8}, {0, 8, 8}}}, .count = 2, .vector = false};
+  if ((word0 >> 26) == 53) // VOP3
+    return EncodingSourceFields{
+        .fields = {{{1, 0, 9}, {1, 9, 9}, {1, 18, 9}}}, .count = 3, .vector = true};
+  // VOP3P shares VOP3's second-word source layout but not its leading bits, and
+  // its packed sources are 64 bits wide, so it reaches the selector the same way.
+  if ((word0 >> 24) == 204) // VOP3P
+    return EncodingSourceFields{
+        .fields = {{{1, 0, 9}, {1, 9, 9}, {1, 18, 9}}}, .count = 3, .vector = true};
+  if ((word0 >> 25) == 63) // VOP1
+    return EncodingSourceFields{.fields = {{{0, 0, 9}}}, .count = 1, .vector = true};
+  if ((word0 >> 25) == 62) // VOPC
+    return EncodingSourceFields{.fields = {{{0, 0, 9}, {0, 9, 8}}}, .count = 2, .vector = true};
+  // VOP2 is the remaining format whose leading bit is clear; the compact
+  // formats above are tested first, so reaching here identifies it.
+  if ((word0 >> 31) == 0) // VOP2
+    return EncodingSourceFields{.fields = {{{0, 0, 9}, {0, 9, 8}}}, .count = 2, .vector = true};
+  return std::nullopt;
+}
+
+/// @brief Replace one bit field in a 32-bit instruction word.
+void set_word_field(uint32_t &word, uint32_t value, uint32_t shift, uint32_t width) {
+  const uint32_t mask = ((uint32_t{1} << width) - 1) << shift;
+  word = (word & ~mask) | ((value << shift) & mask);
+}
+
+/// @brief True when source operand @p index names the base in a 64-bit position.
+///
+/// @details The value alone is not decisive. A vector field that indexes the
+/// register file directly can hold the selector's number while meaning an
+/// ordinary register, so the field has to be one that reaches the scalar
+/// encodings before the value is compared.
+///
+/// Operand::is_vgpr() cannot make that distinction: it is a construction-time
+/// capability of the operand *type*, and the ordinary vector source type is
+/// also the one that accepts scalar values, so it reports true for both.
+[[nodiscard]] bool is_flat_scratch_base_64bit_source(const Instruction &inst, int index,
+                                                     const EncodingSourceFields &layout) {
+  const Operand *op = inst.src_operand(index);
+  if (op == nullptr || op->size_bits() != k64BitOperand)
+    return false;
+  const SourceField &field = layout.fields[static_cast<size_t>(index)];
+  if (layout.vector && field.width != kSelectorCapableVectorFieldWidth)
+    return false;
+  const int value = op->encoding_value();
+  return value == kFlatScratchBaseLo || value == kFlatScratchBaseHi;
+}
+
+/// @brief Copy the instruction's words from the authoritative source image.
+///
+/// @details raw_encoding() addresses only the base-format subobject, so any
+/// literal or modifier word that follows it must come from the text image.
+[[nodiscard]] std::optional<std::vector<uint32_t>>
+instruction_words(const Instruction &inst, uint64_t offset, std::span<const uint8_t> source_text) {
+  const size_t size = static_cast<size_t>(inst.size());
+  if (size < sizeof(uint32_t) || size % sizeof(uint32_t) != 0 ||
+      offset + size > source_text.size()) {
+    return std::nullopt;
+  }
+  std::vector<uint32_t> words(size / sizeof(uint32_t));
+  std::memcpy(words.data(), source_text.data() + offset, size);
+  return words;
+}
+
+/// @brief True when a decoded source beyond the modelled fields names the base.
+///
+/// @details A decoder may report more sources than the encoding has source
+/// fields: a compact accumulate form repeats its destination as a source, and a
+/// literal occupies a position of its own. Neither can carry the selector, so
+/// their presence alone is not a reason to refuse the instruction. One that does
+/// carry it would have nowhere to be rewritten, so it is reported and refused.
+///
+/// Operands the ISA types as vector registers are skipped: every position
+/// reaching here addresses the vector file directly, so such an operand holds a
+/// register number that may coincide with the selector's value.
+[[nodiscard]] bool unmodelled_source_names_selector(const Instruction &inst, int first) {
+  for (int i = first; i < inst.num_src_operands(); ++i) {
+    const Operand *op = inst.src_operand(i);
+    if (op == nullptr || op->is_vgpr() || op->size_bits() != k64BitOperand)
+      continue;
+    const int value = op->encoding_value();
+    if (value == kFlatScratchBaseLo || value == kFlatScratchBaseHi)
+      return true;
+  }
+  return false;
+}
+
+/// @brief Conservative scan used when the encoding has no modelled layout.
+/// @details Without field widths the selector-capable test cannot be applied,
+/// so any remaining 64-bit source carrying the value is reported and the
+/// lowering then refuses the instruction rather than copying it unexamined.
+///
+/// Operands the ISA types as vector registers are excluded first. Every
+/// encoding reaching here addresses the vector file directly, so such an
+/// operand holds a register number rather than a selector; a wide vector
+/// address pair can otherwise share the selector's number and be refused.
+/// Operand::is_vgpr() is usable for exactly that reason here and not in the
+/// modelled formats, whose ordinary source type also accepts scalar values.
+[[nodiscard]] bool instruction_names_selector_in_any_64bit_source(const Instruction &inst) {
+  for (int i = 0; i < inst.num_src_operands(); ++i) {
+    const Operand *op = inst.src_operand(i);
+    if (op == nullptr || op->is_vgpr() || op->size_bits() != k64BitOperand)
+      continue;
+    const int value = op->encoding_value();
+    if (value == kFlatScratchBaseLo || value == kFlatScratchBaseHi)
+      return true;
+  }
+  return false;
+}
+
+} // namespace
+
+bool gfx1250_reads_flat_scratch_base_64bit(const Instruction &inst) {
+  const uint32_t *raw = inst.raw_encoding();
+  if (raw == nullptr)
+    return false;
+  const std::optional<EncodingSourceFields> layout = source_fields(raw[0]);
+  // An unmodelled encoding is reported so the lowering can refuse it rather
+  // than let it reach the copy path unexamined.
+  if (!layout)
+    return instruction_names_selector_in_any_64bit_source(inst);
+  const int sources = std::min(inst.num_src_operands(), static_cast<int>(layout->count));
+  for (int i = 0; i < sources; ++i) {
+    if (is_flat_scratch_base_64bit_source(inst, i, *layout))
+      return true;
+  }
+  return false;
+}
+
+ExpandResult gfx1250_lower_flat_scratch_base_source(const Instruction &inst, uint64_t offset,
+                                                    std::span<const uint8_t> source_text,
+                                                    const LivenessAnalysis &liveness,
+                                                    TranslationContext &) {
+  if (!gfx1250_reads_flat_scratch_base_64bit(inst))
+    return ExpandResult::not_handled();
+
+  auto words = instruction_words(inst, offset, source_text);
+  if (!words) {
+    return ExpandResult::failed(
+        "gfx1250 flat-scratch-base rewrite could not read the complete instruction");
+  }
+
+  const std::optional<EncodingSourceFields> layout = source_fields((*words)[0]);
+  if (!layout) {
+    return ExpandResult::failed(
+        "gfx1250 flat-scratch-base rewrite does not model this instruction encoding",
+        {"Add the source-field layout for this encoding."});
+  }
+  if (unmodelled_source_names_selector(inst, layout->count)) {
+    return ExpandResult::failed(
+        "gfx1250 flat-scratch-base rewrite cannot map operands onto encoding fields");
+  }
+
+  const int rewritable = std::min(inst.num_src_operands(), static_cast<int>(layout->count));
+  std::vector<uint32_t> prologue;
+  std::optional<uint16_t> borrowed_pair;
+  for (int i = 0; i < rewritable; ++i) {
+    if (!is_flat_scratch_base_64bit_source(inst, i, *layout))
+      continue;
+
+    const SourceField &field = layout->fields[static_cast<size_t>(i)];
+    if (field.word >= words->size()) {
+      return ExpandResult::failed(
+          "gfx1250 flat-scratch-base source field lies outside the decoded instruction");
+    }
+
+    if (!layout->vector) {
+      // A scalar read reaches the whole base through the low selector.
+      set_word_field((*words)[field.word], kFlatScratchBaseLo, field.shift, field.width);
+      continue;
+    }
+
+    // A vector read takes the base from an ordinary SGPR pair. One scalar move
+    // serves every affected source position in this instruction.
+    if (!borrowed_pair) {
+      borrowed_pair = liveness.find_free_sgpr_pair(&inst);
+      if (!borrowed_pair || *borrowed_pair + 1 > kMaxOrdinarySgpr) {
+        return ExpandResult::failed(
+            "gfx1250 flat-scratch-base rewrite could not allocate a dead SGPR pair",
+            {"Free an aligned SGPR pair around this instruction."});
+      }
+      // No descriptor growth is involved. This target's scalar file is fixed
+      // rather than sized by the descriptor, and the translator does not write
+      // the legacy granulated field for it, so raising a requirement here would
+      // change nothing. The bound that matters is that the pair stays inside the
+      // architecturally addressable range, which the check above enforces.
+      const auto move = gfx1250::build_sop1(gfx1250::kSMovB64Sop1,
+                                            {.ssrc0 = static_cast<uint8_t>(kFlatScratchBaseLo),
+                                             .sdst = static_cast<uint8_t>(*borrowed_pair)});
+      // Appended one word at a time rather than as an iterator range: the
+      // range form of insert() reduces to a bulk copy whose bounds GCC cannot
+      // relate back to a single-element std::array, and it reports the
+      // one-past-the-end pointer as an out-of-bounds access.
+      for (const uint32_t word : move)
+        prologue.push_back(word);
+    }
+    set_word_field((*words)[field.word], *borrowed_pair, field.shift, field.width);
+  }
+
+  prologue.insert(prologue.end(), words->begin(), words->end());
+  return ExpandResult::success(std::move(prologue));
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file semantic/gfx1250_flat_scratch_base.h
+/// @brief gfx1250 B0-to-A0 lowering for FLAT_SCRATCH_BASE source operands.
+
+#ifndef ROCJITSU_CODE_DBT_SEMANTIC_GFX1250_FLAT_SCRATCH_BASE_H_
+#define ROCJITSU_CODE_DBT_SEMANTIC_GFX1250_FLAT_SCRATCH_BASE_H_
+
+#include "rocjitsu/code/dbt/translation_rule.h"
+
+#include <cstdint>
+#include <span>
+
+namespace rocjitsu {
+
+class Instruction;
+class LivenessAnalysis;
+
+/// @brief True when @p inst reads FLAT_SCRATCH_BASE through a 64-bit source
+/// position that the A0 profile encodes differently.
+///
+/// @details Selector 230 (`SRC_FLAT_SCRATCH_BASE_LO`) and selector 231
+/// (`SRC_FLAT_SCRATCH_BASE_HI`) both deliver the whole 64-bit base value when
+/// they appear in a source position of that width. A0 accepts only the 230
+/// spelling for scalar reads, and takes the value through an ordinary SGPR pair
+/// for vector reads, so both cases need an operand rewrite.
+///
+/// Detection is operand-driven rather than opcode-driven: any instruction with
+/// a 64-bit source position can name these selectors.
+[[nodiscard]] bool gfx1250_reads_flat_scratch_base_64bit(const Instruction &inst);
+
+/// @brief Rewrite a 64-bit FLAT_SCRATCH_BASE source for the A0 profile.
+///
+/// @details Scalar reads keep their instruction and change the selector to 230.
+/// Vector reads cannot name the selector at all, so the base is first moved
+/// into a dead SGPR pair with a 64-bit scalar read and the source position is
+/// repointed at that pair; one pair serves every affected position in the
+/// instruction.
+///
+/// @param inst        The decoded instruction.
+/// @param offset      Byte offset of @p inst in @p source_text.
+/// @param source_text Full source .text bytes, authoritative for literal and
+///                    modifier words that follow the base encoding.
+/// @param liveness    Kernel-scoped live-before data used to find a dead pair.
+/// @param context     Kernel translation context, accepted to match the rule
+///                    signature. A borrowed pair needs no descriptor change on
+///                    this target: its scalar file is fixed rather than sized by
+///                    the descriptor, so only the addressable range constrains
+///                    the choice.
+/// @returns Success with replacement words, NotHandled when @p inst reads no
+///          such operand, or Failed when the rewrite cannot be encoded.
+[[nodiscard]] ExpandResult gfx1250_lower_flat_scratch_base_source(
+    const Instruction &inst, uint64_t offset, std::span<const uint8_t> source_text,
+    const LivenessAnalysis &liveness, TranslationContext &context);
+
+} // namespace rocjitsu
+
+#endif // ROCJITSU_CODE_DBT_SEMANTIC_GFX1250_FLAT_SCRATCH_BASE_H_

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -10741,28 +10741,6 @@ TEST(BinaryTranslatorE2E, Gfx1250CopiesA0CompatibleLowPrecisionSwmmac) {
   EXPECT_EQ(std::memcmp(text[0]->data(), swmmac.data(), 2 * sizeof(uint32_t)), 0);
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250FailsClosedOnFlatScratchBaseHi64BitSource) {
-  // A 64-bit scalar source using the special FLAT_SCRATCH_BASE_HI value (encoding
-  // 231) is not supported on this target and must fail closed rather than copy the
-  // instruction through unchanged. s_mov_b64 reads a 64-bit source.
-  constexpr uint16_t kFlatScratchBaseHi = 231;
-  constexpr auto mov64 =
-      gfx1250::build_sop1(gfx1250::kSMovB64Sop1, {.ssrc0 = kFlatScratchBaseHi, .sdst = 0});
-  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
-  auto image =
-      rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text({mov64[0], kGfx1250SEndpgm});
-  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
-  ASSERT_TRUE(source.is_valid());
-  rocjitsu::BinaryTranslator translator(
-      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
-      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
-                               rocjitsu::ProcessorRevision::Gfx1250A0));
-  auto result = translator.translate(source);
-
-  EXPECT_FALSE(result.ok());
-  EXPECT_EQ(result.elf_bytes, image) << "a fail-closed translation must leave the object unchanged";
-}
-
 TEST(BinaryTranslatorE2E, Gfx1250Allows32BitFlatScratchBaseHiSource) {
   // The same special value in a 32-bit source position is unaffected; s_mov_b32
   // must translate cleanly (identity, same-arch stepping copy).
@@ -13180,4 +13158,372 @@ TEST(KernelDescriptorTranslator, IgnoresNonAllocExecutableSectionsForEntryRange)
       image, shdrs[1].sh_offset, shdrs[1].sh_size, rocjitsu::KernelDescriptorTranslationOptions{});
   EXPECT_TRUE(translations.empty())
       << "non-loadable executable sections must not extend valid kernel entry range";
+}
+
+namespace {
+
+/// @brief Scalar selector naming the low half of the flat-scratch base.
+constexpr uint16_t kFlatScratchBaseLoSelector = 230;
+/// @brief Scalar selector naming the high half of the flat-scratch base.
+constexpr uint16_t kFlatScratchBaseHiSelector = 231;
+
+/// @brief Translate a single-instruction gfx1250 kernel with the B0-to-A0 profile.
+[[nodiscard]] std::vector<uint32_t> translate_gfx1250_b0_to_a0_words(std::vector<uint32_t> words) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  words.push_back(kGfx1250SEndpgm);
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto result = translator.translate(source);
+  EXPECT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  if (!result.ok())
+    return {};
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  EXPECT_FALSE(translated.text_sections().empty());
+  if (translated.text_sections().empty())
+    return {};
+  const auto *section = translated.text_sections()[0];
+  const auto *target_words = reinterpret_cast<const uint32_t *>(section->data());
+  return std::vector<uint32_t>(target_words, target_words + section->size() / sizeof(uint32_t));
+}
+
+} // namespace
+
+// A scalar 64-bit read reaches the whole flat-scratch base through either
+// selector. The A0 profile spells it with the low selector, so the high
+// selector is rewritten in place and the instruction keeps its size.
+TEST(BinaryTranslatorE2E, Gfx1250RewritesScalarFlatScratchBase64BitSourceForA0) {
+  const auto source =
+      gfx1250::build_sop1(gfx1250::kSMovB64Sop1,
+                          {.ssrc0 = static_cast<uint8_t>(kFlatScratchBaseHiSelector), .sdst = 10});
+  const auto out = translate_gfx1250_b0_to_a0_words({source[0]});
+  ASSERT_GE(out.size(), 2u);
+
+  EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector)
+      << "the scalar read must use the low selector on A0";
+  // Only the source selector changes: destination, opcode, and encoding stay.
+  EXPECT_EQ(out[0] & ~0xffu, source[0] & ~0xffu);
+  EXPECT_EQ(out.size(), 2u) << "a scalar rewrite must not add instructions";
+}
+
+// A 64-bit read in the first scalar source position of a two-source encoding.
+TEST(BinaryTranslatorE2E, Gfx1250RewritesScalarFlatScratchBaseInFirstSourceOfSop2ForA0) {
+  const auto source = gfx1250::build_sop2(
+      gfx1250::kSLshlB64Sop2,
+      {.ssrc0 = static_cast<uint8_t>(kFlatScratchBaseHiSelector), .ssrc1 = 130, .sdst = 12});
+  const auto out = translate_gfx1250_b0_to_a0_words({source[0]});
+  ASSERT_GE(out.size(), 2u);
+
+  EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
+  EXPECT_EQ((out[0] >> 8) & 0xffu, 130u) << "the 32-bit shift source is unaffected";
+  EXPECT_EQ(out.size(), 2u);
+}
+
+// The second scalar source position is a separate encoding field, so it needs
+// its own coverage: a rewrite that only ever touched the first would pass every
+// test above.
+TEST(BinaryTranslatorE2E, Gfx1250RewritesScalarFlatScratchBaseInSecondSourceOfSop2ForA0) {
+  constexpr uint8_t kOrdinaryPair = 20;
+  const auto source = gfx1250::build_sop2(
+      gfx1250::kSAndB64Sop2, {.ssrc0 = kOrdinaryPair,
+                              .ssrc1 = static_cast<uint8_t>(kFlatScratchBaseHiSelector),
+                              .sdst = 12});
+  const auto out = translate_gfx1250_b0_to_a0_words({source[0]});
+  ASSERT_GE(out.size(), 2u);
+
+  EXPECT_EQ(out[0] & 0xffu, kOrdinaryPair) << "the first source is untouched";
+  EXPECT_EQ((out[0] >> 8) & 0xffu, kFlatScratchBaseLoSelector)
+      << "the second source must use the low selector on A0";
+  EXPECT_EQ(out.size(), 2u) << "a scalar rewrite must not add instructions";
+}
+
+// The two-source scalar compare is the remaining modelled scalar encoding, and
+// each of its fields is separate from the ones covered above.
+TEST(BinaryTranslatorE2E, Gfx1250RewritesScalarFlatScratchBaseInBothSourcesOfSopcForA0) {
+  constexpr uint8_t kOrdinaryPair = 20;
+  struct SopcCase {
+    const char *name;
+    uint8_t ssrc0;
+    uint8_t ssrc1;
+    uint32_t expected_ssrc0;
+    uint32_t expected_ssrc1;
+  };
+  const SopcCase cases[] = {
+      {"first source", static_cast<uint8_t>(kFlatScratchBaseHiSelector), kOrdinaryPair,
+       kFlatScratchBaseLoSelector, kOrdinaryPair},
+      {"second source", kOrdinaryPair, static_cast<uint8_t>(kFlatScratchBaseHiSelector),
+       kOrdinaryPair, kFlatScratchBaseLoSelector},
+      {"both sources", static_cast<uint8_t>(kFlatScratchBaseHiSelector),
+       static_cast<uint8_t>(kFlatScratchBaseHiSelector), kFlatScratchBaseLoSelector,
+       kFlatScratchBaseLoSelector},
+  };
+  for (const SopcCase &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    const auto source = gfx1250::build_sopc(gfx1250::kSCmpEqU64Sopc,
+                                            {.ssrc0 = test_case.ssrc0, .ssrc1 = test_case.ssrc1});
+    const auto out = translate_gfx1250_b0_to_a0_words({source[0]});
+    ASSERT_GE(out.size(), 2u);
+
+    EXPECT_EQ(out[0] & 0xffu, test_case.expected_ssrc0);
+    EXPECT_EQ((out[0] >> 8) & 0xffu, test_case.expected_ssrc1);
+    EXPECT_EQ(out.size(), 2u) << "a scalar rewrite must not add instructions";
+  }
+}
+
+// The single-source vector encoding is the last modelled layout without
+// coverage. Its source is nine bits wide, so it reaches the selector and takes
+// the staged pair like the other vector forms.
+TEST(BinaryTranslatorE2E, Gfx1250MovesFlatScratchBaseInSingleSourceVectorFormToSgprPairForA0) {
+  const auto source =
+      gfx1250::build_vop1(gfx1250::kVMovB64Vop1, {.src0 = kFlatScratchBaseHiSelector, .vdst = 4});
+  const auto out = translate_gfx1250_b0_to_a0_words({source[0]});
+  ASSERT_GE(out.size(), 3u) << "the rewrite prepends one scalar move";
+
+  ASSERT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+  EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
+  const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+  EXPECT_EQ(pair_base % 2u, 0u) << "a 64-bit scalar operand must be even-aligned";
+  EXPECT_EQ(out[1] & 0x1ffu, pair_base) << "the vector source must name the borrowed pair";
+}
+
+// Two affected positions in one instruction share a single borrowed pair. This
+// is the only direct check that the prologue is emitted once rather than once
+// per rewritten source.
+TEST(BinaryTranslatorE2E, Gfx1250SharesOneBorrowedPairAcrossTwoVectorSourcesForA0) {
+  const auto source = gfx1250::build_vop3(
+      gfx1250::kVAddNcU64Vop3,
+      {.vdst = 0, .src0 = kFlatScratchBaseHiSelector, .src1 = kFlatScratchBaseHiSelector});
+  const auto out = translate_gfx1250_b0_to_a0_words({source[0], source[1]});
+  ASSERT_GE(out.size(), 4u);
+
+  ASSERT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+  EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
+  const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+
+  EXPECT_EQ(out[2] & 0x1ffu, pair_base) << "src0 must name the borrowed pair";
+  EXPECT_EQ((out[2] >> 9) & 0x1ffu, pair_base) << "src1 must name the same pair";
+  EXPECT_EQ(out.size(), 4u) << "one move serves both positions, so only one is emitted";
+}
+
+// The third source is the last modelled field and the only one no other case
+// reaches, so a rewrite that walked just the first two would pass every test
+// above.
+TEST(BinaryTranslatorE2E, Gfx1250MovesFlatScratchBaseInThirdVectorSourceToSgprPairForA0) {
+  const auto source = gfx1250::build_vop3(
+      gfx1250::kVFmaF64Vop3,
+      {.vdst = 0, .src0 = 256 + 2, .src1 = 256 + 4, .src2 = kFlatScratchBaseHiSelector});
+  const auto out = translate_gfx1250_b0_to_a0_words({source[0], source[1]});
+  ASSERT_GE(out.size(), 4u) << "the rewrite prepends one scalar move";
+
+  ASSERT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+  EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
+  const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+  EXPECT_EQ(pair_base % 2u, 0u) << "a 64-bit scalar operand must be even-aligned";
+
+  EXPECT_EQ(out[2] & 0x1ffu, 256u + 2u) << "src0 is unchanged";
+  EXPECT_EQ((out[2] >> 9) & 0x1ffu, 256u + 4u) << "src1 is unchanged";
+  EXPECT_EQ((out[2] >> 18) & 0x1ffu, pair_base) << "src2 must name the borrowed pair";
+}
+
+// VOP3P carries packed 64-bit sources through nine-bit fields, so it reaches
+// the selector exactly as VOP3 does. Leaving it unmodelled would send it to the
+// conservative scan, which skips vector-typed operands and would copy the
+// instruction through unchanged.
+TEST(BinaryTranslatorE2E, Gfx1250MovesVop3pFlatScratchBaseSourceToSgprPairForA0) {
+  const auto source = gfx1250::build_vop3p(
+      gfx1250::kVPkMulF32Vop3p, {.vdst = 0, .src0 = kFlatScratchBaseHiSelector, .src1 = 258});
+  const auto out = translate_gfx1250_b0_to_a0_words({source[0], source[1]});
+  ASSERT_GE(out.size(), 4u) << "the rewrite prepends one scalar move";
+
+  ASSERT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+  EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
+  const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+  EXPECT_EQ(pair_base % 2u, 0u) << "a 64-bit scalar operand must be even-aligned";
+
+  EXPECT_EQ(out[1], source[0]) << "the first word is unchanged";
+  EXPECT_EQ(out[2] & 0x1ffu, pair_base) << "src0 must name the borrowed pair";
+  EXPECT_EQ((out[2] >> 9) & 0x1ffu, 258u) << "src1 is unchanged";
+}
+
+// A decoder may report more sources than the encoding has source fields: an
+// accumulate form repeats its destination and a literal takes a position of its
+// own. Neither can carry the selector, so their presence must not by itself
+// refuse the rewrite.
+TEST(BinaryTranslatorE2E, Gfx1250RewritesCompactFormsWithExtraDecodedOperandsForA0) {
+  struct ExtraOperandCase {
+    const char *name;
+    std::vector<uint32_t> words;
+  };
+  const std::vector<ExtraOperandCase> cases = {
+      {"destination alias",
+       {gfx1250::build_vop2(gfx1250::kVFmacF64Vop2,
+                            {.src0 = kFlatScratchBaseHiSelector, .vsrc1 = 2})[0]}},
+  };
+  for (const ExtraOperandCase &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    const auto out = translate_gfx1250_b0_to_a0_words(test_case.words);
+    ASSERT_GE(out.size(), 3u) << "the rewrite prepends one scalar move";
+
+    ASSERT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+    EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
+    const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+    EXPECT_EQ(out[1] & 0x1ffu, pair_base) << "src0 must name the borrowed pair";
+    EXPECT_EQ((out[1] >> 9) & 0xffu, 2u) << "the VGPR source is unchanged";
+  }
+}
+
+// With every ordinary scalar register live there is no pair to borrow. The
+// rewrite must fail rather than clobber one, and the object must come back
+// unchanged.
+TEST(BinaryTranslatorE2E, Gfx1250FailsClosedWhenNoDeadSgprPairIsAvailableForA0) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const auto vector_read = gfx1250::build_vop3(
+      gfx1250::kVAddNcU64Vop3, {.vdst = 0, .src0 = kFlatScratchBaseHiSelector, .src1 = 256 + 2});
+  std::vector<uint32_t> words = {vector_read[0], vector_read[1]};
+  // Reading every ordinary scalar register after the rewrite keeps them all
+  // live across it, so the allocator has nothing to take.
+  for (uint16_t base = 0; base + 1 <= 101; base += 2) {
+    words.push_back(
+        gfx1250::build_sop2(gfx1250::kSAndB32Sop2, {.ssrc0 = static_cast<uint8_t>(base),
+                                                    .ssrc1 = static_cast<uint8_t>(base + 1),
+                                                    .sdst = 102})[0]);
+  }
+  words.push_back(kGfx1250SEndpgm);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_FALSE(result.dispatchable());
+  EXPECT_EQ(result.elf_bytes, image) << "fail-closed must leave the object unchanged";
+  EXPECT_TRUE(rocjitsu::has_error_containing(
+      result, rocjitsu::DiagnosticKind::ExpandFailed,
+      "flat-scratch-base rewrite could not allocate a dead SGPR pair"));
+}
+
+// An unmodelled encoding carrying a wide vector register whose number equals
+// the selector must still be copied; only genuine scalar reads are refused.
+TEST(BinaryTranslatorE2E, Gfx1250LeavesWideVgprMatchingSelectorNumberUnchangedForA0) {
+  constexpr uint8_t kVgprMatchingSelector = 231;
+  // A NULL scalar base makes the address a 64-bit vector pair, which is a
+  // source operand of exactly the affected width.
+  constexpr uint8_t kNullScalarBase = 124;
+  const auto load =
+      gfx1250::build_vglobal(gfx1250::kGlobalLoadB64Vglobal,
+                             {.saddr = kNullScalarBase, .vdst = 0, .vaddr = kVgprMatchingSelector});
+  const auto out = translate_gfx1250_b0_to_a0_words({load[0], load[1], load[2]});
+  ASSERT_GE(out.size(), 4u);
+  EXPECT_EQ(out[0], load[0]);
+  EXPECT_EQ(out[1], load[1]);
+  EXPECT_EQ(out[2], load[2]);
+}
+
+// With the low registers live the rewrite must borrow from above them. The
+// scalar file is fixed on this target rather than descriptor-allocated, so the
+// requirement is that the borrowed pair stays inside the architectural file.
+TEST(BinaryTranslatorE2E, Gfx1250BorrowsFlatScratchBasePairAboveLiveRegistersForA0) {
+  constexpr uint16_t kHighestOrdinarySgpr = 101;
+  const auto vector_read = gfx1250::build_vop3(
+      gfx1250::kVAddNcU64Vop3, {.vdst = 0, .src0 = kFlatScratchBaseHiSelector, .src1 = 256 + 2});
+  std::vector<uint32_t> words = {vector_read[0], vector_read[1]};
+  // Reading s0..s7 after the rewrite keeps them live across it, so the
+  // allocator cannot choose any of them.
+  for (uint8_t base = 0; base < 8; base += 2) {
+    words.push_back(gfx1250::build_sop2(
+        gfx1250::kSAndB32Sop2,
+        {.ssrc0 = base, .ssrc1 = static_cast<uint8_t>(base + 1), .sdst = 20})[0]);
+  }
+  const auto out = translate_gfx1250_b0_to_a0_words(words);
+  ASSERT_GE(out.size(), 3u);
+
+  ASSERT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+  EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
+  const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+  EXPECT_GE(pair_base, 8u) << "s0..s7 are live, so the pair must sit above them";
+  EXPECT_EQ(pair_base % 2u, 0u) << "a 64-bit scalar operand must be even-aligned";
+  EXPECT_LE(pair_base + 1u, kHighestOrdinarySgpr)
+      << "the borrowed pair must stay inside the ordinary scalar file";
+  EXPECT_EQ(out[2] & 0x1ffu, pair_base) << "the vector read must name the borrowed pair";
+}
+
+// The compact vector formats reach the same rewrite as their VOP3 forms.
+TEST(BinaryTranslatorE2E, Gfx1250MovesCompactVectorFlatScratchBaseSourceToSgprPairForA0) {
+  struct CompactCase {
+    const char *name;
+    std::vector<uint32_t> words;
+  };
+  const std::vector<CompactCase> cases = {
+      {"vop2",
+       {gfx1250::build_vop2(gfx1250::kVAddNcU64Vop2,
+                            {.src0 = kFlatScratchBaseHiSelector, .vsrc1 = 2})[0]}},
+      {"vopc",
+       {gfx1250::build_vopc(gfx1250::kVCmpEqU64Vopc,
+                            {.src0 = kFlatScratchBaseHiSelector, .vsrc1 = 2})[0]}},
+  };
+  for (const CompactCase &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    const auto out = translate_gfx1250_b0_to_a0_words(test_case.words);
+    ASSERT_GE(out.size(), 3u) << "the rewrite prepends one scalar move";
+
+    EXPECT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+    EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
+    const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+    EXPECT_EQ(pair_base % 2u, 0u);
+
+    EXPECT_EQ(out[1] & 0x1ffu, pair_base) << "src0 must name the borrowed pair";
+    EXPECT_EQ((out[1] >> 9) & 0xffu, 2u) << "the VGPR source is unchanged";
+  }
+}
+
+// The compact formats decode their second source as a plain VGPR index, so a
+// VGPR whose number matches the selector must not be mistaken for it.
+TEST(BinaryTranslatorE2E, Gfx1250LeavesCompactVgprMatchingSelectorNumberUnchangedForA0) {
+  constexpr uint8_t kVgprMatchingSelector = 231;
+  const std::vector<uint32_t> sources = {
+      gfx1250::build_vop2(gfx1250::kVAddNcU64Vop2,
+                          {.src0 = 256 + 4, .vsrc1 = kVgprMatchingSelector})[0],
+      gfx1250::build_vopc(gfx1250::kVCmpEqU64Vopc,
+                          {.src0 = 256 + 4, .vsrc1 = kVgprMatchingSelector})[0],
+  };
+  for (const uint32_t source_word : sources) {
+    SCOPED_TRACE(source_word);
+    const auto out = translate_gfx1250_b0_to_a0_words({source_word});
+    ASSERT_GE(out.size(), 2u);
+    EXPECT_EQ(out[0], source_word) << "an ordinary VGPR must be copied verbatim";
+  }
+}
+
+// A vector 64-bit read cannot name the selector on A0, so the base is moved
+// into a dead SGPR pair and the source position is repointed at that pair.
+TEST(BinaryTranslatorE2E, Gfx1250MovesVectorFlatScratchBase64BitSourceToSgprPairForA0) {
+  const auto source = gfx1250::build_vop3(
+      gfx1250::kVAddNcU64Vop3, {.vdst = 0, .src0 = kFlatScratchBaseHiSelector, .src1 = 256 + 2});
+  const auto out = translate_gfx1250_b0_to_a0_words({source[0], source[1]});
+  ASSERT_GE(out.size(), 4u) << "the rewrite prepends one scalar move";
+
+  // The prologue is a 64-bit scalar read of the base through the low selector.
+  const auto expected_prologue_op = static_cast<uint32_t>(gfx1250::kSMovB64Sop1);
+  EXPECT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+  EXPECT_EQ((out[0] >> 8) & 0xffu, expected_prologue_op);
+  EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
+
+  const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+  EXPECT_EQ(pair_base % 2u, 0u) << "a 64-bit scalar operand must be even-aligned";
+  EXPECT_LE(pair_base + 1u, 105u) << "the borrowed pair must be an ordinary SGPR pair";
+
+  // The vector instruction now reads that pair; its other operands are intact.
+  EXPECT_EQ(out[1] & 0xffffu, source[0] & 0xffffu) << "vdst and modifiers are unchanged";
+  EXPECT_EQ(out[2] & 0x1ffu, pair_base) << "src0 must name the borrowed pair";
+  EXPECT_EQ((out[2] >> 9) & 0x1ffu, 256u + 2u) << "src1 is unchanged";
 }


### PR DESCRIPTION
## Motivation

Both scalar selectors deliver the whole 64-bit base when they appear in a 64-bit source position, but A0 reads it only through the low selector, and its vector ALU takes the value from an ordinary SGPR pair instead. B0 input may use either spelling in either position, so both need a rewrite.

## Technical Details

Scalar positions change the selector in place. Vector positions gain one s_mov_b64 that stages the base into a dead SGPR pair, shared across every affected position in the instruction.

The rewrite is selected by operand rather than by mnemonic, which neither the semantic rule table nor Action can express, so it runs after the opcode-keyed lookup misses. Encodings are identified by their leading bits: encoding IDs embed high opcode bits and are not contiguous per format, so they cannot be range-tested. An unrecognized encoding carrying such an operand fails closed rather than being copied.

## Issue Tracking


## Test Plan

Run all CI tests

## Test Result

All CI tests pass (minus one pre-existing failure)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
