### PR TITLE
fix(rccl): Fixing MI350X 2-node allreduce regression

### DIFF
--- a/projects/rccl/test/DdaIpcEligibilityTests.cpp
+++ b/projects/rccl/test/DdaIpcEligibilityTests.cpp
@@ -151,7 +151,7 @@ TEST_F(DdaIpcEligibilityTest, AllToAll_StagingBytesAtThresholdFitsScratch)
 TEST_F(DdaIpcEligibilityTest, AllToAll_StagingBytesOneCountOverThresholdStillEligible)
 {
     // Eligibility is independent of the 4 MiB dispatch cap enforced in collectives.cc.
-    const size_t count = kAlltoAllFloat32CountAt4MbThreshold + 1;
+    const size_t count = kAlltoAllFloat32CountAt4MbThreshold + 4;
     const size_t stagingBytes = testAlltoAllDdaIpcStagingBytes(
         count, mockComm_.comm.nRanks, sizeof(float));
     EXPECT_GT(stagingBytes, kDdaAlltoAllGfx950ThresholdBytes);

--- a/projects/rccl/test/common/DdaAlltoAllTestHelpers.hpp
+++ b/projects/rccl/test/common/DdaAlltoAllTestHelpers.hpp
@@ -65,14 +65,16 @@ inline size_t testAlltoAllDdaIpcStagingBytes(size_t count, int nRanks, size_t ty
 struct DdaAlltoAllMockComm
 {
     ncclComm comm{};
+    char archNameBuf[64]{};
 
     DdaAlltoAllMockComm() { reset("gfx950:sramecc+:xnack-"); }
 
     void reset(const char* archName)
     {
         std::memset(&comm, 0, sizeof(comm));
-        std::strncpy(comm.archName, archName, sizeof(comm.archName) - 1);
-        comm.archName[sizeof(comm.archName) - 1] = '\0';
+        std::strncpy(archNameBuf, archName, sizeof(archNameBuf) - 1);
+        archNameBuf[sizeof(archNameBuf) - 1] = '\0';
+        comm.archName = archNameBuf;
         comm.nNodes = 1;
         comm.nRanks = nccl_dda_detail::kDdaNranks;
         comm.symmetricSupport = 0;

--- a/projects/rccl/tuner/rccl_tuner_gfx950.csv
+++ b/projects/rccl/tuner/rccl_tuner_gfx950.csv
@@ -2,3 +2,6 @@ allreduce,0,16383,tree,ll,1,1,8,-1,-1
 allreduce,16384,524287,ring,ll,-1,1,8,-1,-1
 allreduce,524288,1048575,ring,ll,32,1,8,-1,-1
 allreduce,1048576,2097000,ring,ll,56,1,8,-1,-1
+allreduce,33554432,54525951,ring,ll128,64,2,16,-1,-1
+allreduce,54525952,117440511,tree,simple,64,2,16,-1,-1
+allreduce,117440512,234881024,ring,simple,48,2,16,-1,-1


### PR DESCRIPTION
## Motivation

After switching back to 64 CUs for multi-node (from 48 CUs) there is a perf regression observed at 128MB.

## Technical Details

Performance sweep for different algo (ring/tree), proto (LL, LL128, Simple) and CUs = 48/64 shows room for performance improvement through tuning for 32MB to 224MB range.
Before:

```
size	type	redop	busbw	algo	proto	nchannels
(B)	(us)	(GB/s)	(GB/s)			
33554432	float	sum	127.38	TREE	LL128	64
67108864	float	sum	155.58	RING	LL128	64
134217728	float	sum	229.74	RING	SIMPLE	64
```
After:

```
size	type	redop	busbw	algo	proto	nchannels
(B)	(us)	(GB/s)	(GB/s)			
33554432	float	sum	156.35	RING	LL128	64
67108864	float	sum	190.33	TREE	SIMPLE	64
134217728	float	sum	249.40	RING	SIMPLE	48
```
The performance improvement of up to 1.23x is observed with this tuning.

## Issue Tracking

AICOMRCCL-1642

## Test Plan

Tested and verified on 2-node mi350 cluster.

## Test Result

up to 1.23x gain for 2-node AR in the 32MB to 224MB message range.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
