### PR TITLE
[rocjitsu] Guard the unbounded sleep form on gfx1250 A0

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -32,9 +32,14 @@ namespace {
 /// handled separately by family-level translation rules.
 ///
 /// Separately, a 64-bit source reading FLAT_SCRATCH_BASE is classified via
-/// operand inspection (see gfx1250_reads_flat_scratch_base_64bit), and the
-/// barrier-state query and s_monitor_sleep are DEFERRED with a pass-through
-/// report rather than fail-closed (see gfx1250_b0_to_a0_is_deferred_family).
+/// operand inspection (see gfx1250_reads_flat_scratch_base_64bit). The unbounded
+/// sleep is decided entirely by its semantic rule, which is attempted before raw
+/// encoding translation and returns not-handled for the forms that need nothing,
+/// leaving them on the copy path. This classification is looked up first, but its
+/// action applies only once the rule declines, so a predicate here would turn
+/// every declined sleep into a refusal. The barrier-state query is DEFERRED with
+/// a pass-through report rather than fail-closed (see
+/// gfx1250_b0_to_a0_is_deferred_family).
 inline constexpr std::array<std::string_view, 17> kExactB0ToA0TranslationMnemonics = {
     "ds_load_2addr_b32",
     "ds_load_2addr_b64",
@@ -230,13 +235,14 @@ void gfx1250_b0_to_a0_append_wmma_completion_wait_if_needed(
 }
 
 bool gfx1250_b0_to_a0_is_deferred_family(std::string_view mnemonic) {
-  // s_sleep and s_sleep_var are deliberately absent. They behave identically on
-  // A0 and B0. Only s_monitor_sleep('forever') with MWAIT=0 requires an A0
-  // translation. Copying a plain sleep through is the correct translation, not
-  // an unimplemented one, so reporting
-  // it said nothing and buried the reports that do name a real gap -- one RCCL
-  // all_reduce run emitted 104,831 of them.
-  return mnemonic == "s_get_barrier_state" || mnemonic == "s_monitor_sleep";
+  // No sleep form is deferred. s_sleep and s_sleep_var behave identically on A0
+  // and B0, so copying them through is the correct translation rather than an
+  // unimplemented one -- reporting them said nothing and buried the reports that
+  // do name a real gap, one RCCL all_reduce run emitting 104,831 of them.
+  // s_monitor_sleep was deferred for DEGFXMI400-12268, the 'forever' form with
+  // MWAIT=0; that now has a semantic rule which prepends the required XCNT
+  // drain, so it is translated rather than passed through with a report.
+  return mnemonic == "s_get_barrier_state";
 }
 
 const InstructionLegalization *gfx1250_b0_to_a0_legalization(const Instruction &inst) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -70,6 +70,14 @@ gfx1250_floating_wmma_control_error(const gfx1250::Vop3pMachineInst &matrix,
   return nullptr;
 }
 
+/// @brief Check for one exact, contiguous predecessor in the same basic block.
+[[nodiscard]] bool has_canonical_predecessor(const Instruction &inst, uint32_t expected_word) {
+  const Instruction *previous = inst.previous_instruction();
+  return previous != nullptr && previous->size() == static_cast<int>(sizeof(uint32_t)) &&
+         previous->src_loc() + sizeof(uint32_t) == inst.src_loc() &&
+         previous->raw_encoding() != nullptr && previous->raw_encoding()[0] == expected_word;
+}
+
 /// @brief Append a generated instruction's words to one replacement sequence.
 template <size_t N>
 void append_words(std::vector<uint32_t> &output, const std::array<uint32_t, N> &words) {
@@ -397,6 +405,58 @@ ExpandResult expand_gfx1250_s_clause(const Instruction &inst, uint32_t, uint64_t
   return ExpandResult::success(std::vector<uint32_t>(nop.begin(), nop.end()));
 }
 
+/// @brief Drain outstanding memory work before an unbounded sleep.
+///
+/// @details SIMM16[15] selects the unbounded form; SIMM16[6:0] is an ordinary
+/// duration and needs nothing, so the test is on that one bit rather than on
+/// the whole immediate. The unbounded form carries a stated requirement to drain
+/// XCNT -- the count of outstanding memory operations -- beforehand, so the
+/// wake-up it waits on cannot be missed. The other waits this target exposes
+/// track unrelated work and do not stand in for it.
+///
+/// Both sleep opcodes that take an immediate are covered. The requirement is
+/// stated for the monitor form, whose wake-up arrives through the monitor path;
+/// the plain form encodes the same SIMM16[15] and is guarded too rather than
+/// assumed exempt, because the guard is one instruction, changes no semantics,
+/// and costs nothing when the wait was already satisfied. The variable-duration
+/// sleep takes its count from a register and has no unbounded form, so it is not
+/// handled here.
+///
+/// A guard already immediately in front is left alone so a second pass over
+/// translated text produces the same bytes. The predecessor is matched as a
+/// decoded, contiguous instruction in the same block rather than as the
+/// preceding word: a branch landing on the sleep would otherwise reach it
+/// without executing a wait that merely sits earlier in the text, and a literal
+/// payload equal to the guard's encoding would masquerade as one.
+ExpandResult expand_gfx1250_unbounded_sleep(const Instruction &inst, uint32_t, uint64_t,
+                                            std::span<const uint8_t>, const LivenessAnalysis &,
+                                            TranslationContext &, const LaneLayout *,
+                                            const LaneLayout *) {
+  const bool is_sleep_opcode =
+      inst.opcode() == gfx1250::kSMonitorSleepSopp || inst.opcode() == gfx1250::kSSleepSopp;
+  if (!is_sleep_opcode || inst.size() != static_cast<int>(sizeof(uint32_t)) ||
+      inst.raw_encoding() == nullptr) {
+    return ExpandResult::failed("gfx1250 sleep rule received an unsupported instruction");
+  }
+
+  constexpr uint16_t kSleepForever = uint16_t{1} << 15;
+  const Operand *immediate = inst.src_operand(0);
+  if (immediate == nullptr ||
+      (static_cast<uint16_t>(immediate->encoding_value()) & kSleepForever) == 0) {
+    return ExpandResult::not_handled();
+  }
+
+  const auto guard = gfx1250::build_sopp(gfx1250::kSWaitXcntSopp, {.simm16 = 0});
+  if (has_canonical_predecessor(inst, guard[0]))
+    return ExpandResult::not_handled();
+
+  std::vector<uint32_t> words;
+  words.reserve(2);
+  append_words(words, guard);
+  words.push_back(inst.raw_encoding()[0]);
+  return ExpandResult::success(std::move(words));
+}
+
 /// @brief Decline the one barrier id this profile excludes.
 ///
 /// @details Barrier id -3 is the only one this instruction may not name; every
@@ -652,14 +712,6 @@ struct TensorMaskWrapper {
       .restore = gfx1250::build_sop1(gfx1250::kSMovB32Sop1,
                                      {.ssrc0 = scratch, .sdst = descriptor_base})[0],
   };
-}
-
-/// @brief Check for one exact, contiguous predecessor in the same basic block.
-[[nodiscard]] bool has_canonical_predecessor(const Instruction &inst, uint32_t expected_word) {
-  const Instruction *previous = inst.previous_instruction();
-  return previous != nullptr && previous->size() == static_cast<int>(sizeof(uint32_t)) &&
-         previous->src_loc() + sizeof(uint32_t) == inst.src_loc() &&
-         previous->raw_encoding() != nullptr && previous->raw_encoding()[0] == expected_word;
 }
 
 /// @brief Check whether every path to a tensor load executes the canonical mask clear.
@@ -2342,9 +2394,13 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
 // The semantic translator binary-searches this table, so entries must stay
 // sorted by the full encoding ID and then opcode. VDS encoding IDs include the
 // high opcode bits, hence the four consecutive kVdsOpHi* groups below.
-inline constexpr std::array<TranslationRule, 41> kGfx1250B0ToA0ExpandRules = {{
+inline constexpr std::array<TranslationRule, 43> kGfx1250B0ToA0ExpandRules = {{
     {gfx1250::encoding::kSop1, gfx1250::kSBarrierSignalIsfirstSop1, RuleAction::Expand, 0, 0,
      nullptr, expand_gfx1250_barrier_signal_isfirst, nullptr, nullptr, false},
+    {gfx1250::encoding::kSopp, gfx1250::kSSleepSopp, RuleAction::Expand, 0, 0, nullptr,
+     expand_gfx1250_unbounded_sleep, nullptr, nullptr, false},
+    {gfx1250::encoding::kSopp, gfx1250::kSMonitorSleepSopp, RuleAction::Expand, 0, 0, nullptr,
+     expand_gfx1250_unbounded_sleep, nullptr, nullptr, false},
     {gfx1250::encoding::kSopp, gfx1250::kSClauseSopp, RuleAction::Expand, 0, 0, nullptr,
      expand_gfx1250_s_clause, nullptr, nullptr, false},
     {gfx1250::encoding::kVop3p, gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p, RuleAction::Expand, 0, 0,
@@ -2426,6 +2482,18 @@ inline constexpr std::array<TranslationRule, 41> kGfx1250B0ToA0ExpandRules = {{
     {gfx1250::encoding::kVglobal, gfx1250::kClusterLoadAsyncToLdsB128Vglobal, RuleAction::Expand, 0,
      0, nullptr, expand_gfx1250_cluster_load, nullptr, nullptr},
 }};
+
+// The comment above is advisory; this is not. An entry in the wrong place makes
+// the binary search miss it and, because lower_bound stops early, take the
+// neighbouring rules down with it -- a silent copy-through rather than a
+// failure.
+static_assert(std::ranges::is_sorted(kGfx1250B0ToA0ExpandRules, {},
+                                     [](const TranslationRule &rule) {
+                                       // Must match SemanticTranslator::packed_rule_key().
+                                       return (static_cast<uint32_t>(rule.src_encoding_id) << 16) |
+                                              rule.src_opcode;
+                                     }),
+              "gfx1250 B0-to-A0 expand rules must stay sorted by encoding ID then opcode");
 
 } // namespace
 

--- a/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
@@ -232,8 +232,11 @@ TEST(Gfx1250B0ToA0Library, FansOutRequiredWorkAsCallbackViews) {
 // misbehaving kernel reads these diagnostics for, so it has to reach the
 // callback on the success path too.
 TEST(Gfx1250B0ToA0Library, ReportsDeferredFamilyDiagnosticOnSuccessfulTranslation) {
-  constexpr auto deferred =
-      rocjitsu::gfx1250::build_sopp(rocjitsu::gfx1250::kSMonitorSleepSopp, {.simm16 = 1});
+  // s_get_barrier_state rather than s_monitor_sleep: the latter's erratum is
+  // specific to the unbounded form, which now has a semantic rule, so the
+  // barrier-state query is the only remaining deferred family.
+  constexpr auto deferred = rocjitsu::gfx1250::build_sop1(rocjitsu::gfx1250::kSGetBarrierStateSop1,
+                                                          {.ssrc0 = 0, .sdst = 0});
   constexpr uint32_t kEndpgm = 0xBFB00000u;
   const std::array<uint32_t, 3> text = {deferred[0], deferred[0], kEndpgm};
   const auto source = rocjitsu::test_support::make_gfx1250_code_object(text);
@@ -250,7 +253,7 @@ TEST(Gfx1250B0ToA0Library, ReportsDeferredFamilyDiagnosticOnSuccessfulTranslatio
 
   const auto reported = std::find_if(diagnostics.begin(), diagnostics.end(), [](const auto &item) {
     return item.severity == "warning" && item.kind == "translator-legalization" &&
-           item.mnemonic == "s_monitor_sleep";
+           item.mnemonic == "s_get_barrier_state";
   });
   ASSERT_NE(reported, diagnostics.end())
       << "a successful translation must still report the pass-through gap";
@@ -258,7 +261,7 @@ TEST(Gfx1250B0ToA0Library, ReportsDeferredFamilyDiagnosticOnSuccessfulTranslatio
 
   // Two instructions, one report: the gap is a property of the mnemonic.
   const auto count = std::count_if(diagnostics.begin(), diagnostics.end(), [](const auto &item) {
-    return item.mnemonic == "s_monitor_sleep";
+    return item.mnemonic == "s_get_barrier_state";
   });
   EXPECT_EQ(count, 1);
 }

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -10937,6 +10937,8 @@ TEST(SemanticTranslator, Gfx1250ClassifiesLivenessFreeExpandRules) {
 
   const std::vector<uint32_t> expected = {
       (static_cast<uint32_t>(gfx1250::encoding::kSop1) << 16) | gfx1250::kSBarrierSignalIsfirstSop1,
+      (static_cast<uint32_t>(gfx1250::encoding::kSopp) << 16) | gfx1250::kSSleepSopp,
+      (static_cast<uint32_t>(gfx1250::encoding::kSopp) << 16) | gfx1250::kSMonitorSleepSopp,
       (static_cast<uint32_t>(gfx1250::encoding::kSopp) << 16) | gfx1250::kSClauseSopp,
       (static_cast<uint32_t>(gfx1250::encoding::kVop3p) << 16) |
           gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p,
@@ -11003,7 +11005,7 @@ TEST(BinaryTranslatorE2E, Gfx1250UsesNeutralScaledK128Fp8Bf8Wmma) {
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
 
-  EXPECT_EQ(rocjitsu::semantic_expand_rules_gfx1250_b0_to_a0().size(), 41u);
+  EXPECT_EQ(rocjitsu::semantic_expand_rules_gfx1250_b0_to_a0().size(), 43u);
   for (const WmmaCase &test_case : cases) {
     SCOPED_TRACE(test_case.name);
     auto source_wmma = gfx1250::build_vop3p(test_case.source_opcode, fields);
@@ -12401,6 +12403,232 @@ TEST(BinaryTranslatorE2E, Gfx1250RepointsPcRelativeDataRangeBoundsAfterRelocatio
 
   ASSERT_NO_FATAL_FAILURE(verify_target(false));
   ASSERT_NO_FATAL_FAILURE(verify_target(true));
+}
+
+// SIMM16[15] alone selects the unbounded form. The table separates that test
+// from whole-immediate equality, from an overbroad high-bit check, and from a
+// plain bounded duration, which needs no guard and stays on the copy path.
+TEST(BinaryTranslatorE2E, Gfx1250GuardsUnboundedSleepFormsForA0) {
+  struct SleepCase {
+    const char *name;
+    uint16_t simm16;
+    bool expect_guard;
+  };
+  const std::vector<SleepCase> cases = {
+      {"selector only", 0x8000, true},
+      {"selector with duration", 0x807f, true},
+      {"unrelated high bit", 0x4000, false},
+      {"bounded duration", 0x7f, false},
+  };
+  // Both immediate-taking sleep opcodes encode the unbounded form in the same
+  // bit, so both are driven through the same cases.
+  const std::vector<std::pair<const char *, uint16_t>> opcodes = {
+      {"monitor sleep", gfx1250::kSMonitorSleepSopp},
+      {"plain sleep", gfx1250::kSSleepSopp},
+  };
+  constexpr auto expected_guard = gfx1250::build_sopp(gfx1250::kSWaitXcntSopp, {.simm16 = 0});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  for (const auto &[opcode_name, opcode] : opcodes)
+    for (const SleepCase &test_case : cases) {
+      SCOPED_TRACE(opcode_name);
+      SCOPED_TRACE(test_case.name);
+      const auto sleep = gfx1250::build_sopp(opcode, {.simm16 = test_case.simm16});
+      auto image =
+          rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text({sleep[0], kGfx1250SEndpgm});
+      rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+      rocjitsu::BinaryTranslator translator(
+          ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+          gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                   rocjitsu::ProcessorRevision::Gfx1250A0));
+      auto result = translator.translate(source);
+      ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                              : result.diagnostics.front().message);
+
+      rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+      ASSERT_FALSE(translated.text_sections().empty());
+      const auto *out = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+      const size_t count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+      // Compared as a whole sequence, terminator included, so a truncation or an
+      // extra insertion cannot pass and the reads stay in bounds.
+      const std::vector<uint32_t> actual(out, out + count);
+      const std::vector<uint32_t> want =
+          test_case.expect_guard
+              ? std::vector<uint32_t>{expected_guard[0], sleep[0], kGfx1250SEndpgm}
+              : std::vector<uint32_t>{sleep[0], kGfx1250SEndpgm};
+      EXPECT_EQ(actual, want);
+    }
+}
+
+// A trailing literal can hold the guard's exact encoding without being a guard.
+// Matching the preceding decoded instruction rather than the preceding word is
+// what separates the two; comparing raw words suppressed the guard here.
+TEST(BinaryTranslatorE2E, Gfx1250GuardsUnboundedSleepAfterALiteralMatchingTheGuardForA0) {
+  constexpr uint16_t kSleepForever = uint16_t{1} << 15;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint8_t kLiteralOperand = 255;
+  constexpr auto guard = gfx1250::build_sopp(gfx1250::kSWaitXcntSopp, {.simm16 = 0});
+  constexpr auto sleep =
+      gfx1250::build_sopp(gfx1250::kSMonitorSleepSopp, {.simm16 = kSleepForever});
+  // s_mov_b32 s0, <guard encoding>: two words, the second equal to the guard.
+  constexpr auto mov =
+      gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = kLiteralOperand, .sdst = 0});
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {mov[0], guard[0], sleep[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto *out = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  const size_t count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+  const std::vector<uint32_t> actual(out, out + count);
+
+  const std::vector<uint32_t> want = {mov[0], guard[0], guard[0], sleep[0], kGfx1250SEndpgm};
+  EXPECT_EQ(actual, want) << "the literal is not a guard, so the sleep needs its own";
+}
+
+// A guard in the preceding word is not reachable when a branch jumps over it,
+// so it cannot stand in for the sleep's own. Matching a decoded predecessor in
+// the same basic block is what rejects it; a contiguous-word check would see a
+// guard here and skip the insertion, leaving the branch path undrained.
+//
+// The branch is conditional on purpose. An unconditional one would leave the
+// original guard unreachable, it would be dropped as dead, and the inserted
+// guard would take its place in the output -- the two outcomes would then be
+// byte-identical and the test could not tell them apart.
+TEST(BinaryTranslatorE2E, Gfx1250GuardsUnboundedSleepReachedByABranchForA0) {
+  constexpr uint16_t kSleepForever = uint16_t{1} << 15;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr auto guard = gfx1250::build_sopp(gfx1250::kSWaitXcntSopp, {.simm16 = 0});
+  constexpr auto sleep =
+      gfx1250::build_sopp(gfx1250::kSMonitorSleepSopp, {.simm16 = kSleepForever});
+  // The offset is relative to the following instruction, so +1 skips the guard
+  // and lands on the sleep. The guard runs only on the fallthrough path.
+  constexpr auto branch = gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp, {.simm16 = 1});
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {branch[0], guard[0], sleep[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto *out = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  const size_t count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+  const std::vector<uint32_t> actual(out, out + count);
+
+  // The branch keeps its offset because the inserted guard takes the target's
+  // place, which is what puts the drain on the path that skips the original.
+  const std::vector<uint32_t> want = {branch[0], guard[0], guard[0], sleep[0], kGfx1250SEndpgm};
+  EXPECT_EQ(actual, want) << "the guard the branch skips cannot serve as the sleep's";
+}
+
+// A second pass over already-translated text must produce the same bytes, so a
+// guard that is already in front is recognized instead of duplicated.
+TEST(BinaryTranslatorE2E, Gfx1250UnboundedMonitorSleepGuardIsStableOnSecondPassForA0) {
+  constexpr uint16_t kSleepForever = uint16_t{1} << 15;
+  constexpr auto sleep =
+      gfx1250::build_sopp(gfx1250::kSMonitorSleepSopp, {.simm16 = kSleepForever});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image =
+      rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text({sleep[0], kGfx1250SEndpgm});
+
+  std::vector<uint8_t> current = image;
+  std::vector<uint32_t> first_pass;
+  for (int pass = 0; pass < 2; ++pass) {
+    rocjitsu::AmdGpuCodeObject source(current.data(), current.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    auto result = translator.translate(source);
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    ASSERT_FALSE(translated.text_sections().empty());
+    const auto *out = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+    const size_t count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+    std::vector<uint32_t> words(out, out + count);
+    if (pass == 0) {
+      // Pin the shape once, so the comparison below cannot be satisfied by two
+      // passes agreeing on the wrong sequence.
+      constexpr auto guard = gfx1250::build_sopp(gfx1250::kSWaitXcntSopp, {.simm16 = 0});
+      const std::vector<uint32_t> want = {guard[0], sleep[0], kGfx1250SEndpgm};
+      ASSERT_EQ(words, want);
+      first_pass = words;
+    } else {
+      EXPECT_EQ(words, first_pass) << "the second pass must not add another guard";
+    }
+    current = result.elf_bytes;
+  }
+}
+
+// The barrier-state query is the only mnemonic still passed through with a
+// warning. The sleeps are either handled by a rule or copied deliberately, so
+// warning about them would be noise that buries the one case that is genuinely
+// unhandled. This pins that boundary in both directions.
+TEST(BinaryTranslatorE2E, Gfx1250WarnsOnlyForTheDeferredBarrierStateQueryForA0) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint8_t kInlineZero = 128;
+  struct DeferralCase {
+    const char *name;
+    uint32_t word;
+    bool expect_warning;
+  };
+  const std::vector<DeferralCase> cases = {
+      {"bounded sleep", gfx1250::build_sopp(gfx1250::kSSleepSopp, {.simm16 = 0x7f})[0], false},
+      // The duration comes from a register, so SIMM16[15] cannot classify it and
+      // the rule never sees it. It is copied on purpose, not by omission.
+      {"variable sleep", gfx1250::build_sop1(gfx1250::kSSleepVarSop1, {.ssrc0 = kInlineZero})[0],
+       false},
+      {"barrier state query",
+       gfx1250::build_sop1(gfx1250::kSGetBarrierStateSop1, {.ssrc0 = kInlineZero, .sdst = 0})[0],
+       true},
+  };
+
+  for (const DeferralCase &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+        {test_case.word, kGfx1250SEndpgm});
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+
+    const auto result = translator.translate(source);
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+
+    // Reported through the diagnostic channel rather than stderr, and once per
+    // mnemonic: the translator deduplicates so a common instruction cannot bury
+    // the reports that name a real gap.
+    const auto deferred =
+        std::ranges::find_if(result.diagnostics, [](const rocjitsu::TranslationDiagnostic &item) {
+          return item.severity == rocjitsu::DiagnosticSeverity::Warning &&
+                 item.kind == rocjitsu::DiagnosticKind::Legalization;
+        });
+    if (test_case.expect_warning) {
+      ASSERT_NE(deferred, result.diagnostics.end()) << "the deferred query must be reported";
+      EXPECT_EQ(deferred->mnemonic, "s_get_barrier_state") << "the report must name the query";
+    } else {
+      EXPECT_EQ(deferred, result.diagnostics.end())
+          << "a handled or deliberately copied mnemonic must not be reported";
+    }
+  }
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250FailsClosedOnExcludedBarrierSignalIsfirst) {
@@ -16335,9 +16563,13 @@ translate_gfx1250_b0_to_a0_result(rocjitsu::BinaryTranslator &translator,
                                rocjitsu::ProcessorRevision::Gfx1250A0));
 }
 
-/// @brief An s_monitor_sleep whose A0 handling is deferred.
+/// @brief An s_get_barrier_state, whose A0 handling is still deferred.
+/// @details s_monitor_sleep used to serve here. Its erratum, DEGFXMI400-12268,
+/// is specific to the unbounded form, which now has a semantic rule prepending
+/// the required XCNT drain -- so it is translated rather than passed through,
+/// and the barrier-state query is the only remaining deferred family.
 [[nodiscard]] uint32_t gfx1250_deferred_word() {
-  return gfx1250::build_sopp(gfx1250::kSMonitorSleepSopp, {.simm16 = 1})[0];
+  return gfx1250::build_sop1(gfx1250::kSGetBarrierStateSop1, {.ssrc0 = 0, .sdst = 0})[0];
 }
 
 } // namespace
@@ -16351,23 +16583,8 @@ TEST(BinaryTranslatorE2E, Gfx1250ReportsOncePerDeferredMnemonicWithinOneTranslat
   const auto result = translate_gfx1250_b0_to_a0_result(
       translator, {deferred, deferred, deferred, deferred, deferred});
 
-  EXPECT_EQ(deferred_family_reports(result), (std::vector<std::string>{"s_monitor_sleep"}))
+  EXPECT_EQ(deferred_family_reports(result), (std::vector<std::string>{"s_get_barrier_state"}))
       << "five deferred instructions must produce one diagnostic, not five";
-}
-
-// Distinct deferred mnemonics are distinct gaps, so suppressing one must not
-// suppress another.
-TEST(BinaryTranslatorE2E, Gfx1250ReportsSeparatelyForEachDeferredMnemonic) {
-  const uint32_t deferred = gfx1250_deferred_word();
-  const uint32_t barrier_state =
-      gfx1250::build_sop1(gfx1250::kSGetBarrierStateSop1, {.ssrc0 = 0, .sdst = 0})[0];
-  auto translator = make_gfx1250_b0_to_a0_translator();
-  const auto result = translate_gfx1250_b0_to_a0_result(
-      translator, {deferred, barrier_state, deferred, barrier_state});
-
-  auto reported = deferred_family_reports(result);
-  std::ranges::sort(reported);
-  EXPECT_EQ(reported, (std::vector<std::string>{"s_get_barrier_state", "s_monitor_sleep"}));
 }
 
 // The suppression is scoped to one translation. Process-wide state would let
@@ -16381,8 +16598,8 @@ TEST(BinaryTranslatorE2E, Gfx1250ReportsAgainForEachSeparateTranslation) {
   const auto first = translate_gfx1250_b0_to_a0_result(first_translator, {deferred, deferred});
   const auto second = translate_gfx1250_b0_to_a0_result(second_translator, {deferred, deferred});
 
-  EXPECT_EQ(deferred_family_reports(first), (std::vector<std::string>{"s_monitor_sleep"}));
-  EXPECT_EQ(deferred_family_reports(second), (std::vector<std::string>{"s_monitor_sleep"}))
+  EXPECT_EQ(deferred_family_reports(first), (std::vector<std::string>{"s_get_barrier_state"}));
+  EXPECT_EQ(deferred_family_reports(second), (std::vector<std::string>{"s_get_barrier_state"}))
       << "a second code object must report the gap independently";
 }
 
@@ -16394,8 +16611,8 @@ TEST(BinaryTranslatorE2E, Gfx1250ReportsAgainWhenOneTranslatorIsReused) {
   const auto first = translate_gfx1250_b0_to_a0_result(translator, {deferred, deferred});
   const auto second = translate_gfx1250_b0_to_a0_result(translator, {deferred, deferred});
 
-  EXPECT_EQ(deferred_family_reports(first), (std::vector<std::string>{"s_monitor_sleep"}));
-  EXPECT_EQ(deferred_family_reports(second), (std::vector<std::string>{"s_monitor_sleep"}))
+  EXPECT_EQ(deferred_family_reports(first), (std::vector<std::string>{"s_get_barrier_state"}));
+  EXPECT_EQ(deferred_family_reports(second), (std::vector<std::string>{"s_get_barrier_state"}))
       << "translate() must reset the per-translation suppression state";
 }
 
@@ -16409,7 +16626,7 @@ TEST(BinaryTranslatorE2E, Gfx1250DeferredFamilyReportCarriesOffsetAndMnemonic) {
       translate_gfx1250_b0_to_a0_result(translator, {kGfx1250SNop, deferred, deferred});
 
   const auto reported = std::ranges::find_if(result.diagnostics, [](const auto &diagnostic) {
-    return diagnostic.mnemonic == "s_monitor_sleep";
+    return diagnostic.mnemonic == "s_get_barrier_state";
   });
   ASSERT_NE(reported, result.diagnostics.end());
   EXPECT_EQ(reported->severity, rocjitsu::DiagnosticSeverity::Warning);


### PR DESCRIPTION
SIMM16[15] selects the unbounded form, which requires the counter to be drained first. The guard is prepended and the instruction is otherwise untouched, so the wait keeps its original meaning. Bounded durations are unaffected and stay on the copy path.

The two ordinary sleep mnemonics leave the deferred set as well; they need no change here, so warning about them was noise. The barrier-state query stays deferred and still warns.