### PR TITLE
fix(rccl): Fixing MI350X 2-node allreduce regression

### DIFF
--- a/projects/rccl/tuner/rccl_tuner_gfx950.csv
+++ b/projects/rccl/tuner/rccl_tuner_gfx950.csv
@@ -2,3 +2,6 @@ allreduce,0,16383,tree,ll,1,1,8,-1,-1
 allreduce,16384,524287,ring,ll,-1,1,8,-1,-1
 allreduce,524288,1048575,ring,ll,32,1,8,-1,-1
 allreduce,1048576,2097000,ring,ll,56,1,8,-1,-1
+allreduce,33554432,54525951,ring,ll128,64,2,16,-1,-1
+allreduce,54525952,117440511,tree,simple,64,2,16,-1,-1
+allreduce,117440512,234881024,ring,simple,48,2,16,-1,-1


### PR DESCRIPTION
## Motivation

After switching back to 64 CUs for multi-node (from 48 CUs) there is a perf regression observed at 128MB.

## Technical Details

Performance sweep for different algo (ring/tree), proto (LL, LL128, Simple) and CUs = 48/64 shows room for performance improvement through tuning for 32MB to 224MB range.
Before:
```
size	type	redop	busbw	algo	proto	nchannels
(B)	(us)	(GB/s)	(GB/s)			
33554432	float	sum	127.38	TREE	LL128	64
67108864	float	sum	155.58	RING	LL128	64
134217728	float	sum	229.74	RING	SIMPLE	64
```
After:
```
size	type	redop	busbw	algo	proto	nchannels
(B)	(us)	(GB/s)	(GB/s)			
33554432	float	sum	156.35	RING	LL128	64
67108864	float	sum	190.33	TREE	SIMPLE	64
134217728	float	sum	249.40	RING	SIMPLE	48
```
The performance improvement of up to 1.23x is observed with this tuning.

## Issue Tracking

AICOMRCCL-1642

## Test Plan

Tested and verified on 2-node mi350 cluster.

## Test Result

up to 1.23x gain for 2-node AR in the 32MB to 224MB message range.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
