### PR TITLE
fix(rocjitsu): make plugin sink lifetime explicit

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <span>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -50,8 +51,13 @@ using OwnedPlugin = std::unique_ptr<ExecutionPlugin, PluginDeleter>;
 /// @brief Host destroy trampoline for in-tree plugins created with `new`.
 inline void delete_execution_plugin(void *p) { delete static_cast<ExecutionPlugin *>(p); }
 
-/// @brief Complete sink configuration transferred into an ExecutionPluginGroup.
+/// @brief Move-only sink configuration transferred into an ExecutionPluginGroup.
 struct PluginSinkConfig {
+  /// Add an owned sink and return a reference to it.
+  ///
+  /// The reference remains valid while this configuration, or the
+  /// ExecutionPluginGroup that receives it, owns the sink. Moving the
+  /// configuration transfers ownership without moving the sink itself.
   template <typename Sink, typename... Args> Sink &emplace(Args &&...args) {
     static_assert(std::is_base_of_v<PluginSink, Sink>, "Sink must derive from PluginSink");
     auto sink = std::make_unique<Sink>(std::forward<Args>(args)...);
@@ -60,6 +66,7 @@ struct PluginSinkConfig {
     return result;
   }
 
+  /// Enable one per-plugin FileSink rooted at @p directory.
   void set_file_directory(std::string directory) { file_directory_ = std::move(directory); }
 
 private:
@@ -208,7 +215,7 @@ public:
     return *instance;
   }
 
-protected:
+private:
   /// Internal fanout over sinks whose lifetime is guaranteed by the owning
   /// group or SinkBundle. It is deliberately not part of the public sink API.
   class FanoutSink final : public PluginSink {
@@ -226,18 +233,24 @@ protected:
     std::vector<PluginSink *> children_;
   };
 
+protected:
   /// Owns one fanout sink and any per-fanout child sinks. Member order ensures
   /// the fanout is destroyed before the children it references.
-  struct SinkBundle {
-    std::vector<std::unique_ptr<PluginSink>> children;
-    std::unique_ptr<FanoutSink> fanout;
+  class SinkBundle {
+  public:
+    SinkBundle() = default;
 
-    PluginSink *get() const { return fanout.get(); }
+    [[nodiscard]] PluginSink *get() const { return fanout_.get(); }
+
+  private:
+    friend class ExecutionPluginGroup;
+    std::vector<std::unique_ptr<PluginSink>> children_;
+    std::unique_ptr<FanoutSink> fanout_;
   };
 
   /// Build a sink combining configured sinks + optional file sink.
   /// Returns an empty bundle if no sinks are configured.
-  SinkBundle build_sink_bundle(const std::string &file_name) {
+  [[nodiscard]] SinkBundle build_sink_bundle(const std::string &file_name) const {
     bool has_file = !sink_dir_.empty() && !file_name.empty();
     if (configured_sinks_.empty() && !has_file)
       return {};
@@ -250,24 +263,26 @@ protected:
       auto fs = std::make_unique<FileSink>(sink_dir_ + "/" + file_name);
       if (fs->is_open()) {
         fanout->add(*fs);
-        result.children.push_back(std::move(fs));
+        result.children_.push_back(std::move(fs));
       } else if (fanout->empty()) {
         // Preserve output when the file was the only requested destination.
         // Do not add stderr when another configured sink is already usable,
         // because doing so would unexpectedly duplicate output.
         auto fallback = std::make_unique<StderrSink>();
         fanout->add(*fallback);
-        result.children.push_back(std::move(fallback));
+        result.children_.push_back(std::move(fallback));
       }
     }
-    result.fanout = std::move(fanout);
+    result.fanout_ = std::move(fanout);
     return result;
   }
 
+private:
+  // These sinks are declared before plugin entries so plugins and their local
+  // fanouts are destroyed before the configured sinks they reference.
   std::vector<std::unique_ptr<PluginSink>> configured_sinks_;
   std::string sink_dir_;
 
-private:
   /// Owns the sink assigned to one plugin. The plugin is declared last and is
   /// therefore destroyed before its sink bundle.
   struct PluginEntry {
@@ -275,8 +290,6 @@ private:
     OwnedPlugin plugin;
   };
 
-  // Entries are declared after configured sinks, so plugins and their local
-  // fanouts are destroyed before the configured sinks they reference.
   std::vector<PluginEntry> plugins_;
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
@@ -6,12 +6,12 @@
 ///
 /// ## Sink configuration
 ///
-/// The group controls where plugin output goes. Call add_sink() to add
-/// external sinks (applied to all plugins). Call set_sink_dir() before
-/// adding plugins to enable per-plugin file sinks at <dir>/<name>.log.
+/// The group receives its complete, owned sink configuration at construction.
+/// Sink destinations cannot be added after plugins have received their output
+/// sink, so construction order and lifetime are explicit in the type.
 ///
-/// When a plugin is added via add(), the group constructs a CompositeSink
-/// combining all external sinks + an optional per-plugin FileSink, and
+/// When a plugin is added via add(), the group constructs an internal fanout sink
+/// combining all configured sinks + an optional per-plugin FileSink, and
 /// assigns it to the plugin.
 
 #pragma once
@@ -23,6 +23,8 @@
 #include <memory>
 #include <span>
 #include <string>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace rocjitsu {
@@ -48,32 +50,43 @@ using OwnedPlugin = std::unique_ptr<ExecutionPlugin, PluginDeleter>;
 /// @brief Host destroy trampoline for in-tree plugins created with `new`.
 inline void delete_execution_plugin(void *p) { delete static_cast<ExecutionPlugin *>(p); }
 
-class ExecutionPluginGroup {
-public:
-  ExecutionPluginGroup() = default;
-  virtual ~ExecutionPluginGroup() = default;
-
-  /// Add an external sink that receives output from all plugins.
-  /// The caller retains ownership (e.g., a static singleton or test fixture).
-  void add_sink(PluginSink *s) {
-    if (s)
-      external_sinks_.push_back(s);
+/// @brief Complete sink configuration transferred into an ExecutionPluginGroup.
+struct PluginSinkConfig {
+  template <typename Sink, typename... Args> Sink &emplace(Args &&...args) {
+    static_assert(std::is_base_of_v<PluginSink, Sink>, "Sink must derive from PluginSink");
+    auto sink = std::make_unique<Sink>(std::forward<Args>(args)...);
+    Sink &result = *sink;
+    sinks_.push_back(std::move(sink));
+    return result;
   }
 
-  /// Set directory for per-plugin file sinks. Each plugin added after
-  /// this call gets a FileSink at <dir>/<plugin_name>.log.
-  void set_sink_dir(const std::string &dir) { sink_dir_ = dir; }
+  void set_file_directory(std::string directory) { file_directory_ = std::move(directory); }
+
+private:
+  friend class ExecutionPluginGroup;
+  std::vector<std::unique_ptr<PluginSink>> sinks_;
+  std::string file_directory_;
+};
+
+class ExecutionPluginGroup {
+public:
+  explicit ExecutionPluginGroup(PluginSinkConfig config)
+      : configured_sinks_(std::move(config.sinks_)), sink_dir_(std::move(config.file_directory_)) {}
+
+  virtual ~ExecutionPluginGroup() = default;
 
   /// Add a plugin owned with a boundary-aware deleter (see OwnedPlugin).
   bool add(OwnedPlugin p) {
     if (!p)
       return false;
     for (const auto &existing : plugins_)
-      if (existing->name() == p->name())
+      if (existing.plugin->name() == p->name())
         return false;
     p->slot_index_ = static_cast<uint32_t>(plugins_.size());
-    build_sink_for(*p);
-    plugins_.push_back(std::move(p));
+    SinkBundle sink = build_sink_bundle(p->name() + ".log");
+    if (auto *configured_sink = sink.get())
+      p->sink_ = configured_sink;
+    plugins_.push_back(PluginEntry{std::move(sink), std::move(p)});
     return true;
   }
 
@@ -87,93 +100,93 @@ public:
 
   // -- Lifecycle --
   virtual void onInit() {
-    for (auto &p : plugins_)
-      p->onInit();
+    for (auto &entry : plugins_)
+      entry.plugin->onInit();
   }
 
   virtual void onShutdown() {
-    for (auto &p : plugins_)
-      p->onShutdown();
+    for (auto &entry : plugins_)
+      entry.plugin->onShutdown();
   }
 
   // -- AMDGPU (virtual) --
   virtual void onAmdgpuBeforeExecuteInstruction(uint64_t pc, const Instruction &inst,
                                                 amdgpu::Wavefront &wf) {
-    for (auto &p : plugins_)
-      p->onAmdgpuBeforeExecuteInstruction(pc, inst, wf);
+    for (auto &entry : plugins_)
+      entry.plugin->onAmdgpuBeforeExecuteInstruction(pc, inst, wf);
   }
 
   virtual void onAmdgpuAfterExecuteInstruction(uint64_t pc, const Instruction &inst,
                                                amdgpu::Wavefront &wf) {
-    for (auto &p : plugins_)
-      p->onAmdgpuAfterExecuteInstruction(pc, inst, wf);
+    for (auto &entry : plugins_)
+      entry.plugin->onAmdgpuAfterExecuteInstruction(pc, inst, wf);
   }
 
   virtual void onAmdgpuRouteMemoryInstruction(const Instruction &inst, amdgpu::Wavefront &wf) {
-    for (auto &p : plugins_)
-      p->onAmdgpuRouteMemoryInstruction(inst, wf);
+    for (auto &entry : plugins_)
+      entry.plugin->onAmdgpuRouteMemoryInstruction(inst, wf);
   }
 
   virtual void onAmdgpuDispatchPacketProcessed(const KernelDispatchInfo &info) {
-    for (auto &p : plugins_)
-      p->onAmdgpuDispatchPacketProcessed(info);
+    for (auto &entry : plugins_)
+      entry.plugin->onAmdgpuDispatchPacketProcessed(info);
   }
 
   virtual void onAmdgpuDispatchExecutionBegin(uint32_t dispatch_id) {
-    for (auto &p : plugins_)
-      p->onAmdgpuDispatchExecutionBegin(dispatch_id);
+    for (auto &entry : plugins_)
+      entry.plugin->onAmdgpuDispatchExecutionBegin(dispatch_id);
   }
 
   virtual void onAmdgpuDispatchExecutionEnd(uint32_t dispatch_id) {
-    for (auto &p : plugins_)
-      p->onAmdgpuDispatchExecutionEnd(dispatch_id);
+    for (auto &entry : plugins_)
+      entry.plugin->onAmdgpuDispatchExecutionEnd(dispatch_id);
   }
 
   virtual void onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id,
                                            uint32_t physical_vgpr_count, uint32_t sgpr_count,
                                            std::span<amdgpu::Wavefront *> wavefronts) {
-    for (auto &p : plugins_)
-      p->onAmdgpuWorkgroupDispatched(dispatch_id, wg_id, physical_vgpr_count, sgpr_count,
-                                     wavefronts);
+    for (auto &entry : plugins_)
+      entry.plugin->onAmdgpuWorkgroupDispatched(dispatch_id, wg_id, physical_vgpr_count, sgpr_count,
+                                                wavefronts);
   }
 
   virtual void onAmdgpuWorkgroupCompleted(uint32_t dispatch_id, uint32_t wg_id) {
-    for (auto &p : plugins_)
-      p->onAmdgpuWorkgroupCompleted(dispatch_id, wg_id);
+    for (auto &entry : plugins_)
+      entry.plugin->onAmdgpuWorkgroupCompleted(dispatch_id, wg_id);
   }
 
   virtual void onAmdgpuWavefrontDispatched(amdgpu::Wavefront &wf) {
-    for (auto &p : plugins_)
-      p->onAmdgpuWavefrontDispatched(wf);
+    for (auto &entry : plugins_)
+      entry.plugin->onAmdgpuWavefrontDispatched(wf);
   }
 
   virtual void onAmdgpuWavefrontHalted(amdgpu::Wavefront &wf) {
-    for (auto &p : plugins_)
-      p->onAmdgpuWavefrontHalted(wf);
+    for (auto &entry : plugins_)
+      entry.plugin->onAmdgpuWavefrontHalted(wf);
   }
 
   virtual void onAmdgpuReadVgprLanes(const amdgpu::Wavefront *wf, uint32_t physical_reg,
                                      uint64_t lane_mask,
                                      uint8_t byte_mask = ExecutionPlugin::kFullByteMask) {
-    for (auto &p : plugins_)
-      p->onAmdgpuReadVgprLanes(wf, physical_reg, lane_mask, byte_mask);
+    for (auto &entry : plugins_)
+      entry.plugin->onAmdgpuReadVgprLanes(wf, physical_reg, lane_mask, byte_mask);
   }
 
   virtual void onAmdgpuWriteVgprLanes(const amdgpu::Wavefront *wf, uint32_t physical_reg,
                                       uint64_t lane_mask,
                                       uint8_t byte_mask = ExecutionPlugin::kFullByteMask) {
-    for (auto &p : plugins_)
-      p->onAmdgpuWriteVgprLanes(wf, physical_reg, lane_mask, byte_mask);
+    for (auto &entry : plugins_)
+      entry.plugin->onAmdgpuWriteVgprLanes(wf, physical_reg, lane_mask, byte_mask);
   }
 
   virtual void onAmdgpuReadSgpr(const amdgpu::Wavefront *wf, uint32_t physical_reg) {
-    for (auto &p : plugins_)
-      p->onAmdgpuReadSgpr(wf, physical_reg);
+    for (auto &entry : plugins_)
+      entry.plugin->onAmdgpuReadSgpr(wf, physical_reg);
   }
 
   virtual void onAmdgpuBarrierResolved(std::span<amdgpu::Wavefront *> wavefronts) {
-    for (auto &p : plugins_)
-      p->onAmdgpuBarrierResolved(wavefronts);
+    for (auto &entry : plugins_)
+      entry.plugin->onAmdgpuBarrierResolved(wavefronts);
   }
 
   static std::shared_ptr<ExecutionPluginGroup> empty_group() {
@@ -190,51 +203,81 @@ public:
     // memory at process death. Matches the interposer singleton's never-destructed
     // design for the same reason.
     static std::shared_ptr<ExecutionPluginGroup> *instance =
-        new std::shared_ptr<ExecutionPluginGroup>(std::make_shared<ExecutionPluginGroup>());
+        new std::shared_ptr<ExecutionPluginGroup>(
+            std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{}));
     return *instance;
   }
 
 protected:
-  /// Build a sink combining external sinks + optional file sink.
-  /// Returns nullptr if no sinks are configured (caller should keep default).
-  PluginSink *build_composite_sink(const std::string &file_name = {}) {
-    bool has_file = !sink_dir_.empty() && !file_name.empty();
-    if (external_sinks_.empty() && !has_file)
-      return nullptr;
-    if (external_sinks_.size() == 1 && !has_file)
-      return external_sinks_[0];
+  /// Internal fanout over sinks whose lifetime is guaranteed by the owning
+  /// group or SinkBundle. It is deliberately not part of the public sink API.
+  class FanoutSink final : public PluginSink {
+  public:
+    void add(PluginSink &sink) { children_.push_back(&sink); }
 
-    auto composite = std::make_unique<CompositeSink>();
-    for (auto *s : external_sinks_)
-      composite->add(s);
+    void write(std::string_view msg) override {
+      for (auto *sink : children_)
+        sink->write(msg);
+    }
+
+    bool empty() const { return children_.empty(); }
+
+  private:
+    std::vector<PluginSink *> children_;
+  };
+
+  /// Owns one fanout sink and any per-fanout child sinks. Member order ensures
+  /// the fanout is destroyed before the children it references.
+  struct SinkBundle {
+    std::vector<std::unique_ptr<PluginSink>> children;
+    std::unique_ptr<FanoutSink> fanout;
+
+    PluginSink *get() const { return fanout.get(); }
+  };
+
+  /// Build a sink combining configured sinks + optional file sink.
+  /// Returns an empty bundle if no sinks are configured.
+  SinkBundle build_sink_bundle(const std::string &file_name) {
+    bool has_file = !sink_dir_.empty() && !file_name.empty();
+    if (configured_sinks_.empty() && !has_file)
+      return {};
+
+    SinkBundle result;
+    auto fanout = std::make_unique<FanoutSink>();
+    for (const auto &s : configured_sinks_)
+      fanout->add(*s);
     if (has_file) {
       auto fs = std::make_unique<FileSink>(sink_dir_ + "/" + file_name);
       if (fs->is_open()) {
-        composite->add(fs.get());
-        owned_sinks_.push_back(std::move(fs));
-      } else if (composite->empty()) {
+        fanout->add(*fs);
+        result.children.push_back(std::move(fs));
+      } else if (fanout->empty()) {
         // Preserve output when the file was the only requested destination.
         // Do not add stderr when another configured sink is already usable,
         // because doing so would unexpectedly duplicate output.
-        composite->add(&StderrSink::instance());
+        auto fallback = std::make_unique<StderrSink>();
+        fanout->add(*fallback);
+        result.children.push_back(std::move(fallback));
       }
     }
-    auto *result = composite.get();
-    owned_sinks_.push_back(std::move(composite));
+    result.fanout = std::move(fanout);
     return result;
   }
 
-  std::vector<PluginSink *> external_sinks_;
+  std::vector<std::unique_ptr<PluginSink>> configured_sinks_;
   std::string sink_dir_;
-  std::vector<std::unique_ptr<PluginSink>> owned_sinks_;
 
 private:
-  void build_sink_for(ExecutionPlugin &p) {
-    if (auto *s = build_composite_sink(p.name() + ".log"))
-      p.sink_ = s;
-  }
+  /// Owns the sink assigned to one plugin. The plugin is declared last and is
+  /// therefore destroyed before its sink bundle.
+  struct PluginEntry {
+    SinkBundle sink;
+    OwnedPlugin plugin;
+  };
 
-  std::vector<std::unique_ptr<ExecutionPlugin, PluginDeleter>> plugins_;
+  // Entries are declared after configured sinks, so plugins and their local
+  // fanouts are destroyed before the configured sinks they reference.
+  std::vector<PluginEntry> plugins_;
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/plugin_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/plugin_loader.cpp
@@ -150,13 +150,14 @@ bool load_one(const std::string &name, const flexbuffers::Reference &user_cfg,
 /// @code{.json}
 ///   "sinks": { "types": ["stderr", "file"], "dir": "/tmp/out" }
 /// @endcode
-void configure_sinks(const flexbuffers::Reference &root, ExecutionPluginGroup &group) {
+PluginSinkConfig parse_sink_config(const flexbuffers::Reference &root) {
+  PluginSinkConfig config;
   flexbuffers::Reference sinks = root.IsMap() ? root.AsMap()["sinks"] : flexbuffers::Reference();
 
   // Default: stderr only.
   if (!sinks.IsMap()) {
-    group.add_sink(&StderrSink::instance());
-    return;
+    config.emplace<StderrSink>();
+    return config;
   }
 
   auto sinks_map = sinks.AsMap();
@@ -164,8 +165,8 @@ void configure_sinks(const flexbuffers::Reference &root, ExecutionPluginGroup &g
   std::string dir = sinks_map["dir"].IsString() ? sinks_map["dir"].AsString().c_str() : "";
 
   if (!types.IsVector()) {
-    group.add_sink(&StderrSink::instance());
-    return;
+    config.emplace<StderrSink>();
+    return config;
   }
 
   auto vec = types.AsVector();
@@ -173,21 +174,22 @@ void configure_sinks(const flexbuffers::Reference &root, ExecutionPluginGroup &g
   for (size_t i = 0; i < vec.size(); ++i) {
     std::string token = vec[i].IsString() ? vec[i].AsString().c_str() : "";
     if (token == "stderr") {
-      group.add_sink(&StderrSink::instance());
+      config.emplace<StderrSink>();
       configured = true;
     } else if (token == "stdout") {
-      group.add_sink(&StdoutSink::instance());
+      config.emplace<StdoutSink>();
       configured = true;
     } else if (token == "file") {
       if (!dir.empty()) {
-        group.set_sink_dir(dir);
+        config.set_file_directory(dir);
         configured = true;
       } else
         util::Logger::warn("sink type 'file' requested but no 'dir' set");
     }
   }
   if (!configured)
-    group.add_sink(&StderrSink::instance());
+    config.emplace<StderrSink>();
+  return config;
 }
 
 } // namespace
@@ -233,11 +235,13 @@ PluginLoader::configure_plugin_group(const std::string &config_json, const std::
     throw std::invalid_argument("profiled plugin execution requires num_threads=1");
   }
 
-  std::shared_ptr<ExecutionPluginGroup> group =
-      profiled ? std::make_shared<ProfiledExecutionPluginGroup>()
-               : std::make_shared<ExecutionPluginGroup>();
+  PluginSinkConfig sink_config = parse_sink_config(root);
+  std::shared_ptr<ExecutionPluginGroup> group;
+  if (profiled)
+    group = std::make_shared<ProfiledExecutionPluginGroup>(std::move(sink_config));
+  else
+    group = std::make_shared<ExecutionPluginGroup>(std::move(sink_config));
 
-  configure_sinks(root, *group);
   load_from_config(config_json, *group, plugin_dir);
   return group;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/plugin_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/plugin_loader.cpp
@@ -144,8 +144,8 @@ bool load_one(const std::string &name, const flexbuffers::Reference &user_cfg,
   return true;
 }
 
-/// Configure output sinks on @p group from the optional top-level `sinks`
-/// object. Defaults to a single stderr sink when absent.
+/// Parse owned output sinks from the optional top-level `sinks` object.
+/// Defaults to a single stderr sink when absent.
 ///
 /// @code{.json}
 ///   "sinks": { "types": ["stderr", "file"], "dir": "/tmp/out" }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/plugin_sink.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/plugin_sink.h
@@ -12,7 +12,7 @@
 ///   - Tests: StringSink — captures output for assertions, no stderr scraping.
 ///   - Integration tests: FileSink — writes to <dir>/<plugin_name>.log for
 ///     structured parsing by test harnesses.
-///   - Mixed: CompositeSink — dispatches to multiple sinks simultaneously
+///   - Mixed: the plugin group dispatches to multiple configured sinks
 ///     (e.g., stderr for interactive viewing + file for test parsing).
 ///
 /// ## Wiring
@@ -48,7 +48,6 @@
 #include <cstring>
 #include <string>
 #include <string_view>
-#include <vector>
 
 namespace rocjitsu {
 
@@ -120,25 +119,6 @@ public:
 
 private:
   std::string buf_;
-};
-
-/// @brief Dispatches writes to multiple child sinks.
-class CompositeSink : public PluginSink {
-public:
-  void add(PluginSink *s) {
-    if (s)
-      children_.push_back(s);
-  }
-
-  void write(std::string_view msg) override {
-    for (auto *s : children_)
-      s->write(msg);
-  }
-
-  bool empty() const { return children_.empty(); }
-
-private:
-  std::vector<PluginSink *> children_;
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/profiled_execution_plugin_group.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/profiled_execution_plugin_group.h
@@ -40,10 +40,12 @@ class ProfiledExecutionPluginGroup : public ExecutionPluginGroup {
   };
 
 public:
-  ProfiledExecutionPluginGroup() : start_time_(Clock::now()) {}
+  explicit ProfiledExecutionPluginGroup(PluginSinkConfig config)
+      : ExecutionPluginGroup(std::move(config)), start_time_(Clock::now()) {}
 
   void onInit() override {
-    if (auto *s = build_composite_sink("profile.log"))
+    profile_sink_ = build_sink_bundle("profile.log");
+    if (auto *s = profile_sink_.get())
       sink_ = s;
     ExecutionPluginGroup::onInit();
   }
@@ -202,6 +204,7 @@ private:
   PluginSink &sink() { return *sink_; }
 
   Clock::time_point start_time_;
+  SinkBundle profile_sink_;
   PluginSink *sink_ = &StderrSink::instance();
   std::string current_kernel_name_;
   std::unordered_map<uint32_t, std::string> dispatch_kernel_names_;

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -61,6 +61,7 @@ RJ_DIAGNOSTIC_POP
 #include <set>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 namespace {
@@ -68,6 +69,8 @@ namespace {
 using namespace rocjitsu;
 using namespace rocjitsu::amdgpu;
 using namespace rocjitsu::plugins::race_detector;
+
+static_assert(!std::is_default_constructible_v<ExecutionPluginGroup>);
 
 // SOPP encoding: bits[31:23]=0x17F, bits[22:16]=op, bits[15:0]=simm16.
 constexpr uint32_t sopp(uint32_t op, uint16_t simm16 = 0) {
@@ -304,6 +307,31 @@ public:
     }
     events.push_back(e);
   }
+};
+
+/// Exercises the group contract that sinks remain alive through plugin
+/// destruction, including plugins that emit final output from their destructor.
+class DestructionTrackingSink : public PluginSink {
+public:
+  explicit DestructionTrackingSink(std::vector<std::string> &events) : events_(events) {}
+  ~DestructionTrackingSink() override { events_.push_back("sink"); }
+  void write(std::string_view msg) override { events_.push_back("write:" + std::string(msg)); }
+
+private:
+  std::vector<std::string> &events_;
+};
+
+class DestructorWritingPlugin : public ExecutionPlugin {
+public:
+  explicit DestructorWritingPlugin(std::vector<std::string> &events)
+      : ExecutionPlugin("destructor_writer"), events_(events) {}
+  ~DestructorWritingPlugin() override {
+    sink().write("destroyed\n");
+    events_.push_back("plugin");
+  }
+
+private:
+  std::vector<std::string> &events_;
 };
 
 class MfmaRacePlugin : public ExecutionPlugin {
@@ -612,7 +640,7 @@ struct PluginFixture {
 
   /// Attach an OrderingPlugin, fire onInit, and return a raw pointer to it.
   OrderingPlugin *attach_ordering_plugin() {
-    plugin_group_ = std::make_shared<ExecutionPluginGroup>();
+    plugin_group_ = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
     auto plugin = std::make_unique<OrderingPlugin>();
     auto *p = plugin.get();
     plugin_group_->add(std::move(plugin));
@@ -661,7 +689,7 @@ struct Wave32PluginFixture {
   }
 
   OrderingPlugin *attach_ordering_plugin() {
-    plugin_group = std::make_shared<ExecutionPluginGroup>();
+    plugin_group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
     auto plugin = std::make_unique<OrderingPlugin>();
     auto *p = plugin.get();
     plugin_group->add(std::move(plugin));
@@ -1819,7 +1847,7 @@ TEST(ExecutionPluginTest, WmmaReadObservationSkipsConstantAccumulator) {
 
 TEST(ExecutionPluginTest, MfmaReadObservationReportsRace) {
   PluginFixture f(/*num_wf_slots=*/1);
-  f.plugin_group_ = std::make_shared<ExecutionPluginGroup>();
+  f.plugin_group_ = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
   auto plugin = std::make_unique<MfmaRacePlugin>();
   auto *race_plugin = plugin.get();
   f.plugin_group_->add(std::move(plugin));
@@ -1863,7 +1891,7 @@ TEST(ExecutionPluginTest, MfmaFastPathReadHookReportsRace) {
     util::set_force_scalar_for_testing(false);
 
     PluginFixture f(/*num_wf_slots=*/1);
-    f.plugin_group_ = std::make_shared<ExecutionPluginGroup>();
+    f.plugin_group_ = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
     auto plugin = std::make_unique<MfmaRacePlugin>();
     auto *race_plugin = plugin.get();
     f.plugin_group_->add(std::move(plugin));
@@ -2370,9 +2398,9 @@ TEST(DisasmCacheTest, DisassemblesOnlyFirstInstructionAtPc) {
 }
 
 TEST(RaceDetectorPluginOutputTest, DispatchLineUsesQuestionMarksForUnresolvedKernel) {
-  StringSink sink;
-  ExecutionPluginGroup plugin_group;
-  plugin_group.add_sink(&sink);
+  PluginSinkConfig sink_config;
+  StringSink &sink = sink_config.emplace<StringSink>();
+  ExecutionPluginGroup plugin_group(std::move(sink_config));
   ASSERT_TRUE(plugin_group.add(std::make_unique<plugins::race_detector::RaceDetectorPlugin>()));
 
   KernelDispatchInfo info{};
@@ -2383,9 +2411,9 @@ TEST(RaceDetectorPluginOutputTest, DispatchLineUsesQuestionMarksForUnresolvedKer
 }
 
 TEST(RaceDetectorPluginOutputTest, DispatchLineUsesReadableNameAndExactSymbol) {
-  StringSink sink;
-  ExecutionPluginGroup plugin_group;
-  plugin_group.add_sink(&sink);
+  PluginSinkConfig sink_config;
+  StringSink &sink = sink_config.emplace<StringSink>();
+  ExecutionPluginGroup plugin_group(std::move(sink_config));
   ASSERT_TRUE(plugin_group.add(std::make_unique<plugins::race_detector::RaceDetectorPlugin>()));
 
   KernelDispatchInfo info{};
@@ -2397,6 +2425,34 @@ TEST(RaceDetectorPluginOutputTest, DispatchLineUsesReadableNameAndExactSymbol) {
   EXPECT_NE(sink.str().find("[rocjitsu] Kernel dispatch: \"racy_kernel\" "
                             "symbol=\"_Z11racy_kernelPKfPf\"\n"),
             std::string::npos);
+}
+
+TEST(ExecutionPluginGroupTest, OwnsSingleSinkThroughPluginDestruction) {
+  std::vector<std::string> events;
+  {
+    PluginSinkConfig sink_config;
+    sink_config.emplace<DestructionTrackingSink>(events);
+    ExecutionPluginGroup plugin_group(std::move(sink_config));
+    ASSERT_TRUE(plugin_group.add(std::make_unique<DestructorWritingPlugin>(events)));
+  }
+  EXPECT_EQ(events, (std::vector<std::string>{"write:destroyed\n", "plugin", "sink"}));
+}
+
+TEST(ExecutionPluginGroupTest, OwnsCompositeChildrenThroughPluginDestruction) {
+  std::vector<std::string> events;
+  {
+    PluginSinkConfig sink_config;
+    sink_config.emplace<DestructionTrackingSink>(events);
+    sink_config.emplace<DestructionTrackingSink>(events);
+    ExecutionPluginGroup plugin_group(std::move(sink_config));
+    ASSERT_TRUE(plugin_group.add(std::make_unique<DestructorWritingPlugin>(events)));
+  }
+
+  ASSERT_EQ(events.size(), 5u);
+  EXPECT_EQ(events[0], "write:destroyed\n");
+  EXPECT_EQ(events[1], "write:destroyed\n");
+  EXPECT_EQ(events[2], "plugin");
+  EXPECT_EQ(std::count(events.begin() + 3, events.end(), "sink"), 2);
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -35,6 +35,7 @@
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
 #include "rocjitsu/vm/amdgpu/memory_pipeline.h"
 #include "rocjitsu/vm/soc.h"
+#include "scoped_temp.h"
 #include "util/simd.h"
 #include "util/simd_test_hooks.h"
 
@@ -56,6 +57,8 @@ RJ_DIAGNOSTIC_POP
 #include <cstdint>
 #include <cstring>
 #include <format>
+#include <fstream>
+#include <iterator>
 #include <map>
 #include <memory>
 #include <set>
@@ -2427,18 +2430,22 @@ TEST(RaceDetectorPluginOutputTest, DispatchLineUsesReadableNameAndExactSymbol) {
             std::string::npos);
 }
 
-TEST(ExecutionPluginGroupTest, OwnsSingleSinkThroughPluginDestruction) {
+TEST(ExecutionPluginGroupTest, OwnsConfiguredSinkForRetainedGroupLifetime) {
   std::vector<std::string> events;
+  std::shared_ptr<ExecutionPluginGroup> plugin_group;
   {
     PluginSinkConfig sink_config;
     sink_config.emplace<DestructionTrackingSink>(events);
-    ExecutionPluginGroup plugin_group(std::move(sink_config));
-    ASSERT_TRUE(plugin_group.add(std::make_unique<DestructorWritingPlugin>(events)));
+    plugin_group = std::make_shared<ExecutionPluginGroup>(std::move(sink_config));
+    ASSERT_TRUE(plugin_group->add(std::make_unique<DestructorWritingPlugin>(events)));
   }
+
+  EXPECT_TRUE(events.empty());
+  plugin_group.reset();
   EXPECT_EQ(events, (std::vector<std::string>{"write:destroyed\n", "plugin", "sink"}));
 }
 
-TEST(ExecutionPluginGroupTest, OwnsCompositeChildrenThroughPluginDestruction) {
+TEST(ExecutionPluginGroupTest, FansOutToEveryConfiguredSink) {
   std::vector<std::string> events;
   {
     PluginSinkConfig sink_config;
@@ -2453,6 +2460,24 @@ TEST(ExecutionPluginGroupTest, OwnsCompositeChildrenThroughPluginDestruction) {
   EXPECT_EQ(events[1], "write:destroyed\n");
   EXPECT_EQ(events[2], "plugin");
   EXPECT_EQ(std::count(events.begin() + 3, events.end(), "sink"), 2);
+}
+
+TEST(ExecutionPluginGroupTest, OwnsFileSinkThroughPluginDestruction) {
+  test::ScopedTempDirectory sink_directory("rocjitsu-plugin-sink-lifetime-");
+  const std::string log_path = sink_directory.path() + "/destructor_writer.log";
+  std::vector<std::string> events;
+  {
+    PluginSinkConfig sink_config;
+    sink_config.set_file_directory(sink_directory.path());
+    ExecutionPluginGroup plugin_group(std::move(sink_config));
+    ASSERT_TRUE(plugin_group.add(std::make_unique<DestructorWritingPlugin>(events)));
+  }
+
+  EXPECT_EQ(events, (std::vector<std::string>{"plugin"}));
+  std::ifstream log(log_path);
+  ASSERT_TRUE(log);
+  const std::string contents{std::istreambuf_iterator<char>(log), std::istreambuf_iterator<char>()};
+  EXPECT_EQ(contents, "destroyed\n");
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/halt_snapshot_plugin.h
+++ b/emulation/rocjitsu/tests/halt_snapshot_plugin.h
@@ -159,7 +159,7 @@ private:
 /// @details Returns the group (attach with `soc->set_plugin_group(group)`), and
 /// sets @p out to the contained plugin for later inspection.
 inline std::shared_ptr<ExecutionPluginGroup> make_halt_snapshot_group(HaltSnapshotPlugin **out) {
-  auto group = std::make_shared<ExecutionPluginGroup>();
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
   auto plugin = std::make_unique<HaltSnapshotPlugin>();
   *out = plugin.get();
   [[maybe_unused]] const bool added = group->add(std::move(plugin));
@@ -203,7 +203,7 @@ private:
 
 /// @brief Build a plugin group holding a DispatchCountPlugin, keep a raw handle.
 inline std::shared_ptr<ExecutionPluginGroup> make_dispatch_count_group(DispatchCountPlugin **out) {
-  auto group = std::make_shared<ExecutionPluginGroup>();
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
   auto plugin = std::make_unique<DispatchCountPlugin>();
   *out = plugin.get();
   [[maybe_unused]] const bool added = group->add(std::move(plugin));

--- a/emulation/rocjitsu/tests/plugin_loader_test.cpp
+++ b/emulation/rocjitsu/tests/plugin_loader_test.cpp
@@ -41,28 +41,28 @@ protected:
 };
 
 TEST_F(PluginLoaderTest, LoadsMatchingAbi) {
-  rocjitsu::ExecutionPluginGroup group;
+  rocjitsu::ExecutionPluginGroup group(rocjitsu::PluginSinkConfig{});
   EXPECT_EQ(load("good", group), 1);
   EXPECT_EQ(group.num_plugins(), 1u);
   EXPECT_NE(trace().find("good:create\n"), std::string::npos);
 }
 
 TEST_F(PluginLoaderTest, RejectsAbiMismatchBeforeCreate) {
-  rocjitsu::ExecutionPluginGroup group;
+  rocjitsu::ExecutionPluginGroup group(rocjitsu::PluginSinkConfig{});
   EXPECT_EQ(load("badabi", group), 0);
   EXPECT_TRUE(group.empty());
   EXPECT_EQ(trace().find("badabi:create\n"), std::string::npos);
 }
 
 TEST_F(PluginLoaderTest, RejectsMissingRequiredExport) {
-  rocjitsu::ExecutionPluginGroup group;
+  rocjitsu::ExecutionPluginGroup group(rocjitsu::PluginSinkConfig{});
   EXPECT_EQ(load("missing", group), 0);
   EXPECT_TRUE(group.empty());
   EXPECT_EQ(trace().find("missing:create\n"), std::string::npos);
 }
 
 TEST_F(PluginLoaderTest, DestroysRejectedDuplicateBeforeUnload) {
-  rocjitsu::ExecutionPluginGroup group;
+  rocjitsu::ExecutionPluginGroup group(rocjitsu::PluginSinkConfig{});
   ASSERT_EQ(load("good", group), 1);
   ASSERT_EQ(load("duplicate", group), 0);
 

--- a/emulation/rocjitsu/tests/register_access_test.cpp
+++ b/emulation/rocjitsu/tests/register_access_test.cpp
@@ -101,7 +101,7 @@ struct Fixture {
     cfg.lds_size_kb = 64;
     cu = ComputeUnitCore::create("register_access_cu", cfg, &gpu_mem, &l2);
 
-    plugin_group = std::make_shared<ExecutionPluginGroup>();
+    plugin_group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
     auto recorder = std::make_unique<RecordingPlugin>();
     plugin = recorder.get();
     plugin_group->add(std::move(recorder));


### PR DESCRIPTION
## Summary

Make plugin sink lifetime an ownership property of `ExecutionPluginGroup`
rather than a requirement imposed on callers.

The group previously retained raw pointers supplied through `add_sink()`. A
group can be retained by the SoC after the caller that created a sink has gone
out of scope. This becomes a use-after-free when a plugin emits output during
destruction, as the race detector does for its final summary.

## Changes

- Introduce a move-only `PluginSinkConfig` that owns configured sinks.
- Require sink configuration when constructing plain and profiled plugin
  groups.
- Remove the default group constructor and post-construction `add_sink()` and
  `set_sink_dir()` APIs.
- Parse the complete sink configuration before PluginLoader constructs the
  group.
- Give each plugin entry its own fanout sink bundle.
- Encode teardown order in member ownership:
  - the plugin is destroyed before its per-plugin fanout;
  - the fanout is destroyed before its owned child sinks;
  - all plugin entries are destroyed before group-level configured sinks.
- Make configured-sink storage and fanout mutation private.
- Expose only a narrow, read-only bundle-building helper to the profiled
  subclass.
- Document the lifetime of references returned by
  `PluginSinkConfig::emplace()`.

This avoids a custom group destructor and does not require shared sink
ownership. Ordinary reverse member destruction provides the lifetime
guarantee.

## Coverage

The lifetime regressions cover three ownership paths:

- a retained shared group outliving the configuration scope;
- fanout to multiple group-level configured sinks; and
- an owned per-plugin `FileSink`, with destructor output read after group
  destruction.

Existing plugin loader, profiling, output, register-access, lifecycle, and
representative SoC dispatch coverage exercises the updated construction and
delegation paths.

## Issue Tracking

Related: #9577