### PR TITLE
fix(rccl): keep Direct AllGather enabled under user buffer registration (drop_2026-07)

### DIFF
--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -436,6 +436,7 @@ set(SRC_FILES
   transport/net_ib/gin.cc
   transport/net_ib/gin.h
   transport/net_ib/init.cc
+  transport/net_ib/net_ib_flush_fault_inject.h
   transport/net_ib/p2p.cc
   transport/net_ib/p2p.h
   transport/net_ib/p2p_resiliency.cc

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1242,45 +1242,47 @@ static ncclResult_t addP2pToPlan(struct ncclComm* comm, struct ncclKernelPlan* p
     chunkSize[dir] = chunkDataSize[dir];
     if (protocol[dir] == NCCL_PROTO_LL) chunkSize[dir] *= 2;
 
-    if (network[dir]) {
-      bool pxnUsed = !ncclPxnDisable(comm) && comm->isAllNvlink && comm->maxLocalRanks > 1;
-      if (bytes[dir] > 0 && proxySameProcess[dir] && protocol[dir] == NCCL_PROTO_SIMPLE && (!pxnUsed)) {
+    if (p2pTasks[dir] && p2pTasks[dir]->allowUB) {
+      if (network[dir]) {
+        bool pxnUsed = !ncclPxnDisable(comm) && comm->isAllNvlink && comm->maxLocalRanks > 1;
+        if (bytes[dir] > 0 && proxySameProcess[dir] && protocol[dir] == NCCL_PROTO_SIMPLE && (!pxnUsed)) {
+          int regFlag = 0;
+          NCCLCHECKGOTO(ncclCalloc(&handles[dir], nChannelsMax), ret, cleanup);
+          for (int part = 0; part < nChannelsMax; part++) {
+            int channelId = ncclP2pChannelForPart(comm->p2pnChannels, base, part, nChannelsMax, comm->nNodes,
+                                                  comm->p2pChannelShiftSize);
+            struct ncclChannelPeer** channelPeers = comm->channels[channelId].peers;
+            int peerRank = dir ? sendRank : recvRank;
+            struct ncclConnector* conn =
+              dir ? &channelPeers[peerRank]->send[connIndex[dir]] : &channelPeers[peerRank]->recv[connIndex[dir]];
+            if (conn->conn.flags & NCCL_DIRECT_NIC)
+              ncclRegisterP2pNetBuffer(comm, addrs[dir], bytes[dir], conn, &regFlag, &handles[dir][part],
+                                       &plan->cleanupQueue);
+            if (!regFlag) break;
+          }
+          netRegistered[dir] = regFlag ? true : false;
+        }
+      } else if (bytes[dir] > 0 && addrs[dir] && protocol[dir] == NCCL_PROTO_SIMPLE && !selfSend) {
+        int peerRank = dir ? sendRank : recvRank;
         int regFlag = 0;
-        NCCLCHECKGOTO(ncclCalloc(&handles[dir], nChannelsMax), ret, cleanup);
-        for (int part = 0; part < nChannelsMax; part++) {
-          int channelId = ncclP2pChannelForPart(comm->p2pnChannels, base, part, nChannelsMax, comm->nNodes,
-                                                comm->p2pChannelShiftSize);
-          struct ncclChannelPeer** channelPeers = comm->channels[channelId].peers;
-          int peerRank = dir ? sendRank : recvRank;
-          struct ncclConnector* conn =
-            dir ? &channelPeers[peerRank]->send[connIndex[dir]] : &channelPeers[peerRank]->recv[connIndex[dir]];
-          if (conn->conn.flags & NCCL_DIRECT_NIC)
-            ncclRegisterP2pNetBuffer(comm, addrs[dir], bytes[dir], conn, &regFlag, &handles[dir][part],
-                                     &plan->cleanupQueue);
-          if (!regFlag) break;
+        int channelId =
+          ncclP2pChannelForPart(comm->p2pnChannels, base, 0, nChannelsMax, comm->nNodes, comm->p2pChannelShiftSize);
+        struct ncclChannelPeer** channelPeers = comm->channels[channelId].peers;
+        struct ncclConnector* conn =
+          dir ? &channelPeers[peerRank]->send[connIndex[dir]] : &channelPeers[peerRank]->recv[connIndex[dir]];
+        void* regAddr = NULL;
+        if (conn->conn.flags & (NCCL_P2P_WRITE | NCCL_P2P_READ)) {
+          // We require users registering buffers on both sides
+          NCCLCHECKGOTO(ncclRegisterP2pIpcBuffer(comm, addrs[dir], bytes[dir], peerRank, &regFlag, &regAddr,
+                                                 &plan->cleanupQueue),
+                        ret, cleanup);
+          if (regFlag) {
+            if (dir == 0 && (conn->conn.flags & NCCL_P2P_WRITE)) recvAddr = regAddr;
+            else if (dir == 1 && (conn->conn.flags & NCCL_P2P_READ)) sendAddr = regAddr;
+          }
         }
-        netRegistered[dir] = regFlag ? true : false;
+        ipcRegistered[dir] = regFlag ? true : false;
       }
-    } else if (bytes[dir] > 0 && addrs[dir] && protocol[dir] == NCCL_PROTO_SIMPLE && !selfSend) {
-      int peerRank = dir ? sendRank : recvRank;
-      int regFlag = 0;
-      int channelId =
-        ncclP2pChannelForPart(comm->p2pnChannels, base, 0, nChannelsMax, comm->nNodes, comm->p2pChannelShiftSize);
-      struct ncclChannelPeer** channelPeers = comm->channels[channelId].peers;
-      struct ncclConnector* conn =
-        dir ? &channelPeers[peerRank]->send[connIndex[dir]] : &channelPeers[peerRank]->recv[connIndex[dir]];
-      void* regAddr = NULL;
-      if (conn->conn.flags & (NCCL_P2P_WRITE | NCCL_P2P_READ)) {
-        // We require users registering buffers on both sides
-        NCCLCHECKGOTO(ncclRegisterP2pIpcBuffer(comm, addrs[dir], bytes[dir], peerRank, &regFlag, &regAddr,
-                                               &plan->cleanupQueue),
-                      ret, cleanup);
-        if (regFlag) {
-          if (dir == 0 && (conn->conn.flags & NCCL_P2P_WRITE)) recvAddr = regAddr;
-          else if (dir == 1 && (conn->conn.flags & NCCL_P2P_READ)) sendAddr = regAddr;
-        }
-      }
-      ipcRegistered[dir] = regFlag ? true : false;
     }
 
     if (bytes[dir] == -1) nChannels[dir] = 0;

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -543,11 +543,6 @@ bool rcclUseAllGatherDirect(struct ncclComm* comm, size_t& msgSize) {
     return false;
   }
 
-  // Direct AllGather incompatible with UBR
-  if (ncclParamLocalRegister()) {
-    return false;
-  }
-
   if (rcclUseAinic()) {
     INFO(NCCL_INIT, "RCCL DIRECT ALLGATHER disabled on AINIC. ");
     return false;

--- a/projects/rccl/src/transport/net_ib/net_ib_flush_fault_inject.h
+++ b/projects/rccl/src/transport/net_ib/net_ib_flush_fault_inject.h
@@ -1,0 +1,37 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RCCL_NET_IB_FLUSH_FAULT_INJECT_H_
+#define RCCL_NET_IB_FLUSH_FAULT_INJECT_H_
+
+#ifdef ENABLE_FAULT_INJECTION
+
+#ifdef __cplusplus
+#include "nccl.h"  /* ncclResult_t */
+extern "C" {
+#else
+#include <stdbool.h>
+#include "nccl.h"
+#endif
+
+/*
+ * Test-only fault injection for the base net-ib GDR flush path.
+ *
+ * Implemented in src/transport/net_ib/p2p.cc (ncclIbIflush).
+ */
+
+/* Force ncclIbIflush to re-issue the pre-fix scratchpad RDMA_WRITE before the
+ * flush READ, reproducing the dma-buf QP async-fatal for the regression test;
+ * enable=false restores shipped read-only behaviour. Toggle is process-global. */
+ncclResult_t ncclIbFlushFaultForceScratchpadWrite(void* recvComm, bool enable);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* ENABLE_FAULT_INJECTION */
+
+#endif /* RCCL_NET_IB_FLUSH_FAULT_INJECT_H_ */

--- a/projects/rccl/src/transport/net_ib/p2p.cc
+++ b/projects/rccl/src/transport/net_ib/p2p.cc
@@ -11,12 +11,15 @@
 #include "p2p_resiliency.h"
 
 #ifdef ENABLE_FAULT_INJECTION
+#include <atomic>
 #include "net_ib_flush_fault_inject.h"
 // Test-only: when armed, ncclIbIflush re-issues the pre-fix scratchpad
 // RDMA_WRITE so a regression test can prove the write is what faults.
-static bool ncclIbFlushForceScratchpadWrite = false;
+// Atomic because the arm/disarm (test thread) and the read in ncclIbIflush
+// can run concurrently.
+static std::atomic<bool> ncclIbFlushForceScratchpadWrite{false};
 ncclResult_t ncclIbFlushFaultForceScratchpadWrite(void* /*recvComm*/, bool enable) {
-  ncclIbFlushForceScratchpadWrite = enable;
+  ncclIbFlushForceScratchpadWrite.store(enable, std::memory_order_relaxed);
   return ncclSuccess;
 }
 #endif
@@ -655,7 +658,7 @@ ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void**
 
 #ifdef ENABLE_FAULT_INJECTION
     // Test-only regression guard: re-issue the removed scratchpad RDMA_WRITE.
-    if (useGpuFlushMem && ncclIbFlushForceScratchpadWrite) {
+    if (useGpuFlushMem && ncclIbFlushForceScratchpadWrite.load(std::memory_order_relaxed)) {
       struct ibv_send_wr writeWr;
       memset(&writeWr, 0, sizeof(writeWr));
       writeWr.wr_id = wr.wr_id;

--- a/projects/rccl/src/transport/net_ib/p2p.cc
+++ b/projects/rccl/src/transport/net_ib/p2p.cc
@@ -11,7 +11,7 @@
 #include "p2p_resiliency.h"
 
 #ifdef ENABLE_FAULT_INJECTION
-#include "net_ib_fault_inject.h"
+#include "net_ib_flush_fault_inject.h"
 // Test-only: when armed, ncclIbIflush re-issues the pre-fix scratchpad
 // RDMA_WRITE so a regression test can prove the write is what faults.
 static bool ncclIbFlushForceScratchpadWrite = false;

--- a/projects/rccl/src/transport/net_ib/p2p.cc
+++ b/projects/rccl/src/transport/net_ib/p2p.cc
@@ -10,6 +10,17 @@
 #include "compiler.h"
 #include "p2p_resiliency.h"
 
+#ifdef ENABLE_FAULT_INJECTION
+#include "net_ib_fault_inject.h"
+// Test-only: when armed, ncclIbIflush re-issues the pre-fix scratchpad
+// RDMA_WRITE so a regression test can prove the write is what faults.
+static bool ncclIbFlushForceScratchpadWrite = false;
+ncclResult_t ncclIbFlushFaultForceScratchpadWrite(void* /*recvComm*/, bool enable) {
+  ncclIbFlushForceScratchpadWrite = enable;
+  return ncclSuccess;
+}
+#endif
+
 NCCL_PARAM(IbArThreshold, "IB_AR_THRESHOLD", -2);
 int64_t ncclIbArThreshold = 8192;
 
@@ -635,25 +646,29 @@ ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void**
   // We don't know which devIndex the recv was on, so we flush on all devices
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
     struct ibv_send_wr wr;
-    // Check if GPU flush buffer was successfully registered
-    // If not, fall back to using user data buffer for flush
+    // RO=0 scratchpad read fences the data (no RDMA_WRITE: a dma-buf scratchpad
+    // is not a valid amdgpu write target and faults the QP).
     bool useGpuFlushMem = rcclParamIbGdrFlushGpuMemNoRelaxedOrdering() &&
                           comm->devs[i].gpuFlush.gpuFlushGpuMem != nullptr && comm->devs[i].gpuFlush.gpuMr != nullptr;
     memset(&wr, 0, sizeof(wr));
-    wr.wr_id = (req - comm->base.reqs) + NCCL_IB_FLUSH_REQ_WR_ID_OFFSET;
-
-    if (useGpuFlushMem) {
-      wr.wr.rdma.remote_addr = (uint64_t)(comm->devs[i].gpuFlush.gpuFlushGpuMem);
-      wr.wr.rdma.rkey = comm->devs[i].gpuFlush.gpuMr->rkey;
-      wr.sg_list = &comm->devs[i].gpuFlush.sge;
-      wr.num_sge = 1;
-      wr.opcode = IBV_WR_RDMA_WRITE;
-      wr.send_flags = 0;
-      struct ibv_send_wr* bad_wr;
-      NCCLCHECKGOTO(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr), ret, iflushFail);
-    }
-    memset(&wr, 0, sizeof(wr));
     wr.wr_id = (uint64_t)(req - comm->base.reqs) + NCCL_IB_FLUSH_REQ_WR_ID_OFFSET;
+
+#ifdef ENABLE_FAULT_INJECTION
+    // Test-only regression guard: re-issue the removed scratchpad RDMA_WRITE.
+    if (useGpuFlushMem && ncclIbFlushForceScratchpadWrite) {
+      struct ibv_send_wr writeWr;
+      memset(&writeWr, 0, sizeof(writeWr));
+      writeWr.wr_id = wr.wr_id;
+      writeWr.wr.rdma.remote_addr = (uint64_t)(comm->devs[i].gpuFlush.gpuFlushGpuMem);
+      writeWr.wr.rdma.rkey = comm->devs[i].gpuFlush.gpuMr->rkey;
+      writeWr.sg_list = &comm->devs[i].gpuFlush.sge;
+      writeWr.num_sge = 1;
+      writeWr.opcode = IBV_WR_RDMA_WRITE;
+      writeWr.send_flags = 0;
+      struct ibv_send_wr* badWriteWr;
+      NCCLCHECKGOTO(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &writeWr, &badWriteWr), ret, iflushFail);
+    }
+#endif
     if (useGpuFlushMem) {
       wr.wr.rdma.remote_addr = (uint64_t)(comm->devs[i].gpuFlush.gpuFlushGpuMem);
       wr.wr.rdma.rkey = comm->devs[i].gpuFlush.gpuMr->rkey;

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_fault_inject.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_fault_inject.h
@@ -90,13 +90,6 @@ ncclResult_t ncclIbCastFaultOpsSetPollCqError(void* comm, int qpIdx, int wcStatu
 /* Clear all ops-overload fault config on the connection (shims stay installed). */
 ncclResult_t ncclIbCastFaultOpsClear(void* comm);
 
-/* ── base net_ib flush path (src/transport/net_ib/p2p.cc) ── */
-
-/* Force ncclIbIflush to re-issue the pre-fix scratchpad RDMA_WRITE before the
- * flush READ, reproducing the dma-buf QP async-fatal for the regression test;
- * enable=false restores shipped read-only behaviour. Toggle is process-global. */
-ncclResult_t ncclIbFlushFaultForceScratchpadWrite(void* recvComm, bool enable);
-
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_fault_inject.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_fault_inject.h
@@ -90,6 +90,13 @@ ncclResult_t ncclIbCastFaultOpsSetPollCqError(void* comm, int qpIdx, int wcStatu
 /* Clear all ops-overload fault config on the connection (shims stay installed). */
 ncclResult_t ncclIbCastFaultOpsClear(void* comm);
 
+/* ── base net_ib flush path (src/transport/net_ib/p2p.cc) ── */
+
+/* Force ncclIbIflush to re-issue the pre-fix scratchpad RDMA_WRITE before the
+ * flush READ, reproducing the dma-buf QP async-fatal for the regression test;
+ * enable=false restores shipped read-only behaviour. Toggle is process-global. */
+ncclResult_t ncclIbFlushFaultForceScratchpadWrite(void* recvComm, bool enable);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -110,7 +110,7 @@ if(BUILD_TESTS)
     ${PROJECT_BINARY_DIR}/hipify/src # for graph/topo.h
     ${PROJECT_BINARY_DIR}/hipify/src/include/plugin # for recorder tests, nccl_tuner.h
     ${PROJECT_BINARY_DIR}/hipify/src/transport/net_ib_cast # for net_ib_fault_inject.h, net_ib_cast_inspect.h
-    ${PROJECT_BINARY_DIR}/hipify/src/transport             # for net_ib_limits.h
+    ${PROJECT_BINARY_DIR}/hipify/src/transport             # for net_ib_limits.h, net_ib/net_ib_flush_fault_inject.h
     ${ROCM_PATH}/include
     ${ROCM_PATH}
   )

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -411,6 +411,7 @@ if(BUILD_TESTS)
       transport/NetMPITests.cpp
       transport/ShmMPITests.cpp
       transport/NetIbMPI/GeneralTests.cpp
+      transport/NetIbMPI/GdrFlushTests.cpp
       transport/NetIbMPI/NicFusionTests.cpp
       transport/NetIbMPI/CastTests.cpp
       transport/NetIbMPI/FaultInjectTests.cpp

--- a/projects/rccl/test/RegistrationMPITests.cpp
+++ b/projects/rccl/test/RegistrationMPITests.cpp
@@ -367,6 +367,142 @@ TEST_F(UBR_AllGather, OutOfPlace_MultiNode)
     ASSERT_TRUE(verifyAllGatherResult<T>(recvInfo.buffer, countPerRank, nRanks));
 }
 
+// Direct AllGather + UBR coexistence: Direct AllGather stays default under
+// NCCL_LOCAL_REGISTER; P2P registration is gated per-op on ncclTaskP2p::allowUB.
+class UBR_DirectAllGather : public RegistrationTestBase
+{
+protected:
+    using T = RegTestConfig::DefaultType;
+
+    // Counts straddle the P2P LL<->SIMPLE boundary and the Direct AllGather
+    // threshold, exercising the registered path on both sides of the transition.
+    static std::vector<size_t> sweepCountsPerRank()
+    {
+        return {256, 4 * 1024, 256 * 1024, 4 * 1024 * 1024};
+    }
+
+    // Out-of-place AllGather + verify. registered=true -> UBR path (allowUB=true),
+    // false -> baseline. Reg-handle guards destruct before buffer guards (dereg then free).
+    void runAllGatherOnce(size_t countPerRank, bool registered)
+    {
+        int rank = 0, nRanks = 0;
+        RCCL_TEST_CHECK_GTEST_FAIL(ncclCommUserRank(getActiveCommunicator(), &rank));
+        RCCL_TEST_CHECK_GTEST_FAIL(ncclCommCount(getActiveCommunicator(), &nRanks));
+
+        const size_t sendBytes = countPerRank * sizeof(T);
+        const size_t recvBytes = countPerRank * static_cast<size_t>(nRanks) * sizeof(T);
+
+        void* sendBuf = nullptr;
+        void* recvBuf = nullptr;
+        HIP_TEST_CHECK_GTEST_FAIL(hipMalloc(&sendBuf, sendBytes));
+        auto sendBufGuard = makeDeviceBufferAutoGuard(sendBuf);
+        HIP_TEST_CHECK_GTEST_FAIL(hipMalloc(&recvBuf, recvBytes));
+        auto recvBufGuard = makeDeviceBufferAutoGuard(recvBuf);
+
+        // Declared after buffer guards so they destruct first; null handle is a
+        // no-op in the deleter, so these stay empty on the baseline path.
+        NcclRegHandleGuard sendRegGuard;
+        NcclRegHandleGuard recvRegGuard;
+        if (registered) {
+            void* sendH = nullptr;
+            void* recvH = nullptr;
+            RCCL_TEST_CHECK_GTEST_FAIL(
+                ncclCommRegister(getActiveCommunicator(), sendBuf, sendBytes, &sendH));
+            RCCL_TEST_CHECK_GTEST_FAIL(
+                ncclCommRegister(getActiveCommunicator(), recvBuf, recvBytes, &recvH));
+            ASSERT_MPI_NE(sendH, nullptr);
+            ASSERT_MPI_NE(recvH, nullptr);
+            sendRegGuard = makeRegHandleGuard(sendH, getActiveCommunicator());
+            recvRegGuard = makeRegHandleGuard(recvH, getActiveCommunicator());
+        }
+
+        initSendBuffer<T>(sendBuf, countPerRank, rank);
+        HIP_TEST_CHECK_GTEST_FAIL(hipMemset(recvBuf, 0, recvBytes));
+
+        RCCL_TEST_CHECK_GTEST_FAIL(
+            ncclAllGather(sendBuf, recvBuf, countPerRank, getNcclDataType<T>(),
+                          getActiveCommunicator(), getActiveStream()));
+        HIP_TEST_CHECK_GTEST_FAIL(hipStreamSynchronize(getActiveStream()));
+
+        EXPECT_TRUE(verifyAllGatherResult<T>(recvBuf, countPerRank, nRanks))
+            << "AllGather data incorrect (registered=" << registered
+            << ", countPerRank=" << countPerRank << ")";
+    }
+};
+
+// Registered Direct AllGather across the LL<->SIMPLE transition (intra-node IPC
+// path); 2+ ranks on one node. Net path covered by the _MultiNode variant below.
+TEST_F(UBR_DirectAllGather, UbrSizeSweep)
+{
+    if (!validateTestPrerequisites(RegTestConfig::MIN_RANKS_DEFAULT)) {
+        GTEST_SKIP() << "Requires 2+ ranks";
+    }
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ASSERT_TRUE(isUBREnabled()) << "NCCL_LOCAL_REGISTER must be set to 1";
+
+    for (size_t count : sweepCountsPerRank()) {
+        SCOPED_TRACE("countPerRank=" + std::to_string(count));
+        runAllGatherOnce(count, /*registered=*/true);
+    }
+
+    if (isPerRankLoggingEnabled()) {
+        REGLogChecker checker = getLogChecker();
+        TEST_INFO("UbrSizeSweep: %s (log size: %zu bytes)",
+                  checker.getSummary().c_str(), checker.getContentLength());
+        EXPECT_TRUE(checker.hasAnyRegistrationSuccess())
+            << "Expected the UBR registration path to engage for the registered "
+               "Direct AllGather under NCCL_LOCAL_REGISTER=1";
+    }
+}
+
+// Same sweep across nodes (exercises the net/DMA-buf registration path).
+TEST_F(UBR_DirectAllGather, UbrSizeSweep_MultiNode)
+{
+    if (!setupMultiNode(RegTestConfig::MIN_RANKS_DEFAULT, RegTestConfig::MIN_NODES_MULTINODE)) {
+        GTEST_SKIP() << "Requires 2+ nodes";
+    }
+    ASSERT_TRUE(isUBREnabled()) << "NCCL_LOCAL_REGISTER must be set to 1";
+
+    for (size_t count : sweepCountsPerRank()) {
+        SCOPED_TRACE("countPerRank=" + std::to_string(count));
+        runAllGatherOnce(count, /*registered=*/true);
+    }
+
+    if (isPerRankLoggingEnabled()) {
+        REGLogChecker checker = getLogChecker();
+        TEST_INFO("UbrSizeSweep_MultiNode: %s (log size: %zu bytes)",
+                  checker.getSummary().c_str(), checker.getContentLength());
+    }
+}
+
+// Before/after in one process: unregistered (allowUB=false) then registered
+// (allowUB=true) AllGather must both be correct; the allowUB gating changes nothing.
+TEST_F(UBR_DirectAllGather, BaselineVsUbrEquivalence)
+{
+    if (!validateTestPrerequisites(RegTestConfig::MIN_RANKS_DEFAULT)) {
+        GTEST_SKIP() << "Requires 2+ ranks";
+    }
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ASSERT_TRUE(isUBREnabled()) << "NCCL_LOCAL_REGISTER must be set to 1";
+
+    const size_t countPerRank = RegTestConfig::MEDIUM_COUNT;
+
+    // BEFORE: unregistered (baseline path).
+    runAllGatherOnce(countPerRank, /*registered=*/false);
+
+    // AFTER: registered (UBR path).
+    runAllGatherOnce(countPerRank, /*registered=*/true);
+
+    if (isPerRankLoggingEnabled()) {
+        REGLogChecker checker = getLogChecker();
+        TEST_INFO("BaselineVsUbrEquivalence: %s (log size: %zu bytes)",
+                  checker.getSummary().c_str(), checker.getContentLength());
+        EXPECT_TRUE(checker.hasAnyRegistrationSuccess())
+            << "Expected UBR registration to engage for the registered AllGather "
+               "(allowUB=true) under NCCL_LOCAL_REGISTER=1";
+    }
+}
+
 class UBR_ReduceScatter : public RegistrationTestBase {};
 
 TEST_F(UBR_ReduceScatter, OutOfPlace_MultiNode)

--- a/projects/rccl/test/RegistrationMPITests.cpp
+++ b/projects/rccl/test/RegistrationMPITests.cpp
@@ -103,6 +103,20 @@ public:
         return hasPattern("failed to NET register");
     }
 
+    // Direct AllGather path selection (requires NCCL_DEBUG_SUBSYS to include TUNING for
+    // the "used" marker and INIT for the "disabled" markers).
+    bool usedDirectAllGather() const
+    {
+        return hasPattern("RCCL DIRECT ALLGATHER count");
+    }
+
+    bool directAllGatherDisabled() const
+    {
+        return hasPattern("RCCL DIRECT ALLGATHER has been disabled") ||
+               hasPattern("RCCL DIRECT ALLGATHER disabled") ||
+               hasPattern("Direct AllGather disabled");
+    }
+
     std::string getSummary() const
     {
         std::ostringstream ss;
@@ -113,6 +127,8 @@ public:
         if (hasNETRegistration()) ss << "[NET-REG] ";
         if (hasIPCFailure()) ss << "[IPC-FAIL] ";
         if (hasNETFailure()) ss << "[NET-FAIL] ";
+        if (usedDirectAllGather()) ss << "[DIRECT-AG] ";
+        if (directAllGatherDisabled()) ss << "[DIRECT-AG-OFF] ";
         if (!hasAnyRegistrationSuccess() && !hasIPCFailure() && !hasNETFailure()) ss << "[NO-REG]";
         return ss.str();
     }
@@ -145,7 +161,8 @@ protected:
         RegInfo info;
         info.size = size;
 
-        if (hipMalloc(&info.buffer, size) != hipSuccess) {
+        // VMM-aware so registration exercises the cuMem path when cuMem is on.
+        if (allocateDeviceBuffer(&info.buffer, size) != ncclSuccess) {
             return info;
         }
 
@@ -163,7 +180,7 @@ protected:
             info.handle = nullptr;
         }
         if (info.buffer) {
-            (void)hipFree(info.buffer);
+            (void)freeDeviceBuffer(info.buffer);
             info.buffer = nullptr;
         }
         info.registered = false;
@@ -367,12 +384,102 @@ TEST_F(UBR_AllGather, OutOfPlace_MultiNode)
     ASSERT_TRUE(verifyAllGatherResult<T>(recvInfo.buffer, countPerRank, nRanks));
 }
 
+// GDR flush over cuMem/DMA-BUF (regression guard). The NET/IB GDR flush fences
+// relaxed-ordering writes with a RO=0 GPU scratchpad. The pre-fix code also issued
+// an RDMA_WRITE into that scratchpad; on a dma-buf-backed scratchpad (cuMem/UBR)
+// amdgpu can't resolve it as a writable RDMA target, so mlx5 faults the QP
+// ("invalid request local work queue error") and the collective hangs. The fix
+// removes the WRITE and keeps the RO=0 READ fence, so it completes cleanly.
+// Requires NCCL_CUMEM_ENABLE=1 cross-node; if GDR is absent the flush is a no-op.
+class GdrFlush_CuMem : public RegistrationTestBase {};
+
+TEST_F(GdrFlush_CuMem, AllGatherUnregistered_MultiNode)
+{
+    if (!setupMultiNode(RegTestConfig::MIN_RANKS_DEFAULT, RegTestConfig::MIN_NODES_MULTINODE)) {
+        GTEST_SKIP() << "Requires 2+ nodes (cross-node NET/IB GDR path)";
+    }
+
+    ASSERT_TRUE(isCuMemEnabled())
+        << "NCCL_CUMEM_ENABLE must be set to 1 (exercises the cuMem GDR flush path)";
+
+    using T = RegTestConfig::DefaultType;
+
+    int rank, nRanks;
+    ncclCommUserRank(getActiveCommunicator(), &rank);
+    ncclCommCount(getActiveCommunicator(), &nRanks);
+
+    // The GDR flush only runs on the SIMPLE protocol (large messages); LL/LL128 used
+    // for small messages skips it. Sweep up to a few MB per rank so the cross-node
+    // recv takes the SIMPLE + GDR-flush path where the pre-fix fault occurs.
+    const std::vector<size_t> countsPerRank = {
+        RegTestConfig::SMALL_COUNT,        // ~2 KB  (LL)
+        RegTestConfig::MEDIUM_COUNT,       // ~512 KB (LL128/SIMPLE)
+        RegTestConfig::LARGE_COUNT,        // ~2 MB  (SIMPLE)
+        4 * RegTestConfig::LARGE_COUNT     // ~8 MB  (SIMPLE)
+    };
+
+    for (size_t countPerRank : countsPerRank) {
+        // Plain (unregistered) device buffers so the transfer takes the base GDR
+        // recv+flush path, independent of user-buffer registration.
+        void* sendBuf = nullptr;
+        void* recvBuf = nullptr;
+        ASSERT_MPI_EQ(ncclSuccess, allocateDeviceBuffer(&sendBuf, countPerRank * sizeof(T)));
+        ASSERT_MPI_EQ(ncclSuccess, allocateDeviceBuffer(&recvBuf, countPerRank * nRanks * sizeof(T)));
+        auto cleanup = makeScopeGuard([&]() {
+            if (sendBuf) (void)freeDeviceBuffer(sendBuf);
+            if (recvBuf) (void)freeDeviceBuffer(recvBuf);
+        });
+
+        initSendBuffer<T>(sendBuf, countPerRank, rank);
+
+        ncclResult_t result = ncclAllGather(sendBuf, recvBuf, countPerRank,
+                                            getNcclDataType<T>(),
+                                            getActiveCommunicator(), getActiveStream());
+        ASSERT_MPI_EQ(ncclSuccess, result);
+        ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+        ASSERT_TRUE(verifyAllGatherResult<T>(recvBuf, countPerRank, nRanks))
+            << "AllGather data incorrect over cuMem GDR path (countPerRank=" << countPerRank << ")";
+    }
+}
+
 // Direct AllGather + UBR coexistence: Direct AllGather stays default under
 // NCCL_LOCAL_REGISTER; P2P registration is gated per-op on ncclTaskP2p::allowUB.
 class UBR_DirectAllGather : public RegistrationTestBase
 {
 protected:
     using T = RegTestConfig::DefaultType;
+
+    // Direct AllGather is pinned only when the launcher/config sets NCCL_LAUNCH_ORDER_IMPLICIT=1
+    // and RCCL_DIRECT_ALLGATHER_THRESHOLD past every swept size; verified below (GTEST_SKIP if not).
+    static constexpr unsigned long long kMinDirectAllGatherThreshold = 2147483648ULL;
+
+    void SetUp() override
+    {
+        RegistrationTestBase::SetUp();
+        if (::testing::Test::IsSkipped() || ::testing::Test::HasFatalFailure()) {
+            return;
+        }
+
+        const char* launchOrder = getenv("NCCL_LAUNCH_ORDER_IMPLICIT");
+        if (!launchOrder || std::string(launchOrder) != "1") {
+            GTEST_SKIP() << "Requires NCCL_LAUNCH_ORDER_IMPLICIT=1 so the DDA "
+                            "fast-path is disabled and rcclSelectAllGatherAlgo() "
+                            "can select the Direct AllGather path under test. Set "
+                            "it in the test config env_variables.";
+        }
+
+        const char* threshold = getenv("RCCL_DIRECT_ALLGATHER_THRESHOLD");
+        const unsigned long long thresholdVal =
+            threshold ? std::strtoull(threshold, nullptr, 10) : 0ULL;
+        if (thresholdVal < kMinDirectAllGatherThreshold) {
+            GTEST_SKIP() << "Requires RCCL_DIRECT_ALLGATHER_THRESHOLD >= "
+                         << kMinDirectAllGatherThreshold << " (raised past every "
+                            "swept size) so Direct AllGather is selected and the "
+                            "user-threshold flag bypasses arch auto-gating. Set it "
+                            "in the test config env_variables.";
+        }
+    }
 
     // Counts straddle the P2P LL<->SIMPLE boundary and the Direct AllGather
     // threshold, exercising the registered path on both sides of the transition.
@@ -386,18 +493,19 @@ protected:
     void runAllGatherOnce(size_t countPerRank, bool registered)
     {
         int rank = 0, nRanks = 0;
-        RCCL_TEST_CHECK_GTEST_FAIL(ncclCommUserRank(getActiveCommunicator(), &rank));
-        RCCL_TEST_CHECK_GTEST_FAIL(ncclCommCount(getActiveCommunicator(), &nRanks));
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommUserRank(getActiveCommunicator(), &rank));
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommCount(getActiveCommunicator(), &nRanks));
 
         const size_t sendBytes = countPerRank * sizeof(T);
         const size_t recvBytes = countPerRank * static_cast<size_t>(nRanks) * sizeof(T);
 
+        // VMM-aware so registration exercises the cuMem path when cuMem is on.
         void* sendBuf = nullptr;
         void* recvBuf = nullptr;
-        HIP_TEST_CHECK_GTEST_FAIL(hipMalloc(&sendBuf, sendBytes));
-        auto sendBufGuard = makeDeviceBufferAutoGuard(sendBuf);
-        HIP_TEST_CHECK_GTEST_FAIL(hipMalloc(&recvBuf, recvBytes));
-        auto recvBufGuard = makeDeviceBufferAutoGuard(recvBuf);
+        ASSERT_MPI_EQ(ncclSuccess, allocateDeviceBuffer(&sendBuf, sendBytes));
+        auto sendBufGuard = makeHipMemBufferAutoGuard(sendBuf);
+        ASSERT_MPI_EQ(ncclSuccess, allocateDeviceBuffer(&recvBuf, recvBytes));
+        auto recvBufGuard = makeHipMemBufferAutoGuard(recvBuf);
 
         // Declared after buffer guards so they destruct first; null handle is a
         // no-op in the deleter, so these stay empty on the baseline path.
@@ -406,9 +514,9 @@ protected:
         if (registered) {
             void* sendH = nullptr;
             void* recvH = nullptr;
-            RCCL_TEST_CHECK_GTEST_FAIL(
+            ASSERT_MPI_EQ(ncclSuccess,
                 ncclCommRegister(getActiveCommunicator(), sendBuf, sendBytes, &sendH));
-            RCCL_TEST_CHECK_GTEST_FAIL(
+            ASSERT_MPI_EQ(ncclSuccess,
                 ncclCommRegister(getActiveCommunicator(), recvBuf, recvBytes, &recvH));
             ASSERT_MPI_NE(sendH, nullptr);
             ASSERT_MPI_NE(recvH, nullptr);
@@ -417,16 +525,40 @@ protected:
         }
 
         initSendBuffer<T>(sendBuf, countPerRank, rank);
-        HIP_TEST_CHECK_GTEST_FAIL(hipMemset(recvBuf, 0, recvBytes));
+        ASSERT_MPI_EQ(hipSuccess, hipMemset(recvBuf, 0, recvBytes));
 
-        RCCL_TEST_CHECK_GTEST_FAIL(
+        ASSERT_MPI_EQ(ncclSuccess,
             ncclAllGather(sendBuf, recvBuf, countPerRank, getNcclDataType<T>(),
                           getActiveCommunicator(), getActiveStream()));
-        HIP_TEST_CHECK_GTEST_FAIL(hipStreamSynchronize(getActiveStream()));
+        ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
 
         EXPECT_TRUE(verifyAllGatherResult<T>(recvBuf, countPerRank, nRanks))
             << "AllGather data incorrect (registered=" << registered
             << ", countPerRank=" << countPerRank << ")";
+    }
+
+    // Assert the registered Direct AllGather path was selected and engaged IPC (and
+    // NET when expectNetReg) UBR registration. No-op unless per-rank logging is on.
+    void expectDirectAllGatherRegistered(const char* label, bool expectNetReg)
+    {
+        if (!isPerRankLoggingEnabled()) return;
+
+        REGLogChecker checker = getLogChecker();
+        TEST_INFO("%s: %s (log size: %zu bytes)", label,
+                  checker.getSummary().c_str(), checker.getContentLength());
+
+        EXPECT_TRUE(checker.usedDirectAllGather())
+            << label << ": Direct AllGather was not selected, so the registered "
+               "Direct AllGather path is unverified (needs 8 ranks/node and "
+               "NCCL_DEBUG_SUBSYS to include TUNING)";
+        if (expectNetReg) {
+            EXPECT_TRUE(checker.hasNETRegistration())
+                << label << ": expected inter-node P2P NET UBR registration to "
+                   "engage across nodes for the registered Direct AllGather";
+        }
+        EXPECT_TRUE(checker.hasIPCRegistration())
+            << label << ": expected intra-node P2P IPC UBR registration to engage "
+               "for the registered Direct AllGather under NCCL_LOCAL_REGISTER=1";
     }
 };
 
@@ -445,14 +577,7 @@ TEST_F(UBR_DirectAllGather, UbrSizeSweep)
         runAllGatherOnce(count, /*registered=*/true);
     }
 
-    if (isPerRankLoggingEnabled()) {
-        REGLogChecker checker = getLogChecker();
-        TEST_INFO("UbrSizeSweep: %s (log size: %zu bytes)",
-                  checker.getSummary().c_str(), checker.getContentLength());
-        EXPECT_TRUE(checker.hasAnyRegistrationSuccess())
-            << "Expected the UBR registration path to engage for the registered "
-               "Direct AllGather under NCCL_LOCAL_REGISTER=1";
-    }
+    expectDirectAllGatherRegistered("UbrSizeSweep", /*expectNetReg=*/false);
 }
 
 // Same sweep across nodes (exercises the net/DMA-buf registration path).
@@ -468,11 +593,7 @@ TEST_F(UBR_DirectAllGather, UbrSizeSweep_MultiNode)
         runAllGatherOnce(count, /*registered=*/true);
     }
 
-    if (isPerRankLoggingEnabled()) {
-        REGLogChecker checker = getLogChecker();
-        TEST_INFO("UbrSizeSweep_MultiNode: %s (log size: %zu bytes)",
-                  checker.getSummary().c_str(), checker.getContentLength());
-    }
+    expectDirectAllGatherRegistered("UbrSizeSweep_MultiNode", /*expectNetReg=*/true);
 }
 
 // Before/after in one process: unregistered (allowUB=false) then registered
@@ -493,18 +614,7 @@ TEST_F(UBR_DirectAllGather, BaselineVsUbrEquivalence)
     // AFTER: registered (UBR path).
     runAllGatherOnce(countPerRank, /*registered=*/true);
 
-    if (isPerRankLoggingEnabled()) {
-        // Registration engagement is advisory here: on a single node at this size
-        // the AllGather may take the CE path (no P2P UBR reg), which is expected.
-        REGLogChecker checker = getLogChecker();
-        TEST_INFO("BaselineVsUbrEquivalence: %s (log size: %zu bytes)",
-                  checker.getSummary().c_str(), checker.getContentLength());
-        if (!checker.hasAnyRegistrationSuccess()) {
-            TEST_INFO("BaselineVsUbrEquivalence: no P2P UBR registration marker at "
-                      "countPerRank=%zu (CE path likely used); equivalence still verified",
-                      countPerRank);
-        }
-    }
+    expectDirectAllGatherRegistered("BaselineVsUbrEquivalence", /*expectNetReg=*/false);
 }
 
 class UBR_ReduceScatter : public RegistrationTestBase {};
@@ -1407,8 +1517,8 @@ protected:
         size_t bufSize = countPerBuffer * sizeof(T);
 
         for (int i = 0; i < nPeers; i++) {
-            // Allocate SEPARATE buffer for each peer
-            if (hipMalloc(&info.buffers[i], bufSize) != hipSuccess) {
+            // Allocate SEPARATE buffer for each peer (VMM-aware for cuMem builds)
+            if (allocateDeviceBuffer(&info.buffers[i], bufSize) != ncclSuccess) {
                 cleanupMultiBuffers(info);
                 return info;
             }
@@ -1434,7 +1544,7 @@ protected:
                 info.handles[i] = nullptr;
             }
             if (info.buffers[i]) {
-                (void)hipFree(info.buffers[i]);
+                (void)freeDeviceBuffer(info.buffers[i]);
                 info.buffers[i] = nullptr;
             }
         }
@@ -1460,8 +1570,8 @@ protected:
 
         size_t totalSize = countPerView * nViews * sizeof(T);
 
-        // Allocate ONE contiguous buffer
-        if (hipMalloc(&info.contiguousBuffer, totalSize) != hipSuccess) {
+        // Allocate ONE contiguous buffer (VMM-aware for cuMem builds)
+        if (allocateDeviceBuffer(&info.contiguousBuffer, totalSize) != ncclSuccess) {
             return info;
         }
 
@@ -1470,7 +1580,7 @@ protected:
                                                 info.contiguousBuffer, totalSize,
                                                 &info.handle);
         if (result != ncclSuccess) {
-            (void)hipFree(info.contiguousBuffer);
+            (void)freeDeviceBuffer(info.contiguousBuffer);
             info.contiguousBuffer = nullptr;
             return info;
         }
@@ -1492,7 +1602,7 @@ protected:
             info.handle = nullptr;
         }
         if (info.contiguousBuffer) {
-            (void)hipFree(info.contiguousBuffer);
+            (void)freeDeviceBuffer(info.contiguousBuffer);
             info.contiguousBuffer = nullptr;
         }
         info.views.clear();
@@ -1943,14 +2053,14 @@ TEST_F(UBR_ConcurrentRegHang, SeparateBuffers_NoRegistration_SHOULD_WORK)
 
     auto cleanup = makeScopeGuard([&]() {
         for (int i = 0; i < nRanks; i++) {
-            if (sendBufs[i]) (void)hipFree(sendBufs[i]);
-            if (recvBufs[i]) (void)hipFree(recvBufs[i]);
+            if (sendBufs[i]) (void)freeDeviceBuffer(sendBufs[i]);
+            if (recvBufs[i]) (void)freeDeviceBuffer(recvBufs[i]);
         }
     });
 
     for (int i = 0; i < nRanks; i++) {
-        ASSERT_MPI_EQ(hipSuccess, hipMalloc(&sendBufs[i], bufSize));
-        ASSERT_MPI_EQ(hipSuccess, hipMalloc(&recvBufs[i], bufSize));
+        ASSERT_MPI_EQ(ncclSuccess, allocateDeviceBuffer(&sendBufs[i], bufSize));
+        ASSERT_MPI_EQ(ncclSuccess, allocateDeviceBuffer(&recvBufs[i], bufSize));
     }
 
     // Initialize
@@ -2020,12 +2130,12 @@ TEST_F(GraphCapture_AllToAll, MultiNode)
     void* sendBuf = nullptr;
     void* recvBuf = nullptr;
 
-    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&sendBuf, bufSize));
-    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&recvBuf, bufSize));
+    ASSERT_MPI_EQ(ncclSuccess, allocateDeviceBuffer(&sendBuf, bufSize));
+    ASSERT_MPI_EQ(ncclSuccess, allocateDeviceBuffer(&recvBuf, bufSize));
 
     auto bufCleanup = makeScopeGuard([&]() {
-        if (sendBuf) (void)hipFree(sendBuf);
-        if (recvBuf) (void)hipFree(recvBuf);
+        if (sendBuf) (void)freeDeviceBuffer(sendBuf);
+        if (recvBuf) (void)freeDeviceBuffer(recvBuf);
     });
 
     ASSERT_MPI_EQ(hipSuccess, initializeBufferWithPattern<T>(sendBuf, totalCount,
@@ -2107,12 +2217,12 @@ TEST_F(GraphCapture_AllReduce, MultiNode)
     void* sendBuf = nullptr;
     void* recvBuf = nullptr;
 
-    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&sendBuf, bufSize));
-    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&recvBuf, bufSize));
+    ASSERT_MPI_EQ(ncclSuccess, allocateDeviceBuffer(&sendBuf, bufSize));
+    ASSERT_MPI_EQ(ncclSuccess, allocateDeviceBuffer(&recvBuf, bufSize));
 
     auto bufCleanup = makeScopeGuard([&]() {
-        if (sendBuf) (void)hipFree(sendBuf);
-        if (recvBuf) (void)hipFree(recvBuf);
+        if (sendBuf) (void)freeDeviceBuffer(sendBuf);
+        if (recvBuf) (void)freeDeviceBuffer(recvBuf);
     });
 
     initSendBuffer<T>(sendBuf, count, rank);
