### PR TITLE
test(ci): point therock-ci chain at amdsmi TheRock fork branch

### DIFF
--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -471,6 +471,26 @@ class ConfigureCITest(unittest.TestCase):
         self.assertIn("DTHEROCK_ENABLE_STORAGE_LIBS=ON", cmake_options)
         self.assertNotIn("DTHEROCK_ENABLE_ALL=ON", cmake_options)
 
+    def test_override_changed_projects_scopes_to_amdsmi(self):
+        """TEST_OVERRIDE_CHANGED_PROJECTS bypasses git-diff detection and scopes
+        CI to the given project(s), independent of the actual PR diff."""
+        args = {
+            "is_pull_request": True,
+            "base_ref": "HEAD^",
+            "platform": "linux",
+        }
+
+        with patch.dict(
+            os.environ, {"TEST_OVERRIDE_CHANGED_PROJECTS": "projects/amdsmi"}
+        ):
+            project_to_run, _ = therock_configure_ci.retrieve_projects(args)
+
+        # projects/amdsmi maps to the "core" project.
+        self.assertEqual(len(project_to_run), 1)
+        cmake_options = project_to_run[0]["cmake_options"]
+        self.assertIn("DTHEROCK_ENABLE_CORE=ON", cmake_options)
+        self.assertNotIn("DTHEROCK_ENABLE_ALL=ON", cmake_options)
+
     @patch("therock_configure_ci.get_modified_paths")
     def test_hipfile_pr_skips_windows_ci(self, mock_get_modified):
         """PR with only hipfile changes should not trigger Windows CI (Linux-only component)."""

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -68,7 +68,21 @@ def retry(max_attempts, delay_seconds, exceptions):
 
 @retry(max_attempts=3, delay_seconds=2, exceptions=(TimeoutError))
 def get_modified_paths(base_ref: str) -> Optional[Iterable[str]]:
-    """Returns the paths of modified files relative to the base reference."""
+    """Returns the paths of modified files relative to the base reference.
+
+    TEST OVERRIDE: when TEST_OVERRIDE_CHANGED_PROJECTS is set (space- or
+    comma-separated project paths, e.g. "projects/amdsmi"), detection is
+    bypassed and those paths are returned as the modified set. This scopes CI
+    deterministically regardless of which files a PR touches, which is useful
+    when repointing the workflow chain to a TheRock fork (the workflow-file
+    edits would otherwise fan CI out to all subtrees).
+    TODO(aendurth): Remove after testing the TheRock fork branch.
+    """
+    override = os.environ.get("TEST_OVERRIDE_CHANGED_PROJECTS", "").strip()
+    if override:
+        paths = [p for p in override.replace(",", " ").split() if p]
+        logging.info(f"TEST_OVERRIDE_CHANGED_PROJECTS set, using paths: {paths}")
+        return paths
     return subprocess.run(
         ["git", "diff", "--name-only", base_ref],
         stdout=subprocess.PIPE,
@@ -529,6 +543,11 @@ if __name__ == "__main__":
     )
 
     input_subtrees = os.getenv("SUBTREES", "")
+    # TEST OVERRIDE: when forcing changed projects, ignore SUBTREES from the
+    # detect step so the override is the sole source of scope on the PR path.
+    # TODO(aendurth): Remove after testing the TheRock fork branch.
+    if os.environ.get("TEST_OVERRIDE_CHANGED_PROJECTS", "").strip():
+        input_subtrees = ""
     args["input_subtrees"] = input_subtrees
 
     input_projects = os.getenv("PROJECTS", "")

--- a/.github/workflows/therock-build-linux.yml
+++ b/.github/workflows/therock-build-linux.yml
@@ -46,9 +46,11 @@ jobs:
       - name: Checkout TheRock repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          repository: "ROCm/TheRock"
+          # TEST: fork branch with amdsmi CMakeLists changes
+          # TODO(aendurth): revert to ROCm/TheRock @ pinned SHA after testing
+          repository: "endurthiabhilash/TheRock"
           path: "TheRock"
-          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
+          ref: users/aendurth/amdsmi-test-subprojects-all
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -48,9 +48,11 @@ jobs:
       - name: Checkout TheRock repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          repository: "ROCm/TheRock"
+          # TEST: fork branch with amdsmi CMakeLists changes
+          # TODO(aendurth): revert to ROCm/TheRock @ pinned SHA after testing
+          repository: "endurthiabhilash/TheRock"
           path: "TheRock"
-          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
+          ref: users/aendurth/amdsmi-test-subprojects-all
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -50,9 +50,11 @@ jobs:
       - name: Checkout TheRock repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          repository: "ROCm/TheRock"
