### PR TITLE
[rocjitsu] Preserve gfx1250 B0-to-A0 scratch under register pressure

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
@@ -272,6 +272,11 @@ const BlockLiveness &LivenessAnalysis::block_liveness(const BasicBlock &block) c
   return liveness_.at(it->second);
 }
 
+bool LivenessAnalysis::has_live_before(const Instruction &inst) const {
+  require_available();
+  return live_before_.contains(&inst);
+}
+
 const RegisterSet &LivenessAnalysis::live_before(const Instruction &inst) const {
   require_available();
   auto it = live_before_.find(&inst);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
@@ -152,6 +152,12 @@ public:
   /// @brief Block liveness by block object.
   [[nodiscard]] const BlockLiveness &block_liveness(const BasicBlock &block) const;
 
+  /// @brief Whether a live-before snapshot was materialized for @p inst.
+  /// @details Returns false when @p inst was not part of the analyzed scope.
+  ///          Throws std::logic_error when the analysis is unavailable,
+  ///          matching live_before().
+  [[nodiscard]] bool has_live_before(const Instruction &inst) const;
+
   /// @brief Registers live immediately before @p inst executes.
   [[nodiscard]] const RegisterSet &live_before(const Instruction &inst) const;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1642,7 +1642,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     TranslationContext kernel_context(
         scope.translation->target_vgpr_count, scope.translation->target_agpr_count,
         scope.translation->target_accvgpr_base, scope.translation->target_sgpr_count,
-        scope.translation->target_private_size);
+        scope.translation->target_private_size, scope.translation->uses_dynamic_stack);
     if (scope.translation->needs_lds_overflow_buf) {
       auto virtual_lds_base =
           reserve_virtual_lds_base_sgpr_pair(kernel_context, KernelBlockScope(scope.blocks),
@@ -2655,8 +2655,18 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         remaining_growth_words -= requested_growth_words;
       } else if (!layout.long_branch_sgpr) {
         auto sgpr = reserve_long_branch_sgpr_pair(kernel_context);
-        if (!sgpr)
+        if (!sgpr) {
+          patched_control_flow = {
+              .ok = false,
+              .failure = TextLayoutFailureCategory::ResourceLimit,
+              .source_offset = patched_control_flow.source_offset,
+              .required_windows = {},
+              .message =
+                  "long direct branch requires an additional descriptor-backed SGPR pair after "
+                  "semantic expansion",
+          };
           break;
+        }
         layout.long_branch_sgpr = *sgpr;
       } else {
         break;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
@@ -841,6 +841,8 @@ translate_one_descriptor(rj_code_arch_t guest_arch, rj_code_arch_t host_arch,
   if (!target_private_size)
     append_descriptor_error(result, "private segment size plus lowering addend overflows 32 bits");
   result.target_private_size = target_private_size.value_or(0);
+  result.uses_dynamic_stack =
+      AMDHSA_BITS_GET(src.kernel_code_properties, kd::KERNEL_CODE_PROPERTY_USES_DYNAMIC_STACK) != 0;
   const auto requested_lds_size_checked =
       util::checked_add(src.group_segment_fixed_size, options.group_segment_fixed_size_addend);
   if (!requested_lds_size_checked)
@@ -954,6 +956,7 @@ void KdTranslation::configure_skipped_stub() {
   kernarg_wrapper_original_pointer_offset = 0;
   lds_overflow_kernarg_pointer_offset = 0;
   target_private_size = 0;
+  uses_dynamic_stack = false;
   target_user_sgpr_count = 0;
   source_user_sgpr_count = 0;
   user_sgpr_repair_start = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.h
@@ -164,6 +164,9 @@ struct KernelResourcePlan {
   /// @brief Per-lane private segment size encoded in the target descriptor.
   uint32_t target_private_size = 0;
 
+  /// @brief Whether the source kernel uses a runtime-managed dynamic call stack.
+  bool uses_dynamic_stack = false;
+
   /// @brief Target descriptor wavefront size.
   uint8_t target_wave_size = 64;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -4,6 +4,7 @@
 /// @file semantic/gfx1250_b0_to_a0.cpp
 /// @brief Handwritten semantic expansions for gfx1250 B0-to-A0 translation.
 
+#include "rocjitsu/analysis/def_use_chain.h"
 #include "rocjitsu/analysis/liveness.h"
 #include "rocjitsu/code/dbt/semantic/rules.h"
 #include "rocjitsu/code/dbt/semantic_scratch.h"
@@ -17,6 +18,7 @@
 #include <algorithm>
 #include <array>
 #include <cstring>
+#include <limits>
 #include <optional>
 #include <span>
 #include <string_view>
@@ -45,6 +47,7 @@ constexpr uint8_t kGfx1250M0 = 125;
 constexpr uint16_t kWmmaScaleSrc2PrefixOp = 0x35;
 constexpr uint16_t kWmmaScale16PrefixOp = 0x3a;
 constexpr uint16_t kGfx1250InlineZero = 128;
+constexpr uint32_t kGfx1250ScratchMaxDwordOffset = 0x7ffffcu;
 
 /// @brief Diagnose control fields that are invalid for floating-point WMMA.
 ///
@@ -98,6 +101,278 @@ void append_gfx1250_vgpr_msb_transition(std::vector<uint32_t> &words, uint8_t &c
       static_cast<uint16_t>(new_mode) | (static_cast<uint16_t>(current_mode) << 8);
   append_words(words, gfx1250::build_sopp(gfx1250::kSSetVgprMsbSopp, {.simm16 = immediate}));
   current_mode = new_mode;
+}
+
+[[nodiscard]] std::optional<uint8_t> gfx1250_vgpr_mode_before(const Instruction &inst,
+                                                              const LivenessAnalysis &liveness) {
+  const auto src0_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src0);
+  const auto src1_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src1);
+  const auto src2_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src2);
+  const auto dst_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Dst);
+  if (!src0_bank || !src1_bank || !src2_bank || !dst_bank)
+    return std::nullopt;
+  return static_cast<uint8_t>(*src0_bank | (*src1_bank << 2) | (*src2_bank << 4) |
+                              (*dst_bank << 6));
+}
+
+/// @brief Save or restore one spill-backed low-bank VGPR lease through scratch ST mode.
+///
+/// @details VSCRATCH ST mode uses NULL SADDR, SVE=0, and a signed 24-bit
+/// immediate. Semantic spill storage is non-negative and dword aligned, so the
+/// largest usable dword offset is 0x7ffffc. The caller selects VGPR-MSB mode
+/// zero before using this helper.
+[[nodiscard]] bool append_gfx1250_scratch_preservation(std::vector<uint32_t> &words,
+                                                       const SemanticScratchLease &lease,
+                                                       bool restore) {
+  if (!lease.spilled)
+    return true;
+  if (lease.reg_class != RegClass::VGPR || lease.count == 0 ||
+      static_cast<uint32_t>(lease.base) + lease.count > 256u ||
+      lease.spill_offset + (static_cast<uint32_t>(lease.count) - 1u) * sizeof(uint32_t) >
+          kGfx1250ScratchMaxDwordOffset) {
+    return false;
+  }
+
+  for (uint16_t i = 0; i < lease.count; ++i) {
+    const uint8_t vgpr = static_cast<uint8_t>(lease.base + i);
+    const uint32_t byte_offset = lease.spill_offset + static_cast<uint32_t>(i) * sizeof(uint32_t);
+    append_words(words, gfx1250::build_vscratch(restore ? gfx1250::kScratchLoadB32Vscratch
+                                                        : gfx1250::kScratchStoreB32Vscratch,
+                                                {.saddr = kGfx1250Null,
+                                                 .vdst = restore ? vgpr : uint8_t{0},
+                                                 .vsrc = restore ? uint8_t{0} : vgpr,
+                                                 .ioffset = byte_offset}));
+  }
+  append_words(
+      words, gfx1250::build_sopp(restore ? gfx1250::kSWaitLoadcntSopp : gfx1250::kSWaitStorecntSopp,
+                                 {.simm16 = 0}));
+  return true;
+}
+
+/// @brief Drain outstanding source operations before generated scratch writes.
+///
+/// @details Liveness does not model asynchronous completion. A register can be
+/// selected as scratch while an earlier memory operation still owns a pending
+/// write to it, allowing a late completion to corrupt the replacement.
+///
+/// TODO: Split SGPR-only paths to KMCNT and VGPR paths to their producer
+/// counters. Per-register producer tracking is still needed to preserve
+/// nonzero guest wait counts instead of draining each selected counter to zero.
+void append_gfx1250_scratch_dependency_barrier(std::vector<uint32_t> &words) {
+  append_words(words, gfx1250::build_sopp(gfx1250::kSWaitIdleSopp));
+}
+
+/// @brief How a live SGPR window is carried through low-bank VGPRs.
+enum class Gfx1250SgprCarrierMode : uint8_t {
+  None,       ///< Borrow only dead SGPRs; do not fall back to a carrier.
+  ExecMasked, ///< Broadcast through active lanes and allow spill-backed carriers.
+  LaneZero,   ///< Use EXEC-independent lane-zero operations without carrier spills.
+};
+
+/// @brief Ordinary SGPRs borrowed by one replacement sequence.
+///
+/// @details When the SGPR window is live, `carrier` holds its wave-uniform
+/// values in low-bank VGPRs. The ordinary semantic scratch allocator may in
+/// turn preserve EXEC-masked carrier VGPRs through private memory.
+struct Gfx1250SgprScratchLease {
+  uint16_t base = 0;
+  uint16_t count = 0;
+  std::optional<SemanticScratchLease> carrier;
+  Gfx1250SgprCarrierMode carrier_mode = Gfx1250SgprCarrierMode::None;
+
+  [[nodiscard]] bool has_carrier() const { return carrier.has_value(); }
+};
+
+/// @brief Constraints for one gfx1250 SGPR scratch allocation.
+///
+/// @details Current users request independent Wave32 masks or individual SGPRs,
+/// so none requires tuple alignment. Add an explicit alignment constraint if a
+/// future rule borrows an architectural SGPR tuple.
+struct Gfx1250SgprScratchRequest {
+  uint16_t count = 0;
+  RegisterSet forbidden;
+  Gfx1250SgprCarrierMode carrier_mode = Gfx1250SgprCarrierMode::None;
+};
+
+constexpr uint16_t kGfx1250MaxScratchSgprs =
+    static_cast<uint16_t>(amdgpu::RdnaIsaBase::MAX_SGPRS_PER_WF);
+constexpr uint16_t kGfx1250ScratchBaseSgprBegin = 102;
+constexpr uint16_t kGfx1250ScratchBaseSgprEnd = 104;
+
+/// @brief Registers whose source value or destination result must survive a rule.
+///
+/// @details InstDefUse reports encoded VGPR indices without VGPR-MSB state.
+/// Every allocator receiving this set is capped at the low 256-register bank
+/// and generated carrier code explicitly selects that bank, so an encoded
+/// high-bank operand conservatively forbids its low-bank alias. Supporting
+/// high-bank scratch requires physicalizing this set first.
+[[nodiscard]] RegisterSet gfx1250_instruction_registers(const Instruction &inst) {
+  const InstDefUse def_use(inst);
+  return def_use.uses | def_use.defs;
+}
+
+/// @brief Whether an ordinary SGPR window satisfies one scratch request.
+///
+/// @details gfx1250 provides 106 ordinary SGPRs, so this target-specific
+/// allocator deliberately extends beyond the generic 102-SGPR ceiling and can
+/// use s104/s105. It excludes s102/s103 because a write to either register
+/// requires a dependency wait before a later `src_flat_scratch_base` read,
+/// which a local replacement cannot place in downstream guest code.
+[[nodiscard]] bool gfx1250_sgpr_window_allowed(uint16_t base,
+                                               const Gfx1250SgprScratchRequest &request) {
+  const uint32_t end = static_cast<uint32_t>(base) + request.count;
+  if (request.count == 0 || end > kGfx1250MaxScratchSgprs) {
+    return false;
+  }
+  if (base < kGfx1250ScratchBaseSgprEnd && end > kGfx1250ScratchBaseSgprBegin) {
+    return false;
+  }
+
+  RegisterSet candidate;
+  candidate.expand({RegClass::SGPR, base, static_cast<uint8_t>(request.count)});
+  return !candidate.intersects(request.forbidden);
+}
+
+/// @brief Prefer dead SGPRs, then preserve a live SGPR window through VGPRs.
+///
+/// @details SGPR values cannot be preserved directly by
+/// SemanticScratchAllocator, whose leases are low-bank VGPRs. When
+/// `carrier_mode` is not None, `allocator` supplies those VGPR carriers;
+/// passing a null allocator deliberately disables carrier fallback.
+[[nodiscard]] std::optional<Gfx1250SgprScratchLease>
+acquire_gfx1250_sgprs(const Instruction &inst, const LivenessAnalysis &liveness,
+                      TranslationContext &context, SemanticScratchAllocator *allocator,
+                      const Gfx1250SgprScratchRequest &request) {
+  if (request.count == 0 || request.count > kGfx1250MaxScratchSgprs ||
+      !liveness.has_live_before(inst))
+    return std::nullopt;
+
+  const RegisterSet &live = liveness.live_before(inst);
+  for (uint16_t base = 0; static_cast<uint32_t>(base) + request.count <= kGfx1250MaxScratchSgprs;
+       ++base) {
+    if (!gfx1250_sgpr_window_allowed(base, request))
+      continue;
+    RegisterSet candidate;
+    candidate.expand({RegClass::SGPR, base, static_cast<uint8_t>(request.count)});
+    if (!candidate.intersects(live)) {
+      context.require_sgprs(static_cast<uint32_t>(base) + request.count);
+      return Gfx1250SgprScratchLease{.base = base,
+                                     .count = request.count,
+                                     .carrier = std::nullopt,
+                                     .carrier_mode = Gfx1250SgprCarrierMode::None};
+    }
+  }
+
+  if (request.carrier_mode == Gfx1250SgprCarrierMode::None || allocator == nullptr)
+    return std::nullopt;
+
+  std::optional<uint16_t> victim;
+  for (uint16_t base = 0; static_cast<uint32_t>(base) + request.count <= kGfx1250MaxScratchSgprs;
+       ++base) {
+    if (gfx1250_sgpr_window_allowed(base, request)) {
+      victim = base;
+      break;
+    }
+  }
+  if (!victim)
+    return std::nullopt;
+
+  SemanticScratchRequest carrier_request;
+  carrier_request.count = request.count;
+  carrier_request.forbidden = request.forbidden;
+  // Lane-zero carriers must remain EXEC-independent, while private-memory
+  // spill/fill instructions are EXEC-masked.
+  // TODO: Support simultaneous SGPR/VGPR pressure without suppressing the
+  // guest instruction's memory-counter contribution.
+  carrier_request.allow_spill = request.carrier_mode == Gfx1250SgprCarrierMode::ExecMasked;
+  const SemanticScratchResult carrier = allocator->acquire_vgprs(carrier_request);
+  // TODO: Return the carrier failure alongside the lease so a rejected
+  // dynamic-stack spill can retain its actionable rule-specific diagnostic.
+  if (!carrier)
+    return std::nullopt;
+
+  context.require_sgprs(static_cast<uint32_t>(*victim) + request.count);
+  return Gfx1250SgprScratchLease{.base = *victim,
+                                 .count = request.count,
+                                 .carrier = *carrier.lease,
+                                 .carrier_mode = request.carrier_mode};
+}
+
+/// @brief Save or restore a live SGPR lease through its low-bank VGPR carriers.
+///
+/// @details The caller must select VGPR-MSB mode zero. ExecMasked carriers
+/// broadcast through active lanes and require a forward EXEC-zero guard around
+/// the complete replacement. LaneZero carriers use EXEC-independent lane
+/// operations and cannot themselves be spill-backed.
+[[nodiscard]] bool append_gfx1250_sgpr_preservation(std::vector<uint32_t> &words,
+                                                    const Gfx1250SgprScratchLease &lease,
+                                                    bool restore) {
+  if (!lease.has_carrier())
+    return true;
+  const SemanticScratchLease &carrier = *lease.carrier;
+  if (carrier.reg_class != RegClass::VGPR || carrier.count != lease.count ||
+      static_cast<uint32_t>(carrier.base) + carrier.count > 256u)
+    return false;
+
+  if (lease.carrier_mode == Gfx1250SgprCarrierMode::LaneZero) {
+    if (carrier.spilled)
+      return false;
+    for (uint16_t i = 0; i < lease.count; ++i) {
+      if (restore) {
+        append_words(words,
+                     gfx1250::build_vop3(gfx1250::kVReadlaneB32Vop3,
+                                         {.vdst = static_cast<uint8_t>(lease.base + i),
+                                          .src0 = static_cast<uint16_t>(256u + carrier.base + i),
+                                          .src1 = kGfx1250InlineZero}));
+      } else {
+        append_words(words, gfx1250::build_vop3(gfx1250::kVWritelaneB32Vop3,
+                                                {.vdst = static_cast<uint8_t>(carrier.base + i),
+                                                 .src0 = static_cast<uint16_t>(lease.base + i),
+                                                 .src1 = kGfx1250InlineZero}));
+      }
+    }
+    return true;
+  }
+  if (lease.carrier_mode != Gfx1250SgprCarrierMode::ExecMasked)
+    return false;
+
+  if (!restore) {
+    if (!append_gfx1250_scratch_preservation(words, carrier, false))
+      return false;
+    for (uint16_t i = 0; i < lease.count; ++i) {
+      append_words(words, gfx1250::build_vop1(gfx1250::kVMovB32Vop1,
+                                              {.src0 = static_cast<uint16_t>(lease.base + i),
+                                               .vdst = static_cast<uint8_t>(carrier.base + i)}));
+    }
+    return true;
+  }
+
+  for (uint16_t i = 0; i < lease.count; ++i) {
+    append_words(words, gfx1250::build_vop1(gfx1250::kVReadfirstlaneB32Vop1,
+                                            {.src0 = static_cast<uint16_t>(256u + carrier.base + i),
+                                             .vdst = static_cast<uint8_t>(lease.base + i)}));
+  }
+  return append_gfx1250_scratch_preservation(words, carrier, true);
+}
+
+/// @brief Skip an EXEC-masked vector replacement when EXEC has no active lane.
+///
+/// @details The caller must prove that the guest instruction and every generated
+/// effect are inactive under EXEC=0. Call only after the replacement word list
+/// is final so its PC-relative target remains the first following instruction.
+///
+/// TODO: Share the branch-distance check with the CDNA EXECZ guards after the
+/// architecture-specific SOPP builders have a common callback-based emitter.
+[[nodiscard]] bool prepend_gfx1250_execz_guard_for_masked_replacement(std::vector<uint32_t> &words,
+                                                                      bool required) {
+  if (!required)
+    return true;
+  if (words.size() > static_cast<size_t>(std::numeric_limits<int16_t>::max()))
+    return false;
+  words.insert(words.begin(),
+               gfx1250::build_sopp(gfx1250::kSCbranchExeczSopp,
+                                   {.simm16 = static_cast<uint16_t>(words.size())})[0]);
+  return true;
 }
 
 /// @brief Conservatively remove one hard-clause scheduling directive.
@@ -369,7 +644,7 @@ struct TensorMaskWrapper {
 ExpandResult expand_gfx1250_tensor_load_to_lds(const Instruction &inst, uint32_t, uint64_t,
                                                std::span<const uint8_t>,
                                                const LivenessAnalysis &liveness,
-                                               TranslationContext &, const LaneLayout *,
+                                               TranslationContext &context, const LaneLayout *,
                                                const LaneLayout *) {
   if (inst.mnemonic() != "tensor_load_to_lds" ||
       inst.size() != static_cast<int>(sizeof(gfx1250::VimageMachineInst)) ||
@@ -393,17 +668,21 @@ ExpandResult expand_gfx1250_tensor_load_to_lds(const Instruction &inst, uint32_t
         inst.raw_encoding() + sizeof(gfx1250::VimageMachineInst) / sizeof(uint32_t)));
   }
 
-  const std::optional<uint16_t> scratch = liveness.find_free_sgpr(&inst);
-  if (!scratch || *scratch > kLastOrdinarySgpr) {
-    return ExpandResult::failed(
-        "gfx1250 tensor-load mask rule could not allocate a dead scratch SGPR",
-        {"Provide one dead ordinary SGPR to preserve the descriptor mask word."});
+  Gfx1250SgprScratchRequest scratch_request;
+  scratch_request.count = 1;
+  scratch_request.forbidden = gfx1250_instruction_registers(inst);
+  const auto scratch = acquire_gfx1250_sgprs(inst, liveness, context, nullptr, scratch_request);
+  if (!scratch || scratch->base > kLastOrdinarySgpr) {
+    return ExpandResult::failed("gfx1250 tensor-load mask rule could not allocate scalar scratch",
+                                {"Provide one dead ordinary SGPR."});
   }
 
   std::vector<uint32_t> words;
   words.reserve(6);
+  append_gfx1250_scratch_dependency_barrier(words);
+
   const TensorMaskWrapper wrapper =
-      build_tensor_mask_wrapper(descriptor_base, static_cast<uint8_t>(*scratch));
+      build_tensor_mask_wrapper(descriptor_base, static_cast<uint8_t>(scratch->base));
   words.push_back(wrapper.save);
   // PACK_HH forms {SRC1[31:16], SRC0[31:16]}. Inline zero as SRC0 clears
   // D1[15:0] while preserving all descriptor fields in D1[31:16].
@@ -411,6 +690,7 @@ ExpandResult expand_gfx1250_tensor_load_to_lds(const Instruction &inst, uint32_t
   words.insert(words.end(), inst.raw_encoding(),
                inst.raw_encoding() + sizeof(gfx1250::VimageMachineInst) / sizeof(uint32_t));
   words.push_back(wrapper.restore);
+
   return ExpandResult::success(std::move(words));
 }
 
@@ -793,8 +1073,12 @@ ExpandResult expand_gfx1250_wmma_iu8_spacing(const Instruction &inst, uint32_t, 
 ///
 /// @details Every cluster-load form (both SADDR and off/NULL-saddr, all widths)
 /// is left as a cluster load and wrapped so it executes with M0 forced to zero:
-/// save M0 to a dead SGPR, set M0 = 0, run the load, then restore M0. The opcode
+/// save M0 to a scratch SGPR, set M0 = 0, run the load, then restore M0. The opcode
 /// is not changed.
+///
+/// Under full SGPR pressure, EXEC-independent lane-zero operations carry one
+/// live SGPR through a dead low-bank VGPR. This keeps the guest cluster load
+/// itself unconditional and therefore preserves its wait-counter contribution.
 ///
 /// A second translation preserves the load when its immediately preceding
 /// decoded instruction in the same basic block is the canonical M0 clear. This
@@ -803,7 +1087,7 @@ ExpandResult expand_gfx1250_wmma_iu8_spacing(const Instruction &inst, uint32_t, 
 /// condition must be revisited if such a rule is added.
 ExpandResult expand_gfx1250_cluster_load(const Instruction &inst, uint32_t, uint64_t,
                                          std::span<const uint8_t>, const LivenessAnalysis &liveness,
-                                         TranslationContext &, const LaneLayout *,
+                                         TranslationContext &context, const LaneLayout *,
                                          const LaneLayout *) {
   if (!is_gfx1250_cluster_load(inst.opcode()) ||
       inst.size() != 3 * static_cast<int>(sizeof(uint32_t)) || inst.raw_encoding() == nullptr) {
@@ -815,10 +1099,18 @@ ExpandResult expand_gfx1250_cluster_load(const Instruction &inst, uint32_t, uint
         std::vector<uint32_t>(inst.raw_encoding(), inst.raw_encoding() + 3));
   }
 
-  const std::optional<uint16_t> scratch = liveness.find_free_sgpr(&inst);
-  if (!scratch || *scratch > 105) {
+  SemanticScratchAllocator allocator(
+      inst, liveness, context,
+      SemanticScratchPolicy{.max_vgprs = 256,
+                            .max_spill_dword_offset = kGfx1250ScratchMaxDwordOffset});
+  Gfx1250SgprScratchRequest scratch_request;
+  scratch_request.count = 1;
+  scratch_request.forbidden = gfx1250_instruction_registers(inst);
+  scratch_request.carrier_mode = Gfx1250SgprCarrierMode::LaneZero;
+  const auto scratch = acquire_gfx1250_sgprs(inst, liveness, context, &allocator, scratch_request);
+  if (!scratch || scratch->base > 105) {
     return ExpandResult::failed(
-        "gfx1250 cluster load could not allocate a dead SGPR for M0 preservation");
+        "gfx1250 cluster load could not allocate scalar scratch for M0 preservation");
   }
 
   // Save M0 to scratch, set M0 = 0, run the load, then restore M0. A binary
@@ -829,15 +1121,35 @@ ExpandResult expand_gfx1250_cluster_load(const Instruction &inst, uint32_t, uint
   // MUST use kGfx1250M0 (125): on gfx1250 M0 encodes as 125 and NULL as 124 (the
   // inverse of CDNA), so a write to 124 would be a discarded NULL write.
   std::vector<uint32_t> words;
-  words.reserve(6);
-  append_words(words,
-               gfx1250::build_sop1(gfx1250::kSMovB32Sop1,
-                                   {.ssrc0 = kGfx1250M0, .sdst = static_cast<uint8_t>(*scratch)}));
+  words.reserve(18);
+  append_gfx1250_scratch_dependency_barrier(words);
+  uint8_t current_mode = 0;
+  std::optional<uint8_t> original_mode;
+  if (scratch->has_carrier()) {
+    original_mode = gfx1250_vgpr_mode_before(inst, liveness);
+    if (!original_mode)
+      return ExpandResult::failed(
+          "gfx1250 cluster-load SGPR carrier cannot prove the VGPR-MSB mode");
+    current_mode = *original_mode;
+    append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+    if (!append_gfx1250_sgpr_preservation(words, *scratch, false))
+      return ExpandResult::failed("gfx1250 cluster load could not preserve scalar scratch");
+    append_gfx1250_vgpr_msb_transition(words, current_mode, *original_mode);
+  }
+  append_words(words, gfx1250::build_sop1(
+                          gfx1250::kSMovB32Sop1,
+                          {.ssrc0 = kGfx1250M0, .sdst = static_cast<uint8_t>(scratch->base)}));
   words.push_back(build_cluster_m0_clear());
   words.insert(words.end(), inst.raw_encoding(), inst.raw_encoding() + 3);
-  append_words(words,
-               gfx1250::build_sop1(gfx1250::kSMovB32Sop1,
-                                   {.ssrc0 = static_cast<uint8_t>(*scratch), .sdst = kGfx1250M0}));
+  append_words(words, gfx1250::build_sop1(
+                          gfx1250::kSMovB32Sop1,
+                          {.ssrc0 = static_cast<uint8_t>(scratch->base), .sdst = kGfx1250M0}));
+  if (scratch->has_carrier()) {
+    append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+    if (!append_gfx1250_sgpr_preservation(words, *scratch, true))
+      return ExpandResult::failed("gfx1250 cluster load could not restore scalar scratch");
+    append_gfx1250_vgpr_msb_transition(words, current_mode, *original_mode);
+  }
   return ExpandResult::success(std::move(words));
 }
 
@@ -868,22 +1180,6 @@ ExpandResult expand_gfx1250_ds_addtid(const Instruction &inst, uint32_t, uint64_
 
   gfx1250::VdsMachineInst source{};
   std::memcpy(&source, inst.raw_encoding(), sizeof(source));
-  uint16_t temp = source.vdst;
-  std::optional<SemanticScratchResult> store_scratch;
-  if (is_store) {
-    SemanticScratchAllocator allocator(
-        inst, liveness, context,
-        SemanticScratchPolicy{.max_vgprs = 256, .max_spill_dword_offset = 0});
-    SemanticScratchRequest request;
-    request.count = 1;
-    request.allow_spill = false;
-    store_scratch = allocator.acquire_vgprs(request);
-    if (!*store_scratch) {
-      return ExpandResult::failed(
-          "gfx1250 DS store ADDTID could not allocate a dead low-bank scratch VGPR");
-    }
-    temp = (*store_scratch).lease->base;
-  }
 
   const auto src0_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src0);
   const auto src1_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src1);
@@ -894,14 +1190,42 @@ ExpandResult expand_gfx1250_ds_addtid(const Instruction &inst, uint32_t, uint64_
   }
   const uint8_t original_mode =
       static_cast<uint8_t>(*src0_bank | (*src1_bank << 2) | (*src2_bank << 4) | (*dst_bank << 6));
+
+  uint16_t temp = source.vdst;
+  std::optional<SemanticScratchLease> store_scratch;
+  if (is_store) {
+    SemanticScratchAllocator allocator(
+        inst, liveness, context,
+        SemanticScratchPolicy{.max_vgprs = 256,
+                              .max_spill_dword_offset = kGfx1250ScratchMaxDwordOffset});
+    SemanticScratchRequest request;
+    request.count = 1;
+    request.forbidden = gfx1250_instruction_registers(inst);
+    request.allow_spill = true;
+    const SemanticScratchResult scratch = allocator.acquire_vgprs(request);
+    if (!scratch) {
+      if (scratch.failure == SemanticScratchFailure::DynamicStackUnsupported) {
+        return ExpandResult::failed(
+            "gfx1250 DS store ADDTID cannot use private-memory spills in a dynamic-stack kernel");
+      }
+      return ExpandResult::failed("gfx1250 DS store ADDTID could not allocate low-bank scratch");
+    }
+    store_scratch = *scratch.lease;
+    temp = store_scratch->base;
+  }
   const uint8_t compute_bank = is_load ? *dst_bank : 0;
   const uint8_t compute_mode = static_cast<uint8_t>(compute_bank | (compute_bank << 2) |
                                                     (compute_bank << 4) | (compute_bank << 6));
 
   std::vector<uint32_t> words;
-  words.reserve(18);
+  words.reserve(26);
+  append_gfx1250_scratch_dependency_barrier(words);
   uint8_t current_mode = original_mode;
   append_gfx1250_vgpr_msb_transition(words, current_mode, compute_mode);
+  if (store_scratch && store_scratch->spilled &&
+      !append_gfx1250_scratch_preservation(words, *store_scratch, false)) {
+    return ExpandResult::failed("gfx1250 DS store ADDTID could not preserve low-bank scratch");
+  }
   append_words(
       words, gfx1250::build_vop3(gfx1250::kVMbcntLoU32B32Vop3, {.vdst = static_cast<uint8_t>(temp),
                                                                 .src0 = 193, // inline -1
@@ -936,6 +1260,13 @@ ExpandResult expand_gfx1250_ds_addtid(const Instruction &inst, uint32_t, uint64_
                                             .offset1 = static_cast<uint8_t>(source.offset1),
                                             .addr = static_cast<uint8_t>(temp),
                                             .data0 = static_cast<uint8_t>(source.data0)}));
+    if (store_scratch && store_scratch->spilled) {
+      append_words(words, gfx1250::build_sopp(gfx1250::kSWaitDscntSopp, {.simm16 = 0}));
+      append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+      if (!append_gfx1250_scratch_preservation(words, *store_scratch, true)) {
+        return ExpandResult::failed("gfx1250 DS store ADDTID could not restore low-bank scratch");
+      }
+    }
     append_gfx1250_vgpr_msb_transition(words, current_mode, original_mode);
   } else {
     append_words(words, gfx1250::build_vds(gfx1250::kDsLoadB32Vds,
@@ -969,26 +1300,37 @@ ExpandResult expand_gfx1250_cvt_f32_fp8_e5m3(const Instruction &inst, uint32_t, 
 
   SemanticScratchAllocator allocator(
       inst, liveness, context,
-      SemanticScratchPolicy{.max_vgprs = 256, .max_spill_dword_offset = 0});
+      SemanticScratchPolicy{.max_vgprs = 256,
+                            .max_spill_dword_offset = kGfx1250ScratchMaxDwordOffset});
   SemanticScratchRequest request;
   request.count = 2;
-  request.allow_spill = false;
+  request.forbidden = gfx1250_instruction_registers(inst);
+  request.allow_spill = true;
   const SemanticScratchResult scratch = allocator.acquire_vgprs(request);
   if (!scratch) {
+    if (scratch.failure == SemanticScratchFailure::DynamicStackUnsupported) {
+      return ExpandResult::failed(
+          "gfx1250 E5M3 unpack cannot use private-memory spills in a dynamic-stack kernel");
+    }
     return ExpandResult::failed("gfx1250 E5M3 unpack could not allocate two scratch VGPRs");
   }
   const uint16_t out = scratch.lease->base;
   const uint16_t temp = static_cast<uint16_t>(out + 1u);
 
-  const std::optional<uint16_t> nan_mask = liveness.find_free_sgpr(&inst);
-  const std::optional<uint16_t> exp31_mask =
-      nan_mask ? liveness.find_free_sgpr(&inst, static_cast<uint16_t>(*nan_mask + 1u))
-               : std::nullopt;
-  // The allocator searches only REGISTER_SET_ALLOCATABLE_SGPRS, so successful
-  // results are already ordinary encodable SGPRs.
-  if (!nan_mask || !exp31_mask) {
-    return ExpandResult::failed("gfx1250 E5M3 unpack could not allocate two dead SGPR masks");
+  Gfx1250SgprScratchRequest mask_request;
+  mask_request.count = 2;
+  mask_request.forbidden = request.forbidden;
+  mask_request.forbidden.expand(scratch.lease->registers());
+  // The conversion, both generated compares, and scratch memory are inactive
+  // under EXEC=0. The compare masks and their carrier save/restore are skipped
+  // as one region, so the borrowed SGPR window remains untouched.
+  mask_request.carrier_mode = Gfx1250SgprCarrierMode::ExecMasked;
+  const auto masks = acquire_gfx1250_sgprs(inst, liveness, context, &allocator, mask_request);
+  if (!masks) {
+    return ExpandResult::failed("gfx1250 E5M3 unpack could not allocate two SGPR masks");
   }
+  const uint16_t nan_mask = masks->base;
+  const uint16_t exp31_mask = static_cast<uint16_t>(masks->base + 1u);
 
   const auto src0_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src0);
   const auto src1_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src1);
@@ -1019,8 +1361,18 @@ ExpandResult expand_gfx1250_cvt_f32_fp8_e5m3(const Instruction &inst, uint32_t, 
   const uint8_t byte_sel =
       static_cast<uint8_t>(((source.opsel & 1u) << 1u) | ((source.opsel & 2u) >> 1u));
   std::vector<uint32_t> words;
-  words.reserve(40);
+  words.reserve(64);
+  append_gfx1250_scratch_dependency_barrier(words);
   uint8_t current_mode = original_mode;
+  if (scratch.lease->spilled || masks->has_carrier()) {
+    append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+    if (!append_gfx1250_scratch_preservation(words, *scratch.lease, false)) {
+      return ExpandResult::failed("gfx1250 E5M3 unpack could not preserve its scratch VGPRs");
+    }
+    if (!append_gfx1250_sgpr_preservation(words, *masks, false)) {
+      return ExpandResult::failed("gfx1250 E5M3 unpack could not preserve its SGPR masks");
+    }
+  }
   append_gfx1250_vgpr_msb_transition(words, current_mode, extract_mode);
   append_words(
       words, gfx1250::build_vop3(gfx1250::kVBfeU32Vop3,
@@ -1030,9 +1382,9 @@ ExpandResult expand_gfx1250_cvt_f32_fp8_e5m3(const Instruction &inst, uint32_t, 
                                   .src2 = gfx1250_inline_u32(8)}));
   append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
 
-  append_compare_literal(words, gfx1250::kVCmpEqU32Vop3, static_cast<uint8_t>(*nan_mask),
+  append_compare_literal(words, gfx1250::kVCmpEqU32Vop3, static_cast<uint8_t>(nan_mask),
                          gfx1250_vgpr_src(out), 0xffu);
-  append_compare_literal(words, gfx1250::kVCmpLtU32Vop3, static_cast<uint8_t>(*exp31_mask),
+  append_compare_literal(words, gfx1250::kVCmpLtU32Vop3, static_cast<uint8_t>(exp31_mask),
                          gfx1250_vgpr_src(out), 0xf7u);
   append_words(words,
                gfx1250::build_vop3(gfx1250::kVAndB32Vop3, {.vdst = static_cast<uint8_t>(temp),
@@ -1057,7 +1409,7 @@ ExpandResult expand_gfx1250_cvt_f32_fp8_e5m3(const Instruction &inst, uint32_t, 
                gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3, {.vdst = static_cast<uint8_t>(out),
                                                                .src0 = gfx1250_vgpr_src(out),
                                                                .src1 = gfx1250_vgpr_src(temp),
-                                                               .src2 = *exp31_mask}));
+                                                               .src2 = exp31_mask}));
   append_vop3_literal(words, gfx1250::kVMovB32Vop3,
                       {.vdst = static_cast<uint8_t>(temp), .src0 = 255}, 0x7fa3d000u);
 
@@ -1067,8 +1419,19 @@ ExpandResult expand_gfx1250_cvt_f32_fp8_e5m3(const Instruction &inst, uint32_t, 
                                           {.vdst = static_cast<uint8_t>(source.vdst),
                                            .src0 = gfx1250_vgpr_src(out),
                                            .src1 = gfx1250_vgpr_src(temp),
-                                           .src2 = *nan_mask}));
+                                           .src2 = nan_mask}));
+  if (scratch.lease->spilled || masks->has_carrier()) {
+    append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+    if (!append_gfx1250_sgpr_preservation(words, *masks, true)) {
+      return ExpandResult::failed("gfx1250 E5M3 unpack could not restore its SGPR masks");
+    }
+    if (!append_gfx1250_scratch_preservation(words, *scratch.lease, true)) {
+      return ExpandResult::failed("gfx1250 E5M3 unpack could not restore its scratch VGPRs");
+    }
+  }
   append_gfx1250_vgpr_msb_transition(words, current_mode, original_mode);
+  if (!prepend_gfx1250_execz_guard_for_masked_replacement(words, masks->has_carrier()))
+    return ExpandResult::failed("gfx1250 E5M3 unpack SGPR-carrier guard is too large");
   return ExpandResult::success(std::move(words));
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_scratch.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_scratch.cpp
@@ -97,6 +97,10 @@ SemanticScratchAllocator::acquire_vgprs(const SemanticScratchRequest &request) {
   if (!victim)
     return {.lease = std::nullopt, .failure = SemanticScratchFailure::NoRegisterWindow};
 
+  if (context_.uses_dynamic_stack) {
+    return {.lease = std::nullopt, .failure = SemanticScratchFailure::DynamicStackUnsupported};
+  }
+
   auto spill = allocate_spill_dwords(request.count);
   if (!spill)
     return {.lease = std::nullopt, .failure = SemanticScratchFailure::SpillOffsetUnencodable};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_scratch.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_scratch.h
@@ -24,6 +24,7 @@ enum class SemanticScratchFailure : uint8_t {
   None,
   InvalidRequest,
   NoRegisterWindow,
+  DynamicStackUnsupported,
   SpillOffsetUnencodable,
 };
 
@@ -88,7 +89,10 @@ struct SemanticScratchResult {
 /// @details Each semantic instruction begins at the same transient frame base,
 /// after persistent kernel-wide semantic storage. Allocations within the frame
 /// advance a cursor so simultaneously-live spill payloads cannot overlap. The
-/// kernel descriptor records only the largest frame high-water mark.
+/// kernel descriptor records only the largest frame high-water mark. The frame
+/// does not know whether private memory above the fixed segment is a
+/// runtime-managed call stack, so it leaves dynamic-stack policy to its callers.
+/// SemanticScratchAllocator rejects reservations that would require a spill.
 class SemanticSpillFrame final {
 public:
   explicit SemanticSpillFrame(TranslationContext &context);
@@ -112,6 +116,8 @@ public:
                            TranslationContext &context, SemanticScratchPolicy policy);
 
   /// @brief Prefer dead VGPRs, then borrow and spill an allowed guest window.
+  /// @details Rejects a spill victim in a dynamic-stack kernel, while allowing
+  ///          a genuinely free VGPR window that does not need private storage.
   [[nodiscard]] SemanticScratchResult acquire_vgprs(const SemanticScratchRequest &request);
 
   /// @brief Reserve additional non-overlapping spill state in this rule's frame.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_rule.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_rule.h
@@ -87,6 +87,9 @@ struct KernelResourceRequirements {
   /// @brief Initial per-lane private segment size from descriptor translation.
   uint32_t private_segment_fixed_size = 0;
 
+  /// @brief Whether private memory above the fixed segment is a dynamic call stack.
+  bool uses_dynamic_stack = false;
+
   /// @brief Minimum per-lane private segment size required after spill-backed lowerings.
   uint32_t required_private_segment_fixed_size = 0;
 
@@ -114,10 +117,11 @@ struct KernelResourceRequirements {
   /// @param accum_base Initial target AccVGPR base.
   /// @param sgprs Initial target SGPR count.
   /// @param private_bytes Initial per-lane private segment size.
+  /// @param dynamic_stack Whether the kernel uses a runtime-managed dynamic stack.
   KernelResourceRequirements(uint32_t vgprs, uint32_t agprs, uint32_t accum_base, uint32_t sgprs,
-                             uint32_t private_bytes = 0)
+                             uint32_t private_bytes = 0, bool dynamic_stack = false)
       : num_vgprs(vgprs), num_agprs(agprs), accum_offset(accum_base), num_sgprs(sgprs),
-        private_segment_fixed_size(private_bytes),
+        private_segment_fixed_size(private_bytes), uses_dynamic_stack(dynamic_stack),
         required_private_segment_fixed_size(private_bytes),
         semantic_spill_persistent_end(private_bytes) {}
 
@@ -259,8 +263,8 @@ struct TranslationContext : KernelResourceRequirements, VirtualLdsTranslationSta
   TranslationContext(uint32_t vgprs, uint32_t sgprs) : KernelResourceRequirements(vgprs, sgprs) {}
 
   TranslationContext(uint32_t vgprs, uint32_t agprs, uint32_t accum_base, uint32_t sgprs,
-                     uint32_t private_bytes = 0)
-      : KernelResourceRequirements(vgprs, agprs, accum_base, sgprs, private_bytes) {}
+                     uint32_t private_bytes = 0, bool dynamic_stack = false)
+      : KernelResourceRequirements(vgprs, agprs, accum_base, sgprs, private_bytes, dynamic_stack) {}
 };
 
 /// @brief Status returned by a semantic EXPAND rule lookup or expansion.

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -2728,7 +2728,23 @@ TEST(LivenessAnalysis, UnavailableQueriesFailClosed) {
   const TestInstruction instruction("query");
   const LivenessAnalysis liveness = LivenessAnalysis::unavailable();
 
+  EXPECT_THROW((void)liveness.has_live_before(instruction), std::logic_error);
   EXPECT_THROW((void)liveness.live_before(instruction), std::logic_error);
+}
+
+TEST(LivenessAnalysis, ReportsWhetherLiveBeforeSnapshotWasMaterialized) {
+  auto blocks = build_test_blocks({TestOpcode::UseSgpr4, TestOpcode::End});
+  const Instruction &use = *blocks.front()->instructions().begin();
+  const TestInstruction outside_scope("outside_scope");
+  const LivenessAnalysis liveness = analyze_scope(blocks);
+
+  EXPECT_TRUE(liveness.has_live_before(use));
+  EXPECT_FALSE(liveness.has_live_before(outside_scope));
+  EXPECT_TRUE(liveness.is_live_before(use, {RegClass::SGPR, 4, 1}))
+      << "the materialized snapshot must contain the register used here";
+  EXPECT_FALSE(liveness.is_live_before(outside_scope, {RegClass::SGPR, 4, 1}))
+      << "a missing snapshot reads as nothing-live, so callers must check "
+         "has_live_before first";
 }
 
 TEST(LivenessAnalysis, ExecMaskedVgprDefDoesNotKillInactiveLaneValue) {

--- a/emulation/rocjitsu/tests/dbt/semantic_scratch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/semantic_scratch_test.cpp
@@ -2,20 +2,62 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocjitsu/analysis/liveness.h"
+#include "rocjitsu/code/basic_block.h"
+#include "rocjitsu/code/code_object.h"
 #include "rocjitsu/code/dbt/semantic/cdna3_scratch.h"
 #include "rocjitsu/code/dbt/semantic_scratch.h"
 #include "rocjitsu/code/dbt/translation_rule.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna3/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/opcodes.h"
+#include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
 
 #include <gtest/gtest.h>
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <vector>
 
 namespace rocjitsu {
 namespace {
+
+// TODO: Consolidate this in-memory code-object fixture with the equivalent
+// liveness and spill-manager test scaffolding.
+class ScratchTestTextSection : public Section {
+public:
+  ScratchTestTextSection(std::unique_ptr<char[]> data, std::size_t size)
+      : Section(".text", std::move(data)), size_(size) {}
+
+  std::size_t size() const override { return size_; }
+  uint32_t sectionHeaderNameIdx() const override { return 0; }
+  uint64_t sectionOffset() const override { return 0; }
+
+private:
+  std::size_t size_;
+};
+
+class ScratchTestCodeObject : public CodeObject {
+public:
+  explicit ScratchTestCodeObject(std::vector<uint32_t> words) {
+    const auto byte_size = words.size() * sizeof(uint32_t);
+    image_.resize(byte_size);
+    std::memcpy(image_.data(), words.data(), byte_size);
+
+    auto data = std::make_unique<char[]>(byte_size);
+    std::memcpy(data.get(), words.data(), byte_size);
+    sections_.push_back(std::make_unique<ScratchTestTextSection>(std::move(data), byte_size));
+    text_sections_.push_back(sections_.back().get());
+  }
+};
+
+std::vector<std::unique_ptr<BasicBlock>> build_scratch_test_blocks() {
+  constexpr auto endpgm = gfx1250::build_sopp(gfx1250::kSEndpgmSopp);
+  ScratchTestCodeObject object({endpgm[0]});
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  return BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+}
 
 TEST(SemanticSpillFrame, SeparatesPersistentAndTransientRanges) {
   TranslationContext context(/*vgprs=*/8, /*agprs=*/0, /*accum_base=*/0,
@@ -111,6 +153,52 @@ TEST(SemanticScratchAllocator, ReportsTargetSpillOffsetLimit) {
 
   EXPECT_FALSE(result);
   EXPECT_EQ(result.failure, SemanticScratchFailure::SpillOffsetUnencodable);
+  EXPECT_EQ(context.required_private_segment_fixed_size, 32u);
+}
+
+TEST(SemanticScratchAllocator, RejectsSpillVictimInDynamicStackKernel) {
+  Instruction inst("scratch_test", nullptr);
+  std::vector<BasicBlock *> blocks;
+  LivenessAnalysis liveness(blocks);
+  // With no live-before snapshot, no register window is proven free, so the
+  // allocator must borrow a victim and exercise the spill policy.
+  ASSERT_FALSE(liveness.has_live_before(inst));
+  TranslationContext context(/*vgprs=*/8, /*agprs=*/0, /*accum_base=*/0,
+                             /*sgprs=*/8, /*private_bytes=*/32);
+  context.uses_dynamic_stack = true;
+  SemanticScratchAllocator allocator(
+      inst, liveness, context, SemanticScratchPolicy{.max_vgprs = 8, .max_spill_dword_offset = 0});
+
+  SemanticScratchRequest request;
+  request.count = 1;
+  const SemanticScratchResult result = allocator.acquire_vgprs(request);
+
+  EXPECT_FALSE(result);
+  EXPECT_EQ(result.failure, SemanticScratchFailure::DynamicStackUnsupported);
+  EXPECT_EQ(context.required_private_segment_fixed_size, 32u);
+}
+
+TEST(SemanticScratchAllocator, AllowsFreeWindowInDynamicStackKernel) {
+  auto blocks = build_scratch_test_blocks();
+  std::vector<BasicBlock *> scope;
+  for (const auto &block : blocks)
+    scope.push_back(block.get());
+  const Instruction &inst = *blocks.front()->instructions().begin();
+  LivenessAnalysis liveness(scope);
+  TranslationContext context(/*vgprs=*/8, /*agprs=*/0, /*accum_base=*/0,
+                             /*sgprs=*/8, /*private_bytes=*/32);
+  context.uses_dynamic_stack = true;
+  SemanticScratchAllocator allocator(
+      inst, liveness, context, SemanticScratchPolicy{.max_vgprs = 8, .max_spill_dword_offset = 0});
+
+  SemanticScratchRequest request;
+  request.count = 1;
+  const SemanticScratchResult result = allocator.acquire_vgprs(request);
+
+  ASSERT_TRUE(result);
+  EXPECT_EQ(result.failure, SemanticScratchFailure::None);
+  EXPECT_FALSE(result.lease->spilled);
+  EXPECT_EQ(result.lease->base, 0u);
   EXPECT_EQ(context.required_private_segment_fixed_size, 32u);
 }
 

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -595,8 +595,8 @@ template <size_t N>
 std::vector<uint8_t>
 make_gfx1250_image_with_live_sgprs(const std::array<uint32_t, N> &instruction_words,
                                    uint16_t live_sgprs) {
-  if (live_sgprs > REGISTER_SET_ALLOCATABLE_SGPRS) {
-    ADD_FAILURE() << "liveness wall exceeds the allocatable SGPR range";
+  if (live_sgprs > REGISTER_SET_MAX_SGPRS) {
+    ADD_FAILURE() << "liveness wall exceeds the gfx1250 ordinary SGPR range";
     return {};
   }
   constexpr uint16_t kGfx1250M0Operand = 125;
@@ -4953,6 +4953,59 @@ TEST(BinaryTranslatorE2E, Gfx1250LongDirectBranchGrowthIsIdempotent) {
   ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
                                                           : second.diagnostics.front().message);
   EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250LongBranchReportsSgprExhaustionAfterSemanticExpansion) {
+  using namespace rocr::llvm::amdhsa;
+
+  constexpr size_t kTargetWord = 0x8000;
+  constexpr uint16_t kLiveSgprs = 104;
+  constexpr auto conversion =
+      gfx1250::build_vop3(gfx1250::kVCvtF32Fp8Vop3, {.vdst = 30, .clamp = 1, .src0 = 256 + 22});
+  constexpr uint32_t kGfx1250SNop = 0xBF800000u;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+
+  std::vector<uint32_t> words;
+  words.reserve(kTargetWord + 1);
+  words.push_back(gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp,
+                                      {.simm16 = static_cast<uint16_t>(kTargetWord - 1u)})[0]);
+  words.insert(words.end(), conversion.begin(), conversion.end());
+  for (uint16_t sgpr = 0; sgpr < kLiveSgprs; ++sgpr) {
+    words.push_back(gfx1250::build_sop1(gfx1250::kSMovB32Sop1,
+                                        {.ssrc0 = static_cast<uint8_t>(sgpr), .sdst = 125})[0]);
+  }
+  words.resize(kTargetWord, kGfx1250SNop);
+  words.push_back(kGfx1250SEndpgm);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject layout(image.data(), image.size());
+  ASSERT_TRUE(layout.is_valid());
+  const auto *rodata = rocjitsu::find_section(layout, ".rodata");
+  ASSERT_NE(rodata, nullptr);
+  auto descriptor = rocjitsu::read_kernel_descriptor_for_test(rodata->data());
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+                  12);
+  rocjitsu::write_kernel_descriptor_for_test(image.data() + rodata->sectionOffset(), descriptor);
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(rocjitsu::has_error_containing(
+      result, rocjitsu::DiagnosticKind::ResourceLimit,
+      "long direct branch requires an additional descriptor-backed SGPR pair after semantic "
+      "expansion"));
+  const auto diagnostic = std::ranges::find_if(result.diagnostics, [](const auto &item) {
+    return item.kind == rocjitsu::DiagnosticKind::ResourceLimit;
+  });
+  ASSERT_NE(diagnostic, result.diagnostics.end());
+  EXPECT_EQ(diagnostic->guest_offset, std::optional<uint64_t>(0))
+      << "the resource diagnostic must identify the branch that could not be expanded";
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250CompactConditionalLayoutIsIdempotent) {
@@ -9419,7 +9472,10 @@ TEST(BinaryTranslatorE2E, Gfx1250EmulatesCvtF32Fp8E5m3ForA0) {
 TEST(BinaryTranslatorE2E, Gfx1250E5m3CompareMasksTargetDeadSgprs) {
   constexpr auto conversion = gfx1250::build_vop3(
       gfx1250::kVCvtF32Fp8Vop3, {.vdst = 30, .opsel = 2, .clamp = 1, .src0 = 256 + 22});
-  constexpr uint16_t kLiveSgprs = 8;
+  // s103 is the first dead SGPR but cannot be borrowed safely because it backs
+  // src_flat_scratch_base. The two independent Wave32 masks use s104:s105.
+  constexpr uint16_t kLiveSgprs = 103;
+  constexpr uint16_t kExpectedMaskBase = 104;
   auto image = rocjitsu::make_gfx1250_image_with_live_sgprs(conversion, kLiveSgprs);
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
   rocjitsu::BinaryTranslator translator(
@@ -9454,19 +9510,17 @@ TEST(BinaryTranslatorE2E, Gfx1250E5m3CompareMasksTargetDeadSgprs) {
   ASSERT_TRUE(nan_mask.has_value());
   ASSERT_TRUE(exp31_mask.has_value());
   ASSERT_EQ(cndmask_predicates.size(), 2u);
-  EXPECT_NE(*nan_mask, *exp31_mask);
-  EXPECT_GE(*nan_mask, kLiveSgprs);
-  EXPECT_GE(*exp31_mask, kLiveSgprs);
+  EXPECT_EQ(*nan_mask, kExpectedMaskBase);
+  EXPECT_EQ(*exp31_mask, kExpectedMaskBase + 1u);
   EXPECT_EQ(cndmask_predicates[0], *exp31_mask);
   EXPECT_EQ(cndmask_predicates[1], *nan_mask);
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250E5m3UnpackFailsClosedWithoutPredicateSgprs) {
+TEST(BinaryTranslatorE2E, Gfx1250E5m3UnpackUsesVgprCarriersUnderSgprPressure) {
   constexpr auto conversion = gfx1250::build_vop3(
       gfx1250::kVCvtF32Fp8Vop3, {.vdst = 30, .opsel = 2, .clamp = 1, .src0 = 256 + 22});
-  for (const uint16_t live_sgprs :
-       {static_cast<uint16_t>(rocjitsu::REGISTER_SET_ALLOCATABLE_SGPRS - 1u),
-        static_cast<uint16_t>(rocjitsu::REGISTER_SET_ALLOCATABLE_SGPRS)}) {
+  for (const uint16_t live_sgprs : {static_cast<uint16_t>(rocjitsu::REGISTER_SET_MAX_SGPRS - 1u),
+                                    static_cast<uint16_t>(rocjitsu::REGISTER_SET_MAX_SGPRS)}) {
     SCOPED_TRACE(live_sgprs);
     auto image = rocjitsu::make_gfx1250_image_with_live_sgprs(conversion, live_sgprs);
     rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
@@ -9476,12 +9530,74 @@ TEST(BinaryTranslatorE2E, Gfx1250E5m3UnpackFailsClosedWithoutPredicateSgprs) {
                                  rocjitsu::ProcessorRevision::Gfx1250A0));
     const auto result = translator.translate(source);
 
-    EXPECT_FALSE(result.ok());
-    EXPECT_EQ(result.elf_bytes, image);
-    EXPECT_TRUE(rocjitsu::has_error_containing(
-        result, rocjitsu::DiagnosticKind::ExpandFailed,
-        "gfx1250 E5M3 unpack could not allocate two dead SGPR masks"));
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    const auto decoded =
+        decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+    EXPECT_EQ(std::ranges::count_if(
+                  decoded, [](const auto &inst) { return inst->mnemonic() == "s_cbranch_execz"; }),
+              1);
+    EXPECT_EQ(std::ranges::count_if(
+                  decoded,
+                  [](const auto &inst) { return inst->mnemonic() == "v_readfirstlane_b32_e32"; }),
+              2);
+
+    const auto guard = std::ranges::find_if(
+        decoded, [](const auto &inst) { return inst->mnemonic() == "s_cbranch_execz"; });
+    ASSERT_NE(guard, decoded.end());
+    ASSERT_TRUE((*guard)->branch_offset_bytes().has_value());
+    const uint64_t target =
+        (*guard)->src_loc() + (*guard)->size() + *(*guard)->branch_offset_bytes();
+    const auto following =
+        std::ranges::find_if(decoded, [&](const auto &inst) { return inst->src_loc() == target; });
+    ASSERT_NE(following, decoded.end());
+    EXPECT_EQ((*following)->mnemonic(), "s_mov_b32")
+        << "the EXEC-zero guard must land on the first following guest instruction";
   }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250E5m3SeparatesVectorAndScalarSpillSlots) {
+  constexpr auto conversion = gfx1250::build_vop3(
+      gfx1250::kVCvtF32Fp8Vop3, {.vdst = 30, .opsel = 2, .clamp = 1, .src0 = 256 + 22});
+  auto image =
+      rocjitsu::make_gfx1250_image_with_live_sgprs(conversion, rocjitsu::REGISTER_SET_MAX_SGPRS);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  auto options = gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                          rocjitsu::ProcessorRevision::Gfx1250A0);
+  options.debug_min_free_vgpr = 256;
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+                                        options);
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  std::vector<uint32_t> store_offsets;
+  std::vector<uint32_t> load_offsets;
+  for (const auto &inst : decoded) {
+    if (inst->mnemonic() != "scratch_store_b32" && inst->mnemonic() != "scratch_load_b32")
+      continue;
+    ASSERT_NE(inst->raw_encoding(), nullptr);
+    gfx1250::VscratchMachineInst scratch{};
+    std::memcpy(&scratch, inst->raw_encoding(), sizeof(scratch));
+    (inst->mnemonic() == "scratch_load_b32" ? load_offsets : store_offsets)
+        .push_back(scratch.ioffset);
+  }
+  EXPECT_EQ(store_offsets, (std::vector<uint32_t>{0, 4, 8, 12}));
+  EXPECT_EQ(load_offsets, (std::vector<uint32_t>{8, 12, 0, 4}));
+
+  const auto *rodata = rocjitsu::find_section(translated, ".rodata");
+  ASSERT_NE(rodata, nullptr);
+  const auto descriptor = rocjitsu::read_kernel_descriptor_for_test(rodata->data());
+  EXPECT_GE(descriptor.private_segment_fixed_size, 16u);
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250CopiesWmmaOutsideB0ToA0Profile) {
@@ -10150,6 +10266,88 @@ TEST(BinaryTranslatorE2E, Gfx1250MasksM0AroundSaddrClusterLoadForA0) {
   EXPECT_EQ(second_result.elf_bytes, result.elf_bytes);
 }
 
+TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadsUseVgprCarrierUnderSgprPressure) {
+  for (const uint16_t opcode :
+       {gfx1250::kClusterLoadB32Vglobal, gfx1250::kClusterLoadAsyncToLdsB32Vglobal}) {
+    SCOPED_TRACE(opcode == gfx1250::kClusterLoadB32Vglobal ? "cluster_load_b32"
+                                                           : "cluster_load_async_to_lds_b32");
+    const auto cluster = gfx1250::build_vglobal(opcode, {.saddr = 124, .vdst = 8, .vaddr = 12});
+    auto image =
+        rocjitsu::make_gfx1250_image_with_live_sgprs(cluster, rocjitsu::REGISTER_SET_MAX_SGPRS);
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    const auto result = translator.translate(source);
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    const auto decoded =
+        decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+    EXPECT_EQ(std::ranges::count_if(
+                  decoded, [](const auto &inst) { return inst->mnemonic() == "s_cbranch_execz"; }),
+              0);
+    EXPECT_EQ(std::ranges::count_if(
+                  decoded,
+                  [](const auto &inst) { return inst->mnemonic() == "v_readfirstlane_b32_e32"; }),
+              0);
+    EXPECT_EQ(std::ranges::count_if(
+                  decoded, [](const auto &inst) { return inst->mnemonic() == "v_writelane_b32"; }),
+              1);
+    EXPECT_EQ(std::ranges::count_if(
+                  decoded, [](const auto &inst) { return inst->mnemonic() == "v_readlane_b32"; }),
+              1);
+    EXPECT_EQ(
+        std::ranges::count_if(decoded, [&](const auto &inst) { return inst->opcode() == opcode; }),
+        1);
+    ASSERT_GE(decoded.size(), 8u);
+    ASSERT_EQ(decoded[0]->mnemonic(), "s_wait_idle");
+    ASSERT_EQ(decoded[1]->mnemonic(), "v_writelane_b32");
+    ASSERT_EQ(decoded[6]->mnemonic(), "v_readlane_b32");
+
+    ASSERT_NE(decoded[1]->raw_encoding(), nullptr);
+    ASSERT_NE(decoded[6]->raw_encoding(), nullptr);
+    gfx1250::Vop3MachineInst save{};
+    gfx1250::Vop3MachineInst restore{};
+    std::memcpy(&save, decoded[1]->raw_encoding(), sizeof(save));
+    std::memcpy(&restore, decoded[6]->raw_encoding(), sizeof(restore));
+    EXPECT_EQ(save.src0, restore.vdst) << "the carrier must restore the borrowed SGPR";
+    EXPECT_EQ(static_cast<uint16_t>(256u + save.vdst), restore.src0)
+        << "the carrier save and restore must use the same VGPR";
+    constexpr uint16_t kInlineZero = 128;
+    EXPECT_EQ(save.src1, kInlineZero) << "the EXEC-independent carrier must save through lane zero";
+    EXPECT_EQ(restore.src1, kInlineZero)
+        << "the EXEC-independent carrier must restore through lane zero";
+
+    const auto second = translator.translate(translated);
+    ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                            : second.diagnostics.front().message);
+    EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+  }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadFailsClosedWithoutExecIndependentCarrier) {
+  constexpr auto cluster = gfx1250::build_vglobal(gfx1250::kClusterLoadB32Vglobal,
+                                                  {.saddr = 124, .vdst = 8, .vaddr = 12});
+  auto image =
+      rocjitsu::make_gfx1250_image_with_live_sgprs(cluster, rocjitsu::REGISTER_SET_MAX_SGPRS);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  auto options = gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                          rocjitsu::ProcessorRevision::Gfx1250A0);
+  options.debug_min_free_vgpr = 256;
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+                                        options);
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(rocjitsu::has_error_containing(
+      result, rocjitsu::DiagnosticKind::ExpandFailed,
+      "gfx1250 cluster load could not allocate scalar scratch for M0 preservation"));
+}
+
 TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadPreservesGuestM0ClearWithoutRestore) {
   constexpr auto clear_m0 = gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 128, .sdst = 125});
   constexpr auto cluster = gfx1250::build_vglobal(gfx1250::kClusterLoadB32Vglobal,
@@ -10198,6 +10396,7 @@ TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseNonzeroM0Write) {
       gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 125, .sdst = 0});
   constexpr auto generated_restore =
       gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 0, .sdst = 125});
+  constexpr auto dependency_barrier = gfx1250::build_sopp(gfx1250::kSWaitIdleSopp);
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {nonzero_m0[0], cluster[0], cluster[1], cluster[2], kGfx1250SEndpgm});
@@ -10213,17 +10412,18 @@ TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseNonzeroM0Write) {
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_FALSE(translated.text_sections().empty());
-  ASSERT_EQ(translated.text_sections()[0]->size(), 8 * sizeof(uint32_t));
+  ASSERT_EQ(translated.text_sections()[0]->size(), 9 * sizeof(uint32_t));
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
   EXPECT_EQ(target_words[0], nonzero_m0[0]);
-  EXPECT_EQ(target_words[1], generated_save[0]);
-  EXPECT_EQ(target_words[2], clear_m0[0]);
-  EXPECT_EQ(target_words[3], cluster[0]);
-  EXPECT_EQ(target_words[4], cluster[1]);
-  EXPECT_EQ(target_words[5], cluster[2]);
-  EXPECT_EQ(target_words[6], generated_restore[0]);
-  EXPECT_EQ(target_words[7], kGfx1250SEndpgm);
+  EXPECT_EQ(target_words[1], dependency_barrier[0]);
+  EXPECT_EQ(target_words[2], generated_save[0]);
+  EXPECT_EQ(target_words[3], clear_m0[0]);
+  EXPECT_EQ(target_words[4], cluster[0]);
+  EXPECT_EQ(target_words[5], cluster[1]);
+  EXPECT_EQ(target_words[6], cluster[2]);
+  EXPECT_EQ(target_words[7], generated_restore[0]);
+  EXPECT_EQ(target_words[8], kGfx1250SEndpgm);
 
   rocjitsu::BinaryTranslator verifier(
       ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
@@ -10241,6 +10441,7 @@ TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseZeroWriteToOtherSgpr) {
   constexpr auto clear_m0 = gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 128, .sdst = 125});
   constexpr auto cluster = gfx1250::build_vglobal(gfx1250::kClusterLoadB32Vglobal,
                                                   {.saddr = 124, .vdst = 8, .vaddr = 12});
+  constexpr auto dependency_barrier = gfx1250::build_sopp(gfx1250::kSWaitIdleSopp);
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {clear_s7[0], cluster[0], cluster[1], cluster[2], kGfx1250SEndpgm});
@@ -10256,11 +10457,12 @@ TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseZeroWriteToOtherSgpr) {
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_FALSE(translated.text_sections().empty());
-  ASSERT_EQ(translated.text_sections()[0]->size(), 8 * sizeof(uint32_t));
+  ASSERT_EQ(translated.text_sections()[0]->size(), 9 * sizeof(uint32_t));
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
   EXPECT_EQ(target_words[0], clear_s7[0]);
-  EXPECT_EQ(target_words[2], clear_m0[0]);
+  EXPECT_EQ(target_words[1], dependency_barrier[0]);
+  EXPECT_EQ(target_words[3], clear_m0[0]);
 
   const auto second = translator.translate(translated);
   ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
@@ -10277,6 +10479,7 @@ TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseM0ClearBypassedByBranch)
                                                   {.saddr = 124, .vdst = 8, .vaddr = 12});
   constexpr auto source_restore =
       gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 12, .sdst = 125});
