### PR TITLE
[rocprofiler-compute] Disabling ml-api tracing during pc-sampling-only profiling

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -9,7 +9,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Changed
 
-* ML API tracing options (--torch-trace/--triton-trace/--ml-api-trace) are now rejected when profiling with PC sampling only, since no counters are collected to correlate markers against.
+* ML API tracing options (--torch-trace/--triton-trace/--ml-api-trace) are no longer allowed with PC-sampling-only profiling; the run now fails with an error telling the user to drop the ML API tracing flag or add a counter block, since without counters there is nothing to correlate the markers against.
 
 ### Removed
 

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -9,6 +9,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Changed
 
+* ML API tracing is now rejected when profiling with PC sampling only, since no counters are collected to correlate markers against.
+
 ### Removed
 
 ### Optimized

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -9,7 +9,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Changed
 
-* ML API tracing is now rejected when profiling with PC sampling only, since no counters are collected to correlate markers against.
+* ML API tracing options (--torch-trace/--triton-trace/--ml-api-trace) are now rejected when profiling with PC sampling only, since no counters are collected to correlate markers against.
 
 ### Removed
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -165,6 +165,12 @@ class RocProfCompute_Base:
         """Perform sanitization of inputs"""
         args = self.get_args()
         selected_frameworks = _compute_selected_frameworks(args)
+        if selected_frameworks and is_only_pc_sampling(args.filter_blocks):
+            console_error(
+                "ML API tracing cannot be used with PC-sampling-only profiling, "
+                "which does not collect counters. Remove the ML API tracing option "
+                "or add a counter block."
+            )
         self._selected_frameworks: set[str] = selected_frameworks
 
         if (

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -167,9 +167,9 @@ class RocProfCompute_Base:
         selected_frameworks = _compute_selected_frameworks(args)
         if selected_frameworks and is_only_pc_sampling(args.filter_blocks):
             console_error(
-                "ML API tracing cannot be used with PC-sampling-only profiling, "
-                "which does not collect counters. Remove the ML API tracing option "
-                "or add a counter block."
+                "ML API tracing options (--torch-trace/--triton-trace/--ml-api-trace) "
+                "cannot be used with PC-sampling-only profiling, which does not "
+                "collect counters. Remove the tracing option(s) or add a counter block."
             )
         self._selected_frameworks: set[str] = selected_frameworks
 

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -202,10 +202,10 @@ def test_sanitize_torch_trace(tmp_path, remaining, expected_exception, setup):
         ),
     ],
 )
-def test_sanitize_pc_sampling_only_rejects_ml_api_trace(
+def test_sanitize_pc_sampling_only_rejects_ml_api_tracing_flags(
     tmp_path, filter_blocks, trace_flags, expect_error, expected_frameworks
 ):
-    """ML API tracing is rejected for PC-sampling-only runs and retained when a
+    """ML API tracing flags are rejected for PC-sampling-only runs and retained when a
     counter block is also requested."""
     remaining = _setup_test_files(tmp_path, ["{binary}"], "binary")
     args = _make_sanitize_args(remaining, filter_blocks=filter_blocks, **trace_flags)

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -160,6 +160,65 @@ def test_sanitize_torch_trace(tmp_path, remaining, expected_exception, setup):
 
 
 # ---------------------------------------------------------------------------
+# sanitize() rejects ML API tracing for PC-sampling-only runs
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "filter_blocks, trace_flags, expect_error, expected_frameworks",
+    [
+        pytest.param(
+            ["21"],
+            {"torch_trace": True},
+            True,
+            None,
+            id="pc_only_torch_trace_errors",
+        ),
+        pytest.param(
+            ["pc_sampling"],
+            {"ml_api_trace": True},
+            True,
+            None,
+            id="pc_only_ml_api_trace_errors",
+        ),
+        pytest.param(
+            ["21"],
+            {"triton_trace": True},
+            True,
+            None,
+            id="pc_only_triton_trace_errors",
+        ),
+        pytest.param(
+            ["2", "21"],
+            {"torch_trace": True},
+            False,
+            {"torch"},
+            id="mixed_torch_trace_preserved",
+        ),
+        pytest.param(
+            ["21"],
+            {},
+            False,
+            set(),
+            id="pc_only_no_trace_flag",
+        ),
+    ],
+)
+def test_sanitize_pc_sampling_only_rejects_ml_api_trace(
+    tmp_path, filter_blocks, trace_flags, expect_error, expected_frameworks
+):
+    """ML API tracing is rejected for PC-sampling-only runs and retained when a
+    counter block is also requested."""
+    remaining = _setup_test_files(tmp_path, ["{binary}"], "binary")
+    args = _make_sanitize_args(remaining, filter_blocks=filter_blocks, **trace_flags)
+    profiler = RocProfCompute_Base(args, profiler_mode="rocprofiler-sdk", soc=None)
+    if expect_error:
+        with pytest.raises(SystemExit):
+            profiler.sanitize()
+    else:
+        profiler.sanitize()
+        assert profiler._selected_frameworks == expected_frameworks
+
+
+# ---------------------------------------------------------------------------
 # sanitize() without --torch-trace
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -160,7 +160,7 @@ def test_sanitize_torch_trace(tmp_path, remaining, expected_exception, setup):
 
 
 # ---------------------------------------------------------------------------
-# sanitize() rejects ML API tracing for PC-sampling-only runs
+# sanitize() rejects ML API tracing flags for PC-sampling-only runs
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "filter_blocks, trace_flags, expect_error, expected_frameworks",


### PR DESCRIPTION
## Motivation

When profiling with PC sampling only, so there are no counter results for ML API trace markers to be correlated against.

## Technical Details

If any ML API tracing framework is selected (`--ml-api-trace`, `--torch-trace`, `--triton-trace`) and `is_only_pc_sampling(args.filter_blocks)` is true, it calls `console_error()` and aborts. Mixed runs (a counter block alongside PC sampling) are unaffected and keep tracing enabled.

## Issue Tracking

JIRA ID: ROCM-28127

## Test Plan

Added `test_sanitize_pc_sampling_only_rejects_ml_api_trace` in `tests/test_profiler_base.py`

`python -m pytest tests/test_profiler_base.py -k test_sanitize_pc_sampling_only_rejects_ml_api_trace -v`

## Test Result

PASS

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
