### PR TITLE
fix(rccl): restore in-kernel DDA AlltoAll staging copy for single-block launches

### DIFF
--- a/projects/rccl/src/dda_alltoall_fabric.cu
+++ b/projects/rccl/src/dda_alltoall_fabric.cu
@@ -23,6 +23,20 @@ namespace {
 
 using nccl_dda_detail::DdaFabricBarrierState;
 
+template <typename T, int NRANKS_CT>
+static ncclResult_t launchDdaAllToAllFabric(T** d_ipcbuffs, T* recvbuff, size_t count, const T* sendbuff, int rank,
+                                              int nRanks, meta::comms::FabricGpuBarrier barrierHost, dim3 grid,
+                                              dim3 block, cudaStream_t stream, bool copyInKernel) {
+  if (copyInKernel) {
+    meta::comms::ddaAllToAllFabric<T, NRANKS_CT, true><<<grid, block, 0, stream>>>(
+        d_ipcbuffs, recvbuff, count, sendbuff, rank, nRanks, barrierHost);
+  } else {
+    meta::comms::ddaAllToAllFabric<T, NRANKS_CT, false><<<grid, block, 0, stream>>>(
+        d_ipcbuffs, recvbuff, count, sendbuff, rank, nRanks, barrierHost);
+  }
+  return ncclSuccess;
+}
+
 template <typename T>
 static ncclResult_t ncclAllToAllDdaFabricTyped(const void* sendbuff, void* recvbuff, size_t count, ncclComm* comm,
                                                cudaStream_t stream) {
@@ -50,24 +64,30 @@ static ncclResult_t ncclAllToAllDdaFabricTyped(const void* sendbuff, void* recvb
 
   void* peerPtrsDev = comm->ddaPeerPtrsDev;
   T** d_ipcbuffs = reinterpret_cast<T**>(peerPtrsDev);
+  const bool copyInKernel = meta::comms::ddaAlltoAllSingleBlockGrid(count, sizeof(T));
 
   INFO(NCCL_COLL, "DDA fabric AllToAll: launching kernel: nRanks=%d count=%zu grid=%u block=%u%s", nRanks, count,
        grid.x, block.x, (nRanks == 4 || nRanks == 8) ? " (unrolled)" : " (runtime)");
 
-  CUDACHECK(cudaMemcpyAsync(comm->ddaScratch, sendbuff, totalCount * sizeof(T), cudaMemcpyDeviceToDevice, stream));
+  if (!copyInKernel) {
+    CUDACHECK(cudaMemcpyAsync(comm->ddaScratch, sendbuff, totalCount * sizeof(T), cudaMemcpyDeviceToDevice, stream));
+  }
 
   switch (nRanks) {
   case 4:
-    meta::comms::ddaAllToAllFabric<T, 4><<<grid, block, 0, stream>>>(
-      d_ipcbuffs, static_cast<T*>(recvbuff), count, static_cast<const T*>(sendbuff), comm->rank, nRanks, barrierHost);
+    launchDdaAllToAllFabric<T, 4>(
+        d_ipcbuffs, static_cast<T*>(recvbuff), count, static_cast<const T*>(sendbuff), comm->rank, nRanks, barrierHost,
+        grid, block, stream, copyInKernel);
     break;
   case 8:
-    meta::comms::ddaAllToAllFabric<T, 8><<<grid, block, 0, stream>>>(
-      d_ipcbuffs, static_cast<T*>(recvbuff), count, static_cast<const T*>(sendbuff), comm->rank, nRanks, barrierHost);
+    launchDdaAllToAllFabric<T, 8>(
+        d_ipcbuffs, static_cast<T*>(recvbuff), count, static_cast<const T*>(sendbuff), comm->rank, nRanks, barrierHost,
+        grid, block, stream, copyInKernel);
     break;
   default:
-    meta::comms::ddaAllToAllFabric<T, 0><<<grid, block, 0, stream>>>(
-      d_ipcbuffs, static_cast<T*>(recvbuff), count, static_cast<const T*>(sendbuff), comm->rank, nRanks, barrierHost);
+    launchDdaAllToAllFabric<T, 0>(
+        d_ipcbuffs, static_cast<T*>(recvbuff), count, static_cast<const T*>(sendbuff), comm->rank, nRanks, barrierHost,
+        grid, block, stream, copyInKernel);
     break;
   }
 

--- a/projects/rccl/src/dda_alltoall_ipc.cu
+++ b/projects/rccl/src/dda_alltoall_ipc.cu
@@ -54,9 +54,14 @@ static ncclResult_t ncclAllToAllDdaIpcTyped(const void* sendbuff, void* recvbuff
   void* peerPtrsDev = comm->ddaPeerPtrsDev;
   T** d_ipcbuffs = reinterpret_cast<T**>(peerPtrsDev);
 
-  CUDACHECK(cudaMemcpyAsync(comm->ddaScratch, sendbuff, totalCount * sizeof(T), cudaMemcpyDeviceToDevice, stream));
-  meta::comms::ddaAllToAllIpc<T, kDdaNranks, false><<<grid, block, 0, stream>>>(
-    d_ipcbuffs, static_cast<T*>(recvbuff), count, static_cast<const T*>(sendbuff), comm->rank, barrierHost);
+  if (meta::comms::ddaAlltoAllSingleBlockGrid(count, sizeof(T))) {
+    meta::comms::ddaAllToAllIpc<T, kDdaNranks, false, true><<<grid, block, 0, stream>>>(
+        d_ipcbuffs, static_cast<T*>(recvbuff), count, static_cast<const T*>(sendbuff), comm->rank, barrierHost);
+  } else {
+    CUDACHECK(cudaMemcpyAsync(comm->ddaScratch, sendbuff, totalCount * sizeof(T), cudaMemcpyDeviceToDevice, stream));
+    meta::comms::ddaAllToAllIpc<T, kDdaNranks, false, false><<<grid, block, 0, stream>>>(
+        d_ipcbuffs, static_cast<T*>(recvbuff), count, static_cast<const T*>(sendbuff), comm->rank, barrierHost);
+  }
   CUDACHECK(cudaGetLastError());
 
   return ncclSuccess;

--- a/projects/rccl/src/include/algorithms/CollCommon.h
+++ b/projects/rccl/src/include/algorithms/CollCommon.h
@@ -168,6 +168,15 @@ inline uint32_t divRoundUp(size_t a, size_t b) {
   return y;
 }
 
+// True if per-rank data fits in one CUDA block (512 threads, 16-byte loads per thread).
+// Same threshold as getGridAndBlockDims(). DDA AlltoAll uses it to choose in-kernel
+// staging copy for small messages vs pre-kernel cudaMemcpyAsync for larger ones.
+inline bool ddaAlltoAllSingleBlockGrid(size_t count, int typeSize) {
+  constexpr uint32_t kThreadsPerBlock = 512;
+  const uint32_t elementsPerThread = 16 / typeSize;
+  return count < elementsPerThread * kThreadsPerBlock;
+}
+
 constexpr uint32_t calcBlockCount(size_t numThreads, size_t threadsPerBlock, size_t maxBlocks) {
   const auto uNumThreads = static_cast<uint64_t>(numThreads);
   const auto uThreadsPerBlock = static_cast<uint64_t>(threadsPerBlock);
@@ -190,7 +199,7 @@ inline std::pair<dim3, dim3> getGridAndBlockDims(size_t count, int typeSize, siz
 
   dim3 threads(0, 1, 1);
   dim3 blocks(0, 1, 1);
-  if (count < elementsPerThread * kThreadsPerBlock) {
+  if (ddaAlltoAllSingleBlockGrid(count, typeSize)) {
     threads.x = divRoundUp(count, elementsPerWarp) * kThreadsPerWarp;
     blocks.x = 1;
   } else {

--- a/projects/rccl/src/include/algorithms/alltoall/alltoall_dda.h
+++ b/projects/rccl/src/include/algorithms/alltoall/alltoall_dda.h
@@ -15,14 +15,12 @@
 
 namespace meta::comms {
 
-template <typename T, int NRANKS, bool hasAcc>
+template <typename T, int NRANKS, bool hasAcc, bool kStagingCopyInKernel = false>
 #if defined(USE_ROCM)
 __launch_bounds__(512)
 #endif
   __global__ void ddaAllToAllIpc(T* const* __restrict__ ipcbuffs, T* __restrict__ recvbuff, size_t count,
                                  const T* __restrict__ sendbuff, int selfRank, IpcGpuBarrier barrier) {
-  barrier.syncOnSameBlockIdx<false /* hasPreviousMemAccess */, true /* hasSubsequentMemAccess */>();
-
   // use uint4 to do 16-byte loads to maximize memory efficiency
   // We assume that count % countPerThread == 0. This assumption is enforced
   // before kernel launch
@@ -34,6 +32,21 @@ __launch_bounds__(512)
   const auto idxStart = gtIdx * countPerThread;
   const auto idxEnd = countPerRank;
   const auto idxStride = gridDim.x * blockDim.x * countPerThread;
+
+  if constexpr (kStagingCopyInKernel) {
+    // Small messages: fuse sendbuff -> scratch copy into the kernel to avoid
+    // cudaMemcpyAsync launch overhead on ROCm.
+    const size_t copyCount = count * NRANKS;
+    copyFromSrcToDest<T>(sendbuff, ipcbuffs[selfRank], idxStart, copyCount, idxStride);
+    barrier.syncOnSameBlockIdx<
+        true /* hasPreviousMemAccess */,
+        true /* hasSubsequentMemAccess */>();
+  } else {
+    // Large messages: host enqueues cudaMemcpyAsync into ddaScratch before launch.
+    barrier.syncOnSameBlockIdx<
+        false /* hasPreviousMemAccess */,
+        true /* hasSubsequentMemAccess */>();
+  }
 
   for (size_t idx = idxStart; idx < idxEnd; idx += idxStride) {
 #pragma unroll NRANKS

--- a/projects/rccl/src/include/algorithms/alltoall/alltoall_dda_fabric.h
+++ b/projects/rccl/src/include/algorithms/alltoall/alltoall_dda_fabric.h
@@ -20,15 +20,13 @@
 
 namespace meta::comms {
 
-template <typename T, int NRANKS_CT>
+template <typename T, int NRANKS_CT, bool kStagingCopyInKernel = false>
 #if defined(USE_ROCM)
 __launch_bounds__(512)
 #endif
   __global__
   void ddaAllToAllFabric(T* const* __restrict__ ipcbuffs, T* __restrict__ recvbuff, size_t count,
                          const T* __restrict__ sendbuff, int selfRank, int nRanks, FabricGpuBarrier barrier) {
-  barrier.syncOnSameBlockIdx<false /* hasPreviousMemAccess */, true /* hasSubsequentMemAccess */>();
-
   // use uint4 to do 16-byte loads to maximize memory efficiency. We assume
   // that count % countPerThread == 0, enforced before kernel launch.
   const int nRanksEff = (NRANKS_CT > 0) ? NRANKS_CT : nRanks;
@@ -42,6 +40,18 @@ __launch_bounds__(512)
   const auto idxStart = gtIdx * countPerThread;
   const auto idxEnd = countPerRank;
   const auto idxStride = gridDim.x * blockDim.x * countPerThread;
+
+  if constexpr (kStagingCopyInKernel) {
+    const size_t copyCount = count * nRanksEff;
+    copyFromSrcToDest<T>(sendbuff, ipcbuffs[selfRank], idxStart, copyCount, idxStride);
+    barrier.syncOnSameBlockIdx<
+        true /* hasPreviousMemAccess */,
+        true /* hasSubsequentMemAccess */>();
+  } else {
+    barrier.syncOnSameBlockIdx<
+        false /* hasPreviousMemAccess */,
+        true /* hasSubsequentMemAccess */>();
+  }
 
   for (size_t idx = idxStart; idx < idxEnd; idx += idxStride) {
 #pragma unroll kUnroll

--- a/projects/rccl/test/DdaAlltoAllThresholdTests.cpp
+++ b/projects/rccl/test/DdaAlltoAllThresholdTests.cpp
@@ -95,6 +95,24 @@ TEST_F(DdaAlltoAllThresholdTest, SymmetricSupport_Disabled)
         mockComm_.get(), kAlltoAllFloat32CountAt4MbThreshold, ncclFloat32));
 }
 
+TEST_F(DdaAlltoAllThresholdTest, Gfx950_4KbPerRank_UsesInKernelStagingCopy)
+{
+    mockComm_.reset("gfx950:sramecc+:xnack-");
+    EXPECT_TRUE(testRcclDdaAlltoAllThresholdEnabled(
+        mockComm_.get(), kAlltoAllFloat32CountAt4KbPerRank, ncclFloat32));
+    EXPECT_TRUE(testAlltoAllUsesInKernelStagingCopy(
+        kAlltoAllFloat32CountAt4KbPerRank, ncclFloat32));
+}
+
+TEST_F(DdaAlltoAllThresholdTest, Gfx950_8KbPerRank_UsesPreKernelMemcpy)
+{
+    mockComm_.reset("gfx950:sramecc+:xnack-");
+    EXPECT_TRUE(testRcclDdaAlltoAllThresholdEnabled(
+        mockComm_.get(), kAlltoAllFloat32CountAt8KbPerRank, ncclFloat32));
+    EXPECT_FALSE(testAlltoAllUsesInKernelStagingCopy(
+        kAlltoAllFloat32CountAt8KbPerRank, ncclFloat32));
+}
+
 TEST_F(DdaAlltoAllThresholdTest, StagingBytesAtThresholdMatches4Mb)
 {
     const size_t stagingBytes = testAlltoAllDdaIpcStagingBytes(

--- a/projects/rccl/test/common/DdaAlltoAllTestHelpers.hpp
+++ b/projects/rccl/test/common/DdaAlltoAllTestHelpers.hpp
@@ -8,6 +8,7 @@
 
 #include <cstring>
 
+#include "algorithms/CollCommon.h"
 #include "archinfo.h"
 #include "collectives.h"
 #include "comm.h"
@@ -58,6 +59,12 @@ inline bool testRcclDdaAlltoAllThresholdEnabled(
       kDdaAlltoAllGfx950ThresholdBytes);
 }
 
+// Mirrors dda_alltoall_{ipc,fabric}.cu: in-kernel staging copy on single-block launches only.
+inline bool testAlltoAllUsesInKernelStagingCopy(size_t countPerRank, ncclDataType_t datatype) {
+  const size_t bytesPerRank = countPerRank * static_cast<size_t>(ncclTypeSize(datatype));
+  return meta::comms::ddaAlltoAllSingleBlockGrid(bytesPerRank, /* typeSize= */ 1);
+}
+
 inline size_t testAlltoAllDdaIpcStagingBytes(size_t count, int nRanks, size_t typeSize) {
   return count * static_cast<size_t>(nRanks) * typeSize;
 }
@@ -85,5 +92,11 @@ struct DdaAlltoAllMockComm
 constexpr size_t kAlltoAllFloat32CountAt4MbThreshold =
     kDdaAlltoAllGfx950ThresholdBytes /
     (static_cast<size_t>(nccl_dda_detail::kDdaNranks) * sizeof(float));
+
+// 4 KiB/rank float32: single-block grid on 8-rank IPC launch (in-kernel copy path).
+constexpr size_t kAlltoAllFloat32CountAt4KbPerRank = 1024;
+
+// 8 KiB/rank float32: multi-block grid (pre-kernel memcpy path).
+constexpr size_t kAlltoAllFloat32CountAt8KbPerRank = 2048;
 
 } // namespace RcclUnitTesting


### PR DESCRIPTION
## Motivation

 PR 1514 moved sendbuff→scratch copy to pre-kernel cudaMemcpyAsync, adding ~33% latency on small fp32 in-place AlltoAll (1K–4K/rank) on gfx950. Use in-kernel copy when getGridAndBlockDims selects a single block; keep pre-kernel memcpy for multi-block launches to preserve 1514 correctness.

## Technical Details

- Add ddaAlltoAllSingleBlockGrid() to match the single-block threshold in getGridAndBlockDims()
- Single-block: in-kernel staging copy (pre-1514 behavior)
- Multi-block: pre-kernel cudaMemcpyAsync (1514 behavior)
- Applied to IPC and fabric DDA AlltoAll paths
- Regression: https://github.com/ROCm/rocm-systems/pull/8413

## Issue Tracking

JIRA ID: AICOMRCCL-1649

## Test Plan

- alltoall_perf fp32 in-place, 8 GPUs, 1 node, 50 iters, validation on
- Sizes: 1K–4K (regression), 8K (boundary), 16K–2M (no regression)
- Unit tests for 4 KiB/rank (in-kernel) and 8 KiB/rank (pre-kernel memcpy)

## Test Result

| Size/rank | Baseline | develop | Patch |
|-----------|----------|---------|-------|
| 1K        | 5.04 µs  | 7.42 µs | 5.07 µs |
| 2K        | 5.42 µs  | 7.21 µs | 5.43 µs |
| 4K        | 6.08 µs  | 7.11 µs | 6.10 µs |

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
