### PR TITLE
fix(rccl): keep AINIC transport usable with NCCL_NET_PLUGIN=none

### DIFF
--- a/projects/rccl/src/plugin/gin.cc
+++ b/projects/rccl/src/plugin/gin.cc
@@ -208,12 +208,15 @@ static void initPluginLibsOnceFunc() {
   char* envGinPluginList = nullptr;
   char* savePtr = nullptr;
   int pluginCounter = 0;
+  // "none" and an empty value only opt out of external plugins; they must not disable the internal AINIC path
+  bool extGinPluginRequested = false;
 
   memset(ginPluginLibs, 0, NCCL_GIN_MAX_PLUGINS * sizeof(ginPluginLib_t));
   envGinPlugin = ncclGetEnv("NCCL_GIN_PLUGIN");
   if (envGinPlugin) {
     INFO(NCCL_ENV | NCCL_NET, "NCCL_GIN_PLUGIN set by environment to %s", envGinPlugin);
     if (strcasecmp(envGinPlugin, "none") == 0) envGinPlugin = "";
+    extGinPluginRequested = (envGinPlugin[0] != '\0');
     envGinPluginList = strdup(envGinPlugin);
     // Iterate over list until the list is empty
     ginPluginName = strtok_r(envGinPluginList, ",", &savePtr);
@@ -255,8 +258,8 @@ static void initPluginLibsOnceFunc() {
   if (envNet && (strcasecmp(envNet, "ROCM-IB") == 0)) {
     envNet = "IB-CAST";
   }
-  if ((envNet && strcasecmp(envNet, "IB-CAST") == 0 && !(envGinPlugin)) ||
-      (!envNet && rcclUseAinic() && !(envGinPlugin))) {
+  if ((envNet && strcasecmp(envNet, "IB-CAST") == 0 && !extGinPluginRequested) ||
+      (!envNet && rcclUseAinic() && !extGinPluginRequested)) {
     ginPluginLibs[pluginCounter].ncclGin = &IbCastGinIb;
     ginPluginLibs[pluginCounter].ncclGinPluginState = ncclGinPluginStateInitReady;
     ginPluginLibs[pluginCounter].ncclGinVersion = ncclGinVersion[0];

--- a/projects/rccl/src/plugin/net.cc
+++ b/projects/rccl/src/plugin/net.cc
@@ -259,12 +259,16 @@ static void initPluginLibsOnceFunc() {
   char* envNetPluginList = nullptr;
   char* savePtr = nullptr;
   int pluginCounter = 0;
+  bool envNetPluginNone = false;
 
   memset(netPluginLibs, 0, NCCL_NET_MAX_PLUGINS * sizeof(netPluginLib_t));
   envNetPlugin = ncclGetEnv("NCCL_NET_PLUGIN");
   if (envNetPlugin) {
     INFO(NCCL_ENV | NCCL_NET, "NCCL_NET_PLUGIN set by environment to %s", envNetPlugin);
-    if (strcasecmp(envNetPlugin, "none") == 0) envNetPlugin = "";
+    if (strcasecmp(envNetPlugin, "none") == 0) {
+      envNetPlugin = "";
+      envNetPluginNone = true;
+    }
     envNetPluginList = strdup(envNetPlugin);
     // Iterate over list until the list is empty
     netPluginName = strtok_r(envNetPluginList, ",", &savePtr);
@@ -304,8 +308,10 @@ static void initPluginLibsOnceFunc() {
     if (envNet && (strcasecmp(envNet, "ROCM-IB") == 0)) {
       envNet = "IB-CAST";
     }
-    if ((envNet && strcasecmp(envNet, "IB-CAST") == 0 && !(envNetPlugin)) ||
-        (!envNet && rcclUseAinic() && !(envNetPlugin))) {
+    // NCCL_NET_PLUGIN=none only opts out of external plugins, so it must not disable the internal AINIC path
+    const bool extNetPluginRequested = envNetPlugin && !envNetPluginNone;
+    if ((envNet && strcasecmp(envNet, "IB-CAST") == 0 && !extNetPluginRequested) ||
+        (!envNet && rcclUseAinic() && !extNetPluginRequested)) {
       netPluginLibs[pluginCounter].ncclNet = &netIbCast;
       netPluginLibs[pluginCounter++].ncclNetPluginState = ncclNetPluginStateInitReady;
     } else {

--- a/projects/rccl/src/plugin/net.cc
+++ b/projects/rccl/src/plugin/net.cc
@@ -259,16 +259,15 @@ static void initPluginLibsOnceFunc() {
   char* envNetPluginList = nullptr;
   char* savePtr = nullptr;
   int pluginCounter = 0;
-  bool envNetPluginNone = false;
+  // "none" and an empty value only opt out of external plugins; they must not disable the internal AINIC path
+  bool extNetPluginRequested = false;
 
   memset(netPluginLibs, 0, NCCL_NET_MAX_PLUGINS * sizeof(netPluginLib_t));
   envNetPlugin = ncclGetEnv("NCCL_NET_PLUGIN");
   if (envNetPlugin) {
     INFO(NCCL_ENV | NCCL_NET, "NCCL_NET_PLUGIN set by environment to %s", envNetPlugin);
-    if (strcasecmp(envNetPlugin, "none") == 0) {
-      envNetPlugin = "";
-      envNetPluginNone = true;
-    }
+    if (strcasecmp(envNetPlugin, "none") == 0) envNetPlugin = "";
+    extNetPluginRequested = (envNetPlugin[0] != '\0');
     envNetPluginList = strdup(envNetPlugin);
     // Iterate over list until the list is empty
     netPluginName = strtok_r(envNetPluginList, ",", &savePtr);
@@ -308,8 +307,6 @@ static void initPluginLibsOnceFunc() {
     if (envNet && (strcasecmp(envNet, "ROCM-IB") == 0)) {
       envNet = "IB-CAST";
     }
-    // NCCL_NET_PLUGIN=none only opts out of external plugins, so it must not disable the internal AINIC path
-    const bool extNetPluginRequested = envNetPlugin && !envNetPluginNone;
     if ((envNet && strcasecmp(envNet, "IB-CAST") == 0 && !extNetPluginRequested) ||
         (!envNet && rcclUseAinic() && !extNetPluginRequested)) {
       netPluginLibs[pluginCounter].ncclNet = &netIbCast;


### PR DESCRIPTION
## Motivation

The AINIC auto-select for netIbCast required NCCL_NET_PLUGIN to be unset. "none" is rewritten to an empty string before that check, so the documented way to skip the external plugin search also forced the generic ncclNetIb path even on AINIC hardware, with no way to opt out of external plugins while keeping the internal AINIC transport.

## Technical Details

`initPluginLibsOnceFunc()` gated netIbCast selection on `!(envNetPlugin)` — true only if `NCCL_NET_PLUGIN` was never set. Since `none` rewrites the value to `""` (non-null), it fails this check like any other value. Added `envNetPluginNone` to track the `none` case separately, so the condition becomes `extNetPluginRequested = envNetPlugin && !envNetPluginNone` — true only when a different plugin was actually requested. `none` now disables external plugin search without disabling AINIC auto-select.

## Issue Tracking

JIRA ID : AICOMRCCL-1663

## Test Plan

Live-tested on AINIC hardware (2-node/16-GPU, `NCCL_DEBUG=INFO`) with `NCCL_NET_PLUGIN=none`, before/after. Cross-tested on two non-AINIC clusters (Mellanox and Broadcom NICs) for regression.

## Test Result

AINIC hardware: now correctly selects `IB-CAST` with AINIC optimizations enabled and no external plugin loaded (previously forced generic `IB`). Unset case unaffected. Non-AINIC clusters: no behavior change, `#wrong = 0`, no perf regression.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.