### PR TITLE
[rocprofiler-sdk] Fix --ompt-trace task aborting the profiled application

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/ompt/ompt.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/ompt/ompt.cpp
@@ -190,14 +190,9 @@ ompt_task_schedule_callback(ompt_data_t*       prior_task_data,
     auto* state_prior = as_task_state(pprior);
     if(state_prior == nullptr)
     {
-        // An empty slot is only expected for the trailing early_fulfill case; a
-        // non-empty slot here is an implicit task (ompt_save_state), which has no
-        // explicit-task correlation to pop/retire -- fall through to handle next_task.
-        if(pprior->ptr == nullptr)
-        {
-            if(prior_task_status == ompt_task_early_fulfill) return;
-            ROCP_FATAL << "state_prior == nullptr prior_task_status: " << prior_task_status << ".";
-        }
+        // An implicit task has no explicit-task correlation to pop or retire, and has no
+        // saved state at all unless implicit_task is among the enabled operations.
+        if(pprior->ptr == nullptr && prior_task_status == ompt_task_early_fulfill) return;
     }
     else
     {

--- a/projects/rocprofiler-sdk/tests/rocprofv3/ompt/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/ompt/CMakeLists.txt
@@ -196,6 +196,44 @@ rocprofiler_add_integration_validate_test(
     FIXTURES_REQUIRED rocprofv3-test-ompt-host-parallel
     DISABLED "${IS_HOST_DISABLED}")
 
+# Host-side granular filter: --ompt-trace task must record only the task-category
+# operations (no parallel/sync/mutex/target leakage). Uses 4 threads so that tasks are
+# scheduled across worker threads rather than run inline.
+set(ompt-host-task-output-dir ${CMAKE_CURRENT_BINARY_DIR}/openmp-host-task-trace)
+set(ompt-host-task-env
+    "OMP_NUM_THREADS=4"
+    "OMP_DISPLAY_ENV=1"
+    "ROCR_VISIBLE_DEVICES=0"
+    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
+    )
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-ompt-host-task
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --ompt-trace=task -d
+        ${ompt-host-task-output-dir} -o out --output-format rocpd --log-level env --
+        $<IF:$<TARGET_EXISTS:openmp-host>,$<TARGET_FILE:openmp-host>,openmp-host>
+    DEPENDS openmp-host
+    TIMEOUT 100
+    LABELS "integration-tests;openmp-host"
+    ENVIRONMENT "${ompt-host-task-env}"
+    PRELOAD "${PRELOAD_ENV}"
+    FIXTURES_SETUP rocprofv3-test-ompt-host-task
+    DISABLED "${IS_HOST_DISABLED}")
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-ompt-host-task
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    ARGS ${PYTEST_ARGS} -k test_granular_host_filter_only_task_ops --rocpd-input
+         ${ompt-host-task-output-dir}/out_results.db
+    DISCOVERY_ARGS ${PYTEST_ARGS} -k test_granular_host_filter_only_task_ops
+    TIMEOUT 45
+    LABELS "integration-tests;openmp-host"
+    FIXTURES_REQUIRED rocprofv3-test-ompt-host-task
+    DISABLED "${IS_HOST_DISABLED}")
+
 # Explicit "trace everything" form
 set(ompt-all-output-dir ${CMAKE_CURRENT_BINARY_DIR}/openmp-target-all-trace)
 rocprofiler_add_integration_execute_test(

--- a/projects/rocprofiler-sdk/tests/rocprofv3/ompt/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/ompt/validate.py
@@ -55,6 +55,15 @@ PARALLEL_CATEGORY_OPS = {
     "omp_masked",
 }
 
+# Likewise for the "task" category. Note that omp_implicit_task is not in this set: it
+# belongs to "parallel".
+TASK_CATEGORY_OPS = {
+    "omp_task_create",
+    "omp_task_schedule",
+    "omp_dependences",
+    "omp_task_dependence",
+}
+
 # Representative host-side (CPU) OpenMP operations
 HOST_PARALLEL_OPS = ("omp_parallel_begin", "omp_parallel_end")
 HOST_WORK_OPS = ("omp_work", "omp_sync_region", "omp_dispatch")
@@ -186,6 +195,25 @@ def test_granular_host_filter_only_parallel_ops(rocpd_conn):
         op in ops
         for op in ("omp_parallel_begin", "omp_parallel_end", "omp_implicit_task")
     ), f"--ompt-trace parallel produced no parallel-region records; saw: {sorted(ops)}"
