### PR TITLE
feat(trace-control): Cleanup and clocks policy tightening

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/control/clock.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/clock.hpp
@@ -4,10 +4,19 @@
 #pragma once
 
 #include <chrono>
+#include <concepts>
 
 namespace rocprofsys::control
 {
 using clock_duration = std::chrono::nanoseconds;
 using clock_time_point =
     std::chrono::time_point<std::chrono::steady_clock, clock_duration>;
+
+template <typename Tp>
+concept clock_policy = requires(Tp clk, clock_time_point deadline) {
+    { clk.now() } noexcept -> std::convertible_to<clock_time_point>;
+    { clk.sleep_until(deadline) } -> std::same_as<bool>;
+    { clk.interrupt() } noexcept;
+    { clk.reset() } noexcept;
+};
 }  // namespace rocprofsys::control

--- a/projects/rocprofiler-systems/source/lib/core/control/clocks/posix.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/clocks/posix.hpp
@@ -78,14 +78,14 @@ public:
         return !is_interrupted();
     }
 
-    void interrupt()
+    void interrupt() noexcept
     {
         const auto _thread_state_guard = state::thread::scoped(state::thread::Internal);
         const std::scoped_lock notify_lk{ m_mutex };
         m_interrupted = true;
     }
 
-    void reset()
+    void reset() noexcept
     {
         const auto _thread_state_guard = state::thread::scoped(state::thread::Internal);
         const std::scoped_lock notify_lk{ m_mutex };

--- a/projects/rocprofiler-systems/source/lib/core/control/clocks/steady.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/clocks/steady.cpp
@@ -42,7 +42,7 @@ steady::interrupt() noexcept
 void
 steady::reset() noexcept
 {
-    const std::scoped_lock lk{ m_mutex };
+    const std::scoped_lock clk_lcoks{ m_mutex };
     m_interrupted = false;
 }
 }  // namespace rocprofsys::control::clocks

--- a/projects/rocprofiler-systems/source/lib/core/control/clocks/steady.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/clocks/steady.cpp
@@ -29,7 +29,7 @@ steady::sleep_until(clock_time_point deadline)
 }
 
 void
-steady::interrupt()
+steady::interrupt() noexcept
 {
     const auto _thread_state_guard = state::thread::scoped(state::thread::Internal);
     {
@@ -37,5 +37,12 @@ steady::interrupt()
         m_interrupted = true;
     }
     m_cv.notify_all();
+}
+
+void
+steady::reset() noexcept
+{
+    const std::scoped_lock lk{ m_mutex };
+    m_interrupted = false;
 }
 }  // namespace rocprofsys::control::clocks

--- a/projects/rocprofiler-systems/source/lib/core/control/clocks/steady.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/clocks/steady.hpp
@@ -23,7 +23,8 @@ public:
 
     [[nodiscard]] clock_time_point now() const noexcept;
     [[nodiscard]] bool             sleep_until(clock_time_point deadline);
-    void                           interrupt();
+    void                           interrupt() noexcept;
+    void                           reset() noexcept;
 
 private:
     std::mutex              m_mutex;

--- a/projects/rocprofiler-systems/source/lib/core/control/session.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/session.cpp
@@ -116,6 +116,11 @@ session::apply_locked_transition(const std::function<void()>& mutate,
     // a separate mutex from m_actions_mutex (released below, before
     // notify_pause()/notify_resume() run) so a subscriber callback that
     // re-enters is_active()/is_active_without() cannot deadlock.
+    //
+    // WARNING: on_pause/on_resume run with this mutex still held (see
+    // notify_pause/notify_resume below). A callback must never call
+    // set_action() itself, directly or transitively - that re-enters
+    // m_notify_mutex and deadlocks.
     const std::scoped_lock notify_lk{ m_notify_mutex };
 
     const auto scope_idx  = static_cast<std::size_t>(event_scope);

--- a/projects/rocprofiler-systems/source/lib/core/control/session.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/session.cpp
@@ -41,7 +41,7 @@ session::session() noexcept
 {
     for(auto& tracing_flag : m_scope_tracing)
     {
-        tracing_flag.store(true, std::memory_order_relaxed);
+        tracing_flag.store(true, std::memory_order_release);
     }
 }
 
@@ -62,7 +62,7 @@ session::shutdown()
         }
         for(auto& tracing_flag : m_scope_tracing)
         {
-            tracing_flag.store(true, std::memory_order_relaxed);
+            tracing_flag.store(true, std::memory_order_release);
         }
     }
 }
