### PR TITLE
[rocprofiler-compute] Retarget 3.8.0 changelog to ROCm 10.0.0

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -3,7 +3,7 @@
 Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/](https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/).
 
 
-## ROCm Compute Profiler 3.8.0 for ROCm 7.15.0
+## ROCm Compute Profiler 3.8.0 for ROCm 10.0.0
 
 ### Added
 


### PR DESCRIPTION
## Motivation

The ROCm Compute Profiler 3.8.0 section ships with ROCm 10.0.0. Update the changelog heading to match.

## Technical Details

- CHANGELOG.md: 3.8.0 section heading now reads "for ROCm 10.0.0"

## JIRA ID

JIRA ID: N/A

## Test Plan

- [x] Docs-only change; no tests required

## Test Result

- [x] N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.