### PR TITLE
[rocjitsu] Splice one barrier-state result field on gfx1250 A0

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -33,13 +33,15 @@ namespace {
 ///
 /// Separately, a 64-bit source reading FLAT_SCRATCH_BASE is classified via
 /// operand inspection (see gfx1250_reads_flat_scratch_base_64bit). The unbounded
-/// sleep is decided entirely by its semantic rule, which is attempted before raw
-/// encoding translation and returns not-handled for the forms that need nothing,
-/// leaving them on the copy path. This classification is looked up first, but its
-/// action applies only once the rule declines, so a predicate here would turn
-/// every declined sleep into a refusal. The barrier-state query is DEFERRED with
-/// a pass-through report rather than fail-closed (see
-/// gfx1250_b0_to_a0_is_deferred_family).
+/// sleep and the affected barrier-state ids are decided entirely by their
+/// semantic rules, which are attempted before raw encoding translation and
+/// return not-handled for the forms that need nothing, leaving those on the copy
+/// path. This classification is looked up first, but its action applies only
+/// once a rule declines, so a predicate here would turn every declined
+/// instruction into a refusal. Ordinary sleeps are copied silently; an
+/// unaffected barrier id is copied too, but still carries the DEFERRED
+/// pass-through report (see gfx1250_b0_to_a0_is_deferred_family), because the
+/// query as a whole has no A0 handling beyond the two spliced ids.
 inline constexpr std::array<std::string_view, 17> kExactB0ToA0TranslationMnemonics = {
     "ds_load_2addr_b32",
     "ds_load_2addr_b64",

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -405,6 +405,144 @@ ExpandResult expand_gfx1250_s_clause(const Instruction &inst, uint32_t, uint64_t
   return ExpandResult::success(std::vector<uint32_t>(nop.begin(), nop.end()));
 }
 
+/// @brief Take one field of the barrier-state result from a second query.
+///
+/// @details The result word carries a count in bits [28:24] that this profile
+/// does not populate for the affected barrier ids. A second query on a
+/// different id reports it, so the sequence issues that query into a borrowed
+/// register and splices the field into the original destination. The query
+/// completes through KMCNT, so both results are drained before either is read.
+///
+/// The merge uses scalar bitwise operations, which write SCC, while the query
+/// being replaced does not. SCC is therefore saved into a second borrowed
+/// register and restored afterwards, so a comparison feeding a later branch
+/// still sees its own result. The dataflow model does not track SCC, so this
+/// cannot be inferred from liveness.
+ExpandResult expand_gfx1250_get_barrier_state(const Instruction &inst, uint32_t, uint64_t,
+                                              std::span<const uint8_t>,
+                                              const LivenessAnalysis &liveness,
+                                              TranslationContext &, const LaneLayout *,
+                                              const LaneLayout *) {
+  if (inst.opcode() != gfx1250::kSGetBarrierStateSop1 ||
+      inst.size() != static_cast<int>(sizeof(uint32_t)) || inst.raw_encoding() == nullptr) {
+    return ExpandResult::failed("gfx1250 barrier-state rule received an unsupported instruction");
+  }
+
+  // Result-word layout, most significant first: five reserved bits, a three-bit
+  // named-barrier count, one reserved bit, a seven-bit signal count, five
+  // reserved bits, a seven-bit member count, three reserved bits, and a valid
+  // bit. The spliced field is the named-barrier count at [26:24]; the two
+  // reserved bits above it are carried with it so the destination takes the
+  // whole [28:24] span from the reporting query rather than keeping whatever
+  // the affected one left there.
+  constexpr uint32_t kNamedBarrierCountShift = 24;
+  constexpr uint32_t kNamedBarrierCountBits = 3;
+  constexpr uint32_t kCarriedReservedBits = 2;
+  constexpr uint32_t kFieldMask =
+      (((uint32_t{1} << (kNamedBarrierCountBits + kCarriedReservedBits)) - 1u)
+       << kNamedBarrierCountShift);
+  static_assert(kFieldMask == 0x1f000000u);
+  constexpr uint8_t kSecondQueryId = 129; // inline +1
+  constexpr uint8_t kScalarLiteral = 255;
+  constexpr uint8_t kInlineZero = 128;
+  constexpr uint8_t kInlineOne = 129;
+  constexpr uint16_t kMaxOrdinarySgpr = 105;
+
+  // Dispatch is by opcode, so decline the ids that report the field themselves.
+  //
+  // The two affected ids are negative inline constants. This operand takes an
+  // inline constant or M0 and nothing else, and the M0 form selects the barrier
+  // from a five-bit zero-extended slice of that register, so a register-supplied
+  // id is always in [0, 31] and can never be one of them. Copying the dynamic
+  // form is therefore fail-closed rather than an unchecked assumption, and
+  // refusing it would reject valid input for no gain.
+  constexpr int kAffectedIdInlineFirst = 193;
+  constexpr int kAffectedIdInlineSecond = 194;
+  const Operand *barrier_id = inst.src_operand(0);
+  if (barrier_id == nullptr || (barrier_id->encoding_value() != kAffectedIdInlineFirst &&
+                                barrier_id->encoding_value() != kAffectedIdInlineSecond)) {
+    return ExpandResult::not_handled();
+  }
+
+  // The expansion keeps the affected query as its first word, so a second pass
+  // sees the same instruction again. Recognize the envelope this rule emits --
+  // the companion query for the neighbouring id followed by its wait -- and
+  // leave it alone, so translating already-translated text is a no-op.
+  const Instruction *companion = inst.next_instruction();
+  if (companion != nullptr && companion->opcode() == gfx1250::kSGetBarrierStateSop1 &&
+      companion->raw_encoding() != nullptr &&
+      (companion->raw_encoding()[0] & 0xffu) == kSecondQueryId) {
+    const Instruction *wait = companion->next_instruction();
+    const auto expected_wait = gfx1250::build_sopp(gfx1250::kSWaitKmcntSopp, {.simm16 = 0});
+    if (wait != nullptr && wait->raw_encoding() != nullptr &&
+        wait->raw_encoding()[0] == expected_wait[0]) {
+      return ExpandResult::not_handled();
+    }
+  }
+
+  const Operand *destination = inst.dst_operand(0);
+  if (destination == nullptr || destination->encoding_value() > kMaxOrdinarySgpr)
+    return ExpandResult::failed("gfx1250 barrier-state destination is not an ordinary SGPR");
+  const uint16_t dest = static_cast<uint16_t>(destination->encoding_value());
+
+  // The destination is written rather than read here, so it can look free.
+  const auto borrow = [&](uint16_t after) -> std::optional<uint16_t> {
+    std::optional<uint16_t> pick = liveness.find_free_sgpr(&inst, after);
+    while (pick && (*pick == dest))
+      pick = liveness.find_free_sgpr(&inst, static_cast<uint16_t>(*pick + 1));
+    if (pick && *pick > kMaxOrdinarySgpr)
+      return std::nullopt;
+    return pick;
+  };
+  const std::optional<uint16_t> scratch = borrow(0);
+  if (!scratch)
+    return ExpandResult::failed("gfx1250 barrier-state merge could not allocate a dead SGPR");
+  const std::optional<uint16_t> saved_scc = borrow(static_cast<uint16_t>(*scratch + 1));
+  if (!saved_scc) {
+    return ExpandResult::failed(
+        "gfx1250 barrier-state merge could not allocate a dead SGPR to preserve SCC");
+  }
+  // No descriptor growth is involved. This target's scalar file is fixed rather
+  // than sized by the descriptor, and the translator does not write the legacy
+  // granulated field for it, so raising a requirement here would change nothing.
+  // The bound that matters is that both borrowed registers stay inside the
+  // architecturally addressable range, which the checks above enforce.
+
+  std::vector<uint32_t> words;
+  words.reserve(12);
+  words.push_back(inst.raw_encoding()[0]);
+  append_words(words, gfx1250::build_sop1(
+                          gfx1250::kSGetBarrierStateSop1,
+                          {.ssrc0 = kSecondQueryId, .sdst = static_cast<uint8_t>(*scratch)}));
+  append_words(words, gfx1250::build_sopp(gfx1250::kSWaitKmcntSopp, {.simm16 = 0}));
+
+  // s_cselect_b32 reads SCC without writing it; s_cmp_lg_u32 restores it.
+  append_words(words, gfx1250::build_sop2(gfx1250::kSCselectB32Sop2,
+                                          {.ssrc0 = kInlineOne,
+                                           .ssrc1 = kInlineZero,
+                                           .sdst = static_cast<uint8_t>(*saved_scc)}));
+
+  append_words(
+      words, gfx1250::build_sop2(gfx1250::kSAndB32Sop2, {.ssrc0 = static_cast<uint8_t>(*scratch),
+                                                         .ssrc1 = kScalarLiteral,
+                                                         .sdst = static_cast<uint8_t>(*scratch)}));
+  words.push_back(kFieldMask);
+  append_words(words,
+               gfx1250::build_sop2(gfx1250::kSAndB32Sop2, {.ssrc0 = static_cast<uint8_t>(dest),
+                                                           .ssrc1 = kScalarLiteral,
+                                                           .sdst = static_cast<uint8_t>(dest)}));
+  words.push_back(~kFieldMask);
+  append_words(words,
+               gfx1250::build_sop2(gfx1250::kSOrB32Sop2, {.ssrc0 = static_cast<uint8_t>(dest),
+                                                          .ssrc1 = static_cast<uint8_t>(*scratch),
+                                                          .sdst = static_cast<uint8_t>(dest)}));
+
+  append_words(words, gfx1250::build_sopc(
+                          gfx1250::kSCmpLgU32Sopc,
+                          {.ssrc0 = static_cast<uint8_t>(*saved_scc), .ssrc1 = kInlineZero}));
+  return ExpandResult::success(std::move(words));
+}
+
 /// @brief Drain outstanding memory work before an unbounded sleep.
 ///
 /// @details SIMM16[15] selects the unbounded form; SIMM16[6:0] is an ordinary
@@ -2394,9 +2532,11 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
 // The semantic translator binary-searches this table, so entries must stay
 // sorted by the full encoding ID and then opcode. VDS encoding IDs include the
 // high opcode bits, hence the four consecutive kVdsOpHi* groups below.
-inline constexpr std::array<TranslationRule, 43> kGfx1250B0ToA0ExpandRules = {{
+inline constexpr std::array<TranslationRule, 44> kGfx1250B0ToA0ExpandRules = {{
     {gfx1250::encoding::kSop1, gfx1250::kSBarrierSignalIsfirstSop1, RuleAction::Expand, 0, 0,
      nullptr, expand_gfx1250_barrier_signal_isfirst, nullptr, nullptr, false},
+    {gfx1250::encoding::kSop1, gfx1250::kSGetBarrierStateSop1, RuleAction::Expand, 0, 0, nullptr,
+     expand_gfx1250_get_barrier_state, nullptr, nullptr},
     {gfx1250::encoding::kSopp, gfx1250::kSSleepSopp, RuleAction::Expand, 0, 0, nullptr,
      expand_gfx1250_unbounded_sleep, nullptr, nullptr, false},
     {gfx1250::encoding::kSopp, gfx1250::kSMonitorSleepSopp, RuleAction::Expand, 0, 0, nullptr,

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -11005,7 +11005,7 @@ TEST(BinaryTranslatorE2E, Gfx1250UsesNeutralScaledK128Fp8Bf8Wmma) {
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
 
-  EXPECT_EQ(rocjitsu::semantic_expand_rules_gfx1250_b0_to_a0().size(), 43u);
+  EXPECT_EQ(rocjitsu::semantic_expand_rules_gfx1250_b0_to_a0().size(), 44u);
   for (const WmmaCase &test_case : cases) {
     SCOPED_TRACE(test_case.name);
     auto source_wmma = gfx1250::build_vop3p(test_case.source_opcode, fields);
@@ -12403,6 +12403,248 @@ TEST(BinaryTranslatorE2E, Gfx1250RepointsPcRelativeDataRangeBoundsAfterRelocatio
 
   ASSERT_NO_FATAL_FAILURE(verify_target(false));
   ASSERT_NO_FATAL_FAILURE(verify_target(true));
+}
+
+// The affected barrier-state ids take one result field from a second query.
+// The merge writes SCC, which the replaced query does not, so it is saved and
+// restored around the bitwise operations.
+TEST(BinaryTranslatorE2E, Gfx1250SplicesBarrierStateFieldForA0) {
+  constexpr uint8_t kSecondQueryIdInline = 129;
+  constexpr uint8_t kDestination = 20;
+  constexpr uint8_t kScalarLiteral = 255;
+  constexpr uint8_t kInlineZero = 128;
+  constexpr uint8_t kInlineOne = 129;
+  constexpr uint32_t kFieldMask = 0x1f000000u;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  for (const uint8_t affected_id : {uint8_t{193}, uint8_t{194}}) {
+    SCOPED_TRACE(static_cast<int>(affected_id));
+    const auto query = gfx1250::build_sop1(gfx1250::kSGetBarrierStateSop1,
+                                           {.ssrc0 = affected_id, .sdst = kDestination});
+    auto image =
+        rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text({query[0], kGfx1250SEndpgm});
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    auto result = translator.translate(source);
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    ASSERT_FALSE(translated.text_sections().empty());
+    const auto *out = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+    const size_t count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+    ASSERT_GE(count, 11u);
+
+    // Recover the two borrowed registers from the emitted words, then pin every
+    // instruction against the builder so a changed opcode cannot pass.
+    const uint32_t scratch = (out[1] >> 16) & 0x7fu;
+    const uint32_t saved_scc = (out[3] >> 16) & 0x7fu;
+    EXPECT_NE(scratch, kDestination);
+    EXPECT_NE(saved_scc, kDestination);
+    EXPECT_NE(saved_scc, scratch);
+    EXPECT_LE(scratch, 105u);
+    EXPECT_LE(saved_scc, 105u);
+
+    EXPECT_EQ(out[0], query[0]) << "the original query must be preserved";
+    EXPECT_EQ(out[1], gfx1250::build_sop1(gfx1250::kSGetBarrierStateSop1,
+                                          {.ssrc0 = kSecondQueryIdInline,
+                                           .sdst = static_cast<uint8_t>(scratch)})[0]);
+    EXPECT_EQ(out[2], gfx1250::build_sopp(gfx1250::kSWaitKmcntSopp, {.simm16 = 0})[0])
+        << "both results complete through KMCNT and must be drained";
+    EXPECT_EQ(out[3], gfx1250::build_sop2(gfx1250::kSCselectB32Sop2,
+                                          {.ssrc0 = kInlineOne,
+                                           .ssrc1 = kInlineZero,
+                                           .sdst = static_cast<uint8_t>(saved_scc)})[0])
+        << "SCC must be saved before the merge";
+    EXPECT_EQ(out[4], gfx1250::build_sop2(gfx1250::kSAndB32Sop2,
+                                          {.ssrc0 = static_cast<uint8_t>(scratch),
+                                           .ssrc1 = kScalarLiteral,
+                                           .sdst = static_cast<uint8_t>(scratch)})[0]);
+    EXPECT_EQ(out[5], kFieldMask);
+    EXPECT_EQ(out[6], gfx1250::build_sop2(gfx1250::kSAndB32Sop2, {.ssrc0 = kDestination,
+                                                                  .ssrc1 = kScalarLiteral,
+                                                                  .sdst = kDestination})[0]);
+    EXPECT_EQ(out[7], ~kFieldMask);
+    EXPECT_EQ(out[8],
+              gfx1250::build_sop2(gfx1250::kSOrB32Sop2, {.ssrc0 = kDestination,
+                                                         .ssrc1 = static_cast<uint8_t>(scratch),
+                                                         .sdst = kDestination})[0]);
+    EXPECT_EQ(out[9], gfx1250::build_sopc(
+                          gfx1250::kSCmpLgU32Sopc,
+                          {.ssrc0 = static_cast<uint8_t>(saved_scc), .ssrc1 = kInlineZero})[0])
+        << "SCC must be restored after the merge";
+    EXPECT_EQ(out[10], kGfx1250SEndpgm) << "the expansion must end where the kernel resumes";
+  }
+}
+
+// A comparison feeding a later branch must still see its own result, even
+// though the merge in between writes SCC.
+// The expansion keeps the affected query as its first word, so nothing stops a
+// second pass from matching it again and wrapping another envelope around it.
+// Translating already-translated text must be a no-op.
+// With every ordinary scalar register live there is nowhere to stage the second
+// result or to park SCC, so the splice must refuse rather than clobber one.
+TEST(BinaryTranslatorE2E, Gfx1250FailsClosedWhenBarrierStateHasNoScratchForA0) {
+  constexpr uint8_t kAffectedIdInline = 193;
+  constexpr uint8_t kDestination = 20;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const auto query = gfx1250::build_sop1(gfx1250::kSGetBarrierStateSop1,
+                                         {.ssrc0 = kAffectedIdInline, .sdst = kDestination});
+  std::vector<uint32_t> words = {query[0]};
+  // Reading every ordinary scalar register after the query keeps them all live
+  // across it, so the allocator has nothing to borrow.
+  for (uint16_t base = 0; base + 1 <= 101; base += 2) {
+    words.push_back(
+        gfx1250::build_sop2(gfx1250::kSAndB32Sop2, {.ssrc0 = static_cast<uint8_t>(base),
+                                                    .ssrc1 = static_cast<uint8_t>(base + 1),
+                                                    .sdst = 102})[0]);
+  }
+  words.push_back(kGfx1250SEndpgm);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_FALSE(result.dispatchable());
+  EXPECT_EQ(result.elf_bytes, image) << "fail-closed must leave the object unchanged";
+  EXPECT_TRUE(rocjitsu::has_error_containing(result, rocjitsu::DiagnosticKind::ExpandFailed,
+                                             "could not allocate a dead SGPR"));
+}
+
+// Two affected queries back to back each need their own envelope. This also
+// checks the already-spliced test does not mistake the second query for the
+// companion the first one emits.
+TEST(BinaryTranslatorE2E, Gfx1250SplicesAdjacentBarrierStateQueriesForA0) {
+  constexpr uint8_t kFirstAffectedId = 193;
+  constexpr uint8_t kSecondAffectedId = 194;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const auto first =
+      gfx1250::build_sop1(gfx1250::kSGetBarrierStateSop1, {.ssrc0 = kFirstAffectedId, .sdst = 20});
+  const auto second =
+      gfx1250::build_sop1(gfx1250::kSGetBarrierStateSop1, {.ssrc0 = kSecondAffectedId, .sdst = 22});
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {first[0], second[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto *out = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  const size_t count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+
+  EXPECT_EQ(std::count(out, out + count, first[0]), 1);
+  EXPECT_EQ(std::count(out, out + count, second[0]), 1);
+  // One envelope per affected query, each drained by its own wait.
+  const auto wait = gfx1250::build_sopp(gfx1250::kSWaitKmcntSopp, {.simm16 = 0});
+  EXPECT_EQ(std::count(out, out + count, wait[0]), 2)
+      << "each affected query needs its own companion and drain";
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250BarrierStateSpliceIsStableOnSecondPassForA0) {
+  constexpr uint8_t kAffectedIdInline = 193;
+  constexpr uint8_t kDestination = 20;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const auto query = gfx1250::build_sop1(gfx1250::kSGetBarrierStateSop1,
+                                         {.ssrc0 = kAffectedIdInline, .sdst = kDestination});
+  auto image =
+      rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text({query[0], kGfx1250SEndpgm});
+
+  std::vector<uint8_t> current = image;
+  std::vector<uint32_t> first_pass;
+  for (int pass = 0; pass < 2; ++pass) {
+    rocjitsu::AmdGpuCodeObject source(current.data(), current.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    const auto result = translator.translate(source);
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    ASSERT_FALSE(translated.text_sections().empty());
+    const auto *out = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+    const size_t count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+    std::vector<uint32_t> words(out, out + count);
+    if (pass == 0) {
+      ASSERT_GE(words.size(), 11u) << "the first pass must emit the envelope";
+      first_pass = words;
+    } else {
+      EXPECT_EQ(words, first_pass) << "the second pass must not wrap the splice again";
+    }
+    current = result.elf_bytes;
+  }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250BarrierStateSpliceKeepsGuestSccForA0) {
+  constexpr uint8_t kAffectedIdInline = 193;
+  constexpr uint8_t kInlineZero = 128;
+  const auto compare =
+      gfx1250::build_sopc(gfx1250::kSCmpLgU32Sopc, {.ssrc0 = 0, .ssrc1 = kInlineZero});
+  const auto query =
+      gfx1250::build_sop1(gfx1250::kSGetBarrierStateSop1, {.ssrc0 = kAffectedIdInline, .sdst = 20});
+  const auto branch = gfx1250::build_sopp(gfx1250::kSCbranchScc1Sopp, {.simm16 = 0});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {compare[0], query[0], branch[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  const auto branch_at = std::ranges::find_if(
+      decoded, [](const auto &inst) { return inst->mnemonic() == "s_cbranch_scc1"; });
+  ASSERT_NE(branch_at, decoded.end());
+  ASSERT_NE(branch_at, decoded.begin());
+  EXPECT_EQ((*std::prev(branch_at))->mnemonic(), "s_cmp_lg_u32")
+      << "the branch must read a restored SCC, not the merge result";
+}
+
+// Every other barrier-state id reports the field itself and is copied.
+TEST(BinaryTranslatorE2E, Gfx1250CopiesRemainingBarrierStateQueriesForA0) {
+  constexpr uint8_t kInlineMinusThree = 195;
+  constexpr uint8_t kInlinePlusOne = 129;
+  constexpr uint8_t kM0Selector = 125;
+  constexpr uint8_t kSgprZero = 0;
+  for (const uint8_t barrier_id : {kInlineMinusThree, kInlinePlusOne, kM0Selector, kSgprZero}) {
+    const auto query =
+        gfx1250::build_sop1(gfx1250::kSGetBarrierStateSop1, {.ssrc0 = barrier_id, .sdst = 20});
+    constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+    auto image =
+        rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text({query[0], kGfx1250SEndpgm});
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    auto result = translator.translate(source);
+    ASSERT_TRUE(result.ok()) << "barrier id " << static_cast<int>(barrier_id);
+
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    ASSERT_FALSE(translated.text_sections().empty());
+    const auto *out = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+    EXPECT_EQ(out[0], query[0]);
+    EXPECT_EQ(out[1], kGfx1250SEndpgm) << "barrier id " << static_cast<int>(barrier_id);
+  }
 }
 
 // SIMM16[15] alone selects the unbounded form. The table separates that test


### PR DESCRIPTION
Two of the ids do not report the count field in the result word. A second query on an id that does report it runs into a borrowed register, and the field is spliced into the original destination. Both queries complete through KMCNT, so they are drained before either result is read.

Only ids given as inline constants are decidable. An id taken from the zero-extended low field reports normally, and one held in a register is a runtime value this pass does not evaluate; both stay on the copy path.

This retires the deferred pass-through set, so the classifier no longer warns.