### PR TITLE
fix(rocjitsu): preserve four-word instructions in waitcheck

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/waitcheck.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/waitcheck.cpp
@@ -669,7 +669,7 @@ struct Analyzer {
     RegisterSet local_ready_regs;
     std::optional<PendingWaitGroup> pending_wait_group;
     std::vector<uint32_t> padded(words.begin(), words.end());
-    padded.resize(padded.size() + 2);
+    padded.resize(padded.size() + Decoder::kMaximumInstructionWords - 1);
 
     size_t word_index = 0;
     while (word_index < words.size()) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
@@ -495,10 +495,9 @@ BasicBlock::build_reachable(const CodeObject &co, Decoder &decoder, rj_code_arch
           auto decoded_it = decoded.find(offset);
           if (decoded_it == decoded.end()) {
             // Decode from a small local window instead of copying the complete
-            // .text section. AMDGPU instructions occupy at most three words;
-            // zero padding preserves the decoder's established lookahead
+            // .text section. Zero padding preserves the decoder's lookahead
             // contract at the end of a section.
-            std::array<uint32_t, 3> window{};
+            std::array<uint32_t, Decoder::kMaximumInstructionWords> window{};
             const size_t available =
                 static_cast<size_t>(std::min<uint64_t>(sizeof(window), decode_end - offset));
             std::memcpy(window.data(), text.data() + offset, available);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.h
@@ -27,6 +27,13 @@ class Instruction;
 /// (e.g., the ComputeUnit simulation loop).
 class Decoder {
 public:
+  /// @brief Maximum encoded instruction length accepted by any decoder.
+  ///
+  /// @details GFX1250 scaled WMMA instructions pair two VOP3P encodings and
+  /// occupy four dwords. Decode windows must provide this many readable words,
+  /// zero-padding words beyond the available instruction stream.
+  static constexpr size_t kMaximumInstructionWords = 4;
+
   virtual ~Decoder();
 
   /// @brief Decode a binary instruction.

--- a/emulation/rocjitsu/tests/analysis/waitcheck_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/waitcheck_test.cpp
@@ -5,6 +5,7 @@
 #include "rocjitsu/analysis/indirect_branch_discovery.h"
 #include "rocjitsu/analysis/waitcheck.h"
 #include "rocjitsu/code/amdgpu_code_object.h"
+#include "rocjitsu/code/basic_block.h"
 #include "rocjitsu/code/code_object.h"
 #include "rocjitsu/code/patch/instruction_builder.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna4/machine_insts.h"
@@ -130,6 +131,32 @@ template <typename T> void append_inst(std::vector<uint32_t> &words, const T &in
 [[nodiscard]] WaitcheckReport analyze_gfx1250_normal(const std::vector<uint32_t> &program) {
   TestCodeObject code_object(program);
   return analyze_waitcnts(code_object, ROCJITSU_CODE_ARCH_GFX1250);
+}
+
+TEST(WaitcheckTest, ReachableGfx1250DecodePreservesFourWordInstruction) {
+  const std::vector<uint32_t> program{
+      0xcc3a0200u, 0x42020d04u, 0xcc336008u, 0x04223110u,
+      0xbfb00000u, // s_endpgm.
+  };
+  TestCodeObject code_object(program);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  const std::array<uint64_t, 1> entries{0};
+  const std::array<uint64_t, 1> entry_sizes{program.size() * sizeof(uint32_t)};
+  auto blocks = BasicBlock::build_reachable(code_object, *decoder, ROCJITSU_CODE_ARCH_GFX1250,
+                                            entries, entry_sizes, 32);
+
+  ASSERT_FALSE(blocks.empty());
+  const Instruction &instruction = *blocks.front()->instructions().begin();
+  ASSERT_EQ(instruction.size(), 4 * sizeof(uint32_t));
+  ASSERT_EQ(instruction.num_dst_operands(), 1);
+  ASSERT_EQ(instruction.num_src_operands(), 5);
+  EXPECT_EQ(instruction.dst_operand(0)->to_register_ref(), (RegisterRef{RegClass::VGPR, 8, 8}));
+  EXPECT_EQ(instruction.src_operand(0)->to_register_ref(), (RegisterRef{RegClass::VGPR, 16, 8}));
+  EXPECT_EQ(instruction.src_operand(1)->to_register_ref(), (RegisterRef{RegClass::VGPR, 24, 8}));
+  EXPECT_EQ(instruction.src_operand(2)->to_register_ref(), (RegisterRef{RegClass::VGPR, 8, 8}));
+  ASSERT_NE(instruction.raw_encoding(), nullptr);
+  EXPECT_EQ(instruction.raw_encoding()[3], program[3]);
 }
 
 [[nodiscard]] rdna4::Vop1MachineInst v_mov_b32(uint32_t vdst, uint32_t src_vgpr) {


### PR DESCRIPTION
Waitcheck now preserves the complete encoding of gfx1250 scaled WMMA instructions while constructing reachable control-flow graphs.

These instructions pair two VOP3P encodings and occupy four dwords. The reachable-CFG path copied only three dwords into its local decode window, so the generated decoder read the final matrix-source fields from adjacent stack storage. Identical code objects could consequently produce zero or varying source registers, and a real load dependency could silently disappear from the analysis.

The decoder now owns one maximum-encoding-length contract. Reachable-CFG windows and linear waitcheck stream padding both derive their readable storage from it. The regression passes an exact four-dword scaled WMMA through `BasicBlock::build_reachable` and asserts its structured destination and source register facts plus the retained fourth word; it does not rely on formatted disassembly text.

This restores deterministic dependency analysis for compiler-authored native FP4 kernels. In the motivating NVFP4 kernel, retaining the fourth word changes the affected load wait from a spurious under-accounting result to exact counter parity.

Fixes #9533.

The [standalone SDK-only reproducer](https://gist.github.com/benvanik/0874979aa2640b4a6c53df33671cd661) carries the LLVM encoding oracle, a 16-run structured-diagnostic check, and the isolated patch.