@@ -124,10 +124,10 @@ session::apply_locked_transition(const std::function<void()>& mutate,
     {
         const std::scoped_lock action_lk{ m_actions_mutex };
 
-        was_active = m_scope_tracing[scope_idx].load(std::memory_order_relaxed);
+        was_active = m_scope_tracing[scope_idx].load(std::memory_order_acquire);
         mutate();
         now_active = resolve_locked(event_scope);
-        m_scope_tracing[scope_idx].store(now_active, std::memory_order_relaxed);
+        m_scope_tracing[scope_idx].store(now_active, std::memory_order_release);
     }
 
     if(was_active == now_active)

--- a/projects/rocprofiler-systems/source/lib/core/control/session.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/session.cpp
@@ -26,8 +26,10 @@ using callback_list = std::vector<std::function<void()>>;
 void
 invoke_all(const callback_list& callbacks)
 {
-    for(const auto& cb : callbacks)
-        cb();
+    for(const auto& callback : callbacks)
+    {
+        callback();
+    }
 }
 
 bool
@@ -173,42 +175,65 @@ session::is_active_without(std::string_view name, scope event_scope) const noexc
     });
 }
 
+callback_list
+session::collect_pause_callbacks(scope event_scope)
+{
+    callback_list          to_fire;
+    const std::scoped_lock subs_lk{ m_subscribers_mutex };
+    to_fire.reserve(m_subscribers.size());
+    for(const auto& sub : m_subscribers)
+    {
+        if(!listens_to(sub, event_scope))
+        {
+            continue;
+        }
+        LOG_DEBUG("session: pausing subscriber '{}'", sub.name);
+        if(sub.on_pause)
+        {
+            to_fire.push_back(sub.on_pause);
+        }
+    }
+    return to_fire;
+}
+
 void
 session::notify_pause(scope event_scope)
 {
     const auto _thread_state_guard = state::thread::scoped(state::thread::Internal);
-    callback_list to_fire;
+    invoke_all(collect_pause_callbacks(event_scope));
+}
+
+callback_list
+session::collect_resume_callbacks(scope event_scope)
+{
+    callback_list          to_fire;
+    const std::scoped_lock subs_lk{ m_subscribers_mutex };
+    to_fire.reserve(m_subscribers.size());
+    for(const auto& sub : m_subscribers)
     {
-        const std::scoped_lock subs_lk{ m_subscribers_mutex };
-        to_fire.reserve(m_subscribers.size());
-        for(const auto& sub : m_subscribers)
+        if(!listens_to(sub, event_scope))
         {
-            if(!listens_to(sub, event_scope)) continue;
-            LOG_DEBUG("session: pausing subscriber '{}'", sub.name);
-            if(sub.on_pause) to_fire.push_back(sub.on_pause);
+            continue;
+        }
+        const bool all_active =
+            sub.scopes.all_of([this](scope listened) { return is_active(listened); });
+        if(!all_active)
+        {
+            continue;
+        }
+        LOG_DEBUG("session: resuming subscriber '{}'", sub.name);
+        if(sub.on_resume)
+        {
+            to_fire.push_back(sub.on_resume);
         }
     }
-    invoke_all(to_fire);
+    return to_fire;
 }
 
 void
 session::notify_resume(scope event_scope)
 {
     const auto _thread_state_guard = state::thread::scoped(state::thread::Internal);
-    callback_list to_fire;
-    {
-        const std::scoped_lock subs_lk{ m_subscribers_mutex };
-        to_fire.reserve(m_subscribers.size());
-        for(const auto& sub : m_subscribers)
-        {
-            if(!listens_to(sub, event_scope)) continue;
-            const bool all_active =
-                sub.scopes.all_of([this](scope listened) { return is_active(listened); });
-            if(!all_active) continue;
-            LOG_DEBUG("session: resuming subscriber '{}'", sub.name);
-            if(sub.on_resume) to_fire.push_back(sub.on_resume);
-        }
-    }
-    invoke_all(to_fire);
+    invoke_all(collect_resume_callbacks(event_scope));
 }
 }  // namespace rocprofsys::control