+  constexpr auto dependency_barrier = gfx1250::build_sopp(gfx1250::kSWaitIdleSopp);
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {branch_to_cluster[0], source_save[0], clear_m0[0], cluster[0], cluster[1], cluster[2],
@@ -10293,7 +10496,7 @@ TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseM0ClearBypassedByBranch)
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_FALSE(translated.text_sections().empty());
-  ASSERT_EQ(translated.text_sections()[0]->size(), 11 * sizeof(uint32_t));
+  ASSERT_EQ(translated.text_sections()[0]->size(), 12 * sizeof(uint32_t));
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
   constexpr auto generated_save =
@@ -10303,14 +10506,15 @@ TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseM0ClearBypassedByBranch)
   EXPECT_EQ(target_words[0], branch_to_cluster[0]);
   EXPECT_EQ(target_words[1], source_save[0]);
   EXPECT_EQ(target_words[2], clear_m0[0]);
-  EXPECT_EQ(target_words[3], generated_save[0]);
-  EXPECT_EQ(target_words[4], clear_m0[0]);
-  EXPECT_EQ(target_words[5], cluster[0]);
-  EXPECT_EQ(target_words[6], cluster[1]);
-  EXPECT_EQ(target_words[7], cluster[2]);
-  EXPECT_EQ(target_words[8], generated_restore[0]);
-  EXPECT_EQ(target_words[9], source_restore[0]);
-  EXPECT_EQ(target_words[10], kGfx1250SEndpgm);
+  EXPECT_EQ(target_words[3], dependency_barrier[0]);
+  EXPECT_EQ(target_words[4], generated_save[0]);
+  EXPECT_EQ(target_words[5], clear_m0[0]);
+  EXPECT_EQ(target_words[6], cluster[0]);
+  EXPECT_EQ(target_words[7], cluster[1]);
+  EXPECT_EQ(target_words[8], cluster[2]);
+  EXPECT_EQ(target_words[9], generated_restore[0]);
+  EXPECT_EQ(target_words[10], source_restore[0]);
+  EXPECT_EQ(target_words[11], kGfx1250SEndpgm);
 
   rocjitsu::BinaryTranslator verifier(
       ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
@@ -10675,9 +10879,9 @@ TEST(BinaryTranslatorE2E, Gfx1250GeneratedVgprMsbTransitionsCarryPreviousState) 
       decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_GE(decoded.size(), 5u);
   EXPECT_EQ(decoded[0]->mnemonic(), "s_setreg_imm32_b32");
-  // The first generated transition is preceded by an s_nop (MODE-write separation)
-  // and an s_wait_xcnt (memory drain) before the s_set_vgpr_msb.
-  EXPECT_EQ(decoded[1]->mnemonic(), "s_nop");
+  // The dependency barrier also separates the guest MODE write from the
+  // generated transition. The transition retains its dedicated memory drain.
+  EXPECT_EQ(decoded[1]->mnemonic(), "s_wait_idle");
   EXPECT_EQ(decoded[2]->mnemonic(), "s_wait_xcnt");
   EXPECT_EQ(decoded[3]->mnemonic(), "s_set_vgpr_msb");
   ASSERT_NE(decoded[3]->raw_encoding(), nullptr);
@@ -10699,6 +10903,291 @@ TEST(BinaryTranslatorE2E, Gfx1250GeneratedVgprMsbTransitionsCarryPreviousState) 
   // SRC1 field, not src0_bank. With src1_bank 0 the store transition is a no-op
   // and is elided, leaving only the compute transition and the final restore.
   EXPECT_EQ(generated_modes, (std::vector<uint16_t>{0x0100, 0x0001}));
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250AddtidStoreUsesSpillBackedScratchWhenVgprsAreFull) {
+  using namespace rocr::llvm::amdhsa;
+
+  constexpr auto addtid =
+      gfx1250::build_vds(gfx1250::kDsStoreAddtidB32Vds, {.offset0 = 4, .data0 = 8});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {addtid[0], addtid[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject layout(image.data(), image.size());
+  ASSERT_TRUE(layout.is_valid());
+  const auto *rodata = rocjitsu::find_section(layout, ".rodata");
+  ASSERT_NE(rodata, nullptr);
+  auto descriptor = rocjitsu::read_kernel_descriptor_for_test(rodata->data());
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                  63);
+  rocjitsu::write_kernel_descriptor_for_test(image.data() + rodata->sectionOffset(), descriptor);
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  auto options = gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                          rocjitsu::ProcessorRevision::Gfx1250A0);
+  options.debug_min_free_vgpr = 256;
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+                                        options);
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "scratch_store_b32"; }),
+            1);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "scratch_load_b32"; }),
+            1);
+  EXPECT_EQ(
+      std::ranges::count_if(
+          decoded, [](const auto &inst) { return inst->mnemonic() == "ds_store_addtid_b32"; }),
+      0);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "ds_store_b32"; }),
+            1);
+
+  std::optional<size_t> ds_store_index;
+  std::optional<size_t> ds_wait_index;
+  std::optional<size_t> scratch_load_index;
+  std::optional<gfx1250::VscratchMachineInst> scratch_store;
+  std::optional<gfx1250::VscratchMachineInst> scratch_load;
+  std::optional<gfx1250::VdsMachineInst> ds_store;
+  for (size_t index = 0; index < decoded.size(); ++index) {
+    if (decoded[index]->mnemonic() == "scratch_store_b32") {
+      scratch_store.emplace();
+      std::memcpy(&*scratch_store, decoded[index]->raw_encoding(), sizeof(*scratch_store));
+    } else if (decoded[index]->mnemonic() == "ds_store_b32") {
+      ds_store_index = index;
+      ds_store.emplace();
+      std::memcpy(&*ds_store, decoded[index]->raw_encoding(), sizeof(*ds_store));
+    } else if (decoded[index]->mnemonic() == "s_wait_dscnt") {
+      ds_wait_index = index;
+    } else if (decoded[index]->mnemonic() == "scratch_load_b32") {
+      scratch_load_index = index;
+      scratch_load.emplace();
+      std::memcpy(&*scratch_load, decoded[index]->raw_encoding(), sizeof(*scratch_load));
+    }
+  }
+  ASSERT_TRUE(ds_store_index.has_value());
+  ASSERT_TRUE(ds_wait_index.has_value());
+  ASSERT_TRUE(scratch_load_index.has_value());
+  EXPECT_EQ(*ds_wait_index, *ds_store_index + 1u)
+      << "the DS store must complete before its address VGPR is restored";
+  EXPECT_LT(*ds_wait_index, *scratch_load_index);
+  ASSERT_TRUE(scratch_store.has_value());
+  ASSERT_TRUE(scratch_load.has_value());
+  ASSERT_TRUE(ds_store.has_value());
+  EXPECT_EQ(scratch_store->ioffset, scratch_load->ioffset);
+  EXPECT_EQ(scratch_store->vsrc, scratch_load->vdst);
+  EXPECT_EQ(ds_store->addr, scratch_load->vdst);
+
+  const auto *translated_rodata = rocjitsu::find_section(translated, ".rodata");
+  ASSERT_NE(translated_rodata, nullptr);
+  const auto translated_descriptor =
+      rocjitsu::read_kernel_descriptor_for_test(translated_rodata->data());
+  EXPECT_GE(translated_descriptor.private_segment_fixed_size, sizeof(uint32_t));
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250SpillBackedRulesFailClosedForDynamicStackKernel) {
+  using namespace rocr::llvm::amdhsa;
+
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const auto expect_failure = [&](std::vector<uint32_t> words, std::string_view diagnostic) {
+    SCOPED_TRACE(diagnostic);
+    words.push_back(kGfx1250SEndpgm);
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+    rocjitsu::AmdGpuCodeObject layout(image.data(), image.size());
+    ASSERT_TRUE(layout.is_valid());
+    const auto *rodata = rocjitsu::find_section(layout, ".rodata");
+    ASSERT_NE(rodata, nullptr);
+    auto descriptor = rocjitsu::read_kernel_descriptor_for_test(rodata->data());
+    descriptor.private_segment_fixed_size = 32;
+    AMDHSA_BITS_SET(descriptor.kernel_code_properties, KERNEL_CODE_PROPERTY_USES_DYNAMIC_STACK, 1);
+    AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                    63);
+    rocjitsu::write_kernel_descriptor_for_test(image.data() + rodata->sectionOffset(), descriptor);
+
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    auto options = gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                            rocjitsu::ProcessorRevision::Gfx1250A0);
+    options.debug_min_free_vgpr = 256;
+    rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+                                          options);
+    const auto result = translator.translate(source);
+
+    EXPECT_FALSE(result.ok());
+    EXPECT_EQ(result.elf_bytes, image);
+    EXPECT_TRUE(
+        rocjitsu::has_error_containing(result, rocjitsu::DiagnosticKind::ExpandFailed, diagnostic));
+  };
+
+  constexpr auto addtid =
+      gfx1250::build_vds(gfx1250::kDsStoreAddtidB32Vds, {.offset0 = 4, .data0 = 8});
+  expect_failure(
+      {addtid[0], addtid[1]},
+      "gfx1250 DS store ADDTID cannot use private-memory spills in a dynamic-stack kernel");
+
+  constexpr auto e5m3 = gfx1250::build_vop3(gfx1250::kVCvtF32Fp8Vop3,
+                                            {.vdst = 30, .opsel = 2, .clamp = 1, .src0 = 256 + 22});
+  expect_failure({e5m3[0], e5m3[1]},
+                 "gfx1250 E5M3 unpack cannot use private-memory spills in a dynamic-stack kernel");
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250SpillWaitsForOutstandingVgprProducer) {
+  using namespace rocr::llvm::amdhsa;
+
+  constexpr auto pending_load = gfx1250::build_vds(gfx1250::kDsLoadB32Vds, {.addr = 4, .vdst = 0});
+  constexpr auto addtid =
+      gfx1250::build_vds(gfx1250::kDsStoreAddtidB32Vds, {.offset0 = 4, .data0 = 8});
+  constexpr auto consume_v0 = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 256, .vdst = 9});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {pending_load[0], pending_load[1], addtid[0], addtid[1], consume_v0[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject layout(image.data(), image.size());
+  ASSERT_TRUE(layout.is_valid());
+  const auto *rodata = rocjitsu::find_section(layout, ".rodata");
+  ASSERT_NE(rodata, nullptr);
+  auto descriptor = rocjitsu::read_kernel_descriptor_for_test(rodata->data());
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                  63);
+  rocjitsu::write_kernel_descriptor_for_test(image.data() + rodata->sectionOffset(), descriptor);
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  auto options = gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                          rocjitsu::ProcessorRevision::Gfx1250A0);
+  options.debug_min_free_vgpr = 256;
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+                                        options);
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  std::optional<size_t> pending_load_index;
+  std::optional<size_t> wait_idle_index;
+  std::optional<size_t> scratch_store_index;
+  for (size_t index = 0; index < decoded.size(); ++index) {
+    if (decoded[index]->mnemonic() == "ds_load_b32")
+      pending_load_index = index;
+    else if (decoded[index]->mnemonic() == "s_wait_idle")
+      wait_idle_index = index;
+    else if (decoded[index]->mnemonic() == "scratch_store_b32") {
+      scratch_store_index = index;
+      ASSERT_NE(decoded[index]->raw_encoding(), nullptr);
+      gfx1250::VscratchMachineInst scratch{};
+      std::memcpy(&scratch, decoded[index]->raw_encoding(), sizeof(scratch));
+      EXPECT_EQ(scratch.vsrc, 0u);
+    }
+  }
+  ASSERT_TRUE(pending_load_index.has_value());
+  ASSERT_TRUE(wait_idle_index.has_value());
+  ASSERT_TRUE(scratch_store_index.has_value());
+  EXPECT_LT(*pending_load_index, *wait_idle_index);
+  EXPECT_EQ(*scratch_store_index, *wait_idle_index + 1u)
+      << "the borrowed live VGPR must not be read before its producer completes";
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250DeadScratchWaitsForOutstandingVgprProducer) {
+  constexpr auto pending_load = gfx1250::build_vds(gfx1250::kDsLoadB32Vds, {.addr = 4, .vdst = 0});
+  constexpr auto addtid =
+      gfx1250::build_vds(gfx1250::kDsStoreAddtidB32Vds, {.offset0 = 4, .data0 = 8});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {pending_load[0], pending_load[1], addtid[0], addtid[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  std::optional<size_t> pending_load_index;
+  std::optional<size_t> wait_idle_index;
+  std::optional<size_t> scratch_write_index;
+  for (size_t index = 0; index < decoded.size(); ++index) {
+    if (decoded[index]->mnemonic() == "ds_load_b32")
+      pending_load_index = index;
+    else if (decoded[index]->mnemonic() == "s_wait_idle")
+      wait_idle_index = index;
+    else if (decoded[index]->mnemonic() == "v_mbcnt_lo_u32_b32") {
+      scratch_write_index = index;
+      const rocjitsu::Operand *destination = decoded[index]->dst_operand(0);
+      ASSERT_NE(destination, nullptr);
+      EXPECT_EQ(destination->encoding_value(), 0u);
+    }
+  }
+  ASSERT_TRUE(pending_load_index.has_value());
+  ASSERT_TRUE(wait_idle_index.has_value());
+  ASSERT_TRUE(scratch_write_index.has_value());
+  EXPECT_LT(*pending_load_index, *wait_idle_index);
+  EXPECT_LT(*wait_idle_index, *scratch_write_index)
+      << "a dead scratch VGPR may still have an outstanding producer";
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "scratch_store_b32"; }),
+            0);
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250AddtidLoadWaitsForOutstandingVgprProducer) {
+  constexpr auto pending_load = gfx1250::build_vds(gfx1250::kDsLoadB32Vds, {.addr = 4, .vdst = 0});
+  constexpr auto addtid =
+      gfx1250::build_vds(gfx1250::kDsLoadAddtidB32Vds, {.offset0 = 4, .vdst = 0});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {pending_load[0], pending_load[1], addtid[0], addtid[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  std::optional<size_t> wait_idle_index;
+  std::optional<size_t> scratch_write_index;
+  for (size_t index = 0; index < decoded.size(); ++index) {
+    if (decoded[index]->mnemonic() == "s_wait_idle")
+      wait_idle_index = index;
+    else if (decoded[index]->mnemonic() == "v_mbcnt_lo_u32_b32")
+      scratch_write_index = index;
+  }
+  ASSERT_TRUE(wait_idle_index.has_value());
+  ASSERT_TRUE(scratch_write_index.has_value());
+  EXPECT_LT(*wait_idle_index, *scratch_write_index)
+      << "the ADDTID load destination may still have an outstanding producer";
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250AddtidStoreModeUsesSrc1BankNotSrc0) {
@@ -10960,7 +11449,7 @@ TEST(BinaryTranslatorE2E, Gfx1250TensorLoadAlwaysClearsDynamicMulticastMask) {
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_FALSE(translated.text_sections().empty());
-  ASSERT_GE(translated.text_sections()[0]->size(), 7 * sizeof(uint32_t));
+  ASSERT_GE(translated.text_sections()[0]->size(), 8 * sizeof(uint32_t));
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
   // D0 occupies s[8:11] and D1 occupies s[0:7], so the first dead ordinary
@@ -10969,19 +11458,148 @@ TEST(BinaryTranslatorE2E, Gfx1250TensorLoadAlwaysClearsDynamicMulticastMask) {
   constexpr auto clear_mask =
       gfx1250::build_sop2(gfx1250::kSPackHhB32B16Sop2, {.ssrc0 = 128, .ssrc1 = 0, .sdst = 0});
   constexpr auto restore_d1 = gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 12, .sdst = 0});
-  EXPECT_EQ(target_words[0], save_d1[0]);
-  EXPECT_EQ(target_words[1], clear_mask[0]);
-  EXPECT_EQ(target_words[2], source_tensor[0]);
-  EXPECT_EQ(target_words[3], source_tensor[1]);
-  EXPECT_EQ(target_words[4], source_tensor[2]);
-  EXPECT_EQ(target_words[5], restore_d1[0]);
-  EXPECT_EQ(target_words[6], kGfx1250SEndpgm);
+  constexpr auto dependency_barrier = gfx1250::build_sopp(gfx1250::kSWaitIdleSopp);
+  EXPECT_EQ(target_words[0], dependency_barrier[0]);
+  EXPECT_EQ(target_words[1], save_d1[0]);
+  EXPECT_EQ(target_words[2], clear_mask[0]);
+  EXPECT_EQ(target_words[3], source_tensor[0]);
+  EXPECT_EQ(target_words[4], source_tensor[1]);
+  EXPECT_EQ(target_words[5], source_tensor[2]);
+  EXPECT_EQ(target_words[6], restore_d1[0]);
+  EXPECT_EQ(target_words[7], kGfx1250SEndpgm);
 
   auto second_result = translator.translate(translated);
   ASSERT_TRUE(second_result.ok()) << (second_result.diagnostics.empty()
                                           ? ""
                                           : second_result.diagnostics.front().message);
   EXPECT_EQ(second_result.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250TensorLoadUsesHighDeadSgprUnderCompilerPressure) {
+  constexpr auto source_tensor = gfx1250::build_vimage(
+      gfx1250::kTensorLoadToLdsVimage,
+      {.vaddr4 = 124, .vaddr0 = 8, .vaddr1 = 0, .vaddr2 = 124, .vaddr3 = 124});
+  auto image = rocjitsu::make_gfx1250_image_with_live_sgprs(
+      source_tensor, rocjitsu::REGISTER_SET_ALLOCATABLE_SGPRS);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "s_cbranch_execz"; }),
+            0);
+  EXPECT_EQ(
+      std::ranges::count_if(
+          decoded, [](const auto &inst) { return inst->mnemonic() == "v_readfirstlane_b32_e32"; }),
+      0);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "tensor_load_to_lds"; }),
+            1);
+
+  ASSERT_GE(translated.text_sections()[0]->size(), 7 * sizeof(uint32_t));
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  // The generic 102-SGPR ceiling leaves s102/s103 dead, but gfx1250 scratch
+  // allocation skips those scratch-base registers and uses s104.
+  constexpr uint8_t kScratch = 104;
+  constexpr auto save_d1 =
+      gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 0, .sdst = kScratch});
+  constexpr auto clear_mask =
+      gfx1250::build_sop2(gfx1250::kSPackHhB32B16Sop2, {.ssrc0 = 128, .ssrc1 = 0, .sdst = 0});
+  constexpr auto restore_d1 =
+      gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = kScratch, .sdst = 0});
+  constexpr auto dependency_barrier = gfx1250::build_sopp(gfx1250::kSWaitIdleSopp);
+  EXPECT_EQ(target_words[0], dependency_barrier[0]);
+  EXPECT_EQ(target_words[1], save_d1[0]);
+  EXPECT_EQ(target_words[2], clear_mask[0]);
+  EXPECT_EQ(target_words[3], source_tensor[0]);
+  EXPECT_EQ(target_words[4], source_tensor[1]);
+  EXPECT_EQ(target_words[5], source_tensor[2]);
+  EXPECT_EQ(target_words[6], restore_d1[0]);
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250TensorScratchWaitsForOutstandingSgprProducer) {
+  constexpr auto pending_load =
+      gfx1250::build_smem(gfx1250::kSLoadB32Smem, {.sbase = 8, .sdata = 12, .soffset = 128});
+  constexpr auto source_tensor = gfx1250::build_vimage(
+      gfx1250::kTensorLoadToLdsVimage,
+      {.vaddr4 = 124, .vaddr0 = 8, .vaddr1 = 0, .vaddr2 = 124, .vaddr3 = 124});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {pending_load[0], pending_load[1], source_tensor[0], source_tensor[1], source_tensor[2],
+       kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  std::optional<size_t> pending_load_index;
+  std::optional<size_t> wait_idle_index;
+  std::optional<size_t> scratch_write_index;
+  for (size_t index = 0; index < decoded.size(); ++index) {
+    if (decoded[index]->mnemonic() == "s_load_b32")
+      pending_load_index = index;
+    else if (decoded[index]->mnemonic() == "s_wait_idle")
+      wait_idle_index = index;
+    else if (decoded[index]->mnemonic() == "s_mov_b32") {
+      ASSERT_NE(decoded[index]->raw_encoding(), nullptr);
+      gfx1250::Sop1MachineInst move{};
+      std::memcpy(&move, decoded[index]->raw_encoding(), sizeof(move));
+      if (move.ssrc0 == 0 && move.sdst == 12)
+        scratch_write_index = index;
+    }
+  }
+  ASSERT_TRUE(pending_load_index.has_value());
+  ASSERT_TRUE(wait_idle_index.has_value());
+  ASSERT_TRUE(scratch_write_index.has_value());
+  EXPECT_LT(*pending_load_index, *wait_idle_index);
+  EXPECT_EQ(*scratch_write_index, *wait_idle_index + 1u)
+      << "the dead SGPR scratch may still have an outstanding producer";
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250TensorLoadFailsClosedWhenEverySgprIsLive) {
+  constexpr auto source_tensor = gfx1250::build_vimage(
+      gfx1250::kTensorLoadToLdsVimage,
+      {.vaddr4 = 124, .vaddr0 = 8, .vaddr1 = 0, .vaddr2 = 124, .vaddr3 = 124});
+  auto image =
+      rocjitsu::make_gfx1250_image_with_live_sgprs(source_tensor, rocjitsu::REGISTER_SET_MAX_SGPRS);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(rocjitsu::has_error_containing(
+      result, rocjitsu::DiagnosticKind::ExpandFailed,
+      "gfx1250 tensor-load mask rule could not allocate scalar scratch"));
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250TensorLoadPreservesGuestMaskClearWithoutRestore) {
@@ -11050,14 +11668,16 @@ TEST(BinaryTranslatorE2E, Gfx1250TensorLoadDoesNotReuseNonzeroMaskWrite) {
   constexpr auto clear_mask =
       gfx1250::build_sop2(gfx1250::kSPackHhB32B16Sop2, {.ssrc0 = 128, .ssrc1 = 0, .sdst = 0});
   constexpr auto restore_d1 = gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 12, .sdst = 0});
+  constexpr auto dependency_barrier = gfx1250::build_sopp(gfx1250::kSWaitIdleSopp);
   EXPECT_EQ(target_words[0], source_nonzero[0]);
-  EXPECT_EQ(target_words[1], save_d1[0]);
-  EXPECT_EQ(target_words[2], clear_mask[0]);
-  EXPECT_EQ(target_words[3], source_tensor[0]);
-  EXPECT_EQ(target_words[4], source_tensor[1]);
-  EXPECT_EQ(target_words[5], source_tensor[2]);
-  EXPECT_EQ(target_words[6], restore_d1[0]);
-  EXPECT_EQ(target_words[7], kGfx1250SEndpgm);
+  EXPECT_EQ(target_words[1], dependency_barrier[0]);
+  EXPECT_EQ(target_words[2], save_d1[0]);
+  EXPECT_EQ(target_words[3], clear_mask[0]);
+  EXPECT_EQ(target_words[4], source_tensor[0]);
+  EXPECT_EQ(target_words[5], source_tensor[1]);
+  EXPECT_EQ(target_words[6], source_tensor[2]);
+  EXPECT_EQ(target_words[7], restore_d1[0]);
+  EXPECT_EQ(target_words[8], kGfx1250SEndpgm);
 
   const auto second = translator.translate(translated);
   ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
@@ -11073,6 +11693,7 @@ TEST(BinaryTranslatorE2E, Gfx1250TensorLoadDoesNotReuseClearOfDifferentDescripto
   constexpr auto source_tensor = gfx1250::build_vimage(
       gfx1250::kTensorLoadToLdsVimage,
       {.vaddr4 = 124, .vaddr0 = 8, .vaddr1 = 0, .vaddr2 = 124, .vaddr3 = 124});
+  constexpr auto dependency_barrier = gfx1250::build_sopp(gfx1250::kSWaitIdleSopp);
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {clear_s4[0], source_tensor[0], source_tensor[1], source_tensor[2], kGfx1250SEndpgm});
@@ -11088,11 +11709,12 @@ TEST(BinaryTranslatorE2E, Gfx1250TensorLoadDoesNotReuseClearOfDifferentDescripto
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_FALSE(translated.text_sections().empty());
-  ASSERT_EQ(translated.text_sections()[0]->size(), 8 * sizeof(uint32_t));
+  ASSERT_EQ(translated.text_sections()[0]->size(), 9 * sizeof(uint32_t));
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
   EXPECT_EQ(target_words[0], clear_s4[0]);
-  EXPECT_EQ(target_words[2], clear_s0[0]);
+  EXPECT_EQ(target_words[1], dependency_barrier[0]);
+  EXPECT_EQ(target_words[3], clear_s0[0]);
 
   const auto second = translator.translate(translated);
   ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
@@ -11113,6 +11735,7 @@ TEST(BinaryTranslatorE2E, Gfx1250TensorLoadDoesNotReuseMaskPrefixBypassedByBranc
       {.vaddr4 = 124, .vaddr0 = 8, .vaddr1 = 0, .vaddr2 = 124, .vaddr3 = 124});
   constexpr auto source_restore =
       gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 12, .sdst = 0});
