### PR TITLE
fix(rocshmem) bnxt: dmabuf cq/sq creation

### DIFF
--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -81,8 +81,16 @@ void GDABackend::init() {
 
   type = BackendType::GDA_BACKEND;
 
-  // Initialize QP allocator to finegrained allocator
-  qp_allocator_ = new HIPAllocatorFinegrained();
+  // dmabuf mode: use host-pinned memory for QP/CQ control buffers.
+  // bnxt and mlx5 DV umem_reg only accepts host-accessible memory for these
+  // structures when dmabuf is enabled; device memory (finegrained) causes EIO
+  // from the kernel driver on create_cq/create_qp ioctls.
+  // Legacy peermem mode: retain finegrained device memory as before.
+  if (ibv.is_dmabuf_supported()) {
+    qp_allocator_ = new HIPAllocator(hipHostMalloc, hipFree, hipHostMallocDefault);
+  } else {
+    qp_allocator_ = new HIPAllocatorFinegrained();
+  }
 
   select_nics();
 

--- a/projects/rocshmem/src/gda/bnxt/backend_gda_bnxt.cpp
+++ b/projects/rocshmem/src/gda/bnxt/backend_gda_bnxt.cpp
@@ -99,8 +99,6 @@ void GDABackend::bnxt_create_cqs(int cqe) {
   struct bnxt_re_dv_cq_init_attr cq_init_attr;
   struct bnxt_re_dv_umem_reg_attr umem_attr;
 
-  int dmabuf_enabled = ibv.is_dmabuf_supported();
-
   /* Ignore value of cqe as we only need of length 1 to use CQE compression */
   cqe = 1;
 
@@ -122,19 +120,13 @@ void GDABackend::bnxt_create_cqs(int cqe) {
     qp_allocator_->allocate(reinterpret_cast<void**>(&bnxt_scqs[i].buf), bnxt_scqs[i].length);
     CHECK_HIP(hipMemset(bnxt_scqs[i].buf, 0, bnxt_scqs[i].length));
 
-    if (dmabuf_enabled) {
-      CHECK_HIP(qp_allocator_->GetDmabufHandle(bnxt_scqs[i].buf,
-                                               bnxt_scqs[i].length,
-                                               &bnxt_scqs[i].dmabuf_fd,
-                                               &bnxt_scqs[i].dmabuf_offset));
-    }
-
-    /* Register SCQ UMEM */
+    /* Register SCQ UMEM — CQ/QP control buffers are host-accessible memory;
+     * dmabuf registration is not supported by the bnxt_re driver for these
+     * internal structures (only for the symmetric heap MR). */
     memset(&umem_attr, 0, sizeof(struct bnxt_re_dv_umem_reg_attr));
     umem_attr.addr         = bnxt_scqs[i].buf;
     umem_attr.size         = bnxt_scqs[i].length;
     umem_attr.access_flags = IBV_ACCESS_LOCAL_WRITE;
-    umem_attr.dmabuf_fd    = dmabuf_enabled ? bnxt_scqs[i].dmabuf_fd : 0;
 
     bnxt_scqs[i].umem_handle = bnxt_re_dv.umem_reg(ctx, &umem_attr);
     CHECK_NNULL(bnxt_scqs[i].umem_handle, "bnxt_re_dv_umem_reg(scq_buf)");
@@ -164,19 +156,11 @@ void GDABackend::bnxt_create_cqs(int cqe) {
     qp_allocator_->allocate(reinterpret_cast<void**>(&bnxt_rcqs[i].buf), bnxt_rcqs[i].length);
     CHECK_HIP(hipMemset(bnxt_rcqs[i].buf, 0, bnxt_rcqs[i].length));
 
-    if (dmabuf_enabled) {
-      CHECK_HIP(qp_allocator_->GetDmabufHandle(bnxt_rcqs[i].buf,
-                                               bnxt_rcqs[i].length,
-                                               &bnxt_rcqs[i].dmabuf_fd,
-                                               &bnxt_rcqs[i].dmabuf_offset));
-    }
-
-    /* Register RCQ UMEM */
+    /* Register RCQ UMEM — same reasoning as SCQ: plain path only */
     memset(&umem_attr, 0, sizeof(struct bnxt_re_dv_umem_reg_attr));
     umem_attr.addr         = bnxt_rcqs[i].buf;
     umem_attr.size         = bnxt_rcqs[i].length;
     umem_attr.access_flags = IBV_ACCESS_LOCAL_WRITE;
-    umem_attr.dmabuf_fd    = dmabuf_enabled ? bnxt_rcqs[i].dmabuf_fd : 0;
 
     bnxt_rcqs[i].umem_handle = bnxt_re_dv.umem_reg(ctx, &umem_attr);
     CHECK_NNULL(bnxt_rcqs[i].umem_handle, "bnxt_re_dv_umem_reg(rcq_buf)");
@@ -202,8 +186,6 @@ void GDABackend::bnxt_create_qps(int sq_length) {
   uint64_t msntbl_len;
   uint64_t msntbl_offset;
   int err;
-
-  int dmabuf_enabled = ibv.is_dmabuf_supported();
 
   for (size_t i = 0; i < qps.size(); i++) {
     NicDevice &nic = nic_for_qp(i);
@@ -233,25 +215,19 @@ void GDABackend::bnxt_create_qps(int sq_length) {
     bnxt_qps[i].mem_info.sq_va = (uint64_t) sq_ptr;
     bnxt_qps[i].sq_buf = sq_ptr;
 
-    if (dmabuf_enabled) {
-      CHECK_HIP(qp_allocator_->GetDmabufHandle(sq_ptr,
-                                               bnxt_qps[i].mem_info.sq_len,
-                                               &bnxt_qps[i].sq_dmabuf_fd,
-                                               &bnxt_qps[i].sq_dmabuf_offset));
-    }
-
     /* Obtain MSN Table Pointer */
     msntbl_len             = (bnxt_qps[i].mem_info.sq_psn_sz * bnxt_qps[i].mem_info.sq_npsn);
     msntbl_offset          = bnxt_qps[i].mem_info.sq_len - msntbl_len;
     bnxt_qps[i].msntbl     = (void*) ((char*) bnxt_qps[i].sq_buf + msntbl_offset);
     bnxt_qps[i].msn_tbl_sz = bnxt_qps[i].mem_info.sq_npsn;
 
-    /* Register SQ UMEM */
+    /* Register SQ UMEM — CQ/QP control buffers are finegrained CPU-accessible
+     * memory; dmabuf registration is not supported by the bnxt_re driver for
+     * these internal structures (only for the symmetric heap MR). */
     memset(&umem_attr, 0, sizeof(struct bnxt_re_dv_umem_reg_attr));
     umem_attr.addr         = (void*) bnxt_qps[i].mem_info.sq_va;
     umem_attr.size         = bnxt_qps[i].mem_info.sq_len;
     umem_attr.access_flags = IBV_ACCESS_LOCAL_WRITE;
-    umem_attr.dmabuf_fd    = dmabuf_enabled ? bnxt_qps[i].sq_dmabuf_fd : 0;
 
     sq_umem_handle = bnxt_re_dv.umem_reg(ctx, &umem_attr);
     CHECK_NNULL(sq_umem_handle, "bnxt_re_dv_umem_reg(sq)");
@@ -262,19 +238,11 @@ void GDABackend::bnxt_create_qps(int sq_length) {
     bnxt_qps[i].mem_info.rq_va = (uint64_t) rq_ptr;
     bnxt_qps[i].rq_buf = rq_ptr;
 
-    if (dmabuf_enabled) {
-      CHECK_HIP(qp_allocator_->GetDmabufHandle(rq_ptr,
-                                               bnxt_qps[i].mem_info.rq_len,
-                                               &bnxt_qps[i].rq_dmabuf_fd,
-                                               &bnxt_qps[i].rq_dmabuf_offset));
-    }
-
-    /* Register RQ UMEM */
+    /* Register RQ UMEM — same reasoning as SQ: plain path only */
     memset(&umem_attr, 0, sizeof(struct bnxt_re_dv_umem_reg_attr));
     umem_attr.addr         = (void*) bnxt_qps[i].mem_info.rq_va;
     umem_attr.size         = bnxt_qps[i].mem_info.rq_len;
     umem_attr.access_flags = IBV_ACCESS_LOCAL_WRITE;
-    umem_attr.dmabuf_fd    = dmabuf_enabled ? bnxt_qps[i].rq_dmabuf_fd : 0;
 
     rq_umem_handle = bnxt_re_dv.umem_reg(ctx, &umem_attr);
     CHECK_NNULL(rq_umem_handle, "bnxt_re_dv_umem_reg(rq)");


### PR DESCRIPTION
## Motivation

When using the DMABuf pathway the program crash on create_cq_ex with EIO

## Technical Details

Use host memory to allocate umr for cq/sq memory. The DMABuf memory cannot be used for these regions. 

## Issue Tracking

JIRA ID: AIROCSHMEM-475

## Test Plan

* [x] build and run on bnxt/dmabuf (rck)
* [x] build and run on bnxt/peermem (dell300x)
* [x] build and run on ionic (aus-a10-18)
* [x] build and run on mlx5 (banff)


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
