### PR TITLE
refactor(rocdbgapi): set a workgroup's mark unconditionally

### DIFF
--- a/projects/rocdbgapi/src/queue.cpp
+++ b/projects/rocdbgapi/src/queue.cpp
@@ -380,8 +380,7 @@ compute_queue_t::update_waves ()
       group_leader = nullptr;
 
     wave->set_mark (wave_mark);
-    if (is_first_wave)
-      wave->workgroup ().set_mark (wave_mark);
+    wave->workgroup ().set_mark (wave_mark);
   };
 
   process_t &process = this->process ();


### PR DESCRIPTION
## Motivation

This change is a refactoring to obtain clearer and simpler code.

## Technical Details

A workgroup is alive as long as it has a wave.  Set the epoch mark unconditionally, whenever the mark of any wave of the workgroup is being set.

## Issue Tracking

None.

## Test Plan

Tested by gdb.rocm tests in ROCgdb testsuite.

## Test Result

<!-- Briefly summarize test outcomes. -->

