### PR TITLE
fix(hip): skip incompatible devices during fat-binary extraction instead of aborting

### DIFF
--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -688,11 +688,19 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
           break;
         }
       } else {
-        // We found neither a compatible code object nor SPIRV
-        LogPrintfError(
-            "No compatible code objects found with HIP_FORCE_SPIRV_CODEOBJECT=%d. Rebuild the application with option --offload-arch=%s",
-             HIP_FORCE_SPIRV_CODEOBJECT, device->devices()[0]->isa().targetId());
-        break;
+        // No compatible code object (native, generic, or SPIR-V) is present for
+        // this device. Skip it instead of aborting: other devices in the list
+        // may still have a matching code object. Aborting here makes fat-binary
+        // registration fail for *every* device whenever a single enumerated
+        // device is unsupported (e.g. an iGPU enumerated ahead of a supported
+        // dGPU), which then surfaces as hipErrorInvalidImage on the supported
+        // device even though its code object is present in the bundle.
+        LogPrintfInfo(
+            "Skipping device with no compatible code object "
+            "(HIP_FORCE_SPIRV_CODEOBJECT=%d); rebuild with --offload-arch=%s to "
+            "add support for this device",
+            HIP_FORCE_SPIRV_CODEOBJECT, device->devices()[0]->isa().targetId());
+        continue;
       }
     }
   } while (0);

--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -729,11 +729,19 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
           break;
         }
       } else {
-        // We found neither a compatible code object nor SPIRV
-        LogPrintfError(
-            "No compatible code objects found with HIP_FORCE_SPIRV_CODEOBJECT=%d. Rebuild the application with option --offload-arch=%s",
-             HIP_FORCE_SPIRV_CODEOBJECT, device->devices()[0]->isa().targetId());
-        break;
+        // No compatible code object (native, generic, or SPIR-V) is present for
+        // this device. Skip it instead of aborting: other devices in the list
+        // may still have a matching code object. Aborting here makes fat-binary
+        // registration fail for *every* device whenever a single enumerated
+        // device is unsupported (e.g. an iGPU enumerated ahead of a supported
+        // dGPU), which then surfaces as hipErrorInvalidImage on the supported
+        // device even though its code object is present in the bundle.
+        LogPrintfInfo(
+            "Skipping device with no compatible code object "
+            "(HIP_FORCE_SPIRV_CODEOBJECT=%d); rebuild with --offload-arch=%s to "
+            "add support for this device",
+            HIP_FORCE_SPIRV_CODEOBJECT, device->devices()[0]->isa().targetId());
+        continue;
       }
     }
   } while (0);

--- a/projects/hip-tests/catch/config/configs/unit/module.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/module.yaml
@@ -314,3 +314,13 @@ module:
   Unit_hipFuncGetAttributes_basic:
     <<: *level_2
     tags: [function]
+  Unit_FatBin_NoCompatibleCodeObject_ReturnsInvalidImage:
+    <<: *level_2
+    # Fixture fatbin_mismatch_module.code is built only on the amd platform.
+    disabled: [nvidia_linux, nvidia_windows]
+    tags: [load]
+  Unit_FatBin_MixedArch_IncompatibleDeviceDoesNotPoisonOthers:
+    <<: *level_2
+    # Compiled-in kernel path; fixture/build support is amd-only.
+    disabled: [nvidia_linux, nvidia_windows]
+    tags: [load]

--- a/projects/hip-tests/catch/config/configs/unit/module.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/module.yaml
@@ -315,3 +315,13 @@ module:
   Unit_hipFuncGetAttributes_basic:
     <<: *level_2
     tags: [function]
+  Unit_FatBin_NoCompatibleCodeObject_ReturnsInvalidImage:
+    <<: *level_2
+    # Fixture fatbin_mismatch_module.code is built only on the amd platform.
+    disabled: [nvidia_linux, nvidia_windows]
+    tags: [load]
+  Unit_FatBin_MixedArch_IncompatibleDeviceDoesNotPoisonOthers:
+    <<: *level_2
+    # Compiled-in kernel path; fixture/build support is amd-only.
+    disabled: [nvidia_linux, nvidia_windows]
+    tags: [load]

--- a/projects/hip-tests/catch/unit/module/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/module/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TEST_SRC
     hipDrvLaunchKernelEx.cc
     hipModuleGetFunctionCount.cc
     hipModuleLoadFatBinary.cc
