### PR TITLE
fix(rocr): size KFD io_link buffer to actual sysfs link count

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/topology.c
+++ b/projects/rocr-runtime/libhsakmt/src/topology.c
@@ -2131,9 +2131,22 @@ retry:
 			}
 
 			/* To simplify, allocate maximum needed memory for io_links for each node. This
-			 * removes the need for realloc when indirect and QPI links are added later
+			 * removes the need for realloc when indirect and QPI links are added later.
+			 *
+			 * At this point NumIOLinks holds io_links_count + p2p_links_count, i.e. the
+			 * total number of links sysfs reports for this node. Topologies with link
+			 * aggregation (e.g. multiple XGMI links to the same peer) can report more
+			 * than NumNodes-1 links; sizing the buffer at NumNodes-1 truncated those
+			 * extra links and silently dropped peer connectivity, producing an
+			 * asymmetric/incomplete peer-access matrix. Size the buffer to the actual
+			 * link count, keeping NumNodes-1 as a floor because the indirect-link path
+			 * below (when sysfs does not expose p2p_links) may synthesize up to that
+			 * many links.
 			 */
-			temp_props[i].link = calloc(sys_props.NumNodes - 1, sizeof(HsaIoLinkProperties));
+			uint32_t max_links = temp_props[i].node.NumIOLinks;
+			if (max_links < sys_props.NumNodes - 1)
+				max_links = sys_props.NumNodes - 1;
+			temp_props[i].link = calloc(max_links, sizeof(HsaIoLinkProperties));
 			if (!temp_props[i].link) {
 				ret = HSAKMT_STATUS_NO_MEMORY;
 				free_properties(temp_props, i + 1);
@@ -2149,7 +2162,7 @@ retry:
 				 * remote node (node_to) is not accessible
 				 */
 				while (sys_link_id < num_ioLinks &&
-					link_id < sys_props.NumNodes - 1) {
+					link_id < max_links) {
 					ret = topology_sysfs_get_iolink_props(ctx, i, sys_link_id++,
 								&temp_props[i].link[link_id], false);
 					if (ret == HSAKMT_STATUS_NOT_SUPPORTED) {
@@ -2170,7 +2183,7 @@ retry:
 				/* Parse all the sysfs specified p2p links.
 				 */
 				while (sys_link_id < num_p2pLinks &&
-					link_id < sys_props.NumNodes - 1) {
+					link_id < max_links) {
 					ret = topology_sysfs_get_iolink_props(ctx, i, sys_link_id++,
 								&temp_props[i].link[link_id], true);
 					if (ret == HSAKMT_STATUS_NOT_SUPPORTED) {


### PR DESCRIPTION
**This was just a work-around to try to unblock testing. The real fix should come from KFD sysfs topology not reporting duplicate IO Links**

## Summary

`topology_take_snapshot()` in `libhsakmt` allocated each node's `io_link` array and capped both sysfs parse loops at `sys_props.NumNodes - 1`, which assumes at most one link per peer (a fully-connected single-link graph → N-1 links).

On GPUs that expose **aggregated XGMI links** (multiple io_links to the same peer), a node's real link count (`io_links_count + p2p_links_count`) can exceed `NumNodes - 1`. The parse loop then silently truncated the overflow links. Because the dropped entries were the last-listed peers, some GPU→GPU links never made it into ROCr's `link_matrix_`.

Observed on a 4x `gfx1250` box: `hsa_amd_agent_memory_pool_get_info(..., ACCESS)` returned `NEVER_ALLOWED / hops=0` for a few ordered pairs even though the KFD sysfs topology listed those XGMI io_links. This surfaced upstream as:
- an **asymmetric / incomplete** `hipDeviceCanAccessPeer` matrix (e.g. `GPU3->GPU0`=1 but `GPU0->GPU3`=0), and
- a **segfault in `hipMemcpyPeer`** for the affected (asymmetric) pairs.

### Fix

Size the `link` buffer and both parse-loop bounds by the node's **actual** link count (`NumIOLinks`, which at that point holds `io_links_count + p2p_links_count`), keeping `NumNodes - 1` only as a floor so the indirect-link synthesis path (used when sysfs does not expose `p2p_links`) still has room.

## Test plan

Verified on a 4x `gfx1250` system, building `libhsa-runtime64.so` from this branch against a `/opt/rocm` (TheRock) toolchain and loading it via `LD_LIBRARY_PATH`:

- [x] Direct HSA probe (`hsa_amd_agent_memory_pool_get_info`): all ordered GPU pairs now report `access=DISALLOWED_BY_DEFAULT, hops=1, link=XGMI` (previously two pairs were `NEVER / hops=0`).
- [x] `hipDeviceCanAccessPeer`: peer-access matrix is now fully connected and symmetric (was asymmetric).
- [x] `hipMemcpyPeer` device-to-device copies: 12/12 accessible pairs verified, no crash (previously segfaulted on the asymmetric pairs).
- [x] Behavior on non-aggregated topologies is unchanged (`max_links` floors at `NumNodes - 1`).

> Note: this is a source change without an accompanying `test_*` unit test, so the therock-pr-bot unit-test policy check is expected to flag it.

Made with [Cursor](https://cursor.com)