### PR TITLE
[rocjitsu] Wait for low-precision WMMA completion in gfx1250 B0-to-A0

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -29,6 +29,8 @@
 #include "rocjitsu/code/patch/sidecar_metadata.h"
 #include "rocjitsu/code/relocation_function_table.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna4/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/opcodes.h"
 #include "rocjitsu/isa/arch/amdgpu/isa_properties.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
@@ -90,6 +92,16 @@ LegalizationLookupFn select_legalization(rj_code_arch_t guest, rj_code_arch_t ho
   if (!raw)
     return {};
   return {raw, raw + inst.size() / sizeof(uint32_t)};
+}
+
+void append_gfx1250_wmma_completion_wait(std::vector<uint32_t> &words) {
+  // TODO: Replace this unconditional drain with block-local S_WAIT_ALU
+  // analysis over the final translated instruction stream. It should track
+  // VA_VDST/VM_VSRC register dependencies, account for pre-existing waits,
+  // and emit a wait only immediately before a dependent instruction.
+  constexpr uint16_t kWaitVaVdstZero = 0x0f9f;
+  words.push_back(
+      gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = kWaitVaVdstZero})[0]);
 }
 
 [[nodiscard]] uint32_t text_word_at(std::span<const uint8_t> text, uint64_t offset) {
@@ -2382,6 +2394,10 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
 
           if (expansion.status == ExpandStatus::Success) {
             std::vector<uint32_t> target_words = std::move(expansion.words);
+            if (is_gfx1250_b0_to_a0() &&
+                gfx1250_b0_to_a0_requires_wmma_completion_wait(inst)) {
+              append_gfx1250_wmma_completion_wait(target_words);
+            }
             append_words(kernel_text, target_words);
             queue_trace(pending_traces, inst, offset, leg, false, true, true, target_offset,
                         std::move(target_words));
@@ -2483,6 +2499,15 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         // indirect transfers have already taken their relocation paths above;
         // explicit profile expansions have already continued or failed closed.
         if (guest_arch_ == host_arch_ && leg == nullptr) {
+          if (is_gfx1250_b0_to_a0() &&
+              gfx1250_b0_to_a0_requires_wmma_completion_wait(inst)) {
+            std::vector<uint32_t> target_words = raw_words_for_inst(inst);
+            append_gfx1250_wmma_completion_wait(target_words);
+            append_words(kernel_text, target_words);
+            queue_trace(pending_traces, inst, offset, leg, false, false, true, target_offset,
+                        std::move(target_words));
+            continue;
+          }
           copy_original_instruction(inst, offset, kernel_text, pending_traces);
           continue;
         }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -3,7 +3,7 @@
 
 #include "rocjitsu/code/dbt/binary_translator.h"
 
-#include "rocjitsu/analysis/def_use_chain.h"
+#include "rocjitsu/analysis/gfx1250_vgpr_msb.h"
 #include "rocjitsu/analysis/liveness.h"
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
@@ -29,8 +29,6 @@
 #include "rocjitsu/code/patch/sidecar_metadata.h"
 #include "rocjitsu/code/relocation_function_table.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna4/machine_insts.h"
-#include "rocjitsu/isa/arch/amdgpu/gfx1250/builders.h"
-#include "rocjitsu/isa/arch/amdgpu/gfx1250/opcodes.h"
 #include "rocjitsu/isa/arch/amdgpu/isa_properties.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
@@ -92,16 +90,6 @@ LegalizationLookupFn select_legalization(rj_code_arch_t guest, rj_code_arch_t ho
   if (!raw)
     return {};
   return {raw, raw + inst.size() / sizeof(uint32_t)};
-}
-
-void append_gfx1250_wmma_completion_wait(std::vector<uint32_t> &words) {
-  // TODO: Replace this unconditional drain with block-local S_WAIT_ALU
-  // analysis over the final translated instruction stream. It should track
-  // VA_VDST/VM_VSRC register dependencies, account for pre-existing waits,
-  // and emit a wait only immediately before a dependent instruction.
-  constexpr uint16_t kWaitVaVdstZero = 0x0f9f;
-  words.push_back(
-      gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = kWaitVaVdstZero})[0]);
 }
 
 [[nodiscard]] uint32_t text_word_at(std::span<const uint8_t> text, uint64_t offset) {
@@ -1430,19 +1418,20 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     }
   };
 
-  auto copy_original_instruction = [&](const Instruction &inst, uint64_t offset,
-                                       std::vector<uint8_t> &kernel_text,
-                                       std::vector<PendingTrace> &pending_traces) {
-    const uint32_t inst_size = inst.size();
-    const uint64_t target_offset = kernel_text.size();
-    const auto *words = reinterpret_cast<const uint32_t *>(text.data() + offset);
-    std::vector<uint32_t> copied_words(words, words + inst_size / sizeof(uint32_t));
-    append_words(kernel_text, copied_words);
-    // Continued-failure mode is diagnostic-only. Emit an explicit copy event so
-    // diff reports make it clear which failed source instruction was preserved.
-    queue_trace(pending_traces, inst, offset, nullptr, true, false, false, target_offset,
-                std::move(copied_words));
-  };
+  auto copy_original_instruction =
+      [&](const Instruction &inst, uint64_t offset, std::vector<uint8_t> &kernel_text,
+          std::vector<PendingTrace> &pending_traces, std::span<const uint32_t> suffix_words = {}) {
+        const uint32_t inst_size = inst.size();
+        const uint64_t target_offset = kernel_text.size();
+        const auto *words = reinterpret_cast<const uint32_t *>(text.data() + offset);
+        std::vector<uint32_t> copied_words(words, words + inst_size / sizeof(uint32_t));
+        copied_words.insert(copied_words.end(), suffix_words.begin(), suffix_words.end());
+        append_words(kernel_text, copied_words);
+        // Continued-failure mode is diagnostic-only. Emit an explicit copy event so
+        // diff reports make it clear which failed source instruction was preserved.
+        queue_trace(pending_traces, inst, offset, nullptr, true, false, !suffix_words.empty(),
+                    target_offset, std::move(copied_words));
+      };
 
   auto continue_after_instruction_error = [&](const Instruction &inst, uint64_t offset,
                                               std::vector<uint8_t> &kernel_text,
@@ -1732,6 +1721,15 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     }
     const bool can_use_long_direct_branches =
         next_long_branch_sgpr_pair(kernel_context, host_arch_).has_value();
