### PR TITLE
test(rccl): Extend gin device tests for sdma backend

### DIFF
--- a/projects/rccl-tests/src/gin_rocshmem_gda_factory_test.cu
+++ b/projects/rccl-tests/src/gin_rocshmem_gda_factory_test.cu
@@ -69,7 +69,7 @@ __global__ void gin_atomic_kernel(rocshmem::QueuePair **qps,
     rocshmem::ActiveWFInfo wf_info(peer, rocshmem::ThreadScope::thread);
     printf("gin_atomic_kernel: peer=%d addr=%p rkey=0x%x val=%lld\n",
            peer, remote_addr, rkey, (long long)value);
-    qps[peer]->atomic_nofetch(remote_addr, rkey, value, /*cond=*/0, wf_info);
+    qps[peer]->atomic_add(remote_addr, rkey, value, wf_info);
     printf("gin_atomic_kernel: atomic posted, calling quiet\n");
     qps[peer]->quiet(wf_info);
     printf("gin_atomic_kernel: quiet done\n");
@@ -89,7 +89,7 @@ __global__ void gin_put_signal_kernel(rocshmem::QueuePair **qps,
            peer, dst, dst_rkey, src, src_lkey, nbytes);
     qps[peer]->put_nbi(dst, dst_rkey, src, src_lkey, nbytes, wf_info, /*ring_db=*/false);
     printf("gin_put_signal: atomic signal=%p rkey=0x%x\n", signal_addr, signal_rkey);
-    qps[peer]->atomic_nofetch(signal_addr, signal_rkey, 1, /*cond=*/0, wf_info);
+    qps[peer]->atomic_add(signal_addr, signal_rkey, 1, wf_info);
     printf("gin_put_signal: calling quiet\n");
     qps[peer]->quiet(wf_info);
     printf("gin_put_signal: done\n");

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -1744,14 +1744,6 @@ ncclResult_t ncclDevrCommCreateInternal(struct ncclComm* comm, struct ncclDevCom
     reqs->ginSignalCount = ginSignalTotal;
     reqs->ginCounterCount = ginCounterTotal;
     NCCLCHECK(ncclGinDevCommSetup(comm, reqs, outDevComm));
-#ifdef ENABLE_ROCSHMEM_GIN
-    if (ginSignalTotal > 0 && devr->winSortedCount > 0) {
-      struct ncclDevrWindow* win0 = devr->winSorted[0].win;
-      NCCLCHECKGOTO(ncclGinAnvilBindResourceWindowSignals(comm, win0->userPtr, ginAnvilNetSignalsOffset,
-                                                          nGinContextsTotal, ginSignalTotal),
-                    ret, fail);
-    }
-#endif
   }
 
   CUDACHECKGOTO(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), ret, fail);
@@ -1827,6 +1819,16 @@ ncclResult_t ncclDevrCommCreateInternal(struct ncclComm* comm, struct ncclDevCom
   }
 
   CUDACHECKGOTO(cudaStreamSynchronize(stream), ret, fail_stream_mem_win);
+
+#ifdef ENABLE_ROCSHMEM_GIN
+  // anvil-sdma locates a peer's signal cells by adding a rank stride to its own base, so the cells must sit at the
+  // same offset on every rank. Only the resource window guarantees that, because user windows sort by local address.
+  if (devr->ginEnabled && ginSignalTotal > 0 && outDevComm->resourceWindow != nullptr) {
+    NCCLCHECKGOTO(ncclGinAnvilBindResourceWindowSignals(comm, win->userPtr, ginAnvilNetSignalsOffset,
+                                                        nGinContextsTotal, ginSignalTotal),
+                  ret, fail_stream_mem_win);
+  }
+#endif
 
   NCCLCHECKGOTO(bootstrapBarrier(comm->bootstrap, comm->rank, comm->nRanks, 0xbeef), ret, fail_stream_mem_win);
   CUDACHECKGOTO(cudaStreamDestroy(stream), ret, fail_stream_mem_win);

--- a/projects/rccl/src/include/nccl_device/gin/rocshmem_gda/gin_rocshmem_gda.h
+++ b/projects/rccl/src/include/nccl_device/gin/rocshmem_gda/gin_rocshmem_gda.h
@@ -51,7 +51,7 @@ struct ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA> {
         uintptr_t sigAddr =
           loadConst(loadConst(&rsCtx->signal_raddrs) + peer) + sizeof(uint64_t) * signal.indexedSignal.signalId;
         uint32_t sigRkey = loadConst(loadConst(&rsCtx->signal_rkeys) + peer);
-        qp->atomic_nofetch((void*)sigAddr, sigRkey, (int64_t)signalOpArg, /*cond=*/0, wf_info);
+        qp->atomic_add((void*)sigAddr, sigRkey, (int64_t)signalOpArg, wf_info);
       } else if (hasCounter) {
         qp->quiet(wf_info);
       }
@@ -98,7 +98,7 @@ struct ncclGinApi_PutValue<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA> {
         uintptr_t sigAddr =
           loadConst(loadConst(&rsCtx->signal_raddrs) + peer) + sizeof(uint64_t) * signal.indexedSignal.signalId;
         uint32_t sigRkey = loadConst(loadConst(&rsCtx->signal_rkeys) + peer);
-        qp->atomic_nofetch((void*)sigAddr, sigRkey, (int64_t)signalOpArg, /*cond=*/0, wf_info);
+        qp->atomic_add((void*)sigAddr, sigRkey, (int64_t)signalOpArg, wf_info);
       }
     }
     coop.sync();

--- a/projects/rccl/src/include/nccl_device/gin/rocshmem_gda/queue_pair_device.h
+++ b/projects/rccl/src/include/nccl_device/gin/rocshmem_gda/queue_pair_device.h
@@ -108,7 +108,7 @@ public:
   __device__ void put_nbi_single(void* raddr, uint32_t rkey, const void* laddr, uint32_t lkey, size_t length,
                                  bool ring_db = true);
 
