### PR TITLE
feat(hipfile): Add fastpath backend support to hipFile[Read|Write]Async()

### DIFF
--- a/projects/hipfile/src/amd_detail/async.cpp
+++ b/projects/hipfile/src/amd_detail/async.cpp
@@ -102,7 +102,7 @@ AsyncOp::AsyncOp(IoType _io_type, std::shared_ptr<IFile> _file, std::shared_ptr<
                                             : std::variant<const hoff_t, hoff_t *>{_file_offset}},
       buffer_offset{stream->fixedBufferOffset() ? std::variant<const hoff_t, hoff_t *>{*_buffer_offset}
                                                 : std::variant<const hoff_t, hoff_t *>{_buffer_offset}},
-      bytes_transferred{_bytes_transferred}
+      bytes_transferred{_bytes_transferred}, bytes_transferred_internal{0}
 {
 }
 

--- a/projects/hipfile/src/amd_detail/async.cpp
+++ b/projects/hipfile/src/amd_detail/async.cpp
@@ -111,3 +111,22 @@ AsyncOp::~AsyncOp()
 }
 
 }
+
+extern "C" {
+void
+async_io_cleanup(void *userargs)
+{
+    using namespace hipFile;
+    auto     op                         = static_cast<AsyncOp *>(userargs);
+    ssize_t *bytes_transferred          = op->bytes_transferred;
+    ssize_t  bytes_transferred_internal = op->bytes_transferred_internal;
+    try {
+        Context<AsyncMonitor>::get()->completeOp(op);
+    }
+    catch (const std::invalid_argument &) {
+        *bytes_transferred = -hipFileInternalError;
+        return;
+    }
+    *bytes_transferred = bytes_transferred_internal;
+}
+}

--- a/projects/hipfile/src/amd_detail/async.h
+++ b/projects/hipfile/src/amd_detail/async.h
@@ -40,6 +40,7 @@ public:
     std::variant<const hoff_t, hoff_t *> file_offset;
     std::variant<const hoff_t, hoff_t *> buffer_offset;
     ssize_t *const                       bytes_transferred;
+    ssize_t                              bytes_transferred_internal;
 
     AsyncOp(const AsyncOp &)            = delete;
     AsyncOp &operator=(const AsyncOp &) = delete;

--- a/projects/hipfile/src/amd_detail/async.h
+++ b/projects/hipfile/src/amd_detail/async.h
@@ -71,3 +71,7 @@ private:
     bool                                                 is_finished;
 };
 }
+
+extern "C" {
+void async_io_cleanup(void *userargs);
+}

--- a/projects/hipfile/src/amd_detail/backend.h
+++ b/projects/hipfile/src/amd_detail/backend.h
@@ -9,6 +9,7 @@
 #include "file.h"
 #include "hip.h"
 #include "io.h"
+#include "stream.h"
 #include "sys.h"
 
 #include <climits>
@@ -90,6 +91,20 @@ struct Backend {
     /// @throws Hip::RuntimeError Sys::RuntimeError
     virtual ssize_t io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
                        hoff_t file_offset, hoff_t buffer_offset);
+
+    /// @brief Perform a read or write operation
+    ///
+    /// @param type                      IO type (read/write)
+    /// @param file                      File to read from or write to
+    /// @param buffer                    Buffer to write to or read from
+    /// @param size_p                    Number of bytes to transfer
+    /// @param file_offset_p             Offset from the start of the file
+    /// @param buffer_offset_p           Offset from the start of the buffer
+    /// @param [out] bytes_transferred_p Number of bytes transferred
+    /// @param stream                    Stream to perform the operation on
+    virtual void async_io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer,
+                          size_t *size_p, hoff_t *file_offset_p, hoff_t *buffer_offset_p,
+                          ssize_t *bytes_transferred_p, std::shared_ptr<IStream> stream) = 0;
 
 protected:
     /// @brief Perform a read or write operation

--- a/projects/hipfile/src/amd_detail/backend/asyncop-fallback.cpp
+++ b/projects/hipfile/src/amd_detail/backend/asyncop-fallback.cpp
@@ -44,9 +44,8 @@ AsyncOpFallback::AsyncOpFallback(IoType _io_type, std::shared_ptr<IFile> _file,
                                  ssize_t *_bytes_transferred)
     : AsyncOp{_io_type, std::move(_file), std::move(_buffer), std::move(_stream),
               _size,    _file_offset,     _buffer_offset,     _bytes_transferred},