+    const bool is_gfx1250_b0_to_a0_profile = is_gfx1250_b0_to_a0();
+    std::unordered_map<uint64_t, const Instruction *> source_instruction_by_offset;
+    std::unordered_map<uint64_t, const BasicBlock *> source_block_by_end_offset;
+    for (BasicBlock *block : scope.blocks) {
+      for (const Instruction &inst : block->instructions())
+        source_instruction_by_offset.emplace(inst.src_loc(), &inst);
+      source_block_by_end_offset.emplace(block->end_offset(), block);
+    }
+
     LivenessAnalysisOptions liveness_options;
     liveness_options.max_free_vgpr =
         static_cast<uint16_t>(isa_properties(host_arch_).max_addressable_vgprs_per_wf);
@@ -1769,18 +1767,29 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           live_before_instructions.data(), live_before_instructions.size());
     }
     LivenessAnalysis liveness = LivenessAnalysis::unavailable();
+    std::vector<ScopedCfgEdge> scope_analysis_edges;
     if (scope_requires_liveness) {
-      const auto liveness_edges = scoped_call_liveness_edges(KernelBlockScope(scope.blocks), text);
-      liveness = LivenessAnalysis(KernelBlockScope(scope.blocks), liveness_options, liveness_edges);
+      scope_analysis_edges = scoped_call_liveness_edges(KernelBlockScope(scope.blocks), text);
+      liveness =
+          LivenessAnalysis(KernelBlockScope(scope.blocks), liveness_options, scope_analysis_edges);
     }
 
-    std::unordered_map<uint64_t, const Instruction *> source_instruction_by_offset;
-    std::unordered_map<uint64_t, const BasicBlock *> source_block_by_end_offset;
-    for (BasicBlock *block : scope.blocks) {
-      for (const Instruction &inst : block->instructions())
-        source_instruction_by_offset.emplace(inst.src_loc(), &inst);
-      source_block_by_end_offset.emplace(block->end_offset(), block);
-    }
+    std::unique_ptr<Gfx1250VgprMsbAnalysis> wmma_completion_wait_vgpr_msb;
+    auto needs_profile_wmma_completion_wait = [&](const Instruction &inst) {
+      return is_gfx1250_b0_to_a0_profile && gfx1250_b0_to_a0_requires_wmma_completion_wait(inst);
+    };
+    auto append_profile_wmma_completion_wait_if_needed = [&](const Instruction &inst,
+                                                             std::vector<uint32_t> &words) {
+      if (wmma_completion_wait_vgpr_msb == nullptr) {
+        if (!scope_requires_liveness) {
+          scope_analysis_edges = scoped_call_liveness_edges(KernelBlockScope(scope.blocks), text);
+        }
+        wmma_completion_wait_vgpr_msb = std::make_unique<Gfx1250VgprMsbAnalysis>(
+            KernelBlockScope(scope.blocks), scope.entry, scope_analysis_edges, text);
+      }
+      gfx1250_b0_to_a0_append_wmma_completion_wait_if_needed(inst, source_instruction_by_offset,
+                                                             *wmma_completion_wait_vgpr_msb, words);
+    };
 
     // Raw marker bytes are only candidates. Preserve a pool for this kernel
     // when either its marker and skip are adjacent decoded instructions in this