--- a/projects/rocprofiler-systems/source/lib/core/control/session.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/session.cpp
@@ -8,15 +8,35 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cassert>
 #include <cstddef>
 #include <functional>
 #include <mutex>
 #include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 namespace rocprofsys::control
 {
+namespace
+{
+using callback_list = std::vector<std::function<void()>>;
+
+void
+invoke_all(const callback_list& callbacks)
+{
+    for(const auto& cb : callbacks)
+        cb();
+}
+
+bool
+listens_to(const subscriber& sub, scope event_scope)
+{
+    return sub.scopes.contains(event_scope);
+}
+}  // namespace
+
 session::session() noexcept
 {
     for(auto& tracing_flag : m_scope_tracing)
@@ -29,6 +49,7 @@ void
 session::shutdown()
 {
     const auto _thread_state_guard = state::thread::scoped(state::thread::Internal);
+    const std::scoped_lock notify_lk{ m_notify_mutex };
     {
         const std::scoped_lock subs_lk{ m_subscribers_mutex };
         m_subscribers.clear();
@@ -147,56 +168,42 @@ session::is_active_without(std::string_view name, scope event_scope) const noexc
     });
 }
 
-namespace
-{
-bool
-listens_to(const subscriber& sub, scope event_scope)
-{
-    return sub.scopes.contains(event_scope);
-}
-}  // namespace
-
 void
 session::notify_pause(scope event_scope)
 {
     const auto _thread_state_guard = state::thread::scoped(state::thread::Internal);
-    const std::scoped_lock notify_lk{ m_subscribers_mutex };
-    for(const auto& sub : m_subscribers)
+    callback_list to_fire;
     {
-        if(!listens_to(sub, event_scope))
+        const std::scoped_lock subs_lk{ m_subscribers_mutex };
+        to_fire.reserve(m_subscribers.size());
+        for(const auto& sub : m_subscribers)
         {
-            continue;
-        }
-        LOG_DEBUG("session: pausing subscriber '{}'", sub.name);
-        if(sub.on_pause)
-        {
-            sub.on_pause();
+            if(!listens_to(sub, event_scope)) continue;
+            LOG_DEBUG("session: pausing subscriber '{}'", sub.name);
+            if(sub.on_pause) to_fire.push_back(sub.on_pause);
         }
     }
+    invoke_all(to_fire);
 }
 
 void
 session::notify_resume(scope event_scope)
 {
     const auto _thread_state_guard = state::thread::scoped(state::thread::Internal);
-    const std::scoped_lock notify_lk{ m_subscribers_mutex };
-    for(const auto& sub : m_subscribers)
+    callback_list to_fire;
     {
-        if(!listens_to(sub, event_scope))
+        const std::scoped_lock subs_lk{ m_subscribers_mutex };
+        to_fire.reserve(m_subscribers.size());
+        for(const auto& sub : m_subscribers)
         {
-            continue;
-        }
-        const bool all_active =
-            sub.scopes.all_of([this](scope listened) { return is_active(listened); });
-        if(!all_active)
-        {
-            continue;
-        }
-        LOG_DEBUG("session: resuming subscriber '{}'", sub.name);
-        if(sub.on_resume)
-        {
-            sub.on_resume();
+            if(!listens_to(sub, event_scope)) continue;
+            const bool all_active =
+                sub.scopes.all_of([this](scope listened) { return is_active(listened); });
+            if(!all_active) continue;
+            LOG_DEBUG("session: resuming subscriber '{}'", sub.name);
+            if(sub.on_resume) to_fire.push_back(sub.on_resume);
         }
     }
+    invoke_all(to_fire);
 }
 }  // namespace rocprofsys::control

