### PR TITLE
fix(clr): split memcpy header

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_async_memcpy.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_async_memcpy.h
@@ -2,20 +2,6 @@
 
 #include <hip/amd_detail/amd_hip_runtime.h>
 
-// Accelerated global<->LDS async copy primitives.
-//
-// These are plain builtin loops with no dependency on cooperative groups, so they can be included
-// on their own without pulling in <hip/amd_detail/amd_hip_cooperative_groups.h>.
-//
-// The functions are only defined when the underlying builtins exist. Callers must guard their uses
-// with the same condition:
-//
-//   #if __has_builtin(__builtin_amdgcn_global_store_async_from_lds_b128) and \
-//       __has_builtin(__builtin_amdgcn_global_load_async_to_lds_b128)
-//
-// Availability of the builtins does not imply they are invocable on the target; each individual
-// copy below is additionally wrapped in __builtin_amdgcn_is_invocable.
-
 namespace details {
 
 #if __has_builtin(__builtin_amdgcn_global_store_async_from_lds_b128) and                           \

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_async_memcpy.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_async_memcpy.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <hip/amd_detail/amd_hip_runtime.h>
+
+// Accelerated global<->LDS async copy primitives.
+//
+// These are plain builtin loops with no dependency on cooperative groups, so they can be included
+// on their own without pulling in <hip/amd_detail/amd_hip_cooperative_groups.h>.
+//
+// The functions are only defined when the underlying builtins exist. Callers must guard their uses
+// with the same condition:
+//
+//   #if __has_builtin(__builtin_amdgcn_global_store_async_from_lds_b128) and \
+//       __has_builtin(__builtin_amdgcn_global_load_async_to_lds_b128)
+//
+// Availability of the builtins does not imply they are invocable on the target; each individual
+// copy below is additionally wrapped in __builtin_amdgcn_is_invocable.
+
+namespace details {
+
+#if __has_builtin(__builtin_amdgcn_global_store_async_from_lds_b128) and                           \
+    __has_builtin(__builtin_amdgcn_global_load_async_to_lds_b128)
+
+typedef int __attribute__((ext_vector_type(2))) vint2;
+typedef int __attribute__((ext_vector_type(4))) vint4;
+
+// Some size sanity checks
+static_assert(sizeof(char) == 1);
+static_assert(sizeof(int) == 4);
+static_assert(sizeof(vint2) == 8);
+static_assert(sizeof(vint4) == 16);
+
+template <typename TyElem>
+__device__ static __forceinline__ void accelerated_memcpy_global_to_lds(
+    TyElem* __restrict__ dst, const TyElem* __restrict__ src, const size_t offset,
+    const size_t count) {
+  char* c_dst = ((char*)dst) + offset;
+  char* c_src = ((char*)src) + offset;
+  size_t bytes_left = count;
+
+  while (bytes_left > 0) {
+    if (bytes_left >= 16) {
+      if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_load_async_to_lds_b128))
+        __builtin_amdgcn_global_load_async_to_lds_b128(
+            (__attribute__((address_space(1))) vint4*)c_src,
+            (__attribute__((address_space(3))) vint4*)c_dst, 0 /* offset */, 0 /* cache policy */);
+      bytes_left -= 16;
+      c_src += 16;
+      c_dst += 16;
+    } else if (bytes_left >= 8) {
+      if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_load_async_to_lds_b64))
+        __builtin_amdgcn_global_load_async_to_lds_b64(
+            (__attribute__((address_space(1))) vint2*)c_src,
+            (__attribute__((address_space(3))) vint2*)c_dst, 0 /* offset */, 0 /* cache policy */);
+      bytes_left -= 8;
+      c_src += 8;
+      c_dst += 8;
+    } else if (bytes_left >= 4) {
+      if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_load_async_to_lds_b32))
+        __builtin_amdgcn_global_load_async_to_lds_b32(
+            (__attribute__((address_space(1))) int*)c_src,
+            (__attribute__((address_space(3))) int*)c_dst, 0 /* offset */, 0 /* cache policy */);
+      bytes_left -= 4;
+      c_src += 4;
+      c_dst += 4;
+    } else {
+      if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_load_async_to_lds_b8))
+        __builtin_amdgcn_global_load_async_to_lds_b8(
+            (__attribute__((address_space(1))) char*)c_src,
+            (__attribute__((address_space(3))) char*)c_dst, 0 /* offset */, 0 /* cache policy */);
+      bytes_left--;
+      c_src++;
+      c_dst++;
+    }
+  }
+}
+
+template <typename TyElem>
+__device__ static __forceinline__ void accelerated_memcpy_lds_to_global(
+    TyElem* __restrict__ dst, const TyElem* __restrict__ src, const size_t offset,
+    const size_t count) {
+  char* c_dst = ((char*)dst) + offset;
+  char* c_src = ((char*)src) + offset;
+  size_t bytes_left = count;
+
+  while (bytes_left > 0) {
+    if (bytes_left >= 16) {
+      if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_store_async_from_lds_b128))
+        __builtin_amdgcn_global_store_async_from_lds_b128(
+            (__attribute__((address_space(1))) vint4*)c_dst,
+            (__attribute__((address_space(3))) vint4*)c_src, 0 /* offset */, 0 /* cache policy */);
+      bytes_left -= 16;
+      c_src += 16;
+      c_dst += 16;
+    } else if (bytes_left >= 8) {
+      if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_store_async_from_lds_b64))
+        __builtin_amdgcn_global_store_async_from_lds_b64(
+            (__attribute__((address_space(1))) vint2*)c_dst,
+            (__attribute__((address_space(3))) vint2*)c_src, 0 /* offset */, 0 /* cache policy */);
+      bytes_left -= 8;
+      c_src += 8;
+      c_dst += 8;
+    } else if (bytes_left >= 4) {
+      if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_store_async_from_lds_b32))
+        __builtin_amdgcn_global_store_async_from_lds_b32(
+            (__attribute__((address_space(1))) int*)c_dst,
+            (__attribute__((address_space(3))) int*)c_src, 0 /* offset */, 0 /* cache policy */);
+      bytes_left -= 4;
+      c_src += 4;
+      c_dst += 4;
+    } else {
+      if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_store_async_from_lds_b8))
+        __builtin_amdgcn_global_store_async_from_lds_b8(
+            (__attribute__((address_space(1))) char*)c_dst,
+            (__attribute__((address_space(3))) char*)c_src, 0 /* offset */, 0 /* cache policy */);
+      bytes_left--;
+      c_src++;
+      c_dst++;
+    }
+  }
+}
+
+#endif
+
+}  // namespace details

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups_memcpy.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups_memcpy.h
@@ -2,10 +2,17 @@
 
 #include <type_traits>
 
