### PR TITLE
feat (rccl): add 4-rank GIN barrier test and refresh stale barrier comments

### DIFF
--- a/projects/rccl/bindings/ir/test/IR_gin_mpi_test.cpp
+++ b/projects/rccl/bindings/ir/test/IR_gin_mpi_test.cpp
@@ -135,9 +135,10 @@ int localRankOf(MPI_Comm world) {
  * ==================================================================== */
 
 /* [C1] GIN-only rail barrier: Init once, then Sync `iters` times. Each Sync
- * sends a SignalInc to the peer and waits for the local cell to reach the new
- * epoch, so completion after many rounds proves both ranks stayed in lockstep
- * (a broken epoch would deadlock at iter 1). barrierIndex 0 < railGinBarrierCount. */
+ * bumps cell (base + myRank) on every peer and waits on its own (base + peer)
+ * cell to reach the incremented shadow value, so completion after many rounds
+ * proves both ranks stayed in lockstep (broken shadow bookkeeping would
+ * deadlock at iter 1). barrierIndex 0 < railGinBarrierCount. */
 __global__ void k_ir_gin_barrier(int iters, struct ncclDevComm devComm) {
   /* ncclGin_C / the *_C session structs have no default ctor: the net is
    * constructed via its parameterized ctor, and the session is left as raw

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -1073,19 +1073,13 @@ TEST_F(GinMPIDeviceTests, Barrier_TwoRanks) {
   // appended after the user-facing ginSignalCount range, so it never shifts
   // user signal indices.
   //
-  // ginForceEnable is REQUIRED. ncclDevCommCreateInternal only activates
-  // GIN (populating ginHandles[]/ginSignalBase) when nNodes>1 OR
-  // ginForceEnable OR ginSignalCount!=0 OR ginCounterCount!=0 -- the gate
-  // intentionally ignores railGinBarrierCount. Without this flag a
-  // single-node test that asks only for railGinBarrierCount gets NULL
-  // ginHandles[0], and the barrier's internal waitSignal -> getSignalPtr
-  // dispatch dereferences a NULL ncclGinProxyGpuCtx and faults at (nil)
-  // on the GPU. Other tests dodge the gate accidentally by setting
-  // ginSignalCount/ginCounterCount non-zero; this one has neither so we
-  // ask for GIN explicitly.
+  // GIN activation matters here: without it ginHandles[0] is NULL and the
+  // barrier's internal waitSignal -> getSignalPtr dispatch faults on a NULL
+  // ncclGinProxyGpuCtx. defaultGinReqs() asks for it explicitly by setting
+  // ginConnectionType=FULL, which is what a single-node run needs since this
+  // test requests no signal or counter pool of its own.
   ncclDevCommRequirements reqs = defaultGinReqs();
   reqs.railGinBarrierCount = 1;
-  reqs.ginForceEnable      = true;
   ncclDevComm devComm{};
   ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
   auto devCommCleanup = makeScopeGuard([&]() {
@@ -1156,12 +1150,10 @@ TEST_F(GinMPIDeviceTests, Barrier_FourRanks) {
   constexpr int kIters = 16;
 
   // worldGinBarrierCount=1 covers the 1-CTA launch (barrierIndex=0) and sizes
-  // the pool at 1*worldTeam.nRanks = 4 cells. ginForceEnable mirrors
-  // Barrier_TwoRanks so a run whose GIN activation gate does not count barrier
-  // requirements still gets a valid proxy ctx behind waitSignal.
+  // the pool at 1*worldTeam.nRanks = 4 cells. GIN activation comes from
+  // defaultGinReqs()'s ginConnectionType=FULL, as in Barrier_TwoRanks.
   ncclDevCommRequirements reqs = defaultGinReqs();
   reqs.worldGinBarrierCount = 1;
-  reqs.ginForceEnable       = true;
   ncclDevComm devComm{};
   ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
   auto devCommCleanup = makeScopeGuard([&]() {
@@ -1327,11 +1319,11 @@ TEST_F(GinMPIDeviceTests, BarrierSession_Hybrid) {
   constexpr int kIters = 16;
 
   // The world-team ncclBarrierSession sizes its hybrid LSA+rail-GIN barriers from
-  // reqs.barrierCount (not lsa/railGinBarrierCount); 0 hangs the rail arm. ginForceEnable
-  // activates GIN so the outer barrier's waitSignal has a valid ctx (see Barrier_TwoRanks).
+  // reqs.barrierCount (not lsa/railGinBarrierCount); 0 hangs the rail arm.
+  // defaultGinReqs()'s ginConnectionType=FULL activates GIN so the outer
+  // barrier's waitSignal has a valid ctx (see Barrier_TwoRanks).
   ncclDevCommRequirements reqs = defaultGinReqs();
   reqs.barrierCount        = 1;
-  reqs.ginForceEnable      = true;
   ncclDevComm devComm{};
   ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
   auto devCommCleanup = makeScopeGuard([&]() {
@@ -1886,8 +1878,7 @@ TEST_F(GinMPIDeviceTests, Alltoall_PureReference) {
   ASSERT_LE(nRanks, 8);
 
   // ginSignalCount=1 covers signalIndex=0; railGinBarrierCount=1 matches
-  // our single-CTA launch. Both non-zero so GIN activates without
-  // ginForceEnable.
+  // our single-CTA launch.
   ncclDevCommRequirements reqs = defaultGinReqs();
   reqs.railGinBarrierCount = 1;
   reqs.ginSignalCount      = 1;

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -1021,11 +1021,13 @@ TEST_F(GinMPIDeviceTests, WaitCounterAndSignal) {
 }
 
 // Collective kernel: every rank runs the same code. The barrier composes
-// signal + waitSignal + an epoch counter (gin_barrier__funcs.h:42-60) -- each
-// sync sends SignalInc to every other rank and waits for the local signal
-// cell to reach a higher epoch, so consecutive syncs don't collide on the
-// same expected value. The ncclTeamTagRail{} overload routes to
-// comm.railGinBarrier and the rail team automatically.
+// signal + waitSignal over a per-peer signal window (gin_barrier__funcs.h):
+// each sync sends a SignalInc to every other rank -- bumping cell
+// (base + myRank) on that peer -- then waits on its own (base + peer) cell
+// for every peer. The expected value comes from the local signal shadow,
+// incremented once per sync, so consecutive syncs don't collide on the same
+// value. The ncclTeamTagRail{} overload routes to comm.railGinBarrier and
+// the rail team automatically.
 __global__ void barrier2RanksKernel(int iters, struct ncclDevComm devComm) {
   ncclGin gin{devComm, /*ginContext=*/0};
   // barrierIndex must be < railGinBarrierCount (we set =1, so 0).
@@ -1056,17 +1058,20 @@ TEST_F(GinMPIDeviceTests, Barrier_TwoRanks) {
   ncclCommCount(comm, &nRanks);
   ASSERT_EQ(2, nRanks);
 
-  // Large enough that a stuck-at-zero epoch would deadlock at iter 1
-  // (not silently pass on iter 0); small enough to stay fast. Each round
-  // sends 1 SignalInc per peer (1 in the 2-rank case) and waits for the
-  // corresponding signal cell to reach the new epoch.
+  // Large enough that a stuck-at-zero expected value would deadlock at
+  // iter 1 (not silently pass on iter 0); small enough to stay fast. Each
+  // round sends 1 SignalInc per peer (1 in the 2-rank case) and waits for
+  // that peer's own cell to reach the incremented shadow value.
   constexpr int kIters = 16;
 
   // railGinBarrierCount=1 covers our 1-CTA launch (barrierIndex=0). The
   // barrier session uses the rail-team GIN barrier pool that the runtime
-  // allocates via ncclGinBarrierCreateRequirement; its signal cells live
-  // at (handle.signal0 + barrierIndex), separate from the user-facing
-  // ginSignalCount pool.
+  // allocates via ncclGinBarrierCreateRequirement, which reserves
+  // nBarriers*railTeam.nRanks cells -- one per source rank per barrier -- so
+  // a cell lives at
+  // (handle.signal0 + barrierIndex*railTeam.nRanks + srcRank). That pool is
+  // appended after the user-facing ginSignalCount range, so it never shifts
+  // user signal indices.
   //
   // ginForceEnable is REQUIRED. ncclDevCommCreateInternal only activates
   // GIN (populating ginHandles[]/ginSignalBase) when nNodes>1 OR
@@ -1091,16 +1096,89 @@ TEST_F(GinMPIDeviceTests, Barrier_TwoRanks) {
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Both ranks launch the same kernel -- barrier is collective, no
-  // producer/consumer split. Each rank's iter i sends SignalInc to the
-  // other rank and waits for its own signal cell to reach epoch+1; if the
-  // barrier raced past the peer (epoch broken), iter i+1 would either spin
-  // forever or read a stale epoch. Kernel completion means all kIters
-  // rounds stayed in lockstep.
+  // producer/consumer split. Each rank's iter i sends SignalInc to the other
+  // rank's cell and waits for its own cell for that peer to reach the newly
+  // incremented shadow value; if the barrier raced past the peer, iter i+1
+  // would either spin forever or match a stale count. Kernel completion
+  // means all kIters rounds stayed in lockstep.
   barrier2RanksKernel<<<kGinKernelBlocks, kGinKernelThreads, 0, stream>>>(kIters, devComm);
   ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
 
   // Successful return of the kernel IS the assertion: signal + waitSignal
-  // + epoch all worked together for kIters rounds.
+  // + shadow bookkeeping all worked together for kIters rounds.
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// Same barrier as barrier2RanksKernel but over the world team, so every rank
+// has 3 peers instead of 1.
+__global__ void barrier4RanksKernel(int iters, struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  // barrierIndex must be < worldGinBarrierCount (we set =1, so 0).
+  ncclGinBarrierSession<ncclCoopCta> bar{
+      ncclCoopCta(), gin, ncclTeamTagWorld{}, /*barrierIndex=*/0};
+  for (int i = 0; i < iters; i++) {
+    bar.sync(ncclCoopCta(), cuda::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
+  }
+}
+
+// Multi-peer counterpart to Barrier_TwoRanks. At 2 ranks the barrier has a
+// single peer, so it never exercises the rotating peer order, the distribution
+// of peers across the coop group, or several per-peer waits outstanding at
+// once. With 4 ranks every rank has 3 peers and all three are in play.
+//
+// Deliberately asserts only that the barrier completes, same as
+// Barrier_TwoRanks: how the barrier lays out or accounts for its signals is an
+// internal detail that has already changed once (2.29.7) and may change again,
+// so this test stays behavioural. A regression in the arrival accounting still
+// surfaces -- as a deadlock at some round, not a silent pass.
+//
+// Uses the WORLD GIN barrier, not the rail one: ncclTeamRail has
+// nRanks = comm.nRanks / lsaSize, so a 4-rank job only yields a 4-rank rail
+// team at 4 nodes x 1 GPU, whereas the world team is 4 ranks on any layout
+// (including the 2-node x 2-GPU config the other 4-rank GIN tests run on).
+TEST_F(GinMPIDeviceTests, Barrier_FourRanks) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/4, /*max_processes=*/4))
+    GTEST_SKIP() << "Requires exactly 4 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int nRanks = -1;
+  ncclCommCount(comm, &nRanks);
+  ASSERT_EQ(4, nRanks);
+
+  // Same reasoning as Barrier_TwoRanks: large enough that stuck bookkeeping
+  // deadlocks rather than passing on round 0, small enough to stay fast.
+  constexpr int kIters = 16;
+
+  // worldGinBarrierCount=1 covers the 1-CTA launch (barrierIndex=0) and sizes
+  // the pool at 1*worldTeam.nRanks = 4 cells. ginForceEnable mirrors
+  // Barrier_TwoRanks so a run whose GIN activation gate does not count barrier
+  // requirements still gets a valid proxy ctx behind waitSignal.
+  ncclDevCommRequirements reqs = defaultGinReqs();
+  reqs.worldGinBarrierCount = 1;
+  reqs.ginForceEnable       = true;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // All ranks finished setup before any kernel launches.
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // All four ranks run the same collective loop. Each round every rank signals
+  // its 3 peers and waits for all 3 to arrive; if the arrival accounting broke
+  // for any peer, that round would spin forever rather than pass.
+  barrier4RanksKernel<<<kGinKernelBlocks, kGinKernelThreads, 0, stream>>>(kIters, devComm);
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  // Successful return of the kernel IS the assertion, as in Barrier_TwoRanks:
+  // all kIters rounds kept 4 ranks in lockstep across 3 peers each.
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
@@ -1217,9 +1295,10 @@ TEST_F(GinMPIDeviceTests, BarrierSession_LsaOnly) {
 
 // Collective over the world team: composes the inner LSA barrier with the
 // outer rail-GIN barrier (ncclTeamTagWorld ctor). Mirrors Barrier_TwoRanks'
-// "completion == success" philosophy -- a broken inner or outer epoch
-// deadlocks at iter 1 -- but routes through both substrates. On single node
-// the outer rail arm degenerates; multi-node it crosses rails.
+// "completion == success" philosophy -- a broken inner LSA epoch or outer
+// per-peer signal count deadlocks at iter 1 -- but routes through both
+// substrates. On single node the outer rail arm degenerates; multi-node it
+// crosses rails.
 __global__ void barrierSessionHybridKernel(int iters, struct ncclDevComm devComm) {
   ncclGin gin{devComm, /*ginContext=*/0};
   ncclBarrierSession<ncclCoopCta> bar{
@@ -1262,7 +1341,8 @@ TEST_F(GinMPIDeviceTests, BarrierSession_Hybrid) {
   MPI_Barrier(MPI_COMM_WORLD);
 
   // All ranks run the same collective barrier loop; completion means every
-  // round's inner LSA + outer rail-GIN epochs stayed in lockstep.
+  // round's inner LSA epochs and outer rail-GIN per-peer signal counts
+  // stayed in lockstep.
   barrierSessionHybridKernel<<<kGinKernelBlocks, kGinKernelThreads, 0, stream>>>(kIters, devComm);
   ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
 

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -3368,6 +3368,15 @@
             "NCCL_GIN_TYPE": "2",
             "NCCL_GIN_ENABLE": "1"
           }
+        },
+        {
+          "name": "GIN_Barrier_FourRanks",
+          "description": "ncclGinBarrierSession over the 4-rank world team: 16 collective rounds with 3 peers per rank; completion proves the multi-peer arrival accounting keeps all ranks in lockstep",
+          "test_filter": "GinMPIDeviceTests.Barrier_FourRanks",
+          "env_variables": {
+            "NCCL_GIN_TYPE": "2",
+            "NCCL_GIN_ENABLE": "1"
+          }
         }
       ]
     },


### PR DESCRIPTION
## Motivation

The internal implementation of gin barrier sync changed. Updating the test accordingly.

## Technical Details

The barrier now reserves one cell per source rank per barrier rather than a counter over one shared signal cell.

Barrier_TwoRanks test only ever drives a single peer, so the GIN barrier's multi-peer path -- several per-peer waits outstanding at once -- had no coverage. Add Barrier_FourRanks test over the world team, which is 4 ranks on any node layout, and wire it into the existing 4-rank/2-node runner config.

The signal layout is an internal detail that already changed once in 2.29.7, so a regression in the arrival accounting should surface as a deadlock.

Also refresh comments that still described the pre-2.29.7 GIN barrier as an epoch counter over one shared signal cell, including a stale line-number reference and the wrong cell address formula. The barrier now reserves one cell per source rank per barrier and derives the expected value from the local signal shadow.

## Issue Tracking

JIRA ID: AICOMRCCL-1367

## Test Plan

Added test Barrier_FourRanks to verify that multiple cells work, since the existing Barrier_TwoRanks required only one cell as there was only one peer.

## Test Result

[ RUN      ] GinMPIDeviceTests.Barrier_FourRanks
[       OK ] GinMPIDeviceTests.Barrier_FourRanks (4648 ms)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
