### PR TITLE
test(rccl): migrate VersionGateTests to pure UT

### DIFF
--- a/projects/rccl/test/pure/CMakeLists.txt
+++ b/projects/rccl/test/pure/CMakeLists.txt
@@ -203,6 +203,7 @@ add_executable(rccl-PureUnitTests
   ${RCCL_TEST_DIR}/DdaCollCommonTests.cpp
   ${RCCL_TEST_DIR}/RomeTopoConsensusTests.cpp
   ${RCCL_TEST_DIR}/MiscTests.cpp
+  ${RCCL_TEST_DIR}/VersionGateTests.cpp
   ${RCCL_TEST_DIR}/TimeoutTests.cpp
   ${RCCL_TEST_DIR}/EnqueueCountTests.cpp
   ${RCCL_TEST_DIR}/BootstrapBidirTests.cpp


### PR DESCRIPTION
## Summary

Migrates **VersionGateTests** into the `rccl-PureUnitTests` binary — the first of the
"Tier-1" host-only test migrations.

The 3 tests are header-only assertions on the `rocmwrap.h` constexpr version-gate macros
(`CuMemVersionSupported`, `CuMemHostIsNativeOnly`, `CeBatchAsyncWindow`) — no HIP, no
`librccl`, no GPU. One-line change: add `VersionGateTests.cpp` to the pure UT sources.

## Verification

| | WSL2 (CPU-only, g++) | OCI amd-rccl (ROCm node) |
|---|---|---|
| Build | pass | pass |
| VersionGate | 3/3 | 3/3 |

## Test plan
- [x] `cmake && make` on WSL2/g++ — builds clean.
- [x] `./rccl-PureUnitTests --gtest_filter=VersionGate*` → 3/3.
- [x] OCI ROCm build + run → VersionGate 3/3.
