### PR TITLE
docs(rocdecode): Clarify install and build-utility packaging

### DIFF
--- a/projects/rocdecode/README.md
+++ b/projects/rocdecode/README.md
@@ -71,13 +71,14 @@ SDK, the following standalone rocDecode packages are also available:
 | Package | apt name (Debian/Ubuntu) | dnf/zypper name (RHEL/SLES) | Contents |
 |---------|--------------------------|-----------------------------|----------|
 | Runtime | `amdrocm-decode` | `amdrocm-decode` | Runtime library |
-| Development | `amdrocm-decode-dev` | `amdrocm-decode-devel` | Library, headers, and samples |
-| Test | `amdrocm-decode-test` | `amdrocm-decode-test` | CTest verification, utility sources, and test media |
+| Development | `amdrocm-decode-dev` | `amdrocm-decode-devel` | Library, headers, and CMake helper modules (`share/rocdecode/cmake/`) |
+| Test | `amdrocm-decode-test` | `amdrocm-decode-test` | CTest verification, utility sources (`utils/`), samples, and test media |
 
 > [!IMPORTANT]
-> The rocDecode library and headers come with a standard ROCm Core SDK install,
-> but the files under `/opt/rocm/share/rocdecode/` — the `utils/` utility sources,
-> the `cmake/` helper modules, the `samples/` sources, and the test media — do
+> The rocDecode library, headers, and the CMake helper modules
+> (`/opt/rocm/share/rocdecode/cmake/`) come with a standard ROCm Core SDK install
+> and the development package. However, the `utils/` utility sources, the
+> `samples/` sources, and the test media under `/opt/rocm/share/rocdecode/` do
 > **not** ship with the Core SDK or the development package. These are required to
 > build applications against rocDecode and to build or run the samples and CTests,
 > and are provided by the `amdrocm-decode-test` package. Install it if you build
@@ -121,20 +122,22 @@ After installation, the following files are available:
 
 * Libraries in `/opt/rocm/lib`
 * Header files in `/opt/rocm/include/rocdecode`
-* Samples, utility sources, and CMake helper modules in `/opt/rocm/share/rocdecode`
+* CMake helper modules in `/opt/rocm/share/rocdecode/cmake`
+* Utility sources, samples, and test media in `/opt/rocm/share/rocdecode` (from the test package)
 * Documents in `/opt/rocm/share/doc/rocdecode`
 
   > [!NOTE]
