### PR TITLE
perf(rccl): vectorize fp8/bf8 Prod, MinMax and PreMulSum to 2 elements per pack

### DIFF
--- a/projects/rccl/src/device/reduce_kernel.h
+++ b/projects/rccl/src/device/reduce_kernel.h
@@ -468,15 +468,21 @@ SPECIALIZE_REDUCE(FuncMinMax, __nv_fp8_e5m2, 2, __nv_fp8x2_e5m2,
 #else
 SPECIALIZE_REDUCE(FuncSum, rccl_float8, 1, rccl_float8, hadd(x, y))
 SPECIALIZE_REDUCE(FuncSum, rccl_float8, 2, fp8x2_storage_t, hadd2(x, y))
-SPECIALIZE_REDUCE(FuncProd, rccl_float8, 1, rccl_float8, rccl_float8(float(x) * float(y)))
+SPECIALIZE_REDUCE(FuncProd, rccl_float8, 1, rccl_float8,
+                  rccl_float8(rccl_narrow_sat_f32(float(x) * float(y), RCCL_FP8_MAX_FINITE)))
+SPECIALIZE_REDUCE(FuncProd, rccl_float8, 2, fp8x2_storage_t, hmul2(x, y))
 SPECIALIZE_REDUCE(FuncMinMax, rccl_float8, 1, rccl_float8,
                   rccl_float8(fn.isMinNotMax ? fminf(float(x), float(y)) : fmaxf(float(x), float(y))))
+SPECIALIZE_REDUCE(FuncMinMax, rccl_float8, 2, fp8x2_storage_t, hminmax2(x, y, fn.isMinNotMax))
 
 SPECIALIZE_REDUCE(FuncSum, rccl_bfloat8, 1, rccl_bfloat8, hadd_b(x, y))
 SPECIALIZE_REDUCE(FuncSum, rccl_bfloat8, 2, fp8x2_storage_t, hadd2_b(x, y))
-SPECIALIZE_REDUCE(FuncProd, rccl_bfloat8, 1, rccl_bfloat8, rccl_bfloat8(float(x) * float(y)))
+SPECIALIZE_REDUCE(FuncProd, rccl_bfloat8, 1, rccl_bfloat8,
+                  rccl_bfloat8(rccl_narrow_sat_f32(float(x) * float(y), RCCL_BF8_MAX_FINITE)))
+SPECIALIZE_REDUCE(FuncProd, rccl_bfloat8, 2, fp8x2_storage_t, hmul2_b(x, y))
 SPECIALIZE_REDUCE(FuncMinMax, rccl_bfloat8, 1, rccl_bfloat8,
                   rccl_bfloat8(fn.isMinNotMax ? fminf(float(x), float(y)) : fmaxf(float(x), float(y))))
+SPECIALIZE_REDUCE(FuncMinMax, rccl_bfloat8, 2, fp8x2_storage_t, hminmax2_b(x, y, fn.isMinNotMax))
 #endif
 #endif
 
@@ -819,7 +825,18 @@ struct Apply_PreOp<FuncPreMulSum<rccl_float8>, /*EltPerPack=*/1> {
 
   __device__ static BytePack<sizeof(rccl_float8)> preOp(FuncPreMulSum<rccl_float8> fn,
                                                         BytePack<sizeof(rccl_float8)> a) {
-    return toPack<rccl_float8>(rccl_float8(float(fromPack<rccl_float8>(a)) * float(fn.scalar)));
+    return toPack<rccl_float8>(rccl_float8(
+        rccl_narrow_sat_f32(float(fromPack<rccl_float8>(a)) * float(fn.scalar), RCCL_FP8_MAX_FINITE)));
+  }
+};
+
+template <>
+struct Apply_PreOp<FuncPreMulSum<rccl_float8>, /*EltPerPack=*/2> {
+  static constexpr bool IsIdentity = false;
+
+  __device__ static BytePack<sizeof(fp8x2_storage_t)> preOp(FuncPreMulSum<rccl_float8> fn,
+                                                            BytePack<sizeof(fp8x2_storage_t)> a) {
+    return toPack<fp8x2_storage_t>(hpremul2(fromPack<fp8x2_storage_t>(a), fn.scalar));
   }
 };
 
@@ -829,7 +846,18 @@ struct Apply_PreOp<FuncPreMulSum<rccl_bfloat8>, /*EltPerPack=*/1> {
 
   __device__ static BytePack<sizeof(rccl_bfloat8)> preOp(FuncPreMulSum<rccl_bfloat8> fn,
                                                          BytePack<sizeof(rccl_bfloat8)> a) {
-    return toPack<rccl_bfloat8>(rccl_bfloat8(float(fromPack<rccl_bfloat8>(a)) * float(fn.scalar)));
+    return toPack<rccl_bfloat8>(rccl_bfloat8(
+        rccl_narrow_sat_f32(float(fromPack<rccl_bfloat8>(a)) * float(fn.scalar), RCCL_BF8_MAX_FINITE)));
+  }
+};
+
+template <>
+struct Apply_PreOp<FuncPreMulSum<rccl_bfloat8>, /*EltPerPack=*/2> {
+  static constexpr bool IsIdentity = false;
+
+  __device__ static BytePack<sizeof(fp8x2_storage_t)> preOp(FuncPreMulSum<rccl_bfloat8> fn,
+                                                            BytePack<sizeof(fp8x2_storage_t)> a) {
+    return toPack<fp8x2_storage_t>(hpremul2_b(fromPack<fp8x2_storage_t>(a), fn.scalar));
   }
 };
 #endif

--- a/projects/rccl/src/include/rccl_float8.h
+++ b/projects/rccl/src/include/rccl_float8.h
@@ -27,6 +27,60 @@
 #include <hip/hip_version.h>
 
 typedef uint16_t fp8x2_storage_t;
+
+// Inf handling on the narrow-float downconvert.
+//
+// The default saturates +/-Inf to +/-max_finite, which is what both AMD
+// (MODE.FP16_OVFL=1) and NVIDIA (.satfinite) do in their saturating conversion
+// modes. Setting this to 0 restores the older behavior of clamping only finite
+// values and letting Inf reach the convert unchanged, which yields NaN for fp8
+// (no Inf encoding) and Inf for bf8; it is kept switchable so the two can be
+// compared on hardware. Finite inputs are unaffected either way.
+//
+// Whichever setting is in force applies to both the 1-wide and 2-wide reduce
+// paths, so a reduction result never depends on how the data happened to be
+// aligned.
+#ifndef RCCL_NARROW_FP_SATURATE_INF
+#define RCCL_NARROW_FP_SATURATE_INF 1
+#endif
+
+// Largest finite magnitude of the fp8/bf8 encodings in force for this
+// translation unit. This mirrors the branch below that picks the types: gfx942
+// and the software-emulated fallback use the fnuz variants, where e4m3 stops at
+// 240, while the OCP variants used by the host pass and by gfx950 and gfx12xx
+// reach 448. e5m2 is 57344 in every case.
+#if HIP_VERSION >= 60300000 &&                                                                     \
+    (!__HIP_DEVICE_COMPILE__ || defined(__gfx950__) || defined(__gfx1200__) ||                      \
+     defined(__gfx1201__) || defined(__gfx1250__) || defined(__gfx1251__))
+#define RCCL_FP8_MAX_FINITE 448.0f
+#else
+#define RCCL_FP8_MAX_FINITE 240.0f
+#endif
+#define RCCL_BF8_MAX_FINITE 57344.0f
+
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+// Clamp into the destination's range. Used by the 1-wide reduce specializations
+// and, in its two-lane form further down, by the packed helpers.
+//
+// In the saturating case, elementwise_minimum/maximum are the IEEE-754-2019
+// minimum/maximum operations, which propagate NaN, rather than minNum/maxNum,
+// which return the non-NaN operand. That is what makes a separate NaN guard
+// unnecessary: NaN survives the clamp on its own. gfx950 lowers this to
+// v_maximum3_f32 plus v_minimum3_f32 and gfx1250 to v_maximum_f32 plus
+// v_minimum_f32, two VALU ops per lane; gfx942 has no NaN-propagating min/max
+// and lowers it to a compare and select.
+inline __host__ __device__ float rccl_narrow_sat_f32(float v, float maxFinite) {
+#if RCCL_NARROW_FP_SATURATE_INF
+  return __builtin_elementwise_minimum(__builtin_elementwise_maximum(v, -maxFinite), maxFinite);
+#else
+  // fminf/fmaxf return the non-NaN operand and would also clamp Inf, so both
+  // have to be excluded explicitly here.
+  bool finite = (v == v) && (v < __builtin_huge_valf()) && (v > -__builtin_huge_valf());
+  return finite ? __builtin_fminf(__builtin_fmaxf(v, -maxFinite), maxFinite) : v;
+#endif
+}
+#endif
+
 #if __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
 /*! \brief Struct to represent a 8 bit floating-point number. */
 
@@ -188,6 +242,189 @@ inline __device__ fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y) 
   v.bfp8x2 = y;
   w.bfp8[0] = hadd_b(u.bfp8[0], v.bfp8[0]);
   w.bfp8[1] = hadd_b(u.bfp8[1], v.bfp8[1]);
