### PR TITLE
[rocr] Default to Hotswap version 2

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
@@ -98,6 +98,9 @@ enum class HotswapBackend {
   kRocjitsu,
 };
 
+// Selects the backend from the environment. kRocjitsu is the default;
+// HSA_HOTSWAP_DISABLE turns hotswap off entirely, and HSA_HOTSWAP_ENABLE=1
+// selects kComgr as a transitional fallback.
 void ConfigureHotswapBackend();
 HotswapBackend GetHotswapBackend();
 bool IsRocjitsuHotswapEnabled();

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -383,11 +383,18 @@ std::optional<RewriteDecision> DecideHotswapRewrite(const AgentGfxRevision& gfx,
 }  // namespace
 
 void ConfigureHotswapBackend() {
-  HotswapBackend backend = HotswapBackend::kComgr;
+  // The rocjitsu backend is the default. It only does anything when a gfx1250 A0
+  // agent is present, so selecting it costs nothing on every other device; see
+  // Runtime::LoadHotswapTool(), which returns early otherwise.
+  //
+  // HSA_HOTSWAP_ENABLE=1 selects the COMGR backend instead. That is a transitional
+  // escape hatch, not a supported configuration. "2" keeps naming the rocjitsu
+  // backend so existing invocations that request it explicitly continue to work.
+  HotswapBackend backend = HotswapBackend::kRocjitsu;
   if (IsEnvFlagEnabled("HSA_HOTSWAP_DISABLE")) {
     backend = HotswapBackend::kDisabled;
-  } else if (os::GetEnvVar("HSA_HOTSWAP_ENABLE") == "2") {
-    backend = HotswapBackend::kRocjitsu;
+  } else if (os::GetEnvVar("HSA_HOTSWAP_ENABLE") == "1") {
+    backend = HotswapBackend::kComgr;
   }
   g_hotswap_backend.store(backend, std::memory_order_release);
 }


### PR DESCRIPTION
The rocjitsu backend previously required HSA_HOTSWAP_ENABLE=2 and everything else selected v1. Make 2 the default so no environment setting is needed to get it.

Selecting it is inert on all other hardware: LoadHotswapTool() returns early unless a gfx1250 agent reporting ASIC revision zero is present, so nothing is loaded and no interception is installed anywhere else.

Where such an agent is present, the behavior does change. The hook library becomes required, and hsa_init fails if it cannot be loaded, whereas before the runtime would quietly fall back to COMGR. That is the intended outcome: the alternative is running code on that device that was never adjusted for it.

HSA_HOTSWAP_ENABLE=1 now selects v1, as a way back during the transition. HSA_HOTSWAP_DISABLE is unchanged and still turns hotswap off entirely.