### PR TITLE
docs(hip): Render reference API global defs, driver types, and data s…

### DIFF
--- a/projects/hip/docs/reference/hip_runtime_api/data_structures.rst
+++ b/projects/hip/docs/reference/hip_runtime_api/data_structures.rst
@@ -1,0 +1,240 @@
+.. meta::
+  :description: The HIP runtime API data structures reference page.
+  :keywords: AMD, ROCm, HIP, data structures, structs, unions
+
+.. _data_structures_reference:
+
+*******************************************************************************
+Data structures
+*******************************************************************************
+
+The structs and unions in the HIP runtime API.
+
+.. doxygenstruct:: HIP_ARRAY3D_DESCRIPTOR
+   :members:
+
+.. doxygenstruct:: HIP_ARRAY_DESCRIPTOR
+   :members:
+
+.. doxygenstruct:: HIP_LAUNCH_CONFIG
+   :members:
+
+.. doxygenstruct:: HIP_MEMCPY3D
+   :members:
+
+.. doxygenstruct:: HIP_RESOURCE_DESC
+   :members:
+
+.. doxygenstruct:: HIP_RESOURCE_VIEW_DESC
+   :members:
+
+.. doxygenstruct:: HIP_TEXTURE_DESC
+   :members:
+
+.. doxygenstruct:: dim3
+   :members:
+
+.. doxygenstruct:: hipAccessPolicyWindow
+   :members:
+
+.. doxygenstruct:: hipArrayMapInfo
+   :members:
+
+.. doxygenstruct:: hipArrayMemoryRequirements
+   :members:
+
+.. doxygenstruct:: hipBatchMemOpNodeParams
+   :members:
+
+.. doxygenstruct:: hipChannelFormatDesc
+   :members:
+
+.. doxygenstruct:: hipChildGraphNodeParams
+   :members:
+
+.. doxygenstruct:: hipDevResource
+   :members:
+
+.. doxygenstruct:: hipDevSmResource
+   :members:
+
+.. doxygenstruct:: hipDevSmResourceGroupParams
+   :members:
+
+.. doxygenstruct:: hipDevWorkqueueConfigResource
+   :members:
+
+.. doxygenstruct:: hipDevWorkqueueResource
+   :members:
+
+.. doxygenstruct:: hipDeviceArch_t
+   :members:
+
+.. doxygenstruct:: hipDeviceProp_t
+   :members:
+
+.. doxygenstruct:: hipEventRecordNodeParams
+   :members:
+
+.. doxygenstruct:: hipEventWaitNodeParams
+   :members:
+
+.. doxygenstruct:: hipExtDynDataPrefetchConfig
+   :members:
+
+.. doxygenstruct:: hipExtDynDataPrefetchRegion
+   :members:
+
+.. doxygenstruct:: hipExtent
+   :members:
+
+.. doxygenstruct:: hipExternalMemoryBufferDesc
+   :members:
+
+.. doxygenstruct:: hipExternalMemoryHandleDesc
+   :members:
+
+.. doxygenstruct:: hipExternalMemoryMipmappedArrayDesc
+   :members:
+
+.. doxygenstruct:: hipExternalSemaphoreHandleDesc
+   :members:
+
+.. doxygenstruct:: hipExternalSemaphoreSignalNodeParams
+   :members:
+
+.. doxygenstruct:: hipExternalSemaphoreSignalParams
+   :members:
+
+.. doxygenstruct:: hipExternalSemaphoreWaitNodeParams
+   :members:
+
+.. doxygenstruct:: hipExternalSemaphoreWaitParams
+   :members:
+
+.. doxygenstruct:: hipFuncAttributes
+   :members:
+
+.. doxygenstruct:: hipFunctionLaunchParams
+   :members:
+
+.. doxygenstruct:: hipGraphEdgeData
+   :members:
+
+.. doxygenstruct:: hipGraphInstantiateParams
+   :members:
+
+.. doxygenstruct:: hipGraphNodeParams
+   :members:
+
+.. doxygenstruct:: hipHostNodeParams
+   :members:
+
+.. doxygenstruct:: hipIpcEventHandle_t
+   :members:
+
+.. doxygenstruct:: hipIpcMemHandle_t
+   :members:
+
+.. doxygenstruct:: hipKernelNodeParams
+   :members:
+
+.. doxygenstruct:: hipLaunchAttribute
+   :members:
+
+.. doxygenunion:: hipLaunchAttributeValue
+
+.. doxygenstruct:: hipLaunchConfig_t
+   :members:
+
+.. doxygenstruct:: hipLaunchMemSyncDomainMap
+   :members:
+
+.. doxygenstruct:: hipLaunchParams
+   :members:
+
+.. doxygenstruct:: hipMemAccessDesc
+   :members:
+
+.. doxygenstruct:: hipMemAllocNodeParams
+   :members:
+
+.. doxygenstruct:: hipMemAllocationProp
+   :members:
+
+.. doxygenstruct:: hipMemFabricHandle_t
+   :members:
+
+.. doxygenstruct:: hipMemFreeNodeParams
+   :members:
+
+.. doxygenstruct:: hipMemLocation
+   :members:
+
+.. doxygenstruct:: hipMemPoolProps
+   :members:
+
+.. doxygenstruct:: hipMemPoolPtrExportData
+   :members:
+
+.. doxygenstruct:: hipMemcpy3DBatchOp
+   :members:
+
+.. doxygenstruct:: hipMemcpy3DOperand
+   :members:
+
+.. doxygenstruct:: hipMemcpy3DParms
+   :members:
+
+.. doxygenstruct:: hipMemcpy3DPeerParms
+   :members:
+
+.. doxygenstruct:: hipMemcpyAttributes
+   :members:
+
+.. doxygenstruct:: hipMemcpyNodeParams
+   :members:
+
+.. doxygenstruct:: hipMemsetParams
+   :members:
+
+.. doxygenstruct:: hipMipmappedArray
+   :members:
+
+.. doxygenstruct:: hipOffset3D
+   :members:
+
+.. doxygenstruct:: hipPitchedPtr
+   :members:
+
+.. doxygenstruct:: hipPointerAttribute_t
+   :members:
+
+.. doxygenstruct:: hipPos
+   :members:
+
+.. doxygenstruct:: hipResourceDesc
+   :members:
+
+.. doxygenstruct:: hipResourceViewDesc
+   :members:
+
+.. doxygenunion:: hipStreamBatchMemOpParams
+
+.. doxygenstruct:: hipTextureDesc
+   :members:
+
+.. doxygenstruct:: hipUUID
+   :members:
+
+.. doxygenstruct:: hip_Memcpy2D
+   :members:
+
+.. doxygenstruct:: surfaceReference
+   :members:
+
+.. doxygenstruct:: texture
+   :members:
+
+.. doxygenstruct:: textureReference
+   :members:

