### PR TITLE
fix(aqlprofile): enable CP request marking to fix CHC perf counters on gfx1250

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/gfxip/gfx12/gfx12_primitives.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/gfxip/gfx12/gfx12_primitives.h
@@ -729,6 +729,29 @@ public:
         const uint32_t NUM_PIPES  = 8;
         return (1u << (NUM_PIPES + PIPE_START)) - (1u << PIPE_START);
     }
+    // CP engine TC perf window registers — required to count CP-sourced requests in CHC.
+    static constexpr Register CPC_TC_PERF_COUNTER_WINDOW_SELECT_ADDR =
+        REG_32B_ADDR(GC, 0, regCPC_TC_PERF_COUNTER_WINDOW_SELECT);
+    static constexpr Register CPF_TC_PERF_COUNTER_WINDOW_SELECT_ADDR =
+        REG_32B_ADDR(GC, 0, regCPF_TC_PERF_COUNTER_WINDOW_SELECT);
+    static constexpr Register CPG_TC_PERF_COUNTER_WINDOW_SELECT_ADDR =
+        REG_32B_ADDR(GC, 0, regCPG_TC_PERF_COUNTER_WINDOW_SELECT);
+
+    // CHC perfmon clock gate control — gated by default, must be ungated during collection.
+    static constexpr Register ICG_CHC_CLK_CTRL_ADDR = REG_32B_ADDR(GC, 0, regICG_CHC_CLK_CTRL);
+
+    static uint32_t cp_request_marking_enable_value()
+    {
+        return SET_REG_FIELD_BITS(CPC_TC_PERF_COUNTER_WINDOW_SELECT, ENABLE, 1) |
+               SET_REG_FIELD_BITS(CPC_TC_PERF_COUNTER_WINDOW_SELECT, ALWAYS, 1);
+    }
+    static uint32_t cp_request_marking_disable_value() { return 0; }
+
+    static uint32_t chc_perf_clock_enable_value()
+    {
+        return SET_REG_FIELD_BITS(ICG_CHC_CLK_CTRL, PERF_CLK_OVERRIDE, 1);
+    }
+    static uint32_t chc_perf_clock_disable_value() { return 0; }
 };
 
 }  // namespace gfx12xx

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/pmc_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/pmc_builder.h
@@ -1116,7 +1116,7 @@ public:
             builder.BuildWriteUConfigRegPacket(
                 cmd_buffer, Primitives::RLC_PERFMON_CLK_CNTL_ADDR, 0);
 
-        if constexpr(Primitives::GFXIP_LEVEL >= 12)
+        if constexpr(Primitives::GFXIP_LEVEL == 12)
         {
             if(counters_vec.get_attr() & CounterBlockTcAttr) DisableCpPerfCounters(cmd_buffer);
         }

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/pmc_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/pmc_builder.h
@@ -460,7 +460,7 @@ public:
                                                Primitives::SQ_PERFCOUNTER_CTRL2_ADDR,
                                                Primitives::sq_control2_enable_value());
         }
-        if constexpr(Primitives::GFXIP_LEVEL >= 12)
+        if constexpr(Primitives::GFXIP_LEVEL == 12)
         {
             if(counters_vec.get_attr() & CounterBlockTcAttr) EnableCpPerfCounters(cmd_buffer);
         }

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/pmc_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/pmc_builder.h
@@ -283,6 +283,40 @@ private:
         }
     }
 
