### PR TITLE
[rocprofiler-compute] Remove stale Strix Halo roofline comment

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -826,7 +826,6 @@ class OmniSoC_Base:
         console_debug("profiling", f"perform SoC post processing for {self.__arch}")
         # Roofline can be skipped via --no-roof
         # Roofline not supported on MI 100
-        # Roofline not supported on Strix Halo
         # If --filter-blocks is provided, roofline block (block 4) should be mentioned
         if (
             self.get_args().no_roof


### PR DESCRIPTION
## Motivation

The comment claiming roofline is unsupported on Strix Halo (gfx1151) contradicts the code: gfx1151 is in BENCHMARKING_SUPPORTED, so roofline does run on it.

## Technical Details

- Remove the "Roofline not supported on Strix Halo" comment in OmniSoC_Base.post_profiling()

## JIRA ID

JIRA ID: N/A

## Test Plan

- [x] Comment-only change, no code paths touched

## Test Result

- [x] gfx1151 remains in BENCHMARKING_SUPPORTED; roofline behavior unchanged

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.