+    test_fatbin_mixed_arch.cc
 )
 
 if (HIP_PLATFORM MATCHES "amd")
@@ -38,6 +39,24 @@ else()
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/get_function_module.cc)
 endif()
 add_custom_target(get_function_module DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/get_function_module.code)
+
+# Deliberately-mismatched fat binary for Unit_FatBin_NoCompatibleCodeObject_*:
+# built for gfx900+gfx906 only (fixed archs, NOT ${OFFLOAD_ARCH_LIST}) so it
+# never matches a modern (non-Vega) runner and drives ExtractFatBinaryUsingCOMGR
+# into its "no compatible code object" path.
+if (HIP_PLATFORM MATCHES "amd")
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/fatbin_mismatch_module.code
+                   COMMAND ${CMAKE_HIP_COMPILER} ${HIP_DEVICE_BUILD_FLAGS_NO_ARCH}
+                   --offload-arch=gfx900 --offload-arch=gfx906 --cuda-device-only
+                   -x hip ${CMAKE_CURRENT_SOURCE_DIR}/fatbin_mismatch_module.cc
+                   -I${HIP_INCLUDE_DIR} ${HIP_PATH_OPT}
+                   -o fatbin_mismatch_module.code
+                   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/fatbin_mismatch_module.cc)
+  add_custom_target(fatbin_mismatch_module
+                    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/fatbin_mismatch_module.code)
+  set_property(GLOBAL APPEND PROPERTY G_INSTALL_CUSTOM_TARGETS
+               ${CMAKE_CURRENT_BINARY_DIR}/fatbin_mismatch_module.code)
+endif()
 
 if (NOT WIN32)
   if (HIP_PLATFORM MATCHES "amd")
@@ -432,6 +451,7 @@ if(HIP_PLATFORM MATCHES "amd")
   # These are loaded at runtime by tests in the ModuleTest binary.
   add_dependencies(ModuleTest copyKernel_code copyKernel_s)
   add_dependencies(ModuleTest addKernel_code)
+  add_dependencies(ModuleTest fatbin_mismatch_module)
   # TODO - Rock build failure from clang
   if(NOT WIN32)
     add_dependencies(ModuleTest addKernel_spv)

--- a/projects/hip-tests/catch/unit/module/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/module/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TEST_SRC
     hipDrvLaunchKernelEx.cc
     hipModuleGetFunctionCount.cc
     hipModuleLoadFatBinary.cc
+    test_fatbin_mixed_arch.cc
 )
 
 if (HIP_PLATFORM MATCHES "amd")
@@ -38,6 +39,24 @@ else()
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/get_function_module.cc)
 endif()
 add_custom_target(get_function_module DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/get_function_module.code)
+
+# Deliberately-mismatched fat binary for Unit_FatBin_NoCompatibleCodeObject_*:
+# built for gfx900+gfx906 only (fixed archs, NOT ${OFFLOAD_ARCH_LIST}) so it
+# never matches a modern (non-Vega) runner and drives ExtractFatBinaryUsingCOMGR
+# into its "no compatible code object" path.
+if (HIP_PLATFORM MATCHES "amd")
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/fatbin_mismatch_module.code
+                   COMMAND ${CMAKE_HIP_COMPILER} ${HIP_DEVICE_BUILD_FLAGS_NO_ARCH}
+                   --offload-arch=gfx900 --offload-arch=gfx906 --cuda-device-only
+                   -x hip ${CMAKE_CURRENT_SOURCE_DIR}/fatbin_mismatch_module.cc
+                   -I${HIP_INCLUDE_DIR} ${HIP_PATH_OPT}
+                   -o fatbin_mismatch_module.code
+                   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/fatbin_mismatch_module.cc)
+  add_custom_target(fatbin_mismatch_module
+                    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/fatbin_mismatch_module.code)
+  set_property(GLOBAL APPEND PROPERTY G_INSTALL_CUSTOM_TARGETS
+               ${CMAKE_CURRENT_BINARY_DIR}/fatbin_mismatch_module.code)
+endif()
 
 if (NOT WIN32)
   if (HIP_PLATFORM MATCHES "amd")
@@ -414,6 +433,7 @@ if(HIP_PLATFORM MATCHES "amd")
   # These are loaded at runtime by tests in the ModuleTest binary.
   add_dependencies(ModuleTest copyKernel_code copyKernel_s)
   add_dependencies(ModuleTest addKernel_code)