+    // Ungate CHC perfmon clock and enable CP-sourced request marking on CPC/CPF/CPG.
+    void EnableCpPerfCounters(CmdBuffer* cmd_buffer)
+    {
+        builder.BuildWriteConfigRegPacket(cmd_buffer,
+                                          Primitives::ICG_CHC_CLK_CTRL_ADDR,
+                                          Primitives::chc_perf_clock_enable_value());
+        builder.BuildWriteConfigRegPacket(cmd_buffer,
+                                          Primitives::CPC_TC_PERF_COUNTER_WINDOW_SELECT_ADDR,
+                                          Primitives::cp_request_marking_enable_value());
+        builder.BuildWriteConfigRegPacket(cmd_buffer,
+                                          Primitives::CPF_TC_PERF_COUNTER_WINDOW_SELECT_ADDR,
+                                          Primitives::cp_request_marking_enable_value());
+        builder.BuildWriteConfigRegPacket(cmd_buffer,
+                                          Primitives::CPG_TC_PERF_COUNTER_WINDOW_SELECT_ADDR,
+                                          Primitives::cp_request_marking_enable_value());
+    }
+
+    // Disable CP-sourced request marking then re-gate CHC perfmon clock.
+    void DisableCpPerfCounters(CmdBuffer* cmd_buffer)
+    {
+        builder.BuildWriteConfigRegPacket(cmd_buffer,
+                                          Primitives::CPC_TC_PERF_COUNTER_WINDOW_SELECT_ADDR,
+                                          Primitives::cp_request_marking_disable_value());
+        builder.BuildWriteConfigRegPacket(cmd_buffer,
+                                          Primitives::CPF_TC_PERF_COUNTER_WINDOW_SELECT_ADDR,
+                                          Primitives::cp_request_marking_disable_value());
+        builder.BuildWriteConfigRegPacket(cmd_buffer,
+                                          Primitives::CPG_TC_PERF_COUNTER_WINDOW_SELECT_ADDR,
+                                          Primitives::cp_request_marking_disable_value());
+        builder.BuildWriteConfigRegPacket(cmd_buffer,
+                                          Primitives::ICG_CHC_CLK_CTRL_ADDR,
+                                          Primitives::chc_perf_clock_disable_value());
+    }
+
     uint32_t GetInstanceIndex(uint32_t instance_index, const GpuBlockInfo* block_info)
     {
         // GLARB blocks require special instance handling, so we encode instance_count into
@@ -425,6 +459,10 @@ public:
             builder.BuildWriteUConfigRegPacket(cmd_buffer,
                                                Primitives::SQ_PERFCOUNTER_CTRL2_ADDR,
                                                Primitives::sq_control2_enable_value());
+        }
+        if constexpr(Primitives::GFXIP_LEVEL >= 12)
+        {
+            if(counters_vec.get_attr() & CounterBlockTcAttr) EnableCpPerfCounters(cmd_buffer);
         }
 #if defined(_GFX10_PRIMITIVES_H_) || defined(_GFX11_PRIMITIVES_H_)
         // Clear and enable GUS counters
@@ -1077,6 +1115,11 @@ public:
         if(Primitives::GFXIP_LEVEL == 9)
             builder.BuildWriteUConfigRegPacket(
                 cmd_buffer, Primitives::RLC_PERFMON_CLK_CNTL_ADDR, 0);
+
+        if constexpr(Primitives::GFXIP_LEVEL >= 12)
+        {
+            if(counters_vec.get_attr() & CounterBlockTcAttr) DisableCpPerfCounters(cmd_buffer);
+        }
 
         builder.BuildWriteWaitIdlePacket(cmd_buffer);
     }


### PR DESCRIPTION
## Motivation

CHC_REQ_WRITE and CHC_GL2_REQ_WRITE_LEVEL always read zero on gfx1250 for all workloads. The CHC block was active (CHC_CYCLE and CHC_BUSY were non-zero) but request counters were never incrementing.

## Technical Details

`SQ_PERFCOUNTER_CTRL` only covers shader-sourced requests; `CPC/CPF/CPG_TC_PERF_COUNTER_WINDOW_SELECT` registers must be set with `ENABLE=1|ALWAYS=1` to tag CP engine requests as countable for CHC. The CHC perfmon clock (`ICG_CHC_CLK_CTRL.PERF_CLK_OVERRIDE`) is also ungated as a precaution during collection.

Added `EnableCpPerfCounters()` / `DisableCpPerfCounters()` in `pmc_builder.h`, called at Start/Stop for `GFXIP_LEVEL >= 12` blocks with `CounterBlockTcAttr`. The corresponding register addresses and value helpers are added in `gfx12_primitives.h`.

## Issue Tracking
JIRA ID: ROCM-28631
<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.