### PR TITLE
ci(rocjitsu) Add more gfx1250 semantic tests

### DIFF
--- a/emulation/rocjitsu/tests/corpus/README.md
+++ b/emulation/rocjitsu/tests/corpus/README.md
@@ -9,17 +9,16 @@ deliberate copy-path fix through runtime comparison.
 These source-coverage programs are intentionally outside this qualification
 until their translations or semantic fixtures are ready:
 
-- `barrier_id_minus1_scc_test` (expected offline rewrites: 1)
-- `barrier_id_minus2_scc_test` (expected offline rewrites: 1)
-- `flat_scratch_scalar_hi_test` (expected offline rewrites: 2)
-- `flat_scratch_scalar_lo_test` (expected offline rewrites: 2)
-- `flat_scratch_vector_hi_test` (expected offline rewrites: 1)
-- `flat_scratch_vector_lo_test` (expected offline rewrites: 1)
-- `fp8_e5m3_pack_test` (expected offline rewrites: 4)
-- `monitor_sleep_bounded_test` (expected offline rewrites: 0)
-- `monitor_sleep_unbounded_test` (expected offline rewrites: 1)
-- `permute_pk16_test` (expected offline rewrites: 3)
-- `wmma_split_f16_test` (expected offline rewrites: 4)
+- `barrier_id_minus1_scc_test`
+- `barrier_id_minus2_scc_test`
+- `flat_scratch_scalar_hi_test`
+- `flat_scratch_scalar_lo_test`
+- `flat_scratch_vector_hi_test`
+- `flat_scratch_vector_lo_test`
+- `fp8_e5m3_pack_test`
+- `monitor_sleep_bounded_test`
+- `monitor_sleep_unbounded_test`
+- `permute_pk16_test`
 
 The offline translator currently rejects those forms as unsupported. They are
 not silently accepted or treated as passing translations.

--- a/emulation/rocjitsu/tests/corpus/README.md
+++ b/emulation/rocjitsu/tests/corpus/README.md
@@ -2,16 +2,24 @@
 
 `gfx1250_b0_a0_semantic_tests.json` selects semantic programs whose instruction
 forms have implemented runtime translations. The companion
-`gfx1250_b0_a0_semantic_rewrites.json` pins the exact positive offline rewrite
-count for every selected executable.
+`gfx1250_b0_a0_semantic_rewrites.json` pins the exact non-negative offline
+rewrite count for every selected executable. A zero count qualifies a
+deliberate copy-path fix through runtime comparison.
 
-Four source-coverage programs are intentionally outside this qualification
-until their translations are implemented:
+These source-coverage programs are intentionally outside this qualification
+until their translations or semantic fixtures are ready:
 
-- `barrier_signal_isfirst_test`
-- `fp8_e5m3_pack_test`
-- `wmma_split_f16_test`
-- `wmma_split_fp4_test`
+- `barrier_id_minus1_scc_test` (expected offline rewrites: 1)
+- `barrier_id_minus2_scc_test` (expected offline rewrites: 1)
+- `flat_scratch_scalar_hi_test` (expected offline rewrites: 2)
+- `flat_scratch_scalar_lo_test` (expected offline rewrites: 2)
+- `flat_scratch_vector_hi_test` (expected offline rewrites: 1)
+- `flat_scratch_vector_lo_test` (expected offline rewrites: 1)
+- `fp8_e5m3_pack_test` (expected offline rewrites: 4)
+- `monitor_sleep_bounded_test` (expected offline rewrites: 0)
+- `monitor_sleep_unbounded_test` (expected offline rewrites: 1)
+- `permute_pk16_test` (expected offline rewrites: 3)
+- `wmma_split_f16_test` (expected offline rewrites: 4)
 
 The offline translator currently rejects those forms as unsupported. They are
 not silently accepted or treated as passing translations.

--- a/emulation/rocjitsu/tests/corpus/gfx1250_b0_a0_semantic_rewrites.json
+++ b/emulation/rocjitsu/tests/corpus/gfx1250_b0_a0_semantic_rewrites.json
@@ -1,6 +1,9 @@
 {
   "schema": 1,
   "tests": {
+    "barrier_signal_isfirst_test": {
+      "instructions_requiring_rewrite": 0
+    },
     "cluster_load_test": {
       "instructions_requiring_rewrite": 14
     },
@@ -36,6 +39,9 @@
     },
     "wmma_split_f32_test": {
       "instructions_requiring_rewrite": 7
+    },
+    "wmma_split_fp4_test": {
+      "instructions_requiring_rewrite": 8
     }
   }
 }

--- a/emulation/rocjitsu/tests/corpus/gfx1250_b0_a0_semantic_rewrites.json
+++ b/emulation/rocjitsu/tests/corpus/gfx1250_b0_a0_semantic_rewrites.json
@@ -37,6 +37,9 @@
     "wmma_scale_regular_test": {
       "instructions_requiring_rewrite": 11
     },
+    "wmma_split_f16_test": {
+      "instructions_requiring_rewrite": 6
+    },
     "wmma_split_f32_test": {
       "instructions_requiring_rewrite": 7
     },