@@ -2394,10 +2403,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
 
           if (expansion.status == ExpandStatus::Success) {
             std::vector<uint32_t> target_words = std::move(expansion.words);
-            if (is_gfx1250_b0_to_a0() &&
-                gfx1250_b0_to_a0_requires_wmma_completion_wait(inst)) {
-              append_gfx1250_wmma_completion_wait(target_words);
-            }
+            if (needs_profile_wmma_completion_wait(inst))
+              append_profile_wmma_completion_wait_if_needed(inst, target_words);
             append_words(kernel_text, target_words);
             queue_trace(pending_traces, inst, offset, leg, false, true, true, target_offset,
                         std::move(target_words));
@@ -2499,14 +2506,13 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         // indirect transfers have already taken their relocation paths above;
         // explicit profile expansions have already continued or failed closed.
         if (guest_arch_ == host_arch_ && leg == nullptr) {
-          if (is_gfx1250_b0_to_a0() &&
-              gfx1250_b0_to_a0_requires_wmma_completion_wait(inst)) {
-            std::vector<uint32_t> target_words = raw_words_for_inst(inst);
-            append_gfx1250_wmma_completion_wait(target_words);
-            append_words(kernel_text, target_words);
-            queue_trace(pending_traces, inst, offset, leg, false, false, true, target_offset,
-                        std::move(target_words));
-            continue;
+          if (needs_profile_wmma_completion_wait(inst)) {
+            std::vector<uint32_t> suffix_words;
+            append_profile_wmma_completion_wait_if_needed(inst, suffix_words);
+            if (!suffix_words.empty()) {
+              copy_original_instruction(inst, offset, kernel_text, pending_traces, suffix_words);
+              continue;
+            }
           }
           copy_original_instruction(inst, offset, kernel_text, pending_traces);
           continue;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -166,6 +166,16 @@ inline constexpr std::array<std::string_view, 17> kExactB0ToA0TranslationMnemoni
 
 } // namespace
 
+bool gfx1250_b0_to_a0_requires_wmma_completion_wait(const Instruction &inst) {
+  const std::string_view mnemonic = inst.mnemonic();
+  if (!mnemonic.starts_with("v_wmma_"))
+    return false;
+
+  return mnemonic.find("_fp8") != std::string_view::npos ||
+         mnemonic.find("_bf8") != std::string_view::npos ||
+         mnemonic.find("_f8f6f4") != std::string_view::npos || mnemonic.ends_with("_f4");
+}
+
 const InstructionLegalization *gfx1250_b0_to_a0_legalization(const Instruction &inst) {
   // CLAMP=0 is the common E4M3 operation on both steppings. CLAMP=1 selects
   // the B0-only E5M3 behavior and therefore requires a semantic expansion.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -6,10 +6,14 @@
 
 #include "rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.h"
 
+#include "rocjitsu/analysis/def_use_chain.h"
+#include "rocjitsu/analysis/gfx1250_vgpr_msb.h"
 #include "rocjitsu/code/dbt/generated/legalization_types.h"
 #include "rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/builders.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/encodings.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/opcodes.h"
 #include "rocjitsu/isa/instruction.h"
 
 #include "util/log.h"
@@ -17,6 +21,8 @@
 #include <array>
 #include <cstring>
 #include <string_view>
+#include <unordered_map>
+#include <vector>
 
 namespace rocjitsu {
 namespace {
@@ -164,6 +170,58 @@ inline constexpr std::array<std::string_view, 17> kExactB0ToA0TranslationMnemoni
          mnemonic == "s_monitor_sleep";
 }
 
+[[nodiscard]] bool is_wmma_completion_wait(const Instruction &inst) {
+  if (inst.size() != static_cast<int>(sizeof(uint32_t)) || inst.raw_encoding() == nullptr ||
+      inst.mnemonic() != "s_wait_alu")
+    return false;
+
+  // S_WAIT_ALU SIMM16[15:12] is VA_VDST. Zero waits for all outstanding
+  // destination writes, regardless of any additional counters the source
+  // instruction also drains.
+  constexpr uint32_t kVaVdstMask = 0xf000u;
+  return (inst.raw_encoding()[0] & kVaVdstMask) == 0;
+}
+
+[[nodiscard]] bool has_wmma_completion_wait_ahead(
+    const Instruction &inst,
+    const std::unordered_map<uint64_t, const Instruction *> &source_instruction_by_offset,
+    const Gfx1250VgprMsbAnalysis &vgpr_msb) {
+  RegisterSet pending_defs = InstDefUse(inst, &vgpr_msb, UnknownVgprDefPolicy::ExpandAll).defs;
+  uint64_t next_offset = inst.src_loc() + inst.size();
+  while (true) {
+    const auto next_it = source_instruction_by_offset.find(next_offset);
+    if (next_it == source_instruction_by_offset.end())
+      return false;
+
+    const Instruction &next = *next_it->second;
+    constexpr uint64_t kControlTransferOrTerminator =
+        BRANCH | COND_BRANCH | INDIRECT_BRANCH | INDIRECT_CALL | PROGRAM_TERMINATOR;
+    if ((next.flags() & kControlTransferOrTerminator) != 0)
+      return false;
+    if (is_wmma_completion_wait(next))
+      return true;
+
+    // Bound the scan to affected WMMA and the exact scalar instructions that
+    // generated split forms may place before their trailing completion wait.
+    // The def/use check below independently verifies VGPR transparency for
+    // both generated and hand-written source streams.
+    const std::string_view mnemonic = next.mnemonic();
+    const bool canonical_split_scaffolding =
+        mnemonic == "s_wait_xcnt" || mnemonic == "s_set_vgpr_msb";
+    if (!canonical_split_scaffolding && !gfx1250_b0_to_a0_requires_wmma_completion_wait(next))
+      return false;
+
+    const InstDefUse access(next, &vgpr_msb, UnknownVgprDefPolicy::ExpandAll);
+    if (access.uses.intersects(pending_defs))
+      return false;
+    pending_defs |= access.defs;
+
+    if (next.size() <= 0)
+      return false;
+    next_offset += static_cast<uint64_t>(next.size());
+  }
+}
+
 } // namespace
 
 bool gfx1250_b0_to_a0_requires_wmma_completion_wait(const Instruction &inst) {
@@ -174,6 +232,27 @@ bool gfx1250_b0_to_a0_requires_wmma_completion_wait(const Instruction &inst) {
   return mnemonic.find("_fp8") != std::string_view::npos ||
          mnemonic.find("_bf8") != std::string_view::npos ||
          mnemonic.find("_f8f6f4") != std::string_view::npos || mnemonic.ends_with("_f4");
+}
+
+void gfx1250_b0_to_a0_append_wmma_completion_wait_if_needed(
+    const Instruction &inst,
+    const std::unordered_map<uint64_t, const Instruction *> &source_instruction_by_offset,
+    const Gfx1250VgprMsbAnalysis &vgpr_msb, std::vector<uint32_t> &words) {
+  if (!gfx1250_b0_to_a0_requires_wmma_completion_wait(inst) ||
+      has_wmma_completion_wait_ahead(inst, source_instruction_by_offset, vgpr_msb)) {
+    return;
+  }
+
+  // TODO: Replace this conservative producer-side drain with block-local
+  // S_WAIT_ALU analysis over the final translated instruction stream. It should
+  // track VA_VDST/VM_VSRC dependencies and wait only before a dependent use.
+  // B0 code may schedule scaled WMMA consumers under SCHED_MODE 2 using B0
+  // completion timing. A0 has a lower FP8/FP4 WMMA issue rate, and mode 2 makes
+  // software responsible for VA_VDST dependencies. Wait for pending VALU
+  // destinations without draining unrelated ALU dependency counters.
+  // The no-wait default is 0xff9f; clearing only VA_VDST[15:12] gives 0x0f9f.
+  constexpr uint16_t kWaitVaVdstZero = 0x0f9f;
+  words.push_back(gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = kWaitVaVdstZero})[0]);
 }
 
 const InstructionLegalization *gfx1250_b0_to_a0_legalization(const Instruction &inst) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.h
@@ -27,6 +27,14 @@ struct InstructionLegalization;
 /// changing code.
 [[nodiscard]] const InstructionLegalization *gfx1250_b0_to_a0_legalization(const Instruction &inst);
 
+/// @brief True when a low-precision B0 WMMA needs an A0 completion wait.
+///
+/// @details This conservative classification covers every dense FP8/BF8,
+/// F8F6F4, and FP4 WMMA form that executes through the affected low-precision
+/// path after translation. It is intentionally separate from legalization
+/// because some of these instructions otherwise retain their original encoding.
+[[nodiscard]] bool gfx1250_b0_to_a0_requires_wmma_completion_wait(const Instruction &inst);
+
 } // namespace rocjitsu
 
 #endif // ROCJITSU_CODE_DBT_LEGALIZATION_GFX1250_B0_TO_A0_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.h
@@ -7,8 +7,13 @@
 #ifndef ROCJITSU_CODE_DBT_LEGALIZATION_GFX1250_B0_TO_A0_H_
 #define ROCJITSU_CODE_DBT_LEGALIZATION_GFX1250_B0_TO_A0_H_
 
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
 namespace rocjitsu {
 
+class Gfx1250VgprMsbAnalysis;
 class Instruction;
 struct InstructionLegalization;
 
@@ -34,6 +39,23 @@ struct InstructionLegalization;
 /// path after translation. It is intentionally separate from legalization
 /// because some of these instructions otherwise retain their original encoding.
 [[nodiscard]] bool gfx1250_b0_to_a0_requires_wmma_completion_wait(const Instruction &inst);
+
+/// @brief Append an A0 completion wait when the source stream does not already
+///        provide one for this low-precision WMMA.
+///
+/// @details A trailing VA_VDST=0 wait may cover consecutive independent WMMA
+/// producers, including the two halves of an M=32 expansion. It cannot be
+/// credited across a later WMMA that reads an earlier pending destination.
+/// Only these read-after-write overlaps block credit; overlapping destination
+/// ranges remain creditable because they do not consume a pending result.
+/// Generated VGPR-bank transition instructions are transparent, and physical
+/// VGPR dependencies are resolved with @p vgpr_msb.
+///
+/// @pre The caller has selected the gfx1250 B0-to-A0 translation profile.
+void gfx1250_b0_to_a0_append_wmma_completion_wait_if_needed(
+    const Instruction &inst,
+    const std::unordered_map<uint64_t, const Instruction *> &source_instruction_by_offset,
+    const Gfx1250VgprMsbAnalysis &vgpr_msb, std::vector<uint32_t> &words);
 
 } // namespace rocjitsu
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -873,6 +873,13 @@ ExpandResult expand_gfx1250_wmma_scale_src2(const Instruction &inst, uint32_t, u
     std::vector<uint32_t> words(inst.raw_encoding(), inst.raw_encoding() + 4);
     // Instruction bits [58:50] occupy word 1 bits [26:18].
     set_word_field(words[1], 0x100, 18, 9);
+    // B0 code may schedule scaled WMMA consumers under SCHED_MODE 2 using
+    // B0 completion timing. A0 has a lower FP8/FP4 WMMA issue rate, and mode 2
+    // makes software responsible for VA_VDST dependencies. Wait for pending
+    // VALU destinations without draining unrelated ALU dependency counters.
+    constexpr uint16_t kWaitVaVdstZero = 0x0f9f;
+    append_words(
+        words, gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = kWaitVaVdstZero}));
     return ExpandResult::success(std::move(words));
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -873,13 +873,6 @@ ExpandResult expand_gfx1250_wmma_scale_src2(const Instruction &inst, uint32_t, u
     std::vector<uint32_t> words(inst.raw_encoding(), inst.raw_encoding() + 4);
     // Instruction bits [58:50] occupy word 1 bits [26:18].
     set_word_field(words[1], 0x100, 18, 9);
-    // B0 code may schedule scaled WMMA consumers under SCHED_MODE 2 using
-    // B0 completion timing. A0 has a lower FP8/FP4 WMMA issue rate, and mode 2
-    // makes software responsible for VA_VDST dependencies. Wait for pending
-    // VALU destinations without draining unrelated ALU dependency counters.
-    constexpr uint16_t kWaitVaVdstZero = 0x0f9f;
-    append_words(
-        words, gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = kWaitVaVdstZero}));
     return ExpandResult::success(std::move(words));
   }
 

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -9991,6 +9991,8 @@ TEST(BinaryTranslatorE2E, Gfx1250UsesNeutralScaledK128Fp8Bf8Wmma) {
       .neg = 7,
   };
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr auto completion_wait =
+      gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = 0x0f9f});
 
   EXPECT_EQ(rocjitsu::semantic_expand_rules_gfx1250_b0_to_a0().size(), 39u);
   for (const WmmaCase &test_case : cases) {
@@ -10010,7 +10012,7 @@ TEST(BinaryTranslatorE2E, Gfx1250UsesNeutralScaledK128Fp8Bf8Wmma) {
                                                             : result.diagnostics.front().message);
     rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
     ASSERT_FALSE(translated.text_sections().empty());
-    ASSERT_GE(translated.text_sections()[0]->size(), 5 * sizeof(uint32_t));
+    ASSERT_GE(translated.text_sections()[0]->size(), 6 * sizeof(uint32_t));
     const auto *words = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
     gfx1250::Vop3pMachineInst prefix{};
     gfx1250::Vop3pMachineInst matrix{};
@@ -10034,7 +10036,8 @@ TEST(BinaryTranslatorE2E, Gfx1250UsesNeutralScaledK128Fp8Bf8Wmma) {
     EXPECT_EQ((matrix.pad_14 << 2) | matrix.opsel_hi, test_case.matrix_b_fmt);
     EXPECT_EQ(matrix.neg_hi, 4u) << "preserve only C absolute";
     EXPECT_EQ(matrix.neg, 4u) << "preserve only C negate";
-    EXPECT_EQ(words[4], kGfx1250SEndpgm);
+    EXPECT_EQ(words[4], completion_wait[0]);
+    EXPECT_EQ(words[5], kGfx1250SEndpgm);
   }
 }
 
