### PR TITLE
[rocjitsu] Scope gfx1250 A0 barrier-signal handling to one operand

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -30,7 +30,6 @@ namespace {
 /// NOT-YET-SUPPORTED (classified as needing an expansion but with no semantic
 /// expander, so translating a kernel that uses them fails closed rather than
 /// passing the instruction through unchanged):
-///   * s_barrier_signal_isfirst,
 ///   * v_cvt_pk_fp8_f32, v_cvt_sr_fp8_f32 (only when CLAMP selects the B0-only
 ///     mode; the ordinary form stays on the copy path),
 ///   * v_wmma_scale / v_wmma_scale16 forms without an implemented rule,
@@ -42,8 +41,7 @@ namespace {
 /// warning rather than fail-closed (see is_deferred_gfx1250_family).
 /// Classifying the fail-closed cases keeps the failure explicit and located; add
 /// the semantic rule (and update this note) once each expansion is implemented.
-inline constexpr std::array<std::string_view, 18> kExactB0ToA0TranslationMnemonics = {
-    "s_barrier_signal_isfirst",
+inline constexpr std::array<std::string_view, 17> kExactB0ToA0TranslationMnemonics = {
     "ds_load_2addr_b32",
     "ds_load_2addr_b64",
     "ds_load_2addr_stride64_b32",

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -14,6 +14,7 @@
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/opcodes.h"
 #include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/isa/operand.h"
 
 #include <algorithm>
 #include <array>
@@ -392,6 +393,43 @@ ExpandResult expand_gfx1250_s_clause(const Instruction &inst, uint32_t, uint64_t
 
   const auto nop = gfx1250::build_sopp(gfx1250::kSNopSopp, {.simm16 = 0});
   return ExpandResult::success(std::vector<uint32_t>(nop.begin(), nop.end()));
+}
+
+/// @brief Decline the one barrier id this profile excludes.
+///
+/// @details Barrier id -3 is the only one this instruction may not name; every
+/// other id stays on the copy path.
+///
+/// The decision reads the raw SSRC0 field rather than the decoded operand
+/// value. This operand takes an inline constant or M0 and nothing else, so the
+/// excluded id has exactly one spelling the encoding can state: inline selector
+/// 195. Comparing decoded values instead would not separate that spelling from
+/// a register-supplied id.
+///
+/// The M0 form (selector 125) is copied through, and that is not a hole in the
+/// static check: it takes the id from a zero-extended low field, so it cannot
+/// produce a negative id and therefore cannot name the excluded one at run
+/// time. Were a register-held id able to reach that value, copying would not be
+/// fail-closed and this rule would have to refuse the dynamic form instead.
+ExpandResult expand_gfx1250_barrier_signal_isfirst(const Instruction &inst, uint32_t,
+                                                   uint64_t offset,
+                                                   std::span<const uint8_t> source_text,
+                                                   const LivenessAnalysis &, TranslationContext &,
+                                                   const LaneLayout *, const LaneLayout *) {
+  constexpr uint32_t kExcludedBarrierIdInline = 195;
+
+  const size_t size = static_cast<size_t>(inst.size());
+  if (size < sizeof(uint32_t) || offset + size > source_text.size())
+    return ExpandResult::failed("gfx1250 barrier-signal rule received an unsupported instruction");
+
+  uint32_t word0 = 0;
+  std::memcpy(&word0, source_text.data() + offset, sizeof(word0));
+  if ((word0 & 0xffu) != kExcludedBarrierIdInline)
+    return ExpandResult::not_handled();
+
+  return ExpandResult::failed(
+      "gfx1250 s_barrier_signal_isfirst cannot name barrier id -3 (inline selector 195)",
+      {"Use a different barrier id, or signal it without the first-signal form."});
 }
 
 struct Gfx1250Ds2Shape {
@@ -1604,7 +1642,9 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
 // The semantic translator binary-searches this table, so entries must stay
 // sorted by the full encoding ID and then opcode. VDS encoding IDs include the
 // high opcode bits, hence the four consecutive kVdsOpHi* groups below.
-inline constexpr std::array<TranslationRule, 38> kGfx1250B0ToA0ExpandRules = {{
+inline constexpr std::array<TranslationRule, 39> kGfx1250B0ToA0ExpandRules = {{
+    {gfx1250::encoding::kSop1, gfx1250::kSBarrierSignalIsfirstSop1, RuleAction::Expand, 0, 0,
+     nullptr, expand_gfx1250_barrier_signal_isfirst, nullptr, nullptr, false},
     {gfx1250::encoding::kSopp, gfx1250::kSClauseSopp, RuleAction::Expand, 0, 0, nullptr,
      expand_gfx1250_s_clause, nullptr, nullptr, false},
     {gfx1250::encoding::kVop3p, gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p, RuleAction::Expand, 0, 0,

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -9918,6 +9918,7 @@ TEST(SemanticTranslator, Gfx1250ClassifiesLivenessFreeExpandRules) {
   }
 
   const std::vector<uint32_t> expected = {
+      (static_cast<uint32_t>(gfx1250::encoding::kSop1) << 16) | gfx1250::kSBarrierSignalIsfirstSop1,
       (static_cast<uint32_t>(gfx1250::encoding::kSopp) << 16) | gfx1250::kSClauseSopp,
       (static_cast<uint32_t>(gfx1250::encoding::kVop3p) << 16) |
           gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p,
@@ -9991,7 +9992,7 @@ TEST(BinaryTranslatorE2E, Gfx1250UsesNeutralScaledK128Fp8Bf8Wmma) {
   };
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
 
-  EXPECT_EQ(rocjitsu::semantic_expand_rules_gfx1250_b0_to_a0().size(), 38u);
+  EXPECT_EQ(rocjitsu::semantic_expand_rules_gfx1250_b0_to_a0().size(), 39u);
   for (const WmmaCase &test_case : cases) {
     SCOPED_TRACE(test_case.name);
     auto source_wmma = gfx1250::build_vop3p(test_case.source_opcode, fields);
@@ -10597,12 +10598,11 @@ TEST(BinaryTranslatorE2E, Gfx1250MaterializesDsAddtidAddressForA0) {
   EXPECT_EQ(((*v_bfe)->raw_encoding()[1] >> 18) & 0x1ffu, static_cast<uint16_t>(kInline + 20));
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250FailsClosedOnUnsupportedBarrierSignalIsfirst) {
-  // s_barrier_signal_isfirst is classified as needing an expansion but has no rule
-  // yet, so the translation must fail closed (ExpandMissing) rather than pass the
-  // instruction through. This pins the NOT-YET-SUPPORTED contract for the
-  // classifier-only mnemonics.
-  constexpr auto barrier = gfx1250::build_sop1(gfx1250::kSBarrierSignalIsfirstSop1, {.ssrc0 = 0});
+TEST(BinaryTranslatorE2E, Gfx1250FailsClosedOnExcludedBarrierSignalIsfirst) {
+  // Inline constants encode -1 at 193, so the excluded id is 195.
+  constexpr uint8_t kExcludedBarrierIdInline = 195;
+  constexpr auto barrier =
+      gfx1250::build_sop1(gfx1250::kSBarrierSignalIsfirstSop1, {.ssrc0 = kExcludedBarrierIdInline});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image =
       rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text({barrier[0], kGfx1250SEndpgm});
@@ -10616,11 +10616,49 @@ TEST(BinaryTranslatorE2E, Gfx1250FailsClosedOnUnsupportedBarrierSignalIsfirst) {
 
   EXPECT_FALSE(result.ok());
   EXPECT_EQ(result.elf_bytes, image) << "a fail-closed translation must leave the object unchanged";
-  const auto diagnostic = std::ranges::find_if(result.diagnostics, [](const auto &d) {
-    return d.kind == rocjitsu::DiagnosticKind::ExpandMissing;
-  });
-  ASSERT_NE(diagnostic, result.diagnostics.end());
-  EXPECT_EQ(diagnostic->severity, rocjitsu::DiagnosticSeverity::Error);
+  EXPECT_TRUE(rocjitsu::has_error_containing(
+      result, rocjitsu::DiagnosticKind::ExpandFailed,
+      "s_barrier_signal_isfirst cannot name barrier id -3 (inline selector 195)"));
+}
+
+// Every other barrier id must survive translation unchanged. This operand
+// admits inline constants and M0; the neighbouring inline ids and an M0 source
+// therefore cover the supported spellings.
+//
+// M0 is the one case here that copies a run-time value. It is copied rather
+// than refused because that form draws the id from a zero-extended low field
+// and so cannot reach the excluded negative id. If that ever stopped holding,
+// this case would belong in the fail-closed test above instead.
+TEST(BinaryTranslatorE2E, Gfx1250CopiesRemainingBarrierSignalIsfirstFormsForA0) {
+  constexpr uint8_t kInlineMinusOne = 193;
+  constexpr uint8_t kInlineMinusTwo = 194;
+  constexpr uint8_t kInlineMinusFour = 196;
+  constexpr uint8_t kInlinePlusOne = 129;
+  constexpr uint8_t kM0Selector = 125;
+  for (const uint8_t barrier_id :
+       {kInlineMinusOne, kInlineMinusTwo, kInlineMinusFour, kInlinePlusOne, kM0Selector}) {
+    const auto barrier =
+        gfx1250::build_sop1(gfx1250::kSBarrierSignalIsfirstSop1, {.ssrc0 = barrier_id});
+    constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+    auto image =
+        rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text({barrier[0], kGfx1250SEndpgm});
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    auto result = translator.translate(source);
+    ASSERT_TRUE(result.ok()) << "barrier id " << static_cast<int>(barrier_id) << ": "
+                             << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    ASSERT_FALSE(translated.text_sections().empty());
+    const auto *target_words =
+        reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+    EXPECT_EQ(target_words[0], barrier[0])
+        << "barrier id " << static_cast<int>(barrier_id) << " must be copied verbatim";
+  }
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250WrapsBareF8f6f4WmmaInNeutralScaleForA0) {


### PR DESCRIPTION
The classifier matched the whole mnemonic, so every form was refused. Only one barrier id is affected, so the check moves to the operand and the remaining forms return to the copy path.

The id is decidable only when an inline constant supplies it. An M0 source takes it from a zero-extended low field and cannot reach the affected value; an id held in an SGPR is a runtime value this pass does not evaluate.