### PR TITLE
RCCL/net-ib: enforce the NIC fusion device-count limit in makeVDevice and force-merge

### DIFF
--- a/projects/rccl/src/graph/topo.cc
+++ b/projects/rccl/src/graph/topo.cc
@@ -1314,6 +1314,11 @@ ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* net
            "NET/IB : Invalid NCCL_NET_FORCE_MERGE specified %s. Couldn't parse substring %s. Please provide a "
            "semicolon-delimited list of comma-delimited NIC groups.",
            ncStr, semi);
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+      // RCCL: the loop advances semi at the bottom, so continuing without a step of its own
+      // re-parses the same unparsable substring forever. ":" and "," both parse to zero NICs.
+      semi = strtok_r(NULL, ";", &semi_token);
+#endif
       continue;
     }
 

--- a/projects/rccl/src/graph/topo.cc
+++ b/projects/rccl/src/graph/topo.cc
@@ -1307,8 +1307,15 @@ ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* net
   char* semi = strtok_r(ncStr, ";", &semi_token);
   while (semi) {
     TRACE(NCCL_NET, "Fusing %s", semi);
-    struct netIf userIfs[NCCL_NET_MAX_DEVS_PER_NIC];
-    int nUserIfs = parseStringList(semi, userIfs, NCCL_NET_MAX_DEVS_PER_NIC);
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+    // RCCL: one entry past the limit. parseStringList() truncates silently, so without it an
+    // over-limit group is indistinguishable from a legal full-size one.
+    const int maxUserIfs = NCCL_NET_MAX_DEVS_PER_NIC + 1;
+#else
+    const int maxUserIfs = NCCL_NET_MAX_DEVS_PER_NIC;
+#endif
+    struct netIf userIfs[maxUserIfs];
+    int nUserIfs = parseStringList(semi, userIfs, maxUserIfs);
     if (nUserIfs == 0) {
       INFO(NCCL_NET,
            "NET/IB : Invalid NCCL_NET_FORCE_MERGE specified %s. Couldn't parse substring %s. Please provide a "
@@ -1321,6 +1328,17 @@ ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* net
 #endif
       continue;
     }
+
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+    // RCCL: reject a group that requests more NICs than one vNIC can hold, see maxUserIfs above.
+    // The count is a lower bound, since parsing stopped one entry past the limit.
+    if (nUserIfs > NCCL_NET_MAX_DEVS_PER_NIC) {
+      WARN("TOPO/NET : Specified fused NIC %s which requests at least %d devices. Max %d", semi, nUserIfs,
+           NCCL_NET_MAX_DEVS_PER_NIC);
+      ret = ncclInvalidUsage;
+      goto fail;
+    }
+#endif
 
     ncclNetVDeviceProps_t vProps = {0};
     for (int d = 0; d < nPhysDevs; d++) {
@@ -1365,7 +1383,6 @@ ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* net
     }
 
     semi = strtok_r(NULL, ";", &semi_token);
-    ;
   }
 
 exit:

--- a/projects/rccl/src/graph/topo.cc
+++ b/projects/rccl/src/graph/topo.cc
@@ -1320,6 +1320,16 @@ ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* net
     ncclNetVDeviceProps_t vProps = {0};
     for (int d = 0; d < nPhysDevs; d++) {
       if (matchIfList(propsList[d].name, propsList[d].port, userIfs, nUserIfs, 1)) {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+        // RCCL: a pattern given without ":port" matches every port of a multi-port NIC, so the
+        // number of matches is not bounded by nUserIfs and can overrun devs[].
+        if (vProps.ndevs == NCCL_NET_MAX_DEVS_PER_NIC) {
+          WARN("TOPO/NET : Specified fused NIC %s which matches too many devices. Max %d", semi,
+               NCCL_NET_MAX_DEVS_PER_NIC);
+          ret = ncclInvalidUsage;
+          goto fail;
+        }
+#endif
         vProps.devs[vProps.ndevs++] = d;
       }
     }

--- a/projects/rccl/src/graph/topo.h
+++ b/projects/rccl/src/graph/topo.h
@@ -236,6 +236,8 @@ struct ncclTopoNetInfo {
 };
 
 ncclResult_t ncclTopoProcessNet(ncclXml* xml, const char* dumpXmlFile, struct ncclTopoNetInfo* net);
+ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* netInfo, int* placedDevs,
+                                ncclNetProperties_t* propsList, struct ncclXmlNode** physNetNodes, int nPhysDevs);
 ncclResult_t ncclTopoGetFusionEnv(int* mergeLevel, const char** forceMerge);
 
 #define NCCL_TOPO_XML_MAX_NODES 8192

--- a/projects/rccl/src/transport/net_ib/init.cc
+++ b/projects/rccl/src/transport/net_ib/init.cc
@@ -256,7 +256,7 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   // RCCL: bound the count before props->devs[] is indexed. A negative ndevs clears every
   // per-device check because the build loop never runs, and an over-limit count reads past the end.
-  if (props->ndevs < 0 || props->ndevs > NCCL_IB_MAX_DEVS_PER_NIC) {
+  if (props->ndevs < 1 || props->ndevs > NCCL_IB_MAX_DEVS_PER_NIC) {
     WARN("NET/IB : Can't make virtual NIC with %d devices, max %d", props->ndevs, NCCL_IB_MAX_DEVS_PER_NIC);
     return ncclInvalidUsage;
   }

--- a/projects/rccl/src/transport/net_ib/init.cc
+++ b/projects/rccl/src/transport/net_ib/init.cc
@@ -254,8 +254,9 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   }
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  // RCCL: bound the count before props->devs[] is indexed, an over-limit count reads past the end.
-  if (props->ndevs > NCCL_IB_MAX_DEVS_PER_NIC) {
+  // RCCL: bound the count before props->devs[] is indexed. A negative ndevs clears every
+  // per-device check because the build loop never runs, and an over-limit count reads past the end.
+  if (props->ndevs < 0 || props->ndevs > NCCL_IB_MAX_DEVS_PER_NIC) {
     WARN("NET/IB : Can't make virtual NIC with %d devices, max %d", props->ndevs, NCCL_IB_MAX_DEVS_PER_NIC);
     return ncclInvalidUsage;
   }

--- a/projects/rccl/src/transport/net_ib/init.cc
+++ b/projects/rccl/src/transport/net_ib/init.cc
@@ -253,6 +253,14 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
     return ncclInvalidUsage;
   }
 
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  // RCCL: bound the count before props->devs[] is indexed, an over-limit count reads past the end.
+  if (props->ndevs > NCCL_IB_MAX_DEVS_PER_NIC) {
+    WARN("NET/IB : Can't make virtual NIC with %d devices, max %d", props->ndevs, NCCL_IB_MAX_DEVS_PER_NIC);
+    return ncclInvalidUsage;
+  }
+#endif
+
   if (ncclNMergedIbDevs == MAX_IB_VDEVS) {
     WARN("NET/IB : Cannot allocate any more virtual devices (%d)", MAX_IB_VDEVS);
     return ncclInvalidUsage;

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -207,44 +207,51 @@ ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
     return ncclInvalidUsage;
   }
 
+  if (props->ndevs < 1 || props->ndevs > NCCL_IB_MAX_DEVS_PER_NIC) {
+    WARN("NET/IB : Can't make virtual NIC with %d devices, max %d", props->ndevs, NCCL_IB_MAX_DEVS_PER_NIC);
+    return ncclInvalidUsage;
+  }
+
   if (IbCastNMergedDevs == MAX_IB_VDEVS) {
     WARN("NET/IB : Cannot allocate any more virtual devices (%d)", MAX_IB_VDEVS);
     return ncclInvalidUsage;
   }
 
   // Always count up number of merged devices
-  ncclIbMergedDev* mDev = IbCastMergedDevs + IbCastNMergedDevs;
-  mDev->vProps.ndevs = 0;
-  mDev->speed = 0;
+  ncclIbMergedDev tmp;
+  memset(&tmp, 0, sizeof(tmp));
+  bool used[MAX_IB_DEVS] = {0};
 
   for (int i = 0; i < props->ndevs; i++) {
-    ncclIbDev* dev = IbCastDevs + props->devs[i];
-    if (mDev->vProps.ndevs == NCCL_IB_MAX_DEVS_PER_NIC) return ncclInvalidUsage;
-    mDev->vProps.devs[mDev->vProps.ndevs++] = props->devs[i];
-    mDev->speed += dev->speed;
-    // Each successive time, copy the name '+' new name
-    if (mDev->vProps.ndevs > 1) {
-      snprintf(mDev->devName + strlen(mDev->devName), sizeof(mDev->devName) - strlen(mDev->devName), "+%s",
-               dev->devName);
-    // First time, copy the plain name
-    } else {
-      strncpy(mDev->devName, dev->devName, MAXNAMESIZE);
-    }
-  }
-
-  // Check link layers
-  ncclIbDev* dev0 = IbCastDevs + props->devs[0];
-  for (int i = 1; i < props->ndevs; i++) {
-    if (props->devs[i] >= IbCastNDevs) {
+    if (props->devs[i] < 0 || props->devs[i] >= IbCastNDevs) {
       WARN("NET/IB : Cannot use physical device %d, max %d", props->devs[i], IbCastNDevs);
       return ncclInvalidUsage;
     }
-    ncclIbDev* dev = IbCastDevs + props->devs[i];
+    if (used[props->devs[i]]) continue;
+    const ncclIbDev* dev = IbCastDevs + props->devs[i];
+    tmp.vProps.devs[tmp.vProps.ndevs++] = props->devs[i];
+    tmp.speed += dev->speed;
+    // Each successive time, copy the name '+' new name
+    if (tmp.vProps.ndevs > 1) {
+      size_t off = strlen(tmp.devName);
+      snprintf(tmp.devName + off, sizeof(tmp.devName) - off, "+%s", dev->devName);
+    // First time, copy the plain name
+    } else {
+      strncpy(tmp.devName, dev->devName, MAXNAMESIZE - 1);
+      tmp.devName[MAXNAMESIZE - 1] = '\0';
+    }
+    used[props->devs[i]] = true;
+  }
+
+  // Check link layers
+  const ncclIbDev* dev0 = IbCastDevs + tmp.vProps.devs[0];
+  for (int i = 1; i < tmp.vProps.ndevs; i++) {
+    const ncclIbDev* dev = IbCastDevs + tmp.vProps.devs[i];
     if (dev->link != dev0->link) {
       WARN("NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
            "only one link type using NCCL_IB_HCA",
-           props->devs[0], dev0->devName, dev0->portNum, NCCL_IB_LLSTR(dev0->link), props->devs[i], dev->devName,
-           dev->portNum, NCCL_IB_LLSTR(dev->link));
+           tmp.vProps.devs[0], dev0->devName, dev0->portNum, NCCL_IB_LLSTR(dev0->link), tmp.vProps.devs[i],
+           dev->devName, dev->portNum, NCCL_IB_LLSTR(dev->link));
       return ncclInvalidUsage;
     }
   }
