### PR TITLE
fix(rocr): fix PC sampling hangs on stop/start and concurrent per-XCC flushes

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -1086,6 +1086,14 @@ class GpuAgent : public GpuAgentInt {
   // structure for stochastic sampling
   pcs_data_t pcs_stochastic_data_;
 
+  // Serializes PM4 submit-and-wait sequences on queues_[QueuePCSampling].
+  // AqlQueue::ExecutePM4 stages commands in a single per-queue indirect buffer that it
+  // reuses as soon as it returns, so only one asynchronous PM4 submission may be in
+  // flight on that queue at a time. The per-XCC flush threads and PcSamplingFlush all
+  // share the queue, as do the hosttrap and stochastic sessions.
+  // Lock order: host_buffer_mutex -> pcs_pm4_mutex_.
+  std::mutex pcs_pm4_mutex_;
+
   /// @brief XGMI CPU<->GPU
   bool xgmi_cpu_gpu_;
   /// @brief Is PCIe large BAR enabled.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -1086,11 +1086,8 @@ class GpuAgent : public GpuAgentInt {
   // structure for stochastic sampling
   pcs_data_t pcs_stochastic_data_;
 
-  // Serializes PM4 submit-and-wait sequences on queues_[QueuePCSampling].
-  // AqlQueue::ExecutePM4 stages commands in a single per-queue indirect buffer that it
-  // reuses as soon as it returns, so only one asynchronous PM4 submission may be in
-  // flight on that queue at a time. The per-XCC flush threads and PcSamplingFlush all
-  // share the queue, as do the hosttrap and stochastic sessions.
+  // Serializes PM4 submit-and-wait on queues_[QueuePCSampling]: ExecutePM4 reuses a single
+  // per-queue indirect buffer, so only one submission may be in flight at a time.
   // Lock order: host_buffer_mutex -> pcs_pm4_mutex_.
   std::mutex pcs_pm4_mutex_;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1595,6 +1595,9 @@ void AqlQueue::SetProfiling(bool enabled) {
 // If in_signal is provided, then ExecutePM4 will return and caller may wait for in_signal
 // Note: On gfx8, there is no completion signal support, so ExecutePM4 will block even if
 // in_signal is provided, and it is still valid to check in_signal after ExecutePM4 returns.
+// Note: cmd_data is staged in pm4_ib_buf_, a single indirect buffer per queue that is reused
+// by the next call. When in_signal is provided the caller must wait on it before issuing
+// another PM4 on this queue, otherwise the in-flight command stream is overwritten.
 void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope_t acquireFence,
                           hsa_fence_scope_t releaseFence, hsa_signal_t* in_signal) {
   // pm4_ib_buf_ is a shared resource, so mutually exclude here.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1595,9 +1595,8 @@ void AqlQueue::SetProfiling(bool enabled) {
 // If in_signal is provided, then ExecutePM4 will return and caller may wait for in_signal
 // Note: On gfx8, there is no completion signal support, so ExecutePM4 will block even if
 // in_signal is provided, and it is still valid to check in_signal after ExecutePM4 returns.
-// Note: cmd_data is staged in pm4_ib_buf_, a single indirect buffer per queue that is reused
-// by the next call. When in_signal is provided the caller must wait on it before issuing
-// another PM4 on this queue, otherwise the in-flight command stream is overwritten.
+// Note: cmd_data is staged in pm4_ib_buf_, one indirect buffer per queue that the next call
+// reuses, so with in_signal the caller must wait on it before issuing another PM4 here.
 void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope_t acquireFence,
                           hsa_fence_scope_t releaseFence, hsa_signal_t* in_signal) {
   // pm4_ib_buf_ is a shared resource, so mutually exclude here.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -3707,15 +3707,9 @@ hsa_status_t GpuAgent::PcSamplingCreateFromId(HsaPcSamplingTraceId ioctlId,
   // Initialize per-XCC structures
   pcs_data->num_xcc = properties_.NumXcc;
 
-  // Always drain the trap buffers with PM4 rather than a CPU memcpy over the large-BAR
-  // aperture. The CPU path spins on buf_written_val and then reads the samples directly,
-  // but that handshake only orders the CPU's own accesses: the trap handler writes the
-  // sample payload through GL2, and nothing guarantees those bytes are visible across the
-  // aperture at the point the counter increment is. The memcpy can therefore observe a
-  // partially written record. PM4 issues the WAIT_REG_MEM and the DMA_DATA on the command
-  // processor, inside the same coherent domain, so the copy cannot outrun the payload.
-  // Restoring the CPU fast path requires the trap handler to make the payload visible
-  // before it advances buf_written_val.
+  // Always drain with PM4, never a CPU memcpy: the buf_written_val handshake does not order
+  // the trap handler's GL2 payload writes across the large-BAR aperture, so the CPU can read a
+  // torn record. The CPU path can return once the handler publishes the payload before the count.
   pcs_data->use_pm4_fallback = true;
 
   // Allocate cache-line aligned per-XCC data array
@@ -4053,10 +4047,8 @@ hsa_status_t GpuAgent::PcSamplingCreateFromId(HsaPcSamplingTraceId ioctlId,
   // Allocate contiguous device memory for all XCCs, each XCC gets deviceAllocSize bytes
   size_t deviceAllocSize = AlignUp(sizeof(pcs_sampling_data_t) + (2 * trap_buffer_size), 256);
 
-  // TMA2 carries a single per-XCC stride that the trap handler applies to both the hosttrap and
-  // the stochastic buffer array. If a session of the other method is already active with a
-  // different stride, one of the two arrays would be indexed outside its allocation, so refuse
-  // the session rather than corrupt memory.
+  // TMA2 holds one per-XCC stride shared by the hosttrap and stochastic buffer arrays, so an
+  // active session of the other method with a different stride would index past its allocation.
   const pcs_data_t& other_pcs_data = (sampling_method == HSA_VEN_AMD_PCS_METHOD_HOSTTRAP_V1)
       ? pcs_stochastic_data_
       : pcs_hosttrap_data_;
@@ -4270,10 +4262,8 @@ hsa_status_t GpuAgent::PcSamplingStart(pcs::PcsRuntime::PcSamplingSession& sessi
   // done signals as an exit sentinel to wake worker threads, so restore the
   // expected initial values before creating new monitoring threads.
   //
-  // which_buffer is deliberately left alone: it shadows bit 63 of the device's buf_write_val,
-  // which survives a stop/start pair. Forcing it back to 0 here would make the host drain
-  // buf_written_val0 while the trap handler keeps filling buffer 1, and the WAIT_REG_MEM in
-  // the PM4 flush path would then poll for a count that never arrives.
+  // which_buffer is deliberately not reset: it shadows bit 63 of buf_write_val, which survives
+  // stop/start, so forcing it to 0 would desync the drain and hang the PM4 WAIT_REG_MEM poll.
   for (uint32_t xcc_id = 0; xcc_id < pcs_data->num_xcc; xcc_id++) {
     pcs_data->xcc_data[xcc_id].host_write_offset = 0;
     pcs_data->xcc_data[xcc_id].host_read_offset = 0;
@@ -4611,9 +4601,8 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
     return HSA_STATUS_SUCCESS;
   }
 
-  // ExecutePM4 stages the command stream in the queue's single indirect buffer and returns as
-  // soon as the doorbell is rung, so a concurrent submission would overwrite commands the
-  // command processor has not fetched yet. Hold the lock across both submit-and-wait pairs.
+  // ExecutePM4 returns once the doorbell rings but reuses one indirect buffer per queue, so
+  // hold the lock across both PM4 pairs or a concurrent submission overwrites unfetched commands.
   std::lock_guard<std::mutex> pm4_lock(pcs_pm4_mutex_);
 
   uint32_t next_buffer;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -4044,6 +4044,22 @@ hsa_status_t GpuAgent::PcSamplingCreateFromId(HsaPcSamplingTraceId ioctlId,
 
   // Allocate contiguous device memory for all XCCs, each XCC gets deviceAllocSize bytes
   size_t deviceAllocSize = AlignUp(sizeof(pcs_sampling_data_t) + (2 * trap_buffer_size), 256);
+
+  // TMA2 carries a single per-XCC stride that the trap handler applies to both the hosttrap and
+  // the stochastic buffer array. If a session of the other method is already active with a
+  // different stride, one of the two arrays would be indexed outside its allocation, so refuse
+  // the session rather than corrupt memory.
+  const pcs_data_t& other_pcs_data = (sampling_method == HSA_VEN_AMD_PCS_METHOD_HOSTTRAP_V1)
+      ? pcs_stochastic_data_
+      : pcs_hosttrap_data_;
+  if (other_pcs_data.session && other_pcs_data.per_xcc_device_stride != deviceAllocSize) {
+    debug_print(
+        "PC Sampling: cannot start session, active session uses per-XCC stride %zu but this "
+        "session needs %zu\n",
+        other_pcs_data.per_xcc_device_stride, deviceAllocSize);
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+
   size_t totalDeviceAllocSize = deviceAllocSize * pcs_data->num_xcc;
   pcs_data->per_xcc_device_stride = deviceAllocSize;  // Cache for trap handler update in Destroy
 
@@ -4245,12 +4261,16 @@ hsa_status_t GpuAgent::PcSamplingStart(pcs::PcsRuntime::PcSamplingSession& sessi
   // Reset per-XCC state for a fresh session. PcSamplingStop uses -1 on the
   // done signals as an exit sentinel to wake worker threads, so restore the
   // expected initial values before creating new monitoring threads.
+  //
+  // which_buffer is deliberately left alone: it shadows bit 63 of the device's buf_write_val,
+  // which survives a stop/start pair. Forcing it back to 0 here would make the host drain
+  // buf_written_val0 while the trap handler keeps filling buffer 1, and the WAIT_REG_MEM in
+  // the PM4 flush path would then poll for a count that never arrives.
   for (uint32_t xcc_id = 0; xcc_id < pcs_data->num_xcc; xcc_id++) {
     pcs_data->xcc_data[xcc_id].host_write_offset = 0;
     pcs_data->xcc_data[xcc_id].host_read_offset = 0;
     HSA::hsa_signal_store_screlease(pcs_data->xcc_data[xcc_id].done_sig0, 1);
     HSA::hsa_signal_store_screlease(pcs_data->xcc_data[xcc_id].done_sig1, 1);
-    pcs_data->xcc_data[xcc_id].which_buffer = 0;
   }
   pcs_data->consumer_exit.store(false, std::memory_order_relaxed);
   pcs_data->pending_flush_count = 0;
@@ -4582,6 +4602,11 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
   if (!pcs_data->xcc_data[xcc_id].device_data) {
     return HSA_STATUS_SUCCESS;
   }
+
+  // ExecutePM4 stages the command stream in the queue's single indirect buffer and returns as
+  // soon as the doorbell is rung, so a concurrent submission would overwrite commands the
+  // command processor has not fetched yet. Hold the lock across both submit-and-wait pairs.
+  std::lock_guard<std::mutex> pm4_lock(pcs_pm4_mutex_);
 
   uint32_t next_buffer;
   uint64_t reset_write_val;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -3707,8 +3707,16 @@ hsa_status_t GpuAgent::PcSamplingCreateFromId(HsaPcSamplingTraceId ioctlId,
   // Initialize per-XCC structures
   pcs_data->num_xcc = properties_.NumXcc;
 
-  // Detect if we need PM4 fallback (non-large-BAR systems cannot use CPU atomics on VRAM)
-  pcs_data->use_pm4_fallback = !LargeBarEnabled();
+  // Always drain the trap buffers with PM4 rather than a CPU memcpy over the large-BAR
+  // aperture. The CPU path spins on buf_written_val and then reads the samples directly,
+  // but that handshake only orders the CPU's own accesses: the trap handler writes the
+  // sample payload through GL2, and nothing guarantees those bytes are visible across the
+  // aperture at the point the counter increment is. The memcpy can therefore observe a
+  // partially written record. PM4 issues the WAIT_REG_MEM and the DMA_DATA on the command
+  // processor, inside the same coherent domain, so the copy cannot outrun the payload.
+  // Restoring the CPU fast path requires the trap handler to make the payload visible
+  // before it advances buf_written_val.
+  pcs_data->use_pm4_fallback = true;
 
   // Allocate cache-line aligned per-XCC data array
   // Each per_xcc_pcs_data_t is 64-byte aligned to prevent false sharing between XCCs


### PR DESCRIPTION
## Motivation

PC sampling hangs on gfx942 when a session is paused and resumed. `roctxProfilerPause()`
never returns: the flush path spins in a `WAIT_REG_MEM` with a `0xFFFFFFFF` timeout,
waiting on a sample count the device will never write, and the process has to be killed.
The rocprofiler-sdk `roctx-pause-resume` PC sampling test reproduces this on every run.

Tracing that hang surfaced two more defects in the same path, both of which can corrupt
memory rather than merely stall.

## Technical Details

**The buffer selector drifted out of sync with the device.** `which_buffer` is the host's
shadow of bit 63 of the device's `buf_write_val`, which picks which of the two device
buffers the trap handler fills. `PcSamplingStart()` reset it to `0` on every start, but the
device-side selector survives a stop/start pair. After a resume the host drained
`buf_written_val0` while the trap handler kept writing into buffer 1, so the flush waited on
a counter that was never going to arrive. The reset is removed, with a comment explaining
why the field has to be left alone.

**Concurrent PM4 submissions overwrote each other.** `AqlQueue::ExecutePM4` stages its
command stream in `pm4_ib_buf_`, one indirect buffer per queue that the next call reuses,
and it returns as soon as the doorbell is rung when a completion signal is supplied. The
per-XCC flush threads, `PcSamplingFlush`, and the hosttrap and stochastic sessions all share
`queues_[QueuePCSampling]`, so one submission could overwrite commands the command processor
had not fetched yet. A new `pcs_pm4_mutex_` is held across both submit-and-wait pairs in
`PcSamplingFlushDeviceBuffersPerXCC_PM4`, and the constraint is now documented at
`ExecutePM4` itself.

**Two sessions could disagree on the buffer stride.** TMA2 carries a single per-XCC stride
that the trap handler applies to both the hosttrap and the stochastic buffer array. If a
session of one method is already active with a different stride, the other array gets
indexed outside its allocation. `PcSamplingCreateFromId` now returns
`HSA_STATUS_ERROR_OUT_OF_RESOURCES` instead of creating the session.

## Issue Tracking
JIRA ID: AIROCVAL-37

## Test Plan

Built this ROCr tree together with rocprofiler-sdk and ran the PC sampling suites on gfx942
(MI300A). The two affected suites were stress-run for 100 iterations each rather than once,
to confirm the hang does not resurface intermittently.

## Test Result

No failures or hangs across the stress runs.

- `rocprofv3-test-roctx-pause-resume-pc-sampling` — hung before this change, 100/100
  iterations pass after it.
- `rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation` (9 tests) — 100/100
  iterations pass.
- Stochastic `exec-mask-manipulation` — passes where the driver advertises the method,
  skips cleanly where it does not.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.