-      submitted_size{std::min(*_size, hipFile::getMaxRwCount())}, bytes_transferred_internal{0},
-      gpu_buffer{buffer->getBuffer()}, bounce_buffer_dev_ptr{nullptr},
-      bounce_buffer{nullptr, [](void *addr) { (void)addr; }}
+      submitted_size{std::min(*_size, hipFile::getMaxRwCount())}, gpu_buffer{buffer->getBuffer()},
+      bounce_buffer_dev_ptr{nullptr}, bounce_buffer{nullptr, [](void *addr) { (void)addr; }}
 {
     void *host_ptr = Context<Hip>::get()->hipHostMalloc(submitted_size, 0);
     std::unique_ptr<void, decltype(&hipHostDeleter)> _bounce_buffer{host_ptr, hipHostDeleter};

--- a/projects/hipfile/src/amd_detail/backend/asyncop-fallback.h
+++ b/projects/hipfile/src/amd_detail/backend/asyncop-fallback.h
@@ -27,7 +27,6 @@ namespace hipFile {
 
 struct AsyncOpFallback : AsyncOp {
     size_t      submitted_size;
-    ssize_t     bytes_transferred_internal;
     void *const gpu_buffer;
     void       *bounce_buffer_dev_ptr;
 

--- a/projects/hipfile/src/amd_detail/backend/fallback.cpp
+++ b/projects/hipfile/src/amd_detail/backend/fallback.cpp
@@ -239,22 +239,6 @@ async_io_bind_params(void *userargs)
 }
 
 void
-async_io_cleanup(void *userargs)
-{
-    auto     op                         = static_cast<AsyncOpFallback *>(userargs);
-    ssize_t *bytes_transferred          = op->bytes_transferred;
-    ssize_t  bytes_transferred_internal = op->bytes_transferred_internal;
-    try {
-        Context<AsyncMonitor>::get()->completeOp(op);
-    }
-    catch (const std::invalid_argument &) {
-        *bytes_transferred = -hipFileInternalError;
-        return;
-    }
-    *bytes_transferred = bytes_transferred_internal;
-}
-
-void
 async_io_cpu_copy(void *userargs)
 {
     auto         op                = static_cast<AsyncOpFallback *>(userargs);

--- a/projects/hipfile/src/amd_detail/backend/fallback.h
+++ b/projects/hipfile/src/amd_detail/backend/fallback.h
@@ -52,6 +52,5 @@ protected:
 
 extern "C" {
 void async_io_bind_params(void *userargs);
-void async_io_cleanup(void *userargs);
 void async_io_cpu_copy(void *userargs);
 }

--- a/projects/hipfile/src/amd_detail/backend/fallback.h
+++ b/projects/hipfile/src/amd_detail/backend/fallback.h
@@ -34,7 +34,7 @@ struct Fallback : public Backend {
 
     void async_io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t *size_p,
                   hoff_t *file_offset_p, hoff_t *buffer_offset_p, ssize_t *bytes_transferred_p,
-                  std::shared_ptr<IStream> stream);
+                  std::shared_ptr<IStream> stream) override;
 
     // Once we can import gtest.h and make test suites or test friends everything
     // below here should be made protected.

--- a/projects/hipfile/src/amd_detail/backend/fastpath.cpp
+++ b/projects/hipfile/src/amd_detail/backend/fastpath.cpp
@@ -220,6 +220,23 @@ Fastpath::_io_impl(IoType type, shared_ptr<IFile> file, shared_ptr<IBuffer> buff
     return static_cast<ssize_t>(nbytes);
 }
 
+void
+Fastpath::async_io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t *size_p,
+                   hoff_t *file_offset_p, hoff_t *buffer_offset_p, ssize_t *bytes_transferred_p,
+                   std::shared_ptr<IStream> stream)
+{
+    (void)type;
+    (void)file;
+    (void)buffer;
+    (void)size_p;
+    (void)file_offset_p;
+    (void)buffer_offset_p;
+    (void)bytes_transferred_p;
+    (void)stream;
+
+    throw BackendDisabled();
+}
+
 bool
 Fastpath::is_fallback_eligible(std::exception_ptr e_ptr, ssize_t nbytes) const
 {

--- a/projects/hipfile/src/amd_detail/backend/fastpath.cpp
+++ b/projects/hipfile/src/amd_detail/backend/fastpath.cpp
@@ -301,6 +301,15 @@ async_fastpath_copy(void *userArgs)
         return;
     }
 
+    // Ensure HIP Runtime is initialized. This is a temporary fix to a SEGFAULT
+    // in the HIP Runtime when hipFileRead/hipFileWrite is the first HIP API
+    // call of a new thread.
+    thread_local bool hip_inited{false};
+    if (!hip_inited) {
+        Context<Hip>::get()->hipInit();
+        hip_inited = true;
+    }
+
     hipAmdFileHandle_t handle{};
     handle.fd = op->file->unbufferedFd().value();
     void *devptr =

--- a/projects/hipfile/src/amd_detail/backend/fastpath.cpp
+++ b/projects/hipfile/src/amd_detail/backend/fastpath.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include "async.h"
 #include "buffer.h"
 #include "configuration.h"
 #include "context.h"
@@ -12,6 +13,7 @@
 #include "hipfile.h"
 #include "io.h"
 #include "stats.h"
+#include "util.h"
 
 #include <cerrno>
 #include <cstddef>
@@ -22,6 +24,7 @@
 #include <linux/stat.h>
 #include <memory>
 #include <stdexcept>
+#include <syslog.h>
 #include <system_error>
 
 using namespace hipFile;
@@ -225,16 +228,38 @@ Fastpath::async_io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBu
                    hoff_t *file_offset_p, hoff_t *buffer_offset_p, ssize_t *bytes_transferred_p,
                    std::shared_ptr<IStream> stream)
 {
-    (void)type;
-    (void)file;
-    (void)buffer;
-    (void)size_p;
-    (void)file_offset_p;
-    (void)buffer_offset_p;
-    (void)bytes_transferred_p;
-    (void)stream;
+    size_t limited_size = min(*size_p, hipFile::getMaxRwCount());
 
-    throw BackendDisabled();
+    if (!paramsValid(buffer, limited_size, *file_offset_p, *buffer_offset_p)) {
+        throw std::invalid_argument("The selected file or buffer region is invalid");
+    }
+
+    if (buffer->getGpuId() != stream->getHipDevice()) {
+        throw std::invalid_argument("Buffer GPU ID does not match Stream GPU ID");
+    }
+
+    *bytes_transferred_p = 0;
+
+    auto op = std::shared_ptr<AsyncOp>(new AsyncOp(type, std::move(file), buffer, stream, size_p,
+                                                   file_offset_p, buffer_offset_p, bytes_transferred_p));
+    Context<AsyncMonitor>::get()->addOp(op);
+
+    try {
+        auto stream_lock = stream->getLock();
+        Context<Hip>::get()->hipLaunchHostFunc(op->stream->getHipStream(), async_fastpath_copy, op.get());
+        Context<Hip>::get()->hipLaunchHostFunc(op->stream->getHipStream(), async_io_cleanup, op.get());
+    }
+    catch (...) {
+        // If something threw, still try to enqueue cleanup function
+        try {
+            Context<Hip>::get()->hipLaunchHostFunc(op->stream->getHipStream(), async_io_cleanup, op.get());
+        }
+        catch (...) {
+            Context<Sys>::get()->syslog(LOG_CRIT,
+                                        "Unable to enqueue async cleanup function. This will leak memory.");
+        }
+        throw;
+    }
 }
 
 bool