+  add_dependencies(ModuleTest fatbin_mismatch_module)
   # TODO - Rock build failure from clang
   if(NOT WIN32)
     add_dependencies(ModuleTest addKernel_spv)

--- a/projects/hip-tests/catch/unit/module/fatbin_mismatch_module.cc
+++ b/projects/hip-tests/catch/unit/module/fatbin_mismatch_module.cc
@@ -1,0 +1,19 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+
+SPDX-License-Identifier: MIT
+*/
+
+/*
+Fixture for Unit_FatBin_NoCompatibleCodeObject_ReturnsInvalidImage.
+
+This is compiled by CMake into fatbin_mismatch_module.code targeting gfx900 and
+gfx906 ONLY (two Vega archs), producing a multi-entry offload bundle. Loaded on
+any non-Vega device, no bundle entry matches the device's ISA, which drives
+FatBinaryInfo::ExtractFatBinaryUsingCOMGR through its "no compatible code object"
+else-branch and must return hipErrorInvalidImage.
+*/
+
+#include <hip/hip_runtime.h>
+
+extern "C" __global__ void mismatch_kernel(int* out) { *out = 1; }

--- a/projects/hip-tests/catch/unit/module/test_fatbin_mixed_arch.cc
+++ b/projects/hip-tests/catch/unit/module/test_fatbin_mixed_arch.cc
@@ -1,0 +1,150 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+
+SPDX-License-Identifier: MIT
+*/
+
+/*
+Regression tests for the fat-binary code-object selection fix in
+projects/clr/hipamd/src/hip_fatbin.cpp
+(FatBinaryInfo::ExtractFatBinaryUsingCOMGR).
+
+Bug (ROCm/TheRock#5543): the extraction loop iterated over *all* enumerated
+devices and executed `break` on the first device that had no compatible code
+object in the fat binary. Every device enumerated *after* that one therefore
+never had its program registered, and a later kernel launch on it failed with
+hipErrorInvalidImage -- even though its code object was present in the binary.
+The fix replaces that `break` with `continue`, so an incompatible device is
+skipped instead of poisoning registration for the others.
+
+Two things are verified:
+
+  1. Unit_FatBin_NoCompatibleCodeObject_ReturnsInvalidImage
+       Contract guard (deterministic, single GPU): loading a fat binary that
+       contains no code object matching the current device must still fail with
+       hipErrorInvalidImage. This exercises the modified else-branch and proves
+       `continue` preserves the "no compatible code object" failure (hip_status
+       is initialized to hipErrorInvalidImage and is left untouched when every
+       device is skipped).
+
+  2. Unit_FatBin_MixedArch_IncompatibleDeviceDoesNotPoisonOthers
+       End-to-end regression (multi-GPU): with an incompatible device present
+       (and possibly enumerated first), a compiled-in kernel must still run on
+       a device whose arch IS in the binary. This is the actual #5543 scenario
+       and only reaches the buggy path via the static __hipRegisterFatBinary /
+       StatCO::DigestFatBinary(g_devices) route, hence a compiled-in kernel
+       (not hipModuleLoad*, which is single-device).
+
+Note: #2 only exercises the incompatible-device path when at least one
+enumerated device's arch is absent from the fat binary, i.e. on a system with
+>= 2 distinct archs where the binary is built for a subset. It skips otherwise
+and never produces a false failure. There is no public API to inject a
+controlled multi-device fat binary, so a fully hardware-independent bug-catcher
+for the multi-device loop is not possible.
+*/
+
+#include <hip_test_common.hh>
+#include <hip/hip_runtime.h>
+
+#include <set>
+#include <string>
+#include <vector>
+
+__global__ void writeValueKernel(int* out, int value) { *out = value; }
+
+// Attempt to launch the compiled-in kernel on `dev`. Returns true if the kernel
+// ran and produced the expected value; false if the device had no compatible
+// code object (a legitimate outcome for an unsupported device).
+static bool LaunchKernelOnDevice(int dev, int expected) {
+  HIP_CHECK(hipSetDevice(dev));
+  int* d = nullptr;
+  HIP_CHECK(hipMalloc(&d, sizeof(int)));
+  HIP_CHECK(hipMemset(d, 0, sizeof(int)));
+
+  writeValueKernel<<<1, 1>>>(d, expected);
+  hipError_t launchErr = hipGetLastError();
+  hipError_t syncErr = hipDeviceSynchronize();
+
+  bool ran = (launchErr == hipSuccess && syncErr == hipSuccess);
+  if (ran) {
+    int host = 0;
+    HIP_CHECK(hipMemcpy(&host, d, sizeof(int), hipMemcpyDeviceToHost));
+    REQUIRE(host == expected);
+  } else {
+    // A device with no compatible code object in the binary may fail here; that
+    // is acceptable. What must NOT happen (pre-fix behavior) is that this failure
+    // is observed on *every* device because an incompatible one aborted the whole
+    // registration loop.
+    REQUIRE((launchErr == hipErrorInvalidImage || syncErr == hipErrorInvalidImage ||
+             launchErr == hipErrorInvalidKernelFile ||
+             syncErr == hipErrorInvalidKernelFile ||
+             launchErr == hipErrorSharedObjectInitFailed ||
+             syncErr == hipErrorSharedObjectInitFailed));
+    (void)hipGetLastError();  // clear sticky error
+  }
+
+  HIP_CHECK(hipFree(d));
+  return ran;
+}
+
+/*
+ * Deterministic contract guard: a fat binary with no code object for the current
+ * device's arch must fail with hipErrorInvalidImage. fatbin_mismatch_module.code
+ * is built for gfx900 + gfx906 only (see CMakeLists.txt); on any non-Vega device
+ * neither arch matches, driving ExtractFatBinaryUsingCOMGR into the modified
+ * else-branch. Skips on gfx900/gfx906 so the fixture is guaranteed incompatible.
+ */
+HIP_TEST_CASE(Unit_FatBin_NoCompatibleCodeObject_ReturnsInvalidImage) {
+  hipDeviceProp_t prop;
+  HIP_CHECK(hipGetDeviceProperties(&prop, 0));
+  const std::string arch(prop.gcnArchName);
+  if (arch.rfind("gfx900", 0) == 0 || arch.rfind("gfx906", 0) == 0) {
+    HIP_SKIP_TEST("Fixture is built for gfx900/gfx906; current device matches it");
+    return;
+  }
+
+  hipModule_t module = nullptr;
+  // Observed as hipErrorInvalidImage; accept hipErrorNoBinaryForGpu too since some
+  // stacks surface the "no code object for this device" case with that code.
+  HIP_CHECK_ERRORS(hipModuleLoad(&module, "fatbin_mismatch_module.code"),
+                   hipErrorInvalidImage, hipErrorNoBinaryForGpu);
+}
+
+/*
+ * End-to-end #5543 regression: on a multi-GPU system with >= 2 distinct archs,
+ * a compiled-in kernel must run on at least one device even when an incompatible
+ * device is also enumerated. Pre-fix, an incompatible device sorted ahead of a
+ * supported one aborted registration for all devices and no launch succeeded.
+ */
+HIP_TEST_CASE(Unit_FatBin_MixedArch_IncompatibleDeviceDoesNotPoisonOthers) {
+  int numDevices = 0;
+  HIP_CHECK(hipGetDeviceCount(&numDevices));
+  if (numDevices < 2) {
+    HIP_SKIP_TEST("Requires >= 2 GPUs to exercise the multi-device extraction loop");
+    return;
+  }
+
+  std::set<std::string> archs;
+  for (int i = 0; i < numDevices; ++i) {
+    hipDeviceProp_t prop;
+    HIP_CHECK(hipGetDeviceProperties(&prop, i));
+    archs.insert(std::string(prop.gcnArchName));
+  }
+  if (archs.size() < 2) {
+    HIP_SKIP_TEST(
+        "Requires >= 2 distinct GPU archs (a single-arch fat binary covers "
+        "every device, so the incompatible-device path is never reached)");
+    return;
+  }
+
+  int ranCount = 0;
+  for (int dev = 0; dev < numDevices; ++dev) {
+    if (LaunchKernelOnDevice(dev, 0xABC + dev)) ++ranCount;
+  }
+  INFO("devices=" << numDevices << " distinctArchs=" << archs.size()
+                  << " devicesThatRan=" << ranCount);
+
+  // The crux of the fix: presence of an incompatible device must not prevent the
+  // supported device(s) from running the kernel.
+  REQUIRE(ranCount >= 1);
+}