@@ -10056,7 +10059,7 @@ TEST(BinaryTranslatorE2E, Gfx1250K128WmmaTranslatesCapturedEncodingWithoutK64Fal
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_FALSE(translated.text_sections().empty());
-  EXPECT_EQ(translated.text_sections()[0]->size(), 5 * sizeof(uint32_t));
+  EXPECT_EQ(translated.text_sections()[0]->size(), 6 * sizeof(uint32_t));
   const auto decoded =
       decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
   EXPECT_EQ(std::ranges::count_if(decoded,
@@ -10674,6 +10677,8 @@ TEST(BinaryTranslatorE2E, Gfx1250WrapsBareF8f6f4WmmaInNeutralScaleForA0) {
   };
   constexpr auto wmma = gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p, fields);
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr auto completion_wait =
+      gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = 0x0f9f});
   constexpr size_t kPrefixAndMatrixWords = 4;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {wmma[0], wmma[1], kGfx1250SEndpgm});
@@ -10691,14 +10696,15 @@ TEST(BinaryTranslatorE2E, Gfx1250WrapsBareF8f6f4WmmaInNeutralScaleForA0) {
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   const auto decoded =
       decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
-  ASSERT_GE(decoded.size(), 2u);
+  ASSERT_GE(decoded.size(), 3u);
   EXPECT_EQ(decoded[0]->mnemonic(), "v_wmma_scale_f32_16x16x128_f8f6f4");
   EXPECT_EQ(decoded[0]->size(), 4 * static_cast<int>(sizeof(uint32_t)));
-  EXPECT_EQ(decoded[1]->mnemonic(), "s_endpgm");
+  EXPECT_EQ(decoded[1]->mnemonic(), "s_wait_alu");
+  EXPECT_EQ(decoded[2]->mnemonic(), "s_endpgm");
 
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
-  ASSERT_GE(translated.text_sections()[0]->size() / sizeof(uint32_t), kPrefixAndMatrixWords + 1u);
+  ASSERT_GE(translated.text_sections()[0]->size() / sizeof(uint32_t), kPrefixAndMatrixWords + 2u);
   gfx1250::Vop3pMachineInst prefix{};
   std::memcpy(&prefix, target_words, sizeof(prefix));
   EXPECT_EQ(prefix.op, 0x35u);
@@ -10712,10 +10718,11 @@ TEST(BinaryTranslatorE2E, Gfx1250WrapsBareF8f6f4WmmaInNeutralScaleForA0) {
   EXPECT_EQ(prefix.pad_14, 0u);
   EXPECT_EQ(target_words[2], wmma[0]);
   EXPECT_EQ(target_words[3], wmma[1]);
-  EXPECT_EQ(target_words[kPrefixAndMatrixWords], kGfx1250SEndpgm);
+  EXPECT_EQ(target_words[kPrefixAndMatrixWords], completion_wait[0]);
+  EXPECT_EQ(target_words[kPrefixAndMatrixWords + 1], kGfx1250SEndpgm);
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250CopiesSupportedK64LowPrecisionWmmaThroughForA0) {
+TEST(BinaryTranslatorE2E, Gfx1250PreservesSupportedK64LowPrecisionWmmaAndAppendsWaitForA0) {
   struct Case {
     const char *name;
     uint16_t opcode;
@@ -10731,6 +10738,8 @@ TEST(BinaryTranslatorE2E, Gfx1250CopiesSupportedK64LowPrecisionWmmaThroughForA0)
       {"v_wmma_f16_16x16x64_bf8_bf8", gfx1250::kVWmmaF1616x16x64Bf8Bf8Vop3p},
   }};
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr auto completion_wait =
+      gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = 0x0f9f});
   for (const auto &c : cases) {
     const auto wmma = gfx1250::build_vop3p(
         c.opcode, {.vdst = 32, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
@@ -10752,7 +10761,8 @@ TEST(BinaryTranslatorE2E, Gfx1250CopiesSupportedK64LowPrecisionWmmaThroughForA0)
         reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
     EXPECT_EQ(target_words[0], wmma[0]) << c.name;
     EXPECT_EQ(target_words[1], wmma[1]) << c.name;
-    EXPECT_EQ(target_words[2], kGfx1250SEndpgm) << c.name;
+    EXPECT_EQ(target_words[2], completion_wait[0]) << c.name;
+    EXPECT_EQ(target_words[3], kGfx1250SEndpgm) << c.name;
   }
 }
 
@@ -10779,8 +10789,10 @@ TEST(BinaryTranslatorE2E, Gfx1250CopiesA0CompatibleLowPrecisionSwmmac) {
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   const auto text = translated.text_sections();
   ASSERT_EQ(text.size(), 1u);
-  ASSERT_GE(text[0]->size(), 2 * sizeof(uint32_t));
+  ASSERT_GE(text[0]->size(), 3 * sizeof(uint32_t));
   EXPECT_EQ(std::memcmp(text[0]->data(), swmmac.data(), 2 * sizeof(uint32_t)), 0);
+  const auto *target_words = reinterpret_cast<const uint32_t *>(text[0]->data());
+  EXPECT_EQ(target_words[2], kGfx1250SEndpgm);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250Allows32BitFlatScratchBaseHiSource) {
@@ -11799,7 +11811,7 @@ TEST(BinaryTranslatorE2E, Gfx1250TensorLoadDoesNotReuseMaskPrefixBypassedByBranc
   EXPECT_EQ(second_result.elf_bytes, result.elf_bytes);
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250RegularWmmaScaleEncodesUnusedSrc2AsVgpr) {
+TEST(BinaryTranslatorE2E, Gfx1250RegularWmmaScaleEncodesSrc2AndWaitsForCompletion) {
   // Real VOP3PX2 encoding from the mxscale offline oracle. Bits [58:50] are
   // zero in the B0 object even though SQ decodes that unused field as a scalar
   // dependency. The A0 output must encode VGPR0 without changing other bits.
@@ -11822,12 +11834,18 @@ TEST(BinaryTranslatorE2E, Gfx1250RegularWmmaScaleEncodesUnusedSrc2AsVgpr) {
   ASSERT_FALSE(translated.text_sections().empty());
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  const size_t target_word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+  ASSERT_EQ(target_word_count, 6u);
   constexpr uint32_t kScaleSrc2Mask = 0x1ffu << 18;
+  constexpr uint16_t kWaitVaVdstZero = 0x0f9f;
+  constexpr auto completion_wait =
+      gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = kWaitVaVdstZero});
   EXPECT_EQ(target_words[0], source_scale[0]);
   EXPECT_EQ(target_words[1], (source_scale[1] & ~kScaleSrc2Mask) | (0x100u << 18));
   EXPECT_EQ(target_words[2], source_scale[2]);
   EXPECT_EQ(target_words[3], source_scale[3]);
-  EXPECT_EQ(target_words[4], kGfx1250SEndpgm);
+  EXPECT_EQ(target_words[4], completion_wait[0]);
+  EXPECT_EQ(target_words[5], kGfx1250SEndpgm);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250FloatingScaledWmmaRejectsNonzeroCmFields) {
@@ -12211,6 +12229,8 @@ TEST(BinaryTranslatorE2E, Gfx1250SplitsScale16Fp4AcrossMOnlyForA0) {
       gfx1250::kVWmmaF3232x16x128F4Vop3p,
       {.vdst = 96, .neg_hi = 4, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48, .neg = 4});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr auto completion_wait =
+      gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = 0x0f9f});
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {scale16[0], scale16[1], matrix[0], matrix[1], kGfx1250SEndpgm});
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
@@ -12263,8 +12283,9 @@ TEST(BinaryTranslatorE2E, Gfx1250SplitsScale16Fp4AcrossMOnlyForA0) {
     EXPECT_EQ(replacement.neg_hi, 4u);
     EXPECT_EQ(replacement.neg, 4u);
   }
