### PR TITLE
[rocjitsu][CI] Qualify gfx1250 runtime translations

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -23,9 +23,9 @@ on:
         default: "ROCm/rocjitsu-test-corpus"
         required: true
       corpus_ref:
-        description: "Branch, tag, or SHA containing the packaged-HSACO DBT suite"
-        # Last updated on 2026/07/28.
-        default: "4c232fc5da6e42bb8fb16e2d8797b3415afeca47"
+        description: "Branch, tag, or SHA containing the gfx1250 corpus suites"
+        # Last updated on 2026/07/29.
+        default: "42944a3ff37490441dcd0f1838e289a419af082d"
         required: true
       legacy_corpus_ref:
         description: "Branch, tag, or SHA for the existing corpus tests"
@@ -72,6 +72,7 @@ jobs:
             # leaves substantial runner headroom while this release-only gate lands.
             verify_dbt_idempotence: 1
             dbt_timeout: 60
+            dbt_memory_limit_mib: 4096
             dbt_job_timeout: 20
             test_regex: ''
             build_type: Release
@@ -86,6 +87,7 @@ jobs:
             # paths remain covered by the sanitizer test suite.
             verify_dbt_idempotence: 0
             dbt_timeout: 90
+            dbt_memory_limit_mib: 4096
             dbt_job_timeout: 30
             test_regex: ''
             build_type: RelWithDebInfo
@@ -98,6 +100,7 @@ jobs:
             allow_failure: false
             verify_dbt_idempotence: 0
             dbt_timeout: 30
+            dbt_memory_limit_mib: 4096
             dbt_job_timeout: 20
             run_static_asan_launch: true
             test_regex: ''
@@ -110,7 +113,10 @@ jobs:
           - name: asan-ubsan-gcc
             allow_failure: true
             verify_dbt_idempotence: 0
-            dbt_timeout: 90
+            # GCC's combined sanitizers need additional headroom on the largest
+            # packaged code objects.
+            dbt_timeout: 180
+            dbt_memory_limit_mib: 8192
             dbt_job_timeout: 30
             test_regex: ''
             build_type: RelWithDebInfo
@@ -154,13 +160,13 @@ jobs:
           ref: ${{ github.event.inputs.legacy_corpus_ref || 'aa54cc86c9ebff3eb840743b36ff8d9b3b2d43c4' }}
           path: rocjitsu-test-corpus
 
-      - name: Checkout rocjitsu DBT corpus
+      - name: Checkout gfx1250 corpus
         if: matrix.enable_tsan == 0
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ github.event.inputs.corpus_repository || 'ROCm/rocjitsu-test-corpus' }}
-          # Last updated on 2026/07/28.
-          ref: ${{ github.event.inputs.corpus_ref || '4c232fc5da6e42bb8fb16e2d8797b3415afeca47' }}
+          # Last updated on 2026/07/29.
+          ref: ${{ github.event.inputs.corpus_ref || '42944a3ff37490441dcd0f1838e289a419af082d' }}
           path: rocjitsu-dbt-test-corpus
 
       - name: Set up Python
@@ -338,6 +344,59 @@ jobs:
           bash "${ROCJITSU_SOURCE_DIR}/tests/corpus/run-corpus-tests.sh" "${corpus_test_flags[@]}" || corpus_test_status=$?
           exit "${corpus_test_status}"
 
