### PR TITLE
fix(rocshmem): dependencies should be found during find_package(rocshmem)

### DIFF
--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -481,7 +481,7 @@ if (NOT BUILD_TESTS_ONLY)
       $<$<NOT:$<BOOL:${FILESYSTEM_NO_LINK_NEEDED}>>:stdc++fs>
       $<$<BOOL:${USE_SDMA}>:hsakmt::hsakmt>
     PRIVATE
-      $<$<BOOL:${USE_GDA} OR ${USE_SDMA}>:numa::numa>
+      $<$<OR:$<BOOL:${USE_GDA}>,$<BOOL:${USE_SDMA}>>:numa::numa>
   )
 
   target_link_options(

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -561,12 +561,15 @@ if (NOT BUILD_TESTS_ONLY)
   # ROCm 7.13+ ships NUMAConfig.cmake in rocm_sysdeps so find_dependency(NUMA)
   # works cleanly for consumers. On older ROCm, bake the resolved paths into an
   # included file since no config-mode NUMA package exists.
+  # For ROCm >= 7.13 NUMAConfig.cmake ships in rocm_sysdeps alongside the ROCm
+  # install. Inject a CMAKE_PREFIX_PATH prepend into the generated config using
+  # the hip package location (stable relative to rocm_sysdeps) so internal
+  # find_dependency(NUMA) resolves without requiring downstream project awareness.
+  # For older ROCm, bake the resolved numa::numa target directly.
   set(_rocshmem_numa_include)
   if(${ROCM_MAJOR_VERSION} GREATER 7 OR
      (${ROCM_MAJOR_VERSION} EQUAL 7 AND ${ROCM_MINOR_VERSION} GREATER_EQUAL 13))
-    # ROCm 7.13+ ships NUMAConfig.cmake in rocm_sysdeps — find_dependency(NUMA)
-    # works for consumers via config mode.
-    if(USE_SDMA OR USE_GDA)
+    if(USE_GDA OR USE_SDMA)
       list(APPEND _rocshmem_export_deps PACKAGE NUMA)
     endif()
   elseif(TARGET numa::numa)
@@ -598,6 +601,21 @@ if (NOT BUILD_TESTS_ONLY)
   )
   unset(_rocshmem_include_arg)
   unset(_rocshmem_export_deps)
+  # Patch the generated config to expand CMAKE_PREFIX_PATH with rocm_sysdeps
+  # before find_dependency(NUMA) so NUMAConfig.cmake is found on ROCm >= 7.13
+  # without consumers needing to add rocm_sysdeps to their CMAKE_PREFIX_PATH.
+  if(${ROCM_MAJOR_VERSION} GREATER 7 OR
+     (${ROCM_MAJOR_VERSION} EQUAL 7 AND ${ROCM_MINOR_VERSION} GREATER_EQUAL 13))
+    set(_config_out "${CMAKE_CURRENT_BINARY_DIR}/rocshmem-config.cmake")
+    file(READ "${_config_out}" _config_content)
+    string(REPLACE
+      "find_dependency(NUMA)"
+      "string(REGEX REPLACE \"/lib/cmake/hip$\" \"\" _rocshmem_rocm_root \"\${hip_DIR}\")\nlist(APPEND CMAKE_PREFIX_PATH \"\${_rocshmem_rocm_root}/lib/rocm_sysdeps\")\nunset(_rocshmem_rocm_root)\nfind_dependency(NUMA)\nlist(REMOVE_AT CMAKE_PREFIX_PATH -1)"
+      _config_content "${_config_content}")
+    file(WRITE "${_config_out}" "${_config_content}")
+    unset(_config_out)
+    unset(_config_content)
+  endif()
   include(ROCMPackageConfigHelpers)
   include(ROCMClients)
   rocm_package_setup_component(clients)

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -311,8 +311,8 @@ if (NOT BUILD_TESTS_ONLY)
       endif()
     endif()
 
-    if(NOT TARGET numa::numa)
-      message(STATUS "libnuma not found. Unable to build GDA or SDMA")
+    if(NOT TARGET numa::numa AND (USE_GDA OR USE_SDMA))
+      message(WARNING "libnuma not found. Unable to build GDA or SDMA")
       set(USE_SDMA OFF)
       set(USE_GDA OFF)
       set(GDA_IONIC OFF)
