### PR TITLE
[rocjitsu] Update gfx1250 simulator capabilities

### DIFF
--- a/emulation/rocjitsu/configs/gfx1250.json
+++ b/emulation/rocjitsu/configs/gfx1250.json
@@ -12,19 +12,20 @@
         "device_id": 1250,
         "family_id": 0,
         "unique_id": 1250,
-        "marketing_name": "gfx1250",
+        "marketing_name": "AMD Instinct MI455X",
         "simd_count": 1024,
-        "max_waves_per_simd": 20,
+        "max_waves_per_simd": 16,
         "num_shader_engines": 4,
         "num_shader_arrays_per_engine": 2,
-        "num_cu_per_sh": 4,
+        "num_cu_per_sh": 8,
         "simd_per_cu": 4,
         "wave_front_size": 32,
-        "local_mem_size": 309237645312,
-        "lds_size_kb": 160,
-        "mem_width": 8192,
+        "local_mem_size": 463856467968,
+        "lds_size_kb": 320,
+        "mem_width": 24576,
         "mem_clk_max": 1600,
-        "l2_size_kb": 4096,
+        "l1_size_kb": 64,
+        "l2_size_kb": 196608,
         "num_sdma_engines": 5,
         "num_sdma_xgmi_engines": 12,
         "num_cp_queues": 128,
@@ -39,7 +40,7 @@
         { "name": "vram", "type": "gpu_memory" },
         {
           "name": "iod[0:2]", "type": "iod",
-          "config": [{ "key": "num_hbm_stacks", "value": "4" }]
+          "config": [{ "key": "num_hbm_stacks", "value": "6" }]
         },
         {
           "name": "xcd[0:8]", "type": "xcd",
@@ -47,14 +48,14 @@
             { "name": "l2", "type": "l2_cache" },
             { "name": "cp", "type": "command_processor" },
             {
-              "name": "se[0:4]", "type": "shader_engine",
+              "name": "se[0:2]", "type": "shader_engine",
               "children": [{
-                "name": "cu[0:8]", "type": "compute_unit",
+                "name": "cu[0:16]", "type": "compute_unit",
                 "config": [
-                  { "key": "num_wf_slots", "value": "80" },
+                  { "key": "num_wf_slots", "value": "64" },
                   { "key": "sgprs_per_wf", "value": "128" },
                   { "key": "vgprs_per_wf", "value": "1024" },
-                  { "key": "lds_size_kb", "value": "160" }
+                  { "key": "lds_size_kb", "value": "320" }
                 ]
               }]
             }
@@ -64,20 +65,20 @@
     },
     "links": [
       {
-        "pattern": "xcd[i].cp.req_[j*8+k] -> xcd[i].se[j].cu[k].cpl",
+        "pattern": "xcd[i].cp.req_[j*16+k] -> xcd[i].se[j].cu[k].cpl",
         "for_ranges": [
           { "var_name": "i", "start": 0, "end": 8 },
-          { "var_name": "j", "start": 0, "end": 4 },
-          { "var_name": "k", "start": 0, "end": 8 }
+          { "var_name": "j", "start": 0, "end": 2 },
+          { "var_name": "k", "start": 0, "end": 16 }
         ],
         "latency": 1, "weight": 2
       },
       {
-        "pattern": "xcd[i].se[j].cu[k].req -> xcd[i].l2.cpl_[j*8+k]",
+        "pattern": "xcd[i].se[j].cu[k].req -> xcd[i].l2.cpl_[j*16+k]",
         "for_ranges": [
           { "var_name": "i", "start": 0, "end": 8 },
-          { "var_name": "j", "start": 0, "end": 4 },
-          { "var_name": "k", "start": 0, "end": 8 }
+          { "var_name": "j", "start": 0, "end": 2 },
+          { "var_name": "k", "start": 0, "end": 16 }
         ],
         "latency": 1, "weight": 10
       },
@@ -99,8 +100,8 @@
         "pattern": "xcd[i].se[j].cu[k].adj_req -> xcd[i].se[j].cu[k+1].adj_cpl",
         "for_ranges": [
           { "var_name": "i", "start": 0, "end": 8 },
-          { "var_name": "j", "start": 0, "end": 4 },
-          { "var_name": "k", "start": 0, "end": 7 }
+          { "var_name": "j", "start": 0, "end": 2 },
+          { "var_name": "k", "start": 0, "end": 15 }
         ],
         "latency": 1, "weight": 2
       },
@@ -108,8 +109,8 @@
         "pattern": "xcd[i].se[j].cu[k+1].adj_req_r -> xcd[i].se[j].cu[k].adj_cpl_r",
         "for_ranges": [
           { "var_name": "i", "start": 0, "end": 8 },
-          { "var_name": "j", "start": 0, "end": 4 },
-          { "var_name": "k", "start": 0, "end": 7 }
+          { "var_name": "j", "start": 0, "end": 2 },
+          { "var_name": "k", "start": 0, "end": 15 }
         ],
         "latency": 1, "weight": 2
       }

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -86,7 +86,7 @@ const std::string kGfx1250ConfigPath = std::string(CONFIG_DIR) + "/gfx1250.json"
 constexpr uint32_t S_ENDPGM_GFX12 = 0xBFB00000u;
 constexpr uint32_t S_WAIT_KMCNT_0_GFX12 = 0xBFC70000u;
 constexpr uint32_t S_SET_VGPR_MSB = 0xBF860000u;
-// LLVM references for these gfx1250 register capacities:
+// LLVM references for these gfx1250 register capabilities:
 // - llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp:
 //   getAddressableNumSGPRs() returns 106 ordinary SGPRs for GFX10+.
 // - llvm/lib/Target/AMDGPU/SIRegisterInfo.td:
