### PR TITLE
[rocrtst] Fix hotswap functional tests after flag flip

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -183,6 +183,7 @@ rocr::hotswap::LoadAgentCodeObjectCallbacks MakeLoadCallbacks(LoadRecorder* reco
 void ResetRuntimeTestEnv() {
   g_fake_hsa_env = FakeHsaEnv{};
   g_fake_env_vars.clear();
+  g_fake_env_vars["HSA_HOTSWAP_ENABLE"] = "1";
   rocr::hotswap::ResetAgentGfxRevisionCache();
   rocr::hotswap::ClearRetargetCacheForTesting();
   rocr::hotswap::ForceRetargetCodeObjectFailureForTesting(false);
@@ -245,6 +246,20 @@ rocr::hotswap::AgentGfxRevision MakeRevision(const std::string& gfx_target, uint
 TEST(HotswapBackendSelection, ConfigurationIsImmutableWithinRuntimeGeneration) {
   ResetRuntimeTestEnv();
   EXPECT_EQ(rocr::hotswap::GetHotswapBackend(), rocr::hotswap::HotswapBackend::kComgr);
+
+  g_fake_env_vars.clear();
+  EXPECT_EQ(rocr::hotswap::GetHotswapBackend(), rocr::hotswap::HotswapBackend::kComgr);
+
+  rocr::hotswap::ConfigureHotswapBackend();
+  EXPECT_EQ(rocr::hotswap::GetHotswapBackend(), rocr::hotswap::HotswapBackend::kRocjitsu);
+  EXPECT_TRUE(rocr::hotswap::IsRocjitsuHotswapEnabled());
+
+  g_fake_env_vars["HSA_HOTSWAP_ENABLE"] = "1";
+  EXPECT_EQ(rocr::hotswap::GetHotswapBackend(), rocr::hotswap::HotswapBackend::kRocjitsu);
+
+  rocr::hotswap::ConfigureHotswapBackend();
+  EXPECT_EQ(rocr::hotswap::GetHotswapBackend(), rocr::hotswap::HotswapBackend::kComgr);
+  EXPECT_FALSE(rocr::hotswap::IsRocjitsuHotswapEnabled());
 
   g_fake_env_vars["HSA_HOTSWAP_ENABLE"] = "2";
   EXPECT_EQ(rocr::hotswap::GetHotswapBackend(), rocr::hotswap::HotswapBackend::kComgr);


### PR DESCRIPTION
https://github.com/ROCm/rocm-systems/pull/9514 flipped the default value of HSA_HOTSWAP_ENABLE to 2, which caused some rocrtst failures. This PR fixes those tests.

* fixes https://github.com/ROCm/rocm-systems/issues/9548