### PR DESCRIPTION
## Motivation

Part of https://github.com/ROCm/TheRock/issues/5543 — multi-GPU HIP kernel launch portability.

On a system with more than one GPU, a HIP kernel launch on a *supported* device fails with `hipErrorInvalidImage` if an *unsupported* device is enumerated ahead of it — even though the supported device's code object is present in the fat binary. `FatBinaryInfo::ExtractFatBinaryUsingCOMGR` iterates **all** devices and `break`s out of the whole loop the moment it hits a device with no matching code object, so devices later in the list never get their program registered.

## Technical Details

`ExtractFatBinaryUsingCOMGR` is called with the full device list from the static fat-binary registration path (`StatCO::DigestFatBinary → ExtractFatBinaryUsingCOMGR(g_devices)`), used by compiled-in kernels (`__hipRegisterFatBinary`). If the first device in `g_devices` is unsupported, the `else` branch fires, the loop `break`s before any supported device is processed, and the function returns the initial `hipErrorInvalidImage` — poisoning the whole fat binary. The failure is order-dependent (typical for an iGPU at `cuda:0` + dGPU at `cuda:1`).

**Fix:** change the else-branch `break` to `continue`, so an incompatible device is skipped rather than aborting registration for all devices. The diagnostic is retained but downgraded from `LogPrintfError` to `LogPrintfInfo` and reworded to "Skipping…", since it is no longer fatal. The `if (hip_status != hipSuccess) break;` in the native/generic/SPIR-V branches stay as `break` — those are genuine code-object *load* failures and should still abort.