-  EXPECT_EQ(word_count, 9u);
-  EXPECT_EQ(words[8], kGfx1250SEndpgm);
+  EXPECT_EQ(word_count, 10u);
+  EXPECT_EQ(words[8], completion_wait[0]);
+  EXPECT_EQ(words[9], kGfx1250SEndpgm);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250Scale16Fp4AcceptsScalarAndInlineScaleSources) {
@@ -12482,6 +12503,8 @@ TEST(BinaryTranslatorE2E, Gfx1250PreservesNativeM16Scale16ForA0) {
                                                                               .neg = 4});
   matrix[0] |= uint32_t{1} << 14;
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr auto completion_wait =
+      gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = 0x0f9f});
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {scale16[0], scale16[1], matrix[0], matrix[1], kGfx1250SEndpgm});
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
@@ -12499,14 +12522,15 @@ TEST(BinaryTranslatorE2E, Gfx1250PreservesNativeM16Scale16ForA0) {
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
   const size_t target_word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
-  ASSERT_EQ(target_word_count, 5u);
+  ASSERT_EQ(target_word_count, 6u);
   constexpr uint32_t kUnusedScaleSrc2Mask = 0x1ffu << 18;
   EXPECT_EQ(target_words[0], scale16[0]);
   EXPECT_EQ(target_words[1],
             (scale16[1] & ~kUnusedScaleSrc2Mask) | (static_cast<uint32_t>(256u) << 18));
   EXPECT_EQ(target_words[2], matrix[0]);
   EXPECT_EQ(target_words[3], matrix[1]);
-  EXPECT_EQ(target_words[4], kGfx1250SEndpgm);
+  EXPECT_EQ(target_words[4], completion_wait[0]);
+  EXPECT_EQ(target_words[5], kGfx1250SEndpgm);
 
   const auto decoded =
       decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -2738,6 +2738,10 @@ namespace cdna4 = rocjitsu::cdna4;
 namespace gfx1250 = rocjitsu::gfx1250;
 namespace rdna4 = rocjitsu::rdna4;
 
+constexpr uint16_t kGfx1250WmmaCompletionWaitImmediate = 0x0f9f;
+constexpr auto kGfx1250WmmaCompletionWait =
+    gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = kGfx1250WmmaCompletionWaitImmediate});
+
 /// @brief Build explicit gfx1250 revision options without partial aggregate
 /// initializers, which are rejected by the test suite's warning policy.
 rocjitsu::BinaryTranslatorOptions
