### PR TITLE
fix(rocprofiler-systems): AVX-512 SIGILL on non-AVX-512 hosts (Add ROCPROFSYS_BUILD_PORTABL)

### DIFF
--- a/projects/rocprofiler-systems/cmake/BuildSettings.cmake
+++ b/projects/rocprofiler-systems/cmake/BuildSettings.cmake
@@ -48,10 +48,6 @@ rocprofiler_systems_add_option(ROCPROFSYS_BUILD_RELEASE
 rocprofiler_systems_add_option(ROCPROFSYS_BUILD_EXTRA_OPTIMIZATIONS
     "Extra optimization flags" OFF
 )
-rocprofiler_systems_add_option(ROCPROFSYS_BUILD_PORTABLE
-    "Build with a portable CPU ISA baseline."
-    ON
-)
 rocprofiler_systems_add_option(ROCPROFSYS_BUILD_LTO "Build with link-time optimization"
     OFF
 )

--- a/projects/rocprofiler-systems/cmake/BuildSettings.cmake
+++ b/projects/rocprofiler-systems/cmake/BuildSettings.cmake
@@ -48,6 +48,10 @@ rocprofiler_systems_add_option(ROCPROFSYS_BUILD_RELEASE
 rocprofiler_systems_add_option(ROCPROFSYS_BUILD_EXTRA_OPTIMIZATIONS
     "Extra optimization flags" OFF
 )
+rocprofiler_systems_add_option(ROCPROFSYS_BUILD_PORTABLE
+    "Build with a portable CPU ISA baseline."
+    ON
+)
 rocprofiler_systems_add_option(ROCPROFSYS_BUILD_LTO "Build with link-time optimization"
     OFF
 )

--- a/projects/rocprofiler-systems/cmake/Packages.cmake
+++ b/projects/rocprofiler-systems/cmake/Packages.cmake
@@ -884,6 +884,20 @@ set(TIMEMORY_BUILD_CONTAINERS
 )
 
 # timemory build settings
+
+# With default value OFF, ConfigCpuArch host-detects the builder's CPU and can bake
+# in -mavx512* / -march=native, producing binaries that SIGILL on non-AVX-512 CPUs
+# (e.g. Zen3 / MI250X hosts). ON caps arch flags at AVX2.
+set(TIMEMORY_BUILD_PORTABLE
+    ${ROCPROFSYS_BUILD_PORTABLE}
+    CACHE BOOL
+    "Disable arch flags which may cause portability issues (e.g. AVX-512)"
+    FORCE
+)
+# End users configure this via ROCPROFSYS_BUILD_PORTABLE; hide the internal
+# timemory-prefixed variable to avoid confusion in ccmake / cmake-gui.
+mark_as_advanced(TIMEMORY_BUILD_PORTABLE)
+message(STATUS "Portable setting ROCPROFSYS_BUILD_PORTABLE: ${ROCPROFSYS_BUILD_PORTABLE}")
 set(TIMEMORY_TLS_MODEL "global-dynamic" CACHE STRING "Thread-local static model" FORCE)
 set(TIMEMORY_MAX_THREADS
     "${ROCPROFSYS_MAX_THREADS}"

--- a/projects/rocprofiler-systems/cmake/Packages.cmake
+++ b/projects/rocprofiler-systems/cmake/Packages.cmake
@@ -884,19 +884,6 @@ set(TIMEMORY_BUILD_CONTAINERS
 )
 
 # timemory build settings
-
-# With default value OFF, ConfigCpuArch host-detects the builder's CPU and can bake
-# in -mavx512* / -march=native, producing binaries that SIGILL on non-AVX-512 CPUs
-# (e.g. Zen3 / MI250X hosts). ON caps arch flags at AVX2.
-set(TIMEMORY_BUILD_PORTABLE
-    ${ROCPROFSYS_BUILD_PORTABLE}
-    CACHE BOOL
-    "Disable arch flags which may cause portability issues (e.g. AVX-512)"
-    FORCE
-)
-# End users configure this via ROCPROFSYS_BUILD_PORTABLE.
-mark_as_advanced(TIMEMORY_BUILD_PORTABLE)
-message(STATUS "Portable setting ROCPROFSYS_BUILD_PORTABLE: ${ROCPROFSYS_BUILD_PORTABLE}")
 set(TIMEMORY_TLS_MODEL "global-dynamic" CACHE STRING "Thread-local static model" FORCE)
 set(TIMEMORY_MAX_THREADS
     "${ROCPROFSYS_MAX_THREADS}"

--- a/projects/rocprofiler-systems/cmake/Packages.cmake
+++ b/projects/rocprofiler-systems/cmake/Packages.cmake
@@ -894,8 +894,7 @@ set(TIMEMORY_BUILD_PORTABLE
     "Disable arch flags which may cause portability issues (e.g. AVX-512)"
     FORCE
 )
-# End users configure this via ROCPROFSYS_BUILD_PORTABLE; hide the internal
-# timemory-prefixed variable to avoid confusion in ccmake / cmake-gui.
+# End users configure this via ROCPROFSYS_BUILD_PORTABLE.
 mark_as_advanced(TIMEMORY_BUILD_PORTABLE)
 message(STATUS "Portable setting ROCPROFSYS_BUILD_PORTABLE: ${ROCPROFSYS_BUILD_PORTABLE}")
 set(TIMEMORY_TLS_MODEL "global-dynamic" CACHE STRING "Thread-local static model" FORCE)


### PR DESCRIPTION
## Motivation

Nightly/tarball rocprof-sys built on an AVX-512 CI host bakes AVX-512 into the binaries, so they SIGILL at startup on non-AVX-512 CPUs (e.g. AMD Zen3 / MI250X hosts). This makes rock builds unusable on those systems.
This bumps the vendored timemory to a commit that defaults to a portable CPU ISA baseline, fixing the crash without any rocprofiler-systems code changes.

## Technical Details

TODO:
- [x] Update submodule pointer after merge of https://github.com/ROCm/timemory/pull/39

- Advance the `external/timemory` submodule to the commit that changes the default of `TIMEMORY_BUILD_PORTABLE` from `OFF` to `ON`
- With that default, `timemory/cmake/Modules/ConfigCpuArch.cmake` caps CPU arch flags at AVX2 instead of host-detecting `-mavx512*` / `-march=native` on the builder. This keeps AVX-512 (`%zmm`) instructions out of the rocprof-sys binaries, so they run across non-AVX-512 hosts.

## Issue Tracking

JIRA ID: AIPROFSYST-702
- JIRA ID: ROCM-28107
- JIRA ID: ROCM-27668

## Test Plan

- After a portable build: `objdump -d lib/librocprof-sys.so | grep -c '%zmm'` -> 0, and `rocprof-sys-avail --version` runs (exit 0) on an AMD EPYC 7763 (Zen3, no AVX-512), where the prior build SIGILL'd (exit 132). 

CMake-only change; no unit test

## Test Result

Notes about performance impact
------------------------------------------
- **AVX‑512's win is workload-dependent**. It helps most on dense, hot numeric loops over large contiguous data (HPC kernels, BLAS-style math). It does little for control-flow-heavy, latency-bound, bookkeeping code — which is what a profiler mostly is (sampling, stack unwinding, buffer/hash management, timestamps, string handling). The AVX‑512 you saw here was incidental auto‑vectorization of generic loops (vmovdqu64+vpaddq = a copy/accumulate), not a performance-critical kernel, so dropping it to AVX2 barely moves the needle.
- **Most of the SIMD benefit is already at AVX2. Going from scalar** - AVX2 (256‑bit) captures the bulk of the vectorization gains for general code. AVX2 → AVX‑512 (512‑bit) is diminishing returns unless a hot loop is genuinely 512-bit-bound. x86-64-v3 (AVX2 + FMA + BMI2) is a strong baseline.
- **The target application's performance is unaffected**. rocprof‑sys instruments/measures your app; how rocprof‑sys itself was compiled only affects its own overhead, and that overhead isn't dominated by wide SIMD.

**Other Notes:**
- On some older **AVX‑512 Intel** parts (Skylake‑X / Cascade Lake), heavy AVX‑512 triggered **frequency downclocking** that could make it net‑neutral or even slower for mixed workloads. On modern chips (Ice Lake+, Sapphire Rapids, AMD Zen4) that penalty is small/gone. So on some AVX‑512 systems, an AVX2 build can actually be faster.
AVX‑512 also adds mask registers, 32 vector regs, and new ops that can help specific algorithms even without the width - but that's unlikely to be a factor for a profiler.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