-  __device__ void atomic_nofetch(void* dest, uint32_t rkey, int64_t value, int64_t cond, ActiveWFInfo& wf_info);
+  __device__ void atomic_add(void* dest, uint32_t rkey, int64_t value, ActiveWFInfo& wf_info, bool fence = false);
 
   __device__ void quiet(ActiveWFInfo& wf_info);
 

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -657,7 +657,12 @@ if(BUILD_TESTS)
       target_link_libraries(${test_executable} PRIVATE
           ${ROCSHMEM_INSTALL_DIR}/lib/librocshmem.a
           ibverbs hsa-runtime64 hsakmt numa ${_ROCSHMEM_DRM} ${_ROCSHMEM_DRM_AMDGPU})
-      target_link_options(${test_executable} PRIVATE -fgpu-rdc --hip-link ${_ROCSHMEM_OFFLOAD_FLAGS} -rdynamic)
+      # ROCm < 7.14 emits cooperative_groups::this_cluster() as a non-inline stub, so -fgpu-rdc device TUs collide; keep one copy. Fixed (inline) in 7.14.
+      set(_ROCSHMEM_DEVLINK_EXTRA "")
+      if(ROCM_VERSION VERSION_LESS "71400")
+        set(_ROCSHMEM_DEVLINK_EXTRA "SHELL:-Xoffload-linker --allow-multiple-definition")
+      endif()
+      target_link_options(${test_executable} PRIVATE -fgpu-rdc --hip-link ${_ROCSHMEM_OFFLOAD_FLAGS} -rdynamic ${_ROCSHMEM_DEVLINK_EXTRA})
     endif()
 
     rocm_install(TARGETS ${test_executable} COMPONENT tests)

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -639,9 +639,20 @@ if(BUILD_TESTS)
       if(NOT _ROCSHMEM_DRM_AMDGPU)
         set(_ROCSHMEM_DRM_AMDGPU drm_amdgpu)
       endif()
-      # Enable the GIN device backend in the test kernels so ncclGinCall has a
-      # dispatch case for the corresponding runtime GIN type.
+      # Enable the rocshmem-gda GIN backend in the test kernels so ncclGinCall
+      # has a dispatch case for it.
       target_compile_definitions(${test_executable} PRIVATE NCCL_GIN_ROCSHMEM_GDA_ENABLE=1)
+
+      # Enable anvil-sdma only for the TU that launches its kernels, to avoid a
+      # device-link duplicate-symbol clash. That TU also needs rocSHMEM src included.
+      if(ROCSHMEM_SOURCE_DIR)
+        set(_ANVIL_ROCSHMEM_SRC ${ROCSHMEM_SOURCE_DIR}/src)
+      else()
+        set(_ANVIL_ROCSHMEM_SRC ${CMAKE_SOURCE_DIR}/../rocshmem/src)
+      endif()
+      set_source_files_properties(transport/GinDeviceMPITests.cpp PROPERTIES
+          COMPILE_DEFINITIONS NCCL_GIN_ANVIL_SDMA_ENABLE=1
+          INCLUDE_DIRECTORIES ${_ANVIL_ROCSHMEM_SRC})
       target_compile_options(${test_executable} PRIVATE -fgpu-rdc)
       target_link_libraries(${test_executable} PRIVATE
           ${ROCSHMEM_INSTALL_DIR}/lib/librocshmem.a

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -128,9 +128,9 @@ std::string ginProxyTestSkipReason() {
 // rocSHMEM-GDA (type 4)/SDMA (type 5) implements only INDEXED signals; VA signals are
 // unsupported (Put/PutValue address the signal via indexedSignal.signalId).
 std::string vaSignalTestSkipReason() {
-  if (requestedGinType() == 4)
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA)
     return "VA signals not supported by rocSHMEM-GDA (NCCL_GIN_TYPE=4)";
-  if (requestedGinType() == 5)
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ANVIL_SDMA)
     return "VA signals not supported by SDMA (NCCL_GIN_TYPE=5)";
   return "";
 }

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -36,19 +36,29 @@ std::string ginEnvDisabledReason() {
   return "";
 }
 
-// GIN type requested for this run (2=proxy, 4=rocshmem-gda); 0 if unset.
+// GIN type requested for this run (proxy / rocshmem-gda / anvil-sdma), 0 if unset.
 int requestedGinType() {
   const char* t = std::getenv("NCCL_GIN_TYPE");
   return t ? std::atoi(t) : 0;
 }
 
+// Valid NCCL_GIN_TYPE values, derived from the enum so the numbers stay correct
+// if the type numbering ever changes.
+std::string ginTypeUsage() {
+  return "required NCCL_GIN_TYPE=" +
+         std::to_string(NCCL_NET_DEVICE_GIN_PROXY) + " [proxy], " +
+         std::to_string(NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA) + " [rocshmem-gda] or " +
+         std::to_string(NCCL_NET_DEVICE_GIN_ANVIL_SDMA) + " [anvil-sdma]";
+}
+
 std::string ginTypeReason() {
   const char* ginType = std::getenv("NCCL_GIN_TYPE");
   if (!ginType)
-    return "GIN type not set (required NCCL_GIN_TYPE=2 [proxy] or 4 [rocshmem-gda])";
+    return "GIN type not set (" + ginTypeUsage() + ")";
   int t = requestedGinType();
-  if (t != 2 && t != 4)
-    return std::string("Invalid GIN type: ") + ginType + " (required NCCL_GIN_TYPE=2 [proxy] or 4 [rocshmem-gda])";
+  if (t != NCCL_NET_DEVICE_GIN_PROXY && t != NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA &&
+      t != NCCL_NET_DEVICE_GIN_ANVIL_SDMA)
+    return std::string("Invalid GIN type: ") + ginType + " (" + ginTypeUsage() + ")";
   return "";
 }
 
@@ -78,6 +88,8 @@ std::string intranetReason() {
   int worldSize = 0;
   MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
   if (nodeLocalRanks() != worldSize) return "";
+  // anvil-sdma works single-node without intranet mode
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ANVIL_SDMA) return "";
   const char* intra = std::getenv("RCCL_ENABLE_INTRANET");
   if (!intra || std::strcmp(intra, "1") != 0)
     return "Intranet mode required for single-node run (RCCL_ENABLE_INTRANET=1)";
@@ -93,9 +105,21 @@ std::string crossNodeReason() {
   return "";
 }
 
