### PR TITLE
fix(rccl): Extend fp8 device arithmetic optimizations and restore unroll 8 in gfx1250 device codegen

### DIFF
--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -230,9 +230,9 @@ def calc_unroll_and_pipeline_for_local_arch():
     elif "gfx908" == gfx_name or ("gfx942" == gfx_name and cu_count > 80):
       return (["2"], all_pipelines)
     elif "gfx1250" == gfx_name:
-      # gfx1250 (MI450) benefits from larger unrolls; build only 16 and 32
-      # (32 is the default, see commSetUnrollFactor).
-      return (["16", "32"], all_pipelines)
+      # gfx1250 (MI450) benefits from larger unrolls; Unroll 8 required for FP8 launch;
+      # 32 is the default (commSetUnrollFactor).
+      return (["8", "16", "32"], all_pipelines)
     else:
       return (["4"], all_pipelines)
   else:

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1033,8 +1033,31 @@ static ncclResult_t scheduleCollTasksToPlan(struct ncclComm* comm, struct ncclKe
     plan->threadPerBlock = std::max(plan->threadPerBlock, 192 /* 3*WARP_SIZE */);
 #endif
     if (!plan->kernelSpecialized) {
-      plan->kernelFn = ncclKerns[ncclGetKernelIndex(comm)].kernelFn;
-      plan->kernelSpecialized = ncclKerns[ncclGetKernelIndex(comm)].specialized;
+      int kernelIndex = ncclGetKernelIndex(comm);
+      if (IsArchMatch(comm->archName, "gfx1250") && task->protocol == NCCL_PROTO_LL) {
+        if (getenv("RCCL_UNROLL_FACTOR") != nullptr) {
+          if (kernelIndex == NCCL_UNROLL_32) {
+            static bool warnedLlUnroll32 = false;
+            if (!warnedLlUnroll32) {
+              WARN("RCCL_UNROLL_FACTOR=5 (unroll 32) may cause issues with LL protocol on gfx1250; "
+                   "consider RCCL_UNROLL_FACTOR=3 (unroll 8) for LL protocol collectives.");
+              warnedLlUnroll32 = true;
+            }
+          }
+        } else if (ncclDevFuncUnrollGenerated[NCCL_UNROLL_8]) {
+          if (kernelIndex != NCCL_UNROLL_8) {
+            static bool loggedLlUnrollClamp = false;
+            if (!loggedLlUnrollClamp) {
+              INFO(NCCL_INIT, "Using unroll 8 for LL protocol on gfx1250 (default unroll %d)",
+                   (int)(pow(2.0, (double)kernelIndex)));
+              loggedLlUnrollClamp = true;
+            }
+          }
+          kernelIndex = NCCL_UNROLL_8;
+        }
+      }
+      plan->kernelFn = ncclKerns[kernelIndex].kernelFn;
+      plan->kernelSpecialized = ncclKerns[kernelIndex].specialized;
     }
     // Profiler
     plan->groupApiEventHandle = task->groupApiEventHandle;

--- a/projects/rccl/src/include/rccl_float8.h
+++ b/projects/rccl/src/include/rccl_float8.h
@@ -72,7 +72,7 @@ inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
   } u{0};
   u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_fp8_f16(v1, v1, /* scale */ 1.f, 0);
   return u.fp8[0];
-#elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+#elif __HIP_DEVICE_COMPILE__ && (defined(__gfx942__) || defined(__gfx1250__))
 
   float2_t v;
   uint32_t ival = 0;
@@ -98,7 +98,7 @@ inline __device__ rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y) {
   } u1{0};
   u1.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(v1, v1, /* scale */ 1.f, 0);
   return u1.fp8[0];
-#elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+#elif __HIP_DEVICE_COMPILE__ && (defined(__gfx942__) || defined(__gfx1250__))
 
   float2_t v;
   uint32_t ival = 0;
@@ -124,7 +124,7 @@ inline __device__ fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y) {
   } u{0};
   u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_fp8_f16(v1, v1, /* scale */ 1.f, 0);
   return u.fp8;
-#elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+#elif __HIP_DEVICE_COMPILE__ && (defined(__gfx942__) || defined(__gfx1250__))
   float2_t v;
   uint32_t ival = 0;
   asm volatile("v_pk_add_f32 %0, %1, %2"
@@ -157,7 +157,7 @@ inline __device__ fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y) 
   } u{0};
   u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(v1, v1, /* scale */ 1.f, 0);
   return u.fp8;
