### PR TITLE
[rocjitsu] Make the permute filler effective under an empty mask

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -543,25 +543,46 @@ ExpandResult expand_gfx1250_get_barrier_state(const Instruction &inst, uint32_t,
   return ExpandResult::success(std::move(words));
 }
 
-/// @brief Follow a lookup-table permute with a fixed filler.
+/// @brief Run a lookup-table permute and its filler only under a live mask.
 ///
 /// @details This profile restricts which instruction may issue in the single
-/// slot immediately after the permute to a limited set. The restriction covers
-/// that one slot only, so exactly one filler satisfies it; this is not a
-/// multi-slot spacing requirement and must not be widened into one. The source
-/// may already comply, but once relocation and expansion have run the
-/// translator no longer controls what follows, so the filler is appended
-/// unconditionally.
+/// slot immediately after the permute. The restriction covers that one slot
+/// only, so exactly one filler satisfies it; this is not a multi-slot spacing
+/// rule and must not be widened into one.
 ///
-/// V_NOP is the filler because it issues regardless of the exec mask. An
-/// ordinary VALU is skipped when the mask is zero and would leave the slot
-/// unoccupied in exactly the divergent regions that are hardest to reason about.
+/// The filler occupies that slot only while the exec mask is non-zero; with an
+/// empty mask it degenerates to a scalar no-op and leaves the slot unclaimed.
+/// An ordinary VALU is worse still, being skipped outright.
 ///