@@ -253,8 +260,8 @@ ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   // format -> 0000:00
   char root0[8];
   IbCastGetPciRootFromPath(dev0->pciPath, root0, sizeof(root0));
-  for (int i = 1; i < props->ndevs; i++) {
-    ncclIbDev* dev = IbCastDevs + props->devs[i];
+  for (int i = 1; i < tmp.vProps.ndevs; i++) {
+    const ncclIbDev* dev = IbCastDevs + tmp.vProps.devs[i];
     int numaI = IbCastGetNumaNodeFromPath(dev->pciPath);
     if (numa0 >= 0 && numaI >= 0 && numaI != numa0) {
       WARN("NET/IB : Merging NICs across NUMA nodes (%s numa=%d, %s numa=%d). "
@@ -276,17 +283,18 @@ ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
 
   // CTS Offload and CTS Inline are not yet compatible with NIC Fusion
   // (NCCL_IB_MERGE_NICS). Disable them when a multi-NIC vNIC is created.
-  if (props->ndevs > 1) {
+  if (tmp.vProps.ndevs > 1) {
     if (IbCastOffloadEnabled) {
       INFO(NCCL_INIT | NCCL_NET,
-           "NET/IB : NIC Fusion (ndevs=%d) - disabling CTS Offload (not yet supported with merge)", props->ndevs);
+           "NET/IB : NIC Fusion (ndevs=%d) - disabling CTS Offload (not yet supported with merge)", tmp.vProps.ndevs);
       IbCastOffloadEnabled = false;
     }
   }
 
+  IbCastMergedDevs[IbCastNMergedDevs] = tmp;
   *d = IbCastNMergedDevs++;
-  INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d, mDev->devName, mDev->speed,
-       mDev->vProps.ndevs);
+  INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d, tmp.devName, tmp.speed,
+       tmp.vProps.ndevs);
   return ncclSuccess;
 }
 

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -207,6 +207,7 @@ ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
     return ncclInvalidUsage;
   }
 
+  // Mirrors the guard in ncclIbMakeVDeviceInternal(): bound the count before props->devs[] is indexed.
   if (props->ndevs < 1 || props->ndevs > NCCL_IB_MAX_DEVS_PER_NIC) {
     WARN("NET/IB : Can't make virtual NIC with %d devices, max %d", props->ndevs, NCCL_IB_MAX_DEVS_PER_NIC);
     return ncclInvalidUsage;
@@ -229,6 +230,7 @@ ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
     }
     if (used[props->devs[i]]) continue;
     const ncclIbDev* dev = IbCastDevs + props->devs[i];
+    if (tmp.vProps.ndevs == NCCL_IB_MAX_DEVS_PER_NIC) return ncclInvalidUsage;
     tmp.vProps.devs[tmp.vProps.ndevs++] = props->devs[i];
     tmp.speed += dev->speed;
     // Each successive time, copy the name '+' new name

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -359,6 +359,7 @@ if(BUILD_TESTS)
       EnqueueTests.cpp
       IpcsocketTests.cpp
       TopoEnvPolicyTests.cpp
+      TopoNicFusionTests.cpp
       NetSocketTests.cpp
       PluginCompatV11_test.cpp
       ProxyTests.cpp

--- a/projects/rccl/test/TopoNicFusionTests.cpp
+++ b/projects/rccl/test/TopoNicFusionTests.cpp
@@ -8,20 +8,25 @@
 // (src/graph/topo.cc), driven with a hand-built propsList (no real NICs, GPUs,
 // or net plugin).
 //
-// The case pinned here is the NCCL_NET_FORCE_MERGE pattern that matches more
-// physical devices than ncclNetVDeviceProps_t::devs[] can hold. parseStringList()
-// caps the number of parsed patterns at NCCL_NET_MAX_DEVS_PER_NIC, but a single
-// pattern written without ":port" matches every port of a multi-port NIC
-// (matchPort() accepts any port against -1), so the number of matched devices is
-// not bounded by the number of patterns. Without a bound inside the match loop,
-// vProps.devs[vProps.ndevs++] runs off the end of the stack array.
+// Two ways a NCCL_NET_FORCE_MERGE group can ask for more devices than
+// ncclNetVDeviceProps_t::devs[] holds:
 //
-// IMPORTANT -- on an ordinary build this test cannot tell the fix from its absence,
-// and must not be deleted as vacuous on that basis: the pre-existing
+//   1. More devices matched than patterns given. parseStringList() caps the number of
+//      parsed patterns at NCCL_NET_MAX_DEVS_PER_NIC, but a pattern written without
+//      ":port" matches every port of a multi-port NIC (matchPort() accepts any port
+//      against -1), so the number of matched devices is not bounded by the number of
+//      patterns and vProps.devs[vProps.ndevs++] runs off the end of the stack array.
+//   2. More patterns given than the limit. parseStringList() stops at maxList and drops
+//      the rest silently, so the request looks like a legal full-size one and gets
+//      merged short of what was asked for instead of rejected.
+//
+// Case 2 fails on any build without the fix. Case 1 does not: the pre-existing
 // "vProps.ndevs != nUserIfs" check fails right after the overflowing writes, so the
-// result is ncclInvalidUsage either way. It earns its keep under
-// BUILD_ADDRESS_SANITIZER=ON, where the pre-fix code aborts on the store into devs[]
-// and the fixed code returns cleanly.
+// result is ncclInvalidUsage either way, and only BUILD_ADDRESS_SANITIZER=ON tells the
+// two apart (pre-fix aborts on the store into devs[], fixed returns cleanly). No CI job
+// currently builds this binary with sanitizers, so case 1 pays off when the suite is run
+// from an ASAN build (install.sh --address-sanitizer) -- do not drop it as vacuous on the
+// basis of an ordinary build.
 //
 // Debug-only target (rccl-UnitTestsFixturesDebug): ncclTopoForceMerge has hidden
 // visibility in Release, so it is only linkable from the Debug fixtures binary.
@@ -31,6 +36,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 
 #include "graph/topo.h"  // struct ncclTopoNetInfo, ncclTopoForceMerge()
 #include "graph/xml.h"   // struct ncclXml, xmlAlloc(), xmlAddNode()
@@ -42,54 +48,98 @@ namespace RcclUnitTesting
 namespace
 {
 
-// One multi-port NIC exposed as one propsList entry per port, all sharing the
-// same device name. One more port than devs[] can hold, so a port-less pattern
-// overruns the array by exactly one entry.
-constexpr int kPhysDevs = NCCL_NET_MAX_DEVS_PER_NIC + 1;
+// One device past what a vNIC can hold, which is all these tests need.
+constexpr int kFakeDevs = NCCL_NET_MAX_DEVS_PER_NIC + 1;
 
-// Any name works: it is both the fake device name and the pattern matched against it.
-const char* kFakeNicName = "testnic0";
+// The arrays ncclTopoForceMerge() works on, for a made-up set of NICs. Frees the XML tree
+// in the destructor, so a failing ASSERT_* in the middle of a test does not leak it.
+struct FakeNetTopo
+{
+    struct ncclXml*     xml = nullptr;
+    char                names[kFakeDevs][16];
+    ncclNetProperties_t propsList[kFakeDevs];
+    struct ncclXmlNode* physNetNodes[kFakeDevs];
+    int                 placedDevs[kFakeDevs];
+
+    ~FakeNetTopo() { free(xml); }
+
+    // onePerPort: all entries are ports of a single NIC, sharing one device name.
+    // Otherwise each entry is a separate single-port NIC with a name of its own.
+    void Build(bool onePerPort)
+    {
+        ASSERT_EQ(xmlAlloc(&xml, kFakeDevs + 1), ncclSuccess);
+        struct ncclXmlNode* root = nullptr;
+        ASSERT_EQ(xmlAddNode(xml, nullptr, "system", &root), ncclSuccess);
+
+        memset(propsList, 0, sizeof(propsList));
+        memset(placedDevs, 0, sizeof(placedDevs));
+        for(int dev = 0; dev < kFakeDevs; dev++)
+        {
+            snprintf(names[dev], sizeof(names[dev]), "testnic%d", onePerPort ? 0 : dev);
+            propsList[dev].name = names[dev];
+            propsList[dev].port = onePerPort ? dev + 1 : 1;  // IB port numbers are 1-based
+            ASSERT_EQ(xmlAddNode(xml, root, "net", &physNetNodes[dev]), ncclSuccess);
+        }
+    }
+};
+
+int makeVDeviceCalls = 0;
+
+// Both cases must be rejected on the device count before any vNIC is built, so this only
+// exists to make a regression fail loudly instead of calling through a null pointer.
+ncclResult_t CountingMakeVDevice(int* d, ncclNetVDeviceProps_t* /*props*/)
+{
+    makeVDeviceCalls++;
+    *d = 0;
+    return ncclSuccess;
+}
 
 }  // namespace
 
