### PR TITLE
[RCCL] Add functional test for bootstrap socket poll busy-loop fix

### DIFF
--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -364,6 +364,7 @@ if(BUILD_TESTS)
       PluginCompatV11_test.cpp
       ProxyTests.cpp
       RcclWrapTests.cpp
+      SocketPollTests.cpp
       TransportTests.cpp
       TimeoutTests.cpp
       mem_manager/MemManagerTests.cpp

--- a/projects/rccl/test/SocketPollTests.cpp
+++ b/projects/rccl/test/SocketPollTests.cpp
@@ -18,18 +18,20 @@
  * deliberately slow. It measures the CPU time consumed by the receiving thread
  * while it is blocked waiting for data:
  *
- *   - With NCCL_SOCKET_POLL_TIMEOUT_MSEC > 0 (the fix, default on >= v2.29) the
- *     receiver sleeps in poll(), so it consumes almost no CPU relative to the
- *     wall-clock time it spends waiting.
- *   - With NCCL_SOCKET_POLL_TIMEOUT_MSEC == 0 (pre-fix behavior, and the code
- *     path taken by every release before v2.29) the receiver busy-spins, so it
+ *   - With NCCL_SOCKET_POLL_TIMEOUT_MSEC > 0 the receiver sleeps in poll(), so
+ *     it consumes almost no CPU relative to the wall-clock time it spends
+ *     waiting. The parameter is opt-in and defaults to 0 (see NCCL_PARAM in
+ *     src/misc/socket.cc), so the test sets it explicitly; the poll code path it
+ *     selects only exists on builds that carry the fix.
+ *   - With NCCL_SOCKET_POLL_TIMEOUT_MSEC == 0 (the default, and the only code
+ *     path available on builds lacking the fix) the receiver busy-spins, so it
  *     consumes CPU time roughly equal to the wall-clock wait.
  *
- * The "poll enabled -> low CPU" assertion passes on v2.29+ and fails on any
- * build lacking the fix (where the parameter is ignored and the loop always
- * spins), giving a clean pass-after / fail-before signal. The "poll disabled ->
- * high CPU" case is kept as a control that documents the busy-loop behavior the
- * fix removes.
+ * The "poll enabled -> low CPU" assertion passes on builds that honor the
+ * parameter and fails on any build lacking the fix (where the parameter is
+ * ignored and the loop always spins), giving a clean pass-after / fail-before
+ * signal. The "poll disabled -> high CPU" case is kept as a control that
+ * documents the busy-loop behavior the fix removes.
  */
 
 #include "socket.h"
@@ -39,11 +41,13 @@
 #include "gtest/gtest.h"
 
 #include <atomic>
+#include <chrono>
 #include <cstdio>
 #include <cstring>
 #include <ctime>
 #include <netinet/in.h>
 #include <thread>
