### PR TITLE
ROCM-26081 : [rocclr] flush image read to system scope for pinned host dst

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -1907,6 +1907,10 @@ bool KernelBlitManager::readImage(device::Memory& srcMemory, void* dstHost,
     // Get device memory for this virtual device
     Memory* dstMemory = dev().getRocMemory(amdMemory);
 
+    // Make the copy system-scoped so the pinned host buffer is CPU-visible
+    // when the blocking read returns, like readBuffer does.
+    gpu().addSystemScope();
+
     // Copy image to buffer
     result = copyImageToBuffer(srcMemory, *dstMemory, origin, dstOrigin, size, entire, rowPitch,
                                slicePitch, copyMetadata);


### PR DESCRIPTION
Kernel dispatches use agent-scope release fences by default (AMD_OPT_FLUSH=1). 
A blocking clEnqueueReadImage into a user host pointer pins that buffer and fills it with a blit kernel (`copyImageToBuffer`), but the agent-scope fence only flushes to device scope. So the read can return before the data is actually visible to the CPU.
This breaks the pattern of reading an image, modifying the buffer on the CPU, and writing it back (with no flush in between): the write races with the still-draining read and the image ends up keeping its old contents.
It shows up as `ocltst OCLCreateImage` failures.

## Fix
Promote the read's copy dispatch to system scope in `readImage`, matching what `readBuffer` already does.

## Test Plan
- Read/modify/write repros now return correct data at all sizes (previously wrong for <=256x256).
- `ocltst OCLCreateImage` passes 5/5 (was 3/5).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking
JIRA ID
ROCM-26081

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
