### PR TITLE
[rocjitsu][CI] Link runtime translations to source objects

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -366,14 +366,17 @@ jobs:
           PLAIN_WRAPPER="env ${COMMON_UNSETS} -u HSA_TOOLS_LIB -u HSA_TOOLS_DISABLE_REGISTER -u HSA_HOTSWAP_VERBOSE ${COMMON_HOTSWAP_ENV} ${LAUNCHER} --config ${CONFIG} --"
           TRANSLATED_WRAPPER="env ${COMMON_UNSETS} ${COMMON_HOTSWAP_ENV} HSA_TOOLS_DISABLE_REGISTER=1 HSA_TOOLS_LIB=${HOTSWAP} HSA_HOTSWAP_VERBOSE=1 ${LAUNCHER} --config ${CONFIG} --"
 
+          python3 "${ROCJITSU_SOURCE_DIR}/tests/corpus/test-validate-gfx1250-semantic-translations.py"
+
           python3 -m pytest tests/test_corpus.py \
             --target gfx1250 \
             --suite semantics \
             --run-tests-config "${ROCJITSU_SOURCE_DIR}/tests/corpus/gfx1250_b0_a0_semantic_tests.json" \
             --run-wrapper "${PLAIN_WRAPPER}" \
             --comparison-run-wrapper "${TRANSLATED_WRAPPER}" \