+  return w.bfp8x2;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Packed 2-wide fp8/bf8 reduce helpers: Prod, MinMax and PreMulSum's premul.
+//
+// Each is bit-identical to the per-element expression the 1-wide reduce
+// specializations use. Two properties are needed for that, and neither comes for
+// free:
+//
+//  1. An f32 intermediate. f32 represents every sum and product of two fp8/bf8
+//     values exactly. f16 does not: e4m3 448*448 = 200704 exceeds f16's 65504
+//     and becomes Inf, which then packs to fp8 NaN instead of saturating. This
+//     is why the packed paths do not use the f16 converts even on the targets
+//     that have them.
+//  2. Clamping before the pack. v_cvt_pk_{fp8,bf8}_f32 sends out-of-range values
+//     to NaN/Inf, so rccl_narrow_sat_f32 has to run first. MinMax is the
+//     exception: its result is always one of its inputs and so is already
+//     representable, and it uses the unclamped pack.
+//
+// gfx1250 (MI4xx) can instead saturate in hardware via MODE.FP16_OVFL (bit 23).
+// That is not used here because it is wave-level state that also redirects
+// f32->f16/bf16 converts and v_pk_*_bf16 overflow from Inf to saturation, which
+// reaches well beyond fp8. Note also that the 8-wide v_cvt_scalef32_pk8_*
+// converts ignore FP16_OVFL entirely and always need an explicit clamp.
+// ---------------------------------------------------------------------------
+
+#if __HIP_DEVICE_COMPILE__ &&                                                                     \
+    (defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1200__) ||                         \
+     defined(__gfx1201__) || defined(__gfx1250__) || defined(__gfx1251__))
+#define RCCL_FP8_PACKED_CVT 1
+#endif
+
+#ifdef RCCL_FP8_PACKED_CVT
+inline __device__ float2_t rccl_narrow_sat2_f32(float2_t v, float maxFinite) {
+#if RCCL_NARROW_FP_SATURATE_INF
+  float2_t hi = {maxFinite, maxFinite};
+  float2_t lo = {-maxFinite, -maxFinite};
+  return __builtin_elementwise_minimum(__builtin_elementwise_maximum(v, lo), hi);
+#else
+  v[0] = rccl_narrow_sat_f32(v[0], maxFinite);
+  v[1] = rccl_narrow_sat_f32(v[1], maxFinite);
+  return v;
+#endif
+}
+
+inline __device__ float2_t rccl_unpack2_f32_fp8(fp8x2_storage_t x) {
+  return __builtin_amdgcn_cvt_pk_f32_fp8((int)x, false);
+}
+
+inline __device__ float2_t rccl_unpack2_f32_bf8(fp8x2_storage_t x) {
+  return __builtin_amdgcn_cvt_pk_f32_bf8((int)x, false);
+}
+
+inline __device__ fp8x2_storage_t rccl_pack2_fp8_f32(float2_t v) {
+  return (fp8x2_storage_t)(__builtin_amdgcn_cvt_pk_fp8_f32(v[0], v[1], 0, false) & 0xFFFFu);
+}
+
+inline __device__ fp8x2_storage_t rccl_pack2_bf8_f32(float2_t v) {
+  return (fp8x2_storage_t)(__builtin_amdgcn_cvt_pk_bf8_f32(v[0], v[1], 0, false) & 0xFFFFu);
+}
+
+inline __device__ fp8x2_storage_t rccl_sat_pack2_fp8_f32(float2_t v) {
+  return rccl_pack2_fp8_f32(rccl_narrow_sat2_f32(v, RCCL_FP8_MAX_FINITE));
+}
+
+inline __device__ fp8x2_storage_t rccl_sat_pack2_bf8_f32(float2_t v) {
+  return rccl_pack2_bf8_f32(rccl_narrow_sat2_f32(v, RCCL_BF8_MAX_FINITE));
+}
+#endif
+
+// Packed multiply. Both lanes go through one v_pk_mul_f32 and one packed
+// saturating convert.
+inline __device__ fp8x2_storage_t hmul2(fp8x2_storage_t x, fp8x2_storage_t y) {
+#ifdef RCCL_FP8_PACKED_CVT
+  return rccl_sat_pack2_fp8_f32(rccl_unpack2_f32_fp8(x) * rccl_unpack2_f32_fp8(y));
+#else
+  union {
+    rccl_float8 fp8[2];
+    fp8x2_storage_t fp8x2;
+  } u, v, w;
+  u.fp8x2 = x;
+  v.fp8x2 = y;
+  w.fp8[0] = rccl_float8(rccl_narrow_sat_f32(float(u.fp8[0]) * float(v.fp8[0]), RCCL_FP8_MAX_FINITE));
+  w.fp8[1] = rccl_float8(rccl_narrow_sat_f32(float(u.fp8[1]) * float(v.fp8[1]), RCCL_FP8_MAX_FINITE));
+  return w.fp8x2;
+#endif
+}
+
+inline __device__ fp8x2_storage_t hmul2_b(fp8x2_storage_t x, fp8x2_storage_t y) {
+#ifdef RCCL_FP8_PACKED_CVT
+  return rccl_sat_pack2_bf8_f32(rccl_unpack2_f32_bf8(x) * rccl_unpack2_f32_bf8(y));
+#else
+  union {
+    rccl_bfloat8 bfp8[2];
+    fp8x2_storage_t bfp8x2;
+  } u, v, w;
+  u.bfp8x2 = x;
+  v.bfp8x2 = y;
+  w.bfp8[0] = rccl_bfloat8(rccl_narrow_sat_f32(float(u.bfp8[0]) * float(v.bfp8[0]), RCCL_BF8_MAX_FINITE));
+  w.bfp8[1] = rccl_bfloat8(rccl_narrow_sat_f32(float(u.bfp8[1]) * float(v.bfp8[1]), RCCL_BF8_MAX_FINITE));
+  return w.bfp8x2;
+#endif
+}
+
+// Packed multiply by a broadcast scalar, for PreMulSum's premul step.
+inline __device__ fp8x2_storage_t hpremul2(fp8x2_storage_t x, float s) {
+#ifdef RCCL_FP8_PACKED_CVT
+  float2_t vs = {s, s};
+  return rccl_sat_pack2_fp8_f32(rccl_unpack2_f32_fp8(x) * vs);
+#else
+  union {
+    rccl_float8 fp8[2];
+    fp8x2_storage_t fp8x2;
+  } u, w;
+  u.fp8x2 = x;
+  w.fp8[0] = rccl_float8(rccl_narrow_sat_f32(float(u.fp8[0]) * s, RCCL_FP8_MAX_FINITE));
+  w.fp8[1] = rccl_float8(rccl_narrow_sat_f32(float(u.fp8[1]) * s, RCCL_FP8_MAX_FINITE));
+  return w.fp8x2;
+#endif
+}
+
+inline __device__ fp8x2_storage_t hpremul2_b(fp8x2_storage_t x, float s) {
+#ifdef RCCL_FP8_PACKED_CVT
+  float2_t vs = {s, s};
+  return rccl_sat_pack2_bf8_f32(rccl_unpack2_f32_bf8(x) * vs);
+#else
+  union {
+    rccl_bfloat8 bfp8[2];
+    fp8x2_storage_t bfp8x2;
+  } u, w;
+  u.bfp8x2 = x;
+  w.bfp8[0] = rccl_bfloat8(rccl_narrow_sat_f32(float(u.bfp8[0]) * s, RCCL_BF8_MAX_FINITE));
+  w.bfp8[1] = rccl_bfloat8(rccl_narrow_sat_f32(float(u.bfp8[1]) * s, RCCL_BF8_MAX_FINITE));
+  return w.bfp8x2;
+#endif
+}
+
+// Packed min/max. The result is always one of the inputs, so it is already
+// representable and the pack needs no clamp. fminf/fmaxf are used rather than a
+// packed f16 min/max so that NaN and signed-zero tie-breaks are decided by the
+// same operation the scalar path uses.
+inline __device__ fp8x2_storage_t hminmax2(fp8x2_storage_t x, fp8x2_storage_t y, bool isMin) {
+#ifdef RCCL_FP8_PACKED_CVT
+  float2_t a = rccl_unpack2_f32_fp8(x);
+  float2_t b = rccl_unpack2_f32_fp8(y);
+  float2_t r = {isMin ? fminf(a[0], b[0]) : fmaxf(a[0], b[0]),
+                isMin ? fminf(a[1], b[1]) : fmaxf(a[1], b[1])};
+  return rccl_pack2_fp8_f32(r);
+#else
+  union {
+    rccl_float8 fp8[2];
+    fp8x2_storage_t fp8x2;
+  } u, v, w;
+  u.fp8x2 = x;
+  v.fp8x2 = y;
+  w.fp8[0] = rccl_float8(isMin ? fminf(float(u.fp8[0]), float(v.fp8[0]))
+                               : fmaxf(float(u.fp8[0]), float(v.fp8[0])));
+  w.fp8[1] = rccl_float8(isMin ? fminf(float(u.fp8[1]), float(v.fp8[1]))
+                               : fmaxf(float(u.fp8[1]), float(v.fp8[1])));
+  return w.fp8x2;
+#endif
+}
+
+inline __device__ fp8x2_storage_t hminmax2_b(fp8x2_storage_t x, fp8x2_storage_t y, bool isMin) {
+#ifdef RCCL_FP8_PACKED_CVT
+  float2_t a = rccl_unpack2_f32_bf8(x);
+  float2_t b = rccl_unpack2_f32_bf8(y);
+  float2_t r = {isMin ? fminf(a[0], b[0]) : fmaxf(a[0], b[0]),
+                isMin ? fminf(a[1], b[1]) : fmaxf(a[1], b[1])};
+  return rccl_pack2_bf8_f32(r);
+#else
+  union {
+    rccl_bfloat8 bfp8[2];
+    fp8x2_storage_t bfp8x2;
+  } u, v, w;
+  u.bfp8x2 = x;
+  v.bfp8x2 = y;
+  w.bfp8[0] = rccl_bfloat8(isMin ? fminf(float(u.bfp8[0]), float(v.bfp8[0]))
+                                 : fmaxf(float(u.bfp8[0]), float(v.bfp8[0])));
+  w.bfp8[1] = rccl_bfloat8(isMin ? fminf(float(u.bfp8[1]), float(v.bfp8[1]))
+                                 : fmaxf(float(u.bfp8[1]), float(v.bfp8[1])));
   return w.bfp8x2;
 #endif
 }
