### PR TITLE
feat(rocshmem): make heap allocator a runtime option

### DIFF
--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -50,11 +50,6 @@ option(USE_GDA "Enable GDA conduit" OFF)
 option(USE_SDMA "Enable SDMA transport (MI300X+)" OFF)
 option(USE_THREADS "Enable workgroup threads to share network queues" OFF)
 option(USE_WF_COAL "Enable wavefront message coalescing" OFF)
-option(USE_HEAP_DEVICE_FINEGRAIN "Heap uses GPU memory in finegrain mode" ON)
-option(USE_HEAP_DEVICE_UNCACHED "Heap uses GPU memory in uncached mode" OFF)
-option(USE_HEAP_DEVICE_COARSEGRAIN "Heap uses GPU memory in coarsegrain mode" OFF)
-option(USE_HEAP_DEVICE_VMM_POSIX "Heap uses GPU memory with VMM and POSIX FD IPC (requires ROCm 7.2+)" OFF)
-option(USE_HEAP_DEVICE_VMM_FABRIC "Heap uses GPU memory with VMM and Fabric handles (requires ROCm 7.next)" OFF)
 option(USE_FUNC_CALL "Force compiler to use function calls on library API" OFF)
 option(USE_SHARED_CTX "Request support for shared ctx between WG" OFF)
 option(USE_SINGLE_NODE "Enable single node support only." OFF)
@@ -112,15 +107,6 @@ include(ROCMCheckTargetIds)
 rocm_setup_version(VERSION ${VERSION_STRING})
 
 #############################################################################
-# VALIDATE VMM POSIX ALLOCATOR OPTION
-#############################################################################
-if(USE_HEAP_DEVICE_VMM_POSIX)
-  if(${ROCM_MAJOR_VERSION} LESS 7 OR (${ROCM_MAJOR_VERSION} EQUAL 7 AND ${ROCM_MINOR_VERSION} LESS 2))
-    message(FATAL_ERROR "USE_HEAP_DEVICE_VMM_POSIX requires ROCm 7.2 or newer. Current ROCm version: ${ROCM_MAJOR_VERSION}.${ROCM_MINOR_VERSION}")
-  endif()
-endif()
-
-#############################################################################
 # DETECT POD CAPABILITY
 #############################################################################
 # Try to find AMD SMI library
@@ -166,25 +152,6 @@ if(TARGET amd_smi)
   endif()
 else()
   message(STATUS "AMD SMI library not found - disabling pod-based IPC capability detection")
-endif()
-
-#############################################################################
-# VALIDATE VMM FABRIC ALLOCATOR OPTION
-#############################################################################
-if(USE_HEAP_DEVICE_VMM_FABRIC)
-  if(${ROCM_MAJOR_VERSION} LESS 7 OR (${ROCM_MAJOR_VERSION} EQUAL 7 AND ${ROCM_MINOR_VERSION} LESS 2))
-    message(FATAL_ERROR "USE_HEAP_DEVICE_VMM_FABRIC requires ROCm 7.2 or newer. Current ROCm version: ${ROCM_MAJOR_VERSION}.${ROCM_MINOR_VERSION}")
-  endif()
-
-  # VMM Fabric allocator requires both AMD SMI fabric info and HIP fabric handle support
-  if(NOT HAVE_AMDSMI_GPU_FABRIC_INFO)
-    message(FATAL_ERROR "USE_HEAP_DEVICE_VMM_FABRIC requires both:\n"
-                        "  1. AMD SMI library with amdsmi_get_gpu_fabric_info support\n"
-                        "  2. HIP runtime with hipMemFabricHandle_t support (ROCm 7.14+)\n"
-                        "Either update to ROCm 7.14 or newer, or disable USE_HEAP_DEVICE_VMM_FABRIC.")
-  endif()
-
-  message(STATUS "USE_HEAP_DEVICE_VMM_FABRIC enabled with full fabric handle support")
 endif()
 
 #############################################################################

--- a/projects/rocshmem/cmake/rocshmem_config.h.in
+++ b/projects/rocshmem/cmake/rocshmem_config.h.in
@@ -33,11 +33,6 @@
 #cmakedefine USE_THREADS
 #cmakedefine USE_SHARED_CTX
 #cmakedefine USE_WF_COAL
-#cmakedefine USE_HEAP_DEVICE_FINEGRAIN
-#cmakedefine USE_HEAP_DEVICE_UNCACHED
-#cmakedefine USE_HEAP_DEVICE_COARSEGRAIN
-#cmakedefine USE_HEAP_DEVICE_VMM_POSIX
-#cmakedefine USE_HEAP_DEVICE_VMM_FABRIC
 #cmakedefine HAVE_AMDSMI_GPU_FABRIC_INFO
 #cmakedefine USE_FUNC_CALL
 #cmakedefine USE_SINGLE_NODE

--- a/projects/rocshmem/docs/api/init.rst
+++ b/projects/rocshmem/docs/api/init.rst
@@ -78,7 +78,7 @@ The parameter ``flags`` can be either
 
 .. note::
 
-  When using the VMM POSIX memory allocator (``USE_HEAP_DEVICE_VMM_POSIX``),
+  When using the VMM POSIX memory allocator (``ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_posix``),
   you must use ``ROCSHMEM_INIT_WITH_UNIQUEID`` initialization.
   MPI-based initialization (``ROCSHMEM_INIT_WITH_MPI_COMM``) is not compatible
   with the VMM POSIX allocator and will result in a runtime error.

--- a/projects/rocshmem/docs/build.rst
+++ b/projects/rocshmem/docs/build.rst
@@ -20,7 +20,7 @@ Requirements
 
 * ROCm 6.4.0 or later, including the :doc:`HIP runtime <hip:index>`. For more information, see `ROCm installation for Linux <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/>`_.
 
-  * ROCm 7.2 or later is required for the VMM POSIX memory allocator (``USE_HEAP_DEVICE_VMM_POSIX``).
+  * ROCm 7.2 or later is required for the VMM POSIX and VMM Fabric memory allocators (``ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_posix`` or ``vmm_fabric``).
 
 * The following AMD GPUs have been fully tested for compatibility with rocSHMEM:
 
@@ -133,21 +133,23 @@ tests, as they require MPI to run.
 Memory allocator options
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-rocSHMEM provides several GPU memory allocator options that control how the symmetric heap is allocated:
+rocSHMEM provides several GPU memory allocator options that control how the symmetric heap is allocated.
+The allocator is selected at runtime via the ``ROCSHMEM_HEAP_ALLOCATOR_TYPE`` environment variable:
 
-* **USE_HEAP_DEVICE_FINEGRAIN** (default): GPU memory with fine-grained coherency. Provides CPU access to GPU memory with cache coherency.
+* **finegrained**: GPU memory with fine-grained coherency. Provides CPU access to GPU memory with cache coherency.
+  This is the default on gfx1100 and gfx1201 architectures.
 
-* **USE_HEAP_DEVICE_COARSEGRAIN**: GPU memory with coarse-grained coherency. Better performance for GPU-only access patterns.
+* **coarsegrained**: GPU memory with coarse-grained coherency. Better performance for GPU-only access patterns.
 
-* **USE_HEAP_DEVICE_UNCACHED**: GPU memory in uncached mode (requires ROCm 5.5+). May provide better performance on some architectures.
+* **uncached** (default on most architectures): GPU memory in uncached mode. May provide better performance on some architectures.
 
-* **USE_HEAP_DEVICE_VMM_POSIX**: GPU memory using Virtual Memory Management (VMM) with POSIX file descriptor-based IPC (requires ROCm 7.2+).
+* **vmm_posix**: GPU memory using Virtual Memory Management (VMM) with POSIX file descriptor-based IPC (requires ROCm 7.2+).
   This allocator uses advanced HIP VMM APIs (``hipMemCreate``, ``hipMemAddressReserve``, ``hipMemMap``) and
   cross-process file descriptor sharing via Linux kernel syscalls (``pidfd_open``, ``pidfd_getfd``).
 
   .. note::
 
-    The VMM POSIX allocator requires:
+    The ``vmm_posix`` allocator requires:
 
     * ROCm 7.2 or newer
     * Linux kernel 5.6 or newer
@@ -155,13 +157,17 @@ rocSHMEM provides several GPU memory allocator options that control how the symm
 
     This allocator is experimental and primarily intended for advanced use cases requiring fine-grained control over GPU memory management and IPC mechanisms.
 
-These options are mutually exclusive. To use a non-default allocator, pass the corresponding flag to the build configuration scripts. For example:
+* **vmm_fabric**: GPU memory using VMM with fabric handle-based IPC (requires ROCm 7.14+ with AMD SMI fabric handle support).
+  This allocator is only supported on gfx1250 (MI455) GPUs.
+
+To select a non-default allocator, set the environment variable before launching the application. For example:
 
 .. code-block:: bash
 
-  cd projects/rocshmem/build
-  cmake .. -DUSE_HEAP_DEVICE_COARSEGRAIN=ON -DUSE_HEAP_DEVICE_FINEGRAIN=OFF
-  cmake --build . --parallel 8
+  export ROCSHMEM_HEAP_ALLOCATOR_TYPE=coarsegrained
+  mpiexec -np 2 ./my_rocshmem_app
+
+For a full description of accepted values and defaults, see :ref:`rocshmem-api-env-variables`.
 
 Profiling and tracing support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/projects/rocshmem/docs/build.rst
+++ b/projects/rocshmem/docs/build.rst
@@ -20,7 +20,8 @@ Requirements
 
 * ROCm 6.4.0 or later, including the :doc:`HIP runtime <hip:index>`. For more information, see `ROCm installation for Linux <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/>`_.
 
-  * ROCm 7.2 or later is required for the VMM POSIX and VMM Fabric memory allocators (``ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_posix`` or ``vmm_fabric``).
+  * ROCm 7.2 or later is required for the VMM POSIX memory allocator (``ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_posix``).
+  * ROCm 7.14 or later with AMD SMI fabric handle support is required for the VMM Fabric memory allocator (``ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_fabric``).
 
 * The following AMD GPUs have been fully tested for compatibility with rocSHMEM:
 