+// anvil-SDMA is a single-node backend. Skip (rather than fail/hang) if it is
+// accidentally launched with ranks spanning more than one physical node.
+std::string anvilSingleNodeReason() {
+  if (requestedGinType() != NCCL_NET_DEVICE_GIN_ANVIL_SDMA) return "";
+  int worldSize = 0;
+  MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+  if (nodeLocalRanks() != worldSize)
+    return "anvil-SDMA is a single-node backend; skipping multi-node run";
+  return "";
+}
+
 // First failing prerequisite, or "" if all met.
 std::string ginProxyTestSkipReason() {
-  for (auto check : {ginEnvDisabledReason, ginTypeReason, cuMemReason, intranetReason}) {
+  for (auto check : {ginEnvDisabledReason, ginTypeReason, cuMemReason, intranetReason,
+                     anvilSingleNodeReason}) {
     if (auto reason = check(); !reason.empty()) return reason;
   }
   return "";
@@ -655,9 +679,21 @@ TEST_F(GinMPIDeviceTests, Signal_NoPayload) {
   constexpr ncclGinSignal_t kSigIdx = 1;
   constexpr int             kPeer   = 1;  // rank 0 -> rank 1
 
-  // No buffers, no windows: gin.signal is a zero-byte put. The runtime's
-  // own signal pool is the only memory touched by the GFD; it's allocated
-  // and registered by ncclDevCommCreate based on ginSignalCount.
+  // anvil-sdma binds signal routes only when >=1 window is registered
+  // (dev_runtime.cc gates on winSortedCount>0). Proxy backends need no window.
+  void*            scratchBuf   = nullptr;
+  ncclWindow_t     scratchWin   = nullptr;
+  constexpr size_t kScratchBytes = 4 * 1024;
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ANVIL_SDMA) {
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&scratchBuf, kScratchBytes));
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowRegister(comm, scratchBuf, kScratchBytes,
+                                                      &scratchWin, NCCL_WIN_COLL_SYMMETRIC));
+  }
+  auto scratchCleanup = makeScopeGuard([&]() {
+    if (scratchWin) (void)ncclCommWindowDeregister(comm, scratchWin);
+    if (scratchBuf) (void)ncclMemFree(scratchBuf);
+  });
+
   ncclDevCommRequirements reqs = defaultGinReqs();
   reqs.railGinBarrierCount = 1;
   reqs.ginSignalCount      = 2;
@@ -718,6 +754,21 @@ TEST_F(GinMPIDeviceTests, Signal_HighIdNoOverflow) {
   constexpr ncclGinSignal_t kSigIdx          = 65536;  // > 0xFFFF
   constexpr uint32_t        kSignalPoolCount = 65537;
   constexpr int             kPeer            = 1;       // rank 0 -> rank 1
+
+  // anvil-sdma needs >=1 window for signal routes to bind (see
+  // Signal_NoPayload). Proxy backends keep the no-window path.
+  void*            scratchBuf   = nullptr;
+  ncclWindow_t     scratchWin   = nullptr;
+  constexpr size_t kScratchBytes = 4 * 1024;
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ANVIL_SDMA) {
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&scratchBuf, kScratchBytes));
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowRegister(comm, scratchBuf, kScratchBytes,
+                                                      &scratchWin, NCCL_WIN_COLL_SYMMETRIC));
+  }
+  auto scratchCleanup = makeScopeGuard([&]() {
+    if (scratchWin) (void)ncclCommWindowDeregister(comm, scratchWin);
+    if (scratchBuf) (void)ncclMemFree(scratchBuf);
+  });
 
   ncclDevCommRequirements reqs = defaultGinReqs();
   reqs.railGinBarrierCount = 1;