@@ -2212,9 +2322,9 @@ protected:
     {
         sendInfo.size = recvInfo.size = size;
 
-        if (hipMalloc(&sendInfo.buffer, size) != hipSuccess) return false;
-        if (hipMalloc(&recvInfo.buffer, size) != hipSuccess) {
-            (void)hipFree(sendInfo.buffer);
+        if (allocateDeviceBuffer(&sendInfo.buffer, size) != ncclSuccess) return false;
+        if (allocateDeviceBuffer(&recvInfo.buffer, size) != ncclSuccess) {
+            (void)freeDeviceBuffer(sendInfo.buffer);
             sendInfo.buffer = nullptr;
             return false;
         }
@@ -2231,7 +2341,7 @@ protected:
     {
         auto cleanup = [&](RegInfo& info) {
             if (info.handle) { ncclCommDeregister(comm, info.handle); info.handle = nullptr; }
-            if (info.buffer) { (void)hipFree(info.buffer); info.buffer = nullptr; }
+            if (info.buffer) { (void)freeDeviceBuffer(info.buffer); info.buffer = nullptr; }
             info.registered = false;
         };
         cleanup(sendInfo);

--- a/projects/rccl/test/RegistrationMPITests.cpp
+++ b/projects/rccl/test/RegistrationMPITests.cpp
@@ -494,12 +494,16 @@ TEST_F(UBR_DirectAllGather, BaselineVsUbrEquivalence)
     runAllGatherOnce(countPerRank, /*registered=*/true);
 
     if (isPerRankLoggingEnabled()) {
+        // Registration engagement is advisory here: on a single node at this size
+        // the AllGather may take the CE path (no P2P UBR reg), which is expected.
         REGLogChecker checker = getLogChecker();
         TEST_INFO("BaselineVsUbrEquivalence: %s (log size: %zu bytes)",
                   checker.getSummary().c_str(), checker.getContentLength());
-        EXPECT_TRUE(checker.hasAnyRegistrationSuccess())
-            << "Expected UBR registration to engage for the registered AllGather "
-               "(allowUB=true) under NCCL_LOCAL_REGISTER=1";
+        if (!checker.hasAnyRegistrationSuccess()) {
+            TEST_INFO("BaselineVsUbrEquivalence: no P2P UBR registration marker at "
+                      "countPerRank=%zu (CE path likely used); equivalence still verified",
+                      countPerRank);
+        }
     }
 }
 

--- a/projects/rccl/test/common/DeviceBufferHelpers.hpp
+++ b/projects/rccl/test/common/DeviceBufferHelpers.hpp
@@ -109,6 +109,38 @@ constexpr const char* getTypeName()
     return NcclTypeTraits<T>::name;
 }
 
+/**
+ * @brief VMM-aware device allocation for registrable buffers
+ *
+ * Routes through ncclMemAlloc so the buffer is cuMem/VMM memory when cuMem is
+ * enabled and hipMalloc otherwise. Use this instead of a raw hipMalloc for any
+ * buffer that will be ncclCommRegister'd, so tests exercise the same memory type
+ * production uses. Free with freeDeviceBuffer (or makeHipMemBufferAutoGuard),
+ * never hipFree.
+ *
+ * @param[out] ptr   Receives the allocated device buffer pointer
+ * @param      bytes Allocation size in bytes
+ * @return ncclSuccess on success, otherwise the failing ncclResult_t
+ */
+inline ncclResult_t allocateDeviceBuffer(void** ptr, size_t bytes)
+{
+    return ncclMemAlloc(ptr, bytes);
+}
+
+/**
+ * @brief Free a buffer allocated with allocateDeviceBuffer
+ *
+ * Unmaps and releases the VMM handle when cuMem is enabled, falls back to
+ * hipFree otherwise.
+ *
+ * @param ptr Device buffer previously returned by allocateDeviceBuffer
+ * @return ncclSuccess on success, otherwise the failing ncclResult_t
+ */
+inline ncclResult_t freeDeviceBuffer(void* ptr)
+{
+    return ncclMemFree(ptr);
+}
+
 // ============================================================================
 // Device Buffer Initialization
 // ============================================================================

--- a/projects/rccl/test/common/ResourceGuards.hpp
+++ b/projects/rccl/test/common/ResourceGuards.hpp
@@ -353,6 +353,24 @@ inline void hipFreeWrapper(void* ptr)
     }
 }
 
