### PR TITLE
ROCM-28796 - Fix kfdtest build failure

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDEvictTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDEvictTest.cpp
@@ -63,7 +63,7 @@ void KFDEvictTest::AllocBuffers(bool m_IsParent, HSAuint32 defaultGPUNode, HSAui
               << totalMB << ")MB VRAM in KFD" << std::endl;
     }
 
-    HSAKMT_STATUS ret = 0;
+    HSAKMT_STATUS ret;
     HSAuint32 retry = 0;
     m_Flags.Value = 0;
     m_Flags.ui32.PageSize = HSA_PAGE_SIZE_4KB;


### PR DESCRIPTION
Fix kfdtest build failure due to previous PR.

## Motivation

Fix kfdtest build failure 

## Technical Details

HSAKMT_STATUS ret should be initialized as HSAKMT_STATUS_SUCCESS.


## Issue Tracking

ROCM-28796

## Test Plan

kfdtest pass building

## Test Result

pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
