### PR TITLE
test(rccl): added regression test for network plugin assignment failu…

### DIFF
--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -231,8 +231,8 @@ if(BUILD_TESTS)
   # Create rccl-UnitTests binary
   add_executable(rccl-UnitTests ${TEST_SOURCE_FILES})
 
-  # AICOMRCCL-1534: net_reload_plugin.cpp is compiled into rccl-UnitTests and loaded
-  # in-process via NCCL_NET_PLUGIN=STATIC_PLUGIN (dlopen(NULL)), so no external .so.
+  # AICOMRCCL-1534 / net-plugin assignment tests: net_reload_plugin.cpp is compiled into
+  # rccl-UnitTests and loaded in-process via NCCL_NET_PLUGIN=STATIC_PLUGIN (dlopen(NULL)).
   # Scope its headers to the file so the generic example headers don't shadow others.
   set_source_files_properties(plugin/net_reload_plugin.cpp PROPERTIES
     INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../plugins/net/example/nccl)
@@ -240,7 +240,7 @@ if(BUILD_TESTS)
   # dlsym(dlopen(NULL), ...) only finds symbols present in the dynamic symbol table;
   # export just the one plugin symbol (narrow, unlike a broad -rdynamic).
   target_link_options(rccl-UnitTests PRIVATE
-    "LINKER:--export-dynamic-symbol=ncclNetPlugin_v10")
+    "LINKER:--export-dynamic-symbol=ncclNetPlugin_v12")
 
   # rccl-UnitTestsFixtures: Tests that only use header-only internal dependencies
   # (inline, static, constexpr, template functions) and can run in both Release and Debug.

--- a/projects/rccl/test/NetPluginReloadTests.cpp
+++ b/projects/rccl/test/NetPluginReloadTests.cpp
@@ -4,16 +4,17 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-// Regression test for AICOMRCCL-1534 (NCCL GitHub issue #1978): a non-default
-// NCCL_NET_PLUGIN must remain reloadable after the communicator that first used
-// it is destroyed. Before the fix, ncclNetPluginUnload memset() the plugin
-// struct and wiped the plugin name parsed once from NCCL_NET_PLUGIN, so the
-// second communicator silently fell back to the default net plugin.
+// Whitebox tests for in-process net plugin loading (NCCL_NET_PLUGIN=STATIC_PLUGIN)
+// using plugin/net_reload_plugin.cpp.
 //
-// The test uses a tiny net plugin (plugin/net_reload_plugin.cpp) compiled into
-// this test binary that records every real init() call, then creates and
-// destroys a communicator twice in one process. The plugin must be initialised
-// twice (once per comm).
+// NetPluginReload — AICOMRCCL-1534 (NCCL GitHub issue #1978): a non-default
+// NCCL_NET_PLUGIN must remain reloadable after the communicator that first used
+// it is destroyed.
+//
+// NetPluginAssignFail — NCCL 2.28.7 assignment-failure cleanup (src/plugin/net.cc):
+// when a plugin inits but fails assignment (e.g. incompatible UNPACK version),
+// ncclNetPluginFinalize() must run before probing the next plugin; netName mismatch
+// must skip init entirely.
 
 #include <gtest/gtest.h>
 #include <rccl/rccl.h>
