### PR TITLE
fix(amdsmi): stop `amdsmi_set_clk_freq()` from falsely returning INVAL

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -70,6 +70,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Fixed
 
+- **Fixed `amdsmi_set_clk_freq()` falsely returning `AMDSMI_STATUS_INVAL` on Navi48 (gfx1201)**.
+  - The deep-sleep bitmask validation added previously rejected the entire request when any requested bit fell outside a settable range computed from a prior read, so a supported clock set failed on gfx1201 even though the write is valid. The set is now lenient: out-of-range bits are dropped, and `AMDSMI_STATUS_INVAL` is only returned when no requested level is settable. The read-only check runs after the write, and `TestFrequenciesReadWrite` is re-enabled on Aldebaran (gfx90a / MI210).
+
 - **Fixed `amd-smi ras --cper --json` emitting nothing when there are no CPER entries**.
   - The common no-entries case printed empty output, so consumers feeding stdout to `json.loads` failed with `Expecting value: line 1 column 1 (char 0)`. The command now always emits exactly one valid JSON document: `[]` when there are no entries, or a single aggregated array across all GPUs when there are. `--follow` mode stays silent until entries appear. The human-readable primary-partition warning is also suppressed in JSON mode so it no longer corrupts the output.
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -5390,7 +5390,7 @@ amdsmi_status_t amdsmi_set_gpu_overdrive_level(amdsmi_processor_handle processor
  *  @platform{gpu_bm_linux}
  *
  *  @details Given a processor handle @p processor_handle, this
- *  function will restricts clock @p clk_type to the frequencies
+ *  function restricts clock @p clk_type to the frequencies
  *  selected in @p freq_bitmask. Bit N maps to DPM level N in the
  *  order returned by amdsmi_get_clk_freq(). Set a bit to 1 to
  *  enable and 0 to disable that level.

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -5389,31 +5389,33 @@ amdsmi_status_t amdsmi_set_gpu_overdrive_level(amdsmi_processor_handle processor
  *
  *  @platform{gpu_bm_linux}
  *
- *  @details Given a processor handle @p processor_handle, a clock type @p clk_type, and a
- *  64 bit bitmask @p freq_bitmask, this function will limit the set of
- *  allowable frequencies. If a bit in @p freq_bitmask has a value of 1, then
- *  the frequency (as ordered in an ::amdsmi_frequencies_t returned by
- *  amdsmi_get_clk_freq()) corresponding to that bit index will be
- *  allowed.
+ *  @details Given a processor handle @p processor_handle, this
+ *  function will restricts clock @p clk_type to the frequencies
+ *  selected in @p freq_bitmask. Bit N maps to DPM level N in the
+ *  order returned by amdsmi_get_clk_freq(). Set a bit to 1 to
+ *  enable and 0 to disable that level.
  *
- *  This function will change the performance level to
- *  ::AMDSMI_DEV_PERF_LEVEL_MANUAL in order to modify the set of allowable
- *  frequencies. Caller will need to set to ::AMDSMI_DEV_PERF_LEVEL_AUTO in order
- *  to get back to default state.
+ *  Only settable DPM levels can be enabled. Bits outside the settable range are
+ *  ignored, and the remaining in-range bits are still applied (matching driver
+ *  behavior). The deep-sleep frequency (see ::amdsmi_frequencies_t::has_deep_sleep)
+ *  is not settable, so when it is present the settable level count is
+ *  ::amdsmi_frequencies_t::num_supported minus one. Without a deep-sleep
+ *  frequency, all ::amdsmi_frequencies_t::num_supported levels (0 to
+ *  num_supported - 1) are settable. The call returns ::AMDSMI_STATUS_INVAL if no
+ *  bit selects a settable level.
  *
- *  All bits with indices greater than or equal to
- *  ::amdsmi_frequencies_t::num_supported will be ignored.
+ *  This call sets the performance level to ::AMDSMI_DEV_PERF_LEVEL_MANUAL. Set it
+ *  back to ::AMDSMI_DEV_PERF_LEVEL_AUTO to restore the default behavior.
  *
  *  @note This function requires admin/sudo privileges
  *
  *  @param[in] processor_handle a processor handle
  *
- *  @param[in] clk_type the type of clock for which the set of frequencies
- *  will be modified
+ *  @param[in] clk_type the type of clock to modify
  *
- *  @param[in] freq_bitmask A bitmask indicating the indices of the
- *  frequencies that are to be enabled (1) and disabled (0). Only the lowest
- *  ::amdsmi_frequencies_t.num_supported bits of this mask are relevant.
+ *  @param[in] freq_bitmask Bitmask selecting which DPM levels to allow, where
+ *  bit N enables (1) or disables (0) DPM level N. Bits above the highest settable
+ *  level are ignored. See notes above on settable levels.
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
@@ -4027,29 +4027,30 @@ rsmi_status_t rsmi_dev_overdrive_level_set_v1(uint32_t dv_ind, uint32_t od);
  * @brief Control the set of allowed frequencies that can be used for the
  * specified clock.
  *
- * @details Given a device index @p dv_ind, a clock type @p clk_type, and a
- * 64 bit bitmask @p freq_bitmask, this function will limit the set of
- * allowable frequencies. If a bit in @p freq_bitmask has a value of 1, then
- * the frequency (as ordered in an ::rsmi_frequencies_t returned by
- * rsmi_dev_gpu_clk_freq_get()) corresponding to that bit index will be
- * allowed.
+ * @details Given a device index @p dv_ind, this function will restrict clock
+ * @p clk_type to the frequencies selected in @p freq_bitmask. Bit N maps to
+ * DPM level N in the order returned by rsmi_dev_gpu_clk_freq_get(). Set a bit
+ * to 1 to enable and 0 to disable that level.
  *
- * This function will change the performance level to
- * ::RSMI_DEV_PERF_LEVEL_MANUAL in order to modify the set of allowable
- * frequencies. Caller will need to set to ::RSMI_DEV_PERF_LEVEL_AUTO in order
- * to get back to default state.
+ * Only settable DPM levels can be enabled. Bits outside the settable range are
+ * ignored, and the remaining in-range bits are still applied (matching driver
+ * behavior). The deep-sleep frequency (see ::rsmi_frequencies_t::has_deep_sleep)
+ * is not settable, so when it is present the settable level count is
+ * ::rsmi_frequencies_t::num_supported minus one. Without a deep-sleep
+ * frequency, all ::rsmi_frequencies_t::num_supported levels (0 to
+ * num_supported - 1) are settable. The call returns ::RSMI_STATUS_INVALID_ARGS
+ * if no bit selects a settable level.
  *
- * All bits with indices greater than or equal to
- * ::rsmi_frequencies_t::num_supported will be ignored.
+ * This call sets the performance level to ::RSMI_DEV_PERF_LEVEL_MANUAL. Set it
+ * back to ::RSMI_DEV_PERF_LEVEL_AUTO to restore the default behavior.
  *
  *  @param[in] dv_ind a device index
  *
- *  @param[in] clk_type the type of clock for which the set of frequencies
- *  will be modified
+ *  @param[in] clk_type the type of clock to modify
  *
- *  @param[in] freq_bitmask A bitmask indicating the indices of the
- *  frequencies that are to be enabled (1) and disabled (0). Only the lowest
- *  ::rsmi_frequencies_t.num_supported bits of this mask are relevant.
+ *  @param[in] freq_bitmask Bitmask selecting which DPM levels to allow, where
+ *  bit N enables (1) or disables (0) DPM level N. Bits above the highest settable
+ *  level are ignored. See notes above on settable levels.
  *
  *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *  @retval ::RSMI_STATUS_NOT_SUPPORTED installed software or hardware does not

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -2093,19 +2093,30 @@ rsmi_status_t rsmi_dev_firmware_version_get(uint32_t dv_ind, rsmi_fw_block_t blo
   CATCH
 }
 
-static std::string bitfield_to_freq_string(uint64_t bitf, uint32_t num_supported) {
-  std::string bf_str;
-  std::bitset<RSMI_MAX_NUM_FREQUENCIES> bs(bitf);
-
+// Build the space-separated DPM-level string for pp_dpm_* from a bitmask: bit N
+// selects level N (e.g. 0b101 -> "0 2 "). Bits above the highest settable level
+// are dropped, matching how the driver ignores out-of-range indices. The
+// deep-sleep level ('S') is counted in num_supported but is not writable, so it
+// is excluded from the settable range. Throws RSMI_STATUS_INVALID_ARGS if no
+// settable level remains.
+static std::string bitfield_to_freq_string(uint64_t bitf, uint32_t num_supported,
+                                           bool has_deep_sleep = false) {
   if (num_supported > RSMI_MAX_NUM_FREQUENCIES) {
     throw amd::smi::rsmi_exception(RSMI_STATUS_INVALID_ARGS, __FUNCTION__);
   }
 
-  for (uint32_t i = 0; i < num_supported; ++i) {
+  uint32_t settable = (has_deep_sleep && num_supported > 0) ? num_supported - 1 : num_supported;
+
+  std::string bf_str;
+  std::bitset<RSMI_MAX_NUM_FREQUENCIES> bs(bitf);
+  for (uint32_t i = 0; i < settable; ++i) {
     if (bs[i]) {
       bf_str += std::to_string(i);
       bf_str += " ";
     }
+  }
+  if (bf_str.empty()) {
+    throw amd::smi::rsmi_exception(RSMI_STATUS_INVALID_ARGS, __FUNCTION__);
   }
   return bf_str;
 }
@@ -2125,14 +2136,6 @@ rsmi_status_t rsmi_dev_gpu_clk_freq_set(uint32_t dv_ind, rsmi_clk_type_t clk_typ
     return RSMI_STATUS_INVALID_ARGS;
   }
 
-  amd::smi::DevInfoTypes dev_type;
-  const auto& clk_type_it = kClkTypeMap.find(clk_type);
-  if (clk_type_it != kClkTypeMap.end()) {
-    dev_type = clk_type_it->second;
-  } else {
-    return RSMI_STATUS_INVALID_ARGS;
-  }
-
   ret = rsmi_dev_gpu_clk_freq_get(dv_ind, clk_type, &freqs);
 
   if (ret != RSMI_STATUS_SUCCESS) {
@@ -2144,46 +2147,27 @@ rsmi_status_t rsmi_dev_gpu_clk_freq_set(uint32_t dv_ind, rsmi_clk_type_t clk_typ
     return RSMI_STATUS_UNEXPECTED_SIZE;
   }
 
-  // Deep sleep entry (index 0 in pp_dpm_sclk marked with 'S') is not a real
-  // DPM level; subtract it from the valid count so the bitmask only covers
-  // actual DPM levels.  Bitmask bit i maps to sysfs DPM level i, which
-  // corresponds to freqs.frequency[i] when has_deep_sleep is false, or
-  // freqs.frequency[i+1] when has_deep_sleep is true.
-  if (freqs.num_supported > 0) {
-    uint32_t max_levels = freqs.num_supported;
-    if (freqs.has_deep_sleep) {
-      max_levels--;
-    }
-    uint64_t valid_mask = (max_levels > 0) ? (1ULL << max_levels) - 1 : 0;
-    if (freq_bitmask == 0 || (freq_bitmask & ~valid_mask)) {
-      return RSMI_STATUS_INVALID_ARGS;
-    }
-  }
-
   amd::smi::RocmSMI& smi = amd::smi::RocmSMI::getInstance();
 
   // Above call to rsmi_dev_get_gpu_clk_freq should have emitted an error if
   // assert below is not true
   assert(dv_ind < smi.devices().size());
 
+  // The deep-sleep pseudo-level ('S') is counted in freqs.num_supported but is
+  // not a writable pp_dpm_* label, so it is excluded from the settable range.
+  std::string freq_enable_str =
+      bitfield_to_freq_string(freq_bitmask, freqs.num_supported, freqs.has_deep_sleep);
+
   std::shared_ptr<amd::smi::Device> dev = smi.devices()[dv_ind];
   assert(dev != nullptr);
 
-  // If the sysfs node is read-only, force DPM level is not supported
-  std::string sysfs_path = dev->get_sys_file_path_by_type(dev_type, true);
-  bool read_only = false;
-  int ro_ret = amd::smi::isReadOnlyForAll(sysfs_path, &read_only);
-  if (ro_ret != 0) {
-    return amd::smi::ErrnoToRsmiStatus(ro_ret);
+  amd::smi::DevInfoTypes dev_type;
+  const auto& clk_type_it = kClkTypeMap.find(clk_type);
+  if (clk_type_it != kClkTypeMap.end()) {
+    dev_type = clk_type_it->second;
+  } else {
+    return RSMI_STATUS_INVALID_ARGS;
   }
-  if (read_only) {
-    return RSMI_STATUS_NOT_SUPPORTED;
-  }
-
-  // bitfield_to_freq_string iterates [0, num_supported), but the validation
-  // above already guarantees no bits are set beyond the valid DPM range, so
-  // the extra iteration over the deep sleep index (if present) is harmless.
-  std::string freq_enable_str = bitfield_to_freq_string(freq_bitmask, freqs.num_supported);
 
   ret = rsmi_dev_perf_level_set_v1(dv_ind, RSMI_DEV_PERF_LEVEL_MANUAL);
   if (ret != RSMI_STATUS_SUCCESS) {
@@ -2192,11 +2176,25 @@ rsmi_status_t rsmi_dev_gpu_clk_freq_set(uint32_t dv_ind, rsmi_clk_type_t clk_typ
 
   rsmi_status_t status;
   status = amd::smi::ErrnoToRsmiStatus(dev->writeDevInfo(dev_type, freq_enable_str));
+  ss << __PRETTY_FUNCTION__ << " | Attempted to set clock frequencies for device " << dv_ind
+     << " to: freq_enable_str=|" << freq_enable_str << "|"
+     << " (mask=0x" << std::hex << freq_bitmask << std::dec
+     << ", num_supported=" << freqs.num_supported
+     << ", deep_sleep=" << (freqs.has_deep_sleep ? "Y" : "N") << ", current=" << freqs.current
+     << ")"
+     << "; returned: " << amd::smi::getRSMIStatusString(status, false) << "\n";
+
+  ss << " | freqs[0.." << freqs.num_supported << "):";
+  for (uint32_t fi = 0; fi < freqs.num_supported && fi < RSMI_MAX_NUM_FREQUENCIES; ++fi) {
+    ss << " [" << fi << "]=" << freqs.frequency[fi];
+  }
+  LOG_DEBUG(ss);
 
   if (status == RSMI_STATUS_PERMISSION) {
-    bool post_read_only = false;
-    amd::smi::isReadOnlyForAll(sysfs_path, &post_read_only);
-    if (post_read_only) {
+    std::string sysfs_path = dev->get_sys_file_path_by_type(dev_type, true);
+    bool read_only = false;
+    amd::smi::isReadOnlyForAll(sysfs_path, &read_only);
+    if (read_only) {
       return RSMI_STATUS_NOT_SUPPORTED;
     }
   }

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -2193,8 +2193,9 @@ rsmi_status_t rsmi_dev_gpu_clk_freq_set(uint32_t dv_ind, rsmi_clk_type_t clk_typ
   if (status == RSMI_STATUS_PERMISSION) {
     std::string sysfs_path = dev->get_sys_file_path_by_type(dev_type, true);
     bool read_only = false;
-    amd::smi::isReadOnlyForAll(sysfs_path, &read_only);
-    if (read_only) {
+    // Only upgrade PERMISSION -> NOT_SUPPORTED when the probe succeeds; if it
+    // fails, keep the real write result (PERMISSION).
+    if (amd::smi::isReadOnlyForAll(sysfs_path, &read_only) == 0 && read_only) {
       return RSMI_STATUS_NOT_SUPPORTED;
     }
   }

--- a/projects/amdsmi/tests/amd_smi_test/amdsmitst.exclude
+++ b/projects/amdsmi/tests/amd_smi_test/amdsmitst.exclude
@@ -47,7 +47,6 @@ $BLACKLIST_ALL_ASICS\
 "GpuFunctionalReadOnly.TestVoltCurvRead:"\
 "GpuFunctionalReadOnly.TestFrequenciesRead:"\
 "GpuFunctionalReadWrite.FanReadWrite:"\
-"GpuFunctionalReadWrite.TestFrequenciesReadWrite:"\
 "GpuFunctionalReadWrite.TestPciReadWrite:"\
 "GpuFunctionalReadWrite.TestPowerReadWrite"
 

--- a/projects/amdsmi/tests/amd_smi_test/functional/gpu/clock/frequencies_read_write_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/gpu/clock/frequencies_read_write_test.cc
@@ -26,7 +26,9 @@
 #include <algorithm>
 #include <bitset>
 #include <cstdint>
+#include <cstdlib>
 #include <iostream>
+#include <map>
 #include <string>
 
 #include "amd_smi/amdsmi.h"
@@ -44,7 +46,9 @@ TestFrequenciesReadWrite::~TestFrequenciesReadWrite(void) {}
 
 void TestFrequenciesReadWrite::SetUp(void) {
   TestBase::SetUp();
-
+  // Capture the per-device performance level so Close() can restore it and
+  // avoid leaking a forced 'manual' perf state to later tests.
+  SavePerfLevels();
   return;
 }
 
@@ -56,9 +60,28 @@ void TestFrequenciesReadWrite::DisplayResults(void) const {
 }
 
 void TestFrequenciesReadWrite::Close() {
+  // Restore the performance level captured in SetUp() before amdsmi is shut
+  // down. Runs even if Run() aborted on a failed assertion, so this test cannot
+  // leak a forced 'manual' state to subsequent tests.
+  RestorePerfLevels();
   // This will close handles opened within rsmitst utility calls and call
   // amdsmi_shut_down(), so it should be done after other hsa cleanup
   TestBase::Close();
+}
+
+// Number of writable DPM labels. The deep-sleep pseudo-level ('S') is listed in
+// the table but has no settable numeric label, so it is excluded.
+static uint32_t settable_level_count(const amdsmi_frequencies_t& f) {
+  return (f.has_deep_sleep && f.num_supported > 0) ? f.num_supported - 1 : f.num_supported;
+}
+
+// The subset of a requested set-mask that can actually take effect: the bits
+// within the settable label range [0, settable_level_count). amd-smi (and the
+// driver) drop bits above that, so they never apply.
+static uint64_t effective_level_mask(uint64_t requested_mask, const amdsmi_frequencies_t& f) {
+  uint32_t settable = settable_level_count(f);
+  uint64_t in_range = (settable >= 64) ? ~0ULL : ((1ULL << settable) - 1);
+  return requested_mask & in_range;
 }
 
 void TestFrequenciesReadWrite::Run(void) {
@@ -85,8 +108,22 @@ void TestFrequenciesReadWrite::Run(void) {
   for (uint32_t dv_ind = 0; dv_ind < num_monitor_devs(); ++dv_ind) {
     PrintDeviceHeader(processor_handles_[dv_ind]);
 
+    // Optional debug filter: set AMDSMI_TEST_CLK to a clock name (e.g. "SYS",
+    // "GFX", "DF", "SOC", "MEM", "VCLK0", ...) to restrict this test to a
+    // single clock type. Useful for isolating which clock a set error comes
+    // from by running the test once per clock. Unset => exercise all clocks.
+    const char* only_clk_env = std::getenv("AMDSMI_TEST_CLK");
+
     for (uint32_t clk = AMDSMI_CLK_TYPE_FIRST; clk <= AMDSMI_CLK_TYPE__MAX; ++clk) {
       amdsmi_clk = (amdsmi_clk_type_t)clk;
+
+      if (only_clk_env != nullptr) {
+        auto name_it = clk_type_map.find(amdsmi_clk);
+        std::string clk_name = (name_it != clk_type_map.end()) ? name_it->second : "";
+        if (clk_name != only_clk_env) {
+          continue;  // skip clocks that don't match AMDSMI_TEST_CLK
+        }
+      }
 
       auto freq_read = [&]() -> bool {
         // Skip AMDSMI_CLK_TYPE_PCIE, which does not supported in rocm-smi.
@@ -98,11 +135,30 @@ void TestFrequenciesReadWrite::Run(void) {
           std::cout << "amdsmi_get_clk_freq(" << it->second << ", f)" << std::endl;
         }
 
-        DISPLAY_AMDSMI_API("amdsmi_get_clk_freq", "gpu=" + std::to_string(dv_ind), VERB(STANDARD));
+        DISPLAY_AMDSMI_API("amdsmi_get_clk_freq(" + std::string(FreqEnumToStr(amdsmi_clk)) + ")",
+                           "gpu=" + std::to_string(dv_ind), VERB(STANDARD));
         ret = amdsmi_get_clk_freq(processor_handles_[dv_ind], amdsmi_clk, &f);
         DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
         if (auto it = clk_type_map.find(amdsmi_clk); it != clk_type_map.end()) {
           std::cout << ": " << smi_amdgpu_get_status_string(ret, false) << std::endl;
+        }
+
+        IF_VERB(STANDARD) {
+          if (ret == AMDSMI_STATUS_SUCCESS) {
+            std::cout << "\t**" << FreqEnumToStr(amdsmi_clk) << ":\n"
+                      << "\t\t**Is in deep sleep: " << (f.has_deep_sleep ? "Yes" : "No") << "\n"
+                      << "\t\t**Number of supported frequencies: " << f.num_supported << "\n"
+                      << "\t\t**Current frequency index: " << f.current << "\n"
+                      << "\t\t**Supported frequencies: ";
+            for (uint32_t i = 0; i < f.num_supported; ++i) {
+              std::cout << f.frequency[i] << " Hz";
+              if (i < f.num_supported - 1) {
+                std::cout << ", ";
+              } else {
+                std::cout << std::endl;
+              }
+            }
+          }
         }
 
         if (ret == AMDSMI_STATUS_NOT_SUPPORTED || ret == AMDSMI_STATUS_NOT_YET_IMPLEMENTED) {
@@ -132,25 +188,7 @@ void TestFrequenciesReadWrite::Run(void) {
         // Skip AMDSMI_CLK_TYPE_PCIE, which does not supported in rocm-smi.
         if (amdsmi_clk == AMDSMI_CLK_TYPE_PCIE) return;
 
-        // Build the bitmask dynamically based on reported DPM levels.
-        // The deep sleep entry (if present) is not a valid DPM level,
-        // so exclude it from the count to stay within the valid range.
-        uint32_t dpm_levels = f.num_supported;
-        if (f.has_deep_sleep && dpm_levels > 0) {
-          dpm_levels--;
-        }
-
-        if (dpm_levels < 2) {
-          // Not enough DPM levels to test a non-trivial bitmask; skip.
-          IF_VERB(STANDARD) {
-            std::cout << "\t**Set " << FreqEnumToStr(amdsmi_clk) << ": Only " << dpm_levels
-                      << " DPM level(s), skipping write test." << std::endl;
-          }
-          return;
-        }
-
-        // Pick two valid DPM levels: the second-to-last and the last.
-        freq_bitmask = (1ULL << (dpm_levels - 2)) | (1ULL << (dpm_levels - 1));
+        freq_bitmask = 0b01100;  // Try the 3rd and 4th DPM levels
 
         std::string freq_bm_str = std::bitset<AMDSMI_MAX_NUM_FREQUENCIES>(freq_bitmask).to_string();
 
@@ -160,10 +198,13 @@ void TestFrequenciesReadWrite::Run(void) {
           std::cout << "Setting frequency mask for " << FreqEnumToStr(amdsmi_clk) << " to 0b"
                     << freq_bm_str << " ..." << std::endl;
         }
-        DISPLAY_AMDSMI_API("amdsmi_set_clk_freq", "gpu=" + std::to_string(dv_ind), VERB(STANDARD));
+        std::string set_api = "amdsmi_set_clk_freq(" + std::string(FreqEnumToStr(amdsmi_clk)) +
+                              ", 0b" + freq_bm_str + ")";
+        DISPLAY_AMDSMI_API(set_api, "gpu=" + std::to_string(dv_ind), VERB(STANDARD));
         ret = amdsmi_set_clk_freq(processor_handles_[dv_ind], amdsmi_clk, freq_bitmask);
         DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS,
-                              AMDSMI_STATUS_NOT_SUPPORTED, AMDSMI_STATUS_NO_PERM);
+                              AMDSMI_STATUS_NOT_SUPPORTED, AMDSMI_STATUS_NO_PERM,
+                              AMDSMI_STATUS_INVAL);
         // Certain ASICs does not allow to set particular clocks. If set function for a clock
         // returns permission error despite root access, manually set ret value to success and
         // return
@@ -177,35 +218,47 @@ void TestFrequenciesReadWrite::Run(void) {
           return;
         }
 
-        CHK_ERR_ASRT(ret)
+        // Lenient set contract: amd-smi applies the in-range subset of the
+        // requested mask and drops labels above the max settable level (like the
+        // driver), so a set only fails with INVAL when the mask selects no
+        // settable level at all.
+        if (ret == AMDSMI_STATUS_INVAL) {
+          std::cout << "\t**[Warn] AMDSMI_STATUS_INVAL - Could not set frequency mask for "
+                    << FreqEnumToStr(amdsmi_clk) << " to 0b" << freq_bm_str << " on device ["
+                    << dv_ind << "]!" << std::endl;
+          ASSERT_EQ(effective_level_mask(freq_bitmask, f), 0ULL);
+        } else {
+          CHK_ERR_ASRT(ret)
+        }
+
         DISPLAY_AMDSMI_API("amdsmi_get_clk_freq", "gpu=" + std::to_string(dv_ind), VERB(STANDARD));
         ret = amdsmi_get_clk_freq(processor_handles_[dv_ind], amdsmi_clk, &f);
         DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
         if (ret != AMDSMI_STATUS_SUCCESS) {
           return;
         }
-
         IF_VERB(STANDARD) {
           std::cout << "Frequency is now index " << f.current << std::endl;
           std::cout << "Resetting mask to all frequencies." << std::endl;
         }
-        // Build a valid "all DPM levels" bitmask instead of 0xFFFFFFFF,
-        // which would be rejected since it has bits beyond valid range.
-        uint32_t reset_levels = f.num_supported;
-        if (f.has_deep_sleep && reset_levels > 0) {
-          reset_levels--;
-        }
-        uint64_t all_levels_mask = (reset_levels > 0) ? (1ULL << reset_levels) - 1 : 0;
-        DISPLAY_AMDSMI_API("amdsmi_set_clk_freq", "gpu=" + std::to_string(dv_ind), VERB(STANDARD));
-        ret = amdsmi_set_clk_freq(processor_handles_[dv_ind], amdsmi_clk, all_levels_mask);
-        DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
+
+        freq_bitmask = 0xFFFFFFFF;
+        set_api = "amdsmi_set_clk_freq(" + std::string(FreqEnumToStr(amdsmi_clk)) + ", 0xFFFFFFFF)";
+        DISPLAY_AMDSMI_API(set_api, "gpu=" + std::to_string(dv_ind), VERB(STANDARD));
+        ret = amdsmi_set_clk_freq(processor_handles_[dv_ind], amdsmi_clk, freq_bitmask);
+        DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS,
+                              AMDSMI_STATUS_INVAL);
         if (ret == AMDSMI_STATUS_NOT_SUPPORTED) {
           ret = AMDSMI_STATUS_SUCCESS;
           return;
         }
-        if (ret != AMDSMI_STATUS_SUCCESS) {
+        if (ret == AMDSMI_STATUS_INVAL) {
+          // Only tolerated for a clock with no settable level (e.g. deep-sleep
+          // only); otherwise the "enable all" reset must succeed.
+          ASSERT_EQ(effective_level_mask(freq_bitmask, f), 0ULL);
           return;
         }
+        CHK_ERR_ASRT(ret)
 
         DISPLAY_AMDSMI_API("amdsmi_set_gpu_perf_level", "gpu=" + std::to_string(dv_ind),
                            VERB(STANDARD));
@@ -223,7 +276,9 @@ void TestFrequenciesReadWrite::Run(void) {
         continue;
       }
       freq_write();
-      CHK_ERR_ASRT(ret)
+      if (ret != AMDSMI_STATUS_INVAL) {
+        CHK_ERR_ASRT(ret)
+      }
     }
   }
 }

--- a/projects/amdsmi/tests/amd_smi_test/functional/gpu/power/power_read_write_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/gpu/power/power_read_write_test.cc
@@ -41,7 +41,9 @@ TestPowerReadWrite::~TestPowerReadWrite(void) {}
 
 void TestPowerReadWrite::SetUp(void) {
   TestBase::SetUp();
-
+  // Capture the per-device performance level so Close() can restore it and
+  // avoid leaking a forced 'manual' perf state to later tests.
+  SavePerfLevels();
   return;
 }
 
@@ -53,6 +55,10 @@ void TestPowerReadWrite::DisplayResults(void) const {
 }
 
 void TestPowerReadWrite::Close() {
+  // Restore the performance level captured in SetUp() before amdsmi is shut
+  // down. Runs even if Run() aborted on a failed assertion, so this test cannot
+  // leak a forced 'manual' state to subsequent tests.
+  RestorePerfLevels();
   // This will close handles opened within amdsmitst utility calls and call
   // amdsmi_shut_down(), so it should be done after other hsa cleanup
   TestBase::Close();

--- a/projects/amdsmi/tests/amd_smi_test/test_base.cc
+++ b/projects/amdsmi/tests/amd_smi_test/test_base.cc
@@ -49,6 +49,33 @@ static bool CheckModule(const std::string& fileName, const std::string& cond) {
   return (false);
 }
 
+static std::string get_perf_level_string(amdsmi_dev_perf_level_t level) {
+  switch (level) {
+    case AMDSMI_DEV_PERF_LEVEL_AUTO:
+      return "AUTO";
+    case AMDSMI_DEV_PERF_LEVEL_LOW:
+      return "LOW";
+    case AMDSMI_DEV_PERF_LEVEL_HIGH:
+      return "HIGH";
+    case AMDSMI_DEV_PERF_LEVEL_MANUAL:
+      return "MANUAL";
+    case AMDSMI_DEV_PERF_LEVEL_STABLE_STD:
+      return "STABLE_STD";
+    case AMDSMI_DEV_PERF_LEVEL_STABLE_PEAK:
+      return "STABLE_PEAK";
+    case AMDSMI_DEV_PERF_LEVEL_STABLE_MIN_MCLK:
+      return "STABLE_MIN_MCLK";
+    case AMDSMI_DEV_PERF_LEVEL_STABLE_MIN_SCLK:
+      return "STABLE_MIN_SCLK";
+    case AMDSMI_DEV_PERF_LEVEL_DETERMINISM:
+      return "DETERMINISM";
+    case AMDSMI_DEV_PERF_LEVEL_UNKNOWN:
+      return "UNKNOWN";
+    default:
+      return "UNDEFINED_PERF_LEVEL";
+  }
+}
+
 TestBase::TestBase() : setup_failed_(false) {}
 TestBase::~TestBase() = default;
 
@@ -303,6 +330,45 @@ void TestBase::Close(void) {
   }
   amdsmi_status_t err = amdsmi_shut_down();
   ASSERT_EQ(err, AMDSMI_STATUS_SUCCESS);
+}
+
+void TestBase::SavePerfLevels(void) {
+  for (uint32_t i = 0; i < num_monitor_devs_; ++i) {
+    amdsmi_dev_perf_level_t lvl;
+    amdsmi_status_t err = amdsmi_get_gpu_perf_level(processor_handles_[i], &lvl);
+    if (err == AMDSMI_STATUS_SUCCESS) {
+      saved_perf_level_[i] = lvl;
+      saved_perf_level_valid_[i] = true;
+      IF_VERB(STANDARD) {
+        std::cout << "Saved original performance level for device " << i << ": "
+                  << get_perf_level_string(lvl) << std::endl;
+      }
+    } else {
+      // Device does not expose a settable performance level; skip it so a
+      // later restore does not attempt an unsupported write.
+      saved_perf_level_valid_[i] = false;
+    }
+  }
+}
+
+void TestBase::RestorePerfLevels(void) {
+  for (uint32_t i = 0; i < num_monitor_devs_; ++i) {
+    if (!saved_perf_level_valid_[i]) {
+      continue;  // Original level was never captured for this device.
+    }
+    // Best-effort: intentionally ignore the return so that a restore failure on
+    // one device neither aborts the test nor masks the actual test outcome.
+    amdsmi_status_t err = amdsmi_set_gpu_perf_level(processor_handles_[i], saved_perf_level_[i]);
+    IF_VERB(STANDARD) {
+      if (err == AMDSMI_STATUS_SUCCESS) {
+        std::cout << "Restored perf level dev[" << i
+                  << "]: " << get_perf_level_string(saved_perf_level_[i]) << std::endl;
+      } else {
+        std::cout << "Failed to restore perf level dev[" << i
+                  << "]: " << get_perf_level_string(saved_perf_level_[i]) << std::endl;
+      }
+    }
+  }
 }
 
 void TestBase::DisplayResults(void) const {

--- a/projects/amdsmi/tests/amd_smi_test/test_base.h
+++ b/projects/amdsmi/tests/amd_smi_test/test_base.h
@@ -132,6 +132,11 @@ class TestBase {
   uint32_t socket_count_;                      ///< socket count
   std::vector<amdsmi_socket_handle> sockets_;  ///< sockets
 
+  void SavePerfLevels(void);
+  void RestorePerfLevels(void);
+  amdsmi_dev_perf_level_t saved_perf_level_[MAX_MONITOR_DEVICES];  ///< Restore original perf levels
+  bool saved_perf_level_valid_[MAX_MONITOR_DEVICES] = {false};     ///< Does perf need restoring?
+
  private:
   std::string description_;
   std::string title_;      ///< Displayed title of test


### PR DESCRIPTION
## Summary

`amdsmi_set_clk_freq()` / `rsmi_dev_gpu_clk_freq_set()` could return
`AMDSMI_STATUS_INVAL` for a clock-set that the hardware actually supports. On
Navi48 (gfx1201) this fails `TestFrequenciesReadWrite`, even though Navi31
(gfx1100) runs the identical flow and passes.

## Root cause

The deep-sleep-aware bitmask validation added in ROCM-9294 (#4707) rejects the
*entire* request with `INVAL` as soon as the caller's mask has any bit outside a
"settable" range computed from a prior `get_clk_freq` read. Because that
acceptable range is derived from a separate read and then acted on
(check-then-use), it doesn't always agree with what the driver will actually
accept, so a supported clock-set is falsely rejected on Navi48.

## Fix

- `bitfield_to_freq_string()` now mirrors the amdgpu driver: it silently drops
  bits above the highest settable DPM level and applies the in-range subset,
  raising `INVALID_ARGS` only when the requested mask has *no* settable level.
  Building the write payload this way — instead of validating the mask against a
  separately-read range and then writing — removes the check-then-use mismatch
  that produced the false `INVAL`.
- Deep-sleep (`'S'`) is counted in `num_supported` but is not a writable
  `pp_dpm_*` label, so it is excluded from the settable range (centralized in
  `bitfield_to_freq_string()`).
- The read-only sysfs check is now done only *after* an attempted write returns
  `PERMISSION`, instead of probing before the write. A genuinely read-only node
  still returns `NOT_SUPPORTED`; the result just comes from the actual write
  outcome rather than a separate pre-check.
- The clk-type lookup runs before the perf-level change so an invalid clock type
  no longer forces `MANUAL`.
- Doc comments for `amdsmi_set_clk_freq` / `rsmi_dev_gpu_clk_freq_set` updated to
  describe the lenient contract.

## Tests

- `TestFrequenciesReadWrite` accepts `AMDSMI_STATUS_INVAL` only when no level is
  settable, and exercises both the in-range-subset apply and the "enable all"
  (`0xFFFFFFFF`) reset paths.
- New `TestBase::SavePerfLevels()` / `RestorePerfLevels()` restore the per-device
  performance level in `Close()` so a forced `MANUAL` state cannot leak between
  tests (wired into the frequencies and power read/write tests).

## Validation

- [x] Navi48 / gfx1201 — `TestFrequenciesReadWrite` now passes
- [x] Navi31 / gfx1100 — no regression
- [x] MI3x (gfx942 & gfx950)

## Notes

- Partially reverts the validation added in #4707 (ROCM-9294); the lenient
  behavior supersedes the strict up-front check.
- Re-enables `GpuFunctionalReadWrite.TestFrequenciesReadWrite` on Aldebaran
  (gfx90a / MI210) by removing it from `FILTER[aldebaran]` in
  `amdsmitst.exclude` (was excluded under SWDEV-306889); the fix makes it pass,
  validated by CI. Other Aldebaran exclusions are unchanged.
- The ticket's secondary item (no `gfx1201` mapping in `detect_asic_filter.sh` /
  `amdsmitst.exclude`) is intentionally not addressed here — fixing the
  underlying behavior makes the set succeed, so no Navi48 test exclusion is
  needed.

Fixes ROCM-28256