-/// A filler already in that slot is left alone so a second pass over translated
-/// text produces the same bytes. The successor is matched as a decoded
-/// instruction in the same block rather than as the following word, so a
-/// trailing literal that happens to equal the filler's encoding is not mistaken
-/// for one, and a slot that belongs to a different block is not assumed.
+/// The mask cannot simply be forced, because the permute itself must keep the
+/// original masking and no instruction may be placed between the two. Branching
+/// over both instead satisfies all of that: the permute writes only a vector
+/// register, so under an empty mask it has no architectural effect and skipping
+/// it matches executing it, while the path that does run is guaranteed a live
+/// mask.
+///
+/// The branch is relative to the instruction after it, and its distance is the
+/// body length plus the filler, so the target is the first instruction past this
+/// sequence rather than one inside it. Both endpoints move together with the
+/// emitted code, so the displacement stays correct wherever the sequence lands
+/// and needs no relocation.
+///
+/// A v_nop already occupying the slot is the filler, whether this rule put it
+/// there or the source did, so it is adopted rather than doubled: exactly one
+/// slot is claimed either way, and the branch distance is the same because the
+/// adopted filler sits immediately after the emitted words.
+///
+/// A sequence already in this shape is left alone so a second pass over
+/// translated text produces the same bytes. The filler is matched as a decoded
+/// instruction in the same block, so a trailing literal equal to its encoding is
+/// not mistaken for it. The guard cannot be matched that way: it is a branch, so
+/// it ends its own block and is never the permute's in-block predecessor, and it
+/// is compared as the preceding word instead. That comparison is only meaningful
+/// where a block boundary says the word can be a branch at all; without the
+/// boundary test, a literal payload equal to the guard's encoding would pass for
+/// one and leave the permute unguarded. Both have to be present before the
+/// sequence is judged already guarded, so a stray word alone does not suppress
+/// the rewrite.
 ExpandResult expand_gfx1250_perm_pk16(const Instruction &inst, uint32_t, uint64_t offset,
                                       std::span<const uint8_t> source_text,
                                       const LivenessAnalysis &, TranslationContext &,
@@ -573,16 +594,41 @@ ExpandResult expand_gfx1250_perm_pk16(const Instruction &inst, uint32_t, uint64_
   if (offset > source_text.size() || size > source_text.size() - offset)
     return ExpandResult::failed("gfx1250 permute rule received an unsupported instruction");
 
+  const size_t instruction_dwords = size / sizeof(uint32_t);
   const auto filler = gfx1250::build_vop1(gfx1250::kVNopVop1);
-  const Instruction *following = inst.next_instruction();
-  if (following != nullptr && following->size() == static_cast<int>(sizeof(uint32_t)) &&
-      following->raw_encoding() != nullptr && following->raw_encoding()[0] == filler[0]) {
-    return ExpandResult::not_handled();
-  }
+  // SOPP carries a signed dword offset, so refuse a body it cannot reach
+  // forward rather than narrowing into a backward branch.
+  const size_t skipped_dwords = instruction_dwords + 1;
+  if (skipped_dwords > static_cast<size_t>(std::numeric_limits<int16_t>::max()))
+    return ExpandResult::failed("gfx1250 permute is too long for its guard branch");
+  const auto guard = gfx1250::build_sopp(gfx1250::kSCbranchExeczSopp,
+                                         {.simm16 = static_cast<uint16_t>(skipped_dwords)});
 
-  std::vector<uint32_t> words(size / sizeof(uint32_t));
-  std::memcpy(words.data(), source_text.data() + offset, size);
-  append_words(words, filler);
+  const Instruction *following = inst.next_instruction();
+  const bool filler_follows =
+      following != nullptr && following->size() == static_cast<int>(sizeof(uint32_t)) &&
+      following->raw_encoding() != nullptr && following->raw_encoding()[0] == filler[0];
+  // The guard is a branch, so it terminates its block and is never the permute's
+  // in-block predecessor. It therefore has to be matched as the preceding word,
+  // but only where the permute starts a block: otherwise the preceding word is
+  // an operand or a literal of the instruction before it, not a branch.
+  const bool guard_precedes =
+      inst.previous_instruction() == nullptr && offset >= sizeof(uint32_t) &&
+      std::memcmp(source_text.data() + offset - sizeof(uint32_t), guard.data(), sizeof(uint32_t)) ==
+          0;
+  if (filler_follows && guard_precedes)
+    return ExpandResult::not_handled();
+
+  std::vector<uint32_t> words;
+  words.reserve(instruction_dwords + 2);
+  append_words(words, guard);
+  const size_t body = words.size();
+  words.resize(body + instruction_dwords);
+  std::memcpy(words.data() + body, source_text.data() + offset, size);
+  // A filler already in the slot is copied through by the caller, so appending
+  // one here would claim a second slot the contract does not ask for.
+  if (!filler_follows)
+    append_words(words, filler);
   return ExpandResult::success(std::move(words));
 }
 

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -12408,18 +12408,36 @@ TEST(BinaryTranslatorE2E, Gfx1250RepointsPcRelativeDataRangeBoundsAfterRelocatio
   ASSERT_NO_FATAL_FAILURE(verify_target(true));
 }
 
-// Each lookup-table permute gains a filler in the slot immediately after it,
-// and the rest of the stream is left in place.
-TEST(BinaryTranslatorE2E, Gfx1250AppendsFillerAfterPermPk16ForA0) {
+// Each lookup-table permute runs under a guard so its filler is always
+// effective: an empty mask skips both, a live mask runs both.
+TEST(BinaryTranslatorE2E, Gfx1250GuardsPermPk16FillerWithMaskBranchForA0) {
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   const auto filler = gfx1250::build_vop1(gfx1250::kVNopVop1);
-  for (const uint16_t opcode :
-       {gfx1250::kVPermPk16B4U4Vop3, gfx1250::kVPermPk16B6U4Vop3, gfx1250::kVPermPk16B8U4Vop3}) {
-    SCOPED_TRACE(opcode);
-    const auto permute =
-        gfx1250::build_vop3(opcode, {.vdst = 4, .src0 = 256 + 8, .src1 = 256 + 12});
-    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
-        {permute[0], permute[1], kGfx1250SEndpgm});
+  constexpr uint16_t kScalarLiteral = 255;
+  constexpr uint32_t kLiteralPayload = 0x0badf00du;
+  struct PermuteCase {
+    uint16_t opcode;
+    bool literal;
+  };
+  // The literal form is twelve bytes, so it also proves the branch distance is
+  // derived from the instruction rather than fixed for the eight-byte one.
+  const std::vector<PermuteCase> cases = {{gfx1250::kVPermPk16B4U4Vop3, false},
+                                          {gfx1250::kVPermPk16B6U4Vop3, false},
+                                          {gfx1250::kVPermPk16B8U4Vop3, false},
+                                          {gfx1250::kVPermPk16B4U4Vop3, true}};
+  for (const PermuteCase &test_case : cases) {
+    SCOPED_TRACE(test_case.opcode);
+    SCOPED_TRACE(test_case.literal ? "literal" : "no literal");
+    const auto permute = gfx1250::build_vop3(
+        test_case.opcode,
+        {.vdst = 4,
+         .src0 = test_case.literal ? kScalarLiteral : static_cast<uint16_t>(256 + 8),
+         .src1 = 256 + 12});
+    std::vector<uint32_t> text = {permute[0], permute[1]};
+    if (test_case.literal)
+      text.push_back(kLiteralPayload);
+    text.push_back(kGfx1250SEndpgm);
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(text);
     rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
     rocjitsu::BinaryTranslator translator(
         ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
@@ -12432,41 +12450,34 @@ TEST(BinaryTranslatorE2E, Gfx1250AppendsFillerAfterPermPk16ForA0) {
     rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
     ASSERT_FALSE(translated.text_sections().empty());
     const auto *out = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
-    EXPECT_EQ(out[0], permute[0]) << "the permute itself must be unchanged";
-    EXPECT_EQ(out[1], permute[1]);
-    EXPECT_EQ(out[2], filler[0]) << "a filler must occupy the following slot";
-    EXPECT_EQ(out[3], kGfx1250SEndpgm) << "the rest of the stream must be preserved";
+    const size_t body_dwords = test_case.literal ? 3u : 2u;
+    const auto expected_guard = gfx1250::build_sopp(
+        gfx1250::kSCbranchExeczSopp, {.simm16 = static_cast<uint16_t>(body_dwords + 1)});
+    EXPECT_EQ(out[0], expected_guard[0]) << "the guard must precede the permute";
+    EXPECT_EQ(out[1], permute[0]) << "the permute itself must be unchanged";
+    EXPECT_EQ(out[2], permute[1]);
+    if (test_case.literal) {
+      EXPECT_EQ(out[3], kLiteralPayload) << "the literal must stay with its instruction";
+    }
+    EXPECT_EQ(out[1 + body_dwords], filler[0]) << "the filler must directly follow the permute";
+    EXPECT_EQ(out[2 + body_dwords], kGfx1250SEndpgm) << "the rest of the stream is preserved";
+
+    // Read the sequence back through the decoder so the hand-built guard is
+    // checked against the ISA definition rather than against its own builder.
+    const auto decoded =
+        decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+    ASSERT_GE(decoded.size(), 4u);
+    EXPECT_EQ(decoded[0]->mnemonic(), "s_cbranch_execz");
+    EXPECT_TRUE(decoded[1]->mnemonic().starts_with("v_perm_pk16_"));
+    EXPECT_EQ(decoded[2]->mnemonic(), "v_nop_e32");
+    // The branch is relative to the instruction after it, so its target is the
+    // first instruction past the filler.
+    const auto branch_delta = decoded[0]->branch_offset_bytes();
+    ASSERT_TRUE(branch_delta.has_value());
+    EXPECT_EQ(static_cast<int64_t>(decoded[0]->src_loc()) + sizeof(uint32_t) + *branch_delta,
+              static_cast<int64_t>(decoded[3]->src_loc()))
+        << "the guard must skip exactly the permute and its filler";
   }
-}
-
-// A permute carrying a trailing literal keeps it, and the filler goes after the
-// whole instruction rather than between it and its literal.
-TEST(BinaryTranslatorE2E, Gfx1250AppendsFillerAfterLiteralBearingPermPk16ForA0) {
-  constexpr uint16_t kScalarLiteral = 255;
-  constexpr uint32_t kLiteralPayload = 0x0badf00du;
-  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
-  const auto permute = gfx1250::build_vop3(gfx1250::kVPermPk16B4U4Vop3,
-                                           {.vdst = 4, .src0 = kScalarLiteral, .src1 = 256 + 12});
-  const auto filler = gfx1250::build_vop1(gfx1250::kVNopVop1);
-  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
-      {permute[0], permute[1], kLiteralPayload, kGfx1250SEndpgm});
-  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
-  rocjitsu::BinaryTranslator translator(
-      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
-      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
-                               rocjitsu::ProcessorRevision::Gfx1250A0));
-  auto result = translator.translate(source);
-  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
-                                                          : result.diagnostics.front().message);
-
-  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
-  ASSERT_FALSE(translated.text_sections().empty());
-  const auto *out = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
-  EXPECT_EQ(out[0], permute[0]);
-  EXPECT_EQ(out[1], permute[1]);
-  EXPECT_EQ(out[2], kLiteralPayload) << "the literal must stay with its instruction";
-  EXPECT_EQ(out[3], filler[0]);
-  EXPECT_EQ(out[4], kGfx1250SEndpgm);
 }
 
 // A distinguishable successor shows the filler is inserted before it rather
@@ -12491,14 +12502,188 @@ TEST(BinaryTranslatorE2E, Gfx1250KeepsExistingSuccessorAfterPermPk16FillerForA0)
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_FALSE(translated.text_sections().empty());
   const auto *out = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
-  EXPECT_EQ(out[2], filler[0]) << "the filler takes the slot after the permute";
-  EXPECT_EQ(out[3], successor[0]) << "the original follower must be kept";
-  EXPECT_EQ(out[4], kGfx1250SEndpgm);
+  EXPECT_EQ(out[3], filler[0]) << "the filler takes the slot after the permute";
+  EXPECT_EQ(out[4], successor[0]) << "the original follower must be kept";
+  EXPECT_EQ(out[5], kGfx1250SEndpgm);
+
+  // The skipped span must end on the original follower, not short of it.
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_GE(decoded.size(), 4u);
+  EXPECT_EQ(decoded[0]->mnemonic(), "s_cbranch_execz");
+  EXPECT_EQ(decoded[3]->mnemonic(), "v_mov_b32_e32");
+  const auto branch_delta = decoded[0]->branch_offset_bytes();
+  ASSERT_TRUE(branch_delta.has_value());
+  EXPECT_EQ(static_cast<int64_t>(decoded[0]->src_loc()) + sizeof(uint32_t) + *branch_delta,
+            static_cast<int64_t>(decoded[3]->src_loc()))
+      << "the guard must land on the original follower";
 }
 
