### PR TITLE
refactor(rocprofiler-sdk): address review feedback on #8891 for remove-callbacks-counters

### DIFF
--- a/projects/rocprofiler-sdk/source/docs/conceptual/queue_hooks/queue_callback_removal_architecture.md
+++ b/projects/rocprofiler-sdk/source/docs/conceptual/queue_hooks/queue_callback_removal_architecture.md
@@ -1,0 +1,208 @@
+# Queue Callback Registry Removal — Software Architecture
+
+How queue-interposed services are wired into dispatch interception after the per-queue callback
+registry is removed, why completion routing and enqueue routing deliberately use different context
+sets, and why `stop_context` drains the GPU.
+
+Paths are relative to `projects/rocprofiler-sdk/source/`. Symbols are named rather than cited by
+line number, since line numbers rot faster than the code they point at.
+
+The migration is one PR per service. Counter collection (#8891) introduces the shared
+`hsa/queue_hooks/` infrastructure that the rest build on; SPM (#8887), thread trace (#8790) and PC
+sampling (#8895) follow the same shape. This document describes the mechanism as a whole, and flags
+which service each part currently lives on.
+
+## 1. Diagram
+
+```mermaid
+flowchart TB
+
+  subgraph BEFORE["BEFORE — per-queue callback registry"]
+    direction TB
+    B1["service start_context"]
+    B2["QueueController::add_callback<br/>auto-incrementing ClientID"]
+    B3["Queue::_callbacks map<br/>ClientID -> queue_callbacks_t<br/>_notifiers counter"]
+    B4["WriteInterceptor<br/>queue.signal_callback(...)<br/>iterate map, call write_interceptor"]
+    B5["AsyncSignalHandler<br/>queue.signal_callback(...)<br/>iterate map, call completed_cb"]
+    B6["captured context + callback refs<br/><b>routing by provenance</b>:<br/>a registered callback fires even<br/>after its context is stopped"]
+    B1 --> B2 --> B3
+    B3 --> B4
+    B3 --> B5
+    B3 --- B6
+  end
+
+  subgraph AFTER["AFTER — explicit hooks"]
+    direction TB
+    C1["service start_context<br/>no registration"]
+    C2["WriteInterceptor<br/><b>counters::kernel_dispatch_phase_enter_hook</b><br/>called inline, unconditionally"]
+    C3["counters::is_any_active<br/>folded into no_real_consumers and<br/>forces should_batch_packets = false"]
+    C4["AsyncSignalHandler<br/><b>counters::kernel_dispatch_phase_exit_hook</b><br/>called inline"]
+    C5["hsa/queue_hooks/client_ids.hpp<br/>stable producer tags<br/>COUNTERS / SPM / THREAD_TRACE"]
+    C1 --> C2
+    C2 --> C3
+    C1 --> C4
+    C2 --- C5
+    C4 --- C5
+  end
+
+  subgraph ROUTE["ROUTING — the two context sets are not interchangeable"]
+    direction TB
+    R1["<b>enter hook: get_active_contexts</b><br/>new instrumentation must stop<br/>as soon as the context stops"]
+    R2["<b>exit hook: get_registered_contexts</b><br/>work already on the GPU must<br/>still be able to complete"]
+    R3["using active contexts in the exit hook<br/>drops the completion of any dispatch<br/>in flight at stop_context:<br/>record never delivered,<br/>packet_return_map entry leaked"]
+    R2 -.->|"if this were<br/>get_active_contexts"| R3
+  end
+
+  subgraph STOP["STOP PATH — ordering is load-bearing"]
+    direction TB
+    S1["context::stop_context stops<br/>queue-interposed services <b>before</b><br/>clearing the active slot"]
+    S2["counters::stop_context<br/>1. clear the enabled flag<br/>2. queue_controller_sync (drain)<br/>3. disable_serialization<br/>4. callback_thread_stop"]
+    S3["the service stays visible for the<br/>whole drain, so queue_cb's disabled<br/>path keeps returning serialize=true<br/>and no separate draining flag is needed"]
+    S1 --> S2 --> S3
+  end
+
+  BEFORE ==> AFTER
+  AFTER ==> ROUTE
+  ROUTE ==> STOP
+
+  classDef old fill:#eceff1,stroke:#546e7a,stroke-width:2px,color:#000
+  classDef new fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px,color:#000
+  classDef bad fill:#ffebee,stroke:#c62828,stroke-width:2px,color:#000
+  classDef fix fill:#e3f2fd,stroke:#1565c0,stroke-width:2px,color:#000
+  class B1,B2,B3,B4,B5,B6 old
+  class C1,C2,C3,C4,C5 new
+  class R3 bad
+  class R1,R2,S1,S2,S3 fix
+```
+
+## 2. What the migration changes
+
+Before, a service registered a `queue_callbacks_t` pair with the queue controller when its context
+started. The write interceptor and the async signal handler both walked `Queue::_callbacks` and
+invoked whatever was registered, and `Queue::get_notifiers()` counted the registrations so the
+interceptor could early-out when nothing was subscribed.
+
+After, the service registers nothing. The write interceptor and the async signal handler call the
+service's hooks directly, and each hook decides for itself whether it has work to do by querying the
+context list.
+
+For counter collection:
+
+| Element | Location |
+|---|---|
+| `counters::kernel_dispatch_phase_enter_hook` | `counters/queue_hooks.hpp`, `counters/queue_hooks.cpp` |
+| `counters::kernel_dispatch_phase_exit_hook` | `counters/queue_hooks.hpp`, `counters/queue_hooks.cpp` |
+| `counters::is_any_active` | `counters/queue_hooks.hpp`, `counters/queue_hooks.cpp` |
+| Context filter shared by all three | `counters/queue_hooks.cpp`, `counter_contexts_filter()` |
+| Stable producer tags | `hsa/queue_hooks/client_ids.hpp` |
+| Exit hook call site | `hsa/queue.cpp`, in the async signal handler |
+| `no_real_consumers` gains `!counters::is_any_active()` | `hsa/queue.cpp` |
+| Enter hook call site | `hsa/queue.cpp`, in the write interceptor |
+| Batching disabled while counters are active | `hsa/queue.cpp`, `should_batch_packets` |
+| Service stop path | `counters/core.cpp`, `stop_context()` |
+
+The hook names describe the dispatch phase they run in: the enter hook runs when a dispatch is being
+submitted, the exit hook when its completion signal fires. `is_any_active` is neither phase, so it
+keeps a plain name. Each remaining service mirrors this trio in its own `queue_hooks.{hpp,cpp}`.
+
+`client_ids.hpp` replaces the registry's auto-incrementing `ClientID` with fixed producer tags, so
+the id attached to an instrumentation packet no longer depends on the order in which services
+happened to register. The tags numerically overlap the registry's `ClientID`, which also starts at 1
+and remains in use by services that have not migrated yet. That is inert only because no consumer
+dispatches on the tag — each service identifies its own packets by pointer lookup or `dynamic_cast`
+— and `client_ids.hpp` records what has to change before anything routes on these values.
+
+## 3. Enqueue and completion use different context sets
+
+This is the central design point, and getting it wrong is a silent data-loss bug rather than a crash.
+
+The registry routed completions by **provenance**: the callback pair captured at enqueue time was
+invoked when the packet completed, regardless of whether the owning context was still active. The
+hooks have to reproduce that property without the registry, and they do it by choosing different
+context sets for the two phases:
+
+- The **enter hook** iterates `get_active_contexts`. New instrumentation must stop being added as
+  soon as the context stops.
+- The **exit hook** iterates `get_registered_contexts`. A dispatch already executing on the GPU must
+  still be able to deliver its record, even though its context is no longer active.
+
+Routing the exit hook over active contexts instead loses any dispatch that is in flight when its
+context is stopped: `completed_cb` never runs, so the record is never delivered to the tool, and the
+`packet_return_map` entry is never erased, leaking the AQL packet and its profile allocation. Because
+pause/resume is implemented as `stop_context`/`start_context`, this shows up as missing counter
+records around every pause.
+
+Iterating registered contexts is safe because `completed_cb` self-filters: it resolves ownership by
+looking the packet up in its own context's `packet_return_map` and returns early for packets it does
+not own. Each context therefore still processes only its own packets, and the guarantee is restored
+without reintroducing a registry.
+
+## 4. The stop path
+
+Two orderings matter, both stated at their call sites in the code.
+
+**`context::stop_context` stops queue-interposed services before clearing the active slot.** Counter
+collection, SPM, device thread trace and dispatch thread trace are all stopped ahead of the
+`compare_exchange_strong` that nulls the context's active slot. Clearing the slot first opens a
+window in which the enter hook sees no active context, so a dispatch is submitted without serializer
+packets while the serializer is still enabled.
+
+**`counters::stop_context` drains the GPU before disabling serialization.** The order is: clear the
+service's `enabled` flag, `hsa::queue_controller_sync()`, `disable_serialization()`, then
+`callback_thread_stop()`.
+
+### 4.1 Why the drain is kept
+
+Provenance routing and the drain answer different questions, so one does not replace the other.
+Provenance routing guarantees that a completion which *arrives* is delivered. The drain bounds
+*when completions arrive at all*, which is what the teardown downstream of it depends on: it is what
+makes "the callback thread and the `counter_callback_info` objects outlive every in-flight dispatch"
+true literally, rather than true by an argument about what happens if they do not.
+
+The supporting facts are worth recording, because they are the reason a missing drain is hard to
+notice rather than a reason to omit it:
+
+| Property | Why it holds |
+|---|---|
+| `counter_callback_info` lifetime | Structural. The context holds them as `std::vector<std::shared_ptr<...>>` on the service, and neither `counters::stop_context` nor `context::stop_context` clears that vector. Since the exit hook iterates *registered* contexts, the context and its callbacks are still reachable. |
+| Callback thread does not strand queued work | `consumer_thread_t::exit()` clears `valid` then waits on `exited`, and `consumer_loop` only sets `exited` once `read_ptr == write_ptr`, so the queue drains before the join. Afterwards `consumer_thread_t::add()` takes the self-consume path and runs inline on the caller. Covered by `counters/tests/consumer_test.cpp`, `restart`. |
+| Serializer transition with in-flight serialized dispatches | GPU-ordered independently. `profiler_serializer::disable()` records the previous state and pushes an `hsa_barrier` across the queues, and `kernel_completion_signal` reconciles in-flight dispatches against it. |
+| No separate "draining" flag is needed | `context::stop_context` calls the service stop path while the context is still in the active list, so throughout the drain the enter hook still reaches `queue_cb`, whose disabled path returns `serialize=true` and keeps the serialized-to-unserialized transition coordinated. This only works because the drain happens before the slot is cleared. |
+
+The drain is a bound, not a hard barrier: `Queue::sync` uses a five-second hint and only warns on
+timeout, and `_active_kernels` counts intercepted dispatches only. It is the ordering guarantee for
+teardown, and provenance routing in the exit hook is what makes individual completions correct.
+
+One hazard is not covered by either mechanism: the drain incidentally protects the sequence "stop the
+context, then destroy the counter config". If a tool does that, the guard belongs at the destroy
+path as a drain or a refcount, since that is where the lifetime actually ends.
+
+## 5. Relationship to kernel replay (#8622)
+
+Callback removal is a soft prerequisite for kernel replay, not a blocker, and the two can land in
+either order.
+
+It helps because with the registry there is no explicit "if this context is active" block in the
+write interceptor — the decision is hidden inside the registered callbacks, so disabling a service
+for a single replay pass means mutating the callback structure. Once the hooks are inline, the
+interceptor has an explicit conditional on context activity, which is a much easier place to express
+that a context is active globally but inactive for this pass.
+
+The routing rule in section 3 matters more under replay than without it. Replay runs N passes per
+dispatch and reuses `process_packet_batch` for each pass, so every pass creates its own
+instrumentation packet and its own `packet_return_map` entry. A dropped completion is one lost record
+without replay; under replay it is N leaked packets per dispatch plus silently missing counter
+groups. The replay loop also waits on its `pass_done` barrier with no timeout, so a stall on the
+completion path becomes an application hang rather than data loss.
+
+## 6. Known gaps
+
+1. Thread trace, PC sampling and device counter collection still use the registry, so
+   `Queue::_callbacks`, `Queue::get_notifiers()` and `QueueController::add_callback` cannot be
+   deleted yet. `client_ids.hpp` already reserves tags for thread trace and PC sampling.
+2. Several in-flight PRs edit the same `no_real_consumers` expression in `hsa/queue.cpp`.
+   Consolidating the predicate into one `needs_interception(queue)` helper would remove the
+   recurring conflict.
+3. `counters::is_any_active()` forces `should_batch_packets = false` for every dispatch while any
+   counter context is active. The performance effect of that, combined with kernel replay's own
+   gate, has not been measured.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -368,24 +368,26 @@ stop_context(rocprofiler_context_id_t idx)
         const context* _expected = itr.load(std::memory_order_acquire);
         if(_expected && _expected->context_idx == idx.handle)
         {
+            // Stop queue-interposed services while the context is still in the active list so
+            // write_hook can coordinate serialized->unserialized transitions during drain.
+            if(_expected->dispatch_counter_collection)
+            {
+                rocprofiler::counters::stop_context(const_cast<context*>(_expected));
+            }
+
+            if(_expected->dispatch_spm)
+                rocprofiler::spm::stop_context(const_cast<context*>(_expected));
+
+            if(_expected->device_thread_trace) _expected->device_thread_trace->stop_context();
+            if(_expected->dispatch_thread_trace)
+                _expected->dispatch_thread_trace->stop_context();
+
             bool success = itr.compare_exchange_strong(_expected, nullptr);
 
             if(success)
             {
                 auto nactive = get_num_active_contexts().load(std::memory_order_acquire);
                 if(nactive > 0) get_num_active_contexts().fetch_sub(1, std::memory_order_release);
-
-                if(_expected->dispatch_counter_collection)
-                {
-                    rocprofiler::counters::stop_context(const_cast<context*>(_expected));
-                }
-
-                if(_expected->dispatch_spm)
-                    rocprofiler::spm::stop_context(const_cast<context*>(_expected));
-
-                if(_expected->device_thread_trace) _expected->device_thread_trace->stop_context();
-                if(_expected->dispatch_thread_trace)
-                    _expected->dispatch_thread_trace->stop_context();
 
                 rocprofiler::hsa::queue_interposition::
                     notify_queue_interposition_consumer_context_stopped(_expected);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -368,8 +368,11 @@ stop_context(rocprofiler_context_id_t idx)
         const context* _expected = itr.load(std::memory_order_acquire);
         if(_expected && _expected->context_idx == idx.handle)
         {
-            // Stop queue-interposed services while the context is still in the active list so
-            // write_hook can coordinate serialized->unserialized transitions during drain.
+            // Stop queue-interposed services before clearing the active slot so
+            // disable_serialization() always runs before dispatches stop being instrumented.
+            // Clearing the slot first opens the opposite window, in which write_hook sees no
+            // active context and a dispatch is submitted without serializer packets while the
+            // serializer is still enabled.
             if(_expected->dispatch_counter_collection)
             {
                 rocprofiler::counters::stop_context(const_cast<context*>(_expected));

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -119,11 +119,10 @@ get_registered_contexts(context_array_t& data, context_filter_t filter)
     data.reserve(num_ctx);
     for(auto& itr : *get_registered_contexts_impl())
     {
+        if(!itr.has_value()) continue;
+
         const auto* ctx = &itr.value();
-        if(ctx)
-        {
-            if(!filter || (filter && filter(ctx))) data.emplace_back(ctx);
-        }
+        if(!filter || (filter && filter(ctx))) data.emplace_back(ctx);
     }
     return data;
 }
@@ -422,6 +421,8 @@ get_client_contexts(rocprofiler_client_id_t id)
 
     for(auto& itr : *get_registered_contexts_impl())
     {
+        if(!itr.has_value()) continue;
+
         if(itr->client_idx == id.handle)
         {
             _data.emplace_back(rocprofiler_context_id_t{.handle = itr->context_idx});
@@ -438,6 +439,8 @@ stop_client_contexts(rocprofiler_client_id_t client_id)
     auto ret = ROCPROFILER_STATUS_SUCCESS;
     for(auto& itr : *get_registered_contexts_impl())
     {
+        if(!itr.has_value()) continue;
+
         if(itr->client_idx == client_id.handle)
         {
             auto status = stop_context(rocprofiler_context_id_t{itr->context_idx});
@@ -472,6 +475,8 @@ deregister_client_contexts(rocprofiler_client_id_t client_id)
 {
     for(auto& itr : *get_registered_contexts_impl())
     {
+        if(!itr.has_value()) continue;
+
         if(itr->client_idx == client_id.handle && buffer::get_buffers())
         {
             for(auto& bitr : *buffer::get_buffers())

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -370,9 +370,9 @@ stop_context(rocprofiler_context_id_t idx)
         {
             // Stop queue-interposed services before clearing the active slot so
             // disable_serialization() always runs before dispatches stop being instrumented.
-            // Clearing the slot first opens the opposite window, in which write_hook sees no
-            // active context and a dispatch is submitted without serializer packets while the
-            // serializer is still enabled.
+            // Clearing the slot first opens the opposite window, in which
+            // kernel_dispatch_phase_enter_hook sees no active context and a dispatch is submitted
+            // without serializer packets while the serializer is still enabled.
             if(_expected->dispatch_counter_collection)
             {
                 rocprofiler::counters::stop_context(const_cast<context*>(_expected));
@@ -382,8 +382,7 @@ stop_context(rocprofiler_context_id_t idx)
                 rocprofiler::spm::stop_context(const_cast<context*>(_expected));
 
             if(_expected->device_thread_trace) _expected->device_thread_trace->stop_context();
-            if(_expected->dispatch_thread_trace)
-                _expected->dispatch_thread_trace->stop_context();
+            if(_expected->dispatch_thread_trace) _expected->dispatch_thread_trace->stop_context();
 
             bool success = itr.compare_exchange_strong(_expected, nullptr);
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
@@ -182,13 +182,17 @@ stop_context(const context::context* ctx)
 
     if(controller)
     {
-        // Drain in-flight dispatches while the context remains in the active list (see
-        // context::stop_context ordering). Completions are routed via registered contexts in
-        // counters::signal_completion_hook.
-        hsa::queue_controller_sync();
+        // No GPU drain here. In-flight dispatches are handled by signal_completion_hook routing
+        // over registered rather than active contexts; the serializer transition is reconciled
+        // GPU-side by the hsa_barrier that profiler_serializer::disable() pushes.
         controller->disable_serialization();
+        // No per-queue callback to remove; counters::write_hook no-ops once
+        // dispatch_counter_collection is disabled above.
     }
 
+    // Safe with completions still outstanding: consumer_thread_t::exit() waits until the queue is
+    // empty before joining, and consumer_thread_t::add() consumes inline once the thread is gone,
+    // so a completion arriving after this point is still processed on the async handler thread.
     callback_thread_stop();
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
@@ -162,8 +162,8 @@ start_context(const context::context* ctx)
     if(!already_enabled)
     {
         // Counter collection no longer registers a per-queue callback with the queue
-        // controller; the HSA write interceptor calls counters::write_hook /
-        // signal_completion_hook directly (see hsa/queue.cpp). Keep the callback thread.
+        // controller; the HSA write interceptor calls counters::kernel_dispatch_phase_enter_hook /
+        // kernel_dispatch_phase_exit_hook directly (see hsa/queue.cpp). Keep the callback thread.
         callback_thread_start();
     }
 }
@@ -182,11 +182,11 @@ stop_context(const context::context* ctx)
 
     if(controller)
     {
-        // No GPU drain here. In-flight dispatches are handled by signal_completion_hook routing
-        // over registered rather than active contexts; the serializer transition is reconciled
-        // GPU-side by the hsa_barrier that profiler_serializer::disable() pushes.
+        // No GPU drain here. In-flight dispatches are handled by kernel_dispatch_phase_exit_hook
+        // routing over registered rather than active contexts; the serializer transition is
+        // reconciled GPU-side by the hsa_barrier that profiler_serializer::disable() pushes.
         controller->disable_serialization();
-        // No per-queue callback to remove; counters::write_hook no-ops once
+        // No per-queue callback to remove; counters::kernel_dispatch_phase_enter_hook no-ops once
         // dispatch_counter_collection is disabled above.
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
@@ -182,9 +182,11 @@ stop_context(const context::context* ctx)
 
     if(controller)
     {
+        // Drain in-flight dispatches while the context remains in the active list (see
+        // context::stop_context ordering). Completions are routed via registered contexts in
+        // counters::signal_completion_hook.
+        hsa::queue_controller_sync();
         controller->disable_serialization();
-        // No per-queue callback to remove; counters::write_hook no-ops once
-        // dispatch_counter_collection is disabled above.
     }
 
     callback_thread_stop();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
@@ -182,17 +182,26 @@ stop_context(const context::context* ctx)
 
     if(controller)
     {
-        // No GPU drain here. In-flight dispatches are handled by kernel_dispatch_phase_exit_hook
-        // routing over registered rather than active contexts; the serializer transition is
-        // reconciled GPU-side by the hsa_barrier that profiler_serializer::disable() pushes.
+        // Drain in-flight dispatches before anything else is torn down. The review of #8891
+        // accepted provenance-based completion routing on the condition that the callback thread
+        // and the counter_callback_info objects stay alive until in-flight dispatches drain, so the
+        // drain is what makes that condition hold literally rather than by argument.
+        //
+        // context::stop_context calls this function while the context is still in the active list,
+        // which is what keeps the service visible for the duration of the drain: the enter hook
+        // still reaches queue_cb, and queue_cb's disabled path returns serialize=true so the
+        // serialized->unserialized transition stays coordinated until disable_serialization() runs
+        // below. That ordering is why no separate "draining" flag is needed -- but it only works
+        // because the drain happens here, before the slot is cleared.
+        hsa::queue_controller_sync();
         controller->disable_serialization();
         // No per-queue callback to remove; counters::kernel_dispatch_phase_enter_hook no-ops once
         // dispatch_counter_collection is disabled above.
     }
 
-    // Safe with completions still outstanding: consumer_thread_t::exit() waits until the queue is
-    // empty before joining, and consumer_thread_t::add() consumes inline once the thread is gone,
-    // so a completion arriving after this point is still processed on the async handler thread.
+    // After the drain. consumer_thread_t::exit() also waits until its queue is empty before
+    // joining, and add() consumes inline once the thread is gone, so a late completion is still
+    // processed -- but that is a backstop, not the guarantee the review asked for.
     callback_thread_stop();
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/queue_hooks.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/queue_hooks.cpp
@@ -83,8 +83,9 @@ kernel_dispatch_phase_exit_hook(const hsa::Queue& /*queue*/,
 {
     // Route by packet provenance, not current activeness: completed_cb self-filters via
     // packet_return_map, so in-flight dispatches still complete after stop_context removes the
-    // context from the active list. This is the mechanism that makes stop_context safe without a
-    // GPU drain, and it is also what kernel replay needs, since each pass completes separately.
+    // context from the active list. This is what guarantees a completion that arrives is delivered;
+    // the drain in stop_context is what bounds when completions arrive. Kernel replay needs the
+    // same property, since each pass completes separately.
     auto contexts = context::get_registered_contexts(counter_contexts_filter());
     for(const auto* ctx : contexts)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/queue_hooks.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/queue_hooks.cpp
@@ -82,7 +82,8 @@ signal_completion_hook(const hsa::Queue& /*queue*/,
 {
     // Route by packet provenance, not current activeness: completed_cb self-filters via
     // packet_return_map, so in-flight dispatches still complete after stop_context removes the
-    // context from the active list (required for kernel replay and ordinary stop/drain).
+    // context from the active list. This is the mechanism that makes stop_context safe without a
+    // GPU drain, and it is also what kernel replay needs, since each pass completes separately.
     auto contexts = context::get_registered_contexts(counter_contexts_filter());
     for(const auto* ctx : contexts)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/queue_hooks.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/queue_hooks.cpp
@@ -32,7 +32,7 @@ namespace counters
 namespace
 {
 auto
-active_counter_contexts_filter()
+counter_contexts_filter()
 {
     return [](const context::context* ctx) -> bool {
         return ctx && ctx->dispatch_counter_collection != nullptr;
@@ -51,7 +51,7 @@ write_hook(const hsa::Queue&                                        queue,
            hsa::inst_pkt_t&                                         inst_pkt,
            bool&                                                    is_serialized)
 {
-    auto active = context::get_active_contexts(active_counter_contexts_filter());
+    auto active = context::get_active_contexts(counter_contexts_filter());
     for(const auto* ctx : active)
     {
         for(auto& cb : ctx->dispatch_counter_collection->callbacks)
@@ -80,8 +80,11 @@ signal_completion_hook(const hsa::Queue& /*queue*/,
                        hsa::inst_pkt_t&                            inst_pkt,
                        kernel_dispatch::profiling_time             dispatch_time)
 {
-    auto active = context::get_active_contexts(active_counter_contexts_filter());
-    for(const auto* ctx : active)
+    // Route by packet provenance, not current activeness: completed_cb self-filters via
+    // packet_return_map, so in-flight dispatches still complete after stop_context removes the
+    // context from the active list (required for kernel replay and ordinary stop/drain).
+    auto contexts = context::get_registered_contexts(counter_contexts_filter());
+    for(const auto* ctx : contexts)
     {
         for(auto& cb : ctx->dispatch_counter_collection->callbacks)
         {
@@ -93,7 +96,7 @@ signal_completion_hook(const hsa::Queue& /*queue*/,
 bool
 is_any_active()
 {
-    return !context::get_active_contexts(active_counter_contexts_filter()).empty();
+    return !context::get_active_contexts(counter_contexts_filter()).empty();
 }
 }  // namespace counters
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/queue_hooks.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/queue_hooks.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -41,15 +41,16 @@ counter_contexts_filter()
 }  // namespace
 
 void
-write_hook(const hsa::Queue&                                        queue,
-           const hsa::rocprofiler_packet&                           kernel_packet,
-           rocprofiler_kernel_id_t                                  kernel_id,
-           rocprofiler_dispatch_id_t                                dispatch_id,
-           rocprofiler_user_data_t*                                 user_data,
-           const hsa::queue_info_session_t::external_corr_id_map_t& ext_corr_ids,
-           const context::correlation_id*                           correlation_id,
-           hsa::inst_pkt_t&                                         inst_pkt,
-           bool&                                                    is_serialized)
+kernel_dispatch_phase_enter_hook(
+    const hsa::Queue&                                        queue,
+    const hsa::rocprofiler_packet&                           kernel_packet,
+    rocprofiler_kernel_id_t                                  kernel_id,
+    rocprofiler_dispatch_id_t                                dispatch_id,
+    rocprofiler_user_data_t*                                 user_data,
+    const hsa::queue_info_session_t::external_corr_id_map_t& ext_corr_ids,
+    const context::correlation_id*                           correlation_id,
+    hsa::inst_pkt_t&                                         inst_pkt,
+    bool&                                                    is_serialized)
 {
     auto active = context::get_active_contexts(counter_contexts_filter());
     for(const auto* ctx : active)
@@ -73,12 +74,12 @@ write_hook(const hsa::Queue&                                        queue,
 }
 
 void
-signal_completion_hook(const hsa::Queue& /*queue*/,
-                       const hsa::rocprofiler_packet& /*kernel_packet*/,
-                       std::shared_ptr<hsa::queue_info_session_t>& session,
-                       hsa::packet_data_t&                         packet,
-                       hsa::inst_pkt_t&                            inst_pkt,
-                       kernel_dispatch::profiling_time             dispatch_time)
+kernel_dispatch_phase_exit_hook(const hsa::Queue& /*queue*/,
+                                const hsa::rocprofiler_packet& /*kernel_packet*/,
+                                std::shared_ptr<hsa::queue_info_session_t>& session,
+                                hsa::packet_data_t&                         packet,
+                                hsa::inst_pkt_t&                            inst_pkt,
+                                kernel_dispatch::profiling_time             dispatch_time)
 {
     // Route by packet provenance, not current activeness: completed_cb self-filters via
     // packet_return_map, so in-flight dispatches still complete after stop_context removes the

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/queue_hooks.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/queue_hooks.hpp
@@ -51,8 +51,9 @@ write_hook(const hsa::Queue&                                        queue,
            bool&                                                    is_serialized);
 
 // Explicit replacement for the dispatch-counter completion callback. Iterates
-// active dispatch_counter_collection contexts and calls each callback's
-// completed_cb.
+// registered dispatch_counter_collection contexts (not only active ones) and calls
+// each callback's completed_cb; completed_cb self-filters via packet_return_map so
+// in-flight dispatches still complete after stop_context.
 void
 signal_completion_hook(const hsa::Queue&                           queue,
                        const hsa::rocprofiler_packet&              kernel_packet,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/queue_hooks.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/queue_hooks.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -40,27 +40,28 @@ namespace counters
 // appends produced packets to inst_pkt, OR-folding each callback's serialize flag
 // into is_serialized.
 void
-write_hook(const hsa::Queue&                                        queue,
-           const hsa::rocprofiler_packet&                           kernel_packet,
-           rocprofiler_kernel_id_t                                  kernel_id,
-           rocprofiler_dispatch_id_t                                dispatch_id,
-           rocprofiler_user_data_t*                                 user_data,
-           const hsa::queue_info_session_t::external_corr_id_map_t& ext_corr_ids,
-           const context::correlation_id*                           correlation_id,
-           hsa::inst_pkt_t&                                         inst_pkt,
-           bool&                                                    is_serialized);
+kernel_dispatch_phase_enter_hook(
+    const hsa::Queue&                                        queue,
+    const hsa::rocprofiler_packet&                           kernel_packet,
+    rocprofiler_kernel_id_t                                  kernel_id,
+    rocprofiler_dispatch_id_t                                dispatch_id,
+    rocprofiler_user_data_t*                                 user_data,
+    const hsa::queue_info_session_t::external_corr_id_map_t& ext_corr_ids,
+    const context::correlation_id*                           correlation_id,
+    hsa::inst_pkt_t&                                         inst_pkt,
+    bool&                                                    is_serialized);
 
 // Explicit replacement for the dispatch-counter completion callback. Iterates
 // registered dispatch_counter_collection contexts (not only active ones) and calls
 // each callback's completed_cb; completed_cb self-filters via packet_return_map so
 // in-flight dispatches still complete after stop_context.
 void
-signal_completion_hook(const hsa::Queue&                           queue,
-                       const hsa::rocprofiler_packet&              kernel_packet,
-                       std::shared_ptr<hsa::queue_info_session_t>& session,
-                       hsa::packet_data_t&                         packet,
-                       hsa::inst_pkt_t&                            inst_pkt,
-                       kernel_dispatch::profiling_time             dispatch_time);
+kernel_dispatch_phase_exit_hook(const hsa::Queue&                           queue,
+                                const hsa::rocprofiler_packet&              kernel_packet,
+                                std::shared_ptr<hsa::queue_info_session_t>& session,
+                                hsa::packet_data_t&                         packet,
+                                hsa::inst_pkt_t&                            inst_pkt,
+                                kernel_dispatch::profiling_time             dispatch_time);
 
 // True if any context currently has dispatch counter collection active.
 bool

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/queue_hooks_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/queue_hooks_test.cpp
@@ -27,6 +27,7 @@
 #include "lib/rocprofiler-sdk/counters/dispatch_handlers.hpp"
 #include "lib/rocprofiler-sdk/counters/tests/hsa_tables.hpp"
 #include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
+#include "lib/rocprofiler-sdk/hsa/aql_packet.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp"
@@ -39,7 +40,10 @@
 #include <gtest/gtest.h>
 #include <hsa/hsa.h>
 
+#include <algorithm>
 #include <memory>
+#include <mutex>
+#include <vector>
 
 using namespace rocprofiler::counters::test_constants;
 using namespace rocprofiler;
@@ -116,6 +120,51 @@ user_dispatch_cb(rocprofiler_dispatch_counting_service_data_t dispatch_data,
     (void) dispatch_data;
 }
 
+// Records delivered to the tool, keyed by dispatch id. Guarded because before stop_context the
+// consumer thread delivers these, and after it consumer_thread_t::add() consumes inline on the
+// caller -- so the writer can be either thread depending on when the completion lands.
+struct delivered_records
+{
+    std::mutex          mtx{};
+    std::vector<size_t> dispatch_ids{};
+
+    void add(size_t dispatch_id)
+    {
+        auto lk = std::unique_lock{mtx};
+        dispatch_ids.emplace_back(dispatch_id);
+    }
+
+    std::vector<size_t> snapshot()
+    {
+        auto lk = std::unique_lock{mtx};
+        return dispatch_ids;
+    }
+
+    // Reset so a repeated run of the test does not see the previous run's deliveries.
+    void clear()
+    {
+        auto lk = std::unique_lock{mtx};
+        dispatch_ids.clear();
+    }
+};
+
+delivered_records&
+get_delivered()
+{
+    static delivered_records _v{};
+    return _v;
+}
+
+void
+user_record_cb(rocprofiler_dispatch_counting_service_data_t dispatch_data,
+               rocprofiler_counter_record_t*,
+               size_t,
+               rocprofiler_user_data_t,
+               void*)
+{
+    get_delivered().add(dispatch_data.dispatch_info.dispatch_id);
+}
+
 // is_any_active replaces the queue.get_notifiers() signal that the old per-queue
 // callback registration used to provide to the HSA write interceptor gate. With
 // no dispatch-counter-collection context active, it must report inactive. This
@@ -125,12 +174,27 @@ TEST(counters_queue_hooks, is_any_active_false_when_no_context_active)
     EXPECT_FALSE(rocprofiler::counters::is_any_active());
 }
 
-// Regression for callback-registry removal: a dispatch enqueued while the context
-// is active must still complete (and drain packet_return_map) when stop_context
-// runs before the GPU completion callback. Kernel replay depends on this because
-// each replay pass reuses the same counter-collection completion path.
+// Regression for callback-registry removal, per the review on #8891: dispatches enqueued while the
+// context is active must still complete when stop_context runs before their GPU completions land.
+//
+// Two invariants are checked, because they fail independently:
+//
+//  1. Routing. Each dispatch's packet_return_map entry is erased by its own completion, so the map
+//     is asserted to drop by exactly one per completion rather than only to reach zero at the end.
+//     An aggregate check would pass even if one completion erased another dispatch's entry.
+//  2. Delivery. Every dispatch reaches the tool's record callback. Erasure happens in completed_cb
+//     before the hand-off to the consumer, so a test that only checks the map would pass even if
+//     nothing were ever delivered -- which is the failure the review actually described.
+//
+// Several dispatches are in flight at once, since a single one cannot distinguish "routed the one
+// entry" from "routed by provenance".
+//
+// No kernel executes here, so the counter values are whatever the profile's output buffer holds;
+// the assertion is about delivery, not values.
 TEST(counters_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
 {
+    constexpr size_t num_dispatches = 3;
+
     ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
     test_init();
 
@@ -139,8 +203,10 @@ TEST(counters_queue_hooks, stop_context_in_flight_completion_routes_via_hook_pat
     context::push_client(1);
 
     ROCPROFILER_CALL(rocprofiler_create_context(&get_client_ctx()), "context creation failed");
+    // A record callback is supplied so delivery is observable; the base test passed nullptr, which
+    // is why it could not detect a dropped completion.
     ROCPROFILER_CALL(rocprofiler_configure_callback_dispatch_counting_service(
-                         get_client_ctx(), user_dispatch_cb, nullptr, nullptr, nullptr),
+                         get_client_ctx(), user_dispatch_cb, nullptr, user_record_cb, nullptr),
                      "Could not setup counting service");
     ROCPROFILER_CALL(rocprofiler_start_context(get_client_ctx()), "start context");
 
@@ -189,44 +255,77 @@ TEST(counters_queue_hooks, stop_context_in_flight_completion_routes_via_hook_pat
     hsa::rocprofiler_packet  pkt{};
     context::correlation_id  corr_id{.internal = 99};
 
-    auto user_data = rocprofiler_user_data_t{.value = corr_id.internal};
-    auto ret_pkt   = rocprofiler::counters::queue_cb(ctx_p,
-                                                   cb_info,
-                                                   fq,
-                                                   pkt,
-                                                   expected.kernel_id,
-                                                   expected.dispatch_id,
-                                                   &user_data,
-                                                   {},
-                                                   &corr_id);
-    ASSERT_TRUE(ret_pkt.packet);
+    get_delivered().clear();
+
+    // Enqueue several dispatches while the context is active. Each queue_cb call must register its
+    // own entry; if the implementation ever pooled one packet across concurrent dispatches, the
+    // size assertion below would catch it rather than the test silently degenerating to one.
+    std::vector<std::unique_ptr<hsa::AQLPacket>> in_flight;
+    std::vector<size_t>                          dispatch_ids;
+    for(size_t i = 0; i < num_dispatches; ++i)
+    {
+        const size_t dispatch_id = expected.dispatch_id + i;
+        auto         user_data   = rocprofiler_user_data_t{.value = corr_id.internal};
+        auto         ret_pkt     = rocprofiler::counters::queue_cb(
+            ctx_p, cb_info, fq, pkt, expected.kernel_id, dispatch_id, &user_data, {}, &corr_id);
+        ASSERT_TRUE(ret_pkt.packet) << "queue_cb produced no instrumentation for dispatch " << i;
+        in_flight.emplace_back(std::move(ret_pkt.packet));
+        dispatch_ids.emplace_back(dispatch_id);
+    }
 
     size_t map_size_before_stop = 0;
     cb_info->packet_return_map.rlock([&](const auto& data) { map_size_before_stop = data.size(); });
-    ASSERT_EQ(map_size_before_stop, 1U) << "queue_cb should register instrumentation in the map";
+    ASSERT_EQ(map_size_before_stop, num_dispatches)
+        << "queue_cb should register one packet_return_map entry per in-flight dispatch";
 
-    // Simulate stop while the dispatch is still in flight on the GPU.
+    // Stop while every dispatch is still in flight on the GPU. This is the window the review
+    // described: the context leaves the active list, so a completion hook that routed by
+    // activeness would find nothing to deliver to.
     ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
     EXPECT_FALSE(rocprofiler::counters::is_any_active());
 
-    auto sess = std::make_shared<hsa::queue_info_session_t>(hsa::queue_info_session_t{.queue = fq});
-    auto& packet_data    = sess->packet_data.emplace_back();
-    sess->correlation_id = &corr_id;
+    // Complete them one at a time, checking the map drops by exactly one each time.
+    for(size_t i = 0; i < num_dispatches; ++i)
+    {
+        auto sess =
+            std::make_shared<hsa::queue_info_session_t>(hsa::queue_info_session_t{.queue = fq});
+        auto& packet_data                                     = sess->packet_data.emplace_back();
+        sess->correlation_id                                  = &corr_id;
+        packet_data.callback_record.dispatch_info.dispatch_id = dispatch_ids[i];
 
-    rocprofiler::counters::inst_pkt_t inst_pkt;
-    // Construct the pair in place rather than via make_pair: make_pair would deduce the tag's
-    // enum type and rely on a pair-to-pair conversion, where piecewise construction converts the
-    // tag to ClientID directly. Also matches how the production hook emplaces.
-    inst_pkt.emplace_back(std::move(ret_pkt.packet), hsa::queue_hooks::COUNTERS_CLIENT_ID);
+        rocprofiler::counters::inst_pkt_t inst_pkt;
+        // Construct the pair in place rather than via make_pair: make_pair would deduce the tag's
+        // enum type and rely on a pair-to-pair conversion, where piecewise construction converts
+        // the tag to ClientID directly. Also matches how the production hook emplaces.
+        inst_pkt.emplace_back(std::move(in_flight[i]), hsa::queue_hooks::COUNTERS_CLIENT_ID);
 
-    rocprofiler::counters::kernel_dispatch_phase_exit_hook(
-        fq, pkt, sess, packet_data, inst_pkt, rocprofiler::kernel_dispatch::profiling_time{});
+        rocprofiler::counters::kernel_dispatch_phase_exit_hook(
+            fq, pkt, sess, packet_data, inst_pkt, rocprofiler::kernel_dispatch::profiling_time{});
 
-    size_t map_size_after_completion = 1;
+        size_t remaining = num_dispatches;
+        cb_info->packet_return_map.rlock([&](const auto& data) { remaining = data.size(); });
+        EXPECT_EQ(remaining, num_dispatches - (i + 1))
+            << "completion " << i
+            << " should erase exactly its own packet_return_map entry after stop_context";
+    }
+
+    size_t map_size_after_completion = num_dispatches;
     cb_info->packet_return_map.rlock(
         [&](const auto& data) { map_size_after_completion = data.size(); });
     EXPECT_EQ(map_size_after_completion, 0U)
         << "packet_return_map must drain via kernel_dispatch_phase_exit_hook after stop_context";
+
+    // Delivery. callback_thread_stop() has already run as part of stop_context, so these arrive
+    // through the inline path in consumer_thread_t::add() rather than the consumer thread -- which
+    // is precisely the lifetime property the review asked to be kept intact.
+    auto delivered = get_delivered().snapshot();
+    EXPECT_EQ(delivered.size(), num_dispatches)
+        << "every in-flight dispatch must reach the tool's record callback after stop_context";
+    for(auto dispatch_id : dispatch_ids)
+    {
+        EXPECT_NE(std::find(delivered.begin(), delivered.end(), dispatch_id), delivered.end())
+            << "no record delivered for dispatch " << dispatch_id;
+    }
 
     registration::set_init_status(1);
     registration::finalize();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/queue_hooks_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/queue_hooks_test.cpp
@@ -253,7 +253,10 @@ TEST(counters_queue_hooks, stop_context_in_flight_completion_routes_via_hook_pat
 
     hsa::QueueHooksFakeQueue fq(agent, expected.queue_id);
     hsa::rocprofiler_packet  pkt{};
-    context::correlation_id  corr_id{.internal = 99};
+    // correlation_id declares constructors and holds private ref counters, so it is not an
+    // aggregate and cannot take a designated initializer.
+    context::correlation_id corr_id{};
+    corr_id.internal = 99;
 
     get_delivered().clear();
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/queue_hooks_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/queue_hooks_test.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,12 +20,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include "lib/rocprofiler-sdk/counters/core.hpp"
-#include "lib/rocprofiler-sdk/counters/dispatch_handlers.hpp"
 #include "lib/rocprofiler-sdk/counters/queue_hooks.hpp"
-#include "lib/rocprofiler-sdk/counters/tests/hsa_tables.hpp"
 #include "lib/rocprofiler-sdk/agent.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/counters/core.hpp"
+#include "lib/rocprofiler-sdk/counters/dispatch_handlers.hpp"
+#include "lib/rocprofiler-sdk/counters/tests/hsa_tables.hpp"
 #include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
@@ -139,13 +139,9 @@ TEST(counters_queue_hooks, stop_context_in_flight_completion_routes_via_hook_pat
     context::push_client(1);
 
     ROCPROFILER_CALL(rocprofiler_create_context(&get_client_ctx()), "context creation failed");
-    ROCPROFILER_CALL(
-        rocprofiler_configure_callback_dispatch_counting_service(get_client_ctx(),
-                                                                 user_dispatch_cb,
-                                                                 nullptr,
-                                                                 nullptr,
-                                                                 nullptr),
-        "Could not setup counting service");
+    ROCPROFILER_CALL(rocprofiler_configure_callback_dispatch_counting_service(
+                         get_client_ctx(), user_dispatch_cb, nullptr, nullptr, nullptr),
+                     "Could not setup counting service");
     ROCPROFILER_CALL(rocprofiler_start_context(get_client_ctx()), "start context");
 
     auto* ctx_p = context::get_mutable_registered_context(get_client_ctx());
@@ -163,7 +159,7 @@ TEST(counters_queue_hooks, stop_context_in_flight_completion_routes_via_hook_pat
 
     rocprofiler_counter_id_t counter_id = {.handle = 0};
     {
-        auto mets = rocprofiler::counters::loadMetrics();
+        auto        mets = rocprofiler::counters::loadMetrics();
         const auto* gfx_metrics =
             rocprofiler::common::get_val(mets->arch_to_metric, std::string(agent.name()));
         ASSERT_TRUE(gfx_metrics);
@@ -180,18 +176,18 @@ TEST(counters_queue_hooks, stop_context_in_flight_completion_routes_via_hook_pat
     ASSERT_NE(counter_id.handle, 0U);
 
     expected_dispatch expected = {};
-    ROCPROFILER_CALL(rocprofiler_create_counter_config(
-                         agent.get_rocp_agent()->id, &counter_id, 1, &expected.id),
-                     "Unable to create profile");
+    ROCPROFILER_CALL(
+        rocprofiler_create_counter_config(agent.get_rocp_agent()->id, &counter_id, 1, &expected.id),
+        "Unable to create profile");
     cb_info->callback_args = &expected;
     expected.queue_id      = {.handle = 1};
-    expected.agent_id    = agent.get_rocp_agent()->id;
-    expected.kernel_id   = 42;
-    expected.dispatch_id = 7;
+    expected.agent_id      = agent.get_rocp_agent()->id;
+    expected.kernel_id     = 42;
+    expected.dispatch_id   = 7;
 
     hsa::QueueHooksFakeQueue fq(agent, expected.queue_id);
-    hsa::rocprofiler_packet pkt{};
-    context::correlation_id corr_id{.internal = 99};
+    hsa::rocprofiler_packet  pkt{};
+    context::correlation_id  corr_id{.internal = 99};
 
     auto user_data = rocprofiler_user_data_t{.value = corr_id.internal};
     auto ret_pkt   = rocprofiler::counters::queue_cb(ctx_p,
@@ -206,34 +202,31 @@ TEST(counters_queue_hooks, stop_context_in_flight_completion_routes_via_hook_pat
     ASSERT_TRUE(ret_pkt.packet);
 
     size_t map_size_before_stop = 0;
-    cb_info->packet_return_map.rlock(
-        [&](const auto& data) { map_size_before_stop = data.size(); });
+    cb_info->packet_return_map.rlock([&](const auto& data) { map_size_before_stop = data.size(); });
     ASSERT_EQ(map_size_before_stop, 1U) << "queue_cb should register instrumentation in the map";
 
     // Simulate stop while the dispatch is still in flight on the GPU.
     ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
     EXPECT_FALSE(rocprofiler::counters::is_any_active());
 
-    auto  sess        = std::make_shared<hsa::queue_info_session_t>(hsa::queue_info_session_t{.queue = fq});
-    auto& packet_data = sess->packet_data.emplace_back();
+    auto sess = std::make_shared<hsa::queue_info_session_t>(hsa::queue_info_session_t{.queue = fq});
+    auto& packet_data    = sess->packet_data.emplace_back();
     sess->correlation_id = &corr_id;
 
     rocprofiler::counters::inst_pkt_t inst_pkt;
-    inst_pkt.emplace_back(
-        std::make_pair(std::move(ret_pkt.packet), hsa::queue_hooks::COUNTERS_CLIENT_ID));
+    // Construct the pair in place rather than via make_pair: make_pair would deduce the tag's
+    // enum type and rely on a pair-to-pair conversion, where piecewise construction converts the
+    // tag to ClientID directly. Also matches how the production hook emplaces.
+    inst_pkt.emplace_back(std::move(ret_pkt.packet), hsa::queue_hooks::COUNTERS_CLIENT_ID);
 
-    rocprofiler::counters::signal_completion_hook(fq,
-                                                  pkt,
-                                                  sess,
-                                                  packet_data,
-                                                  inst_pkt,
-                                                  rocprofiler::kernel_dispatch::profiling_time{});
+    rocprofiler::counters::kernel_dispatch_phase_exit_hook(
+        fq, pkt, sess, packet_data, inst_pkt, rocprofiler::kernel_dispatch::profiling_time{});
 
     size_t map_size_after_completion = 1;
     cb_info->packet_return_map.rlock(
         [&](const auto& data) { map_size_after_completion = data.size(); });
     EXPECT_EQ(map_size_after_completion, 0U)
-        << "packet_return_map must drain via signal_completion_hook after stop_context";
+        << "packet_return_map must drain via kernel_dispatch_phase_exit_hook after stop_context";
 
     registration::set_init_status(1);
     registration::finalize();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/queue_hooks_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/queue_hooks_test.cpp
@@ -17,15 +17,105 @@
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
+#include "lib/rocprofiler-sdk/counters/core.hpp"
+#include "lib/rocprofiler-sdk/counters/dispatch_handlers.hpp"
 #include "lib/rocprofiler-sdk/counters/queue_hooks.hpp"
+#include "lib/rocprofiler-sdk/counters/tests/hsa_tables.hpp"
+#include "lib/rocprofiler-sdk/agent.hpp"
+#include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp"
+#include "lib/rocprofiler-sdk/kernel_dispatch/profiling_time.hpp"
+#include "lib/rocprofiler-sdk/registration.hpp"
+
+#include <rocprofiler-sdk/dispatch_counting_service.h>
+#include <rocprofiler-sdk/rocprofiler.h>
 
 #include <gtest/gtest.h>
+#include <hsa/hsa.h>
+
+#include <memory>
+
+using namespace rocprofiler::counters::test_constants;
+using namespace rocprofiler;
+
+#define ROCPROFILER_CALL(result, msg)                                                              \
+    {                                                                                              \
+        rocprofiler_status_t CHECKSTATUS = result;                                                 \
+        ASSERT_EQ(CHECKSTATUS, ROCPROFILER_STATUS_SUCCESS)                                         \
+            << msg << ": " << rocprofiler_get_status_string(CHECKSTATUS);                          \
+    }
+
+namespace rocprofiler
+{
+namespace hsa
+{
+class QueueHooksFakeQueue : public Queue
+{
+public:
+    QueueHooksFakeQueue(const AgentCache& a, rocprofiler_queue_id_t id)
+    : Queue(a, get_api_table())
+    , _agent(a)
+    , _id(id)
+    {}
+    const AgentCache&      get_agent() const final { return _agent; };
+    rocprofiler_queue_id_t get_id() const final { return _id; };
+
+    ~QueueHooksFakeQueue() override = default;
+
+private:
+    const AgentCache&      _agent;
+    rocprofiler_queue_id_t _id = {};
+};
+}  // namespace hsa
+}  // namespace rocprofiler
 
 namespace
 {
+rocprofiler_context_id_t&
+get_client_ctx()
+{
+    static rocprofiler_context_id_t ctx{0};
+    return ctx;
+}
+
+void
+test_init()
+{
+    HsaApiTable table;
+    table.amd_ext_ = &get_ext_table();
+    table.core_    = &get_api_table();
+    agent::construct_agent_cache(&table);
+    ASSERT_TRUE(hsa::get_queue_controller() != nullptr);
+    hsa::get_queue_controller()->init(get_api_table(), get_ext_table());
+}
+
+struct expected_dispatch
+{
+    rocprofiler_counter_config_id_t id          = {.handle = 0};
+    rocprofiler_queue_id_t          queue_id    = {.handle = 0};
+    rocprofiler_agent_id_t          agent_id    = {.handle = 0};
+    uint64_t                        kernel_id   = 0;
+    uint64_t                        dispatch_id = 0;
+};
+
+void
+user_dispatch_cb(rocprofiler_dispatch_counting_service_data_t dispatch_data,
+                 rocprofiler_counter_config_id_t*             config,
+                 rocprofiler_user_data_t*,
+                 void* callback_data_args)
+{
+    auto& expected = *static_cast<expected_dispatch*>(callback_data_args);
+    ASSERT_NE(config, nullptr);
+    config->handle = expected.id.handle;
+    (void) dispatch_data;
+}
+
 // is_any_active replaces the queue.get_notifiers() signal that the old per-queue
 // callback registration used to provide to the HSA write interceptor gate. With
 // no dispatch-counter-collection context active, it must report inactive. This
@@ -33,5 +123,119 @@ namespace
 TEST(counters_queue_hooks, is_any_active_false_when_no_context_active)
 {
     EXPECT_FALSE(rocprofiler::counters::is_any_active());
+}
+
+// Regression for callback-registry removal: a dispatch enqueued while the context
+// is active must still complete (and drain packet_return_map) when stop_context
+// runs before the GPU completion callback. Kernel replay depends on this because
+// each replay pass reuses the same counter-collection completion path.
+TEST(counters_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
+{
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    registration::init_logging();
+    registration::set_init_status(-1);
+    context::push_client(1);
+
+    ROCPROFILER_CALL(rocprofiler_create_context(&get_client_ctx()), "context creation failed");
+    ROCPROFILER_CALL(
+        rocprofiler_configure_callback_dispatch_counting_service(get_client_ctx(),
+                                                                 user_dispatch_cb,
+                                                                 nullptr,
+                                                                 nullptr,
+                                                                 nullptr),
+        "Could not setup counting service");
+    ROCPROFILER_CALL(rocprofiler_start_context(get_client_ctx()), "start context");
+
+    auto* ctx_p = context::get_mutable_registered_context(get_client_ctx());
+    ASSERT_TRUE(ctx_p);
+    ASSERT_TRUE(ctx_p->dispatch_counter_collection);
+    ASSERT_EQ(ctx_p->dispatch_counter_collection->callbacks.size(), 1);
+    auto cb_info = ctx_p->dispatch_counter_collection->callbacks.front();
+
+    ASSERT_TRUE(hsa::get_queue_controller() != nullptr);
+    auto agents = hsa::get_queue_controller()->get_supported_agents();
+    ASSERT_GT(agents.size(), 0);
+
+    const auto& [_, agent] = *agents.begin();
+    ASSERT_TRUE(agent.get_rocp_agent());
+
+    rocprofiler_counter_id_t counter_id = {.handle = 0};
+    {
+        auto mets = rocprofiler::counters::loadMetrics();
+        const auto* gfx_metrics =
+            rocprofiler::common::get_val(mets->arch_to_metric, std::string(agent.name()));
+        ASSERT_TRUE(gfx_metrics);
+        ASSERT_FALSE(gfx_metrics->empty());
+        for(const auto& metric : *gfx_metrics)
+        {
+            if(metric.expression().empty())
+            {
+                counter_id.handle = metric.id();
+                break;
+            }
+        }
+    }
+    ASSERT_NE(counter_id.handle, 0U);
+
+    expected_dispatch expected = {};
+    ROCPROFILER_CALL(rocprofiler_create_counter_config(
+                         agent.get_rocp_agent()->id, &counter_id, 1, &expected.id),
+                     "Unable to create profile");
+    cb_info->callback_args = &expected;
+    expected.queue_id      = {.handle = 1};
+    expected.agent_id    = agent.get_rocp_agent()->id;
+    expected.kernel_id   = 42;
+    expected.dispatch_id = 7;
+
+    hsa::QueueHooksFakeQueue fq(agent, expected.queue_id);
+    hsa::rocprofiler_packet pkt{};
+    context::correlation_id corr_id{.internal = 99};
+
+    auto user_data = rocprofiler_user_data_t{.value = corr_id.internal};
+    auto ret_pkt   = rocprofiler::counters::queue_cb(ctx_p,
+                                                   cb_info,
+                                                   fq,
+                                                   pkt,
+                                                   expected.kernel_id,
+                                                   expected.dispatch_id,
+                                                   &user_data,
+                                                   {},
+                                                   &corr_id);
+    ASSERT_TRUE(ret_pkt.packet);
+
+    size_t map_size_before_stop = 0;
+    cb_info->packet_return_map.rlock(
+        [&](const auto& data) { map_size_before_stop = data.size(); });
+    ASSERT_EQ(map_size_before_stop, 1U) << "queue_cb should register instrumentation in the map";
+
+    // Simulate stop while the dispatch is still in flight on the GPU.
+    ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
+    EXPECT_FALSE(rocprofiler::counters::is_any_active());
+
+    auto  sess        = std::make_shared<hsa::queue_info_session_t>(hsa::queue_info_session_t{.queue = fq});
+    auto& packet_data = sess->packet_data.emplace_back();
+    sess->correlation_id = &corr_id;
+
+    rocprofiler::counters::inst_pkt_t inst_pkt;
+    inst_pkt.emplace_back(
+        std::make_pair(std::move(ret_pkt.packet), hsa::queue_hooks::COUNTERS_CLIENT_ID));
+
+    rocprofiler::counters::signal_completion_hook(fq,
+                                                  pkt,
+                                                  sess,
+                                                  packet_data,
+                                                  inst_pkt,
+                                                  rocprofiler::kernel_dispatch::profiling_time{});
+
+    size_t map_size_after_completion = 1;
+    cb_info->packet_return_map.rlock(
+        [&](const auto& data) { map_size_after_completion = data.size(); });
+    EXPECT_EQ(map_size_after_completion, 0U)
+        << "packet_return_map must drain via signal_completion_hook after stop_context";
+
+    registration::set_init_status(1);
+    registration::finalize();
 }
 }  // namespace

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -171,12 +171,12 @@ AsyncSignalHandler(hsa_signal_value_t /*signal_v*/, void* data)
 
         // Counter collection completion is migrated off the callback registry (see
         // WriteInterceptor); invoke it explicitly here.
-        counters::signal_completion_hook(queue_info_session.queue,
-                                         packet.kernel_packet,
-                                         _session,
-                                         packet,
-                                         packet.instrumentation_packets,
-                                         dispatch_time);
+        counters::kernel_dispatch_phase_exit_hook(queue_info_session.queue,
+                                                  packet.kernel_packet,
+                                                  _session,
+                                                  packet,
+                                                  packet.instrumentation_packets,
+                                                  dispatch_time);
 
         if(packet.is_serialized)
         {
@@ -632,15 +632,16 @@ WriteInterceptor(const void* packets,
 
             // Counter collection is migrated off the per-queue callback registry: call its hook
             // explicitly (the other services still flow through signal_callback above).
-            counters::write_hook(queue,
-                                 kernel_packet,
-                                 kernel_id,
-                                 dispatch_id,
-                                 &_packet_data.user_data,
-                                 _packet_data.tracing_data.external_correlation_ids,
-                                 corr_id,
-                                 _packet_data.instrumentation_packets,
-                                 _packet_data.is_serialized);
+            counters::kernel_dispatch_phase_enter_hook(
+                queue,
+                kernel_packet,
+                kernel_id,
+                dispatch_id,
+                &_packet_data.user_data,
+                _packet_data.tracing_data.external_correlation_ids,
+                corr_id,
+                _packet_data.instrumentation_packets,
+                _packet_data.is_serialized);
 
             bool inserted_before = false;
             if(_packet_data.is_serialized)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp
@@ -39,6 +39,14 @@ namespace queue_hooks
 // tag is stored in inst_pkt_t. The enum is deliberately unscoped rather than an
 // enum class: unscoped keeps the implicit conversion to ClientID, so the emplace
 // sites need no cast, while still grouping the values under one type.
+//
+// These values numerically overlap the per-queue registry's auto-incrementing
+// ClientID, which also starts at 1 and is still in use by the services that have
+// not been migrated yet. That is inert only because no consumer routes on the tag:
+// counters' completed_cb and thread trace's post_kernel_call both identify their
+// own packets by pointer lookup or dynamic_cast. Before adding a consumer that
+// dispatches on these values, either finish migrating the remaining services off
+// the registry or move this enum to a range the registry cannot produce.
 enum client_id : int64_t
 {
     COUNTERS_CLIENT_ID     = 1,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -34,10 +34,18 @@ namespace queue_hooks
 // Only distinctness matters; values are fixed for test-order stability.
 // Services are migrated off the per-queue callback registry one at a time; the
 // unused ids are reserved so the tag values stay stable across those PRs.
-constexpr int64_t COUNTERS_CLIENT_ID     = 1;
-constexpr int64_t THREAD_TRACE_CLIENT_ID = 2;
-constexpr int64_t PC_SAMPLING_CLIENT_ID  = 3;
-constexpr int64_t SPM_CLIENT_ID          = 4;
+//
+// The underlying type is fixed to int64_t to match hsa::ClientID, which is how the
+// tag is stored in inst_pkt_t. The enum is deliberately unscoped rather than an
+// enum class: unscoped keeps the implicit conversion to ClientID, so the emplace
+// sites need no cast, while still grouping the values under one type.
+enum client_id : int64_t
+{
+    COUNTERS_CLIENT_ID     = 1,
+    THREAD_TRACE_CLIENT_ID = 2,
+    PC_SAMPLING_CLIENT_ID  = 3,
+    SPM_CLIENT_ID          = 4,
+};
 }  // namespace queue_hooks
 }  // namespace hsa
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -1012,16 +1012,6 @@ finalize()
     std::call_once(_once, []() {
         auto num_clients = get_num_clients();
         set_fini_status(-1);
-
-        // Stop contexts and run tool finalization while queue interception is still
-        // intact. counters::stop_context relies on a live queue controller to drain
-        // in-flight dispatches and coordinate serializer teardown; running that after
-        // queue_controller_fini() is undefined.
-        if(get_init_status() > 0)
-        {
-            invoke_client_finalizers();
-        }
-
         hsa::async_copy_fini();
         counters::device_counting_service_finalize();
         hsa::queue_controller_fini();
@@ -1036,6 +1026,10 @@ finalize()
 #endif
         code_object::finalize();
         context::correlation_id_finalize();
+        if(get_init_status() > 0)
+        {
+            invoke_client_finalizers();
+        }
         if(num_clients > 0) internal_threading::finalize();
         set_fini_status(1);
     });

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -1012,6 +1012,16 @@ finalize()
     std::call_once(_once, []() {
         auto num_clients = get_num_clients();
         set_fini_status(-1);
+
+        // Stop contexts and run tool finalization while queue interception is still
+        // intact. counters::stop_context relies on a live queue controller to drain
+        // in-flight dispatches and coordinate serializer teardown; running that after
+        // queue_controller_fini() is undefined.
+        if(get_init_status() > 0)
+        {
+            invoke_client_finalizers();
+        }
+
         hsa::async_copy_fini();
         counters::device_counting_service_finalize();
         hsa::queue_controller_fini();
@@ -1026,10 +1036,6 @@ finalize()
 #endif
         code_object::finalize();
         context::correlation_id_finalize();
-        if(get_init_status() > 0)
-        {
-            invoke_client_finalizers();
-        }
         if(num_clients > 0) internal_threading::finalize();
         set_fini_status(1);
     });


### PR DESCRIPTION

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This PR implements the fix @bwelton requested in his review of PR #8891 on 23 July, and intends to implement all of the comments and suggestions in the PR #8891 review by @vlaindic.

@bwelton identified that the migration changed completion routing from *provenance-based* to *liveness-based*, and prescribed the fix: route by packet provenance rather than current activeness, by iterating registered rather than only active contexts. That is what this PR does. Credit to @bwelton  for identifying the regression.

@vlaindic 's review of PR #8891 asked for a number of important changes as well including function renaming of write and signal completion hooks, the enum and the copyright years. These are all also addressed here.



The regression noted by @bwelton, restated, is that the per-queue callback registry fired an in-flight dispatch's completion regardless of whether its context was still active, and the old `stop_context` relied on that. The new completion hook re-queried `get_active_contexts` at completion time, while `context::stop_context` nulls the active slot at `context/context.cpp:371` *before* calling `counters::stop_context`. So a kernel dispatched while the context was active but completing after `rocprofiler_stop_context()` returns found zero active contexts, `completed_cb` never ran, the counter record was silently lost, and the `packet_return_map` entry leaked with possible misassociation on packet-address reuse.

It is not hypothetical as #8891's CI shows two test failures out of 955 on `gfx94X`, and both are pause/resume counter-collection tests:

```
rocprofv3-test-roctx-pause-resume-tracing.test_counter_collection_data
  E assert 0 > 0                                     <- zero counter records

rocprofv3-test-counter-collection-pmc-selected-regions.test_counter_collection_only_inside_selected_regions
  E AssertionError: expected 4 counter record(s) for 'target_kernel'
    (one per resume window) but found 1
```

On `develop` the same job passes 100% of 975 tests including both by name; #8891 changes 12 source files and no tests. Pause is `stop_context`, so a dispatch in flight at pause loses its completion — four resume windows yield one record.

Note that this PR is meant to be stacked onto `users/vkale/remove-callbacks-counters`, the head branch of #8891. Merging this PR updates that branch.


## Technical Details

### Completion routing

`counters/queue_hooks.cpp` — the exit hook iterates `get_registered_contexts` instead of `get_active_contexts`. `completed_cb` already resolves ownership by pointer lookup in `packet_return_map` and self-filters, so each context still processes only its own packets; this restores provenance routing without reintroducing the registry. The enter hook and `is_any_active` keep using active contexts, because new instrumentation must stop as soon as the context stops.

### The lifetime condition from the review

@bwelton conditioned the fix on the callback thread and the `counter_callback_info` objects staying alive until in-flight dispatches drain, noting `stop_context` calls `callback_thread_stop()` unconditionally at `core.cpp:190`. Both halves hold, and the test now asserts the second:

- **`counter_callback_info` lifetime** is structural. `context.hpp:84` holds them as `std::vector<std::shared_ptr<counters::counter_callback_info>>` on the service, and neither `counters::stop_context` nor `context::stop_context` clears that vector. Since the hook now iterates *registered* contexts, the context and its `shared_ptr` callbacks are still reachable, so the objects outlive the drain by construction.
- **The callback thread** does not strand anything. `consumer_thread_t::exit()` sets `valid = false`, then waits on `exited`, and `consumer_loop` only sets `exited` once `read_ptr == write_ptr`, so everything already queued is consumed before the join. After that, `consumer_thread_t::add()` takes the `selfconsume` path and invokes `consume_fn` inline on the caller, so a completion arriving after the thread is gone is still processed — on the async signal handler thread. `counters/tests/consumer_test.cpp` `restart` already covers the drain-on-exit half.

### Serialization ordering

`context/context.cpp` — `stop_context` now stops counters, SPM, device thread trace and dispatch thread trace **before** the `compare_exchange_strong` that clears the active slot, so `disable_serialization()` always runs before dispatches stop being instrumented. Clearing the slot first opens the opposite window, in which a dispatch is submitted without serializer packets while the serializer is still enabled. This is the counters-side analogue of the second blocking issue bwelton raised on #8887.

### Maintaining drain for liveness-based routing 

Note: A stale comment on the exit hook, left over from the revision that removed the drain, claimed provenance routing made `stop_context` safe *without* a drain. It contradicted the code a few files away and is corrected here to say what each mechanism actually guarantees.



`counters::stop_context` retains `hsa::queue_controller_sync()` ahead of `disable_serialization()`, and `callback_thread_stop()` now runs after it rather than alongside.

This is what makes the lifetime condition above hold literally rather than by argument. An intermediate revision of this branch removed the drain, reasoning that `consumer_thread_t::exit()` drains its own queue and `add()` self-consumes inline afterwards. Both facts are true and remain a useful backstop, but they are not the guarantee that was asked for: they argue a late completion is still processed, rather than ensuring there is no late completion to process. The comment at the call site now says which is which.

Ordering is load-bearing and stated at the call site. `context::stop_context` runs `counters::stop_context` while the context is still in the active list, so throughout the drain the enter hook still reaches `queue_cb`, whose disabled path returns `serialize=true` and keeps the serialized-to-unserialized transition coordinated until `disable_serialization()` runs. That is what removes the need for a separate draining flag on the counters side, and it only works because the drain happens before the active slot is cleared.

The companion SPM PR #8887 does the same, and reverts a removal that had followed @SrirakshaNag's suggestion on #8887. The reasoning for doing that there: provenance routing guarantees that a completion which *arrives* is delivered, whereas the drain bounds *when completions arrive at all*, and the teardown depends on the latter — so the two are not substitutes.

### Review feedback from @vlaindic

**Hook renames**, using the name agreed in that thread, since "write" did not convey that this is a write-interceptor hook:

| Before | After |
|---|---|
| `counters::write_hook` | `counters::kernel_dispatch_phase_enter_hook` |
| `counters::signal_completion_hook` | `counters::kernel_dispatch_phase_exit_hook` |

The exit hook is renamed for symmetry even though only the enter hook was flagged — leaving one half renamed reads worse than either alternative, and the paired names make the enqueue-versus-completion asymmetry above easier to follow. `is_any_active` keeps its name, being neither phase. SPM mirrors these names on its own branch and is deliberately left alone until #8887's review settles, so the two are briefly inconsistent by choice.

**`client_ids.hpp` enum.** The `int64_t` was not arbitrary: `using ClientID = int64_t` at `hsa/rocprofiler_packet.hpp:37`, and the tag is stored in `inst_pkt_t` as a `ClientID`. The four constants are now an **unscoped** enum with `int64_t` as its fixed underlying type, which groups them under one type while preserving the implicit conversion, so no emplace site needs a cast; `enum class` would have required one at each.

The declaration now also records bwelton's non-blocking observation from #8790: these tags numerically overlap the registry's auto-incrementing `ClientID`, which also starts at 1 and is still in use by the unmigrated services. That is inert only because no consumer dispatches on the tag — counters' `completed_cb` and thread trace's `post_kernel_call` both identify their own packets by pointer lookup or `dynamic_cast`. The comment states what has to happen before that changes, so it is visible to whoever first tries to route on these values rather than living only in a PR thread.

**Copyright headers.** 2025 to 2026 on the four files the base PR adds.

### Software Architecture Doc

`docs/conceptual/queue_hooks/queue_callback_removal_architecture.md` documents the mechanism this stack establishes: why the enter hook routes over active contexts while the exit hook routes over registered ones, why that asymmetry is the difference between delivering and dropping an in-flight dispatch's completion, and why the stop path drains. It was written on a separate branch and is folded in here so it is reviewed next to the code it describes, and so the drain rationale lives somewhere more durable than a PR thread.

It references code by file and symbol rather than by line number, and carries its diagram as inline mermaid rather than a checked-in image. It is not added to `_toc.yml.in`, matching the kernel replay design doc on #8622, so it is not published to the documentation site.

## Acceptance criteria

Validated when both of these go from failing to passing on a `gfx94X` runner:

- [x] `tests.integration.validate.rocprofv3-test-roctx-pause-resume-tracing.test_counter_collection_data`
- [ ] `tests.integration.validate.rocprofv3-test-counter-collection-pmc-selected-regions.test_counter_collection_only_inside_selected_regions`

Both are pre-existing tests that pass on `develop` and fail on #8891, so they are an objective target rather than a test authored alongside the fix.

### Notes on #8891's other check failures

Not caused by the code, for whoever triages them:

- `6.2 • ubuntu-22.04 • aqlprofile-internal` never got past image setup: `GPGKeyTemporarilyNotFoundError` and an HTTP 500 from the package host.
- `Analyze (python)` and `Analyze (actions)` fail with a workflow template error rather than a finding — `.github/workflows/rocprofiler-sdk-codeql.yml` lines 62-63, "Unexpected value ''". The jobs never ran, and this affects every PR in the repository.
- `therock-pr-bot` reports `Timed out waiting for required checks to complete`, listing the three above; it is downstream of them. #8891's empty Test Plan and Test Result sections and its `Not ready to Review` label are worth fixing regardless, but they are not what turned this check red.

### Integration with Kernel replay PR and associated tests 

Kernel replay (#8622) runs N passes per dispatch and reuses `process_packet_batch` for each, so every pass creates its own instrumentation packet and `packet_return_map` entry. A dropped completion is one lost record today; under replay it is N leaked packets per dispatch plus silently missing counter groups. The replay loop also waits on its `pass_done` barrier with no timeout, so a stall on the completion path becomes an application hang rather than data loss.

## JIRA ID

Tracked internally.

## Test Plan

- **The two pre-existing integration tests** under Acceptance criteria, which currently fail on #8891.
- **Strengthened unit regression test**, `counters/tests/queue_hooks_test.cpp` — `stop_context_in_flight_completion_routes_via_hook_path`, now written to what bwelton asked for. Three dispatches are registered while the context is active, the context is stopped with all three in flight, and completions fire one at a time. It asserts both that the map drops by exactly one per completion, which an aggregate check would not catch if one completion erased another's entry, and that **every** dispatch reaches the tool's record callback. The earlier version passed `nullptr` for the record callback and drove one dispatch, so it could observe neither property.
- Existing counter-collection unit tests, including `counters/tests/consumer_test.cpp` `restart`, which covers the consumer drain-on-exit behaviour that now backs up the explicit drain rather than substituting for it.
- Existing rocprofv3 counter-collection integration tests.

## Test Result

Not yet built or executed — no ROCm toolchain or GPU in the environment these changes were prepared in. Verified statically:

- `clang-format` 11.1.0, the version pinned by the repo's `.clang-format`, produces no churn outside the lines changed here. An initial pass with a newer clang-format reformatted unrelated lines and was discarded.
- No references to the old hook names remain on the branch outside `spm/`, which is unmigrated on this base and correctly untouched.
- A standalone translation unit confirms the new enum converts to `ClientID` in both the piecewise and `make_pair` forms.

Note the strengthened test's delivery assertion has not been run. It depends on counter evaluation yielding at least one record for a dispatch that never executed on hardware; if the profile's output buffer decodes to nothing, the assertion will report that rather than silently passing, which is the intended behaviour but is worth watching on the first CI run.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