@@ -769,6 +1006,89 @@ inline __device__ fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y) 
   w.fp8[1] = hadd_b(u.fp8[1], v.fp8[1]);
 
   return w.fp8x2;
+}
+
+// Per-element forms of the packed reduce helpers, for builds without the fp8
+// conversion instructions. The rccl_float8/rccl_bfloat8 constructors saturate,
+// so these define the semantics the packed paths above have to reproduce.
+inline __device__ fp8x2_storage_t hmul2(fp8x2_storage_t x, fp8x2_storage_t y) {
+  union {
+    rccl_float8 fp8[2];
+    fp8x2_storage_t fp8x2;
+  } u, v, w;
+  u.fp8x2 = x;
+  v.fp8x2 = y;
+  w.fp8[0] = rccl_float8(rccl_narrow_sat_f32(float(u.fp8[0]) * float(v.fp8[0]), RCCL_FP8_MAX_FINITE));
+  w.fp8[1] = rccl_float8(rccl_narrow_sat_f32(float(u.fp8[1]) * float(v.fp8[1]), RCCL_FP8_MAX_FINITE));
+
+  return w.fp8x2;
+}
+
+inline __device__ fp8x2_storage_t hmul2_b(fp8x2_storage_t x, fp8x2_storage_t y) {
+  union {
+    rccl_bfloat8 bfp8[2];
+    fp8x2_storage_t bfp8x2;
+  } u, v, w;
+  u.bfp8x2 = x;
+  v.bfp8x2 = y;
+  w.bfp8[0] = rccl_bfloat8(rccl_narrow_sat_f32(float(u.bfp8[0]) * float(v.bfp8[0]), RCCL_BF8_MAX_FINITE));
+  w.bfp8[1] = rccl_bfloat8(rccl_narrow_sat_f32(float(u.bfp8[1]) * float(v.bfp8[1]), RCCL_BF8_MAX_FINITE));
+
+  return w.bfp8x2;
+}
+
+inline __device__ fp8x2_storage_t hpremul2(fp8x2_storage_t x, float s) {
+  union {
+    rccl_float8 fp8[2];
+    fp8x2_storage_t fp8x2;
+  } u, w;
+  u.fp8x2 = x;
+  w.fp8[0] = rccl_float8(rccl_narrow_sat_f32(float(u.fp8[0]) * s, RCCL_FP8_MAX_FINITE));
+  w.fp8[1] = rccl_float8(rccl_narrow_sat_f32(float(u.fp8[1]) * s, RCCL_FP8_MAX_FINITE));
+
+  return w.fp8x2;
+}
+
+inline __device__ fp8x2_storage_t hpremul2_b(fp8x2_storage_t x, float s) {
+  union {
+    rccl_bfloat8 bfp8[2];
+    fp8x2_storage_t bfp8x2;
+  } u, w;
+  u.bfp8x2 = x;
+  w.bfp8[0] = rccl_bfloat8(rccl_narrow_sat_f32(float(u.bfp8[0]) * s, RCCL_BF8_MAX_FINITE));
+  w.bfp8[1] = rccl_bfloat8(rccl_narrow_sat_f32(float(u.bfp8[1]) * s, RCCL_BF8_MAX_FINITE));
+
+  return w.bfp8x2;
+}
+
+inline __device__ fp8x2_storage_t hminmax2(fp8x2_storage_t x, fp8x2_storage_t y, bool isMin) {
+  union {
+    rccl_float8 fp8[2];
+    fp8x2_storage_t fp8x2;
+  } u, v, w;
+  u.fp8x2 = x;
+  v.fp8x2 = y;
+  w.fp8[0] = rccl_float8(isMin ? fminf(float(u.fp8[0]), float(v.fp8[0]))
+                               : fmaxf(float(u.fp8[0]), float(v.fp8[0])));
+  w.fp8[1] = rccl_float8(isMin ? fminf(float(u.fp8[1]), float(v.fp8[1]))
+                               : fmaxf(float(u.fp8[1]), float(v.fp8[1])));
+
+  return w.fp8x2;
+}
+
+inline __device__ fp8x2_storage_t hminmax2_b(fp8x2_storage_t x, fp8x2_storage_t y, bool isMin) {
+  union {
+    rccl_bfloat8 bfp8[2];
+    fp8x2_storage_t bfp8x2;
+  } u, v, w;
+  u.bfp8x2 = x;
+  v.bfp8x2 = y;
+  w.bfp8[0] = rccl_bfloat8(isMin ? fminf(float(u.bfp8[0]), float(v.bfp8[0]))
+                                 : fmaxf(float(u.bfp8[0]), float(v.bfp8[0])));
+  w.bfp8[1] = rccl_bfloat8(isMin ? fminf(float(u.bfp8[1]), float(v.bfp8[1]))
+                                 : fmaxf(float(u.bfp8[1]), float(v.bfp8[1])));
+
+  return w.bfp8x2;
 }
 
 // Special operator overloading

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -256,6 +256,7 @@ if(BUILD_TESTS)
       DdaCollCommonTests.cpp
       VersionInfoTests.cpp
       device/TestOp128.cpp
