### PR TITLE
fix(clr): Calculate LDS correctly in hip occupancy for gfx11 in WGP mode

### DIFF
--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -580,8 +580,10 @@ hipError_t ihipGetDeviceProperties(hipDeviceProp_tR0600* props, int device) {
   ::strncpy(deviceProps.name, info.boardName_, sizeof(info.boardName_));
   memcpy(deviceProps.uuid.bytes, info.uuid_, sizeof(info.uuid_));
   deviceProps.totalGlobalMem = info.globalMemSize_;
+  const size_t ldsPerMultiprocessor = static_cast<size_t>(info.localMemSizePerCU_) *
+      (deviceHandle->settings().enableWgpMode_ ? 2 : 1);
   deviceProps.sharedMemPerBlock = info.localMemSizePerCU_;
-  deviceProps.sharedMemPerMultiprocessor = info.localMemSizePerCU_;
+  deviceProps.sharedMemPerMultiprocessor = ldsPerMultiprocessor;
   deviceProps.regsPerBlock = info.availableRegistersPerCU_;
   deviceProps.warpSize = info.wavefrontWidth_;
   deviceProps.maxThreadsPerBlock = info.maxWorkGroupSize_;
@@ -625,7 +627,7 @@ hipError_t ihipGetDeviceProperties(hipDeviceProp_tR0600* props, int device) {
   deviceProps.pciDomainID = info.pciDomainID;
   deviceProps.pciBusID = info.deviceTopology_.pcie.bus;
   deviceProps.pciDeviceID = info.deviceTopology_.pcie.device;
-  deviceProps.maxSharedMemoryPerMultiProcessor = info.localMemSizePerCU_;
+  deviceProps.maxSharedMemoryPerMultiProcessor = ldsPerMultiprocessor;
   deviceProps.canMapHostMemory = 1;
   deviceProps.regsPerMultiprocessor = info.availableRegistersPerCU_;
   snprintf(deviceProps.gcnArchName, sizeof(deviceProps.gcnArchName), "%s", isa.targetId());
@@ -785,6 +787,8 @@ hipError_t hipGetDevicePropertiesR0000(hipDeviceProp_tR0000* prop, int device) {
   const auto& isa = deviceHandle->isa();
   ::strncpy(deviceProps.name, info.boardName_, sizeof(deviceProps.name));
   deviceProps.totalGlobalMem = info.globalMemSize_;
+  const size_t ldsPerMultiprocessor = static_cast<size_t>(info.localMemSizePerCU_) *
+      (deviceHandle->settings().enableWgpMode_ ? 2 : 1);
   deviceProps.sharedMemPerBlock = info.localMemSizePerCU_;
   deviceProps.regsPerBlock = info.availableRegistersPerCU_;
   deviceProps.warpSize = info.wavefrontWidth_;
@@ -827,7 +831,7 @@ hipError_t hipGetDevicePropertiesR0000(hipDeviceProp_tR0000* prop, int device) {
   deviceProps.pciDomainID = info.pciDomainID;
   deviceProps.pciBusID = info.deviceTopology_.pcie.bus;
   deviceProps.pciDeviceID = info.deviceTopology_.pcie.device;
-  deviceProps.maxSharedMemoryPerMultiProcessor = info.localMemSizePerCU_;
+  deviceProps.maxSharedMemoryPerMultiProcessor = ldsPerMultiprocessor;
   deviceProps.canMapHostMemory = 1;
   // FIXME: This should be removed, targets can have character names as well.
   deviceProps.gcnArch = isa.versionMajor() * 100 + isa.versionMinor() * 10 + isa.versionStepping();

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -78,10 +78,23 @@ hipError_t ihipOccupancyMaxActiveBlocksPerMultiprocessor(
   const size_t alu_occupancy = simdPerCU * std::min(MaxWavesPerSimd, GprWaves);
   const int alu_limited_threads = static_cast<int>(alu_occupancy * wavefrontSize);
 
-  const size_t total_used_lds = wrkGrpInfo->usedLDSSize_ + dynamicSMemSize;
+  // The LDS limit must be expressed in the same unit as the ALU limit computed
+  // above. In WGP mode a workgroup allocates out of the LDS pool of the whole
+  // WGP (2 CUs), so the per-CU pool has to be doubled to match. Kernels
+  // compiled with -mcumode report isWGPMode_ == false and keep the per-CU pool.
+  const uint64_t lds_pool_size = wrkGrpInfo->isWGPMode_
+      ? static_cast<uint64_t>(device.info().localMemSize_) * 2
+      : static_cast<uint64_t>(device.info().localMemSize_);
+
+  // HW allocates LDS in fixed size alignment, so a workgroup is accounted for
+  // aligned size rather than for the exact number of bytes requested.
+  const uint32_t lds_granularity = device.isa().ldsAlignment();
+  const size_t requested_lds = wrkGrpInfo->usedLDSSize_ + dynamicSMemSize;
+  const size_t total_used_lds = lds_granularity != 0
+      ? amd::alignUp(requested_lds, lds_granularity) : requested_lds;
+
   const int lds_occupancy_wgs = total_used_lds != 0
-      ? static_cast<int>(device.info().localMemSize_ / total_used_lds)
-      : INT_MAX;
+      ? static_cast<int>(lds_pool_size / total_used_lds) : INT_MAX;
   // Calculate how many blocks of inputBlockSize we can fit per CU
   // Need to align with hardware wavefront size. If they want 65 threads, but
   // waves are 64, then we need 128 threads per block.

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -82,16 +82,16 @@ hipError_t ihipOccupancyMaxActiveBlocksPerMultiprocessor(
   // above. In WGP mode a workgroup allocates out of the LDS pool of the whole
   // WGP (2 CUs), so the per-CU pool has to be doubled to match. Kernels
   // compiled with -mcumode report isWGPMode_ == false and keep the per-CU pool.
-  const uint64_t lds_pool_size = wrkGrpInfo->isWGPMode_
-      ? static_cast<uint64_t>(device.info().localMemSize_) * 2
-      : static_cast<uint64_t>(device.info().localMemSize_);
+  const uint64_t lds_pool_size = static_cast<uint64_t>(device.info().localMemSizePerCU_) *
+      (wrkGrpInfo->isWGPMode_ ? 2 : 1);
 
   // HW allocates LDS in fixed size alignment, so a workgroup is accounted for
-  // aligned size rather than for the exact number of bytes requested.
-  const uint32_t lds_granularity = device.isa().ldsAlignment();
+  // the aligned size rather than for the exact number of bytes requested.
+  const size_t lds_granularity = device.isa().ldsAlignment();
   const size_t requested_lds = wrkGrpInfo->usedLDSSize_ + dynamicSMemSize;
   const size_t total_used_lds = lds_granularity != 0
-      ? amd::alignUp(requested_lds, lds_granularity) : requested_lds;
+      ? ((requested_lds + lds_granularity - 1) / lds_granularity) * lds_granularity
+      : requested_lds;
 
   const int lds_occupancy_wgs = total_used_lds != 0
       ? static_cast<int>(lds_pool_size / total_used_lds) : INT_MAX;
@@ -103,6 +103,13 @@ hipError_t ihipOccupancyMaxActiveBlocksPerMultiprocessor(
   *maxBlocksPerCU = alu_limited_threads / aligned_input_size;
   // Unless those blocks are further constrained by LDS size.
   *maxBlocksPerCU = std::min(*maxBlocksPerCU, lds_occupancy_wgs);
+
+  // The count above is per scheduling unit of the kernel: a WGP for a WGP mode
+  // kernel, a single CU for a kernel compiled with -mcumode.
+  if (wrkGrpInfo->isWGPMode_ != device.settings().enableWgpMode_) {
+    *maxBlocksPerCU = wrkGrpInfo->isWGPMode_
+        ? (*maxBlocksPerCU / 2) : (*maxBlocksPerCU * 2);
+  }
 
   // Return optimal block size: min of ALU limit and requested size
   *bestBlockSize = std::min(alu_limited_threads, aligned_input_size);

--- a/projects/hip-tests/catch/config/configs/unit/occupancy.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/occupancy.yaml
@@ -63,3 +63,13 @@ occupancy:
   Unit_hipOccupancyMaxPotentialClusterSize_Negative_Parameters: *level_2
   Unit_hipOccupancyMaxPotentialClusterSize_Positive_RangeValidation: *level_2
   Unit_hipOccupancyMaxPotentialClusterSize_Verify_Launch: *level_2
+  Unit_hipOccupancy_Positive_SharedMemPerMultiprocessorConsistency:
+    <<: *level_2
+    # WGP/CU LDS reporting is AMD specific; not built for the NVIDIA platform
+    disabled: [nvidia]
+  Unit_hipOccupancy_Positive_OccupancyMatchesSharedMemPerMultiprocessor:
+    <<: *level_2
+    disabled: [nvidia]
+  Unit_hipOccupancy_Positive_ZeroLdsMatchesThreadLimit:
+    <<: *level_2
+    disabled: [nvidia]

--- a/projects/hip-tests/catch/unit/occupancy/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/occupancy/CMakeLists.txt
@@ -37,6 +37,12 @@ if(HIP_PLATFORM MATCHES "amd")
     CheckRejectedArchs($ENV{HCC_AMDGPU_TARGET})
   endif()
 
+  # The WGP/CU reporting is AMD specific.
+  set(TEST_SRC
+    ${TEST_SRC}
+    hipOccupancyLdsPerMultiprocessor.cc
+    )
+
   if(CLUSTERS_SUPPORTED EQUAL 1)
     message(STATUS "Adding clusters tests")
     set(TEST_SRC

--- a/projects/hip-tests/catch/unit/occupancy/hipOccupancyLdsPerMultiprocessor.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipOccupancyLdsPerMultiprocessor.cc
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+Testcase Scenarios :
+Unit_hipOccupancy_Positive_SharedMemPerMultiprocessorConsistency - Validate that the shared memory
+fields of hipDeviceProp_t agree with each other. On targets with a WGP (2 CUs sharing one LDS pool)
+the per multiprocessor pool is larger than the per block limit, and both per multiprocessor fields
+have to report that same pool.
+Unit_hipOccupancy_Positive_OccupancyMatchesSharedMemPerMultiprocessor - Validate that the occupancy
+reported by hipOccupancyMaxActiveBlocksPerMultiprocessor never claims more LDS than
+sharedMemPerMultiprocessor advertises, i.e. that the API and the device properties describe the
+same pool in the same unit.
+Unit_hipOccupancy_Positive_ZeroLdsMatchesThreadLimit - Validate that a kernel which uses no LDS is
+limited only by maxThreadsPerMultiProcessor, i.e. that the occupancy is reported per the same
+multiprocessor that multiProcessorCount counts.
+
+Note: the LDS allocation granularity is not exposed through hipDeviceProp_t, so these tests avoid
+depending on it. They verify that the occupancy API and the device properties stay consistent with
+each other, which no single field can be checked against on its own. Verifying that the pool is
+physically correct requires measuring co-residency on the device.
+*/
+
+#include "occupancy_common.hh"
+
+#include <climits>
+#include <limits>
+
+static __global__ void dynLdsKernel(unsigned int* out) {
+  extern __shared__ unsigned int smem[];
+  if (threadIdx.x == UINT_MAX) {  // never taken; keeps smem live
+    out[0] = smem[0];
+  }
+}
+
+HIP_TEST_CASE(Unit_hipOccupancy_Positive_SharedMemPerMultiprocessorConsistency) {
+  hipDeviceProp_t devProp;
+  HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
+
+  REQUIRE(devProp.sharedMemPerBlock > 0);
+  REQUIRE(devProp.sharedMemPerMultiprocessor > 0);
+
+  // A multiprocessor holds at least one maximally sized block, and its pool is a whole number of
+  // per block limits (1x in CU mode, 2x when a WGP of 2 CUs is the multiprocessor).
+  REQUIRE(devProp.sharedMemPerMultiprocessor >= devProp.sharedMemPerBlock);
+  REQUIRE((devProp.sharedMemPerMultiprocessor % devProp.sharedMemPerBlock) == 0);
+
+  // Both per multiprocessor fields describe the same pool and are filled in by separate code
+  // paths, so they must not drift apart.
+  REQUIRE(devProp.maxSharedMemoryPerMultiProcessor == devProp.sharedMemPerMultiprocessor);
+
+}
+
+HIP_TEST_CASE(Unit_hipOccupancy_Positive_OccupancyMatchesSharedMemPerMultiprocessor) {
+  hipDeviceProp_t devProp;
+  HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
+
+  const int blockSize = devProp.warpSize * 2;
+  REQUIRE(blockSize <= devProp.maxThreadsPerBlock);
+
+  int prevNumBlocks = std::numeric_limits<int>::max();
+  size_t prevLds = 0;
+
+  // Sizing the request as a fraction of the advertised pool keeps this independent of the LDS
+  // allocation granularity: rounding up can only ever reduce the block count, never raise it.
+  // The fractions are walked from smallest to largest request so that the monotonicity check
+  // below sees a strictly growing LDS size.
+  for (const int fraction : {16, 8, 4, 3, 2}) {
+    const size_t dynLds = devProp.sharedMemPerMultiprocessor / fraction;
+    if (dynLds == 0 || dynLds > devProp.sharedMemPerBlock) {
+      continue;  // a single block cannot allocate more than the per block limit
+    }
+
+    int numBlocks = 0;
+    HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &numBlocks, reinterpret_cast<const void*>(dynLdsKernel), blockSize, dynLds));
+
+    INFO("dynLds = " << dynLds << ", numBlocks = " << numBlocks);
+    REQUIRE(numBlocks >= 1);
+
+    // The blocks reported as co-resident must fit in the advertised pool. This fails if the
+    // occupancy calculation and the reported property disagree about the size of a
+    // multiprocessor's LDS.
+    REQUIRE(static_cast<size_t>(numBlocks) * dynLds <= devProp.sharedMemPerMultiprocessor);
+
+    // And they must still fit in the thread budget of the same multiprocessor.
+    REQUIRE((numBlocks * blockSize) <= devProp.maxThreadsPerMultiProcessor);
+
+    // Occupancy cannot rise as a block asks for more LDS.
+    if (prevLds != 0 && dynLds > prevLds) {
+      REQUIRE(numBlocks <= prevNumBlocks);
+    }
+    prevNumBlocks = numBlocks;
+    prevLds = dynLds;
+  }
+}
+
+HIP_TEST_CASE(Unit_hipOccupancy_Positive_ZeroLdsMatchesThreadLimit) {
+  hipDeviceProp_t devProp;
+  HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
+
+  const int blockSize = devProp.warpSize * 2;
+  REQUIRE(blockSize <= devProp.maxThreadsPerBlock);
+
+  if ((devProp.maxThreadsPerMultiProcessor % blockSize) != 0) {
+    WARN("maxThreadsPerMultiProcessor is not a multiple of the block size; skipping");
+    return;
+  }
+
+  int numBlocks = 0;
+  HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+      &numBlocks, reinterpret_cast<const void*>(dynLdsKernel), blockSize, 0));
+
+  // With no LDS in play the only limit left is the thread budget, so the two have to agree. They
+  // are only comparable if both are expressed per the same multiprocessor, which is what this
+  // checks: a kernel scheduled on a smaller unit than multiProcessorCount counts would report
+  // proportionally fewer blocks here.
+  INFO("blockSize = " << blockSize << ", numBlocks = " << numBlocks);
+  REQUIRE((numBlocks * blockSize) == devProp.maxThreadsPerMultiProcessor);
+}


### PR DESCRIPTION
## Motivation

To report the appropriate shared Memory or LDS on gfx11 archs (Navi3x and Strix Halo) and maxBlocksPerCU in cumode that are currently being reported incorrectly by hip occupancy API.

## Technical Details

Few variables like alu occupancy are calculated for WorkGroup (WG contains 2 CUs) whereas others like sharedMemPerMultiprocessor are calculated per CU causing mismatch in the LDS calculations.  Fix these to be uniform per WGP so that LDS or shared memory is reported correctly thereby maximizing the occupancy for various kernels.

## Issue Tracking

JIRA ID :  ROCM-28582

## Test Plan

The reproducer should report correct LDS

## Test Result

PASS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.


[ROCM-28582]: https://amd-hub.atlassian.net/browse/ROCM-28582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