+#include <vector>
 
 namespace RcclUnitTesting {
 namespace {
@@ -95,14 +99,20 @@ TransferMeasurement RunSlowTransfer() {
   const uint64_t magic = NCCL_SOCKET_MAGIC;
   const enum ncclSocketType type = ncclSocketTypeBootstrap;
 
+  // Abort flag lives on listenSock; ncclSocketAccept copies it onto acceptSock,
+  // so raising it unblocks a thread parked in the blocking accept() loop (e.g.
+  // when the connect side fails and no peer ever arrives).
+  volatile uint32_t abortFlag = 0;
+
   struct ncclSocket listenSock;
   union ncclSocketAddress listenAddr = LoopbackAddr();
-  if (ncclSocketInit(&listenSock, &listenAddr, magic, type) != ncclSuccess) {
+  if (ncclSocketInit(&listenSock, &listenAddr, magic, type, &abortFlag) != ncclSuccess) {
     TEST_INFO("ncclSocketInit(listen) failed");
     return m;
   }
   if (ncclSocketListen(&listenSock) != ncclSuccess) {
     TEST_INFO("ncclSocketListen failed");
+    ncclSocketClose(&listenSock);
     return m;
   }
 
@@ -130,7 +140,11 @@ TransferMeasurement RunSlowTransfer() {
     acceptOk.store(acceptSock.state == ncclSocketStateReady);
   });
 
+  // Zero-init so that, if ncclSocketInit() fails below, connectSock has state
+  // ncclSocketStateNone (0) and the ncclSocketClose() cleanup path is a safe
+  // no-op instead of acting on a garbage descriptor.
   struct ncclSocket connectSock;
+  memset(&connectSock, 0, sizeof(connectSock));
   union ncclSocketAddress connectAddr = boundAddr;
   bool connectOk = false;
   if (ncclSocketInit(&connectSock, &connectAddr, magic, type) == ncclSuccess &&
@@ -140,6 +154,10 @@ TransferMeasurement RunSlowTransfer() {
     TEST_INFO("ncclSocketConnect failed");
   }
 
+  // If the connect side never came up, no peer will reach the accept() loop;
+  // raise the abort flag so acceptThread returns instead of blocking until the
+  // test timeout fires.
+  if (!connectOk) abortFlag = 1;
   acceptThread.join();
 
   if (!connectOk || !acceptOk.load()) {
@@ -179,6 +197,11 @@ TransferMeasurement RunSlowTransfer() {
   ncclResult_t sendRes =
       ncclSocketSend(&acceptSock, sendBuf.data(), kPayloadBytes);
 
+  // If the payload never went out, the receiver would otherwise sit in
+  // ncclSocketRecv() until the test timeout. Shut the sender side down so the
+  // peer sees EOF and recvThread can join promptly.
+  if (sendRes != ncclSuccess) ncclSocketShutdown(&acceptSock, SHUT_RDWR);
+
   recvThread.join();
 
   if (sendRes == ncclSuccess && m.dataValid)
@@ -197,11 +220,15 @@ TransferMeasurement RunSlowTransfer() {
 void CheckSlowTransfer(bool expectBusy) {
   TransferMeasurement m = RunSlowTransfer();
 
-  if (!m.connected) {
-    GTEST_SKIP() << "Could not establish a loopback socket pair; "
-                 << "networking may be unavailable in this environment.";
-    return;
-  }
+  // Loopback (127.0.0.1) bootstrap sockets must always come up in the test
+  // environment, so a failed handshake is a real defect, not a reason to skip.
+  // A skip would also be misleading here: in the isolated child a skip exits
+  // RCCL_TEST_SKIPPED, which the runner does not count as a failure, so the
+  // outer gtest case would report PASSED and hide a broken handshake. Fail hard
+  // instead.
+  ASSERT_TRUE(m.connected)
+      << "Could not establish a loopback bootstrap socket pair; the slow-transfer "
+      << "measurement never ran.";
 
   ASSERT_TRUE(m.dataValid) << "Payload was not received intact over the socket pair.";
   ASSERT_GT(m.wallMs, kSenderIdleMs * 0.5)

--- a/projects/rccl/test/SocketPollTests.cpp
+++ b/projects/rccl/test/SocketPollTests.cpp
@@ -1,0 +1,266 @@
+/*************************************************************************
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+/*
+ * Functional regression test for the bootstrap socket busy-loop fix.
+ *
+ * The NCCL_SOCKET_POLL_TIMEOUT_MSEC parameter, when set to a non-zero value,
+ * makes socketWait() block in poll() until the socket becomes readable/writable
+ * instead of spinning on socketProgress(), which previously pinned a CPU core at
+ * ~100% for the whole duration of a bootstrap transfer that was waiting on a
+ * slow / late peer.
+ *
+ * This test exercises the public ncclSocket* send/recv path (which routes
+ * through socketWait) over a loopback connection where the sender is
+ * deliberately slow. It measures the CPU time consumed by the receiving thread
+ * while it is blocked waiting for data:
+ *
+ *   - With NCCL_SOCKET_POLL_TIMEOUT_MSEC > 0 (the fix, default on >= v2.29) the
+ *     receiver sleeps in poll(), so it consumes almost no CPU relative to the
+ *     wall-clock time it spends waiting.
+ *   - With NCCL_SOCKET_POLL_TIMEOUT_MSEC == 0 (pre-fix behavior, and the code
+ *     path taken by every release before v2.29) the receiver busy-spins, so it
+ *     consumes CPU time roughly equal to the wall-clock wait.
+ *
+ * The "poll enabled -> low CPU" assertion passes on v2.29+ and fails on any
+ * build lacking the fix (where the parameter is ignored and the loop always
+ * spins), giving a clean pass-after / fail-before signal. The "poll disabled ->
+ * high CPU" case is kept as a control that documents the busy-loop behavior the
+ * fix removes.
+ */
+
+#include "socket.h"
+
+#include "common/ErrCode.hpp"
+#include "common/ProcessIsolatedTestRunner.hpp"
+#include "gtest/gtest.h"
+
+#include <atomic>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <netinet/in.h>
+#include <thread>
+
+namespace RcclUnitTesting {
+namespace {
+
+// Wall-clock time the sender stays idle before delivering the payload. The
+// receiver is blocked inside socketWait() for (approximately) this long, which
+// is the window in which busy-looping vs. polling is distinguishable.
+constexpr int kSenderIdleMs = 1000;
+
+// Payload is intentionally tiny so a single TCP segment / read completes the
+// transfer once the data is finally sent.
+constexpr int kPayloadBytes = 4096;
+
+// Fraction of the wait spent burning CPU. A polling receiver stays far below
+// this; a busy-looping receiver sits near 1.0. 0.5 leaves a wide margin for
+// scheduler noise on loaded CI machines.
+constexpr double kCpuBusyThreshold = 0.5;
+
+double timespecDiffMs(const struct timespec &start, const struct timespec &end) {
+  return (end.tv_sec - start.tv_sec) * 1e3 +
+         (end.tv_nsec - start.tv_nsec) / 1e6;
+}
+
+// Loopback (127.0.0.1) address with an ephemeral port for ncclSocketListen().
+union ncclSocketAddress LoopbackAddr() {
+  union ncclSocketAddress addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin.sin_family = AF_INET;
+  addr.sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin.sin_port = 0; // kernel assigns a free port
+  return addr;
+}
+
+// Outcome of a single slow-transfer measurement, run entirely inside an
+// isolated child process so NCCL_SOCKET_POLL_TIMEOUT_MSEC is read fresh.
+struct TransferMeasurement {
+  bool connected = false;   // connection pair was established
+  bool dataValid = false;   // payload received intact
+  double wallMs = 0.0;      // wall time the receiver spent in ncclSocketRecv
+  double cpuMs = 0.0;       // CPU time the receiver thread burned in that span
+};
+
+// Establishes a loopback ncclSocket pair, then transfers a small payload with
+// the sender deliberately delayed by kSenderIdleMs, measuring how much CPU the
+// receiving thread burns while blocked in ncclSocketRecv().
+TransferMeasurement RunSlowTransfer() {
+  TransferMeasurement m;
+
+  const uint64_t magic = NCCL_SOCKET_MAGIC;
+  const enum ncclSocketType type = ncclSocketTypeBootstrap;
+
+  struct ncclSocket listenSock;
+  union ncclSocketAddress listenAddr = LoopbackAddr();
+  if (ncclSocketInit(&listenSock, &listenAddr, magic, type) != ncclSuccess) {
+    TEST_INFO("ncclSocketInit(listen) failed");
+    return m;
+  }
+  if (ncclSocketListen(&listenSock) != ncclSuccess) {
+    TEST_INFO("ncclSocketListen failed");
+    return m;
+  }
+
+  union ncclSocketAddress boundAddr;
+  if (ncclSocketGetAddr(&listenSock, &boundAddr) != ncclSuccess) {
+    TEST_INFO("ncclSocketGetAddr failed");
+    ncclSocketClose(&listenSock);
+    return m;
+  }
+
+  // Accept side runs on its own thread; the connect side drives the main
+  // thread. Both handshakes (magic/type exchange) must progress concurrently.
+  struct ncclSocket acceptSock;
+  memset(&acceptSock, 0, sizeof(acceptSock));
+  std::atomic<bool> acceptOk{false};
+  std::thread acceptThread([&]() {
+    if (ncclSocketInit(&acceptSock, nullptr, magic, type) != ncclSuccess) {
+      TEST_INFO("ncclSocketInit(accept) failed");
+      return;
+    }
+    if (ncclSocketAccept(&acceptSock, &listenSock) != ncclSuccess) {
+      TEST_INFO("ncclSocketAccept failed");
+      return;
+    }
+    acceptOk.store(acceptSock.state == ncclSocketStateReady);
+  });
+
+  struct ncclSocket connectSock;
+  union ncclSocketAddress connectAddr = boundAddr;
+  bool connectOk = false;
+  if (ncclSocketInit(&connectSock, &connectAddr, magic, type) == ncclSuccess &&
+      ncclSocketConnect(&connectSock) == ncclSuccess) {
+    connectOk = (connectSock.state == ncclSocketStateReady);
+  } else {
+    TEST_INFO("ncclSocketConnect failed");
+  }
+
+  acceptThread.join();
+
+  if (!connectOk || !acceptOk.load()) {
+    TEST_INFO("Failed to establish socket pair (connect=%d accept=%d)",
+              connectOk ? 1 : 0, acceptOk.load() ? 1 : 0);
+    ncclSocketClose(&connectSock);
+    ncclSocketClose(&acceptSock);
+    ncclSocketClose(&listenSock);
+    return m;
+  }
+  m.connected = true;
+
+  // Receiver: connect side. Blocks in ncclSocketRecv() -> socketWait() until
+  // the (delayed) payload arrives, measuring its own thread CPU consumption.
+  std::vector<char> recvBuf(kPayloadBytes, 0);
+  std::thread recvThread([&]() {
+    struct timespec cpu0, cpu1, wall0, wall1;
+    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &cpu0);
+    clock_gettime(CLOCK_MONOTONIC, &wall0);
+
+    ncclResult_t r = ncclSocketRecv(&connectSock, recvBuf.data(), kPayloadBytes);
+
+    clock_gettime(CLOCK_MONOTONIC, &wall1);
+    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &cpu1);
+
+    m.wallMs = timespecDiffMs(wall0, wall1);
+    m.cpuMs = timespecDiffMs(cpu0, cpu1);
+    m.dataValid = (r == ncclSuccess);
+  });
+
+  // Sender: accept side. Stay idle so the receiver is parked in socketWait,
+  // then deliver the whole payload at once.
+  std::vector<char> sendBuf(kPayloadBytes);
+  for (int i = 0; i < kPayloadBytes; ++i)
+    sendBuf[i] = static_cast<char>(i & 0xff);
+  std::this_thread::sleep_for(std::chrono::milliseconds(kSenderIdleMs));
+  ncclResult_t sendRes =
+      ncclSocketSend(&acceptSock, sendBuf.data(), kPayloadBytes);
+
+  recvThread.join();
+
+  if (sendRes == ncclSuccess && m.dataValid)
+    m.dataValid = (memcmp(sendBuf.data(), recvBuf.data(), kPayloadBytes) == 0);
+  else
+    m.dataValid = false;
+
+  ncclSocketClose(&connectSock);
+  ncclSocketClose(&acceptSock);
+  ncclSocketClose(&listenSock);
+  return m;
+}
+
+// Shared body: run the slow transfer and check correctness + the CPU ratio.
+// expectBusy selects the assertion direction (control vs. fix).
+void CheckSlowTransfer(bool expectBusy) {
+  TransferMeasurement m = RunSlowTransfer();
+
+  if (!m.connected) {
+    GTEST_SKIP() << "Could not establish a loopback socket pair; "
+                 << "networking may be unavailable in this environment.";
+    return;
+  }
+
+  ASSERT_TRUE(m.dataValid) << "Payload was not received intact over the socket pair.";
+  ASSERT_GT(m.wallMs, kSenderIdleMs * 0.5)
+      << "Receiver returned too quickly (wall=" << m.wallMs
+      << "ms); the slow-sender wait was not exercised.";
+
+  const double ratio = m.cpuMs / m.wallMs;
+  TEST_INFO("Slow transfer: wall=%.1fms cpu=%.1fms ratio=%.3f (expectBusy=%d)",
+            m.wallMs, m.cpuMs, ratio, expectBusy ? 1 : 0);
+
+  if (expectBusy) {
+    // Control: NCCL_SOCKET_POLL_TIMEOUT_MSEC=0 reproduces the pre-fix busy loop.
+    EXPECT_GT(ratio, kCpuBusyThreshold)
+        << "Expected the receiver to busy-spin when polling is disabled, but it "
+        << "consumed little CPU (cpu=" << m.cpuMs << "ms / wall=" << m.wallMs
+        << "ms). ratio=" << ratio;
+  } else {
+    // Fix: with polling enabled the receiver must sleep, not spin.
+    EXPECT_LT(ratio, kCpuBusyThreshold)
+        << "Receiver busy-spun while waiting for a slow peer even though "
+        << "NCCL_SOCKET_POLL_TIMEOUT_MSEC is set. This indicates the bootstrap "
+        << "socket poll fix is missing or ineffective. cpu="
+        << m.cpuMs << "ms / wall=" << m.wallMs << "ms, ratio=" << ratio;
+  }
+}
+
+} // namespace
+
+// The bug fix: NCCL_SOCKET_POLL_TIMEOUT_MSEC > 0 makes a blocked bootstrap
+// receive wait in poll() instead of burning a CPU core. Passes on v2.29+
+// (fix present) and fails on pre-fix builds where the parameter is ignored.
+TEST(SocketPollTimeout, PollEnabledDoesNotBusyLoop) {
+  ProcessIsolatedTestRunner::ExecutionOptions options;
+  options.stopOnFirstFailure = false;
+  options.verboseLogging = true;
+
+  RUN_ISOLATED_TESTS_WITH_OPTIONS(
+      options,
+      ProcessIsolatedTestRunner::TestConfig(
+          "PollEnabledDoesNotBusyLoop",
+          []() { CheckSlowTransfer(/*expectBusy=*/false); })
+          .withEnvironment({{"NCCL_SOCKET_POLL_TIMEOUT_MSEC", "5000"}})
+          .withTimeout(std::chrono::seconds(60)));
+}
+
+// Control: NCCL_SOCKET_POLL_TIMEOUT_MSEC=0 selects the exact code path used by
+// every pre-v2.29 build, demonstrating the busy loop the fix removes.
+TEST(SocketPollTimeout, PollDisabledBusyLoops) {
+  ProcessIsolatedTestRunner::ExecutionOptions options;
+  options.stopOnFirstFailure = false;
+  options.verboseLogging = true;
+
+  RUN_ISOLATED_TESTS_WITH_OPTIONS(
+      options,
+      ProcessIsolatedTestRunner::TestConfig(
+          "PollDisabledBusyLoops",
+          []() { CheckSlowTransfer(/*expectBusy=*/true); })
+          .withEnvironment({{"NCCL_SOCKET_POLL_TIMEOUT_MSEC", "0"}})
+          .withTimeout(std::chrono::seconds(60)));
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/test_categories_fixtures_debug.yaml
+++ b/projects/rccl/test/test_categories_fixtures_debug.yaml
@@ -25,6 +25,7 @@ test_categories:
       - "DdaIpcEligibilityTest.*"
       - "DdaFabricEligibilityTest.*"
       - "NetSocketTests.*"
+      - "SocketPollTimeout.*"
       - "Ipcsocket.*"
       - "XmlTest.*"
       - "NetDevsPolicyP2pNetTests.*"

--- a/projects/rccl/tools/scripts/test_runner/configs/ainic.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/ainic.json
@@ -221,6 +221,23 @@
       ]
     },
 
+    "a_socket_poll_bootstrap": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixturesDebug",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 120,
+      "description": "A16: bootstrap socket busy-loop regression. Validates that NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of pinning a CPU core at 100%. Single node, no NIC/GPU required.",
+      "tests": [
+        {
+          "name": "A16_Socket_BootstrapPollNoBusyLoop",
+          "description": "With NCCL_SOCKET_POLL_TIMEOUT_MSEC set, a receiver blocked on a slow peer sleeps in poll() (low CPU); the control case with the param at 0 reproduces the pre-fix busy loop (high CPU).",
+          "test_filter": "SocketPollTimeout.*"
+        }
+      ]
+    },
+
     "b_base": {
       "description": "Sweep base: derived suites run the full 1024-16G range for both allreduce and alltoall. Sets NO shared env_variables so each sweep runs against stock defaults plus its own per-suite knobs, and NO group-level command_args by design - every test sets its own explicit, complete command_args so nothing is silently concatenated/duplicated.",
       "is_gtest": false,
@@ -430,6 +447,7 @@
     { "name": "A9-A13. Component - GIN proxy",        "config": "a_gin",             "enabled": true },
     { "name": "A14. GIN enable gate (ROCM-27070)",    "config": "a_gin_enable_gate", "enabled": true },
     { "name": "A15. GIN AINIC backend (ROCM-27070)",  "config": "a_gin_ainic_backend", "enabled": true },
+    { "name": "A16. Component - Bootstrap socket poll", "config": "a_socket_poll_bootstrap", "enabled": true },
 
     { "name": "B1. IB baseline",                     "config": "b1_ib",             "enabled": true },
     { "name": "B2. CAST alltoall full (1K-16G)",     "config": "b_alltoall_cast_full", "enabled": true },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
@@ -1081,6 +1081,22 @@
         }
       ]
     },
+    "socket_poll_bootstrap": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixturesDebug",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 120,
+      "description": "Bootstrap socket busy-loop regression. Validates that NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of pinning a CPU core at 100%. Single node, no NIC/GPU required.",
+      "tests": [
+        {
+          "name": "Socket_BootstrapPollNoBusyLoop",
+          "description": "With NCCL_SOCKET_POLL_TIMEOUT_MSEC set, a receiver blocked on a slow peer sleeps in poll() (low CPU); the control case with the param at 0 reproduces the pre-fix busy loop (high CPU).",
+          "test_filter": "SocketPollTimeout.*"
+        }
+      ]
+    },
     "unit_tests_fixtures_debug": {
       "is_gtest": true,
       "binary": "rccl-UnitTestsFixturesDebug",
@@ -2907,6 +2923,12 @@
       "name": "Unit Tests - Fixtures (Release)",
       "description": "Non-MPI unit tests using header-only fixtures (Release and Debug)",
       "config": "unit_tests_fixtures",
+      "enabled": true
+    },
+    {
+      "name": "Bootstrap socket poll - no busy loop",
+      "description": "AICOMRCCL-1322: NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of busy-spinning a CPU core (Debug only, no NIC/GPU required)",
+      "config": "socket_poll_bootstrap",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -905,6 +905,18 @@
         {"name": "PluginCompatV11.CollNetLazyInitialization", "description": "AICOMRCCL-1532: v11 collnet plugin compat layer initializes lazily", "test_filter": "PluginCompatV11.CollNetLazyInitialization"}
       ]
     },
+    "socket_poll_bootstrap": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixturesDebug",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 120,
+      "description": "Bootstrap socket busy-loop regression. Validates that NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of pinning a CPU core at 100%. Single node, no NIC/GPU required.",
+      "tests": [
+        {"name": "Socket_BootstrapPollNoBusyLoop", "description": "With NCCL_SOCKET_POLL_TIMEOUT_MSEC set, a receiver blocked on a slow peer sleeps in poll() (low CPU); the control case with the param at 0 reproduces the pre-fix busy loop (high CPU).", "test_filter": "SocketPollTimeout.*"}
+      ]
+    },
     "net_plugin_reload": {
       "is_gtest": true,
       "binary": "rccl-UnitTests",
@@ -3404,6 +3416,12 @@
       "name": "Plugin Compat v11 - Lazy Init",
       "description": "AICOMRCCL-1532: v11 net/collnet plugin compat layer lazy initialization (Debug only)",
       "config": "plugin_compat_v11",
+      "enabled": true
+    },
+    {
+      "name": "Bootstrap socket poll - no busy loop",
+      "description": "AICOMRCCL-1322: NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of busy-spinning a CPU core (Debug only, no NIC/GPU required)",
+      "config": "socket_poll_bootstrap",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -485,6 +485,22 @@
         }
       ]
     },