+      device/NarrowFloatReduce_test.cpp
       device/GinDeviceTests.cpp
       device/GinAnvilIpcDevice_test.cpp
       DeviceApiTests.cpp

--- a/projects/rccl/test/device/NarrowFloatReduce_test.cpp
+++ b/projects/rccl/test/device/NarrowFloatReduce_test.cpp
@@ -1,0 +1,273 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Unit tests for the packed 2-wide fp8/bf8 reduce helpers in
+// src/include/rccl_float8.h:
+//   hadd2 / hadd2_b        - sum
+//   hminmax2 / hminmax2_b  - min / max
+//   hmul2 / hmul2_b        - product
+//   hpremul2 / hpremul2_b  - multiply by a broadcast scalar
+//
+// They operate on fp8x2_storage_t, a uint16_t holding two fp8 bytes (element 0
+// in the low byte). Depending on the target they take either the packed
+// conversion path (gfx942/gfx950/gfx12xx) or a per-element fallback.
+//
+// Two invariants are checked.
+//
+// First, the 2-wide packed result is bit-identical to applying the same
+// operation one element at a time via the expressions reduce_kernel.h uses for
+// EltPerPack=1. That is what makes the EltPerPack=2 specializations a pure
+// vectorization: a reduction result cannot depend on whether a given element
+// happened to land in an aligned pair. This is not circular even though both
+// widths share rccl_narrow_sat_f32, because the packed path clamps two lanes at
+// once and converts with the hardware pack, while the scalar path clamps one
+// lane and converts through the HIP fp8 constructor.
+//
+// Second, saturation is checked directly rather than against a reference: with
+// RCCL_NARROW_FP_SATURATE_INF set, no product may come back as Inf, and NaN must
+// stay NaN.
+//
+// The oracle runs on the device, not the host, because the fp8 encoding is not
+// portable: gfx942 uses the fnuz variants (e4m3 max 240) while gfx950 and
+// gfx12xx use OCP (e4m3 max 448), so a host-computed reference would disagree
+// with the device for reasons unrelated to the helpers. Both the helper result
+// and the oracle come back as raw bytes and are compared bit-for-bit; decoded
+// floats come back too, only to make failures readable and to tell a genuine
+// numeric difference apart from a NaN that is merely encoded differently.
+
+#include "DeviceTestBase.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+#include "rccl_float8.h"
+
+namespace RcclUnitTesting
+{
+
+enum NarrowOp { OP_ADD = 0, OP_MIN, OP_MAX, OP_MUL, OP_PREMUL };
+
+// Compile-time selection between the fp8 (e4m3) and bf8 (e5m2) helper family.
+template<bool IsBf8> struct NarrowTraits;
+
+template<> struct NarrowTraits<false> {
+  using elem_t = rccl_float8;
+  static __device__ fp8x2_storage_t add(fp8x2_storage_t x, fp8x2_storage_t y)             { return hadd2(x, y); }
+  static __device__ fp8x2_storage_t minmax(fp8x2_storage_t x, fp8x2_storage_t y, bool mn) { return hminmax2(x, y, mn); }
+  static __device__ fp8x2_storage_t mul(fp8x2_storage_t x, fp8x2_storage_t y)             { return hmul2(x, y); }
+  static __device__ fp8x2_storage_t premul(fp8x2_storage_t x, float s)                    { return hpremul2(x, s); }
+  static __device__ elem_t          scalarAdd(elem_t a, elem_t b)                         { return hadd(a, b); }
+  static constexpr float            kMaxFinite = RCCL_FP8_MAX_FINITE;
+};
+
+template<> struct NarrowTraits<true> {
+  using elem_t = rccl_bfloat8;
+  static __device__ fp8x2_storage_t add(fp8x2_storage_t x, fp8x2_storage_t y)             { return hadd2_b(x, y); }
+  static __device__ fp8x2_storage_t minmax(fp8x2_storage_t x, fp8x2_storage_t y, bool mn) { return hminmax2_b(x, y, mn); }
+  static __device__ fp8x2_storage_t mul(fp8x2_storage_t x, fp8x2_storage_t y)             { return hmul2_b(x, y); }
+  static __device__ fp8x2_storage_t premul(fp8x2_storage_t x, float s)                    { return hpremul2_b(x, s); }
+  static __device__ elem_t          scalarAdd(elem_t a, elem_t b)                         { return hadd_b(a, b); }
+  static constexpr float            kMaxFinite = RCCL_BF8_MAX_FINITE;
+};
+
+template<bool IsBf8>
+__device__ inline void decode2(fp8x2_storage_t v, float& lo, float& hi) {
+  union { typename NarrowTraits<IsBf8>::elem_t e[2]; fp8x2_storage_t s; } u;
+  u.s = v;
+  lo = float(u.e[0]);
+  hi = float(u.e[1]);
+}
+
+// For each pair: run the packed helper, and independently run the per-element
+// EltPerPack=1 expression from reduce_kernel.h as the oracle.
+// RCCL_FP8_MAX_FINITE differs between the host pass (OCP, 448) and fnuz device
+// builds (240), so the device reports the value it actually saturates to.
+template<bool IsBf8>
+__global__ void kReportMaxFinite(float* out) { *out = NarrowTraits<IsBf8>::kMaxFinite; }
+
+template<bool IsBf8>
+__global__ void kNarrowReduce(const fp8x2_storage_t* __restrict__ X,
+                              const fp8x2_storage_t* __restrict__ Y,
+                              float scalar, int op,
+                              fp8x2_storage_t* __restrict__ packedRaw,
+                              fp8x2_storage_t* __restrict__ refRaw,
+                              float* __restrict__ packedF,
+                              float* __restrict__ refF, int n) {
+  using elem_t = typename NarrowTraits<IsBf8>::elem_t;
+  constexpr float kMax = NarrowTraits<IsBf8>::kMaxFinite;
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= n) return;
+
+  fp8x2_storage_t x = X[i];
+  fp8x2_storage_t y = (Y != nullptr) ? Y[i] : fp8x2_storage_t(0);
+
+  fp8x2_storage_t packed;
+  switch (op) {
+    case OP_ADD: packed = NarrowTraits<IsBf8>::add(x, y);          break;
+    case OP_MIN: packed = NarrowTraits<IsBf8>::minmax(x, y, true);  break;
+    case OP_MAX: packed = NarrowTraits<IsBf8>::minmax(x, y, false); break;
+    case OP_MUL: packed = NarrowTraits<IsBf8>::mul(x, y);          break;
+    default:     packed = NarrowTraits<IsBf8>::premul(x, scalar);   break;
+  }
+
+  union { elem_t e[2]; fp8x2_storage_t s; } ux, uy, uw;
+  ux.s = x;
+  uy.s = y;
+  for (int l = 0; l < 2; ++l) {
+    float a = float(ux.e[l]);
+    float b = float(uy.e[l]);
+    switch (op) {
+      // Sum's EltPerPack=1 form is the scalar hadd helper, not a float add, so
+      // the oracle uses hadd too.
+      case OP_ADD: uw.e[l] = NarrowTraits<IsBf8>::scalarAdd(ux.e[l], uy.e[l]); break;
+      // Min/Max return one of their inputs, so they need no clamp; Prod and
+      // PreMulSum go through the same saturation the 1-wide path now applies.
+      case OP_MIN: uw.e[l] = elem_t(fminf(a, b));                              break;
+      case OP_MAX: uw.e[l] = elem_t(fmaxf(a, b));                              break;
+      case OP_MUL: uw.e[l] = elem_t(rccl_narrow_sat_f32(a * b, kMax));         break;
+      default:     uw.e[l] = elem_t(rccl_narrow_sat_f32(a * scalar, kMax));    break;
+    }
+  }
+
+  packedRaw[i] = packed;
+  refRaw[i]    = uw.s;
+  decode2<IsBf8>(packed, packedF[2 * i], packedF[2 * i + 1]);
+  decode2<IsBf8>(uw.s, refF[2 * i], refF[2 * i + 1]);
+}
+
+class NarrowFloatReduceTest : public DeviceTestBase {
+protected:
+  template<bool IsBf8>
+  float deviceMaxFinite() {
+    DeviceBuffer<float> d(1);
+    kReportMaxFinite<IsBf8><<<1, 1>>>(d.ptr);
+    syncAndCheck();
+    return d.download();
+  }
+
+  // Bit-for-bit comparison. A mismatch where both lanes decode to NaN is
+  // reported separately: it is a difference in NaN encoding, not in value.
+  static void expectBitMatch(const std::vector<fp8x2_storage_t>& packedRaw,
+                             const std::vector<fp8x2_storage_t>& refRaw,
+                             const std::vector<float>& packedF,
+                             const std::vector<float>& refF,
+                             const char* name, float scalar, bool haveScalar) {
+    int valueMismatches = 0;
+    int nanEncodingOnly = 0;
+    for (size_t i = 0; i < packedRaw.size(); ++i) {
+      if (packedRaw[i] == refRaw[i]) continue;
+      for (int l = 0; l < 2; ++l) {
+        float p = packedF[2 * i + l];
+        float r = refF[2 * i + l];
+        uint8_t pb = static_cast<uint8_t>((packedRaw[i] >> (8 * l)) & 0xFF);
+        uint8_t rb = static_cast<uint8_t>((refRaw[i] >> (8 * l)) & 0xFF);
+        if (pb == rb) continue;
+        if (std::isnan(p) && std::isnan(r)) {
+          ++nanEncodingOnly;
+          continue;
+        }
+        if (valueMismatches < 10) {
+          std::string ctx;
+          if (haveScalar) ctx = " scalar=" + std::to_string(scalar);
+          ADD_FAILURE() << name << ": pair " << i << " lane " << l << " packed=0x" << std::hex
+                        << unsigned(pb) << " (" << std::dec << p << ") oracle=0x" << std::hex
+                        << unsigned(rb) << " (" << std::dec << r << ")" << ctx;
+        }
+        ++valueMismatches;
+      }
+    }
+    EXPECT_EQ(valueMismatches, 0) << name << ": " << valueMismatches << " lanes differ in value";
+    if (nanEncodingOnly != 0)
+      GTEST_LOG_(INFO) << name << ": " << nanEncodingOnly
+                       << " lanes are NaN in both but with different encodings";
+  }
+
+  // Saturation checked on its own terms rather than against a reference: with
+  // RCCL_NARROW_FP_SATURATE_INF nothing may come back as Inf, and every finite
+  // result must be within range. NaN is allowed through unchanged.
+  static void expectSaturated(const std::vector<float>& out, float maxFinite, const char* name) {
+    int infs = 0, oor = 0;
+    for (float v : out) {
+      if (std::isnan(v)) continue;
+      if (std::isinf(v)) ++infs;
+      else if (std::fabs(v) > maxFinite) ++oor;
+    }
+#if RCCL_NARROW_FP_SATURATE_INF
+    EXPECT_EQ(infs, 0) << name << ": " << infs << " results are Inf despite saturation being on";
+#endif
+    EXPECT_EQ(oor, 0) << name << ": " << oor << " finite results exceed " << maxFinite;
+  }
+
+  // Every ordered pair of fp8 bytes. Lane 0 carries (a,b) and lane 1 the
+  // swapped (b,a), so each lane independently sees all 65536 pairs and a
+  // lane-swap bug cannot cancel out.
+  template<bool IsBf8>
+  void runTwoInput(int op, const char* name) {
+    const int N = 256 * 256;
+    std::vector<fp8x2_storage_t> hx(N), hy(N);
+    for (int idx = 0; idx < N; ++idx) {
+      uint8_t a = static_cast<uint8_t>(idx & 0xFF);
+      uint8_t b = static_cast<uint8_t>((idx >> 8) & 0xFF);
+      hx[idx] = static_cast<fp8x2_storage_t>(a | (static_cast<uint16_t>(b) << 8));
+      hy[idx] = static_cast<fp8x2_storage_t>(b | (static_cast<uint16_t>(a) << 8));
+    }
+    DeviceBuffer<fp8x2_storage_t> dx(N), dy(N), dpr(N), drr(N);
+    dx.copyFrom(hx);
+    dy.copyFrom(hy);
+    DeviceBuffer<float> dpf(2 * N), drf(2 * N);
+
+    kNarrowReduce<IsBf8><<<gridFor(N), kDefaultBlockSize>>>(
+        dx.ptr, dy.ptr, 0.0f, op, dpr.ptr, drr.ptr, dpf.ptr, drf.ptr, N);
+    syncAndCheck();
+    std::vector<float> packedF = dpf.copyTo();
+    expectBitMatch(dpr.copyTo(), drr.copyTo(), packedF, drf.copyTo(), name, 0.0f, false);
+    if (op == OP_MUL) expectSaturated(packedF, deviceMaxFinite<IsBf8>(), name);
+  }
+
+  // Every fp8 byte in both lanes, against scalars that cover zero, negative,
+  // fractional, and magnitudes large enough to force saturation.
+  template<bool IsBf8>
+  void runPreMul(const char* name) {
+    const int N = 256 * 256;
+    std::vector<fp8x2_storage_t> hx(N);
+    for (int idx = 0; idx < N; ++idx) {
+      uint8_t a = static_cast<uint8_t>(idx & 0xFF);
+      uint8_t b = static_cast<uint8_t>((idx >> 8) & 0xFF);
+      hx[idx] = static_cast<fp8x2_storage_t>(a | (static_cast<uint16_t>(b) << 8));
+    }
+    DeviceBuffer<fp8x2_storage_t> dx(N), dpr(N), drr(N);
+    dx.copyFrom(hx);
+    DeviceBuffer<float> dpf(2 * N), drf(2 * N);
+
+    const float maxFinite = deviceMaxFinite<IsBf8>();
+    const float scalars[] = {0.0f, -0.0f, 0.5f, 1.0f, 2.0f, -1.0f, -3.5f, 100.0f, 1e30f, -1e30f};
+    for (float s : scalars) {
+      kNarrowReduce<IsBf8><<<gridFor(N), kDefaultBlockSize>>>(
+          dx.ptr, nullptr, s, OP_PREMUL, dpr.ptr, drr.ptr, dpf.ptr, drf.ptr, N);
+      syncAndCheck();
+      std::vector<float> packedF = dpf.copyTo();
+      expectBitMatch(dpr.copyTo(), drr.copyTo(), packedF, drf.copyTo(), name, s, true);
+      expectSaturated(packedF, maxFinite, name);
+    }
+  }
+};
+
+// ---- fp8 (e4m3) ----
+TEST_F(NarrowFloatReduceTest, Fp8Add)    { runTwoInput<false>(OP_ADD, "hadd2"); }
+TEST_F(NarrowFloatReduceTest, Fp8Min)    { runTwoInput<false>(OP_MIN, "hminmax2/min"); }
+TEST_F(NarrowFloatReduceTest, Fp8Max)    { runTwoInput<false>(OP_MAX, "hminmax2/max"); }
+TEST_F(NarrowFloatReduceTest, Fp8Mul)    { runTwoInput<false>(OP_MUL, "hmul2"); }
+TEST_F(NarrowFloatReduceTest, Fp8PreMul) { runPreMul<false>("hpremul2"); }
+
+// ---- bf8 (e5m2) ----
+TEST_F(NarrowFloatReduceTest, Bf8Add)    { runTwoInput<true>(OP_ADD, "hadd2_b"); }
+TEST_F(NarrowFloatReduceTest, Bf8Min)    { runTwoInput<true>(OP_MIN, "hminmax2_b/min"); }
+TEST_F(NarrowFloatReduceTest, Bf8Max)    { runTwoInput<true>(OP_MAX, "hminmax2_b/max"); }
+TEST_F(NarrowFloatReduceTest, Bf8Mul)    { runTwoInput<true>(OP_MUL, "hmul2_b"); }
+TEST_F(NarrowFloatReduceTest, Bf8PreMul) { runPreMul<true>("hpremul2_b"); }
+
+} // namespace RcclUnitTesting