+  constexpr auto dependency_barrier = gfx1250::build_sopp(gfx1250::kSWaitIdleSopp);
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {branch_to_tensor[0], source_save[0], source_clear[0], source_tensor[0], source_tensor[1],
@@ -11129,7 +11752,7 @@ TEST(BinaryTranslatorE2E, Gfx1250TensorLoadDoesNotReuseMaskPrefixBypassedByBranc
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_FALSE(translated.text_sections().empty());
-  ASSERT_GE(translated.text_sections()[0]->size(), 9 * sizeof(uint32_t));
+  ASSERT_GE(translated.text_sections()[0]->size(), 10 * sizeof(uint32_t));
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
   constexpr auto relocated_branch = gfx1250::build_sopp(gfx1250::kSBranchSopp, {.simm16 = 0});
@@ -11138,14 +11761,15 @@ TEST(BinaryTranslatorE2E, Gfx1250TensorLoadDoesNotReuseMaskPrefixBypassedByBranc
   constexpr auto generated_restore =
       gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 13, .sdst = 0});
   EXPECT_EQ(target_words[0], relocated_branch[0]);
-  EXPECT_EQ(target_words[1], generated_save[0]);
-  EXPECT_EQ(target_words[2], source_clear[0]);
-  EXPECT_EQ(target_words[3], source_tensor[0]);
-  EXPECT_EQ(target_words[4], source_tensor[1]);
-  EXPECT_EQ(target_words[5], source_tensor[2]);
-  EXPECT_EQ(target_words[6], generated_restore[0]);
-  EXPECT_EQ(target_words[7], source_restore[0]);
-  EXPECT_EQ(target_words[8], kGfx1250SEndpgm);
+  EXPECT_EQ(target_words[1], dependency_barrier[0]);
+  EXPECT_EQ(target_words[2], generated_save[0]);
+  EXPECT_EQ(target_words[3], source_clear[0]);
+  EXPECT_EQ(target_words[4], source_tensor[0]);
+  EXPECT_EQ(target_words[5], source_tensor[1]);
+  EXPECT_EQ(target_words[6], source_tensor[2]);
+  EXPECT_EQ(target_words[7], generated_restore[0]);
+  EXPECT_EQ(target_words[8], source_restore[0]);
+  EXPECT_EQ(target_words[9], kGfx1250SEndpgm);
 
   auto second_result = translator.translate(translated);
   ASSERT_TRUE(second_result.ok()) << (second_result.diagnostics.empty()


### PR DESCRIPTION
## Motivation

Several gfx1250 B0-to-A0 semantic rewrites failed closed when register pressure left no dead SGPR or VGPR scratch.

## Technical Details

- Preserve live low-bank VGPR scratch in private memory and carry live SGPR scratch through spill-backed VGPRs for EXEC-masked replacements.
- Use the full ordinary SGPR range for tensor scratch and diagnose long-branch SGPR exhaustion after semantic expansion.
- Account for private-segment storage, wait for ADDTID stores before restoring scratch, and cover each affected pressure path.

## Issue Tracking

N/A

## Test Plan

Build RocJITsu, run focused translator and semantic corpus tests, run the full CTest suite, and validate the 20,000-object offline DBT corpus with idempotence checking.

## Test Result

- `ninja all` passed.
- The focused pressure tests passed 6/6, all gfx1250 translator tests passed 87/87, and all seven semantic corpus objects translated idempotently.
- CTest passed 2,241/2,241, including RCCL 5/5; three environment-specific tests were skipped.
- The offline DBT corpus completed with 19,999 passed and one expected resource-limit failure.
- Pre-commit passed on all changed files.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.