-            --comparison-required-stderr "[hsa-hotswap-rj] eager translated " \
-            --comparison-required-stderr "status=0" \
+            --comparison-required-stderr "[hsa-hotswap-rj] eager translation " \
+            --comparison-required-stderr "outcome=translated" \
+            --comparison-required-stderr "translation_status=0 status=0" \
             --artifact-directory .pytest-artifacts/gfx1250-semantic-qualification \
             --timeout "${ROCJITSU_SEMANTIC_TIMEOUT_SECONDS}" \
             -q \

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_gfx1250_b0_to_a0.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_gfx1250_b0_to_a0.h
@@ -17,6 +17,14 @@
 extern "C" {
 #endif
 
+/// Provenance collected while translating one exact code-object ELF.
+typedef struct rj_gfx1250_b0_to_a0_translation_info_s {
+  /// 64-bit FNV-1a identity of the complete source ELF byte sequence.
+  uint64_t source_code_object_id;
+  /// Number of source instructions whose translated encoding changed.
+  size_t changed_instruction_count;
+} rj_gfx1250_b0_to_a0_translation_info_t;
+
 /// Translate one gfx1250 B0 AMDGPU code-object ELF for execution on gfx1250 A0.
 ///
 /// The input must be a standalone gfx1250 AMDGPU code object. On success, the
@@ -39,6 +47,26 @@ extern "C" {
 RJ_API_EXPORT rj_status_t rj_gfx1250_b0_to_a0_translate(const void *source_elf, size_t source_size,
                                                         uint8_t **translated_elf,
                                                         size_t *translated_size);
+
+/// Translate one gfx1250 B0 code object and report source provenance.
+///
+/// This is the provenance-reporting form of rj_gfx1250_b0_to_a0_translate().
+/// @p info is cleared before argument validation. When all arguments are valid,
+/// source_code_object_id is populated before parsing, so failed translation
+/// attempts can still be associated with their exact input.
+///
+/// @param[in] source_elf Source code-object bytes.
+/// @param[in] source_size Number of bytes in @p source_elf.
+/// @param[out] translated_elf Newly allocated translated code-object bytes.
+/// @param[out] translated_size Number of bytes in @p translated_elf.
+/// @param[out] info Stable source identity and changed-instruction count.
+/// @return The same status values as rj_gfx1250_b0_to_a0_translate().
+#ifdef __cplusplus
+[[nodiscard]]
+#endif
+RJ_API_EXPORT rj_status_t rj_gfx1250_b0_to_a0_translate_with_info(
+    const void *source_elf, size_t source_size, uint8_t **translated_elf, size_t *translated_size,
+    rj_gfx1250_b0_to_a0_translation_info_t *info);
 
 /// Release storage returned by rj_gfx1250_b0_to_a0_translate().
 /// @param[in] translated_elf Allocation to release; NULL is accepted.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/code_object_identity.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/code_object_identity.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file code_object_identity.h
+/// @brief Stable identity for exact code-object bytes.
+
+#ifndef ROCJITSU_CODE_CODE_OBJECT_IDENTITY_H_
+#define ROCJITSU_CODE_CODE_OBJECT_IDENTITY_H_
+
+#include <cstddef>
+#include <cstdint>
+
+namespace rocjitsu {
+
+/// Return the 64-bit FNV-1a identity of an exact code-object byte sequence.
+///
+/// This intentionally covers the full ELF image, including metadata, so an
+/// offline-selected embedded object and the runtime-loaded object can be joined
+/// without relying on a process-local reader handle or filename.
+inline uint64_t stable_code_object_id(const void *data, size_t size) noexcept {
+  constexpr uint64_t kOffsetBasis = 14695981039346656037ULL;
+  constexpr uint64_t kPrime = 1099511628211ULL;
+
+  uint64_t identity = kOffsetBasis;
+  const auto *bytes = static_cast<const uint8_t *>(data);
+  for (size_t index = 0; index < size; ++index) {
+    identity ^= bytes[index];
+    identity *= kPrime;
+  }
+  return identity;
+}
+
+} // namespace rocjitsu
+
+#endif // ROCJITSU_CODE_CODE_OBJECT_IDENTITY_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_library.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_library.cpp
@@ -4,21 +4,28 @@
 #include "rocjitsu/code/rj_gfx1250_b0_to_a0.h"
 
 #include "rocjitsu/code/amdgpu_code_object.h"
+#include "rocjitsu/code/code_object_identity.h"
 #include "rocjitsu/code/dbt/binary_translator.h"
 
 #include <cstdlib>
 #include <cstring>
 #include <new>
 
-rj_status_t rj_gfx1250_b0_to_a0_translate(const void *source_elf, size_t source_size,
-                                          uint8_t **translated_elf, size_t *translated_size) {
+rj_status_t rj_gfx1250_b0_to_a0_translate_with_info(const void *source_elf, size_t source_size,
+                                                    uint8_t **translated_elf,
+                                                    size_t *translated_size,
+                                                    rj_gfx1250_b0_to_a0_translation_info_t *info) {
   if (translated_elf)
     *translated_elf = nullptr;
   if (translated_size)
     *translated_size = 0;
+  if (info)
+    *info = {};
 
-  if (!source_elf || source_size == 0 || !translated_elf || !translated_size)
+  if (!source_elf || source_size == 0 || !translated_elf || !translated_size || !info)
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
+
+  info->source_code_object_id = rocjitsu::stable_code_object_id(source_elf, source_size);
 
   try {
     const auto *source_bytes = static_cast<const uint8_t *>(source_elf);
@@ -31,6 +38,10 @@ rj_status_t rj_gfx1250_b0_to_a0_translate(const void *source_elf, size_t source_
     options.output_revision = rocjitsu::ProcessorRevision::Gfx1250A0;
     rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
                                           options);
+    translator.set_trace_callback([&](const rocjitsu::TranslationTraceEvent &trace) {
+      if (trace.changed)
+        ++info->changed_instruction_count;
+    });
     auto result = translator.translate(source);
     if (result.elf_bytes.empty() || !result.dispatchable())
       return ROCJITSU_STATUS_ERROR;
@@ -48,6 +59,13 @@ rj_status_t rj_gfx1250_b0_to_a0_translate(const void *source_elf, size_t source_
   } catch (...) {
     return ROCJITSU_STATUS_ERROR;
   }
+}
+
+rj_status_t rj_gfx1250_b0_to_a0_translate(const void *source_elf, size_t source_size,
+                                          uint8_t **translated_elf, size_t *translated_size) {
+  rj_gfx1250_b0_to_a0_translation_info_t info{};
+  return rj_gfx1250_b0_to_a0_translate_with_info(source_elf, source_size, translated_elf,
+                                                 translated_size, &info);
 }
 
 void rj_gfx1250_b0_to_a0_free(void *translated_elf) { std::free(translated_elf); }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
@@ -10,6 +10,7 @@
 
 #include <atomic>
 #include <cerrno>
+#include <cinttypes>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
@@ -52,12 +53,24 @@ bool verbose_logging() {
 void log(const char *format, ...) {
   if (!verbose_logging())
     return;
+  flockfile(stderr);
   std::fputs("[hsa-hotswap-rj] ", stderr);
   va_list args;
   va_start(args, format);
   std::vfprintf(stderr, format, args);
   va_end(args);
   std::fputc('\n', stderr);
+  funlockfile(stderr);
+}
+
+void log_translation(uint64_t source_id, const char *outcome, size_t changed, size_t input_bytes,
+                     size_t output_bytes, rj_status_t translation_status,
+                     hsa_status_t load_status) {
+  log("eager translation source_id=fnv1a64:%016" PRIx64
+      " input_revision=b0 output_revision=a0 outcome=%s changed=%zu"
+      " input_bytes=%zu output_bytes=%zu translation_status=%d status=%d",
+      source_id, outcome, changed, input_bytes, output_bytes, static_cast<int>(translation_status),
+      static_cast<int>(load_status));
 }
 
 template <typename Fn> hsa_status_t hsa_boundary(Fn &&fn) noexcept {
@@ -646,23 +659,31 @@ hsa_status_t HSA_API load_agent_code_object(hsa_executable_t executable, hsa_age
     // fixed B0-to-A0 profile.
     uint8_t *translated_data = nullptr;
     size_t translated_size = 0;
-    const rj_status_t translate_status = rj_gfx1250_b0_to_a0_translate(
-        source->data(), source->size(), &translated_data, &translated_size);
+    rj_gfx1250_b0_to_a0_translation_info_t info{};
+    const rj_status_t translate_status = rj_gfx1250_b0_to_a0_translate_with_info(
+        source->data(), source->size(), &translated_data, &translated_size, &info);
     if (translate_status != ROCJITSU_STATUS_SUCCESS || translated_data == nullptr ||
         translated_size == 0) {
       rj_gfx1250_b0_to_a0_free(translated_data);
+      log_translation(info.source_code_object_id, "translation_failed",
+                      info.changed_instruction_count, source->size(), 0, translate_status,
+                      HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
       return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
     }
 
     Blob translated = copy_bytes(translated_data, translated_size);
     rj_gfx1250_b0_to_a0_free(translated_data);
-    if (translated == nullptr)
+    if (translated == nullptr) {
+      log_translation(info.source_code_object_id, "output_copy_failed",
+                      info.changed_instruction_count, source->size(), translated_size,
+                      translate_status, HSA_STATUS_ERROR_OUT_OF_RESOURCES);
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+    }
 
     const hsa_status_t load_status =
         load_owned_bytes(executable, agent, translated, options, loaded, *api, original_load);
-    log("eager translated input_bytes=%zu output_bytes=%zu status=%d", source->size(),
-        translated_size, static_cast<int>(load_status));
+    log_translation(info.source_code_object_id, "translated", info.changed_instruction_count,
+                    source->size(), translated_size, translate_status, load_status);
     return load_status;
   });
 }
@@ -750,5 +771,12 @@ extern "C" RJ_HOOK_EXPORT void rj_test_clear_retained_storage() {
   std::lock_guard lock(g_state.storage_mutex);
   g_state.readers.clear();
   g_state.executables.clear();
+}
+
+// Test-only: emit a deterministic translation record so concurrent logger tests
+// do not need to race the fake HSA loader state.
+extern "C" RJ_HOOK_EXPORT void rj_test_log_translation(uint64_t source_id, size_t changed) {
+  log_translation(source_id, "translated", changed, 64, 96, ROCJITSU_STATUS_SUCCESS,
+                  HSA_STATUS_SUCCESS);
 }
 #endif // RJ_HOTSWAP_TEST_HOOKS

--- a/emulation/rocjitsu/tests/corpus/test-validate-gfx1250-semantic-translations.py
+++ b/emulation/rocjitsu/tests/corpus/test-validate-gfx1250-semantic-translations.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+VALIDATOR_PATH = Path(__file__).with_name("validate-gfx1250-semantic-translations.py")
+SPEC = importlib.util.spec_from_file_location(
+    "gfx1250_semantic_validator", VALIDATOR_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VALIDATOR)
+
+SOURCE_ID = "fnv1a64:0123456789abcdef"
+OTHER_SOURCE_ID = "fnv1a64:fedcba9876543210"
+
+
+def runtime_record(
+    *,
+    source_id: str,
+    changed: int,
+    outcome: str = "translated",
+    translation_status: int = 0,
+    status: int = 0,
+) -> str:
+    return (
+        "[hsa-hotswap-rj] eager translation "
+        f"source_id={source_id} "
+        "input_revision=b0 output_revision=a0 "
+        f"outcome={outcome} changed={changed} "
+        "input_bytes=64 output_bytes=96 "
+        f"translation_status={translation_status} status={status}\n"
+    )
+
+
+class RuntimeEvidenceTest(unittest.TestCase):
+    def test_accepts_expected_successes_with_one_matching_fixture(self) -> None:
+        runtime_text = runtime_record(
+            source_id=SOURCE_ID,
+            changed=3,
+        ) + runtime_record(
+            source_id=OTHER_SOURCE_ID,
+            changed=0,
+        )
+
+        self.assertEqual(
+            VALIDATOR.validate_runtime_evidence(runtime_text, SOURCE_ID, 3, 2),
+            (1, 2),
+        )
+
+    def test_rejects_matching_success_plus_failed_record(self) -> None:
+        runtime_text = runtime_record(
+            source_id=SOURCE_ID,
+            changed=3,
+        ) + runtime_record(
+            source_id=OTHER_SOURCE_ID,
+            changed=0,
+            outcome="translation_failed",
+            translation_status=1,
+            status=1,
+        )
+
+        with self.assertRaisesRegex(ValueError, "1 successful records"):
+            VALIDATOR.validate_runtime_evidence(runtime_text, SOURCE_ID, 3, 2)
+
+    def test_rejects_anonymous_legacy_records(self) -> None:
+        runtime_text = (
+            "[hsa-hotswap-rj] eager translated "
+            "input_bytes=64 output_bytes=96 status=0\n"
+        )
+
+        with self.assertRaisesRegex(
+            ValueError, "no successful runtime record matching"
+        ):
+            VALIDATOR.validate_runtime_evidence(runtime_text, SOURCE_ID, 3, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/emulation/rocjitsu/tests/corpus/validate-gfx1250-semantic-translations.py
+++ b/emulation/rocjitsu/tests/corpus/validate-gfx1250-semantic-translations.py
@@ -11,12 +11,24 @@ SUMMARY_PATTERN = re.compile(
     r"^  total=(?P<total>\d+) changed=(?P<changed>\d+) shown=(?P<shown>\d+)$",
     re.MULTILINE,
 )
-RUNTIME_PATTERN = re.compile(
-    r"^\[hsa-hotswap-rj\] eager translated "
-    r"input_bytes=\d+ output_bytes=\d+ status=0$",
+SOURCE_ID_PATTERN = re.compile(
+    r"^source_code_object_id: (?P<source_id>fnv1a64:[0-9a-f]{16})$",
     re.MULTILINE,
 )
-RUNTIME_PREFIX = "[hsa-hotswap-rj] eager translated "
+RUNTIME_PATTERN = re.compile(
+    r"^\[hsa-hotswap-rj\] eager translation "
+    r"source_id=(?P<source_id>fnv1a64:[0-9a-f]{16}) "
+    r"input_revision=(?P<input_revision>[a-z0-9]+) "
+    r"output_revision=(?P<output_revision>[a-z0-9]+) "
+    r"outcome=(?P<outcome>[a-z_]+) "
+    r"changed=(?P<changed>\d+) "
+    r"input_bytes=(?P<input_bytes>\d+) "
+    r"output_bytes=(?P<output_bytes>\d+) "
+    r"translation_status=(?P<translation_status>-?\d+) "
+    r"status=(?P<status>-?\d+)$",
+    re.MULTILINE,
+)
+RUNTIME_PREFIX = "[hsa-hotswap-rj] eager translation "
 
 
 def main() -> int:
@@ -43,6 +55,7 @@ def main() -> int:
                 f"logs/{test}.comparison.run.log",
             )
             diff = run_translation(args.translator, binary)
+            source_id = parse_source_id(test, diff)
             changed = parse_changed_count(test, diff)
             if changed != expected_changed:
                 raise ValueError(
@@ -54,23 +67,24 @@ def main() -> int:
                 raise ValueError(f"{reference_log} unexpectedly activated translation")
 
             runtime_text = runtime_log.read_text(encoding="utf-8")
-            runtime_translations = runtime_text.count(RUNTIME_PREFIX)
-            successful_runtime_translations = len(RUNTIME_PATTERN.findall(runtime_text))
-            if (
-                runtime_translations != args.expected_runtime_translations
-                or successful_runtime_translations != args.expected_runtime_translations
-            ):
-                raise ValueError(
-                    f"{runtime_log} has {runtime_translations} runtime translations "
-                    f"and {successful_runtime_translations} successful records; "
-                    f"expected {args.expected_runtime_translations} of each"
+            try:
+                matching_runtime_records, runtime_translations = (
+                    validate_runtime_evidence(
+                        runtime_text,
+                        source_id,
+                        expected_changed,
+                        args.expected_runtime_translations,
+                    )
                 )
+            except ValueError as error:
+                raise ValueError(f"{runtime_log}: {error}") from error
 
             output = args.artifact_directory / "translation-diffs" / f"{test}.log"
             output.parent.mkdir(parents=True, exist_ok=True)
             output.write_text(diff, encoding="utf-8")
             print(
-                f"{test}: changed={changed} "
+                f"{test}: source_id={source_id} changed={changed} "
+                f"matching_runtime_records={matching_runtime_records} "
                 f"runtime_translations={runtime_translations}"
             )
         except (OSError, RuntimeError, ValueError) as error:
@@ -157,6 +171,8 @@ def run_translation(translator: Path, binary: Path) -> str:
         "b0",
         "--output-revision",
         "a0",
+        "--code-object-index",
+        "0",
         "--output-mode",
         "diff",
     ]
@@ -184,6 +200,96 @@ def parse_changed_count(test: str, diff: str) -> int:
             "expected one"
         )
     return int(matches[0].group("changed"))
+
+
+def parse_source_id(test: str, diff: str) -> str:
+    matches = list(SOURCE_ID_PATTERN.finditer(diff))
+    if len(matches) != 1:
+        raise ValueError(
+            f"offline translation for {test} emitted {len(matches)} source identities; "
+            "expected one"
+        )
+    return matches[0].group("source_id")
+
+
+def parse_runtime_records(runtime_text: str) -> list[re.Match[str]]:
+    return list(RUNTIME_PATTERN.finditer(runtime_text))
+
+
+def find_matching_runtime_records(
+    runtime_records: list[re.Match[str]],
+    source_id: str,
+    expected_changed: int,
+) -> list[re.Match[str]]:
+    return [
+        record
+        for record in runtime_records
+        if record.group("source_id") == source_id
+        and record.group("input_revision") == "b0"
+        and record.group("output_revision") == "a0"
+        and record.group("outcome") == "translated"
+        and int(record.group("changed")) == expected_changed
+        and int(record.group("translation_status")) == 0
+        and int(record.group("status")) == 0
+    ]
+
+
+def successful_runtime_records(
+    runtime_records: list[re.Match[str]],
+) -> list[re.Match[str]]:
+    return [
+        record
+        for record in runtime_records
+        if record.group("input_revision") == "b0"
+        and record.group("output_revision") == "a0"
+        and record.group("outcome") == "translated"
+        and int(record.group("translation_status")) == 0
+        and int(record.group("status")) == 0
+    ]
+
+
+def validate_runtime_evidence(
+    runtime_text: str,
+    source_id: str,
+    expected_changed: int,
+    expected_runtime_translations: int,
+) -> tuple[int, int]:
+    runtime_translations = runtime_text.count(RUNTIME_PREFIX)
+    runtime_records = parse_runtime_records(runtime_text)
+    successful_records = successful_runtime_records(runtime_records)
+    matching_records = find_matching_runtime_records(
+        successful_records, source_id, expected_changed
+    )
+    if not matching_records:
+        observed = [
+            {
+                "source_id": record.group("source_id"),
+                "input_revision": record.group("input_revision"),
+                "output_revision": record.group("output_revision"),
+                "outcome": record.group("outcome"),
+                "changed": int(record.group("changed")),
+                "translation_status": int(record.group("translation_status")),
+                "status": int(record.group("status")),
+            }
+            for record in runtime_records
+        ]
+        raise ValueError(
+            "no successful runtime record matching "
+            f"source_id={source_id}, revisions=b0-to-a0, and "
+            f"changed={expected_changed}; observed={observed}"
+        )
+    if (
+        runtime_translations != expected_runtime_translations
+        or len(runtime_records) != expected_runtime_translations
+        or len(successful_records) != expected_runtime_translations
+    ):
+        raise ValueError(
+            f"found {runtime_translations} runtime translations, "
+            f"{len(runtime_records)} machine-readable records, and "
+            f"{len(successful_records)} successful records; expected "
+            f"{expected_runtime_translations} of each"
+        )
+    return len(matching_records), runtime_translations
 
 
 if __name__ == "__main__":

--- a/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
@@ -18,19 +18,38 @@
 
 namespace {
 
+#ifdef GFX1250_B0_TO_A0_FIXTURE
+uint64_t source_identity(const std::vector<uint8_t> &bytes) {
+  constexpr uint64_t kOffsetBasis = 14695981039346656037ULL;
+  constexpr uint64_t kPrime = 1099511628211ULL;
+  uint64_t identity = kOffsetBasis;
+  for (uint8_t byte : bytes) {
+    identity ^= byte;
+    identity *= kPrime;
+  }
+  return identity;
+}
+#endif
+
 TEST(Gfx1250B0ToA0Library, RejectsInvalidArgumentsAndClearsOutputs) {
   auto *output = reinterpret_cast<uint8_t *>(0x1);
   size_t output_size = 1;
-  EXPECT_EQ(rj_gfx1250_b0_to_a0_translate(nullptr, 0, &output, &output_size),
+  rj_gfx1250_b0_to_a0_translation_info_t info{1, 1};
+  EXPECT_EQ(rj_gfx1250_b0_to_a0_translate_with_info(nullptr, 0, &output, &output_size, &info),
             ROCJITSU_STATUS_INVALID_ARGUMENT);
   EXPECT_EQ(output, nullptr);
   EXPECT_EQ(output_size, 0u);
+  EXPECT_EQ(info.source_code_object_id, 0u);
+  EXPECT_EQ(info.changed_instruction_count, 0u);
 
   constexpr std::array<uint8_t, 64> kNotElf = {'N', 'O', 'T', 'E', 'L', 'F'};
-  EXPECT_EQ(rj_gfx1250_b0_to_a0_translate(kNotElf.data(), kNotElf.size(), &output, &output_size),
+  EXPECT_EQ(rj_gfx1250_b0_to_a0_translate_with_info(kNotElf.data(), kNotElf.size(), &output,
+                                                    &output_size, &info),
             ROCJITSU_STATUS_INVALID_CODE_OBJECT);
   EXPECT_EQ(output, nullptr);
   EXPECT_EQ(output_size, 0u);
+  EXPECT_NE(info.source_code_object_id, 0u);
+  EXPECT_EQ(info.changed_instruction_count, 0u);
 
   rj_gfx1250_b0_to_a0_free(nullptr);
 }
@@ -45,9 +64,13 @@ TEST(Gfx1250B0ToA0Library, TranslatesRealGfx1250CodeObject) {
 
   uint8_t *output = nullptr;
   size_t output_size = 0;
-  ASSERT_EQ(rj_gfx1250_b0_to_a0_translate(source.data(), source.size(), &output, &output_size),
+  rj_gfx1250_b0_to_a0_translation_info_t info{};
+  ASSERT_EQ(rj_gfx1250_b0_to_a0_translate_with_info(source.data(), source.size(), &output,
+                                                    &output_size, &info),
             ROCJITSU_STATUS_SUCCESS);
   ASSERT_NE(output, nullptr);
+  EXPECT_EQ(info.source_code_object_id, source_identity(source));
+  EXPECT_GT(info.changed_instruction_count, 0u);
   constexpr std::array<uint8_t, 4> kElfMagic = {0x7f, 'E', 'L', 'F'};
   ASSERT_GE(output_size, kElfMagic.size());
   EXPECT_TRUE(std::equal(kElfMagic.begin(), kElfMagic.end(), output));

--- a/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
@@ -10,10 +10,15 @@
 #include <atomic>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <iomanip>
 #include <iterator>
 #include <new>
+#include <regex>
+#include <sstream>
+#include <string>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -22,6 +27,7 @@ extern "C" bool OnLoad(HsaApiTable *, uint64_t, uint64_t, const char *const *);
 extern "C" void OnUnload();
 extern "C" size_t rj_test_retained_executable_buffer_count();
 extern "C" void rj_test_clear_retained_storage();
+extern "C" void rj_test_log_translation(uint64_t source_id, size_t changed);
 
 namespace {
 
@@ -287,6 +293,39 @@ TEST_F(HsaHotswapHookTest, UnloadRestoresAndAllowsReinstall) {
   EXPECT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
 }
 
+TEST_F(HsaHotswapHookTest, EmitsConcurrentTranslationRecordsAtomically) {
+  constexpr size_t kThreadCount = 8;
+  constexpr size_t kRecordsPerThread = 32;
+
+  ASSERT_EQ(setenv("HSA_HOTSWAP_VERBOSE", "1", 1), 0);
+  testing::internal::CaptureStderr();
+  std::vector<std::thread> workers;
+  workers.reserve(kThreadCount);
+  for (size_t thread_index = 0; thread_index < kThreadCount; ++thread_index) {
+    workers.emplace_back([thread_index] {
+      for (size_t record_index = 0; record_index < kRecordsPerThread; ++record_index) {
+        const uint64_t source_id = thread_index * kRecordsPerThread + record_index;
+        rj_test_log_translation(source_id, record_index);
+      }
+    });
+  }
+  for (auto &worker : workers)
+    worker.join();
+  const std::string log_text = testing::internal::GetCapturedStderr();
+  ASSERT_EQ(unsetenv("HSA_HOTSWAP_VERBOSE"), 0);
+
+  const std::regex record_pattern(
+      R"(^\[hsa-hotswap-rj\] eager translation source_id=fnv1a64:[0-9a-f]{16} input_revision=b0 output_revision=a0 outcome=translated changed=[0-9]+ input_bytes=64 output_bytes=96 translation_status=0 status=0$)");
+  std::istringstream lines(log_text);
+  std::string line;
+  size_t record_count = 0;
+  while (std::getline(lines, line)) {
+    EXPECT_TRUE(std::regex_match(line, record_pattern)) << line;
+    ++record_count;
+  }
+  EXPECT_EQ(record_count, kThreadCount * kRecordsPerThread);
+}
+
 // A rejected install must not leave the hook stuck. install() commits g_state.core
 // only AFTER its one fallible step (building the saved-table snapshot), so a
 // rejected or throwing install cannot latch core non-null and permanently reject
@@ -334,9 +373,13 @@ TEST_F(HsaHotswapHookTest, TranslatesGfx1250AndRetainsOutputUntilDestroy) {
   ASSERT_EQ(
       api.core.hsa_code_object_reader_create_from_memory_fn(source.data(), source.size(), &reader),
       HSA_STATUS_SUCCESS);
-  ASSERT_EQ(api.core.hsa_executable_load_agent_code_object_fn(kExecutable, kA0Agent, reader,
-                                                              nullptr, nullptr),
-            HSA_STATUS_SUCCESS);
+  ASSERT_EQ(setenv("HSA_HOTSWAP_VERBOSE", "1", 1), 0);
+  testing::internal::CaptureStderr();
+  const hsa_status_t load_status = api.core.hsa_executable_load_agent_code_object_fn(
+      kExecutable, kA0Agent, reader, nullptr, nullptr);
+  const std::string log_text = testing::internal::GetCapturedStderr();
+  ASSERT_EQ(unsetenv("HSA_HOTSWAP_VERBOSE"), 0);
+  ASSERT_EQ(load_status, HSA_STATUS_SUCCESS);
 
   ASSERT_GE(g_loaded_bytes.size(), rocjitsu::EI_MAGIC_SIZE);
   EXPECT_EQ(std::memcmp(g_loaded_bytes.data(), rocjitsu::EI_MAGIC, rocjitsu::EI_MAGIC_SIZE), 0);
@@ -344,6 +387,22 @@ TEST_F(HsaHotswapHookTest, TranslatesGfx1250AndRetainsOutputUntilDestroy) {
   EXPECT_NE(g_loaded_reader.handle, reader.handle);
   EXPECT_EQ(g_load_agent_calls, 1);
   EXPECT_EQ(rj_test_retained_executable_buffer_count(), 1u);
+
+  uint64_t identity = 14695981039346656037ULL;
+  for (uint8_t byte : source) {
+    identity ^= byte;
+    identity *= 1099511628211ULL;
+  }
+  std::ostringstream expected_identity;
+  expected_identity << "source_id=fnv1a64:" << std::hex << std::setfill('0') << std::setw(16)
+                    << identity;
+  EXPECT_NE(log_text.find("[hsa-hotswap-rj] eager translation "), std::string::npos) << log_text;
+  EXPECT_NE(log_text.find(expected_identity.str()), std::string::npos) << log_text;
+  EXPECT_NE(log_text.find(" input_revision=b0 output_revision=a0 outcome=translated changed="),
+            std::string::npos)
+      << log_text;
+  EXPECT_EQ(log_text.find(" changed=0 "), std::string::npos) << log_text;
+  EXPECT_NE(log_text.find(" translation_status=0 status=0"), std::string::npos) << log_text;
 
   EXPECT_EQ(api.core.hsa_executable_destroy_fn(kExecutable), HSA_STATUS_SUCCESS);
   EXPECT_EQ(rj_test_retained_executable_buffer_count(), 0u);

--- a/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
@@ -443,9 +443,10 @@ TEST(RjDbtTranslate, Smoke) {
                                          << stdout_text;
   EXPECT_TRUE(stderr_text.empty()) << stderr_text;
 
-  const std::array<std::string_view, 5> expected = {
-      "rj_dbt_translate: ok", "source_words: bf8cc07f", "source: s_waitcnt",
-      "target_words:",        "target: s_wait",
+  const std::array<std::string_view, 6> expected = {
+      "rj_dbt_translate: ok",   "source_code_object_id: fnv1a64:",
+      "source_words: bf8cc07f", "source: s_waitcnt",
+      "target_words:",          "target: s_wait",
   };
   for (const std::string_view needle : expected) {
     EXPECT_TRUE(contains(stdout_text, needle))

--- a/emulation/rocjitsu/tools/dbt_translate.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate.cpp
@@ -5,6 +5,7 @@
 
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/code_object_identity.h"
 #include "rocjitsu/code/dbt/binary_translator.h"
 #include "rocjitsu/code/executable.h"
 #include "rocjitsu/isa/decoder.h"
@@ -475,6 +476,8 @@ ToolResult<TranslateOutput> translate_code_object(const TranslateOptions &option
     add_error(output, kInputError, error.empty() ? "failed to load input" : error);
     return output;
   }
+  output.value.source_code_object_id =
+      stable_code_object_id(input.code_object->image_data(), input.code_object->image_size());
 
   const bool need_report = options.collect_diagnostics;
   const bool need_source_disassembly = options.disassembly == DisassemblyMode::Source ||

--- a/emulation/rocjitsu/tools/dbt_translate.h
+++ b/emulation/rocjitsu/tools/dbt_translate.h
@@ -88,6 +88,8 @@ struct TranslateOptions {
 
 struct TranslateOutput {
   std::vector<uint8_t> elf_bytes;
+  /// 64-bit FNV-1a identity of the exact selected source code-object bytes.
+  uint64_t source_code_object_id = 0;
   rj_code_arch_t host_arch = ROCJITSU_CODE_ARCH_INVALID;
   uint32_t target_mach = 0;
   ProcessorRevision input_revision = ProcessorRevision::Unspecified;

--- a/emulation/rocjitsu/tools/dbt_translate_cli.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate_cli.cpp
@@ -522,6 +522,8 @@ void print_text_report(std::ostream &os, const CliOptions &options,
   os << "rj_dbt_translate: " << (result.ok() ? "ok" : "failed") << "\n";
   os << "input: " << options.translate.input_path << "\n";
   os << "input_target: " << options.input_target_name << "\n";
+  os << "source_code_object_id: fnv1a64:" << std::hex << std::setfill('0') << std::setw(16)
+     << output.source_code_object_id << std::dec << std::setfill(' ') << "\n";
   if (options.saw_input_revision)
     os << "input_revision: " << revision_name(output.input_revision) << "\n";
   os << "output_target: " << options.output_target_name << "\n";


### PR DESCRIPTION
## Motivation

Semantic qualification must prove that the runtime path translated the same embedded code object and performed the same positive instruction changes as the offline baseline. Process-wide success counts alone cannot establish that relationship.

## Technical Details

- Assign exact code-object bytes a stable FNV-1a identity and expose it in offline diff output.
- Extend the fixed-profile translation API with source identity and changed-instruction provenance.
- Emit fixed-field per-load runtime records with source identity, revisions, outcome, rewrite count, byte sizes, translation status, and loader status.
- Require an identity, revision, outcome, and count match before applying the secondary total-record assertion.
- Select embedded code-object index zero explicitly and update workflow stderr requirements.

## Issue Tracking

N/A

## Test Plan

- Build the translation CLI, production and test hooks, fixed-profile library test, and CLI smoke test.
- Run the focused library, hook, symbol-boundary, and CLI test set.
- Run all 12 selected gfx1250 simulator comparisons with the TheRock SDK.
- Validate all 12 offline identities and counts against their runtime records.
- Confirm anonymous, wrong-identity, wrong-count, and failed-outcome records are rejected.
- Run repository hooks on every changed file.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