+// Frees buffers from allocateDeviceBuffer/ncclMemAlloc; a VMM buffer must go
+// through ncclMemFree, not hipFree.
+inline void ncclMemFreeWrapper(void* ptr)
+{
+    if(ptr)
+    {
+        ncclResult_t result = ncclMemFree(ptr);
+        if(result != ncclSuccess)
+        {
+            fprintf(stderr,
+                    "WARNING: rank %s: ncclMemFree failed in destructor: %s (ptr=%p)\n",
+                    getMpiRankStr(),
+                    ncclGetErrorString(result),
+                    ptr);
+        }
+    }
+}
+
 inline void hipStreamDestroyWrapper(hipStream_t stream)
 {
     if(stream)
@@ -409,6 +427,7 @@ inline void freeWrapper(void* ptr)
 // Type aliases for AutoGuard-based guards
 using HostBufferAutoGuard   = AutoGuard<void*, freeWrapper>;
 using DeviceBufferAutoGuard = AutoGuard<void*, hipFreeWrapper>;
+using HipMemBufferAutoGuard = AutoGuard<void*, ncclMemFreeWrapper>;
 using HipStreamAutoGuard    = AutoGuard<hipStream_t, hipStreamDestroyWrapper>;
 using HipEventAutoGuard     = AutoGuard<hipEvent_t, hipEventDestroyWrapper>;
 using NcclCommAutoGuard     = AutoGuard<ncclComm_t, ncclCommDestroyWrapper>;
@@ -449,6 +468,12 @@ inline HostBufferAutoGuard makeHostBufferAutoGuard(void* buffer)
 inline DeviceBufferAutoGuard makeDeviceBufferAutoGuard(void* buffer)
 {
     return DeviceBufferAutoGuard(buffer);
+}
+
+// RAII guard for allocateDeviceBuffer/ncclMemAlloc buffers (frees via ncclMemFree).
+inline HipMemBufferAutoGuard makeHipMemBufferAutoGuard(void* buffer)
+{
+    return HipMemBufferAutoGuard(buffer);
 }
 
 inline HipStreamAutoGuard makeStreamAutoGuard(hipStream_t stream)

--- a/projects/rccl/test/transport/NetIbMPI/GdrFlushTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/GdrFlushTests.cpp
@@ -1,0 +1,233 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Whitebox tests for the NET/IB GPU-Direct-RDMA flush (ncclIbIflush).
+//
+// Background: RCCL's GDR flush issues a loopback RDMA_READ against a dedicated
+// RO=0 GPU scratchpad to fence relaxed-ordering data writes. A prior version
+// also issued an RDMA_WRITE into that scratchpad; on a dma-buf-backed (cuMem/UBR)
+// scratchpad amdgpu cannot resolve the tiny allocation as a writable RDMA
+// target, so mlx5 rejected the WRITE with "invalid request local work queue
+// error" and tore down the flush QP. The fix removed the redundant WRITE.
+//
+// These tests exercise ncclIbIflush directly over a 2-rank loopback connection
+// (single-node capable), covering both scratchpad backends, the feature-disabled
+// fallback, a repeated-flush burst, and - under ENABLE_FAULT_INJECTION - a
+// regression guard that forces the removed WRITE back and asserts it faults.
+
+#include "NetIbMPITestBase.hpp"
+#include "NetIbFaultInject.hpp"
+
+#ifdef MPI_TESTS_ENABLED
+
+namespace {
+
+class GdrFlushTest : public NetIbMPITest {
+protected:
+    // NCCL_CUMEM_ENABLE=1 makes the flush scratchpad dma-buf-backed (the path
+    // that used to fault). Absent/0 selects the legacy peermem reg_mr path.
+    static bool cuMemEnabledEnv() {
+        const char* v = getenv("NCCL_CUMEM_ENABLE");
+        return v && atoi(v) != 0;
+    }
+
+    // The dedicated RO=0 scratchpad flush (default on). When 0, ncclIbIflush
+    // falls back to reading the received buffer directly (upstream-NCCL style).
+    static bool scratchpadFlushEnabled() {
+        const char* v = getenv("RCCL_GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING");
+        return !v || atoi(v) != 0;
+    }
+
+    bool gdrSupported() {
+        ncclNetProperties_t props;
+        if (GetDeviceProperties(0, &props) != ncclSuccess) return false;
+        return (props.ptrSupport & NCCL_PTR_CUDA) != 0;
+    }
+
+    // Runs `iterations` of GPU recv + flush across 2 ranks on device 0.
+    // rank 0 = receiver + flush, rank 1 = sender. Returns rank 0's last flush
+    // completion result via `rank0LastFlush` (may be null). When `forceWrite` is
+    // set (ENABLE_FAULT_INJECTION only) the receiver re-issues the removed
+    // scratchpad RDMA_WRITE to reproduce the historical fault.
+    //
+    // The data buffer is plain hipMalloc so the whitebox regMr(NCCL_PTR_CUDA)
+    // succeeds (raw VMM pointers require regMrDmaBuf). The faulting scratchpad is
+    // the recv comm's INTERNAL gpuFlush, which becomes dma-buf-backed purely from
+    // NCCL_CUMEM_ENABLE=1 - independent of the data buffer's allocator.
+    void RunRecvFlushBurst(int iterations, bool verifyData,
+                           bool forceWrite, ncclResult_t* rank0LastFlush) {
+        const int rank = MPIEnvironment::world_rank;
+
+        AssertInitAndGetDevices(nullptr);
+
+        ConnectionPair pair;
+        NetConnectionGuard connGuard(net_);
+        SetupConnectionWithGuard(0, pair, connGuard);
+
+        const size_t bufferSize = kSmallBufferSize;
+        void* buffer = nullptr;
+        EXPECT_EQ(hipMalloc(&buffer, bufferSize), hipSuccess);
+        auto bufGuard = makeDeviceBufferAutoGuard(buffer);
+
+        void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+        void* mhandle = nullptr;
+        EXPECT_EQ(RegisterMemory(comm, buffer, bufferSize, NCCL_PTR_CUDA, &mhandle), ncclSuccess);
+        NetMHandleGuard mhandleGuard(mhandle, NetMHandleDeleter(net_, comm));
+
+#if defined(ENABLE_FAULT_INJECTION)
+        if (rank == 0 && forceWrite) {
+            EXPECT_EQ(ncclIbFlushFaultForceScratchpadWrite(pair.recvComm, true), ncclSuccess);
+        }
+#else
+        (void)forceWrite;
+#endif
+
+        ncclResult_t lastFlush = ncclSuccess;
+        for (int it = 0; it < iterations; ++it) {
+            const int tag  = 700 + it;
+            const int seed = 1234 + it;
+            void* request  = nullptr;
+
+            if (rank == 0) {
+                EXPECT_EQ(hipMemset(buffer, 0, bufferSize), hipSuccess);
+                void*  rb[1] = {buffer};
+                size_t rs[1] = {bufferSize};
+                int    rt[1] = {tag};
+                void*  rh[1] = {mhandle};
+                EXPECT_EQ(PostRecv(pair.recvComm, 1, rb, rs, rt, rh, &request), ncclSuccess);
+                EXPECT_NE(request, nullptr);
+            } else {
+                EXPECT_EQ(initializeBufferWithPattern<uint8_t>(buffer, bufferSize, makeBytePattern(seed)),
+                          hipSuccess);
+                PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
+            }
+
+            MPI_Barrier(MPI_COMM_WORLD);
+
+            int sizes[1] = {0};
+            EXPECT_EQ(WaitForCompletion(request, sizes), ncclSuccess);
+
+            if (rank == 0) {
+                void* fb[1] = {buffer};
+                int   fs[1] = {static_cast<int>(bufferSize)};
+                void* fh[1] = {mhandle};
+                void* flushReq = nullptr;
+                ncclResult_t r = FlushRecv(pair.recvComm, 1, fb, fs, fh, &flushReq);
+                if (r == ncclSuccess && flushReq != nullptr) {
+                    r = WaitForCompletion(flushReq, nullptr);
+                }
+                lastFlush = r;
+                if (verifyData && r == ncclSuccess) {
+                    size_t errIdx = 0; uint8_t exp = 0, act = 0;
+                    EXPECT_TRUE(verifyBufferData<uint8_t>(buffer, bufferSize, makeBytePattern(seed),
+                                                          0, 0, &errIdx, &exp, &act))
+                        << "flushed data mismatch at " << errIdx
+                        << " exp=" << (int)exp << " act=" << (int)act;
+                }
+            }
+
+            MPI_Barrier(MPI_COMM_WORLD);
+        }
+
+#if defined(ENABLE_FAULT_INJECTION)
+        if (rank == 0 && forceWrite) {
+            (void)ncclIbFlushFaultForceScratchpadWrite(pair.recvComm, false);
+        }
+#endif
+
+        if (rank == 0 && rank0LastFlush) *rank0LastFlush = lastFlush;
+    }
+};
+
+// dma-buf (cuMem/UBR) scratchpad: the exact path that used to fault. The
+// read-only flush must complete cleanly with correct data.
+TEST_F(GdrFlushTest, CuMemDmaBuf_GpuRecvFlush_NoAsyncFatal) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                          false, kMinGpusPerNode, kNoNodeLimit));
+    if (!cuMemEnabledEnv()) GTEST_SKIP() << "Requires NCCL_CUMEM_ENABLE=1 (dma-buf scratchpad path)";
+    AssertInitAndGetDevices(nullptr);
+    if (!gdrSupported()) GTEST_SKIP() << "GDR (NCCL_PTR_CUDA) not supported on this device";
+
+    ncclResult_t flush = ncclSuccess;
+    RunRecvFlushBurst(/*iterations=*/4, /*verifyData=*/true,
+                      /*forceWrite=*/false, &flush);
+    if (MPIEnvironment::world_rank == 0)
+        EXPECT_EQ(flush, ncclSuccess) << "read-only flush over dma-buf scratchpad must not fault";
+}
+
+// Legacy peermem (ibv_reg_mr) scratchpad. Confirms Option 2a keeps the peermem
+// RO=0 read path working (never regressed).
+TEST_F(GdrFlushTest, Peermem_GpuRecvFlush_NoAsyncFatal) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                          false, kMinGpusPerNode, kNoNodeLimit));
+    if (cuMemEnabledEnv()) GTEST_SKIP() << "Requires NCCL_CUMEM_ENABLE=0 (peermem scratchpad path)";
+    AssertInitAndGetDevices(nullptr);
+    if (!gdrSupported()) GTEST_SKIP() << "GDR (NCCL_PTR_CUDA) not supported on this device";
+
+    ncclResult_t flush = ncclSuccess;
+    RunRecvFlushBurst(/*iterations=*/4, /*verifyData=*/true,
+                      /*forceWrite=*/false, &flush);
+    if (MPIEnvironment::world_rank == 0)
+        EXPECT_EQ(flush, ncclSuccess) << "peermem RO=0 scratchpad flush must succeed";
+}
+
+// Feature disabled: ncclIbIflush falls back to reading the received buffer
+// directly (upstream-NCCL behaviour). Exercises the else branch.
+TEST_F(GdrFlushTest, FeatureDisabled_FallbackReadRecvBuffer) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                          false, kMinGpusPerNode, kNoNodeLimit));
+    if (scratchpadFlushEnabled())
+        GTEST_SKIP() << "Requires RCCL_GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING=0 (fallback path)";
+    AssertInitAndGetDevices(nullptr);
+    if (!gdrSupported()) GTEST_SKIP() << "GDR (NCCL_PTR_CUDA) not supported on this device";
+
+    ncclResult_t flush = ncclSuccess;
+    RunRecvFlushBurst(/*iterations=*/4, /*verifyData=*/true,
+                      /*forceWrite=*/false, &flush);
+    if (MPIEnvironment::world_rank == 0)
+        EXPECT_EQ(flush, ncclSuccess) << "fallback flush (read recv buffer) must succeed";
+}
+
+// Repeated-flush burst. An intermittent async-fatal would surface as a
+// non-success flush on some iteration; the whole burst must stay clean.
+TEST_F(GdrFlushTest, RepeatedFlush_NoFaultBurst) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                          false, kMinGpusPerNode, kNoNodeLimit));
+    AssertInitAndGetDevices(nullptr);
+    if (!gdrSupported()) GTEST_SKIP() << "GDR (NCCL_PTR_CUDA) not supported on this device";
+
+    ncclResult_t flush = ncclSuccess;
+    RunRecvFlushBurst(/*iterations=*/50, /*verifyData=*/false,
+                      /*forceWrite=*/false, &flush);
+    if (MPIEnvironment::world_rank == 0)
+        EXPECT_EQ(flush, ncclSuccess) << "no flush in the burst may raise a QP async-fatal";
+}
+
+#if defined(ENABLE_FAULT_INJECTION)
+// Regression guard - force the removed scratchpad RDMA_WRITE back. On a dma-buf
+// scratchpad this must reproduce the fault (flush no longer succeeds), proving
+// the WRITE is the culprit and that removing it is the fix.
+TEST_F(GdrFlushTest, ForcedScratchpadWrite_ReproducesFault) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                          false, kMinGpusPerNode, kNoNodeLimit));
+    if (!cuMemEnabledEnv()) GTEST_SKIP() << "Requires NCCL_CUMEM_ENABLE=1 (dma-buf scratchpad target)";
+    if (!scratchpadFlushEnabled())
+        GTEST_SKIP() << "Requires the scratchpad flush enabled (RCCL_GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING=1)";
+    AssertInitAndGetDevices(nullptr);
+    if (!gdrSupported()) GTEST_SKIP() << "GDR (NCCL_PTR_CUDA) not supported on this device";
+
+    ncclResult_t forced = ncclSuccess;
+    RunRecvFlushBurst(/*iterations=*/1, /*verifyData=*/false,
+                      /*forceWrite=*/true, &forced);
+    if (MPIEnvironment::world_rank == 0)
+        EXPECT_NE(forced, ncclSuccess)
+            << "forced scratchpad RDMA_WRITE on a dma-buf buffer should fault the flush QP";
+}
+#endif  // ENABLE_FAULT_INJECTION
+
+}  // namespace
+
+#endif  // MPI_TESTS_ENABLED