@@ -9991,8 +9995,7 @@ TEST(BinaryTranslatorE2E, Gfx1250UsesNeutralScaledK128Fp8Bf8Wmma) {
       .neg = 7,
   };
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
-  constexpr auto completion_wait =
-      gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = 0x0f9f});
+  constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
 
   EXPECT_EQ(rocjitsu::semantic_expand_rules_gfx1250_b0_to_a0().size(), 39u);
   for (const WmmaCase &test_case : cases) {
@@ -10677,8 +10680,7 @@ TEST(BinaryTranslatorE2E, Gfx1250WrapsBareF8f6f4WmmaInNeutralScaleForA0) {
   };
   constexpr auto wmma = gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p, fields);
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
-  constexpr auto completion_wait =
-      gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = 0x0f9f});
+  constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
   constexpr size_t kPrefixAndMatrixWords = 4;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {wmma[0], wmma[1], kGfx1250SEndpgm});
@@ -10738,8 +10740,7 @@ TEST(BinaryTranslatorE2E, Gfx1250PreservesSupportedK64LowPrecisionWmmaAndAppends
       {"v_wmma_f16_16x16x64_bf8_bf8", gfx1250::kVWmmaF1616x16x64Bf8Bf8Vop3p},
   }};
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
-  constexpr auto completion_wait =
-      gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = 0x0f9f});
+  constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
   for (const auto &c : cases) {
     const auto wmma = gfx1250::build_vop3p(
         c.opcode, {.vdst = 32, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
@@ -10751,19 +10752,211 @@ TEST(BinaryTranslatorE2E, Gfx1250PreservesSupportedK64LowPrecisionWmmaAndAppends
         ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
         gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
                                  rocjitsu::ProcessorRevision::Gfx1250A0));
+    struct TraceClassification {
+      bool copied_original;
+      bool semantic_lowering;
+      bool changed;
+      size_t target_word_count;
+    };
+    std::optional<TraceClassification> wmma_trace;
+    translator.set_trace_callback([&](const rocjitsu::TranslationTraceEvent &event) {
+      if (event.source_words.size() != wmma.size() || event.source_words[0] != wmma[0] ||
+          event.source_words[1] != wmma[1]) {
+        return;
+      }
+      wmma_trace = {.copied_original = event.copied_original,
+                    .semantic_lowering = event.semantic_lowering,
+                    .changed = event.changed,
+                    .target_word_count = event.target_words.size()};
+    });
     auto result = translator.translate(source);
 
     ASSERT_TRUE(result.ok()) << c.name << ": "
                              << (result.diagnostics.empty() ? ""
                                                             : result.diagnostics.front().message);
     rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    ASSERT_FALSE(translated.text_sections().empty()) << c.name;
+    ASSERT_GE(translated.text_sections()[0]->size(), 4 * sizeof(uint32_t)) << c.name;
     const auto *target_words =
         reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
     EXPECT_EQ(target_words[0], wmma[0]) << c.name;
     EXPECT_EQ(target_words[1], wmma[1]) << c.name;
     EXPECT_EQ(target_words[2], completion_wait[0]) << c.name;
     EXPECT_EQ(target_words[3], kGfx1250SEndpgm) << c.name;
+    ASSERT_TRUE(wmma_trace.has_value()) << c.name;
+    EXPECT_TRUE(wmma_trace->copied_original) << c.name;
+    EXPECT_FALSE(wmma_trace->semantic_lowering) << c.name;
+    EXPECT_TRUE(wmma_trace->changed) << c.name;
+    EXPECT_EQ(wmma_trace->target_word_count, 3u) << c.name;
+
+    const auto second = translator.translate(translated);
+    ASSERT_TRUE(second.ok()) << c.name << ": "
+                             << (second.diagnostics.empty() ? ""
+                                                            : second.diagnostics.front().message);
+    EXPECT_EQ(second.elf_bytes, result.elf_bytes) << c.name;
   }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250DoesNotCreditTrailingWaitAcrossDependentWmma) {
+  constexpr auto producer =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 32, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
+  constexpr auto consumer =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 96, .src0 = 256 + 8, .src1 = 256 + 16, .src2 = 256 + 32});
+  constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {producer[0], producer[1], consumer[0], consumer[1], completion_wait[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  ASSERT_GE(translated.text_sections()[0]->size(), 7 * sizeof(uint32_t));
+  EXPECT_EQ(target_words[0], producer[0]);
+  EXPECT_EQ(target_words[1], producer[1]);
+  EXPECT_EQ(target_words[2], completion_wait[0]);
+  EXPECT_EQ(target_words[3], consumer[0]);
+  EXPECT_EQ(target_words[4], consumer[1]);
+  EXPECT_EQ(target_words[5], completion_wait[0]);
+  EXPECT_EQ(target_words[6], kGfx1250SEndpgm);
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250CompletionWaitCreditChecksOnlyVaVdst) {
+  struct Case {
+    const char *name;
+    uint16_t simm16;
+    bool expect_inserted_wait;
+  };
+  const std::array<Case, 2> cases = {{
+      {"nonzero VA_VDST", 0x1f9f, true},
+      {"zero VA_VDST with other waits", 0x0000, false},
+  }};
+  constexpr auto wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 32, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
+  constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+
+  for (const auto &c : cases) {
+    const auto source_wait = gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = c.simm16});
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+        {wmma[0], wmma[1], source_wait[0], kGfx1250SEndpgm});
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+
+    const auto result = translator.translate(source);
+    ASSERT_TRUE(result.ok()) << c.name << ": "
+                             << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    ASSERT_FALSE(translated.text_sections().empty()) << c.name;
+    ASSERT_GE(translated.text_sections()[0]->size(),
+              (c.expect_inserted_wait ? 5u : 4u) * sizeof(uint32_t))
+        << c.name;
+    const auto *target_words =
+        reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+    const size_t source_wait_index = c.expect_inserted_wait ? 3u : 2u;
+    if (c.expect_inserted_wait) {
+      EXPECT_EQ(target_words[2], completion_wait[0]) << c.name;
+    }
+    EXPECT_EQ(target_words[source_wait_index], source_wait[0]) << c.name;
+    EXPECT_EQ(target_words[source_wait_index + 1], kGfx1250SEndpgm) << c.name;
+
+    const auto second = translator.translate(translated);
+    ASSERT_TRUE(second.ok()) << c.name << ": "
+                             << (second.diagnostics.empty() ? ""
+                                                            : second.diagnostics.front().message);
+    EXPECT_EQ(second.elf_bytes, result.elf_bytes) << c.name;
+  }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250CreditsWaitAcrossCanonicalBankTransitionScaffolding) {
+  constexpr auto lower_bank_wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 32, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
+  constexpr auto wait_xcnt = gfx1250::build_sopp(gfx1250::kSWaitXcntSopp, {.simm16 = 0});
+  constexpr auto select_bank_one =
+      gfx1250::build_sopp(gfx1250::kSSetVgprMsbSopp, {.simm16 = 0x0055});
+  constexpr auto upper_bank_wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 96, .src0 = 256 + 8, .src1 = 256 + 16, .src2 = 256 + 24});
+  constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {lower_bank_wmma[0], lower_bank_wmma[1], wait_xcnt[0], select_bank_one[0], upper_bank_wmma[0],
+       upper_bank_wmma[1], completion_wait[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "s_wait_alu"; }),
+            1);
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250CreditsPhysicallyAdjacentWaitAcrossBasicBlockBoundary) {
+  // The conditional branch makes the wait a block leader while the physically
+  // preceding WMMA remains on the fallthrough path.
+  constexpr auto branch_to_wait = gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp, {.simm16 = 2});
+  constexpr auto wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x64Fp8Fp8Vop3p,
+                           {.vdst = 32, .src0 = 256 + 64, .src1 = 256 + 128, .src2 = 256 + 192});
+  constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {branch_to_wait[0], wmma[0], wmma[1], completion_wait[0], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "s_wait_alu"; }),
+            1);
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250CopiesA0CompatibleLowPrecisionSwmmac) {
@@ -11837,9 +12030,7 @@ TEST(BinaryTranslatorE2E, Gfx1250RegularWmmaScaleEncodesSrc2AndWaitsForCompletio
   const size_t target_word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
   ASSERT_EQ(target_word_count, 6u);
   constexpr uint32_t kScaleSrc2Mask = 0x1ffu << 18;
-  constexpr uint16_t kWaitVaVdstZero = 0x0f9f;
-  constexpr auto completion_wait =
-      gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = kWaitVaVdstZero});
+  constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
   EXPECT_EQ(target_words[0], source_scale[0]);
   EXPECT_EQ(target_words[1], (source_scale[1] & ~kScaleSrc2Mask) | (0x100u << 18));
   EXPECT_EQ(target_words[2], source_scale[2]);
