### PR TITLE
[rocprofiler-compute] Scope 7.14 upcoming roofline entry to gfx1153

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -127,7 +127,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Upcoming changes
 
-* Roofline support for RDNA3.5 gfx115x devices.
+* Roofline support for gfx1153 devices.
 
 ### Known issues
 


### PR DESCRIPTION
## Motivation

The ROCm 7.14.0 "Upcoming changes" entry now names gfx1153, the only RDNA3.5 part still awaiting roofline support. gfx1150/gfx1151/gfx1152 roofline support shipped in 3.7.0 and 3.8.0.

## Technical Details

- CHANGELOG.md: "Roofline support for RDNA3.5 gfx115x devices." -> "Roofline support for gfx1153 devices."

## JIRA ID

JIRA ID: N/A

## Test Plan

- [x] Markdown-only change, no code paths touched

## Test Result

- [x] Renders correctly in CHANGELOG.md

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.