### PR TITLE
fix(rocjitsu) simdojo: fix request_exit barrier deadlock

### DIFF
--- a/emulation/rocjitsu/cmake/rj_generate_installed_gtest_ctest.cmake
+++ b/emulation/rocjitsu/cmake/rj_generate_installed_gtest_ctest.cmake
@@ -26,10 +26,12 @@ function(rj_generate_installed_gtest_ctest)
         message(FATAL_ERROR "OUTPUT_FILE is required")
     endif()
 
+    # RequestExitWakesAllPartitions is registered manually with a short
+    # timeout because its expected regression mode is a deadlocked process.
     execute_process(
         COMMAND
             "${ARG_TEST_EXECUTABLE}" --gtest_list_tests
-            "--gtest_filter=-*Benchmark*"
+            "--gtest_filter=-*Benchmark*:*RequestExitWakesAllPartitions*"
         RESULT_VARIABLE _result
         OUTPUT_VARIABLE _tests
         ERROR_VARIABLE _errors

--- a/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
+++ b/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
@@ -298,8 +298,11 @@ void SimulationEngine::worker_loop(PartitionID partition_id) {
       // Phase 4: Barrier (completion function computes new global_lbts).
       barrier_->arrive_and_wait();
       if (done_.load(std::memory_order_acquire)) {
-        // After arrive_and_wait, if done_ was set by the completion function,
-        // ALL threads see it simultaneously and ALL exit.
+        // request_exit() can set done_ while peers released from the same phase
+        // are already entering the next one. Contribute this worker's arrival
+        // instead of abandoning that phase and stranding those peers.
+        ctx.local_next.store(TICK_MAX, std::memory_order_relaxed);
+        barrier_->arrive_and_drop();
         return;
       }
     }

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -520,8 +520,29 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif()
 # Benchmarks are timing tools, not correctness tests; keep them out of the
 # default ctest run (invoke them directly via
-# ./rocjitsu_tests --gtest_filter='*Benchmark*').
-rj_add_gtest_tests(rocjitsu_tests TEST_FILTER -*Benchmark*)
+# ./rocjitsu_tests --gtest_filter='*Benchmark*'). The request-exit stress test
+# is registered separately so CTest can bound a deadlocked child process.
+rj_add_gtest_tests(
+    rocjitsu_tests
+    TEST_FILTER "-*Benchmark*:*RequestExitWakesAllPartitions*"
+)
+
+# RequestExitWakesAllPartitions may require several runs to show regression
+# (deadlock). Run 30 times with a 10 second timeout to boost chances of seeing
+# the failures. Usually fails within the first 5 times and 30 passing tests
+# takes about 2.5s in CI.
+rj_add_test(
+    NAME "TerminationTest.RequestExitWakesAllPartitions"
+    COMMAND
+        $<TARGET_FILE:rocjitsu_tests>
+        "--gtest_filter=TerminationTest.RequestExitWakesAllPartitions"
+        "--gtest_repeat=30"
+    TIMEOUT 10
+    INSTALL_COMMAND
+        "bin/rocjitsu_tests"
+        "--gtest_filter=TerminationTest.RequestExitWakesAllPartitions"
+        "--gtest_repeat=30"
+)
 
 # Exercise the Linux-only model ISA contract in a decoder-only final link.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/emulation/rocjitsu/tests/simdojo_sim_test.cpp
+++ b/emulation/rocjitsu/tests/simdojo_sim_test.cpp
@@ -464,24 +464,23 @@ TEST(TerminationTest, MaxTicksSentinel) {
 }
 
 TEST(TerminationTest, RequestExitWakesAllPartitions) {
-  // max_ticks as safety net. Keep low since each tick = one barrier round.
-  SimulationEngine engine({.max_ticks = 500, .num_threads = 4});
+  // Infinite work makes request_exit() the only termination path.
+  SimulationEngine engine({.num_threads = 4});
   auto root = std::make_unique<CompositeComponent>("root");
   for (int i = 0; i < 4; ++i)
     root->add_child(std::make_unique<InfiniteComponent>("inf" + std::to_string(i)));
   engine.topology().set_root(std::move(root));
   engine.create();
 
-  // Run in background, request exit after 50ms.
-  std::thread runner([&]() { engine.run(); });
+  ExitStatus exit_status;
+  std::thread runner([&]() { exit_status = engine.run(); });
+
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
   engine.request_exit("test stop");
   runner.join();
 
-  // Accept either EXIT_REQUEST (request_exit propagated) or COMPLETED
-  // (max_ticks safety net fired first).
-  auto reason = engine.last_exit().reason;
-  EXPECT_TRUE(reason == ExitReason::EXIT_REQUEST || reason == ExitReason::COMPLETED);
+  EXPECT_EQ(exit_status.reason, ExitReason::EXIT_REQUEST);
 }
 
 TEST(TerminationTest, StepModeConsistency) {


### PR DESCRIPTION

## Motivation

We had an intermittent CI failure caused by deadlock in simdojo. The first commit makes the fix, and the second commit makes changes to the test to make the failure more likely (if there is an unintentional revert).

## Technical Details

Simdojo simulation workers assumed that `done_` could only be set by the barrier completion function, which allowed the workers to assume in "Phase 4" that every worker would see `done_ == true` and return.

This is no longer true because `request_exit` can set `done_` asychronously from another thread. This means that workers do not necessarily return from the barrier simultaneously so threads can have different values for `done_`. If a thread does the regular return while another is running, there will be a deadlock at the next barrier.

To fix this, we add an `arrive_and_drop()` before returning, much like the other exits in that function. Reset `local_next` to `TICK_MAX` so others entering the next barrier phase are also not stranded.


## Issue Tracking

CI failures can be seen in rocjitsu PRs like PR #7890.

## Test Plan

Updates a test to make the intermittent failure more likely over 30 executions.

## Test Result

The fix makes every iteration of the test pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
