### PR TITLE
[rocjitsu] Add trailing filler after lookup-table permutes

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -33,15 +33,15 @@ namespace {
 ///
 /// Separately, a 64-bit source reading FLAT_SCRATCH_BASE is classified via
 /// operand inspection (see gfx1250_reads_flat_scratch_base_64bit). The unbounded
-/// sleep and the affected barrier-state ids are decided entirely by their
-/// semantic rules, which are attempted before raw encoding translation and
-/// return not-handled for the forms that need nothing, leaving those on the copy
-/// path. This classification is looked up first, but its action applies only
-/// once a rule declines, so a predicate here would turn every declined
-/// instruction into a refusal. Ordinary sleeps are copied silently; an
-/// unaffected barrier id is copied too, but still carries the DEFERRED
-/// pass-through report (see gfx1250_b0_to_a0_is_deferred_family), because the
-/// query as a whole has no A0 handling beyond the two spliced ids.
+/// sleep, the affected barrier-state ids, and the lookup-table permutes are
+/// decided entirely by their semantic rules, which are attempted before raw
+/// encoding translation and return not-handled for the forms that need nothing,
+/// leaving those on the copy path. This classification is looked up first, but
+/// its action applies only once a rule declines, so a predicate here would turn
+/// every declined instruction into a refusal. Ordinary sleeps are copied
+/// silently; an unaffected barrier id is copied too, but still carries the
+/// DEFERRED pass-through report (see gfx1250_b0_to_a0_is_deferred_family),
+/// because the query as a whole has no A0 handling beyond the two spliced ids.
 inline constexpr std::array<std::string_view, 17> kExactB0ToA0TranslationMnemonics = {
     "ds_load_2addr_b32",
     "ds_load_2addr_b64",

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -543,6 +543,49 @@ ExpandResult expand_gfx1250_get_barrier_state(const Instruction &inst, uint32_t,
   return ExpandResult::success(std::move(words));
 }
 
+/// @brief Follow a lookup-table permute with a fixed filler.
+///
+/// @details This profile restricts which instruction may issue in the single
+/// slot immediately after the permute to a limited set. The restriction covers
+/// that one slot only, so exactly one filler satisfies it; this is not a
+/// multi-slot spacing requirement and must not be widened into one. The source
+/// may already comply, but once relocation and expansion have run the
+/// translator no longer controls what follows, so the filler is appended
+/// unconditionally.
+///
+/// V_NOP is the filler because it issues regardless of the exec mask. An
+/// ordinary VALU is skipped when the mask is zero and would leave the slot
+/// unoccupied in exactly the divergent regions that are hardest to reason about.
+///
+/// A filler already in that slot is left alone so a second pass over translated
+/// text produces the same bytes. The successor is matched as a decoded
+/// instruction in the same block rather than as the following word, so a
+/// trailing literal that happens to equal the filler's encoding is not mistaken
+/// for one, and a slot that belongs to a different block is not assumed.
+ExpandResult expand_gfx1250_perm_pk16(const Instruction &inst, uint32_t, uint64_t offset,
+                                      std::span<const uint8_t> source_text,
+                                      const LivenessAnalysis &, TranslationContext &,
+                                      const LaneLayout *, const LaneLayout *) {
+  if (inst.size() <= 0 || inst.size() % static_cast<int>(sizeof(uint32_t)) != 0)
+    return ExpandResult::failed("gfx1250 permute rule received an unsupported instruction");
+  const size_t size = static_cast<size_t>(inst.size());
+  // Subtraction keeps the bound check from wrapping on a large offset.
+  if (offset > source_text.size() || size > source_text.size() - offset)
+    return ExpandResult::failed("gfx1250 permute rule received an unsupported instruction");
+
+  const auto filler = gfx1250::build_vop1(gfx1250::kVNopVop1);
+  const Instruction *following = inst.next_instruction();
+  if (following != nullptr && following->size() == static_cast<int>(sizeof(uint32_t)) &&
+      following->raw_encoding() != nullptr && following->raw_encoding()[0] == filler[0]) {
+    return ExpandResult::not_handled();
+  }
+
+  std::vector<uint32_t> words(size / sizeof(uint32_t));
+  std::memcpy(words.data(), source_text.data() + offset, size);
+  append_words(words, filler);
+  return ExpandResult::success(std::move(words));
+}
+
 /// @brief Drain outstanding memory work before an unbounded sleep.
 ///
 /// @details SIMM16[15] selects the unbounded form; SIMM16[6:0] is an ordinary
@@ -2532,7 +2575,7 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
 // The semantic translator binary-searches this table, so entries must stay
 // sorted by the full encoding ID and then opcode. VDS encoding IDs include the
 // high opcode bits, hence the four consecutive kVdsOpHi* groups below.
-inline constexpr std::array<TranslationRule, 44> kGfx1250B0ToA0ExpandRules = {{
+inline constexpr std::array<TranslationRule, 47> kGfx1250B0ToA0ExpandRules = {{
     {gfx1250::encoding::kSop1, gfx1250::kSBarrierSignalIsfirstSop1, RuleAction::Expand, 0, 0,
      nullptr, expand_gfx1250_barrier_signal_isfirst, nullptr, nullptr, false},
     {gfx1250::encoding::kSop1, gfx1250::kSGetBarrierStateSop1, RuleAction::Expand, 0, 0, nullptr,
@@ -2575,6 +2618,12 @@ inline constexpr std::array<TranslationRule, 44> kGfx1250B0ToA0ExpandRules = {{
      expand_gfx1250_tensor_load_to_lds, nullptr, nullptr},
     {gfx1250::encoding::kVop3OpHi3, gfx1250::kVCvtF32Fp8Vop3, RuleAction::Expand, 0, 0, nullptr,
      expand_gfx1250_cvt_f32_fp8_e5m3, nullptr, nullptr},
+    {gfx1250::encoding::kVop3OpHi4, gfx1250::kVPermPk16B4U4Vop3, RuleAction::Expand, 0, 0, nullptr,
+     expand_gfx1250_perm_pk16, nullptr, nullptr, false},
+    {gfx1250::encoding::kVop3OpHi4, gfx1250::kVPermPk16B6U4Vop3, RuleAction::Expand, 0, 0, nullptr,
+     expand_gfx1250_perm_pk16, nullptr, nullptr, false},
+    {gfx1250::encoding::kVop3OpHi4, gfx1250::kVPermPk16B8U4Vop3, RuleAction::Expand, 0, 0, nullptr,
+     expand_gfx1250_perm_pk16, nullptr, nullptr, false},
     {gfx1250::encoding::kVop3OpHi6, gfx1250::kVCvtPkFp8F32Vop3, RuleAction::Expand, 0, 0, nullptr,
      expand_gfx1250_cvt_pk_fp8_f32_e5m3, nullptr, nullptr},
     {gfx1250::encoding::kVop3OpHi6, gfx1250::kVCvtSrFp8F32Vop3, RuleAction::Expand, 0, 0, nullptr,

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -10953,6 +10953,9 @@ TEST(SemanticTranslator, Gfx1250ClassifiesLivenessFreeExpandRules) {
           gfx1250::kVWmmaF3216x16x128Bf8Fp8Vop3p,
       (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
           gfx1250::kVWmmaF3216x16x128Bf8Bf8Vop3p,
+      (static_cast<uint32_t>(gfx1250::encoding::kVop3OpHi4) << 16) | gfx1250::kVPermPk16B4U4Vop3,
+      (static_cast<uint32_t>(gfx1250::encoding::kVop3OpHi4) << 16) | gfx1250::kVPermPk16B6U4Vop3,
+      (static_cast<uint32_t>(gfx1250::encoding::kVop3OpHi4) << 16) | gfx1250::kVPermPk16B8U4Vop3,
   };
   // The standalone 32x16 FP4 and packed-f16 K=128 rules are deliberately
   // absent because they query operand-bank liveness.
@@ -11005,7 +11008,7 @@ TEST(BinaryTranslatorE2E, Gfx1250UsesNeutralScaledK128Fp8Bf8Wmma) {
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
 
-  EXPECT_EQ(rocjitsu::semantic_expand_rules_gfx1250_b0_to_a0().size(), 44u);
+  EXPECT_EQ(rocjitsu::semantic_expand_rules_gfx1250_b0_to_a0().size(), 47u);
   for (const WmmaCase &test_case : cases) {
     SCOPED_TRACE(test_case.name);
     auto source_wmma = gfx1250::build_vop3p(test_case.source_opcode, fields);
@@ -12403,6 +12406,127 @@ TEST(BinaryTranslatorE2E, Gfx1250RepointsPcRelativeDataRangeBoundsAfterRelocatio
 
   ASSERT_NO_FATAL_FAILURE(verify_target(false));
   ASSERT_NO_FATAL_FAILURE(verify_target(true));
+}
+
+// Each lookup-table permute gains a filler in the slot immediately after it,
+// and the rest of the stream is left in place.
+TEST(BinaryTranslatorE2E, Gfx1250AppendsFillerAfterPermPk16ForA0) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const auto filler = gfx1250::build_vop1(gfx1250::kVNopVop1);
+  for (const uint16_t opcode :
+       {gfx1250::kVPermPk16B4U4Vop3, gfx1250::kVPermPk16B6U4Vop3, gfx1250::kVPermPk16B8U4Vop3}) {
+    SCOPED_TRACE(opcode);
+    const auto permute =
+        gfx1250::build_vop3(opcode, {.vdst = 4, .src0 = 256 + 8, .src1 = 256 + 12});
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+        {permute[0], permute[1], kGfx1250SEndpgm});
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    auto result = translator.translate(source);
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    ASSERT_FALSE(translated.text_sections().empty());
+    const auto *out = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+    EXPECT_EQ(out[0], permute[0]) << "the permute itself must be unchanged";
+    EXPECT_EQ(out[1], permute[1]);
+    EXPECT_EQ(out[2], filler[0]) << "a filler must occupy the following slot";
+    EXPECT_EQ(out[3], kGfx1250SEndpgm) << "the rest of the stream must be preserved";
+  }
+}
+
+// A permute carrying a trailing literal keeps it, and the filler goes after the
+// whole instruction rather than between it and its literal.
+TEST(BinaryTranslatorE2E, Gfx1250AppendsFillerAfterLiteralBearingPermPk16ForA0) {
+  constexpr uint16_t kScalarLiteral = 255;
+  constexpr uint32_t kLiteralPayload = 0x0badf00du;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const auto permute = gfx1250::build_vop3(gfx1250::kVPermPk16B4U4Vop3,
+                                           {.vdst = 4, .src0 = kScalarLiteral, .src1 = 256 + 12});
+  const auto filler = gfx1250::build_vop1(gfx1250::kVNopVop1);
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {permute[0], permute[1], kLiteralPayload, kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto *out = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  EXPECT_EQ(out[0], permute[0]);
+  EXPECT_EQ(out[1], permute[1]);
+  EXPECT_EQ(out[2], kLiteralPayload) << "the literal must stay with its instruction";
+  EXPECT_EQ(out[3], filler[0]);
+  EXPECT_EQ(out[4], kGfx1250SEndpgm);
+}
+
+// A distinguishable successor shows the filler is inserted before it rather
+// than replacing it.
+TEST(BinaryTranslatorE2E, Gfx1250KeepsExistingSuccessorAfterPermPk16FillerForA0) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const auto permute =
+      gfx1250::build_vop3(gfx1250::kVPermPk16B4U4Vop3, {.vdst = 4, .src0 = 256 + 8});
+  const auto successor = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 256 + 2, .vdst = 6});
+  const auto filler = gfx1250::build_vop1(gfx1250::kVNopVop1);
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {permute[0], permute[1], successor[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto *out = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  EXPECT_EQ(out[2], filler[0]) << "the filler takes the slot after the permute";
+  EXPECT_EQ(out[3], successor[0]) << "the original follower must be kept";
+  EXPECT_EQ(out[4], kGfx1250SEndpgm);
+}
+
+// A permute whose slot is already filled is left alone, so a second pass over
+// translated text produces the same bytes.
+TEST(BinaryTranslatorE2E, Gfx1250PermPk16FillerIsStableOnSecondPassForA0) {
+  const auto permute =
+      gfx1250::build_vop3(gfx1250::kVPermPk16B4U4Vop3, {.vdst = 4, .src0 = 256 + 8});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {permute[0], permute[1], kGfx1250SEndpgm});
+
+  std::vector<uint8_t> current = image;
+  std::vector<uint32_t> first_pass;
+  for (int pass = 0; pass < 2; ++pass) {
+    rocjitsu::AmdGpuCodeObject source(current.data(), current.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    auto result = translator.translate(source);
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    ASSERT_FALSE(translated.text_sections().empty());
+    const auto *out = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+    const size_t count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+    std::vector<uint32_t> words(out, out + count);
+    if (pass == 0)
+      first_pass = words;
+    else
+      EXPECT_EQ(words, first_pass) << "the second pass must not add another filler";
+    current = result.elf_bytes;
+  }
 }
 
 // The affected barrier-state ids take one result field from a second query.


### PR DESCRIPTION
This profile restricts which instruction may issue after the permute. The input may already satisfy that, but relocation and expansion can change what ends up next, so the translator appends its own filler rather than relying on the neighbor it inherited. A redundant filler costs a single slot.

V_NOP is used because it issues regardless of the exec mask. An ordinary VALU is skipped when the mask is zero, which would leave the slot unoccupied in exactly the divergent regions that are hardest to reason about, so it is not a valid substitute here.