@@ -259,4 +284,47 @@ Fastpath::is_fallback_eligible(std::exception_ptr e_ptr, ssize_t nbytes) const
         // Thrown exception not eligible for fallback.
         return false;
     }
+}
+
+extern "C" {
+void
+async_fastpath_copy(void *userArgs)
+{
+    auto op = static_cast<AsyncOp *>(userArgs);
+
+    const hoff_t buffer_offset = *get_variant_ptr(op->buffer_offset);
+    const hoff_t file_offset   = *get_variant_ptr(op->file_offset);
+    const size_t size          = std::min(*get_variant_ptr(op->size), hipFile::getMaxRwCount());
+
+    if (!paramsValid(op->buffer, size, file_offset, buffer_offset)) {
+        op->bytes_transferred_internal = -hipFileInvalidValue;
+        return;
+    }
+
+    hipAmdFileHandle_t handle{};
+    handle.fd = op->file->unbufferedFd().value();
+    void *devptr =
+        reinterpret_cast<void *>(reinterpret_cast<intptr_t>(op->buffer->getBuffer()) + buffer_offset);
+
+    try {
+        ssize_t nbytes = 0;
+        switch (op->io_type) {
+            case IoType::Read:
+                nbytes = static_cast<ssize_t>(
+                    Context<Hip>::get()->hipAmdFileRead(handle, devptr, size, file_offset));
+                break;
+            case IoType::Write:
+                nbytes = static_cast<ssize_t>(
+                    Context<Hip>::get()->hipAmdFileWrite(handle, devptr, size, file_offset));
+                break;
+            default:
+                op->bytes_transferred_internal = -hipFileInternalError;
+                return;
+        }
+        op->bytes_transferred_internal = nbytes;
+    }
+    catch (...) {
+        op->bytes_transferred_internal = -hipFileInternalError;
+    }
+}
 }

--- a/projects/hipfile/src/amd_detail/backend/fastpath.h
+++ b/projects/hipfile/src/amd_detail/backend/fastpath.h
@@ -33,6 +33,10 @@ struct Fastpath : public BackendWithFallback {
     int score(const std::shared_ptr<IFile> &file, const std::shared_ptr<IBuffer> &buffer, size_t size,
               hoff_t file_offset, hoff_t buffer_offset) const override;
 
+    void async_io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t *size_p,
+                  hoff_t *file_offset_p, hoff_t *buffer_offset_p, ssize_t *bytes_transferred_p,
+                  std::shared_ptr<IStream> stream) override;
+
 protected:
     ssize_t _io_impl(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
                      hoff_t file_offset, hoff_t buffer_offset) override;

--- a/projects/hipfile/src/amd_detail/backend/fastpath.h
+++ b/projects/hipfile/src/amd_detail/backend/fastpath.h
@@ -44,3 +44,7 @@ protected:
 };
 
 }
+
+extern "C" {
+void async_fastpath_copy(void *userArgs);
+}

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -180,11 +180,10 @@ getCachedBackends()
     return backends;
 }
 
-ssize_t
-hipFileIo(IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size, hoff_t file_offset,
-          hoff_t buffer_offset, const vector<shared_ptr<Backend>> &backends)
-try {
-    auto [file, buffer] = Context<DriverState>::get()->getFileAndBuffer(fh, buffer_base);
+static shared_ptr<Backend>
+selectBackend(const vector<shared_ptr<Backend>> &backends, const shared_ptr<IFile> &file,
+              const shared_ptr<IBuffer> &buffer, size_t size, hoff_t file_offset, hoff_t buffer_offset)
+{
     int                      score{-1};
     std::shared_ptr<Backend> backend{};
 
@@ -204,6 +203,17 @@ try {
             throw std::runtime_error("All backends refused IO request");
         }
     }
+
+    return backend;
+}
+
+ssize_t
+hipFileIo(IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size, hoff_t file_offset,
+          hoff_t buffer_offset, const vector<shared_ptr<Backend>> &backends)
+try {
+    auto [file, buffer] = Context<DriverState>::get()->getFileAndBuffer(fh, buffer_base);
+
+    std::shared_ptr<Backend> backend{selectBackend(backends, file, buffer, size, file_offset, buffer_offset)};
 
     return backend->io(type, std::move(file), std::move(buffer), size, file_offset, buffer_offset);
 }
