### PR TITLE
[rocjitsu][CI] Update corpus SDK to TheRock 7.15

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -49,7 +49,7 @@ env:
   ROCJITSU_DBT_CORPUS_DIR: ${{ github.workspace }}/rocjitsu-dbt-test-corpus
   ROCJITSU_DBT_VENV: ${{ github.workspace }}/gfx1250-dbt-venv-${{ github.run_id }}-${{ github.run_attempt }}
   ROCJITSU_HSACO_CORPUS: ${{ github.workspace }}/gfx1250-packaged-hsacos-${{ github.run_id }}-${{ github.run_attempt }}
-  ROCM_SDK_VERSION: 7.14.0a20260624
+  ROCM_SDK_VERSION: 7.15.0a20260728
   UV_VERSION: 0.9.26
 
 jobs:


### PR DESCRIPTION
## Motivation

The gfx1250 corpus workflow remained pinned to TheRock 7.14 because ROCr 7.15 exposed unsupported compact SDMA copy packets in the simulator. The preceding simulator fix now handles those packet layouts.

## Technical Details

Update the corpus workflow SDK snapshot from 7.14.0a20260624 to the locally validated 7.15.0a20260728 release.

## Issue Tracking

N/A

## Test Result

- Rocjitsu built successfully against TheRock 7.15.0a20260728.
- The gfx1250 SDMA suite passed 17/17.
- The semantic comparison and strict runtime-evidence validation passed 12/12.
- The original timeout cases passed 3/3 under the 15-second limit.
- The non-RCCL CTest suite passed 2232/2232 with three expected skips.
- Repository hooks passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