Return value is now order-independent: registration succeeds iff **any** device has a compatible code object. No configuration that previously succeeded regresses.

| devices | old `break` | new `continue` |
|---|---|---|
| none valid | InvalidImage | **InvalidImage** (same) |
| valid first, invalid after | success | success |
| invalid first, valid after | InvalidImage (bug) | success (fixed) |
| genuine `AddDevProgram` load failure | error | error (unchanged) |

- File changed: `projects/clr/hipamd/src/hip_fatbin.cpp`

**Review focus:** skipped devices leave their `dev_programs_[i]` slot unbuilt. The kernel-launch path handles this gracefully (verified), and this partial state was already reachable pre-fix (supported-first/incompatible-last also left a null slot), but reviewers should confirm the other consumers tolerate it — `hipModuleGetFunction`/symbol lookup, texture/surface refs, and global-var registration on the skipped device.

## Issue Tracking

- GitHub issue: https://github.com/ROCm/TheRock/issues/5543

## Test Plan

Adds `projects/hip-tests/catch/unit/module/test_fatbin_mixed_arch.cc` (registered under `ModuleTest`):
- **`Unit_FatBin_NoCompatibleCodeObject_ReturnsInvalidImage`** — deterministic single-GPU contract guard. Loads a bundle built for gfx900+gfx906 only, drives the modified `else` branch, asserts it still returns `hipErrorInvalidImage`.
- **`Unit_FatBin_MixedArch_IncompatibleDeviceDoesNotPoisonOthers`** — end-to-end #5543 regression, multi-GPU. Launches a compiled-in kernel on every device and requires at least one runs.

Coverage caveat: the multi-device bug lives only in the static `__hipRegisterFatBinary` path; `hipModuleLoad*` goes through `DynCO` (single device), so there is no public API to inject a controlled multi-device fat binary. Test #1 is a single-device contract guard; test #2 only *reaches* the incompatible-device path with ≥2 distinct archs where the binary covers a subset, and skips cleanly otherwise.

Planned coverage:
- CI build of clr / hip-tests
- Existing HIP fat-binary / module unit tests
- `ModuleTest` — `Unit_FatBin_*` (new)
- Multi-GPU heterogeneous-arch smoke test, both device orders
- Single-GPU regression (supported and unsupported arch)

## Test Result

Reproduced on real hardware (RX 7600 gfx1102 + RX 9060 XT gfx1200, Windows; runtime sorts gfx1102 → `cuda:0`, gfx1200 → `cuda:1`) using TheRock `gfx120X-all` wheel (bundle has gfx1200, not gfx1102) — the exact #5543 shape:

| Case | Before | After patch |
|---|---|---|
| launch on supported 9060, 7600 first | `hipErrorInvalidImage` | works |
| Hide 7600 (`HIP_VISIBLE_DEVICES=1`) | works (workaround) | works |
| Launch on genuinely-unsupported 7600 | fails | fails (correct) |
| Only unsupported card visible | InvalidImage | InvalidImage (unchanged) |

Fix validated by binary-patching the shipped `amdhip64` with the equivalent `break`→`continue`; this PR is the source form with the log retained.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.