-#elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+#elif __HIP_DEVICE_COMPILE__ && (defined(__gfx942__) || defined(__gfx1250__))
   float2_t v;
   uint32_t ival = 0;
   asm volatile("v_pk_add_f32 %0, %1, %2"
@@ -445,7 +445,7 @@ struct rccl_float8 {
 
   constexpr inline HIP_HOST_DEVICE rccl_float8(const rccl_float8& a) : data(a.data) {}
 
-#if defined(__gfx942__) || defined(__gfx950__)
+#if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
     // device specific optimized F8 down-conversion code
 
   template <bool stochastic_rounding = false>
@@ -480,7 +480,7 @@ struct rccl_float8 {
 #endif // __gfx942__
 
     // constructor from float
-#if defined(__gfx942__) || defined(__gfx950__)
+#if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
 
     // NOTE: ON-DEVICE... always optimal bias
   explicit HIP_DEVICE rccl_float8(float v, rocblas_hip_f8_rounding_mode rm = rocblas_hip_f8_rounding_mode::standard,
@@ -520,7 +520,7 @@ struct rccl_float8 {
     : rccl_float8((float)v, rm, rng) {}
 
     // convert to float
-#if defined(__gfx942__) || defined(__gfx950__)
+#if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
     // upcast using device specific intrinsic
   explicit inline HIP_DEVICE operator float() const {
     float fval;
@@ -579,7 +579,7 @@ struct rccl_bfloat8 {
 
   constexpr inline HIP_HOST_DEVICE rccl_bfloat8(const rccl_bfloat8& a) : data(a.data) {}
 
-#if defined(__gfx942__) || defined(__gfx950__)
+#if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
     // device specific optimized F8 down-conversion code
 
   template <bool stochastic_rounding = false>
@@ -614,7 +614,7 @@ struct rccl_bfloat8 {
 #endif // __gfx942__
 
     // constructor from float
-#if defined(__gfx942__) || defined(__gfx950__)
+#if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
 
     // NOTE: ON-DEVICE... always optimal bias
   explicit HIP_DEVICE rccl_bfloat8(float v, rocblas_hip_f8_rounding_mode rm = rocblas_hip_f8_rounding_mode::standard,
@@ -654,7 +654,7 @@ struct rccl_bfloat8 {
     : rccl_bfloat8((float)v, rm, rng) {}
 
     // convert to float
-#if defined(__gfx942__) || defined(__gfx950__)
+#if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
     // upcast using device specific intrinsic
   explicit inline HIP_DEVICE operator float() const {
     float fval;
@@ -984,7 +984,7 @@ template <
   typename std::enable_if<
     (!(std::is_same<T, Ta>{}) && (std::is_same<T, rccl_float8>{} || std::is_same<T, rccl_bfloat8>{})), int>::type = 0>
 inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng) {
-#if defined(__gfx942__) || defined(__gfx950__)
+#if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
     // NOTE: we are directly calling cast_to_f8_from_f32 instead of constructor to optimize away one runtime branch
   T val;
   if (std::is_same<T, rccl_float8>::value)


### PR DESCRIPTION
Restore unroll 8 in gfx1250 device codegen so FP8 kernels link and launch (RCCL_UNROLL_FACTOR=3). Extend gfx950 FP8 device optimizations to gfx1250

## Motivation

FP8 ReduceScatter on gfx1250 fails on rccl/gfx1250 after #8880 narrowed device codegen to unroll 16/32 only. FP8 Ring/Simple requires the unroll-8 kernel variant and fails with invalid device function. gfx1250 was also excluded from FP8 device optimizations in rccl_float8.h.

## Technical Details

- generate.py: Build unroll 8, 16, and 32 for gfx1250 (unroll 8 required for FP8 launch and RCCL_UNROLL_FACTOR=3; 32 remains the default per commSetUnrollFactor).
- rccl_float8.h: Extend gfx950 FP8 cast/upcast optimizations to gfx1250; use gfx942-style hadd intrinsics (gfx950 scalef32 is unsupported on gfx1250).

Related: #8880 — https://github.com/ROCm/rocm-systems/commit/4ee4eb0a4f87f1acf1956ebfb07ae60b5790a018

## Issue Tracking

JIRA ID: ROCM-28679

## Test Plan

- Build RCCL for gfx1250 (./install.sh -l)
- Run reduce_scatter_perf @ 64M, MPI 4 ranks, Ring/Simple
- Compare FP32 and FP8 with default unroll and RCCL_UNROLL_FACTOR=3 (unroll 8)
- Compare against rccl/gfx1250 baseline (c318fa3) and prior good build (e0ebb75)

## Test Result

| Build | FP8 Ring/Simple | FP8 busbw (unroll 8) |
| --- | --- | --- |
| `c318fa3` (baseline) | FAIL (`invalid device function`) | ... |
| This PR | PASS | ... |
| `e0ebb75` (reference) | PASS | ... |

FP32 Ring/Simple behavior is unchanged from the baseline. FP8 Ring/Simple no longer fails on the default path and completes successfully. With `RCCL_UNROLL_FACTOR=3` (unroll 8) and applying the fp8 device optimizations to gfx1250, FP8 bandwidth improves over both the broken baseline and the prior reference build.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
