### PR TITLE
feat(rocprofiler-sdk): validate rocattach pathname lookup by GNU Build ID when device/inode does not match

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -23,6 +23,7 @@
 #include "ptrace_session.hpp"
 
 #include "lib/common/environment.hpp"
+#include "lib/common/filesystem.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/common/static_object.hpp"
 
@@ -30,7 +31,6 @@
 #include <rocprofiler-sdk-rocattach/rocattach.h>
 #include <rocprofiler-sdk-rocattach/types.h>
 
-#include <filesystem>
 #include <fstream>
 #include <map>
 #include <mutex>
@@ -45,6 +45,8 @@ namespace rocattach
 {
 namespace
 {
+namespace fs = common::filesystem;
+
 using session_t = rocprofiler::rocattach::PTraceSession;
 
 struct pid_entry_t
@@ -207,7 +209,7 @@ resolve_attach_tid(pid_t pid)
 {
     auto            task_dir = "/proc/" + std::to_string(pid) + "/task";
     std::error_code ec;
-    for(const auto& entry : std::filesystem::directory_iterator(task_dir, ec))
+    for(const auto& entry : fs::directory_iterator(task_dir, ec))
     {
         if(!entry.is_directory()) continue;
 
@@ -238,12 +240,11 @@ resolve_attach_tid(pid_t pid)
 }
 
 rocattach_status_t
-validate_target_absolute_tool_path(pid_t pid, const std::filesystem::path& tool_path)
+validate_target_absolute_tool_path(pid_t pid, const fs::path& tool_path)
 {
-    auto target_path =
-        std::filesystem::path{fmt::format("/proc/{}/root", pid)} / tool_path.relative_path();
+    auto target_path = fs::path{fmt::format("/proc/{}/root", pid)} / tool_path.relative_path();
     std::error_code ec;
-    if(!std::filesystem::exists(target_path, ec))
+    if(!fs::exists(target_path, ec))
     {
         if(ec)
         {
@@ -264,7 +265,7 @@ validate_target_absolute_tool_path(pid_t pid, const std::filesystem::path& tool_
         return ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT;
     }
 
-    if(!std::filesystem::is_regular_file(target_path, ec))
+    if(!fs::is_regular_file(target_path, ec))
     {
         if(ec)
         {
@@ -321,7 +322,7 @@ setup(int pid)
     const char* tool_lib_path = tool_lib_path_env.c_str();
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Tool library path: " << tool_lib_path;
 
-    auto tool_path = std::filesystem::path{tool_lib_path_env};
+    auto tool_path = fs::path{tool_lib_path_env};
     if(tool_path.empty())
     {
         ROCP_ERROR << "[rocprofiler-sdk-rocattach] Tool library path must not be empty.";
@@ -470,7 +471,7 @@ collect_process_tree(pid_t root_pid)
 
         auto            task_dir = "/proc/" + std::to_string(pid) + "/task";
         std::error_code ec;
-        for(const auto& entry : std::filesystem::directory_iterator(task_dir, ec))
+        for(const auto& entry : fs::directory_iterator(task_dir, ec))
         {
             if(!entry.is_directory()) continue;
             auto          children_path = entry.path() / "children";

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -487,9 +487,10 @@ read_mapped_file(const std::string& path, const mapped_object& object, bool requ
 std::optional<target_elf>
 open_target_elf(pid_t pid, const mapped_object& object)
 {
-    // Prefer map_files because it is a kernel-provided handle to the exact file
-    // backing the mapped object. If permissions block that path, fall back to
-    // the same path as seen through the target root and still validate device/inode.
+    // Prefer map_files because it identifies the exact file backing the
+    // mapping. If permissions block it, open the pathname through the target
+    // root. Device/inode equality remains the fast path; a mismatch requires
+    // matching GNU Build IDs.
     const auto& mapping        = object.mappings.front();
     auto        map_files_path = fmt::format("/proc/{}/map_files/{:x}-{:x}",
                                       pid,
@@ -572,27 +573,22 @@ calculate_load_bias(const target_elf& elf, const mapped_object& object)
     auto page_size =
         (page_size_value > 0) ? static_cast<uint64_t>(page_size_value) : uint64_t{4096};
 
-    auto mapping_matches_bias = [&](const memory_mapping& mapping, uint64_t bias) {
-        for(const auto& segment : elf.load_segments)
-        {
-            if(segment.p_filesz == 0) continue;
-            auto file_end = checked_add(segment.p_offset, segment.p_filesz);
-            if(!file_end) continue;
-            auto file_page_begin = align_down(segment.p_offset, page_size);
-            auto file_page_end   = align_up(*file_end, page_size);
-            if(!file_page_end || mapping.file_offset < file_page_begin ||
-               mapping.file_offset >= *file_page_end)
-            {
-                continue;
-            }
+    auto load_segment_is_mapped = [&](const Elf64_Phdr& segment, uint64_t bias) {
+        if(segment.p_filesz == 0) return true;
 
-            auto virtual_page = align_down(segment.p_vaddr, page_size);
-            auto file_delta   = mapping.file_offset - file_page_begin;
-            auto relative     = checked_add(virtual_page, file_delta);
-            auto expected     = relative ? checked_add(bias, *relative) : std::nullopt;
-            if(expected && *expected == mapping.start) return true;
-        }
-        return false;
+        auto file_page    = align_down(segment.p_offset, page_size);
+        auto virtual_page = align_down(segment.p_vaddr, page_size);
+        auto runtime_page = checked_add(bias, virtual_page);
+        if(!runtime_page) return false;
+
+        return std::any_of(
+            object.mappings.begin(), object.mappings.end(), [&](const auto& mapping) {
+                if(*runtime_page < mapping.start || *runtime_page >= mapping.end) return false;
+
+                auto mapping_delta = *runtime_page - mapping.start;
+                auto mapped_offset = checked_add(mapping.file_offset, mapping_delta);
+                return mapped_offset && *mapped_offset == file_page;
+            });
     };
 
     auto candidates = std::vector<uint64_t>{};
@@ -617,11 +613,14 @@ calculate_load_bias(const target_elf& elf, const mapped_object& object)
                                       : std::nullopt;
             if(!candidate) continue;
 
-            auto all_mappings_match =
-                std::all_of(object.mappings.begin(), object.mappings.end(), [&](const auto& item) {
-                    return mapping_matches_bias(item, *candidate);
+            // A valid loader instance must account for every file-backed
+            // PT_LOAD. Other mappings of the same inode are unrelated to that
+            // instance and must not invalidate an otherwise unique bias.
+            auto all_load_segments_mapped = std::all_of(
+                elf.load_segments.begin(), elf.load_segments.end(), [&](const auto& load) {
+                    return load_segment_is_mapped(load, *candidate);
                 });
-            if(all_mappings_match &&
+            if(all_load_segments_mapped &&
                std::find(candidates.begin(), candidates.end(), *candidate) == candidates.end())
             {
                 candidates.emplace_back(*candidate);
@@ -685,12 +684,18 @@ parse_gnu_build_id(const uint8_t* data, size_t size)
 bool
 note_is_file_backed_load(const target_elf& elf, const Elf64_Phdr& note)
 {
-    auto note_end = checked_add(note.p_vaddr, note.p_filesz);
-    if(!note_end) return false;
+    if(note.p_filesz == 0) return false;
 
     return std::any_of(elf.load_segments.begin(), elf.load_segments.end(), [&](const auto& load) {
-        auto load_end = checked_add(load.p_vaddr, load.p_filesz);
-        return load_end && note.p_vaddr >= load.p_vaddr && *note_end <= *load_end;
+        if(note.p_vaddr < load.p_vaddr || note.p_offset < load.p_offset) return false;
+
+        auto virtual_delta = note.p_vaddr - load.p_vaddr;
+        auto file_delta    = note.p_offset - load.p_offset;
+
+        // The note bytes read from the file must be the same bytes represented
+        // at note.p_vaddr in the file-backed PT_LOAD segment.
+        return virtual_delta == file_delta && virtual_delta <= load.p_filesz &&
+               note.p_filesz <= load.p_filesz - virtual_delta;
     });
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -34,6 +34,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
+#include <sys/uio.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -41,6 +42,7 @@
 #include <cerrno>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <exception>
 #include <filesystem>
@@ -63,6 +65,9 @@ namespace
 // Keep limits generous enough for debug builds, but bounded so malformed target
 // ELFs cannot force unbounded memory use or symbol/hash traversal.
 constexpr auto MAX_TARGET_ELF_SIZE      = uint64_t{512} * 1024 * 1024;
+constexpr auto MAX_ELF_NOTE_SIZE        = uint64_t{1024} * 1024;
+constexpr auto MAX_BUILD_ID_SIZE        = uint64_t{4096};
+constexpr auto ELF_NOTE_ALIGNMENT       = uint64_t{4};
 constexpr auto MAX_DYNAMIC_SYMBOLS      = size_t{1} << 24;
 constexpr auto MAX_GNU_HASH_CHAIN_STEPS = size_t{1} << 24;
 
@@ -110,10 +115,11 @@ struct mapped_object_key_hash
 
 struct target_elf
 {
-    std::string             path          = {};
-    std::vector<uint8_t>    data          = {};
-    ELFIO::elfio            reader        = {};
-    std::vector<Elf64_Phdr> load_segments = {};
+    std::string             path                      = {};
+    std::vector<uint8_t>    data                      = {};
+    ELFIO::elfio            reader                    = {};
+    std::vector<Elf64_Phdr> load_segments             = {};
+    bool                    metadata_identity_matches = false;
 };
 
 std::optional<uint64_t>
@@ -141,6 +147,15 @@ uint64_t
 align_down(uint64_t value, uint64_t alignment)
 {
     return value - (value % alignment);
+}
+
+std::optional<uint64_t>
+align_up(uint64_t value, uint64_t alignment)
+{
+    if(alignment == 0) return std::nullopt;
+    auto remainder = value % alignment;
+    if(remainder == 0) return value;
+    return checked_add(value, alignment - remainder);
 }
 
 bool
@@ -414,13 +429,18 @@ read_file_from_fd(int fd, const std::string& path, uint64_t size)
 }
 
 std::optional<target_elf>
-read_file_if_matches_mapping(const std::string& path, const mapped_object& object)
+read_mapped_file(const std::string& path, const mapped_object& object, bool require_identity_match)
 {
     struct stat st
     {};
 
     auto fd = ::open(path.c_str(), O_RDONLY | O_CLOEXEC);
-    if(fd < 0) return std::nullopt;
+    if(fd < 0)
+    {
+        ROCP_TRACE << "[rocprofiler-sdk-rocattach] Could not open target ELF " << path << ": "
+                   << std::strerror(errno);
+        return std::nullopt;
+    }
     auto close_fd = common::scope_destructor{[fd]() { ::close(fd); }};
 
     if(::fstat(fd, &st) != 0)
@@ -430,8 +450,10 @@ read_file_if_matches_mapping(const std::string& path, const mapped_object& objec
         return std::nullopt;
     }
 
-    if(major(st.st_dev) != object.device_major || minor(st.st_dev) != object.device_minor ||
-       static_cast<uint64_t>(st.st_ino) != object.inode)
+    auto identity_matches = major(st.st_dev) == object.device_major &&
+                            minor(st.st_dev) == object.device_minor &&
+                            static_cast<uint64_t>(st.st_ino) == object.inode;
+    if(require_identity_match && !identity_matches)
     {
         ROCP_WARNING << "[rocprofiler-sdk-rocattach] Refusing to use " << path
                      << " because its opened device/inode does not match the mapped object";
@@ -455,9 +477,10 @@ read_file_if_matches_mapping(const std::string& path, const mapped_object& objec
     auto data = read_file_from_fd(fd, path, static_cast<uint64_t>(st.st_size));
     if(!data || data->empty()) return std::nullopt;
 
-    auto elf = target_elf{};
-    elf.path = path;
-    elf.data = std::move(*data);
+    auto elf                      = target_elf{};
+    elf.path                      = path;
+    elf.data                      = std::move(*data);
+    elf.metadata_identity_matches = identity_matches;
     return elf;
 }
 
@@ -472,10 +495,18 @@ open_target_elf(pid_t pid, const mapped_object& object)
                                       pid,
                                       static_cast<uint64_t>(mapping.start),
                                       static_cast<uint64_t>(mapping.end));
-    if(auto elf = read_file_if_matches_mapping(map_files_path, object))
+#if defined(ROCPROFILER_ROCATTACH_TESTING)
+    auto disable_map_files = std::getenv("ROCATTACH_TEST_DISABLE_MAP_FILES") != nullptr;
+#else
+    constexpr auto disable_map_files = false;
+#endif
+    if(!disable_map_files)
     {
-        ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << map_files_path;
-        return elf;
+        if(auto elf = read_mapped_file(map_files_path, object, true))
+        {
+            ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << map_files_path;
+            return elf;
+        }
     }
 
     auto target_path = strip_deleted_suffix(object.path);
@@ -484,7 +515,7 @@ open_target_elf(pid_t pid, const mapped_object& object)
         auto root_path = (std::filesystem::path{fmt::format("/proc/{}/root", pid)} /
                           std::filesystem::path{target_path}.relative_path())
                              .string();
-        if(auto elf = read_file_if_matches_mapping(root_path, object))
+        if(auto elf = read_mapped_file(root_path, object, false))
         {
             ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << root_path;
             return elf;
@@ -541,44 +572,277 @@ calculate_load_bias(const target_elf& elf, const mapped_object& object)
     auto page_size =
         (page_size_value > 0) ? static_cast<uint64_t>(page_size_value) : uint64_t{4096};
 
-    auto first_load_segment = std::min_element(
-        elf.load_segments.begin(), elf.load_segments.end(), [](const auto& lhs, const auto& rhs) {
-            return lhs.p_vaddr < rhs.p_vaddr;
-        });
-    if(first_load_segment == elf.load_segments.end())
+    auto mapping_matches_bias = [&](const memory_mapping& mapping, uint64_t bias) {
+        for(const auto& segment : elf.load_segments)
+        {
+            if(segment.p_filesz == 0) continue;
+            auto file_end = checked_add(segment.p_offset, segment.p_filesz);
+            if(!file_end) continue;
+            auto file_page_begin = align_down(segment.p_offset, page_size);
+            auto file_page_end   = align_up(*file_end, page_size);
+            if(!file_page_end || mapping.file_offset < file_page_begin ||
+               mapping.file_offset >= *file_page_end)
+            {
+                continue;
+            }
+
+            auto virtual_page = align_down(segment.p_vaddr, page_size);
+            auto file_delta   = mapping.file_offset - file_page_begin;
+            auto relative     = checked_add(virtual_page, file_delta);
+            auto expected     = relative ? checked_add(bias, *relative) : std::nullopt;
+            if(expected && *expected == mapping.start) return true;
+        }
+        return false;
+    };
+
+    auto candidates = std::vector<uint64_t>{};
+    for(const auto& mapping : object.mappings)
     {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Target ELF has no PT_LOAD segments: "
-                   << object.path;
-        return std::nullopt;
+        for(const auto& segment : elf.load_segments)
+        {
+            if(segment.p_filesz == 0) continue;
+            auto file_end = checked_add(segment.p_offset, segment.p_filesz);
+            if(!file_end) continue;
+            auto file_page_begin = align_down(segment.p_offset, page_size);
+            auto file_page_end   = align_up(*file_end, page_size);
+            if(!file_page_end || mapping.file_offset < file_page_begin ||
+               mapping.file_offset >= *file_page_end)
+            {
+                continue;
+            }
+
+            auto virtual_page = align_down(segment.p_vaddr, page_size);
+            auto relative     = checked_add(virtual_page, mapping.file_offset - file_page_begin);
+            auto candidate = relative ? checked_sub(static_cast<uint64_t>(mapping.start), *relative)
+                                      : std::nullopt;
+            if(!candidate) continue;
+
+            auto all_mappings_match =
+                std::all_of(object.mappings.begin(), object.mappings.end(), [&](const auto& item) {
+                    return mapping_matches_bias(item, *candidate);
+                });
+            if(all_mappings_match &&
+               std::find(candidates.begin(), candidates.end(), *candidate) == candidates.end())
+            {
+                candidates.emplace_back(*candidate);
+            }
+        }
     }
 
-    auto first_mapping        = object.mappings.front();
-    auto segment_file_page    = align_down(first_load_segment->p_offset, page_size);
-    auto segment_virtual_page = align_down(first_load_segment->p_vaddr, page_size);
-    // Match the maps entry to the PT_LOAD segment by file page before using it
-    // to derive the ET_DYN load bias.
-    if(first_mapping.file_offset != segment_file_page)
+    if(candidates.size() != 1)
     {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] First target mapping for " << object.path
-                   << " has file offset 0x" << std::hex << first_mapping.file_offset
-                   << ", but the first PT_LOAD segment starts at file page 0x" << segment_file_page
-                   << std::dec;
-        return std::nullopt;
-    }
-
-    // For ET_DYN shared objects, load bias is runtime start minus page-aligned
-    // segment virtual address.
-    auto bias = checked_sub(static_cast<uint64_t>(first_mapping.start), segment_virtual_page);
-    if(!bias)
-    {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Invalid target mapping/segment pair for "
-                   << object.path << ": mapping start is below segment virtual page";
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Could not calculate a unique load bias for "
+                   << object.path << " from its PT_LOAD segments and mappings";
         return std::nullopt;
     }
 
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Calculated target load bias for " << object.path
-               << " as 0x" << std::hex << *bias << std::dec;
-    return bias;
+               << " as 0x" << std::hex << candidates.front() << std::dec;
+    return candidates.front();
+}
+
+std::optional<std::vector<uint8_t>>
+parse_gnu_build_id(const uint8_t* data, size_t size)
+{
+    auto result = std::vector<uint8_t>{};
+    auto found  = false;
+    auto cursor = uint64_t{0};
+
+    while(cursor < size)
+    {
+        if(sizeof(Elf64_Nhdr) > size - cursor) return std::nullopt;
+
+        auto header = Elf64_Nhdr{};
+        std::memcpy(&header, data + cursor, sizeof(header));
+        cursor += sizeof(header);
+
+        auto name_size = align_up(header.n_namesz, ELF_NOTE_ALIGNMENT);
+        auto desc_size = align_up(header.n_descsz, ELF_NOTE_ALIGNMENT);
+        if(!name_size || !desc_size || *name_size > size - cursor) return std::nullopt;
+
+        auto name_offset = cursor;
+        cursor += *name_size;
+        if(*desc_size > size - cursor) return std::nullopt;
+
+        auto is_gnu_build_id = header.n_type == NT_GNU_BUILD_ID && header.n_namesz == 4 &&
+                               header.n_descsz > 0 && header.n_descsz <= MAX_BUILD_ID_SIZE &&
+                               std::memcmp(data + name_offset, "GNU", 4) == 0;
+        if(is_gnu_build_id)
+        {
+            // Multiple Build ID notes are ambiguous and should not be used
+            // to relax filesystem identity checks.
+            if(found) return std::nullopt;
+            result.assign(data + cursor, data + cursor + header.n_descsz);
+            found = true;
+        }
+        cursor += *desc_size;
+    }
+
+    if(!found) return std::nullopt;
+    return result;
+}
+
+bool
+note_is_file_backed_load(const target_elf& elf, const Elf64_Phdr& note)
+{
+    auto note_end = checked_add(note.p_vaddr, note.p_filesz);
+    if(!note_end) return false;
+
+    return std::any_of(elf.load_segments.begin(), elf.load_segments.end(), [&](const auto& load) {
+        auto load_end = checked_add(load.p_vaddr, load.p_filesz);
+        return load_end && note.p_vaddr >= load.p_vaddr && *note_end <= *load_end;
+    });
+}
+
+std::optional<std::vector<uint8_t>>
+build_id_from_file(const target_elf& elf)
+{
+    auto result = std::vector<uint8_t>{};
+    auto found  = false;
+
+    for(const auto& segment : elf.reader.segments)
+    {
+        if(segment == nullptr || segment->get_type() != PT_NOTE) continue;
+
+        auto note = to_phdr(*segment);
+        if(note.p_filesz == 0 || note.p_filesz > MAX_ELF_NOTE_SIZE ||
+           !has_range(elf.data.size(), note.p_offset, note.p_filesz) ||
+           !note_is_file_backed_load(elf, note))
+        {
+            continue;
+        }
+
+        auto build_id =
+            parse_gnu_build_id(elf.data.data() + note.p_offset, static_cast<size_t>(note.p_filesz));
+        if(!build_id) continue;
+        if(found) return std::nullopt;
+        result = std::move(*build_id);
+        found  = true;
+    }
+
+    if(!found) return std::nullopt;
+    return result;
+}
+
+bool
+range_is_readable_mapping(const mapped_object& object, uint64_t address, uint64_t size)
+{
+    auto end = checked_add(address, size);
+    if(!end) return false;
+
+    return std::any_of(object.mappings.begin(), object.mappings.end(), [&](const auto& mapping) {
+        return mapping.permissions.find('r') != std::string::npos && address >= mapping.start &&
+               *end <= mapping.end;
+    });
+}
+
+std::optional<std::vector<uint8_t>>
+read_target_memory(pid_t pid, uint64_t address, size_t size)
+{
+    if(size == 0 || size > MAX_ELF_NOTE_SIZE || address > std::numeric_limits<uintptr_t>::max())
+    {
+        return std::nullopt;
+    }
+
+    auto data = std::vector<uint8_t>(size);
+    auto read = size_t{0};
+    while(read < size)
+    {
+        auto remote_address = checked_add(address, read);
+        if(!remote_address || *remote_address > std::numeric_limits<uintptr_t>::max())
+        {
+            return std::nullopt;
+        }
+
+        auto local = iovec{data.data() + read, size - read};
+        auto remote =
+            // process_vm_readv represents the remote process address as a pointer.
+            // NOLINTNEXTLINE(performance-no-int-to-ptr)
+            iovec{reinterpret_cast<void*>(static_cast<uintptr_t>(*remote_address)), size - read};
+        auto ret = ::process_vm_readv(pid, &local, 1, &remote, 1, 0);
+        if(ret < 0)
+        {
+            if(errno == EINTR) continue;
+            ROCP_TRACE << "[rocprofiler-sdk-rocattach] Could not read target memory at 0x"
+                       << std::hex << *remote_address << std::dec << ": " << std::strerror(errno);
+            return std::nullopt;
+        }
+        if(ret == 0) return std::nullopt;
+        read += static_cast<size_t>(ret);
+    }
+    return data;
+}
+
+std::optional<std::vector<uint8_t>>
+build_id_from_target_memory(pid_t                pid,
+                            const target_elf&    elf,
+                            const mapped_object& object,
+                            uint64_t             load_bias)
+{
+    auto result = std::vector<uint8_t>{};
+    auto found  = false;
+
+    for(const auto& segment : elf.reader.segments)
+    {
+        if(segment == nullptr || segment->get_type() != PT_NOTE) continue;
+
+        auto note = to_phdr(*segment);
+        if(note.p_filesz == 0 || note.p_filesz > MAX_ELF_NOTE_SIZE ||
+           note.p_memsz < note.p_filesz || !note_is_file_backed_load(elf, note))
+        {
+            continue;
+        }
+
+        auto runtime_address = checked_add(load_bias, note.p_vaddr);
+        if(!runtime_address || !range_is_readable_mapping(object, *runtime_address, note.p_filesz))
+        {
+            continue;
+        }
+
+        auto note_data =
+            read_target_memory(pid, *runtime_address, static_cast<size_t>(note.p_filesz));
+        if(!note_data) continue;
+
+        auto build_id = parse_gnu_build_id(note_data->data(), note_data->size());
+        if(!build_id) continue;
+        if(found) return std::nullopt;
+        result = std::move(*build_id);
+        found  = true;
+    }
+
+    if(!found) return std::nullopt;
+    return result;
+}
+
+bool
+build_id_matches_target(pid_t                pid,
+                        const target_elf&    elf,
+                        const mapped_object& object,
+                        uint64_t             load_bias)
+{
+    auto file_build_id = build_id_from_file(elf);
+    if(!file_build_id)
+    {
+        ROCP_WARNING << "[rocprofiler-sdk-rocattach] Cannot validate " << elf.path
+                     << " against the mapped object because it has no unique mapped GNU Build ID";
+        return false;
+    }
+
+    auto target_build_id = build_id_from_target_memory(pid, elf, object, load_bias);
+    if(!target_build_id)
+    {
+        ROCP_WARNING << "[rocprofiler-sdk-rocattach] Cannot validate " << elf.path
+                     << " because no unique GNU Build ID could be read from the target mapping";
+        return false;
+    }
+
+    if(*target_build_id != *file_build_id)
+    {
+        ROCP_WARNING << "[rocprofiler-sdk-rocattach] Refusing to use " << elf.path
+                     << " because its GNU Build ID does not match the target's mapped image";
+        return false;
+    }
+    return true;
 }
 
 std::optional<uint64_t>
@@ -831,6 +1095,10 @@ resolve_target_symbol(pid_t pid, const mapped_object& object, std::string_view s
 
     auto load_bias = calculate_load_bias(*elf, object);
     if(!load_bias) return std::nullopt;
+    if(!elf->metadata_identity_matches && !build_id_matches_target(pid, *elf, object, *load_bias))
+    {
+        return std::nullopt;
+    }
 
     auto sym = lookup_dynamic_symbol(*elf, symbol);
     if(!sym)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -42,7 +42,6 @@
 #include <cerrno>
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
 #include <cstring>
 #include <exception>
 #include <filesystem>
@@ -66,10 +65,15 @@ namespace
 // ELFs cannot force unbounded memory use or symbol/hash traversal.
 constexpr auto MAX_TARGET_ELF_SIZE      = uint64_t{512} * 1024 * 1024;
 constexpr auto MAX_ELF_NOTE_SIZE        = uint64_t{1024} * 1024;
+constexpr auto MAX_TARGET_READ_SIZE     = uint64_t{1024} * 1024;
 constexpr auto MAX_BUILD_ID_SIZE        = uint64_t{4096};
-constexpr auto ELF_NOTE_ALIGNMENT       = uint64_t{4};
 constexpr auto MAX_DYNAMIC_SYMBOLS      = size_t{1} << 24;
 constexpr auto MAX_GNU_HASH_CHAIN_STEPS = size_t{1} << 24;
+
+// Note names and descriptors are padded to 4 bytes, not to the containing
+// segment's p_align. GNU emits .note.gnu.property in a PT_NOTE declaring
+// p_align 8 yet still pads the name to 4, so honoring p_align misparses it.
+constexpr auto ELF_NOTE_ALIGNMENT = uint64_t{4};
 
 struct memory_mapping
 {
@@ -115,11 +119,11 @@ struct mapped_object_key_hash
 
 struct target_elf
 {
-    std::string             path                      = {};
-    std::vector<uint8_t>    data                      = {};
-    ELFIO::elfio            reader                    = {};
-    std::vector<Elf64_Phdr> load_segments             = {};
-    bool                    metadata_identity_matches = false;
+    std::string             path                     = {};
+    std::vector<uint8_t>    data                     = {};
+    ELFIO::elfio            reader                   = {};
+    std::vector<Elf64_Phdr> load_segments            = {};
+    bool                    identity_matches_mapping = false;
 };
 
 std::optional<uint64_t>
@@ -146,6 +150,7 @@ checked_mul(uint64_t lhs, uint64_t rhs)
 uint64_t
 align_down(uint64_t value, uint64_t alignment)
 {
+    if(alignment == 0) return value;
     return value - (value % alignment);
 }
 
@@ -428,6 +433,10 @@ read_file_from_fd(int fd, const std::string& path, uint64_t size)
     return data;
 }
 
+// When require_identity_match is set, the file is rejected unless its device
+// and inode match what /proc/<pid>/maps reports for the mapping. The outcome is
+// recorded either way in target_elf::identity_matches_mapping; a file admitted
+// without that equality must later pass resolve_target_symbol's Build ID check.
 std::optional<target_elf>
 read_mapped_file(const std::string& path, const mapped_object& object, bool require_identity_match)
 {
@@ -477,33 +486,29 @@ read_mapped_file(const std::string& path, const mapped_object& object, bool requ
     auto data = read_file_from_fd(fd, path, static_cast<uint64_t>(st.st_size));
     if(!data || data->empty()) return std::nullopt;
 
-    auto elf                      = target_elf{};
-    elf.path                      = path;
-    elf.data                      = std::move(*data);
-    elf.metadata_identity_matches = identity_matches;
+    auto elf                     = target_elf{};
+    elf.path                     = path;
+    elf.data                     = std::move(*data);
+    elf.identity_matches_mapping = identity_matches;
     return elf;
 }
 
 std::optional<target_elf>
-open_target_elf(pid_t pid, const mapped_object& object)
+open_target_elf(pid_t pid, const mapped_object& object, bool pathname_only)
 {
-    // Prefer map_files because it identifies the exact file backing the
-    // mapping. If permissions block it, open the pathname through the target
-    // root. Device/inode equality remains the fast path; a mismatch requires
-    // matching GNU Build IDs.
-    const auto& mapping        = object.mappings.front();
-    auto        map_files_path = fmt::format("/proc/{}/map_files/{:x}-{:x}",
-                                      pid,
-                                      static_cast<uint64_t>(mapping.start),
-                                      static_cast<uint64_t>(mapping.end));
-#if defined(ROCPROFILER_ROCATTACH_TESTING)
-    auto disable_map_files = std::getenv("ROCATTACH_TEST_DISABLE_MAP_FILES") != nullptr;
-#else
-    constexpr auto disable_map_files = false;
-#endif
-    if(!disable_map_files)
+    // map_files is preferred because it names the exact file backing the
+    // mapping, so its device/inode must match. The target-root pathname is only
+    // a best guess at the same file, so it settles for a Build ID match.
+    if(!pathname_only)
     {
-        if(auto elf = read_mapped_file(map_files_path, object, true))
+        // Any mapping of this object will do: mapped_object groups mappings by
+        // device/inode, so all of their map_files links resolve to one file.
+        const auto& mapping        = object.mappings.front();
+        auto        map_files_path = fmt::format("/proc/{}/map_files/{:x}-{:x}",
+                                          pid,
+                                          static_cast<uint64_t>(mapping.start),
+                                          static_cast<uint64_t>(mapping.end));
+        if(auto elf = read_mapped_file(map_files_path, object, /*require_identity_match=*/true))
         {
             ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << map_files_path;
             return elf;
@@ -516,7 +521,7 @@ open_target_elf(pid_t pid, const mapped_object& object)
         auto root_path = (std::filesystem::path{fmt::format("/proc/{}/root", pid)} /
                           std::filesystem::path{target_path}.relative_path())
                              .string();
-        if(auto elf = read_mapped_file(root_path, object, false))
+        if(auto elf = read_mapped_file(root_path, object, /*require_identity_match=*/false))
         {
             ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << root_path;
             return elf;
@@ -573,71 +578,44 @@ calculate_load_bias(const target_elf& elf, const mapped_object& object)
     auto page_size =
         (page_size_value > 0) ? static_cast<uint64_t>(page_size_value) : uint64_t{4096};
 
-    auto load_segment_is_mapped = [&](const Elf64_Phdr& segment, uint64_t bias) {
-        if(segment.p_filesz == 0) return true;
-
-        auto file_page    = align_down(segment.p_offset, page_size);
-        auto virtual_page = align_down(segment.p_vaddr, page_size);
-        auto runtime_page = checked_add(bias, virtual_page);
-        if(!runtime_page) return false;
-
-        return std::any_of(
-            object.mappings.begin(), object.mappings.end(), [&](const auto& mapping) {
-                if(*runtime_page < mapping.start || *runtime_page >= mapping.end) return false;
-
-                auto mapping_delta = *runtime_page - mapping.start;
-                auto mapped_offset = checked_add(mapping.file_offset, mapping_delta);
-                return mapped_offset && *mapped_offset == file_page;
-            });
-    };
-
-    auto candidates = std::vector<uint64_t>{};
-    for(const auto& mapping : object.mappings)
+    auto first_load_segment = std::min_element(
+        elf.load_segments.begin(), elf.load_segments.end(), [](const auto& lhs, const auto& rhs) {
+            return lhs.p_vaddr < rhs.p_vaddr;
+        });
+    if(first_load_segment == elf.load_segments.end())
     {
-        for(const auto& segment : elf.load_segments)
-        {
-            if(segment.p_filesz == 0) continue;
-            auto file_end = checked_add(segment.p_offset, segment.p_filesz);
-            if(!file_end) continue;
-            auto file_page_begin = align_down(segment.p_offset, page_size);
-            auto file_page_end   = align_up(*file_end, page_size);
-            if(!file_page_end || mapping.file_offset < file_page_begin ||
-               mapping.file_offset >= *file_page_end)
-            {
-                continue;
-            }
-
-            auto virtual_page = align_down(segment.p_vaddr, page_size);
-            auto relative     = checked_add(virtual_page, mapping.file_offset - file_page_begin);
-            auto candidate = relative ? checked_sub(static_cast<uint64_t>(mapping.start), *relative)
-                                      : std::nullopt;
-            if(!candidate) continue;
-
-            // A valid loader instance must account for every file-backed
-            // PT_LOAD. Other mappings of the same inode are unrelated to that
-            // instance and must not invalidate an otherwise unique bias.
-            auto all_load_segments_mapped = std::all_of(
-                elf.load_segments.begin(), elf.load_segments.end(), [&](const auto& load) {
-                    return load_segment_is_mapped(load, *candidate);
-                });
-            if(all_load_segments_mapped &&
-               std::find(candidates.begin(), candidates.end(), *candidate) == candidates.end())
-            {
-                candidates.emplace_back(*candidate);
-            }
-        }
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Target ELF has no PT_LOAD segments: "
+                   << object.path;
+        return std::nullopt;
     }
 
-    if(candidates.size() != 1)
+    auto first_mapping        = object.mappings.front();
+    auto segment_file_page    = align_down(first_load_segment->p_offset, page_size);
+    auto segment_virtual_page = align_down(first_load_segment->p_vaddr, page_size);
+    // Match the maps entry to the PT_LOAD segment by file page before using it
+    // to derive the ET_DYN load bias.
+    if(first_mapping.file_offset != segment_file_page)
     {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Could not calculate a unique load bias for "
-                   << object.path << " from its PT_LOAD segments and mappings";
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] First target mapping for " << object.path
+                   << " has file offset 0x" << std::hex << first_mapping.file_offset
+                   << ", but the first PT_LOAD segment starts at file page 0x" << segment_file_page
+                   << std::dec;
+        return std::nullopt;
+    }
+
+    // For ET_DYN shared objects, load bias is runtime start minus page-aligned
+    // segment virtual address.
+    auto bias = checked_sub(static_cast<uint64_t>(first_mapping.start), segment_virtual_page);
+    if(!bias)
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Invalid target mapping/segment pair for "
+                   << object.path << ": mapping start is below segment virtual page";
         return std::nullopt;
     }
 
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Calculated target load bias for " << object.path
-               << " as 0x" << std::hex << candidates.front() << std::dec;
-    return candidates.front();
+               << " as 0x" << std::hex << *bias << std::dec;
+    return bias;
 }
 
 std::optional<std::vector<uint8_t>>
@@ -668,11 +646,12 @@ parse_gnu_build_id(const uint8_t* data, size_t size)
                                std::memcmp(data + name_offset, "GNU", 4) == 0;
         if(is_gnu_build_id)
         {
-            // Multiple Build ID notes are ambiguous and should not be used
-            // to relax filesystem identity checks.
-            if(found) return std::nullopt;
-            result.assign(data + cursor, data + cursor + header.n_descsz);
-            found = true;
+            auto build_id = std::vector<uint8_t>(data + cursor, data + cursor + header.n_descsz);
+            // Repeated notes carrying the same Build ID are consistent. Notes
+            // that disagree are ambiguous and must not relax identity checks.
+            if(found && result != build_id) return std::nullopt;
+            result = std::move(build_id);
+            found  = true;
         }
         cursor += *desc_size;
     }
@@ -699,34 +678,51 @@ note_is_file_backed_load(const target_elf& elf, const Elf64_Phdr& note)
     });
 }
 
+// Walks the usable PT_NOTE segments and returns the Build ID they agree on.
+// read_note supplies the bytes of one note segment and returns nullopt when
+// they cannot be obtained from that source.
+template <typename ReadNoteT>
 std::optional<std::vector<uint8_t>>
-build_id_from_file(const target_elf& elf)
+unique_gnu_build_id(const target_elf& elf, ReadNoteT&& read_note)
 {
-    auto result = std::vector<uint8_t>{};
-    auto found  = false;
+    auto result = std::optional<std::vector<uint8_t>>{};
 
     for(const auto& segment : elf.reader.segments)
     {
         if(segment == nullptr || segment->get_type() != PT_NOTE) continue;
 
         auto note = to_phdr(*segment);
+        // Bounds every read of this note, including the pointer arithmetic in
+        // the file-backed read_note, and keeps both sources describing the same
+        // bytes so their Build IDs are comparable.
         if(note.p_filesz == 0 || note.p_filesz > MAX_ELF_NOTE_SIZE ||
+           note.p_memsz < note.p_filesz ||
            !has_range(elf.data.size(), note.p_offset, note.p_filesz) ||
            !note_is_file_backed_load(elf, note))
         {
             continue;
         }
 
-        auto build_id =
-            parse_gnu_build_id(elf.data.data() + note.p_offset, static_cast<size_t>(note.p_filesz));
+        auto note_data = read_note(note);
+        if(!note_data) continue;
+
+        auto build_id = parse_gnu_build_id(note_data->data(), note_data->size());
         if(!build_id) continue;
-        if(found) return std::nullopt;
+
+        if(result && *result != *build_id) return std::nullopt;
         result = std::move(*build_id);
-        found  = true;
     }
 
-    if(!found) return std::nullopt;
     return result;
+}
+
+std::optional<std::vector<uint8_t>>
+build_id_from_file(const target_elf& elf)
+{
+    return unique_gnu_build_id(elf, [&elf](const Elf64_Phdr& note) {
+        const auto* begin = elf.data.data() + note.p_offset;
+        return std::optional<std::vector<uint8_t>>{std::in_place, begin, begin + note.p_filesz};
+    });
 }
 
 bool
@@ -744,7 +740,7 @@ range_is_readable_mapping(const mapped_object& object, uint64_t address, uint64_
 std::optional<std::vector<uint8_t>>
 read_target_memory(pid_t pid, uint64_t address, size_t size)
 {
-    if(size == 0 || size > MAX_ELF_NOTE_SIZE || address > std::numeric_limits<uintptr_t>::max())
+    if(size == 0 || size > MAX_TARGET_READ_SIZE || !checked_add(address, size))
     {
         return std::nullopt;
     }
@@ -754,10 +750,7 @@ read_target_memory(pid_t pid, uint64_t address, size_t size)
     while(read < size)
     {
         auto remote_address = checked_add(address, read);
-        if(!remote_address || *remote_address > std::numeric_limits<uintptr_t>::max())
-        {
-            return std::nullopt;
-        }
+        if(!remote_address) return std::nullopt;
 
         auto local = iovec{data.data() + read, size - read};
         auto remote =
@@ -784,39 +777,14 @@ build_id_from_target_memory(pid_t                pid,
                             const mapped_object& object,
                             uint64_t             load_bias)
 {
-    auto result = std::vector<uint8_t>{};
-    auto found  = false;
-
-    for(const auto& segment : elf.reader.segments)
-    {
-        if(segment == nullptr || segment->get_type() != PT_NOTE) continue;
-
-        auto note = to_phdr(*segment);
-        if(note.p_filesz == 0 || note.p_filesz > MAX_ELF_NOTE_SIZE ||
-           note.p_memsz < note.p_filesz || !note_is_file_backed_load(elf, note))
-        {
-            continue;
-        }
-
+    return unique_gnu_build_id(elf, [&](const Elf64_Phdr& note) {
         auto runtime_address = checked_add(load_bias, note.p_vaddr);
         if(!runtime_address || !range_is_readable_mapping(object, *runtime_address, note.p_filesz))
         {
-            continue;
+            return std::optional<std::vector<uint8_t>>{};
         }
-
-        auto note_data =
-            read_target_memory(pid, *runtime_address, static_cast<size_t>(note.p_filesz));
-        if(!note_data) continue;
-
-        auto build_id = parse_gnu_build_id(note_data->data(), note_data->size());
-        if(!build_id) continue;
-        if(found) return std::nullopt;
-        result = std::move(*build_id);
-        found  = true;
-    }
-
-    if(!found) return std::nullopt;
-    return result;
+        return read_target_memory(pid, *runtime_address, static_cast<size_t>(note.p_filesz));
+    });
 }
 
 bool
@@ -1093,14 +1061,17 @@ address_in_executable_mapping(const mapped_object& object, uint64_t address)
 }
 
 std::optional<uint64_t>
-resolve_target_symbol(pid_t pid, const mapped_object& object, std::string_view symbol)
+resolve_target_symbol(pid_t                pid,
+                      const mapped_object& object,
+                      std::string_view     symbol,
+                      bool                 pathname_only)
 {
-    auto elf = open_target_elf(pid, object);
+    auto elf = open_target_elf(pid, object, pathname_only);
     if(!elf || !parse_target_elf(*elf)) return std::nullopt;
 
     auto load_bias = calculate_load_bias(*elf, object);
     if(!load_bias) return std::nullopt;
-    if(!elf->metadata_identity_matches && !build_id_matches_target(pid, *elf, object, *load_bias))
+    if(!elf->identity_matches_mapping && !build_id_matches_target(pid, *elf, object, *load_bias))
     {
         return std::nullopt;
     }
@@ -1139,14 +1110,18 @@ resolve_target_symbol(pid_t pid, const mapped_object& object, std::string_view s
 }  // namespace
 
 bool
-find_symbol(int target_pid, void*& addr, const std::string& library, const std::string& symbol)
+find_symbol(int                target_pid,
+            void*&             addr,
+            const std::string& library,
+            const std::string& symbol,
+            bool               pathname_only)
 {
     addr = nullptr;
 
     auto object = select_unique_mapped_object(target_pid, library);
     if(!object) return false;
 
-    if(auto resolved = resolve_target_symbol(target_pid, *object, symbol))
+    if(auto resolved = resolve_target_symbol(target_pid, *object, symbol, pathname_only))
     {
         // NOLINTNEXTLINE(performance-no-int-to-ptr)
         addr = reinterpret_cast<void*>(*resolved);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -70,9 +70,9 @@ constexpr auto MAX_BUILD_ID_SIZE        = uint64_t{4096};
 constexpr auto MAX_DYNAMIC_SYMBOLS      = size_t{1} << 24;
 constexpr auto MAX_GNU_HASH_CHAIN_STEPS = size_t{1} << 24;
 
-// Note names and descriptors are padded to 4 bytes, not to the containing
+// Note names and descriptors are padded to 4 bytes regardless of the containing
 // segment's p_align. GNU emits .note.gnu.property in a PT_NOTE declaring
-// p_align 8 yet still pads the name to 4, so honoring p_align misparses it.
+// p_align 8, yet its name is still padded to 4.
 constexpr auto ELF_NOTE_ALIGNMENT = uint64_t{4};
 
 struct memory_mapping

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -589,6 +589,10 @@ calculate_load_bias(const target_elf& elf, const mapped_object& object)
         return std::nullopt;
     }
 
+    // Mappings are sorted by start address, so front() is the object's lowest
+    // mapping. That is the loader's first PT_LOAD as long as the object is
+    // mapped once; a second independent mapping of the same inode placed below
+    // it would produce a bias for the wrong instance.
     auto first_mapping        = object.mappings.front();
     auto segment_file_page    = align_down(first_load_segment->p_offset, page_size);
     auto segment_virtual_page = align_down(first_load_segment->p_vaddr, page_size);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -147,10 +147,10 @@ checked_mul(uint64_t lhs, uint64_t rhs)
     return lhs * rhs;
 }
 
-uint64_t
+std::optional<uint64_t>
 align_down(uint64_t value, uint64_t alignment)
 {
-    if(alignment == 0) return value;
+    if(alignment == 0) return std::nullopt;
     return value - (value % alignment);
 }
 
@@ -596,20 +596,26 @@ calculate_load_bias(const target_elf& elf, const mapped_object& object)
     auto first_mapping        = object.mappings.front();
     auto segment_file_page    = align_down(first_load_segment->p_offset, page_size);
     auto segment_virtual_page = align_down(first_load_segment->p_vaddr, page_size);
+    if(!segment_file_page || !segment_virtual_page)
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Invalid page size " << page_size
+                   << " while calculating load bias for " << object.path;
+        return std::nullopt;
+    }
     // Match the maps entry to the PT_LOAD segment by file page before using it
     // to derive the ET_DYN load bias.
-    if(first_mapping.file_offset != segment_file_page)
+    if(first_mapping.file_offset != *segment_file_page)
     {
         ROCP_ERROR << "[rocprofiler-sdk-rocattach] First target mapping for " << object.path
                    << " has file offset 0x" << std::hex << first_mapping.file_offset
-                   << ", but the first PT_LOAD segment starts at file page 0x" << segment_file_page
+                   << ", but the first PT_LOAD segment starts at file page 0x" << *segment_file_page
                    << std::dec;
         return std::nullopt;
     }
 
     // For ET_DYN shared objects, load bias is runtime start minus page-aligned
     // segment virtual address.
-    auto bias = checked_sub(static_cast<uint64_t>(first_mapping.start), segment_virtual_page);
+    auto bias = checked_sub(static_cast<uint64_t>(first_mapping.start), *segment_virtual_page);
     if(!bias)
     {
         ROCP_ERROR << "[rocprofiler-sdk-rocattach] Invalid target mapping/segment pair for "

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -787,6 +787,13 @@ build_id_from_target_memory(pid_t                pid,
     });
 }
 
+// Runs only when the file's device/inode did not match the mapping, which is
+// the case for a file found by pathname under /proc/<pid>/root after an overlay
+// or bind mount gave the same content a different inode. Matching Build IDs
+// then say the file and the mapped image are the same build. That is an
+// identity check, not an integrity check: the linker writes the Build ID once
+// and nothing recomputes it, so a library whose bytes are edited after linking
+// keeps its original note and is still accepted here.
 bool
 build_id_matches_target(pid_t                pid,
                         const target_elf&    elf,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -22,6 +22,7 @@
 
 #include "symbol_lookup.hpp"
 
+#include "lib/common/filesystem.hpp"
 #include "lib/common/hasher.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/common/scope_destructor.hpp"
@@ -44,7 +45,6 @@
 #include <cstdint>
 #include <cstring>
 #include <exception>
-#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <optional>
@@ -61,6 +61,8 @@ namespace rocattach
 {
 namespace
 {
+namespace fs = common::filesystem;
+
 // Keep limits generous enough for debug builds, but bounded so malformed target
 // ELFs cannot force unbounded memory use or symbol/hash traversal.
 constexpr auto MAX_TARGET_ELF_SIZE      = uint64_t{512} * 1024 * 1024;
@@ -518,9 +520,9 @@ open_target_elf(pid_t pid, const mapped_object& object, bool pathname_only)
     auto target_path = strip_deleted_suffix(object.path);
     if(!target_path.empty() && target_path.front() == '/')
     {
-        auto root_path = (std::filesystem::path{fmt::format("/proc/{}/root", pid)} /
-                          std::filesystem::path{target_path}.relative_path())
-                             .string();
+        auto root_path =
+            (fs::path{fmt::format("/proc/{}/root", pid)} / fs::path{target_path}.relative_path())
+                .string();
         if(auto elf = read_mapped_file(root_path, object, /*require_identity_match=*/false))
         {
             ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << root_path;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.hpp
@@ -28,8 +28,10 @@ namespace rocprofiler
 {
 namespace rocattach
 {
-// pathname_only opens the mapped object through /proc/<pid>/root instead of
-// /proc/<pid>/map_files, which containers may not expose.
+// pathname_only forces the /proc/<pid>/root path instead of
+// /proc/<pid>/map_files. No production caller sets it: the lookup already falls
+// back to the pathname when map_files is unavailable. It exists so tests can
+// exercise that fallback deterministically.
 bool
 find_symbol(int                target_pid,
             void*&             addr,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.hpp
@@ -28,8 +28,14 @@ namespace rocprofiler
 {
 namespace rocattach
 {
+// pathname_only opens the mapped object through /proc/<pid>/root instead of
+// /proc/<pid>/map_files, which containers may not expose.
 bool
-find_symbol(int target_pid, void*& addr, const std::string& library, const std::string& symbol);
+find_symbol(int                target_pid,
+            void*&             addr,
+            const std::string& library,
+            const std::string& symbol,
+            bool               pathname_only = false);
 
 }  // namespace rocattach
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -88,8 +88,8 @@ if(TARGET rocprofiler-sdk::rocprofiler-sdk-build-flags
     target_compile_definitions(rocattach-symbol-lookup-fixture-shifted
                                PRIVATE ROCATTACH_FIXTURE_PADDED=1)
     rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-no-build-id 7 "")
-    # rocattach_add_symbol_lookup_fixture links with "--build-id". This appends
-    # after it, and the last --build-id flag on the link line wins.
+    # rocattach_add_symbol_lookup_fixture links with "--build-id". This appends after it,
+    # and the last --build-id flag on the link line wins.
     target_link_options(rocattach-symbol-lookup-fixture-no-build-id PRIVATE
                         "LINKER:--build-id=none")
     rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-a 4 "")

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -73,6 +73,7 @@ if(TARGET rocprofiler-sdk::rocprofiler-sdk-build-flags
         target_sources(${NAME} PRIVATE symbol_lookup_fixture.cpp)
         target_compile_definitions(${NAME} PRIVATE ROCATTACH_FIXTURE_VALUE=${VALUE})
         target_link_libraries(${NAME} PRIVATE rocprofiler-sdk::tests-build-flags)
+        target_link_options(${NAME} PRIVATE "LINKER:--build-id")
         set_target_properties(${NAME} PROPERTIES OUTPUT_NAME
                                                  "rocprofiler-register.so.${NAME}")
         if(HASH_STYLE)
@@ -86,6 +87,9 @@ if(TARGET rocprofiler-sdk::rocprofiler-sdk-build-flags
     rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-shifted 6 "")
     target_compile_definitions(rocattach-symbol-lookup-fixture-shifted
                                PRIVATE ROCATTACH_FIXTURE_PADDED=1)
+    rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-no-build-id 7 "")
+    set_property(TARGET rocattach-symbol-lookup-fixture-no-build-id
+                 PROPERTY LINK_OPTIONS "LINKER:--build-id=none")
     rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-a 4 "")
     rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-b 5 "")
 
@@ -96,6 +100,8 @@ if(TARGET rocprofiler-sdk::rocprofiler-sdk-build-flags
         rocattach-symbol-lookup-test
         PRIVATE "${ROCATTACH_SYMBOL_LOOKUP_SOURCE_ROOT}"
                 "${ROCATTACH_SYMBOL_LOOKUP_SOURCE_ROOT}/lib/rocprofiler-sdk-rocattach")
+    target_compile_definitions(rocattach-symbol-lookup-test
+                               PRIVATE ROCPROFILER_ROCATTACH_TESTING=1)
     target_link_libraries(
         rocattach-symbol-lookup-test
         PRIVATE rocprofiler-sdk::rocprofiler-sdk-shared-library
@@ -109,6 +115,7 @@ if(TARGET rocprofiler-sdk::rocprofiler-sdk-build-flags
         rocattach-symbol-lookup-fixture-gnu
         rocattach-symbol-lookup-fixture-sysv
         rocattach-symbol-lookup-fixture-shifted
+        rocattach-symbol-lookup-fixture-no-build-id
         rocattach-symbol-lookup-fixture-ambiguous-a
         rocattach-symbol-lookup-fixture-ambiguous-b)
 
@@ -119,6 +126,7 @@ if(TARGET rocprofiler-sdk::rocprofiler-sdk-build-flags
              $<TARGET_FILE:rocattach-symbol-lookup-fixture-gnu>
              $<TARGET_FILE:rocattach-symbol-lookup-fixture-sysv>
              $<TARGET_FILE:rocattach-symbol-lookup-fixture-shifted>
+             $<TARGET_FILE:rocattach-symbol-lookup-fixture-no-build-id>
              $<TARGET_FILE:rocattach-symbol-lookup-fixture-ambiguous-a>
              $<TARGET_FILE:rocattach-symbol-lookup-fixture-ambiguous-b>
         TIMEOUT 30

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -108,6 +108,7 @@ if(TARGET rocprofiler-sdk::rocprofiler-sdk-build-flags
                 rocprofiler-sdk::rocprofiler-sdk-headers
                 rocprofiler-sdk::rocprofiler-sdk-build-flags
                 rocprofiler-sdk::rocprofiler-sdk-common-library
+                rocprofiler-sdk::tests-common-library
                 ${CMAKE_DL_LIBS})
     add_dependencies(
         rocattach-symbol-lookup-test

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -88,8 +88,10 @@ if(TARGET rocprofiler-sdk::rocprofiler-sdk-build-flags
     target_compile_definitions(rocattach-symbol-lookup-fixture-shifted
                                PRIVATE ROCATTACH_FIXTURE_PADDED=1)
     rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-no-build-id 7 "")
-    set_property(TARGET rocattach-symbol-lookup-fixture-no-build-id
-                 PROPERTY LINK_OPTIONS "LINKER:--build-id=none")
+    # rocattach_add_symbol_lookup_fixture links with "--build-id". This appends
+    # after it, and the last --build-id flag on the link line wins.
+    target_link_options(rocattach-symbol-lookup-fixture-no-build-id PRIVATE
+                        "LINKER:--build-id=none")
     rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-a 4 "")
     rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-b 5 "")
 
@@ -100,8 +102,6 @@ if(TARGET rocprofiler-sdk::rocprofiler-sdk-build-flags
         rocattach-symbol-lookup-test
         PRIVATE "${ROCATTACH_SYMBOL_LOOKUP_SOURCE_ROOT}"
                 "${ROCATTACH_SYMBOL_LOOKUP_SOURCE_ROOT}/lib/rocprofiler-sdk-rocattach")
-    target_compile_definitions(rocattach-symbol-lookup-test
-                               PRIVATE ROCPROFILER_ROCATTACH_TESTING=1)
     target_link_libraries(
         rocattach-symbol-lookup-test
         PRIVATE rocprofiler-sdk::rocprofiler-sdk-shared-library

--- a/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
@@ -34,11 +34,13 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -250,11 +252,102 @@ expect_malformed_mapped_elf_fails()
     std::filesystem::remove(path_buffer);
 }
 
+std::optional<size_t>
+find_build_id_descriptor(const std::vector<uint8_t>& bytes)
+{
+    auto header = Elf64_Ehdr{};
+    if(bytes.size() < sizeof(header)) return std::nullopt;
+    std::memcpy(&header, bytes.data(), sizeof(header));
+
+    for(auto idx = uint16_t{0}; idx < header.e_phnum; ++idx)
+    {
+        auto segment = Elf64_Phdr{};
+        auto offset  = header.e_phoff + (static_cast<size_t>(idx) * header.e_phentsize);
+        if(offset + sizeof(segment) > bytes.size()) return std::nullopt;
+        std::memcpy(&segment, bytes.data() + offset, sizeof(segment));
+        if(segment.p_type != PT_NOTE) continue;
+
+        auto cursor = static_cast<size_t>(segment.p_offset);
+        auto end    = cursor + static_cast<size_t>(segment.p_filesz);
+        if(end > bytes.size()) return std::nullopt;
+
+        while(cursor + sizeof(Elf64_Nhdr) <= end)
+        {
+            auto note = Elf64_Nhdr{};
+            std::memcpy(&note, bytes.data() + cursor, sizeof(note));
+
+            auto name_offset = cursor + sizeof(note);
+            auto descriptor  = name_offset + ((note.n_namesz + 3U) & ~3U);
+            auto next        = descriptor + ((note.n_descsz + 3U) & ~3U);
+            if(descriptor > end || next > end) break;
+
+            if(note.n_type == NT_GNU_BUILD_ID && note.n_namesz == 4 && note.n_descsz > 0 &&
+               std::memcmp(bytes.data() + name_offset, "GNU", 4) == 0)
+            {
+                return descriptor;
+            }
+            cursor = next;
+        }
+    }
+    return std::nullopt;
+}
+
+// Copies source and flips one byte inside its NT_GNU_BUILD_ID descriptor. The
+// result is byte-identical to the source everywhere else, so a rejection can
+// only come from the Build ID comparison and never from a layout difference.
+void
+copy_with_flipped_build_id(const std::string& source, const std::string& destination)
+{
+    auto input = std::ifstream{source, std::ios::binary};
+    auto bytes = std::vector<uint8_t>{std::istreambuf_iterator<char>{input},
+                                      std::istreambuf_iterator<char>{}};
+    input.close();
+
+    auto descriptor = find_build_id_descriptor(bytes);
+    if(!descriptor)
+    {
+        std::cerr << "could not locate a GNU Build ID note in " << source << '\n';
+        std::exit(1);
+    }
+    bytes.at(*descriptor) ^= 0xffU;
+
+    auto output = std::ofstream{destination, std::ios::binary | std::ios::trunc};
+    output.write(reinterpret_cast<const char*>(bytes.data()),
+                 static_cast<std::streamsize>(bytes.size()));
+    output.close();
+    if(!output)
+    {
+        std::cerr << "failed to write Build ID variant " << destination << '\n';
+        std::exit(1);
+    }
+}
+
+// Callers fork and then run dlopen and std::filesystem in the child, which is
+// only safe from a single-threaded parent. Should a dependency ever start a
+// thread at load time, fail loudly here rather than deadlock on the loader lock.
+void
+require_single_threaded(const char* context)
+{
+    auto status = std::ifstream{"/proc/self/status"};
+    auto line   = std::string{};
+    while(std::getline(status, line))
+    {
+        if(line.rfind("Threads:", 0) != 0) continue;
+        if(std::stoi(line.substr(line.find(':') + 1)) != 1)
+        {
+            std::cerr << context << " requires a single-threaded process, but " << line << '\n';
+            std::exit(1);
+        }
+        return;
+    }
+}
+
 void
 expect_root_fallback_validates_build_id(const loaded_library& source,
-                                        const loaded_library& different_build,
                                         const loaded_library& no_build_id)
 {
+    require_single_threaded("cross-process fallback test");
+
     auto path = std::filesystem::temp_directory_path() /
                 "librocprofiler-register.so.rocattach-replaced-XXXXXX";
     auto path_buffer = path.string();
@@ -323,10 +416,8 @@ expect_root_fallback_validates_build_id(const loaded_library& source,
 
     close(address_pipe[1]);
     close(done_pipe[0]);
-    setenv("ROCATTACH_TEST_DISABLE_MAP_FILES", "1", 1);
 
     auto cleanup = rocprofiler::common::scope_destructor{[&]() {
-        unsetenv("ROCATTACH_TEST_DISABLE_MAP_FILES");
         auto done         = char{};
         auto write_result = write(done_pipe[1], &done, sizeof(done));
         (void) write_result;
@@ -345,26 +436,31 @@ expect_root_fallback_validates_build_id(const loaded_library& source,
         std::exit(1);
     }
 
+    // Forces the /proc/<pid>/root fallback, which is the path a containerized
+    // target takes when /proc/<pid>/map_files is unavailable.
+    constexpr auto pathname_only = true;
+
     void* resolved = nullptr;
-    if(!rocprofiler::rocattach::find_symbol(child, resolved, path_buffer, ATTACH_SYMBOL_NAME) ||
+    if(!rocprofiler::rocattach::find_symbol(
+           child, resolved, path_buffer, ATTACH_SYMBOL_NAME, pathname_only) ||
        reinterpret_cast<uintptr_t>(resolved) != expected)
     {
         std::cerr << "find_symbol failed cross-process Build ID fallback validation\n";
         std::exit(1);
     }
 
-    // A layout-compatible pathname replacement with another Build ID must not
-    // be used to resolve a symbol from the still-mapped original.
+    // A byte-identical pathname replacement that differs only in its Build ID
+    // must not be used to resolve a symbol from the still-mapped original.
     auto replacement = path_buffer + ".replacement";
-    std::filesystem::copy_file(
-        different_build.path, replacement, std::filesystem::copy_options::overwrite_existing);
+    copy_with_flipped_build_id(source.path, replacement);
     std::filesystem::rename(replacement, path_buffer);
 
     resolved = nullptr;
-    if(rocprofiler::rocattach::find_symbol(child, resolved, path_buffer, ATTACH_SYMBOL_NAME))
+    if(rocprofiler::rocattach::find_symbol(
+           child, resolved, path_buffer, ATTACH_SYMBOL_NAME, pathname_only))
     {
-        std::cerr << "find_symbol unexpectedly accepted a replacement ELF with a different "
-                     "Build ID\n";
+        std::cerr << "find_symbol unexpectedly accepted a replacement ELF whose only difference "
+                     "is its Build ID\n";
         std::exit(1);
     }
 
@@ -372,7 +468,8 @@ expect_root_fallback_validates_build_id(const loaded_library& source,
         no_build_id.path, replacement, std::filesystem::copy_options::overwrite_existing);
     std::filesystem::rename(replacement, path_buffer);
     resolved = nullptr;
-    if(rocprofiler::rocattach::find_symbol(child, resolved, path_buffer, ATTACH_SYMBOL_NAME))
+    if(rocprofiler::rocattach::find_symbol(
+           child, resolved, path_buffer, ATTACH_SYMBOL_NAME, pathname_only))
     {
         std::cerr << "find_symbol unexpectedly accepted a replacement ELF without a Build ID\n";
         std::exit(1);
@@ -445,7 +542,7 @@ main(int argc, char** argv)
     }
     expect_ambiguous_basename_fails();
     expect_malformed_mapped_elf_fails();
-    expect_root_fallback_validates_build_id(libraries.at(0), libraries.at(3), libraries.at(4));
+    expect_root_fallback_validates_build_id(libraries.at(0), libraries.at(4));
 
     std::cout << "Test PASSED: target ELF resolver resolved exact mapped libraries and rejected "
                  "ambiguous and malformed mappings\n";

--- a/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
@@ -33,6 +33,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -247,23 +248,82 @@ expect_malformed_mapped_elf_fails()
     munmap(mapping, contents.size());
     std::filesystem::remove(path_buffer);
 }
+
+void
+expect_root_fallback_validates_build_id(const loaded_library& source,
+                                        const loaded_library& different_build,
+                                        const loaded_library& no_build_id)
+{
+    auto path = std::filesystem::temp_directory_path() /
+                "librocprofiler-register.so.rocattach-replaced-XXXXXX";
+    auto path_buffer = path.string();
+    auto fd          = mkstemp(path_buffer.data());
+    if(fd < 0)
+    {
+        std::cerr << "mkstemp failed for replaced ELF fixture\n";
+        std::exit(1);
+    }
+    close(fd);
+
+    std::filesystem::copy_file(
+        source.path, path_buffer, std::filesystem::copy_options::overwrite_existing);
+    auto mapped = load_library(path_buffer.c_str());
+
+    // Keep the original inode mapped, but replace its pathname with an
+    // identical ELF on a different inode. This models the identity mismatch
+    // seen when maps exposes an OverlayFS backing file.
+    std::filesystem::remove(path_buffer);
+    std::filesystem::copy_file(source.path, path_buffer);
+
+    setenv("ROCATTACH_TEST_DISABLE_MAP_FILES", "1", 1);
+    expect_resolves_to_dlsym(mapped);
+
+    // A layout-compatible pathname replacement with another Build ID must not
+    // be used to resolve a symbol from the still-mapped original.
+    auto replacement = path_buffer + ".replacement";
+    std::filesystem::copy_file(
+        different_build.path, replacement, std::filesystem::copy_options::overwrite_existing);
+    std::filesystem::rename(replacement, path_buffer);
+
+    void* resolved = nullptr;
+    if(rocprofiler::rocattach::find_symbol(getpid(), resolved, mapped.path, ATTACH_SYMBOL_NAME))
+    {
+        std::cerr << "find_symbol unexpectedly accepted a replacement ELF with a different "
+                     "Build ID\n";
+        std::exit(1);
+    }
+
+    std::filesystem::copy_file(
+        no_build_id.path, replacement, std::filesystem::copy_options::overwrite_existing);
+    std::filesystem::rename(replacement, path_buffer);
+    resolved = nullptr;
+    if(rocprofiler::rocattach::find_symbol(getpid(), resolved, mapped.path, ATTACH_SYMBOL_NAME))
+    {
+        std::cerr << "find_symbol unexpectedly accepted a replacement ELF without a Build ID\n";
+        std::exit(1);
+    }
+    unsetenv("ROCATTACH_TEST_DISABLE_MAP_FILES");
+
+    cleanup_loaded_library(mapped);
+    std::filesystem::remove(path_buffer);
+}
 }  // namespace
 
 int
 main(int argc, char** argv)
 {
-    if(argc != 7)
+    if(argc != 8)
     {
         std::cerr << "Usage: " << argv[0]
                   << " <normal-lib> <gnu-hash-lib> <sysv-hash-lib> <shifted-lib> "
-                     "<ambiguous-a> <ambiguous-b>\n";
+                     "<no-build-id-lib> <ambiguous-a> <ambiguous-b>\n";
         return 1;
     }
 
     auto libraries = std::vector<loaded_library>{};
-    libraries.reserve(6);
+    libraries.reserve(7);
     for(auto* path :
-        std::array<const char*, 6>{argv[1], argv[2], argv[3], argv[4], argv[5], argv[6]})
+        std::array<const char*, 7>{argv[1], argv[2], argv[3], argv[4], argv[5], argv[6], argv[7]})
     {
         libraries.emplace_back(load_library(path));
     }
@@ -288,6 +348,7 @@ main(int argc, char** argv)
     }
     expect_ambiguous_basename_fails();
     expect_malformed_mapped_elf_fails();
+    expect_root_fallback_validates_build_id(libraries.at(0), libraries.at(3), libraries.at(4));
 
     std::cout << "Test PASSED: target ELF resolver resolved exact mapped libraries and rejected "
                  "ambiguous and malformed mappings\n";

--- a/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
@@ -475,30 +475,6 @@ expect_root_fallback_validates_build_id(const loaded_library& source,
         std::exit(1);
     }
 }
-
-void
-expect_unrelated_mapping_does_not_change_resolution(const loaded_library& library)
-{
-    auto fd = open(library.path.c_str(), O_RDONLY | O_CLOEXEC);
-    if(fd < 0)
-    {
-        std::cerr << "open failed for unrelated mapping test\n";
-        std::exit(1);
-    }
-    auto close_fd = rocprofiler::common::scope_destructor{[&]() { close(fd); }};
-
-    auto  page_size_value = sysconf(_SC_PAGESIZE);
-    auto  page_size = (page_size_value > 0) ? static_cast<size_t>(page_size_value) : size_t{4096};
-    auto* mapping   = mmap(nullptr, page_size, PROT_READ, MAP_PRIVATE, fd, 0);
-    if(mapping == MAP_FAILED)
-    {
-        std::cerr << "mmap failed for unrelated mapping test\n";
-        std::exit(1);
-    }
-    auto unmap = rocprofiler::common::scope_destructor{[&]() { munmap(mapping, page_size); }};
-
-    expect_resolves_to_dlsym(library);
-}
 }  // namespace
 
 int
@@ -526,7 +502,6 @@ main(int argc, char** argv)
     expect_resolves_to_dlsym(libraries.at(3));
     expect_resolves_to_dlsym(libraries.at(4));
     expect_different_symbol_offsets(libraries.at(0), libraries.at(3));
-    expect_unrelated_mapping_does_not_change_resolution(libraries.at(0));
     {
         auto sectionless_normal  = create_and_load_sectionless_copy(libraries.at(0), "normal");
         auto sectionless_gnu     = create_and_load_sectionless_copy(libraries.at(1), "gnu");

--- a/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
@@ -22,6 +22,8 @@
 
 #include "symbol_lookup.hpp"
 
+#include "common/filesystem.hpp"
+
 #include "lib/common/scope_destructor.hpp"
 
 #include <dlfcn.h>
@@ -38,7 +40,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <optional>
@@ -70,7 +71,7 @@ cleanup_loaded_library(loaded_library& library)
     if(library.remove_on_cleanup && !library.path.empty())
     {
         std::error_code ec;
-        std::filesystem::remove(library.path, ec);
+        common::fs::remove(library.path, ec);
     }
 }
 
@@ -164,7 +165,7 @@ loaded_library
 create_and_load_sectionless_copy(const loaded_library& source, std::string_view label)
 {
     auto path =
-        std::filesystem::temp_directory_path() /
+        common::fs::temp_directory_path() /
         ("librocprofiler-register.so.rocattach-sectionless-" + std::string{label} + "-XXXXXX");
     auto path_buffer = path.string();
     auto fd          = mkstemp(path_buffer.data());
@@ -211,8 +212,8 @@ create_and_load_sectionless_copy(const loaded_library& source, std::string_view 
 void
 expect_malformed_mapped_elf_fails()
 {
-    auto path = std::filesystem::temp_directory_path() /
-                "librocprofiler-register.so.rocattach-malformed-XXXXXX";
+    auto path =
+        common::fs::temp_directory_path() / "librocprofiler-register.so.rocattach-malformed-XXXXXX";
     auto path_buffer = path.string();
     auto fd          = mkstemp(path_buffer.data());
     if(fd < 0)
@@ -245,12 +246,12 @@ expect_malformed_mapped_elf_fails()
         std::cerr << "find_symbol unexpectedly resolved malformed mapped ELF " << path_buffer
                   << " to " << resolved << '\n';
         munmap(mapping, contents.size());
-        std::filesystem::remove(path_buffer);
+        common::fs::remove(path_buffer);
         std::exit(1);
     }
 
     munmap(mapping, contents.size());
-    std::filesystem::remove(path_buffer);
+    common::fs::remove(path_buffer);
 }
 
 std::optional<size_t>
@@ -327,8 +328,8 @@ bool
 expect_pathname_lookup_validates_build_id(const loaded_library& source,
                                           const loaded_library& no_build_id)
 {
-    auto path = std::filesystem::temp_directory_path() /
-                "librocprofiler-register.so.rocattach-replaced-XXXXXX";
+    auto path =
+        common::fs::temp_directory_path() / "librocprofiler-register.so.rocattach-replaced-XXXXXX";
     auto path_buffer = path.string();
     auto fd          = mkstemp(path_buffer.data());
     if(fd < 0)
@@ -338,8 +339,7 @@ expect_pathname_lookup_validates_build_id(const loaded_library& source,
     }
     close(fd);
 
-    std::filesystem::copy_file(
-        source.path, path_buffer, std::filesystem::copy_options::overwrite_existing);
+    common::fs::copy_file(source.path, path_buffer, common::fs::copy_options::overwrite_existing);
 
     auto mapped = load_library(path_buffer.c_str());
     auto unload_mapped =
@@ -392,9 +392,9 @@ expect_pathname_lookup_validates_build_id(const loaded_library& source,
             std::cerr << "cross-process Build ID child did not exit cleanly\n";
         }
         std::error_code ec;
-        std::filesystem::remove(path_buffer, ec);
-        std::filesystem::remove(path_buffer + ".replacement", ec);
-        std::filesystem::remove(path_buffer + ".flipped", ec);
+        common::fs::remove(path_buffer, ec);
+        common::fs::remove(path_buffer + ".replacement", ec);
+        common::fs::remove(path_buffer + ".flipped", ec);
     }};
 
     // Repoint the pathname at a different inode while the child keeps the
@@ -402,9 +402,8 @@ expect_pathname_lookup_validates_build_id(const loaded_library& source,
     // otherwise the Build ID comparison would never be reached.
     auto install_at_pathname = [&](const std::string& file) {
         auto replacement = path_buffer + ".replacement";
-        std::filesystem::copy_file(
-            file, replacement, std::filesystem::copy_options::overwrite_existing);
-        std::filesystem::rename(replacement, path_buffer);
+        common::fs::copy_file(file, replacement, common::fs::copy_options::overwrite_existing);
+        common::fs::rename(replacement, path_buffer);
 
         struct stat installed
         {};

--- a/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
@@ -29,6 +29,7 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include <array>
@@ -267,16 +268,90 @@ expect_root_fallback_validates_build_id(const loaded_library& source,
 
     std::filesystem::copy_file(
         source.path, path_buffer, std::filesystem::copy_options::overwrite_existing);
-    auto mapped = load_library(path_buffer.c_str());
 
-    // Keep the original inode mapped, but replace its pathname with an
-    // identical ELF on a different inode. This models the identity mismatch
-    // seen when maps exposes an OverlayFS backing file.
-    std::filesystem::remove(path_buffer);
-    std::filesystem::copy_file(source.path, path_buffer);
+    auto address_pipe = std::array<int, 2>{};
+    auto done_pipe    = std::array<int, 2>{};
+    if(pipe(address_pipe.data()) != 0 || pipe(done_pipe.data()) != 0)
+    {
+        std::cerr << "pipe failed for cross-process fallback test\n";
+        std::exit(1);
+    }
 
+    auto child = fork();
+    if(child < 0)
+    {
+        std::cerr << "fork failed for cross-process fallback test\n";
+        std::exit(1);
+    }
+    if(child == 0)
+    {
+        close(address_pipe[0]);
+        close(done_pipe[1]);
+
+        auto        mapped = load_library(path_buffer.c_str());
+        struct stat before
+        {};
+        if(stat(path_buffer.c_str(), &before) != 0) _exit(2);
+
+        // Keep the original inode mapped, but replace its pathname with an
+        // identical ELF on a different inode. This models the identity mismatch
+        // seen when maps exposes an OverlayFS backing file.
+        std::filesystem::remove(path_buffer);
+        std::filesystem::copy_file(source.path, path_buffer);
+
+        struct stat after
+        {};
+        if(stat(path_buffer.c_str(), &after) != 0 ||
+           (before.st_dev == after.st_dev && before.st_ino == after.st_ino))
+        {
+            _exit(3);
+        }
+
+        auto* expected = dlsym(mapped.handle, ATTACH_SYMBOL_NAME);
+        auto  address  = reinterpret_cast<uintptr_t>(expected);
+        if(expected == nullptr || write(address_pipe[1], &address, sizeof(address)) !=
+                                      static_cast<ssize_t>(sizeof(address)))
+        {
+            _exit(4);
+        }
+
+        auto done = char{};
+        if(read(done_pipe[0], &done, sizeof(done)) != static_cast<ssize_t>(sizeof(done))) _exit(5);
+        cleanup_loaded_library(mapped);
+        _exit(0);
+    }
+
+    close(address_pipe[1]);
+    close(done_pipe[0]);
     setenv("ROCATTACH_TEST_DISABLE_MAP_FILES", "1", 1);
-    expect_resolves_to_dlsym(mapped);
+
+    auto cleanup = rocprofiler::common::scope_destructor{[&]() {
+        unsetenv("ROCATTACH_TEST_DISABLE_MAP_FILES");
+        auto done         = char{};
+        auto write_result = write(done_pipe[1], &done, sizeof(done));
+        (void) write_result;
+        close(done_pipe[1]);
+        close(address_pipe[0]);
+        (void) waitpid(child, nullptr, 0);
+        std::error_code ec;
+        std::filesystem::remove(path_buffer, ec);
+        std::filesystem::remove(path_buffer + ".replacement", ec);
+    }};
+
+    auto expected = uintptr_t{};
+    if(read(address_pipe[0], &expected, sizeof(expected)) != static_cast<ssize_t>(sizeof(expected)))
+    {
+        std::cerr << "child failed to prepare cross-process fallback test\n";
+        std::exit(1);
+    }
+
+    void* resolved = nullptr;
+    if(!rocprofiler::rocattach::find_symbol(child, resolved, path_buffer, ATTACH_SYMBOL_NAME) ||
+       reinterpret_cast<uintptr_t>(resolved) != expected)
+    {
+        std::cerr << "find_symbol failed cross-process Build ID fallback validation\n";
+        std::exit(1);
+    }
 
     // A layout-compatible pathname replacement with another Build ID must not
     // be used to resolve a symbol from the still-mapped original.
@@ -285,8 +360,8 @@ expect_root_fallback_validates_build_id(const loaded_library& source,
         different_build.path, replacement, std::filesystem::copy_options::overwrite_existing);
     std::filesystem::rename(replacement, path_buffer);
 
-    void* resolved = nullptr;
-    if(rocprofiler::rocattach::find_symbol(getpid(), resolved, mapped.path, ATTACH_SYMBOL_NAME))
+    resolved = nullptr;
+    if(rocprofiler::rocattach::find_symbol(child, resolved, path_buffer, ATTACH_SYMBOL_NAME))
     {
         std::cerr << "find_symbol unexpectedly accepted a replacement ELF with a different "
                      "Build ID\n";
@@ -297,15 +372,35 @@ expect_root_fallback_validates_build_id(const loaded_library& source,
         no_build_id.path, replacement, std::filesystem::copy_options::overwrite_existing);
     std::filesystem::rename(replacement, path_buffer);
     resolved = nullptr;
-    if(rocprofiler::rocattach::find_symbol(getpid(), resolved, mapped.path, ATTACH_SYMBOL_NAME))
+    if(rocprofiler::rocattach::find_symbol(child, resolved, path_buffer, ATTACH_SYMBOL_NAME))
     {
         std::cerr << "find_symbol unexpectedly accepted a replacement ELF without a Build ID\n";
         std::exit(1);
     }
-    unsetenv("ROCATTACH_TEST_DISABLE_MAP_FILES");
+}
 
-    cleanup_loaded_library(mapped);
-    std::filesystem::remove(path_buffer);
+void
+expect_unrelated_mapping_does_not_change_resolution(const loaded_library& library)
+{
+    auto fd = open(library.path.c_str(), O_RDONLY | O_CLOEXEC);
+    if(fd < 0)
+    {
+        std::cerr << "open failed for unrelated mapping test\n";
+        std::exit(1);
+    }
+    auto close_fd = rocprofiler::common::scope_destructor{[&]() { close(fd); }};
+
+    auto  page_size_value = sysconf(_SC_PAGESIZE);
+    auto  page_size = (page_size_value > 0) ? static_cast<size_t>(page_size_value) : size_t{4096};
+    auto* mapping   = mmap(nullptr, page_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    if(mapping == MAP_FAILED)
+    {
+        std::cerr << "mmap failed for unrelated mapping test\n";
+        std::exit(1);
+    }
+    auto unmap = rocprofiler::common::scope_destructor{[&]() { munmap(mapping, page_size); }};
+
+    expect_resolves_to_dlsym(library);
 }
 }  // namespace
 
@@ -322,7 +417,7 @@ main(int argc, char** argv)
 
     auto libraries = std::vector<loaded_library>{};
     libraries.reserve(7);
-    for(auto* path :
+    for(const auto* path :
         std::array<const char*, 7>{argv[1], argv[2], argv[3], argv[4], argv[5], argv[6], argv[7]})
     {
         libraries.emplace_back(load_library(path));
@@ -332,7 +427,9 @@ main(int argc, char** argv)
     expect_resolves_to_dlsym(libraries.at(1));
     expect_resolves_to_dlsym(libraries.at(2));
     expect_resolves_to_dlsym(libraries.at(3));
+    expect_resolves_to_dlsym(libraries.at(4));
     expect_different_symbol_offsets(libraries.at(0), libraries.at(3));
+    expect_unrelated_mapping_does_not_change_resolution(libraries.at(0));
     {
         auto sectionless_normal  = create_and_load_sectionless_copy(libraries.at(0), "normal");
         auto sectionless_gnu     = create_and_load_sectionless_copy(libraries.at(1), "gnu");

--- a/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
@@ -33,6 +33,7 @@
 #include <unistd.h>
 
 #include <array>
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -322,32 +323,10 @@ copy_with_flipped_build_id(const std::string& source, const std::string& destina
     }
 }
 
-// Callers fork and then run dlopen and std::filesystem in the child, which is
-// only safe from a single-threaded parent. Should a dependency ever start a
-// thread at load time, fail loudly here rather than deadlock on the loader lock.
 void
-require_single_threaded(const char* context)
+expect_pathname_lookup_validates_build_id(const loaded_library& source,
+                                          const loaded_library& no_build_id)
 {
-    auto status = std::ifstream{"/proc/self/status"};
-    auto line   = std::string{};
-    while(std::getline(status, line))
-    {
-        if(line.rfind("Threads:", 0) != 0) continue;
-        if(std::stoi(line.substr(line.find(':') + 1)) != 1)
-        {
-            std::cerr << context << " requires a single-threaded process, but " << line << '\n';
-            std::exit(1);
-        }
-        return;
-    }
-}
-
-void
-expect_root_fallback_validates_build_id(const loaded_library& source,
-                                        const loaded_library& no_build_id)
-{
-    require_single_threaded("cross-process fallback test");
-
     auto path = std::filesystem::temp_directory_path() /
                 "librocprofiler-register.so.rocattach-replaced-XXXXXX";
     auto path_buffer = path.string();
@@ -362,118 +341,112 @@ expect_root_fallback_validates_build_id(const loaded_library& source,
     std::filesystem::copy_file(
         source.path, path_buffer, std::filesystem::copy_options::overwrite_existing);
 
-    auto address_pipe = std::array<int, 2>{};
-    auto done_pipe    = std::array<int, 2>{};
-    if(pipe(address_pipe.data()) != 0 || pipe(done_pipe.data()) != 0)
+    auto mapped = load_library(path_buffer.c_str());
+    auto unload_mapped =
+        rocprofiler::common::scope_destructor{[&]() { cleanup_loaded_library(mapped); }};
+
+    auto* symbol = dlsym(mapped.handle, ATTACH_SYMBOL_NAME);
+    if(symbol == nullptr)
     {
-        std::cerr << "pipe failed for cross-process fallback test\n";
+        std::cerr << "dlsym failed for " << path_buffer << "::" << ATTACH_SYMBOL_NAME << '\n';
+        std::exit(1);
+    }
+    auto expected = reinterpret_cast<uintptr_t>(symbol);
+
+    struct stat mapped_identity
+    {};
+    if(stat(path_buffer.c_str(), &mapped_identity) != 0)
+    {
+        std::cerr << "stat failed for " << path_buffer << '\n';
+        std::exit(1);
+    }
+
+    auto done_pipe = std::array<int, 2>{};
+    if(pipe(done_pipe.data()) != 0)
+    {
+        std::cerr << "pipe failed for cross-process Build ID test\n";
         std::exit(1);
     }
 
     auto child = fork();
     if(child < 0)
     {
-        std::cerr << "fork failed for cross-process fallback test\n";
+        std::cerr << "fork failed for cross-process Build ID test\n";
         std::exit(1);
     }
     if(child == 0)
     {
-        close(address_pipe[0]);
         close(done_pipe[1]);
-
-        auto        mapped = load_library(path_buffer.c_str());
-        struct stat before
-        {};
-        if(stat(path_buffer.c_str(), &before) != 0) _exit(2);
-
-        // Keep the original inode mapped, but replace its pathname with an
-        // identical ELF on a different inode. This models the identity mismatch
-        // seen when maps exposes an OverlayFS backing file.
-        std::filesystem::remove(path_buffer);
-        std::filesystem::copy_file(source.path, path_buffer);
-
-        struct stat after
-        {};
-        if(stat(path_buffer.c_str(), &after) != 0 ||
-           (before.st_dev == after.st_dev && before.st_ino == after.st_ino))
-        {
-            _exit(3);
-        }
-
-        auto* expected = dlsym(mapped.handle, ATTACH_SYMBOL_NAME);
-        auto  address  = reinterpret_cast<uintptr_t>(expected);
-        if(expected == nullptr || write(address_pipe[1], &address, sizeof(address)) !=
-                                      static_cast<ssize_t>(sizeof(address)))
-        {
-            _exit(4);
-        }
-
         auto done = char{};
-        if(read(done_pipe[0], &done, sizeof(done)) != static_cast<ssize_t>(sizeof(done))) _exit(5);
-        cleanup_loaded_library(mapped);
+        while(read(done_pipe[0], &done, sizeof(done)) < 0 && errno == EINTR)
+        {}
         _exit(0);
     }
 
-    close(address_pipe[1]);
     close(done_pipe[0]);
-
-    auto cleanup = rocprofiler::common::scope_destructor{[&]() {
-        auto done         = char{};
-        auto write_result = write(done_pipe[1], &done, sizeof(done));
-        (void) write_result;
+    auto release_child = rocprofiler::common::scope_destructor{[&]() {
         close(done_pipe[1]);
-        close(address_pipe[0]);
-        (void) waitpid(child, nullptr, 0);
+        auto status = int{};
+        if(waitpid(child, &status, 0) != child || !WIFEXITED(status) || WEXITSTATUS(status) != 0)
+        {
+            std::cerr << "cross-process Build ID child did not exit cleanly\n";
+        }
         std::error_code ec;
         std::filesystem::remove(path_buffer, ec);
         std::filesystem::remove(path_buffer + ".replacement", ec);
+        std::filesystem::remove(path_buffer + ".flipped", ec);
     }};
 
-    auto expected = uintptr_t{};
-    if(read(address_pipe[0], &expected, sizeof(expected)) != static_cast<ssize_t>(sizeof(expected)))
-    {
-        std::cerr << "child failed to prepare cross-process fallback test\n";
-        std::exit(1);
-    }
+    // Repoint the pathname at a different inode while the child keeps the
+    // original one mapped. Confirm the inode actually changed,
+    // otherwise the Build ID comparison would never be reached.
+    auto install_at_pathname = [&](const std::string& file) {
+        auto replacement = path_buffer + ".replacement";
+        std::filesystem::copy_file(
+            file, replacement, std::filesystem::copy_options::overwrite_existing);
+        std::filesystem::rename(replacement, path_buffer);
 
-    // Forces the /proc/<pid>/root fallback, which is the path a containerized
-    // target takes when /proc/<pid>/map_files is unavailable.
+        struct stat installed
+        {};
+        if(stat(path_buffer.c_str(), &installed) != 0 ||
+           (installed.st_dev == mapped_identity.st_dev &&
+            installed.st_ino == mapped_identity.st_ino))
+        {
+            std::cerr << "replacing " << path_buffer << " did not change its inode\n";
+            std::exit(1);
+        }
+    };
+
+    // Forces the /proc/<pid>/root path instead of /proc/<pid>/map_files.
     constexpr auto pathname_only = true;
 
-    void* resolved = nullptr;
-    if(!rocprofiler::rocattach::find_symbol(
-           child, resolved, path_buffer, ATTACH_SYMBOL_NAME, pathname_only) ||
-       reinterpret_cast<uintptr_t>(resolved) != expected)
-    {
-        std::cerr << "find_symbol failed cross-process Build ID fallback validation\n";
-        std::exit(1);
-    }
+    auto expect_lookup = [&](bool should_resolve, const char* description) {
+        void* resolved    = nullptr;
+        auto  did_resolve = rocprofiler::rocattach::find_symbol(
+            child, resolved, path_buffer, ATTACH_SYMBOL_NAME, pathname_only);
+        if(did_resolve != should_resolve)
+        {
+            std::cerr << description << '\n';
+            std::exit(1);
+        }
+        if(should_resolve && reinterpret_cast<uintptr_t>(resolved) != expected)
+        {
+            std::cerr << "find_symbol resolved the wrong address: " << description << '\n';
+            std::exit(1);
+        }
+    };
 
-    // A byte-identical pathname replacement that differs only in its Build ID
-    // must not be used to resolve a symbol from the still-mapped original.
-    auto replacement = path_buffer + ".replacement";
-    copy_with_flipped_build_id(source.path, replacement);
-    std::filesystem::rename(replacement, path_buffer);
+    install_at_pathname(source.path);
+    expect_lookup(true, "find_symbol rejected a pathname replacement with a matching Build ID");
 
-    resolved = nullptr;
-    if(rocprofiler::rocattach::find_symbol(
-           child, resolved, path_buffer, ATTACH_SYMBOL_NAME, pathname_only))
-    {
-        std::cerr << "find_symbol unexpectedly accepted a replacement ELF whose only difference "
-                     "is its Build ID\n";
-        std::exit(1);
-    }
+    auto flipped = path_buffer + ".flipped";
+    copy_with_flipped_build_id(source.path, flipped);
+    install_at_pathname(flipped);
+    expect_lookup(false,
+                  "find_symbol accepted a replacement whose only difference is its Build ID");
 
-    std::filesystem::copy_file(
-        no_build_id.path, replacement, std::filesystem::copy_options::overwrite_existing);
-    std::filesystem::rename(replacement, path_buffer);
-    resolved = nullptr;
-    if(rocprofiler::rocattach::find_symbol(
-           child, resolved, path_buffer, ATTACH_SYMBOL_NAME, pathname_only))
-    {
-        std::cerr << "find_symbol unexpectedly accepted a replacement ELF without a Build ID\n";
-        std::exit(1);
-    }
+    install_at_pathname(no_build_id.path);
+    expect_lookup(false, "find_symbol accepted a replacement without a Build ID");
 }
 }  // namespace
 
@@ -517,7 +490,7 @@ main(int argc, char** argv)
     }
     expect_ambiguous_basename_fails();
     expect_malformed_mapped_elf_fails();
-    expect_root_fallback_validates_build_id(libraries.at(0), libraries.at(4));
+    expect_pathname_lookup_validates_build_id(libraries.at(0), libraries.at(4));
 
     std::cout << "Test PASSED: target ELF resolver resolved exact mapped libraries and rejected "
                  "ambiguous and malformed mappings\n";

--- a/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
@@ -323,7 +323,7 @@ copy_with_flipped_build_id(const std::string& source, const std::string& destina
     }
 }
 
-void
+bool
 expect_pathname_lookup_validates_build_id(const loaded_library& source,
                                           const loaded_library& no_build_id)
 {
@@ -334,7 +334,7 @@ expect_pathname_lookup_validates_build_id(const loaded_library& source,
     if(fd < 0)
     {
         std::cerr << "mkstemp failed for replaced ELF fixture\n";
-        std::exit(1);
+        return false;
     }
     close(fd);
 
@@ -349,7 +349,7 @@ expect_pathname_lookup_validates_build_id(const loaded_library& source,
     if(symbol == nullptr)
     {
         std::cerr << "dlsym failed for " << path_buffer << "::" << ATTACH_SYMBOL_NAME << '\n';
-        std::exit(1);
+        return false;
     }
     auto expected = reinterpret_cast<uintptr_t>(symbol);
 
@@ -358,21 +358,21 @@ expect_pathname_lookup_validates_build_id(const loaded_library& source,
     if(stat(path_buffer.c_str(), &mapped_identity) != 0)
     {
         std::cerr << "stat failed for " << path_buffer << '\n';
-        std::exit(1);
+        return false;
     }
 
     auto done_pipe = std::array<int, 2>{};
     if(pipe(done_pipe.data()) != 0)
     {
         std::cerr << "pipe failed for cross-process Build ID test\n";
-        std::exit(1);
+        return false;
     }
 
     auto child = fork();
     if(child < 0)
     {
         std::cerr << "fork failed for cross-process Build ID test\n";
-        std::exit(1);
+        return false;
     }
     if(child == 0)
     {
@@ -413,8 +413,9 @@ expect_pathname_lookup_validates_build_id(const loaded_library& source,
             installed.st_ino == mapped_identity.st_ino))
         {
             std::cerr << "replacing " << path_buffer << " did not change its inode\n";
-            std::exit(1);
+            return false;
         }
+        return true;
     };
 
     // Forces the /proc/<pid>/root path instead of /proc/<pid>/map_files.
@@ -427,26 +428,37 @@ expect_pathname_lookup_validates_build_id(const loaded_library& source,
         if(did_resolve != should_resolve)
         {
             std::cerr << description << '\n';
-            std::exit(1);
+            return false;
         }
         if(should_resolve && reinterpret_cast<uintptr_t>(resolved) != expected)
         {
             std::cerr << "find_symbol resolved the wrong address: " << description << '\n';
-            std::exit(1);
+            return false;
         }
+        return true;
     };
 
-    install_at_pathname(source.path);
-    expect_lookup(true, "find_symbol rejected a pathname replacement with a matching Build ID");
+    if(!install_at_pathname(source.path)) return false;
+    if(!expect_lookup(true, "find_symbol rejected a pathname replacement with a matching Build ID"))
+    {
+        return false;
+    }
 
     auto flipped = path_buffer + ".flipped";
     copy_with_flipped_build_id(source.path, flipped);
-    install_at_pathname(flipped);
-    expect_lookup(false,
-                  "find_symbol accepted a replacement whose only difference is its Build ID");
+    if(!install_at_pathname(flipped)) return false;
+    if(!expect_lookup(false,
+                      "find_symbol accepted a replacement whose only difference is its Build ID"))
+    {
+        return false;
+    }
 
-    install_at_pathname(no_build_id.path);
-    expect_lookup(false, "find_symbol accepted a replacement without a Build ID");
+    if(!install_at_pathname(no_build_id.path)) return false;
+    if(!expect_lookup(false, "find_symbol accepted a replacement without a Build ID"))
+    {
+        return false;
+    }
+    return true;
 }
 }  // namespace
 
@@ -490,7 +502,7 @@ main(int argc, char** argv)
     }
     expect_ambiguous_basename_fails();
     expect_malformed_mapped_elf_fails();
-    expect_pathname_lookup_validates_build_id(libraries.at(0), libraries.at(4));
+    if(!expect_pathname_lookup_validates_build_id(libraries.at(0), libraries.at(4))) return 1;
 
     std::cout << "Test PASSED: target ELF resolver resolved exact mapped libraries and rejected "
                  "ambiguous and malformed mappings\n";


### PR DESCRIPTION
## Motivation

When rocattach resolves a symbol in a target process, it first attempts to open the exact mapped ELF through `/proc/<pid>/map_files`

That path may be unavailable because of kernel configuration or capability restrictions. rocattach then falls back to opening the mapped pathname through `/proc/<pid>/root`.

In OverlayFS containers, the device and inode reported by `/proc/<pid>/maps` can describe the underlying backing file, while `/proc/<pid>/root` opens the overlay-visible file. The two paths may therefore refer to the same ELF content while reporting different device/inode metadata, causing the existing fallback to reject valid container attachment.

This change preserves device/inode equality as the fast path and validates a metadata-mismatched `/proc/<pid>/root` fallback by comparing the candidate ELF’s GNU Build ID with the Build ID in the target’s currently mapped image.

## Technical Details
### `symbol_lookup.cpp`

* Preserve `/proc/<pid>/map_files` with strict device/inode validation as the preferred path.
* Fall back to `/proc/<pid>/root/<mapped-path>` when `map_files` is unavailable.
* On device/inode mismatch:
  * Read the GNU Build ID from the candidate ELF and the target’s mapped image.
  * Accept the fallback only when the Build IDs match.
* Apply consistent `PT_NOTE` validation to both file and memory reads.

### `symbol_lookup.hpp`

* Add an internal option for tests to bypass `map_files` and directly exercise the pathname fallback.

### `tests/rocattach`

* Add test `expect_root_fallback_validates_build_id` to verify that
  * Different inode, same Build ID → accept.
  * Different inode, different Build ID → reject.
  * Different inode, no Build ID → reject.
  
 It  forces `/proc/<pid>/root` lookup instead of `/proc/<pid>/map_files`, which is precisely the branch where device/inode mismatch is allowed only after Build-ID validation.

## Issue Tracking

JIRA ID: ROCM-28593

## Test Plan

Added new tests in tests/rocattach

## Test Result

New and existing tests pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