@@ -455,7 +465,8 @@ catch (...) {
 
 static hipFileError_t
 hipFileIOAsync(IoType io_type, hipFileHandle_t fh, void *buffer_base, size_t *size_p, hoff_t *file_offset_p,
-               hoff_t *buffer_offset_p, ssize_t *bytes_transferred_p, hipStream_t hipStream)
+               hoff_t *buffer_offset_p, ssize_t *bytes_transferred_p, hipStream_t hipStream,
+               const vector<shared_ptr<Backend>> &backends)
 try {
     if (Context<DriverState>::get()->getRefCount() == 0) {
         ensureDriverInit();
@@ -466,8 +477,12 @@ try {
 
     auto [file, buffer, stream] =
         Context<DriverState>::get()->getFileBufferAndStream(fh, buffer_base, hipStream);
-    Fallback().async_io(io_type, file, buffer, size_p, file_offset_p, buffer_offset_p, bytes_transferred_p,
-                        stream);
+
+    std::shared_ptr<Backend> backend{
+        selectBackend(backends, file, buffer, *size_p, *file_offset_p, *buffer_offset_p)};
+
+    backend->async_io(io_type, file, buffer, size_p, file_offset_p, buffer_offset_p, bytes_transferred_p,
+                      stream);
 
     return {hipFileSuccess, hipSuccess};
 }
@@ -493,7 +508,7 @@ hipFileReadAsync(hipFileHandle_t fh, void *buffer_base, size_t *size_p, hoff_t *
 try {
     hipFileInit();
     return hipFileIOAsync(IoType::Read, fh, buffer_base, size_p, file_offset_p, buffer_offset_p, bytes_read_p,
-                          stream);
+                          stream, getCachedBackends());
 }
 catch (...) {
     return handle_exception();
@@ -505,7 +520,7 @@ hipFileWriteAsync(hipFileHandle_t fh, void *buffer_base, size_t *size_p, hoff_t 
 try {
     hipFileInit();
     return hipFileIOAsync(IoType::Write, fh, buffer_base, size_p, file_offset_p, buffer_offset_p,
-                          bytes_written_p, stream);
+                          bytes_written_p, stream, getCachedBackends());
 }
 catch (...) {
     return handle_exception();

--- a/projects/hipfile/test/amd_detail/async.cpp
+++ b/projects/hipfile/test/amd_detail/async.cpp
@@ -886,6 +886,7 @@ struct AsyncFastpathCopyOp : public ::testing::Test,
         EXPECT_CALL(*mbuffer, getBuffer)
             .Times(AnyNumber())
             .WillRepeatedly(Return(reinterpret_cast<hipStream_t>(0xFEFEFEFE)));
+        EXPECT_CALL(mhip, hipInit).Times(AnyNumber());
 
         op = std::make_shared<AsyncOp>(io_type, mfile, mbuffer, mstream, &size, &file_offset, &buffer_offset,
                                        &bytes_transferred);

--- a/projects/hipfile/test/amd_detail/async.cpp
+++ b/projects/hipfile/test/amd_detail/async.cpp
@@ -7,6 +7,7 @@
 #include "backend.h"
 #include "backend/asyncop-fallback.h"
 #include "backend/fallback.h"
+#include "backend/fastpath.h"
 #include "context.h"
 #include "file.h"
 #include "hipfile.h"
@@ -23,6 +24,7 @@
 #include "mstream.h"
 #include "msys.h"
 #include "state.h"
+#include "util.h"
 
 #include <array>
 #include <cerrno>
@@ -716,5 +718,256 @@ TEST_P(AsyncIoOpWithParams, cpuCopyReadPreadPwriteRetriesOnEINTR)
 INSTANTIATE_TEST_SUITE_P(AsyncIoOpWithParamsSuite, AsyncIoOpWithParams,
                          ::testing::Values(AsyncIoOpBindParams{IoType::Read, true, true, true},
                                            AsyncIoOpBindParams{IoType::Write, true, true, true}));
+
+struct FastpathAsyncIO : public HipFileOpened {
+    FastpathAsyncIO()
+        : mfile{std::make_shared<StrictMock<MFile>>()}, mbuffer{std::make_shared<StrictMock<MBuffer>>()},
+          mstream{std::make_shared<StrictMock<MStream>>()}, size{1024 * 1024}, file_offset{0},
+          buffer_offset{0}, bytes_transferred{0}
+    {
+    }
+    void SetUpStreamFlags()
+    {
+        EXPECT_CALL(*mstream, fixedBufferOffset).Times(AnyNumber()).WillRepeatedly(Return(false));
+        EXPECT_CALL(*mstream, fixedFileOffset).Times(AnyNumber()).WillRepeatedly(Return(false));
+        EXPECT_CALL(*mstream, fixedIOSize).Times(AnyNumber()).WillRepeatedly(Return(false));
+        EXPECT_CALL(*mstream, pageAligned).Times(AnyNumber()).WillRepeatedly(Return(false));
+        EXPECT_CALL(*mbuffer, getBuffer)
+            .Times(AnyNumber())
+            .WillRepeatedly(Return(reinterpret_cast<hipStream_t>(0xFEFEFEFE)));
+    }
+    StrictMock<MHip>                     mhip;
+    StrictMock<MSys>                     msys;
+    std::shared_ptr<StrictMock<MFile>>   mfile;
+    std::shared_ptr<StrictMock<MBuffer>> mbuffer;
+    std::shared_ptr<StrictMock<MStream>> mstream;
+    size_t                               size;
+    hoff_t                               file_offset;
+    hoff_t                               buffer_offset;
+    ssize_t                              bytes_transferred;
+};
+
+TEST_F(FastpathAsyncIO, bufferOffsetNegativeThrows)
+{
+    buffer_offset = -1;
+    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(size));
+    EXPECT_THROW(Fastpath().async_io(IoType::Read, mfile, mbuffer, &size, &file_offset, &buffer_offset,
+                                     &bytes_transferred, mstream),
+                 std::invalid_argument);
+}
+
+TEST_F(FastpathAsyncIO, bufferOffsetTooLargeThrows)
+{
+    buffer_offset = static_cast<hoff_t>(size);
+    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(size));
+    EXPECT_THROW(Fastpath().async_io(IoType::Read, mfile, mbuffer, &size, &file_offset, &buffer_offset,
+                                     &bytes_transferred, mstream),
+                 std::invalid_argument);
+}
+
+TEST_F(FastpathAsyncIO, fileOffsetNegativeThrows)
+{
+    file_offset = -1;
+    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(size));
+    EXPECT_THROW(Fastpath().async_io(IoType::Read, mfile, mbuffer, &size, &file_offset, &buffer_offset,
+                                     &bytes_transferred, mstream),
+                 std::invalid_argument);
+}
+
+TEST_F(FastpathAsyncIO, mismatchingGpuIdsThrows)
+{
+    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(size));
+    EXPECT_CALL(*mbuffer, getGpuId).WillOnce(Return(0));
+    EXPECT_CALL(*mstream, getHipDevice).WillOnce(Return(1));
+    EXPECT_THROW(Fastpath().async_io(IoType::Read, mfile, mbuffer, &size, &file_offset, &buffer_offset,
+                                     &bytes_transferred, mstream),
+                 std::invalid_argument);
+}
+
+TEST_F(FastpathAsyncIO, validParamsEnqueuesCopyAndCleanup)
+{
+    SetUpStreamFlags();
+    StrictMock<MAsyncMonitor> masync_monitor;
+    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(size));
+    EXPECT_CALL(*mbuffer, getGpuId).WillOnce(Return(0));
+    EXPECT_CALL(*mstream, getHipDevice).WillOnce(Return(0));
+    EXPECT_CALL(masync_monitor, addOp);
+    EXPECT_CALL(*mstream, getLock);
+    EXPECT_CALL(*mstream, getHipStream).Times(2);
+    EXPECT_CALL(mhip, hipLaunchHostFunc(_, Eq(&async_fastpath_copy), _));
+    EXPECT_CALL(mhip, hipLaunchHostFunc(_, Eq(&async_io_cleanup), _));
+    Fastpath().async_io(IoType::Read, mfile, mbuffer, &size, &file_offset, &buffer_offset, &bytes_transferred,
+                        mstream);
+}
+
+TEST_F(FastpathAsyncIO, zeroSizeEnqueuesCopyAndCleanup)
+{
+    size = 0;
+    SetUpStreamFlags();
+    StrictMock<MAsyncMonitor> masync_monitor;
+    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(1024));
+    EXPECT_CALL(*mbuffer, getGpuId).WillOnce(Return(0));
+    EXPECT_CALL(*mstream, getHipDevice).WillOnce(Return(0));
+    EXPECT_CALL(masync_monitor, addOp);
+    EXPECT_CALL(*mstream, getLock);
+    EXPECT_CALL(*mstream, getHipStream).Times(2);
+    EXPECT_CALL(mhip, hipLaunchHostFunc(_, Eq(&async_fastpath_copy), _));
+    EXPECT_CALL(mhip, hipLaunchHostFunc(_, Eq(&async_io_cleanup), _));
+    Fastpath().async_io(IoType::Read, mfile, mbuffer, &size, &file_offset, &buffer_offset, &bytes_transferred,
+                        mstream);
+}
+
+TEST_F(FastpathAsyncIO, attemptToQueueCleanupOnStreamSubmissionFailure)
+{
+    SetUpStreamFlags();
+    StrictMock<MAsyncMonitor> masync_monitor;
+    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(size));
+    EXPECT_CALL(*mbuffer, getGpuId).WillOnce(Return(0));
+    EXPECT_CALL(*mstream, getHipDevice).WillOnce(Return(0));
+    EXPECT_CALL(masync_monitor, addOp);
+    EXPECT_CALL(*mstream, getLock);
+    EXPECT_CALL(*mstream, getHipStream).Times(AnyNumber());
+    EXPECT_CALL(mhip, hipLaunchHostFunc(_, Eq(&async_fastpath_copy), _))
+        .WillOnce(Throw(Hip::RuntimeError(hipErrorInvalidHandle)));
+    EXPECT_CALL(mhip, hipLaunchHostFunc(_, Eq(&async_io_cleanup), _));
+    EXPECT_THROW(Fastpath().async_io(IoType::Read, mfile, mbuffer, &size, &file_offset, &buffer_offset,
+                                     &bytes_transferred, mstream),
+                 Hip::RuntimeError);
+}
+
+TEST_F(FastpathAsyncIO, syslogCalledWhenCleanupEnqueueAlsoFails)
+{
+    SetUpStreamFlags();
+    StrictMock<MAsyncMonitor> masync_monitor;
+    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(size));
+    EXPECT_CALL(*mbuffer, getGpuId).WillOnce(Return(0));
+    EXPECT_CALL(*mstream, getHipDevice).WillOnce(Return(0));
+    EXPECT_CALL(masync_monitor, addOp);
+    EXPECT_CALL(*mstream, getLock);
+    EXPECT_CALL(*mstream, getHipStream).Times(AnyNumber());
+    EXPECT_CALL(mhip, hipLaunchHostFunc(_, Eq(&async_fastpath_copy), _))
+        .WillOnce(Throw(Hip::RuntimeError(hipErrorInvalidHandle)));
+    EXPECT_CALL(mhip, hipLaunchHostFunc(_, Eq(&async_io_cleanup), _))
+        .WillOnce(Throw(Hip::RuntimeError(hipErrorInvalidHandle)));
+    EXPECT_CALL(msys, syslog);
+    EXPECT_THROW(Fastpath().async_io(IoType::Read, mfile, mbuffer, &size, &file_offset, &buffer_offset,
+                                     &bytes_transferred, mstream),
+                 Hip::RuntimeError);
+}
+
+struct AsyncFastpathCopyParams {
+    IoType io_type;
+    bool   fixed_buffer_offset;
+    bool   fixed_file_offset;
+    bool   fixed_io_size;
+};
+
+struct AsyncFastpathCopyOp : public ::testing::Test,
+                             public ::testing::WithParamInterface<AsyncFastpathCopyParams> {
+    AsyncFastpathCopyOp()
+        : mfile{std::make_shared<StrictMock<MFile>>()}, mbuffer{std::make_shared<StrictMock<MBuffer>>()},
+          mstream{std::make_shared<StrictMock<MStream>>()}
+    {
+    }
+    void SetUp() override
+    {
+        auto [_io_type, _fixed_buffer_offset, _fixed_file_offset, _fixed_io_size] = GetParam();
+        io_type                                                                   = _io_type;
+        fixed_buffer_offset                                                       = _fixed_buffer_offset;
+        fixed_file_offset                                                         = _fixed_file_offset;
+        fixed_io_size                                                             = _fixed_io_size;
+
+        EXPECT_CALL(*mstream, fixedBufferOffset)
+            .Times(AnyNumber())
+            .WillRepeatedly(Return(fixed_buffer_offset));
+        EXPECT_CALL(*mstream, fixedFileOffset).Times(AnyNumber()).WillRepeatedly(Return(fixed_file_offset));
+        EXPECT_CALL(*mstream, fixedIOSize).Times(AnyNumber()).WillRepeatedly(Return(fixed_io_size));
+        EXPECT_CALL(*mstream, pageAligned).Times(AnyNumber()).WillRepeatedly(Return(false));
+        EXPECT_CALL(*mbuffer, getBuffer)
+            .Times(AnyNumber())
+            .WillRepeatedly(Return(reinterpret_cast<hipStream_t>(0xFEFEFEFE)));
+
+        op = std::make_shared<AsyncOp>(io_type, mfile, mbuffer, mstream, &size, &file_offset, &buffer_offset,
+                                       &bytes_transferred);
+    }
+    StrictMock<MHip>                     mhip;
+    StrictMock<MSys>                     msys;
+    StrictMock<MAsyncMonitor>            masync_monitor;
+    std::shared_ptr<StrictMock<MFile>>   mfile;
+    std::shared_ptr<StrictMock<MBuffer>> mbuffer;
+    std::shared_ptr<StrictMock<MStream>> mstream;
+    IoType                               io_type             = IoType::Read;
+    size_t                               size                = 1_MiB;
+    hoff_t                               file_offset         = 0;
+    hoff_t                               buffer_offset       = 0;
+    ssize_t                              bytes_transferred   = 0;
+    bool                                 fixed_buffer_offset = false;
+    bool                                 fixed_file_offset   = false;
+    bool                                 fixed_io_size       = false;
+    std::shared_ptr<AsyncOp>             op;
+};
+
+TEST_P(AsyncFastpathCopyOp, invalidRegionSetsError)
+{
+    // Overwrite the buffer_offset variant directly so both fixed and non-fixed
+    // cases present the invalid value when async_fastpath_copy runs.
+    op->buffer_offset.emplace<const hoff_t>(static_cast<hoff_t>(size));
+    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(size));
+    async_fastpath_copy(op.get());
+    ASSERT_EQ(op->bytes_transferred_internal, -hipFileInvalidValue);
+}
+
+TEST_P(AsyncFastpathCopyOp, ioReturnsFullSize)
+{
+    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(size));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(42));
+    if (io_type == IoType::Read) {
+        EXPECT_CALL(mhip, hipAmdFileRead).WillOnce(Return(size));
+    }
+    else {
+        EXPECT_CALL(mhip, hipAmdFileWrite).WillOnce(Return(size));
+    }
+    async_fastpath_copy(op.get());
+    ASSERT_EQ(op->bytes_transferred_internal, static_cast<ssize_t>(size));
+}
+
+TEST_P(AsyncFastpathCopyOp, hipExceptionSetsError)
+{
+    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(size));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(42));
+    if (io_type == IoType::Read) {
+        EXPECT_CALL(mhip, hipAmdFileRead).WillOnce(Throw(Hip::RuntimeError(hipErrorUnknown)));
+    }
+    else {
+        EXPECT_CALL(mhip, hipAmdFileWrite).WillOnce(Throw(Hip::RuntimeError(hipErrorUnknown)));
+    }
+    async_fastpath_copy(op.get());
+    ASSERT_EQ(op->bytes_transferred_internal, -hipFileInternalError);
+}
+
+TEST_P(AsyncFastpathCopyOp, sizeClampedToMaxRwCount)
+{
+    // Overwrite the size variant directly so both fixed and non-fixed cases
+    // present the large size to async_fastpath_copy.
+    op->size = hipFile::getMaxRwCount() + 1;
+    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(hipFile::getMaxRwCount() + 1));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(42));
+    if (io_type == IoType::Read) {
+        EXPECT_CALL(mhip, hipAmdFileRead(_, _, Eq(hipFile::getMaxRwCount()), _))
+            .WillOnce(Return(hipFile::getMaxRwCount()));
+    }
+    else {
+        EXPECT_CALL(mhip, hipAmdFileWrite(_, _, Eq(hipFile::getMaxRwCount()), _))
+            .WillOnce(Return(hipFile::getMaxRwCount()));
+    }
+    async_fastpath_copy(op.get());
+    ASSERT_EQ(op->bytes_transferred_internal, static_cast<ssize_t>(hipFile::getMaxRwCount()));
+}
+
+INSTANTIATE_TEST_SUITE_P(AsyncFastpathCopyOpSuite, AsyncFastpathCopyOp,
+                         ::testing::Values(AsyncFastpathCopyParams{IoType::Read, true, true, true},
+                                           AsyncFastpathCopyParams{IoType::Write, true, true, true},
+                                           AsyncFastpathCopyParams{IoType::Read, false, false, false},
+                                           AsyncFastpathCopyParams{IoType::Write, false, false, false}));
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/projects/hipfile/test/amd_detail/mbackend.h
+++ b/projects/hipfile/test/amd_detail/mbackend.h
@@ -23,6 +23,10 @@ struct MBackend : Backend {
                 (hipFile::IoType type, std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t,
                  hoff_t),
                 (override));
