### PR TITLE
feat(rocSHMEM): Add resource-usage comparison scripts #AIROCSHMEM-474

### DIFF
--- a/projects/rocshmem/scripts/functional_tests/perf_compare.py
+++ b/projects/rocshmem/scripts/functional_tests/perf_compare.py
@@ -263,7 +263,7 @@ def plot_latency(
     fig, ax = plt.subplots(figsize=(10, 6))
 
     for label, df in [(baseline_label, baseline_df), *variant_dfs.items()]:
-        style = _VARIANT_STYLES.get(label, {})
+        style = _VARIANT_STYLES["baseline"] if label == baseline_label else _VARIANT_STYLES.get(label, {})
         ax.plot(
             df["msg_size"],
             df["latency_us"],

--- a/projects/rocshmem/scripts/functional_tests/perf_compare.py
+++ b/projects/rocshmem/scripts/functional_tests/perf_compare.py
@@ -257,11 +257,12 @@ def plot_latency(
     baseline_df: pd.DataFrame,
     variant_dfs: dict[str, pd.DataFrame],
     outdir: Path,
+    baseline_label: str = "baseline",
 ) -> None:
     """Generate a latency-vs-message-size plot for one test."""
     fig, ax = plt.subplots(figsize=(10, 6))
 
-    for label, df in [("baseline", baseline_df), *variant_dfs.items()]:
+    for label, df in [(baseline_label, baseline_df), *variant_dfs.items()]:
         style = _VARIANT_STYLES.get(label, {})
         ax.plot(
             df["msg_size"],
@@ -301,6 +302,7 @@ def make_heatmap(
     baseline_data: dict[str, pd.DataFrame],
     variant_datasets: dict[str, dict[str, pd.DataFrame]],
     outdir: Path,
+    baseline_label: str = "baseline",
 ) -> None:
     """Generate a summary heatmap of % performance change vs baseline."""
     # Compute metrics for baseline
@@ -412,7 +414,7 @@ def make_heatmap(
         ax=ax,
         cbar_kws={"label": "% change (green = better)", "ticks": boundaries},
     )
-    ax.set_title("Performance vs develop baseline (% change)")
+    ax.set_title(f"Performance vs {baseline_label} (% change)")
     ax.set_ylabel("")
     fig.tight_layout()
     fig.savefig(outdir / "heatmap_summary.png", dpi=150)
@@ -431,6 +433,7 @@ def write_per_test_txt(
     baseline_iqr: dict,           # msg_size -> stats (may be empty for single-iter)
     variant_iqr: dict[str, dict], # variant -> msg_size -> stats
     outdir: Path,
+    baseline_label: str = "baseline",
 ) -> None:
     """Write a per-test summary text file with salient metrics and IQR stats."""
     lines = []
@@ -442,7 +445,7 @@ def write_per_test_txt(
     lines.append("Salient Metrics")
     lines.append("-" * 40)
     VAL_W, PCT_W = 12, 8
-    hdr = f"{'Metric':<14} {'baseline':>{VAL_W}}"
+    hdr = f"{'Metric':<14} {baseline_label:>{VAL_W}}"
     for vname in variant_dfs:
         col_w = VAL_W + 1 + PCT_W
         hdr += f"  {vname:>{col_w}}"
@@ -480,7 +483,7 @@ def write_per_test_txt(
                 f"{lo}  {hi}  {s['lat_med']:>10.3f}  {s['bw_med']:>10.3f}"
             )
 
-    _iqr_table("baseline", baseline_iqr)
+    _iqr_table(baseline_label, baseline_iqr)
     for vname in variant_dfs:
         _iqr_table(vname, variant_iqr.get(vname, {}))
 
@@ -514,6 +517,10 @@ def main():
     parser.add_argument(
         "--baseline", required=True,
         help="Baseline log dir(s) — single path or glob (e.g. build-develop/logs-heatmap-*)",
+    )
+    parser.add_argument(
+        "--baseline-label", default="baseline",
+        help="Label for the baseline series in plots/tables (default: baseline)",
     )
     parser.add_argument(
         "--variants", nargs="+", required=True,
@@ -574,7 +581,7 @@ def main():
     for test_name in sorted(all_test_names):
         vdfs = {vn: vd[test_name] for vn, vd in variant_datasets.items()
                 if test_name in vd}
-        plot_latency(test_name, baseline_data[test_name], vdfs, plot_dir)
+        plot_latency(test_name, baseline_data[test_name], vdfs, plot_dir, args.baseline_label)
         write_per_test_txt(
             test_name,
             baseline_data[test_name],
@@ -582,11 +589,12 @@ def main():
             baseline_iqr.get(test_name, {}),
             {vn: variant_iqr.get(vn, {}).get(test_name, {}) for vn in vdfs},
             plot_dir,
+            args.baseline_label,
         )
     print(f"Generated {len(all_test_names)} per-test plots and summaries in {plot_dir}/")
 
     # Generate summary heatmap
-    make_heatmap(baseline_data, variant_datasets, args.outdir)
+    make_heatmap(baseline_data, variant_datasets, args.outdir, args.baseline_label)
 
     # Print summary table to stdout and save to file
     _RAW_FMT = {
@@ -608,7 +616,7 @@ def main():
     _p("\n" + "=" * 80)
     _p("SUMMARY: metrics for tests common to all variants")
     _p("=" * 80)
-    header = f"{'Test':<30} {'Metric':<12} {'baseline':>{VAL_W}}"
+    header = f"{'Test':<30} {'Metric':<12} {args.baseline_label:>{VAL_W}}"
     for vname in variant_datasets:
         header += f"  {vname:>{COL_W}}"
     _p(header)

--- a/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
@@ -75,7 +75,7 @@ while [[ $# -gt 0 ]]; do
     --force-rebuild) FORCE_REBUILD=true; shift ;;
     --match)         MATCH="$2";         shift 2 ;;
     -h|--help)
-      sed -n '2,/^###$/p' "$0" | head -n -1
+      sed -n '2,/^#####/p' "$0" | head -n -1
       exit 0 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
@@ -88,6 +88,19 @@ cd "$ROCSHMEM_DIR"
 
 
 TOOLS_DIR="$ROCSHMEM_DIR/scripts/functional_tests"
+
+# Tracks the worktree currently being built so the EXIT trap below can clean
+# it up if the build fails partway through (errexit exits the script before
+# reaching the normal `git worktree remove` call, otherwise leaking a
+# worktree registration + /tmp checkout).
+CURRENT_WORKTREE=""
+_cleanup_worktree() {
+  if [[ -n "$CURRENT_WORKTREE" ]]; then
+    git -C "$ROCSHMEM_DIR" worktree remove --force "$CURRENT_WORKTREE" 2>/dev/null || true
+    CURRENT_WORKTREE=""
+  fi
+}
+trap _cleanup_worktree EXIT
 
 _find_build_config() {
   local worktree="$1"
@@ -126,11 +139,11 @@ measure_commit() {
   local worktree="/tmp/rocshmem-resource-usage-${sha}-$$"
 
   git -C "$ROCSHMEM_DIR" worktree add "$worktree" "$commit" --detach >&2
+  CURRENT_WORKTREE="$worktree"
 
   FOUND_BUILD_CONFIG="$(_find_build_config "$worktree" "$BUILD_CONFIG")"
   if [[ -z "$FOUND_BUILD_CONFIG" ]]; then
     echo "ERROR: Cannot find $BUILD_CONFIG in baseline worktree" >&2
-    git -C "$ROCSHMEM_DIR" worktree remove "$worktree" || true
     exit 1
   fi
 
@@ -150,6 +163,7 @@ measure_commit() {
   )
 
   git -C "$ROCSHMEM_DIR" worktree remove "$worktree" >&2 || true
+  CURRENT_WORKTREE=""
 
   # measure_commit's stdout is captured by the caller (CSV_1="$(measure_commit ...)")
   # and must contain only the final `echo "$csv"` path -- redirect this script's own

--- a/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
@@ -134,10 +134,23 @@ measure_commit() {
 
 echo "=== resource usage: $COMMIT_1${COMMIT_2:+ vs $COMMIT_2} ($GPU_TARGET / $BUILD_CONFIG) ==="
 
+# Only restore if we're not already on it -- `checkout --force` to the ref
+# you're already on still overwrites any uncommitted changes to tracked
+# files (e.g. edits made to other scripts while this one was running, or on
+# a cache hit where measure_commit never checked anything out to begin with).
+_restore_original_ref() {
+  local current_ref
+  current_ref="$(git rev-parse --abbrev-ref HEAD)"
+  [[ "$current_ref" == "HEAD" ]] && current_ref="$(git rev-parse HEAD)"
+  if [[ "$current_ref" != "$ORIGINAL_REF" ]]; then
+    git checkout --quiet --force "$ORIGINAL_REF" 2>/dev/null || true
+  fi
+}
+
 CSV_1="$(measure_commit "$COMMIT_1")"
 SHA_1="$(git rev-parse --short=12 "$COMMIT_1")"
 
-git checkout --quiet --force "$ORIGINAL_REF" 2>/dev/null || true
+_restore_original_ref
 
 if [[ -z "$COMMIT_2" ]]; then
   echo ""
@@ -148,7 +161,7 @@ fi
 CSV_2="$(measure_commit "$COMMIT_2")"
 SHA_2="$(git rev-parse --short=12 "$COMMIT_2")"
 
-git checkout --quiet --force "$ORIGINAL_REF" 2>/dev/null || true
+_restore_original_ref
 
 OUTDIR="$ROCSHMEM_DIR/resource-usage-${GPU_TARGET}-${BUILD_CONFIG}-${SHA_1}-vs-${SHA_2}"
 mkdir -p "$OUTDIR"

--- a/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
@@ -3,11 +3,10 @@
 # Compare per-kernel GPU resource usage (VGPR/SGPR/AGPR/scratch/LDS/occupancy)
 # between two commits (or one commit vs the current working tree).
 #
-# This is the git-checkout-based counterpart to
-# .claude/skills/rocshmem-resource-usage/scripts/measure.sh (which measures
-# the working tree in place, no checkout). Use this script when you need to
-# bisect a regression across history or compare a PR branch against its
-# merge-base, rather than iterating on local edits.
+# This is the git-checkout-based counterpart to measuring the working tree in
+# place with no checkout. Use this script when you need to bisect a
+# regression across history or compare a PR branch against its merge-base,
+# rather than iterating on local edits.
 #
 # Builds are cached per (gpu_target, build_config, commit) under
 # resource-usage-cache/ so re-comparing COMMIT_1 against a different COMMIT_2
@@ -35,9 +34,7 @@
 #
 # IMPORTANT: this script does `git checkout --force --detach` on the repo you
 # run it from. Stash or commit your working-tree changes first — it will
-# silently check out over uncommitted edits. For same-tree iteration with no
-# checkout, use scripts/functional_tests/measure.sh + compare.sh instead (see
-# the rocshmem-resource-usage skill, section A).
+# silently check out over uncommitted edits.
 #
 # Example:
 # COMMIT_1=d48c64f6e COMMIT_2=3caf8d080 BUILD_CONFIG=all_backends \
@@ -49,10 +46,8 @@
 ###############################################################################
 set -euo pipefail
 
-# COMMIT_1="${COMMIT_1:-HEAD}"
-# COMMIT_2="${COMMIT_2:-}"
-COMMIT_1=f41d40f
-COMMIT_2=749f856
+COMMIT_1="${COMMIT_1:-HEAD}"
+COMMIT_2="${COMMIT_2:-}"
 GPU_TARGET="${GPU_TARGET:-gfx950}"
 BUILD_CONFIG="${BUILD_CONFIG:-all_backends}"
 

--- a/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+###############################################################################
+# Compare per-kernel GPU resource usage (VGPR/SGPR/AGPR/scratch/LDS/occupancy)
+# between two commits (or one commit vs the current working tree).
+#
+# This is the git-checkout-based counterpart to
+# .claude/skills/rocshmem-resource-usage/scripts/measure.sh (which measures
+# the working tree in place, no checkout). Use this script when you need to
+# bisect a regression across history or compare a PR branch against its
+# merge-base, rather than iterating on local edits.
+#
+# Builds are cached per (gpu_target, build_config, commit) under
+# resource-usage-cache/ so re-comparing COMMIT_1 against a different COMMIT_2
+# doesn't rebuild COMMIT_1 again.
+#
+# Usage:
+#   Edit COMMIT_1 / COMMIT_2 / GPU_TARGET / BUILD_CONFIG below, then:
+#     ./resource_usage_compare.sh
+#   or override via env without editing the file:
+#     COMMIT_1=develop COMMIT_2=HEAD ./resource_usage_compare.sh
+#
+# Env knobs:
+#   SKIP_BUILD=true     reuse whatever's already cached, just regenerate the
+#                       diff report/chart (fast iteration on report format).
+#   FORCE_REBUILD=true  rebuild+re-extract even if the commit is already
+#                       cached (needed after changing BUILD_CONFIG or the
+#                       resource-usage extraction scripts themselves).
+#   MATCH=<regex>       pin kernels matching this regex (against demangled or
+#                       mangled name, case-insensitive) to the top of every
+#                       report/chart regardless of delta -- use this to keep
+#                       an eye on a specific kernel instead of whatever has
+#                       the largest delta, e.g. MATCH='alltoall_test'.
+#
+# Leave COMMIT_2 empty ("") to just measure COMMIT_1 with no comparison.
+#
+# IMPORTANT: this script does `git checkout --force --detach` on the repo you
+# run it from. Stash or commit your working-tree changes first — it will
+# silently check out over uncommitted edits. For same-tree iteration with no
+# checkout, use scripts/functional_tests/measure.sh + compare.sh instead (see
+# the rocshmem-resource-usage skill, section A).
+#
+# Example:
+# COMMIT_1=d48c64f6e COMMIT_2=3caf8d080 BUILD_CONFIG=all_backends \
+#  FORCE_REBUILD=true ./resource_usage_compare.sh
+#
+# Example, pinning a specific kernel to the top of every report/chart:
+# COMMIT_1=673440d COMMIT_2=da18d28 BUILD_CONFIG=all_backends \
+#  MATCH='alltoall_test' ./resource_usage_compare.sh
+###############################################################################
+set -euo pipefail
+
+# COMMIT_1="${COMMIT_1:-HEAD}"
+# COMMIT_2="${COMMIT_2:-}"
+COMMIT_1=f41d40f
+COMMIT_2=749f856
+GPU_TARGET="${GPU_TARGET:-gfx950}"
+BUILD_CONFIG="${BUILD_CONFIG:-all_backends}"
+
+SKIP_BUILD="${SKIP_BUILD:-false}"
+FORCE_REBUILD="${FORCE_REBUILD:-false}"
+MATCH="${MATCH:-}"
+
+ROCSHMEM_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+cd "$ROCSHMEM_DIR"
+
+if [[ "$SKIP_BUILD" != "true" ]] && ! git diff --quiet HEAD --; then
+  echo "ERROR: tracked files have uncommitted changes. This script runs 'git checkout'" >&2
+  echo "and will silently discard them. Stash/commit first, or set SKIP_BUILD=true" >&2
+  echo "if you only want to regenerate the diff report from cached builds." >&2
+  echo "(untracked files are not affected by checkout and are ignored by this check)" >&2
+  exit 1
+fi
+
+ORIGINAL_REF="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$ORIGINAL_REF" == "HEAD" ]]; then
+  ORIGINAL_REF="$(git rev-parse HEAD)"
+fi
+
+CACHE_ROOT="$ROCSHMEM_DIR/resource-usage-cache"
+mkdir -p "$CACHE_ROOT"
+
+# measure_commit <commit> -> prints the path to that commit's cached CSV
+measure_commit() {
+  local commit="$1"
+  local sha
+  sha="$(git rev-parse --short=12 "$commit")"
+  local cache_dir="$CACHE_ROOT/${GPU_TARGET}-${BUILD_CONFIG}-${sha}"
+  local csv="$cache_dir/res-${sha}.csv"
+
+  if [[ -f "$csv" && "$FORCE_REBUILD" != "true" ]]; then
+    echo "  [$sha] cached -> $csv" >&2
+    echo "$csv"
+    return
+  fi
+
+  if [[ "$SKIP_BUILD" == "true" ]]; then
+    echo "ERROR: SKIP_BUILD=true but no cached CSV for $sha at $csv" >&2
+    exit 1
+  fi
+
+  echo "  [$sha] building ($GPU_TARGET / $BUILD_CONFIG)..." >&2
+  mkdir -p "$cache_dir"
+  local build_dir="$cache_dir/build"
+
+  git checkout --quiet --force --detach "$sha"
+
+  mkdir -p "$build_dir"
+  rm -rf "${build_dir:?}"/*
+  (
+    cd "$build_dir"
+    # measure_commit's own stdout is captured by the caller ($(measure_commit ...)) and
+    # must contain only the final `echo "$csv"` path below -- tee's stdout copy of the
+    # build log must go to stderr (>&2), not stdout, or it corrupts the captured path
+    # (and can make it megabytes long, blowing out ARG_MAX in later `cp "$CSV_1" ...`).
+    "$ROCSHMEM_DIR/scripts/build_configs/$BUILD_CONFIG" \
+      -DGPU_TARGETS="$GPU_TARGET" \
+      -DCMAKE_CXX_FLAGS="-Rpass-analysis=kernel-resource-usage" 2>&1 |
+      tee "$cache_dir/build.log" >&2
+    grep -B1 -A9 "Function Name:" "$cache_dir/build.log" >"$cache_dir/resource_usage_summary.log" || true
+  )
+
+  # measure_commit's stdout is captured by the caller (CSV_1="$(measure_commit ...)")
+  # and must contain only the final `echo "$csv"` path -- redirect this script's own
+  # report (which prints to stdout) to stderr so it stays visible without corrupting
+  # the captured path.
+  python3 "$ROCSHMEM_DIR/scripts/functional_tests/resource_usage_to_csv.py" \
+    --log "$cache_dir/resource_usage_summary.log" \
+    --arch "$GPU_TARGET" --build-config "$BUILD_CONFIG" --commit "$sha" \
+    --out "$csv" >&2
+
+  # Build artifacts are large and reproducible from the log; drop them but
+  # keep the log + CSV (cheap, and enough to regenerate the CSV if its format
+  # changes) so re-running with FORCE_REBUILD=false stays fast.
+  rm -rf "$build_dir"
+
+  echo "$csv"
+}
+
+echo "=== resource usage: $COMMIT_1${COMMIT_2:+ vs $COMMIT_2} ($GPU_TARGET / $BUILD_CONFIG) ==="
+
+CSV_1="$(measure_commit "$COMMIT_1")"
+SHA_1="$(git rev-parse --short=12 "$COMMIT_1")"
+
+git checkout --quiet --force "$ORIGINAL_REF" 2>/dev/null || true
+
+if [[ -z "$COMMIT_2" ]]; then
+  echo ""
+  echo "Single-commit snapshot -> $CSV_1"
+  exit 0
+fi
+
+CSV_2="$(measure_commit "$COMMIT_2")"
+SHA_2="$(git rev-parse --short=12 "$COMMIT_2")"
+
+git checkout --quiet --force "$ORIGINAL_REF" 2>/dev/null || true
+
+OUTDIR="$ROCSHMEM_DIR/resource-usage-${GPU_TARGET}-${BUILD_CONFIG}-${SHA_1}-vs-${SHA_2}"
+mkdir -p "$OUTDIR"
+cp "$CSV_1" "$OUTDIR/res-${SHA_1}.csv"
+cp "$CSV_2" "$OUTDIR/res-${SHA_2}.csv"
+
+SORT_BY_TYPE=(
+  "VGPRs" "TotalSGPRs" "AGPRs" "ScratchBytesPerLane"
+  "OccupancyWavesPerSIMD" "SGPRsSpill" "VGPRsSpill" "LDSBytesPerBlock"
+)
+for sort_by in "${SORT_BY_TYPE[@]}"; do
+  python3 "$ROCSHMEM_DIR/scripts/functional_tests/resource_usage_diff.py" \
+    --baseline "$CSV_1" \
+    --branch "$CSV_2" \
+    --out "$OUTDIR/res_diff_${sort_by}.csv" \
+    --chart "$OUTDIR/res_diff_${sort_by}.png" \
+    --top 20 --sort-by "$sort_by" \
+    ${MATCH:+--match "$MATCH"}
+done
+
+echo ""
+echo "Done. Self-contained report -> $OUTDIR/"
+echo "  inputs:  res-${SHA_1}.csv, res-${SHA_2}.csv"
+echo "  reports: res_diff_<Column>.{csv,png} for each of: ${SORT_BY_TYPE[*]}"

--- a/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
@@ -5,7 +5,10 @@
 #
 # Builds are cached per (gpu_target, build_config, commit) under
 # $PROJECTS_DIR/build-cache so re-comparing COMMIT_1 against a
-# different COMMIT_2 doesn't rebuild COMMIT_1 again.
+# different COMMIT_2 doesn't rebuild COMMIT_1 again. The durable outputs of
+# that build (res-<sha>.csv, build.log, resource_usage_summary.log) live
+# separately under $PROJECTS_DIR/resource-usage-cache, so build-cache can be
+# wiped for disk space without losing prior measurements.
 #
 # Each commit is built in an isolated git worktree under /tmp so the main
 # working tree is never touched — uncommitted changes are safe.
@@ -36,8 +39,7 @@
 #                         report/chart regardless of delta.
 #   --output-dir DIR      Directory to write the comparison report (CSVs +
 #                         charts) to. Default:
-#                         build-cache/<gpu>-<config>-<sha1>-vs-<sha2>/
-#                         under the rocshmem repo root.
+#                         $PROJECTS_DIR/resource-usage/<gpu>-<config>-<sha1>-vs-<sha2>/
 #
 # Example: compare two explicit commits
 #   ./resource_usage_compare.sh --commit1 d48c64f6e --commit2 3caf8d080 \
@@ -128,7 +130,8 @@ measure_commit() {
   local commit="$1"
   local sha="$2"
   local build_dir="$PROJECTS_DIR/build-cache/${GPU_TARGET}-${BUILD_CONFIG}-${sha}"
-  local csv="$build_dir/res-${sha}.csv"
+  local cache_dir="$PROJECTS_DIR/resource-usage/cache/${GPU_TARGET}-${BUILD_CONFIG}-${sha}"
+  local csv="$cache_dir/res-${sha}.csv"
 
   if [[ -f "$csv" && "$FORCE_REBUILD" == false ]]; then
     echo "  [$sha] cached -> $csv" >&2
@@ -158,18 +161,21 @@ measure_commit() {
   # relying on it.
   rm -rf "$build_dir"
   mkdir -p "$build_dir"
+  mkdir -p "$cache_dir"
   (
     cd "$build_dir"
     # measure_commit's own stdout is captured by the caller ($(measure_commit ...)) and
     # must contain only the final `echo "$csv"` path below -- tee's stdout copy of the
     # build log must go to stderr (>&2), not stdout, or it corrupts the captured path
     # (and can make it megabytes long, blowing out ARG_MAX in later `cp "$CSV_1" ...`).
+    # build.log/resource_usage_summary.log are written under cache_dir (not
+    # build_dir) so they survive a `rm -rf build-cache/`.
     "$FOUND_BUILD_CONFIG" \
       --fresh \
       -DGPU_TARGETS="$GPU_TARGET" \
       -DCMAKE_CXX_FLAGS="-Rpass-analysis=kernel-resource-usage" 2>&1 |
-      tee "$build_dir/build.log" >&2
-    grep -B1 -A9 "Function Name:" "$build_dir/build.log" >"$build_dir/resource_usage_summary.log" || true
+      tee "$cache_dir/build.log" >&2
+    grep -B1 -A9 "Function Name:" "$cache_dir/build.log" >"$cache_dir/resource_usage_summary.log" || true
   )
 
   git -C "$ROCSHMEM_DIR" worktree remove "$worktree" >&2 || true
@@ -180,7 +186,7 @@ measure_commit() {
   # report (which prints to stdout) to stderr so it stays visible without corrupting
   # the captured path.
   python3 "$TOOLS_DIR/resource_usage_to_csv.py" \
-    --log "$build_dir/resource_usage_summary.log" \
+    --log "$cache_dir/resource_usage_summary.log" \
     --arch "$GPU_TARGET" --build-config "$BUILD_CONFIG" --commit "$sha" \
     --out "$csv" >&2
 

--- a/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
@@ -45,6 +45,11 @@
 #  MATCH='alltoall_test' ./resource_usage_compare.sh
 ###############################################################################
 set -euo pipefail
+# Without this, command substitution $(...) (e.g. CSV_1="$(measure_commit ...)")
+# runs in a subshell with errexit silently UNSET, so a failing command inside
+# measure_commit (e.g. python3 erroring out) does not stop the script -- it
+# just falls through to `echo "$csv"`, which exits 0 and masks the failure.
+shopt -s inherit_errexit
 
 COMMIT_1="${COMMIT_1:-HEAD}"
 COMMIT_2="${COMMIT_2:-}"
@@ -74,6 +79,15 @@ fi
 
 CACHE_ROOT="$ROCSHMEM_DIR/resource-usage-cache"
 mkdir -p "$CACHE_ROOT"
+
+# Snapshot the tool scripts *before* any git checkout below moves the working
+# tree to an older commit that may not contain them (or may contain an older,
+# incompatible version). Always run the current (ORIGINAL_REF) version of
+# these scripts, regardless of which commit is checked out for the build.
+TOOLS_DIR="$CACHE_ROOT/.tools"
+mkdir -p "$TOOLS_DIR"
+cp "$ROCSHMEM_DIR/scripts/functional_tests/resource_usage_to_csv.py" "$TOOLS_DIR/"
+cp "$ROCSHMEM_DIR/scripts/functional_tests/resource_usage_diff.py" "$TOOLS_DIR/"
 
 # measure_commit <commit> -> prints the path to that commit's cached CSV
 measure_commit() {
@@ -119,7 +133,7 @@ measure_commit() {
   # and must contain only the final `echo "$csv"` path -- redirect this script's own
   # report (which prints to stdout) to stderr so it stays visible without corrupting
   # the captured path.
-  python3 "$ROCSHMEM_DIR/scripts/functional_tests/resource_usage_to_csv.py" \
+  python3 "$TOOLS_DIR/resource_usage_to_csv.py" \
     --log "$cache_dir/resource_usage_summary.log" \
     --arch "$GPU_TARGET" --build-config "$BUILD_CONFIG" --commit "$sha" \
     --out "$csv" >&2
@@ -173,7 +187,7 @@ SORT_BY_TYPE=(
   "OccupancyWavesPerSIMD" "SGPRsSpill" "VGPRsSpill" "LDSBytesPerBlock"
 )
 for sort_by in "${SORT_BY_TYPE[@]}"; do
-  python3 "$ROCSHMEM_DIR/scripts/functional_tests/resource_usage_diff.py" \
+  python3 "$TOOLS_DIR/resource_usage_diff.py" \
     --baseline "$CSV_1" \
     --branch "$CSV_2" \
     --out "$OUTDIR/res_diff_${sort_by}.csv" \

--- a/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
@@ -3,46 +3,48 @@
 # Compare per-kernel GPU resource usage (VGPR/SGPR/AGPR/scratch/LDS/occupancy)
 # between two commits (or one commit vs the current working tree).
 #
-# This is the git-checkout-based counterpart to measuring the working tree in
-# place with no checkout. Use this script when you need to bisect a
-# regression across history or compare a PR branch against its merge-base,
-# rather than iterating on local edits.
-#
 # Builds are cached per (gpu_target, build_config, commit) under
-# resource-usage-cache/ so re-comparing COMMIT_1 against a different COMMIT_2
-# doesn't rebuild COMMIT_1 again.
+# $PROJECTS_DIR/build-resource-usage-* so re-comparing COMMIT_1 against a
+# different COMMIT_2 doesn't rebuild COMMIT_1 again.
+#
+# Each commit is built in an isolated git worktree under /tmp so the main
+# working tree is never touched — uncommitted changes are safe.
 #
 # Usage:
-#   Edit COMMIT_1 / COMMIT_2 / GPU_TARGET / BUILD_CONFIG below, then:
-#     ./resource_usage_compare.sh
-#   or override via env without editing the file:
-#     COMMIT_1=develop COMMIT_2=HEAD ./resource_usage_compare.sh
+#   ./resource_usage_compare.sh [OPTIONS]
 #
-# Env knobs:
-#   SKIP_BUILD=true     reuse whatever's already cached, just regenerate the
-#                       diff report/chart (fast iteration on report format).
-#   FORCE_REBUILD=true  rebuild+re-extract even if the commit is already
-#                       cached (needed after changing BUILD_CONFIG or the
-#                       resource-usage extraction scripts themselves).
-#   MATCH=<regex>       pin kernels matching this regex (against demangled or
-#                       mangled name, case-insensitive) to the top of every
-#                       report/chart regardless of delta -- use this to keep
-#                       an eye on a specific kernel instead of whatever has
-#                       the largest delta, e.g. MATCH='alltoall_test'.
+# Options:
+#   --commit1 REF         First commit/branch to measure (default: HEAD, or
+#                         merge-base with --base-branch when --pr is set).
+#   --commit2 REF         Second commit/branch to compare against commit1.
+#                         Omit to just snapshot commit1 with no diff.
+#   --pr NUM              Fetch GitHub PR #NUM and compare it against its
+#                         merge-base with --base-branch. Sets commit2=FETCH_HEAD
+#                         and commit1=merge-base unless overridden.
+#   --base-branch NAME    Base branch for merge-base resolution with --pr
+#                         (default: origin/develop).
+#   --gpu-target ARCH     GPU target architecture (default: gfx950).
+#   --build-config CFG    Build config script under scripts/build_configs/
+#                         (default: all_backends).
+#   --skip-build          Reuse whatever's already cached, just regenerate the
+#                         diff report/chart (fast iteration on report format).
+#   --force-rebuild       Rebuild+re-extract even if the commit is already
+#                         cached (needed after changing --build-config or the
+#                         resource-usage extraction scripts themselves).
+#   --match REGEX         Pin kernels matching this regex (against demangled or
+#                         mangled name, case-insensitive) to the top of every
+#                         report/chart regardless of delta.
 #
-# Leave COMMIT_2 empty ("") to just measure COMMIT_1 with no comparison.
+# Example: compare two explicit commits
+#   ./resource_usage_compare.sh --commit1 d48c64f6e --commit2 3caf8d080 \
+#     --build-config all_backends --force-rebuild
 #
-# IMPORTANT: this script does `git checkout --force --detach` on the repo you
-# run it from. Stash or commit your working-tree changes first — it will
-# silently check out over uncommitted edits.
+# Example: compare a PR against its merge-base with develop
+#   ./resource_usage_compare.sh --pr 42 --build-config all_backends
 #
-# Example:
-# COMMIT_1=d48c64f6e COMMIT_2=3caf8d080 BUILD_CONFIG=all_backends \
-#  FORCE_REBUILD=true ./resource_usage_compare.sh
-#
-# Example, pinning a specific kernel to the top of every report/chart:
-# COMMIT_1=673440d COMMIT_2=da18d28 BUILD_CONFIG=all_backends \
-#  MATCH='alltoall_test' ./resource_usage_compare.sh
+# Example: pin a specific kernel to the top of every report/chart
+#   ./resource_usage_compare.sh --commit1 673440d --commit2 da18d28 \
+#     --match alltoall_test
 ###############################################################################
 set -euo pipefail
 # Without this, command substitution $(...) (e.g. CSV_1="$(measure_commit ...)")
@@ -51,120 +53,135 @@ set -euo pipefail
 # just falls through to `echo "$csv"`, which exits 0 and masks the failure.
 shopt -s inherit_errexit
 
-COMMIT_1="${COMMIT_1:-HEAD}"
-COMMIT_2="${COMMIT_2:-}"
-GPU_TARGET="${GPU_TARGET:-gfx950}"
-BUILD_CONFIG="${BUILD_CONFIG:-all_backends}"
+COMMIT_1=""
+COMMIT_2=""
+GPU_TARGET="gfx950"
+BUILD_CONFIG="all_backends"
+PR_NUM=""
+BASE_BRANCH="origin/develop"
+SKIP_BUILD=false
+FORCE_REBUILD=false
+MATCH=""
 
-SKIP_BUILD="${SKIP_BUILD:-false}"
-FORCE_REBUILD="${FORCE_REBUILD:-false}"
-MATCH="${MATCH:-}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --commit1)       COMMIT_1="$2";      shift 2 ;;
+    --commit2)       COMMIT_2="$2";      shift 2 ;;
+    --pr)            PR_NUM="$2";        shift 2 ;;
+    --base-branch)   BASE_BRANCH="$2";   shift 2 ;;
+    --gpu-target)    GPU_TARGET="$2";    shift 2 ;;
+    --build-config)  BUILD_CONFIG="$2";  shift 2 ;;
+    --skip-build)    SKIP_BUILD=true;    shift ;;
+    --force-rebuild) FORCE_REBUILD=true; shift ;;
+    --match)         MATCH="$2";         shift 2 ;;
+    -h|--help)
+      sed -n '2,/^###$/p' "$0" | head -n -1
+      exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
 
 SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
 ROCSHMEM_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PROJECTS_DIR="$(cd "$ROCSHMEM_DIR/.." && pwd)"
 cd "$ROCSHMEM_DIR"
 
-if [[ "$SKIP_BUILD" != "true" ]] && ! git diff --quiet HEAD --; then
-  echo "ERROR: tracked files have uncommitted changes. This script runs 'git checkout'" >&2
-  echo "and will silently discard them. Stash/commit first, or set SKIP_BUILD=true" >&2
-  echo "if you only want to regenerate the diff report from cached builds." >&2
-  echo "(untracked files are not affected by checkout and are ignored by this check)" >&2
-  exit 1
-fi
 
-ORIGINAL_REF="$(git rev-parse --abbrev-ref HEAD)"
-if [[ "$ORIGINAL_REF" == "HEAD" ]]; then
-  ORIGINAL_REF="$(git rev-parse HEAD)"
-fi
+TOOLS_DIR="$ROCSHMEM_DIR/scripts/functional_tests"
 
-CACHE_ROOT="$ROCSHMEM_DIR/resource-usage-cache"
-mkdir -p "$CACHE_ROOT"
-
-# Snapshot the tool scripts *before* any git checkout below moves the working
-# tree to an older commit that may not contain them (or may contain an older,
-# incompatible version). Always run the current (ORIGINAL_REF) version of
-# these scripts, regardless of which commit is checked out for the build.
-TOOLS_DIR="$CACHE_ROOT/.tools"
-mkdir -p "$TOOLS_DIR"
-cp "$ROCSHMEM_DIR/scripts/functional_tests/resource_usage_to_csv.py" "$TOOLS_DIR/"
-cp "$ROCSHMEM_DIR/scripts/functional_tests/resource_usage_diff.py" "$TOOLS_DIR/"
+_find_build_config() {
+  local worktree="$1"
+  local config="$2"
+  local result=""
+  for candidate in \
+    "$worktree/scripts/build_configs/$config" \
+    "$worktree/projects/rocshmem/scripts/build_configs/$config"; do
+    if [[ -x "$candidate" ]]; then
+      result="$candidate"
+      break
+    fi
+  done
+  echo "$result"
+}
 
 # measure_commit <commit> -> prints the path to that commit's cached CSV
 measure_commit() {
   local commit="$1"
-  local sha
-  sha="$(git rev-parse --short=12 "$commit")"
-  local cache_dir="$CACHE_ROOT/${GPU_TARGET}-${BUILD_CONFIG}-${sha}"
-  local csv="$cache_dir/res-${sha}.csv"
+  local sha="$2"
+  local build_dir="$PROJECTS_DIR/build-resource-usage-${GPU_TARGET}-${BUILD_CONFIG}-${sha}"
+  local csv="$build_dir/res-${sha}.csv"
 
-  if [[ -f "$csv" && "$FORCE_REBUILD" != "true" ]]; then
+  if [[ -f "$csv" && "$FORCE_REBUILD" == false ]]; then
     echo "  [$sha] cached -> $csv" >&2
     echo "$csv"
     return
   fi
 
-  if [[ "$SKIP_BUILD" == "true" ]]; then
-    echo "ERROR: SKIP_BUILD=true but no cached CSV for $sha at $csv" >&2
+  if [[ "$SKIP_BUILD" == true ]]; then
+    echo "ERROR: --skip-build set but no cached CSV for $sha at $csv" >&2
     exit 1
   fi
 
   echo "  [$sha] building ($GPU_TARGET / $BUILD_CONFIG)..." >&2
-  mkdir -p "$cache_dir"
-  local build_dir="$cache_dir/build"
+  local worktree="/tmp/rocshmem-resource-usage-${sha}-$$"
 
-  git checkout --quiet --force --detach "$(git rev-parse "$commit")"
+  git -C "$ROCSHMEM_DIR" worktree add "$worktree" "$commit" --detach >&2
+
+  FOUND_BUILD_CONFIG="$(_find_build_config "$worktree" "$BUILD_CONFIG")"
+  if [[ -z "$FOUND_BUILD_CONFIG" ]]; then
+    echo "ERROR: Cannot find $BUILD_CONFIG in baseline worktree" >&2
+    git -C "$ROCSHMEM_DIR" worktree remove "$worktree" || true
+    exit 1
+  fi
 
   mkdir -p "$build_dir"
-  rm -rf "${build_dir:?}"/*
   (
     cd "$build_dir"
     # measure_commit's own stdout is captured by the caller ($(measure_commit ...)) and
     # must contain only the final `echo "$csv"` path below -- tee's stdout copy of the
     # build log must go to stderr (>&2), not stdout, or it corrupts the captured path
     # (and can make it megabytes long, blowing out ARG_MAX in later `cp "$CSV_1" ...`).
-    "$ROCSHMEM_DIR/scripts/build_configs/$BUILD_CONFIG" \
+    "$FOUND_BUILD_CONFIG" \
+      --fresh \
       -DGPU_TARGETS="$GPU_TARGET" \
       -DCMAKE_CXX_FLAGS="-Rpass-analysis=kernel-resource-usage" 2>&1 |
-      tee "$cache_dir/build.log" >&2
-    grep -B1 -A9 "Function Name:" "$cache_dir/build.log" >"$cache_dir/resource_usage_summary.log" || true
+      tee "$build_dir/build.log" >&2
+    grep -B1 -A9 "Function Name:" "$build_dir/build.log" >"$build_dir/resource_usage_summary.log" || true
   )
+
+  git -C "$ROCSHMEM_DIR" worktree remove "$worktree" >&2 || true
 
   # measure_commit's stdout is captured by the caller (CSV_1="$(measure_commit ...)")
   # and must contain only the final `echo "$csv"` path -- redirect this script's own
   # report (which prints to stdout) to stderr so it stays visible without corrupting
   # the captured path.
   python3 "$TOOLS_DIR/resource_usage_to_csv.py" \
-    --log "$cache_dir/resource_usage_summary.log" \
+    --log "$build_dir/resource_usage_summary.log" \
     --arch "$GPU_TARGET" --build-config "$BUILD_CONFIG" --commit "$sha" \
     --out "$csv" >&2
-
-  # Build artifacts are large and reproducible from the log; drop them but
-  # keep the log + CSV (cheap, and enough to regenerate the CSV if its format
-  # changes) so re-running with FORCE_REBUILD=false stays fast.
-  rm -rf "$build_dir"
 
   echo "$csv"
 }
 
+if [[ -n "$PR_NUM" ]]; then
+  echo "  Fetching PR #${PR_NUM}..." >&2
+  git -C "$ROCSHMEM_DIR" fetch origin "pull/${PR_NUM}/head"
+  COMMIT_2="${COMMIT_2:-FETCH_HEAD}"
+  if [[ -z "$COMMIT_1" ]]; then
+    COMMIT_1="$(git merge-base FETCH_HEAD "$BASE_BRANCH")" || {
+      echo "ERROR: Cannot find merge-base between PR #${PR_NUM} and $BASE_BRANCH" >&2
+      echo "       Make sure '$BASE_BRANCH' exists (try: git fetch origin)" >&2
+      exit 1
+    }
+  fi
+else
+  COMMIT_1="${COMMIT_1:-HEAD}"
+fi
+
 echo "=== resource usage: $COMMIT_1${COMMIT_2:+ vs $COMMIT_2} ($GPU_TARGET / $BUILD_CONFIG) ==="
 
-# Only restore if we're not already on it -- `checkout --force` to the ref
-# you're already on still overwrites any uncommitted changes to tracked
-# files (e.g. edits made to other scripts while this one was running, or on
-# a cache hit where measure_commit never checked anything out to begin with).
-_restore_original_ref() {
-  local current_ref
-  current_ref="$(git rev-parse --abbrev-ref HEAD)"
-  [[ "$current_ref" == "HEAD" ]] && current_ref="$(git rev-parse HEAD)"
-  if [[ "$current_ref" != "$ORIGINAL_REF" ]]; then
-    git checkout --quiet --force "$ORIGINAL_REF" 2>/dev/null || true
-  fi
-}
-
-CSV_1="$(measure_commit "$COMMIT_1")"
 SHA_1="$(git rev-parse --short=12 "$COMMIT_1")"
-
-_restore_original_ref
+CSV_1="$(measure_commit "$COMMIT_1" "$SHA_1")"
 
 if [[ -z "$COMMIT_2" ]]; then
   echo ""
@@ -172,10 +189,8 @@ if [[ -z "$COMMIT_2" ]]; then
   exit 0
 fi
 
-CSV_2="$(measure_commit "$COMMIT_2")"
 SHA_2="$(git rev-parse --short=12 "$COMMIT_2")"
-
-_restore_original_ref
+CSV_2="$(measure_commit "$COMMIT_2" "$SHA_2")"
 
 OUTDIR="$ROCSHMEM_DIR/resource-usage-${GPU_TARGET}-${BUILD_CONFIG}-${SHA_1}-vs-${SHA_2}"
 mkdir -p "$OUTDIR"
@@ -186,6 +201,7 @@ SORT_BY_TYPE=(
   "VGPRs" "TotalSGPRs" "AGPRs" "ScratchBytesPerLane"
   "OccupancyWavesPerSIMD" "SGPRsSpill" "VGPRsSpill" "LDSBytesPerBlock"
 )
+
 for sort_by in "${SORT_BY_TYPE[@]}"; do
   python3 "$TOOLS_DIR/resource_usage_diff.py" \
     --baseline "$CSV_1" \

--- a/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
@@ -55,7 +55,8 @@ SKIP_BUILD="${SKIP_BUILD:-false}"
 FORCE_REBUILD="${FORCE_REBUILD:-false}"
 MATCH="${MATCH:-}"
 
-ROCSHMEM_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+ROCSHMEM_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$ROCSHMEM_DIR"
 
 if [[ "$SKIP_BUILD" != "true" ]] && ! git diff --quiet HEAD --; then
@@ -97,7 +98,7 @@ measure_commit() {
   mkdir -p "$cache_dir"
   local build_dir="$cache_dir/build"
 
-  git checkout --quiet --force --detach "$sha"
+  git checkout --quiet --force --detach "$(git rev-parse "$commit")"
 
   mkdir -p "$build_dir"
   rm -rf "${build_dir:?}"/*

--- a/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
@@ -4,7 +4,7 @@
 # between two commits (or one commit vs the current working tree).
 #
 # Builds are cached per (gpu_target, build_config, commit) under
-# $PROJECTS_DIR/build-resource-usage-* so re-comparing COMMIT_1 against a
+# $PROJECTS_DIR/build-cache so re-comparing COMMIT_1 against a
 # different COMMIT_2 doesn't rebuild COMMIT_1 again.
 #
 # Each commit is built in an isolated git worktree under /tmp so the main
@@ -34,6 +34,10 @@
 #   --match REGEX         Pin kernels matching this regex (against demangled or
 #                         mangled name, case-insensitive) to the top of every
 #                         report/chart regardless of delta.
+#   --output-dir DIR      Directory to write the comparison report (CSVs +
+#                         charts) to. Default:
+#                         build-cache/<gpu>-<config>-<sha1>-vs-<sha2>/
+#                         under the rocshmem repo root.
 #
 # Example: compare two explicit commits
 #   ./resource_usage_compare.sh --commit1 d48c64f6e --commit2 3caf8d080 \
@@ -62,6 +66,7 @@ BASE_BRANCH="origin/develop"
 SKIP_BUILD=false
 FORCE_REBUILD=false
 MATCH=""
+OUTPUT_DIR=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -74,6 +79,7 @@ while [[ $# -gt 0 ]]; do
     --skip-build)    SKIP_BUILD=true;    shift ;;
     --force-rebuild) FORCE_REBUILD=true; shift ;;
     --match)         MATCH="$2";         shift 2 ;;
+    --output-dir)    OUTPUT_DIR="$2";    shift 2 ;;
     -h|--help)
       sed -n '2,/^#####/p' "$0" | head -n -1
       exit 0 ;;
@@ -121,7 +127,7 @@ _find_build_config() {
 measure_commit() {
   local commit="$1"
   local sha="$2"
-  local build_dir="$PROJECTS_DIR/build-resource-usage-${GPU_TARGET}-${BUILD_CONFIG}-${sha}"
+  local build_dir="$PROJECTS_DIR/build-cache/${GPU_TARGET}-${BUILD_CONFIG}-${sha}"
   local csv="$build_dir/res-${sha}.csv"
 
   if [[ -f "$csv" && "$FORCE_REBUILD" == false ]]; then
@@ -210,7 +216,7 @@ fi
 SHA_2="$(git rev-parse --short=12 "$COMMIT_2")"
 CSV_2="$(measure_commit "$COMMIT_2" "$SHA_2")"
 
-OUTDIR="$ROCSHMEM_DIR/resource-usage-${GPU_TARGET}-${BUILD_CONFIG}-${SHA_1}-vs-${SHA_2}"
+OUTDIR="${OUTPUT_DIR:-$PROJECTS_DIR/resource-usage/${GPU_TARGET}-${BUILD_CONFIG}-${SHA_1}-vs-${SHA_2}}"
 mkdir -p "$OUTDIR"
 cp "$CSV_1" "$OUTDIR/res-${SHA_1}.csv"
 cp "$CSV_2" "$OUTDIR/res-${SHA_2}.csv"

--- a/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/resource_usage_compare.sh
@@ -147,6 +147,10 @@ measure_commit() {
     exit 1
   fi
 
+  # cmake's --fresh has been unreliable at fully resetting cache/generated
+  # state between commits, so wipe the directory ourselves instead of
+  # relying on it.
+  rm -rf "$build_dir"
   mkdir -p "$build_dir"
   (
     cd "$build_dir"

--- a/projects/rocshmem/scripts/functional_tests/resource_usage_diff.py
+++ b/projects/rocshmem/scripts/functional_tests/resource_usage_diff.py
@@ -80,12 +80,27 @@ COLOR_NEUTRAL = "#9aa5b1"
 COLOR_STRIPE = "#f2f2f2"
 
 
+# Internal-linkage kernels (anonymous-namespace / local template instantiations,
+# e.g. static `ipc_fadd<T>` helpers) get a compiler-generated ".intern.<hash>"
+# suffix appended to their mangled name for disambiguation. That hash is not
+# stable across separate compilations of the same source, so matching on the
+# raw mangled name treats the *same* kernel as removed-in-baseline +
+# added-in-branch whenever it recompiles with a different hash -- which was
+# silently excluding most kernels from the diff (and could hide a real
+# regression in one of them). Strip the suffix before using it as the match key.
+_INTERN_SUFFIX_RE = re.compile(r"\.intern\.[0-9a-f]+$")
+
+
+def match_key_name(mangled_name):
+    return _INTERN_SUFFIX_RE.sub("", mangled_name)
+
+
 def load(path: Path):
     with open(path, newline="") as f:
         rows = list(csv.DictReader(f))
     by_key = {}
     for r in rows:
-        key = (r["arch"], r["build_config"], r["mangled_name"])
+        key = (r["arch"], r["build_config"], match_key_name(r["mangled_name"]))
         by_key[key] = r
     return by_key
 

--- a/projects/rocshmem/scripts/functional_tests/resource_usage_diff.py
+++ b/projects/rocshmem/scripts/functional_tests/resource_usage_diff.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+###############################################################################
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""Diff two resource-usage CSVs (see resource_usage_to_csv.py) produced from
+two different commits/builds, matched on (arch, build_config, mangled_name).
+
+Matching by mangled_name (not source_file:line) so a function that moved
+lines between commits is still compared correctly; template instantiations
+keep distinct mangled names so they stay distinct rows.
+
+Occupancy [waves/SIMD] is not an independent resource: it is the compiler's
+resident-wavefront count per SIMD, capped by whichever of the VGPR file, the
+SGPR file, or the LDS budget is tightest for that specific kernel. It can
+move in a different direction than any single resource column — e.g. VGPRs
+can go up while occupancy also goes up, if the same change relieves LDS or
+SGPR pressure instead. For that reason this script colors the occupancy
+panel by its own delta (more waves/SIMD = better) independently of how the
+VGPR/SGPR/scratch/LDS panels are colored (less usage = better).
+
+Usage:
+    python3 scripts/functional_tests/resource_usage_diff.py \\
+        --baseline resource_usage_commitA.csv \\
+        --branch   resource_usage_commitB.csv \\
+        --out      resource_usage_diff.csv \\
+        --chart    resource_usage_diff.png \\
+        --sort-by VGPRs
+
+Use --match <regex> to pin specific kernels (matched against demangled_name or
+mangled_name, case-insensitive) at the top of the text report and chart, even
+if their delta is zero for every column -- useful when tracking one or two
+kernels you care about instead of whatever happens to have the largest delta.
+"""
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+
+NUMERIC_COLS = [
+    "TotalSGPRs",
+    "VGPRs",
+    "AGPRs",
+    "ScratchBytesPerLane",
+    "OccupancyWavesPerSIMD",
+    "SGPRsSpill",
+    "VGPRsSpill",
+    "LDSBytesPerBlock",
+]
+
+# Columns worth calling out in the text report / chart when they differ and
+# are non-zero on at least one side. Occupancy is handled separately (see
+# module docstring) since it's a derived result, not a resource you spend.
+REPORT_COLS = [
+    "VGPRs",
+    "TotalSGPRs",
+    "VGPRsSpill",
+    "SGPRsSpill",
+    "ScratchBytesPerLane",
+    "LDSBytesPerBlock",
+]
+
+RESOURCE_LABELS = {
+    "VGPRs": "VGPRs",
+    "TotalSGPRs": "SGPRs",
+    "VGPRsSpill": "VGPR Spill",
+    "SGPRsSpill": "SGPR Spill",
+    "ScratchBytesPerLane": "Scratch [B/lane]",
+    "LDSBytesPerBlock": "LDS [B/block]",
+}
+OCC_COL = "OccupancyWavesPerSIMD"
+OCC_LABEL = "Occupancy [waves/SIMD]"
+
+COLOR_GOOD = "#2ca02c"
+COLOR_BAD = "#d62728"
+COLOR_NEUTRAL = "#9aa5b1"
+COLOR_STRIPE = "#f2f2f2"
+
+
+def load(path: Path):
+    with open(path, newline="") as f:
+        rows = list(csv.DictReader(f))
+    by_key = {}
+    for r in rows:
+        key = (r["arch"], r["build_config"], r["mangled_name"])
+        by_key[key] = r
+    return by_key
+
+
+def to_num(v):
+    try:
+        return int(v)
+    except (ValueError, TypeError):
+        return 0
+
+
+def short_commit(commit):
+    return commit[:10] if commit else ""
+
+
+def row_key(r):
+    return (r["arch"], r["build_config"], r["mangled_name"])
+
+
+def select_pinned(ordered, match_re):
+    """Rows whose demangled or mangled name matches --match, in existing |delta|-sorted order."""
+    if not match_re:
+        return []
+    return [r for r in ordered if match_re.search(r["demangled_name"]) or match_re.search(r["mangled_name"])]
+
+
+def build_diff_rows(baseline, branch):
+    all_keys = set(baseline) | set(branch)
+    diff_rows = []
+    for key in all_keys:
+        b = baseline.get(key)
+        n = branch.get(key)
+        status = "added" if b is None else "removed" if n is None else "common"
+        row = {
+            "arch": key[0],
+            "build_config": key[1],
+            "mangled_name": key[2],
+            "demangled_name": (n or b).get("demangled_name", key[2]),
+            "status": status,
+        }
+        for col in NUMERIC_COLS:
+            bv = to_num(b[col]) if b else 0
+            nv = to_num(n[col]) if n else 0
+            row[f"{col}_baseline"] = bv if b else ""
+            row[f"{col}_branch"] = nv if n else ""
+            row[f"{col}_delta"] = nv - bv
+        diff_rows.append(row)
+    return diff_rows
+
+
+def write_csv(diff_rows, out_path, sort_by):
+    out_fields = ["arch", "build_config", "demangled_name", "mangled_name", "status"]
+    for col in NUMERIC_COLS:
+        out_fields += [f"{col}_baseline", f"{col}_branch", f"{col}_delta"]
+
+    ordered = sorted(diff_rows, key=lambda r: abs(r[f"{sort_by}_delta"]), reverse=True)
+    with open(out_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=out_fields)
+        writer.writeheader()
+        for r in ordered:
+            writer.writerow({col: r.get(col, "") for col in out_fields})
+    return ordered
+
+
+def print_kernel_block(r, sort_by, sort_label):
+    d = r[f"{sort_by}_delta"]
+    sign = "+" if d > 0 else ""
+    status_note = f"  [{r['status']} vs baseline]" if r["status"] != "common" else ""
+    print(f"\n  {sign}{d:>5} {sort_label}  {r['arch']}/{r['build_config']}  {r['demangled_name']}{status_note}")
+    printed_any = False
+    for col in REPORT_COLS:
+        delta = r[f"{col}_delta"]
+        if delta == 0:
+            continue
+        bv, nv = r[f"{col}_baseline"], r[f"{col}_branch"]
+        if bv == 0 and nv == 0:
+            continue
+        csign = "+" if delta > 0 else ""
+        bv_disp = "-" if bv == "" else bv
+        nv_disp = "-" if nv == "" else nv
+        print(f"      {RESOURCE_LABELS[col]:22s} {bv_disp:>5} -> {nv_disp:<5} ({csign}{delta})")
+        printed_any = True
+    occ_delta = r[f"{OCC_COL}_delta"]
+    if occ_delta != 0:
+        ob, on = r[f"{OCC_COL}_baseline"], r[f"{OCC_COL}_branch"]
+        ob_disp = "-" if ob == "" else ob
+        on_disp = "-" if on == "" else on
+        direction = "DECREASED (worse)" if occ_delta < 0 else "INCREASED (better)"
+        print(f"      {OCC_LABEL:22s} {ob_disp:>5} -> {on_disp:<5} {direction}")
+        printed_any = True
+    if not printed_any:
+        print("      (no change in any resource column)")
+
+
+def print_report(ordered, sort_by, top_n, match_re=None):
+    sort_label = RESOURCE_LABELS.get(sort_by, OCC_LABEL)
+    changed = [r for r in ordered if r["status"] == "common" and r[f"{sort_by}_delta"] != 0]
+    added = [r for r in ordered if r["status"] == "added"]
+    removed = [r for r in ordered if r["status"] == "removed"]
+    print(f"{len(changed)} kernels changed {sort_label}, {len(added)} added, {len(removed)} removed\n")
+
+    print("Occupancy [waves/SIMD] is derived from whichever of VGPR/SGPR/LDS is the tightest\n"
+          "constraint for a given kernel, so it can move independently of any single resource\n"
+          "column below — it is reported per kernel, not implied by the other deltas.\n")
+
+    pinned = select_pinned(ordered, match_re)
+    pinned_keys = {row_key(r) for r in pinned}
+    if pinned:
+        print(f"Pinned kernels matching --match {match_re.pattern!r} "
+              f"({len(pinned)} match{'es' if len(pinned) != 1 else ''}, shown regardless of delta):")
+        for r in pinned:
+            print_kernel_block(r, sort_by, sort_label)
+        print()
+
+    remaining = [r for r in changed if row_key(r) not in pinned_keys]
+    print(f"Top {min(top_n, len(remaining))} kernels ranked by |{sort_label} delta| "
+          f"(baseline -> branch, all non-zero deltas shown):")
+    for r in remaining[:top_n]:
+        print_kernel_block(r, sort_by, sort_label)
+
+
+def wrap_label(row, width=42, pinned=False):
+    name = row["demangled_name"]
+    if len(name) > width:
+        name = name[: width - 1] + "…"
+    prefix = "★ " if pinned else ""
+    return f"{prefix}{name}\n[{row['arch']}/{row['build_config']}]"
+
+
+def make_chart(ordered, sort_by, chart_path, top_n, baseline_commit, branch_commit, match_re=None):
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("matplotlib not available; skipping chart", file=sys.stderr)
+        return
+    try:
+        import seaborn as sns
+        sns.set_theme(style="whitegrid", font_scale=0.95)
+    except ImportError:
+        pass
+
+    common = [r for r in ordered if r["status"] == "common"]
+    pinned = select_pinned(common, match_re)
+    pinned_keys = {row_key(r) for r in pinned}
+    remaining = [r for r in common if r[f"{sort_by}_delta"] != 0 and row_key(r) not in pinned_keys]
+    changed = pinned + remaining[:top_n]
+    if not changed:
+        print("No changed kernels to chart; skipping chart", file=sys.stderr)
+        return
+    if pinned:
+        print(f"Pinning {len(pinned)} kernel(s) matching --match {match_re.pattern!r} to the chart "
+              f"(marked with ★), regardless of delta.", file=sys.stderr)
+
+    # Largest delta at the top of the chart; pinned kernels always rendered above everything else.
+    changed = list(reversed(changed))
+    n = len(changed)
+    y = list(range(n))
+    labels = [wrap_label(r, pinned=row_key(r) in pinned_keys) for r in changed]
+
+    # Only render panels for resource types that actually changed among the displayed
+    # kernels, plus occupancy always last. A pinned kernel with a non-zero baseline/branch
+    # value also activates its column even with zero delta, since pinning means "I want to
+    # study this kernel" -- an unchanged-but-nonzero resource is still worth showing for it.
+    def col_active(c):
+        for r in changed:
+            if r[f"{c}_delta"] != 0:
+                return True
+            if row_key(r) in pinned_keys and (r[f"{c}_baseline"] or r[f"{c}_branch"]):
+                return True
+        return False
+
+    active_cols = [c for c in REPORT_COLS if col_active(c)]
+    if sort_by in active_cols:
+        active_cols.remove(sort_by)
+        active_cols.insert(0, sort_by)
+    panels = active_cols + [OCC_COL]
+
+    fig_height = max(3.7, 0.5 * n + 2.0)
+    fig, axes = plt.subplots(
+        1, len(panels),
+        figsize=(3.0 * len(panels) + 2.2, fig_height),
+        sharey=True,
+    )
+    if len(panels) == 1:
+        axes = [axes]
+
+    bar_h = 0.34
+    for ax, col in zip(axes, panels):
+        bvals = [r[f"{col}_baseline"] or 0 for r in changed]
+        nvals = [r[f"{col}_branch"] or 0 for r in changed]
+        deltas = [r[f"{col}_delta"] for r in changed]
+        if col == OCC_COL:
+            colors = [COLOR_GOOD if d > 0 else COLOR_BAD if d < 0 else COLOR_NEUTRAL for d in deltas]
+        else:
+            colors = [COLOR_BAD if d > 0 else COLOR_GOOD if d < 0 else COLOR_NEUTRAL for d in deltas]
+
+        for i in y:
+            if i % 2 == 0:
+                ax.axhspan(i - 0.5, i + 0.5, color=COLOR_STRIPE, zorder=0)
+
+        ax.barh([i + bar_h / 2 for i in y], bvals, height=bar_h, color=COLOR_NEUTRAL, zorder=2, label="baseline")
+        ax.barh([i - bar_h / 2 for i in y], nvals, height=bar_h, color=colors, zorder=2, label="branch")
+
+        xmax = max(bvals + nvals + [1])
+        for i, (bv, nv) in enumerate(zip(bvals, nvals)):
+            if bv == 0 and nv == 0:
+                continue
+            ax.text(max(bv, nv) + xmax * 0.03, i, f"{bv}→{nv}", va="center", fontsize=7.5, color="#333333")
+
+        ax.set_xlim(0, xmax * 1.28)
+        ax.set_title(RESOURCE_LABELS.get(col, OCC_LABEL), fontsize=10, fontweight="bold")
+        ax.tick_params(axis="x", labelsize=8)
+        for spine in ("top", "right"):
+            ax.spines[spine].set_visible(False)
+        ax.grid(axis="y", visible=False)
+
+    axes[0].set_yticks(y)
+    axes[0].set_yticklabels(labels, fontsize=8)
+    axes[0].set_ylim(-0.5, n - 0.5)
+
+    baseline_label = short_commit(baseline_commit) or "baseline"
+    branch_label = short_commit(branch_commit) or "branch"
+
+    # suptitle/legend/axes are stacked in the header region above the panels. Their y
+    # positions below are figure-fraction coordinates, but the figure height itself scales
+    # with n (see fig_height above) -- a fixed fraction gap shrinks to nothing in absolute
+    # terms for small n (few kernels), which is what caused the title/legend to overlap.
+    # Reserving the header in fixed inches and converting to a fraction of fig_height keeps
+    # the gap visually constant regardless of how many kernels are plotted.
+    TOP_MARGIN_IN = 0.15
+    TITLE_HEIGHT_IN = 0.45  # two lines at fontsize 12
+    TITLE_LEGEND_GAP_IN = 0.18
+    LEGEND_HEIGHT_IN = 0.2  # one line at fontsize 9
+    LEGEND_AXES_GAP_IN = 0.15
+
+    title_y = 1 - TOP_MARGIN_IN / fig_height
+    legend_y = 1 - (TOP_MARGIN_IN + TITLE_HEIGHT_IN + TITLE_LEGEND_GAP_IN) / fig_height
+    axes_top = 1 - (TOP_MARGIN_IN + TITLE_HEIGHT_IN + TITLE_LEGEND_GAP_IN
+                     + LEGEND_HEIGHT_IN + LEGEND_AXES_GAP_IN) / fig_height
+
+    from matplotlib.patches import Patch
+    legend_elems = [
+        Patch(color=COLOR_NEUTRAL, label=f"{baseline_label}  (top bar)"),
+        Patch(color=COLOR_BAD, label=f"{branch_label}  (bottom bar) — regressed"),
+        Patch(color=COLOR_GOOD, label=f"{branch_label}  (bottom bar) — improved"),
+    ]
+    fig.legend(handles=legend_elems, loc="upper center", ncol=3, bbox_to_anchor=(0.5, legend_y),
+               fontsize=9, frameon=False)
+
+    fig.suptitle(
+        f"Resource usage — top {n} kernels by |{RESOURCE_LABELS.get(sort_by, sort_by)} delta|\n"
+        f"baseline {baseline_label}  →  branch {branch_label}  (values shown as baseline→branch; "
+        f"usage panels: lower=better, occupancy: higher=better)",
+        fontsize=12, y=title_y,
+    )
+    fig.tight_layout(rect=[0, 0, 1, axes_top])
+    fig.savefig(chart_path, dpi=160, bbox_inches="tight")
+    print(f"Wrote chart to {chart_path}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--baseline", required=True, type=Path, help="CSV from the baseline commit")
+    ap.add_argument("--branch", required=True, type=Path, help="CSV from the branch/candidate commit")
+    ap.add_argument("--out", required=True, type=Path, help="diff CSV to write")
+    ap.add_argument("--chart", type=Path, default=None, help="PNG path for the side-by-side comparison chart (default: --out with .png extension)")
+    ap.add_argument("--no-chart", action="store_true", help="skip chart generation")
+    ap.add_argument("--sort-by", default="VGPRs", choices=NUMERIC_COLS, help="column to rank kernels by (largest |delta| first)")
+    ap.add_argument("--top", type=int, default=20, help="number of kernels to show in the text report and chart")
+    ap.add_argument("--match", default=None,
+                     help="regex (case-insensitive) matched against demangled/mangled kernel name; "
+                          "matching kernels are pinned to the top of the text report and chart "
+                          "regardless of delta, e.g. --match 'alltoall_test|wg_put_kernel'")
+    args = ap.parse_args()
+
+    if not args.baseline.exists():
+        sys.exit(f"error: baseline CSV not found: {args.baseline}")
+    if not args.branch.exists():
+        sys.exit(f"error: branch CSV not found: {args.branch}")
+
+    match_re = None
+    if args.match:
+        try:
+            match_re = re.compile(args.match, re.IGNORECASE)
+        except re.error as e:
+            sys.exit(f"error: invalid --match regex {args.match!r}: {e}")
+
+    baseline = load(args.baseline)
+    branch = load(args.branch)
+    baseline_commit = next(iter(baseline.values()))["commit"] if baseline else ""
+    branch_commit = next(iter(branch.values()))["commit"] if branch else ""
+
+    diff_rows = build_diff_rows(baseline, branch)
+    ordered = write_csv(diff_rows, args.out, args.sort_by)
+    print(f"Wrote {len(ordered)} rows to {args.out}")
+
+    if match_re and not select_pinned(ordered, match_re):
+        print(f"warning: --match {args.match!r} matched no kernels in either CSV", file=sys.stderr)
+
+    print_report(ordered, args.sort_by, args.top, match_re)
+
+    if not args.no_chart:
+        chart_path = args.chart or args.out.with_suffix(".png")
+        make_chart(ordered, args.sort_by, chart_path, args.top, baseline_commit, branch_commit, match_re)
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/rocshmem/scripts/functional_tests/resource_usage_to_csv.py
+++ b/projects/rocshmem/scripts/functional_tests/resource_usage_to_csv.py
@@ -4,8 +4,8 @@
 #
 # SPDX-License-Identifier: MIT
 ###############################################################################
-"""Parse a resource_usage_summary.log (produced by RESOURCE_USAGE=ON builds,
-see resource_usage_report.md) into a normalized CSV, one row per kernel.
+"""Parse a resource_usage_summary.log (produced by a build compiled with
+-Rpass-analysis=kernel-resource-usage) into a normalized CSV, one row per kernel.
 
 Usage:
     python3 scripts/functional_tests/resource_usage_to_csv.py \\

--- a/projects/rocshmem/scripts/functional_tests/resource_usage_to_csv.py
+++ b/projects/rocshmem/scripts/functional_tests/resource_usage_to_csv.py
@@ -145,7 +145,15 @@ def main():
         key = (args.arch, args.build_config, r["source_file"], r["line"], r["mangled_name"])
         existing[key] = r
 
-    rows = sorted(existing.values(), key=lambda r: (r["arch"], r["build_config"], r["source_file"], int(r["line"])))
+    # Sort by demangled_name (not line number) within each source file so that
+    # renaming/retyping kernels (e.g. AMOStandardTest<int> -> AMOStandardTest_int<...>)
+    # doesn't reshuffle row order -- related kernels stay adjacent alphabetically,
+    # so two CSVs from before/after a rename can be opened side-by-side and scrolled
+    # in tandem without any cross-CSV matching logic.
+    rows = sorted(
+        existing.values(),
+        key=lambda r: (r["arch"], r["build_config"], r["source_file"], r["demangled_name"]),
+    )
     with open(args.out, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=FIELDS)
         writer.writeheader()

--- a/projects/rocshmem/scripts/functional_tests/resource_usage_to_csv.py
+++ b/projects/rocshmem/scripts/functional_tests/resource_usage_to_csv.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+###############################################################################
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""Parse a resource_usage_summary.log (produced by RESOURCE_USAGE=ON builds,
+see resource_usage_report.md) into a normalized CSV, one row per kernel.
+
+Usage:
+    python3 scripts/functional_tests/resource_usage_to_csv.py \\
+        --log build/resource_usage_summary.log \\
+        --arch gfx950 --build-config ipc_single \\
+        --out resource_usage.csv
+
+Rows are appended to --out (header written once). Re-running with the same
+(arch, build-config, source_file, line, mangled_name) tuple replaces the
+existing row instead of duplicating it, so re-generating a build's numbers
+is idempotent.
+"""
+
+import argparse
+import csv
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+FIELDS = [
+    "arch",
+    "build_config",
+    "commit",
+    "source_file",
+    "line",
+    "mangled_name",
+    "demangled_name",
+    "TotalSGPRs",
+    "VGPRs",
+    "AGPRs",
+    "ScratchBytesPerLane",
+    "DynamicStack",
+    "OccupancyWavesPerSIMD",
+    "SGPRsSpill",
+    "VGPRsSpill",
+    "LDSBytesPerBlock",
+]
+
+# Maps the label text before ':' (bracketed units stripped) to a CSV column.
+KEY_TO_COLUMN = {
+    "Function Name": "mangled_name",
+    "TotalSGPRs": "TotalSGPRs",
+    "VGPRs": "VGPRs",
+    "AGPRs": "AGPRs",
+    "ScratchSize": "ScratchBytesPerLane",
+    "Dynamic Stack": "DynamicStack",
+    "Occupancy": "OccupancyWavesPerSIMD",
+    "SGPRs Spill": "SGPRsSpill",
+    "VGPRs Spill": "VGPRsSpill",
+    "LDS Size": "LDSBytesPerBlock",
+}
+
+
+def parse_log(log_path: Path):
+    """Yield one dict per kernel found in a resource_usage_summary.log file."""
+    row = None
+    with open(log_path, "r", errors="replace") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            # Expected: "<file>:<line>:<col>: <Key> [unit]: <value>"
+            parts = line.split(":", 3)
+            if len(parts) != 4:
+                continue
+            source_file, lineno, _col, rest = parts
+            if not lineno.isdigit() or ":" not in rest.strip() and "Function Name" not in rest:
+                pass
+            if ": " not in rest.lstrip():
+                continue
+            key_part, _, value = rest.strip().partition(":")
+            key = key_part.split(" [")[0].strip()
+            value = value.strip()
+            column = KEY_TO_COLUMN.get(key)
+            if column is None:
+                continue
+            if column == "mangled_name":
+                if row is not None:
+                    yield row
+                row = {"source_file": source_file.strip(), "line": lineno, column: value}
+            else:
+                if row is None:
+                    continue
+                row[column] = value
+        if row is not None:
+            yield row
+
+
+def demangle_all(names):
+    """Batch-demangle via a single c++filt invocation; falls back to raw names."""
+    if not names or shutil.which("c++filt") is None:
+        return {n: n for n in names}
+    proc = subprocess.run(
+        ["c++filt"], input="\n".join(names), capture_output=True, text=True, check=True
+    )
+    demangled = proc.stdout.splitlines()
+    return dict(zip(names, demangled))
+
+
+def load_existing(csv_path: Path):
+    if not csv_path.exists():
+        return {}
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        return {
+            (r["arch"], r["build_config"], r["source_file"], r["line"], r["mangled_name"]): r
+            for r in reader
+        }
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--log", required=True, type=Path, help="path to resource_usage_summary.log")
+    ap.add_argument("--arch", required=True, help="GPU target, e.g. gfx950")
+    ap.add_argument("--build-config", required=True, help="build_configs script used, e.g. ipc_single")
+    ap.add_argument("--commit", default="", help="optional git commit/ref this build came from")
+    ap.add_argument("--out", required=True, type=Path, help="CSV file to write/append to")
+    ap.add_argument("--top", type=int, default=10, help="print top-N kernels by VGPRs to stdout (0 to disable)")
+    args = ap.parse_args()
+
+    if not args.log.exists():
+        sys.exit(f"error: log not found: {args.log}")
+
+    parsed = list(parse_log(args.log))
+    if not parsed:
+        sys.exit(f"error: no 'Function Name:' blocks found in {args.log}")
+
+    demangled = demangle_all(sorted({r["mangled_name"] for r in parsed}))
+
+    existing = load_existing(args.out)
+    for r in parsed:
+        r["arch"] = args.arch
+        r["build_config"] = args.build_config
+        r["commit"] = args.commit
+        r["demangled_name"] = demangled.get(r["mangled_name"], r["mangled_name"])
+        for col in FIELDS:
+            r.setdefault(col, "")
+        key = (args.arch, args.build_config, r["source_file"], r["line"], r["mangled_name"])
+        existing[key] = r
+
+    rows = sorted(existing.values(), key=lambda r: (r["arch"], r["build_config"], r["source_file"], int(r["line"])))
+    with open(args.out, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=FIELDS)
+        writer.writeheader()
+        for r in rows:
+            writer.writerow({col: r.get(col, "") for col in FIELDS})
+
+    print(f"Wrote {len(rows)} rows ({len(parsed)} from this log) to {args.out}")
+
+    if args.top > 0:
+        this_run = sorted(parsed, key=lambda r: int(r.get("VGPRs") or 0), reverse=True)
+        print(f"\nTop {min(args.top, len(this_run))} kernels by VGPRs ({args.arch}/{args.build_config}):")
+        for r in this_run[: args.top]:
+            name = demangled.get(r["mangled_name"], r["mangled_name"])
+            print(
+                f"  VGPR={r.get('VGPRs',''):>4} SGPR={r.get('TotalSGPRs',''):>4} "
+                f"Scratch={r.get('ScratchBytesPerLane','0'):>4} Occ={r.get('OccupancyWavesPerSIMD',''):>3} "
+                f"  {name}  ({r['source_file']}:{r['line']})"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/rocshmem/scripts/functional_tests/resource_usage_to_csv.py
+++ b/projects/rocshmem/scripts/functional_tests/resource_usage_to_csv.py
@@ -13,10 +13,10 @@ Usage:
         --arch gfx950 --build-config ipc_single \\
         --out resource_usage.csv
 
-Rows are appended to --out (header written once). Re-running with the same
-(arch, build-config, source_file, line, mangled_name) tuple replaces the
-existing row instead of duplicating it, so re-generating a build's numbers
-is idempotent.
+Rows are written to --out. If --out already exists, its rows are loaded and
+updated: re-running with the same (arch, build-config, source_file, line,
+mangled_name) tuple replaces the existing row instead of duplicating it, so
+re-generating a build's numbers is idempotent.
 """
 
 import argparse

--- a/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
@@ -63,6 +63,8 @@ BASE_BRANCH="origin/develop"
 BASELINE_DIR=""
 BRANCH_DIR=""
 OUTDIR=""
+BASELINE_LABEL=""
+BRANCH_LABEL_OVERRIDE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -76,6 +78,8 @@ while [[ $# -gt 0 ]]; do
     --base-branch)   BASE_BRANCH="$2";                     shift 2 ;;
     --baseline-dir)  BASELINE_DIR="$2";                    shift 2 ;;
     --branch-dir)    BRANCH_DIR="$2";                      shift 2 ;;
+    --baseline-label) BASELINE_LABEL="$2";                 shift 2 ;;
+    --branch-label)  BRANCH_LABEL_OVERRIDE="$2";           shift 2 ;;
     --skip-build)    SKIP_BUILD=1;                         shift ;;
     --skip-baseline) SKIP_BASELINE=1;                      shift ;;
     --skip-develop)  SKIP_BASELINE=1;                      shift ;;
@@ -107,9 +111,11 @@ export LD_LIBRARY_PATH="${OMPI_HOME:-$HOME/ompi}/lib:${LD_LIBRARY_PATH:-}"
 # ---------------------------------------------------------------------------
 cd "$ROCSHMEM_DIR"
 
+BASELINE_LABEL="${BASELINE_LABEL:-baseline}"
+
 if [[ -n "$PR_NUM" ]]; then
   # PR mode: compare PR branch against develop baseline
-  BRANCH_LABEL="pr${PR_NUM}"
+  BRANCH_LABEL="${BRANCH_LABEL_OVERRIDE:-pr${PR_NUM}}"
   BRANCH_SAFE="pr${PR_NUM}"
   BUILD_BASELINE="${BASELINE_DIR:-$PROJECTS_DIR/build-develop}"
   BUILD_BRANCH="${BRANCH_DIR:-$PROJECTS_DIR/build-${BRANCH_SAFE}}"
@@ -139,7 +145,7 @@ else
     exit 1
   }
   MERGE_BASE_SHORT="$(git rev-parse --short "$MERGE_BASE")"
-  BRANCH_LABEL="$BRANCH_NAME"
+  BRANCH_LABEL="${BRANCH_LABEL_OVERRIDE:-$BRANCH_NAME}"
   BRANCH_SAFE="$(echo "$BRANCH_NAME" | tr '/' '-' | tr -cd '[:alnum:]-_.')"
 
   BUILD_BASELINE="${BASELINE_DIR:-$PROJECTS_DIR/build-baseline-$MERGE_BASE_SHORT}"
@@ -324,7 +330,7 @@ run_iterations() {
 }
 
 if [[ $SKIP_BASELINE -eq 0 ]]; then
-  run_iterations "$BUILD_BASELINE" "logs-${SUITE}" "baseline"
+  run_iterations "$BUILD_BASELINE" "logs-${SUITE}" "$BASELINE_LABEL"
 else
   echo "  Skipping baseline test runs (--skip-baseline)"
 fi
@@ -363,6 +369,7 @@ done
 
 "$PYTHON" "$COMPARE" \
   --baseline "$BUILD_BASELINE/logs-${SUITE}-*" \
+  --baseline-label "$BASELINE_LABEL" \
   --variants "${VARIANT_ARGS[@]}" \
   --outdir "$OUTDIR"
 


### PR DESCRIPTION
## Motivation

Register spills, occupancy drops, and scratch/LDS growth are common side effects of rocSHMEM kernel changes, but today the only way to catch them is a full wall-clock perf run (noisy, slow, multi-iteration). Add tooling that extracts compiler-emitted per-kernel resource usage (`-Rpass-analysis=kernel-resource-usage`: VGPRs/SGPRs/AGPRs/scratch/LDS/occupancy) from a single build and diffs it between two commits: a faster, deterministic signal for judging whether a code change helped or hurt register pressure/occupancy, usable standalone or as a complement to wall-clock heatmap comparisons.

## Technical Details

- `resource_usage_compare.sh`: git-checkout-based driver that builds two commits with `-Rpass-analysis=kernel-resource-usage`, caches builds per (GPU target, build config, commit) under `resource-usage-cache/`, and produces a self-contained diff report per resource type.
- `resource_usage_to_csv.py`: parses a build's resource-usage log into a normalized, idempotent CSV (one row per kernel).
- `resource_usage_diff.py`: diffs two CSVs by mangled kernel name, prints a ranked text report, and renders a side-by-side bar chart per resource column; supports `--match` to pin specific kernels regardless of delta.

## Output Example

<img width="3693" height="1906" alt="image" src="https://github.com/user-attachments/assets/6131c0e7-a382-411c-bc7f-57c0f9860bc4" />


## Issue Tracking

JIRA ID: AIROCSHMEM-474

Co-authored-by: @kesag 