+    "socket_poll_bootstrap": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixturesDebug",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 120,
+      "description": "Bootstrap socket busy-loop regression. Validates that NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of pinning a CPU core at 100%. Single node, no NIC/GPU required.",
+      "tests": [
+        {
+          "name": "Socket_BootstrapPollNoBusyLoop",
+          "description": "With NCCL_SOCKET_POLL_TIMEOUT_MSEC set, a receiver blocked on a slow peer sleeps in poll() (low CPU); the control case with the param at 0 reproduces the pre-fix busy loop (high CPU).",
+          "test_filter": "SocketPollTimeout.*"
+        }
+      ]
+    },
     "unit_tests_fixtures_debug": {
       "is_gtest": true,
       "binary": "rccl-UnitTestsFixturesDebug",
@@ -2609,6 +2625,12 @@
       "name": "Unit Tests - Fixtures (Release)",
       "description": "Non-MPI unit tests using header-only fixtures (Release and Debug)",
       "config": "unit_tests_fixtures",
+      "enabled": true
+    },
+    {
+      "name": "Bootstrap socket poll - no busy loop",
+      "description": "AICOMRCCL-1322: NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of busy-spinning a CPU core (Debug only, no NIC/GPU required)",
+      "config": "socket_poll_bootstrap",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
@@ -1087,6 +1087,22 @@
         }
       ]
     },
