### PR TITLE
[rocjitsu] use native scaled WMMA forms for gfx1250 A0 

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -33,7 +33,8 @@ namespace {
 ///   * v_cvt_pk_fp8_f32, v_cvt_sr_fp8_f32 (only when CLAMP selects the B0-only
 ///     mode; the ordinary form stays on the copy path),
 ///   * v_wmma_scale / v_wmma_scale16 forms without an implemented rule,
-///   * integer IU8/IU4 WMMA/SWMMAC.
+///   * integer IU4 and IU8 WMMA/SWMMAC forms without an implemented spacing
+///     rule.
 /// Separately, a 64-bit source using FLAT_SCRATCH_BASE_HI is classified via
 /// operand inspection (see uses_flat_scratch_base_hi_64bit_source), and the
 /// barrier-state and sleep/monitor families are DEFERRED with a pass-through
@@ -87,9 +88,10 @@ inline constexpr std::array<std::string_view, 18> kExactB0ToA0TranslationMnemoni
     return true;
 
   // The eight K=128 FP8/BF8 forms and the standalone 32x16 FP4 WMMA exist on B0
-  // but not A0, so they require semantic expansion. The f32 K=128 forms split
-  // into two native K=64 FP8/BF8 operations; f16 and standalone 32x16 FP4 still
-  // fail closed in their semantic rules.
+  // but not A0, so they require semantic expansion. The common f32 K=128 forms
+  // use one neutral regular-Scale mixed-format operation; encodings with source
+  // OPSEL fields that do not map to that form retain the native K=64 split.
+  // The f16 and standalone 32x16 FP4 forms still fail closed.
   const bool is_k128_fp8_bf8 = (mnemonic.starts_with("v_wmma_f16_16x16x128_") ||
                                 mnemonic.starts_with("v_wmma_f32_16x16x128_")) &&
                                (mnemonic.ends_with("_fp8_fp8") || mnemonic.ends_with("_fp8_bf8") ||
@@ -99,9 +101,9 @@ inline constexpr std::array<std::string_view, 18> kExactB0ToA0TranslationMnemoni
 
   // A0 trap/CWSR recovery requires every low-precision F8F6F4 WMMA to carry its
   // load-scale prefix, even when the requested scale is 1.0. Standalone input
-  // is therefore wrapped with inline-zero neutral E8M0 scales. Scale16,
-  // regular Scale, and B0-only M=32 forms have separate encoding and
-  // scale-source translations.
+  // is therefore wrapped with inline-zero neutral E8M0 scales. Native M=16
+  // Scale16 is retained with its unused prefix field normalized. B0-only M=32
+  // scaled forms split into two native M=16 operations.
   if (mnemonic == "v_wmma_f32_16x16x128_f8f6f4" || mnemonic.starts_with("v_wmma_scale"))
     return true;
 
@@ -117,9 +119,10 @@ inline constexpr std::array<std::string_view, 18> kExactB0ToA0TranslationMnemoni
   // opcode field. They therefore stay on the same-stepping byte-copy path.
 
   // The A0 co-execution distance exceeds B0 only for integer IU8/IU4 WMMA or
-  // SWMMAC. FP16/BF16 need four spacing slots on both steppings, while floating
-  // FP8 forms need no additional A0 padding. The integer forms remain
-  // fail-closed until a CFG-aware spacing pass can inspect following VALU.
+  // SWMMAC. FP16/BF16 need four spacing slots on both revisions, while floating
+  // FP8 forms need no additional A0 padding. The implemented long-K IU8 forms
+  // use conservative fixed padding; other integer forms fail closed pending a
+  // CFG-aware spacing pass that can inspect following instructions.
   const bool is_wmma_like = mnemonic.starts_with("v_wmma_") || mnemonic.starts_with("v_swmmac_");
   return is_wmma_like && (mnemonic.find("_iu8") != std::string_view::npos ||
                           mnemonic.find("_iu4") != std::string_view::npos);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -89,8 +89,8 @@ inline constexpr std::array<std::string_view, 18> kExactB0ToA0TranslationMnemoni
 
   // The eight K=128 FP8/BF8 forms and the standalone 32x16 FP4 WMMA exist on B0
   // but not A0, so they require semantic expansion. The common f32 K=128 forms
-  // use one neutral regular-Scale mixed-format operation; encodings with source
-  // OPSEL fields that do not map to that form retain the native K=64 split.
+  // use one neutral regular-Scale mixed-format operation. Source fields with no
+  // meaning for these opcodes are discarded while constructing the target.
   // The f16 and standalone 32x16 FP4 forms still fail closed.
   const bool is_k128_fp8_bf8 = (mnemonic.starts_with("v_wmma_f16_16x16x128_") ||
                                 mnemonic.starts_with("v_wmma_f32_16x16x128_")) &&

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -87,9 +87,9 @@ inline constexpr std::array<std::string_view, 18> kExactB0ToA0TranslationMnemoni
     return true;
 
   // The eight K=128 FP8/BF8 forms and the standalone 32x16 FP4 WMMA exist on B0
-  // but not A0, so they require semantic expansion. The f32 K=128 family has an
-  // exact neutral regular-Scale lowering; f16 and standalone 32x16 FP4 still fail
-  // closed in their semantic rules.
+  // but not A0, so they require semantic expansion. The f32 K=128 forms split
+  // into two native K=64 FP8/BF8 operations; f16 and standalone 32x16 FP4 still
+  // fail closed in their semantic rules.
   const bool is_k128_fp8_bf8 = (mnemonic.starts_with("v_wmma_f16_16x16x128_") ||
                                 mnemonic.starts_with("v_wmma_f32_16x16x128_")) &&
                                (mnemonic.ends_with("_fp8_fp8") || mnemonic.ends_with("_fp8_bf8") ||
@@ -106,10 +106,10 @@ inline constexpr std::array<std::string_view, 18> kExactB0ToA0TranslationMnemoni
     return true;
 
   // K=64 FP8/BF8 WMMA is present on A0 and retains its architectural encoding.
-  // It stays on the ordinary copy path. K=128 F8F6F4 is also present on A0, but
-  // the A0 profile uses its scaled wrapper in software-visible code. Semantic
-  // lowerings may still use it as the matrix body of that atomic four-DWORD
-  // wrapper.
+  // It stays on the ordinary copy path. It is distinct from the scale-capable
+  // K=128 F8F6F4 matrix body: only that body consumes an immediately preceding
+  // LD_SCALE. The A0 profile therefore wraps bare F8F6F4 input in the scaled
+  // four-DWORD form, while native K=64 FP8/BF8 remains unscaled.
   //
   // FP8/BF8 SWMMAC is present on both A0 and B0. Unlike dense K=128 WMMA,
   // the gfx1250 A0-to-B0 change table does not classify these sparse forms as

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -1064,9 +1064,9 @@ ExpandResult expand_gfx1250_bare_f8f6f4_wmma(const Instruction &inst, uint32_t, 
 /// reuse hints are cleared: the target instruction family differs, and a
 /// preceding source instruction may itself expand to more than one operation.
 ///
-/// The source opcode has no matrix-format or OPSEL modifiers. Those encoding
-/// fields are therefore ignored rather than copied into the target's format
-/// selectors. Matrix reuse hints are also deliberately cleared because the
+/// The source opcode does not encode matrix formats in OPSEL/OPSEL_HI. Rebuild
+/// the target format selectors from the source opcode rather than copying those
+/// fields. The defined matrix reuse hints are deliberately cleared because the
 /// target belongs to a different instruction family. Only the defined C
 /// absolute and negate bits are transferred.
 ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_t,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -46,6 +46,23 @@ constexpr uint16_t kWmmaScaleSrc2PrefixOp = 0x35;
 constexpr uint16_t kWmmaScale16PrefixOp = 0x3a;
 constexpr uint16_t kGfx1250InlineZero = 128;
 
+/// @brief Diagnose control fields that are invalid for floating-point WMMA.
+///
+/// @details CM in the matrix body and SCL_CM in a scale prefix are both
+/// required to be zero. Keep this validation at every floating-point WMMA
+/// entry point so malformed encodings cannot be copied or expanded.
+[[nodiscard]] const char *
+gfx1250_floating_wmma_control_error(const gfx1250::Vop3pMachineInst &matrix,
+                                    const gfx1250::Vop3pMachineInst *scale = nullptr) {
+  if (scale != nullptr && scale->clamp != 0)
+    return "Input is malformed, SCL_CM must be set to zero for scaled floating-point WMMA";
+  if (matrix.clamp != 0) {
+    return "Input is malformed, CLAMP \"must be set to zero\" for WMMA/SWMMAC producing "
+           "floating-point results";
+  }
+  return nullptr;
+}
+
 /// @brief Append a generated instruction's words to one replacement sequence.
 template <size_t N>
 void append_words(std::vector<uint32_t> &output, const std::array<uint32_t, N> &words) {
@@ -363,12 +380,12 @@ void set_word_field(uint32_t &word, uint32_t value, uint32_t shift, uint32_t wid
 ///
 /// gfx1250 B0 additionally introduces the M=32 FP4 form. A0 has the M=16
 /// F8F6F4 operation, so the profile translates M=32 into two independent
-/// halves. The scale layout assigns M=0..15 and M=16..31 to lanes 0..15 and
-/// 16..31 of the same
-/// A-scale VGPR; SCL_OPSEL selects the corresponding lane half. Matrix B and
-/// its scale are shared. D, A, and a VGPR C are sliced by eight dwords. Both
-/// replacement matrix-format fields are forced to FP4, and reuse promises are
-/// cleared because each half names a different A/D register range.
+/// halves. The first operation covers rows 0..15, and the second covers rows
+/// 16..31. SCL_OPSEL=0 and SCL_OPSEL=1 select the matching A-scale lanes
+/// 0..15 and 16..31. Matrix B and its scale are shared. D, A, and a VGPR C are
+/// sliced by eight dwords. Both replacement matrix-format fields are forced to
+/// FP4, and reuse promises are cleared because each half names a different A/D
+/// register range.
 ExpandResult expand_gfx1250_wmma_scale_src2(const Instruction &inst, uint32_t, uint64_t,
                                             std::span<const uint8_t>,
                                             const LivenessAnalysis &liveness, TranslationContext &,
@@ -383,6 +400,8 @@ ExpandResult expand_gfx1250_wmma_scale_src2(const Instruction &inst, uint32_t, u
   gfx1250::Vop3pMachineInst matrix{};
   std::memcpy(&scale, inst.raw_encoding(), sizeof(scale));
   std::memcpy(&matrix, inst.raw_encoding() + 2, sizeof(matrix));
+  if (const char *error = gfx1250_floating_wmma_control_error(matrix, &scale))
+    return ExpandResult::failed(error);
   if (matrix.op != gfx1250::kVWmmaF3232x16x128F4Vop3p) {
     std::vector<uint32_t> words(inst.raw_encoding(), inst.raw_encoding() + 4);
     // Instruction bits [58:50] occupy word 1 bits [26:18].
@@ -523,9 +542,10 @@ ExpandResult expand_gfx1250_wmma_32x16_f4(const Instruction &inst, uint32_t, uin
 ///
 /// The M=32 FP4 form is represented by two native M=16 Scale16 instructions.
 /// Matrix A, C, and D are sliced by eight dwords; matrix B and both Scale16
-/// sources are shared. SCL_OPSEL selects lanes 0..15 for rows 0..15 and lanes
-/// 16..31 for rows 16..31. This partitions independent output rows without
-/// introducing a new accumulation boundary along K.
+/// sources are shared. The first operation covers rows 0..15 using A-scale
+/// lanes 0..15, and the second covers rows 16..31 using A-scale lanes 16..31.
+/// This partitions independent output rows without introducing a new
+/// accumulation boundary along K.
 ExpandResult expand_gfx1250_wmma_scale16(const Instruction &inst, uint32_t, uint64_t,
                                          std::span<const uint8_t>, const LivenessAnalysis &liveness,
                                          TranslationContext &, const LaneLayout *,
@@ -548,8 +568,21 @@ ExpandResult expand_gfx1250_wmma_scale16(const Instruction &inst, uint32_t, uint
                                            matrix.op != gfx1250::kVWmmaF3232x16x128F4Vop3p)) {
     return ExpandResult::failed("gfx1250 Scale16 WMMA rule received an unsupported base opcode");
   }
+  if (const char *error = gfx1250_floating_wmma_control_error(matrix, &scale))
+    return ExpandResult::failed(error);
 
   constexpr uint16_t kVgprEncoding = 256;
+  const std::array<uint16_t, 2> encoded_scales = {static_cast<uint16_t>(scale.src0),
+                                                  static_cast<uint16_t>(scale.src1)};
+  for (const uint16_t encoded_scale : encoded_scales) {
+    if (encoded_scale < kVgprEncoding)
+      continue;
+    const uint16_t base = static_cast<uint16_t>(encoded_scale - kVgprEncoding);
+    if ((base & 1u) != 0 || base > 254u) {
+      return ExpandResult::failed(
+          "gfx1250 Scale16 VGPR scale sources must be even-aligned pairs in v0:v255");
+    }
+  }
   if (matrix.op == gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p) {
     std::vector<uint32_t> words(inst.raw_encoding(), inst.raw_encoding() + 4);
     set_word_field(words[1], kVgprEncoding, 18, 9);
@@ -584,8 +617,6 @@ ExpandResult expand_gfx1250_wmma_scale16(const Instruction &inst, uint32_t, uint
   const uint16_t upper_a = physical(*src0_bank, static_cast<uint16_t>(src0 + kHalfDwords));
   const uint16_t shared_b = physical(*src1_bank, src1);
   bool first_dst_overlaps_scale = false;
-  const std::array<uint16_t, 2> encoded_scales = {static_cast<uint16_t>(scale.src0),
-                                                  static_cast<uint16_t>(scale.src1)};
   for (const uint16_t encoded_scale : encoded_scales) {
     if (encoded_scale >= kVgprEncoding) {
       const uint16_t scale_base = static_cast<uint16_t>(encoded_scale - kVgprEncoding);
@@ -987,6 +1018,11 @@ ExpandResult expand_gfx1250_bare_f8f6f4_wmma(const Instruction &inst, uint32_t, 
         "gfx1250 bare F8F6F4 WMMA rule received an unsupported instruction");
   }
 
+  gfx1250::Vop3pMachineInst matrix{};
+  std::memcpy(&matrix, inst.raw_encoding(), sizeof(matrix));
+  if (const char *error = gfx1250_floating_wmma_control_error(matrix))
+    return ExpandResult::failed(error);
+
   std::vector<uint32_t> words;
   words.reserve(4);
   constexpr uint16_t kVgprEncoding = 256;
@@ -995,22 +1031,6 @@ ExpandResult expand_gfx1250_bare_f8f6f4_wmma(const Instruction &inst, uint32_t, 
                                                                     .src2 = kVgprEncoding}));
   words.insert(words.end(), inst.raw_encoding(), inst.raw_encoding() + 2);
   return ExpandResult::success(std::move(words));
-}
-
-/// @brief Return the K=64 replacement opcode for one B0 K=128 FP8/BF8 WMMA.
-[[nodiscard]] uint16_t gfx1250_k128_wmma_replacement(uint16_t opcode) {
-  switch (opcode) {
-  case gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p:
-    return gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p;
-  case gfx1250::kVWmmaF3216x16x128Fp8Bf8Vop3p:
-    return gfx1250::kVWmmaF3216x16x64Fp8Bf8Vop3p;
-  case gfx1250::kVWmmaF3216x16x128Bf8Fp8Vop3p:
-    return gfx1250::kVWmmaF3216x16x64Bf8Fp8Vop3p;
-  case gfx1250::kVWmmaF3216x16x128Bf8Bf8Vop3p:
-    return gfx1250::kVWmmaF3216x16x64Bf8Bf8Vop3p;
-  default:
-    return 0;
-  }
 }
 
 /// @brief Return the mixed-format selections for one f32 K=128 FP8/BF8 WMMA.
@@ -1044,15 +1064,15 @@ ExpandResult expand_gfx1250_bare_f8f6f4_wmma(const Instruction &inst, uint32_t, 
 /// reuse hints are cleared: the target instruction family differs, and a
 /// preceding source instruction may itself expand to more than one operation.
 ///
-/// The source family's OPSEL[1:0] fields do not have a proven mapping into the
-/// mixed-format matrix body: the detailed scaled encoding reserves prefix bit
-/// 12 and consumes the body OPSEL fields as matrix formats. If either source
-/// field is nonzero, retain the two-K=64 fallback. That fallback writes the
-/// first partial to a dead aligned tuple when VDST overlaps an upper A/B input.
-ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_t offset,
-                                      std::span<const uint8_t> source_text,
-                                      const LivenessAnalysis &liveness, TranslationContext &context,
-                                      const LaneLayout *, const LaneLayout *) {
+/// The source opcode has no matrix-format or OPSEL modifiers. Those encoding
+/// fields are therefore ignored rather than copied into the target's format
+/// selectors. Matrix reuse hints are also deliberately cleared because the
+/// target belongs to a different instruction family. Only the defined C
+/// absolute and negate bits are transferred.
+ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_t,
+                                      std::span<const uint8_t>, const LivenessAnalysis &,
+                                      TranslationContext &, const LaneLayout *,
+                                      const LaneLayout *) {
   switch (inst.opcode()) {
   case gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p:
   case gfx1250::kVWmmaF1616x16x128Fp8Bf8Vop3p:
@@ -1065,175 +1085,39 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
     break;
   }
 
-  const uint16_t replacement_opcode = gfx1250_k128_wmma_replacement(inst.opcode());
-  if (replacement_opcode == 0)
-    return ExpandResult::failed("gfx1250 K=128 WMMA rule received an unsupported opcode");
-
   uint8_t matrix_a_fmt = 0;
   uint8_t matrix_b_fmt = 0;
-  if (inst.size() == static_cast<int>(sizeof(gfx1250::Vop3pMachineInst)) &&
-      inst.raw_encoding() != nullptr &&
-      gfx1250_k128_wmma_formats(inst.opcode(), matrix_a_fmt, matrix_b_fmt)) {
-    gfx1250::Vop3pMachineInst source{};
-    std::memcpy(&source, inst.raw_encoding(), sizeof(source));
-    if (source.clamp != 0) {
-      return ExpandResult::failed(
-          "Input is malformed, CLAMP \"must be set to zero\" for WMMA/SWMMAC producing "
-          "floating-point results");
-    }
-    const bool has_mappable_opsel = (source.opsel & 0x3u) == 0 && source.opsel_hi == 0;
-    constexpr uint16_t kVgprEncoding = 256;
-    if (has_mappable_opsel && source.src0 >= kVgprEncoding && source.src1 >= kVgprEncoding) {
-      std::vector<uint32_t> words;
-      words.reserve(4);
-      append_words(words, gfx1250::build_vop3p(kWmmaScaleSrc2PrefixOp, {.src0 = kGfx1250InlineZero,
-                                                                        .src1 = kGfx1250InlineZero,
-                                                                        .src2 = kVgprEncoding}));
-      append_words(words, gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p,
-                                               {.vdst = static_cast<uint8_t>(source.vdst),
-                                                .neg_hi = static_cast<uint8_t>(source.neg_hi),
-                                                .opsel = matrix_a_fmt,
-                                                .clamp = static_cast<uint8_t>(source.clamp),
-                                                .src0 = static_cast<uint16_t>(source.src0),
-                                                .src1 = static_cast<uint16_t>(source.src1),
-                                                .src2 = static_cast<uint16_t>(source.src2),
-                                                .opsel_hi = matrix_b_fmt,
-                                                .neg = static_cast<uint8_t>(source.neg)}));
-      return ExpandResult::success(std::move(words));
-    }
-  }
-
-  const auto dst_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Dst);
-  const auto src2_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src2);
-  if (!dst_bank || !src2_bank) {
-    return ExpandResult::failed(
-        "gfx1250 K=128 WMMA split cannot prove VDST and SRC2 VGPR-MSB banks",
-        {"Make the VGPR-MSB fields known on every CFG path reaching this instruction."});
-  }
-  if (offset > source_text.size() ||
-      static_cast<size_t>(inst.size()) > source_text.size() - offset ||
-      inst.size() < static_cast<int>(sizeof(gfx1250::Vop3pMachineInst))) {
+  if (inst.size() != static_cast<int>(sizeof(gfx1250::Vop3pMachineInst)) ||
+      inst.raw_encoding() == nullptr) {
     return ExpandResult::failed("gfx1250 K=128 WMMA has no complete source encoding");
   }
+  if (!gfx1250_k128_wmma_formats(inst.opcode(), matrix_a_fmt, matrix_b_fmt))
+    return ExpandResult::failed("gfx1250 K=128 WMMA rule received an unsupported opcode");
 
-  const size_t source_word_count = static_cast<size_t>(inst.size()) / sizeof(uint32_t);
-  std::vector<uint32_t> first(source_word_count);
-  std::memcpy(first.data(), source_text.data() + offset, static_cast<size_t>(inst.size()));
-  std::array<uint32_t, 2> second = {first[0], first[1]};
+  gfx1250::Vop3pMachineInst source{};
+  std::memcpy(&source, inst.raw_encoding(), sizeof(source));
+  if (const char *error = gfx1250_floating_wmma_control_error(source))
+    return ExpandResult::failed(error);
 
-  set_word_field(first[0], replacement_opcode, 16, 8);
-  first[0] &= ~((uint32_t{1} << 13) | (uint32_t{1} << 14));
-  set_word_field(second[0], replacement_opcode, 16, 8);
-  second[0] &= ~((uint32_t{1} << 13) | (uint32_t{1} << 14));
-
-  const uint16_t src0 = static_cast<uint16_t>(first[1] & 0x1ffu);
-  const uint16_t src1 = static_cast<uint16_t>((first[1] >> 9) & 0x1ffu);
   constexpr uint16_t kVgprEncoding = 256;
-  constexpr uint16_t kHalfInputDwords = 8;
-  if (src0 < kVgprEncoding || src1 < kVgprEncoding) {
+  if (source.src0 < kVgprEncoding || source.src1 < kVgprEncoding) {
     return ExpandResult::failed("gfx1250 K=128 WMMA matrix operands are not ordinary VGPR ranges");
   }
 
-  const uint16_t src0_low = static_cast<uint16_t>(src0 - kVgprEncoding);
-  const uint16_t src1_low = static_cast<uint16_t>(src1 - kVgprEncoding);
-  const auto src0_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src0);
-  const auto src1_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src1);
-  if (!src0_bank || !src1_bank) {
-    return ExpandResult::failed(
-        "gfx1250 K=128 WMMA split cannot prove A/B VGPR-MSB banks",
-        {"Make the VGPR-MSB fields known on every CFG path reaching this instruction."});
-  }
-
-  const auto overlaps = [](uint16_t lhs, uint16_t lhs_count, uint16_t rhs, uint16_t rhs_count) {
-    return lhs < static_cast<uint32_t>(rhs) + rhs_count &&
-           rhs < static_cast<uint32_t>(lhs) + lhs_count;
-  };
-  const uint16_t physical_dst =
-      static_cast<uint16_t>(*dst_bank * 256u + static_cast<uint16_t>(first[0] & 0xffu));
-  const uint16_t dst_dwords =
-      inst.dst_operand(0) != nullptr ? inst.dst_operand(0)->vgpr_count() : kHalfInputDwords;
-  const uint16_t physical_upper_a =
-      static_cast<uint16_t>(*src0_bank * 256u + src0_low + kHalfInputDwords);
-  const uint16_t physical_upper_b =
-      static_cast<uint16_t>(*src1_bank * 256u + src1_low + kHalfInputDwords);
-  const bool needs_partial_accumulator_scratch =
-      overlaps(physical_dst, dst_dwords, physical_upper_a, kHalfInputDwords) ||
-      overlaps(physical_dst, dst_dwords, physical_upper_b, kHalfInputDwords);
-
-  std::optional<SemanticScratchLease> partial_accumulator_scratch;
-  if (needs_partial_accumulator_scratch) {
-    SemanticScratchAllocator allocator(
-        inst, liveness, context,
-        SemanticScratchPolicy{.max_vgprs = static_cast<uint16_t>(REGISTER_SET_MAX_VGPRS),
-                              .max_spill_dword_offset = 0});
-    SemanticScratchRequest request;
-    request.count = dst_dwords;
-    request.alignment = dst_dwords;
-    request.allow_spill = false;
-    const auto forbid = [&](uint16_t base, uint16_t count) {
-      request.forbidden.expand(RegisterRef{RegClass::VGPR, base, static_cast<uint8_t>(count)});
-    };
-    forbid(physical_dst, dst_dwords);
-    forbid(static_cast<uint16_t>(*src0_bank * 256u + src0_low), 2 * kHalfInputDwords);
-    forbid(static_cast<uint16_t>(*src1_bank * 256u + src1_low), 2 * kHalfInputDwords);
-    const uint16_t encoded_src2 = static_cast<uint16_t>((first[1] >> 18) & 0x1ffu);
-    if (encoded_src2 >= kVgprEncoding) {
-      forbid(static_cast<uint16_t>(*src2_bank * 256u + encoded_src2 - kVgprEncoding), dst_dwords);
-    }
-
-    const SemanticScratchResult scratch = allocator.acquire_vgprs(request);
-    if (!scratch) {
-      return ExpandResult::failed(
-          "gfx1250 K=128 WMMA could not allocate a partial accumulator",
-          {"Provide one aligned dead VGPR tuple matching the WMMA destination width."});
-    }
-    partial_accumulator_scratch = *scratch.lease;
-  }
-
-  const bool src0_crosses_bank = static_cast<uint32_t>(src0_low) + kHalfInputDwords > 0xffu;
-  const bool src1_crosses_bank = static_cast<uint32_t>(src1_low) + kHalfInputDwords > 0xffu;
-  if ((src0_crosses_bank && *src0_bank == 3) || (src1_crosses_bank && *src1_bank == 3)) {
-    return ExpandResult::failed(
-        "gfx1250 K=128 WMMA bank-crossing input exceeds the addressable VGPR range");
-  }
-
-  const uint8_t original_mode =
-      static_cast<uint8_t>(*src0_bank | (*src1_bank << 2) | (*src2_bank << 4) | (*dst_bank << 6));
-  const uint16_t second_src0 =
-      static_cast<uint16_t>(*src0_bank * 256u + src0_low + kHalfInputDwords);
-  const uint16_t second_src1 =
-      static_cast<uint16_t>(*src1_bank * 256u + src1_low + kHalfInputDwords);
-
-  // The gfx1250 dependency table requires software spacing only when the first
-  // Matrix D overlaps the following WMMA's A/B/Index inputs. The ordinary path
-  // proves that no such overlap exists, and the scratch path forbids its
-  // partial tuple from every A/B window. Matrix D feeding Matrix C through
-  // SRC2 is interlocked, so no V_NOP is inserted between the two K64 WMMAs.
-  uint16_t partial_accumulator = physical_dst;
-  if (partial_accumulator_scratch) {
-    partial_accumulator = partial_accumulator_scratch->base;
-    set_word_field(first[0], partial_accumulator & 0xffu, 0, 8);
-  }
-
-  set_word_field(second[1], kVgprEncoding + (second_src0 & 0xffu), 0, 9);
-  set_word_field(second[1], kVgprEncoding + (second_src1 & 0xffu), 9, 9);
-  set_word_field(second[1], kVgprEncoding + (partial_accumulator & 0xffu), 18, 9);
-  second[0] &= ~(uint32_t{1} << 10);
-  second[1] &= ~(uint32_t{1} << 31);
-
-  const uint8_t partial_bank = static_cast<uint8_t>(partial_accumulator / 256u);
-  const uint8_t first_mode = static_cast<uint8_t>((original_mode & 0x3fu) | (partial_bank << 6));
-  const uint8_t second_mode = static_cast<uint8_t>(
-      (second_src0 / 256u) | ((second_src1 / 256u) << 2) | (partial_bank << 4) | (*dst_bank << 6));
-
   std::vector<uint32_t> words;
-  words.reserve(first.size() + second.size() + 9);
-  uint8_t current_mode = original_mode;
-  append_gfx1250_vgpr_msb_transition(words, current_mode, first_mode);
-  words.insert(words.end(), first.begin(), first.end());
-  append_gfx1250_vgpr_msb_transition(words, current_mode, second_mode);
-  append_words(words, second);
-  append_gfx1250_vgpr_msb_transition(words, current_mode, original_mode);
+  words.reserve(4);
+  append_words(words, gfx1250::build_vop3p(kWmmaScaleSrc2PrefixOp, {.src0 = kGfx1250InlineZero,
+                                                                    .src1 = kGfx1250InlineZero,
+                                                                    .src2 = kVgprEncoding}));
+  append_words(words, gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p,
+                                           {.vdst = static_cast<uint8_t>(source.vdst),
+                                            .neg_hi = static_cast<uint8_t>(source.neg_hi & 0x4u),
+                                            .opsel = matrix_a_fmt,
+                                            .src0 = static_cast<uint16_t>(source.src0),
+                                            .src1 = static_cast<uint16_t>(source.src1),
+                                            .src2 = static_cast<uint16_t>(source.src2),
+                                            .opsel_hi = matrix_b_fmt,
+                                            .neg = static_cast<uint8_t>(source.neg & 0x4u)}));
   return ExpandResult::success(std::move(words));
 }
 
@@ -1254,13 +1138,13 @@ inline constexpr std::array<TranslationRule, 38> kGfx1250B0ToA0ExpandRules = {{
     {gfx1250::encoding::kVop3p, gfx1250::kVSwmmacI3216x16x128Iu8Vop3p, RuleAction::Expand, 0, 0,
      nullptr, expand_gfx1250_wmma_iu8_spacing, nullptr, nullptr, false},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p, RuleAction::Expand, 0,
-     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr},
+     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr, false},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF3216x16x128Fp8Bf8Vop3p, RuleAction::Expand, 0,
-     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr},
+     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr, false},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF3216x16x128Bf8Fp8Vop3p, RuleAction::Expand, 0,
-     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr},
+     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr, false},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF3216x16x128Bf8Bf8Vop3p, RuleAction::Expand, 0,
-     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr},
+     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr, false},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p, RuleAction::Expand, 0,
      0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr, false},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF1616x16x128Fp8Bf8Vop3p, RuleAction::Expand, 0,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -315,7 +315,6 @@ ExpandResult expand_gfx1250_tensor_load_to_lds(const Instruction &inst, uint32_t
     return ExpandResult::failed(
         "gfx1250 tensor-load mask rule received an unsupported instruction");
   }