+      - name: Compare plain and translated gfx1250 simulator runs
+        if: ${{ !cancelled() && matrix.name == 'release' && steps.build_rocjitsu.outcome == 'success' }}
+        timeout-minutes: 45
+        working-directory: ${{ env.ROCJITSU_DBT_CORPUS_DIR }}
+        shell: bash
+        env:
+          ROCJITSU_SEMANTIC_TIMEOUT_SECONDS: 120
+        run: |
+          ROCM_PATH="$(rocm-sdk path --root)"
+          export ROCM_PATH
+          LAUNCHER="${ROCJITSU_BUILD_DIR}/tools/rocjitsu/rocjitsu"
+          CONFIG="${ROCJITSU_SOURCE_DIR}/configs/gfx1250.json"
+          HOTSWAP="${ROCJITSU_BUILD_DIR}/lib/rocjitsu/src/rocjitsu/hooks/libhsa_hotswap_rocjitsu.so"
+          test -f "${HOTSWAP}"
+          # Disable ROCr's built-in mechanism in both legs. Load the branch-built
+          # hook explicitly so the candidate leg qualifies this checkout. Keep
+          # every env option before the shared NAME=VALUE assignment.
+          COMMON_UNSETS="-u LD_PRELOAD -u HSA_HOTSWAP_ENABLE"
+          COMMON_HOTSWAP_ENV="HSA_HOTSWAP_DISABLE=1"
+          PLAIN_WRAPPER="env ${COMMON_UNSETS} -u HSA_TOOLS_LIB -u HSA_TOOLS_DISABLE_REGISTER -u HSA_HOTSWAP_VERBOSE ${COMMON_HOTSWAP_ENV} ${LAUNCHER} --config ${CONFIG} --"
+          TRANSLATED_WRAPPER="env ${COMMON_UNSETS} ${COMMON_HOTSWAP_ENV} HSA_TOOLS_DISABLE_REGISTER=1 HSA_TOOLS_LIB=${HOTSWAP} HSA_HOTSWAP_VERBOSE=1 ${LAUNCHER} --config ${CONFIG} --"
+
+          python3 -m pytest tests/test_corpus.py \
+            --target gfx1250 \
+            --suite semantics \
+            --run-tests-config "${ROCJITSU_SOURCE_DIR}/tests/corpus/gfx1250_b0_a0_semantic_tests.json" \
+            --run-wrapper "${PLAIN_WRAPPER}" \
+            --comparison-run-wrapper "${TRANSLATED_WRAPPER}" \
+            --comparison-required-stderr "[hsa-hotswap-rj] eager translated " \
+            --comparison-required-stderr "status=0" \
+            --artifact-directory .pytest-artifacts/gfx1250-semantic-qualification \
+            --timeout "${ROCJITSU_SEMANTIC_TIMEOUT_SECONDS}" \
+            -q \
+            --tb=short
+
+          python3 "${ROCJITSU_SOURCE_DIR}/tests/corpus/validate-gfx1250-semantic-translations.py" \
+            --translator "${ROCJITSU_BUILD_DIR}/tools/rj_dbt_translate" \
+            --selection "${ROCJITSU_SOURCE_DIR}/tests/corpus/gfx1250_b0_a0_semantic_tests.json" \
+            --expectations "${ROCJITSU_SOURCE_DIR}/tests/corpus/gfx1250_b0_a0_semantic_rewrites.json" \
+            --artifact-directory .pytest-artifacts/gfx1250-semantic-qualification \
+            --expected-runtime-translations 2
+
+      - name: Upload gfx1250 semantic qualification logs
+        if: ${{ always() && matrix.name == 'release' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gfx1250-semantic-qualification-${{ matrix.name }}
+          path: |
+            ${{ env.ROCJITSU_DBT_CORPUS_DIR }}/.pytest-artifacts/gfx1250-semantic-qualification/**/logs
+            ${{ env.ROCJITSU_DBT_CORPUS_DIR }}/.pytest-artifacts/gfx1250-semantic-qualification/translation-diffs
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Extract pinned gfx1250 packaged HSACOs
         id: extract_dbt
         if: ${{ !cancelled() && matrix.enable_tsan == 0 && steps.build_rocjitsu.outcome == 'success' }}
@@ -393,6 +452,7 @@ jobs:
             --dbt-expected-rewrites "${ROCJITSU_SOURCE_DIR}/tests/corpus/dbt/gfx1250_b0_a0_expected_rewrites.json" \
             --dbt-allow-incomplete-corpus \
             --dbt-timeout "${{ matrix.dbt_timeout }}" \
+            --dbt-memory-limit-mib "${{ matrix.dbt_memory_limit_mib }}" \
             --artifact-directory .pytest-artifacts/gfx1250-dbt \
             -n "${DBT_WORKERS}" \
             -q \

--- a/emulation/rocjitsu/tests/corpus/README.md
+++ b/emulation/rocjitsu/tests/corpus/README.md
@@ -1,0 +1,17 @@
+# RocJITsu corpus policy
+
+`gfx1250_b0_a0_semantic_tests.json` selects semantic programs whose instruction
+forms have implemented runtime translations. The companion
+`gfx1250_b0_a0_semantic_rewrites.json` pins the exact positive offline rewrite
+count for every selected executable.
+
+Four source-coverage programs are intentionally outside this qualification
+until their translations are implemented:
+
+- `barrier_signal_isfirst_test`
+- `fp8_e5m3_pack_test`
+- `wmma_split_f16_test`
+- `wmma_split_fp4_test`
+
+The offline translator currently rejects those forms as unsupported. They are
+not silently accepted or treated as passing translations.

--- a/emulation/rocjitsu/tests/corpus/gfx1250_b0_a0_semantic_rewrites.json
+++ b/emulation/rocjitsu/tests/corpus/gfx1250_b0_a0_semantic_rewrites.json
@@ -1,0 +1,41 @@
+{
+  "schema": 1,
+  "tests": {
+    "cluster_load_test": {
+      "instructions_requiring_rewrite": 14
+    },
+    "ds_2addr_test": {
+      "instructions_requiring_rewrite": 9
+    },
+    "ds_addtid_test": {
+      "instructions_requiring_rewrite": 3
+    },
+    "ds_storexchg_2addr_test": {
+      "instructions_requiring_rewrite": 6
+    },
+    "fp8_e5m3_unpack_test": {
+      "instructions_requiring_rewrite": 5
+    },
+    "integer_wmma_hazard_test": {
+      "instructions_requiring_rewrite": 3
+    },
+    "s_clause_test": {
+      "instructions_requiring_rewrite": 1
+    },
+    "tensor_load_to_lds_test": {
+      "instructions_requiring_rewrite": 4
+    },
+    "wmma_scale16_m16_test": {
+      "instructions_requiring_rewrite": 5
+    },
+    "wmma_scale16_m32_test": {
+      "instructions_requiring_rewrite": 8
+    },
+    "wmma_scale_regular_test": {
+      "instructions_requiring_rewrite": 11
+    },
+    "wmma_split_f32_test": {
+      "instructions_requiring_rewrite": 7
+    }
+  }
+}

--- a/emulation/rocjitsu/tests/corpus/gfx1250_b0_a0_semantic_tests.json
+++ b/emulation/rocjitsu/tests/corpus/gfx1250_b0_a0_semantic_tests.json
@@ -1,0 +1,16 @@
+{
+  "semantics": [
+    "cluster_load_test",
+    "ds_2addr_test",
+    "ds_addtid_test",
+    "ds_storexchg_2addr_test",
+    "fp8_e5m3_unpack_test",
+    "integer_wmma_hazard_test",
+    "s_clause_test",
+    "tensor_load_to_lds_test",
+    "wmma_scale_regular_test",
+    "wmma_scale16_m16_test",
+    "wmma_scale16_m32_test",
+    "wmma_split_f32_test"
+  ]
+}

--- a/emulation/rocjitsu/tests/corpus/validate-gfx1250-semantic-translations.py
+++ b/emulation/rocjitsu/tests/corpus/validate-gfx1250-semantic-translations.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+SUMMARY_PATTERN = re.compile(
+    r"^  total=(?P<total>\d+) changed=(?P<changed>\d+) shown=(?P<shown>\d+)$",
+    re.MULTILINE,
+)
+RUNTIME_PATTERN = re.compile(
+    r"^\[hsa-hotswap-rj\] eager translated "
+    r"input_bytes=\d+ output_bytes=\d+ status=0$",
+    re.MULTILINE,
+)
+RUNTIME_PREFIX = "[hsa-hotswap-rj] eager translated "
+
+
+def main() -> int:
+    args = parse_args()
+    expectations = load_expectations(args.expectations)
+    selected_tests = load_selection(args.selection)
+    if set(expectations) != set(selected_tests):
+        missing = sorted(set(selected_tests) - set(expectations))
+        extra = sorted(set(expectations) - set(selected_tests))
+        raise ValueError(
+            f"selection and expectations differ: missing={missing}, extra={extra}"
+        )
+    failures = []
+
+    for test, expected_changed in expectations.items():
+        try:
+            binary = find_one(args.artifact_directory, f"build/bin/{test}")
+            reference_log = find_one(
+                args.artifact_directory,
+                f"logs/{test}.reference.run.log",
+            )
+            runtime_log = find_one(
+                args.artifact_directory,
+                f"logs/{test}.comparison.run.log",
+            )
+            diff = run_translation(args.translator, binary)
+            changed = parse_changed_count(test, diff)
+            if changed != expected_changed:
+                raise ValueError(
+                    f"reported changed={changed}; expected {expected_changed}"
+                )
+
+            reference_text = reference_log.read_text(encoding="utf-8")
+            if RUNTIME_PREFIX in reference_text:
+                raise ValueError(f"{reference_log} unexpectedly activated translation")
+
+            runtime_text = runtime_log.read_text(encoding="utf-8")
+            runtime_translations = runtime_text.count(RUNTIME_PREFIX)
+            successful_runtime_translations = len(RUNTIME_PATTERN.findall(runtime_text))
+            if (
+                runtime_translations != args.expected_runtime_translations
+                or successful_runtime_translations != args.expected_runtime_translations
+            ):
+                raise ValueError(
+                    f"{runtime_log} has {runtime_translations} runtime translations "
+                    f"and {successful_runtime_translations} successful records; "
+                    f"expected {args.expected_runtime_translations} of each"
+                )
+
+            output = args.artifact_directory / "translation-diffs" / f"{test}.log"
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(diff, encoding="utf-8")
+            print(
+                f"{test}: changed={changed} "
+                f"runtime_translations={runtime_translations}"
+            )
+        except (OSError, RuntimeError, ValueError) as error:
+            failures.append(f"{test}: {error}")
+
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate offline rewrite counts and fixture-specific runtime "
+            "translation evidence for gfx1250 semantic programs."
+        )
+    )
+    parser.add_argument("--translator", type=Path, required=True)
+    parser.add_argument("--selection", type=Path, required=True)
+    parser.add_argument("--expectations", type=Path, required=True)
+    parser.add_argument("--artifact-directory", type=Path, required=True)
+    parser.add_argument("--expected-runtime-translations", type=int, required=True)
+    return parser.parse_args()
+
+
+def load_expectations(path: Path) -> dict[str, int]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema") != 1:
+        raise ValueError(f"{path} must use schema 1")
+    tests = payload.get("tests")
+    if not isinstance(tests, dict) or not tests:
+        raise ValueError(f"{path} field 'tests' must be a non-empty object")
+
+    expectations = {}
+    for test, entry in tests.items():
+        if not isinstance(test, str) or not test:
+            raise ValueError(f"{path} test names must be non-empty strings")
+        if not isinstance(entry, dict):
+            raise ValueError(f"{path} test '{test}' must contain an object")
+        changed = entry.get("instructions_requiring_rewrite")
+        if isinstance(changed, bool) or not isinstance(changed, int) or changed <= 0:
+            raise ValueError(
+                f"{path} test '{test}' must require a positive rewrite count"
+            )
+        expectations[test] = changed
+    return expectations
+
+
+def load_selection(path: Path) -> list[str]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    tests = payload.get("semantics")
+    if (
+        not isinstance(tests, list)
+        or not tests
+        or any(not isinstance(test, str) or not test for test in tests)
+    ):
+        raise ValueError(f"{path} field 'semantics' must be a non-empty string list")
+    if len(tests) != len(set(tests)):
+        raise ValueError(f"{path} field 'semantics' contains duplicates")
+    return tests
+
+
+def find_one(root: Path, suffix: str) -> Path:
+    matches = [
+        path for path in root.rglob(Path(suffix).name) if str(path).endswith(suffix)
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"{root} has {len(matches)} paths ending in {suffix!r}; expected one"
+        )
+    return matches[0]
+
+
+def run_translation(translator: Path, binary: Path) -> str:
+    command = [
+        str(translator),
+        str(binary),
+        "--input-target",
+        "gfx1250",
+        "--output-target",
+        "gfx1250",
+        "--input-revision",
+        "b0",
+        "--output-revision",
+        "a0",
+        "--output-mode",
+        "diff",
+    ]
+    process = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        errors="replace",
+        check=False,
+    )
+    if process.returncode:
+        raise RuntimeError(
+            f"offline translation failed with status {process.returncode}: "
+            f"{process.stderr.strip()}"
+        )
+    return process.stdout
+
+
+def parse_changed_count(test: str, diff: str) -> int:
+    matches = list(SUMMARY_PATTERN.finditer(diff))
+    if len(matches) != 1:
+        raise ValueError(
+            f"offline translation for {test} emitted {len(matches)} summaries; "
+            "expected one"
+        )
+    return int(matches[0].group("changed"))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Motivation

Runtime translation qualification needs both an independent semantic baseline and evidence that the fixture code object, not merely a support object, was actually rewritten. The gfx1250 same-ISA hook must also fail closed when a code object cannot be translated completely.

## Technical Details

- Make the gfx1250 B0-to-A0 runtime profile reject incomplete translations while preserving the existing policy for other profiles.
- Select the synthetic same-ISA guest by its configured topology identity and map descriptor-created guest queues without scanning physical host queues.
- Emit stable per-load provenance with source identity, revision selection, outcome, and instruction-change counters.
- Build the pinned launcher-neutral corpus in Actions, classify every fixture, isolate the plain baseline from runtime hooks, and compare targeted plain and translated simulator results exactly.

## Issue Tracking

N/A

## Test Plan

- Build the RocJITsu launcher and runtime hook with the pinned TheRock SDK.
- Run the focused hook and configuration tests.
- Build the semantic corpus and compare every targeted fixture before and after strict runtime translation on the gfx1250 simulator.
- Run repository hooks and a local peanut review.

## Test Result

Passed. The focused tests, repository hooks, and full targeted simulator qualification pass. Every target reports fixture-specific instruction changes and equivalent normalized results.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.