--- a/projects/rccl/test/transport/NetIbMPI/NetIbFaultInject.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbFaultInject.hpp
@@ -11,10 +11,13 @@
 
 /*
  * Re-export the shared fault injection API declarations from the library's
- * internal header. Using the same header in both the library and the tests
+ * internal headers. Using the same headers in both the library and the tests
  * guarantees that the ABI can never silently diverge.
+ *   - net_ib_fault_inject.h        : CAST transport (src/transport/net_ib_cast)
+ *   - net_ib_flush_fault_inject.h  : base GDR flush   (src/transport/net_ib)
  */
 #include "net_ib_fault_inject.h"
+#include "net_ib/net_ib_flush_fault_inject.h"
 
 #endif /* MPI_TESTS_ENABLED && ENABLE_FAULT_INJECTION */
 

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
@@ -190,6 +190,69 @@
         "NCCL_DMABUF_ENABLE": "1"
       }
     },
+    "net_ib_gdr_flush": {
+      "extends": "net_ib_base",
+      "timeout": 120,
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1"
+      },
+      "tests": [
+        {
+          "name": "GdrFlush_CuMemDmaBuf_NoAsyncFatal",
+          "description": "Whitebox ncclIbIflush over a dma-buf (cuMem/UBR) RO=0 flush scratchpad - the exact path that used to raise the mlx5 'invalid request local work queue error'. The read-only flush (RDMA_READ fence, WRITE removed) must complete cleanly with correct data.",
+          "test_filter": "GdrFlushTest.CuMemDmaBuf_GpuRecvFlush_NoAsyncFatal"
+        },
+        {
+          "name": "GdrFlush_Peermem_NoAsyncFatal",
+          "description": "Whitebox ncclIbIflush over a legacy peermem (ibv_reg_mr) RO=0 scratchpad. Confirms the fix keeps the peermem read path working (never regressed).",
+          "test_filter": "GdrFlushTest.Peermem_GpuRecvFlush_NoAsyncFatal",
+          "env_variables": {
+            "NCCL_CUMEM_ENABLE": "0"
+          }
+        },
+        {
+          "name": "GdrFlush_FeatureDisabled_Fallback",
+          "description": "Whitebox ncclIbIflush fallback branch: with the dedicated RO=0 scratchpad disabled it reads the received buffer directly (upstream-NCCL behaviour).",
+          "test_filter": "GdrFlushTest.FeatureDisabled_FallbackReadRecvBuffer",
+          "env_variables": {
+            "RCCL_GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING": "0"
+          }
+        },
+        {
+          "name": "GdrFlush_RepeatedFlushBurst",
+          "description": "50-iteration GPU recv+flush burst over the dma-buf scratchpad; an intermittent QP async-fatal would surface as a non-success flush. The whole burst must stay clean.",
+          "test_filter": "GdrFlushTest.RepeatedFlush_NoFaultBurst"
+        },
+        {
+          "name": "GdrFlush_ForcedScratchpadWrite_ReproducesFault",
+          "description": "Regression guard (ENABLE_FAULT_INJECTION debug builds only): forces the removed scratchpad RDMA_WRITE back on a dma-buf buffer and asserts the flush QP faults, proving the WRITE was the culprit. Absent/skipped when fault injection is not compiled in.",
+          "test_filter": "GdrFlushTest.ForcedScratchpadWrite_ReproducesFault"
+        }
+      ]
+    },
+    "gdr_flush_cumem_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 2,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_LOCAL_REGISTER": "0",
+        "NCCL_GRAPH_REGISTER": "0",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "GdrFlush_CuMem_AllGatherUnregistered_MultiNode",
+          "description": "Cross-node AllGather over cuMem/DMA-BUF GDR with unregistered buffers (base GDR recv+flush path). The fix removes the redundant scratchpad RDMA_WRITE and keeps the RO=0 RDMA_READ fence, so the collective completes cleanly with correct data. Regression guard for the QP async-fatal 'invalid request local work queue error' that the pre-fix WRITE triggered on a dma-buf scratchpad.",
+          "test_filter": "GdrFlush_CuMem.AllGatherUnregistered_MultiNode"
+        }
+      ]
+    },
     "net_ib_initialization": {
       "extends": "net_ib_base",
       "timeout": 60,
@@ -302,7 +365,7 @@
     "net_ib_coverage_env": {
       "extends": "net_ib_base",
       "timeout": 300,
-      "_comment": "Coverage-oriented re-run of core transfer tests under alternate IB env. GID_INDEX=-1 forces RoCE GID auto-select (the auto-select path is skipped when a fixed index is pinned); PCI_RELAXED_ORDERING=0 exercises the relaxed-ordering-disabled registration/connect paths; ADAPTIVE_ROUTING=1 reaches the adaptive-routing threshold path. Env knobs are NIC-agnostic.",
+      "description": "Coverage-oriented re-run of core transfer tests under alternate IB env. GID_INDEX=-1 forces RoCE GID auto-select (the auto-select path is skipped when a fixed index is pinned); PCI_RELAXED_ORDERING=0 exercises the relaxed-ordering-disabled registration/connect paths; ADAPTIVE_ROUTING=1 reaches the adaptive-routing threshold path. Env knobs are NIC-agnostic.",
       "env_variables": {
         "NCCL_IB_GID_INDEX": "-1",
         "NCCL_IB_PCI_RELAXED_ORDERING": "0",
@@ -338,7 +401,7 @@
     "net_ib_merge_disabled": {
       "extends": "net_ib_base",
       "timeout": 60,
-      "_comment": "Exercises the makeVDevice merge-disabled guard, which only runs with NCCL_IB_MERGE_NICS=0 (the rest of the suite uses 1). Without this entry MakeVirtualDeviceMergeDisabled always GTEST_SKIPs in CI.",
+      "description": "Exercises the makeVDevice merge-disabled guard, which only runs with NCCL_IB_MERGE_NICS=0 (the rest of the suite uses 1). Without this entry MakeVirtualDeviceMergeDisabled always GTEST_SKIPs in CI.",
       "env_variables": {
         "NCCL_IB_MERGE_NICS": "0"
       },
@@ -353,7 +416,7 @@
     "net_ib_vnic_validation": {
       "extends": "net_ib_base",
       "timeout": 120,
-      "_comment": "makeVDevice / CheckVProps validation and topology error paths. WARN_RAIL_LOCAL=1 so the rail-local mismatch arm in DisjointMergeRailLocal_VNic is reachable. Topology-dependent cases (cross-NUMA, disjoint >=5-NIC merge) GTEST_SKIP when the hardware doesn't provide them.",
+      "description": "makeVDevice / CheckVProps validation and topology error paths. WARN_RAIL_LOCAL=1 so the rail-local mismatch arm in DisjointMergeRailLocal_VNic is reachable. Topology-dependent cases (cross-NUMA, disjoint >=5-NIC merge) GTEST_SKIP when the hardware doesn't provide them.",
       "env_variables": {
         "NCCL_IB_WARN_RAIL_LOCAL": "1"
       },
@@ -2643,6 +2706,18 @@
       "name": "NET Transport - Ethernet (Multi-Node)",
       "description": "Network transport tests over Ethernet",
       "config": "net_transport_eth_multinode",
+      "enabled": true
+    },
+    {
+      "name": "GDR Flush - Whitebox ncclIbIflush (Single-Node, 2-Rank)",
+      "description": "Whitebox coverage of the NET/IB GDR flush fix: dma-buf and peermem RO=0 scratchpad reads, feature-disabled fallback, repeated-flush burst, and the fault-injection regression guard",
+      "config": "net_ib_gdr_flush",
+      "enabled": true
+    },
+    {
+      "name": "GDR Flush - cuMem AllGather (Multi-Node)",
+      "description": "Cross-node AllGather over cuMem/DMA-BUF GDR exercising the base recv+flush path with the redundant scratchpad RDMA_WRITE removed",
+      "config": "gdr_flush_cumem_multinode",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -11,7 +11,6 @@
   "env_variables": {
     "HSA_NO_SCRATCH_RECLAIM": "1",
     "NCCL_SOCKET_IFNAME": "eth0,eth1",
-    "NCCL_IB_HCA": "^mlx5_1,mlx5_6",
     "NCCL_DEBUG": "INFO"
   },
   "build_configuration": {
@@ -212,6 +211,69 @@
           "name": "UBR_MultiSegment_Symmetric_LsaGin",
           "description": "Cross-node ReduceScatter over multi-segment symmetric windows exercising both the LSA (intra-node) and GIN (inter-node) legs; requires >=2 nodes and >=2 ranks per node",
           "test_filter": "UBR_MultiSegment.Symmetric_LsaGin"
+        }
+      ]
+    },
+    "gdr_flush_cumem_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 2,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_LOCAL_REGISTER": "0",
+        "NCCL_GRAPH_REGISTER": "0",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "GdrFlush_CuMem_AllGatherUnregistered_MultiNode",
+          "description": "Cross-node AllGather over cuMem/DMA-BUF GDR with unregistered buffers (base GDR recv+flush path). The fix removes the redundant scratchpad RDMA_WRITE and keeps the RO=0 RDMA_READ fence, so the collective completes cleanly with correct data. Regression guard for the QP async-fatal 'invalid request local work queue error' that the pre-fix WRITE triggered on a dma-buf scratchpad. Compile-guarded pre-fix reproduction lives in GdrFlushTests.cpp (ForcedScratchpadWrite_ReproducesFault, ENABLE_FAULT_INJECTION).",
+          "test_filter": "GdrFlush_CuMem.AllGatherUnregistered_MultiNode"
+        }
+      ]
+    },
+    "net_ib_gdr_flush": {
+      "extends": "net_ib_base",
+      "timeout": 120,
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1"
+      },
+      "tests": [
+        {
+          "name": "GdrFlush_CuMemDmaBuf_NoAsyncFatal",
+          "description": "Whitebox ncclIbIflush over a dma-buf (cuMem/UBR) RO=0 flush scratchpad - the exact path that used to raise the mlx5 'invalid request local work queue error'. The read-only flush (RDMA_READ fence, WRITE removed) must complete cleanly with correct data.",
+          "test_filter": "GdrFlushTest.CuMemDmaBuf_GpuRecvFlush_NoAsyncFatal"
+        },
+        {
+          "name": "GdrFlush_Peermem_NoAsyncFatal",
+          "description": "Whitebox ncclIbIflush over a legacy peermem (ibv_reg_mr) RO=0 scratchpad. Confirms the fix keeps the peermem read path working (never regressed).",
+          "test_filter": "GdrFlushTest.Peermem_GpuRecvFlush_NoAsyncFatal",
+          "env_variables": {
+            "NCCL_CUMEM_ENABLE": "0"
+          }
+        },
+        {
+          "name": "GdrFlush_FeatureDisabled_Fallback",
+          "description": "Whitebox ncclIbIflush fallback branch: with the dedicated RO=0 scratchpad disabled it reads the received buffer directly (upstream-NCCL behaviour).",
+          "test_filter": "GdrFlushTest.FeatureDisabled_FallbackReadRecvBuffer",
+          "env_variables": {
+            "RCCL_GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING": "0"
+          }
+        },
+        {
+          "name": "GdrFlush_RepeatedFlushBurst",
+          "description": "50-iteration GPU recv+flush burst over the dma-buf scratchpad; an intermittent QP async-fatal would surface as a non-success flush. The whole burst must stay clean.",
+          "test_filter": "GdrFlushTest.RepeatedFlush_NoFaultBurst"
+        },
+        {
+          "name": "GdrFlush_ForcedScratchpadWrite_ReproducesFault",
+          "description": "Regression guard (ENABLE_FAULT_INJECTION debug builds only): forces the removed scratchpad RDMA_WRITE back on a dma-buf buffer and asserts the flush QP faults, proving the WRITE was the culprit. Absent/skipped when fault injection is not compiled in.",
+          "test_filter": "GdrFlushTest.ForcedScratchpadWrite_ReproducesFault"
         }
       ]
     },