-
   gfx1250::VimageMachineInst source{};
   std::memcpy(&source, inst.raw_encoding(), sizeof(source));
   constexpr uint8_t kLastOrdinarySgpr = 105;
@@ -390,7 +389,6 @@ ExpandResult expand_gfx1250_wmma_scale_src2(const Instruction &inst, uint32_t, u
     set_word_field(words[1], 0x100, 18, 9);
     return ExpandResult::success(std::move(words));
   }
-
   constexpr uint16_t kVgprEncoding = 256;
   constexpr uint16_t kHalfDwords = 8;
   if (matrix.src0 < kVgprEncoding || matrix.src1 < kVgprEncoding) {
@@ -422,8 +420,8 @@ ExpandResult expand_gfx1250_wmma_scale_src2(const Instruction &inst, uint32_t, u
   const uint16_t upper_a = physical(*src0_bank, static_cast<uint16_t>(src0 + kHalfDwords));
   const uint16_t shared_b = physical(*src1_bank, src1);
   bool first_dst_overlaps_scale = false;
-  const std::array<uint16_t, 2> encoded_scales = {
-      static_cast<uint16_t>(scale.src0), static_cast<uint16_t>(scale.src1)};
+  const std::array<uint16_t, 2> encoded_scales = {static_cast<uint16_t>(scale.src0),
+                                                  static_cast<uint16_t>(scale.src1)};
   for (const uint16_t encoded_scale : encoded_scales) {
     if (encoded_scale >= kVgprEncoding) {
       const uint16_t scale_base = static_cast<uint16_t>(encoded_scale - kVgprEncoding);
@@ -431,8 +429,7 @@ ExpandResult expand_gfx1250_wmma_scale_src2(const Instruction &inst, uint32_t, u
     }
   }
   if (overlaps(first_dst, kHalfDwords, upper_a, kHalfDwords) ||
-      overlaps(first_dst, kHalfDwords, shared_b, kHalfDwords) ||
-      first_dst_overlaps_scale ||
+      overlaps(first_dst, kHalfDwords, shared_b, kHalfDwords) || first_dst_overlaps_scale ||
       (src2_is_vgpr &&
        overlaps(first_dst, kHalfDwords,
                 physical(*src2_bank, static_cast<uint16_t>(src2 + kHalfDwords)), kHalfDwords))) {
@@ -573,8 +570,7 @@ ExpandResult expand_gfx1250_wmma_scale16(const Instruction &inst, uint32_t, uint
   const auto src2_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src2);
   const auto dst_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Dst);
   if (!src0_bank || !src1_bank || !src2_bank || !dst_bank) {
-    return ExpandResult::failed(
-        "gfx1250 Scale16 32x16 FP4 split cannot prove the VGPR-MSB mode");
+    return ExpandResult::failed("gfx1250 Scale16 32x16 FP4 split cannot prove the VGPR-MSB mode");
   }
 
   const auto physical = [](uint8_t bank, uint16_t reg) {
@@ -588,8 +584,8 @@ ExpandResult expand_gfx1250_wmma_scale16(const Instruction &inst, uint32_t, uint
   const uint16_t upper_a = physical(*src0_bank, static_cast<uint16_t>(src0 + kHalfDwords));
   const uint16_t shared_b = physical(*src1_bank, src1);
   bool first_dst_overlaps_scale = false;
-  const std::array<uint16_t, 2> encoded_scales = {
-      static_cast<uint16_t>(scale.src0), static_cast<uint16_t>(scale.src1)};
+  const std::array<uint16_t, 2> encoded_scales = {static_cast<uint16_t>(scale.src0),
+                                                  static_cast<uint16_t>(scale.src1)};
   for (const uint16_t encoded_scale : encoded_scales) {
     if (encoded_scale >= kVgprEncoding) {
       const uint16_t scale_base = static_cast<uint16_t>(encoded_scale - kVgprEncoding);
@@ -597,8 +593,7 @@ ExpandResult expand_gfx1250_wmma_scale16(const Instruction &inst, uint32_t, uint
     }
   }
   if (overlaps(first_dst, kHalfDwords, upper_a, kHalfDwords) ||
-      overlaps(first_dst, kHalfDwords, shared_b, kHalfDwords) ||
-      first_dst_overlaps_scale ||
+      overlaps(first_dst, kHalfDwords, shared_b, kHalfDwords) || first_dst_overlaps_scale ||
       (src2_is_vgpr &&
        overlaps(first_dst, kHalfDwords,
                 physical(*src2_bank, static_cast<uint16_t>(src2 + kHalfDwords)), kHalfDwords))) {
@@ -611,8 +606,7 @@ ExpandResult expand_gfx1250_wmma_scale16(const Instruction &inst, uint32_t, uint
   const bool src2_crosses = src2_is_vgpr && static_cast<uint32_t>(src2) + kHalfDwords > 0xffu;
   if ((src0_crosses && *src0_bank == 3) || (dst_crosses && *dst_bank == 3) ||
       (src2_crosses && *src2_bank == 3)) {
-    return ExpandResult::failed(
-        "gfx1250 Scale16 32x16 FP4 split exceeds the VGPR address space");
+    return ExpandResult::failed("gfx1250 Scale16 32x16 FP4 split exceeds the VGPR address space");
   }
 
   const uint8_t original_mode =
@@ -1082,30 +1076,29 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
       gfx1250_k128_wmma_formats(inst.opcode(), matrix_a_fmt, matrix_b_fmt)) {
     gfx1250::Vop3pMachineInst source{};
     std::memcpy(&source, inst.raw_encoding(), sizeof(source));
+    if (source.clamp != 0) {
+      return ExpandResult::failed(
+          "Input is malformed, CLAMP \"must be set to zero\" for WMMA/SWMMAC producing "
+          "floating-point results");
+    }
     const bool has_mappable_opsel = (source.opsel & 0x3u) == 0 && source.opsel_hi == 0;
     constexpr uint16_t kVgprEncoding = 256;
     if (has_mappable_opsel && source.src0 >= kVgprEncoding && source.src1 >= kVgprEncoding) {
       std::vector<uint32_t> words;
       words.reserve(4);
-      append_words(
-          words,
-          gfx1250::build_vop3p(
-              kWmmaScaleSrc2PrefixOp,
-              {.src0 = kGfx1250InlineZero,
-               .src1 = kGfx1250InlineZero,
-               .src2 = kVgprEncoding}));
-      append_words(words,
-                   gfx1250::build_vop3p(
-                       gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p,
-                       {.vdst = static_cast<uint8_t>(source.vdst),
-                        .neg_hi = static_cast<uint8_t>(source.neg_hi),
-                        .opsel = matrix_a_fmt,
-                        .clamp = static_cast<uint8_t>(source.clamp),
-                        .src0 = static_cast<uint16_t>(source.src0),
-                        .src1 = static_cast<uint16_t>(source.src1),
-                        .src2 = static_cast<uint16_t>(source.src2),
-                        .opsel_hi = matrix_b_fmt,
-                        .neg = static_cast<uint8_t>(source.neg)}));
+      append_words(words, gfx1250::build_vop3p(kWmmaScaleSrc2PrefixOp, {.src0 = kGfx1250InlineZero,
+                                                                        .src1 = kGfx1250InlineZero,
+                                                                        .src2 = kVgprEncoding}));
+      append_words(words, gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p,
+                                               {.vdst = static_cast<uint8_t>(source.vdst),
+                                                .neg_hi = static_cast<uint8_t>(source.neg_hi),
+                                                .opsel = matrix_a_fmt,
+                                                .clamp = static_cast<uint8_t>(source.clamp),
+                                                .src0 = static_cast<uint16_t>(source.src0),
+                                                .src1 = static_cast<uint16_t>(source.src1),
+                                                .src2 = static_cast<uint16_t>(source.src2),
+                                                .opsel_hi = matrix_b_fmt,
+                                                .neg = static_cast<uint8_t>(source.neg)}));
       return ExpandResult::success(std::move(words));
     }
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -37,14 +37,14 @@ constexpr uint8_t kGfx1250M0 = 125;
 
 /// @brief VOP3P opcode of the WMMA-scale prefix half of a scaled-WMMA pair.
 /// @details The scale prefix that fuses with a following WMMA is not a standalone
-/// named VOP3P op in the generated opcode table (it is a structural VOP3PX2/PX3
-/// prefix), so its opcode is named here rather than pulled from gfx1250 opcodes.
+/// named VOP3P op in the generated opcode table (it is the first half of a
+/// structural VOP3PX2 instruction), so its opcode is named here rather than
+/// pulled from gfx1250 opcodes.
 /// kWmmaScaleSrc2PrefixOp is the VOP3PX2 scale-src2 prefix; kWmmaScale16PrefixOp
-/// is the VOP3PX3 Scale16 prefix.
+/// is the VOP3PX2 Scale16 prefix.
 constexpr uint16_t kWmmaScaleSrc2PrefixOp = 0x35;
 constexpr uint16_t kWmmaScale16PrefixOp = 0x3a;
 constexpr uint16_t kGfx1250InlineZero = 128;
-constexpr uint32_t kGfx1250ScratchMaxDwordOffset = 0x7ffffcu;
 
 /// @brief Append a generated instruction's words to one replacement sequence.
 template <size_t N>
@@ -81,40 +81,6 @@ void append_gfx1250_vgpr_msb_transition(std::vector<uint32_t> &words, uint8_t &c
       static_cast<uint16_t>(new_mode) | (static_cast<uint16_t>(current_mode) << 8);
   append_words(words, gfx1250::build_sopp(gfx1250::kSSetVgprMsbSopp, {.simm16 = immediate}));
   current_mode = new_mode;
-}
-
-/// @brief Save or restore one spill-backed low-bank VGPR lease through scratch ST mode.
-///
-/// @details VSCRATCH ST mode uses NULL SADDR, SVE=0, and a signed 24-bit
-/// immediate. Semantic spill storage is non-negative and dword aligned, so the
-/// largest usable dword offset is 0x7ffffc. The caller selects VGPR-MSB mode
-/// zero before using this helper.
-[[nodiscard]] bool append_gfx1250_scratch_preservation(std::vector<uint32_t> &words,
-                                                       const SemanticScratchLease &lease,
-                                                       bool restore) {
-  if (!lease.spilled)
-    return true;
-  if (lease.reg_class != RegClass::VGPR || lease.count == 0 ||
-      static_cast<uint32_t>(lease.base) + lease.count > 256u ||
-      lease.spill_offset + (static_cast<uint32_t>(lease.count) - 1u) * sizeof(uint32_t) >
-          kGfx1250ScratchMaxDwordOffset) {
-    return false;
-  }
-
-  for (uint16_t i = 0; i < lease.count; ++i) {
-    const uint8_t vgpr = static_cast<uint8_t>(lease.base + i);
-    const uint32_t byte_offset = lease.spill_offset + static_cast<uint32_t>(i) * sizeof(uint32_t);
-    append_words(words, gfx1250::build_vscratch(restore ? gfx1250::kScratchLoadB32Vscratch
-                                                        : gfx1250::kScratchStoreB32Vscratch,
-                                                {.saddr = kGfx1250Null,
-                                                 .vdst = restore ? vgpr : uint8_t{0},
-                                                 .vsrc = restore ? uint8_t{0} : vgpr,
-                                                 .ioffset = byte_offset}));
-  }
-  append_words(
-      words, gfx1250::build_sopp(restore ? gfx1250::kSWaitLoadcntSopp : gfx1250::kSWaitStorecntSopp,
-                                 {.simm16 = 0}));
-  return true;
 }
 
 /// @brief Conservatively remove one hard-clause scheduling directive.
@@ -427,15 +393,13 @@ ExpandResult expand_gfx1250_wmma_scale_src2(const Instruction &inst, uint32_t, u
 
   constexpr uint16_t kVgprEncoding = 256;
   constexpr uint16_t kHalfDwords = 8;
-  if (scale.src0 < kVgprEncoding || scale.src1 < kVgprEncoding || matrix.src0 < kVgprEncoding ||
-      matrix.src1 < kVgprEncoding) {
-    return ExpandResult::failed("gfx1250 regular-Scale 32x16 FP4 operands are not VGPR ranges");
+  if (matrix.src0 < kVgprEncoding || matrix.src1 < kVgprEncoding) {
+    return ExpandResult::failed(
+        "gfx1250 regular-Scale 32x16 FP4 matrix inputs are not VGPR ranges");
   }
-  const bool src2_is_vgpr = matrix.src2 >= kVgprEncoding;
-  const uint16_t scale_src0 = static_cast<uint16_t>(scale.src0 - kVgprEncoding);
-  const uint16_t scale_src1 = static_cast<uint16_t>(scale.src1 - kVgprEncoding);
   const uint16_t src0 = static_cast<uint16_t>(matrix.src0 - kVgprEncoding);
   const uint16_t src1 = static_cast<uint16_t>(matrix.src1 - kVgprEncoding);
+  const bool src2_is_vgpr = matrix.src2 >= kVgprEncoding;
   const uint16_t src2 = src2_is_vgpr ? static_cast<uint16_t>(matrix.src2 - kVgprEncoding) : 0;
 
   const auto src0_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src0);
@@ -457,10 +421,18 @@ ExpandResult expand_gfx1250_wmma_scale_src2(const Instruction &inst, uint32_t, u
   const uint16_t first_dst = physical(*dst_bank, matrix.vdst);
   const uint16_t upper_a = physical(*src0_bank, static_cast<uint16_t>(src0 + kHalfDwords));
   const uint16_t shared_b = physical(*src1_bank, src1);
+  bool first_dst_overlaps_scale = false;
+  const std::array<uint16_t, 2> encoded_scales = {
+      static_cast<uint16_t>(scale.src0), static_cast<uint16_t>(scale.src1)};
+  for (const uint16_t encoded_scale : encoded_scales) {
+    if (encoded_scale >= kVgprEncoding) {
+      const uint16_t scale_base = static_cast<uint16_t>(encoded_scale - kVgprEncoding);
+      first_dst_overlaps_scale |= overlaps(first_dst, kHalfDwords, scale_base, 1);
+    }
+  }
   if (overlaps(first_dst, kHalfDwords, upper_a, kHalfDwords) ||
       overlaps(first_dst, kHalfDwords, shared_b, kHalfDwords) ||
-      overlaps(first_dst, kHalfDwords, physical(0, scale_src0), 1) ||
-      overlaps(first_dst, kHalfDwords, physical(0, scale_src1), 1) ||
+      first_dst_overlaps_scale ||
       (src2_is_vgpr &&
        overlaps(first_dst, kHalfDwords,
                 physical(*src2_bank, static_cast<uint16_t>(src2 + kHalfDwords)), kHalfDwords))) {
@@ -546,65 +518,29 @@ ExpandResult expand_gfx1250_wmma_32x16_f4(const Instruction &inst, uint32_t, uin
   return static_cast<uint16_t>(256u + vgpr);
 }
 
-/// @brief Gather either the even or odd bytes of one B64 Scale16 operand.
+/// @brief Preserve M=16 Scale16 and split the B0 M=32 FP4 form across M for A0.
 ///
-/// @details Scale16 stores eight block-16 exponent bytes in two VGPRs. A0
-/// regular Scale consumes four block-32 bytes. A scale-preserving lowering
-/// therefore executes two WMMAs: the low-K pass gathers bytes 0,2,4,6 and the
-/// high-K pass gathers bytes 1,3,5,7. Combining adjacent bytes (for example
-/// with max) is not equivalent because each scale applies to different matrix
-/// data.
-void append_gfx1250_scale16_gather(std::vector<uint32_t> &words, uint16_t src_lo, uint16_t dst,
-                                   uint16_t temp, bool odd) {
-  const auto vgpr = gfx1250_vgpr_src;
-  const auto bfe = [&](uint16_t out, uint16_t src, uint16_t bit) {
-    append_words(words,
-                 gfx1250::build_vop3(gfx1250::kVBfeU32Vop3, {.vdst = static_cast<uint8_t>(out),
-                                                             .src0 = vgpr(src),
-                                                             .src1 = gfx1250_inline_u32(bit),
-                                                             .src2 = gfx1250_inline_u32(8)}));
-  };
-  const auto insert = [&](uint16_t value, uint16_t shift) {
-    append_words(words,
-                 gfx1250::build_vop3(gfx1250::kVLshlOrB32Vop3, {.vdst = static_cast<uint8_t>(dst),
-                                                                .src0 = vgpr(value),
-                                                                .src1 = gfx1250_inline_u32(shift),
-                                                                .src2 = vgpr(dst)}));
-  };
-
-  const uint16_t first_bit = odd ? 8 : 0;
-  bfe(dst, src_lo, first_bit);
-  bfe(temp, src_lo, static_cast<uint16_t>(first_bit + 16));
-  insert(temp, 8);
-  bfe(temp, static_cast<uint16_t>(src_lo + 1u), first_bit);
-  insert(temp, 16);
-  bfe(temp, static_cast<uint16_t>(src_lo + 1u), static_cast<uint16_t>(first_bit + 16));
-  insert(temp, 24);
-}
-
-/// @brief Convert B0 Scale16 WMMA to A0 regular-Scale WMMAs.
+/// @details The M=16 Scale16 instruction is available on both revisions, so its
+/// four-DWORD encoding is retained except for the required VGPR0 encoding in
+/// the scale prefix's unused SRC2 field.
 ///
-/// @details The two passes consume the even and odd Scale16 bytes and mutually
-/// exclusive K=16 portions of matrix A. Their results accumulate through D.
-/// The B0-only 32x16 FP4 form additionally splits M into two 16-row halves,
-/// producing four passes. On gfx1250, lanes 0..15 and
-/// 16..31 of the same A-scale pair correspond to those two M halves; the
-/// replacement regular-Scale prefix selects the half with SCL_OPSEL. Each M
-/// half slices eight VGPRs from A, C, and D while sharing B. This preserves the
-/// scale-to-submatrix mapping; the revisions retain their documented native
-/// intermediate-accumulator precision.
+/// The M=32 FP4 form is represented by two native M=16 Scale16 instructions.
+/// Matrix A, C, and D are sliced by eight dwords; matrix B and both Scale16
+/// sources are shared. SCL_OPSEL selects lanes 0..15 for rows 0..15 and lanes
+/// 16..31 for rows 16..31. This partitions independent output rows without
+/// introducing a new accumulation boundary along K.
 ExpandResult expand_gfx1250_wmma_scale16(const Instruction &inst, uint32_t, uint64_t,
                                          std::span<const uint8_t>, const LivenessAnalysis &liveness,
-                                         TranslationContext &context, const LaneLayout *,
+                                         TranslationContext &, const LaneLayout *,
                                          const LaneLayout *) {
-  // The prefix opcode shares its structural lookup key with ordinary VOP3
+  // The prefix opcode shares its structural lookup key with ordinary VOP3P
   // instructions. Decline those collisions so their own legalization can
-  // report an unimplemented expansion instead of a misleading Scale16 error.
+  // diagnose them instead of reporting a misleading Scale16 error.
   if (!inst.mnemonic().starts_with("v_wmma_scale16_f32_"))
     return ExpandResult::not_handled();
   if (inst.size() != 4 * static_cast<int>(sizeof(uint32_t)) || inst.raw_encoding() == nullptr) {
     return ExpandResult::failed(
-        "gfx1250 Scale16 WMMA rule received an unsupported VOP3PX3 instruction");
+        "gfx1250 Scale16 WMMA rule received an unsupported VOP3PX2 instruction");
   }
 
   gfx1250::Vop3pMachineInst scale{};
@@ -617,279 +553,105 @@ ExpandResult expand_gfx1250_wmma_scale16(const Instruction &inst, uint32_t, uint
   }
 
   constexpr uint16_t kVgprEncoding = 256;
-  if (scale.src0 < kVgprEncoding || scale.src1 < kVgprEncoding) {
-    return ExpandResult::failed("gfx1250 Scale16 WMMA scale operands are not VGPR pairs");
-  }
-  const uint16_t scale_a = static_cast<uint16_t>(scale.src0 - kVgprEncoding);
-  const uint16_t scale_b = static_cast<uint16_t>(scale.src1 - kVgprEncoding);
-  if (scale_a >= 255 || scale_b >= 255) {
-    return ExpandResult::failed("gfx1250 Scale16 WMMA scale pair crosses the low VGPR bank");
-  }
-  if ((scale_a & 1u) != 0 || (scale_b & 1u) != 0) {
-    return ExpandResult::failed(
-        "gfx1250 Scale16 WMMA scale pair is not even-aligned as required by the ISA");
+  if (matrix.op == gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p) {
+    std::vector<uint32_t> words(inst.raw_encoding(), inst.raw_encoding() + 4);
+    set_word_field(words[1], kVgprEncoding, 18, 9);
+    return ExpandResult::success(std::move(words));
   }
 
-  if (matrix.src0 < kVgprEncoding || matrix.src1 < kVgprEncoding) {
-    return ExpandResult::failed("gfx1250 Scale16 WMMA matrix inputs are not VGPR ranges");
-  }
-  const uint16_t matrix_a = static_cast<uint16_t>(matrix.src0 - kVgprEncoding);
-  const uint16_t matrix_b = static_cast<uint16_t>(matrix.src1 - kVgprEncoding);
-  const bool is_m32 = matrix.op == gfx1250::kVWmmaF3232x16x128F4Vop3p;
+  if (matrix.src0 < kVgprEncoding || matrix.src1 < kVgprEncoding)
+    return ExpandResult::failed("gfx1250 Scale16 32x16 FP4 matrix inputs are not VGPR ranges");
 
-  const uint8_t matrix_a_fmt = is_m32 ? 4u : static_cast<uint8_t>(matrix.opsel);
-  const uint8_t matrix_b_fmt =
-      is_m32 ? 4u : static_cast<uint8_t>((matrix.pad_14 != 0 ? 4u : 0u) | matrix.opsel_hi);
-  const auto matrix_width = [](uint8_t fmt) -> uint16_t {
-    if (fmt <= 1)
-      return 16; // FP8/BF8: K subblocks are selected by lane.
-    if (fmt <= 3)
-      return 12; // FP6/BF6: three VGPRs per K=16 subblock.
-    if (fmt == 4)
-      return 8; // FP4: two VGPRs per K=16 subblock.
-    return 0;
-  };
-  const uint16_t matrix_a_width = matrix_width(matrix_a_fmt);
-  const uint16_t matrix_a_total_width = static_cast<uint16_t>(matrix_a_width * (is_m32 ? 2u : 1u));
-  const uint16_t matrix_b_width = matrix_width(matrix_b_fmt);
-  if (matrix_a_width == 0 || matrix_b_width == 0) {
-    return ExpandResult::failed("gfx1250 Scale16 WMMA has an unknown matrix format");
-  }
-  // gfx1250 permits one VALU co-execution slot for an F8F6F4 WMMA only when
-  // both matrix inputs are FP4. Every other F8F6F4 combination permits three.
-  // Generated VALU that overwrites masked-A must cover the complete window.
-  const int wmma_valu_hazard_slots = matrix_a_fmt == 4u && matrix_b_fmt == 4u ? 1 : 3;
+  constexpr uint16_t kHalfDwords = 8;
+  const uint16_t src0 = static_cast<uint16_t>(matrix.src0 - kVgprEncoding);
+  const uint16_t src1 = static_cast<uint16_t>(matrix.src1 - kVgprEncoding);
+  const bool src2_is_vgpr = matrix.src2 >= kVgprEncoding;
+  const uint16_t src2 = src2_is_vgpr ? static_cast<uint16_t>(matrix.src2 - kVgprEncoding) : 0;
 
   const auto src0_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src0);
   const auto src1_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src1);
   const auto src2_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src2);
   const auto dst_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Dst);
   if (!src0_bank || !src1_bank || !src2_bank || !dst_bank) {
-    return ExpandResult::failed("gfx1250 Scale16 WMMA cannot prove the VGPR-MSB mode");
+    return ExpandResult::failed(
+        "gfx1250 Scale16 32x16 FP4 split cannot prove the VGPR-MSB mode");
   }
+
+  const auto physical = [](uint8_t bank, uint16_t reg) {
+    return static_cast<uint16_t>(bank * 256u + reg);
+  };
+  const auto overlaps = [](uint16_t lhs, uint16_t lhs_count, uint16_t rhs, uint16_t rhs_count) {
+    return lhs < static_cast<uint32_t>(rhs) + rhs_count &&
+           rhs < static_cast<uint32_t>(lhs) + lhs_count;
+  };
+  const uint16_t first_dst = physical(*dst_bank, matrix.vdst);
+  const uint16_t upper_a = physical(*src0_bank, static_cast<uint16_t>(src0 + kHalfDwords));
+  const uint16_t shared_b = physical(*src1_bank, src1);
+  bool first_dst_overlaps_scale = false;
+  const std::array<uint16_t, 2> encoded_scales = {
+      static_cast<uint16_t>(scale.src0), static_cast<uint16_t>(scale.src1)};
+  for (const uint16_t encoded_scale : encoded_scales) {
+    if (encoded_scale >= kVgprEncoding) {
+      const uint16_t scale_base = static_cast<uint16_t>(encoded_scale - kVgprEncoding);
+      first_dst_overlaps_scale |= overlaps(first_dst, kHalfDwords, scale_base, 2);
+    }
+  }
+  if (overlaps(first_dst, kHalfDwords, upper_a, kHalfDwords) ||
+      overlaps(first_dst, kHalfDwords, shared_b, kHalfDwords) ||
+      first_dst_overlaps_scale ||
+      (src2_is_vgpr &&
+       overlaps(first_dst, kHalfDwords,
+                physical(*src2_bank, static_cast<uint16_t>(src2 + kHalfDwords)), kHalfDwords))) {
+    return ExpandResult::failed(
+        "gfx1250 Scale16 32x16 lower destination overlaps an input needed by the upper half");
+  }
+
+  const bool dst_crosses = static_cast<uint32_t>(matrix.vdst) + kHalfDwords > 0xffu;
+  const bool src0_crosses = static_cast<uint32_t>(src0) + kHalfDwords > 0xffu;
+  const bool src2_crosses = src2_is_vgpr && static_cast<uint32_t>(src2) + kHalfDwords > 0xffu;
+  if ((src0_crosses && *src0_bank == 3) || (dst_crosses && *dst_bank == 3) ||
+      (src2_crosses && *src2_bank == 3)) {
+    return ExpandResult::failed(
+        "gfx1250 Scale16 32x16 FP4 split exceeds the VGPR address space");
+  }
+
   const uint8_t original_mode =
       static_cast<uint8_t>(*src0_bank | (*src1_bank << 2) | (*src2_bank << 4) | (*dst_bank << 6));
-  const uint32_t matrix_a_absolute = matrix_a + static_cast<uint32_t>(*src0_bank) * 256u;
-  const uint32_t matrix_b_absolute = matrix_b + static_cast<uint32_t>(*src1_bank) * 256u;
-  if (matrix_a_absolute + matrix_a_total_width > REGISTER_SET_MAX_VGPRS ||
-      matrix_b_absolute + matrix_b_width > REGISTER_SET_MAX_VGPRS) {
-    return ExpandResult::failed("gfx1250 Scale16 WMMA matrix range exceeds the VGPR file");
-  }
-
-  const uint16_t destination_dwords = static_cast<uint16_t>(is_m32 ? 16u : 8u);
-  const bool src2_is_vgpr = matrix.src2 >= kVgprEncoding;
-  const uint16_t matrix_c = src2_is_vgpr ? static_cast<uint16_t>(matrix.src2 - kVgprEncoding) : 0u;
-  const uint32_t matrix_c_absolute = matrix_c + static_cast<uint32_t>(*src2_bank) * 256u;
-  const uint32_t destination_absolute = matrix.vdst + static_cast<uint32_t>(*dst_bank) * 256u;
-
-  RegisterSet architectural_vgprs;
-  architectural_vgprs.expand(RegisterRef{RegClass::VGPR, scale_a, static_cast<uint8_t>(2)});
-  architectural_vgprs.expand(RegisterRef{RegClass::VGPR, scale_b, static_cast<uint8_t>(2)});
-  architectural_vgprs.expand(RegisterRef{RegClass::VGPR, static_cast<uint16_t>(matrix_a_absolute),
-                                         static_cast<uint8_t>(matrix_a_total_width)});
-  architectural_vgprs.expand(RegisterRef{RegClass::VGPR, static_cast<uint16_t>(matrix_b_absolute),
-                                         static_cast<uint8_t>(matrix_b_width)});
-  architectural_vgprs.expand(RegisterRef{RegClass::VGPR,
-                                         static_cast<uint16_t>(destination_absolute),
-                                         static_cast<uint8_t>(destination_dwords)});
-  if (src2_is_vgpr) {
-    architectural_vgprs.expand(RegisterRef{RegClass::VGPR, static_cast<uint16_t>(matrix_c_absolute),
-                                           static_cast<uint8_t>(destination_dwords)});
-  }
-
-  SemanticScratchAllocator allocator(
-      inst, liveness, context,
-      SemanticScratchPolicy{.max_vgprs = 256,
-                            .max_spill_dword_offset = kGfx1250ScratchMaxDwordOffset});
-  SemanticScratchRequest matrix_request;
-  matrix_request.count = static_cast<uint16_t>(matrix_a_width + 5u);
-  matrix_request.alignment = 2;
-  matrix_request.forbidden = architectural_vgprs;
-  matrix_request.allow_spill = true;
-  const SemanticScratchResult matrix_scratch = allocator.acquire_vgprs(matrix_request);
-  if (!matrix_scratch) {
-    return ExpandResult::failed(
-        "gfx1250 Scale16 WMMA could not allocate its contiguous scratch range");
-  }
-  const uint16_t masked_a = matrix_scratch.lease->base;
-
-  std::array<uint16_t, 5> scalar_scratch{};
-  for (uint16_t i = 0; i < scalar_scratch.size(); ++i) {
-    scalar_scratch[i] = static_cast<uint16_t>(masked_a + matrix_a_width + i);
-  }
-  const uint16_t scale_a_lo = scalar_scratch[0];
-  const uint16_t scale_b_lo = scalar_scratch[1];
-  const uint16_t scale_a_hi = scalar_scratch[2];
-  const uint16_t scale_b_hi = scalar_scratch[3];
-  const uint16_t temp = scalar_scratch[4];
-
-  const auto overlaps = [](uint32_t lhs, uint16_t lhs_count, uint32_t rhs, uint16_t rhs_count) {
-    return lhs < rhs + rhs_count && rhs < lhs + lhs_count;
-  };
-  constexpr uint16_t kMHalfDwords = 8;
-  const bool dst_crosses = is_m32 && static_cast<uint32_t>(matrix.vdst) + kMHalfDwords > 0xffu;
-  const bool src2_crosses =
-      is_m32 && src2_is_vgpr && static_cast<uint32_t>(matrix_c) + kMHalfDwords > 0xffu;
-  if ((dst_crosses && *dst_bank == 3) || (src2_crosses && *src2_bank == 3)) {
-    return ExpandResult::failed("gfx1250 Scale16 M=32 C/D split exceeds the VGPR address space");
-  }
-  if (destination_absolute + destination_dwords > REGISTER_SET_MAX_VGPRS ||
-      (src2_is_vgpr && matrix_c_absolute + destination_dwords > REGISTER_SET_MAX_VGPRS)) {
-    return ExpandResult::failed("gfx1250 Scale16 WMMA C/D range exceeds the VGPR file");
-  }
-
-  if (overlaps(destination_absolute, destination_dwords, matrix_a_absolute, matrix_a_total_width) ||
-      overlaps(destination_absolute, destination_dwords, matrix_b_absolute, matrix_b_width)) {
-    return ExpandResult::failed("gfx1250 Scale16 destination destructively overlaps matrix A or B");
-  }
-  if (is_m32 && src2_is_vgpr && overlaps(destination_absolute, 8, matrix_c_absolute + 8u, 8)) {
-    return ExpandResult::failed("gfx1250 Scale16 lower destination overlaps the upper C half");
-  }
-
-  const auto first_wmma_mode = [&](uint16_t m_half) {
-    const uint8_t pass_src2_bank =
-        static_cast<uint8_t>(*src2_bank + (m_half != 0 && src2_crosses ? 1u : 0u));
-    const uint8_t pass_dst_bank =
-        static_cast<uint8_t>(*dst_bank + (m_half != 0 && dst_crosses ? 1u : 0u));
-    return static_cast<uint8_t>((*src1_bank << 2) | (pass_src2_bank << 4) | (pass_dst_bank << 6));
-  };
-  const auto accumulate_wmma_mode = [&](uint16_t m_half) {
-    const uint8_t pass_dst_bank =
-        static_cast<uint8_t>(*dst_bank + (m_half != 0 && dst_crosses ? 1u : 0u));
-    return static_cast<uint8_t>((*src1_bank << 2) | (pass_dst_bank << 4) | (pass_dst_bank << 6));
-  };
-
-  std::optional<uint16_t> mask_sgpr;
-  if (matrix_a_fmt <= 1) {
-    mask_sgpr = liveness.find_free_sgpr(&inst);
-    if (!mask_sgpr || *mask_sgpr > 105) {
-      return ExpandResult::failed(
-          "gfx1250 Scale16 lane-mask split could not allocate a dead scratch SGPR");
-    }
-  }
-
   std::vector<uint32_t> words;
-  words.reserve(128);
+  words.reserve(12);
   uint8_t current_mode = original_mode;
-  // Scale operands architecturally ignore VGPR-MSB. The gather instructions
-  // are ordinary VALU, so explicitly select low-bank scratch/source registers.
-  append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
-  if (!append_gfx1250_scratch_preservation(words, *matrix_scratch.lease, false)) {
-    return ExpandResult::failed(
-        "gfx1250 Scale16 WMMA could not preserve its borrowed masked-A range");
+  for (uint16_t half = 0; half < 2; ++half) {
+    if (half != 0 && (src0_crosses || dst_crosses || src2_crosses)) {
+      const uint8_t upper_mode =
+          static_cast<uint8_t>((*src0_bank + (src0_crosses ? 1u : 0u)) | (*src1_bank << 2) |
+                               ((*src2_bank + (src2_crosses ? 1u : 0u)) << 4) |
+                               ((*dst_bank + (dst_crosses ? 1u : 0u)) << 6));
+      append_gfx1250_vgpr_msb_transition(words, current_mode, upper_mode);
+    }
+
+    std::array<uint32_t, 2> prefix = {inst.raw_encoding()[0], inst.raw_encoding()[1]};
+    prefix[0] &= ~((uint32_t{1} << 13) | (uint32_t{1} << 14));
+    set_word_field(prefix[0], half, 11, 1);
+    set_word_field(prefix[1], kVgprEncoding, 18, 9);
+    append_words(words, prefix);
+
+    const uint16_t delta = static_cast<uint16_t>(half * kHalfDwords);
+    auto replacement = gfx1250::build_vop3p(
+        gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p,
+        {.vdst = static_cast<uint8_t>((matrix.vdst + delta) & 0xffu),
+         .neg_hi = static_cast<uint8_t>(matrix.neg_hi),
+         .opsel = 4,
+         .clamp = static_cast<uint8_t>(matrix.clamp),
+         .src0 = static_cast<uint16_t>(kVgprEncoding + ((src0 + delta) & 0xffu)),
+         .src1 = static_cast<uint16_t>(kVgprEncoding + src1),
+         .src2 = src2_is_vgpr ? static_cast<uint16_t>(kVgprEncoding + ((src2 + delta) & 0xffu))
+                              : static_cast<uint16_t>(matrix.src2),
+         .neg = static_cast<uint8_t>(matrix.neg)});
+    replacement[0] |= uint32_t{1} << 14; // matrix B: FP4
+    append_words(words, replacement);
   }
-  append_gfx1250_scale16_gather(words, scale_a, scale_a_lo, temp, false);
-  append_gfx1250_scale16_gather(words, scale_b, scale_b_lo, temp, false);
-  append_gfx1250_scale16_gather(words, scale_a, scale_a_hi, temp, true);
-  append_gfx1250_scale16_gather(words, scale_b, scale_b_hi, temp, true);
-
-  const auto append_masked_a = [&](uint16_t m_half, bool high) {
-    const uint32_t matrix_a_half =
-        matrix_a_absolute + static_cast<uint32_t>(m_half) * matrix_a_width;
-    if (matrix_a_fmt <= 1) {
-      append_words(words,
-                   gfx1250::build_sop1(gfx1250::kSMovB32Sop1,
-                                       {.ssrc0 = 0xff, .sdst = static_cast<uint8_t>(*mask_sgpr)}));
-      words.push_back(high ? 0xffff0000u : 0x0000ffffu);
-      for (uint16_t i = 0; i < matrix_a_width; ++i) {
-        const uint32_t source = matrix_a_half + i;
-        const uint8_t source_bank = static_cast<uint8_t>(source / 256u);
-        append_gfx1250_vgpr_msb_transition(words, current_mode,
-                                           static_cast<uint8_t>(source_bank << 2));
-        append_words(words, gfx1250::build_vop3(
-                                gfx1250::kVCndmaskB32Vop3,
-                                {.vdst = static_cast<uint8_t>(masked_a + i),
-                                 .src0 = gfx1250_inline_u32(0),
-                                 .src1 = gfx1250_vgpr_src(static_cast<uint16_t>(source & 0xffu)),
-                                 .src2 = *mask_sgpr}));
-      }
-      return;
-    }
-
-    const uint16_t subblock_width = matrix_a_fmt <= 3 ? 3 : 2;
-    for (uint16_t i = 0; i < matrix_a_width; ++i) {
-      const bool is_high_subblock = ((i / subblock_width) & 1u) != 0;
-      const uint32_t source_absolute = matrix_a_half + i;
-      const uint8_t source_bank = static_cast<uint8_t>(source_absolute / 256u);
-      append_gfx1250_vgpr_msb_transition(words, current_mode, source_bank);
-      const uint16_t source = is_high_subblock == high
-                                  ? gfx1250_vgpr_src(static_cast<uint16_t>(source_absolute & 0xffu))
-                                  : gfx1250_inline_u32(0);
-      append_words(
-          words, gfx1250::build_vop3(gfx1250::kVMovB32Vop3,
-                                     {.vdst = static_cast<uint8_t>(masked_a + i), .src0 = source}));
-    }
-  };
-
-  const auto build_pass = [&](uint16_t m_half, uint16_t pass_scale_a, uint16_t pass_scale_b,
-                              bool accumulate_d) {
-    std::array<uint32_t, 4> pass = {inst.raw_encoding()[0], inst.raw_encoding()[1],
-                                    inst.raw_encoding()[2], inst.raw_encoding()[3]};
-    set_word_field(pass[0], kWmmaScaleSrc2PrefixOp, 16, 8);
-    // Splitting changes the A/D ranges, so the original reuse promises no
-    // longer apply. M=32 assigns its two halves to scale lanes 0..15 and
-    // 16..31. M=16 already carries an architectural SCL_OPSEL selection which
-    // must survive the Scale16-to-regular-Scale conversion.
-    pass[0] &= ~((uint32_t{1} << 13) | (uint32_t{1} << 14));
-    set_word_field(pass[0], is_m32 ? m_half : static_cast<uint16_t>(scale.opsel & 1u), 11, 1);
-    set_word_field(pass[1], gfx1250_vgpr_src(pass_scale_a), 0, 9);
-    set_word_field(pass[1], gfx1250_vgpr_src(pass_scale_b), 9, 9);
-    set_word_field(pass[1], gfx1250_vgpr_src(0), 18, 9);
-    set_word_field(pass[3], gfx1250_vgpr_src(masked_a), 0, 9);
-    if (is_m32) {
-      const uint16_t m_delta = static_cast<uint16_t>(m_half * kMHalfDwords);
-      set_word_field(pass[2], static_cast<uint32_t>((matrix.vdst + m_delta) & 0xffu), 0, 8);
-      set_word_field(pass[2], 4, 11, 3); // matrix A format: FP4
-      pass[2] |= uint32_t{1} << 14;      // matrix B format: FP4
-      set_word_field(pass[2], gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p, 16, 8);
-      set_word_field(pass[3], 0, 27, 2); // remaining B format bits for FP4
-      if (!accumulate_d) {
-        set_word_field(pass[3],
-                       src2_is_vgpr
-                           ? gfx1250_vgpr_src(static_cast<uint16_t>((matrix_c + m_delta) & 0xffu))
-                           : static_cast<uint16_t>(matrix.src2),
-                       18, 9);
-      }
-    }
-    if (accumulate_d) {
-      const uint16_t m_delta = static_cast<uint16_t>(is_m32 ? m_half * kMHalfDwords : 0u);
-      set_word_field(
-          pass[3], gfx1250_vgpr_src(static_cast<uint16_t>((matrix.vdst + m_delta) & 0xffu)), 18, 9);
-      pass[2] &= ~(uint32_t{1} << 10);
-      pass[3] &= ~(uint32_t{1} << 31);
-    }
-    words.insert(words.end(), pass.begin(), pass.end());
-  };
-
-  const uint16_t m_halves = static_cast<uint16_t>(is_m32 ? 2u : 1u);
-  for (uint16_t m_half = 0; m_half < m_halves; ++m_half) {
-    append_masked_a(m_half, false);
-    append_gfx1250_vgpr_msb_transition(words, current_mode, first_wmma_mode(m_half));
-    build_pass(m_half, scale_a_lo, scale_b_lo, false);
-    // The next VALU sequence overwrites masked-A while the preceding WMMA may
-    // still read it. Cover every format-dependent co-execution slot.
-    for (int slot = 0; slot < wmma_valu_hazard_slots; ++slot)
-      append_words(words, gfx1250::build_vop1(gfx1250::kVNopVop1));
-    append_masked_a(m_half, true);
-    append_gfx1250_vgpr_msb_transition(words, current_mode, accumulate_wmma_mode(m_half));
-    build_pass(m_half, scale_a_hi, scale_b_hi, true);
-    if (m_half + 1u != m_halves) {
-      for (int slot = 0; slot < wmma_valu_hazard_slots; ++slot)
-        append_words(words, gfx1250::build_vop1(gfx1250::kVNopVop1));
-    }
-  }
-  // The allocator proves only that an unspilled range is dead before the
-  // source WMMA. A following source VALU may therefore define masked-A even
-  // when no spill restore is needed. Keep every subsequent VALU, including
-  // restoration loads, outside the final WMMA input-read window.
-  for (int slot = 0; slot < wmma_valu_hazard_slots; ++slot)
-    append_words(words, gfx1250::build_vop1(gfx1250::kVNopVop1));
-  append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
-  if (!append_gfx1250_scratch_preservation(words, *matrix_scratch.lease, true)) {
-    return ExpandResult::failed(
-        "gfx1250 Scale16 WMMA could not restore its borrowed masked-A range");
-  }
-  append_gfx1250_vgpr_msb_transition(words, current_mode, original_mode);
+  if (src0_crosses || dst_crosses || src2_crosses)
+    append_gfx1250_vgpr_msb_transition(words, current_mode, original_mode);
   return ExpandResult::success(std::move(words));
 }
 
@@ -1214,9 +976,9 @@ ExpandResult expand_gfx1250_cvt_f32_fp8_e5m3(const Instruction &inst, uint32_t, 
 /// @brief Wrap a standalone low-precision WMMA in an A0-safe neutral scale prefix.
 ///
 /// @details gfx1250 A0 cannot safely expose the bare F8F6F4 matrix instruction to
-/// trap/CWSR recovery. The documented workaround is the regular-Scale four-DWORD
-/// form. In the scale-source context, inline integer zero selects the neutral
-/// E8M0 scale. Keep the original two-DWORD matrix body byte-for-byte so its
+/// trap/CWSR recovery. The documented A0 form is the regular-Scale four-DWORD
+/// instruction. In the scale-source context, inline integer zero selects the
+/// neutral E8M0 scale. Keep the original two-DWORD matrix body byte-for-byte so its
 /// formats, accumulator, modifiers, and register operands retain their source
 /// semantics. The prefix's otherwise-unused SRC2 must encode VGPR0 to avoid the
 /// documented false scalar dependency.
@@ -1257,16 +1019,42 @@ ExpandResult expand_gfx1250_bare_f8f6f4_wmma(const Instruction &inst, uint32_t, 
   }
 }
 
-/// @brief Split a B0 K=128 FP8/BF8 WMMA into two A0 K=64 WMMAs.
+/// @brief Return the mixed-format selections for one f32 K=128 FP8/BF8 WMMA.
+[[nodiscard]] bool gfx1250_k128_wmma_formats(uint16_t opcode, uint8_t &matrix_a_fmt,
+                                             uint8_t &matrix_b_fmt) {
+  matrix_a_fmt = 0;
+  matrix_b_fmt = 0;
+  switch (opcode) {
+  case gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p:
+    return true;
+  case gfx1250::kVWmmaF3216x16x128Fp8Bf8Vop3p:
+    matrix_b_fmt = 1;
+    return true;
+  case gfx1250::kVWmmaF3216x16x128Bf8Fp8Vop3p:
+    matrix_a_fmt = 1;
+    return true;
+  case gfx1250::kVWmmaF3216x16x128Bf8Bf8Vop3p:
+    matrix_a_fmt = 1;
+    matrix_b_fmt = 1;
+    return true;
+  default:
+    return false;
+  }
+}
+
+/// @brief Lower a B0 K=128 FP8/BF8 WMMA to an A0 K=128 mixed-format WMMA.
 ///
-/// @details The first instruction consumes the low eight-VGPR A/B halves with
-/// the original C. The second consumes the upper halves and feeds the partial D
-/// back as C. If the ordinary partial destination would overwrite an upper
-/// input, the first result is written to one dead destination-width tuple. The
-/// native K=64 FP8/BF8 family does not consume LD_SCALE; only the K=128 F8F6F4
-/// matrix body has that behavior. The split preserves the K partition and
-/// accumulator flow, but each revision retains its documented native
-/// intermediate-accumulator precision.
+/// @details The preferred path emits one regular-Scale F8F6F4 operation with
+/// FP8/BF8 matrix-format selectors and neutral inline E8M0 scales. It retains
+/// the K=128 accumulation topology and requires no partial destination. Source
+/// reuse hints are cleared: the target instruction family differs, and a
+/// preceding source instruction may itself expand to more than one operation.
+///
+/// The source family's OPSEL[1:0] fields do not have a proven mapping into the
+/// mixed-format matrix body: the detailed scaled encoding reserves prefix bit
+/// 12 and consumes the body OPSEL fields as matrix formats. If either source
+/// field is nonzero, retain the two-K=64 fallback. That fallback writes the
+/// first partial to a dead aligned tuple when VDST overlaps an upper A/B input.
 ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_t offset,
                                       std::span<const uint8_t> source_text,
                                       const LivenessAnalysis &liveness, TranslationContext &context,
@@ -1286,6 +1074,41 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
   const uint16_t replacement_opcode = gfx1250_k128_wmma_replacement(inst.opcode());
   if (replacement_opcode == 0)
     return ExpandResult::failed("gfx1250 K=128 WMMA rule received an unsupported opcode");
+
+  uint8_t matrix_a_fmt = 0;
+  uint8_t matrix_b_fmt = 0;
+  if (inst.size() == static_cast<int>(sizeof(gfx1250::Vop3pMachineInst)) &&
+      inst.raw_encoding() != nullptr &&
+      gfx1250_k128_wmma_formats(inst.opcode(), matrix_a_fmt, matrix_b_fmt)) {
+    gfx1250::Vop3pMachineInst source{};
+    std::memcpy(&source, inst.raw_encoding(), sizeof(source));
+    const bool has_mappable_opsel = (source.opsel & 0x3u) == 0 && source.opsel_hi == 0;
+    constexpr uint16_t kVgprEncoding = 256;
+    if (has_mappable_opsel && source.src0 >= kVgprEncoding && source.src1 >= kVgprEncoding) {
+      std::vector<uint32_t> words;
+      words.reserve(4);
+      append_words(
+          words,
+          gfx1250::build_vop3p(
+              kWmmaScaleSrc2PrefixOp,
+              {.src0 = kGfx1250InlineZero,
+               .src1 = kGfx1250InlineZero,
+               .src2 = kVgprEncoding}));
+      append_words(words,
+                   gfx1250::build_vop3p(
+                       gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p,
+                       {.vdst = static_cast<uint8_t>(source.vdst),
+                        .neg_hi = static_cast<uint8_t>(source.neg_hi),
+                        .opsel = matrix_a_fmt,
+                        .clamp = static_cast<uint8_t>(source.clamp),
+                        .src0 = static_cast<uint16_t>(source.src0),
+                        .src1 = static_cast<uint16_t>(source.src1),
+                        .src2 = static_cast<uint16_t>(source.src2),
+                        .opsel_hi = matrix_b_fmt,
+                        .neg = static_cast<uint8_t>(source.neg)}));
+      return ExpandResult::success(std::move(words));
+    }
+  }
 
   const auto dst_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Dst);
   const auto src2_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src2);
@@ -1388,7 +1211,7 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
   const uint16_t second_src1 =
       static_cast<uint16_t>(*src1_bank * 256u + src1_low + kHalfInputDwords);
 
-  // The MI450 dependency table requires software spacing only when the first
+  // The gfx1250 dependency table requires software spacing only when the first
   // Matrix D overlaps the following WMMA's A/B/Index inputs. The ordinary path
   // proves that no such overlap exists, and the scratch path forbids its
   // partial tuple from every A/B window. Matrix D feeding Matrix C through

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -549,10 +549,11 @@ ExpandResult expand_gfx1250_wmma_32x16_f4(const Instruction &inst, uint32_t, uin
 /// @brief Gather either the even or odd bytes of one B64 Scale16 operand.
 ///
 /// @details Scale16 stores eight block-16 exponent bytes in two VGPRs. A0
-/// regular Scale consumes four block-32 bytes. An exact lowering therefore
-/// executes two WMMAs: the low-K pass gathers bytes 0,2,4,6 and the high-K
-/// pass gathers bytes 1,3,5,7. Combining adjacent bytes (for example with
-/// max) is not equivalent because each scale applies to different matrix data.
+/// regular Scale consumes four block-32 bytes. A scale-preserving lowering
+/// therefore executes two WMMAs: the low-K pass gathers bytes 0,2,4,6 and the
+/// high-K pass gathers bytes 1,3,5,7. Combining adjacent bytes (for example
+/// with max) is not equivalent because each scale applies to different matrix
+/// data.
 void append_gfx1250_scale16_gather(std::vector<uint32_t> &words, uint16_t src_lo, uint16_t dst,
                                    uint16_t temp, bool odd) {
   const auto vgpr = gfx1250_vgpr_src;
@@ -581,7 +582,7 @@ void append_gfx1250_scale16_gather(std::vector<uint32_t> &words, uint16_t src_lo
   insert(temp, 24);
 }
 
-/// @brief Convert B0 Scale16 WMMA to exact A0 regular-Scale WMMAs.
+/// @brief Convert B0 Scale16 WMMA to A0 regular-Scale WMMAs.
 ///
 /// @details The two passes consume the even and odd Scale16 bytes and mutually
 /// exclusive K=16 portions of matrix A. Their results accumulate through D.
@@ -589,7 +590,9 @@ void append_gfx1250_scale16_gather(std::vector<uint32_t> &words, uint16_t src_lo
 /// producing four passes. On gfx1250, lanes 0..15 and
 /// 16..31 of the same A-scale pair correspond to those two M halves; the
 /// replacement regular-Scale prefix selects the half with SCL_OPSEL. Each M
-/// half slices eight VGPRs from A, C, and D while sharing B.
+/// half slices eight VGPRs from A, C, and D while sharing B. This preserves the
+/// scale-to-submatrix mapping; the revisions retain their documented native
+/// intermediate-accumulator precision.
 ExpandResult expand_gfx1250_wmma_scale16(const Instruction &inst, uint32_t, uint64_t,
                                          std::span<const uint8_t>, const LivenessAnalysis &liveness,
                                          TranslationContext &context, const LaneLayout *,
@@ -1238,37 +1241,37 @@ ExpandResult expand_gfx1250_bare_f8f6f4_wmma(const Instruction &inst, uint32_t, 
   return ExpandResult::success(std::move(words));
 }
 
-/// @brief Lower a B0-only K=128 FP8/BF8 WMMA for A0.
-///
-/// @details A0's regular-Scale mixed-format WMMA implements the same f32 K=128
-/// operation when both scale sources use the context-sensitive inline-zero
-/// encoding for neutral E8M0 scaling. This avoids a temporary SGPR and a
-/// scalar-to-vector ALU dependency. Select the FP8/BF8 matrix formats in the
-/// mixed base instruction and encode VGPR0 in the regular-Scale prefix's
-/// architecturally unused SRC2 field.
-///
-/// The regular-Scale instruction only has an f32 output. The f16 forms remain
-/// fail-closed because chaining two K=64 instructions would round the
-/// intermediate accumulator to f16 instead of preserving one final f16 round.
-ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_t,
-                                      std::span<const uint8_t>, const LivenessAnalysis &,
-                                      TranslationContext &, const LaneLayout *,
-                                      const LaneLayout *) {
-  uint8_t matrix_a_fmt = 0;
-  uint8_t matrix_b_fmt = 0;
-  switch (inst.opcode()) {
+/// @brief Return the K=64 replacement opcode for one B0 K=128 FP8/BF8 WMMA.
+[[nodiscard]] uint16_t gfx1250_k128_wmma_replacement(uint16_t opcode) {
+  switch (opcode) {
   case gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p:
-    break;
+    return gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p;
   case gfx1250::kVWmmaF3216x16x128Fp8Bf8Vop3p:
-    matrix_b_fmt = 1;
-    break;
+    return gfx1250::kVWmmaF3216x16x64Fp8Bf8Vop3p;
   case gfx1250::kVWmmaF3216x16x128Bf8Fp8Vop3p:
-    matrix_a_fmt = 1;
-    break;
+    return gfx1250::kVWmmaF3216x16x64Bf8Fp8Vop3p;
   case gfx1250::kVWmmaF3216x16x128Bf8Bf8Vop3p:
-    matrix_a_fmt = 1;
-    matrix_b_fmt = 1;
-    break;
+    return gfx1250::kVWmmaF3216x16x64Bf8Bf8Vop3p;
+  default:
+    return 0;
+  }
+}
+
+/// @brief Split a B0 K=128 FP8/BF8 WMMA into two A0 K=64 WMMAs.
+///
+/// @details The first instruction consumes the low eight-VGPR A/B halves with
+/// the original C. The second consumes the upper halves and feeds the partial D
+/// back as C. If the ordinary partial destination would overwrite an upper
+/// input, the first result is written to one dead destination-width tuple. The
+/// native K=64 FP8/BF8 family does not consume LD_SCALE; only the K=128 F8F6F4
+/// matrix body has that behavior. The split preserves the K partition and
+/// accumulator flow, but each revision retains its documented native
+/// intermediate-accumulator precision.
+ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_t offset,
+                                      std::span<const uint8_t> source_text,
+                                      const LivenessAnalysis &liveness, TranslationContext &context,
+                                      const LaneLayout *, const LaneLayout *) {
+  switch (inst.opcode()) {
   case gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p:
   case gfx1250::kVWmmaF1616x16x128Fp8Bf8Vop3p:
   case gfx1250::kVWmmaF1616x16x128Bf8Fp8Vop3p:
@@ -1277,34 +1280,144 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
         "gfx1250 f16 K=128 WMMA A0 lowering is not yet implemented",
         {"Provide an exact packed-f16 accumulator and single-rounding lowering."});
   default:
-    return ExpandResult::failed("gfx1250 K=128 WMMA rule received an unsupported opcode");
+    break;
   }
 
-  if (inst.size() != 2 * static_cast<int>(sizeof(uint32_t)) || inst.raw_encoding() == nullptr)
-    return ExpandResult::failed("gfx1250 f32 K=128 WMMA rule received a non-base encoding");
+  const uint16_t replacement_opcode = gfx1250_k128_wmma_replacement(inst.opcode());
+  if (replacement_opcode == 0)
+    return ExpandResult::failed("gfx1250 K=128 WMMA rule received an unsupported opcode");
 
-  gfx1250::Vop3pMachineInst source{};
-  std::memcpy(&source, inst.raw_encoding(), sizeof(source));
+  const auto dst_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Dst);
+  const auto src2_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src2);
+  if (!dst_bank || !src2_bank) {
+    return ExpandResult::failed(
+        "gfx1250 K=128 WMMA split cannot prove VDST and SRC2 VGPR-MSB banks",
+        {"Make the VGPR-MSB fields known on every CFG path reaching this instruction."});
+  }
+  if (offset > source_text.size() ||
+      static_cast<size_t>(inst.size()) > source_text.size() - offset ||
+      inst.size() < static_cast<int>(sizeof(gfx1250::Vop3pMachineInst))) {
+    return ExpandResult::failed("gfx1250 K=128 WMMA has no complete source encoding");
+  }
+
+  const size_t source_word_count = static_cast<size_t>(inst.size()) / sizeof(uint32_t);
+  std::vector<uint32_t> first(source_word_count);
+  std::memcpy(first.data(), source_text.data() + offset, static_cast<size_t>(inst.size()));
+  std::array<uint32_t, 2> second = {first[0], first[1]};
+
+  set_word_field(first[0], replacement_opcode, 16, 8);
+  first[0] &= ~((uint32_t{1} << 13) | (uint32_t{1} << 14));
+  set_word_field(second[0], replacement_opcode, 16, 8);
+  second[0] &= ~((uint32_t{1} << 13) | (uint32_t{1} << 14));
+
+  const uint16_t src0 = static_cast<uint16_t>(first[1] & 0x1ffu);
+  const uint16_t src1 = static_cast<uint16_t>((first[1] >> 9) & 0x1ffu);
   constexpr uint16_t kVgprEncoding = 256;
-  if (source.src0 < kVgprEncoding || source.src1 < kVgprEncoding) {
+  constexpr uint16_t kHalfInputDwords = 8;
+  if (src0 < kVgprEncoding || src1 < kVgprEncoding) {
     return ExpandResult::failed("gfx1250 K=128 WMMA matrix operands are not ordinary VGPR ranges");
   }
 
+  const uint16_t src0_low = static_cast<uint16_t>(src0 - kVgprEncoding);
+  const uint16_t src1_low = static_cast<uint16_t>(src1 - kVgprEncoding);
+  const auto src0_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src0);
+  const auto src1_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src1);
+  if (!src0_bank || !src1_bank) {
+    return ExpandResult::failed(
+        "gfx1250 K=128 WMMA split cannot prove A/B VGPR-MSB banks",
+        {"Make the VGPR-MSB fields known on every CFG path reaching this instruction."});
+  }
+
+  const auto overlaps = [](uint16_t lhs, uint16_t lhs_count, uint16_t rhs, uint16_t rhs_count) {
+    return lhs < static_cast<uint32_t>(rhs) + rhs_count &&
+           rhs < static_cast<uint32_t>(lhs) + lhs_count;
+  };
+  const uint16_t physical_dst =
+      static_cast<uint16_t>(*dst_bank * 256u + static_cast<uint16_t>(first[0] & 0xffu));
+  const uint16_t dst_dwords =
+      inst.dst_operand(0) != nullptr ? inst.dst_operand(0)->vgpr_count() : kHalfInputDwords;
+  const uint16_t physical_upper_a =
+      static_cast<uint16_t>(*src0_bank * 256u + src0_low + kHalfInputDwords);
+  const uint16_t physical_upper_b =
+      static_cast<uint16_t>(*src1_bank * 256u + src1_low + kHalfInputDwords);
+  const bool needs_partial_accumulator_scratch =
+      overlaps(physical_dst, dst_dwords, physical_upper_a, kHalfInputDwords) ||
+      overlaps(physical_dst, dst_dwords, physical_upper_b, kHalfInputDwords);
+
+  std::optional<SemanticScratchLease> partial_accumulator_scratch;
+  if (needs_partial_accumulator_scratch) {
+    SemanticScratchAllocator allocator(
+        inst, liveness, context,
+        SemanticScratchPolicy{.max_vgprs = static_cast<uint16_t>(REGISTER_SET_MAX_VGPRS),
+                              .max_spill_dword_offset = 0});
+    SemanticScratchRequest request;
+    request.count = dst_dwords;
+    request.alignment = dst_dwords;
+    request.allow_spill = false;
+    const auto forbid = [&](uint16_t base, uint16_t count) {
+      request.forbidden.expand(RegisterRef{RegClass::VGPR, base, static_cast<uint8_t>(count)});
+    };
+    forbid(physical_dst, dst_dwords);
+    forbid(static_cast<uint16_t>(*src0_bank * 256u + src0_low), 2 * kHalfInputDwords);
+    forbid(static_cast<uint16_t>(*src1_bank * 256u + src1_low), 2 * kHalfInputDwords);
+    const uint16_t encoded_src2 = static_cast<uint16_t>((first[1] >> 18) & 0x1ffu);
+    if (encoded_src2 >= kVgprEncoding) {
+      forbid(static_cast<uint16_t>(*src2_bank * 256u + encoded_src2 - kVgprEncoding), dst_dwords);
+    }
+
+    const SemanticScratchResult scratch = allocator.acquire_vgprs(request);
+    if (!scratch) {
+      return ExpandResult::failed(
+          "gfx1250 K=128 WMMA could not allocate a partial accumulator",
+          {"Provide one aligned dead VGPR tuple matching the WMMA destination width."});
+    }
+    partial_accumulator_scratch = *scratch.lease;
+  }
+
+  const bool src0_crosses_bank = static_cast<uint32_t>(src0_low) + kHalfInputDwords > 0xffu;
+  const bool src1_crosses_bank = static_cast<uint32_t>(src1_low) + kHalfInputDwords > 0xffu;
+  if ((src0_crosses_bank && *src0_bank == 3) || (src1_crosses_bank && *src1_bank == 3)) {
+    return ExpandResult::failed(
+        "gfx1250 K=128 WMMA bank-crossing input exceeds the addressable VGPR range");
+  }
+
+  const uint8_t original_mode =
+      static_cast<uint8_t>(*src0_bank | (*src1_bank << 2) | (*src2_bank << 4) | (*dst_bank << 6));
+  const uint16_t second_src0 =
+      static_cast<uint16_t>(*src0_bank * 256u + src0_low + kHalfInputDwords);
+  const uint16_t second_src1 =
+      static_cast<uint16_t>(*src1_bank * 256u + src1_low + kHalfInputDwords);
+
+  // The MI450 dependency table requires software spacing only when the first
+  // Matrix D overlaps the following WMMA's A/B/Index inputs. The ordinary path
+  // proves that no such overlap exists, and the scratch path forbids its
+  // partial tuple from every A/B window. Matrix D feeding Matrix C through
+  // SRC2 is interlocked, so no V_NOP is inserted between the two K64 WMMAs.
+  uint16_t partial_accumulator = physical_dst;
+  if (partial_accumulator_scratch) {
+    partial_accumulator = partial_accumulator_scratch->base;
+    set_word_field(first[0], partial_accumulator & 0xffu, 0, 8);
+  }
+
+  set_word_field(second[1], kVgprEncoding + (second_src0 & 0xffu), 0, 9);
+  set_word_field(second[1], kVgprEncoding + (second_src1 & 0xffu), 9, 9);
+  set_word_field(second[1], kVgprEncoding + (partial_accumulator & 0xffu), 18, 9);
+  second[0] &= ~(uint32_t{1} << 10);
+  second[1] &= ~(uint32_t{1} << 31);
+
+  const uint8_t partial_bank = static_cast<uint8_t>(partial_accumulator / 256u);
+  const uint8_t first_mode = static_cast<uint8_t>((original_mode & 0x3fu) | (partial_bank << 6));
+  const uint8_t second_mode = static_cast<uint8_t>(
+      (second_src0 / 256u) | ((second_src1 / 256u) << 2) | (partial_bank << 4) | (*dst_bank << 6));
+
   std::vector<uint32_t> words;
-  words.reserve(4);
-  append_words(words, gfx1250::build_vop3p(kWmmaScaleSrc2PrefixOp, {.src0 = kGfx1250InlineZero,
-                                                                    .src1 = kGfx1250InlineZero,
-                                                                    .src2 = kVgprEncoding}));
-  append_words(words, gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p,
-                                           {.vdst = static_cast<uint8_t>(source.vdst),
-                                            .neg_hi = static_cast<uint8_t>(source.neg_hi),
-                                            .opsel = matrix_a_fmt,
-                                            .clamp = static_cast<uint8_t>(source.clamp),
-                                            .src0 = static_cast<uint16_t>(source.src0),
-                                            .src1 = static_cast<uint16_t>(source.src1),
-                                            .src2 = static_cast<uint16_t>(source.src2),
-                                            .opsel_hi = matrix_b_fmt,
-                                            .neg = static_cast<uint8_t>(source.neg)}));
+  words.reserve(first.size() + second.size() + 9);
+  uint8_t current_mode = original_mode;
+  append_gfx1250_vgpr_msb_transition(words, current_mode, first_mode);
+  words.insert(words.end(), first.begin(), first.end());
+  append_gfx1250_vgpr_msb_transition(words, current_mode, second_mode);
+  append_words(words, second);
+  append_gfx1250_vgpr_msb_transition(words, current_mode, original_mode);
   return ExpandResult::success(std::move(words));
 }
 
@@ -1325,13 +1438,13 @@ inline constexpr std::array<TranslationRule, 38> kGfx1250B0ToA0ExpandRules = {{
     {gfx1250::encoding::kVop3p, gfx1250::kVSwmmacI3216x16x128Iu8Vop3p, RuleAction::Expand, 0, 0,
      nullptr, expand_gfx1250_wmma_iu8_spacing, nullptr, nullptr, false},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p, RuleAction::Expand, 0,
-     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr, false},
+     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF3216x16x128Fp8Bf8Vop3p, RuleAction::Expand, 0,
-     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr, false},
+     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF3216x16x128Bf8Fp8Vop3p, RuleAction::Expand, 0,
-     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr, false},
+     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF3216x16x128Bf8Bf8Vop3p, RuleAction::Expand, 0,
-     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr, false},
+     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p, RuleAction::Expand, 0,
      0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr, false},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF1616x16x128Fp8Bf8Vop3p, RuleAction::Expand, 0,

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -9940,28 +9940,38 @@ TEST(BinaryTranslatorE2E, Gfx1250SplitsRegularScaleFp4AcrossMForA0) {
   }
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250RegularScaleFp4RejectsSharedBOverlap) {
+TEST(BinaryTranslatorE2E, Gfx1250RegularScaleFp4RejectsEveryDestructiveUpperInputOverlap) {
+  struct OverlapCase {
+    const char *name;
+    gfx1250::Vop3pBuilderFields matrix;
+  };
+  constexpr std::array cases = {
+      OverlapCase{"upper_a", {.vdst = 96, .src0 = 256 + 88, .src1 = 256 + 32, .src2 = 256 + 48}},
+      OverlapCase{"shared_b", {.vdst = 96, .src0 = 256 + 16, .src1 = 256 + 96, .src2 = 256 + 48}},
+      OverlapCase{"upper_c", {.vdst = 96, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 88}},
+  };
   constexpr auto scale =
       gfx1250::build_vop3p(0x35, {.src0 = 256 + 64, .src1 = 256 + 66, .src2 = 0});
-  constexpr auto matrix =
-      gfx1250::build_vop3p(gfx1250::kVWmmaF3232x16x128F4Vop3p,
-                           {.vdst = 96, .src0 = 256 + 16, .src1 = 256 + 96, .src2 = 256 + 48});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
-  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
-      {scale[0], scale[1], matrix[0], matrix[1], kGfx1250SEndpgm});
-  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  for (const OverlapCase &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    const auto matrix = gfx1250::build_vop3p(gfx1250::kVWmmaF3232x16x128F4Vop3p, test_case.matrix);
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+        {scale[0], scale[1], matrix[0], matrix[1], kGfx1250SEndpgm});
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
 
-  rocjitsu::BinaryTranslator translator(
-      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
-      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
-                               rocjitsu::ProcessorRevision::Gfx1250A0));
-  const auto result = translator.translate(source);
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    const auto result = translator.translate(source);
 