+    MOCK_METHOD(void, async_io,
+                (hipFile::IoType type, std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t *, hoff_t *,
+                 hoff_t *, ssize_t *, std::shared_ptr<IStream>),
+                (override));
     MOCK_METHOD(ssize_t, _io_impl,
                 (hipFile::IoType type, std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t,
                  hoff_t),
@@ -36,6 +40,10 @@ struct MBackendWithFallback : BackendWithFallback {
     MOCK_METHOD(ssize_t, _io_impl,
                 (IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
                  hoff_t file_offset, hoff_t buffer_offset),
+                (override));
+    MOCK_METHOD(void, async_io,
+                (hipFile::IoType type, std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t *, hoff_t *,
+                 hoff_t *, ssize_t *, std::shared_ptr<IStream>),
                 (override));
     MOCK_METHOD(bool, is_fallback_eligible, (std::exception_ptr e_ptr, ssize_t nbytes), (const, override));
 };

--- a/projects/hipfile/test/system/async.cpp
+++ b/projects/hipfile/test/system/async.cpp
@@ -7,6 +7,7 @@
 #include "backend/asyncop-fallback.h"
 #include "backend/memcpy-kernel.h"
 #include "buffer.h"
+#include "configuration.h"
 #include "context.h"
 #include "hip.h"
 #include "io.h"
@@ -773,6 +774,127 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 #ifdef __HIP_PLATFORM_AMD__
+
+enum class AsyncIoTestBackend {
+    Fastpath,
+    Fallback,
+};
+
+struct AsyncBackendParam {
+    AsyncIoTestBackend backend;
+    std::string        backend_name;
+    AsyncIoFunction    io;
+};
+
+HIPFILE_WARN_NO_EXIT_DTOR_OFF
+static std::array<AsyncBackendParam, 4> asyncBackendParams{{
+    {AsyncIoTestBackend::Fastpath, "Fastpath", {hipFileReadAsync, "hipFileReadAsync"}},
+    {AsyncIoTestBackend::Fastpath, "Fastpath", {hipFileWriteAsync, "hipFileWriteAsync"}},
+    {AsyncIoTestBackend::Fallback, "Fallback", {hipFileReadAsync, "hipFileReadAsync"}},
+    {AsyncIoTestBackend::Fallback, "Fallback", {hipFileWriteAsync, "hipFileWriteAsync"}},
+}};
+HIPFILE_WARN_NO_EXIT_DTOR_ON
+
+// Exercises the read/write async golden path against each backend explicitly.
+// Only one backend is enabled at a time so that if the selected backend's
+// score() rejects the op, hipFileIOAsync throws instead of silently choosing
+// the other backend. This guarantees the intended backend is actually run.
+class HipAsyncBackendForced : public HipAsync, public ::testing::WithParamInterface<AsyncBackendParam> {
+public:
+    void SetUp() override
+    {
+        HipAsync::SetUp();
+        backend = GetParam().backend;
+        io_op   = GetParam().io.function;
+        name    = GetParam().io.name;
+
+        Context<Configuration>::get()->fastpath(false);
+        Context<Configuration>::get()->fallback(false);
+        switch (backend) {
+            case AsyncIoTestBackend::Fastpath:
+                Context<Configuration>::get()->fastpath(true);
+                break;
+            case AsyncIoTestBackend::Fallback:
+                Context<Configuration>::get()->fallback(true);
+                break;
+            default:
+                FAIL() << "Unsupported AsyncIoTestBackend";
+        }
+
+        if (name == "hipFileReadAsync") {
+            HipFileDataOps::zeroMemoryRegion(dev_ptr, 0, buffer_size);
+            HipFileDataOps::randomizeFileRegion(tf.fd, file_size);
+        }
+        else {
+            HipFileDataOps::zeroFileRegion(tf.fd, file_size);
+            HipFileDataOps::randomizeMemoryRegion(dev_ptr, 0, buffer_size);
+        }
+
+        ASSERT_EQ(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking), hipSuccess);
+        ASSERT_EQ(hipFileStreamRegister(stream, 0xf), HIPFILE_SUCCESS);
+    }
+    void TearDown() override
+    {
+        ASSERT_EQ(hipFileStreamDeregister(stream), HIPFILE_SUCCESS);
+        ASSERT_EQ(hipStreamDestroy(stream), hipSuccess);
+        Context<Configuration>::get()->fastpath(true);
+        Context<Configuration>::get()->fallback(true);
+        HipAsync::TearDown();
+    }
+    AsyncIoTestBackend backend = AsyncIoTestBackend::Fastpath;
+    hipFileError_t (*io_op)(hipFileHandle_t, void *, size_t *, hoff_t *, hoff_t *, ssize_t *, hipStream_t);
+    std::string name;
+    hipStream_t stream;
+};
+
+TEST_P(HipAsyncBackendForced, zeroOffsets)
+{
+    ASSERT_EQ(io_op(fh, dev_ptr, &io_size, &file_offset, &buffer_offset, &bytes_transferred, stream),
+              HIPFILE_SUCCESS);
+    ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
+    ASSERT_EQ(bytes_transferred, io_size);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
+}
+
+TEST_P(HipAsyncBackendForced, bufferOffsetAligned)
+{
+    buffer_offset = 4_KiB;
+    io_size -= 4_KiB;
+    ASSERT_EQ(io_op(fh, dev_ptr, &io_size, &file_offset, &buffer_offset, &bytes_transferred, stream),
+              HIPFILE_SUCCESS);
+    ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
+    ASSERT_EQ(bytes_transferred, io_size);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
+    if (name == "hipFileReadAsync") {
+        HipFileDataOps::assertZeroedMemRegion(dev_ptr, 0, 4_KiB);
+    }
+    else {
+        HipFileDataOps::assertZeroedFileRegion(tf.fd, static_cast<hoff_t>(io_size), 4_KiB);
+    }
+}
+
+TEST_P(HipAsyncBackendForced, fileOffsetAligned)
+{
+    file_offset = 4_KiB;
+    io_size -= 4_KiB;
+    ASSERT_EQ(io_op(fh, dev_ptr, &io_size, &file_offset, &buffer_offset, &bytes_transferred, stream),
+              HIPFILE_SUCCESS);
+    ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
+    ASSERT_EQ(bytes_transferred, io_size);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
+    if (name == "hipFileReadAsync") {
+        HipFileDataOps::assertZeroedMemRegion(dev_ptr, static_cast<hoff_t>(io_size), 4_KiB);
+    }
+    else {
+        HipFileDataOps::assertZeroedFileRegion(tf.fd, 0, 4_KiB);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(HipAsyncBackendForcedSuite, HipAsyncBackendForced,
+                         ::testing::ValuesIn(asyncBackendParams),
+                         [](const testing::TestParamInfo<HipAsyncBackendForced::ParamType> &param_info) {
+                             return param_info.param.backend_name + "_" + param_info.param.io.name;
+                         });
 
 class HipAsyncStreamUnfixedPaused : public HipAsync {
 public:


### PR DESCRIPTION
## Motivation

We want the async API to use the AIS IO path.

## Technical Details

- Add backend scoring and selection to hipfile async IO calls.
- Add async_io() method to Fastpath backend which enqueues a function on the passed in stream to perform IO on the AIS path.
- Backend failover is not supported.
- System tests added that force each backend to perform async IO.

## Issue Tracking

JIRA ID: AIHIPFILE-158

Addresses https://github.com/ROCm/hipFile/issues/260 (first question about fastpath support)

## Test Plan

Run system tests on Rowlet using an AIS capable FS.

## Test Result

All system tests passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