--- a/projects/rocprofiler-systems/source/lib/core/control/session.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/session.hpp
@@ -128,7 +128,7 @@ public:
     {
         assert(static_cast<std::size_t>(event_scope) < SCOPE_COUNT);
         return m_scope_tracing[static_cast<std::size_t>(event_scope)].load(
-            std::memory_order_relaxed);
+            std::memory_order_acquire);
     }
 
     /// True iff every trigger of @p event_scope except @p name currently has

--- a/projects/rocprofiler-systems/source/lib/core/control/session.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/session.hpp
@@ -152,6 +152,11 @@ private:
     void               notify_pause(scope event_scope);
     void               notify_resume(scope event_scope);
 
+    [[nodiscard]] std::vector<std::function<void()>> collect_pause_callbacks(
+        scope event_scope);
+    [[nodiscard]] std::vector<std::function<void()>> collect_resume_callbacks(
+        scope event_scope);
+
     /// Applies @p mutate to the scoped action map under lock, recomputes
     /// that scope's active state, and broadcasts if it changed. Shared by
     /// register_trigger(), unregister_trigger(), and set_action().

--- a/projects/rocprofiler-systems/source/lib/core/control/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/control/tests/CMakeLists.txt
@@ -17,6 +17,22 @@ target_include_directories(
     PRIVATE ${PROJECT_SOURCE_DIR}/source/lib ${CMAKE_BINARY_DIR}/source/lib
 )
 
+add_library(control-steady-clock-tests OBJECT test_steady_clock.cpp)
+
+target_link_libraries(
+    control-steady-clock-tests
+    PRIVATE
+        rocprofiler-systems-googletest-library
+        rocprofiler-systems-core-library
+        rocprofiler-systems-common-library
+        rocprofiler-systems-logger
+)
+
+target_include_directories(
+    control-steady-clock-tests
+    PRIVATE ${PROJECT_SOURCE_DIR}/source/lib ${CMAKE_BINARY_DIR}/source/lib
+)
+
 add_library(control-session-scope-tests OBJECT test_session_scope.cpp)
 
 target_link_libraries(

--- a/projects/rocprofiler-systems/source/lib/core/control/tests/test_session_scope.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/tests/test_session_scope.cpp
@@ -3,9 +3,15 @@
 
 #include "core/control/session.hpp"
 
+#include <atomic>
+#include <chrono>
+#include <future>
 #include <gtest/gtest.h>
+#include <memory>
 #include <string>
+#include <thread>
 #include <utility>
+#include <vector>
 
 namespace
 {
@@ -174,4 +180,68 @@ TEST_F(session_scope_test, unregister_removes_only_the_matching_scope)
     }
     EXPECT_FALSE(s.is_active(scope::sampling))
         << "unregistering the global window must not remove the same-named sampling one";
+}
+
+// The failure mode is a deadlock, not a wrong value, so the publish runs on a
+// worker thread against a deadline. Everything that thread touches is
+// shared_ptr-owned and captured by the thread itself: a deadlocked worker can
+// only be detached, and must not be left holding references into this frame.
+TEST(session_callback_test, callback_may_re_enter_the_session)
+{
+    auto sess = std::make_shared<session>();
+    auto gate =
+        std::make_shared<mock_trigger>(*sess, "gate", scope::global, action::trace);
+    auto reentered = std::make_shared<std::atomic<int>>(0);
+
+    sess->subscribe({ [owner = sess.get(), reentered]() {
+                         owner->subscribe({ nullptr, nullptr, "added_from_callback" });
+                         reentered->fetch_add(1);
+                     },
+                      nullptr, "reentrant_sub" });
+
+    std::packaged_task<void()> publish{ [sess, gate]() {
+        gate->set_action(action::pause);
+    } };
+    auto        done = publish.get_future();
+    std::thread worker{ std::move(publish) };
+
+    if(done.wait_for(std::chrono::seconds{ 5 }) != std::future_status::ready)
+    {
+        worker.detach();
+        FAIL() << "subscriber callback deadlocked re-entering the session";
+    }
+
+    worker.join();
+    EXPECT_EQ(reentered->load(), 1);
+}
+
+// Finalization tears down the subsystems these callbacks touch well before it
+// joins the trigger threads that can fire them, so a callback that outlives
+// shutdown() reaches freed state.
+TEST(session_callback_test, shutdown_waits_for_an_in_flight_callback)
+{
+    auto sess = std::make_shared<session>();
+    auto gate =
+        std::make_shared<mock_trigger>(*sess, "gate", scope::global, action::trace);
+
+    std::atomic<bool> callback_entered{ false };
+    std::atomic<bool> callback_finished{ false };
+
+    sess->subscribe({ [&callback_entered, &callback_finished]() {
+                         callback_entered.store(true);
+                         std::this_thread::sleep_for(std::chrono::milliseconds{ 200 });
+                         callback_finished.store(true);
+                     },
+                      nullptr, "slow_sub" });
+
+    std::thread publisher{ [gate]() { gate->set_action(action::pause); } };
+
+    while(!callback_entered.load())
+        std::this_thread::sleep_for(std::chrono::milliseconds{ 1 });
+
+    sess->shutdown();
+    EXPECT_TRUE(callback_finished.load())
+        << "shutdown() returned while a subscriber callback was still running";
+
+    publisher.join();
 }

