### PR TITLE
fix(rocshmem): Functional-test buffer sizing, dispatch, and tile team-count defects

### DIFF
--- a/projects/rocshmem/tests/functional_tests/team_alltoall_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_alltoall_tester.cpp
@@ -169,7 +169,7 @@ template <typename T1>
 void TeamAlltoallTester<T1>::resetBuffers(size_t size) {
 
   int num_elems = size / sizeof(T1);
-  int buff_size = num_elems * sizeof(T1) * args.num_wgs * n_pes;
+  size_t buff_size = num_elems * sizeof(T1) * args.num_wgs * n_pes;
   int idx = 0;
 
   for(unsigned int wg_id = 0; wg_id < args.num_wgs; wg_id++) {

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -939,6 +939,7 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
     case HostCtxCreateTestType:
       test_name = "Host CTX Create";
       testers.push_back(new HostCtxCreateTester(args));
+      break;
     case TeamSplit2DTestType:
       test_name = "Team Split 2D";
       testers.push_back(new TeamSplit2DTester(args));

--- a/projects/rocshmem/tests/functional_tests/tile_allgather_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tile_allgather_tester.cpp
@@ -216,7 +216,7 @@ __global__ void TileAllgatherTest(rocshmem_team_t *teams, int num_teams,
  *****************************************************************************/
 TileAllgatherTester::TileAllgatherTester(TesterArguments args)
     : Tester(args) {
-  num_teams = 4;  // Default to 4 teams
+  num_teams = args.num_wgs;  // Default to num_wgs teams.
 
   // Allocate teams using hipHostMalloc
   CHECK_HIP(hipHostMalloc(&teams, num_teams * sizeof(rocshmem_team_t)));

--- a/projects/rocshmem/tests/functional_tests/tile_broadcast_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tile_broadcast_tester.cpp
@@ -207,7 +207,7 @@ __global__ void TileBroadcastTest(rocshmem_team_t *teams, int num_teams,
  *****************************************************************************/
 TileBroadcastTester::TileBroadcastTester(TesterArguments args)
     : Tester(args) {
-  num_teams = 4;  // Default to 4 teams
+  num_teams = args.num_wgs;  // Default to num_wgs teams.
 
   // Allocate teams using hipHostMalloc
   CHECK_HIP(hipHostMalloc(&teams, num_teams * sizeof(rocshmem_team_t)));


### PR DESCRIPTION
# Fix functional-test buffer sizing, test dispatch, and tile team counts

## Motivation

This PR corrects several independent issues discovered while running the rocSHMEM functional test suite on AMD Instinct MI250X GPUs.

The issues affected:

- Large all-to-all test configurations.
- Selection of the host-context creation test.
- Tile collective configurations where the requested number of workgroups differed from the hard-coded number of teams.

## Technical Details

### Prevent integer overflow in the all-to-all tester

`TeamAlltoallTester::resetBuffers()` stored the computed buffer size in an `int`:

```cpp
int buff_size = num_elems * sizeof(T1) * args.num_wgs * n_pes;
```

Large message sizes and higher PE counts can cause this calculation to exceed the range of a 32-bit signed integer. The resulting overflow can produce an invalid buffer size and lead to incorrect allocations or memory-access failures.

This PR changes `buff_size` to `size_t`:

```cpp
size_t buff_size = num_elems * sizeof(T1) * args.num_wgs * n_pes;
```

This matches the type of the input size and the types expected by memory-allocation and memory-copy operations.

### Prevent `HostCtxCreateTestType` fallthrough

The `HostCtxCreateTestType` case in `Tester::create()` did not contain a terminating `break`.

Before the correction, selecting the host-context test also entered the following `TeamSplit2DTestType` case.

The observed behavior was:

```text
Requested operation: host_ctx_create
Reported test: Team Split 2D
```

This PR adds the missing `break`:

```cpp
case HostCtxCreateTestType:
  test_name = "Host CTX Create";
  testers.push_back(new HostCtxCreateTester(args));
  break;
```

The correction ensures that selecting `HostCtxCreateTestType` creates only the intended `HostCtxCreateTester`.

After this correction, the executable correctly reports:

```text
Creating Test: Host CTX Create
```

A separate runtime failure remains during host-context creation inside `HostInterface::acquire_window_context()`. That failure is independent of the test-selection fallthrough and is not addressed by this PR.

### Match tile all-gather team counts to the requested workgroups

`TileAllgatherTester` previously used a fixed number of teams:

```cpp
num_teams = 4;
```

The tile collective kernels associate team operations with the configured workgroups. A fixed team count can therefore disagree with `args.num_wgs`, particularly in tests configured with one workgroup.

This PR changes the initialization to:

```cpp
num_teams = args.num_wgs;
```

This keeps team allocation consistent with the number of workgroups requested by the test.

### Match tile broadcast team counts to the requested workgroups

`TileBroadcastTester` also previously used a fixed number of teams:

```cpp
num_teams = 4;
```

This PR changes it to:

```cpp
num_teams = args.num_wgs;
```

This keeps the number of allocated teams consistent with the workgroup configuration used by the tile broadcast kernel.

## Issue Tracking

FIXES issue #9493

## Test Plan

The changes were built and investigated using:

- rocSHMEM 3.6.0
- rocSHMEM source revision `0faeba51143054a65cb06303c96cb571c8138317`
- AMD Instinct MI250X GPUs
- `gfx90a`
- ROCm 7.2.0
- Cray MPICH 9.1.0
- Pure IPC and combined-backend builds
- A 6 GiB symmetric heap per PE

Validation included the following steps:

1. Rebuild the rocSHMEM library and functional-test executable after applying the source corrections.
2. Run all-to-all configurations across multiple PE counts and large message sizes.
3. Select operation 118 directly and verify that it executes `HostCtxCreateTester` instead of falling through to `TeamSplit2DTester`.
4. Run targeted tile all-gather configurations with workgroup counts that differ from four.
5. Run targeted tile broadcast configurations with workgroup counts that differ from four.
6. Compare execution through the installed CTest suite, the Frontier launcher, and rocSHMEM’s functional-test driver.

The host-context dispatch check used the equivalent of:

```bash
rocshmem_functional_tests \
    -a 118 \
    -w 1 \
    -z 1 \
    -localbuftype heap
```

Before the missing `break` was restored, this command reported:

```text
Creating Test: Team Split 2D
```

After the correction, it reported:

```text
Creating Test: Host CTX Create
```

## Test Result

- The modified rocSHMEM library and functional-test executable compile and link successfully.
- The all-to-all buffer-size calculation no longer stores the computed byte count in a 32-bit signed integer.
- `HostCtxCreateTestType` now dispatches to the intended tester without falling through to `TeamSplit2DTestType`.
- Tile all-gather now allocates a number of teams consistent with the requested number of workgroups.
- Tile broadcast now allocates a number of teams consistent with the requested number of workgroups.
- The test-selection correction was verified by observing the test banner before and after adding the missing `break`.
- A separate `host_ctx_create` runtime segmentation fault remains in `HostInterface::acquire_window_context()` and is outside the scope of this PR.

## Submission Checklist

- [x] I have reviewed the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
- [x] The changes are limited to the described functional-test corrections.
- [x] The rocSHMEM library and functional-test executable build successfully.
- [x] Relevant test configurations and remaining known failures are documented above.