-// A single NCCL_NET_FORCE_MERGE pattern matching more devices than
-// ncclNetVDeviceProps_t::devs[] holds must be rejected inside the match loop,
-// before the write, rather than overflowing the stack array.
+// Case 1: a single pattern that matches more devices than ncclNetVDeviceProps_t::devs[] holds
+// must be rejected inside the match loop, before the write, rather than overflowing the array.
 TEST(TopoNicFusionTests, ForceMerge_PatternMatchingMoreDevsThanArray_Rejected)
 {
-    // The vNIC-construction arguments (xml, physNetNodes, netInfo.makeVDevice)
-    // are not exercised: the call must bail on the device count before it
-    // reaches ncclTopoMakeVnic(). They are still built as real, valid objects so
-    // the test itself does not rely on that to stay defined.
-    struct ncclXml* xml = nullptr;
-    ASSERT_EQ(xmlAlloc(&xml, kPhysDevs + 1), ncclSuccess);
-    struct ncclXmlNode* root = nullptr;
-    ASSERT_EQ(xmlAddNode(xml, nullptr, "system", &root), ncclSuccess);
+    FakeNetTopo topo;
+    ASSERT_NO_FATAL_FAILURE(topo.Build(/*onePerPort=*/true));
 
-    char                names[kPhysDevs][16];
-    ncclNetProperties_t propsList[kPhysDevs];
-    struct ncclXmlNode* physNetNodes[kPhysDevs];
-    int                 placedDevs[kPhysDevs];
+    struct ncclTopoNetInfo netInfo;
+    memset(&netInfo, 0, sizeof(netInfo));
+    netInfo.maxDevsPerNic = NCCL_NET_MAX_DEVS_PER_NIC;
+    netInfo.makeVDevice   = CountingMakeVDevice;
+    netInfo.forceMerge    = topo.names[0];  // no ":port", so it matches every port
 
-    memset(propsList, 0, sizeof(propsList));
-    memset(placedDevs, 0, sizeof(placedDevs));
-    for(int dev = 0; dev < kPhysDevs; dev++)
+    makeVDeviceCalls = 0;
+    EXPECT_EQ(ncclTopoForceMerge(topo.xml, &netInfo, topo.placedDevs, topo.propsList, topo.physNetNodes, kFakeDevs),
+              ncclInvalidUsage);
+    EXPECT_EQ(makeVDeviceCalls, 0) << "An over-limit group must be rejected before the merge";
+}
+
+// Case 2: a group listing more NICs than a vNIC can hold must be rejected, not truncated to
+// the limit and merged.
+TEST(TopoNicFusionTests, ForceMerge_GroupListingMoreDevsThanLimit_Rejected)
+{
+    FakeNetTopo topo;
+    ASSERT_NO_FATAL_FAILURE(topo.Build(/*onePerPort=*/false));
+
+    std::string forceMerge;
+    for(int dev = 0; dev < kFakeDevs; dev++)
     {
-        snprintf(names[dev], sizeof(names[dev]), "%s", kFakeNicName);
-        propsList[dev].name = names[dev];
-        propsList[dev].port = dev + 1;  // IB port numbers are 1-based
-        ASSERT_EQ(xmlAddNode(xml, root, "net", &physNetNodes[dev]), ncclSuccess);
+        if(dev > 0) forceMerge += ',';
+        forceMerge += topo.names[dev];
     }
 
     struct ncclTopoNetInfo netInfo;
     memset(&netInfo, 0, sizeof(netInfo));
     netInfo.maxDevsPerNic = NCCL_NET_MAX_DEVS_PER_NIC;
-    netInfo.forceMerge    = kFakeNicName;
+    netInfo.makeVDevice   = CountingMakeVDevice;
+    netInfo.forceMerge    = forceMerge.c_str();
 
-    EXPECT_EQ(ncclTopoForceMerge(xml, &netInfo, placedDevs, propsList, physNetNodes, kPhysDevs),
+    makeVDeviceCalls = 0;
+    EXPECT_EQ(ncclTopoForceMerge(topo.xml, &netInfo, topo.placedDevs, topo.propsList, topo.physNetNodes, kFakeDevs),
               ncclInvalidUsage);
-
-    free(xml);
+    EXPECT_EQ(makeVDeviceCalls, 0) << "A group of " << kFakeDevs << " NICs must not be merged as "
+                                  << NCCL_NET_MAX_DEVS_PER_NIC;
 }
 
 }  // namespace RcclUnitTesting

--- a/projects/rccl/test/TopoNicFusionTests.cpp
+++ b/projects/rccl/test/TopoNicFusionTests.cpp
@@ -1,0 +1,101 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Unit tests for NIC fusion input validation in ncclTopoForceMerge()
+// (src/graph/topo.cc), driven with a hand-built propsList (no real NICs, GPUs,
+// or net plugin).
+//
+// The case pinned here is the NCCL_NET_FORCE_MERGE pattern that matches more
+// physical devices than ncclNetVDeviceProps_t::devs[] can hold. parseStringList()
+// caps the number of parsed patterns at NCCL_NET_MAX_DEVS_PER_NIC, but a single
+// pattern written without ":port" matches every port of a multi-port NIC
+// (matchPort() accepts any port against -1), so the number of matched devices is
+// not bounded by the number of patterns. Without a bound inside the match loop,
+// vProps.devs[vProps.ndevs++] runs off the end of the stack array.
+//
+// IMPORTANT -- this test has no behavioural red/green signature on a normal
+// build, and must not be deleted as vacuous on that basis. Before the fix, the
+// overflowing writes are immediately followed by the pre-existing
+// "vProps.ndevs != nUserIfs" check, which fails, so the return code is
+// ncclInvalidUsage with or without the fix. The value of the test is that it
+// makes the overflow reproducible under a sanitizer build
+// (BUILD_ADDRESS_SANITIZER=ON, see the top-level CMakeLists.txt): there the
+// pre-fix code aborts with a stack-buffer-overflow at the store into devs[],
+// while the fixed code returns cleanly. Treat an ASan run of this test as the
+// real assertion; the EXPECT below only pins the contract on ordinary builds.
+//
+// The test target is rccl-UnitTestsFixturesDebug (Debug only): ncclTopoForceMerge
+// lives inside librccl.so with default-hidden visibility in Release builds, so it
+// is only linkable from the Debug fixtures binary -- exactly like
+// TopoEnvPolicyTests, ParamTests::ncclLoadParam, ArgCheckTests' argcheck helpers,
+// etc.
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "graph/topo.h"  // struct ncclTopoNetInfo, ncclTopoForceMerge()
+#include "graph/xml.h"   // struct ncclXml, xmlAlloc(), xmlAddNode()
+#include "nccl_net.h"    // ncclNetProperties_t, NCCL_NET_MAX_DEVS_PER_NIC
+
+namespace RcclUnitTesting
+{
+
+namespace
+{
+
+// One multi-port NIC exposed as one propsList entry per port, all sharing the
+// same device name. One more port than devs[] can hold, so a port-less pattern
+// overruns the array by exactly one entry.
+constexpr int kPhysDevs = NCCL_NET_MAX_DEVS_PER_NIC + 1;
+
+const char* kNicName = "mlx5_0";
+
+}  // namespace
+
+// A single NCCL_NET_FORCE_MERGE pattern matching more devices than
+// ncclNetVDeviceProps_t::devs[] holds must be rejected inside the match loop,
+// before the write, rather than overflowing the stack array.
+TEST(TopoNicFusionTests, ForceMerge_PatternMatchingMoreDevsThanArray_Rejected)
+{
+    // The vNIC-construction arguments (xml, physNetNodes, netInfo.makeVDevice)
+    // are not exercised: the call must bail on the device count before it
+    // reaches ncclTopoMakeVnic(). They are still built as real, valid objects so
+    // the test itself does not rely on that to stay defined.
+    struct ncclXml* xml = nullptr;
+    ASSERT_EQ(xmlAlloc(&xml, kPhysDevs + 1), ncclSuccess);
+    struct ncclXmlNode* root = nullptr;
+    ASSERT_EQ(xmlAddNode(xml, nullptr, "system", &root), ncclSuccess);
+
+    char                names[kPhysDevs][16];
+    ncclNetProperties_t propsList[kPhysDevs];
+    struct ncclXmlNode* physNetNodes[kPhysDevs];
+    int                 placedDevs[kPhysDevs];
+
+    memset(propsList, 0, sizeof(propsList));
+    memset(placedDevs, 0, sizeof(placedDevs));
+    for(int dev = 0; dev < kPhysDevs; dev++)
+    {
+        snprintf(names[dev], sizeof(names[dev]), "%s", kNicName);
+        propsList[dev].name = names[dev];
+        propsList[dev].port = dev + 1;  // IB port numbers are 1-based
+        ASSERT_EQ(xmlAddNode(xml, root, "net", &physNetNodes[dev]), ncclSuccess);
+    }
+
+    struct ncclTopoNetInfo netInfo;
+    memset(&netInfo, 0, sizeof(netInfo));
+    netInfo.maxDevsPerNic = NCCL_NET_MAX_DEVS_PER_NIC;
+    netInfo.forceMerge    = kNicName;
+
+    EXPECT_EQ(ncclTopoForceMerge(xml, &netInfo, placedDevs, propsList, physNetNodes, kPhysDevs),
+              ncclInvalidUsage);
+
+    free(xml);
+}
+
+}  // namespace RcclUnitTesting