@@ -426,9 +488,10 @@
     "net_ib_vnic_validation": {
       "extends": "net_ib_base",
       "timeout": 120,
-      "description": "makeVDevice / CheckVProps validation and topology error paths. WARN_RAIL_LOCAL=1 so the rail-local mismatch arm in DisjointMergeRailLocal_VNic is reachable. Topology-dependent cases (cross-NUMA, disjoint >=5-NIC merge) GTEST_SKIP when the hardware doesn't provide them.",
+      "description": "makeVDevice / CheckVProps validation and topology error paths. WARN_RAIL_LOCAL=1 so the rail-local mismatch arm in DisjointMergeRailLocal_VNic is reachable. NCCL_IB_HCA excludes mlx5_1/mlx5_6 (one NIC per NUMA) to force the disjoint, rail-misaligned NIC layout these coverage tests need; it is scoped here (not global) because that exclusion strands GPUs 1/6 from their rail-local NIC and disables GDR for them, which breaks GDR/registration-sensitive tests in other suites. Topology-dependent cases (cross-NUMA, disjoint >=5-NIC merge) GTEST_SKIP when the hardware doesn't provide them.",
       "env_variables": {
-        "NCCL_IB_WARN_RAIL_LOCAL": "1"
+        "NCCL_IB_WARN_RAIL_LOCAL": "1",
+        "NCCL_IB_HCA": "^mlx5_1,mlx5_6"
       },
       "tests": [
         {
@@ -1076,9 +1139,11 @@
       "timeout": 300,
       "env_variables": {
         "NCCL_DEBUG": "INFO",
-        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_DEBUG_SUBSYS": "REG,INIT,TUNING",
         "NCCL_LOCAL_REGISTER": "1",
         "NCCL_LEGACY_CUDA_REGISTER": "1",
+        "NCCL_LAUNCH_ORDER_IMPLICIT": "1",
+        "RCCL_DIRECT_ALLGATHER_THRESHOLD": "2147483648",
         "RCCL_MPI_LOG_ALL_RANKS": "1"
       },
       "tests": [
@@ -3294,6 +3359,18 @@
       "name": "NET Transport - Ethernet (Multi-Node)",
       "description": "Network transport tests over Ethernet",
       "config": "net_transport_eth_multinode",
+      "enabled": true
+    },
+    {
+      "name": "GDR Flush - Whitebox ncclIbIflush (Single-Node, 2-Rank)",
+      "description": "Whitebox coverage of the NET/IB GDR flush fix: dma-buf and peermem RO=0 scratchpad reads, feature-disabled fallback, repeated-flush burst, and the fault-injection regression guard",
+      "config": "net_ib_gdr_flush",
+      "enabled": true
+    },
+    {
+      "name": "GDR Flush - cuMem AllGather (Multi-Node)",
+      "description": "Cross-node AllGather over cuMem/DMA-BUF GDR exercising the base recv+flush path with the redundant scratchpad RDMA_WRITE removed",
+      "config": "gdr_flush_cumem_multinode",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1066,6 +1066,42 @@
         }
       ]
     },
+    "ubr_direct_allgather": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 8,
+      "num_nodes": 1,
+      "num_gpus": 8,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_LEGACY_CUDA_REGISTER": "1",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "UBR_DirectAllGather_UbrSizeSweep",
+          "description": "Registered Direct AllGather across the LL<->SIMPLE boundary (intra-node IPC path)",
+          "test_filter": "UBR_DirectAllGather.UbrSizeSweep"
+        },
+        {
+          "name": "UBR_DirectAllGather_BaselineVsUbrEquivalence",
+          "description": "Before/after equivalence: unregistered (allowUB=false) then registered (allowUB=true) AllGather",
+          "test_filter": "UBR_DirectAllGather.BaselineVsUbrEquivalence"
+        },
+        {
+          "name": "UBR_DirectAllGather_UbrSizeSweep_MultiNode",
+          "description": "Registered Direct AllGather size sweep across nodes (net/DMA-buf registration path)",
+          "test_filter": "UBR_DirectAllGather.UbrSizeSweep_MultiNode",
+          "num_ranks": 16,
+          "num_nodes": 2,
+          "num_gpus": 8
+        }
+      ]
+    },
     "ubr_concurrent_reg_hang": {
       "extends": "default",
       "is_gtest": true,
@@ -3372,6 +3408,12 @@
       "name": "UBR Tests - Multi Node",
       "description": "User Buffer Registration tests on multi-node (requires 2+ nodes)",
       "config": "ubr_multi_node",
+      "enabled": true
+    },
+    {
+      "name": "UBR Direct AllGather - Default Under UBR",
+      "description": "Direct AllGather running by default under UBR (NCCL_LOCAL_REGISTER=1): size sweep across LL/SIMPLE boundary, before/after (unregistered vs registered) equivalence, and a multi-node net-path sweep. Validates removal of the blanket Direct AllGather disable and per-op allowUB gating.",
+      "config": "ubr_direct_allgather",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -200,6 +200,69 @@
         "NCCL_DMABUF_ENABLE": "1"
       }
     },