+    "socket_poll_bootstrap": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixturesDebug",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 120,
+      "description": "Bootstrap socket busy-loop regression. Validates that NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of pinning a CPU core at 100%. Single node, no NIC/GPU required.",
+      "tests": [
+        {
+          "name": "Socket_BootstrapPollNoBusyLoop",
+          "description": "With NCCL_SOCKET_POLL_TIMEOUT_MSEC set, a receiver blocked on a slow peer sleeps in poll() (low CPU); the control case with the param at 0 reproduces the pre-fix busy loop (high CPU).",
+          "test_filter": "SocketPollTimeout.*"
+        }
+      ]
+    },
     "unit_tests_fixtures_debug": {
       "is_gtest": true,
       "binary": "rccl-UnitTestsFixturesDebug",
@@ -2908,6 +2924,12 @@
       "name": "Unit Tests - Fixtures (Release)",
       "description": "Non-MPI unit tests using header-only fixtures (Release and Debug)",
       "config": "unit_tests_fixtures",
+      "enabled": true
+    },
+    {
+      "name": "Bootstrap socket poll - no busy loop",
+      "description": "AICOMRCCL-1322: NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of busy-spinning a CPU core (Debug only, no NIC/GPU required)",
+      "config": "socket_poll_bootstrap",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
@@ -1096,6 +1096,22 @@
         }
       ]
     },
