### PR TITLE
docs(rocprofiler-systems): Update ROCm 7.15 references to ROCm 10.0

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/](https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/).
 
-## ROCm Systems Profiler 1.8.0 for ROCm 7.15.0 (unreleased)
+## ROCm Systems Profiler 1.8.0 for ROCm 10.0 (unreleased)
 
 ### Added
 
@@ -31,7 +31,7 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
   `signal_wait_until_on_stream`, `broadcastmem_on_stream`, `alltoallmem_on_stream`,
   `barrier_all_on_stream`, `sync_all_on_stream`, `quiet_on_stream`) as
   `rocm_rocshmem_api` spans in Perfetto traces and rocpd databases. Requires
-  rocprofiler-sdk >= 1.3.4 and rocSHMEM >= 3.6.0 (included in ROCm 7.15).
+  rocprofiler-sdk >= 1.3.4 and rocSHMEM >= 3.6.0 (included in ROCm 10.0).
   As of rocSHMEM 3.6.0, `USE_ROCPROFILER_REGISTER` defaults to `ON`, so
   package installations automatically include this support. A `rocshmem` example
   demonstrating two-PE usage of all nine APIs is included under `examples/rocshmem`.

--- a/projects/rocprofiler-systems/examples/rocshmem/README.md
+++ b/projects/rocprofiler-systems/examples/rocshmem/README.md
@@ -27,7 +27,7 @@ all nine `rocm_rocshmem_api` spans:
 
 - CMake 3.25+
 - ROCm with HIP runtime
-- rocSHMEM ≥ 3.6.0 (included in ROCm 7.15)
+- rocSHMEM ≥ 3.6.0 (included in ROCm 10.0)
 - MPI runtime (e.g. Open MPI)
 
 ## Building


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md section header from `ROCm 7.15.0` to `ROCm 10.0`
- Update two parenthetical `(included in ROCm 7.15)` references to `ROCm 10.0` in CHANGELOG.md and `examples/rocshmem/README.md`

ROCm 7.15 has been officially renamed to ROCm 10.0.

## Issue Tracking

JIRA ID - AIPROFSYST-696

## Test plan

- [x] Verify no remaining `ROCm 7.15` references in documentation under `projects/rocprofiler-systems/`