+    "net_ib_gdr_flush": {
+      "extends": "net_ib_base",
+      "timeout": 120,
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1"
+      },
+      "tests": [
+        {
+          "name": "GdrFlush_CuMemDmaBuf_NoAsyncFatal",
+          "description": "Whitebox ncclIbIflush over a dma-buf (cuMem/UBR) RO=0 flush scratchpad - the exact path that used to raise the mlx5 'invalid request local work queue error'. The read-only flush (RDMA_READ fence, WRITE removed) must complete cleanly with correct data.",
+          "test_filter": "GdrFlushTest.CuMemDmaBuf_GpuRecvFlush_NoAsyncFatal"
+        },
+        {
+          "name": "GdrFlush_Peermem_NoAsyncFatal",
+          "description": "Whitebox ncclIbIflush over a legacy peermem (ibv_reg_mr) RO=0 scratchpad. Confirms the fix keeps the peermem read path working (never regressed).",
+          "test_filter": "GdrFlushTest.Peermem_GpuRecvFlush_NoAsyncFatal",
+          "env_variables": {
+            "NCCL_CUMEM_ENABLE": "0"
+          }
+        },
+        {
+          "name": "GdrFlush_FeatureDisabled_Fallback",
+          "description": "Whitebox ncclIbIflush fallback branch: with the dedicated RO=0 scratchpad disabled it reads the received buffer directly (upstream-NCCL behaviour).",
+          "test_filter": "GdrFlushTest.FeatureDisabled_FallbackReadRecvBuffer",
+          "env_variables": {
+            "RCCL_GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING": "0"
+          }
+        },
+        {
+          "name": "GdrFlush_RepeatedFlushBurst",
+          "description": "50-iteration GPU recv+flush burst over the dma-buf scratchpad; an intermittent QP async-fatal would surface as a non-success flush. The whole burst must stay clean.",
+          "test_filter": "GdrFlushTest.RepeatedFlush_NoFaultBurst"
+        },
+        {
+          "name": "GdrFlush_ForcedScratchpadWrite_ReproducesFault",
+          "description": "Regression guard (ENABLE_FAULT_INJECTION debug builds only): forces the removed scratchpad RDMA_WRITE back on a dma-buf buffer and asserts the flush QP faults, proving the WRITE was the culprit. Absent/skipped when fault injection is not compiled in.",
+          "test_filter": "GdrFlushTest.ForcedScratchpadWrite_ReproducesFault"
+        }
+      ]
+    },
+    "gdr_flush_cumem_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 2,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_LOCAL_REGISTER": "0",
+        "NCCL_GRAPH_REGISTER": "0",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "GdrFlush_CuMem_AllGatherUnregistered_MultiNode",
+          "description": "Cross-node AllGather over cuMem/DMA-BUF GDR with unregistered buffers (base GDR recv+flush path). The fix removes the redundant scratchpad RDMA_WRITE and keeps the RO=0 RDMA_READ fence, so the collective completes cleanly with correct data. Regression guard for the QP async-fatal 'invalid request local work queue error' that the pre-fix WRITE triggered on a dma-buf scratchpad.",
+          "test_filter": "GdrFlush_CuMem.AllGatherUnregistered_MultiNode"
+        }
+      ]
+    },
     "net_ib_initialization": {
       "extends": "net_ib_base",
       "timeout": 60,
@@ -312,7 +375,7 @@
     "net_ib_coverage_env": {
       "extends": "net_ib_base",
       "timeout": 300,
-      "_comment": "Coverage-oriented re-run of core transfer tests under alternate IB env. GID_INDEX=-1 forces RoCE GID auto-select (the auto-select path is skipped when a fixed index is pinned); PCI_RELAXED_ORDERING=0 exercises the relaxed-ordering-disabled registration/connect paths; ADAPTIVE_ROUTING=1 reaches the adaptive-routing threshold path. Env knobs are NIC-agnostic.",
+      "description": "Coverage-oriented re-run of core transfer tests under alternate IB env. GID_INDEX=-1 forces RoCE GID auto-select (the auto-select path is skipped when a fixed index is pinned); PCI_RELAXED_ORDERING=0 exercises the relaxed-ordering-disabled registration/connect paths; ADAPTIVE_ROUTING=1 reaches the adaptive-routing threshold path. Env knobs are NIC-agnostic.",
       "env_variables": {
         "NCCL_IB_GID_INDEX": "-1",
         "NCCL_IB_PCI_RELAXED_ORDERING": "0",
@@ -348,7 +411,7 @@
     "net_ib_merge_disabled": {
       "extends": "net_ib_base",
       "timeout": 60,
-      "_comment": "Exercises the makeVDevice merge-disabled guard, which only runs with NCCL_IB_MERGE_NICS=0 (the rest of the suite uses 1). Without this entry MakeVirtualDeviceMergeDisabled always GTEST_SKIPs in CI.",
+      "description": "Exercises the makeVDevice merge-disabled guard, which only runs with NCCL_IB_MERGE_NICS=0 (the rest of the suite uses 1). Without this entry MakeVirtualDeviceMergeDisabled always GTEST_SKIPs in CI.",
       "env_variables": {
         "NCCL_IB_MERGE_NICS": "0"
       },
@@ -363,7 +426,7 @@
     "net_ib_vnic_validation": {
       "extends": "net_ib_base",
       "timeout": 120,
-      "_comment": "makeVDevice / CheckVProps validation and topology error paths. WARN_RAIL_LOCAL=1 so the rail-local mismatch arm in DisjointMergeRailLocal_VNic is reachable. Topology-dependent cases (cross-NUMA, disjoint >=5-NIC merge) GTEST_SKIP when the hardware doesn't provide them.",
+      "description": "makeVDevice / CheckVProps validation and topology error paths. WARN_RAIL_LOCAL=1 so the rail-local mismatch arm in DisjointMergeRailLocal_VNic is reachable. Topology-dependent cases (cross-NUMA, disjoint >=5-NIC merge) GTEST_SKIP when the hardware doesn't provide them.",
       "env_variables": {
         "NCCL_IB_WARN_RAIL_LOCAL": "1"
       },
@@ -2543,6 +2606,18 @@
       "name": "NET Transport - Ethernet (Multi-Node)",
       "description": "Network transport tests over Ethernet",
       "config": "net_transport_eth_multinode",
+      "enabled": true
+    },
+    {
+      "name": "GDR Flush - Whitebox ncclIbIflush (Single-Node, 2-Rank)",
+      "description": "Whitebox coverage of the NET/IB GDR flush fix: dma-buf and peermem RO=0 scratchpad reads, feature-disabled fallback, repeated-flush burst, and the fault-injection regression guard",
+      "config": "net_ib_gdr_flush",
+      "enabled": true
+    },
+    {
+      "name": "GDR Flush - cuMem AllGather (Multi-Node)",
+      "description": "Cross-node AllGather over cuMem/DMA-BUF GDR exercising the base recv+flush path with the redundant scratchpad RDMA_WRITE removed",
+      "config": "gdr_flush_cumem_multinode",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
@@ -196,6 +196,69 @@
         "NCCL_DMABUF_ENABLE": "1"
       }
     },
+    "net_ib_gdr_flush": {
+      "extends": "net_ib_base",
+      "timeout": 120,
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1"
+      },
+      "tests": [
+        {
+          "name": "GdrFlush_CuMemDmaBuf_NoAsyncFatal",
+          "description": "Whitebox ncclIbIflush over a dma-buf (cuMem/UBR) RO=0 flush scratchpad - the exact path that used to raise the mlx5 'invalid request local work queue error'. The read-only flush (RDMA_READ fence, WRITE removed) must complete cleanly with correct data.",
+          "test_filter": "GdrFlushTest.CuMemDmaBuf_GpuRecvFlush_NoAsyncFatal"
+        },
+        {
+          "name": "GdrFlush_Peermem_NoAsyncFatal",
+          "description": "Whitebox ncclIbIflush over a legacy peermem (ibv_reg_mr) RO=0 scratchpad. Confirms the fix keeps the peermem read path working (never regressed).",
+          "test_filter": "GdrFlushTest.Peermem_GpuRecvFlush_NoAsyncFatal",
+          "env_variables": {
+            "NCCL_CUMEM_ENABLE": "0"
+          }
+        },
+        {
+          "name": "GdrFlush_FeatureDisabled_Fallback",
+          "description": "Whitebox ncclIbIflush fallback branch: with the dedicated RO=0 scratchpad disabled it reads the received buffer directly (upstream-NCCL behaviour).",
+          "test_filter": "GdrFlushTest.FeatureDisabled_FallbackReadRecvBuffer",
+          "env_variables": {
+            "RCCL_GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING": "0"
+          }
+        },
+        {
+          "name": "GdrFlush_RepeatedFlushBurst",
+          "description": "50-iteration GPU recv+flush burst over the dma-buf scratchpad; an intermittent QP async-fatal would surface as a non-success flush. The whole burst must stay clean.",
+          "test_filter": "GdrFlushTest.RepeatedFlush_NoFaultBurst"
+        },
+        {
+          "name": "GdrFlush_ForcedScratchpadWrite_ReproducesFault",
+          "description": "Regression guard (ENABLE_FAULT_INJECTION debug builds only): forces the removed scratchpad RDMA_WRITE back on a dma-buf buffer and asserts the flush QP faults, proving the WRITE was the culprit. Absent/skipped when fault injection is not compiled in.",
+          "test_filter": "GdrFlushTest.ForcedScratchpadWrite_ReproducesFault"
+        }
+      ]
+    },
+    "gdr_flush_cumem_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 2,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_LOCAL_REGISTER": "0",
+        "NCCL_GRAPH_REGISTER": "0",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "GdrFlush_CuMem_AllGatherUnregistered_MultiNode",
+          "description": "Cross-node AllGather over cuMem/DMA-BUF GDR with unregistered buffers (base GDR recv+flush path). The fix removes the redundant scratchpad RDMA_WRITE and keeps the RO=0 RDMA_READ fence, so the collective completes cleanly with correct data. Regression guard for the QP async-fatal 'invalid request local work queue error' that the pre-fix WRITE triggered on a dma-buf scratchpad.",
+          "test_filter": "GdrFlush_CuMem.AllGatherUnregistered_MultiNode"
+        }
+      ]
+    },
     "net_ib_initialization": {
       "extends": "net_ib_base",
       "timeout": 60,
@@ -308,7 +371,7 @@
     "net_ib_coverage_env": {
       "extends": "net_ib_base",
       "timeout": 300,
-      "_comment": "Coverage-oriented re-run of core transfer tests under alternate IB env. GID_INDEX=-1 forces RoCE GID auto-select (the auto-select path is skipped when a fixed index is pinned); PCI_RELAXED_ORDERING=0 exercises the relaxed-ordering-disabled registration/connect paths; ADAPTIVE_ROUTING=1 reaches the adaptive-routing threshold path. Env knobs are NIC-agnostic.",
+      "description": "Coverage-oriented re-run of core transfer tests under alternate IB env. GID_INDEX=-1 forces RoCE GID auto-select (the auto-select path is skipped when a fixed index is pinned); PCI_RELAXED_ORDERING=0 exercises the relaxed-ordering-disabled registration/connect paths; ADAPTIVE_ROUTING=1 reaches the adaptive-routing threshold path. Env knobs are NIC-agnostic.",
       "env_variables": {
         "NCCL_IB_GID_INDEX": "-1",
         "NCCL_IB_PCI_RELAXED_ORDERING": "0",
@@ -344,7 +407,7 @@
     "net_ib_merge_disabled": {
       "extends": "net_ib_base",
       "timeout": 60,
-      "_comment": "Exercises the makeVDevice merge-disabled guard, which only runs with NCCL_IB_MERGE_NICS=0 (the rest of the suite uses 1). Without this entry MakeVirtualDeviceMergeDisabled always GTEST_SKIPs in CI.",
+      "description": "Exercises the makeVDevice merge-disabled guard, which only runs with NCCL_IB_MERGE_NICS=0 (the rest of the suite uses 1). Without this entry MakeVirtualDeviceMergeDisabled always GTEST_SKIPs in CI.",
       "env_variables": {
         "NCCL_IB_MERGE_NICS": "0"
       },
@@ -359,7 +422,7 @@
     "net_ib_vnic_validation": {
       "extends": "net_ib_base",
       "timeout": 120,
-      "_comment": "makeVDevice / CheckVProps validation and topology error paths. WARN_RAIL_LOCAL=1 so the rail-local mismatch arm in DisjointMergeRailLocal_VNic is reachable. Topology-dependent cases (cross-NUMA, disjoint >=5-NIC merge) GTEST_SKIP when the hardware doesn't provide them.",
+      "description": "makeVDevice / CheckVProps validation and topology error paths. WARN_RAIL_LOCAL=1 so the rail-local mismatch arm in DisjointMergeRailLocal_VNic is reachable. Topology-dependent cases (cross-NUMA, disjoint >=5-NIC merge) GTEST_SKIP when the hardware doesn't provide them.",
       "env_variables": {
         "NCCL_IB_WARN_RAIL_LOCAL": "1"
       },
@@ -2644,6 +2707,18 @@
       "name": "NET Transport - Ethernet (Multi-Node)",
       "description": "Network transport tests over Ethernet",
       "config": "net_transport_eth_multinode",
+      "enabled": true
+    },
+    {
+      "name": "GDR Flush - Whitebox ncclIbIflush (Single-Node, 2-Rank)",
+      "description": "Whitebox coverage of the NET/IB GDR flush fix: dma-buf and peermem RO=0 scratchpad reads, feature-disabled fallback, repeated-flush burst, and the fault-injection regression guard",
+      "config": "net_ib_gdr_flush",
+      "enabled": true
+    },
+    {
+      "name": "GDR Flush - cuMem AllGather (Multi-Node)",
+      "description": "Cross-node AllGather over cuMem/DMA-BUF GDR exercising the base recv+flush path with the redundant scratchpad RDMA_WRITE removed",
+      "config": "gdr_flush_cumem_multinode",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
@@ -205,6 +205,69 @@
         "NCCL_DMABUF_ENABLE": "1"
       }
     },
+    "net_ib_gdr_flush": {
+      "extends": "net_ib_base",
+      "timeout": 120,
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1"
+      },
+      "tests": [
+        {
+          "name": "GdrFlush_CuMemDmaBuf_NoAsyncFatal",
+          "description": "Whitebox ncclIbIflush over a dma-buf (cuMem/UBR) RO=0 flush scratchpad - the exact path that used to raise the mlx5 'invalid request local work queue error'. The read-only flush (RDMA_READ fence, WRITE removed) must complete cleanly with correct data.",
+          "test_filter": "GdrFlushTest.CuMemDmaBuf_GpuRecvFlush_NoAsyncFatal"
+        },
+        {
+          "name": "GdrFlush_Peermem_NoAsyncFatal",
+          "description": "Whitebox ncclIbIflush over a legacy peermem (ibv_reg_mr) RO=0 scratchpad. Confirms the fix keeps the peermem read path working (never regressed).",
+          "test_filter": "GdrFlushTest.Peermem_GpuRecvFlush_NoAsyncFatal",
+          "env_variables": {
+            "NCCL_CUMEM_ENABLE": "0"
+          }
+        },
+        {
+          "name": "GdrFlush_FeatureDisabled_Fallback",
+          "description": "Whitebox ncclIbIflush fallback branch: with the dedicated RO=0 scratchpad disabled it reads the received buffer directly (upstream-NCCL behaviour).",
+          "test_filter": "GdrFlushTest.FeatureDisabled_FallbackReadRecvBuffer",
+          "env_variables": {
+            "RCCL_GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING": "0"
+          }
+        },
+        {
+          "name": "GdrFlush_RepeatedFlushBurst",
+          "description": "50-iteration GPU recv+flush burst over the dma-buf scratchpad; an intermittent QP async-fatal would surface as a non-success flush. The whole burst must stay clean.",
+          "test_filter": "GdrFlushTest.RepeatedFlush_NoFaultBurst"
+        },
+        {
+          "name": "GdrFlush_ForcedScratchpadWrite_ReproducesFault",
+          "description": "Regression guard (ENABLE_FAULT_INJECTION debug builds only): forces the removed scratchpad RDMA_WRITE back on a dma-buf buffer and asserts the flush QP faults, proving the WRITE was the culprit. Absent/skipped when fault injection is not compiled in.",
+          "test_filter": "GdrFlushTest.ForcedScratchpadWrite_ReproducesFault"
+        }
+      ]
+    },
+    "gdr_flush_cumem_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 2,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_LOCAL_REGISTER": "0",
+        "NCCL_GRAPH_REGISTER": "0",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "GdrFlush_CuMem_AllGatherUnregistered_MultiNode",
+          "description": "Cross-node AllGather over cuMem/DMA-BUF GDR with unregistered buffers (base GDR recv+flush path). The fix removes the redundant scratchpad RDMA_WRITE and keeps the RO=0 RDMA_READ fence, so the collective completes cleanly with correct data. Regression guard for the QP async-fatal 'invalid request local work queue error' that the pre-fix WRITE triggered on a dma-buf scratchpad.",
+          "test_filter": "GdrFlush_CuMem.AllGatherUnregistered_MultiNode"
+        }
+      ]
+    },
     "net_ib_initialization": {
       "extends": "net_ib_base",
       "timeout": 60,
@@ -317,7 +380,7 @@
     "net_ib_coverage_env": {
       "extends": "net_ib_base",
       "timeout": 300,
-      "_comment": "Coverage-oriented re-run of core transfer tests under alternate IB env. GID_INDEX=-1 forces RoCE GID auto-select (the auto-select path is skipped when a fixed index is pinned); PCI_RELAXED_ORDERING=0 exercises the relaxed-ordering-disabled registration/connect paths; ADAPTIVE_ROUTING=1 reaches the adaptive-routing threshold path. Env knobs are NIC-agnostic.",
+      "description": "Coverage-oriented re-run of core transfer tests under alternate IB env. GID_INDEX=-1 forces RoCE GID auto-select (the auto-select path is skipped when a fixed index is pinned); PCI_RELAXED_ORDERING=0 exercises the relaxed-ordering-disabled registration/connect paths; ADAPTIVE_ROUTING=1 reaches the adaptive-routing threshold path. Env knobs are NIC-agnostic.",
       "env_variables": {
         "NCCL_IB_GID_INDEX": "-1",
         "NCCL_IB_PCI_RELAXED_ORDERING": "0",
@@ -353,7 +416,7 @@
     "net_ib_merge_disabled": {
       "extends": "net_ib_base",
       "timeout": 60,
-      "_comment": "Exercises the makeVDevice merge-disabled guard, which only runs with NCCL_IB_MERGE_NICS=0 (the rest of the suite uses 1). Without this entry MakeVirtualDeviceMergeDisabled always GTEST_SKIPs in CI.",
+      "description": "Exercises the makeVDevice merge-disabled guard, which only runs with NCCL_IB_MERGE_NICS=0 (the rest of the suite uses 1). Without this entry MakeVirtualDeviceMergeDisabled always GTEST_SKIPs in CI.",
       "env_variables": {
         "NCCL_IB_MERGE_NICS": "0"
       },
@@ -368,7 +431,7 @@
     "net_ib_vnic_validation": {
       "extends": "net_ib_base",
       "timeout": 120,
-      "_comment": "makeVDevice / CheckVProps validation and topology error paths. WARN_RAIL_LOCAL=1 so the rail-local mismatch arm in DisjointMergeRailLocal_VNic is reachable. Topology-dependent cases (cross-NUMA, disjoint >=5-NIC merge) GTEST_SKIP when the hardware doesn't provide them.",
+      "description": "makeVDevice / CheckVProps validation and topology error paths. WARN_RAIL_LOCAL=1 so the rail-local mismatch arm in DisjointMergeRailLocal_VNic is reachable. Topology-dependent cases (cross-NUMA, disjoint >=5-NIC merge) GTEST_SKIP when the hardware doesn't provide them.",
       "env_variables": {
         "NCCL_IB_WARN_RAIL_LOCAL": "1"
       },
@@ -3429,6 +3492,18 @@
       "name": "NET Transport - Ethernet (Multi-Node)",
       "description": "Network transport tests over Ethernet",
       "config": "net_transport_eth_multinode",
+      "enabled": true
+    },
+    {
+      "name": "GDR Flush - Whitebox ncclIbIflush (Single-Node, 2-Rank)",
+      "description": "Whitebox coverage of the NET/IB GDR flush fix: dma-buf and peermem RO=0 scratchpad reads, feature-disabled fallback, repeated-flush burst, and the fault-injection regression guard",
+      "config": "net_ib_gdr_flush",
+      "enabled": true
+    },
+    {
+      "name": "GDR Flush - cuMem AllGather (Multi-Node)",
+      "description": "Cross-node AllGather over cuMem/DMA-BUF GDR exercising the base recv+flush path with the redundant scratchpad RDMA_WRITE removed",
+      "config": "gdr_flush_cumem_multinode",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
@@ -190,6 +190,69 @@
         "NCCL_DMABUF_ENABLE": "1"
       }
     },
+    "net_ib_gdr_flush": {
+      "extends": "net_ib_base",
+      "timeout": 120,
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1"
+      },
+      "tests": [
+        {
+          "name": "GdrFlush_CuMemDmaBuf_NoAsyncFatal",
+          "description": "Whitebox ncclIbIflush over a dma-buf (cuMem/UBR) RO=0 flush scratchpad - the exact path that used to raise the mlx5 'invalid request local work queue error'. The read-only flush (RDMA_READ fence, WRITE removed) must complete cleanly with correct data.",
+          "test_filter": "GdrFlushTest.CuMemDmaBuf_GpuRecvFlush_NoAsyncFatal"
+        },
+        {
+          "name": "GdrFlush_Peermem_NoAsyncFatal",
+          "description": "Whitebox ncclIbIflush over a legacy peermem (ibv_reg_mr) RO=0 scratchpad. Confirms the fix keeps the peermem read path working (never regressed).",
+          "test_filter": "GdrFlushTest.Peermem_GpuRecvFlush_NoAsyncFatal",
+          "env_variables": {
+            "NCCL_CUMEM_ENABLE": "0"
+          }
+        },
+        {
+          "name": "GdrFlush_FeatureDisabled_Fallback",
+          "description": "Whitebox ncclIbIflush fallback branch: with the dedicated RO=0 scratchpad disabled it reads the received buffer directly (upstream-NCCL behaviour).",
+          "test_filter": "GdrFlushTest.FeatureDisabled_FallbackReadRecvBuffer",
+          "env_variables": {
+            "RCCL_GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING": "0"
+          }
+        },
+        {
+          "name": "GdrFlush_RepeatedFlushBurst",
+          "description": "50-iteration GPU recv+flush burst over the dma-buf scratchpad; an intermittent QP async-fatal would surface as a non-success flush. The whole burst must stay clean.",
+          "test_filter": "GdrFlushTest.RepeatedFlush_NoFaultBurst"
+        },
+        {
+          "name": "GdrFlush_ForcedScratchpadWrite_ReproducesFault",
+          "description": "Regression guard (ENABLE_FAULT_INJECTION debug builds only): forces the removed scratchpad RDMA_WRITE back on a dma-buf buffer and asserts the flush QP faults, proving the WRITE was the culprit. Absent/skipped when fault injection is not compiled in.",
+          "test_filter": "GdrFlushTest.ForcedScratchpadWrite_ReproducesFault"
+        }
+      ]
+    },
+    "gdr_flush_cumem_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 2,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_LOCAL_REGISTER": "0",
+        "NCCL_GRAPH_REGISTER": "0",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "GdrFlush_CuMem_AllGatherUnregistered_MultiNode",
+          "description": "Cross-node AllGather over cuMem/DMA-BUF GDR with unregistered buffers (base GDR recv+flush path). The fix removes the redundant scratchpad RDMA_WRITE and keeps the RO=0 RDMA_READ fence, so the collective completes cleanly with correct data. Regression guard for the QP async-fatal 'invalid request local work queue error' that the pre-fix WRITE triggered on a dma-buf scratchpad.",
+          "test_filter": "GdrFlush_CuMem.AllGatherUnregistered_MultiNode"
+        }
+      ]
+    },
     "net_ib_initialization": {
       "extends": "net_ib_base",
       "timeout": 60,
@@ -302,7 +365,7 @@
     "net_ib_coverage_env": {
       "extends": "net_ib_base",
       "timeout": 300,
-      "_comment": "Coverage-oriented re-run of core transfer tests under alternate IB env. GID_INDEX=-1 forces RoCE GID auto-select (the auto-select path is skipped when a fixed index is pinned); PCI_RELAXED_ORDERING=0 exercises the relaxed-ordering-disabled registration/connect paths; ADAPTIVE_ROUTING=1 reaches the adaptive-routing threshold path. Env knobs are NIC-agnostic.",
+      "description": "Coverage-oriented re-run of core transfer tests under alternate IB env. GID_INDEX=-1 forces RoCE GID auto-select (the auto-select path is skipped when a fixed index is pinned); PCI_RELAXED_ORDERING=0 exercises the relaxed-ordering-disabled registration/connect paths; ADAPTIVE_ROUTING=1 reaches the adaptive-routing threshold path. Env knobs are NIC-agnostic.",
       "env_variables": {
         "NCCL_IB_GID_INDEX": "-1",
         "NCCL_IB_PCI_RELAXED_ORDERING": "0",
@@ -338,7 +401,7 @@
     "net_ib_merge_disabled": {
       "extends": "net_ib_base",
       "timeout": 60,
-      "_comment": "Exercises the makeVDevice merge-disabled guard, which only runs with NCCL_IB_MERGE_NICS=0 (the rest of the suite uses 1). Without this entry MakeVirtualDeviceMergeDisabled always GTEST_SKIPs in CI.",
+      "description": "Exercises the makeVDevice merge-disabled guard, which only runs with NCCL_IB_MERGE_NICS=0 (the rest of the suite uses 1). Without this entry MakeVirtualDeviceMergeDisabled always GTEST_SKIPs in CI.",
       "env_variables": {
         "NCCL_IB_MERGE_NICS": "0"
       },
@@ -353,7 +416,7 @@
     "net_ib_vnic_validation": {
       "extends": "net_ib_base",
       "timeout": 120,
-      "_comment": "makeVDevice / CheckVProps validation and topology error paths. WARN_RAIL_LOCAL=1 so the rail-local mismatch arm in DisjointMergeRailLocal_VNic is reachable. Topology-dependent cases (cross-NUMA, disjoint >=5-NIC merge) GTEST_SKIP when the hardware doesn't provide them.",
+      "description": "makeVDevice / CheckVProps validation and topology error paths. WARN_RAIL_LOCAL=1 so the rail-local mismatch arm in DisjointMergeRailLocal_VNic is reachable. Topology-dependent cases (cross-NUMA, disjoint >=5-NIC merge) GTEST_SKIP when the hardware doesn't provide them.",
       "env_variables": {
         "NCCL_IB_WARN_RAIL_LOCAL": "1"
       },
@@ -2638,6 +2701,18 @@
       "name": "NET Transport - Ethernet (Multi-Node)",
       "description": "Network transport tests over Ethernet",
       "config": "net_transport_eth_multinode",
+      "enabled": true
+    },
+    {
+      "name": "GDR Flush - Whitebox ncclIbIflush (Single-Node, 2-Rank)",
+      "description": "Whitebox coverage of the NET/IB GDR flush fix: dma-buf and peermem RO=0 scratchpad reads, feature-disabled fallback, repeated-flush burst, and the fault-injection regression guard",
+      "config": "net_ib_gdr_flush",
+      "enabled": true
+    },
+    {
+      "name": "GDR Flush - cuMem AllGather (Multi-Node)",
+      "description": "Cross-node AllGather over cuMem/DMA-BUF GDR exercising the base recv+flush path with the redundant scratchpad RDMA_WRITE removed",
+      "config": "gdr_flush_cumem_multinode",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455x_perf.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455x_perf.json
@@ -25,7 +25,7 @@
   ],
   "build_configuration": {
     "enabled": false,
-    "_comment": "perf binaries come from rccl_tests_build_configuration / external build"
+    "description": "perf binaries come from rccl_tests_build_configuration / external build"
   },
   "test_configurations": {
     "perf_base": {

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -61,6 +61,50 @@
       }
     },
 
+    "net_ib_gdr_flush": {
+      "extends": "net_ib_base",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 120,
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1"
+      },
+      "tests": [
+        {
+          "name": "GdrFlush_CuMemDmaBuf_NoAsyncFatal",
+          "description": "Whitebox ncclIbIflush over a dma-buf (cuMem/UBR) RO=0 flush scratchpad - the exact path that used to raise the mlx5 'invalid request local work queue error'. The read-only flush (RDMA_READ fence, WRITE removed) must complete cleanly with correct data.",
+          "test_filter": "GdrFlushTest.CuMemDmaBuf_GpuRecvFlush_NoAsyncFatal"
+        },
+        {
+          "name": "GdrFlush_Peermem_NoAsyncFatal",
+          "description": "Whitebox ncclIbIflush over a legacy peermem (ibv_reg_mr) RO=0 scratchpad. Confirms the fix keeps the peermem read path working (never regressed).",
+          "test_filter": "GdrFlushTest.Peermem_GpuRecvFlush_NoAsyncFatal",
+          "env_variables": {
+            "NCCL_CUMEM_ENABLE": "0"
+          }
+        },
+        {
+          "name": "GdrFlush_FeatureDisabled_Fallback",
+          "description": "Whitebox ncclIbIflush fallback branch: with the dedicated RO=0 scratchpad disabled it reads the received buffer directly (upstream-NCCL behaviour).",
+          "test_filter": "GdrFlushTest.FeatureDisabled_FallbackReadRecvBuffer",
+          "env_variables": {
+            "RCCL_GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING": "0"
+          }
+        },
+        {
+          "name": "GdrFlush_RepeatedFlushBurst",
+          "description": "50-iteration GPU recv+flush burst over the dma-buf scratchpad; an intermittent QP async-fatal would surface as a non-success flush. The whole burst must stay clean.",
+          "test_filter": "GdrFlushTest.RepeatedFlush_NoFaultBurst"
+        },
+        {
+          "name": "GdrFlush_ForcedScratchpadWrite_ReproducesFault",
+          "description": "Regression guard (ENABLE_FAULT_INJECTION debug builds only): forces the removed scratchpad RDMA_WRITE back on a dma-buf buffer and asserts the flush QP faults, proving the WRITE was the culprit. Absent/skipped when fault injection is not compiled in.",
+          "test_filter": "GdrFlushTest.ForcedScratchpadWrite_ReproducesFault"
+        }
+      ]
+    },
+
     "net_ib_initialization": {
       "extends": "net_ib_base",
       "timeout": 60,
@@ -916,6 +960,12 @@
       "name": "NET IB - Initialization",
       "description": "InfiniBand plugin initialization and device enumeration",
       "config": "net_ib_initialization",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - GDR Flush (Whitebox ncclIbIflush)",
+      "description": "Whitebox coverage of the NET/IB GDR flush fix: dma-buf and peermem RO=0 scratchpad reads, feature-disabled fallback, repeated-flush burst, and the fault-injection regression guard",
+      "config": "net_ib_gdr_flush",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/lib/schema.json
+++ b/projects/rccl/tools/scripts/test_runner/lib/schema.json
@@ -61,6 +61,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable note about this build configuration (not interpreted by the runner)"
+        },
         "install_flags": {
           "type": "array",
           "items": { "type": "string" },

--- a/projects/rccl/tools/scripts/test_runner/lib/schema.json
+++ b/projects/rccl/tools/scripts/test_runner/lib/schema.json
@@ -61,6 +61,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Set to false to skip building librccl.so entirely (e.g. perf configs whose binaries come from an external build). Defaults to true."
+        },
         "description": {
           "type": "string",
           "description": "Human-readable note about this build configuration (not interpreted by the runner)"

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -622,6 +622,11 @@ class TestExecutor:
                 print("SKIP: Build step skipped (--no-build)")
             return True
 
+        if not self.build_config.get("enabled", True):
+            if self.args.verbose:
+                print("SKIP: librccl build disabled (build_configuration.enabled=false)")
+            return True
+
         print("="*80)
         print("BUILDING RCCL")
         print("="*80)


### PR DESCRIPTION
> Copy of #9206 targeting `rccl/drop_2026-07`.

## Motivation

Direct AllGather was force-disabled whenever user buffer registration was active (`NCCL_LOCAL_REGISTER=1`), so any application that registers buffers lost the Direct AllGather fast path and took a measurable AllGather performance hit. The two features should coexist: registration is an opportunistic, per-operation optimization and does not require turning Direct AllGather off globally.

## Technical Details

Two changes restore upstream-NCCL parity:

- `src/rccl_wrap.cc` (`rcclUseAllGatherDirect`): removed the blanket `if (ncclParamLocalRegister()) return false;` early-out that disabled Direct AllGather for the whole communicator whenever `NCCL_LOCAL_REGISTER` was set. This guard was the workaround introduced with the original UBR enablement (`f2e4b30b64`, AICOMRCCL-98).
- `src/enqueue.cc` (`addP2pToPlan`): wrapped the opportunistic P2P buffer registration — both the NET/DirectNIC path and the intra-node IPC path — in `if (p2pTasks[dir] && p2pTasks[dir]->allowUB) { ... }`. Registration is now gated per-operation on `ncclTaskP2p::allowUB` instead of being globally suppressed, matching upstream NCCL. Ops that opt out of UB simply skip registration; Direct AllGather stays on the default path.

## Issue Tracking

JIRA ID: AICOMRCCL-1553

## Test Plan

Added `UBR_DirectAllGather` coexistence tests in `projects/rccl/test/RegistrationMPITests.cpp` and ran them with `NCCL_LOCAL_REGISTER=1` on MI300X:
- `UbrSizeSweep` — registered Direct AllGather across the LL<->SIMPLE protocol boundary (intra-node IPC path).
- `UbrSizeSweep_MultiNode` — same sweep across nodes, exercising the NET/DMA-buf registration path.
- `BaselineVsUbrEquivalence` — unregistered (`allowUB=false`) then registered (`allowUB=true`) AllGather in one process; both must be correct, proving the gating changes results for neither.

Configs: single node / 8 ranks and 2 nodes / 16 ranks (ppr:8:node, IB, `--mca pml ucx`).

## Test Result

All three tests pass. Single node: 2 passed, `UbrSizeSweep_MultiNode` skipped (requires 2 nodes). Two nodes / 16 ranks: 3 passed with correct AllGather verification, no NCCL failures, no out-of-bounds values, and no regression to the non-registered path.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