--- a/projects/rccl/test/TopoNicFusionTests.cpp
+++ b/projects/rccl/test/TopoNicFusionTests.cpp
@@ -16,22 +16,15 @@
 // not bounded by the number of patterns. Without a bound inside the match loop,
 // vProps.devs[vProps.ndevs++] runs off the end of the stack array.
 //
-// IMPORTANT -- this test has no behavioural red/green signature on a normal
-// build, and must not be deleted as vacuous on that basis. Before the fix, the
-// overflowing writes are immediately followed by the pre-existing
-// "vProps.ndevs != nUserIfs" check, which fails, so the return code is
-// ncclInvalidUsage with or without the fix. The value of the test is that it
-// makes the overflow reproducible under a sanitizer build
-// (BUILD_ADDRESS_SANITIZER=ON, see the top-level CMakeLists.txt): there the
-// pre-fix code aborts with a stack-buffer-overflow at the store into devs[],
-// while the fixed code returns cleanly. Treat an ASan run of this test as the
-// real assertion; the EXPECT below only pins the contract on ordinary builds.
+// IMPORTANT -- on an ordinary build this test cannot tell the fix from its absence,
+// and must not be deleted as vacuous on that basis: the pre-existing
+// "vProps.ndevs != nUserIfs" check fails right after the overflowing writes, so the
+// result is ncclInvalidUsage either way. It earns its keep under
+// BUILD_ADDRESS_SANITIZER=ON, where the pre-fix code aborts on the store into devs[]
+// and the fixed code returns cleanly.
 //
-// The test target is rccl-UnitTestsFixturesDebug (Debug only): ncclTopoForceMerge
-// lives inside librccl.so with default-hidden visibility in Release builds, so it
-// is only linkable from the Debug fixtures binary -- exactly like
-// TopoEnvPolicyTests, ParamTests::ncclLoadParam, ArgCheckTests' argcheck helpers,
-// etc.
+// Debug-only target (rccl-UnitTestsFixturesDebug): ncclTopoForceMerge has hidden
+// visibility in Release, so it is only linkable from the Debug fixtures binary.
 
 #include <gtest/gtest.h>
 
@@ -54,7 +47,8 @@ namespace
 // overruns the array by exactly one entry.
 constexpr int kPhysDevs = NCCL_NET_MAX_DEVS_PER_NIC + 1;
 
-const char* kNicName = "mlx5_0";
+// Any name works: it is both the fake device name and the pattern matched against it.
+const char* kFakeNicName = "testnic0";
 
 }  // namespace
 
@@ -81,7 +75,7 @@ TEST(TopoNicFusionTests, ForceMerge_PatternMatchingMoreDevsThanArray_Rejected)
     memset(placedDevs, 0, sizeof(placedDevs));
     for(int dev = 0; dev < kPhysDevs; dev++)
     {
-        snprintf(names[dev], sizeof(names[dev]), "%s", kNicName);
+        snprintf(names[dev], sizeof(names[dev]), "%s", kFakeNicName);
         propsList[dev].name = names[dev];
         propsList[dev].port = dev + 1;  // IB port numbers are 1-based
         ASSERT_EQ(xmlAddNode(xml, root, "net", &physNetNodes[dev]), ncclSuccess);
@@ -90,7 +84,7 @@ TEST(TopoNicFusionTests, ForceMerge_PatternMatchingMoreDevsThanArray_Rejected)
     struct ncclTopoNetInfo netInfo;
     memset(&netInfo, 0, sizeof(netInfo));
     netInfo.maxDevsPerNic = NCCL_NET_MAX_DEVS_PER_NIC;
-    netInfo.forceMerge    = kNicName;
+    netInfo.forceMerge    = kFakeNicName;
 
     EXPECT_EQ(ncclTopoForceMerge(xml, &netInfo, placedDevs, propsList, physNetNodes, kPhysDevs),
               ncclInvalidUsage);

--- a/projects/rccl/test/test_categories_fixtures_debug.yaml
+++ b/projects/rccl/test/test_categories_fixtures_debug.yaml
@@ -29,6 +29,7 @@ test_categories:
       - "XmlTest.*"
       - "NetDevsPolicyP2pNetTests.*"
       - "TopoTest.*"
+      - "TopoNicFusionTests.*"
     exclude_windows:
       - "*"
     labels:

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -1784,11 +1784,8 @@ TEST_F(NetIbMPITest, MultipleOutstandingSendRecv) {
 //   - below the limit:  succeeds
 //   - at the limit:     succeeds
 //   - above the limit:  rejected, no device added
-//   - duplicate device indices: deduplicated into a single-NIC vNIC
 //
-// The limit is a compile-time property of the plugin API version, not an env var:
-// NCCL_NET_MAX_DEVS_PER_NIC tracks the negotiated net API (4 for v9..v11, 8 for v12).
-// Never hardcode it here.
+// The limit is a compile-time property of the negotiated plugin API, not an env var.
 //
 // makeVDevice() is additive — each successful call appends a new merged device
 // to the device list. Physical devices remain visible (hiding is done by the
@@ -1799,6 +1796,13 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
     ASSERT_TRUE(validateTestPrerequisites(kMinProcessesForMPI, MPITestConstants::kNoProcessLimit,
                                          kRequirePowerOfTwo, 1, kNoNodeLimit))
         << "Test requirements not met";
+
+    // Every sub-test below requests ndevs > 1, which the plugin refuses outright when
+    // merging is off, making the over-limit sub-test pass for the wrong reason.
+    const char* mergeEnv = getenv("NCCL_IB_MERGE_NICS");
+    if (mergeEnv && atoi(mergeEnv) == 0) {
+        GTEST_SKIP() << "NIC merging disabled (NCCL_IB_MERGE_NICS=0)";
+    }
 
     ASSERT_EQ(InitNetIb(), ncclSuccess);
 
@@ -1816,8 +1820,10 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
         memset(&allProps[i], 0, sizeof(ncclNetProperties_t));
         ASSERT_EQ(GetDeviceProperties(i, &allProps[i]), ncclSuccess);
 
-        bool isMerged = (allProps[i].name && strchr(allProps[i].name, '+') != nullptr);
-        if (!isMerged) {
+        // The plugin registers a 1:1 vNIC per physical NIC at init, so a physical device
+        // is the one whose own index equals the index it wraps. A deduped 1-device vNIC
+        // left by an earlier test also has ndevs == 1 but wraps a different index.
+        if (allProps[i].vProps.ndevs == 1 && allProps[i].vProps.devs[0] == i) {
             physicalDevices.push_back(i);
         }
     }
@@ -1898,6 +1904,11 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
     // =========================================================================
     expectMergeSucceeds(mergeCount);
 
+    if (mergeCount < kMaxDevsPerNic) {
+        TEST_INFO("Only %d same-speed NICs available; the ndevs == %d boundary was not exercised",
+                  mergeCount, kMaxDevsPerNic);
+    }
+
     // =========================================================================
     // Sub-test 3: above the limit — must be rejected, no device added
     //
@@ -1916,6 +1927,8 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
             int ndevs;
             int devs[kOverLimit];
         } oversized;
+        static_assert(offsetof(ncclNetVDeviceProps_t, devs) == offsetof(decltype(oversized), devs),
+                      "oversized request must stay layout-compatible with ncclNetVDeviceProps_t");
         oversized.ndevs = kOverLimit;
         for (int i = 0; i < kOverLimit; i++) {
             oversized.devs[i] = selected[i % mergeCount];
@@ -1932,44 +1945,6 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
         int ndevAfter = 0;
         ASSERT_EQ(GetDeviceCount(&ndevAfter), ncclSuccess);
         EXPECT_EQ(ndevAfter, ndevBefore) << "Failed merge should not add any devices";
-    }
-
-    // =========================================================================
-    // Sub-test 4: duplicate indices collapse into a single-NIC vNIC
-    //
-    // This is the dedup that masked the original ROCM-28479 failure: a props array with a
-    // repeated index yields fewer constituents than ndevs suggests. Pin the behaviour so a
-    // future test cannot mistake "deduplicated" for "over the limit".
-    // =========================================================================
-    {
-        int ndevBefore = 0;
-        ASSERT_EQ(GetDeviceCount(&ndevBefore), ncclSuccess);
-
-        ncclNetVDeviceProps_t vProps;
-        memset(&vProps, 0, sizeof(vProps));
-        vProps.ndevs = 2;
-        vProps.devs[0] = selected[0];
-        vProps.devs[1] = selected[0];
-
-        int vdev = -1;
-        ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess)
-            << "A duplicate-index merge is a valid single-NIC request";
-        ASSERT_GE(vdev, 0);
-
-        int ndevAfter = 0;
-        ASSERT_EQ(GetDeviceCount(&ndevAfter), ncclSuccess);
-        EXPECT_EQ(ndevAfter, ndevBefore + 1);
-
-        ncclNetProperties_t vdevProps;
-        memset(&vdevProps, 0, sizeof(vdevProps));
-        ASSERT_EQ(GetDeviceProperties(vdev, &vdevProps), ncclSuccess);
-        ASSERT_NE(vdevProps.name, nullptr);
-
-        EXPECT_EQ(strchr(vdevProps.name, '+'), nullptr)
-            << "Duplicate indices should collapse to one constituent, got name '"
-            << vdevProps.name << "'";
-        EXPECT_EQ(vdevProps.speed, allProps[selected[0]].speed)
-            << "Deduplicated merge must not double-count speed";
     }
 }
 

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -7,6 +7,7 @@
 #include "NetIbMPITestBase.hpp"
 
 #include <chrono>
