### PR TITLE
docs(hipfile) fixed typo in link

### DIFF
--- a/projects/hipfile/docs/reference/hipFile-cuFile-compatibility.rst
+++ b/projects/hipfile/docs/reference/hipFile-cuFile-compatibility.rst
@@ -18,4 +18,4 @@ There is no hipFile counterpart to cuFile's ``cuFileDriverClose_v2`` alias. Both
 
 There is no hipFile counterpart to cuFile's ``sockaddr_t`` typedef. Use ``struct sockaddr`` or add a custom implementation of the typedef.
 
-`HIPIFY <https://rocm.docs.amd.com/projects/HIPIFY/en/latest/index.html>`_ provides information about converting CUDA code to ROCm code. A `cuFile-to-hipFile API map <https://rocm.docs.amd.com/projects/HIPIFY/en/latest/reference/tables/cuFile_API_supported_by_HIP.md>`_ is available.
+`HIPIFY <https://rocm.docs.amd.com/projects/HIPIFY/en/latest/index.html>`_ provides information about converting CUDA code to ROCm code. A `cuFile-to-hipFile API map <https://rocm.docs.amd.com/projects/HIPIFY/en/latest/reference/tables/cuFile_API_supported_by_HIP.html>`_ is available.


### PR DESCRIPTION
## Motivation
The link to the cufile-hipfile compat table pointed to an md file rather than an html file; have fixed that.

JIRA  ID : AIROCDOC-4196