+          # TEST: fork branch with amdsmi CMakeLists changes
+          # TODO(aendurth): revert to ROCm/TheRock @ pinned SHA after testing
+          repository: "endurthiabhilash/TheRock"
           path: "TheRock"
-          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
+          ref: users/aendurth/amdsmi-test-subprojects-all
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -79,9 +79,11 @@ jobs:
       - name: Checkout TheRock repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: "ROCm/TheRock"
+          # TEST: fork branch with amdsmi CMakeLists changes
+          # TODO(aendurth): revert to ROCm/TheRock @ pinned SHA after testing
+          repository: "endurthiabhilash/TheRock"
           path: TheRock
-          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
+          ref: users/aendurth/amdsmi-test-subprojects-all
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -116,6 +118,10 @@ jobs:
           SUBTREES: ${{ steps.detect.outputs.subtrees }}
           PROJECTS: ${{ inputs.projects }}
           PLATFORM: "linux"
+          # TEST OVERRIDE: force amdsmi scope regardless of PR diff so the
+          # workflow-file edits (repointing to the fork) don't fan CI out to
+          # all subtrees. TODO(aendurth): Remove after testing the fork branch.
+          TEST_OVERRIDE_CHANGED_PROJECTS: "projects/amdsmi"
         run: |
           python .github/scripts/therock_configure_ci.py
 
@@ -125,6 +131,10 @@ jobs:
           SUBTREES: ${{ steps.detect.outputs.subtrees }}
           PROJECTS: ${{ inputs.projects }}
           PLATFORM: "windows"
+          # TEST OVERRIDE: force amdsmi scope regardless of PR diff so the
+          # workflow-file edits (repointing to the fork) don't fan CI out to
+          # all subtrees. TODO(aendurth): Remove after testing the fork branch.
+          TEST_OVERRIDE_CHANGED_PROJECTS: "projects/amdsmi"
         run: |
           python .github/scripts/therock_configure_ci.py
 

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -56,9 +56,11 @@ jobs:
       - name: Checkout TheRock repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          repository: "ROCm/TheRock"
+          # TEST: fork branch with amdsmi CMakeLists changes
+          # TODO(aendurth): revert to ROCm/TheRock @ pinned SHA after testing
+          repository: "endurthiabhilash/TheRock"
           path: "TheRock"
-          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
+          ref: users/aendurth/amdsmi-test-subprojects-all
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -60,7 +60,10 @@ jobs:
       - name: "Fetch 'build_tools' from repository"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          repository: "ROCm/TheRock"
+          # TEST: fork branch with amdsmi CMakeLists changes
+          # TODO(aendurth): revert to ROCm/TheRock @ pinned SHA after testing
+          repository: "endurthiabhilash/TheRock"
+          ref: users/aendurth/amdsmi-test-subprojects-all
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -77,8 +80,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          repository: "ROCm/TheRock"
-          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
+          # TEST: fork branch with amdsmi CMakeLists changes
+          # TODO(aendurth): revert to ROCm/TheRock @ pinned SHA after testing
+          repository: "endurthiabhilash/TheRock"
+          ref: users/aendurth/amdsmi-test-subprojects-all
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -67,7 +67,10 @@ jobs:
         with:
           sparse-checkout: build_tools
           path: "prejob"
-          repository: "ROCm/TheRock"
+          # TEST: fork branch with amdsmi CMakeLists changes
+          # TODO(aendurth): revert to ROCm/TheRock @ pinned SHA after testing
+          repository: "endurthiabhilash/TheRock"
+          ref: users/aendurth/amdsmi-test-subprojects-all
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -79,8 +82,10 @@ jobs:
       - name: "Checking out repository"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          repository: "ROCm/TheRock"
-          ref: 2e7c190b99caa226a8644eda6eca720b3db102d5 # 2026-07-22
+          # TEST: fork branch with amdsmi CMakeLists changes
+          # TODO(aendurth): revert to ROCm/TheRock @ pinned SHA after testing
+          repository: "endurthiabhilash/TheRock"
+          ref: users/aendurth/amdsmi-test-subprojects-all
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
 **Do not merge — CI validation only.**

Repoints all TheRock checkouts in the therock-ci.yml workflow chain to endurthiabhilash/TheRock@users/aendurth/amdsmi-test-subprojects-all to validate the fork's amdsmi CMakeLists changes.

Adds a TEST_OVERRIDE_CHANGED_PROJECTS hook to therock_configure_ci.py so change detection can be forced to projects/amdsmi regardless of the PR diff. Without it, editing therock* workflow files would fan CI out to all subtrees (check_for_workflow_file_related_to_ci). The override also blanks SUBTREES so it is the sole source of scope on the PR path.

TODO(aendurth): revert all repoints to ROCm/TheRock @ pinned SHA and remove the override after testing.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
