### PR TITLE
fix(hsakmt): return error on vendor PM4 overflow instead of silent drop

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
@@ -897,10 +897,7 @@ hsa_status_t ComputeQueue::VendorSpecificAqlToPm4(char* cpu, amd_aql_pm4_ib* pac
   if (required_size > cmdbuf_aql_frame_size) {
     pr_err("PM4 command buffer overflow in VendorSpecific: required %zu bytes, limit %u bytes\n",
            required_size, cmdbuf_aql_frame_size);
-    // Oversized vendor IB: drop the PM4 payload but still retire the AQL
-    // packet and signal completion, matching the existing
-    // vendor_packet_process=off skip contract below (no queue hang).
-    process_packet = false;
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
   pr_debug("queue %p %s VENDOR_SPECIFIC pkt pm4_addr %p pm4_size %#x cs=%" PRIx64 "\n", ring,


### PR DESCRIPTION
  VendorSpecificAqlToPm4 was silently dropping oversized PM4 payloads by setting process_packet=false when
  required_size exceeded the frame limit. This caused silent data corruption: the AQL packet completed successfully
   but the actual GPU work was never executed.

  Change the overflow handling to return HSA_STATUS_ERROR_OUT_OF_RESOURCES. This allows callers to detect the
  failure and handle it appropriately rather than proceeding with incorrect results.

  Motivation

  The existing overflow handling in VendorSpecificAqlToPm4 silently skips vendor PM4 payloads when they exceed the
  command buffer frame size, while still signaling successful completion. This leads to silent data corruption where callers believe their GPU operations completed but no work was actually performed.

  KernelDispatchAqlToPm4 and BarrierGenericAqlToPm4 both return HSA_STATUS_ERROR_OUT_OF_RESOURCES on overflow,
  allowing callers to detect and handle failures. VendorSpecificAqlToPm4 should behave consistently.

  Technical Details

  - Remove the silent skip path that set process_packet=false on overflow
  - Return HSA_STATUS_ERROR_OUT_OF_RESOURCES immediately when required_size exceeds cmdbuf_aql_frame_size
  - Aligns error handling with KernelDispatchAqlToPm4 and BarrierGenericAqlToPm4

  Issue Tracking

  JIRA ID: AIRUNTIME-2552

  Test Plan

  Build verification on WDDM platform.

  Test Result

  Pending validation.

  Submission Checklist

  - Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