### PR DESCRIPTION
## Summary

Stacked on #9474, which the exhaustive test needs in order to pass on gfx942.

`FuncSum` was the only fp8/bf8 reduce op with an `EltPerPack=2` specialization. Prod, MinMax and PreMulSum fell back to per-element code that widened, operated and narrowed one byte at a time, costing registers and scratch. This adds packed primitives over `v_cvt_pk_{f32_fp8,f32_bf8}` and `v_cvt_pk_{fp8,bf8}_f32`, the helpers `hmul2`, `hpremul2` and `hminmax2` plus their bf8 forms, and the matching `EltPerPack=2` specializations. Enabled on gfx942, gfx950, gfx12xx and gfx1250; other targets keep the per-element path.

**Why f32 and not the f16 converts.** gfx950 and gfx1250 both have fp8-to-f16 converts, and they are tempting because they are cheaper. They are also wrong here: f32 represents every sum and product of two fp8 values exactly, but f16 does not. e4m3 `448 * 448 = 200704` exceeds f16's 65504, becomes Inf, and then packs to fp8 NaN rather than saturating. So all three ops use an f32 intermediate.

**Saturation.** The clamp is now explicit and shared by the 1-wide and 2-wide paths, so a reduction result cannot depend on whether a given element happened to land in an aligned pair. `RCCL_NARROW_FP_SATURATE_INF` selects how Inf is handled:

- **1 (default)** — Inf saturates to the format maximum. This matches AMD's `MODE.FP16_OVFL=1` and NVIDIA's `.satfinite`, i.e. the de facto standard for narrow-float conversion.
- **0** — the previous behavior, where only finite values were clamped and Inf reached the convert unchanged, giving NaN for fp8 (which has no Inf encoding) and Inf for bf8.

Finite inputs are identical under both settings. The switch is retained so the two can be compared on hardware. In the saturating case the clamp uses the NaN-propagating IEEE-754-2019 `minimum`/`maximum` rather than `minNum`/`maxNum`, which means no separate NaN guard is needed; it lowers to `v_maximum3_f32`/`v_minimum3_f32` on gfx950 and `v_maximum_f32`/`v_minimum_f32` on gfx1250, two VALU ops per lane. MinMax needs no clamp at all, since its result is always one of its inputs.

MI4xx could saturate in hardware via `MODE.FP16_OVFL` instead, which would make the clamp free. That is deliberately not used: the bit is wave-level state that also redirects f32-to-f16/bf16 converts and `v_pk_*_bf16` overflow from Inf to saturation, reaching well beyond fp8. Worth noting for future work that the 8-wide `v_cvt_scalef32_pk8_*` converts ignore `FP16_OVFL` entirely and always need an explicit clamp.