@@ -480,7 +480,8 @@ if (NOT BUILD_TESTS_ONLY)
       -fgpu-rdc
       $<$<NOT:$<BOOL:${FILESYSTEM_NO_LINK_NEEDED}>>:stdc++fs>
       $<$<BOOL:${USE_SDMA}>:hsakmt::hsakmt>
-      $<$<BOOL:${USE_GDA}>:numa::numa>
+    PRIVATE
+      $<$<BOOL:${USE_GDA} OR ${USE_SDMA}>:numa::numa>
   )
 
   target_link_options(
@@ -502,10 +503,8 @@ if (NOT BUILD_TESTS_ONLY)
   endif()
 
   if(USE_ROCPROFILER_REGISTER AND TARGET rocprofiler-register::rocprofiler-register)
-    target_compile_definitions(${PROJECT_NAME}
-      PRIVATE ROCSHMEM_ROCPROFILER_REGISTER=1)
     target_link_libraries(${PROJECT_NAME}
-      PRIVATE rocprofiler-register::rocprofiler-register)
+                          PRIVATE rocprofiler-register::rocprofiler-register)
   endif()
 
   if(${ROCM_MAJOR_VERSION} LESS 7)
@@ -551,11 +550,27 @@ if (NOT BUILD_TESTS_ONLY)
       rocm-dev
   )
 
-  # Generate a baked numa::numa imported target file from the paths resolved at
-  # rocshmem build time. This avoids re-detecting NUMA at consumer configure
-  # time (no find_dependency(NUMA), no FindNUMA.cmake, no CMAKE_MODULE_PATH
-  # manipulation) and works regardless of whether a NUMAConfig.cmake exists.
-  if(TARGET numa::numa)
+  set(_rocshmem_export_deps)
+  if(USE_SDMA AND TARGET hsakmt::hsakmt)
+    list(APPEND _rocshmem_export_deps PACKAGE hsakmt)
+  endif()
+  if(USE_ROCPROFILER_REGISTER AND TARGET rocprofiler-register::rocprofiler-register)
+    list(APPEND _rocshmem_export_deps PACKAGE rocprofiler-register)
+  endif()
+
+  # ROCm 7.13+ ships NUMAConfig.cmake in rocm_sysdeps so find_dependency(NUMA)
+  # works cleanly for consumers. On older ROCm, bake the resolved paths into an
+  # included file since no config-mode NUMA package exists.
+  set(_rocshmem_numa_include)
+  if(${ROCM_MAJOR_VERSION} GREATER 7 OR
+     (${ROCM_MAJOR_VERSION} EQUAL 7 AND ${ROCM_MINOR_VERSION} GREATER_EQUAL 13))
+    # ROCm 7.13+ ships NUMAConfig.cmake in rocm_sysdeps — find_dependency(NUMA)
+    # works for consumers via config mode.
+    if(USE_SDMA OR USE_GDA)
+      list(APPEND _rocshmem_export_deps PACKAGE NUMA)
+    endif()
+  elseif(TARGET numa::numa)
+    # Older ROCm: bake resolved paths so consumers need no FindNUMA.cmake.
     get_target_property(_numa_lib numa::numa IMPORTED_LOCATION)
     get_target_property(_numa_inc numa::numa INTERFACE_INCLUDE_DIRECTORIES)
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/rocshmem-numa-targets.cmake"
@@ -568,23 +583,20 @@ if (NOT BUILD_TESTS_ONLY)
       "set(NUMA_FOUND TRUE)\n")
     unset(_numa_lib)
     unset(_numa_inc)
-  else()
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/rocshmem-numa-targets.cmake" "")
+    set(_rocshmem_numa_include "${CMAKE_CURRENT_BINARY_DIR}/rocshmem-numa-targets.cmake")
   endif()
 
-  set(_rocshmem_export_deps)
-  if(USE_SDMA AND TARGET hsakmt::hsakmt)
-    list(APPEND _rocshmem_export_deps PACKAGE hsakmt)
-  endif()
-  if(USE_ROCPROFILER_REGISTER AND TARGET rocprofiler-register::rocprofiler-register)
-    list(APPEND _rocshmem_export_deps PACKAGE rocprofiler-register)
+  set(_rocshmem_include_arg)
+  if(_rocshmem_numa_include)
+    set(_rocshmem_include_arg INCLUDE "${_rocshmem_numa_include}")
   endif()
   rocm_export_targets(
     TARGETS roc::rocshmem
     NAMESPACE roc::
     DEPENDS ${_rocshmem_export_deps}
-    INCLUDE "${CMAKE_CURRENT_BINARY_DIR}/rocshmem-numa-targets.cmake"
+    ${_rocshmem_include_arg}
   )
