### PR TITLE
docs(rocprofiler-compute): document ROCm Optiq analysis workflow

### DIFF
--- a/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
@@ -580,6 +580,8 @@ Examples:
    :width: 800
 
 
+.. _analysis-output-format:
+
 Analysis output format
 ======================
 

--- a/projects/rocprofiler-compute/docs/how-to/analyze/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/mode.rst
@@ -34,6 +34,7 @@ options.
 * :doc:`cli`
 * :doc:`standalone-gui` (experimental feature)
 * :doc:`tui` (experimental feature)
+* :doc:`optiq` (separate graphical application)
 
 .. note::
 

--- a/projects/rocprofiler-compute/docs/how-to/analyze/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/mode.rst
@@ -34,7 +34,7 @@ options.
 * :doc:`cli`
 * :doc:`standalone-gui` (experimental feature)
 * :doc:`tui` (experimental feature)
-* :doc:`optiq` (separate graphical application)
+* :doc:`optiq` (graphical application)
 
 .. note::
 

--- a/projects/rocprofiler-compute/docs/how-to/analyze/optiq.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/optiq.rst
@@ -1,0 +1,40 @@
+.. meta::
+   :description: How to analyze ROCm Compute Profiler data with ROCm Optiq (Beta)
+   :keywords: ROCm Compute Profiler, ROCm Optiq, ROCm, profiler, tool, Instinct,
+              accelerator, AMD, analysis, analysis database, SQLite
+
+.. _analyze-with-rocm-optiq:
+
+******************************
+Analyze with ROCm Optiq (Beta)
+******************************
+
+ROCm Optiq (Beta) is a separate graphical application for interactively visualizing ROCm
+Compute Profiler analysis data. It opens the analysis database emitted by
+ROCm Compute Profiler analysis.
+
+Before using this workflow, review the `ROCm Optiq system requirements`_ and confirm that
+your ROCm Optiq version supports the analysis database schema emitted by your installed
+ROCm Compute Profiler version. Version and platform compatibility requirements can change
+independently.
+
+1. Generate a ROCm Compute Profiler analysis database from an existing
+   workload directory:
+
+   .. code-block:: shell-session
+
+      $ rocprof-compute analyze --output-name <analysis_name> --output-format db -p <workload_directory>
+
+   ``<analysis_name>`` can contain only alphanumeric characters, underscores, and hyphens.
+   The command creates ``<analysis_name>.db`` in the current working directory.
+
+2. After confirming a compatible ROCm Compute Profiler and ROCm Optiq version combination,
+   start ROCm Optiq and open ``<analysis_name>.db`` using **File > Open** or by dragging the
+   file into the application window. See the `ROCm Optiq analysis guide`_ for the current
+   opening workflow and interface details.
+
+See :doc:`CLI analysis <cli>` for complete output-format behavior and
+:ref:`analysis database schema <analysis-database>` details.
+
+.. _ROCm Optiq analysis guide: https://rocm.docs.amd.com/projects/roc-optiq/en/latest/how-to/view-analysis.html
+.. _ROCm Optiq system requirements: https://rocm.docs.amd.com/projects/roc-optiq/en/latest/install/optiq-install.html#system-requirements

--- a/projects/rocprofiler-compute/docs/how-to/analyze/optiq.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/optiq.rst
@@ -1,40 +1,32 @@
 .. meta::
-   :description: How to analyze ROCm Compute Profiler data with ROCm Optiq (Beta)
+   :description: How to analyze ROCm Compute Profiler data with ROCm Optiq
    :keywords: ROCm Compute Profiler, ROCm Optiq, ROCm, profiler, tool, Instinct,
               accelerator, AMD, analysis, analysis database, SQLite
 
 .. _analyze-with-rocm-optiq:
 
-******************************
-Analyze with ROCm Optiq (Beta)
-******************************
+***********************
+Analyze with ROCm Optiq
+***********************
 
