### PR TITLE
fix(kfdtest): handle NUMA CONFIG mode target correctly

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/CMakeLists.txt
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/CMakeLists.txt
@@ -112,11 +112,18 @@ cmake_policy( SET CMP0074 NEW )
 # Try CONFIG mode first (TheRock), fall back to manual discovery (standalone)
 find_package(NUMA CONFIG QUIET)
 if(NUMA_FOUND)
-    # Normalize: ensure NUMA::NUMA target exists even if CONFIG only provides variables
-    if(NOT TARGET NUMA::NUMA)
-        add_library(NUMA::NUMA UNKNOWN IMPORTED)
+    # CONFIG mode provides numa::numa (lowercase)
+    # Use it directly if it exists, otherwise create NUMA::NUMA from variables
+    if(NOT TARGET numa::numa AND NOT TARGET NUMA::NUMA)
+        # CONFIG provided variables but no target - forward to NUMA_LIBRARIES
+        add_library(NUMA::NUMA INTERFACE IMPORTED)
         set_target_properties(NUMA::NUMA PROPERTIES
-            IMPORTED_LOCATION "${NUMA_LIBRARY}")
+            INTERFACE_LINK_LIBRARIES "${NUMA_LIBRARIES}")
+    elseif(TARGET numa::numa AND NOT TARGET NUMA::NUMA)
+        # Create NUMA::NUMA as an alias for compatibility
+        # Note: We use the lowercase target directly in target_link_libraries
+        add_library(NUMA::NUMA INTERFACE IMPORTED)
+        target_link_libraries(NUMA::NUMA INTERFACE numa::numa)
     endif()
 else()
     find_library(NUMA_LIBRARY NAMES numa PATHS /usr/lib /usr/local/lib)


### PR DESCRIPTION
Follow-up to PR #8221 kfdtest CMake modernization.

When NUMA is found via CONFIG mode (TheRock build), it provides a numa::numa (lowercase) target but not the NUMA_LIBRARY variable. The current code tried to use NUMA_LIBRARY which is undefined in CONFIG mode, causing:

  CMake Error: IMPORTED_LOCATION not set for imported target
  "NUMA::NUMA" configuration "Release"

Fix by extracting IMPORTED_LOCATION and INTERFACE_INCLUDE_DIRECTORIES from the lowercase numa::numa target and creating a proper uppercase NUMA::NUMA SHARED IMPORTED target. Falls back to NUMA_LIBRARIES variable if the target doesn't exist.

## Motivation
To modernize kfdtest build system


## Issue Tracking
JIRA ID: AILIKFD-40

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