+  unset(_rocshmem_include_arg)
   unset(_rocshmem_export_deps)
   include(ROCMPackageConfigHelpers)
   include(ROCMClients)

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -311,8 +311,9 @@ if (NOT BUILD_TESTS_ONLY)
       endif()
     endif()
 
-    if(USE_GDA AND NOT TARGET numa::numa)
-      message(STATUS "libnuma not found. Unable to build GDA")
+    if(NOT TARGET numa::numa)
+      message(STATUS "libnuma not found. Unable to build GDA or SDMA")
+      set(USE_SDMA OFF)
       set(USE_GDA OFF)
       set(GDA_IONIC OFF)
       set(GDA_BNXT OFF)
@@ -360,13 +361,6 @@ if (NOT BUILD_TESTS_ONLY)
     endif()
     set_target_properties(hsakmt::hsakmt PROPERTIES INTERFACE_LINK_LIBRARIES "${_hsakmt_iface_libs}")
     unset(_hsakmt_iface_libs)
-  endif()
-
-  if(USE_ROCPROFILER_REGISTER)
-    find_package(rocprofiler-register QUIET)
-    if(NOT rocprofiler-register_FOUND)
-      message(STATUS "rocprofiler-register not found - rocSHMEM tracing disabled.")
-    endif()
   endif()
 
   if(USE_ROCPROFILER_REGISTER)
@@ -507,10 +501,11 @@ if (NOT BUILD_TESTS_ONLY)
     )
   endif()
 
-  if(rocprofiler-register_FOUND)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE ROCSHMEM_ROCPROFILER_REGISTER=1)
+  if(USE_ROCPROFILER_REGISTER AND TARGET rocprofiler-register::rocprofiler-register)
+    target_compile_definitions(${PROJECT_NAME}
+      PRIVATE ROCSHMEM_ROCPROFILER_REGISTER=1)
     target_link_libraries(${PROJECT_NAME}
-                          PRIVATE rocprofiler-register::rocprofiler-register)
+      PRIVATE rocprofiler-register::rocprofiler-register)
   endif()
 
   if(${ROCM_MAJOR_VERSION} LESS 7)
@@ -556,11 +551,41 @@ if (NOT BUILD_TESTS_ONLY)
       rocm-dev
   )
 
+  # Generate a baked numa::numa imported target file from the paths resolved at
+  # rocshmem build time. This avoids re-detecting NUMA at consumer configure
+  # time (no find_dependency(NUMA), no FindNUMA.cmake, no CMAKE_MODULE_PATH
+  # manipulation) and works regardless of whether a NUMAConfig.cmake exists.
+  if(TARGET numa::numa)
+    get_target_property(_numa_lib numa::numa IMPORTED_LOCATION)
+    get_target_property(_numa_inc numa::numa INTERFACE_INCLUDE_DIRECTORIES)
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/rocshmem-numa-targets.cmake"
+      "if(NOT TARGET numa::numa)\n"
+      "  add_library(numa::numa SHARED IMPORTED)\n"
+      "  set_target_properties(numa::numa PROPERTIES\n"
+      "    IMPORTED_LOCATION \"${_numa_lib}\"\n"
+      "    INTERFACE_INCLUDE_DIRECTORIES \"${_numa_inc}\")\n"
+      "endif()\n"
+      "set(NUMA_FOUND TRUE)\n")
+    unset(_numa_lib)
+    unset(_numa_inc)
+  else()
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/rocshmem-numa-targets.cmake" "")
+  endif()
+
+  set(_rocshmem_export_deps)
+  if(USE_SDMA AND TARGET hsakmt::hsakmt)
+    list(APPEND _rocshmem_export_deps PACKAGE hsakmt)
+  endif()
+  if(USE_ROCPROFILER_REGISTER AND TARGET rocprofiler-register::rocprofiler-register)
+    list(APPEND _rocshmem_export_deps PACKAGE rocprofiler-register)
+  endif()
   rocm_export_targets(
     TARGETS roc::rocshmem
     NAMESPACE roc::
-    DEPENDS PACKAGE NUMA
+    DEPENDS ${_rocshmem_export_deps}
+    INCLUDE "${CMAKE_CURRENT_BINARY_DIR}/rocshmem-numa-targets.cmake"
   )