--- a/projects/rocprofiler-systems/source/lib/core/control/tests/test_session_scope.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/tests/test_session_scope.cpp
@@ -11,13 +11,15 @@
 #include <string>
 #include <thread>
 #include <utility>
-#include <vector>
 
 namespace
 {
 using rocprofsys::control::action;
 using rocprofsys::control::scope;
 using rocprofsys::control::session;
+
+constexpr auto CALLBACK_REENTRY_TIMEOUT = std::chrono::seconds{ 5 };
+constexpr auto SLOW_CALLBACK_SLEEP      = std::chrono::milliseconds{ 200 };
 
 // Minimal trigger stub: registers under a fixed name and scope, and exposes
 // set_action() so a test can drive a later action change.
@@ -188,24 +190,30 @@ TEST_F(session_scope_test, unregister_removes_only_the_matching_scope)
 // only be detached, and must not be left holding references into this frame.
 TEST(session_callback_test, callback_may_re_enter_the_session)
 {
-    auto sess = std::make_shared<session>();
-    auto gate =
+    const auto sess = std::make_shared<session>();
+    const auto gate =
         std::make_shared<mock_trigger>(*sess, "gate", scope::global, action::trace);
-    auto reentered = std::make_shared<std::atomic<int>>(0);
+    const auto reentered = std::make_shared<std::atomic<int>>(0);
 
-    sess->subscribe({ [owner = sess.get(), reentered]() {
-                         owner->subscribe({ nullptr, nullptr, "added_from_callback" });
-                         reentered->fetch_add(1);
-                     },
-                      nullptr, "reentrant_sub" });
+    sess->subscribe({ .on_pause =
+                          [owner = sess.get(), reentered]() {
+                              owner->subscribe({ .on_pause  = nullptr,
+                                                 .on_resume = nullptr,
+                                                 .name      = "added_from_callback",
+                                                 .scopes    = { scope::global } });
+                              reentered->fetch_add(1);
+                          },
+                      .on_resume = nullptr,
+                      .name      = "reentrant_sub",
+                      .scopes    = { scope::global } });
 
     std::packaged_task<void()> publish{ [sess, gate]() {
         gate->set_action(action::pause);
     } };
-    auto        done = publish.get_future();
+    const auto  done = publish.get_future();
     std::thread worker{ std::move(publish) };
 
-    if(done.wait_for(std::chrono::seconds{ 5 }) != std::future_status::ready)
+    if(done.wait_for(CALLBACK_REENTRY_TIMEOUT) != std::future_status::ready)
     {
         worker.detach();
         FAIL() << "subscriber callback deadlocked re-entering the session";
@@ -220,24 +228,29 @@ TEST(session_callback_test, callback_may_re_enter_the_session)
 // shutdown() reaches freed state.
 TEST(session_callback_test, shutdown_waits_for_an_in_flight_callback)
 {
-    auto sess = std::make_shared<session>();
-    auto gate =
+    const auto sess = std::make_shared<session>();
+    const auto gate =
         std::make_shared<mock_trigger>(*sess, "gate", scope::global, action::trace);
 
     std::atomic<bool> callback_entered{ false };
     std::atomic<bool> callback_finished{ false };
 
-    sess->subscribe({ [&callback_entered, &callback_finished]() {
-                         callback_entered.store(true);
-                         std::this_thread::sleep_for(std::chrono::milliseconds{ 200 });
-                         callback_finished.store(true);
-                     },
-                      nullptr, "slow_sub" });
+    sess->subscribe({ .on_pause =
+                          [&callback_entered, &callback_finished]() {
+                              callback_entered.store(true);
+                              std::this_thread::sleep_for(SLOW_CALLBACK_SLEEP);
+                              callback_finished.store(true);
+                          },
+                      .on_resume = nullptr,
+                      .name      = "slow_sub",
+                      .scopes    = { scope::global } });
 
     std::thread publisher{ [gate]() { gate->set_action(action::pause); } };
 
     while(!callback_entered.load())
+    {
         std::this_thread::sleep_for(std::chrono::milliseconds{ 1 });
+    }
 
     sess->shutdown();
     EXPECT_TRUE(callback_finished.load())

--- a/projects/rocprofiler-systems/source/lib/core/control/tests/test_steady_clock.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/tests/test_steady_clock.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "core/control/clocks/steady.hpp"
+#include "core/control/session.hpp"
+
+#include "core/control/triggers/time_window.hpp"
+#include <memory>
+
+#include <chrono>
+#include <gtest/gtest.h>
+#include <thread>
+
+namespace
+{
+using rocprofsys::control::clock_duration;
+using rocprofsys::control::session;
+using rocprofsys::control::clocks::steady;
+using time_window_t = rocprofsys::control::triggers::time_window<steady>;
+
+bool
+wait_until_active(session& sess, bool expected)
+{
+    constexpr auto timeout  = std::chrono::seconds{ 2 };
+    const auto     deadline = std::chrono::steady_clock::now() + timeout;
+    while(sess.is_active() != expected)
+    {
+        if(std::chrono::steady_clock::now() > deadline) return false;
+        std::this_thread::sleep_for(std::chrono::milliseconds{ 1 });
+    }
+    return true;
+}
+}  // namespace
+
+TEST(steady_clock_test, reset_allows_reuse_after_interrupt)
+{
+    steady clk{};
+    clk.interrupt();
+    clk.reset();
+
+    EXPECT_TRUE(clk.sleep_until(clk.now() - clock_duration{ 1 }));
+}
+
+// A clock outlives the windows driven by it, so stopping one window must not
+// make the next one bail out of its first sleep. The two windows share a clock
+// sequentially - the first is joined and destroyed before the second exists -
+// which is the arrangement production uses across a stop/restart.
+TEST(steady_clock_test, window_started_on_a_stopped_clock_still_runs)
+{
+    auto   s_ptr = std::make_shared<session>();
+    auto&  s     = *s_ptr;
+    steady clk{};
+
+    constexpr auto long_delay = clock_duration{ 10'000'000'000LL };  // 10 s
+    {
+        time_window_t first{ s_ptr, clk, time_window_t::config{ long_delay, {} } };
+        first.start();
+        first.stop();
+    }
+
+    // No duration: the active state is terminal, so the poll cannot miss it.
+    constexpr auto delay = clock_duration{ 20'000'000 };  // 20 ms
+    time_window_t  second{ s_ptr, clk, time_window_t::config{ delay, {} } };
+
+    ASSERT_FALSE(s.is_active()) << "a pending delay should leave the session paused";
+
+    second.start();
+    EXPECT_TRUE(wait_until_active(s, true))
+        << "session should become active once the second window's delay elapses";
+}

--- a/projects/rocprofiler-systems/source/lib/core/control/tests/test_steady_clock.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/tests/test_steady_clock.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include "core/control/clock.hpp"
 #include "core/control/clocks/steady.hpp"
 #include "core/control/session.hpp"
 
@@ -25,7 +26,10 @@ wait_until_active(session& sess, bool expected)
     const auto     deadline = std::chrono::steady_clock::now() + timeout;
     while(sess.is_active() != expected)
     {
-        if(std::chrono::steady_clock::now() > deadline) return false;
+        if(std::chrono::steady_clock::now() > deadline)
+        {
+            return false;
+        }
         std::this_thread::sleep_for(std::chrono::milliseconds{ 1 });
     }
     return true;
@@ -47,24 +51,24 @@ TEST(steady_clock_test, reset_allows_reuse_after_interrupt)
 // which is the arrangement production uses across a stop/restart.
 TEST(steady_clock_test, window_started_on_a_stopped_clock_still_runs)
 {
-    auto   s_ptr = std::make_shared<session>();
-    auto&  s     = *s_ptr;
-    steady clk{};
+    const auto sess_ptr = std::make_shared<session>();
+    auto&      sess     = *sess_ptr;
+    steady     clk{};
 
     constexpr auto long_delay = clock_duration{ 10'000'000'000LL };  // 10 s
     {
-        time_window_t first{ s_ptr, clk, time_window_t::config{ long_delay, {} } };
+        time_window_t first{ sess_ptr, clk, { long_delay, {} } };
         first.start();
         first.stop();
     }
 
     // No duration: the active state is terminal, so the poll cannot miss it.
     constexpr auto delay = clock_duration{ 20'000'000 };  // 20 ms
-    time_window_t  second{ s_ptr, clk, time_window_t::config{ delay, {} } };
+    time_window_t  second{ sess_ptr, clk, { delay, {} } };
 
-    ASSERT_FALSE(s.is_active()) << "a pending delay should leave the session paused";
+    ASSERT_FALSE(sess.is_active()) << "a pending delay should leave the session paused";
 
     second.start();
-    EXPECT_TRUE(wait_until_active(s, true))
+    EXPECT_TRUE(wait_until_active(sess, true))
         << "session should become active once the second window's delay elapses";
 }

--- a/projects/rocprofiler-systems/source/lib/core/control/triggers/time_window.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/triggers/time_window.hpp
@@ -77,6 +77,9 @@ public:
             return;
         }
         m_clock.interrupt();
+        // join() throws if called from the thread being joined; stop() is
+        // noexcept, so that would terminate. Treat self-join as already-stopped.
+        if(m_thread.get_id() == std::this_thread::get_id()) return;
         m_thread.join();
     }
 

--- a/projects/rocprofiler-systems/source/lib/core/control/triggers/time_window.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/triggers/time_window.hpp
@@ -23,7 +23,7 @@ struct time_window_specs
     clock_duration duration{};
 };
 
-template <typename Clock>
+template <clock_policy Clock>
 class time_window
 {
 public:
@@ -64,6 +64,7 @@ public:
         {
             return;
         }
+        m_clock.reset();
         m_thread = std::thread{ [this]() { worker(); } };
     }
 

--- a/projects/rocprofiler-systems/source/lib/core/control/triggers/time_window.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/control/triggers/time_window.hpp
@@ -79,7 +79,10 @@ public:
         m_clock.interrupt();
         // join() throws if called from the thread being joined; stop() is
         // noexcept, so that would terminate. Treat self-join as already-stopped.
-        if(m_thread.get_id() == std::this_thread::get_id()) return;
+        if(m_thread.get_id() == std::this_thread::get_id())
+        {
+            return;
+        }
         m_thread.join();
     }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/tests/test_roctx_client.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/tests/test_roctx_client.cpp
@@ -277,6 +277,24 @@ TEST_F(roctx_client_control_test, pause_resume_no_filter)
     EXPECT_TRUE(client->get_trigger().should_write_markers());
 }
 
+TEST_F(roctx_client_control_test, no_filter_range_started_while_paused_suppresses_markers)
+{
+    auto client = make_client("");
+
+    client->get_trigger().on_pause();
+    EXPECT_FALSE(client->get_trigger().should_write_markers());
+
+    // Opening a range must not lift the pause when no region filter is set.
+    client->get_trigger().on_range_start(1, "Region1");
+    EXPECT_FALSE(client->get_trigger().should_write_markers());
+
+    client->get_trigger().on_resume();
+    EXPECT_TRUE(client->get_trigger().should_write_markers());
+
+    client->get_trigger().on_range_stop(1);
+    EXPECT_TRUE(client->get_trigger().should_write_markers());
+}
+
 // ---------------------------------------------------------------------------
 // Selective Region Tracing - Example 1: Normal Case
 // ---------------------------------------------------------------------------

--- a/projects/rocprofiler-systems/source/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(UNIT_TEST_OBJECTS
     $<TARGET_OBJECTS:demangler-tests>
     $<TARGET_OBJECTS:sdk-tracing-config-tests>
     $<TARGET_OBJECTS:control-posix-clock-tests>
+    $<TARGET_OBJECTS:control-steady-clock-tests>
     $<TARGET_OBJECTS:control-session-scope-tests>
     $<TARGET_OBJECTS:trace-period-config-tests>
     $<TARGET_OBJECTS:track-registry-tests>


### PR DESCRIPTION
## Motivation

- Final PR for the trace control related feature and refactoring. 
- Mostly the cleanup and tightening the policies and conditions for clock interrupts

## Technical Details

- `clocks::steady` gains `reset()`, and `time_window::start()` calls it. The interrupted flag is sticky and a clock outlives the windows driven by it, so a window created after an earlier one was stopped would bail out of its first `sleep_until`.
- Subscriber callbacks are no longer invoked under the subscriber lock. `notify_pause`, `notify_resume` and `force_initial_pause` copy the callbacks to fire under `m_subscribers_mutex` and invoke them after releasing it, so the lock is not held across work that can be slow and a callback is free to call `subscribe()`.

## Issue Tracking

JIRA ID: AIPROFSYST-91

## Test Plan

- Whole-project build; the full `rocprof-sys-unit-tests` binary.
- Four new GTest cases, each written against the unfixed state first and confirmed to fail there: clock reuse after a stop, callback re-entrancy, `shutdown()` draining an in-flight callback, and roctx marker suppression for a range opened while paused.
- Existing pause/resume coverage: `test_time_window.py`, `test_roctx.py`, `test_minimal.py`, `test_selective_regions.py`, `test_transpose.py`.

## Test Result

- Build clean, no new warnings. `rocprof-sys-unit-tests`: **1198/1198**.
- `test_time_window.py` + `test_roctx.py` + `test_minimal.py`: passed.
- `test_selective_regions.py` + `test_transpose.py`: passed.
- The `shutdown()` change adds a lock acquisition during finalization, so the pytest suites were re-run afterwards specifically to confirm no deadlock there. They pass.
- Each new test verified to fail without its fix: the clock test's session never activates and the poll deadline expires; the re-entrancy test deadlocks (guarded by a deadline so it reports a failure rather than hanging); `shutdown()` returns mid-callback; the roctx test fails under the previous `!filter || (in_region && !paused)` formula.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