+    "socket_poll_bootstrap": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixturesDebug",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 120,
+      "description": "Bootstrap socket busy-loop regression. Validates that NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of pinning a CPU core at 100%. Single node, no NIC/GPU required.",
+      "tests": [
+        {
+          "name": "Socket_BootstrapPollNoBusyLoop",
+          "description": "With NCCL_SOCKET_POLL_TIMEOUT_MSEC set, a receiver blocked on a slow peer sleeps in poll() (low CPU); the control case with the param at 0 reproduces the pre-fix busy loop (high CPU).",
+          "test_filter": "SocketPollTimeout.*"
+        }
+      ]
+    },
     "unit_tests_fixtures_debug": {
       "is_gtest": true,
       "binary": "rccl-UnitTestsFixturesDebug",
@@ -3693,6 +3709,12 @@
       "name": "Unit Tests - Fixtures (Release)",
       "description": "Non-MPI unit tests using header-only fixtures (Release and Debug)",
       "config": "unit_tests_fixtures",
+      "enabled": true
+    },
+    {
+      "name": "Bootstrap socket poll - no busy loop",
+      "description": "AICOMRCCL-1322: NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of busy-spinning a CPU core (Debug only, no NIC/GPU required)",
+      "config": "socket_poll_bootstrap",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
@@ -1081,6 +1081,22 @@
         }
       ]
     },