+  unset(_rocshmem_export_deps)
   include(ROCMPackageConfigHelpers)
   include(ROCMClients)
   rocm_package_setup_component(clients)

--- a/projects/rocshmem/docker/smoketest-rocm-multiversions/Dockerfile
+++ b/projects/rocshmem/docker/smoketest-rocm-multiversions/Dockerfile
@@ -12,6 +12,15 @@
 #   docker build -f docker/smoketest-rocm-multiversions/Dockerfile \
 #     --build-arg ROCSHMEM_REF=develop -t rocshmem-multiversion .
 #
+# Add a TheRock nightly tarball from rocm.nightlies.amd.com:
+#   docker build ... \
+#     --build-arg ROCM_NIGHTLY_VERSION=10.1.0a20260731 \
+#     --build-arg ROCM_NIGHTLY_ARCH=gfx950 \
+#     -t rocshmem-multiversion .
+#   # Or resolve the latest automatically:
+#   docker build ... --build-arg ROCM_NIGHTLY_VERSION=latest \
+#     --build-arg ROCM_NIGHTLY_ARCH=gfx950 -t rocshmem-multiversion .
+#
 # Run (compile-only, no GPU needed):
 #   docker run --rm rocshmem-multiversion --build-only
 #
@@ -139,6 +148,41 @@ RUN if [ -n "${BUILD_THEROCK}" ]; then \
            -DTHEROCK_AMDGPU_FAMILIES="${THEROCK_GPU_FAMILIES}" \
       && cmake --build build \
       && echo "TheRock super-build: OK"; \
+    fi
+
+###############################################################################
+# TheRock nightly tarball (optional)
+# Downloads a pre-built nightly from https://rocm.nightlies.amd.com/tarball-multi-arch/
+# and installs it under /opt/rocm-<version> so build_and_test.sh picks it up.
+#
+# ROCM_NIGHTLY_ARCH:    GPU arch slice, e.g. gfx950, gfx94X (default: gfx94X)
+# ROCM_NIGHTLY_VERSION: version+date string, e.g. 10.1.0a20260731
+#                       Set to "latest" to auto-resolve the most recent build.
+#
+# Examples:
+#   --build-arg ROCM_NIGHTLY_VERSION=10.1.0a20260731
+#   --build-arg ROCM_NIGHTLY_VERSION=latest --build-arg ROCM_NIGHTLY_ARCH=gfx950
+###############################################################################
+ARG ROCM_NIGHTLY_VERSION=
+ARG ROCM_NIGHTLY_ARCH=gfx94X
+ARG ROCM_NIGHTLY_BASE_URL=https://rocm.nightlies.amd.com/tarball-multi-arch
+RUN if [ -n "${ROCM_NIGHTLY_VERSION}" ]; then \
+      arch="${ROCM_NIGHTLY_ARCH}" \
+      && ver="${ROCM_NIGHTLY_VERSION}" \
+      && if [ "${ver}" = "latest" ]; then \
+           ver=$(curl -fsSL "${ROCM_NIGHTLY_BASE_URL}/" \
+                 | grep -oE "therock-dist-linux-${arch}-dcgpu-[0-9]+\.[0-9]+\.[0-9]+a[0-9]+\.tar\.gz" \
+                 | sed "s/therock-dist-linux-${arch}-dcgpu-//;s/\.tar\.gz//" \
+                 | sort -t'a' -k1,1V -k2,2n | tail -1); \
+           echo "Resolved latest nightly: ${ver}"; \
+         fi \
+      && tarball="therock-dist-linux-${arch}-dcgpu-${ver}.tar.gz" \
+      && dest="/opt/rocm-${ver}" \
+      && mkdir -p "${dest}" \
+      && echo "Downloading ${tarball} -> ${dest}" \
+      && curl -fSL "${ROCM_NIGHTLY_BASE_URL}/${tarball}" \
+           | tar -xz -C "${dest}" \
+      && echo "Installed TheRock nightly ${ver} at ${dest}"; \
     fi
 
 ###############################################################################

--- a/projects/rocshmem/docker/smoketest-rocm-multiversions/Dockerfile
+++ b/projects/rocshmem/docker/smoketest-rocm-multiversions/Dockerfile
@@ -66,7 +66,8 @@ RUN mkdir -p /etc/apt/keyrings \
  && for ver in ${ROCM_LEGACY_VERSIONS}; do \
       apt-get install -y rocm${ver}; \
     done \
