### PR TITLE
[CLR] Add swap blit kernel final

### DIFF
--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -3076,14 +3076,6 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
     }
   }
 
-  if (attrs != nullptr && !stream.device().settings().sdma_swap_supported_) {
-    for (size_t i = 0; i < numAttrs; ++i) {
-      if (attrs[i].flags & hipMemcpyFlagExtOpSwap) {
-        return hipErrorNotSupported;
-      }
-    }
-  }
-
   if (attrs != nullptr && !stream.device().settings().sdma_indirect_supported_) {
     const unsigned int kIndirectMask =
         hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst;

--- a/projects/clr/rocclr/device/blitcl.cpp
+++ b/projects/clr/rocclr/device/blitcl.cpp
@@ -150,6 +150,9 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
           (__global uchar *)descriptor.destination_address;
       ulong copy_index = ((ulong)group_ordinal * workgroup_size) + work_item_id;
 
+      // The element width is the largest power-of-two (<= 16) that divides both
+      // the source and destination addresses (chosen host-side), so every access
+      // below is naturally aligned even for offset/unaligned copy operands.
       if (descriptor.aligned_element_size == sizeof(ulong2)) {
         __global ulong2 *source_data = (__global ulong2 *)(source);
         __global ulong2 *destination_data = (__global ulong2 *)(destination);
@@ -157,9 +160,30 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
           destination_data[copy_index] = source_data[copy_index];
           copy_index += copy_stride;
         }
-      } else {
+      } else if (descriptor.aligned_element_size == sizeof(ulong)) {
+        __global ulong *source_data = (__global ulong *)(source);
+        __global ulong *destination_data = (__global ulong *)(destination);
+        while (copy_index < descriptor.aligned_element_count) {
+          destination_data[copy_index] = source_data[copy_index];
+          copy_index += copy_stride;
+        }
+      } else if (descriptor.aligned_element_size == sizeof(uint)) {
         __global uint *source_data = (__global uint *)(source);
         __global uint *destination_data = (__global uint *)(destination);
+        while (copy_index < descriptor.aligned_element_count) {
+          destination_data[copy_index] = source_data[copy_index];
+          copy_index += copy_stride;
+        }
+      } else if (descriptor.aligned_element_size == sizeof(ushort)) {
+        __global ushort *source_data = (__global ushort *)(source);
+        __global ushort *destination_data = (__global ushort *)(destination);
+        while (copy_index < descriptor.aligned_element_count) {
+          destination_data[copy_index] = source_data[copy_index];
+          copy_index += copy_stride;
+        }
+      } else {
+        __global uchar *source_data = (__global uchar *)(source);
+        __global uchar *destination_data = (__global uchar *)(destination);
         while (copy_index < descriptor.aligned_element_count) {
           destination_data[copy_index] = source_data[copy_index];
           copy_index += copy_stride;
@@ -172,6 +196,82 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
         ulong tail_end = tail_start + descriptor.trailing_byte_count;
         for (ulong i = tail_start; i < tail_end; ++i) {
           destination[i] = source[i];
+        }
+      }
+    }
+
+    __kernel void __amd_rocclr_swapBufferBatch(
+        __global const CopyBufferBatchDescriptor *descriptors,
+        uint workgroup_size,
+        uint copy_stride) {
+      uint work_item_id = __builtin_amdgcn_workitem_id_x();
+      uint group_ordinal = __builtin_amdgcn_workgroup_id_x();
+      uint descriptor_index = __builtin_amdgcn_workgroup_id_y();
+
+      CopyBufferBatchDescriptor descriptor = descriptors[descriptor_index];
+      __global uchar *source = (__global uchar *)descriptor.source_address;
+      __global uchar *destination =
+          (__global uchar *)descriptor.destination_address;
+      ulong copy_index = ((ulong)group_ordinal * workgroup_size) + work_item_id;
+
+      // The element width is the largest power-of-two (<= 16) that divides both
+      // the source and destination addresses (chosen host-side), so every access
+      // below is naturally aligned even for offset/unaligned swap operands.
+      if (descriptor.aligned_element_size == sizeof(ulong2)) {
+        __global ulong2 *source_data = (__global ulong2 *)(source);
+        __global ulong2 *destination_data = (__global ulong2 *)(destination);
+        while (copy_index < descriptor.aligned_element_count) {
+          ulong2 tmp = source_data[copy_index];
+          source_data[copy_index] = destination_data[copy_index];
+          destination_data[copy_index] = tmp;
+          copy_index += copy_stride;
+        }
+      } else if (descriptor.aligned_element_size == sizeof(ulong)) {
+        __global ulong *source_data = (__global ulong *)(source);
+        __global ulong *destination_data = (__global ulong *)(destination);
+        while (copy_index < descriptor.aligned_element_count) {
+          ulong tmp = source_data[copy_index];
+          source_data[copy_index] = destination_data[copy_index];
+          destination_data[copy_index] = tmp;
+          copy_index += copy_stride;
+        }
+      } else if (descriptor.aligned_element_size == sizeof(uint)) {
+        __global uint *source_data = (__global uint *)(source);
+        __global uint *destination_data = (__global uint *)(destination);
+        while (copy_index < descriptor.aligned_element_count) {
+          uint tmp = source_data[copy_index];
+          source_data[copy_index] = destination_data[copy_index];
+          destination_data[copy_index] = tmp;
+          copy_index += copy_stride;
+        }
+      } else if (descriptor.aligned_element_size == sizeof(ushort)) {
+        __global ushort *source_data = (__global ushort *)(source);
+        __global ushort *destination_data = (__global ushort *)(destination);
+        while (copy_index < descriptor.aligned_element_count) {
+          ushort tmp = source_data[copy_index];
+          source_data[copy_index] = destination_data[copy_index];
+          destination_data[copy_index] = tmp;
+          copy_index += copy_stride;
+        }
+      } else {
+        __global uchar *source_data = (__global uchar *)(source);
+        __global uchar *destination_data = (__global uchar *)(destination);
+        while (copy_index < descriptor.aligned_element_count) {
+          uchar tmp = source_data[copy_index];
+          source_data[copy_index] = destination_data[copy_index];
+          destination_data[copy_index] = tmp;
+          copy_index += copy_stride;
+        }
+      }
+      if ((descriptor.trailing_byte_count != 0) && (group_ordinal == 0) &&
+          (work_item_id == 0)) {
+        ulong tail_start =
+            descriptor.aligned_element_count * descriptor.aligned_element_size;
+        ulong tail_end = tail_start + descriptor.trailing_byte_count;
+        for (ulong i = tail_start; i < tail_end; ++i) {
+          uchar t = source[i];
+          source[i] = destination[i];
+          destination[i] = t;
         }
       }
     }

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2876,10 +2876,11 @@ bool KernelBlitManager::ShaderCopyBufferBatchRaw(
     const uint64_t destination_address = reinterpret_cast<uint64_t>(copy_operation.dst);
     needs_system_scope |= copy_operation.needs_system_scope || !copy_operation.metadata.isAsync_;
     attach_signal |= copy_operation.attach_signal || !copy_operation.metadata.isAsync_;
-    const bool addresses_aligned = ((source_address % kMaxAlignment) == 0) &&
-                                   ((destination_address % kMaxAlignment) == 0);
-    const uint32_t aligned_element_size =
-        (addresses_aligned) ? kMaxAlignment : sizeof(uint32_t);
+    // Use the largest power-of-two element width (<= kMaxAlignment) that divides
+    // both endpoints.
+    const uint64_t combined_alignment = source_address | destination_address;
+    const uint32_t aligned_element_size = static_cast<uint32_t>(std::min<uint64_t>(
+        combined_alignment & (~combined_alignment + 1), kMaxAlignment));
     const uint64_t aligned_element_count =
         copy_operation.size / aligned_element_size;
     const uint32_t trailing_byte_count =
@@ -3118,6 +3119,122 @@ bool KernelBlitManager::ReadBufferBatch(const std::vector<amd::BatchReadMemoryOp
 }
 
 // ================================================================================================
+bool KernelBlitManager::useShaderSwapPath(const Memory& src, const Memory& dst, size_t srcOffset,
+                                          size_t dstOffset, size_t size,
+                                          const amd::CopyMetadata& metadata) const {
+  const bool isSdmaPref =
+      metadata.copyEnginePreference_ == amd::CopyMetadata::CopyEnginePreference::SDMA;
+  const bool isBlitPref =
+      metadata.copyEnginePreference_ == amd::CopyMetadata::CopyEnginePreference::BLIT;
+  if (!dev().settings().sdma_swap_supported_) return true;  // no HW swap -> shader
+
+  // SDMA COPY_LINEAR_SWAP requires 32 byte alignment, so use blit kernel in these cases
+  constexpr uint64_t kSdmaSwapAlignment = 32;
+  const uint64_t srcAddr = src.virtualAddress() + srcOffset;
+  const uint64_t dstAddr = dst.virtualAddress() + dstOffset;
+  if (((srcAddr | dstAddr) & (kSdmaSwapAlignment - 1)) != 0) return true;
+
+  if (isSdmaPref) return false;                             // explicit CE  -> SDMA
+  if (isBlitPref) return true;                              // explicit BLIT -> shader
+  return size <= dev().settings().sdmaSwapThreshold_;        // else size-based
+}
+
+// ================================================================================================
+bool KernelBlitManager::ShaderSwapBufferBatch(
+    const std::vector<amd::BatchCopyOp>& copy_operations) const {
+  std::scoped_lock transfer_operations_lock(lockXferOps_);
+
+  constexpr uint32_t kMaxAlignment = 2 * sizeof(uint64_t);
+  constexpr uint32_t kLocalWorkSize = 512;
+  const uint32_t max_workgroups_per_copy = std::max<uint32_t>(
+      dev().settings().limit_blit_wg_ / copy_operations.size(), 1);
+  const size_t descriptor_bytes =
+      copy_operations.size() * sizeof(CopyBufferBatchDescriptor);
+  void* descriptor_buffer = gpu().allocKernArg(descriptor_bytes, kCBAlignment);
+  CopyBufferBatchDescriptor* descriptors =
+      static_cast<CopyBufferBatchDescriptor*>(descriptor_buffer);
+  size_t descriptor_index = 0;
+  uint64_t max_aligned_element_count = 0;
+  bool needs_system_scope = false;
+  bool attach_signal = false;
+
+  for (const auto& copy_operation : copy_operations) {
+    device::Memory* source_device_memory =
+        copy_operation.srcMemory->getDeviceMemory(
+            *copy_operation.srcMemory->getContext().devices()[0]);
+    device::Memory* destination_device_memory =
+        copy_operation.dstMemory->getDeviceMemory(
+            *copy_operation.dstMemory->getContext().devices()[0]);
+
+    const uint64_t source_address =
+        source_device_memory->virtualAddress() + copy_operation.srcOffset;
+    const uint64_t destination_address =
+        destination_device_memory->virtualAddress() + copy_operation.dstOffset;
+
+    // Overlapping src/dst within one swap op is UB (same contract as the SDMA swap).
+    assert((source_address + copy_operation.size <= destination_address ||
+            destination_address + copy_operation.size <= source_address) &&
+           "ShaderSwapBufferBatch: src and dst ranges must not overlap");
+
+    const bool source_svm_atomics =
+        (source_device_memory->owner()->getMemFlags() & CL_MEM_SVM_ATOMICS) != 0;
+    const bool destination_svm_atomics =
+        (destination_device_memory->owner()->getMemFlags() & CL_MEM_SVM_ATOMICS) != 0;
+    needs_system_scope |=
+        (!source_svm_atomics && source_device_memory->isHostMemDirectAccess()) ||
+        (!destination_svm_atomics && destination_device_memory->isHostMemDirectAccess()) ||
+        !copy_operation.metadata.isAsync_;
+    attach_signal |= !copy_operation.metadata.isAsync_;
+    // Use the largest power-of-two element width (<= kMaxAlignment) that divides
+    // both endpoints.
+    const uint64_t combined_alignment = source_address | destination_address;
+    const uint32_t aligned_element_size = static_cast<uint32_t>(std::min<uint64_t>(
+        combined_alignment & (~combined_alignment + 1), kMaxAlignment));
+    const uint64_t aligned_element_count =
+        copy_operation.size / aligned_element_size;
+    const uint32_t trailing_byte_count =
+        copy_operation.size % aligned_element_size;
+    max_aligned_element_count =
+        std::max(max_aligned_element_count, aligned_element_count);
+
+    descriptors[descriptor_index++] = {
+        source_address, destination_address, aligned_element_count,
+        aligned_element_size, trailing_byte_count};
+  }
+
+  uint32_t workgroup_count = static_cast<uint32_t>(
+      std::min<uint64_t>(max_workgroups_per_copy,
+                         amd::alignUp(max_aligned_element_count,
+                                      static_cast<uint64_t>(kLocalWorkSize)) /
+                             kLocalWorkSize));
+  workgroup_count = std::max<uint32_t>(workgroup_count, 1);
+  const uint32_t copy_stride = workgroup_count * kLocalWorkSize;
+
+  amd::Kernel* const kernel = kernels_[BlitSwapBufferBatch];
+  constexpr bool kDirectVa = true;
+  setArgument(kernel, 0, sizeof(cl_mem), descriptor_buffer, 0, nullptr,
+              kDirectVa);
+
+  setArgument(kernel, 1, sizeof(kLocalWorkSize), &kLocalWorkSize);
+  setArgument(kernel, 2, sizeof(copy_stride), &copy_stride);
+
+  size_t global_work_size[2] = {copy_stride, copy_operations.size()};
+  size_t local_work_size[2] = {kLocalWorkSize, 1};
+  amd::NDRangeContainer nd_range(2, nullptr, global_work_size, local_work_size);
+
+  address parameters = captureArguments(kernel);
+  if (needs_system_scope) {
+    gpu().addSystemScope();
+  }
+  bool submit_result =
+      gpu().submitKernelInternal(nd_range, *kernel, parameters, nullptr, 0,
+                                 nullptr, nullptr, attach_signal);
+  releaseArguments(parameters);
+
+  return submit_result;
+}
+
+// ================================================================================================
 bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& copyOps) const {
   if (copyOps.empty()) {
     return true;
@@ -3135,6 +3252,7 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
   // Partition into intra-device (kernel blit) and inter-device (DMA batch) groups.
   std::vector<amd::BatchCopyOp> d2dCopyOps;
   std::vector<amd::BatchCopyOp> p2pCopyOps;
+  std::vector<amd::BatchCopyOp> swapShaderOps;
 
   for (const auto& op : copyOps) {
     device::Memory* srcDevMem = op.srcMemory->getDeviceMemory(
@@ -3149,15 +3267,16 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
 
     const Memory& srcMem = gpuMem(*srcDevMem);
     const Memory& dstMem = gpuMem(*dstDevMem);
-    bool isLinearCopyOp = op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpLinear;
-    // ShaderCopyBufferBatch only describes linear copies; route swap/other ops through DMA.
-    bool useShaderCopyPath =
-        isLinearCopyOp && useShaderCopyBufferPath(srcMem, dstMem, op.size, op.metadata);
+    bool isSwapOp = op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpSwap;
+    bool isLinearOp = op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpLinear;
 
-    if (useShaderCopyPath) {
+    if (isSwapOp && useShaderSwapPath(srcMem, dstMem, op.srcOffset, op.dstOffset, op.size,
+                                      op.metadata)) {
+      swapShaderOps.push_back(op);
+    } else if (isLinearOp && useShaderCopyBufferPath(srcMem, dstMem, op.size, op.metadata)) {
       d2dCopyOps.push_back(op);
     } else {
-      p2pCopyOps.push_back(op);
+      p2pCopyOps.push_back(op);   // large HW-supported swaps + everything else
     }
   }
 
@@ -3191,10 +3310,10 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
     }
   }
 
-  // Dispatch intra-device copies for overlap with SDMA.
+  // Dispatch intra-device copies and shader swaps for overlap with SDMA.
   // Set engine to Compute so WaitingSignal(Compute) inside copyBuffer does not
   // see an engine switch and does not add the batch's current_id_ as a dependency.
-  if (!d2dCopyOps.empty()) {
+  if (!d2dCopyOps.empty() || !swapShaderOps.empty()) {
     gpu().Barriers().SetActiveEngine(HwQueueEngine::Compute);
     // Re-add priorSignal as external so intra copies depend on prior stream operations.
     if (priorSignal != nullptr) {
@@ -3212,6 +3331,16 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
       if (!ShaderCopyBufferBatch(copy_ops_by_size)) {
         LogError("KernelBlitManager::ShaderCopyBufferBatch: Intra-device batch "
                  "copy failed!");
+        return false;
+      }
+    }
+
+    std::map<size_t, std::vector<amd::BatchCopyOp>, std::greater<size_t>> swap_ops_by_size;
+    for (const auto& op : swapShaderOps) { swap_ops_by_size[op.size].push_back(op); }
+    for (const auto& swap_ops_by_size_entry : swap_ops_by_size) {
+      const auto& swap_ops = swap_ops_by_size_entry.second;
+      if (!ShaderSwapBufferBatch(swap_ops)) {
+        LogError("KernelBlitManager::ShaderSwapBufferBatch: Intra-device batch swap failed!");
         return false;
       }
     }

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -309,6 +309,7 @@ class KernelBlitManager : public DmaBlitManager {
     StreamOpsIncrement,
     StreamOpsDecrement,
     BlitCopyBufferBatch,
+    BlitSwapBufferBatch,
     BlitLinearTotal,
     FillImage = BlitLinearTotal,
     BlitCopyImage,
@@ -634,6 +635,13 @@ class KernelBlitManager : public DmaBlitManager {
   //! Copies a batch of raw virtual-address ranges using the shader path
   bool ShaderCopyBufferBatchRaw(const std::vector<BatchRawCopyOp>& copy_ops) const;
 
+  //! Returns true if a batch swap should use the shader path.
+  bool useShaderSwapPath(const Memory& src, const Memory& dst, size_t srcOffset, size_t dstOffset,
+                         size_t size, const amd::CopyMetadata& metadata) const;
+
+  //! Swaps a batch of buffer pairs using a single/multiple shader dispatch
+  bool ShaderSwapBufferBatch(const std::vector<amd::BatchCopyOp>& copy_operations) const;
+
   //! Atomically updates a memory location (i.e. writes, increments or decrements the memory).
   bool streamOpsUpdate(uint blitType, device::Memory& memory, uint64_t value, size_t offset,
                        size_t sizeBytes) const;
@@ -659,6 +667,7 @@ static const char* BlitName[KernelBlitManager::BlitTotal] = {
     "__amd_rocclr_initHeap",           "__amd_rocclr_batchMemOp",
     "__amd_rocclr_streamOpsIncrement", "__amd_rocclr_streamOpsDecrement",
     "__amd_rocclr_copyBufferBatch",
+    "__amd_rocclr_swapBufferBatch",
     "__amd_rocclr_fillImage",          "__amd_rocclr_copyImage",
     "__amd_rocclr_copyImage1DA",       "__amd_rocclr_copyImageToBuffer",
     "__amd_rocclr_copyBufferToImage"};

--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -47,6 +47,7 @@ Settings::Settings() {
       flagIsDefault(GPU_PINNED_MIN_XFER_SIZE) ? 64 * Ki : GPU_PINNED_MIN_XFER_SIZE * Mi;
 
   sdmaCopyThreshold_ = GPU_FORCE_BLIT_COPY_SIZE * Ki;
+  sdmaSwapThreshold_ = GPU_FORCE_BLIT_SWAP_SIZE * Ki;
 
   // Don't support Denormals for single precision by default
   singleFpDenorm_ = false;

--- a/projects/clr/rocclr/device/rocm/rocsettings.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.hpp
@@ -58,6 +58,7 @@ class Settings : public device::Settings {
   size_t pinnedMinXferSize_;  //!< Minimal buffer size for pinned transfer
 
   size_t sdmaCopyThreshold_;   //!< Use SDMA to copy above this size
+  size_t sdmaSwapThreshold_;   //!< Use SDMA for batch swaps above this size
   size_t sdma_p2p_threshold_;  //!< Use SDMA in P2P above this size
 
   uint32_t hmmFlags_;       //!< HMM functionality control flags

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -178,11 +178,7 @@ release(uint, HIP_HIDDEN_FREE_MEM, 0,                                         \
         "0 = Disable")                                                        \
 release(size_t, GPU_FORCE_BLIT_COPY_SIZE, 16,                                 \
         "Use Blit until this size(in KB) for copies")                         \
-/* GPU_FORCE_BLIT_SWAP_SIZE: default 16 is a placeholder mirroring           \
- * GPU_FORCE_BLIT_COPY_SIZE. TODO: tune from perf -- swap moves 2x the bytes \
- * of a copy (read+write both endpoints) so the tuned value is expected to be \
- * LOWER. Only consulted when sdma_swap_supported_ is true.                 */ \
-release(size_t, GPU_FORCE_BLIT_SWAP_SIZE, 16,                                 \
+release(size_t, GPU_FORCE_BLIT_SWAP_SIZE, 128,                                \
         "Use shader blit for batch swaps until this size (in KB)")            \
 release(uint, ROC_ACTIVE_WAIT_TIMEOUT, 0,                                     \
         "Forces active wait of GPU interrup for the timeout(us)")             \

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -178,6 +178,12 @@ release(uint, HIP_HIDDEN_FREE_MEM, 0,                                         \
         "0 = Disable")                                                        \
 release(size_t, GPU_FORCE_BLIT_COPY_SIZE, 16,                                 \
         "Use Blit until this size(in KB) for copies")                         \
+/* GPU_FORCE_BLIT_SWAP_SIZE: default 16 is a placeholder mirroring           \
+ * GPU_FORCE_BLIT_COPY_SIZE. TODO: tune from perf -- swap moves 2x the bytes \
+ * of a copy (read+write both endpoints) so the tuned value is expected to be \
+ * LOWER. Only consulted when sdma_swap_supported_ is true.                 */ \
+release(size_t, GPU_FORCE_BLIT_SWAP_SIZE, 16,                                 \
+        "Use shader blit for batch swaps until this size (in KB)")            \
 release(uint, ROC_ACTIVE_WAIT_TIMEOUT, 0,                                     \
         "Forces active wait of GPU interrup for the timeout(us)")             \
 release(bool, ROC_ENABLE_LARGE_BAR, true,                                     \

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -849,6 +849,10 @@ memory:
     tags: [transfer, stream]
   Unit_hipMemcpyBatchAsync_D2H_Functional: *level_2
   Unit_hipMemcpyBatchAsync_H2H_Functional: *level_2
+  Unit_hipMemcpyBatchAsync_Swap_H2D_Functional: *level_2
+  Unit_hipMemcpyBatchAsync_Swap_D2H_Functional: *level_2
+  Unit_hipMemcpyBatchAsync_Swap_MultiOp: *level_2
+  Unit_hipMemcpyBatchAsync_Swap_UnalignedMatrix: *level_2
   Unit_hipMemcpyBatchAsync_Mixed_Functional:
     <<: *level_2
     tags: [transfer]

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -893,20 +893,10 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Swap_MultiOp) {
 /**
  * Test Description
  * ------------------------
- * - Parameterized H<->D swap correctness over mismatched src/dst
- *   byte offsets and two transfer sizes.  For each (src_off, dst_off) pair the
- *   difference d = (dst_addr - src_addr) selects the largest shareable op width
- *   per the design doc's per-copy op-size algorithm, exercising op widths
- *   1/2/4/8/16 plus head/tail handling:
- *
- *     (0,0)   -> 16-byte body, no head/tail
- *     (4,4)   -> 4-byte-aligned, aligned fallback
- *     (0,15)  -> d=15 (odd) -> 1-byte body
- *     (1,15)  -> d=14 -> 2-byte body, head=1
- *     (3,11)  -> d=8  -> 8-byte body, head=5
- *     (3,9)   -> d=6  -> 2-byte body, head=1
- *     (1,0)   -> d=-1 (odd) -> 1-byte body
- *     (8,8)   -> 8-byte-aligned mismatch-free
+ * - Parameterized H<->D swap correctness over mismatched src/dst byte offsets and two
+ *   transfer sizes. For each (src_off, dst_off) pair, the implementation selects the
+ *   largest power-of-two element width (<= 16) that divides both endpoint addresses;
+ *   any remainder is handled as a trailing byte tail.
  *
  *   Sizes: 4096 and 131072 above and below SDMA threshold
  *
@@ -930,7 +920,8 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Swap_UnalignedMatrix) {
       GENERATE(std::make_pair(size_t{0}, size_t{0}), std::make_pair(size_t{4}, size_t{4}),
                std::make_pair(size_t{0}, size_t{15}), std::make_pair(size_t{1}, size_t{15}),
                std::make_pair(size_t{3}, size_t{11}), std::make_pair(size_t{3}, size_t{9}),
-               std::make_pair(size_t{1}, size_t{0}), std::make_pair(size_t{8}, size_t{8}));
+               std::make_pair(size_t{1}, size_t{0}), std::make_pair(size_t{8}, size_t{8}),
+               std::make_pair(size_t{2}, size_t{2}));
   const size_t size = GENERATE(size_t{4096}, size_t{131072});
   const size_t src_off = off.first;
   const size_t dst_off = off.second;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -656,6 +656,343 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_H2H_Functional) {
   VerifyHostBuffers(dst, copy_size);
 }
 
+#if HT_AMD
+/**
+ * Test Description
+ * ------------------------
+ * - Verify hipMemcpyBatchAsync with hipMemcpyFlagExtOpSwap
+ *   exchanges the contents of a hipHostMalloc host buffer and a hipMalloc
+ *   device buffer (H->D direction: host src <-> device dst).
+ *
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Swap_H2D_Functional) {
+  constexpr size_t kNumElements = 4096;
+  constexpr size_t kSizeBytes = kNumElements * sizeof(int);
+  constexpr int kValHost = 42;
+  constexpr int kValDev = 99;
+
+  // Host buffer via hipHostMalloc so it is a tracked amd::Memory (Host type).
+  void* h_src = nullptr;
+  HIP_CHECK(hipHostMalloc(&h_src, kSizeBytes));
+
+  // Device buffer via hipMalloc.
+  void* d_dst = nullptr;
+  HIP_CHECK(hipMalloc(&d_dst, kSizeBytes));
+
+  // Fill host side with kValHost, device side with kValDev.
+  std::vector<int> hostInit(kNumElements, kValHost);
+  std::memcpy(h_src, hostInit.data(), kSizeBytes);
+
+  std::vector<int> devInit(kNumElements, kValDev);
+  HIP_CHECK(hipMemcpy(d_dst, devInit.data(), kSizeBytes, hipMemcpyHostToDevice));
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  void* dsts[] = {d_dst};
+  void* srcs[] = {h_src};
+  size_t sizes[] = {kSizeBytes};
+  size_t attrsIdxs[] = {0};
+
+  hipMemcpyAttributes attr{};
+  attr.flags = hipMemcpyFlagExtOpSwap;
+  attr.srcAccessOrder = hipMemcpySrcAccessOrderStream;
+
+  size_t failIdx = 0;
+  hipError_t err =
+      hipMemcpyBatchAsync(dsts, srcs, sizes, 1, &attr, attrsIdxs, 1, &failIdx, stream);
+  if (err == hipErrorNotSupported) {
+    HIP_CHECK(hipStreamDestroy(stream));
+    HIP_CHECK(hipFree(d_dst));
+    HIP_CHECK(hipHostFree(h_src));
+    HIP_SKIP_TEST(HipTest::SkipReason::kSdmaSwapUnsupported);
+  }
+  HIP_CHECK(err);
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // After swap: host side should hold kValDev, device side kValHost.
+  std::vector<int> resultDev(kNumElements);
+  HIP_CHECK(hipMemcpy(resultDev.data(), d_dst, kSizeBytes, hipMemcpyDeviceToHost));
+
+  const int* resultHost = static_cast<const int*>(h_src);
+  for (size_t i = 0; i < kNumElements; i++) {
+    INFO("host[" << i << "] = " << resultHost[i] << " (expected " << kValDev << ")");
+    REQUIRE(resultHost[i] == kValDev);
+    INFO("dev[" << i << "] = " << resultDev[i] << " (expected " << kValHost << ")");
+    REQUIRE(resultDev[i] == kValHost);
+  }
+
+  HIP_CHECK(hipFree(d_dst));
+  HIP_CHECK(hipHostFree(h_src));
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verify hipMemcpyBatchAsync swap in the reverse direction:
+ *   device src (hipMalloc) <-> host dst (hipHostMalloc).
+ *
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Swap_D2H_Functional) {
+  constexpr size_t kNumElements = 4096;
+  constexpr size_t kSizeBytes = kNumElements * sizeof(int);
+  constexpr int kValDev = 11;
+  constexpr int kValHost = 77;
+
+  // Device buffer.
+  void* d_src = nullptr;
+  HIP_CHECK(hipMalloc(&d_src, kSizeBytes));
+
+  // Host buffer via hipHostMalloc.
+  void* h_dst = nullptr;
+  HIP_CHECK(hipHostMalloc(&h_dst, kSizeBytes));
+
+  // Fill device side with kValDev, host side with kValHost.
+  std::vector<int> devInit(kNumElements, kValDev);
+  HIP_CHECK(hipMemcpy(d_src, devInit.data(), kSizeBytes, hipMemcpyHostToDevice));
+
+  std::vector<int> hostInit(kNumElements, kValHost);
+  std::memcpy(h_dst, hostInit.data(), kSizeBytes);
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  // dst=h_dst (host), src=d_src (device).
+  void* dsts[] = {h_dst};
+  void* srcs[] = {d_src};
+  size_t sizes[] = {kSizeBytes};
+  size_t attrsIdxs[] = {0};
+
+  hipMemcpyAttributes attr{};
+  attr.flags = hipMemcpyFlagExtOpSwap;
+  attr.srcAccessOrder = hipMemcpySrcAccessOrderStream;
+
+  size_t failIdx = 0;
+  hipError_t err =
+      hipMemcpyBatchAsync(dsts, srcs, sizes, 1, &attr, attrsIdxs, 1, &failIdx, stream);
+  if (err == hipErrorNotSupported) {
+    HIP_CHECK(hipStreamDestroy(stream));
+    HIP_CHECK(hipFree(d_src));
+    HIP_CHECK(hipHostFree(h_dst));
+    HIP_SKIP_TEST(HipTest::SkipReason::kSdmaSwapUnsupported);
+  }
+  HIP_CHECK(err);
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // After swap: device side holds kValHost, host side holds kValDev.
+  std::vector<int> resultDev(kNumElements);
+  HIP_CHECK(hipMemcpy(resultDev.data(), d_src, kSizeBytes, hipMemcpyDeviceToHost));
+
+  const int* resultHost = static_cast<const int*>(h_dst);
+  for (size_t i = 0; i < kNumElements; i++) {
+    INFO("dev[" << i << "] = " << resultDev[i] << " (expected " << kValHost << ")");
+    REQUIRE(resultDev[i] == kValHost);
+    INFO("host[" << i << "] = " << resultHost[i] << " (expected " << kValDev << ")");
+    REQUIRE(resultHost[i] == kValDev);
+  }
+
+  HIP_CHECK(hipFree(d_src));
+  HIP_CHECK(hipHostFree(h_dst));
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verify hipMemcpyBatchAsync with multiple H<->D swap ops in a
+ *   single call.
+ *
+ *   Four independent host<->device pairs are swapped in one call; all must be
+ *   correct after synchronization.
+ *
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Swap_MultiOp) {
+  constexpr size_t kNumOps = 4;
+  constexpr size_t kNumElements = 1024;
+  constexpr size_t kSizeBytes = kNumElements * sizeof(int);
+
+  // Each pair has distinct sentinel values to confirm independence.
+  constexpr int kHostVals[kNumOps] = {10, 20, 30, 40};
+  constexpr int kDevVals[kNumOps] = {55, 66, 77, 88};
+
+  void* h_bufs[kNumOps] = {};
+  void* d_bufs[kNumOps] = {};
+
+  for (size_t op = 0; op < kNumOps; ++op) {
+    HIP_CHECK(hipHostMalloc(&h_bufs[op], kSizeBytes));
+    HIP_CHECK(hipMalloc(&d_bufs[op], kSizeBytes));
+
+    std::vector<int> hi(kNumElements, kHostVals[op]);
+    std::memcpy(h_bufs[op], hi.data(), kSizeBytes);
+
+    std::vector<int> di(kNumElements, kDevVals[op]);
+    HIP_CHECK(hipMemcpy(d_bufs[op], di.data(), kSizeBytes, hipMemcpyHostToDevice));
+  }
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  // All ops share the same swap attribute (index 0).
+  size_t sizes[kNumOps];
+  size_t attrsIdxs[kNumOps];
+  for (size_t op = 0; op < kNumOps; ++op) {
+    sizes[op] = kSizeBytes;
+    attrsIdxs[op] = 0;
+  }
+
+  hipMemcpyAttributes attr{};
+  attr.flags = hipMemcpyFlagExtOpSwap;
+  attr.srcAccessOrder = hipMemcpySrcAccessOrderStream;
+
+  size_t failIdx = 0;
+  hipError_t err = hipMemcpyBatchAsync(d_bufs, h_bufs, sizes, kNumOps, &attr,
+                                       attrsIdxs, 1, &failIdx, stream);
+  if (err == hipErrorNotSupported) {
+    HIP_CHECK(hipStreamDestroy(stream));
+    for (size_t op = 0; op < kNumOps; ++op) {
+      HIP_CHECK(hipFree(d_bufs[op]));
+      HIP_CHECK(hipHostFree(h_bufs[op]));
+    }
+    HIP_SKIP_TEST(HipTest::SkipReason::kSdmaSwapUnsupported);
+  }
+  HIP_CHECK(err);
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // Verify every pair independently.
+  for (size_t op = 0; op < kNumOps; ++op) {
+    std::vector<int> resultDev(kNumElements);
+    HIP_CHECK(hipMemcpy(resultDev.data(), d_bufs[op], kSizeBytes, hipMemcpyDeviceToHost));
+    const int* resultHost = static_cast<const int*>(h_bufs[op]);
+    for (size_t i = 0; i < kNumElements; i++) {
+      INFO("op=" << op << " dev[" << i << "]=" << resultDev[i]
+                 << " (expected " << kHostVals[op] << ")");
+      REQUIRE(resultDev[i] == kHostVals[op]);
+      INFO("op=" << op << " host[" << i << "]=" << resultHost[i]
+                 << " (expected " << kDevVals[op] << ")");
+      REQUIRE(resultHost[i] == kDevVals[op]);
+    }
+  }
+
+  for (size_t op = 0; op < kNumOps; ++op) {
+    HIP_CHECK(hipFree(d_bufs[op]));
+    HIP_CHECK(hipHostFree(h_bufs[op]));
+  }
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Parameterized H<->D swap correctness over mismatched src/dst
+ *   byte offsets and two transfer sizes.  For each (src_off, dst_off) pair the
+ *   difference d = (dst_addr - src_addr) selects the largest shareable op width
+ *   per the design doc's per-copy op-size algorithm, exercising op widths
+ *   1/2/4/8/16 plus head/tail handling:
+ *
+ *     (0,0)   -> 16-byte body, no head/tail
+ *     (4,4)   -> 4-byte-aligned, aligned fallback
+ *     (0,15)  -> d=15 (odd) -> 1-byte body
+ *     (1,15)  -> d=14 -> 2-byte body, head=1
+ *     (3,11)  -> d=8  -> 8-byte body, head=5
+ *     (3,9)   -> d=6  -> 2-byte body, head=1
+ *     (1,0)   -> d=-1 (odd) -> 1-byte body
+ *     (8,8)   -> 8-byte-aligned mismatch-free
+ *
+ *   Sizes: 4096 and 131072 above and below SDMA threshold
+ *
+ *   Each host/device allocation is size+64 bytes.  The full host allocation is
+ *   filled with 0xAA and the full device allocation with 0xBB.  A single swap of
+ *   `size` bytes is issued from host+src_off <-> device+dst_off.  After sync the
+ *   transfer region must be swapped (host holds 0xBB, device holds 0xAA) and all
+ *   bytes OUTSIDE the transfer region (the padding) must be UNCHANGED (host
+ *   padding still 0xAA, device padding still 0xBB).
+ *
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Swap_UnalignedMatrix) {
+  constexpr uint8_t kHostFill = 0xAA;
+  constexpr uint8_t kDevFill = 0xBB;
+  constexpr size_t kPad = 64;
+
+  const std::pair<size_t, size_t> off =
+      GENERATE(std::make_pair(size_t{0}, size_t{0}), std::make_pair(size_t{4}, size_t{4}),
+               std::make_pair(size_t{0}, size_t{15}), std::make_pair(size_t{1}, size_t{15}),
+               std::make_pair(size_t{3}, size_t{11}), std::make_pair(size_t{3}, size_t{9}),
+               std::make_pair(size_t{1}, size_t{0}), std::make_pair(size_t{8}, size_t{8}));
+  const size_t size = GENERATE(size_t{4096}, size_t{131072});
+  const size_t src_off = off.first;
+  const size_t dst_off = off.second;
+
+  INFO("src_off=" << src_off << " dst_off=" << dst_off << " size=" << size);
+
+  void* h_base = nullptr;
+  void* d_base = nullptr;
+  HIP_CHECK(hipHostMalloc(&h_base, size + kPad));
+  HIP_CHECK(hipMalloc(&d_base, size + kPad));
+
+  std::memset(h_base, kHostFill, size + kPad);
+  HIP_CHECK(hipMemset(d_base, kDevFill, size + kPad));
+
+  void* src = static_cast<uint8_t*>(h_base) + src_off;
+  void* dst = static_cast<uint8_t*>(d_base) + dst_off;
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  void* dsts[] = {dst};
+  void* srcs[] = {src};
+  size_t sizes[] = {size};
+  size_t attrsIdxs[] = {0};
+
+  hipMemcpyAttributes attr{};
+  attr.flags = hipMemcpyFlagExtOpSwap;
+  attr.srcAccessOrder = hipMemcpySrcAccessOrderStream;
+
+  size_t failIdx = 0;
+  // Do NOT skip on hipErrorNotSupported: at baseline the large unaligned case
+  // routes to SDMA and fails, which is the state [!shouldfail] absorbs.
+  HIP_CHECK(hipMemcpyBatchAsync(dsts, srcs, sizes, 1, &attr, attrsIdxs, 1, &failIdx, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // Copy both buffers back in full so padding can be verified too.
+  std::vector<uint8_t> devResult(size + kPad);
+  HIP_CHECK(hipMemcpy(devResult.data(), d_base, size + kPad, hipMemcpyDeviceToHost));
+  const uint8_t* hostResult = static_cast<const uint8_t*>(h_base);
+
+  for (size_t i = 0; i < size + kPad; i++) {
+    const bool in_host_region = (i >= src_off) && (i < src_off + size);
+    const uint8_t expected_host = in_host_region ? kDevFill : kHostFill;
+    INFO("host byte " << i << " (region=" << in_host_region << ") = "
+                      << static_cast<int>(hostResult[i]) << " expected "
+                      << static_cast<int>(expected_host));
+    REQUIRE(hostResult[i] == expected_host);
+
+    const bool in_dev_region = (i >= dst_off) && (i < dst_off + size);
+    const uint8_t expected_dev = in_dev_region ? kHostFill : kDevFill;
+    INFO("dev byte " << i << " (region=" << in_dev_region << ") = "
+                     << static_cast<int>(devResult[i]) << " expected "
+                     << static_cast<int>(expected_dev));
+    REQUIRE(devResult[i] == expected_dev);
+  }
+
+  HIP_CHECK(hipFree(d_base));
+  HIP_CHECK(hipHostFree(h_base));
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+#endif
+
 /**
  * Test Description
  * ------------------------


### PR DESCRIPTION
## Motivation

Add the swap blit kernel to handle this memcpy operation for small sizes and offset/unaligned memory addresses.

## Technical Details

Adds the `__amd_rocclr_swapBufferBatch` kernel and extends `__amd_rocclr_copyBufferBatch` to handle offset memory addresses.

## Issue Tracking

JIRA ID: ROCM-27454

## Test Plan

Testing added to hip-tests to verify kernel

## Test Result

Passes locally

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