+#include "amd_hip_async_memcpy.h"
 #include "amd_hip_cooperative_groups.h"
 
 namespace cooperative_groups {
 namespace details {
+#if __has_builtin(__builtin_amdgcn_global_store_async_from_lds_b128) and                           \
+    __has_builtin(__builtin_amdgcn_global_load_async_to_lds_b128)
+using ::details::accelerated_memcpy_global_to_lds;
+using ::details::accelerated_memcpy_lds_to_global;
+#endif
+
 template <typename TyGroup> struct can_group_do_async_copy : public std::false_type {};
 template <unsigned int size, typename TyPar>
 struct can_group_do_async_copy<cooperative_groups::thread_block_tile<size, TyPar>>
@@ -17,110 +24,6 @@ template <> struct can_group_do_async_copy<cooperative_groups::thread_block>
 
 #if __has_builtin(__builtin_amdgcn_global_store_async_from_lds_b128) and                           \
     __has_builtin(__builtin_amdgcn_global_load_async_to_lds_b128)
-template <typename TyElem>
-__CG_STATIC_QUALIFIER__ void accelerated_memcpy_global_to_lds(TyElem* __restrict__ dst,
-                                                              const TyElem* __restrict__ src,
-                                                              const size_t offset,
-                                                              const size_t count) {
-  typedef int __attribute__((ext_vector_type(2))) vint2;
-  typedef int __attribute__((ext_vector_type(4))) vint4;
-
-  // Some size sanity checks
-  static_assert(sizeof(char) == 1);
-  static_assert(sizeof(int) == 4);
-  static_assert(sizeof(vint2) == 8);
-  static_assert(sizeof(vint4) == 16);
-
-  char* c_dst = ((char*)dst) + offset;
-  char* c_src = ((char*)src) + offset;
-  size_t bytes_left = count;
-
-  while (bytes_left > 0) {
-    if (bytes_left >= 16) {
-      if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_load_async_to_lds_b128))
-        __builtin_amdgcn_global_load_async_to_lds_b128(
-            (__attribute__((address_space(1))) vint4*)c_src,
-            (__attribute__((address_space(3))) vint4*)c_dst, 0 /* offset */, 0 /* cache policy */);
-      bytes_left -= 16;
-      c_src += 16;
-      c_dst += 16;
-    } else if (bytes_left >= 8) {
-      if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_load_async_to_lds_b64))
-        __builtin_amdgcn_global_load_async_to_lds_b64(
-            (__attribute__((address_space(1))) vint2*)c_src,
-            (__attribute__((address_space(3))) vint2*)c_dst, 0 /* offset */, 0 /* cache policy */);
-      bytes_left -= 8;
-      c_src += 8;
-      c_dst += 8;
-    } else if (bytes_left >= 4) {
-      if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_load_async_to_lds_b32))
-        __builtin_amdgcn_global_load_async_to_lds_b32(
-            (__attribute__((address_space(1))) int*)c_src,
-            (__attribute__((address_space(3))) int*)c_dst, 0 /* offset */, 0 /* cache policy */);
-      bytes_left -= 4;
-      c_src += 4;
-      c_dst += 4;
-    } else {
-      if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_load_async_to_lds_b8))
-        __builtin_amdgcn_global_load_async_to_lds_b8(
-            (__attribute__((address_space(1))) char*)c_src,
-            (__attribute__((address_space(3))) char*)c_dst, 0 /* offset */, 0 /* cache policy */);
-      bytes_left--;
-      c_src++;
-      c_dst++;
-    }
-  }
-}
-
-template <typename TyElem>
-__CG_STATIC_QUALIFIER__ void accelerated_memcpy_lds_to_global(TyElem* __restrict__ dst,
-                                                              const TyElem* __restrict__ src,
-                                                              const size_t offset,
-                                                              const size_t count) {
-  typedef int __attribute__((ext_vector_type(2))) vint2;
-  typedef int __attribute__((ext_vector_type(4))) vint4;
-
-  char* c_dst = ((char*)dst) + offset;
-  char* c_src = ((char*)src) + offset;
-  size_t bytes_left = count;
-
-  while (bytes_left > 0) {
-    if (bytes_left >= 16) {
-      if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_store_async_from_lds_b128))
-        __builtin_amdgcn_global_store_async_from_lds_b128(
-            (__attribute__((address_space(1))) vint4*)c_dst,
-            (__attribute__((address_space(3))) vint4*)c_src, 0 /* offset */, 0 /* cache policy */);
-      bytes_left -= 16;
-      c_src += 16;
-      c_dst += 16;
-    } else if (bytes_left >= 8) {
-      if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_store_async_from_lds_b64))
-        __builtin_amdgcn_global_store_async_from_lds_b64(
-            (__attribute__((address_space(1))) vint2*)c_dst,
-            (__attribute__((address_space(3))) vint2*)c_src, 0 /* offset */, 0 /* cache policy */);
-      bytes_left -= 8;
-      c_src += 8;
-      c_dst += 8;
-    } else if (bytes_left >= 4) {
-      if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_store_async_from_lds_b32))
-        __builtin_amdgcn_global_store_async_from_lds_b32(
-            (__attribute__((address_space(1))) int*)c_dst,
-            (__attribute__((address_space(3))) int*)c_src, 0 /* offset */, 0 /* cache policy */);
-      bytes_left -= 4;
-      c_src += 4;
-      c_dst += 4;
-    } else {
-      if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_store_async_from_lds_b8))
-        __builtin_amdgcn_global_store_async_from_lds_b8(
-            (__attribute__((address_space(1))) char*)c_dst,
-            (__attribute__((address_space(3))) char*)c_src, 0 /* offset */, 0 /* cache policy */);
-      bytes_left--;
-      c_src++;
-      c_dst++;
-    }
-  }
-}
-
 template <class TyGroup, typename TyElem,
           typename std::enable_if<details::can_group_do_async_copy<TyGroup>{}, bool>::type = true>
 __CG_STATIC_QUALIFIER__ void dispatch_async_memcpy(const TyGroup& group, TyElem* __restrict__ dst,


### PR DESCRIPTION
## Motivation

split the memcpy header

## Technical Details

make the memcpy header include-able on its own. This should allow other teams to use this without writing their own builtin wrappers.

## Issue Tracking

NA

## Test Plan

The tests should compile fine.

## Test Result

Test compiles fine.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

Co-authored-by: Claude <noreply@anthropic.com>