### PR TITLE
clr: use system-scope dispatch acquire fence

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -2241,15 +2241,17 @@ VirtualGPU::VirtualGPU(Device& device, bool profiling, bool cooperative,
 
   if (device.settings().fenceScopeAgent_) {
     const auto& isa = device.isa();
-    const bool isGfx12 = (isa.versionMajor() == 12) && (isa.versionMinor() == 0) &&
-                         (isa.versionStepping() == 0 || isa.versionStepping() == 1);
+    const bool needsSystemScopeAcquire =
+        ((isa.versionMajor() == 12) && (isa.versionMinor() == 0) &&
+         (isa.versionStepping() == 0 || isa.versionStepping() == 1)) ||
+        (isa.versionMajor() >= 13);
 
     dispatchPacketHeaderNoSync_ =
         ((device.settings().ext_dispatch_packet_ ? vendorSpecificHBits : kernelDispatchHBits) |
-         (isGfx12 ? sysAcquireAgentReleaseHBits : agentScopeHBits));
+         (needsSystemScopeAcquire ? sysAcquireAgentReleaseHBits : agentScopeHBits));
     dispatchPacketHeader_ =
         ((device.settings().ext_dispatch_packet_ ? vendorSpecificHBits : kernelDispatchHBits) |
-         barrierHBits | (isGfx12 ? sysAcquireAgentReleaseHBits : agentScopeHBits));
+         barrierHBits | (needsSystemScopeAcquire ? sysAcquireAgentReleaseHBits : agentScopeHBits));
   } else {
     dispatchPacketHeaderNoSync_ =
         ((device.settings().ext_dispatch_packet_ ? vendorSpecificHBits : kernelDispatchHBits) |


### PR DESCRIPTION
On gfx1310 (ISA major 13), the agent-scope flush optimization (AMD_OPT_FLUSH=1 -> fenceScopeAgent_) selected an agent-scope acquire fence for kernel dispatch. An agent-scope acquire invalidates only I/K/L1, not L2. When a kernel writes a fine-grained/pinned host allocation and the host subsequently overwrites it, the next kernel reads stale L2 data left by the previous kernel, causing silent data corruption (e.g. EventTest
Unit_hipEventCreateWithFlags_DefaultFlg_{Coh,NonCoh}HstMem).

A system-scope acquire was only applied to gfx12. Extend it to (versionMajor() >= 13) so the dispatch acquire invalidates L2 against host/system writes.

Verified: baseline reproduces 100% corruption; with this change EventTest passes (31,457,283 assertions) and a standalone in-place-square reproducer is clean across all sizes/iterations.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