@@ -11989,6 +12180,11 @@ TEST(BinaryTranslatorE2E, Gfx1250SplitsRegularScaleFp4AcrossMForA0) {
     EXPECT_EQ(replacement.clamp, 0u);
     EXPECT_EQ(replacement.neg, 4u);
   }
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250RegularScaleFp4RejectsEveryDestructiveUpperInputOverlap) {
@@ -12229,8 +12425,7 @@ TEST(BinaryTranslatorE2E, Gfx1250SplitsScale16Fp4AcrossMOnlyForA0) {
       gfx1250::kVWmmaF3232x16x128F4Vop3p,
       {.vdst = 96, .neg_hi = 4, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48, .neg = 4});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
-  constexpr auto completion_wait =
-      gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = 0x0f9f});
+  constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {scale16[0], scale16[1], matrix[0], matrix[1], kGfx1250SEndpgm});
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
@@ -12286,6 +12481,11 @@ TEST(BinaryTranslatorE2E, Gfx1250SplitsScale16Fp4AcrossMOnlyForA0) {
   EXPECT_EQ(word_count, 10u);
   EXPECT_EQ(words[8], completion_wait[0]);
   EXPECT_EQ(words[9], kGfx1250SEndpgm);
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250Scale16Fp4AcceptsScalarAndInlineScaleSources) {
@@ -12503,8 +12703,7 @@ TEST(BinaryTranslatorE2E, Gfx1250PreservesNativeM16Scale16ForA0) {
                                                                               .neg = 4});
   matrix[0] |= uint32_t{1} << 14;
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
-  constexpr auto completion_wait =
-      gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = 0x0f9f});
+  constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {scale16[0], scale16[1], matrix[0], matrix[1], kGfx1250SEndpgm});
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
@@ -12765,6 +12964,11 @@ TEST(BinaryTranslatorE2E, Gfx1250SplitsStandalone32x16Fp4IntoScaledHalvesForA0) 
     EXPECT_EQ(body.src1, 256u + kMatrixB) << "matrix B is shared by both halves";
     EXPECT_EQ(body.src2, 256u + kMatrixC + delta);
   }
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
 }
 
 // The upper half slices eight dwords off matrix A, so a base near the top of a