+
+
+def test_granular_host_filter_only_task_ops(rocpd_conn):
+    """Counterpart to the parallel filter: --ompt-trace task must record only the
+    task-category operations, must not leak parallel/sync/mutex/target ops, and must
+    record the explicit tasks the workload creates."""
+    ops = set(_ompt_op_counts(rocpd_conn))
+    if not ops:
+        pytest.skip("no OMPT records present; the task-filter run was likely not run")
+
+    leaks = {op for op in ops if op not in TASK_CATEGORY_OPS}
+    assert not leaks, (
+        f"--ompt-trace task leaked non-task-category operations into the trace: "
+        f"{sorted(leaks)}"
+    )
+    for op in ("omp_task_create", "omp_task_schedule"):
+        assert (
+            op in ops
+        ), f"--ompt-trace task produced no {op!r} records; saw: {sorted(ops)}"
 
 
 def test_ompt_all_form_is_complete(rocpd_conn):


### PR DESCRIPTION
## Motivation

`rocprofv3 --ompt-trace task` aborts the profiled application on any host
OpenMP task workload: `ompt.cpp:199 state_prior == nullptr prior_task_status:
7`, SIGABRT, exit 134. Deterministic and architecture-independent.

## Technical Details

OMPT callbacks are registered with the OpenMP runtime per operation, and a
task's internal slot is only populated by `task_create` (explicit tasks) or
`implicit_task` begin. `implicit_task` resolves under the **parallel**
category while `task_schedule` resolves under **task**, so `--ompt-trace task`
traces `task_schedule` with nothing to populate an implicit task's slot.
`ompt_task_schedule_callback` treated an empty prior slot as impossible outside
a trailing `early_fulfill` and hit `ROCP_FATAL`. Status 7 is
`ompt_task_switch`, which every worker thread raises when it picks up a
deferred task at a taskwait, hence the simultaneous aborts across threads.

An empty prior slot simply means there is no explicit-task correlation to pop
or retire, which the rest of the callback already handles: `state_prior` is
never dereferenced on that path (the pop is in the `else`, `state_next` is
independent, the retire is guarded). Removing the fatal is the whole fix; no
other behavior changes.

Adding `implicit_task` to the `task` category was rejected as an alternative:
it would emit implicit-task records under `--ompt-trace task`, breaking the
no-leakage contract the granular-category tests assert.

## JIRA ID

JIRA ID : AIPROFSDK-994

## Test Plan

New `rocprofv3-test-ompt-host-task` execute/validate pair covering
`--ompt-trace=task` on `openmp-host` at 4 threads, reproducing the ticket's
command line. Granular-category coverage previously existed only for `target`
and `parallel`, so nothing exercised the `task` filter and CI never saw this.

## Test Result

Verified on gfx942 (MI300-class, one of the ASICs in AIPROFSDK-994; gfx1250
and gfx950 were not tested here), rocprofiler-sdk 1.3.5 built from `develop`,
ROCm 7.2.3 install.

- Reproduced the reported failure exactly: `ompt.cpp:199 state_prior ==
  nullptr prior_task_status: 7` on multiple threads, core dump, exit 134.
- Before the fix: 20/20 abort at 4 threads and 20/20 at 2 threads.
- After the fix: 0 failures in 380 stress runs (4/8/16 threads) plus a 72-run
  category matrix at 2/4/8 threads over nine `--ompt-trace` combinations.
- The new test aborts (`Subprocess aborted`) without the code change.
- OMPT suite 19/19; broader tracing sweep 93/93.
- AddressSanitizer clean over 8 runs (4 category combinations x 2 thread
  counts), zero errors.
- Filtering drops nothing: 16 `omp_task_create` for the workload's 16 tasks
  and 32 `omp_task_schedule` under `--ompt-trace task`, identical to the counts
  under `parallel task` and `all`.
## Submission Checklist

- [x] Look over the contributing guidelines at <https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests>