### PR TITLE
[rocjitsu] Repair gfx1250 B0-to-A0 instruction hazards

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 rj_add_object_library(rocjitsu_analysis
     def_use_chain.cpp
+    gfx1250_rewrite_hazards.cpp
     gfx1250_vgpr_msb.cpp
     indirect_branch_discovery.cpp
     liveness.cpp

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_rewrite_hazards.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_rewrite_hazards.cpp
@@ -1,0 +1,524 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/analysis/gfx1250_rewrite_hazards.h"
+
+#include "rocjitsu/analysis/gfx1250_vgpr_msb.h"
+#include "rocjitsu/code/basic_block.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/machine_insts.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/isa/operand.h"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <set>
+#include <string_view>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace rocjitsu {
+
+RegisterSet Gfx1250GeneratedValuHazard::avoid_destination_vgprs_in_bank(uint8_t bank) const {
+  RegisterSet physical;
+  for (uint8_t nops = 1; nops <= kMaxNops; ++nops)
+    physical |= defs_requiring_nops[nops];
+
+  RegisterSet result;
+  if (bank >= 4)
+    return result;
+  constexpr uint16_t kVgprsPerBank = 256;
+  physical.for_each([&](RegisterRef ref) {
+    if (ref.cls == RegClass::VGPR && ref.index / kVgprsPerBank == bank) {
+      result.expand({RegClass::VGPR, static_cast<uint16_t>(ref.index % kVgprsPerBank), ref.width});
+    }
+  });
+  return result;
+}
+
+uint8_t Gfx1250GeneratedValuHazard::required_nops(const RegisterSet &defs,
+                                                  const RegisterSet &uses) const {
+  for (uint8_t nops = kMaxNops; nops != 0; --nops) {
+    if (defs.intersects(defs_requiring_nops[nops]) || uses.intersects(uses_requiring_nops[nops])) {
+      return nops;
+    }
+  }
+  return 0;
+}
+
+namespace {
+
+[[nodiscard]] bool is_valu(const Instruction &inst) { return inst.mnemonic().starts_with("v_"); }
+
+[[nodiscard]] bool is_wmma(const Instruction &inst) {
+  return inst.mnemonic().starts_with("v_wmma_") || inst.mnemonic().starts_with("v_swmmac_");
+}
+
+[[nodiscard]] bool is_swmmac(const Instruction &inst) {
+  return inst.mnemonic().starts_with("v_swmmac_");
+}
+
+[[nodiscard]] bool is_trans(const Instruction &inst) {
+  const std::string_view mnemonic = inst.mnemonic();
+  constexpr std::array<std::string_view, 8> prefixes = {
+      "v_exp_", "v_log_", "v_rcp_", "v_rsq_", "v_sqrt_", "v_sin_", "v_cos_", "v_tanh_",
+  };
+  return std::ranges::any_of(prefixes,
+                             [&](std::string_view prefix) { return mnemonic.starts_with(prefix); });
+}
+
+[[nodiscard]] const uint32_t *wmma_matrix_words(const Instruction &inst) {
+  if (inst.raw_encoding() == nullptr)
+    return nullptr;
+  const std::string_view mnemonic = inst.mnemonic();
+  if ((mnemonic.starts_with("v_wmma_scale_") || mnemonic.starts_with("v_wmma_scale16_")) &&
+      inst.size() >= 4 * static_cast<int>(sizeof(uint32_t))) {
+    return inst.raw_encoding() + 2;
+  }
+  if (inst.size() >= 2 * static_cast<int>(sizeof(uint32_t)))
+    return inst.raw_encoding();
+  return nullptr;
+}
+
+/// @brief Decode the MATRIX_A_FMT field from a gfx1250 VOP3P WMMA body.
+[[nodiscard]] uint8_t wmma_matrix_a_format(const gfx1250::Vop3pMachineInst &matrix) {
+  return static_cast<uint8_t>(matrix.opsel);
+}
+
+/// @brief Decode the split MATRIX_B_FMT field from a gfx1250 VOP3P WMMA body.
+///
+/// @details The generated machine struct names reserved encoding bit 14
+/// `pad_14`, but gfx1250 WMMA assigns that bit as MATRIX_B_FMT[2]. Keep the
+/// encoding-specific assembly in one helper so latency classification cannot
+/// silently omit the high format bit.
+[[nodiscard]] uint8_t wmma_matrix_b_format(const gfx1250::Vop3pMachineInst &matrix) {
+  return static_cast<uint8_t>((matrix.pad_14 << 2u) | matrix.opsel_hi);
+}
+
+/// @brief LLVM gfx1250 WMMA-to-ordinary-VALU distance for one producer.
+[[nodiscard]] uint8_t wmma_to_valu_distance(const Instruction &inst) {
+  const std::string_view mnemonic = inst.mnemonic();
+  if (is_swmmac(inst))
+    return mnemonic.find("_iu8") != std::string_view::npos ? 4 : 2;
+  if (mnemonic.find("_iu8") != std::string_view::npos)
+    return 8;
+
+  // Mixed F8F6F4 is the only gfx1250 dense class whose latency depends on
+  // encoded formats. Either F8 input selects the eight-slot category.
+  if (mnemonic.find("f8f6f4") != std::string_view::npos) {
+    const uint32_t *matrix_words = wmma_matrix_words(inst);
+    if (matrix_words == nullptr)
+      return 8;
+    gfx1250::Vop3pMachineInst matrix{};
+    std::memcpy(&matrix, matrix_words, sizeof(matrix));
+    return wmma_matrix_a_format(matrix) <= 1 || wmma_matrix_b_format(matrix) <= 1 ? 8 : 4;
+  }
+  return 4;
+}
+
+void expand_operand(RegisterSet &set, const Instruction &inst, const Operand &operand,
+                    const Gfx1250VgprMsbAnalysis &vgpr_msb) {
+  auto ref = operand.to_register_ref();
+  if (!ref || ref->cls != RegClass::VGPR)
+    return;
+  if (const auto bank = vgpr_msb.bank_before(inst, operand.vgpr_msb_role())) {
+    ref->index = static_cast<uint16_t>(ref->index + static_cast<uint16_t>(*bank) * 256u);
+    set.expand(*ref);
+    return;
+  }
+
+  // A join with different MODE.VGPR_MSB values can select any one bank.
+  // Timing exclusions are may-access facts, so retain all four possibilities.
+  for (uint16_t bank = 0; bank < 4; ++bank) {
+    RegisterRef possible = *ref;
+    possible.index = static_cast<uint16_t>(possible.index + bank * 256u);
+    set.expand(possible);
+  }
+}
+
+struct PhysicalVgprAccesses {
+  RegisterSet defs;
+  RegisterSet uses;
+};
+
+[[nodiscard]] PhysicalVgprAccesses physical_vgpr_accesses(const Instruction &inst,
+                                                          const Gfx1250VgprMsbAnalysis &vgpr_msb) {
+  PhysicalVgprAccesses result;
+  for (int index = 0; index < inst.num_dst_operands(); ++index) {
+    if (const Operand *operand = inst.dst_operand(index))
+      expand_operand(result.defs, inst, *operand, vgpr_msb);
+  }
+  for (int index = 0; index < inst.num_src_operands(); ++index) {
+    if (const Operand *operand = inst.src_operand(index))
+      expand_operand(result.uses, inst, *operand, vgpr_msb);
+  }
+  std::vector<const Operand *> implicit_uses;
+  inst.implicit_use_operands(implicit_uses);
+  for (const Operand *operand : implicit_uses) {
+    if (operand != nullptr)
+      expand_operand(result.uses, inst, *operand, vgpr_msb);
+  }
+  return result;
+}
+
+struct WmmaCoexecutionAccesses {
+  RegisterSet definition;
+  RegisterSet definition_conflicts;
+  RegisterSet inputs;
+};
+
+[[nodiscard]] WmmaCoexecutionAccesses
+wmma_coexecution_accesses(const Instruction &inst, const Gfx1250VgprMsbAnalysis &vgpr_msb) {
+  WmmaCoexecutionAccesses result;
+  if (const Operand *destination = inst.dst_operand(0)) {
+    expand_operand(result.definition, inst, *destination, vgpr_msb);
+    expand_operand(result.definition_conflicts, inst, *destination, vgpr_msb);
+  }
+  for (int index = 0; index < std::min(inst.num_src_operands(), 2); ++index) {
+    if (const Operand *operand = inst.src_operand(index)) {
+      expand_operand(result.definition_conflicts, inst, *operand, vgpr_msb);
+      expand_operand(result.inputs, inst, *operand, vgpr_msb);
+    }
+  }
+  if (is_swmmac(inst)) {
+    if (const Operand *index = inst.src_operand(2)) {
+      expand_operand(result.definition_conflicts, inst, *index, vgpr_msb);
+      expand_operand(result.inputs, inst, *index, vgpr_msb);
+    }
+  }
+  return result;
+}
+
+} // namespace
+
+bool gfx1250_is_rewrite_hazard_producer(const Instruction &inst) {
+  return is_trans(inst) || is_wmma(inst);
+}
+
+bool gfx1250_scope_has_rewrite_hazard_producer(KernelBlockScope blocks) {
+  for (BasicBlock *block : blocks) {
+    if (block == nullptr)
+      continue;
+    for (const Instruction &inst : block->instructions()) {
+      if (gfx1250_is_rewrite_hazard_producer(inst))
+        return true;
+    }
+  }
+  return false;
+}
+
+class Gfx1250RewriteHazardAnalysis::Impl {
+public:
+  Impl(KernelBlockScope blocks, BasicBlock *entry, std::span<const ScopedCfgEdge> extra_edges,
+       std::span<const uint8_t> text)
+      : vgpr_msb_(blocks, entry, extra_edges, text) {
+    std::unordered_map<const BasicBlock *, size_t> block_index;
+    block_index.reserve(blocks.size());
+    predecessors_.resize(blocks.size());
+    successors_.resize(blocks.size());
+    instructions_.resize(blocks.size());
+    for (size_t index = 0; index < blocks.size(); ++index) {
+      BasicBlock *block = blocks[index];
+      if (block == nullptr)
+        continue;
+      block_index.emplace(block, index);
+      auto &instructions = instructions_[index];
+      instructions.reserve(block->num_instructions());
+      for (const Instruction &inst : block->instructions()) {
+        instruction_position_.emplace(&inst, std::pair{index, instructions.size()});
+        instructions.push_back(&inst);
+      }
+    }
+
+    const auto add_edge = [&](const BasicBlock *from, const BasicBlock *to) {
+      const auto from_it = block_index.find(from);
+      const auto to_it = block_index.find(to);
+      if (from_it == block_index.end() || to_it == block_index.end())
+        return;
+      auto &successors = successors_[from_it->second];
+      if (std::ranges::find(successors, to_it->second) == successors.end())
+        successors.push_back(to_it->second);
+      auto &predecessors = predecessors_[to_it->second];
+      if (std::ranges::find(predecessors, from_it->second) == predecessors.end())
+        predecessors.push_back(from_it->second);
+    };
+    for (const BasicBlock *block : blocks) {
+      if (block == nullptr)
+        continue;
+      for (const BasicBlock *successor : block->successors())
+        add_edge(block, successor);
+    }
+    for (const ScopedCfgEdge &edge : extra_edges)
+      add_edge(edge.from, edge.to);
+  }
+
+  [[nodiscard]] Gfx1250GeneratedValuHazard before_generated_valu(const Instruction &inst) const {
+    Gfx1250GeneratedValuHazard result;
+    const auto initial = instruction_position_.find(&inst);
+    if (initial == instruction_position_.end())
+      return result;
+
+    struct Cursor {
+      size_t block = 0;
+      size_t exclusive_index = 0;
+      uint8_t valu_distance = 0;
+      bool nearest_valu_seen = false;
+    };
+    std::vector<Cursor> worklist = {
+        {.block = initial->second.first, .exclusive_index = initial->second.second}};
+    std::set<std::tuple<size_t, size_t, uint8_t, bool>> visited;
+
+    while (!worklist.empty()) {
+      Cursor cursor = worklist.back();
+      worklist.pop_back();
+      if (!visited
+               .emplace(cursor.block, cursor.exclusive_index, cursor.valu_distance,
+                        cursor.nearest_valu_seen)
+               .second) {
+        continue;
+      }
+
+      const auto &instructions = instructions_[cursor.block];
+      size_t index = cursor.exclusive_index;
+      bool expired = false;
+      while (index != 0) {
+        const Instruction &previous = *instructions[--index];
+        if (!is_valu(previous))
+          continue;
+
+        if (!cursor.nearest_valu_seen) {
+          cursor.nearest_valu_seen = true;
+          if (is_trans(previous)) {
+            const PhysicalVgprAccesses accesses = physical_vgpr_accesses(previous, vgpr_msb_);
+            // TRANS write -> generated VALU read, or TRANS read -> generated
+            // VALU write. A write/write pair is not a co-execution conflict.
+            result.uses_requiring_nops[1] |= accesses.defs;
+            result.defs_requiring_nops[1] |= accesses.uses;
+          }
+        }
+
+        if (is_wmma(previous)) {
+          const uint8_t required = wmma_to_valu_distance(previous);
+          if (cursor.valu_distance < required) {
+            const uint8_t missing = static_cast<uint8_t>(required - cursor.valu_distance);
+            const WmmaCoexecutionAccesses accesses = wmma_coexecution_accesses(previous, vgpr_msb_);
+            result.uses_requiring_nops[missing] |= accesses.definition;
+            result.defs_requiring_nops[missing] |= accesses.definition_conflicts;
+          }
+        }
+
+        ++cursor.valu_distance;
+        if (cursor.valu_distance >= Gfx1250GeneratedValuHazard::kMaxNops) {
+          expired = true;
+          break;
+        }
+      }
+      if (expired)
+        continue;
+
+      for (size_t predecessor : predecessors_[cursor.block]) {
+        worklist.push_back({.block = predecessor,
+                            .exclusive_index = instructions_[predecessor].size(),
+                            .valu_distance = cursor.valu_distance,
+                            .nearest_valu_seen = cursor.nearest_valu_seen});
+      }
+    }
+    return result;
+  }
+
+  [[nodiscard]] std::vector<Gfx1250InstructionHazard> find_instruction_hazards() const {
+    struct ConsumerHazards {
+      std::optional<Gfx1250InstructionHazard> trans;
+      std::optional<Gfx1250InstructionHazard> wmma;
+    };
+    std::unordered_map<const Instruction *, ConsumerHazards> hazards_by_consumer;
+    std::unordered_map<const Instruction *, PhysicalVgprAccesses> physical_access_cache;
+    std::unordered_map<const Instruction *, WmmaCoexecutionAccesses> wmma_access_cache;
+
+    const auto physical_accesses = [&](const Instruction &inst) -> const PhysicalVgprAccesses & {
+      auto [it, inserted] = physical_access_cache.try_emplace(&inst);
+      if (inserted)
+        it->second = physical_vgpr_accesses(inst, vgpr_msb_);
+      return it->second;
+    };
+    const auto wmma_accesses = [&](const Instruction &inst) -> const WmmaCoexecutionAccesses & {
+      auto [it, inserted] = wmma_access_cache.try_emplace(&inst);
+      if (inserted)
+        it->second = wmma_coexecution_accesses(inst, vgpr_msb_);
+      return it->second;
+    };
+    const auto record = [](std::optional<Gfx1250InstructionHazard> &destination,
+                           Gfx1250InstructionHazard candidate) {
+      if (!destination || candidate.missing_nops() > destination->missing_nops())
+        destination = candidate;
+    };
+
+    struct Cursor {
+      size_t block = 0;
+      size_t next_index = 0;
+      uint8_t valu_distance = 0;
+    };
+    std::vector<Cursor> worklist;
+    // The generated-VALU maximum bounds the reachable forward state today.
+    // Retain one defensive state beyond it so a future consumer-specific
+    // distance cannot make the worklist index depend on scan-loop ordering.
+    std::vector<std::array<uint32_t, Gfx1250GeneratedValuHazard::kMaxNops + 2>> visited_epochs(
+        instructions_.size());
+    uint32_t traversal_epoch = 0;
+
+    // Timing windows are sparse in real code. Walk forward from each producer
+    // for its bounded lifetime instead of walking backward from every VALU in
+    // the kernel.
+    for (size_t producer_block = 0; producer_block < instructions_.size(); ++producer_block) {
+      const auto &block_instructions = instructions_[producer_block];
+      for (size_t producer_index = 0; producer_index < block_instructions.size();
+           ++producer_index) {
+        const Instruction *producer_ptr = block_instructions[producer_index];
+        if (producer_ptr == nullptr)
+          continue;
+        const Instruction &producer = *producer_ptr;
+        const bool producer_is_trans = is_trans(producer);
+        const bool producer_is_wmma = is_wmma(producer);
+        if (!producer_is_trans && !producer_is_wmma)
+          continue;
+
+        const uint8_t max_distance =
+            producer_is_wmma ? static_cast<uint8_t>(wmma_to_valu_distance(producer) + 1u) : 1u;
+        const auto scan_block = [&](Cursor &cursor) {
+          const auto &instructions = instructions_[cursor.block];
+          size_t index = cursor.next_index;
+          while (index < instructions.size()) {
+            const Instruction &current = *instructions[index++];
+            if (!is_valu(current))
+              continue;
+
+            const bool current_is_wmma = is_wmma(current);
+            const bool current_is_trans = is_trans(current);
+            if (producer_is_trans) {
+              if (!current_is_wmma && !current_is_trans) {
+                const PhysicalVgprAccesses &producer_accesses = physical_accesses(producer);
+                const PhysicalVgprAccesses &current_accesses = physical_accesses(current);
+                if (current_accesses.uses.intersects(producer_accesses.defs) ||
+                    current_accesses.defs.intersects(producer_accesses.uses)) {
+                  record(hazards_by_consumer[&current].trans,
+                         {.kind = Gfx1250InstructionHazardKind::TransCoexecution,
+                          .producer_offset = producer.src_loc(),
+                          .consumer_offset = current.src_loc(),
+                          .required_slots = 1,
+                          .existing_valu_slots = 0});
+                }
+              }
+              return true;
+            }
+
+            if (!current_is_trans || current_is_wmma) {
+              const uint8_t required = static_cast<uint8_t>(wmma_to_valu_distance(producer) +
+                                                            (current_is_wmma ? 1u : 0u));
+              const WmmaCoexecutionAccesses &producer_accesses = wmma_accesses(producer);
+              const bool overlaps =
+                  current_is_wmma
+                      ? producer_accesses.definition.intersects(wmma_accesses(current).inputs)
+                      : (physical_accesses(current).uses.intersects(producer_accesses.definition) ||
+                         physical_accesses(current).defs.intersects(
+                             producer_accesses.definition_conflicts));
+              if (overlaps && cursor.valu_distance < required) {
+                record(hazards_by_consumer[&current].wmma,
+                       {.kind = Gfx1250InstructionHazardKind::WmmaCoexecution,
+                        .producer_offset = producer.src_loc(),
+                        .consumer_offset = current.src_loc(),
+                        .required_slots = required,
+                        .existing_valu_slots = cursor.valu_distance});
+              }
+            }
+
+            ++cursor.valu_distance;
+            if (cursor.valu_distance >= max_distance)
+              return true;
+          }
+          return false;
+        };
+
+        // Most timing windows expire in their producer's block. Avoid allocating
+        // and maintaining a CFG worklist for that common case.
+        Cursor initial = {
+            .block = producer_block, .next_index = producer_index + 1u, .valu_distance = 0};
+        if (scan_block(initial))
+          continue;
+
+        if (++traversal_epoch == 0) {
+          for (auto &epochs : visited_epochs)
+            epochs.fill(0);
+          traversal_epoch = 1;
+        }
+        worklist.clear();
+        for (size_t successor : successors_[producer_block])
+          worklist.push_back(
+              {.block = successor, .next_index = 0, .valu_distance = initial.valu_distance});
+
+        while (!worklist.empty()) {
+          Cursor cursor = worklist.back();
+          worklist.pop_back();
+          uint32_t &visited = visited_epochs[cursor.block][cursor.valu_distance];
+          if (visited == traversal_epoch)
+            continue;
+          visited = traversal_epoch;
+          if (scan_block(cursor))
+            continue;
+          for (size_t successor : successors_[cursor.block]) {
+            worklist.push_back(
+                {.block = successor, .next_index = 0, .valu_distance = cursor.valu_distance});
+          }
+        }
+      }
+    }
+
+    std::vector<Gfx1250InstructionHazard> hazards;
+    for (const auto &block_instructions : instructions_) {
+      for (const Instruction *inst : block_instructions) {
+        const auto found = hazards_by_consumer.find(inst);
+        if (found == hazards_by_consumer.end())
+          continue;
+        if (found->second.trans)
+          hazards.push_back(*found->second.trans);
+        if (found->second.wmma)
+          hazards.push_back(*found->second.wmma);
+      }
+    }
+    return hazards;
+  }
+
+private:
+  Gfx1250VgprMsbAnalysis vgpr_msb_;
+  std::vector<std::vector<size_t>> predecessors_;
+  std::vector<std::vector<size_t>> successors_;
+  std::vector<std::vector<const Instruction *>> instructions_;
+  std::unordered_map<const Instruction *, std::pair<size_t, size_t>> instruction_position_;
+};
+
+Gfx1250RewriteHazardAnalysis::Gfx1250RewriteHazardAnalysis(
+    KernelBlockScope blocks, BasicBlock *entry, std::span<const ScopedCfgEdge> extra_edges,
+    std::span<const uint8_t> text)
+    : impl_(std::make_unique<Impl>(blocks, entry, extra_edges, text)) {}
+
+Gfx1250RewriteHazardAnalysis::~Gfx1250RewriteHazardAnalysis() = default;
+Gfx1250RewriteHazardAnalysis::Gfx1250RewriteHazardAnalysis(
+    Gfx1250RewriteHazardAnalysis &&) noexcept = default;
+Gfx1250RewriteHazardAnalysis &
+Gfx1250RewriteHazardAnalysis::operator=(Gfx1250RewriteHazardAnalysis &&) noexcept = default;
+
+Gfx1250GeneratedValuHazard
+Gfx1250RewriteHazardAnalysis::before_generated_valu(const Instruction &inst) const {
+  return impl_->before_generated_valu(inst);
+}
+
+std::vector<Gfx1250InstructionHazard>
+Gfx1250RewriteHazardAnalysis::find_instruction_hazards() const {
+  return impl_->find_instruction_hazards();
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_rewrite_hazards.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_rewrite_hazards.h
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file gfx1250_rewrite_hazards.h
+/// @brief Short instruction-timing windows visible at gfx1250 rewrite sites.
+
+#pragma once
+
+#include "rocjitsu/analysis/liveness.h"
+#include "rocjitsu/isa/register_set.h"
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <vector>
+
+namespace rocjitsu {
+
+class BasicBlock;
+class Instruction;
+
+/// @brief Whether one source instruction can open a supported gfx1250 rewrite
+/// timing window.
+[[nodiscard]] bool gfx1250_is_rewrite_hazard_producer(const Instruction &inst);
+
+/// @brief Whether a scope contains a source instruction that can open a
+/// gfx1250 rewrite timing window.
+///
+/// @details The full analysis is unnecessary without a TRANS, WMMA, or SWMMAC
+/// producer: copied instructions cannot violate one of the supported rules,
+/// and a generated ordinary VALU has no active source window to overlap.
+[[nodiscard]] bool gfx1250_scope_has_rewrite_hazard_producer(KernelBlockScope blocks);
+
+/// @brief Timing constraints for an ordinary VALU inserted before one source instruction.
+///
+/// @details Each set at index N contains registers whose use as a generated
+/// destination would require N leading V_NOPs. The union is a soft scratch
+/// allocation exclusion: selecting another dead range avoids padding, while a
+/// high-pressure fallback can still select an overlapping range and emit the
+/// exact maximum separation returned by required_nops().
+struct Gfx1250GeneratedValuHazard {
+  static constexpr uint8_t kMaxNops = 8;
+
+  std::array<RegisterSet, kMaxNops + 1> defs_requiring_nops;
+  std::array<RegisterSet, kMaxNops + 1> uses_requiring_nops;
+
+  /// @brief Logical VGPRs to avoid for destinations generated in one physical bank.
+  ///
+  /// @details Timing analysis tracks the complete 1024-entry physical register
+  /// file. SemanticScratchAllocator uses logical indices within one 256-VGPR
+  /// bank, so this query selects physical accesses from @p bank and projects
+  /// them into the allocator's index space. It considers destination conflicts
+  /// only; current callers emit a write before any read of the selected lease.
+  [[nodiscard]] RegisterSet avoid_destination_vgprs_in_bank(uint8_t bank) const;
+
+  /// @brief Leading V_NOPs needed before generated VALU accesses.
+  [[nodiscard]] uint8_t required_nops(const RegisterSet &defs, const RegisterSet &uses = {}) const;
+};
+
+enum class Gfx1250InstructionHazardKind : uint8_t {
+  TransCoexecution,
+  WmmaCoexecution,
+};
+
+/// @brief One insufficient instruction-level separation in decoded gfx1250 code.
+struct Gfx1250InstructionHazard {
+  Gfx1250InstructionHazardKind kind = Gfx1250InstructionHazardKind::TransCoexecution;
+  uint64_t producer_offset = 0;
+  uint64_t consumer_offset = 0;
+  uint8_t required_slots = 0;
+  uint8_t existing_valu_slots = 0;
+
+  [[nodiscard]] uint8_t missing_nops() const {
+    return required_slots > existing_valu_slots ? required_slots - existing_valu_slots : 0;
+  }
+};
+
+/// @brief Bounded CFG-aware recognizer for supported hazards at semantic rewrites.
+///
+/// @details The generated-VALU query models the gfx1250 portions of LLVM's
+/// GCNHazardRecognizer that can be newly triggered when a lowering inserts an
+/// ordinary vector VALU using allocator-selected VGPRs:
+///
+/// - WMMA/SWMMAC co-execution windows, including format-dependent 4/8 and 2/4
+///   WMMA-to-VALU distances.
+/// - A non-TRANS VALU immediately following a TRANS instruction.
+///
+/// Only eight preceding VALU slots can matter to that query, so it walks a
+/// finite, memoized predecessor window rather than materializing whole-kernel
+/// history. The forward decoded-stream verifier also supports WMMA-to-WMMA,
+/// whose IU8 form can require nine slots.
+///
+/// This is deliberately not full LLVM hazard parity. The supported decoded
+/// stream directions are TRANS-to-ordinary-vector-VALU and
+/// WMMA/SWMMAC-to-ordinary-vector-VALU-or-WMMA/SWMMAC. Mixed TRANS/WMMA
+/// directions, pseudo-scalar or SGPR TRANS overlaps, and unrelated gfx1250
+/// instruction hazards remain outside this analysis.
+class Gfx1250RewriteHazardAnalysis {
+public:
+  Gfx1250RewriteHazardAnalysis(KernelBlockScope blocks, BasicBlock *entry,
+                               std::span<const ScopedCfgEdge> extra_edges = {},
+                               std::span<const uint8_t> text = {});
+  ~Gfx1250RewriteHazardAnalysis();
+
+  Gfx1250RewriteHazardAnalysis(const Gfx1250RewriteHazardAnalysis &) = delete;
+  Gfx1250RewriteHazardAnalysis &operator=(const Gfx1250RewriteHazardAnalysis &) = delete;
+  Gfx1250RewriteHazardAnalysis(Gfx1250RewriteHazardAnalysis &&) noexcept;
+  Gfx1250RewriteHazardAnalysis &operator=(Gfx1250RewriteHazardAnalysis &&) noexcept;
+
+  /// @brief Return constraints for an ordinary VALU inserted immediately before @p inst.
+  [[nodiscard]] Gfx1250GeneratedValuHazard before_generated_valu(const Instruction &inst) const;
+
+  /// @brief Verify the supported TRANS/WMMA timing subset in a decoded stream.
+  [[nodiscard]] std::vector<Gfx1250InstructionHazard> find_instruction_hazards() const;
+
+private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -4,6 +4,7 @@
 #include "rocjitsu/code/dbt/binary_translator.h"
 
 #include "rocjitsu/analysis/def_use_chain.h"
+#include "rocjitsu/analysis/gfx1250_rewrite_hazards.h"
 #include "rocjitsu/analysis/liveness.h"
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
@@ -29,6 +30,7 @@
 #include "rocjitsu/code/patch/sidecar_metadata.h"
 #include "rocjitsu/code/relocation_function_table.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna4/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/isa_properties.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
@@ -1730,6 +1732,11 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       liveness_options.min_free_vgpr = *options_.debug_min_free_vgpr;
     std::vector<const Instruction *> live_before_instructions;
     bool scope_requires_liveness = false;
+    const bool needs_gfx1250_rewrite_hazards =
+        guest_arch_ == ROCJITSU_CODE_ARCH_GFX1250 && host_arch_ == ROCJITSU_CODE_ARCH_GFX1250 &&
+        options_.input_revision == ProcessorRevision::Gfx1250B0 &&
+        options_.output_revision == ProcessorRevision::Gfx1250A0;
+    bool scope_has_gfx1250_rewrite_hazard_producer = false;
     if (semantic_translator_ && semantic_translator_->has_rules()) {
       // Semantic expansion rules are the only BinaryTranslator path that queries
       // LivenessAnalysis. Other rewrites use separate resource strategies: virtual
@@ -1746,6 +1753,10 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           // its own live-before requirement.
           const bool operand_driven_rewrite =
               is_gfx1250_b0_to_a0() && gfx1250_reads_flat_scratch_base_64bit(inst);
+          if (needs_gfx1250_rewrite_hazards && !scope_has_gfx1250_rewrite_hazard_producer &&
+              gfx1250_is_rewrite_hazard_producer(inst)) {
+            scope_has_gfx1250_rewrite_hazard_producer = true;
+          }
           if (semantic_translator_->expand_rule_requires_liveness(inst) || operand_driven_rewrite) {
             scope_requires_liveness = true;
             live_before_instructions.push_back(&inst);
@@ -1757,9 +1768,27 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           live_before_instructions.data(), live_before_instructions.size());
     }
     LivenessAnalysis liveness = LivenessAnalysis::unavailable();
+    std::vector<ScopedCfgEdge> liveness_edges;
     if (scope_requires_liveness) {
-      const auto liveness_edges = scoped_call_liveness_edges(KernelBlockScope(scope.blocks), text);
+      liveness_edges = scoped_call_liveness_edges(KernelBlockScope(scope.blocks), text);
       liveness = LivenessAnalysis(KernelBlockScope(scope.blocks), liveness_options, liveness_edges);
+    }
+    std::optional<Gfx1250RewriteHazardAnalysis> gfx1250_rewrite_hazards;
+    std::unordered_map<uint64_t, uint8_t> gfx1250_leading_hazard_nops;
+    const KernelBlockScope kernel_blocks(scope.blocks);
+    if (needs_gfx1250_rewrite_hazards &&
+        (scope_has_gfx1250_rewrite_hazard_producer ||
+         ((!semantic_translator_ || !semantic_translator_->has_rules()) &&
+          gfx1250_scope_has_rewrite_hazard_producer(kernel_blocks)))) {
+      if (liveness_edges.empty())
+        liveness_edges = scoped_call_liveness_edges(kernel_blocks, text);
+      gfx1250_rewrite_hazards.emplace(kernel_blocks, scope.entry, liveness_edges, text);
+      kernel_context.gfx1250_rewrite_hazards = &*gfx1250_rewrite_hazards;
+      for (const Gfx1250InstructionHazard &hazard :
+           gfx1250_rewrite_hazards->find_instruction_hazards()) {
+        uint8_t &required = gfx1250_leading_hazard_nops[hazard.consumer_offset];
+        required = std::max(required, hazard.missing_nops());
+      }
     }
 
     std::unordered_map<uint64_t, const Instruction *> source_instruction_by_offset;
@@ -2098,6 +2127,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         const uint64_t offset = inst.src_loc();
         uint64_t target_offset = kernel_text.size();
         const uint32_t inst_size = inst.size();
+        kernel_context.leading_valu_hazard_nops = 0;
 
         if (active_generated_island_pool && offset < active_generated_island_pool->source_end)
           continue;
@@ -2339,6 +2369,14 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                .is_call = source_fixup.source_is_call});
           append_nop_padding(kernel_text, sizeof(uint32_t), host_arch_);
           continue;
+        }
+
+        if (const auto hazard = gfx1250_leading_hazard_nops.find(offset);
+            hazard != gfx1250_leading_hazard_nops.end()) {
+          const uint32_t v_nop = gfx1250::build_vop1(gfx1250::kVNopVop1)[0];
+          for (uint8_t slot = 0; slot < hazard->second; ++slot)
+            append_words(kernel_text, std::span<const uint32_t>(&v_nop, 1));
+          kernel_context.leading_valu_hazard_nops = hazard->second;
         }
 
         const uint32_t *raw = inst.raw_encoding();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -5,6 +5,7 @@
 /// @brief Handwritten semantic expansions for gfx1250 B0-to-A0 translation.
 
 #include "rocjitsu/analysis/def_use_chain.h"
+#include "rocjitsu/analysis/gfx1250_rewrite_hazards.h"
 #include "rocjitsu/analysis/liveness.h"
 #include "rocjitsu/code/dbt/semantic/rules.h"
 #include "rocjitsu/code/dbt/semantic_scratch.h"
@@ -71,6 +72,25 @@ gfx1250_floating_wmma_control_error(const gfx1250::Vop3pMachineInst &matrix,
 template <size_t N>
 void append_words(std::vector<uint32_t> &output, const std::array<uint32_t, N> &words) {
   output.insert(output.end(), words.begin(), words.end());
+}
+
+[[nodiscard]] Gfx1250GeneratedValuHazard
+generated_valu_hazard_before(const TranslationContext &context, const Instruction &inst) {
+  if (context.gfx1250_rewrite_hazards == nullptr)
+    return {};
+  return context.gfx1250_rewrite_hazards->before_generated_valu(inst);
+}
+
+void append_generated_valu_hazard_nops(std::vector<uint32_t> &words,
+                                       const Gfx1250GeneratedValuHazard &hazard,
+                                       const TranslationContext &context, const RegisterSet &defs,
+                                       const RegisterSet &uses = {}) {
+  const uint8_t required = hazard.required_nops(defs, uses);
+  const uint8_t additional = required > context.leading_valu_hazard_nops
+                                 ? static_cast<uint8_t>(required - context.leading_valu_hazard_nops)
+                                 : 0;
+  for (uint8_t slot = 0; slot < additional; ++slot)
+    append_words(words, gfx1250::build_vop1(gfx1250::kVNopVop1));
 }
 
 /// @brief Change the gfx1250 VGPR-bank mode while preserving trap recovery state.
@@ -192,6 +212,7 @@ struct Gfx1250SgprScratchLease {
 struct Gfx1250SgprScratchRequest {
   uint16_t count = 0;
   RegisterSet forbidden;
+  RegisterSet avoid;
   Gfx1250SgprCarrierMode carrier_mode = Gfx1250SgprCarrierMode::None;
 };
 
@@ -281,6 +302,7 @@ acquire_gfx1250_sgprs(const Instruction &inst, const LivenessAnalysis &liveness,
   SemanticScratchRequest carrier_request;
   carrier_request.count = request.count;
   carrier_request.forbidden = request.forbidden;
+  carrier_request.avoid = request.avoid;
   // Lane-zero carriers must remain EXEC-independent, while private-memory
   // spill/fill instructions are EXEC-masked.
   // TODO: Support simultaneous SGPR/VGPR pressure without suppressing the
@@ -1146,9 +1168,11 @@ ExpandResult expand_gfx1250_cluster_load(const Instruction &inst, uint32_t, uint
       inst, liveness, context,
       SemanticScratchPolicy{.max_vgprs = 256,
                             .max_spill_dword_offset = kGfx1250ScratchMaxDwordOffset});
+  const Gfx1250GeneratedValuHazard leading_hazard = generated_valu_hazard_before(context, inst);
   Gfx1250SgprScratchRequest scratch_request;
   scratch_request.count = 1;
   scratch_request.forbidden = gfx1250_instruction_registers(inst);
+  scratch_request.avoid = leading_hazard.avoid_destination_vgprs_in_bank(0);
   scratch_request.carrier_mode = Gfx1250SgprCarrierMode::LaneZero;
   const auto scratch = acquire_gfx1250_sgprs(inst, liveness, context, &allocator, scratch_request);
   if (!scratch || scratch->base > 105) {
@@ -1175,6 +1199,9 @@ ExpandResult expand_gfx1250_cluster_load(const Instruction &inst, uint32_t, uint
           "gfx1250 cluster-load SGPR carrier cannot prove the VGPR-MSB mode");
     current_mode = *original_mode;
     append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+    RegisterSet generated_carrier_defs;
+    generated_carrier_defs.expand(scratch->carrier->registers());
+    append_generated_valu_hazard_nops(words, leading_hazard, context, generated_carrier_defs);
     if (!append_gfx1250_sgpr_preservation(words, *scratch, false))
       return ExpandResult::failed("gfx1250 cluster load could not preserve scalar scratch");
     append_gfx1250_vgpr_msb_transition(words, current_mode, *original_mode);
@@ -1223,6 +1250,7 @@ ExpandResult expand_gfx1250_ds_addtid(const Instruction &inst, uint32_t, uint64_
 
   gfx1250::VdsMachineInst source{};
   std::memcpy(&source, inst.raw_encoding(), sizeof(source));
+  const Gfx1250GeneratedValuHazard leading_hazard = generated_valu_hazard_before(context, inst);
 
   const auto src0_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src0);
   const auto src1_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src1);
@@ -1244,6 +1272,7 @@ ExpandResult expand_gfx1250_ds_addtid(const Instruction &inst, uint32_t, uint64_
     SemanticScratchRequest request;
     request.count = 1;
     request.forbidden = gfx1250_instruction_registers(inst);
+    request.avoid = leading_hazard.avoid_destination_vgprs_in_bank(0);
     request.allow_spill = true;
     const SemanticScratchResult scratch = allocator.acquire_vgprs(request);
     if (!scratch) {
@@ -1265,6 +1294,10 @@ ExpandResult expand_gfx1250_ds_addtid(const Instruction &inst, uint32_t, uint64_
   append_gfx1250_scratch_dependency_barrier(words);
   uint8_t current_mode = original_mode;
   append_gfx1250_vgpr_msb_transition(words, current_mode, compute_mode);
+  RegisterSet generated_temp;
+  generated_temp.expand(
+      RegisterRef{RegClass::VGPR, static_cast<uint16_t>(temp + compute_bank * 256u), 1});
+  append_generated_valu_hazard_nops(words, leading_hazard, context, generated_temp);
   if (store_scratch && store_scratch->spilled &&
       !append_gfx1250_scratch_preservation(words, *store_scratch, false)) {
     return ExpandResult::failed("gfx1250 DS store ADDTID could not preserve low-bank scratch");
@@ -1348,6 +1381,8 @@ ExpandResult expand_gfx1250_cvt_f32_fp8_e5m3(const Instruction &inst, uint32_t, 
   SemanticScratchRequest request;
   request.count = 2;
   request.forbidden = gfx1250_instruction_registers(inst);
+  const Gfx1250GeneratedValuHazard leading_hazard = generated_valu_hazard_before(context, inst);
+  request.avoid = leading_hazard.avoid_destination_vgprs_in_bank(0);
   request.allow_spill = true;
   const SemanticScratchResult scratch = allocator.acquire_vgprs(request);
   if (!scratch) {
@@ -1364,6 +1399,7 @@ ExpandResult expand_gfx1250_cvt_f32_fp8_e5m3(const Instruction &inst, uint32_t, 
   mask_request.count = 2;
   mask_request.forbidden = request.forbidden;
   mask_request.forbidden.expand(scratch.lease->registers());
+  mask_request.avoid = leading_hazard.avoid_destination_vgprs_in_bank(0);
   // The conversion, both generated compares, and scratch memory are inactive
   // under EXEC=0. The compare masks and their carrier save/restore are skipped
   // as one region, so the borrowed SGPR window remains untouched.
@@ -1406,6 +1442,14 @@ ExpandResult expand_gfx1250_cvt_f32_fp8_e5m3(const Instruction &inst, uint32_t, 
   std::vector<uint32_t> words;
   words.reserve(64);
   append_gfx1250_scratch_dependency_barrier(words);
+  RegisterSet generated_defs;
+  generated_defs.expand(scratch.lease->registers());
+  if (masks->carrier)
+    generated_defs.expand(masks->carrier->registers());
+  RegisterSet generated_uses;
+  generated_uses.expand(RegisterRef{
+      RegClass::VGPR, static_cast<uint16_t>(source.src0 - kVgprEncoding + *src0_bank * 256u), 1});
+  append_generated_valu_hazard_nops(words, leading_hazard, context, generated_defs, generated_uses);
   uint8_t current_mode = original_mode;
   if (scratch.lease->spilled || masks->has_carrier()) {
     append_gfx1250_vgpr_msb_transition(words, current_mode, 0);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_scratch.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_scratch.cpp
@@ -41,14 +41,15 @@ SemanticScratchAllocator::SemanticScratchAllocator(const Instruction &inst,
 
 bool SemanticScratchAllocator::window_is_allowed(uint16_t base,
                                                  const SemanticScratchRequest &request,
-                                                 uint16_t available_count) const {
+                                                 uint16_t available_count, bool allow_avoid) const {
   if (request.count == 0 || request.alignment == 0 || base % request.alignment != 0 ||
       static_cast<uint32_t>(base) + request.count > available_count)
     return false;
 
   RegisterSet candidate;
   candidate.expand(RegisterRef{RegClass::VGPR, base, static_cast<uint8_t>(request.count)});
-  return !candidate.intersects(request.forbidden);
+  return !candidate.intersects(request.forbidden) &&
+         (allow_avoid || !candidate.intersects(request.avoid));
 }
 
 SemanticScratchResult
@@ -64,53 +65,61 @@ SemanticScratchAllocator::acquire_vgprs(const SemanticScratchRequest &request) {
   // computation and descriptor growth.
   const uint16_t allocated_vgprs =
       static_cast<uint16_t>(std::min<uint32_t>(context_.num_vgprs, policy_.max_vgprs));
-  uint16_t unused_search_start = 0;
-  while (auto unused = liveness_.find_globally_unused_vgpr_run(
-             &inst_, request.count, unused_search_start, request.alignment, allocated_vgprs)) {
-    if (window_is_allowed(*unused, request, allocated_vgprs)) {
-      context_.require_vgprs(static_cast<uint32_t>(*unused) + request.count);
-      return {.lease = SemanticScratchLease{.reg_class = RegClass::VGPR,
-                                            .base = *unused,
-                                            .count = request.count,
-                                            .spilled = false,
-                                            .spill_offset = 0},
-              .failure = SemanticScratchFailure::None};
+  for (const bool allow_avoid : {false, true}) {
+    uint16_t unused_search_start = 0;
+    while (auto unused = liveness_.find_globally_unused_vgpr_run(
+               &inst_, request.count, unused_search_start, request.alignment, allocated_vgprs)) {
+      if (window_is_allowed(*unused, request, allocated_vgprs, allow_avoid)) {
+        context_.require_vgprs(static_cast<uint32_t>(*unused) + request.count);
+        return {.lease = SemanticScratchLease{.reg_class = RegClass::VGPR,
+                                              .base = *unused,
+                                              .count = request.count,
+                                              .spilled = false,
+                                              .spill_offset = 0},
+                .failure = SemanticScratchFailure::None};
+      }
+      unused_search_start = static_cast<uint16_t>(*unused + request.alignment);
     }
-    unused_search_start = static_cast<uint16_t>(*unused + request.alignment);
   }
 
-  uint16_t search_start = 0;
-  while (auto free =
-             liveness_.find_free_run(&inst_, request.count, search_start, request.alignment)) {
-    if (static_cast<uint32_t>(*free) + request.count > policy_.max_vgprs)
-      break;
-    if (window_is_allowed(*free, request, policy_.max_vgprs)) {
-      context_.require_vgprs(static_cast<uint32_t>(*free) + request.count);
-      return {.lease = SemanticScratchLease{.reg_class = RegClass::VGPR,
-                                            .base = *free,
-                                            .count = request.count,
-                                            .spilled = false,
-                                            .spill_offset = 0},
-              .failure = SemanticScratchFailure::None};
+  for (const bool allow_avoid : {false, true}) {
+    uint16_t search_start = 0;
+    while (auto free =
+               liveness_.find_free_run(&inst_, request.count, search_start, request.alignment)) {
+      if (static_cast<uint32_t>(*free) + request.count > policy_.max_vgprs)
+        break;
+      if (window_is_allowed(*free, request, policy_.max_vgprs, allow_avoid)) {
+        context_.require_vgprs(static_cast<uint32_t>(*free) + request.count);
+        return {.lease = SemanticScratchLease{.reg_class = RegClass::VGPR,
+                                              .base = *free,
+                                              .count = request.count,
+                                              .spilled = false,
+                                              .spill_offset = 0},
+                .failure = SemanticScratchFailure::None};
+      }
+      search_start = static_cast<uint16_t>(*free + request.alignment);
     }
-    search_start = static_cast<uint16_t>(*free + request.alignment);
   }
 
   if (!request.allow_spill)
     return {.lease = std::nullopt, .failure = SemanticScratchFailure::NoRegisterWindow};
 
   std::optional<uint16_t> victim;
-  if (request.preferred_victim_base &&
-      window_is_allowed(*request.preferred_victim_base, request, allocated_vgprs)) {
-    victim = request.preferred_victim_base;
-  } else {
-    for (uint16_t base = 0; static_cast<uint32_t>(base) + request.count <= allocated_vgprs;
-         ++base) {
-      if (window_is_allowed(base, request, allocated_vgprs)) {
-        victim = base;
-        break;
+  for (const bool allow_avoid : {false, true}) {
+    if (request.preferred_victim_base &&
+        window_is_allowed(*request.preferred_victim_base, request, allocated_vgprs, allow_avoid)) {
+      victim = request.preferred_victim_base;
+    } else {
+      for (uint16_t base = 0; static_cast<uint32_t>(base) + request.count <= allocated_vgprs;
+           ++base) {
+        if (window_is_allowed(base, request, allocated_vgprs, allow_avoid)) {
+          victim = base;
+          break;
+        }
       }
     }
+    if (victim)
+      break;
   }
 
   if (!victim)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_scratch.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_scratch.h
@@ -72,6 +72,15 @@ struct SemanticScratchRequest {
   uint16_t count = 0;
   uint16_t alignment = 1;
   RegisterSet forbidden;
+  /// @brief Registers to avoid when another legal window is available.
+  ///
+  /// @details Unlike `forbidden`, this is a preference rather than a hard
+  /// correctness constraint. Target timing analyses use it to steer scratch
+  /// away from registers covered by a short hardware access window. If every
+  /// legal window intersects this set, allocation may still succeed. The
+  /// target emitter must query its timing analysis for the selected lease and
+  /// insert any required separation.
+  RegisterSet avoid;
   bool allow_spill = true;
   std::optional<uint16_t> preferred_victim_base;
 };
@@ -126,7 +135,7 @@ public:
 
 private:
   [[nodiscard]] bool window_is_allowed(uint16_t base, const SemanticScratchRequest &request,
-                                       uint16_t available_count) const;
+                                       uint16_t available_count, bool allow_avoid) const;
 
   const Instruction &inst_;
   const LivenessAnalysis &liveness_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_rule.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_rule.h
@@ -37,6 +37,7 @@ namespace rocjitsu {
 
 class Instruction;
 class LivenessAnalysis;
+class Gfx1250RewriteHazardAnalysis;
 
 /// @brief Architecture-neutral resource accounting shared by semantic lowerings.
 ///
@@ -251,13 +252,37 @@ struct VirtualLdsTranslationState {
   uint32_t virtual_lds_kernarg_pointer_offset = 0;
 };
 
+/// @brief gfx1250 B0-to-A0 timing state owned by BinaryTranslator.
+struct Gfx1250HazardTranslationState {
+  /// @brief Short timing windows that allocator-backed gfx1250 rules must honor.
+  ///
+  /// @details Other translation pairs leave the pointer null.
+  const Gfx1250RewriteHazardAnalysis *gfx1250_rewrite_hazards = nullptr;
+
+  /// @brief Source-boundary V_NOPs already emitted before the current rewrite.
+  ///
+  /// @details The whole-stream gfx1250 B0-to-A0 repair covers conflicts already
+  /// present around the source instruction. Allocator-backed expansions use
+  /// this count when a generated first VALU needs an equal or larger gap, so
+  /// the boundary receives the maximum required separation rather than two
+  /// independently accumulated gaps.
+  ///
+  /// Semantic expansions must preserve source-window VALU slots and must query
+  /// the analysis before their first generated VALU access. This keeps the
+  /// decoded-stream repair and generated-instruction repair composable without
+  /// a production re-decode of the translated kernel.
+  uint8_t leading_valu_hazard_nops = 0;
+};
+
 /// @brief Per-kernel state passed through semantic translation rules.
 ///
 /// @details Inheritance preserves the compact field access used by existing
 /// rules while making the ownership split explicit. Generic DBT/DBI resource
 /// helpers can consume KernelResourceRequirements without depending on virtual
-/// LDS, and pair-specific lowerings can consume VirtualLdsTranslationState.
-struct TranslationContext : KernelResourceRequirements, VirtualLdsTranslationState {
+/// LDS, and pair-specific lowerings can consume their dedicated state.
+struct TranslationContext : KernelResourceRequirements,
+                            VirtualLdsTranslationState,
+                            Gfx1250HazardTranslationState {
   TranslationContext() = default;
 
   TranslationContext(uint32_t vgprs, uint32_t sgprs) : KernelResourceRequirements(vgprs, sgprs) {}

--- a/emulation/rocjitsu/tests/dbt/semantic_scratch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/semantic_scratch_test.cpp
@@ -333,6 +333,28 @@ TEST(SemanticScratchAllocator, AllowsFreeWindowInDynamicStackKernel) {
   EXPECT_EQ(context.required_private_segment_fixed_size, 32u);
 }
 
+TEST(SemanticScratchAllocator, PrefersAvoidDisjointWindowAndAllowsFallback) {
+  Instruction inst("scratch_test", nullptr);
+  std::vector<BasicBlock *> blocks;
+  LivenessAnalysis liveness(blocks);
+  TranslationContext context(/*vgprs=*/4, /*agprs=*/0, /*accum_base=*/0,
+                             /*sgprs=*/8, /*private_bytes=*/0);
+  SemanticScratchAllocator allocator(
+      inst, liveness, context, SemanticScratchPolicy{.max_vgprs = 4, .max_spill_dword_offset = 64});
+
+  SemanticScratchRequest request;
+  request.count = 2;
+  request.avoid.expand({RegClass::VGPR, 0, 2});
+  const SemanticScratchResult disjoint = allocator.acquire_vgprs(request);
+  ASSERT_TRUE(disjoint);
+  EXPECT_EQ(disjoint.lease->base, 2u);
+
+  request.avoid.expand({RegClass::VGPR, 2, 2});
+  const SemanticScratchResult fallback = allocator.acquire_vgprs(request);
+  ASSERT_TRUE(fallback);
+  EXPECT_EQ(fallback.lease->base, 0u);
+}
+
 TEST(Cdna3ScratchEmitter, MaterializesSaveAndRestoreSequences) {
   const SemanticScratchLease lease{
       .reg_class = RegClass::VGPR, .base = 6, .count = 2, .spilled = true, .spill_offset = 48};

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -15,8 +15,10 @@
 /// These tests complement the hardware tests in hsa_translate_test.cpp which
 /// verify correctness on real DBT host GPUs.
 
+#include "rocjitsu/analysis/gfx1250_rewrite_hazards.h"
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/basic_block.h"
 #include "rocjitsu/code/dbt/binary_translator.h"
 #include "rocjitsu/code/dbt/encoding_translator.h"
 #include "rocjitsu/code/dbt/generated/encoding_cdna4_to_cdna3.h"
@@ -4455,6 +4457,25 @@ decode_text_instructions(const rocjitsu::Section &text, rj_code_arch_t arch) {
     decoded.push_back(std::move(inst));
   }
   return decoded;
+}
+
+std::vector<rocjitsu::Gfx1250InstructionHazard>
+find_gfx1250_instruction_hazards(const rocjitsu::AmdGpuCodeObject &object) {
+  auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  if (!decoder)
+    return {};
+  auto owned_blocks = rocjitsu::BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  std::vector<rocjitsu::BasicBlock *> blocks;
+  blocks.reserve(owned_blocks.size());
+  for (const auto &block : owned_blocks)
+    blocks.push_back(block.get());
+  if (blocks.empty())
+    return {};
+  const auto &text = object.text_sections().front();
+  rocjitsu::Gfx1250RewriteHazardAnalysis analysis(
+      rocjitsu::KernelBlockScope(blocks), blocks.front(), {},
+      {reinterpret_cast<const uint8_t *>(text->data()), text->size()});
+  return analysis.find_instruction_hazards();
 }
 
 // --- Synthetic BinaryTranslator integration tests ---
@@ -9473,6 +9494,85 @@ TEST(BinaryTranslatorE2E, Gfx1250EmulatesCvtF32Fp8E5m3ForA0) {
   EXPECT_EQ(bfe_count, 1) << "E5M3 unpack must isolate the byte with exactly one v_bfe_u32";
 }
 
+TEST(BinaryTranslatorE2E, Gfx1250E5m3ScratchAvoidsPrecedingWmmaWindow) {
+  // The source conversion itself does not overlap this WMMA, so adjacent source
+  // instructions are legal. A liveness-only allocator used to select dead
+  // v0:v1 for the generated unpack, introducing a new overlap with the WMMA
+  // destination. Prefer a disjoint dead range instead of padding.
+  constexpr auto wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 0, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
+  constexpr auto conversion =
+      gfx1250::build_vop3(gfx1250::kVCvtF32Fp8Vop3, {.vdst = 30, .clamp = 1, .src0 = 256 + 22});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {wmma[0], wmma[1], conversion[0], conversion[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  const auto bfe = std::ranges::find_if(
+      decoded, [](const auto &item) { return item->mnemonic() == "v_bfe_u32"; });
+  ASSERT_NE(bfe, decoded.end());
+  const rocjitsu::Operand *destination = (*bfe)->dst_operand(0);
+  ASSERT_NE(destination, nullptr);
+  const auto scratch = destination->to_register_ref();
+  ASSERT_TRUE(scratch.has_value());
+  EXPECT_GE(scratch->index, 8u);
+  EXPECT_EQ(std::ranges::count_if(decoded,
+                                  [](const auto &item) { return item->mnemonic() == "v_nop_e32"; }),
+            0);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250E5m3ScratchPadsWhenEveryWindowOverlapsWmma) {
+  // Force the only dead two-VGPR scratch range to v254:v255, which overlaps
+  // the preceding dense WMMA destination v248:v255. The allocator must retain
+  // the usable fallback and the rewrite must insert the exact four-slot gap.
+  constexpr auto wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 248, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
+  constexpr auto conversion =
+      gfx1250::build_vop3(gfx1250::kVCvtF32Fp8Vop3, {.vdst = 30, .clamp = 1, .src0 = 256 + 22});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {wmma[0], wmma[1], conversion[0], conversion[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  auto options = gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                          rocjitsu::ProcessorRevision::Gfx1250A0);
+  options.debug_min_free_vgpr = 254;
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+                                        options);
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  EXPECT_TRUE(find_gfx1250_instruction_hazards(translated).empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  const auto bfe = std::ranges::find_if(
+      decoded, [](const auto &item) { return item->mnemonic() == "v_bfe_u32"; });
+  ASSERT_NE(bfe, decoded.end());
+  const rocjitsu::Operand *destination = (*bfe)->dst_operand(0);
+  ASSERT_NE(destination, nullptr);
+  const auto scratch = destination->to_register_ref();
+  ASSERT_TRUE(scratch.has_value());
+  EXPECT_EQ(scratch->index, 254u);
+
+  const size_t index = static_cast<size_t>(std::distance(decoded.begin(), bfe));
+  ASSERT_GE(index, 4u);
+  for (size_t slot = 0; slot < 4; ++slot)
+    EXPECT_EQ(decoded[index - 4 + slot]->mnemonic(), "v_nop_e32");
+}
+
 TEST(BinaryTranslatorE2E, Gfx1250E5m3CompareMasksTargetDeadSgprs) {
   constexpr auto conversion = gfx1250::build_vop3(
       gfx1250::kVCvtF32Fp8Vop3, {.vdst = 30, .opsel = 2, .clamp = 1, .src0 = 256 + 22});
@@ -9559,6 +9659,62 @@ TEST(BinaryTranslatorE2E, Gfx1250E5m3UnpackUsesVgprCarriersUnderSgprPressure) {
     EXPECT_EQ((*following)->mnemonic(), "s_mov_b32")
         << "the EXEC-zero guard must land on the first following guest instruction";
   }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250E5m3CarrierPrefersWmmaDisjointSpillVictim) {
+  using namespace rocr::llvm::amdhsa;
+
+  constexpr auto wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 0, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
+  constexpr auto conversion = gfx1250::build_vop3(
+      gfx1250::kVCvtF32Fp8Vop3, {.vdst = 30, .opsel = 2, .clamp = 1, .src0 = 256 + 22});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+
+  std::vector<uint32_t> words = {wmma[0], wmma[1], conversion[0], conversion[1]};
+  for (size_t slot = 0; slot < 4; ++slot)
+    words.push_back(gfx1250::build_vop1(gfx1250::kVNopVop1)[0]);
+  // Mark every low-bank VGPR globally used without making it live at the
+  // conversion. The debug floor then forces both the unpack tuple and the SGPR
+  // carrier tuple through the spill-victim tier.
+  for (uint16_t vdst = 0; vdst < 256; ++vdst) {
+    words.push_back(gfx1250::build_vop1(gfx1250::kVMovB32Vop1,
+                                        {.src0 = 128, .vdst = static_cast<uint8_t>(vdst)})[0]);
+  }
+  words.push_back(kGfx1250SEndpgm);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject layout(image.data(), image.size());
+  ASSERT_TRUE(layout.is_valid());
+  const auto *rodata = rocjitsu::find_section(layout, ".rodata");
+  ASSERT_NE(rodata, nullptr);
+  auto descriptor = rocjitsu::read_kernel_descriptor_for_test(rodata->data());
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                  63);
+  rocjitsu::write_kernel_descriptor_for_test(image.data() + rodata->sectionOffset(), descriptor);
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  EXPECT_TRUE(find_gfx1250_instruction_hazards(source).empty());
+  auto options = gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                          rocjitsu::ProcessorRevision::Gfx1250A0);
+  options.debug_min_free_vgpr = 256;
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+                                        options);
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  EXPECT_TRUE(find_gfx1250_instruction_hazards(translated).empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  const auto bfe = std::ranges::find_if(
+      decoded, [](const auto &item) { return item->mnemonic() == "v_bfe_u32"; });
+  ASSERT_NE(bfe, decoded.end());
+  EXPECT_EQ(std::ranges::count_if(decoded.begin(), bfe,
+                                  [](const auto &item) { return item->mnemonic() == "v_nop_e32"; }),
+            0)
+      << "both spill-backed tuples should avoid the active WMMA window";
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250E5m3SeparatesVectorAndScalarSpillSlots) {
@@ -10332,6 +10488,56 @@ TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadsUseVgprCarrierUnderSgprPressure) {
   }
 }
 
+TEST(BinaryTranslatorE2E, Gfx1250ClusterCarrierPadsPrecedingWmmaWindow) {
+  // Full SGPR pressure requires a lane-zero VGPR carrier. Force that carrier
+  // to v255, which overlaps the preceding dense WMMA destination v248:v255.
+  // The source cluster load is not an ordinary VALU and is legal without a
+  // gap; the generated v_writelane_b32 needs the four-slot separation.
+  constexpr auto wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 248, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
+  constexpr auto cluster = gfx1250::build_vglobal(gfx1250::kClusterLoadB32Vglobal,
+                                                  {.saddr = 124, .vdst = 8, .vaddr = 12});
+  constexpr std::array<uint32_t, 5> source_words = {
+      wmma[0], wmma[1], cluster[0], cluster[1], cluster[2],
+  };
+  auto image =
+      rocjitsu::make_gfx1250_image_with_live_sgprs(source_words, rocjitsu::REGISTER_SET_MAX_SGPRS);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  EXPECT_TRUE(find_gfx1250_instruction_hazards(source).empty());
+
+  auto options = gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                          rocjitsu::ProcessorRevision::Gfx1250A0);
+  options.debug_min_free_vgpr = 255;
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+                                        options);
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  EXPECT_TRUE(find_gfx1250_instruction_hazards(translated).empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  const auto save = std::ranges::find_if(
+      decoded, [](const auto &item) { return item->mnemonic() == "v_writelane_b32"; });
+  ASSERT_NE(save, decoded.end());
+  ASSERT_NE((*save)->raw_encoding(), nullptr);
+  gfx1250::Vop3MachineInst encoded_save{};
+  std::memcpy(&encoded_save, (*save)->raw_encoding(), sizeof(encoded_save));
+  EXPECT_EQ(encoded_save.vdst, 255u);
+
+  const size_t index = static_cast<size_t>(std::distance(decoded.begin(), save));
+  ASSERT_GE(index, 4u);
+  for (size_t slot = 0; slot < 4; ++slot)
+    EXPECT_EQ(decoded[index - 4 + slot]->mnemonic(), "v_nop_e32");
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
 TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadFailsClosedWithoutExecIndependentCarrier) {
   constexpr auto cluster = gfx1250::build_vglobal(gfx1250::kClusterLoadB32Vglobal,
                                                   {.saddr = 124, .vdst = 8, .vaddr = 12});
@@ -10595,6 +10801,366 @@ TEST(BinaryTranslatorE2E, Gfx1250MaterializesDsAddtidAddressForA0) {
   // is the field width (inline 20 -> 148). Together: (value >> 0) & ((1<<20)-1).
   EXPECT_EQ(((*v_bfe)->raw_encoding()[1] >> 9) & 0x1ffu, kInline);
   EXPECT_EQ(((*v_bfe)->raw_encoding()[1] >> 18) & 0x1ffu, static_cast<uint16_t>(kInline + 20));
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250AddtidLoadPadsPrecedingWmmaWindow) {
+  // DS itself does not consume a WMMA co-execution slot. Its A0 lowering starts
+  // with ordinary VALU that writes the architectural load destination, so an
+  // overlapping preceding WMMA requires the dense latency-8 four-slot gap.
+  constexpr auto wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 0, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
+  constexpr auto addtid = gfx1250::build_vds(gfx1250::kDsLoadAddtidB32Vds, {.vdst = 0});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {wmma[0], wmma[1], addtid[0], addtid[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  EXPECT_TRUE(find_gfx1250_instruction_hazards(source).empty());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  EXPECT_TRUE(find_gfx1250_instruction_hazards(translated).empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  const auto mbcnt = std::ranges::find_if(
+      decoded, [](const auto &item) { return item->mnemonic() == "v_mbcnt_lo_u32_b32"; });
+  ASSERT_NE(mbcnt, decoded.end());
+  const size_t index = static_cast<size_t>(std::distance(decoded.begin(), mbcnt));
+  ASSERT_GE(index, 4u);
+  for (size_t slot = 0; slot < 4; ++slot)
+    EXPECT_EQ(decoded[index - 4 + slot]->mnemonic(), "v_nop_e32");
+}
+
+TEST(Gfx1250InstructionHazardVerifier, ReportsWmmaToValuOverlap) {
+  constexpr auto wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 0, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
+  constexpr auto overwrite = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 0});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {wmma[0], wmma[1], overwrite[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject object(image.data(), image.size());
+
+  const auto hazards = find_gfx1250_instruction_hazards(object);
+  ASSERT_EQ(hazards.size(), 1u);
+  EXPECT_EQ(hazards[0].kind, rocjitsu::Gfx1250InstructionHazardKind::WmmaCoexecution);
+  EXPECT_EQ(hazards[0].producer_offset, 0u);
+  EXPECT_EQ(hazards[0].consumer_offset, 8u);
+  EXPECT_EQ(hazards[0].required_slots, 4u);
+  EXPECT_EQ(hazards[0].existing_valu_slots, 0u);
+  EXPECT_EQ(hazards[0].missing_nops(), 4u);
+}
+
+TEST(Gfx1250InstructionHazardVerifier, ClassifiesF8f6f4MatrixFormats) {
+  struct FormatCase {
+    const char *name;
+    uint8_t matrix_a;
+    uint8_t matrix_b;
+    uint8_t required_slots;
+  };
+  constexpr std::array cases = {
+      FormatCase{"f8_a", 0, 2, 8},
+      FormatCase{"f8_b", 2, 1, 8},
+      FormatCase{"f6_pair", 2, 2, 4},
+      FormatCase{"matrix_b_high_bit", 2, 6, 4},
+  };
+  constexpr auto overwrite = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 0});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+
+  for (const FormatCase &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    auto wmma = gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p,
+                                     {.vdst = 0,
+                                      .opsel = test_case.matrix_a,
+                                      .src0 = 256 + 64,
+                                      .src1 = 256 + 128,
+                                      .src2 = 256 + 192,
+                                      .opsel_hi = static_cast<uint8_t>(test_case.matrix_b & 0x3u)});
+    if ((test_case.matrix_b & 0x4u) != 0)
+      wmma[0] |= 1u << 14u;
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+        {wmma[0], wmma[1], overwrite[0], kGfx1250SEndpgm});
+    rocjitsu::AmdGpuCodeObject object(image.data(), image.size());
+
+    const auto hazards = find_gfx1250_instruction_hazards(object);
+    ASSERT_EQ(hazards.size(), 1u);
+    EXPECT_EQ(hazards[0].kind, rocjitsu::Gfx1250InstructionHazardKind::WmmaCoexecution);
+    EXPECT_EQ(hazards[0].required_slots, test_case.required_slots);
+    EXPECT_EQ(hazards[0].missing_nops(), test_case.required_slots);
+  }
+}
+
+TEST(Gfx1250InstructionHazardVerifier, ProjectsDestinationAvoidSetIntoSelectedBank) {
+  rocjitsu::Gfx1250GeneratedValuHazard hazard;
+  hazard.defs_requiring_nops[4].expand({rocjitsu::RegClass::VGPR, 260, 2});
+
+  const rocjitsu::RegisterSet bank0 = hazard.avoid_destination_vgprs_in_bank(0);
+  const rocjitsu::RegisterSet bank1 = hazard.avoid_destination_vgprs_in_bank(1);
+  EXPECT_TRUE(bank0.none());
+  EXPECT_TRUE(bank1.contains({rocjitsu::RegClass::VGPR, 4, 2}));
+}
+
+TEST(Gfx1250InstructionHazardVerifier, ReportsTransToValuOverlap) {
+  constexpr auto trans = gfx1250::build_vop1(gfx1250::kVExpF32Vop1, {.src0 = 256 + 64, .vdst = 0});
+  constexpr auto overwrite = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 128, .vdst = 64});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {trans[0], overwrite[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject object(image.data(), image.size());
+
+  const auto hazards = find_gfx1250_instruction_hazards(object);
+  ASSERT_EQ(hazards.size(), 1u);
+  EXPECT_EQ(hazards[0].kind, rocjitsu::Gfx1250InstructionHazardKind::TransCoexecution);
+  EXPECT_EQ(hazards[0].producer_offset, 0u);
+  EXPECT_EQ(hazards[0].consumer_offset, 4u);
+  EXPECT_EQ(hazards[0].required_slots, 1u);
+  EXPECT_EQ(hazards[0].existing_valu_slots, 0u);
+  EXPECT_EQ(hazards[0].missing_nops(), 1u);
+}
+
+TEST(Gfx1250InstructionHazardVerifier, ReportsWmmaToWmmaOverlap) {
+  constexpr auto producer =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 0, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
+  constexpr auto consumer =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 32, .src0 = 256, .src1 = 256 + 96, .src2 = 256 + 160});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {producer[0], producer[1], consumer[0], consumer[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject object(image.data(), image.size());
+
+  const auto hazards = find_gfx1250_instruction_hazards(object);
+  ASSERT_EQ(hazards.size(), 1u);
+  EXPECT_EQ(hazards[0].kind, rocjitsu::Gfx1250InstructionHazardKind::WmmaCoexecution);
+  EXPECT_EQ(hazards[0].producer_offset, 0u);
+  EXPECT_EQ(hazards[0].consumer_offset, 8u);
+  EXPECT_EQ(hazards[0].required_slots, 5u);
+  EXPECT_EQ(hazards[0].existing_valu_slots, 0u);
+  EXPECT_EQ(hazards[0].missing_nops(), 5u);
+}
+
+TEST(Gfx1250InstructionHazardVerifier, ReportsWmmaOverlapAcrossCfgEdges) {
+  constexpr auto wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 0, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
+  constexpr auto consume = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 256, .vdst = 32});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const uint32_t scalar_nop = gfx1250::build_sopp(gfx1250::kSNopSopp, {.simm16 = 0})[0];
+
+  struct Case {
+    const char *name;
+    std::vector<uint32_t> words;
+  };
+  const std::array cases = {
+      Case{.name = "predecessor",
+           .words = {wmma[0], wmma[1], gfx1250::build_sopp(gfx1250::kSBranchSopp, {.simm16 = 1})[0],
+                     scalar_nop, consume[0], kGfx1250SEndpgm}},
+      Case{.name = "join",
+           .words = {gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp, {.simm16 = 3})[0], wmma[0],
+                     wmma[1], gfx1250::build_sopp(gfx1250::kSBranchSopp, {.simm16 = 1})[0],
+                     scalar_nop, consume[0], kGfx1250SEndpgm}},
+      Case{.name = "loop_backedge",
+           .words = {consume[0], gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp, {.simm16 = 3})[0],
+                     wmma[0], wmma[1],
+                     gfx1250::build_sopp(gfx1250::kSBranchSopp, {.simm16 = 0xfffb})[0],
+                     kGfx1250SEndpgm}},
+  };
+
+  for (const Case &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(test_case.words);
+    rocjitsu::AmdGpuCodeObject object(image.data(), image.size());
+    const auto hazards = find_gfx1250_instruction_hazards(object);
+    ASSERT_EQ(hazards.size(), 1u);
+    EXPECT_EQ(hazards[0].kind, rocjitsu::Gfx1250InstructionHazardKind::WmmaCoexecution);
+    EXPECT_EQ(hazards[0].required_slots, 4u);
+    EXPECT_EQ(hazards[0].existing_valu_slots, 0u);
+    EXPECT_EQ(hazards[0].missing_nops(), 4u);
+  }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250RepairsCopiedTransToValuOverlap) {
+  constexpr auto trans = gfx1250::build_vop1(gfx1250::kVExpF32Vop1, {.src0 = 256 + 64, .vdst = 0});
+  constexpr auto consume = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 256, .vdst = 1});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const uint32_t scalar_nop = gfx1250::build_sopp(gfx1250::kSNopSopp, {.simm16 = 0})[0];
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {trans[0], scalar_nop, consume[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_EQ(find_gfx1250_instruction_hazards(source).size(), 1u)
+      << "an SALU instruction does not occupy the required VALU separation slot";
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  EXPECT_TRUE(find_gfx1250_instruction_hazards(translated).empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  const auto mov = std::ranges::find_if(
+      decoded, [](const auto &item) { return item->mnemonic() == "v_mov_b32_e32"; });
+  ASSERT_NE(mov, decoded.end());
+  ASSERT_NE(mov, decoded.begin());
+  EXPECT_EQ((*std::prev(mov))->mnemonic(), "v_nop_e32");
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250RepairsCopiedWmmaToValuOverlap) {
+  constexpr auto wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 0, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
+  constexpr auto consume = gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = 256, .vdst = 32});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {wmma[0], wmma[1], consume[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_EQ(find_gfx1250_instruction_hazards(source).size(), 1u);
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  EXPECT_TRUE(find_gfx1250_instruction_hazards(translated).empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  const auto mov = std::ranges::find_if(
+      decoded, [](const auto &item) { return item->mnemonic() == "v_mov_b32_e32"; });
+  ASSERT_NE(mov, decoded.end());
+  const size_t index = static_cast<size_t>(std::distance(decoded.begin(), mov));
+  ASSERT_GE(index, 4u);
+  for (size_t slot = 0; slot < 4; ++slot)
+    EXPECT_EQ(decoded[index - 4 + slot]->mnemonic(), "v_nop_e32");
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250RepairsCopiedWmmaToWmmaOverlap) {
+  constexpr auto producer =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 0, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
+  constexpr auto consumer =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 32, .src0 = 256, .src1 = 256 + 96, .src2 = 256 + 160});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {producer[0], producer[1], consumer[0], consumer[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_EQ(find_gfx1250_instruction_hazards(source).size(), 1u);
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  EXPECT_TRUE(find_gfx1250_instruction_hazards(translated).empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  const auto second_wmma =
+      std::ranges::find_if(std::next(decoded.begin()), decoded.end(), [](const auto &item) {
+        return item->mnemonic().starts_with("v_wmma_");
+      });
+  ASSERT_NE(second_wmma, decoded.end());
+  const size_t index = static_cast<size_t>(std::distance(decoded.begin(), second_wmma));
+  ASSERT_GE(index, 5u);
+  for (size_t slot = 0; slot < 5; ++slot)
+    EXPECT_EQ(decoded[index - 5 + slot]->mnemonic(), "v_nop_e32");
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250AddtidLoadRecognizesWmmaAcrossCfgEdges) {
+  constexpr auto wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 0, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
+  constexpr auto addtid = gfx1250::build_vds(gfx1250::kDsLoadAddtidB32Vds, {.vdst = 0});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const uint32_t scalar_nop = gfx1250::build_sopp(gfx1250::kSNopSopp, {.simm16 = 0})[0];
+
+  struct Case {
+    const char *name;
+    std::vector<uint32_t> words;
+  };
+  const std::array cases = {
+      Case{.name = "predecessor",
+           .words = {wmma[0], wmma[1], gfx1250::build_sopp(gfx1250::kSBranchSopp, {.simm16 = 1})[0],
+                     scalar_nop, addtid[0], addtid[1], kGfx1250SEndpgm}},
+      Case{.name = "join",
+           .words = {gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp, {.simm16 = 3})[0], wmma[0],
+                     wmma[1], gfx1250::build_sopp(gfx1250::kSBranchSopp, {.simm16 = 1})[0],
+                     scalar_nop, addtid[0], addtid[1], kGfx1250SEndpgm}},
+      Case{.name = "loop_backedge",
+           .words = {addtid[0], addtid[1],
+                     gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp, {.simm16 = 3})[0], wmma[0],
+                     wmma[1], gfx1250::build_sopp(gfx1250::kSBranchSopp, {.simm16 = 0xfffa})[0],
+                     kGfx1250SEndpgm}},
+  };
+
+  for (const Case &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(test_case.words);
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    const auto result = translator.translate(source);
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    const auto decoded =
+        decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+    const auto mbcnt = std::ranges::find_if(
+        decoded, [](const auto &item) { return item->mnemonic() == "v_mbcnt_lo_u32_b32"; });
+    ASSERT_NE(mbcnt, decoded.end());
+    const size_t index = static_cast<size_t>(std::distance(decoded.begin(), mbcnt));
+    ASSERT_GE(index, 4u);
+    for (size_t slot = 0; slot < 4; ++slot)
+      EXPECT_EQ(decoded[index - 4 + slot]->mnemonic(), "v_nop_e32");
+  }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250AddtidLoadPadsPrecedingTransWindow) {
+  // The first generated VALU writes v64 while the preceding TRANS still reads
+  // v64. One V_NOP covers this newly introduced write-after-read overlap.
+  constexpr auto trans = gfx1250::build_vop1(gfx1250::kVExpF32Vop1, {.src0 = 256 + 64, .vdst = 0});
+  constexpr auto addtid = gfx1250::build_vds(gfx1250::kDsLoadAddtidB32Vds, {.vdst = 64});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {trans[0], addtid[0], addtid[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  const auto mbcnt = std::ranges::find_if(
+      decoded, [](const auto &item) { return item->mnemonic() == "v_mbcnt_lo_u32_b32"; });
+  ASSERT_NE(mbcnt, decoded.end());
+  ASSERT_NE(mbcnt, decoded.begin());
+  EXPECT_EQ((*std::prev(mbcnt))->mnemonic(), "v_nop_e32");
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250FailsClosedOnUnsupportedBarrierSignalIsfirst) {


### PR DESCRIPTION
## Motivation

Register liveness alone does not guarantee scratch VGPR safety while TRANS or WMMA instructions remain in a co-execution window.

## Technical Details

- Recognize TRANS-to-VALU, WMMA/SWMMAC-to-VALU, and WMMA/SWMMAC-to-WMMA VGPR conflicts across source CFGs.
- Prefer scratch ranges outside active windows and insert the minimum required V_NOP padding for copied and generated instructions.
- Cover ADDTID, E5M3, and cluster-load carrier rewrites while avoiding CFG allocation for same-block windows.

This builds on the globally unused VGPR fast path in #9532.

Mixed TRANS/WMMA directions, pseudo-scalar and SGPR TRANS overlaps, and general padding coalescing remain future work. This is not full LLVM hazard-recognizer parity.

## Issue Tracking

N/A

## Test Plan

Run focused hazard and semantic-scratch tests, the full CTest suite, repository hooks, and output and idempotence qualification across the pinned 20,000-object gfx1250 corpus.

## Test Result

- The rebased CTest suite passed 2,335/2,335 with three expected skips.
- Focused post-rebase coverage passed 146/146.
- A full corpus sweep repaired all 21,426 supported findings in 2,140 objects, with none remaining.
- The post-review 19,999-object routine sweep remained byte-identical and idempotent; the oversized RCCL input was excluded.
- Repository hooks passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.