-  EXPECT_FALSE(result.ok());
-  EXPECT_EQ(result.elf_bytes, image);
-  EXPECT_TRUE(rocjitsu::has_error_containing(
-      result, rocjitsu::DiagnosticKind::ExpandFailed,
-      "regular-Scale 32x16 lower destination overlaps an input needed by the upper half"));
+    EXPECT_FALSE(result.ok());
+    EXPECT_EQ(result.elf_bytes, image);
+    EXPECT_TRUE(rocjitsu::has_error_containing(
+        result, rocjitsu::DiagnosticKind::ExpandFailed,
+        "regular-Scale 32x16 lower destination overlaps an input needed by the upper half"));
+  }
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250RegularScaleFp4RejectsScaleSourceOverlap) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -8970,34 +8970,35 @@ TEST(SemanticTranslator, Gfx1250ClassifiesLivenessFreeExpandRules) {
   EXPECT_EQ(liveness_free_rules, expected);
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250SplitsF32K128Fp8Bf8WmmaWithoutScratchWhenInputsDoNotOverlap) {
+TEST(BinaryTranslatorE2E, Gfx1250UsesNeutralScaledK128Fp8Bf8WmmaWhenSourceOpselMaps) {
   struct WmmaCase {
     const char *name;
     uint16_t source_opcode;
-    uint16_t replacement_opcode;
+    uint8_t matrix_a_fmt;
+    uint8_t matrix_b_fmt;
   };
   constexpr std::array cases = {
-      WmmaCase{"fp8_fp8", gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p,
-               gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p},
-      WmmaCase{"fp8_bf8", gfx1250::kVWmmaF3216x16x128Fp8Bf8Vop3p,
-               gfx1250::kVWmmaF3216x16x64Fp8Bf8Vop3p},
-      WmmaCase{"bf8_fp8", gfx1250::kVWmmaF3216x16x128Bf8Fp8Vop3p,
-               gfx1250::kVWmmaF3216x16x64Bf8Fp8Vop3p},
-      WmmaCase{"bf8_bf8", gfx1250::kVWmmaF3216x16x128Bf8Bf8Vop3p,
-               gfx1250::kVWmmaF3216x16x64Bf8Bf8Vop3p},
+      WmmaCase{"fp8_fp8", gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p, 0, 0},
+      WmmaCase{"fp8_bf8", gfx1250::kVWmmaF3216x16x128Fp8Bf8Vop3p, 0, 1},
+      WmmaCase{"bf8_fp8", gfx1250::kVWmmaF3216x16x128Bf8Fp8Vop3p, 1, 0},
+      WmmaCase{"bf8_bf8", gfx1250::kVWmmaF3216x16x128Bf8Bf8Vop3p, 1, 1},
   };
   constexpr gfx1250::Vop3pBuilderFields fields{
       .vdst = 54,
+      .neg_hi = 4,
+      .opsel = 4,
       .src0 = 256 + 16,
       .src1 = 256 + 32,
       .src2 = 256 + 48,
+      .neg = 4,
   };
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
 
   EXPECT_EQ(rocjitsu::semantic_expand_rules_gfx1250_b0_to_a0().size(), 38u);
   for (const WmmaCase &test_case : cases) {
     SCOPED_TRACE(test_case.name);
-    const auto source_wmma = gfx1250::build_vop3p(test_case.source_opcode, fields);
+    auto source_wmma = gfx1250::build_vop3p(test_case.source_opcode, fields);
+    source_wmma[0] |= uint32_t{1} << 14;
     auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
         {source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
     rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
@@ -9010,32 +9011,37 @@ TEST(BinaryTranslatorE2E, Gfx1250SplitsF32K128Fp8Bf8WmmaWithoutScratchWhenInputs
     ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
                                                             : result.diagnostics.front().message);
     rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
-    const auto decoded =
-        decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
-    std::vector<gfx1250::Vop3pMachineInst> replacements;
-    for (const auto &candidate : decoded) {
-      if (candidate->opcode() != test_case.replacement_opcode)
-        continue;
-      ASSERT_NE(candidate->raw_encoding(), nullptr);
-      gfx1250::Vop3pMachineInst replacement{};
-      std::memcpy(&replacement, candidate->raw_encoding(), sizeof(replacement));
-      replacements.push_back(replacement);
-    }
-    ASSERT_EQ(replacements.size(), 2u);
+    ASSERT_FALSE(translated.text_sections().empty());
+    ASSERT_GE(translated.text_sections()[0]->size(), 5 * sizeof(uint32_t));
+    const auto *words =
+        reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+    gfx1250::Vop3pMachineInst prefix{};
+    gfx1250::Vop3pMachineInst matrix{};
+    std::memcpy(&prefix, words, sizeof(prefix));
+    std::memcpy(&matrix, words + 2, sizeof(matrix));
 
-    EXPECT_EQ(replacements[0].vdst, fields.vdst);
-    EXPECT_EQ(replacements[0].src0, 256u + 16u);
-    EXPECT_EQ(replacements[0].src1, 256u + 32u);
-    EXPECT_EQ(replacements[0].src2, 256u + 48u);
+    EXPECT_EQ(prefix.op, 0x35u);
+    EXPECT_EQ(prefix.src0, 128u);
+    EXPECT_EQ(prefix.src1, 128u);
+    EXPECT_EQ(prefix.src2, 256u);
+    EXPECT_EQ(prefix.opsel, 0u) << "clear source matrix-A reuse in the new encoding";
+    EXPECT_EQ(prefix.pad_14, 0u) << "clear source matrix-B reuse in the new encoding";
+    EXPECT_EQ(prefix.opsel_hi, 0u);
 
-    EXPECT_EQ(replacements[1].vdst, fields.vdst);
-    EXPECT_EQ(replacements[1].src0, 256u + 24u);
-    EXPECT_EQ(replacements[1].src1, 256u + 40u);
-    EXPECT_EQ(replacements[1].src2, 256u + fields.vdst);
+    EXPECT_EQ(matrix.op, gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p);
+    EXPECT_EQ(matrix.vdst, fields.vdst);
+    EXPECT_EQ(matrix.src0, fields.src0);
+    EXPECT_EQ(matrix.src1, fields.src1);
+    EXPECT_EQ(matrix.src2, fields.src2);
+    EXPECT_EQ(matrix.opsel, test_case.matrix_a_fmt);
+    EXPECT_EQ((matrix.pad_14 << 2) | matrix.opsel_hi, test_case.matrix_b_fmt);
+    EXPECT_EQ(matrix.neg_hi, fields.neg_hi);
+    EXPECT_EQ(matrix.neg, fields.neg);
+    EXPECT_EQ(words[4], kGfx1250SEndpgm);
   }
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250K128WmmaUsesScratchWhenDestinationOverlapsUpperInput) {
+TEST(BinaryTranslatorE2E, Gfx1250K128WmmaFallbackUsesScratchForUnmappedOpselAndOverlap) {
   struct OverlapCase {
     const char *name;
     uint8_t vdst;
@@ -9050,9 +9056,16 @@ TEST(BinaryTranslatorE2E, Gfx1250K128WmmaUsesScratchWhenDestinationOverlapsUpper
 
   for (const OverlapCase &test_case : cases) {
     SCOPED_TRACE(test_case.name);
-    const auto source_wmma = gfx1250::build_vop3p(
+    auto source_wmma = gfx1250::build_vop3p(
         gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p,
-        {.vdst = test_case.vdst, .src0 = test_case.src0, .src1 = test_case.src1, .src2 = 128});
+        {.vdst = test_case.vdst,
+         .neg_hi = 4,
+         .opsel = 6,
+         .src0 = test_case.src0,
+         .src1 = test_case.src1,
+         .src2 = 128,
+         .neg = 4});
+    source_wmma[0] |= uint32_t{1} << 14;
     auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
         {source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
     rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
@@ -9090,12 +9103,65 @@ TEST(BinaryTranslatorE2E, Gfx1250K128WmmaUsesScratchWhenDestinationOverlapsUpper
     EXPECT_EQ(replacements[0].src0, test_case.src0);
     EXPECT_EQ(replacements[0].src1, test_case.src1);
     EXPECT_EQ(replacements[0].src2, 128u);
+    EXPECT_EQ(replacements[0].opsel & 4u, 0u);
+    EXPECT_EQ(replacements[0].pad_14, 0u);
+    EXPECT_EQ(replacements[0].neg_hi, 4u);
+    EXPECT_EQ(replacements[0].neg, 4u);
 
     EXPECT_EQ(replacements[1].vdst, test_case.vdst);
     EXPECT_EQ(replacements[1].src0, test_case.src0 + 8u);
     EXPECT_EQ(replacements[1].src1, test_case.src1 + 8u);
     EXPECT_EQ(replacements[1].src2, 256u + scratch);
+    EXPECT_EQ(replacements[1].opsel & 4u, 0u);
+    EXPECT_EQ(replacements[1].pad_14, 0u);
+    EXPECT_EQ(replacements[1].neg_hi, 0u);
+    EXPECT_EQ(replacements[1].neg, 0u);
   }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250K128WmmaFallbackKeepsNoOverlapPathScratchFree) {
+  constexpr auto source_wmma = gfx1250::build_vop3p(
+      gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p,
+      {.vdst = 96, .opsel = 2, .src0 = 256 + 248, .src1 = 256 + 40, .src2 = 128});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  std::vector<gfx1250::Vop3pMachineInst> replacements;
+  std::vector<uint16_t> modes;
+  for (const auto &candidate : decoded) {
+    if (candidate->mnemonic() == "s_set_vgpr_msb") {
+      ASSERT_NE(candidate->raw_encoding(), nullptr);
+      modes.push_back(static_cast<uint16_t>(candidate->raw_encoding()[0] & 0xffffu));
+      continue;
+    }
+    if (candidate->opcode() != gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p)
+      continue;
+    ASSERT_NE(candidate->raw_encoding(), nullptr);
+    gfx1250::Vop3pMachineInst replacement{};
+    std::memcpy(&replacement, candidate->raw_encoding(), sizeof(replacement));
+    replacements.push_back(replacement);
+  }
+
+  ASSERT_EQ(replacements.size(), 2u);
+  EXPECT_EQ(replacements[0].vdst, 96u);
+  EXPECT_EQ(replacements[0].src0, 256u + 248u);
+  EXPECT_EQ(replacements[1].vdst, 96u);
+  EXPECT_EQ(replacements[1].src0, 256u);
+  EXPECT_EQ(replacements[1].src1, 256u + 48u);
+  EXPECT_EQ(replacements[1].src2, 256u + 96u);
+  EXPECT_EQ(modes, (std::vector<uint16_t>{0x0001u, 0x0100u}));
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250F32K128WmmaRejectsNonVgprMatrixInputs) {
@@ -9347,7 +9413,7 @@ TEST(BinaryTranslatorE2E, Gfx1250WrapsBareF8f6f4WmmaInNeutralScaleForA0) {
       .src1 = 256 + 128,
       .src2 = 256 + 192,
       .opsel_hi = 1,
-      .neg = 3,
+      .neg = 4,
   };
   constexpr auto wmma = gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p, fields);
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
@@ -9811,15 +9877,15 @@ TEST(BinaryTranslatorE2E, Gfx1250PreservesVop3DppExtensionWord) {
 
 TEST(BinaryTranslatorE2E, Gfx1250SplitsRegularScaleFp4AcrossMForA0) {
   constexpr auto scale =
-      gfx1250::build_vop3p(0x35, {.src0 = 256 + 64, .src1 = 256 + 66, .src2 = 0});
+      gfx1250::build_vop3p(0x35,
+                           {.src0 = 256 + 64, .src1 = 256 + 66, .src2 = 0, .opsel_hi = 1});
   constexpr auto matrix =
       gfx1250::build_vop3p(gfx1250::kVWmmaF3232x16x128F4Vop3p, {.vdst = 96,
-                                                                .neg_hi = 5,
-                                                                .clamp = 1,
+                                                                .neg_hi = 4,
                                                                 .src0 = 256 + 16,
                                                                 .src1 = 256 + 32,
                                                                 .src2 = 256 + 48,
-                                                                .neg = 3});
+                                                                .neg = 4});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {scale[0], scale[1], matrix[0], matrix[1], kGfx1250SEndpgm});
@@ -9848,6 +9914,8 @@ TEST(BinaryTranslatorE2E, Gfx1250SplitsRegularScaleFp4AcrossMForA0) {
     EXPECT_EQ((words[offset] >> 11) & 0x1u, half);
     EXPECT_EQ(words[offset] & ((1u << 13) | (1u << 14)), 0u);
     EXPECT_EQ((words[offset + 1] >> 18) & 0x1ffu, 0x100u);
+    EXPECT_EQ((words[offset + 1] >> 27) & 0x1u, 1u)
+        << "B scale selection uses SCL_OPSEL_HI[0]";
 
     gfx1250::Vop3pMachineInst replacement{};
     std::memcpy(&replacement, words + offset + 2, sizeof(replacement));
@@ -9859,9 +9927,9 @@ TEST(BinaryTranslatorE2E, Gfx1250SplitsRegularScaleFp4AcrossMForA0) {
     EXPECT_EQ(replacement.opsel, 4u);
     EXPECT_EQ(replacement.pad_14, 1u);
     EXPECT_EQ(replacement.opsel_hi, 0u);
-    EXPECT_EQ(replacement.neg_hi, 5u);
-    EXPECT_EQ(replacement.clamp, 1u);
-    EXPECT_EQ(replacement.neg, 3u);
+    EXPECT_EQ(replacement.neg_hi, 4u);
+    EXPECT_EQ(replacement.clamp, 0u);
+    EXPECT_EQ(replacement.neg, 4u);
   }
 }
 
@@ -9928,6 +9996,42 @@ TEST(BinaryTranslatorE2E, Gfx1250RegularScaleFp4RejectsScaleSourceOverlap) {
         result, rocjitsu::DiagnosticKind::ExpandFailed,
         "regular-Scale 32x16 lower destination overlaps an input needed by the upper half"));
   }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250RegularScaleFp4AcceptsScalarAndInlineScaleSources) {
+  constexpr auto scale =
+      gfx1250::build_vop3p(0x35, {.src0 = 4, .src1 = 128, .src2 = 0});
+  constexpr auto matrix =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3232x16x128F4Vop3p,
+                           {.vdst = 96, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {scale[0], scale[1], matrix[0], matrix[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto *words = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  const size_t word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+  size_t prefix_count = 0;
+  for (size_t i = 0; i + 1 < word_count; ++i) {
+    if (((words[i] >> 16) & 0xffu) != 0x35u)
+      continue;
+    gfx1250::Vop3pMachineInst prefix{};
+    std::memcpy(&prefix, words + i, sizeof(prefix));
+    EXPECT_EQ(prefix.src0, 4u);
+    EXPECT_EQ(prefix.src1, 128u);
+    EXPECT_EQ(prefix.src2, 256u);
+    ++prefix_count;
+  }
+  EXPECT_EQ(prefix_count, 2u);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250RegularScaleFp4AdjustsUpperCAndDestinationBanks) {
@@ -10045,22 +10149,27 @@ TEST(BinaryTranslatorE2E, Gfx1250RegularScaleFp4RejectsBank3UpperHalfOverflow) {
       "regular-Scale 32x16 FP4 split exceeds the VGPR address space"));
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250SplitsScale16Fp4AcrossMAndKForA0) {
-  constexpr auto scale16 =
-      gfx1250::build_vop3p(0x3a, {.src0 = 256 + 64, .src1 = 256 + 66, .src2 = 256});
+TEST(BinaryTranslatorE2E, Gfx1250SplitsScale16Fp4AcrossMOnlyForA0) {
+  auto scale16 = gfx1250::build_vop3p(
+      0x3a,
+      {.neg_hi = 2,
+       .opsel = 4,
+       .src0 = 256 + 64,
+       .src1 = 256 + 66,
+       .src2 = 0,
+       .opsel_hi = 1,
+       .neg = 2});
+  scale16[0] |= uint32_t{1} << 14;
   constexpr auto matrix =
       gfx1250::build_vop3p(gfx1250::kVWmmaF3232x16x128F4Vop3p, {.vdst = 96,
-                                                                .neg_hi = 5,
-                                                                .clamp = 1,
+                                                                .neg_hi = 4,
                                                                 .src0 = 256 + 16,
                                                                 .src1 = 256 + 32,
                                                                 .src2 = 256 + 48,
-                                                                .neg = 7});
-  constexpr auto overwrite_masked_a =
-      gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 0});
+                                                                .neg = 4});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
-      {scale16[0], scale16[1], matrix[0], matrix[1], overwrite_masked_a[0], kGfx1250SEndpgm});
+      {scale16[0], scale16[1], matrix[0], matrix[1], kGfx1250SEndpgm});
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
 
   rocjitsu::BinaryTranslator translator(
@@ -10076,49 +10185,107 @@ TEST(BinaryTranslatorE2E, Gfx1250SplitsScale16Fp4AcrossMAndKForA0) {
   const size_t word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
   std::vector<size_t> pass_offsets;
   for (size_t i = 0; i < word_count; ++i) {
-    if (((words[i] >> 16) & 0xffu) == 0x35u)
+    if (((words[i] >> 16) & 0xffu) == 0x3au)
       pass_offsets.push_back(i);
   }
-  ASSERT_EQ(pass_offsets.size(), 4u);
+  ASSERT_EQ(pass_offsets.size(), 2u);
 
-  std::array<uint16_t, 4> scale_a_sources{};
-  for (uint16_t pass_index = 0; pass_index < 4; ++pass_index) {
-    const uint16_t m_half = pass_index / 2u;
-    const bool accumulate = (pass_index & 1u) != 0;
-    const size_t offset = pass_offsets[pass_index];
+  for (uint16_t half = 0; half < 2; ++half) {
+    const size_t offset = pass_offsets[half];
     ASSERT_LE(offset + 4, word_count);
-    EXPECT_EQ((words[offset] >> 11) & 0x1u, m_half);
+    gfx1250::Vop3pMachineInst prefix{};
+    std::memcpy(&prefix, words + offset, sizeof(prefix));
+    EXPECT_EQ(prefix.op, 0x3au);
+    EXPECT_EQ(prefix.src0, 256u + 64u);
+    EXPECT_EQ(prefix.src1, 256u + 66u);
+    EXPECT_EQ(prefix.src2, 256u);
+    EXPECT_EQ(prefix.opsel, half);
+    EXPECT_EQ(prefix.opsel_hi, 1u);
+    EXPECT_EQ(prefix.pad_14, 0u);
+    EXPECT_EQ(prefix.neg_hi, 2u);
+    EXPECT_EQ(prefix.neg, 2u);
     EXPECT_EQ(words[offset] & ((1u << 13) | (1u << 14)), 0u);
-    scale_a_sources[pass_index] = static_cast<uint16_t>(words[offset + 1] & 0x1ffu);
 
     gfx1250::Vop3pMachineInst replacement{};
     std::memcpy(&replacement, words + offset + 2, sizeof(replacement));
-    const uint16_t destination = static_cast<uint16_t>(96u + m_half * 8u);
+    const uint16_t destination = static_cast<uint16_t>(96u + half * 8u);
     EXPECT_EQ(replacement.op, gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p);
     EXPECT_EQ(replacement.vdst, destination);
-    EXPECT_EQ(replacement.src0, 256u)
-        << "the dead v0 range should be selected as unspilled masked-A scratch";
+    EXPECT_EQ(replacement.src0, 256u + 16u + half * 8u);
     EXPECT_EQ(replacement.src1, 256u + 32u);
-    EXPECT_EQ(replacement.src2, accumulate ? 256u + destination : 256u + 48u + m_half * 8u);
+    EXPECT_EQ(replacement.src2, 256u + 48u + half * 8u);
     EXPECT_EQ(replacement.opsel, 4u);
     EXPECT_EQ(replacement.pad_14, 1u);
     EXPECT_EQ(replacement.opsel_hi, 0u);
-    EXPECT_EQ(replacement.clamp, 1u);
-    EXPECT_EQ(replacement.neg_hi & 0x3u, 1u);
-    EXPECT_EQ(replacement.neg & 0x3u, 3u);
-    EXPECT_EQ((replacement.neg_hi >> 2) & 0x1u, accumulate ? 0u : 1u);
-    EXPECT_EQ((replacement.neg >> 2) & 0x1u, accumulate ? 0u : 1u);
+    EXPECT_EQ(replacement.neg_hi, 4u);
+    EXPECT_EQ(replacement.neg, 4u);
   }
-  EXPECT_NE(scale_a_sources[0], scale_a_sources[1]);
-  EXPECT_EQ(scale_a_sources[0], scale_a_sources[2]);
-  EXPECT_EQ(scale_a_sources[1], scale_a_sources[3]);
+  EXPECT_EQ(word_count, 9u);
+  EXPECT_EQ(words[8], kGfx1250SEndpgm);
+}
 
-  // The following source VALU defines the selected unspilled scratch range.
-  // Keep it outside the final FP4 WMMA's one-slot input-read window.
-  const uint32_t v_nop = gfx1250::build_vop1(gfx1250::kVNopVop1)[0];
-  ASSERT_LT(pass_offsets.back() + 5, word_count);
-  EXPECT_EQ(words[pass_offsets.back() + 4], v_nop);
-  EXPECT_EQ(words[pass_offsets.back() + 5], overwrite_masked_a[0]);
+TEST(BinaryTranslatorE2E, Gfx1250Scale16Fp4AcceptsScalarAndInlineScaleSources) {
+  constexpr auto scale16 =
+      gfx1250::build_vop3p(0x3a, {.src0 = 4, .src1 = 128, .src2 = 0});
+  constexpr auto matrix =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3232x16x128F4Vop3p,
+                           {.vdst = 96, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {scale16[0], scale16[1], matrix[0], matrix[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto *words = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  const size_t word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+  size_t prefix_count = 0;
+  for (size_t i = 0; i + 1 < word_count; ++i) {
+    if (((words[i] >> 16) & 0xffu) != 0x3au)
+      continue;
+    gfx1250::Vop3pMachineInst prefix{};
+    std::memcpy(&prefix, words + i, sizeof(prefix));
+    EXPECT_EQ(prefix.src0, 4u);
+    EXPECT_EQ(prefix.src1, 128u);
+    EXPECT_EQ(prefix.src2, 256u);
+    ++prefix_count;
+  }
+  EXPECT_EQ(prefix_count, 2u);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250Scale16Fp4RejectsScalePairOverlap) {
+  constexpr auto matrix =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3232x16x128F4Vop3p,
+                           {.vdst = 96, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+
+  for (const gfx1250::Vop3pBuilderFields fields : {
+           gfx1250::Vop3pBuilderFields{.src0 = 256 + 96, .src1 = 256 + 64, .src2 = 0},
+           gfx1250::Vop3pBuilderFields{.src0 = 256 + 64, .src1 = 256 + 96, .src2 = 0},
+       }) {
+    const auto scale16 = gfx1250::build_vop3p(0x3a, fields);
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+        {scale16[0], scale16[1], matrix[0], matrix[1], kGfx1250SEndpgm});
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    const auto result = translator.translate(source);
+
+    EXPECT_FALSE(result.ok());
+    EXPECT_EQ(result.elf_bytes, image);
+    EXPECT_TRUE(rocjitsu::has_error_containing(
+        result, rocjitsu::DiagnosticKind::ExpandFailed,
+        "Scale16 32x16 lower destination overlaps an input needed by the upper half"));
+  }
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250Scale16Fp4AdjustsUpperCAndDestinationBanks) {
@@ -10146,16 +10313,15 @@ TEST(BinaryTranslatorE2E, Gfx1250Scale16Fp4AdjustsUpperCAndDestinationBanks) {
   const size_t word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
   std::vector<size_t> pass_offsets;
   for (size_t i = 0; i < word_count; ++i) {
-    if (((words[i] >> 16) & 0xffu) == 0x35u)
+    if (((words[i] >> 16) & 0xffu) == 0x3au)
       pass_offsets.push_back(i);
   }
-  ASSERT_EQ(pass_offsets.size(), 4u);
-  for (size_t pass_index = 2; pass_index < 4; ++pass_index) {
-    gfx1250::Vop3pMachineInst replacement{};
-    std::memcpy(&replacement, words + pass_offsets[pass_index] + 2, sizeof(replacement));
-    EXPECT_EQ(replacement.vdst, 4u);
-    EXPECT_EQ(replacement.src2, 256u + 4u);
-  }
+  ASSERT_EQ(pass_offsets.size(), 2u);
+  gfx1250::Vop3pMachineInst upper{};
+  std::memcpy(&upper, words + pass_offsets[1] + 2, sizeof(upper));
+  EXPECT_EQ(upper.vdst, 4u);
+  EXPECT_EQ(upper.src0, 256u + 24u);
+  EXPECT_EQ(upper.src2, 256u + 4u);
 
   const auto decoded =
       decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
@@ -10167,7 +10333,7 @@ TEST(BinaryTranslatorE2E, Gfx1250Scale16Fp4AdjustsUpperCAndDestinationBanks) {
     }
   }
   EXPECT_NE(std::ranges::find(modes, 0xe0u), modes.end());
-  EXPECT_NE(std::ranges::find(modes, 0xf0u), modes.end());
+  EXPECT_EQ(modes.back(), 0x90u);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250Scale16Fp4RejectsBank3UpperHalfOverflow) {
@@ -10192,15 +10358,22 @@ TEST(BinaryTranslatorE2E, Gfx1250Scale16Fp4RejectsBank3UpperHalfOverflow) {
   EXPECT_EQ(result.elf_bytes, image);
   EXPECT_TRUE(
       rocjitsu::has_error_containing(result, rocjitsu::DiagnosticKind::ExpandFailed,
-                                     "Scale16 M=32 C/D split exceeds the VGPR address space"));
+                                     "Scale16 32x16 FP4 split exceeds the VGPR address space"));
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250ConvertsScale16F8f6f4ToRegularScaleForA0) {
+TEST(BinaryTranslatorE2E, Gfx1250PreservesNativeM16Scale16ForA0) {
   constexpr auto scale16 = gfx1250::build_vop3p(
-      0x3a, {.opsel = 1, .src0 = 256 + 64, .src1 = 256 + 66, .src2 = 256, .opsel_hi = 1});
-  constexpr auto matrix =
+      0x3a, {.neg_hi = 2, .opsel = 1, .src0 = 4, .src1 = 6, .src2 = 0, .opsel_hi = 1});
+  auto matrix =
       gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p,
-                           {.vdst = 96, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 128});
+                           {.vdst = 96,
+                            .neg_hi = 4,
+                            .opsel = 3,
+                            .src0 = 256 + 16,
+                            .src1 = 256 + 32,
+                            .src2 = 128,
+                            .neg = 4});
+  matrix[0] |= uint32_t{1} << 14;
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {scale16[0], scale16[1], matrix[0], matrix[1], kGfx1250SEndpgm});
@@ -10216,82 +10389,29 @@ TEST(BinaryTranslatorE2E, Gfx1250ConvertsScale16F8f6f4ToRegularScaleForA0) {
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_FALSE(translated.text_sections().empty());
-  const auto decoded =
-      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
-  EXPECT_EQ(std::ranges::count_if(decoded,
-                                  [](const auto &inst) {
-                                    return inst->mnemonic() == "v_wmma_scale_f32_16x16x128_f8f6f4";
-                                  }),
-            2);
-  EXPECT_EQ(std::ranges::count_if(decoded,
-                                  [](const auto &inst) {
-                                    return inst->mnemonic().starts_with("v_wmma_scale16_f32_");
-                                  }),
-            0);
-  EXPECT_EQ(std::ranges::count_if(decoded,
-                                  [](const auto &inst) { return inst->mnemonic() == "v_max_u32"; }),
-            0);
-
-  // Assert the value-defining operands of the two emitted scale passes, not just
-  // that they are scale-form WMMAs. Each pass is a 4-dword VOP3PX2 whose prefix
-  // half carries the regular-scale prefix opcode in word[0] bits [23:16] and its
-  // scale-A/scale-B sources in word[1] bits [8:0]/[17:9]. The two passes read the
-  // low and high scale halves; the second pass additionally accumulates the first
-  // pass's result (its C source becomes the intermediate D and the reuse bit is
-  // cleared). Read straight from the emitted words so operand miscompiles are
-  // caught.
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
   const size_t target_word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
-  constexpr uint32_t kScalePrefixOp = 0x35;
-  std::vector<size_t> pass_offsets;
-  for (size_t i = 0; i < target_word_count; ++i) {
-    if (((target_words[i] >> 16) & 0xffu) == kScalePrefixOp)
-      pass_offsets.push_back(i);
-  }
-  ASSERT_EQ(pass_offsets.size(), 2u) << "expected two regular-scale prefix passes";
-  for (const size_t pass_offset : pass_offsets) {
-    EXPECT_EQ((target_words[pass_offset] >> 11) & 1u, 1u)
-        << "M=16 must preserve the source A-scale lane selector";
-    EXPECT_EQ((target_words[pass_offset + 1] >> 27) & 1u, 1u)
-        << "Matrix B selection comes from SCL_OPSEL_HI[0]";
-  }
-  // The source scale operands were src0=v64, src1=v66 (VGPR encodings 256+64,
-  // 256+66). The two passes read the low and high scale halves derived from those.
-  const uint16_t first_scale_a = static_cast<uint16_t>(target_words[pass_offsets[0] + 1] & 0x1ffu);
-  const uint16_t second_scale_a = static_cast<uint16_t>(target_words[pass_offsets[1] + 1] & 0x1ffu);
-  EXPECT_GE(first_scale_a, 256u) << "first pass scale-A must be a VGPR";
-  EXPECT_GE(second_scale_a, 256u) << "second pass scale-A must be a VGPR";
-  EXPECT_NE(first_scale_a, second_scale_a) << "the two passes must read different scale halves";
+  ASSERT_EQ(target_word_count, 5u);
+  constexpr uint32_t kUnusedScaleSrc2Mask = 0x1ffu << 18;
+  EXPECT_EQ(target_words[0], scale16[0]);
+  EXPECT_EQ(target_words[1],
+            (scale16[1] & ~kUnusedScaleSrc2Mask) | (static_cast<uint32_t>(256u) << 18));
+  EXPECT_EQ(target_words[2], matrix[0]);
+  EXPECT_EQ(target_words[3], matrix[1]);
+  EXPECT_EQ(target_words[4], kGfx1250SEndpgm);
 
-  // FP8/FP8 is not the all-FP4 fast case. The gfx1250 hazard table requires
-  // three VALU co-execution slots before generated VALU may overwrite matrix A.
-  const uint32_t v_nop = gfx1250::build_vop1(gfx1250::kVNopVop1)[0];
-  ASSERT_LT(pass_offsets[0] + 7, target_word_count);
-  EXPECT_EQ(target_words[pass_offsets[0] + 4], v_nop);
-  EXPECT_EQ(target_words[pass_offsets[0] + 5], v_nop);
-  EXPECT_EQ(target_words[pass_offsets[0] + 6], v_nop);
-  EXPECT_NE(target_words[pass_offsets[0] + 7], v_nop);
-  ASSERT_LT(pass_offsets[1] + 7, target_word_count);
-  EXPECT_EQ(target_words[pass_offsets[1] + 4], v_nop);
-  EXPECT_EQ(target_words[pass_offsets[1] + 5], v_nop);
-  EXPECT_EQ(target_words[pass_offsets[1] + 6], v_nop);
-  EXPECT_NE(target_words[pass_offsets[1] + 7], v_nop);
-
-  // The FP8 matrix-A format takes the lane-mask K-selection path: each pass
-  // isolates its own K=16 half by cndmask'ing matrix-A lanes against a lane
-  // mask built from the low/high 16-bit halves. Pin those two mask literals so a
-  // regression that drops the split (or masks the wrong half) is caught, not
-  // just the WMMA opcode count.
-  const auto contains_word = [&](uint32_t value) {
-    return std::any_of(target_words, target_words + target_word_count,
-                       [&](uint32_t w) { return w == value; });
-  };
-  EXPECT_TRUE(contains_word(0x0000ffffu)) << "missing low-half Scale16 lane mask";
-  EXPECT_TRUE(contains_word(0xffff0000u)) << "missing high-half Scale16 lane mask";
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(std::ranges::count_if(decoded,
+                                  [](const auto &candidate) {
+                                    return candidate->mnemonic() ==
+                                           "v_wmma_scale16_f32_16x16x128_f8f6f4";
+                                  }),
+            1);
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250Scale16UsesSpillBackedScratchWhenVgprsAreFull) {
+TEST(BinaryTranslatorE2E, Gfx1250Scale16M32DoesNotNeedScratchWhenVgprsAreFull) {
   using namespace rocr::llvm::amdhsa;
 
   constexpr auto scale16 =
@@ -10360,33 +10480,21 @@ TEST(BinaryTranslatorE2E, Gfx1250Scale16UsesSpillBackedScratchWhenVgprsAreFull) 
                           .byte_offset = scratch.ioffset});
   }
 
-  // FP4 Scale16 needs eight masked-A lanes and five scalar temporaries. With
-  // every free register forced above the low-bank policy, the lowering borrows
-  // v[0:12], saves every lane, and restores the same range and offsets.
-  ASSERT_EQ(stores.size(), 13u);
-  ASSERT_EQ(loads.size(), 13u);
-  for (uint8_t i = 0; i < 13; ++i) {
-    EXPECT_EQ(stores[i].vgpr, i);
-    EXPECT_EQ(stores[i].byte_offset, static_cast<uint32_t>(i) * sizeof(uint32_t));
-    EXPECT_EQ(loads[i].vgpr, i);
-    EXPECT_EQ(loads[i].byte_offset, static_cast<uint32_t>(i) * sizeof(uint32_t));
-  }
-  EXPECT_EQ(wait_store_count, 1u);
-  EXPECT_EQ(wait_load_count, 1u);
-
-  const uint32_t wait_store = gfx1250::build_sopp(gfx1250::kSWaitStorecntSopp, {.simm16 = 0})[0];
-  const uint32_t wait_load = gfx1250::build_sopp(gfx1250::kSWaitLoadcntSopp, {.simm16 = 0})[0];
-  const uint32_t v_nop = gfx1250::build_vop1(gfx1250::kVNopVop1)[0];
-  ASSERT_LT(stores.back().word_offset + 3, target_word_count);
-  EXPECT_EQ(target_words[stores.back().word_offset + 3], wait_store);
-  ASSERT_GT(loads.front().word_offset, 0u);
-  EXPECT_EQ(target_words[loads.front().word_offset - 1], v_nop)
-      << "the final WMMA must clear its co-execution hazard before restoration";
-  ASSERT_LT(loads.back().word_offset + 3, target_word_count);
-  EXPECT_EQ(target_words[loads.back().word_offset + 3], wait_load);
+  EXPECT_TRUE(stores.empty());
+  EXPECT_TRUE(loads.empty());
+  EXPECT_EQ(wait_store_count, 0u);
+  EXPECT_EQ(wait_load_count, 0u);
+  EXPECT_EQ(std::ranges::count_if(decoded,
+                                  [](const auto &candidate) {
+                                    return candidate->mnemonic() ==
+                                           "v_wmma_scale16_f32_16x16x128_f8f6f4";
+                                  }),
+            2);
+  ASSERT_GT(target_word_count, 0u);
+  EXPECT_EQ(target_words[target_word_count - 1], kGfx1250SEndpgm);
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250Scale16SpillOffsetFailureLeavesElfUnchanged) {
+TEST(BinaryTranslatorE2E, Gfx1250Scale16M32IgnoresUnavailableScratchSpillSpace) {
   using namespace rocr::llvm::amdhsa;
 
   constexpr auto scale16 =
@@ -10415,11 +10523,8 @@ TEST(BinaryTranslatorE2E, Gfx1250Scale16SpillOffsetFailureLeavesElfUnchanged) {
                                         options);
   const auto result = translator.translate(source);
 
-  EXPECT_FALSE(result.ok());
-  EXPECT_EQ(result.elf_bytes, image);
-  EXPECT_TRUE(rocjitsu::has_error_containing(
-      result, rocjitsu::DiagnosticKind::ExpandFailed,
-      "Scale16 WMMA could not allocate its contiguous scratch range"));
+  EXPECT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                         : result.diagnostics.front().message);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250FailsClosedOnStandalone32x16Fp4ForA0) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -8957,14 +8957,6 @@ TEST(SemanticTranslator, Gfx1250ClassifiesLivenessFreeExpandRules) {
       (static_cast<uint32_t>(gfx1250::encoding::kVop3p) << 16) |
           gfx1250::kVSwmmacI3216x16x128Iu8Vop3p,
       (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
-          gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p,
-      (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
-          gfx1250::kVWmmaF3216x16x128Fp8Bf8Vop3p,
-      (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
-          gfx1250::kVWmmaF3216x16x128Bf8Fp8Vop3p,
-      (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
-          gfx1250::kVWmmaF3216x16x128Bf8Bf8Vop3p,
-      (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
           gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p,
       (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
           gfx1250::kVWmmaF1616x16x128Fp8Bf8Vop3p,
@@ -8978,27 +8970,27 @@ TEST(SemanticTranslator, Gfx1250ClassifiesLivenessFreeExpandRules) {
   EXPECT_EQ(liveness_free_rules, expected);
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250LowersF32K128Fp8Bf8WmmaToNeutralRegularScale) {
+TEST(BinaryTranslatorE2E, Gfx1250SplitsF32K128Fp8Bf8WmmaWithoutScratchWhenInputsDoNotOverlap) {
   struct WmmaCase {
     const char *name;
     uint16_t source_opcode;
-    uint8_t matrix_a_fmt;
-    uint8_t matrix_b_fmt;
+    uint16_t replacement_opcode;
   };
   constexpr std::array cases = {
-      WmmaCase{"fp8_fp8", gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p, 0, 0},
-      WmmaCase{"fp8_bf8", gfx1250::kVWmmaF3216x16x128Fp8Bf8Vop3p, 0, 1},
-      WmmaCase{"bf8_fp8", gfx1250::kVWmmaF3216x16x128Bf8Fp8Vop3p, 1, 0},
-      WmmaCase{"bf8_bf8", gfx1250::kVWmmaF3216x16x128Bf8Bf8Vop3p, 1, 1},
+      WmmaCase{"fp8_fp8", gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p,
+               gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p},
+      WmmaCase{"fp8_bf8", gfx1250::kVWmmaF3216x16x128Fp8Bf8Vop3p,
+               gfx1250::kVWmmaF3216x16x64Fp8Bf8Vop3p},
+      WmmaCase{"bf8_fp8", gfx1250::kVWmmaF3216x16x128Bf8Fp8Vop3p,
+               gfx1250::kVWmmaF3216x16x64Bf8Fp8Vop3p},
+      WmmaCase{"bf8_bf8", gfx1250::kVWmmaF3216x16x128Bf8Bf8Vop3p,
+               gfx1250::kVWmmaF3216x16x64Bf8Bf8Vop3p},
   };
   constexpr gfx1250::Vop3pBuilderFields fields{
       .vdst = 54,
-      .neg_hi = 5,
-      .clamp = 1,
       .src0 = 256 + 16,
       .src1 = 256 + 32,
       .src2 = 256 + 48,
-      .neg = 3,
   };
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
 
@@ -9020,48 +9012,89 @@ TEST(BinaryTranslatorE2E, Gfx1250LowersF32K128Fp8Bf8WmmaToNeutralRegularScale) {
     rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
     const auto decoded =
         decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
-    EXPECT_EQ(std::ranges::count_if(decoded,
-                                    [](const auto &candidate) {
-                                      return candidate->mnemonic() ==
-                                             "v_wmma_scale_f32_16x16x128_f8f6f4";
-                                    }),
-              1);
-    EXPECT_EQ(std::ranges::count_if(decoded,
-                                    [](const auto &candidate) {
-                                      return candidate->mnemonic().find("16x16x64") !=
-                                             std::string_view::npos;
-                                    }),
-              0);
+    std::vector<gfx1250::Vop3pMachineInst> replacements;
+    for (const auto &candidate : decoded) {
+      if (candidate->opcode() != test_case.replacement_opcode)
+        continue;
+      ASSERT_NE(candidate->raw_encoding(), nullptr);
+      gfx1250::Vop3pMachineInst replacement{};
+      std::memcpy(&replacement, candidate->raw_encoding(), sizeof(replacement));
+      replacements.push_back(replacement);
+    }
+    ASSERT_EQ(replacements.size(), 2u);
 
-    const auto *words = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
-    const size_t word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
-    const auto prefix = std::find_if(words, words + word_count, [](uint32_t word) {
-      return ((word >> 24) & 0xffu) == 0xccu && ((word >> 16) & 0xffu) == 0x35u;
-    });
-    ASSERT_NE(prefix, words + word_count);
-    ASSERT_GE(words + word_count - prefix, 4);
-    gfx1250::Vop3pMachineInst scale_prefix{};
-    std::memcpy(&scale_prefix, prefix, sizeof(scale_prefix));
-    EXPECT_EQ(scale_prefix.src0, 128u);
-    EXPECT_EQ(scale_prefix.src1, 128u);
-    EXPECT_EQ(scale_prefix.src2, 256u);
-    EXPECT_EQ(scale_prefix.neg, 0u);
-    EXPECT_EQ(scale_prefix.neg_hi, 0u);
-    EXPECT_EQ(scale_prefix.opsel, 0u);
-    EXPECT_EQ(scale_prefix.opsel_hi, 0u);
+    EXPECT_EQ(replacements[0].vdst, fields.vdst);
+    EXPECT_EQ(replacements[0].src0, 256u + 16u);
+    EXPECT_EQ(replacements[0].src1, 256u + 32u);
+    EXPECT_EQ(replacements[0].src2, 256u + 48u);
 
-    gfx1250::Vop3pMachineInst replacement{};
-    std::memcpy(&replacement, prefix + 2, sizeof(replacement));
-    EXPECT_EQ(replacement.op, gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p);
-    EXPECT_EQ(replacement.vdst, fields.vdst);
-    EXPECT_EQ(replacement.neg_hi, fields.neg_hi);
-    EXPECT_EQ(replacement.clamp, fields.clamp);
-    EXPECT_EQ(replacement.src0, fields.src0);
-    EXPECT_EQ(replacement.src1, fields.src1);
-    EXPECT_EQ(replacement.src2, fields.src2);
-    EXPECT_EQ(replacement.opsel, test_case.matrix_a_fmt);
-    EXPECT_EQ(replacement.opsel_hi, test_case.matrix_b_fmt);
-    EXPECT_EQ(replacement.neg, fields.neg);
+    EXPECT_EQ(replacements[1].vdst, fields.vdst);
+    EXPECT_EQ(replacements[1].src0, 256u + 24u);
+    EXPECT_EQ(replacements[1].src1, 256u + 40u);
+    EXPECT_EQ(replacements[1].src2, 256u + fields.vdst);
+  }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250K128WmmaUsesScratchWhenDestinationOverlapsUpperInput) {
+  struct OverlapCase {
+    const char *name;
+    uint8_t vdst;
+    uint16_t src0;
+    uint16_t src1;
+  };
+  constexpr std::array cases = {
+      OverlapCase{"upper_a", 26, 256 + 18, 256 + 114},
+      OverlapCase{"upper_b", 122, 256 + 18, 256 + 114},
+  };
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+
+  for (const OverlapCase &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    const auto source_wmma = gfx1250::build_vop3p(
+        gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p,
+        {.vdst = test_case.vdst, .src0 = test_case.src0, .src1 = test_case.src1, .src2 = 128});
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+        {source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    auto result = translator.translate(source);
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    const auto decoded =
+        decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+
+    std::vector<gfx1250::Vop3pMachineInst> replacements;
+    for (const auto &candidate : decoded) {
+      if (candidate->opcode() != gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p)
+        continue;
+      ASSERT_NE(candidate->raw_encoding(), nullptr);
+      gfx1250::Vop3pMachineInst replacement{};
+      std::memcpy(&replacement, candidate->raw_encoding(), sizeof(replacement));
+      replacements.push_back(replacement);
+    }
+    ASSERT_EQ(replacements.size(), 2u);
+
+    const uint8_t scratch = replacements[0].vdst;
+    EXPECT_NE(scratch, test_case.vdst);
+    EXPECT_EQ(scratch % 8u, 0u);
+    EXPECT_FALSE(scratch < test_case.src0 - 256u + 16u &&
+                 test_case.src0 - 256u < static_cast<uint16_t>(scratch) + 8u);
+    EXPECT_FALSE(scratch < test_case.src1 - 256u + 16u &&
+                 test_case.src1 - 256u < static_cast<uint16_t>(scratch) + 8u);
+
+    EXPECT_EQ(replacements[0].src0, test_case.src0);
+    EXPECT_EQ(replacements[0].src1, test_case.src1);
+    EXPECT_EQ(replacements[0].src2, 128u);
+
+    EXPECT_EQ(replacements[1].vdst, test_case.vdst);
+    EXPECT_EQ(replacements[1].src0, test_case.src0 + 8u);
+    EXPECT_EQ(replacements[1].src1, test_case.src1 + 8u);
+    EXPECT_EQ(replacements[1].src2, 256u + scratch);
   }
 }
 

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -8957,6 +8957,14 @@ TEST(SemanticTranslator, Gfx1250ClassifiesLivenessFreeExpandRules) {
       (static_cast<uint32_t>(gfx1250::encoding::kVop3p) << 16) |
           gfx1250::kVSwmmacI3216x16x128Iu8Vop3p,
       (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
+          gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p,
+      (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
+          gfx1250::kVWmmaF3216x16x128Fp8Bf8Vop3p,
+      (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
+          gfx1250::kVWmmaF3216x16x128Bf8Fp8Vop3p,
+      (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
+          gfx1250::kVWmmaF3216x16x128Bf8Bf8Vop3p,
+      (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
           gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p,
       (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
           gfx1250::kVWmmaF1616x16x128Fp8Bf8Vop3p,
@@ -8970,7 +8978,7 @@ TEST(SemanticTranslator, Gfx1250ClassifiesLivenessFreeExpandRules) {
   EXPECT_EQ(liveness_free_rules, expected);
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250UsesNeutralScaledK128Fp8Bf8WmmaWhenSourceOpselMaps) {
+TEST(BinaryTranslatorE2E, Gfx1250UsesNeutralScaledK128Fp8Bf8Wmma) {
   struct WmmaCase {
     const char *name;
     uint16_t source_opcode;
@@ -8985,12 +8993,13 @@ TEST(BinaryTranslatorE2E, Gfx1250UsesNeutralScaledK128Fp8Bf8WmmaWhenSourceOpselM
   };
   constexpr gfx1250::Vop3pBuilderFields fields{
       .vdst = 54,
-      .neg_hi = 4,
-      .opsel = 4,
+      .neg_hi = 7,
+      .opsel = 7,
       .src0 = 256 + 16,
       .src1 = 256 + 32,
       .src2 = 256 + 48,
-      .neg = 4,
+      .opsel_hi = 3,
+      .neg = 7,
   };
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
 
@@ -9034,93 +9043,16 @@ TEST(BinaryTranslatorE2E, Gfx1250UsesNeutralScaledK128Fp8Bf8WmmaWhenSourceOpselM
     EXPECT_EQ(matrix.src2, fields.src2);
     EXPECT_EQ(matrix.opsel, test_case.matrix_a_fmt);
     EXPECT_EQ((matrix.pad_14 << 2) | matrix.opsel_hi, test_case.matrix_b_fmt);
-    EXPECT_EQ(matrix.neg_hi, fields.neg_hi);
-    EXPECT_EQ(matrix.neg, fields.neg);
+    EXPECT_EQ(matrix.neg_hi, 4u) << "preserve only C absolute";
+    EXPECT_EQ(matrix.neg, 4u) << "preserve only C negate";
     EXPECT_EQ(words[4], kGfx1250SEndpgm);
   }
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250K128WmmaFallbackUsesScratchForUnmappedOpselAndOverlap) {
-  struct OverlapCase {
-    const char *name;
-    uint8_t vdst;
-    uint16_t src0;
-    uint16_t src1;
-  };
-  constexpr std::array cases = {
-      OverlapCase{"upper_a", 26, 256 + 18, 256 + 114},
-      OverlapCase{"upper_b", 122, 256 + 18, 256 + 114},
-  };
-  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
-
-  for (const OverlapCase &test_case : cases) {
-    SCOPED_TRACE(test_case.name);
-    auto source_wmma =
-        gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p, {.vdst = test_case.vdst,
-                                                                      .neg_hi = 4,
-                                                                      .opsel = 6,
-                                                                      .src0 = test_case.src0,
-                                                                      .src1 = test_case.src1,
-                                                                      .src2 = 128,
-                                                                      .neg = 4});
-    source_wmma[0] |= uint32_t{1} << 14;
-    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
-        {source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
-    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
-
-    rocjitsu::BinaryTranslator translator(
-        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
-        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
-                                 rocjitsu::ProcessorRevision::Gfx1250A0));
-    auto result = translator.translate(source);
-    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
-                                                            : result.diagnostics.front().message);
-    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
-    const auto decoded =
-        decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
-
-    std::vector<gfx1250::Vop3pMachineInst> replacements;
-    for (const auto &candidate : decoded) {
-      if (candidate->opcode() != gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p)
-        continue;
-      ASSERT_NE(candidate->raw_encoding(), nullptr);
-      gfx1250::Vop3pMachineInst replacement{};
-      std::memcpy(&replacement, candidate->raw_encoding(), sizeof(replacement));
-      replacements.push_back(replacement);
-    }
-    ASSERT_EQ(replacements.size(), 2u);
-
-    const uint8_t scratch = replacements[0].vdst;
-    EXPECT_NE(scratch, test_case.vdst);
-    EXPECT_EQ(scratch % 8u, 0u);
-    EXPECT_FALSE(scratch < test_case.src0 - 256u + 16u &&
-                 test_case.src0 - 256u < static_cast<uint16_t>(scratch) + 8u);
-    EXPECT_FALSE(scratch < test_case.src1 - 256u + 16u &&
-                 test_case.src1 - 256u < static_cast<uint16_t>(scratch) + 8u);
-
-    EXPECT_EQ(replacements[0].src0, test_case.src0);
-    EXPECT_EQ(replacements[0].src1, test_case.src1);
-    EXPECT_EQ(replacements[0].src2, 128u);
-    EXPECT_EQ(replacements[0].opsel & 4u, 0u);
-    EXPECT_EQ(replacements[0].pad_14, 0u);
-    EXPECT_EQ(replacements[0].neg_hi, 4u);
-    EXPECT_EQ(replacements[0].neg, 4u);
-
-    EXPECT_EQ(replacements[1].vdst, test_case.vdst);
-    EXPECT_EQ(replacements[1].src0, test_case.src0 + 8u);
-    EXPECT_EQ(replacements[1].src1, test_case.src1 + 8u);
-    EXPECT_EQ(replacements[1].src2, 256u + scratch);
-    EXPECT_EQ(replacements[1].opsel & 4u, 0u);
-    EXPECT_EQ(replacements[1].pad_14, 0u);
-    EXPECT_EQ(replacements[1].neg_hi, 0u);
-    EXPECT_EQ(replacements[1].neg, 0u);
-  }
-}
-
-TEST(BinaryTranslatorE2E, Gfx1250K128WmmaFallbackKeepsNoOverlapPathScratchFree) {
-  constexpr auto source_wmma = gfx1250::build_vop3p(
-      gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p,
-      {.vdst = 96, .opsel = 2, .src0 = 256 + 248, .src1 = 256 + 40, .src2 = 128});
+TEST(BinaryTranslatorE2E, Gfx1250K128WmmaTranslatesCapturedEncodingWithoutK64Fallback) {
+  // Captured compiler encoding. OPSEL_HI is three, but these source fields do
+  // not select matrix formats for this opcode and must not gate translation.
+  constexpr std::array<uint32_t, 2> source_wmma = {0xCC800088u, 0x1A02E542u};
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
@@ -9134,39 +9066,33 @@ TEST(BinaryTranslatorE2E, Gfx1250K128WmmaFallbackKeepsNoOverlapPathScratchFree) 
                                                           : result.diagnostics.front().message);
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  EXPECT_EQ(translated.text_sections()[0]->size(), 5 * sizeof(uint32_t));
   const auto decoded =
       decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
-  std::vector<gfx1250::Vop3pMachineInst> replacements;
-  std::vector<uint16_t> modes;
-  for (const auto &candidate : decoded) {
-    if (candidate->mnemonic() == "s_set_vgpr_msb") {
-      ASSERT_NE(candidate->raw_encoding(), nullptr);
-      modes.push_back(static_cast<uint16_t>(candidate->raw_encoding()[0] & 0xffffu));
-      continue;
-    }
-    if (candidate->opcode() != gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p)
-      continue;
-    ASSERT_NE(candidate->raw_encoding(), nullptr);
-    gfx1250::Vop3pMachineInst replacement{};
-    std::memcpy(&replacement, candidate->raw_encoding(), sizeof(replacement));
-    replacements.push_back(replacement);
-  }
-
-  ASSERT_EQ(replacements.size(), 2u);
-  EXPECT_EQ(replacements[0].vdst, 96u);
-  EXPECT_EQ(replacements[0].src0, 256u + 248u);
-  EXPECT_EQ(replacements[1].vdst, 96u);
-  EXPECT_EQ(replacements[1].src0, 256u);
-  EXPECT_EQ(replacements[1].src1, 256u + 48u);
-  EXPECT_EQ(replacements[1].src2, 256u + 96u);
-  EXPECT_EQ(modes, (std::vector<uint16_t>{0x0001u, 0x0100u}));
+  EXPECT_EQ(std::ranges::count_if(decoded,
+                                  [](const auto &candidate) {
+                                    return candidate->mnemonic() ==
+                                           "v_wmma_scale_f32_16x16x128_f8f6f4";
+                                  }),
+            1);
+  EXPECT_EQ(std::ranges::count_if(decoded,
+                                  [](const auto &candidate) {
+                                    return candidate->mnemonic().find("16x16x64_fp8") !=
+                                               std::string_view::npos ||
+                                           candidate->mnemonic().find("16x16x64_bf8") !=
+                                               std::string_view::npos;
+                                  }),
+            0);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250F32K128WmmaRejectsNonVgprMatrixInputs) {
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   for (const gfx1250::Vop3pBuilderFields fields : {
-           gfx1250::Vop3pBuilderFields{.vdst = 54, .src0 = 128, .src1 = 256 + 32, .src2 = 256 + 48},
-           gfx1250::Vop3pBuilderFields{.vdst = 54, .src0 = 256 + 16, .src1 = 128, .src2 = 256 + 48},
+           gfx1250::Vop3pBuilderFields{
+               .vdst = 54, .src0 = 128, .src1 = 256 + 32, .src2 = 256 + 48, .opsel_hi = 3},
+           gfx1250::Vop3pBuilderFields{
+               .vdst = 54, .src0 = 256 + 16, .src1 = 128, .src2 = 256 + 48, .opsel_hi = 3},
        }) {
     const auto source_wmma = gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p, fields);
     auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
@@ -9187,9 +9113,13 @@ TEST(BinaryTranslatorE2E, Gfx1250F32K128WmmaRejectsNonVgprMatrixInputs) {
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250F32K128WmmaRejectsClamp) {
-  constexpr auto source_wmma = gfx1250::build_vop3p(
-      gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p,
-      {.vdst = 54, .clamp = 1, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48});
+  constexpr auto source_wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p, {.vdst = 54,
+                                                                    .clamp = 1,
+                                                                    .src0 = 256 + 16,
+                                                                    .src1 = 256 + 32,
+                                                                    .src2 = 256 + 48,
+                                                                    .opsel_hi = 3});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
@@ -9867,6 +9797,69 @@ TEST(BinaryTranslatorE2E, Gfx1250RegularWmmaScaleEncodesUnusedSrc2AsVgpr) {
   EXPECT_EQ(target_words[4], kGfx1250SEndpgm);
 }
 
+TEST(BinaryTranslatorE2E, Gfx1250FloatingScaledWmmaRejectsNonzeroCmFields) {
+  struct CmCase {
+    const char *name;
+    uint16_t prefix_opcode;
+    uint8_t prefix_cm;
+    uint8_t matrix_cm;
+    const char *diagnostic;
+  };
+  constexpr std::array cases = {
+      CmCase{"regular_prefix", 0x35, 1, 0, "SCL_CM must be set to zero"},
+      CmCase{"regular_matrix", 0x35, 0, 1, "CLAMP \"must be set to zero\""},
+      CmCase{"scale16_prefix", 0x3a, 1, 0, "SCL_CM must be set to zero"},
+      CmCase{"scale16_matrix", 0x3a, 0, 1, "CLAMP \"must be set to zero\""},
+  };
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+
+  for (const CmCase &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    const auto prefix = gfx1250::build_vop3p(
+        test_case.prefix_opcode, {.clamp = test_case.prefix_cm, .src0 = 4, .src1 = 6, .src2 = 0});
+    const auto matrix =
+        gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p, {.vdst = 96,
+                                                                      .clamp = test_case.matrix_cm,
+                                                                      .src0 = 256 + 16,
+                                                                      .src1 = 256 + 32,
+                                                                      .src2 = 128});
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+        {prefix[0], prefix[1], matrix[0], matrix[1], kGfx1250SEndpgm});
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    const auto result = translator.translate(source);
+
+    EXPECT_FALSE(result.ok());
+    EXPECT_EQ(result.elf_bytes, image);
+    EXPECT_TRUE(rocjitsu::has_error_containing(result, rocjitsu::DiagnosticKind::ExpandFailed,
+                                               test_case.diagnostic));
+  }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250BareFloatingWmmaRejectsClamp) {
+  constexpr auto matrix = gfx1250::build_vop3p(
+      gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p,
+      {.vdst = 96, .clamp = 1, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 128});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {matrix[0], matrix[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(rocjitsu::has_error_containing(
+      result, rocjitsu::DiagnosticKind::ExpandFailed,
+      "CLAMP \"must be set to zero\" for WMMA/SWMMAC producing floating-point results"));
+}
+
 TEST(BinaryTranslatorE2E, Gfx1250PreservesVop3DppExtensionWord) {
   // Real rocSPARSE encoding: v_fma_f32_e64_dpp is a 64-bit VOP3 followed by
   // one DPP control DWORD. The decoder must consume and preserve all 12 bytes,
@@ -10266,17 +10259,84 @@ TEST(BinaryTranslatorE2E, Gfx1250Scale16Fp4AcceptsScalarAndInlineScaleSources) {
   EXPECT_EQ(prefix_count, 2u);
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250Scale16Fp4RejectsScalePairOverlap) {
-  constexpr auto matrix =
-      gfx1250::build_vop3p(gfx1250::kVWmmaF3232x16x128F4Vop3p,
-                           {.vdst = 96, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48});
+TEST(BinaryTranslatorE2E, Gfx1250Scale16RejectsMisalignedOrOutOfRangeVgprPairs) {
+  struct MatrixCase {
+    const char *name;
+    uint16_t opcode;
+  };
+  constexpr std::array matrix_cases = {
+      MatrixCase{"m16", gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p},
+      MatrixCase{"m32", gfx1250::kVWmmaF3232x16x128F4Vop3p},
+  };
+  struct ScaleCase {
+    const char *name;
+    bool source1;
+    uint16_t base;
+  };
+  constexpr std::array scale_cases = {
+      ScaleCase{"src0_odd", false, 65},
+      ScaleCase{"src1_odd", true, 67},
+      ScaleCase{"src0_v255", false, 255},
+      ScaleCase{"src1_v255", true, 255},
+  };
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
 
-  for (const gfx1250::Vop3pBuilderFields fields : {
-           gfx1250::Vop3pBuilderFields{.src0 = 256 + 96, .src1 = 256 + 64, .src2 = 0},
-           gfx1250::Vop3pBuilderFields{.src0 = 256 + 64, .src1 = 256 + 96, .src2 = 0},
-       }) {
-    const auto scale16 = gfx1250::build_vop3p(0x3a, fields);
+  for (const MatrixCase &matrix_case : matrix_cases) {
+    for (const ScaleCase &scale_case : scale_cases) {
+      SCOPED_TRACE(std::string(matrix_case.name) + "_" + scale_case.name);
+      const auto scale16 = gfx1250::build_vop3p(
+          0x3a, {.src0 = static_cast<uint16_t>(256 + (scale_case.source1 ? 64 : scale_case.base)),
+                 .src1 = static_cast<uint16_t>(256 + (scale_case.source1 ? scale_case.base : 66)),
+                 .src2 = 0});
+      const auto matrix = gfx1250::build_vop3p(
+          matrix_case.opcode, {.vdst = 96, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48});
+      auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+          {scale16[0], scale16[1], matrix[0], matrix[1], kGfx1250SEndpgm});
+      rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+      rocjitsu::BinaryTranslator translator(
+          ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+          gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                   rocjitsu::ProcessorRevision::Gfx1250A0));
+      const auto result = translator.translate(source);
+
+      EXPECT_FALSE(result.ok());
+      EXPECT_EQ(result.elf_bytes, image);
+      EXPECT_TRUE(rocjitsu::has_error_containing(
+          result, rocjitsu::DiagnosticKind::ExpandFailed,
+          "Scale16 VGPR scale sources must be even-aligned pairs in v0:v255"));
+    }
+  }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250Scale16Fp4RejectsEveryDestructiveUpperInputOverlap) {
+  struct OverlapCase {
+    const char *name;
+    gfx1250::Vop3pBuilderFields scale;
+    gfx1250::Vop3pBuilderFields matrix;
+  };
+  constexpr std::array cases = {
+      OverlapCase{"scale_src0_second_register",
+                  {.src0 = 256 + 96, .src1 = 256 + 64, .src2 = 0},
+                  {.vdst = 97, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48}},
+      OverlapCase{"scale_src1_second_register",
+                  {.src0 = 256 + 64, .src1 = 256 + 96, .src2 = 0},
+                  {.vdst = 97, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48}},
+      OverlapCase{"upper_a",
+                  {.src0 = 256 + 64, .src1 = 256 + 66, .src2 = 0},
+                  {.vdst = 96, .src0 = 256 + 88, .src1 = 256 + 32, .src2 = 256 + 48}},
+      OverlapCase{"shared_b",
+                  {.src0 = 256 + 64, .src1 = 256 + 66, .src2 = 0},
+                  {.vdst = 96, .src0 = 256 + 16, .src1 = 256 + 96, .src2 = 256 + 48}},
+      OverlapCase{"upper_c",
+                  {.src0 = 256 + 64, .src1 = 256 + 66, .src2 = 0},
+                  {.vdst = 96, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 88}},
+  };
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+
+  for (const OverlapCase &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    const auto scale16 = gfx1250::build_vop3p(0x3a, test_case.scale);
+    const auto matrix = gfx1250::build_vop3p(gfx1250::kVWmmaF3232x16x128F4Vop3p, test_case.matrix);
     auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
         {scale16[0], scale16[1], matrix[0], matrix[1], kGfx1250SEndpgm});
     rocjitsu::AmdGpuCodeObject source(image.data(), image.size());

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -9013,8 +9013,7 @@ TEST(BinaryTranslatorE2E, Gfx1250UsesNeutralScaledK128Fp8Bf8WmmaWhenSourceOpselM
     rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
     ASSERT_FALSE(translated.text_sections().empty());
     ASSERT_GE(translated.text_sections()[0]->size(), 5 * sizeof(uint32_t));
-    const auto *words =
-        reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+    const auto *words = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
     gfx1250::Vop3pMachineInst prefix{};
     gfx1250::Vop3pMachineInst matrix{};
     std::memcpy(&prefix, words, sizeof(prefix));
@@ -9056,15 +9055,14 @@ TEST(BinaryTranslatorE2E, Gfx1250K128WmmaFallbackUsesScratchForUnmappedOpselAndO
 
   for (const OverlapCase &test_case : cases) {
     SCOPED_TRACE(test_case.name);
-    auto source_wmma = gfx1250::build_vop3p(
-        gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p,
-        {.vdst = test_case.vdst,
-         .neg_hi = 4,
-         .opsel = 6,
-         .src0 = test_case.src0,
-         .src1 = test_case.src1,
-         .src2 = 128,
-         .neg = 4});
+    auto source_wmma =
+        gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p, {.vdst = test_case.vdst,
+                                                                      .neg_hi = 4,
+                                                                      .opsel = 6,
+                                                                      .src0 = test_case.src0,
+                                                                      .src1 = test_case.src1,
+                                                                      .src2 = 128,
+                                                                      .neg = 4});
     source_wmma[0] |= uint32_t{1} << 14;
     auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
         {source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
@@ -9186,6 +9184,28 @@ TEST(BinaryTranslatorE2E, Gfx1250F32K128WmmaRejectsNonVgprMatrixInputs) {
         rocjitsu::has_error_containing(result, rocjitsu::DiagnosticKind::ExpandFailed,
                                        "K=128 WMMA matrix operands are not ordinary VGPR ranges"));
   }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250F32K128WmmaRejectsClamp) {
+  constexpr auto source_wmma = gfx1250::build_vop3p(
+      gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p,
+      {.vdst = 54, .clamp = 1, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(rocjitsu::has_error_containing(
+      result, rocjitsu::DiagnosticKind::ExpandFailed,
+      "Input is malformed, CLAMP \"must be set to zero\" for WMMA/SWMMAC producing "
+      "floating-point results"));
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250F16K128Fp8Bf8WmmaStillFailsClosedForA0) {
@@ -9877,15 +9897,10 @@ TEST(BinaryTranslatorE2E, Gfx1250PreservesVop3DppExtensionWord) {
 
 TEST(BinaryTranslatorE2E, Gfx1250SplitsRegularScaleFp4AcrossMForA0) {
   constexpr auto scale =
-      gfx1250::build_vop3p(0x35,
-                           {.src0 = 256 + 64, .src1 = 256 + 66, .src2 = 0, .opsel_hi = 1});
-  constexpr auto matrix =
-      gfx1250::build_vop3p(gfx1250::kVWmmaF3232x16x128F4Vop3p, {.vdst = 96,
-                                                                .neg_hi = 4,
-                                                                .src0 = 256 + 16,
-                                                                .src1 = 256 + 32,
-                                                                .src2 = 256 + 48,
-                                                                .neg = 4});
+      gfx1250::build_vop3p(0x35, {.src0 = 256 + 64, .src1 = 256 + 66, .src2 = 0, .opsel_hi = 1});
+  constexpr auto matrix = gfx1250::build_vop3p(
+      gfx1250::kVWmmaF3232x16x128F4Vop3p,
+      {.vdst = 96, .neg_hi = 4, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48, .neg = 4});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {scale[0], scale[1], matrix[0], matrix[1], kGfx1250SEndpgm});
@@ -9914,8 +9929,7 @@ TEST(BinaryTranslatorE2E, Gfx1250SplitsRegularScaleFp4AcrossMForA0) {
     EXPECT_EQ((words[offset] >> 11) & 0x1u, half);
     EXPECT_EQ(words[offset] & ((1u << 13) | (1u << 14)), 0u);
     EXPECT_EQ((words[offset + 1] >> 18) & 0x1ffu, 0x100u);
-    EXPECT_EQ((words[offset + 1] >> 27) & 0x1u, 1u)
-        << "B scale selection uses SCL_OPSEL_HI[0]";
+    EXPECT_EQ((words[offset + 1] >> 27) & 0x1u, 1u) << "B scale selection uses SCL_OPSEL_HI[0]";
 
     gfx1250::Vop3pMachineInst replacement{};
     std::memcpy(&replacement, words + offset + 2, sizeof(replacement));
@@ -9999,8 +10013,7 @@ TEST(BinaryTranslatorE2E, Gfx1250RegularScaleFp4RejectsScaleSourceOverlap) {
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250RegularScaleFp4AcceptsScalarAndInlineScaleSources) {
-  constexpr auto scale =
-      gfx1250::build_vop3p(0x35, {.src0 = 4, .src1 = 128, .src2 = 0});
+  constexpr auto scale = gfx1250::build_vop3p(0x35, {.src0 = 4, .src1 = 128, .src2 = 0});
   constexpr auto matrix =
       gfx1250::build_vop3p(gfx1250::kVWmmaF3232x16x128F4Vop3p,
                            {.vdst = 96, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48});
@@ -10150,23 +10163,17 @@ TEST(BinaryTranslatorE2E, Gfx1250RegularScaleFp4RejectsBank3UpperHalfOverflow) {
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250SplitsScale16Fp4AcrossMOnlyForA0) {
-  auto scale16 = gfx1250::build_vop3p(
-      0x3a,
-      {.neg_hi = 2,
-       .opsel = 4,
-       .src0 = 256 + 64,
-       .src1 = 256 + 66,
-       .src2 = 0,
-       .opsel_hi = 1,
-       .neg = 2});
+  auto scale16 = gfx1250::build_vop3p(0x3a, {.neg_hi = 2,
+                                             .opsel = 4,
+                                             .src0 = 256 + 64,
+                                             .src1 = 256 + 66,
+                                             .src2 = 0,
+                                             .opsel_hi = 1,
+                                             .neg = 2});
   scale16[0] |= uint32_t{1} << 14;
-  constexpr auto matrix =
-      gfx1250::build_vop3p(gfx1250::kVWmmaF3232x16x128F4Vop3p, {.vdst = 96,
-                                                                .neg_hi = 4,
-                                                                .src0 = 256 + 16,
-                                                                .src1 = 256 + 32,
-                                                                .src2 = 256 + 48,
-                                                                .neg = 4});
+  constexpr auto matrix = gfx1250::build_vop3p(
+      gfx1250::kVWmmaF3232x16x128F4Vop3p,
+      {.vdst = 96, .neg_hi = 4, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48, .neg = 4});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {scale16[0], scale16[1], matrix[0], matrix[1], kGfx1250SEndpgm});
@@ -10225,8 +10232,7 @@ TEST(BinaryTranslatorE2E, Gfx1250SplitsScale16Fp4AcrossMOnlyForA0) {
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250Scale16Fp4AcceptsScalarAndInlineScaleSources) {
-  constexpr auto scale16 =
-      gfx1250::build_vop3p(0x3a, {.src0 = 4, .src1 = 128, .src2 = 0});
+  constexpr auto scale16 = gfx1250::build_vop3p(0x3a, {.src0 = 4, .src1 = 128, .src2 = 0});
   constexpr auto matrix =
       gfx1250::build_vop3p(gfx1250::kVWmmaF3232x16x128F4Vop3p,
                            {.vdst = 96, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48});
@@ -10364,15 +10370,13 @@ TEST(BinaryTranslatorE2E, Gfx1250Scale16Fp4RejectsBank3UpperHalfOverflow) {
 TEST(BinaryTranslatorE2E, Gfx1250PreservesNativeM16Scale16ForA0) {
   constexpr auto scale16 = gfx1250::build_vop3p(
       0x3a, {.neg_hi = 2, .opsel = 1, .src0 = 4, .src1 = 6, .src2 = 0, .opsel_hi = 1});
-  auto matrix =
-      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p,
-                           {.vdst = 96,
-                            .neg_hi = 4,
-                            .opsel = 3,
-                            .src0 = 256 + 16,
-                            .src1 = 256 + 32,
-                            .src2 = 128,
-                            .neg = 4});
+  auto matrix = gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p, {.vdst = 96,
+                                                                              .neg_hi = 4,
+                                                                              .opsel = 3,
+                                                                              .src0 = 256 + 16,
+                                                                              .src1 = 256 + 32,
+                                                                              .src2 = 128,
+                                                                              .neg = 4});
   matrix[0] |= uint32_t{1} << 14;
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
@@ -10524,7 +10528,7 @@ TEST(BinaryTranslatorE2E, Gfx1250Scale16M32IgnoresUnavailableScratchSpillSpace) 
   const auto result = translator.translate(source);
 
   EXPECT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
-                                                         : result.diagnostics.front().message);
+                                                          : result.diagnostics.front().message);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250FailsClosedOnStandalone32x16Fp4ForA0) {


### PR DESCRIPTION
Revise gfx1250 B0-to-A0 WMMA translation so native scaled operations
stay native where possible, M=32 operations are partitioned only along
independent output rows, and f32 K=128 FP8/BF8 operations retain their
original K=128 accumulation topology.

The examples below use rocJITsu disassembly spelling. Long instructions
are wrapped with trailing backslashes solely for readability. Comments
call out encoded control fields that are not always printed as assembly
modifiers.

1. Preserve native M=16 Scale16

- Recognize V_WMMA_SCALE16_F32_16X16X128_F8F6F4 as available on both
  revisions.
- Copy the complete four-DWORD source instruction instead of converting
  it into regular-Scale operations.
- Normalize only the unused scale-prefix SRC2 field in bits 58:50 to the
  required VGPR0 operand encoding, 0x100.
- Preserve scale operands, scale selectors, matrix formats, A/B/C
  operands, destination fields, C modifiers, and valid reuse hints.
- Validate floating control fields and Scale16 VGPR-pair alignment before
  retaining the instruction.
- Remove the old M=16 even/odd scale-byte gathers, masked-A construction,
  extra K accumulation boundary, scratch allocation, spill save/restore,
  and generated V_NOP padding from this path.

Before:

    v_wmma_scale16_f32_16x16x128_f8f6f4 \
        v[96:103], v[16:23], v[32:39], v[48:55], \
        v[64:65], v[66:67] \
        matrix_a_fmt:MATRIX_FMT_FP4 \
        matrix_b_fmt:MATRIX_FMT_FP4

After:

    v_wmma_scale16_f32_16x16x128_f8f6f4 \
        v[96:103], v[16:23], v[32:39], v[48:55], \
        v[64:65], v[66:67] \
        matrix_a_fmt:MATRIX_FMT_FP4 \
        matrix_b_fmt:MATRIX_FMT_FP4

The assembly is intentionally identical. The only binary change is the
unused prefix SRC2 normalization, which is not shown by the
disassembler.

2. Split M=32 scaled FP4 only across M

- Lower V_WMMA_SCALE_F32_32X16X128_F4 and
  V_WMMA_SCALE16_F32_32X16X128_F4 into exactly two native
  V_WMMA_*_F32_16X16X128_F8F6F4 operations of the corresponding scale
  form.
- Slice matrix A by eight DWORDs for rows 16..31.
- Slice matrix C by eight DWORDs when C is a VGPR.
- Slice matrix D by eight DWORDs for rows 16..31.
- Share matrix B and both scale sources between the row operations.
- Select A-scale lanes 0..15 for rows 0..15 and lanes 16..31 for rows
  16..31.
- Preserve the source B-scale selector in both prefixes.
- Preserve C absolute and C negate in both row operations because each
  consumes an independent original C tile.
- Encode both target matrix formats as FP4.
- Normalize unused prefix SRC2 to 0x100 in both target operations.
- Clear RA and RB because the source expands into a different
  instruction sequence.
- Eliminate the previous four-operation M-and-K split.

Before:

    v_wmma_scale16_f32_32x16x128_f4 \
        v[96:111], v[16:31], v[32:39], v[48:63], \
        v[64:65], v[66:67]

After:

    ; Rows 0..15 use A-scale lanes 0..15.
    v_wmma_scale16_f32_16x16x128_f8f6f4 \
        v[96:103], v[16:23], v[32:39], v[48:55], \
        v[64:65], v[66:67] \
        matrix_a_fmt:MATRIX_FMT_FP4 \
        matrix_b_fmt:MATRIX_FMT_FP4

    ; Rows 16..31 use A-scale lanes 16..31.
    v_wmma_scale16_f32_16x16x128_f8f6f4 \
        v[104:111], v[24:31], v[32:39], v[56:63], \
        v[64:65], v[66:67] \
        matrix_a_fmt:MATRIX_FMT_FP4 \
        matrix_b_fmt:MATRIX_FMT_FP4 \
        matrix_a_scale:MATRIX_SCALE_ROW1

This keeps K intact: A, C, and D advance by eight VGPRs; B and the scale
operands remain shared.

3. Make the M=32 split safe across register banks and overlapping ranges

- Track SRC0, SRC1, SRC2, and VDST VGPR-MSB roles independently.
- Detect whether adding eight registers crosses a 256-register boundary
  for A, C, or D.
- Emit the corresponding upper-half VGPR-MSB mode before the second
  operation and restore the original mode afterward.
- Preserve the B bank because B is shared and does not move.
- Reject any split that would advance an affected role beyond bank 3.
- Reject a split when the first destination overlaps upper A, shared B,
  upper C, or either scale source needed by the second operation.
- Treat regular-Scale VGPR sources as one-register ranges and Scale16
  VGPR sources as two-register ranges.
- Evaluate scale-source overlaps in the low VGPR bank because scale
  operands ignore VGPR-MSB.
- Do not add a V_NOP between row operations: their results are disjoint,
  and the overlap checks protect every input needed by the second
  operation.

A boundary-crossing split has the following shape:

    ; Lower A tile is v[248:255] in SRC0 bank 0.
    v_wmma_scale16_f32_16x16x128_f8f6f4 \
        v[96:103], v[248:255], v[32:39], v[48:55], \
        v[64:65], v[66:67] \
        matrix_a_fmt:MATRIX_FMT_FP4 \
        matrix_b_fmt:MATRIX_FMT_FP4

    s_wait_xcnt 0
    s_set_vgpr_msb 1

    ; Encoded v[0:7] now names physical v[256:263] for SRC0.
    v_wmma_scale16_f32_16x16x128_f8f6f4 \
        v[104:111], v[0:7], v[32:39], v[56:63], \
        v[64:65], v[66:67] \
        matrix_a_fmt:MATRIX_FMT_FP4 \
        matrix_b_fmt:MATRIX_FMT_FP4 \
        matrix_a_scale:MATRIX_SCALE_ROW1

    s_wait_xcnt 0
    s_set_vgpr_msb 256

The packed S_SET_VGPR_MSB immediate records both the new and previous
mode. In this example 1 selects SRC0 bank 1, and 256 restores mode 0
from mode 1.

4. Accept scalar and inline scale sources and validate Scale16 pairs

- Allow SGPR and inline scale operands to be copied into both generated
  prefixes.
- Continue destructive-overlap checks only for encoded VGPR scales.
- Require each Scale16 VGPR operand to name an even-aligned pair within
  v0:v255 before native pass-through or expansion.
- Reject odd bases and v255 because they cannot name a complete
  two-register Scale16 source.

Before:

    v_wmma_scale_f32_32x16x128_f4 \
        v[96:111], v[16:31], v[32:39], v[48:63], s4, 0

After:

    v_wmma_scale_f32_16x16x128_f8f6f4 \
        v[96:103], v[16:23], v[32:39], v[48:55], s4, 0 \
        matrix_a_fmt:MATRIX_FMT_FP4 \
        matrix_b_fmt:MATRIX_FMT_FP4

    v_wmma_scale_f32_16x16x128_f8f6f4 \
        v[104:111], v[24:31], v[32:39], v[56:63], s4, 0 \
        matrix_a_fmt:MATRIX_FMT_FP4 \
        matrix_b_fmt:MATRIX_FMT_FP4 \
        matrix_a_scale:MATRIX_SCALE_ROW1

5. Translate f32 K=128 FP8/BF8 with one neutral-scaled K=128 operation

- Map all four FP8/BF8 A/B combinations to the corresponding Atype and
  Btype fields of V_WMMA_F32_16X16X128_F8F6F4.
- Emit one regular-Scale K=128 operation instead of introducing two
  K=64 accumulation steps.
- Use inline integer zero for both neutral E8M0 scales.
- Normalize the unused scale-prefix SRC2 field to 0x100.
- Preserve the source destination, A/B/C operands, and defined C
  absolute and negate modifiers.
- Clear RA and RB because the target belongs to a different instruction
  family.
- Ignore source encoding fields that have no meaning for these opcodes;
  reconstruct the target format selectors from the source opcode.
- Require A and B to be ordinary VGPR ranges.
- Keep the f16 K=128 forms fail-closed because splitting K would add an
  intermediate packed-f16 rounding boundary.
- Remove the K=64 fallback and all partial-accumulator scratch
  allocation.

Before:

    v_wmma_f32_16x16x128_fp8_bf8 \
        v[54:61], v[16:31], v[32:47], v[48:55]

After:

    v_wmma_scale_f32_16x16x128_f8f6f4 \
        v[54:61], v[16:31], v[32:47], v[48:55], 0, 0 \
        matrix_b_fmt:MATRIX_FMT_BF8

The target consumes all K=128 A and B data in one operation. The two
trailing zero operands encode neutral E8M0 scales.

6. Validate floating WMMA control fields

- Reject nonzero CM in every translated floating-point WMMA body.
- Reject nonzero SCL_CM in regular-Scale and Scale16 prefixes.
- Apply validation before native pass-through as well as before
  expansion.
- Cover regular-Scale, Scale16, bare F8F6F4, and f32 K=128 entry paths.
- Return the source code object unchanged with an explicit malformed
  input diagnostic when validation fails.

Examples rejected as malformed:

    v_wmma_scale16_f32_16x16x128_f8f6f4 ... scl_cm:1
    v_wmma_f32_16x16x128_fp8_fp8 ... clamp

7. Remove obsolete implementation machinery

- Remove the Scale16 byte-gather helper.
- Remove the spill-backed low-bank VGPR preservation helper.
- Remove the scratch-offset constant used only by that helper.
- Remove Scale16 scratch requests and scratch-register bookkeeping.
- Remove masked matrix-A generation for FP8, BF8, FP6, BF6, and FP4.
- Remove scratch spill and restore operations around Scale16 expansion.
- Remove Scale16 VALU-to-WMMA padding that became unnecessary with
  native operations.
- Remove the K=64 replacement mapping, liveness-dependent temporary
  allocation, and VGPR-MSB transitions used only by that fallback.

8. Correct and expand documentation and tests

- Use VOP3PX2 terminology consistently.
- Document M=16 Scale16 as native pass-through with prefix
  normalization.
- Document the manual-defined M=32 row partition and scale-lane
  selection.
- Document that prefix bits 13 and 14 are RA and RB and are cleared when
  expansion changes the instruction sequence.
- Cover exact M=16 pass-through behavior.
- Cover two-operation M-only lowering for both scaled forms.
- Cover A, C, and D offsets, shared B, shared scale operands, scale
  selectors, matrix formats, and reuse clearing.
- Cover scalar, inline, and VGPR scale operands.
- Cover every destructive-overlap term, including overlap with only the
  second register of a Scale16 pair.
- Cover VGPR-bank transitions, mode restoration, and bank-3 overflow.
- Cover all four f32 K=128 FP8/BF8 mappings and a captured compiler
  encoding with nonsemantic source fields set.
- Cover malformed CM/SCL_CM inputs and invalid Scale16 VGPR pairs.
- Classify the f32 K=128 rules as liveness-free.

Validation

- Focused gfx1250 translation and decode tests: 74 passed.
- Complete rocjitsu_tests suite: 2067 passed.
- Existing environment-gated skip:
  ExecutionPluginTest.MfmaFastPathReadHookReportsRace.
- All pre-commit hooks passed.
