### PR TITLE
fix(rccl): saturate fp8/bf8 Sum, and fix 1-wide hadd on gfx942

### DIFF
--- a/projects/rccl/src/include/rccl_float8.h
+++ b/projects/rccl/src/include/rccl_float8.h
@@ -79,7 +79,15 @@ inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
   asm volatile("v_pk_add_f32 %0, %1, %2"
                : "=v"(v)
                : "v"(__builtin_amdgcn_cvt_pk_f32_fp8(x.__x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_fp8(y.__x, 0)));
-  return __builtin_amdgcn_cvt_pk_fp8_f32(v[0], v[0], ival, false);
+  // The builtin returns the packed fp8 bytes in an int. Returning that int
+  // directly would select rccl_float8's numeric int constructor, which converts
+  // the bit pattern as a value, so reinterpret it as raw storage instead.
+  union {
+    fp8x2_storage_t fp8x2;
+    rccl_float8 fp8[2];
+  } u{0};
+  u.fp8x2 = (fp8x2_storage_t)__builtin_amdgcn_cvt_pk_fp8_f32(v[0], v[0], ival, false);
+  return u.fp8[0];
 #else
   return rccl_float8(float(x) + float(y));
 #endif
@@ -105,7 +113,14 @@ inline __device__ rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y) {
   asm volatile("v_pk_add_f32 %0, %1, %2"
                : "=v"(v)
                : "v"(__builtin_amdgcn_cvt_pk_f32_bf8(x.__x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_bf8(y.__x, 0)));
-  return __builtin_amdgcn_cvt_pk_bf8_f32(v[0], v[0], ival, false);
+  // See hadd: reinterpret the packed bytes rather than letting the int
+  // constructor convert them numerically.
+  union {
+    fp8x2_storage_t bfp8x2;
+    rccl_bfloat8 bfp8[2];
+  } u{0};
+  u.bfp8x2 = (fp8x2_storage_t)__builtin_amdgcn_cvt_pk_bf8_f32(v[0], v[0], ival, false);
+  return u.bfp8[0];
 #else
   return rccl_bfloat8(float(x) + float(y));
 #endif

--- a/projects/rccl/src/include/rccl_float8.h
+++ b/projects/rccl/src/include/rccl_float8.h
@@ -47,10 +47,13 @@ typedef struct {
 #if __HIP_DEVICE_COMPILE__ && (defined(__gfx942__))
 typedef __hip_fp8_e4m3_fnuz rccl_float8;
 typedef __hip_fp8_e5m2_fnuz rccl_bfloat8;
+#define RCCL_FP8_MAX_FINITE 240.0f
 #else
 typedef __hip_fp8_e4m3 rccl_float8;
 typedef __hip_fp8_e5m2 rccl_bfloat8;
+#define RCCL_FP8_MAX_FINITE 448.0f
 #endif
+#define RCCL_BF8_MAX_FINITE 57344.0f
 
 typedef _Float16 half_t;
 typedef _Float16 half2_t __attribute__((ext_vector_type(2)));
@@ -59,6 +62,59 @@ typedef short shortx2_t __attribute__((ext_vector_type(2)));
 typedef short __attribute__((ext_vector_type(2))) __amd_shortx2_storage_t;
 typedef float float2_t __attribute__((ext_vector_type(2)));
 
+// The packed converts the adds below finish with round rather than saturate, so
+// a sum that leaves the destination's range comes back as Inf, or as NaN for
+// e4m3, which has no Inf encoding: Sum(448, 18) returned the 0x7f that means NaN
+// rather than the 0x7e that encodes 448. Clamping the intermediate first makes
+// such a sum saturate to +/-max_finite, which is what the hip_fp8 constructors
+// do in __HIP_SATFINITE mode and so what the paths that go through float() have
+// always done. A sum is Inf only when an operand is.
+//
+// These are the IEEE-754-2019 minimum/maximum operations, which propagate NaN
+// rather than returning the other operand, so a NaN sum survives the clamp
+// without a separate guard.
+#if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+inline __device__ half2_t rccl_clamp2_f16(half2_t v, half2_t bound) {
+  return __builtin_elementwise_minimum(__builtin_elementwise_maximum(v, -bound), bound);
+}
+
+// e5m2 shares f16's exponent range, so unlike e4m3 -- whose sums stop at 896 --
+// its sums can leave f16: 57344+57344 is 114688 and f16 stops at 65504. That
+// overflow produces the same Inf an Inf operand does, and the two have to end up
+// in different places, so the sum alone cannot decide it. The operands can. No
+// finite e5m2 value exceeds max_finite, so raising the bound to
+// max(|x|, |y|, max_finite) leaves it at max_finite for finite operands and
+// lifts it to Inf exactly when one operand is Inf, which is when the clamp has
+// to stop clamping. A NaN operand makes the bound NaN, which the clamp then
+// propagates -- the wanted answer, since the sum is NaN too.
+inline __device__ half2_t rccl_add_clamp2_bf8_f16(half2_t a, half2_t b) {
+  const half2_t maxFinite = {(half_t)RCCL_BF8_MAX_FINITE, (half_t)RCCL_BF8_MAX_FINITE};
+  half2_t bound = __builtin_elementwise_maximum(
+      __builtin_elementwise_maximum(__builtin_elementwise_abs(a), __builtin_elementwise_abs(b)),
+      maxFinite);
+  half2_t v;
+  asm volatile("v_pk_add_f16 %0, %1, %2" : "=v"(v) : "v"(a), "v"(b));
+  return rccl_clamp2_f16(v, bound);
+}
+#endif
+
+// gfx942 and gfx1250 add in f32, which holds every sum exactly, so the bound is
+// always max_finite and only the clamp is needed. Neither has a NaN-propagating
+// min/max, so this is written as the v_med3_f32 plus a compare and a select that
+// the hip_fp8 constructors emit for the paths that go through float(), and it
+// guards the clamp the way they do, letting every non-finite value through
+// rather than only NaN. NaN has to survive on both targets. Inf only arises on
+// gfx1250, whose types are the OCP variants: an Inf operand there gives an Inf
+// sum, which has to stay Inf rather than saturate to max_finite. gfx942's fnuz
+// types have no Inf encoding, so nothing it can decode reaches that case and its
+// behavior is the same either way.
+#if __HIP_DEVICE_COMPILE__ && (defined(__gfx942__) || defined(__gfx1250__))
+inline __device__ float rccl_clamp_f32(float v, float maxFinite) {
+  float clamped = __builtin_amdgcn_fmed3f(v, -maxFinite, maxFinite);
+  return __builtin_isfinite(v) ? clamped : v;
+}
+#endif
+
 inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
 #if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
   half2_t v1;
@@ -66,6 +122,8 @@ inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
                : "=v"(v1)
                : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(x.__x, 1.f, 0)),
                  "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(y.__x, 1.f, 0)));
+  const half2_t maxFinite = {(half_t)RCCL_FP8_MAX_FINITE, (half_t)RCCL_FP8_MAX_FINITE};
+  v1 = rccl_clamp2_f16(v1, maxFinite);
   union {
     shortx2_t i16_vec;
     rccl_float8 fp8[4];
@@ -79,6 +137,7 @@ inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
   asm volatile("v_pk_add_f32 %0, %1, %2"
                : "=v"(v)
                : "v"(__builtin_amdgcn_cvt_pk_f32_fp8(x.__x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_fp8(y.__x, 0)));
+  v[0] = rccl_clamp_f32(v[0], RCCL_FP8_MAX_FINITE);
   // The builtin returns the packed fp8 bytes in an int. Returning that int
   // directly would select rccl_float8's numeric int constructor, which converts
   // the bit pattern as a value, so reinterpret it as raw storage instead.
@@ -95,11 +154,8 @@ inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
 
 inline __device__ rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y) {
 #if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
-  half2_t v1;
-  asm volatile("v_pk_add_f16 %0, %1, %2"
-               : "=v"(v1)
-               : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x.__x, 1.f, 0)),
-                 "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y.__x, 1.f, 0)));
+  half2_t v1 = rccl_add_clamp2_bf8_f16(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x.__x, 1.f, 0),
+                                       __builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y.__x, 1.f, 0));
   union {
     shortx2_t i16_vec;
     rccl_bfloat8 fp8[4];
@@ -113,6 +169,7 @@ inline __device__ rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y) {
   asm volatile("v_pk_add_f32 %0, %1, %2"
                : "=v"(v)
                : "v"(__builtin_amdgcn_cvt_pk_f32_bf8(x.__x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_bf8(y.__x, 0)));
+  v[0] = rccl_clamp_f32(v[0], RCCL_BF8_MAX_FINITE);
   // See hadd: reinterpret the packed bytes rather than letting the int
   // constructor convert them numerically.
   union {
@@ -133,6 +190,8 @@ inline __device__ fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y) {
                : "=v"(v1)
                : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(x, 1.f, 0)),
                  "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(y, 1.f, 0)));
+  const half2_t maxFinite = {(half_t)RCCL_FP8_MAX_FINITE, (half_t)RCCL_FP8_MAX_FINITE};
+  v1 = rccl_clamp2_f16(v1, maxFinite);
   union {
     shortx2_t i16_vec;
     fp8x2_storage_t fp8;
@@ -145,7 +204,8 @@ inline __device__ fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y) {
   asm volatile("v_pk_add_f32 %0, %1, %2"
                : "=v"(v)
                : "v"(__builtin_amdgcn_cvt_pk_f32_fp8(x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_fp8(y, 0)));
-  return __builtin_amdgcn_cvt_pk_fp8_f32(v[0], v[1], ival, false);
+  return __builtin_amdgcn_cvt_pk_fp8_f32(rccl_clamp_f32(v[0], RCCL_FP8_MAX_FINITE),
+                                         rccl_clamp_f32(v[1], RCCL_FP8_MAX_FINITE), ival, false);
 #else
   union {
     rccl_float8 fp8[2];
@@ -161,11 +221,8 @@ inline __device__ fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y) {
 
 inline __device__ fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y) {
 #if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
-  half2_t v1;
-  asm volatile("v_pk_add_f16 %0, %1, %2"
-               : "=v"(v1)
-               : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x, 1.f, 0)),
-                 "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y, 1.f, 0)));
+  half2_t v1 = rccl_add_clamp2_bf8_f16(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x, 1.f, 0),
+                                       __builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y, 1.f, 0));
   union {
     shortx2_t i16_vec;
     fp8x2_storage_t fp8;
@@ -178,7 +235,8 @@ inline __device__ fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y) 
   asm volatile("v_pk_add_f32 %0, %1, %2"
                : "=v"(v)
                : "v"(__builtin_amdgcn_cvt_pk_f32_bf8(x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_bf8(y, 0)));
-  return __builtin_amdgcn_cvt_pk_bf8_f32(v[0], v[1], ival, false);
+  return __builtin_amdgcn_cvt_pk_bf8_f32(rccl_clamp_f32(v[0], RCCL_BF8_MAX_FINITE),
+                                         rccl_clamp_f32(v[1], RCCL_BF8_MAX_FINITE), ival, false);
 #else
   union {
     rccl_bfloat8 bfp8[2];

--- a/projects/rccl/src/include/rccl_float8.h
+++ b/projects/rccl/src/include/rccl_float8.h
@@ -82,19 +82,23 @@ inline __device__ half2_t rccl_clamp2_f16(half2_t v, half2_t bound) {
 // its sums can leave f16: 57344+57344 is 114688 and f16 stops at 65504. That
 // overflow produces the same Inf an Inf operand does, and the two have to end up
 // in different places, so the sum alone cannot decide it. The operands can. No
-// finite e5m2 value exceeds max_finite, so raising the bound to
-// max(|x|, |y|, max_finite) leaves it at max_finite for finite operands and
-// lifts it to Inf exactly when one operand is Inf, which is when the clamp has
-// to stop clamping. A NaN operand makes the bound NaN, which the clamp then
-// propagates -- the wanted answer, since the sum is NaN too.
+// finite e5m2 value exceeds max_finite, so widening the clamp's limits to
+// max(x, y, max_finite) above and min(x, y, -max_finite) below leaves them at
+// +/-max_finite for finite operands and opens the relevant side to infinity
+// exactly when an operand is the infinity that has to survive. A NaN operand
+// makes both limits NaN, which the clamp then propagates -- the wanted answer,
+// since the sum is NaN too.
+//
+// Taking the limits from the operands rather than their magnitudes is what keeps
+// this to four instructions: each limit is one v_pk_maximum3_f16 or
+// v_pk_minimum3_f16, and no absolute value has to be materialized first.
 inline __device__ half2_t rccl_add_clamp2_bf8_f16(half2_t a, half2_t b) {
   const half2_t maxFinite = {(half_t)RCCL_BF8_MAX_FINITE, (half_t)RCCL_BF8_MAX_FINITE};
-  half2_t bound = __builtin_elementwise_maximum(
-      __builtin_elementwise_maximum(__builtin_elementwise_abs(a), __builtin_elementwise_abs(b)),
-      maxFinite);
+  half2_t hi = __builtin_elementwise_maximum(__builtin_elementwise_maximum(a, b), maxFinite);
+  half2_t lo = __builtin_elementwise_minimum(__builtin_elementwise_minimum(a, b), -maxFinite);
   half2_t v;
   asm volatile("v_pk_add_f16 %0, %1, %2" : "=v"(v) : "v"(a), "v"(b));
-  return rccl_clamp2_f16(v, bound);
+  return __builtin_elementwise_minimum(__builtin_elementwise_maximum(v, lo), hi);
 }
 #endif
 

--- a/projects/rccl/src/include/rccl_float8.h
+++ b/projects/rccl/src/include/rccl_float8.h
@@ -47,10 +47,13 @@ typedef struct {
 #if __HIP_DEVICE_COMPILE__ && (defined(__gfx942__))
 typedef __hip_fp8_e4m3_fnuz rccl_float8;
 typedef __hip_fp8_e5m2_fnuz rccl_bfloat8;
+#define RCCL_FP8_MAX_FINITE 240.0f
 #else
 typedef __hip_fp8_e4m3 rccl_float8;
 typedef __hip_fp8_e5m2 rccl_bfloat8;
+#define RCCL_FP8_MAX_FINITE 448.0f
 #endif
+#define RCCL_BF8_MAX_FINITE 57344.0f
 
 typedef _Float16 half_t;
 typedef _Float16 half2_t __attribute__((ext_vector_type(2)));
@@ -59,6 +62,56 @@ typedef short shortx2_t __attribute__((ext_vector_type(2)));
 typedef short __attribute__((ext_vector_type(2))) __amd_shortx2_storage_t;
 typedef float float2_t __attribute__((ext_vector_type(2)));
 
+// The packed converts the adds below finish with round rather than saturate, so
+// a sum that leaves the destination's range comes back as Inf, or as NaN for
+// e4m3, which has no Inf encoding: Sum(448, 18) returned the 0x7f that means NaN
+// rather than the 0x7e that encodes 448. Clamping the intermediate first makes
+// such a sum saturate to +/-max_finite, which is what the hip_fp8 constructors
+// do in __HIP_SATFINITE mode and so what the paths that go through float() have
+// always done. A sum is Inf only when an operand is.
+//
+// These are the IEEE-754-2019 minimum/maximum operations, which propagate NaN
+// rather than returning the other operand, so a NaN sum survives the clamp
+// without a separate guard.
+#if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+inline __device__ half2_t rccl_clamp2_f16(half2_t v, half2_t bound) {
+  return __builtin_elementwise_minimum(__builtin_elementwise_maximum(v, -bound), bound);
+}
+
+// e5m2 shares f16's exponent range, so unlike e4m3 -- whose sums stop at 896 --
+// its sums can leave f16: 57344+57344 is 114688 and f16 stops at 65504. That
+// overflow produces the same Inf an Inf operand does, and the two have to end up
+// in different places, so the sum alone cannot decide it. The operands can. No
+// finite e5m2 value exceeds max_finite, so raising the bound to
+// max(|x|, |y|, max_finite) leaves it at max_finite for finite operands and
+// lifts it to Inf exactly when one operand is Inf, which is when the clamp has
+// to stop clamping. A NaN operand makes the bound NaN, which the clamp then
+// propagates -- the wanted answer, since the sum is NaN too.
+inline __device__ half2_t rccl_add_clamp2_bf8_f16(half2_t a, half2_t b) {
+  const half2_t maxFinite = {(half_t)RCCL_BF8_MAX_FINITE, (half_t)RCCL_BF8_MAX_FINITE};
+  half2_t bound = __builtin_elementwise_maximum(
+      __builtin_elementwise_maximum(__builtin_elementwise_abs(a), __builtin_elementwise_abs(b)),
+      maxFinite);
+  half2_t v;
+  asm volatile("v_pk_add_f16 %0, %1, %2" : "=v"(v) : "v"(a), "v"(b));
+  return rccl_clamp2_f16(v, bound);
+}
+#endif
+
+// gfx942 adds in f32, which holds every sum exactly, so only the clamp is
+// needed. Its fp8 types are the fnuz variants, which have no Inf encoding, so
+// neither an operand nor their f32 sum can be Inf and the bound is always
+// max_finite; NaN is the only value the clamp has to let through. gfx942 has no
+// NaN-propagating min/max, so this is the same v_med3_f32 plus v_cmp_o_f32 and
+// v_cndmask_b32 that the hip_fp8 constructors emit for the paths that go through
+// float().
+#if __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+inline __device__ float rccl_clamp_f32(float v, float maxFinite) {
+  float clamped = __builtin_amdgcn_fmed3f(v, -maxFinite, maxFinite);
+  return (v == v) ? clamped : v;
+}
+#endif
+
 inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
 #if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
   half2_t v1;
@@ -66,6 +119,8 @@ inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
                : "=v"(v1)
                : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(x.__x, 1.f, 0)),
                  "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(y.__x, 1.f, 0)));
+  const half2_t maxFinite = {(half_t)RCCL_FP8_MAX_FINITE, (half_t)RCCL_FP8_MAX_FINITE};
+  v1 = rccl_clamp2_f16(v1, maxFinite);
   union {
     shortx2_t i16_vec;
     rccl_float8 fp8[4];
@@ -79,6 +134,7 @@ inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
   asm volatile("v_pk_add_f32 %0, %1, %2"
                : "=v"(v)
                : "v"(__builtin_amdgcn_cvt_pk_f32_fp8(x.__x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_fp8(y.__x, 0)));
+  v[0] = rccl_clamp_f32(v[0], RCCL_FP8_MAX_FINITE);
   // The builtin returns the packed fp8 bytes in an int. Returning that int
   // directly would select rccl_float8's numeric int constructor, which converts
   // the bit pattern as a value, so reinterpret it as raw storage instead.
@@ -95,11 +151,8 @@ inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
 
 inline __device__ rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y) {
 #if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
-  half2_t v1;
-  asm volatile("v_pk_add_f16 %0, %1, %2"
-               : "=v"(v1)
-               : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x.__x, 1.f, 0)),
-                 "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y.__x, 1.f, 0)));
+  half2_t v1 = rccl_add_clamp2_bf8_f16(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x.__x, 1.f, 0),
+                                       __builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y.__x, 1.f, 0));
   union {
     shortx2_t i16_vec;
     rccl_bfloat8 fp8[4];
@@ -113,6 +166,7 @@ inline __device__ rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y) {
   asm volatile("v_pk_add_f32 %0, %1, %2"
                : "=v"(v)
                : "v"(__builtin_amdgcn_cvt_pk_f32_bf8(x.__x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_bf8(y.__x, 0)));
+  v[0] = rccl_clamp_f32(v[0], RCCL_BF8_MAX_FINITE);
   // See hadd: reinterpret the packed bytes rather than letting the int
   // constructor convert them numerically.
   union {
@@ -133,6 +187,8 @@ inline __device__ fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y) {
                : "=v"(v1)
                : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(x, 1.f, 0)),
                  "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(y, 1.f, 0)));
+  const half2_t maxFinite = {(half_t)RCCL_FP8_MAX_FINITE, (half_t)RCCL_FP8_MAX_FINITE};
+  v1 = rccl_clamp2_f16(v1, maxFinite);
   union {
     shortx2_t i16_vec;
     fp8x2_storage_t fp8;
@@ -145,7 +201,8 @@ inline __device__ fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y) {
   asm volatile("v_pk_add_f32 %0, %1, %2"
                : "=v"(v)
                : "v"(__builtin_amdgcn_cvt_pk_f32_fp8(x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_fp8(y, 0)));
-  return __builtin_amdgcn_cvt_pk_fp8_f32(v[0], v[1], ival, false);
+  return __builtin_amdgcn_cvt_pk_fp8_f32(rccl_clamp_f32(v[0], RCCL_FP8_MAX_FINITE),
+                                         rccl_clamp_f32(v[1], RCCL_FP8_MAX_FINITE), ival, false);
 #else
   union {
     rccl_float8 fp8[2];
@@ -161,11 +218,8 @@ inline __device__ fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y) {
 
 inline __device__ fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y) {
 #if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
-  half2_t v1;
-  asm volatile("v_pk_add_f16 %0, %1, %2"
-               : "=v"(v1)
-               : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x, 1.f, 0)),
-                 "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y, 1.f, 0)));
+  half2_t v1 = rccl_add_clamp2_bf8_f16(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x, 1.f, 0),
+                                       __builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y, 1.f, 0));
   union {
     shortx2_t i16_vec;
     fp8x2_storage_t fp8;
@@ -178,7 +232,8 @@ inline __device__ fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y) 
   asm volatile("v_pk_add_f32 %0, %1, %2"
                : "=v"(v)
                : "v"(__builtin_amdgcn_cvt_pk_f32_bf8(x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_bf8(y, 0)));
-  return __builtin_amdgcn_cvt_pk_bf8_f32(v[0], v[1], ival, false);
+  return __builtin_amdgcn_cvt_pk_bf8_f32(rccl_clamp_f32(v[0], RCCL_BF8_MAX_FINITE),
+                                         rccl_clamp_f32(v[1], RCCL_BF8_MAX_FINITE), ival, false);
 #else
   union {
     rccl_bfloat8 bfp8[2];

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -346,6 +346,7 @@ if(BUILD_TESTS)
       device/TestTdmCopy.cpp
       device/TestAsyncCopy.cpp
       device/TestLdsTransfer.cpp
+      device/NarrowFloatSum_test.cpp
       device/GinDeviceTests.cpp
       device/GinAnvilIpcDevice_test.cpp
       device/HierarchicalShuffleTests.cpp

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -256,6 +256,7 @@ if(BUILD_TESTS)
       DdaCollCommonTests.cpp
       VersionInfoTests.cpp
       device/TestOp128.cpp
+      device/NarrowFloatSum_test.cpp
       device/GinDeviceTests.cpp
       device/GinAnvilIpcDevice_test.cpp
       DeviceApiTests.cpp

--- a/projects/rccl/test/device/NarrowFloatSum_test.cpp
+++ b/projects/rccl/test/device/NarrowFloatSum_test.cpp
@@ -1,0 +1,258 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Regression tests for the fp8/bf8 Sum helpers in src/include/rccl_float8.h:
+//   hadd / hadd_b    - one element
+//   hadd2 / hadd2_b  - two elements packed into a uint16_t, element 0 low
+//
+// These are the helpers FuncSum dispatches to. Their packed conversions round
+// rather than saturate, so a sum of two finite operands that leaves the
+// destination's range used to come back as Inf, or as NaN for e4m3, which has no
+// Inf encoding: Sum(448, 18) returned 0x7f, a NaN, instead of the 0x7e that
+// encodes 448. All 65536 ordered byte pairs are swept, which covers every input
+// the helpers can be given.
+//
+// Three independent things are checked.
+//
+// First, the result matches what elem_t(float(a) + float(b)) returns, that is,
+// an f32 add narrowed by the HIP fp8 constructor. That constructor saturates in
+// __HIP_SATFINITE mode, and it is the path Prod, MinMax and PreMulSum already
+// take, so it is both the behavior Sum is meant to share and an oracle that
+// shares no code with the helpers under test.
+//
+// Second, the 1-wide and 2-wide results agree byte for byte, so a reduction's
+// answer cannot depend on whether an element happened to land in an aligned
+// pair. On gfx942 it did: the 1-wide helper recovered the packed bytes through
+// rccl_float8's numeric int constructor, which reinterpreted them as a value.
+//
+// Third, the promised semantics, without reference to any implementation, since
+// an oracle can only show that two paths agree and not that either is right:
+// finite operands give a finite in-range result, saturated exactly to
+// +/-max_finite when the exact sum is out of range; an Inf operand gives Inf,
+// except where the destination cannot hold one; a NaN operand gives NaN.
+//
+// The oracle runs on the device because the encoding is not portable: gfx942
+// uses the fnuz variants, where e4m3 stops at 240 and there are no Inf
+// encodings at all, while gfx950 and gfx12xx use OCP, where it stops at 448. A
+// host-computed reference would disagree for reasons having nothing to do with
+// the helpers. The operands and results therefore come back both as raw bytes,
+// for exact comparison, and as floats the device decoded, so the host can apply
+// the rules without knowing which encoding is in force.
+
+#include "DeviceTestBase.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "rccl_float8.h"
+
+namespace RcclUnitTesting
+{
+
+// Compile-time selection between the fp8 (e4m3) and bf8 (e5m2) helper family.
+template<bool IsBf8> struct SumTraits;
+
+template<> struct SumTraits<false> {
+  using elem_t = rccl_float8;
+  static __device__ fp8x2_storage_t packed(fp8x2_storage_t x, fp8x2_storage_t y) { return hadd2(x, y); }
+  static __device__ elem_t          scalar(elem_t a, elem_t b)                   { return hadd(a, b); }
+  static constexpr float            kMaxFinite = RCCL_FP8_MAX_FINITE;
+};
+
+template<> struct SumTraits<true> {
+  using elem_t = rccl_bfloat8;
+  static __device__ fp8x2_storage_t packed(fp8x2_storage_t x, fp8x2_storage_t y) { return hadd2_b(x, y); }
+  static __device__ elem_t          scalar(elem_t a, elem_t b)                   { return hadd_b(a, b); }
+  static constexpr float            kMaxFinite = RCCL_BF8_MAX_FINITE;
+};
+
+template<bool IsBf8>
+__device__ inline void decode2(fp8x2_storage_t v, float& lo, float& hi) {
+  union { typename SumTraits<IsBf8>::elem_t e[2]; fp8x2_storage_t s; } u;
+  u.s = v;
+  lo = float(u.e[0]);
+  hi = float(u.e[1]);
+}
+
+// RCCL_FP8_MAX_FINITE differs between the host pass (OCP, 448) and an fnuz
+// device build (240), so the device reports the limit it actually saturates to.
+template<bool IsBf8>
+__global__ void kReportMaxFinite(float* out) { *out = SumTraits<IsBf8>::kMaxFinite; }
+
+template<bool IsBf8>
+__global__ void kSum(const fp8x2_storage_t* __restrict__ X, const fp8x2_storage_t* __restrict__ Y,
+                     fp8x2_storage_t* __restrict__ packedRaw, fp8x2_storage_t* __restrict__ scalarRaw,
+                     fp8x2_storage_t* __restrict__ oracleRaw, float* __restrict__ packedF,
+                     float* __restrict__ scalarF, float* __restrict__ oracleF,
+                     float* __restrict__ aF, float* __restrict__ bF, int n) {
+  using elem_t = typename SumTraits<IsBf8>::elem_t;
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= n) return;
+
+  const fp8x2_storage_t x = X[i];
+  const fp8x2_storage_t y = Y[i];
+
+  union { elem_t e[2]; fp8x2_storage_t s; } ux, uy, us, uo;
+  ux.s = x;
+  uy.s = y;
+  for (int l = 0; l < 2; ++l) {
+    us.e[l] = SumTraits<IsBf8>::scalar(ux.e[l], uy.e[l]);
+    uo.e[l] = elem_t(float(ux.e[l]) + float(uy.e[l]));
+  }
+
+  const fp8x2_storage_t packed = SumTraits<IsBf8>::packed(x, y);
+  packedRaw[i] = packed;
+  scalarRaw[i] = us.s;
+  oracleRaw[i] = uo.s;
+  decode2<IsBf8>(packed, packedF[2 * i], packedF[2 * i + 1]);
+  decode2<IsBf8>(us.s, scalarF[2 * i], scalarF[2 * i + 1]);
+  decode2<IsBf8>(uo.s, oracleF[2 * i], oracleF[2 * i + 1]);
+  decode2<IsBf8>(x, aF[2 * i], aF[2 * i + 1]);
+  decode2<IsBf8>(y, bF[2 * i], bF[2 * i + 1]);
+}
+
+class NarrowFloatSumTest : public DeviceTestBase {
+protected:
+  template<bool IsBf8>
+  float deviceMaxFinite() {
+    DeviceBuffer<float> d(1);
+    kReportMaxFinite<IsBf8><<<1, 1>>>(d.ptr);
+    syncAndCheck();
+    return d.download();
+  }
+
+  // Bit-for-bit comparison. A mismatch where both sides decode to NaN is
+  // reported separately: that is a difference in NaN encoding, not in value.
+  static void expectBitMatch(const std::vector<fp8x2_storage_t>& got,
+                             const std::vector<fp8x2_storage_t>& want,
+                             const std::vector<float>& gotF, const std::vector<float>& wantF,
+                             const char* what) {
+    int mismatches = 0, nanEncodingOnly = 0, reported = 0;
+    for (size_t i = 0; i < got.size(); ++i) {
+      if (got[i] == want[i]) continue;
+      for (int l = 0; l < 2; ++l) {
+        const uint8_t g = static_cast<uint8_t>((got[i] >> (8 * l)) & 0xFF);
+        const uint8_t w = static_cast<uint8_t>((want[i] >> (8 * l)) & 0xFF);
+        if (g == w) continue;
+        if (std::isnan(gotF[2 * i + l]) && std::isnan(wantF[2 * i + l])) {
+          ++nanEncodingOnly;
+          continue;
+        }
+        if (reported++ < 10)
+          ADD_FAILURE() << what << ": pair " << i << " lane " << l << " got 0x" << std::hex
+                        << unsigned(g) << " (" << std::dec << gotF[2 * i + l] << ") want 0x"
+                        << std::hex << unsigned(w) << " (" << std::dec << wantF[2 * i + l] << ")";
+        ++mismatches;
+      }
+    }
+    EXPECT_EQ(mismatches, 0) << what << ": " << mismatches << " lanes differ in value";
+    if (nanEncodingOnly != 0)
+      GTEST_LOG_(INFO) << what << ": " << nanEncodingOnly
+                       << " lanes are NaN on both sides with different encodings";
+  }
+
+  // The exact sum is computed in double, which is exact for these operands:
+  // every fp8/bf8 value and every sum of two of them is representable there, so
+  // the only rounding in play is the one the helper itself performs.
+  static void expectRule(const std::vector<float>& aF, const std::vector<float>& bF,
+                         const std::vector<float>& rF, float maxFinite, const char* what) {
+    int badFinite = 0, badSat = 0, badSpecial = 0, reported = 0, saturating = 0;
+    for (size_t k = 0; k < rF.size(); ++k) {
+      const double a = aF[k], b = bF[k], r = rF[k];
+      const double exact = a + b;
+
+      if (std::isnan(a) || std::isnan(b) || std::isnan(exact)) {
+        if (!std::isnan(r)) {
+          if (reported++ < 10)
+            ADD_FAILURE() << what << ": " << a << " + " << b << " = " << r << ", expected NaN";
+          ++badSpecial;
+        }
+        continue;
+      }
+
+      if (std::isinf(a) || std::isinf(b)) {
+        // Inf is expected, but a destination without an Inf encoding can only
+        // answer NaN, so that is accepted too.
+        const bool ok = (std::isinf(r) && std::signbit(r) == std::signbit(exact)) || std::isnan(r);
+        if (!ok) {
+          if (reported++ < 10)
+            ADD_FAILURE() << what << ": " << a << " + " << b << " = " << r
+                          << ", expected Inf of the same sign, or NaN";
+          ++badSpecial;
+        }
+        continue;
+      }
+
+      if (!std::isfinite(r) || std::fabs(r) > maxFinite) {
+        if (reported++ < 10)
+          ADD_FAILURE() << what << ": " << a << " + " << b << " = " << exact << " came back as "
+                        << r << ", expected a finite value within +/-" << maxFinite;
+        ++badFinite;
+        continue;
+      }
+      if (std::fabs(exact) > maxFinite) {
+        ++saturating;
+        if (r != std::copysign(maxFinite, exact)) {
+          if (reported++ < 10)
+            ADD_FAILURE() << what << ": " << a << " + " << b << " = " << exact << " came back as "
+                          << r << ", expected " << std::copysign(maxFinite, exact);
+          ++badSat;
+        }
+      }
+    }
+    EXPECT_EQ(badFinite, 0) << what << ": " << badFinite << " lanes left the finite range";
+    EXPECT_EQ(badSat, 0) << what << ": " << badSat << " lanes did not saturate to the limit";
+    EXPECT_EQ(badSpecial, 0) << what << ": " << badSpecial << " lanes mishandled Inf or NaN";
+    // The overflow cases are the whole point, so fail rather than pass quietly
+    // if the sweep somehow contains none of them.
+    EXPECT_GT(saturating, 0) << what << ": no lane overflowed, so saturation went unexercised";
+    GTEST_LOG_(INFO) << what << ": " << saturating << " of " << rF.size()
+                     << " lanes overflowed and had to saturate";
+  }
+
+  // Every ordered pair of bytes. Lane 0 carries (a,b) and lane 1 the swapped
+  // (b,a), so each lane independently sees all 65536 pairs and a lane-swap or
+  // lane-drop bug cannot cancel out.
+  template<bool IsBf8>
+  void run(const char* what) {
+    const int N = 256 * 256;
+    std::vector<fp8x2_storage_t> hx(N), hy(N);
+    for (int idx = 0; idx < N; ++idx) {
+      const uint8_t a = static_cast<uint8_t>(idx & 0xFF);
+      const uint8_t b = static_cast<uint8_t>((idx >> 8) & 0xFF);
+      hx[idx] = static_cast<fp8x2_storage_t>(a | (static_cast<uint16_t>(b) << 8));
+      hy[idx] = static_cast<fp8x2_storage_t>(b | (static_cast<uint16_t>(a) << 8));
+    }
+    DeviceBuffer<fp8x2_storage_t> dx(N), dy(N), dp(N), ds(N), dor(N);
+    dx.copyFrom(hx);
+    dy.copyFrom(hy);
+    DeviceBuffer<float> dpf(2 * N), dsf(2 * N), dof(2 * N), daf(2 * N), dbf(2 * N);
+
+    kSum<IsBf8><<<gridFor(N), kDefaultBlockSize>>>(dx.ptr, dy.ptr, dp.ptr, ds.ptr, dor.ptr, dpf.ptr,
+                                                   dsf.ptr, dof.ptr, daf.ptr, dbf.ptr, N);
+    syncAndCheck();
+
+    const std::vector<fp8x2_storage_t> packedRaw = dp.copyTo(), scalarRaw = ds.copyTo(),
+                                       oracleRaw = dor.copyTo();
+    const std::vector<float> packedF = dpf.copyTo(), scalarF = dsf.copyTo(), oracleF = dof.copyTo();
+    const std::vector<float> aF = daf.copyTo(), bF = dbf.copyTo();
+
+    // Checking both widths against the oracle also settles them against each
+    // other, so there is no third comparison.
+    const std::string two = std::string(what) + " 2-wide vs float() oracle";
+    const std::string one = std::string(what) + " 1-wide vs float() oracle";
+    expectBitMatch(packedRaw, oracleRaw, packedF, oracleF, two.c_str());
+    expectBitMatch(scalarRaw, oracleRaw, scalarF, oracleF, one.c_str());
+    expectRule(aF, bF, packedF, deviceMaxFinite<IsBf8>(), what);
+  }
+};
+
+TEST_F(NarrowFloatSumTest, Fp8Sum) { run<false>("hadd2"); }
+TEST_F(NarrowFloatSumTest, Bf8Sum) { run<true>("hadd2_b"); }
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/device/NarrowFloatSum_test.cpp
+++ b/projects/rccl/test/device/NarrowFloatSum_test.cpp
@@ -61,14 +61,12 @@ template<> struct SumTraits<false> {
   using elem_t = rccl_float8;
   static __device__ fp8x2_storage_t packed(fp8x2_storage_t x, fp8x2_storage_t y) { return hadd2(x, y); }
   static __device__ elem_t          scalar(elem_t a, elem_t b)                   { return hadd(a, b); }
-  static constexpr float            kMaxFinite = RCCL_FP8_MAX_FINITE;
 };
 
 template<> struct SumTraits<true> {
   using elem_t = rccl_bfloat8;
   static __device__ fp8x2_storage_t packed(fp8x2_storage_t x, fp8x2_storage_t y) { return hadd2_b(x, y); }
   static __device__ elem_t          scalar(elem_t a, elem_t b)                   { return hadd_b(a, b); }
-  static constexpr float            kMaxFinite = RCCL_BF8_MAX_FINITE;
 };
 
 template<bool IsBf8>
@@ -79,10 +77,24 @@ __device__ inline void decode2(fp8x2_storage_t v, float& lo, float& hi) {
   hi = float(u.e[1]);
 }
 
-// RCCL_FP8_MAX_FINITE differs between the host pass (OCP, 448) and an fnuz
-// device build (240), so the device reports the limit it actually saturates to.
+// The limit is a property of the encoding, which the architecture decides:
+// e4m3 stops at 240 in the fnuz form gfx942 uses and at 448 in the OCP form
+// gfx950 uses. The device recovers it from the type by decoding all 256
+// encodings and keeping the largest finite magnitude, rather than reading the
+// constant the implementation clamps with, which would leave the saturation
+// check unable to see an error in that constant. It also keeps the test off a
+// macro that exists only on the architectures whose fp8 hardware the header
+// targets, so this still compiles for the likes of gfx90a.
 template<bool IsBf8>
-__global__ void kReportMaxFinite(float* out) { *out = SumTraits<IsBf8>::kMaxFinite; }
+__global__ void kReportMaxFinite(float* out) {
+  float best = 0.0f;
+  for (int b = 0; b < 256; ++b) {
+    float lo, hi;
+    decode2<IsBf8>(static_cast<fp8x2_storage_t>(b), lo, hi);
+    if (isfinite(lo) && lo > best) best = lo;
+  }
+  *out = best;
+}
 
 template<bool IsBf8>
 __global__ void kSum(const fp8x2_storage_t* __restrict__ X, const fp8x2_storage_t* __restrict__ Y,

--- a/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
@@ -115,7 +115,8 @@
         {"name": "MiscTests.Sorter", "description": "Task coll sorter unit test", "test_filter": "MiscTests.Sorter"},
         {"name": "VersionInfoTests", "description": "HIP/ROCm version string formatting tests", "test_filter": "VersionInfoTests.*"},
         {"name": "GinDeviceTest", "description": "GIN proxy backend device-leaf tests", "test_filter": "GinDeviceTest.*"},
-        {"name": "DdaCollCommon", "description": "DDA collective common helper tests", "test_filter": "DdaCollCommon.*"}
+        {"name": "DdaCollCommon", "description": "DDA collective common helper tests", "test_filter": "DdaCollCommon.*"},
+        {"name": "NarrowFloatSumTest", "description": "fp8/bf8 Sum helpers over every byte pair (rccl_float8.h hadd/hadd2)", "test_filter": "NarrowFloatSumTest.*"}
       ]
     },
     "unit_tests_gdr": {


### PR DESCRIPTION
Fixes #9556
Fixes #9478

**Problem.** Two correctness bugs in the narrow-float (fp8/bf8) reduce path. The gfx942 1-wide `hadd`/`hadd_b` recovered the packed bytes through `rccl_float8`'s numeric `int` constructor, which converts them as a value instead of reinterpreting them, so 1-wide Sum was wrong on nearly every input and disagreed with 2-wide on 64882 of the 65536 byte pairs — a reduction's answer depended on whether an element happened to land in an aligned pair. Separately, on every target the packed converts round rather than saturate, so a sum of two *finite* operands that left the destination's range came back as Inf for bf8, or as NaN for e4m3, which has no Inf encoding: `Sum(448, 18)` returned `0x7f` rather than the `0x7e` that encodes 448.

**Fixes.** The 1-wide helpers now take the low byte through a union, matching what the gfx950 path and the 2-wide helpers already did. For saturation, the intermediate is clamped before the pack, so finite operands saturate to ±max_finite and an Inf result means an Inf operand — which is what the `hip_fp8` constructors do in `__HIP_SATFINITE` mode, and so what Prod, MinMax and PreMulSum have always done. Only Sum takes the packed path, so only Sum changed. The clamp is spelled per target: gfx950 uses the IEEE-754-2019 min/max operations, which propagate NaN, with e5m2's limits built from the operands so an Inf operand stays distinguishable from an overflow that left f16; gfx942 and gfx1250 have no NaN-propagating min/max and so use `v_med3_f32` plus a compare and select, passing every non-finite value through rather than only NaN, since gfx1250's OCP e5m2 can carry a genuine Inf where gfx942's fnuz types cannot. Saturation is not free: measured on 8 MI350X, e4m3 costs +0.4% on AllReduce, +1.9% on ReduceScatter and +1.7% on AllReduceWithBias, and e5m2 +0.8%, +2.8% and +3.5%.

**Tests.** `NarrowFloatSum_test.cpp` sweeps all 65536 ordered byte pairs — every input the four helpers can be given — at both widths, with lane 0 carrying `(a,b)` and lane 1 the swapped `(b,a)` so a lane-swap or lane-drop bug cannot cancel out. Each result is checked against an oracle that shares no code with the helpers, `elem_t(float(a) + float(b))`, which settles the two widths against each other, and then against the promised semantics directly, since an oracle can only show that two paths agree and not that either is right: finite operands give a finite in-range result, saturated exactly to ±max_finite when the exact sum is out of range; an Inf operand gives Inf, except where the destination cannot hold one; a NaN operand gives NaN. The saturation limit is derived on the device from the encoding rather than read from the constant the implementation clamps with, so the test can see an error in that constant, and the count of overflowing lanes is asserted non-zero so the saturation checks cannot pass vacuously. Built against develop's header it fails on both gfx942 and gfx950 and names the bug; it passes with these fixes. It needs one GPU and no communicator. On gfx942 and gfx950 the sweep, `rccl-UnitTests`, `rccl-UnitTestsFixtures` and an exhaustive golden comparison against develop were all green — Prod, MinMax and PreMulSum byte-identical, every changed Sum case a finite-operand overflow that now saturates — but those runs predate the rebase and are worth repeating, since the rebase pulled `62ef479fa0` into the same lines the clamp sits on. gfx1250 is compile-verified only: every fp8/bf8 Sum kernel builds, and the test builds for it, but nothing has been run there, and it is the one target where the non-finite passthrough is load-bearing because OCP e5m2 can carry a genuine Inf.