-ROCm Optiq (Beta) is a separate graphical application for interactively visualizing ROCm
-Compute Profiler analysis data. It opens the analysis database emitted by
-ROCm Compute Profiler analysis.
+.. note::
+
+   The ROCm Compute Profiler integration with ROCm Optiq is in beta.
+
+ROCm Optiq is a graphical application for interactively visualizing ROCm Compute
+Profiler analysis data.
+
+The two tools integrate through the analysis database. Generate one with the ``db``
+:ref:`analysis output format <analysis-output-format>`, then open it in ROCm Optiq.
+See :ref:`analysis database schema <analysis-database>` for what it contains.
 
 Before using this workflow, review the `ROCm Optiq system requirements`_ and confirm that
 your ROCm Optiq version supports the analysis database schema emitted by your installed
 ROCm Compute Profiler version. Version and platform compatibility requirements can change
 independently.
 
-1. Generate a ROCm Compute Profiler analysis database from an existing
-   workload directory:
-
-   .. code-block:: shell-session
-
-      $ rocprof-compute analyze --output-name <analysis_name> --output-format db -p <workload_directory>
-
-   ``<analysis_name>`` can contain only alphanumeric characters, underscores, and hyphens.
-   The command creates ``<analysis_name>.db`` in the current working directory.
-
-2. After confirming a compatible ROCm Compute Profiler and ROCm Optiq version combination,
-   start ROCm Optiq and open ``<analysis_name>.db`` using **File > Open** or by dragging the
-   file into the application window. See the `ROCm Optiq analysis guide`_ for the current
-   opening workflow and interface details.
-
-See :doc:`CLI analysis <cli>` for complete output-format behavior and
-:ref:`analysis database schema <analysis-database>` details.
+See the `ROCm Optiq analysis guide`_ for the current opening workflow and interface
+details.
 
 .. _ROCm Optiq analysis guide: https://rocm.docs.amd.com/projects/roc-optiq/en/latest/how-to/view-analysis.html
 .. _ROCm Optiq system requirements: https://rocm.docs.amd.com/projects/roc-optiq/en/latest/install/optiq-install.html#system-requirements

--- a/projects/rocprofiler-compute/docs/index.rst
+++ b/projects/rocprofiler-compute/docs/index.rst
@@ -1,6 +1,7 @@
 .. meta::
    :description: ROCm Compute Profiler documentation and reference
-   :keywords: Omniperf, ROCm, profiler, tool, Instinct, GPUs, accelerator, AMD
+   :keywords: Omniperf, ROCm, profiler, tool, Instinct, GPUs, accelerator, AMD,
+              ROCm Optiq, graphical analysis
 
 *******************************************
 ROCm Compute Profiler (rocprofiler-compute)
@@ -51,6 +52,9 @@ in practice.
 
       * :doc:`how-to/profile/mode`
       * :doc:`how-to/analyze/mode`
+
+        * :doc:`ROCm Optiq (Beta) <how-to/analyze/optiq>` for graphical analysis of
+          ROCm Compute Profiler analysis data
 
         * :doc:`how-to/analyze/cli`
 

--- a/projects/rocprofiler-compute/docs/index.rst
+++ b/projects/rocprofiler-compute/docs/index.rst
@@ -53,14 +53,13 @@ in practice.
       * :doc:`how-to/profile/mode`
       * :doc:`how-to/analyze/mode`
 
-        * :doc:`ROCm Optiq (Beta) <how-to/analyze/optiq>` for graphical analysis of
-          ROCm Compute Profiler analysis data
-
         * :doc:`how-to/analyze/cli`
 
         * :doc:`how-to/analyze/standalone-gui`
 
         * :doc:`how-to/analyze/tui`
+
+        * :doc:`how-to/analyze/optiq`
 
    .. grid-item-card:: Conceptual
 

--- a/projects/rocprofiler-compute/docs/install/quickstart.rst
+++ b/projects/rocprofiler-compute/docs/install/quickstart.rst
@@ -230,17 +230,17 @@ analysis options are available to accommodate different workflows.
     - Links to docs
   * - :doc:`CLI (Command Line Interface) </how-to/analyze/cli>`
     - Fast, scriptable insights; great for automation and quick checks.
-    - `CLI analysis <https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst>`_
+    - :doc:`CLI analysis </how-to/analyze/cli>`
   * - :doc:`GUI (Standalone Graphical Interface) </how-to/analyze/standalone-gui>`
     - Interactive exploration, visual drill-down, and detailed charts.