@@ -30,12 +31,8 @@
 namespace RcclUnitTesting {
 namespace {
 
-// One create/destroy cycle per iteration; the plugin must be (re)initialised
-// once per cycle, so the expected init count equals this.
 constexpr int kNumCommCycles = 2;
 
-// Creates a unique file from an mkstemp template and unlinks it on scope exit,
-// so an early-returning ASSERT_ cannot leak it into /tmp
 class ScopedTempFile {
  public:
   explicit ScopedTempFile(const char* pathTemplate) : path_(pathTemplate) {
@@ -54,7 +51,6 @@ class ScopedTempFile {
   ScopedTempFile& operator=(const ScopedTempFile&) = delete;
 
   bool valid() const { return valid_; }
-
   const std::string& path() const { return path_; }
 
  private:
@@ -71,25 +67,38 @@ int countLines(const std::string& path) {
   return count;
 }
 
+// Returns the reason this host cannot run the test, or "" when it can.
+// GTEST_SKIP() must be issued by the caller: it expands to a bare return and
+// would otherwise only leave this helper, letting the test body run on.
+std::string gpuSkipReason() {
+  int deviceCount = 0;
+  if (hipGetDeviceCount(&deviceCount) != hipSuccess || deviceCount < 1)
+    return "requires at least one GPU";
+  return "";
+}
+
+void initAndDestroyComm() {
+  ncclUniqueId id;
+  ASSERT_EQ(ncclGetUniqueId(&id), ncclSuccess);
+
+  ncclComm_t comm = nullptr;
+  ASSERT_EQ(ncclCommInitRank(&comm, 1, id, 0), ncclSuccess);
+  ASSERT_EQ(ncclCommDestroy(comm), ncclSuccess);
+}
+
 } // namespace
 
 TEST(NetPluginReload, CustomPluginReloadsAfterCommDestroy) {
   RUN_ISOLATED_TEST("NetPluginReload.CustomPluginReloadsAfterCommDestroy", []() {
-    int deviceCount = 0;
-    if (hipGetDeviceCount(&deviceCount) != hipSuccess || deviceCount < 1)
-      GTEST_SKIP() << "requires at least one GPU";
+    if (auto reason = gpuSkipReason(); !reason.empty()) GTEST_SKIP() << reason;
+    ASSERT_EQ(hipSetDevice(0), hipSuccess);
 
     ScopedTempFile counterFile("/tmp/rccl_net_reload_XXXXXX");
     ASSERT_TRUE(counterFile.valid()) << "failed to create counter file";
 
     ASSERT_EQ(setenv("RCCL_NET_RELOAD_COUNTER_FILE", counterFile.path().c_str(), 1), 0);
-
-    // The test plugin is compiled into this binary and its ncclNetPlugin_v10
-    // symbol is exported (see test/CMakeLists.txt). NCCL_NET_PLUGIN=STATIC_PLUGIN
-    // makes the loader dlopen(NULL) and resolve that in-process symbol
+    // ncclNetPlugin_v12 is exported from this binary (see test/CMakeLists.txt).
     ASSERT_EQ(setenv("NCCL_NET_PLUGIN", "STATIC_PLUGIN", 1), 0);
-
-    ASSERT_EQ(hipSetDevice(0), hipSuccess);
 
     for (int cycle = 0; cycle < kNumCommCycles; ++cycle) {
       ncclUniqueId id;
@@ -97,18 +106,96 @@ TEST(NetPluginReload, CustomPluginReloadsAfterCommDestroy) {
 
       ncclComm_t comm = nullptr;
       ASSERT_EQ(ncclCommInitRank(&comm, 1, id, 0), ncclSuccess)
-        << "comm init cycle " << cycle << " failed";
+          << "comm init cycle " << cycle << " failed";
 
       ASSERT_EQ(ncclCommDestroy(comm), ncclSuccess);
     }
 
-    int loads = countLines(counterFile.path());
-
-    // Fixed: plugin reloaded for every cycle -> kNumCommCycles init calls.
-    // Pre-fix: name wiped on unload, later cycles use the default plugin -> 1.
+    const int loads = countLines(counterFile.path());
     EXPECT_EQ(loads, kNumCommCycles)
         << "custom net plugin init count = " << loads << " (expected "
         << kNumCommCycles << "; fewer means the plugin was not reloaded after destroy)";
+  });
+}
+
+TEST(NetPluginAssignFail, FinalizesOnFailedAssignment) {
+  RUN_ISOLATED_TEST("NetPluginAssignFail.FinalizesOnFailedAssignment", []() {
+    if (auto reason = gpuSkipReason(); !reason.empty()) GTEST_SKIP() << reason;
+    ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+    ScopedTempFile initFile("/tmp/rccl_net_assign_init_XXXXXX");
+    ScopedTempFile finalizeFile("/tmp/rccl_net_assign_fin_XXXXXX");
+    ASSERT_TRUE(initFile.valid()) << "failed to create init counter file";
+    ASSERT_TRUE(finalizeFile.valid()) << "failed to create finalize counter file";
+
+    ASSERT_EQ(setenv("RCCL_NET_TEST_PLUGIN_MODE", "assign_fail", 1), 0);
+    ASSERT_EQ(setenv("RCCL_NET_ASSIGN_FAIL_INIT_FILE", initFile.path().c_str(), 1), 0);
+    ASSERT_EQ(setenv("RCCL_NET_ASSIGN_FAIL_FINALIZE_FILE", finalizeFile.path().c_str(), 1), 0);
+    ASSERT_EQ(setenv("NCCL_NET_PLUGIN", "STATIC_PLUGIN", 1), 0);
+
+    initAndDestroyComm();
+
+    EXPECT_EQ(countLines(initFile.path()), 1)
+        << "external plugin init must run once before assignment failure";
+    EXPECT_EQ(countLines(finalizeFile.path()), 1)
+        << "ncclNetPluginFinalize() must run when assignment fails";
+  });
+}
+
+TEST(NetPluginAssignFail, NetNameMismatchSkipsInit) {
+  RUN_ISOLATED_TEST("NetPluginAssignFail.NetNameMismatchSkipsInit", []() {
+    if (auto reason = gpuSkipReason(); !reason.empty()) GTEST_SKIP() << reason;
+    ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+    ScopedTempFile initFile("/tmp/rccl_net_assign_init_XXXXXX");
+    ScopedTempFile finalizeFile("/tmp/rccl_net_assign_fin_XXXXXX");
+    ASSERT_TRUE(initFile.valid()) << "failed to create init counter file";
+    ASSERT_TRUE(finalizeFile.valid()) << "failed to create finalize counter file";
+
+    ASSERT_EQ(setenv("RCCL_NET_TEST_PLUGIN_MODE", "assign_fail", 1), 0);
+    ASSERT_EQ(setenv("RCCL_NET_ASSIGN_FAIL_INIT_FILE", initFile.path().c_str(), 1), 0);
+    ASSERT_EQ(setenv("RCCL_NET_ASSIGN_FAIL_FINALIZE_FILE", finalizeFile.path().c_str(), 1), 0);
+    ASSERT_EQ(setenv("NCCL_NET_PLUGIN", "STATIC_PLUGIN", 1), 0);
+    ASSERT_EQ(setenv("NCCL_IB_DISABLE", "1", 1), 0);
+
+    ncclUniqueId id;
+    ASSERT_EQ(ncclGetUniqueId(&id), ncclSuccess);
+
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    config.netName = const_cast<char*>("Socket");
+
+    ncclComm_t comm = nullptr;
+    ASSERT_EQ(ncclCommInitRankConfig(&comm, 1, id, 0, &config), ncclSuccess);
+    ASSERT_EQ(ncclCommDestroy(comm), ncclSuccess);
+
+    EXPECT_EQ(countLines(initFile.path()), 0)
+        << "ReloadTest must not be inited when netName requests Socket";
+    EXPECT_EQ(countLines(finalizeFile.path()), 0)
+        << "ReloadTest must not be finalized when it was never inited";
+  });
+}
+
+TEST(NetPluginAssignFail, SurvivesMultipleCommCycles) {
+  RUN_ISOLATED_TEST("NetPluginAssignFail.SurvivesMultipleCommCycles", []() {
+    if (auto reason = gpuSkipReason(); !reason.empty()) GTEST_SKIP() << reason;
+    ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+    ScopedTempFile initFile("/tmp/rccl_net_assign_init_XXXXXX");
+    ScopedTempFile finalizeFile("/tmp/rccl_net_assign_fin_XXXXXX");
+    ASSERT_TRUE(initFile.valid());
+    ASSERT_TRUE(finalizeFile.valid());
+
+    ASSERT_EQ(setenv("RCCL_NET_TEST_PLUGIN_MODE", "assign_fail", 1), 0);
+    ASSERT_EQ(setenv("RCCL_NET_ASSIGN_FAIL_INIT_FILE", initFile.path().c_str(), 1), 0);
+    ASSERT_EQ(setenv("RCCL_NET_ASSIGN_FAIL_FINALIZE_FILE", finalizeFile.path().c_str(), 1), 0);
+    ASSERT_EQ(setenv("NCCL_NET_PLUGIN", "STATIC_PLUGIN", 1), 0);
+
+    for (int cycle = 0; cycle < kNumCommCycles; ++cycle) initAndDestroyComm();
+
+    EXPECT_EQ(countLines(initFile.path()), kNumCommCycles)
+        << "each comm cycle must init the external plugin once";
+    EXPECT_EQ(countLines(finalizeFile.path()), kNumCommCycles)
+        << "each failed assignment must finalize the external plugin once";
   });
 }
 

--- a/projects/rccl/test/plugin/net_reload_plugin.cpp
+++ b/projects/rccl/test/plugin/net_reload_plugin.cpp
@@ -13,16 +13,13 @@
 // Compiled as C++ (the RCCL project only enables CXX/HIP), so the plugin symbol
 // is exported with C linkage and default visibility for RCCL's dlsym() lookup.
 //
-// The vtable below is built from the vendored example net headers, which are a
-// separate copy of the v10 plugin ABI from the one getNcclNet_v10() casts the
-// dlsym'd symbol to. Keeping the plugin on v10 is deliberate, and a mismatch
-// between the two copies cannot silently weaken the test: a changed struct
-// layout makes the loader call through wrong offsets and the test fails, and if
-// v10 support is ever dropped the symbol is never looked up, the counter file
-// stays empty and the test asserts with an init count of 0.
+// RCCL_NET_TEST_PLUGIN_MODE=assign_fail selects an incompatible UNPACK device
+// version (assignment rejected after init) and records init/finalize via
+// RCCL_NET_ASSIGN_FAIL_{INIT,FINALIZE}_FILE (NCCL 2.28.7 net.cc fix).
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "net.h" // from plugins/net/example/nccl
 
 #define __hidden __attribute__((visibility("hidden")))
@@ -31,8 +28,8 @@
 
 static char kPluginName[] = "ReloadTest";
 
-static void recordLoad() {
-  const char* path = getenv("RCCL_NET_RELOAD_COUNTER_FILE");
+static void recordLine(const char* envVar) {
+  const char* path = getenv(envVar);
   if (path == nullptr) return;
 
   FILE* f = fopen(path, "a");
@@ -42,15 +39,28 @@ static void recordLoad() {
   fclose(f);
 }
 
-__hidden ncclResult_t pluginInit_v10(ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction) {
-  (void)logFunction; (void)profFunction;
-  recordLoad();
+static int assignFailMode() {
+  const char* mode = getenv("RCCL_NET_TEST_PLUGIN_MODE");
+  return mode && strcmp(mode, "assign_fail") == 0;
+}
+
+__hidden ncclResult_t pluginInit(void** ctx, uint64_t commId, ncclNetCommConfig_v12_t* config,
+                                 ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction) {
+  (void)ctx; (void)commId; (void)config; (void)logFunction; (void)profFunction;
+  recordLine("RCCL_NET_RELOAD_COUNTER_FILE");
+  recordLine("RCCL_NET_ASSIGN_FAIL_INIT_FILE");
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t pluginFinalize(void* ctx) {
+  (void)ctx;
+  recordLine("RCCL_NET_ASSIGN_FAIL_FINALIZE_FILE");
   return ncclSuccess;
 }
 
 __hidden ncclResult_t pluginDevices(int* ndev) { *ndev = 1; return ncclSuccess; }
 
-__hidden ncclResult_t pluginGetProperties_v10(int dev, ncclNetProperties_v10_t* props) {
+__hidden ncclResult_t pluginGetProperties(int dev, ncclNetProperties_v12_t* props) {
   props->name = kPluginName;
   props->pciPath = nullptr;
   props->guid = 0;
@@ -62,18 +72,26 @@ __hidden ncclResult_t pluginGetProperties_v10(int dev, ncclNetProperties_v10_t* 
   props->latency = 0;
   props->maxComms = 1024 * 1024;
   props->maxRecvs = NCCL_PLUGIN_MAX_RECVS;
-  props->netDeviceType = NCCL_NET_DEVICE_HOST;
-  props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
+  if (assignFailMode()) {
+    props->netDeviceType = NCCL_NET_DEVICE_UNPACK;
+    props->netDeviceVersion = NCCL_NET_DEVICE_UNPACK_VERSION - 1;
+  } else {
+    props->netDeviceType = NCCL_NET_DEVICE_HOST;
+    props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
+  }
   props->vProps.ndevs = 1;
   props->vProps.devs[0] = dev;
   props->maxP2pBytes = NCCL_MAX_NET_SIZE_BYTES;
   props->maxCollBytes = NCCL_MAX_NET_SIZE_BYTES;
+  props->maxMultiRequestSize = 1;
+  props->railId = NCCL_NET_ID_UNDEF;
+  props->planeId = NCCL_NET_ID_UNDEF;
   return ncclSuccess;
 }
 
-__hidden ncclResult_t pluginListen_v10(int d, void* handle, void** listenComm) { return ncclInternalError; }
-__hidden ncclResult_t pluginConnect_v10(int dev, ncclNetCommConfig_v10_t* config, void* handle, void** sendComm, ncclNetDeviceHandle_v10_t** sendDevComm) { return ncclInternalError; }
-__hidden ncclResult_t pluginAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle_v10_t** recvDevComm) { return ncclInternalError; }
+__hidden ncclResult_t pluginListen(void* ctx, int dev, void* handle, void** listenComm) { return ncclInternalError; }
+__hidden ncclResult_t pluginConnect(void* ctx, int dev, void* handle, void** sendComm, ncclNetDeviceHandle_v12_t** sendDevComm) { return ncclInternalError; }
+__hidden ncclResult_t pluginAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle_v12_t** recvDevComm) { return ncclInternalError; }
 __hidden ncclResult_t pluginRegMr(void* comm, void* data, size_t size, int type, void** mhandle) { return ncclInternalError; }
 __hidden ncclResult_t pluginRegMrDmaBuf(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle) { return ncclInternalError; }
 __hidden ncclResult_t pluginDeregMr(void* comm, void* mhandle) { return ncclInternalError; }
@@ -86,15 +104,16 @@ __hidden ncclResult_t pluginCloseRecv(void* recvComm) { return ncclInternalError
 __hidden ncclResult_t pluginCloseListen(void* listenComm) { return ncclInternalError; }
 __hidden ncclResult_t pluginIrecvConsumed(void* recvComm, int n, void* request) { return ncclInternalError; }
 __hidden ncclResult_t pluginGetDeviceMr(void* comm, void* mhandle, void** dptr_mhandle) { return ncclInternalError; }
-__hidden ncclResult_t pluginMakeVDevice_v10(int* d, ncclNetVDeviceProps_v10_t* props) { return ncclInternalError; }
+__hidden ncclResult_t pluginMakeVDevice(int* d, ncclNetVDeviceProps_v12_t* props) { return ncclInternalError; }
+__hidden ncclResult_t pluginSetNetAttr(void* ctx, ncclNetAttr_v12_t* netAttr) { return ncclSuccess; }
 
-extern "C" __exported const ncclNet_v10_t ncclNetPlugin_v10 = {
+extern "C" __exported const ncclNet_v12_t ncclNetPlugin_v12 = {
   kPluginName,
-  pluginInit_v10,
+  pluginInit,
   pluginDevices,
-  pluginGetProperties_v10,
-  pluginListen_v10,
-  pluginConnect_v10,
+  pluginGetProperties,
+  pluginListen,
+  pluginConnect,
   pluginAccept,
   pluginRegMr,
   pluginRegMrDmaBuf,
@@ -108,5 +127,7 @@ extern "C" __exported const ncclNet_v10_t ncclNetPlugin_v10 = {
   pluginCloseListen,
   pluginGetDeviceMr,
   pluginIrecvConsumed,
-  pluginMakeVDevice_v10,
+  pluginMakeVDevice,
+  pluginFinalize,
+  pluginSetNetAttr,
 };

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -916,7 +916,10 @@
         "NCCL_DEBUG": "INFO"
       },
       "tests": [
-        {"name": "NetPluginReload.CustomPluginReloadsAfterCommDestroy", "description": "AICOMRCCL-1534: a non-default NCCL_NET_PLUGIN must remain reloadable after the communicator that first used it is destroyed", "test_filter": "NetPluginReload.CustomPluginReloadsAfterCommDestroy"}
+        {"name": "NetPluginReload.CustomPluginReloadsAfterCommDestroy", "description": "AICOMRCCL-1534: a non-default NCCL_NET_PLUGIN must remain reloadable after the communicator that first used it is destroyed", "test_filter": "NetPluginReload.CustomPluginReloadsAfterCommDestroy"},
+        {"name": "NetPluginAssignFail.FinalizesOnFailedAssignment", "description": "NCCL 2.28.7: ncclNetPluginFinalize() runs when plugin init succeeds but assignment fails (incompatible UNPACK version)", "test_filter": "NetPluginAssignFail.FinalizesOnFailedAssignment"},
+        {"name": "NetPluginAssignFail.NetNameMismatchSkipsInit", "description": "NCCL 2.28.7: comm config netName mismatch skips external plugin init entirely", "test_filter": "NetPluginAssignFail.NetNameMismatchSkipsInit"},
+        {"name": "NetPluginAssignFail.SurvivesMultipleCommCycles", "description": "NCCL 2.28.7: failed assignment cleanup leaves no orphaned state across multiple comm cycles", "test_filter": "NetPluginAssignFail.SurvivesMultipleCommCycles"}
       ]
     },
     "debug_tests": {


### PR DESCRIPTION
Added (NCCL 2.28.7 assignment fix) regression tests:

 - FinalizesOnFailedAssignment — finalize on failed assignment
 - NetNameMismatchSkipsInit — netName mismatch skips init
 - SurvivesMultipleCommCycles — no orphaned state across cycles


## Issue Tracking

JIRA ID: AICOMRCCL-1315

## Test Plan

- CI validation enabled.
- manual validation.

## Test Result
Test | Result | Time
-- | -- | --
NetPluginReload.CustomPluginReloadsAfterCommDestroy | PASS | 7.9 s
NetPluginAssignFail.FinalizesOnFailedAssignment | PASS | 6.8 s
NetPluginAssignFail.NetNameMismatchSkipsInit | PASS | 5.7 s
NetPluginAssignFail.SurvivesMultipleCommCycles | PASS | 6.2 s


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
