### PR TITLE
fix(ci): update gfx942 single-GPU runner label to ccs-csp

### DIFF
--- a/.github/workflows/media-libs-ci.yml
+++ b/.github/workflows/media-libs-ci.yml
@@ -119,5 +119,5 @@ jobs:
     uses: ./.github/workflows/therock-media-test-packages.yml
     with:
       amdgpu_families: "gfx94X-dcgpu"
-      test_runs_on: "linux-gfx942-1gpu-ossci-rocm"
+      test_runs_on: "linux-gfx942-1gpu-ccs-csp-ossci-rocm"
       platform: "linux"


### PR DESCRIPTION
## Summary

- Updates `test_runs_on` in `media-libs-ci.yml` from `linux-gfx942-1gpu-ossci-rocm` → `linux-gfx942-1gpu-ccs-csp-ossci-rocm`

`linux-gfx942-1gpu-ossci-rocm` was the Vultr cluster single-GPU label, removed as part of the Vultr decommission in ROCm/therock-ci-config#21. Without this fix, the `therock-test-linux` job in media-libs-ci will queue indefinitely with no runner to pick it up.

`linux-gfx942-1gpu-ccs-csp-ossci-rocm` is the current `test-runs-on` default for gfx94x in therock-ci-config.

## Test plan

- [ ] Confirm `therock-test-linux` (Test Media Libs) picks up a runner on next trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)