### PR TITLE
fix(rocclr): speed up RCCL batch copies - correct IPC/VMM P2P agent + skip redundant join barrier

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -615,43 +615,6 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
 
 
 // ================================================================================================
-// Resolves the real HSA agents for a src/dst memory pair using pointer_info
-inline void DmaBlitManager::resolveAgents(const Memory& srcMem, const Memory& dstMem,
-                                          address srcAddr, address dstAddr,
-                                          hsa_agent_t& srcAgent, hsa_agent_t& dstAgent) const {
-  // Use agents stored in memory objects during creation
-  srcAgent = srcMem.getOwningAgent();
-  dstAgent = dstMem.getOwningAgent();
-
-  // Handle invalid agent (shouldn't happen if create() properly initialized)
-  if (srcAgent.handle == 0) {
-    srcAgent = srcMem.isHostMemDirectAccess() ? dev().getCpuAgent() : dev().getBackendDevice();
-    if (static_cast<const amd::Memory*>(srcMem.owner())->ipcShared() ||
-        static_cast<const amd::Memory*>(srcMem.owner())->vmmImported()) {
-      hsa_amd_pointer_info_t info = {sizeof(hsa_amd_pointer_info_t)};
-      if (HSA_STATUS_SUCCESS ==
-          Hsa::pointer_info(const_cast<address>(srcAddr), &info, nullptr, nullptr, nullptr)) {
-        srcAgent = info.agentOwner;
-      }
-    } else {
-        srcAgent = srcMem.isHostMemDirectAccess() ? srcMem.dev().getCpuAgent() : srcMem.dev().getBackendDevice();
-    }
-  }
-  if (dstAgent.handle == 0) {
-    dstAgent = dstMem.isHostMemDirectAccess() ? dev().getCpuAgent() : dev().getBackendDevice();
-    if (static_cast<const amd::Memory*>(dstMem.owner())->ipcShared() ||
-        static_cast<const amd::Memory*>(dstMem.owner())->vmmImported()) {
-      hsa_amd_pointer_info_t info = {sizeof(hsa_amd_pointer_info_t)};
-      if (HSA_STATUS_SUCCESS == Hsa::pointer_info(dstAddr, &info, nullptr, nullptr, nullptr)) {
-        dstAgent = info.agentOwner;
-      }
-    } else {
-        dstAgent = dstMem.isHostMemDirectAccess() ? dstMem.dev().getCpuAgent() : dstMem.dev().getBackendDevice();
-    }
-  }
-}
-
-// ================================================================================================
 bool DmaBlitManager::hsaCopy(const Memory& srcMemory, const Memory& dstMemory,
                              const amd::Coord3D& srcOrigin, const amd::Coord3D& dstOrigin,
                              const amd::Coord3D& size, amd::CopyMetadata& copyMetadata) const {
@@ -663,9 +626,10 @@ bool DmaBlitManager::hsaCopy(const Memory& srcMemory, const Memory& dstMemory,
   src += srcOrigin[0];
   dst += dstOrigin[0];
 
-  hsa_agent_t srcAgent;
-  hsa_agent_t dstAgent;
-  resolveAgents(srcMemory, dstMemory, src, dst, srcAgent, dstAgent);
+  // Owning agents are computed when the memory is created, including IPC/VMM-imported
+  // memory, so no per-copy pointer_info query is needed.
+  hsa_agent_t srcAgent = srcMemory.getOwningAgent();
+  hsa_agent_t dstAgent = dstMemory.getOwningAgent();
 
   // Blocking D2H copies need a wait anyways so better wait here
   // than having to wait on the device for dependent signals for SDMA which is slow
@@ -703,9 +667,9 @@ bool DmaBlitManager::hsaCopyBatch(const std::vector<amd::BatchCopyOp>& copyOps,
     address src = reinterpret_cast<address>(srcMem.getDeviceMemory()) + op.srcOffset;
     address dst = reinterpret_cast<address>(dstMem.getDeviceMemory()) + op.dstOffset;
 
-    hsa_agent_t srcAgent;
-    hsa_agent_t dstAgent;
-    resolveAgents(srcMem, dstMem, src, dst, srcAgent, dstAgent);
+    // Owning agents are cached at memory creation time.
+    hsa_agent_t srcAgent = srcMem.getOwningAgent();
+    hsa_agent_t dstAgent = dstMem.getOwningAgent();
 
     // Normalize agents to ensure the calling device's SDMA engines are used,
     // matching the rocrCopyBuffer agent selection logic.

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -228,12 +228,6 @@ class DmaBlitManager : public device::HostBlitManager {
                              size_t& partial       //!< Extra offset for memory alignment
   ) const;
 
-  //! Resolves the real HSA agents for a src/dst memory pair.
-  //! Handles IPC shared memory where dev() may not reflect the true owning agent.
-  inline void resolveAgents(const Memory& srcMem, const Memory& dstMem,
-                            address srcAddr, address dstAddr,
-                            hsa_agent_t& srcAgent, hsa_agent_t& dstAgent) const;
-
   //! Assits in transferring data from Host to Local or vice versa
   //! taking into account the Hsail profile supported by Hsa Agent
   bool hsaCopy(const Memory& srcMemory, const Memory& dstMemory, const amd::Coord3D& srcOrigin,

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -158,6 +158,20 @@ Device::Device(hsa_agent_t bkendDevice)
   cache_state_ = Device::CacheState::kCacheStateInvalid;
 }
 
+int Device::agentGlobalIndex(hsa_agent_t agent) {
+  for (size_t gpu_idx = 0; gpu_idx < gpu_agents_.size(); ++gpu_idx) {
+    if (gpu_agents_[gpu_idx].handle == agent.handle) {
+      return static_cast<int>(gpu_idx);
+    }
+  }
+  for (size_t cpu_idx = 0; cpu_idx < cpu_agents_.size(); ++cpu_idx) {
+    if (cpu_agents_[cpu_idx].agent.handle == agent.handle) {
+      return static_cast<int>(gpu_agents_.size() + cpu_idx);
+    }
+  }
+  return -1;
+}
+
 void Device::setupCpuAgent() {
   int32_t numaDistance = std::numeric_limits<int32_t>::max();
   uint32_t index = 0;  // 0 as default

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -384,6 +384,11 @@ class Device : public NullDevice {
   //! Get the CPU agent with the least NUMA distance to this GPU
   const hsa_agent_t& getCpuAgent() const { return cpu_agent_info_->agent; }
 
+  //! Maps an HSA agent to a stable global index shared across all devices. GPU agents
+  //! occupy [0, numGpuAgents); CPU agents occupy [numGpuAgents, numGpuAgents + numCpuAgents).
+  //! Returns -1 if the agent is not one of the enumerated agents.
+  static int agentGlobalIndex(hsa_agent_t agent);
+
   //! Get the CPU agent that is in a 'index' NUMA node
   const hsa_agent_t getCpuAgent(int index) const {
     if ((index < 0) || (index >= cpu_agents_.size())) {

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -1144,6 +1144,27 @@ bool Buffer::create(bool alloc_local) {
   return (success = (deviceMemory_ != nullptr));
 }
 
+// Recompute the owning agent from a live pointer_info query. Used once the virtual
+// address is actually backed (post hsa_amd_vmem_map), which is the only point where the
+// true owner of VMM-mapped / imported memory can be resolved.
+void Memory::refreshOwningAgentFromPointerInfo() {
+  if (deviceMemory_ == nullptr) {
+    return;
+  }
+
+  hsa_amd_pointer_info_t info = {};
+  info.size = sizeof(info);
+  hsa_status_t err = hsa_amd_pointer_info(reinterpret_cast<address>(deviceMemory_), &info, nullptr,
+                                          nullptr, nullptr);
+
+  // info.agentOwner is the agent that actually owns the backing pages (a peer device for
+  // imported memory). Fall back to this device's backend if the query can't resolve it.
+  hsa_agent_t agent =
+      (err == HSA_STATUS_SUCCESS && info.agentOwner.handle != 0) ? info.agentOwner
+                                                                 : dev().getBackendDevice();
+  setOwningAgent(agent);
+}
+
 // Helper function to compute and cache the owning agent
 void Buffer::computeAndSetOwningAgent() {
   hsa_agent_t agent;
@@ -1168,12 +1189,11 @@ void Buffer::computeAndSetOwningAgent() {
     hsa_status_t err = hsa_amd_pointer_info(
         reinterpret_cast<address>(deviceMemory_), &info, nullptr, nullptr, nullptr);
 
-    if (err == HSA_STATUS_SUCCESS && info.type == HSA_EXT_POINTER_TYPE_IPC) {
-      agent = info.agentOwner;
-    } else {
-      // Fallback to backend device
-      agent = dev().getBackendDevice();
-    }
+    // info.agentOwner is the agent that actually owns the backing pages (a peer device for
+    // IPC/imported memory). Note ROCr does not always tag IPC-opened memory with
+    // HSA_EXT_POINTER_TYPE_IPC, so key off a valid agentOwner rather than the pointer type.
+    agent = (err == HSA_STATUS_SUCCESS && info.agentOwner.handle != 0) ? info.agentOwner
+                                                                       : dev().getBackendDevice();
   } else if (kind_ == MEMORY_KIND_ARENA || kind_ == MEMORY_KIND_HOST) {
     // Arena and host memory use CPU agent
     agent = dev().getCpuAgent();

--- a/projects/clr/rocclr/device/rocm/rocmemory.hpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.hpp
@@ -114,6 +114,18 @@ class Memory : public device::Memory {
     return agent;
   }
 
+  //! Get the global index of the owning agent (computed during create(), thread-safe).
+  //! Lets copy paths classify agents (CPU / local / peer) without handle comparisons.
+  int getOwningAgentIndex() const {
+    return owningAgentIndex_.load(std::memory_order_acquire);
+  }
+
+  //! Recompute and cache the owning agent by querying pointer_info on the (already-backed)
+  //! device memory. Needed for VMM-mapped / VMM-imported (interprocess) memory: the true
+  //! owner is only known after hsa_amd_vmem_map backs the virtual address, which happens
+  //! after create() runs, so the agent cannot be resolved at create() time.
+  void refreshOwningAgentFromPointerInfo();
+
   //! Validates allocated memory for possible workarounds
   virtual bool ValidateMemory() { return true; }
 
@@ -123,9 +135,11 @@ class Memory : public device::Memory {
   // Decrement map count
   void decIndMapCount() override;
 
-  //! Set the owning agent (called during create() after allocation, thread-safe)
+  //! Set the owning agent (called during create() after allocation, thread-safe).
+  //! Also caches the agent's global index for fast classification during copies.
   void setOwningAgent(hsa_agent_t agent) {
     owningAgentHandle_.store(agent.handle, std::memory_order_release);
+    owningAgentIndex_.store(Device::agentGlobalIndex(agent), std::memory_order_release);
   }
 
   // Free / deregister device memory.
@@ -176,6 +190,7 @@ class Memory : public device::Memory {
 
   amd::Memory* pinnedMemory_;        //!< Memory used as pinned system memory
   std::atomic<uint64_t> owningAgentHandle_;  //!< HSA agent handle (atomic for thread-safety)
+  std::atomic<int> owningAgentIndex_{-1};    //!< Global index of the owning agent (thread-safe)
 };
 
 class Buffer : public roc::Memory {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -3575,11 +3575,17 @@ void VirtualGPU::submitBatchCopyMemory(amd::BatchCopyMemoryCommand& cmd) {
     result = false;
   }
 
-  // Synchronize the launch (compute) stream with SDMA engines.
-  // WaitingSignal(Compute) inside dispatchBarrierPacket detects the engine switch
-  // from SDMA→Compute, collects the SDMA completion signal as a barrier dependency,
-  // and updates engine_ to Compute before ActiveSignal tags the profiling signal.
-  if (result) {
+  // copyBufferBatch records every completion signal it produced. The last one sits at
+  // current_id_ and is attached to this command; any signals that are not implicitly
+  // ordered behind it (mixed shader + SDMA paths, or multiple SDMA engine groups running
+  // in parallel) are queued as external signals. Only then is a barrier needed, to join
+  // them into a single completion signal for this command -- otherwise the next command's
+  // profilingBegin() clears those external signals and the dependency is lost.
+  //
+  // When there are no extra signals (e.g. a pure P2P/D2D batch that collapses to one
+  // engine-group op), the sole completion signal already represents the whole batch and
+  // the next op waits on it through the engine switch, so the barrier is pure overhead.
+  if (result && !Barriers().IsExternalSignalListEmpty()) {
     dispatchBarrierPacket(kNopPacketHeader);
   }
 
@@ -4194,6 +4200,11 @@ void VirtualGPU::submitVirtualMap(amd::VirtualMapCommand& vcmd) {
       constexpr bool kImportVmmForInterprocess = true;
       dev().FinalizeMapMemObjBookkeeping(vaddr_sub_obj, phys_mem_obj, const_cast<void*>(vcmd.ptr()),
                                          kImportVmmForInterprocess);
+      // The VA is now backed, so the true owning agent (a peer device for imported memory)
+      // can finally be resolved. create() ran before the mapping existed, so cache it now.
+      if (auto* devMem = static_cast<Memory*>(vaddr_sub_obj->getDeviceMemory(dev()))) {
+        devMem->refreshOwningAgentFromPointerInfo();
+      }
     } else {
       LogError("HSA Command: hsa_amd_vmem_map failed!");
     }


### PR DESCRIPTION
## Motivation

Batched device copies (e.g. RCCL all-gather over `hipMemcpyBatchAsync`) were leaving significant performance on the table:

- Large inter-device (P2P) transfers ran at roughly half the achievable bandwidth due to a P2P engine-selection regression: IPC/VMM peer buffers resolved to the local backend agent instead of the true peer owner, so copies were misclassified as same-device D2D and lost the per-peer xGMI SDMA engine.
- Every batch copy paid a fixed join-barrier overhead that dominates small transfers.

Net result on 8x MI300X: small message sizes are up to **~40% faster**, and large-transfer bandwidth (previously ~halved by the regression) is restored.

## Technical Details

**1) Resolve the true owning agent for IPC/VMM memory (correctness fix; the large-size win)**

Cache each memory object's real owning HSA agent (and its global agent index) at creation and read it directly in the copy paths instead of re-querying `hsa_amd_pointer_info` on every copy. Two gaps in owning-agent resolution for imported memory are fixed; both caused inter-device (P2P) writes to be misclassified as same-device D2D, losing the per-peer xGMI SDMA engine and roughly halving large-transfer bandwidth:

- **IPC-opened memory:** `hsa_amd_pointer_info` returns the correct peer owner in `agentOwner`, but ROCr does not tag it with `HSA_EXT_POINTER_TYPE_IPC` (observed `type=3`). The old code keyed off the pointer type and fell back to the local backend. Now we key off a valid `agentOwner`.
- **VMM-mapped / VMM-imported (interprocess) memory:** the mapped-VA object is created before `hsa_amd_vmem_map` backs the address and before `setVmmImported()` runs, so the owner could not be resolved at create time. Add `roc::Memory::refreshOwningAgentFromPointerInfo()` and call it from `submitVirtualMap()` right after `vmem_map` succeeds.

Also add `Device::agentGlobalIndex()` and store `owningAgentIndex_` on `roc::Memory`, remove the redundant per-copy `resolveAgents()` fallback, and have `hsaCopy()`/`hsaCopyBatch()` read the cached agents directly.

**2) Skip the batch-copy join barrier when it is not needed (small-size perf)**

`submitBatchCopyMemory` unconditionally dispatched a barrier packet after `copyBufferBatch` to join the sub-copy completion signals. When the batch collapses to a single engine-group op (e.g. a pure P2P/D2D all-gather), the sole completion signal already represents the whole batch and the next stream op waits on it via the engine switch, so the barrier is pure overhead. Only dispatch it when `copyBufferBatch` left extra parallel signals (mixed shader+SDMA, or multiple SDMA engine groups) that must be joined into one completion signal for this command.

## Issue Tracking

JIRA ID: ROCM-28783

## Test Plan

8-rank `hipIpcOpenMemHandle` + `hipMemcpyBatchAsync` all-gather on 8x MI300X, sizes 1 KB - 4 GB.

## Test Result

IPC destinations resolve to the true peer owner (no unresolved / zero agent handles), the redundant join barrier is skipped for pure-P2P batches, data validates, and small message sizes improve by up to ~40%.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