+    "socket_poll_bootstrap": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixturesDebug",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 120,
+      "description": "Bootstrap socket busy-loop regression. Validates that NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of pinning a CPU core at 100%. Single node, no NIC/GPU required.",
+      "tests": [
+        {
+          "name": "Socket_BootstrapPollNoBusyLoop",
+          "description": "With NCCL_SOCKET_POLL_TIMEOUT_MSEC set, a receiver blocked on a slow peer sleeps in poll() (low CPU); the control case with the param at 0 reproduces the pre-fix busy loop (high CPU).",
+          "test_filter": "SocketPollTimeout.*"
+        }
+      ]
+    },
     "unit_tests_fixtures_debug": {
       "is_gtest": true,
       "binary": "rccl-UnitTestsFixturesDebug",
@@ -2902,6 +2918,12 @@
       "name": "Unit Tests - Fixtures (Release)",
       "description": "Non-MPI unit tests using header-only fixtures (Release and Debug)",
       "config": "unit_tests_fixtures",
+      "enabled": true
+    },
+    {
+      "name": "Bootstrap socket poll - no busy loop",
+      "description": "AICOMRCCL-1322: NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of busy-spinning a CPU core (Debug only, no NIC/GPU required)",
+      "config": "socket_poll_bootstrap",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -47,6 +47,23 @@
       }
     },
 