@@ -12816,6 +13020,11 @@ TEST(BinaryTranslatorE2E, Gfx1250Standalone32x16Fp4AdjustsUpperABank) {
   ASSERT_GE(modes.size(), 2u) << "the crossing must emit a transition and a restore";
   EXPECT_EQ(modes.front(), 0x01u) << "the upper half selects the next Src0 bank";
   EXPECT_EQ(modes.back(), 0x00u) << "the entry mode must be restored";
+
+  const auto second = translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
 }
 
 // Matrix A and B must be register ranges; the standalone form has no lowering
@@ -12913,6 +13122,7 @@ TEST(BinaryTranslatorE2E, Gfx1250Standalone32x16Fp4SplitMatchesUnsplitExecution)
                                                                 .src1 = 256 + kMatrixB,
                                                                 .src2 = 256 + kMatrixC});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {matrix[0], matrix[1], kGfx1250SEndpgm});
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
@@ -12948,7 +13158,10 @@ TEST(BinaryTranslatorE2E, Gfx1250Standalone32x16Fp4SplitMatchesUnsplitExecution)
     body_words.insert(body_words.end(), text_words + offset, text_words + offset + words);
     offset += words;
   }
-  ASSERT_EQ(body_words.size(), 8u) << "expected two four-word VOP3PX2 pairs";
+  ASSERT_EQ(body_words.size(), 9u)
+      << "expected two four-word VOP3PX2 pairs and one completion wait";
+  EXPECT_EQ(body_words.back(), completion_wait[0]);
+  body_words.pop_back();
 
   rocjitsu::amdgpu::GpuMemory gpu_mem("gfx1250_fp4_split_diff_mem");
   rocjitsu::amdgpu::L2Cache l2("gfx1250_fp4_split_diff_l2");


### PR DESCRIPTION
gfx1250 A0 completes dense low-precision WMMA operations at different rates than B0. When rocJITsu translates B0 code to A0, B0 scheduling—particularly under SCHED_MODE 2—can allow a following instruction to consume an FP8, BF8, F8F6F4, or FP4 WMMA destination before it is ready on A0.

This change inserts s_wait_alu with VA_VDST=0 for affected B0-to-A0 translations, covering both preserved instructions and semantic expansions. Dependency and VGPR-bank analysis prevents waits from being shared across dependent WMMAs while allowing one trailing wait to cover independent producers, including M=32 operations split into two M=16 halves. Existing valid waits are preserved, repeated translation is stable, and unaffected WMMA and SWMMAC forms remain unchanged.