### PR TITLE
[rocprofiler-sdk] Fix rocprofv3 adding rocpd to a caller-requested --output-format

### DIFF
--- a/projects/rocprofiler-sdk/CHANGELOG.md
+++ b/projects/rocprofiler-sdk/CHANGELOG.md
@@ -22,8 +22,8 @@ Full documentation for ROCprofiler-SDK is available at [rocm.docs.amd.com/projec
     - `--spm-config` option in `rocprofv3-avail` to list available SPM configurations.
   - JSON and rocpd output format support for SPM.
   - OpenMP (OMPT) tracing via the new `--ompt-trace` flag:
-    - Accepts a bare boolean or category list (`all, thread, parallel, task, sync, mutex, target, device, error`). Must be requested explicitly; like `--kokkos-trace`, it is not folded into `--sys-trace`/`--runtime-trace`.
-    - rocpd-only trace: records go to the rocpd database (auto-added when another format is requested) and export via `rocpd convert`.
+    - Accepts a bare boolean or category list (`all, thread, parallel, task, sync, mutex, target, device, error`); also folded into `--sys-trace`/`--runtime-trace`.
+    - rocpd-only trace: records go to the rocpd database (the default output format) and export via `rocpd convert`.
 
 **Documentation:**
 

--- a/projects/rocprofiler-sdk/CHANGELOG.md
+++ b/projects/rocprofiler-sdk/CHANGELOG.md
@@ -22,7 +22,7 @@ Full documentation for ROCprofiler-SDK is available at [rocm.docs.amd.com/projec
     - `--spm-config` option in `rocprofv3-avail` to list available SPM configurations.
   - JSON and rocpd output format support for SPM.
   - OpenMP (OMPT) tracing via the new `--ompt-trace` flag:
-    - Accepts a bare boolean or category list (`all, thread, parallel, task, sync, mutex, target, device, error`); also folded into `--sys-trace`/`--runtime-trace`.
+    - Accepts a bare boolean or category list (`all, thread, parallel, task, sync, mutex, target, device, error`). Must be requested explicitly; like `--kokkos-trace`, it is not folded into `--sys-trace`/`--runtime-trace`.
     - rocpd-only trace: records go to the rocpd database (auto-added when another format is requested) and export via `rocpd convert`.
 
 **Documentation:**

--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -1679,7 +1679,6 @@ def run(app_args, args, **kwargs):
             "memory_allocation_trace",
             "scratch_memory_trace",
             "rccl_trace",
-            "ompt_trace",
             "rocdecode_trace",
             "rocjpeg_trace",
             "rocshmem_trace",
@@ -1697,7 +1696,6 @@ def run(app_args, args, **kwargs):
             "memory_allocation_trace",
             "scratch_memory_trace",
             "rccl_trace",
-            "ompt_trace",
             "rocdecode_trace",
             "rocjpeg_trace",
             "rocshmem_trace",
@@ -1707,10 +1705,9 @@ def run(app_args, args, **kwargs):
 
     # OMPT is a rocpd-only trace: it is written to the rocpd database and exported to
     # other formats via `rocpd convert`; the direct csv/json/pftrace/otf2 emitters do
-    # not contain OMPT records. This runs after the --sys-trace/--runtime-trace folds
-    # have resolved args.ompt_trace, which honors an explicit --ompt-trace=false. If
-    # OMPT tracing is effectively enabled but rocpd was not requested, add it so OMPT
-    # data is not silently dropped, and warn the user.
+    # not contain OMPT records. OMPT is intentionally not folded into --sys-trace or
+    # --runtime-trace, so args.ompt_trace is truthy only for an explicit --ompt-trace;
+    # if rocpd was not requested, add it so OMPT data is not silently dropped, and warn.
     if bool(getattr(args, "ompt_trace", None)) and "rocpd" not in args.output_format:
         warning(
             "--ompt-trace: OMPT data is only emitted to the 'rocpd' output format; "

--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -1679,6 +1679,7 @@ def run(app_args, args, **kwargs):
             "memory_allocation_trace",
             "scratch_memory_trace",
             "rccl_trace",
+            "ompt_trace",
             "rocdecode_trace",
             "rocjpeg_trace",
             "rocshmem_trace",
@@ -1696,26 +1697,13 @@ def run(app_args, args, **kwargs):
             "memory_allocation_trace",
             "scratch_memory_trace",
             "rccl_trace",
+            "ompt_trace",
             "rocdecode_trace",
             "rocjpeg_trace",
             "rocshmem_trace",
             "hipfile_trace",
         ):
             setattrifnone(args, itr, True)
-
-    # OMPT is a rocpd-only trace: it is written to the rocpd database and exported to
-    # other formats via `rocpd convert`; the direct csv/json/pftrace/otf2 emitters do
-    # not contain OMPT records. OMPT is intentionally not folded into --sys-trace or
-    # --runtime-trace, so args.ompt_trace is truthy only for an explicit --ompt-trace;
-    # if rocpd was not requested, add it so OMPT data is not silently dropped, and warn.
-    if bool(getattr(args, "ompt_trace", None)) and "rocpd" not in args.output_format:
-        warning(
-            "--ompt-trace: OMPT data is only emitted to the 'rocpd' output format; "
-            "the requested output format(s) {fmts} will not contain OMPT records. "
-            "Adding 'rocpd' to --output-format -- use `rocpd convert` to export OMPT "
-            "to csv/pftrace/otf2.".format(fmts=", ".join(args.output_format))
-        )
-        args.output_format.append("rocpd")
 
     update_env(
         "ROCPROF_OUTPUT_FORMAT", ",".join(args.output_format), append=True, join_char=","

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-with-openmp.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-with-openmp.rst
@@ -96,13 +96,13 @@ The preceding files contain detailed profiling information about GPU kernel exec
 Tracing OpenMP runtime events with ``--ompt-trace``
 ====================================================
 
-The flags shown above capture HIP / HSA / kernel-dispatch / memory activity but not OpenMP-level structure. To trace OpenMP itself, pass ``--ompt-trace`` (or ``ROCPROF_OMPT_TRACE=1``); it is not enabled by ``--sys-trace`` or ``--runtime-trace``. This is a host-side facility: it records CPU-side OpenMP execution (thread lifecycle, parallel regions, work-sharing, tasks, sync regions, mutexes, dispatch) even for applications that never offload, plus host-side target-offload events (``target``, ``target_data_op``, ``target_submit``, ``device_initialize`` / ``device_load`` / ``device_finalize``) for offloading applications.
+The flags shown above capture HIP / HSA / kernel-dispatch / memory activity but not OpenMP-level structure. To trace OpenMP itself, pass ``--ompt-trace`` (or ``ROCPROF_OMPT_TRACE=1``; it is also enabled implicitly by ``--sys-trace`` and ``--runtime-trace``). This is a host-side facility: it records CPU-side OpenMP execution (thread lifecycle, parallel regions, work-sharing, tasks, sync regions, mutexes, dispatch) even for applications that never offload, plus host-side target-offload events (``target``, ``target_data_op``, ``target_submit``, ``device_initialize`` / ``device_load`` / ``device_finalize``) for offloading applications.
 
 .. code-block:: bash
 
     rocprofv3 --ompt-trace --kernel-trace --memory-copy-trace --output-format rocpd -- ./vector_add
 
-OMPT is a rocpd-only trace: records are written to the rocpd database (``rocpd`` is also the default output format) and are **not** emitted by the direct CSV / JSON / Perfetto / OTF2 generators. If ``--ompt-trace`` is combined with another ``--output-format``, ``rocprofv3`` prints a warning and adds ``rocpd`` automatically so OMPT data is not lost. To view OMPT in CSV / Perfetto / OTF2, convert the database with ``rocpd convert`` (see below).
+OMPT is a rocpd-only trace: records are written to the rocpd database (``rocpd`` is also the default output format) and are **not** emitted by the direct CSV / JSON / Perfetto / OTF2 generators. OMPT records are only captured when ``rocpd`` is among the requested ``--output-format`` values, so a run that requests only the deprecated direct generators contains no OMPT data. To view OMPT in CSV / Perfetto / OTF2, keep the ``rocpd`` output and convert the database with ``rocpd convert`` (see below).
 
 Combined with ``--kernel-trace`` / ``--memory-copy-trace``, each GPU kernel can be correlated with the surrounding ``target_submit`` / ``target_data_op`` region on the host and placed on the same timeline as the enclosing ``parallel`` / ``work`` regions and tasks.
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-with-openmp.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-with-openmp.rst
@@ -96,7 +96,7 @@ The preceding files contain detailed profiling information about GPU kernel exec
 Tracing OpenMP runtime events with ``--ompt-trace``
 ====================================================
 
-The flags shown above capture HIP / HSA / kernel-dispatch / memory activity but not OpenMP-level structure. To trace OpenMP itself, pass ``--ompt-trace`` (or ``ROCPROF_OMPT_TRACE=1``; it is also enabled implicitly by ``--sys-trace`` and ``--runtime-trace``). This is a host-side facility: it records CPU-side OpenMP execution (thread lifecycle, parallel regions, work-sharing, tasks, sync regions, mutexes, dispatch) even for applications that never offload, plus host-side target-offload events (``target``, ``target_data_op``, ``target_submit``, ``device_initialize`` / ``device_load`` / ``device_finalize``) for offloading applications.
+The flags shown above capture HIP / HSA / kernel-dispatch / memory activity but not OpenMP-level structure. To trace OpenMP itself, pass ``--ompt-trace`` (or ``ROCPROF_OMPT_TRACE=1``); it is not enabled by ``--sys-trace`` or ``--runtime-trace``. This is a host-side facility: it records CPU-side OpenMP execution (thread lifecycle, parallel regions, work-sharing, tasks, sync regions, mutexes, dispatch) even for applications that never offload, plus host-side target-offload events (``target``, ``target_data_op``, ``target_submit``, ``device_initialize`` / ``device_load`` / ``device_finalize``) for offloading applications.
 
 .. code-block:: bash
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
@@ -628,7 +628,7 @@ OMPT trace
 
     rocprofv3 --ompt-trace --output-format rocpd -- <application_path>
 
-OMPT is a rocpd-only trace: records are written to the rocpd database (the default output format) and are not emitted by the direct CSV / JSON / Perfetto / OTF2 generators. If ``--ompt-trace`` is used with another ``--output-format``, ``rocprofv3`` warns and adds ``rocpd`` automatically; use ``rocpd convert`` to export OMPT to CSV / Perfetto / OTF2. ``--ompt-trace`` is also enabled implicitly by ``--sys-trace`` and ``--runtime-trace``.
+OMPT is a rocpd-only trace: records are written to the rocpd database (the default output format) and are not emitted by the direct CSV / JSON / Perfetto / OTF2 generators. If ``--ompt-trace`` is used with another ``--output-format``, ``rocprofv3`` warns and adds ``rocpd`` automatically; use ``rocpd convert`` to export OMPT to CSV / Perfetto / OTF2. ``--ompt-trace`` must be requested explicitly: like ``--kokkos-trace``, it traces a programming model rather than a ROCm runtime API, so it is not enabled by ``--sys-trace`` or ``--runtime-trace``.
 
 .. note::
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
@@ -628,7 +628,7 @@ OMPT trace
 
     rocprofv3 --ompt-trace --output-format rocpd -- <application_path>
 
-OMPT is a rocpd-only trace: records are written to the rocpd database (the default output format) and are not emitted by the direct CSV / JSON / Perfetto / OTF2 generators. If ``--ompt-trace`` is used with another ``--output-format``, ``rocprofv3`` warns and adds ``rocpd`` automatically; use ``rocpd convert`` to export OMPT to CSV / Perfetto / OTF2. ``--ompt-trace`` must be requested explicitly: like ``--kokkos-trace``, it traces a programming model rather than a ROCm runtime API, so it is not enabled by ``--sys-trace`` or ``--runtime-trace``.
+OMPT is a rocpd-only trace: records are written to the rocpd database (the default output format) and are not emitted by the direct CSV / JSON / Perfetto / OTF2 generators. OMPT records are only captured when ``rocpd`` is among the requested ``--output-format`` values, so a run that requests only the deprecated direct generators contains no OMPT data; use ``rocpd convert`` to export OMPT to CSV / Perfetto / OTF2. ``--ompt-trace`` is also enabled implicitly by ``--sys-trace`` and ``--runtime-trace``.
 
 .. note::
 

--- a/projects/rocprofiler-sdk/tests/rocprofv3/ompt/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/ompt/CMakeLists.txt
@@ -90,12 +90,10 @@ rocprofiler_add_integration_validate_test(
     TEST_PATHS validate.py
     COPY conftest.py
     CONFIG pytest.ini
-    ARGS ${PYTEST_ARGS} -k
-         "not test_granular and not test_ompt_all_form_is_complete and not test_sys_trace"
+    ARGS ${PYTEST_ARGS} -k "not test_granular and not test_ompt_all_form_is_complete"
          --rocpd-input ${ompt-tracing-output-dir}/out_results.db
-    DISCOVERY_ARGS
-        ${PYTEST_ARGS} -k
-        "not test_granular and not test_ompt_all_form_is_complete and not test_sys_trace"
+    DISCOVERY_ARGS ${PYTEST_ARGS} -k
+                   "not test_granular and not test_ompt_all_form_is_complete"
     TIMEOUT 45
     LABELS "integration-tests;openmp-target"
     FIXTURES_REQUIRED rocprofv3-test-ompt-tracing
@@ -224,35 +222,3 @@ rocprofiler_add_integration_validate_test(
     LABELS "integration-tests;openmp-target"
     FIXTURES_REQUIRED rocprofv3-test-ompt-all
     DISABLED "${IS_DISABLED}")
-
-# --sys-trace implicit OMPT: profiling with --sys-trace (no explicit --ompt-trace) and a
-# non-rocpd --output-format must still implicitly enable OMPT and auto-add the rocpd
-# output so OMPT records are captured. Uses --output-format csv to exercise the auto-add
-# path. Runs on the host workload so it is not gated on target-offload support.
-set(ompt-sys-trace-output-dir ${CMAKE_CURRENT_BINARY_DIR}/openmp-host-sys-trace)
-rocprofiler_add_integration_execute_test(
-    rocprofv3-test-ompt-sys-trace
-    COMMAND
-        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --sys-trace -d
-        ${ompt-sys-trace-output-dir} -o out --output-format csv --log-level env --
-        $<IF:$<TARGET_EXISTS:openmp-host>,$<TARGET_FILE:openmp-host>,openmp-host>
-    DEPENDS openmp-host
-    TIMEOUT 100
-    LABELS "integration-tests;openmp-host"
-    ENVIRONMENT "${ompt-host-env}"
-    PRELOAD "${PRELOAD_ENV}"
-    FIXTURES_SETUP rocprofv3-test-ompt-sys-trace
-    DISABLED "${IS_HOST_DISABLED}")
-
-rocprofiler_add_integration_validate_test(
-    rocprofv3-test-ompt-sys-trace
-    TEST_PATHS validate.py
-    COPY conftest.py
-    CONFIG pytest.ini
-    ARGS ${PYTEST_ARGS} -k test_sys_trace_implicit_ompt_in_rocpd --rocpd-input
-         ${ompt-sys-trace-output-dir}/out_results.db
-    DISCOVERY_ARGS ${PYTEST_ARGS} -k test_sys_trace_implicit_ompt_in_rocpd
-    TIMEOUT 45
-    LABELS "integration-tests;openmp-host"
-    FIXTURES_REQUIRED rocprofv3-test-ompt-sys-trace
-    DISABLED "${IS_HOST_DISABLED}")

--- a/projects/rocprofiler-sdk/tests/rocprofv3/ompt/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/ompt/CMakeLists.txt
@@ -90,10 +90,12 @@ rocprofiler_add_integration_validate_test(
     TEST_PATHS validate.py
     COPY conftest.py
     CONFIG pytest.ini
-    ARGS ${PYTEST_ARGS} -k "not test_granular and not test_ompt_all_form_is_complete"
+    ARGS ${PYTEST_ARGS} -k
+         "not test_granular and not test_ompt_all_form_is_complete and not test_sys_trace"
          --rocpd-input ${ompt-tracing-output-dir}/out_results.db
-    DISCOVERY_ARGS ${PYTEST_ARGS} -k
-                   "not test_granular and not test_ompt_all_form_is_complete"
+    DISCOVERY_ARGS
+        ${PYTEST_ARGS} -k
+        "not test_granular and not test_ompt_all_form_is_complete and not test_sys_trace"
     TIMEOUT 45
     LABELS "integration-tests;openmp-target"
     FIXTURES_REQUIRED rocprofv3-test-ompt-tracing
@@ -222,3 +224,35 @@ rocprofiler_add_integration_validate_test(
     LABELS "integration-tests;openmp-target"
     FIXTURES_REQUIRED rocprofv3-test-ompt-all
     DISABLED "${IS_DISABLED}")
+
+# --sys-trace implicit OMPT: profiling with --sys-trace (no explicit --ompt-trace) must
+# still enable OMPT tracing, so the rocpd output contains OMPT records. OMPT is a
+# rocpd-only trace, so the rocpd output format is requested explicitly. Runs on the host
+# workload so it is not gated on target-offload support.
+set(ompt-sys-trace-output-dir ${CMAKE_CURRENT_BINARY_DIR}/openmp-host-sys-trace)
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-ompt-sys-trace
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --sys-trace -d
+        ${ompt-sys-trace-output-dir} -o out --output-format rocpd --log-level env --
+        $<IF:$<TARGET_EXISTS:openmp-host>,$<TARGET_FILE:openmp-host>,openmp-host>
+    DEPENDS openmp-host
+    TIMEOUT 100
+    LABELS "integration-tests;openmp-host"
+    ENVIRONMENT "${ompt-host-env}"
+    PRELOAD "${PRELOAD_ENV}"
+    FIXTURES_SETUP rocprofv3-test-ompt-sys-trace
+    DISABLED "${IS_HOST_DISABLED}")
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-ompt-sys-trace
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    ARGS ${PYTEST_ARGS} -k test_sys_trace_implicit_ompt_in_rocpd --rocpd-input
+         ${ompt-sys-trace-output-dir}/out_results.db
+    DISCOVERY_ARGS ${PYTEST_ARGS} -k test_sys_trace_implicit_ompt_in_rocpd
+    TIMEOUT 45
+    LABELS "integration-tests;openmp-host"
+    FIXTURES_REQUIRED rocprofv3-test-ompt-sys-trace
+    DISABLED "${IS_HOST_DISABLED}")

--- a/projects/rocprofiler-sdk/tests/rocprofv3/ompt/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/ompt/validate.py
@@ -33,8 +33,6 @@
 # OMPT operation set is queried from there. The "OMPT" category string is set in
 # source/lib/output/domain_type.cpp.
 
-import os
-import sqlite3
 import sys
 from collections import Counter
 
@@ -207,33 +205,6 @@ def test_ompt_all_form_is_complete(rocpd_conn):
         f"--ompt-trace all is missing target_submit events on a target-offload "
         f"workload; saw: {sorted(ops)}"
     )
-
-
-def test_sys_trace_implicit_ompt_in_rocpd(request):
-    """Regression guard for the --sys-trace implicit-OMPT path. Profiling with
-    --sys-trace (no explicit --ompt-trace) and a non-rocpd --output-format must
-    still implicitly enable OMPT and auto-add the rocpd output so OMPT data is not
-    dropped. A missing database here means that auto-add regressed, so this asserts
-    the database exists (rather than skipping like the shared rocpd_conn fixture)
-    and that it actually contains OMPT records."""
-    filename = request.config.getoption("--rocpd-input")
-    assert os.path.isfile(filename), (
-        f"rocpd database '{filename}' was not created; --sys-trace should implicitly "
-        "enable OMPT and auto-add the 'rocpd' output format even when another "
-        "--output-format was requested"
-    )
-    conn = sqlite3.connect(filename)
-    try:
-        counts = _ompt_op_counts(conn)
-        assert (
-            sum(counts.values()) > 0
-        ), "rocpd database contains no OMPT records under --sys-trace"
-        assert any(op in counts for op in HOST_PARALLEL_OPS), (
-            f"expected host-side parallel-region events ({HOST_PARALLEL_OPS}) under "
-            f"--sys-trace; saw: {sorted(counts)}"
-        )
-    finally:
-        conn.close()
 
 
 if __name__ == "__main__":

--- a/projects/rocprofiler-sdk/tests/rocprofv3/ompt/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/ompt/validate.py
@@ -33,6 +33,8 @@
 # OMPT operation set is queried from there. The "OMPT" category string is set in
 # source/lib/output/domain_type.cpp.
 
+import os
+import sqlite3
 import sys
 from collections import Counter
 
@@ -205,6 +207,31 @@ def test_ompt_all_form_is_complete(rocpd_conn):
         f"--ompt-trace all is missing target_submit events on a target-offload "
         f"workload; saw: {sorted(ops)}"
     )
+
+
+def test_sys_trace_implicit_ompt_in_rocpd(request):
+    """Regression guard for the --sys-trace implicit-OMPT path. Profiling with
+    --sys-trace and no explicit --ompt-trace must still enable OMPT tracing, so the
+    rocpd output contains OMPT records. A missing database means the run itself
+    failed, so this asserts the database exists (rather than skipping like the shared
+    rocpd_conn fixture) and that it actually contains OMPT records."""
+    filename = request.config.getoption("--rocpd-input")
+    assert os.path.isfile(filename), (
+        f"rocpd database '{filename}' was not created; expected the --sys-trace run to "
+        "write a rocpd database containing implicitly-enabled OMPT records"
+    )
+    conn = sqlite3.connect(filename)
+    try:
+        counts = _ompt_op_counts(conn)
+        assert (
+            sum(counts.values()) > 0
+        ), "rocpd database contains no OMPT records under --sys-trace"
+        assert any(op in counts for op in HOST_PARALLEL_OPS), (
+            f"expected host-side parallel-region events ({HOST_PARALLEL_OPS}) under "
+            f"--sys-trace; saw: {sorted(counts)}"
+        )
+    finally:
+        conn.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`rocprofv3` silently appended `rocpd` to the caller's `--output-format` whenever OMPT tracing was enabled. Because `--ompt-trace` is folded into `--sys-trace` and `--runtime-trace`, `rocprofv3 --sys-trace --output-format csv` emitted an extra `<name>_results.db` that the caller never asked for.

That regressed the rocprofv3 BasicApps CQE trace suite on ROCm 7.15.0-20260716: `--sys-trace` and `--runtime-trace` flipped to FAILED on every application, and the unexpected `.db` also tripped a latent crash in the QA harness that prevented any results from being written. Last known good was 7.14.0-RC3, which predates #6437.

## Technical Details

`source/bin/rocprofv3.py`: remove the block that warned and appended `rocpd` to `args.output_format`. That is the only behavioral change; the `--sys-trace` / `--runtime-trace` OMPT folds are left exactly as they are.

Mutating a caller-requested output format is the wrong trade-off. The accompanying warning also named `--ompt-trace` even in the common case where the caller never passed it, only an aggregate flag. Since `rocpd` is the default output format, `--sys-trace` still records OMPT; OMPT data is only absent when a non-`rocpd` `--output-format` is requested explicitly, and writing CSV / Perfetto / OTF2 directly from `rocprofv3` is deprecated in favor of `rocpd convert`.

`tests/rocprofv3/ompt/`: `rocprofv3-test-ompt-sys-trace` asserted the auto-add path through `--output-format csv`. Implicit OMPT under `--sys-trace` is preserved and still worth guarding, so the test now requests `--output-format rocpd` explicitly and `test_sys_trace_implicit_ompt_in_rocpd` is kept, with its wording updated.

Docs and `CHANGELOG.md`: drop the claim that `rocprofv3` adds `rocpd` automatically, and state that OMPT records are only captured when `rocpd` is among the requested formats. The statements that OMPT is folded into the aggregate flags remain, since that behavior is unchanged.

Follow-up to #6437.

## Issue Tracking

JIRA ID: ROCM-28360

## Test Plan

- Output-file-set check on gfx942 (MI300X), mirroring the CQE invocation (`--stats --sys-trace --output-format csv -d <dir> -o v3`) against a HIP workload; repeated for `--runtime-trace`, plus a control with an explicit `-f csv rocpd`. Run against ROCm 7.2.3's installed tool libraries via `--rocm-root`, which has no `--ompt-trace` at all and so isolates the format mutation from OMPT content.
- Before/after diff of the fully resolved `ROCPROF_*` environment across `--sys-trace`, `--runtime-trace`, `--ompt-trace`, `--sys-trace --ompt-trace`, `--ompt-trace=false --sys-trace`, `--ompt-trace parallel task`, `--kokkos-trace` and a bare `--output-format csv`, each with and without an explicit format.
- `pytest --collect-only` over the ompt validator for every `-k` selector in `CMakeLists.txt`, to confirm the retained test runs only under its own fixture.
- `black` (26.5.1) and `cmake-format` on all changed files.

## Test Result

- `--sys-trace --output-format csv` loses exactly one file, `v3_results.db` (13 -> 12). All 12 CSVs are unchanged: identical headers and identical row counts. `--runtime-trace` behaves the same (11 -> 10). With an explicit `-f csv rocpd` the `.db` is still written, so only the implicit append was removed.
- The only environment change in any scenario is `ROCPROF_OUTPUT_FORMAT`, which stays `csv` instead of becoming `csv,rocpd`. `ROCPROF_OMPT_TRACE=1` is still set wherever it was before, including under both aggregate flags, and the full environment is byte-identical for every run that did not request a non-`rocpd` format (for example a bare `--sys-trace`). `--ompt-trace=false --sys-trace` still disables OMPT.
- Test selection is unchanged: the shared validator run still deselects `test_sys_trace_implicit_ompt_in_rocpd` (4/8 collected), its own run selects exactly it (1/8), and it still fails loudly when the database is missing.
- Formatters clean.
- The CQE suite is expected to recover: in the failing log every failure traces to the unexpected `.db` — 16 `--sys-trace` failures against 16 unsupported-`.db` validations, and the 14 `--runtime-trace` failures are 12 of those plus the 2 pre-existing `scratchMemorySpill` `memory_copy_trace*.csv` failures already present in RC3.

The `TypeError` in the QA harness (`ProfilerUtils.py:178`) is a separate latent defect that this PR only makes dormant; it will resurface for any run using the default `rocpd` output format and is tracked separately.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.