+    "socket_poll_bootstrap": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixturesDebug",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 120,
+      "description": "Bootstrap socket busy-loop regression. Validates that NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of pinning a CPU core at 100%. Single node, no NIC/GPU required.",
+      "tests": [
+        {
+          "name": "Socket_BootstrapPollNoBusyLoop",
+          "description": "With NCCL_SOCKET_POLL_TIMEOUT_MSEC set, a receiver blocked on a slow peer sleeps in poll() (low CPU); the control case with the param at 0 reproduces the pre-fix busy loop (high CPU).",
+          "test_filter": "SocketPollTimeout.*"
+        }
+      ]
+    },
+
     "net_ib_base": {
       "extends": "default",
       "is_gtest": true,
@@ -912,6 +929,12 @@
     }
   },
   "test_suites": [
+    {
+      "name": "Bootstrap socket poll - no busy loop",
+      "description": "AICOMRCCL-1322: NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of busy-spinning a CPU core (Debug only, no NIC/GPU required)",
+      "config": "socket_poll_bootstrap",
+      "enabled": true
+    },
     {
       "name": "NET IB - Initialization",
       "description": "InfiniBand plugin initialization and device enumeration",


### PR DESCRIPTION
## Motivation

Bootstrap socket I/O (used during communicator initialization) previously
busy-spun in socketWait() whenever a send/recv was waiting on a slow or late
peer, pinning a CPU core at ~100% for the whole duration of the wait. On large
scale jobs this competes with other CPU-intensive work during startup. The
NCCL_SOCKET_POLL_TIMEOUT_MSEC parameter addresses this by blocking in poll()
until the socket becomes readable/writable instead of spinning. This PR adds a
functional regression test that locks in that behavior so it cannot silently
regress.

## Technical Details

- New gtest suite SocketPollTimeout in projects/rccl/test/SocketPollTests.cpp,
  built into the rccl-UnitTestsFixturesDebug target and registered in the
  fixtures-debug ctest categories.
- The test builds a loopback ncclSocket pair via the public ncclSocket* API,
  delays the sender, and measures the receiver thread CPU-time vs wall-time ratio
  while it is blocked in ncclSocketRecv() (which routes through socketWait()).
  - PollEnabledDoesNotBusyLoop (NCCL_SOCKET_POLL_TIMEOUT_MSEC=5000): the receiver
    sleeps in poll(), so CPU/wall ratio is ~0.
  - PollDisabledBusyLoops (NCCL_SOCKET_POLL_TIMEOUT_MSEC=0): control that
    reproduces the busy loop, ratio ~1.
- Each case runs in an isolated forked process so the parameter (cached on first
  read) is picked up fresh from the environment.
- Registered as A16 in the AINIC test plan (configs/ainic.json, Group A) so it is
  exercised under the ainic-test label as part of the component smoke set.

## Issue Tracking

JIRA ID : AICOMRCCL-1322

## Test Plan

- Build: cmake --build build/debug --target rccl-UnitTestsFixturesDebug
- Run: ./rccl-UnitTestsFixturesDebug --gtest_filter='SocketPollTimeout.*'
- Also exercised via the ainic-test label (Group A, A16).

## Test Result

- On develop (fix present): both cases PASS (ratio 0.000 for the enabled case,
  1.000 for the control).
- On a pre-fix build (RCCL 2.28.9): PollEnabledDoesNotBusyLoop FAILS (ratio
  1.000, the parameter is ignored and the loop spins), confirming the test is an
  effective guard (pass-after / fail-before).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