-    - `Standalone GUI analysis <https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-compute/docs/how-to/analyze/standalone-gui.rst>`_
+    - :doc:`Standalone GUI analysis </how-to/analyze/standalone-gui>`
   * - :doc:`TUI (Textual User Interface) </how-to/analyze/tui>`
     - Lightweight, keyboard-driven experience for terminals.
-    - `Text-based User Interface (TUI) analysis <https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-compute/docs/how-to/analyze/tui.rst>`_
-  * - :doc:`ROCm Optiq (Beta) </how-to/analyze/optiq>`
+    - :doc:`Text-based User Interface (TUI) analysis </how-to/analyze/tui>`
+  * - :doc:`ROCm Optiq </how-to/analyze/optiq>`
     - Interactive graphical exploration of generated ROCm Compute Profiler
-      analysis databases in a separate application.
-    - `ROCm Optiq (Beta) <https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-compute/docs/how-to/analyze/optiq.rst>`_
+      analysis databases.
+    - :doc:`ROCm Optiq analysis </how-to/analyze/optiq>`
 
 **Analysis Command:**
 

--- a/projects/rocprofiler-compute/docs/install/quickstart.rst
+++ b/projects/rocprofiler-compute/docs/install/quickstart.rst
@@ -1,6 +1,7 @@
 .. meta::
    :description:  Quickstart guide for ROCm Compute Profiler (rocprofiler-compute)
-   :keywords: Omniperf, ROCm, profiler, tool, Instinct, AMD, Profile, Analyze, CLI, performance counters, quickstart, guide
+   :keywords: Omniperf, ROCm, ROCm Optiq, profiler, tool, Instinct, AMD,
+              Profile, Analyze, CLI, performance counters, quickstart, guide
 
 **********
 Quickstart
@@ -216,13 +217,15 @@ Use multiple blocks (5 and 7) for detailed metric collection
 Analysis
 =========
 
-Analysis phase refers to the process of examining profiling data to understand GPU kernel performance, identify bottlenecks, and determine optimization opportunities. ROCm Compute Profiler provides multiple analysis modes to accommodate different workflows.
+Analysis phase refers to the process of examining profiling data to understand GPU kernel
+performance, identify bottlenecks, and determine optimization opportunities. Multiple
+analysis options are available to accommodate different workflows.
 
 .. list-table::
   :header-rows: 1
   :widths: 25 25 25
 
-  * - Mode
+  * - Analysis option
     - When to Use
     - Links to docs
   * - :doc:`CLI (Command Line Interface) </how-to/analyze/cli>`
@@ -234,6 +237,10 @@ Analysis phase refers to the process of examining profiling data to understand G
   * - :doc:`TUI (Textual User Interface) </how-to/analyze/tui>`
     - Lightweight, keyboard-driven experience for terminals.
     - `Text-based User Interface (TUI) analysis <https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-compute/docs/how-to/analyze/tui.rst>`_
+  * - :doc:`ROCm Optiq (Beta) </how-to/analyze/optiq>`
+    - Interactive graphical exploration of generated ROCm Compute Profiler
+      analysis databases in a separate application.
+    - `ROCm Optiq (Beta) <https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-compute/docs/how-to/analyze/optiq.rst>`_
 
 **Analysis Command:**
 

--- a/projects/rocprofiler-compute/docs/sphinx/_toc.yml.in
+++ b/projects/rocprofiler-compute/docs/sphinx/_toc.yml.in
@@ -30,6 +30,7 @@ subtrees:
       - file: how-to/analyze/cli.rst
       - file: how-to/analyze/standalone-gui.rst
       - file: how-to/analyze/tui.rst
+      - file: how-to/analyze/optiq.rst
 
   - caption: Conceptual
     entries:

--- a/projects/rocprofiler-compute/docs/what-is-rocprof-compute.rst
+++ b/projects/rocprofiler-compute/docs/what-is-rocprof-compute.rst
@@ -1,7 +1,6 @@
 .. meta::
    :description: What is ROCm Compute Profiler?