@@ -99,15 +99,18 @@ constexpr uint32_t S_SET_VGPR_MSB = 0xBF860000u;
 //   high VGPRs still use the encoded v0-v255 operand window; s_set_vgpr_msb
 //   supplies two high address bits per operand role.
 // - llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp:
-//   GFX12.5 reports four SIMDs per CU, 20 waves per SIMD, and 160 KiB of
-//   addressable local memory.
+//   GFX12.5 reports four SIMD units per CU.
 constexpr uint32_t kGfx1250ScalarSlots = 128;
 constexpr uint32_t kGfx1250Wave32VgprAllocation = 1024;
 constexpr uint32_t kGfx1250VgprEncodingGranule = 16;
 constexpr uint32_t kGfx1250SimdsPerCu = 4;
-constexpr uint32_t kGfx1250MaxWavesPerSimd = 20;
+constexpr uint32_t kGfx1250MaxWavesPerSimd = 16;
 constexpr uint32_t kGfx1250WaveSlotsPerCu = kGfx1250SimdsPerCu * kGfx1250MaxWavesPerSimd;
-constexpr uint32_t kGfx1250LdsSizeKb = 160;
+constexpr uint32_t kGfx1250LdsSizeKb = 320;
+constexpr uint64_t kGfx1250HbmBytes = 432ull * 1024 * 1024 * 1024;
+constexpr uint32_t kGfx1250HbmWidthBits = 12 * 2048;
+constexpr uint32_t kGfx1250VectorCacheSizeKb = 64;
+constexpr uint32_t kGfx1250L2SizeKb = 192 * 1024;
 constexpr uint32_t kSdmaOpCopy = 1;
 constexpr uint32_t kSdmaOpFence = 5;
 constexpr uint32_t kSdmaOpPollRegmem = 8;
@@ -614,20 +617,33 @@ TEST(Gfx1250ConfigTest, ConfigLoadsTopology) {
 
   EXPECT_TRUE(loaded.device.present);
   EXPECT_EQ(loaded.device.gfx_target_version, 120500u);
+  EXPECT_EQ(loaded.device.marketing_name, "AMD Instinct MI455X");
   EXPECT_EQ(loaded.device.simd_count, 1024u);
   EXPECT_EQ(loaded.device.max_waves_per_simd, kGfx1250MaxWavesPerSimd);
+  EXPECT_EQ(loaded.device.num_shader_engines, 4u);
   EXPECT_EQ(loaded.device.num_shader_arrays_per_engine, 2u);
-  EXPECT_EQ(loaded.device.num_cu_per_sh, 4u);
+  EXPECT_EQ(loaded.device.num_cu_per_sh, 8u);
   EXPECT_EQ(loaded.device.simd_per_cu, kGfx1250SimdsPerCu);
   EXPECT_EQ(loaded.device.wave_front_size, 32u);
+  EXPECT_EQ(loaded.device.local_mem_size, kGfx1250HbmBytes);
   EXPECT_EQ(loaded.device.lds_size_kb, kGfx1250LdsSizeKb);
-  EXPECT_EQ(loaded.device.mem_width, 8192u);
-  EXPECT_EQ(loaded.device.marketing_name, "gfx1250");
+  EXPECT_EQ(loaded.device.mem_width, kGfx1250HbmWidthBits);
+  EXPECT_EQ(loaded.device.l1_size_kb, kGfx1250VectorCacheSizeKb);
+  EXPECT_EQ(loaded.device.l2_size_kb, kGfx1250L2SizeKb);
 
   EXPECT_EQ(soc->num_xcds(), 8u);
   EXPECT_EQ(soc->num_iods(), 2u);
-  EXPECT_EQ(soc->xcd(0)->num_shader_engines(), 4u);
-  EXPECT_EQ(soc->xcd(0)->shader_engine(0)->num_compute_units(), 8u);
+  EXPECT_EQ(soc->iod(0)->req_ports().size(), 6u);
+  EXPECT_EQ(soc->iod(1)->req_ports().size(), 6u);
+  EXPECT_EQ(soc->xcd(0)->num_shader_engines(), 2u);
+  EXPECT_EQ(soc->xcd(0)->shader_engine(0)->num_compute_units(), 16u);
+  EXPECT_EQ(loaded.device.num_shader_engines / loaded.device.num_shader_arrays_per_engine,
+            soc->xcd(0)->num_shader_engines());
+  EXPECT_EQ(loaded.device.num_shader_arrays_per_engine * loaded.device.num_cu_per_sh,
+            soc->xcd(0)->shader_engine(0)->num_compute_units());
+  EXPECT_EQ(soc->num_xcds() * soc->xcd(0)->num_shader_engines() *
+                soc->xcd(0)->shader_engine(0)->num_compute_units() * loaded.device.simd_per_cu,
+            loaded.device.simd_count);
   auto *cu = soc->xcd(0)->shader_engine(0)->compute_unit(0);
   ASSERT_NE(cu, nullptr);
   EXPECT_EQ(cu->wf_size(), 32u);


### PR DESCRIPTION
## Motivation

The gfx1250 simulator configuration retained placeholder geometry and device properties inherited from earlier targets.

## Technical Details

- Update gfx1250 register, compute, memory, cache, and package topology capabilities.
- Source every hardware constant updated by this change from the AMD CDNA 5 Architecture white paper: https://www.amd.com/content/dam/amd/en/documents/products/technologies/cdna/amd-cdna5-whitepaper.pdf
- Validate the device properties against the instantiated topology.

## Issue Tracking

N/A

## Test Plan

Build RocJITsu and run focused gfx1250 and configuration tests.

## Test Result

- The gfx1250 tests passed 192/192.
- The configuration tests passed 48/48.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.