### PR TITLE
fix(rccl): repair stale CE_Internal_Neg assertion and CE_AlltoAll_8Ranks DDA preemption

### DIFF
--- a/projects/rccl/test/ce/CeInternalMPITests.cpp
+++ b/projects/rccl/test/ce/CeInternalMPITests.cpp
@@ -584,15 +584,23 @@ TEST_F(CeInternalMPITest, LaunchFourOpsNullStreamSucceeds)
 // ===========================================================================
 
 // NEG-01: ncclCeImplemented returns false for collectives CE does not handle.
+//
+// NOTE: ncclFuncAllReduce was moved out of this negative list in PR #8443
+// ("Users/galaband/rccl ce ar no pipeline"), which added CE AllReduce support
+// (ce_coll.cc's ncclCeImplemented() switch now returns true for
+// ncclFuncAllReduce). That PR updated the switch statement but never updated
+// this test, leaving a stale assertion that CE_Internal_Neg has failed on
+// ever since (verified identical on rccl/gfx1250:f43c171 and PR #8945 tip).
+// AllReduce's positive expectation now lives in NEG-02 below, alongside the
+// driver-gated checks for the other CE-supported collectives.
 TEST(CeInternalNeg, CeImplementedReturnsFalseForUnsupported)
 {
-    EXPECT_FALSE(ncclCeImplemented(ncclFuncAllReduce,    ncclDevSum, ncclFloat32));
     EXPECT_FALSE(ncclCeImplemented(ncclFuncBroadcast,    ncclDevSum, ncclFloat32));
     EXPECT_FALSE(ncclCeImplemented(ncclFuncReduceScatter, ncclDevSum, ncclFloat32));
 }
 
 // NEG-02: On ROCm 7.12+ or 7.0.2.x, ncclCeImplemented returns true for
-//         the four supported CE collectives.
+//         the five supported CE collectives.
 TEST(CeInternalNeg, CeImplementedReturnsTrueOnSupportedDriver)
 {
     if(!isCeDriverSupported())
@@ -605,6 +613,7 @@ TEST(CeInternalNeg, CeImplementedReturnsTrueOnSupportedDriver)
     EXPECT_TRUE(ncclCeImplemented(ncclFuncAlltoAll,  ncclDevSum, ncclFloat32));
     EXPECT_TRUE(ncclCeImplemented(ncclFuncScatter,   ncclDevSum, ncclFloat32));
     EXPECT_TRUE(ncclCeImplemented(ncclFuncGather,    ncclDevSum, ncclFloat32));
+    EXPECT_TRUE(ncclCeImplemented(ncclFuncAllReduce, ncclDevSum, ncclFloat32));
 }
 
 // ===========================================================================

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -1633,7 +1633,10 @@
         {
           "name": "CE_AlltoAll_8Ranks",
           "description": "AlltoAll CE correctness — default production topology (8 ranks)",
-          "test_filter": "CeMPI_AlltoAll.EightRanks"
+          "test_filter": "CeMPI_AlltoAll.EightRanks",
+          "env_variables": {
+            "RCCL_DDA_ENABLE": "0"
+          }
         },
         {
           "name": "CE_Scatter_8Ranks",


### PR DESCRIPTION
## Motivation

CE_Internal_Neg and CE_AlltoAll_8Ranks were both failing: the former still asserted
that CE AllReduce was unimplemented after PR #8443 added support for it, and the
latter never actually exercised CE dispatch because AlltoAll's DDA-IPC path has no
guard against preempting it, unlike AllGather. This PR fixes both so they validate
what they're meant to.

## Technical Details

CE_Internal_Neg still expected CE AllReduce to be unimplemented after PR #8443
added support for it, so move that assertion to the expect-true side.
CE_AlltoAll_8Ranks never reached CE dispatch because AlltoAll's DDA-IPC path,
unlike AllGather's, has no guard preventing it from preempting CE at 8 ranks;
add RCCL_DDA_ENABLE=0 to that test to force the path it's meant to validate.
Both fixes verified with no regressions across the full test suite.

## Issue Tracking

JIRA ID: TBD!

## Test Plan

Filtered runs of CE_Internal_Neg and CE_AlltoAll_8Ranks before/after the fix,
then a full test_runner suite run to check for regressions.

## Test Result

Both tests pass after the fix (failed before). Full suite: 596 tests, only
the pre-existing unrelated failures remain, no new regressions.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