--- a/projects/rocshmem/docs/build.rst
+++ b/projects/rocshmem/docs/build.rst
@@ -137,12 +137,11 @@ Memory allocator options
 rocSHMEM provides several GPU memory allocator options that control how the symmetric heap is allocated.
 The allocator is selected at runtime via the ``ROCSHMEM_HEAP_ALLOCATOR_TYPE`` environment variable:
 
-* **finegrained**: GPU memory with fine-grained coherency. Provides CPU access to GPU memory with cache coherency.
-  This is the default on gfx1100 and gfx1201 architectures.
+* **finegrained** (default): GPU memory with fine-grained coherency. Provides CPU access to GPU memory with cache coherency.
 
 * **coarsegrained**: GPU memory with coarse-grained coherency. Better performance for GPU-only access patterns.
 
-* **uncached** (default on most architectures): GPU memory in uncached mode. May provide better performance on some architectures.
+* **uncached**: GPU memory in uncached mode. May provide better performance on some architectures.
 
 * **vmm_posix**: GPU memory using Virtual Memory Management (VMM) with POSIX file descriptor-based IPC (requires ROCm 7.2+).
   This allocator uses advanced HIP VMM APIs (``hipMemCreate``, ``hipMemAddressReserve``, ``hipMemMap``) and

--- a/projects/rocshmem/docs/build.rst
+++ b/projects/rocshmem/docs/build.rst
@@ -141,7 +141,7 @@ The allocator is selected at runtime via the ``ROCSHMEM_HEAP_ALLOCATOR_TYPE`` en
 
 * **coarsegrained**: GPU memory with coarse-grained coherency. Better performance for GPU-only access patterns.
 
-* **uncached**: GPU memory in uncached mode. May provide better performance on some architectures.
+* **uncached**: GPU memory in uncached mode (requires ROCm 5.5+). May provide better performance on some architectures.
 
 * **vmm_posix**: GPU memory using Virtual Memory Management (VMM) with POSIX file descriptor-based IPC (requires ROCm 7.2+).
   This allocator uses advanced HIP VMM APIs (``hipMemCreate``, ``hipMemAddressReserve``, ``hipMemMap``) and
@@ -155,7 +155,6 @@ The allocator is selected at runtime via the ``ROCSHMEM_HEAP_ALLOCATOR_TYPE`` en
     * Linux kernel 5.6 or newer
     * TCP Bootstrap-based initialization (not compatible with MPI-based initialization)
 
-    This allocator is experimental and primarily intended for advanced use cases requiring fine-grained control over GPU memory management and IPC mechanisms.
 
 * **vmm_fabric**: GPU memory using VMM with fabric handle-based IPC (requires ROCm 7.14+ with AMD SMI fabric handle support).
   This allocator is only supported on gfx1250 (MI455) GPUs.

--- a/projects/rocshmem/docs/env_variables.rst
+++ b/projects/rocshmem/docs/env_variables.rst
@@ -39,6 +39,16 @@ control the behavior of rocSHMEM.
         |
         | Examples: ``trace:noversion``, ``env:full``, ``api:noenv``, ``trace:nocolor``
 
+    * - | ``ROCSHMEM_HEAP_ALLOCATOR_TYPE``
+        | Selects the GPU memory allocator used for the symmetric heap.
+      - arch-dependent
+      - | ``uncached``: GPU memory in uncached mode (default on most architectures).
+        | ``finegrained``: Fine-grained coherent GPU memory (default on gfx1100, gfx1201).
+        | ``coarsegrained``: Coarse-grained coherent GPU memory.
+        | ``vmm_posix``: VMM with POSIX fd-based IPC (requires ROCm 7.2+, Linux 5.6+, TCP bootstrap).
+        | ``vmm_fabric``: VMM with fabric handle IPC (requires ROCm 7.14+, gfx1250/MI455 only).
+        | Values are case-insensitive.
+
     * - | ``ROCSHMEM_HEAP_SIZE``
         | Defines the size of the rocSHMEM symmetric heap in bytes (per PE).
       - ``1073741824`` (1 GB)

--- a/projects/rocshmem/src/build_info.cpp
+++ b/projects/rocshmem/src/build_info.cpp
@@ -26,6 +26,7 @@
 #include "rocshmem/rocshmem.hpp"
 #include "rocshmem_config_embedded.hpp"
 #include "util.hpp"
+#include "memory/default_allocator.hpp"
 
 #include <rocm-core/rocm_version.h>
 