--- a/projects/hip/docs/reference/hip_runtime_api/driver_types.rst
+++ b/projects/hip/docs/reference/hip_runtime_api/driver_types.rst
@@ -1,0 +1,12 @@
+.. meta::
+  :description: The driver types reference page.
+  :keywords: AMD, ROCm, HIP, driver types
+
+.. _driver_types_reference:
+
+*******************************************************************************
+Driver types
+*******************************************************************************
+
+.. doxygengroup:: DriverTypes
+   :content-only:

--- a/projects/hip/docs/reference/hip_runtime_api/global_defines.rst
+++ b/projects/hip/docs/reference/hip_runtime_api/global_defines.rst
@@ -1,0 +1,12 @@
+.. meta::
+  :description: The global enum and defines reference page.
+  :keywords: AMD, ROCm, HIP, global defines, global enum, macros
+
+.. _global_defines_reference:
+
+*******************************************************************************
+Global enum and defines
+*******************************************************************************
+
+.. doxygengroup:: GlobalDefs
+   :content-only:

--- a/projects/hip/docs/reference/hip_runtime_api/global_defines_enums_structs_files.rst
+++ b/projects/hip/docs/reference/hip_runtime_api/global_defines_enums_structs_files.rst
@@ -9,7 +9,6 @@ Global defines, enums, structs and files
 
 The structs, define macros, enums and files in the HIP runtime API.
 
-* :doc:`Global enum and defines <../../doxygen/html/group___global_defs>`
-* :doc:`Driver types <../../doxygen/html/group___driver_types>`
-* :doc:`../../doxygen/html/annotated`
-* :doc:`../../doxygen/html/files`
+* :doc:`Global enum and defines <global_defines>`
+* :doc:`Driver types <driver_types>`
+* :doc:`Data structures <data_structures>`

--- a/projects/hip/docs/sphinx/_toc.yml.in
+++ b/projects/hip/docs/sphinx/_toc.yml.in
@@ -99,10 +99,9 @@ subtrees:
       - file: reference/hip_runtime_api/global_defines_enums_structs_files
         subtrees:
         - entries:
-          - file: doxygen/html/group___global_defs
-          - file: doxygen/html/group___driver_types
-          - file: doxygen/html/annotated
-          - file: doxygen/html/files
+          - file: reference/hip_runtime_api/global_defines
+          - file: reference/hip_runtime_api/driver_types
+          - file: reference/hip_runtime_api/data_structures
   - file: reference/math_api
   - file: reference/complex_math_api
   - file: reference/env_variables


### PR DESCRIPTION
…tructures through Sphinx

Replace the four raw Doxygen HTML links in the "Global defines, enums, structs and files" reference section with Sphinx-rendered pages so the runtime API reference is fully Sphinx-based:

- global_defines.rst and driver_types.rst render the GlobalDefs and DriverTypes groups via Breathe doxygengroup, matching the module pages.
- data_structures.rst documents the public HIP data structures with members via doxygenstruct/doxygenunion, excluding internal cooperative_groups types.
- Repoint the toc and the landing page at the new pages and drop the raw doxygen/html links.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
