### PR TITLE
feat(clr): distinguish presented and execution ISAs

### DIFF
--- a/projects/clr/CMakeLists.txt
+++ b/projects/clr/CMakeLists.txt
@@ -133,6 +133,11 @@ if(CLR_BUILD_OCL)
     add_subdirectory(opencl)
 endif()
 
+if(BUILD_TESTING)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
 #############################
 # Code formatting
 #############################

--- a/projects/clr/hipamd/src/hip_library.cpp
+++ b/projects/clr/hipamd/src/hip_library.cpp
@@ -372,7 +372,7 @@ hipError_t hipKernelGetAttribute(int* pi, hipFunction_attribute attrib, hipKerne
       break;
     case HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES: {
       int maxDynamicSharedSizeBytes = static_cast<int>(wrkGrpInfo.maxDynamicSharedSizeBytes_);
-      const int alignmentSize = device.isa().ldsAlignment();
+      const int alignmentSize = device.executionIsa().ldsAlignment();
       *pi = amd::alignDown(maxDynamicSharedSizeBytes, alignmentSize);
       break;
     }

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -42,11 +42,16 @@ hipError_t ihipOccupancyMaxActiveBlocksPerMultiprocessor(
     inputBlockSize = maxWorkGroupSize;
   }
   
-  // Find wave occupancy per CU => simd_per_cu * GPR usage
-  // Limited by SPI 32 per CU, hence 8 per SIMD
-  const size_t MaxWavesPerSimd = (device.isa().versionMajor() <= 9) ? 8 : 16;
+  // Physical occupancy limits follow the execution ISA, while wave size and
+  // resource use come from the selected kernel metadata. A code transformation
+  // that changes resource use must provide updated metadata; CLR cannot infer
+  // that change here.
+  // Limited by SPI 32 per CU, hence 8 per SIMD.
+  const size_t MaxWavesPerSimd =
+      (device.executionIsa().versionMajor() <= 9) ? 8 : 16;
   const size_t wavefrontSize = wrkGrpInfo->wavefrontSize_;
-  const bool adjust_for_wave64 = device.isa().versionMajor() >= 10 && wavefrontSize == 64;
+  const bool adjust_for_wave64 =
+      device.executionIsa().versionMajor() >= 10 && wavefrontSize == 64;
   const uint32_t VgprGranularity = adjust_for_wave64
       ? device.info().vgprAllocGranularity_ >> 1
       : device.info().vgprAllocGranularity_;
@@ -72,8 +77,8 @@ hipError_t ihipOccupancyMaxActiveBlocksPerMultiprocessor(
   // on kernel metadata, multiply the number of SIMDs by 2, to account for
   // 2CUs in 1 WGP.
   const uint32_t simdPerCU = wrkGrpInfo->isWGPMode_
-      ? device.isa().simdPerCU() * 2
-      : device.isa().simdPerCU();
+      ? device.executionIsa().simdPerCU() * 2
+      : device.executionIsa().simdPerCU();
 
   const size_t alu_occupancy = simdPerCU * std::min(MaxWavesPerSimd, GprWaves);
   const int alu_limited_threads = static_cast<int>(alu_occupancy * wavefrontSize);
@@ -487,7 +492,7 @@ hipError_t hipOccupancyAvailableDynamicSMemPerBlock(size_t* dynamicSmemSize, con
       staticSharedMemoryUsage * std::min(numBlocks, maxNumBlocks);
   const int maxDynamicSmemSize = std::min(maxSharedMemoryPerMultiProcessor / maxNumBlocks,
                                           maxDynamicSharedSizeBytes);
-  const int alignmentSize = device.isa().ldsAlignment();
+  const int alignmentSize = device.executionIsa().ldsAlignment();
 
   const int dynamic_smem_size = std::max(maxDynamicSmemSize,
                                          std::min(maxSharedMemoryPerMultiProcessor / numBlocks,
@@ -723,7 +728,7 @@ hipError_t ihipLaunchKernel(const void* hostFunction, dim3 gridDim, dim3 blockDi
 
   constexpr auto gridDimYZmax = static_cast<uint64_t>(std::numeric_limits<uint16_t>::max()) + 1;
   const amd::Device* device = g_devices[deviceId]->devices()[0];
-  if (device->isa().versionMajor() >= 12 &&
+  if (device->executionIsa().versionMajor() >= 12 &&
       (gridDim.y > gridDimYZmax || gridDim.z > gridDimYZmax)) {
     return hipErrorInvalidConfiguration;
   }

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -938,6 +938,8 @@ Device::Device()
       heap_buffer_(nullptr),
       initial_heap_buffer_(nullptr),
       arena_mem_obj_(nullptr),
+      isa_(nullptr),
+      executionIsa_(nullptr),
       vaCacheAccess_(nullptr),
       vaCacheMap_(nullptr),
       index_(0) {
@@ -997,9 +999,12 @@ size_t GetMaxStackSize(const std::string& procName) {
   }
 }
 
-bool Device::create(const Isa& isa) {
+bool Device::create(const Isa& isa) { return create(isa, isa); }
+
+bool Device::create(const Isa& presentedIsa, const Isa& executionIsa) {
   assert(!vaCacheAccess_ && !vaCacheMap_);
-  isa_ = &isa;
+  isa_ = &presentedIsa;
+  executionIsa_ = &executionIsa;
   // VA Cache Ops Lock
   vaCacheAccess_ = new std::recursive_mutex();
   if (nullptr == vaCacheAccess_) {
@@ -1013,7 +1018,7 @@ bool Device::create(const Isa& isa) {
   if (!amd::IS_HIP) {
     stack_size_ = 16 * Ki;
   }
-  maxStackSize_ = GetMaxStackSize(isa_->processorName());
+  maxStackSize_ = GetMaxStackSize(executionIsa_->processorName());
   return true;
 }
 

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -718,9 +718,9 @@ class Settings {
                                               //  that replaces generic OS allocation routines
       uint supportDepthsRGB_ : 1;             //!< Support DEPTH and sRGB channel order format
       uint singleFpDenorm_ : 1;               //!< Support Single FP Denorm
-      uint enableWgpMode_ : 1;                //!< Enable WGP mode for this device
-      uint enableWave32Mode_ : 1;             //!< Enable Wave32 mode for this device
-      uint lcWavefrontSize64_ : 1;            //!< Enable Wave64 mode for this device
+      uint enableWgpMode_ : 1;                //!< Runtime CU/WGP accounting mode
+      uint enableWave32Mode_ : 1;             //!< Compiler Wave32 mode
+      uint lcWavefrontSize64_ : 1;            //!< Compiler Wave64 mode
       uint enableXNACK_ : 1;                  //!< Enable XNACK feature
       uint enableCoopGroups_ : 1;             //!< Enable cooperative groups feature
       uint enableCoopMultiDeviceGroups_ : 1;  //!< Enable cooperative groups multi device
@@ -733,7 +733,8 @@ class Settings {
       uint groupMemCarveout_ : 1;             //!< Group memory carveout functionality
       uint sdma_indirect_supported_ : 1;     //!< SDMA linear indirect copy (gfx1250+)
       uint aql_device_ring_buf_ : 1;          //!< Place the AQL queue ring buffer in device memory
-      uint reserved_ : 8;
+      uint lcWgpMode_ : 1;                    //!< Compiler WGP mode
+      uint reserved_ : 7;
     };
     uint value_;
   };
@@ -1791,8 +1792,11 @@ class Device : public RuntimeObject {
   Device();
   virtual ~Device();
 
-  //! Initializes abstraction layer device object
+  //! Initializes a device whose presented and execution ISAs are identical.
   bool create(const Isa& isa);
+
+  //! Initializes a device with distinct presented and execution ISAs.
+  bool create(const Isa& presentedIsa, const Isa& executionIsa);
 
   uint retain() {
     // Overwrite the RuntimeObject::retain().
@@ -2282,10 +2286,16 @@ class Device : public RuntimeObject {
   //! Returns TRUE if the device is available for computations
   bool isOnline() const { return online_; }
 
-  //! Returns device isa.
+  //! Returns the ISA presented for code and device-library selection.
   const Isa& isa() const {
     assert(isa_);
     return *isa_;
+  }
+
+  //! Returns the physical ISA used for hardware-specific runtime policy.
+  const Isa& executionIsa() const {
+    assert(executionIsa_);
+    return *executionIsa_;
   }
 
   //! Return a non-zero uint64_t value that uniquely identifies the device.
@@ -2494,7 +2504,8 @@ class Device : public RuntimeObject {
   std::unordered_map<amd::CommandQueue*, bool> activeQueues;  //!< The set of active queues
   uint8_t group_mem_carveout_hint_{0}; //!< LDS carveout percentage (0 = no preference)
  private:
-  const Isa* isa_;  //!< Device isa
+  const Isa* isa_;           //!< Presented/code-selection ISA
+  const Isa* executionIsa_;  //!< Physical hardware execution ISA
   bool IsTypeMatching(cl_device_type type, bool offlineDevices);
 
 #if defined(WITH_HSA_DEVICE)

--- a/projects/clr/rocclr/device/devprogram.cpp
+++ b/projects/clr/rocclr/device/devprogram.cpp
@@ -529,7 +529,7 @@ bool Program::compileImpl(const std::string& sourceCode,
   driverOptions.push_back("-mllvm");
   driverOptions.push_back("-amdgpu-prelink");
 
-  if (!device().settings().enableWgpMode_) {
+  if (!device().settings().lcWgpMode_) {
     driverOptions.push_back("-mcumode");
   }
 
@@ -862,7 +862,7 @@ bool Program::linkImpl(amd::option::Options* options) {
   codegenOptions.push_back("-mllvm");
   codegenOptions.push_back("-amdgpu-internalize-symbols");
 
-  if (!device().settings().enableWgpMode_) {
+  if (!device().settings().lcWgpMode_) {
     codegenOptions.push_back("-mcumode");
   }
 

--- a/projects/clr/rocclr/device/pal/palsettings.cpp
+++ b/projects/clr/rocclr/device/pal/palsettings.cpp
@@ -229,6 +229,8 @@ bool Settings::create(const Pal::DeviceProperties& palProp,
       return false;
   }
 
+  lcWgpMode_ = enableWgpMode_;
+
   if (0 == palProp.engineProperties[Pal::EngineTypeDma].engineCount) {
     disableSdma_ = true;
   }

--- a/projects/clr/rocclr/device/rocm/roccounters.cpp
+++ b/projects/clr/rocclr/device/rocm/roccounters.cpp
@@ -418,7 +418,7 @@ PerfCounter::PerfCounter(
   info_.eventIndex_ = eventIndex;      // Counter Event Selection (counter_id)
 
   // these block indices are valid for the SI (Gfx8) & Gfx9 devices
-  switch (roc_device_.isa().versionMajor()) {
+  switch (roc_device_.executionIsa().versionMajor()) {
     case (9):
       gfxVersion_ = ROC_GFX9;
       if (blockIndex < gfx9BlockIdOrcaToRocrSize) {

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -98,7 +98,7 @@ bool NullDevice::create(const amd::Isa& isa) {
 
   roc::Settings* hsaSettings = new roc::Settings();
   settings_ = hsaSettings;
-  if (!hsaSettings || !hsaSettings->create(false, isa, isa.xnack() == amd::Isa::Feature::Enabled)) {
+  if (!hsaSettings || !hsaSettings->create(false, isa, isa)) {
     LogPrintfError("Error creating settings for offline HSA device %s", isa.targetId());
     return false;
   }
@@ -606,6 +606,51 @@ bool Device::create() {
     return false;
   }
 
+  hsa_isa_t execution_isa_handle = {};
+  hsa_status_t execution_isa_status = Hsa::agent_get_info(
+      bkendDevice_,
+      static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_EXECUTION_ISA),
+      &execution_isa_handle);
+  if (execution_isa_status != HSA_STATUS_SUCCESS) {
+    LogPrintfError(
+        "Unable to get physical execution ISA for HSA device %s (PCI ID %x): "
+        "HSA status %d. A ROCr runtime that implements "
+        "HSA_AMD_AGENT_INFO_EXECUTION_ISA is required",
+        agent_name, pciDeviceId_, static_cast<int>(execution_isa_status));
+    return false;
+  }
+
+  uint32_t execution_isa_name_length = 0;
+  if (HSA_STATUS_SUCCESS !=
+      Hsa::isa_get_info_alt(execution_isa_handle, HSA_ISA_INFO_NAME_LENGTH,
+                            &execution_isa_name_length)) {
+    LogPrintfError(
+        "Unable to get physical execution ISA name length for HSA device %s "
+        "(PCI ID %x)",
+        agent_name, pciDeviceId_);
+    return false;
+  }
+
+  std::vector<char> execution_isa_name(execution_isa_name_length + 1, '\0');
+  if (HSA_STATUS_SUCCESS !=
+      Hsa::isa_get_info_alt(execution_isa_handle, HSA_ISA_INFO_NAME,
+                            execution_isa_name.data())) {
+    LogPrintfError(
+        "Unable to get physical execution ISA name for HSA device %s (PCI ID "
+        "%x)",
+        agent_name, pciDeviceId_);
+    return false;
+  }
+
+  const amd::Isa* execution_isa =
+      amd::Isa::findIsa(execution_isa_name.data());
+  if (execution_isa == nullptr || !execution_isa->runtimeRocSupported()) {
+    LogPrintfError(
+        "Unsupported physical execution ISA %s for HSA device %s (PCI ID %x)",
+        execution_isa_name.data(), agent_name, pciDeviceId_);
+    return false;
+  }
+
   if (HSA_STATUS_SUCCESS !=
       Hsa::agent_get_info(bkendDevice_, HSA_AGENT_INFO_PROFILE, &agent_profile_)) {
     LogPrintfError("Unable to get profile for HSA device %s (PCI ID %x)", agent_name, pciDeviceId_);
@@ -643,9 +688,9 @@ bool Device::create() {
   assert(!settings_);
   roc::Settings* hsaSettings = new roc::Settings();
   settings_ = hsaSettings;
-  if (!hsaSettings || !hsaSettings->create((agent_profile_ == HSA_PROFILE_FULL), *isa,
-                                           isa->xnack() == amd::Isa::Feature::Enabled, coop_groups,
-                                           isXgmi_)) {
+  if (!hsaSettings ||
+      !hsaSettings->create((agent_profile_ == HSA_PROFILE_FULL), *isa,
+                           *execution_isa, coop_groups, isXgmi_)) {
     LogPrintfError("Unable to create settings for HSA device %s (PCI ID %x)", agent_name,
                    pciDeviceId_);
     return false;
@@ -657,7 +702,7 @@ bool Device::create() {
     return false;
   }
 
-  if (!amd::Device::create(*isa)) {
+  if (!amd::Device::create(*isa, *execution_isa)) {
     LogPrintfError("Unable to setup device for HSA device %s (PCI ID %x)", agent_name,
                    pciDeviceId_);
     return false;
@@ -1098,8 +1143,9 @@ bool Device::populateOCLDeviceConstants() {
   }
 
   if (info_.globalMemCacheLineSize_ < 256 &&
-      (isa().versionMajor() >= 13 ||
-       (isa().versionMajor() == 12 && isa().versionMinor() >= 5))) {
+      (executionIsa().versionMajor() >= 13 ||
+       (executionIsa().versionMajor() == 12 &&
+        executionIsa().versionMinor() >= 5))) {
     info_.globalMemCacheLineSize_ = 256;
   }
 
@@ -1133,7 +1179,9 @@ bool Device::populateOCLDeviceConstants() {
     return false;
   }
 
-  if (!(isa().versionMajor() == 9 && isa().versionMinor() == 0 && isa().versionStepping() == 2)) {
+  if (!(executionIsa().versionMajor() == 9 &&
+        executionIsa().versionMinor() == 0 &&
+        executionIsa().versionStepping() == 2)) {
     if (info_.maxEngineClockFrequency_ <= 0) {
       LogError("maxEngineClockFrequency_ is NOT positive!");
     }
@@ -1398,7 +1446,7 @@ bool Device::populateOCLDeviceConstants() {
 
   ::strncpy(info_.driverVersion_, ss.str().c_str(), sizeof(info_.driverVersion_) - 1);
 
-  if (isa().versionMajor() >= 9) {
+  if (executionIsa().versionMajor() >= 9) {
     info_.version_ =
         "OpenCL " /*OPENCL_VERSION_STR*/
         "2.0"
@@ -1566,15 +1614,18 @@ bool Device::populateOCLDeviceConstants() {
       info_.svmCapabilities_ |= CL_DEVICE_SVM_FINE_GRAIN_SYSTEM;
     }
     if (amd::IS_HIP) {
-      if (info_.iommuv2_ || isa().versionMajor() >= 8) {
+      if (info_.iommuv2_ || executionIsa().versionMajor() >= 8) {
         info_.svmCapabilities_ |= CL_DEVICE_SVM_ATOMICS;
       }
     }
   }
 
   if (settings().checkExtension(ClAmdDeviceAttributeQuery)) {
-    info_.simdWidth_ = isa().simdWidth();
-    info_.simdInstructionWidth_ = isa().simdInstructionWidth();
+    info_.simdWidth_ = executionIsa().simdWidth();
+    info_.simdInstructionWidth_ = executionIsa().simdInstructionWidth();
+    // This is the logical wave size of code compiled for the presented ISA.
+    // CLR's kernel metadata and programming model use that wave model even
+    // when the physical execution ISA has a different native wave size.
     if (HSA_STATUS_SUCCESS !=
         Hsa::agent_get_info(bkendDevice_, HSA_AGENT_INFO_WAVEFRONT_SIZE, &info_.wavefrontWidth_)) {
       return false;
@@ -1637,9 +1688,9 @@ bool Device::populateOCLDeviceConstants() {
     info_.l2CacheSize_ = cache_sizes[1];
     info_.timeStampFrequency_ = 1000000;
     info_.globalMemChannelBanks_ = 4;
-    info_.globalMemChannelBankWidth_ = isa().memChannelBankWidth();
-    info_.localMemSizePerCU_ = isa().localMemSizePerCU();
-    info_.localMemBanks_ = isa().localMemBanks();
+    info_.globalMemChannelBankWidth_ = executionIsa().memChannelBankWidth();
+    info_.localMemSizePerCU_ = executionIsa().localMemSizePerCU();
+    info_.localMemBanks_ = executionIsa().localMemBanks();
     info_.numAsyncQueues_ = kMaxAsyncQueues;
     info_.numRTQueues_ = info_.numAsyncQueues_;
     info_.numRTCUs_ = info_.maxComputeUnits_;
@@ -1666,7 +1717,7 @@ bool Device::populateOCLDeviceConstants() {
   info_.maxOnDeviceEvents_ = settings().numDeviceEvents_;
 
   std::string addressableNumVGPRs, totalNumVGPRs, vGPRAllocGranule;
-  std::string isaName = isa().isaName();
+  std::string isaName = executionIsa().isaName();
   info_.availableVGPRs_ =
       amd::device::getValueFromIsaMeta(isaName, "AddressableNumVGPRs", addressableNumVGPRs)
       ? atoi(addressableNumVGPRs.c_str())
@@ -1679,6 +1730,9 @@ bool Device::populateOCLDeviceConstants() {
       ? atoi(vGPRAllocGranule.c_str())
       : 0;
 
+  // Express the physical VGPR capacity in the logical work-item units used by
+  // presented kernel metadata and HIP device properties. A transformation
+  // that changes register usage must provide corresponding kernel metadata.
   info_.availableRegistersPerCU_ = info_.vgprsPerSimd_ * info_.simdPerCU_ * info_.wavefrontWidth_;
   ClPrint(amd::LOG_INFO, amd::LOG_INIT,
           "addressableNumVGPRs=%u, totalNumVGPRs=%u, vGPRAllocGranule=%u,"
@@ -1742,7 +1796,8 @@ bool Device::populateOCLDeviceConstants() {
   }
 
   ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Gfx Major/Minor/Stepping: %d/%d/%d, Device ID: 0x%x",
-          isa().versionMajor(), isa().versionMinor(), isa().versionStepping(), pciDeviceId_);
+          executionIsa().versionMajor(), executionIsa().versionMinor(),
+          executionIsa().versionStepping(), pciDeviceId_);
   ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Using dev kernel arg wa = %d", settings().kernel_arg_impl_);
   ClPrint(amd::LOG_INFO, amd::LOG_INIT, "HMM support: %d, XNACK: %d, Direct host access: %d",
           info_.hmmSupported_, info_.hmmCpuMemoryAccessible_, info_.hmmDirectHostAccess_);
@@ -1790,9 +1845,9 @@ bool Device::populateOCLDeviceConstants() {
   info_.gpuDirectRdmaWithHipVmmSupported_ =
       info_.virtualMemoryManagement_ && info_.dmabufSupported_;
 
-  if (isa().versionMajor() < 8) {
+  if (executionIsa().versionMajor() < 8) {
     info_.sgprsPerSimd_ = 512;
-  } else if (isa().versionMajor() < 10) {
+  } else if (executionIsa().versionMajor() < 10) {
     info_.sgprsPerSimd_ = 800;
   } else {
     info_.sgprsPerSimd_ =
@@ -2461,7 +2516,7 @@ void* Device::deviceLocalAlloc(size_t size, const AllocationFlags& flags, bool a
   if (flags.executable_) {
     hsa_mem_flags |= HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG;
   }
-  if (flags.uncached_ && isa().versionMajor() == 12) {
+  if (flags.uncached_ && executionIsa().versionMajor() == 12) {
     hsa_mem_flags |= HSA_AMD_MEMORY_POOL_UNCACHED_FLAG;
   }
 

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -1440,7 +1440,8 @@ bool Image::createInteropImage() {
 
   // Set cubemap face if GL cubemap
   if (glObj && glObj->getGLTarget() == GL_TEXTURE_CUBE_MAP) {
-    desc.setFace(glObj->getCubemapFace(), dev().isa().versionMajor());
+    desc.setFace(glObj->getCubemapFace(),
+                 dev().executionIsa().versionMajor());
   }
 
   hsa_status_t err =

--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -87,11 +87,14 @@ Settings::Settings() {
 }
 
 // ================================================================================================
-bool Settings::create(bool fullProfile, const amd::Isa& isa, bool enableXNACK, bool coop_groups,
+bool Settings::create(bool fullProfile, const amd::Isa& presentedIsa,
+                      const amd::Isa& executionIsa, bool coop_groups,
                       bool isXgmi) {
-  uint32_t gfxipMajor = isa.versionMajor();
-  uint32_t gfxipMinor = isa.versionMinor();
-  uint32_t gfxStepping = isa.versionStepping();
+  const uint32_t gfxipMajor = executionIsa.versionMajor();
+  const uint32_t gfxipMinor = executionIsa.versionMinor();
+  const uint32_t gfxStepping = executionIsa.versionStepping();
+  const uint32_t presentedGfxipMajor = presentedIsa.versionMajor();
+  const uint32_t presentedGfxipMinor = presentedIsa.versionMinor();
 
   customHostAllocator_ = false;
 
@@ -103,7 +106,7 @@ bool Settings::create(bool fullProfile, const amd::Isa& isa, bool enableXNACK, b
   } else {
     pinnedXferSize_ = std::max(pinnedXferSize_, pinnedMinXferSize_);
   }
-  enableXNACK_ = enableXNACK;
+  enableXNACK_ = presentedIsa.xnack() == amd::Isa::Feature::Enabled;
 
   // Enable extensions
   enableExtension(ClKhrByteAddressableStore);
@@ -151,21 +154,34 @@ bool Settings::create(bool fullProfile, const amd::Isa& isa, bool enableXNACK, b
     sdma_swap_supported_ = true;
   }
 
-  setKernelArgImpl(isa, isXgmi);
+  setKernelArgImpl(executionIsa, isXgmi);
 
+  // Physical CU/WGP accounting and queue masks must match the execution ISA.
   if (gfxipMajor >= 10) {
-     enableWave32Mode_ = true;
-     // Disable wgp mode for gfx1250 and later
-     if (gfxipMajor == 12 && gfxipMinor >= 5) {
-        enableWgpMode_ = false;
-     } else {
-        enableWgpMode_ = GPU_ENABLE_WGP_MODE;
-     }
-     if (gfxipMajor == 10 && gfxipMinor == 1) {
-       // GFX10.1 HW doesn't support custom pitch. Enable double copy workaround
-       // TODO: This should be updated when ROCr support custom pitch
-       imageBufferWar_ = GPU_IMAGE_BUFFER_WAR;
-     }
+    // gfx1250 does not support WGP mode.
+    if (gfxipMajor == 12 && gfxipMinor >= 5) {
+      enableWgpMode_ = false;
+    } else {
+      enableWgpMode_ = GPU_ENABLE_WGP_MODE;
+    }
+  }
+
+  // CLR compiles code for the presented ISA. Keep its wave and CU/WGP modes
+  // separate from the physical modes that the translated code executes on.
+  if (presentedGfxipMajor >= 10) {
+    enableWave32Mode_ = true;
+    // gfx1250 does not support WGP mode.
+    if (presentedGfxipMajor == 12 && presentedGfxipMinor >= 5) {
+      lcWgpMode_ = false;
+    } else {
+      lcWgpMode_ = GPU_ENABLE_WGP_MODE;
+    }
+  }
+
+  if (gfxipMajor == 10 && gfxipMinor == 1) {
+    // GFX10.1 HW doesn't support custom pitch. Enable double copy workaround
+    // TODO: This should be updated when ROCr support custom pitch
+    imageBufferWar_ = GPU_IMAGE_BUFFER_WAR;
   }
 
   if (!flagIsDefault(GPU_ENABLE_WAVE32_MODE)) {

--- a/projects/clr/rocclr/device/rocm/rocsettings.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.hpp
@@ -68,7 +68,8 @@ class Settings : public device::Settings {
   Settings();
 
   //! Creates settings
-  bool create(bool fullProfile, const amd::Isa& isa, bool enableXNACK, bool coop_groups = false,
+  bool create(bool fullProfile, const amd::Isa& presentedIsa,
+              const amd::Isa& executionIsa, bool coop_groups = false,
               bool isXgmi = false);
 
  private:
@@ -88,4 +89,3 @@ class Settings : public device::Settings {
 
 /*@}*/  // namespace amd::roc
 }  // namespace amd::roc
-

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -2240,7 +2240,7 @@ VirtualGPU::VirtualGPU(Device& device, bool profiling, bool cooperative,
                                             << HSA_PACKET_HEADER_TYPE);
 
   if (device.settings().fenceScopeAgent_) {
-    const auto& isa = device.isa();
+    const auto& isa = device.executionIsa();
     const bool isGfx12 = (isa.versionMajor() == 12) && (isa.versionMinor() == 0) &&
                          (isa.versionStepping() == 0 || isa.versionStepping() == 1);
 
@@ -2350,7 +2350,8 @@ bool VirtualGPU::create() {
                                        dedicated_queue_));
   if (!gpu_queue_) return false;
 
-  if (dev().isa().versionMajor() == 12 && dev().isa().versionMinor() >= 5) {
+  if (dev().executionIsa().versionMajor() == 12 &&
+      dev().executionIsa().versionMinor() >= 5) {
     metadata_preloader_.SetLaunchDescriptorVersion(AMD_LAUNCH_DESCRIPTOR_VERSION_GFX1250);
   }
 
@@ -4836,7 +4837,8 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
       auto& dispatchPacketExt = dispatchPacketUnion.extKernelDispatch;
       // Encodings [1, 127] represent a range from 0% (no group memory) to 100% (maximum
       // group memory)
-      if (dev().isa().versionMajor() == 12 && dev().isa().versionMinor() == 5) {
+      if (dev().executionIsa().versionMajor() == 12 &&
+          dev().executionIsa().versionMinor() == 5) {
         dispatchPacketExt.perf_hint.group_mem_carveout = 127;
       } else {
         dispatchPacketExt.perf_hint.group_mem_carveout = (percent + 1) * 1.26F;

--- a/projects/clr/tests/CMakeLists.txt
+++ b/projects/clr/tests/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+#
+# SPDX-License-Identifier: MIT
+
+if(ROCCLR_ENABLE_HSA)
+  add_executable(rocclr-isa-policy-test isa_policy_test.cpp)
+  target_link_libraries(rocclr-isa-policy-test PRIVATE rocclr)
+  add_test(NAME rocclr-isa-policy COMMAND rocclr-isa-policy-test)
+endif()
+
+if(CLR_BUILD_HIP AND HIP_PLATFORM STREQUAL "amd")
+  find_package(hsa-runtime64 1.11 REQUIRED CONFIG)
+  add_executable(hip-isa-views-test isa_views_test.cpp)
+  target_compile_definitions(hip-isa-views-test PRIVATE __HIP_PLATFORM_AMD__)
+  target_include_directories(hip-isa-views-test PRIVATE
+    ${HIP_COMMON_DIR}/include
+    ${PROJECT_SOURCE_DIR}/hipamd/include
+    ${PROJECT_BINARY_DIR}/hipamd/include)
+  target_link_libraries(hip-isa-views-test PRIVATE
+    amdhip64
+    hsa-runtime64::hsa-runtime64)
+  add_test(NAME hip-isa-views-native COMMAND hip-isa-views-test)
+  set_tests_properties(hip-isa-views-native PROPERTIES SKIP_RETURN_CODE 77)
+endif()

--- a/projects/clr/tests/isa_policy_test.cpp
+++ b/projects/clr/tests/isa_policy_test.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "device/device.hpp"
+#include "device/rocm/rocsettings.hpp"
+
+#include <cstdio>
+
+// ROCclr is a static library. Its enclosing HIP or OpenCL runtime normally
+// provides this dispatch table, so a direct unit-test link supplies a stub.
+cl_icd_dispatch amd::ICDDispatchedObject::icdVendorDispatch_[] = {0};
+
+namespace {
+
+bool check(bool condition, const char* message) {
+  if (!condition) {
+    std::fprintf(stderr, "FAIL: %s\n", message);
+  }
+  return condition;
+}
+
+}  // namespace
+
+int main() {
+  const amd::Isa* presented = amd::Isa::findIsa("amdgcn-amd-amdhsa--gfx1250");
+  const amd::Isa* presentedWgp = amd::Isa::findIsa("amdgcn-amd-amdhsa--gfx1100");
+  const amd::Isa* execution = amd::Isa::findIsa("amdgcn-amd-amdhsa--gfx942:xnack+");
+  const amd::Isa* legacyExecution = amd::Isa::findIsa("amdgcn-amd-amdhsa--gfx900");
+  if (!check(presented != nullptr, "missing gfx1250 test ISA") ||
+      !check(presentedWgp != nullptr, "missing gfx1100 test ISA") ||
+      !check(execution != nullptr, "missing gfx942 test ISA") ||
+      !check(legacyExecution != nullptr, "missing gfx900 test ISA")) {
+    return 1;
+  }
+
+  amd::roc::Settings nativeExecution;
+  amd::roc::Settings nativeLegacyExecution;
+  amd::roc::Settings nativePresented;
+  amd::roc::Settings nativePresentedWgp;
+  amd::roc::Settings split;
+  amd::roc::Settings splitLegacyExecution;
+  amd::roc::Settings splitWgp;
+  if (!check(nativeExecution.create(false, *execution, *execution),
+             "failed to create native execution settings") ||
+      !check(nativeLegacyExecution.create(false, *legacyExecution, *legacyExecution),
+             "failed to create native legacy execution settings") ||
+      !check(nativePresented.create(false, *presented, *presented),
+             "failed to create native presented settings") ||
+      !check(nativePresentedWgp.create(false, *presentedWgp, *presentedWgp),
+             "failed to create native presented WGP settings") ||
+      !check(split.create(false, *presented, *execution), "failed to create split settings") ||
+      !check(splitLegacyExecution.create(false, *presented, *legacyExecution),
+             "failed to create split legacy execution settings") ||
+      !check(splitWgp.create(false, *presentedWgp, *execution),
+             "failed to create split WGP settings")) {
+    return 1;
+  }
+
+  bool passed = true;
+  passed &= check(split.barrier_value_packet_ == nativeExecution.barrier_value_packet_ &&
+                      split.barrier_value_packet_ != nativePresented.barrier_value_packet_,
+                  "barrier packet policy did not follow the execution ISA");
+  passed &= check(split.ext_dispatch_packet_ == nativeExecution.ext_dispatch_packet_ &&
+                      split.ext_dispatch_packet_ != nativePresented.ext_dispatch_packet_,
+                  "dispatch packet policy did not follow the execution ISA");
+  passed &= check(split.sdma_indirect_supported_ == nativeExecution.sdma_indirect_supported_ &&
+                      split.sdma_indirect_supported_ != nativePresented.sdma_indirect_supported_,
+                  "SDMA packet policy did not follow the execution ISA");
+  passed &= check(splitLegacyExecution.kernel_arg_impl_ == nativeLegacyExecution.kernel_arg_impl_ &&
+                      splitLegacyExecution.kernel_arg_impl_ != nativePresented.kernel_arg_impl_,
+                  "kernel argument policy did not follow the execution ISA");
+  passed &= check(split.enableWave32Mode_ == nativePresented.enableWave32Mode_ &&
+                      split.lcWavefrontSize64_ == nativePresented.lcWavefrontSize64_ &&
+                      split.enableWave32Mode_ != nativeExecution.enableWave32Mode_ &&
+                      split.lcWavefrontSize64_ != nativeExecution.lcWavefrontSize64_,
+                  "wave code-generation policy did not follow the presented ISA");
+  passed &=
+      check(!nativePresented.enableXNACK_ && !split.enableXNACK_ && nativeExecution.enableXNACK_,
+            "XNACK target feature did not follow the presented ISA");
+  passed &= check(!splitWgp.enableWgpMode_ && splitWgp.lcWgpMode_,
+                  "physical and compiler WGP modes were not kept separate");
+  passed &= check(splitWgp.enableWgpMode_ == nativeExecution.enableWgpMode_ &&
+                      splitWgp.lcWgpMode_ == nativePresentedWgp.lcWgpMode_,
+                  "WGP policies did not follow their respective ISA views");
+
+  return passed ? 0 : 1;
+}

--- a/projects/clr/tests/isa_views_test.cpp
+++ b/projects/clr/tests/isa_views_test.cpp
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip/hip_runtime.h>
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<hsa_agent_t> gpus;
+
+hsa_status_t findGpu(hsa_agent_t agent, void*) {
+  hsa_device_type_t type = HSA_DEVICE_TYPE_CPU;
+  hsa_status_t status = hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &type);
+  if (status != HSA_STATUS_SUCCESS) {
+    return status;
+  }
+  if (type == HSA_DEVICE_TYPE_GPU) {
+    gpus.push_back(agent);
+  }
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_agent_t findGpuForHipDevice(const hipDeviceProp_t& properties) {
+  for (hsa_agent_t gpu : gpus) {
+    uint32_t domain = 0;
+    uint32_t bdf = 0;
+    if (hsa_agent_get_info(gpu, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_DOMAIN),
+                           &domain) != HSA_STATUS_SUCCESS ||
+        hsa_agent_get_info(gpu, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_BDFID), &bdf) !=
+            HSA_STATUS_SUCCESS) {
+      continue;
+    }
+    const uint32_t bus = (bdf >> 8) & 0xff;
+    const uint32_t device = (bdf >> 3) & 0x1f;
+    if (domain == static_cast<uint32_t>(properties.pciDomainID) &&
+        bus == static_cast<uint32_t>(properties.pciBusID) &&
+        device == static_cast<uint32_t>(properties.pciDeviceID)) {
+      return gpu;
+    }
+  }
+  return {};
+}
+
+bool isaName(hsa_isa_t isa, std::string& name) {
+  uint32_t length = 0;
+  if (hsa_isa_get_info_alt(isa, HSA_ISA_INFO_NAME_LENGTH, &length) != HSA_STATUS_SUCCESS) {
+    return false;
+  }
+  std::vector<char> buffer(length + 1, '\0');
+  if (hsa_isa_get_info_alt(isa, HSA_ISA_INFO_NAME, buffer.data()) != HSA_STATUS_SUCCESS) {
+    return false;
+  }
+  name = buffer.data();
+  return true;
+}
+
+bool containsTarget(const std::string& isa, const char* target) {
+  if (target == nullptr) {
+    return true;
+  }
+  const std::string needle = std::string("--") + target;
+  const size_t position = isa.find(needle);
+  if (position == std::string::npos) {
+    return false;
+  }
+  const size_t end = position + needle.size();
+  return end == isa.size() || isa[end] == ':';
+}
+
+bool checkBlit() {
+  constexpr size_t size = 4096;
+  constexpr unsigned char pattern = 0x5a;
+  void* deviceBuffer = nullptr;
+  if (hipMalloc(&deviceBuffer, size) != hipSuccess) {
+    return false;
+  }
+
+  std::vector<unsigned char> source(size, pattern);
+  std::vector<unsigned char> destination(size, 0);
+  hipError_t status = hipMemcpy(deviceBuffer, source.data(), size, hipMemcpyHostToDevice);
+  if (status == hipSuccess) {
+    status = hipMemcpy(destination.data(), deviceBuffer, size, hipMemcpyDeviceToHost);
+  }
+  hipError_t freeStatus = hipFree(deviceBuffer);
+  if (status != hipSuccess || freeStatus != hipSuccess) {
+    return false;
+  }
+  for (unsigned char value : destination) {
+    if (value != pattern) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  const bool expectQueryFailure = argc == 2 && std::strcmp(argv[1], "--expect-query-failure") == 0;
+  const char* expectedPresented = argc >= 2 && !expectQueryFailure ? argv[1] : nullptr;
+  const char* expectedExecution = argc >= 3 ? argv[2] : nullptr;
+
+  // Check for physical hardware before HIP initialization so that a machine
+  // without a GPU can skip without hiding a CLR execution-ISA query failure.
+  if (hsa_init() != HSA_STATUS_SUCCESS) {
+    return 1;
+  }
+  hsa_status_t hsaStatus = hsa_iterate_agents(findGpu, nullptr);
+  if (hsaStatus != HSA_STATUS_SUCCESS || gpus.empty()) {
+    hsa_shut_down();
+    return 77;
+  }
+
+  if (expectQueryFailure) {
+    const hsa_agent_t gpu = gpus.front();
+    hsa_isa_t executionIsa = {};
+    hsaStatus = hsa_agent_get_info(
+        gpu, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_EXECUTION_ISA), &executionIsa);
+    if (hsaStatus == HSA_STATUS_SUCCESS) {
+      hsa_shut_down();
+      return 1;
+    }
+  }
+
+  int deviceCount = 0;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+  if (expectQueryFailure) {
+    std::printf(
+        "execution_isa_query_status=%d\nhip_status=%d\n"
+        "device_count=%d\n",
+        static_cast<int>(hsaStatus), static_cast<int>(hipStatus), deviceCount);
+    hsa_shut_down();
+    return hipStatus == hipErrorNoDevice && deviceCount == 0 ? 0 : 1;
+  }
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::fprintf(stderr, "HIP device initialization failed: %d\n", static_cast<int>(hipStatus));
+    hsa_shut_down();
+    return 1;
+  }
+
+  hipDeviceProp_t properties = {};
+  if (hipGetDeviceProperties(&properties, 0) != hipSuccess) {
+    hsa_shut_down();
+    return 1;
+  }
+
+  const hsa_agent_t gpu = findGpuForHipDevice(properties);
+  if (gpu.handle == 0) {
+    hsa_shut_down();
+    return 1;
+  }
+
+  hsa_isa_t presentedIsa = {};
+  hsa_isa_t executionIsa = {};
+  std::string presentedName;
+  std::string executionName;
+  if (hsa_agent_get_info(gpu, HSA_AGENT_INFO_ISA, &presentedIsa) != HSA_STATUS_SUCCESS ||
+      hsa_agent_get_info(gpu, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_EXECUTION_ISA),
+                         &executionIsa) != HSA_STATUS_SUCCESS ||
+      !isaName(presentedIsa, presentedName) || !isaName(executionIsa, executionName)) {
+    hsa_shut_down();
+    return 1;
+  }
+
+  const bool native = expectedPresented == nullptr;
+  const char* presentedTarget = native ? properties.gcnArchName : expectedPresented;
+  const std::string gcnArchIsa = std::string("amdgcn-amd-amdhsa--") + properties.gcnArchName;
+  uint32_t presentedWavefrontSize = 0;
+  if (hsa_agent_get_info(gpu, HSA_AGENT_INFO_WAVEFRONT_SIZE, &presentedWavefrontSize) !=
+      HSA_STATUS_SUCCESS) {
+    hsa_shut_down();
+    return 1;
+  }
+  bool passed = containsTarget(presentedName, presentedTarget) &&
+                containsTarget(gcnArchIsa, presentedTarget) &&
+                containsTarget(executionName, expectedExecution) &&
+                properties.warpSize == static_cast<int>(presentedWavefrontSize) &&
+                (!native || presentedName == executionName) && checkBlit();
+
+  std::printf(
+      "presented_isa=%s\nexecution_isa=%s\ngcn_arch=%s\n"
+      "warp_size=%d\nmax_threads_per_multiprocessor=%d\n",
+      presentedName.c_str(), executionName.c_str(), properties.gcnArchName, properties.warpSize,
+      properties.maxThreadsPerMultiProcessor);
+  hsa_shut_down();
+  return passed ? 0 : 1;
+}

--- a/projects/rocr-runtime/rocrtst/suites/functional/agent_props.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/agent_props.cc
@@ -239,4 +239,22 @@ void AgentPropTest::QueryAgentClockCounters() {
   }
 }
 
+void AgentPropTest::QueryAgentExecutionIsa() {
+  std::vector<hsa_agent_t> gpus;
+  hsa_status_t err = hsa_iterate_agents(rocrtst::IterateGPUAgents, &gpus);
+  ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+
+  for (hsa_agent_t gpu : gpus) {
+    hsa_isa_t isa = {};
+    hsa_isa_t execution_isa = {};
+    err = hsa_agent_get_info(gpu, HSA_AGENT_INFO_ISA, &isa);
+    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+    err = hsa_agent_get_info(
+        gpu, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_EXECUTION_ISA),
+        &execution_isa);
+    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+    EXPECT_EQ(execution_isa.handle, isa.handle);
+  }
+}
+
 #undef RET_IF_HSA_ERR

--- a/projects/rocr-runtime/rocrtst/suites/functional/agent_props.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/agent_props.cc
@@ -253,6 +253,13 @@ void AgentPropTest::QueryAgentExecutionIsa() {
         gpu, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_EXECUTION_ISA),
         &execution_isa);
     ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+
+    uint32_t isa_name_length = 0;
+    err = hsa_isa_get_info_alt(execution_isa, HSA_ISA_INFO_NAME_LENGTH,
+                               &isa_name_length);
+    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+    EXPECT_GT(isa_name_length, 0u);
+
     EXPECT_EQ(execution_isa.handle, isa.handle);
   }
 }

--- a/projects/rocr-runtime/rocrtst/suites/functional/agent_props.h
+++ b/projects/rocr-runtime/rocrtst/suites/functional/agent_props.h
@@ -80,6 +80,9 @@ class AgentPropTest : public TestBase {
   // @Brief: Query Clock Counter property of agents of a ROCm platform
   void QueryAgentClockCounters();
 
+  // @Brief: Query physical execution ISA property of GPU agents
+  void QueryAgentExecutionIsa();
+
  private:
   // Capture value for all agents on system
   std::vector<std::string> propList_;

--- a/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
@@ -507,6 +507,7 @@ TEST(rocrtstFunc, AgentPropertiesTests) {
     if (!RunCustomTestProlog(&propTest)) return;
     propTest.QueryAgentUUID();
     propTest.QueryAgentClockCounters();
+    propTest.QueryAgentExecutionIsa();
     RunCustomTestEpilog(&propTest);
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -2344,6 +2344,7 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
       }
     } break;
     case HSA_AGENT_INFO_ISA:
+    case HSA_AMD_AGENT_INFO_EXECUTION_ISA:
       *((hsa_isa_t*)value) = core::Isa::Handle(supported_isas()[0]);
       break;
     case HSA_AGENT_INFO_EXTENSIONS: {

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -82,9 +82,10 @@
  * - 1.28 - hsa_amd_agent_info_t: HSA_AMD_AGENT_INFO_HOST_ALLOC_DMABUF_SUPPORTED
  * - 1.29 - hsa_amd_image_create_v2, hsa_amd_interop_map_buffer_with_size
  * - 1.30 - hsa_amd_queue_get_info: engine type and SDMA engine ID
+ * - 1.31 - hsa_amd_agent_info_t: HSA_AMD_AGENT_INFO_EXECUTION_ISA
  */
 #define HSA_AMD_INTERFACE_VERSION_MAJOR 1
-#define HSA_AMD_INTERFACE_VERSION_MINOR 30
+#define HSA_AMD_INTERFACE_VERSION_MINOR 31
 
 #ifdef __cplusplus
 extern "C" {
@@ -986,6 +987,15 @@ typedef enum hsa_amd_agent_info_s {
    * The type of this attribute is bool.
    */
   HSA_AMD_AGENT_INFO_HOST_ALLOC_DMABUF_SUPPORTED = 0xA124,
+  /**
+   * Concrete physical instruction set used by a GPU agent for hardware
+   * execution. The type of this attribute is ::hsa_isa_t. This attribute is
+   * only for hardware-specific runtime policy. Code-object and compilation
+   * target selection must use the standard agent ISA queries. API tools must
+   * preserve this value when presenting another ISA through
+   * ::HSA_AGENT_INFO_ISA.
+   */
+  HSA_AMD_AGENT_INFO_EXECUTION_ISA = 0xA125,
 } hsa_amd_agent_info_t;
 
 /**


### PR DESCRIPTION
## Motivation

Depends on #9362.

An HSA API tool may present a compatibility ISA so clients select code objects
and compiler targets for an ISA that the tool can process before execution. The
physical GPU may nevertheless require different hardware-specific runtime
policy.

CLR currently uses the standard HSA agent ISA for both purposes. This change
keeps that ISA authoritative for code selection while using the new physical
execution-ISA query only where CLR policy depends on the actual hardware.

## Technical Details

Cache two ISA views during ROCr device creation:

- `isa()` remains the presented ISA obtained through the standard HSA agent ISA
  view.
- `executionIsa()` is the physical ISA obtained through `HSA_AMD_AGENT_INFO_EXECUTION_ISA`.

Code-object selection, device-library and internal-kernel selection, target features,
and wave-size code generation continue to follow the presented ISA.
Physical resource limits, queue and dispatch-packet policy, memory workarounds,
performance-counter layout, and hardware occupancy limits use the execution ISA.

Two details are intentionally kept separate:

- Compiler WGP mode is split from runtime CU/WGP accounting because the former
  controls generated code while the latter describes the physical device.
- XNACK follows the presented target ID because it is a code-object target
  feature. Physical memory capabilities continue to come from the agent and
  memory-pool properties.

## Issue Tracking

JIRA ID: ROCM-28199

## Test Plan

Build the affected CLR targets and run the focused ISA policy and ISA-view
tests.

## Test Result

- `rocclr-isa-policy` and `hip-isa-views-native` passed.
- Native execution preserved identical presented and execution behavior.
- Integration testing with distinct ISA views preserved the presented ISA for
  HIP and code-selection behavior while reporting the physical ISA through the
  execution-ISA query.
- Query failure was handled explicitly without falling back to the presented
  ISA.