### PR TITLE
fix(clr): honor hipExtAnyOrderLaunch for captured kernel nodes

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -76,7 +76,8 @@ hipError_t ihipGraphAddKernelNode(hip::GraphNode** pGraphNode, hip::Graph* graph
                                   int globalWorkSizeX_remainder = 0,
                                   int globalWorkSizeY_remainder = 0,
                                   int globalWorkSizeZ_remainder = 0,
-                                  dim3 clusterDim = {1, 1, 1}) {
+                                  dim3 clusterDim = {1, 1, 1},
+                                  uint32_t launchFlags = 0) {
   if (!hip::Graph::isGraphValid(graph)) {
     return hipErrorInvalidValue;
   }
@@ -117,7 +118,8 @@ hipError_t ihipGraphAddKernelNode(hip::GraphNode** pGraphNode, hip::Graph* graph
 
   *pGraphNode =
       new hip::GraphKernelNode(pNodeParams, pNodeEvents, coopKernel, globalWorkSizeX_remainder,
-                               globalWorkSizeY_remainder, globalWorkSizeZ_remainder, clusterDim);
+                               globalWorkSizeY_remainder, globalWorkSizeZ_remainder, clusterDim,
+                               launchFlags);
   status = ihipGraphAddNode(*pGraphNode, graph, pDependencies, numDependencies, capture, deviceId);
   return status;
 }
@@ -302,7 +304,8 @@ hipError_t ihipExtLaunchKernel(hipStream_t stream, hipFunction_t f, uint32_t glo
   status = ihipGraphAddKernelNode(
       &pGraphNode, s->GetCaptureGraph(), s->GetLastCapturedNodes().data(),
       s->GetLastCapturedNodes().size(), &nodeParams, &nodeEvents, true, 0, s->DeviceId(),
-      globalWorkSizeX_remainder, globalWorkSizeY_remainder, globalWorkSizeZ_remainder);
+      globalWorkSizeX_remainder, globalWorkSizeY_remainder, globalWorkSizeZ_remainder,
+      {1, 1, 1}, flags);
 
   if (status != hipSuccess) {
     return status;

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1422,6 +1422,7 @@ class GraphKernelNode : public GraphNode {
   int globalWorkSizeY_remainder_;
   int globalWorkSizeZ_remainder_;
   dim3 clusterDim_;                    //!< Cluster dimensions for cluster launch
+  uint32_t launchFlags_;               //!< Ext launch flags (e.g. hipExtAnyOrderLaunch)
   hipFunction_t resolvedFunc_ = nullptr;  //!< Cached resolved function to avoid redundant lookups
 
  protected:
@@ -1434,6 +1435,7 @@ class GraphKernelNode : public GraphNode {
     globalWorkSizeY_remainder_ = rhs.globalWorkSizeY_remainder_;
     globalWorkSizeZ_remainder_ = rhs.globalWorkSizeZ_remainder_;
     clusterDim_ = rhs.clusterDim_;
+    launchFlags_ = rhs.launchFlags_;
     hipError_t status = copyParams(&rhs.kernelParams_);
     if (status != hipSuccess) {
       ClPrint(amd::LOG_ERROR, amd::LOG_CODE, "[hipGraph] Failed to allocate memory to copy params");
@@ -1655,7 +1657,8 @@ class GraphKernelNode : public GraphNode {
                   int globalWorkSizeX_remainder = 0,
                   int globalWorkSizeY_remainder = 0,
                   int globalWorkSizeZ_remainder = 0,
-                  dim3 clusterDim = {1, 1, 1})
+                  dim3 clusterDim = {1, 1, 1},
+                  uint32_t launchFlags = 0)
       : GraphNode(hipGraphNodeTypeKernel, "bold", "octagon", "KERNEL") {
     kernelEvents_ = {0};
     if (pEvents != nullptr) {
@@ -1672,6 +1675,7 @@ class GraphKernelNode : public GraphNode {
     globalWorkSizeY_remainder_ = globalWorkSizeY_remainder;
     globalWorkSizeZ_remainder_ = globalWorkSizeZ_remainder;
     clusterDim_ = clusterDim;
+    launchFlags_ = launchFlags;
   }
 
   ~GraphKernelNode() { freeParams(); }
@@ -1734,17 +1738,8 @@ class GraphKernelNode : public GraphNode {
     }
     commands_.reserve(1);
     amd::Command* command;
-    uint32_t flags = 0;
-    if (DEBUG_HIP_FORCE_ASYNC_QUEUE) {
-      // If there is one dependency, but many edges, then execute this node in any order
-      if (((dependencies_.size() == 1) && (dependencies_[0]->GetEdges().size() > 1) &&
-           (DEBUG_HIP_FORCE_GRAPH_QUEUES == 1))) {
-        // Makes sure the first node in the edges will have a barrier always
-        if (dependencies_[0]->GetEdges()[0] != this) {
-          flags = hipExtAnyOrderLaunch;
-        }
-      }
-    }
+    // Honor ext launch flags captured at graph-build time (e.g. hipExtAnyOrderLaunch).
+    uint32_t flags = launchFlags_;
 
     const amd::Device* device = g_devices[dev_id_]->devices()[0];
     amd::HIPLaunchParams launch_params(kernelParams_.gridDim.x, kernelParams_.gridDim.y,

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -241,8 +241,6 @@ release(bool, HIP_VMEM_MANAGE_SUPPORT, true,                                  \
         "Virtual Memory Management Support")                                  \
 release(uint, DEBUG_HIP_GRAPH_DOT_PRINT, 0,                               \
         "0 = Disable, 1 = Print during Graph Inst, 2 = Print during Graph Launch") \
-release(bool, DEBUG_HIP_FORCE_ASYNC_QUEUE, false,                             \
-        "Forces grpahs into async queue mode. DEBUG_HIP_FORCE_GRAPH_QUEUES must be 1") \
 release(uint, DEBUG_HIP_FORCE_GRAPH_QUEUES, 4,                                \
         "Forces the number of streams for the graph parallel execution")      \
 release(uint, DEBUG_HIP_GRAPH_BATCH_SIZE, 256,                                \


### PR DESCRIPTION
When a kernel launched with hipExtAnyOrderLaunch was captured into a graph (via hipExtLaunchKernel / hipExtModuleLaunchKernel), the flag was silently dropped: ihipExtLaunchKernel received the flags but never forwarded them to ihipGraphAddKernelNode, GraphKernelNode had no field to store them, and GraphKernelNode::CreateCommand hardcoded flags = 0. As a result the dispatch packet's barrier bit stayed set (header 0xb02) for the graph node, whereas the same direct launch correctly cleared it (0xa02), so any-order execution was not actually enabled inside graphs.

Thread the captured launch flags through the capture path: store them on a new GraphKernelNode::launchFlags_ member, forward them from ihipExtLaunchKernel through ihipGraphAddKernelNode into the node constructor, and use the stored value in CreateCommand. Ordered launches (no flag) are unaffected and keep their barrier bit.

Also drop the now-redundant DEBUG_HIP_FORCE_ASYNC_QUEUE debug override in CreateCommand and remove the flag definition from flags.hpp, since the real capture path now carries the flag.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
JIRA ID: AIRUNTIME-0

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