--- a/emulation/rocjitsu/tests/corpus/gfx1250_b0_a0_semantic_tests.json
+++ b/emulation/rocjitsu/tests/corpus/gfx1250_b0_a0_semantic_tests.json
@@ -1,5 +1,6 @@
 {
   "semantics": [
+    "barrier_signal_isfirst_test",
     "cluster_load_test",
     "ds_2addr_test",
     "ds_addtid_test",
@@ -11,6 +12,7 @@
     "wmma_scale_regular_test",
     "wmma_scale16_m16_test",
     "wmma_scale16_m32_test",
-    "wmma_split_f32_test"
+    "wmma_split_f32_test",
+    "wmma_split_fp4_test"
   ]
 }

--- a/emulation/rocjitsu/tests/corpus/gfx1250_b0_a0_semantic_tests.json
+++ b/emulation/rocjitsu/tests/corpus/gfx1250_b0_a0_semantic_tests.json
@@ -12,6 +12,7 @@
     "wmma_scale_regular_test",
     "wmma_scale16_m16_test",
     "wmma_scale16_m32_test",
+    "wmma_split_f16_test",
     "wmma_split_f32_test",
     "wmma_split_fp4_test"
   ]

--- a/emulation/rocjitsu/tests/corpus/test-validate-gfx1250-semantic-translations.py
+++ b/emulation/rocjitsu/tests/corpus/test-validate-gfx1250-semantic-translations.py
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: MIT
 
 import importlib.util
+import json
 from pathlib import Path
+import tempfile
 import unittest
 
 VALIDATOR_PATH = Path(__file__).with_name("validate-gfx1250-semantic-translations.py")
@@ -35,6 +37,66 @@ def runtime_record(
         "input_bytes=64 output_bytes=96 "
         f"translation_status={translation_status} status={status}\n"
     )
+
+
+class LoadExpectationsTest(unittest.TestCase):
+    def load_expectations(self, payload: object) -> dict[str, int]:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "expectations.json"
+            path.write_text(
+                json.dumps(payload),
+                encoding="utf-8",
+            )
+            return VALIDATOR.load_expectations(path)
+
+    def load_entry(self, entry: dict[str, object]) -> dict[str, int]:
+        return self.load_expectations({"schema": 1, "tests": {"semantic_test": entry}})
+
+    def assert_invalid(self, entry: dict[str, object]) -> None:
+        with self.assertRaises(ValueError):
+            self.load_entry(entry)
+
+    def test_accepts_valid_rewrite_counts(self) -> None:
+        for value in (0, 3):
+            with self.subTest(value=value):
+                self.assertEqual(
+                    self.load_entry({"instructions_requiring_rewrite": value}),
+                    {"semantic_test": value},
+                )
+
+    def test_rejects_invalid_rewrite_counts(self) -> None:
+        entries = (
+            {"instructions_requiring_rewrite": -1},
+            {"instructions_requiring_rewrite": False},
+            {},
+            {"instructions_requiring_rewrite": 0.0},
+            {"instructions_requiring_rewrite": "0"},
+            {"instructions_requiring_rewrite": None},
+        )
+        for entry in entries:
+            with self.subTest(entry=entry):
+                self.assert_invalid(entry)
+
+    def test_rejects_invalid_payloads(self) -> None:
+        payloads = (
+            {"tests": {"semantic_test": {"instructions_requiring_rewrite": 0}}},
+            {
+                "schema": 2,
+                "tests": {"semantic_test": {"instructions_requiring_rewrite": 0}},
+            },
+            {"schema": 1},
+            {"schema": 1, "tests": {}},
+            {"schema": 1, "tests": []},
+            {
+                "schema": 1,
+                "tests": {"": {"instructions_requiring_rewrite": 0}},
+            },
+            {"schema": 1, "tests": {"semantic_test": 0}},
+        )
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                with self.assertRaises(ValueError):
+                    self.load_expectations(payload)
 
 
 class RuntimeEvidenceTest(unittest.TestCase):

--- a/emulation/rocjitsu/tests/corpus/validate-gfx1250-semantic-translations.py
+++ b/emulation/rocjitsu/tests/corpus/validate-gfx1250-semantic-translations.py
@@ -126,9 +126,9 @@ def load_expectations(path: Path) -> dict[str, int]:
         if not isinstance(entry, dict):
             raise ValueError(f"{path} test '{test}' must contain an object")
         changed = entry.get("instructions_requiring_rewrite")
-        if isinstance(changed, bool) or not isinstance(changed, int) or changed <= 0:
+        if isinstance(changed, bool) or not isinstance(changed, int) or changed < 0:
             raise ValueError(
-                f"{path} test '{test}' must require a positive rewrite count"
+                f"{path} test '{test}' must use a non-negative rewrite count"
             )
         expectations[test] = changed
     return expectations


### PR DESCRIPTION
## Motivation

Register new added semantic tests to the CI workflow.

## Technical Details
- Register tests to ci to cover affected instructions in PR stack:
https://github.com/ROCm/rocm-systems/pull/9405
- Change py to also allow 0 rewrite

## Issue Tracking

Issue ID: https://github.com/ROCm/rocm-systems/issues/7891

## Test Plan

Run corpus CI

## Test Result

Wait CI to pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