+#include <cstddef>
 
 #ifdef MPI_TESTS_ENABLED
 
@@ -76,6 +77,7 @@ TEST_F(NetIbMPITest, MakeVirtualDeviceNegativeNdevs) {
     ASSERT_EQ(GetDeviceCount(&ndevBefore), ncclSuccess);
 
     ncclNetVDeviceProps_t vProps;
+    memset(&vProps, 0, sizeof(vProps));
     vProps.ndevs = -1;
 
     int vdev = -1;
@@ -1918,13 +1920,13 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
     // Sub-test 1: below the limit
     // =========================================================================
     if (mergeCount >= 3) {
-        expectMergeSucceeds(mergeCount - 1);
+        ASSERT_NO_FATAL_FAILURE(expectMergeSucceeds(mergeCount - 1));
     }
 
     // =========================================================================
     // Sub-test 2: at the limit (or at the node's maximum, when it has fewer NICs)
     // =========================================================================
-    expectMergeSucceeds(mergeCount);
+    ASSERT_NO_FATAL_FAILURE(expectMergeSucceeds(mergeCount));
 
     if (mergeCount < kMaxDevsPerNic) {
         TEST_INFO("Only %d same-speed NICs available; the ndevs == %d boundary was not exercised",
@@ -1945,6 +1947,13 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
         ASSERT_EQ(GetDeviceCount(&ndevBefore), ncclSuccess);
 
         constexpr int kOverLimit = kMaxDevsPerNic + 1;
+
+        // The spare slot below only extends devs[], and so only keeps a one-entry overrun inside
+        // this object, while devs[] is the trailing member of the struct.
+        static_assert(offsetof(ncclNetVDeviceProps_t, devs) + sizeof(ncclNetVDeviceProps_t::devs) ==
+                          sizeof(ncclNetVDeviceProps_t),
+                      "ncclNetVDeviceProps_t gained a member after devs[]");
+
         union {
             ncclNetVDeviceProps_t props;
             char padded[sizeof(ncclNetVDeviceProps_t) + sizeof(int)];

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -60,14 +60,25 @@ TEST_F(NetIbMPITest, MakeVirtualDeviceInvalidProps) {
     int vdev = -1;
     ncclResult_t result = MakeVirtualDevice(&vdev, &vProps);
     EXPECT_EQ(result, ncclInvalidUsage) << "Should fail with zero devices";
+}
 
-    // Negative test: negative count. It clears every per-device check because the
-    // build loop never runs, so without an explicit bound it registers an empty vNIC.
+TEST_F(NetIbMPITest, MakeVirtualDeviceNegativeNdevs) {
+    // A negative count clears every per-device check, because the build loop never runs.
+    // Without an explicit bound it registers a vNIC with no constituent device.
+    ASSERT_TRUE(validateTestPrerequisites(kMinProcessesForMPI, MPITestConstants::kNoProcessLimit,
+                                         kRequirePowerOfTwo, 1, kNoNodeLimit))
+        << "Test requirements not met";
+
+    int ndev = 0;
+    AssertInitAndGetDevices(&ndev);
+
     int ndevBefore = 0;
     ASSERT_EQ(GetDeviceCount(&ndevBefore), ncclSuccess);
 
+    ncclNetVDeviceProps_t vProps;
     vProps.ndevs = -1;
-    vdev = -1;
+
+    int vdev = -1;
     EXPECT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclInvalidUsage)
         << "Should fail with a negative device count";
 
@@ -1794,12 +1805,10 @@ TEST_F(NetIbMPITest, MultipleOutstandingSendRecv) {
 // =============================================================================
 // Test: MergeMultipleDevices
 //
-// Exercises makeVDevice() around the NCCL_NET_MAX_DEVS_PER_NIC boundary:
-//   - below the limit:  succeeds
-//   - at the limit:     succeeds
-//   - above the limit:  rejected, no device added
-//
-// The limit is a compile-time property of the negotiated plugin API, not an env var.
+// Tests makeVDevice() with increasing numbers of physical devices:
+//   - below NCCL_NET_MAX_DEVS_PER_NIC: should succeed
+//   - at the limit:                    should succeed
+//   - above the limit:                 should fail, adding no device
 //
 // makeVDevice() is additive — each successful call appends a new merged device
 // to the device list. Physical devices remain visible (hiding is done by the
@@ -1811,8 +1820,8 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
                                          kRequirePowerOfTwo, 1, kNoNodeLimit))
         << "Test requirements not met";
 
-    // Every sub-test below requests ndevs > 1, which the plugin refuses outright when
-    // merging is off, making the over-limit sub-test pass for the wrong reason.
+    // With merging off, every ndevs > 1 request is refused and the over-limit case would
+    // pass for the wrong reason.
     const char* mergeEnv = getenv("NCCL_IB_MERGE_NICS");
     if (mergeEnv && atoi(mergeEnv) == 0) {
         GTEST_SKIP() << "NIC merging disabled (NCCL_IB_MERGE_NICS=0)";
@@ -1826,7 +1835,7 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
 
     constexpr int kMaxDevsPerNic = NCCL_NET_MAX_DEVS_PER_NIC;
 
-    // --- Collect all device properties and identify the physical devices ---
+    // --- Collect all device properties and identify physical (non-merged) devices ---
     std::vector<ncclNetProperties_t> allProps(ndev);
     std::vector<int> physicalDevices;
 
@@ -1834,9 +1843,8 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
         memset(&allProps[i], 0, sizeof(ncclNetProperties_t));
         ASSERT_EQ(GetDeviceProperties(i, &allProps[i]), ncclSuccess);
 
-        // The plugin registers a 1:1 vNIC per physical NIC at init, so a physical device
-        // is the one whose own index equals the index it wraps. A deduped 1-device vNIC
-        // left by an earlier test also has ndevs == 1 but wraps a different index.
+        // Only the init-time 1:1 vNICs wrap their own index; MakeVirtualDeviceDuplicateDevs
+        // leaves behind a deduped vNIC that also has ndevs == 1 but wraps a lower index.
         if (allProps[i].vProps.ndevs == 1 && allProps[i].vProps.devs[0] == i) {
             physicalDevices.push_back(i);
         }
@@ -1847,7 +1855,7 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
     }
 
     // --- Take up to kMaxDevsPerNic physical devices sharing one speed ---
-    const int targetSpeed = allProps[physicalDevices[0]].speed;
+    int targetSpeed = allProps[physicalDevices[0]].speed;
     std::vector<int> selected;
 
     for (size_t i = 0; i < physicalDevices.size() && (int)selected.size() < kMaxDevsPerNic; i++) {
@@ -1956,9 +1964,11 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
             << "Merging " << kOverLimit << " devices must be rejected (limit is "
             << kMaxDevsPerNic << ")";
 
+        // Device count should NOT have changed
         int ndevAfter = 0;
         ASSERT_EQ(GetDeviceCount(&ndevAfter), ncclSuccess);
-        EXPECT_EQ(ndevAfter, ndevBefore) << "Failed merge should not add any devices";
+        EXPECT_EQ(ndevAfter, ndevBefore)
+            << "Failed merge should not add any devices";
     }
 }
 

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -60,6 +60,20 @@ TEST_F(NetIbMPITest, MakeVirtualDeviceInvalidProps) {
     int vdev = -1;
     ncclResult_t result = MakeVirtualDevice(&vdev, &vProps);
     EXPECT_EQ(result, ncclInvalidUsage) << "Should fail with zero devices";
+
+    // Negative test: negative count. It clears every per-device check because the
+    // build loop never runs, so without an explicit bound it registers an empty vNIC.
+    int ndevBefore = 0;
+    ASSERT_EQ(GetDeviceCount(&ndevBefore), ncclSuccess);
+
+    vProps.ndevs = -1;
+    vdev = -1;
+    EXPECT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclInvalidUsage)
+        << "Should fail with a negative device count";
+
+    int ndevAfter = 0;
+    ASSERT_EQ(GetDeviceCount(&ndevAfter), ncclSuccess);
+    EXPECT_EQ(ndevAfter, ndevBefore) << "A rejected request must not register a device";
 }
 
 TEST_F(NetIbMPITest, MakeVirtualDeviceMergeDisabled) {

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -1935,30 +1935,29 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
     // Sub-test 3: above the limit — must be rejected, no device added
     //
     // ncclNetVDeviceProps_t::devs[] holds exactly NCCL_NET_MAX_DEVS_PER_NIC entries, so an
-    // over-limit request cannot be expressed in that struct. Use a layout-compatible
-    // oversized buffer: the plugin must reject on the ndevs count alone, before it ever
-    // indexes devs[]. Backing the extra entries with real memory keeps this test free of
-    // out-of-bounds access even if the guard regresses.
+    // over-limit request cannot be expressed in that struct. Pad a real props object with one
+    // spare devs[] slot: the plugin must reject on the ndevs count alone, before it ever
+    // indexes devs[], and a regressed guard that walks one entry too far stays inside memory
+    // this test owns.
     // =========================================================================
     {
         int ndevBefore = 0;
         ASSERT_EQ(GetDeviceCount(&ndevBefore), ncclSuccess);
 
         constexpr int kOverLimit = kMaxDevsPerNic + 1;
-        struct {
-            int ndevs;
-            int devs[kOverLimit];
-        } oversized;
-        static_assert(offsetof(ncclNetVDeviceProps_t, devs) == offsetof(decltype(oversized), devs),
-                      "oversized request must stay layout-compatible with ncclNetVDeviceProps_t");
-        oversized.ndevs = kOverLimit;
-        for (int i = 0; i < kOverLimit; i++) {
-            oversized.devs[i] = selected[i % mergeCount];
+        union {
+            ncclNetVDeviceProps_t props;
+            char padded[sizeof(ncclNetVDeviceProps_t) + sizeof(int)];
+        } request;
+
+        memset(&request, 0, sizeof(request));
+        request.props.ndevs = kOverLimit;
+        for (int i = 0; i < kMaxDevsPerNic; i++) {
+            request.props.devs[i] = selected[i % mergeCount];
         }
 
         int vdev = -1;
-        ncclResult_t result =
-            MakeVirtualDevice(&vdev, reinterpret_cast<ncclNetVDeviceProps_t*>(&oversized));
+        ncclResult_t result = MakeVirtualDevice(&vdev, &request.props);
 
         EXPECT_EQ(result, ncclInvalidUsage)
             << "Merging " << kOverLimit << " devices must be rejected (limit is "

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -1780,10 +1780,15 @@ TEST_F(NetIbMPITest, MultipleOutstandingSendRecv) {
 // =============================================================================
 // Test: MergeMultipleDevices
 //
-// Tests makeVDevice() with increasing numbers of physical devices:
-//   - 3 devices: should succeed (within NCCL_NET_MAX_DEVS_PER_NIC = 4 limit)
-//   - 4 devices: should succeed (at the limit)
-//   - 5 devices: should fail (exceeds the limit)
+// Exercises makeVDevice() around the NCCL_NET_MAX_DEVS_PER_NIC boundary:
+//   - below the limit:  succeeds
+//   - at the limit:     succeeds
+//   - above the limit:  rejected, no device added
+//   - duplicate device indices: deduplicated into a single-NIC vNIC
+//
+// The limit is a compile-time property of the plugin API version, not an env var:
+// NCCL_NET_MAX_DEVS_PER_NIC tracks the negotiated net API (4 for v9..v11, 8 for v12).
+// Never hardcode it here.
 //
 // makeVDevice() is additive — each successful call appends a new merged device
 // to the device list. Physical devices remain visible (hiding is done by the
@@ -1801,6 +1806,8 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
     ASSERT_EQ(GetDeviceCount(&ndev), ncclSuccess);
     ASSERT_GT(ndev, 0);
 
+    constexpr int kMaxDevsPerNic = NCCL_NET_MAX_DEVS_PER_NIC;
+
     // --- Collect all device properties and identify physical (non-merged) devices ---
     std::vector<ncclNetProperties_t> allProps(ndev);
     std::vector<int> physicalDevices;
@@ -1815,160 +1822,154 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
         }
     }
 
-    if (physicalDevices.size() < 5) {
-        GTEST_SKIP() << "Need at least 5 physical (non-merged) IB devices, found "
-                     << physicalDevices.size();
+    if (physicalDevices.empty()) {
+        GTEST_SKIP() << "No physical (non-merged) IB devices found";
     }
 
-    // --- Find 5 physical devices with matching speed ---
-    int targetSpeed = allProps[physicalDevices[0]].speed;
+    // --- Take up to kMaxDevsPerNic physical devices sharing one speed ---
+    const int targetSpeed = allProps[physicalDevices[0]].speed;
     std::vector<int> selected;
 
-    for (size_t i = 0; i < physicalDevices.size() && selected.size() < 5; i++) {
+    for (size_t i = 0; i < physicalDevices.size() && (int)selected.size() < kMaxDevsPerNic; i++) {
         int devIdx = physicalDevices[i];
         if (allProps[devIdx].speed == targetSpeed) {
             selected.push_back(devIdx);
         }
     }
 
-    if (selected.size() < 5) {
-        GTEST_SKIP() << "Could not find 5 physical devices with matching speed. "
-                     << "Found " << selected.size() << " devices at speed " << targetSpeed;
+    const int mergeCount = (int)selected.size();
+    if (mergeCount < 2) {
+        GTEST_SKIP() << "Need at least 2 physical devices at a common speed, found " << mergeCount
+                     << " at speed " << targetSpeed;
     }
 
-    // =========================================================================
-    // Sub-test 1: Merge 3 devices (should succeed, under limit of 4)
-    // =========================================================================
-    {
+    // Merge selected[0..count-1] and check the resulting vNIC. Distinct indices only,
+    // so the merged device must report exactly `count` constituents.
+    auto expectMergeSucceeds = [&](int count) {
+        SCOPED_TRACE(testing::Message() << "merging " << count << " devices, limit " << kMaxDevsPerNic);
+
         int ndevBefore = 0;
         ASSERT_EQ(GetDeviceCount(&ndevBefore), ncclSuccess);
 
         ncclNetVDeviceProps_t vProps;
         memset(&vProps, 0, sizeof(vProps));
-        vProps.ndevs = 3;
-        vProps.devs[0] = selected[0];
-        vProps.devs[1] = selected[1];
-        vProps.devs[2] = selected[2];
-
-        int vdev = -1;
-        ncclResult_t result = MakeVirtualDevice(&vdev, &vProps);
-
-        EXPECT_EQ(result, ncclSuccess)
-            << "Merging 3 devices should succeed (within limit of 4)";
-
-        if (result == ncclSuccess) {
-            EXPECT_GE(vdev, 0) << "Virtual device index should be non-negative";
-
-            // Device count should increase by 1
-            int ndevAfter = 0;
-            ASSERT_EQ(GetDeviceCount(&ndevAfter), ncclSuccess);
-            EXPECT_EQ(ndevAfter, ndevBefore + 1)
-                << "makeVDevice should add exactly one device";
-
-            // Verify the new merged device properties
-            ncclNetProperties_t vdevProps;
-            memset(&vdevProps, 0, sizeof(vdevProps));
-            ASSERT_EQ(GetDeviceProperties(vdev, &vdevProps), ncclSuccess);
-
-            // Name should contain two '+' separators (3 devices)
-            ASSERT_NE(vdevProps.name, nullptr);
-            std::string mergedName(vdevProps.name);
-            int plusCount = 0;
-            for (char c : mergedName) {
-                if (c == '+') plusCount++;
-            }
-            EXPECT_EQ(plusCount, 2)
-                << "3-device merge should have 2 '+' separators, got " << plusCount
-                << " in name '" << mergedName << "'";
-
-            // Speed should be sum of 3 constituents
-            int expectedSpeed = allProps[selected[0]].speed +
-                                allProps[selected[1]].speed +
-                                allProps[selected[2]].speed;
-            EXPECT_EQ(vdevProps.speed, expectedSpeed)
-                << "Merged speed should be " << expectedSpeed << ", got " << vdevProps.speed;
+        vProps.ndevs = count;
+        int expectedSpeed = 0;
+        for (int i = 0; i < count; i++) {
+            vProps.devs[i] = selected[i];
+            expectedSpeed += allProps[selected[i]].speed;
         }
-    }
-
-    // =========================================================================
-    // Sub-test 2: Merge 4 devices (should succeed, at the limit)
-    // =========================================================================
-    {
-        int ndevBefore = 0;
-        ASSERT_EQ(GetDeviceCount(&ndevBefore), ncclSuccess);
-
-        ncclNetVDeviceProps_t vProps;
-        memset(&vProps, 0, sizeof(vProps));
-        vProps.ndevs = 4;
-        vProps.devs[0] = selected[0];
-        vProps.devs[1] = selected[1];
-        vProps.devs[2] = selected[2];
-        vProps.devs[3] = selected[3];
 
         int vdev = -1;
-        ncclResult_t result = MakeVirtualDevice(&vdev, &vProps);
+        ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess)
+            << "Merging " << count << " devices should succeed";
+        ASSERT_GE(vdev, 0) << "Virtual device index should be non-negative";
 
-        EXPECT_EQ(result, ncclSuccess)
-            << "Merging 4 devices should succeed (at the limit of NCCL_NET_MAX_DEVS_PER_NIC)";
-
-        if (result == ncclSuccess) {
-            EXPECT_GE(vdev, 0);
-
-            int ndevAfter = 0;
-            ASSERT_EQ(GetDeviceCount(&ndevAfter), ncclSuccess);
-            EXPECT_EQ(ndevAfter, ndevBefore + 1);
-
-            ncclNetProperties_t vdevProps;
-            memset(&vdevProps, 0, sizeof(vdevProps));
-            ASSERT_EQ(GetDeviceProperties(vdev, &vdevProps), ncclSuccess);
-
-            // Name should contain three '+' separators (4 devices)
-            ASSERT_NE(vdevProps.name, nullptr);
-            std::string mergedName(vdevProps.name);
-            int plusCount = 0;
-            for (char c : mergedName) {
-                if (c == '+') plusCount++;
-            }
-            EXPECT_EQ(plusCount, 3)
-                << "4-device merge should have 3 '+' separators, got " << plusCount
-                << " in name '" << mergedName << "'";
-
-            // Speed should be sum of 4 constituents
-            int expectedSpeed = allProps[selected[0]].speed +
-                                allProps[selected[1]].speed +
-                                allProps[selected[2]].speed +
-                                allProps[selected[3]].speed;
-            EXPECT_EQ(vdevProps.speed, expectedSpeed)
-                << "Merged speed should be " << expectedSpeed << ", got " << vdevProps.speed;
-        }
-    }
-
-    // =========================================================================
-    // Sub-test 3: Merge 5 devices (should FAIL, exceeds limit of 4)
-    // =========================================================================
-    {
-        int ndevBefore = 0;
-        ASSERT_EQ(GetDeviceCount(&ndevBefore), ncclSuccess);
-
-        ncclNetVDeviceProps_t vProps;
-        memset(&vProps, 0, sizeof(vProps));
-        vProps.ndevs = 5;
-        vProps.devs[0] = selected[0];
-        vProps.devs[1] = selected[1];
-        vProps.devs[2] = selected[2];
-        vProps.devs[3] = selected[3];
-
-        int vdev = -1;
-        ncclResult_t result = MakeVirtualDevice(&vdev, &vProps);
-
-        EXPECT_NE(result, ncclSuccess)
-            << "Merging 5 devices should fail (exceeds NCCL_NET_MAX_DEVS_PER_NIC = 4)";
-
-        // Device count should NOT have changed
         int ndevAfter = 0;
         ASSERT_EQ(GetDeviceCount(&ndevAfter), ncclSuccess);
-        EXPECT_EQ(ndevAfter, ndevBefore)
-            << "Failed merge should not add any devices";
+        EXPECT_EQ(ndevAfter, ndevBefore + 1) << "makeVDevice should add exactly one device";
+
+        ncclNetProperties_t vdevProps;
+        memset(&vdevProps, 0, sizeof(vdevProps));
+        ASSERT_EQ(GetDeviceProperties(vdev, &vdevProps), ncclSuccess);
+        ASSERT_NE(vdevProps.name, nullptr);
+
+        std::string mergedName(vdevProps.name);
+        int plusCount = 0;
+        for (char c : mergedName) {
+            if (c == '+') plusCount++;
+        }
+        EXPECT_EQ(plusCount, count - 1)
+            << count << "-device merge should have " << count - 1 << " '+' separators, got "
+            << plusCount << " in name '" << mergedName << "'";
+        EXPECT_EQ(vdevProps.speed, expectedSpeed)
+            << "Merged speed should be " << expectedSpeed << ", got " << vdevProps.speed;
+    };
+
+    // =========================================================================
+    // Sub-test 1: below the limit
+    // =========================================================================
+    if (mergeCount >= 3) {
+        expectMergeSucceeds(mergeCount - 1);
+    }
+
+    // =========================================================================
+    // Sub-test 2: at the limit (or at the node's maximum, when it has fewer NICs)
+    // =========================================================================
+    expectMergeSucceeds(mergeCount);
+
+    // =========================================================================
+    // Sub-test 3: above the limit — must be rejected, no device added
+    //
+    // ncclNetVDeviceProps_t::devs[] holds exactly NCCL_NET_MAX_DEVS_PER_NIC entries, so an
+    // over-limit request cannot be expressed in that struct. Use a layout-compatible
+    // oversized buffer: the plugin must reject on the ndevs count alone, before it ever
+    // indexes devs[]. Backing the extra entries with real memory keeps this test free of
+    // out-of-bounds access even if the guard regresses.
+    // =========================================================================
+    {
+        int ndevBefore = 0;
+        ASSERT_EQ(GetDeviceCount(&ndevBefore), ncclSuccess);
+
+        constexpr int kOverLimit = kMaxDevsPerNic + 1;
+        struct {
+            int ndevs;
+            int devs[kOverLimit];
+        } oversized;
+        oversized.ndevs = kOverLimit;
+        for (int i = 0; i < kOverLimit; i++) {
+            oversized.devs[i] = selected[i % mergeCount];
+        }
+
+        int vdev = -1;
+        ncclResult_t result =
+            MakeVirtualDevice(&vdev, reinterpret_cast<ncclNetVDeviceProps_t*>(&oversized));
+
+        EXPECT_EQ(result, ncclInvalidUsage)
+            << "Merging " << kOverLimit << " devices must be rejected (limit is "
+            << kMaxDevsPerNic << ")";
+
+        int ndevAfter = 0;
+        ASSERT_EQ(GetDeviceCount(&ndevAfter), ncclSuccess);
+        EXPECT_EQ(ndevAfter, ndevBefore) << "Failed merge should not add any devices";
+    }
+
+    // =========================================================================
+    // Sub-test 4: duplicate indices collapse into a single-NIC vNIC
+    //
+    // This is the dedup that masked the original ROCM-28479 failure: a props array with a
+    // repeated index yields fewer constituents than ndevs suggests. Pin the behaviour so a
+    // future test cannot mistake "deduplicated" for "over the limit".
+    // =========================================================================
+    {
+        int ndevBefore = 0;
+        ASSERT_EQ(GetDeviceCount(&ndevBefore), ncclSuccess);
+
+        ncclNetVDeviceProps_t vProps;
+        memset(&vProps, 0, sizeof(vProps));
+        vProps.ndevs = 2;
+        vProps.devs[0] = selected[0];
+        vProps.devs[1] = selected[0];
+
+        int vdev = -1;
+        ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess)
+            << "A duplicate-index merge is a valid single-NIC request";
+        ASSERT_GE(vdev, 0);
+
+        int ndevAfter = 0;
+        ASSERT_EQ(GetDeviceCount(&ndevAfter), ncclSuccess);
+        EXPECT_EQ(ndevAfter, ndevBefore + 1);
+
+        ncclNetProperties_t vdevProps;
+        memset(&vdevProps, 0, sizeof(vdevProps));
+        ASSERT_EQ(GetDeviceProperties(vdev, &vdevProps), ncclSuccess);
+        ASSERT_NE(vdevProps.name, nullptr);
+
+        EXPECT_EQ(strchr(vdevProps.name, '+'), nullptr)
+            << "Duplicate indices should collapse to one constituent, got name '"
+            << vdevProps.name << "'";
+        EXPECT_EQ(vdevProps.speed, allProps[selected[0]].speed)
+            << "Deduplicated merge must not double-count speed";
     }
 }
 

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -1812,7 +1812,7 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
 
     constexpr int kMaxDevsPerNic = NCCL_NET_MAX_DEVS_PER_NIC;
 
-    // --- Collect all device properties and identify physical (non-merged) devices ---
+    // --- Collect all device properties and identify the physical devices ---
     std::vector<ncclNetProperties_t> allProps(ndev);
     std::vector<int> physicalDevices;
 
@@ -1829,7 +1829,7 @@ TEST_F(NetIbMPITest, MergeMultipleDevices) {
     }
 
     if (physicalDevices.empty()) {
-        GTEST_SKIP() << "No physical (non-merged) IB devices found";
+        GTEST_SKIP() << "No physical IB devices found";
     }
 
     // --- Take up to kMaxDevsPerNic physical devices sharing one speed ---

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
@@ -364,9 +364,19 @@
           "test_filter": "NetIbMPITest.MakeVirtualDeviceOutOfRangeDev"
         },
         {
+          "name": "NetIB_VNic_NegativeNdevs",
+          "description": "makeVDevice rejects a negative device count",
+          "test_filter": "NetIbMPITest.MakeVirtualDeviceNegativeNdevs"
+        },
+        {
           "name": "NetIB_VNic_DuplicateDevs",
           "description": "makeVDevice dedups a repeated device into a single-device vNIC",
           "test_filter": "NetIbMPITest.MakeVirtualDeviceDuplicateDevs"
+        },
+        {
+          "name": "NetIB_VNic_MergeMultipleDevices",
+          "description": "makeVDevice merges up to NCCL_NET_MAX_DEVS_PER_NIC devices and rejects an over-limit request. GTEST_SKIPs without two physical NICs at a common speed",
+          "test_filter": "NetIbMPITest.MergeMultipleDevices"
         },
         {
           "name": "NetIB_VNic_CrossNuma",

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -469,9 +469,19 @@
           "test_filter": "NetIbMPITest.MakeVirtualDeviceOutOfRangeDev"
         },
         {
+          "name": "NetIB_VNic_NegativeNdevs",
+          "description": "makeVDevice rejects a negative device count",
+          "test_filter": "NetIbMPITest.MakeVirtualDeviceNegativeNdevs"
+        },
+        {
           "name": "NetIB_VNic_DuplicateDevs",
           "description": "makeVDevice dedups a repeated device into a single-device vNIC",
           "test_filter": "NetIbMPITest.MakeVirtualDeviceDuplicateDevs"
+        },
+        {
+          "name": "NetIB_VNic_MergeMultipleDevices",
+          "description": "makeVDevice merges up to NCCL_NET_MAX_DEVS_PER_NIC devices and rejects an over-limit request. GTEST_SKIPs without two physical NICs at a common speed",
+          "test_filter": "NetIbMPITest.MergeMultipleDevices"
         },
         {
           "name": "NetIB_VNic_CrossNuma",

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -670,6 +670,11 @@
           "test_filter": "TopoTest.*"
         },
         {
+          "name": "TopoNicFusionTests",
+          "description": "NIC fusion input validation in the topology layer",
+          "test_filter": "TopoNicFusionTests.*"
+        },
+        {
           "name": "DdaIpcEligibilityTest",
           "description": "Dda IPC eligibility tests",
           "test_filter": "DdaIpcEligibilityTest.*"

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -374,9 +374,19 @@
           "test_filter": "NetIbMPITest.MakeVirtualDeviceOutOfRangeDev"
         },
         {
+          "name": "NetIB_VNic_NegativeNdevs",
+          "description": "makeVDevice rejects a negative device count",
+          "test_filter": "NetIbMPITest.MakeVirtualDeviceNegativeNdevs"
+        },
+        {
           "name": "NetIB_VNic_DuplicateDevs",
           "description": "makeVDevice dedups a repeated device into a single-device vNIC",
           "test_filter": "NetIbMPITest.MakeVirtualDeviceDuplicateDevs"
+        },
+        {
+          "name": "NetIB_VNic_MergeMultipleDevices",
+          "description": "makeVDevice merges up to NCCL_NET_MAX_DEVS_PER_NIC devices and rejects an over-limit request. GTEST_SKIPs without two physical NICs at a common speed",
+          "test_filter": "NetIbMPITest.MergeMultipleDevices"
         },
         {
           "name": "NetIB_VNic_CrossNuma",

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
@@ -370,9 +370,19 @@
           "test_filter": "NetIbMPITest.MakeVirtualDeviceOutOfRangeDev"
         },
         {
+          "name": "NetIB_VNic_NegativeNdevs",
+          "description": "makeVDevice rejects a negative device count",
+          "test_filter": "NetIbMPITest.MakeVirtualDeviceNegativeNdevs"
+        },
+        {
           "name": "NetIB_VNic_DuplicateDevs",
           "description": "makeVDevice dedups a repeated device into a single-device vNIC",
           "test_filter": "NetIbMPITest.MakeVirtualDeviceDuplicateDevs"
+        },
+        {
+          "name": "NetIB_VNic_MergeMultipleDevices",
+          "description": "makeVDevice merges up to NCCL_NET_MAX_DEVS_PER_NIC devices and rejects an over-limit request. GTEST_SKIPs without two physical NICs at a common speed",
+          "test_filter": "NetIbMPITest.MergeMultipleDevices"
         },
         {
           "name": "NetIB_VNic_CrossNuma",

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
@@ -379,9 +379,19 @@
           "test_filter": "NetIbMPITest.MakeVirtualDeviceOutOfRangeDev"
         },
         {
+          "name": "NetIB_VNic_NegativeNdevs",
+          "description": "makeVDevice rejects a negative device count",
+          "test_filter": "NetIbMPITest.MakeVirtualDeviceNegativeNdevs"
+        },
+        {
           "name": "NetIB_VNic_DuplicateDevs",
           "description": "makeVDevice dedups a repeated device into a single-device vNIC",
           "test_filter": "NetIbMPITest.MakeVirtualDeviceDuplicateDevs"
+        },
+        {
+          "name": "NetIB_VNic_MergeMultipleDevices",
+          "description": "makeVDevice merges up to NCCL_NET_MAX_DEVS_PER_NIC devices and rejects an over-limit request. GTEST_SKIPs without two physical NICs at a common speed",
+          "test_filter": "NetIbMPITest.MergeMultipleDevices"
         },
         {
           "name": "NetIB_VNic_CrossNuma",

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
@@ -364,9 +364,19 @@
           "test_filter": "NetIbMPITest.MakeVirtualDeviceOutOfRangeDev"
         },
         {
+          "name": "NetIB_VNic_NegativeNdevs",
+          "description": "makeVDevice rejects a negative device count",
+          "test_filter": "NetIbMPITest.MakeVirtualDeviceNegativeNdevs"
+        },
+        {
           "name": "NetIB_VNic_DuplicateDevs",
           "description": "makeVDevice dedups a repeated device into a single-device vNIC",
           "test_filter": "NetIbMPITest.MakeVirtualDeviceDuplicateDevs"
+        },
+        {
+          "name": "NetIB_VNic_MergeMultipleDevices",
+          "description": "makeVDevice merges up to NCCL_NET_MAX_DEVS_PER_NIC devices and rejects an over-limit request. GTEST_SKIPs without two physical NICs at a common speed",
+          "test_filter": "NetIbMPITest.MergeMultipleDevices"
         },
         {
           "name": "NetIB_VNic_CrossNuma",

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -247,6 +247,11 @@
           "test_filter": "NetIbMPITest.MakeVirtualDeviceInvalidProps"
         },
         {
+          "name": "NetIB_VDev_NegativeNdevs",
+          "description": "Reject makeVDevice with a negative ndevs (ncclInvalidUsage)",
+          "test_filter": "NetIbMPITest.MakeVirtualDeviceNegativeNdevs"
+        },
+        {
           "name": "NetIB_VDev_MergeMultipleDevices",
           "description": "Merge more than two physical IB NICs into a single virtual device",
           "test_filter": "NetIbMPITest.MergeMultipleDevices"


### PR DESCRIPTION
## Motivation

ROCM-28479: NIC fusion accepted more NICs than the limit instead of rejecting the merge. It turned out to be two separate problems:

- The test was asserting against a stale limit. `NetIbMPITest.MergeMultipleDevices` hardcoded a maximum of 4 devices per vNIC, but `NCCL_NET_MAX_DEVS_PER_NIC` has been 8 for some time, so the case meant to prove "the merge is rejected past the limit" was submitting a legal 4-device request
- The product indexed `props->devs[]` before validating `props->ndevs`, its in-loop guard was unreachable, and a negative count registered a vNIC with no devices.

## Technical Details

- `src/transport/net_ib/init.cc`: validate `props->ndevs` upfront, before any indexing, with a diagnostic naming the offending count and the limit
- `src/transport/net_ib_cast/init.cc`: sync with the implementation from net_ib
- `src/graph/topo.cc`: found separately, same defect class. `ncclTopoForceMerge` fills a stack-allocated `ncclNetVDeviceProps_t` from `NCCL_NET_FORCE_MERGE` with one `devs[]` write per matching device and only checks the count after the loop
- `src/graph/topo.cc`: a hang in the same loop, found while validating the above. An unparsable group logged the problem and hit `continue`, which skips the loop's only token advance, so `NCCL_NET_FORCE_MERGE=","` re-parsed the same token forever instead of skipping the bad group

Test changes:
- `MergeMultipleDevices` derives the limit from `NCCL_NET_MAX_DEVS_PER_NIC` instead of restating it, populates every entry it declares, and covers three points explicitly: below the limit, exactly at the limit, and one over it. The over-limit request cannot be expressed in `ncclNetVDeviceProps_t`, so it uses a layout-compatible oversized buffer, which keeps the test free of out-of-bounds access even if the guard regresses. Physical NICs are now identified by `vProps` rather than by the absence of `+` in the name, which misclassifies the deduped single-device vNIC that `MakeVirtualDeviceDuplicateDevs` leaves in the device table.
- New `MakeVirtualDeviceNegativeNdevs` for the negative count, and new `TopoNicFusionTests` for the force-merge overflow

## Issue Tracking

JIRA ID: ROCM-28479

## Test Plan

- Checked related tests on a single Ruby node (MI350X, Broadcom RoCE, 8 NICs)
- CI tests

## Test Result

Single Ruby node (MI350X, 8x Broadcom `bnxt_re` RoCE), debug build, run at the rank counts the test_runner configs use:

- `rccl-UnitTestsFixturesDebug --gtest_filter=TopoNicFusionTests.*`: 1 passed
- `rccl-UnitTestsMPI --gtest_filter=NetIbMPITest.*` on 2 ranks: 64 passed, 46 skipped, 5 failed
- `rccl-UnitTestsMPI` on 4 ranks with the `net_ib_stress_4rank` filter: 5 passed

The five failures in the 2-rank run are the tests that require four processes (`FanInStress`, `FanOutStress`, `AllToAllStress`, `BidirectionalMultiRank`, `LongRunningMultiRank`), and they pass in the 4-rank run. That split is how the configs drive the suite: `net_ib_base` is `num_ranks: 2` and those five sit in a separate `net_ib_stress_4rank` group. The 46 skips are the Cast/WRR suites, which need their scheduler env vars, plus `MakeVirtualDeviceMergeDisabled` (needs `NCCL_IB_MERGE_NICS=0`) and `DisjointMergeRailLocal_VNic` (needs a rail-disjoint topology).

Every test touched by this PR passed: `MakeVirtualDevice`, `MakeVirtualDeviceInvalidProps`, `MakeVirtualDeviceNegativeNdevs`, `MakeVirtualDeviceOutOfRangeDev`, `MakeVirtualDeviceDuplicateDevs`, `MakeVirtualDeviceCrossNuma`, `MergeMultipleDevices`, the whole `*_VNic` set, and `TopoNicFusionTests`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