- && apt-get clean && rm -rf /var/lib/apt/lists/*
+ && apt-get clean && rm -rf /var/lib/apt/lists/* \
+ && { update-alternatives --query rocm >/dev/null 2>&1 && update-alternatives --remove-all rocm; }
 
 ###############################################################################
 # ROCm 7.13 (TheRock repo.amd.com)
@@ -78,12 +79,14 @@ RUN wget -qO- https://repo.amd.com/rocm/packages/gpg/rocm.gpg \
       > /etc/apt/sources.list.d/amdrocm.list \
  && apt-get update \
  && apt-get install -y \
-      amdrocm-core-dev${ROCM_THEROCK_VERSION} \
-      amdrocm-core${ROCM_THEROCK_VERSION}-gfx942 \
-      amdrocm-core${ROCM_THEROCK_VERSION}-gfx950 \
-      amdrocm-developer-tools${ROCM_THEROCK_VERSION} \
-      amdrocm-runtime-dev \
- && ln -sf /opt/rocm/core/.info /opt/rocm/.info \
+      "amdrocm-core-dev${ROCM_THEROCK_VERSION}" \
+      "amdrocm-core${ROCM_THEROCK_VERSION}-gfx942" \
+      "amdrocm-core${ROCM_THEROCK_VERSION}-gfx950" \
+      "amdrocm-developer-tools${ROCM_THEROCK_VERSION}" \
+      "amdrocm-runtime-dev${ROCM_THEROCK_VERSION}" \
+      "amdrocm-runtime${ROCM_THEROCK_VERSION}" \
+      "amdrocm-llvm${ROCM_THEROCK_VERSION}" \
+      "amdrocm-sysdeps${ROCM_THEROCK_VERSION}" \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ###############################################################################
@@ -186,9 +189,20 @@ RUN if [ -n "${ROCM_NIGHTLY_VERSION}" ]; then \
     fi
 
 ###############################################################################
-# Python wheel dependencies
+# Python venv + wheel dependencies
 ###############################################################################
-RUN pip install --break-system-packages pybind11 pytest
+# Install Python build deps declared in rocshmem's own pyproject.toml into a
+# dedicated venv so the system Python install is not modified.
+# COPY from local context so local changes are respected (works for both
+# USE_SRC and ROCSHMEM_REF builds since the build context is always local).
+COPY python/pyproject.toml /tmp/rocshmem-pyproject.toml
+ENV ROCSHMEM_VENV=/opt/rocshmem-venv
+RUN python3 -m venv ${ROCSHMEM_VENV} \
+ && ${ROCSHMEM_VENV}/bin/pip install \
+      $(python3 -c "import tomllib; f=open('/tmp/rocshmem-pyproject.toml','rb'); d=tomllib.load(f); print(' '.join(d.get('build-system',{}).get('requires',[])))") \
+      pytest \
+      pyyaml
+ENV PATH="${ROCSHMEM_VENV}/bin:${PATH}"
 
 ###############################################################################
 # Environment

--- a/projects/rocshmem/docker/smoketest-rocm-multiversions/Dockerfile
+++ b/projects/rocshmem/docker/smoketest-rocm-multiversions/Dockerfile
@@ -1,7 +1,7 @@
 # =============================================================================
 # Multi-ROCm-version rocSHMEM smoketest
 #
-# Installs multiple ROCm versions side-by-side (6.3, 6.4, 7.0, 7.2 + 7.13 TheRock),
+# Installs multiple ROCm versions side-by-side (6.3, 6.4, 7.0, 7.2 + 7.13/7.14 TheRock),
 # builds rocshmem against a default subset, runs ping-pong smoketest + Python wheel.
 #
 # Build from local checkout:
@@ -32,7 +32,8 @@
 FROM ubuntu:24.04
 
 ARG ROCM_LEGACY_VERSIONS="6.3.3 6.4.3 7.0.2 7.2.4"
-ARG ROCM_THEROCK_VERSION=7.13
+ARG ROCM_THEROCK_VERSIONS="7.13 7.14"
+ARG ROCM_THEROCK_GPU_TARGETS="gfx942 gfx950 gfx1250"
 
 ###############################################################################
 # System dependencies
@@ -50,7 +51,7 @@ RUN apt-get update \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ###############################################################################
-# ROCm 6.3 + 7.2 (traditional repo.radeon.com)
+# ROCm legacy versions (traditional repo.radeon.com)
 ###############################################################################
 RUN mkdir -p /etc/apt/keyrings \
  && wget -qO- https://repo.radeon.com/rocm/rocm.gpg.key \
@@ -70,7 +71,7 @@ RUN mkdir -p /etc/apt/keyrings \
  && { update-alternatives --query rocm >/dev/null 2>&1 && update-alternatives --remove-all rocm; }
 
 ###############################################################################
-# ROCm 7.13 (TheRock repo.amd.com)
+# ROCm TheRock versions (repo.amd.com)
 ###############################################################################
 RUN wget -qO- https://repo.amd.com/rocm/packages/gpg/rocm.gpg \
     | gpg --dearmor > /etc/apt/keyrings/amdrocm.gpg \
@@ -78,15 +79,15 @@ RUN wget -qO- https://repo.amd.com/rocm/packages/gpg/rocm.gpg \
       https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404 stable main" \
       > /etc/apt/sources.list.d/amdrocm.list \
  && apt-get update \
- && apt-get install -y \
-      "amdrocm-core-dev${ROCM_THEROCK_VERSION}" \
-      "amdrocm-core${ROCM_THEROCK_VERSION}-gfx942" \
-      "amdrocm-core${ROCM_THEROCK_VERSION}-gfx950" \
-      "amdrocm-developer-tools${ROCM_THEROCK_VERSION}" \
-      "amdrocm-runtime-dev${ROCM_THEROCK_VERSION}" \
-      "amdrocm-runtime${ROCM_THEROCK_VERSION}" \
-      "amdrocm-llvm${ROCM_THEROCK_VERSION}" \
-      "amdrocm-sysdeps${ROCM_THEROCK_VERSION}" \
+ && for ver in ${ROCM_THEROCK_VERSIONS}; do \
+      pkgs="amdrocm-developer-tools${ver} amdrocm-runtime-dev${ver} amdrocm-runtime${ver} amdrocm-llvm${ver} amdrocm-sysdeps${ver}"; \
+      for gpu in ${ROCM_THEROCK_GPU_TARGETS}; do \
+        for pkg in "amdrocm-core${ver}-${gpu}" "amdrocm-core-dev${ver}-${gpu}"; do \
+          apt-cache show "${pkg}" >/dev/null 2>&1 && pkgs="${pkgs} ${pkg}"; \
+        done; \
+      done; \
+      apt-get install -y ${pkgs}; \
+    done \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ###############################################################################
@@ -161,10 +162,6 @@ RUN if [ -n "${BUILD_THEROCK}" ]; then \
 # ROCM_NIGHTLY_ARCH:    GPU arch slice, e.g. gfx950, gfx94X (default: gfx94X)
 # ROCM_NIGHTLY_VERSION: version+date string, e.g. 10.1.0a20260731
 #                       Set to "latest" to auto-resolve the most recent build.
-#
-# Examples:
-#   --build-arg ROCM_NIGHTLY_VERSION=10.1.0a20260731
-#   --build-arg ROCM_NIGHTLY_VERSION=latest --build-arg ROCM_NIGHTLY_ARCH=gfx950
 ###############################################################################
 ARG ROCM_NIGHTLY_VERSION=
 ARG ROCM_NIGHTLY_ARCH=gfx94X

--- a/projects/rocshmem/docker/smoketest-rocm-multiversions/build_and_test.sh
+++ b/projects/rocshmem/docker/smoketest-rocm-multiversions/build_and_test.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 # Default versions to build/test (subset of installed)
-DEFAULT_VERSIONS="6.3.3 7.0.2 7.2.4 7.13"
+DEFAULT_VERSIONS="6.3.3 7.0.2 7.2.4 7.13 7.14"
 
 BUILD_ONLY=false
 ALL_VERSIONS=false
@@ -140,8 +140,11 @@ for rocm_dir in "${ROCM_VERSIONS[@]}"; do
         continue
     fi
 
-    run_step "$version" "cmake install" \
-        cmake --install "$builddir" || true
+    if ! run_step "$version" "cmake install" \
+        cmake --install "$builddir"; then
+        FAIL+=("$version:install")
+        continue
+    fi
 
     # Show NUMA detection result
     echo "--- [$version] NUMA detection ---"
@@ -149,13 +152,35 @@ for rocm_dir in "${ROCM_VERSIONS[@]}"; do
         | grep -v "ADVANCED\|^#" || true
 
     # -----------------------------------------------------------------
-    # 2. Functional smoke test (ping-pong, 2 PEs)
+    # 2. Examples build (external package smoke test)
+    # Builds the examples directory as a standalone CMake project against
+    # the installed rocshmem, validating the exported cmake config.
+    # -----------------------------------------------------------------
+    examplesdir="/app/build-examples-${version}"
+    if ! run_step "$version" "examples build" \
+        env PATH="${rocm_dir}/bin:${rocm_dir}/llvm/bin:${PATH}" \
+            LD_LIBRARY_PATH="${rocm_dir}/lib:${LD_LIBRARY_PATH:-}" \
+        cmake -S "$SRC/examples" -B "$examplesdir" \
+            -Drocshmem_ROOT="${installdir}" \
+            -DCMAKE_PREFIX_PATH="${installdir};${rocm_dir}" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DMPI_ROOT="$OMPI"; then
+        FAIL+=("$version:examples-configure")
+        ok=false
+    elif ! run_step "$version" "examples compile" \
+        cmake --build "$examplesdir" --parallel "$(nproc)"; then
+        FAIL+=("$version:examples-compile")
+        ok=false
+    fi
+
+    # -----------------------------------------------------------------
+    # 3. Functional smoke test (ping-pong, 2 PEs)
     # -----------------------------------------------------------------
     if [[ "$BUILD_ONLY" == false && "$HAS_GPU" == true ]]; then
         run_step "$version" "putnbi test" \
             env LD_LIBRARY_PATH="${rocm_dir}/lib:${LD_LIBRARY_PATH}" \
             mpiexec -n 2 "$builddir/tests/functional_tests/rocshmem_functional_tests" \
-                -a 3 -w 1 -z 256 \
+                -a 31 -w 1 -z 256 \
             || { FAIL+=("$version:putnbi"); ok=false; }
     fi
 

--- a/projects/rocshmem/docker/smoketest-rocm-multiversions/build_and_test.sh
+++ b/projects/rocshmem/docker/smoketest-rocm-multiversions/build_and_test.sh
@@ -110,9 +110,14 @@ for rocm_dir in "${ROCM_VERSIONS[@]}"; do
 
     # -----------------------------------------------------------------
     # 1. CMake configure + build + install
+    # Prepend rocm_dir to PATH and LD_LIBRARY_PATH so compiler wrappers,
+    # hipconfig, and shared libraries resolve to the target ROCm version
+    # rather than whatever /opt/rocm symlinks to.
     # -----------------------------------------------------------------
     mkdir -p "$builddir"
     if ! run_step "$version" "cmake configure" \
+        env PATH="${rocm_dir}/bin:${rocm_dir}/llvm/bin:${PATH}" \
+            LD_LIBRARY_PATH="${rocm_dir}/lib:${LD_LIBRARY_PATH:-}" \
         cmake -S "$SRC" -B "$builddir" \
             -DCMAKE_PREFIX_PATH="$rocm_dir" \
             -DCMAKE_INSTALL_PREFIX="$installdir" \
@@ -128,6 +133,8 @@ for rocm_dir in "${ROCM_VERSIONS[@]}"; do
     fi
 
     if ! run_step "$version" "cmake build" \
+        env PATH="${rocm_dir}/bin:${rocm_dir}/llvm/bin:${PATH}" \
+            LD_LIBRARY_PATH="${rocm_dir}/lib:${LD_LIBRARY_PATH:-}" \
         cmake --build "$builddir" --parallel "$(nproc)"; then
         FAIL+=("$version:build")
         continue
@@ -158,15 +165,17 @@ for rocm_dir in "${ROCM_VERSIONS[@]}"; do
     if [[ "$NO_WHEEL" == false && -d "$SRC/python" ]]; then
         run_step "$version" "python wheel" \
             env ROCM_PATH="$rocm_dir" ROCSHMEM_HOME="$installdir" \
-                pip install --no-build-isolation --break-system-packages \
+                pip install --no-build-isolation \
                     -e "$SRC/python" \
             || { FAIL+=("$version:wheel"); ok=false; }
 
-        # Python smoke test (needs GPU)
+        # Python smoke test (needs GPU, run under mpiexec so OMPI_COMM_WORLD_SIZE
+        # is set and rocshmem initializes correctly with 2 PEs)
         if [[ "$BUILD_ONLY" == false && "$HAS_GPU" == true ]]; then
             run_step "$version" "python smoke test" \
                 env ROCM_PATH="$rocm_dir" ROCSHMEM_HOME="$installdir" \
-                    python3 -m pytest "$SRC/python/tests/test_smoke.py" -v \
+                    LD_LIBRARY_PATH="${rocm_dir}/lib:${LD_LIBRARY_PATH:-}" \
+                mpiexec -n 2 python3 -m pytest "$SRC/python/tests/test_smoke.py" -v \
                 || { FAIL+=("$version:pytest"); ok=false; }
         fi
     fi

--- a/projects/rocshmem/docker/smoketest-rocm-multiversions/build_and_test.sh
+++ b/projects/rocshmem/docker/smoketest-rocm-multiversions/build_and_test.sh
@@ -146,6 +146,7 @@ for rocm_dir in "${ROCM_VERSIONS[@]}"; do
     # -----------------------------------------------------------------
     if [[ "$BUILD_ONLY" == false && "$HAS_GPU" == true ]]; then
         run_step "$version" "putnbi test" \
+            env LD_LIBRARY_PATH="${rocm_dir}/lib:${LD_LIBRARY_PATH}" \
             mpiexec -n 2 "$builddir/tests/functional_tests/rocshmem_functional_tests" \
                 -a 3 -w 1 -z 256 \
             || { FAIL+=("$version:putnbi"); ok=false; }

--- a/projects/rocshmem/examples/CMakeLists.txt
+++ b/projects/rocshmem/examples/CMakeLists.txt
@@ -26,7 +26,9 @@ cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
 ###############################################################################
 # PROJECT
 ###############################################################################
-include(${CMAKE_SOURCE_DIR}/cmake/setup_project.cmake)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/setup_project.cmake")
+  include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/setup_project.cmake)
+endif()
 project(rocshmem_examples VERSION 1.0.0 LANGUAGES CXX)
 
 find_package(MPI)
@@ -34,6 +36,7 @@ find_package(hip REQUIRED)
 if (NOT TARGET roc::rocshmem)
   find_package(rocshmem REQUIRED)
 endif()
+message(STATUS "Found rocshmem: ${rocshmem_DIR} (found version \"${rocshmem_VERSION}\")")
 
 ###############################################################################
 # SOURCES

--- a/projects/rocshmem/python/pyproject.toml
+++ b/projects/rocshmem/python/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-# nanobind is the binding backend (used by TheRock).
+# Keep in sync with TheRock's authoritative build recipe:
+#   https://github.com/ROCm/TheRock/blob/main/comm-libs/CMakeLists.txt
+#   https://github.com/ROCm/TheRock/blob/main/comm-libs/artifact-rocshmem.toml
 requires = [
     "setuptools>=40.8.0",
     "wheel",

--- a/projects/rocshmem/src/api_trace.cc
+++ b/projects/rocshmem/src/api_trace.cc
@@ -144,9 +144,9 @@ RocshmemGetFunctionTable_impl()
             table_array.data(), table_array.size(), &lib_id);
 
     if(rocp_reg_status != ROCP_REG_SUCCESS && rocp_reg_status != ROCP_REG_NO_TOOLS) {
-        fprintf(stderr, "[rocprofiler-sdk-rocshmem][%d] rocprofiler-register failed with error code %d : %s\n",
-                getpid(), rocp_reg_status,
-                rocprofiler_register_error_string(rocp_reg_status));
+        LOG_WARN("[rocprofiler-sdk-rocshmem][%d] rocprofiler-register failed with error code %d : %s\n",
+                 getpid(), rocp_reg_status,
+                 rocprofiler_register_error_string(rocp_reg_status));
     }
 #endif
 


### PR DESCRIPTION
## Motivation

find_package(rocshmem) requires a number of dependencies to be also found in consumer code: libnuma, rocprofiler-register, hsakmt. 

These are added to the roc::rocshmem target as dependencies but they are not automatically resolved at find_package(rocshmem) time


## Technical Details

Add the required behavior changes to `rocm_export_targets` so that these dependencies get resolved automatically upon consumer code invocation. 

THere is a difference in behavior for libnuma between pre-7.13 and post 7.13 as in prior versions we would import system numa, rather than in later versions /opt/rocm/sysdeps provided libnuma. 

## Issue Tracking

JIRA ID: ROCM-28794, AIROCSHMEM-471

## Test Plan

Can build the pytorch enabled wheel using the docker smoketest multiversion 

## Test Result

* [ ] can build rocshmem enabled pytorch on nightly therock

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