@@ -79,6 +80,17 @@ static void print_rocm_info(std::ostream& os) {
                            + std::to_string(ROCM_VERSION_MINOR) + "."
                            + std::to_string(ROCM_VERSION_PATCH);
   print_entry(os, "ROCm", rocm_version.c_str());
+}
+
+static void print_heap_allocator_info(std::ostream& os) {
+  static const char* names[AllocatorTypeLast + 1] = {
+    "coarsegrained", "finegrained", "uncached",
+    "vmm_posix", "vmm_fabric", "host", "posix", "(unknown)"
+  };
+  AllocatorType t = get_default_allocator()->get_type();
+  int idx = (t >= 0 && t < AllocatorTypeLast) ? static_cast<int>(t)
+                                               : static_cast<int>(AllocatorTypeLast);
+  print_entry(os, "Heap Allocator", names[idx]);
 }
 
 static void print_mpi_info(std::ostream& os) {
@@ -165,6 +177,7 @@ void print_build_info(std::ostream& os) {
   print_arch_info(os);
   print_rocm_info(os);
   print_mpi_info(os);
+  print_heap_allocator_info(os);
   parse_config(os);
 
   os << "################################################################################\n";

--- a/projects/rocshmem/src/containers/atomic_wf_queue.hpp
+++ b/projects/rocshmem/src/containers/atomic_wf_queue.hpp
@@ -329,14 +329,14 @@ class AtomicWFQueue {
 template <typename TYPE>
 class AtomicWFQueueProxy {
   using AtomicWFQueueT = AtomicWFQueue<TYPE>;
-  using ProxyT = DeviceProxy<HIPAllocator, AtomicWFQueueT>;
+  using ProxyT = DeviceProxy<AtomicWFQueueT>;
 
  public:
   __host__ __device__ AtomicWFQueueT* get() { return proxy_.get(); }
 
   explicit AtomicWFQueueProxy(const MemoryAllocator& alloc = HIPAllocator(),
                               size_t num_elems = 1)
-      : allocator_{alloc}, proxy_{num_elems} {
+      : allocator_{alloc}, proxy_{num_elems, allocator_} {
     new (proxy_.get()) AtomicWFQueueT(allocator_);
   }
 

--- a/projects/rocshmem/src/containers/free_list.hpp
+++ b/projects/rocshmem/src/containers/free_list.hpp
@@ -260,14 +260,14 @@ class FreeList {
 template <typename TYPE>
 class FreeListProxy {
   using FreeListT = FreeList<TYPE>;
-  using ProxyT = DeviceProxy<HIPAllocator, FreeListT>;
+  using ProxyT = DeviceProxy<FreeListT>;
 
  public:
   __host__ __device__ FreeListT* get() { return proxy_.get(); }
 
   explicit FreeListProxy(const MemoryAllocator& alloc = HIPAllocator(),
                          size_t num_elems = 1)
-      : allocator_{alloc}, proxy_{num_elems} {
+      : allocator_{alloc}, proxy_{num_elems, allocator_} {
     new (proxy_.get()) FreeListT(allocator_);
   }
 

--- a/projects/rocshmem/src/device_proxy.hpp
+++ b/projects/rocshmem/src/device_proxy.hpp
@@ -41,13 +41,13 @@ class DeviceProxy {
   DeviceProxy() = default;
 
   DeviceProxy(size_t num_elems, MemoryAllocator& alloc)
-      : allocator_{&alloc}, num_elems_{num_elems} {
+      : num_elems_{num_elems} {
     size_t size_bytes = sizeof(T) * num_elems_;
     T* temp{nullptr};
-    allocator_->allocate(reinterpret_cast<void**>(&temp), size_bytes);
+    alloc.allocate(reinterpret_cast<void**>(&temp), size_bytes);
     assert(temp);
     memset(static_cast<void*>(temp), 0, size_bytes);
-    std::unique_ptr<T, Deleter> up{temp, Deleter{allocator_}};
+    std::unique_ptr<T, Deleter> up{temp, Deleter{alloc}};
     up_ = std::move(up);
     ptr_ = up_.get();
   }
@@ -69,25 +69,15 @@ class DeviceProxy {
   __host__ __device__ T* get() { return ptr_; }
 
  private:
-  /**
-   * @brief Internal Deleter functor is required by up_ member.
-   * The allocator pointer must outlive this Deleter.
-   */
   class Deleter {
    public:
     Deleter() = default;
-    explicit Deleter(MemoryAllocator* a) : a_{a} {}
-    void operator()(void* x) { if (a_) a_->deallocate(x); }
+    explicit Deleter(const MemoryAllocator& a) : a_{a} {}
+    void operator()(void* x) { a_.deallocate(x); }
 
    private:
-    MemoryAllocator* a_{nullptr};
+    MemoryAllocator a_{};
   };
-
-  /**
-   * @brief Pointer to the externally owned allocator.
-   * Must outlive this DeviceProxy instance.
-   */
-  MemoryAllocator* allocator_{nullptr};
 
   /**
    * @brief Unique pointer for tracking the proxy.

--- a/projects/rocshmem/src/device_proxy.hpp
+++ b/projects/rocshmem/src/device_proxy.hpp
@@ -31,40 +31,24 @@
 #include <cstring>
 #include <cassert>
 
+#include "memory/memory_allocator.hpp"
+
 namespace rocshmem {
 
-template <typename ALLOCATOR, typename T>
+template <typename T>
 class DeviceProxy {
  public:
   DeviceProxy() = default;
 
-  DeviceProxy(size_t num_elems) : num_elems_ {num_elems} {
-    /**
-     * @brief The allocation size of the internal memory
-     *
-    */
+  DeviceProxy(size_t num_elems, MemoryAllocator& alloc)
+      : allocator_{&alloc}, num_elems_{num_elems} {
     size_t size_bytes = sizeof(T) * num_elems_;
-    /*
-     * Allocate memory and verify that the allocation worked.
-     */
     T* temp{nullptr};
-    allocator_.allocate(reinterpret_cast<void**>(&temp), size_bytes);
+    allocator_->allocate(reinterpret_cast<void**>(&temp), size_bytes);
     assert(temp);
-
-    /*
-     * Default memory provided by the allocation to recognizable bytes.
-     */
     memset(static_cast<void*>(temp), 0, size_bytes);
-
-    /*
-     * Pass the memory into a unique ptr for tracking.
-     */
-    std::unique_ptr<T, Deleter> up{temp};
+    std::unique_ptr<T, Deleter> up{temp, Deleter{allocator_}};
     up_ = std::move(up);
-
-    /*
-     * Set a c-style ptr for access by the device.
-     */
     ptr_ = up_.get();
   }
 
@@ -86,20 +70,24 @@ class DeviceProxy {
 
  private:
   /**
-   * @brief Internal Deleter functor is required by up_ member
+   * @brief Internal Deleter functor is required by up_ member.
+   * The allocator pointer must outlive this Deleter.
    */
   class Deleter {
    public:
-    void operator()(void* x) { a_.deallocate(x); }
+    Deleter() = default;
+    explicit Deleter(MemoryAllocator* a) : a_{a} {}
+    void operator()(void* x) { if (a_) a_->deallocate(x); }
 
    private:
-    ALLOCATOR a_;
+    MemoryAllocator* a_{nullptr};
   };
 
   /**
-   * @brief Externally provided allocator type.
+   * @brief Pointer to the externally owned allocator.
+   * Must outlive this DeviceProxy instance.
    */
-  ALLOCATOR allocator_{};
+  MemoryAllocator* allocator_{nullptr};
 
   /**
    * @brief Unique pointer for tracking the proxy.

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -122,6 +122,9 @@ namespace envvar {
     const var<size_t> heap_size("HEAP_SIZE",
       "Defines the size of the rocSHMEM symmetric heap in bytes (per PE). Size in bytes (per PE); Note: the heap is on GPU memory",
       1L << 30);
+    const var<std::string> heap_allocator_type("HEAP_ALLOCATOR_TYPE",
+      "Selects the allocator type for the symmetric heap. Accepted values: uncached, finegrained, coarsegrained, vmm_posix, vmm_fabric. "
+      "Default is arch-dependent: uncached for most GPUs, finegrained for gfx1100 and gfx1201.");
     const var<std::string> backend("BACKEND",
       "When rocSHMEM is compiled for all backends, this environment variable selects which backend to execute. The default value is an empty string and rocSHMEM auto-selects the most appropriate backend. ipc: IPC Backend; ro: Reverse Offload Backend; gda: GPU Direct Async Backend");
     const var<size_t> max_num_contexts("MAX_NUM_CONTEXTS",

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -124,7 +124,7 @@ namespace envvar {
       1L << 30);
     const var<std::string> heap_allocator_type("HEAP_ALLOCATOR_TYPE",
       "Selects the allocator type for the symmetric heap. Accepted values: uncached, finegrained, coarsegrained, vmm_posix, vmm_fabric. "
-      "Default is arch-dependent: uncached for most GPUs, finegrained for gfx1100 and gfx1201.");
+      "Default is finegrained.");
     const var<std::string> backend("BACKEND",
       "When rocSHMEM is compiled for all backends, this environment variable selects which backend to execute. The default value is an empty string and rocSHMEM auto-selects the most appropriate backend. ipc: IPC Backend; ro: Reverse Offload Backend; gda: GPU Direct Async Backend");
     const var<size_t> max_num_contexts("MAX_NUM_CONTEXTS",

--- a/projects/rocshmem/src/envvar.hpp
+++ b/projects/rocshmem/src/envvar.hpp
@@ -498,6 +498,7 @@ namespace envvar {
     extern const var<bool> uniqueid_with_mpi;
     extern const var<types::debug_level> debug_level;
     extern const var<size_t> heap_size;
+    extern const var<std::string> heap_allocator_type;
     extern const var<size_t> max_num_teams;
     extern const var<std::string> backend;
     extern const var<bool> disable_mixed_ipc;

--- a/projects/rocshmem/src/gda/backend_gda.hpp
+++ b/projects/rocshmem/src/gda/backend_gda.hpp
@@ -413,7 +413,7 @@ class GDABackend : public Backend {
    *
    * @note Internal data ownership is managed by the proxy
    */
-  HdpProxy<HIPHostAllocator> hdp_proxy_{};
+  HdpProxy hdp_proxy_{};
 
   /**
    * @brief Holds a copy of the default context for host functions

--- a/projects/rocshmem/src/gda/gda_context_proxy.hpp
+++ b/projects/rocshmem/src/gda/gda_context_proxy.hpp
@@ -35,7 +35,7 @@ namespace rocshmem {
 class GDABackend;
 
 class GDADefaultContextProxy {
-  using ProxyT = DeviceProxy<HIPAllocator, GDAContext>;
+  using ProxyT = DeviceProxy<GDAContext>;
 
  public:
   GDADefaultContextProxy() = default;
@@ -44,9 +44,9 @@ class GDADefaultContextProxy {
    * Placement new the memory which is allocated by proxy_
    */
   explicit GDADefaultContextProxy(GDABackend* backend, TeamInfo *tinfo,
-                                  [[maybe_unused]] const HIPAllocator& alloc = HIPAllocator(),
+                                  HIPAllocator alloc = HIPAllocator(),
                                   size_t num_elems = 1)
-  : proxy_{num_elems}, constructed_{true} {
+  : alloc_{alloc}, proxy_{num_elems, alloc_}, constructed_{true} {
     auto ctx{proxy_.get()};
     new (ctx) GDAContext(reinterpret_cast<Backend*>(backend), 0);
     ctx->tinfo = tinfo;
@@ -85,6 +85,7 @@ class GDADefaultContextProxy {
   __host__ __device__ Context* get() { return proxy_.get(); }
 
  private:
+  HIPAllocator alloc_{};
   /*
    * @brief Memory managed by the lifetime of this object
    */

--- a/projects/rocshmem/src/hdp_proxy.hpp
+++ b/projects/rocshmem/src/hdp_proxy.hpp
@@ -32,15 +32,15 @@
 namespace rocshmem {
 
 class HdpProxy {
-  using HdpProxyT = DeviceProxy<HIPHostAllocator, HdpPolicy>;
+  using HdpProxyT = DeviceProxy<HdpPolicy>;
 
  public:
   /*
    * Placement new the memory which is allocated by proxy_
    */
-  HdpProxy([[maybe_unused]] const HIPHostAllocator& alloc = HIPHostAllocator(),
+  HdpProxy(const HIPHostAllocator& alloc = HIPHostAllocator(),
            size_t num_elems = 1)
-    : proxy_{num_elems} {
+    : alloc_{alloc}, proxy_{num_elems, alloc_} {
     new (proxy_.get()) HdpPolicy();
   }
 
@@ -66,6 +66,7 @@ class HdpProxy {
   __host__ __device__ HdpPolicy* get() { return proxy_.get(); }
 
  private:
+  HIPHostAllocator alloc_{};
   /*
    * @brief Memory managed by the lifetime of this object
    */

--- a/projects/rocshmem/src/hdp_proxy.hpp
+++ b/projects/rocshmem/src/hdp_proxy.hpp
@@ -27,18 +27,20 @@
 
 #include "device_proxy.hpp"
 #include "hdp_policy.hpp"
+#include "memory/hip_allocator.hpp"
 
 namespace rocshmem {
 
-template <typename ALLOCATOR>
 class HdpProxy {
-  using HdpProxyT = DeviceProxy<ALLOCATOR, HdpPolicy>;
+  using HdpProxyT = DeviceProxy<HIPHostAllocator, HdpPolicy>;
 
  public:
   /*
    * Placement new the memory which is allocated by proxy_
    */
-  HdpProxy(size_t num_elems = 1) : proxy_{num_elems} {
+  HdpProxy([[maybe_unused]] const HIPHostAllocator& alloc = HIPHostAllocator(),
+           size_t num_elems = 1)
+    : proxy_{num_elems} {
     new (proxy_.get()) HdpPolicy();
   }
 

--- a/projects/rocshmem/src/ipc/backend_ipc.hpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.hpp
@@ -205,7 +205,7 @@ class IPCBackend : public Backend {
    *
    * @note Internal data ownership is managed by the proxy
    */
-  HdpProxy<HIPHostAllocator> hdp_proxy_{};
+  HdpProxy hdp_proxy_{};
 
   /**
    * @brief Holds a copy of the default context for host functions

--- a/projects/rocshmem/src/ipc/ipc_context_proxy.hpp
+++ b/projects/rocshmem/src/ipc/ipc_context_proxy.hpp
@@ -35,7 +35,7 @@ namespace rocshmem {
 class IPCBackend;
 
 class IPCDefaultContextProxy {
-  using ProxyT = DeviceProxy<HIPAllocator, IPCContext>;
+  using ProxyT = DeviceProxy<IPCContext>;
 
  public:
   IPCDefaultContextProxy() = default;
@@ -44,9 +44,9 @@ class IPCDefaultContextProxy {
    * Placement new the memory which is allocated by proxy_
    */
   explicit IPCDefaultContextProxy(IPCBackend* backend, TeamInfo *tinfo,
-                                  [[maybe_unused]] const HIPAllocator& alloc = HIPAllocator(),
+                                  HIPAllocator alloc = HIPAllocator(),
                                   size_t num_elems = 1)
-  : proxy_{num_elems}, constructed_{true} {
+  : alloc_{alloc}, proxy_{num_elems, alloc_}, constructed_{true} {
     auto ctx{proxy_.get()};
     new (ctx) IPCContext(reinterpret_cast<Backend*>(backend), 0);
     ctx->tinfo = tinfo;
@@ -78,6 +78,7 @@ class IPCDefaultContextProxy {
   __host__ __device__ Context* get() { return proxy_.get(); }
 
  private:
+  HIPAllocator alloc_{};
   /*
    * @brief Memory managed by the lifetime of this object
    */

--- a/projects/rocshmem/src/memory/CMakeLists.txt
+++ b/projects/rocshmem/src/memory/CMakeLists.txt
@@ -33,8 +33,8 @@ target_sources(
     dlmalloc.cpp
 )
 
-# Add VMM POSIX allocator for ROCm 7.2+
-if(USE_HEAP_DEVICE_VMM_POSIX)
+# Add VMM POSIX allocator when the HIP version supports it (ROCm 7.2+)
+if(${ROCM_MAJOR_VERSION} GREATER 7 OR (${ROCM_MAJOR_VERSION} EQUAL 7 AND ${ROCM_MINOR_VERSION} GREATER_EQUAL 2))
   target_sources(
     ${PROJECT_NAME}
     PRIVATE
@@ -42,8 +42,8 @@ if(USE_HEAP_DEVICE_VMM_POSIX)
   )
 endif()
 
-# Add VMM Fabric allocator for ROCm 7.14+ with AMD SMI fabric support
-if(USE_HEAP_DEVICE_VMM_FABRIC AND HAVE_AMDSMI_GPU_FABRIC_INFO)
+# Add VMM Fabric allocator when AMD SMI fabric support is available (ROCm 7.14+)
+if(HAVE_AMDSMI_GPU_FABRIC_INFO)
   target_sources(
     ${PROJECT_NAME}
     PRIVATE

--- a/projects/rocshmem/src/memory/default_allocator.hpp
+++ b/projects/rocshmem/src/memory/default_allocator.hpp
@@ -26,7 +26,6 @@
 #define LIBRARY_SRC_MEMORY_DEFAULT_ALLOCATOR_HPP_
 
 #include <algorithm>
-#include <cstring>
 #include <string>
 
 #include <hip/hip_runtime_api.h>
@@ -40,38 +39,17 @@ namespace rocshmem {
 
   static void set_default_allocator()
   {
-    int hip_dev_id{};
-    hipError_t err = hipGetDevice(&hip_dev_id);
-    if (err != hipSuccess) {
-      LOG_ERROR_ABORT("Could not get current device. Aborting");
-    }
-
-    char arch_name[256];
-    hipDeviceProp_t prop;
-    err = hipGetDeviceProperties(&prop, hip_dev_id);
-    if (err != hipSuccess) {
-      LOG_ERROR_ABORT("Could not get device properties. Aborting");
-    }
-    strncpy(arch_name, prop.gcnArchName, sizeof(arch_name) - 1);
-    arch_name[sizeof(arch_name) - 1] = '\0';
-
-    // Arch-based default: finegrained for RDNA3/RDNA4 (gfx1100, gfx1201),
-    // uncached for everything else.
-    bool arch_wants_finegrained =
-        (strncmp(arch_name, "gfx1100", strlen("gfx1100")) == 0 ||
-         strncmp(arch_name, "gfx1201", strlen("gfx1201")) == 0);
-
     std::string requested = envvar::heap_allocator_type.get_value();
     // Normalise to lower-case for case-insensitive matching.
     std::transform(requested.begin(), requested.end(), requested.begin(), ::tolower);
 
     // Resolve the effective allocator type.
-    // Priority: envvar > arch default.
+    // Priority: envvar > default (finegrained).
     enum class AllocChoice { finegrained, coarsegrained, uncached, vmm_posix, vmm_fabric };
     AllocChoice choice;
 
     if (requested.empty()) {
-      choice = arch_wants_finegrained ? AllocChoice::finegrained : AllocChoice::uncached;
+      choice = AllocChoice::finegrained;
     } else if (requested == "finegrained") {
       choice = AllocChoice::finegrained;
     } else if (requested == "coarsegrained") {

--- a/projects/rocshmem/src/memory/default_allocator.hpp
+++ b/projects/rocshmem/src/memory/default_allocator.hpp
@@ -52,7 +52,8 @@ namespace rocshmem {
     if (err != hipSuccess) {
       LOG_ERROR_ABORT("Could not get device properties. Aborting");
     }
-    std::snprintf(arch_name, sizeof(arch_name), "%s", prop.gcnArchName);
+    strncpy(arch_name, prop.gcnArchName, sizeof(arch_name) - 1);
+    arch_name[sizeof(arch_name) - 1] = '\0';
 
     // Arch-based default: finegrained for RDNA3/RDNA4 (gfx1100, gfx1201),
     // uncached for everything else.
@@ -117,7 +118,7 @@ namespace rocshmem {
 #endif
         break;
       case AllocChoice::vmm_fabric:
-#if HIP_VERSION >= 70200000 && defined HAVE_AMDSMI_GPU_FABRIC_INFO
+#if defined HAVE_AMDSMI_GPU_FABRIC_INFO
         default_allocator_ = new HIPAllocatorVMMFabric();
 #else
         LOG_ERROR_ABORT("ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_fabric requires ROCm 7.14+ "

--- a/projects/rocshmem/src/memory/default_allocator.hpp
+++ b/projects/rocshmem/src/memory/default_allocator.hpp
@@ -25,53 +25,15 @@
 #ifndef LIBRARY_SRC_MEMORY_DEFAULT_ALLOCATOR_HPP_
 #define LIBRARY_SRC_MEMORY_DEFAULT_ALLOCATOR_HPP_
 
+#include <algorithm>
+#include <cstring>
+#include <string>
+
 #include <hip/hip_runtime_api.h>
 
 #include "envvar.hpp"
 #include "log.hpp"
 #include "hip_allocator.hpp"
-
-#if ((defined(USE_HEAP_DEVICE_COARSEGRAIN) ? 1 : 0) + \
-      (defined(USE_HEAP_DEVICE_FINEGRAIN) ? 1 : 0) + \
-      (defined(USE_HEAP_DEVICE_UNCACHED) ? 1 : 0) + \
-      (defined(USE_HEAP_DEVICE_VMM_POSIX) ? 1 : 0) + \
-      (defined(USE_HEAP_DEVICE_VMM_FABRIC) ? 1 : 0)) > 1
- #error "Multiple USE_HEAP_DEVICE_* allocator options enabled; exactly one allocator type must be selected"
- #endif
-
-// the using statements remain in the code until we commit
-// the change to make the default allocator a runtime decision.
-#if defined USE_HEAP_DEVICE_COARSEGRAIN
-using HIPDefaultFinegrainedAllocator = rocshmem::HIPAllocatorCoarsegrained;
-#endif
-#if defined USE_HEAP_DEVICE_FINEGRAIN
-using HIPDefaultFinegrainedAllocator = rocshmem::HIPAllocatorFinegrained;
-#endif
-
-#if defined USE_HEAP_DEVICE_UNCACHED
-#if defined HAVE_DEVICE_MALLOC_UNCACHED
-using HIPDefaultFinegrainedAllocator = rocshmem::HIPAllocatorUncached;
-#else
-#error "USE_HEAP_DEVICE_UNCACHED unsupported in this HIP version"
-#endif
-#endif
-
-#if defined USE_HEAP_DEVICE_VMM_POSIX
-#if HIP_VERSION >= 70200000
-using HIPDefaultFinegrainedAllocator = rocshmem::HIPAllocatorVMMPosixFd;
-#else
-#error "USE_HEAP_DEVICE_VMM_POSIX requires ROCm 7.2 or newer (HIP_VERSION >= 70200000)"
-#endif
-#endif
-
-#if defined USE_HEAP_DEVICE_VMM_FABRIC
-#if HIP_VERSION >= 70200000
-using HIPDefaultFinegrainedAllocator = rocshmem::HIPAllocatorVMMFabric;
-#else
-// Precise ROCm version required for Fabric allocator to be adjusted
-#error "USE_HEAP_DEVICE_VMM_FABRIC requires ROCm 7.2 or newer (HIP_VERSION >= 70200000)"
-#endif
-#endif
 
 namespace rocshmem {
   extern HIPAllocator *default_allocator_;
@@ -90,39 +52,79 @@ namespace rocshmem {
     if (err != hipSuccess) {
       LOG_ERROR_ABORT("Could not get device properties. Aborting");
     }
-    std::snprintf(arch_name, sizeof(arch_name), "%s",prop.gcnArchName);
+    std::snprintf(arch_name, sizeof(arch_name), "%s", prop.gcnArchName);
 
-#if defined USE_HEAP_DEVICE_COARSEGRAIN
-    default_allocator_ = new HIPAllocatorCoarsegrained();
-#endif
-#if defined USE_HEAP_DEVICE_FINEGRAIN
-    default_allocator_ = new HIPAllocatorFinegrained();
-#endif
-#if defined USE_HEAP_DEVICE_UNCACHED
-#if defined HAVE_DEVICE_MALLOC_UNCACHED
-    // Temporary hack that will be fixed when we add the ability
-    // to use an environment variable to set the Heap Allocatory Type.
-    // With that commit we will introduce also a generic 'default'
-    // setting that can be adjusted for different architectures.
-    // This is to avoid failures with rocSHMEM on gfx1201 if using
-    // Uncached allocator with ROCm 7.2.0
-    if (strncmp(arch_name, "gfx1201", strlen("gfx1201")) == 0) {
-      default_allocator_ = new HIPAllocatorFinegrained();
+    // Arch-based default: finegrained for RDNA3/RDNA4 (gfx1100, gfx1201),
+    // uncached for everything else.
+    bool arch_wants_finegrained =
+        (strncmp(arch_name, "gfx1100", strlen("gfx1100")) == 0 ||
+         strncmp(arch_name, "gfx1201", strlen("gfx1201")) == 0);
+
+    std::string requested = envvar::heap_allocator_type.get_value();
+    // Normalise to lower-case for case-insensitive matching.
+    std::transform(requested.begin(), requested.end(), requested.begin(), ::tolower);
+
+    // Resolve the effective allocator type.
+    // Priority: envvar > arch default.
+    enum class AllocChoice { finegrained, coarsegrained, uncached, vmm_posix, vmm_fabric };
+    AllocChoice choice;
+
+    if (requested.empty()) {
+      choice = arch_wants_finegrained ? AllocChoice::finegrained : AllocChoice::uncached;
+    } else if (requested == "finegrained") {
+      choice = AllocChoice::finegrained;
+    } else if (requested == "coarsegrained") {
+      choice = AllocChoice::coarsegrained;
+    } else if (requested == "uncached") {
+      choice = AllocChoice::uncached;
+    } else if (requested == "vmm_posix") {
+      choice = AllocChoice::vmm_posix;
+    } else if (requested == "vmm_fabric") {
+      choice = AllocChoice::vmm_fabric;
     } else {
-      default_allocator_ = new HIPAllocatorUncached();
+      LOG_ERROR_ABORT("Unknown ROCSHMEM_HEAP_ALLOCATOR_TYPE value: '%s'. "
+                      "Accepted values: uncached, finegrained, coarsegrained, vmm_posix, vmm_fabric.",
+                      requested.c_str());
+      return;
     }
+
+    // Fall back to finegrained if uncached is not available in this build.
+    if (choice == AllocChoice::uncached) {
+#if !defined HAVE_DEVICE_MALLOC_UNCACHED
+      LOG_WARN("ROCSHMEM_HEAP_ALLOCATOR_TYPE=uncached is not supported in this build "
+               "(requires ROCm 6.0+). Falling back to finegrained.");
+      choice = AllocChoice::finegrained;
 #endif
+    }
+
+    switch (choice) {
+      case AllocChoice::finegrained:
+        default_allocator_ = new HIPAllocatorFinegrained();
+        break;
+      case AllocChoice::coarsegrained:
+        default_allocator_ = new HIPAllocatorCoarsegrained();
+        break;
+      case AllocChoice::uncached:
+#if defined HAVE_DEVICE_MALLOC_UNCACHED
+        default_allocator_ = new HIPAllocatorUncached();
 #endif
-#if defined USE_HEAP_DEVICE_VMM_POSIX
+        break;
+      case AllocChoice::vmm_posix:
 #if HIP_VERSION >= 70200000
-    default_allocator_ = new HIPAllocatorVMMPosixFd();
+        default_allocator_ = new HIPAllocatorVMMPosixFd();
+#else
+        LOG_ERROR_ABORT("ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_posix requires ROCm 7.2 or newer.");
 #endif
+        break;
+      case AllocChoice::vmm_fabric:
+#if HIP_VERSION >= 70200000 && defined HAVE_AMDSMI_GPU_FABRIC_INFO
+        default_allocator_ = new HIPAllocatorVMMFabric();
+#else
+        LOG_ERROR_ABORT("ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_fabric requires ROCm 7.14+ "
+                        "with AMD SMI fabric handle support.");
 #endif
-#if defined USE_HEAP_DEVICE_VMM_FABRIC
-#if HIP_VERSION >= 70200000
-    default_allocator_ = new HIPAllocatorVMMFabric();
-#endif
-#endif
+        break;
+    }
   }
 
   [[maybe_unused]] static HIPAllocator* get_default_allocator()

--- a/projects/rocshmem/src/memory/hip_allocator_vmm_fabric.cpp
+++ b/projects/rocshmem/src/memory/hip_allocator_vmm_fabric.cpp
@@ -26,7 +26,7 @@
 #include "log.hpp"
 #include "hip_allocator_vmm_common.hpp"
 
-#if HIP_VERSION >= 70200000
+#if defined HAVE_AMDSMI_GPU_FABRIC_INFO
 
 #include <cstring>
 
@@ -323,4 +323,4 @@ hipError_t HIPAllocatorVMMFabric::GetDmabufHandle(void *dev_ptr, size_t size, in
 
 }  // namespace rocshmem
 
-#endif  // HIP_VERSION >= 70200000
+#endif  // HAVE_AMDSMI_GPU_FABRIC_INFO

--- a/projects/rocshmem/src/memory/hip_allocator_vmm_fabric.cpp
+++ b/projects/rocshmem/src/memory/hip_allocator_vmm_fabric.cpp
@@ -110,7 +110,7 @@ HIPAllocatorVMMFabric::HIPAllocatorVMMFabric()
 
   if (!fabric_supported) {
     fprintf(stderr, "ROCSHMEM_ERROR: Fabric handle type is not supported on device %d. "
-            "The USE_HEAP_DEVICE_VMM_FABRIC allocator requires a GPU with fabric handle support. "
+            "The vmm_fabric allocator requires a GPU with fabric handle support. "
             "Please use a different memory allocator.\n",
             device_id);
     abort();

--- a/projects/rocshmem/src/memory/hip_allocator_vmm_posix.cpp
+++ b/projects/rocshmem/src/memory/hip_allocator_vmm_posix.cpp
@@ -136,7 +136,7 @@ HIPAllocatorVMMPosixFd::HIPAllocatorVMMPosixFd() : HIPAllocator(VMMAlloc, VMMFre
 
   if (!vmm_supported) {
     LOG_ERROR_ABORT("Virtual Memory Management (VMM) is not supported on device %d. "
-                    "The USE_HEAP_DEVICE_VMM_POSIX allocator requires a GPU with VMM support. "
+                    "The vmm_posix allocator requires a GPU with VMM support. "
                     "Please use a different memory allocator.", device_id);
   }
 

--- a/projects/rocshmem/src/memory/hip_allocator_vmm_posix.cpp
+++ b/projects/rocshmem/src/memory/hip_allocator_vmm_posix.cpp
@@ -35,6 +35,24 @@
 #include <sys/prctl.h>
 #include <sys/utsname.h>
 
+// Syscall numbers for pidfd_open (Linux 5.3+) and pidfd_getfd (Linux 5.6+).
+// Older kernel headers may not define these; provide the x86-64 values as a
+// fallback so the code compiles — the runtime kernel check will gate their use.
+#ifndef __NR_pidfd_open
+#  if defined(__x86_64__)
+#    define __NR_pidfd_open 434
+#  elif defined(__aarch64__)
+#    define __NR_pidfd_open 434
+#  endif
+#endif
+#ifndef __NR_pidfd_getfd
+#  if defined(__x86_64__)
+#    define __NR_pidfd_getfd 438
+#  elif defined(__aarch64__)
+#    define __NR_pidfd_getfd 438
+#  endif
+#endif
+
 namespace rocshmem {
 
 // Static member definitions

--- a/projects/rocshmem/src/memory/notifier.hpp
+++ b/projects/rocshmem/src/memory/notifier.hpp
@@ -101,12 +101,12 @@ class Notifier {
 
 template <detail::atomic::rocshmem_memory_scope scope>
 class NotifierProxy {
-  using ProxyT = DeviceProxy<HIPAllocator, Notifier<scope>>;
+  using ProxyT = DeviceProxy<Notifier<scope>>;
 
  public:
-  NotifierProxy([[maybe_unused]] const HIPAllocator& alloc = HIPAllocator(),
+  NotifierProxy(const HIPAllocator& alloc = HIPAllocator(),
                 size_t num_elems = 1)
-    : proxy_{num_elems} {
+    : alloc_{alloc}, proxy_{num_elems, alloc_} {
     new (proxy_.get()) Notifier<scope>();
   }
 
@@ -125,6 +125,7 @@ class NotifierProxy {
   __host__ __device__ Notifier<scope>* get() { return proxy_.get(); }
 
  private:
+  HIPAllocator alloc_{};
   ProxyT proxy_{};
 };
 

--- a/projects/rocshmem/src/memory/notifier.hpp
+++ b/projects/rocshmem/src/memory/notifier.hpp
@@ -28,6 +28,7 @@
 #include "device_proxy.hpp"
 #include "util.hpp"
 #include "atomic.hpp"
+#include "hip_allocator.hpp"
 
 namespace rocshmem {
 
@@ -98,12 +99,14 @@ class Notifier {
   uint32_t count_ {};
 };
 
-template <typename ALLOCATOR, detail::atomic::rocshmem_memory_scope scope>
+template <detail::atomic::rocshmem_memory_scope scope>
 class NotifierProxy {
-  using ProxyT = DeviceProxy<ALLOCATOR, Notifier<scope>>;
+  using ProxyT = DeviceProxy<HIPAllocator, Notifier<scope>>;
 
  public:
-  NotifierProxy(size_t num_elems = 1) : proxy_{num_elems} {
+  NotifierProxy([[maybe_unused]] const HIPAllocator& alloc = HIPAllocator(),
+                size_t num_elems = 1)
+    : proxy_{num_elems} {
     new (proxy_.get()) Notifier<scope>();
   }
 

--- a/projects/rocshmem/src/reverse_offload/backend_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_proxy.hpp
@@ -47,15 +47,15 @@ struct BackendRegister {
 };
 
 class BackendProxy {
-  using ProxyT = DeviceProxy<HIPHostAllocator, BackendRegister>;
+  using ProxyT = DeviceProxy<BackendRegister>;
 
  public:
   /*
    * Placement new the memory which is allocated by proxy_
    */
-  BackendProxy([[maybe_unused]] const HIPHostAllocator& alloc = HIPHostAllocator(),
+  BackendProxy(const HIPHostAllocator& alloc = HIPHostAllocator(),
                size_t num_elems = 1)
-    : proxy_{num_elems} {
+    : alloc_{alloc}, proxy_{num_elems, alloc_} {
     new (proxy_.get()) BackendRegister();
   }
 
@@ -71,6 +71,7 @@ class BackendProxy {
   __host__ __device__ BackendRegister *get() { return proxy_.get(); }
 
  private:
+  HIPHostAllocator alloc_{};
   /*
    * @brief Memory managed by the lifetime of this object
    */

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -68,11 +68,11 @@ ROBackend::ROBackend(MPI_Comm comm)
 
   size_t num_buff_elems = envvar::max_num_contexts * max_wg_size_;
 
-  g_ret_buffer_ = RetBufferProxyT(num_buff_elems);
+  g_ret_buffer_ = RetBufferProxyT(num_buff_elems, ret_buffer_alloc_);
 
-  atomic_ret_buffer_ = RetBufferProxyT(num_buff_elems);
+  atomic_ret_buffer_ = RetBufferProxyT(num_buff_elems, ret_buffer_alloc_);
 
-  status_ = StatusProxyT(num_buff_elems);
+  status_ = StatusProxyT(num_buff_elems, status_alloc_);
 
   queue_ = Queue(envvar::max_num_contexts, queue_size_);
 
@@ -164,11 +164,11 @@ void ROBackend::setup_ctxs() {
 void ROBackend::setup_default_ctx_buffers() {
   size_t num_buff_elems = envvar::max_wavefront_buffers * wf_size_;
 
-  g_ret_buffer_default_ctx_ = RetBufferProxyT(num_buff_elems);
+  g_ret_buffer_default_ctx_ = RetBufferProxyT(num_buff_elems, ret_buffer_alloc_);
 
-  atomic_ret_buffer_default_ctx_ = RetBufferProxyT(num_buff_elems);
+  atomic_ret_buffer_default_ctx_ = RetBufferProxyT(num_buff_elems, ret_buffer_alloc_);
 
-  status_default_ctx_ = StatusProxyT(num_buff_elems);
+  status_default_ctx_ = StatusProxyT(num_buff_elems, status_alloc_);
 
   default_ctx_status_.get()->allocate_queue(envvar::max_wavefront_buffers);
   default_ctx_g_ret_buffer_.get()->allocate_queue(envvar::max_wavefront_buffers);

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -119,7 +119,7 @@ ROBackend::ROBackend(MPI_Comm comm)
    */
   setup_team_shared();
 
-  default_block_handle_proxy_ = DefaultBlockHandleProxyT(
+  default_block_handle_proxy_ = DefaultBlockHandleProxy(
                                 g_ret_buffer_.get(),
                                 atomic_ret_buffer_.get(), &queue_,
                                 status_.get(), default_ctx_status_.get(),
@@ -130,7 +130,7 @@ ROBackend::ROBackend(MPI_Comm comm)
 
   default_context_proxy_ = DefaultContextProxy(this, tinfo);
 
-  block_handle_proxy_ = BlockHandleProxyT(g_ret_buffer_.get(),
+  block_handle_proxy_ = BlockHandleProxy(g_ret_buffer_.get(),
                         atomic_ret_buffer_.get(), &queue_,
                         max_wg_size_, status_.get(), envvar::max_num_contexts);
   setup_ctxs();

--- a/projects/rocshmem/src/reverse_offload/backend_ro.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.hpp
@@ -56,9 +56,8 @@ class ROHostContext;
  * the host (which is an inversion of the normal behavior).
  */
 class ROBackend : public Backend {
-  using RetBufferProxyT = DeviceProxy<HIPAllocator, uint64_t>;
-  using StatusProxyT =
-          DeviceProxy<HIPDefaultFinegrainedAllocator, char>;
+  using RetBufferProxyT = DeviceProxy<uint64_t>;
+  using StatusProxyT = DeviceProxy<char>;
 
  public:
   /**
@@ -347,6 +346,7 @@ class ROBackend : public Backend {
   /**
    * @brief Return buffer for rocshmem_g API
    */
+  HIPAllocator ret_buffer_alloc_{};
   RetBufferProxyT g_ret_buffer_;
   RetBufferProxyT g_ret_buffer_default_ctx_;
 
@@ -363,6 +363,7 @@ class ROBackend : public Backend {
    * operation completes. The GPU then resets status back to zero. There is
    * a separate status variable for each work-item in a RO Context
    */
+  HIPDefaultFinegrainedAllocator status_alloc_{};
   StatusProxyT status_;
   StatusProxyT status_default_ctx_;
 };

--- a/projects/rocshmem/src/reverse_offload/backend_ro.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.hpp
@@ -268,7 +268,7 @@ class ROBackend : public Backend {
    *
    * @note Internal data ownership is managed by the proxy
    */
-  HdpProxy<HIPHostAllocator> hdp_proxy_{};
+  HdpProxy hdp_proxy_{};
 
   /**
    * @brief Handle to device profiler memory

--- a/projects/rocshmem/src/reverse_offload/backend_ro.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.hpp
@@ -363,7 +363,7 @@ class ROBackend : public Backend {
    * operation completes. The GPU then resets status back to zero. There is
    * a separate status variable for each work-item in a RO Context
    */
-  HIPDefaultFinegrainedAllocator status_alloc_{};
+  HIPAllocatorFinegrained status_alloc_{};
   StatusProxyT status_;
   StatusProxyT status_default_ctx_;
 };

--- a/projects/rocshmem/src/reverse_offload/backend_ro.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.hpp
@@ -169,12 +169,12 @@ class ROBackend : public Backend {
   /**
    * @brief Handle to block resources
    */
-  BlockHandleProxyT block_handle_proxy_;
+  BlockHandleProxy block_handle_proxy_;
 
   /**
    * @brief Handle to block resources
    */
-  DefaultBlockHandleProxyT default_block_handle_proxy_;
+  DefaultBlockHandleProxy default_block_handle_proxy_;
 
  protected:
   /**

--- a/projects/rocshmem/src/reverse_offload/block_handle.hpp
+++ b/projects/rocshmem/src/reverse_offload/block_handle.hpp
@@ -54,7 +54,7 @@ struct BlockHandle {
 };
 
 class DefaultBlockHandleProxy {
-  using ProxyT = DeviceProxy<HIPDefaultFinegrainedAllocator, BlockHandle>;
+  using ProxyT = DeviceProxy<BlockHandle>;
 
  public:
   DefaultBlockHandleProxy() = default;
@@ -64,9 +64,9 @@ class DefaultBlockHandleProxy {
                           AWF_Queue_statusT *default_ctx_status,
                           AWF_Queue_ret_buffT *default_ctx_g_ret,
                           AWF_Queue_ret_buffT *default_ctx_atomic_ret,
-                          [[maybe_unused]] const HIPDefaultFinegrainedAllocator& alloc = HIPDefaultFinegrainedAllocator(),
+                          const HIPDefaultFinegrainedAllocator& alloc = HIPDefaultFinegrainedAllocator(),
                           size_t num_elems = 1)
-    : proxy_{num_elems} {
+    : alloc_{alloc}, proxy_{num_elems, alloc_} {
 
     // TODO(bpotter): create a default queue for this queue descriptor
     auto queue_descriptor{queue->descriptor(0)};
@@ -97,19 +97,20 @@ class DefaultBlockHandleProxy {
   __host__ __device__ BlockHandle *get() { return proxy_.get(); }
 
  private:
+  HIPDefaultFinegrainedAllocator alloc_{};
   ProxyT proxy_{};
 };
 
 class BlockHandleProxy {
-  using ProxyT = DeviceProxy<HIPDefaultFinegrainedAllocator, BlockHandle>;
+  using ProxyT = DeviceProxy<BlockHandle>;
 
  public:
   BlockHandleProxy() = default;
 
   BlockHandleProxy(void *g_ret, void *atomic_ret, Queue *queue, size_t offset,
                    volatile char *status, size_t max_blocks,
-                   [[maybe_unused]] const HIPDefaultFinegrainedAllocator& alloc = HIPDefaultFinegrainedAllocator())
-    : proxy_{max_blocks} {
+                   const HIPDefaultFinegrainedAllocator& alloc = HIPDefaultFinegrainedAllocator())
+    : alloc_{alloc}, proxy_{max_blocks, alloc_} {
 
     for (size_t i{0}; i < max_blocks; i++) {
       auto queue_descriptor{queue->descriptor(i)};
@@ -140,6 +141,7 @@ class BlockHandleProxy {
   __host__ __device__ BlockHandle *get() { return proxy_.get(); }
 
  private:
+  HIPDefaultFinegrainedAllocator alloc_{};
   ProxyT proxy_{};
 };
 

--- a/projects/rocshmem/src/reverse_offload/block_handle.hpp
+++ b/projects/rocshmem/src/reverse_offload/block_handle.hpp
@@ -64,7 +64,7 @@ class DefaultBlockHandleProxy {
                           AWF_Queue_statusT *default_ctx_status,
                           AWF_Queue_ret_buffT *default_ctx_g_ret,
                           AWF_Queue_ret_buffT *default_ctx_atomic_ret,
-                          const HIPDefaultFinegrainedAllocator& alloc = HIPDefaultFinegrainedAllocator(),
+                          const HIPAllocatorFinegrained& alloc = HIPAllocatorFinegrained(),
                           size_t num_elems = 1)
     : alloc_{alloc}, proxy_{num_elems, alloc_} {
 
@@ -97,7 +97,7 @@ class DefaultBlockHandleProxy {
   __host__ __device__ BlockHandle *get() { return proxy_.get(); }
 
  private:
-  HIPDefaultFinegrainedAllocator alloc_{};
+  HIPAllocatorFinegrained alloc_{};
   ProxyT proxy_{};
 };
 
@@ -109,7 +109,7 @@ class BlockHandleProxy {
 
   BlockHandleProxy(void *g_ret, void *atomic_ret, Queue *queue, size_t offset,
                    volatile char *status, size_t max_blocks,
-                   const HIPDefaultFinegrainedAllocator& alloc = HIPDefaultFinegrainedAllocator())
+                   const HIPAllocatorFinegrained& alloc = HIPAllocatorFinegrained())
     : alloc_{alloc}, proxy_{max_blocks, alloc_} {
 
     for (size_t i{0}; i < max_blocks; i++) {
@@ -141,7 +141,7 @@ class BlockHandleProxy {
   __host__ __device__ BlockHandle *get() { return proxy_.get(); }
 
  private:
-  HIPDefaultFinegrainedAllocator alloc_{};
+  HIPAllocatorFinegrained alloc_{};
   ProxyT proxy_{};
 };
 

--- a/projects/rocshmem/src/reverse_offload/block_handle.hpp
+++ b/projects/rocshmem/src/reverse_offload/block_handle.hpp
@@ -30,6 +30,7 @@
 #include "ipc_policy.hpp"
 #include "profiler.hpp"
 #include "queue.hpp"
+#include "memory/hip_allocator.hpp"
 
 namespace rocshmem {
 
@@ -52,9 +53,8 @@ struct BlockHandle {
   AWF_Queue_ret_buffT *default_ctx_atomic_ret{nullptr};
 };
 
-template <typename ALLOCATOR>
 class DefaultBlockHandleProxy {
-  using ProxyT = DeviceProxy<ALLOCATOR, BlockHandle>;
+  using ProxyT = DeviceProxy<HIPDefaultFinegrainedAllocator, BlockHandle>;
 
  public:
   DefaultBlockHandleProxy() = default;
@@ -64,6 +64,7 @@ class DefaultBlockHandleProxy {
                           AWF_Queue_statusT *default_ctx_status,
                           AWF_Queue_ret_buffT *default_ctx_g_ret,
                           AWF_Queue_ret_buffT *default_ctx_atomic_ret,
+                          [[maybe_unused]] const HIPDefaultFinegrainedAllocator& alloc = HIPDefaultFinegrainedAllocator(),
                           size_t num_elems = 1)
     : proxy_{num_elems} {
 
@@ -99,17 +100,15 @@ class DefaultBlockHandleProxy {
   ProxyT proxy_{};
 };
 
-using DefaultBlockHandleProxyT = DefaultBlockHandleProxy<HIPDefaultFinegrainedAllocator>;
-
-template <typename ALLOCATOR>
 class BlockHandleProxy {
-  using ProxyT = DeviceProxy<ALLOCATOR, BlockHandle>;
+  using ProxyT = DeviceProxy<HIPDefaultFinegrainedAllocator, BlockHandle>;
 
  public:
   BlockHandleProxy() = default;
 
   BlockHandleProxy(void *g_ret, void *atomic_ret, Queue *queue, size_t offset,
-                   volatile char *status, size_t max_blocks)
+                   volatile char *status, size_t max_blocks,
+                   [[maybe_unused]] const HIPDefaultFinegrainedAllocator& alloc = HIPDefaultFinegrainedAllocator())
     : proxy_{max_blocks} {
 
     for (size_t i{0}; i < max_blocks; i++) {
@@ -142,11 +141,7 @@ class BlockHandleProxy {
 
  private:
   ProxyT proxy_{};
-
-  size_t num_blocks_{};
 };
-
-using BlockHandleProxyT = BlockHandleProxy<HIPDefaultFinegrainedAllocator>;
 
 }  // namespace rocshmem
 

--- a/projects/rocshmem/src/reverse_offload/context_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_proxy.hpp
@@ -35,7 +35,7 @@ namespace rocshmem {
 class ROBackend;
 
 class DefaultContextProxy {
-  using ProxyT = DeviceProxy<HIPAllocator, ROContext>;
+  using ProxyT = DeviceProxy<ROContext>;
 
  public:
   DefaultContextProxy() = default;
@@ -44,9 +44,9 @@ class DefaultContextProxy {
    * Placement new the memory which is allocated by proxy_
    */
   explicit DefaultContextProxy(ROBackend* backend, [[maybe_unused]] TeamInfo *tinfo,
-                               [[maybe_unused]] const HIPAllocator& alloc = HIPAllocator(),
+                               HIPAllocator alloc = HIPAllocator(),
                                size_t num_elems = 1)
-  : proxy_{num_elems}, constructed_{true} {
+  : alloc_{alloc}, proxy_{num_elems, alloc_}, constructed_{true} {
     auto ctx{proxy_.get()};
     new (ctx) ROContext(reinterpret_cast<Backend*>(backend), -1, true);
     rocshmem_ctx_t local{ctx, nullptr};
@@ -77,6 +77,7 @@ class DefaultContextProxy {
   __host__ __device__ Context* get() { return proxy_.get(); }
 
  private:
+  HIPAllocator alloc_{};
   /*
    * @brief Memory managed by the lifetime of this object
    */

--- a/projects/rocshmem/src/reverse_offload/profiler.hpp
+++ b/projects/rocshmem/src/reverse_offload/profiler.hpp
@@ -52,14 +52,14 @@ typedef NullStats<RO_NUM_STATS> ROStats;
 #endif
 
 class ProfilerProxy {
-  using ProxyT = DeviceProxy<HIPAllocator, ROStats>;
+  using ProxyT = DeviceProxy<ROStats>;
 
  public:
   ProfilerProxy() = default;
 
   explicit ProfilerProxy(size_t num_blocks,
-                         [[maybe_unused]] const HIPAllocator& alloc = HIPAllocator())
-    : proxy_{num_blocks}, num_elem_{num_blocks} {
+                         const HIPAllocator& alloc = HIPAllocator())
+    : alloc_{alloc}, proxy_{num_blocks, alloc_}, num_elem_{num_blocks} {
 
     auto *stat{proxy_.get()};
     assert(stat);
@@ -93,6 +93,7 @@ class ProfilerProxy {
   }
 
  private:
+  HIPAllocator alloc_{};
   ProxyT proxy_{};
 
   size_t num_elem_{0};

--- a/projects/rocshmem/src/reverse_offload/queue.hpp
+++ b/projects/rocshmem/src/reverse_offload/queue.hpp
@@ -64,7 +64,7 @@ class Queue {
 
   QueueProxy queue_proxy_{};
 
-  QueueDescProxyT queue_desc_proxy_{};
+  QueueDescProxy queue_desc_proxy_{};
 
   QueueElementProxy queue_element_cache_proxy_{};
 

--- a/projects/rocshmem/src/reverse_offload/queue.hpp
+++ b/projects/rocshmem/src/reverse_offload/queue.hpp
@@ -68,7 +68,7 @@ class Queue {
 
   QueueElementProxy queue_element_cache_proxy_{};
 
-  HdpProxy<HIPHostAllocator> hdp_proxy_{};
+  HdpProxy hdp_proxy_{};
 
   [[maybe_unused]] size_t max_queues_{};
 

--- a/projects/rocshmem/src/reverse_offload/queue_desc_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/queue_desc_proxy.hpp
@@ -51,14 +51,14 @@ typedef struct queue_desc {
 } __attribute__((__aligned__(64))) queue_desc_t;
 
 class QueueDescProxy {
-  using ProxyT = DeviceProxy<HIPDefaultFinegrainedAllocator, queue_desc_t>;
+  using ProxyT = DeviceProxy<queue_desc_t>;
 
  public:
   QueueDescProxy() = default;
 
   QueueDescProxy(size_t max_queues,
-                 [[maybe_unused]] const HIPDefaultFinegrainedAllocator& alloc = HIPDefaultFinegrainedAllocator())
-    : proxy_{max_queues}, max_queues_{max_queues} {
+                 const HIPDefaultFinegrainedAllocator& alloc = HIPDefaultFinegrainedAllocator())
+    : alloc_{alloc}, proxy_{max_queues, alloc_}, max_queues_{max_queues} {
 
     auto *queue_descs{proxy_.get()};
     for (size_t i{0}; i < max_queues_; i++) {
@@ -78,6 +78,7 @@ class QueueDescProxy {
   __host__ __device__ queue_desc_t *get() { return proxy_.get(); }
 
  private:
+  HIPDefaultFinegrainedAllocator alloc_{};
   ProxyT proxy_{};
 
   size_t max_queues_{};

--- a/projects/rocshmem/src/reverse_offload/queue_desc_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/queue_desc_proxy.hpp
@@ -57,7 +57,7 @@ class QueueDescProxy {
   QueueDescProxy() = default;
 
   QueueDescProxy(size_t max_queues,
-                 const HIPDefaultFinegrainedAllocator& alloc = HIPDefaultFinegrainedAllocator())
+                 const HIPAllocatorFinegrained& alloc = HIPAllocatorFinegrained())
     : alloc_{alloc}, proxy_{max_queues, alloc_}, max_queues_{max_queues} {
 
     auto *queue_descs{proxy_.get()};
@@ -78,7 +78,7 @@ class QueueDescProxy {
   __host__ __device__ queue_desc_t *get() { return proxy_.get(); }
 
  private:
-  HIPDefaultFinegrainedAllocator alloc_{};
+  HIPAllocatorFinegrained alloc_{};
   ProxyT proxy_{};
 
   size_t max_queues_{};

--- a/projects/rocshmem/src/reverse_offload/queue_desc_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/queue_desc_proxy.hpp
@@ -26,6 +26,7 @@
 #define LIBRARY_SRC_REVERSE_OFFLOAD_QUEUE_DESC_PROXY_HPP_
 
 #include "device_proxy.hpp"
+#include "memory/hip_allocator.hpp"
 
 namespace rocshmem {
 
@@ -49,14 +50,14 @@ typedef struct queue_desc {
   char padding2[56];
 } __attribute__((__aligned__(64))) queue_desc_t;
 
-template <typename ALLOCATOR>
 class QueueDescProxy {
-  using ProxyT = DeviceProxy<ALLOCATOR, queue_desc_t>;
+  using ProxyT = DeviceProxy<HIPDefaultFinegrainedAllocator, queue_desc_t>;
 
  public:
   QueueDescProxy() = default;
 
-  QueueDescProxy(size_t max_queues)
+  QueueDescProxy(size_t max_queues,
+                 [[maybe_unused]] const HIPDefaultFinegrainedAllocator& alloc = HIPDefaultFinegrainedAllocator())
     : proxy_{max_queues}, max_queues_{max_queues} {
 
     auto *queue_descs{proxy_.get()};
@@ -81,8 +82,6 @@ class QueueDescProxy {
 
   size_t max_queues_{};
 };
-
-using QueueDescProxyT = QueueDescProxy<HIPDefaultFinegrainedAllocator>;
 
 }  // namespace rocshmem
 

--- a/projects/rocshmem/src/reverse_offload/queue_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/queue_proxy.hpp
@@ -76,12 +76,12 @@ typedef struct queue_element {
 } __attribute__((__aligned__(64))) queue_element_t;
 
 class QueueElementProxy {
-  using ProxyT = DeviceProxy<PosixAligned64Allocator, queue_element_t>;
+  using ProxyT = DeviceProxy<queue_element_t>;
 
  public:
-  QueueElementProxy([[maybe_unused]] const PosixAligned64Allocator& alloc = PosixAligned64Allocator(),
+  QueueElementProxy(const PosixAligned64Allocator& alloc = PosixAligned64Allocator(),
                     size_t num_elems = 1)
-    : proxy_{num_elems} {
+    : alloc_{alloc}, proxy_{num_elems, alloc_} {
     new (proxy_.get()) queue_element_t();
   }
 
@@ -98,12 +98,13 @@ class QueueElementProxy {
   __host__ __device__ queue_element_t* get() { return proxy_.get(); }
 
  private:
+  PosixAligned64Allocator alloc_{};
   ProxyT proxy_{};
 };
 
 class QueueProxy {
-  using ProxyT = DeviceProxy<HIPHostAllocator, queue_element_t *>;
-  using ProxyPerBlockT = DeviceProxy<HIPHostAllocator, queue_element_t>;
+  using ProxyT = DeviceProxy<queue_element_t *>;
+  using ProxyPerBlockT = DeviceProxy<queue_element_t>;
 
  public:
   /**
@@ -115,9 +116,10 @@ class QueueProxy {
   QueueProxy() = default;
 
   QueueProxy(size_t max_queues, size_t queue_size,
-             [[maybe_unused]] const HIPHostAllocator& alloc = HIPHostAllocator())
-    : queue_proxy_{max_queues},
-      per_block_queue_proxy_{queue_size * max_queues},
+             const HIPHostAllocator& alloc = HIPHostAllocator())
+    : alloc_{alloc},
+      queue_proxy_{max_queues, alloc_},
+      per_block_queue_proxy_{queue_size * max_queues, alloc_},
       max_queues_{max_queues}, queue_size_{queue_size},
       total_queue_elements_{queue_size * max_queues} {
 
@@ -142,6 +144,7 @@ class QueueProxy {
   __host__ __device__ queue_element_t **get() { return queue_proxy_.get(); }
 
  private:
+  HIPHostAllocator alloc_{};
   ProxyT queue_proxy_{};
 
   ProxyPerBlockT per_block_queue_proxy_{};

--- a/projects/rocshmem/src/reverse_offload/ro_team_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/ro_team_proxy.hpp
@@ -33,16 +33,16 @@
 namespace rocshmem {
 
 class ROTeamProxy {
-  using ProxyT = DeviceProxy<HIPAllocator, ROTeam>;
+  using ProxyT = DeviceProxy<ROTeam>;
 
  public:
   /*
    * Placement new the memory which is allocated by proxy_
    */
   ROTeamProxy(Backend* backend, MPI_Comm comm, int pe, int npes,
-              [[maybe_unused]] const HIPAllocator& alloc = HIPAllocator(),
+              const HIPAllocator& alloc = HIPAllocator(),
               size_t num_elems = 1)
-    : proxy_{num_elems} {
+    : alloc_{alloc}, proxy_{num_elems, alloc_} {
 
     mpilib_ftable_.Comm_dup(comm, &team_world_comm_);
 
@@ -82,6 +82,7 @@ class ROTeamProxy {
    */
   MPI_Comm team_world_comm_;
 
+  HIPAllocator alloc_{};
   /*
    * @brief Memory managed by the lifetime of this object
    */

--- a/projects/rocshmem/src/reverse_offload/window_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/window_proxy.hpp
@@ -34,15 +34,15 @@ namespace rocshmem {
 
 class WindowProxy {
  private:
-  using ProxyT = DeviceProxy<HostAllocator, WindowInfoMPI *>;
+  using ProxyT = DeviceProxy<WindowInfoMPI *>;
 
  public:
   /*
    * Placement new the memory which is allocated by proxy_
    */
   WindowProxy(SymmetricHeap *heap, MPI_Comm comm, size_t num_windows,
-              [[maybe_unused]] const HostAllocator& alloc = HostAllocator())
-    : proxy_{num_windows}, num_windows_{num_windows} {
+              const HostAllocator& alloc = HostAllocator())
+    : alloc_{alloc}, proxy_{num_windows, alloc_}, num_windows_{num_windows} {
 
     WindowInfoMPI** window_info{proxy_.get()};
 
@@ -79,6 +79,7 @@ class WindowProxy {
 
   __host__ size_t get_num_MPI_windows() { return num_windows_; }
  private:
+  HostAllocator alloc_{};
   /*
    * @brief Memory managed by the lifetime of this object
    */

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -164,11 +164,14 @@ static void setFilesLimit() {
 [[maybe_unused]] __host__ void inline library_init(MPI_Comm comm) {
   assert(!backend);
 
-#if defined(USE_HEAP_DEVICE_VMM_POSIX)
-  LOG_ERROR_EXIT("VMM POSIX allocator (USE_HEAP_DEVICE_VMM_POSIX) is not compatible with MPI-based initialization.\n"
-                 "  Please use ROCSHMEM_INIT_WITH_UNIQUEID instead or disable VMM POSIX allocator.\n"
-                 "  ");
-#endif
+  {
+    const std::string alloc_type = envvar::heap_allocator_type.get_value();
+    if (alloc_type == "vmm_posix" || alloc_type == "VMM_POSIX") {
+      LOG_ERROR_EXIT("ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_posix is not compatible with MPI-based initialization.\n"
+                     "  Please use ROCSHMEM_INIT_WITH_UNIQUEID instead or choose a different allocator type.\n"
+                     "  ");
+    }
+  }
 
   int count = 0;
   CHECK_HIP(hipGetDeviceCount(&count));

--- a/projects/rocshmem/src/sync/abql_block_mutex.hpp
+++ b/projects/rocshmem/src/sync/abql_block_mutex.hpp
@@ -114,12 +114,12 @@ class ABQLBlockMutex {
 };
 
 class ABQLBlockMutexProxy {
-  using ProxyT = DeviceProxy<HIPDefaultFinegrainedAllocator, ABQLBlockMutex>;
+  using ProxyT = DeviceProxy<ABQLBlockMutex>;
 
  public:
-  explicit ABQLBlockMutexProxy([[maybe_unused]] const MemoryAllocator& alloc = *get_default_allocator(),
+  explicit ABQLBlockMutexProxy(const MemoryAllocator& alloc = *get_default_allocator(),
                                size_t num_elems = 1)
-      : proxy_{num_elems} {}
+      : alloc_{alloc}, proxy_{num_elems, alloc_} {}
 
   ABQLBlockMutexProxy(const ABQLBlockMutexProxy& other) = delete;
 
@@ -132,6 +132,7 @@ class ABQLBlockMutexProxy {
   __host__ __device__ ABQLBlockMutex* get() { return proxy_.get(); }
 
  private:
+  MemoryAllocator alloc_{};
   ProxyT proxy_{};
 };
 

--- a/projects/rocshmem/tests/unit_tests/ipc_impl_simple_fine_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_impl_simple_fine_gtest.hpp
@@ -149,7 +149,7 @@ class IPCImplSimpleFine : public ::testing::TestWithParam<std::tuple<int, int, i
     using IpcImplT = typename Config::impl_type;
     using MPI_T = RemoteHeapInfo<CommunicatorMPI>;
     using NotifierT = Notifier<detail::atomic::memory_scope_agent>;
-    using NotifierProxyT = NotifierProxy<HIPAllocator, detail::atomic::memory_scope_agent>;
+    using NotifierProxyT = NotifierProxy<detail::atomic::memory_scope_agent>;
     using FN_T1 = void (*)(IpcImplT*, bool*, int*, int*, int*, size_t, TestType, NotifierT*);
     using FN_T2 = void (*)(bool*, int*, int*, size_t, NotifierT*);
 

--- a/projects/rocshmem/tests/unit_tests/ipc_impl_tiled_fine_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_impl_tiled_fine_gtest.hpp
@@ -155,7 +155,7 @@ class IPCImplTiledFine : public ::testing::TestWithParam<std::tuple<int, int, in
     using IpcImplT = typename Config::impl_type;
     using MPI_T = RemoteHeapInfo<CommunicatorMPI>;
     using NotifierT = Notifier<detail::atomic::memory_scope_agent>;
-    using NotifierProxyT = NotifierProxy<HIPAllocator, detail::atomic::memory_scope_agent>;
+    using NotifierProxyT = NotifierProxy<detail::atomic::memory_scope_agent>;
     using FN_T1 = void (*)(IpcImplT*, bool*, int*, int*, int*, size_t, TestType, NotifierT*);
     using FN_T2 = void (*)(bool*, int*, int*, size_t, NotifierT*);
 

--- a/projects/rocshmem/tests/unit_tests/notifier_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/notifier_gtest.hpp
@@ -124,7 +124,7 @@ class NotifierBase : public ::testing::Test {
 
 class NotifierBlockTestFixture : public NotifierBase {
     using NotifierT = Notifier<detail::atomic::memory_scope_workgroup>;
-    using NotifierProxyT = NotifierProxy<HIPAllocator, detail::atomic::memory_scope_workgroup>;
+    using NotifierProxyT = NotifierProxy<detail::atomic::memory_scope_workgroup>;
 
   public:
     void
@@ -146,7 +146,7 @@ class NotifierBlockTestFixture : public NotifierBase {
 
 class NotifierAgentTestFixture : public NotifierBase {
     using NotifierT = Notifier<detail::atomic::memory_scope_agent>;
-    using NotifierProxyT = NotifierProxy<HIPAllocator, detail::atomic::memory_scope_agent>;
+    using NotifierProxyT = NotifierProxy<detail::atomic::memory_scope_agent>;
 
   public:
     void


### PR DESCRIPTION
## Motivation
Replace compile-time heap allocator options with a runtime environment variable

## Technical Details

The five USE_HEAP_DEVICE_* CMake options (USE_HEAP_DEVICE_FINEGRAIN, USE_HEAP_DEVICE_UNCACHED, USE_HEAP_DEVICE_COARSEGRAIN, USE_HEAP_DEVICE_VMM_POSIX, USE_HEAP_DEVICE_VMM_FABRIC) have been removed. The allocator is now selected at runtime via:

```
ROCSHMEM_HEAP_ALLOCATOR_TYPE=<value>
```
Accepted values: uncached, finegrained, coarsegrained, vmm_posix, vmm_fabric (case-insensitive).

Default: architecture-dependent — finegrained for gfx1100 and gfx1201, uncached for all other targets.

Key changes:
  - VMM POSIX allocator source (hip_allocator_vmm_posix.cpp) is now compiled unconditionally when ROCm ≥ 7.2 is detected, rather than behind a build flag.
  - VMM Fabric allocator source is compiled unconditionally when AMD SMI fabric handle support is detected.
  - DeviceProxy and related proxies (HdpProxy, NotifierProxy, QueueDescProxy, BlockHandleProxy) now receive the allocator type as a constructor argument instead of reading a compile-time constant.
  - Documentation updated to reflect runtime selection (docs/build.rst, docs/env_variables.rst).

## Issue Tracking

JIRA ID:  AIROCSHMEM-473
JIRA ID:  AIROCSHMEM-252

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