-  > The `utils/`, `cmake/`, and `samples/` sources and the test media under
-  > `/opt/rocm/share/rocdecode/` are provided by the `amdrocm-decode-test` package.
-  > Install it (see [Install](#install)) if you build against rocDecode or run the
-  > samples and CTests.
+  > The `utils/` and `samples/` sources and the test media under
+  > `/opt/rocm/share/rocdecode/` are provided by the `amdrocm-decode-test` package
+  > (the CMake helper modules in `share/rocdecode/cmake/` ship with the development
+  > package). Install `amdrocm-decode-test` (see [Install](#install)) if you build
+  > against rocDecode or run the samples and CTests.
 
 If you obtain rocDecode from [TheRock](https://github.com/ROCm/TheRock)'s generic
-(`.tar.zst`) artifacts instead of distribution packages, these `share/rocdecode/`
-files ship in the `rocdecode-test` artifact (for example, `rocdecode_test_generic`)
-rather than `rocdecode-dev`. Install it with TheRock's
-`install_rocm_from_artifacts.py` helper by adding `--tests` together with
+(`.tar.zst`) artifacts instead of distribution packages, the `utils/`, `samples/`,
+and test media under `share/rocdecode/` ship in the `rocdecode-test` artifact (for
+example, `rocdecode_test_generic`) rather than `rocdecode-dev`. Install it with
+TheRock's `install_rocm_from_artifacts.py` helper by adding `--tests` together with
 `--rocdecode`:
 
   ```shell

--- a/projects/rocdecode/README.md
+++ b/projects/rocdecode/README.md
@@ -22,15 +22,26 @@ access the video decoding features available on your GPU.
 > [!IMPORTANT]
 > `gfx908` or higher GPU required
 
-### ROCm via TheRock
+### ROCm
 
-rocDecode is built and installed as part of [TheRock](https://github.com/ROCm/TheRock). All core dependencies are provided by the TheRock build, including:
+Install ROCm using the package manager for your distribution by following the
+official [Install AMD ROCm](https://rocm.docs.amd.com/en/latest/install/rocm.html)
+guide. Use the selector on that page to choose your GPU, operating system, and
+install method. This is the recommended way to obtain ROCm and rocDecode for most
+users.
+
+The ROCm package repositories provide all of rocDecode's core dependencies,
+including:
 
 * HIP runtime and development libraries
 * AMD Clang++ compiler (C++17 required)
 * Libva and VA-API drivers
 * Libdrm (amdgpu)
 * CMake and pkg-config
+
+rocDecode is also built and installed as part of
+[TheRock](https://github.com/ROCm/TheRock), which is the recommended path for
+source builds and nightly/CI artifacts.
 
 ### FFmpeg (required for samples and tests)
 
@@ -40,7 +51,47 @@ rocDecode is built and installed as part of [TheRock](https://github.com/ROCm/Th
   sudo apt install libavcodec-dev libavformat-dev libavutil-dev
   ```
 
-## Build and install
+## Install
+
+### Install with the package manager (recommended)
+
+rocDecode is included with the ROCm Core SDK on Linux. A standard ROCm
+installation using the `amdrocm-core-sdk` meta package installs the rocDecode
+runtime library and development headers by default. Follow the official
+[Install AMD ROCm](https://rocm.docs.amd.com/en/latest/install/rocm.html) guide
+and use the selector to choose your GPU, operating system, and install method.
+
+If you only want the ROCm video decode components without the rest of the Core
+SDK, the following standalone rocDecode packages are also available:
+
+> [!NOTE]
+> The `amdrocm-decode` package names apply to ROCm 7.13 and later. Earlier ROCm
+> releases use different package naming.
+
+| Package | apt name (Debian/Ubuntu) | dnf/zypper name (RHEL/SLES) | Contents |
+|---------|--------------------------|-----------------------------|----------|
+| Runtime | `amdrocm-decode` | `amdrocm-decode` | Runtime library |
+| Development | `amdrocm-decode-dev` | `amdrocm-decode-devel` | Library, headers, and samples |
+| Test | `amdrocm-decode-test` | `amdrocm-decode-test` | CTest verification, utility sources, and test media |
+
+> [!IMPORTANT]
+> The rocDecode library and headers come with a standard ROCm Core SDK install,
+> but the files under `/opt/rocm/share/rocdecode/` — the `utils/` utility sources,
+> the `cmake/` helper modules, the `samples/` sources, and the test media — do
+> **not** ship with the Core SDK or the development package. These are required to
+> build applications against rocDecode and to build or run the samples and CTests,
+> and are provided by the `amdrocm-decode-test` package. Install it if you build
+> against rocDecode (for example, when building rocAL):
+>
+>   ```shell
+>   # Debian / Ubuntu
+>   sudo apt install amdrocm-decode-test
+>
+>   # RHEL / SLES
+>   sudo dnf install amdrocm-decode-test
+>   ```
+
+### Build and install from source
 
 rocDecode is built as part of [TheRock](https://github.com/ROCm/TheRock). To build standalone from source:
 
@@ -70,8 +121,33 @@ After installation, the following files are available:
 
 * Libraries in `/opt/rocm/lib`
 * Header files in `/opt/rocm/include/rocdecode`
-* Samples in `/opt/rocm/share/rocdecode`
+* Samples, utility sources, and CMake helper modules in `/opt/rocm/share/rocdecode`
 * Documents in `/opt/rocm/share/doc/rocdecode`
+
+  > [!NOTE]
+  > The `utils/`, `cmake/`, and `samples/` sources and the test media under
+  > `/opt/rocm/share/rocdecode/` are provided by the `amdrocm-decode-test` package.
+  > Install it (see [Install](#install)) if you build against rocDecode or run the
+  > samples and CTests.
+
+If you obtain rocDecode from [TheRock](https://github.com/ROCm/TheRock)'s generic
+(`.tar.zst`) artifacts instead of distribution packages, these `share/rocdecode/`
+files ship in the `rocdecode-test` artifact (for example, `rocdecode_test_generic`)
+rather than `rocdecode-dev`. Install it with TheRock's
+`install_rocm_from_artifacts.py` helper by adding `--tests` together with
+`--rocdecode`:
+
+  ```shell
+  python build_tools/install_rocm_from_artifacts.py \
+      --latest-release \
+      --amdgpu-family gfx110X-all \
+      --rocdecode \
+      --tests
+  ```
+
+See TheRock's
+[Installing artifacts](https://github.com/ROCm/TheRock/blob/main/docs/development/installing_artifacts.md)
+guide for other options.
 
 ### Using sample application
 

--- a/projects/rocdecode/docs/install/rocDecode-install.rst
+++ b/projects/rocdecode/docs/install/rocDecode-install.rst
@@ -82,6 +82,61 @@ This includes the ROCm runtime and system dependencies.
 
             sudo zypper install amdrocm-decode-devel
 
+.. _install-build-utilities:
+
+Locating build utilities and samples
+====================================
+
+Building applications against rocDecode, or building and running the samples and
+CTest-based tests, requires the utility sources, CMake helper modules, and sample
+sources that are installed to ``$ROCM_PATH/share/rocdecode/``:
+
+* ``share/rocdecode/utils/`` - utility classes and HIP kernels shared by the samples
+  (for example, ``RocVideoDecoder`` and ``VideoDemuxer``)
+* ``share/rocdecode/cmake/`` - ``FindFFmpeg``, ``FindLibva``, and ``FindLibdrm_amdgpu``
+  helper modules
+* ``share/rocdecode/samples/`` - sample application sources
+* ``share/rocdecode/video/`` and ``share/rocdecode/frames/`` - test media and reference frames
+* ``share/rocdecode/test/`` - CTest definitions and test scripts
+
+The rocDecode runtime library and development headers come with a standard ROCm
+Core SDK install (the ``amdrocm-core-sdk`` meta package). However, the
+``share/rocdecode/`` files listed above do **not** ship with the Core SDK or the
+development package. When installing with a package manager, they are provided by
+the ``amdrocm-decode-test`` package. Install it if you need the utility sources,
+CMake modules, or samples to build against rocDecode (for example, when building
+rocAL). The ``amdrocm-decode`` package names apply to ROCm 7.13 and later; earlier
+ROCm releases use different package naming.
+
+.. tab-set::
+
+   .. tab-item:: Debian-based distros
+
+      .. code-block:: bash
+
+         sudo apt install amdrocm-decode-test
+
+   .. tab-item:: RHEL-based distros
+
+      .. code-block:: bash
+
+         sudo dnf install amdrocm-decode-test
+
+   .. tab-item:: SLES
+
+      .. code-block:: bash
+
+         sudo zypper install amdrocm-decode-test
+
+.. note::
+
+   In the generic (``.tar.zst``) artifacts published by TheRock, these
+   ``share/rocdecode/`` files are packaged in the ``rocdecode-test`` artifact
+   (for example, ``rocdecode_test_generic``) rather than the
+   ``rocdecode-dev`` artifact. If you obtain rocDecode from those artifacts,
+   install or extract the ``rocdecode-test`` artifact in addition to
+   ``rocdecode-dev``.
+
 .. _install-nightly:
 
 Install a nightly build

--- a/projects/rocdecode/docs/install/rocDecode-install.rst
+++ b/projects/rocdecode/docs/install/rocDecode-install.rst
@@ -88,25 +88,27 @@ Locating build utilities and samples
 ====================================
 
 Building applications against rocDecode, or building and running the samples and
-CTest-based tests, requires the utility sources, CMake helper modules, and sample
+CTest-based tests, requires the CMake helper modules, utility sources, and sample
 sources that are installed to ``$ROCM_PATH/share/rocdecode/``:
 
+* ``share/rocdecode/cmake/`` - ``FindFFmpeg``, ``FindLibva``, and ``FindLibdrm_amdgpu``
+  helper modules (ships with the development package)
 * ``share/rocdecode/utils/`` - utility classes and HIP kernels shared by the samples
   (for example, ``RocVideoDecoder`` and ``VideoDemuxer``)
-* ``share/rocdecode/cmake/`` - ``FindFFmpeg``, ``FindLibva``, and ``FindLibdrm_amdgpu``
-  helper modules
 * ``share/rocdecode/samples/`` - sample application sources
 * ``share/rocdecode/video/`` and ``share/rocdecode/frames/`` - test media and reference frames
 * ``share/rocdecode/test/`` - CTest definitions and test scripts
 
-The rocDecode runtime library and development headers come with a standard ROCm
-Core SDK install (the ``amdrocm-core-sdk`` meta package). However, the
-``share/rocdecode/`` files listed above do **not** ship with the Core SDK or the
-development package. When installing with a package manager, they are provided by
-the ``amdrocm-decode-test`` package. Install it if you need the utility sources,
-CMake modules, or samples to build against rocDecode (for example, when building
-rocAL). The ``amdrocm-decode`` package names apply to ROCm 7.13 and later; earlier
-ROCm releases use different package naming.
+The rocDecode runtime library, development headers, and the CMake helper modules
+(``share/rocdecode/cmake/``) come with a standard ROCm Core SDK install (the
+``amdrocm-core-sdk`` meta package) and the development package. However, the
+remaining ``share/rocdecode/`` files listed above — the ``utils/`` sources, the
+``samples/`` sources, and the test media — do **not** ship with the Core SDK or
+the development package. When installing with a package manager, they are provided
+by the ``amdrocm-decode-test`` package. Install it if you need the utility sources
+or samples to build against rocDecode (for example, when building rocAL). The
+``amdrocm-decode`` package names apply to ROCm 7.13 and later; earlier ROCm
+releases use different package naming.
 
 .. tab-set::
 
@@ -130,11 +132,11 @@ ROCm releases use different package naming.
 
 .. note::
 
-   In the generic (``.tar.zst``) artifacts published by TheRock, these
-   ``share/rocdecode/`` files are packaged in the ``rocdecode-test`` artifact
-   (for example, ``rocdecode_test_generic``) rather than the
-   ``rocdecode-dev`` artifact. If you obtain rocDecode from those artifacts,
-   install or extract the ``rocdecode-test`` artifact in addition to
+   In the generic (``.tar.zst``) artifacts published by TheRock, the ``utils/``,
+   ``samples/``, and test media under ``share/rocdecode/`` are packaged in the
+   ``rocdecode-test`` artifact (for example, ``rocdecode_test_generic``) rather
+   than the ``rocdecode-dev`` artifact. If you obtain rocDecode from those
+   artifacts, install or extract the ``rocdecode-test`` artifact in addition to
    ``rocdecode-dev``.
 
 .. _install-nightly:


### PR DESCRIPTION
## Motivation

Building applications against rocDecode, and building or running the samples and CTests, requires the utility sources, CMake helper modules, and sample sources installed under `$ROCM_PATH/share/rocdecode/`. These files do not ship with the ROCm Core SDK or the rocDecode development package — they are only provided by the test package. This trips up downstream consumers such as rocAL, whose build fails without them (see ROCm/rocAL#495).

This PR updates the rocDecode `README.md` and install docs to clarify where the library, headers, and build utilities come from, and how to obtain the missing pieces.

## Technical Details

- Clarify that the rocDecode runtime library and development headers ship with a standard ROCm Core SDK install (`amdrocm-core-sdk` meta package).
- Document that the `share/rocdecode/` utilities (`utils/`, `cmake/`, `samples/`, test media) are provided by the `amdrocm-decode-test` package, and must be installed to build against rocDecode or run the samples/CTests.
- Add the correct ROCm 7.13+ package names (`amdrocm-decode`, `amdrocm-decode-dev`/`-devel`, `amdrocm-decode-test`) with apt/dnf/zypper commands.
- Note the equivalent path for TheRock generic (`.tar.zst`) artifacts, where these files live in the `rocdecode-test` artifact rather than `rocdecode-dev`.

Note: this documents the current behavior as an interim measure. The underlying fix is to route `share/rocdecode/utils/**`, `cmake/**`, and `samples/**` into `[components.dev]` in TheRock's `artifact-rocdecode.toml` so they land in the dev package where consumers expect them.

## Issue Tracking

<!-- GitHub issue -->
Closes #9237

## Test Plan

Documentation-only change. Verified the package names against a ROCm 7.14 install (`amdrocm-decode-test` resolves and is installed) and confirmed the changed Markdown/reStructuredText files have no trailing whitespace and end with a newline (pre-commit `trailing-whitespace` / `end-of-file-fixer`).

## Test Result

No functional/code changes. Docs render as expected; no unit tests required for doc-only changes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.