@@ -1882,41 +1933,47 @@ TEST_F(GinMPIDeviceTests, Alltoall_PureReference) {
   ncclDevCommRequirements reqs = defaultGinReqs();
   reqs.railGinBarrierCount = 1;
   reqs.ginSignalCount      = 1;
-  ncclDevComm devComm{};
-  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
-  auto devCommCleanup = makeScopeGuard([&]() {
-    (void)ncclDevCommDestroy(comm, &devComm);
-  });
 
   // 1 (alignment/tail edges), 1024 (medium), 65536 (saturating).
   const std::vector<size_t> counts = {1, 1024, size_t{1} << 16};
   constexpr int kCTAs          = 1;   // == railGinBarrierCount
   constexpr int kThreadsPerCTA = 512; // matches the production example launch
 
+  // Register windows ONCE (largest count) and reuse, BEFORE ncclDevCommCreate
+  // activates GIN: some backends resolve a buffer's address at registration,
+  // which only succeeds pre-activation.
+  const size_t maxBytes = counts.back() * static_cast<size_t>(nRanks) * sizeof(float);
+
+  void* dSend = nullptr;
+  void* dRecv = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSend, maxBytes));
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dRecv, maxBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dSend) (void)ncclMemFree(dSend);
+    if (dRecv) (void)ncclMemFree(dRecv);
+  });
+
+  ncclWindow_t sendWin = nullptr, recvWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+      ncclCommWindowRegister(comm, dSend, maxBytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
+  ASSERT_MPI_EQ(ncclSuccess,
+      ncclCommWindowRegister(comm, dRecv, maxBytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (sendWin) (void)ncclCommWindowDeregister(comm, sendWin);
+    if (recvWin) (void)ncclCommWindowDeregister(comm, recvWin);
+  });
+
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
   for (size_t count : counts) {
     SCOPED_TRACE(::testing::Message() << "count=" << count);
 
     const size_t totalElements = count * static_cast<size_t>(nRanks);
     const size_t sizeBytes     = totalElements * sizeof(float);
-
-    void* dSend = nullptr;
-    void* dRecv = nullptr;
-    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSend, sizeBytes));
-    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dRecv, sizeBytes));
-    auto memCleanup = makeScopeGuard([&]() {
-      if (dSend) (void)ncclMemFree(dSend);
-      if (dRecv) (void)ncclMemFree(dRecv);
-    });
-
-    ncclWindow_t sendWin = nullptr, recvWin = nullptr;
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclCommWindowRegister(comm, dSend, sizeBytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclCommWindowRegister(comm, dRecv, sizeBytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
-    auto winCleanup = makeScopeGuard([&]() {
-      if (sendWin) (void)ncclCommWindowDeregister(comm, sendWin);
-      if (recvWin) (void)ncclCommWindowDeregister(comm, recvWin);
-    });
 
     // Per-source/per-dest pattern: every byte of every slice has a unique
     // expected value, so a misrouted slice surfaces as a mismatch.
@@ -2056,40 +2113,46 @@ TEST_F(GinMPIDeviceTests, AlltoallHybrid_Reference) {
   ncclDevCommRequirements reqs = defaultGinReqs();
   reqs.barrierCount        = 1;
   reqs.ginSignalCount      = 1;
+
+  const std::vector<size_t> counts = {1, 1024, size_t{1} << 16};
+  constexpr int kCTAs          = 1;
+  constexpr int kThreadsPerCTA = 512;
+
+  // Register windows ONCE (largest count) and reuse, BEFORE ncclDevCommCreate
+  // activates GIN: some backends resolve a buffer's address at registration,
+  // which only succeeds pre-activation.
+  const size_t maxBytes = counts.back() * static_cast<size_t>(nRanks) * sizeof(float);
+
+  void* dSend = nullptr;
+  void* dRecv = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSend, maxBytes));
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dRecv, maxBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dSend) (void)ncclMemFree(dSend);
+    if (dRecv) (void)ncclMemFree(dRecv);
+  });
+
+  ncclWindow_t sendWin = nullptr, recvWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+      ncclCommWindowRegister(comm, dSend, maxBytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
+  ASSERT_MPI_EQ(ncclSuccess,
+      ncclCommWindowRegister(comm, dRecv, maxBytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (sendWin) (void)ncclCommWindowDeregister(comm, sendWin);
+    if (recvWin) (void)ncclCommWindowDeregister(comm, recvWin);
+  });
+
   ncclDevComm devComm{};
   ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
   auto devCommCleanup = makeScopeGuard([&]() {
     (void)ncclDevCommDestroy(comm, &devComm);
   });
 
-  const std::vector<size_t> counts = {1, 1024, size_t{1} << 16};
-  constexpr int kCTAs          = 1;
-  constexpr int kThreadsPerCTA = 512;
-
   for (size_t count : counts) {
     SCOPED_TRACE(::testing::Message() << "count=" << count);
 
     const size_t totalElements = count * static_cast<size_t>(nRanks);
     const size_t sizeBytes     = totalElements * sizeof(float);
-
-    void* dSend = nullptr;
-    void* dRecv = nullptr;
-    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSend, sizeBytes));
-    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dRecv, sizeBytes));
-    auto memCleanup = makeScopeGuard([&]() {
-      if (dSend) (void)ncclMemFree(dSend);
-      if (dRecv) (void)ncclMemFree(dRecv);
-    });
-
-    ncclWindow_t sendWin = nullptr, recvWin = nullptr;
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclCommWindowRegister(comm, dSend, sizeBytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclCommWindowRegister(comm, dRecv, sizeBytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
-    auto winCleanup = makeScopeGuard([&]() {
-      if (sendWin) (void)ncclCommWindowDeregister(comm, sendWin);
-      if (recvWin) (void)ncclCommWindowDeregister(comm, recvWin);
-    });
 
     // Same deterministic pattern as Alltoall_PureReference.
     std::vector<float> hostSend(totalElements, 0.0f);
@@ -2859,7 +2922,7 @@ TEST_F(GinMPIDeviceTests, Alltoall_CrossNode) {
 
 // =====================================================================
 // Coverage for the new NCCL 2.29.7 GIN device-API features. All run on the
-// device-API NCCL_GIN_TYPE=2 path with cross-node placement (2 ranks on 2
+// device-API GIN proxy path with cross-node placement (2 ranks on 2
 // nodes). Tests for features that depend on topology/library support that
 // may be unavailable skip gracefully rather than fail.
 // =====================================================================
@@ -2880,7 +2943,7 @@ TEST_F(GinMPIDeviceTests, Properties_NLsaTeams) {
   ncclCommProperties_t props = NCCL_COMM_PROPERTIES_INITIALIZER;
   ASSERT_EQ(ncclSuccess, ncclCommQueryProperties(comm, &props));
 
-  // Backend type must match the requested NCCL_GIN_TYPE (2=proxy, 4=rocshmem-gda).
+  // Backend type must match the requested NCCL_GIN_TYPE (proxy / rocshmem-gda / anvil-sdma).
   EXPECT_EQ(requestedGinType(), (int)props.ginType);
 
   // nLsaTeams = nRanks / lsaSize: >= 1 and must evenly divide nRanks.
@@ -3889,8 +3952,11 @@ std::string intraNodeSymReason() {
 // symmetric-memory RS kernel (RailA2A_LsaLD) eligible, so this drives the
 // production kernel path -- not a hand-written reference kernel.
 TEST_F(GinMPIDeviceTests, ReduceScatter_Symmetric) {
-  if (requestedGinType() == 4)
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA)
     GTEST_SKIP() << "Skipping symmetric ReduceScatter (RailA2A_LsaLD) for rocSHMEM-GDA";
+  // anvil-sdma is single-node. Symmetric ReduceScatter is a multi-node test.
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ANVIL_SDMA)
+    GTEST_SKIP() << "Symmetric ReduceScatter not supported for anvil-sdma: single-node backend";
   if (auto reason = ginProxyTestSkipReason(); !reason.empty())
     GTEST_SKIP() << reason;
 
@@ -3978,8 +4044,11 @@ TEST_F(GinMPIDeviceTests, ReduceScatter_Symmetric) {
 // Same as ReduceScatter_Symmetric but exercises ncclAvg, which drives the
 // FuncSumPostDiv post-divide path on the symmetric RS kernel (RailA2A_LsaLD).
 TEST_F(GinMPIDeviceTests, ReduceScatter_Symmetric_Avg) {
-  if (requestedGinType() == 4)
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA)
     GTEST_SKIP() << "Skipping symmetric ReduceScatter (RailA2A_LsaLD) for rocSHMEM-GDA";
+  // anvil-sdma is single-node. Symmetric ReduceScatter is a multi-node test.
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ANVIL_SDMA)
+    GTEST_SKIP() << "Symmetric ReduceScatter not supported for anvil-sdma: single-node backend";
   if (auto reason = ginProxyTestSkipReason(); !reason.empty())
     GTEST_SKIP() << reason;
 

--- a/projects/rccl/tools/scripts/test_runner/configs/gin_rocshmem_backends_mellanox.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/gin_rocshmem_backends_mellanox.json
@@ -1,0 +1,222 @@
+{
+  "system_configurations": {
+    "name": "RCCL-GIN-rocSHMEM-Backends-MI300X-Mellanox-IB",
+    "description": "GIN rocSHMEM backends (GDA and SDMA) on MI300X over Mellanox IB. alltoall_perf (D3/D4) plus the full GinMPIDeviceTests suite run one-mpirun-per-test."
+  },
+  "paths": {
+    "workdir": "${WORKDIR:-$PWD}",
+    "rocm_path": "${ROCM_PATH:-/opt/rocm}",
+    "mpi_path": "${MPI_PATH:-/opt/shared/ompi}"
+  },
+  "env_variables": {
+    "NCCL_SOCKET_IFNAME": "eth0,eth1",
+    "HSA_NO_SCRATCH_RECLAIM": "1",
+    "NCCL_DEBUG": "INFO"
+  },
+  "rocshmem_build_configuration": {
+    "enabled": true,
+    "source_dir": "${ROCSHMEM_DIR:-${WORKDIR}/../rocshmem}",
+    "checkout_command": "cd \"$(git rev-parse --show-toplevel)\" && git sparse-checkout add projects/rocshmem",
+    "build_command": "mkdir -p build && cd build && ../scripts/build_configs/all_backends -DMPI_ROOT=/usr -DUSE_EXTERNAL_MPI=OFF -DGPU_TARGETS=gfx942 -DCMAKE_INSTALL_PREFIX=${WORKDIR}/../rocshmem/install -DUSE_IPC=ON -DUSE_SDMA=ON"
+  },
+  "build_configuration": {
+    "install_flags": [
+      "-l",
+      "--debug",
+      "-t",
+      "--enable-mpi-tests",
+      "--enable-code-coverage",
+      "--prefix",
+      "${WORKDIR}/install"
+    ],
+    "cmake_options": "-DENABLE_ROCSHMEM_GIN=ON -DROCSHMEM_INSTALL_DIR=${WORKDIR}/../rocshmem/install",
+    "parallel_jobs": 64
+  },
+  "rccl_tests_build_configuration": {
+    "enabled": true,
+    "source_dir": "${RCCL_TESTS_DIR:-${WORKDIR}/../rccl-tests}",
+    "build_command": "cmake -B build -DCMAKE_BUILD_TYPE=Release -DUSE_MPI=ON -DENABLE_DEVICE_API=ON -DENABLE_ROCSHMEM=ON -DGPU_TARGETS=gfx942 -DRCCL_DIR=${WORKDIR}/install/lib/cmake/rccl -DRCCL_SOURCE_DIR=${WORKDIR} -DROCSHMEM_INSTALL_DIR=${WORKDIR}/../rocshmem/install -DROCSHMEM_LIBRARY=${WORKDIR}/../rocshmem/install/lib/librocshmem.a && cmake --build build -j$(nproc)"
+  },
+  "test_configurations": {
+    "default": {
+      "env_variables": {},
+      "rerun_env_variables": {
+        "NCCL_DEBUG": "INFO"
+      }
+    },
+
+    "gin_perf_base": {
+      "is_gtest": false,
+      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/alltoall_perf",
+      "num_ranks": 16,
+      "num_nodes": 2,
+      "num_gpus": 8,
+      "timeout": 600,
+      "command_args": "-b 1 -e 1G -f 2 -g 1",
+      "env_variables": {
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_CUMEM_ENABLE": "1"
+      }
+    },
+    "gin_perf_gda": {
+      "extends": "gin_perf_base",
+      "env_variables": {
+        "NCCL_GIN_TYPE": "4"
+      },
+      "tests": [
+        { "name": "GIN_GDA_D3", "description": "GDA alltoall, GinAlltoAllKernel, pure-GIN (-R 2 -D 3)", "command_args": "-R 2 -D 3" },
+        { "name": "GIN_GDA_D4", "description": "GDA alltoall, HybridAlltoAllKernel, LSA+GIN (-R 2 -D 4)", "command_args": "-R 2 -D 4" }
+      ]
+    },
+    "gin_perf_gda_1node": {
+      "extends": "gin_perf_base",
+      "description": "Single-node GDA alltoall (num_nodes=1, 8 ranks): same params as the multi-node GDA perf but all ranks packed on one node.",
+      "num_ranks": 8,
+      "num_nodes": 1,
+      "env_variables": {
+        "NCCL_GIN_TYPE": "4"
+      },
+      "tests": [
+        { "name": "GIN_GDA_1N_D3", "description": "GDA alltoall single-node, GinAlltoAllKernel, pure-GIN (-R 2 -D 3)", "command_args": "-R 2 -D 3" },
+        { "name": "GIN_GDA_1N_D4", "description": "GDA alltoall single-node, HybridAlltoAllKernel, LSA+GIN (-R 2 -D 4)", "command_args": "-R 2 -D 4" }
+      ]
+    },
+    "gin_perf_sdma": {
+      "extends": "gin_perf_base",
+      "description": "SDMA is a single-node backend: all ranks are packed onto one node (num_nodes=1, 8 ranks).",
+      "num_ranks": 8,
+      "num_nodes": 1,
+      "env_variables": {
+        "NCCL_GIN_TYPE": "5"
+      },
+      "tests": [
+        { "name": "GIN_SDMA_D3", "description": "SDMA alltoall, GinAlltoAllKernel, pure-GIN (-R 2 -D 3)", "command_args": "-R 2 -D 3" },
+        { "name": "GIN_SDMA_D4", "description": "SDMA alltoall, HybridAlltoAllKernel, LSA+GIN (-R 2 -D 4)", "command_args": "-R 2 -D 4" }
+      ]
+    },
+
+    "gin_devmpi_common": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 2,
+      "num_gpus": 1,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_ENV_PLUGIN": "none",
+        "NCCL_DMABUF_ENABLE": "1"
+      },
+      "tests": [
+        { "name": "Put_BasicAndOffsets",      "description": "GIN device put with base + offset variants",            "test_filter": "GinMPIDeviceTests.Put_BasicAndOffsets" },
+        { "name": "Put_CrossNode",            "description": "GIN device put crossing the IB fabric",                 "test_filter": "GinMPIDeviceTests.Put_CrossNode" },
+        { "name": "PutValue_Inline",          "description": "GIN device inline put-value",                           "test_filter": "GinMPIDeviceTests.PutValue_Inline" },
+        { "name": "Signal_NoPayload",         "description": "GIN device signal, no payload",                         "test_filter": "GinMPIDeviceTests.Signal_NoPayload" },
+        { "name": "Signal_HighIdNoOverflow",  "description": "GIN device signal with high id, no overflow",           "test_filter": "GinMPIDeviceTests.Signal_HighIdNoOverflow" },
+        { "name": "WaitCounter_Local",        "description": "GIN device wait-counter, local",                        "test_filter": "GinMPIDeviceTests.WaitCounter_Local" },
+        { "name": "WaitCounterAndSignal",     "description": "GIN device wait-counter combined with signal",          "test_filter": "GinMPIDeviceTests.WaitCounterAndSignal" },
+        { "name": "Barrier_TwoRanks",         "description": "GIN device two-rank barrier",                           "test_filter": "GinMPIDeviceTests.Barrier_TwoRanks" },
+        {
+          "name": "BarrierSession_LsaOnly", "description": "ncclBarrierSession LSA-only (2 ranks/node, non-trivial LSA team)", "test_filter": "GinMPIDeviceTests.BarrierSession_LsaOnly",
+          "num_ranks": 4, "num_gpus": 2
+        },
+        {
+          "name": "BarrierSession_Hybrid", "description": "ncclBarrierSession hybrid inner-LSA + outer rail-GIN (2 ranks/node)", "test_filter": "GinMPIDeviceTests.BarrierSession_Hybrid",
+          "num_ranks": 4, "num_gpus": 2
+        },
+        { "name": "SignalAdd_AndShadow",      "description": "GIN device signal-add and shadow counter",              "test_filter": "GinMPIDeviceTests.SignalAdd_AndShadow" },
+        { "name": "SymPtr_PutAndPutValue",    "description": "GIN symmetric-pointer put and put-value",               "test_filter": "GinMPIDeviceTests.SymPtr_PutAndPutValue" },
+        { "name": "Alltoall_PureReference",   "description": "GIN pure-reference alltoall kernel",                    "test_filter": "GinMPIDeviceTests.Alltoall_PureReference" },
+        {
+          "name": "AlltoallHybrid_Reference", "description": "GIN hybrid (LSA + GIN) alltoall reference (2 ranks/node)", "test_filter": "GinMPIDeviceTests.AlltoallHybrid_Reference",
+          "num_ranks": 4, "num_gpus": 2
+        },
+        { "name": "MultiContext_AllFourRoute","description": "GIN multi-context, all four routes",                    "test_filter": "GinMPIDeviceTests.MultiContext_AllFourRoute" },
+        {
+          "name": "MultiContext_NonPowerOf2", "description": "GIN multi-context with non-power-of-2 context count (NCONNECTIONS=3, NCONTEXTS=3)", "test_filter": "GinMPIDeviceTests.MultiContext_NonPowerOf2",
+          "env_variables": { "NCCL_GIN_NCONNECTIONS": "3", "NCCL_GIN_NCONTEXTS": "3" }
+        },
+        { "name": "LargeBuffer_Sweep",        "description": "GIN large-buffer size sweep",                           "test_filter": "GinMPIDeviceTests.LargeBuffer_Sweep", "timeout": 300 },
+        {
+          "name": "Disable_Error", "description": "Negative: devCommCreate must reject GIN when NCCL_GIN_ENABLE=0", "test_filter": "GinMPIDeviceTests.Disable_Error",
+          "env_variables": { "NCCL_GIN_ENABLE": "0" }
+        },
+        {
+          "name": "Invalid_SignalPool", "description": "Negative: oversized signal pool rejected at devCommCreate", "test_filter": "GinMPIDeviceTests.Invalid_SignalPool",
+          "env_variables": { "NCCL_GIN_SIGNAL_POOL_SIZE": "0x40000000" }
+        },
+        {
+          "name": "Invalid_CounterPool", "description": "Negative: oversized counter pool rejected at devCommCreate", "test_filter": "GinMPIDeviceTests.Invalid_CounterPool",
+          "env_variables": { "NCCL_GIN_COUNTER_POOL_SIZE": "0x40000000" }
+        },
+        { "name": "Teardown_NoLeaks",         "description": "GIN teardown leaves no leaks",                          "test_filter": "GinMPIDeviceTests.Teardown_NoLeaks" },
+        { "name": "Init_Destroy_Stress",      "description": "GIN init/destroy stress loop",                          "test_filter": "GinMPIDeviceTests.Init_Destroy_Stress", "timeout": 300 },
+        { "name": "Alltoall_CrossNode",       "description": "GIN cross-node alltoall (self-skips unless >=16 ranks)", "test_filter": "GinMPIDeviceTests.Alltoall_CrossNode" },
+        { "name": "Properties_NLsaTeams",     "description": "GIN properties: number of LSA teams",                   "test_filter": "GinMPIDeviceTests.Properties_NLsaTeams" },
+        { "name": "MultiContext_Exclusive",   "description": "GIN multi-context exclusive contexts",                  "test_filter": "GinMPIDeviceTests.MultiContext_Exclusive" },
+        { "name": "VASignal_Put",             "description": "GIN VA-signal put",                                     "test_filter": "GinMPIDeviceTests.VASignal_Put" },
+        {
+          "name": "RailConnection_Create", "description": "GIN rail connection create; rail-only mode (NCCL_CROSS_NIC=0)", "test_filter": "GinMPIDeviceTests.RailConnection_Create",
+          "env_variables": { "NCCL_CROSS_NIC": "0" }
+        },
+        {
+          "name": "ReduceScatter_Symmetric", "description": "Symmetric-memory ReduceScatter sum (2 ranks/node)", "test_filter": "GinMPIDeviceTests.ReduceScatter_Symmetric",
+          "num_ranks": 4, "num_gpus": 2
+        },
+        {
+          "name": "ReduceScatter_Symmetric_Avg", "description": "Symmetric-memory ReduceScatter avg (2 ranks/node)", "test_filter": "GinMPIDeviceTests.ReduceScatter_Symmetric_Avg",
+          "num_ranks": 4, "num_gpus": 2
+        }
+      ]
+    },
+    "gin_devmpi_gda": {
+      "extends": "gin_devmpi_common",
+      "env_variables": {
+        "NCCL_GIN_TYPE": "4"
+      }
+    },
+    "gin_devmpi_sdma": {
+      "extends": "gin_devmpi_common",
+      "description": "SDMA is a single-node backend: every GinMPIDeviceTests case runs on a single node (num_nodes=1). Cross-node cases (Put_CrossNode/Alltoall_CrossNode/ReduceScatter_Symmetric*) self-skip.",
+      "num_nodes": 1,
+      "env_variables": {
+        "NCCL_GIN_TYPE": "5"
+      }
+    }
+  },
+  "test_suites": [
+    {
+      "name": "GIN alltoall - GDA",
+      "description": "alltoall_perf (D3/D4) on the GDA backend, 2 nodes x 8 GPUs",
+      "config": "gin_perf_gda",
+      "enabled": true
+    },
+    {
+      "name": "GIN alltoall - GDA (single node)",
+      "description": "alltoall_perf (D3/D4) on the GDA backend, single node x 8 GPUs",
+      "config": "gin_perf_gda_1node",
+      "enabled": true
+    },
+    {
+      "name": "GIN alltoall - SDMA",
+      "description": "alltoall_perf (D3/D4) on the SDMA backend, single node x 8 GPUs",
+      "config": "gin_perf_sdma",
+      "enabled": true
+    },
+    {
+      "name": "GIN Device MPI Tests - GDA",
+      "description": "Every GinMPIDeviceTests case, one mpirun per test, on the GDA backend",
+      "config": "gin_devmpi_gda",
+      "enabled": true
+    },
+    {
+      "name": "GIN Device MPI Tests - SDMA (single node)",
+      "description": "Every GinMPIDeviceTests case, one mpirun per test, on the SDMA backend (single node)",
+      "config": "gin_devmpi_sdma",
+      "enabled": true
+    }
+  ]
+
+}

--- a/projects/rccl/tools/scripts/test_runner/lib/schema.json
+++ b/projects/rccl/tools/scripts/test_runner/lib/schema.json
@@ -132,6 +132,49 @@
       }
     },
 
