### PR TITLE
[rocjitsu] Prefer globally unused VGPR scratch

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.cpp
@@ -28,7 +28,7 @@ enum class OperandExpansionKind { Use, Def };
 
 void expand_operand_register(RegisterSet &set, const Instruction &inst, const Operand &operand,
                              RegisterRef ref, const Gfx1250VgprMsbAnalysis *vgpr_msb,
-                             OperandExpansionKind kind) {
+                             OperandExpansionKind kind, UnknownVgprDefPolicy unknown_vgpr_defs) {
   if (vgpr_msb == nullptr || ref.cls != RegClass::VGPR) {
     set.expand(ref);
     return;
@@ -42,10 +42,10 @@ void expand_operand_register(RegisterSet &set, const Instruction &inst, const Op
   }
 
   // A dynamic MODE write or disagreeing CFG predecessors can leave the bank
-  // unknown. The instruction accesses exactly ONE of these four physical tuples.
-  if (kind == OperandExpansionKind::Use) {
-    // May-read: treating all four as possibly-read is the sound path-insensitive
-    // over-approximation for liveness.
+  // unknown. The instruction accesses exactly ONE of these four physical
+  // tuples. A may-read, and a must-write recorded for whole-kernel usage rather
+  // than for kills, both need the sound over-approximation.
+  if (kind == OperandExpansionKind::Use || unknown_vgpr_defs == UnknownVgprDefPolicy::ExpandAll) {
     for (uint16_t candidate = 0; candidate < 4; ++candidate) {
       RegisterRef possible = ref;
       possible.index = static_cast<uint16_t>(possible.index + candidate * 256u);
@@ -68,15 +68,17 @@ void expand_operand_register(RegisterSet &set, const Instruction &inst, const Op
 }
 
 void add_def(InstDefUse &du, const Instruction &inst, const Operand &operand, RegisterRef ref,
-             const Gfx1250VgprMsbAnalysis *vgpr_msb) {
-  expand_operand_register(du.defs, inst, operand, ref, vgpr_msb, OperandExpansionKind::Def);
+             const Gfx1250VgprMsbAnalysis *vgpr_msb, UnknownVgprDefPolicy unknown_vgpr_defs) {
+  expand_operand_register(du.defs, inst, operand, ref, vgpr_msb, OperandExpansionKind::Def,
+                          unknown_vgpr_defs);
   if (is_exec_masked_def(ref))
     du.has_exec_masked_vector_def = true;
 }
 
 } // namespace
 
-InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vgpr_msb) {
+InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vgpr_msb,
+                       UnknownVgprDefPolicy unknown_vgpr_defs) {
   has_predicated_def = inst.flags() & PREDICATED_DEF;
 
   for (int i = 0; i < inst.num_dst_operands(); ++i) {
@@ -84,8 +86,12 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
     if (op == nullptr)
       continue;
     if (auto ref = op->to_register_ref())
-      add_def(*this, inst, *op, *ref, vgpr_msb);
+      add_def(*this, inst, *op, *ref, vgpr_msb, unknown_vgpr_defs);
   }
+  // No generated instruction currently reports an implicit VGPR def. If one is
+  // added for gfx1250, it must expose an operand with a VGPR-MSB role so global
+  // usage can resolve the physical bank instead of recording only the raw low
+  // eight-bit index.
   inst.implicit_defs(defs);
 
   for (int i = 0; i < inst.num_src_operands(); ++i) {
@@ -93,7 +99,8 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
     if (op == nullptr)
       continue;
     if (auto ref = op->to_register_ref())
-      expand_operand_register(uses, inst, *op, *ref, vgpr_msb, OperandExpansionKind::Use);
+      expand_operand_register(uses, inst, *op, *ref, vgpr_msb, OperandExpansionKind::Use,
+                              unknown_vgpr_defs);
   }
 
   if (vgpr_msb == nullptr) {
@@ -116,7 +123,8 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
     if (op == nullptr)
       continue;
     if (auto ref = op->to_register_ref())
-      expand_operand_register(uses, inst, *op, *ref, vgpr_msb, OperandExpansionKind::Use);
+      expand_operand_register(uses, inst, *op, *ref, vgpr_msb, OperandExpansionKind::Use,
+                              unknown_vgpr_defs);
   }
 
   // The flat hook also reports encoded-field implicit reads with no backing

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.h
@@ -19,12 +19,19 @@ namespace rocjitsu {
 class Instruction;
 class Gfx1250VgprMsbAnalysis;
 
+/// @brief How to represent a gfx1250 VGPR definition whose physical bank is unknown.
+enum class UnknownVgprDefPolicy : uint8_t {
+  Omit,      ///< Do not claim a must-write for liveness kill computation.
+  ExpandAll, ///< Mark every possible physical tuple for whole-kernel usage scans.
+};
+
 /// @brief Registers read and written by one decoded instruction.
 class InstDefUse {
 public:
   /// @brief Extract explicit operand register refs.
   /// @param inst Decoded instruction whose operands have stable lifetimes.
-  InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vgpr_msb = nullptr);
+  InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vgpr_msb = nullptr,
+             UnknownVgprDefPolicy unknown_vgpr_defs = UnknownVgprDefPolicy::Omit);
 
   RegisterSet defs;                        ///< Registers overwritten by the instruction.
   RegisterSet uses;                        ///< Registers read before the instruction writes defs.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
@@ -7,13 +7,16 @@
 #include "rocjitsu/analysis/gfx1250_vgpr_msb.h"
 #include "rocjitsu/code/basic_block.h"
 #include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/isa/operand.h"
 #include "util/bit.h"
 
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstring>
 #include <deque>
 #include <stdexcept>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 
@@ -76,6 +79,55 @@ void dfs_reverse_post_order(const BasicBlock &start,
   return kills;
 }
 
+[[nodiscard]] std::optional<uint32_t> text_word_at(std::span<const uint8_t> text, uint64_t offset) {
+  if (text.empty() || offset + sizeof(uint32_t) > text.size())
+    return std::nullopt;
+  uint32_t word = 0;
+  std::memcpy(&word, text.data() + offset, sizeof(word));
+  return word;
+}
+
+[[nodiscard]] bool may_access_vgprs_indirectly(const Instruction &inst,
+                                               std::span<const uint8_t> text) {
+  const std::string_view mnemonic = inst.mnemonic();
+  // TODO: Move indirect-VGPR access properties into decoded instruction
+  // metadata so future ISA variants cannot bypass this completeness gate.
+  if (mnemonic.starts_with("v_movrel") || mnemonic.starts_with("v_swaprel") ||
+      mnemonic == "s_set_gpr_idx_on") {
+    return true;
+  }
+
+  // GPR indexing can also be enabled by writing MODE.GPR_IDX_EN through a
+  // generic S_SETREG form. Dynamic writes covering bit 27 fail closed; immediate
+  // writes can stay eligible when their decoded literal proves the bit is clear.
+  const bool is_dynamic_setreg = mnemonic == "s_setreg_b32";
+  const bool is_immediate_setreg = mnemonic == "s_setreg_imm32_b32";
+  if (!is_dynamic_setreg && !is_immediate_setreg) {
+    return false;
+  }
+  const Operand *hwreg_operand = inst.dst_operand(0);
+  if (hwreg_operand == nullptr)
+    return true;
+  const uint16_t hwreg = static_cast<uint16_t>(hwreg_operand->encoding_value());
+  const uint16_t id = hwreg & 0x3fu;
+  const uint16_t begin = (hwreg >> 6) & 0x1fu;
+  const uint16_t width = static_cast<uint16_t>(((hwreg >> 11) & 0x1fu) + 1u);
+  constexpr uint16_t kModeHwreg = 1;
+  constexpr uint16_t kGprIdxEnableBit = 27;
+  if (id != kModeHwreg || begin > kGprIdxEnableBit ||
+      static_cast<uint32_t>(begin) + width <= kGprIdxEnableBit) {
+    return false;
+  }
+
+  if (is_dynamic_setreg)
+    return true;
+
+  const auto literal = text_word_at(text, inst.src_loc() + sizeof(uint32_t));
+  if (!literal || inst.size() < 2 * static_cast<int>(sizeof(uint32_t)))
+    return true;
+  return ((*literal >> (kGprIdxEnableBit - begin)) & 1u) != 0;
+}
+
 } // namespace
 
 LivenessAnalysis::LivenessAnalysis(UnavailableTag) : available_(false) {}
@@ -107,7 +159,23 @@ LivenessAnalysis::LivenessAnalysis(KernelBlockScope blocks, LivenessAnalysisOpti
   min_free_vgpr_ = options.min_free_vgpr;
   max_free_vgpr_ =
       static_cast<uint16_t>(std::min<size_t>(options.max_free_vgpr, REGISTER_SET_MAX_VGPRS));
-  analyze(blocks, options, extra_edges);
+  deferred_blocks_.assign(blocks.begin(), blocks.end());
+  scoped_blocks_.reserve(blocks.size());
+  for (const BasicBlock *block : blocks) {
+    if (block != nullptr)
+      scoped_blocks_.insert(block);
+  }
+  deferred_extra_edges_.assign(extra_edges.begin(), extra_edges.end());
+  deferred_live_before_instructions_.assign(options.live_before_instructions.begin(),
+                                            options.live_before_instructions.end());
+  deferred_restrict_live_before_to_instructions_ = options.restrict_live_before_to_instructions;
+
+  const KernelBlockScope deferred_scope(deferred_blocks_);
+  if (options.arch == ROCJITSU_CODE_ARCH_GFX1250 && options.entry_block != nullptr) {
+    gfx1250_vgpr_msb_ = std::make_unique<Gfx1250VgprMsbAnalysis>(
+        deferred_scope, options.entry_block, deferred_extra_edges_, options.text);
+  }
+  collect_global_register_usage(deferred_scope, options.text);
 }
 
 LivenessAnalysis::~LivenessAnalysis() = default;
@@ -119,12 +187,35 @@ void LivenessAnalysis::require_available() const {
     throw std::logic_error("liveness query from a rule marked liveness-free");
 }
 
-void LivenessAnalysis::analyze(KernelBlockScope blocks, const LivenessAnalysisOptions &options,
-                               std::span<const ScopedCfgEdge> extra_edges) {
-  if (options.arch == ROCJITSU_CODE_ARCH_GFX1250 && options.entry_block != nullptr) {
-    gfx1250_vgpr_msb_ = std::make_unique<Gfx1250VgprMsbAnalysis>(blocks, options.entry_block,
-                                                                 extra_edges, options.text);
+void LivenessAnalysis::ensure_analyzed() const {
+  require_available();
+  if (analyzed_)
+    return;
+
+  analyze(KernelBlockScope(deferred_blocks_), deferred_restrict_live_before_to_instructions_,
+          deferred_live_before_instructions_, deferred_extra_edges_);
+  analyzed_ = true;
+}
+
+void LivenessAnalysis::collect_global_register_usage(KernelBlockScope blocks,
+                                                     std::span<const uint8_t> text) {
+  for (BasicBlock *block : blocks) {
+    if (block == nullptr)
+      continue;
+    for (const Instruction &inst : block->instructions()) {
+      if (may_access_vgprs_indirectly(inst, text))
+        global_vgpr_usage_is_complete_ = false;
+
+      const InstDefUse accesses(inst, gfx1250_vgpr_msb_.get(), UnknownVgprDefPolicy::ExpandAll);
+      globally_used_registers_ |= accesses.defs;
+      globally_used_registers_ |= accesses.uses;
+    }
   }
+}
+
+void LivenessAnalysis::analyze(KernelBlockScope blocks, bool restrict_live_before_to_instructions,
+                               std::span<const Instruction *const> live_before_instructions,
+                               std::span<const ScopedCfgEdge> extra_edges) const {
   liveness_.resize(blocks.size());
   block_index_.reserve(blocks.size());
   for (size_t i = 0; i < blocks.size(); ++i) {
@@ -132,11 +223,11 @@ void LivenessAnalysis::analyze(KernelBlockScope blocks, const LivenessAnalysisOp
       block_index_.emplace(blocks[i], i);
   }
 
-  const bool filter_live_before = options.restrict_live_before_to_instructions;
+  const bool filter_live_before = restrict_live_before_to_instructions;
   std::unordered_set<const Instruction *> requested_live_before;
   if (filter_live_before) {
-    requested_live_before.reserve(options.live_before_instructions.size());
-    for (const Instruction *inst : options.live_before_instructions) {
+    requested_live_before.reserve(live_before_instructions.size());
+    for (const Instruction *inst : live_before_instructions) {
       if (inst != nullptr)
         requested_live_before.insert(inst);
     }
@@ -265,7 +356,7 @@ void LivenessAnalysis::analyze(KernelBlockScope blocks, const LivenessAnalysisOp
 }
 
 const BlockLiveness &LivenessAnalysis::block_liveness(const BasicBlock &block) const {
-  require_available();
+  ensure_analyzed();
   auto it = block_index_.find(&block);
   if (it == block_index_.end())
     throw std::out_of_range("block_liveness: block was not part of this analysis");
@@ -273,12 +364,12 @@ const BlockLiveness &LivenessAnalysis::block_liveness(const BasicBlock &block) c
 }
 
 bool LivenessAnalysis::has_live_before(const Instruction &inst) const {
-  require_available();
+  ensure_analyzed();
   return live_before_.contains(&inst);
 }
 
 const RegisterSet &LivenessAnalysis::live_before(const Instruction &inst) const {
-  require_available();
+  ensure_analyzed();
   auto it = live_before_.find(&inst);
   return it != live_before_.end() ? it->second : empty_;
 }
@@ -295,10 +386,33 @@ std::optional<uint8_t> LivenessAnalysis::vgpr_msb_bank_before(const Instruction 
   return gfx1250_vgpr_msb_->bank_before(inst, role);
 }
 
+std::optional<uint16_t>
+LivenessAnalysis::find_globally_unused_vgpr_run(const Instruction *inst, uint16_t count,
+                                                uint16_t search_start, uint16_t base_alignment,
+                                                uint16_t available_count) const {
+  require_available();
+  assert(count > 0 && "Must request at least one register");
+  assert(base_alignment > 0 && "Register tuple alignment must be non-zero");
+  if (inst == nullptr || !global_vgpr_usage_is_complete_ ||
+      !scoped_blocks_.contains(inst->parent())) {
+    return std::nullopt;
+  }
+  const size_t first_candidate = std::max<size_t>(search_start, min_free_vgpr_);
+  const size_t limit = std::min<size_t>(available_count, max_free_vgpr_);
+  for (size_t base = util::align_up(first_candidate, static_cast<size_t>(base_alignment));
+       base + count <= limit; base += base_alignment) {
+    if (!any_live_in_range(globally_used_registers_, RegClass::VGPR, static_cast<uint16_t>(base),
+                           count)) {
+      return static_cast<uint16_t>(base);
+    }
+  }
+  return std::nullopt;
+}
+
 std::optional<uint16_t> LivenessAnalysis::find_free_run(const Instruction *inst, uint16_t count,
                                                         uint16_t search_start,
                                                         uint16_t base_alignment) const {
-  require_available();
+  ensure_analyzed();
   assert(count > 0 && "Must request at least one register");
   assert(base_alignment > 0 && "Register tuple alignment must be non-zero");
   auto live_it = live_before_.find(inst);
@@ -317,7 +431,7 @@ std::optional<uint16_t> LivenessAnalysis::find_free_run(const Instruction *inst,
 
 std::optional<uint16_t> LivenessAnalysis::find_free_sgpr_pair(const Instruction *inst,
                                                               uint16_t search_start) const {
-  require_available();
+  ensure_analyzed();
   auto live_it = live_before_.find(inst);
   if (live_it == live_before_.end())
     return std::nullopt;
@@ -335,7 +449,7 @@ std::optional<uint16_t> LivenessAnalysis::find_free_sgpr_pair(const Instruction 
 
 std::optional<uint16_t> LivenessAnalysis::find_free_sgpr(const Instruction *inst,
                                                          uint16_t search_start) const {
-  require_available();
+  ensure_analyzed();
   auto live_it = live_before_.find(inst);
   if (live_it == live_before_.end())
     return std::nullopt;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
@@ -23,6 +23,7 @@
 #include <optional>
 #include <span>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace rocjitsu {
@@ -71,7 +72,7 @@ struct LivenessAnalysisOptions {
   /// @brief Kernel entry block where architectural VGPR_MSB state is zero.
   BasicBlock *entry_block = nullptr;
 
-  /// @brief Lowest VGPR index that find_free_run() may return.
+  /// @brief Lowest VGPR index that a VGPR scratch query may return.
   ///
   /// @details This is a debug-oriented allocation floor, not a dataflow fact.
   /// The computed live-before sets remain the normal kernel liveness result,
@@ -79,7 +80,7 @@ struct LivenessAnalysisOptions {
   /// range to test whether semantic lowerings clobber guest registers.
   uint16_t min_free_vgpr = 0;
 
-  /// @brief Exclusive destination-ISA limit for VGPR scratch allocation.
+  /// @brief Exclusive destination-ISA limit for all VGPR scratch queries.
   ///
   /// @details RegisterSet may track more VGPR indices than a particular
   /// destination encoding can name. Keeping this allocation ceiling separate
@@ -89,9 +90,10 @@ struct LivenessAnalysisOptions {
 
   /// @brief Restrict instruction-level live-before materialization to selected instructions.
   ///
-  /// @details Block-level dataflow still analyzes every instruction in the
-  /// kernel scope. This option only controls which per-instruction RegisterSet
-  /// snapshots are stored for live_before()/find_free_*() queries.
+  /// @details When a query first requests CFG liveness, block-level dataflow
+  /// analyzes every instruction in the kernel scope. This option only controls
+  /// which per-instruction RegisterSet snapshots are then stored for
+  /// live_before()/find_free_*() queries.
   bool restrict_live_before_to_instructions = false;
 
   /// @brief Instruction pointers that need live-before snapshots when filtering is enabled.
@@ -122,15 +124,22 @@ struct LivenessAnalysisOptions {
 /// walking into other decoded code.
 [[nodiscard]] std::vector<const BasicBlock *> reverse_post_order(KernelBlockScope blocks);
 
-/// @brief Backward SGPR/VGPR/ACC_VGPR liveness over one decoded kernel CFG scope.
+/// @brief Kernel-global register usage plus deferred backward CFG liveness.
+///
+/// @details Construction eagerly resolves gfx1250 VGPR banks and scans global
+/// register usage. The backward CFG fixed point and live-before snapshots are
+/// materialized on the first query that needs them. Queries on one analysis
+/// object are not thread-safe because const query methods may populate that
+/// deferred cache.
 class LivenessAnalysis {
 public:
-  /// @brief Compute liveness for one kernel's block set.
+  /// @brief Prepare register analysis for one kernel's block set.
   ///
   /// @details Successor/predecessor edges that leave @p blocks are ignored.
   /// DBT callers must pass only the blocks reachable from the kernel descriptor
   /// entry being translated, not every block decoded from the containing code
-  /// object.
+  /// object. The pointed-to BasicBlocks and their Instructions must outlive this
+  /// analysis because deferred CFG queries retain and later dereference them.
   /// @param blocks Blocks in one kernel CFG scope.
   LivenessAnalysis(KernelBlockScope blocks, LivenessAnalysisOptions options = {},
                    std::span<const ScopedCfgEdge> extra_edges = {});
@@ -148,6 +157,12 @@ public:
   /// std::logic_error so an incorrectly classified rule cannot silently use
   /// missing liveness data.
   [[nodiscard]] static LivenessAnalysis unavailable();
+
+  /// @brief Whether a query has materialized the deferred backward CFG state.
+  ///
+  /// @details This is useful for qualification and tests that must verify the
+  /// kernel-unused allocation path did not force the expensive fixed point.
+  [[nodiscard]] bool has_materialized_cfg_liveness() const { return analyzed_; }
 
   /// @brief Block liveness by block object.
   [[nodiscard]] const BlockLiveness &block_liveness(const BasicBlock &block) const;
@@ -168,6 +183,28 @@ public:
   /// @returns nullopt when this is not a gfx1250 analysis or the state is ambiguous.
   [[nodiscard]] std::optional<uint8_t> vgpr_msb_bank_before(const Instruction &inst,
                                                             amdgpu::VgprMsbRole role) const;
+
+  /// @brief Find a VGPR tuple that no instruction in the kernel reads or writes.
+  ///
+  /// @details This query is cheaper and stronger than point liveness: the
+  /// selected tuple is unused everywhere, so it is dead at every instruction
+  /// in the decoded source scope. It does not force the deferred CFG
+  /// live-before computation. This conclusion requires a complete decoded
+  /// kernel scope, including reachable callees supplied through scoped edges.
+  /// Scopes with relative or GPR-indexed VGPR access fail closed because encoded
+  /// operands do not identify every physical register they may touch.
+  ///
+  /// @param inst Instruction that will use the tuple. It must belong to the
+  ///        analyzed scope.
+  /// @param count Number of consecutive VGPRs required.
+  /// @param search_start Lowest candidate base requested by the caller.
+  /// @param base_alignment Required tuple-base alignment.
+  /// @param available_count Exclusive upper bound imposed by the current
+  ///        descriptor allocation.
+  [[nodiscard]] std::optional<uint16_t> find_globally_unused_vgpr_run(
+      const Instruction *inst, uint16_t count, uint16_t search_start = 0,
+      uint16_t base_alignment = 1,
+      uint16_t available_count = static_cast<uint16_t>(REGISTER_SET_MAX_VGPRS)) const;
 
   /// @brief Find N consecutive dead VGPRs immediately before an instruction.
   ///
@@ -204,16 +241,31 @@ private:
   /// @throws std::logic_error if liveness data was intentionally not built.
   void require_available() const;
 
-  void analyze(KernelBlockScope blocks, const LivenessAnalysisOptions &options,
-               std::span<const ScopedCfgEdge> extra_edges);
+  /// @brief Materialize CFG live-before state on the first query that needs it.
+  void ensure_analyzed() const;
+
+  /// @brief Collect whole-kernel register use without running backward dataflow.
+  void collect_global_register_usage(KernelBlockScope blocks, std::span<const uint8_t> text);
+
+  void analyze(KernelBlockScope blocks, bool restrict_live_before_to_instructions,
+               std::span<const Instruction *const> live_before_instructions,
+               std::span<const ScopedCfgEdge> extra_edges) const;
 
   bool available_ = true;
+  mutable bool analyzed_ = false;
+  bool global_vgpr_usage_is_complete_ = true;
   uint16_t min_free_vgpr_ = 0;
   uint16_t max_free_vgpr_ = 0;
   std::unique_ptr<Gfx1250VgprMsbAnalysis> gfx1250_vgpr_msb_;
-  std::vector<BlockLiveness> liveness_;
-  std::unordered_map<const BasicBlock *, size_t> block_index_;
-  std::unordered_map<const Instruction *, RegisterSet> live_before_;
+  RegisterSet globally_used_registers_;
+  std::vector<BasicBlock *> deferred_blocks_;
+  std::unordered_set<const BasicBlock *> scoped_blocks_;
+  bool deferred_restrict_live_before_to_instructions_ = false;
+  std::vector<const Instruction *> deferred_live_before_instructions_;
+  std::vector<ScopedCfgEdge> deferred_extra_edges_;
+  mutable std::vector<BlockLiveness> liveness_;
+  mutable std::unordered_map<const BasicBlock *, size_t> block_index_;
+  mutable std::unordered_map<const Instruction *, RegisterSet> live_before_;
   static constexpr RegisterSet empty_{};
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_scratch.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_scratch.cpp
@@ -58,6 +58,27 @@ SemanticScratchAllocator::acquire_vgprs(const SemanticScratchRequest &request) {
     return {.lease = std::nullopt, .failure = SemanticScratchFailure::InvalidRequest};
   }
 
+  // A register unused by the decoded kernel is stronger than a point-liveness
+  // result: it is dead at every source rewrite boundary. Prefer such a tuple
+  // inside the descriptor allocation so the common case avoids CFG live-before
+  // computation and descriptor growth.
+  const uint16_t allocated_vgprs =
+      static_cast<uint16_t>(std::min<uint32_t>(context_.num_vgprs, policy_.max_vgprs));
+  uint16_t unused_search_start = 0;
+  while (auto unused = liveness_.find_globally_unused_vgpr_run(
+             &inst_, request.count, unused_search_start, request.alignment, allocated_vgprs)) {
+    if (window_is_allowed(*unused, request, allocated_vgprs)) {
+      context_.require_vgprs(static_cast<uint32_t>(*unused) + request.count);
+      return {.lease = SemanticScratchLease{.reg_class = RegClass::VGPR,
+                                            .base = *unused,
+                                            .count = request.count,
+                                            .spilled = false,
+                                            .spill_offset = 0},
+              .failure = SemanticScratchFailure::None};
+    }
+    unused_search_start = static_cast<uint16_t>(*unused + request.alignment);
+  }
+
   uint16_t search_start = 0;
   while (auto free =
              liveness_.find_free_run(&inst_, request.count, search_start, request.alignment)) {
@@ -78,8 +99,6 @@ SemanticScratchAllocator::acquire_vgprs(const SemanticScratchRequest &request) {
   if (!request.allow_spill)
     return {.lease = std::nullopt, .failure = SemanticScratchFailure::NoRegisterWindow};
 
-  const uint16_t allocated_vgprs =
-      static_cast<uint16_t>(std::min<uint32_t>(context_.num_vgprs, policy_.max_vgprs));
   std::optional<uint16_t> victim;
   if (request.preferred_victim_base &&
       window_is_allowed(*request.preferred_victim_base, request, allocated_vgprs)) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_scratch.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_scratch.h
@@ -115,7 +115,7 @@ public:
   SemanticScratchAllocator(const Instruction &inst, const LivenessAnalysis &liveness,
                            TranslationContext &context, SemanticScratchPolicy policy);
 
-  /// @brief Prefer dead VGPRs, then borrow and spill an allowed guest window.
+  /// @brief Prefer kernel-unused VGPRs, then site-dead or spilled guest windows.
   /// @details Rejects a spill victim in a dynamic-stack kernel, while allowing
   ///          a genuinely free VGPR window that does not need private storage.
   [[nodiscard]] SemanticScratchResult acquire_vgprs(const SemanticScratchRequest &request);

--- a/emulation/rocjitsu/lib/util/include/util/intrusive_list.h
+++ b/emulation/rocjitsu/lib/util/include/util/intrusive_list.h
@@ -58,6 +58,12 @@ public:
   {
     return this->parent_;
   }
+
+  const ParentT *parent() const
+    requires(metaprogramming::IsNonVoid<ParentT>)
+  {
+    return this->parent_;
+  }
 };
 
 template <typename T, typename... Options> class IListIterator {

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -12,6 +12,8 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna3/builders.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna3/mubuf.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna3/opcodes.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna4/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna4/opcodes.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna4/operand.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/builders.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/opcodes.h"
@@ -2730,6 +2732,7 @@ TEST(LivenessAnalysis, UnavailableQueriesFailClosed) {
 
   EXPECT_THROW((void)liveness.has_live_before(instruction), std::logic_error);
   EXPECT_THROW((void)liveness.live_before(instruction), std::logic_error);
+  EXPECT_THROW((void)liveness.find_globally_unused_vgpr_run(&instruction, 1), std::logic_error);
 }
 
 TEST(LivenessAnalysis, ReportsWhetherLiveBeforeSnapshotWasMaterialized) {
@@ -2786,6 +2789,8 @@ TEST(LivenessAnalysis, Gfx1250VgprMsbResolvesPhysicalRegisterBank) {
   ASSERT_NE(instruction, blocks.front()->instructions().end());
   EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Src0), 2);
   EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Dst), 2);
+  EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&*instruction, 1, 1, 1, 2), 1)
+      << "a known bank-2 access must not make the raw low-bank tuple look used";
   EXPECT_TRUE(liveness.is_live_before(*instruction, {RegClass::VGPR, 513, 1}));
   EXPECT_FALSE(liveness.is_live_before(*instruction, {RegClass::VGPR, 1, 1}));
 }
@@ -2970,6 +2975,211 @@ TEST(LivenessAnalysis, Gfx1250ImplicitVgprUseUnknownBankReadsEveryCandidate) {
     EXPECT_TRUE(liveness.is_live_before(*instruction,
                                         {RegClass::VGPR, static_cast<uint16_t>(1 + bank * 256), 1}))
         << "unknown-bank implicit read must may-read candidate bank " << bank;
+}
+
+TEST(LivenessAnalysis, Gfx1250UnknownBankDefMakesEveryCandidateGloballyUsed) {
+  // A dynamic MODE write leaves the destination bank ambiguous. Whole-kernel
+  // usage must reserve all four candidate tuples, while backward liveness must
+  // not pretend the one physical write kills all four.
+  constexpr uint16_t kModeAllBanksHwreg = 1u | (12u << 6) | (7u << 11);
+  constexpr auto setreg =
+      gfx1250::build_sopk(gfx1250::kSSetregB32Sopk, {.simm16 = kModeAllBanksHwreg, .sdst = 0});
+  constexpr auto move = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 1});
+  constexpr auto end = gfx1250::build_sopp(gfx1250::kSEndpgmSopp);
+  TestCodeObject co({setreg[0], move[0], end[0]});
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_EQ(blocks.size(), 1u);
+  auto scope = block_scope(blocks);
+
+  LivenessAnalysisOptions options;
+  options.arch = ROCJITSU_CODE_ARCH_GFX1250;
+  options.entry_block = scope.front();
+  options.text = text_span(co);
+  LivenessAnalysis liveness(KernelBlockScope(scope), options);
+
+  auto instruction = blocks.front()->instructions().begin();
+  ++instruction;
+  ASSERT_NE(instruction, blocks.front()->instructions().end());
+  EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Dst), std::nullopt);
+  for (uint16_t bank = 0; bank < 4; ++bank) {
+    const uint16_t candidate = static_cast<uint16_t>(1 + bank * 256);
+    EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&*instruction, 1, candidate, 1,
+                                                     static_cast<uint16_t>(candidate + 1)),
+              std::nullopt)
+        << "unknown-bank definition must reserve candidate bank " << bank;
+  }
+  EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&*instruction, 1, 0, 1, 4), 0);
+  EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&*instruction, 1, 2, 1, 4), 2);
+
+  const BlockLiveness &state = liveness.block_liveness(*blocks.front());
+  EXPECT_FALSE(state.kill.contains({RegClass::VGPR, 1, 1}));
+  EXPECT_FALSE(state.kill.contains({RegClass::VGPR, 257, 1}));
+}
+
+TEST(LivenessAnalysis, Gfx1250RelativeVgprAccessDisablesGlobalUnusedQuery) {
+  // M0 can redirect the encoded v0 source to any relative tuple, including v1
+  // which would otherwise appear globally unused.
+  constexpr auto move = gfx1250::build_vop1(gfx1250::kVMovrelsB32Vop1, {.src0 = 0, .vdst = 2});
+  constexpr auto end = gfx1250::build_sopp(gfx1250::kSEndpgmSopp);
+  TestCodeObject co({move[0], end[0]});
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_EQ(blocks.size(), 1u);
+  auto scope = block_scope(blocks);
+
+  LivenessAnalysisOptions options;
+  options.arch = ROCJITSU_CODE_ARCH_GFX1250;
+  options.entry_block = scope.front();
+  options.text = text_span(co);
+  LivenessAnalysis liveness(KernelBlockScope(scope), options);
+
+  const Instruction &instruction = *blocks.front()->instructions().begin();
+  EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&instruction, 1, 1, 1, 2), std::nullopt);
+  EXPECT_FALSE(liveness.has_materialized_cfg_liveness());
+}
+
+TEST(LivenessAnalysis, Gfx1250SwaprelDisablesGlobalUnusedQuery) {
+  constexpr auto swap = gfx1250::build_vop1(gfx1250::kVSwaprelB32Vop1, {.src0 = 0, .vdst = 2});
+  constexpr auto end = gfx1250::build_sopp(gfx1250::kSEndpgmSopp);
+  TestCodeObject co({swap[0], end[0]});
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_EQ(blocks.size(), 1u);
+  auto scope = block_scope(blocks);
+
+  LivenessAnalysisOptions options;
+  options.arch = ROCJITSU_CODE_ARCH_GFX1250;
+  options.entry_block = scope.front();
+  options.text = text_span(co);
+  LivenessAnalysis liveness(KernelBlockScope(scope), options);
+
+  const Instruction &instruction = *blocks.front()->instructions().begin();
+  EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&instruction, 1, 1, 1, 2), std::nullopt);
+  EXPECT_FALSE(liveness.has_materialized_cfg_liveness());
+}
+
+TEST(LivenessAnalysis, Gfx1250GprIndexModeWriteDisablesGlobalUnusedQuery) {
+  // A runtime MODE[27] write can enable GPR indexing, after which ordinary
+  // encoded operands may access M0-offset VGPRs.
+  constexpr uint16_t kModeGprIdxEnableHwreg = 1u | (27u << 6);
+  constexpr auto setreg =
+      gfx1250::build_sopk(gfx1250::kSSetregB32Sopk, {.simm16 = kModeGprIdxEnableHwreg, .sdst = 0});
+  constexpr auto move = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 256, .vdst = 0});
+  constexpr auto end = gfx1250::build_sopp(gfx1250::kSEndpgmSopp);
+  TestCodeObject co({setreg[0], move[0], end[0]});
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_EQ(blocks.size(), 1u);
+  auto scope = block_scope(blocks);
+
+  LivenessAnalysisOptions options;
+  options.arch = ROCJITSU_CODE_ARCH_GFX1250;
+  options.entry_block = scope.front();
+  options.text = text_span(co);
+  LivenessAnalysis liveness(KernelBlockScope(scope), options);
+
+  auto instruction = blocks.front()->instructions().begin();
+  ++instruction;
+  ASSERT_NE(instruction, blocks.front()->instructions().end());
+  EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&*instruction, 1, 1, 1, 2), std::nullopt);
+  EXPECT_FALSE(liveness.has_materialized_cfg_liveness());
+}
+
+TEST(LivenessAnalysis, Gfx1250ImmediateGprIndexModeWriteUsesLiteralValue) {
+  constexpr uint16_t kModeGprIdxEnableHwreg = 1u | (27u << 6);
+  constexpr auto setreg =
+      gfx1250::build_sopk(gfx1250::kSSetregImm32B32Sopk, {.simm16 = kModeGprIdxEnableHwreg});
+  constexpr auto move = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 256, .vdst = 0});
+  constexpr auto end = gfx1250::build_sopp(gfx1250::kSEndpgmSopp);
+
+  for (uint32_t literal : {0u, 1u}) {
+    SCOPED_TRACE(literal);
+    TestCodeObject co({setreg[0], literal, move[0], end[0]});
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+    ASSERT_NE(decoder, nullptr);
+    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+    ASSERT_EQ(blocks.size(), 1u);
+    auto scope = block_scope(blocks);
+
+    LivenessAnalysisOptions options;
+    options.arch = ROCJITSU_CODE_ARCH_GFX1250;
+    options.entry_block = scope.front();
+    options.text = text_span(co);
+    LivenessAnalysis liveness(KernelBlockScope(scope), options);
+
+    auto instruction = blocks.front()->instructions().begin();
+    ++instruction;
+    ASSERT_NE(instruction, blocks.front()->instructions().end());
+    const auto unused = liveness.find_globally_unused_vgpr_run(&*instruction, 1, 1, 1, 2);
+    if (literal == 0)
+      EXPECT_EQ(unused, 1);
+    else
+      EXPECT_EQ(unused, std::nullopt);
+    EXPECT_FALSE(liveness.has_materialized_cfg_liveness());
+  }
+}
+
+TEST(LivenessAnalysis, Cdna4DynamicGprIndexModeWriteDisablesGlobalUnusedQuery) {
+  constexpr uint16_t kModeGprIdxEnableHwreg = 1u | (27u << 6);
+  constexpr auto setreg =
+      cdna4::build_sopk(cdna4::kSSetregB32Sopk, {.simm16 = kModeGprIdxEnableHwreg, .sdst = 0});
+  constexpr auto move = cdna4::build_vop1(cdna4::kVMovB32Vop1, {.src0 = 256, .vdst = 0});
+  constexpr auto end = cdna4::build_sopp(cdna4::kSEndpgmSopp);
+  TestCodeObject co({setreg[0], move[0], end[0]});
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_EQ(blocks.size(), 1u);
+  auto scope = block_scope(blocks);
+
+  LivenessAnalysisOptions options;
+  options.arch = ROCJITSU_CODE_ARCH_CDNA4;
+  options.text = text_span(co);
+  LivenessAnalysis liveness(KernelBlockScope(scope), options);
+
+  auto instruction = blocks.front()->instructions().begin();
+  ++instruction;
+  ASSERT_NE(instruction, blocks.front()->instructions().end());
+  EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&*instruction, 1, 1, 1, 2), std::nullopt);
+  EXPECT_FALSE(liveness.has_materialized_cfg_liveness());
+}
+
+TEST(LivenessAnalysis, Cdna4ImmediateGprIndexModeWriteUsesLiteralValue) {
+  constexpr uint16_t kModeGprIdxEnableHwreg = 1u | (27u << 6);
+  constexpr auto setreg =
+      cdna4::build_sopk(cdna4::kSSetregImm32B32Sopk, {.simm16 = kModeGprIdxEnableHwreg});
+  constexpr auto move = cdna4::build_vop1(cdna4::kVMovB32Vop1, {.src0 = 256, .vdst = 0});
+  constexpr auto end = cdna4::build_sopp(cdna4::kSEndpgmSopp);
+
+  for (uint32_t literal : {0u, 1u}) {
+    SCOPED_TRACE(literal);
+    TestCodeObject co({setreg[0], literal, move[0], end[0]});
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    ASSERT_NE(decoder, nullptr);
+    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+    ASSERT_EQ(blocks.size(), 1u);
+    auto scope = block_scope(blocks);
+
+    LivenessAnalysisOptions options;
+    options.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    options.text = text_span(co);
+    LivenessAnalysis liveness(KernelBlockScope(scope), options);
+
+    auto instruction = blocks.front()->instructions().begin();
+    ++instruction;
+    ASSERT_NE(instruction, blocks.front()->instructions().end());
+    const auto unused = liveness.find_globally_unused_vgpr_run(&*instruction, 1, 1, 1, 2);
+    if (literal == 0)
+      EXPECT_EQ(unused, 1);
+    else
+      EXPECT_EQ(unused, std::nullopt);
+    EXPECT_FALSE(liveness.has_materialized_cfg_liveness());
+  }
 }
 
 TEST(LivenessAnalysis, Gfx1250DynamicModeWriteConservativelyUsesEveryBank) {
@@ -3337,6 +3547,42 @@ TEST(LivenessAnalysis, MinFreeVgprForcesScratchAllocationAboveFloor) {
   EXPECT_EQ(liveness.find_free_sgpr(&use, 0), 0);
   EXPECT_EQ(liveness.find_free_run(&use, 1, 0), 4);
   EXPECT_EQ(liveness.find_free_run(&use, 1, 7), 7);
+}
+
+TEST(LivenessAnalysis, GloballyUnusedRunHonorsMinFreeVgprFloor) {
+  auto blocks = build_test_blocks({TestOpcode::UseSgpr4, TestOpcode::End});
+  auto scope = block_scope(blocks);
+  LivenessAnalysisOptions options;
+  options.min_free_vgpr = 4;
+  LivenessAnalysis liveness(KernelBlockScope(scope), options);
+
+  const Instruction &use = *blocks[0]->instructions().begin();
+  EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&use, 1, 0, 1, 8), 4);
+  EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&use, 1, 0, 1, 4), std::nullopt);
+  EXPECT_FALSE(liveness.has_materialized_cfg_liveness());
+}
+
+TEST(LivenessAnalysis, FindsGloballyUnusedRunBeforeSiteDeadFallback) {
+  auto blocks = build_test_blocks({TestOpcode::UseVgpr0, TestOpcode::Nop, TestOpcode::End});
+  auto scope = block_scope(blocks);
+  const LivenessAnalysis liveness{KernelBlockScope(scope)};
+
+  auto instruction = blocks.front()->instructions().begin();
+  ++instruction;
+  ASSERT_NE(instruction, blocks.front()->instructions().end());
+
+  EXPECT_FALSE(liveness.has_materialized_cfg_liveness());
+  EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&*instruction, 1, 0, 1, 4), 1);
+  EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&*instruction, 2, 0, 2, 4), 2);
+  EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&*instruction, 2, 0, 1, 1), std::nullopt);
+  EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&*instruction, 1, 0, 1, 0), std::nullopt);
+  EXPECT_FALSE(liveness.has_materialized_cfg_liveness());
+  EXPECT_EQ(liveness.find_free_run(&*instruction, 1), 0)
+      << "v0 is dead at this site but is not globally unused";
+  EXPECT_TRUE(liveness.has_materialized_cfg_liveness());
+
+  Instruction outside_scope("outside_scope", nullptr);
+  EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&outside_scope, 1, 0, 1, 4), std::nullopt);
 }
 
 TEST(LivenessAnalysis, FreeVgprAllocationHonorsDestinationLimit) {

--- a/emulation/rocjitsu/tests/dbt/semantic_scratch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/semantic_scratch_test.cpp
@@ -7,17 +7,23 @@
 #include "rocjitsu/code/dbt/semantic/cdna3_scratch.h"
 #include "rocjitsu/code/dbt/semantic_scratch.h"
 #include "rocjitsu/code/dbt/translation_rule.h"
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna3/builders.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna3/machine_insts.h"
-#include "rocjitsu/isa/arch/amdgpu/gfx1250/builders.h"
-#include "rocjitsu/isa/arch/amdgpu/gfx1250/opcodes.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna3/opcodes.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna4/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna4/opcodes.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cstdint>
 #include <cstring>
+#include <iterator>
 #include <memory>
+#include <span>
 #include <vector>
 
 namespace rocjitsu {
@@ -40,8 +46,8 @@ private:
 
 class ScratchTestCodeObject : public CodeObject {
 public:
-  explicit ScratchTestCodeObject(std::vector<uint32_t> words) {
-    const auto byte_size = words.size() * sizeof(uint32_t);
+  explicit ScratchTestCodeObject(std::span<const uint32_t> words) {
+    const auto byte_size = words.size_bytes();
     image_.resize(byte_size);
     std::memcpy(image_.data(), words.data(), byte_size);
 
@@ -53,10 +59,26 @@ public:
 };
 
 std::vector<std::unique_ptr<BasicBlock>> build_scratch_test_blocks() {
-  constexpr auto endpgm = gfx1250::build_sopp(gfx1250::kSEndpgmSopp);
-  ScratchTestCodeObject object({endpgm[0]});
-  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
-  return BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  constexpr auto move = cdna3::build_vop1(cdna3::kVMovB32Vop1, {.src0 = 256, .vdst = 0});
+  constexpr auto end = cdna3::build_sopp(cdna3::kSEndpgmSopp);
+  constexpr std::array words = {move[0], end[0]};
+  ScratchTestCodeObject code(words);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  return BasicBlock::build(code, *decoder, ROCJITSU_CODE_ARCH_CDNA3);
+}
+
+std::vector<BasicBlock *>
+scratch_test_scope(const std::vector<std::unique_ptr<BasicBlock>> &blocks) {
+  std::vector<BasicBlock *> scope;
+  scope.reserve(blocks.size());
+  for (const auto &block : blocks)
+    scope.push_back(block.get());
+  return scope;
+}
+
+std::span<const uint8_t> scratch_test_text(const CodeObject &code) {
+  const Section *text = code.text_sections().front();
+  return {reinterpret_cast<const uint8_t *>(text->data()), text->size()};
 }
 
 TEST(SemanticSpillFrame, SeparatesPersistentAndTransientRanges) {
@@ -137,6 +159,115 @@ TEST(SemanticScratchAllocator, FallsBackToNonForbiddenSpillVictim) {
   EXPECT_EQ(context.required_private_segment_fixed_size, 40u);
 }
 
+TEST(SemanticScratchAllocator, PrefersKernelUnusedOverSiteDeadVgpr) {
+  auto blocks = build_scratch_test_blocks();
+  auto scope = scratch_test_scope(blocks);
+  const LivenessAnalysis liveness{KernelBlockScope(scope)};
+  auto site = blocks.front()->instructions().begin();
+  ++site;
+  ASSERT_NE(site, blocks.front()->instructions().end());
+
+  TranslationContext context(/*vgprs=*/8, /*agprs=*/0, /*accum_base=*/0,
+                             /*sgprs=*/8, /*private_bytes=*/64);
+  SemanticScratchAllocator allocator(*site, liveness, context,
+                                     Cdna3ScratchEmitter::allocation_policy());
+  SemanticScratchRequest request;
+  request.count = 1;
+  const SemanticScratchResult result = allocator.acquire_vgprs(request);
+
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(result.lease->spilled);
+  EXPECT_EQ(result.lease->base, 1u);
+  EXPECT_FALSE(liveness.has_materialized_cfg_liveness())
+      << "kernel-unused allocation must not force backward CFG liveness";
+}
+
+TEST(SemanticScratchAllocator, KernelUnusedSearchSkipsForbiddenWindow) {
+  auto blocks = build_scratch_test_blocks();
+  auto scope = scratch_test_scope(blocks);
+  const LivenessAnalysis liveness{KernelBlockScope(scope)};
+  auto site = blocks.front()->instructions().begin();
+  ++site;
+  ASSERT_NE(site, blocks.front()->instructions().end());
+
+  TranslationContext context(/*vgprs=*/8, /*agprs=*/0, /*accum_base=*/0,
+                             /*sgprs=*/8, /*private_bytes=*/64);
+  SemanticScratchAllocator allocator(*site, liveness, context,
+                                     Cdna3ScratchEmitter::allocation_policy());
+  SemanticScratchRequest request;
+  request.count = 1;
+  request.forbidden.expand({RegClass::VGPR, 1, 3});
+  const SemanticScratchResult result = allocator.acquire_vgprs(request);
+
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(result.lease->spilled);
+  EXPECT_EQ(result.lease->base, 4u);
+  EXPECT_FALSE(liveness.has_materialized_cfg_liveness());
+}
+
+TEST(SemanticScratchAllocator, GprIndexModeWriteBypassesKernelUnusedTier) {
+  constexpr uint16_t kModeGprIdxEnableHwreg = 1u | (27u << 6);
+  constexpr auto setreg =
+      cdna4::build_sopk(cdna4::kSSetregB32Sopk, {.simm16 = kModeGprIdxEnableHwreg, .sdst = 0});
+  constexpr auto move = cdna4::build_vop1(cdna4::kVMovB32Vop1, {.src0 = 256, .vdst = 0});
+  constexpr auto end = cdna4::build_sopp(cdna4::kSEndpgmSopp);
+  constexpr std::array words = {setreg[0], move[0], end[0]};
+  ScratchTestCodeObject code(words);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(code, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_EQ(blocks.size(), 1u);
+  auto scope = scratch_test_scope(blocks);
+
+  LivenessAnalysisOptions options;
+  options.arch = ROCJITSU_CODE_ARCH_CDNA4;
+  options.text = scratch_test_text(code);
+  const LivenessAnalysis liveness{KernelBlockScope(scope), options};
+  auto site = blocks.front()->instructions().begin();
+  std::advance(site, 2);
+  ASSERT_NE(site, blocks.front()->instructions().end());
+
+  TranslationContext context(/*vgprs=*/2, /*agprs=*/0, /*accum_base=*/0,
+                             /*sgprs=*/8, /*private_bytes=*/64);
+  SemanticScratchAllocator allocator(*site, liveness, context,
+                                     Cdna3ScratchEmitter::allocation_policy());
+  SemanticScratchRequest request;
+  request.count = 1;
+  request.allow_spill = false;
+  const SemanticScratchResult result = allocator.acquire_vgprs(request);
+
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(result.lease->spilled);
+  EXPECT_EQ(result.lease->base, 0u);
+  EXPECT_TRUE(liveness.has_materialized_cfg_liveness())
+      << "GPR indexing must bypass the kernel-unused tier";
+}
+
+TEST(SemanticScratchAllocator, SiteDeadTierCanGrowDescriptor) {
+  auto blocks = build_scratch_test_blocks();
+  auto scope = scratch_test_scope(blocks);
+  const LivenessAnalysis liveness{KernelBlockScope(scope)};
+  const Instruction &site = *blocks.front()->instructions().begin();
+
+  // The sole descriptor-allocated register v0 is read at this site, so the
+  // kernel-unused tier has no in-descriptor choice and point liveness grows the
+  // allocation to v1.
+  TranslationContext context(/*vgprs=*/1, /*agprs=*/0, /*accum_base=*/0,
+                             /*sgprs=*/8, /*private_bytes=*/64);
+  SemanticScratchAllocator allocator(site, liveness, context,
+                                     Cdna3ScratchEmitter::allocation_policy());
+  SemanticScratchRequest request;
+  request.count = 1;
+  request.allow_spill = false;
+  const SemanticScratchResult result = allocator.acquire_vgprs(request);
+
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(result.lease->spilled);
+  EXPECT_EQ(result.lease->base, 1u);
+  EXPECT_EQ(context.required_vgpr_count, 2u);
+  EXPECT_TRUE(liveness.has_materialized_cfg_liveness());
+}
+
 TEST(SemanticScratchAllocator, ReportsTargetSpillOffsetLimit) {
   Instruction inst("scratch_test", nullptr);
   std::vector<BasicBlock *> blocks;
@@ -198,7 +329,7 @@ TEST(SemanticScratchAllocator, AllowsFreeWindowInDynamicStackKernel) {
   ASSERT_TRUE(result);
   EXPECT_EQ(result.failure, SemanticScratchFailure::None);
   EXPECT_FALSE(result.lease->spilled);
-  EXPECT_EQ(result.lease->base, 0u);
+  EXPECT_EQ(result.lease->base, 1u);
   EXPECT_EQ(context.required_private_segment_fixed_size, 32u);
 }
 

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -11133,7 +11133,8 @@ TEST(BinaryTranslatorE2E, Gfx1250DeadScratchWaitsForOutstandingVgprProducer) {
       scratch_write_index = index;
       const rocjitsu::Operand *destination = decoded[index]->dst_operand(0);
       ASSERT_NE(destination, nullptr);
-      EXPECT_EQ(destination->encoding_value(), 0u);
+      EXPECT_EQ(destination->encoding_value(), 1u)
+          << "globally unused v1 is preferred over site-dead v0";
     }
   }
   ASSERT_TRUE(pending_load_index.has_value());


### PR DESCRIPTION
## Motivation

Semantic scratch allocation currently computes full backward CFG liveness before it can select a temporary VGPR. Many kernels have a register tuple that is never read or written and is already covered by the descriptor allocation. Such a tuple is safe at every source rewrite boundary and can be claimed without point-liveness dataflow or descriptor growth.

## Technical Details

- Collect whole-kernel source register usage while preparing liveness state.
- Resolve known gfx1250 VGPR-MSB banks precisely and conservatively mark every candidate tuple for ambiguous banked definitions.
- Fail closed for scopes with relative or GPR-indexed VGPR access.
- Try an aligned, non-forbidden globally unused tuple within the existing ordinary-VGPR allocation before point-liveness and spill tiers.
- Defer backward CFG live-before computation until a fallback query needs it while retaining the existing site-dead, descriptor-growth, and spill behavior.

This commit adds only the globally unused VGPR tier. Candidate-specific instruction timing, full timing analysis, and an equivalent SGPR fast path remain follow-up work.

## Issue Tracking

N/A

## Test Plan

Run focused liveness and semantic-scratch tests, the complete RocJITsu suite, repository hooks, and paired output, idempotence, CPU, and RSS qualification across the pinned 20,000-object gfx1250 corpus.

## Test Result

- Matched Release builds reduced aggregate translation CPU from 586.960 to 540.761 seconds, or 7.87%. The ordinary 19,999-object slice improved 2.77%, with a 5.58% median per-object reduction.
- Peak RSS was flat: the ordinary-object median delta was zero, its mean delta was -2.4 KiB, and the oversized-object delta was -968 KiB.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