## Measured effect

Across the 504 fp8/bf8 reduce kernels, from the per-kernel `resources.json`, with **zero register spills** before or after:

| arch | VGPR | scratch |
|---|---|---|
| gfx942 | −834 | −6632 B |
| gfx950 | −1324 | −5264 B |
| gfx1250 | +14 | +24072 B |

gfx1250 gains scratch rather than losing it. I confirmed this is not the saturation clamp by rebuilding gfx1250 with the clamp deleted outright, which still showed +25504 B. It comes from enabling the wider path itself: VGPR pressure rises on the worst kernels (`reducescatter_ring_*`, 340 to 406) and the compiler stops promoting some stack objects. There are no spills, so whether this costs any real performance is unknown and needs MI4xx hardware to answer.

## Test plan

`NarrowFloatReduce_test` sweeps all 65536 ordered fp8 byte pairs for each op, placing `(a,b)` in lane 0 and `(b,a)` in lane 1 so each lane independently sees every pair and a lane-swap bug cannot cancel out. It checks two things: that the 2-wide result is bit-identical to the 1-wide expression, comparing **raw bytes** so signed-zero and NaN-encoding differences cannot hide; and, independently of any reference, that saturation admits no out-of-range or Inf result. The oracle runs on the device because the fp8 encoding is not portable — gfx942 and the software fallback use fnuz (e4m3 max 240) while gfx950 and gfx12xx use OCP (448).

- [x] Clean build for gfx90a, gfx942, gfx950 and gfx1250
- [x] All 10 tests pass on gfx90a, exercising the per-element fallback and the harness
- [x] Codegen verified per arch: `v_pk_mul_f32`, packed unpack/pack, and the expected clamp lowering on each target
- [x] `RCCL_NARROW_FP_SATURATE_INF=0` also builds on all four targets and produces the expected alternative lowering
- [ ] **Exhaustive bit-exactness run on gfx950 hardware** — this is the gate that matters and it has not been done; the available machine is gfx90a, which only takes the fallback path
- [ ] Run on gfx942 hardware
- [ ] Performance measurement, particularly on gfx1250

Made with [Cursor](https://cursor.com)