-// A permute whose slot is already filled is left alone, so a second pass over
+// A permute already in the guarded shape is left alone, so a second pass over
 // translated text produces the same bytes.
-TEST(BinaryTranslatorE2E, Gfx1250PermPk16FillerIsStableOnSecondPassForA0) {
+// Inserting the guard and filler grows the text, so any branch spanning the
+// permute has to be repaired. A back edge must re-enter at the guard rather than
+// at the permute, or the body would run once with an unchecked mask.
+TEST(BinaryTranslatorE2E, Gfx1250RepairsLoopBackEdgeAroundGuardedPermPk16ForA0) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const auto permute = gfx1250::build_vop3(gfx1250::kVPermPk16B4U4Vop3,
+                                           {.vdst = 4, .src0 = 256 + 8, .src1 = 256 + 10});
+  // Branch back three dwords from the instruction after it, landing on the
+  // permute: [permute lo, permute hi, back edge] is the loop body.
+  const auto back_edge =
+      gfx1250::build_sopp(gfx1250::kSCbranchExecnzSopp, {.simm16 = static_cast<uint16_t>(-3)});
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {permute[0], permute[1], back_edge[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  // Pin the inserted sequence, not just the back edge: without these the rule
+  // could decline the input entirely and the retarget check would still hold,
+  // because decoded[0] would be the pre-existing branch.
+  ASSERT_GE(decoded.size(), 4u);
+  EXPECT_EQ(decoded[0]->mnemonic(), "s_cbranch_execz") << "the guard heads the loop body";
+  EXPECT_TRUE(decoded[1]->mnemonic().starts_with("v_perm_pk16_"));
+  EXPECT_EQ(decoded[2]->mnemonic(), "v_nop_e32") << "the rule must have inserted its own filler";
+
+  const rocjitsu::Instruction *edge = nullptr;
+  for (const auto &inst : decoded) {
+    if (inst->mnemonic() == "s_cbranch_execnz")
+      edge = inst.get();
+  }
+  ASSERT_NE(edge, nullptr);
+  const auto delta = edge->branch_offset_bytes();
+  ASSERT_TRUE(delta.has_value());
+  EXPECT_EQ(static_cast<int64_t>(edge->src_loc()) + sizeof(uint32_t) + *delta,
+            static_cast<int64_t>(decoded[0]->src_loc()))
+      << "the back edge must re-enter at the guard, not inside the guarded body";
+}
+
+// A guard already present but not in this rule's exact shape is not recognized,
+// so the rule wraps its own. The pre-existing branch must still reach what it
+// originally skipped once the text has grown.
+TEST(BinaryTranslatorE2E, Gfx1250RepairsNoncanonicalGuardAroundPermPk16ForA0) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const auto permute = gfx1250::build_vop3(gfx1250::kVPermPk16B4U4Vop3,
+                                           {.vdst = 4, .src0 = 256 + 8, .src1 = 256 + 10});
+  // Skips the two permute dwords only, so it is not the encoding this rule emits.
+  const auto existing = gfx1250::build_sopp(gfx1250::kSCbranchExeczSopp, {.simm16 = 2});
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {existing[0], permute[0], permute[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_GE(decoded.size(), 2u);
+  EXPECT_EQ(decoded[0]->mnemonic(), "s_cbranch_execz");
+
+  const auto delta = decoded[0]->branch_offset_bytes();
+  ASSERT_TRUE(delta.has_value());
+  const int64_t target = static_cast<int64_t>(decoded[0]->src_loc()) + sizeof(uint32_t) + *delta;
+  EXPECT_EQ(target, static_cast<int64_t>(decoded.back()->src_loc()))
+      << "the pre-existing branch must still land past the permute it skipped";
+  EXPECT_EQ(decoded.back()->mnemonic(), "s_endpgm");
+}
+
+// The guard is recognized as the preceding word, so a literal payload equal to
+// its encoding would masquerade as one and suppress the rewrite. Only a real
+// branch ends a block, so the permute must also start one for the match to
+// stand.
+TEST(BinaryTranslatorE2E, Gfx1250GuardsPermPk16AfterLiteralMatchingGuardEncodingForA0) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint16_t kScalarLiteral = 255;
+  const auto permute =
+      gfx1250::build_vop3(gfx1250::kVPermPk16B4U4Vop3, {.vdst = 4, .src0 = 256 + 8});
+  const auto filler = gfx1250::build_vop1(gfx1250::kVNopVop1);
+  // The payload is the exact guard this rule emits for a two-dword permute, and
+  // it lands in the word directly before one.
+  const auto guard = gfx1250::build_sopp(gfx1250::kSCbranchExeczSopp, {.simm16 = 3});
+  const auto carrier = gfx1250::build_vop3(gfx1250::kVAddF32Vop3,
+                                           {.vdst = 2, .src0 = kScalarLiteral, .src1 = 256 + 1});
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {carrier[0], carrier[1], guard[0], permute[0], permute[1], filler[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  const auto permute_at = std::ranges::find_if(
+      decoded, [](const auto &inst) { return inst->mnemonic().starts_with("v_perm_pk16_"); });
+  ASSERT_NE(permute_at, decoded.end());
+  ASSERT_NE(permute_at, decoded.begin());
+  EXPECT_EQ((*std::prev(permute_at))->mnemonic(), "s_cbranch_execz")
+      << "a literal that merely looks like the guard must not suppress the rewrite";
+}
+
+// A source v_nop already in the slot is the filler, so the rule must adopt it
+// rather than append a second one: the contract is exactly one claimed slot.
+TEST(BinaryTranslatorE2E, Gfx1250AdoptsExistingVNopAsPermPk16FillerForA0) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const auto permute =
+      gfx1250::build_vop3(gfx1250::kVPermPk16B4U4Vop3, {.vdst = 4, .src0 = 256 + 8});
+  const auto filler = gfx1250::build_vop1(gfx1250::kVNopVop1);
+  const auto guard = gfx1250::build_sopp(gfx1250::kSCbranchExeczSopp, {.simm16 = 3});
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {permute[0], permute[1], filler[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto *out = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  const size_t count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+  ASSERT_GE(count, 5u);
+  EXPECT_EQ(out[0], guard[0]) << "the guard is still added, because none was present";
+  EXPECT_EQ(out[1], permute[0]);
+  EXPECT_EQ(out[2], permute[1]);
+  EXPECT_EQ(out[3], filler[0]);
+  EXPECT_EQ(out[4], kGfx1250SEndpgm) << "the source v_nop must serve as the filler, not be doubled";
+
+  // The guard still has to skip the whole sequence, adopted filler included.
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_GE(decoded.size(), 4u);
+  EXPECT_EQ(decoded[0]->mnemonic(), "s_cbranch_execz");
+  EXPECT_EQ(decoded[3]->mnemonic(), "s_endpgm");
+  const auto delta = decoded[0]->branch_offset_bytes();
+  ASSERT_TRUE(delta.has_value());
+  EXPECT_EQ(static_cast<int64_t>(decoded[0]->src_loc()) + sizeof(uint32_t) + *delta,
+            static_cast<int64_t>(decoded[3]->src_loc()));
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250PermPk16GuardIsStableOnSecondPassForA0) {
   const auto permute =
       gfx1250::build_vop3(gfx1250::kVPermPk16B4U4Vop3, {.vdst = 4, .src0 = 256 + 8});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
@@ -12524,7 +12709,7 @@ TEST(BinaryTranslatorE2E, Gfx1250PermPk16FillerIsStableOnSecondPassForA0) {
     if (pass == 0)
       first_pass = words;
     else
-      EXPECT_EQ(words, first_pass) << "the second pass must not add another filler";
+      EXPECT_EQ(words, first_pass) << "the second pass must not add another guard or filler";
     current = result.elf_bytes;
   }
 }


### PR DESCRIPTION
The filler the preceding commit appends after a lookup-table permute claims the
following slot only while the exec mask is non-zero. Under an empty mask a
v_nop degenerates to a scalar no-op and the slot goes unclaimed, and an ordinary
VALU is worse still, being skipped outright. The mask cannot simply be forced,
because the permute has to keep its original masking and nothing may be placed
between the two, so the filler this commit completes is ineffective exactly
where it is needed.

A branch over both resolves it: the permute writes only a vector register, so
under an empty mask skipping it matches executing it, while the path that does
run is guaranteed a live mask. The branch is relative to the instruction after
it and spans the body plus the filler, so both endpoints move with the emitted
code and no relocation is needed; branches that span the permute are repaired by
the existing placement map, and a body beyond the signed simm16 forward range is
refused rather than narrowed into a backward branch. A v_nop already in the slot
is adopted instead of doubled, and a sequence already in this shape is left
alone -- which requires the permute to start a basic block, or a literal payload
equal to the guard encoding would pass for a guard and leave the permute
unprotected.