-   :keywords: Omniperf, ROCm, profiler, tool, Instinct, accelerator, AMD,
-              ROCm Optiq, analysis database
+   :keywords: Omniperf, ROCm, profiler, tool, Instinct, accelerator, AMD
 
 ******************************
 What is ROCm Compute Profiler?
@@ -55,21 +54,13 @@ Additionally, ROCm Compute Profiler provides in-depth memory chart analysis, roo
 analysis, baseline comparisons, and more, ensuring a thorough understanding of
 system performance.
 
-ROCm Compute Profiler supports analysis through its
-:doc:`command-line interface </how-to/analyze/cli>`, built-in
-:doc:`standalone GUI </how-to/analyze/standalone-gui>` (experimental), and
-:doc:`text-based user interface (TUI) </how-to/analyze/tui>` (experimental).
-:doc:`ROCm Optiq (Beta) </how-to/analyze/optiq>` is a separate graphical
-application that visualizes ROCm Compute Profiler analysis database output.
+ROCm Compute Profiler supports several analysis options. See
+:doc:`analyze mode </how-to/analyze/mode>` for the full list and guidance on
+choosing between them.
 
 The following list describes ROCm Compute Profiler's features at a high level.
 
 * :doc:`Support for AMD Instinct MI300, MI200, and MI100 accelerators <reference/compatible-accelerators>`
-
-* :doc:`Standalone GUI analyzer </how-to/analyze/standalone-gui>` (experimental)
-
-* :doc:`ROCm Optiq (Beta) </how-to/analyze/optiq>`, a separate graphical application for
-  visualizing ROCm Compute Profiler analysis database output
 
 * :ref:`Filtering <filtering>` to reduce profiling time
 

--- a/projects/rocprofiler-compute/docs/what-is-rocprof-compute.rst
+++ b/projects/rocprofiler-compute/docs/what-is-rocprof-compute.rst
@@ -1,6 +1,7 @@
 .. meta::
    :description: What is ROCm Compute Profiler?
-   :keywords: Omniperf, ROCm, profiler, tool, Instinct, accelerator, AMD
+   :keywords: Omniperf, ROCm, profiler, tool, Instinct, accelerator, AMD,
+              ROCm Optiq, analysis database
 
 ******************************
 What is ROCm Compute Profiler?
@@ -54,12 +55,21 @@ Additionally, ROCm Compute Profiler provides in-depth memory chart analysis, roo
 analysis, baseline comparisons, and more, ensuring a thorough understanding of
 system performance.
 
-ROCm Compute Profiler supports analysis through both the :doc:`command line </how-to/analyze/cli>`.
+ROCm Compute Profiler supports analysis through its
+:doc:`command-line interface </how-to/analyze/cli>`, built-in
+:doc:`standalone GUI </how-to/analyze/standalone-gui>` (experimental), and
+:doc:`text-based user interface (TUI) </how-to/analyze/tui>` (experimental).
+:doc:`ROCm Optiq (Beta) </how-to/analyze/optiq>` is a separate graphical
+application that visualizes ROCm Compute Profiler analysis database output.
+
 The following list describes ROCm Compute Profiler's features at a high level.
 
 * :doc:`Support for AMD Instinct MI300, MI200, and MI100 accelerators <reference/compatible-accelerators>`
 
 * :doc:`Standalone GUI analyzer </how-to/analyze/standalone-gui>` (experimental)
+
+* :doc:`ROCm Optiq (Beta) </how-to/analyze/optiq>`, a separate graphical application for
+  visualizing ROCm Compute Profiler analysis database output
 
 * :ref:`Filtering <filtering>` to reduce profiling time
 


### PR DESCRIPTION
> [!NOTE]
> Reverted. This was merged to `rocprofiler-compute-develop` before the documentation team reviewed it. The merge was reverted in 2dc3139132, and the same changes are up for review in #9457.

## Motivation

Add docs for analyzing ROCm Compute Profiler data in ROCm Optiq.

## Technical Details

- Add dedicated ROCm Optiq analysis workflow doc
- Add Optiq to generated documentation navigation
- Reference current Optiq requirements and analysis guide

## Issue Tracking

JIRA ID: AIPROFCOMP-737

## Test Plan

- [x] Build Sphinx HTML documentation

## Test Result

- [x] Sphinx HTML documentation built

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
