### PR TITLE
fix(rocr): Fix invalid int-to-enum conversion in KFDEvictTest

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDEvictTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDEvictTest.cpp
@@ -63,7 +63,7 @@ void KFDEvictTest::AllocBuffers(bool m_IsParent, HSAuint32 defaultGPUNode, HSAui
               << totalMB << ")MB VRAM in KFD" << std::endl;
     }
 
-    HSAKMT_STATUS ret = 0;
+    HSAKMT_STATUS ret = HSAKMT_STATUS_SUCCESS;
     HSAuint32 retry = 0;
     m_Flags.Value = 0;
     m_Flags.ui32.PageSize = HSA_PAGE_SIZE_4KB;


### PR DESCRIPTION
Initialize HSAKMT_STATUS ret with HSAKMT_STATUS_SUCCESS instead of 0. Assigning the integer literal 0 to the HSAKMT_STATUS enum is an ill-formed conversion that GCC rejects by default (-fpermissive), breaking the kfdtest build. Use the proper enum value instead.

Build error:

  KFDEvictTest.cpp: In member function 'void KFDEvictTest::AllocBuffers(
  bool, HSAuint32, HSAuint32, HSAuint64, std::vector<void*>&)':
  KFDEvictTest.cpp:66:25: error: invalid conversion from 'int' to
  'HSAKMT_STATUS' {aka '_HSAKMT_STATUS'} [-fpermissive]
     66 |     HSAKMT_STATUS ret = 0;
        |                         ^
        |                         |
        |                         int
  make[2]: *** [CMakeFiles/kfdtest.dir/build.make:569:
  CMakeFiles/kfdtest.dir/src/KFDEvictTest.cpp.o] Error 1

## Motivation

Fix the kfdtest build failure on newer GCC toolchains (e.g. GCC 15.2).

## Technical Details

In KFDEvictTest::AllocBuffers, HSAKMT_STATUS ret = 0; implicitly converts int to the HSAKMT_STATUS enum, which GCC rejects by default. Changed it to HSAKMT_STATUS ret = HSAKMT_STATUS_SUCCESS; (same value 0, no behavior change).

## Test Plan

Rebuild kfdtest and confirm compilation succeeds.

## Test Result

KFDEvictTest.cpp compiles cleanly and kfdtest links successfully