### PR TITLE
[RCCL] auto-disable WarpSpeed above limit instead of erroring

### DIFF
--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -746,8 +746,12 @@ bool rcclCanUseWarpSpeedAuto(struct ncclComm* comm, int nNodes) {
          (rcclParamWarpSpeedAutoMode() != 0) && comm-> cuCount > 128; // Only use in SPX mode, 256 CU on gfx950
 }
 
+bool rcclWarpSpeedChannelCountSupported(struct ncclComm* comm) {
+  return comm->nChannels <= (MAXCHANNELS) / 2;
+}
+
 ncclResult_t validChannelsForWarpSpeed(struct ncclComm* comm, struct ncclTaskColl* info) {
-  if (info->useWarpSpeed && comm->nChannels > (MAXCHANNELS) / 2) {
+  if (info->useWarpSpeed && !rcclWarpSpeedChannelCountSupported(comm)) {
     WARN("WarpSpeed does not support more than %d channels. Current number of channels is %d. To avoid hang, run with "
          "RCCL_WARP_SPEED_AUTO=0",
          MAXCHANNELS / 2, comm->nChannels);
@@ -785,8 +789,16 @@ ncclResult_t rcclSetWarpSpeedAuto(struct ncclComm* comm, struct ncclTaskColl* in
       if (!unrollFactorSet) comm->unroll = NCCL_UNROLL_2;
     }
     if (rcclIsAboveWarpSpeedThreshold(comm, info, nBytes)) {
-      info->nWarps = 4;
-      info->useWarpSpeed = true;
+      // Skip WarpSpeed when the comm exceeds its channel limit (e.g. RCCL_ENABLE_INTRANET=1 drives
+      // nChannels to MAXCHANNELS) instead of failing. Force-enable still errors below.
+      if (!rcclWarpSpeedChannelCountSupported(comm)) {
+        if (comm->rank == 0)
+          INFO(NCCL_TUNING, "RCCL WarpSpeed auto-disabled: %d channels exceeds max %d supported",
+               comm->nChannels, MAXCHANNELS / 2);
+      } else {
+        info->nWarps = 4;
+        info->useWarpSpeed = true;
+      }
     }
   }
   NCCLCHECK(validChannelsForWarpSpeed(comm, info));


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
WarpSpeed auto mode was enabling WarpSpeed and then hard-failing the collective with invalid argument whenever the comm's channel count exceeded WarpSpeed's supported limit (MAXCHANNELS/2). This change makes auto mode fall back to the default path in that case instead of erroring, so valid configs no longer break.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Some configs, in this case RCCL_ENABLE_INTRANET=1 push the comm to the full 512 channels, so auto mode enabled WarpSpeed and then failed the collective with invalid argument (e.g. AllReduce ≥ 64 MB). Surfaced by the Enqueue_GraphRegister_On coverage test. This PR makes sure we fallback instead of reporting error for cases like this. Force-enable will still report error in this case.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