+    "rocshmem_build_configuration": {
+      "description": "Controls how rocSHMEM is built BEFORE RCCL (RCCL's rocSHMEM GIN backend links the rocSHMEM install). Runs first in the build sequence. Absent section => step skipped.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Set to false to skip building rocSHMEM. Default: true when the section is present."
+        },
+        "source_dir": {
+          "type": "string",
+          "description": "Path to the rocSHMEM checkout. Supports ~ and $VAR expansion. Default: $workdir/../rocshmem."
+        },
+        "checkout_command": {
+          "description": "Optional command run only when source_dir is absent, to fetch/materialize it. String runs via shell; argv array runs without one. Supports ~ and $VAR expansion.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
+        },
+        "install_script": {
+          "type": "string",
+          "description": "Name of the build script inside source_dir. Default: 'install.sh'."
+        },
+        "build_command": {
+          "description": "Explicit build command (string run via shell, or argv array). Overrides install_script + install_flags.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
+        },
+        "install_flags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Flags passed to install_script. Supports ~ and $VAR expansion."
+        },
+        "env_variables": {
+          "$ref": "#/$defs/env_variables_map",
+          "description": "Environment variables set only during the rocSHMEM build step"
+        }
+      }
+    },
+
     "test_configurations": {
       "description": "Named test configuration blocks. Each key is a configuration name referenced by test_suites or via 'extends'.",
       "type": "object",

--- a/projects/rccl/tools/scripts/test_runner/lib/test_config.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_config.py
@@ -492,6 +492,16 @@ class TestConfigProcessor:
         """
         return self.config.get("rccl_tests_build_configuration", {})
 
+    def get_rocshmem_build_config(self):
+        """
+        Get the rocSHMEM build configuration settings.
+
+        Returns:
+            dict: rocSHMEM build configuration (source_dir, build_command,
+                  install_flags, env_variables, etc.). Empty dict if not present.
+        """
+        return self.config.get("rocshmem_build_configuration", {})
+
     def validate_config(self):
         """
         Validate the configuration for required fields.

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -271,6 +271,7 @@ class TestExecutor:
                 print(f"WARNING: No system_env_variables for '{system}'. Available: {available}")
         self.build_config = config_processor.get_build_config()
         self.rccl_tests_build_config = config_processor.get_rccl_tests_build_config()
+        self.rocshmem_build_config = config_processor.get_rocshmem_build_config()
 
         # Setup directories
         self.setup_directories()
@@ -597,6 +598,144 @@ class TestExecutor:
         print('        ./install.sh --cmake-options "-DENABLE_CODE_COVERAGE=ON" ...')
         print("=" * 80)
 
+    def build_rocshmem(self):
+        """
+        Build rocSHMEM from source BEFORE RCCL.
+
+        RCCL's rocSHMEM GIN backend links against a prebuilt rocSHMEM install
+        (``-DROCSHMEM_INSTALL_DIR=...``), so this must run before build_rccl().
+        Mirrors build_rccl_tests(): configured via the rocshmem_build_configuration
+        block (source_dir + build_command, or install_script + install_flags).
+        An absent section (or enabled=false) makes this a no-op.
+
+        Like rccl-tests, this builds an existing checkout at source_dir; it does
+        not clone the repo.
+
+        Returns:
+            bool: True if the build succeeded or was skipped.
+        """
+        if self.using_custom_lib:
+            if self.args.verbose:
+                print("SKIP: rocSHMEM build skipped (using custom RCCL library from environment)")
+            return True
+
+        if self.args.no_build:
+            if self.args.verbose:
+                print("SKIP: rocSHMEM build skipped (--no-build)")
+            return True
+
+        cfg = self.rocshmem_build_config
+        if not cfg:
+            if self.args.verbose:
+                print("SKIP: no rocshmem_build_configuration; skipping rocSHMEM build")
+            return True
+        if not cfg.get("enabled", True):
+            print("SKIP: rocSHMEM build disabled (rocshmem_build_configuration.enabled=false)")
+            return True
+
+        print("="*80)
+        print("BUILDING rocSHMEM")
+        print("="*80)
+
+        workdir = self.paths.get("workdir", os.getcwd())
+        rocm_path = self._rocm_root()
+        mpi_path = self.paths.get("mpi_path", "")
+
+        def _expand(p):
+            return os.path.expanduser(expand_env_vars(str(p)))
+
+        source_dir = _expand(cfg.get("source_dir", os.path.join(workdir, "..", "rocshmem")))
+        if not os.path.isdir(source_dir):
+            # source_dir absent (e.g. a sparse monorepo checkout that excludes
+            # rocSHMEM). If a checkout_command is configured, run it to obtain
+            # the source (e.g. `git sparse-checkout add projects/rocshmem`),
+            # then re-check. A string runs through the shell; an argv array does not.
+            checkout_command = cfg.get("checkout_command")
+            if checkout_command:
+                print(f"rocSHMEM source not present at {source_dir}; "
+                      "running checkout_command to obtain it")
+                if isinstance(checkout_command, (list, tuple)):
+                    ccmd = [_expand(a) for a in checkout_command]
+                    cuse_shell = False
+                else:
+                    ccmd = _expand(checkout_command)
+                    cuse_shell = True
+                print(f"  checkout_command: {ccmd if cuse_shell else ' '.join(ccmd)}")
+                try:
+                    cresult = subprocess.run(
+                        ccmd, cwd=workdir, env=os.environ.copy(),
+                        shell=cuse_shell, capture_output=False,
+                    )
+                except Exception as e:
+                    print(f"ERROR: rocSHMEM checkout_command raised: {e}")
+                    return False
+                if cresult.returncode != 0:
+                    print("ERROR: rocSHMEM checkout_command failed")
+                    return False
+            if not os.path.isdir(source_dir):
+                print(f"ERROR: rocSHMEM source directory not found: {source_dir}")
+                print("       Provide rocshmem_build_configuration.source_dir (an existing "
+                      "checkout) or a checkout_command that materializes it.")
+                return False
+
+        install_flags = [_expand(f) for f in cfg.get("install_flags", [])]
+        build_env_vars = cfg.get("env_variables", {})
+
+        # Explicit build_command wins; a string runs through the shell (so &&,
+        # $(nproc), cd, etc. work), an argv array runs without one.
+        build_command = cfg.get("build_command")
+        if build_command:
+            if isinstance(build_command, (list, tuple)):
+                cmd = [_expand(arg) for arg in build_command]
+                use_shell = False
+            else:
+                cmd = _expand(build_command)
+                use_shell = True
+        else:
+            install_script = os.path.join(source_dir, cfg.get("install_script", "install.sh"))
+            if not os.path.isfile(install_script):
+                print(f"ERROR: rocSHMEM build script not found: {install_script}")
+                print("       Provide rocshmem_build_configuration.build_command or "
+                      "install_script.")
+                return False
+            cmd = [install_script] + install_flags
+            use_shell = False
+
+        env = os.environ.copy()
+        env['ROCM_PATH'] = rocm_path
+        if mpi_path:
+            env['MPI_PATH'] = mpi_path
+            env['MPI_HOME'] = mpi_path
+        for key, value in build_env_vars.items():
+            env[key] = str(value)
+
+        if self.args.verbose:
+            print(f"Source directory: {source_dir}")
+            print(f"ROCm path:        {rocm_path}")
+            print(f"MPI path:         {mpi_path}")
+            print(f"Command:          {cmd if use_shell else ' '.join(cmd)}")
+            if build_env_vars:
+                print("Build environment variables:")
+                for key, value in build_env_vars.items():
+                    print(f"  {key}={value}")
+
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=source_dir,
+                env=env,
+                shell=use_shell,
+                capture_output=False,
+            )
+            if result.returncode != 0:
+                print("ERROR: rocSHMEM build failed")
+                return False
+            print("rocSHMEM build completed successfully")
+            return True
+        except Exception as e:
+            print(f"ERROR: rocSHMEM build failed with exception: {e}")
+            return False
+
     def build_rccl(self):
         """
         Build RCCL using install.sh with configurable build settings.
@@ -630,10 +769,18 @@ class TestExecutor:
         rocm_path = self._rocm_root()
         mpi_path = self.paths.get("mpi_path", "")
 
-        install_flags = list(self.build_config.get("install_flags", []))
+        # Expand env vars / ~ (e.g. ${WORKDIR}, ${ROCM_SYSTEMS:-...}) so build
+        # paths need not be hardcoded. Mirrors build_rccl_tests(); a no-op for
+        # flags/options that contain no ${VAR} references.
+        def _expand(p):
+            return os.path.expanduser(expand_env_vars(str(p)))
+
+        install_flags = [_expand(f) for f in self.build_config.get("install_flags", [])]
         cmake_options = self.build_config.get("cmake_options", "")
         if isinstance(cmake_options, dict):
-            cmake_options = " ".join(f"-D{k}={v}" for k, v in cmake_options.items())
+            cmake_options = " ".join(f"-D{k}={_expand(v)}" for k, v in cmake_options.items())
+        else:
+            cmake_options = _expand(cmake_options)
         build_env_vars = self.build_config.get("env_variables", {})
         parallel_jobs = self.build_config.get("parallel_jobs")
 

--- a/projects/rccl/tools/scripts/test_runner/test_runner.py
+++ b/projects/rccl/tools/scripts/test_runner/test_runner.py
@@ -59,6 +59,14 @@ def main():
 
         # Build RCCL (if not --no-build)
         if not args.no_build:
+            # Build rocSHMEM first if the config provides a
+            # rocshmem_build_configuration section (RCCL's rocSHMEM GIN backend
+            # links its install); no-op otherwise.
+            if not executor.build_rocshmem():
+                print("ERROR: rocSHMEM build failed")
+                if args.verbose:
+                    print("Exiting: rocSHMEM build failed")
+                sys.exit(1)
             if not executor.build_rccl():
                 print("ERROR: Build failed")
                 if args.verbose:


### PR DESCRIPTION
## Motivation

Extend the existing GIN device MPI tests to cover the anvil-SDMA backend.

## Technical Details

Enable SDMA dispatch in the test kernels and skip paths that don't apply to the backend.

## Issue Tracking

JIRA ID: AICOMRCCL-1475

## Test Plan

Run the existing `GinMPIDeviceTests` suite to confirm the existing tests are compatible with the GIN SDMA anvil backend

## Test Result

All tests pass for GIN type `NCCL_NET_DEVICE_GIN_ANVIL_SDMA`

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
